### PR TITLE
task-1903 v2: RFC-0327 §A1 — Wire jaccard-0.85 at compaction boundary

### DIFF
--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -621,6 +621,16 @@ let compact_memory_bank_if_needed
             consolidated_parsed
         in
         let deduped = dedup_by_key memory_row_key by_recency in
+        (* RFC-0327 §A1: after exact-key dedup, also drop similarity
+           duplicates (jaccard >= 0.85).  This catches paraphrase rows
+           that share enough tokens with an earlier row. *)
+        let deduped, _sim_dropped, _sim_merge_map =
+          similarity_dedup
+            ~threshold:0.85
+            ~key_of:memory_row_key
+            ~text_of:(fun row -> row.text)
+            deduped
+        in
         let dedup_dropped = max 0 (before_notes - List.length deduped) in
         if List.length deduped <= target_notes && dedup_dropped = 0 && invalid = 0
         then
@@ -666,7 +676,9 @@ let compact_memory_bank_if_needed
                   Hashtbl.replace kind_dropped_keys key row.kind
           in
           let recent_floor = max 16 (min 64 (target_notes / 5)) in
-          by_recency
+          (* P0 fix: use deduped (not by_recency) to prevent
+             similarity-deduped rows from being re-introduced. *)
+          deduped
           |> take recent_floor
           |> List.iter (fun row -> add_row ~ignore_kind_cap:false row);
           let by_priority =
@@ -682,7 +694,8 @@ let compact_memory_bank_if_needed
           in
           List.iter (fun row -> add_row ~ignore_kind_cap:false row) by_priority;
           if !selected_count < target_notes then
-            List.iter (fun row -> add_row ~ignore_kind_cap:true row) by_recency;
+            (* P0 fix: use deduped (not by_recency) for fallback too. *)
+            List.iter (fun row -> add_row ~ignore_kind_cap:true row) deduped;
           let selected =
             !selected_rev
             |> List.rev

--- a/lib/keeper/keeper_memory_bank_selection.ml
+++ b/lib/keeper/keeper_memory_bank_selection.ml
@@ -41,6 +41,56 @@ let dedup_by_key (key_of : 'a -> string) (items : 'a list) : 'a list =
 
 let jaccard_similarity = Text_similarity.jaccard_similarity
 
+(** RFC-0327 §A1 — Remove rows that are similarity-duplicates of earlier rows.
+
+    For each row, compare its text against all preceding rows.  When the
+    jaccard similarity is >= [threshold], the later row is considered a
+    duplicate and is dropped.  Returns the filtered list together with
+    the count of dropped rows and a mapping from dropped-row identities
+    to the identity of the surviving (earlier) row.
+
+    This is intentionally separate from [dedup_by_key]: key-based dedup
+    catches exact matches cheaply; similarity dedup catches paraphrase
+    duplicates that share enough tokens. *)
+let similarity_dedup
+    ~(threshold : float)
+    ~(key_of : 'a -> string)
+    ~(text_of : 'a -> string)
+    (items : 'a list)
+  : 'a list * int * (string * string) list =
+  let n = List.length items in
+  if n <= 1 then (items, 0, [])
+  else
+    let arr = Array.of_list items in
+    let alive = Array.make n true in
+    let merge_map : (string * string) list ref = ref [] in
+    let drop_count = ref 0 in
+    for i = 1 to n - 1 do
+      if alive.(i) then begin
+        let ti = text_of arr.(i) in
+        let dominated = ref false in
+        for j = 0 to i - 1 do
+          if alive.(j) && not !dominated then begin
+            let tj = text_of arr.(j) in
+            let sim = jaccard_similarity ti tj in
+            if Float.compare sim threshold >= 0 then begin
+              dominated := true;
+              alive.(i) <- false;
+              incr drop_count;
+              merge_map :=
+                (key_of arr.(i), key_of arr.(j)) :: !merge_map
+            end
+          end
+        done
+      end
+    done;
+    let result =
+      Array.to_list arr
+      |> List.mapi (fun idx item -> (alive.(idx), item))
+      |> List.filter_map (fun (keep, item) -> if keep then Some item else None)
+    in
+    (result, !drop_count, List.rev !merge_map)
+
 (* Punctuation strip used by the dedup key — fully static, hoist to
    module level so the DFA is built once per process. *)
 let normalize_punct_re =

--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -72,6 +72,15 @@ let no_memory_bank_compaction =
   }
 ;;
 
+(** RFC-0327 §A1 — Outcome of a memory bank write operation.
+    [Persisted] means the row was written as-is.
+    [Merged_into target_id] means the row was similarity-matched
+    (jaccard >= 0.85) to an existing row and merged into it. *)
+type write_outcome =
+  | Persisted
+  | Merged_into of string
+;;
+
 let keeper_memory_schema_version = 2
 let short_term_horizon = "short_term"
 let mid_term_horizon = "mid_term"


### PR DESCRIPTION
## Summary

Clean rewrite of RFC-0327 §A1 from latest `origin/main`. Addresses **all P0/P1 feedback** from jeong-sik on closed PR #24300.

Adds similarity-based deduplication to memory bank compaction using jaccard similarity at 0.85 threshold. This catches paraphrase duplicates that share enough tokens with an earlier row but differ in their exact key (`kind:text_hash`).

## Changes (3 files, +74/-2)

| File | Change |
|------|--------|
| `lib/keeper/keeper_memory_policy.ml` | Add `write_outcome` type: `Persisted | Merged_into of string` |
| `lib/keeper/keeper_memory_bank_selection.ml` | Add `similarity_dedup` function using `jaccard_similarity` with configurable threshold |
| `lib/keeper/keeper_memory_bank.ml` | Wire `similarity_dedup` into `compact_memory_bank_if_needed` after `dedup_by_key`, before truncation |

## P0 Fixes from PR #24300 Review

1. **Selection re-introduction bug fixed:** Pass 1 (`recent_floor`) and Pass 3 (`fallback`) now iterate over `deduped` instead of `by_recency`, preventing similarity-deduped rows from being re-introduced into the selection result.

2. **Double-counting fix:** `dedup_dropped` is now calculated as `max 0 (before_notes - List.length deduped)` — since `deduped` already reflects both key-based and similarity-based dedup, no separate `sim_dropped` subtraction is needed.

3. **Clean branch:** This PR is based on `origin/main` and contains only memory-bank files. No unrelated pacing/TLA or sandbox git-root commits.

## What it does

1. After exact-key dedup (`dedup_by_key memory_row_key`), the new `similarity_dedup` function compares each remaining row's text against all earlier rows using jaccard similarity.
2. If jaccard >= 0.85, the later row is dropped as a paraphrase duplicate.
3. The `write_outcome` type provides a typed result for write operations.

## Scope note

`write_outcome` is declared in `keeper_memory_policy.ml` and available for consumption by future write-path integration. The compaction-path dedup is the primary deliverable of RFC-0327 §A1.