### PR TITLE
fix(workspace_git): try git rev-parse before has_git_marker in git_root

### DIFF
--- a/lib/workspace/workspace_git.ml
+++ b/lib/workspace/workspace_git.ml
@@ -82,10 +82,18 @@ let has_git_marker path =
   in
   try walk path with Sys_error _ -> false
 
-(** Get git root directory *)
+(** Get git root directory.
+    Tries [git rev-parse --show-toplevel] first; [has_git_marker] is a
+    fast-path optimisation that can fail inside Docker sandboxes where
+    [Sys.file_exists] does not see the host-side [.git] directory, so we
+    only use it as a fallback diagnostic, not a gate. *)
 let git_root ~base_path =
-  if not (has_git_marker base_path) then None
-  else git_first_line ~repo_path:base_path [ "rev-parse"; "--show-toplevel" ]
+  match git_first_line ~repo_path:base_path [ "rev-parse"; "--show-toplevel" ] with
+  | Some _ as result -> result
+  | None ->
+    if has_git_marker base_path then
+      git_first_line ~repo_path:base_path [ "rev-parse"; "--show-toplevel" ]
+    else None
 
 (** Check if directory is a git repository *)
 let is_git_repo ~base_path =


### PR DESCRIPTION
## Problem

`Workspace_git.git_root` returns `None` in Docker sandboxes because `has_git_marker` uses `Sys.file_exists` to walk parent directories looking for `.git`, but the host-side `.git` directory is not visible inside the container. This causes `git_root` to return `None` before even trying `git rev-parse --show-toplevel`.

## Impact

`task_completion_gate.ml:82` calls `Workspace_git.git_root`; when it returns `None`, `git_commit_exists` is always `false`, causing all evidence_refs commit hash validation to fail. The evaluator gate returns empty responses, blocking all contracted task completions across the workspace.

## Fix

Try `git rev-parse --show-toplevel` first (which works correctly in the sandbox — verified with live test), and only use `has_git_marker` as a fallback diagnostic. The `has_git_marker` fast-path is preserved but no longer gates the git call.

## Testing

- `git rev-parse --show-toplevel` returns `/home/keeper/playground/rondo/repos/masc` correctly in the Docker sandbox
- `git_root` now returns `Some` path instead of `None`

Fixes task-2288.