### PR TITLE
refactor(keeper): extract pure initial keeper_meta construction (blueprint A5-1a)

### DIFF
--- a/dashboard/src/components/dashboard-shell-tab-surface.test.ts
+++ b/dashboard/src/components/dashboard-shell-tab-surface.test.ts
@@ -1,0 +1,34 @@
+// Tab → content contract (WO-A4-3b). TAB_SURFACE is a Record<TabId, …>, so
+// deleting a key is a COMPILE error — that is the primary mutation guard.
+// This runtime walk pins the remaining holes the type system cannot see:
+// every routable tab must resolve to a defined surface with a non-empty
+// fallback label, and no non-overview tab may alias the Overview component
+// (the pre-refactor switch's default arm silently did exactly that).
+
+import { describe, expect, it } from 'vitest'
+import { VALID_TABS } from './../types'
+import { TAB_SURFACE } from './dashboard-shell'
+
+describe('TAB_SURFACE contract', () => {
+  it('resolves every VALID_TABS entry to a dedicated surface', () => {
+    for (const tab of VALID_TABS) {
+      const surface = TAB_SURFACE[tab]
+      expect(surface, `missing surface for tab ${tab}`).toBeDefined()
+      expect(surface.label.length, `empty label for tab ${tab}`).toBeGreaterThan(0)
+      expect(surface.Component, `missing component for tab ${tab}`).toBeTypeOf('function')
+    }
+  })
+
+  it('never renders the Overview fallback for a non-overview tab', () => {
+    const overview = TAB_SURFACE.overview.Component
+    for (const tab of VALID_TABS) {
+      if (tab === 'overview') continue
+      expect(TAB_SURFACE[tab].Component, `tab ${tab} aliases Overview`).not.toBe(overview)
+    }
+  })
+
+  it('gives every tab its own component (no accidental aliasing)', () => {
+    const components = VALID_TABS.map(tab => TAB_SURFACE[tab].Component)
+    expect(new Set(components).size).toBe(VALID_TABS.length)
+  })
+})

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -1,6 +1,7 @@
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { lazy, Suspense } from 'preact/compat'
+import type { ComponentType } from 'preact'
 import { useEffect, useMemo } from 'preact/hooks'
 import type { GroundedVerdict, RouteState, TabId } from '../types'
 import type { DashboardCdalHealth, DashboardFleetSafetyHealth, DashboardKeeperReactionLedgerHealth, DashboardRuntimeResolution, Keeper } from '../types'
