### PR TITLE
fix(runtime): migrate stream_idle_timeout_s off transport (OAS 0.211.10) — main red

### DIFF
--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -289,15 +289,17 @@ let provider_config_preserving_http_transport
     ~sw
     ~net
     ?clock
-    ?stream_idle_timeout_s
     ?body_timeout_s
     ~(provider_cfg : Llm_provider.Provider_config.t)
     ()
   : Llm_provider.Llm_transport.t =
+  (* RFC-OAS-026: stream_idle_timeout_s moved off transport construction
+     (OAS 0.211.10 "remove implicit execution limits") and is now applied at
+     the agent builder via [Agent_sdk.Builder.with_stream_idle_timeout]. The
+     transport itself carries no idle deadline; OAS does not infer one. *)
   let http_transport =
     Llm_provider.Complete.make_http_transport
       ?clock
-      ?stream_idle_timeout_s
       ?body_timeout_s
       ~sw
       ~net
@@ -327,12 +329,13 @@ let provider_config_preserving_http_transport
           (patch_request req));
     }
 
-let transport_for_provider ~sw ~net ?clock ?stream_idle_timeout_s ?body_timeout_s ~provider_cfg () =
+let transport_for_provider ~sw ~net ?clock ?body_timeout_s ~provider_cfg () =
   (* CLI subprocess transport removed (2026-05-31); every provider dispatches
      over HTTP. Runtime MCP policy is applied via the tool-lane resolver and
      per-request patching, not at transport construction, so it is no longer
-     threaded here. *)
-  Ok (Some (provider_config_preserving_http_transport ~sw ~net ?clock ?stream_idle_timeout_s ?body_timeout_s ~provider_cfg ()))
+     threaded here. stream_idle_timeout_s is applied at the builder, not here
+     (see RFC-OAS-026 note above). *)
+  Ok (Some (provider_config_preserving_http_transport ~sw ~net ?clock ?body_timeout_s ~provider_cfg ()))
 
 let runtime_id_of_config (config : config) =
   let runtime_prefix = "runtime:" in
@@ -944,7 +947,6 @@ let build
          ~sw
          ~net
          ?clock
-         ?stream_idle_timeout_s:config.stream_idle_timeout_s
          ?body_timeout_s:config.body_timeout_s
          ~provider_cfg:config.provider_cfg
          ()
@@ -1051,7 +1053,6 @@ let resume_from_checkpoint
          ~sw
          ~net
          ?clock
-         ?stream_idle_timeout_s:config.stream_idle_timeout_s
          ?body_timeout_s:config.body_timeout_s
          ~provider_cfg:config.provider_cfg
          ()


### PR DESCRIPTION
## 뭘 고쳤나
main 빌드 에러(`runtime_agent.ml:300` `?stream_idle_timeout_s cannot be applied`) 해결. head `032dd156a1`.

## 근본
OAS 0.211.10(commit `eed7ce6f` *"remove implicit execution limits"*)가 `stream_idle_timeout_s`를 `Complete.make_http_transport`(transport 생성)에서 빼고 `Agent_sdk.Builder.with_stream_idle_timeout`으로 이동. masc `#24335` 머지가 구 API(transport에 `stream_idle` 넘김)를 그대로 둬 **main red**(B&T failure).

## 수정
transport 생성 체인(`make_http_transport` / `provider_config_preserving_http_transport` / `transport_for_provider` + build/resume 호출)에서 `?stream_idle_timeout_s` 제거.

## regression 점검 (idle 동작 유지)
idle deadline은 이미 올바른 곳에 있었다:
- **build**: `Runtime_agent_context.builder_without_approval`(line 270)이 `with_stream_idle_timeout` 적용.
- **resume**: `prepare_resume`(line 516) agent_config `stream_idle_timeout_s` 필드.

즉 transport 체인만 구 API 잔재 → 제거해도 idle 동작 유지.

## 검증
- 워크트리 `dune build --root .` **exit 0**(에러 없음).
- main CI B&T = **failure**(동일 에러) → 본 PR로 해결.

Co-Authored-By: Claude <noreply@anthropic.com>