### PR TITLE
refactor(keeper): keep event bus observational

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -640,11 +640,6 @@ let run_keeper_cycle
                         (turn_event_bus_manifest_decision turn_event_bus))
                    Keeper_runtime_manifest.Event_bus_correlated
                in
-               let run_result =
-                 match event_bus_integrity_error_snapshot () with
-                 | Some integrity_err -> Error integrity_err
-                 | None -> run_result
-               in
                let degraded_retry_info = turn_state.degraded_retry_info in
                let degraded_retry_applied = Option.is_some degraded_retry_info in
                let degraded_retry_runtime =

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -113,8 +113,8 @@ let run (ctx : ctx)
       ; cleanup
       ; drain_turn_event_bus
       ; event_bus
-      ; event_bus_integrity_error_snapshot
-      ; tool_completed_count_snapshot
+      ; event_bus_integrity_error_snapshot = _
+      ; tool_completed_count_snapshot = _
       ; attempt = _attempt
       } =
     ctx
@@ -122,6 +122,16 @@ let run (ctx : ctx)
   (match Eio_context.get_clock () with
    | Error msg -> Error (Agent_sdk.Error.Internal msg), turn_state
    | Ok clock ->
+   (* Same-run retry authority comes from OAS's typed checkpoint boundary.
+      OAS invokes the sink only after mutating the agent state at a declared
+      checkpoint stage, and MASC marks the stage before delegating persistence.
+      Therefore a sink failure also closes replay authority: the attempt may
+      already contain effects even when the durable write failed. A lossy
+      Event_bus observation must never reopen or close this boundary.
+
+      [test_keeper_turn_driver_failover] proves both directions: transport
+      failure before any stage may fall back, while every typed stage blocks a
+      same-run fallback. *)
    let checkpoint_stage_observed = Atomic.make false in
   let do_run
         ~(execution : runtime_execution)
@@ -325,30 +335,20 @@ let run (ctx : ctx)
         meta.name;
       Ok result, turn_state
     | Error err ->
-      let _ = drain_turn_event_bus ~site:"reconcile_pre_check" () in
-      let err =
-        match event_bus_integrity_error_snapshot () with
-        | Some integrity_err -> integrity_err
-        | None -> err
-      in
-      let tool_completed_count = tool_completed_count_snapshot () in
       let checkpoint_observed =
         not
           (Keeper_turn_driver_try_provider.same_run_retry_allowed
              checkpoint_stage_observed)
       in
-      let same_run_retry_has_input_authority =
-        tool_completed_count = 0 && not checkpoint_observed
-      in
+      let same_run_retry_has_input_authority = not checkpoint_observed in
       if not same_run_retry_has_input_authority
       then
         Log.Keeper.info
           ~keeper_name:meta.name
           "%s: same-run runtime retry deferred after durable run progress \
-           (event_count=%d checkpoint_observed=%b); \
+           (checkpoint_observed=%b); \
            current OAS contract cannot continue without admitting the input again"
           meta.name
-          tool_completed_count
           checkpoint_observed;
       match
           Keeper_turn_runtime_budget.plan_degraded_retry_step

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -817,7 +817,7 @@ let test_attempt_loop_does_not_gate_network_retry () =
     4
     (List.length !events)
 
-let test_attempt_loop_blocks_retry_after_any_checkpoint_stage () =
+let test_typed_checkpoint_is_the_same_run_retry_authority () =
   let stages =
     [ Agent_sdk.Agent.After_assistant_collected
     ; Agent_sdk.Agent.After_tool_results_appended
@@ -965,9 +965,9 @@ let () =
             `Quick
             test_attempt_loop_does_not_gate_network_retry;
           Alcotest.test_case
-            "any checkpoint stage blocks same-run retry"
+            "typed checkpoint is same-run retry authority"
             `Quick
-            test_attempt_loop_blocks_retry_after_any_checkpoint_stage;
+            test_typed_checkpoint_is_the_same_run_retry_authority;
           Alcotest.test_case
             "attempt loop preserves last SDK error"
             `Quick


### PR DESCRIPTION
## 무엇을 바꾸는가

- lossy OAS Event_bus integrity observation이 최종 `run_result`를 덮어쓰던 경로를 제거합니다.
- `ToolCompleted` 관측 개수로 same-run retry를 막던 제어 결합을 제거합니다.
- same-run retry authority는 OAS의 typed checkpoint stage 하나만 사용합니다. checkpoint sink 실패도 stage 관측 뒤 발생하므로 재실행을 열지 않습니다.

## 경계

Event_bus는 관측/투영 표면입니다. durable execution authority가 아니며 Keeper lane의 성공, 실패, retry를 결정하지 않습니다.

## 검증

- `git diff --check`
- touched OCaml parser 및 `ocamlformat --check`
- typed checkpoint stage가 retry authority임을 검증하는 기존 failover test 명세 유지
- exact diff: 17 additions + 22 deletions = 39줄

현재 ac5fd OAS source focused graph는 이 diff 밖의 runtime-MCP, approval, runtime-model migration blocker에서 중단됩니다. 이 PR을 전체 green으로 주장하지 않으며 후속 소형 PR에서 해당 표면을 제거합니다.