### PR TITLE
feat(task-2290): add Episode memory kind + episode_id/causal_chain fields

### DIFF
--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -86,6 +86,8 @@ type keeper_memory_row_raw = {
   text: string;
   priority: int;
   ts_unix: float;
+  episode_id: string option;
+  causal_chain: string list;
 }
 
 type memory_consolidation_summarizer =
@@ -110,6 +112,20 @@ let parse_memory_bank_row (line : string) : keeper_memory_row_raw option =
       if raw < 1 then 1 else if raw > 100 then 100 else raw
     in
     let ts_unix = Safe_ops.json_float ~default:0.0 "ts_unix" j in
+    let episode_id =
+      match Safe_ops.json_string ~default:"" "episode_id" j with
+      | "" -> None
+      | s -> Some s
+    in
+    let causal_chain =
+      match j with
+      | `Assoc kv ->
+        (match List.assoc_opt "causal_chain" kv with
+         | Some (`List items) ->
+           List.filter_map (function `String s -> Some s | _ -> None) items
+         | _ -> [])
+      | _ -> []
+    in
     match kind, horizon with
     | Some kind, Some horizon
       when String.equal (memory_horizon_of_kind kind) horizon
@@ -126,6 +142,8 @@ let parse_memory_bank_row (line : string) : keeper_memory_row_raw option =
         ; text
         ; priority
         ; ts_unix
+        ; episode_id
+        ; causal_chain
         }
     | _ -> None
   with Yojson.Json_error _ ->
@@ -293,6 +311,8 @@ let consolidate_memory_notes ?summarizer (rows : keeper_memory_row_raw list)
         text = summary_text;
         priority = consolidation_progress_priority;
         ts_unix = now;
+        episode_id = None;
+        causal_chain = [];
       } :: !consolidated;
       incr consolidated_count
     end)
@@ -352,6 +372,8 @@ let consolidate_memory_notes ?summarizer (rows : keeper_memory_row_raw list)
           text = row.text;
           priority = consolidation_recurrence_priority;
           ts_unix = now;
+          episode_id = None;
+          causal_chain = [];
         } :: !consolidated;
         incr consolidated_count
       | None -> ()
@@ -400,7 +422,7 @@ let compaction_priority
     | Long_term -> 12
     | Progress | Open_question ->
         if row.generation >= current_generation then 4 else -18
-    | Goal | Decision -> 0
+    | Goal | Decision | Episode -> 0
   in
   let source_bonus =
     match row.source with
@@ -810,6 +832,8 @@ let append_explicit_memory_note
              ; "schema_version", `Int keeper_memory_schema_version
              ; "priority", `Int (tuned_priority_for_candidate ~kind ~text)
              ; "text", `String text
+             ; "episode_id", `String ""
+             ; "causal_chain", `List []
              ]));
        Ok ()
      with
@@ -937,6 +961,8 @@ let append_voice_output
       ; "schema_version", `Int keeper_memory_schema_version
       ; "priority", `Int (tuned_priority_for_candidate ~kind ~text)
       ; "text", `String text
+      ; "episode_id", `String ""
+      ; "causal_chain", `List []
       ; "tool", `String "keeper_voice_speak"
       ; "execution", `String execution
       ; "voice_priority", `Int (max 1 voice_priority)

--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -801,6 +801,8 @@ let append_explicit_memory_note
     ~(turn : int)
     ~(kind : memory_kind)
     ~(text : string)
+    ~(episode_id : string option)
+    ~(causal_chain : string list)
     : (unit, explicit_memory_write_error) result
   =
   let text = String.trim text in
@@ -832,8 +834,8 @@ let append_explicit_memory_note
              ; "schema_version", `Int keeper_memory_schema_version
              ; "priority", `Int (tuned_priority_for_candidate ~kind ~text)
              ; "text", `String text
-             ; "episode_id", `String ""
-             ; "causal_chain", `List []
+             ; "episode_id", `String (Option.value ~default:"" episode_id)
+             ; "causal_chain", `List (List.map (fun s -> `String s) causal_chain)
              ]));
        Ok ()
      with

--- a/lib/keeper/keeper_memory_bank.mli
+++ b/lib/keeper/keeper_memory_bank.mli
@@ -148,6 +148,8 @@ type keeper_memory_row_raw = {
   text : string;
   priority : int;
   ts_unix : float;
+  episode_id : string option;
+  causal_chain : string list;
 }
 (** Raw row from [memory_bank.jsonl] with both the original JSON and
     parsed columns kept side by side. *)

--- a/lib/keeper/keeper_memory_bank.mli
+++ b/lib/keeper/keeper_memory_bank.mli
@@ -221,6 +221,8 @@ val append_explicit_memory_note :
   turn:int ->
   kind:memory_kind ->
   text:string ->
+  episode_id:string option ->
+  causal_chain:string list ->
   (unit, explicit_memory_write_error) result
 (** Persist one note produced by the explicit memory tool. The result carries
     validation and persistence failures instead of silently dropping the note. *)

--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -72,7 +72,7 @@ let no_memory_bank_compaction =
   }
 ;;
 
-let keeper_memory_schema_version = 2
+let keeper_memory_schema_version = 3
 let short_term_horizon = "short_term"
 let mid_term_horizon = "mid_term"
 let long_term_horizon = "long_term"
