### PR TITLE
fix(exec): wire Execute timeout_sec through to Process_eio dispatch

### DIFF
--- a/lib/exec/exec_dispatch.ml
+++ b/lib/exec/exec_dispatch.ml
@@ -200,7 +200,7 @@ let process_spec_of_simple (s : Shell_ir.simple) =
   in
   (argv, env, cwd)
 
-let dispatch_simple ?base_host_env ?stdin_content ?on_output_chunk (s : Shell_ir.simple) =
+let dispatch_simple ?base_host_env ?stdin_content ?timeout_sec ?on_output_chunk (s : Shell_ir.simple) =
   let on_output_chunk, emitted = tracked_output_callback on_output_chunk in
   let argv, env, cwd = process_spec_of_simple s in
   let result =
@@ -223,6 +223,7 @@ let dispatch_simple ?base_host_env ?stdin_content ?on_output_chunk (s : Shell_ir
                  ~actor:`Tool_local_runtime
                  ~raw_source
                  ~summary:"exec dispatch simple"
+                 ?timeout_sec
                  ?env:host_env
                  ?cwd
                  argv
@@ -231,6 +232,7 @@ let dispatch_simple ?base_host_env ?stdin_content ?on_output_chunk (s : Shell_ir
                  ~actor:`Tool_local_runtime
                  ~raw_source
                  ~summary:"exec dispatch simple streaming"
+                 ?timeout_sec
                  ?env:host_env
                  ?cwd
                  ~on_stdout_chunk:(fun chunk -> on_chunk (`Stdout chunk))
@@ -243,6 +245,7 @@ let dispatch_simple ?base_host_env ?stdin_content ?on_output_chunk (s : Shell_ir
                  ~actor:`Tool_local_runtime
                  ~raw_source
                  ~summary:"exec dispatch simple stdin"
+                 ?timeout_sec
                  ?env:host_env
                  ?cwd
                  ~stdin_content
@@ -252,6 +255,7 @@ let dispatch_simple ?base_host_env ?stdin_content ?on_output_chunk (s : Shell_ir
                  ~actor:`Tool_local_runtime
                  ~raw_source
                  ~summary:"exec dispatch simple stdin streaming"
+                 ?timeout_sec
                  ?env:host_env
                  ?cwd
                  ~on_stdout_chunk:(fun chunk -> on_chunk (`Stdout chunk))
@@ -269,6 +273,12 @@ let dispatch_simple ?base_host_env ?stdin_content ?on_output_chunk (s : Shell_ir
          | status, stdout, stderr ->
              apply_redirect_plan redirect_plan { status; stdout; stderr })
       | Docker { runner; _ } ->
+        (* [Sandbox_target.runner] has no timeout parameter, so [timeout_sec]
+           does not reach Docker-dispatched commands.  Threading it through
+           would require changing the [runner]/[pipeline_runner] closure
+           type in [Sandbox_target] (a public type every keeper-side Docker
+           runner construction site implements); left as a follow-up rather
+           than forced here. *)
         let on_stdout_chunk, on_stderr_chunk =
           match child_on_output_chunk with
           | None -> None, None
@@ -339,7 +349,7 @@ let docker_pipeline_specs stages =
 (* TEL-OK: this lower-level Shell IR dispatcher is wrapped by Execute/keeper
    telemetry at the action boundary; it preserves output delivery but does not
    record action-level telemetry directly. *)
-let rec dispatch_pipeline ?base_host_env ?stdin_content ?on_output_chunk stages =
+let rec dispatch_pipeline ?base_host_env ?stdin_content ?timeout_sec ?on_output_chunk stages =
   let on_output_chunk, emitted = tracked_output_callback on_output_chunk in
   let decomposed_stage_callback ~is_final (simple : Shell_ir.simple) on_output_chunk =
     match on_output_chunk with
@@ -373,12 +383,14 @@ let rec dispatch_pipeline ?base_host_env ?stdin_content ?on_output_chunk stages 
                      ~actor:`Tool_local_runtime
                      ~raw_source
                      ~summary:"exec dispatch pipeline"
+                     ?timeout_sec
                      specs
                | Some on_chunk ->
                    Exec_gate.run_argv_pipeline_with_status_split
                      ~actor:`Tool_local_runtime
                      ~raw_source
                      ~summary:"exec dispatch pipeline streaming"
+                     ?timeout_sec
                      ~on_stdout_chunk:(fun chunk -> on_chunk (`Stdout chunk))
                      ~on_stderr_chunk:(fun chunk -> on_chunk (`Stderr chunk))
                      specs
@@ -387,6 +399,9 @@ let rec dispatch_pipeline ?base_host_env ?stdin_content ?on_output_chunk stages 
          | None -> (
              match docker_pipeline_specs stages with
              | Some (runner, specs) ->
+                 (* [Sandbox_target.pipeline_runner] has no timeout parameter
+                    either — same gap as the [Docker] branch in
+                    [dispatch_simple] above. *)
                  let on_stdout_chunk, on_stderr_chunk =
                    match on_output_chunk with
                    | None -> None, None
@@ -409,6 +424,7 @@ let rec dispatch_pipeline ?base_host_env ?stdin_content ?on_output_chunk stages 
                        let stage_result =
                          dispatch_simple
                            ?base_host_env
+                           ?timeout_sec
                            ?on_output_chunk:stage_on_output_chunk
                            ~stdin_content:prev_stdout
                            s
@@ -478,6 +494,7 @@ let rec dispatch_pipeline ?base_host_env ?stdin_content ?on_output_chunk stages 
                         let first_result =
                           dispatch_simple
                             ?base_host_env
+                            ?timeout_sec
                             ?on_output_chunk:first_on_output_chunk
                             s
                         in
@@ -525,12 +542,12 @@ let rec dispatch_pipeline ?base_host_env ?stdin_content ?on_output_chunk stages 
   in
   emit_unseen_captured_output on_output_chunk emitted result
 
-and dispatch ?base_host_env ?on_output_chunk (ir : Shell_ir.t) =
+and dispatch ?base_host_env ?timeout_sec ?on_output_chunk (ir : Shell_ir.t) =
   match ir with
-  | Shell_ir.Simple s -> dispatch_simple ?base_host_env ?on_output_chunk s
-  | Pipeline stages -> dispatch_pipeline ?base_host_env ?on_output_chunk stages
+  | Shell_ir.Simple s -> dispatch_simple ?base_host_env ?timeout_sec ?on_output_chunk s
+  | Pipeline stages -> dispatch_pipeline ?base_host_env ?timeout_sec ?on_output_chunk stages
 
-let dispatch_decided ?base_host_env ?on_output_chunk (envelope : Shell_ir_risk.decided Shell_ir_risk.decided_ir) :
+let dispatch_decided ?base_host_env ?timeout_sec ?on_output_chunk (envelope : Shell_ir_risk.decided Shell_ir_risk.decided_ir) :
     dispatch_result =
   (match envelope.Shell_ir_risk.risk with
    | Shell_ir_risk.Destructive_protected ->
@@ -543,4 +560,4 @@ let dispatch_decided ?base_host_env ?on_output_chunk (envelope : Shell_ir_risk.d
    | Shell_ir_risk.R1_Reversible_mutation
    | Shell_ir_risk.R2_Irreversible ->
        ());
-  dispatch ?base_host_env ?on_output_chunk envelope.Shell_ir_risk.ir
+  dispatch ?base_host_env ?timeout_sec ?on_output_chunk envelope.Shell_ir_risk.ir

--- a/lib/exec/exec_dispatch.mli
+++ b/lib/exec/exec_dispatch.mli
@@ -11,6 +11,7 @@ val resolve_arg : Shell_ir.arg -> string
 val dispatch_simple :
   ?base_host_env:string array ->
   ?stdin_content:string ->
+  ?timeout_sec:float ->
   ?on_output_chunk:([ `Stdout of string | `Stderr of string ] -> unit) ->
   Shell_ir.simple ->
   dispatch_result
@@ -20,29 +21,37 @@ val dispatch_simple :
     [?on_output_chunk] is invoked for every chunk read from
     stdout/stderr while the process is running on the host sandbox path,
     including host commands that receive typed stdin. Docker runner targets
-    receive the same callback contract. *)
+    receive the same callback contract.  [?timeout_sec], when supplied, is
+    forwarded to [Exec_gate] on the [Host] sandbox path only; absent, the
+    call keeps [Exec_gate]'s existing default timeout.  The [Docker] path
+    ignores it — [Sandbox_target.runner] has no timeout parameter yet. *)
 
 val dispatch :
   ?base_host_env:string array ->
+  ?timeout_sec:float ->
   ?on_output_chunk:([ `Stdout of string | `Stderr of string ] -> unit) ->
   Shell_ir.t ->
   dispatch_result
 (** General dispatch over any [Shell_ir.t] variant.  [Simple] routes
     to [dispatch_simple]; [Pipeline] routes to internal pipeline
     logic.  Prefer [dispatch_decided] for production keeper paths.
-    Exposed for tests and legacy call sites. *)
+    Exposed for tests and legacy call sites.  [?timeout_sec] is forwarded
+    unchanged; see [dispatch_simple] for the Host/Docker caveat. *)
 
 val dispatch_decided :
   ?base_host_env:string array ->
+  ?timeout_sec:float ->
   ?on_output_chunk:([ `Stdout of string | `Stderr of string ] -> unit) ->
   Shell_ir_risk.decided Shell_ir_risk.decided_ir ->
   dispatch_result
 (** RFC-0160 S3: dispatch a risk-classified IR.  The phantom type
-    ensures the IR has passed through [Shell_ir_risk.classify]. *)
+    ensures the IR has passed through [Shell_ir_risk.classify].
+    [?timeout_sec] is forwarded unchanged to [dispatch]. *)
 
 val dispatch_pipeline :
   ?base_host_env:string array ->
   ?stdin_content:string ->
