### PR TITLE
fix(guards): retarget Execute surface guard to the argv-SSOT contract

### DIFF
--- a/lib/tool_surface/tool_shard_types_schemas_execute.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_execute.ml
@@ -4,7 +4,11 @@
     The public descriptor exposes one command SSOT: a non-empty [argv] process
     vector for a single process, or [pipeline] containing non-empty [argv]
     vectors for explicit Shell IR pipelines. Raw [cmd] strings and the retired
-    duplicate [executable] field are intentionally absent from the schema. *)
+    duplicate [executable] field are intentionally absent from the schema.
+
+    Accepted fields: argv, pipeline, env, cwd, timeout_sec, stdin, stdout,
+    stderr. This sentence is the contract line checked by
+    scripts/check-execute-async-surface.sh — update both together. *)
 
 let tool_execute_exec_stage_schema =
   `Assoc

--- a/scripts/check-execute-async-surface.sh
+++ b/scripts/check-execute-async-surface.sh
@@ -54,13 +54,13 @@ require_normalized_text \
   "It does not expose \`job_id\`, \`request_id\`, \`poll\`, or \`cancel\` fields." \
   "async lifecycle field exclusion in Execute runbook"
 
-require_text \
+require_normalized_text \
   "lib/tool_surface/tool_shard_types_schemas_execute.ml" \
-  "Accepted fields: executable, argv, pipeline, env, cwd, timeout_sec, stdin, stdout, stderr." \
+  "Accepted fields: argv, pipeline, env, cwd, timeout_sec, stdin, stdout, stderr." \
   "typed Execute accepted-field list"
 require_normalized_text \
   "lib/tool_surface/tool_shard_types_schemas_execute.ml" \
-  "this tool no longer \\ exposes background task lifecycle tools" \
+  "this tool does not expose background task lifecycle tools" \
   "typed Execute background lifecycle exclusion"
 reject_text \
   "lib/tool_surface/tool_shard_types_schemas_execute.ml" \


### PR DESCRIPTION
## 무엇을

main Meta Guards RED(층 3, #24391) 복구 — `check-execute-async-surface.sh`의 needle 2개를 #24384가 바꾼 실제 계약에 재조준하고, 스키마 파일 doc comment에 canonical accepted-field 문장을 넣어 쌍이 함께 움직이게 했습니다.

## 왜

#24384(`214eec8f6c`)가 `executable` 필드를 argv 단일 SSOT로 제거하고 lifecycle 문구를 개서("no longer exposes" → "does not expose")하면서 guard를 갱신하지 않아, 이후 모든 push에서 Meta Guards가 실패합니다.

- accepted-field needle: `executable` 제거 + 줄바꿈에 강건하도록 `require_normalized_text`로 전환 (기존 `require_text`는 grep -F 라인 단위라 문장이 두 줄에 걸치면 매치 불가)
- lifecycle needle: 현재 문구로 갱신
- 스키마 doc comment: canonical 문장 + guard 상호참조 명시

## 검증

- `bash scripts/check-execute-async-surface.sh` → PASS (require/reject 나머지 needle 전부 통과 확인)

## 관련

- masc#24391 (main RED 3층 umbrella) — 층 3
- 층 1은 #24389, 층 2는 별도 PR 예정

RFC-WAIVED: guard 스크립트를 이미 머지된 #24384의 계약에 정렬하는 후속 수정, 새 설계 없음.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
