### PR TITLE
feat(keeper): create-without-boot (no_boot) on masc_keeper_create_from_persona (A5-3)

### DIFF
--- a/dashboard/src/components/dashboard-shell-tab-surface.test.ts
+++ b/dashboard/src/components/dashboard-shell-tab-surface.test.ts
@@ -1,0 +1,34 @@
+// Tab → content contract (WO-A4-3b). TAB_SURFACE is a Record<TabId, …>, so
+// deleting a key is a COMPILE error — that is the primary mutation guard.
+// This runtime walk pins the remaining holes the type system cannot see:
+// every routable tab must resolve to a defined surface with a non-empty
+// fallback label, and no non-overview tab may alias the Overview component
+// (the pre-refactor switch's default arm silently did exactly that).
+
+import { describe, expect, it } from 'vitest'
+import { VALID_TABS } from './../types'
+import { TAB_SURFACE } from './dashboard-shell'
+
+describe('TAB_SURFACE contract', () => {
+  it('resolves every VALID_TABS entry to a dedicated surface', () => {
+    for (const tab of VALID_TABS) {
+      const surface = TAB_SURFACE[tab]
+      expect(surface, `missing surface for tab ${tab}`).toBeDefined()
+      expect(surface.label.length, `empty label for tab ${tab}`).toBeGreaterThan(0)
+      expect(surface.Component, `missing component for tab ${tab}`).toBeTypeOf('function')
+    }
+  })
+
+  it('never renders the Overview fallback for a non-overview tab', () => {
+    const overview = TAB_SURFACE.overview.Component
+    for (const tab of VALID_TABS) {
+      if (tab === 'overview') continue
+      expect(TAB_SURFACE[tab].Component, `tab ${tab} aliases Overview`).not.toBe(overview)
+    }
+  })
+
+  it('gives every tab its own component (no accidental aliasing)', () => {
+    const components = VALID_TABS.map(tab => TAB_SURFACE[tab].Component)
+    expect(new Set(components).size).toBe(VALID_TABS.length)
+  })
+})

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -1,6 +1,7 @@
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { lazy, Suspense } from 'preact/compat'
+import type { ComponentType } from 'preact'
 import { useEffect, useMemo } from 'preact/hooks'
 import type { GroundedVerdict, RouteState, TabId } from '../types'
 import type { DashboardCdalHealth, DashboardFleetSafetyHealth, DashboardKeeperReactionLedgerHealth, DashboardRuntimeResolution, Keeper } from '../types'
