### PR TITLE
fix(test): qualify keeper chat row type

### DIFF
--- a/test/test_keeper_chat_delivery_journal.ml
+++ b/test/test_keeper_chat_delivery_journal.ml
@@ -361,7 +361,7 @@ let test_chat_append_once_converges_across_processes () =
     await_child second;
     let matching_rows =
       Keeper_chat_store.load ~base_dir:base_path ~keeper_name:"sangsu"
-      |> List.filter (fun row ->
+      |> List.filter (fun (row : Keeper_chat_store.chat_message) ->
            Keeper_chat_store.Role.equal row.role Keeper_chat_store.Role.User
            && String.equal row.content "cross-process request")
     in


### PR DESCRIPTION
## What changed

- annotate the filtered delivery-journal row as `Keeper_chat_store.chat_message`

## Why

OCaml could not resolve the namespaced `role` record field from the unannotated `List.filter` callback on current `main`, so the test target failed with `Unbound record field role`.

## Impact

This is a test-only type-disambiguation fix. Runtime behavior and public interfaces are unchanged.

## Validation

- `ocamlc -stop-after parsing -c test/test_keeper_chat_delivery_journal.ml`
- `ocamlformat --check test/test_keeper_chat_delivery_journal.ml`
- `git diff --check`
- focused wrapper attempted; the normal run stopped at the repository pin guard because current `main` expects OAS `0.211.8` while the shared switch has `0.211.9`
- bypassing that guard reached the known unrelated OAS API drift in `lib/keeper/keeper_event_bridge.ml` before this test target could typecheck

Full Dune validation remains CI-authoritative.