+  ?timeout_sec:float ->
   ?on_output_chunk:([ `Stdout of string | `Stderr of string ] -> unit) ->
   Shell_ir.t list ->
   dispatch_result
@@ -54,4 +63,8 @@ val dispatch_pipeline :
     same callback contract. Decomposed fallback pipeline paths stream each
     stage's stderr and the final stage's stdout through the same callback
     contract while preserving intermediate stdout as stdin for the next
-    stage. *)
+    stage.  [?timeout_sec] applies uniformly to every stage on the host
+    native-pipeline and decomposed-fallback paths (one deadline per spawn,
+    mirroring [Exec_gate.run_argv_pipeline_with_status_split]); the Docker
+    [pipeline_runner] path ignores it — [Sandbox_target.pipeline_runner] has
+    no timeout parameter yet. *)

--- a/lib/exec/exec_dispatch.mli
+++ b/lib/exec/exec_dispatch.mli
@@ -63,8 +63,18 @@ val dispatch_pipeline :
     same callback contract. Decomposed fallback pipeline paths stream each
     stage's stderr and the final stage's stdout through the same callback
     contract while preserving intermediate stdout as stdin for the next
-    stage.  [?timeout_sec] applies uniformly to every stage on the host
-    native-pipeline and decomposed-fallback paths (one deadline per spawn,
-    mirroring [Exec_gate.run_argv_pipeline_with_status_split]); the Docker
-    [pipeline_runner] path ignores it — [Sandbox_target.pipeline_runner] has
-    no timeout parameter yet. *)
+    stage.
+
+    [?timeout_sec] semantics are path-dependent, not uniform:
+    - Host native pipeline (every stage [Host] sandbox with no redirects,
+      per [host_pipeline_specs]): forwarded to
+      [Exec_gate.run_argv_pipeline_with_status_split], which wraps the
+      *entire* pipeline await in a single
+      [Eio.Time.with_timeout_exn] — one deadline for the whole pipeline,
+      not per stage (see [Process_eio.run_argv_pipeline_with_status_split]).
+    - Decomposed fallback (mixed sandboxes, any stage with redirects, or no
+      matching Docker [pipeline_runner]): each stage is dispatched in turn
+      via [dispatch_simple ?timeout_sec], so the deadline resets per stage;
+      worst-case total wall time is [List.length stages * timeout_sec].
+    - Docker [pipeline_runner] path: ignores [?timeout_sec] entirely —
+      [Sandbox_target.pipeline_runner] has no timeout parameter yet. *)

--- a/lib/keeper/keeper_tool_execute_input.ml
+++ b/lib/keeper/keeper_tool_execute_input.ml
@@ -58,6 +58,12 @@ let typed_input_has_env = function
     env <> []
 ;;
 
+let typed_input_timeout_sec = function
+  | Keeper_tool_execute_typed_input.Exec { timeout_sec; _ }
+  | Keeper_tool_execute_typed_input.Pipeline { timeout_sec; _ } ->
+    timeout_sec
+;;
+
 let typed_validation_error_text error =
   Format.asprintf "%a" Keeper_tool_execute_typed_input.pp_validation_error error
 ;;

--- a/lib/keeper/keeper_tool_execute_input.mli
+++ b/lib/keeper/keeper_tool_execute_input.mli
@@ -7,6 +7,9 @@ val shell_quote_for_policy : string -> string
 val typed_stage_command_text : executable:string -> argv:string list -> string
 val typed_input_command_text : Keeper_tool_execute_typed_input.execute_input -> string
 val typed_input_has_env : Keeper_tool_execute_typed_input.execute_input -> bool
+val typed_input_timeout_sec : Keeper_tool_execute_typed_input.execute_input -> float option
+(** Projects the caller-supplied per-spawn timeout override, or [None] when
+    absent (dispatch then keeps its existing default). *)
 
 val typed_validation_error_text
   :  Keeper_tool_execute_typed_input.validation_error

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -608,6 +608,7 @@ let has_typed_execute_input_key = Keeper_tool_execute_input.has_typed_execute_in
 let assoc_upsert = Keeper_tool_execute_input.assoc_upsert
 let typed_input_command_text = Keeper_tool_execute_input.typed_input_command_text
 let typed_input_has_env = Keeper_tool_execute_input.typed_input_has_env
+let typed_input_timeout_sec = Keeper_tool_execute_input.typed_input_timeout_sec
 let typed_validation_error_text = Keeper_tool_execute_input.typed_validation_error_text
 
 let typed_validation_deterministic_retry_fields
