### PR TITLE
fix(ci): remove orphaned Shell IR differential-safety gate (#24352)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -744,20 +744,14 @@ jobs:
         run: |
           opam exec -- dune build --root . @test/runtest-test_runtime_config_validity
 
-      - name: Shell IR differential-safety harness gate
-        # RFC-0208: the differential harness asserts the monotone-safety
-        # invariant (the composed verdict is never below the word-list
-        # floor, so the typed path can only escalate) and pins the
-        # structurally-typed ratchet (git checkout -> R1, reset -> R2).
-        # Hard-fail (no continue-on-error) so a typed arm weakened below
-        # the floor blocks merge. The quick suite runs it too via
-        # `dune test`, but that step is continue-on-error (non-gating) and
-        # is also superseded under main churn — which let the P4 gh-parser
-        # commit drop silently from #19762. This focused gate is the fix.
-        # See: lib/exec/test/test_shell_ir_differential.ml.
-        run: |
-          opam exec -- dune build --root . @lib/exec/test/runtest-test_shell_ir_differential
-
+      # NOTE: the "Shell IR differential-safety harness gate" step was removed
+      # here. #24332 (nonhierarchical Gate refactor) retired the entire
+      # shell_ir risk/typed subsystem (Shell_ir_risk, Shell_ir_typed,
+      # checked_shell_ir — now zero consumers; exec risk moved to the Gate),
+      # including lib/exec/test/test_shell_ir_differential.ml. The orphaned
+      # gate built @lib/exec/test/runtest-test_shell_ir_differential, an empty
+      # alias, hard-failing main (issue #24352). Restoring is infeasible (the
+      # tested subsystem is gone); removing the dead gate completes #24332.
       - name: Env knob catalog drift gate
         # Detects when lib/config/env_config_*.ml has been edited
         # (new MASC_* env var added, doc reworded, knob removed) but


### PR DESCRIPTION
## 무엇
`main` red를 만드는 orphan CI 게이트 제거 (P0 #24352). 작은 단일 변경(ci.yml 한 스텝).

## 근본
#24332(nonhierarchical Gate 리팩터, −26만줄)가 shell_ir risk/typed 서브시스템(`Shell_ir_risk`·`Shell_ir_typed`·`checked_shell_ir` — 현재 **소비자 0**, exec 위험판단은 새 Gate로 이동)과 `test_shell_ir_differential.ml`을 은퇴시켰는데, ci.yml에 그 게이트만 남아 `@lib/exec/test/runtest-test_shell_ir_differential`(빈 alias)를 빌드 → `Error: Alias ... empty` hard-fail.

## 왜 복원이 아니라 제거인가
테스트가 의존하는 `Shell_ir_risk`·`Shell_ir_typed`가 함께 삭제돼서 "테스트만 `git checkout`" 복원은 컴파일 불가. 대상 서브시스템 자체가 은퇴됐으니 게이트 제거가 #24332 청소의 **완결**이에요 (회귀를 덮는 게 아님).

## 관찰 (별도·비차단)
구조적 typed 위험분류 → 판단 기반 Gate 전환은 exec-safety **결정론**을 국소적으로 약화해요. exec 무방비는 아님(Gate가 커버). 결정론 안전판이 필요하면 별도 이슈로.

Fixes #24352.
