### PR TITLE
refactor(governance): route keeper policy to operator approval

### DIFF
--- a/docs/rfc/RFC-0319-operator-approval-mode.md
+++ b/docs/rfc/RFC-0319-operator-approval-mode.md
@@ -1,6 +1,6 @@
 # RFC-0319 — Operator Approval Mode (AUTO 승인 모드) with separation-of-duties invariant
 
-- Status: Draft
+- Status: Implemented
 - Area: keeper HITL queue decision path: `lib/keeper/keeper_guards.ml` (`governance_approval_guard`), `lib/governance_pipeline.ml` (`to_oas_approval_callback`), `lib/keeper/keeper_approval_queue*.ml` (`submit_and_await`, `resolve_with_policy`, rule matching, audit), `lib/server/server_dashboard_http.ml` + `server_routes_http_routes_dashboard.ml` (dashboard resolve/mode API), and `dashboard/src/components/approvals/approvals-surface.ts` / `dashboard/src/components/governance-actions.ts`.
 - Builds on / touches: RFC-0304 (HITL summary), the keeper-v2 approvals surface (#23603), the existing `Agent_sdk.Hooks.ApprovalRequired` callback path, `Keeper_approval_queue.submit_and_await`, `Keeper_approval_queue.resolve_with_policy`, and the per-request "항상 승인" rule (`respondToKeeperApproval(id, 'approve', rememberRule=true)`).
 - Evidence base: keeper-v2 design mockup (`~/Downloads/Keeper Agent v2 (standalone) (3).html`) renders an **AUTO 승인 모드** panel with the note "비가역·파괴적(bad)은 항상 수동 결재 — 직무분리 원칙". Audit 2026-07-08: no runtime operator-toggleable keeper approval mode exists. `rg "approval_mode|approval-mode" lib/server/ dashboard/src` returns **zero** dashboard/governance mode endpoints; current auto paths are fixed keeper metadata/rule paths in `Governance_pipeline.to_oas_approval_callback` (`always_approve`, `find_matching_rule`) plus the legacy SDK-local `operator_approval.ml` policy, not a global operator mode.
@@ -9,9 +9,9 @@
 
 The v2 design promises an operator control the runtime does not have: a **mode** that lets the operator run the HITL queue in *auto* (low-risk keeper actions clear without a human) or *manual* (every gated action waits), with a hard invariant that destructive/irreversible actions are **never** auto-approved.
 
-Today:
+At the 2026-07-08 design audit (before implementation):
 
-- `governance_approval_guard` only decides when a keeper tool call needs approval; the real approve/queue/reject decision is in `Governance_pipeline.to_oas_approval_callback`, which may reject hard-forbidden requests, auto-approve `always_approve`, auto-approve a remembered rule match, or call `Keeper_approval_queue.submit_and_await`.
+- `governance_approval_guard` now decides when a keeper tool call needs approval; the real approve/queue decision is in `Governance_pipeline.to_oas_approval_callback`. Critical risk or a structured runtime blocker establishes an operator-only floor: it bypasses automatic flags/rules/mode and enters the ordinary HITL continuation path instead of becoming a terminal policy rejection.
 - The dashboard can approve, approve+always (a per-request rule persisted through `resolve_with_policy`), or reject via `respondToKeeperApproval` -> `/api/v1/dashboard/governance/approvals/resolve`. There is **no mode**: the operator cannot say "auto-clear low-risk for the next hour" and they cannot see or change a global posture.
 - Building the design's toggle as UI-only would be a **dead/dangerous stub**: a switch that reads as "auto-approving keeper actions" while gating nothing. A governance control that does not actually gate is worse than absent — it manufactures false assurance. This violates the workspace no-stub / no-silent-failure bar and is safety-relevant.
 
@@ -58,13 +58,13 @@ type approval_risk_projection =
 
 ### 4. Decision integration
 
-At the keeper approval callback decision point (`Governance_pipeline.to_oas_approval_callback`), consult the mode after hard-forbidden rejection and before `always_approve` / remembered-rule / `submit_and_await`:
+At the keeper approval callback decision point (`Governance_pipeline.to_oas_approval_callback`), apply the operator-only floor before `always_approve`, remembered rules, and approval mode:
 
 ```
 decide(request):
   risk = approval_risk_projection(request)
-  if hard_forbidden(request):                (* critical/runtime blocker today *)
-      -> Reject + audit hard_forbidden        (* existing terminal wall *)
+  if manual_approval_required(request):       (* critical/runtime blocker *)
+      -> Manual HITL continuation             (* never an automatic decision *)
   if soft_forbidden(request):                (* destructive tool/op signal today *)
       -> Manual (submit_and_await)            (* mode must not bypass it *)
   if risk ∈ {Classified Critical, Classified High, Unclassified _}:
@@ -77,7 +77,7 @@ decide(request):
 ```
 
 - The `{Critical, High} | Unclassified -> Manual` line is evaluated **before** the mode branch, so no mode can reach a destructive action. Exhaustive `match` over the projection and mode; a new band or mode fails to compile until handled.
-- Existing always/rule auto-approval remains orthogonal but must share the same floor: hard-forbidden still rejects before any auto path, mode never overrides `soft_forbidden`, and `High | Critical | Unclassified` never auto-approves by mode.
+- Existing always/rule auto-approval remains orthogonal but shares the same floor: operator-only requests skip every auto path, mode never overrides `soft_forbidden`, and `High | Critical | Unclassified` never auto-approves by mode. An explicit one-shot operator grant is consumed before the floor is re-evaluated so a resolved continuation can actually run.
 - `Keeper_approval_queue.audit_approval_event` records mode auto-clears with a distinct `event_type` such as `auto_approved_mode_low_risk`, `auto_approved=true`, `created_by=auto_mode`, and the authorizing mode/risk fields.
 
 ### 5. Operator API
@@ -100,7 +100,7 @@ decide(request):
 ## Verification
 
 - **Mode round-trip**: GET/POST reflect the set mode; an out-of-variant POST is rejected.
-- **Queue integration**: `governance_approval_guard` still raises `ApprovalRequired`; `to_oas_approval_callback` chooses exactly one of hard reject, mode auto-approve, always/rule auto-approve, or `Keeper_approval_queue.submit_and_await`.
+- **Queue integration**: `governance_approval_guard` raises `ApprovalRequired`; `to_oas_approval_callback` chooses exactly one of operator continuation, mode auto-approve, always/rule auto-approve, or ordinary threshold approval.
 - **Invariant (must-fail model)**: in `Auto_low_risk`, a `critical` and a `high` request are queued/rejected according to the existing hard floor, never auto. TLA+ `NextBuggy = Next \/ AutoApprovesDestructive` must violate `NoDestructiveAutoApproval`; clean `Next` must satisfy it (per the workspace TLA+ bug-model pattern).
 - **Classifier/downcast bug cases**: a destructive request that a buggy classifier/downcast reports as low but still carries the existing destructive tool/op signal is manual-only; a missing risk field and an unknown future wire value become `Unclassified`; assert no `Auto_approved` record is emitted for any of these cases.
 - **Fail-closed**: an unclassified/missing band is queued, not auto-approved, in every mode.

--- a/docs/rfc/RFC-0329-keeper-execute-governance-payload-aware-and-typed-exemption.md
+++ b/docs/rfc/RFC-0329-keeper-execute-governance-payload-aware-and-typed-exemption.md
@@ -14,17 +14,30 @@
 > requires follow-up issue [#23906](https://github.com/jeong-sik/masc/issues/23906)
 > and security review.
 
+> **Operator-continuation correction (2026-07-12).** The terminal Critical
+> rejection described below is historical. `governance_approval_guard` now
+> returns `ApprovalRequired` for the Keeper High/Critical floor and the approval
+> callback registers the ordinary nonblocking HITL continuation. Automatic
+> flags, remembered rules, and approval mode cannot cross that floor; an exact
+> one-shot operator resolution can resume the Keeper in a later cycle.
+
 ---
 
-## 1. Problem — a granted capability that is unconditionally blocked
+## 1. Historical problem — a granted capability was unconditionally blocked
 
-A keeper is granted the `tool_execute` tool in its `tool_access`. The governance gate then blocks every use of it, unconditionally, in a way HITL cannot resolve. The structure is:
+A keeper was granted the `tool_execute` tool in its `tool_access`, while the
+governance gate blocked every use in a way HITL could not resolve. Before the
+2026-07-12 operator-continuation correction, the structure was:
 
 1. `tool_execute` is force-marked destructive in the catalog (`static_destructive_tool_names` includes `"tool_execute"`, `tool_catalog.ml:183-184`, applied via `force_true_if_member` `:416`), so `classify_with_metadata "tool_execute"` returns `Some Critical`. Independently, `risk_of_keeper Execute -> Critical` (`governance_pipeline_risk.ml:141`) is unconditional. Either source alone makes the risk Critical, ignoring the command payload.
-2. `keeper_guards.governance_approval_guard` (`keeper_guards.ml:944-963`) computes `hard_forbidden = auto_approval_hard_forbidden ~risk = (risk = Critical || runtime_auto_approval_blocked)` (`governance_pipeline.ml:104-105`). For Critical this is true, and the guard returns `Agent_sdk.Hooks.Block` with reason "hard_forbidden: unconditional block regardless of HITL mode" (`:958`) — before the tool handler runs.
-3. There is no active exemption path. A prior attempt read keeper names from `MASC_CODE_EXEMPT_KEEPERS` and bypassed the generic `needs_approval` branch, but it was removed because the decision was not scoped to a typed code-tool category and was not audited. Critical Execute remains blocked before any future exemption point.
+2. `keeper_guards.governance_approval_guard` computed a terminal policy predicate for Critical/runtime blockers and returned `Agent_sdk.Hooks.Block` before the tool handler or HITL continuation could run. That branch is retired; the current guard returns `ApprovalRequired` and the callback owns the operator continuation.
+3. There is no active exemption path. A prior attempt read keeper names from `MASC_CODE_EXEMPT_KEEPERS` and bypassed the generic `needs_approval` branch, but it was removed because the decision was not scoped to a typed code-tool category and was not audited. Critical Execute now reaches the ordinary operator continuation, but no exemption can bypass that decision.
 
-Net: no keeper can run any shell command — `git status` and `rm -rf /` alike — and no HITL approval can change that. A capability that is always blocked is not a capability. This is the "weird structure" the incident (RFC-0328) exposed; `mad-improver` correctly observed "Execute is blocked" and then confabulated a repo-mapping cause because the true structure is invisible to the keeper.
+The historical result was that no keeper could run any shell command — `git
+status` and `rm -rf /` alike — and no HITL approval could change that. The
+terminal part of that structure is now removed. Payload-aware risk remains a
+separate Gap A: read-only and destructive commands can still share the same
+approval band, but an operator decision is no longer made impossible.
 
 The already-built typed classifier that *can* tell `git status` from `rm -rf /` — `Masc_exec.Shell_ir_risk` (closed sum `R0_Read | R1_Reversible_mutation | R2_Irreversible | Destructive_protected`, `shell_ir_risk.mli:10-14`) plus the handler-level `Approval_policy`/`catastrophic_floor` (RFC-0254, Active) — lives *inside* the handler and is categorically unreachable for the governance decision (`rg 'Shell_ir|Approval_policy|R0_Read' lib/governance_pipeline*.ml` = 0 hits). The cruder gate runs first and shadows the typed one.
 
@@ -54,7 +67,7 @@ This is the correction that an adversarial pass forced, and it is the load-beari
 - `Docker` (`:1158`), `Awk` with `system()` (`:1165`)
 - unknown/interpreter heads not otherwise typed (perl, ruby, php, osascript, deno, bun, Rscript, `tar --to-command`)
 
-Mapping `R0_Read → Low` flatly would let `awk 'BEGIN{system("...")}'`, `perl -e`, an unknown binary, `$VAR`-bearing argv, or a compound `git status; rm -rf /` slip below the `hard_forbidden` Critical line. That is fail-open. The claim in an earlier draft that "these already fail closed to Critical inside classify" is false and is corrected here.
+Mapping `R0_Read → Low` flatly would let `awk 'BEGIN{system("...")}'`, `perl -e`, an unknown binary, `$VAR`-bearing argv, or a compound `git status; rm -rf /` slip below the Critical operator floor. That is fail-open. The claim in an earlier draft that "these already fail closed to Critical inside classify" is false and is corrected here.
 
 De-escalate below Critical **only when both** conditions hold:
 
@@ -98,8 +111,11 @@ It removes two classifiers (the catalog destructive override and `risk_of_keeper
 
 **Current production-safe state (verified 2026-07-10).**
 `governance_approval_guard` has no keeper-name exemption. Critical decisions
-take the `hard_forbidden` Block branch, and every remaining decision at or above
-the keeper confirmation threshold returns `ApprovalRequired`.
+and every remaining decision at or above the keeper confirmation threshold
+return `ApprovalRequired`. The approval callback then enforces the operator-only
+floor: Critical calls cannot use automatic flags, remembered rules, or approval
+mode, but an explicit operator resolution can resume the nonblocking Keeper
+continuation.
 
 **Removed unsafe attempt.** PR #23761 added `MASC_CODE_EXEMPT_KEEPERS` as a
 space-split set of raw keeper-name strings. The generic approval branch checked
@@ -149,7 +165,7 @@ Override clause: this is a security-loosening change, not production-blocking; i
 
 Exercise `Governance_pipeline_risk.assess_risk ~tool_name:"tool_execute"` (the wiring), not only `Shell_ir_risk.classify` (the substrate):
 
-- Below Critical (must NOT hard_forbidden): `git status`, `git log --oneline -5`, `git diff`, `ls`, `cat FILE`, `rg PATTERN`, `gh pr view 123`, `gh pr diff 123` → Low.
+- Below Critical (must not enter the High/Critical operator floor): `git status`, `git log --oneline -5`, `git diff`, `ls`, `cat FILE`, `rg PATTERN`, `gh pr view 123`, `gh pr diff 123` → Low.
 - Fail-closed to Critical (the actual risk surface — these are the tests the earlier draft omitted): `awk 'BEGIN{system("id")}'`, `perl -e '...'`, `ruby -e '...'`, `tar --to-command ...`, `docker run ...`, an unknown binary, `gh <unknown-subcommand>`, `$VAR`-bearing argv, and the compound `git status; rm -rf /` → each ≥ Critical.
 - Known-destructive to Critical: `rm -rf /`, `git push --force`, `mkfs...`, `sed -i ...`, any `$( )` substitution, `curl ... | sh` → Critical.
 - R1 floor: `git commit`, `curl https://...`, `ssh host` → High (reaches the approval floor), asserted to NOT auto-run at production `keeper_confirm_threshold`.
@@ -157,7 +173,7 @@ Exercise `Governance_pipeline_risk.assess_risk ~tool_name:"tool_execute"` (the w
 ### 6.2 Exemption (Gap B)
 
 - The retired `MASC_CODE_EXEMPT_KEEPERS` value has no effect: a High-risk non-code tool still returns `ApprovalRequired`.
-- Critical Execute remains Block even when the retired environment variable names the current keeper.
+- Critical Execute remains `ApprovalRequired` even when the retired environment variable names the current keeper; it is never terminally rejected by this policy.
 - Any future typed exemption must prove that only its explicit typed code-tool category can continue and that exactly one exemption audit event is emitted.
 
 ### 6.3 Flag audit (Gap A gating)
@@ -174,11 +190,11 @@ A test/assertion that with `MASC_SHELL_IR_APPROVAL_GATE_ENABLED` off (if reachab
 | RFC-0160 shell-ir-first-class | Implemented | Established Shell-IR as the single decision substrate in the exec runtime; Gap A completes that for the governance layer. |
 | RFC-0208 shell-ir-compositional-risk-ast | Draft | Owns the compositional risk AST with `R0_Read`; Gap A consumes it. |
 | RFC-0091 execute-typed-argv | Implemented | Provides the typed argv → `Shell_ir` lowering Gap A reuses; each argv token is literal by construction, which is why a typed classifier (not substring) is the correct basis and why non-literal argv must fail closed. |
-| RFC-0254 shell-ir-approval-autonomous-policy | Active | The landed handler-level typed gate that already allows `git status` but runs downstream of and is shadowed by the governance Block. Gap A lifts its typed verdict up into the PreToolUse risk assessment. |
+| RFC-0254 shell-ir-approval-autonomous-policy | Active | The landed handler-level typed gate already distinguishes `git status`, but it still runs downstream of the coarser governance approval classification. Gap A lifts its typed verdict into the PreToolUse risk assessment. |
 | RFC-0255 shell-ir-path-typed-scope-and-floor-narrow | Draft | Documents the per-binary string-exemption ladder as the N-of-M fail-open pattern to avoid (§2.2). |
 | RFC-0131 shell command gate facade | referenced | The handler-side gate facade, structurally separate from `governance_approval_guard`; confirms the two-gate split Gap A unifies. |
-| RFC-0321 hard-forbidden-typed-error | Draft/impl | Made `hard_forbidden` a typed `Block`; its open-question #3 (dual risk evaluation) is exactly the governance-vs-ShellIR shadowing Gap A fixes. |
-| RFC-0304 hitl-critical-bounded-escalation | Draft | Its Defer/escalation applies to the ApprovalRequired path, which Critical Execute never reaches (it Blocks first). After Gap A, R1/High Execute reaches that path. |
+| RFC-0321 retired terminal-policy error | Historical | Its terminal `Block` is retired. Its open-question #3 (dual risk evaluation) still describes the governance-vs-ShellIR shadowing Gap A fixes. |
+| RFC-0304 hitl-critical-bounded-escalation | Draft | Its Defer/escalation now applies to High/Critical Keeper requests through the `ApprovalRequired` continuation path. |
 | RFC-0309 typed-gh-capability-gating | Draft | The `gh` capability axis Gap A §3.1 consumes for unrecognized subcommands (`Gh_capability_policy.disposition_of`). |
 | RFC-0312 keeper-repo-mapping-advisory-scope | Accepted | Confirms repo mappings are advisory and non-gating; Gap A/B must not re-introduce a hidden cap 0312 removed. |
 | RFC-0126 silent-fallback-discipline | Implemented | The fail-closed discipline Gap A honors (Unknown → Critical, never a permissive default). |

--- a/lib/config_dir_resolver/config_dir_resolver.ml
+++ b/lib/config_dir_resolver/config_dir_resolver.ml
@@ -178,7 +178,11 @@ let canonical_base_path raw =
   if String.equal normalized ""
   then Error Empty_after_normalization
   else
-    let absolute = absolute_path_from ~cwd:(current_working_dir ()) normalized in
+    let absolute =
+      if Filename.is_relative normalized
+      then absolute_path_from ~cwd:(current_working_dir ()) normalized
+      else normalized
+    in
     let canonical = Env_config_core.normalize_masc_base_path_input absolute in
     if String.equal canonical "" || Filename.is_relative canonical
     then Error (Could_not_derive_absolute { input = raw })

--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -31,6 +31,32 @@ let assess_trifecta = Governance_pipeline_risk.assess_trifecta
 let combinatorial_risk_escalation = Governance_pipeline_risk.combinatorial_risk_escalation
 let assess_risk = Governance_pipeline_risk.assess_risk
 
+type keeper_risk_assessment =
+  { base_risk : risk_level
+  ; effective_risk : risk_level
+  ; trifecta_active : bool
+  }
+
+type keeper_risk_context = { trifecta_active : bool }
+
+let keeper_risk_context ~active_tool_names =
+  let trifecta_count, _, _, _ = assess_trifecta ~active_tool_names in
+  { trifecta_active = trifecta_count >= 3 }
+;;
+
+let assess_keeper_risk ~context ~tool_name ~input =
+  let trifecta_active = context.trifecta_active in
+  let base_risk = assess_risk ~tool_name ~input in
+  let effective_risk =
+    combinatorial_risk_escalation
+      ~trifecta_active
+      ~tool_name
+      ~input
+      ~base_risk
+  in
+  { base_risk; effective_risk; trifecta_active }
+;;
+
 (* ── Trace ID generation ────────────────────────────────────── *)
 
 let trace_id prefix =
@@ -88,21 +114,17 @@ let runtime_auto_approval_blocked = function
       Keeper_meta_contract.blocker_class_auto_approval_blocked blocker.klass
 ;;
 
-(** PR-E (Plan v3 Leak 1): split the legacy [auto_approval_forbidden]
-    into a "hard" component that always wins and a "soft" pattern
-    component that a narrowly-scoped routine allowlist match is
-    permitted to override.
-
-    - Hard forbidden = the request is at Critical risk OR structured
-      [runtime.last_blocker] is set.  Routine matchers must not
-      bypass these — this is where real safety walls live.  The
-      blocker [detail] is free-form UI/debug context, not a policy
-      classifier.
-    - Soft forbidden = the tool name or op string trips
-      [destructive_tool_or_op] (a substring filter on "shell"/"git"
-      plus a small list of bash/git ops). *)
-let auto_approval_hard_forbidden ~risk meta =
+(** Critical risk and structured runtime blockers establish an operator-only
+    confirmation floor. They prohibit automatic approval, but they do not make
+    an operator decision impossible: the request follows the ordinary HITL
+    continuation path and can resume the Keeper lane after resolution. The
+    blocker [detail] remains display context, never a policy classifier. *)
+let manual_approval_required ~risk meta =
   risk = Critical || runtime_auto_approval_blocked meta
+;;
+
+let keeper_manual_approval_required ~risk meta =
+  risk = High || manual_approval_required ~risk meta
 ;;
 
 (** Minimum risk level that triggers audit logging. *)
@@ -117,11 +139,10 @@ let decide ?meta ~governance_level ~tool_name ~input () =
   let risk = assess_risk ~tool_name ~input in
   let trace_id = generate_trace_id () in
   let action =
-    if auto_approval_hard_forbidden ~risk meta then
+    if manual_approval_required ~risk meta then
       `Require_confirm
         (Printf.sprintf
-           "Governance (%s): %s risk tool %S requires confirmation: auto-approval is \
-            hard-forbidden"
+           "Governance (%s): %s risk tool %S requires operator confirmation"
            governance_level
            (risk_level_to_string risk)
            tool_name)
@@ -309,21 +330,6 @@ let approval_band_of_risk = function
   | Critical -> Operator_approval.Band_critical
 ;;
 
-(* Human-readable reason attached to a hard-forbidden rejection.
-   Reports every wall that fired — Critical risk, an active runtime
-   blocker, or both — so operators see the complete disposition in the
-   audit trail rather than only the highest-precedence one. *)
-let forbidden_reject_reason ~risk ~runtime_blocked =
-  match risk = Critical, runtime_blocked with
-  | true, true ->
-    "critical risk tool and runtime contract both block auto-approval"
-  | true, false -> "critical risk tool cannot be auto-approved"
-  | false, true -> "runtime contract blocks auto-approval"
-  | false, false ->
-    invalid_arg
-      "forbidden_reject_reason: expected Critical risk or runtime auto-approval blocker"
-;;
-
 type hitl_approval_grant =
   { approval_id : string
   ; approved_action : Keeper_event_queue.hitl_approved_action
@@ -352,63 +358,14 @@ let consume_hitl_approval_grant grant ~keeper_name ~tool_name ~input =
   && Atomic.compare_and_set grant.consumed false true
 ;;
 
-(* Reject a hard-forbidden request outright, auditing the decision as a
-   terminal event. Called before any HITL queue path so the request can
-   never be approved by an operator or a remembered rule. *)
-let reject_hard_forbidden ~config ~keeper_name ~tool_name ~input ~risk ~meta () =
-  let risk_level = queue_risk_level risk in
-  let base_path = (config : Workspace.config).base_path in
-  let runtime_blocked = runtime_auto_approval_blocked meta in
-  let reason = forbidden_reject_reason ~risk ~runtime_blocked in
-  let turn_id =
-    Option.map
-      (fun (m : Keeper_meta_contract.keeper_meta) -> m.runtime.usage.total_turns + 1)
-      meta
-  in
-  let task_id = Option.bind meta Keeper_runtime_contract.current_task_id_opt in
-  let goal_id = Option.bind meta Keeper_runtime_contract.primary_goal_id_opt in
-  let goal_ids =
-    match meta with
-    | Some (m : Keeper_meta_contract.keeper_meta) -> m.active_goal_ids
-    | None -> []
-  in
-  let runtime_contract =
-    Option.map (Keeper_runtime_contract.runtime_contract_json ~config) meta
-  in
-  let sandbox_target =
-    Option.map
-      (fun keeper_meta -> Keeper_runtime_contract.backend_of_meta keeper_meta)
-      meta
-  in
-  let selected_model = selected_model_of_meta meta in
-  let decision = Agent_sdk.Hooks.Reject reason in
-  Keeper_approval_queue.audit_approval_event
-    ~base_path
-    ~event_type:Keeper_approval_queue.approval_audit_hard_forbidden_event
-    ~id:(Keeper_approval_queue.generate_id ())
-    ~keeper_name
-    ~tool_name
-    ~risk_level
-    ?turn_id
-    ?task_id
-    ?goal_id
-    ~goal_ids
-    ?sandbox_target
-    ?runtime_contract
-    ?selected_model
-    ~disposition:"Blocked"
-    ~disposition_reason:"hard_forbidden"
-    ~auto_approved:false
-    ~decision:(Keeper_approval_queue.Approval_resolved decision)
-    ();
-  decision
-;;
-
 let to_oas_approval_callback
       ~config
       ~governance_level
       ~keeper_name
       ?meta
+      ?meta_provider
+      ?active_tool_names
+      ?risk_context
       ?clock
       ?continuation_channel
       ?(lane_policy = Keeper_approval_queue.Blocking)
@@ -416,37 +373,52 @@ let to_oas_approval_callback
       ()
   : Agent_sdk.Hooks.approval_callback
   =
+  if Option.is_some meta && Option.is_some meta_provider
+  then invalid_arg "to_oas_approval_callback: provide meta or meta_provider, not both";
+  if Option.is_some active_tool_names && Option.is_some risk_context
+  then
+    invalid_arg
+      "to_oas_approval_callback: provide active_tool_names or risk_context, not both";
+  let risk_context =
+    match risk_context with
+    | Some context -> context
+    | None ->
+      let active_tool_names =
+        match active_tool_names with
+        | Some names -> names
+        | None ->
+          Tool_shard.get_agent_shards keeper_name
+          |> Tool_shard.tools_of_shards
+          |> List.map (fun (schema : Masc_domain.tool_schema) -> schema.name)
+      in
+      keeper_risk_context ~active_tool_names
+  in
   fun ~tool_name ~input ->
-    let active_tool_names =
-      Tool_shard.get_agent_shards keeper_name
-      |> Tool_shard.tools_of_shards
-      |> List.map (fun (s : Masc_domain.tool_schema) -> s.name)
+    let meta, metadata_unavailable =
+      match meta_provider with
+      | Some current ->
+        (match current () with
+         | Some meta -> Some meta, false
+         | None -> None, true)
+      | None -> meta, false
     in
-    let trifecta_count, _, _, _ = assess_trifecta ~active_tool_names in
-    let trifecta_active = trifecta_count >= 3 in
-    let base_risk = assess_risk ~tool_name ~input in
-    let risk =
-      combinatorial_risk_escalation ~trifecta_active ~tool_name ~input ~base_risk
+    let risk_assessment =
+      assess_keeper_risk ~context:risk_context ~tool_name ~input
     in
+    let base_risk = risk_assessment.base_risk in
+    let risk = risk_assessment.effective_risk in
+    let trifecta_active = risk_assessment.trifecta_active in
     let needs_approval =
       match keeper_confirm_threshold governance_level with
       | Some threshold -> risk_level_to_int risk >= risk_level_to_int threshold
       | None -> false
     in
-    let hard_forbidden = auto_approval_hard_forbidden ~risk meta in
+    let operator_floor =
+      metadata_unavailable || keeper_manual_approval_required ~risk meta
+    in
     let soft_forbidden = auto_approval_soft_forbidden ~tool_name ~input in
-    if hard_forbidden
-    then (
-      Log.Governance.debug
-        "[%s] hard_forbidden tool=%s base=%s effective=%s: rejecting outright"
-        keeper_name
-        tool_name
-        (risk_level_to_string base_risk)
-        (risk_level_to_string risk);
-      reject_hard_forbidden ~config ~keeper_name ~tool_name ~input ~risk ~meta ())
-    else (
-      let auto_approval_forbidden = soft_forbidden in
-      let requires_operator_approval = needs_approval || auto_approval_forbidden in
+    let auto_approval_forbidden = operator_floor || soft_forbidden in
+    let requires_operator_approval = needs_approval || auto_approval_forbidden in
       let base_path = (config : Workspace.config).base_path in
       if trifecta_active
       then
@@ -573,16 +545,22 @@ let to_oas_approval_callback
           Agent_sdk.Hooks.Approve
         | None ->
           match
-            Keeper_approval_queue.find_matching_rule
-              ~base_path
-              ~keeper_name
-              ~tool_name
-              ~input
-              ~risk_level
-              ?sandbox_profile
-              ?backend
-              ?runtime_contract
-              ()
+            (* A remembered rule is an exact operator decision, not a blanket
+               automatic mode.  Soft signals may reuse it; the High/Critical
+               operator floor may not. *)
+            if operator_floor
+            then None
+            else
+              Keeper_approval_queue.find_matching_rule
+                ~base_path
+                ~keeper_name
+                ~tool_name
+                ~input
+                ~risk_level
+                ?sandbox_profile
+                ?backend
+                ?runtime_contract
+                ()
           with
           | Some matched ->
             Keeper_approval_queue.audit_approval_event
@@ -668,7 +646,30 @@ let to_oas_approval_callback
                   ?continuation_channel
                   ()
             in
-            (match Operator_approval.decide_approval_mode ~mode ~band with
+            (match
+               if metadata_unavailable
+               then
+                 Operator_approval.Queue_for_operator
+                   { mode
+                   ; band
+                   ; reason = Operator_approval.Metadata_unavailable
+                   }
+               else if operator_floor
+               then
+                 Operator_approval.Queue_for_operator
+                   { mode
+                   ; band
+                   ; reason = Operator_approval.Separation_of_duties_floor
+                   }
+               else if soft_forbidden
+               then
+                 Operator_approval.Queue_for_operator
+                   { mode
+                   ; band
+                   ; reason = Operator_approval.Automatic_approval_prohibited
+                   }
+               else Operator_approval.decide_approval_mode ~mode ~band
+             with
              | Operator_approval.Auto_approved { mode; band } ->
                Keeper_approval_queue.audit_approval_event
                  ~base_path
@@ -694,5 +695,5 @@ let to_oas_approval_callback
                  ();
                Agent_sdk.Hooks.Approve
              | Operator_approval.Queue_for_operator { reason; mode = _; band = _ } ->
-               submit_for_operator reason)))
+               submit_for_operator reason))
 ;;

--- a/lib/governance_pipeline.mli
+++ b/lib/governance_pipeline.mli
@@ -30,7 +30,7 @@ val confirm_threshold : string -> risk_level option
 (** Minimum risk level that requires confirmation for the given governance level.
     Returns [None] for "development" (no threshold-triggered confirmation
     needed) or when HITL thresholds are disabled. This threshold does not
-    include the hard-forbidden auto-approval override applied by {!decide}. *)
+    include the operator-only confirmation floor applied by {!decide}. *)
 
 val keeper_confirm_threshold : string -> risk_level option
 (** Keeper-specific confirmation threshold.
@@ -51,9 +51,39 @@ val assess_risk : tool_name:string -> input:Yojson.Safe.t -> risk_level
     - Medium: state-changing reads
     - Low: readonly/status/query surfaces *)
 
-val auto_approval_hard_forbidden :
+type keeper_risk_assessment =
+  { base_risk : risk_level
+  ; effective_risk : risk_level
+  ; trifecta_active : bool
+  }
+
+type keeper_risk_context
+
+val keeper_risk_context :
+  active_tool_names:string list -> keeper_risk_context
+(** Derive the immutable combinatorial context for one installed agent tool
+    surface. Compute once when assembling the run, not per tool call. *)
+
+val assess_keeper_risk :
+  context:keeper_risk_context ->
+  tool_name:string ->
+  input:Yojson.Safe.t ->
+  keeper_risk_assessment
+(** Keeper risk projection shared by the pre-tool guard and approval callback.
+    [context] belongs to the immutable tool surface installed for the current
+    run, avoiding shard lookup and capability rescans on the per-tool hot path. *)
+
+val manual_approval_required :
   risk:risk_level -> Keeper_meta_contract.keeper_meta option -> bool
-(** True when auto-approval must be blocked regardless of HITL threshold. *)
+(** True when a Critical call or structured runtime blocker requires a real
+    operator decision. Automatic flags, remembered rules, and approval mode
+    cannot bypass this floor; an explicit one-shot operator grant can. *)
+
+val keeper_manual_approval_required :
+  risk:risk_level -> Keeper_meta_contract.keeper_meta option -> bool
+(** Keeper-only operator floor. In addition to {!manual_approval_required},
+    High-risk calls require a real operator decision. This keeps the generic
+    front-door governance thresholds distinct from the Keeper contract. *)
 
 val decide :
   ?meta:Keeper_meta_contract.keeper_meta ->
@@ -64,7 +94,7 @@ val decide :
   governance_decision
 (** Evaluate a tool call against governance policy and return a decision.
     - development: allow Low/Medium/High while HITL is enabled, audit High+Critical,
-      but always confirm hard-forbidden calls
+      but always confirm calls subject to the operator-only floor
     - production: confirm Critical, audit Medium+
     - enterprise: confirm High+Critical, audit all
     - paranoid: confirm Medium+High+Critical, audit all
@@ -72,14 +102,15 @@ val decide :
     [meta] is optional because front-door governance is server-scoped:
     it classifies the tool call itself and does not need keeper runtime
     state. The [runtime_auto_approval_blocked] component of
-    [auto_approval_hard_forbidden] is keeper-scoped (it inspects
+    [manual_approval_required] is keeper-scoped (it inspects
     [meta.runtime.last_blocker]), so passing [None] from the front door
     is intentional and correct.
 
-    Hard-forbidden calls (Critical risk or keeper runtime blocker) always
-    require confirmation, even if they would otherwise fall below the
-    governance threshold, and even when HITL thresholds are disabled, so
-    disabling HITL cannot silently auto-approve destructive operations. *)
+    Critical calls and calls with a keeper runtime blocker always require
+    operator confirmation, even if they would otherwise fall below the
+    governance threshold and even when ordinary HITL thresholds are disabled.
+    They are queued through the standard continuation path rather than being
+    terminally rejected. *)
 
 val make_pre_hook :
   ?meta:Keeper_meta_contract.keeper_meta ->
@@ -152,6 +183,9 @@ val to_oas_approval_callback :
   governance_level:string ->
   keeper_name:string ->
   ?meta:Keeper_meta_contract.keeper_meta ->
+  ?meta_provider:(unit -> Keeper_meta_contract.keeper_meta option) ->
+  ?active_tool_names:string list ->
+  ?risk_context:keeper_risk_context ->
   ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
   ?continuation_channel:Keeper_continuation_channel.t ->
   ?lane_policy:Keeper_approval_queue.lane_policy ->
@@ -160,8 +194,11 @@ val to_oas_approval_callback :
   Agent_sdk.Hooks.approval_callback
 (** Build an OAS approval callback with HITL approval handling.
 
-    Pre-computes trifecta status from the keeper's active shard tool set.
-    When trifecta is active, state-modifying tools get risk escalation.
+    [risk_context] should be the immutable projection shared by the current
+    agent run. Compatibility callers may instead provide [active_tool_names],
+    or omit both to derive the context from keeper shard state once when the
+    callback is built. When trifecta is active, state-modifying tools get risk
+    escalation.
 
     With [lane_policy = Blocking] (the compatibility default), a tool that
     exceeds the governance threshold suspends via
@@ -176,9 +213,16 @@ val to_oas_approval_callback :
     It is scoped by the caller to the independent cycle opened by that wake;
     there is no persisted blanket rule or time-based grant.
 
+    [meta_provider] is the live per-turn metadata source used by production
+    Keeper runs. It is sampled for every approval decision so a runtime blocker
+    established between tool calls cannot be bypassed by captured turn-start
+    metadata. Supplying both [meta] and [meta_provider] is invalid. [meta] is
+    retained for immutable callers and focused tests.
+
     Tools below the threshold are auto-approved unless auto-approval is
-    explicitly forbidden. Critical risk and runtime safety blockers still enter
-    the operator approval queue even when HITL thresholds are otherwise
-    disabled. Soft destructive tool-name/op heuristics are HITL-dependent.
+    explicitly forbidden. High/Critical Keeper risk and runtime safety blockers
+    still enter the operator approval queue even when HITL thresholds are
+    otherwise disabled. Soft destructive tool-name/op heuristics are
+    HITL-dependent.
 
     @since 2.262.0 (#5902, #5907) *)

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -822,7 +822,8 @@ let run_turn
                          ~config
                          ~governance_level:(Env_config_core.governance_level ())
                          ~keeper_name:meta.name
-                         ~meta
+                         ~meta_provider:s.Keeper_run_tools.current_meta
+                         ~risk_context:s.Keeper_run_tools.risk_context
                          ?clock:(Eio_context.get_clock_opt ())
                          ?continuation_channel
                          ~lane_policy:Keeper_approval_queue.Nonblocking

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -81,10 +81,46 @@ let read_recent_audit_raw store limit =
 
 let approval_audit_pending_event = "pending"
 let approval_audit_resolved_event = "resolved"
-let approval_audit_hard_forbidden_event = "hard_forbidden"
 let approval_audit_summary_event = "summary_updated"
 let approval_sse_pending_event = "approval:pending"
 let approval_sse_resolved_event = "approval:resolved"
+
+type approval_audit_event_kind =
+  | Audit_pending
+  | Audit_resolved
+  | Audit_expired
+  | Audit_timeout
+  | Audit_cancelled
+  | Audit_auto_rule
+  | Audit_auto_always
+  | Audit_rule_created
+  | Audit_legacy_terminal_rejection
+  | Audit_other of string
+
+let approval_audit_event_kind_of_wire = function
+  | "pending" -> Audit_pending
+  | "resolved" -> Audit_resolved
+  | "expired" -> Audit_expired
+  | "approval_timeout" -> Audit_timeout
+  | "cancelled" -> Audit_cancelled
+  | "auto_approved_rule_match" -> Audit_auto_rule
+  | "auto_approved_always" -> Audit_auto_always
+  | "rule_created" -> Audit_rule_created
+  | "hard_forbidden" -> Audit_legacy_terminal_rejection
+  | other -> Audit_other other
+;;
+
+let approval_audit_event_kind_to_canonical_wire = function
+  | Audit_pending -> "pending"
+  | Audit_resolved | Audit_legacy_terminal_rejection -> "resolved"
+  | Audit_expired -> "expired"
+  | Audit_timeout -> "approval_timeout"
+  | Audit_cancelled -> "cancelled"
+  | Audit_auto_rule -> "auto_approved_rule_match"
+  | Audit_auto_always -> "auto_approved_always"
+  | Audit_rule_created -> "rule_created"
+  | Audit_other other -> other
+;;
 let approval_sse_summary_event = "approval:summary_updated"
 
 let non_empty_reason reason =
@@ -350,16 +386,44 @@ let resolved_approval_decision_kind json =
 let resolved_history_event json =
   match Safe_ops.json_string_opt "event" json with
   | Some event ->
-    String.equal event approval_audit_resolved_event
-    || String.equal event approval_audit_hard_forbidden_event
+    (match approval_audit_event_kind_of_wire event with
+     | Audit_resolved | Audit_legacy_terminal_rejection -> true
+     | Audit_pending
+     | Audit_expired
+     | Audit_timeout
+     | Audit_cancelled
+     | Audit_auto_rule
+     | Audit_auto_always
+     | Audit_rule_created
+     | Audit_other _ -> false)
   | None -> false
 ;;
 
 let resolved_approval_json_of_audit_event json =
   let resolved_at = Safe_ops.json_float_opt "ts" json in
+  let event_kind =
+    Safe_ops.json_string_opt "event" json
+    |> Option.map approval_audit_event_kind_of_wire
+  in
+  let disposition_reason =
+    match event_kind with
+    | Some Audit_legacy_terminal_rejection -> `String "retired_terminal_policy"
+    | Some
+        (Audit_pending
+        | Audit_resolved
+        | Audit_expired
+        | Audit_timeout
+        | Audit_cancelled
+        | Audit_auto_rule
+        | Audit_auto_always
+        | Audit_rule_created
+        | Audit_other _)
+    | None ->
+      json_member_or_null "disposition_reason" json
+  in
   `Assoc
     [ "id", `String (Safe_ops.json_string ~default:"" "id" json)
-    ; "event", `String (Safe_ops.json_string ~default:"" "event" json)
+    ; "event", `String approval_audit_resolved_event
     ; "keeper_name", `String (Safe_ops.json_string ~default:"" "keeper" json)
     ; "tool_name", `String (Safe_ops.json_string ~default:"" "tool" json)
     ; "risk_level", `String (Safe_ops.json_string ~default:"" "risk" json)
@@ -377,7 +441,7 @@ let resolved_approval_json_of_audit_event json =
     ; "goal_ids", json_member_or_null "goal_ids" json
     ; "sandbox_target", json_member_or_null "sandbox_target" json
     ; "disposition", json_member_or_null "disposition" json
-    ; "disposition_reason", json_member_or_null "disposition_reason" json
+    ; "disposition_reason", disposition_reason
     ; "actor", json_member_or_null "actor" json
     ; "approval_mode", json_member_or_null "approval_mode" json
     ; "authorizing_band", json_member_or_null "authorizing_band" json

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -256,9 +256,27 @@ val approval_audit_pending_event : string
 val approval_audit_resolved_event : string
 (** Event tag persisted when an approval is resolved. *)
 
-val approval_audit_hard_forbidden_event : string
-(** Event tag persisted when governance rejects a hard-forbidden approval
-    (Critical risk or an active runtime blocker) without queuing it. *)
+type approval_audit_event_kind =
+  | Audit_pending
+  | Audit_resolved
+  | Audit_expired
+  | Audit_timeout
+  | Audit_cancelled
+  | Audit_auto_rule
+  | Audit_auto_always
+  | Audit_rule_created
+  | Audit_legacy_terminal_rejection
+  | Audit_other of string
+
+val approval_audit_event_kind_of_wire : string -> approval_audit_event_kind
+(** Decode the exact persisted wire variant. The legacy terminal-rejection
+    variant is read-only migration support and is never emitted by current
+    code. *)
+
+val approval_audit_event_kind_to_canonical_wire :
+  approval_audit_event_kind -> string
+(** Canonical dashboard projection. Legacy terminal rejections project as
+    [resolved], so the retired label is never displayed. *)
 
 val generate_id : unit -> string
 (** Generate a unique approval/audit id. *)

--- a/lib/keeper/keeper_guards.ml
+++ b/lib/keeper/keeper_guards.ml
@@ -904,6 +904,7 @@ let governance_approval_guard
     ?meta_provider
     ~(meta_ref : Keeper_meta_contract.keeper_meta ref)
     ~on_gate_decision
+    ()
   : Agent_sdk.Hooks.hooks =
   if Option.is_some active_tool_names && Option.is_some risk_context
   then
@@ -1004,6 +1005,7 @@ let build_chain
     ~on_gate_decision
     ~(pre_tool_use_guard :
         tool_name:string -> input:Yojson.Safe.t -> string option)
+    ()
   : Agent_sdk.Hooks.hooks =
   compose_all [
     timing_guard ~tool_start_time;
@@ -1018,5 +1020,6 @@ let build_chain
       ~risk_context
       ?meta_provider
       ~meta_ref
-      ~on_gate_decision;
+      ~on_gate_decision
+      ();
   ]

--- a/lib/keeper/keeper_guards.ml
+++ b/lib/keeper/keeper_guards.ml
@@ -883,30 +883,15 @@ let destructive_guard
              Printf.sprintf "pattern='%s' (%s)" pattern desc
            in
            let latency_ms = (Time_compat.now () -. t0) *. 1000.0 in
-           Otel_metric_store.inc_counter
-             Keeper_metrics.(to_string GuardsFailures)
-             ~labels:[("keeper", keeper_name); ("site", "destructive_guard")]
-             ();
-           log_gate_rejection
-             ~keeper_name ~stage:"destructive_guard" ~tool_name
-             ~reason_code:"destructive_guard" ~reason_key:pattern
-             "keeper:%s destructive pattern in %s: '%s' (%s)"
-             keeper_name tool_name pattern desc;
-           broadcast_tool_skipped
-             ~keeper_name ~tool_name ~reason_code:"destructive_guard";
            let source_path = keeper_guards_source_path in
            let source_line = __LINE__ in
            report_gate_decision on_gate_decision
              ~source_path:(Some source_path) ~source_line:(Some source_line)
-             ~stage:"destructive_guard" ~decision:Gate_block
-             ~reason_code:"destructive_guard" ~reason_text
+             ~stage:"destructive_guard" ~decision:Gate_approval_required
+             ~reason_code:"destructive_approval_required" ~reason_text
              ~tool_name ~keeper_name ~input ~turn ~accumulated_cost_usd
              ~stage_latency_ms:latency_ms;
-           Agent_sdk.Hooks.Block
-             (render_inline_skip_reason_with_source
-                ~source_path ~source_line
-                ~tool_name ~reason_code:"destructive_guard"
-                ~reason_text))
+           Agent_sdk.Hooks.ApprovalRequired)
     | _ -> Agent_sdk.Hooks.Continue)
 
 (** Governance approval gate. Escalates via [ApprovalRequired] when
@@ -914,9 +899,30 @@ let destructive_guard
     confirm threshold. Relies on an approval callback wired into the
     agent Builder to resolve the decision. *)
 let governance_approval_guard
+    ?active_tool_names
+    ?risk_context
+    ?meta_provider
     ~(meta_ref : Keeper_meta_contract.keeper_meta ref)
     ~on_gate_decision
   : Agent_sdk.Hooks.hooks =
+  if Option.is_some active_tool_names && Option.is_some risk_context
+  then
+    invalid_arg
+      "governance_approval_guard: provide active_tool_names or risk_context, not both";
+  let risk_context =
+    match risk_context with
+    | Some context -> context
+    | None ->
+      let active_tool_names =
+        match active_tool_names with
+        | Some names -> names
+        | None ->
+          Tool_shard.get_agent_shards (!meta_ref).name
+          |> Tool_shard.tools_of_shards
+          |> List.map (fun (schema : Masc_domain.tool_schema) -> schema.name)
+      in
+      Governance_pipeline.keeper_risk_context ~active_tool_names
+  in
   hooks_of_pre_tool_use (fun event ->
     match event with
     | Agent_sdk.Hooks.PreToolUse
@@ -924,7 +930,20 @@ let governance_approval_guard
       let t0 = Time_compat.now () in
       let keeper_name = (!meta_ref).name in
       let governance_level = Env_config_core.governance_level () in
-      let risk = Governance_pipeline.assess_risk ~tool_name ~input in
+      let risk =
+        (Governance_pipeline.assess_keeper_risk
+           ~context:risk_context
+           ~tool_name
+           ~input).effective_risk
+      in
+      let meta, metadata_unavailable =
+        match meta_provider with
+        | None -> Some !meta_ref, false
+        | Some current ->
+          (match current () with
+           | Some meta -> Some meta, false
+           | None -> None, true)
+      in
       let needs_approval =
         match Governance_pipeline.keeper_confirm_threshold governance_level with
         | Some threshold ->
@@ -932,36 +951,27 @@ let governance_approval_guard
           >= Governance_pipeline.risk_level_to_int threshold
         | None -> false
       in
-      (* task-1627: unconditional hard_forbidden gate — blocks before HITL *)
-      let hard_forbidden =
-        Governance_pipeline.auto_approval_hard_forbidden ~risk (Some !meta_ref)
+      let manual_approval_required =
+        Governance_pipeline.keeper_manual_approval_required
+          ~risk
+          meta
       in
-      if hard_forbidden then begin
-        let latency_ms = (Time_compat.now () -. t0) *. 1000.0 in
-        let source_path = keeper_guards_source_path in
-        let source_line = __LINE__ in
-        report_gate_decision on_gate_decision
-          ~source_path:(Some source_path) ~source_line:(Some source_line)
-          ~stage:"governance_approval" ~decision:Gate_block
-          ~reason_code:"hard_forbidden"
-          ~reason_text:"hard_forbidden: unconditional block regardless of HITL mode"
-          ~tool_name ~keeper_name ~input ~turn ~accumulated_cost_usd
-          ~stage_latency_ms:latency_ms;
-        Agent_sdk.Hooks.Block
-          (render_inline_skip_reason_with_source
-             ~source_path ~source_line
-             ~tool_name ~reason_code:"hard_forbidden"
-             ~reason_text:"hard_forbidden: unconditional block regardless of HITL mode")
-      end
-      else if needs_approval then begin
+      if metadata_unavailable || manual_approval_required || needs_approval
+      then begin
         let latency_ms = (Time_compat.now () -. t0) *. 1000.0 in
         let source_path = keeper_guards_source_path in
         let source_line = __LINE__ in
         report_gate_decision on_gate_decision
           ~source_path:(Some source_path) ~source_line:(Some source_line)
           ~stage:"governance_approval" ~decision:Gate_approval_required
-          ~reason_code:"governance_approval"
-          ~reason_text:"risk threshold reached; operator approval required"
+          ~reason_code:
+            (if metadata_unavailable
+             then "governance_metadata_unavailable"
+             else "governance_approval")
+          ~reason_text:
+            (if metadata_unavailable
+             then "live Keeper metadata is unavailable; operator decision required"
+             else "risk policy requires an explicit operator decision")
           ~tool_name ~keeper_name ~input ~turn ~accumulated_cost_usd
           ~stage_latency_ms:latency_ms;
         Agent_sdk.Hooks.ApprovalRequired
@@ -989,6 +999,8 @@ let build_chain
     ~(denied : string list)
     ~(max_cost_usd : float option)
     ~(destructive_ops_policy : Destructive_ops_policy.t)
+    ~risk_context
+    ?meta_provider
     ~on_gate_decision
     ~(pre_tool_use_guard :
         tool_name:string -> input:Yojson.Safe.t -> string option)
@@ -1002,5 +1014,9 @@ let build_chain
     deny_guard ~meta_ref ~on_gate_decision ~denied;
     cost_guard ~meta_ref ~on_gate_decision ~max_cost_usd;
     destructive_guard ~meta_ref ~on_gate_decision ~policy:destructive_ops_policy;
-    governance_approval_guard ~meta_ref ~on_gate_decision;
+    governance_approval_guard
+      ~risk_context
+      ?meta_provider
+      ~meta_ref
+      ~on_gate_decision;
   ]

--- a/lib/keeper/keeper_guards.mli
+++ b/lib/keeper/keeper_guards.mli
@@ -223,6 +223,7 @@ val governance_approval_guard :
   ?meta_provider:(unit -> Keeper_meta_contract.keeper_meta option) ->
   meta_ref:Keeper_meta_contract.keeper_meta ref ->
   on_gate_decision:(gate_decision_event -> unit) ->
+  unit ->
   Agent_sdk.Hooks.hooks
 
 (** Build the full keeper pre_tool_use chain in canonical order:
@@ -242,6 +243,7 @@ val build_chain :
   on_gate_decision:(gate_decision_event -> unit) ->
   pre_tool_use_guard:
     (tool_name:string -> input:Yojson.Safe.t -> string option) ->
+  unit ->
   Agent_sdk.Hooks.hooks
 
 module For_testing : sig

--- a/lib/keeper/keeper_guards.mli
+++ b/lib/keeper/keeper_guards.mli
@@ -218,6 +218,9 @@ val destructive_guard :
 (** Governance gate. Escalates via [ApprovalRequired] when the
     assessed risk meets or exceeds the keeper-confirm threshold. *)
 val governance_approval_guard :
+  ?active_tool_names:string list ->
+  ?risk_context:Governance_pipeline.keeper_risk_context ->
+  ?meta_provider:(unit -> Keeper_meta_contract.keeper_meta option) ->
   meta_ref:Keeper_meta_contract.keeper_meta ref ->
   on_gate_decision:(gate_decision_event -> unit) ->
   Agent_sdk.Hooks.hooks
@@ -234,6 +237,8 @@ val build_chain :
   denied:string list ->
   max_cost_usd:float option ->
   destructive_ops_policy:Destructive_ops_policy.t ->
+  risk_context:Governance_pipeline.keeper_risk_context ->
+  ?meta_provider:(unit -> Keeper_meta_contract.keeper_meta option) ->
   on_gate_decision:(gate_decision_event -> unit) ->
   pre_tool_use_guard:
     (tool_name:string -> input:Yojson.Safe.t -> string option) ->

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -286,6 +286,7 @@ let make_hooks
       ?meta_provider
       ~on_gate_decision:record_gate_decision
       ~pre_tool_use_guard
+      ()
   in
   let non_gate_hooks =
     { Agent_sdk.Hooks.empty with

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -214,6 +214,9 @@ let make_hooks
     ?(max_cost_usd : float option)
     ?(destructive_ops_policy : Destructive_ops_policy.t =
         Destructive_ops_policy.default)
+    ?active_tool_names
+    ?risk_context
+    ?meta_provider
     ?(pre_tool_use_guard :
         tool_name:string -> input:Yojson.Safe.t -> string option =
         fun ~tool_name:_ ~input:_ -> None)
@@ -243,6 +246,10 @@ let make_hooks
   let readonly_observation_state =
     Keeper_guards.make_readonly_observation_state ()
   in
+  if Option.is_some active_tool_names && Option.is_some risk_context
+  then
+    invalid_arg
+      "Keeper_hooks_oas.make_hooks: provide active_tool_names or risk_context, not both";
   let streak_threshold = 5 in
   ignore trajectory_acc;
   let record_gate_decision = Keeper_guards.ignore_gate_decision in
@@ -252,6 +259,20 @@ let make_hooks
      attempted action into tool-call and trajectory lanes so blocked
      pre-tool attempts are not invisible to tool-stats. *)
   let guard_chain =
+    let risk_context =
+      match risk_context with
+      | Some context -> context
+      | None ->
+        let active_tool_names =
+          match active_tool_names with
+          | Some names -> names
+          | None ->
+            Tool_shard.get_agent_shards (!meta_ref).name
+            |> Tool_shard.tools_of_shards
+            |> List.map (fun (schema : Masc_domain.tool_schema) -> schema.name)
+        in
+        Governance_pipeline.keeper_risk_context ~active_tool_names
+    in
     Keeper_guards.build_chain
       ~meta_ref
       ~tool_start_time
@@ -261,6 +282,8 @@ let make_hooks
       ~denied:keeper_denied_tools
       ~max_cost_usd
       ~destructive_ops_policy
+      ~risk_context
+      ?meta_provider
       ~on_gate_decision:record_gate_decision
       ~pre_tool_use_guard
   in

--- a/lib/keeper/keeper_hooks_oas.mli
+++ b/lib/keeper/keeper_hooks_oas.mli
@@ -158,6 +158,9 @@ val make_hooks :
   generation:int ->
   ?max_cost_usd:float ->
   ?destructive_ops_policy:Destructive_ops_policy.t ->
+  ?active_tool_names:string list ->
+  ?risk_context:Governance_pipeline.keeper_risk_context ->
+  ?meta_provider:(unit -> Keeper_meta_contract.keeper_meta option) ->
   ?pre_tool_use_guard:(tool_name:string ->
                        input:Yojson.Safe.t -> string option) ->
   ?on_tool_executed:(tool_name:string ->

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -303,8 +303,8 @@ let blocker_class_continue_gate = function
     this blocker should prevent auto-approval (including [always_approve]
     and remembered allow-rules) for the keeper's next tool call.
 
-    Only blockers that signal genuine safety/uncertainty conditions are
-    hard-forbidden.  Transient liveness signals — capacity backpressure,
+    Only blockers that signal genuine safety/uncertainty conditions establish
+    an operator-only approval floor. Transient liveness signals — capacity backpressure,
     queue timeouts, turn timeouts, SDK budget/idle/input conditions — do
     NOT block auto-approval, so automated recovery flows are not stalled
     by a momentary runtime hiccup.

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -202,7 +202,7 @@ val blocker_class_auto_approval_blocked : blocker_class -> bool
 (** [blocker_class_auto_approval_blocked b] is [true] iff this blocker
     class should prevent auto-approval of the keeper's next tool call
     (including [always_approve] and remembered allow-rules).  Only
-    safety/uncertainty classes are hard-forbidden; transient liveness
+    safety/uncertainty classes require an operator decision; transient liveness
     signals such as [Capacity_backpressure], [Turn_timeout], and SDK
     budget/idle/input conditions are intentionally excluded so
     automated recovery flows are not stalled.  Exhaustive — adding a

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -75,6 +75,8 @@ type agent_setup = Keeper_run_tools_hooks.agent_setup =
   ; hooks : Agent_sdk.Hooks.hooks
   ; reducer : Agent_sdk.Context_reducer.t
   ; acc : hook_accumulator
+  ; current_meta : unit -> Keeper_meta_contract.keeper_meta option
+  ; risk_context : Governance_pipeline.keeper_risk_context
   ; all_tool_names : string list
   ; tool_context_estimate : Keeper_run_prompt.tool_schema_context_estimate
   ; receipt_turn_count_ref : int option ref

--- a/lib/keeper/keeper_run_tools.mli
+++ b/lib/keeper/keeper_run_tools.mli
@@ -75,6 +75,8 @@ type agent_setup =
   ; hooks : Agent_sdk.Hooks.hooks
   ; reducer : Agent_sdk.Context_reducer.t
   ; acc : hook_accumulator
+  ; current_meta : unit -> Keeper_meta_contract.keeper_meta option
+  ; risk_context : Governance_pipeline.keeper_risk_context
   ; all_tool_names : string list
   ; tool_context_estimate : Keeper_run_prompt.tool_schema_context_estimate
   ; receipt_turn_count_ref : int option ref

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -16,6 +16,8 @@ type agent_setup =
   ; hooks : Agent_sdk.Hooks.hooks
   ; reducer : Agent_sdk.Context_reducer.t
   ; acc : hook_accumulator
+  ; current_meta : unit -> Keeper_meta_contract.keeper_meta option
+  ; risk_context : Governance_pipeline.keeper_risk_context
   ; all_tool_names : string list
   ; tool_context_estimate : Keeper_run_prompt.tool_schema_context_estimate
   ; receipt_turn_count_ref : int option ref
@@ -176,13 +178,50 @@ let assemble_hooks
      ; runtime_config_path
      };
   Keeper_run_tools_hook_accumulator.record_requested_tool_names
-      acc
+    acc
       initial_schema_filter;
     let meta_ref = ref acc.meta in
+    let meta_available = ref true in
+    let mark_meta_unavailable reason =
+      if !meta_available
+      then
+        Log.Keeper.error
+          "keeper tool policy metadata unavailable keeper=%s reason=%s; requiring operator approval"
+          meta.name reason;
+      meta_available := false
+    in
+    let refresh_meta_from_registry () =
+      match
+        Keeper_registry.get_with_health
+          ~base_path:config.base_path
+          meta.name
+      with
+      | Some (entry, Keeper_registry.Healthy) ->
+        if not !meta_available
+        then
+          Log.Keeper.info
+            "keeper tool policy metadata recovered keeper=%s"
+            meta.name;
+        acc.meta <- entry.meta;
+        meta_ref := entry.meta;
+        meta_available := true;
+        ()
+      | Some (_, health) ->
+        mark_meta_unavailable
+          (Keeper_registry.registry_entry_validation_error_to_string health)
+      | None -> mark_meta_unavailable "registry_entry_missing"
+    in
+    let current_meta () =
+      if !meta_available then Some !meta_ref else None
+    in
     let public_alias_pre_tool_use_guard ~tool_name ~input:_ =
       Keeper_tool_resolution.public_alias_guidance_for_internal_call
         ~allowed_tool_names:acc.requested_tool_names
         tool_name
+    in
+    let risk_context =
+      Governance_pipeline.keeper_risk_context
+        ~active_tool_names:all_tool_names
     in
     let base_hooks =
       Keeper_hooks_oas.make_hooks
@@ -190,6 +229,8 @@ let assemble_hooks
         ~meta_ref
         ~turn_ctx_cell
         ~generation
+        ~risk_context
+        ~meta_provider:current_meta
         ?max_cost_usd
         ?trajectory_acc
         ~on_tool_executed:
@@ -217,11 +258,7 @@ let assemble_hooks
             then "ok"
             else "ok_no_progress"
           in
-          (match Keeper_registry.get ~base_path:config.base_path meta.name with
-           | Some entry ->
-             acc.meta <- entry.meta;
-             meta_ref := entry.meta
-           | None -> ());
+          refresh_meta_from_registry ();
           let task_id = Keeper_run_tools_task_scope.task_id_scope_of_tool_call ~tool_name ~input ~output_text ~meta:acc.meta in
           acc.tool_calls
           <- { tool_name
@@ -309,6 +346,20 @@ let assemble_hooks
              ()))
         ~pre_tool_use_guard:public_alias_pre_tool_use_guard
         ()
+    in
+    let refresh_meta_hook : Agent_sdk.Hooks.hooks =
+      { Agent_sdk.Hooks.empty with
+        pre_tool_use =
+          Some
+            (fun event ->
+               (match event with
+                | Agent_sdk.Hooks.PreToolUse _ -> refresh_meta_from_registry ()
+                | _ -> ());
+               Agent_sdk.Hooks.Continue)
+      }
+    in
+    let base_hooks =
+      Agent_sdk.Hooks.compose ~outer:refresh_meta_hook ~inner:base_hooks
     in
     let before_turn_hook : Agent_sdk.Hooks.hooks =
       { Agent_sdk.Hooks.empty with
@@ -828,6 +879,8 @@ let assemble_hooks
       ; hooks
       ; reducer
       ; acc
+      ; current_meta
+      ; risk_context
       ; all_tool_names
       ; tool_context_estimate
       ; receipt_turn_count_ref

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -556,6 +556,12 @@ let approval_state_json ~pending_approval_count ~pending_approvals ~latest_tool_
   in
   let latest_event_kind =
     Option.bind latest_approval_audit (json_string_opt_member "event")
+    |> Option.map Keeper_approval_queue.approval_audit_event_kind_of_wire
+  in
+  let latest_event_wire =
+    Option.map
+      Keeper_approval_queue.approval_audit_event_kind_to_canonical_wire
+      latest_event_kind
   in
   let resolution_mode =
     Option.bind latest_tool_call (json_string_opt_member "approval_mode")
@@ -565,15 +571,22 @@ let approval_state_json ~pending_approval_count ~pending_approvals ~latest_tool_
     if pending_approval_count > 0 then "pending"
     else
       match latest_event_kind with
-      | Some "auto_approved_always" -> "always_flag"
-      | Some "auto_approved_rule_match" -> "always_rule"
-      | Some event
-        when String.equal event Keeper_approval_queue.approval_audit_hard_forbidden_event ->
-        "hard_forbidden"
-      | Some "resolved" -> "resolved"
-      | Some "expired" | Some "approval_timeout" -> "expired"
-      | Some "cancelled" -> "cancelled"
-      | Some _ -> "observed"
+      | Some Keeper_approval_queue.Audit_auto_always -> "always_flag"
+      | Some Keeper_approval_queue.Audit_auto_rule -> "always_rule"
+      | Some
+          (Keeper_approval_queue.Audit_resolved
+          | Keeper_approval_queue.Audit_legacy_terminal_rejection) ->
+        "resolved"
+      | Some
+          (Keeper_approval_queue.Audit_expired
+          | Keeper_approval_queue.Audit_timeout) ->
+        "expired"
+      | Some Keeper_approval_queue.Audit_cancelled -> "cancelled"
+      | Some
+          (Keeper_approval_queue.Audit_pending
+          | Keeper_approval_queue.Audit_rule_created
+          | Keeper_approval_queue.Audit_other _) ->
+        "observed"
       | None -> "idle"
   in
   `Assoc
@@ -581,7 +594,7 @@ let approval_state_json ~pending_approval_count ~pending_approvals ~latest_tool_
       ("state", `String state);
       ("pending_count", `Int pending_approval_count);
       ("resolution_mode", Json_util.string_opt_to_json resolution_mode);
-      ("latest_event_kind", Json_util.string_opt_to_json latest_event_kind);
+      ("latest_event_kind", Json_util.string_opt_to_json latest_event_wire);
       ( "latest_event_at",
         match Option.bind latest_approval_audit (json_float_opt_member "ts") with
         | Some ts -> `String (Masc_domain.iso8601_of_unix_seconds ts)

--- a/lib/keeper/keeper_runtime_trust_timeline.ml
+++ b/lib/keeper/keeper_runtime_trust_timeline.ml
@@ -82,18 +82,23 @@ let severity_of_decision = function
 
 let severity_of_tool_call success = if success then "ok" else "bad"
 
-let severity_of_approval_event event decision =
-  match event with
-  | "pending" -> "warn"
-  | "expired" | "approval_timeout" | "cancelled" -> "bad"
-  | event when String.equal event Keeper_approval_queue.approval_audit_hard_forbidden_event ->
+let severity_of_approval_event event_kind decision =
+  match event_kind with
+  | Keeper_approval_queue.Audit_pending -> "warn"
+  | Keeper_approval_queue.Audit_expired
+  | Keeper_approval_queue.Audit_timeout
+  | Keeper_approval_queue.Audit_cancelled
+  | Keeper_approval_queue.Audit_legacy_terminal_rejection ->
     "bad"
-  | "resolved" -> (
+  | Keeper_approval_queue.Audit_resolved -> (
       match decision with
       | Some raw when String_util.contains_substring_ci raw "reject" -> "bad"
       | _ -> "ok")
-  | "auto_approved_rule_match" | "auto_approved_always" | "rule_created" -> "ok"
-  | _ -> "warn"
+  | Keeper_approval_queue.Audit_auto_rule
+  | Keeper_approval_queue.Audit_auto_always
+  | Keeper_approval_queue.Audit_rule_created ->
+    "ok"
+  | Keeper_approval_queue.Audit_other _ -> "warn"
 
 let severity_of_transition_type event_type =
   if String_util.contains_substring_ci event_type "failed"
@@ -168,6 +173,9 @@ let live_pending_approval_timeline_event json =
 let approval_event_timeline_event json =
   match json_float_opt_member "ts" json, json_string_opt_member "event" json with
   | Some ts_unix, Some event ->
+      let event_kind =
+        Keeper_approval_queue.approval_audit_event_kind_of_wire event
+      in
       let tool_name =
         json_string_opt_member "tool" json |> Option.value ~default:"tool"
       in
@@ -180,14 +188,15 @@ let approval_event_timeline_event json =
       in
       let decision = json_string_opt_member "decision" json in
       let kind, title, summary, next_human_action =
-        match event with
-        | "pending" ->
+        match event_kind with
+        | Keeper_approval_queue.Audit_pending ->
             ( "approval_requested",
               Printf.sprintf "Approval · %s" tool_name,
               approval_summary
                 "approval requested and waiting for operator decision",
               Some "resolve_approval" )
-        | "resolved" ->
+        | Keeper_approval_queue.Audit_resolved
+        | Keeper_approval_queue.Audit_legacy_terminal_rejection ->
             let decision_label =
               Option.value ~default:"resolved" decision
             in
@@ -195,7 +204,7 @@ let approval_event_timeline_event json =
               Printf.sprintf "Approval · %s" tool_name,
               approval_summary (Printf.sprintf "approval %s" decision_label),
               None )
-        | "expired" ->
+        | Keeper_approval_queue.Audit_expired ->
             let blocker_note = "" in
             let next_action = "retry_or_rerun" in
             let decision_label =
@@ -207,7 +216,8 @@ let approval_event_timeline_event json =
               Printf.sprintf "Approval · %s" tool_name,
               approval_summary (decision_label ^ blocker_note),
               Some next_action )
-        | "approval_timeout" | "cancelled" ->
+        | Keeper_approval_queue.Audit_timeout
+        | Keeper_approval_queue.Audit_cancelled ->
             let summary =
               match decision with
               | Some value -> value
@@ -217,7 +227,7 @@ let approval_event_timeline_event json =
               Printf.sprintf "Approval · %s" tool_name,
               approval_summary summary,
               Some "retry_or_rerun" )
-        | "auto_approved_rule_match" ->
+        | Keeper_approval_queue.Audit_auto_rule ->
             let matched_by =
               json |> json_member "rule_match"
               |> json_string_opt_member "matched_by"
@@ -227,17 +237,17 @@ let approval_event_timeline_event json =
               Printf.sprintf "Approval Rule · %s" tool_name,
               approval_summary (Printf.sprintf "auto-approved by %s" matched_by),
               None )
-        | "auto_approved_always" ->
+        | Keeper_approval_queue.Audit_auto_always ->
             ( "approval_always_flag",
               Printf.sprintf "Approval Always · %s" tool_name,
               approval_summary "auto-approved by keeper always_approve flag",
               None )
-        | "rule_created" ->
+        | Keeper_approval_queue.Audit_rule_created ->
             ( "approval_rule_created",
               Printf.sprintf "Approval Rule · %s" tool_name,
               approval_summary "persistent approval rule recorded",
               None )
-        | other ->
+        | Keeper_approval_queue.Audit_other other ->
             ( "approval_event",
               Printf.sprintf "Approval · %s" tool_name,
               approval_summary other,
@@ -250,7 +260,7 @@ let approval_event_timeline_event json =
            ~goal_ids:(goal_ids_of_json json)
            ?next_human_action
            ~ts_unix ~kind ~title ~summary
-           ~severity:(severity_of_approval_event event decision) ())
+           ~severity:(severity_of_approval_event event_kind decision) ())
   | _ -> None
 
 let decision_timeline_event json =

--- a/lib/operator_approval.ml
+++ b/lib/operator_approval.ml
@@ -42,6 +42,8 @@ type risk_band =
 
 type approval_mode_queue_reason =
   | Separation_of_duties_floor
+  | Metadata_unavailable
+  | Automatic_approval_prohibited
   | Manual_mode
   | Not_auto_eligible
 
@@ -110,6 +112,8 @@ let auto_eligible_bands_json () =
 
 let approval_mode_queue_reason_to_string = function
   | Separation_of_duties_floor -> "separation_of_duties_floor"
+  | Metadata_unavailable -> "metadata_unavailable"
+  | Automatic_approval_prohibited -> "automatic_approval_prohibited"
   | Manual_mode -> "manual_mode"
   | Not_auto_eligible -> "not_auto_eligible"
 

--- a/lib/operator_approval.mli
+++ b/lib/operator_approval.mli
@@ -49,6 +49,8 @@ type risk_band =
 
 type approval_mode_queue_reason =
   | Separation_of_duties_floor
+  | Metadata_unavailable
+  | Automatic_approval_prohibited
   | Manual_mode
   | Not_auto_eligible
 

--- a/test/test_governance_pipeline.ml
+++ b/test/test_governance_pipeline.ml
@@ -553,14 +553,14 @@ let test_risk_payload_beats_low_override () =
 (* ── Governance Level Decision Tests ────────────────────────── *)
 
 let test_development_confirms_critical () =
-  (* Hard-forbidden gate is unconditional: even development must confirm
+  (* The operator-only floor is unconditional: even development must confirm
      Critical-risk tools rather than allowing silent auto-approval. *)
   let d = Gp.decide ~governance_level:"development"
     ~tool_name:"masc_delete_workspace" ~input:`Null () in
   (match d.action with
    | `Require_confirm reason ->
      Alcotest.(check bool) "reason non-empty" true (String.length reason > 0)
-   | `Allow -> Alcotest.fail "development should confirm hard-forbidden critical"
+   | `Allow -> Alcotest.fail "development should confirm critical"
    | `Deny _ -> Alcotest.fail "development should confirm critical, not deny");
   Alcotest.(check string) "risk" "critical" (Gp.risk_level_to_string d.risk)
 
@@ -690,7 +690,7 @@ let setup () =
 
 let test_hook_development_blocks_critical () =
   (* The front-door pre_hook uses decide without keeper meta, but the
-     unconditional hard-forbidden gate still blocks Critical risk. *)
+     unconditional operator-confirmation floor still gates Critical risk. *)
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   setup ();
@@ -707,9 +707,9 @@ let test_hook_development_blocks_critical () =
      let status = Yojson.Safe.Util.((Tool_result.data r) |> member "status" |> to_string) in
      Alcotest.(check string) "awaiting_approval" "awaiting_approval" status
    | Tool_dispatch.Pass ->
-     Alcotest.fail "development should block hard-forbidden critical"
+     Alcotest.fail "development should gate critical"
    | Tool_dispatch.Proceed _ ->
-     Alcotest.fail "development should block hard-forbidden critical, not proceed");
+     Alcotest.fail "development should gate critical, not proceed");
   cleanup_tmpdir tmpdir
 
 let test_hook_production_blocks_critical () =
@@ -888,10 +888,10 @@ let test_hitl_disabled_allows_noncritical_below_threshold () =
     | `Allow -> ()
     | `Require_confirm _ ->
       Alcotest.fail "HITL disabled should keep noncritical below-threshold calls allowed"
-    | `Deny _ -> Alcotest.fail "high risk should not be denied by hard-forbidden gate")
+    | `Deny _ -> Alcotest.fail "high risk should not be denied by operator floor")
 
 (* ── HITL governance blocker tests ──────────────────────────── *)
-(* Adversarial review blockers for hard-forbidden front-door / keeper
+(* Adversarial review blockers for the operator-only front-door / keeper
    governance scope. *)
 
 let make_test_meta ?(last_blocker = None) () =
@@ -1013,7 +1013,7 @@ let test_decide_runtime_blocker_requires_confirm () =
   in
   match d.action with
   | `Require_confirm reason ->
-    Alcotest.(check bool) "reason mentions hard-forbidden" true
+    Alcotest.(check bool) "reason is explicit" true
       (String.length reason > 0)
   | `Allow ->
     Alcotest.fail "runtime blocker should require confirmation for non-Critical tool"
@@ -1035,10 +1035,10 @@ let test_decide_front_door_none_allows_noncritical () =
   | `Deny _ ->
     Alcotest.fail "front-door (meta=None) should allow non-Critical, non-destructive tool"
 
-let test_oas_callback_critical_rejects_hard_forbidden () =
+let test_oas_callback_critical_queues_operator_continuation () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
-  let keeper_name = "hard-forbidden-critical-reject-test" in
+  let keeper_name = "critical-operator-continuation-test" in
   let initial_pending = AQ.pending_count () in
   let tmpdir = make_tmpdir () in
   Fun.protect
@@ -1050,18 +1050,22 @@ let test_oas_callback_critical_rejects_hard_forbidden () =
            ~config
            ~governance_level:"production"
            ~keeper_name
+           ~lane_policy:AQ.Nonblocking
            ()
        in
        Alcotest.(check bool)
-         "Critical request is hard-forbidden"
+         "nonblocking Critical request returns a pending decision"
          true
          (match callback ~tool_name:"masc_delete_workspace" ~input:`Null with
           | Agent_sdk.Hooks.Reject _ -> true
           | Agent_sdk.Hooks.Approve | Agent_sdk.Hooks.Edit _ -> false);
        Alcotest.(check int)
-         "hard-forbidden request never enters operator approval queue"
-         0
+         "Critical request enters the operator approval queue"
+         1
          (AQ.pending_count_for_keeper ~keeper_name);
+       (match pending_id_for_keeper ~keeper_name with
+        | Some id -> resolve_pending_or_fail ~id ~decision:(Agent_sdk.Hooks.Reject "test cleanup")
+        | None -> Alcotest.fail "expected queued Critical approval");
        Alcotest.(check int)
          "pending count restored"
          initial_pending
@@ -1352,8 +1356,8 @@ let () =
         `Quick test_decide_runtime_blocker_requires_confirm;
       Alcotest.test_case "decide: front-door None allows non-Critical" `Quick
         test_decide_front_door_none_allows_noncritical;
-      Alcotest.test_case "OAS callback: Critical rejects hard-forbidden" `Quick
-        test_oas_callback_critical_rejects_hard_forbidden;
+      Alcotest.test_case "OAS callback: Critical queues operator continuation" `Quick
+        test_oas_callback_critical_queues_operator_continuation;
     ];
     "trace_id", [
       Alcotest.test_case "has gov_ prefix" `Quick test_decision_has_trace_id;

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -1544,9 +1544,9 @@ let test_callback_auto_mode_approves_gated_low_risk_and_records_history () =
     ~finally:AQ.For_testing.reset_audit_store
     (fun () ->
       let keeper_name = "auto-low-risk-keeper" in
-      let input = `Assoc [ ("op", `String "git") ] in
+      let input = `Assoc [] in
       Alcotest.(check string)
-        "soft-only fixture stays below hard-forbidden risk"
+        "plain fixture stays in the auto-eligible band"
         "low"
         (GP.assess_risk ~tool_name:"masc_status" ~input |> GP.risk_level_to_string);
       set_approval_mode_or_fail config OA.Auto_low_risk;
@@ -1592,12 +1592,63 @@ let test_callback_auto_mode_approves_gated_low_risk_and_records_history () =
           "expected one auto_mode resolved event, got %d"
           (List.length events))
 
-let test_callback_auto_mode_critical_rejects_hard_forbidden () =
+let test_callback_metadata_unavailable_queues_low_risk () =
+  with_test_config @@ fun config ->
+  let keeper_name = "metadata-unavailable-keeper" in
+  let initial_pending = AQ.pending_count () in
+  AQ.For_testing.reset_audit_store ();
+  Fun.protect
+    ~finally:AQ.For_testing.reset_audit_store
+    (fun () ->
+      set_approval_mode_or_fail config OA.Auto_low_risk;
+      let callback =
+        GP.to_oas_approval_callback
+          ~config
+          ~governance_level:"production"
+          ~keeper_name
+          ~meta_provider:(fun () -> None)
+          ~active_tool_names:[ "masc_status" ]
+          ~lane_policy:AQ.Nonblocking
+          ()
+      in
+      Alcotest.(check bool)
+        "metadata-unavailable low-risk request reports pending"
+        true
+        (approval_decision_is_reject
+           (callback ~tool_name:"masc_status" ~input:(`Assoc [])));
+      Alcotest.(check int)
+        "metadata-unavailable request enters queue"
+        (initial_pending + 1)
+        (AQ.pending_count ());
+      (match
+         find_audit_event
+           ~base_path:config.base_path
+           ~keeper_name
+           ~event_type:AQ.approval_audit_pending_event
+       with
+       | Some json ->
+         Alcotest.(check string)
+           "typed metadata-unavailable reason"
+           "metadata_unavailable"
+           Yojson.Safe.Util.(json |> member "disposition_reason" |> to_string)
+       | None -> Alcotest.fail "expected metadata-unavailable pending audit");
+      (match pending_id_for_keeper ~keeper_name with
+       | Some id ->
+         resolve_pending_or_fail
+           ~id
+           ~decision:(Agent_sdk.Hooks.Reject "test cleanup")
+       | None -> Alcotest.fail "expected metadata-unavailable approval id");
+      Alcotest.(check int)
+        "pending count restored"
+        initial_pending
+        (AQ.pending_count ()))
+
+let test_callback_auto_mode_critical_queues_nonblocking () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   Mcp_eio.set_net (Eio.Stdenv.net env);
   Mcp_eio.set_clock (Eio.Stdenv.clock env);
-  let keeper_name = "auto-critical-hard-forbidden-keeper" in
+  let keeper_name = "auto-critical-operator-keeper" in
   let initial_pending = AQ.pending_count () in
   let base_path = temp_dir () in
   AQ.For_testing.reset_audit_store ();
@@ -1609,38 +1660,35 @@ let test_callback_auto_mode_critical_rejects_hard_forbidden () =
       let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
       let config = (Mcp_server.workspace_config state) in
       set_approval_mode_or_fail config OA.Auto_low_risk;
-      Eio.Switch.run @@ fun sw ->
-      let decision_promise =
-        Eio.Fiber.fork_promise ~sw (fun () ->
-          let cb =
-            GP.to_oas_approval_callback
-              ~config
-              ~governance_level:"production"
-              ~keeper_name
-              ()
-          in
-          cb
-            ~tool_name:"tool_edit_file"
-            ~input:
-              (`Assoc
-                [ ("path", `String "lib/example.ml")
-                ; ("content", `String "let x = 1\n")
-                ]))
+      let cb =
+        GP.to_oas_approval_callback
+          ~config
+          ~governance_level:"production"
+          ~keeper_name
+          ~lane_policy:AQ.Nonblocking
+          ()
       in
       let decision =
-        match Eio.Promise.await decision_promise with
-        | Ok decision -> decision
-        | Error exn ->
-          Alcotest.failf "approval callback raised: %s" (Printexc.to_string exn)
+        cb
+          ~tool_name:"tool_edit_file"
+          ~input:
+            (`Assoc
+              [ ("path", `String "lib/example.ml")
+              ; ("content", `String "let x = 1\n")
+              ])
       in
       Alcotest.(check bool)
-        "critical request is hard-forbidden"
+        "nonblocking Critical request reports pending"
         true
         (approval_decision_is_reject decision);
       Alcotest.(check int)
-        "hard-forbidden request never enters queue"
-        initial_pending
+        "Critical request enters queue"
+        (initial_pending + 1)
         (AQ.pending_count ());
+      (match pending_id_for_keeper ~keeper_name with
+       | Some id -> resolve_pending_or_fail ~id ~decision:(Agent_sdk.Hooks.Reject "test cleanup")
+       | None -> Alcotest.fail "expected queued Critical approval");
+      Alcotest.(check int) "pending count restored" initial_pending (AQ.pending_count ());
       check_no_auto_mode_resolved ~base_path ~keeper_name)
 
 let test_callback_production_claimed_worktree_write_auto_approved () =
@@ -1940,7 +1988,7 @@ let test_callback_manual_mode_preserves_remembered_soft_forbidden () =
   let tool_name = "masc_status" in
   let input = `Assoc [ ("op", `String "git") ] in
   Alcotest.(check string)
-    "soft-only fixture stays below hard-forbidden risk"
+    "soft-only fixture stays below Critical risk"
     "low"
     (GP.assess_risk ~tool_name ~input |> GP.risk_level_to_string);
   let id =
@@ -1977,7 +2025,7 @@ let test_callback_manual_mode_preserves_remembered_soft_forbidden () =
     in
     wait_for_immediate_approve_or_fail ~keeper_name ~pending_before result
 
-let test_callback_manual_mode_preserves_always_approve_threshold () =
+let test_callback_always_approve_cannot_bypass_high_floor () =
   with_test_config @@ fun config ->
   Eio.Switch.run @@ fun sw ->
   let keeper_name = "test-keeper" in
@@ -2003,14 +2051,26 @@ let test_callback_manual_mode_preserves_always_approve_threshold () =
         ~input:(`Assoc [("title", `String "test")])
         ()
     in
-    wait_for_immediate_approve_or_fail ~keeper_name ~pending_before result
+    let id = wait_for_pending_or_result ~keeper_name result in
+    Alcotest.(check int) "High request enters operator queue"
+      (pending_before + 1) (AQ.pending_count ());
+    resolve_pending_or_fail ~id ~decision:Agent_sdk.Hooks.Approve;
+    yield_until (fun () -> Option.is_some !result);
+    Alcotest.(check int) "pending count restored" pending_before
+      (AQ.pending_count ());
+    match !result with
+    | Some Agent_sdk.Hooks.Approve -> ()
+    | Some (Agent_sdk.Hooks.Reject reason) ->
+      Alcotest.fail ("expected operator approval, got reject: " ^ reason)
+    | Some (Agent_sdk.Hooks.Edit _) ->
+      Alcotest.fail "expected operator approval, got edit"
+    | None -> Alcotest.fail "High approval callback did not return"
 
-let test_callback_typed_last_blocker_rejects_hard_forbidden () =
+let test_callback_typed_last_blocker_queues_operator () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   Mcp_eio.set_net (Eio.Stdenv.net env);
   Mcp_eio.set_clock (Eio.Stdenv.clock env);
-  Eio.Switch.run @@ fun sw ->
   let keeper_name = "typed-blocked-keeper" in
   let initial_pending = AQ.pending_count () in
   let base_path = temp_dir () in
@@ -2019,52 +2079,52 @@ let test_callback_typed_last_blocker_rejects_hard_forbidden () =
     (fun () ->
       let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
       let config = Mcp_server.workspace_config state in
-      let meta =
-        let base =
-          meta_from_json
-            (`Assoc
-              [
-                ("name", `String keeper_name);
-                ("agent_name", `String ("keeper-" ^ keeper_name ^ "-agent"));
-                ("trace_id", `String "runtime-blocked-trace");
-                ("sandbox_profile", `String "docker");
-                ("network_mode", `String "inherit");
-                ("always_approve", `Bool true);
-              ])
-        in
-        let blocker =
+      let meta_ref =
+        ref
+          (meta_from_json
+             (`Assoc
+               [
+                 ("name", `String keeper_name);
+                 ("agent_name", `String ("keeper-" ^ keeper_name ^ "-agent"));
+                 ("trace_id", `String "runtime-blocked-trace");
+                 ("sandbox_profile", `String "docker");
+                 ("network_mode", `String "inherit");
+                 ("always_approve", `Bool true);
+               ]))
+      in
+      let cb =
+        GP.to_oas_approval_callback
+          ~config ~governance_level:"production" ~keeper_name
+          ~meta_provider:(fun () -> Some !meta_ref)
+          ~lane_policy:AQ.Nonblocking ()
+      in
+      let blocker =
           let open Masc.Keeper_meta_contract in
           blocker_info_of_class
             ~detail:"completion contract violated"
             Completion_contract_violation
-        in
-        { base with
-          runtime = { base.runtime with last_blocker = Some blocker };
-        }
       in
-      let decision_promise =
-        Eio.Fiber.fork_promise ~sw (fun () ->
-          let cb =
-            GP.to_oas_approval_callback
-              ~config ~governance_level:"production" ~keeper_name ~meta ()
-          in
-          cb
-            ~tool_name:"masc_create_task"
-            ~input:(`Assoc [ ("title", `String "test") ]))
-      in
+      meta_ref :=
+        { !meta_ref with
+          runtime = { (!meta_ref).runtime with last_blocker = Some blocker };
+        };
       let decision =
-        match Eio.Promise.await decision_promise with
-        | Ok decision -> decision
-        | Error exn -> Alcotest.failf "approval callback raised: %s" (Printexc.to_string exn)
+        cb
+          ~tool_name:"masc_create_task"
+          ~input:(`Assoc [ ("title", `String "test") ])
       in
       Alcotest.(check bool)
-        "typed last_blocker makes request hard-forbidden and rejects outright"
+        "mid-turn typed last_blocker reports a pending operator decision"
         true
         (approval_decision_is_reject decision);
       Alcotest.(check int)
-        "hard-forbidden request never enters the approval queue"
-        initial_pending
-        (AQ.pending_count ()))
+        "typed last_blocker enters the approval queue"
+        (initial_pending + 1)
+        (AQ.pending_count ());
+      (match pending_id_for_keeper ~keeper_name with
+       | Some id -> resolve_pending_or_fail ~id ~decision:(Agent_sdk.Hooks.Reject "test cleanup")
+       | None -> Alcotest.fail "expected blocker approval to be queued");
+      Alcotest.(check int) "pending count restored" initial_pending (AQ.pending_count ()))
 
 let test_callback_transient_last_blocker_preserves_always_approve () =
   with_test_config @@ fun config ->
@@ -2137,12 +2197,12 @@ let test_runtime_trust_classifies_always_approve_flag () =
         "auto_approved_always"
         (approval |> member "latest_event_kind" |> to_string))
 
-let test_callback_always_approve_respects_hard_forbidden () =
+let test_callback_always_approve_respects_operator_floor () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   Mcp_eio.set_net (Eio.Stdenv.net env);
   Mcp_eio.set_clock (Eio.Stdenv.clock env);
-  let keeper_name = "always-hard-forbidden-keeper" in
+  let keeper_name = "always-operator-floor-keeper" in
   let base_path = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_path)
@@ -2167,27 +2227,32 @@ let test_callback_always_approve_respects_hard_forbidden () =
           ~governance_level:"production"
           ~keeper_name
           ~meta
+          ~lane_policy:AQ.Nonblocking
           ()
       in
       Alcotest.(check bool)
-        "always_approve does not bypass hard-forbidden"
+        "always_approve does not bypass operator floor"
         true
         (approval_decision_is_reject
            (cb ~tool_name:"tool_edit_file" ~input:(`Assoc [("path", `String "/dangerous")])));
       Alcotest.(check int)
-        "hard-forbidden request never enters queue"
-        initial_pending
+        "operator-floor request enters queue"
+        (initial_pending + 1)
         (AQ.pending_count ());
+      (match pending_id_for_keeper ~keeper_name with
+       | Some id -> resolve_pending_or_fail ~id ~decision:(Agent_sdk.Hooks.Reject "test cleanup")
+       | None -> Alcotest.fail "expected operator-floor approval to be queued");
+      Alcotest.(check int) "pending count restored" initial_pending (AQ.pending_count ());
       check_no_auto_mode_resolved ~base_path ~keeper_name;
       ())
 
-let test_callback_hitl_disabled_hard_forbidden_rejects_without_queuing () =
+let test_callback_hitl_disabled_keeps_operator_floor () =
   with_env Env_config_core.disable_hitl_env_key "true" @@ fun () ->
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   Mcp_eio.set_net (Eio.Stdenv.net env);
   Mcp_eio.set_clock (Eio.Stdenv.clock env);
-  let keeper_name = "hitl-disabled-hard-forbidden-keeper" in
+  let keeper_name = "hitl-disabled-operator-floor-keeper" in
   let initial_pending = AQ.pending_count () in
   let base_path = temp_dir () in
   AQ.For_testing.reset_audit_store ();
@@ -2204,10 +2269,11 @@ let test_callback_hitl_disabled_hard_forbidden_rejects_without_queuing () =
           ~config
           ~governance_level:"production"
           ~keeper_name
+          ~lane_policy:AQ.Nonblocking
           ()
       in
       Alcotest.(check bool)
-        "hard-forbidden rejects when HITL threshold is disabled"
+        "operator floor remains pending when ordinary HITL threshold is disabled"
         true
         (approval_decision_is_reject
            (cb ~tool_name:"tool_edit_file" ~input:(`Assoc [ ("path", `String "/dangerous") ])));
@@ -2217,7 +2283,7 @@ let test_callback_hitl_disabled_hard_forbidden_rejects_without_queuing () =
           find_audit_event
             ~base_path
             ~keeper_name
-            ~event_type:AQ.approval_audit_hard_forbidden_event
+            ~event_type:AQ.approval_audit_pending_event
         with
         | Some _ -> true
         | None -> false);
@@ -2225,7 +2291,7 @@ let test_callback_hitl_disabled_hard_forbidden_rejects_without_queuing () =
          find_audit_event
            ~base_path
            ~keeper_name
-           ~event_type:AQ.approval_audit_hard_forbidden_event
+           ~event_type:AQ.approval_audit_pending_event
        with
        | Some json ->
          Alcotest.(check string)
@@ -2234,21 +2300,25 @@ let test_callback_hitl_disabled_hard_forbidden_rejects_without_queuing () =
            (Yojson.Safe.Util.(json |> member "disposition" |> to_string));
          Alcotest.(check string)
            "audit disposition_reason"
-           "hard_forbidden"
+           "separation_of_duties_floor"
            (Yojson.Safe.Util.(json |> member "disposition_reason" |> to_string))
-       | None -> Alcotest.fail "expected hard-forbidden audit event");
+       | None -> Alcotest.fail "expected pending operator approval audit event");
       Alcotest.(check int)
-        "hard-forbidden request never enters queue"
-        initial_pending
-        (AQ.pending_count ()))
+        "operator-floor request enters queue"
+        (initial_pending + 1)
+        (AQ.pending_count ());
+      (match pending_id_for_keeper ~keeper_name with
+       | Some id -> resolve_pending_or_fail ~id ~decision:(Agent_sdk.Hooks.Reject "test cleanup")
+       | None -> Alcotest.fail "expected operator-floor approval to be queued");
+      Alcotest.(check int) "pending count restored" initial_pending (AQ.pending_count ()))
 
-let test_callback_hitl_enabled_hard_forbidden_rejects_without_queuing () =
+let test_callback_hitl_enabled_queues_operator_floor () =
   with_env Env_config_core.disable_hitl_env_key "" @@ fun () ->
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   Mcp_eio.set_net (Eio.Stdenv.net env);
   Mcp_eio.set_clock (Eio.Stdenv.clock env);
-  let keeper_name = "hitl-enabled-hard-forbidden-keeper" in
+  let keeper_name = "hitl-enabled-operator-floor-keeper" in
   let initial_pending = AQ.pending_count () in
   let base_path = temp_dir () in
   AQ.For_testing.reset_audit_store ();
@@ -2265,18 +2335,23 @@ let test_callback_hitl_enabled_hard_forbidden_rejects_without_queuing () =
           ~config
           ~governance_level:"production"
           ~keeper_name
+          ~lane_policy:AQ.Nonblocking
           ()
       in
       Alcotest.(check bool)
-        "hard-forbidden rejects when HITL threshold is enabled"
+        "operator floor reports pending when HITL is enabled"
         true
         (approval_decision_is_reject
            (cb ~tool_name:"masc_delete_workspace" ~input:`Null));
       check_no_auto_mode_resolved ~base_path ~keeper_name;
       Alcotest.(check int)
-        "hard-forbidden request never enters queue"
-        initial_pending
-        (AQ.pending_count ()))
+        "operator-floor request enters queue"
+        (initial_pending + 1)
+        (AQ.pending_count ());
+      (match pending_id_for_keeper ~keeper_name with
+       | Some id -> resolve_pending_or_fail ~id ~decision:(Agent_sdk.Hooks.Reject "test cleanup")
+       | None -> Alcotest.fail "expected operator-floor approval to be queued");
+      Alcotest.(check int) "pending count restored" initial_pending (AQ.pending_count ()))
 
 let test_callback_hitl_disabled_soft_forbidden_requires_approval () =
   with_env Env_config_core.disable_hitl_env_key "true" @@ fun () ->
@@ -2288,7 +2363,7 @@ let test_callback_hitl_disabled_soft_forbidden_requires_approval () =
   let keeper_name = "hitl-disabled-soft-forbidden-keeper" in
   let input = `Assoc [ ("op", `String "git") ] in
   Alcotest.(check string)
-    "soft-only fixture stays below hard-forbidden risk"
+    "soft-only fixture stays below Critical risk"
     "low"
     (GP.assess_risk ~tool_name:"masc_status" ~input |> GP.risk_level_to_string);
   let initial_pending = AQ.pending_count () in
@@ -2299,6 +2374,7 @@ let test_callback_hitl_disabled_soft_forbidden_requires_approval () =
     (fun () ->
       let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
       let config = Mcp_server.workspace_config state in
+      set_approval_mode_or_fail config OA.Auto_low_risk;
       Eio.Fiber.fork ~sw (fun () ->
         let cb =
           GP.to_oas_approval_callback
@@ -2376,16 +2452,31 @@ let test_list_recent_resolved_json_projects_resolved_history () =
       ~tool_name:"tool_search_files" ~risk_level:AQ.Low ()
   done;
   AQ.audit_approval_event ~base_path
+    ~event_type:"hard_forbidden" ~id:"legacy-terminal"
+    ~keeper_name ~tool_name:"tool_edit_file" ~risk_level:AQ.Critical
+    ~decision:(AQ.Approval_resolved (Agent_sdk.Hooks.Reject "legacy terminal rejection")) ();
+  AQ.audit_approval_event ~base_path
+    ~event_type:"approval_timeout" ~id:"timeout-is-not-resolution"
+    ~keeper_name ~tool_name:"tool_search_files" ~risk_level:AQ.Medium
+    ~decision:(AQ.Approval_expired "operator wait timed out") ();
+  AQ.audit_approval_event ~base_path
     ~event_type:AQ.approval_audit_resolved_event ~id:"newer-resolved"
     ~keeper_name ~tool_name:"tool_search_files" ~risk_level:AQ.Medium
     ~decision:(AQ.Approval_resolved Agent_sdk.Hooks.Approve) ();
-  match AQ.list_recent_resolved_json ~base_path ~n:2 () with
-  | [ newest; older ] ->
+  match AQ.list_recent_resolved_json ~base_path ~n:3 () with
+  | [ newest; legacy; older ] ->
     let open Yojson.Safe.Util in
     Alcotest.(check string) "newest first" "newer-resolved"
       (newest |> member "id" |> to_string);
-    Alcotest.(check string) "older second" "older-resolved"
+    Alcotest.(check string) "older resolution retained" "older-resolved"
       (older |> member "id" |> to_string);
+    Alcotest.(check string) "legacy terminal retained" "legacy-terminal"
+      (legacy |> member "id" |> to_string);
+    Alcotest.(check string) "legacy label canonicalized" "resolved"
+      (legacy |> member "event" |> to_string);
+    Alcotest.(check string) "legacy disposition canonicalized"
+      "retired_terminal_policy"
+      (legacy |> member "disposition_reason" |> to_string);
     Alcotest.(check string) "keeper name" keeper_name
       (older |> member "keeper_name" |> to_string);
     Alcotest.(check string) "tool name" "tool_search_files"
@@ -2406,7 +2497,9 @@ let test_list_recent_resolved_json_projects_resolved_history () =
       (has_assoc_key "requested_at" older)
   | items ->
     Alcotest.fail
-      (Printf.sprintf "expected two resolved audits, got %d" (List.length items))
+      (Printf.sprintf
+         "expected three true/canonical resolved audits with timeout excluded, got %d"
+         (List.length items))
 
 let test_runtime_trust_approval_read_model_filters_after_wide_scan () =
   with_test_config @@ fun config ->
@@ -2425,10 +2518,10 @@ let test_runtime_trust_approval_read_model_filters_after_wide_scan () =
           ])
       in
       AQ.audit_approval_event ~base_path:config.base_path
-        ~event_type:AQ.approval_audit_resolved_event
-        ~id:"runtime-trust-target-audit"
+        ~event_type:"hard_forbidden"
+        ~id:"runtime-trust-legacy-terminal-audit"
         ~keeper_name ~tool_name:"tool_search_files" ~risk_level:AQ.Medium
-        ~decision:(AQ.Approval_resolved Agent_sdk.Hooks.Approve) ();
+        ~decision:(AQ.Approval_resolved (Agent_sdk.Hooks.Reject "legacy rejection")) ();
       for i = 1 to 64 do
         AQ.audit_approval_event ~base_path:config.base_path
           ~event_type:AQ.approval_audit_resolved_event
@@ -2541,8 +2634,10 @@ let () =
       ("callback_integration", [
         Alcotest.test_case "Auto_low_risk gated low band resolves with history" `Quick
           test_callback_auto_mode_approves_gated_low_risk_and_records_history;
-        Alcotest.test_case "Auto_low_risk critical hard-forbidden rejects" `Quick
-          test_callback_auto_mode_critical_rejects_hard_forbidden;
+        Alcotest.test_case "metadata unavailable queues low-risk" `Quick
+          test_callback_metadata_unavailable_queues_low_risk;
+        Alcotest.test_case "Auto_low_risk Critical queues nonblocking" `Quick
+          test_callback_auto_mode_critical_queues_nonblocking;
         Alcotest.test_case "production claimed worktree write auto-approved" `Quick
           test_callback_production_claimed_worktree_write_auto_approved;
         Alcotest.test_case "Auto_low_risk high band queues for operator" `Quick
@@ -2554,20 +2649,20 @@ let () =
           test_callback_manual_mode_preserves_remembered_medium_policy;
         Alcotest.test_case "Manual preserves remembered soft rule" `Quick
           test_callback_manual_mode_preserves_remembered_soft_forbidden;
-        Alcotest.test_case "Manual preserves always_approve threshold" `Quick
-          test_callback_manual_mode_preserves_always_approve_threshold;
-        Alcotest.test_case "typed last_blocker rejects hard-forbidden" `Quick
-          test_callback_typed_last_blocker_rejects_hard_forbidden;
+        Alcotest.test_case "always_approve cannot bypass High floor" `Quick
+          test_callback_always_approve_cannot_bypass_high_floor;
+        Alcotest.test_case "typed last_blocker queues operator" `Quick
+          test_callback_typed_last_blocker_queues_operator;
         Alcotest.test_case "transient last_blocker preserves always_approve" `Quick
           test_callback_transient_last_blocker_preserves_always_approve;
         Alcotest.test_case "runtime trust classifies always_approve flag" `Quick
           test_runtime_trust_classifies_always_approve_flag;
-        Alcotest.test_case "always_approve respects hard-forbidden" `Quick
-          test_callback_always_approve_respects_hard_forbidden;
-        Alcotest.test_case "HITL disabled hard-forbidden rejects without queuing" `Quick
-          test_callback_hitl_disabled_hard_forbidden_rejects_without_queuing;
-        Alcotest.test_case "HITL enabled hard-forbidden rejects without queuing" `Quick
-          test_callback_hitl_enabled_hard_forbidden_rejects_without_queuing;
+        Alcotest.test_case "always_approve respects operator floor" `Quick
+          test_callback_always_approve_respects_operator_floor;
+        Alcotest.test_case "HITL disabled keeps operator floor" `Quick
+          test_callback_hitl_disabled_keeps_operator_floor;
+        Alcotest.test_case "HITL enabled queues operator floor" `Quick
+          test_callback_hitl_enabled_queues_operator_floor;
         Alcotest.test_case "HITL disabled still queues soft forbidden tools" `Quick
           test_callback_hitl_disabled_soft_forbidden_requires_approval;
       ]);

--- a/test/test_keeper_guards.ml
+++ b/test/test_keeper_guards.ml
@@ -382,7 +382,7 @@ let test_cost_guard_disabled () =
   in
   check string "no budget -> Continue" "Continue" (decision_kind d)
 
-let test_destructive_guard_notifies_block_observer () =
+let test_destructive_guard_requires_operator_approval () =
   let meta_ref = make_meta_ref "test_keeper" in
   let observed = ref [] in
   let on_gate_decision event = observed := event :: !observed in
@@ -399,13 +399,14 @@ let test_destructive_guard_notifies_block_observer () =
          ~input:(`Assoc [ ("command", `String "rm -rf /") ])
          ())
   in
-  check string "destructive command -> Block" "Block" (decision_kind d);
+  check string "destructive command -> ApprovalRequired"
+    "ApprovalRequired" (decision_kind d);
   match !observed with
   | [ event ] ->
     check string "stage" "destructive_guard" event.KG.stage;
-    check string "decision" "block"
+    check string "decision" "approval_required"
       (KG.gate_decision_to_string event.KG.decision);
-    check string "reason_code" "destructive_guard" event.KG.reason_code;
+    check string "reason_code" "destructive_approval_required" event.KG.reason_code;
     check string "tool_name" "shell_exec" event.KG.tool_name
   | events ->
     failf "expected one destructive observer event, got %d" (List.length events)
@@ -874,25 +875,23 @@ let test_governance_approval_critical_code_blocks_with_legacy_exemption () =
            ~input:(`Assoc [ ("cmd", `String "git status") ])
            ())
     in
-    check string "legacy exemption cannot bypass critical code block"
-      "Block" (decision_kind d);
-    check bool "override carries hard-forbidden reason" true
-      (contains_substring (override_text d) "code=hard_forbidden");
+    check string "legacy exemption cannot bypass critical approval"
+      "ApprovalRequired" (decision_kind d);
     match !observed with
     | [ event ] ->
       check string "stage" "governance_approval" event.KG.stage;
-      check string "decision" "block"
+      check string "decision" "approval_required"
         (KG.gate_decision_to_string event.KG.decision);
-      check string "reason_code" "hard_forbidden" event.KG.reason_code;
+      check string "reason_code" "governance_approval" event.KG.reason_code;
       check string "tool_name" "tool_execute" event.KG.tool_name;
       check (option string) "source_path"
         (Some "lib/keeper/keeper_guards.ml")
         event.KG.source_path
     | events ->
-      failf "expected one hard-forbidden observer event, got %d"
+      failf "expected one operator-approval observer event, got %d"
         (List.length events))))
 
-let test_governance_approval_hard_forbidden_blocks_without_hitl () =
+let test_governance_approval_critical_requires_operator_without_hitl () =
   with_env "MASC_GOVERNANCE_LEVEL" "development" (fun () ->
   with_env "MASC_DISABLE_HITL" "true" (fun () ->
     let meta_ref = make_meta_ref "test_keeper" in
@@ -905,29 +904,115 @@ let test_governance_approval_hard_forbidden_blocks_without_hitl () =
            ~input:(`Assoc [ ("target", `String "workspace") ])
            ())
     in
-    check string "critical hard-forbidden tool -> Block"
-      "Block" (decision_kind d);
-    check bool "block carries hard-forbidden reason" true
-      (contains_substring (override_text d) "code=hard_forbidden");
+    check string "Critical tool -> ApprovalRequired"
+      "ApprovalRequired" (decision_kind d);
     match !observed with
     | [ event ] ->
       check string "stage" "governance_approval" event.KG.stage;
-      check string "decision" "block"
+      check string "decision" "approval_required"
         (KG.gate_decision_to_string event.KG.decision);
-      check string "reason_code" "hard_forbidden" event.KG.reason_code;
+      check string "reason_code" "governance_approval" event.KG.reason_code;
       check string "tool_name" "masc_force_reset" event.KG.tool_name;
       check (option string) "source_path"
         (Some "lib/keeper/keeper_guards.ml")
         event.KG.source_path
     | events ->
-      failf "expected one hard-forbidden observer event, got %d"
+      failf "expected one operator-approval observer event, got %d"
         (List.length events)))
+
+let test_keeper_chain_high_requires_operator_without_hitl () =
+  with_env "MASC_GOVERNANCE_LEVEL" "development" (fun () ->
+  with_env "MASC_DISABLE_HITL" "true" (fun () ->
+    let keeper_name = "test_keeper" in
+    let meta_ref = make_meta_ref keeper_name in
+    let observed = ref [] in
+    let tool_name = "keeper_surface_post" in
+    let input = `Assoc [ "content", `String "follow up" ] in
+    Masc.Tool_shard.set_agent_shards
+      keeper_name
+      Masc.Tool_shard.default_shard_names;
+    Fun.protect
+      ~finally:(fun () -> Masc.Tool_shard.remove_agent_shards keeper_name)
+      (fun () ->
+         let active_tool_names =
+           Masc.Tool_shard.tools_of_shards
+             Masc.Tool_shard.default_shard_names
+           |> List.map
+                (fun (schema : Masc_domain.tool_schema) -> schema.name)
+         in
+         let risk_context =
+           Masc.Governance_pipeline.keeper_risk_context
+             ~active_tool_names
+         in
+         let assessment =
+           Masc.Governance_pipeline.assess_keeper_risk
+             ~context:risk_context
+             ~tool_name
+             ~input
+         in
+         check string "fixture base risk" "medium"
+           (Masc.Governance_pipeline.risk_level_to_string assessment.base_risk);
+         check string "active shards escalate fixture to High" "high"
+           (Masc.Governance_pipeline.risk_level_to_string
+              assessment.effective_risk);
+         let hook =
+           KG.build_chain
+             ~meta_ref
+             ~tool_start_time:(ref 0.0)
+             ~streak_state:(KG.make_streak_state ())
+             ~readonly_observation_state:(KG.make_readonly_observation_state ())
+             ~streak_threshold:8
+             ~denied:[]
+             ~max_cost_usd:None
+             ~destructive_ops_policy:Masc.Destructive_ops_policy.default
+             ~risk_context
+             ~on_gate_decision:(fun event -> observed := event :: !observed)
+             ~pre_tool_use_guard:(fun ~tool_name:_ ~input:_ -> None)
+         in
+         let decision = invoke hook (pre_tool_use_event ~tool_name ~input ()) in
+         check string
+           "effective-High tool reaches operator approval through the full chain"
+           "ApprovalRequired"
+           (decision_kind decision);
+         match !observed with
+         | [ event ] ->
+           check string "stage" "governance_approval" event.KG.stage;
+           check string "decision" "approval_required"
+             (KG.gate_decision_to_string event.KG.decision)
+         | events ->
+           failf "expected one operator-approval observer event, got %d"
+             (List.length events))))
 
 let meta_with_blocker klass meta =
   let open Masc.Keeper_meta_contract in
   let blocker = blocker_info_of_class ~detail:"test blocker" klass in
   { meta with runtime = { meta.runtime with last_blocker = Some blocker } }
 ;;