@@ -677,6 +678,20 @@ let typed_validation_recovery_fields
              ; "stderr", `Assoc [ "discard", `Bool true ]
              ; "cwd", `String "repos/<repo>"
              ])
+  | Keeper_tool_execute_typed_input.Timeout_sec_not_positive _ ->
+    diagnosis ~rule_id:"execute_timeout_sec_not_positive"
+    @ recovery_plan
+        ~input_shape:"timeout_sec"
+        ~instruction:
+          "Retry Execute with timeout_sec set to a finite number greater \
+           than 0 (seconds), or omit the field to use the existing default \
+           timeout."
+        ~example:
+          (`Assoc
+             [ "executable", `String "<same as previous call>"
+             ; "argv", `List []
+             ; "timeout_sec", `Float 120.0
+             ])
   | Keeper_tool_execute_typed_input.Empty_executable _
   | Keeper_tool_execute_typed_input.Executable_repeated_in_argv0 _
   | Keeper_tool_execute_typed_input.Argv_contains_shell_metachar _
@@ -697,7 +712,7 @@ let docker_local_fallback_target =
 
 let input_with_cwd cwd = function
   | Keeper_tool_execute_typed_input.Exec
-      { executable; argv; cwd = _; env; stdin; stdout; stderr } ->
+      { executable; argv; cwd = _; env; stdin; stdout; stderr; timeout_sec } ->
     Keeper_tool_execute_typed_input.Exec
       { executable
       ; argv
@@ -706,9 +721,11 @@ let input_with_cwd cwd = function
       ; stdin
       ; stdout
       ; stderr
+      ; timeout_sec
       }
-  | Keeper_tool_execute_typed_input.Pipeline { stages; cwd = _; env } ->
-    Keeper_tool_execute_typed_input.Pipeline { stages; cwd = Some cwd; env }
+  | Keeper_tool_execute_typed_input.Pipeline { stages; cwd = _; env; timeout_sec } ->
+    Keeper_tool_execute_typed_input.Pipeline
+      { stages; cwd = Some cwd; env; timeout_sec }
 
 let typed_input_shell_ir_unvalidated input =
   match Keeper_tool_execute_typed_input.to_shell_ir_unvalidated input with
@@ -1077,6 +1094,7 @@ let handle_tool_execute_typed
           Retired_env_warnings.report_shell_ir_path_jail_if_set
             ~source:"execute"
             ();
+          let dispatch_timeout_sec = typed_input_timeout_sec input in
           let dispatch_result =
             if Env_config_runtime.Shell_ir_approval_gate.enabled ()
             then (
@@ -1104,6 +1122,7 @@ let handle_tool_execute_typed
                 ~workdir:cwd
                 ~sandbox:dispatch_sandbox
                 ?base_host_env
+                ?timeout_sec:dispatch_timeout_sec
                 ~on_output_chunk
                 envelope)
             else
@@ -1113,6 +1132,7 @@ let handle_tool_execute_typed
                 ~workdir:cwd
                 ~sandbox:dispatch_sandbox
                 ?base_host_env
+                ?timeout_sec:dispatch_timeout_sec
                 ~on_output_chunk
                 envelope
           in

--- a/lib/keeper/keeper_tool_execute_typed_input.ml
+++ b/lib/keeper/keeper_tool_execute_typed_input.ml
@@ -197,18 +197,30 @@ let optional_redirect_target ~path fields key =
       (json_type_name value)
 ;;
 
-(* [timeout_sec] shape check only: accepts a JSON int or float and stores it
-   unvalidated.  Positivity/finiteness is [validate]'s job (check_timeout_sec
-   below), mirroring how [cwd]'s absolute-path check lives in [validate]
-   rather than here. *)
+(* [timeout_sec] shape check only: accepts a JSON int, float, or numeric
+   string, storing the parsed float unvalidated.  The LLM-facing schema
+   advertises ["number","string"] (numeric strings such as "30"), so a
+   string form must parse rather than regress a schema-legal input.
+   Positivity/finiteness is [validate]'s job (check_timeout_sec below),
+   mirroring how [cwd]'s absolute-path check lives in [validate] rather than
+   here — so "inf"/"nan" coerce here and are rejected there. *)
 let optional_timeout_sec ~path fields key =
   match member fields key with
   | None | Some `Null -> Ok None
   | Some (`Float value) -> Ok (Some value)
   | Some (`Int value) -> Ok (Some (float_of_int value))
+  | Some (`String value) ->
+    (match float_of_string_opt value with
+     | Some parsed -> Ok (Some parsed)
+     | None ->
+       result_errorf
+         "%s.%s must be a number or numeric string, got %S"
+         path
+         key
+         value)
   | Some value ->
     result_errorf
-      "%s.%s must be number, got %s"
+      "%s.%s must be a number or numeric string, got %s"
       path
       key
       (json_type_name value)

--- a/lib/keeper/keeper_tool_execute_typed_input.ml
+++ b/lib/keeper/keeper_tool_execute_typed_input.ml
@@ -656,9 +656,18 @@ let pp_validation_error ppf = function
 ;;
 
 let validation_error_alternatives : validation_error -> string list = function
+  | Empty_executable _ -> []
+  | Executable_repeated_in_argv0 _ -> []
   | Argv_contains_shell_metachar _ -> []
   | Argv_contains_shell_pipeline_operator _ -> [ "Execute.pipeline" ]
   | Argv_contains_shell_redirection _ ->
     [ "stderr:{discard:true}"; "stdout:{discard:true}"; "Execute.pipeline" ]
-  | _ -> []
+  | Redirect_path_not_absolute _ -> []
+  | Cwd_not_absolute _ -> []
+  | Pipeline_empty -> []
+  | Pipeline_too_short -> []
+  | Env_key_invalid _ -> []
+  (* No alternative field exists: the fix is a valid value in the same
+     [timeout_sec] field, already stated by [pp_validation_error]. *)
+  | Timeout_sec_not_positive _ -> []
 ;;

--- a/lib/keeper/keeper_tool_execute_typed_input.ml
+++ b/lib/keeper/keeper_tool_execute_typed_input.ml
@@ -17,11 +17,13 @@ type execute_input =
       stdin : redirect_target;
       stdout : redirect_target;
       stderr : redirect_target;
+      timeout_sec : float option;
     }
   | Pipeline of {
       stages : exec_stage list;
       cwd : string option;
       env : (string * string) list;
+      timeout_sec : float option;
     }
 
 type validation_error =
@@ -53,6 +55,7 @@ type validation_error =
   | Pipeline_empty
   | Pipeline_too_short
   | Env_key_invalid of string
+  | Timeout_sec_not_positive of float
 
 let json_type_name (json : Yojson.Safe.t) =
   match json with
@@ -194,6 +197,23 @@ let optional_redirect_target ~path fields key =
       (json_type_name value)
 ;;
 
+(* [timeout_sec] shape check only: accepts a JSON int or float and stores it
+   unvalidated.  Positivity/finiteness is [validate]'s job (check_timeout_sec
+   below), mirroring how [cwd]'s absolute-path check lives in [validate]
+   rather than here. *)
+let optional_timeout_sec ~path fields key =
+  match member fields key with
+  | None | Some `Null -> Ok None
+  | Some (`Float value) -> Ok (Some value)
+  | Some (`Int value) -> Ok (Some (float_of_int value))
+  | Some value ->
+    result_errorf
+      "%s.%s must be number, got %s"
+      path
+      key
+      (json_type_name value)
+;;
+
 let parse_stage ~path_prefix ~index (value : Yojson.Safe.t) =
   let ( let* ) = Result.bind in
   let path = Printf.sprintf "%s[%d]" path_prefix index in
@@ -254,6 +274,7 @@ let of_json (json : Yojson.Safe.t) =
   in
   let* cwd = optional_string ~path:"$" fields "cwd" in
   let* env = optional_env ~path:"$" fields in
+  let* timeout_sec = optional_timeout_sec ~path:"$" fields "timeout_sec" in
   match executable_present, pipeline_value with
   | true, Some _ ->
     Error
@@ -268,7 +289,7 @@ let of_json (json : Yojson.Safe.t) =
     let* stdin = optional_redirect_target ~path:"$" fields "stdin" in
     let* stdout = optional_redirect_target ~path:"$" fields "stdout" in
     let* stderr = optional_redirect_target ~path:"$" fields "stderr" in
-    Ok (Exec { executable; argv; cwd; env; stdin; stdout; stderr })
+    Ok (Exec { executable; argv; cwd; env; stdin; stdout; stderr; timeout_sec })
   | false, Some (path, value) ->
     (* RFC-0198 Phase B 한계: typed redirect triple(stdin/stdout/stderr)은 [Exec]
        variant에만 존재하고 [Pipeline]에는 없다. 그런데 이 세 키는
@@ -294,7 +315,7 @@ let of_json (json : Yojson.Safe.t) =
          {executable, argv} form with the typed redirect fields."
     else
       let* stages = parse_pipeline ~path value in
-      Ok (Pipeline { stages; cwd; env })
+      Ok (Pipeline { stages; cwd; env; timeout_sec })
   | false, None -> Error "$.executable or $.pipeline is required"
 ;;
 
@@ -410,6 +431,12 @@ let check_env env =
   loop env
 ;;
 
+let check_timeout_sec = function
+  | None -> Ok ()
+  | Some v when Float.is_finite v && v > 0.0 -> Ok ()
+  | Some v -> Error (Timeout_sec_not_positive v)
+;;
+
 let check_exec ~executable ~argv ~cwd ~env =
   let ( let* ) = Result.bind in
   let trimmed = String.trim executable in
@@ -437,16 +464,18 @@ let check_redirects ~stdin ~stdout ~stderr =
 ;;
 
 let validate = function
-  | Exec { executable; argv; cwd; env; stdin; stdout; stderr } ->
+  | Exec { executable; argv; cwd; env; stdin; stdout; stderr; timeout_sec } ->
     let ( let* ) = Result.bind in
     let* () = check_exec ~executable ~argv ~cwd ~env in
-    check_redirects ~stdin ~stdout ~stderr
+    let* () = check_redirects ~stdin ~stdout ~stderr in
+    check_timeout_sec timeout_sec
   | Pipeline { stages = []; _ } -> Error Pipeline_empty
   | Pipeline { stages = [ _ ]; _ } -> Error Pipeline_too_short
-  | Pipeline { stages; cwd; env } ->
+  | Pipeline { stages; cwd; env; timeout_sec } ->
     let ( let* ) = Result.bind in
     let* () = check_cwd cwd in
     let* () = check_env env in
+    let* () = check_timeout_sec timeout_sec in
     let rec each = function
       | [] -> Ok ()
       | { executable; argv } :: rest ->
@@ -517,11 +546,11 @@ let redirects_of ~cwd ~stdin ~stdout ~stderr =
 let to_shell_ir_unvalidated ?(sandbox = Masc_exec.Sandbox_target.host ()) input =
   let ( let* ) = Result.bind in
   match input with
-  | Exec { executable; argv; cwd; env; stdin; stdout; stderr } ->
+  | Exec { executable; argv; cwd; env; stdin; stdout; stderr; timeout_sec = _ } ->
     let stage = { executable; argv } in
     let redirects = redirects_of ~cwd ~stdin ~stdout ~stderr in
     shell_simple ~sandbox ?cwd ~env ~redirects stage
-  | Pipeline { stages; cwd; env } ->
+  | Pipeline { stages; cwd; env; timeout_sec = _ } ->
     let* simples =
       let rec loop acc = function
         | [] -> Ok (List.rev acc)
@@ -619,6 +648,11 @@ let pp_validation_error ppf = function
     Format.pp_print_string ppf "pipeline requires at least two stages"
   | Env_key_invalid k ->
     Format.fprintf ppf "env key %S is not [A-Za-z0-9_]+" k
+  | Timeout_sec_not_positive v ->
+    Format.fprintf
+      ppf
+      "timeout_sec %.3f must be a finite number greater than 0"
+      v
 ;;
 
 let validation_error_alternatives : validation_error -> string list = function

--- a/lib/keeper/keeper_tool_execute_typed_input.mli
+++ b/lib/keeper/keeper_tool_execute_typed_input.mli
@@ -82,9 +82,19 @@ type execute_input =
       (** Per-stage redirects are intentionally not exposed here — pipe
           construction owns the inter-stage fd plumbing.  Out-of-stage
           redirects on the pipeline's endpoints are a deferred extension.
-          [timeout_sec] applies uniformly to every stage, mirroring how
-          {!Masc_exec.Exec_gate.run_argv_pipeline_with_status_split} applies
-          one deadline per spawned stage. *)
+
+          [timeout_sec]'s effective semantics depend on which dispatch path
+          {!Masc_exec.Exec_dispatch.dispatch_pipeline} selects for the
+          lowered stages.  A typed [Pipeline]'s stages always lower with no
+          redirects and share one [sandbox] value per call (defaulting to
+          {!Masc_exec.Sandbox_target.host}), so with the default sandbox
+          every stage takes the host native-pipeline path: there,
+          {!Masc_exec.Exec_gate.run_argv_pipeline_with_status_split} wraps
+          the *whole* pipeline await in a single deadline — one deadline
+          for the entire pipeline, not one per stage. If a caller resolves
+          a non-host (Docker) sandbox instead, stages fall to the Docker
+          [pipeline_runner] path, which ignores [timeout_sec] entirely (no
+          timeout parameter exists there yet). *)
 
 type validation_error =
   | Empty_executable of { argv : string list }

--- a/lib/keeper/keeper_tool_execute_typed_input.mli
+++ b/lib/keeper/keeper_tool_execute_typed_input.mli
@@ -59,21 +59,32 @@ type execute_input =
       stdin : redirect_target;
       stdout : redirect_target;
       stderr : redirect_target;
+      timeout_sec : float option;
     }
       (** [stdin], [stdout], [stderr] default to {!Inherit} when absent
           from JSON.  RFC-0198 Phase B introduced them so the LLM can
           express "discard stderr" or "write stdout to an absolute path"
           via typed schema, instead of attempting shell redirection
           syntax inside an execve-style argv (which silently leaks as
-          a runtime [find: 2>/dev/null: unknown primary] failure). *)
+          a runtime [find: 2>/dev/null: unknown primary] failure).
+          [timeout_sec] is [None] when absent from JSON, in which case the
+          dispatch chain keeps using its existing default timeout.  When
+          present, it is threaded as an optional per-spawn override through
+          {!Keeper_tool_execute_shell_ir.dispatch_classified} down to the
+          Process_eio runner; {!validate} (not this parse step) rejects
+          non-positive or non-finite values. *)
   | Pipeline of {
       stages : exec_stage list;
       cwd : string option;
       env : (string * string) list;
+      timeout_sec : float option;
     }
       (** Per-stage redirects are intentionally not exposed here — pipe
           construction owns the inter-stage fd plumbing.  Out-of-stage
-          redirects on the pipeline's endpoints are a deferred extension. *)
+          redirects on the pipeline's endpoints are a deferred extension.
+          [timeout_sec] applies uniformly to every stage, mirroring how
+          {!Masc_exec.Exec_gate.run_argv_pipeline_with_status_split} applies
+          one deadline per spawned stage. *)
 
 type validation_error =
   | Empty_executable of { argv : string list }
