### PR TITLE
fix(keeper): stamp session_id on OAS per-turn checkpoints

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -671,9 +671,22 @@ let run_turn
               in
               let checkpoint_sink (snapshot : Agent_sdk.Agent.checkpoint_snapshot) =
                 Option.iter (fun observe -> observe snapshot.stage) on_checkpoint_stage;
+                (* OAS's per-turn pipeline builds checkpoints with an empty
+                   session_id (the OAS agent carries no session field), so the
+                   sink must stamp the keeper's own session identity before
+                   persisting. [meta.runtime.trace_id] is a validated,
+                   non-empty [Trace_id.t]; without this restamp the OAS
+                   checkpoint store rejects the write with "session_id must not
+                   be empty" and every keeper turn dies. *)
+                let checkpoint =
+                  { snapshot.checkpoint with
+                    session_id =
+                      Keeper_id.Trace_id.to_string meta.runtime.trace_id
+                  }
+                in
                 Keeper_checkpoint_store.save_oas
                   ~session_dir:session.session_dir
-                  snapshot.checkpoint
+                  checkpoint
               in
               let call_run_named ?raw_trace ~initial_messages () =
                 (* Keeper does not impose a cumulative turn, time, token, or cost

--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -142,6 +142,15 @@ let delete_oas_history_files ~(session_dir : string) ~(snapshot_ids : string lis
    below) wraps this with the RFC-0225 §3.2 stale-write guard. *)
 let save_oas_unguarded ~(session_dir : string) (ckpt : Agent_sdk.Checkpoint.t)
   : (unit, string) result =
+  if String.length ckpt.session_id = 0 then
+    (* Fail loud at the persistence boundary: a checkpoint with an empty
+       session_id is unpersistable. The primary Eio path already rejects it
+       ([Checkpoint_store.save] validates session_id), but the non-Eio
+       [fallback] below would otherwise silently write "<session_dir>/.json"
+       and drop the checkpoint. Callers must stamp a validated, non-empty
+       session_id (the keeper trace_id) before persisting. *)
+    Error "save_oas: refusing checkpoint with empty session_id"
+  else
   let fallback () =
     match Keeper_fs.save_atomic
       (oas_checkpoint_path ~session_dir ~session_id:ckpt.session_id)

--- a/test/test_keeper_checkpoint_stale_guard.ml
+++ b/test/test_keeper_checkpoint_stale_guard.ml
@@ -133,6 +133,44 @@ let test_cold_start_backfills_from_disk () =
     save_ok ~session_dir (make_checkpoint ~session_id:sid ~turn_count:9 ~marker:"v9")
       "forward save after cold start")
 
+let string_contains ~needle haystack =
+  let nlen = String.length needle and hlen = String.length haystack in
+  let rec at i = i + nlen <= hlen && (String.sub haystack i nlen = needle || at (i + 1)) in
+  nlen = 0 || at 0
+
+(* The OAS per-turn pipeline builds checkpoints with an empty session_id (the
+   OAS agent carries no session field). The keeper sink stamps a validated,
+   non-empty trace_id before persisting; [save_oas] fails loud on an empty
+   session_id rather than letting the non-Eio fallback silently write
+   "<session_dir>/.json" and drop the checkpoint. *)
+let test_empty_session_id_rejected () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun _sw ->
+  Keeper_checkpoint_store.For_testing.reset_stale_write_guard ();
+  let session_dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir session_dir) (fun () ->
+    (match
+       Keeper_checkpoint_store.save_oas ~session_dir
+         (make_checkpoint ~session_id:"" ~turn_count:1 ~marker:"empty")
+     with
+     | Ok () -> fail "save_oas accepted an empty session_id"
+     | Error msg ->
+       check bool "error names the empty session_id" true
+         (string_contains ~needle:"empty session_id" msg));
+    (* The silent non-Eio fallback would have written "<session_dir>/.json". *)
+    check bool "no orphan .json written for empty session_id" false
+      (Sys.file_exists (Filename.concat session_dir ".json"));
+    (* A stamped, non-empty session_id persists and round-trips. *)
+    save_ok ~session_dir
+      (make_checkpoint ~session_id:"trace-1-0000a" ~turn_count:1 ~marker:"stamped")
+      "stamped save";
+    match Keeper_checkpoint_store.load_oas ~session_dir ~session_id:"trace-1-0000a" with
+    | Ok on_disk ->
+      check string "round-trips the stamped session_id" "trace-1-0000a"
+        on_disk.Agent_sdk.Checkpoint.session_id
+    | Error _ -> fail "load after stamped save failed")
+
 let () =
   run "Keeper_checkpoint_store checkpoint watermark (RFC-0225 §3.2)"
     [
@@ -142,5 +180,7 @@ let () =
             test_forward_equal_and_stale;
           test_case "cold start backfills last turn_count from disk" `Quick
             test_cold_start_backfills_from_disk;
+          test_case "empty session_id is refused, not silently dropped" `Quick
+            test_empty_session_id_rejected;
         ] );
     ]