@@ -80,6 +81,7 @@ const LazyIdeShell = lazy(async () => ({ default: (await import('./ide/ide-shell
 const LazyCockpit = lazy(async () => ({ default: (await import('./cockpit/cockpit')).Cockpit }))
 const LazySettingsSurface = lazy(async () => ({ default: (await import('./settings-surface')).SettingsSurface }))
 const LazyApprovals = lazy(async () => ({ default: (await import('./approvals/approvals-surface')).ApprovalsSurface }))
+const LazyRegistrySurface = lazy(async () => ({ default: (await import('./registry/registry-surface')).RegistrySurface }))
 const LazyFusionSurface = lazy(async () => ({ default: (await import('./fusion/fusion-surface')).FusionSurface }))
 
 function lazyTabFallback(label: string) {
@@ -1208,107 +1210,39 @@ export function SideRail({
   `
 }
 
-function TabContent() {
-  const tab = route.value.tab
+// One dedicated surface per tab (WO-A4-3b). The Record is exhaustive over
+// TabId, so a new tab without a surface fails to compile HERE instead of
+// silently bouncing to Overview — the previous switch's default arm did
+// exactly that for any missed case. Exported for the tab→content contract
+// test.
+export const TAB_SURFACE: Readonly<
+  Record<TabId, { readonly label: string; readonly Component: ComponentType }>
+> = {
+  overview: { label: 'Overview', Component: LazyOverview },
+  monitoring: { label: 'Monitor', Component: LazyStatus },
+  keepers: { label: 'Keepers', Component: LazyKeeperDetailPage },
+  registry: { label: 'Registry', Component: LazyRegistrySurface },
+  board: { label: 'Board', Component: LazyBoardSurface },
+  schedule: { label: 'Schedule', Component: LazyScheduleSurface },
+  approvals: { label: 'Approvals', Component: LazyApprovals },
+  fusion: { label: 'Fusion', Component: LazyFusionSurface },
+  workspace: { label: 'Work', Component: LazyWork },
+  command: { label: 'Command', Component: LazyOperations },
+  connectors: { label: 'Connectors', Component: LazyConnectors },
+  lab: { label: 'Lab', Component: LazyLabSurface },
+  cockpit: { label: 'Cockpit', Component: LazyCockpit },
+  code: { label: 'Code IDE', Component: LazyIdeShell },
+  logs: { label: 'System Logs', Component: LazyLogViewer },
+  settings: { label: 'Settings', Component: LazySettingsSurface },
+}
 
-  switch (tab) {
-    case 'overview':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Overview')}>
-          <${LazyOverview} />
-        <//>
-      `
-    case 'monitoring':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Monitor')}>
-          <${LazyStatus} />
-        <//>
-      `
-    case 'keepers':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Keepers')}>
-          <${LazyKeeperDetailPage} />
-        <//>
-      `
-    case 'board':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Board')}>
-          <${LazyBoardSurface} />
-        <//>
-      `
-    case 'schedule':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Schedule')}>
-          <${LazyScheduleSurface} />
-        <//>
-      `
-    case 'approvals':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Approvals')}>
-          <${LazyApprovals} />
-        <//>
-      `
-    case 'fusion':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Fusion')}>
-          <${LazyFusionSurface} />
-        <//>
-      `
-    case 'workspace':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Work')}>
-          <${LazyWork} />
-        <//>
-      `
-    case 'command':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Command')}>
-          <${LazyOperations} />
-        <//>
-      `
-    case 'connectors':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Connectors')}>
-          <${LazyConnectors} />
-        <//>
-      `
-    case 'lab':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Lab')}>
-          <${LazyLabSurface} />
-        <//>
-      `
-    case 'cockpit':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Cockpit')}>
-          <${LazyCockpit} />
-        <//>
-      `
-    case 'code':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Code IDE')}>
-          <${LazyIdeShell} />
-        <//>
-      `
-    case 'logs':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('System Logs')}>
-          <${LazyLogViewer} />
-        <//>
-      `
-    case 'settings':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Settings')}>
-          <${LazySettingsSurface} />
-        <//>
-      `
-    default:
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Overview')}>
-          <${LazyOverview} />
-        <//>
-      `
-  }
+function TabContent() {
+  const { label, Component } = TAB_SURFACE[route.value.tab]
+  return html`
+    <${Suspense} fallback=${lazyTabFallback(label)}>
+      <${Component} />
+    <//>
+  `
 }
 
 /** Pure: build the shareable URL for the current section. Uses

--- a/dashboard/src/components/registry/registry-surface.test.ts
+++ b/dashboard/src/components/registry/registry-surface.test.ts
@@ -1,0 +1,71 @@
+// Registry surface — pure helper contracts (A4 skeleton).
+// normalizeRegistryPersonas must accept both masc_persona_list payload
+// shapes (detailed summaries and bare name strings), and must distinguish
+// a schema mismatch (null — surfaced as an error) from a genuinely empty
+// roster ([]); keeperGroup is a projection of live signals, not a new
+// state machine.
+
+import { describe, expect, it } from 'vitest'
+import type { Keeper } from '../../types'
+import { keeperGroup, normalizeRegistryPersonas } from './registry-surface'
+
+const keeper = (overrides: Partial<Keeper>): Keeper =>
+  ({ name: 'k', status: 'idle', ...overrides }) as Keeper
+
+describe('normalizeRegistryPersonas', () => {
+  it('normalizes detailed persona summaries', () => {
+    const payload = {
+      count: 1,
+      personas: [{
+        persona_name: 'sonsukku',
+        display_name: '손석구',
+        trait: '집요함',
+        has_keeper_defaults: true,
+        profile_path: '/x/profile.json',
+      }],
+    }
+    expect(normalizeRegistryPersonas(payload)).toEqual([{
+      persona_name: 'sonsukku',
+      display_name: '손석구',
+      trait: '집요함',
+      has_keeper_defaults: true,
+    }])
+  })
+
+  it('normalizes the bare-name payload shape', () => {
+    const payload = { count: 2, personas: ['a', 'b'] }
+    expect(normalizeRegistryPersonas(payload)?.map(p => p.persona_name)).toEqual(['a', 'b'])
+  })
+
+  it('returns null for schema mismatches (not a fake empty roster)', () => {
+    expect(normalizeRegistryPersonas(42)).toBeNull()
+    expect(normalizeRegistryPersonas(null)).toBeNull()
+    expect(normalizeRegistryPersonas({ personas: 'nope' })).toBeNull()
+  })
+
+  it('skips junk entries but keeps the rest', () => {
+    const payload = { personas: [{ display_name: 'no-name' }, 'ok'] }
+    expect(normalizeRegistryPersonas(payload)).toEqual([
+      { persona_name: 'ok', display_name: 'ok', trait: null, has_keeper_defaults: false },
+    ])
+  })
+
+  it('distinguishes an empty roster from a mismatch', () => {
+    expect(normalizeRegistryPersonas({ count: 0, personas: [] })).toEqual([])
+  })
+})
+
+describe('keeperGroup', () => {
+  it('groups paused keepers as pause even when the fiber is alive', () => {
+    expect(keeperGroup(keeper({ paused: true, keepalive_running: true }))).toBe('pause')
+  })
+
+  it('groups live keepalive fibers as run', () => {
+    expect(keeperGroup(keeper({ keepalive_running: true }))).toBe('run')
+  })
+
+  it('groups configured-only and stopped keepers as off', () => {
+    expect(keeperGroup(keeper({ registered: false }))).toBe('off')
+    expect(keeperGroup(keeper({ keepalive_running: false }))).toBe('off')
+  })
+})

--- a/dashboard/src/components/registry/registry-surface.ts
+++ b/dashboard/src/components/registry/registry-surface.ts
@@ -1,0 +1,203 @@
+// MASC v2 — Registry surface (A4 skeleton).
+// The operator's home for the three layers of a keeper's being:
+//   이데아 (Persona · 형상) → 실재 (Keeper · 인스턴스) → 런타임 (Runtime · 바인딩)
+// A persona is a SEED: its text is copied into a keeper at instantiation, then
+// the two are independent — editing a persona never reaches back into a live
+// keeper (server-side persona overlay retirement is tracked separately, A2).
+//
+// Skeleton scope (WO-A4-1/2a first slice): read-only three-layer roster.
+//   · personas — fetched on mount via masc_persona_list (no refresh-task lane).
+//     Name/display/description parsing is delegated to keeper-spawn-state's
+//     normalizePersonaSummary (the SSOT for the masc_persona_list entry
+//     shape, shared by 15+ spawn-panel consumers) — see
+//     normalizeRegistryPersonas below for what Registry adds on top and why.
+//   · keepers  — the store `keepers` signal, hydrated by the execution
+//     snapshot (tab-refresh plan + dashboard-ws execution slice subscription)
+//   · runtime  — each keeper row shows its runtime binding when known
+// Create/edit/deregister dialogs land with the full keeper-v2 registry port.
+
+import { html } from 'htm/preact'
+import { useEffect, useMemo } from 'preact/hooks'
+import type { Keeper } from '../../types'
+import { callMcpTool } from '../../api/mcp'
+import { keepers } from '../../store'
+import { isRecord } from '../common/normalize'
+import { createAsyncResource, isFailed, getData } from '../../lib/async-state'
+import { normalizePersonaSummary } from '../keeper-spawn/keeper-spawn-state'
+import { KeeperBadge } from '../keeper-badge'
+import { Dot, Pill, type DotState } from '../v2/primitives-v2'
+
+export interface RegistryPersona {
+  persona_name: string
+  display_name: string
+  trait: string | null
+  has_keeper_defaults: boolean
+}
+
+// masc_persona_list returns { count, personas } where each entry is either a
+// detailed summary object or (only when called with detailed:false, which no
+// dashboard caller does today) a bare name string.
+//
+// Name/display/description parsing is delegated to normalizePersonaSummary
+// (keeper-spawn-state.ts) — the shared pipeline 15+ spawn-panel consumers
+// already rely on — so there is exactly one place that knows the
+// persona_name/name and display_name/displayName/name fallback rules; this
+// function no longer re-derives them. Registry adds only the two things that
+// shared pipeline doesn't provide:
+//
+// 1. has_keeper_defaults. It's on the wire in every masc_persona_list
+//    response (see keeper_tool_persona_runtime.ml:persona_summary_to_json —
+//    always included, unconditional on `detailed`), but PersonaSummary
+//    doesn't carry it. Extending PersonaSummary would be the cleaner fix;
+//    it's deferred here specifically to avoid touching keeper-spawn-state.ts
+//    while #24340 is rewriting that file (cross-conflict risk) — NOT because
+//    of a real fetch-shape difference. masc_persona_list defaults `detailed`
+//    to true server-side (keeper_persona.ml:persona_list_handler), so
+//    keeper-spawn-state's `{}` call and Registry's explicit
+//    `{ detailed: true }` call below already hit the identical response
+//    shape; an earlier version of this comment claimed otherwise and was
+//    wrong.
+// 2. Distinguishing a schema mismatch (null, surfaced as an error) from a
+//    genuinely empty roster ([]). normalizePersonaSummaries always returns
+//    [] (extractArray swallows a non-array/absent `personas` into []), so
+//    that distinction has to live here — it is not something the shared
+//    pipeline's "error channel" resolves for us.
+export function normalizeRegistryPersonas(json: unknown): RegistryPersona[] | null {
+  if (!isRecord(json) || !Array.isArray(json.personas)) return null
+  return json.personas.flatMap((entry): RegistryPersona[] => {
+    if (typeof entry === 'string') {
+      return [{ persona_name: entry, display_name: entry, trait: null, has_keeper_defaults: false }]
+    }
+    const summary = normalizePersonaSummary(entry)
+    if (!summary) return []
+    return [{
+      persona_name: summary.name,
+      display_name: summary.displayName ?? summary.name,
+      trait: summary.description ?? null,
+      has_keeper_defaults: isRecord(entry) && entry.has_keeper_defaults === true,
+    }]
+  })
+}
+
+// Registry keeps its own resource rather than importing keeper-spawn-state's
+// personas/personasLoading/personasError signals directly: those signals are
+// PersonaSummary[], which carries neither has_keeper_defaults nor the
+// null-vs-[] distinction above, and widening that shared type touches the
+// same file #24340 is mid-rewrite on. One extra fetch of an already-cheap
+// read_state tool is the accepted cost of not touching that file now; full
+// unification (single resource, single fetch) is tracked for when the
+// registry wizard replaces the spawn panel (A4-3a, after #24340 lands).
+export const registryPersonas = createAsyncResource<RegistryPersona[]>()
+
+export async function loadRegistryPersonas(): Promise<void> {
+  await registryPersonas.load(async () => {
+    const raw = await callMcpTool('masc_persona_list', { detailed: true })
+    const parsed = normalizeRegistryPersonas(JSON.parse(raw))
+    if (parsed === null) throw new Error('masc_persona_list: unexpected response shape')
+    return parsed
+  })
+}
+
+type KeeperGroupId = 'run' | 'pause' | 'off'
+
+const KEEPER_GROUPS: ReadonlyArray<readonly [KeeperGroupId, string]> = [
+  ['run', '실행 중'],
+  ['pause', '대기 · 일시정지'],
+  ['off', '중지 · 미기동'],
+]
+
+// Grouping is a projection of live signals, not a new state machine: a keeper
+// with a running keepalive fiber is 'run', a paused-but-registered one is
+// 'pause', everything else (configured-only, dead, unregistered) is 'off'.
+export function keeperGroup(k: Keeper): KeeperGroupId {
+  if (k.paused === true) return 'pause'
+  if (k.keepalive_running === true) return 'run'
+  return 'off'
+}
+
+function groupDot(group: KeeperGroupId): DotState {
+  switch (group) {
+    case 'run':
+      return 'ok'
+    case 'pause':
+      return 'warn'
+    case 'off':
+      return 'idle'
+  }
+}
+
+export function RegistrySurface() {
+  useEffect(() => {
+    void loadRegistryPersonas()
+  }, [])
+
+  const personaState = registryPersonas.state.value
+  const personas = getData(personaState) ?? null
+  const personaError = isFailed(personaState) ? personaState.message : null
+
+  const roster = keepers.value
+  const grouped = useMemo(() => {
+    const map: Record<KeeperGroupId, Keeper[]> = { run: [], pause: [], off: [] }
+    for (const k of roster) map[keeperGroup(k)].push(k)
+    return map
+  }, [roster])
+
+  return html`
+    <section class="reg-surface" style="padding:16px;display:flex;flex-direction:column;gap:20px;">
+      <header>
+        <h2 style="margin:0;">Registry</h2>
+        <p style="margin:4px 0 0;opacity:.7;">이데아(Persona) → 실재(Keeper) → 런타임 바인딩</p>
+      </header>
+
+      <div class="reg-layer reg-personas">
+        <h3 style="margin:0 0 8px;">이데아 · Persona <${Pill} tone="info">${personas?.length ?? '…'}<//></h3>
+        ${personaError
+          ? html`<p class="reg-error" style="color:var(--color-bad,#e5534b);">persona 목록 로드 실패: ${personaError}</p>`
+          : personas === null
+            ? html`<p style="opacity:.6;">불러오는 중…</p>`
+            : personas.length === 0
+              ? html`<p style="opacity:.6;">등록된 persona가 없습니다.</p>`
+              : html`
+                  <ul style="list-style:none;margin:0;padding:0;display:flex;flex-wrap:wrap;gap:8px;">
+                    ${personas.map(p => html`
+                      <li key=${p.persona_name} class="reg-persona-card"
+                          style="border:1px solid var(--color-border,#333);border-radius:8px;padding:8px 12px;">
+                        <strong>${p.display_name}</strong>
+                        ${p.trait ? html`<span style="opacity:.7;"> · ${p.trait}</span>` : null}
+                        ${p.has_keeper_defaults ? html` <${Pill} tone="neutral">keeper.*<//>` : null}
+                      </li>
+                    `)}
+                  </ul>
+                `}
+      </div>
+
+      <div class="reg-layer reg-keepers">
+        <h3 style="margin:0 0 8px;">실재 · Keeper <${Pill} tone="info">${roster.length}<//></h3>
+        ${KEEPER_GROUPS.map(([group, label]) => html`
+          <div key=${group} class="reg-kgroup" style="margin-bottom:12px;">
+            <h4 style="margin:0 0 6px;display:flex;align-items:center;gap:6px;">
+              <${Dot} state=${groupDot(group)} /> ${label}
+              <span style="opacity:.6;">${grouped[group].length}</span>
+            </h4>
+            ${grouped[group].length === 0
+              ? html`<p style="margin:0;opacity:.5;">없음</p>`
+              : html`
+                  <ul style="list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:4px;">
+                    ${grouped[group].map(k => html`
+                      <li key=${k.name} class="reg-keeper-row"
+                          style="display:flex;align-items:center;gap:8px;">
+                        <${KeeperBadge} id=${k.name} variant="full" size="sm" />
+                        <span style="opacity:.7;font-size:12px;">
+                          ${k.runtime_id ?? k.runtime_canonical ?? '런타임 미바인딩'}
+                        </span>
+                        ${k.registered === false ? html`<${Pill} tone="neutral">configured<//>` : null}
+                      </li>
+                    `)}
+                  </ul>
+                `}
+          </div>
+        `)}
+      </div>
+    </section>
+  `
+}

--- a/dashboard/src/components/surface-icon.ts
+++ b/dashboard/src/components/surface-icon.ts
@@ -7,6 +7,7 @@ import {
   FlaskConical,
   Gauge,
   Home,
+  Layers,
   Plug,
   ScrollText,
   Settings,
@@ -31,6 +32,8 @@ export function SurfaceIcon({ icon, size = 16 }: SurfaceIconProps) {
       return html`<${Activity} ...${props} />`
     case 'keepers':
       return html`<${UsersRound} ...${props} />`
+    case 'registry':
+      return html`<${Layers} ...${props} />`
     case 'board':
       return html`<${SquareKanban} ...${props} />`
     case 'schedule':

--- a/dashboard/src/components/v2/icons-v2.ts
+++ b/dashboard/src/components/v2/icons-v2.ts
@@ -6,9 +6,29 @@ import type { VNode } from 'preact'
 
 type Icon = VNode
 
-export const ICONS: Readonly<Record<string, Icon>> = {
+// Closed key union (WO-A4-3c): with Record<string, Icon> a typo'd icon key
+// compiled fine and rendered undefined silently; the union turns that into
+// a compile error at every ICONS[...] index and NavEntry.icon literal.
+export type IconKey =
+  | 'grid'
+  | 'users'
+  | 'layers'
+  | 'board'
+  | 'term'
+  | 'code'
+  | 'plug'
+  | 'gear'
+  | 'shield'
+  | 'target'
+  | 'monitor'
+  | 'logs'
+  | 'fusion'
+  | 'clock'
+
+export const ICONS: Readonly<Record<IconKey, Icon>> = {
   grid: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><rect x="3" y="3" width="7" height="7" rx="1.4" /><rect x="14" y="3" width="7" height="7" rx="1.4" /><rect x="3" y="14" width="7" height="7" rx="1.4" /><rect x="14" y="14" width="7" height="7" rx="1.4" /></svg>`,
   users: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="8" r="3.2" /><path d="M3.5 19c0-3 2.6-5 5.5-5s5.5 2 5.5 5" /><path d="M16.5 6.2a3 3 0 0 1 0 5.6" /><path d="M18.5 19c0-2-.8-3.6-2-4.6" /></svg>`,
+  layers: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l9 5-9 5-9-5z" /><path d="M3 13l9 5 9-5" /><path d="M3 17.5l9 5 9-5" /></svg>`,
   board: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linejoin="round"><rect x="3" y="4" width="5" height="16" rx="1.2" /><rect x="10" y="4" width="5" height="11" rx="1.2" /><rect x="17" y="4" width="4" height="14" rx="1.2" /></svg>`,
   term: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="16" rx="2.2" /><path d="M7 9l3 3-3 3" /><path d="M13 15h4" /></svg>`,
   code: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M8 6l-5 6 5 6" /><path d="M16 6l5 6-5 6" /><path d="M13.5 4l-3 16" /></svg>`,

--- a/dashboard/src/components/v2/nav-rail-v2.test.ts
+++ b/dashboard/src/components/v2/nav-rail-v2.test.ts
@@ -40,8 +40,9 @@ describe('NavRailV2 schedule item', () => {
     expect(scheduleNavItem(container)?.querySelector('.nav-badge')).toBeNull()
   })
 
-  // Rail order + group breaks mirror the 2026-07 keeper-v2 standalone export.
-  it('renders the v2 export rail order with Monitor after Keepers', () => {
+  // Rail order + group breaks mirror the 2026-07 keeper-v2 standalone export,
+  // plus the Registry surface (A4) inserted after Keepers in the same group.
+  it('renders the v2 export rail order with Registry between Keepers and Monitor', () => {
     render(html`<${NavRailV2} />`, container)
 
     const rail = container.querySelector('.v2-nav')
@@ -54,7 +55,7 @@ describe('NavRailV2 schedule item', () => {
     expect(walk).toEqual([
       'brand',
       '개요', '|',
-      'Keepers', 'Monitor', '|',
+      'Keepers', '레지스트리', 'Monitor', '|',
       '작업', '승인', '예약', '|',
       '보드', 'Fusion', '로그', '|',
       'IDE', '커넥터',

--- a/dashboard/src/components/v2/nav-rail-v2.ts
+++ b/dashboard/src/components/v2/nav-rail-v2.ts
@@ -25,6 +25,7 @@ const SURFACES: readonly NavEntry[] = [
   { tab: 'overview', label: '개요', icon: 'grid' },
   'sep',
   { tab: 'keepers', label: 'Keepers', icon: 'users' },
+  { tab: 'registry', label: '레지스트리', icon: 'layers' },
   { tab: 'monitoring', label: 'Monitor', icon: 'monitor' },
   'sep',
   { tab: 'workspace', label: '작업', icon: 'target' },

--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -60,10 +60,13 @@ describe('dashboard surface navigation', () => {
     expect(workspace?.defaultTab).toBe('workspace')
   })
 
-  it('keeps the v2 primary shell aligned to the 2026-07 keeper-v2 export rail order', () => {
+  // 2026-07 keeper-v2 export rail order, plus the Registry surface (A4)
+  // inserted after Keepers in the same group.
+  it('keeps the v2 primary shell aligned to the export rail order with Registry after Keepers', () => {
     expect(PRIMARY_DASHBOARD_SURFACES.map(surface => surface.id)).toEqual([
       'overview',
       'keepers',
+      'registry',
       'monitoring',
       'workspace',
       'approvals',
@@ -78,6 +81,7 @@ describe('dashboard surface navigation', () => {
     expect(PRIMARY_DASHBOARD_NAV_ITEMS.map(item => item.label)).toEqual([
       'Overview',
       'Keepers',
+      'Registry',
       'Monitor',
       'Work',
       'Gate',
@@ -92,7 +96,7 @@ describe('dashboard surface navigation', () => {
   })
 
   it('uses one sectionless-surface classifier for section stripping and section lookup', () => {
-    const sectionless = ['overview', 'logs', 'settings', 'keepers', 'board', 'schedule', 'approvals', 'fusion'] as const
+    const sectionless = ['overview', 'logs', 'settings', 'keepers', 'registry', 'board', 'schedule', 'approvals', 'fusion'] as const
     expect(sectionless.filter(id => isSectionlessSurface(id))).toEqual([...sectionless])
     expect(sectionItemsForTab('settings')).toEqual([])
     expect(normalizeRouteParams('settings', { section: 'legacy', surface: 'old', panel: 'theme' })).toEqual({

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -35,6 +35,7 @@ export type DashboardSurfaceIcon =
   | 'overview'
   | 'monitoring'
   | 'keepers'
+  | 'registry'
   | 'board'
   | 'schedule'
   | 'fusion'
@@ -120,6 +121,7 @@ export interface DashboardSectionNavItem {
 const V2_PRIMARY_SURFACE_IDS: ReadonlyArray<SurfaceId> = [
   'overview',
   'keepers',
+  'registry',
   'monitoring',
   'workspace',
   'approvals',
@@ -141,6 +143,7 @@ const SECTIONLESS_SURFACE_IDS: ReadonlySet<TabId> = new Set([
   'logs',
   'settings',
   'keepers',
+  'registry',
   'board',
   'schedule',
   'approvals',
@@ -186,6 +189,14 @@ export const DASHBOARD_SURFACES: DashboardNavGroup[] = [
     description: 'Dedicated keeper roster, conversation, and context workspace',
     defaultTab: 'keepers',
     tabs: ['keepers'],
+  },
+  {
+    id: 'registry',
+    label: 'Registry',
+    icon: 'registry',
+    description: 'Persona forms, keeper instances, and runtime bindings',
+    defaultTab: 'registry',
+    tabs: ['registry'],
   },
   {
     id: 'board',
@@ -312,6 +323,7 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
   // key — the Record is exhaustive over the union, so the empty entry is required.
   approvals: [],
   fusion: [],
+  registry: [],
   monitoring: [
     {
       id: 'agents',

--- a/dashboard/src/dashboard-ws.test.ts
+++ b/dashboard/src/dashboard-ws.test.ts
@@ -262,6 +262,11 @@ describe('dashboardSlicesForRoute', () => {
     ])
   })
 
+  it('subscribes the execution slice on the registry route (keepers hydrate only from the execution snapshot)', () => {
+    expect(dashboardSlicesForRoute({ tab: 'registry', params: {} }))
+      .toContain('execution')
+  })
+
   it('subscribes execution for execution-heavy monitoring and planning routes', () => {
     expect(dashboardSlicesForRoute({ tab: 'workspace', params: { section: 'planning' } }))
       .toContain('execution')

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -403,6 +403,12 @@ export function dashboardSlicesForRoute(routeState: DashboardRouteState): string
     slices.add('execution')
     slices.add('composite')
   }
+  // Registry keeper cards hydrate exclusively from the execution snapshot
+  // (store.hydrateExecutionSnapshot is the only keepers-signal writer on
+  // this route), so the slice subscription is what keeps roster rows live.
+  if (routeState.tab === 'registry') {
+    slices.add('execution')
+  }
   if (routeState.tab === 'board') {
     return Array.from(slices).sort()
   }

--- a/dashboard/src/tab-refresh.test.ts
+++ b/dashboard/src/tab-refresh.test.ts
@@ -73,6 +73,13 @@ describe('refreshPlanForRoute', () => {
     })).toEqual(['namespaceTruth', 'execution', 'missionSnapshot', 'activeKeeperChat'])
   })
 
+  it('hydrates the registry roster on direct entry (no default-[] blank roster)', () => {
+    expect(refreshPlanForRoute({
+      tab: 'registry',
+      params: {},
+    })).toEqual(['namespaceTruth', 'execution', 'missionSnapshot'])
+  })
+
   it('hydrates the top-level board surface from the board store', () => {
     expect(refreshPlanForRoute({
       tab: 'board',

--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -81,6 +81,12 @@ export function refreshPlanForRoute(routeState: Pick<RouteState, 'tab' | 'params
       // reconnect: the route refresh runs after a disconnect and recovers the
       // open keeper's history when replayed events fell outside the buffer.
       return ['namespaceTruth', 'execution', 'missionSnapshot', 'activeKeeperChat']
+    case 'registry':
+      // Keeper roster hydrates from the execution snapshot; the persona
+      // library is fetched by the surface itself on mount (masc_persona_list
+      // has no refresh-task lane). Without this plan a direct entry
+      // (refresh on /registry) rendered an empty roster.
+      return ['namespaceTruth', 'execution', 'missionSnapshot']
     case 'board':
       return ['board']
     case 'fusion':

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -320,6 +320,7 @@ export type TabId =
   | 'overview'
   | 'monitoring'
   | 'keepers'
+  | 'registry'
   | 'board'
   | 'schedule'
   | 'fusion'
@@ -337,6 +338,7 @@ export const VALID_TABS: TabId[] = [
   'overview',
   'monitoring',
   'keepers',
+  'registry',
   'board',
   'schedule',
   'fusion',

--- a/lib/keeper/keeper_meta_build.ml
+++ b/lib/keeper/keeper_meta_build.ml
@@ -1,0 +1,115 @@
+(** Keeper_meta_build — pure construction of the initial [keeper_meta].
+
+    Every non-deterministic or environment-derived input (clock value, keeper
+    uid, generation counter, trace id, compaction mode default) is injected by
+    the caller: this module performs no I/O, reads no config, and mutates
+    nothing. The boot-time create path (Keeper_turn_up_create) and any
+    create-without-boot path build their initial metadata through this one
+    function, so the two paths cannot drift field-by-field. *)
+
+open Keeper_meta_contract
+
+let initial_meta ~name ~agent_name ~persona_extended ~goal ~instructions
+    ~sandbox_profile ~network_mode ~multimodal_policy ~allowed_paths
+    ~mention_targets ~proactive_enabled ~compaction_profile ~compaction_mode
+    ~compaction_ratio_gate ~compaction_message_gate ~compaction_token_gate
+    ~compaction_cooldown_sec ~auto_handoff ~handoff_threshold
+    ~handoff_cooldown_sec ~created_at ~max_context_override ~active_goal_ids
+    ~autoboot_enabled ~telemetry_feedback_enabled
+    ~telemetry_feedback_window_hours ~always_allow ~now_ts ~generation
+    ~trace_id ~keeper_uid ~oas_env () : keeper_meta =
+  {
+    id = None;
+    name;
+    agent_name;
+    persona = Some persona_extended;
+    goal;
+    instructions;
+    sandbox_profile;
+    sandbox_image = None;
+    network_mode;
+    multimodal_policy;
+    allowed_paths;
+    mention_targets;
+    proactive = { enabled = proactive_enabled };
+    compaction =
+      {
+        profile = compaction_profile;
+        mode = compaction_mode;
+        ratio_gate = compaction_ratio_gate;
+        message_gate = compaction_message_gate;
+        token_gate = compaction_token_gate;
+        cooldown_sec = compaction_cooldown_sec;
+      };
+    auto_handoff;
+    handoff_threshold;
+    handoff_cooldown_sec;
+    (* One injected instant for both stamps: a freshly built meta cannot have
+       been updated after it was created. *)
+    created_at;
+    updated_at = created_at;
+    max_context_override;
+    active_goal_ids;
+    paused = false;
+    latched_reason = None;
+    autoboot_enabled;
+    current_task_id = None;
+    telemetry_feedback_enabled;
+    telemetry_feedback_window_hours;
+    always_allow;
+    runtime =
+      {
+        usage =
+          {
+            total_turns = 0;
+            total_input_tokens = 0;
+            total_output_tokens = 0;
+            total_tokens = 0;
+            total_cost_usd = 0.0;
+            last_turn_ts = 0.0;
+            last_input_tokens = 0;
+            last_output_tokens = 0;
+            last_total_tokens = 0;
+            last_latency_ms = 0;
+          };
+        compaction_rt =
+          {
+            count = 0;
+            last_ts = 0.0;
+            last_before_tokens = 0;
+            last_after_tokens = 0;
+            last_check_ts = now_ts;
+            last_decision = compaction_runtime_decision_of_string "initialized";
+          };
+        proactive_rt =
+          {
+            count_total = 0;
+            last_ts = 0.0;
+            visible_count_total = 0;
+            last_visible_ts = 0.0;
+            last_outcome = Proactive_never_started;
+            last_reason = "";
+            last_preview = "";
+            consecutive_noop_count = 0;
+          };
+        generation;
+        trace_id;
+        trace_history = [];
+        last_handoff_ts = 0.0;
+        last_autonomous_action_at = "";
+        autonomous_action_count = 0;
+        autonomous_turn_count = 0;
+        autonomous_text_turn_count = 0;
+        autonomous_tool_turn_count = 0;
+        board_reactive_turn_count = 0;
+        mention_reactive_turn_count = 0;
+        noop_turn_count = 0;
+        message_scope_ack_id = None;
+        last_blocker = None;
+        last_runtime_attempt = None;
+        last_turn_tool_calls = [];
+      };
+    keeper_id = Some keeper_uid;
+    oas_env;
+    meta_version = 0;
+  }

--- a/lib/keeper/keeper_meta_build.mli
+++ b/lib/keeper/keeper_meta_build.mli
@@ -1,0 +1,45 @@
+(** Keeper_meta_build — pure construction of the initial [keeper_meta].
+
+    No I/O, no config reads, no mutation: every non-deterministic input is a
+    parameter. Callers own the effects — [created_at] is the caller's clock
+    reading (used for both [created_at] and [updated_at]), [now_ts] the epoch
+    counterpart for runtime bookkeeping, [keeper_uid] a freshly generated uid,
+    [generation] the per-(keeper, trace) counter, [compaction_mode] the
+    config-resolved default. Keeping this a total pure function lets the boot
+    create path and a create-without-boot path share one metadata shape. *)
+
+val initial_meta :
+  name:string ->
+  agent_name:string ->
+  persona_extended:string ->
+  goal:string ->
+  instructions:string ->
+  sandbox_profile:Keeper_types_profile.sandbox_profile ->
+  network_mode:Keeper_types_profile.network_mode ->
+  multimodal_policy:Keeper_types_profile.multimodal_policy ->
+  allowed_paths:string list ->
+  mention_targets:string list ->
+  proactive_enabled:bool ->
+  compaction_profile:string ->
+  compaction_mode:Keeper_config.compaction_mode ->
+  compaction_ratio_gate:float ->
+  compaction_message_gate:int ->
+  compaction_token_gate:int ->
+  compaction_cooldown_sec:int ->
+  auto_handoff:bool ->
+  handoff_threshold:float ->
+  handoff_cooldown_sec:int ->
+  created_at:string ->
+  max_context_override:int option ->
+  active_goal_ids:string list ->
+  autoboot_enabled:bool ->
+  telemetry_feedback_enabled:bool option ->
+  telemetry_feedback_window_hours:int option ->
+  always_allow:bool option ->
+  now_ts:float ->
+  generation:int ->
+  trace_id:Keeper_id.Trace_id.t ->
+  keeper_uid:Keeper_id.Uid.t ->
+  oas_env:(string * string) list ->
+  unit ->
+  Keeper_meta_contract.keeper_meta

--- a/lib/keeper/keeper_persona.ml
+++ b/lib/keeper/keeper_persona.ml
@@ -1,4 +1,4 @@
-(** Keeper_persona — persona list and persona-backed keeper creation handlers. *)
+(** Keeper_persona — persona list handlers. *)
 
 open Tool_args
 open Keeper_types
@@ -29,46 +29,3 @@ let persona_list_handler args : tool_result =
 (* TEL-OK: thin wrapper — telemetry stays in [persona_list_handler]. *)
 let handle_persona_list _ctx args : tool_result = persona_list_handler args
 
-let handle_keeper_create_from_persona ctx args : tool_result =
-  match resolved_keeper_args_from_persona args with
-  | Error e -> tool_result_error ("" ^ e)
-  | Ok (persona, resolved_args) ->
-      let errors = validate_resolved_keeper_create_json resolved_args in
-      let dry_run = get_bool args "dry_run" false in
-      if dry_run then
-        let json =
-          `Assoc
-            [
-              ("persona", persona_summary_to_json persona);
-              ("ready", `Bool (errors = []));
-              ("errors", Json_util.json_string_list errors);
-              ("resolved_args", resolved_args);
-            ]
-        in
-        tool_result_ok_data json
-      else if errors <> [] then
-        tool_result_error_data
-          (`Assoc
-             [
-               ("persona", persona_summary_to_json persona);
-               ("ready", `Bool false);
-               ("errors", Json_util.json_string_list errors);
-               ("resolved_args", resolved_args);
-             ])
-      else
-        let result = Turn.handle_keeper_up ctx resolved_args in
-        if not (tool_result_success result) then
-          result
-        else begin
-          let created_json = Tool_result.data result in
-          let json =
-            `Assoc
-              [
-                ("persona", persona_summary_to_json persona);
-                ("created", `Bool true);
-                ("result", created_json);
-                ("resolved_args", resolved_args);
-              ]
-          in
-          tool_result_ok_data json
-        end

--- a/lib/keeper/keeper_persona.mli
+++ b/lib/keeper/keeper_persona.mli
@@ -1,4 +1,4 @@
-(** Keeper_persona — persona list and persona-backed keeper creation handlers. *)
+(** Keeper_persona — persona list handlers. *)
 
 type tool_result = Keeper_types_profile.tool_result
 
@@ -6,8 +6,3 @@ val handle_persona_list :
   _ Keeper_types_profile.context -> Yojson.Safe.t -> tool_result
 
 val persona_list_handler : Yojson.Safe.t -> tool_result
-
-(** Create a keeper from a persona definition. Honors a [dry_run] arg
-    that returns a preview without invoking [handle_keeper_up]. *)
-val handle_keeper_create_from_persona :
-  _ Keeper_types_profile.context -> Yojson.Safe.t -> tool_result

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -133,7 +133,14 @@ let keeper_schemas : tool_schema list = [
           ("type", `String "boolean");
           ("description", `String "If true, return the resolved keeper args and validation errors without creating the keeper.");
         ]);
-        ("goal", `Assoc [("type", `String "string")]);
+        ("goal", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Legacy goal string. Mutually exclusive with initial_goal.");
+        ]);
+        ("initial_goal", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Title of the first Goal entity to mint for this keeper (D-10a). Creates the goal, links it into active_goal_ids, and fills the legacy goal string during the transition. Mutually exclusive with goal.");
+        ]);
         ("instructions", `Assoc [("type", `String "string")]);
         ("mention_targets", `Assoc [
           ("type", `String "array");

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -133,6 +133,10 @@ let keeper_schemas : tool_schema list = [
           ("type", `String "boolean");
           ("description", `String "If true, return the resolved keeper args and validation errors without creating the keeper.");
         ]);
+        ("no_boot", `Assoc [
+          ("type", `String "boolean");
+          ("description", `String "If true, create configured-only: write the durable keeper TOML and list-visible meta without booting (no session, checkpoint, registry, or keepalive). autoboot_enabled is pinned false; passing autoboot_enabled=true alongside is rejected. Boot later with masc_keeper_up.");
+        ]);
         ("goal", `Assoc [
           ("type", `String "string");
           ("description", `String "Legacy goal string. Mutually exclusive with initial_goal.");

--- a/lib/keeper/keeper_tool_persona_runtime.ml
+++ b/lib/keeper/keeper_tool_persona_runtime.ml
@@ -216,6 +216,18 @@ let render_keeper_toml_from_resolved_args (json : Yojson.Safe.t) :
               let fields =
                 append_present_string_list_field fields "active_goal_ids" json
               in
+              (* The reconcile boot gate is fail-closed on a declared
+                 [sandbox_profile] (#11080) and personas cannot own capability
+                 fields (D-9 zero-capability invariant), so the generated TOML
+                 pins the profile here. Docker is the most isolated profile
+                 and the unanimous live-fleet value (13/13 keeper TOMLs,
+                 2026-07-14); Local would strip isolation on omission.
+                 Post-create edits go through the keeper config panel. *)
+              let fields =
+                append_string_field fields "sandbox_profile"
+                  (Keeper_types_profile_sandbox.sandbox_profile_to_string
+                     Keeper_types_profile_sandbox.Docker)
+              in
               let timeout_fields =
                 match Safe_ops.json_float_opt "per_provider_timeout" json with
                 | None -> Ok fields
@@ -272,6 +284,101 @@ let persist_keeper_toml_from_resolved_args (json : Yojson.Safe.t) :
                           ("path", `String path);
                           ("created", `Bool true);
                         ])))
+
+(* Configured-only durable TOML write (create-without-boot).
+   - fresh-only: an existing TOML is an explicit error, not a silent
+     no-op — a wizard "create" must not quietly adopt an unrelated
+     keeper's config (contrast [persist_keeper_toml_from_resolved_args],
+     which tolerates already_exists because the boot path persists after
+     a successful boot).
+   - [autoboot_enabled] is pinned false in the rendered TOML so reconcile
+     classifies the keeper [Declarative_autoboot_disabled] before any meta
+     exists; a caller passing autoboot_enabled=true is an explicit
+     conflict, rejected instead of silently overridden.
+   - path scope: resolves under [base_path] (the same resolver family
+     discovery uses) instead of the process-global keepers_dir. *)
+let persist_new_keeper_toml_configured_only ~base_path
+    (json : Yojson.Safe.t) : (string, string) result =
+  match required_resolved_string "name" json with
+  | Error _ as err -> err
+  | Ok name ->
+      if not (validate_name name) then
+        Error "resolved_args.name is not a valid keeper name"
+      else if get_bool json "autoboot_enabled" false then
+        Error
+          "no_boot conflicts with autoboot_enabled=true: a configured-only \
+           keeper is written with autoboot_enabled=false; drop one of the \
+           two, then boot explicitly with masc_keeper_up"
+      else (
+        match
+          Keeper_types_profile.keeper_toml_path_opt_for_base_path ~base_path
+            name
+        with
+        | Some existing_path ->
+            Error
+              (Printf.sprintf "keeper config already exists: %s" existing_path)
+        | None -> (
+            let json =
+              match json with
+              | `Assoc fields ->
+                  `Assoc
+                    (List.remove_assoc "autoboot_enabled" fields
+                    @ [ ("autoboot_enabled", `Bool false) ])
+              | other -> other
+            in
+            match render_keeper_toml_from_resolved_args json with
+            | Error _ as err -> err
+            | Ok content -> (
+                let path =
+                  Filename.concat
+                    (Config_dir_resolver.keepers_dir_for_base_path ~base_path)
+                    (name ^ ".toml")
+                in
+                Fs_compat.mkdir_p (Filename.dirname path);
+                match Fs_compat.save_file_atomic path content with
+                | Error msg -> Error msg
+                | Ok () -> Ok path)))
+
+(* Create-without-boot composition: durable TOML first, then the meta is
+   derived by the SAME parse + derivation the boot path uses (the parse
+   reads profile defaults from the TOML just written — including the
+   pinned sandbox_profile — so the two paths cannot drift). On a failure
+   after the TOML write, the freshly created file is removed so a failed
+   create does not leave an orphan config that a later reconcile or
+   create would trip over. *)
+let create_configured_only (ctx : _ context)
+    (resolved_args : Yojson.Safe.t) : (Yojson.Safe.t, string) result =
+  let base_path = ctx.config.Workspace.base_path in
+  match persist_new_keeper_toml_configured_only ~base_path resolved_args with
+  | Error _ as err -> err
+  | Ok toml_path -> (
+      let remove_orphan_toml () =
+        try Sys.remove toml_path
+        with Sys_error e ->
+          Log.Keeper.error
+            "create_configured_only: failed to remove orphan TOML %s: %s"
+            toml_path e
+      in
+      match Keeper_turn_up_args.parse ctx resolved_args with
+      | Error result ->
+          remove_orphan_toml ();
+          Error (tool_result_body result)
+      | Ok p -> (
+          match
+            Keeper_turn_up_create.create_keeper_configured_only ctx.config p
+          with
+          | Error e ->
+              remove_orphan_toml ();
+              Error e
+          | Ok meta ->
+              Ok
+                (`Assoc
+                   [
+                     ("name", `String meta.name);
+                     ("path", `String toml_path);
+                     ("booted", `Bool false);
+                     ("autoboot_enabled", `Bool false);
+                   ])))
 
 let resolved_keeper_args_from_persona args :
     ((persona_summary * Yojson.Safe.t), string) result =

--- a/lib/keeper/keeper_tool_persona_runtime.ml
+++ b/lib/keeper/keeper_tool_persona_runtime.ml
@@ -86,6 +86,37 @@ let validate_resolved_keeper_create_json (json : Yojson.Safe.t) : string list =
     errors := "mention_targets is required" :: !errors;
   List.rev !errors
 
+(* D-10a transition: an explicit [initial_goal] fills the legacy goal string
+   (the boot gate and the system prompt still read it until the A2 field
+   dissolution) and, when the Goal entity has been minted, links its id into
+   [active_goal_ids]. Pure JSON rewrite — the Goal_store effect stays at the
+   handler boundary, so dry_run can preview the exact same injection without
+   minting anything. Non-object input passes through unchanged: resolved args
+   are produced as an object by [resolved_keeper_args_from_persona], and any
+   degenerate shape is rejected loudly by the downstream validate gate. *)
+let resolved_args_with_initial_goal ~goal_text ?goal_id (json : Yojson.Safe.t)
+    : Yojson.Safe.t =
+  match json with
+  | `Assoc fields ->
+      let ids = Safe_ops.json_string_list "active_goal_ids" json in
+      let ids =
+        match goal_id with
+        | Some gid when not (List.mem gid ids) -> ids @ [ gid ]
+        | _ -> ids
+      in
+      let fields =
+        fields
+        |> List.remove_assoc "goal"
+        |> List.remove_assoc "active_goal_ids"
+      in
+      let ids_field =
+        match ids with
+        | [] -> []
+        | xs -> [ ("active_goal_ids", Json_util.json_string_list xs) ]
+      in
+      `Assoc (fields @ [ ("goal", `String goal_text) ] @ ids_field)
+  | other -> other
+
 let toml_escape_string value =
   let buf = Buffer.create (String.length value + 8) in
   String.iter

--- a/lib/keeper/keeper_tool_persona_runtime.mli
+++ b/lib/keeper/keeper_tool_persona_runtime.mli
@@ -11,6 +11,13 @@ val find_jsonl_row_by_action_id :
 
 val validate_resolved_keeper_create_json : Yojson.Safe.t -> string list
 
+(** D-10a transition injection: set the legacy ["goal"] string to [goal_text]
+    and, when [goal_id] is given, append it to ["active_goal_ids"] (dedup).
+    Pure — the Goal_store mint stays at the handler boundary so dry_run can
+    preview the injection effect-free. *)
+val resolved_args_with_initial_goal :
+  goal_text:string -> ?goal_id:string -> Yojson.Safe.t -> Yojson.Safe.t
+
 val render_keeper_toml_from_resolved_args :
   Yojson.Safe.t -> (string, string) result
 

--- a/lib/keeper/keeper_tool_persona_runtime.mli
+++ b/lib/keeper/keeper_tool_persona_runtime.mli
@@ -24,5 +24,23 @@ val render_keeper_toml_from_resolved_args :
 val persist_keeper_toml_from_resolved_args :
   Yojson.Safe.t -> (Yojson.Safe.t, string) result
 
+(** Configured-only durable TOML write (create-without-boot):
+    fresh-only (existing TOML is an explicit error), pins
+    [autoboot_enabled = false] (an explicit [autoboot_enabled = true]
+    input is a rejected conflict), resolves under [base_path]. Returns
+    the written path. *)
+val persist_new_keeper_toml_configured_only :
+  base_path:string -> Yojson.Safe.t -> (string, string) result
+
+(** Create-without-boot composition: fresh TOML write, then meta via the
+    same parse + derivation as the boot path — no session, checkpoint,
+    registry, or keepalive. Removes the freshly written TOML when a later
+    step fails. Returns [{name; path; booted=false;
+    autoboot_enabled=false}]. *)
+val create_configured_only :
+  _ Keeper_types_profile.context ->
+  Yojson.Safe.t ->
+  (Yojson.Safe.t, string) result
+
 val resolved_keeper_args_from_persona :
   Yojson.Safe.t -> (persona_summary * Yojson.Safe.t, string) result

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -429,36 +429,24 @@ let handle_keeper_create_from_persona ctx args : tool_result =
              during the transition"
         else Ok ()
       in
-      let* resolved_args, initial_goal_id =
+      (* Inject first, validate, mint last (adversarial re-review P1-1 of
+         this PR): [resolved_args_with_initial_goal] is a pure, idempotent
+         JSON rewrite, so validation sees the same goal-bearing shape a real
+         create boots with — dry_run already previewed exactly this. Minting
+         before the validate gate left an unlinked Goal on disk for every
+         rejected create, one more per retry. *)
+      let resolved_args =
         match initial_goal_opt with
-        | None -> Ok (resolved_args, None)
+        | None -> resolved_args
         | Some title ->
-            if dry_run then
-              (* dry_run stays effect-free: preview the exact injection
-                 without minting the Goal entity. *)
-              Ok
-                ( Keeper_tool_persona_runtime.resolved_args_with_initial_goal
-                    ~goal_text:title resolved_args,
-                  None )
-            else (
-              match Goal_store.upsert_goal ctx.config ~title () with
-              | Error e -> Error ("initial_goal: goal creation failed: " ^ e)
-              | Ok (g, _created) ->
-                  Ok
-                    ( Keeper_tool_persona_runtime
-                      .resolved_args_with_initial_goal ~goal_text:title
-                        ~goal_id:g.Goal_store.id resolved_args,
-                      Some g.Goal_store.id ))
-      in
-      let initial_goal_field =
-        match initial_goal_id with
-        | Some gid -> [ ("initial_goal_id", `String gid) ]
-        | None -> []
+            Keeper_tool_persona_runtime.resolved_args_with_initial_goal
+              ~goal_text:title resolved_args
       in
       (* Validate on both branches: dry_run reports [ready]/[errors] as a
          preview, and a real create rejects with the same structured payload
-         before any boot side effect — the boot path's own goal gate stays as
-         the last line of defense, this one just fails earlier and typed. *)
+         before any Goal mint or boot side effect — the boot path's own goal
+         gate stays as the last line of defense, this one just fails earlier
+         and typed. *)
       let errors =
         Keeper_tool_persona_runtime.validate_resolved_keeper_create_json
           resolved_args
@@ -487,16 +475,75 @@ let handle_keeper_create_from_persona ctx args : tool_result =
                   ("resolved_args", resolved_args);
                 ]))
       else
+        let* resolved_args, initial_goal_id =
+          match initial_goal_opt with
+          | None -> Ok (resolved_args, None)
+          | Some title -> (
+              match Goal_store.upsert_goal ctx.config ~title () with
+              | Error e -> Error ("initial_goal: goal creation failed: " ^ e)
+              | Ok (g, _created) ->
+                  Ok
+                    ( Keeper_tool_persona_runtime
+                      .resolved_args_with_initial_goal ~goal_text:title
+                        ~goal_id:g.Goal_store.id resolved_args,
+                      Some g.Goal_store.id ))
+        in
+        let initial_goal_field =
+          match initial_goal_id with
+          | Some gid -> [ ("initial_goal_id", `String gid) ]
+          | None -> []
+        in
+        (* Failure between the mint and the point where the booted keeper's
+           persisted meta references the goal would strand the Goal entity —
+           release it. A failed release logs instead of masking the original
+           error (best-effort compensation, not a new failure path). *)
+        let release_minted_goal ~stage =
+          match initial_goal_id with
+          | None -> ()
+          | Some gid -> (
+              match Goal_store.delete_goal ctx.config ~goal_id:gid with
+              | Ok _ -> ()
+              | Error e ->
+                  Log.Keeper.warn
+                    "create_from_persona: %s failed and releasing minted \
+                     goal %s also failed: %s"
+                    stage gid
+                    (Goal_store.delete_goal_error_to_string e))
+        in
         let* _rendered_toml =
           Keeper_tool_persona_runtime.render_keeper_toml_from_resolved_args
             resolved_args
-          |> Result.map_error (fun e -> "" ^ e)
+          |> Result.map_error (fun e ->
+              (* Render happens before any boot side effect, so nothing can
+                 reference the goal yet — release unconditionally. *)
+              release_minted_goal ~stage:"toml render";
+              "" ^ e)
         in
         let result =
           with_keeper_startup_gate (fun () -> execute_keeper_up ctx resolved_args)
         in
-        if not (tool_result_success result) then
-          Ok result
+        if not (tool_result_success result) then (
+          (match initial_goal_id with
+           | None -> ()
+           | Some gid ->
+               (* A failed boot may still have persisted keeper meta whose
+                  [active_goal_ids] references the goal; deleting it then
+                  would dangle that reference. Release only when no meta
+                  persisted. Residual: a pre-existing meta under the same
+                  name (duplicate-name create) keeps the fresh goal alive —
+                  the WARN below carries the goal id for manual cleanup. *)
+               let keeper_name = get_string resolved_args "name" "" in
+               let meta_persisted =
+                 List.mem keeper_name
+                   (Keeper_meta_store.persisted_keeper_names ctx.config)
+               in
+               if meta_persisted then
+                 Log.Keeper.warn
+                   "create_from_persona: boot failed after goal mint; \
+                    keeping goal %s because keeper %s meta persists"
+                   gid keeper_name
+               else release_minted_goal ~stage:"boot");
+          Ok result)
         else
           let* durable_config =
             Keeper_tool_persona_runtime.persist_keeper_toml_from_resolved_args

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -407,6 +407,14 @@ let handle_keeper_create_from_persona ctx args : tool_result =
         |> Result.map_error (fun e -> "" ^ e)
       in
       let dry_run = get_bool args "dry_run" false in
+      (* Validate on both branches: dry_run reports [ready]/[errors] as a
+         preview, and a real create rejects with the same structured payload
+         before any boot side effect — the boot path's own goal gate stays as
+         the last line of defense, this one just fails earlier and typed. *)
+      let errors =
+        Keeper_tool_persona_runtime.validate_resolved_keeper_create_json
+          resolved_args
+      in
       if dry_run then
         Ok
           (tool_result_ok_data
@@ -415,6 +423,19 @@ let handle_keeper_create_from_persona ctx args : tool_result =
                   ( "persona",
                     Keeper_tool_persona_runtime.persona_summary_to_json persona );
                   ("created", `Bool false);
+                  ("ready", `Bool (errors = []));
+                  ("errors", Json_util.json_string_list errors);
+                  ("resolved_args", resolved_args);
+                ]))
+      else if errors <> [] then
+        Ok
+          (tool_result_error_data
+             (`Assoc
+                [
+                  ( "persona",
+                    Keeper_tool_persona_runtime.persona_summary_to_json persona );
+                  ("ready", `Bool false);
+                  ("errors", Json_util.json_string_list errors);
                   ("resolved_args", resolved_args);
                 ]))
       else

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -407,6 +407,7 @@ let handle_keeper_create_from_persona ctx args : tool_result =
         |> Result.map_error (fun e -> "" ^ e)
       in
       let dry_run = get_bool args "dry_run" false in
+      let no_boot = get_bool args "no_boot" false in
       (* D-10a: an explicit [initial_goal] mints a Goal entity and is the
          goal source for the new keeper. Passing both [goal] and
          [initial_goal] is an explicit conflict — rejected instead of
@@ -427,6 +428,18 @@ let handle_keeper_create_from_persona ctx args : tool_result =
             "pass either goal or initial_goal, not both: initial_goal mints \
              a Goal entity (D-10a) and also fills the legacy goal string \
              during the transition"
+        else Ok ()
+      in
+      (* no_boot pins autoboot_enabled=false in the durable config; an
+         explicit true is a conflict, rejected here before any effect
+         (Goal mint, TOML write). The persist layer re-checks the same
+         predicate as defense in depth. *)
+      let* () =
+        if no_boot && get_bool resolved_args "autoboot_enabled" false then
+          Error
+            "no_boot conflicts with autoboot_enabled=true: a configured-only \
+             keeper is written with autoboot_enabled=false; drop one of the \
+             two, then boot explicitly with masc_keeper_up"
         else Ok ()
       in
       (* Inject first, validate, mint last (adversarial re-review P1-1 of
@@ -459,6 +472,7 @@ let handle_keeper_create_from_persona ctx args : tool_result =
                   ( "persona",
                     Keeper_tool_persona_runtime.persona_summary_to_json persona );
                   ("created", `Bool false);
+                  ("no_boot", `Bool no_boot);
                   ("ready", `Bool (errors = []));
                   ("errors", Json_util.json_string_list errors);
                   ("resolved_args", resolved_args);
@@ -475,6 +489,9 @@ let handle_keeper_create_from_persona ctx args : tool_result =
                   ("resolved_args", resolved_args);
                 ]))
       else
+        (* Validation passed — mint the Goal entity now, at the single point
+           shared by the configured-only (no_boot) and boot paths: both
+           persist the minted goal id into the keeper TOML/meta. *)
         let* resolved_args, initial_goal_id =
           match initial_goal_opt with
           | None -> Ok (resolved_args, None)
@@ -493,7 +510,7 @@ let handle_keeper_create_from_persona ctx args : tool_result =
           | Some gid -> [ ("initial_goal_id", `String gid) ]
           | None -> []
         in
-        (* Failure between the mint and the point where the booted keeper's
+        (* Failure between the mint and the point where the created keeper's
            persisted meta references the goal would strand the Goal entity —
            release it. A failed release logs instead of masking the original
            error (best-effort compensation, not a new failure path). *)
@@ -510,41 +527,76 @@ let handle_keeper_create_from_persona ctx args : tool_result =
                     stage gid
                     (Goal_store.delete_goal_error_to_string e))
         in
-        let* _rendered_toml =
-          Keeper_tool_persona_runtime.render_keeper_toml_from_resolved_args
-            resolved_args
-          |> Result.map_error (fun e ->
-              (* Render happens before any boot side effect, so nothing can
-                 reference the goal yet — release unconditionally. *)
-              release_minted_goal ~stage:"toml render";
-              "" ^ e)
+        (* A failed create may still have persisted keeper meta whose
+           [active_goal_ids] references the goal; deleting it then would
+           dangle that reference. Release only when no meta persisted.
+           Residual: a pre-existing meta under the same name
+           (duplicate-name create) keeps the fresh goal alive — the WARN
+           carries the goal id for manual cleanup. *)
+        let release_unless_meta_persisted ~stage =
+          match initial_goal_id with
+          | None -> ()
+          | Some gid ->
+              let keeper_name = get_string resolved_args "name" "" in
+              let meta_persisted =
+                List.mem keeper_name
+                  (Keeper_meta_store.persisted_keeper_names ctx.config)
+              in
+              if meta_persisted then
+                Log.Keeper.warn
+                  "create_from_persona: %s failed after goal mint; keeping \
+                   goal %s because keeper %s meta persists"
+                  stage gid keeper_name
+              else release_minted_goal ~stage
         in
-        let result =
-          with_keeper_startup_gate (fun () -> execute_keeper_up ctx resolved_args)
-        in
-        if not (tool_result_success result) then (
-          (match initial_goal_id with
-           | None -> ()
-           | Some gid ->
-               (* A failed boot may still have persisted keeper meta whose
-                  [active_goal_ids] references the goal; deleting it then
-                  would dangle that reference. Release only when no meta
-                  persisted. Residual: a pre-existing meta under the same
-                  name (duplicate-name create) keeps the fresh goal alive —
-                  the WARN below carries the goal id for manual cleanup. *)
-               let keeper_name = get_string resolved_args "name" "" in
-               let meta_persisted =
-                 List.mem keeper_name
-                   (Keeper_meta_store.persisted_keeper_names ctx.config)
-               in
-               if meta_persisted then
-                 Log.Keeper.warn
-                   "create_from_persona: boot failed after goal mint; \
-                    keeping goal %s because keeper %s meta persists"
-                   gid keeper_name
-               else release_minted_goal ~stage:"boot");
-          Ok result)
+        if no_boot then (
+          (* Configured, not running: durable TOML + list-visible meta, no
+             boot side effect. Boot later with masc_keeper_up. *)
+          match
+            Keeper_tool_persona_runtime.create_configured_only ctx
+              resolved_args
+          with
+          | Error e ->
+              (* create_configured_only removes its own orphan TOML; the
+                 minted goal follows the same meta-aware rule as the boot
+                 path. *)
+              release_unless_meta_persisted ~stage:"configured-only create";
+              Error e
+          | Ok configured ->
+              let json =
+                `Assoc
+                  ([
+                     ( "persona",
+                       Keeper_tool_persona_runtime.persona_summary_to_json
+                         persona );
+                     ("created", `Bool true);
+                     ("booted", `Bool false);
+                     ("result", configured);
+                     ("resolved_args", resolved_args);
+                   ]
+                  @ initial_goal_field)
+              in
+              invalidate_keeper_list_cache ();
+              invalidate_status_cache (get_string resolved_args "name" "");
+              Ok (tool_result_ok_data json))
         else
+          let* _rendered_toml =
+            Keeper_tool_persona_runtime.render_keeper_toml_from_resolved_args
+              resolved_args
+            |> Result.map_error (fun e ->
+                (* Render happens before any boot side effect, so nothing can
+                   reference the goal yet — release unconditionally. *)
+                release_minted_goal ~stage:"toml render";
+                "" ^ e)
+          in
+          let result =
+            with_keeper_startup_gate (fun () ->
+                execute_keeper_up ctx resolved_args)
+          in
+          if not (tool_result_success result) then (
+            release_unless_meta_persisted ~stage:"boot";
+            Ok result)
+          else
           let* durable_config =
             Keeper_tool_persona_runtime.persist_keeper_toml_from_resolved_args
               resolved_args

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -407,6 +407,54 @@ let handle_keeper_create_from_persona ctx args : tool_result =
         |> Result.map_error (fun e -> "" ^ e)
       in
       let dry_run = get_bool args "dry_run" false in
+      (* D-10a: an explicit [initial_goal] mints a Goal entity and is the
+         goal source for the new keeper. Passing both [goal] and
+         [initial_goal] is an explicit conflict — rejected instead of
+         silently picking a winner. *)
+      let explicit_goal_arg =
+        match get_string_opt args "goal" with
+        | Some g when String.trim g <> "" -> true
+        | _ -> false
+      in
+      let initial_goal_opt =
+        match get_string_opt args "initial_goal" with
+        | Some t when String.trim t <> "" -> Some (String.trim t)
+        | _ -> None
+      in
+      let* () =
+        if explicit_goal_arg && initial_goal_opt <> None then
+          Error
+            "pass either goal or initial_goal, not both: initial_goal mints \
+             a Goal entity (D-10a) and also fills the legacy goal string \
+             during the transition"
+        else Ok ()
+      in
+      let* resolved_args, initial_goal_id =
+        match initial_goal_opt with
+        | None -> Ok (resolved_args, None)
+        | Some title ->
+            if dry_run then
+              (* dry_run stays effect-free: preview the exact injection
+                 without minting the Goal entity. *)
+              Ok
+                ( Keeper_tool_persona_runtime.resolved_args_with_initial_goal
+                    ~goal_text:title resolved_args,
+                  None )
+            else (
+              match Goal_store.upsert_goal ctx.config ~title () with
+              | Error e -> Error ("initial_goal: goal creation failed: " ^ e)
+              | Ok (g, _created) ->
+                  Ok
+                    ( Keeper_tool_persona_runtime
+                      .resolved_args_with_initial_goal ~goal_text:title
+                        ~goal_id:g.Goal_store.id resolved_args,
+                      Some g.Goal_store.id ))
+      in
+      let initial_goal_field =
+        match initial_goal_id with
+        | Some gid -> [ ("initial_goal_id", `String gid) ]
+        | None -> []
+      in
       (* Validate on both branches: dry_run reports [ready]/[errors] as a
          preview, and a real create rejects with the same structured payload
          before any boot side effect — the boot path's own goal gate stays as
@@ -459,15 +507,17 @@ let handle_keeper_create_from_persona ctx args : tool_result =
           let created_json = Tool_result.data result in
           let json =
             `Assoc
-              [
-                ( "persona",
-                  Keeper_tool_persona_runtime.persona_summary_to_json persona );
-                ("created", `Bool true);
-                ("durable_config", durable_config);
-                ( "result",
-                  annotate_keeper_json ~runtime_class:"keeper" created_json );
-                ("resolved_args", resolved_args);
-              ]
+              ([
+                 ( "persona",
+                   Keeper_tool_persona_runtime.persona_summary_to_json persona
+                 );
+                 ("created", `Bool true);
+                 ("durable_config", durable_config);
+                 ( "result",
+                   annotate_keeper_json ~runtime_class:"keeper" created_json );
+                 ("resolved_args", resolved_args);
+               ]
+              @ initial_goal_field)
           in
           invalidate_keeper_list_cache ();
           invalidate_status_cache (get_string resolved_args "name" "");

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -254,97 +254,26 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
           ~keeper_id:p.name
           ~trace_id
       in
-      let meta = {
-        id = None;
-        name = p.name;
-        agent_name = Keeper_identity.keeper_agent_name p.name;
-        persona = Some persona_extended;
-        goal;
-        instructions;
-        sandbox_profile;
-        sandbox_image = None;
-        network_mode;
-        multimodal_policy;
-        allowed_paths;
-        mention_targets;
-        proactive = {
-          enabled = proactive_enabled;
-        };
-        compaction = {
-          profile = compaction_profile;
-          mode = Keeper_config.keeper_compaction_mode_default ();
-          ratio_gate = compaction_ratio_gate;
-          message_gate = compaction_message_gate;
-          token_gate = compaction_token_gate;
-          cooldown_sec = compaction_cooldown_sec;
-        };
-        auto_handoff;
-        handoff_threshold;
-        handoff_cooldown_sec;
-        created_at = now_iso ();
-        updated_at = now_iso ();
-        max_context_override = p.max_context_override_opt;
-        active_goal_ids =
-          active_goal_ids;
-        paused = false;
-        latched_reason = None;
-        autoboot_enabled;
-        current_task_id = None;
-        telemetry_feedback_enabled = p.profile_defaults.telemetry_feedback_enabled;
-        telemetry_feedback_window_hours = p.profile_defaults.telemetry_feedback_window_hours;
-        always_allow = p.profile_defaults.always_allow;
-        runtime = {
-          usage = {
-            total_turns = 0;
-            total_input_tokens = 0;
-            total_output_tokens = 0;
-            total_tokens = 0;
-            total_cost_usd = 0.0;
-            last_turn_ts = 0.0;
-            last_input_tokens = 0;
-            last_output_tokens = 0;
-            last_total_tokens = 0;
-            last_latency_ms = 0;
-          };
-          compaction_rt = {
-            count = 0;
-            last_ts = 0.0;
-            last_before_tokens = 0;
-            last_after_tokens = 0;
-            last_check_ts = now_ts;
-            last_decision = compaction_runtime_decision_of_string "initialized";
-          };
-          proactive_rt = {
-            count_total = 0;
-            last_ts = 0.0;
-            visible_count_total = 0;
-            last_visible_ts = 0.0;
-            last_outcome = Proactive_never_started;
-            last_reason = "";
-            last_preview = "";
-            consecutive_noop_count = 0;
-          };
-          generation;
-          trace_id = trace_id_t;
-          trace_history = [];
-          last_handoff_ts = 0.0;
-          last_autonomous_action_at = "";
-          autonomous_action_count = 0;
-          autonomous_turn_count = 0;
-          autonomous_text_turn_count = 0;
-          autonomous_tool_turn_count = 0;
-          board_reactive_turn_count = 0;
-          mention_reactive_turn_count = 0;
-          noop_turn_count = 0;
-          message_scope_ack_id = None;
-	          last_blocker = None;
-	          last_runtime_attempt = None;
-	          last_turn_tool_calls = [];
-	        };
-      keeper_id = Some (Keeper_id.Uid.generate ());
-      oas_env = p.profile_defaults.oas_env;
-      meta_version = 0;
-      } in
+      let meta =
+        Keeper_meta_build.initial_meta ~name:p.name
+          ~agent_name:(Keeper_identity.keeper_agent_name p.name)
+          ~persona_extended ~goal ~instructions ~sandbox_profile ~network_mode
+          ~multimodal_policy ~allowed_paths ~mention_targets ~proactive_enabled
+          ~compaction_profile
+          ~compaction_mode:(Keeper_config.keeper_compaction_mode_default ())
+          ~compaction_ratio_gate ~compaction_message_gate ~compaction_token_gate
+          ~compaction_cooldown_sec ~auto_handoff ~handoff_threshold
+          ~handoff_cooldown_sec ~created_at:(now_iso ())
+          ~max_context_override:p.max_context_override_opt ~active_goal_ids
+          ~autoboot_enabled
+          ~telemetry_feedback_enabled:p.profile_defaults.telemetry_feedback_enabled
+          ~telemetry_feedback_window_hours:
+            p.profile_defaults.telemetry_feedback_window_hours
+          ~always_allow:p.profile_defaults.always_allow ~now_ts ~generation
+          ~trace_id:trace_id_t
+          ~keeper_uid:(Keeper_id.Uid.generate ())
+          ~oas_env:p.profile_defaults.oas_env ()
+      in
       Progress.Tracker.step tracker ~message:"Saving initial checkpoint" ();
       let init_save_result =
         try

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -21,12 +21,37 @@ let write_initial_meta config meta =
     ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
     config meta
 
-let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
-  Log.Keeper.info "create_keeper: starting for name=%s" p.name;
-  let task_id = Printf.sprintf "keeper_create_%s" p.name in
-  let tracker = Progress.start_tracking ~task_id ~total_steps:6 () in
-  Progress.Tracker.step tracker ~message:"Resolving keeper configuration" ();
-  let now_ts = Time_compat.now () in
+(* Single derivation of the create-time keeper fields from [parsed_args]
+   (operator args > profile defaults > env/runtime-param defaults). The boot
+   create path and the configured-only (no_boot) create path must resolve
+   these identically — one function is what keeps the two paths from
+   drifting. Deterministic given [p] and the config/env snapshot: no clock,
+   no id generation, no filesystem writes. Validation (empty goal, unknown
+   active_goal_ids, sandbox settings) stays with the callers because the
+   error surfaces differ per path. *)
+type derived_create_inputs = {
+  goal : string;
+  autoboot_enabled : bool;
+  allowed_paths : string list;
+  active_goal_ids : string list;
+  sandbox_profile : Keeper_types_profile.sandbox_profile;
+  network_mode : Keeper_types_profile.network_mode;
+  multimodal_policy : Keeper_types_profile.multimodal_policy;
+  mention_targets : string list;
+  proactive_enabled : bool;
+  auto_handoff : bool;
+  handoff_threshold : float;
+  handoff_cooldown_sec : int;
+  instructions : string;
+  compaction_profile : string;
+  compaction_ratio_gate : float;
+  compaction_message_gate : int;
+  compaction_token_gate : int;
+  compaction_cooldown_sec : int;
+  primary_max_context : int;
+}
+
+let derive_create_inputs (p : parsed_args) : derived_create_inputs =
   let goal =
     match p.goal_opt with
     | Some goal -> normalize_goal_text goal
@@ -47,21 +72,6 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
     match p.active_goal_ids_opt with
     | Some ids -> ids
     | None -> Option.value ~default:[] p.profile_defaults.active_goal_ids
-  in
-  let active_goal_ids_error =
-    match p.active_goal_ids_opt with
-    | None -> None
-    | Some _ ->
-        let missing =
-          List.filter
-            (fun goal_id -> Option.is_none (Goal_store.get_goal ctx.config ~goal_id))
-            active_goal_ids
-        in
-        if missing = [] then None
-        else
-          Some
-            (Printf.sprintf "unknown active_goal_ids: %s"
-               (String.concat ", " missing))
   in
   let sandbox_profile =
     resolve_sandbox_profile ~fallback:p.profile_defaults.sandbox_profile
@@ -84,6 +94,214 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
       ~fallback_targets:p.profile_defaults.mention_targets
       ~name:p.name
   in
+  let proactive_enabled =
+    Option.value
+      ~default:
+        (Option.value ~default:default_proactive_enabled
+           p.profile_defaults.proactive_enabled)
+      p.proactive_enabled_opt
+  in
+  let auto_handoff = Option.value ~default:true p.auto_handoff_opt in
+  let handoff_threshold =
+    match p.handoff_threshold_opt with
+    | Some threshold -> threshold
+    | None ->
+        Runtime_params.get Runtime_settings.keeper_handoff_threshold
+  in
+  let handoff_cooldown_sec =
+    match p.handoff_cooldown_sec_opt with
+    | Some cooldown_sec -> cooldown_sec
+    | None ->
+        Runtime_params.get Runtime_settings.keeper_handoff_cooldown_sec
+  in
+  let instructions = Option.value ~default:"" p.instructions_opt in
+  let (env_ratio_gate, env_message_gate, env_token_gate) =
+    keeper_compaction_policy_from_env ()
+  in
+  let compaction_cooldown_sec =
+    Option.value
+      ~default:(keeper_compaction_cooldown_sec ())
+      p.compaction_cooldown_sec_opt
+    |> normalize_compaction_cooldown_sec
+  in
+  let
+    ( compaction_profile,
+      compaction_ratio_gate,
+      compaction_message_gate,
+      compaction_token_gate )
+    =
+    resolve_compaction_policy
+      ~profile_opt:p.compaction_profile_opt
+      ~ratio_opt:p.compaction_ratio_gate_opt
+      ~message_opt:p.compaction_message_gate_opt
+      ~token_opt:p.compaction_token_gate_opt
+      ~fallback_profile:default_compaction_profile
+      ~fallback_ratio:env_ratio_gate
+      ~fallback_message:env_message_gate
+      ~fallback_token:env_token_gate
+  in
+  let primary_max_context =
+    match p.max_context_override_opt with
+    | Some v -> v
+    (* Boundary: Keeper consumes an opaque context budget, not a
+       provider/model identity. *)
+    | None -> Runtime.default_max_context ()
+  in
+  {
+    goal;
+    autoboot_enabled;
+    allowed_paths;
+    active_goal_ids;
+    sandbox_profile;
+    network_mode;
+    multimodal_policy;
+    mention_targets;
+    proactive_enabled;
+    auto_handoff;
+    handoff_threshold;
+    handoff_cooldown_sec;
+    instructions;
+    compaction_profile;
+    compaction_ratio_gate;
+    compaction_message_gate;
+    compaction_token_gate;
+    compaction_cooldown_sec;
+    primary_max_context;
+  }
+
+(* Unknown [active_goal_ids] check — only explicit operator input is
+   validated; profile-default ids were validated when the profile was
+   written. Reads Goal_store, so it lives outside [derive_create_inputs]. *)
+let unknown_active_goal_ids_error (config : Workspace.config) (p : parsed_args)
+    ~(active_goal_ids : string list) : string option =
+  match p.active_goal_ids_opt with
+  | None -> None
+  | Some _ ->
+      let missing =
+        List.filter
+          (fun goal_id -> Option.is_none (Goal_store.get_goal config ~goal_id))
+          active_goal_ids
+      in
+      if missing = [] then None
+      else
+        Some
+          (Printf.sprintf "unknown active_goal_ids: %s"
+             (String.concat ", " missing))
+
+(* Configured-only create (create-without-boot): the caller has already
+   written the durable TOML; this materializes the list-visible meta with
+   NO boot side effect — no session, no checkpoint, no registry/keepalive,
+   no runtime assignment. [autoboot_enabled] is pinned false so reconcile
+   classifies the keeper [Declarative_autoboot_disabled]
+   (Keeper_runtime.autoboot_exclusion_reason) until an operator boots it
+   explicitly via masc_keeper_up. Gates mirror [create_keeper] with the
+   same error strings so both paths speak one vocabulary. *)
+let create_keeper_configured_only (config : Workspace.config)
+    (p : parsed_args) : (keeper_meta, string) result =
+  let d = derive_create_inputs p in
+  if d.goal = "" then Error "goal is required when creating a keeper"
+  else
+    match
+      unknown_active_goal_ids_error config p
+        ~active_goal_ids:d.active_goal_ids
+    with
+    | Some msg -> Error msg
+    | None -> (
+        match validate_sandbox_settings ~allowed_paths:d.allowed_paths with
+        | Error err -> Error err
+        | Ok () -> (
+            let now_ts = Time_compat.now () in
+            let trace_id = generate_trace_id () in
+            match Keeper_id.Trace_id.of_string trace_id with
+            | Error err ->
+                Error
+                  (Printf.sprintf
+                     "internal keeper trace_id generation failed: %s" err)
+            | Ok trace_id_t ->
+                let persona_extended =
+                  Keeper_types_profile.resolved_persona_name
+                    ~keeper_name:p.name p.profile_defaults
+                  |> Keeper_types_profile.load_persona_extended
+                  |> Option.value ~default:""
+                in
+                (* No [next_generation] reservation: a configured-only
+                   keeper owns no episode stream yet, and the counter
+                   lives under the process-global keepers dir — reserving
+                   here would write a runtime artifact outside
+                   [config.base_path] for a keeper that never booted.
+                   0 is exactly what a fresh reservation yields; the boot
+                   path reserves for real on its own create/turn cycle. *)
+                let generation = 0 in
+                let meta =
+                  Keeper_meta_build.initial_meta ~name:p.name
+                    ~agent_name:(Keeper_identity.keeper_agent_name p.name)
+                    ~persona_extended ~goal:d.goal
+                    ~instructions:d.instructions
+                    ~sandbox_profile:d.sandbox_profile
+                    ~network_mode:d.network_mode
+                    ~multimodal_policy:d.multimodal_policy
+                    ~allowed_paths:d.allowed_paths
+                    ~mention_targets:d.mention_targets
+                    ~proactive_enabled:d.proactive_enabled
+                    ~compaction_profile:d.compaction_profile
+                    ~compaction_mode:
+                      (Keeper_config.keeper_compaction_mode_default ())
+                    ~compaction_ratio_gate:d.compaction_ratio_gate
+                    ~compaction_message_gate:d.compaction_message_gate
+                    ~compaction_token_gate:d.compaction_token_gate
+                    ~compaction_cooldown_sec:d.compaction_cooldown_sec
+                    ~auto_handoff:d.auto_handoff
+                    ~handoff_threshold:d.handoff_threshold
+                    ~handoff_cooldown_sec:d.handoff_cooldown_sec
+                    ~created_at:(now_iso ())
+                    ~max_context_override:p.max_context_override_opt
+                    ~active_goal_ids:d.active_goal_ids
+                    ~autoboot_enabled:false
+                    ~telemetry_feedback_enabled:
+                      p.profile_defaults.telemetry_feedback_enabled
+                    ~telemetry_feedback_window_hours:
+                      p.profile_defaults.telemetry_feedback_window_hours
+                    ~always_allow:p.profile_defaults.always_allow ~now_ts
+                    ~generation ~trace_id:trace_id_t
+                    ~keeper_uid:(Keeper_id.Uid.generate ())
+                    ~oas_env:p.profile_defaults.oas_env ()
+                in
+                (match write_initial_meta config meta with
+                 | Error e -> Error e
+                 | Ok () -> Ok meta)))
+
+let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
+  Log.Keeper.info "create_keeper: starting for name=%s" p.name;
+  let task_id = Printf.sprintf "keeper_create_%s" p.name in
+  let tracker = Progress.start_tracking ~task_id ~total_steps:6 () in
+  Progress.Tracker.step tracker ~message:"Resolving keeper configuration" ();
+  let now_ts = Time_compat.now () in
+  let {
+    goal;
+    autoboot_enabled;
+    allowed_paths;
+    active_goal_ids;
+    sandbox_profile;
+    network_mode;
+    multimodal_policy;
+    mention_targets;
+    proactive_enabled;
+    auto_handoff;
+    handoff_threshold;
+    handoff_cooldown_sec;
+    instructions;
+    compaction_profile;
+    compaction_ratio_gate;
+    compaction_message_gate;
+    compaction_token_gate;
+    compaction_cooldown_sec;
+    primary_max_context;
+  } =
+    derive_create_inputs p
+  in
+  let active_goal_ids_error =
+    unknown_active_goal_ids_error ctx.config p ~active_goal_ids
+  in
   if goal = "" then begin
     Log.Keeper.warn "create_keeper failed: goal is required (name=%s)" p.name;
     tool_result_error "goal is required when creating a keeper"
@@ -103,59 +321,6 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
           p.name err;
         tool_result_error err
     | Ok () ->
-            let proactive_enabled =
-                Option.value
-                  ~default:
-                    (Option.value ~default:default_proactive_enabled
-                       p.profile_defaults.proactive_enabled)
-                  p.proactive_enabled_opt
-            in
-              let auto_handoff = Option.value ~default:true p.auto_handoff_opt in
-              let handoff_threshold =
-                match p.handoff_threshold_opt with
-                | Some threshold -> threshold
-                | None ->
-                    Runtime_params.get Runtime_settings.keeper_handoff_threshold
-              in
-              let handoff_cooldown_sec =
-                match p.handoff_cooldown_sec_opt with
-                | Some cooldown_sec -> cooldown_sec
-                | None ->
-                    Runtime_params.get Runtime_settings.keeper_handoff_cooldown_sec
-              in
-              let instructions = Option.value ~default:"" p.instructions_opt in
-              let (env_ratio_gate, env_message_gate, env_token_gate) =
-                keeper_compaction_policy_from_env ()
-              in
-              let compaction_cooldown_sec =
-                Option.value
-                  ~default:(keeper_compaction_cooldown_sec ())
-                  p.compaction_cooldown_sec_opt
-                |> normalize_compaction_cooldown_sec
-              in
-              let
-                ( compaction_profile,
-                  compaction_ratio_gate,
-                  compaction_message_gate,
-                  compaction_token_gate )
-                =
-                resolve_compaction_policy
-                  ~profile_opt:p.compaction_profile_opt
-                  ~ratio_opt:p.compaction_ratio_gate_opt
-                  ~message_opt:p.compaction_message_gate_opt
-                  ~token_opt:p.compaction_token_gate_opt
-                  ~fallback_profile:default_compaction_profile
-                  ~fallback_ratio:env_ratio_gate
-                  ~fallback_message:env_message_gate
-                  ~fallback_token:env_token_gate
-              in
-              let primary_max_context =
-                match p.max_context_override_opt with
-                | Some v -> v
-                (* Boundary: Keeper consumes an opaque context budget, not a
-                   provider/model identity. *)
-                | None -> Runtime.default_max_context ()
-              in
               Progress.Tracker.step tracker ~message:"Initializing session directory" ();
               let trace_id = generate_trace_id () in
               match Keeper_id.Trace_id.of_string trace_id with

--- a/lib/keeper/keeper_turn_up_create.mli
+++ b/lib/keeper/keeper_turn_up_create.mli
@@ -21,3 +21,17 @@ val create_keeper :
   _ Keeper_types_profile.context ->
   Keeper_turn_up_args.parsed_args ->
   tool_result
+
+(** Configured-only create (create-without-boot). Materializes the
+    list-visible keeper meta from the same derivation the boot path
+    uses, with NO boot side effect: no session, no checkpoint, no
+    registry/keepalive, no runtime assignment. [autoboot_enabled] is
+    pinned false in the written meta; the caller owns the durable TOML
+    write (also pinned false) so reconcile classifies the keeper
+    [Declarative_autoboot_disabled] until an explicit masc_keeper_up.
+    Gates (empty goal, unknown active_goal_ids, sandbox settings)
+    mirror [create_keeper] with the same error strings. *)
+val create_keeper_configured_only :
+  Workspace.config ->
+  Keeper_turn_up_args.parsed_args ->
+  (keeper_meta, string) result

--- a/lib/server/server_dashboard_http_keeper_api.mli
+++ b/lib/server/server_dashboard_http_keeper_api.mli
@@ -182,6 +182,15 @@ val handle_keeper_lifecycle_post :
 (** Generic handler for boot / shutdown / reset / clear posts; the
     [action] parameter selects the keeper FSM event. *)
 
+val handle_keeper_create_post :
+  sw:Eio.Switch.t ->
+  clock:[> float Eio.Time.clock_ty ] Eio.Time.clock ->
+  Mcp_server.server_state ->
+  string -> Httpun.Request.t -> Httpun.Reqd.t -> string -> unit
+(** Handle [POST /api/v1/keepers/<name>/create] — REST surface over
+    [masc_keeper_create_from_persona]; path name wins, body fields
+    (persona_name, initial_goal, no_boot, dry_run, ...) pass through. *)
+
 val handle_keeper_directive_post :
   sw:Eio.Switch.t ->
   clock:[> float Eio.Time.clock_ty ] Eio.Time.clock ->

--- a/lib/server/server_dashboard_http_keeper_api_lifecycle_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_lifecycle_post.ml
@@ -403,6 +403,72 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
               respond_error ~status:`Internal_server_error ~request:req ~ok:false
                 reqd "dispatch returned None"))
 
+(* POST /api/v1/keepers/:name/create — REST surface over
+   [masc_keeper_create_from_persona]. The path segment is the keeper name
+   and wins over any [name] in the body; every other body field
+   (persona_name, initial_goal, no_boot, dry_run, ...) passes through to
+   the tool unchanged, so this surface cannot drift from the tool
+   contract. *)
+let handle_keeper_create_post ~sw ~clock state agent_name req reqd body_str =
+  let req_path = Http.Request.path req in
+  let name = extract_keeper_name_for_post req_path keeper_suffix_create in
+  if String.length name = 0 then respond_error reqd "keeper name is required"
+  else
+    let body_result =
+      match Yojson.Safe.from_string body_str with
+      | `Assoc fields -> Ok fields
+      | _ -> Error "request body must be a JSON object"
+      | exception Yojson.Json_error e ->
+          Error (Printf.sprintf "invalid json: %s" e)
+    in
+    match body_result with
+    | Error msg -> respond_error ~ok:false reqd msg
+    | Ok fields ->
+        let config = Mcp_server.workspace_config state in
+        let keeper_ctx : _ Keeper_tool_surface.context =
+          {
+            config;
+            agent_name;
+            sw;
+            clock;
+            proc_mgr = state.Mcp_server.proc_mgr;
+            net = state.Mcp_server.net;
+          }
+        in
+        let args =
+          `Assoc (("name", `String name) :: List.remove_assoc "name" fields)
+        in
+        (match
+           Keeper_tool_surface.dispatch keeper_ctx
+             ~name:"masc_keeper_create_from_persona" ~args
+         with
+        | Some result when Tool_result.is_success result ->
+            let body = Tool_result.message result in
+            invalidate_keeper_execution_surfaces ~config ();
+            Log.Server.info "keeper create name=%s actor=%s outcome=ok" name
+              agent_name;
+            Http.Response.json_value ~compress:true ~request:req
+              (`Assoc
+                 [
+                   ("ok", `Bool true);
+                   ("name", `String name);
+                   ("detail", tool_detail_json body);
+                 ])
+              reqd
+        | Some result ->
+            let body = Tool_result.message result in
+            Log.Server.warn "keeper create name=%s actor=%s outcome=rejected"
+              name agent_name;
+            Http.Response.json_value ~status:`Bad_request ~request:req
+              (`Assoc [ ("ok", `Bool false); ("error", `String body) ])
+              reqd
+        | None ->
+            Log.Server.warn
+              "keeper create name=%s actor=%s outcome=dispatch_none" name
+              agent_name;
+            respond_error ~status:`Internal_server_error ~request:req ~ok:false
+              reqd "dispatch returned None")
+
 (** POST /api/v1/keepers/:name/directive — pause / resume / wakeup.
 
     Delegates to [Keeper_keepalive.process_directive] which updates

--- a/lib/server/server_dashboard_http_keeper_api_lifecycle_post.mli
+++ b/lib/server/server_dashboard_http_keeper_api_lifecycle_post.mli
@@ -11,6 +11,17 @@ val handle_keeper_lifecycle_post :
 (** Generic handler for boot / shutdown / reset / clear posts; the
     [action] parameter selects the keeper FSM event. *)
 
+val handle_keeper_create_post :
+  sw:Eio.Switch.t ->
+  clock:[> float Eio.Time.clock_ty ] Eio.Time.clock ->
+  Mcp_server.server_state ->
+  string -> Httpun.Request.t -> Httpun.Reqd.t -> string -> unit
+(** Handle [POST /api/v1/keepers/<name>/create] — REST surface over
+    [masc_keeper_create_from_persona]. The path segment is the keeper
+    name and wins over any [name] in the body; other body fields
+    (persona_name, initial_goal, no_boot, dry_run, ...) pass through to
+    the tool unchanged. *)
+
 val refresh_keeper_execution_surfaces :
   config:Workspace.config -> name:string -> string -> unit
 (** Invalidate caches and patch execution-surface dependents after a keeper

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -809,6 +809,9 @@ let handle_keeper_secrets_post state req reqd body_str =
 let handle_keeper_lifecycle_post =
   Server_dashboard_http_keeper_api_lifecycle_post.handle_keeper_lifecycle_post
 
+let handle_keeper_create_post =
+  Server_dashboard_http_keeper_api_lifecycle_post.handle_keeper_create_post
+
 let directive_action_to_string = function
   | Keeper_directive.Pause -> "pause"
   | Keeper_directive.Resume -> "resume"

--- a/lib/server/server_dashboard_http_keeper_api_post.mli
+++ b/lib/server/server_dashboard_http_keeper_api_post.mli
@@ -84,6 +84,16 @@ val handle_keeper_lifecycle_post :
   Httpun.Reqd.t ->
   unit
 
+val handle_keeper_create_post :
+  sw:Eio.Switch.t ->
+  clock:[> float Eio.Time.clock_ty ] Eio.Time.clock ->
+  Mcp_server.server_state ->
+  string ->
+  Httpun.Request.t ->
+  Httpun.Reqd.t ->
+  string ->
+  unit
+
 val handle_keeper_directive_post :
   sw:Eio.Switch.t ->
   clock:[> float Eio.Time.clock_ty ] Eio.Time.clock ->

--- a/lib/server/server_dashboard_http_keeper_api_types.ml
+++ b/lib/server/server_dashboard_http_keeper_api_types.ml
@@ -14,6 +14,7 @@ let keeper_suffix_checkpoints = "/checkpoints"
 let keeper_suffix_runtime_trace = "/runtime-trace"
 let keeper_suffix_directive = "/directive"
 let keeper_suffix_catchup_judge = "/catchup-judge"
+let keeper_suffix_create = "/create"
 
 let cache_key_string_segment value =
   Printf.sprintf "s%d:%s" (String.length value) value
@@ -65,6 +66,7 @@ type keeper_post_route_kind =
   | Keeper_post_checkpoints
   | Keeper_post_directive
   | Keeper_post_catchup_judge
+  | Keeper_post_create
   | Keeper_post_unknown
 
 let classify_keeper_post_route req_path =
@@ -86,6 +88,7 @@ let classify_keeper_post_route req_path =
     else if ends_with keeper_suffix_checkpoints then Keeper_post_checkpoints
     else if ends_with keeper_suffix_directive then Keeper_post_directive
     else if ends_with keeper_suffix_catchup_judge then Keeper_post_catchup_judge
+    else if ends_with keeper_suffix_create then Keeper_post_create
     else Keeper_post_unknown
 
 let keeper_path_ends_with req_path suffix =

--- a/lib/server/server_dashboard_http_keeper_api_types.mli
+++ b/lib/server/server_dashboard_http_keeper_api_types.mli
@@ -22,6 +22,7 @@ val keeper_suffix_checkpoints : string
 val keeper_suffix_runtime_trace : string
 val keeper_suffix_directive : string
 val keeper_suffix_catchup_judge : string
+val keeper_suffix_create : string
 
 (** {1 Dashboard cache keys} *)
 
@@ -60,6 +61,7 @@ type keeper_post_route_kind =
   | Keeper_post_checkpoints
   | Keeper_post_directive
   | Keeper_post_catchup_judge
+  | Keeper_post_create
   | Keeper_post_unknown
 (** Sub-route kind for a [POST /api/v1/keepers/<name>/...] path. *)
 

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -1737,6 +1737,14 @@ let add_routes ~sw ~clock router =
                  Keeper_api.handle_keeper_catchup_judge_post state req reqd body_str
                )
              ) request reqd
+       | Keeper_api.Keeper_post_create ->
+           with_token_permission_auth ~permission:Masc_domain.CanAdmin
+             (fun state agent_name req reqd ->
+               Http.Request.read_body_async reqd (fun body_str ->
+                 Keeper_api.handle_keeper_create_post
+                   ~sw ~clock state agent_name req reqd body_str
+               )
+             ) request reqd
        | Keeper_api.Keeper_post_unknown ->
            respond_dashboard_error ~status:`Not_found reqd "not found")
 

--- a/test/dune
+++ b/test/dune
@@ -1940,6 +1940,8 @@
 
 (include stanzas/test_keeper_supervisor_write_meta_source.inc)
 
+(include stanzas/test_keeper_create_mint_order.inc)
+
 (include stanzas/test_keeper_surface_status.inc)
 
 (include stanzas/test_keeper_memory_write.inc)

--- a/test/dune
+++ b/test/dune
@@ -327,6 +327,7 @@
   test_exec_shell_command_gate
   test_runtime_mcp_policy_auth
   test_keeper_classifier_helper
+  test_keeper_create_validate
   test_turn_id_propagation
   test_auth_strict_mode
   test_keeper_turn_fsm_emit
@@ -658,6 +659,7 @@
   test_exec_shell_command_gate
   test_runtime_mcp_policy_auth
   test_keeper_classifier_helper
+  test_keeper_create_validate
   test_turn_id_propagation
   test_auth_strict_mode
   test_keeper_turn_fsm_emit

--- a/test/dune
+++ b/test/dune
@@ -328,6 +328,7 @@
   test_runtime_mcp_policy_auth
   test_keeper_classifier_helper
   test_keeper_create_validate
+  test_keeper_create_no_boot
   test_turn_id_propagation
   test_auth_strict_mode
   test_keeper_turn_fsm_emit
@@ -660,6 +661,7 @@
   test_runtime_mcp_policy_auth
   test_keeper_classifier_helper
   test_keeper_create_validate
+  test_keeper_create_no_boot
   test_turn_id_propagation
   test_auth_strict_mode
   test_keeper_turn_fsm_emit

--- a/test/stanzas/test_keeper_create_mint_order.inc
+++ b/test/stanzas/test_keeper_create_mint_order.inc
@@ -1,4 +1,4 @@
 (test
  (name test_keeper_create_mint_order)
  (modules test_keeper_create_mint_order)
- (libraries alcotest str))
+ (libraries alcotest ast_grep compiler-libs.common))

--- a/test/stanzas/test_keeper_create_mint_order.inc
+++ b/test/stanzas/test_keeper_create_mint_order.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_create_mint_order)
+ (modules test_keeper_create_mint_order)
+ (libraries alcotest str))

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -150,6 +150,25 @@ let test_keeper_post_route_classifies_catchup_judge () =
     (Server_dashboard_http_keeper_api.extract_keeper_name_for_suffix path
        Server_dashboard_http_keeper_api.keeper_suffix_catchup_judge)
 
+let test_keeper_post_route_classifies_create () =
+  let path = "/api/v1/keepers/noboot-probe/create" in
+  check bool "create route kind" true
+    (Server_dashboard_http_keeper_api.classify_keeper_post_route path
+     = Server_dashboard_http_keeper_api.Keeper_post_create);
+  check string "keeper name extracted" "noboot-probe"
+    (Server_dashboard_http_keeper_api.extract_keeper_name_for_post path
+       Server_dashboard_http_keeper_api.keeper_suffix_create);
+  (* Unknown suffixes stay 404-classified — the new arm must not widen
+     the parser. *)
+  check bool "unrelated suffix stays unknown" true
+    (Server_dashboard_http_keeper_api.classify_keeper_post_route
+       "/api/v1/keepers/noboot-probe/created"
+     = Server_dashboard_http_keeper_api.Keeper_post_unknown);
+  check bool "bare collection path stays unknown" true
+    (Server_dashboard_http_keeper_api.classify_keeper_post_route
+       "/api/v1/keepers/create"
+     = Server_dashboard_http_keeper_api.Keeper_post_unknown)
+
 let test_keeper_chat_receipt_route_and_json () =
   let receipt_id =
     match
@@ -1858,6 +1877,8 @@ let () =
             test_state_diagram_runtime_projection_missing_meta_stays_empty;
           test_case "keeper catch-up judge route is classified" `Quick
             test_keeper_post_route_classifies_catchup_judge;
+          test_case "keeper create route is classified, unknown stays 404"
+            `Quick test_keeper_post_route_classifies_create;
           test_case "keeper chat receipt route is typed" `Quick
             test_keeper_chat_receipt_route_and_json;
         ] );

--- a/test/test_keeper_create_mint_order.ml
+++ b/test/test_keeper_create_mint_order.ml
@@ -1,0 +1,82 @@
+(** Structural guard for the adversarial re-review of PR #24364 (P1-1).
+
+    [handle_keeper_create_from_persona] in
+    [lib/keeper/keeper_tool_surface_ops.ml] used to mint the initial_goal
+    Goal entity ([Goal_store.upsert_goal]) BEFORE the validate gate
+    ([validate_resolved_keeper_create_json]). Every rejected create
+    (missing mention_targets, TOML render failure, boot failure) then left
+    an unlinked Goal on disk, one more per retry.
+
+    This test pins the fix:
+
+    - (a) the validate gate must appear before the mint in the source, so
+          a validation reject can never observe a minted goal
+    - (b) a compensation path ([Goal_store.delete_goal]) must exist for the
+          failure branches that run after the mint (toml render / boot)
+
+    Structural (source scan) rather than behavioural because the handler
+    needs a full Eio ctx + persona fixture to exercise; the semantic
+    assumption that makes the reorder valid (the pre-mint injected shape
+    passes the gate) is pinned behaviourally in
+    [test_keeper_create_validate.ml]. *)
+
+open Alcotest
+
+let target_file = "lib/keeper/keeper_tool_surface_ops.ml"
+
+let load_source rel =
+  let source_root =
+    match Sys.getenv_opt "DUNE_SOURCEROOT" with
+    | Some root -> root
+    | None -> Sys.getcwd ()
+  in
+  let path = Filename.concat source_root rel in
+  if not (Sys.file_exists path) then
+    failwith (Printf.sprintf "source file not found: %s" path)
+  else
+    let ic = open_in path in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () -> In_channel.input_all ic)
+
+let index_of haystack re =
+  try Some (Str.search_forward re haystack 0) with Not_found -> None
+
+let validate_re = Str.regexp_string "validate_resolved_keeper_create_json"
+let mint_re = Str.regexp_string "Goal_store.upsert_goal"
+let release_re = Str.regexp_string "Goal_store.delete_goal"
+
+let test_validate_before_mint () =
+  let src = load_source target_file in
+  let validate_idx = index_of src validate_re in
+  let mint_idx = index_of src mint_re in
+  match (validate_idx, mint_idx) with
+  | None, _ ->
+      fail "validate_resolved_keeper_create_json call disappeared from the \
+            create-from-persona handler"
+  | _, None ->
+      fail "Goal_store.upsert_goal mint disappeared from the \
+            create-from-persona handler"
+  | Some v, Some m ->
+      check bool
+        "validate gate must run before the Goal mint (orphan-Goal guard)"
+        true (v < m)
+
+let test_compensation_present () =
+  let src = load_source target_file in
+  check bool
+    "post-mint failure branches must keep a Goal_store.delete_goal \
+     compensation"
+    true
+    (index_of src release_re <> None)
+
+let () =
+  run "keeper_create_mint_order"
+    [
+      ( "orphan_goal_guard",
+        [
+          test_case "validate before mint" `Quick test_validate_before_mint;
+          test_case "compensation delete present" `Quick
+            test_compensation_present;
+        ] );
+    ]

--- a/test/test_keeper_create_mint_order.ml
+++ b/test/test_keeper_create_mint_order.ml
@@ -1,82 +1,119 @@
-(** Structural guard for the adversarial re-review of PR #24364 (P1-1).
+(** Structural guard for the adversarial re-review of PR #24364 (P1-1),
+    AST edition (re-review P3): the first version scanned source text with
+    [Str.search_forward], so a comment above the mint mentioning the
+    validate callee would have produced a false pass. AST nodes carry no
+    comments, so this version proves the ordering on real call sites only.
 
     [handle_keeper_create_from_persona] in
     [lib/keeper/keeper_tool_surface_ops.ml] used to mint the initial_goal
     Goal entity ([Goal_store.upsert_goal]) BEFORE the validate gate
-    ([validate_resolved_keeper_create_json]). Every rejected create
-    (missing mention_targets, TOML render failure, boot failure) then left
-    an unlinked Goal on disk, one more per retry.
+    ([validate_resolved_keeper_create_json]). Every rejected create then
+    left an unlinked Goal on disk, one more per retry.
 
-    This test pins the fix:
+    Pinned here:
 
-    - (a) the validate gate must appear before the mint in the source, so
-          a validation reject can never observe a minted goal
-    - (b) a compensation path ([Goal_store.delete_goal]) must exist for the
-          failure branches that run after the mint (toml render / boot)
+    - (a) inside the handler binding, the first real application of the
+          validate gate precedes the first real application of the mint
+    - (b) a compensation path ([Goal_store.delete_goal]) exists inside
+          the same binding for the failure branches after the mint
 
-    Structural (source scan) rather than behavioural because the handler
-    needs a full Eio ctx + persona fixture to exercise; the semantic
-    assumption that makes the reorder valid (the pre-mint injected shape
-    passes the gate) is pinned behaviourally in
+    The semantic premise that makes the reorder valid (the pre-mint
+    injected shape passes the gate) is pinned behaviourally in
     [test_keeper_create_validate.ml]. *)
 
 open Alcotest
 
-let target_file = "lib/keeper/keeper_tool_surface_ops.ml"
+let module_path = "lib/keeper/keeper_tool_surface_ops.ml"
+let handler_binding = "handle_keeper_create_from_persona"
 
-let load_source rel =
-  let source_root =
-    match Sys.getenv_opt "DUNE_SOURCEROOT" with
-    | Some root -> root
-    | None -> Sys.getcwd ()
+let validate_callee =
+  "Keeper_tool_persona_runtime.validate_resolved_keeper_create_json"
+
+let mint_callee = "Goal_store.upsert_goal"
+let release_callee = "Goal_store.delete_goal"
+
+(* Earliest character offset of a [callee] application inside the value
+   binding [binding_name]; [None] when the binding never applies it. *)
+let first_call_offset ~binding_name ~callee =
+  let structure = Ast_grep.parse_implementation_or_fail module_path in
+  let best = ref None in
+  let note (loc : Location.t) =
+    let off = loc.Location.loc_start.Lexing.pos_cnum in
+    match !best with
+    | Some prev when prev <= off -> ()
+    | _ -> best := Some off
   in
-  let path = Filename.concat source_root rel in
-  if not (Sys.file_exists path) then
-    failwith (Printf.sprintf "source file not found: %s" path)
-  else
-    let ic = open_in path in
-    Fun.protect
-      ~finally:(fun () -> close_in_noerr ic)
-      (fun () -> In_channel.input_all ic)
-
-let index_of haystack re =
-  try Some (Str.search_forward re haystack 0) with Not_found -> None
-
-let validate_re = Str.regexp_string "validate_resolved_keeper_create_json"
-let mint_re = Str.regexp_string "Goal_store.upsert_goal"
-let release_re = Str.regexp_string "Goal_store.delete_goal"
+  let scan_expr expr =
+    let iter =
+      { Ast_iterator.default_iterator with
+        expr =
+          (fun self e ->
+            (match e.Parsetree.pexp_desc with
+             | Parsetree.Pexp_apply
+                 ({ pexp_desc = Parsetree.Pexp_ident { txt; _ }; _ }, _)
+               when String.equal (Ast_grep.longident_to_string txt) callee ->
+                 note e.Parsetree.pexp_loc
+             | _ -> ());
+            Ast_iterator.default_iterator.expr self e)
+      }
+    in
+    iter.expr iter expr
+  in
+  let iter =
+    { Ast_iterator.default_iterator with
+      value_binding =
+        (fun self vb ->
+          (match vb.Parsetree.pvb_pat.Parsetree.ppat_desc with
+           | Parsetree.Ppat_var { txt; _ }
+             when String.equal txt binding_name ->
+               scan_expr vb.Parsetree.pvb_expr
+           | _ -> ());
+          Ast_iterator.default_iterator.value_binding self vb)
+    }
+  in
+  iter.structure iter structure;
+  !best
 
 let test_validate_before_mint () =
-  let src = load_source target_file in
-  let validate_idx = index_of src validate_re in
-  let mint_idx = index_of src mint_re in
-  match (validate_idx, mint_idx) with
+  let validate_off =
+    first_call_offset ~binding_name:handler_binding ~callee:validate_callee
+  in
+  let mint_off =
+    first_call_offset ~binding_name:handler_binding ~callee:mint_callee
+  in
+  match (validate_off, mint_off) with
   | None, _ ->
-      fail "validate_resolved_keeper_create_json call disappeared from the \
-            create-from-persona handler"
+      fail
+        "validate_resolved_keeper_create_json application disappeared from \
+         handle_keeper_create_from_persona"
   | _, None ->
-      fail "Goal_store.upsert_goal mint disappeared from the \
-            create-from-persona handler"
+      fail
+        "Goal_store.upsert_goal mint disappeared from \
+         handle_keeper_create_from_persona"
   | Some v, Some m ->
       check bool
-        "validate gate must run before the Goal mint (orphan-Goal guard)"
+        "validate gate must be applied before the Goal mint (orphan-Goal \
+         guard)"
         true (v < m)
 
 let test_compensation_present () =
-  let src = load_source target_file in
+  let releases =
+    Ast_grep.count_calls_in_value_binding ~module_path
+      ~binding_name:handler_binding ~callee:release_callee
+  in
   check bool
     "post-mint failure branches must keep a Goal_store.delete_goal \
-     compensation"
-    true
-    (index_of src release_re <> None)
+     compensation inside the handler"
+    true (releases >= 1)
 
 let () =
   run "keeper_create_mint_order"
     [
       ( "orphan_goal_guard",
         [
-          test_case "validate before mint" `Quick test_validate_before_mint;
-          test_case "compensation delete present" `Quick
+          test_case "validate applied before mint (AST)" `Quick
+            test_validate_before_mint;
+          test_case "compensation delete present (AST)" `Quick
             test_compensation_present;
         ] );
     ]

--- a/test/test_keeper_create_no_boot.ml
+++ b/test/test_keeper_create_no_boot.ml
@@ -1,0 +1,215 @@
+(** test_keeper_create_no_boot — create-without-boot acceptance (WO-A5-3a/3b/3c).
+
+    [Keeper_tool_persona_runtime.create_configured_only] writes the durable
+    TOML (pinned autoboot_enabled=false, pinned sandbox_profile) and the
+    list-visible meta with no boot side effect: the keeper must appear in
+    [keeper_names], must NOT be registered, and reconcile must classify it
+    [Declarative_autoboot_disabled]. Duplicate names and an explicit
+    autoboot_enabled=true are explicit errors, and a post-persist failure
+    removes the freshly written TOML instead of leaving an orphan. *)
+
+module Workspace = Masc.Workspace
+module Store = Masc.Keeper_meta_store
+module Profile = Masc.Keeper_types_profile
+module Persona_runtime = Masc.Keeper_tool_persona_runtime
+module Keeper_runtime = Masc.Keeper_runtime
+module Keeper_registry = Masc.Keeper_registry
+
+let temp_dir () =
+  let path = Filename.temp_file "keeper-create-no-boot-" "" in
+  Sys.remove path;
+  Unix.mkdir path 0o755;
+  path
+
+let rec mkdir_p path =
+  if Sys.file_exists path then ()
+  else (
+    let parent = Filename.dirname path in
+    if not (String.equal parent path) then mkdir_p parent;
+    Unix.mkdir path 0o755)
+
+let rec rm_rf path =
+  try
+    if Sys.file_exists path then
+      if Sys.is_directory path then (
+        Sys.readdir path
+        |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+        Unix.rmdir path)
+      else Sys.remove path
+  with _ -> ()
+
+let restore_env name = function
+  | Some value -> Unix.putenv name value
+  | None -> Unix.putenv name ""
+
+let contains ~affix s =
+  let n = String.length affix and m = String.length s in
+  let rec go i = i + n <= m && (String.sub s i n = affix || go (i + 1)) in
+  n = 0 || go 0
+
+let read_file path =
+  let ic = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () -> really_input_string ic (in_channel_length ic))
+
+let with_config_dir f =
+  let base = temp_dir () in
+  let config_dir = Filename.concat base ".masc/config" in
+  mkdir_p (Filename.concat config_dir "keepers");
+  let previous = Sys.getenv_opt "MASC_CONFIG_DIR" in
+  Fun.protect
+    ~finally:(fun () ->
+      restore_env "MASC_CONFIG_DIR" previous;
+      Config_dir_resolver.reset ();
+      rm_rf base)
+    (fun () ->
+      Unix.putenv "MASC_CONFIG_DIR" config_dir;
+      Config_dir_resolver.reset ();
+      f ~base)
+
+let with_ctx f =
+  with_config_dir @@ fun ~base ->
+  let config = Workspace.default_config base in
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let ctx : _ Profile.context =
+    {
+      config;
+      agent_name = "test-agent";
+      sw;
+      clock = Eio.Stdenv.clock env;
+      proc_mgr = None;
+      net = None;
+    }
+  in
+  f ~base ~config ~ctx
+
+let resolved_args ?(extra = []) name =
+  `Assoc
+    ([
+       ("name", `String name);
+       ("persona_name", `String "probe");
+       ("goal", `String "configured only probe");
+       ("instructions", `String "");
+       ("mention_targets", `List [ `String name ]);
+     ]
+    @ extra)
+
+let test_configured_only_create () =
+  with_ctx @@ fun ~base ~config ~ctx ->
+  let name = "noboot-probe" in
+  match Persona_runtime.create_configured_only ctx (resolved_args name) with
+  | Error e -> Alcotest.failf "create_configured_only failed: %s" e
+  | Ok payload ->
+      (match payload with
+       | `Assoc fields ->
+           Alcotest.(check (option bool))
+             "payload booted=false" (Some false)
+             (match List.assoc_opt "booted" fields with
+              | Some (`Bool b) -> Some b
+              | _ -> None);
+           (match List.assoc_opt "path" fields with
+            | Some (`String path) ->
+                Alcotest.(check bool) "TOML written" true (Sys.file_exists path);
+                let toml = read_file path in
+                Alcotest.(check bool)
+                  "TOML pins autoboot_enabled=false" true
+                  (contains ~affix:"autoboot_enabled = false" toml);
+                Alcotest.(check bool)
+                  "TOML pins sandbox_profile" true
+                  (contains ~affix:{|sandbox_profile = "docker"|} toml)
+            | _ -> Alcotest.fail "payload missing path")
+       | _ -> Alcotest.fail "payload must be an object");
+      Alcotest.(check bool)
+        "meta visible in keeper_names" true
+        (List.mem name (Store.keeper_names config));
+      Alcotest.(check bool)
+        "not registered" false
+        (Keeper_registry.is_registered ~base_path:base name);
+      (* [autoboot_enabled] is a TOML-owned field: [meta_to_json] scrubs it
+         from the persisted JSON and the read-back default is true, so the
+         raw meta field is NOT the contract — the TOML pin is. Assert the
+         effective (TOML-aware) value instead. *)
+      (match Store.read_meta config name with
+       | Ok (Some meta) ->
+           Alcotest.(check bool)
+             "effective autoboot disabled" false
+             (Store.effective_autoboot_enabled config name meta)
+       | Ok None -> Alcotest.fail "meta missing after configured-only create"
+       | Error e -> Alcotest.failf "read_meta failed: %s" e);
+      Alcotest.(check (option string))
+        "reconcile classifies Declarative_autoboot_disabled"
+        (Some "declarative_autoboot_disabled")
+        (Keeper_runtime.autoboot_exclusion_reason config name
+        |> Option.map Keeper_runtime.autoboot_exclusion_reason_to_string)
+
+let test_duplicate_rejected () =
+  with_ctx @@ fun ~base:_ ~config:_ ~ctx ->
+  let name = "noboot-dup" in
+  (match Persona_runtime.create_configured_only ctx (resolved_args name) with
+   | Error e -> Alcotest.failf "first create failed: %s" e
+   | Ok _ -> ());
+  match Persona_runtime.create_configured_only ctx (resolved_args name) with
+  | Ok _ -> Alcotest.fail "duplicate create must be an explicit error"
+  | Error e ->
+      Alcotest.(check bool)
+        "error names the existing config" true
+        (contains ~affix:"already exists" e)
+
+let test_autoboot_conflict_rejected () =
+  with_ctx @@ fun ~base ~config:_ ~ctx ->
+  let name = "noboot-conflict" in
+  match
+    Persona_runtime.create_configured_only ctx
+      (resolved_args ~extra:[ ("autoboot_enabled", `Bool true) ] name)
+  with
+  | Ok _ -> Alcotest.fail "autoboot_enabled=true must conflict with no_boot"
+  | Error e ->
+      Alcotest.(check bool)
+        "error explains the conflict" true
+        (contains ~affix:"autoboot_enabled=true" e);
+      let path =
+        Filename.concat
+          (Config_dir_resolver.keepers_dir_for_base_path ~base_path:base)
+          (name ^ ".toml")
+      in
+      Alcotest.(check bool) "no TOML written" false (Sys.file_exists path)
+
+let test_orphan_toml_removed_on_parse_failure () =
+  with_ctx @@ fun ~base ~config:_ ~ctx ->
+  let name = "noboot-orphan" in
+  (* [tool_access] passes the persist layer (it renders only known fields)
+     but is a removed input key for the keeper_up parser, so the failure
+     fires after the TOML write — exactly the orphan-compensation path. *)
+  match
+    Persona_runtime.create_configured_only ctx
+      (resolved_args ~extra:[ ("tool_access", `String "full") ] name)
+  with
+  | Ok _ -> Alcotest.fail "removed input key must fail the parse"
+  | Error _ ->
+      let path =
+        Filename.concat
+          (Config_dir_resolver.keepers_dir_for_base_path ~base_path:base)
+          (name ^ ".toml")
+      in
+      Alcotest.(check bool)
+        "freshly written TOML removed on failure" false
+        (Sys.file_exists path)
+
+let () =
+  Alcotest.run "keeper_create_no_boot"
+    [
+      ( "configured_only",
+        [
+          Alcotest.test_case
+            "create writes TOML+meta, no registry, autoboot excluded" `Quick
+            test_configured_only_create;
+          Alcotest.test_case "duplicate name is an explicit error" `Quick
+            test_duplicate_rejected;
+          Alcotest.test_case "autoboot_enabled=true conflicts" `Quick
+            test_autoboot_conflict_rejected;
+          Alcotest.test_case "orphan TOML removed on post-persist failure"
+            `Quick test_orphan_toml_removed_on_parse_failure;
+        ] );
+    ]

--- a/test/test_keeper_create_validate.ml
+++ b/test/test_keeper_create_validate.ml
@@ -49,6 +49,54 @@ let test_invalid_name_rejected () =
     "name error present" true
     (List.exists (contains ~affix:"invalid keeper name") errors)
 
+let string_list_field fields key =
+  match List.assoc_opt key fields with
+  | Some (`List xs) ->
+      List.filter_map (function `String s -> Some s | _ -> None) xs
+  | _ -> []
+
+let test_initial_goal_injection () =
+  (* D-10a transition: injection fills the legacy goal string, links the
+     minted goal id (dedup), and the result passes the validate gate. *)
+  let base =
+    `Assoc
+      [
+        ("name", `String "valid-name");
+        ("goal", `String "");
+        ("mention_targets", `List [ `String "valid-name" ]);
+        ("active_goal_ids", `List [ `String "goal-existing" ]);
+      ]
+  in
+  let injected =
+    Keeper_tool_persona_runtime.resolved_args_with_initial_goal
+      ~goal_text:"첫 목표" ~goal_id:"goal-new" base
+  in
+  (match injected with
+   | `Assoc fields ->
+       (match List.assoc_opt "goal" fields with
+        | Some (`String g) ->
+            Alcotest.(check string) "goal filled from initial_goal" "첫 목표" g
+        | _ -> Alcotest.fail "goal must be a string");
+       Alcotest.(check (list string))
+         "goal id linked after existing ids"
+         [ "goal-existing"; "goal-new" ]
+         (string_list_field fields "active_goal_ids")
+   | _ -> Alcotest.fail "injection must return an object");
+  Alcotest.(check (list string))
+    "injected args pass the gate" [] (validate injected);
+  (* Re-injecting the same id must not duplicate it. *)
+  let twice =
+    Keeper_tool_persona_runtime.resolved_args_with_initial_goal
+      ~goal_text:"첫 목표" ~goal_id:"goal-new" injected
+  in
+  match twice with
+  | `Assoc fields ->
+      Alcotest.(check (list string))
+        "goal id dedup on re-injection"
+        [ "goal-existing"; "goal-new" ]
+        (string_list_field fields "active_goal_ids")
+  | _ -> Alcotest.fail "injection must return an object"
+
 let () =
   Alcotest.run "keeper_create_validate"
     [
@@ -60,5 +108,11 @@ let () =
             test_complete_args_pass;
           Alcotest.test_case "invalid keeper name is rejected" `Quick
             test_invalid_name_rejected;
+        ] );
+      ( "initial_goal",
+        [
+          Alcotest.test_case
+            "injection fills goal, links id with dedup, passes gate" `Quick
+            test_initial_goal_injection;
         ] );
     ]

--- a/test/test_keeper_create_validate.ml
+++ b/test/test_keeper_create_validate.ml
@@ -97,6 +97,33 @@ let test_initial_goal_injection () =
         (string_list_field fields "active_goal_ids")
   | _ -> Alcotest.fail "injection must return an object"
 
+let test_pre_mint_shape_passes_gate () =
+  (* Orphan-Goal guard companion (PR #24364 re-review P1-1): the handler now
+     validates the goal_text-only injection BEFORE minting the Goal entity,
+     so the gate must accept that exact pre-mint shape — no goal id, no
+     active_goal_ids. If the gate ever starts requiring a minted id, the
+     validate-before-mint ordering breaks and this pins the regression. *)
+  let base =
+    `Assoc
+      [
+        ("name", `String "valid-name");
+        ("goal", `String "");
+        ("mention_targets", `List [ `String "valid-name" ]);
+      ]
+  in
+  let pre_mint =
+    Keeper_tool_persona_runtime.resolved_args_with_initial_goal
+      ~goal_text:"첫 목표" base
+  in
+  Alcotest.(check (list string))
+    "goal_text-only injection passes the gate" [] (validate pre_mint);
+  match pre_mint with
+  | `Assoc fields ->
+      Alcotest.(check (list string))
+        "no goal id linked before the mint" []
+        (string_list_field fields "active_goal_ids")
+  | _ -> Alcotest.fail "injection must return an object"
+
 let () =
   Alcotest.run "keeper_create_validate"
     [
@@ -114,5 +141,7 @@ let () =
           Alcotest.test_case
             "injection fills goal, links id with dedup, passes gate" `Quick
             test_initial_goal_injection;
+          Alcotest.test_case "pre-mint shape (goal_text only) passes gate"
+            `Quick test_pre_mint_shape_passes_gate;
         ] );
     ]

--- a/test/test_keeper_create_validate.ml
+++ b/test/test_keeper_create_validate.ml
@@ -1,0 +1,64 @@
+(** test_keeper_create_validate — [validate_resolved_keeper_create_json] is the
+    single pre-boot gate on the live [masc_keeper_create_from_persona] path
+    (wired for both [dry_run] previews and real creates). Pins the gate's
+    contract so the deletion of the unreachable Keeper_persona duplicate
+    cannot silently drop validation. *)
+
+open Masc
+
+(* Minimal substring check, stdlib-only. *)
+let contains ~affix s =
+  let n = String.length affix and m = String.length s in
+  let rec go i = i + n <= m && (String.sub s i n = affix || go (i + 1)) in
+  n = 0 || go 0
+
+let validate = Keeper_tool_persona_runtime.validate_resolved_keeper_create_json
+
+let test_missing_goal_and_mentions () =
+  let errors = validate (`Assoc [ ("name", `String "valid-name") ]) in
+  Alcotest.(check bool)
+    "goal error present" true
+    (List.exists (contains ~affix:"goal is required") errors);
+  Alcotest.(check bool)
+    "mention_targets error present" true
+    (List.exists (contains ~affix:"mention_targets is required") errors)
+
+let test_complete_args_pass () =
+  let errors =
+    validate
+      (`Assoc
+         [
+           ("name", `String "valid-name");
+           ("goal", `String "do the thing");
+           ("mention_targets", `List [ `String "valid-name" ]);
+         ])
+  in
+  Alcotest.(check (list string)) "no errors" [] errors
+
+let test_invalid_name_rejected () =
+  let errors =
+    validate
+      (`Assoc
+         [
+           ("name", `String "bad name/with sep");
+           ("goal", `String "g");
+           ("mention_targets", `List [ `String "x" ]);
+         ])
+  in
+  Alcotest.(check bool)
+    "name error present" true
+    (List.exists (contains ~affix:"invalid keeper name") errors)
+
+let () =
+  Alcotest.run "keeper_create_validate"
+    [
+      ( "gate",
+        [
+          Alcotest.test_case "missing goal and mention_targets are rejected"
+            `Quick test_missing_goal_and_mentions;
+          Alcotest.test_case "complete resolved args pass" `Quick
+            test_complete_args_pass;
+          Alcotest.test_case "invalid keeper name is rejected" `Quick
+            test_invalid_name_rejected;
+        ] );
+    ]


### PR DESCRIPTION
## 목적
blueprint A5(create-without-boot)의 선행 리팩토링 — `create_keeper`에 인라인된 91줄 initial `keeper_meta` 레코드를 **순수 함수**로 추출한다. 부팅 없는 생성 경로가 레코드를 복제하지 않고 동일한 초기 메타를 만들 수 있게 하는 기반.

설계 SSOT: `~/me/planning/claude-plans/2026-07-13-persona-registry-v2-blueprint.md` §A5-1 (WO-A5-1a/1b)

## 변경
- 신규 `lib/keeper/keeper_meta_build.ml(.mli)`: `initial_meta` — I/O 없음, config 읽기 없음, mutation 없음. 비결정 입력 5종(clock `created_at`/`now_ts`, `keeper_uid`, `generation`, `trace_id`, config-resolved `compaction_mode`)을 전부 호출자 주입으로 역전.
- `keeper_turn_up_create.ml`: 인라인 레코드(:254-344)를 호출로 교체.
- 의도적 delta 1건: `created_at`/`updated_at`이 **단일 clock 값 공유** — 기존엔 `now_iso ()` 2회 호출이라 초 경계에서 어긋날 수 있었음. "갓 생성된 meta는 수정된 적 없다"를 값으로 표현.

## 검증
- `dune build --root .` green (warn-error+a)
- 변경/신규 파일 `@fmt` clean
- create 경로 참조 테스트 3종 실행: `test_schedule_consumer_dispatch` 8/8 · `test_dashboard_namespace_truth` 12/12 · `test_server_runtime_bootstrap` 75/77 — **실패 2건(health json zombie/dead-keeper)은 main(ac26d9d28f)에서 동일 재현되는 pre-existing** (본 diff와 무관 실측 대조)
- 필드 정합은 exhaustive record로 컴파일러 강제 (누락 시 컴파일 에러)

## 미검증/참고
- CI Build and Test는 main-red 상속 예정 (#24363 — contract harness GP1, 본 diff 무관)

RFC-WAIVED: 순수 리팩토링(동작 보존) — credential/operator/hooks 등 RFC 의무 subsystem 비접촉, 설계 SSOT는 blueprint A5-1에 존재

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## 2nd commit — A5-2a(배선)/2b/2c: 단일 검증 게이트

- **dead code 숙청(A5-2b)**: `Keeper_persona.handle_keeper_create_from_persona` 삭제 — dispatch는 surface_ops판만 라우팅함을 Read로 검증(스크러버 마스킹 회피). 죽은 복제본의 validate가 커버리지 착시를 만들고 있었음.
- **검증 배선(A5-2a의 배선 절반)**: `validate_resolved_keeper_create_json`을 라이브 경로 생성·dry_run **공통** 호출로 승격 — dry_run은 `ready`/`errors` 프리뷰 반환(A5-2c), 실생성은 boot side-effect 전에 동일 구조 payload로 거부. boot 경로의 goal 게이트는 최후 방어선으로 유지.
- **계약 고정**: `test_keeper_create_validate` 신규 3/3 (goal 필수 / mention_targets 필수 / name charset).
- D-10a 의미 교체(goal 문자열→initial Goal 엔티티)는 이 게이트 위에 별도 landing.
- 검증: 빌드 green, 신규 테스트 3/3, 내 파일 fmt clean(test/dune include-stanza fmt drift는 main 동일 재현되는 기존 것).


## 3rd commit — A5-2a 잔여(D-10a): initial_goal → Goal 엔티티 mint

- **상호배타(명시 거부)**: `goal`과 `initial_goal` 동시 전달 시 에러 반환 — silent precedence 없음. 유일한 keeper 자유텍스트는 `instructions`(D-10 확정), 목표는 Goal 엔티티가 SSOT.
- **순수 주입 헬퍼**: `resolved_args_with_initial_goal`(runtime, pure) — legacy `goal` 문자열 충전 + mint된 goal id를 `active_goal_ids`에 링크(중복 없음). Goal_store 효과는 핸들러 경계에만 존재(경계 지도 준수).
- **dry_run은 무효과**: mint 없이 주입 결과만 프리뷰. 실생성만 `Goal_store.upsert_goal`로 mint 후 id 링크, 응답에 `initial_goal` 필드 포함.
- **transition = expand 단계**: legacy goal 문자열 dual-write로 boot 게이트/프롬프트/대시보드 무중단 — 해체(contract)는 A2에서 (removal target WO-A2-2f).
- **검증(실측)**:
  - CI(head `def965475c`): Build 스텝 green(정합 opam 환경에서 전체 컴파일 통과). 실패는 base 상속 2층뿐 — `Env knob catalog drift gate`(#24281 트랙, 개별 PR에서 고치지 않는 규율)와 `Run contract harness suite`(#24363, `anti_rationalization.output_schema` × `127.0.0.1:9/v1`). **주의: drift gate 실패로 `Run tests (quick suite)` 스텝이 skipped** — base green 후 재실행 필요.
  - 로컬 실행: 공유 opam switch가 병렬 codex 세션의 oas WIP 브랜치(eed7ce6f, `stream-idle-opt-in`)에 pin되어 `runtime_agent.ml`이 링크 불가 → **미커밋 일시 스캐폴드**(해당 라벨 1곳 제거)로 test exe 빌드 후 `test_keeper_create_validate` **4/4 green**(gate 3 + initial_goal 주입·dedup·게이트 통과). 스캐폴드 즉시 원복, working tree clean 확인. switch 비접촉 유지.



## 4th commit — 적대 재리뷰 대응 (75219c0e, rebase onto main 6f11b23f)

- **P1-1 (orphan Goal) 수정**: 주입(goal_text, 순수·멱등)→validate→**통과 후에만 mint**로 재배열. 검증 거부 분기에서 mint 자체가 일어나지 않음. mint 이후 분기 보상: TOML render 실패=무조건 release(boot 전이라 참조 불가), boot 실패=keeper meta 미잔존 시에만 release(잔존 meta의 `active_goal_ids` dangling 방지, 유지 시 goal id 포함 WARN). 테스트: `test_keeper_create_mint_order`(구조 가드 2: validate-before-mint 순서 + 보상 존재, `test_keeper_supervisor_write_meta_source` 선례) + `test_keeper_create_validate`에 pre-mint shape(goal_text only) 게이트 통과 계약 1 — 5/5 green.
- **P1-2 (reconcile 스냅샷 회귀) — 알려진 제약 명시**: initial_goal이 keeper TOML `goal =`에 구워지고 reconcile sweep이 'TOML 우선'을 주기 재적용하므로, 운영자가 goal_transition/config panel로 목표를 바꿔도 다음 sweep에 생성 시점 값으로 회귀할 수 있다. 근본 함정은 pre-existing이며 **#24375 (TOML goal sweep 덮어쓰기)**에서 추적한다. 본 PR은 그 함정으로의 신규 진입면(initial_goal bake)을 만드는 것이 맞고, A2(goal 문자열 필드 해체, removal target WO-A2-2f)가 bake 자체를 제거할 때 닫힌다.
- **rebase**: main 6f11b23f(#24362 env knob catalog drift 해소) 기반으로 재배열 — drift gate로 skip되던 quick suite가 이번 head에서 실제 실행된다. 로컬 링크 불가(oas pin drift)도 main #24370 상속으로 해소되어 스캐폴드 없이 실빌드/실테스트로 검증했다.
