### PR TITLE
fix(exec): declare typed failure_class on Execute caller-input rejections

### DIFF
--- a/lib/exec_core.ml
+++ b/lib/exec_core.ml
@@ -443,6 +443,29 @@ let semantic_status_is_success = function
   | Partial -> false
 ;;
 
+(* Declared projection onto the shared tool-failure taxonomy
+   (Tool_result.tool_failure_class), emitted on the wire as the
+   "failure_class" field that Keeper_tools_oas_failure_boundary reads as a
+   closed enum. Without this declaration every Execute failure fell back to
+   Runtime_failure at that boundary, collapsing timeouts (retryable) and
+   policy blocks (deterministic) into one unknown, non-retryable signature
+   (sangsu keeper incident, 2026-07-12). [None] exactly when
+   [semantic_status_is_success] holds, so success payloads never carry a
+   failure class. *)
+let failure_class_of_semantic_status = function
+  | Ok | No_match -> None
+  | Timeout -> Some Tool_result.Transient_error
+  | Blocked -> Some Tool_result.Policy_rejection
+  | Partial | Runtime_error -> Some Tool_result.Runtime_failure
+;;
+
+let failure_class_field semantic_status =
+  match failure_class_of_semantic_status semantic_status with
+  | None -> []
+  | Some failure_class ->
+    [ "failure_class", `String (Tool_result.tool_failure_class_to_string failure_class) ]
+;;
+
 let family_label = function
   | Read -> "read"
   | Search -> "search"
@@ -779,6 +802,7 @@ let outcome_to_json ?(extra = []) ?(env_snapshot = None) = function
          ; "summary", `String result.summary
          ; "artifact_refs", `List (List.map artifact_ref_to_json result.artifact_refs)
          ]
+       @ failure_class_field result.semantic_status
        @ hint_fields
        @ semantic_fields_of_executed result
        @ (match
@@ -835,6 +859,7 @@ let outcome_to_json ?(extra = []) ?(env_snapshot = None) = function
          ; "hint", `String result.hint
          ; "recovery_hint", `String result.hint
          ]
+       @ failure_class_field Blocked
        @ diagnosis_field
        @ alternatives_field
        @ env_field)

--- a/lib/exec_core.mli
+++ b/lib/exec_core.mli
@@ -114,6 +114,18 @@ val classify_command_of_ir : Masc_exec.Shell_ir.t -> classification
 val classification_to_json : classification -> Yojson.Safe.t
 
 val string_of_semantic_status : semantic_status -> string
+
+val failure_class_of_semantic_status :
+  semantic_status ->
+  Tool_result.tool_failure_class option
+(** Declared projection onto the shared tool-failure taxonomy, emitted on the
+    wire as the ["failure_class"] field of every failed outcome JSON. [None]
+    exactly when {!semantic_status_is_success} holds. Timeout declares
+    [Transient_error] (retryable), Blocked declares [Policy_rejection];
+    Partial/Runtime_error declare [Runtime_failure]. *)
+
+val semantic_status_is_success : semantic_status -> bool
+
 val semantic_status_of_process :
   cmd:string ->
   output:string ->

--- a/lib/keeper/keeper_tool_dispatch_runtime.ml
+++ b/lib/keeper/keeper_tool_dispatch_runtime.ml
@@ -486,7 +486,8 @@ let descriptor_route_invariant_payload ~tool_name descriptor =
   `Assoc
     [ "ok", `Bool false
     ; "error", `String "keeper_tool_descriptor_route_invariant"
-    ; "failure_class", `String "runtime_failure"
+    ; ( "failure_class"
+      , `String (Tool_result.tool_failure_class_to_string Tool_result.Runtime_failure) )
     ; "tool", `String tool_name
     ; "descriptor_id", `String descriptor_id
     ; "executor", `String executor
@@ -662,7 +663,9 @@ let execute_keeper_tool_call_with_outcome
             (let fields =
                [ "ok", `Bool false
                ; "error", `String "tool_not_allowed"
-               ; "failure_class", `String "policy_rejection"
+               ; ( "failure_class"
+                 , `String
+                     (Tool_result.tool_failure_class_to_string Tool_result.Policy_rejection) )
                ; "tool", `String name
                ; "reason", `String reason
                ; "hint", `String hint
@@ -808,7 +811,9 @@ let execute_keeper_tool_call_with_outcome
             let fields =
               [ "ok", `Bool false
               ; "error", `String "unknown_tool"
-              ; "failure_class", `String "policy_rejection"
+              ; ( "failure_class"
+                , `String
+                    (Tool_result.tool_failure_class_to_string Tool_result.Policy_rejection) )
               ; "tool", `String unknown_name
               ]
               @ suggestion_fields

--- a/lib/keeper/keeper_tool_dispatch_runtime.mli
+++ b/lib/keeper/keeper_tool_dispatch_runtime.mli
@@ -152,9 +152,16 @@ val classify_tool_result_payload : string -> tool_result_payload
     plain text or malformed JSON. *)
 val failure_class_of_tool_result_payload : string -> Tool_result.tool_failure_class option
 
-(** [false] when a failed tool payload is a business-rule workflow
-    rejection that should be shown to the keeper without opening the
-    repeated-failure circuit breaker. *)
+(** [false] for [Policy_rejection] and [Workflow_rejection] — deterministic,
+    caller-visible rejections (permission/guardrail/validation denials and
+    business-rule refusals) surface as their own typed error/alternatives
+    instead of a loop-breaker hint, and repetition handling belongs to the
+    OAS-side episode detector at the LLM boundary. [true] (breaker applies)
+    for [Transient_error], [Runtime_failure], and [None] (undeclared,
+    conservatively treated as counting). Execute's own failure/blocked/
+    validation payloads declare [Policy_rejection] as of the sangsu
+    Ambiguous_failure_signature fix (masc#24314) and are routed by this same
+    predicate — no Execute-specific branch exists or is needed. *)
 val should_apply_circuit_breaker_to_failure_payload : Tool_result.tool_failure_class option -> bool
 
 (** Tag-based dispatch callback for masc_* tools without handler registry entries.

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -11,6 +11,16 @@ let elapsed_duration_ms ~start_time ~end_time =
   | _ when elapsed_ms < 1. -> 1
   | _ -> int_of_float elapsed_ms
 
+(* Typed declaration for pre-dispatch rejections (input parse/validation,
+   Shell IR gate, path policy, approvals): caller-input and policy denials
+   are Policy_rejection in the shared taxonomy (RFC-0062 §3.2). The OAS
+   failure boundary reads this field; leaving it undeclared collapses these
+   deterministic rejections into Runtime_failure -> error_class Unknown. *)
+let policy_rejection_failure_class_fields =
+  [ ( "failure_class"
+    , `String (Tool_result.tool_failure_class_to_string Tool_result.Policy_rejection) )
+  ]
+
 type path_probe =
   { path_argument : string
   ; resolved_path : string
@@ -758,6 +768,7 @@ let handle_tool_execute_typed
         error_json
           ~fields:
             ([ "typed", `Bool true; "cwd", `String cwd ]
+             @ policy_rejection_failure_class_fields
              @ execution_location_fields cwd)
           e
       | Ok input ->
@@ -768,6 +779,7 @@ let handle_tool_execute_typed
            in
            let fields =
              [ "typed", `Bool true; "cwd", `String cwd ]
+             @ policy_rejection_failure_class_fields
              @ execution_location_fields cwd
              @ typed_validation_deterministic_retry_fields e
              @ typed_validation_recovery_fields e
@@ -964,7 +976,11 @@ let handle_tool_execute_typed
             | None -> []
           in
           error_json
-            ~fields:(typed_error_fields @ deterministic_retry_fields @ extra_fields)
+            ~fields:
+              (typed_error_fields
+               @ policy_rejection_failure_class_fields
+               @ deterministic_retry_fields
+               @ extra_fields)
             msg
         in
         if Masc_exec.Shell_ir_risk.is_destructive envelope

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -755,7 +755,16 @@ let handle_tool_execute_typed
       ~write_enabled:true
       ~args
   with
-    | Error e -> error_json e
+    | Error e ->
+      (* cwd resolution rejects a bad/absent working directory
+         (cwd_not_directory, directory does not exist) — a deterministic
+         caller/config rejection, same family as the of_json/validate
+         rejections below.  Declare Policy_rejection so the boundary does
+         not resolve it to Runtime_failure→(Non_retryable, Unknown) and
+         count it against the circuit breaker. *)
+      error_json
+        ~fields:([ "typed", `Bool true ] @ policy_rejection_failure_class_fields)
+        e
     | Ok cwd ->
         let execution_location_fields cwd =
           [ ( "execution_location"

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -316,7 +316,8 @@ let transient_mutex_contention_tool_error
         [ "ok", `Bool false
         ; "error", `String message
         ; "error_class", `String transient_mutex_contention_error_class
-        ; "failure_class", `String "transient_error"
+        ; ( "failure_class"
+          , `String (Tool_result.tool_failure_class_to_string Tool_result.Transient_error) )
         ; "recoverable", `Bool true
         ; "transient", `Bool true
         ; "retry_recommended", `Bool true

--- a/lib/keeper/keeper_tools_oas_failure_boundary.ml
+++ b/lib/keeper/keeper_tools_oas_failure_boundary.ml
@@ -1,5 +1,6 @@
 type t =
   { failure_class : Tool_result.tool_failure_class
+  ; failure_class_declared : bool
   ; is_workflow_rejection : bool
   ; deterministic_classification :
       Keeper_tool_deterministic_error.classification option
@@ -45,9 +46,15 @@ let classify_raw_failure raw =
           | None -> Some json))
     | None -> None
   in
+  let declared_failure_class = Option.bind classification_json failure_class_of_json in
   let failure_class =
-    Option.bind classification_json failure_class_of_json
-    |> Option.value ~default:Tool_result.Runtime_failure
+    (* Undeclared payloads resolve to Runtime_failure: the conservative
+       non-retryable projection of "the producer stated no class". The
+       resolution is surfaced through [failure_class_declared] so producers
+       that must declare (Execute outcome/blocked/validation JSON since the
+       sangsu incident fix) are testable and regressions are visible instead
+       of silently reclassified. *)
+    Option.value declared_failure_class ~default:Tool_result.Runtime_failure
   in
   let deterministic_classification =
     if Tool_result.is_retryable failure_class
@@ -58,6 +65,7 @@ let classify_raw_failure raw =
         Keeper_tool_deterministic_error.classify_with_source
   in
   { failure_class
+  ; failure_class_declared = Option.is_some declared_failure_class
   ; is_workflow_rejection = (failure_class = Tool_result.Workflow_rejection)
   ; deterministic_classification
   }

--- a/lib/keeper/keeper_tools_oas_failure_boundary.ml
+++ b/lib/keeper/keeper_tools_oas_failure_boundary.ml
@@ -54,9 +54,7 @@ let classify_raw_failure raw =
        that must declare (Execute outcome/blocked/validation JSON since the
        sangsu incident fix) are testable and regressions are visible instead
        of silently reclassified. *)
-    (* DET-OK: not a guessed parse default — the undeclared case is carried
-       as [failure_class_declared = false] alongside this conservative
-       resolution. *)
+    (* DET-OK: typed via [failure_class_declared], not a guessed default. *)
     Option.value declared_failure_class ~default:Tool_result.Runtime_failure
   in
   let deterministic_classification =

--- a/lib/keeper/keeper_tools_oas_failure_boundary.ml
+++ b/lib/keeper/keeper_tools_oas_failure_boundary.ml
@@ -54,6 +54,9 @@ let classify_raw_failure raw =
        that must declare (Execute outcome/blocked/validation JSON since the
        sangsu incident fix) are testable and regressions are visible instead
        of silently reclassified. *)
+    (* DET-OK: not a guessed parse default — the undeclared case is carried
+       as [failure_class_declared = false] alongside this conservative
+       resolution. *)
     Option.value declared_failure_class ~default:Tool_result.Runtime_failure
   in
   let deterministic_classification =

--- a/lib/keeper/keeper_tools_oas_failure_boundary.mli
+++ b/lib/keeper/keeper_tools_oas_failure_boundary.mli
@@ -6,6 +6,12 @@
 
 type t =
   { failure_class : Tool_result.tool_failure_class
+  ; failure_class_declared : bool
+    (** [true] when the payload itself declared a parseable
+        ["failure_class"]; [false] when the boundary resolved the missing or
+        malformed declaration to [Runtime_failure]. Execute failure payloads
+        (outcome, blocked, input validation, Shell IR policy rejects) always
+        declare since the sangsu signature-collapse fix (2026-07-12). *)
   ; is_workflow_rejection : bool
   ; deterministic_classification :
       Keeper_tool_deterministic_error.classification option

--- a/lib/keeper/keeper_tools_oas_handler.ml
+++ b/lib/keeper/keeper_tools_oas_handler.ml
@@ -186,7 +186,10 @@ let make_keeper_tool_handler
                        ; "message", `String message
                        ; "recoverable", `Bool true
                        ; "error_class", `String "transient"
-                       ; "failure_class", `String "transient_error"
+                       ; ( "failure_class"
+                         , `String
+                             (Tool_result.tool_failure_class_to_string
+                                Tool_result.Transient_error) )
                        ])
                 in
                 Tool_result.error