### PR DESCRIPTION
## 문제

모든 keeper 턴이 `checkpoint sink failed at after_assistant_collected: session_id must not be empty`로 사망. keeper fleet 전체가 매 턴 죽는 최심각 회귀.

## Root cause (배선 버그 — 레거시 데이터 아님)

- OAS SDK의 자동 per-turn checkpoint sink는 `session_id = ""`로 checkpoint를 만든다: `agent_sdk/pipeline/pipeline.ml`이 `Agent_checkpoint.build_checkpoint`를 `~session_id` 없이 호출하고, 그 인자 default가 `""`.
- masc의 sink(`keeper_agent_run.ml`)는 이 checkpoint를 **restamp 없이** `save_oas`로 저장한다.
- masc가 `Keeper_turn_driver.run_named ~session_id:(trace_id)`로 넘긴 값은 OAS agent에 threading되지 않는다 — OAS `agent_config`에는 session_id 필드가 없다. 그 값은 masc 자체 persist 경로(`runtime_oas_checkpoint`)와 로깅에서만 쓰인다.
- 결과: 빈 `session_id`가 OAS `checkpoint_store.save`의 `validate_session_id`(empty reject, #31부터의 계약)에 걸려 매 턴 실패.

`meta.runtime.trace_id`는 비어있지 않다(`Keeper_id.Trace_id.t = private string`, `of_string`이 empty를 거부하는 sealed 타입). 원인은 trace_id가 아니라 sink가 OAS의 빈 session_id를 그대로 흘린 것.

## 변경

1. **`keeper_agent_run.ml` sink**: persist 전 checkpoint의 session_id를 keeper의 검증된 `trace_id`로 restamp — `{ snapshot.checkpoint with session_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id }`.
2. **`keeper_checkpoint_store.ml` `save_oas_unguarded`**: 빈 `session_id`를 **fail-loud reject**. 기존엔 primary Eio 경로만 거부하고, 비-Eio fallback은 `<session_dir>/.json`을 조용히 써서 checkpoint를 유실했다. 이제 persistence 경계에서 빈 session_id를 표현 불가능하게 만든다.
3. **test**: 빈 session_id는 거부되고 orphan `.json`이 생기지 않음 + stamp된 session_id는 저장·round-trip.

## 검증 상태 (미완 — 정직 고지)

- **로컬 컴파일/테스트 검증 불가**: 현 masc main이 pre-existing RED(`Build and Test` 다수 커밋 연속 failure — `Unbound Agent_sdk.Types.unbounded_max_turns` 등 execution-limits API drift)라 이 브랜치도 base가 안 빌드된다. 이 실패들은 **본 변경과 무관**하며 진행 중인 cross-repo 리팩터의 중간상태다.
- 변경 자체는 타입 검토로 확인: `Agent_sdk.Checkpoint.t.session_id : string`(공개 record)이라 restamp 유효, `save_oas_unguarded` guard는 `(unit,string) result` 유지.
- **guard 안전성 = call-site 전수 감사**: `save_oas`의 다른 호출처(`keeper_context_core.save_oas_checkpoint`)는 `session_id = session.session_id`를 stamp하고, `create_session`의 모든 호출처(`keeper_post_turn`/`keeper_turn_up_create`/`keeper_tool_surface_ops`/`keeper_heartbeat_loop_presence`)가 `~session_id`를 trace_id 유래(`Trace_id.to_string ... trace_id`, sealed non-empty)로 넘긴다. 따라서 guard는 정상 경로를 거부하지 않고, OAS sink의 default `""`만 잡는다. 관측 에러가 `after_assistant_collected`(sink 단계)에만 나고 명시적 persist 경로엔 없었던 것과 일치.
- 추가한 `test_empty_session_id_rejected`는 **main green 복구 후 CI에서 실행·검증** 예정. 그 전까지 Draft 유지.

## 범위 밖 (follow-up)

- 이 회귀와 함께 발생한 on-disk 스키마 skew(goal_store `verifier_policy`, event-queue escalation 라벨, candidate ledger 필드)는 **런타임 데이터**이며 별도 운영 마이그레이션으로 처리한다(repo 변경 아님).

RFC-WAIVED: keeper 턴 실행/trace_id 경로는 credential/identity/operator-control/keeper-sandbox/hooks/workflow 게이트 대상 아님.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