@@ -121,12 +132,20 @@ type validation_error =
   | Pipeline_empty
   | Pipeline_too_short
   | Env_key_invalid of string
+  | Timeout_sec_not_positive of float
+      (** [timeout_sec] must be a finite number strictly greater than 0.
+          Rejected at {!validate} rather than {!of_json}, mirroring how
+          {!Cwd_not_absolute} validates a JSON-shape-correct value. *)
 
 val of_json : Yojson.Safe.t -> (execute_input, string) result
 (** Parse the typed Execute JSON boundary.  Accepts either
     [{executable, argv?, cwd?, env?, timeout_sec?}] for [Exec] or
-    [{pipeline = [{executable, argv?}, ...], cwd?, env?}] for [Pipeline].
-    [timeout_sec] is accepted at this layer and consumed by the caller.
+    [{pipeline = [{executable, argv?}, ...], cwd?, env?, timeout_sec?}] for
+    [Pipeline].  [timeout_sec] must be a JSON number (int or float) when
+    present; the value is stored on {!execute_input} and threaded through
+    dispatch as an optional per-spawn timeout override.  This function only
+    checks the JSON shape (number vs. not) — {!validate} rejects
+    non-positive or non-finite [timeout_sec] values.
     [executable] and [pipeline] together, raw command-string fields, [{stages =
     ...}], and other unsupported fields are intentionally rejected here.  No
     compatibility normalization is applied at parse time: missing [find .]
@@ -138,7 +157,9 @@ val validate : execute_input -> (unit, validation_error) result
     success, or the first {!validation_error} encountered.  Validation
     mirrors lowering's bounded argv0 autocorrection: a leading executable
     duplicate with at least one following argument is tolerated, while the
-    caller-authored input is not mutated.  No side effects, no exceptions. *)
+    caller-authored input is not mutated.  Also rejects a present
+    [timeout_sec] that is non-positive, infinite, or NaN.  No side effects,
+    no exceptions. *)
 
 val to_shell_ir_unvalidated :
   ?sandbox:Masc_exec.Sandbox_target.t ->

--- a/lib/keeper_tooling/keeper_tool_execute_shell_ir.ml
+++ b/lib/keeper_tooling/keeper_tool_execute_shell_ir.ml
@@ -217,6 +217,7 @@ let dispatch_classified
       ~workdir
       ~sandbox
       ?base_host_env
+      ?timeout_sec
       ?on_output_chunk
       envelope
   =
@@ -278,6 +279,7 @@ let dispatch_classified
                 Ok
                   (Masc_exec.Exec_dispatch.dispatch_decided
                      ?base_host_env
+                     ?timeout_sec
                      ?on_output_chunk
                      envelope))))
 ;;
@@ -291,6 +293,7 @@ let dispatch
       ~workdir
       ~sandbox
       ?base_host_env
+      ?timeout_sec
       ?on_output_chunk
       ir
   =
@@ -302,6 +305,7 @@ let dispatch
     ~workdir
     ~sandbox
     ?base_host_env
+    ?timeout_sec
     ?on_output_chunk
     (classify ir)
 ;;
@@ -323,6 +327,7 @@ let dispatch_classified_with_approval
       ~workdir
       ~sandbox
       ?base_host_env
+      ?timeout_sec
       ?on_output_chunk
       ~agent_id
       ~approval_config
@@ -352,6 +357,7 @@ let dispatch_classified_with_approval
          ~workdir
          ~sandbox
          ?base_host_env
+         ?timeout_sec
          ?on_output_chunk
          envelope
      | Ask { bin = request_bin; _ } ->

--- a/lib/keeper_tooling/keeper_tool_execute_shell_ir.mli
+++ b/lib/keeper_tooling/keeper_tool_execute_shell_ir.mli
@@ -77,6 +77,7 @@ val dispatch_classified :
   workdir:string ->
   sandbox:Masc_exec.Sandbox_target.t ->
   ?base_host_env:string array ->
