### PR TITLE
fix(keeper): add typed Agent_failure Row_kind to stop mislabeling OAS errors as transport failures

### DIFF
--- a/dashboard/src/api/dashboard-turn-records.ts
+++ b/dashboard/src/api/dashboard-turn-records.ts
@@ -815,9 +815,10 @@ export type TurnTranscriptLine = {
   role: string
   content: string
   ts?: number
-  // Writer-declared row kind; present (e.g. 'transport_failure') only on
-  // non-utterance assistant rows so the inspector can mark a failed reply
-  // distinctly rather than quoting it as the keeper's own words.
+  // Writer-declared row kind; present (e.g. 'transport_failure' /
+  // 'agent_failure', masc#24314 / oas#2585) only on non-utterance
+  // assistant rows so the inspector can mark a failed reply distinctly
+  // rather than quoting it as the keeper's own words.
   kind?: string
 }
 

--- a/dashboard/src/api/schemas/keeper-catchup-digest.ts
+++ b/dashboard/src/api/schemas/keeper-catchup-digest.ts
@@ -31,6 +31,12 @@ const KeeperCatchupDigestChatSchema = object({
   // Null / absent when new_messages is 0 (no first row to anchor).
   first_new_ts: optional(nullable(number())),
   transport_failures: number(),
+  // masc#24314 / oas#2585: counted separately from transport_failures — a
+  // typed OAS Agent error, a turn with no visible reply, or an
+  // admission/validation rejection, none of which are transport problems.
+  // Optional so a dashboard deploy that lands ahead of the backend does not
+  // fail-closed on the whole digest; absent reads as 0 at the call site.
+  agent_failures: optional(number()),
 })
 
 const KeeperCatchupDigestTurnsSchema = object({

--- a/dashboard/src/api/schemas/keeper-chat-history.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.ts
@@ -288,9 +288,11 @@ export const KeeperChatHistoryMessageSchema = object({
   // RFC-0235 P3: server-parsed rich chat blocks. Carried on history rows so
   // reloads preserve the structured render instead of re-parsing plain text.
   blocks: optional(array(KeeperChatBlockSchema)),
-  // Row kind (keeper_chat_store.ml :838-841). `transport_failure` is minted
-  // so a reload can tell a failed request apart from a real keeper reply;
-  // open string() per the same deploy-window rationale as `role`.
+  // Row kind (keeper_chat_store.ml Row_kind). `transport_failure` /
+  // `agent_failure` (masc#24314 / oas#2585) are minted so a reload can
+  // tell a failed request apart from a real keeper reply, and tell a
+  // wire-level failure apart from a typed OAS agent failure; open
+  // string() per the same deploy-window rationale as `role`.
   kind: optional(string()),
   // K1e read model: backend-owned provenance for what a history row can prove
   // about the stream/turn lifecycle. Kept optional for deploy windows and

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -195,6 +195,34 @@ describe('ChatTranscript', () => {
     expect(container.querySelector('[data-chat-blocks]')).toBeNull()
   })
 
+  it('renders an agent_failure row with a distinct badge from transport_failure (masc#24314 / oas#2585)', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          entry({
+            id: 'err-agent-1',
+            role: 'assistant',
+            source: 'direct_assistant',
+            label: 'sangsu',
+            text: '응답을 만들지 못했습니다',
+            rawText: '응답을 만들지 못했습니다',
+            delivery: 'agent_failure',
+            error: 'Keeper request failed: ToolFailureRecoveryFailed',
+          }),
+        ]}
+        emptyText="empty"
+        variant="messenger"
+      />`,
+      container,
+    )
+
+    const card = container.querySelector('[data-chat-failure-card]')
+    expect(card).not.toBeNull()
+    expect(card?.getAttribute('data-chat-failure-kind')).toBe('agent_failure')
+    expect(card?.textContent).toContain('에이전트 실패')
+    expect(card?.textContent).not.toContain('전송 실패')
+  })
+
   it('keeps generic client errors distinct from durable transport failures', () => {
     render(
       html`<${ChatTranscript}

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -422,6 +422,8 @@ function deliveryLabel(entry: KeeperConversationEntry): string {
       return 'error'
     case 'transport_failure':
       return 'transport failure'
+    case 'agent_failure':
+      return 'agent failure'
     case 'interrupted':
       return 'interrupted'
     case 'history':
@@ -2142,27 +2144,38 @@ function renderStructuredFailureText(text: string): Array<string | VNode> {
   })
 }
 
-/** Typed failure card for kind=transport_failure rows.
+/** Typed failure card for kind=transport_failure / kind=agent_failure rows
+ * (masc#24314 / oas#2585).
  *
  * The discriminator is the writer-declared row kind (normalized to the closed
- * delivery='transport_failure' variant), never a string match on the content.
- * The raw error text is diagnostic payload, shown collapsed. The reassurance line states
- * what the backend guarantees: a Transport_failure row is watermark-neutral
- * (keeper_chat_store), so the user message it failed to answer stays pending
- * for the keeper's next turn. */
-function ChatFailureCard({ diagnostic }: { diagnostic: string }) {
+ * delivery='transport_failure' | 'agent_failure' variant), never a string
+ * match on the content. The raw error text is diagnostic payload, shown
+ * collapsed. The reassurance line states what the backend guarantees: both
+ * row kinds are watermark-neutral (keeper_chat_store), so the user message
+ * it failed to answer stays pending for the keeper's next turn regardless of
+ * which kind caused it — only the badge distinguishes wire-level transport
+ * failures from the agent's own execution failures. */
+function ChatFailureCard({
+  diagnostic,
+  kind,
+}: {
+  diagnostic: string
+  kind: 'transport_failure' | 'agent_failure'
+}) {
   const [detailOpen, setDetailOpen] = useState(false)
+  const badgeLabel = kind === 'agent_failure' ? '에이전트 실패' : '전송 실패'
   return html`
     <div
       class="flex flex-col gap-2 rounded-[var(--r-1)] border border-[var(--color-status-error)]/40 bg-[var(--color-bg-surface)] p-3"
       data-chat-structured-error
       data-chat-failure-card
+      data-chat-failure-kind=${kind}
     >
       <div class="flex flex-wrap items-center gap-2">
         <span
           class="inline-flex items-center rounded-[var(--r-0)] bg-[var(--color-status-error)]/15 px-2 py-0.5 text-2xs font-bold uppercase tracking-[var(--track-caps)] text-[var(--color-status-error)]"
         >
-          응답 실패
+          ${badgeLabel}
         </span>
         <span class="text-sm font-semibold text-[var(--color-fg-primary)]">
           이 턴은 응답을 만들지 못했습니다
@@ -2438,13 +2451,15 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
   const liveLabel = liveMessageLabel(entry)
   const messageText = liveLabel ? '' : entry.text || '(empty reply)'
   const messageLength = messageText.length
-  // keeper-state.ts maps the writer-declared kind=transport_failure to its own
-  // closed delivery variant; only that durable row renders the typed
-  // failure card, because its reassurance ("보낸 메시지는 사라지지 않았습니다")
-  // holds only when the keeper never answered. interrupted/timeout keep any
-  // partial text and render as prose plus the diagnostic banner below.
+  // keeper-state.ts maps the writer-declared kind=transport_failure /
+  // kind=agent_failure (masc#24314 / oas#2585) to their own closed delivery
+  // variants; only those durable rows render the typed failure card,
+  // because its reassurance ("보낸 메시지는 사라지지 않았습니다") holds only
+  // when the keeper never answered. interrupted/timeout keep any partial
+  // text and render as prose plus the diagnostic banner below.
   const isFailureMessage =
-    entry.delivery === 'transport_failure' && !!entry.error?.trim()
+    (entry.delivery === 'transport_failure' || entry.delivery === 'agent_failure')
+    && !!entry.error?.trim()
   const richTextRole = entry.role === 'assistant' || entry.role === 'system'
   const hasRealText = !liveLabel && !!entry.text && entry.text.trim().length > 0
   const traceOwnsIntermediateText = !hasRealText && (entry.traceSteps?.length ?? 0) > 0
@@ -2692,6 +2707,7 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
             ${isFailureMessage
               ? html`<${ChatFailureCard}
                   diagnostic=${entry.error?.trim() ? entry.error : messageText}
+                  kind=${entry.delivery === 'agent_failure' ? 'agent_failure' : 'transport_failure'}
                 />`
               : hasEffectiveBlocks
               ? html`<${ChatBlocks} blocks=${effectiveBlocks} fallbackText=${entry.text} />`

--- a/dashboard/src/components/keeper-catchup-digest-card.test.ts
+++ b/dashboard/src/components/keeper-catchup-digest-card.test.ts
@@ -89,6 +89,33 @@ describe('KeeperCatchupDigestCard', () => {
     expect(screen.getByTestId('keeper-catchup-judge-run')).toHaveTextContent('판정 실행')
   })
 
+  it('counts agent_failures toward activity and renders a distinct chip from transport failures (masc#24314 / oas#2585)', () => {
+    const digest = makeDigest({
+      chat: {
+        new_messages: 2,
+        first_new_ts: 1_777_000_030,
+        transport_failures: 1,
+        agent_failures: 2,
+      },
+    })
+
+    // Base total (15) + 1 transport_failures + 2 agent_failures.
+    expect(keeperCatchupDigestActivityCount(digest)).toBe(18)
+
+    render(html`<${KeeperCatchupDigestCard} digest=${digest} />`)
+
+    expect(screen.getByText('전송 실패 1')).toBeInTheDocument()
+    expect(screen.getByText('에이전트 실패 2')).toBeInTheDocument()
+  })
+
+  it('treats an absent agent_failures field as 0 (dashboard-ahead-of-backend rollout)', () => {
+    const digest = makeDigest()
+
+    expect(keeperCatchupDigestActivityCount(digest)).toBe(15)
+    render(html`<${KeeperCatchupDigestCard} digest=${digest} />`)
+    expect(screen.queryByText(/에이전트 실패/)).not.toBeInTheDocument()
+  })
+
   it('starts a manual catch-up judgment and links to the Fusion run', async () => {
     const digest = makeDigest()
     runKeeperCatchupJudgmentMock.mockResolvedValue({

--- a/dashboard/src/components/keeper-catchup-digest-card.ts
+++ b/dashboard/src/components/keeper-catchup-digest-card.ts
@@ -16,6 +16,8 @@ export function keeperCatchupDigestActivityCount(digest: KeeperCatchupDigest): n
   return (
     chat.new_messages +
     chat.transport_failures +
+    // masc#24314 / oas#2585: optional during rollout; absent reads as 0.
+    (chat.agent_failures ?? 0) +
     turns.completed +
     turns.failed +
     turns.crashes +
@@ -105,6 +107,9 @@ function digestChips(digest: KeeperCatchupDigest): DigestChip[] {
   if (turns.failed > 0) chips.push({ key: 'turns-failed', text: `턴 실패 ${turns.failed}`, tone: 'warn' })
   if (turns.crashes > 0) chips.push({ key: 'turns-crashes', text: `크래시 ${turns.crashes}`, tone: 'warn' })
   if (chat.transport_failures > 0) chips.push({ key: 'transport', text: `전송 실패 ${chat.transport_failures}`, tone: 'warn' })
+  // masc#24314 / oas#2585: counted separately from transport_failures.
+  const agentFailures = chat.agent_failures ?? 0
+  if (agentFailures > 0) chips.push({ key: 'agent', text: `에이전트 실패 ${agentFailures}`, tone: 'warn' })
   return chips
 }
 

--- a/dashboard/src/components/keeper-turn-inspector.test.ts
+++ b/dashboard/src/components/keeper-turn-inspector.test.ts
@@ -889,6 +889,44 @@ describe('KeeperTurnInspector v2 drawer', () => {
     expect(container.querySelector('[data-testid="turn-transcript-assistant-absent"]')).toBeTruthy()
   })
 
+  it('labels a transport_failure row distinctly from an agent_failure row (masc#24314 / oas#2585)', async () => {
+    fetchKeeperTurnRecordsMock.mockResolvedValue(turnRecordsWithMemoryOs())
+    fetchKeeperTurnTranscriptMock.mockResolvedValue({
+      keeper: 'albini',
+      turn_ref: 'trace-active#42',
+      found: true,
+      source: 'keeper_chat_store',
+      user: [{ role: 'user', content: 'deploy the staging build', ts: 1_781_587_540 }],
+      assistant: [
+        {
+          role: 'assistant',
+          content: 'Keeper request failed: ToolFailureRecoveryFailed',
+          ts: 1_781_587_560,
+          kind: 'agent_failure',
+        },
+      ],
+    })
+
+    const { container } = render(html`<${KeeperTurnInspector} keeperName="albini" />`)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('T42')
+    })
+
+    fireEvent.click(container.querySelector('.kti-turn-summary')!)
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="turn-detail-drawer"]')).toBeTruthy()
+    })
+
+    fireEvent.click(container.querySelector('[data-testid="turn-tab-messages"]')!)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="turn-transcript-assistant-failure"]')?.textContent).toBe(
+        'agent failure',
+      )
+    })
+  })
+
   it('warns when the timing source fails while keeping turn records visible', async () => {
     fetchKeeperTurnRecordsMock.mockResolvedValue(turnRecordsWithMemoryOs())
     fetchKeeperToolCallsMock.mockRejectedValue(new Error('tool log unavailable'))

--- a/dashboard/src/components/keeper-turn-inspector.ts
+++ b/dashboard/src/components/keeper-turn-inspector.ts
@@ -877,8 +877,9 @@ function OperatorLine({ line, seq }: { line: TurnTranscriptLine | null; seq: num
   `
 }
 
-// One keeper response line. A transport-failure row is labelled distinctly and
-// never presented as the keeper's own utterance.
+// One keeper response line. A transport-failure or agent-failure row
+// (masc#24314 / oas#2585) is labelled distinctly by its writer-declared
+// cause and never presented as the keeper's own utterance.
 function KeeperLine({
   keeperName,
   line,
@@ -888,14 +889,17 @@ function KeeperLine({
   line: TurnTranscriptLine | null
   seq: number
 }) {
-  const isFailure = line?.kind === 'transport_failure'
+  const failureLabel =
+    line?.kind === 'transport_failure' ? 'transport failure'
+    : line?.kind === 'agent_failure' ? 'agent failure'
+    : null
   return html`
     <div class="kti-msg">
       <div class="kti-msg-h">
         <span class="kti-msg-role assistant">assistant</span>
         <span class="who">${keeperName}</span>
-        ${isFailure
-          ? html`<span class="pill bad" data-testid="turn-transcript-assistant-failure">transport failure</span>`
+        ${failureLabel
+          ? html`<span class="pill bad" data-testid="turn-transcript-assistant-failure">${failureLabel}</span>`
           : null}
         <span class="seq">#${seq}</span>
       </div>

--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -610,6 +610,20 @@ describe('thread history merge & persistence', () => {
     expect(ok[0]?.delivery).toBe('history')
   })
 
+  it('marks an agent_failure row as error delivery, not a saved reply (masc#24314 / oas#2585)', () => {
+    const entries = chatHistoryEntriesFromRest('echo', [
+      { role: 'user', content: 'do it', ts: 1_780_000_000 },
+      {
+        role: 'assistant',
+        content: 'Keeper request failed: ToolFailureRecoveryFailed',
+        ts: 1_780_000_000,
+        kind: 'agent_failure',
+      },
+    ])
+    expect(entries[1]?.delivery).toBe('agent_failure')
+    expect(entries[1]?.error).toBe('Keeper request failed: ToolFailureRecoveryFailed')
+  })
+
   it('prefers server-provided rich blocks for assistant rows', () => {
     const entries = chatHistoryEntriesFromRest('echo', [
       { role: 'assistant', content: 'hello', ts: 1_780_000_000, blocks: [{ t: 'image', src: 'https://x.com/a.png' }] },

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -877,13 +877,18 @@ function normalizeHistoryEntry(
   const speakerAuthority = asString(raw.speaker_authority) ?? null
   // RFC-0233 §7: asString rejects malformed join keys instead of repairing them.
   const turnRef = asString(raw.turn_ref) ?? null
-  // keeper_chat_store mints kind=transport_failure (row content is the
-  // "Keeper request failed: ..." text) so a reload can tell a failed request
-  // apart from a real reply. Preserve that writer-declared provenance as its
-  // own delivery variant: generic client/tool errors have different watermark
-  // semantics and must not inherit the durable-row reassurance.
+  // keeper_chat_store mints kind=transport_failure / kind=agent_failure (row
+  // content is the "Keeper request failed: ..." text) so a reload can tell a
+  // failed request apart from a real reply, and (masc#24314 / oas#2585) tell
+  // a wire-level transport failure apart from a typed OAS agent failure.
+  // Preserve that writer-declared provenance as its own delivery variant:
+  // generic client/tool errors have different watermark semantics and must
+  // not inherit the durable-row reassurance.
+  const rawKind = asString(raw.kind)
   const delivery: KeeperConversationDelivery =
-    asString(raw.kind) === 'transport_failure' ? 'transport_failure' : 'history'
+    rawKind === 'transport_failure' ? 'transport_failure'
+    : rawKind === 'agent_failure' ? 'agent_failure'
+    : 'history'
   const serverBlocks = normalizeBlocks(raw.blocks, role)
   const blocks = serverBlocks
     ?? ((role === 'assistant' || role === 'system') && text
@@ -907,7 +912,7 @@ function normalizeHistoryEntry(
     timestamp,
     turnRef,
     delivery,
-    error: delivery === 'transport_failure' ? rawText : null,
+    error: delivery === 'transport_failure' || delivery === 'agent_failure' ? rawText : null,
     streamState: null,
     streamContract,
     details: null,
@@ -1476,7 +1481,8 @@ interface RestChatHistoryMessage {
     mime_type: string
     data: string
   }>
-  // Row kind; 'transport_failure' distinguishes a persisted failed request.
+  // Row kind; 'transport_failure' / 'agent_failure' distinguish a persisted
+  // failed request by cause (masc#24314 / oas#2585).
   kind?: string
   // RFC-0235 P3: backend-parsed rich chat blocks. When present the dashboard
   // prefers them over its local parser.

--- a/dashboard/src/lib/keeper-delivery.test.ts
+++ b/dashboard/src/lib/keeper-delivery.test.ts
@@ -22,14 +22,15 @@ const EXPECTED: Record<KeeperConversationDelivery, 'in-flight' | 'failed' | 'oth
   cancelled: 'other',
   error: 'failed',
   transport_failure: 'failed',
+  agent_failure: 'failed',
   interrupted: 'failed',
 }
 
 describe('keeper-delivery classifiers', () => {
   const all = Object.keys(EXPECTED) as KeeperConversationDelivery[]
 
-  it('covers all 11 delivery variants', () => {
-    expect(all).toHaveLength(11)
+  it('covers all 12 delivery variants', () => {
+    expect(all).toHaveLength(12)
   })
 
   it('classifies every variant into exactly one bucket', () => {
@@ -52,8 +53,9 @@ describe('keeper-delivery classifiers', () => {
     expect([...IN_FLIGHT_DELIVERY].sort()).toEqual(['queued', 'sending', 'streaming'])
   })
 
-  it('classifies durable transport failure separately from generic errors', () => {
+  it('classifies durable transport/agent failure separately from generic errors', () => {
     expect([...FAILED_DELIVERY].sort()).toEqual([
+      'agent_failure',
       'error',
       'interrupted',
       'timeout',

--- a/dashboard/src/lib/keeper-delivery.ts
+++ b/dashboard/src/lib/keeper-delivery.ts
@@ -22,6 +22,7 @@ export const IN_FLIGHT_DELIVERY = [
 export const FAILED_DELIVERY = [
   'error',
   'transport_failure',
+  'agent_failure',
   'timeout',
   'interrupted',
 ] as const satisfies ReadonlyArray<KeeperConversationDelivery>

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -743,9 +743,15 @@ export type KeeperConversationDelivery =
   | 'cancelled'
   | 'error'
   // Durable keeper_chat_store row written when a request failed before the
-  // keeper produced an utterance. Unlike generic client/tool errors, this
-  // writer-declared state is watermark-neutral.
+  // keeper produced an utterance, caused by a wire-level (Api/Provider)
+  // error reaching the LLM backend. Unlike generic client/tool errors,
+  // this writer-declared state is watermark-neutral.
   | 'transport_failure'
+  // masc#24314 / oas#2585: the same watermark-neutral failure marker for
+  // every other cause — a typed OAS Agent error (e.g.
+  // ToolFailureRecoveryFailed), a turn with no visible reply, or an
+  // admission/validation rejection. Not a transport problem.
+  | 'agent_failure'
   // Stream ended without a terminal RUN_FINISHED / RUN_ERROR event —
   // the transport was cut mid-response, so the text may be incomplete.
   | 'interrupted'

--- a/docs/design/keeper-catchup-digest.md
+++ b/docs/design/keeper-catchup-digest.md
@@ -18,7 +18,7 @@ GET /api/v1/keepers/:name/digest?since_unix=<float>
   "keeper": "garnet",
   "since_unix": 1782976498.87,
   "generated_at_unix": 1783003000.1,
-  "chat": { "new_messages": 12, "first_new_ts": 1782976500.2, "transport_failures": 2 },
+  "chat": { "new_messages": 12, "first_new_ts": 1782976500.2, "transport_failures": 2, "agent_failures": 1 },
   "turns": { "completed": 34, "failed": 3, "crashes": 1 },
   "tasks": {
     "claimed": 2, "done": 1, "released": 1, "cancelled": 0,
@@ -50,7 +50,7 @@ GET /api/v1/keepers/:name/digest?since_unix=<float>
 
 | 카테고리 | 소스 | 필터 |
 |---|---|---|
-| chat | `Keeper_chat_store` (`.masc/keeper_chat/<name>.jsonl`, ts append-ordered) | `ts > since`; `Row_kind.Transport_failure`는 별도 카운트 |
+| chat | `Keeper_chat_store` (`.masc/keeper_chat/<name>.jsonl`, ts append-ordered) | `ts > since`; `Row_kind.Transport_failure`/`Row_kind.Agent_failure`는 각각 별도 카운트 (masc#24314 / oas#2585) |
 | turns.completed | keeper-local `turn-records/YYYY-MM/DD.jsonl` (day-partitioned) | day 파일 >= since 날짜만 open 후 `ts > since` |
 | turns.failed | activity-events `keeper.turn_failed` (actor/keeper_name match) | `ts_ms > since*1000` |
 | turns.crashes | keeper-local `crash-events/YYYY-MM/DD.jsonl` | `ts > since` |

--- a/lib/keeper/keeper_agent_error.ml
+++ b/lib/keeper/keeper_agent_error.ml
@@ -18,18 +18,98 @@ let sdk_error_kind_for_receipt err =
 
 (* masc#24314 / oas#2585: which side of the OAS <-> keeper boundary
    produced [err], for typed downstream failure display (e.g. keeper chat
-   Row_kind). [Transport_layer] is the wire-level Api/Provider failure
-   surface reaching the LLM backend; every other constructor is the
-   agent's own execution, config, or orchestration outcome — not evidence
-   of a transport-layer failure, even though today every [sdk_error] ends
-   up rendered through the same "Keeper request failed: ..." terminal
-   marker. *)
+   Row_kind). [Transport_layer] means the failure surfaced while actually
+   talking to (or being rejected by) the remote LLM backend over the
+   wire: connectivity, auth-to-connect, protocol drift, or a wire-level
+   service refusal (rate limit / overload / quota / 5xx). [Agent_layer]
+   means the failure is about the agent's own local state or authored
+   request content (missing host config, a malformed payload the agent
+   built, its own context-window bookkeeping) or its execution/config/
+   orchestration outcome generally — the wire itself is not at fault,
+   even though today every [sdk_error] ends up rendered through the same
+   "Keeper request failed: ..." terminal marker. *)
 type failure_origin =
   | Transport_layer
   | Agent_layer
 
+(* [Agent_sdk.Retry.api_error]: every arm named explicitly (no catch-all)
+   so a new oas variant forces a compile-time decision here. *)
+let api_error_failure_origin : Agent_sdk.Retry.api_error -> failure_origin = function
+  | Agent_sdk.Retry.RateLimited _ ->
+    Transport_layer (* wire-level service rate-limit signal *)
+  | Agent_sdk.Retry.Overloaded _ ->
+    Transport_layer (* wire-level service overload signal *)
+  | Agent_sdk.Retry.ServerError _ -> Transport_layer (* HTTP 5xx from the provider *)
+  | Agent_sdk.Retry.AuthError _ ->
+    Transport_layer (* provider rejected credentials over the wire (401) *)
+  | Agent_sdk.Retry.AuthorizationError _ ->
+    Transport_layer (* provider refused authorization over the wire (403) *)
+  | Agent_sdk.Retry.PaymentRequired _ ->
+    Transport_layer (* external service refusal: billing/quota (402) *)
+  | Agent_sdk.Retry.InvalidRequest _ ->
+    Agent_layer (* agent-authored malformed payload, not a wire fault *)
+  | Agent_sdk.Retry.NotFound _ ->
+    Transport_layer
+    (* a definitive wire rejection reached us (provider says the
+       resource doesn't exist), same bucket as AuthError/
+       AuthorizationError -- Keeper_runtime_failure_route.route_of_api_error
+       groups this with [rotate Model_unavailable], distinct from
+       [judge Deterministic_request]/[Context_overflow]'s agent-local
+       arms *)
+  | Agent_sdk.Retry.ContextOverflow _ ->
+    Agent_layer (* agent's own context-window management *)
+  | Agent_sdk.Retry.NetworkError _ ->
+    Transport_layer (* connection-level failure reaching the provider *)
+  | Agent_sdk.Retry.Timeout _ -> Transport_layer (* wire-level request timeout *)
+;;
+
+(* [Llm_provider.Error.provider_error]: every arm named explicitly (no
+   catch-all) so a new oas variant forces a compile-time decision here. *)
+let provider_error_failure_origin : Llm_provider.Error.provider_error -> failure_origin = function
+  | Llm_provider.Error.MissingApiKey _ ->
+    Agent_layer
+    (* host never sent a request: no credential configured, mirrors
+       Config.MissingEnvVar *)
+  | Llm_provider.Error.InvalidConfig _ -> Agent_layer (* host configuration problem *)
+  | Llm_provider.Error.ParseError _ ->
+    Transport_layer (* provider sent unparseable bytes over the wire *)
+  | Llm_provider.Error.UnknownVariant _ ->
+    Transport_layer (* protocol drift from the provider *)
+  | Llm_provider.Error.ProviderUnavailable _ ->
+    Transport_layer (* remote service unreachable *)
+  | Llm_provider.Error.RateLimit _ ->
+    Transport_layer (* wire-level service rate-limit signal *)
+  | Llm_provider.Error.HardQuota _ ->
+    Transport_layer (* wire-level service quota refusal *)
+  | Llm_provider.Error.CapacityExhausted _ ->
+    Transport_layer (* wire-level service capacity refusal *)
+  | Llm_provider.Error.AuthError _ ->
+    Transport_layer (* provider rejected credentials over the wire *)
+  | Llm_provider.Error.AuthorizationError _ ->
+    Transport_layer (* provider refused authorization over the wire *)
+  | Llm_provider.Error.ServerError _ -> Transport_layer (* HTTP 5xx from the provider *)
+  | Llm_provider.Error.NetworkError _ ->
+    Transport_layer (* connection-level failure reaching the provider *)
+  | Llm_provider.Error.Timeout _ -> Transport_layer (* wire-level request timeout *)
+  | Llm_provider.Error.InvalidRequest _ ->
+    Agent_layer (* agent-authored malformed payload, not a wire fault *)
+  | Llm_provider.Error.NotFound _ ->
+    Transport_layer
+    (* a definitive wire rejection reached us (provider says the
+       resource doesn't exist), same bucket as AuthError/
+       AuthorizationError -- Keeper_runtime_failure_route.route_of_provider_error
+       groups this with [rotate Model_unavailable], distinct from
+       [judge Deterministic_request]'s agent-local arm *)
+  | Llm_provider.Error.ProviderTerminal _ ->
+    Transport_layer
+    (* provider-issued terminal rejection over the wire (e.g. account
+       suspended) -- still a wire response, just non-retryable; same
+       bucket as AuthError/HardQuota's "service refusal" *)
+;;
+
 let failure_origin_of_sdk_error = function
-  | Agent_sdk.Error.Api _ | Agent_sdk.Error.Provider _ -> Transport_layer
+  | Agent_sdk.Error.Api err -> api_error_failure_origin err
+  | Agent_sdk.Error.Provider err -> provider_error_failure_origin err
   | Agent_sdk.Error.Agent _
   | Agent_sdk.Error.Mcp _
   | Agent_sdk.Error.Config _

--- a/lib/keeper/keeper_agent_error.ml
+++ b/lib/keeper/keeper_agent_error.ml
@@ -16,6 +16,29 @@ let sdk_error_kind_for_receipt err =
   Keeper_execution_receipt.error_kind_of_string (sdk_error_kind err)
 ;;
 
+(* masc#24314 / oas#2585: which side of the OAS <-> keeper boundary
+   produced [err], for typed downstream failure display (e.g. keeper chat
+   Row_kind). [Transport_layer] is the wire-level Api/Provider failure
+   surface reaching the LLM backend; every other constructor is the
+   agent's own execution, config, or orchestration outcome — not evidence
+   of a transport-layer failure, even though today every [sdk_error] ends
+   up rendered through the same "Keeper request failed: ..." terminal
+   marker. *)
+type failure_origin =
+  | Transport_layer
+  | Agent_layer
+
+let failure_origin_of_sdk_error = function
+  | Agent_sdk.Error.Api _ | Agent_sdk.Error.Provider _ -> Transport_layer
+  | Agent_sdk.Error.Agent _
+  | Agent_sdk.Error.Mcp _
+  | Agent_sdk.Error.Config _
+  | Agent_sdk.Error.Serialization _
+  | Agent_sdk.Error.Io _
+  | Agent_sdk.Error.Orchestration _
+  | Agent_sdk.Error.Internal _ -> Agent_layer
+;;
+
 let network_error_kind_user_label = function
   | Llm_provider.Http_client.Connection_refused -> "connection refused"
   | Llm_provider.Http_client.Dns_failure -> "DNS lookup failed"

--- a/lib/keeper/keeper_agent_error.mli
+++ b/lib/keeper/keeper_agent_error.mli
@@ -8,6 +8,17 @@ val sdk_error_kind_for_receipt
   :  Agent_sdk.Error.sdk_error
   -> Keeper_execution_receipt.error_kind
 
+(** Which side of the OAS boundary [err] originates from, for typed
+    downstream classification (e.g. keeper chat Row_kind). [Transport_layer]
+    is the wire-level Api/Provider failure surface reaching the LLM
+    backend; every other constructor is the agent's own execution, config,
+    or orchestration outcome — not a transport-layer failure. *)
+type failure_origin =
+  | Transport_layer
+  | Agent_layer
+
+val failure_origin_of_sdk_error : Agent_sdk.Error.sdk_error -> failure_origin
+
 (** User-facing SDK error message for keeper chat/tool surfaces.
     Keeps low-level SDK prefixes out of persisted keeper replies while
     telemetry and terminal reason codes continue to use structured errors. *)

--- a/lib/keeper/keeper_agent_error.mli
+++ b/lib/keeper/keeper_agent_error.mli
@@ -10,9 +10,16 @@ val sdk_error_kind_for_receipt
 
 (** Which side of the OAS boundary [err] originates from, for typed
     downstream classification (e.g. keeper chat Row_kind). [Transport_layer]
-    is the wire-level Api/Provider failure surface reaching the LLM
-    backend; every other constructor is the agent's own execution, config,
-    or orchestration outcome — not a transport-layer failure. *)
+    means the failure surfaced while actually talking to (or being
+    rejected by) the remote LLM backend over the wire: connectivity,
+    auth-to-connect, protocol drift, or a wire-level service refusal
+    (rate limit / overload / quota / 5xx). Within [Api] and [Provider],
+    nested payloads are classified individually — e.g. a missing local
+    credential ([Provider (MissingApiKey _)]) or an agent-authored
+    malformed request ([Api (InvalidRequest _)]) is [Agent_layer], not
+    [Transport_layer], because no wire fault occurred. Every other
+    top-level constructor is the agent's own execution, config, or
+    orchestration outcome — not a transport-layer failure. *)
 type failure_origin =
   | Transport_layer
   | Agent_layer

--- a/lib/keeper/keeper_chat_delivery_journal.ml
+++ b/lib/keeper/keeper_chat_delivery_journal.ml
@@ -24,6 +24,7 @@ type terminal_delivery =
       ; turn_ref : Ids.Turn_ref.t option
       }
   | Transport_failure of { content : string }
+  | Agent_failure of { content : string }
   | No_assistant_reply of { reason : no_assistant_reply_reason }
 
 and no_assistant_reply_reason =
@@ -119,9 +120,11 @@ let error_to_string = function
 let validate_terminal terminal =
   match terminal.ok, terminal.delivery with
   | true, (Assistant_reply _ | No_assistant_reply _) -> Ok ()
-  | false, Transport_failure _ -> Ok ()
+  | false, (Transport_failure _ | Agent_failure _) -> Ok ()
   | true, Transport_failure _ ->
     Error (Invalid_terminal "successful status cannot carry a transport failure")
+  | true, Agent_failure _ ->
+    Error (Invalid_terminal "successful status cannot carry an agent failure")
   | false, (Assistant_reply _ | No_assistant_reply _) ->
     Error (Invalid_terminal "failed status cannot carry a successful delivery")
 ;;
@@ -254,6 +257,9 @@ let terminal_delivery_to_yojson = function
   | Transport_failure { content } ->
     `Assoc
       [ "kind", `String "transport_failure"; "content", `String content ]
+  | Agent_failure { content } ->
+    `Assoc
+      [ "kind", `String "agent_failure"; "content", `String content ]
   | No_assistant_reply { reason = Continuation_checkpoint } ->
     `Assoc
       [ "kind", `String "no_assistant_reply"
@@ -553,6 +559,15 @@ let terminal_delivery_of_yojson = function
        in
        let* content = string "content" fields in
        Ok (Transport_failure { content })
+     | "agent_failure" ->
+       let* () =
+         validate_fields
+           ~context:"agent failure terminal delivery"
+           ~expected:[ "kind"; "content" ]
+           fields
+       in
+       let* content = string "content" fields in
+       Ok (Agent_failure { content })
      | "no_assistant_reply" ->
        let* reason = string "reason" fields in
        (match reason with
@@ -979,6 +994,24 @@ let append_terminal ~base_path journal ~user_row_id terminal =
       ~surface:journal.payload.surface
       ?conversation_id:journal.payload.conversation_id
       ~assistant_kind:Keeper_chat_store.Row_kind.Transport_failure
+      ~stream_lifecycle:
+        [ Keeper_chat_store.Run_started
+        ; Keeper_chat_store.Text_message_start
+        ; Keeper_chat_store.Text_message_end
+        ; Keeper_chat_store.Run_error
+        ]
+      ()
+    |> Result.map row_id_of_append_once
+    |> Result.map_error (fun detail -> Transcript_error detail)
+  | Agent_failure { content } ->
+    Keeper_chat_store.append_assistant_message_once
+      ~base_dir:base_path
+      ~keeper_name:journal.payload.keeper_name
+      ~delivery_key:journal.delivery_key
+      ~content
+      ~surface:journal.payload.surface
+      ?conversation_id:journal.payload.conversation_id
+      ~assistant_kind:Keeper_chat_store.Row_kind.Agent_failure
       ~stream_lifecycle:
         [ Keeper_chat_store.Run_started
         ; Keeper_chat_store.Text_message_start

--- a/lib/keeper/keeper_chat_delivery_journal.mli
+++ b/lib/keeper/keeper_chat_delivery_journal.mli
@@ -30,6 +30,11 @@ type terminal_delivery =
       ; turn_ref : Ids.Turn_ref.t option
       }
   | Transport_failure of { content : string }
+      (** Wire-level (Api/Provider) error reaching the LLM backend. *)
+  | Agent_failure of { content : string }
+      (** masc#24314 / oas#2585: every other terminal failure — a typed OAS
+          Agent error, a turn with no visible reply, or an admission/
+          validation rejection — none of which are transport problems. *)
   | No_assistant_reply of { reason : no_assistant_reply_reason }
 
 and no_assistant_reply_reason =

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -90,30 +90,40 @@ end
 (* What an assistant line *is*, declared by the writer at append time.
    [Utterance] is something the keeper actually said; [Transport_failure]
    is the server persisting a failed request terminal ("Keeper request
-   failed: ...") so the operator still sees the failure after a reload.
-   Readers branch on the type: a transport failure is not a self reply —
-   it does not advance the lane watermark, so the user line it failed to
-   answer stays pending until the keeper's next real utterance — and it
-   is never quoted back as the keeper's own words. On disk the field is
-   ["kind"], absent for utterances so pre-existing rows read unchanged. *)
+   failed: ...") caused by a wire-level (Api/Provider) error reaching the
+   LLM backend; [Agent_failure] is the same terminal marker for every
+   other cause — a typed OAS Agent error (e.g. ToolFailureRecoveryFailed),
+   a turn that completed with no visible reply, or an admission/validation
+   rejection that never reached the runtime. Readers branch on the type
+   only to decide "is this a self reply" — both non-utterance kinds are
+   not: neither advances the lane watermark, so the user line either
+   failed to answer stays pending until the keeper's next real utterance,
+   and neither is ever quoted back as the keeper's own words. On disk the
+   field is ["kind"], absent for utterances so pre-existing rows read
+   unchanged. *)
 module Row_kind = struct
   type t =
     | Utterance
     | Transport_failure
+    | Agent_failure
 
   let to_label = function
     | Utterance -> "utterance"
     | Transport_failure -> "transport_failure"
+    | Agent_failure -> "agent_failure"
 
   let of_label = function
     | "utterance" -> Some Utterance
     | "transport_failure" -> Some Transport_failure
+    | "agent_failure" -> Some Agent_failure
     | _ -> None
 
   let equal a b =
     match a, b with
-    | Utterance, Utterance | Transport_failure, Transport_failure -> true
-    | (Utterance | Transport_failure), _ -> false
+    | Utterance, Utterance
+    | Transport_failure, Transport_failure
+    | Agent_failure, Agent_failure -> true
+    | (Utterance | Transport_failure | Agent_failure), _ -> false
 end
 
 type stream_lifecycle_event =
@@ -580,7 +590,7 @@ let encode_line ~(role : Role.t) ~content ~ts ?message_id ?attachments ?tool_cal
   let kind_field =
     match kind with
     | Row_kind.Utterance -> []
-    | Row_kind.Transport_failure ->
+    | Row_kind.Transport_failure | Row_kind.Agent_failure ->
         [ ("kind", `String (Row_kind.to_label kind)) ]
   in
   let all_fields =
@@ -815,7 +825,8 @@ let append_turn ~base_dir ~keeper_name ~(user_content : string)
    propagate it. The failure is still counted + warn-logged here so callers that
    use the unit wrapper below keep the existing swallow-and-count telemetry. *)
 let append_assistant_message_result ~base_dir ~keeper_name ~(content : string)
-    ?surface ?conversation_id ?audio ?blocks ?turn_ref ?stream_lifecycle () :
+    ?surface ?conversation_id ?audio ?blocks ?(assistant_kind = Row_kind.Utterance)
+    ?turn_ref ?stream_lifecycle () :
     (unit, string) result =
   try
     ensure_dir_once ~base_dir;
@@ -827,7 +838,7 @@ let append_assistant_message_result ~base_dir ~keeper_name ~(content : string)
     let ts = Time_compat.now () in
     let line =
       encode_line ~role:Role.Assistant ~content ~ts ?surface ?conversation_id
-        ?audio ?blocks ?turn_ref ?stream_lifecycle ()
+        ?audio ?blocks ~kind:assistant_kind ?turn_ref ?stream_lifecycle ()
     in
     append_chat_payload_durable path (line ^ "\n");
     Ok ()
@@ -1535,7 +1546,7 @@ let to_json_array ?base_dir ?trace_block_by_turn_ref
                  failure apart from keeper speech. *)
               @ (match m.kind with
                  | Row_kind.Utterance -> []
-                 | Row_kind.Transport_failure ->
+                 | Row_kind.Transport_failure | Row_kind.Agent_failure ->
                      [ ("kind", `String (Row_kind.to_label m.kind)) ])
               @ opt_string_field "tool_call_id" m.tool_call_id
               @ opt_string_field "tool_call_name" m.tool_call_name
@@ -1624,7 +1635,7 @@ let transcript_line_to_json (m : chat_message) : Yojson.Safe.t =
          back as the keeper's own words. *)
     @ (match m.kind with
        | Row_kind.Utterance -> []
-       | Row_kind.Transport_failure ->
+       | Row_kind.Transport_failure | Row_kind.Agent_failure ->
            [ ("kind", `String (Row_kind.to_label m.kind)) ]))
 
 let turn_transcript_to_json ~keeper ~turn_ref (t : turn_transcript) :

--- a/lib/keeper/keeper_chat_store.mli
+++ b/lib/keeper/keeper_chat_store.mli
@@ -54,17 +54,23 @@ end
 (** What an assistant line {e is}, declared by the writer at append.
     [Utterance] is something the keeper actually said.
     [Transport_failure] is the server persisting a failed request
-    terminal (["Keeper request failed: ..."]) so the operator still sees
-    the failure after a reload — it is {e not} a self reply: it does not
-    advance the lane watermark, so the user line it failed to answer
-    stays pending until the keeper's next real utterance, and
-    observation never quotes it back as the keeper's own words.
+    terminal (["Keeper request failed: ..."]) caused by a wire-level
+    (Api/Provider) error reaching the LLM backend. [Agent_failure] is the
+    same terminal marker for every other cause: a typed OAS Agent error
+    (e.g. ToolFailureRecoveryFailed), a turn that completed with no
+    visible reply, or an admission/validation rejection that never
+    reached the runtime — none of these are transport problems. Neither
+    is a self reply: neither advances the lane watermark, so the user
+    line it failed to answer stays pending until the keeper's next real
+    utterance, and observation never quotes either back as the keeper's
+    own words.
     Persisted as ["kind"]; the field is absent for utterances, so rows
     written before it existed read unchanged. *)
 module Row_kind : sig
   type t =
     | Utterance
     | Transport_failure
+    | Agent_failure
 
   val to_label : t -> string
   val of_label : string -> t option
@@ -208,7 +214,8 @@ type chat_message = {
     coordinate and is written on all lines of the turn; [external_message_id]
     belongs to the inbound user line only. [assistant_kind] declares what
     the assistant line is (default [Utterance]); the failed-request
-    persistence path passes [Transport_failure]. Failures are logged but
+    persistence path passes [Transport_failure] or [Agent_failure]
+    depending on where the failure originated. Failures are logged but
     never raised except for {!Eio.Cancel.Cancelled}. *)
 (** [append_turn_result] is {!append_turn} with an explicit persistence
     result. Queue consumers use it so a durable delivery receipt cannot become
@@ -254,7 +261,12 @@ val append_turn :
 (** [append_assistant_message_result] is {!append_assistant_message} that
     returns [Error msg] on a write failure instead of swallowing it (the failure
     is still counted + warn-logged). For callers whose own contract requires
-    surfacing a chat-append failure — e.g. {!Fusion_sink.emit}. *)
+    surfacing a chat-append failure — e.g. {!Fusion_sink.emit}.
+    [assistant_kind] declares what the line is (default [Utterance]);
+    masc#24314 / oas#2585: the connector-route failure persistence path
+    passes [Transport_failure] or [Agent_failure] here — before this field
+    existed, that path had no way to mark a failure line as anything but
+    an ordinary utterance. *)
 val append_assistant_message_result :
   base_dir:string ->
   keeper_name:string ->
@@ -263,6 +275,7 @@ val append_assistant_message_result :
   ?conversation_id:string ->
   ?audio:audio_clip ->
   ?blocks:chat_block list ->
+  ?assistant_kind:Row_kind.t ->
   ?turn_ref:Ids.Turn_ref.t ->
   ?stream_lifecycle:stream_lifecycle_event list ->
   unit ->
@@ -378,7 +391,7 @@ val to_json_array :
 (** A keeper turn's transcript, derived by an exact join on the persisted
     [turn_ref]. [user] holds the operator request line(s) that opened the
     turn; [assistant] holds the keeper response line(s) (utterance and
-    typed transport-failure markers). Tool rows are excluded — their full
+    typed transport/agent-failure markers). Tool rows are excluded — their full
     I/O is surfaced by the tool-call store keyed on [execution_id]. Both
     lists are empty when no persisted row carries the requested
     [turn_ref] (old rows, redacted, or outside the retained window). *)