@@ -203,7 +206,10 @@ let make_keeper_tool_handler
                        ; "message", `String message
                        ; "recoverable", `Bool true
                        ; "error_class", `String "transient"
-                       ; "failure_class", `String "transient_error"
+                       ; ( "failure_class"
+                         , `String
+                             (Tool_result.tool_failure_class_to_string
+                                Tool_result.Transient_error) )
                        ])
                 in
                 Tool_result.error

--- a/lib/keeper/keeper_tools_oas_workflow.ml
+++ b/lib/keeper/keeper_tools_oas_workflow.ml
@@ -272,7 +272,8 @@ let workflow_rejection_payload_json
   let fields =
     [ "ok", `Bool false
     ; "error", `String message
-    ; "failure_class", `String "workflow_rejection"
+    ; ( "failure_class"
+      , `String (Tool_result.tool_failure_class_to_string Tool_result.Workflow_rejection) )
     ; "error_class", `String (workflow_rejection_error_class_to_string error_class)
     ; "recoverable", `Bool (workflow_rejection_recoverability_to_bool recoverability)
     ]

--- a/lib/task/workflow_rejection_payload.ml
+++ b/lib/task/workflow_rejection_payload.ml
@@ -57,7 +57,8 @@ let payload_json
   let fields =
     [ "ok", `Bool false
     ; "error", `String message
-    ; "failure_class", `String "workflow_rejection"
+    ; ( "failure_class"
+      , `String (Tool_result.tool_failure_class_to_string Tool_result.Workflow_rejection) )
     ; "error_class", `String "deterministic"
     ; "recoverable", `Bool recoverable
     ]

--- a/test/test_exec_core.ml
+++ b/test/test_exec_core.ml
@@ -677,6 +677,101 @@ let test_history_compaction_triggers () =
      through the Eio_guard.protect wrapper and produced a valid file. *)
   check int "compacted to compact_to" 1_000 (List.length results)
 
+(* failure_class wire declaration (sangsu incident, 2026-07-12): every failed
+   Execute payload must declare its Tool_result class so the OAS failure
+   boundary stops collapsing timeouts, policy blocks, and runtime errors into
+   one Runtime_failure/Unknown signature. *)
+
+let process_json ?classification ~cmd ~status ~output () =
+  Masc.Exec_core.process_result_json
+    ?classification
+    ~base_path:"/tmp"
+    ~keeper_name:"exec-core"
+    ~cmd
+    ~status
+    ~output
+    ()
+
+let boundary_of_json json =
+  Masc.Keeper_tools_oas_failure_boundary.classify_raw_failure
+    (Yojson.Safe.to_string json)
+
+let test_timeout_declares_transient_failure_class () =
+  let json = process_json ~cmd:"sleep 999" ~status:(Unix.WEXITED 124) ~output:"" () in
+  check bool "ok" false (json |> member "ok" |> to_bool);
+  check string "semantic_status" "timeout" (get_string_field json "semantic_status");
+  check string "failure_class" "transient_error" (get_string_field json "failure_class");
+  let boundary = boundary_of_json json in
+  check bool "declared" true
+    boundary.Masc.Keeper_tools_oas_failure_boundary.failure_class_declared;
+  check bool "boundary transient" true
+    (boundary.Masc.Keeper_tools_oas_failure_boundary.failure_class
+     = Tool_result.Transient_error)
+
+let test_runtime_error_declares_runtime_failure_class () =
+  (* Incident shape: `ls ls lib` exits non-zero immediately. *)
+  let json =
+    process_json
+      ~cmd:"ls ls lib"
+      ~status:(Unix.WEXITED 2)
+      ~output:"ls: cannot access 'ls': No such file or directory"
+      ()
+  in
+  check string "semantic_status" "runtime_error"
+    (get_string_field json "semantic_status");
+  check string "failure_class" "runtime_failure" (get_string_field json "failure_class");
+  let boundary = boundary_of_json json in
+  check bool "declared" true
+    boundary.Masc.Keeper_tools_oas_failure_boundary.failure_class_declared;
+  check bool "boundary runtime_failure" true
+    (boundary.Masc.Keeper_tools_oas_failure_boundary.failure_class
+     = Tool_result.Runtime_failure)
+
+let test_blocked_declares_policy_rejection_failure_class () =
+  let json =
+    Masc.Exec_core.blocked_result_json
+      ~cmd:"rm -rf /"
+      ~error:"destructive_operation_blocked"
+      ~reason:"blocked by policy"
+      ()
+  in
+  check bool "ok" false (json |> member "ok" |> to_bool);
+  check string "failure_class" "policy_rejection"
+    (get_string_field json "failure_class");
+  let boundary = boundary_of_json json in
+  check bool "declared" true
+    boundary.Masc.Keeper_tools_oas_failure_boundary.failure_class_declared;
+  check bool "boundary policy_rejection" true
+    (boundary.Masc.Keeper_tools_oas_failure_boundary.failure_class
+     = Tool_result.Policy_rejection)
+
+let test_success_carries_no_failure_class () =
+  let json = process_json ~cmd:"ls lib" ~status:(Unix.WEXITED 0) ~output:"a.ml" () in
+  check bool "ok" true (json |> member "ok" |> to_bool);
+  check bool "failure_class absent" true (json |> member "failure_class" = `Null)
+
+let test_semantic_no_match_carries_no_failure_class () =
+  let cmd = "rg missing_pattern lib/" in
+  let json =
+    process_json
+      ~classification:(classification_of_cmd cmd)
+      ~cmd
+      ~status:(Unix.WEXITED 1)
+      ~output:""
+      ()
+  in
+  check bool "ok" true (json |> member "ok" |> to_bool);
+  check bool "failure_class absent" true (json |> member "failure_class" = `Null)
+
+let test_undeclared_payload_resolves_to_runtime_failure_undeclared () =
+  let boundary =
+    Masc.Keeper_tools_oas_failure_boundary.classify_raw_failure {|{"error":"boom"}|}
+  in
+  check bool "resolved runtime_failure" true
+    (boundary.Masc.Keeper_tools_oas_failure_boundary.failure_class
+     = Tool_result.Runtime_failure);
+  check bool "undeclared" false
+    boundary.Masc.Keeper_tools_oas_failure_boundary.failure_class_declared
 
 let () =
   run "exec_core"
@@ -775,5 +870,20 @@ let () =
             `Quick test_history_compaction;
           test_case "compaction above threshold rewrites to compact_to"
             `Slow test_history_compaction_triggers;
+        ] );
+      ( "failure_class",
+        [
+          test_case "timeout declares transient_error" `Quick
+            test_timeout_declares_transient_failure_class;
+          test_case "runtime error declares runtime_failure" `Quick
+            test_runtime_error_declares_runtime_failure_class;
+          test_case "blocked declares policy_rejection" `Quick
+            test_blocked_declares_policy_rejection_failure_class;
+          test_case "success carries no failure_class" `Quick
+            test_success_carries_no_failure_class;
+          test_case "semantic no-match carries no failure_class" `Quick
+            test_semantic_no_match_carries_no_failure_class;
+          test_case "undeclared payload resolves to runtime_failure, undeclared"
+            `Quick test_undeclared_payload_resolves_to_runtime_failure_undeclared;
         ] );
     ]

--- a/test/test_exec_core.ml
+++ b/test/test_exec_core.ml
@@ -727,6 +727,26 @@ let test_runtime_error_declares_runtime_failure_class () =
     (boundary.Masc.Keeper_tools_oas_failure_boundary.failure_class
      = Tool_result.Runtime_failure)
 
+let test_partial_declares_runtime_failure_class () =
+  (* Partial (found some matches, some paths errored) maps to Runtime_failure
+     like Runtime_error -- see [failure_class_of_semantic_status]. *)
+  let json =
+    process_json
+      ~cmd:"find lib -name '*.ml'"
+      ~status:(Unix.WEXITED 1)
+      ~output:"lib/exec_core.ml\nfind: lib/private: Permission denied"
+      ()
+  in
+  check bool "ok" false (json |> member "ok" |> to_bool);
+  check string "semantic_status" "partial" (get_string_field json "semantic_status");
+  check string "failure_class" "runtime_failure" (get_string_field json "failure_class");
+  let boundary = boundary_of_json json in
+  check bool "declared" true
+    boundary.Masc.Keeper_tools_oas_failure_boundary.failure_class_declared;
+  check bool "boundary runtime_failure" true
+    (boundary.Masc.Keeper_tools_oas_failure_boundary.failure_class
+     = Tool_result.Runtime_failure)
+
 let test_blocked_declares_policy_rejection_failure_class () =
   let json =
     Masc.Exec_core.blocked_result_json
@@ -877,6 +897,8 @@ let () =
             test_timeout_declares_transient_failure_class;
           test_case "runtime error declares runtime_failure" `Quick
             test_runtime_error_declares_runtime_failure_class;
+          test_case "partial declares runtime_failure" `Quick
+            test_partial_declares_runtime_failure_class;
           test_case "blocked declares policy_rejection" `Quick
             test_blocked_declares_policy_rejection_failure_class;
           test_case "success carries no failure_class" `Quick

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -1288,6 +1288,53 @@ let test_workflow_rejection_payload_skips_circuit_breaker () =
     (KET.should_apply_circuit_breaker_to_failure_payload
        (KET.failure_class_of_tool_result_payload runtime_payload))
 
+(* fix(exec): declare typed failure_class on every failed Execute payload
+   (masc#24314) taught Execute's OWN producers (Exec_core.blocked_result_json,
+   process_result_json) to declare failure_class for the first time. That
+   makes Execute policy/deterministic rejections newly eligible for the
+   breaker-skip branch above — a behavior change the hand-built literals in
+   [test_workflow_rejection_payload_skips_circuit_breaker] cannot catch,
+   since they never exercise the real producer. This test proves the
+   interaction end-to-end on the payload Exec_core actually emits, the same
+   discipline [test_keeper_validation_breaker_exempt.ml] applies to
+   keeper_task_create. *)
+let test_execute_producer_payloads_route_through_circuit_breaker () =
+  let blocked_payload =
+    Masc.Exec_core.blocked_result_json
+      ~cmd:"rm -rf /"
+      ~error:"destructive_operation_blocked"
+      ~reason:"blocked by policy"
+      ()
+    |> Yojson.Safe.to_string
+  in
+  check (option string) "Exec_core blocked payload declares policy_rejection"
+    (Some "policy_rejection")
+    (Option.map Tool_result.tool_failure_class_to_string
+       (KET.failure_class_of_tool_result_payload blocked_payload));
+  check bool "Exec_core blocked payload skips circuit breaker" false
+    (KET.should_apply_circuit_breaker_to_failure_payload
+       (KET.failure_class_of_tool_result_payload blocked_payload));
+  (* Incident shape: `ls ls lib` exits non-zero immediately with no matching
+     semantic classifier -> runtime_error -> Runtime_failure (still counted,
+     the pre-fix Ambiguous_failure_signature collapse target). *)
+  let runtime_error_payload =
+    Masc.Exec_core.process_result_json
+      ~base_path:"/tmp"
+      ~keeper_name:"exec-core-breaker-test"
+      ~cmd:"ls ls lib"
+      ~status:(Unix.WEXITED 2)
+      ~output:"ls: cannot access 'ls': No such file or directory"
+      ()
+    |> Yojson.Safe.to_string
+  in
+  check (option string) "Exec_core runtime_error payload declares runtime_failure"
+    (Some "runtime_failure")
+    (Option.map Tool_result.tool_failure_class_to_string
+       (KET.failure_class_of_tool_result_payload runtime_error_payload));
+  check bool "Exec_core runtime_error payload still trips circuit breaker" true
+    (KET.should_apply_circuit_breaker_to_failure_payload
+       (KET.failure_class_of_tool_result_payload runtime_error_payload))
+
 let test_tool_execute_raw_cmd_requires_typed_shell_ir () =
   with_exec_fixture "tool_execute_raw_cmd_requires_typed_shell_ir"
     (fun ~config ~meta ~ctx_work ->
@@ -1832,6 +1879,8 @@ let () =
         test_tool_result_or_error_preserves_failure_class;
       test_case "workflow rejection skips circuit breaker" `Quick
         test_workflow_rejection_payload_skips_circuit_breaker;
+      test_case "Exec_core producer payloads route through circuit breaker"
+        `Quick test_execute_producer_payloads_route_through_circuit_breaker;
       test_case "tool_execute raw cmd requires typed Shell IR" `Quick
         test_tool_execute_raw_cmd_requires_typed_shell_ir;
       test_case "tool_execute pipe argv emits pipeline recovery plan" `Quick

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -1429,6 +1429,38 @@ let test_tool_execute_pipe_argv_emits_pipeline_recovery_plan () =
         (member "instruction" plan |> to_string |> fun s ->
           contains_substring s "Do not use sh -c"))
 
+(* A cwd that resolve_tool_execute_cwd rejects (outside the sandbox allowed
+   roots) is a deterministic caller/config rejection.  Before the fix its
+   payload carried no failure_class, so the boundary resolved it to
+   Runtime_failure→(Non_retryable, Unknown) and counted it against the
+   circuit breaker.  It must declare policy_rejection, like the sibling
+   of_json/validate rejections. *)
+let test_tool_execute_rejected_cwd_declares_policy_rejection () =
+  with_exec_fixture "tool_execute_rejected_cwd_policy_rejection"
+    (fun ~config ~meta ~ctx_work ->
+      let input =
+        `Assoc
+          [ "executable", `String "echo"
+          ; "argv", `List [ `String "hi" ]
+          ; "cwd", `String "/root/denied-outside-sandbox-xyz"
+          ]
+      in
+      let raw =
+        KET.execute_keeper_tool_call
+          ~config
+          ~meta
+          ~ctx_work
+          ~exec_cache:None
+          ~name:"tool_execute"
+          ~input
+          ()
+      in
+      let json = parse_json raw in
+      let open Yojson.Safe.Util in
+      check bool "call failed" false (member "ok" json |> to_bool);
+      check string "cwd rejection declares policy_rejection" "policy_rejection"
+        (member "failure_class" json |> to_string))
+
 let keeper_msg_input_schema () =
   match
     List.find_opt
@@ -1885,6 +1917,8 @@ let () =
         test_tool_execute_raw_cmd_requires_typed_shell_ir;
       test_case "tool_execute pipe argv emits pipeline recovery plan" `Quick
         test_tool_execute_pipe_argv_emits_pipeline_recovery_plan;
+      test_case "tool_execute rejected cwd declares policy_rejection" `Quick
+        test_tool_execute_rejected_cwd_declares_policy_rejection;
       test_case "OAS handler threads Eio context to keeper dispatch" `Quick
         test_oas_handler_threads_eio_context_to_keeper_dispatch;
       test_case "registered dispatch does not require masc_ prefix" `Quick


### PR DESCRIPTION
## 목적

sangsu 사고(2026-07-12, `Ambiguous_failure_signature` 턴 사망) RCA의 masc 측 공동 근본원인 수정 — **Execute 실패 분류 붕괴 제거**.

RCA 확정 사실 (정정: 아래 "리뷰 대응" §4 참조 — 최초 서술은 과대주장이었다): 범용 dispatch 게이트(`keeper_tool_dispatch_runtime.ml`의 tool_not_allowed/unknown_tool/descriptor_route_invariant, `tool_input_validation.ml`의 스키마 검증 미들웨어)는 이 PR 이전부터 이미 `failure_class`를 emit하고 있었다. 실제 갭은 **Execute 자신의** outcome/validation JSON — `exec_core.outcome_to_json`(Executed 실패·Blocked_result)과 `keeper_tool_execute_runtime.ml`의 pre-dispatch 거부(typed input parse/validate, Shell IR gate/path/approval/policy)만 `failure_class`를 emit하지 않아 `Keeper_tools_oas_failure_boundary`가 이들을 `Runtime_failure`로 resolve → `tool_bridge`가 `error_class=Unknown, recoverable=false`로 투영했다. **타임아웃(WEXITED 124 → `semantic_status=Timeout`까지 typed로 살아있던 정보), 정책 차단, 입력 validation 거부, 일반 nonzero exit이 Execute 경로 안에서 전부 `(Execute, Non_retryable, Unknown)` 단일 signature로 붕괴**했고, 이 충돌이 사고의 `previous_count=1/current_count=3` 카운트를 만들었다.

## 변경

| 위치 | 내용 |
|------|------|
| `lib/exec_core.ml(i)` | `failure_class_of_semantic_status` — `semantic_status` → `Tool_result.tool_failure_class` **exhaustive 투영** (Timeout→`Transient_error`, Blocked→`Policy_rejection`, Partial/Runtime_error→`Runtime_failure`, 성공→없음). `outcome_to_json`이 Executed 실패·Blocked_result 양쪽에 emit. catch-all `_` 없음 — status variant 추가 시 컴파일 타임 결정 강제 |
| `lib/keeper/keeper_tool_execute_runtime.ml` | pre-dispatch 거부 3지점(typed input parse/validate, Shell IR gate·path·approval·policy 에러)이 `Policy_rejection` 선언 (RFC-0062 §3.2 caller-input validation) |
| `lib/keeper/keeper_tools_oas_failure_boundary.ml(i)` | `failure_class_declared : bool` 추가 — undeclared→`Runtime_failure` resolution을 silent default에서 **typed·testable**로 |
| `test/test_exec_core.ml` | `failure_class` suite — timeout/runtime(사고 형태 `ls ls lib`)/blocked/success/no-match/undeclared/**partial**(리뷰 대응 §3), boundary 왕복 검증 포함 |

## 결과 (OAS signature 변화)

| Execute 실패 원인 | 이전 signature | 이후 signature |
|---|---|---|
| 타임아웃 | `(Non_retryable, Unknown)` | `(Recoverable, Transient)` — 재시도 가능으로 복원 (masc 자체 taxonomy와 의미 일치) |
| 정책/validation 거부 | `(Non_retryable, Unknown)` | `(Non_retryable, Deterministic)` |
| nonzero exit | `(Non_retryable, Unknown)` | `(Non_retryable, Unknown)` — 원인 불명은 정직하게 Unknown 유지 |

서로 다른 실패 원인이 더 이상 episode detect의 같은 `Failure_map` 키로 합산되지 않는다.

## 비변경 (의도적)

- boundary의 nested `error` JSON 언래핑: 구조적 JSON 파싱(closed enum parse)이며 substring 휴리스틱이 아님 — 유지.
- `timeout_sec` 수용-후-무시 함정(typed input에 필드만 있고 전달 site 0): **별도 PR** — `Exec_dispatch` 전 체인 파라미터 스레딩이 필요해 분리.
- 대시보드 `Row_kind` 2-variant 오분류: 별도 PR.

## 리뷰 대응 (적대적 셀프 리뷰)

1. **Circuit breaker 상호작용 (P1)**: `should_apply_circuit_breaker_to_failure_payload`는 `Policy_rejection`/`Workflow_rejection`을 breaker 밖으로 라우팅하도록 이미 설계되어 있었다(dispatch_runtime의 tool_not_allowed/unknown_tool도 동일 경로). 이 PR이 Execute 자신의 실패/blocked/validation 페이로드에 `Policy_rejection`을 처음 선언하면서, Execute 실패가 처음으로 이 predicate를 통해 breaker를 우회하게 됐다 — 기존 설계와 일관되므로 라우팅은 변경하지 않고, `keeper_tool_dispatch_runtime.mli`에 이 상호작용을 명문화하고 `test/test_keeper_tool_dispatch_runtime.ml`에 실제 Exec_core producer 페이로드(`blocked_result_json`→policy_rejection→breaker 우회, `process_result_json`의 runtime_error→breaker 적용)로 라우팅을 고정하는 테스트를 추가했다.
2. **failure_class 리터럴 산포 (P1)**: raw string literal 8곳(`workflow_rejection_payload.ml`, `keeper_tools_oas_workflow.ml`, `keeper_tool_dispatch_runtime.ml`×3, `keeper_tools_oas_handler.ml`×2, `keeper_tools_oas.ml`) 전부 `Tool_result.tool_failure_class_to_string`로 교체 완료(8/8). wire byte 불변, 컴파일러가 두 리더(`keeper_tools_oas_failure_boundary.ml`, `keeper_tool_dispatch_runtime.ml`)와의 문자열 일치를 강제하도록 SSOT화.
3. **Partial 테스트 케이스 누락 (P2)**: `test_exec_core.ml`에 `Partial → runtime_failure` 테스트 추가 완료.
4. **PR 서술 과대주장 정정**: 위 "RCA 확정 사실" 문단을 수정 — 실제 갭은 Execute 자신의 payload에 한정.

## 검증

- 로컬 dune build 미실행 (CI 빌드) — repo 규칙.
- `Keeper_tools_oas_failure_boundary.t` record 생성처는 모듈 내부 1곳뿐임을 rg로 전수 확인 (field 추가 안전).
- 소비처(handler_exec :145/:151/:241/:398)는 read-only — 무변경 호환.
- `bash scripts/ci/check-determinism-contract.sh` 통과 확인.

## 참고

- RCA: `~/me/reports/masc-oas-sangsu-ambiguous-failure-rca-20260712.html` (Workflow 9-agent 적대 검증)
- OAS 측 대응 PR: jeong-sik/oas#2585 (detect totality)
- 선행: oas#2582 (grouped pairing)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
