### PR TITLE
test(task): pin prompt resolution for the coverage suite — CI sandbox 'Prompt missing' (unmasking 2/N, biggest group)

### DIFF
--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -9,6 +9,36 @@ let () = Random.self_init ()
 let () = Mirage_crypto_rng_unix.use_default ()
 let () = Keeper_task_owner_backend.install_hooks ()
 
+(* The completion-review path renders the registry prompt
+   [verification.anti_rationalization]. This executable never pinned a
+   markdown dir, so prompt resolution depended on whatever the host/dune
+   context happened to expose — green on developer machines, "Prompt ...
+   is missing" inside the CI dune sandbox, which failed every
+   handle_done / handle_transition LLM-review case (quick-suite
+   unmasking #24377). Pin resolution to the repo's own prompt files —
+   the same idiom test_keeper_deliberation uses; that executable passes
+   inside the CI sandbox, so the mechanism is CI-proven. *)
+let has_prompt_root path =
+  Sys.file_exists
+    (Filename.concat path "config/prompts/verification.anti_rationalization.md")
+
+let repo_root () =
+  match Sys.getenv_opt "DUNE_SOURCEROOT" with
+  | Some root when has_prompt_root root -> root
+  | _ ->
+      let rec ascend path =
+        if has_prompt_root path then path
+        else
+          let parent = Filename.dirname path in
+          if String.equal parent path then Sys.getcwd () else ascend parent
+      in
+      ascend (Sys.getcwd ())
+
+let () =
+  Prompt_registry.set_markdown_dir
+    (Filename.concat (repo_root ()) "config/prompts");
+  Masc.Prompt_defaults.init ()
+
 let test_runtime_toml =
   {|
 [runtime]


### PR DESCRIPTION
#24377 unmasking의 최대 그룹(coverage 14케이스) 수정.

**진단**: `test_tool_task_coverage`는 Prompt_registry markdown dir을 핀하지 않아 `verification.anti_rationalization` 해석이 호스트/dune 컨텍스트 임의에 의존 — 개발자 머신 green, **CI dune 샌드박스에서 "Prompt … is missing"** → completion verifier fail-closed → handle_done/handle_transition LLM-review 14케이스 전멸. quick suite가 unskip되는 순간 표면화.

**수정**: repo `config/prompts`를 `DUNE_SOURCEROOT`(+ascend fallback)로 핀 — `test_keeper_deliberation`과 동일 관용구이며, 그 실행 파일이 **CI 샌드박스 안에서 통과함을 같은 런 로그로 확인**(메커니즘 CI-proven). 로컬 102/102.

**판정**: stale/env 결함 — 제품 회귀 아님 (verifier의 fail-closed 동작 자체는 올바름).

RFC-WAIVED: 테스트 환경 결정론 수정 단건

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
