### PR TITLE
fix(keeper): make chat persistence commit-aware

### DIFF
--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -100,6 +100,8 @@ describe('Keeper chat durable receipt API', () => {
       keeper_name: 'echo',
       receipt_id: 'chatq_00000000-0000-4000-8000-000000000001',
       revision: 7,
+      availability: 'available',
+      load_errors: [],
       state: {
         kind: 'failed',
         failure_kind: 'delivery_failed',
@@ -111,6 +113,8 @@ describe('Keeper chat durable receipt API', () => {
       keeperName: 'echo',
       receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
       revision: 7,
+      availability: 'available',
+      loadErrors: [],
       state: {
         kind: 'failed',
         failureKind: 'delivery_failed',
@@ -121,12 +125,55 @@ describe('Keeper chat durable receipt API', () => {
     })
   })
 
+  it('preserves typed quarantine metadata and restart interruption', () => {
+    expect(parseKeeperChatReceipt({
+      schema: 'keeper_chat_queue.receipt.v1',
+      keeper_name: 'echo',
+      receipt_id: 'chatq_00000000-0000-4000-8000-000000000001',
+      revision: 8,
+      availability: 'quarantined',
+      load_errors: [
+        {
+          kind: 'durability_uncertain',
+          message: 'Queue durability is uncertain; operator recovery is required.',
+        },
+      ],
+      state: {
+        kind: 'failed',
+        failure_kind: 'recovery_interrupted',
+        detail: 'server restarted with an inflight receipt',
+        completed_at: 43,
+        outcome_ref: null,
+      },
+    })).toMatchObject({
+      availability: 'quarantined',
+      loadErrors: [{ kind: 'durability_uncertain' }],
+      state: { kind: 'failed', failureKind: 'recovery_interrupted' },
+    })
+  })
+
+  it('rejects availability that disagrees with load errors', () => {
+    expect(() => parseKeeperChatReceipt({
+      schema: 'keeper_chat_queue.receipt.v1',
+      keeper_name: 'echo',
+      receipt_id: 'chatq_00000000-0000-4000-8000-000000000001',
+      revision: 8,
+      availability: 'available',
+      load_errors: [
+        { kind: 'durability_uncertain', message: 'operator recovery required' },
+      ],
+      state: { kind: 'pending' },
+    })).toThrow('availability disagrees')
+  })
+
   it('rejects an unknown receipt lifecycle instead of guessing', () => {
     expect(() => parseKeeperChatReceipt({
       schema: 'keeper_chat_queue.receipt.v1',
       keeper_name: 'echo',
       receipt_id: 'chatq_00000000-0000-4000-8000-000000000001',
       revision: 1,
+      availability: 'available',
+      load_errors: [],
       state: { kind: 'lost_somewhere' },
     })).toThrow('unknown state')
   })
@@ -137,6 +184,8 @@ describe('Keeper chat durable receipt API', () => {
       keeper_name: 'echo',
       receipt_id: 'receipt-echo-1',
       revision: 1,
+      availability: 'available',
+      load_errors: [],
       state: { kind: 'pending' },
     })).toThrow('missing identity')
   })
@@ -147,6 +196,8 @@ describe('Keeper chat durable receipt API', () => {
       keeper_name: 'echo',
       receipt_id: 'chatq_00000000-0000-4000-8000-000000000001',
       revision: 2,
+      availability: 'available',
+      load_errors: [],
       state: { kind: 'delivered', completed_at: 42, outcome_ref: 7 },
     })).toThrow('outcome_ref must be a string or null')
   })