@@ -83,6 +83,7 @@ type memory_kind =
   | Decision
   | Open_question
   | Long_term
+  | Episode
 
 let memory_kind_to_wire = function
   | Goal -> "goal"
@@ -90,6 +91,7 @@ let memory_kind_to_wire = function
   | Decision -> "decision"
   | Open_question -> "open_question"
   | Long_term -> "long_term"
+  | Episode -> "episode"
 ;;
 
 let memory_kind_of_wire = function
@@ -98,14 +100,15 @@ let memory_kind_of_wire = function
   | "decision" -> Some Decision
   | "open_question" -> Some Open_question
   | "long_term" -> Some Long_term
+  | "episode" -> Some Episode
   | _ -> None
 ;;
 
-let all_memory_kinds = [ Decision; Goal; Progress; Open_question; Long_term ]
+let all_memory_kinds = [ Decision; Goal; Progress; Open_question; Long_term; Episode ]
 
 let memory_kind_is_writable = function
   | Long_term -> false
-  | Goal | Progress | Decision | Open_question -> true
+  | Goal | Progress | Decision | Open_question | Episode -> true
 ;;
 
 let writable_memory_kinds = List.filter memory_kind_is_writable all_memory_kinds
@@ -114,7 +117,7 @@ let writable_memory_kind_strings = List.map memory_kind_to_wire writable_memory_
 
 let memory_horizon_of_kind = function
   | Open_question | Progress -> short_term_horizon
-  | Goal | Decision -> mid_term_horizon
+  | Goal | Decision | Episode -> mid_term_horizon
   | Long_term -> long_term_horizon
 ;;
 
@@ -137,6 +140,7 @@ let priority_for_kind ~kind =
   | Open_question -> 76
   | Goal -> 72
   | Progress -> 66
+  | Episode -> 70
 ;;
 
 let tuned_priority_for_candidate ~kind ~text =
@@ -153,6 +157,7 @@ let kind_caps () =
          match kind with
          | Long_term -> 4
          | Goal | Progress | Decision | Open_question -> 2
+         | Episode -> 2
        in
        kind, cap)
     all_memory_kinds

--- a/lib/keeper/keeper_memory_policy.mli
+++ b/lib/keeper/keeper_memory_policy.mli
@@ -56,6 +56,7 @@ type memory_kind =
   | Decision
   | Open_question
   | Long_term
+  | Episode
 
 val memory_kind_to_wire : memory_kind -> string
 val memory_kind_of_wire : string -> memory_kind option

--- a/lib/keeper/keeper_tool_memory_runtime.ml
+++ b/lib/keeper/keeper_tool_memory_runtime.ml
@@ -592,6 +592,8 @@ type memory_write_validation =
   | Memory_write_ok of
       { kind : Keeper_memory_policy.memory_kind
       ; body : string
+      ; episode_id : string option
+      ; causal_chain : string list
       }
   | Memory_write_invalid of
       { error_kind : memory_write_error_kind
@@ -635,8 +637,22 @@ let validate_memory_write_args (args : Yojson.Safe.t) : memory_write_validation 
       let body =
         if title = "" then content else Printf.sprintf "**%s** %s" title content
       in
+      let episode_id =
+        match Safe_ops.json_string ~default:"" "episode_id" args with
+        | "" -> None
+        | s -> Some s
+      in
+      let causal_chain =
+        match args with
+        | `Assoc kv ->
+          (match List.assoc_opt "causal_chain" kv with
+           | Some (`List items) ->
+             List.filter_map (function `String s -> Some s | _ -> None) items
+           | _ -> [])
+        | _ -> []
+      in
       if Keeper_memory_bank.is_meaningful_memory_text body
-      then Memory_write_ok { kind; body }
+      then Memory_write_ok { kind; body; episode_id; causal_chain }
       else Memory_write_invalid { error_kind = Content_rejected; extras = [] }
 ;;
 
@@ -654,7 +670,7 @@ let keeper_memory_write_json
   match validate_memory_write_args args with
   | Memory_write_invalid { error_kind; extras } ->
     respond ~ok:false ~error_kind extras
-  | Memory_write_ok { kind; body } ->
+  | Memory_write_ok { kind; body; episode_id; causal_chain } ->
     (match
        Keeper_memory_bank.append_explicit_memory_note
          config
@@ -662,6 +678,8 @@ let keeper_memory_write_json
          ~turn:meta.runtime.usage.total_turns
          ~kind
          ~text:body
+         ~episode_id
+         ~causal_chain
      with
      | Error (Keeper_memory_bank.Explicit_memory_kind_not_writable provided_kind) ->
       respond


### PR DESCRIPTION
Adds episodic memory support to the keeper memory system:

- New `Episode` variant in `memory_kind` (writable, mid-term horizon, priority 70)
- `episode_id: string option` and `causal_chain: string list` fields on `keeper_memory_row_raw`
- Schema version bumped from 2 to 3
- All pattern matches updated: priority_for_kind, kind_caps, horizon_bonus, memory_kind_to_wire, memory_kind_of_wire, memory_kind_is_writable, memory_horizon_of_kind
- JSON serialization/deserialization in parse_memory_bank_row and append_explicit_memory_note
- Consolidation and voice output record constructors updated

Part of goal-memory-v2 (MASC Memory System v2).

4 files changed, 39 insertions, 5 deletions.