+  ?timeout_sec:float ->
   ?on_output_chunk:([ `Stdout of string | `Stderr of string ] -> unit) ->
   Masc_exec.Shell_ir_risk.decided Masc_exec.Shell_ir_risk.decided_ir ->
   (Masc_exec.Exec_dispatch.dispatch_result, dispatch_error) result
@@ -86,7 +87,12 @@ val dispatch_classified :
     callers pass [false].  Catastrophic operations are policy-denied, and
     typed gh capability asks and privileged programs are [Approval_required];
     both also apply to the approval-gate kill-switch path. [?on_output_chunk] is
-    forwarded to the host dispatch path for live output streaming. *)
+    forwarded to the host dispatch path for live output streaming.
+    [?timeout_sec], when supplied, is forwarded to
+    {!Masc_exec.Exec_dispatch.dispatch_decided}; absent, the dispatch chain
+    keeps its existing default timeout.  It only reaches the Host sandbox
+    spawn path — {!Masc_exec.Sandbox_target.runner} (the Docker path) has no
+    timeout parameter yet, so Docker-dispatched commands ignore it. *)
 
 val dispatch_classified_with_approval :
   ?allow_pipes:bool ->
@@ -96,6 +102,7 @@ val dispatch_classified_with_approval :
   workdir:string ->
   sandbox:Masc_exec.Sandbox_target.t ->
   ?base_host_env:string array ->
+  ?timeout_sec:float ->
   ?on_output_chunk:([ `Stdout of string | `Stderr of string ] -> unit) ->
   agent_id:Masc_exec.Agent_id.t ->
   approval_config:Masc_exec.Approval_config.t ->
@@ -111,7 +118,9 @@ val dispatch_classified_with_approval :
     [Allow] and [Suggest_confirm] proceed to {!dispatch_classified}, which
     still applies the privileged fail-closed floor before process dispatch.
     A nested pipeline whose last stage is itself a pipeline yields
-    [Too_complex], matching {!dispatch_classified}. *)
+    [Too_complex], matching {!dispatch_classified}.  [?timeout_sec] is
+    forwarded unchanged to {!dispatch_classified} on the [Allow]/
+    [Suggest_confirm] path; see its docstring for the Docker-path caveat. *)
 
 val dispatch :
   ?allow_pipes:bool ->
@@ -121,8 +130,10 @@ val dispatch :
   workdir:string ->
   sandbox:Masc_exec.Sandbox_target.t ->
   ?base_host_env:string array ->
+  ?timeout_sec:float ->
   ?on_output_chunk:([ `Stdout of string | `Stderr of string ] -> unit) ->
   Masc_exec.Shell_ir.t ->
   (Masc_exec.Exec_dispatch.dispatch_result, dispatch_error) result
 (** Run the canonical keeper Shell IR pipeline:
-    classify -> typed gate -> path validation -> dispatch_decided. *)
+    classify -> typed gate -> path validation -> dispatch_decided.
+    [?timeout_sec] is forwarded unchanged to {!dispatch_classified}. *)

--- a/lib/tool_surface/tool_shard_types_schemas_execute.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_execute.ml
@@ -105,23 +105,23 @@ let tool_execute_cwd_field =
 ;;
 
 let tool_execute_timeout_sec_field =
-  (* Historical schema carry-over (Issue #18472, 2026-06-08 cleanup):
-     caller-side timeout fields were removed as part of the spirit of
-     PR #20479 ("tool 자체가 알아서 타임아웃으로 튕기든 해야지 그걸
-     왜 되나 안 되나 우리가 관찰하고 있나?"). The LLM-facing JSON
-     schema is preserved for backwards compatibility with callers
-     that still emit the field; the wire-format quirk (string vs
-     number) is still accepted but is now advisory only — the
-     dispatch path no longer reads it. *)
+  (* Re-wired live: caller-side timeout was removed as advisory-only in the
+     Issue #18472 / PR #20479 cleanup, but the dispatch path now reads it
+     again and forwards it to Process_eio (a timed-out command exits 124).
+     The wire-format quirk (string vs number) stays: both ["number","string"]
+     are accepted and a numeric string is parsed as a number by
+     [Keeper_tool_execute_typed_input.optional_timeout_sec] — so the schema
+     and the parser agree on the accepted domain. *)
   ( "timeout_sec"
   , `Assoc
       [ ( "type"
         , `List [ `String "number"; `String "string" ] )
       ; ( "description"
         , `String
-            "Deprecated. The caller-side timeout knob is no longer \
-             observed; the tool itself owns hang protection. Numeric \
-             strings (e.g. \"30\") are accepted but ignored." )
+            "Per-call wall-clock timeout in seconds for this command. \
+             Observed by the dispatch path; a command that exceeds it is \
+             terminated (exit code 124). Numeric strings (e.g. \"30\") are \
+             accepted and parsed as numbers." )
       ] )
 ;;
 

--- a/test/test_exec_dispatch.ml
+++ b/test/test_exec_dispatch.ml
@@ -1351,5 +1351,53 @@ let () =
   assert (result.status = Unix.WEXITED 124);
   assert (elapsed < 8.0)
 
+(* --- dispatch_pipeline: decomposed fallback path applies ?timeout_sec
+   per stage, not once for the whole pipeline ---
+
+   [host_pipeline_specs] requires every stage to be [Host] sandbox with no
+   redirects; a [Fd_to_fd] redirect on the first stage makes it (and
+   [docker_pipeline_specs], which requires a Docker sandbox) return [None],
+   so [dispatch_pipeline] falls to the sequential per-stage [chain] instead
+   of the single-deadline native pipeline exercised above.  The first stage
+   exits immediately and should not consume any of the second stage's
+   [timeout_sec] budget; only the sleeping second stage should hit the
+   0.5s deadline.  8.0s stays generous for one [reap_proc_with_clock]
+   escalation, matching the bound used by the native-pipeline test. *)
+
+let () =
+  with_eio @@ fun () ->
+  let open Masc_exec.Shell_ir in
+  let host_sandbox = Masc_exec.Sandbox_target.host () in
+  let sh_bin = Masc_exec.Exec_program.of_string "sh" |> Result.get_ok in
+  let fast_stage =
+    Simple
+      { bin = sh_bin
+      ; args = [ Lit ("-c", default_meta); Lit ("exit 0", default_meta) ]
+      ; env = []
+      ; cwd = None
+      ; redirects = [ Masc_exec.Redirect_scope.Fd_to_fd { src = 2; dst = 1 } ]
+      ; sandbox = host_sandbox
+      }
+  in
+  let slow_stage =
+    Simple
+      { bin = sh_bin
+      ; args = [ Lit ("-c", default_meta); Lit ("sleep 30", default_meta) ]
+      ; env = []
+      ; cwd = None
+      ; redirects = []
+      ; sandbox = host_sandbox
+      }
+  in
+  let t0 = Unix.gettimeofday () in
+  let result =
+    Masc_exec.Exec_dispatch.dispatch_pipeline
+      ~timeout_sec:0.5
+      [ fast_stage; slow_stage ]
+  in
+  let elapsed = Unix.gettimeofday () -. t0 in
+  assert (result.status = Unix.WEXITED 124);
+  assert (elapsed < 8.0)
+
 let () =
   Printf.printf "p7_exec_dispatch: all tests passed.\n"

--- a/test/test_exec_dispatch.ml
+++ b/test/test_exec_dispatch.ml
@@ -1283,5 +1283,73 @@ let () =
   | Error (Keeper_tool_execute_shell_ir.Policy_denied _) -> ()
   | Error _ -> assert false
 
+(* --- dispatch_simple / dispatch_pipeline thread ?timeout_sec into
+   Exec_gate/Process_eio (this PR) ---
+
+   Before this PR, [Exec_dispatch] had no [?timeout_sec] parameter at all —
+   every caller silently got [Exec_gate]'s 60s default no matter what the
+   typed Execute JSON boundary parsed.  These tests prove the parameter is
+   live end to end: a "sleep 30" is spawned with a much shorter
+   [timeout_sec] and must be killed (exit 124) well before either the sleep
+   duration or the previous 60s default would elapse.  [reap_proc_with_clock]
+   allows up to a 2s SIGTERM grace period per process before escalating to
+   SIGKILL, and the pipeline test reaps two processes sequentially, so the
+   8s elapsed bound below is generous relative to [timeout_sec] itself. *)
+
+let () =
+  with_eio @@ fun () ->
+  let open Masc_exec.Shell_ir in
+  let bin = Masc_exec.Exec_program.of_string "sh" |> Result.get_ok in
+  let ir =
+    { bin
+    ; args = [ Lit ("-c", default_meta); Lit ("sleep 30", default_meta) ]
+    ; env = []
+    ; cwd = None
+    ; redirects = []
+    ; sandbox = Masc_exec.Sandbox_target.host ()
+    }
+  in
+  let t0 = Unix.gettimeofday () in
+  let result = Masc_exec.Exec_dispatch.dispatch_simple ~timeout_sec:0.5 ir in
+  let elapsed = Unix.gettimeofday () -. t0 in
+  assert (result.status = Unix.WEXITED 124);
+  assert (elapsed < 8.0)
+
+let () =
+  with_eio @@ fun () ->
+  let open Masc_exec.Shell_ir in
+  let host_sandbox = Masc_exec.Sandbox_target.host () in
+  let sh_bin = Masc_exec.Exec_program.of_string "sh" |> Result.get_ok in
+  let cat_bin = Masc_exec.Exec_program.of_string "cat" |> Result.get_ok in
+  let slow_stage =
+    Simple
+      { bin = sh_bin
+      ; args = [ Lit ("-c", default_meta); Lit ("sleep 30", default_meta) ]
+      ; env = []
+      ; cwd = None
+      ; redirects = []
+      ; sandbox = host_sandbox
+      }
+  in
+  let cat_stage =
+    Simple
+      { bin = cat_bin
+      ; args = []
+      ; env = []
+      ; cwd = None
+      ; redirects = []
+      ; sandbox = host_sandbox
+      }
+  in
+  let t0 = Unix.gettimeofday () in
+  let result =
+    Masc_exec.Exec_dispatch.dispatch_pipeline
+      ~timeout_sec:0.5
+      [ slow_stage; cat_stage ]
+  in
+  let elapsed = Unix.gettimeofday () -. t0 in
+  assert (result.status = Unix.WEXITED 124);
+  assert (elapsed < 8.0)
+
 let () =
   Printf.printf "p7_exec_dispatch: all tests passed.\n"

--- a/test/test_keeper_tool_execute_typed_input.ml
+++ b/test/test_keeper_tool_execute_typed_input.ml
@@ -1272,8 +1272,8 @@ let test_of_json_rejects_redirect_with_both_discard_and_file () =
    field to store it in, so a caller-supplied timeout never reached
    [Exec_dispatch] and the "increase timeout_sec" recovery hint in
    [Exec_core] pointed at a no-op.  These tests cover the fix: JSON shape
-   parsing (int/float/absent) here, and positivity/finiteness in
-   [validate]. *)
+   parsing (int/float/numeric-string/absent) here, and positivity/finiteness
+   in [validate]. *)
 
 let test_of_json_accepts_timeout_sec_as_float () =
   let input =
@@ -1313,13 +1313,33 @@ let test_of_json_timeout_sec_absent_is_none () =
   | Execute_input.Pipeline _ -> Alcotest.fail "expected Exec"
 ;;
 
+let test_of_json_accepts_timeout_sec_as_numeric_string () =
+  (* The LLM-facing schema advertises ["number","string"] with the example
+     "30", so a numeric string must parse (not regress a schema-legal input). *)
+  let input =
+    parse_json_exn
+      (`Assoc
+          [ "executable", `String "sleep"
+          ; "argv", `List [ `String "5" ]
+          ; "timeout_sec", `String "30"
+          ])
+  in
+  match input with
+  | Execute_input.Exec { timeout_sec; _ } ->
+    Alcotest.(check (option (float 0.001)))
+      "numeric string coerces to number"
+      (Some 30.0)
+      timeout_sec
+  | Execute_input.Pipeline _ -> Alcotest.fail "expected Exec"
+;;
+
 let test_of_json_rejects_non_numeric_timeout_sec () =
   let msg =
     parse_json_error
       (`Assoc
           [ "executable", `String "sleep"
           ; "argv", `List [ `String "5" ]
-          ; "timeout_sec", `String "30"
+          ; "timeout_sec", `String "soon"
           ])
   in
   Alcotest.(check bool)
