### PR TITLE
fix(prompts): resolve markdown dir from DUNE_SOURCEROOT when unpinned (unmasking 3/N)

### DIFF
--- a/lib/prompt_registry/prompt_registry.ml
+++ b/lib/prompt_registry/prompt_registry.ml
@@ -221,7 +221,32 @@ let set_markdown_dir dir =
   with_override_mutation_lock (fun () ->
       with_mutex (fun () -> markdown_dir := Some dir))
 
-let get_markdown_dir () = !markdown_dir
+(* Dune-context fallback for the markdown dir (quick-suite unmasking
+   #24377, 'Prompt ... is missing' class). Production always pins the dir
+   through [Prompt_defaults.bootstrap_runtime], and an explicit
+   [set_markdown_dir] always wins. Test executables, however, run inside
+   dune's sandbox where the cwd has no [config/prompts]; every executable
+   that forgot the per-test pin resolved prompts to "missing" only in CI.
+   DUNE_SOURCEROOT is set by dune for every build/exec/runtest and absent
+   in production processes, so this is a deterministic, environment-scoped
+   branch — not a permissive default: outside dune the behaviour is
+   byte-identical to before (None). Tests that need true prompt absence
+   pin an explicit empty dir (see [with_task_create_prompt_missing] in
+   test_keeper_prompt_external.ml), which this never overrides. *)
+let dune_sourceroot_markdown_dir =
+  lazy
+    (match Sys.getenv_opt "DUNE_SOURCEROOT" with
+    | None -> None
+    | Some root ->
+        let dir = Filename.concat (Filename.concat root "config") "prompts" in
+        if Sys.file_exists dir && Sys.is_directory dir then Some dir else None)
+
+let effective_markdown_dir () =
+  match !markdown_dir with
+  | Some _ as pinned -> pinned
+  | None -> Lazy.force dune_sourceroot_markdown_dir
+
+let get_markdown_dir () = effective_markdown_dir ()
 
 let is_valid_prompt_key key =
   key <> ""
@@ -234,7 +259,9 @@ let is_valid_prompt_key key =
 let prompt_markdown_path key =
   if not (is_valid_prompt_key key) then None
   else
-    Option.map (fun dir -> Filename.concat dir (key ^ ".md")) !markdown_dir
+    Option.map
+      (fun dir -> Filename.concat dir (key ^ ".md"))
+      (effective_markdown_dir ())
 
 (** Read a markdown file, stripping YAML frontmatter if present.
     Returns only the body after the closing [---] delimiter. *)

--- a/lib/prompt_registry/prompt_registry.mli
+++ b/lib/prompt_registry/prompt_registry.mli
@@ -124,8 +124,11 @@ val set_markdown_dir : string -> unit
     looks under for [<key>.md]. *)
 
 val get_markdown_dir : unit -> string option
-(** Returns the currently-pinned markdown dir, [None] if
-    {!set_markdown_dir} was never called. *)
+(** Returns the effective markdown dir: the {!set_markdown_dir} pin when
+    one exists, else — only when DUNE_SOURCEROOT is set (dune build/test
+    context, never production) and [<root>/config/prompts] exists — that
+    directory. [None] otherwise. Tests that need true prompt absence pin
+    an explicit empty directory instead of relying on the unset state. *)
 
 val load_prompts_from_directory : string -> unit
 (** Auto-discovers [*.md] files under [dir], parses YAML

--- a/test/dune
+++ b/test/dune
@@ -1938,6 +1938,8 @@
 
 (include stanzas/test_keeper_supervisor_write_meta_source.inc)
 
+(include stanzas/test_prompt_registry_dune_fallback.inc)
+
 (include stanzas/test_keeper_surface_status.inc)
 
 (include stanzas/test_keeper_memory_write.inc)

--- a/test/stanzas/test_prompt_registry_dune_fallback.inc
+++ b/test/stanzas/test_prompt_registry_dune_fallback.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_prompt_registry_dune_fallback)
+ (modules test_prompt_registry_dune_fallback)
+ (libraries masc_test_deps))