@@ -80,6 +81,7 @@ const LazyIdeShell = lazy(async () => ({ default: (await import('./ide/ide-shell
 const LazyCockpit = lazy(async () => ({ default: (await import('./cockpit/cockpit')).Cockpit }))
 const LazySettingsSurface = lazy(async () => ({ default: (await import('./settings-surface')).SettingsSurface }))
 const LazyApprovals = lazy(async () => ({ default: (await import('./approvals/approvals-surface')).ApprovalsSurface }))
+const LazyRegistrySurface = lazy(async () => ({ default: (await import('./registry/registry-surface')).RegistrySurface }))
 const LazyFusionSurface = lazy(async () => ({ default: (await import('./fusion/fusion-surface')).FusionSurface }))
 
 function lazyTabFallback(label: string) {
@@ -1208,107 +1210,39 @@ export function SideRail({
   `
 }
 
-function TabContent() {
-  const tab = route.value.tab
+// One dedicated surface per tab (WO-A4-3b). The Record is exhaustive over
+// TabId, so a new tab without a surface fails to compile HERE instead of
+// silently bouncing to Overview — the previous switch's default arm did
+// exactly that for any missed case. Exported for the tab→content contract
+// test.
+export const TAB_SURFACE: Readonly<
+  Record<TabId, { readonly label: string; readonly Component: ComponentType }>
+> = {
+  overview: { label: 'Overview', Component: LazyOverview },
+  monitoring: { label: 'Monitor', Component: LazyStatus },
+  keepers: { label: 'Keepers', Component: LazyKeeperDetailPage },
+  registry: { label: 'Registry', Component: LazyRegistrySurface },
+  board: { label: 'Board', Component: LazyBoardSurface },
+  schedule: { label: 'Schedule', Component: LazyScheduleSurface },
+  approvals: { label: 'Approvals', Component: LazyApprovals },
+  fusion: { label: 'Fusion', Component: LazyFusionSurface },
+  workspace: { label: 'Work', Component: LazyWork },
+  command: { label: 'Command', Component: LazyOperations },
+  connectors: { label: 'Connectors', Component: LazyConnectors },
+  lab: { label: 'Lab', Component: LazyLabSurface },
+  cockpit: { label: 'Cockpit', Component: LazyCockpit },
+  code: { label: 'Code IDE', Component: LazyIdeShell },
+  logs: { label: 'System Logs', Component: LazyLogViewer },
+  settings: { label: 'Settings', Component: LazySettingsSurface },
+}
 
-  switch (tab) {
-    case 'overview':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Overview')}>
-          <${LazyOverview} />
-        <//>
-      `
-    case 'monitoring':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Monitor')}>
-          <${LazyStatus} />
-        <//>
-      `
-    case 'keepers':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Keepers')}>
-          <${LazyKeeperDetailPage} />
-        <//>
-      `
-    case 'board':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Board')}>
-          <${LazyBoardSurface} />
-        <//>
-      `
-    case 'schedule':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Schedule')}>
-          <${LazyScheduleSurface} />
-        <//>
-      `
-    case 'approvals':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Approvals')}>
-          <${LazyApprovals} />
-        <//>
-      `
-    case 'fusion':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Fusion')}>
-          <${LazyFusionSurface} />
-        <//>
-      `
-    case 'workspace':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Work')}>
-          <${LazyWork} />
-        <//>
-      `
-    case 'command':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Command')}>
-          <${LazyOperations} />
-        <//>
-      `
-    case 'connectors':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Connectors')}>
-          <${LazyConnectors} />
-        <//>
-      `
-    case 'lab':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Lab')}>
-          <${LazyLabSurface} />
-        <//>
-      `
-    case 'cockpit':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Cockpit')}>
-          <${LazyCockpit} />
-        <//>
-      `
-    case 'code':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Code IDE')}>
-          <${LazyIdeShell} />
-        <//>
-      `
-    case 'logs':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('System Logs')}>
-          <${LazyLogViewer} />
-        <//>
-      `
-    case 'settings':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Settings')}>
-          <${LazySettingsSurface} />
-        <//>
-      `
-    default:
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Overview')}>
-          <${LazyOverview} />
-        <//>
-      `
-  }
+function TabContent() {
+  const { label, Component } = TAB_SURFACE[route.value.tab]
+  return html`
+    <${Suspense} fallback=${lazyTabFallback(label)}>
+      <${Component} />
+    <//>
+  `
 }
 
 /** Pure: build the shareable URL for the current section. Uses

--- a/dashboard/src/components/registry/registry-surface.test.ts
+++ b/dashboard/src/components/registry/registry-surface.test.ts
@@ -1,0 +1,71 @@
+// Registry surface — pure helper contracts (A4 skeleton).
+// normalizeRegistryPersonas must accept both masc_persona_list payload
+// shapes (detailed summaries and bare name strings), and must distinguish
+// a schema mismatch (null — surfaced as an error) from a genuinely empty
+// roster ([]); keeperGroup is a projection of live signals, not a new
+// state machine.
+
+import { describe, expect, it } from 'vitest'
+import type { Keeper } from '../../types'
+import { keeperGroup, normalizeRegistryPersonas } from './registry-surface'
+
+const keeper = (overrides: Partial<Keeper>): Keeper =>
+  ({ name: 'k', status: 'idle', ...overrides }) as Keeper
+
+describe('normalizeRegistryPersonas', () => {
+  it('normalizes detailed persona summaries', () => {
+    const payload = {
+      count: 1,
+      personas: [{
+        persona_name: 'sonsukku',
+        display_name: '손석구',
+        trait: '집요함',
+        has_keeper_defaults: true,
+        profile_path: '/x/profile.json',
+      }],
+    }
+    expect(normalizeRegistryPersonas(payload)).toEqual([{
+      persona_name: 'sonsukku',
+      display_name: '손석구',
+      trait: '집요함',
+      has_keeper_defaults: true,
+    }])
+  })
+
+  it('normalizes the bare-name payload shape', () => {
+    const payload = { count: 2, personas: ['a', 'b'] }
+    expect(normalizeRegistryPersonas(payload)?.map(p => p.persona_name)).toEqual(['a', 'b'])
+  })
+
+  it('returns null for schema mismatches (not a fake empty roster)', () => {
+    expect(normalizeRegistryPersonas(42)).toBeNull()
+    expect(normalizeRegistryPersonas(null)).toBeNull()
+    expect(normalizeRegistryPersonas({ personas: 'nope' })).toBeNull()
+  })
+
+  it('skips junk entries but keeps the rest', () => {
+    const payload = { personas: [{ display_name: 'no-name' }, 'ok'] }
+    expect(normalizeRegistryPersonas(payload)).toEqual([
+      { persona_name: 'ok', display_name: 'ok', trait: null, has_keeper_defaults: false },
+    ])
+  })
+
+  it('distinguishes an empty roster from a mismatch', () => {
+    expect(normalizeRegistryPersonas({ count: 0, personas: [] })).toEqual([])
+  })
+})
+
+describe('keeperGroup', () => {
+  it('groups paused keepers as pause even when the fiber is alive', () => {
+    expect(keeperGroup(keeper({ paused: true, keepalive_running: true }))).toBe('pause')
+  })
+
+  it('groups live keepalive fibers as run', () => {
+    expect(keeperGroup(keeper({ keepalive_running: true }))).toBe('run')
+  })
+
+  it('groups configured-only and stopped keepers as off', () => {
+    expect(keeperGroup(keeper({ registered: false }))).toBe('off')
+    expect(keeperGroup(keeper({ keepalive_running: false }))).toBe('off')
+  })
+})

--- a/dashboard/src/components/registry/registry-surface.ts
+++ b/dashboard/src/components/registry/registry-surface.ts
@@ -1,0 +1,203 @@
+// MASC v2 — Registry surface (A4 skeleton).
+// The operator's home for the three layers of a keeper's being:
+//   이데아 (Persona · 형상) → 실재 (Keeper · 인스턴스) → 런타임 (Runtime · 바인딩)
+// A persona is a SEED: its text is copied into a keeper at instantiation, then
+// the two are independent — editing a persona never reaches back into a live
+// keeper (server-side persona overlay retirement is tracked separately, A2).
+//
+// Skeleton scope (WO-A4-1/2a first slice): read-only three-layer roster.
+//   · personas — fetched on mount via masc_persona_list (no refresh-task lane).
+//     Name/display/description parsing is delegated to keeper-spawn-state's
+//     normalizePersonaSummary (the SSOT for the masc_persona_list entry
+//     shape, shared by 15+ spawn-panel consumers) — see
+//     normalizeRegistryPersonas below for what Registry adds on top and why.
+//   · keepers  — the store `keepers` signal, hydrated by the execution
+//     snapshot (tab-refresh plan + dashboard-ws execution slice subscription)
+//   · runtime  — each keeper row shows its runtime binding when known
+// Create/edit/deregister dialogs land with the full keeper-v2 registry port.
+
+import { html } from 'htm/preact'
+import { useEffect, useMemo } from 'preact/hooks'
+import type { Keeper } from '../../types'
+import { callMcpTool } from '../../api/mcp'
+import { keepers } from '../../store'
+import { isRecord } from '../common/normalize'
+import { createAsyncResource, isFailed, getData } from '../../lib/async-state'
+import { normalizePersonaSummary } from '../keeper-spawn/keeper-spawn-state'
+import { KeeperBadge } from '../keeper-badge'
+import { Dot, Pill, type DotState } from '../v2/primitives-v2'
+
+export interface RegistryPersona {
+  persona_name: string
+  display_name: string
+  trait: string | null
+  has_keeper_defaults: boolean
+}
+
+// masc_persona_list returns { count, personas } where each entry is either a
+// detailed summary object or (only when called with detailed:false, which no
+// dashboard caller does today) a bare name string.
+//
+// Name/display/description parsing is delegated to normalizePersonaSummary
+// (keeper-spawn-state.ts) — the shared pipeline 15+ spawn-panel consumers
+// already rely on — so there is exactly one place that knows the
+// persona_name/name and display_name/displayName/name fallback rules; this
+// function no longer re-derives them. Registry adds only the two things that
+// shared pipeline doesn't provide:
+//
+// 1. has_keeper_defaults. It's on the wire in every masc_persona_list
+//    response (see keeper_tool_persona_runtime.ml:persona_summary_to_json —
+//    always included, unconditional on `detailed`), but PersonaSummary
+//    doesn't carry it. Extending PersonaSummary would be the cleaner fix;
+//    it's deferred here specifically to avoid touching keeper-spawn-state.ts
+//    while #24340 is rewriting that file (cross-conflict risk) — NOT because
+//    of a real fetch-shape difference. masc_persona_list defaults `detailed`
+//    to true server-side (keeper_persona.ml:persona_list_handler), so
+//    keeper-spawn-state's `{}` call and Registry's explicit
+//    `{ detailed: true }` call below already hit the identical response
+//    shape; an earlier version of this comment claimed otherwise and was
+//    wrong.
+// 2. Distinguishing a schema mismatch (null, surfaced as an error) from a
+//    genuinely empty roster ([]). normalizePersonaSummaries always returns
+//    [] (extractArray swallows a non-array/absent `personas` into []), so
+//    that distinction has to live here — it is not something the shared
+//    pipeline's "error channel" resolves for us.
+export function normalizeRegistryPersonas(json: unknown): RegistryPersona[] | null {
+  if (!isRecord(json) || !Array.isArray(json.personas)) return null
+  return json.personas.flatMap((entry): RegistryPersona[] => {
+    if (typeof entry === 'string') {
+      return [{ persona_name: entry, display_name: entry, trait: null, has_keeper_defaults: false }]
+    }
+    const summary = normalizePersonaSummary(entry)
+    if (!summary) return []
+    return [{
+      persona_name: summary.name,
+      display_name: summary.displayName ?? summary.name,
+      trait: summary.description ?? null,
+      has_keeper_defaults: isRecord(entry) && entry.has_keeper_defaults === true,
+    }]
+  })
+}
+
+// Registry keeps its own resource rather than importing keeper-spawn-state's
+// personas/personasLoading/personasError signals directly: those signals are
+// PersonaSummary[], which carries neither has_keeper_defaults nor the
+// null-vs-[] distinction above, and widening that shared type touches the
+// same file #24340 is mid-rewrite on. One extra fetch of an already-cheap
+// read_state tool is the accepted cost of not touching that file now; full
+// unification (single resource, single fetch) is tracked for when the
+// registry wizard replaces the spawn panel (A4-3a, after #24340 lands).
+export const registryPersonas = createAsyncResource<RegistryPersona[]>()
+
+export async function loadRegistryPersonas(): Promise<void> {
+  await registryPersonas.load(async () => {
+    const raw = await callMcpTool('masc_persona_list', { detailed: true })
+    const parsed = normalizeRegistryPersonas(JSON.parse(raw))
+    if (parsed === null) throw new Error('masc_persona_list: unexpected response shape')
+    return parsed
+  })
+}
+
+type KeeperGroupId = 'run' | 'pause' | 'off'
+
+const KEEPER_GROUPS: ReadonlyArray<readonly [KeeperGroupId, string]> = [
+  ['run', '실행 중'],
+  ['pause', '대기 · 일시정지'],
+  ['off', '중지 · 미기동'],
+]
+
+// Grouping is a projection of live signals, not a new state machine: a keeper
+// with a running keepalive fiber is 'run', a paused-but-registered one is
+// 'pause', everything else (configured-only, dead, unregistered) is 'off'.
+export function keeperGroup(k: Keeper): KeeperGroupId {
+  if (k.paused === true) return 'pause'
+  if (k.keepalive_running === true) return 'run'
+  return 'off'
+}
+
+function groupDot(group: KeeperGroupId): DotState {
+  switch (group) {
+    case 'run':
+      return 'ok'
+    case 'pause':
+      return 'warn'
+    case 'off':
+      return 'idle'
+  }
+}
+
+export function RegistrySurface() {
+  useEffect(() => {
+    void loadRegistryPersonas()
+  }, [])
+
+  const personaState = registryPersonas.state.value
+  const personas = getData(personaState) ?? null
+  const personaError = isFailed(personaState) ? personaState.message : null
+
+  const roster = keepers.value
+  const grouped = useMemo(() => {
+    const map: Record<KeeperGroupId, Keeper[]> = { run: [], pause: [], off: [] }
+    for (const k of roster) map[keeperGroup(k)].push(k)
+    return map
+  }, [roster])
+
+  return html`
+    <section class="reg-surface" style="padding:16px;display:flex;flex-direction:column;gap:20px;">
+      <header>
+        <h2 style="margin:0;">Registry</h2>
+        <p style="margin:4px 0 0;opacity:.7;">이데아(Persona) → 실재(Keeper) → 런타임 바인딩</p>
+      </header>
+
+      <div class="reg-layer reg-personas">
+        <h3 style="margin:0 0 8px;">이데아 · Persona <${Pill} tone="info">${personas?.length ?? '…'}<//></h3>
+        ${personaError
+          ? html`<p class="reg-error" style="color:var(--color-bad,#e5534b);">persona 목록 로드 실패: ${personaError}</p>`
+          : personas === null
+            ? html`<p style="opacity:.6;">불러오는 중…</p>`
+            : personas.length === 0
+              ? html`<p style="opacity:.6;">등록된 persona가 없습니다.</p>`
+              : html`
+                  <ul style="list-style:none;margin:0;padding:0;display:flex;flex-wrap:wrap;gap:8px;">
+                    ${personas.map(p => html`
+                      <li key=${p.persona_name} class="reg-persona-card"
+                          style="border:1px solid var(--color-border,#333);border-radius:8px;padding:8px 12px;">
+                        <strong>${p.display_name}</strong>
+                        ${p.trait ? html`<span style="opacity:.7;"> · ${p.trait}</span>` : null}
+                        ${p.has_keeper_defaults ? html` <${Pill} tone="neutral">keeper.*<//>` : null}
+                      </li>
+                    `)}
+                  </ul>
+                `}
+      </div>
+
+      <div class="reg-layer reg-keepers">
+        <h3 style="margin:0 0 8px;">실재 · Keeper <${Pill} tone="info">${roster.length}<//></h3>
+        ${KEEPER_GROUPS.map(([group, label]) => html`
+          <div key=${group} class="reg-kgroup" style="margin-bottom:12px;">
+            <h4 style="margin:0 0 6px;display:flex;align-items:center;gap:6px;">
+              <${Dot} state=${groupDot(group)} /> ${label}
+              <span style="opacity:.6;">${grouped[group].length}</span>
+            </h4>
+            ${grouped[group].length === 0
+              ? html`<p style="margin:0;opacity:.5;">없음</p>`
+              : html`
+                  <ul style="list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:4px;">
+                    ${grouped[group].map(k => html`
+                      <li key=${k.name} class="reg-keeper-row"
+                          style="display:flex;align-items:center;gap:8px;">
+                        <${KeeperBadge} id=${k.name} variant="full" size="sm" />
+                        <span style="opacity:.7;font-size:12px;">
+                          ${k.runtime_id ?? k.runtime_canonical ?? '런타임 미바인딩'}
+                        </span>
+                        ${k.registered === false ? html`<${Pill} tone="neutral">configured<//>` : null}
+                      </li>
+                    `)}
+                  </ul>
+                `}
+          </div>
+        `)}
+      </div>
+    </section>
+  `
+}

--- a/dashboard/src/components/surface-icon.ts
+++ b/dashboard/src/components/surface-icon.ts
@@ -7,6 +7,7 @@ import {
   FlaskConical,
   Gauge,
   Home,
+  Layers,
   Plug,
   ScrollText,
   Settings,
@@ -31,6 +32,8 @@ export function SurfaceIcon({ icon, size = 16 }: SurfaceIconProps) {
       return html`<${Activity} ...${props} />`
     case 'keepers':
       return html`<${UsersRound} ...${props} />`
+    case 'registry':
+      return html`<${Layers} ...${props} />`
     case 'board':
       return html`<${SquareKanban} ...${props} />`
     case 'schedule':

--- a/dashboard/src/components/v2/icons-v2.ts
+++ b/dashboard/src/components/v2/icons-v2.ts
@@ -6,9 +6,29 @@ import type { VNode } from 'preact'
 
 type Icon = VNode
 
-export const ICONS: Readonly<Record<string, Icon>> = {
+// Closed key union (WO-A4-3c): with Record<string, Icon> a typo'd icon key
+// compiled fine and rendered undefined silently; the union turns that into
+// a compile error at every ICONS[...] index and NavEntry.icon literal.
+export type IconKey =
+  | 'grid'
+  | 'users'
+  | 'layers'
+  | 'board'
+  | 'term'
+  | 'code'
+  | 'plug'
+  | 'gear'
+  | 'shield'
+  | 'target'
+  | 'monitor'
+  | 'logs'
+  | 'fusion'
+  | 'clock'
+
+export const ICONS: Readonly<Record<IconKey, Icon>> = {
   grid: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><rect x="3" y="3" width="7" height="7" rx="1.4" /><rect x="14" y="3" width="7" height="7" rx="1.4" /><rect x="3" y="14" width="7" height="7" rx="1.4" /><rect x="14" y="14" width="7" height="7" rx="1.4" /></svg>`,
   users: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="8" r="3.2" /><path d="M3.5 19c0-3 2.6-5 5.5-5s5.5 2 5.5 5" /><path d="M16.5 6.2a3 3 0 0 1 0 5.6" /><path d="M18.5 19c0-2-.8-3.6-2-4.6" /></svg>`,
+  layers: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l9 5-9 5-9-5z" /><path d="M3 13l9 5 9-5" /><path d="M3 17.5l9 5 9-5" /></svg>`,
   board: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linejoin="round"><rect x="3" y="4" width="5" height="16" rx="1.2" /><rect x="10" y="4" width="5" height="11" rx="1.2" /><rect x="17" y="4" width="4" height="14" rx="1.2" /></svg>`,
   term: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="16" rx="2.2" /><path d="M7 9l3 3-3 3" /><path d="M13 15h4" /></svg>`,
   code: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M8 6l-5 6 5 6" /><path d="M16 6l5 6-5 6" /><path d="M13.5 4l-3 16" /></svg>`,

--- a/dashboard/src/components/v2/nav-rail-v2.test.ts
+++ b/dashboard/src/components/v2/nav-rail-v2.test.ts
@@ -40,8 +40,9 @@ describe('NavRailV2 schedule item', () => {
     expect(scheduleNavItem(container)?.querySelector('.nav-badge')).toBeNull()
   })
 
-  // Rail order + group breaks mirror the 2026-07 keeper-v2 standalone export.
-  it('renders the v2 export rail order with Monitor after Keepers', () => {
+  // Rail order + group breaks mirror the 2026-07 keeper-v2 standalone export,
+  // plus the Registry surface (A4) inserted after Keepers in the same group.
+  it('renders the v2 export rail order with Registry between Keepers and Monitor', () => {
     render(html`<${NavRailV2} />`, container)
 
     const rail = container.querySelector('.v2-nav')
@@ -54,7 +55,7 @@ describe('NavRailV2 schedule item', () => {
     expect(walk).toEqual([
       'brand',
       '개요', '|',
-      'Keepers', 'Monitor', '|',
+      'Keepers', '레지스트리', 'Monitor', '|',
       '작업', '승인', '예약', '|',
       '보드', 'Fusion', '로그', '|',
       'IDE', '커넥터',

--- a/dashboard/src/components/v2/nav-rail-v2.ts
+++ b/dashboard/src/components/v2/nav-rail-v2.ts
@@ -25,6 +25,7 @@ const SURFACES: readonly NavEntry[] = [
   { tab: 'overview', label: '개요', icon: 'grid' },
   'sep',
   { tab: 'keepers', label: 'Keepers', icon: 'users' },
+  { tab: 'registry', label: '레지스트리', icon: 'layers' },
   { tab: 'monitoring', label: 'Monitor', icon: 'monitor' },
   'sep',
   { tab: 'workspace', label: '작업', icon: 'target' },

--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -60,10 +60,13 @@ describe('dashboard surface navigation', () => {
     expect(workspace?.defaultTab).toBe('workspace')
   })
 
-  it('keeps the v2 primary shell aligned to the 2026-07 keeper-v2 export rail order', () => {
+  // 2026-07 keeper-v2 export rail order, plus the Registry surface (A4)
+  // inserted after Keepers in the same group.
+  it('keeps the v2 primary shell aligned to the export rail order with Registry after Keepers', () => {
     expect(PRIMARY_DASHBOARD_SURFACES.map(surface => surface.id)).toEqual([
       'overview',
       'keepers',
+      'registry',
       'monitoring',
       'workspace',
       'approvals',
@@ -78,6 +81,7 @@ describe('dashboard surface navigation', () => {
     expect(PRIMARY_DASHBOARD_NAV_ITEMS.map(item => item.label)).toEqual([
       'Overview',
       'Keepers',
+      'Registry',
       'Monitor',
       'Work',
       'Gate',
@@ -92,7 +96,7 @@ describe('dashboard surface navigation', () => {
   })
 
   it('uses one sectionless-surface classifier for section stripping and section lookup', () => {
-    const sectionless = ['overview', 'logs', 'settings', 'keepers', 'board', 'schedule', 'approvals', 'fusion'] as const
+    const sectionless = ['overview', 'logs', 'settings', 'keepers', 'registry', 'board', 'schedule', 'approvals', 'fusion'] as const
     expect(sectionless.filter(id => isSectionlessSurface(id))).toEqual([...sectionless])
     expect(sectionItemsForTab('settings')).toEqual([])
     expect(normalizeRouteParams('settings', { section: 'legacy', surface: 'old', panel: 'theme' })).toEqual({

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -35,6 +35,7 @@ export type DashboardSurfaceIcon =
   | 'overview'
   | 'monitoring'
   | 'keepers'
+  | 'registry'
   | 'board'
   | 'schedule'
   | 'fusion'
@@ -120,6 +121,7 @@ export interface DashboardSectionNavItem {
 const V2_PRIMARY_SURFACE_IDS: ReadonlyArray<SurfaceId> = [
   'overview',
   'keepers',
+  'registry',
   'monitoring',
   'workspace',
   'approvals',
@@ -141,6 +143,7 @@ const SECTIONLESS_SURFACE_IDS: ReadonlySet<TabId> = new Set([
   'logs',
   'settings',
   'keepers',
+  'registry',
   'board',
   'schedule',
   'approvals',
@@ -186,6 +189,14 @@ export const DASHBOARD_SURFACES: DashboardNavGroup[] = [
     description: 'Dedicated keeper roster, conversation, and context workspace',
     defaultTab: 'keepers',
     tabs: ['keepers'],
+  },
+  {
+    id: 'registry',
+    label: 'Registry',
+    icon: 'registry',
+    description: 'Persona forms, keeper instances, and runtime bindings',
+    defaultTab: 'registry',
+    tabs: ['registry'],
   },
   {
     id: 'board',
@@ -312,6 +323,7 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
   // key — the Record is exhaustive over the union, so the empty entry is required.
   approvals: [],
   fusion: [],
+  registry: [],
   monitoring: [
     {
       id: 'agents',

--- a/dashboard/src/dashboard-ws.test.ts
+++ b/dashboard/src/dashboard-ws.test.ts
@@ -262,6 +262,11 @@ describe('dashboardSlicesForRoute', () => {
     ])
   })
 
+  it('subscribes the execution slice on the registry route (keepers hydrate only from the execution snapshot)', () => {
+    expect(dashboardSlicesForRoute({ tab: 'registry', params: {} }))
+      .toContain('execution')
+  })
+
   it('subscribes execution for execution-heavy monitoring and planning routes', () => {
     expect(dashboardSlicesForRoute({ tab: 'workspace', params: { section: 'planning' } }))
       .toContain('execution')

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -403,6 +403,12 @@ export function dashboardSlicesForRoute(routeState: DashboardRouteState): string
     slices.add('execution')
     slices.add('composite')
   }
+  // Registry keeper cards hydrate exclusively from the execution snapshot
+  // (store.hydrateExecutionSnapshot is the only keepers-signal writer on
+  // this route), so the slice subscription is what keeps roster rows live.
+  if (routeState.tab === 'registry') {
+    slices.add('execution')
+  }
   if (routeState.tab === 'board') {
     return Array.from(slices).sort()
   }

--- a/dashboard/src/tab-refresh.test.ts
+++ b/dashboard/src/tab-refresh.test.ts
@@ -73,6 +73,13 @@ describe('refreshPlanForRoute', () => {
     })).toEqual(['namespaceTruth', 'execution', 'missionSnapshot', 'activeKeeperChat'])
   })
 
+  it('hydrates the registry roster on direct entry (no default-[] blank roster)', () => {
+    expect(refreshPlanForRoute({
+      tab: 'registry',
+      params: {},
+    })).toEqual(['namespaceTruth', 'execution', 'missionSnapshot'])
+  })
+
   it('hydrates the top-level board surface from the board store', () => {
     expect(refreshPlanForRoute({
       tab: 'board',

--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -81,6 +81,12 @@ export function refreshPlanForRoute(routeState: Pick<RouteState, 'tab' | 'params
       // reconnect: the route refresh runs after a disconnect and recovers the
       // open keeper's history when replayed events fell outside the buffer.
       return ['namespaceTruth', 'execution', 'missionSnapshot', 'activeKeeperChat']
+    case 'registry':
+      // Keeper roster hydrates from the execution snapshot; the persona
+      // library is fetched by the surface itself on mount (masc_persona_list
+      // has no refresh-task lane). Without this plan a direct entry
+      // (refresh on /registry) rendered an empty roster.
+      return ['namespaceTruth', 'execution', 'missionSnapshot']
     case 'board':
       return ['board']
     case 'fusion':

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -320,6 +320,7 @@ export type TabId =
   | 'overview'
   | 'monitoring'
   | 'keepers'
+  | 'registry'
   | 'board'
   | 'schedule'
   | 'fusion'
@@ -337,6 +338,7 @@ export const VALID_TABS: TabId[] = [
   'overview',
   'monitoring',
   'keepers',
+  'registry',
   'board',
   'schedule',
   'fusion',

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -133,6 +133,10 @@ let keeper_schemas : tool_schema list = [
           ("type", `String "boolean");
           ("description", `String "If true, return the resolved keeper args and validation errors without creating the keeper.");
         ]);
+        ("no_boot", `Assoc [
+          ("type", `String "boolean");
+          ("description", `String "If true, create configured-only: write the durable keeper TOML and list-visible meta without booting (no session, checkpoint, registry, or keepalive). autoboot_enabled is pinned false; passing autoboot_enabled=true alongside is rejected. Boot later with masc_keeper_up.");
+        ]);
         ("goal", `Assoc [
           ("type", `String "string");
           ("description", `String "Legacy goal string. Mutually exclusive with initial_goal.");

--- a/lib/keeper/keeper_tool_persona_runtime.ml
+++ b/lib/keeper/keeper_tool_persona_runtime.ml
@@ -216,6 +216,18 @@ let render_keeper_toml_from_resolved_args (json : Yojson.Safe.t) :
               let fields =
                 append_present_string_list_field fields "active_goal_ids" json
               in
+              (* The reconcile boot gate is fail-closed on a declared
+                 [sandbox_profile] (#11080) and personas cannot own capability
+                 fields (D-9 zero-capability invariant), so the generated TOML
+                 pins the profile here. Docker is the most isolated profile
+                 and the unanimous live-fleet value (13/13 keeper TOMLs,
+                 2026-07-14); Local would strip isolation on omission.
+                 Post-create edits go through the keeper config panel. *)
+              let fields =
+                append_string_field fields "sandbox_profile"
+                  (Keeper_types_profile_sandbox.sandbox_profile_to_string
+                     Keeper_types_profile_sandbox.Docker)
+              in
               let timeout_fields =
                 match Safe_ops.json_float_opt "per_provider_timeout" json with
                 | None -> Ok fields
@@ -272,6 +284,101 @@ let persist_keeper_toml_from_resolved_args (json : Yojson.Safe.t) :
                           ("path", `String path);
                           ("created", `Bool true);
                         ])))
+
+(* Configured-only durable TOML write (create-without-boot).
+   - fresh-only: an existing TOML is an explicit error, not a silent
+     no-op — a wizard "create" must not quietly adopt an unrelated
+     keeper's config (contrast [persist_keeper_toml_from_resolved_args],
+     which tolerates already_exists because the boot path persists after
+     a successful boot).
+   - [autoboot_enabled] is pinned false in the rendered TOML so reconcile
+     classifies the keeper [Declarative_autoboot_disabled] before any meta
+     exists; a caller passing autoboot_enabled=true is an explicit
+     conflict, rejected instead of silently overridden.
+   - path scope: resolves under [base_path] (the same resolver family
+     discovery uses) instead of the process-global keepers_dir. *)
+let persist_new_keeper_toml_configured_only ~base_path
+    (json : Yojson.Safe.t) : (string, string) result =
+  match required_resolved_string "name" json with
+  | Error _ as err -> err
+  | Ok name ->
+      if not (validate_name name) then
+        Error "resolved_args.name is not a valid keeper name"
+      else if get_bool json "autoboot_enabled" false then
+        Error
+          "no_boot conflicts with autoboot_enabled=true: a configured-only \
+           keeper is written with autoboot_enabled=false; drop one of the \
+           two, then boot explicitly with masc_keeper_up"
+      else (
+        match
+          Keeper_types_profile.keeper_toml_path_opt_for_base_path ~base_path
+            name
+        with
+        | Some existing_path ->
+            Error
+              (Printf.sprintf "keeper config already exists: %s" existing_path)
+        | None -> (
+            let json =
+              match json with
+              | `Assoc fields ->
+                  `Assoc
+                    (List.remove_assoc "autoboot_enabled" fields
+                    @ [ ("autoboot_enabled", `Bool false) ])
+              | other -> other
+            in
+            match render_keeper_toml_from_resolved_args json with
+            | Error _ as err -> err
+            | Ok content -> (
+                let path =
+                  Filename.concat
+                    (Config_dir_resolver.keepers_dir_for_base_path ~base_path)
+                    (name ^ ".toml")
+                in
+                Fs_compat.mkdir_p (Filename.dirname path);
+                match Fs_compat.save_file_atomic path content with
+                | Error msg -> Error msg
+                | Ok () -> Ok path)))
+
+(* Create-without-boot composition: durable TOML first, then the meta is
+   derived by the SAME parse + derivation the boot path uses (the parse
+   reads profile defaults from the TOML just written — including the
+   pinned sandbox_profile — so the two paths cannot drift). On a failure
+   after the TOML write, the freshly created file is removed so a failed
+   create does not leave an orphan config that a later reconcile or
+   create would trip over. *)
+let create_configured_only (ctx : _ context)
+    (resolved_args : Yojson.Safe.t) : (Yojson.Safe.t, string) result =
+  let base_path = ctx.config.Workspace.base_path in
+  match persist_new_keeper_toml_configured_only ~base_path resolved_args with
+  | Error _ as err -> err
+  | Ok toml_path -> (
+      let remove_orphan_toml () =
+        try Sys.remove toml_path
+        with Sys_error e ->
+          Log.Keeper.error
+            "create_configured_only: failed to remove orphan TOML %s: %s"
+            toml_path e
+      in
+      match Keeper_turn_up_args.parse ctx resolved_args with
+      | Error result ->
+          remove_orphan_toml ();
+          Error (tool_result_body result)
+      | Ok p -> (
+          match
+            Keeper_turn_up_create.create_keeper_configured_only ctx.config p
+          with
+          | Error e ->
+              remove_orphan_toml ();
+              Error e
+          | Ok meta ->
+              Ok
+                (`Assoc
+                   [
+                     ("name", `String meta.name);
+                     ("path", `String toml_path);
+                     ("booted", `Bool false);
+                     ("autoboot_enabled", `Bool false);
+                   ])))
 
 let resolved_keeper_args_from_persona args :
     ((persona_summary * Yojson.Safe.t), string) result =

--- a/lib/keeper/keeper_tool_persona_runtime.mli
+++ b/lib/keeper/keeper_tool_persona_runtime.mli
@@ -24,5 +24,23 @@ val render_keeper_toml_from_resolved_args :
 val persist_keeper_toml_from_resolved_args :
   Yojson.Safe.t -> (Yojson.Safe.t, string) result
 
+(** Configured-only durable TOML write (create-without-boot):
+    fresh-only (existing TOML is an explicit error), pins
+    [autoboot_enabled = false] (an explicit [autoboot_enabled = true]
+    input is a rejected conflict), resolves under [base_path]. Returns
+    the written path. *)
+val persist_new_keeper_toml_configured_only :
+  base_path:string -> Yojson.Safe.t -> (string, string) result
+
+(** Create-without-boot composition: fresh TOML write, then meta via the
+    same parse + derivation as the boot path — no session, checkpoint,
+    registry, or keepalive. Removes the freshly written TOML when a later
+    step fails. Returns [{name; path; booted=false;
+    autoboot_enabled=false}]. *)
+val create_configured_only :
+  _ Keeper_types_profile.context ->
+  Yojson.Safe.t ->
+  (Yojson.Safe.t, string) result
+
 val resolved_keeper_args_from_persona :
   Yojson.Safe.t -> (persona_summary * Yojson.Safe.t, string) result

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -407,6 +407,7 @@ let handle_keeper_create_from_persona ctx args : tool_result =
         |> Result.map_error (fun e -> "" ^ e)
       in
       let dry_run = get_bool args "dry_run" false in
+      let no_boot = get_bool args "no_boot" false in
       (* D-10a: an explicit [initial_goal] mints a Goal entity and is the
          goal source for the new keeper. Passing both [goal] and
          [initial_goal] is an explicit conflict — rejected instead of
@@ -427,6 +428,18 @@ let handle_keeper_create_from_persona ctx args : tool_result =
             "pass either goal or initial_goal, not both: initial_goal mints \
              a Goal entity (D-10a) and also fills the legacy goal string \
              during the transition"
+        else Ok ()
+      in
+      (* no_boot pins autoboot_enabled=false in the durable config; an
+         explicit true is a conflict, rejected here before any effect
+         (Goal mint, TOML write). The persist layer re-checks the same
+         predicate as defense in depth. *)
+      let* () =
+        if no_boot && get_bool resolved_args "autoboot_enabled" false then
+          Error
+            "no_boot conflicts with autoboot_enabled=true: a configured-only \
+             keeper is written with autoboot_enabled=false; drop one of the \
+             two, then boot explicitly with masc_keeper_up"
         else Ok ()
       in
       (* Inject first, validate, mint last (adversarial re-review P1-1 of
@@ -459,6 +472,7 @@ let handle_keeper_create_from_persona ctx args : tool_result =
                   ( "persona",
                     Keeper_tool_persona_runtime.persona_summary_to_json persona );
                   ("created", `Bool false);
+                  ("no_boot", `Bool no_boot);
                   ("ready", `Bool (errors = []));
                   ("errors", Json_util.json_string_list errors);
                   ("resolved_args", resolved_args);
@@ -475,6 +489,9 @@ let handle_keeper_create_from_persona ctx args : tool_result =
                   ("resolved_args", resolved_args);
                 ]))
       else
+        (* Validation passed — mint the Goal entity now, at the single point
+           shared by the configured-only (no_boot) and boot paths: both
+           persist the minted goal id into the keeper TOML/meta. *)
         let* resolved_args, initial_goal_id =
           match initial_goal_opt with
           | None -> Ok (resolved_args, None)
@@ -493,7 +510,7 @@ let handle_keeper_create_from_persona ctx args : tool_result =
           | Some gid -> [ ("initial_goal_id", `String gid) ]
           | None -> []
         in
-        (* Failure between the mint and the point where the booted keeper's
+        (* Failure between the mint and the point where the created keeper's
            persisted meta references the goal would strand the Goal entity —
            release it. A failed release logs instead of masking the original
            error (best-effort compensation, not a new failure path). *)
@@ -510,41 +527,76 @@ let handle_keeper_create_from_persona ctx args : tool_result =
                     stage gid
                     (Goal_store.delete_goal_error_to_string e))
         in
-        let* _rendered_toml =
-          Keeper_tool_persona_runtime.render_keeper_toml_from_resolved_args
-            resolved_args
-          |> Result.map_error (fun e ->
-              (* Render happens before any boot side effect, so nothing can
-                 reference the goal yet — release unconditionally. *)
-              release_minted_goal ~stage:"toml render";
-              "" ^ e)
+        (* A failed create may still have persisted keeper meta whose
+           [active_goal_ids] references the goal; deleting it then would
+           dangle that reference. Release only when no meta persisted.
+           Residual: a pre-existing meta under the same name
+           (duplicate-name create) keeps the fresh goal alive — the WARN
+           carries the goal id for manual cleanup. *)
+        let release_unless_meta_persisted ~stage =
+          match initial_goal_id with
+          | None -> ()
+          | Some gid ->
+              let keeper_name = get_string resolved_args "name" "" in
+              let meta_persisted =
+                List.mem keeper_name
+                  (Keeper_meta_store.persisted_keeper_names ctx.config)
+              in
+              if meta_persisted then
+                Log.Keeper.warn
+                  "create_from_persona: %s failed after goal mint; keeping \
+                   goal %s because keeper %s meta persists"
+                  stage gid keeper_name
+              else release_minted_goal ~stage
         in
-        let result =
-          with_keeper_startup_gate (fun () -> execute_keeper_up ctx resolved_args)
-        in
-        if not (tool_result_success result) then (
-          (match initial_goal_id with
-           | None -> ()
-           | Some gid ->
-               (* A failed boot may still have persisted keeper meta whose
-                  [active_goal_ids] references the goal; deleting it then
-                  would dangle that reference. Release only when no meta
-                  persisted. Residual: a pre-existing meta under the same
-                  name (duplicate-name create) keeps the fresh goal alive —
-                  the WARN below carries the goal id for manual cleanup. *)
-               let keeper_name = get_string resolved_args "name" "" in
-               let meta_persisted =
-                 List.mem keeper_name
-                   (Keeper_meta_store.persisted_keeper_names ctx.config)
-               in
-               if meta_persisted then
-                 Log.Keeper.warn
-                   "create_from_persona: boot failed after goal mint; \
-                    keeping goal %s because keeper %s meta persists"
-                   gid keeper_name
-               else release_minted_goal ~stage:"boot");
-          Ok result)
+        if no_boot then (
+          (* Configured, not running: durable TOML + list-visible meta, no
+             boot side effect. Boot later with masc_keeper_up. *)
+          match
+            Keeper_tool_persona_runtime.create_configured_only ctx
+              resolved_args
+          with
+          | Error e ->
+              (* create_configured_only removes its own orphan TOML; the
+                 minted goal follows the same meta-aware rule as the boot
+                 path. *)
+              release_unless_meta_persisted ~stage:"configured-only create";
+              Error e
+          | Ok configured ->
+              let json =
+                `Assoc
+                  ([
+                     ( "persona",
+                       Keeper_tool_persona_runtime.persona_summary_to_json
+                         persona );
+                     ("created", `Bool true);
+                     ("booted", `Bool false);
+                     ("result", configured);
+                     ("resolved_args", resolved_args);
+                   ]
+                  @ initial_goal_field)
+              in
+              invalidate_keeper_list_cache ();
+              invalidate_status_cache (get_string resolved_args "name" "");
+              Ok (tool_result_ok_data json))
         else
+          let* _rendered_toml =
+            Keeper_tool_persona_runtime.render_keeper_toml_from_resolved_args
+              resolved_args
+            |> Result.map_error (fun e ->
+                (* Render happens before any boot side effect, so nothing can
+                   reference the goal yet — release unconditionally. *)
+                release_minted_goal ~stage:"toml render";
+                "" ^ e)
+          in
+          let result =
+            with_keeper_startup_gate (fun () ->
+                execute_keeper_up ctx resolved_args)
+          in
+          if not (tool_result_success result) then (
+            release_unless_meta_persisted ~stage:"boot";
+            Ok result)
+          else
           let* durable_config =
             Keeper_tool_persona_runtime.persist_keeper_toml_from_resolved_args
               resolved_args

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -172,14 +172,14 @@ let derive_create_inputs (p : parsed_args) : derived_create_inputs =
 (* Unknown [active_goal_ids] check — only explicit operator input is
    validated; profile-default ids were validated when the profile was
    written. Reads Goal_store, so it lives outside [derive_create_inputs]. *)
-let unknown_active_goal_ids_error (ctx : _ context) (p : parsed_args)
+let unknown_active_goal_ids_error (config : Workspace.config) (p : parsed_args)
     ~(active_goal_ids : string list) : string option =
   match p.active_goal_ids_opt with
   | None -> None
   | Some _ ->
       let missing =
         List.filter
-          (fun goal_id -> Option.is_none (Goal_store.get_goal ctx.config ~goal_id))
+          (fun goal_id -> Option.is_none (Goal_store.get_goal config ~goal_id))
           active_goal_ids
       in
       if missing = [] then None
@@ -187,6 +187,88 @@ let unknown_active_goal_ids_error (ctx : _ context) (p : parsed_args)
         Some
           (Printf.sprintf "unknown active_goal_ids: %s"
              (String.concat ", " missing))
+
+(* Configured-only create (create-without-boot): the caller has already
+   written the durable TOML; this materializes the list-visible meta with
+   NO boot side effect — no session, no checkpoint, no registry/keepalive,
+   no runtime assignment. [autoboot_enabled] is pinned false so reconcile
+   classifies the keeper [Declarative_autoboot_disabled]
+   (Keeper_runtime.autoboot_exclusion_reason) until an operator boots it
+   explicitly via masc_keeper_up. Gates mirror [create_keeper] with the
+   same error strings so both paths speak one vocabulary. *)
+let create_keeper_configured_only (config : Workspace.config)
+    (p : parsed_args) : (keeper_meta, string) result =
+  let d = derive_create_inputs p in
+  if d.goal = "" then Error "goal is required when creating a keeper"
+  else
+    match
+      unknown_active_goal_ids_error config p
+        ~active_goal_ids:d.active_goal_ids
+    with
+    | Some msg -> Error msg
+    | None -> (
+        match validate_sandbox_settings ~allowed_paths:d.allowed_paths with
+        | Error err -> Error err
+        | Ok () -> (
+            let now_ts = Time_compat.now () in
+            let trace_id = generate_trace_id () in
+            match Keeper_id.Trace_id.of_string trace_id with
+            | Error err ->
+                Error
+                  (Printf.sprintf
+                     "internal keeper trace_id generation failed: %s" err)
+            | Ok trace_id_t ->
+                let persona_extended =
+                  Keeper_types_profile.resolved_persona_name
+                    ~keeper_name:p.name p.profile_defaults
+                  |> Keeper_types_profile.load_persona_extended
+                  |> Option.value ~default:""
+                in
+                (* No [next_generation] reservation: a configured-only
+                   keeper owns no episode stream yet, and the counter
+                   lives under the process-global keepers dir — reserving
+                   here would write a runtime artifact outside
+                   [config.base_path] for a keeper that never booted.
+                   0 is exactly what a fresh reservation yields; the boot
+                   path reserves for real on its own create/turn cycle. *)
+                let generation = 0 in
+                let meta =
+                  Keeper_meta_build.initial_meta ~name:p.name
+                    ~agent_name:(Keeper_identity.keeper_agent_name p.name)
+                    ~persona_extended ~goal:d.goal
+                    ~instructions:d.instructions
+                    ~sandbox_profile:d.sandbox_profile
+                    ~network_mode:d.network_mode
+                    ~multimodal_policy:d.multimodal_policy
+                    ~allowed_paths:d.allowed_paths
+                    ~mention_targets:d.mention_targets
+                    ~proactive_enabled:d.proactive_enabled
+                    ~compaction_profile:d.compaction_profile
+                    ~compaction_mode:
+                      (Keeper_config.keeper_compaction_mode_default ())
+                    ~compaction_ratio_gate:d.compaction_ratio_gate
+                    ~compaction_message_gate:d.compaction_message_gate
+                    ~compaction_token_gate:d.compaction_token_gate
+                    ~compaction_cooldown_sec:d.compaction_cooldown_sec
+                    ~auto_handoff:d.auto_handoff
+                    ~handoff_threshold:d.handoff_threshold
+                    ~handoff_cooldown_sec:d.handoff_cooldown_sec
+                    ~created_at:(now_iso ())
+                    ~max_context_override:p.max_context_override_opt
+                    ~active_goal_ids:d.active_goal_ids
+                    ~autoboot_enabled:false
+                    ~telemetry_feedback_enabled:
+                      p.profile_defaults.telemetry_feedback_enabled
+                    ~telemetry_feedback_window_hours:
+                      p.profile_defaults.telemetry_feedback_window_hours
+                    ~always_allow:p.profile_defaults.always_allow ~now_ts
+                    ~generation ~trace_id:trace_id_t
+                    ~keeper_uid:(Keeper_id.Uid.generate ())
+                    ~oas_env:p.profile_defaults.oas_env ()
+                in
+                (match write_initial_meta config meta with
+                 | Error e -> Error e
+                 | Ok () -> Ok meta)))
 
 let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
   Log.Keeper.info "create_keeper: starting for name=%s" p.name;
@@ -218,7 +300,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
     derive_create_inputs p
   in
   let active_goal_ids_error =
-    unknown_active_goal_ids_error ctx p ~active_goal_ids
+    unknown_active_goal_ids_error ctx.config p ~active_goal_ids
   in
   if goal = "" then begin
     Log.Keeper.warn "create_keeper failed: goal is required (name=%s)" p.name;

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -21,12 +21,37 @@ let write_initial_meta config meta =
     ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
     config meta
 
-let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
-  Log.Keeper.info "create_keeper: starting for name=%s" p.name;
-  let task_id = Printf.sprintf "keeper_create_%s" p.name in
-  let tracker = Progress.start_tracking ~task_id ~total_steps:6 () in
-  Progress.Tracker.step tracker ~message:"Resolving keeper configuration" ();
-  let now_ts = Time_compat.now () in
+(* Single derivation of the create-time keeper fields from [parsed_args]
+   (operator args > profile defaults > env/runtime-param defaults). The boot
+   create path and the configured-only (no_boot) create path must resolve
+   these identically — one function is what keeps the two paths from
+   drifting. Deterministic given [p] and the config/env snapshot: no clock,
+   no id generation, no filesystem writes. Validation (empty goal, unknown
+   active_goal_ids, sandbox settings) stays with the callers because the
+   error surfaces differ per path. *)
+type derived_create_inputs = {
+  goal : string;
+  autoboot_enabled : bool;
+  allowed_paths : string list;
+  active_goal_ids : string list;
+  sandbox_profile : Keeper_types_profile.sandbox_profile;
+  network_mode : Keeper_types_profile.network_mode;
+  multimodal_policy : Keeper_types_profile.multimodal_policy;
+  mention_targets : string list;
+  proactive_enabled : bool;
+  auto_handoff : bool;
+  handoff_threshold : float;
+  handoff_cooldown_sec : int;
+  instructions : string;
+  compaction_profile : string;
+  compaction_ratio_gate : float;
+  compaction_message_gate : int;
+  compaction_token_gate : int;
+  compaction_cooldown_sec : int;
+  primary_max_context : int;
+}
+
+let derive_create_inputs (p : parsed_args) : derived_create_inputs =
   let goal =
     match p.goal_opt with
     | Some goal -> normalize_goal_text goal
@@ -47,21 +72,6 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
     match p.active_goal_ids_opt with
     | Some ids -> ids
     | None -> Option.value ~default:[] p.profile_defaults.active_goal_ids
-  in
-  let active_goal_ids_error =
-    match p.active_goal_ids_opt with
-    | None -> None
-    | Some _ ->
-        let missing =
-          List.filter
-            (fun goal_id -> Option.is_none (Goal_store.get_goal ctx.config ~goal_id))
-            active_goal_ids
-        in
-        if missing = [] then None
-        else
-          Some
-            (Printf.sprintf "unknown active_goal_ids: %s"
-               (String.concat ", " missing))
   in
   let sandbox_profile =
     resolve_sandbox_profile ~fallback:p.profile_defaults.sandbox_profile
@@ -84,6 +94,132 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
       ~fallback_targets:p.profile_defaults.mention_targets
       ~name:p.name
   in
+  let proactive_enabled =
+    Option.value
+      ~default:
+        (Option.value ~default:default_proactive_enabled
+           p.profile_defaults.proactive_enabled)
+      p.proactive_enabled_opt
+  in
+  let auto_handoff = Option.value ~default:true p.auto_handoff_opt in
+  let handoff_threshold =
+    match p.handoff_threshold_opt with
+    | Some threshold -> threshold
+    | None ->
+        Runtime_params.get Runtime_settings.keeper_handoff_threshold
+  in
+  let handoff_cooldown_sec =
+    match p.handoff_cooldown_sec_opt with
+    | Some cooldown_sec -> cooldown_sec
+    | None ->
+        Runtime_params.get Runtime_settings.keeper_handoff_cooldown_sec
+  in
+  let instructions = Option.value ~default:"" p.instructions_opt in
+  let (env_ratio_gate, env_message_gate, env_token_gate) =
+    keeper_compaction_policy_from_env ()
+  in
+  let compaction_cooldown_sec =
+    Option.value
+      ~default:(keeper_compaction_cooldown_sec ())
+      p.compaction_cooldown_sec_opt
+    |> normalize_compaction_cooldown_sec
+  in
+  let
+    ( compaction_profile,
+      compaction_ratio_gate,
+      compaction_message_gate,
+      compaction_token_gate )
+    =
+    resolve_compaction_policy
+      ~profile_opt:p.compaction_profile_opt
+      ~ratio_opt:p.compaction_ratio_gate_opt
+      ~message_opt:p.compaction_message_gate_opt
+      ~token_opt:p.compaction_token_gate_opt
+      ~fallback_profile:default_compaction_profile
+      ~fallback_ratio:env_ratio_gate
+      ~fallback_message:env_message_gate
+      ~fallback_token:env_token_gate
+  in
+  let primary_max_context =
+    match p.max_context_override_opt with
+    | Some v -> v
+    (* Boundary: Keeper consumes an opaque context budget, not a
+       provider/model identity. *)
+    | None -> Runtime.default_max_context ()
+  in
+  {
+    goal;
+    autoboot_enabled;
+    allowed_paths;
+    active_goal_ids;
+    sandbox_profile;
+    network_mode;
+    multimodal_policy;
+    mention_targets;
+    proactive_enabled;
+    auto_handoff;
+    handoff_threshold;
+    handoff_cooldown_sec;
+    instructions;
+    compaction_profile;
+    compaction_ratio_gate;
+    compaction_message_gate;
+    compaction_token_gate;
+    compaction_cooldown_sec;
+    primary_max_context;
+  }
+
+(* Unknown [active_goal_ids] check — only explicit operator input is
+   validated; profile-default ids were validated when the profile was
+   written. Reads Goal_store, so it lives outside [derive_create_inputs]. *)
+let unknown_active_goal_ids_error (ctx : _ context) (p : parsed_args)
+    ~(active_goal_ids : string list) : string option =
+  match p.active_goal_ids_opt with
+  | None -> None
+  | Some _ ->
+      let missing =
+        List.filter
+          (fun goal_id -> Option.is_none (Goal_store.get_goal ctx.config ~goal_id))
+          active_goal_ids
+      in
+      if missing = [] then None
+      else
+        Some
+          (Printf.sprintf "unknown active_goal_ids: %s"
+             (String.concat ", " missing))
+
+let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
+  Log.Keeper.info "create_keeper: starting for name=%s" p.name;
+  let task_id = Printf.sprintf "keeper_create_%s" p.name in
+  let tracker = Progress.start_tracking ~task_id ~total_steps:6 () in
+  Progress.Tracker.step tracker ~message:"Resolving keeper configuration" ();
+  let now_ts = Time_compat.now () in
+  let {
+    goal;
+    autoboot_enabled;
+    allowed_paths;
+    active_goal_ids;
+    sandbox_profile;
+    network_mode;
+    multimodal_policy;
+    mention_targets;
+    proactive_enabled;
+    auto_handoff;
+    handoff_threshold;
+    handoff_cooldown_sec;
+    instructions;
+    compaction_profile;
+    compaction_ratio_gate;
+    compaction_message_gate;
+    compaction_token_gate;
+    compaction_cooldown_sec;
+    primary_max_context;
+  } =
+    derive_create_inputs p
+  in
+  let active_goal_ids_error =
+    unknown_active_goal_ids_error ctx p ~active_goal_ids
+  in
   if goal = "" then begin
     Log.Keeper.warn "create_keeper failed: goal is required (name=%s)" p.name;
     tool_result_error "goal is required when creating a keeper"
@@ -103,59 +239,6 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
           p.name err;
         tool_result_error err
     | Ok () ->
-            let proactive_enabled =
-                Option.value
-                  ~default:
-                    (Option.value ~default:default_proactive_enabled
-                       p.profile_defaults.proactive_enabled)
-                  p.proactive_enabled_opt
-            in
-              let auto_handoff = Option.value ~default:true p.auto_handoff_opt in
-              let handoff_threshold =
-                match p.handoff_threshold_opt with
-                | Some threshold -> threshold
-                | None ->
-                    Runtime_params.get Runtime_settings.keeper_handoff_threshold
-              in
-              let handoff_cooldown_sec =
-                match p.handoff_cooldown_sec_opt with
-                | Some cooldown_sec -> cooldown_sec
-                | None ->
-                    Runtime_params.get Runtime_settings.keeper_handoff_cooldown_sec
-              in
-              let instructions = Option.value ~default:"" p.instructions_opt in
-              let (env_ratio_gate, env_message_gate, env_token_gate) =
-                keeper_compaction_policy_from_env ()
-              in
-              let compaction_cooldown_sec =
-                Option.value
-                  ~default:(keeper_compaction_cooldown_sec ())
-                  p.compaction_cooldown_sec_opt
-                |> normalize_compaction_cooldown_sec
-              in
-              let
-                ( compaction_profile,
-                  compaction_ratio_gate,
-                  compaction_message_gate,
-                  compaction_token_gate )
-                =
-                resolve_compaction_policy
-                  ~profile_opt:p.compaction_profile_opt
-                  ~ratio_opt:p.compaction_ratio_gate_opt
-                  ~message_opt:p.compaction_message_gate_opt
-                  ~token_opt:p.compaction_token_gate_opt
-                  ~fallback_profile:default_compaction_profile
-                  ~fallback_ratio:env_ratio_gate
-                  ~fallback_message:env_message_gate
-                  ~fallback_token:env_token_gate
-              in
-              let primary_max_context =
-                match p.max_context_override_opt with
-                | Some v -> v
-                (* Boundary: Keeper consumes an opaque context budget, not a
-                   provider/model identity. *)
-                | None -> Runtime.default_max_context ()
-              in
               Progress.Tracker.step tracker ~message:"Initializing session directory" ();
               let trace_id = generate_trace_id () in
               match Keeper_id.Trace_id.of_string trace_id with

--- a/lib/keeper/keeper_turn_up_create.mli
+++ b/lib/keeper/keeper_turn_up_create.mli
@@ -21,3 +21,17 @@ val create_keeper :
   _ Keeper_types_profile.context ->
   Keeper_turn_up_args.parsed_args ->
   tool_result
+
+(** Configured-only create (create-without-boot). Materializes the
+    list-visible keeper meta from the same derivation the boot path
+    uses, with NO boot side effect: no session, no checkpoint, no
+    registry/keepalive, no runtime assignment. [autoboot_enabled] is
+    pinned false in the written meta; the caller owns the durable TOML
+    write (also pinned false) so reconcile classifies the keeper
+    [Declarative_autoboot_disabled] until an explicit masc_keeper_up.
+    Gates (empty goal, unknown active_goal_ids, sandbox settings)
+    mirror [create_keeper] with the same error strings. *)
+val create_keeper_configured_only :
+  Workspace.config ->
+  Keeper_turn_up_args.parsed_args ->
+  (keeper_meta, string) result

--- a/lib/server/server_dashboard_http_keeper_api.mli
+++ b/lib/server/server_dashboard_http_keeper_api.mli
@@ -182,6 +182,15 @@ val handle_keeper_lifecycle_post :
 (** Generic handler for boot / shutdown / reset / clear posts; the
     [action] parameter selects the keeper FSM event. *)
 
+val handle_keeper_create_post :
+  sw:Eio.Switch.t ->
+  clock:[> float Eio.Time.clock_ty ] Eio.Time.clock ->
+  Mcp_server.server_state ->
+  string -> Httpun.Request.t -> Httpun.Reqd.t -> string -> unit
+(** Handle [POST /api/v1/keepers/<name>/create] — REST surface over
+    [masc_keeper_create_from_persona]; path name wins, body fields
+    (persona_name, initial_goal, no_boot, dry_run, ...) pass through. *)
+
 val handle_keeper_directive_post :
   sw:Eio.Switch.t ->
   clock:[> float Eio.Time.clock_ty ] Eio.Time.clock ->

--- a/lib/server/server_dashboard_http_keeper_api_lifecycle_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_lifecycle_post.ml
@@ -403,6 +403,72 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
               respond_error ~status:`Internal_server_error ~request:req ~ok:false
                 reqd "dispatch returned None"))
 
+(* POST /api/v1/keepers/:name/create — REST surface over
+   [masc_keeper_create_from_persona]. The path segment is the keeper name
+   and wins over any [name] in the body; every other body field
+   (persona_name, initial_goal, no_boot, dry_run, ...) passes through to
+   the tool unchanged, so this surface cannot drift from the tool
+   contract. *)
+let handle_keeper_create_post ~sw ~clock state agent_name req reqd body_str =
+  let req_path = Http.Request.path req in
+  let name = extract_keeper_name_for_post req_path keeper_suffix_create in
+  if String.length name = 0 then respond_error reqd "keeper name is required"
+  else
+    let body_result =
+      match Yojson.Safe.from_string body_str with
+      | `Assoc fields -> Ok fields
+      | _ -> Error "request body must be a JSON object"
+      | exception Yojson.Json_error e ->
+          Error (Printf.sprintf "invalid json: %s" e)
+    in
+    match body_result with
+    | Error msg -> respond_error ~ok:false reqd msg
+    | Ok fields ->
+        let config = Mcp_server.workspace_config state in
+        let keeper_ctx : _ Keeper_tool_surface.context =
+          {
+            config;
+            agent_name;
+            sw;
+            clock;
+            proc_mgr = state.Mcp_server.proc_mgr;
+            net = state.Mcp_server.net;
+          }
+        in
+        let args =
+          `Assoc (("name", `String name) :: List.remove_assoc "name" fields)
+        in
+        (match
+           Keeper_tool_surface.dispatch keeper_ctx
+             ~name:"masc_keeper_create_from_persona" ~args
+         with
+        | Some result when Tool_result.is_success result ->
+            let body = Tool_result.message result in
+            invalidate_keeper_execution_surfaces ~config ();
+            Log.Server.info "keeper create name=%s actor=%s outcome=ok" name
+              agent_name;
+            Http.Response.json_value ~compress:true ~request:req
+              (`Assoc
+                 [
+                   ("ok", `Bool true);
+                   ("name", `String name);
+                   ("detail", tool_detail_json body);
+                 ])
+              reqd
+        | Some result ->
+            let body = Tool_result.message result in
+            Log.Server.warn "keeper create name=%s actor=%s outcome=rejected"
+              name agent_name;
+            Http.Response.json_value ~status:`Bad_request ~request:req
+              (`Assoc [ ("ok", `Bool false); ("error", `String body) ])
+              reqd
+        | None ->
+            Log.Server.warn
+              "keeper create name=%s actor=%s outcome=dispatch_none" name
+              agent_name;
+            respond_error ~status:`Internal_server_error ~request:req ~ok:false
+              reqd "dispatch returned None")
+
 (** POST /api/v1/keepers/:name/directive — pause / resume / wakeup.
 
     Delegates to [Keeper_keepalive.process_directive] which updates

--- a/lib/server/server_dashboard_http_keeper_api_lifecycle_post.mli
+++ b/lib/server/server_dashboard_http_keeper_api_lifecycle_post.mli
@@ -11,6 +11,17 @@ val handle_keeper_lifecycle_post :
 (** Generic handler for boot / shutdown / reset / clear posts; the
     [action] parameter selects the keeper FSM event. *)
 
+val handle_keeper_create_post :
+  sw:Eio.Switch.t ->
+  clock:[> float Eio.Time.clock_ty ] Eio.Time.clock ->
+  Mcp_server.server_state ->
+  string -> Httpun.Request.t -> Httpun.Reqd.t -> string -> unit
+(** Handle [POST /api/v1/keepers/<name>/create] — REST surface over
+    [masc_keeper_create_from_persona]. The path segment is the keeper
+    name and wins over any [name] in the body; other body fields
+    (persona_name, initial_goal, no_boot, dry_run, ...) pass through to
+    the tool unchanged. *)
+
 val refresh_keeper_execution_surfaces :
   config:Workspace.config -> name:string -> string -> unit
 (** Invalidate caches and patch execution-surface dependents after a keeper

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -809,6 +809,9 @@ let handle_keeper_secrets_post state req reqd body_str =
 let handle_keeper_lifecycle_post =
   Server_dashboard_http_keeper_api_lifecycle_post.handle_keeper_lifecycle_post
 
+let handle_keeper_create_post =
+  Server_dashboard_http_keeper_api_lifecycle_post.handle_keeper_create_post
+
 let directive_action_to_string = function
   | Keeper_directive.Pause -> "pause"
   | Keeper_directive.Resume -> "resume"

--- a/lib/server/server_dashboard_http_keeper_api_post.mli
+++ b/lib/server/server_dashboard_http_keeper_api_post.mli
@@ -84,6 +84,16 @@ val handle_keeper_lifecycle_post :
   Httpun.Reqd.t ->
   unit
 
+val handle_keeper_create_post :
+  sw:Eio.Switch.t ->
+  clock:[> float Eio.Time.clock_ty ] Eio.Time.clock ->
+  Mcp_server.server_state ->
+  string ->
+  Httpun.Request.t ->
+  Httpun.Reqd.t ->
+  string ->
+  unit
+
 val handle_keeper_directive_post :
   sw:Eio.Switch.t ->
   clock:[> float Eio.Time.clock_ty ] Eio.Time.clock ->

--- a/lib/server/server_dashboard_http_keeper_api_types.ml
+++ b/lib/server/server_dashboard_http_keeper_api_types.ml
@@ -14,6 +14,7 @@ let keeper_suffix_checkpoints = "/checkpoints"
 let keeper_suffix_runtime_trace = "/runtime-trace"
 let keeper_suffix_directive = "/directive"
 let keeper_suffix_catchup_judge = "/catchup-judge"
+let keeper_suffix_create = "/create"
 
 let cache_key_string_segment value =
   Printf.sprintf "s%d:%s" (String.length value) value
@@ -65,6 +66,7 @@ type keeper_post_route_kind =
   | Keeper_post_checkpoints
   | Keeper_post_directive
   | Keeper_post_catchup_judge
+  | Keeper_post_create
   | Keeper_post_unknown
 
 let classify_keeper_post_route req_path =
@@ -86,6 +88,7 @@ let classify_keeper_post_route req_path =
     else if ends_with keeper_suffix_checkpoints then Keeper_post_checkpoints
     else if ends_with keeper_suffix_directive then Keeper_post_directive
     else if ends_with keeper_suffix_catchup_judge then Keeper_post_catchup_judge
+    else if ends_with keeper_suffix_create then Keeper_post_create
     else Keeper_post_unknown
 
 let keeper_path_ends_with req_path suffix =

--- a/lib/server/server_dashboard_http_keeper_api_types.mli
+++ b/lib/server/server_dashboard_http_keeper_api_types.mli
@@ -22,6 +22,7 @@ val keeper_suffix_checkpoints : string
 val keeper_suffix_runtime_trace : string
 val keeper_suffix_directive : string
 val keeper_suffix_catchup_judge : string
+val keeper_suffix_create : string
 
 (** {1 Dashboard cache keys} *)
 
@@ -60,6 +61,7 @@ type keeper_post_route_kind =
   | Keeper_post_checkpoints
   | Keeper_post_directive
   | Keeper_post_catchup_judge
+  | Keeper_post_create
   | Keeper_post_unknown
 (** Sub-route kind for a [POST /api/v1/keepers/<name>/...] path. *)
 

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -1737,6 +1737,14 @@ let add_routes ~sw ~clock router =
                  Keeper_api.handle_keeper_catchup_judge_post state req reqd body_str
                )
              ) request reqd
+       | Keeper_api.Keeper_post_create ->
+           with_token_permission_auth ~permission:Masc_domain.CanAdmin
+             (fun state agent_name req reqd ->
+               Http.Request.read_body_async reqd (fun body_str ->
+                 Keeper_api.handle_keeper_create_post
+                   ~sw ~clock state agent_name req reqd body_str
+               )
+             ) request reqd
        | Keeper_api.Keeper_post_unknown ->
            respond_dashboard_error ~status:`Not_found reqd "not found")
 

--- a/test/dune
+++ b/test/dune
@@ -328,6 +328,7 @@
   test_runtime_mcp_policy_auth
   test_keeper_classifier_helper
   test_keeper_create_validate
+  test_keeper_create_no_boot
   test_turn_id_propagation
   test_auth_strict_mode
   test_keeper_turn_fsm_emit
@@ -660,6 +661,7 @@
   test_runtime_mcp_policy_auth
   test_keeper_classifier_helper
   test_keeper_create_validate
+  test_keeper_create_no_boot
   test_turn_id_propagation
   test_auth_strict_mode
   test_keeper_turn_fsm_emit

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -150,6 +150,25 @@ let test_keeper_post_route_classifies_catchup_judge () =
     (Server_dashboard_http_keeper_api.extract_keeper_name_for_suffix path
        Server_dashboard_http_keeper_api.keeper_suffix_catchup_judge)
 
+let test_keeper_post_route_classifies_create () =
+  let path = "/api/v1/keepers/noboot-probe/create" in
+  check bool "create route kind" true
+    (Server_dashboard_http_keeper_api.classify_keeper_post_route path
+     = Server_dashboard_http_keeper_api.Keeper_post_create);
+  check string "keeper name extracted" "noboot-probe"
+    (Server_dashboard_http_keeper_api.extract_keeper_name_for_post path
+       Server_dashboard_http_keeper_api.keeper_suffix_create);
+  (* Unknown suffixes stay 404-classified — the new arm must not widen
+     the parser. *)
+  check bool "unrelated suffix stays unknown" true
+    (Server_dashboard_http_keeper_api.classify_keeper_post_route
+       "/api/v1/keepers/noboot-probe/created"
+     = Server_dashboard_http_keeper_api.Keeper_post_unknown);
+  check bool "bare collection path stays unknown" true
+    (Server_dashboard_http_keeper_api.classify_keeper_post_route
+       "/api/v1/keepers/create"
+     = Server_dashboard_http_keeper_api.Keeper_post_unknown)
+
 let test_keeper_chat_receipt_route_and_json () =
   let receipt_id =
     match
@@ -1858,6 +1877,8 @@ let () =
             test_state_diagram_runtime_projection_missing_meta_stays_empty;
           test_case "keeper catch-up judge route is classified" `Quick
             test_keeper_post_route_classifies_catchup_judge;
+          test_case "keeper create route is classified, unknown stays 404"
+            `Quick test_keeper_post_route_classifies_create;
           test_case "keeper chat receipt route is typed" `Quick
             test_keeper_chat_receipt_route_and_json;
         ] );

--- a/test/test_keeper_create_no_boot.ml
+++ b/test/test_keeper_create_no_boot.ml
@@ -1,0 +1,215 @@
+(** test_keeper_create_no_boot — create-without-boot acceptance (WO-A5-3a/3b/3c).
+
+    [Keeper_tool_persona_runtime.create_configured_only] writes the durable
+    TOML (pinned autoboot_enabled=false, pinned sandbox_profile) and the
+    list-visible meta with no boot side effect: the keeper must appear in
+    [keeper_names], must NOT be registered, and reconcile must classify it
+    [Declarative_autoboot_disabled]. Duplicate names and an explicit
+    autoboot_enabled=true are explicit errors, and a post-persist failure
+    removes the freshly written TOML instead of leaving an orphan. *)
+
+module Workspace = Masc.Workspace
+module Store = Masc.Keeper_meta_store
+module Profile = Masc.Keeper_types_profile
+module Persona_runtime = Masc.Keeper_tool_persona_runtime
+module Keeper_runtime = Masc.Keeper_runtime
+module Keeper_registry = Masc.Keeper_registry
+
+let temp_dir () =
+  let path = Filename.temp_file "keeper-create-no-boot-" "" in
+  Sys.remove path;
+  Unix.mkdir path 0o755;
+  path
+
+let rec mkdir_p path =
+  if Sys.file_exists path then ()
+  else (
+    let parent = Filename.dirname path in
+    if not (String.equal parent path) then mkdir_p parent;
+    Unix.mkdir path 0o755)
+
+let rec rm_rf path =
+  try
+    if Sys.file_exists path then
+      if Sys.is_directory path then (
+        Sys.readdir path
+        |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+        Unix.rmdir path)
+      else Sys.remove path
+  with _ -> ()
+
+let restore_env name = function
+  | Some value -> Unix.putenv name value
+  | None -> Unix.putenv name ""
+
+let contains ~affix s =
+  let n = String.length affix and m = String.length s in
+  let rec go i = i + n <= m && (String.sub s i n = affix || go (i + 1)) in
+  n = 0 || go 0
+
+let read_file path =
+  let ic = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () -> really_input_string ic (in_channel_length ic))
+
+let with_config_dir f =
+  let base = temp_dir () in
+  let config_dir = Filename.concat base ".masc/config" in
+  mkdir_p (Filename.concat config_dir "keepers");
+  let previous = Sys.getenv_opt "MASC_CONFIG_DIR" in
+  Fun.protect
+    ~finally:(fun () ->
+      restore_env "MASC_CONFIG_DIR" previous;
+      Config_dir_resolver.reset ();
+      rm_rf base)
+    (fun () ->
+      Unix.putenv "MASC_CONFIG_DIR" config_dir;
+      Config_dir_resolver.reset ();
+      f ~base)
+
+let with_ctx f =
+  with_config_dir @@ fun ~base ->
+  let config = Workspace.default_config base in
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let ctx : _ Profile.context =
+    {
+      config;
+      agent_name = "test-agent";
+      sw;
+      clock = Eio.Stdenv.clock env;
+      proc_mgr = None;
+      net = None;
+    }
+  in
+  f ~base ~config ~ctx
+
+let resolved_args ?(extra = []) name =
+  `Assoc
+    ([
+       ("name", `String name);
+       ("persona_name", `String "probe");
+       ("goal", `String "configured only probe");
+       ("instructions", `String "");
+       ("mention_targets", `List [ `String name ]);
+     ]
+    @ extra)
+
+let test_configured_only_create () =
+  with_ctx @@ fun ~base ~config ~ctx ->
+  let name = "noboot-probe" in
+  match Persona_runtime.create_configured_only ctx (resolved_args name) with
+  | Error e -> Alcotest.failf "create_configured_only failed: %s" e
+  | Ok payload ->
+      (match payload with
+       | `Assoc fields ->
+           Alcotest.(check (option bool))
+             "payload booted=false" (Some false)
+             (match List.assoc_opt "booted" fields with
+              | Some (`Bool b) -> Some b
+              | _ -> None);
+           (match List.assoc_opt "path" fields with
+            | Some (`String path) ->
+                Alcotest.(check bool) "TOML written" true (Sys.file_exists path);
+                let toml = read_file path in
+                Alcotest.(check bool)
+                  "TOML pins autoboot_enabled=false" true
+                  (contains ~affix:"autoboot_enabled = false" toml);
+                Alcotest.(check bool)
+                  "TOML pins sandbox_profile" true
+                  (contains ~affix:{|sandbox_profile = "docker"|} toml)
+            | _ -> Alcotest.fail "payload missing path")
+       | _ -> Alcotest.fail "payload must be an object");
+      Alcotest.(check bool)
+        "meta visible in keeper_names" true
+        (List.mem name (Store.keeper_names config));
+      Alcotest.(check bool)
+        "not registered" false
+        (Keeper_registry.is_registered ~base_path:base name);
+      (* [autoboot_enabled] is a TOML-owned field: [meta_to_json] scrubs it
+         from the persisted JSON and the read-back default is true, so the
+         raw meta field is NOT the contract — the TOML pin is. Assert the
+         effective (TOML-aware) value instead. *)
+      (match Store.read_meta config name with
+       | Ok (Some meta) ->
+           Alcotest.(check bool)
+             "effective autoboot disabled" false
+             (Store.effective_autoboot_enabled config name meta)
+       | Ok None -> Alcotest.fail "meta missing after configured-only create"
+       | Error e -> Alcotest.failf "read_meta failed: %s" e);
+      Alcotest.(check (option string))
+        "reconcile classifies Declarative_autoboot_disabled"
+        (Some "declarative_autoboot_disabled")
+        (Keeper_runtime.autoboot_exclusion_reason config name
+        |> Option.map Keeper_runtime.autoboot_exclusion_reason_to_string)
+
+let test_duplicate_rejected () =
+  with_ctx @@ fun ~base:_ ~config:_ ~ctx ->
+  let name = "noboot-dup" in
+  (match Persona_runtime.create_configured_only ctx (resolved_args name) with
+   | Error e -> Alcotest.failf "first create failed: %s" e
+   | Ok _ -> ());
+  match Persona_runtime.create_configured_only ctx (resolved_args name) with
+  | Ok _ -> Alcotest.fail "duplicate create must be an explicit error"
+  | Error e ->
+      Alcotest.(check bool)
+        "error names the existing config" true
+        (contains ~affix:"already exists" e)
+
+let test_autoboot_conflict_rejected () =
+  with_ctx @@ fun ~base ~config:_ ~ctx ->
+  let name = "noboot-conflict" in
+  match
+    Persona_runtime.create_configured_only ctx
+      (resolved_args ~extra:[ ("autoboot_enabled", `Bool true) ] name)
+  with
+  | Ok _ -> Alcotest.fail "autoboot_enabled=true must conflict with no_boot"
+  | Error e ->
+      Alcotest.(check bool)
+        "error explains the conflict" true
+        (contains ~affix:"autoboot_enabled=true" e);
+      let path =
+        Filename.concat
+          (Config_dir_resolver.keepers_dir_for_base_path ~base_path:base)
+          (name ^ ".toml")
+      in
+      Alcotest.(check bool) "no TOML written" false (Sys.file_exists path)
+
+let test_orphan_toml_removed_on_parse_failure () =
+  with_ctx @@ fun ~base ~config:_ ~ctx ->
+  let name = "noboot-orphan" in
+  (* [tool_access] passes the persist layer (it renders only known fields)
+     but is a removed input key for the keeper_up parser, so the failure
+     fires after the TOML write — exactly the orphan-compensation path. *)
+  match
+    Persona_runtime.create_configured_only ctx
+      (resolved_args ~extra:[ ("tool_access", `String "full") ] name)
+  with
+  | Ok _ -> Alcotest.fail "removed input key must fail the parse"
+  | Error _ ->
+      let path =
+        Filename.concat
+          (Config_dir_resolver.keepers_dir_for_base_path ~base_path:base)
+          (name ^ ".toml")
+      in
+      Alcotest.(check bool)
+        "freshly written TOML removed on failure" false
+        (Sys.file_exists path)
+
+let () =
+  Alcotest.run "keeper_create_no_boot"
+    [
+      ( "configured_only",
+        [
+          Alcotest.test_case
+            "create writes TOML+meta, no registry, autoboot excluded" `Quick
+            test_configured_only_create;
+          Alcotest.test_case "duplicate name is an explicit error" `Quick
+            test_duplicate_rejected;
+          Alcotest.test_case "autoboot_enabled=true conflicts" `Quick
+            test_autoboot_conflict_rejected;
+          Alcotest.test_case "orphan TOML removed on post-persist failure"
+            `Quick test_orphan_toml_removed_on_parse_failure;
+        ] );
+    ]


### PR DESCRIPTION
## A5-3: create-without-boot (Configured-not-Running)

**Stacked PR** — base = `feat/a5-create-meta-build` (#24364). 이 diff는 A5-3만 담습니다. #24364 머지 후 base를 main으로 리타깃합니다.

설계 SSOT: `~/me/planning/claude-plans/2026-07-13-persona-registry-v2-blueprint.md` Track A §A5-3 (WO-A5-3a/3b/3c). 적대 검증에서 REFUTED된 "register_offline 좀비" 경로를 쓰지 않는 것이 핵심: registry에 어떤 항목도 만들지 않고, TOML `autoboot_enabled=false` 고정으로 reconcile이 `Declarative_autoboot_disabled`로 분류하게 합니다.

### 1st commit — 파생 추출 (동작 보존)
- `derive_create_inputs : parsed_args -> derived_create_inputs` — 생성 시점 필드 해석(운영자 인자 > profile defaults > env/runtime-param 기본값)을 단일 함수로. `create_keeper`는 레코드를 기존 바인딩 이름으로 destructuring — 이후 본문(메타 빌드·체크포인트·keepalive)은 텍스트 동일.
- `unknown_active_goal_ids_error` — Goal_store 읽기는 순수 파생 밖에 유지.
- 부팅 경로와 configured-only 경로가 같은 함수를 쓰는 것이 드리프트 방지의 본체.

### 2nd commit — no_boot 본체
- **`persist_new_keeper_toml_configured_only`**: fresh-only(기존 TOML은 silent already_exists no-op이 아니라 명시 에러, WO-A5-3b) · TOML에 `autoboot_enabled=false` 고정(명시적 true는 거부되는 충돌) · `base_path` 스코프 resolver 사용(전역 keepers_dir 아님, WO-A5-3c).
- **`create_keeper_configured_only`**: meta를 부팅 경로와 **같은 parse+파생**으로 구성, 게이트 에러 문자열 동일. `generation=0` — 예약하면 base_path 밖 전역 keepers dir에 런타임 아티팩트를 쓰게 됨(Test_isolation_breach #24280 계열 회피; 0은 신선한 예약이 돌려주는 값과 동일).
- **`create_configured_only` 조합**: TOML 먼저 기록 → parse가 방금 쓴 파일에서 profile defaults(고정된 sandbox_profile 포함)를 읽음 → meta 기록. 후속 단계 실패 시 방금 쓴 TOML 제거(고아 config 방지).
- **render가 `sandbox_profile = "docker"`를 생성 TOML에 고정**: reconcile 부팅 게이트는 선언된 sandbox_profile에 fail-closed(#11080)이고 persona는 capability 필드를 소유할 수 없으므로(D-9), 기존 생성 TOML은 reconcile을 통과할 수 없었음. Docker는 라이브 fleet 만장일치 값(13/13 TOML, 2026-07-14) — Local이면 누락 시 격리가 벗겨짐. 사후 변경은 config panel 경유.
- 핸들러: `no_boot` 인자(스키마 문서화), autoboot 충돌은 효과(Goal mint·TOML 기록) 전에 조기 거부, dry_run 응답에 `no_boot` 에코. `initial_goal`(D-10a)과 조합 동작.

### 3rd commit — A5-3d: REST create 라우트
- `POST /api/v1/keepers/<name>/create` — `keeper_suffix_create`+`Keeper_post_create` variant+분류 arm(boundary parser 연장, unknown suffix 404 유지 — `/keepers/create`(이름 없음)·`/created` 비확장 테스트로 고정).
- 핸들러는 얇게: path name이 body name보다 우선, 나머지 body 필드(persona_name/initial_goal/no_boot/dry_run…)는 도구로 무변형 통과 — REST 표면이 도구 계약에서 드리프트 불가. 성공=execution surface 무효화, 도구 거부=400, dispatch 부재=500.
- 인증: 다른 keeper lifecycle POST와 동일한 `with_token_permission_auth CanAdmin`.
- `test_dashboard_http_core` 51/51 (신규 분류 케이스 포함).

### WO-A5-3e: sigil/slot — 실측 결과 신규 코드 없음 (기존 파생 재사용 확정)
blueprint의 선행 확인 조항("기존 defaulting 실측 후 있으면 재사용") 이행 결과: sigil/slot은 백엔드 필드가 아니라 **대시보드 `keeper-badge.ts`가 이미 keeper id의 순수 함수로 결정론 파생** 중 — `kSigil(id)`(글리프)+`kSlot(id)`(FNV-1a 32-bit→1..12, SPEC §3.6 "color alone never identifies a keeper"). create 인자·저장 상태·wizard 질문 모두 불필요(D-8과 이미 일치). 시안의 "최소 사용 슬롯" 할당은 지속 상태+충돌 semantics를 새로 요구하므로 채택하지 않음. sandbox 기본값 조항은 2nd 커밋의 render pin(docker)으로 이행됨.

### 검증 (실측)
- `test_keeper_create_no_boot` 4/4: ①TOML+meta 기록·registry 미등록·`Declarative_autoboot_disabled` 분류 ②중복 이름 명시 에러 ③autoboot_enabled=true 충돌 거부(TOML 미기록) ④parse 실패 시 고아 TOML 제거.
- `test_keeper_toml` 99/99 (render 변경 회귀 없음), `test_keeper_create_validate` 4/4.
- meta의 `autoboot_enabled`는 TOML-소유 필드(`meta_to_json` 스크럽, 읽기 기본 true) — 계약은 raw 필드가 아니라 `effective_autoboot_enabled`(TOML-aware)로 assert.
- 로컬 실행은 공유 opam switch의 oas WIP pin(자세히: #24364 body) 때문에 미커밋 일시 스캐폴드로 수행 후 원복(working tree clean).

### 미검증/한계
- **boot-later 경로**: no_boot 생성 후 `masc_keeper_up`은 meta-존재 분기(update_keeper→start_keepalive)로 부팅되는 구조이나, 체크포인트/세션 부재 내성은 통합 수준 검증 필요 — follow-up 항목.
- CI Build and Test는 main-red 2층(#24281/#24363) 상속 예정. drift gate 실패 시 quick suite가 skip되므로 base green 후 재확인 필요.
- **스택 PR이라 빌드 스위트 미트리거(실측)**: base=feature 브랜치인 PR은 경량 체크 4종만 돌았음(TLA+ drift/check×2/ocamlformat 전부 pass). 현재 rollup green은 **빌드 증거가 아님** — #24364 머지 후 main 리타깃 시점에 Build and Test가 처음 돕니다. 로컬 실행 증거(4/4, 99/99)가 현 시점의 실검증.

RFC-WAIVED: 설계 SSOT는 blueprint A5-3 + 적대 검증 메모리(2026-07-13) — credential/operator/hooks 등 RFC 의무 subsystem 비접촉

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)




## 적대 재리뷰 대응 (rebase → head `f75c1b1e8d`)

1. **스택 상속 P1×2 해소**: base #24364의 orphan Goal(P1-1)·reconcile 회귀(P1-2) 수정 커밋(`75219c0e`) 위로 rebase. 이 PR의 no_boot 경로도 같은 규율로 재구성 — **mint를 validate 통과 뒤 no_boot/boot 공통 지점으로 이동**(no_boot keeper도 Goal 엔티티를 받음, D-10a 일관), `create_configured_only` 실패 시 minted goal을 boot 경로와 같은 meta-aware 규칙으로 release(자체 orphan TOML 제거와 대칭). 테스트: no_boot 4/4 + mint_order 가드 2/2 + validate 5/5 green.
2. **CI 증거**: base가 main 리타깃되면(=#24364 머지 후) 첫 실 Build and Test가 생성된다. 리타깃 전이라도 이번 rebase로 main `6f11b23f`(#24362 drift gate 해소)를 상속하므로, 리타깃 시점 CI는 quick suite가 skip 없이 실행된다.
3. **purge 열린 질문 — 답변 완료**: no_boot keeper(TOML+meta, registry 없음)는 대시보드 purge 라우트가 `submit_dormant`(Dormant_meta) 분기로 완전 삭제한다(TOML 아티팩트 포함). 단 MCP `masc_keeper_down`은 registry-less keeper를 거부(untracked cleanup 방어)하므로 정리는 대시보드 purge로만 가능하고, `masc_keeper_up`은 meta 기반 update→start_keepalive로 부팅시킨다(Declarative_autoboot_disabled는 autoboot loop 전용). 상세 근거는 코멘트 참조. 인접 gap(purge가 minted Goal 미정리)은 별도 이슈로 기록.