@@ -1556,6 +1576,10 @@ let suite =
           "timeout_sec_of_json_absent_is_none"
           `Quick
           test_of_json_timeout_sec_absent_is_none
+      ; Alcotest.test_case
+          "timeout_sec_of_json_accepts_numeric_string"
+          `Quick
+          test_of_json_accepts_timeout_sec_as_numeric_string
       ; Alcotest.test_case
           "timeout_sec_of_json_rejects_non_numeric"
           `Quick

--- a/test/test_keeper_tool_execute_typed_input.ml
+++ b/test/test_keeper_tool_execute_typed_input.ml
@@ -12,7 +12,7 @@ let typed_ok input =
   | Error _ -> false
 ;;
 
-let mk_exec executable argv =
+let mk_exec ?(timeout_sec = None) executable argv =
   Execute_input.Exec
     { executable
     ; argv
@@ -21,6 +21,7 @@ let mk_exec executable argv =
     ; stdin = Execute_input.Inherit
     ; stdout = Execute_input.Inherit
     ; stderr = Execute_input.Inherit
+    ; timeout_sec
     }
 ;;
 
@@ -155,7 +156,8 @@ let test_case case () =
 
 let test_pipeline_empty () =
   let input =
-    Execute_input.Pipeline { stages = []; cwd = None; env = [] }
+    Execute_input.Pipeline
+      { stages = []; cwd = None; env = []; timeout_sec = None }
   in
   Alcotest.(check bool)
     "pipeline with empty stages is rejected"
@@ -169,6 +171,7 @@ let test_pipeline_single_stage_rejected () =
       { stages = [ { executable = "rg"; argv = [ "pattern" ] } ]
       ; cwd = None
       ; env = []
+      ; timeout_sec = None
       }
   in
   Alcotest.(check bool)
@@ -186,6 +189,7 @@ let test_pipeline_stage_executable_check () =
           ]
       ; cwd = None
       ; env = []
+      ; timeout_sec = None
       }
   in
   Alcotest.(check bool)
@@ -375,7 +379,7 @@ let test_of_json_pipeline () =
           ])
   in
   match input with
-  | Execute_input.Pipeline { stages; cwd; env } ->
+  | Execute_input.Pipeline { stages; cwd; env; _ } ->
     Alcotest.(check int) "stage count" 2 (List.length stages);
     Alcotest.(check (option string)) "cwd" (Some "/tmp") cwd;
     Alcotest.(check (list (pair string string))) "env" [] env;
@@ -439,7 +443,7 @@ let test_of_json_keeps_empty_pipeline_stage_for_validation () =
           ])
   in
   match input with
-  | Execute_input.Pipeline { stages; cwd; env } ->
+  | Execute_input.Pipeline { stages; cwd; env; _ } ->
     Alcotest.(check (option string)) "cwd" (Some "/tmp") cwd;
     Alcotest.(check (list (pair string string))) "env" [] env;
     (match stages with
@@ -586,6 +590,7 @@ let test_pipeline_lowers_to_shell_ir_pipeline () =
           ]
       ; cwd = Some "/tmp"
       ; env = [ "LC_ALL", "C" ]
+      ; timeout_sec = None
       }
   in
   match to_shell_ir_exn input with
@@ -621,6 +626,7 @@ let test_exec_lowering_preserves_duplicate_executable_argv () =
       ; stdin = Execute_input.Inherit
       ; stdout = Execute_input.Inherit
       ; stderr = Execute_input.Inherit
+      ; timeout_sec = None
       }
   in
   match Execute_input.to_shell_ir input with
@@ -648,6 +654,7 @@ let test_exec_lowering_preserves_single_argv_equal_to_executable () =
       ; stdin = Execute_input.Inherit
       ; stdout = Execute_input.Inherit
       ; stderr = Execute_input.Inherit
+      ; timeout_sec = None
       }
   in
   match Execute_input.to_shell_ir input with
@@ -674,6 +681,7 @@ let test_pipeline_lowering_preserves_single_stage_argv_equal_to_executable () =
           ]
       ; cwd = None
       ; env = []
+      ; timeout_sec = None
       }
   in
   match Execute_input.to_shell_ir input with
@@ -706,6 +714,7 @@ let test_pipeline_lowering_preserves_duplicate_stage_argv () =
           ]
       ; cwd = None
       ; env = []
+      ; timeout_sec = None
       }
   in
   match Execute_input.to_shell_ir input with
@@ -752,6 +761,7 @@ let test_pipeline_lowers_with_injected_docker_sandbox () =
           ]
       ; cwd = Some "/tmp"
       ; env = []
+      ; timeout_sec = None
       }
   in
   match
@@ -783,6 +793,7 @@ let test_pipe_character_in_exec_argv_is_literal () =
       ; stdin = Execute_input.Inherit
       ; stdout = Execute_input.Inherit
       ; stderr = Execute_input.Inherit
+      ; timeout_sec = None
       }
   in
   match to_shell_ir_exn input with
@@ -806,6 +817,7 @@ let test_standalone_pipe_operator_in_exec_argv_rejected () =
         ; stdin = Execute_input.Inherit
         ; stdout = Execute_input.Inherit
         ; stderr = Execute_input.Inherit
+        ; timeout_sec = None
         }
     in
     match Execute_input.validate input with
@@ -860,6 +872,7 @@ let test_gh_multiline_body_lowers_to_literal_argv () =
       ; stdin = Execute_input.Inherit
       ; stdout = Execute_input.Inherit
       ; stderr = Execute_input.Inherit
+      ; timeout_sec = None
       }
   in
   match to_shell_ir_exn input with
@@ -889,6 +902,7 @@ let test_cwd_not_absolute () =
       ; stdin = Execute_input.Inherit
       ; stdout = Execute_input.Inherit
       ; stderr = Execute_input.Inherit
+      ; timeout_sec = None
       }
   in
   Alcotest.(check bool)
@@ -907,6 +921,7 @@ let test_env_key_invalid () =
       ; stdin = Execute_input.Inherit
       ; stdout = Execute_input.Inherit
       ; stderr = Execute_input.Inherit
+      ; timeout_sec = None
       }
   in
   Alcotest.(check bool)
@@ -948,6 +963,7 @@ let test_shell_redirection_token_rejected () =
           ; stdin = Execute_input.Inherit
           ; stdout = Execute_input.Inherit
           ; stderr = Execute_input.Inherit
+          ; timeout_sec = None
           }
       in
       expect_redirection_rejected ~token input)
@@ -982,6 +998,7 @@ let test_legitimate_metachar_still_allowed () =
           ; stdin = Execute_input.Inherit
           ; stdout = Execute_input.Inherit
           ; stderr = Execute_input.Inherit
+          ; timeout_sec = None
           }
       in
       match Execute_input.validate  input with
@@ -1038,6 +1055,7 @@ let test_redirection_rejected_emits_typed_alternative () =
       ; stdin = Execute_input.Inherit
       ; stdout = Execute_input.Inherit
       ; stderr = Execute_input.Inherit
+      ; timeout_sec = None
       }
   in
   match Execute_input.validate  input with
@@ -1099,10 +1117,11 @@ let mk_exec_with_redirects
       ?(stdin = Execute_input.Inherit)
       ?(stdout = Execute_input.Inherit)
       ?(stderr = Execute_input.Inherit)
+      ?(timeout_sec = None)
       ()
   =
   Execute_input.Exec
-    { executable; argv; cwd; env; stdin; stdout; stderr }
+    { executable; argv; cwd; env; stdin; stdout; stderr; timeout_sec }
 ;;
 
 let count_redirects ir =
@@ -1246,6 +1265,121 @@ let test_of_json_rejects_redirect_with_both_discard_and_file () =
   match Execute_input.of_json json with
   | Ok _ -> Alcotest.fail "of_json must reject conflicting discard+file"
   | Error _ -> ()
+;;
+
+(* [timeout_sec] used to be accepted into the allowed-field list and then
+   silently dropped: [of_json] never read it, and [Exec]/[Pipeline] had no
+   field to store it in, so a caller-supplied timeout never reached
+   [Exec_dispatch] and the "increase timeout_sec" recovery hint in
+   [Exec_core] pointed at a no-op.  These tests cover the fix: JSON shape
+   parsing (int/float/absent) here, and positivity/finiteness in
+   [validate]. *)
+
+let test_of_json_accepts_timeout_sec_as_float () =
+  let input =
+    parse_json_exn
+      (`Assoc
+          [ "executable", `String "sleep"
+          ; "argv", `List [ `String "5" ]
+          ; "timeout_sec", `Float 30.5
+          ])
+  in
+  match input with
+  | Execute_input.Exec { timeout_sec; _ } ->
+    Alcotest.(check (option (float 0.001))) "timeout_sec" (Some 30.5) timeout_sec
+  | Execute_input.Pipeline _ -> Alcotest.fail "expected Exec"
+;;
+
+let test_of_json_accepts_timeout_sec_as_int () =
+  let input =
+    parse_json_exn
+      (`Assoc
+          [ "executable", `String "sleep"
+          ; "argv", `List [ `String "5" ]
+          ; "timeout_sec", `Int 45
+          ])
+  in
+  match input with
+  | Execute_input.Exec { timeout_sec; _ } ->
+    Alcotest.(check (option (float 0.001))) "timeout_sec" (Some 45.0) timeout_sec
+  | Execute_input.Pipeline _ -> Alcotest.fail "expected Exec"
+;;
+
+let test_of_json_timeout_sec_absent_is_none () =
+  let input = mk_exec "ls" [] in
+  match input with
+  | Execute_input.Exec { timeout_sec; _ } ->
+    Alcotest.(check bool) "timeout_sec absent stays None" true (Option.is_none timeout_sec)
+  | Execute_input.Pipeline _ -> Alcotest.fail "expected Exec"
+;;
+
+let test_of_json_rejects_non_numeric_timeout_sec () =
+  let msg =
+    parse_json_error
+      (`Assoc
+          [ "executable", `String "sleep"
+          ; "argv", `List [ `String "5" ]
+          ; "timeout_sec", `String "30"
+          ])
+  in
+  Alcotest.(check bool)
+    "error names the rejected field"
+    true
+    (String_util.contains_substring_ci msg "timeout_sec")
+;;
+
+let test_of_json_pipeline_accepts_timeout_sec () =
+  let input =
+    parse_json_exn
+      (`Assoc
+          [ ( "pipeline"
+            , `List
+                [ `Assoc
+                    [ "executable", `String "printf"
+                    ; "argv", `List [ `String "hello" ]
+                    ]
+                ; `Assoc [ "executable", `String "wc"; "argv", `List [ `String "-c" ] ]
+                ] )
+          ; "timeout_sec", `Float 12.0
+          ])
+  in
+  match input with
+  | Execute_input.Pipeline { timeout_sec; _ } ->
+    Alcotest.(check (option (float 0.001))) "pipeline timeout_sec" (Some 12.0) timeout_sec
+  | Execute_input.Exec _ -> Alcotest.fail "expected Pipeline"
+;;
+
+let test_timeout_sec_zero_rejected () =
+  let input = mk_exec ~timeout_sec:(Some 0.0) "ls" [] in
+  match Execute_input.validate input with
+  | Error (Execute_input.Timeout_sec_not_positive v) ->
+    Alcotest.(check (float 0.001)) "rejected value echoed" 0.0 v
+  | Error other ->
+    Alcotest.failf
+      "expected Timeout_sec_not_positive, got %a"
+      Execute_input.pp_validation_error
+      other
+  | Ok () -> Alcotest.fail "timeout_sec=0 should be rejected"
+;;
+
+let test_timeout_sec_negative_rejected () =
+  let input = mk_exec ~timeout_sec:(Some (-5.0)) "ls" [] in
+  Alcotest.(check bool) "negative timeout_sec rejected" false (typed_ok input)
+;;
+
+let test_timeout_sec_nan_rejected () =
+  let input = mk_exec ~timeout_sec:(Some Float.nan) "ls" [] in
+  Alcotest.(check bool) "NaN timeout_sec rejected" false (typed_ok input)
+;;
+
+let test_timeout_sec_infinite_rejected () =
+  let input = mk_exec ~timeout_sec:(Some Float.infinity) "ls" [] in
+  Alcotest.(check bool) "infinite timeout_sec rejected" false (typed_ok input)
+;;
+
+let test_timeout_sec_positive_finite_accepted () =
+  let input = mk_exec ~timeout_sec:(Some 120.0) "ls" [] in
+  Alcotest.(check bool) "positive finite timeout_sec accepted" true (typed_ok input)
 ;;
 
 let suite =
@@ -1410,6 +1544,43 @@ let suite =
           "rfc_0198_phaseb_of_json_rejects_discard_and_file"
           `Quick
           test_of_json_rejects_redirect_with_both_discard_and_file