@@ -157,6 +208,8 @@ describe('Keeper chat durable receipt API', () => {
       keeper_name: 'echo',
       receipt_id: 'chatq_00000000-0000-4000-8000-000000000001',
       revision: 2,
+      availability: 'available',
+      load_errors: [],
       state: {
         kind: 'failed',
         failure_kind: 'delivery_failed',
@@ -174,6 +227,8 @@ describe('Keeper chat durable receipt API', () => {
         keeper_name: 'keeper sangsu',
         receipt_id: 'chatq_00000000-0000-4000-8000-000000000001',
         revision: 2,
+        availability: 'available',
+        load_errors: [],
         state: { kind: 'pending' },
       }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
     )

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -692,6 +692,21 @@ export async function streamKeeperMessage(
 
 export type KeeperChatReceiptFailureKind = KeeperQueueReceiptFailureKind
 
+export type KeeperChatReceiptAvailability = 'available' | 'quarantined'
+
+export type KeeperChatReceiptLoadErrorKind =
+  | 'invalid_path'
+  | 'read_failed'
+  | 'parse_failed'
+  | 'migration_failed'
+  | 'recovery_failed'
+  | 'durability_uncertain'
+
+export interface KeeperChatReceiptLoadError {
+  kind: KeeperChatReceiptLoadErrorKind
+  message: string
+}
+
 export type KeeperChatReceiptState =
   | { kind: 'pending' }
   | { kind: 'inflight'; leaseId: string; startedAt: number }
@@ -708,6 +723,8 @@ export interface KeeperChatReceipt {
   keeperName: string
   receiptId: string
   revision: number
+  availability: KeeperChatReceiptAvailability
+  loadErrors: KeeperChatReceiptLoadError[]
   state: KeeperChatReceiptState
 }
 
@@ -720,6 +737,16 @@ const KEEPER_CHAT_RECEIPT_FAILURE_KINDS = new Set<KeeperChatReceiptFailureKind>(
   'delivery_failed',
   'cancelled',
   'internal_error',
+  'recovery_interrupted',
+])
+
+const KEEPER_CHAT_RECEIPT_LOAD_ERROR_KINDS = new Set<KeeperChatReceiptLoadErrorKind>([
+  'invalid_path',
+  'read_failed',
+  'parse_failed',
+  'migration_failed',
+  'recovery_failed',
+  'durability_uncertain',
 ])
 
 export function parseKeeperChatReceipt(value: unknown): KeeperChatReceipt {
@@ -729,6 +756,8 @@ export function parseKeeperChatReceipt(value: unknown): KeeperChatReceipt {
   const keeperName = asString(value.keeper_name, '').trim()
   const receiptId = asString(value.receipt_id, '').trim()
   const revision = asNumber(value.revision)
+  const availability = asString(value.availability, '').trim()
+  const rawLoadErrors = value.load_errors
   const rawState = isRecord(value.state) ? value.state : null
   const kind = asString(rawState?.kind, '').trim()
   if (
@@ -738,8 +767,27 @@ export function parseKeeperChatReceipt(value: unknown): KeeperChatReceipt {
     || typeof revision !== 'number'
     || !Number.isSafeInteger(revision)
     || revision < 0
+    || (availability !== 'available' && availability !== 'quarantined')
+    || !Array.isArray(rawLoadErrors)
   ) {
     throw new Error('Keeper chat receipt response is missing identity or state')
+  }
+  const loadErrors = rawLoadErrors.map((rawError): KeeperChatReceiptLoadError => {
+    if (!isRecord(rawError)) {
+      throw new Error('Keeper chat receipt load error must be an object')
+    }
+    const errorKind = asString(rawError.kind, '') as KeeperChatReceiptLoadErrorKind
+    const message = asString(rawError.message, '').trim()
+    if (!KEEPER_CHAT_RECEIPT_LOAD_ERROR_KINDS.has(errorKind) || !message) {
+      throw new Error('Keeper chat receipt has invalid load error metadata')
+    }
+    return { kind: errorKind, message }
+  })
+  if (
+    (availability === 'available' && loadErrors.length !== 0)
+    || (availability === 'quarantined' && loadErrors.length === 0)
+  ) {
+    throw new Error('Keeper chat receipt availability disagrees with load errors')
   }
   let state: KeeperChatReceiptState
   const nullableString = (fieldName: string, fieldValue: unknown): string | null => {
@@ -797,7 +845,7 @@ export function parseKeeperChatReceipt(value: unknown): KeeperChatReceipt {
     default:
       throw new Error(`Keeper chat receipt has unknown state: ${kind || '<empty>'}`)
   }
-  return { keeperName, receiptId, revision, state }
+  return { keeperName, receiptId, revision, availability, loadErrors, state }
 }
 
 export async function fetchKeeperChatReceipt(

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -408,6 +408,19 @@ describe('ChatTranscript', () => {
           reason: 'history row records durable server stream lifecycle replay',
         },
       },
+      {
+        id: 'smoke-durability-uncertain',
+        role: 'assistant',
+        content: 'queue receipt requires operator recovery',
+        ts: 1_780_000_002,
+        kind: 'transport_failure',
+        stream_contract: {
+          source: 'queue_poll',
+          status: 'queue_poll_result',
+          delivery_receipt: 'server_receipt_durability_uncertain',
+          reason: 'receipt is visible but parent directory fsync failed',
+        },
+      },
     ])
 
     render(
@@ -441,6 +454,18 @@ describe('ChatTranscript', () => {
     expect(failure.getAttribute('data-chat-stream-contract-delivery-receipt')).toBe('server_lifecycle_replay_only')
     expect(failure.getAttribute('data-chat-stream-contract-badge-state')).toBe('server-replay')
     expect(failure.querySelector('[data-chat-stream-contract-badge]')?.textContent).toContain('서버 기록 복구')
+    const uncertain = container.querySelector(
+      '[data-chat-entry-id="smoke-durability-uncertain"]',
+    ) as HTMLElement
+    expect(uncertain.getAttribute('data-chat-stream-contract-delivery-receipt')).toBe(
+      'server_receipt_durability_uncertain',
+    )
+    expect(uncertain.getAttribute('data-chat-stream-contract-badge-state')).toBe(
+      'durability-uncertain',
+    )
+    expect(uncertain.querySelector('[data-chat-stream-contract-badge]')?.textContent).toContain(
+      '내구성 확인 필요',
+    )
     // transport_failure renders the typed card, so the raw diagnostic is
     // collapsed by default (the legacy banner is suppressed for card rows)
     // and surfaces only on expand.

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -426,7 +426,7 @@ describe('ChatTranscript', () => {
     expect(legacy.getAttribute('data-chat-stream-contract-delivery-receipt')).toBe('no_delivery_receipt')
     expect(legacy.getAttribute('data-chat-stream-contract-badge-state')).toBe('no-turn-ref')
     const noTurnBadge = legacy.querySelector('[data-chat-stream-contract-badge]')
-    expect(noTurnBadge?.textContent).toContain('턴 연결 없음')
+    expect(noTurnBadge?.textContent).toContain('턴 연결 정보 없음')
     expect(noTurnBadge?.getAttribute('title')).toContain('conversation_id=discord:guild-1:channel:chan-1')
     expect(noTurnBadge?.getAttribute('title')).toContain('speaker_name=Minsu')
 
@@ -440,7 +440,7 @@ describe('ChatTranscript', () => {
     expect(failure.getAttribute('data-chat-stream-contract-lifecycle-events')).toBe('RUN_STARTED,RUN_ERROR')
     expect(failure.getAttribute('data-chat-stream-contract-delivery-receipt')).toBe('server_lifecycle_replay_only')
     expect(failure.getAttribute('data-chat-stream-contract-badge-state')).toBe('server-replay')
-    expect(failure.querySelector('[data-chat-stream-contract-badge]')?.textContent).toContain('서버 replay')
+    expect(failure.querySelector('[data-chat-stream-contract-badge]')?.textContent).toContain('서버 기록 복구')
     // transport_failure renders the typed card, so the raw diagnostic is
     // collapsed by default (the legacy banner is suppressed for card rows)
     // and surfaces only on expand.

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -541,13 +541,13 @@ function streamContractBadgeInfo(entry: KeeperConversationEntry): StreamContract
   ].filter((value): value is string => Boolean(value)).join(' · ')
   switch (contract.deliveryReceipt) {
     case 'server_lifecycle_replay_only':
-      return { label: '서버 replay', title, state: 'server-replay' }
+      return { label: '서버 기록 복구', title, state: 'server-replay' }
     case 'no_delivery_receipt':
       switch (contract.status) {
         case 'history_without_turn_ref':
-          return { label: '턴 연결 없음', title, state: 'no-turn-ref' }
+          return { label: '턴 연결 정보 없음', title, state: 'no-turn-ref' }
         case 'contract_gap':
-          return { label: '수신 gap', title, state: 'contract-gap' }
+          return { label: '전달 상태 확인 필요', title, state: 'contract-gap' }
         default:
           return null
       }

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -466,6 +466,8 @@ function QueueReceiptBadge({ entry }: { entry: KeeperConversationEntry }) {
       case 'inflight': return 'Keeper 처리 중'
       case 'delivered': return '처리 완료'
       case 'failed': return '처리 실패'
+      case 'durability_uncertain': return '내구성 확인 필요'
+      case 'unavailable': return '큐 확인 불가'
       default: return '상태 확인 필요'
     }
   })()
@@ -518,7 +520,7 @@ function sourceBadgeInfo(entry: KeeperConversationEntry): { label: string; cls: 
 type StreamContractBadgeInfo = {
   label: string
   title: string
-  state: 'contract-gap' | 'no-turn-ref' | 'server-replay'
+  state: 'contract-gap' | 'durability-uncertain' | 'no-turn-ref' | 'server-replay'
 }
 
 function streamContractBadgeInfo(entry: KeeperConversationEntry): StreamContractBadgeInfo | null {
@@ -540,6 +542,8 @@ function streamContractBadgeInfo(entry: KeeperConversationEntry): StreamContract
     sourceContext || null,
   ].filter((value): value is string => Boolean(value)).join(' · ')
   switch (contract.deliveryReceipt) {
+    case 'server_receipt_durability_uncertain':
+      return { label: '내구성 확인 필요', title, state: 'durability-uncertain' }
     case 'server_lifecycle_replay_only':
       return { label: '서버 기록 복구', title, state: 'server-replay' }
     case 'no_delivery_receipt':
@@ -562,6 +566,8 @@ function streamContractBadgeClass(state: StreamContractBadgeInfo['state']): stri
       return 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--color-status-warn)]'
     case 'contract-gap':
       return 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--color-status-warn)]'
+    case 'durability-uncertain':
+      return 'border-[var(--danger-20)] bg-[var(--danger-10)] text-[var(--color-status-danger)]'
     case 'no-turn-ref':
       return 'border-[var(--color-border-default)] bg-[var(--color-bg-surface)] text-[var(--color-fg-secondary)]'
   }
@@ -625,6 +631,7 @@ function overviewRows(details: KeeperConversationDetails): Array<{ label: string
     details.queueReceiptId ? { label: '큐 receipt', value: details.queueReceiptId } : null,
     details.queueShutdownOperationId ? { label: '종료 작업 ID', value: details.queueShutdownOperationId } : null,
     details.queueState ? { label: '큐 상태', value: details.queueState } : null,
+    details.queueDurability ? { label: '큐 내구성', value: details.queueDurability } : null,
     details.queueFailureKind ? { label: '큐 실패', value: details.queueFailureKind } : null,
     typeof details.queueRevision === 'number' ? { label: '큐 revision', value: `${details.queueRevision}` } : null,
     typeof details.queuePendingCount === 'number' ? { label: '접수 시 pending', value: `${details.queuePendingCount}` } : null,

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -252,6 +252,38 @@ describe('reconcileKeeperChatReceipts', () => {
     })
   })
 
+  it('stops polling and refuses to call a quarantined receipt durable', async () => {
+    fetchKeeperChatReceipt.mockResolvedValue({
+      keeperName: 'echo',
+      receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
+      revision: 2,
+      availability: 'quarantined',
+      loadErrors: [
+        {
+          kind: 'durability_uncertain',
+          message: 'Queue durability is uncertain; operator recovery is required.',
+        },
+      ],
+      state: { kind: 'inflight', leaseId: 'lease-1', startedAt: 42 },
+    })
+
+    await reconcileKeeperChatReceipts('echo')
+
+    const entry = keeperThreads.value.echo?.find(candidate => (
+      candidate.details?.queueReceiptId === 'chatq_00000000-0000-4000-8000-000000000001'
+    ))
+    expect(entry?.delivery).toBe('error')
+    expect(entry?.details?.queueState).toBe('durability_uncertain')
+    expect(entry?.details?.queueDurability).toBe('uncertain')
+    expect(entry?.streamContract?.deliveryReceipt).toBe(
+      'server_receipt_durability_uncertain',
+    )
+    expect(entry?.error).toContain('재전송하지 말고')
+
+    await reconcileKeeperChatReceipts('echo')
+    expect(fetchKeeperChatReceipt).toHaveBeenCalledTimes(1)
+  })
+
   it('fails closed instead of retrying forever when Delivered lacks outcome_ref', async () => {
     fetchKeeperChatReceipt.mockResolvedValue({
       keeperName: 'echo',
@@ -1421,6 +1453,8 @@ describe('sendKeeperThreadMessage stream outcome', () => {
       keeperName: 'echo',
       receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
       revision: 4,
+      availability: 'available',
+      loadErrors: [],
       state: { kind: 'pending' },
     })
     streamKeeperMessage.mockImplementation(emitting([
@@ -1437,6 +1471,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
           queue_revision: 4,
           pending_count: 1,
           inflight_count: 0,
+          queue_durability: 'durable',
           shutdown_operation_id: null,
         },
       },
@@ -1466,6 +1501,8 @@ describe('sendKeeperThreadMessage stream outcome', () => {
       keeperName: 'echo',
       receiptId: 'chatq_00000000-0000-4000-8000-000000000002',
       revision: 5,
+      availability: 'available',
+      loadErrors: [],
       state: {
         kind: 'failed',
         failureKind: 'turn_failed',
@@ -1488,6 +1525,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
           queue_revision: 4,
           pending_count: 1,
           inflight_count: 0,
+          queue_durability: 'durable',
           shutdown_operation_id: null,
         },
       },

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -1496,6 +1496,44 @@ describe('sendKeeperThreadMessage stream outcome', () => {
     )
   })
 
+  it('does not let RUN_FINISHED overwrite an uncertain queue receipt', async () => {
+    streamKeeperMessage.mockImplementation(emitting([
+      { type: 'RUN_STARTED' },
+      {
+        type: 'CUSTOM',
+        name: 'KEEPER_CHAT_QUEUED',
+        value: {
+          keeper_name: 'echo',
+          status: 'queued_durability_uncertain',
+          receipt_id: 'chatq_00000000-0000-4000-8000-000000000003',
+          queue_revision: 6,
+          pending_count: 1,
+          inflight_count: 0,
+          queue_durability: 'uncertain',
+          shutdown_operation_id: null,
+        },
+      },
+      { type: 'RUN_FINISHED' },
+    ], true))
+
+    await sendKeeperThreadMessage('echo', '진행 상황?')
+
+    const reply = (keeperThreads.value.echo ?? []).find(entry => entry.role === 'assistant')
+    expect(reply?.delivery).toBe('error')
+    expect(reply?.details).toMatchObject({
+      queueReceiptId: 'chatq_00000000-0000-4000-8000-000000000003',
+      queueRevision: 6,
+      queueState: 'durability_uncertain',
+      queueDurability: 'uncertain',
+    })
+    expect(reply?.error).toContain('crash 내구성')
+    expect(reply?.streamContract).toMatchObject({
+      source: 'queue_event',
+      status: 'queue_request_event',
+      eventName: 'KEEPER_CHAT_QUEUED',
+    })
+  })
+
   it('does not let the short ACK RUN_FINISHED overwrite a durable failed receipt', async () => {
     fetchKeeperChatReceipt.mockResolvedValue({
       keeperName: 'echo',

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -1338,11 +1338,21 @@ export async function sendKeeperThreadMessage(
       return
     }
 
-    const finalDelivery =
-      finalEntry?.delivery === 'queued'
-        ? 'queued' as KeeperConversationDelivery
-        : 'delivered' as KeeperConversationDelivery
-    if (!finalText && finalDelivery !== 'queued' && !toolCallEnded) {
+    const preserveQueueDurabilityFailure =
+      finalEntry?.delivery === 'error'
+      && finalEntry.details?.queueState === 'durability_uncertain'
+      && finalEntry.details.queueDurability === 'uncertain'
+    const finalDelivery: KeeperConversationDelivery = (() => {
+      if (finalEntry?.delivery === 'queued') return 'queued'
+      if (preserveQueueDurabilityFailure) return 'error'
+      return 'delivered'
+    })()
+    if (
+      !finalText
+      && finalDelivery !== 'queued'
+      && !preserveQueueDurabilityFailure
+      && !toolCallEnded
+    ) {
       finalizeAssistantEntry(keeperName, assistantId, {
         text: EMPTY_VISIBLE_REPLY_TEXT,
         rawText: finalEntry?.rawText || EMPTY_VISIBLE_REPLY_TEXT,
@@ -1372,10 +1382,12 @@ export async function sendKeeperThreadMessage(
       delivery: finalDelivery,
       streamState: null,
       timestamp: new Date().toISOString(),
-      error: null,
-      streamContract: keeperClientObservedSseStreamContract('sse_event', 'backend_terminal_event', {
-        eventName: 'RUN_FINISHED',
-      }),
+      error: preserveQueueDurabilityFailure ? finalEntry.error : null,
+      streamContract: preserveQueueDurabilityFailure
+        ? finalEntry.streamContract
+        : keeperClientObservedSseStreamContract('sse_event', 'backend_terminal_event', {
+            eventName: 'RUN_FINISHED',
+          }),
     })
     if (toolCallEnded) void hydrateKeeperToolOutputs(keeperName)
     if (requestId) {

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -822,6 +822,39 @@ export async function reconcileKeeperChatReceipts(name: string): Promise<void> {
       if (typeof currentRevision === 'number' && receipt.revision < currentRevision) {
         return
       }
+      if (receipt.availability === 'quarantined') {
+        const errorKinds = receipt.loadErrors.map(error => error.kind)
+        const durabilityUncertain = errorKinds.includes('durability_uncertain')
+        const message = durabilityUncertain
+          ? '큐 receipt는 서버에 보이지만 crash 내구성을 확정하지 못했습니다. 재전송하지 말고 운영자 복구를 기다리세요.'
+          : `큐 receipt 저장소가 격리되었습니다 (${errorKinds.join(', ')}). 운영자 복구가 필요합니다.`
+        const receiptTargets = pendingTerminalTranscriptConvergence.get(keeperName)
+        receiptTargets?.delete(receiptId)
+        if (receiptTargets?.size === 0) {
+          pendingTerminalTranscriptConvergence.delete(keeperName)
+        }
+        setRecordValue(keeperActionErrors, keeperName, message)
+        finalizeAssistantEntry(keeperName, entry.id, {
+          delivery: 'error',
+          error: message,
+          streamState: null,
+          details: {
+            ...(entry.details ?? {}),
+            queueRevision: receipt.revision,
+            queueState: durabilityUncertain ? 'durability_uncertain' : 'unavailable',
+            queueDurability: durabilityUncertain ? 'uncertain' : null,
+            queueFailureKind:
+              receipt.state.kind === 'failed' ? receipt.state.failureKind : null,
+          },
+          streamContract: keeperStreamContract('queue_poll', 'queue_poll_result', {
+            deliveryReceipt: durabilityUncertain
+              ? 'server_receipt_durability_uncertain'
+              : 'no_delivery_receipt',
+            reason: `receipt ${receiptId} is quarantined (${errorKinds.join(',')})`,
+          }),
+        })
+        return
+      }
       if (
         typeof currentRevision === 'number'
         && receipt.revision === currentRevision

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -325,6 +325,10 @@ function normalizeStreamDeliveryReceipt(value: unknown): KeeperConversationStrea
   switch (asString(value)?.trim()) {
     case 'client_observed_sse_event':
       return 'client_observed_sse_event'
+    case 'server_durable_receipt':
+      return 'server_durable_receipt'
+    case 'server_receipt_durability_uncertain':
+      return 'server_receipt_durability_uncertain'
     case 'server_lifecycle_replay_only':
       return 'server_lifecycle_replay_only'
     case 'no_delivery_receipt':

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -103,6 +103,7 @@ describe('applyKeeperStreamEvent', () => {
         queue_revision: 12,
         pending_count: 3,
         inflight_count: 1,
+        queue_durability: 'durable',
         shutdown_operation_id: ' shutdown-op-7 ',
       },
     })).toBeNull()
@@ -116,12 +117,61 @@ describe('applyKeeperStreamEvent', () => {
       queueRevision: 12,
       queuePendingCount: 3,
       queueInflightCount: 1,
+      queueDurability: 'durable',
     })
     expect(entry?.streamContract).toMatchObject({
       source: 'queue_event',
       eventName: 'KEEPER_CHAT_QUEUED',
       deliveryReceipt: 'client_observed_sse_event',
     })
+  })
+
+  it('surfaces a committed receipt with uncertain crash durability without polling it as pending', () => {
+    assistantEntry()
+    expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_CHAT_QUEUED',
+      value: {
+        keeper_name: 'sangsu',
+        status: 'queued_durability_uncertain',
+        receipt_id: 'chatq_00000000-0000-4000-8000-000000000008',
+        queue_revision: 13,
+        pending_count: 4,
+        inflight_count: 1,
+        queue_durability: 'uncertain',
+        shutdown_operation_id: null,
+      },
+    })).toBeNull()
+
+    const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
+    expect(entry?.delivery).toBe('error')
+    expect(entry?.details).toMatchObject({
+      queueReceiptId: 'chatq_00000000-0000-4000-8000-000000000008',
+      queueRevision: 13,
+      queueState: 'durability_uncertain',
+      queueDurability: 'uncertain',
+    })
+    expect(entry?.error).toContain('재전송하지 말고')
+    expect(entry?.streamContract?.reason).toBe(
+      'receipt chatq_00000000-0000-4000-8000-000000000008 durability uncertain',
+    )
+  })
+
+  it('rejects queue acceptance without an exact durability contract', () => {
+    assistantEntry()
+    expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_CHAT_QUEUED',
+      value: {
+        keeper_name: 'sangsu',
+        status: 'queued',
+        receipt_id: 'chatq_00000000-0000-4000-8000-000000000009',
+        queue_revision: 14,
+        pending_count: 1,
+        inflight_count: 0,
+        shutdown_operation_id: null,
+      },
+    })).toBe('Keeper queue acceptance has invalid durability metadata.')
   })
 
   it('rejects a busy queue acceptance event without a durable receipt', () => {
@@ -167,10 +217,12 @@ describe('applyKeeperStreamEvent', () => {
   it('rejects missing, blank, or wrongly typed shutdown operation metadata', () => {
     assistantEntry()
     const baseValue = {
+      status: 'queued',
       receipt_id: 'chatq_00000000-0000-4000-8000-000000000007',
       queue_revision: 1,
       pending_count: 1,
       inflight_count: 0,
+      queue_durability: 'durable',
     }
 
     for (const shutdownOperationId of [undefined, '   ', 7]) {

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -688,6 +688,12 @@ export function applyKeeperStreamEvent(
         const revision = asNumber(queued?.queue_revision)
         const pendingCount = asNumber(queued?.pending_count)
         const inflightCount = asNumber(queued?.inflight_count)
+        const queueStatus = asString(queued?.status, '').trim()
+        const queueDurability = (() => {
+          const raw = queued?.queue_durability
+          if (raw === 'durable' || raw === 'uncertain') return raw
+          return null
+        })()
         const shutdownOperationId = (() => {
           const raw = queued?.shutdown_operation_id
           if (raw === null) return null
@@ -709,12 +715,28 @@ export function applyKeeperStreamEvent(
         ) {
           return 'Keeper queue acceptance is missing its durable receipt metadata.'
         }
+        if (queueDurability === null) {
+          return 'Keeper queue acceptance has invalid durability metadata.'
+        }
+        if (
+          (queueDurability === 'durable' && queueStatus !== 'queued')
+          || (
+            queueDurability === 'uncertain'
+            && queueStatus !== 'queued_durability_uncertain'
+          )
+        ) {
+          return 'Keeper queue acceptance has inconsistent durability status.'
+        }
         if (shutdownOperationId === undefined) {
           return 'Keeper queue acceptance has invalid shutdown operation metadata.'
         }
+        const durabilityUncertain = queueDurability === 'uncertain'
         updateThreadEntry(keeperName, assistantEntryId, entry => ({
           ...entry,
-          delivery: 'queued',
+          delivery: durabilityUncertain ? 'error' : 'queued',
+          error: durabilityUncertain
+            ? '서버가 receipt를 수락했지만 crash 내구성을 확정하지 못했습니다. 재전송하지 말고 운영자 복구를 기다리세요.'
+            : entry.error,
           streamState: null,
           details: {
             ...(entry.details ?? {}),
@@ -723,11 +745,14 @@ export function applyKeeperStreamEvent(
             queueRevision: revision,
             queuePendingCount: pendingCount,
             queueInflightCount: inflightCount,
-            queueState: 'pending',
+            queueState: durabilityUncertain ? 'durability_uncertain' : 'pending',
+            queueDurability,
           },
           streamContract: keeperClientObservedSseStreamContract('queue_event', 'queue_request_event', {
             eventName: 'KEEPER_CHAT_QUEUED',
-            reason: `durable receipt ${receiptId}`,
+            reason: durabilityUncertain
+              ? `receipt ${receiptId} durability uncertain`
+              : `durable receipt ${receiptId}`,
           }),
         }))
         return null

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -773,6 +773,12 @@ export type KeeperQueueReceiptLifecycle =
   | 'inflight'
   | 'delivered'
   | 'failed'
+  | 'durability_uncertain'
+  | 'unavailable'
+
+export type KeeperQueueDurability =
+  | 'durable'
+  | 'uncertain'
 
 export type KeeperQueueReceiptFailureKind =
   | 'turn_failed'
@@ -783,6 +789,7 @@ export type KeeperQueueReceiptFailureKind =
   | 'delivery_failed'
   | 'cancelled'
   | 'internal_error'
+  | 'recovery_interrupted'
 
 export interface KeeperConversationDetails {
   traceId?: string | null
@@ -807,6 +814,7 @@ export interface KeeperConversationDetails {
   queuePendingCount?: number | null
   queueInflightCount?: number | null
   queueState?: KeeperQueueReceiptLifecycle | null
+  queueDurability?: KeeperQueueDurability | null
   queueFailureKind?: KeeperQueueReceiptFailureKind | null
   queueCorrelationError?: 'missing_outcome_ref' | null
   rawPayload?: unknown
@@ -988,6 +996,7 @@ export type KeeperConversationStreamContractStatus =
 export type KeeperConversationStreamDeliveryReceipt =
   | 'client_observed_sse_event'
   | 'server_durable_receipt'
+  | 'server_receipt_durability_uncertain'
   | 'server_lifecycle_replay_only'
   | 'no_delivery_receipt'
 

--- a/lib/fs_compat/atomic_write.ml
+++ b/lib/fs_compat/atomic_write.ml
@@ -7,19 +7,8 @@
 let fsync_path path =
   let fd = Unix.openfile path [ Unix.O_RDONLY ] 0 in
   Stdlib.Fun.protect
-    ~finally:(fun () ->
-      try Unix.close fd with
-      | Eio.Cancel.Cancelled _ as e -> raise e
-      | exn ->
-        Stdlib.Printf.eprintf
-          "[fs_compat] fsync_path close failed: %s\n%!"
-          (Printexc.to_string exn))
-    (fun () ->
-      try Unix.fsync fd with
-      | Unix.Unix_error ((Unix.EINVAL | Unix.EOPNOTSUPP), _, _) ->
-        (* Some filesystems (tmpfs on some kernels) reject fsync. The data
-           is still durable to the extent the underlying FS offers. *)
-        ())
+    ~finally:(fun () -> Unix.close fd)
+    (fun () -> Unix.fsync fd)
 ;;
 
 (* #10205 finding 2: keep the atomic-tmp filename shape in one place
@@ -45,8 +34,7 @@ let save_file_atomic
     save_file tmp content;
     fsync_path tmp;
     Stdlib.Sys.rename tmp path;
-    (try fsync_path dir with
-     | Unix.Unix_error _ -> ());
+    fsync_path dir;
     Ok ()
   with
   | Eio.Cancel.Cancelled _ as e ->

--- a/lib/fs_compat/atomic_write.ml
+++ b/lib/fs_compat/atomic_write.ml
@@ -20,31 +20,67 @@ let fsync_path path =
 let atomic_tmp_prefix = ".atomic_"
 let atomic_tmp_suffix = ".tmp"
 
-let save_file_atomic
+type failure_stage =
+  | Not_renamed
+  | Renamed_durability_uncertain
+
+type failure =
+  { stage : failure_stage
+  ; message : string
+  }
+
+let failure_to_string failure = failure.message
+
+let save_file_atomic_detailed
   ~(save_file : string -> string -> unit)
   (path : string)
   (content : string)
-  : (unit, string) Result.t
+  : (unit, failure) Result.t
   =
   let dir = Stdlib.Filename.dirname path in
-  let tmp =
-    Stdlib.Filename.temp_file ~temp_dir:dir atomic_tmp_prefix atomic_tmp_suffix
+  let tmp = ref None in
+  let renamed = ref false in
+  let cleanup_tmp () =
+    match !tmp with
+    | None -> ()
+    | Some tmp_path ->
+      (try Stdlib.Sys.remove tmp_path with
+       | Sys_error _ -> ())
   in
   try
-    save_file tmp content;
-    fsync_path tmp;
-    Stdlib.Sys.rename tmp path;
+    let tmp_path =
+      Stdlib.Filename.temp_file
+        ~temp_dir:dir
+        atomic_tmp_prefix
+        atomic_tmp_suffix
+    in
+    tmp := Some tmp_path;
+    save_file tmp_path content;
+    fsync_path tmp_path;
+    Stdlib.Sys.rename tmp_path path;
+    renamed := true;
     fsync_path dir;
     Ok ()
   with
   | Eio.Cancel.Cancelled _ as e ->
-    (try Stdlib.Sys.remove tmp with
-     | Sys_error _ -> ());
+    cleanup_tmp ();
     raise e
   | exn ->
-    (try Stdlib.Sys.remove tmp with
-     | Sys_error _ -> ());
-    Error (Printf.sprintf "save_file_atomic %s: %s" path (Printexc.to_string exn))
+    cleanup_tmp ();
+    Error
+      { stage =
+          (if !renamed then Renamed_durability_uncertain else Not_renamed)
+      ; message =
+          Printf.sprintf
+            "save_file_atomic %s: %s"
+            path
+            (Printexc.to_string exn)
+      }
+;;
+
+let save_file_atomic ~save_file path content =
+  save_file_atomic_detailed ~save_file path content
+  |> Result.map_error failure_to_string
 ;;
 
 let is_atomic_orphan_name name =

--- a/lib/fs_compat/atomic_write.mli
+++ b/lib/fs_compat/atomic_write.mli
@@ -16,12 +16,39 @@
     this module stays free of [Fs_compat]'s Eio bridge — same
     cycle-free placement pattern as [Mkdir_memo] and [Fd_cache]. *)
 
-(** [save_file_atomic ~save_file path content] writes [content] to
-    a temp file in [path]'s directory, fsyncs the tmp, renames it
-    over [path], and best-effort fsyncs the parent directory.
+(** Whether an atomic write failure happened before or after the rename commit
+    point. After-rename failure means the new file is visible in the current
+    process but crash durability could not be proven. *)
+type failure_stage =
+  | Not_renamed
+  | Renamed_durability_uncertain
 
-    Returns [Ok ()] on success or [Error msg] when the write or
-    rename fails (the tmp is cleaned up). Re-raises
+type failure =
+  { stage : failure_stage
+  ; message : string
+  }
+
+val failure_to_string : failure -> string
+
+(** [save_file_atomic_detailed ~save_file path content] writes [content] to
+    a temp file in [path]'s directory, fsyncs the tmp, renames it over [path],
+    and fsyncs the parent directory. No fsync failure is swallowed.
+
+    [Not_renamed] proves the old target remains authoritative.
+    [Renamed_durability_uncertain] means the new target is already visible and
+    callers must not roll in-memory state back to the old revision. *)
+val save_file_atomic_detailed
+  :  save_file:(string -> string -> unit)
+  -> string
+  -> string
+  -> (unit, failure) Result.t
+
+(** Compatibility wrapper around {!save_file_atomic_detailed}.
+
+    Returns [Error msg] for every durability failure, preserving the existing
+    explicit-failure API while erasing only the stage. Stateful callers that
+    might roll memory back must use {!save_file_atomic_detailed} to distinguish
+    the rename commit point. Re-raises
     [Eio.Cancel.Cancelled] after cleaning up the tmp — cancellation
     must not be swallowed (RFC-0143). *)
 val save_file_atomic

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -135,9 +135,16 @@ let load_file_unix (path : string) : string =
 
 let save_file_unix (path : string) (content : string) : unit =
   let oc = Stdlib.open_out path in
-  Stdlib.Fun.protect
-    ~finally:(fun () -> Stdlib.close_out_noerr oc)
-    (fun () -> Stdlib.output_string oc content)
+  match Stdlib.output_string oc content with
+  | () ->
+    (match Stdlib.close_out oc with
+     | () -> ()
+     | exception exn ->
+       Stdlib.close_out_noerr oc;
+       raise exn)
+  | exception exn ->
+    Stdlib.close_out_noerr oc;
+    raise exn
 ;;
 
 (* RFC-0108: per-path Stdlib.Mutex registry + fresh-fd open/close
@@ -288,6 +295,24 @@ let save_file (path : string) (content : string) : unit =
        Eio.Path.save ~create:(`Or_truncate 0o644) eio_path content)
 ;;
 
+type atomic_write_failure_stage = Atomic_write.failure_stage =
+  | Not_renamed
+  | Renamed_durability_uncertain
+
+type atomic_write_failure = Atomic_write.failure =
+  { stage : atomic_write_failure_stage
+  ; message : string
+  }
+
+let save_file_atomic_detailed path content =
+  test_exec_home_guard ~op:"save_file_atomic" path;
+  run_blocking_unix_io (fun () ->
+    Atomic_write.save_file_atomic_detailed
+      ~save_file:save_file_unix
+      path
+      content)
+;;
+
 let save_file_atomic path content =
   test_exec_home_guard ~op:"save_file_atomic" path;
   run_blocking_unix_io (fun () ->
@@ -325,6 +350,29 @@ let file_exists (path : string) : bool =
          true
        with
        | Eio.Io _ -> false)
+;;
+
+type path_probe_failure =
+  { error : Unix.error
+  ; function_name : string
+  ; argument : string
+  }
+
+let path_probe_failure_to_string failure =
+  Printf.sprintf
+    "%s(%s): %s"
+    failure.function_name
+    failure.argument
+    (Unix.error_message failure.error)
+;;
+
+let probe_path path =
+  run_blocking_unix_io (fun () ->
+    match Unix.stat path with
+    | stats -> Ok (Some stats)
+    | exception Unix.Unix_error (Unix.ENOENT, _, _) -> Ok None
+    | exception Unix.Unix_error (error, function_name, argument) ->
+      Error { error; function_name; argument })
 ;;
 
 (** Load entire file contents as string, or [None] when the file is
@@ -925,7 +973,15 @@ let fsync_directory_result dir =
       run_unix_io ~operation:Parent_directory_fsync (fun () -> Unix.fsync fd)
     in
     let close_result =
-      run_unix_io ~operation:Parent_directory_close (fun () -> Unix.close fd)
+      match Unix.close fd with
+      | () -> Ok ()
+      | exception Unix.Unix_error (error, function_name, argument) ->
+        Error
+          (unix_failure
+             ~operation:Parent_directory_close
+             error
+             function_name
+             argument)
     in
     (match fsync_result, close_result with
      | Ok (), Ok () -> Ok ()
@@ -957,6 +1013,12 @@ let open_append_file path =
     , false )
 ;;
 
+let rec lock_whole_file fd =
+  match Unix.lockf fd Unix.F_LOCK 0 with
+  | () -> ()
+  | exception Unix.Unix_error (Unix.EINTR, _, _) -> lock_whole_file fd
+;;
+
 let with_private_append_fd_locked ~op path f =
   test_exec_home_guard ~op path;
   let dir = Filename.dirname path in
@@ -977,7 +1039,7 @@ let with_private_append_fd_locked ~op path f =
           (fun () ->
              Unix.fchmod lock_fd 0o600;
              ignore (Unix.lseek lock_fd 0 Unix.SEEK_SET : int);
-             Unix.lockf lock_fd Unix.F_LOCK 0;
+             lock_whole_file lock_fd;
              let fd, created = open_append_file path in
              Fun.protect
                ~finally:(fun () -> Unix.close fd)

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -258,7 +258,7 @@ let mkdir_p_durable_unix path =
       ensure parent;
       (try Unix.mkdir path 0o755 with
        | Unix.Unix_error (Unix.EEXIST, _, _) ->
-         ignore (directory_exists_unix path : bool));
+         if not (directory_exists_unix path) then ensure path);
       fsync_directory_unix parent)
   in
   let existed = directory_exists_unix path in
@@ -1038,7 +1038,9 @@ let with_private_append_fd_locked ~op path f =
           ~finally:(fun () -> Unix.close lock_fd)
           (fun () ->
              Unix.fchmod lock_fd 0o600;
-             ignore (Unix.lseek lock_fd 0 Unix.SEEK_SET : int);
+             let (_lock_position : int) =
+               Unix.lseek lock_fd 0 Unix.SEEK_SET
+             in
              lock_whole_file lock_fd;
              let fd, created = open_append_file path in
              Fun.protect
@@ -1077,7 +1079,7 @@ let update_private_file_durable_locked_result path decide =
     ~op:"update_private_file_durable_locked"
     path
     (fun fd ->
-       ignore (Unix.lseek fd 0 Unix.SEEK_SET : int);
+       let (_read_position : int) = Unix.lseek fd 0 Unix.SEEK_SET in
        let existing = read_fd_contents fd in
        let suffix, result = decide existing in
        match suffix with
@@ -1127,7 +1129,9 @@ let append_private_jsonl_durable_locked_result path suffix =
              if original_length = 0
              then true
              else (
-               ignore (Unix.lseek fd (original_length - 1) Unix.SEEK_SET : int);
+               let (_tail_position : int) =
+                 Unix.lseek fd (original_length - 1) Unix.SEEK_SET
+               in
                let byte = Bytes.create 1 in
                let rec read_tail () =
                  match Unix.read fd byte 0 1 with
@@ -1141,7 +1145,9 @@ let append_private_jsonl_durable_locked_result path suffix =
            if not tail_is_complete
            then Error Incomplete_jsonl_tail
            else (
-             ignore (Unix.lseek fd 0 Unix.SEEK_END : int);
+             let (_append_position : int) =
+               Unix.lseek fd 0 Unix.SEEK_END
+             in
              append_fd_durable
                ~io:durable_append_unix_io
                ~fd

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -116,6 +116,14 @@ let with_fs_or_fallback ~path ~fallback f =
   | None -> fallback ()
 ;;
 
+let run_blocking_unix_io f =
+  match Atomic.get global_fs with
+  | None -> f ()
+  | Some _ ->
+    (try Eio_unix.run_in_systhread ~label:"fs-compat-blocking-io" f with
+     | Stdlib.Effect.Unhandled _ -> f ())
+;;
+
 let load_file_unix (path : string) : string =
   let ic = Stdlib.open_in path in
   Stdlib.Fun.protect
@@ -212,6 +220,49 @@ let mkdir_p_unix (path : string) : unit =
   ensure_dir path
 ;;
 
+let fsync_directory_unix path =
+  let fd = Unix.openfile path [ Unix.O_RDONLY; Unix.O_CLOEXEC ] 0 in
+  Fun.protect
+    ~finally:(fun () -> Unix.close fd)
+    (fun () -> Unix.fsync fd)
+;;
+
+let directory_exists_unix path =
+  match Unix.stat path with
+  | { Unix.st_kind = Unix.S_DIR; _ } -> true
+  | { Unix.st_kind = (Unix.S_REG | Unix.S_CHR | Unix.S_BLK | Unix.S_LNK
+                     | Unix.S_FIFO | Unix.S_SOCK)
+    ; _
+    } ->
+    raise (Unix.Unix_error (Unix.ENOTDIR, "mkdir_p_durable", path))
+  | exception Unix.Unix_error (Unix.ENOENT, _, _) -> false
+;;
+
+let mkdir_p_durable_unix path =
+  let rec ensure path =
+    if String.equal path ""
+       || String.equal path "."
+       || String.equal path "/"
+    then ()
+    else if directory_exists_unix path
+    then ()
+    else (
+      let parent = Filename.dirname path in
+      ensure parent;
+      (try Unix.mkdir path 0o755 with
+       | Unix.Unix_error (Unix.EEXIST, _, _) ->
+         ignore (directory_exists_unix path : bool));
+      fsync_directory_unix parent)
+  in
+  let existed = directory_exists_unix path in
+  ensure path;
+  if existed
+     && not (String.equal path "")
+     && not (String.equal path ".")
+     && not (String.equal path "/")
+  then fsync_directory_unix (Filename.dirname path)
+;;
+
 (** Load entire file contents as string.
     Eio-native when available, fallback to Unix.
     @raises Sys_error on all I/O failures. Eio.Io is normalized internally. *)
@@ -238,7 +289,9 @@ let save_file (path : string) (content : string) : unit =
 ;;
 
 let save_file_atomic path content =
-  Atomic_write.save_file_atomic ~save_file path content
+  test_exec_home_guard ~op:"save_file_atomic" path;
+  run_blocking_unix_io (fun () ->
+    Atomic_write.save_file_atomic ~save_file:save_file_unix path content)
 ;;
 
 let is_atomic_orphan_name = Atomic_write.is_atomic_orphan_name
@@ -391,6 +444,15 @@ let mkdir_p (path : string) : unit =
     (fun fs ->
        let eio_path = Eio.Path.(fs / path) in
        Eio.Path.mkdirs ~exists_ok:true ~perm:0o755 eio_path)
+;;
+
+(** Create a directory hierarchy and durably publish every newly-created
+    directory entry before returning. Existing leaf directories have their
+    parent entry synced once as well, so retry after an uncertain fsync cannot
+    report success without re-establishing the durability boundary. *)
+let mkdir_p_durable path =
+  test_exec_home_guard ~op:"mkdir_p_durable" path;
+  run_blocking_unix_io (fun () -> mkdir_p_durable_unix path)
 ;;
 
 (* RFC-0162 §3.1: once-per-path mkdir memoize. Hot append paths
@@ -662,20 +724,28 @@ let reset_fd_cache_for_testing () = Fd_cache.reset_for_testing ()
 
 let with_cached_writer_for_testing path f = Fd_cache.with_writer path f
 
-let rec read_fd_chunks fd buffer =
+let read_fd_contents fd =
   let chunk = Bytes.create 65536 in
-  match Unix.read fd chunk 0 (Bytes.length chunk) with
-  | 0 -> Buffer.contents buffer
-  | count ->
-    Buffer.add_subbytes buffer chunk 0 count;
-    read_fd_chunks fd buffer
-  | exception Unix.Unix_error (Unix.EINTR, _, _) -> read_fd_chunks fd buffer
+  let buffer = Buffer.create 4096 in
+  let rec loop () =
+    match Unix.read fd chunk 0 (Bytes.length chunk) with
+    | 0 -> Buffer.contents buffer
+    | count ->
+      Buffer.add_subbytes buffer chunk 0 count;
+      loop ()
+    | exception Unix.Unix_error (Unix.EINTR, _, _) -> loop ()
+  in
+  loop ()
+;;
 
 type durable_append_operation =
   | Write
   | Append_fsync
   | Rollback_truncate
   | Rollback_fsync
+  | Parent_directory_open
+  | Parent_directory_fsync
+  | Parent_directory_close
 
 type durable_append_failure =
   | Unix_error of
@@ -691,11 +761,16 @@ type durable_append_error =
   ; rollback_failures : durable_append_failure list
   }
 
+exception Durable_append_failed of durable_append_error
+
 let durable_append_operation_to_string = function
   | Write -> "write"
   | Append_fsync -> "append fsync"
   | Rollback_truncate -> "rollback truncate"
   | Rollback_fsync -> "rollback fsync"
+  | Parent_directory_open -> "parent directory open"
+  | Parent_directory_fsync -> "parent directory fsync"
+  | Parent_directory_close -> "parent directory close"
 ;;
 
 let durable_append_failure_to_string = function
@@ -720,6 +795,16 @@ let durable_append_error_to_string { append_failure; rollback_failures } =
       (failures
        |> List.map durable_append_failure_to_string
        |> String.concat "; ")
+;;
+
+let () =
+  Printexc.register_printer (function
+    | Durable_append_failed error ->
+      Some
+        (Printf.sprintf
+           "Fs_compat.Durable_append_failed(%s)"
+           (durable_append_error_to_string error))
+    | _ -> None)
 ;;
 
 type durable_append_io_for_testing =
@@ -784,65 +869,174 @@ let append_fd_durable ~io ~fd ~original_length suffix =
 let append_fd_durable_for_testing = append_fd_durable
 
 let durable_append_unix_io =
-  { write = Unix.write; ftruncate = Unix.ftruncate; fsync = Unix.fsync }
+  { write = Unix.single_write; ftruncate = Unix.ftruncate; fsync = Unix.fsync }
 ;;
 
-let fsync_parent_directory dir =
-  let fd = Unix.openfile dir [ Unix.O_RDONLY; Unix.O_CLOEXEC ] 0 in
-  Fun.protect
-    ~finally:(fun () -> Unix.close fd)
-    (fun () -> Unix.fsync fd)
+type durable_append_eio_mutex_entry =
+  { mutex : Eio.Mutex.t
+  ; mutable users : int
+  }
+
+let durable_append_eio_mutex_registry
+  : (string, durable_append_eio_mutex_entry) Hashtbl.t
+  =
+  Hashtbl.create 32
 ;;
 
-let rec lock_whole_file fd =
-  match Unix.lockf fd Unix.F_LOCK 0 with
-  | () -> ()
-  | exception Unix.Unix_error (Unix.EINTR, _, _) -> lock_whole_file fd
+let durable_append_eio_mutex_registry_mu = Stdlib.Mutex.create ()
+
+let acquire_durable_append_eio_mutex path =
+  Stdlib.Mutex.protect durable_append_eio_mutex_registry_mu (fun () ->
+    match Hashtbl.find_opt durable_append_eio_mutex_registry path with
+    | Some entry ->
+      entry.users <- entry.users + 1;
+      entry
+    | None ->
+      let entry = { mutex = Eio.Mutex.create (); users = 1 } in
+      Hashtbl.add durable_append_eio_mutex_registry path entry;
+      entry)
 ;;
 
-let run_blocking_durable_append ~path f =
-  with_fs_or_fallback
-    ~path
-    ~fallback:f
-    (fun _fs ->
-       Eio_unix.run_in_systhread ~label:"fs-compat-durable-append" f)
+let release_durable_append_eio_mutex path entry =
+  Stdlib.Mutex.protect durable_append_eio_mutex_registry_mu (fun () ->
+    entry.users <- entry.users - 1;
+    if entry.users = 0
+    then
+      match Hashtbl.find_opt durable_append_eio_mutex_registry path with
+      | Some current when current == entry ->
+        Hashtbl.remove durable_append_eio_mutex_registry path
+      | Some _ | None -> ())
 ;;
 
-let update_private_file_durable_locked_result path decide =
-  test_exec_home_guard ~op:"update_private_file_durable_locked" path;
+let fsync_directory_result dir =
+  match Unix.openfile dir [ Unix.O_RDONLY; Unix.O_CLOEXEC ] 0 with
+  | exception Unix.Unix_error (error, function_name, argument) ->
+    Error
+      { append_failure =
+          unix_failure
+            ~operation:Parent_directory_open
+            error
+            function_name
+            argument
+      ; rollback_failures = []
+      }
+  | fd ->
+    let fsync_result =
+      run_unix_io ~operation:Parent_directory_fsync (fun () -> Unix.fsync fd)
+    in
+    let close_result =
+      run_unix_io ~operation:Parent_directory_close (fun () -> Unix.close fd)
+    in
+    (match fsync_result, close_result with
+     | Ok (), Ok () -> Ok ()
+     | Error append_failure, Ok () | Ok (), Error append_failure ->
+       Error { append_failure; rollback_failures = [] }
+     | Error fsync_failure, Error close_failure ->
+       Error
+         { append_failure = fsync_failure
+         ; rollback_failures = [ close_failure ]
+         })
+;;
+
+let open_append_file path =
+  try
+    ( Unix.openfile path
+        [ Unix.O_RDWR
+        ; Unix.O_CREAT
+        ; Unix.O_EXCL
+        ; Unix.O_APPEND
+        ; Unix.O_CLOEXEC
+        ]
+        0o600
+    , true )
+  with
+  | Unix.Unix_error (Unix.EEXIST, _, _) ->
+    ( Unix.openfile path
+        [ Unix.O_RDWR; Unix.O_APPEND; Unix.O_CLOEXEC ]
+        0o600
+    , false )
+;;
+
+let with_private_append_fd_locked ~op path f =
+  test_exec_home_guard ~op path;
   let dir = Filename.dirname path in
   mkdir_p_memoized dir;
   let path_mu = get_append_path_mutex path in
-  run_blocking_durable_append ~path (fun () ->
-    Stdlib.Mutex.protect path_mu (fun () ->
-      let fd =
-        Unix.openfile path
-          [ Unix.O_RDWR; Unix.O_CREAT; Unix.O_APPEND; Unix.O_CLOEXEC ]
-          0o600
-      in
-      Fun.protect
-        ~finally:(fun () -> Unix.close fd)
-        (fun () ->
-           Unix.fchmod fd 0o600;
-           fsync_parent_directory dir;
-           (* See Unix.lseek: only the file-position side effect is required. *)
-           ignore (Unix.lseek fd 0 Unix.SEEK_SET : int);
-           lock_whole_file fd;
-           (* See Unix.lseek: only the file-position side effect is required. *)
-           ignore (Unix.lseek fd 0 Unix.SEEK_SET : int);
-           let existing = read_fd_chunks fd (Buffer.create 4096) in
-           let suffix, result = decide existing in
-           match suffix with
-            | None -> Ok result
-            | Some suffix ->
-              (* See Unix.lseek: only the file-position side effect is required. *)
-              let original_length = Unix.lseek fd 0 Unix.SEEK_END in
-              append_fd_durable
-                ~io:durable_append_unix_io
-                ~fd
-                ~original_length
-                suffix
-              |> Result.map (fun () -> result))))
+  let run () =
+    run_blocking_unix_io (fun () ->
+      Stdlib.Mutex.protect path_mu (fun () ->
+        Fd_cache.invalidate path;
+        let lock_path = path ^ ".lock" in
+        let lock_fd =
+          Unix.openfile lock_path
+            [ Unix.O_RDWR; Unix.O_CREAT; Unix.O_CLOEXEC ]
+            0o600
+        in
+        Fun.protect
+          ~finally:(fun () -> Unix.close lock_fd)
+          (fun () ->
+             Unix.fchmod lock_fd 0o600;
+             ignore (Unix.lseek lock_fd 0 Unix.SEEK_SET : int);
+             Unix.lockf lock_fd Unix.F_LOCK 0;
+             let fd, created = open_append_file path in
+             Fun.protect
+               ~finally:(fun () -> Unix.close fd)
+               (fun () ->
+                  Unix.fchmod fd 0o600;
+                  let needs_parent_sync =
+                    created || (Unix.fstat fd).Unix.st_size = 0
+                  in
+                  if needs_parent_sync
+                  then
+                    match fsync_directory_result dir with
+                    | Error error -> Error error
+                    | Ok () -> Ok (f fd)
+                  else Ok (f fd)))))
+  in
+  match Atomic.get global_fs with
+  | Some _ ->
+    let entry = acquire_durable_append_eio_mutex path in
+    Fun.protect
+      ~finally:(fun () -> release_durable_append_eio_mutex path entry)
+      (fun () ->
+         match
+           Eio.Mutex.use_rw ~protect:true entry.mutex (fun () ->
+             try Ok (run ()) with
+             | exn -> Error (exn, Printexc.get_raw_backtrace ()))
+         with
+         | Ok result -> result
+         | Error (exn, backtrace) ->
+           Printexc.raise_with_backtrace exn backtrace)
+  | None -> run ()
+;;
+
+let update_private_file_durable_locked_result path decide =
+  match with_private_append_fd_locked
+    ~op:"update_private_file_durable_locked"
+    path
+    (fun fd ->
+       ignore (Unix.lseek fd 0 Unix.SEEK_SET : int);
+       let existing = read_fd_contents fd in
+       let suffix, result = decide existing in
+       match suffix with
+       | None -> Ok result
+       | Some suffix ->
+         let original_length = Unix.lseek fd 0 Unix.SEEK_END in
+         append_fd_durable
+           ~io:durable_append_unix_io
+           ~fd
+           ~original_length
+           suffix
+         |> Result.map (fun () -> result))
+  with
+  | Error error -> Error error
+  | Ok result -> result
+;;
+
+let update_private_file_durable_locked path decide =
+  match update_private_file_durable_locked_result path decide with
+  | Ok result -> result
+  | Error error -> raise (Durable_append_failed error)
 ;;
 
 type private_jsonl_append_error =
@@ -851,8 +1045,7 @@ type private_jsonl_append_error =
   | Durable_jsonl_append_failed of durable_append_error
 
 let private_jsonl_append_error_to_string = function
-  | Incomplete_jsonl_tail ->
-    "existing JSONL file ends with an incomplete row"
+  | Incomplete_jsonl_tail -> "existing JSONL file ends with an incomplete row"
   | Invalid_jsonl_suffix ->
     "JSONL append suffix must be non-empty and newline-terminated"
   | Durable_jsonl_append_failed error -> durable_append_error_to_string error
@@ -863,53 +1056,39 @@ let append_private_jsonl_durable_locked_result path suffix =
      || not (Char.equal suffix.[String.length suffix - 1] '\n')
   then Error Invalid_jsonl_suffix
   else (
-    test_exec_home_guard ~op:"append_private_jsonl_durable_locked" path;
-    let dir = Filename.dirname path in
-    mkdir_p_memoized dir;
-    let path_mu = get_append_path_mutex path in
-    run_blocking_durable_append ~path (fun () ->
-      Stdlib.Mutex.protect path_mu (fun () ->
-        let fd =
-          Unix.openfile path
-            [ Unix.O_RDWR; Unix.O_CREAT; Unix.O_APPEND; Unix.O_CLOEXEC ]
-            0o600
-        in
-        Fun.protect
-          ~finally:(fun () -> Unix.close fd)
-          (fun () ->
-             Unix.fchmod fd 0o600;
-             fsync_parent_directory dir;
-             (* See Unix.lseek: only the file-position side effect is required. *)
-             ignore (Unix.lseek fd 0 Unix.SEEK_SET : int);
-             lock_whole_file fd;
-             let original_length = Unix.lseek fd 0 Unix.SEEK_END in
-             let tail_is_complete =
-               if original_length = 0
-               then true
-               else (
-                 (* See Unix.lseek: only the file-position side effect is required. *)
-                 ignore (Unix.lseek fd (original_length - 1) Unix.SEEK_SET : int);
-                 let byte = Bytes.create 1 in
-                 let rec read_tail () =
-                   match Unix.read fd byte 0 1 with
-                   | 1 -> Char.equal (Bytes.get byte 0) '\n'
-                   | 0 -> false
-                   | _ -> false
-                   | exception Unix.Unix_error (Unix.EINTR, _, _) -> read_tail ()
-                 in
-                 read_tail ())
-             in
-             if not tail_is_complete
-             then Error Incomplete_jsonl_tail
+    match with_private_append_fd_locked
+      ~op:"append_private_jsonl_durable_locked"
+      path
+      (fun fd ->
+           let original_length = Unix.lseek fd 0 Unix.SEEK_END in
+           let tail_is_complete =
+             if original_length = 0
+             then true
              else (
-               (* See Unix.lseek: only the file-position side effect is required. *)
-               ignore (Unix.lseek fd 0 Unix.SEEK_END : int);
-               append_fd_durable
-                 ~io:durable_append_unix_io
-                 ~fd
-                 ~original_length
-                 suffix
-               |> Result.map_error (fun error -> Durable_jsonl_append_failed error))))))
+               ignore (Unix.lseek fd (original_length - 1) Unix.SEEK_SET : int);
+               let byte = Bytes.create 1 in
+               let rec read_tail () =
+                 match Unix.read fd byte 0 1 with
+                 | 1 -> Char.equal (Bytes.get byte 0) '\n'
+                 | 0 -> false
+                 | _ -> false
+                 | exception Unix.Unix_error (Unix.EINTR, _, _) -> read_tail ()
+               in
+               read_tail ())
+           in
+           if not tail_is_complete
+           then Error Incomplete_jsonl_tail
+           else (
+             ignore (Unix.lseek fd 0 Unix.SEEK_END : int);
+             append_fd_durable
+               ~io:durable_append_unix_io
+               ~fd
+               ~original_length
+               suffix
+             |> Result.map_error (fun error -> Durable_jsonl_append_failed error)))
+    with
+    | Error error -> Error (Durable_jsonl_append_failed error)
+    | Ok result -> result)
 ;;
 
 let append_jsonl (path : string) (json : Yojson.Safe.t) : unit =

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -102,6 +102,11 @@ val realpath : string -> string
 (** Create directory recursively. *)
 val mkdir_p : string -> unit
 
+val mkdir_p_durable : string -> unit
+(** Recursively create a directory and fsync each newly published parent
+    entry. Runs blocking Unix operations on a system thread when Eio is active.
+    Raises on any mkdir/open/fsync/close failure. *)
+
 (** [mkdir_p_memoized path] is [mkdir_p] but skips the stat/mkdir
     syscalls on every call after the first for the same [path].
     Use on hot append paths (jsonl writers, ledger appends) where the
@@ -182,6 +187,9 @@ type durable_append_operation =
   | Append_fsync
   | Rollback_truncate
   | Rollback_fsync
+  | Parent_directory_open
+  | Parent_directory_fsync
+  | Parent_directory_close
 
 type durable_append_failure =
   | Unix_error of
@@ -197,42 +205,30 @@ type durable_append_error =
   ; rollback_failures : durable_append_failure list
   }
 
-(** Render a structured durable-append failure without discarding the original
-    [Unix.error] or rollback failures. *)
+exception Durable_append_failed of durable_append_error
+
 val durable_append_error_to_string : durable_append_error -> string
 
-(** [update_private_file_durable_locked_result path decide] serializes in-process
-    callers with the shared per-path append mutex, takes a cross-process file
-    lock, reads the exact existing bytes, and calls [decide]. [Some suffix]
-    appends the complete suffix and fsyncs it before returning [Ok]; [None]
-    performs no write. If writing or the append fsync fails, the file is
-    truncated to its original length and that rollback is fsynced. [Error]
-    preserves the append failure and every rollback failure. Setup, read, and
-    [decide] exceptions still propagate. The file is created with mode [0600],
-    and every transaction fsyncs its parent directory before touching payload
-    bytes so a failed creation can be retried without silently skipping that
-    durability boundary. Filesystems that reject directory fsync fail
-    explicitly. The shared path mutex serializes this operation with cached
-    JSONL writers without closing their already-flushed descriptors. When the
-    Eio filesystem is active, the transaction and [decide] run in a system
-    thread so a contended file cannot stop unrelated fibers; [decide] therefore
-    must not perform Eio effects. *)
+(** Serialize in-process and cross-process writers, read the current bytes, and
+    append the suffix selected by [decide]. A successful append is fsynced.
+    Partial write/fsync failure rolls back to the original length and fsyncs the
+    rollback; both primary and rollback failures remain typed. Blocking Unix
+    I/O and per-path lock waits run on an Eio system thread when available. *)
 val update_private_file_durable_locked_result :
   string -> (string -> string option * 'a) -> ('a, durable_append_error) result
+
+val update_private_file_durable_locked :
+  string -> (string -> string option * 'a) -> 'a
 
 type private_jsonl_append_error =
   | Incomplete_jsonl_tail
   | Invalid_jsonl_suffix
   | Durable_jsonl_append_failed of durable_append_error
 
-(** Append one or more complete JSONL rows without reading the existing file.
-    The operation holds the same in-process and cross-process path locks as
-    {!update_private_file_durable_locked_result}, verifies only that an existing
-    file ends at a newline boundary, then appends and fsyncs with rollback on
-    failure. Every transaction also fsyncs the parent directory. Runtime cost
-    is proportional to [suffix], not to historical file size. When the Eio
-    filesystem is active, the entire blocking lock/write/fsync transaction runs
-    in a system thread so one contended file cannot stop unrelated fibers. *)
+(** Append complete JSONL rows after checking only the existing final byte.
+    The hot-path cost is proportional to the appended suffix, not history size.
+    Blocking Unix I/O and per-path lock waits run on an Eio system thread when
+    available. *)
 val append_private_jsonl_durable_locked_result :
   string -> string -> (unit, private_jsonl_append_error) result
 
@@ -244,8 +240,6 @@ type durable_append_io_for_testing =
   ; fsync : Unix.file_descr -> unit
   }
 
-(** Direct fd-level seam for deterministic partial-write and rollback tests.
-    Production code uses the same implementation with [Unix] operations. *)
 val append_fd_durable_for_testing :
   io:durable_append_io_for_testing ->
   fd:Unix.file_descr ->

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -34,8 +34,27 @@ val load_file_opt : string -> string option
 (** Save string to file (overwrite). *)
 val save_file : string -> string -> unit
 
-(** Write content to path via temp file + rename.
-    Returns [Error msg] on I/O failure instead of raising. *)
+(** Whether a durable atomic write failed before or after its rename commit
+    point. *)
+type atomic_write_failure_stage =
+  | Not_renamed
+  | Renamed_durability_uncertain
+
+type atomic_write_failure =
+  { stage : atomic_write_failure_stage
+  ; message : string
+  }
+
+(** Typed durability result. A caller receiving
+    [Renamed_durability_uncertain] must keep the new in-memory revision because
+    the rename is already visible, while quarantining further mutations until
+    recovery establishes a single authority. *)
+val save_file_atomic_detailed :
+  string -> string -> (unit, atomic_write_failure) Result.t
+
+(** Compatibility atomic writer. Returns [Error msg] for every durability
+    failure but erases the commit stage. Stateful commit protocols must use
+    {!save_file_atomic_detailed} before deciding whether memory may roll back. *)
 val save_file_atomic : string -> string -> (unit, string) Result.t
 
 (** [true] iff [name] matches the [.atomic_*.tmp] pattern produced
@@ -71,6 +90,21 @@ val append_file : string -> string -> unit
 
 (** Check if file exists. *)
 val file_exists : string -> bool
+
+type path_probe_failure =
+  { error : Unix.error
+  ; function_name : string
+  ; argument : string
+  }
+
+(** [probe_path path] returns [Ok None] only for [ENOENT], [Ok (Some stats)]
+    for an observable path, and a typed [Error] for every other stat failure.
+    Blocking Unix stat runs on an Eio system thread when the runtime filesystem
+    is active, so callers can distinguish absence without blocking a Keeper
+    scheduler domain or parsing exception text. *)
+val probe_path : string -> (Unix.stats option, path_probe_failure) result
+
+val path_probe_failure_to_string : path_probe_failure -> string
 
 (** Return file size or None *)
 val file_size : string -> int option
@@ -209,11 +243,26 @@ exception Durable_append_failed of durable_append_error
 
 val durable_append_error_to_string : durable_append_error -> string
 
-(** Serialize in-process and cross-process writers, read the current bytes, and
-    append the suffix selected by [decide]. A successful append is fsynced.
-    Partial write/fsync failure rolls back to the original length and fsyncs the
-    rollback; both primary and rollback failures remain typed. Blocking Unix
-    I/O and per-path lock waits run on an Eio system thread when available. *)
+(** [update_private_file_durable_locked_result path decide] serializes
+    in-process callers with a refcounted per-path Eio mutex and the shared
+    append mutex, then locks the separate [path ^ ".lock"] inode across
+    processes. Keeping the lock off the payload inode prevents an unrelated
+    payload read/close from releasing this process's POSIX record lock.
+
+    The operation reads the exact existing bytes and calls [decide]. [Some
+    suffix] appends the complete suffix and fsyncs it before returning [Ok];
+    [None] performs no write. If writing or append fsync fails, the file is
+    truncated to its original length and that rollback is fsynced. [Error]
+    preserves the append failure and every rollback failure. Setup, read, and
+    [decide] exceptions still propagate.
+
+    The payload and lock files are mode [0600]. Every first-file transaction
+    fsyncs the parent directory before touching payload bytes; filesystems that
+    reject directory fsync fail explicitly. The shared path mutex serializes
+    this operation with cached JSONL writers without closing their
+    already-flushed descriptors. When the Eio filesystem is active, the
+    blocking transaction and [decide] run in a system thread; [decide]
+    therefore must not perform Eio effects. *)
 val update_private_file_durable_locked_result :
   string -> (string -> string option * 'a) -> ('a, durable_append_error) result
 
@@ -225,10 +274,14 @@ type private_jsonl_append_error =
   | Invalid_jsonl_suffix
   | Durable_jsonl_append_failed of durable_append_error
 
-(** Append complete JSONL rows after checking only the existing final byte.
-    The hot-path cost is proportional to the appended suffix, not history size.
-    Blocking Unix I/O and per-path lock waits run on an Eio system thread when
-    available. *)
+(** Append one or more complete JSONL rows without reading history. The
+    operation holds the same in-process mutexes and separate cross-process lock
+    inode as {!update_private_file_durable_locked_result}, verifies only that
+    an existing payload ends at a newline boundary, then appends and fsyncs
+    with rollback on failure. A first payload creation also fsyncs its parent
+    directory. Runtime cost is proportional to [suffix], not historical file
+    size. Blocking lock/write/fsync work runs in a system thread when Eio is
+    active. *)
 val append_private_jsonl_durable_locked_result :
   string -> string -> (unit, private_jsonl_append_error) result
 

--- a/lib/gate/discord_observability.ml
+++ b/lib/gate/discord_observability.ml
@@ -33,6 +33,7 @@ type ambient_outcome =
   | Ambient_dropped_unbound
   | Ambient_dropped_empty
   | Ambient_dropped_too_long
+  | Ambient_persistence_failed
 
 type reply_outcome =
   | Reply_empty
@@ -64,6 +65,7 @@ let ambient_outcome_label = function
   | Ambient_dropped_unbound -> "dropped_unbound"
   | Ambient_dropped_empty -> "dropped_empty"
   | Ambient_dropped_too_long -> "dropped_too_long"
+  | Ambient_persistence_failed -> "persistence_failed"
 
 let reply_outcome_label = function
   | Reply_empty -> "empty"

--- a/lib/gate/discord_observability.mli
+++ b/lib/gate/discord_observability.mli
@@ -37,6 +37,7 @@ type ambient_outcome =
   | Ambient_dropped_unbound
   | Ambient_dropped_empty
   | Ambient_dropped_too_long
+  | Ambient_persistence_failed
 
 type reply_outcome =
   | Reply_empty

--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -469,7 +469,9 @@ let ensure_metadata key value metadata =
 let persist_connector_assistant_reply ~base_dir ~keeper_name ~source ?surface
     ?conversation_id ?turn_ref ~reply () =
   let content = String.trim reply in
-  if content <> "" then begin
+  if String.equal content ""
+  then Ok ()
+  else
     let surface =
       match surface with
       | Some surface -> surface
@@ -477,10 +479,14 @@ let persist_connector_assistant_reply ~base_dir ~keeper_name ~source ?surface
     in
     (* RFC-0233 §7: [turn_ref] is the join key the keeper minted into the
        reply payload, carried onto this connector turn's assistant row. *)
-    Keeper_chat_store.append_assistant_message ~base_dir ~keeper_name
-      ~content ~surface ?conversation_id ?turn_ref ();
-    Keeper_chat_broadcast.chat_appended ~keeper_name ~source ~content ()
-  end
+    (match
+       Keeper_chat_store.append_assistant_message_result ~base_dir ~keeper_name
+         ~content ~surface ?conversation_id ?turn_ref ()
+     with
+     | Error _ as error -> error
+     | Ok () ->
+       Keeper_chat_broadcast.chat_appended ~keeper_name ~source ~content ();
+       Ok ())
 
 (* Trailing [()] keeps [?on_text_snapshot] erasable (warning 16): the wrappers
    below either pass it ([dispatch_with_text_snapshot]) or omit it so it defaults
@@ -552,20 +558,30 @@ let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~submission_owne
         Option.to_list (Keeper_identity.Keeper_id.of_string keeper_name)
     | Some _ | None -> []
   in
-  Keeper_chat_store.append_user_message
-    ~base_dir:config.Workspace.base_path
-    ~keeper_name
-    ~content:(String.trim content)
-    ~surface
-    ?conversation_id
-    ?external_message_id
-    ~speaker:
-      { Keeper_chat_store.speaker_id = opt channel_user_id
-      ; speaker_name = opt channel_user_name
-      ; speaker_authority = Keeper_chat_store.External
-      }
-    ~extra_mentions
-    ();
+  let user_persisted =
+    Keeper_chat_store.append_user_message_result
+      ~base_dir:config.Workspace.base_path
+      ~keeper_name
+      ~content:(String.trim content)
+      ~surface
+      ?conversation_id
+      ?external_message_id
+      ~speaker:
+        { Keeper_chat_store.speaker_id = opt channel_user_id
+        ; speaker_name = opt channel_user_name
+        ; speaker_authority = Keeper_chat_store.External
+        }
+      ~extra_mentions
+      ()
+  in
+  match user_persisted with
+  | Error detail ->
+    Log.Server.error
+      "channel gate inbound transcript persistence failed keeper=%s lane=%s error=%s"
+      keeper_name lane detail;
+    Gate_protocol.Keeper_error_result
+      "The connector message could not be durably recorded and was not dispatched."
+  | Ok () ->
   Keeper_chat_broadcast.chat_appended
     ~keeper_name ~source:lane ();
   let args =
@@ -778,10 +794,20 @@ let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~submission_owne
           (try Some (Yojson.Safe.from_string body)
            with Yojson.Json_error _ -> None)
       in
-      persist_connector_assistant_reply
-        ~base_dir:config.Workspace.base_path ~keeper_name ~source:lane
-        ~surface ?conversation_id ?turn_ref ~reply ();
-      Gate_protocol.Reply { content = reply; structured; stats; message_request = None }
+      (match
+         persist_connector_assistant_reply
+           ~base_dir:config.Workspace.base_path ~keeper_name ~source:lane
+           ~surface ?conversation_id ?turn_ref ~reply ()
+       with
+       | Ok () ->
+         Gate_protocol.Reply
+           { content = reply; structured; stats; message_request = None }
+       | Error detail ->
+         Log.Server.error
+           "channel gate assistant transcript persistence failed keeper=%s lane=%s error=%s"
+           keeper_name lane detail;
+         Gate_protocol.Keeper_error_result
+           "The Keeper reply could not be durably recorded.")
   | `Async_ack (_, Some result) | `Streaming (Some result) ->
       Gate_protocol.Keeper_error_result (redact_text (Tool_result.message result))
   | `Async_ack (_, None) | `Streaming None ->

--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -206,7 +206,7 @@ let busy_ack_reply_text ?in_flight (request : Gate_protocol.message_request) =
    outbound adapter. *)
 let busy_ack_reply_text_queued
     ~(admission_rejection : Keeper_turn_admission.rejection)
-    ~keeper_name ~receipt_id =
+    ~keeper_name ~receipt_id ~durability =
   let in_flight_text =
     match admission_rejection.in_flight with
     | None -> ""
@@ -215,15 +215,21 @@ let busy_ack_reply_text_queued
           " Current turn: %s."
           (Keeper_turn_admission.lane_to_string lane)
   in
-  match admission_rejection.shutdown_operation_id with
-  | Some operation_id ->
+  match durability, admission_rejection.shutdown_operation_id with
+  | Keeper_chat_queue.Durability_uncertain _, _ ->
+      Printf.sprintf
+        "%s accepted your message at receipt_id=%s, but could not prove the \n\
+         queue directory's crash durability. Do not resend it blindly. This \n\
+         Keeper's chat queue is quarantined until operator recovery.%s"
+        keeper_name receipt_id in_flight_text
+  | Keeper_chat_queue.Durable, Some operation_id ->
       Printf.sprintf
         "%s is stopping under shutdown operation %s; your message is durably \
          queued and will wait for the next active lane (receipt_id=%s).%s"
         keeper_name
         (Keeper_shutdown_types.Operation_id.to_string operation_id)
         receipt_id in_flight_text
-  | None ->
+  | Keeper_chat_queue.Durable, None ->
       Printf.sprintf
         "%s is busy; your message is queued and will be answered once the current \
          turn finishes (receipt_id=%s).%s"
@@ -242,6 +248,13 @@ let chat_queue_message_request ~channel ~channel_user_id ~keeper_name
         [ ( "shutdown_operation_id"
           , Keeper_shutdown_types.Operation_id.to_string operation_id ) ]
   in
+  let durability_metadata =
+    match receipt.durability with
+    | Keeper_chat_queue.Durable ->
+        [ "queue_durability", "durable" ]
+    | Keeper_chat_queue.Durability_uncertain _ ->
+        [ "queue_durability", "uncertain" ]
+  in
   { Gate_protocol.request_id = receipt_id
   ; destination_type = "keeper"
   ; destination_id = keeper_name
@@ -257,6 +270,7 @@ let chat_queue_message_request ~channel ~channel_user_id ~keeper_name
       ; "pending_count", string_of_int receipt.pending_count
       ; "inflight_count", string_of_int receipt.inflight_count
       ]
+      @ durability_metadata
       @ shutdown_metadata
       @ metadata
   }
@@ -755,7 +769,8 @@ let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~submission_owne
       let reply =
         redact_text
           (busy_ack_reply_text_queued ~admission_rejection ~keeper_name
-             ~receipt_id:message_request.request_id)
+             ~receipt_id:message_request.request_id
+             ~durability:receipt.durability)
       in
       let stats =
         Some { Gate_protocol.model_used = "runtime"; duration_ms; tokens_used = 0 }

--- a/lib/gate_keeper_backend.mli
+++ b/lib/gate_keeper_backend.mli
@@ -135,9 +135,10 @@ val persist_connector_assistant_reply :
   ?turn_ref:Ids.Turn_ref.t ->
   reply:string ->
   unit ->
-  unit
+  (unit, string) result
 (** Persist a completed connector direct reply on the same chat lane that
-    received the inbound user line. Empty replies are ignored.
+    received the inbound user line. Empty replies return [Ok ()]. The broadcast
+    is emitted only after durable persistence succeeds.
     [turn_ref] (RFC-0233 §7) is the join key the keeper minted into the
     reply payload, stamped on the assistant row. *)
 

--- a/lib/keeper/keeper_chat_delivery_journal.ml
+++ b/lib/keeper/keeper_chat_delivery_journal.ml
@@ -80,6 +80,10 @@ type error =
       }
   | Transcript_error of string
   | Invalid_terminal of string
+  | Commit_durability_uncertain of
+      { committed : t
+      ; detail : string
+      }
 
 let schema_version = 1
 let ( let* ) = Result.bind
@@ -114,6 +118,11 @@ let error_to_string = function
   | Transcript_error detail ->
     "chat delivery transcript persistence failed: " ^ detail
   | Invalid_terminal detail -> "chat delivery terminal is invalid: " ^ detail
+  | Commit_durability_uncertain { committed; detail } ->
+    Printf.sprintf
+      "chat delivery journal revision %d is visible, but crash durability is uncertain: %s"
+      committed.revision
+      detail
 ;;
 
 let validate_terminal terminal =
@@ -127,12 +136,25 @@ let validate_terminal terminal =
 ;;
 
 type operation_lock =
-  { mutex : Stdlib.Mutex.t
+  { mutex : Eio.Mutex.t
   ; mutable users : int
   }
 
 let operation_locks : (string, operation_lock) Hashtbl.t = Hashtbl.create 16
 let operation_locks_mutex = Stdlib.Mutex.create ()
+let quarantined_records : (string, t * string) Hashtbl.t = Hashtbl.create 16
+let quarantined_records_mutex = Stdlib.Mutex.create ()
+let fail_next_save_after_rename_for_testing = Atomic.make false
+
+let quarantine_record record_path journal detail =
+  Stdlib.Mutex.protect quarantined_records_mutex (fun () ->
+    Hashtbl.replace quarantined_records record_path (journal, detail))
+
+let quarantine_error record_path =
+  Stdlib.Mutex.protect quarantined_records_mutex (fun () ->
+    Hashtbl.find_opt quarantined_records record_path)
+  |> Option.map (fun (committed, detail) ->
+    Commit_durability_uncertain { committed; detail })
 
 let acquire_operation_lock key =
   Stdlib.Mutex.protect operation_locks_mutex (fun () ->
@@ -141,7 +163,7 @@ let acquire_operation_lock key =
       lock.users <- lock.users + 1;
       lock
     | None ->
-      let lock = { mutex = Stdlib.Mutex.create (); users = 1 } in
+      let lock = { mutex = Eio.Mutex.create (); users = 1 } in
       Hashtbl.add operation_locks key lock;
       lock)
 ;;
@@ -160,7 +182,16 @@ let with_operation_lock key f =
   let lock = acquire_operation_lock key in
   Fun.protect
     ~finally:(fun () -> release_operation_lock key lock)
-    (fun () -> Stdlib.Mutex.protect lock.mutex f)
+    (fun () ->
+      match
+        Eio_guard.with_mutex lock.mutex (fun () ->
+          try Ok (f ()) with
+          | exception_ ->
+            Error (exception_, Printexc.get_raw_backtrace ()))
+      with
+      | Ok result -> result
+      | Error (exception_, backtrace) ->
+        Printexc.raise_with_backtrace exception_ backtrace)
 ;;
 
 let valid_keeper_name name =
@@ -707,10 +738,19 @@ let of_yojson = function
   | _ -> Error (Decode_error "journal record must be an object")
 ;;
 
+let probe_record_path record_path =
+  match Fs_compat.probe_path record_path with
+  | Ok result -> Ok result
+  | Error failure ->
+    Error
+      (Io_error (Fs_compat.path_probe_failure_to_string failure))
+;;
+
 let load_path_unlocked record_path =
-  if not (Fs_compat.file_exists record_path)
-  then Error (Not_found record_path)
-  else
+  let* stats = probe_record_path record_path in
+  match stats with
+  | None -> Error (Not_found record_path)
+  | Some _ ->
     try
       Fs_compat.load_file record_path |> Yojson.Safe.from_string |> of_yojson
     with
@@ -726,16 +766,49 @@ let same_identity left right =
 ;;
 
 let save record_path journal =
-  Keeper_fs.save_json_atomic record_path (to_yojson journal)
-  |> Result.map_error (fun detail -> Io_error detail)
+  try
+    ignore (Keeper_fs.ensure_dir (Filename.dirname record_path) : string);
+    let inject_after_rename =
+      Atomic.exchange fail_next_save_after_rename_for_testing false
+    in
+    let result =
+      to_yojson journal
+      |> Yojson.Safe.pretty_to_string
+      |> Fs_compat.save_file_atomic_detailed record_path
+    in
+    match result with
+    | Ok () when not inject_after_rename -> Ok ()
+    | Ok () ->
+      let detail =
+        "injected delivery-journal parent-directory durability failure after rename"
+      in
+      quarantine_record record_path journal detail;
+      Error (Commit_durability_uncertain { committed = journal; detail })
+    | Error { Fs_compat.stage = Fs_compat.Not_renamed; message } ->
+      Error (Io_error message)
+    | Error
+        { Fs_compat.stage = Fs_compat.Renamed_durability_uncertain
+        ; message
+        } ->
+      quarantine_record record_path journal message;
+      Error
+        (Commit_durability_uncertain
+           { committed = journal; detail = message })
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error (Io_error (Printexc.to_string exn))
 ;;
 
 let prepare ~base_path ~delivery_key ~payload ~now =
   let* record_path = path ~base_path ~keeper_name:payload.keeper_name delivery_key in
   with_operation_lock record_path (fun () ->
-    if Fs_compat.file_exists record_path
-    then Error (Already_exists record_path)
-    else
+    match quarantine_error record_path with
+    | Some error -> Error error
+    | None ->
+    let* existing = probe_record_path record_path in
+    match existing with
+    | Some _ -> Error (Already_exists record_path)
+    | None ->
       let redaction =
         Keeper_secret_redaction.snapshot
           ~base_path
@@ -783,6 +856,11 @@ let replace
       identity.delivery_key
   in
   with_operation_lock record_path (fun () ->
+    let* () =
+      match quarantine_error record_path with
+      | None -> Ok ()
+      | Some error -> Error error
+    in
     let* existing = load_path_unlocked record_path in
     if not (same_identity existing identity)
     then Error Identity_mismatch
@@ -1091,9 +1169,16 @@ let list_for_keeper ~base_path ~keeper_name =
   then Error (Invalid_keeper_name keeper_name)
   else
     let directory = records_dir ~base_path ~keeper_name in
-    if not (Fs_compat.file_exists directory)
-    then Ok []
-    else
+    let* directory_stats = probe_record_path directory in
+    match directory_stats with
+    | None -> Ok []
+    | Some stats when stats.Unix.st_kind <> Unix.S_DIR ->
+      Error
+        (Io_error
+           (Printf.sprintf
+              "chat delivery journal path is not a directory: %s"
+              directory))
+    | Some _ ->
       try
         Sys.readdir directory
         |> Array.to_list
@@ -1161,9 +1246,27 @@ let dashboard_queue_user_row_origin ~base_path ~keeper_name receipt_ids =
 
 let recover_all ~base_path ~now =
   let keepers_dir = Common.keepers_runtime_dir_of_base ~base_path in
-  if not (Fs_compat.file_exists keepers_dir)
-  then { recovered = 0; already_final = 0; failures = [] }
-  else
+  let inventory_failure error =
+    { recovered = 0
+    ; already_final = 0
+    ; failures =
+        [ { keeper_name = "<inventory>"
+          ; delivery_ref = "inventory"
+          ; error
+          }
+        ]
+    }
+  in
+  match probe_record_path keepers_dir with
+  | Ok None -> { recovered = 0; already_final = 0; failures = [] }
+  | Error error -> inventory_failure error
+  | Ok (Some stats) when stats.Unix.st_kind <> Unix.S_DIR ->
+    inventory_failure
+      (Io_error
+         (Printf.sprintf
+            "Keeper runtime inventory path is not a directory: %s"
+            keepers_dir))
+  | Ok (Some _) ->
     try
       Sys.readdir keepers_dir
       |> Array.to_list
@@ -1206,19 +1309,13 @@ let recover_all ~base_path ~now =
     with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
     | exn ->
-      { recovered = 0
-      ; already_final = 0
-      ; failures =
-          [ { keeper_name = "<inventory>"
-            ; delivery_ref = "inventory"
-            ; error = Io_error (Printexc.to_string exn)
-            }
-          ]
-      }
+      inventory_failure (Io_error (Printexc.to_string exn))
 ;;
 
 module For_testing = struct
   let to_yojson = to_yojson
   let of_yojson = of_yojson
   let path = path
+  let fail_next_save_after_rename () =
+    Atomic.set fail_next_save_after_rename_for_testing true
 end

--- a/lib/keeper/keeper_chat_delivery_journal.ml
+++ b/lib/keeper/keeper_chat_delivery_journal.ml
@@ -767,7 +767,9 @@ let same_identity left right =
 
 let save record_path journal =
   try
-    ignore (Keeper_fs.ensure_dir (Filename.dirname record_path) : string);
+    let (_journal_dir : string) =
+      Keeper_fs.ensure_dir (Filename.dirname record_path)
+    in
     let inject_after_rename =
       Atomic.exchange fail_next_save_after_rename_for_testing false
     in

--- a/lib/keeper/keeper_chat_delivery_journal.mli
+++ b/lib/keeper/keeper_chat_delivery_journal.mli
@@ -86,6 +86,10 @@ type error =
       }
   | Transcript_error of string
   | Invalid_terminal of string
+  | Commit_durability_uncertain of
+      { committed : t
+      ; detail : string
+      }
 
 val error_to_string : error -> string
 val phase_to_string : phase -> string
@@ -180,4 +184,5 @@ module For_testing : sig
     keeper_name:string ->
     Identity.delivery_key ->
     (string, error) result
+  val fail_next_save_after_rename : unit -> unit
 end

--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -539,7 +539,7 @@ let snapshot_to_yojson ~revision receipts =
     ]
 
 let save_json_atomic path json =
-  Fs_compat.mkdir_p (Filename.dirname path);
+  ignore (Keeper_fs.ensure_dir (Filename.dirname path) : string);
   json
   |> Yojson.Safe.pretty_to_string
   |> Fs_compat.save_file_atomic path
@@ -921,6 +921,12 @@ let with_entry_lock entry f =
     Printexc.raise_with_backtrace exception_ backtrace
 
 let persistence_configured () = Option.is_some (Atomic.get persistence_base_path)
+
+let persistence_matches_base_path ~base_path =
+  match Atomic.get persistence_base_path with
+  | Some configured -> String.equal configured base_path
+  | None -> false
+;;
 
 let first_snapshot_error entry =
   match entry.load_errors with

--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -70,6 +70,7 @@ type snapshot_load_error_kind =
   | Parse_failed
   | Migration_failed
   | Recovery_failed
+  | Durability_uncertain
 
 type snapshot_load_error = {
   kind : snapshot_load_error_kind;
@@ -83,6 +84,11 @@ type mutation_error =
   | Invalid_input of string
   | Revision_exhausted
   | Persist_failed of string
+  | Commit_durability_uncertain of
+      { revision : int64
+      ; receipt_ids : Receipt_id.t list
+      ; error : snapshot_load_error
+      }
 
 let snapshot_load_error_kind_to_string = function
   | Invalid_path -> "invalid_path"
@@ -90,12 +96,21 @@ let snapshot_load_error_kind_to_string = function
   | Parse_failed -> "parse_failed"
   | Migration_failed -> "migration_failed"
   | Recovery_failed -> "recovery_failed"
+  | Durability_uncertain -> "durability_uncertain"
 
 let mutation_error_to_string = function
   | Persistence_not_configured -> "chat queue persistence is not configured"
   | Invalid_input message -> "chat queue input is invalid: " ^ message
   | Revision_exhausted -> "chat queue revision domain is exhausted"
   | Persist_failed message -> "chat queue persistence failed: " ^ message
+  | Commit_durability_uncertain { revision; receipt_ids; error } ->
+    Printf.sprintf
+      "chat queue mutation committed at revision %Ld for receipt(s) [%s], but durability is uncertain: %s"
+      revision
+      (receipt_ids
+       |> List.map Receipt_id.to_string
+       |> String.concat ",")
+      error.message
   | Snapshot_unavailable error ->
     Printf.sprintf
       "chat queue snapshot unavailable (%s): %s"
@@ -116,6 +131,7 @@ type receipt_view = {
 type receipt_lookup = {
   revision : int64;
   receipt : receipt_view option;
+  load_errors : snapshot_load_error list;
 }
 
 type diagnostic_snapshot = {
@@ -131,7 +147,12 @@ type enqueue_receipt = {
   revision : int64;
   pending_count : int;
   inflight_count : int;
+  durability : commit_durability;
 }
+
+and commit_durability =
+  | Durable
+  | Durability_uncertain of snapshot_load_error
 
 type configure_report = {
   restored_keeper_count : int;
@@ -174,6 +195,7 @@ let persistence_file = "chat-queue.json"
 let persistence_base_path : string option Atomic.t = Atomic.make None
 let global_load_errors : snapshot_load_error list Atomic.t = Atomic.make []
 let fail_next_persist_for_testing = Atomic.make false
+let fail_next_persist_after_rename_for_testing = Atomic.make false
 let transition_observer : transition_observer option Atomic.t = Atomic.make None
 
 let registry_mutex = Eio.Mutex.create ()
@@ -538,19 +560,41 @@ let snapshot_to_yojson ~revision receipts =
     ; "receipts", `List (List.map stored_receipt_to_yojson receipts)
     ]
 
-let save_json_atomic path json =
+let save_json_atomic_detailed path json =
   ignore (Keeper_fs.ensure_dir (Filename.dirname path) : string);
   json
   |> Yojson.Safe.pretty_to_string
-  |> Fs_compat.save_file_atomic path
+  |> Fs_compat.save_file_atomic_detailed path
 
 let persist_snapshot_to_path path ~revision receipts =
   if Atomic.exchange fail_next_persist_for_testing false
-  then Error "injected chat queue persist failure"
+  then
+    Error
+      { Fs_compat.stage = Fs_compat.Not_renamed
+      ; message = "injected chat queue persist failure before rename"
+      }
   else
-    try save_json_atomic path (snapshot_to_yojson ~revision receipts) with
+    let inject_after_rename =
+      Atomic.exchange fail_next_persist_after_rename_for_testing false
+    in
+    try
+      match
+        save_json_atomic_detailed path (snapshot_to_yojson ~revision receipts)
+      with
+      | Ok () when inject_after_rename ->
+        Error
+          { Fs_compat.stage = Fs_compat.Renamed_durability_uncertain
+          ; message =
+              "injected chat queue parent-directory durability failure after rename"
+          }
+      | result -> result
+    with
     | Eio.Cancel.Cancelled _ as exception_ -> raise exception_
-    | exception_ -> Error (Printexc.to_string exception_)
+    | exception_ ->
+      Error
+        { Fs_compat.stage = Fs_compat.Not_renamed
+        ; message = Printexc.to_string exception_
+        }
 
 let revision_in_domain revision =
   Int64.compare revision 0L >= 0 && Int64.compare revision max_revision <= 0
@@ -725,6 +769,20 @@ let parse_v1_for_migration json =
     Result.map (fun pending -> inflight @ pending) (parse_message_list items_json)
   | Error error, _ | _, Error error -> Error error
 
+let load_error kind ?path message = { kind; path; message }
+
+type path_probe =
+  | Path_missing
+  | Path_present of Unix.stats
+  | Path_probe_failed of string
+
+let probe_path path =
+  match Fs_compat.probe_path path with
+  | Ok None -> Path_missing
+  | Ok (Some stats) -> Path_present stats
+  | Error failure ->
+    Path_probe_failed (Fs_compat.path_probe_failure_to_string failure)
+
 let migrate_v1_to_v2 path json =
   match parse_v1_for_migration json with
   | Error error -> Error (`Parse error)
@@ -737,17 +795,28 @@ let migrate_v1_to_v2 path json =
     in
     let revision = 1L in
     (match persist_snapshot_to_path path ~revision receipts with
-     | Ok () -> Ok (revision, receipts)
-     | Error error -> Error (`Persist error))
+     | Ok () -> Ok (revision, receipts, [])
+     | Error { Fs_compat.stage = Fs_compat.Not_renamed; message } ->
+       Error (`Persist message)
+     | Error
+         { Fs_compat.stage = Fs_compat.Renamed_durability_uncertain
+         ; message
+         } ->
+       let error =
+         load_error Durability_uncertain ~path
+           ("the migrated v2 snapshot is visible, but parent-directory \n\
+             durability could not be proven; the migrated receipts remain \n\
+             observable and this Keeper queue is quarantined: " ^ message)
+       in
+       Ok (revision, receipts, [ error ]))
 
 type loaded_snapshot = {
   revision : int64;
   receipts : stored_receipt list;
   migrated : bool;
   recovered_count : int;
+  load_errors : snapshot_load_error list;
 }
-
-let load_error kind ?path message = { kind; path; message }
 
 let recovered_queue_terminal ~base_path ~keeper_name receipts =
   let inflight_ids =
@@ -815,7 +884,14 @@ let recover_inflight ~base_path ~keeper_name path ~revision receipts =
       0 receipts
   in
   if recovered_count = 0
-  then Ok { revision; receipts; migrated = false; recovered_count = 0 }
+  then
+    Ok
+      { revision
+      ; receipts
+      ; migrated = false
+      ; recovered_count = 0
+      ; load_errors = []
+      }
   else
     let recovered_terminal =
       recovered_queue_terminal ~base_path ~keeper_name receipts
@@ -849,19 +925,46 @@ let recover_inflight ~base_path ~keeper_name path ~revision receipts =
              ("failed to reconcile delivery journal: " ^ error))
       | Ok receipts ->
         (match persist_snapshot_to_path path ~revision receipts with
-         | Ok () -> Ok { revision; receipts; migrated = false; recovered_count }
-         | Error error ->
+         | Ok () ->
+           Ok
+             { revision
+             ; receipts
+             ; migrated = false
+             ; recovered_count
+             ; load_errors = []
+             }
+         | Error { Fs_compat.stage = Fs_compat.Not_renamed; message } ->
            Error
              (load_error Recovery_failed ~path
-                ("failed to persist restart recovery: " ^ error)))
+                ("failed to persist restart recovery: " ^ message))
+         | Error
+             { Fs_compat.stage = Fs_compat.Renamed_durability_uncertain
+             ; message
+             } ->
+           let error =
+             load_error Durability_uncertain ~path
+               ("the recovered queue revision is visible, but \n\
+                 parent-directory durability could not be proven; recovered \n\
+                 receipts remain observable and this Keeper queue is \n\
+                 quarantined: " ^ message)
+           in
+           Ok
+             { revision
+             ; receipts
+             ; migrated = false
+             ; recovered_count
+             ; load_errors = [ error ]
+             })
 
 let load_snapshot ~base_path ~keeper_name =
   match snapshot_path ~base_path ~keeper_name with
   | Error message -> Error (load_error Invalid_path message)
   | Ok path ->
-    if not (Sys.file_exists path)
-    then Ok None
-    else
+    (match probe_path path with
+     | Path_missing -> Ok None
+     | Path_probe_failed message ->
+       Error (load_error Read_failed ~path message)
+     | Path_present _ ->
       match Safe_ops.read_json_file_safe path with
       | Error message -> Error (load_error Read_failed ~path message)
       | Ok json ->
@@ -880,8 +983,15 @@ let load_snapshot ~base_path ~keeper_name =
                    receipts))
          | Ok schema when String.equal schema schema_v1 ->
            (match migrate_v1_to_v2 path json with
-            | Ok (revision, receipts) ->
-              Ok (Some { revision; receipts; migrated = true; recovered_count = 0 })
+            | Ok (revision, receipts, load_errors) ->
+              Ok
+                (Some
+                   { revision
+                   ; receipts
+                   ; migrated = true
+                   ; recovered_count = 0
+                   ; load_errors
+                   })
             | Error (`Parse message) ->
               Error (load_error Parse_failed ~path message)
             | Error (`Persist message) ->
@@ -891,7 +1001,7 @@ let load_snapshot ~base_path ~keeper_name =
          | Ok schema ->
            Error
              (load_error Parse_failed ~path
-                (Printf.sprintf "unsupported chat queue schema: %s" schema)))
+                (Printf.sprintf "unsupported chat queue schema: %s" schema))))
 
 let create_entry ?(revision = 0L) ?(receipts = []) ?(load_errors = []) () =
   { mutex = Eio.Mutex.create (); revision; receipts; load_errors }
@@ -929,12 +1039,13 @@ let persistence_matches_base_path ~base_path =
 ;;
 
 let first_snapshot_error entry =
-  match entry.load_errors with
-  | error :: _ -> Some error
-  | [] ->
-    (match Atomic.get global_load_errors with
-     | error :: _ -> Some error
-     | [] -> None)
+  with_entry_lock entry (fun () ->
+    match entry.load_errors with
+    | error :: _ -> Some error
+    | [] ->
+      (match Atomic.get global_load_errors with
+       | error :: _ -> Some error
+       | [] -> None))
 
 let mutation_entry ~keeper_name ~create =
   match Atomic.get persistence_base_path with
@@ -974,21 +1085,40 @@ let inflight_receipts receipts =
        | Stored_pending _ | Stored_delivered _ | Stored_failed _ -> None)
     receipts
 
+type commit_outcome =
+  { revision : int64
+  ; durability : commit_durability
+  }
+
 let commit (entry : queue_entry) ~path receipts =
   let before_receipts = entry.receipts in
   let before_revision = entry.revision in
-  if Int64.compare before_revision max_revision >= 0
-  then Error Revision_exhausted
-  else
+  match entry.load_errors, Atomic.get global_load_errors with
+  | error :: _, _ | [], error :: _ -> Error (Snapshot_unavailable error)
+  | [], [] when Int64.compare before_revision max_revision >= 0 ->
+    Error Revision_exhausted
+  | [], [] ->
     let revision = Int64.succ before_revision in
     entry.receipts <- receipts;
     entry.revision <- revision;
     match persist_snapshot_to_path path ~revision receipts with
-    | Ok () -> Ok revision
-    | Error message ->
+    | Ok () -> Ok { revision; durability = Durable }
+    | Error { Fs_compat.stage = Fs_compat.Not_renamed; message } ->
       entry.receipts <- before_receipts;
       entry.revision <- before_revision;
       Error (Persist_failed message)
+    | Error
+        { Fs_compat.stage = Fs_compat.Renamed_durability_uncertain
+        ; message
+        } ->
+      let error =
+        load_error Durability_uncertain ~path
+          ("the new queue revision is visible, but parent-directory durability \n\
+            could not be proven; this Keeper queue is quarantined and the \n\
+            committed receipt must not be retried blindly: " ^ message)
+      in
+      entry.load_errors <- error :: entry.load_errors;
+      Ok { revision; durability = Durability_uncertain error }
     | exception (Eio.Cancel.Cancelled _ as exception_) ->
       entry.receipts <- before_receipts;
       entry.revision <- before_revision;
@@ -1010,15 +1140,25 @@ let enqueue ~keeper_name message =
           let receipts = entry.receipts @ [ receipt ] in
           match commit entry ~path receipts with
           | Error _ as error -> error
-          | Ok revision ->
+          | Ok { revision; durability } ->
             Ok
               { receipt_id
               ; revision
               ; pending_count = List.length (pending_receipts receipts)
               ; inflight_count = List.length (inflight_receipts receipts)
+              ; durability
               })
     in
     (match result with
+     | Ok ({ durability = Durability_uncertain error; _ } as receipt) ->
+       Log.Keeper.error
+         "keeper_chat_queue: accepted receipt with uncertain crash durability keeper=%s receipt_id=%s revision=%Ld: %s"
+         keeper_name
+         (Receipt_id.to_string receipt.receipt_id)
+         receipt.revision
+         error.message;
+       notify_transition ~keeper_name ~revision:receipt.revision;
+       Ok receipt
      | Ok receipt ->
        notify_transition ~keeper_name ~revision:receipt.revision;
        Ok receipt
@@ -1091,12 +1231,25 @@ let lease_batch ~keeper_name =
               in
               match commit entry ~path receipts with
               | Error error -> `Error error
-              | Ok revision -> `Leased ({ lease_id; items }, revision))
+              | Ok { revision; durability = Durable } ->
+                `Leased ({ lease_id; items }, revision)
+              | Ok
+                  { revision
+                  ; durability = Durability_uncertain error
+                  } ->
+                `Committed_durability_uncertain
+                  ( List.map (fun (item : leased_message) -> item.receipt_id) items
+                  , revision
+                  , error ))
     in
     (match result with
      | `Leased (lease, revision) ->
        notify_transition ~keeper_name ~revision;
        `Leased lease
+     | `Committed_durability_uncertain (receipt_ids, revision, error) ->
+       notify_transition ~keeper_name ~revision;
+       `Error
+         (Commit_durability_uncertain { revision; receipt_ids; error })
      | `Empty -> `Empty
      | `Already_leased lease_id -> `Already_leased lease_id
      | `Error error -> `Error error)
@@ -1161,12 +1314,22 @@ let finalize ~keeper_name ~lease_id ~outcome =
             in
             match commit entry ~path receipts with
             | Error error -> `Error error
-            | Ok revision -> `Finalized (matched, revision))
+            | Ok { revision; durability = Durable } ->
+              `Finalized (matched, revision)
+            | Ok
+                { revision
+                ; durability = Durability_uncertain error
+                } ->
+              `Committed_durability_uncertain (matched, revision, error))
     in
     (match result with
      | `Finalized (receipts, revision) ->
        notify_transition ~keeper_name ~revision;
        `Finalized receipts
+     | `Committed_durability_uncertain (receipt_ids, revision, error) ->
+       notify_transition ~keeper_name ~revision;
+       `Error
+         (Commit_durability_uncertain { revision; receipt_ids; error })
      | `Unknown_lease -> `Unknown_lease
      | `Error error -> `Error error)
 
@@ -1202,12 +1365,22 @@ let nack ~keeper_name ~lease_id =
             in
             match commit entry ~path receipts with
             | Error error -> `Error error
-            | Ok revision -> `Requeued (matched, revision))
+            | Ok { revision; durability = Durable } ->
+              `Requeued (matched, revision)
+            | Ok
+                { revision
+                ; durability = Durability_uncertain error
+                } ->
+              `Committed_durability_uncertain (matched, revision, error))
     in
     (match result with
      | `Requeued (receipts, revision) ->
        notify_transition ~keeper_name ~revision;
        `Requeued receipts
+     | `Committed_durability_uncertain (receipt_ids, revision, error) ->
+       notify_transition ~keeper_name ~revision;
+       `Error
+         (Commit_durability_uncertain { revision; receipt_ids; error })
      | `Unknown_lease -> `Unknown_lease
      | `Error error -> `Error error)
 
@@ -1312,24 +1485,37 @@ let snapshot ~keeper_name =
         })
 
 let lookup_receipt ~keeper_name ~receipt_id =
-  match mutation_entry ~keeper_name ~create:false with
-  | Error _ as error -> error
-  | Ok (_, _, None) -> Ok { revision = 0L; receipt = None }
-  | Ok (_, _, Some entry) ->
-    with_entry_lock entry (fun () ->
-        let receipt =
-          List.find_map
-            (fun receipt ->
-               if Receipt_id.equal receipt.receipt_id receipt_id
-               then
-                 Some
-                   ({ receipt_id = receipt.receipt_id
-                    ; state = receipt_state_of_stored receipt.state
-                    } : receipt_view)
-               else None)
-            entry.receipts
-        in
-        Ok { revision = entry.revision; receipt })
+  match Atomic.get persistence_base_path with
+  | None -> Error Persistence_not_configured
+  | Some base_path ->
+    (match snapshot_path ~base_path ~keeper_name with
+     | Error message ->
+       Error (Snapshot_unavailable (load_error Invalid_path message))
+     | Ok _ ->
+       (match Atomic.get global_load_errors with
+        | error :: _ -> Error (Snapshot_unavailable error)
+        | [] ->
+          (match find_entry keeper_name with
+           | None -> Ok { revision = 0L; receipt = None; load_errors = [] }
+           | Some entry ->
+             with_entry_lock entry (fun () ->
+                 let receipt =
+                   List.find_map
+                     (fun receipt ->
+                        if Receipt_id.equal receipt.receipt_id receipt_id
+                        then
+                          Some
+                            ({ receipt_id = receipt.receipt_id
+                             ; state = receipt_state_of_stored receipt.state
+                             } : receipt_view)
+                        else None)
+                     entry.receipts
+                 in
+                 Ok
+                   { revision = entry.revision
+                   ; receipt
+                   ; load_errors = entry.load_errors
+                   }))))
 
 let all_keeper_names () =
   with_registry_rw (fun () ->
@@ -1348,11 +1534,27 @@ let configure_persistence ~base_path =
   let restored_mutations = ref [] in
   let keepers_dir = Common.keepers_runtime_dir_of_base ~base_path in
   let keeper_names =
-    if not (Sys.file_exists keepers_dir)
-    then []
-    else
-      try Array.to_list (Sys.readdir keepers_dir) with
-      | exception_ ->
+    match probe_path keepers_dir with
+    | Path_missing -> []
+    | Path_probe_failed message ->
+      let error =
+        load_error Read_failed ~path:keepers_dir
+          ("failed to inspect keeper chat queue registry: " ^ message)
+      in
+      load_errors := (None, error) :: !load_errors;
+      Atomic.set global_load_errors [ error ];
+      []
+    | Path_present stats when stats.Unix.st_kind <> Unix.S_DIR ->
+      let error =
+        load_error Read_failed ~path:keepers_dir
+          "keeper chat queue registry path is not a directory"
+      in
+      load_errors := (None, error) :: !load_errors;
+      Atomic.set global_load_errors [ error ];
+      []
+    | Path_present _ ->
+      (try Array.to_list (Sys.readdir keepers_dir) with
+       | exception_ ->
         let error =
           load_error Read_failed ~path:keepers_dir
             ("failed to discover keeper chat queue snapshots: "
@@ -1360,13 +1562,26 @@ let configure_persistence ~base_path =
         in
         load_errors := (None, error) :: !load_errors;
         Atomic.set global_load_errors [ error ];
-        []
+        [])
   in
   List.iter
     (fun keeper_name ->
        let path = Filename.concat (Filename.concat keepers_dir keeper_name) persistence_file in
-       if Sys.file_exists path
-       then if not (valid_keeper_name keeper_name)
+       match probe_path path with
+       | Path_missing -> ()
+       | Path_probe_failed message ->
+         let error =
+           load_error Read_failed ~path
+             ("failed to inspect keeper chat queue snapshot: " ^ message)
+         in
+         load_errors := (Some keeper_name, error) :: !load_errors;
+         if valid_keeper_name keeper_name
+         then
+           with_registry_rw (fun () ->
+               Hashtbl.replace registry keeper_name
+                 (create_entry ~load_errors:[ error ] ()))
+       | Path_present _ ->
+         if not (valid_keeper_name keeper_name)
          then
            let error =
              load_error Invalid_path ~path
@@ -1381,10 +1596,16 @@ let configure_persistence ~base_path =
              if loaded.migrated then incr migrated_keeper_count;
              recovered_receipt_count :=
                !recovered_receipt_count + loaded.recovered_count;
+             List.iter
+               (fun error ->
+                  load_errors := (Some keeper_name, error) :: !load_errors)
+               loaded.load_errors;
              with_registry_rw (fun () ->
                  Hashtbl.replace registry keeper_name
                    (create_entry ~revision:loaded.revision
-                      ~receipts:loaded.receipts ()));
+                      ~receipts:loaded.receipts
+                      ~load_errors:loaded.load_errors
+                      ()));
              if loaded.migrated || loaded.recovered_count > 0
              then
                restored_mutations :=
@@ -1408,10 +1629,14 @@ let configure_persistence ~base_path =
 module For_testing = struct
   let reset () =
     Atomic.set fail_next_persist_for_testing false;
+    Atomic.set fail_next_persist_after_rename_for_testing false;
     Atomic.set persistence_base_path None;
     Atomic.set global_load_errors [];
     Atomic.set transition_observer None;
     with_registry_rw (fun () -> Hashtbl.clear registry)
 
   let fail_next_persist () = Atomic.set fail_next_persist_for_testing true
+
+  let fail_next_persist_after_rename () =
+    Atomic.set fail_next_persist_after_rename_for_testing true
 end

--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -561,7 +561,9 @@ let snapshot_to_yojson ~revision receipts =
     ]
 
 let save_json_atomic_detailed path json =
-  ignore (Keeper_fs.ensure_dir (Filename.dirname path) : string);
+  let (_queue_dir : string) =
+    Keeper_fs.ensure_dir (Filename.dirname path)
+  in
   json
   |> Yojson.Safe.pretty_to_string
   |> Fs_compat.save_file_atomic_detailed path

--- a/lib/keeper/keeper_chat_queue.mli
+++ b/lib/keeper/keeper_chat_queue.mli
@@ -158,6 +158,11 @@ val configure_persistence : base_path:string -> configure_report
 
 val persistence_configured : unit -> bool
 
+val persistence_matches_base_path : base_path:string -> bool
+(** Verify that queue persistence is configured for the exact workspace root.
+    This lets startup publish route readiness only after the queue owns the same
+    BasePath as the server state. *)
+
 (** Enqueue only after the receipt-bearing version-2 snapshot commits. *)
 val enqueue :
   keeper_name:string -> queued_message -> (enqueue_receipt, mutation_error) result

--- a/lib/keeper/keeper_chat_queue.mli
+++ b/lib/keeper/keeper_chat_queue.mli
@@ -83,6 +83,7 @@ type snapshot_load_error_kind =
   | Parse_failed
   | Migration_failed
   | Recovery_failed
+  | Durability_uncertain
 
 type snapshot_load_error = {
   kind : snapshot_load_error_kind;
@@ -96,6 +97,11 @@ type mutation_error =
   | Invalid_input of string
   | Revision_exhausted
   | Persist_failed of string
+  | Commit_durability_uncertain of
+      { revision : int64
+      ; receipt_ids : Receipt_id.t list
+      ; error : snapshot_load_error
+      }
 
 val snapshot_load_error_kind_to_string : snapshot_load_error_kind -> string
 val mutation_error_to_string : mutation_error -> string
@@ -114,6 +120,7 @@ type receipt_view = {
 type receipt_lookup = {
   revision : int64;
   receipt : receipt_view option;
+  load_errors : snapshot_load_error list;
 }
 
 type diagnostic_snapshot = {
@@ -129,7 +136,12 @@ type enqueue_receipt = {
   revision : int64;
   pending_count : int;
   inflight_count : int;
+  durability : commit_durability;
 }
+
+and commit_durability =
+  | Durable
+  | Durability_uncertain of snapshot_load_error
 
 type configure_report = {
   restored_keeper_count : int;
@@ -163,7 +175,11 @@ val persistence_matches_base_path : base_path:string -> bool
     This lets startup publish route readiness only after the queue owns the same
     BasePath as the server state. *)
 
-(** Enqueue only after the receipt-bearing version-2 snapshot commits. *)
+(** Enqueue only after the receipt-bearing version-2 snapshot reaches the
+    atomic rename commit point. [Durable] proves the parent directory was also
+    fsynced. [Durability_uncertain _] preserves the accepted receipt and
+    revision, quarantines only this Keeper's queue, and tells the caller not to
+    retry blindly. *)
 val enqueue :
   keeper_name:string -> queued_message -> (enqueue_receipt, mutation_error) result
 
@@ -212,11 +228,15 @@ val lookup_receipt :
   receipt_id:Receipt_id.t ->
   (receipt_lookup, mutation_error) result
 (** Atomically return the receipt observation with the queue revision that
-    produced it. *)
+    produced it. Keeper-local mutation quarantine does not hide a receipt that
+    is already known in memory; [load_errors] tells readers why further
+    mutations are unavailable. A missing receipt under non-empty [load_errors]
+    is not authoritative absence. *)
 
 val all_keeper_names : unit -> string list
 
 module For_testing : sig
   val reset : unit -> unit
   val fail_next_persist : unit -> unit
+  val fail_next_persist_after_rename : unit -> unit
 end

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -656,8 +656,9 @@ let find_provenance_in_text existing ~delivery_key ~transcript_slot =
       then Ok found
       else
         let line_end =
-          String.index_from_opt existing offset '\n'
-          |> Option.value ~default:length
+          match String.index_from_opt existing offset '\n' with
+          | Some line_end -> line_end
+          | None -> length
         in
         let line = String.sub existing offset (line_end - offset) in
         let next_offset = if line_end < length then line_end + 1 else length in

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -648,65 +648,74 @@ let provenance_of_line ~line_number line =
   | Yojson.Json_error detail -> fail detail
 ;;
 
-let find_provenance existing ~delivery_key ~transcript_slot =
-  existing
-  |> String.split_on_char '\n'
-  |> List.mapi (fun index line -> index + 1, line)
-  |> List.fold_left
-       (fun result (line_number, line) ->
+let find_provenance_in_text existing ~delivery_key ~transcript_slot =
+  try
+    let length = String.length existing in
+    let rec scan ~line_number ~offset found =
+      if offset >= length
+      then Ok found
+      else
+        let line_end =
+          String.index_from_opt existing offset '\n'
+          |> Option.value ~default:length
+        in
+        let line = String.sub existing offset (line_end - offset) in
+        let next_offset = if line_end < length then line_end + 1 else length in
+        if String.equal line ""
+        then scan ~line_number:(line_number + 1) ~offset:next_offset found
+        else
           let ( let* ) = Result.bind in
-          let* found = result in
-          if String.equal line ""
-          then Ok found
-          else
-            let* provenance = provenance_of_line ~line_number line in
-            match provenance, found with
-            | None, _ -> Ok found
-            | Some (candidate_key, candidate_slot, row_id), None
-              when
-                Keeper_chat_delivery_identity.delivery_key_equal
-                  delivery_key
-                  candidate_key
-                && Keeper_chat_delivery_identity.transcript_slot_equal
-                     transcript_slot
-                     candidate_slot ->
-              Ok (Some row_id)
-            | Some (candidate_key, candidate_slot, _), Some _
-              when
-                Keeper_chat_delivery_identity.delivery_key_equal
-                  delivery_key
-                  candidate_key
-                && Keeper_chat_delivery_identity.transcript_slot_equal
-                     transcript_slot
-                     candidate_slot ->
-              Error "duplicate Keeper chat delivery provenance rows"
-            | Some _, _ -> Ok found)
-       (Ok None)
+          let* provenance = provenance_of_line ~line_number line in
+          (match provenance, found with
+           | None, _ ->
+             scan ~line_number:(line_number + 1) ~offset:next_offset found
+           | Some (candidate_key, candidate_slot, row_id), None
+             when
+               Keeper_chat_delivery_identity.delivery_key_equal
+                 delivery_key
+                 candidate_key
+               && Keeper_chat_delivery_identity.transcript_slot_equal
+                    transcript_slot
+                    candidate_slot ->
+             scan
+               ~line_number:(line_number + 1)
+               ~offset:next_offset
+               (Some row_id)
+           | Some (candidate_key, candidate_slot, _), Some _
+             when
+               Keeper_chat_delivery_identity.delivery_key_equal
+                 delivery_key
+                 candidate_key
+               && Keeper_chat_delivery_identity.transcript_slot_equal
+                    transcript_slot
+                    candidate_slot ->
+             Error "duplicate Keeper chat delivery provenance rows"
+           | Some _, _ ->
+             scan ~line_number:(line_number + 1) ~offset:next_offset found)
+    in
+    scan ~line_number:1 ~offset:0 None
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error (Printexc.to_string exn)
 ;;
 
 let append_line_once path ~delivery_key ~transcript_slot ~row_id line =
   match
     Fs_compat.update_private_file_durable_locked_result path (fun existing ->
-      match find_provenance existing ~delivery_key ~transcript_slot with
-      | Error detail -> None, Error detail
-      | Ok (Some existing_row_id) ->
-        None, Ok (Already_present { row_id = existing_row_id })
-      | Ok None -> Some (line ^ "\n"), Ok (Appended { row_id }))
+      let existing_length = String.length existing in
+      if
+        existing_length > 0
+        && not (Char.equal existing.[existing_length - 1] '\n')
+      then None, Error "existing Keeper chat JSONL has an incomplete final row"
+      else
+        match find_provenance_in_text existing ~delivery_key ~transcript_slot with
+        | Error detail -> None, Error detail
+        | Ok (Some existing_row_id) ->
+          None, Ok (Already_present { row_id = existing_row_id })
+        | Ok None -> Some (line ^ "\n"), Ok (Appended { row_id }))
   with
   | Ok result -> result
   | Error error -> Error (Fs_compat.durable_append_error_to_string error)
-;;
-
-let append_chat_payload_durable path payload =
-  match Fs_compat.append_private_jsonl_durable_locked_result path payload with
-  | Ok () -> ()
-  | Error error ->
-    raise
-      (Sys_error
-         (Printf.sprintf
-            "%s: %s"
-            path
-            (Fs_compat.private_jsonl_append_error_to_string error)))
 ;;
 
 (* Tool calls with empty accumulated arguments are normalised to "{}" so
@@ -725,6 +734,18 @@ let normalize_tool_call_id ~position call_id =
 let user_line_mentions ~extra_mentions content =
   Keeper_lane_mentions.mention_ids_of_content content @ extra_mentions
   |> List.sort_uniq Keeper_identity.Keeper_id.compare
+
+let append_chat_payload_durable path payload =
+  match Fs_compat.append_private_jsonl_durable_locked_result path payload with
+  | Ok () -> ()
+  | Error error ->
+    raise
+      (Sys_error
+         (Printf.sprintf
+            "%s: %s"
+            path
+            (Fs_compat.private_jsonl_append_error_to_string error)))
+;;
 
 let append_turn_result ~base_dir ~keeper_name ~(user_content : string)
     ~(user_attachments : attachment list) ?(tool_calls = []) ?surface
@@ -814,9 +835,10 @@ let append_turn ~base_dir ~keeper_name ~(user_content : string)
    a caller bound by a no-silent-loss contract (e.g. {!Fusion_sink.emit}) can
    propagate it. The failure is still counted + warn-logged here so callers that
    use the unit wrapper below keep the existing swallow-and-count telemetry. *)
-let append_assistant_message_result ~base_dir ~keeper_name ~(content : string)
-    ?surface ?conversation_id ?audio ?blocks ?turn_ref ?stream_lifecycle () :
-    (unit, string) result =
+let append_assistant_message_row_result ~base_dir ~keeper_name
+    ~(content : string) ?surface ?conversation_id ?audio ?blocks ?turn_ref
+    ?stream_lifecycle ?delivery_identity
+    ?(assistant_kind = Row_kind.Utterance) () : (string, string) result =
   try
     ensure_dir_once ~base_dir;
     let redaction = redaction_for ~base_dir ~keeper_name in
@@ -825,12 +847,20 @@ let append_assistant_message_result ~base_dir ~keeper_name ~(content : string)
     let audio = Option.map (redact_audio redaction) audio in
     let path = chat_path ~base_dir ~keeper_name in
     let ts = Time_compat.now () in
+    let row_id = mint_message_id ~ts in
     let line =
-      encode_line ~role:Role.Assistant ~content ~ts ?surface ?conversation_id
-        ?audio ?blocks ?turn_ref ?stream_lifecycle ()
+      match delivery_identity with
+      | None ->
+        encode_line ~role:Role.Assistant ~content ~ts ~message_id:row_id
+          ?surface ?conversation_id ?audio ?blocks ?turn_ref ?stream_lifecycle
+          ~kind:assistant_kind ()
+      | Some (delivery_key, transcript_slot) ->
+        encode_line ~role:Role.Assistant ~content ~ts ~message_id:row_id
+          ?surface ?conversation_id ?audio ?blocks ?turn_ref ?stream_lifecycle
+          ~kind:assistant_kind ~delivery_key ~transcript_slot ()
     in
     append_chat_payload_durable path (line ^ "\n");
-    Ok ()
+    Ok row_id
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
@@ -841,6 +871,24 @@ let append_assistant_message_result ~base_dir ~keeper_name ~(content : string)
     Log.Keeper.warn "keeper_chat_store: assistant append failed for %s: %s"
       (sanitize_name keeper_name) (Printexc.to_string exn);
     Error (Printexc.to_string exn)
+
+let append_assistant_message_result ~base_dir ~keeper_name ~(content : string)
+    ?surface ?conversation_id ?audio ?blocks ?turn_ref ?stream_lifecycle () =
+  append_assistant_message_row_result ~base_dir ~keeper_name ~content ?surface
+    ?conversation_id ?audio ?blocks ?turn_ref ?stream_lifecycle ()
+  |> Result.map (fun _row_id -> ())
+;;
+
+let append_delivery_assistant_message_result ~base_dir ~keeper_name
+    ~delivery_key ~(content : string) ?surface ?conversation_id
+    ?(assistant_kind = Row_kind.Utterance) ?blocks ?turn_ref ?stream_lifecycle
+    () =
+  append_assistant_message_row_result ~base_dir ~keeper_name ~content ?surface
+    ?conversation_id ?blocks ?turn_ref ?stream_lifecycle ~assistant_kind
+    ~delivery_identity:
+      (delivery_key, Keeper_chat_delivery_identity.Terminal_assistant)
+    ()
+;;
 
 let append_assistant_message_once
       ~base_dir
@@ -911,9 +959,9 @@ let append_assistant_message ~base_dir ~keeper_name ~(content : string)
 (* RFC-0226: inbound user line recorded at delivery time, before (and
    independent of) any turn. A single user line — the assistant reply,
    if one ever comes, is appended separately by the reply path. *)
-let append_user_message ~base_dir ~keeper_name ~(content : string)
+let append_user_message_row_result ~base_dir ~keeper_name ~(content : string)
     ?(attachments = []) ?surface ?conversation_id ?external_message_id ?speaker
-    ?(extra_mentions = []) () =
+    ?(extra_mentions = []) ?delivery_identity () =
   try
     ensure_dir_once ~base_dir;
     let redaction = redaction_for ~base_dir ~keeper_name in
@@ -922,13 +970,23 @@ let append_user_message ~base_dir ~keeper_name ~(content : string)
     let persisted_attachments = List.map persisted_attachment attachments in
     let path = chat_path ~base_dir ~keeper_name in
     let ts = Time_compat.now () in
+    let row_id = mint_message_id ~ts in
     let line =
-      encode_line ~role:Role.User ~content ~ts ?surface ?conversation_id
-        ~attachments:persisted_attachments
-        ?external_message_id ?speaker
-        ~mentions:(user_line_mentions ~extra_mentions content) ()
+      match delivery_identity with
+      | None ->
+        encode_line ~role:Role.User ~content ~ts ~message_id:row_id ?surface
+          ?conversation_id ~attachments:persisted_attachments
+          ?external_message_id ?speaker
+          ~mentions:(user_line_mentions ~extra_mentions content) ()
+      | Some (delivery_key, transcript_slot) ->
+        encode_line ~role:Role.User ~content ~ts ~message_id:row_id ?surface
+          ?conversation_id ~attachments:persisted_attachments
+          ?external_message_id ?speaker
+          ~mentions:(user_line_mentions ~extra_mentions content) ~delivery_key
+          ~transcript_slot ()
     in
-    append_chat_payload_durable path (line ^ "\n")
+    append_chat_payload_durable path (line ^ "\n");
+    Ok row_id
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
@@ -936,8 +994,37 @@ let append_user_message ~base_dir ~keeper_name ~(content : string)
       Keeper_metrics.(to_string ChatStoreFailures)
       ~labels:[("operation", Keeper_chat_store_operation.(to_label Append))]
       ();
+    let detail = Printexc.to_string exn in
     Log.Keeper.warn "keeper_chat_store: user append failed for %s: %s"
-      (sanitize_name keeper_name) (Printexc.to_string exn)
+      (sanitize_name keeper_name) detail;
+    Error detail
+
+let append_user_message_result ~base_dir ~keeper_name ~(content : string)
+    ?(attachments = []) ?surface ?conversation_id ?external_message_id ?speaker
+    ?(extra_mentions = []) () =
+  append_user_message_row_result ~base_dir ~keeper_name ~content ~attachments
+    ?surface ?conversation_id ?external_message_id ?speaker ~extra_mentions ()
+  |> Result.map (fun _row_id -> ())
+;;
+
+let append_delivery_user_message_result ~base_dir ~keeper_name ~delivery_key
+    ~(content : string) ?(attachments = []) ?surface ?conversation_id
+    ?external_message_id ?speaker ?(extra_mentions = []) () =
+  append_user_message_row_result ~base_dir ~keeper_name ~content ~attachments
+    ?surface ?conversation_id ?external_message_id ?speaker ~extra_mentions
+    ~delivery_identity:
+      (delivery_key, Keeper_chat_delivery_identity.Accepted_user)
+    ()
+;;
+
+let append_user_message ~base_dir ~keeper_name ~(content : string)
+    ?(attachments = []) ?surface ?conversation_id ?external_message_id ?speaker
+    ?(extra_mentions = []) () =
+  ignore
+    (append_user_message_result ~base_dir ~keeper_name ~content ~attachments
+       ?surface ?conversation_id ?external_message_id ?speaker ~extra_mentions
+       ()
+      : (unit, string) result)
 
 let append_user_message_once
       ~base_dir

--- a/lib/keeper/keeper_chat_store.mli
+++ b/lib/keeper/keeper_chat_store.mli
@@ -268,6 +268,24 @@ val append_assistant_message_result :
   unit ->
   (unit, string) result
 
+val append_delivery_assistant_message_result :
+  base_dir:string ->
+  keeper_name:string ->
+  delivery_key:Keeper_chat_delivery_identity.delivery_key ->
+  content:string ->
+  ?surface:Surface_ref.t ->
+  ?conversation_id:string ->
+  ?assistant_kind:Row_kind.t ->
+  ?blocks:chat_block list ->
+  ?turn_ref:Ids.Turn_ref.t ->
+  ?stream_lifecycle:stream_lifecycle_event list ->
+  unit ->
+  (string, string) result
+(** O(suffix) normal-path terminal append for a newly transitioned delivery
+    journal. Returns the persisted row id. Restart recovery must use
+    {!append_assistant_message_once}, whose O(history) lookup is reserved for
+    the ambiguous crash window. *)
+
 (** Idempotent terminal assistant append. The per-Keeper lookup and append are
     serialized, so callback re-entry and restart recovery converge on one row
     for the exact typed delivery slot. A malformed persisted provenance row is
@@ -322,6 +340,39 @@ val append_user_message :
   ?extra_mentions:Keeper_identity.Keeper_id.t list ->
   unit ->
   unit
+
+val append_user_message_result :
+  base_dir:string ->
+  keeper_name:string ->
+  content:string ->
+  ?attachments:attachment list ->
+  ?surface:Surface_ref.t ->
+  ?conversation_id:string ->
+  ?external_message_id:string ->
+  ?speaker:speaker ->
+  ?extra_mentions:Keeper_identity.Keeper_id.t list ->
+  unit ->
+  (unit, string) result
+(** Result-returning inbound recorder for connector and admission boundaries.
+    A caller must not broadcast or dispatch the message unless this returns
+    [Ok ()]. *)
+
+val append_delivery_user_message_result :
+  base_dir:string ->
+  keeper_name:string ->
+  delivery_key:Keeper_chat_delivery_identity.delivery_key ->
+  content:string ->
+  ?attachments:attachment list ->
+  ?surface:Surface_ref.t ->
+  ?conversation_id:string ->
+  ?external_message_id:string ->
+  ?speaker:speaker ->
+  ?extra_mentions:Keeper_identity.Keeper_id.t list ->
+  unit ->
+  (string, string) result
+(** O(suffix) normal-path accepted-user append for a newly prepared delivery
+    journal. Returns the persisted row id. Restart recovery retains the exact
+    append-once scan for crash reconciliation. *)
 
 (** Idempotent accepted-user append for a direct/queued delivery identity. *)
 val append_user_message_once :

--- a/lib/keeper/keeper_fs.ml
+++ b/lib/keeper/keeper_fs.ml
@@ -26,7 +26,7 @@ let ensure_dir (path : string) : string =
     if not (Hashtbl.mem ensured_dirs path) || not (Fs_compat.file_exists path) then begin
       match
         try
-          Fs_compat.mkdir_p path;
+          Fs_compat.mkdir_p_durable path;
           Hashtbl.replace ensured_dirs path ();
           Ok ()
         with

--- a/lib/keeper/keeper_fs.ml
+++ b/lib/keeper/keeper_fs.ml
@@ -9,62 +9,134 @@
     @since 2.162.0 — #3721 keeper stabilization *)
 
 (* ================================================================ *)
-(* Directory Cache (Eio.Mutex-protected)                            *)
+(* Directory Cache (path-local Eio synchronization)                 *)
 (* ================================================================ *)
 
-let dir_mu = Eio.Mutex.create ()
 let ensured_dirs : (string, unit) Hashtbl.t = Hashtbl.create 16
 
+type dir_lock =
+  { mutex : Eio.Mutex.t
+  ; mutable users : int
+  }
+
+let dir_state_mu = Stdlib.Mutex.create ()
+let dir_locks : (string, dir_lock) Hashtbl.t = Hashtbl.create 16
+let dir_cache_epoch = ref (ref ())
+
+let dir_cache_key path =
+  let path = Env_config_core.strip_path_trailing_slashes path in
+  if Filename.is_relative path
+  then Filename.concat (Sys.getcwd ()) path
+  else path
+
+let dir_is_cached path =
+  Stdlib.Mutex.protect dir_state_mu (fun () ->
+    Hashtbl.mem ensured_dirs path)
+
+let acquire_dir_lock path =
+  Stdlib.Mutex.protect dir_state_mu (fun () ->
+    match Hashtbl.find_opt dir_locks path with
+    | Some lock ->
+      lock.users <- lock.users + 1;
+      lock
+    | None ->
+      let lock = { mutex = Eio.Mutex.create (); users = 1 } in
+      Hashtbl.add dir_locks path lock;
+      lock)
+
+let release_dir_lock path lock =
+  Stdlib.Mutex.protect dir_state_mu (fun () ->
+    lock.users <- lock.users - 1;
+    if lock.users = 0
+    then
+      match Hashtbl.find_opt dir_locks path with
+      | Some current when current == lock -> Hashtbl.remove dir_locks path
+      | Some _ | None -> ())
+
+let capture_dir_cache_epoch () =
+  Stdlib.Mutex.protect dir_state_mu (fun () -> !dir_cache_epoch)
+
+let mark_dir_cached_if_current path expected_epoch =
+  Stdlib.Mutex.protect dir_state_mu (fun () ->
+    if !dir_cache_epoch == expected_epoch
+    then Hashtbl.replace ensured_dirs path ())
+
 let ensure_dir (path : string) : string =
-  (* Capture exceptions inside the mutex body so the lock exits normally,
-     then re-raise after release. Escaping an exception from
-     Eio.Mutex.use_rw poisons the mutex and breaks all subsequent
-     ensure_dir calls in the same process (Issue #8475: fleet-test
-     isolation runtime failures). *)
-  let deferred_exn = ref None in
-  Eio_guard.with_mutex dir_mu (fun () ->
-    if not (Hashtbl.mem ensured_dirs path) || not (Fs_compat.file_exists path) then begin
-      match
-        try
-          Fs_compat.mkdir_p_durable path;
-          Hashtbl.replace ensured_dirs path ();
-          Ok ()
-        with
-        | Eio.Cancel.Cancelled _ as exn ->
-            Otel_metric_store.inc_counter
-              Keeper_metrics.(to_string FsFailures)
-              ~labels:[("path", path); ("site", Keeper_fs_failure_site.(to_label Ensure_dir_cancelled))]
-              ();
-            Log.Keeper.warn "filesystem_runtime: ensure_dir cancelled path=%s" path;
-            Error (exn, Printexc.get_raw_backtrace ())
-        | exn ->
-            Keeper_fd_pressure.note_exception
-              ~site:"filesystem_runtime.ensure_dir"
-              exn;
-            Keeper_disk_pressure.note_exception
-              ~site:"filesystem_runtime.ensure_dir"
-              exn;
-            Otel_metric_store.inc_counter
-              Keeper_metrics.(to_string FsFailures)
-              ~labels:[("path", path); ("site", Keeper_fs_failure_site.(to_label Ensure_dir_failed))]
-              ();
-            Log.Keeper.warn "filesystem_runtime: ensure_dir failed path=%s: %s"
-              path (Printexc.to_string exn);
-            Error (exn, Printexc.get_raw_backtrace ())
-      with
-      | Ok () -> ()
-      | Error err -> deferred_exn := Some err
-    end);
-  match !deferred_exn with
-  | Some (exn, bt) -> Printexc.raise_with_backtrace exn bt
-  | None -> path
+  let key = dir_cache_key path in
+  if dir_is_cached key
+  then path
+  else
+    let lock = acquire_dir_lock key in
+    Fun.protect
+      ~finally:(fun () -> release_dir_lock key lock)
+      (fun () ->
+        let result =
+          Eio_guard.with_mutex lock.mutex (fun () ->
+            try
+              if not (dir_is_cached key)
+              then begin
+                let expected_epoch = capture_dir_cache_epoch () in
+                Fs_compat.mkdir_p_durable path;
+                mark_dir_cached_if_current key expected_epoch
+              end;
+              Ok ()
+            with
+            | exn -> Error (exn, Printexc.get_raw_backtrace ()))
+        in
+        match result with
+        | Ok () -> path
+        | Error ((Eio.Cancel.Cancelled _ as exn), bt) ->
+          Otel_metric_store.inc_counter
+            Keeper_metrics.(to_string FsFailures)
+            ~labels:
+              [ "path", path
+              ; ( "site"
+                , Keeper_fs_failure_site.(to_label Ensure_dir_cancelled) )
+              ]
+            ();
+          Log.Keeper.warn "filesystem_runtime: ensure_dir cancelled path=%s" path;
+          Printexc.raise_with_backtrace exn bt
+        | Error (exn, bt) ->
+          Keeper_fd_pressure.note_exception
+            ~site:"filesystem_runtime.ensure_dir"
+            exn;
+          Keeper_disk_pressure.note_exception
+            ~site:"filesystem_runtime.ensure_dir"
+            exn;
+          Otel_metric_store.inc_counter
+            Keeper_metrics.(to_string FsFailures)
+            ~labels:
+              [ "path", path
+              ; "site", Keeper_fs_failure_site.(to_label Ensure_dir_failed)
+              ]
+            ();
+          Log.Keeper.warn
+            "filesystem_runtime: ensure_dir failed path=%s: %s"
+            path
+            (Printexc.to_string exn);
+          Printexc.raise_with_backtrace exn bt)
 
 let invalidate_dir (path : string) : unit =
-  Eio_guard.with_mutex dir_mu (fun () ->
-    Hashtbl.remove ensured_dirs path)
+  let key = dir_cache_key path in
+  Stdlib.Mutex.protect dir_state_mu (fun () ->
+    dir_cache_epoch := ref ();
+    let rec is_same_or_descendant candidate =
+      if String.equal candidate key
+      then true
+      else
+        let parent = Filename.dirname candidate in
+        if String.equal parent candidate
+        then false
+        else is_same_or_descendant parent
+    in
+    Hashtbl.filter_map_inplace
+      (fun candidate () ->
+        if is_same_or_descendant candidate then None else Some ())
+      ensured_dirs)
 
 let clear_dir_cache () : unit =
-  Eio_guard.with_mutex dir_mu (fun () ->
+  Stdlib.Mutex.protect dir_state_mu (fun () ->
+    dir_cache_epoch := ref ();
     Hashtbl.clear ensured_dirs)
 
 (* ================================================================ *)

--- a/lib/keeper/keeper_fs.mli
+++ b/lib/keeper/keeper_fs.mli
@@ -7,12 +7,15 @@
 
 (** {1 Directory Management} *)
 
-(** Ensure [path] exists, creating it recursively if needed.
-    Fiber-safe: protected by Eio.Mutex. Returns [path] for chaining. *)
+(** Ensure [path] exists, creating it recursively if needed. A successful path
+    is cached for the process lifetime: cache hits perform no stat or mkdir.
+    Cache misses synchronize only with the same path, so one Keeper's directory
+    fsync cannot serialize unrelated Keeper lanes. Returns [path] for chaining. *)
 val ensure_dir : string -> string
 
-(** Remove [path] from the directory cache.
-    Call after external deletion or move. *)
+(** Remove [path] and every cached descendant from the directory cache. Call
+    after external deletion or move so a later child write recreates its full
+    directory chain instead of trusting stale process-local ancestry. *)
 val invalidate_dir : string -> unit
 
 (** Clear the entire directory cache. Useful in tests. *)

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -321,7 +321,11 @@ let prepare_keeper_chat_persistence ~(workspace_config : Workspace.config) =
     let queue_report = Keeper_chat_queue.configure_persistence ~base_path in
     List.iter
       (fun (keeper_name, (error : Keeper_chat_queue.snapshot_load_error)) ->
-         let keeper_label = Option.value keeper_name ~default:"<registry>" in
+         let keeper_label =
+           match keeper_name with
+           | Some keeper_name -> keeper_name
+           | None -> "<registry>"
+         in
          Log.Keeper.error
            "keeper_chat_queue: snapshot unavailable keeper=%s: %s"
            keeper_label

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -283,19 +283,8 @@ let filteri_with_fair_yield =
   Server_bootstrap_loops_fiber.filteri_with_fair_yield
 let iteri_with_fair_yield = Server_bootstrap_loops_fiber.iteri_with_fair_yield
 
-let start_keeper_loops
-      ~sw
-      ~clock
-      ~net
-      ~domain_mgr
-      ~proc_mgr
-      (state : Mcp_server.server_state)
-  =
-  Progress.set_sse_callback Sse.broadcast;
-  (* Wire stop_keeper hook so zombie GC can terminate keeper fibers *)
-  Atomic.set Workspace_hooks.stop_keeper_fn Keeper_keepalive.stop_keepalive;
-  Atomic.set Workspace_hooks.runtime_agents_fn keeper_registry_runtime_agents;
-  let base_path = (Mcp_server.workspace_config state).base_path in
+let prepare_keeper_chat_persistence ~(workspace_config : Workspace.config) =
+  let base_path = workspace_config.base_path in
   let delivery_recovery =
     Keeper_chat_delivery_journal.recover_all
       ~base_path
@@ -316,17 +305,73 @@ let start_keeper_loops
       delivery_recovery.recovered
       delivery_recovery.already_final
       (List.length delivery_recovery.failures);
-  (* Request status is recovered only after transcript journals converge: a
-     poller must never observe a final Lost status while its durable terminal
-     row is still absent. *)
-  let recovered_keeper_msg_requests =
-    Keeper_msg_async.recover_lost_disk_records ~base_path
-  in
-  if recovered_keeper_msg_requests > 0
-  then
-    Log.Keeper.warn
-      "keeper_msg_async: recovered %d disk-only non-terminal request record(s) as lost"
-      recovered_keeper_msg_requests;
+  match delivery_recovery.failures with
+  | failure :: _ ->
+    Error
+      (Printf.sprintf
+         "keeper chat delivery recovery failed before queue readiness: keeper=%s delivery_ref=%s error=%s"
+         failure.keeper_name
+         failure.delivery_ref
+         (Keeper_chat_delivery_journal.error_to_string failure.error))
+  | [] ->
+    Keeper_chat_queue.set_transition_observer
+      (Some
+         (fun ~keeper_name ~revision ->
+            Keeper_chat_broadcast.queue_changed ~keeper_name ~revision ()));
+    let queue_report = Keeper_chat_queue.configure_persistence ~base_path in
+    List.iter
+      (fun (keeper_name, (error : Keeper_chat_queue.snapshot_load_error)) ->
+         let keeper_label = Option.value keeper_name ~default:"<registry>" in
+         Log.Keeper.error
+           "keeper_chat_queue: snapshot unavailable keeper=%s: %s"
+           keeper_label
+           error.Keeper_chat_queue.message)
+      queue_report.load_errors;
+    if queue_report.recovered_receipt_count > 0
+    then
+      Log.Keeper.warn
+        "keeper_chat_queue: recovered %d inflight receipt(s) during startup"
+        queue_report.recovered_receipt_count;
+    let registry_errors =
+      List.filter_map
+        (function
+          | None, error -> Some error
+          | Some _, _ -> None)
+        queue_report.load_errors
+    in
+    (match registry_errors with
+     | error :: _ ->
+       Error
+         (Printf.sprintf
+            "keeper chat queue registry recovery failed: %s"
+            error.Keeper_chat_queue.message)
+     | [] ->
+       if not (Keeper_chat_queue.persistence_matches_base_path ~base_path)
+       then Error "keeper chat queue did not acquire the server BasePath"
+       else (
+         let recovered_keeper_msg_requests =
+           Keeper_msg_async.recover_lost_disk_records ~base_path
+         in
+         if recovered_keeper_msg_requests > 0
+         then
+           Log.Keeper.warn
+             "keeper_msg_async: recovered %d disk-only non-terminal request record(s) as lost"
+             recovered_keeper_msg_requests;
+         Ok ()))
+;;
+
+let start_keeper_loops
+      ~sw
+      ~clock
+      ~net
+      ~domain_mgr
+      ~proc_mgr
+      (state : Mcp_server.server_state)
+  =
+  Progress.set_sse_callback Sse.broadcast;
+  (* Wire stop_keeper hook so zombie GC can terminate keeper fibers *)
+  Atomic.set Workspace_hooks.stop_keeper_fn Keeper_keepalive.stop_keepalive;
+  Atomic.set Workspace_hooks.runtime_agents_fn keeper_registry_runtime_agents;
   (* Shared Agent_sdk Event_bus used as the runtime transport between subsystems.
      Configuration is sourced from [Masc_event_bus_policy.oas_runtime] so the
      buffer-size/policy choice is auditable in source rather than implicit in
@@ -1132,24 +1177,6 @@ let start_keeper_loops
          handle_turn wires process_single_turn for actual turn execution. *)
       (try
          let base_path = (Mcp_server.workspace_config state).base_path in
-         Keeper_chat_queue.set_transition_observer
-           (Some
-              (fun ~keeper_name ~revision ->
-                 Keeper_chat_broadcast.queue_changed ~keeper_name
-                   ~revision ()));
-         let queue_report = Keeper_chat_queue.configure_persistence ~base_path in
-         List.iter
-           (fun (keeper_name, (error : Keeper_chat_queue.snapshot_load_error)) ->
-              let keeper_label =
-                match keeper_name with
-                | Some keeper_name -> keeper_name
-                | None -> "<registry>"
-              in
-              Log.Keeper.error
-                "keeper_chat_queue: snapshot unavailable keeper=%s: %s"
-                keeper_label
-                error.Keeper_chat_queue.message)
-           queue_report.load_errors;
          Keeper_chat_consumer.start ~sw ~clock
            ~base_path
            ~handle_turn:(fun ~sw ~keeper_name ~delivery_key ~queued_message ->

--- a/lib/server/server_bootstrap_loops.mli
+++ b/lib/server/server_bootstrap_loops.mli
@@ -15,6 +15,13 @@ val install_tooling :
     according to [governance_level] (e.g. ["restricted"], ["full"]).
     Idempotent; safe to call once per server instance. *)
 
+val prepare_keeper_chat_persistence :
+  workspace_config:Workspace.config -> (unit, string) result
+(** Recover delivery journals, restore the durable Keeper chat queue, and only
+    then reconcile disk-only request records. Registry discovery failure is a
+    readiness error; individual corrupt keeper snapshots remain isolated.
+    Startup calls this before publishing server route readiness. *)
+
 val start_keeper_loops :
   sw:Eio.Switch.t ->
   clock:float Eio.Time.clock_ty Eio.Resource.t ->

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -1139,8 +1139,30 @@ let keeper_chat_receipt_state_json = function
       ]
 ;;
 
-let keeper_chat_receipt_json ~keeper_name ~revision
+let keeper_chat_receipt_json ~keeper_name ~revision ~load_errors
     (receipt : Keeper_chat_queue.receipt_view) =
+  let public_load_error_message = function
+    | Keeper_chat_queue.Invalid_path ->
+      "Keeper chat queue path is invalid."
+    | Keeper_chat_queue.Read_failed ->
+      "Keeper chat queue storage could not be read."
+    | Keeper_chat_queue.Parse_failed ->
+      "Keeper chat queue storage could not be decoded."
+    | Keeper_chat_queue.Migration_failed ->
+      "Keeper chat queue storage migration did not complete."
+    | Keeper_chat_queue.Recovery_failed ->
+      "Keeper chat queue recovery did not complete."
+    | Keeper_chat_queue.Durability_uncertain ->
+      "Keeper chat queue durability is uncertain; operator recovery is required."
+  in
+  let load_error_json (error : Keeper_chat_queue.snapshot_load_error) =
+    `Assoc
+      [ ( "kind"
+        , `String
+            (Keeper_chat_queue.snapshot_load_error_kind_to_string error.kind) )
+      ; "message", `String (public_load_error_message error.kind)
+      ]
+  in
   `Assoc
     [ "schema", `String "keeper_chat_queue.receipt.v1"
     ; "keeper_name", `String keeper_name
@@ -1149,6 +1171,9 @@ let keeper_chat_receipt_json ~keeper_name ~revision
           (Keeper_chat_queue.Receipt_id.to_string receipt.receipt_id) )
     ; "revision", `Intlit (Int64.to_string revision)
     ; "state", keeper_chat_receipt_state_json receipt.state
+    ; ( "availability"
+      , `String (if load_errors = [] then "available" else "quarantined") )
+    ; "load_errors", `List (List.map load_error_json load_errors)
     ]
 ;;
 
@@ -1195,15 +1220,29 @@ let handle_keeper_get_subroutes state req request reqd =
        | Ok receipt_id ->
          (match Keeper_chat_queue.lookup_receipt ~keeper_name:name ~receipt_id with
           | Error error ->
+            Log.Keeper.warn
+              "keeper chat receipt read unavailable keeper=%s receipt_id=%s: %s"
+              name
+              raw_receipt_id
+              (Keeper_chat_queue.mutation_error_to_string error);
             Server_auth.respond_json_value_with_cors ~status:`Service_unavailable
               request reqd
-              (error_json (Keeper_chat_queue.mutation_error_to_string error))
-          | Ok { receipt = None; _ } ->
+              (error_json "keeper chat receipt is temporarily unavailable")
+          | Ok { receipt = None; load_errors = _ :: _; _ } ->
+            Server_auth.respond_json_value_with_cors ~status:`Service_unavailable
+              request reqd
+              (error_json
+                 "keeper chat receipt absence is not authoritative while its Keeper queue is quarantined")
+          | Ok { receipt = None; load_errors = []; _ } ->
             Server_auth.respond_json_value_with_cors ~status:`Not_found request reqd
               (error_json "keeper chat receipt not found")
-          | Ok { revision; receipt = Some receipt } ->
+          | Ok { revision; receipt = Some receipt; load_errors } ->
             Server_auth.respond_json_value_with_cors ~status:`OK request reqd
-              (keeper_chat_receipt_json ~keeper_name:name ~revision receipt)))
+              (keeper_chat_receipt_json
+                 ~keeper_name:name
+                 ~revision
+                 ~load_errors
+                 receipt)))
   | None ->
   if ends_with "/digest" then (
     (* Keeper catch-up digest (since-last-seen). Inherits the enclosing

--- a/lib/server/server_dashboard_http_keeper_api.mli
+++ b/lib/server/server_dashboard_http_keeper_api.mli
@@ -230,6 +230,7 @@ val keeper_chat_receipt_route : string -> (string * string) option
 val keeper_chat_receipt_json :
   keeper_name:string ->
   revision:int64 ->
+  load_errors:Keeper_chat_queue.snapshot_load_error list ->
   Keeper_chat_queue.receipt_view ->
   Yojson.Safe.t
 (** Read-only typed receipt projection returned by the route above. *)

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -591,30 +591,40 @@ let handle_ambient ~base_dir
     else begin
       let parent_channel_id = State.parent_channel_of_thread ~channel_id in
       let thread_id = Option.map (fun _ -> channel_id) parent_channel_id in
+      let persisted =
+        Keeper_chat_store.append_user_message_result
+          ~base_dir ~keeper_name ~content:trimmed
+          ~surface:
+            (Surface_ref.Discord
+               {
+                 guild_id;
+                 channel_id;
+                 parent_channel_id;
+                 thread_id;
+               })
+          ~conversation_id:(discord_conversation_id ~guild_id ~channel_id)
+          ~external_message_id:message_id
+          ~speaker:
+            { Keeper_chat_store.speaker_id = Some author_id
+            ; speaker_name = author_name
+            ; speaker_authority = Keeper_chat_store.External
+            }
+          ()
+      in
+      (match persisted with
+       | Error detail ->
+         Log.Server.error
+           "discord ambient transcript persistence failed keeper=%s channel=%s message=%s error=%s"
+           keeper_name channel_id message_id detail;
+         Discord_observability.record_ambient
+           Discord_observability.Ambient_persistence_failed
+       | Ok () ->
       let attention_event_id =
         record_external_attention ~base_dir ~keeper_name ~guild_id ~channel_id
           ~message_id ~author_id ~author_name ~content:trimmed
           ~mentions_bot:false ~route:"ambient"
           ~urgency:Keeper_external_attention.Ambient
       in
-      Keeper_chat_store.append_user_message
-        ~base_dir ~keeper_name ~content:trimmed
-        ~surface:
-          (Surface_ref.Discord
-             {
-               guild_id;
-               channel_id;
-               parent_channel_id;
-               thread_id;
-             })
-        ~conversation_id:(discord_conversation_id ~guild_id ~channel_id)
-        ~external_message_id:message_id
-        ~speaker:
-          { Keeper_chat_store.speaker_id = Some author_id
-          ; speaker_name = author_name
-          ; speaker_authority = Keeper_chat_store.External
-          }
-        ();
       Keeper_chat_broadcast.chat_appended ~keeper_name ~source:State.channel ();
       (* RFC-connector-ambient-attention-wake P3: wake the (possibly idle) keeper
          on this ambient message via an edge stimulus carrying the external-
@@ -664,7 +674,7 @@ let handle_ambient ~base_dir
          ()
        | Some _ | None -> ());
       Discord_observability.record_ambient
-        Discord_observability.Ambient_recorded
+        Discord_observability.Ambient_recorded)
     end
 
 let on_ambient ~base_dir (ev : Gw.gateway_event) =

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -178,6 +178,7 @@ type dashboard_deferred_chat =
   ; receipt_id : string
   ; shutdown_operation_id : Keeper_shutdown_types.Operation_id.t option
   ; queue_revision : int64
+  ; queue_durability : Keeper_chat_queue.commit_durability
   }
 
 let dashboard_busy_queue_state ~base_path ~keeper_name =
@@ -189,18 +190,24 @@ let dashboard_busy_queue_state ~base_path ~keeper_name =
     if not (Keeper_chat_queue.persistence_configured ())
     then true
     else
-      let snapshot = Keeper_chat_queue.snapshot ~keeper_name in
-      snapshot.load_errors <> []
-      || snapshot.pending <> []
-      || snapshot.inflight <> []
+      match Keeper_chat_queue.has_active_receipts ~keeper_name with
+      | Ok active -> active
+      | Error _ -> true
   in
   match in_flight, chat_waiting, queue_waiting, shutdown_operation_id with
   | None, false, false, None -> None
   | _ -> Some (in_flight, chat_waiting, shutdown_operation_id)
 
 let dashboard_deferred_ack_text ~keeper_name deferred =
-  match deferred.shutdown_operation_id with
-  | Some operation_id ->
+  match deferred.queue_durability, deferred.shutdown_operation_id with
+  | Keeper_chat_queue.Durability_uncertain _, _ ->
+    Printf.sprintf
+      "%s accepted your message at receipt_id=%s, but could not prove the \n\
+       queue directory's crash durability. Do not resend it blindly. This \n\
+       Keeper's chat queue is quarantined until operator recovery."
+      keeper_name
+      deferred.receipt_id
+  | Keeper_chat_queue.Durable, Some operation_id ->
     Printf.sprintf
       "%s is stopping under operation %s; your message was durably accepted \
        (receipt_id=%s, pending_count=%d, inflight_count=%d) for the next active \
@@ -211,7 +218,7 @@ let dashboard_deferred_ack_text ~keeper_name deferred =
       deferred.receipt_id
       deferred.pending_count
       deferred.inflight_count
-  | None ->
+  | Keeper_chat_queue.Durable, None ->
     Printf.sprintf
       "%s is busy; your message was durably accepted (receipt_id=%s, \
        pending_count=%d, inflight_count=%d). The Dashboard will track it through \
@@ -229,6 +236,7 @@ let dashboard_deferred_chat_to_json ~keeper_name
      ; receipt_id
      ; shutdown_operation_id
      ; queue_revision
+     ; queue_durability
      } : dashboard_deferred_chat) =
   let in_flight_fields =
     match in_flight with
@@ -240,9 +248,26 @@ let dashboard_deferred_chat_to_json ~keeper_name
           , `Float started_at )
         ]
   in
+  let durability_fields =
+    match queue_durability with
+    | Keeper_chat_queue.Durable ->
+      [ "queue_durability", `String "durable" ]
+    | Keeper_chat_queue.Durability_uncertain error ->
+      [ "queue_durability", `String "uncertain"
+      ; ( "queue_durability_error_kind"
+        , `String
+            (Keeper_chat_queue.snapshot_load_error_kind_to_string error.kind) )
+      ]
+  in
+  let status =
+    match queue_durability with
+    | Keeper_chat_queue.Durable -> "queued"
+    | Keeper_chat_queue.Durability_uncertain _ ->
+      "queued_durability_uncertain"
+  in
   `Assoc
     ([ ("keeper_name", `String keeper_name)
-     ; ("status", `String "queued")
+     ; ("status", `String status)
      ; ("queue", `String "keeper_chat_queue")
      ; ("pending_count", `Int pending_count)
      ; ("inflight_count", `Int inflight_count)
@@ -255,6 +280,7 @@ let dashboard_deferred_chat_to_json ~keeper_name
          | Some operation_id ->
            `String (Keeper_shutdown_types.Operation_id.to_string operation_id) )
      ]
+     @ durability_fields
      @ in_flight_fields)
 
 let enqueue_dashboard_payload
@@ -282,6 +308,7 @@ let enqueue_dashboard_payload
         ; inflight_count = receipt.inflight_count
         ; receipt_id = Keeper_chat_queue.Receipt_id.to_string receipt.receipt_id
         ; queue_revision = receipt.revision
+        ; queue_durability = receipt.durability
         ; shutdown_operation_id
         }
 
@@ -1347,9 +1374,12 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
      still an authenticated dashboard operator, so it keeps Owner authority
      while recording the Gate surface label. *)
   let chat_speaker : Keeper_chat_store.speaker = chat_speaker_of_request payload in
-  let dashboard_direct_stream =
+  let direct_delivery_journal_required =
     (not queued_turn)
     && (not connector_user_line_recorded_upstream)
+  in
+  let dashboard_direct_stream =
+    direct_delivery_journal_required
     && not (has_external_speaker payload)
   in
   let direct_delivery_journal = ref None in
@@ -1358,6 +1388,22 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
   in
   let set_direct_delivery_journal journal =
     direct_delivery_journal := Some journal
+  in
+  let adopt_direct_delivery_journal = function
+    | Ok journal ->
+      set_direct_delivery_journal journal;
+      Ok journal
+    | Error
+        (Keeper_chat_delivery_journal.Commit_durability_uncertain
+           { committed; _ } as error) ->
+      set_direct_delivery_journal committed;
+      Log.Keeper.error
+        "keeper_stream: delivery journal committed with uncertain crash durability keeper=%s revision=%d: %s"
+        payload.name
+        committed.revision
+        (journal_error error);
+      Error (journal_error error)
+    | Error error -> Error (journal_error error)
   in
   let on_direct_request_accepted request_id =
     let ( let* ) = Result.bind in
@@ -1385,9 +1431,8 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
         ~delivery_key
         ~payload:accepted_payload
         ~now:(Time_compat.now ())
-      |> Result.map_error journal_error
+      |> adopt_direct_delivery_journal
     in
-    set_direct_delivery_journal prepared;
     let* user_row_id =
       Keeper_chat_store.append_delivery_user_message_result
         ~base_dir:base_path
@@ -1406,18 +1451,16 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
         ~identity:prepared
         ~user_row_id:(Some user_row_id)
         ~now:(Time_compat.now ())
-      |> Result.map_error journal_error
+      |> adopt_direct_delivery_journal
     in
-    set_direct_delivery_journal accepted;
     let* running =
       Keeper_chat_delivery_journal.mark_running
         ~base_path
         ~expected_revision:accepted.revision
         ~identity:accepted
         ~now:(Time_compat.now ())
-      |> Result.map_error journal_error
+      |> adopt_direct_delivery_journal
     in
-    set_direct_delivery_journal running;
     Ok ()
   in
   let on_queue_turn_admitted () =
@@ -1459,9 +1502,8 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
         ~delivery_key
         ~payload:accepted_payload
         ~now:(Time_compat.now ())
-      |> Result.map_error journal_error
+      |> adopt_direct_delivery_journal
     in
-    set_direct_delivery_journal prepared;
     let* user_row_id =
       match user_row_origin with
       | Keeper_chat_delivery_journal.Already_persisted_upstream -> Ok None
@@ -1486,18 +1528,16 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
         ~identity:prepared
         ~user_row_id
         ~now:(Time_compat.now ())
-      |> Result.map_error journal_error
+      |> adopt_direct_delivery_journal
     in
-    set_direct_delivery_journal accepted;
     let* running =
       Keeper_chat_delivery_journal.mark_running
         ~base_path
         ~expected_revision:accepted.revision
         ~identity:accepted
         ~now:(Time_compat.now ())
-      |> Result.map_error journal_error
+      |> adopt_direct_delivery_journal
     in
-    set_direct_delivery_journal running;
     Ok ()
   in
   let commit_direct_terminal terminal =
@@ -1512,9 +1552,8 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
             ~identity:journal
             ~terminal
             ~now:(Time_compat.now ())
-          |> Result.map_error journal_error
+          |> adopt_direct_delivery_journal
         in
-        set_direct_delivery_journal pending;
         drive pending
       | Keeper_chat_delivery_journal.Terminal_pending
           { terminal = persisted_terminal; user_row_id } ->
@@ -1561,9 +1600,8 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
             ~identity:journal
             ~transcript_row_id
             ~now:(Time_compat.now ())
-          |> Result.map_error journal_error
+          |> adopt_direct_delivery_journal
         in
-        set_direct_delivery_journal committed;
         drive committed
       | Keeper_chat_delivery_journal.Transcript_committed _ ->
         let* final =
@@ -1572,9 +1610,8 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
             ~expected_revision:journal.revision
             ~identity:journal
             ~now:(Time_compat.now ())
-          |> Result.map_error journal_error
+          |> adopt_direct_delivery_journal
         in
-        set_direct_delivery_journal final;
         Ok ()
       | Keeper_chat_delivery_journal.Final _ -> Ok ()
       | Keeper_chat_delivery_journal.Prepared
@@ -1725,7 +1762,7 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
           (Keeper_msg_async.submit_error_to_json error |> Yojson.Safe.to_string)
     | Ok background_sw ->
       let on_accepted =
-        if dashboard_direct_stream
+        if direct_delivery_journal_required
         then Some on_direct_request_accepted
         else None
       in
@@ -1794,15 +1831,42 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
         in
         match dispatch_result with
         | Ok (`Deferred rejection) ->
-            push_worker_event (Stream_queued_turn_deferred rejection);
-            Tool_result.ok
-              ~tool_name:"masc_keeper_msg"
-              ~start_time
-              (Yojson.Safe.to_string
-                 (`Assoc
-                    [ ("status", `String "deferred")
-                    ; ("admission", admission_rejection_to_json rejection)
-                    ]))
+            if queued_turn
+            then begin
+              push_worker_event (Stream_queued_turn_deferred rejection);
+              Tool_result.ok
+                ~tool_name:"masc_keeper_msg"
+                ~start_time
+                (Yojson.Safe.to_string
+                   (`Assoc
+                      [ ("status", `String "deferred")
+                      ; ("admission", admission_rejection_to_json rejection)
+                      ]))
+            end
+            else
+              let err =
+                match rejection.shutdown_operation_id with
+                | Some operation_id ->
+                  Printf.sprintf
+                    "Keeper admission is fenced by shutdown operation %s; this direct request was not queued."
+                    (Keeper_shutdown_types.Operation_id.to_string operation_id)
+                | None ->
+                  Printf.sprintf
+                    "Keeper admission is busy with %d waiting chat requests; this direct request was not queued."
+                    rejection.waiting
+              in
+              let persisted = persist_failure_reply err in
+              let queued_outcome =
+                failure_outcome_after_persist
+                  ~queued_turn:false
+                  ~failure_kind:Turn_failed
+                  ~detail:err
+                  persisted
+              in
+              push_worker_event
+                (Stream_terminal
+                   { status = Stream_rejected; body = err; queued_outcome });
+              Tool_result.error ~tool_name:"masc_keeper_msg" ~start_time err
         | Ok (`Queued queued) ->
             let body =
               Yojson.Safe.to_string

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -1224,6 +1224,24 @@ let queued_delivery_outcome_of_turn_ref = function
             "queued turn persisted a reply but the reply payload had no valid turn_ref"
         }
 
+let delivery_outcome_after_persist ~queued_turn ~turn_ref = function
+  | Ok () ->
+    if queued_turn
+    then Some (queued_delivery_outcome_of_turn_ref turn_ref)
+    else None
+  | Error detail ->
+    Some (Failed { kind = Transcript_persist_failed; detail })
+
+let failure_outcome_after_persist ~queued_turn ~failure_kind ~detail = function
+  | Ok () ->
+    if queued_turn then Some (Failed { kind = failure_kind; detail }) else None
+  | Error persist_error ->
+    Some
+      (Failed
+         { kind = Transcript_persist_failed
+         ; detail = persist_error
+         })
+
 type keeper_stream_bridge_state = Keeper_chat_oas_stream_bridge.state
 
 type translated_keeper_stream_event =
@@ -1338,10 +1356,6 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
   let journal_error error =
     Keeper_chat_delivery_journal.error_to_string error
   in
-  let row_id_of_append_once = function
-    | Keeper_chat_store.Appended { row_id }
-    | Keeper_chat_store.Already_present { row_id } -> row_id
-  in
   let set_direct_delivery_journal journal =
     direct_delivery_journal := Some journal
   in
@@ -1374,8 +1388,8 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
       |> Result.map_error journal_error
     in
     set_direct_delivery_journal prepared;
-    let* user_row =
-      Keeper_chat_store.append_user_message_once
+    let* user_row_id =
+      Keeper_chat_store.append_delivery_user_message_result
         ~base_dir:base_path
         ~keeper_name:payload.name
         ~delivery_key
@@ -1390,7 +1404,7 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
         ~base_path
         ~expected_revision:prepared.revision
         ~identity:prepared
-        ~user_row_id:(Some (row_id_of_append_once user_row))
+        ~user_row_id:(Some user_row_id)
         ~now:(Time_compat.now ())
       |> Result.map_error journal_error
     in
@@ -1454,7 +1468,7 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
       | Keeper_chat_delivery_journal.Already_persisted { row_id } ->
         Ok (Some row_id)
       | Keeper_chat_delivery_journal.Needs_append ->
-        Keeper_chat_store.append_user_message_once
+        Keeper_chat_store.append_delivery_user_message_result
           ~base_dir:base_path
           ~keeper_name:payload.name
           ~delivery_key
@@ -1463,7 +1477,7 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
           ~surface:chat_surface
           ~speaker:chat_speaker
           ()
-        |> Result.map (fun result -> Some (row_id_of_append_once result))
+        |> Result.map Option.some
     in
     let* accepted =
       Keeper_chat_delivery_journal.mark_accepted
@@ -1509,7 +1523,7 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
           match persisted_terminal.delivery with
           | Keeper_chat_delivery_journal.Assistant_reply
               { content; blocks; turn_ref } ->
-            Keeper_chat_store.append_assistant_message_once
+            Keeper_chat_store.append_delivery_assistant_message_result
               ~base_dir:base_path
               ~keeper_name:payload.name
               ~delivery_key
@@ -1519,9 +1533,8 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
               ?turn_ref
               ~stream_lifecycle:completed_stream_lifecycle
               ()
-            |> Result.map row_id_of_append_once
           | Keeper_chat_delivery_journal.Transport_failure { content } ->
-            Keeper_chat_store.append_assistant_message_once
+            Keeper_chat_store.append_delivery_assistant_message_result
               ~base_dir:base_path
               ~keeper_name:payload.name
               ~delivery_key
@@ -1530,7 +1543,6 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
               ~assistant_kind:Keeper_chat_store.Row_kind.Transport_failure
               ~stream_lifecycle:errored_stream_lifecycle
               ()
-            |> Result.map row_id_of_append_once
           | Keeper_chat_delivery_journal.No_assistant_reply
               { reason =
                   ( Keeper_chat_delivery_journal.Continuation_checkpoint
@@ -1598,9 +1610,11 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
        connector user line (Discord/Slack busy message enqueued onto the chat
        queue), re-recording it here would double-write. The gate inbound line is
        assistant-less, so the message is already "pending" — nothing to add. *)
-    if Option.is_some !direct_delivery_journal then ()
-    else if not connector_user_line_recorded_upstream then
-      Keeper_chat_store.append_user_message
+    if Option.is_some !direct_delivery_journal
+       || connector_user_line_recorded_upstream
+    then Ok ()
+    else
+      Keeper_chat_store.append_user_message_result
         ~base_dir:base_path
         ~keeper_name:payload.name
         ~content:payload.message
@@ -1695,16 +1709,11 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
     in
     let persisted = persist_failure_reply body in
     let queued_outcome =
-      if not queued_turn then None
-      else
-        match persisted with
-        | Ok () -> Some (Failed { kind = failure_kind; detail = body })
-        | Error persist_error ->
-            Some
-              (Failed
-                 { kind = Transcript_persist_failed
-                 ; detail = persist_error
-                 })
+      failure_outcome_after_persist
+        ~queued_turn
+        ~failure_kind
+        ~detail:body
+        persisted
     in
     push_worker_event (Stream_terminal { status; body; queued_outcome });
     persisted
@@ -1876,21 +1885,17 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
                  visible_reply
              with
              | Some err ->
+                 let persisted = persist_failure_reply err in
                  let queued_outcome =
-                   if not queued_turn then None
-                   else
-                     match persist_failure_reply err with
-                     | Ok () -> Some (Failed { kind = Turn_failed; detail = err })
-                     | Error persist_error ->
-                         Some
-                           (Failed
-                              { kind = Transcript_persist_failed
-                              ; detail = persist_error
-                              })
+                   failure_outcome_after_persist
+                     ~queued_turn
+                     ~failure_kind:Turn_failed
+                     ~detail:err
+                     persisted
                  in
                  if not queued_turn
                  then
-                   (match persist_failure_reply err with
+                   (match persisted with
                     | Ok () -> ()
                     | Error persist_error ->
                       Log.Keeper.error
@@ -1943,23 +1948,12 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
                        ()
                  in
                  let delivered_after_persist ?content persisted =
-                   match persisted with
-                   | Ok () ->
+                   (match persisted with
+                    | Ok () ->
                        Keeper_chat_broadcast.chat_appended
-                         ~keeper_name:payload.name ~source:chat_source ?content ();
-                       if queued_turn
-                       then
-                         Some (queued_delivery_outcome_of_turn_ref turn_ref)
-                       else None
-                   | Error persist_error ->
-                       if queued_turn
-                       then
-                         Some
-                           (Failed
-                              { kind = Transcript_persist_failed
-                              ; detail = persist_error
-                              })
-                       else None
+                         ~keeper_name:payload.name ~source:chat_source ?content ()
+                    | Error _ -> ());
+                   delivery_outcome_after_persist ~queued_turn ~turn_ref persisted
                  in
                  let turn_outcome =
                    Keeper_turn_outcome.of_reply_payload payload_json_opt
@@ -2003,8 +1997,10 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
                                (Failed
                                   { kind = Transcript_persist_failed; detail }))
                         | None ->
-                          persist_user_message_only ();
-                          None)
+                          persist_user_message_only ()
+                          |> delivery_outcome_after_persist
+                               ~queued_turn:false
+                               ~turn_ref:None)
                    | Keeper_turn_outcome.No_visible_reply, _
                    | Keeper_turn_outcome.Visible_reply, None ->
                        if has_visible_blocks
@@ -2024,9 +2020,11 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
                                    { kind = Transcript_persist_failed
                                    ; detail = persist_error
                                    }))
-                       else (
-                         persist_user_message_only ();
-                         None)
+                       else
+                         persist_user_message_only ()
+                         |> delivery_outcome_after_persist
+                              ~queued_turn:false
+                              ~turn_ref:None
                    | Keeper_turn_outcome.Visible_reply, Some visible_reply ->
                        persist_assistant_reply ~assistant_content:visible_reply
                        |> delivered_after_persist ~content:visible_reply
@@ -2062,16 +2060,11 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
         | Ok (`Ran (false, err)) ->
             let persisted = persist_failure_reply err in
             let queued_outcome =
-              if not queued_turn then None
-              else
-                match persisted with
-                | Ok () -> Some (Failed { kind = Turn_failed; detail = err })
-                | Error persist_error ->
-                    Some
-                      (Failed
-                         { kind = Transcript_persist_failed
-                         ; detail = persist_error
-                         })
+              failure_outcome_after_persist
+                ~queued_turn
+                ~failure_kind:Turn_failed
+                ~detail:err
+                persisted
             in
             push_worker_event
               (Stream_terminal
@@ -2080,16 +2073,11 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
         | Error err ->
             let persisted = persist_failure_reply err in
             let queued_outcome =
-              if not queued_turn then None
-              else
-                match persisted with
-                | Ok () -> Some (Failed { kind = Turn_failed; detail = err })
-                | Error persist_error ->
-                    Some
-                      (Failed
-                         { kind = Transcript_persist_failed
-                         ; detail = persist_error
-                         })
+              failure_outcome_after_persist
+                ~queued_turn
+                ~failure_kind:Turn_failed
+                ~detail:err
+                persisted
             in
             push_worker_event
               (Stream_terminal
@@ -2105,16 +2093,11 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
     | Error body ->
         let persisted = persist_failure_reply body in
         let queued_outcome =
-          if not queued_turn then None
-          else
-            match persisted with
-            | Ok () -> Some (Failed { kind = Turn_failed; detail = body })
-            | Error persist_error ->
-                Some
-                  (Failed
-                     { kind = Transcript_persist_failed
-                     ; detail = persist_error
-                     })
+          failure_outcome_after_persist
+            ~queued_turn
+            ~failure_kind:Turn_failed
+            ~detail:body
+            persisted
         in
         push_worker_event
           (Stream_terminal
@@ -2260,7 +2243,15 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
         ; body = message
         ; queued_outcome
         } ->
-        let message = redact_text message in
+        let message =
+          match queued_outcome with
+          | Some (Failed { kind = Transcript_persist_failed; _ }) when queued_turn ->
+            "The queued cancellation could not be durably recorded. Check the Keeper queue receipt in the Dashboard; internal storage detail is available to operators only."
+          | Some (Failed { kind = Transcript_persist_failed; _ }) ->
+            "The Keeper cancellation could not be durably recorded. Internal storage detail is available to operators only."
+          | Some (Failed _ | Delivered _ | Deferred _) | None ->
+            redact_text message
+        in
         publish_terminal ~status:(Request_stream Stream_cancelled) ~message ();
         Keeper_chat_events.publish events Text_message_end;
         Keeper_chat_events.publish events (Run_finished { run_id });
@@ -2270,7 +2261,17 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
         ; body = err
         ; queued_outcome
         } ->
-        let err = redact_text err in
+        let err =
+          match queued_outcome with
+          | Some (Failed { kind = Transcript_persist_failed; _ }) when queued_turn ->
+            "The queued response could not be durably recorded. Check the Keeper queue receipt in the Dashboard; internal storage detail is available to operators only."
+          | Some (Failed { kind = Transcript_persist_failed; _ }) ->
+            "The Keeper response could not be durably recorded. Internal storage detail is available to operators only."
+          | Some (Failed { kind = Stream_projection_failed; _ }) ->
+            "The queued response reached an internal projection failure. Check the Keeper queue receipt in the Dashboard."
+          | Some (Failed _ | Delivered _ | Deferred _) | None ->
+            redact_text err
+        in
         publish_terminal ~status:(Request_stream status) ~message:err ();
         Keeper_chat_events.publish events Text_message_end;
         Keeper_chat_events.publish events (Event_error { message = err });
@@ -2757,6 +2758,8 @@ module For_testing = struct
   let direct_reply_terminal_error = direct_reply_terminal_error
   let queued_delivery_outcome_of_turn_ref =
     queued_delivery_outcome_of_turn_ref
+  let delivery_outcome_after_persist = delivery_outcome_after_persist
+  let failure_outcome_after_persist = failure_outcome_after_persist
   let visible_reply_with_stream_fallback = visible_reply_with_stream_fallback
   let redacted_visible_reply_with_stream_fallback =
     redacted_visible_reply_with_stream_fallback

--- a/lib/server/server_routes_http_keeper_stream.mli
+++ b/lib/server/server_routes_http_keeper_stream.mli
@@ -271,6 +271,17 @@ module For_testing : sig
     ?has_visible_blocks:bool -> Yojson.Safe.t option -> string -> string option
   val queued_delivery_outcome_of_turn_ref :
     Ids.Turn_ref.t option -> queued_turn_outcome
+  val delivery_outcome_after_persist :
+    queued_turn:bool ->
+    turn_ref:Ids.Turn_ref.t option ->
+    (unit, string) result ->
+    queued_turn_outcome option
+  val failure_outcome_after_persist :
+    queued_turn:bool ->
+    failure_kind:queued_turn_failure_kind ->
+    detail:string ->
+    (unit, string) result ->
+    queued_turn_outcome option
   val visible_reply_with_stream_fallback :
     streamed_text:string -> string -> string
   val redacted_visible_reply_with_stream_fallback :

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -6,6 +6,8 @@ module Mcp_server = Mcp_server
 module Mcp_eio = Mcp_server_eio
 module Config_root_bootstrap = Server_runtime_config_root_bootstrap
 
+exception Keeper_chat_queue_bootstrap_failed of string
+
 let config_bootstrap_mode = Config_root_bootstrap.config_bootstrap_mode
 let bootstrap_base_path_config_root = Config_root_bootstrap.bootstrap_base_path_config_root
 let startup_config_resolution = Config_root_bootstrap.startup_config_resolution
@@ -1075,9 +1077,15 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       let state, path_diagnostics =
         init_state_blocking ()
       in
+      let workspace_config = Mcp_server.workspace_config state in
+      (match
+         Server_bootstrap_loops.prepare_keeper_chat_persistence ~workspace_config
+       with
+       | Ok () -> ()
+       | Error detail -> raise (Keeper_chat_queue_bootstrap_failed detail));
       server_state := Some state;
       Server_startup_state.mark_state_ready
-        ~backend_mode:(Workspace.backend_name (Mcp_server.workspace_config state));
+        ~backend_mode:(Workspace.backend_name workspace_config);
       let resolved_base, masc_dir =
         Server_bootstrap_loops.start_background_maintenance ~sw ~clock ~env state
       in

--- a/lib/server_keeper_waiting_inventory.ml
+++ b/lib/server_keeper_waiting_inventory.ml
@@ -305,12 +305,7 @@ let chat_queue_invariant_error_row keeper_name queue_index
 let chat_queue_load_error_row keeper_name
     (error : Keeper_chat_queue.snapshot_load_error) =
   let kind =
-    match error.kind with
-    | Keeper_chat_queue.Invalid_path -> "invalid_path"
-    | Keeper_chat_queue.Read_failed -> "read_failed"
-    | Keeper_chat_queue.Parse_failed -> "parse_failed"
-    | Keeper_chat_queue.Migration_failed -> "migration_failed"
-    | Keeper_chat_queue.Recovery_failed -> "recovery_failed"
+    Keeper_chat_queue.snapshot_load_error_kind_to_string error.kind
   in
   read_error_row ~keeper_name ~waiting_on:"chat_queue_snapshot"
     ~next_action:"repair_keeper_chat_queue_snapshot"

--- a/test/dune
+++ b/test/dune
@@ -2087,8 +2087,6 @@
 
 (include stanzas/test_keeper_chat_coalescing.inc)
 
-(include stanzas/test_fs_compat_durable_append.inc)
-
 (include stanzas/test_keeper_turn_admission.inc)
 
 (include stanzas/test_keeper_memory_bank_compaction_errors.inc)

--- a/test/dune
+++ b/test/dune
@@ -2087,6 +2087,8 @@
 
 (include stanzas/test_keeper_chat_coalescing.inc)
 
+(include stanzas/test_fs_compat_durable_append.inc)
+
 (include stanzas/test_keeper_turn_admission.inc)
 
 (include stanzas/test_keeper_memory_bank_compaction_errors.inc)

--- a/test/stanzas/test_keeper_fs.inc
+++ b/test/stanzas/test_keeper_fs.inc
@@ -1,4 +1,4 @@
 (test
  (name test_keeper_fs)
  (modules test_keeper_fs)
- (libraries masc alcotest yojson unix eio eio_main))
+ (libraries masc masc_core fs_compat alcotest yojson unix eio eio_main))

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -170,7 +170,7 @@ let test_keeper_chat_receipt_route_and_json () =
     (Server_dashboard_http_keeper_api.keeper_chat_receipt_route (path ^ "/extra"));
   let json =
     Server_dashboard_http_keeper_api.keeper_chat_receipt_json
-      ~keeper_name:"idealist" ~revision:7L
+      ~keeper_name:"idealist" ~revision:7L ~load_errors:[]
       { Keeper_chat_queue.receipt_id
       ; state =
           Keeper_chat_queue.Failed
@@ -191,10 +191,42 @@ let test_keeper_chat_receipt_route_and_json () =
      | _ -> "invalid");
   check string "receipt JSON failure kind" "delivery_failed"
     (json |> member "state" |> member "failure_kind" |> to_string);
+  check string "healthy receipt availability" "available"
+    (json |> member "availability" |> to_string);
   check bool "receipt JSON redacts failure detail" false
     (contains_substring
        (json |> member "state" |> member "detail" |> to_string)
-       "sk-proj-abcdefghijklmnopqrstuvwxyz")
+       "sk-proj-abcdefghijklmnopqrstuvwxyz");
+  let quarantined_json =
+    Server_dashboard_http_keeper_api.keeper_chat_receipt_json
+      ~keeper_name:"idealist"
+      ~revision:8L
+      ~load_errors:
+        [ { Keeper_chat_queue.kind = Keeper_chat_queue.Durability_uncertain
+          ; path = Some "/Users/operator/private/.masc/keepers/idealist/chat-queue.json"
+          ; message =
+              "save_file_atomic /Users/operator/private/.masc/keepers/idealist/chat-queue.json: EIO"
+          }
+        ]
+      { Keeper_chat_queue.receipt_id; state = Keeper_chat_queue.Pending }
+  in
+  let public_error =
+    quarantined_json
+    |> member "load_errors"
+    |> index 0
+    |> member "message"
+    |> to_string
+  in
+  check string "quarantined receipt availability" "quarantined"
+    (quarantined_json |> member "availability" |> to_string);
+  check string "quarantine error kind stays typed" "durability_uncertain"
+    (quarantined_json
+     |> member "load_errors"
+     |> index 0
+     |> member "kind"
+     |> to_string);
+  check bool "public quarantine error omits BasePath" false
+    (contains_substring public_error "/Users/operator/private")
 
 let with_test_env f =
   let dir = test_dir () in

--- a/test/test_discord_observability.ml
+++ b/test/test_discord_observability.ml
@@ -22,6 +22,8 @@ let test_label_contract () =
     (Obs.inbound_outcome_label Obs.Dispatch_unavailable);
   check string "ambient too_long" "dropped_too_long"
     (Obs.ambient_outcome_label Obs.Ambient_dropped_too_long);
+  check string "ambient persistence failure" "persistence_failed"
+    (Obs.ambient_outcome_label Obs.Ambient_persistence_failed);
   check string "reply failed" "send_error"
     (Obs.reply_outcome_label Obs.Reply_send_failed)
 

--- a/test/test_fs_compat.ml
+++ b/test/test_fs_compat.ml
@@ -104,6 +104,41 @@ let test_save_file_atomic_overwrites_existing () =
   check string "overwrite succeeded" "new" (Fs_compat.load_file target)
 ;;
 
+let test_save_file_atomic_detailed_types_temp_creation_failure () =
+  Fs_compat.clear_fs ();
+  with_tmp_dir
+  @@ fun base ->
+  let target = Filename.concat (Filename.concat base "missing") "out.json" in
+  match Fs_compat.save_file_atomic_detailed target "new" with
+  | Error { stage = Fs_compat.Not_renamed; _ } -> ()
+  | Error { stage = Fs_compat.Renamed_durability_uncertain; _ } ->
+    fail "temp-file creation failure was classified after rename"
+  | Ok () -> fail "atomic write unexpectedly created an absent parent"
+;;
+
+let test_probe_path_distinguishes_missing_from_stat_failure () =
+  Fs_compat.clear_fs ();
+  with_tmp_dir
+  @@ fun base ->
+  let missing = Filename.concat base "missing" in
+  (match Fs_compat.probe_path missing with
+   | Ok None -> ()
+   | Ok (Some _) -> fail "missing path was reported present"
+   | Error failure ->
+     fail
+       ("missing path produced an error: "
+        ^ Fs_compat.path_probe_failure_to_string failure));
+  let regular_parent = Filename.concat base "regular" in
+  Fs_compat.save_file regular_parent "not a directory";
+  match Fs_compat.probe_path (Filename.concat regular_parent "child") with
+  | Error { error = Unix.ENOTDIR; _ } -> ()
+  | Error failure ->
+    fail
+      ("unexpected path probe error: "
+       ^ Fs_compat.path_probe_failure_to_string failure)
+  | Ok _ -> fail "ENOTDIR was collapsed into path absence"
+;;
+
 let with_redirected_stderr (f : unit -> 'a) : 'a * string =
   let tmp = Filename.temp_file "masc_stderr_" ".log" in
   let saved = Unix.dup Unix.stderr in
@@ -323,6 +358,14 @@ let () =
             "overwrites existing target"
             `Quick
             test_save_file_atomic_overwrites_existing
+        ; test_case
+            "types temp-file creation before rename"
+            `Quick
+            test_save_file_atomic_detailed_types_temp_creation_failure
+        ; test_case
+            "probe distinguishes missing from stat failure"
+            `Quick
+            test_probe_path_distinguishes_missing_from_stat_failure
         ] )
     ; ( "load_jsonl_diagnostics"
       , [ test_case

--- a/test/test_fs_compat_durable_append.ml
+++ b/test/test_fs_compat_durable_append.ml
@@ -221,7 +221,109 @@ let with_temp_jsonl original f =
   let output = open_out_bin path in
   output_string output original;
   close_out output;
-  Fun.protect ~finally:(fun () -> Sys.remove path) (fun () -> f path)
+  Fun.protect
+    ~finally:(fun () ->
+      Sys.remove path;
+      let lock_path = path ^ ".lock" in
+      if Sys.file_exists lock_path then Sys.remove lock_path)
+    (fun () -> f path)
+;;
+
+let test_private_jsonl_first_creation_is_durable () =
+  let dir = Filename.temp_file "masc_private_jsonl_dir_" "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o700;
+  let path = Filename.concat dir "keeper.jsonl" in
+  Fun.protect
+    ~finally:(fun () ->
+      Sys.readdir dir
+      |> Array.iter (fun name -> Sys.remove (Filename.concat dir name));
+      Unix.rmdir dir)
+    (fun () ->
+      match
+        Fs_compat.append_private_jsonl_durable_locked_result
+          path
+          "{\"row\":1}\n"
+      with
+      | Error error -> fail (Fs_compat.private_jsonl_append_error_to_string error)
+      | Ok () ->
+        check string "new durable JSONL content" "{\"row\":1}\n"
+          (Fs_compat.load_file path);
+        check int "new durable JSONL mode" 0o600
+          ((Unix.stat path).Unix.st_perm land 0o777);
+        check bool "separate cross-process lock inode exists" true
+          (Sys.file_exists (path ^ ".lock")))
+;;
+
+let write_signal fd =
+  let byte = Bytes.make 1 'x' in
+  ignore (Unix.single_write fd byte 0 1 : int)
+;;
+
+let read_signal fd =
+  let byte = Bytes.create 1 in
+  match Unix.read fd byte 0 1 with
+  | 1 -> ()
+  | count -> failf "expected one synchronization byte, got %d" count
+;;
+
+let test_transcript_read_close_does_not_release_writer_lock () =
+  with_temp_jsonl "{\"row\":0}\n" @@ fun path ->
+  let ready_read, ready_write = Unix.pipe ~cloexec:true () in
+  let release_read, release_write = Unix.pipe ~cloexec:true () in
+  let holder_pid =
+    match Unix.fork () with
+    | 0 ->
+      Unix.close ready_read;
+      Unix.close release_write;
+      let result =
+        Fs_compat.update_private_file_durable_locked_result path (fun _existing ->
+          write_signal ready_write;
+          read_signal release_read;
+          None, ())
+      in
+      (match result with Ok () -> exit 0 | Error _ -> exit 2)
+    | pid -> pid
+  in
+  Unix.close ready_write;
+  Unix.close release_read;
+  read_signal ready_read;
+  let read_fd = Unix.openfile path [ Unix.O_RDONLY; Unix.O_CLOEXEC ] 0 in
+  Unix.close read_fd;
+  let acquired_read, acquired_write = Unix.pipe ~cloexec:true () in
+  let contender_pid =
+    match Unix.fork () with
+    | 0 ->
+      Unix.close acquired_read;
+      let result =
+        Fs_compat.append_private_jsonl_durable_locked_result
+          path
+          "{\"row\":1}\n"
+      in
+      (match result with
+       | Ok () ->
+         write_signal acquired_write;
+         exit 0
+       | Error _ -> exit 3)
+    | pid -> pid
+  in
+  Unix.close acquired_write;
+  let readable_before_release, _, _ = Unix.select [ acquired_read ] [] [] 0.05 in
+  write_signal release_write;
+  let readable_after_release, _, _ = Unix.select [ acquired_read ] [] [] 2.0 in
+  if readable_after_release = [] then Unix.kill contender_pid Sys.sigkill
+  else read_signal acquired_read;
+  Unix.close ready_read;
+  Unix.close release_write;
+  Unix.close acquired_read;
+  let _, holder_status = Unix.waitpid [] holder_pid in
+  let _, contender_status = Unix.waitpid [] contender_pid in
+  check int "read-close does not release the writer lock" 0
+    (List.length readable_before_release);
+  check int "contender acquires after writer release" 1
+    (List.length readable_after_release);
+  check bool "holder exits cleanly" true (holder_status = Unix.WEXITED 0);
+  check bool "contender exits cleanly" true (contender_status = Unix.WEXITED 0)
 ;;
 
 let test_private_jsonl_append_preserves_complete_history () =
@@ -287,6 +389,14 @@ let () =
             "private JSONL append preserves complete history"
             `Quick
             test_private_jsonl_append_preserves_complete_history
+        ; test_case
+            "private JSONL first creation is durable"
+            `Quick
+            test_private_jsonl_first_creation_is_durable
+        ; test_case
+            "transcript reads preserve cross-process writer lock"
+            `Quick
+            test_transcript_read_close_does_not_release_writer_lock
         ; test_case
             "private JSONL append rejects incomplete tail"
             `Quick

--- a/test/test_fs_compat_durable_append.ml
+++ b/test/test_fs_compat_durable_append.ml
@@ -290,40 +290,34 @@ let test_transcript_read_close_does_not_release_writer_lock () =
   read_signal ready_read;
   let read_fd = Unix.openfile path [ Unix.O_RDONLY; Unix.O_CLOEXEC ] 0 in
   Unix.close read_fd;
-  let acquired_read, acquired_write = Unix.pipe ~cloexec:true () in
-  let contender_pid =
-    match Unix.fork () with
-    | 0 ->
-      Unix.close acquired_read;
-      let result =
-        Fs_compat.append_private_jsonl_durable_locked_result
-          path
-          "{\"row\":1}\n"
-      in
-      (match result with
-       | Ok () ->
-         write_signal acquired_write;
-         exit 0
-       | Error _ -> exit 3)
-    | pid -> pid
+  let contender_fd =
+    Unix.openfile (path ^ ".lock") [ Unix.O_RDWR; Unix.O_CLOEXEC ] 0
   in
-  Unix.close acquired_write;
-  let readable_before_release, _, _ = Unix.select [ acquired_read ] [] [] 0.05 in
+  let try_lock () =
+    ignore (Unix.lseek contender_fd 0 Unix.SEEK_SET : int);
+    match Unix.lockf contender_fd Unix.F_TLOCK 0 with
+    | () -> `Acquired
+    | exception Unix.Unix_error ((Unix.EACCES | Unix.EAGAIN), _, _) ->
+      `Contended
+  in
+  let before_release = try_lock () in
+  (match before_release with
+   | `Acquired -> Unix.lockf contender_fd Unix.F_ULOCK 0
+   | `Contended -> ());
   write_signal release_write;
-  let readable_after_release, _, _ = Unix.select [ acquired_read ] [] [] 2.0 in
-  if readable_after_release = [] then Unix.kill contender_pid Sys.sigkill
-  else read_signal acquired_read;
   Unix.close ready_read;
   Unix.close release_write;
-  Unix.close acquired_read;
   let _, holder_status = Unix.waitpid [] holder_pid in
-  let _, contender_status = Unix.waitpid [] contender_pid in
-  check int "read-close does not release the writer lock" 0
-    (List.length readable_before_release);
-  check int "contender acquires after writer release" 1
-    (List.length readable_after_release);
-  check bool "holder exits cleanly" true (holder_status = Unix.WEXITED 0);
-  check bool "contender exits cleanly" true (contender_status = Unix.WEXITED 0)
+  let after_release = try_lock () in
+  (match after_release with
+   | `Acquired -> Unix.lockf contender_fd Unix.F_ULOCK 0
+   | `Contended -> ());
+  Unix.close contender_fd;
+  check bool "read-close does not release the writer lock" true
+    (before_release = `Contended);
+  check bool "contender acquires after writer release" true
+    (after_release = `Acquired);
+  check bool "holder exits cleanly" true (holder_status = Unix.WEXITED 0)
 ;;
 
 let test_private_jsonl_append_preserves_complete_history () =

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -158,10 +158,13 @@ let test_persist_connector_assistant_reply_records_lane_reply () =
         ~content:"<@bot> factorio?"
         ~surface
         ~conversation_id:"discord:guild-1:channel:chan-9" ();
-      Gate_keeper_backend.persist_connector_assistant_reply ~base_dir
-        ~keeper_name ~source:"discord" ~surface
-        ~conversation_id:"discord:guild-1:channel:chan-9"
-        ~reply:"already answered" ();
+      ignore
+        (Gate_keeper_backend.persist_connector_assistant_reply ~base_dir
+           ~keeper_name ~source:"discord" ~surface
+           ~conversation_id:"discord:guild-1:channel:chan-9"
+           ~reply:"already answered" ()
+         |> Result.get_ok
+          : unit);
       match K.load ~base_dir ~keeper_name with
       | [ user; assistant ] ->
           check string "user line first" "user" (K.Role.to_label user.K.role);
@@ -185,8 +188,11 @@ let test_persist_connector_assistant_reply_ignores_empty_reply () =
     ~finally:(fun () -> try remove_tree base_dir with _ -> ())
     (fun () ->
       let keeper_name = "discord-empty-reply-keeper" in
-      Gate_keeper_backend.persist_connector_assistant_reply ~base_dir
-        ~keeper_name ~source:"discord" ~reply:"   " ();
+      ignore
+        (Gate_keeper_backend.persist_connector_assistant_reply ~base_dir
+           ~keeper_name ~source:"discord" ~reply:"   " ()
+         |> Result.get_ok
+          : unit);
       check int "empty reply does not create chat file" 0
         (List.length (K.load ~base_dir ~keeper_name)))
 

--- a/test/test_keeper_busy_dashboard_deferred.ml
+++ b/test/test_keeper_busy_dashboard_deferred.ml
@@ -56,9 +56,12 @@ let with_env body =
       ignore (Workspace.init config ~agent_name:(Some keeper_name));
       Keeper_turn_admission.For_testing.reset ();
       Keeper_chat_queue.For_testing.reset ();
-      let report = Keeper_chat_queue.configure_persistence ~base_path:base in
-      check "chat queue persistence configured without load errors"
-        (report.load_errors = []);
+      check "startup queue configuration succeeds before consumers"
+        (Result.is_ok
+           (Server_bootstrap_loops.prepare_keeper_chat_persistence
+              ~workspace_config:config));
+      check "startup queue owns the server BasePath"
+        (Keeper_chat_queue.persistence_matches_base_path ~base_path:base);
       Eio.Switch.run (fun sw ->
         Eio.Switch.on_release sw Keeper_chat_queue.For_testing.reset;
         body ~base ~clock))
@@ -98,6 +101,38 @@ let with_busy_slots ~base ~sw keeper_names f =
     ~finally:(fun () ->
       List.iter (fun (_, set_release) -> Eio.Promise.resolve set_release ()) slots)
     f
+;;
+
+let test_registry_discovery_failure_blocks_readiness () =
+  Printf.printf "Test: queue registry discovery failure blocks readiness\n%!";
+  let base =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf
+         "masc-chat-registry-failure-%d-%d"
+         (Unix.getpid ())
+         (int_of_float (Unix.gettimeofday () *. 1_000_000.)))
+  in
+  Unix.mkdir base 0o755;
+  Fun.protect
+    ~finally:(fun () -> Fs_compat.remove_tree base)
+    (fun () ->
+      let keepers_dir = Common.keepers_runtime_dir_of_base ~base_path:base in
+      Fs_compat.mkdir_p (Filename.dirname keepers_dir);
+      let output = open_out_bin keepers_dir in
+      output_string output "not a directory";
+      close_out output;
+      Eio_main.run
+      @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      Keeper_chat_queue.For_testing.reset ();
+      let result =
+        Server_bootstrap_loops.prepare_keeper_chat_persistence
+          ~workspace_config:(Workspace.default_config base)
+      in
+      check "registry discovery error rejects startup readiness"
+        (Result.is_error result);
+      Keeper_chat_queue.For_testing.reset ())
 ;;
 
 let test_busy_dashboard_enqueues () =
@@ -287,6 +322,39 @@ let test_stream_headers_close_per_turn_response () =
     (Httpun.Headers.get headers "connection" = Some "close")
 ;;
 
+let test_direct_transcript_failure_is_terminal () =
+  Printf.printf "Test: direct transcript failure is a terminal outcome\n%!";
+  let outcome =
+    Server_routes_http_keeper_stream.For_testing.delivery_outcome_after_persist
+      ~queued_turn:false ~turn_ref:None (Error "disk unavailable")
+  in
+  check "direct persistence failure is not reported as success"
+    (match outcome with
+     | Some (Server_routes_http_keeper_stream.Failed failure) ->
+       failure.kind = Server_routes_http_keeper_stream.Transcript_persist_failed
+       && String.equal failure.detail "disk unavailable"
+     | Some
+         (Server_routes_http_keeper_stream.Delivered _
+         | Server_routes_http_keeper_stream.Deferred _)
+     | None -> false);
+  let timeout_outcome =
+    Server_routes_http_keeper_stream.For_testing.failure_outcome_after_persist
+      ~queued_turn:false
+      ~failure_kind:Server_routes_http_keeper_stream.Turn_timed_out
+      ~detail:"request timed out"
+      (Error "disk unavailable")
+  in
+  check "direct timeout persistence failure is not discarded"
+    (match timeout_outcome with
+     | Some (Server_routes_http_keeper_stream.Failed failure) ->
+       failure.kind = Server_routes_http_keeper_stream.Transcript_persist_failed
+       && String.equal failure.detail "disk unavailable"
+     | Some
+         (Server_routes_http_keeper_stream.Delivered _
+         | Server_routes_http_keeper_stream.Deferred _)
+     | None -> false)
+;;
+
 let test_shutdown_fenced_dashboard_ack_preserves_cause () =
   Printf.printf
     "Test: shutdown-fenced dashboard ACK preserves operation cause\n%!";
@@ -367,12 +435,14 @@ let test_stream_surface_preserves_typed_shutdown_rejection () =
 ;;
 
 let () =
+  test_registry_discovery_failure_blocks_readiness ();
   test_busy_dashboard_enqueues ();
   test_free_dashboard_not_enqueued ();
   test_existing_backlog_defers_new_dashboard_message ();
   test_concurrent_busy_dashboard_enqueues_are_per_keeper ();
   test_busy_dashboard_persist_failure_is_explicit ();
   test_stream_headers_close_per_turn_response ();
+  test_direct_transcript_failure_is_terminal ();
   test_shutdown_fenced_dashboard_ack_preserves_cause ();
   test_stream_surface_preserves_typed_shutdown_rejection ();
   if !failures > 0

--- a/test/test_keeper_chat_coalescing.ml
+++ b/test/test_keeper_chat_coalescing.ml
@@ -160,7 +160,7 @@ let test_durable_receipt_lifecycle () =
      Keeper_chat_queue.lookup_receipt ~keeper_name
        ~receipt_id:enqueued.receipt_id
    with
-   | Ok { revision; receipt = Some { state = Delivered _; _ } } ->
+   | Ok { revision; receipt = Some { state = Delivered _; _ }; _ } ->
      check "receipt lookup returns terminal state" true;
      check "receipt lookup returns its atomic snapshot revision"
        (Int64.equal revision terminal.revision)
@@ -333,6 +333,53 @@ let test_persist_failures_roll_back () =
     "failed nack leaves original lease inflight"
     ((Keeper_chat_queue.snapshot ~keeper_name).inflight <> [])
 
+let test_post_rename_uncertainty_keeps_receipt_and_isolates_keeper () =
+  Printf.printf
+    "Test: post-rename durability uncertainty keeps the accepted receipt and isolates one Keeper\n%!";
+  with_base "keeper-chat-post-rename" @@ fun base_path ->
+  let keeper_name = "uncertain" in
+  let healthy_keeper = "healthy" in
+  ignore (configure base_path : Keeper_chat_queue.configure_report);
+  Keeper_chat_queue.For_testing.fail_next_persist_after_rename ();
+  let accepted =
+    match Keeper_chat_queue.enqueue ~keeper_name (message "accepted once") with
+    | Ok ({ durability = Durability_uncertain _; _ } as receipt) ->
+      check "uncertain enqueue returns its committed receipt" true;
+      receipt
+    | Ok _ | Error _ ->
+      check "uncertain enqueue returns its committed receipt" false;
+      failwith "missing uncertain receipt"
+  in
+  let accepted_id =
+    Keeper_chat_queue.Receipt_id.to_string accepted.receipt_id
+  in
+  let snapshot = Keeper_chat_queue.snapshot ~keeper_name in
+  check "uncertain commit keeps the new revision" (snapshot.revision = accepted.revision);
+  check "uncertain commit keeps the receipt in memory"
+    (active_ids snapshot.pending = [ accepted_id ]);
+  check "uncertain commit quarantines only its Keeper" (snapshot.load_errors <> []);
+  (match
+     Keeper_chat_queue.lookup_receipt
+       ~keeper_name
+       ~receipt_id:accepted.receipt_id
+   with
+   | Ok { receipt = Some { state = Pending; _ }; load_errors = _ :: _; _ } ->
+     check "quarantine keeps the accepted receipt observable" true
+   | Ok _ | Error _ ->
+     check "quarantine keeps the accepted receipt observable" false);
+  let persisted = Fs_compat.load_file (snapshot_path ~base_path ~keeper_name) in
+  check "uncertain commit keeps the receipt in the renamed snapshot"
+    (String_util.contains_substring persisted accepted_id);
+  (match Keeper_chat_queue.enqueue ~keeper_name (message "must not retry") with
+   | Error (Snapshot_unavailable { kind = Durability_uncertain; _ }) ->
+     check "later mutation is rejected by the Keeper quarantine" true
+   | Ok _ | Error _ ->
+     check "later mutation is rejected by the Keeper quarantine" false);
+  (match Keeper_chat_queue.enqueue ~keeper_name:healthy_keeper (message "independent") with
+   | Ok { durability = Durable; _ } ->
+     check "another Keeper remains writable" true
+   | Ok _ | Error _ -> check "another Keeper remains writable" false)
+
 let v1_message_json ?(source = `Assoc [ "kind", `String "dashboard" ]) content =
   `Assoc
     [ "content", `String content
@@ -405,6 +452,43 @@ let test_v1_atomic_migration () =
        (Json_util.get_string json "schema" = Some "keeper_chat_queue.v2")
    | Error _ -> check "migrated snapshot is readable" false)
 
+let test_v1_post_rename_uncertainty_preserves_migrated_receipts () =
+  Printf.printf
+    "Test: uncertain v1 migration preserves visible receipts under quarantine\n%!";
+  with_base "keeper-chat-v1-uncertain" @@ fun base_path ->
+  let keeper_name = "v1-uncertain" in
+  let path = snapshot_path ~base_path ~keeper_name in
+  let v1 =
+    `Assoc
+      [ "schema", `String "keeper_chat_queue.v1"
+      ; "items", `List [ v1_message_json "legacy accepted" ]
+      ; "inflight", `Null
+      ]
+  in
+  save_raw path (Yojson.Safe.pretty_to_string v1);
+  Keeper_chat_queue.For_testing.fail_next_persist_after_rename ();
+  let report = Keeper_chat_queue.configure_persistence ~base_path in
+  check "uncertain migration is still counted" (report.migrated_keeper_count = 1);
+  check "uncertain migration reports its quarantine" (report.load_errors <> []);
+  let snapshot = Keeper_chat_queue.snapshot ~keeper_name in
+  check "uncertain migration keeps its visible receipt" (List.length snapshot.pending = 1);
+  (match snapshot.pending with
+   | [ receipt ] ->
+     (match
+        Keeper_chat_queue.lookup_receipt
+          ~keeper_name
+          ~receipt_id:receipt.receipt_id
+      with
+      | Ok { receipt = Some { state = Pending; _ }; load_errors = _ :: _; _ } ->
+        check "migrated receipt remains queryable" true
+      | Ok _ | Error _ -> check "migrated receipt remains queryable" false)
+   | _ -> check "migrated receipt remains queryable" false);
+  (match Keeper_chat_queue.enqueue ~keeper_name (message "must wait for recovery") with
+   | Error (Snapshot_unavailable { kind = Durability_uncertain; _ }) ->
+     check "uncertain migrated queue rejects further mutation" true
+   | Ok _ | Error _ ->
+     check "uncertain migrated queue rejects further mutation" false)
+
 let test_corrupt_snapshot_is_quarantined () =
   Printf.printf "Test: corrupt snapshot is explicit and never overwritten as empty\n%!";
   with_base "keeper-chat-corrupt" @@ fun base_path ->
@@ -431,7 +515,7 @@ let test_corrupt_snapshot_is_quarantined () =
     | Error error -> failwith error
   in
   (match Keeper_chat_queue.lookup_receipt ~keeper_name ~receipt_id:unknown_id with
-   | Error (Snapshot_unavailable _) ->
+   | Ok { receipt = None; load_errors = _ :: _; _ } ->
      check "receipt lookup does not collapse unreadable into absent" true
    | Ok _ | Error _ ->
      check "receipt lookup does not collapse unreadable into absent" false);
@@ -751,7 +835,9 @@ let () =
   test_source_boundaries_preserve_fifo_runs ();
   test_nack_and_restart_preserve_receipt ();
   test_persist_failures_roll_back ();
+  test_post_rename_uncertainty_keeps_receipt_and_isolates_keeper ();
   test_v1_atomic_migration ();
+  test_v1_post_rename_uncertainty_preserves_migrated_receipts ();
   test_corrupt_snapshot_is_quarantined ();
   test_invalid_v2_is_not_a_compatibility_fallback ();
   test_invalid_v2_attachment_is_not_silently_dropped ();

--- a/test/test_keeper_chat_delivery_journal.ml
+++ b/test/test_keeper_chat_delivery_journal.ml
@@ -38,7 +38,9 @@ let direct_key () =
 
 let chat_path base_path keeper_name =
   Filename.concat
-    (Filename.concat (Filename.concat base_path ".masc") "keeper_chat")
+    (Filename.concat
+       (Common.masc_dir_from_base_path ~base_path)
+       "keeper_chat")
     (keeper_name ^ ".jsonl")
 ;;
 
@@ -182,6 +184,68 @@ let test_stale_revision_and_phase_fail_closed () =
     | Ok _ -> fail "terminal result skipped the Running phase")
 ;;
 
+let test_post_rename_uncertainty_preserves_visible_journal_and_quarantines_key () =
+  with_temp_dir (fun base_path ->
+    let key = direct_key () in
+    let prepared =
+      Journal.prepare
+        ~base_path
+        ~delivery_key:key
+        ~payload:(payload ())
+        ~now:1.0
+      |> expect_ok
+    in
+    Journal.For_testing.fail_next_save_after_rename ();
+    let committed =
+      match
+        Journal.mark_accepted
+          ~base_path
+          ~expected_revision:prepared.revision
+          ~identity:prepared
+          ~user_row_id:(Some "msg-user")
+          ~now:2.0
+      with
+      | Error (Journal.Commit_durability_uncertain { committed; _ }) ->
+        committed
+      | Error error -> fail (Journal.error_to_string error)
+      | Ok _ -> fail "post-rename uncertainty was reported as durable"
+    in
+    check int "uncertain journal keeps committed revision" 1 committed.revision;
+    (match committed.phase with
+     | Journal.Accepted { user_row_id = Some "msg-user" } -> ()
+     | phase ->
+       failf
+         "uncertain journal lost committed phase: %s"
+         (Journal.phase_to_string phase));
+    let visible =
+      Journal.load ~base_path ~keeper_name:"sangsu" key |> expect_ok
+    in
+    check int "renamed journal remains observable" 1 visible.revision;
+    (match
+       Journal.mark_accepted
+         ~base_path
+         ~expected_revision:prepared.revision
+         ~identity:prepared
+         ~user_row_id:(Some "msg-user")
+         ~now:3.0
+     with
+     | Error (Journal.Commit_durability_uncertain { committed; _ }) ->
+       check int "stale retry is stopped by typed quarantine" 1 committed.revision
+     | Error error -> fail (Journal.error_to_string error)
+     | Ok _ -> fail "quarantined journal accepted another transition");
+    let independent_payload =
+      { (payload ()) with keeper_name = "albini" }
+    in
+    ignore
+      (Journal.prepare
+         ~base_path
+         ~delivery_key:key
+         ~payload:independent_payload
+         ~now:4.0
+       |> expect_ok
+        : Journal.t))
+;;
+
 let test_corrupt_record_is_explicit () =
   with_temp_dir (fun base_path ->
     let key = direct_key () in
@@ -299,6 +363,88 @@ let test_chat_append_once_converges () =
       (row_id terminal_second);
     let history = Keeper_chat_store.load ~base_dir:base_path ~keeper_name:"sangsu" in
     check int "one user and one terminal row" 2 (List.length history))
+;;
+
+let test_chat_append_once_converges_across_processes () =
+  with_temp_dir (fun base_path ->
+    let delivery_key = direct_key () in
+    Keeper_chat_store.append_assistant_message_result
+      ~base_dir:base_path
+      ~keeper_name:"sangsu"
+      ~content:"seed"
+      ()
+    |> Result.get_ok;
+    let ready_read, ready_write = Unix.pipe () in
+    let append_child () =
+      Unix.close ready_write;
+      let byte = Bytes.create 1 in
+      let rec await_start () =
+        match Unix.read ready_read byte 0 1 with
+        | 1 -> ()
+        | 0 -> exit 2
+        | _ -> await_start ()
+        | exception Unix.Unix_error (Unix.EINTR, _, _) -> await_start ()
+      in
+      await_start ();
+      let result =
+        Keeper_chat_store.append_user_message_once
+          ~base_dir:base_path
+          ~keeper_name:"sangsu"
+          ~delivery_key
+          ~content:"cross-process request"
+          ~surface:
+            (Surface_ref.Dashboard { session_id = Some "dashboard-session" })
+          ~speaker:(payload ()).speaker
+          ()
+      in
+      Unix.close ready_read;
+      exit (if Result.is_ok result then 0 else 3)
+    in
+    let spawn () =
+      match Unix.fork () with
+      | 0 -> append_child ()
+      | pid -> pid
+    in
+    let first = spawn () in
+    let second = spawn () in
+    Unix.close ready_read;
+    let rec release_children offset =
+      if offset = 2
+      then ()
+      else
+        match Unix.write_substring ready_write "xy" offset (2 - offset) with
+        | 0 -> fail "cross-process start barrier made no write progress"
+        | written -> release_children (offset + written)
+        | exception Unix.Unix_error (Unix.EINTR, _, _) ->
+          release_children offset
+    in
+    release_children 0;
+    Unix.close ready_write;
+    let await_child pid =
+      match Unix.waitpid [] pid with
+      | _, Unix.WEXITED 0 -> ()
+      | _, status ->
+        failf
+          "cross-process append child failed: %s"
+          (match status with
+           | Unix.WEXITED code -> Printf.sprintf "exit %d" code
+           | Unix.WSIGNALED signal -> Printf.sprintf "signal %d" signal
+           | Unix.WSTOPPED signal -> Printf.sprintf "stopped %d" signal)
+    in
+    await_child first;
+    await_child second;
+    let matching_rows =
+      Keeper_chat_store.load ~base_dir:base_path ~keeper_name:"sangsu"
+      |> List.filter (fun (row : Keeper_chat_store.chat_message) ->
+           Keeper_chat_store.Role.equal
+             row.role
+             Keeper_chat_store.Role.User
+           && String.equal row.content "cross-process request")
+    in
+    check int
+      "cross-process retries persist one provenance row"
+      1
+      (List.length matching_rows))
 ;;
 
 let test_chat_append_once_rejects_incomplete_tail () =
@@ -625,6 +771,10 @@ let () =
             `Quick
             test_stale_revision_and_phase_fail_closed
         ; test_case
+            "post-rename uncertainty preserves and quarantines"
+            `Quick
+            test_post_rename_uncertainty_preserves_visible_journal_and_quarantines_key
+        ; test_case
             "corrupt records are explicit"
             `Quick
             test_corrupt_record_is_explicit
@@ -636,6 +786,10 @@ let () =
             "chat append-once converges"
             `Quick
             test_chat_append_once_converges
+        ; test_case
+            "chat append-once converges across processes"
+            `Quick
+            test_chat_append_once_converges_across_processes
         ; test_case
             "chat append-once rejects incomplete tail"
             `Quick

--- a/test/test_keeper_chat_delivery_journal.ml
+++ b/test/test_keeper_chat_delivery_journal.ml
@@ -36,6 +36,12 @@ let direct_key () =
   | Error error -> fail error
 ;;
 
+let chat_path base_path keeper_name =
+  Filename.concat
+    (Filename.concat (Filename.concat base_path ".masc") "keeper_chat")
+    (keeper_name ^ ".jsonl")
+;;
+
 let payload () : Journal.accepted_payload =
   { keeper_name = "sangsu"
   ; submitted_by = "owner"
@@ -195,10 +201,18 @@ let test_corrupt_record_is_explicit () =
       |> expect_ok
     in
     Fs_compat.save_file record_path "not-json";
-    match Journal.load ~base_path ~keeper_name:"sangsu" key with
-    | Error (Journal.Decode_error _) -> ()
-    | Error error -> fail (Journal.error_to_string error)
-    | Ok _ -> fail "corrupt journal was treated as readable")
+    (match Journal.load ~base_path ~keeper_name:"sangsu" key with
+     | Error (Journal.Decode_error _) -> ()
+     | Error error -> fail (Journal.error_to_string error)
+     | Ok _ -> fail "corrupt journal was treated as readable");
+    Keeper_chat_queue.For_testing.reset ();
+    let startup =
+      Server_bootstrap_loops.prepare_keeper_chat_persistence
+        ~workspace_config:(Masc.Workspace.default_config base_path)
+    in
+    check bool "corrupt delivery journal blocks readiness" true
+      (Result.is_error startup);
+    Keeper_chat_queue.For_testing.reset ())
 ;;
 
 let test_journal_rejects_unknown_and_duplicate_fields () =
@@ -287,88 +301,34 @@ let test_chat_append_once_converges () =
     check int "one user and one terminal row" 2 (List.length history))
 ;;
 
-let test_chat_append_once_converges_across_processes () =
+let test_chat_append_once_rejects_incomplete_tail () =
   with_temp_dir (fun base_path ->
-    let delivery_key = direct_key () in
-    let seed =
-      Keeper_chat_store.append_assistant_message_result
+    let keeper_name = "sangsu" in
+    Keeper_chat_store.append_assistant_message_result
+      ~base_dir:base_path
+      ~keeper_name
+      ~content:"initial"
+      ()
+    |> Result.get_ok;
+    let path = chat_path base_path keeper_name in
+    let incomplete = "{\"role\":\"assistant\"}" in
+    let output = open_out_bin path in
+    output_string output incomplete;
+    close_out output;
+    let result =
+      Keeper_chat_store.append_user_message_once
         ~base_dir:base_path
-        ~keeper_name:"sangsu"
-        ~content:"seed"
+        ~keeper_name
+        ~delivery_key:(direct_key ())
+        ~content:"must not append"
         ()
     in
-    (match seed with
-     | Ok () -> ()
-     | Error detail -> fail detail);
-    let ready_read, ready_write = Unix.pipe () in
-    let append_child () =
-      Unix.close ready_write;
-      let byte = Bytes.create 1 in
-      let rec await_start () =
-        match Unix.read ready_read byte 0 1 with
-        | 1 -> ()
-        | 0 -> exit 2
-        | _ -> await_start ()
-        | exception Unix.Unix_error (Unix.EINTR, _, _) -> await_start ()
-      in
-      await_start ();
-      let result =
-        Keeper_chat_store.append_user_message_once
-          ~base_dir:base_path
-          ~keeper_name:"sangsu"
-          ~delivery_key
-          ~content:"cross-process request"
-          ~surface:
-            (Surface_ref.Dashboard { session_id = Some "dashboard-session" })
-          ~speaker:(payload ()).speaker
-          ()
-      in
-      Unix.close ready_read;
-      exit (if Result.is_ok result then 0 else 3)
-    in
-    let spawn () =
-      match Unix.fork () with
-      | 0 -> append_child ()
-      | pid -> pid
-    in
-    let first = spawn () in
-    let second = spawn () in
-    Unix.close ready_read;
-    let rec release_children offset =
-      if offset = 2
-      then ()
-      else
-        match Unix.write_substring ready_write "xy" offset (2 - offset) with
-        | 0 -> fail "cross-process start barrier made no write progress"
-        | written -> release_children (offset + written)
-        | exception Unix.Unix_error (Unix.EINTR, _, _) ->
-          release_children offset
-    in
-    release_children 0;
-    Unix.close ready_write;
-    let await_child pid =
-      match Unix.waitpid [] pid with
-      | _, Unix.WEXITED 0 -> ()
-      | _, status ->
-        failf
-          "cross-process append child failed: %s"
-          (match status with
-           | Unix.WEXITED code -> Printf.sprintf "exit %d" code
-           | Unix.WSIGNALED signal -> Printf.sprintf "signal %d" signal
-           | Unix.WSTOPPED signal -> Printf.sprintf "stopped %d" signal)
-    in
-    await_child first;
-    await_child second;
-    let matching_rows =
-      Keeper_chat_store.load ~base_dir:base_path ~keeper_name:"sangsu"
-      |> List.filter (fun row ->
-           Keeper_chat_store.Role.equal row.role Keeper_chat_store.Role.User
-           && String.equal row.content "cross-process request")
-    in
-    check int
-      "cross-process retries persist one provenance row"
-      1
-      (List.length matching_rows))
+    check bool "append-once fails closed on an incomplete tail" true
+      (Result.is_error result);
+    let input = open_in_bin path in
+    let persisted = really_input_string input (in_channel_length input) in
+    close_in input;
+    check string "append-once leaves incomplete bytes untouched" incomplete persisted)
 ;;
 
 let test_restart_recovery_converges_without_duplicate_rows () =
@@ -517,10 +477,12 @@ let test_queue_restart_finalizes_receipt_without_redispatch () =
        |> expect_ok
         : Journal.t);
     Keeper_chat_queue.For_testing.reset ();
-    let recovery = Journal.recover_all ~base_path ~now:3.0 in
-    check int "queue journal recovered" 1 recovery.recovered;
-    let queue_recovery = Keeper_chat_queue.configure_persistence ~base_path in
-    check int "one inflight receipt reconciled" 1 queue_recovery.recovered_receipt_count;
+    let startup_recovery =
+      Server_bootstrap_loops.prepare_keeper_chat_persistence
+        ~workspace_config:(Masc.Workspace.default_config base_path)
+    in
+    check bool "startup journal-before-queue recovery succeeds" true
+      (Result.is_ok startup_recovery);
     (match
        Keeper_chat_queue.lookup_receipt
          ~keeper_name:"sangsu"
@@ -675,9 +637,9 @@ let () =
             `Quick
             test_chat_append_once_converges
         ; test_case
-            "chat append-once converges across processes"
+            "chat append-once rejects incomplete tail"
             `Quick
-            test_chat_append_once_converges_across_processes
+            test_chat_append_once_rejects_incomplete_tail
         ; test_case
             "restart recovery converges"
             `Quick

--- a/test/test_keeper_chat_store_append_result.ml
+++ b/test/test_keeper_chat_store_append_result.ml
@@ -24,9 +24,11 @@ let rec remove_tree path =
 
 let keeper_name = "chat-store-append-keeper"
 
-let chat_path base_dir =
+let persisted_path base_dir =
   Filename.concat
-    (Filename.concat (Filename.concat base_dir ".masc") "keeper_chat")
+    (Filename.concat
+       (Common.masc_dir_from_base_path ~base_path:base_dir)
+       "keeper_chat")
     (keeper_name ^ ".jsonl")
 
 let test_ok_on_writable_dir () =
@@ -43,7 +45,12 @@ let test_ok_on_writable_dir () =
       Alcotest.(check int)
         "chat transcript is private"
         0o600
-        ((Unix.stat (chat_path base_dir)).Unix.st_perm land 0o777))
+        ((Unix.stat (persisted_path base_dir)).Unix.st_perm land 0o777);
+      match S.load ~base_dir ~keeper_name with
+      | [ row ] ->
+        Alcotest.(check string) "durable row is readable" "hello" row.content
+      | rows ->
+        Alcotest.failf "expected one readable row, got %d" (List.length rows))
 
 (* base_dir nested under a regular file: directory creation / file open fails
    (ENOTDIR), so the write raises and must surface as [Error]. *)
@@ -73,7 +80,7 @@ let test_incomplete_tail_fails_closed_without_rewrite () =
           ~content:"initial" ()
       in
       Alcotest.(check bool) "initial append succeeds" true (Result.is_ok initial);
-      let path = chat_path base_dir in
+      let path = persisted_path base_dir in
       let corrupt = "{\"role\":\"assistant\"}" in
       let output = open_out_bin path in
       output_string output corrupt;

--- a/test/test_keeper_chat_store_append_result.ml
+++ b/test/test_keeper_chat_store_append_result.ml
@@ -6,6 +6,7 @@
    callers. *)
 
 module S = Masc.Keeper_chat_store
+module Identity = Masc.Keeper_chat_delivery_identity
 
 let temp_base_path prefix =
   Filename.concat
@@ -23,11 +24,9 @@ let rec remove_tree path =
 
 let keeper_name = "chat-store-append-keeper"
 
-let persisted_path base_dir =
+let chat_path base_dir =
   Filename.concat
-    (Filename.concat
-       (Common.masc_dir_from_base_path ~base_path:base_dir)
-       "keeper_chat")
+    (Filename.concat (Filename.concat base_dir ".masc") "keeper_chat")
     (keeper_name ^ ".jsonl")
 
 let test_ok_on_writable_dir () =
@@ -40,7 +39,11 @@ let test_ok_on_writable_dir () =
           ~content:"hello" ()
       in
       Alcotest.(check bool)
-        "append to a writable temp dir is Ok" true (Result.is_ok result))
+        "append to a writable temp dir is Ok" true (Result.is_ok result);
+      Alcotest.(check int)
+        "chat transcript is private"
+        0o600
+        ((Unix.stat (chat_path base_dir)).Unix.st_perm land 0o777))
 
 (* base_dir nested under a regular file: directory creation / file open fails
    (ENOTDIR), so the write raises and must surface as [Error]. *)
@@ -60,30 +63,6 @@ let test_error_when_path_under_a_file () =
         "append under a non-directory path is Error" true
         (Result.is_error result))
 
-let test_append_is_owner_only_and_durable () =
-  let base_dir = temp_base_path "keeper-chat-store-private" in
-  Fun.protect
-    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
-    (fun () ->
-      let result =
-        S.append_assistant_message_result ~base_dir ~keeper_name
-          ~content:"private durable row" ()
-      in
-      Alcotest.(check bool) "durable append succeeds" true (Result.is_ok result);
-      let path = persisted_path base_dir in
-      Alcotest.(check int)
-        "chat history is owner-only"
-        0o600
-        ((Unix.stat path).Unix.st_perm land 0o777);
-      match S.load ~base_dir ~keeper_name with
-      | [ row ] ->
-        Alcotest.(check string)
-          "durable row is readable"
-          "private durable row"
-          row.content
-      | rows ->
-        Alcotest.failf "expected one readable row, got %d" (List.length rows))
-
 let test_incomplete_tail_fails_closed_without_rewrite () =
   let base_dir = temp_base_path "keeper-chat-store-incomplete" in
   Fun.protect
@@ -91,11 +70,11 @@ let test_incomplete_tail_fails_closed_without_rewrite () =
     (fun () ->
       let initial =
         S.append_assistant_message_result ~base_dir ~keeper_name
-          ~content:"seed" ()
+          ~content:"initial" ()
       in
-      Alcotest.(check bool) "seed append succeeds" true (Result.is_ok initial);
-      let path = persisted_path base_dir in
-      let corrupt = "{\"role\":\"assistant\"" in
+      Alcotest.(check bool) "initial append succeeds" true (Result.is_ok initial);
+      let path = chat_path base_dir in
+      let corrupt = "{\"role\":\"assistant\"}" in
       let output = open_out_bin path in
       output_string output corrupt;
       close_out output;
@@ -104,14 +83,73 @@ let test_incomplete_tail_fails_closed_without_rewrite () =
           ~content:"must not append" ()
       in
       Alcotest.(check bool)
-        "incomplete tail is explicit" true (Result.is_error result);
+        "incomplete JSONL tail is explicit" true (Result.is_error result);
       let input = open_in_bin path in
       let persisted = really_input_string input (in_channel_length input) in
       close_in input;
+      Alcotest.(check string) "incomplete bytes remain untouched" corrupt persisted)
+
+let test_delivery_hot_path_keeps_recovery_idempotency () =
+  let base_dir = temp_base_path "keeper-chat-store-delivery" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let request_id =
+        Identity.Request_id.of_string "req-delivery-hot-path"
+        |> Result.get_ok
+      in
+      let delivery_key = Identity.Direct_request request_id in
+      let user_row_id =
+        S.append_delivery_user_message_result
+          ~base_dir
+          ~keeper_name
+          ~delivery_key
+          ~content:"inspect source"
+          ()
+        |> Result.get_ok
+      in
+      let assistant_row_id =
+        S.append_delivery_assistant_message_result
+          ~base_dir
+          ~keeper_name
+          ~delivery_key
+          ~content:"inspection complete"
+          ()
+        |> Result.get_ok
+      in
+      let recovered_user =
+        S.append_user_message_once
+          ~base_dir
+          ~keeper_name
+          ~delivery_key
+          ~content:"inspect source"
+          ()
+        |> Result.get_ok
+      in
+      let recovered_assistant =
+        S.append_assistant_message_once
+          ~base_dir
+          ~keeper_name
+          ~delivery_key
+          ~content:"inspection complete"
+          ()
+        |> Result.get_ok
+      in
+      let recovered_row_id = function
+        | S.Appended { row_id } | S.Already_present { row_id } -> row_id
+      in
       Alcotest.(check string)
-        "incomplete bytes remain untouched"
-        corrupt
-        persisted)
+        "recovery finds hot-path user row"
+        user_row_id
+        (recovered_row_id recovered_user);
+      Alcotest.(check string)
+        "recovery finds hot-path assistant row"
+        assistant_row_id
+        (recovered_row_id recovered_assistant);
+      Alcotest.(check int)
+        "recovery does not duplicate rows"
+        2
+        (List.length (S.load ~base_dir ~keeper_name)))
 
 let () =
   Alcotest.run "keeper_chat_store_append_result"
@@ -121,9 +159,9 @@ let () =
           Alcotest.test_case "writable dir -> Ok" `Quick test_ok_on_writable_dir;
           Alcotest.test_case "path under a file -> Error" `Quick
             test_error_when_path_under_a_file;
-          Alcotest.test_case "owner-only durable append" `Quick
-            test_append_is_owner_only_and_durable;
           Alcotest.test_case "incomplete tail fails closed" `Quick
             test_incomplete_tail_fails_closed_without_rewrite;
+          Alcotest.test_case "delivery hot path remains recoverable" `Quick
+            test_delivery_hot_path_keeps_recovery_idempotency;
         ] );
     ]

--- a/test/test_keeper_fs.ml
+++ b/test/test_keeper_fs.ml
@@ -64,6 +64,44 @@ let test_ensure_dir_invalidate () =
   check bool "recreated after invalidate" true (Sys.file_exists dir);
   cleanup_dir base
 
+let test_ensure_dir_invalidate_removes_descendant_cache () =
+  let base = temp_dir () in
+  let keeper_dir = Filename.concat base "keepers/sangsu" in
+  let deliveries_dir = Filename.concat keeper_dir ".chat-deliveries" in
+  ignore (KF.ensure_dir deliveries_dir);
+  cleanup_dir keeper_dir;
+  check bool "purged descendant is gone" false (Sys.file_exists deliveries_dir);
+  KF.invalidate_dir keeper_dir;
+  ignore (KF.ensure_dir deliveries_dir);
+  check bool "descendant is recreated after ancestor invalidation" true
+    (Sys.file_exists deliveries_dir);
+  cleanup_dir base
+
+let test_ensure_dir_cache_does_not_lexically_collapse_symlink_parent () =
+  let base = temp_dir () in
+  let real_sub = Filename.concat base "real/sub" in
+  let link = Filename.concat base "link" in
+  Fs_compat.mkdir_p real_sub;
+  Unix.symlink real_sub link;
+  Fun.protect
+    ~finally:(fun () ->
+      (try Unix.unlink link with
+       | Unix.Unix_error _ -> ());
+      cleanup_dir base)
+    (fun () ->
+      let through_symlink = Filename.concat link "../cache" in
+      let lexical_peer = Filename.concat base "cache" in
+      ignore (KF.ensure_dir through_symlink);
+      check bool
+        "symlink parent resolves to its target parent"
+        true
+        (Sys.file_exists (Filename.concat base "real/cache"));
+      ignore (KF.ensure_dir lexical_peer);
+      check bool
+        "lexically similar path retains separate cache authority"
+        true
+        (Sys.file_exists lexical_peer))
+
 let test_clear_dir_cache () =
   let base = temp_dir () in
   let dir = Filename.concat base "cleartest" in
@@ -153,8 +191,18 @@ let test_generate_trace_id_format () =
 (* Concurrent ensure_dir (Eio-based)                                *)
 (* ================================================================ *)
 
+let with_eio body =
+  Eio_main.run @@ fun environment ->
+  Eio_guard.enable ();
+  Fs_compat.set_fs (Eio.Stdenv.fs environment);
+  Fun.protect
+    ~finally:(fun () ->
+      Fs_compat.clear_fs ();
+      Eio_guard.disable ())
+    (fun () -> body environment)
+
 let test_concurrent_ensure_dir () =
-  Eio_main.run @@ fun _env ->
+  with_eio @@ fun _env ->
   let base = temp_dir () in
   KF.clear_dir_cache ();
   let dir = Filename.concat base "concurrent" in
@@ -169,7 +217,7 @@ let test_concurrent_ensure_dir () =
   cleanup_dir base
 
 let test_concurrent_save_atomic () =
-  Eio_main.run @@ fun _env ->
+  with_eio @@ fun _env ->
   let base = temp_dir () in
   let path = Filename.concat base "concurrent.txt" in
   let errors = Atomic.make 0 in
@@ -201,6 +249,10 @@ let () =
         [
           test_case "creates and caches" `Quick test_ensure_dir_creates_and_caches;
           test_case "invalidate" `Quick test_ensure_dir_invalidate;
+          test_case "invalidate descendants" `Quick
+            test_ensure_dir_invalidate_removes_descendant_cache;
+          test_case "symlink parent is not lexically aliased" `Quick
+            test_ensure_dir_cache_does_not_lexically_collapse_symlink_parent;
           test_case "clear cache" `Quick test_clear_dir_cache;
           test_case "failure does not poison mutex" `Quick
             test_ensure_dir_failure_does_not_poison_mutex;


### PR DESCRIPTION
## Outcome

This draft makes Keeper chat acceptance and transcript persistence explicit across queue, direct stream, restart recovery, and Dashboard receipt projection.

It is intentionally **BLOCKED / DO NOT MERGE**. The adversarial pass found remaining architectural work listed below; this PR is the review surface for the concrete durability and observability changes already implemented.

## What changed

- Make private transcript append cross-process serialized and durable, with a separate lock inode, complete-write loops, fsync, and typed rollback failures.
- Add a typed atomic-write commit boundary: pre-rename failure versus visible-but-parent-durability-uncertain.
- Preserve committed queue revisions/receipts after rename uncertainty, quarantine only the affected Keeper queue, and keep known receipts queryable.
- Add direct delivery journals and startup recovery before chat readiness.
- Use Eio mutexes for effectful per-key operations; keep Stdlib mutexes limited to short metadata sections.
- Remove the global `ensure_dir` filesystem-stat hot path and make its cache path-local, invalidatable, and symlink-safe.
- Distinguish ENOENT from permission/stat failures through a shared typed path probe.
- Surface queue durability and quarantine through SSE, receipt HTTP JSON, and Dashboard state without exposing BasePath details on the known-quarantine response.
- Preserve `recovery_interrupted` and receipt availability in the Dashboard typed contract.
- Close external-speaker admission deferral as an explicit durable failure instead of leaving a false-success Running journal.
- Preserve an uncertain queue acceptance across the short ACK's later `RUN_FINISHED`; the Dashboard no longer rewrites it to `delivered`.

## Adversarial review fixes included

- Post-rename memory rollback split-brain.
- `close_out` flush failure leaking a temporary-file descriptor.
- `file_exists=false` collapsing EACCES/EIO/ENOTDIR into authoritative absence.
- `Stdlib.Mutex` held across Eio effects.
- One directory fsync serializing unrelated Keeper paths.
- Known quarantined receipts being shown as `server_durable_receipt`.
- Full local BasePath leakage through the known-quarantine receipt load-error projection.
- New durability variants missing from exhaustive OCaml/TypeScript consumers.
- Busy-state projection allocating terminal receipt views unnecessarily.
- `RUN_FINISHED` erasing a durability-uncertain acceptance warning and contract.

## Validation

- OCaml parser, ocamlformat, and `git diff --check`: pass.
- Focused Dune compile: changed fs/queue/journal/server modules and all changed test objects pass.
- `test_fs_compat_durable_append.exe`: 11/11 pass.
- Dashboard TypeScript and targeted ESLint: pass.
- Dashboard `keeper-actions` suite after the uncertainty finalization fix: 91/91 pass.
- Earlier focused Dashboard suites (`api/keeper`, `keeper-stream`, `keeper-state`, `chat/primitives`, `keeper-actions`): 360/360 pass.
- Full local linked test build is blocked before these targets by the machine's installed OAS 0.211.9 `episode.previous` list versus this checkout's exact 0.211.8 interface. CI's pinned environment remains the full-build authority.

## Merge blockers

- #24324 — async and transcript append paths still erase post-commit uncertainty, enabling blind retry after a possibly committed write.
- #24322 — terminal settlement must return the already-committed actual terminal; `Final _ -> Ok ()` can otherwise split success journal from timeout/error projection.
- #24317 — one corrupt delivery journal still blocks global chat readiness instead of quarantining one Keeper recovery lane.
- #24315 — connector ingress/outbound acknowledgement still needs its own durable replayable receipt boundary.
- #24316 — lifetime queue snapshots and journals cause `Theta(N^2)` cumulative writes, fleet head-of-line blocking, lifetime admission/startup scans, and a non-atomic direct-to-queue handoff. The required design is an indexed per-Keeper transactional lane, not a TTL/count heuristic.
- #24328 — server-owned queue receipts cannot be reconstructed from empty browser state after reload, and lifecycle/availability are not represented as orthogonal typed state.
- #24326 — public queue SSE/receipt errors still need a typed boundary separating internal paths/exact secrets from safe client diagnostics.

Related inherited request-path performance debt is tracked in #24327: `Keeper_msg_async.submit` scans/decodes the request directory on every submit.

Additional performance evidence and crash-cut acceptance criteria are recorded in #24316. Compact JSON alone is only a constant-factor mitigation and does not satisfy Lane-per-Keeper progress.

## Boundary

This is MASC runtime/persistence work. It does not move MASC semantics into OAS and does not make OAS depend on MASC.
