### PR TITLE
fix(build): restore main compile — masc-side turn sentinel + #24385 stragglers

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -144,7 +144,7 @@ let raw_trace_for_dispatch
     None
 ;;
 
-let keeper_max_turns = Agent_sdk.Types.unbounded_max_turns
+let keeper_max_turns = Runtime_agent_context.unbounded_max_turns
 
 module For_testing = struct
   let sse_event_progress_kind = Turn_helpers.sse_event_progress_kind

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -321,7 +321,7 @@ let run_named
     ?(system_prompt = "")
     ?(tools = [])
     ?(initial_messages = [])
-    ?(max_turns = Agent_sdk.Types.unbounded_max_turns)
+    ?(max_turns = Runtime_agent_context.unbounded_max_turns)
     ~max_idle_turns
     ?stream_idle_timeout_s
     ?body_timeout_s

--- a/lib/runtime/runtime_agent_context.ml
+++ b/lib/runtime/runtime_agent_context.ml
@@ -5,7 +5,15 @@
     [Runtime_agent] remains the public facade and still performs the
     approval wiring and final [build_safe] / [Agent.resume] calls. *)
 
-let default_max_turns = Agent_sdk.Types.unbounded_max_turns
+(* [0] is the pinned SDK's documented unbounded sentinel (agent_sdk
+   lib/base/types.mli: "[0] = no turn-count limit; positive values enforce
+   a finite limit") and is what [Agent_sdk.Types.has_finite_max_turns]
+   tests against. The SDK exports the predicate but no named constant
+   (a name only exists in the unmerged oas#2589), so masc owns the name
+   here. If an oas release ships a named sentinel, replace this value
+   with that re-export (masc#24391 layer 2). *)
+let unbounded_max_turns = 0
+let default_max_turns = unbounded_max_turns
 
 type stop_reason =
   | Completed
@@ -463,7 +471,7 @@ let prepare_resume ~(config : config) ~(checkpoint : Agent_sdk.Checkpoint.t)
   let max_turns_for_resume =
     if Agent_sdk.Types.has_finite_max_turns config.max_turns
     then checkpoint.turn_count + config.max_turns
-    else Agent_sdk.Types.unbounded_max_turns
+    else unbounded_max_turns
   in
   let patched_checkpoint =
     { checkpoint with

--- a/lib/runtime/runtime_agent_context.mli
+++ b/lib/runtime/runtime_agent_context.mli
@@ -136,6 +136,13 @@ type config = {
 
 (** {1 Default config builder} *)
 
+val unbounded_max_turns : int
+(** The pinned SDK's documented "no turn-count limit" sentinel ([0],
+    agent_sdk lib/base/types.mli); the value
+    {!Agent_sdk.Types.has_finite_max_turns} tests against. The SDK
+    exports the predicate but no named constant, so masc names it here
+    (masc#24391 layer 2). *)
+
 val default_config :
   name:string ->
   provider_cfg:Llm_provider.Provider_config.t ->
@@ -185,6 +192,6 @@ val prepare_resume :
 (** [prepare_resume ~config ~checkpoint] computes the patched
     checkpoint + agent_config + options for an
     [Agent.resume] call.  Pure — no side effects.  The patched
-    agent config preserves {!Agent_sdk.Types.unbounded_max_turns}; otherwise it
+    agent config preserves {!unbounded_max_turns}; otherwise it
     extends [config.max_turns] beyond the consumed [checkpoint.turn_count] for
     generic finite OAS clients. Keeper callers use the unbounded sentinel. *)

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -265,7 +265,13 @@ let enqueue_dashboard_payload
       ; user_blocks = payload.user_blocks
       ; attachments = payload.attachments
       ; timestamp = Eio.Time.now clock
-      ; source = Keeper_chat_queue.Dashboard
+        (* Same dashboard SSE thread convention as run_keeper_stream below;
+           the continuation channel resumes the deferred turn on this
+           thread. The payload is fresh HTTP input, so the user transcript
+           row is appended at delivery (Needs_append), never skipped. *)
+      ; source =
+          Keeper_chat_queue.Dashboard { thread_id = "keeper:" ^ payload.name }
+      ; user_row_origin = Keeper_chat_store.Needs_append
       }
   with
   | Error error -> Error (Keeper_chat_queue.mutation_error_to_string error)

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -433,7 +433,7 @@ and resume_worker_via_oas
       ?selection_note:meta.selection_note
       ()
   in
-  let max_turns = Agent_sdk.Types.unbounded_max_turns in
+  let max_turns = Runtime_agent_context.unbounded_max_turns in
   let thinking_enabled = Option.value ~default:false meta.thinking_enabled in
   let config, options =
     Worker_container.build_resume_config

--- a/test/test_keeper_busy_dashboard_deferred.ml
+++ b/test/test_keeper_busy_dashboard_deferred.ml
@@ -122,7 +122,7 @@ let test_busy_dashboard_enqueues () =
   check "dashboard queue revision advances" (snapshot.revision = 1L);
   (match snapshot.pending with
    | [ { Keeper_chat_queue.message =
-           { Keeper_chat_queue.content; source = Dashboard; _ }
+           { Keeper_chat_queue.content; source = Dashboard _; _ }
        ; _
        } ] ->
      check "queued content is the user's message" (String.equal content "are you there?")
@@ -155,7 +155,8 @@ let test_existing_backlog_defers_new_dashboard_message () =
        ; user_blocks = []
        ; attachments = []
        ; timestamp = Eio.Time.now clock
-       ; source = Dashboard
+       ; source = Dashboard { thread_id = "keeper:" ^ keeper_name }
+       ; user_row_origin = Keeper_chat_store.Needs_append
        }
    with
    | Ok receipt ->

--- a/test/test_keeper_chat_direct_delivery.ml
+++ b/test/test_keeper_chat_direct_delivery.ml
@@ -91,7 +91,7 @@ type flow =
   ; transcript_committed : Direct.t
   }
 
-let complete_flow ?(time_offset = 0.0) ~base_path ~request_id =
+let complete_flow ?(time_offset = 0.0) ~base_path ~request_id () =
   let at value = time_offset +. value in
   let prepared =
     Direct.prepare ~base_path ~request_id ~payload:(payload ()) ~now:(at 1.0)
@@ -126,7 +126,7 @@ let complete_flow ?(time_offset = 0.0) ~base_path ~request_id =
 let test_direct_flow_is_active_only _env =
   with_temp_dir (fun base_path ->
     let request_id = request_id "direct-flow" in
-    let flow = complete_flow ~base_path ~request_id in
+    let flow = complete_flow ~base_path ~request_id () in
     check int64 "five active phases produce four revisions" 4L flow.transcript_committed.revision;
     let loaded =
       Direct.load ~base_path ~keeper_name:"sangsu" ~request_id |> expect_ok
@@ -149,6 +149,7 @@ let fail_after_rename_io () =
       | Keeper_fs.Parent_directory_fsync_after_rename ->
         failwith "synthetic post-rename fsync failure"
       | Keeper_fs.Directory_prepare
+      | Keeper_fs.Payload_encode
       | Keeper_fs.Temp_file_create
       | Keeper_fs.Payload_write
       | Keeper_fs.Payload_fsync
@@ -226,6 +227,7 @@ let test_transcript_append_crash_retries_once _env =
         ~before_durable_write:(function
           | Keeper_fs.Payload_write -> failwith "synthetic checkpoint write crash"
           | Keeper_fs.Directory_prepare
+          | Keeper_fs.Payload_encode
           | Keeper_fs.Temp_file_create
           | Keeper_fs.Payload_fsync
           | Keeper_fs.Temp_file_close
@@ -452,7 +454,7 @@ let test_remove_requires_canonical_terminal_proof_and_reports_ambiguity _env =
   with_temp_dir (fun base_path ->
     Eio.Switch.run (fun background_sw ->
       let request_id = request_id "direct-remove-proof" in
-      let flow = complete_flow ~base_path ~request_id in
+      let flow = complete_flow ~base_path ~request_id () in
       let ops =
         Keeper_msg_async.For_testing.make_request_ops
           ~generate_request_id:(fun () -> Direct.Request_id.to_string request_id)
@@ -494,7 +496,7 @@ let test_remove_requires_canonical_terminal_proof_and_reports_ambiguity _env =
        | Error error -> fail (Direct.error_to_string error)
        | Ok _ -> fail "active checkpoint survived an observed unlink");
       let replacement =
-        complete_flow ~time_offset:10.0 ~base_path ~request_id
+        complete_flow ~time_offset:10.0 ~base_path ~request_id ()
       in
       (match
          Direct.remove_after_async_terminal
@@ -520,7 +522,7 @@ let test_startup_checkpoint_rejects_volatile_poll_terminal _env =
   with_temp_dir (fun base_path ->
     Eio.Switch.run (fun background_sw ->
       let request_id = request_id "direct-volatile-terminal" in
-      let flow = complete_flow ~base_path ~request_id in
+      let flow = complete_flow ~base_path ~request_id () in
       let publications = Atomic.make 0 in
       let ops =
         Keeper_msg_async.For_testing.make_request_ops
@@ -532,6 +534,7 @@ let test_startup_checkpoint_rejects_volatile_poll_terminal _env =
               if ordinal = 3
               then failwith "synthetic terminal publication ambiguity"
             | Keeper_fs.Directory_prepare
+            | Keeper_fs.Payload_encode
             | Keeper_fs.Temp_file_create
             | Keeper_fs.Payload_write
             | Keeper_fs.Payload_fsync
@@ -578,7 +581,7 @@ let test_corrupt_canonical_terminal_is_typed_and_preserved _env =
   with_temp_dir (fun base_path ->
     Eio.Switch.run (fun background_sw ->
       let request_id = request_id "direct-corrupt-terminal" in
-      let flow = complete_flow ~base_path ~request_id in
+      let flow = complete_flow ~base_path ~request_id () in
       let request_id_wire = Direct.Request_id.to_string request_id in
       let ops =
         Keeper_msg_async.For_testing.make_request_ops

--- a/test/test_keeper_execution_receipt_observation_wire.ml
+++ b/test/test_keeper_execution_receipt_observation_wire.ml
@@ -99,20 +99,20 @@ let () =
           { elapsed_sec = 300.0
           ; timeout_sec = 300.0
           ; turn_count = 7
-          ; max_turns = Agent_sdk.Types.unbounded_max_turns
+          ; max_turns = Runtime_agent_context.unbounded_max_turns
           }
       , Printf.sprintf
           "execution_timeout_observed:elapsed_sec=300.0,timeout_sec=300.0,turn_count=7,max_turns=%d"
-          Agent_sdk.Types.unbounded_max_turns )
+          Runtime_agent_context.unbounded_max_turns )
     ; ( Runtime_agent.ExecutionIdleTimeoutObserved
           { idle_sec = 120.0
           ; idle_timeout_sec = 120.0
           ; turn_count = 7
-          ; max_turns = Agent_sdk.Types.unbounded_max_turns
+          ; max_turns = Runtime_agent_context.unbounded_max_turns
           }
       , Printf.sprintf
           "execution_idle_timeout_observed:idle_sec=120.0,idle_timeout_sec=120.0,turn_count=7,max_turns=%d"
-          Agent_sdk.Types.unbounded_max_turns )
+          Runtime_agent_context.unbounded_max_turns )
     ]
   in
   List.iter

--- a/test/test_keeper_replay_checkpoint.ml
+++ b/test/test_keeper_replay_checkpoint.ml
@@ -373,13 +373,13 @@ let test_execution_observations_preserve_tool_replay_suffix () =
         { elapsed_sec = 300.0
         ; timeout_sec = 300.0
         ; turn_count = 4
-        ; max_turns = Agent_sdk.Types.unbounded_max_turns
+        ; max_turns = Runtime_agent_context.unbounded_max_turns
         }
     ; Runtime_agent.ExecutionIdleTimeoutObserved
         { idle_sec = 120.0
         ; idle_timeout_sec = 120.0
         ; turn_count = 4
-        ; max_turns = Agent_sdk.Types.unbounded_max_turns
+        ; max_turns = Runtime_agent_context.unbounded_max_turns
         }
     ]
   in

--- a/test/test_keeper_turn_outcome.ml
+++ b/test/test_keeper_turn_outcome.ml
@@ -60,7 +60,7 @@ let test_of_stop_reason () =
           { elapsed_sec = 300.0
           ; timeout_sec = 300.0
           ; turn_count = 3
-          ; max_turns = Agent_sdk.Types.unbounded_max_turns
+          ; max_turns = Runtime_agent_context.unbounded_max_turns
           }));
   check outcome "idle timeout observation -> no visible reply"
     TO.No_visible_reply
@@ -69,7 +69,7 @@ let test_of_stop_reason () =
           { idle_sec = 120.0
           ; idle_timeout_sec = 120.0
           ; turn_count = 3
-          ; max_turns = Agent_sdk.Types.unbounded_max_turns
+          ; max_turns = Runtime_agent_context.unbounded_max_turns
           }));
   check outcome "chat yield -> checkpoint" TO.Continuation_checkpoint
     (TO.of_stop_reason
@@ -101,7 +101,7 @@ let test_of_result_surface () =
           { elapsed_sec = 300.0
           ; timeout_sec = 300.0
           ; turn_count = 3
-          ; max_turns = Agent_sdk.Types.unbounded_max_turns
+          ; max_turns = Runtime_agent_context.unbounded_max_turns
           }));
   check outcome "idle timeout observation -> no visible reply"
     TO.No_visible_reply
@@ -110,7 +110,7 @@ let test_of_result_surface () =
           { idle_sec = 120.0
           ; idle_timeout_sec = 120.0
           ; turn_count = 3
-          ; max_turns = Agent_sdk.Types.unbounded_max_turns
+          ; max_turns = Runtime_agent_context.unbounded_max_turns
           }))
 
 let test_autonomous_yield_boundary_contract () =

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -1122,7 +1122,7 @@ let test_runtime_agent_execution_limits_are_observations () =
                { elapsed_sec = 300.0
                ; timeout_sec = 300.0
                ; turn_count = 4
-               ; max_turns = Agent_sdk.Types.unbounded_max_turns
+               ; max_turns = Runtime_agent_context.unbounded_max_turns
                })))
   in
   check string "execution timeout event" "completed" execution_timeout.event;