--- a/lib/keeper/keeper_chat_store.mli
+++ b/lib/keeper/keeper_chat_store.mli
@@ -53,13 +53,25 @@ end
 
 (** What an assistant line {e is}, declared by the writer at append.
     [Utterance] is something the keeper actually said.
-    [Transport_failure] is the server persisting a failed request
-    terminal (["Keeper request failed: ..."]) caused by a wire-level
-    (Api/Provider) error reaching the LLM backend. [Agent_failure] is the
-    same terminal marker for every other cause: a typed OAS Agent error
-    (e.g. ToolFailureRecoveryFailed), a turn that completed with no
-    visible reply, or an admission/validation rejection that never
-    reached the runtime — none of these are transport problems. Neither
+
+    The failure terminal (["Keeper request failed: ..."]) splits into two
+    kinds by {e where} the turn stopped, not by whether an OAS call was
+    ever made:
+    - [Transport_failure]: the turn failed outside the agent's own
+      reasoning output. This covers a wire-level SDK error classified
+      {!Keeper_agent_error.Transport_layer}, a delivery-layer cutoff
+      before any OAS Agent error boundary was reached (worker timeout,
+      operator/system cancellation), a raw exception or admission
+      rejection with no typed OAS boundary reached at all, and any case
+      where no failure-origin classification is available — none of
+      these are the agent choosing an outcome.
+    - [Agent_failure]: an SDK error classified
+      {!Keeper_agent_error.Agent_layer} — a typed OAS Agent error (e.g.
+      ToolFailureRecoveryFailed), or another agent-side execution/config/
+      orchestration outcome.
+
+    A turn that completed with no visible reply is also persisted as a
+    failure terminal (kind depends on the same split above). Neither kind
     is a self reply: neither advances the lane watermark, so the user
     line it failed to answer stays pending until the keeper's next real
     utterance, and observation never quotes either back as the keeper's

--- a/lib/keeper/keeper_surface_read.ml
+++ b/lib/keeper/keeper_surface_read.ml
@@ -39,7 +39,7 @@ let message_json (m : Store.chat_message) : Yojson.Safe.t =
   let kind_fields =
     match m.kind with
     | Store.Row_kind.Utterance -> []
-    | Store.Row_kind.Transport_failure ->
+    | Store.Row_kind.Transport_failure | Store.Row_kind.Agent_failure ->
         [ ("kind", `String (Store.Row_kind.to_label m.kind)) ]
   in
   `Assoc

--- a/lib/keeper/keeper_tool_boundary.ml
+++ b/lib/keeper/keeper_tool_boundary.ml
@@ -24,7 +24,3 @@ let to_tool_keeper_context (ctx : _ context) : _ Keeper_tool_surface.context =
 
 let dispatch ctx ~name ~args =
   Keeper_tool_surface.dispatch (to_tool_keeper_context ctx) ~name ~args
-
-let dispatch_stream ?on_text_delta ?on_event ctx ~name ~args =
-  Keeper_tool_surface.dispatch_stream ?on_text_delta ?on_event (to_tool_keeper_context ctx) ~name
-    ~args

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -730,6 +730,7 @@ let dispatch_stream
       ?continuation_channel
       ?on_admission_rejected
       ?on_admitted
+      ?on_run_failure_origin
       ctx
       ~name
       ~args
@@ -748,6 +749,7 @@ let dispatch_stream
               ?continuation_channel
               ?on_admission_rejected
               ?on_admitted
+              ?on_run_failure_origin
               ctx
               args))
   | _ -> None

--- a/lib/keeper/keeper_tool_surface.mli
+++ b/lib/keeper/keeper_tool_surface.mli
@@ -47,6 +47,7 @@ val dispatch_stream :
   ?continuation_channel:Keeper_continuation_channel.t ->
   ?on_admission_rejected:(Keeper_turn_admission.rejection -> unit) ->
   ?on_admitted:(unit -> (unit, string) result) ->
+  ?on_run_failure_origin:(Keeper_agent_error.failure_origin -> unit) ->
   _ context -> name:string -> args:Yojson.Safe.t -> tool_result option
 
 (** Non-blocking streaming dispatch for direct chat admission. The Keeper turn

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -858,6 +858,7 @@ let handle_keeper_msg_stream
       ?continuation_channel
       ?on_admission_rejected
       ?on_admitted
+      ?on_run_failure_origin
       ctx
       args
   : tool_result
@@ -876,6 +877,7 @@ let handle_keeper_msg_stream
         ?continuation_channel
         ?on_admission_rejected
         ?on_admitted
+        ?on_run_failure_origin
         ctx
         resolved_args
     in

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -591,6 +591,7 @@ let run_keeper_msg_turn_admitted
       ?on_event
       ?event_bus
       ?continuation_channel
+      ?on_run_failure_origin
       ctx
       args
   : tool_result
@@ -1136,6 +1137,9 @@ let run_keeper_msg_turn_admitted
             | Error err ->
               let e_str = Agent_sdk.Error.to_string err in
               let user_message = Keeper_agent_error.user_message_of_sdk_error err in
+              Option.iter
+                (fun notify -> notify (Keeper_agent_error.failure_origin_of_sdk_error err))
+                on_run_failure_origin;
               (try
                  let _ = Trajectory.finalize trajectory_acc
                    (Trajectory.Failed e_str) in
@@ -1339,6 +1343,7 @@ let handle_keeper_msg
       ?continuation_channel
       ?on_admission_rejected
       ?on_admitted
+      ?on_run_failure_origin
       ctx
       args
   : tool_result
@@ -1357,6 +1362,7 @@ let handle_keeper_msg
       ?on_event
       ?event_bus
       ?continuation_channel
+      ?on_run_failure_origin
       ctx
       args
   else
@@ -1374,6 +1380,7 @@ let handle_keeper_msg
                  ?on_event
                  ?event_bus
                  ?continuation_channel
+                 ?on_run_failure_origin
                  ctx
                  args
              | Error detail ->
@@ -1385,6 +1392,7 @@ let handle_keeper_msg
               ?on_event
               ?event_bus
               ?continuation_channel
+              ?on_run_failure_origin
               ctx
               args)
     with
@@ -1427,6 +1435,7 @@ let handle_keeper_msg_if_free
       ?on_event
       ?event_bus
       ?continuation_channel
+      ?on_run_failure_origin
       ctx
       args
   =
@@ -1443,6 +1452,7 @@ let handle_keeper_msg_if_free
          ?on_event
          ?event_bus
          ?continuation_channel
+         ?on_run_failure_origin
          ctx
          args)
   else
@@ -1455,5 +1465,6 @@ let handle_keeper_msg_if_free
           ?on_event
           ?event_bus
           ?continuation_channel
+          ?on_run_failure_origin
           ctx
           args)