--- a/test/test_prompt_registry_dune_fallback.ml
+++ b/test/test_prompt_registry_dune_fallback.ml
@@ -1,0 +1,69 @@
+(** Behavioural pin for the DUNE_SOURCEROOT markdown-dir fallback
+    (quick-suite unmasking #24377, 'Prompt ... is missing' class).
+
+    Contract under test, in priority order:
+
+    - (a) with no [set_markdown_dir] pin, a test executable running under
+          dune (DUNE_SOURCEROOT set, [<root>/config/prompts] exists)
+          resolves prompts through the fallback — the failure mode that
+          broke dozens of quick-suite executables inside the CI sandbox
+          can no longer exist
+    - (b) an explicit [set_markdown_dir] pin always wins over the
+          fallback, so fixtures that pin an empty directory to exercise
+          true prompt absence (test_keeper_prompt_external's
+          [with_task_create_prompt_missing]) keep working
+
+    This suite runs under dune, so DUNE_SOURCEROOT is present by
+    construction; the no-dune (production) branch is byte-identical to the
+    pre-change behaviour and is not reachable from a dune-run test. *)
+
+open Alcotest
+
+(* A prompt file that ships in config/prompts/ and is rendered on the live
+   completion-review path — the exact key the CI failures named. *)
+let known_prompt_key = "verification.anti_rationalization"
+
+let test_fallback_engages_when_unpinned () =
+  Prompt_registry.clear ();
+  (match Prompt_registry.get_markdown_dir () with
+   | Some dir ->
+       check bool "fallback dir is <root>/config/prompts" true
+         (Filename.check_suffix dir (Filename.concat "config" "prompts"))
+   | None ->
+       fail
+         "expected the DUNE_SOURCEROOT fallback to engage for an unpinned \
+          registry under dune");
+  check bool "a shipped prompt resolves through the fallback" true
+    (String.trim (Prompt_registry.get_prompt known_prompt_key) <> "")
+
+let test_explicit_pin_wins_over_fallback () =
+  Prompt_registry.clear ();
+  let dir = Filename.temp_file "prompt-fallback-pin" "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o700;
+  Fun.protect
+    ~finally:(fun () ->
+      Prompt_registry.clear ();
+      try Unix.rmdir dir with Unix.Unix_error _ -> ())
+    (fun () ->
+      Prompt_registry.set_markdown_dir dir;
+      (match Prompt_registry.get_markdown_dir () with
+       | Some pinned -> check string "pin is visible, not the fallback" dir pinned
+       | None -> fail "explicit pin must be visible through get_markdown_dir");
+      check string
+        "prompt is truly absent under an empty pinned dir (fallback does \
+         not leak through)"
+        ""
+        (String.trim (Prompt_registry.get_prompt known_prompt_key)))
+
+let () =
+  run "prompt_registry_dune_fallback"
+    [
+      ( "markdown_dir_fallback",
+        [
+          test_case "unpinned registry falls back to DUNE_SOURCEROOT" `Quick
+            test_fallback_engages_when_unpinned;
+          test_case "explicit pin wins over the fallback" `Quick
+            test_explicit_pin_wins_over_fallback;
+        ] );
+    ]


### PR DESCRIPTION
## 'Prompt … is missing' 클래스 근본 수정 (quick-suite unmasking #24377, 3/N)

**문제**: main run 29309190508의 quick suite 실패 41스위트 중 46곳에서 `Prompt 'verification.anti_rationalization' is missing`. 테스트 실행 파일은 dune 샌드박스(cwd에 config/prompts 없음)에서 돌고, per-test `set_markdown_dir` 핀을 빠뜨린 모든 실행 파일이 CI에서만 프롬프트 해석에 실패한다(개발 머신에서는 우연히 green).

**왜 per-exe 핀 반복이 아닌가**: #24378이 실행 파일 1개를 per-exe 핀으로 고쳤다. 남은 수십 개에 같은 핀을 복붙하는 것은 CLAUDE.md 워크어라운드 기준의 N-of-M 시그니처("같은 변환을 N개 사이트에서 N번") 그 자체다. 같은 메커니즘(DUNE_SOURCEROOT)을 라이브러리 해석 기본값으로 승격해 1곳에서 클래스를 닫는다.

**변경** (`lib/prompt_registry` 2파일, +34/−4):
- markdown dir이 **핀되지 않았고** `DUNE_SOURCEROOT`가 존재(=모든 dune build/exec/runtest, 프로덕션 프로세스엔 절대 없음)하며 `<root>/config/prompts`가 실재할 때만 그 디렉토리로 폴백 — 환경 스코프가 닫힌 결정론적 분기이며 permissive default가 아님.
- 명시적 `set_markdown_dir`가 항상 우선 — 빈 dir을 핀해 "프롬프트 부재"를 검증하는 픽스처(`with_task_create_prompt_missing`) 무영향.
- dune 밖 동작은 byte-identical(None). `.mli` 문서 갱신.

**검증 (실측 A/B, stash로 유무 비교)**:
| 스위트 | 폴백 없음 | 폴백 있음 |
|---|---|---|
| test_completion_trust_harness | 4/7 fail | **2/7 fail** (잔여 2 = pre-existing evaluator-mock 클래스, 양쪽 동일) |
| test_keeper_prompt_external (명시 핀 픽스처) | 10/10 pass | **10/10 pass** (무영향) |
| anti_rationalization_empty_reject | 2/4 fail | 2/4 fail (pre-existing, 무변화) |
| ocaml_north_star_task_lifecycle | 2/5 fail | 2/5 fail (pre-existing, 무변화) |

새 실패 0, OK→FAIL 뒤집힘 0. 잔여 실패들은 prompt 클래스가 아니라 evaluator-mock/행동 드리프트 클래스로, umbrella #24377에서 그룹별 트리아지 계속.

**env knob 게이트**: `DUNE_SOURCEROOT`는 dune이 세팅하는 비-MASC_* 변수로 catalog 스코프 밖 (gate는 MASC_* 신설을 검사).

RFC-WAIVED: 단일 해석-기본값 gap 수정 — 신규 architecture 없음, #24377 umbrella + #24378 선례의 클래스 승격

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
