### PR TITLE
task-2288: fix evidence_refs gate — use Config_dir_resolver.repos_dir, re-raise Cancelled

### DIFF
--- a/lib/task_completion_gate.ml
+++ b/lib/task_completion_gate.ml
@@ -80,13 +80,26 @@ let artifact_file_path ~base_path ref_path =
 
 let git_commit_exists ~base_path commit =
   match Workspace_git.git_root ~base_path with
-  | None -> false
   | Some root ->
+    (try Workspace_git.commit_exists ~root ~commit
+     with Eio.Cancel.Cancelled _ as e -> raise e | _ -> false)
+  | None ->
+    (* Sandbox base_path may not be a git root itself.
+       Search repos/ subdirectories for a repo containing the commit. *)
+    let repos_dir = Filename.concat base_path "repos" in
     (try
-       Workspace_git.commit_exists ~root ~commit
-     with
-     | Eio.Cancel.Cancelled _ as e -> raise e
-     | _ -> false)
+       directory_entries repos_dir
+       |> List.filter_map (fun name ->
+         let repo = Filename.concat repos_dir name in
+         match Workspace_git.git_root ~base_path:repo with
+         | Some root ->
+           (try
+              if Workspace_git.commit_exists ~root ~commit then Some true
+              else None
+            with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None)
+         | None -> None)
+       |> List.exists (fun x -> x)
+     with _ -> false)
 
 let trajectory_paths_for_trace ~base_path trace_id =
   if not (is_safe_ref_segment trace_id)

--- a/lib/task_completion_gate.ml
+++ b/lib/task_completion_gate.ml
@@ -85,8 +85,9 @@ let git_commit_exists ~base_path commit =
      with Eio.Cancel.Cancelled _ as e -> raise e | _ -> false)
   | None ->
     (* Sandbox base_path may not be a git root itself.
-       Search repos/ subdirectories for a repo containing the commit. *)
-    let repos_dir = Filename.concat base_path "repos" in
+       Use Config_dir_resolver.repos_dir (SSOT) to find repos/,
+       then search each repo subdirectory for the commit. *)
+    let repos_dir = Config_dir_resolver.repos_dir ~base_path in
     (try
        directory_entries repos_dir
        |> List.filter_map (fun name ->
@@ -99,7 +100,9 @@ let git_commit_exists ~base_path commit =
             with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None)
          | None -> None)
        |> List.exists (fun x -> x)
-     with _ -> false)
+     with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | _ -> false)
 
 let trajectory_paths_for_trace ~base_path trace_id =
   if not (is_safe_ref_segment trace_id)


### PR DESCRIPTION
## Summary

Fixes the evidence_refs gate (`task_completion_gate.ml:81`) that blocks all contracted task completions when the sandbox root lacks a `.git` directory.

## Changes

**`lib/task_completion_gate.ml`** — `git_commit_exists`:

1. **P0 — Cancelled re-raise**: The outer `with _ -> false` was swallowing `Eio.Cancel.Cancelled`. Now re-raises it explicitly before catching other exceptions.

2. **P1 — SSOT for repos_dir**: Replaced `Filename.concat base_path "repos"` with `Config_dir_resolver.repos_dir ~base_path` (single source of truth).

## Background

PR #24271 was previously closed by owner with these two review findings. This PR addresses both.

## Testing

- `Config_dir_resolver.repos_dir` is already used across the codebase (keeper_tool_shared_runtime.ml, keeper_sandbox_control.ml, etc.)
- The Cancelled re-raise follows the same pattern used in the `Some root` branch above