+      ; Alcotest.test_case
+          "timeout_sec_of_json_accepts_float"
+          `Quick
+          test_of_json_accepts_timeout_sec_as_float
+      ; Alcotest.test_case
+          "timeout_sec_of_json_accepts_int"
+          `Quick
+          test_of_json_accepts_timeout_sec_as_int
+      ; Alcotest.test_case
+          "timeout_sec_of_json_absent_is_none"
+          `Quick
+          test_of_json_timeout_sec_absent_is_none
+      ; Alcotest.test_case
+          "timeout_sec_of_json_rejects_non_numeric"
+          `Quick
+          test_of_json_rejects_non_numeric_timeout_sec
+      ; Alcotest.test_case
+          "timeout_sec_of_json_pipeline_accepts"
+          `Quick
+          test_of_json_pipeline_accepts_timeout_sec
+      ; Alcotest.test_case
+          "timeout_sec_zero_rejected"
+          `Quick
+          test_timeout_sec_zero_rejected
+      ; Alcotest.test_case
+          "timeout_sec_negative_rejected"
+          `Quick
+          test_timeout_sec_negative_rejected
+      ; Alcotest.test_case "timeout_sec_nan_rejected" `Quick test_timeout_sec_nan_rejected
+      ; Alcotest.test_case
+          "timeout_sec_infinite_rejected"
+          `Quick
+          test_timeout_sec_infinite_rejected
+      ; Alcotest.test_case
+          "timeout_sec_positive_finite_accepted"
+          `Quick
+          test_timeout_sec_positive_finite_accepted
       ])
 ;;
 