--- a/lib/keeper/keeper_turn.mli
+++ b/lib/keeper/keeper_turn.mli
@@ -141,26 +141,36 @@ val handle_keeper_msg :
   ?continuation_channel:Keeper_continuation_channel.t ->
   ?on_admission_rejected:(Keeper_turn_admission.rejection -> unit) ->
   ?on_admitted:(unit -> (unit, string) result) ->
+  ?on_run_failure_origin:(Keeper_agent_error.failure_origin -> unit) ->
   _ Keeper_types_profile.context -> Yojson.Safe.t -> tool_result
 (** [event_bus] is captured at the handler boundary and reused by the admitted
     turn body. Callers that omit it keep the legacy process/domain fallback, but
     async wrappers should pass an explicit value captured before submitting the
     background turn. [on_admission_rejected] receives the typed admission
     result before the legacy tool error is rendered; queue consumers use it to
-    keep a leased receipt pending without matching diagnostic strings. *)
+    keep a leased receipt pending without matching diagnostic strings.
+    [on_run_failure_origin] fires exactly when [Keeper_agent_run.run_turn]
+    itself returned [Error]: it receives the typed classification of that
+    [Agent_sdk.Error.sdk_error] before it collapses into the tool-result
+    message string, so a caller that persists the failure (masc#24314 /
+    oas#2585) can pick the right chat Row_kind instead of assuming every
+    keeper_msg failure is a transport problem. It does not fire for
+    admission rejections or input-validation errors, which never reach
+    [run_turn]. *)
 
 val handle_keeper_msg_if_free :
   ?on_text_delta:(string -> unit) ->
   ?on_event:(Agent_sdk.Types.sse_event -> unit) ->
   ?event_bus:Agent_sdk.Event_bus.t ->
   ?continuation_channel:Keeper_continuation_channel.t ->
