### PR TITLE
fix(lint): drop comment-terminator trap sequence from oas_env warn string

### DIFF
--- a/lib/keeper/keeper_types_profile_oas_env.ml
+++ b/lib/keeper/keeper_types_profile_oas_env.ml
@@ -59,7 +59,7 @@ let extract_oas_env_from_doc (doc : Keeper_toml_loader.toml_doc)
             ();
           Log.Keeper.warn
             "keeper.oas_env: dropping key=%S — suffix %S not in \
-             allowlist (OAS_<PROVIDER>_*); \
+             allowlist (OAS_<PROVIDER>_...); \
              fix the TOML or expand the allowlist"
             k
             suffix;


### PR DESCRIPTION
## 무엇을

main Lint Suite RED 복구 — `lib/keeper/keeper_types_profile_oas_env.ml:62`의 warn 문자열에서 `OAS_<PROVIDER>_*)` 시퀀스를 lint 권고형 `OAS_<PROVIDER>_...`로 교체했습니다 (1줄).

## 왜

- #24386(`1042a78f2a`)이 넣은 로그 문자열이 blocking lint `no-ocaml-comment-terminator-trap`에 걸립니다 (lint는 텍스트 스캔이라 문자열 리터럴도 검사).
- 이 1건으로 main 연속 4커밋(`39aec730`/`4f7b6aa3`/`9d59e836`/`29ef3c95`)의 Fundamental Check가 전부 RED — 다른 PR들의 재라벨/병합 게이트를 막고 있습니다.

## 검증

- `bash scripts/lint/no-ocaml-comment-terminator-trap.sh` → clean
- `bash scripts/ci/run-lint-suite.sh blocking` → all 26 lints passed
- 변경은 문자열 리터럴 내 1문자 수준 — 포맷 인자(`%S` 2개) 불변, 컴파일 영향 없음

RFC-WAIVED: 로그 문자열 1줄 cosmetic 수정, subsystem 로직 비접촉.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