@@ -1139,7 +1139,7 @@ let test_runtime_agent_execution_limits_are_observations () =
                { idle_sec = 120.0
                ; idle_timeout_sec = 120.0
                ; turn_count = 4
-               ; max_turns = Agent_sdk.Types.unbounded_max_turns
+               ; max_turns = Runtime_agent_context.unbounded_max_turns
                })))
   in
   check string "idle timeout event" "completed" idle_timeout.event;
@@ -1362,7 +1362,7 @@ let test_runtime_agent_context_preserves_unbounded_resume_budget () =
       ~system_prompt:""
       ~tools:[]
   in
-  let config = { config with max_turns = Agent_sdk.Types.unbounded_max_turns } in
+  let config = { config with max_turns = Runtime_agent_context.unbounded_max_turns } in
   let checkpoint =
     { Agent_sdk.Checkpoint.version = Agent_sdk.Checkpoint.checkpoint_version
     ; session_id = "session"


### PR DESCRIPTION
## 무엇을

main 컴파일 복구 (masc#24391 층 2+4). #24386 머지 이후 main은 `dune build` 자체가 불가능한 상태입니다.

### 층 2 — 존재하지 않는 oas API 참조 (#24386 귀책)

`Agent_sdk.Types.unbounded_max_turns`는 **어떤 배포된 oas에도 없습니다** (pin v0.211.9 @ 902c45d2, oas main, 전 릴리즈). 출처는 미머지 **oas#2589**인데, 라이벌 #2590이 이미 oas main에 착지해 이 API가 그 형태로 도착할 가능성은 낮습니다.

실측 근거 (pin 소스 = opam 5.5.0 switch @ 902c45d2):
- `lib/base/types.mli:41` — `(** [0] = no turn-count limit; positive values enforce a finite limit. *)` → **0-sentinel은 pin의 문서화된 계약**
- `lib/base/types.mli:85` — `val has_finite_max_turns : int -> bool` → **predicate는 pin에 이미 export됨** (미싱은 이름 상수뿐)

수정: `Runtime_agent_context.unbounded_max_turns = 0`을 masc-side SSOT로 정의(.mli export + 계약 주석), 19참조/9파일 rewire (codemod). oas가 이름 상수를 릴리즈하면 re-export로 교체 (removal 조건 주석 명시).

### 층 4 — #24385 마이그레이션 잔여 (red main 위 머지라 CI 미포착)

`Dashboard { thread_id }` + `user_row_origin` 추가가 writer 1곳 + 테스트 3곳을 미스:
- `server_routes_http_keeper_stream.ml` enqueue → `Dashboard { thread_id = "keeper:" ^ name }` (같은 파일 SSE thread 관례) + `user_row_origin = Needs_append` (fresh HTTP payload — Already_persisted*로 두면 사용자 메시지가 transcript에서 조용히 소실되는 방향의 오류라 fail-safe 선택)
- `test_keeper_busy_dashboard_deferred.ml` 생성자/패턴 arity 2곳
- `test_keeper_chat_direct_delivery.ml` — `complete_flow`의 unerasable optional(warning 16)에 unit 인자, exhaustive `Keeper_fs` stage match 3곳에 신규 `Payload_encode` arm (catch-all 없이 명시 — FSM sparse match 금지 규칙 준수)

## 검증

- 로컬 `dune build --root .`가 기존 에러 클래스 전부 통과 진행 — 단, 마지막 실행 중 병렬 세션의 opam agent_sdk **0.211.10 설치로 switch가 선언 pin에서 drift**하여 (17:48 KST 실측) 이후 로컬 결과는 오염됨. **판정은 pin 기반 CI가 정본**.
- switch drift는 별도 broadcast로 공지.

## 부수 발견 (범위 밖, 기록)

- `"keeper:" ^ name` 리터럴 lib/ 6곳 산포, SSOT 헬퍼 부재 — 별도 정리 대상.

Related: masc#24391, oas#2589/#2590.

RFC-WAIVED: 이미 머지된 #24386/#24385의 컴파일 계약 위반을 pin의 문서화된 기존 계약으로 정렬하는 복구 PR, 신규 설계 없음.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