+  ?on_run_failure_origin:(Keeper_agent_error.failure_origin -> unit) ->
   _ Keeper_types_profile.context ->
   Yojson.Safe.t ->
   [ `Ran of tool_result | `Busy of Keeper_turn_admission.rejection ]
 (** Non-blocking chat entrypoint for direct dashboard streaming. It runs the
     same admitted turn body as [handle_keeper_msg] only when the keeper slot is
     immediately available; otherwise it returns [`Busy] without parking behind
-    an in-flight turn. *)
+    an in-flight turn. See [handle_keeper_msg] for [on_run_failure_origin]. *)
 
 (** Stop a running keeper agent. *)
 val handle_keeper_down : _ Keeper_types_profile.context -> Yojson.Safe.t -> tool_result

--- a/lib/keeper/keeper_world_observation_message_scope.ml
+++ b/lib/keeper/keeper_world_observation_message_scope.ml
@@ -113,7 +113,8 @@ let recent_direct_conversation_of_messages
           }
       | Keeper_chat_store.Role.Assistant ->
         (match m.kind with
-         | Keeper_chat_store.Row_kind.Transport_failure -> None
+         | Keeper_chat_store.Row_kind.Transport_failure
+         | Keeper_chat_store.Row_kind.Agent_failure -> None
          | Keeper_chat_store.Row_kind.Utterance ->
            (match m.audio with
             | Some _ -> None
@@ -195,10 +196,11 @@ let render_recent_direct_conversation_context
 
 (* User lines after the keeper's last assistant line, in lane order. The
    shared positional watermark for mentions and scope. Only an assistant
-   *utterance* is a self reply; a [Transport_failure] row is the server
-   persisting a failed request terminal — the keeper never answered, so
-   the user line stays pending until the keeper's next real utterance
-   (which, per positional semantics, clears every pending line). *)
+   *utterance* is a self reply; a [Transport_failure] or [Agent_failure]
+   row is the server persisting a failed request terminal — the keeper
+   never answered, so the user line stays pending until the keeper's
+   next real utterance (which, per positional semantics, clears every
+   pending line). *)
 let user_lines_after_last_self (messages : Keeper_chat_store.chat_message list)
   : Keeper_chat_store.chat_message list
   =
@@ -208,7 +210,8 @@ let user_lines_after_last_self (messages : Keeper_chat_store.chat_message list)
       | Keeper_chat_store.Role.Assistant -> (
         match m.kind with
         | Keeper_chat_store.Row_kind.Utterance -> []
-        | Keeper_chat_store.Row_kind.Transport_failure -> acc)
+        | Keeper_chat_store.Row_kind.Transport_failure
+        | Keeper_chat_store.Row_kind.Agent_failure -> acc)
       | Keeper_chat_store.Role.User -> m :: acc
       | Keeper_chat_store.Role.Tool -> acc)
     []

--- a/lib/keeper_catchup_digest.ml
+++ b/lib/keeper_catchup_digest.ml
@@ -85,6 +85,7 @@ type chat =
   { new_messages : int
   ; first_new_ts : float option
   ; transport_failures : int
+  ; agent_failures : int
   }
 
 type turns =
@@ -350,14 +351,18 @@ let payload_identity_match ~identity_of payload =
 
 (* Page [Keeper_chat_store] backward from the tail, counting rows strictly
    after [since]. Utterances (user/assistant) are [new_messages];
-   [Transport_failure] rows are counted separately; tool rows are ignored.
-   The store's own parser owns chat read-drop accounting, so chat parse
-   failures do not enter [read_errors]. Rows are de-duped by their stable
-   [id] across page overlaps. *)
+   [Transport_failure] and [Agent_failure] rows are counted separately
+   (masc#24314 / oas#2585: the two are not the same failure class — merging
+   them back into one counter would reintroduce the exact conflation this
+   Row_kind split exists to remove); tool rows are ignored. The store's own
+   parser owns chat read-drop accounting, so chat parse failures do not
+   enter [read_errors]. Rows are de-duped by their stable [id] across page
+   overlaps. *)
 let read_chat ~base_dir ~keeper_name ~since ~errs =
   let seen : (string, unit) Hashtbl.t = Hashtbl.create 64 in
   let new_messages = ref 0 in
   let transport = ref 0 in
+  let agent = ref 0 in
   let first_new = ref None in
   let truncated = ref false in
   let note_first ts =
@@ -370,6 +375,7 @@ let read_chat ~base_dir ~keeper_name ~since ~errs =
       Hashtbl.add seen id ();
       (match kind with
        | Keeper_chat_store.Row_kind.Transport_failure -> incr transport
+       | Keeper_chat_store.Row_kind.Agent_failure -> incr agent
        | Keeper_chat_store.Row_kind.Utterance ->
          (match role with
           | Keeper_chat_store.Role.User | Keeper_chat_store.Role.Assistant ->
@@ -412,6 +418,7 @@ let read_chat ~base_dir ~keeper_name ~since ~errs =
   ( { new_messages = !new_messages
     ; first_new_ts = !first_new
     ; transport_failures = !transport
+    ; agent_failures = !agent
     }
   , !truncated )
 ;;
@@ -729,6 +736,7 @@ let to_json (t : t) : Yojson.Safe.t =
           [ "new_messages", `Int t.chat.new_messages
           ; "first_new_ts", float_opt_to_json t.chat.first_new_ts
           ; "transport_failures", `Int t.chat.transport_failures
+          ; "agent_failures", `Int t.chat.agent_failures
           ] )
     ; ( "turns"
       , `Assoc

--- a/lib/keeper_catchup_digest.mli
+++ b/lib/keeper_catchup_digest.mli
@@ -47,6 +47,7 @@ type chat =
   { new_messages : int
   ; first_new_ts : float option
   ; transport_failures : int
+  ; agent_failures : int
   }
 
 type turns =
@@ -130,7 +131,8 @@ val build :
     Sources (all filtered to activity strictly after [since_unix]):
     - [chat]: [Keeper_chat_store] paged backward from the tail; utterances
       count as [new_messages], [Row_kind.Transport_failure] rows as
-      [transport_failures].
+      [transport_failures], [Row_kind.Agent_failure] rows as
+      [agent_failures].
     - [turns.completed]: keeper-local [turn-records] day-files.
     - [turns.failed]: activity-events [keeper.turn_failed] for the keeper.
     - [turns.crashes]: [Keeper_crash_persistence] recent crash events.

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -799,6 +799,12 @@ let execute_keeper_stream_tool_streaming
   =
   let start_time = Eio.Time.now clock in
   let admission_rejection = ref None in
+  (* masc#24314 / oas#2585: captures the typed OAS boundary classification
+     when [run_turn] itself failed, so the caller can persist the right
+     chat Row_kind instead of assuming every keeper_msg failure is a
+     transport problem. Stays [None] for admission/validation rejections,
+     which never reach [run_turn]. *)
+  let failure_origin = ref None in
   let success, body, failure_class =
     try
       let keeper_ctx : _ Keeper_tool_surface.context =
@@ -816,6 +822,7 @@ let execute_keeper_stream_tool_streaming
           ~on_admission_rejected:(fun rejection ->
             admission_rejection := Some rejection)
           ?on_admitted
+          ~on_run_failure_origin:(fun origin -> failure_origin := Some origin)
           keeper_ctx
           ~continuation_channel
           ~name:"masc_keeper_msg"
@@ -888,7 +895,7 @@ let execute_keeper_stream_tool_streaming
         | None -> ());
       Tool_registry.record_call_if_known ~source:Agent_internal
         ~tool_name:"masc_keeper_msg" ~success ~duration_ms ();
-      `Ran (success, body)
+      `Ran (success, body, !failure_origin)
 
 let execute_keeper_stream_tool_streaming_if_free
       ~sw
@@ -902,6 +909,9 @@ let execute_keeper_stream_tool_streaming_if_free
       ~on_text_delta
   =
   let start_time = Eio.Time.now clock in
+  (* masc#24314 / oas#2585: see [execute_keeper_stream_tool_streaming]'s
+     [failure_origin] for the contract. *)
+  let failure_origin = ref None in
   let outcome =
     try
       let keeper_ctx : _ Keeper_tool_surface.context =
@@ -919,6 +929,7 @@ let execute_keeper_stream_tool_streaming_if_free
           ~on_text_delta
           ?on_event
           ~continuation_channel
+          ~on_run_failure_origin:(fun origin -> failure_origin := Some origin)
           keeper_ctx
           arguments
       with
@@ -990,7 +1001,7 @@ let execute_keeper_stream_tool_streaming_if_free
         | None -> ());
       Tool_registry.record_call_if_known ~source:Agent_internal
         ~tool_name:"masc_keeper_msg" ~success ~duration_ms ();
-      `Ran (success, body)
+      `Ran (success, body, !failure_origin)
 
 (** Send a Run_error AG-UI event with the given message. *)
 let send_keeper_error ?on_closed writer mutex closed ~thread_id ~run_id err =
@@ -1531,6 +1542,17 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
               ~stream_lifecycle:errored_stream_lifecycle
               ()
             |> Result.map row_id_of_append_once
+          | Keeper_chat_delivery_journal.Agent_failure { content } ->
+            Keeper_chat_store.append_assistant_message_once
+              ~base_dir:base_path
+              ~keeper_name:payload.name
+              ~delivery_key
+              ~content
+              ~surface:chat_surface
+              ~assistant_kind:Keeper_chat_store.Row_kind.Agent_failure
+              ~stream_lifecycle:errored_stream_lifecycle
+              ()
+            |> Result.map row_id_of_append_once
           | Keeper_chat_delivery_journal.No_assistant_reply
               { reason =
                   ( Keeper_chat_delivery_journal.Continuation_checkpoint
@@ -1609,7 +1631,13 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
         ~speaker:chat_speaker
         ()
   in
-  let persist_failure_reply err =
+  (* masc#24314 / oas#2585: [row_kind] is required, not defaulted — every
+     call site must state whether this failure is [Transport_failure]
+     (wire-level Api/Provider error) or [Agent_failure] (everything else:
+     a typed OAS Agent error, a turn with no visible reply, or an
+     admission/validation rejection). See callers for the typed reasoning
+     behind each choice. *)
+  let persist_failure_reply ~(row_kind : Keeper_chat_store.Row_kind.t) err =
     (* The failure marker is typed, not an utterance: it renders for the
        operator but does not advance the lane watermark, so the user
        message it failed to answer stays pending for the keeper's next
@@ -1618,12 +1646,28 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
       Keeper_metrics.(to_string ChatTransportFailures)
       ~labels:[ ("keeper", payload.name); ("source", chat_source) ]
       ();
+    let delivery_journal_kind =
+      match row_kind with
+      | Keeper_chat_store.Row_kind.Transport_failure ->
+          Keeper_chat_delivery_journal.Transport_failure
+            { content = persisted_error_reply err }
+      | Keeper_chat_store.Row_kind.Agent_failure ->
+          Keeper_chat_delivery_journal.Agent_failure
+            { content = persisted_error_reply err }
+      | Keeper_chat_store.Row_kind.Utterance ->
+          (* Every call site in this module passes [Transport_failure] or
+             [Agent_failure]; [Utterance] here means a caller mis-threaded
+             the classification. Fail loudly rather than silently render
+             the failure marker as if the keeper had actually said it. *)
+          invalid_arg
+            "persist_failure_reply: row_kind must not be Row_kind.Utterance"
+    in
     (* RFC-connector-deferred-reply-via-chat-queue §3.4: the failure must be
        DURABLE on both paths — a post-ACK deferred turn that fails must not
        vanish on restart/replay (counter + live broadcast alone is silent
        failure under this feature's "queued, will answer" contract).
        - Dashboard route ([recorded_upstream = false]): the turn owns the user
-         line, so record the paired [Transport_failure] row (user message stays
+         line, so record the paired failure row (user message stays
          pending for the next turn; keeper never reads the error as its words).
        - Connector route ([recorded_upstream = true]): the gate inbound boundary
          already persisted the user line (assistant-less). The paired
@@ -1636,7 +1680,7 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
         commit_direct_terminal
           { ok = false
           ; poll_body = err
-          ; delivery = Keeper_chat_delivery_journal.Transport_failure { content = persisted_error_reply err }
+          ; delivery = delivery_journal_kind
           }
       else if connector_user_line_recorded_upstream then
        Keeper_chat_store.append_assistant_message_result
@@ -1644,6 +1688,7 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
          ~keeper_name:payload.name
          ~content:(persisted_error_reply err)
          ~surface:chat_surface
+         ~assistant_kind:row_kind
          ~stream_lifecycle:errored_stream_lifecycle
          ()
       else
@@ -1654,7 +1699,7 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
          ~user_attachments:payload.attachments
          ~surface:chat_surface
          ~speaker:chat_speaker
-         ~assistant_kind:Keeper_chat_store.Row_kind.Transport_failure
+         ~assistant_kind:row_kind
          ~assistant_content:(persisted_error_reply err)
          ~stream_lifecycle:errored_stream_lifecycle
          ()
@@ -1693,7 +1738,17 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
           , Printf.sprintf "%s (cancelled_by=%s)" reason cancelled_by
           , Turn_cancelled )
     in
-    let persisted = persist_failure_reply body in
+    (* Both [worker_abort_reason] variants are the async submission layer
+       cutting the turn off from the outside (wall-clock budget or an
+       operator/system cancellation) before any OAS Agent error boundary
+       is reached — a genuine transport-layer interruption, not an agent
+       execution outcome. *)
+    let row_kind =
+      match reason with
+      | Keeper_msg_async.Timeout _ | Keeper_msg_async.Worker_cancelled _ ->
+          Keeper_chat_store.Row_kind.Transport_failure
+    in
+    let persisted = persist_failure_reply ~row_kind body in
     let queued_outcome =
       if not queued_turn then None
       else
@@ -1773,12 +1828,17 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
               then Error (Printexc.to_string exn)
               else
                 (try
-                   Ok
-                     (`Ran
-	                        (execute_keeper_stream_tool ~sw:request_sw ~clock
-	                           ?auth_token
-	                           state ~agent_name ~arguments:args
-                            ~continuation_channel))
+                   (* [execute_keeper_stream_tool] is the non-streaming
+                      fallback used only after the streaming dispatch itself
+                      raised — it never reaches a typed OAS error boundary,
+                      so [failure_origin] is unavailable ([None]) here. *)
+                   let success, body =
+                     execute_keeper_stream_tool ~sw:request_sw ~clock
+                       ?auth_token
+                       state ~agent_name ~arguments:args
+                       ~continuation_channel
+                   in
+                   Ok (`Ran (success, body, None))
                  with
                  | Eio.Cancel.Cancelled _ as e -> raise e
                  | exn2 -> Error (Printexc.to_string exn2))
@@ -1828,7 +1888,7 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
                     ; queued_outcome = None
                     });
                Tool_result.error ~tool_name:"masc_keeper_msg" ~start_time detail)
-        | Ok (`Ran (true, body)) ->
+        | Ok (`Ran (true, body, _failure_origin)) ->
             let payload_json_opt, visible_reply = extract_visible_reply body in
             let streamed_text =
               Keeper_stream_text_accum.streamed_text worker_text_accum
@@ -1876,10 +1936,16 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
                  visible_reply
              with
              | Some err ->
+                 (* The tool call itself succeeded ([`Ran (true, body)]) — the
+                    runtime completed the turn at the transport level. [err]
+                    here is [direct_reply_terminal_error]'s "no visible reply"
+                    diagnosis, an agent-behavior outcome, not a transport
+                    fault. *)
+                 let row_kind = Keeper_chat_store.Row_kind.Agent_failure in
                  let queued_outcome =
                    if not queued_turn then None
                    else
