### PR TITLE
refactor(keeper): unify chat delivery recovery surfaces

### DIFF
--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -29,6 +29,7 @@ import {
   pauseKeeper,
   parseKeeperRuntimeTrace,
   parseKeeperChatReceipt,
+  resolveKeeperChatRecovery,
   queuedKeeperMessageError,
   queuedKeeperMessageToReply,
   resumeKeeper,
@@ -101,7 +102,7 @@ describe('Keeper chat durable receipt API', () => {
       schema: 'keeper_chat_queue.receipt.v2',
       keeper_name: 'echo',
       receipt_id: 'chatq_00000000-0000-4000-8000-000000000001',
-      revision: 8,
+      revision: '8',
       state: {
         kind: 'recovery_required',
         lease_id: 'lease_00000000-0000-4000-8000-000000000002',
@@ -111,7 +112,7 @@ describe('Keeper chat durable receipt API', () => {
     })).toEqual({
       keeperName: 'echo',
       receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
-      revision: 8,
+      revision: '8',
       state: {
         kind: 'recovery_required',
         leaseId: 'lease_00000000-0000-4000-8000-000000000002',
@@ -126,7 +127,7 @@ describe('Keeper chat durable receipt API', () => {
       schema: 'keeper_chat_queue.receipt.v2',
       keeper_name: 'echo',
       receipt_id: 'chatq_00000000-0000-4000-8000-000000000001',
-      revision: 8,
+      revision: '8',
       state: {
         kind: 'recovery_required',
         lease_id: 'lease_00000000-0000-4000-8000-000000000002',
@@ -141,7 +142,7 @@ describe('Keeper chat durable receipt API', () => {
       schema: 'keeper_chat_queue.receipt.v2',
       keeper_name: 'echo',
       receipt_id: 'chatq_00000000-0000-4000-8000-000000000001',
-      revision: 7,
+      revision: '7',
       state: {
         kind: 'failed',
         failure_kind: 'delivery_failed',
@@ -152,7 +153,7 @@ describe('Keeper chat durable receipt API', () => {
     })).toEqual({
       keeperName: 'echo',
       receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
-      revision: 7,
+      revision: '7',
       state: {
         kind: 'failed',
         failureKind: 'delivery_failed',
@@ -170,7 +171,7 @@ describe('Keeper chat durable receipt API', () => {
         schema: 'keeper_chat_queue.receipt.v2',
         keeper_name: 'echo',
         receipt_id: 'chatq_00000000-0000-4000-8000-000000000001',
-        revision: 7,
+        revision: '7',
         state: {
           kind: 'failed',
           failure_kind: failureKind,
@@ -187,7 +188,7 @@ describe('Keeper chat durable receipt API', () => {
       schema: 'keeper_chat_queue.receipt.v2',
       keeper_name: 'echo',
       receipt_id: 'chatq_00000000-0000-4000-8000-000000000001',
-      revision: 1,
+      revision: '1',
       state: { kind: 'lost_somewhere' },
     })).toThrow('unknown state')
   })
@@ -197,7 +198,7 @@ describe('Keeper chat durable receipt API', () => {
       schema: 'keeper_chat_queue.receipt.v2',
       keeper_name: 'echo',
       receipt_id: 'receipt-echo-1',
-      revision: 1,
+      revision: '1',
       state: { kind: 'pending' },
     })).toThrow('missing identity')
   })
@@ -207,7 +208,7 @@ describe('Keeper chat durable receipt API', () => {
       schema: 'keeper_chat_queue.receipt.v2',
       keeper_name: 'echo',
       receipt_id: 'chatq_00000000-0000-4000-8000-000000000001',
-      revision: 2,
+      revision: '2',
       state: { kind: 'delivered', completed_at: 42, outcome_ref: 7 },
     })).toThrow('outcome_ref must be a string or null')
   })
@@ -217,7 +218,7 @@ describe('Keeper chat durable receipt API', () => {
       schema: 'keeper_chat_queue.receipt.v2',
       keeper_name: 'echo',
       receipt_id: 'chatq_00000000-0000-4000-8000-000000000001',
-      revision: 2,
+      revision: '2',
       state: {
         kind: 'failed',
         failure_kind: 'delivery_failed',
@@ -234,7 +235,7 @@ describe('Keeper chat durable receipt API', () => {
         schema: 'keeper_chat_queue.receipt.v2',
         keeper_name: 'keeper sangsu',
         receipt_id: 'chatq_00000000-0000-4000-8000-000000000001',
-        revision: 2,
+        revision: '2',
         state: { kind: 'pending' },
       }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
     )
@@ -248,6 +249,49 @@ describe('Keeper chat durable receipt API', () => {
     expect(fetchMock).toHaveBeenCalledWith(
       '/api/v1/keepers/keeper%20sangsu/chat/receipts/chatq_00000000-0000-4000-8000-000000000001',
       expect.objectContaining({ headers: expect.any(Object) }),
+    )
+  })
+
+  it('resolves one exact recovery receipt with string revision and lease evidence', async () => {
+    const receiptId = 'chatq_00000000-0000-4000-8000-000000000001'
+    const leaseId = 'lease_00000000-0000-4000-8000-000000000002'
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        schema: 'keeper_chat_queue.recovery.result.v1',
+        ok: true,
+        decision: 'requeue_unconfirmed',
+        receipt: {
+          schema: 'keeper_chat_queue.receipt.v2',
+          keeper_name: 'keeper sangsu',
+          receipt_id: receiptId,
+          revision: '9223372036854775806',
+          state: { kind: 'pending' },
+        },
+        audit: { recorded: true },
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await resolveKeeperChatRecovery(
+      'keeper sangsu',
+      receiptId,
+      '9223372036854775805',
+      leaseId,
+      { kind: 'requeue_unconfirmed' },
+    )
+
+    expect(result.receipt.revision).toBe('9223372036854775806')
+    expect(fetchMock).toHaveBeenCalledWith(
+      `/api/v1/keepers/keeper%20sangsu/chat/receipts/${receiptId}/recovery`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          schema: 'keeper_chat_queue.recovery.request.v1',
+          expected_revision: '9223372036854775805',
+          lease_id: leaseId,
+          decision: { kind: 'requeue_unconfirmed' },
+        }),
+      }),
     )
   })
 

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -28,7 +28,7 @@ import {
   DEFAULT_POST_TIMEOUT_MS,
 } from './core'
 import { ensureDevToken, resetDevTokenBootstrap } from './dev-token'
-import { isKeeperChatReceiptId } from '../lib/keeper-chat-receipt'
+import { isKeeperChatReceiptId, parseKeeperQueueRevision } from '../lib/keeper-chat-receipt'
 import type {
   KeeperCompositeSnapshot,
   FleetCompositeSnapshot,
@@ -724,8 +724,22 @@ export type KeeperChatReceiptState =
 export interface KeeperChatReceipt {
   keeperName: string
   receiptId: string
-  revision: number
+  revision: string
   state: KeeperChatReceiptState
+}
+
+export type KeeperChatRecoveryDecision =
+  | { kind: 'requeue_unconfirmed' }
+  | {
+      kind: 'cancel_unconfirmed'
+      detail: string
+      outcomeRef: string | null
+    }
+
+export interface KeeperChatRecoveryResult {
+  decision: KeeperChatRecoveryDecision['kind']
+  receipt: KeeperChatReceipt
+  audit: { recorded: true } | { recorded: false; error: string }
 }
 
 const KEEPER_CHAT_RECEIPT_FAILURE_KINDS = new Set<KeeperChatReceiptFailureKind>([
@@ -745,16 +759,14 @@ export function parseKeeperChatReceipt(value: unknown): KeeperChatReceipt {
   }
   const keeperName = asString(value.keeper_name, '').trim()
   const receiptId = asString(value.receipt_id, '').trim()
-  const revision = asNumber(value.revision)
+  const revision = parseKeeperQueueRevision(value.revision)
   const rawState = isRecord(value.state) ? value.state : null
   const kind = asString(rawState?.kind, '').trim()
   if (
     !keeperName
     || !isKeeperChatReceiptId(receiptId)
     || !rawState
-    || typeof revision !== 'number'
-    || !Number.isSafeInteger(revision)
-    || revision < 0
+    || revision === undefined
   ) {
     throw new Error('Keeper chat receipt response is missing identity or state')
   }
@@ -839,6 +851,52 @@ export async function fetchKeeperChatReceipt(
     throw new Error(`fetchKeeperChatReceipt: HTTP ${resp.status} ${resp.statusText}`)
   }
   return parseKeeperChatReceipt(data)
+}
+
+export async function resolveKeeperChatRecovery(
+  keeperName: string,
+  receiptId: string,
+  expectedRevision: string,
+  leaseId: string,
+  decision: KeeperChatRecoveryDecision,
+): Promise<KeeperChatRecoveryResult> {
+  const decisionPayload = decision.kind === 'requeue_unconfirmed'
+    ? { kind: decision.kind }
+    : {
+        kind: decision.kind,
+        detail: decision.detail,
+        outcome_ref: decision.outcomeRef,
+      }
+  const raw = await post<unknown>(
+    `/api/v1/keepers/${encodeURIComponent(keeperName)}/chat/receipts/${encodeURIComponent(receiptId)}/recovery`,
+    {
+      schema: 'keeper_chat_queue.recovery.request.v1',
+      expected_revision: expectedRevision,
+      lease_id: leaseId,
+      decision: decisionPayload,
+    },
+  )
+  if (
+    !isRecord(raw)
+    || raw.schema !== 'keeper_chat_queue.recovery.result.v1'
+    || raw.ok !== true
+    || raw.decision !== decision.kind
+    || !isRecord(raw.audit)
+    || typeof raw.audit.recorded !== 'boolean'
+  ) {
+    throw new Error('resolveKeeperChatRecovery: invalid response envelope')
+  }
+  const receipt = parseKeeperChatReceipt(raw.receipt)
+  if (receipt.keeperName !== keeperName || receipt.receiptId !== receiptId) {
+    throw new Error('resolveKeeperChatRecovery: response identity mismatch')
+  }
+  const audit = raw.audit.recorded
+    ? { recorded: true as const }
+    : {
+        recorded: false as const,
+        error: asString(raw.audit.error, '').trim() || 'recovery audit persistence failed',
+      }
+  return { decision: decision.kind, receipt, audit }
 }
 
 export async function fetchKeeperChatHistory(

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -724,6 +724,55 @@ describe('ChatTranscript', () => {
     expect(onClick.mock.calls[0]?.[0].id).toBe('a1')
   })
 
+  it('renders only exact single-receipt recovery decisions', async () => {
+    const onRecoveryRequeue = vi.fn().mockResolvedValue(undefined)
+    const onRecoveryCancel = vi.fn().mockResolvedValue(undefined)
+    const prompt = vi.spyOn(window, 'prompt').mockReturnValue('operator verified no delivery')
+    const target = entry({
+      id: 'recovery-receipt',
+      role: 'assistant',
+      source: 'direct_assistant',
+      label: 'sangsu',
+      text: 'queued',
+      delivery: 'queued',
+      details: {
+        queueReceiptId: 'chatq_00000000-0000-4000-8000-000000000001',
+        queueRevision: '8',
+        queueState: 'recovery_required',
+      },
+    })
+
+    render(
+      html`<${ChatTranscript}
+        entries=${[target]}
+        emptyText="empty"
+        variant="messenger"
+        action=${{ onRecoveryRequeue, onRecoveryCancel }}
+      />`,
+      container,
+    )
+
+    const requeue = container.querySelector(
+      '[data-chat-queue-recovery-action="requeue_unconfirmed"]',
+    ) as HTMLButtonElement
+    const cancel = container.querySelector(
+      '[data-chat-queue-recovery-action="cancel_unconfirmed"]',
+    ) as HTMLButtonElement
+    expect(requeue).not.toBeNull()
+    expect(cancel).not.toBeNull()
+
+    fireEvent.click(requeue)
+    await waitFor(() => expect(onRecoveryRequeue).toHaveBeenCalledWith(target))
+    fireEvent.click(cancel)
+    await waitFor(() => {
+      expect(onRecoveryCancel).toHaveBeenCalledWith(
+        target,
+        'operator verified no delivery',
+      )
+    })
+    expect(prompt).toHaveBeenCalledTimes(1)
+  })
+
   it('copies the message text from an assistant message copy button', () => {
     const writeText = vi.fn().mockResolvedValue(undefined)
     Object.assign(globalThis.navigator, { clipboard: { writeText } })

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -372,9 +372,11 @@ function ChatMetaChip({ info, compact }: { info: ChatMetaInfo | null; compact: b
 type ChatTranscriptVariant = 'default' | 'messenger'
 type ChatTranscriptSize = 'default' | 'primary'
 type ChatTranscriptAction = {
-  label: string
+  label?: string
   title?: string
-  onClick: (entry: KeeperConversationEntry) => void
+  onClick?: (entry: KeeperConversationEntry) => void
+  onRecoveryRequeue?: (entry: KeeperConversationEntry) => Promise<void>
+  onRecoveryCancel?: (entry: KeeperConversationEntry, detail: string) => Promise<void>
 }
 
 export const THINKING_TRACE_PREVIEW_CHARS = 2400
@@ -438,7 +440,11 @@ function showDeliveryBadge(entry: KeeperConversationEntry, variant: ChatTranscri
   return entry.delivery !== 'history' && entry.delivery !== 'delivered'
 }
 
-function QueueReceiptBadge({ entry }: { entry: KeeperConversationEntry }) {
+function QueueReceiptBadge({ entry, action }: {
+  entry: KeeperConversationEntry
+  action?: ChatTranscriptAction
+}) {
+  const [recoveryPending, setRecoveryPending] = useState<'requeue' | 'cancel' | null>(null)
   const receiptId = entry.details?.queueReceiptId?.trim()
   const shutdownOperationId = entry.details?.queueShutdownOperationId?.trim()
   const queueState = entry.details?.queueState
@@ -459,15 +465,64 @@ function QueueReceiptBadge({ entry }: { entry: KeeperConversationEntry }) {
     label,
     shutdownOperationId ? `shutdown operation ${shutdownOperationId}` : null,
   ].filter((value): value is string => value !== null).join(' · ')
+  const runRecovery = async (
+    kind: 'requeue' | 'cancel',
+    operation: () => Promise<void>,
+  ) => {
+    setRecoveryPending(kind)
+    try {
+      await operation()
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : String(error), 'error')
+    } finally {
+      setRecoveryPending(null)
+    }
+  }
+  const cancelRecovery = () => {
+    if (!action?.onRecoveryCancel) return
+    const detail = window.prompt('미확인 배송을 취소하는 이유를 입력하세요.')
+    if (detail === null) return
+    if (!detail || detail !== detail.trim()) {
+      showToast('취소 이유는 공백 없이 정확히 입력해야 합니다.', 'error')
+      return
+    }
+    void runRecovery('cancel', () => action.onRecoveryCancel!(entry, detail))
+  }
   return html`
-    <span
-      class="inline-flex items-center rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-0.5 text-2xs font-semibold text-[var(--color-fg-secondary)]"
-      title=${title}
-      data-chat-queue-state-badge=${queueState}
-      data-chat-queue-receipt=${receiptId}
-      data-chat-queue-shutdown-operation-id=${shutdownOperationId ?? undefined}
-    >
-      ${label}${shutdownLabel}
+    <span class="inline-flex flex-wrap items-center gap-1.5">
+      <span
+        class="inline-flex items-center rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-0.5 text-2xs font-semibold text-[var(--color-fg-secondary)]"
+        title=${title}
+        data-chat-queue-state-badge=${queueState}
+        data-chat-queue-receipt=${receiptId}
+        data-chat-queue-shutdown-operation-id=${shutdownOperationId ?? undefined}
+      >
+        ${label}${shutdownLabel}
+      </span>
+      ${queueState === 'recovery_required' && action?.onRecoveryRequeue
+        ? html`
+            <button
+              type="button"
+              disabled=${recoveryPending !== null}
+              class="rounded-[var(--r-0)] border border-[var(--warn-20)] bg-[var(--warn-10)] px-2 py-0.5 text-2xs font-semibold text-[var(--warn-bright)] disabled:opacity-50"
+              data-chat-queue-recovery-action="requeue_unconfirmed"
+              onClick=${() => {
+                void runRecovery('requeue', () => action.onRecoveryRequeue!(entry))
+              }}
+            >${recoveryPending === 'requeue' ? '반영 중...' : '미확인 배송 재큐잉'}</button>
+          `
+        : null}
+      ${queueState === 'recovery_required' && action?.onRecoveryCancel
+        ? html`
+            <button
+              type="button"
+              disabled=${recoveryPending !== null}
+              class="rounded-[var(--r-0)] border border-[var(--danger-20)] bg-[var(--danger-10)] px-2 py-0.5 text-2xs font-semibold text-[var(--color-status-err)] disabled:opacity-50"
+              data-chat-queue-recovery-action="cancel_unconfirmed"
+              onClick=${cancelRecovery}
+            >${recoveryPending === 'cancel' ? '반영 중...' : '미확인 배송 취소'}</button>
+          `
+        : null}
     </span>
   `
 }
@@ -610,7 +665,7 @@ function overviewRows(details: KeeperConversationDetails): Array<{ label: string
     details.queueShutdownOperationId ? { label: '종료 작업 ID', value: details.queueShutdownOperationId } : null,
     details.queueState ? { label: '큐 상태', value: details.queueState } : null,
     details.queueFailureKind ? { label: '큐 실패', value: details.queueFailureKind } : null,
-    typeof details.queueRevision === 'number' ? { label: '큐 revision', value: `${details.queueRevision}` } : null,
+    typeof details.queueRevision === 'string' ? { label: '큐 revision', value: details.queueRevision } : null,
     typeof details.queuePendingCount === 'number' ? { label: '접수 시 pending', value: `${details.queuePendingCount}` } : null,
     typeof details.queueInflightCount === 'number' ? { label: '접수 시 inflight', value: `${details.queueInflightCount}` } : null,
     typeof details.queueRecoveryRequiredCount === 'number'
@@ -2574,7 +2629,7 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
                           </span>
                         `
                       : null}
-                    <${QueueReceiptBadge} entry=${entry} />
+                    <${QueueReceiptBadge} entry=${entry} action=${action} />
                     <${StreamContractBadge} badge=${streamContractBadge} compact=${true} />
                     <${ChatMetaChip} info=${surfaceInfo} compact=${true} />
                     <${ChatMetaChip} info=${speakerInfo} compact=${true} />
@@ -2598,7 +2653,7 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
                           </span>
                         `
                       : null}
-                    <${QueueReceiptBadge} entry=${entry} />
+                    <${QueueReceiptBadge} entry=${entry} action=${action} />
                     ${timestamp
                       ? html`
                           <span class="inline-flex items-center rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] px-2.5 py-1 text-2xs font-medium tabular-nums text-[var(--color-fg-secondary)]">
@@ -2617,14 +2672,14 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
                 `}
           </div>
         </div>
-        ${action
+        ${action?.label && action.onClick
           ? html`
               <button
                 type="button"
                 class=${`border border-[var(--accent-20)] bg-[var(--accent-10)] text-xs font-semibold text-[var(--color-accent-fg)] transition-colors hover:bg-[var(--accent-20)] ${CHAT_FOCUS_RING} ${
                   isMessenger ? 'rounded-[var(--r-1)] px-2.5 py-1' : 'rounded-[var(--r-0)] px-3 py-1'
                 }`}
-                onClick=${() => action.onClick(entry)}
+                onClick=${() => action.onClick!(entry)}
                 title=${action.title ?? action.label}
                 data-testid="chat-message-action"
               >

--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -1009,7 +1009,7 @@ describe('KeeperConversationPanel', () => {
         details: {
           queueReceiptId: `chatq_00000000-0000-4000-8000-${String(index).padStart(12, '0')}`,
           queueShutdownOperationId: queueState === 'pending' ? 'shutdown-op-7' : null,
-          queueRevision: index + 1,
+          queueRevision: String(index + 1),
           queueState,
         },
       })),

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -23,6 +23,8 @@ import {
   isKeeperThreadMessageSendInFlight,
   probeKeeperRuntime,
   reconcileKeeperChatReceipts,
+  requeueKeeperChatRecoveryEntry,
+  cancelKeeperChatRecoveryEntry,
   recoverKeeperRuntime,
   resumePendingKeeperChatRequests,
   sendKeeperThreadMessage,
@@ -763,11 +765,16 @@ export function KeeperConversationPanel({
   // compare can skip unchanged messages — an inline `{ ...onClick }` literal
   // would be a new reference each render and defeat the memo.
   const inspectAction = useMemo(
-    () =>
-      onInspectTurn
+    () => ({
+      ...(onInspectTurn
         ? { label: '턴 상세', title: '이 메시지 턴 상세 열기', onClick: onInspectTurn }
-        : undefined,
-    [onInspectTurn],
+        : {}),
+      onRecoveryRequeue: (entry: KeeperConversationEntry) =>
+        requeueKeeperChatRecoveryEntry(keeperName, entry),
+      onRecoveryCancel: (entry: KeeperConversationEntry, detail: string) =>
+        cancelKeeperChatRecoveryEntry(keeperName, entry, detail),
+    }),
+    [keeperName, onInspectTurn],
   )
   const transcriptEmptyText =
     hasQuery && visibleThreadWithQueue.length > 0

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -10,6 +10,7 @@ const {
   cancelQueuedKeeperMessage,
   fetchKeeperChatHistory,
   fetchKeeperChatReceipt,
+  resolveKeeperChatRecovery,
   fetchQueuedKeeperMessageResult,
   isTerminalQueuedKeeperMessage,
   queuedKeeperMessageError,
@@ -27,6 +28,7 @@ const {
   ),
   fetchKeeperChatHistory: vi.fn(),
   fetchKeeperChatReceipt: vi.fn(),
+  resolveKeeperChatRecovery: vi.fn(),
   fetchQueuedKeeperMessageResult: vi.fn(),
   isTerminalQueuedKeeperMessage: vi.fn((result: { status: string }) => (
     result.status === 'done'
@@ -52,6 +54,7 @@ vi.mock('./api/keeper', () => ({
   cancelQueuedKeeperMessage,
   fetchKeeperChatHistory,
   fetchKeeperChatReceipt,
+  resolveKeeperChatRecovery,
   fetchQueuedKeeperMessageResult,
   isTerminalQueuedKeeperMessage,
   queuedKeeperMessageError,
@@ -89,6 +92,8 @@ import {
   noteKeeperChatAppended,
   probeKeeperRuntime,
   reconcileKeeperChatReceipts,
+  requeueKeeperChatRecoveryEntry,
+  cancelKeeperChatRecoveryEntry,
   recoverKeeperRuntime,
   refreshActiveKeeperChatHistory,
   resumePendingKeeperChatRequests,
@@ -221,7 +226,7 @@ describe('reconcileKeeperChatReceipts', () => {
           streamState: null,
           details: {
             queueReceiptId: 'chatq_00000000-0000-4000-8000-000000000001',
-            queueRevision: 1,
+            queueRevision: '1',
             queuePendingCount: 1,
             queueInflightCount: 0,
             queueState: 'pending',
@@ -234,13 +239,14 @@ describe('reconcileKeeperChatReceipts', () => {
     fetchKeeperChatHistory.mockReset()
     fetchKeeperChatHistory.mockResolvedValue([])
     fetchKeeperChatReceipt.mockReset()
+    resolveKeeperChatRecovery.mockReset()
   })
 
   it('retains the queued message while exact delivery recovery is required', async () => {
     fetchKeeperChatReceipt.mockResolvedValue({
       keeperName: 'echo',
       receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
-      revision: 3,
+      revision: '3',
       state: {
         kind: 'recovery_required',
         leaseId: 'lease_00000000-0000-4000-8000-000000000002',
@@ -259,11 +265,88 @@ describe('reconcileKeeperChatReceipts', () => {
     expect(entry?.error).toBeFalsy()
   })
 
+  it('requeues only with the freshly observed revision and lease', async () => {
+    const entry = keeperThreads.value.echo![0]!
+    fetchKeeperChatReceipt.mockResolvedValue({
+      keeperName: 'echo',
+      receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
+      revision: '9223372036854775805',
+      state: {
+        kind: 'recovery_required',
+        leaseId: 'lease_00000000-0000-4000-8000-000000000002',
+        startedAt: 42,
+        dispatchable: false,
+      },
+    })
+    resolveKeeperChatRecovery.mockResolvedValue({
+      decision: 'requeue_unconfirmed',
+      receipt: {
+        keeperName: 'echo',
+        receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
+        revision: '9223372036854775806',
+        state: { kind: 'pending' },
+      },
+      audit: { recorded: true },
+    })
+
+    await requeueKeeperChatRecoveryEntry('echo', entry)
+
+    expect(resolveKeeperChatRecovery).toHaveBeenCalledWith(
+      'echo',
+      'chatq_00000000-0000-4000-8000-000000000001',
+      '9223372036854775805',
+      'lease_00000000-0000-4000-8000-000000000002',
+      { kind: 'requeue_unconfirmed' },
+    )
+    expect(keeperThreads.value.echo?.[0]?.details?.queueRevision)
+      .toBe('9223372036854775806')
+  })
+
+  it('surfaces audit failure after an exact cancellation was committed', async () => {
+    const entry = keeperThreads.value.echo![0]!
+    fetchKeeperChatReceipt.mockResolvedValue({
+      keeperName: 'echo',
+      receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
+      revision: '3',
+      state: {
+        kind: 'recovery_required',
+        leaseId: 'lease_00000000-0000-4000-8000-000000000002',
+        startedAt: 42,
+        dispatchable: false,
+      },
+    })
+    resolveKeeperChatRecovery.mockResolvedValue({
+      decision: 'cancel_unconfirmed',
+      receipt: {
+        keeperName: 'echo',
+        receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
+        revision: '4',
+        state: {
+          kind: 'failed',
+          failureKind: 'cancelled',
+          detail: 'operator verified no delivery',
+          completedAt: 43,
+          outcomeRef: null,
+        },
+      },
+      audit: { recorded: false, error: 'audit disk unavailable' },
+    })
+
+    await cancelKeeperChatRecoveryEntry(
+      'echo',
+      entry,
+      'operator verified no delivery',
+    )
+
+    expect(keeperThreads.value.echo?.[0]?.details?.queueState).toBe('failed')
+    expect(keeperActionErrors.value.echo).toContain('audit disk unavailable')
+  })
+
   it('moves a busy ACK to delivered only after the durable terminal receipt', async () => {
     fetchKeeperChatReceipt.mockResolvedValue({
       keeperName: 'echo',
       receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
-      revision: 4,
+      revision: '4',
       state: { kind: 'delivered', completedAt: 42, outcomeRef: RECEIPT_TURN_REF },
     })
     fetchKeeperChatHistory.mockResolvedValue([
@@ -288,7 +371,7 @@ describe('reconcileKeeperChatReceipts', () => {
     fetchKeeperChatReceipt.mockResolvedValue({
       keeperName: 'echo',
       receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
-      revision: 4,
+      revision: '4',
       state: { kind: 'delivered', completedAt: 42, outcomeRef: null },
     })
 
@@ -311,7 +394,7 @@ describe('reconcileKeeperChatReceipts', () => {
     fetchKeeperChatReceipt.mockResolvedValue({
       keeperName: 'echo',
       receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
-      revision: 4,
+      revision: '4',
       state: { kind: 'delivered', completedAt: 42, outcomeRef: RECEIPT_TURN_REF },
     })
     fetchKeeperChatHistory.mockResolvedValue([
@@ -338,7 +421,7 @@ describe('reconcileKeeperChatReceipts', () => {
     fetchKeeperChatReceipt.mockResolvedValue({
       keeperName: 'echo',
       receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
-      revision: 4,
+      revision: '4',
       state: { kind: 'delivered', completedAt: 42, outcomeRef: RECEIPT_TURN_REF },
     })
     fetchKeeperChatHistory
@@ -374,7 +457,7 @@ describe('reconcileKeeperChatReceipts', () => {
     fetchKeeperChatReceipt.mockResolvedValue({
       keeperName: 'echo',
       receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
-      revision: 4,
+      revision: '4',
       state: { kind: 'delivered', completedAt: 42, outcomeRef: RECEIPT_TURN_REF },
     })
     fetchKeeperChatHistory
@@ -408,7 +491,7 @@ describe('reconcileKeeperChatReceipts', () => {
     fetchKeeperChatReceipt.mockResolvedValue({
       keeperName: 'echo',
       receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
-      revision: 4,
+      revision: '4',
       state: { kind: 'delivered', completedAt: 42, outcomeRef: RECEIPT_TURN_REF },
     })
     let resolveHistory!: (history: Array<{
@@ -446,7 +529,7 @@ describe('reconcileKeeperChatReceipts', () => {
     fetchKeeperChatReceipt.mockResolvedValue({
       keeperName: 'echo',
       receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
-      revision: 5,
+      revision: '5',
       state: {
         kind: 'failed',
         failureKind: 'delivery_failed',
@@ -469,13 +552,13 @@ describe('reconcileKeeperChatReceipts', () => {
     let resolveOlder!: (value: {
       keeperName: string
       receiptId: string
-      revision: number
+      revision: string
       state: { kind: 'pending' }
     }) => void
     let resolveNewer!: (value: {
       keeperName: string
       receiptId: string
-      revision: number
+      revision: string
       state: { kind: 'delivered'; completedAt: number; outcomeRef: string }
     }) => void
     const older = new Promise<Parameters<typeof resolveOlder>[0]>(resolve => {
@@ -493,21 +576,21 @@ describe('reconcileKeeperChatReceipts', () => {
     resolveNewer({
       keeperName: 'echo',
       receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
-      revision: 6,
+      revision: '6',
       state: { kind: 'delivered', completedAt: 44, outcomeRef: RECEIPT_TURN_REF },
     })
     await newerReconciliation
     resolveOlder({
       keeperName: 'echo',
       receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
-      revision: 5,
+      revision: '5',
       state: { kind: 'pending' },
     })
     await olderReconciliation
 
     const entry = keeperThreads.value.echo?.[0]
     expect(entry?.delivery).toBe('delivered')
-    expect(entry?.details?.queueRevision).toBe(6)
+    expect(entry?.details?.queueRevision).toBe('6')
     expect(entry?.details?.queueState).toBe('delivered')
   })
 
@@ -519,7 +602,7 @@ describe('reconcileKeeperChatReceipts', () => {
     fetchKeeperChatReceipt.mockResolvedValueOnce({
       keeperName: 'echo',
       receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
-      revision: 2,
+      revision: '2',
       state: { kind: 'pending' },
     })
     await reconcileKeeperChatReceipts('echo')
@@ -540,7 +623,7 @@ describe('reconcileKeeperChatReceipts', () => {
     let resolveNewer!: (value: {
       keeperName: string
       receiptId: string
-      revision: number
+      revision: string
       state: { kind: 'delivered'; completedAt: number; outcomeRef: string }
     }) => void
     const older = new Promise<never>((_resolve, reject) => {
@@ -558,7 +641,7 @@ describe('reconcileKeeperChatReceipts', () => {
     resolveNewer({
       keeperName: 'echo',
       receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
-      revision: 7,
+      revision: '7',
       state: { kind: 'delivered', completedAt: 46, outcomeRef: RECEIPT_TURN_REF },
     })
     await newerReconciliation
@@ -585,7 +668,7 @@ describe('reconcileKeeperChatReceipts', () => {
     fetchKeeperChatReceipt.mockResolvedValue({
       keeperName: 'echo',
       receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
-      revision: 3,
+      revision: '3',
       state: { kind: 'delivered', completedAt: 45, outcomeRef: RECEIPT_TURN_REF },
     })
 
@@ -1561,7 +1644,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
     fetchKeeperChatReceipt.mockResolvedValue({
       keeperName: 'echo',
       receiptId: 'chatq_00000000-0000-4000-8000-000000000001',
-      revision: 4,
+      revision: '4',
       state: { kind: 'pending' },
     })
     streamKeeperMessage.mockImplementation(emitting([
@@ -1575,7 +1658,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
           keeper_name: 'echo',
           status: 'queued',
           receipt_id: 'chatq_00000000-0000-4000-8000-000000000001',
-          queue_revision: 4,
+          queue_revision: '4',
           pending_count: 1,
           inflight_count: 0,
           recovery_required_count: 0,
@@ -1593,7 +1676,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
     expect(reply?.text).toContain('message is queued')
     expect(reply?.details).toMatchObject({
       queueReceiptId: 'chatq_00000000-0000-4000-8000-000000000001',
-      queueRevision: 4,
+      queueRevision: '4',
       queuePendingCount: 1,
       queueInflightCount: 0,
       queueRecoveryRequiredCount: 0,
@@ -1608,7 +1691,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
     fetchKeeperChatReceipt.mockResolvedValue({
       keeperName: 'echo',
       receiptId: 'chatq_00000000-0000-4000-8000-000000000002',
-      revision: 5,
+      revision: '5',
       state: {
         kind: 'failed',
         failureKind: 'turn_failed',
@@ -1628,7 +1711,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
           keeper_name: 'echo',
           status: 'queued',
           receipt_id: 'chatq_00000000-0000-4000-8000-000000000002',
-          queue_revision: 4,
+          queue_revision: '4',
           pending_count: 1,
           inflight_count: 0,
           recovery_required_count: 0,

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -4,6 +4,7 @@ import {
   cancelQueuedKeeperMessage,
   fetchKeeperChatHistory,
   fetchKeeperChatReceipt,
+  resolveKeeperChatRecovery,
   fetchQueuedKeeperMessageResult,
   interruptKeeperTurn as apiInterruptKeeperTurn,
   isTerminalQueuedKeeperMessage,
@@ -22,6 +23,7 @@ import { asString, isRecord } from './components/common/normalize'
 import { keeperTurnOutcomeSuppressesReply } from './keeper-message'
 import { invalidateDashboardCache, refreshDashboard } from './store'
 import { isAbortError } from './lib/async-state'
+import { compareKeeperQueueRevisions } from './lib/keeper-chat-receipt'
 import type {
   ChatBlock,
   KeeperConversationAttachment,
@@ -836,12 +838,15 @@ export async function reconcileKeeperChatReceipts(name: string): Promise<void> {
       if (!currentEntry || currentEntry.details?.queueReceiptId !== receiptId) return
       const currentRevision = currentEntry.details.queueRevision
       const currentState = currentEntry.details.queueState
-      if (typeof currentRevision === 'number' && receipt.revision < currentRevision) {
+      if (
+        typeof currentRevision === 'string'
+        && compareKeeperQueueRevisions(receipt.revision, currentRevision) < 0
+      ) {
         return
       }
       if (
-        typeof currentRevision === 'number'
-        && receipt.revision === currentRevision
+        typeof currentRevision === 'string'
+        && compareKeeperQueueRevisions(receipt.revision, currentRevision) === 0
         && currentState
         && currentState !== receipt.state.kind
       ) {
@@ -979,6 +984,78 @@ export async function reconcileKeeperChatReceipts(name: string): Promise<void> {
   } else if (keeperActionErrors.value[keeperName]?.startsWith('큐 receipt 조회 실패:')) {
     setRecordValue(keeperActionErrors, keeperName, null)
   }
+}
+
+async function resolveKeeperChatRecoveryEntry(
+  keeperName: string,
+  entry: KeeperConversationEntry,
+  decision:
+    | { kind: 'requeue_unconfirmed' }
+    | { kind: 'cancel_unconfirmed'; detail: string; outcomeRef: string | null },
+): Promise<void> {
+  const receiptId = entry.details?.queueReceiptId?.trim() ?? ''
+  if (!receiptId) {
+    throw new Error('복구할 durable queue receipt가 없습니다.')
+  }
+  setRecordValue(keeperActionErrors, keeperName, null)
+  try {
+    const observed = await fetchKeeperChatReceipt(keeperName, receiptId)
+    if (observed.state.kind !== 'recovery_required') {
+      throw new Error(`receipt ${receiptId} is ${observed.state.kind}, not recovery_required`)
+    }
+    const result = await resolveKeeperChatRecovery(
+      keeperName,
+      receiptId,
+      observed.revision,
+      observed.state.leaseId,
+      decision,
+    )
+    const state = result.receipt.state
+    const details = {
+      ...(entry.details ?? {}),
+      queueRevision: result.receipt.revision,
+      queueState: state.kind,
+      queueFailureKind: state.kind === 'failed' ? state.failureKind : null,
+    }
+    finalizeAssistantEntry(keeperName, entry.id, {
+      delivery: state.kind === 'failed' ? 'error' : state.kind === 'delivered' ? 'delivered' : 'queued',
+      streamState: null,
+      details,
+      error: state.kind === 'failed' ? state.detail : undefined,
+    })
+    if (!result.audit.recorded) {
+      setRecordValue(
+        keeperActionErrors,
+        keeperName,
+        `복구 결정은 반영됐지만 audit 기록에 실패했습니다: ${result.audit.error}`,
+      )
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    setRecordValue(keeperActionErrors, keeperName, `큐 복구 결정 실패: ${message}`)
+    throw error
+  }
+}
+
+export async function requeueKeeperChatRecoveryEntry(
+  keeperName: string,
+  entry: KeeperConversationEntry,
+): Promise<void> {
+  await resolveKeeperChatRecoveryEntry(keeperName, entry, {
+    kind: 'requeue_unconfirmed',
+  })
+}
+
+export async function cancelKeeperChatRecoveryEntry(
+  keeperName: string,
+  entry: KeeperConversationEntry,
+  detail: string,
+): Promise<void> {
+  await resolveKeeperChatRecoveryEntry(keeperName, entry, {
+    kind: 'cancel_unconfirmed',
+    detail,
+    outcomeRef: null,
+  })
 }
 
 /** React to a server `keeper_chat_appended` push: re-merge the

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -100,7 +100,7 @@ describe('applyKeeperStreamEvent', () => {
         keeper_name: 'sangsu',
         status: 'queued',
         receipt_id: 'chatq_00000000-0000-4000-8000-000000000007',
-        queue_revision: 12,
+        queue_revision: '12',
         pending_count: 3,
         inflight_count: 1,
         recovery_required_count: 1,
@@ -114,7 +114,7 @@ describe('applyKeeperStreamEvent', () => {
     expect(entry?.details).toMatchObject({
       queueReceiptId: 'chatq_00000000-0000-4000-8000-000000000007',
       queueShutdownOperationId: 'shutdown-op-7',
-      queueRevision: 12,
+      queueRevision: '12',
       queuePendingCount: 3,
       queueInflightCount: 1,
       queueRecoveryRequiredCount: 1,
@@ -148,7 +148,7 @@ describe('applyKeeperStreamEvent', () => {
       name: 'KEEPER_CHAT_QUEUED',
       value: {
         receipt_id: 'not-a-chat-receipt',
-        queue_revision: 1,
+        queue_revision: '1',
         pending_count: 1,
         inflight_count: 0,
         recovery_required_count: 0,
@@ -176,7 +176,7 @@ describe('applyKeeperStreamEvent', () => {
       name: 'KEEPER_CHAT_QUEUED',
       value: {
         receipt_id: 'chatq_00000000-0000-4000-8000-000000000007',
-        queue_revision: 1,
+        queue_revision: '1',
         pending_count: 1,
         inflight_count: 0,
         shutdown_operation_id: null,
@@ -188,7 +188,7 @@ describe('applyKeeperStreamEvent', () => {
     assistantEntry()
     const baseValue = {
       receipt_id: 'chatq_00000000-0000-4000-8000-000000000007',
-      queue_revision: 1,
+      queue_revision: '1',
       pending_count: 1,
       inflight_count: 0,
       recovery_required_count: 0,

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -35,7 +35,7 @@ import { isRecord, asNumber, asString } from './components/common/normalize'
 import { toolEntryIdFromCallId } from './tool-call-output-store'
 import { STREAMING_THINKING_PREVIEW_CHARS } from './config/constants'
 import { updatePendingKeeperChatAssistantDraft } from './keeper-chat-pending'
-import { isKeeperChatReceiptId } from './lib/keeper-chat-receipt'
+import { isKeeperChatReceiptId, parseKeeperQueueRevision } from './lib/keeper-chat-receipt'
 
 const KEEPER_MESSAGE_CANCELLED_TEXT = '요청이 취소되었습니다.'
 export const TERMINAL_REQUEST_STATUSES = new Set(['done', 'error', 'lost', 'cancelled'])
@@ -685,7 +685,7 @@ export function applyKeeperStreamEvent(
         flushPendingThinkingDeltas(keeperName, assistantEntryId)
         const queued = isRecord(event.value) ? event.value : null
         const receiptId = asString(queued?.receipt_id, '').trim()
-        const revision = asNumber(queued?.queue_revision)
+        const revision = parseKeeperQueueRevision(queued?.queue_revision)
         const pendingCount = asNumber(queued?.pending_count)
         const inflightCount = asNumber(queued?.inflight_count)
         const recoveryRequiredCount = asNumber(queued?.recovery_required_count)
@@ -698,9 +698,7 @@ export function applyKeeperStreamEvent(
         })()
         if (
           !isKeeperChatReceiptId(receiptId)
-          || typeof revision !== 'number'
-          || !Number.isSafeInteger(revision)
-          || revision < 0
+          || revision === undefined
           || typeof pendingCount !== 'number'
           || !Number.isSafeInteger(pendingCount)
           || pendingCount < 1

--- a/dashboard/src/lib/keeper-chat-receipt.ts
+++ b/dashboard/src/lib/keeper-chat-receipt.ts
@@ -4,3 +4,19 @@ const KEEPER_CHAT_RECEIPT_ID_PATTERN =
 export function isKeeperChatReceiptId(value: string): boolean {
   return KEEPER_CHAT_RECEIPT_ID_PATTERN.test(value)
 }
+
+const KEEPER_QUEUE_REVISION_PATTERN = /^(0|[1-9][0-9]*)$/
+
+export function parseKeeperQueueRevision(value: unknown): string | undefined {
+  return typeof value === 'string' && KEEPER_QUEUE_REVISION_PATTERN.test(value)
+    ? value
+    : undefined
+}
+
+export function compareKeeperQueueRevisions(left: string, right: string): -1 | 0 | 1 {
+  if (left.length < right.length) return -1
+  if (left.length > right.length) return 1
+  if (left < right) return -1
+  if (left > right) return 1
+  return 0
+}

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -724,7 +724,7 @@ export interface KeeperConversationDetails {
   queueReceiptId?: string | null
   /** Shutdown fence that caused this message to be deferred, when present. */
   queueShutdownOperationId?: string | null
-  queueRevision?: number | null
+  queueRevision?: string | null
   queuePendingCount?: number | null
   queueInflightCount?: number | null
   queueRecoveryRequiredCount?: number | null

--- a/lib/keeper/keeper_chat_receipt_projection.ml
+++ b/lib/keeper/keeper_chat_receipt_projection.ml
@@ -1,0 +1,40 @@
+let state_json = function
+  | Keeper_chat_queue.Pending -> `Assoc [ "kind", `String "pending" ]
+  | Keeper_chat_queue.Inflight { lease_id; started_at } ->
+    `Assoc
+      [ "kind", `String "inflight"
+      ; "lease_id", `String lease_id
+      ; "started_at", `Float started_at
+      ]
+  | Keeper_chat_queue.Recovery_required { lease_id; started_at } ->
+    `Assoc
+      [ "kind", `String "recovery_required"
+      ; "lease_id", `String lease_id
+      ; "started_at", `Float started_at
+      ; "dispatchable", `Bool false
+      ]
+  | Keeper_chat_queue.Delivered completion ->
+    `Assoc
+      [ "kind", `String "delivered"
+      ; "completed_at", `Float completion.completed_at
+      ; "outcome_ref", Json_util.string_opt_to_json completion.outcome_ref
+      ]
+  | Keeper_chat_queue.Failed failure ->
+    `Assoc
+      [ "kind", `String "failed"
+      ; "failure_kind", `String (Keeper_chat_queue.failure_kind_to_string failure.kind)
+      ; "detail", `String (Observability_redact.redact_text failure.detail)
+      ; "completed_at", `Float failure.completed_at
+      ; "outcome_ref", Json_util.string_opt_to_json failure.outcome_ref
+      ]
+;;
+let receipt_json ~keeper_name ~revision
+    (receipt : Keeper_chat_queue.receipt_view) =
+  `Assoc
+    [ "schema", `String "keeper_chat_queue.receipt.v2"
+    ; "keeper_name", `String keeper_name
+    ; "receipt_id", `String (Keeper_chat_queue.Receipt_id.to_string receipt.receipt_id)
+    ; "revision", `String (Int64.to_string revision)
+    ; "state", state_json receipt.state
+    ]
+;;

--- a/lib/keeper/keeper_chat_receipt_projection.mli
+++ b/lib/keeper/keeper_chat_receipt_projection.mli
@@ -1,0 +1,13 @@
+(** Canonical external projection of one Keeper chat queue receipt.
+
+    Queue persistence has a separate private wire format.  HTTP, dashboard,
+    and operator tools use this projection so revision and state semantics
+    cannot drift between surfaces. *)
+
+val state_json : Keeper_chat_queue.receipt_state -> Yojson.Safe.t
+
+val receipt_json :
+  keeper_name:string ->
+  revision:int64 ->
+  Keeper_chat_queue.receipt_view ->
+  Yojson.Safe.t

--- a/lib/keeper/keeper_chat_recovery_command.ml
+++ b/lib/keeper/keeper_chat_recovery_command.ml
@@ -1,0 +1,395 @@
+let request_schema = "keeper_chat_queue.recovery.request.v1"
+let tool_command_schema = "keeper_chat_queue.recovery.command.v1"
+let result_schema = "keeper_chat_queue.recovery.result.v1"
+
+type cancellation =
+  { detail : string
+  ; outcome_ref : string option
+  }
+
+type decision =
+  | Requeue_unconfirmed
+  | Cancel_unconfirmed of cancellation
+
+type request =
+  { expected_revision : int64
+  ; lease_id : string
+  ; decision : decision
+  }
+
+type t =
+  { keeper_name : string
+  ; receipt_id : Keeper_chat_queue.Receipt_id.t
+  ; request : request
+  }
+
+type input_error =
+  | Object_required of
+      { context : string
+      ; observed_kind : string
+      }
+  | Duplicate_fields of
+      { context : string
+      ; fields : string list
+      }
+  | Unsupported_fields of
+      { context : string
+      ; fields : string list
+      }
+  | Missing_fields of
+      { context : string
+      ; fields : string list
+      }
+  | Invalid_field of
+      { field : string
+      ; expectation : string
+      }
+  | Unsupported_schema of string
+  | Unsupported_decision of string
+  | Invalid_keeper_name of string
+  | Invalid_receipt_id of string
+
+let input_error_to_string = function
+  | Object_required { context; observed_kind } ->
+    Printf.sprintf "%s must be an object (received %s)" context observed_kind
+  | Duplicate_fields { context; fields } ->
+    Printf.sprintf "%s contains duplicate field(s): %s" context
+      (String.concat ", " fields)
+  | Unsupported_fields { context; fields } ->
+    Printf.sprintf "%s contains unsupported field(s): %s" context
+      (String.concat ", " fields)
+  | Missing_fields { context; fields } ->
+    Printf.sprintf "%s is missing required field(s): %s" context
+      (String.concat ", " fields)
+  | Invalid_field { field; expectation } ->
+    Printf.sprintf "%s %s" field expectation
+  | Unsupported_schema schema ->
+    Printf.sprintf "unsupported recovery command schema %S" schema
+  | Unsupported_decision kind ->
+    Printf.sprintf "unsupported recovery decision kind %S" kind
+  | Invalid_keeper_name keeper_name ->
+    Printf.sprintf "invalid keeper name %S" keeper_name
+  | Invalid_receipt_id detail -> detail
+;;
+let input_error_to_json error =
+  let kind, details =
+    match error with
+    | Object_required { context; observed_kind } ->
+      ( "object_required"
+      , [ "context", `String context; "observed_kind", `String observed_kind ] )
+    | Duplicate_fields { context; fields } ->
+      ( "duplicate_fields"
+      , [ "context", `String context
+        ; "fields", `List (List.map (fun field -> `String field) fields)
+        ] )
+    | Unsupported_fields { context; fields } ->
+      ( "unsupported_fields"
+      , [ "context", `String context
+        ; "fields", `List (List.map (fun field -> `String field) fields)
+        ] )
+    | Missing_fields { context; fields } ->
+      ( "missing_fields"
+      , [ "context", `String context
+        ; "fields", `List (List.map (fun field -> `String field) fields)
+        ] )
+    | Invalid_field { field; expectation } ->
+      ( "invalid_field"
+      , [ "field", `String field; "expectation", `String expectation ] )
+    | Unsupported_schema schema ->
+      "unsupported_schema", [ "schema", `String schema ]
+    | Unsupported_decision decision ->
+      "unsupported_decision", [ "decision", `String decision ]
+    | Invalid_keeper_name keeper_name ->
+      "invalid_keeper_name", [ "keeper_name", `String keeper_name ]
+    | Invalid_receipt_id detail ->
+      "invalid_receipt_id", [ "detail", `String detail ]
+  in
+  `Assoc
+    ([ "error", `String "keeper_chat_recovery_invalid_input"
+     ; "kind", `String kind
+     ; "message", `String (input_error_to_string error)
+     ]
+     @ details)
+;;
+
+let dedupe_keep_order values =
+  let rec loop seen acc = function
+    | [] -> List.rev acc
+    | value :: rest ->
+      if List.mem value seen
+      then loop seen acc rest
+      else loop (value :: seen) (value :: acc) rest
+  in
+  loop [] [] values
+;;
+
+let duplicate_fields fields =
+  let rec loop seen duplicates = function
+    | [] -> dedupe_keep_order (List.rev duplicates)
+    | (field, _) :: rest ->
+      if List.mem field seen
+      then loop seen (field :: duplicates) rest
+      else loop (field :: seen) duplicates rest
+  in
+  loop [] [] fields
+;;
+
+let validate_exact_object ~context ~expected fields =
+  match duplicate_fields fields with
+  | _ :: _ as fields -> Error (Duplicate_fields { context; fields })
+  | [] ->
+    let unsupported =
+      List.filter_map
+        (fun (field, _) -> if List.mem field expected then None else Some field)
+        fields
+    in
+    let missing =
+      List.filter (fun field -> not (List.mem_assoc field fields)) expected
+    in
+    if unsupported <> []
+    then Error (Unsupported_fields { context; fields = unsupported })
+    else if missing <> []
+    then Error (Missing_fields { context; fields = missing })
+    else Ok ()
+;;
+
+let required field fields =
+  match List.assoc_opt field fields with
+  | Some value -> Ok value
+  | None -> Error (Missing_fields { context = "recovery command"; fields = [ field ] })
+;;
+
+let exact_nonblank_string ~field = function
+  | `String value
+    when not (String.equal value "") && String.equal value (String.trim value) ->
+    Ok value
+  | `String _ ->
+    Error
+      (Invalid_field
+         { field; expectation = "must be non-empty without surrounding whitespace" })
+  | value ->
+    Error
+      (Invalid_field
+         { field
+         ; expectation =
+             Printf.sprintf "must be a string (received %s)" (Json_util.kind_name value)
+         })
+;;
+
+let canonical_nonnegative_int64 ~field = function
+  | `String wire ->
+    (match Int64.of_string_opt wire with
+     | Some value
+       when Int64.compare value 0L >= 0
+            && String.equal wire (Int64.to_string value) ->
+       Ok value
+     | Some _ | None ->
+       Error
+         (Invalid_field
+            { field; expectation = "must be a canonical non-negative int64 string" }))
+  | value ->
+    Error
+      (Invalid_field
+         { field
+         ; expectation =
+             Printf.sprintf
+               "must be a canonical int64 string (received %s)"
+               (Json_util.kind_name value)
+         })
+;;
+
+let parse_decision = function
+  | `Assoc fields ->
+    let ( let* ) = Result.bind in
+    let* kind_json = required "kind" fields in
+    let* kind = exact_nonblank_string ~field:"decision.kind" kind_json in
+    (match kind with
+     | "requeue_unconfirmed" ->
+       let* () =
+         validate_exact_object ~context:"requeue decision" ~expected:[ "kind" ] fields
+       in
+       Ok Requeue_unconfirmed
+     | "cancel_unconfirmed" ->
+       let* () =
+         validate_exact_object
+           ~context:"cancel decision"
+           ~expected:[ "kind"; "detail"; "outcome_ref" ]
+           fields
+       in
+       let* detail_json = required "detail" fields in
+       let* detail = exact_nonblank_string ~field:"decision.detail" detail_json in
+       let* outcome_ref_json = required "outcome_ref" fields in
+       let* outcome_ref =
+         match outcome_ref_json with
+         | `Null -> Ok None
+         | value ->
+           exact_nonblank_string ~field:"decision.outcome_ref" value
+           |> Result.map (fun value -> Some value)
+       in
+       Ok (Cancel_unconfirmed { detail; outcome_ref })
+     | unsupported -> Error (Unsupported_decision unsupported))
+  | value ->
+    Error
+      (Object_required
+         { context = "decision"; observed_kind = Json_util.kind_name value })
+;;
+
+let parse_request_components fields =
+  let ( let* ) = Result.bind in
+  let* revision_json = required "expected_revision" fields in
+  let* expected_revision =
+    canonical_nonnegative_int64 ~field:"expected_revision" revision_json
+  in
+  let* lease_id_json = required "lease_id" fields in
+  let* lease_id = exact_nonblank_string ~field:"lease_id" lease_id_json in
+  let* decision_json = required "decision" fields in
+  let* decision = parse_decision decision_json in
+  Ok { expected_revision; lease_id; decision }
+;;
+
+let parse_schema ~expected fields =
+  let ( let* ) = Result.bind in
+  let* schema_json = required "schema" fields in
+  let* schema = exact_nonblank_string ~field:"schema" schema_json in
+  if String.equal schema expected then Ok () else Error (Unsupported_schema schema)
+;;
+
+let parse_request = function
+  | `Assoc fields ->
+    let ( let* ) = Result.bind in
+    let* () =
+      validate_exact_object
+        ~context:"keeper chat recovery request"
+        ~expected:[ "schema"; "expected_revision"; "lease_id"; "decision" ]
+        fields
+    in
+    let* () = parse_schema ~expected:request_schema fields in
+    parse_request_components fields
+  | value ->
+    Error
+      (Object_required
+         { context = "keeper chat recovery request"
+         ; observed_kind = Json_util.kind_name value
+         })
+;;
+
+let make ~keeper_name ~raw_receipt_id request =
+  if not (Keeper_config.validate_name keeper_name)
+  then Error (Invalid_keeper_name keeper_name)
+  else
+    match Keeper_chat_queue.Receipt_id.of_string raw_receipt_id with
+    | Ok receipt_id -> Ok { keeper_name; receipt_id; request }
+    | Error detail -> Error (Invalid_receipt_id detail)
+;;
+
+let parse_tool_command = function
+  | `Assoc fields ->
+    let ( let* ) = Result.bind in
+    let* () =
+      validate_exact_object
+        ~context:"keeper chat recovery tool command"
+        ~expected:
+          [ "schema"
+          ; "keeper_name"
+          ; "receipt_id"
+          ; "expected_revision"
+          ; "lease_id"
+          ; "decision"
+          ]
+        fields
+    in
+    let* () = parse_schema ~expected:tool_command_schema fields in
+    let* keeper_name_json = required "keeper_name" fields in
+    let* keeper_name = exact_nonblank_string ~field:"keeper_name" keeper_name_json in
+    let* receipt_id_json = required "receipt_id" fields in
+    let* raw_receipt_id = exact_nonblank_string ~field:"receipt_id" receipt_id_json in
+    let* request = parse_request_components fields in
+    make ~keeper_name ~raw_receipt_id request
+  | value ->
+    Error
+      (Object_required
+         { context = "keeper chat recovery tool command"
+         ; observed_kind = Json_util.kind_name value
+         })
+;;
+
+let decision_label = function
+  | Requeue_unconfirmed -> "requeue_unconfirmed"
+  | Cancel_unconfirmed _ -> "cancel_unconfirmed"
+;;
+
+let execute ~now command =
+  let resolution =
+    match command.request.decision with
+    | Requeue_unconfirmed -> Keeper_chat_queue.Requeue_unconfirmed
+    | Cancel_unconfirmed { detail; outcome_ref } ->
+      Keeper_chat_queue.Cancel_unconfirmed
+        { cancelled_at = now; detail; outcome_ref }
+  in
+  Keeper_chat_queue.resolve_recovery_required
+    ~keeper_name:command.keeper_name
+    ~receipt_id:command.receipt_id
+    ~expected_revision:command.request.expected_revision
+    ~lease_id:command.request.lease_id
+    ~resolution
+;;
+
+let audit config ~actor command ~outcome =
+  try
+    Audit_log.log_action
+      config
+      ~agent_id:actor
+      ~action:(Audit_log.Custom "keeper_chat_queue_recovery_resolve")
+      ~details:
+        (`Assoc
+          [ "keeper_name", `String command.keeper_name
+          ; ( "receipt_id"
+            , `String (Keeper_chat_queue.Receipt_id.to_string command.receipt_id) )
+          ; ( "expected_revision"
+            , `String (Int64.to_string command.request.expected_revision) )
+          ; "lease_id", `String command.request.lease_id
+          ; "decision", `String (decision_label command.request.decision)
+          ])
+      ~outcome
+      ();
+    Ok ()
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error (Printexc.to_string exn)
+;;
+
+let audit_json = function
+  | Ok () -> `Assoc [ "recorded", `Bool true ]
+  | Error detail ->
+    `Assoc
+      [ "recorded", `Bool false
+      ; "error", `String (Observability_redact.redact_text detail)
+      ]
+;;
+
+let success_json ~audit command
+    (report : Keeper_chat_queue.recovery_resolution_report) =
+  let receipt : Keeper_chat_queue.receipt_view =
+    { receipt_id = report.receipt_id; state = report.state }
+  in
+  `Assoc
+    [ "schema", `String result_schema
+    ; "ok", `Bool true
+    ; "decision", `String (decision_label command.request.decision)
+    ; ( "receipt"
+      , Keeper_chat_receipt_projection.receipt_json
+          ~keeper_name:command.keeper_name
+          ~revision:report.revision
+          receipt )
+    ; "audit", audit
+    ]
+;;
+
+let mutation_error_json ~audit error =
+  `Assoc
+    [ "schema", `String result_schema
+    ; "ok", `Bool false
+    ; "error", Keeper_chat_queue.mutation_error_to_json error
+    ; "audit", audit
+    ]
+;;

--- a/lib/keeper/keeper_chat_recovery_command.mli
+++ b/lib/keeper/keeper_chat_recovery_command.mli
@@ -1,0 +1,95 @@
+(** Typed command boundary for resolving one crash-ambiguous chat receipt.
+
+    Resolution is an operator decision, never an automatic retry.  Both HTTP
+    and MCP surfaces parse into this type and execute the same exact
+    receipt/revision/lease compare-and-set. *)
+
+val request_schema : string
+val tool_command_schema : string
+val result_schema : string
+
+type cancellation =
+  { detail : string
+  ; outcome_ref : string option
+  }
+
+type decision =
+  | Requeue_unconfirmed
+  | Cancel_unconfirmed of cancellation
+
+type request =
+  { expected_revision : int64
+  ; lease_id : string
+  ; decision : decision
+  }
+
+type t =
+  { keeper_name : string
+  ; receipt_id : Keeper_chat_queue.Receipt_id.t
+  ; request : request
+  }
+
+type input_error =
+  | Object_required of
+      { context : string
+      ; observed_kind : string
+      }
+  | Duplicate_fields of
+      { context : string
+      ; fields : string list
+      }
+  | Unsupported_fields of
+      { context : string
+      ; fields : string list
+      }
+  | Missing_fields of
+      { context : string
+      ; fields : string list
+      }
+  | Invalid_field of
+      { field : string
+      ; expectation : string
+      }
+  | Unsupported_schema of string
+  | Unsupported_decision of string
+  | Invalid_keeper_name of string
+  | Invalid_receipt_id of string
+
+val input_error_to_string : input_error -> string
+val input_error_to_json : input_error -> Yojson.Safe.t
+
+val parse_request : Yojson.Safe.t -> (request, input_error) result
+
+val make :
+  keeper_name:string ->
+  raw_receipt_id:string ->
+  request ->
+  (t, input_error) result
+
+val parse_tool_command : Yojson.Safe.t -> (t, input_error) result
+
+val decision_label : decision -> string
+
+val execute :
+  now:float ->
+  t ->
+  (Keeper_chat_queue.recovery_resolution_report, Keeper_chat_queue.mutation_error)
+    result
+
+val audit :
+  Workspace.config ->
+  actor:string ->
+  t ->
+  outcome:Audit_log.outcome ->
+  (unit, string) result
+
+val audit_json : (unit, string) result -> Yojson.Safe.t
+
+val success_json :
+  audit:Yojson.Safe.t ->
+  t ->
+  Keeper_chat_queue.recovery_resolution_report ->
+  Yojson.Safe.t
+
+val mutation_error_json :
+  audit:Yojson.Safe.t -> Keeper_chat_queue.mutation_error -> Yojson.Safe.t

--- a/lib/keeper/keeper_msg_async.ml
+++ b/lib/keeper/keeper_msg_async.ml
@@ -1034,8 +1034,12 @@ let load_record_at_path ~base_path ~request_id path =
     Unreadable reason
 ;;
 
+type record_location =
+  | Active_location
+  | Terminal_location
+
 type located_load_result =
-  | Located of entry
+  | Located of entry * record_location
   | Located_absent
   | Located_unreadable of string
   | Located_rejected of access_rejection
@@ -1221,7 +1225,7 @@ let load_record_canonical_located ~base_path ~request_id : located_load_result =
                   <> entry_record_to_json terminal_entry ->
           Located_unreadable
             "conflicting terminal request records coexist across persistence partitions"
-        | Found _ | Absent -> Located terminal_entry
+        | Found _ | Absent -> Located (terminal_entry, Terminal_location)
         | Unreadable reason ->
           Located_unreadable
             (Printf.sprintf
@@ -1232,7 +1236,7 @@ let load_record_canonical_located ~base_path ~request_id : located_load_result =
      | Rejected rejection -> Located_rejected rejection
      | Absent ->
        (match load_record_at_path ~base_path ~request_id active_path with
-      | Found entry -> Located entry
+      | Found entry -> Located (entry, Active_location)
       | Unreadable reason -> Located_unreadable reason
       | Rejected rejection -> Located_rejected rejection
       | Absent -> Located_absent))
@@ -1240,7 +1244,7 @@ let load_record_canonical_located ~base_path ~request_id : located_load_result =
 
 let load_record_canonical ~base_path ~request_id : load_result =
   match load_record_canonical_located ~base_path ~request_id with
-  | Located entry -> Found entry
+  | Located (entry, _) -> Found entry
   | Located_absent -> Absent
   | Located_unreadable reason -> Unreadable reason
   | Located_rejected rejection -> Rejected rejection
@@ -2303,7 +2307,7 @@ let poll ~base_path ~caller request_id : load_result =
          | None -> Found entry)
       | None ->
         (match load_record_canonical_located ~base_path ~request_id with
-         | Located entry ->
+         | Located (entry, _) ->
            (match owner_rejection ~caller entry with
             | Some rejection -> Rejected rejection
             | None ->
@@ -2341,7 +2345,7 @@ let load_canonical_durable_terminal ~base_path ~caller request_id =
              Error (Canonical_terminal_unreadable reason)
            | Located_rejected rejection ->
              Error (Canonical_terminal_access_rejected rejection)
-           | Located (entry, location, _source_path) ->
+           | Located (entry, location) ->
              (match owner_rejection ~caller entry with
               | Some rejection ->
                 Error (Canonical_terminal_access_rejected rejection)
@@ -2351,7 +2355,7 @@ let load_canonical_durable_terminal ~base_path ~caller request_id =
                 else
                   match location with
                   | Terminal_location -> Ok { terminal_entry = entry }
-                  | Active_location | Legacy_location ->
+                  | Active_location ->
                     Error
                       (Canonical_terminal_noncanonical_location entry.status))))
 ;;
@@ -2450,7 +2454,7 @@ let cancel_disk_record ~base_path ~caller ~request_id =
   | Located_absent -> Cancel_not_found
   | Located_unreadable reason -> Cancel_unreadable reason
   | Located_rejected rejection -> Cancel_rejected rejection
-  | Located entry ->
+  | Located (entry, _) ->
     (match owner_rejection ~caller entry with
      | Some rejection -> Cancel_rejected rejection
      | None when is_terminal_status entry.status ->

--- a/lib/mcp_server_eio_caller_identity.ml
+++ b/lib/mcp_server_eio_caller_identity.ml
@@ -1,5 +1,9 @@
 type owner_keeper_identity = string * string option
 
+type direct_call_authority =
+  | Catalog_policy
+  | Restricted_profile
+
 type t = {
   agent_name : string;
   agent_name_is_ephemeral : bool;
@@ -231,8 +235,8 @@ let resolve_explicit_bound_alias ~config ~workspace_initialized ~log_mcp_exn
     agent_name
 
 let resolve ~(config : Workspace_utils_backend_setup.config) ~tool_name ~arguments ~identity
-    ~cached_resolved_agent ~auth_token ~internal_keeper_runtime ~workspace_initialized
-    ~log_mcp_exn =
+    ~cached_resolved_agent ~auth_token ~internal_keeper_runtime
+    ~direct_call_authority ~workspace_initialized ~log_mcp_exn =
   let explicit_agent_name = caller_agent_name_from_arguments arguments in
   let has_explicit_agent_name = Option.is_some explicit_agent_name in
   let minted_name =
@@ -266,7 +270,10 @@ let resolve ~(config : Workspace_utils_backend_setup.config) ~tool_name ~argumen
   let mode_gate_error =
     if
       (not internal_keeper_runtime_tool)
-      && not (Tool_catalog.allow_direct_call tool_name)
+      &&
+      match direct_call_authority with
+      | Restricted_profile -> false
+      | Catalog_policy -> not (Tool_catalog.allow_direct_call tool_name)
     then
       Some (direct_call_block_message tool_name)
     else

--- a/lib/mcp_server_eio_caller_identity.mli
+++ b/lib/mcp_server_eio_caller_identity.mli
@@ -1,5 +1,11 @@
 type owner_keeper_identity = string * string option
 
+type direct_call_authority =
+  | Catalog_policy
+  | Restricted_profile
+(** [Restricted_profile] means the call already passed an exact managed or
+    operator profile membership gate.  It does not weaken authentication. *)
+
 (** A resolved caller name tagged with the origin decided at mint time.
 
     Replaces the [Client_name_kind] string classifier: the
@@ -41,6 +47,7 @@ val resolve :
   cached_resolved_agent:(string * bool) option ->
   auth_token:string option ->
   internal_keeper_runtime:bool ->
+  direct_call_authority:direct_call_authority ->
   workspace_initialized:(unit -> bool) ->
   log_mcp_exn:(label:string -> exn -> unit) ->
   t

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -84,10 +84,24 @@ let execute_tool_eio
     | None -> ()
     | Some sid -> Client_registry_eio.set_resolved_name sid agent_name ~is_ephemeral
   in
+  let direct_call_authority =
+    match profile with
+    | Mcp_server_eio_tool_profile.Full ->
+      Mcp_server_eio_caller_identity.Catalog_policy
+    | Managed_agent | Operator_remote ->
+      if
+        Mcp_server_eio_tool_profile.tool_allowed_in_profile
+          ~internal_keeper_runtime
+          state
+          profile
+          name
+      then Mcp_server_eio_caller_identity.Restricted_profile
+      else Mcp_server_eio_caller_identity.Catalog_policy
+  in
   let caller_identity =
     Mcp_server_eio_caller_identity.resolve ~config ~tool_name:name ~arguments
       ~identity ~cached_resolved_agent ~auth_token ~internal_keeper_runtime
-      ~workspace_initialized:(fun () -> workspace_init_cached)
+      ~direct_call_authority ~workspace_initialized:(fun () -> workspace_init_cached)
       ~log_mcp_exn
   in
   let agent_name = caller_identity.agent_name in
@@ -158,9 +172,22 @@ let execute_tool_eio
     let auth_result =
       if auth_enabled
       then (
-        match
-          Auth.authorize_tool_v2 config.base_path ~agent_name ~token ~tool_name:name
-        with
+        let permission_result =
+          match profile with
+          | Mcp_server_eio_tool_profile.Operator_remote ->
+            Auth.check_permission
+              config.base_path
+              ~agent_name
+              ~token
+              ~permission:Masc_domain.CanAdmin
+          | Full | Managed_agent ->
+            Auth.authorize_tool_v2
+              config.base_path
+              ~agent_name
+              ~token
+              ~tool_name:name
+        in
+        match permission_result with
         | Ok () -> Ok ()
         | Error err -> Error err)
       else Ok ()

--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -11,10 +11,11 @@ type tool_profile = Mcp_server_eio_types.tool_profile =
   | Operator_remote
 
 let operator_remote_instructions =
-  "MASC remote operator profile exposes only four control-plane tools: \
-masc_operator_snapshot, masc_operator_digest, masc_operator_action, and masc_operator_confirm. \
+  "MASC remote operator profile exposes five operator tools plus surface audit: \
+masc_operator_snapshot, masc_operator_digest, masc_operator_action, masc_operator_chat_recovery_resolve, masc_operator_confirm, and masc_surface_audit. \
 Read raw state with masc_operator_snapshot first when needed, and prefer masc_operator_digest for intervention-oriented supervision. \
 Use masc_operator_action for guided actions only. \
+Use masc_operator_chat_recovery_resolve only with the exact receipt_id, revision, and lease_id observed from queue state; it never auto-redelivers. \
 When confirm_required=true, you must call masc_operator_confirm with the returned confirm_token before the action executes. \
 Do not assume access to any other MASC tool from this endpoint."
 
@@ -212,6 +213,7 @@ let custom_tool_titles : (string * string) list = [
   ("masc_operator_snapshot", "Operator Snapshot");
   ("masc_operator_digest", "Operator Digest");
   ("masc_operator_action", "Operator Action");
+  ("masc_operator_chat_recovery_resolve", "Resolve Chat Recovery");
   ("masc_operator_confirm", "Operator Confirm");
   (* SDK projections *)
   (* Misc *)

--- a/lib/mcp_server_eio_tool_profile.mli
+++ b/lib/mcp_server_eio_tool_profile.mli
@@ -8,7 +8,7 @@
     - [Full]: developer / internal MCP surface (full catalog).
     - [Managed_agent]: spawned agent surface (SDK contract +
       passthrough subset).
-    - [Operator_remote]: control-plane surface (4 operator tools).
+    - [Operator_remote]: control-plane surface (5 operator tools plus audit).
 
     Pagination contract: callers consume {!parse_cursor_only_params}
     / {!requested_tool_list_params} as concrete records — record
@@ -58,10 +58,11 @@ val managed_agent_instructions : string
     surface diverge in inventory. *)
 
 val operator_remote_instructions : string
-(** [Operator_remote] profile instructions.  Names the 4 operator
+(** [Operator_remote] profile instructions.  Names the 5 operator
     tools ([masc_operator_snapshot], [masc_operator_digest],
-    [masc_operator_action], [masc_operator_confirm]) and the
-    confirm_token contract for [confirm_required = true]. *)
+    [masc_operator_action], [masc_operator_chat_recovery_resolve],
+    [masc_operator_confirm]), the surface-audit tool, and the confirm_token
+    contract for [confirm_required = true]. *)
 
 (** {1 Schema filtering} *)
 

--- a/lib/operator/operator_tool.ml
+++ b/lib/operator/operator_tool.ml
@@ -22,6 +22,23 @@ type tool_result = Tool_result.result
 
 type 'a context = 'a Tool_operator.context
 
+module Operator_remote_name = Tool_name.Operator_remote_name
+module Operator_name = Tool_name.Operator_name
+
+let operator_remote_tool_name name = Operator_remote_name.to_string name
+
+let operator_tool_name name =
+  operator_remote_tool_name (Operator_remote_name.Operator_tool name)
+;;
+
+let chat_recovery_tool_name =
+  operator_tool_name Operator_name.Operator_chat_recovery_resolve
+;;
+
+let surface_audit_tool_name =
+  operator_remote_tool_name Operator_remote_name.Surface_audit
+;;
+
 
 (* RFC-0189 PR-1b.11 — typed result.
 
@@ -140,6 +157,94 @@ let digest_schema ~remote =
 
 let surface_audit_schema = Tool_schemas_misc.surface_audit_schema
 
+let chat_recovery_decision_schema =
+  `Assoc
+    [ ( "oneOf"
+      , `List
+          [ `Assoc
+              [ "type", `String "object"
+              ; "additionalProperties", `Bool false
+              ; ( "properties"
+                , `Assoc
+                    [ ( "kind"
+                      , `Assoc
+                          [ "type", `String "string"
+                          ; "enum", `List [ `String "requeue_unconfirmed" ]
+                          ] )
+                    ] )
+              ; "required", `List [ `String "kind" ]
+              ]
+          ; `Assoc
+              [ "type", `String "object"
+              ; "additionalProperties", `Bool false
+              ; ( "properties"
+                , `Assoc
+                    [ ( "kind"
+                      , `Assoc
+                          [ "type", `String "string"
+                          ; "enum", `List [ `String "cancel_unconfirmed" ]
+                          ] )
+                    ; "detail", `Assoc [ "type", `String "string"; "minLength", `Int 1 ]
+                    ; ( "outcome_ref"
+                      , `Assoc
+                          [ ( "oneOf"
+                            , `List
+                                [ `Assoc
+                                    [ "type", `String "string"
+                                    ; "minLength", `Int 1
+                                    ]
+                                ; `Assoc [ "type", `String "null" ]
+                                ] )
+                          ] )
+                    ] )
+              ; ( "required"
+                , `List
+                    [ `String "kind"; `String "detail"; `String "outcome_ref" ] )
+              ]
+          ] )
+    ]
+;;
+
+let chat_recovery_schema =
+  { name = chat_recovery_tool_name
+  ; description =
+      "Resolve exactly one crash-ambiguous Keeper chat receipt. The observed receipt_id, canonical revision string, and lease_id must all match; this tool never auto-redelivers."
+  ; input_schema =
+      `Assoc
+        [ "type", `String "object"
+        ; "additionalProperties", `Bool false
+        ; ( "properties"
+          , schema_properties
+              [ ( "schema"
+                , `Assoc
+                    [ "type", `String "string"
+                    ; ( "enum"
+                      , `List
+                          [ `String Keeper_chat_recovery_command.tool_command_schema ] )
+                    ] )
+              ; "keeper_name", `Assoc [ "type", `String "string"; "minLength", `Int 1 ]
+              ; "receipt_id", `Assoc [ "type", `String "string"; "minLength", `Int 1 ]
+              ; ( "expected_revision"
+                , `Assoc
+                    [ "type", `String "string"
+                    ; "pattern", `String "^(0|[1-9][0-9]*)$"
+                    ] )
+              ; "lease_id", `Assoc [ "type", `String "string"; "minLength", `Int 1 ]
+              ; "decision", chat_recovery_decision_schema
+              ] )
+        ; ( "required"
+          , `List
+              [ `String "schema"
+              ; `String "keeper_name"
+              ; `String "receipt_id"
+              ; `String "expected_revision"
+              ; `String "lease_id"
+              ; `String "decision"
+              ] )
+        ]
+  }
+;;
+
 let action_schema ~remote =
   {
     name = "masc_operator_action";
@@ -199,6 +304,63 @@ let confirm_schema =
           ("required", `List [ `String "confirm_token" ]);
         ];
   }
+
+let recovery_mutation_failure_class = function
+  | Keeper_chat_queue.Invalid_input _
+  | Keeper_chat_queue.Receipt_already_terminal _
+  | Keeper_chat_queue.Receipt_not_recovery_required _
+  | Keeper_chat_queue.Recovery_revision_mismatch _
+  | Keeper_chat_queue.Recovery_lease_mismatch _ ->
+    Tool_result.Workflow_rejection
+  | Keeper_chat_queue.Persistence_not_configured
+  | Keeper_chat_queue.Snapshot_unavailable _
+  | Keeper_chat_queue.Revision_exhausted
+  | Keeper_chat_queue.Persist_failed _ ->
+    Tool_result.Runtime_failure
+;;
+
+let chat_recovery_result ~tool_name ~start_time (ctx : _ context) args =
+  match Keeper_chat_recovery_command.parse_tool_command args with
+  | Error error ->
+    let data = Keeper_chat_recovery_command.input_error_to_json error in
+    Tool_result.make_err
+      ~tool_name
+      ~class_:Tool_result.Workflow_rejection
+      ~start_time
+      ~data
+      (Yojson.Safe.to_string data)
+  | Ok command ->
+    let result =
+      Keeper_chat_recovery_command.execute ~now:(Time_compat.now ()) command
+    in
+    let audit =
+      Keeper_chat_recovery_command.audit
+        ctx.config
+        ~actor:ctx.agent_name
+        command
+        ~outcome:
+          (match result with
+           | Ok _ -> Audit_log.Success
+           | Error error ->
+             Audit_log.Failure (Keeper_chat_queue.mutation_error_to_string error))
+      |> Keeper_chat_recovery_command.audit_json
+    in
+    (match result with
+     | Ok report ->
+       Tool_result.make_ok
+         ~tool_name
+         ~start_time
+         ~data:(Keeper_chat_recovery_command.success_json ~audit command report)
+         ()
+     | Error error ->
+       let data = Keeper_chat_recovery_command.mutation_error_json ~audit error in
+       Tool_result.make_err
+         ~tool_name
+         ~class_:(recovery_mutation_failure_class error)
+         ~start_time
+         ~data
+         (Yojson.Safe.to_string data))
+;;
 
 let judgment_write_schema =
   {
@@ -282,6 +444,8 @@ let dispatch (ctx : 'a context) ~name ~args : Tool_result.result option =
       Some
         (result_of_json ~tool_name:name ~start_time:start
            (Operator_control.action_json control_ctx args))
+  | tool_name when String.equal tool_name chat_recovery_tool_name ->
+      Some (chat_recovery_result ~tool_name ~start_time:start ctx args)
   | "masc_operator_confirm" ->
       Some
         (result_of_json ~tool_name:name ~start_time:start
@@ -306,6 +470,7 @@ let schemas : tool_schema list =
     snapshot_schema ~remote:false;
     digest_schema ~remote:false;
     action_schema ~remote:false;
+    chat_recovery_schema;
     confirm_schema;
     surface_audit_schema ~remote:false;
     judgment_write_schema;
@@ -316,17 +481,12 @@ let remote_schemas : tool_schema list =
     snapshot_schema ~remote:true;
     digest_schema ~remote:true;
     action_schema ~remote:true;
+    chat_recovery_schema;
     confirm_schema;
     surface_audit_schema ~remote:true;
   ]
 
-module Operator_remote_name = Tool_name.Operator_remote_name
-module Operator_name = Tool_name.Operator_name
-
 let remote_tool_names : string list = Operator_remote_name.all_strings
-let operator_remote_tool_name name = Operator_remote_name.to_string name
-let operator_tool_name name = operator_remote_tool_name (Operator_remote_name.Operator_tool name)
-let surface_audit_tool_name = operator_remote_tool_name Operator_remote_name.Surface_audit
 
 (* ================================================================ *)
 (* Tool_spec registration                                           *)
@@ -340,7 +500,10 @@ let tool_spec_read_only =
   ]
 
 (* Tools with explicit catalog metadata that must be preserved. *)
-let tool_spec_hidden = [ "masc_operator_judgment_write"; surface_audit_tool_name ]
+let tool_spec_hidden =
+  [ "masc_operator_judgment_write"; surface_audit_tool_name; chat_recovery_tool_name ]
+;;
+
 let tool_spec_hidden_actions = [ operator_tool_name Operator_name.Operator_action ]
 
 let () =
@@ -348,6 +511,9 @@ let () =
     (fun (s : tool_schema) ->
       let is_hidden = List.mem s.name tool_spec_hidden || List.mem s.name tool_spec_hidden_actions in
       let existing = Tool_catalog.metadata s.name in
+      let direct_call_when_hidden =
+        is_hidden && not (String.equal s.name chat_recovery_tool_name)
+      in
       Tool_spec.register
         (Tool_spec.create
            ~name:s.name
@@ -357,7 +523,7 @@ let () =
            ~handler_binding:Tag_dispatch
            ~is_read_only:(List.mem s.name tool_spec_read_only)
            ~visibility:(if is_hidden then Tool_catalog.Hidden else Tool_catalog.Default)
-           ~allow_direct_call_when_hidden:is_hidden
+           ~allow_direct_call_when_hidden:direct_call_when_hidden
            ?reason:existing.reason
            ()))
     schemas

--- a/lib/operator/operator_tool.mli
+++ b/lib/operator/operator_tool.mli
@@ -47,6 +47,7 @@ val dispatch :
     - [masc_operator_digest] — daily digest.
     - [masc_operator_action] — schedule an action (requires
       confirm via separate call).
+    - [masc_operator_chat_recovery_resolve] — exact receipt recovery CAS.
     - [masc_operator_confirm] — confirm a pending action.
     - [masc_operator_judgment_write] — record a judgment (hidden
       from default catalog).

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -219,11 +219,6 @@ let payload_of_queued_message ~keeper_name
   ; attachments = queued_message.attachments
   }
 
-let user_line_recorded_upstream = function
-  | Keeper_chat_store.Needs_append -> false
-  | Keeper_chat_store.Already_persisted _
-  | Keeper_chat_store.Already_persisted_upstream -> true
-
 let trimmed_env_opt name =
   match Sys.getenv_opt name with
   | None -> None
@@ -1824,9 +1819,6 @@ let start_keeper_loops_owned
                           Slack delivery skipped for keeper=%s \
                           (queued reply will not be delivered)"
                          keeper_name));
-             let connector_user_line_recorded_upstream =
-               user_line_recorded_upstream queued_message.user_row_origin
-             in
              (* Derive the typed reply-continuation channel from the queued
                 message source so [process_single_turn] can route the
                 assistant reply to the originating connector (Discord/Slack)
@@ -1837,7 +1829,8 @@ let start_keeper_loops_owned
              in
              let turn_outcome =
                match
-                 process_single_turn ~connector_user_line_recorded_upstream
+                 process_single_turn
+                   ~user_row_origin:queued_message.user_row_origin
                    ~queued_turn:true
                    ~delivery_key:(Some delivery_key)
                    ~state ~clock ~auth_token:None

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -999,53 +999,6 @@ let cached_keeper_composite_json config name =
   | other -> `OK, other
 ;;
 
-let keeper_chat_receipt_state_json = function
-  | Keeper_chat_queue.Pending ->
-    `Assoc [ "kind", `String "pending" ]
-  | Keeper_chat_queue.Inflight { lease_id; started_at } ->
-    `Assoc
-      [ "kind", `String "inflight"
-      ; "lease_id", `String lease_id
-      ; "started_at", `Float started_at
-      ]
-  | Keeper_chat_queue.Recovery_required { lease_id; started_at } ->
-    `Assoc
-      [ "kind", `String "recovery_required"
-      ; "lease_id", `String lease_id
-      ; "started_at", `Float started_at
-      ; "dispatchable", `Bool false
-      ]
-  | Keeper_chat_queue.Delivered completion ->
-    `Assoc
-      [ "kind", `String "delivered"
-      ; "completed_at", `Float completion.completed_at
-      ; "outcome_ref", json_string_opt completion.outcome_ref
-      ]
-  | Keeper_chat_queue.Failed failure ->
-    `Assoc
-      [ "kind", `String "failed"
-      ; ( "failure_kind"
-        , `String (Keeper_chat_queue.failure_kind_to_string failure.kind) )
-      ; ( "detail"
-        , `String (Observability_redact.redact_text failure.detail) )
-      ; "completed_at", `Float failure.completed_at
-      ; "outcome_ref", json_string_opt failure.outcome_ref
-      ]
-;;
-
-let keeper_chat_receipt_json ~keeper_name ~revision
-    (receipt : Keeper_chat_queue.receipt_view) =
-  `Assoc
-    [ "schema", `String "keeper_chat_queue.receipt.v2"
-    ; "keeper_name", `String keeper_name
-    ; ( "receipt_id"
-      , `String
-          (Keeper_chat_queue.Receipt_id.to_string receipt.receipt_id) )
-    ; "revision", `String (Int64.to_string revision)
-    ; "state", keeper_chat_receipt_state_json receipt.state
-    ]
-;;
-
 let keeper_chat_receipt_route req_path =
   if not (String.starts_with ~prefix:keeper_api_prefix req_path)
   then None

--- a/lib/server/server_dashboard_http_keeper_api.mli
+++ b/lib/server/server_dashboard_http_keeper_api.mli
@@ -62,6 +62,19 @@ val handle_keeper_catchup_judge_post :
 (** Handle [POST /catchup-judge] by recomputing the keeper catch-up digest
     and starting an out-of-band Fusion judge run. *)
 
+val handle_keeper_chat_recovery_post :
+  Mcp_server.server_state ->
+  string ->
+  Httpun.Request.t ->
+  Httpun.Reqd.t ->
+  keeper_name:string ->
+  raw_receipt_id:string ->
+  string ->
+  unit
+(** Resolve exactly one recovery-required chat receipt using the caller's
+    revision and lease evidence. The route is wired only behind token-bound
+    [CanAdmin] authorization. *)
+
 (** {1 POST route classifier}
 
     keeper_post_route_kind ADT + classifier + path helpers live in
@@ -211,13 +224,6 @@ val handle_keeper_get_subroutes :
 val keeper_chat_receipt_route : string -> (string * string) option
 (** Parse the exact
     [/api/v1/keepers/<name>/chat/receipts/<receipt_id>] read route. *)
-
-val keeper_chat_receipt_json :
-  keeper_name:string ->
-  revision:int64 ->
-  Keeper_chat_queue.receipt_view ->
-  Yojson.Safe.t
-(** Read-only typed receipt projection returned by the route above. *)
 
 (** {1 Memory-OS dashboard JSON} *)
 

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -449,6 +449,83 @@ let duplicate_assoc_keys fields =
   in
   loop [] [] fields
 
+let keeper_chat_recovery_error_status = function
+  | Keeper_chat_queue.Invalid_input _ -> `Bad_request
+  | Keeper_chat_queue.Receipt_already_terminal _
+  | Keeper_chat_queue.Receipt_not_recovery_required _
+  | Keeper_chat_queue.Recovery_revision_mismatch _
+  | Keeper_chat_queue.Recovery_lease_mismatch _ ->
+      `Conflict
+  | Keeper_chat_queue.Persistence_not_configured
+  | Keeper_chat_queue.Snapshot_unavailable _
+  | Keeper_chat_queue.Revision_exhausted
+  | Keeper_chat_queue.Persist_failed _ ->
+      `Service_unavailable
+
+let handle_keeper_chat_recovery_post state agent_name req reqd ~keeper_name
+    ~raw_receipt_id body_str =
+  let respond ?(status = `OK) json =
+    Http.Response.json_value ~status ~request:req json reqd
+  in
+  let parsed =
+    try
+      Yojson.Safe.from_string body_str
+      |> Keeper_chat_recovery_command.parse_request
+    with
+    | Yojson.Json_error detail ->
+      Error
+        (Keeper_chat_recovery_command.Invalid_field
+           { field = "request body"; expectation = "is invalid JSON: " ^ detail })
+  in
+  match parsed with
+  | Error error ->
+    respond
+      ~status:`Bad_request
+      (`Assoc
+        [ "schema", `String Keeper_chat_recovery_command.result_schema
+        ; "ok", `Bool false
+        ; "error", Keeper_chat_recovery_command.input_error_to_json error
+        ])
+  | Ok recovery_request ->
+    (match
+       Keeper_chat_recovery_command.make
+         ~keeper_name
+         ~raw_receipt_id
+         recovery_request
+     with
+     | Error error ->
+       respond
+         ~status:`Bad_request
+         (`Assoc
+           [ "schema", `String Keeper_chat_recovery_command.result_schema
+           ; "ok", `Bool false
+           ; "error", Keeper_chat_recovery_command.input_error_to_json error
+           ])
+     | Ok command ->
+       let result =
+         Keeper_chat_recovery_command.execute ~now:(Time_compat.now ()) command
+       in
+       let audit =
+         Keeper_chat_recovery_command.audit
+           (Mcp_server.workspace_config state)
+           ~actor:agent_name
+           command
+           ~outcome:
+             (match result with
+              | Ok _ -> Audit_log.Success
+              | Error error ->
+                Audit_log.Failure
+                  (Keeper_chat_queue.mutation_error_to_string error))
+         |> Keeper_chat_recovery_command.audit_json
+       in
+       (match result with
+        | Ok report ->
+          respond (Keeper_chat_recovery_command.success_json ~audit command report)
+        | Error error ->
+          respond
+            ~status:(keeper_chat_recovery_error_status error)
+            (Keeper_chat_recovery_command.mutation_error_json ~audit error)))
+
 let dashboard_field_type_error key expected value =
   Error
     (Printf.sprintf "%s must be %s (received %s)" key expected

--- a/lib/server/server_dashboard_http_keeper_api_post.mli
+++ b/lib/server/server_dashboard_http_keeper_api_post.mli
@@ -28,6 +28,16 @@ val respond_error :
 val handle_keeper_catchup_judge_post :
   Mcp_server.server_state -> Httpun.Request.t -> Httpun.Reqd.t -> string -> unit
 
+val handle_keeper_chat_recovery_post :
+  Mcp_server.server_state ->
+  string ->
+  Httpun.Request.t ->
+  Httpun.Reqd.t ->
+  keeper_name:string ->
+  raw_receipt_id:string ->
+  string ->
+  unit
+
 val stat_json_of_path : string -> Yojson.Safe.t
 val oas_checkpoint_summary_json :
   source_kind:string ->

--- a/lib/server/server_dashboard_http_keeper_api_types.ml
+++ b/lib/server/server_dashboard_http_keeper_api_types.ml
@@ -15,6 +15,9 @@ let keeper_suffix_runtime_trace = "/runtime-trace"
 let keeper_suffix_directive = "/directive"
 let keeper_suffix_catchup_judge = "/catchup-judge"
 
+let keeper_chat_receipt_state_json = Keeper_chat_receipt_projection.state_json
+let keeper_chat_receipt_json = Keeper_chat_receipt_projection.receipt_json
+
 let cache_key_string_segment value =
   Printf.sprintf "s%d:%s" (String.length value) value
 ;;
@@ -55,6 +58,11 @@ let keeper_runtime_trace_cache_key (config : Workspace.config) name ?trace_id
     limit
 ;;
 
+type keeper_chat_recovery_route =
+  { keeper_name : string
+  ; receipt_id : string
+  }
+
 type keeper_post_route_kind =
   | Keeper_post_config
   | Keeper_post_secrets
@@ -65,12 +73,32 @@ type keeper_post_route_kind =
   | Keeper_post_checkpoints
   | Keeper_post_directive
   | Keeper_post_catchup_judge
+  | Keeper_post_chat_recovery of keeper_chat_recovery_route
   | Keeper_post_unknown
 
-let classify_keeper_post_route req_path =
-  if not (String.starts_with ~prefix:keeper_api_prefix req_path) then
-    Keeper_post_unknown
+let keeper_chat_recovery_route req_path =
+  if not (String.starts_with ~prefix:keeper_api_prefix req_path)
+  then None
   else
+    let rest =
+      String.sub
+        req_path
+        (String.length keeper_api_prefix)
+        (String.length req_path - String.length keeper_api_prefix)
+    in
+    match String.split_on_char '/' rest with
+    | [ keeper_name; "chat"; "receipts"; receipt_id; "recovery" ]
+      when not (String.equal keeper_name "") && not (String.equal receipt_id "") ->
+      Some { keeper_name; receipt_id }
+    | _ -> None
+;;
+
+let classify_keeper_post_route req_path =
+  match keeper_chat_recovery_route req_path with
+  | Some route -> Keeper_post_chat_recovery route
+  | None when not (String.starts_with ~prefix:keeper_api_prefix req_path) ->
+    Keeper_post_unknown
+  | None ->
     let plen = String.length keeper_api_prefix in
     let tlen = String.length req_path in
     let ends_with suffix =

--- a/lib/server/server_dashboard_http_keeper_api_types.mli
+++ b/lib/server/server_dashboard_http_keeper_api_types.mli
@@ -23,6 +23,15 @@ val keeper_suffix_runtime_trace : string
 val keeper_suffix_directive : string
 val keeper_suffix_catchup_judge : string
 
+val keeper_chat_receipt_state_json :
+  Keeper_chat_queue.receipt_state -> Yojson.Safe.t
+
+val keeper_chat_receipt_json :
+  keeper_name:string ->
+  revision:int64 ->
+  Keeper_chat_queue.receipt_view ->
+  Yojson.Safe.t
+
 (** {1 Dashboard cache keys} *)
 
 val cache_key_string_segment : string -> string
@@ -50,6 +59,11 @@ val keeper_runtime_trace_cache_key :
 (** Cache key for [/api/v1/keepers/<name>/runtime-trace]. Optional query
     fields are tagged so absent values cannot collide with literal payloads. *)
 
+type keeper_chat_recovery_route =
+  { keeper_name : string
+  ; receipt_id : string
+  }
+
 type keeper_post_route_kind =
   | Keeper_post_config
   | Keeper_post_secrets
@@ -60,6 +74,7 @@ type keeper_post_route_kind =
   | Keeper_post_checkpoints
   | Keeper_post_directive
   | Keeper_post_catchup_judge
+  | Keeper_post_chat_recovery of keeper_chat_recovery_route
   | Keeper_post_unknown
 (** Sub-route kind for a [POST /api/v1/keepers/<name>/...] path. *)
 

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -2297,7 +2297,7 @@ let process_single_turn ~user_row_origin ~queued_turn
                            Tool_result.ok
                              ~tool_name:"masc_keeper_msg"
                              ~start_time
-                             body))))
+                             body)))))
         | Ok (`Ran (false, err)) ->
             let persisted = persist_failure_reply err in
             let queued_outcome =

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -1403,6 +1403,14 @@ let queued_delivery_outcome_of_turn_ref = function
             "queued turn persisted a reply but the reply payload had no valid turn_ref"
         }
 
+let committed_delivery_outcome ~queued_turn ~turn_ref = function
+  | Error persist_error -> Error persist_error
+  | Ok () ->
+      Ok
+        (if queued_turn
+         then Some (queued_delivery_outcome_of_turn_ref turn_ref)
+         else None)
+
 type keeper_stream_bridge_state = Keeper_chat_oas_stream_bridge.state
 
 type translated_keeper_stream_event =
@@ -2168,26 +2176,17 @@ let process_single_turn ~user_row_origin ~queued_turn
                          ()
                  in
                  let delivered_after_persist ?content persisted =
-                   match persisted with
-                   | Ok () ->
+                   match
+                     committed_delivery_outcome ~queued_turn ~turn_ref persisted
+                   with
+                   | Ok queued_outcome ->
                        Keeper_chat_broadcast.chat_appended
                          ~keeper_name:payload.name ~source:chat_source ?content ();
-                       if queued_turn
-                       then
-                         Some (queued_delivery_outcome_of_turn_ref turn_ref)
-                       else None
-                   | Error persist_error ->
-                       if queued_turn
-                       then
-                         Some
-                           (Failed
-                              { kind = Transcript_persist_failed
-                              ; detail = persist_error
-                              })
-                       else None
+                       Ok queued_outcome
+                   | Error _ as error -> error
                  in
                  let turn_outcome = canonical_reply.turn_outcome in
-                 let queued_outcome =
+                 let delivery_result =
                    match turn_outcome, String_util.trim_to_option visible_reply with
                    | Keeper_turn_outcome.Continuation_checkpoint, _ when queued_turn ->
                        let detail =
@@ -2195,35 +2194,25 @@ let process_single_turn ~user_row_origin ~queued_turn
                        in
                        (match persist_failure_reply detail with
                         | Ok () ->
-                            Some
-                              (Failed
-                                 { kind = Continuation_checkpoint_without_reply
-                                 ; detail
-                                 })
-                        | Error persist_error ->
-                            Some
-                              (Failed
-                                 { kind = Transcript_persist_failed
-                                 ; detail = persist_error
-                                 }))
+                            Ok
+                              (Some
+                                 (Failed
+                                    { kind = Continuation_checkpoint_without_reply
+                                    ; detail
+                                    }))
+                        | Error persist_error -> Error persist_error)
                    | Keeper_turn_outcome.Continuation_checkpoint, _ ->
                        (match !direct_delivery_checkpoint with
                         | Some _ ->
-                          (match
-                             commit_direct_terminal
-                               ~ok:true
-                               ~body
-                               ~data:payload_json_opt
-                               Keeper_chat_direct_delivery.No_assistant_reply
-                           with
-                           | Ok () -> None
-                           | Error detail ->
-                             Some
-                               (Failed
-                                  { kind = Transcript_persist_failed; detail }))
+                          commit_direct_terminal
+                            ~ok:true
+                            ~body
+                            ~data:payload_json_opt
+                            Keeper_chat_direct_delivery.No_assistant_reply
+                          |> Result.map (fun () -> None)
                         | None ->
                           persist_user_message_only ();
-                          None)
+                          Ok None)
                    | Keeper_turn_outcome.No_visible_reply, _
                    | Keeper_turn_outcome.Visible_reply, None ->
                        if has_visible_blocks
@@ -2236,21 +2225,40 @@ let process_single_turn ~user_row_origin ~queued_turn
                            "no visible reply was produced for this queued message"
                          in
                          (match persist_failure_reply detail with
-                          | Ok () -> Some (Failed { kind = No_visible_reply; detail })
-                          | Error persist_error ->
-                              Some
-                                (Failed
-                                   { kind = Transcript_persist_failed
-                                   ; detail = persist_error
-                                   }))
+                          | Ok () ->
+                            Ok (Some (Failed { kind = No_visible_reply; detail }))
+                          | Error persist_error -> Error persist_error)
                        else (
                          persist_user_message_only ();
-                         None)
+                         Ok None)
                    | Keeper_turn_outcome.Visible_reply, Some visible_reply ->
                        persist_assistant_reply ~assistant_content:visible_reply
                        |> delivered_after_persist ~content:visible_reply
                  in
-                 (match queued_outcome with
+                 (match delivery_result with
+                  | Error persist_error ->
+                      let queued_outcome =
+                        if queued_turn
+                        then
+                          Some
+                            (Failed
+                               { kind = Transcript_persist_failed
+                               ; detail = persist_error
+                               })
+                        else None
+                      in
+                      push_worker_event
+                        (Stream_terminal
+                           { status = Stream_error
+                           ; body = persist_error
+                           ; queued_outcome
+                           });
+                      Tool_result.error
+                        ~tool_name:"masc_keeper_msg"
+                        ~start_time
+                        persist_error
+                  | Ok queued_outcome ->
+                   (match queued_outcome with
                   | Some (Failed { detail; _ }) ->
                       push_worker_event
                         (Stream_terminal
@@ -3076,6 +3084,7 @@ module For_testing = struct
   let direct_reply_terminal_error = direct_reply_terminal_error
   let queued_delivery_outcome_of_turn_ref =
     queued_delivery_outcome_of_turn_ref
+  let committed_delivery_outcome = committed_delivery_outcome
   let format_surface_context = format_surface_context
   let surface_context_to_instructions = surface_context_to_instructions
   let empty_stream_bridge_state = empty_keeper_stream_bridge_state

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -170,6 +170,7 @@ type dashboard_deferred_chat =
   ; chat_waiting : bool
   ; pending_count : int
   ; inflight_count : int
+  ; recovery_required_count : int
   ; receipt_id : string
   ; shutdown_operation_id : Keeper_shutdown_types.Operation_id.t option
   ; queue_revision : int64
@@ -184,43 +185,66 @@ let dashboard_busy_queue_state ~base_path ~keeper_name =
     if not (Keeper_chat_queue.persistence_configured ())
     then true
     else
-      let snapshot = Keeper_chat_queue.snapshot ~keeper_name in
-      snapshot.load_errors <> []
-      || snapshot.pending <> []
-      || snapshot.inflight <> []
+      match Keeper_chat_queue.lane_status ~keeper_name with
+      | Error _ -> true
+      | Ok { has_active; health = Keeper_chat_queue.Ready; _ } -> has_active
+      | Ok
+          { health =
+              ( Keeper_chat_queue.Persistence_reconciliation_required
+              | Keeper_chat_queue.Delivery_recovery_required _
+              | Keeper_chat_queue.Unavailable _ )
+          ; _
+          } ->
+        true
   in
   match in_flight, chat_waiting, queue_waiting, shutdown_operation_id with
   | None, false, false, None -> None
   | _ -> Some (in_flight, chat_waiting, shutdown_operation_id)
 
 let dashboard_deferred_ack_text ~keeper_name deferred =
-  match deferred.shutdown_operation_id with
-  | Some operation_id ->
+  if deferred.recovery_required_count < 0
+  then invalid_arg "dashboard deferred recovery count must be non-negative"
+  else if deferred.recovery_required_count > 0
+  then
     Printf.sprintf
-      "%s is stopping under operation %s; your message was durably accepted \
-       (receipt_id=%s, pending_count=%d, inflight_count=%d) for the next active \
-       lane. The Dashboard will track it through Pending, Inflight, and a \
-       terminal Delivered or Failed state."
-      keeper_name
-      (Keeper_shutdown_types.Operation_id.to_string operation_id)
-      deferred.receipt_id
-      deferred.pending_count
-      deferred.inflight_count
-  | None ->
-    Printf.sprintf
-      "%s is busy; your message was durably accepted (receipt_id=%s, \
-       pending_count=%d, inflight_count=%d). The Dashboard will track it through \
-       Pending, Inflight, and a terminal Delivered or Failed state."
+      "%s accepted your message durably (receipt_id=%s, pending_count=%d, \
+       inflight_count=%d, recovery_required_count=%d). This Keeper lane has an \
+       earlier delivery whose external effect is unconfirmed; it will remain \
+       non-dispatchable until an operator resolves that exact receipt."
       keeper_name
       deferred.receipt_id
       deferred.pending_count
       deferred.inflight_count
+      deferred.recovery_required_count
+  else
+    match deferred.shutdown_operation_id with
+    | Some operation_id ->
+      Printf.sprintf
+        "%s is stopping under operation %s; your message was durably accepted \
+         (receipt_id=%s, pending_count=%d, inflight_count=%d) for the next active \
+         lane. The Dashboard will track it through Pending, Inflight, and a \
+         terminal Delivered or Failed state."
+        keeper_name
+        (Keeper_shutdown_types.Operation_id.to_string operation_id)
+        deferred.receipt_id
+        deferred.pending_count
+        deferred.inflight_count
+    | None ->
+      Printf.sprintf
+        "%s is busy; your message was durably accepted (receipt_id=%s, \
+         pending_count=%d, inflight_count=%d). The Dashboard will track it through \
+         Pending, Inflight, and a terminal Delivered or Failed state."
+        keeper_name
+        deferred.receipt_id
+        deferred.pending_count
+        deferred.inflight_count
 
 let dashboard_deferred_chat_to_json ~keeper_name
     ({ in_flight
      ; chat_waiting
      ; pending_count
      ; inflight_count
+     ; recovery_required_count
      ; receipt_id
      ; shutdown_operation_id
      ; queue_revision
@@ -241,9 +265,10 @@ let dashboard_deferred_chat_to_json ~keeper_name
      ; ("queue", `String "keeper_chat_queue")
      ; ("pending_count", `Int pending_count)
      ; ("inflight_count", `Int inflight_count)
+     ; ("recovery_required_count", `Int recovery_required_count)
      ; ("chat_waiting", `Bool chat_waiting)
      ; ("receipt_id", `String receipt_id)
-     ; ("queue_revision", `Intlit (Int64.to_string queue_revision))
+     ; ("queue_revision", `String (Int64.to_string queue_revision))
      ; ( "shutdown_operation_id"
        , match shutdown_operation_id with
          | None -> `Null
@@ -254,6 +279,8 @@ let dashboard_deferred_chat_to_json ~keeper_name
 
 let enqueue_dashboard_payload
       ~clock
+      ~thread_id
+      ~user_row_origin
       payload
       ~in_flight
       ~chat_waiting
@@ -265,13 +292,8 @@ let enqueue_dashboard_payload
       ; user_blocks = payload.user_blocks
       ; attachments = payload.attachments
       ; timestamp = Eio.Time.now clock
-        (* Same dashboard SSE thread convention as run_keeper_stream below;
-           the continuation channel resumes the deferred turn on this
-           thread. The payload is fresh HTTP input, so the user transcript
-           row is appended at delivery (Needs_append), never skipped. *)
-      ; source =
-          Keeper_chat_queue.Dashboard { thread_id = "keeper:" ^ payload.name }
-      ; user_row_origin = Keeper_chat_store.Needs_append
+      ; source = Keeper_chat_queue.Dashboard { thread_id }
+      ; user_row_origin
       }
   with
   | Error error -> Error (Keeper_chat_queue.mutation_error_to_string error)
@@ -281,12 +303,17 @@ let enqueue_dashboard_payload
         ; chat_waiting
         ; pending_count = receipt.pending_count
         ; inflight_count = receipt.inflight_count
+        ; recovery_required_count = receipt.recovery_required_count
         ; receipt_id = Keeper_chat_queue.Receipt_id.to_string receipt.receipt_id
         ; queue_revision = receipt.revision
         ; shutdown_operation_id
         }
 
-let dashboard_deferred_chat_of_rejection ~clock payload
+let dashboard_deferred_chat_of_rejection
+      ~clock
+      ~thread_id
+      ~user_row_origin
+      payload
      ({ Keeper_turn_admission.waiting
      ; in_flight
      ; shutdown_operation_id
@@ -296,18 +323,22 @@ let dashboard_deferred_chat_of_rejection ~clock payload
      lane, rather than starting a turn behind the fence. *)
   enqueue_dashboard_payload
     ~clock
+    ~thread_id
+    ~user_row_origin
     payload
     ~in_flight
     ~chat_waiting:(waiting > 0)
     ~shutdown_operation_id
 
-let defer_dashboard_payload_if_busy ~base_path ~clock payload =
+let defer_dashboard_payload_if_busy ~base_path ~clock ~thread_id payload =
   match dashboard_busy_queue_state ~base_path ~keeper_name:payload.name with
   | None -> `Not_busy
   | Some (in_flight, chat_waiting, shutdown_operation_id) ->
       (match
          enqueue_dashboard_payload
            ~clock
+           ~thread_id
+           ~user_row_origin:Keeper_chat_store.Needs_append
            payload
            ~in_flight
            ~chat_waiting
@@ -1383,20 +1414,20 @@ type translated_keeper_stream_event =
 let empty_keeper_stream_bridge_state = Keeper_chat_oas_stream_bridge.empty_state
 let translate_oas_stream_event = Keeper_chat_oas_stream_bridge.translate
 
-(* [connector_user_line_recorded_upstream] and [queued_turn] are required
-   labelled arguments, not optional with the "default" their .mli doc
-   comments describe: the function ends in labelled args with no positional
-   terminator, so a leading optional could not be erased (warning 16). Every
-   caller states explicitly whether the gate inbound boundary already owns
-   the user line, and whether this turn was dispatched from the queue
-   consumer. *)
-let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
+(* [user_row_origin] and [queued_turn] are required labelled arguments. Every
+   caller presents the typed transcript provenance selected at its persistence
+   boundary; this function never infers ownership from a connector label or
+   message content. *)
+let process_single_turn ~user_row_origin ~queued_turn
     ~delivery_key
     ~state ~clock ~auth_token ~thread_id ~continuation_channel ~closed
     ~client_disconnects
     ~payload ~run_id ~message_id ~agent_name ~submitted_by
     ~(events : Keeper_chat_events.keeper_chat_event Eio.Stream.t) =
   let base_path = (Mcp_server.workspace_config state).base_path in
+  let direct_delivery_checkpoint : Keeper_chat_direct_delivery.t option ref =
+    ref None
+  in
   let redaction =
     Keeper_secret_redaction.snapshot ~base_path ~keeper_name:payload.name
   in
@@ -1451,8 +1482,61 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
     Eio.Mutex.use_rw ~protect:true terminal_delivery_mu (fun () ->
       if not (Atomic.get terminal_pushed) then staged_completion := Some completion)
   in
+  let report_direct_checkpoint_error ~operation checkpoint detail =
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string LifecycleCallbackFailures)
+      ~labels:[ "callback", "keeper_chat_direct_delivery"; "operation", operation ]
+      ();
+    Log.Keeper.error
+      "keeper_stream: direct checkpoint %s failed keeper=%s request_id=%s phase=%s error=%s"
+      operation
+      checkpoint.Keeper_chat_direct_delivery.payload.keeper_name
+      (Keeper_chat_direct_delivery.Request_id.to_string checkpoint.request_id)
+      (Keeper_chat_direct_delivery.phase_kind_to_string
+         (Keeper_chat_direct_delivery.phase_kind checkpoint.phase))
+      detail
+  in
+  let cleanup_direct_checkpoint () =
+    match !direct_delivery_checkpoint with
+    | None -> ()
+    | Some checkpoint ->
+      (match checkpoint.Keeper_chat_direct_delivery.phase with
+       | Keeper_chat_direct_delivery.Transcript_committed _ ->
+         (match
+            Keeper_chat_direct_delivery.observe_async_terminal
+              ~base_path
+              ~identity:checkpoint
+          with
+          | Error error ->
+            report_direct_checkpoint_error
+              ~operation:"observe_async_terminal"
+              checkpoint
+              (Keeper_chat_direct_delivery.error_to_string error)
+          | Ok proof ->
+            (match
+               Keeper_chat_direct_delivery.remove_after_async_terminal
+                 ~base_path
+                 ~identity:checkpoint
+                 ~proof
+             with
+             | Ok () -> direct_delivery_checkpoint := None
+             | Error error ->
+               report_direct_checkpoint_error
+                 ~operation:"remove_after_async_terminal"
+                 checkpoint
+                 (Keeper_chat_direct_delivery.error_to_string error)))
+       | ( Keeper_chat_direct_delivery.Prepared
+         | Keeper_chat_direct_delivery.User_row_committed _
+         | Keeper_chat_direct_delivery.Running _
+         | Keeper_chat_direct_delivery.Effect_staged _ ) ->
+         report_direct_checkpoint_error
+           ~operation:"terminal_before_transcript_commit"
+           checkpoint
+           "canonical request terminal committed while its direct transcript checkpoint remains incomplete")
+  in
   let publish_committed_completion
       (settlement : Keeper_msg_async.worker_settlement) =
+    cleanup_direct_checkpoint ();
     let completion =
       completion_of_worker_settlement
         ~queued_turn
@@ -1545,50 +1629,33 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
   let chat_speaker : Keeper_chat_store.speaker = chat_speaker_of_request payload in
   let dashboard_direct_stream =
     (not queued_turn)
-    && (not connector_user_line_recorded_upstream)
+    && (match user_row_origin with
+        | Keeper_chat_store.Needs_append -> true
+        | Keeper_chat_store.Already_persisted _
+        | Keeper_chat_store.Already_persisted_upstream -> false)
     && not (has_external_speaker payload)
   in
-  let direct_delivery_journal = ref None in
-  let journal_error error =
-    Keeper_chat_delivery_journal.error_to_string error
+  let direct_delivery_error error =
+    Keeper_chat_direct_delivery.error_to_string error
   in
-  let row_id_of_append_once = function
-    | Keeper_chat_store.Appended { row_id }
-    | Keeper_chat_store.Already_present { row_id } -> row_id
+  let set_direct_delivery_checkpoint checkpoint =
+    direct_delivery_checkpoint := Some checkpoint
   in
-  let set_direct_delivery_journal journal =
-    direct_delivery_journal := Some journal
+  let queue_delivery_key () =
+    match queued_turn, delivery_key with
+    | true, Some (Keeper_chat_delivery_identity.Queue_receipts _ as key) ->
+      Ok key
+    | true, Some (Keeper_chat_delivery_identity.Direct_request _) ->
+      Error "queued Keeper turn received a direct-request delivery identity"
+    | true, None ->
+      Error "queued Keeper turn is missing its receipt delivery identity"
+    | false, _ -> Error "non-queued Keeper turn requested queue delivery identity"
   in
-  let on_direct_request_accepted request_id =
+  let append_queued_user_row_once () =
     let ( let* ) = Result.bind in
-    let* request_id =
-      Keeper_chat_delivery_identity.Request_id.of_string request_id
-    in
-    let delivery_key =
-      Keeper_chat_delivery_identity.Direct_request request_id
-    in
-    let accepted_payload : Keeper_chat_delivery_journal.accepted_payload =
-      { keeper_name = payload.name
-      ; submitted_by
-      ; user_content = payload.message
-      ; user_attachments = payload.attachments
-      ; surface = chat_surface
-      ; conversation_id = None
-      ; external_message_id = None
-      ; speaker = chat_speaker
-      ; user_row_origin = Keeper_chat_delivery_journal.Needs_append
-      }
-    in
-    let* prepared =
-      Keeper_chat_delivery_journal.prepare
-        ~base_path
-        ~delivery_key
-        ~payload:accepted_payload
-        ~now:(Time_compat.now ())
-      |> Result.map_error journal_error
-    in
-    set_direct_delivery_journal prepared;
-    let* user_row =
+    let* delivery_key = queue_delivery_key () in
+    match user_row_origin with
+    | Keeper_chat_store.Needs_append ->
       Keeper_chat_store.append_user_message_once
         ~base_dir:base_path
         ~keeper_name:payload.name
@@ -1598,50 +1665,46 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
         ~surface:chat_surface
         ~speaker:chat_speaker
         ()
-    in
-    let* accepted =
-      Keeper_chat_delivery_journal.mark_accepted
-        ~base_path
-        ~expected_revision:prepared.revision
-        ~identity:prepared
-        ~user_row_id:(Some (row_id_of_append_once user_row))
-        ~now:(Time_compat.now ())
-      |> Result.map_error journal_error
-    in
-    set_direct_delivery_journal accepted;
-    let* running =
-      Keeper_chat_delivery_journal.mark_running
-        ~base_path
-        ~expected_revision:accepted.revision
-        ~identity:accepted
-        ~now:(Time_compat.now ())
-      |> Result.map_error journal_error
-    in
-    set_direct_delivery_journal running;
-    Ok ()
+      |> Result.map (fun _ -> ())
+    | Keeper_chat_store.Already_persisted _
+    | Keeper_chat_store.Already_persisted_upstream ->
+      Ok ()
   in
-  let on_queue_turn_admitted () =
+  let append_queued_assistant_once ~content ?blocks ?turn_ref () =
     let ( let* ) = Result.bind in
-    let* delivery_key, receipt_ids =
-      match delivery_key with
-      | Some (Keeper_chat_delivery_identity.Queue_receipts receipt_ids as key) ->
-        Ok (key, receipt_ids)
-      | Some (Keeper_chat_delivery_identity.Direct_request _) ->
-        Error "queued Keeper turn received a direct-request delivery identity"
-      | None -> Error "queued Keeper turn is missing its receipt delivery identity"
+    let* delivery_key = queue_delivery_key () in
+    Keeper_chat_store.append_assistant_message_once
+      ~base_dir:base_path
+      ~keeper_name:payload.name
+      ~delivery_key
+      ~content
+      ~surface:chat_surface
+      ?blocks
+      ?turn_ref
+      ~stream_lifecycle:completed_stream_lifecycle
+      ()
+    |> Result.map (fun _ -> ())
+  in
+  let append_queued_transport_failure_once content =
+    let ( let* ) = Result.bind in
+    let* delivery_key = queue_delivery_key () in
+    Keeper_chat_store.append_assistant_message_once
+      ~base_dir:base_path
+      ~keeper_name:payload.name
+      ~delivery_key
+      ~content
+      ~surface:chat_surface
+      ~assistant_kind:Keeper_chat_store.Row_kind.Transport_failure
+      ~stream_lifecycle:errored_stream_lifecycle
+      ()
+    |> Result.map (fun _ -> ())
+  in
+  let on_direct_request_accepted request_id =
+    let ( let* ) = Result.bind in
+    let* request_id =
+      Keeper_chat_delivery_identity.Request_id.of_string request_id
     in
-    let user_row_origin =
-      if connector_user_line_recorded_upstream
-      then Ok Keeper_chat_delivery_journal.Already_persisted_upstream
-      else
-        Keeper_chat_delivery_journal.dashboard_queue_user_row_origin
-          ~base_path
-          ~keeper_name:payload.name
-          receipt_ids
-        |> Result.map_error journal_error
-    in
-    let* user_row_origin = user_row_origin in
-    let accepted_payload : Keeper_chat_delivery_journal.accepted_payload =
+    let accepted_payload : Keeper_chat_direct_delivery.accepted_payload =
       { keeper_name = payload.name
       ; submitted_by
       ; user_content = payload.message
@@ -1650,145 +1713,80 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
       ; conversation_id = None
       ; external_message_id = None
       ; speaker = chat_speaker
-      ; user_row_origin
       }
     in
     let* prepared =
-      Keeper_chat_delivery_journal.prepare
+      Keeper_chat_direct_delivery.prepare
         ~base_path
-        ~delivery_key
+        ~request_id
         ~payload:accepted_payload
         ~now:(Time_compat.now ())
-      |> Result.map_error journal_error
+      |> Result.map_error direct_delivery_error
     in
-    set_direct_delivery_journal prepared;
-    let* user_row_id =
-      match user_row_origin with
-      | Keeper_chat_delivery_journal.Already_persisted_upstream -> Ok None
-      | Keeper_chat_delivery_journal.Already_persisted { row_id } ->
-        Ok (Some row_id)
-      | Keeper_chat_delivery_journal.Needs_append ->
-        Keeper_chat_store.append_user_message_once
-          ~base_dir:base_path
-          ~keeper_name:payload.name
-          ~delivery_key
-          ~content:payload.message
-          ~attachments:payload.attachments
-          ~surface:chat_surface
-          ~speaker:chat_speaker
-          ()
-        |> Result.map (fun result -> Some (row_id_of_append_once result))
-    in
-    let* accepted =
-      Keeper_chat_delivery_journal.mark_accepted
+    set_direct_delivery_checkpoint prepared;
+    let* user_committed =
+      Keeper_chat_direct_delivery.commit_user_row
         ~base_path
-        ~expected_revision:prepared.revision
         ~identity:prepared
-        ~user_row_id
         ~now:(Time_compat.now ())
-      |> Result.map_error journal_error
+      |> Result.map_error direct_delivery_error
     in
-    set_direct_delivery_journal accepted;
+    set_direct_delivery_checkpoint user_committed;
     let* running =
-      Keeper_chat_delivery_journal.mark_running
+      Keeper_chat_direct_delivery.mark_running
         ~base_path
-        ~expected_revision:accepted.revision
-        ~identity:accepted
+        ~identity:user_committed
         ~now:(Time_compat.now ())
-      |> Result.map_error journal_error
+      |> Result.map_error direct_delivery_error
     in
-    set_direct_delivery_journal running;
+    set_direct_delivery_checkpoint running;
     Ok ()
   in
-  let commit_direct_terminal terminal =
+  let direct_user_row_origin () =
+    match !direct_delivery_checkpoint with
+    | Some
+        { Keeper_chat_direct_delivery.phase =
+            Keeper_chat_direct_delivery.Running { user_row_id }
+        ; _
+        } ->
+      Ok (Keeper_chat_store.Already_persisted { row_id = user_row_id })
+    | Some checkpoint ->
+      Error
+        (Printf.sprintf
+           "direct Keeper delivery cannot hand off to the queue from phase=%s"
+           (Keeper_chat_direct_delivery.phase_kind_to_string
+              (Keeper_chat_direct_delivery.phase_kind checkpoint.phase)))
+    | None -> Error "direct Keeper delivery checkpoint is unavailable"
+  in
+  let on_queue_turn_admitted () =
+    append_queued_user_row_once ()
+  in
+  let commit_direct_terminal ~ok ~body ~data transcript_effect =
     let ( let* ) = Result.bind in
-    let rec drive journal =
-      match journal.Keeper_chat_delivery_journal.phase with
-      | Keeper_chat_delivery_journal.Running _ ->
-        let* pending =
-          Keeper_chat_delivery_journal.mark_terminal_pending
-            ~base_path
-            ~expected_revision:journal.revision
-            ~identity:journal
-            ~terminal
-            ~now:(Time_compat.now ())
-          |> Result.map_error journal_error
-        in
-        set_direct_delivery_journal pending;
-        drive pending
-      | Keeper_chat_delivery_journal.Terminal_pending
-          { terminal = persisted_terminal; user_row_id } ->
-        let delivery_key = journal.delivery_key in
-        let* transcript_row_id =
-          match persisted_terminal.delivery with
-          | Keeper_chat_delivery_journal.Assistant_reply
-              { content; blocks; turn_ref } ->
-            Keeper_chat_store.append_assistant_message_once
-              ~base_dir:base_path
-              ~keeper_name:payload.name
-              ~delivery_key
-              ~content
-              ~surface:chat_surface
-              ?blocks
-              ?turn_ref
-              ~stream_lifecycle:completed_stream_lifecycle
-              ()
-            |> Result.map row_id_of_append_once
-          | Keeper_chat_delivery_journal.Transport_failure { content } ->
-            Keeper_chat_store.append_assistant_message_once
-              ~base_dir:base_path
-              ~keeper_name:payload.name
-              ~delivery_key
-              ~content
-              ~surface:chat_surface
-              ~assistant_kind:Keeper_chat_store.Row_kind.Transport_failure
-              ~stream_lifecycle:errored_stream_lifecycle
-              ()
-            |> Result.map row_id_of_append_once
-          | Keeper_chat_delivery_journal.No_assistant_reply
-              { reason =
-                  ( Keeper_chat_delivery_journal.Continuation_checkpoint
-                  | Keeper_chat_delivery_journal.Queued_for_later _ )
-              } ->
-            (match user_row_id with
-             | Some user_row_id -> Ok user_row_id
-             | None ->
-               Error
-                 "continuation checkpoint requires an accepted user transcript row")
-        in
-        let* committed =
-          Keeper_chat_delivery_journal.mark_transcript_committed
-            ~base_path
-            ~expected_revision:journal.revision
-            ~identity:journal
-            ~transcript_row_id
-            ~now:(Time_compat.now ())
-          |> Result.map_error journal_error
-        in
-        set_direct_delivery_journal committed;
-        drive committed
-      | Keeper_chat_delivery_journal.Transcript_committed _ ->
-        let* final =
-          Keeper_chat_delivery_journal.mark_final
-            ~base_path
-            ~expected_revision:journal.revision
-            ~identity:journal
-            ~now:(Time_compat.now ())
-          |> Result.map_error journal_error
-        in
-        set_direct_delivery_journal final;
-        Ok ()
-      | Keeper_chat_delivery_journal.Final _ -> Ok ()
-      | Keeper_chat_delivery_journal.Prepared
-      | Keeper_chat_delivery_journal.Accepted _ ->
-        Error
-          (Printf.sprintf
-             "direct Keeper delivery reached terminal commit from phase=%s"
-             (Keeper_chat_delivery_journal.phase_to_string journal.phase))
-    in
-    match !direct_delivery_journal with
-    | None -> Error "direct Keeper delivery journal is unavailable"
-    | Some journal -> drive journal
+    match !direct_delivery_checkpoint with
+    | None -> Error "direct Keeper delivery checkpoint is unavailable"
+    | Some checkpoint ->
+      let* staged =
+        Keeper_chat_direct_delivery.stage_effect
+          ~base_path
+          ~identity:checkpoint
+          ~staged:
+            { Keeper_chat_direct_delivery.request_result = { ok; body; data }
+            ; transcript_effect
+            }
+          ~now:(Time_compat.now ())
+        |> Result.map_error direct_delivery_error
+      in
+      set_direct_delivery_checkpoint staged;
+      let* committed =
+        Keeper_chat_direct_delivery.commit_transcript
+          ~base_path
+          ~identity:staged
+          ~now:(Time_compat.now ())
+        |> Result.map_error direct_delivery_error
+      in
+      set_direct_delivery_checkpoint committed;
+      Ok ()
   in
   (* RFC-0301 item 6: collect generated media from the same stream so the assistant
      turn can persist it as reload-visible chat blocks. The bridge surfaces this
@@ -1800,19 +1798,21 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
     push_worker_event (Stream_event evt)
   in
   let persist_user_message_only () =
-    (* RFC-connector-deferred-reply-via-chat-queue §3.4: when the gate inbound boundary already recorded this
-       connector user line (Discord/Slack busy message enqueued onto the chat
-       queue), re-recording it here would double-write. The gate inbound line is
-       assistant-less, so the message is already "pending" — nothing to add. *)
-    if Option.is_some !direct_delivery_journal then ()
-    else if not connector_user_line_recorded_upstream then
-      Keeper_chat_store.append_user_message
-        ~base_dir:base_path
-        ~keeper_name:payload.name
-        ~content:payload.message
-        ~attachments:payload.attachments
-        ~surface:chat_surface
-        ~speaker:chat_speaker
+    if Option.is_some !direct_delivery_checkpoint || queued_turn
+    then ()
+    else
+      match user_row_origin with
+      | Keeper_chat_store.Needs_append ->
+        Keeper_chat_store.append_user_message
+          ~base_dir:base_path
+          ~keeper_name:payload.name
+          ~content:payload.message
+          ~attachments:payload.attachments
+          ~surface:chat_surface
+          ~speaker:chat_speaker
+          ()
+      | Keeper_chat_store.Already_persisted _
+      | Keeper_chat_store.Already_persisted_upstream ->
         ()
   in
   let persist_failure_reply err =
@@ -1824,46 +1824,40 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
       Keeper_metrics.(to_string ChatTransportFailures)
       ~labels:[ ("keeper", payload.name); ("source", chat_source) ]
       ();
-    (* RFC-connector-deferred-reply-via-chat-queue §3.4: the failure must be
-       DURABLE on both paths — a post-ACK deferred turn that fails must not
-       vanish on restart/replay (counter + live broadcast alone is silent
-       failure under this feature's "queued, will answer" contract).
-       - Dashboard route ([recorded_upstream = false]): the turn owns the user
-         line, so record the paired [Transport_failure] row (user message stays
-         pending for the next turn; keeper never reads the error as its words).
-       - Connector route ([recorded_upstream = true]): the gate inbound boundary
-         already persisted the user line (assistant-less). The paired
-         [append_turn] would double-record that user line, so persist an
-         assistant-only durable failure marker instead — the failure survives a
-         restart and stays joined to the already-pending user line. *)
+    let content = persisted_error_reply err in
     let persisted =
-      if Option.is_some !direct_delivery_journal
+      if Option.is_some !direct_delivery_checkpoint
       then
         commit_direct_terminal
-          { ok = false
-          ; poll_body = err
-          ; delivery = Keeper_chat_delivery_journal.Transport_failure { content = persisted_error_reply err }
-          }
-      else if connector_user_line_recorded_upstream then
-       Keeper_chat_store.append_assistant_message_result
-         ~base_dir:base_path
-         ~keeper_name:payload.name
-         ~content:(persisted_error_reply err)
-         ~surface:chat_surface
-         ~stream_lifecycle:errored_stream_lifecycle
-         ()
+          ~ok:false
+          ~body:err
+          ~data:None
+          (Keeper_chat_direct_delivery.Transport_failure { content })
+      else if queued_turn
+      then append_queued_transport_failure_once content
       else
-       Keeper_chat_store.append_turn_result
-         ~base_dir:base_path
-         ~keeper_name:payload.name
-         ~user_content:payload.message
-         ~user_attachments:payload.attachments
-         ~surface:chat_surface
-         ~speaker:chat_speaker
-         ~assistant_kind:Keeper_chat_store.Row_kind.Transport_failure
-         ~assistant_content:(persisted_error_reply err)
-         ~stream_lifecycle:errored_stream_lifecycle
-         ()
+        match user_row_origin with
+        | Keeper_chat_store.Needs_append ->
+          Keeper_chat_store.append_turn_result
+            ~base_dir:base_path
+            ~keeper_name:payload.name
+            ~user_content:payload.message
+            ~user_attachments:payload.attachments
+            ~surface:chat_surface
+            ~speaker:chat_speaker
+            ~assistant_kind:Keeper_chat_store.Row_kind.Transport_failure
+            ~assistant_content:content
+            ~stream_lifecycle:errored_stream_lifecycle
+            ()
+        | Keeper_chat_store.Already_persisted _
+        | Keeper_chat_store.Already_persisted_upstream ->
+          Keeper_chat_store.append_assistant_message_result
+            ~base_dir:base_path
+            ~keeper_name:payload.name
+            ~content
+            ~surface:chat_surface
+            ~stream_lifecycle:errored_stream_lifecycle
+            ()
     in
     Result.iter
       (fun () ->
@@ -1973,11 +1967,19 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
               with
               | `Ran result -> Ok (`Ran result)
               | `Busy rejection ->
-                  (match
-                   dashboard_deferred_chat_of_rejection ~clock payload rejection
-                   with
-                   | Ok queued -> Ok (`Queued queued)
-                   | Error message -> Error message)
+                  (match direct_user_row_origin () with
+                   | Error message -> Error message
+                   | Ok user_row_origin ->
+                     (match
+                        dashboard_deferred_chat_of_rejection
+                          ~clock
+                          ~thread_id
+                          ~user_row_origin
+                          payload
+                          rejection
+                      with
+                      | Ok queued -> Ok (`Queued queued)
+                      | Error message -> Error message))
             else
               (match
                  execute_keeper_stream_tool_streaming
@@ -2028,21 +2030,11 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
             in
             let body = Yojson.Safe.to_string data in
             let committed =
-              let ( let* ) = Result.bind in
-              let* receipt_id =
-                Keeper_chat_delivery_identity.Receipt_id.of_string
-                  queued.receipt_id
-              in
               commit_direct_terminal
-                { ok = true
-                ; poll_body = body
-                ; delivery =
-                    Keeper_chat_delivery_journal.No_assistant_reply
-                      { reason =
-                          Keeper_chat_delivery_journal.Queued_for_later
-                            { receipt_id }
-                      }
-                }
+                ~ok:true
+                ~body
+                ~data:(Some data)
+                Keeper_chat_direct_delivery.No_assistant_reply
             in
             (match committed with
              | Ok () ->
@@ -2133,41 +2125,47 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
                  Tool_result.error ~tool_name:"masc_keeper_msg" ~start_time err
              | None ->
                  let persist_assistant_reply ~assistant_content =
-                   if Option.is_some !direct_delivery_journal
+                   if Option.is_some !direct_delivery_checkpoint
                    then
                      commit_direct_terminal
-                       { ok = true
-                       ; poll_body = body
-                       ; delivery =
-                           Keeper_chat_delivery_journal.Assistant_reply
-                             { content = assistant_content
-                             ; blocks
-                             ; turn_ref
-                             }
-                       }
-                   else if connector_user_line_recorded_upstream then
-                     Keeper_chat_store.append_assistant_message_result
-                       ~base_dir:base_path
-                       ~keeper_name:payload.name
+                       ~ok:true
+                       ~body
+                       ~data:payload_json_opt
+                       (Keeper_chat_direct_delivery.Assistant_reply
+                          { content = assistant_content; blocks; turn_ref })
+                   else if queued_turn
+                   then
+                     append_queued_assistant_once
                        ~content:assistant_content
-                       ~surface:chat_surface
                        ?blocks
                        ?turn_ref
-                       ~stream_lifecycle:completed_stream_lifecycle
                        ()
                    else
-                     Keeper_chat_store.append_turn_result
-                       ~base_dir:base_path
-                       ~keeper_name:payload.name
-                       ~user_content:payload.message
-                       ~user_attachments:payload.attachments
-                       ~surface:chat_surface
-                       ~speaker:chat_speaker
-                       ~assistant_content
-                       ?blocks
-                       ?turn_ref
-                       ~stream_lifecycle:completed_stream_lifecycle
-                       ()
+                     match user_row_origin with
+                     | Keeper_chat_store.Needs_append ->
+                       Keeper_chat_store.append_turn_result
+                         ~base_dir:base_path
+                         ~keeper_name:payload.name
+                         ~user_content:payload.message
+                         ~user_attachments:payload.attachments
+                         ~surface:chat_surface
+                         ~speaker:chat_speaker
+                         ~assistant_content
+                         ?blocks
+                         ?turn_ref
+                         ~stream_lifecycle:completed_stream_lifecycle
+                         ()
+                     | Keeper_chat_store.Already_persisted _
+                     | Keeper_chat_store.Already_persisted_upstream ->
+                       Keeper_chat_store.append_assistant_message_result
+                         ~base_dir:base_path
+                         ~keeper_name:payload.name
+                         ~content:assistant_content
+                         ~surface:chat_surface
+                         ?blocks
+                         ?turn_ref
+                         ~stream_lifecycle:completed_stream_lifecycle
+                         ()
                  in
                  let delivered_after_persist ?content persisted =
                    match persisted with
@@ -2209,18 +2207,14 @@ let process_single_turn ~connector_user_line_recorded_upstream ~queued_turn
                                  ; detail = persist_error
                                  }))
                    | Keeper_turn_outcome.Continuation_checkpoint, _ ->
-                       (match !direct_delivery_journal with
+                       (match !direct_delivery_checkpoint with
                         | Some _ ->
                           (match
                              commit_direct_terminal
-                               { ok = true
-                               ; poll_body = body
-                               ; delivery =
-                                   Keeper_chat_delivery_journal.No_assistant_reply
-                                     { reason =
-                                         Keeper_chat_delivery_journal.Continuation_checkpoint
-                                     }
-                               }
+                               ~ok:true
+                               ~body
+                               ~data:payload_json_opt
+                               Keeper_chat_direct_delivery.No_assistant_reply
                            with
                            | Ok () -> None
                            | Error detail ->
@@ -2976,7 +2970,8 @@ let handle_keeper_chat_stream ~sw ~clock ~submitted_by state request reqd payloa
              (* Dashboard stream route: no gate inbound boundary recorded this
                 user line, so the turn owns recording both sides (RFC-connector-deferred-reply-via-chat-queue §3.4). *)
              ignore
-               (process_single_turn ~connector_user_line_recorded_upstream:false
+               (process_single_turn
+                  ~user_row_origin:Keeper_chat_store.Needs_append
                   ~queued_turn:false ~delivery_key:None
                   ~state ~clock
                   ~auth_token:(auth_token_from_request request)
@@ -2989,7 +2984,12 @@ let handle_keeper_chat_stream ~sw ~clock ~submitted_by state request reqd payloa
            if has_external_speaker payload then run_now ()
            else
              match
-               try defer_dashboard_payload_if_busy ~base_path ~clock payload
+               try
+                 defer_dashboard_payload_if_busy
+                   ~base_path
+                   ~clock
+                   ~thread_id
+                   payload
                with
                | Eio.Cancel.Cancelled _ as exn -> raise exn
                | exn -> `Queue_error (Printexc.to_string exn)
@@ -3048,8 +3048,15 @@ module For_testing = struct
   let turn_instructions_for_request = turn_instructions_for_request
   let args_of_request = args_of_request
   let modalities_for_request = modalities_for_request
-  let defer_dashboard_payload_if_busy_evidence ~base_path ~clock payload =
-    match defer_dashboard_payload_if_busy ~base_path ~clock payload with
+  let defer_dashboard_payload_if_busy_evidence
+        ~base_path
+        ~clock
+        ~thread_id
+        payload
+    =
+    match
+      defer_dashboard_payload_if_busy ~base_path ~clock ~thread_id payload
+    with
     | `Not_busy -> `Not_busy
     | `Queued queued ->
         `Queued
@@ -3057,8 +3064,10 @@ module For_testing = struct
           , dashboard_deferred_ack_text ~keeper_name:payload.name queued )
     | `Queue_error message -> `Queue_error message
 
-  let defer_dashboard_payload_if_busy ~base_path ~clock payload =
-    match defer_dashboard_payload_if_busy ~base_path ~clock payload with
+  let defer_dashboard_payload_if_busy ~base_path ~clock ~thread_id payload =
+    match
+      defer_dashboard_payload_if_busy ~base_path ~clock ~thread_id payload
+    with
     | `Not_busy -> `Not_busy
     | `Queued queued -> `Queued queued.pending_count
     | `Queue_error message -> `Queue_error message

--- a/lib/server/server_routes_http_keeper_stream.mli
+++ b/lib/server/server_routes_http_keeper_stream.mli
@@ -178,7 +178,7 @@ type queued_turn_outcome =
 val queued_turn_failure_kind_to_string : queued_turn_failure_kind -> string
 
 val process_single_turn :
-  connector_user_line_recorded_upstream:bool ->
+  user_row_origin:Keeper_chat_store.user_row_origin ->
   queued_turn:bool ->
   delivery_key:Keeper_chat_delivery_identity.delivery_key option ->
   state:Mcp_server.server_state ->
@@ -205,14 +205,11 @@ val process_single_turn :
     cancel the accepted request. [auth_token] is [None] for queue-consumer
     turns where no HTTP request is available.
 
-    [connector_user_line_recorded_upstream] (default [false]) tells the turn
-    that the inbound user line was already persisted by the gate inbound
-    boundary ([Gate_keeper_backend.dispatch_core], RFC-0226 sole-recorder).
-    When [true] the turn records the assistant reply only and never re-writes
-    the user line — set by the queue consumer for connector ([Discord]/[Slack])
-    sources whose busy message was enqueued after the gate already recorded it
-    (RFC-connector-deferred-reply-via-chat-queue §3.4). [false] keeps the dashboard-route behaviour of recording
-    both sides.
+    [user_row_origin] is the durable provenance selected by the accepting
+    boundary. [Needs_append] makes this turn own the user row;
+    [Already_persisted] and [Already_persisted_upstream] prohibit a duplicate
+    append. Queue-consumer turns pass the exact provenance stored with their
+    receipt instead of deriving ownership from a connector label.
 
     [queued_turn] (default [false], set [true] only by
     [Server_bootstrap_loops]'s queue-consumer [handle_turn] wiring) changes
@@ -272,11 +269,13 @@ module For_testing : sig
   val defer_dashboard_payload_if_busy :
     base_path:string ->
     clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
+    thread_id:string ->
     keeper_chat_stream_request ->
     [ `Not_busy | `Queued of int | `Queue_error of string ]
   val defer_dashboard_payload_if_busy_evidence :
     base_path:string ->
     clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
+    thread_id:string ->
     keeper_chat_stream_request ->
     [ `Not_busy
     | `Queued of Yojson.Safe.t * string

--- a/lib/server/server_routes_http_keeper_stream.mli
+++ b/lib/server/server_routes_http_keeper_stream.mli
@@ -289,6 +289,11 @@ module For_testing : sig
     ?has_visible_blocks:bool -> Yojson.Safe.t option -> string -> string option
   val queued_delivery_outcome_of_turn_ref :
     Ids.Turn_ref.t option -> queued_turn_outcome
+  val committed_delivery_outcome :
+    queued_turn:bool ->
+    turn_ref:Ids.Turn_ref.t option ->
+    (unit, string) result ->
+    (queued_turn_outcome option, string) result
   val format_surface_context : Yojson.Safe.t -> string
   val surface_context_to_instructions : Yojson.Safe.t -> string option
   val empty_stream_bridge_state : keeper_stream_bridge_state

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -1674,6 +1674,19 @@ let add_routes ~sw ~clock router =
   (* Keeper POST sub-routes. *)
   |> Http.Router.prefix_post "/api/v1/keepers/" (fun request reqd ->
        match Keeper_api.classify_keeper_post_route (Http.Request.path request) with
+       | Keeper_api.Keeper_post_chat_recovery { keeper_name; receipt_id } ->
+           with_token_permission_auth ~permission:Masc_domain.CanAdmin
+             (fun state agent_name req reqd ->
+               Http.Request.read_body_async reqd (fun body_str ->
+                 Keeper_api.handle_keeper_chat_recovery_post
+                   state
+                   agent_name
+                   req
+                   reqd
+                   ~keeper_name
+                   ~raw_receipt_id:receipt_id
+                   body_str))
+             request reqd
        | Keeper_api.Keeper_post_config ->
            with_token_permission_auth ~permission:Masc_domain.CanAdmin
              (fun state agent_name req reqd ->

--- a/lib/tool/tool_catalog.ml
+++ b/lib/tool/tool_catalog.ml
@@ -249,6 +249,13 @@ let explicit_metadata : (string * metadata) list =
        masc_execute) removed — no dispatch path, no schema, no caller. *)
     ( "masc_operator_action",
       hidden_active "Internal operator-action route; hidden from the public tool surface." );
+    ( "masc_operator_chat_recovery_resolve",
+      with_execution_policy
+        ~readonly:false
+        ~idempotent:false
+        (hidden_active
+           ~allow_direct_call_when_hidden:false
+           "Operator-profile-only exact recovery of one crash-ambiguous Keeper chat receipt.") );
     ( "masc_set_param",
       hidden_active
         "Internal HTTP runtime-parameter mutation route; hidden from the public tool surface." );

--- a/lib/tool/tool_name.ml
+++ b/lib/tool/tool_name.ml
@@ -168,12 +168,14 @@ end
 module Operator_name = struct
   type t =
     | Operator_action
+    | Operator_chat_recovery_resolve
     | Operator_confirm
     | Operator_digest
     | Operator_snapshot
 
   let to_string = function
     | Operator_action -> "masc_operator_action"
+    | Operator_chat_recovery_resolve -> "masc_operator_chat_recovery_resolve"
     | Operator_confirm -> "masc_operator_confirm"
     | Operator_digest -> "masc_operator_digest"
     | Operator_snapshot -> "masc_operator_snapshot"
@@ -181,6 +183,7 @@ module Operator_name = struct
 
   let of_string = function
     | "masc_operator_action" -> Some Operator_action
+    | "masc_operator_chat_recovery_resolve" -> Some Operator_chat_recovery_resolve
     | "masc_operator_confirm" -> Some Operator_confirm
     | "masc_operator_digest" -> Some Operator_digest
     | "masc_operator_snapshot" -> Some Operator_snapshot
@@ -213,6 +216,7 @@ module Operator_remote_name = struct
     [ Operator_tool Operator_name.Operator_snapshot
     ; Operator_tool Operator_name.Operator_digest
     ; Operator_tool Operator_name.Operator_action
+    ; Operator_tool Operator_name.Operator_chat_recovery_resolve
     ; Operator_tool Operator_name.Operator_confirm
     ; Surface_audit
     ]

--- a/lib/tool/tool_name.mli
+++ b/lib/tool/tool_name.mli
@@ -71,6 +71,7 @@ end
 module Operator_name : sig
   type t =
     | Operator_action
+    | Operator_chat_recovery_resolve
     | Operator_confirm
     | Operator_digest
     | Operator_snapshot

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -186,8 +186,7 @@ let test_keeper_chat_receipt_route_and_json () =
     (json |> member "state" |> member "kind" |> to_string);
   check string "receipt JSON revision" "7"
     (match json |> member "revision" with
-     | `Int revision -> string_of_int revision
-     | `Intlit revision -> revision
+     | `String revision -> revision
      | _ -> "invalid");
   check string "receipt JSON failure kind" "delivery_failed"
     (json |> member "state" |> member "failure_kind" |> to_string);
@@ -195,6 +194,20 @@ let test_keeper_chat_receipt_route_and_json () =
     (contains_substring
        (json |> member "state" |> member "detail" |> to_string)
        "sk-proj-abcdefghijklmnopqrstuvwxyz")
+
+let test_keeper_chat_recovery_route_is_exact () =
+  let receipt_id = "chatq_00000000-0000-4000-8000-000000000123" in
+  let path =
+    "/api/v1/keepers/idealist/chat/receipts/" ^ receipt_id ^ "/recovery"
+  in
+  (match Server_dashboard_http_keeper_api.classify_keeper_post_route path with
+   | Server_dashboard_http_keeper_api.Keeper_post_chat_recovery route ->
+       check string "recovery route keeper" "idealist" route.keeper_name;
+       check string "recovery route receipt" receipt_id route.receipt_id
+   | _ -> fail "exact recovery route was not classified");
+  check bool "recovery route rejects extra segments" true
+    (Server_dashboard_http_keeper_api.classify_keeper_post_route (path ^ "/bulk")
+     = Server_dashboard_http_keeper_api.Keeper_post_unknown)
 
 let with_test_env f =
   let dir = test_dir () in
@@ -1860,6 +1873,8 @@ let () =
             test_keeper_post_route_classifies_catchup_judge;
           test_case "keeper chat receipt route is typed" `Quick
             test_keeper_chat_receipt_route_and_json;
+          test_case "keeper chat recovery route is exact" `Quick
+            test_keeper_chat_recovery_route_is_exact;
         ] );
       ( "lifecycle event classification (#22071)",
         [ test_case "event_of_string round-trips to_string" `Quick

--- a/test/test_keeper_busy_dashboard_deferred.ml
+++ b/test/test_keeper_busy_dashboard_deferred.ml
@@ -18,6 +18,7 @@ let check name cond =
 ;;
 
 let keeper_name = "busy-dashboard-keeper"
+let thread_id = "busy-dashboard-thread"
 
 let payload ?(name = keeper_name) ?(content = "are you there?") ()
     : Server_routes_http_keeper_stream.keeper_chat_stream_request =
@@ -111,6 +112,7 @@ let test_busy_dashboard_enqueues () =
      Server_routes_http_keeper_stream.For_testing.defer_dashboard_payload_if_busy
        ~base_path:base
        ~clock
+       ~thread_id
        (payload ())
    with
    | `Queued len -> check "queue length is reported" (len = 1)
@@ -122,10 +124,11 @@ let test_busy_dashboard_enqueues () =
   check "dashboard queue revision advances" (snapshot.revision = 1L);
   (match snapshot.pending with
    | [ { Keeper_chat_queue.message =
-           { Keeper_chat_queue.content; source = Dashboard _; _ }
+           { Keeper_chat_queue.content; source = Dashboard { thread_id = queued_thread_id }; _ }
        ; _
        } ] ->
      check "queued content is the user's message" (String.equal content "are you there?")
+     ; check "queued dashboard thread is exact" (String.equal queued_thread_id thread_id)
    | _ -> check "queue holds one dashboard receipt" false)
 ;;
 
@@ -137,6 +140,7 @@ let test_free_dashboard_not_enqueued () =
      Server_routes_http_keeper_stream.For_testing.defer_dashboard_payload_if_busy
        ~base_path:base
        ~clock
+       ~thread_id
        (payload ~content:"run now" ())
    with
    | `Not_busy -> check "free keeper stays on direct stream path" true
@@ -155,7 +159,7 @@ let test_existing_backlog_defers_new_dashboard_message () =
        ; user_blocks = []
        ; attachments = []
        ; timestamp = Eio.Time.now clock
-       ; source = Dashboard { thread_id = "keeper:" ^ keeper_name }
+       ; source = Dashboard { thread_id }
        ; user_row_origin = Keeper_chat_store.Needs_append
        }
    with
@@ -167,6 +171,7 @@ let test_existing_backlog_defers_new_dashboard_message () =
      Server_routes_http_keeper_stream.For_testing.defer_dashboard_payload_if_busy
        ~base_path:base
        ~clock
+       ~thread_id
        (payload ~content:"newer dashboard message" ())
    with
    | `Queued len -> check "newer message joins existing backlog" (len = 2)
@@ -206,6 +211,7 @@ let test_concurrent_busy_dashboard_enqueues_are_per_keeper () =
         Server_routes_http_keeper_stream.For_testing.defer_dashboard_payload_if_busy
           ~base_path:base
           ~clock
+          ~thread_id:(Printf.sprintf "%s-%d" thread_id i)
           (payload ~name:keeper_name
              ~content:(Printf.sprintf "burst message %d" i)
              ())
@@ -258,11 +264,12 @@ let test_busy_dashboard_persist_failure_is_explicit () =
   @@ fun sw ->
   with_busy_slot ~base ~sw
   @@ fun () ->
-  Keeper_chat_queue.For_testing.fail_next_persist ();
+  Keeper_chat_queue.For_testing.fail_transaction_at_stages [ Mutation_applied ];
   (match
      Server_routes_http_keeper_stream.For_testing.defer_dashboard_payload_if_busy
        ~base_path:base
        ~clock
+       ~thread_id
        (payload ~content:"do not acknowledge this as queued" ())
    with
    | `Queue_error message ->
@@ -304,6 +311,7 @@ let test_shutdown_fenced_dashboard_ack_preserves_cause () =
      Server_routes_http_keeper_stream.For_testing
      .defer_dashboard_payload_if_busy_evidence
        ~base_path:base ~clock
+       ~thread_id
        (payload ~content:"keep this through shutdown" ())
    with
    | `Queued (json, ack) ->

--- a/test/test_keeper_chat_coalescing.ml
+++ b/test/test_keeper_chat_coalescing.ml
@@ -572,17 +572,34 @@ let test_restart_requires_explicit_recovery_without_journal () =
    | Error (Keeper_chat_queue.Recovery_lease_mismatch _) ->
      check "mismatched recovery evidence is rejected" true
    | Ok _ | Error _ -> check "mismatched recovery evidence is rejected" false);
+  let recovery_fields =
+    [ ( "schema"
+      , `String Keeper_chat_recovery_command.tool_command_schema )
+    ; "keeper_name", `String keeper_name
+    ; "receipt_id", `String (receipt_wire receipt.receipt_id)
+    ; "expected_revision", `String "3"
+    ; "lease_id", `String lease.lease_id
+    ; ( "decision"
+      , `Assoc [ "kind", `String "requeue_unconfirmed" ] )
+    ]
+  in
   (match
-     Keeper_chat_queue.resolve_recovery_required
-       ~keeper_name
-       ~receipt_id:receipt.receipt_id
-       ~expected_revision:3L
-       ~lease_id:lease.lease_id
-       ~resolution:Requeue_unconfirmed
+     Keeper_chat_recovery_command.parse_tool_command
+       (`Assoc (("unexpected", `Bool true) :: recovery_fields))
    with
-   | Ok { revision = 4L; state = Pending; _ } ->
-     check "exact operator decision requeues once" true
-   | Ok _ | Error _ -> check "exact operator decision requeues once" false);
+   | Error (Keeper_chat_recovery_command.Unsupported_fields _) ->
+     check "operator command rejects extra fields" true
+   | Ok _ | Error _ -> check "operator command rejects extra fields" false);
+  (match Keeper_chat_recovery_command.parse_tool_command (`Assoc recovery_fields) with
+   | Error error ->
+     fail
+       "typed operator recovery command parses"
+       (Keeper_chat_recovery_command.input_error_to_string error)
+   | Ok command ->
+     (match Keeper_chat_recovery_command.execute ~now:4.0 command with
+      | Ok { revision = 4L; state = Pending; _ } ->
+        check "exact operator decision requeues once" true
+      | Ok _ | Error _ -> check "exact operator decision requeues once" false));
   (match Keeper_chat_queue.lease_next ~keeper_name with
    | `Leased replay ->
      check "explicit requeue preserves receipt identity"

--- a/test/test_keeper_structured_output_schema.ml
+++ b/test/test_keeper_structured_output_schema.ml
@@ -209,7 +209,9 @@ let test_operator_remote_tool_name_ssot_matches_remote_schemas () =
     (list string)
     "operator remote exported names"
     (List.sort String.compare Tool_name.Operator_remote_name.all_strings)
-    (List.sort String.compare Operator_tool.remote_tool_names)
+    (List.sort String.compare Operator_tool.remote_tool_names);
+  check bool "chat recovery cannot bypass operator profile" false
+    (Tool_catalog.allow_direct_call "masc_operator_chat_recovery_resolve")
 ;;
 
 let test_fusion_judge_schema_uses_parser_wire_contract () =

--- a/test/test_keeper_turn_outcome.ml
+++ b/test/test_keeper_turn_outcome.ml
@@ -295,6 +295,22 @@ let test_queued_delivery_requires_exact_turn_ref () =
   | Stream.Failed _ | Stream.Deferred _ ->
     fail "valid turn_ref must produce Delivered"
 
+let test_terminal_commit_error_cannot_become_delivery_success () =
+  let persist_error = "terminal transcript fsync failed" in
+  let check_error label queued_turn =
+    match
+      Stream.For_testing.committed_delivery_outcome
+        ~queued_turn
+        ~turn_ref:None
+        (Error persist_error)
+    with
+    | Error observed -> check string label persist_error observed
+    | Ok None -> fail (label ^ " was downgraded to direct delivery success")
+    | Ok (Some _) -> fail (label ^ " was downgraded to queued delivery success")
+  in
+  check_error "direct commit preserves typed Error" false;
+  check_error "queued commit preserves typed Error" true
+
 let body fields = `Assoc fields
 
 let test_direct_reply_visible_text () =
@@ -352,6 +368,8 @@ let () =
             test_turn_ref_payload_decode;
           test_case "queued delivery requires exact turn_ref" `Quick
             test_queued_delivery_requires_exact_turn_ref;
+          test_case "terminal commit error cannot become delivery success" `Quick
+            test_terminal_commit_error_cannot_become_delivery_success;
         ] );
       ( "direct_reply",
         [

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -745,7 +745,7 @@ let test_handle_request_initialize_operator_profile () =
               | _ -> ""
             in
             Alcotest.(check bool) "mentions operator profile" true
-              (contains_substring instructions "four control-plane tools");
+              (contains_substring instructions "five operator tools plus surface audit");
             Alcotest.(check bool) "mentions confirm workflow" true
               (contains_substring instructions "confirm_required=true")
         | _ -> Alcotest.fail "result not an object")
@@ -784,6 +784,7 @@ let test_handle_request_tools_list_operator_profile () =
                  Alcotest.(check (list string)) "operator-only tools"
                    [
                      "masc_operator_action";
+                     "masc_operator_chat_recovery_resolve";
                      "masc_operator_confirm";
                      "masc_operator_digest";
                      "masc_operator_snapshot";
@@ -1496,6 +1497,7 @@ let test_execute_tool_explicit_agent_name_not_overridden () =
       ~tool_name:"masc_bind" ~arguments ~identity
       ~cached_resolved_agent:(Some ("cached-stale-nickname", false))
       ~auth_token:None ~internal_keeper_runtime:false
+      ~direct_call_authority:Masc.Mcp_server_eio_caller_identity.Catalog_policy
       ~workspace_initialized:(fun () -> false)
       ~log_mcp_exn:(fun ~label:_ _ -> ())
   in
@@ -1536,6 +1538,7 @@ let test_execute_tool_domain_agent_name_does_not_reuse_joined_nickname () =
       ~arguments:(`Assoc [ ("agent_name", `String "alpha-agent") ])
       ~identity ~cached_resolved_agent:None
       ~auth_token:None ~internal_keeper_runtime:false
+      ~direct_call_authority:Masc.Mcp_server_eio_caller_identity.Catalog_policy
       ~workspace_initialized:(fun () -> true)
       ~log_mcp_exn:(fun ~label:_ _ -> ())
   in
@@ -1851,6 +1854,7 @@ let test_execute_tool_http_auth_token_overrides_stale_argument_token () =
       ~identity ~cached_resolved_agent:None
       ~auth_token:(Some "http-auth-token")
       ~internal_keeper_runtime:false
+      ~direct_call_authority:Masc.Mcp_server_eio_caller_identity.Catalog_policy
       ~workspace_initialized:(fun () -> true)
       ~log_mcp_exn:(fun ~label:_ _ -> ())
   in
@@ -1874,6 +1878,7 @@ let test_execute_tool_legacy_argument_token_ignored_without_http_auth () =
       ~arguments:(`Assoc [ ("token", `String "legacy-argument-token") ])
       ~identity ~cached_resolved_agent:None
       ~auth_token:None ~internal_keeper_runtime:false
+      ~direct_call_authority:Masc.Mcp_server_eio_caller_identity.Catalog_policy
       ~workspace_initialized:(fun () -> true)
       ~log_mcp_exn:(fun ~label:_ _ -> ())
   in
@@ -1897,6 +1902,7 @@ let test_execute_tool_without_mcp_session_uses_generated_identity () =
       ~arguments:(`Assoc [ ("message", `String "generated identity check") ])
       ~identity ~cached_resolved_agent:None
       ~auth_token:None ~internal_keeper_runtime:false
+      ~direct_call_authority:Masc.Mcp_server_eio_caller_identity.Catalog_policy
       ~workspace_initialized:(fun () -> true)
       ~log_mcp_exn:(fun ~label:_ _ -> ())
   in

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -428,6 +428,7 @@ let test_retired_front_door_tools_absent_from_schema_inventory () =
       "masc_operator_snapshot";
       "masc_operator_digest";
       "masc_operator_action";
+      "masc_operator_chat_recovery_resolve";
       "masc_operator_confirm";
       "masc_operator_judgment_write";
       "masc_keeper_repair";


### PR DESCRIPTION
## Summary

Follow-up to merged #24385.

- route direct dashboard delivery through the merged durable checkpoint contract and keep queued receipts as the sole queue lifecycle authority
- preserve typed user-row provenance across direct-to-queued races; no content inference or compatibility journal
- expose O(1) lane health and explicit recovery-required counts without materializing queue snapshots on the busy hot path
- add exact admin HTTP + operator MCP recovery commands keyed by receipt_id, canonical revision, and lease_id
- make canonical decimal revision strings the dashboard wire SSOT and add single-receipt requeue/cancel controls
- keep operator recovery out of generic CanBroadcast: /mcp/operator requires CanAdmin and the hidden tool cannot bypass its restricted profile
- preserve terminal transcript commit failures as typed Error for direct and queued turns; an Error cannot enter the Stream_done or successful Tool_result arm
- keep execution budgets observational; this change adds no turn/cost/token stopping policy

## Failure semantics

- crash-ambiguous delivery remains non-dispatchable until an explicit operator decision
- no automatic redelivery, substring inference, fallback journal, or silent persistence downgrade
- audit persistence failure is returned explicitly without disguising an already committed queue mutation
- one Keeper recovery lane does not block unrelated Keeper lanes

## Validation

- dashboard TypeScript typecheck: pass
- focused dashboard tests: 345 pass
- focused direct/queued terminal commit Error regression: added
- changed OCaml source/interface/test parsing: pass with OCaml 5.4.1 and 5.5.0
- ocamlformat check, diff check, comment-terminator guard, and execute-async surface guard: pass
- focused local Dune target build was not started because another worktree held the shared repo build lock; no parallel full build was forced
- full Dune remains PR CI authority; checks are running on the exact PR head