### PR DESCRIPTION
## 배경

sangsu 사고 RCA(`~/me/reports/masc-oas-sangsu-ambiguous-failure-rca-20260712.html`)에서 확인된 결함:
Execute 도구의 `timeout_sec`이 typed JSON 경계에서 **수용-후-무시(accept-then-ignore)** 상태였습니다.

- `lib/keeper/keeper_tool_execute_typed_input.ml`의 `of_json`이 `"timeout_sec"`을 `reject_unknown_fields ~allowed` 목록에 넣어놓고도 실제로는 파싱하지 않고 버립니다.
- `execute_input = Exec {...} | Pipeline {...}` variant 자체에 timeout 필드가 없어 저장할 곳도 없었습니다.
- `exec_core.ml`의 timeout recovery hint(“increase timeout_sec moderately”)는 재시도를 이 필드로 유도하지만, 실제로는 아무 효과가 없는 no-op을 가리키고 있었습니다.
- 실행 체인(`Keeper_tool_execute_shell_ir` → `Masc_exec.Exec_dispatch` → `Process_eio` 러너)에는 애초에 `timeout_sec`을 받는 파라미터 자체가 없어, 모든 호출이 `Exec_gate.default_exec_timeout_sec = 60.0`으로 고정되어 있었습니다.

관련: masc #24314 (`failure_class` 선언), oas#2585.

## 변경 사항

1. **타입 경계** (`keeper_tool_execute_typed_input.ml`/`.mli`)
   - `Exec`/`Pipeline` variant에 `timeout_sec : float option` 필드 추가.
   - `of_json`: JSON 타입만 검사(`int`/`float` 허용, 그 외 타입 거부). 값 자체의 양수/유한성 검사는 하지 않음 — `cwd`의 절대경로 검사가 `of_json`이 아닌 `validate`에 있는 기존 패턴을 그대로 따름.
   - `validate`: 새 `Timeout_sec_not_positive of float` variant 추가, `check_timeout_sec`으로 `Float.is_finite v && v > 0.0` 검사. 0, 음수, NaN, Infinity 전부 typed error로 거부(silent drop 없음).
   - `to_shell_ir_unvalidated`의 기존 `Exec {...}` / `Pipeline {...}` 완전 분해 패턴에 `timeout_sec` 필드가 누락되어 있던 것도 함께 수정(이 파일 내부에서 unqualified로 참조되는 지점이라 최초 grep 스윕에서 한 번 누락됐다가 재검토 중 발견).

2. **실행 경로 스레딩** (`?timeout_sec:float option` optional 인자로 전달, Shell_ir에 필드를 추가하지 않음 — `on_output_chunk`/`base_host_env`가 이미 이런 식으로 전달되는 기존 관례를 따름)
   - `keeper_tool_execute_runtime.ml`: `typed_input_timeout_sec input`으로 추출해 `dispatch_classified`/`dispatch_classified_with_approval` 양쪽 호출에 전달.
   - `keeper_tool_execute_shell_ir.ml`/`.mli`: `dispatch_classified`, `dispatch_classified_with_approval`, `dispatch` 세 함수 모두 `?timeout_sec` 추가, `Exec_dispatch.dispatch_decided`까지 그대로 전달.
   - `exec_dispatch.ml`/`.mli`: `dispatch_simple`, `dispatch`, `dispatch_decided`, `dispatch_pipeline` 전부 `?timeout_sec` 추가. Host sandbox 경로에서 `Exec_gate.run_argv_with_status_split*`/`run_argv_pipeline_with_status_split` 호출에 전달(decomposed fallback pipeline의 재귀 호출 포함).
   - 값이 없으면(`None`) 기존 default 경로 그대로 유지 — 새 상수/캡 없음.

3. **Docker 분기 미지원 (의도적으로 남긴 gap)**
   - `Masc_exec.Sandbox_target.runner`/`pipeline_runner` 클로저 타입에는 timeout 파라미터가 아예 없습니다. 이걸 넓히려면 모든 keeper 측 Docker runner 구성 지점(공개 타입)을 같이 고쳐야 하는 더 큰 변경이라, 이번 PR 범위에서는 무리하게 우회하지 않고 `exec_dispatch.ml`의 Docker 분기 두 곳에 주석으로 명시만 했습니다. Docker로 dispatch되는 명령은 여전히 `timeout_sec`을 무시합니다(기존 동작과 동일, 새로운 회귀 아님). 후속 작업으로 남겨둡니다.

## 테스트

- `test/test_keeper_tool_execute_typed_input.ml`: `timeout_sec` JSON 파싱 성공(float/int), 미지정 시 `None`, 비숫자 타입 거부, pipeline에도 threading 확인, 그리고 `validate`에서 0/음수/NaN/Infinity 거부 + 양수-유한 값 수용 케이스 9개 추가.
- `test/test_exec_dispatch.ml`: `Exec_dispatch.dispatch_simple`/`dispatch_pipeline`에 실제 `sleep 30` 프로세스를 짧은 `timeout_sec`(0.5s)로 실행해, 실제로 기존 60s 기본값이나 sleep 시간을 기다리지 않고 조기에 `exit 124`로 종료되는지 실측 검증 2건 추가(경과 시간 assertion 포함).
- `Keeper_tool_execute_shell_ir.dispatch_classified` 계층은 순수 파라미터 전달(로직 없음)이라 별도 실측 테스트를 추가하지 않았습니다 — `sh`/`sleep`이 risk classification에서 `Privileged`로 분류되어(알려진 목록에 없는 실행파일은 fail-closed) 이 계층을 통해서는 실측 타이밍 테스트가 불가능했고(정책 게이트에서 `Approval_required`로 먼저 막힘), diff 자체가 자명한 3줄 punning이라 컴파일러 검증으로 충분하다고 판단했습니다.
- 로컬 `dune build`는 레포 규칙상 실행하지 않았습니다. 대신 `rg`로 `Keeper_tool_execute_typed_input.Exec`/`Pipeline`의 전체 생성/분해 지점을 레포 전체에서 전수 확인했습니다(레코드에 필드가 추가되면 전체 필드를 나열하는 패턴/리터럴은 컴파일 에러가 나는 지점이라, 실제로 이 과정에서 이 파일 내부의 `to_shell_ir_unvalidated` 하나를 놓쳤다가 재스윕 중 발견해 수정했습니다).

## 미검증/남은 리스크

- CI(`dune build`/`dune test`)는 아직 실행하지 않았습니다. push 후 확인 필요.
- Docker sandbox 경로의 `timeout_sec` 미지원은 위에 명시한 대로 의도적 gap입니다.