-                     match persist_failure_reply err with
+                     match persist_failure_reply ~row_kind err with
                      | Ok () -> Some (Failed { kind = Turn_failed; detail = err })
                      | Error persist_error ->
                          Some
@@ -1890,7 +1956,7 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
                  in
                  if not queued_turn
                  then
-                   (match persist_failure_reply err with
+                   (match persist_failure_reply ~row_kind err with
                     | Ok () -> ()
                     | Error persist_error ->
                       Log.Keeper.error
@@ -1970,7 +2036,9 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
                        let detail =
                          "queued turn ended with a continuation checkpoint and no delivered reply"
                        in
-                       (match persist_failure_reply detail with
+                       (* The turn ran and yielded at a checkpoint — an agent
+                          lifecycle outcome, not a transport fault. *)
+                       (match persist_failure_reply ~row_kind:Keeper_chat_store.Row_kind.Agent_failure detail with
                         | Ok () ->
                             Some
                               (Failed
@@ -2016,7 +2084,9 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
                          let detail =
                            "no visible reply was produced for this queued message"
                          in
-                         (match persist_failure_reply detail with
+                         (* The turn ran and completed with no visible reply —
+                            an agent-behavior outcome, not a transport fault. *)
+                         (match persist_failure_reply ~row_kind:Keeper_chat_store.Row_kind.Agent_failure detail with
                           | Ok () -> Some (Failed { kind = No_visible_reply; detail })
                           | Error persist_error ->
                               Some
@@ -2059,8 +2129,25 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
                            ; queued_outcome
                            });
                       Tool_result.ok ~tool_name:"masc_keeper_msg" ~start_time body))
-        | Ok (`Ran (false, err)) ->
-            let persisted = persist_failure_reply err in
+        | Ok (`Ran (false, err, failure_origin)) ->
+            (* [failure_origin] is [Some _] exactly when [Turn.handle_keeper_msg]
+               (or [_if_free]) reached [run_turn]'s typed [Error] arm — the OAS
+               Agent boundary. It is [None] for admission rejections and
+               input-validation errors, which never reach [run_turn] and have
+               no typed OAS classification available; the pre-existing
+               [Transport_failure] label is kept for those, since they are
+               scheduling/validation rejections, not agent execution
+               outcomes, and there is no typed signal to distinguish further
+               without expanding this PR's scope. *)
+            let row_kind =
+              match failure_origin with
+              | Some Keeper_agent_error.Transport_layer ->
+                  Keeper_chat_store.Row_kind.Transport_failure
+              | Some Keeper_agent_error.Agent_layer ->
+                  Keeper_chat_store.Row_kind.Agent_failure
+              | None -> Keeper_chat_store.Row_kind.Transport_failure
+            in
+            let persisted = persist_failure_reply ~row_kind err in
             let queued_outcome =
               if not queued_turn then None
               else
@@ -2078,7 +2165,14 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
                  { status = Stream_error; body = err; queued_outcome });
             Tool_result.error ~tool_name:"masc_keeper_msg" ~start_time err
         | Error err ->
-            let persisted = persist_failure_reply err in
+            (* No [Tool_result] was ever produced on this path (a raw
+               exception from the dispatch try/with, or the async
+               submission layer's own admission failure) — no typed OAS
+               boundary was reached, so [Transport_failure] is kept. *)
+            let persisted =
+              persist_failure_reply
+                ~row_kind:Keeper_chat_store.Row_kind.Transport_failure err
+            in
             let queued_outcome =
               if not queued_turn then None
               else
@@ -2103,7 +2197,13 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
     match submit_result with
     | Ok request_id -> Some request_id
     | Error body ->
-        let persisted = persist_failure_reply body in
+        (* [Keeper_msg_async.submit] rejected admission before any turn ran
+           (e.g. background-switch setup failed) — no typed OAS boundary
+           was reached, so [Transport_failure] is kept. *)
+        let persisted =
+          persist_failure_reply
+            ~row_kind:Keeper_chat_store.Row_kind.Transport_failure body
+        in
         let queued_outcome =
           if not queued_turn then None
           else

--- a/test/dune
+++ b/test/dune
@@ -779,6 +779,14 @@
  (modules test_keeper_failure_judgment_contract)
  (libraries alcotest masc_test_deps))
 
+; masc#24314 / oas#2585: pure classification unit tests for
+; Keeper_agent_error.failure_origin_of_sdk_error (the typed OAS Agent-vs-
+; transport seam the Row_kind fix threads through).
+(test
+ (name test_keeper_agent_error)
+ (modules test_keeper_agent_error)
+ (libraries alcotest masc_test_deps))
+
 (test
  (name test_server_request_authority)
  (modules test_server_request_authority)

--- a/test/test_keeper_agent_error.ml
+++ b/test/test_keeper_agent_error.ml
@@ -1,0 +1,126 @@
+(* masc#24314 / oas#2585: [Keeper_agent_error.failure_origin_of_sdk_error]
+   is the typed classification seam this PR adds — it decides, from the
+   OAS [Agent_sdk.Error.sdk_error] value itself (never from string
+   matching), whether a keeper_msg turn failure originated at the
+   wire-level Api/Provider boundary ([Transport_layer]) or from the
+   agent's own execution/config/orchestration outcome ([Agent_layer]).
+   Every constructor of [sdk_error] is exercised so a new variant added to
+   the SDK forces a compile-time decision here, not a silent default. *)
+
+open Alcotest
+module Keeper_agent_error = Masc.Keeper_agent_error
+
+let check_origin label expected err =
+  check
+    bool
+    label
+    true
+    (match expected, Keeper_agent_error.failure_origin_of_sdk_error err with
+     | Keeper_agent_error.Transport_layer, Keeper_agent_error.Transport_layer
+     | Keeper_agent_error.Agent_layer, Keeper_agent_error.Agent_layer -> true
+     | (Keeper_agent_error.Transport_layer | Keeper_agent_error.Agent_layer), _ ->
+       false)
+;;
+
+let test_api_is_transport_layer () =
+  check_origin
+    "Api is Transport_layer"
+    Keeper_agent_error.Transport_layer
+    (Agent_sdk.Error.Api
+       (Agent_sdk.Retry.RateLimited { retry_after = None; message = "rate limited" }))
+;;
+
+let test_provider_is_transport_layer () =
+  check_origin
+    "Provider is Transport_layer"
+    Keeper_agent_error.Transport_layer
+    (Agent_sdk.Error.Provider
+       (Llm_provider.Error.MissingApiKey { var_name = "OPENAI_API_KEY" }))
+;;
+
+(* The exact case from the real incident (masc#24314 RCA): OAS's
+   [ToolFailureRecoveryFailed] is an agent-side outcome, not a transport
+   problem, and must not classify as [Transport_layer]. *)
+let test_tool_failure_recovery_failed_is_agent_layer () =
+  check_origin
+    "Agent(ToolFailureRecoveryFailed) is Agent_layer"
+    Keeper_agent_error.Agent_layer
+    (Agent_sdk.Error.Agent
+       (Agent_sdk.Error.ToolFailureRecoveryFailed
+          { stage = Agent_sdk.Error.Judge_response; detail = "judge unreachable" }))
+;;
+
+let test_agent_other_variant_is_agent_layer () =
+  check_origin
+    "Agent(MaxTurnsExceeded) is Agent_layer"
+    Keeper_agent_error.Agent_layer
+    (Agent_sdk.Error.Agent (Agent_sdk.Error.MaxTurnsExceeded { turns = 40; limit = 40 }))
+;;
+
+let test_mcp_is_agent_layer () =
+  check_origin
+    "Mcp is Agent_layer"
+    Keeper_agent_error.Agent_layer
+    (Agent_sdk.Error.Mcp
+       (Agent_sdk.Error.ToolCallFailed { tool_name = "keeper_board_list"; detail = "boom" }))
+;;
+
+let test_config_is_agent_layer () =
+  check_origin
+    "Config is Agent_layer"
+    Keeper_agent_error.Agent_layer
+    (Agent_sdk.Error.Config (Agent_sdk.Error.MissingEnvVar { var_name = "MASC_BASE_PATH" }))
+;;
+
+let test_serialization_is_agent_layer () =
+  check_origin
+    "Serialization is Agent_layer"
+    Keeper_agent_error.Agent_layer
+    (Agent_sdk.Error.Serialization (Agent_sdk.Error.JsonParseError { detail = "bad json" }))
+;;
+
+let test_io_is_agent_layer () =
+  check_origin
+    "Io is Agent_layer"
+    Keeper_agent_error.Agent_layer
+    (Agent_sdk.Error.Io
+       (Agent_sdk.Error.FileOpFailed { op = "read"; path = "/tmp/x"; detail = "ENOENT" }))
+;;
+
+let test_orchestration_is_agent_layer () =
+  check_origin
+    "Orchestration is Agent_layer"
+    Keeper_agent_error.Agent_layer
+    (Agent_sdk.Error.Orchestration (Agent_sdk.Error.UnknownAgent { name = "ghost" }))
+;;
+
+let test_internal_is_agent_layer () =
+  check_origin
+    "Internal is Agent_layer"
+    Keeper_agent_error.Agent_layer
+    (Agent_sdk.Error.Internal "unexpected internal state")
+;;
+
+let () =
+  run
+    "keeper_agent_error"
+    [ ( "failure_origin_of_sdk_error"
+      , [ test_case "Api -> Transport_layer" `Quick test_api_is_transport_layer
+        ; test_case "Provider -> Transport_layer" `Quick test_provider_is_transport_layer
+        ; test_case
+            "Agent(ToolFailureRecoveryFailed) -> Agent_layer"
+            `Quick
+            test_tool_failure_recovery_failed_is_agent_layer
+        ; test_case
+            "Agent(MaxTurnsExceeded) -> Agent_layer"
+            `Quick
+            test_agent_other_variant_is_agent_layer
+        ; test_case "Mcp -> Agent_layer" `Quick test_mcp_is_agent_layer
+        ; test_case "Config -> Agent_layer" `Quick test_config_is_agent_layer
+        ; test_case "Serialization -> Agent_layer" `Quick test_serialization_is_agent_layer
+        ; test_case "Io -> Agent_layer" `Quick test_io_is_agent_layer
+        ; test_case "Orchestration -> Agent_layer" `Quick test_orchestration_is_agent_layer
+        ; test_case "Internal -> Agent_layer" `Quick test_internal_is_agent_layer
+        ] )
+    ]
+;;

--- a/test/test_keeper_agent_error.ml
+++ b/test/test_keeper_agent_error.ml
@@ -5,7 +5,13 @@
    wire-level Api/Provider boundary ([Transport_layer]) or from the
    agent's own execution/config/orchestration outcome ([Agent_layer]).
    Every constructor of [sdk_error] is exercised so a new variant added to
-   the SDK forces a compile-time decision here, not a silent default. *)
+   the SDK forces a compile-time decision here, not a silent default.
+   [Api] and [Provider] additionally descend into their nested payload —
+   a missing local credential or an agent-authored malformed request is
+   [Agent_layer] even though the top-level constructor is [Api]/[Provider],
+   because no wire fault occurred (see
+   [Keeper_agent_error.api_error_failure_origin] /
+   [provider_error_failure_origin] for the full per-variant mapping). *)
 
 open Alcotest
 module Keeper_agent_error = Masc.Keeper_agent_error
@@ -30,12 +36,54 @@ let test_api_is_transport_layer () =
        (Agent_sdk.Retry.RateLimited { retry_after = None; message = "rate limited" }))
 ;;
 
-let test_provider_is_transport_layer () =
+(* Contradiction fix: a missing local credential means no request ever
+   reached the wire, so this must not classify the same as a genuine
+   transport failure (was wrongly Transport_layer prior to this PR). *)
+let test_provider_missing_api_key_is_agent_layer () =
   check_origin
-    "Provider is Transport_layer"
-    Keeper_agent_error.Transport_layer
+    "Provider(MissingApiKey) is Agent_layer"
+    Keeper_agent_error.Agent_layer
     (Agent_sdk.Error.Provider
        (Llm_provider.Error.MissingApiKey { var_name = "OPENAI_API_KEY" }))
+;;
+
+let test_provider_rate_limit_is_transport_layer () =
+  check_origin
+    "Provider(RateLimit) is Transport_layer"
+    Keeper_agent_error.Transport_layer
+    (Agent_sdk.Error.Provider
+       (Llm_provider.Error.RateLimit
+          { provider = "openai"; retry_after = None; detail = "rate limited" }))
+;;
+
+let test_api_context_overflow_is_agent_layer () =
+  check_origin
+    "Api(ContextOverflow) is Agent_layer"
+    Keeper_agent_error.Agent_layer
+    (Agent_sdk.Error.Api
+       (Agent_sdk.Retry.ContextOverflow { message = "context too large"; limit = None }))
+;;
+
+let test_api_invalid_request_is_agent_layer () =
+  check_origin
+    "Api(InvalidRequest) is Agent_layer"
+    Keeper_agent_error.Agent_layer
+    (Agent_sdk.Error.Api
+       (Agent_sdk.Retry.InvalidRequest
+          { message = "bad payload"; reason = Agent_sdk.Retry.Unknown_invalid_request }))
+;;
+
+(* NotFound reached us as a definitive wire rejection (the provider told
+   us the resource doesn't exist), unlike InvalidRequest/ContextOverflow
+   which never leave agent-local territory --
+   Keeper_runtime_failure_route.route_of_provider_error groups this with
+   [rotate Model_unavailable], the same bucket as AuthError. *)
+let test_provider_not_found_is_transport_layer () =
+  check_origin
+    "Provider(NotFound) is Transport_layer"
+    Keeper_agent_error.Transport_layer
+    (Agent_sdk.Error.Provider
+       (Llm_provider.Error.NotFound { provider = "openai"; detail = "model not found" }))
 ;;
 
 (* The exact case from the real incident (masc#24314 RCA): OAS's
@@ -106,7 +154,26 @@ let () =
     "keeper_agent_error"
     [ ( "failure_origin_of_sdk_error"
       , [ test_case "Api -> Transport_layer" `Quick test_api_is_transport_layer
-        ; test_case "Provider -> Transport_layer" `Quick test_provider_is_transport_layer
+        ; test_case
+            "Provider(MissingApiKey) -> Agent_layer"
+            `Quick
+            test_provider_missing_api_key_is_agent_layer
+        ; test_case
+            "Provider(RateLimit) -> Transport_layer"
+            `Quick
+            test_provider_rate_limit_is_transport_layer
+        ; test_case
+            "Api(ContextOverflow) -> Agent_layer"
+            `Quick
+            test_api_context_overflow_is_agent_layer
+        ; test_case
+            "Api(InvalidRequest) -> Agent_layer"
+            `Quick
+            test_api_invalid_request_is_agent_layer
+        ; test_case
+            "Provider(NotFound) -> Transport_layer"
+            `Quick
+            test_provider_not_found_is_transport_layer
         ; test_case
             "Agent(ToolFailureRecoveryFailed) -> Agent_layer"
             `Quick

--- a/test/test_keeper_catchup_digest.ml
+++ b/test/test_keeper_catchup_digest.ml
@@ -215,7 +215,9 @@ let crash_row ~ts = json_line (`Assoc [ "ts", `Float ts; "reason", `String "boom
 
 let write_rich_fixture base =
   (* chat: one legacy row before since (excluded), two utterances after,
-     one transport-failure after. *)
+     one transport-failure and one agent-failure after (masc#24314 /
+     oas#2585: the two Row_kind failure variants are counted separately,
+     not merged). *)
   let cf = chat_file base in
   append_line cf (chat_row ~role:"user" ~ts:(since_unix -. 10.) ());
   append_line cf (chat_row ~id:"m1" ~role:"user" ~ts:(since_unix +. 10.) ());
@@ -223,6 +225,9 @@ let write_rich_fixture base =
   append_line
     cf
     (chat_row ~id:"m3" ~role:"assistant" ~kind:"transport_failure" ~ts:(since_unix +. 12.) ());
+  append_line
+    cf
+    (chat_row ~id:"m4" ~role:"assistant" ~kind:"agent_failure" ~ts:(since_unix +. 13.) ());
   (* turn-records across two day-files straddling since; day-file B carries a
      deliberately corrupt line that must surface in read_errors. *)
   let td = turn_dir base in
@@ -315,7 +320,7 @@ let test_counts_and_boundary () =
   with_workspace (fun base ->
     write_rich_fixture base;
     let digest = D.build ~base_path:base ~keeper_name:keeper ~since_unix ~now_unix in
-    let { D.chat = { new_messages; first_new_ts; transport_failures }
+    let { D.chat = { new_messages; first_new_ts; transport_failures; agent_failures }
         ; turns = { completed; failed; crashes }
         ; tasks = { claimed; done_; released; cancelled; items = task_items }
         ; board = { posted; commented; voted }
@@ -340,6 +345,7 @@ let test_counts_and_boundary () =
     (* chat *)
     Alcotest.(check int) "new_messages (2 utterances after since)" 2 new_messages;
     Alcotest.(check int) "transport_failures" 1 transport_failures;
+    Alcotest.(check int) "agent_failures" 1 agent_failures;
     Alcotest.(check (option (float 0.0001)))
       "first_new_ts is the earliest new utterance"
       (Some (since_unix +. 10.))

--- a/test/test_keeper_chat_delivery_journal.ml
+++ b/test/test_keeper_chat_delivery_journal.ml
@@ -232,6 +232,49 @@ let test_journal_rejects_unknown_and_duplicate_fields () =
    | _ -> fail "journal encoder did not produce an object")
 ;;
 
+(* masc#24314 / oas#2585: [Agent_failure] round-trips through the journal
+   wire format the same way [Transport_failure] already does — the two
+   are typed separately so a reload can tell a wire-level transport
+   failure apart from a typed OAS agent failure. *)
+let test_agent_failure_terminal_delivery_roundtrip () =
+  let journal : Journal.t =
+    { schema_version = 1
+    ; revision = 1
+    ; delivery_key = direct_key ()
+    ; payload = payload ()
+    ; phase =
+        Journal.Terminal_pending
+          { terminal =
+              { ok = false
+              ; poll_body = "keeper_msg turn failed"
+              ; delivery =
+                  Journal.Agent_failure
+                    { content = "Keeper request failed: ToolFailureRecoveryFailed" }
+              }
+          ; user_row_id = Some "msg-user"
+          }
+    ; created_at = 1.0
+    ; updated_at = 2.0
+    }
+  in
+  let json = Journal.For_testing.to_yojson journal in
+  match Journal.For_testing.of_yojson json with
+  | Error error -> fail (Journal.error_to_string error)
+  | Ok decoded ->
+    (match decoded.phase with
+     | Journal.Terminal_pending
+         { terminal = { delivery = Journal.Agent_failure { content }; ok; _ }; _ } ->
+       check bool "not ok" false ok;
+       check
+         string
+         "content preserved"
+         "Keeper request failed: ToolFailureRecoveryFailed"
+         content
+     | Journal.Terminal_pending { terminal = { delivery = Journal.Transport_failure _; _ }; _ } ->
+       fail "Agent_failure decoded as Transport_failure"
+     | _ -> fail "expected Terminal_pending phase")
+;;
+
 let row_id = function
   | Keeper_chat_store.Appended { row_id }
   | Keeper_chat_store.Already_present { row_id } -> row_id
@@ -670,6 +713,10 @@ let () =
             "schema drift fails closed"
             `Quick
             test_journal_rejects_unknown_and_duplicate_fields
+        ; test_case
+            "agent_failure terminal delivery roundtrips (masc#24314 / oas#2585)"
+            `Quick
+            test_agent_failure_terminal_delivery_roundtrip
         ; test_case
             "chat append-once converges"
             `Quick

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -324,6 +324,29 @@ let test_recent_direct_context_omits_transport_failure_as_self_reply () =
       Alcotest.(check bool) "failure text is not a self utterance" false
         (contains_substring rendered "Keeper request failed"))
 
+let test_recent_direct_context_omits_agent_failure_as_self_reply () =
+  let base_dir = temp_base_path "keeper-chat-recent-agent-failure" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-recent-agent-failure" in
+      K.append_turn ~base_dir ~keeper_name
+        ~user_content:"please answer this"
+        ~user_attachments:[]
+        ~surface:(Masc.Surface_ref.Dashboard { session_id = None })
+        ~assistant_kind:K.Row_kind.Agent_failure
+        ~assistant_content:"Keeper request failed: ToolFailureRecoveryFailed"
+        ();
+      let lines =
+        K.load ~base_dir ~keeper_name
+        |> MS.recent_direct_conversation_of_messages
+      in
+      Alcotest.(check (list string)) "failed request keeps user only"
+        [ "user" ] (recent_roles lines);
+      let rendered = MS.render_recent_direct_conversation_context lines in
+      Alcotest.(check bool) "failure text is not a self utterance" false
+        (contains_substring rendered "Keeper request failed"))
+
 let test_recent_direct_context_omits_voice_audio_self_echo () =
   let base_dir = temp_base_path "keeper-chat-recent-voice" in
   Fun.protect
@@ -863,6 +886,34 @@ let test_failure_turn_kind_roundtrip () =
           let raw = read_file (chat_path ~base_dir ~keeper_name) in
           Alcotest.(check bool) "failure row persists the kind field" true
             (contains_substring raw {|"kind":"transport_failure"|})
+      | messages ->
+          Alcotest.failf "expected 2 rows, got %d" (List.length messages))
+
+(* masc#24314 / oas#2585: the same round-trip for the typed agent-failure
+   marker, added so a typed OAS Agent error (e.g. ToolFailureRecoveryFailed)
+   is no longer indistinguishable from a wire-level transport failure. *)
+let test_agent_failure_turn_kind_roundtrip () =
+  let base_dir = temp_base_path "keeper-chat-store-kind-agent" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-kind-agent" in
+      K.append_turn ~base_dir ~keeper_name
+        ~user_content:"ping"
+        ~user_attachments:[]
+        ~surface:(Masc.Surface_ref.Dashboard { session_id = None })
+        ~assistant_kind:K.Row_kind.Agent_failure
+        ~assistant_content:"Keeper request failed: ToolFailureRecoveryFailed"
+        ();
+      match K.load ~base_dir ~keeper_name with
+      | [ user; asst ] ->
+          Alcotest.(check bool) "user row is an utterance" true
+            (K.Row_kind.equal user.kind K.Row_kind.Utterance);
+          Alcotest.(check bool) "assistant row is an agent failure" true
+            (K.Row_kind.equal asst.kind K.Row_kind.Agent_failure);
+          let raw = read_file (chat_path ~base_dir ~keeper_name) in
+          Alcotest.(check bool) "failure row persists the kind field" true
+            (contains_substring raw {|"kind":"agent_failure"|})
       | messages ->
           Alcotest.failf "expected 2 rows, got %d" (List.length messages))
 
@@ -1899,6 +1950,8 @@ let () =
         [
           Alcotest.test_case "failure turn kind roundtrip" `Quick
             test_failure_turn_kind_roundtrip;
+          Alcotest.test_case "agent failure turn kind roundtrip" `Quick
+            test_agent_failure_turn_kind_roundtrip;
           Alcotest.test_case "absent kind reads utterance" `Quick
             test_kind_absent_reads_utterance;
           Alcotest.test_case "unknown kind reported, reads utterance" `Quick
@@ -1931,6 +1984,8 @@ let () =
             test_recent_direct_context_renders_prior_reply_and_tool_evidence;
           Alcotest.test_case "recent context omits transport failure as reply" `Quick
             test_recent_direct_context_omits_transport_failure_as_self_reply;
+          Alcotest.test_case "recent context omits agent failure as reply" `Quick
+            test_recent_direct_context_omits_agent_failure_as_self_reply;
           Alcotest.test_case "recent context omits voice audio self echo" `Quick
             test_recent_direct_context_omits_voice_audio_self_echo;
           Alcotest.test_case "recent context is owner-direct only" `Quick


### PR DESCRIPTION
WORKAROUND-WAIVED: pr-rfc-check.sh STRING_CLASSIFIER 시그니처는 "문자열 매칭 없음"이라는 부정문(negation)에 반응한 false positive다. 이 PR은 정확히 그 반대 — 기존에 없던 typed 분류(`Keeper_agent_error.failure_origin_of_sdk_error`, `Agent_sdk.Error.sdk_error`에 대한 exhaustive match)를 신설해 string/substring 분류를 도입하지 않고 결정을 내리도록 한 변경이다.

## 배경

`Keeper_chat_store.Row_kind`가 `Utterance | Transport_failure` 2-variant 닫힌 합이라, 실패한 keeper 턴을 영속할 때 원인과 무관하게 전부 `Transport_failure`로 고정되어 있었다.

실사고(2026-07-12 sangsu): OAS의 typed agent error `Error.Agent(ToolFailureRecoveryFailed ...)`가 transport 문제가 아님에도 대시보드에 "transport failure"로 표기됨. RCA: `~/me/reports/masc-oas-sangsu-ambiguous-failure-rca-20260712.html` 결함 5(Row_kind 어휘 부재).

관련: #24314, oas#2585

## 변경 내용

### 1. Row_kind에 `Agent_failure` variant 추가

`Keeper_chat_store.Row_kind`를 `Utterance | Transport_failure | Agent_failure` 3-variant로 확장. 직렬화는 기존 `to_label`/`of_label` 방식 그대로(`"agent_failure"` 문자열), 기존 `"transport_failure"`/absent-field(utterance) 값은 그대로 파싱된다 — 마이그레이션 불필요.

### 2. Typed 분류 seam: `Keeper_agent_error.failure_origin_of_sdk_error`

실패가 typed 값으로 도달하는 지점은 `lib/keeper/keeper_turn.ml`의 `run_keeper_msg_turn_admitted` 내부, `Keeper_agent_run.run_turn`이 `Error err`를 반환하는 순간이다 (`err : Agent_sdk.Error.sdk_error`). 여기서 곧바로 문자열로 뭉개지기 전에 typed 분류를 내린다.

`Agent_sdk.Error.Api _ | Agent_sdk.Error.Provider _ -> Transport_layer`로 최상위 constructor만 보고 뭉뚱그리던 최초 구현은 적대적 셀프 리뷰(아래 코멘트)에서 반박되어, `Api`/`Provider`의 nested payload까지 descend하는 exhaustive match(`api_error_failure_origin` / `provider_error_failure_origin`, catch-all 없음)로 교체했다:

- **Transport_layer** (wire round-trip이 실제로 발생/응답): RateLimited/Overloaded/ServerError/AuthError/AuthorizationError/PaymentRequired/NetworkError/Timeout/NotFound (api_error), ParseError/UnknownVariant/ProviderUnavailable/RateLimit/HardQuota/CapacityExhausted/AuthError/AuthorizationError/ServerError/NetworkError/Timeout/NotFound/ProviderTerminal (provider_error)
- **Agent_layer** (wire fault 아님 — 로컬 상태/authored 콘텐츠): InvalidRequest/ContextOverflow (api_error), MissingApiKey/InvalidConfig/InvalidRequest (provider_error)

`NotFound`와 `PaymentRequired`는 가이드에 명시되지 않아 자체 판단이 필요했던 항목이다. `NotFound`는 최초 Agent_layer로 판단했으나, 같은 레포의 기존 `lib/keeper_runtime/keeper_runtime_failure_route.ml`(RFC-0313 W2)이 `NotFound`를 `AuthError`/`AuthorizationError`와 같은 `rotate` 버킷(정의적 wire 거부 응답 도착)으로 분류하고 `InvalidRequest`/`ContextOverflow`(agent-local, `judge` 버킷)와는 구분하고 있음을 발견해 Transport_layer로 수정했다. `PaymentRequired`는 외부 서비스의 billing/quota 거부(HTTP 402)로 판단해 Transport_layer.

### 3. 스레딩: 새 `?on_run_failure_origin` 콜백

typed 값이 persist 지점(`server_routes_http_keeper_stream.ml`)까지 직접 오지 않으므로, 기존에도 쓰이던 `?on_admission_rejected` 콜백과 동일한 패턴으로 새 콜백을 추가해 체인을 통과시켰다:

```
Turn.handle_keeper_msg / handle_keeper_msg_if_free (keeper_turn.ml)
  -> Keeper_tool_surface.dispatch_stream (keeper_tool_surface.ml)
     -> Keeper_tool_surface_ops.handle_keeper_msg_stream (keeper_tool_surface_ops.ml)
  -> execute_keeper_stream_tool_streaming[_if_free] (server_routes_http_keeper_stream.ml)
     : ref cell로 캡처, 반환 튜플에 `Ran (bool, string, failure_origin option)`로 확장
```

`Tool_result.tool_failure_class`(기존 존재하는 Transient_error/Runtime_failure 등)를 재사용하지 않은 이유: 그 필드는 이미 재시도(`is_retryable`)·로그레벨·telemetry label 소비처가 있고, `Turn.handle_keeper_msg`의 에러 분기는 지금 항상 default(`Runtime_failure`)라 재사용 시 telemetry/재시도 시맨틱이 부수적으로 바뀐다. 이번 PR 범위(Row_kind 분류/표시)를 넘는 변경이라 판단해 완전히 별도의 side-channel로 뺐다.

`persist_failure_reply`는 `~row_kind`를 필수 인자로 받도록 바꿔 모든 8개 호출부가 명시적으로 결정하게 강제했다.

### 4. Transport_failure로 남긴 경로 (typed 값 도달 불가, 근거 명시)

- `Keeper_msg_async.Timeout` / `Worker_cancelled` (async 제출 레이어의 외부 인터럽트 — wall-clock 타임아웃/오퍼레이터 취소. `run_turn`의 typed 에러 경계 자체에 도달하지 않음. 이것도 타입 매치로 명시적 결정.)
- `dispatch_result`의 raw exception catch (`Error err ->`) — try/with에서 잡힌 순수 OCaml 예외, typed OAS 신호 없음
- `submit_result`의 `Error body` — `Keeper_msg_async.submit` 자체의 admission 단계 거부(예: background switch 실패), `run_turn` 진입 전

### 5. 부수 발견: `append_assistant_message_result`에 `?assistant_kind` 파라미터 자체가 없었음

`persist_failure_reply`의 connector-route 분기(`connector_user_line_recorded_upstream = true`)가 이 함수를 호출하는데, 이 함수는 `?kind`를 받지 않아 항상 `encode_line`의 기본값 `Utterance`로 떨어지고 있었다. 즉 커넥터(Discord/Slack 등)로 들어온 요청이 실패하면 **에러 텍스트가 keeper가 실제로 한 말(Utterance)처럼 영속되고 있었다** — Transport_failure/Agent_failure 분류보다 더 근본적인 결함. `?assistant_kind:Row_kind.t`(기본 `Utterance`, 하위호환)를 추가해 고쳤다.

### 6. `Keeper_chat_delivery_journal.terminal_delivery`에도 `Agent_failure` 추가

dashboard-direct-stream 경로(commit_direct_terminal/journal 기반)도 동일 문제라 `Transport_failure | Agent_failure | ...`로 확장. JSON 인코딩/디코딩(`"kind":"agent_failure"`) 대칭 추가.

### 7. `Keeper_catchup_digest`에 `agent_failures` 카운터 분리

`transport_failures`와 병합하면 이 PR이 없애려는 바로 그 conflation을 카운터 레벨에서 재도입하는 것이므로 별도 카운트로 분리.

### 8. 대시보드

- `types/core.ts`: `KeeperConversationDelivery`에 `'agent_failure'` 추가
- `lib/keeper-delivery.ts`: `FAILED_DELIVERY`에 추가 (drift-guard 테스트도 갱신)
- `keeper-state.ts`: `raw.kind` → `delivery` 매핑에 `agent_failure` 분기 추가
- `components/chat/primitives.ts`: `ChatFailureCard`에 `kind` prop 추가, 배지 "전송 실패" vs "에이전트 실패"로 구분 렌더
- `components/keeper-turn-inspector.ts`: 턴 인스펙터 pill이 `line.kind`에 따라 "transport failure"/"agent failure" 구분 표시 (RCA에서 지목된 실제 렌더 지점)
- `components/keeper-catchup-digest-card.ts`: `에이전트 실패 N` 칩 추가

## 테스트

- OCaml: `test/test_keeper_agent_error.ml` (신규, 리뷰 대응으로 확장) — `failure_origin_of_sdk_error`의 모든 9개 `sdk_error` variant를 exhaustive하게 검증 (`ToolFailureRecoveryFailed` 케이스 명시 포함) + `Api`/`Provider` nested payload 케이스: `Provider(MissingApiKey)`→Agent_layer, `Provider(RateLimit)`/`Provider(NotFound)`→Transport_layer, `Api(ContextOverflow)`/`Api(InvalidRequest)`→Agent_layer
- OCaml: `test_keeper_chat_store.ml` — Row_kind 직렬화 왕복(신규 `agent_failure` + 레거시 `transport_failure`/absent 값), recent-context가 agent_failure를 self-reply로 취급하지 않는지
- OCaml: `test_keeper_chat_delivery_journal.ml` — journal wire format에서 `Agent_failure` 왕복
- OCaml: `test_keeper_catchup_digest.ml` — `agent_failures` 카운터 분리 검증 (fixture에 agent_failure 행 추가)
- 대시보드: `keeper-delivery.test.ts`/`keeper-state.test.ts`/`primitives.test.ts`/`keeper-turn-inspector.test.ts`/`keeper-catchup-digest-card.test.ts` 갱신 + 신규 케이스
- 대시보드: `npx tsc --noEmit` 통과 (0 errors), `vitest run` 전체 스위트 648 files / 8896 tests 통과
- OCaml: 로컬 `dune build` 미실행(레포 규칙상 CI 전용) — `rg` 전수 스윕으로 `Row_kind`/`terminal_delivery` exhaustive match 전수 확인 완료

## 건드리지 않은 것

- lifecycle FSM (keeper phase 등)
- `Tool_result.tool_failure_class`의 기존 시맨틱(재시도/로그레벨/telemetry) — 이번 분류와 별도 채널로 유지
- Keeper_msg_async 레벨의 타임아웃/취소 분류 세분화 (범위 밖)