+
+let test_governance_metadata_unavailable_requires_operator () =
+  with_env "MASC_GOVERNANCE_LEVEL" "development" (fun () ->
+  with_env "MASC_DISABLE_HITL" "true" (fun () ->
+    let meta_ref = make_meta_ref "test_keeper" in
+    let observed = ref [] in
+    let hook =
+      KG.governance_approval_guard
+        ~active_tool_names:[ "keeper_time_now" ]
+        ~meta_provider:(fun () -> None)
+        ~meta_ref
+        ~on_gate_decision:(fun event -> observed := event :: !observed)
+    in
+    let decision =
+      invoke hook (pre_tool_use_event ~tool_name:"keeper_time_now" ())
+    in
+    check string "missing live metadata fails closed"
+      "ApprovalRequired" (decision_kind decision);
+    match !observed with
+    | [ event ] ->
+      check string "typed reason" "governance_metadata_unavailable"
+        event.KG.reason_code
+    | events ->
+      failf "expected one metadata-unavailable event, got %d"
+        (List.length events)))
 
 let test_governance_approval_serious_blocker_overrides () =
   with_env "MASC_GOVERNANCE_LEVEL" "development" (fun () ->
@@ -943,10 +1028,8 @@ let test_governance_approval_serious_blocker_overrides () =
            ~input:(`Assoc [ ("title", `String "follow up") ])
            ())
     in
