### PR TITLE
test(keeper): retarget write_meta silent-failure guard after #24332 supervisor split (quick-suite unmasking 1/N)

### DIFF
--- a/test/test_keeper_supervisor_write_meta_source.ml
+++ b/test/test_keeper_supervisor_write_meta_source.ml
@@ -18,11 +18,20 @@
     Keeper_registry fixture to exercise; the risk we guard against is
     exactly that someone collapses the handler back to [ignore] during
     cleanup.
+
+    #24332 split the supervisor: the guarded presence-sync call site moved
+    from [keeper_supervisor.ml] to
+    [keeper_supervisor_supervise_keepalive.ml] (the [match write_meta ...]
+    with its [Error] arm moved intact). The guard follows the call site —
+    the old file no longer contains any [write_meta], which made check (b)
+    fail while the behaviour it pinned was alive in the new module. This
+    failure surfaced only when the quick suite unskipped (it had been
+    masked behind the env-knob gate).
 *)
 
 open Alcotest
 
-let target_file = "lib/keeper/keeper_supervisor.ml"
+let target_file = "lib/keeper/keeper_supervisor_supervise_keepalive.ml"
 
 let load_source rel =
   let source_root =


### PR DESCRIPTION
main quick-suite unmasking의 1건: #8391 가드가 보던 presence-sync `write_meta` 콜사이트가 #24332 supervisor 분할에서 `keeper_supervisor_supervise_keepalive.ml:131`로 **온전히 이사**(match + Error arm 유지) — 회귀 아님, 가드 재조준. 옛 파일에는 write_meta가 0건이라 check (b)가 헛발 실패.

이 실패가 지금 드러난 이유: env-knob drift gate 실패가 `Run tests (quick suite)` 스텝을 skip시키던 기간 동안 마스킹 — 게이트 해소로 스위트가 처음 다시 돌면서 표면화. 같은 기간의 누적 실패 ~20그룹은 별도 umbrella 이슈로 추적.

로컬 2/2 green.

RFC-WAIVED: 테스트 파일 단건 재조준

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