-    check string "serious last_blocker -> Block"
-      "Block" (decision_kind d);
-    check bool "block carries hard-forbidden reason" true
-      (contains_substring (override_text d) "code=hard_forbidden")))
+    check string "serious last_blocker -> ApprovalRequired"
+      "ApprovalRequired" (decision_kind d)))
 
 let test_governance_approval_transient_blocker_allows () =
   with_env "MASC_GOVERNANCE_LEVEL" "development" (fun () ->
@@ -1080,8 +1163,8 @@ let () = run "Keeper_guards" [
     test_case "no budget -> continue" `Quick test_cost_guard_disabled;
   ];
   "destructive_guard", [
-    test_case "notifies observer on block" `Quick
-      test_destructive_guard_notifies_block_observer;
+    test_case "requires operator approval" `Quick
+      test_destructive_guard_requires_operator_approval;
   ];
   "streak_guard", [
     test_case "under threshold -> continue" `Quick test_streak_guard_under_threshold;
@@ -1122,10 +1205,14 @@ let () = run "Keeper_guards" [
   "governance_approval_guard", [
     test_case "legacy exemption cannot bypass high-risk approval" `Quick
       test_governance_approval_legacy_exemption_cannot_bypass_high;
-    test_case "critical code blocks with legacy exemption" `Quick
+    test_case "critical code requires approval with legacy exemption" `Quick
       test_governance_approval_critical_code_blocks_with_legacy_exemption;
-    test_case "hard-forbidden blocks without HITL" `Quick
-      test_governance_approval_hard_forbidden_blocks_without_hitl;
+    test_case "Critical requires operator without HITL" `Quick
+      test_governance_approval_critical_requires_operator_without_hitl;
+    test_case "High requires operator through chain without HITL" `Quick
+      test_keeper_chain_high_requires_operator_without_hitl;
+    test_case "metadata unavailable requires operator" `Quick
+      test_governance_metadata_unavailable_requires_operator;
     test_case "serious last_blocker overrides without HITL" `Quick
       test_governance_approval_serious_blocker_overrides;
     test_case "transient last_blocker allows without HITL" `Quick

--- a/test/test_keeper_guards.ml
+++ b/test/test_keeper_guards.ml
@@ -835,7 +835,7 @@ let test_governance_approval_legacy_exemption_cannot_bypass_high () =
     let meta_ref = make_meta_ref "test_keeper" in
     let observed = ref [] in
     let on_gate_decision event = observed := event :: !observed in
-    let hook = KG.governance_approval_guard ~meta_ref ~on_gate_decision in
+    let hook = KG.governance_approval_guard ~meta_ref ~on_gate_decision () in
     let d =
       invoke hook
         (pre_tool_use_event ~tool_name:"masc_create_task"
@@ -868,7 +868,7 @@ let test_governance_approval_critical_code_blocks_with_legacy_exemption () =
     let meta_ref = make_meta_ref "test_keeper" in
     let observed = ref [] in
     let on_gate_decision event = observed := event :: !observed in
-    let hook = KG.governance_approval_guard ~meta_ref ~on_gate_decision in
+    let hook = KG.governance_approval_guard ~meta_ref ~on_gate_decision () in
     let d =
       invoke hook
         (pre_tool_use_event ~tool_name:"tool_execute"
@@ -897,7 +897,7 @@ let test_governance_approval_critical_requires_operator_without_hitl () =
     let meta_ref = make_meta_ref "test_keeper" in
     let observed = ref [] in
     let on_gate_decision event = observed := event :: !observed in
-    let hook = KG.governance_approval_guard ~meta_ref ~on_gate_decision in
+    let hook = KG.governance_approval_guard ~meta_ref ~on_gate_decision () in
     let d =
       invoke hook
         (pre_tool_use_event ~tool_name:"masc_force_reset"
@@ -968,6 +968,7 @@ let test_keeper_chain_high_requires_operator_without_hitl () =
              ~risk_context
              ~on_gate_decision:(fun event -> observed := event :: !observed)
              ~pre_tool_use_guard:(fun ~tool_name:_ ~input:_ -> None)
+             ()
          in
          let decision = invoke hook (pre_tool_use_event ~tool_name ~input ()) in
          check string
@@ -1000,6 +1001,7 @@ let test_governance_metadata_unavailable_requires_operator () =
         ~meta_provider:(fun () -> None)
         ~meta_ref
         ~on_gate_decision:(fun event -> observed := event :: !observed)
+        ()
     in
     let decision =
       invoke hook (pre_tool_use_event ~tool_name:"keeper_time_now" ())
@@ -1021,7 +1023,7 @@ let test_governance_approval_serious_blocker_overrides () =
     meta_ref := meta_with_blocker Masc.Keeper_meta_contract.Completion_contract_violation !meta_ref;
     let observed = ref [] in
     let on_gate_decision event = observed := event :: !observed in
-    let hook = KG.governance_approval_guard ~meta_ref ~on_gate_decision in
+    let hook = KG.governance_approval_guard ~meta_ref ~on_gate_decision () in
     let d =
       invoke hook
         (pre_tool_use_event ~tool_name:"masc_create_task"
@@ -1038,7 +1040,7 @@ let test_governance_approval_transient_blocker_allows () =
     meta_ref := meta_with_blocker Masc.Keeper_meta_contract.Turn_timeout !meta_ref;
     let observed = ref [] in
     let on_gate_decision event = observed := event :: !observed in
-    let hook = KG.governance_approval_guard ~meta_ref ~on_gate_decision in
+    let hook = KG.governance_approval_guard ~meta_ref ~on_gate_decision () in
     let d =
       invoke hook
         (pre_tool_use_event ~tool_name:"masc_create_task"


### PR DESCRIPTION
## Summary

- retire terminal Keeper policy rejection and route High/Critical/runtime-blocker calls through nonblocking operator approval
- make the Keeper pre-tool guard and OAS approval callback share one immutable effective-risk context and live metadata projection
- preserve exact remembered soft-signal rules while preventing automatic flags, rules, or modes from crossing the High/Critical floor
- fail closed with a typed `metadata_unavailable` queue reason when live registry metadata is missing or invalid
- canonicalize historical terminal-policy audit rows without emitting or displaying the retired vocabulary

## Runtime behavior

- an operator decision wakes a later Keeper cycle; it does not block the active lane
- `MASC_DISABLE_HITL` no longer lets High/effective-High calls bypass the Keeper guard
- absolute BasePath normalization avoids per-tool `getcwd`; pre/post registry reads remain distinct policy-before/tool-after boundaries
- the installed tool surface is projected once per run and shared by guard/callback, so there is no per-tool shard mutex or capability rescan

## Compatibility

The retired wire label remains only in one typed read-only legacy decoder plus migration fixtures. Current policy and audit emitters never produce it. Removing the decoder would make persisted history unreadable, so migration compatibility is intentionally explicit rather than hidden.

## Verification

- all changed OCaml files parse with OCaml 5.4 tooling
- `ocamlformat --check`
- `git diff --check`
- independent adversarial structural review: P0/P1/P2 none

Focused local typecheck is blocked before Dune by the shared switch being pinned to OAS 0.211.9 while MASC main intentionally pins 0.211.8. Required CI is the exact build authority.
