### PR TITLE
refactor(gate): own approval decisions in MASC

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -137,10 +137,10 @@ let pending_entry_to_yojson (entry : pending_approval) =
 ;;
 
 let approval_decision_to_yojson = function
-  | Agent_sdk.Hooks.Approve -> `Assoc [ "kind", `String "approve" ]
-  | Agent_sdk.Hooks.Reject reason ->
+  | Decision.Approve -> `Assoc [ "kind", `String "approve" ]
+  | Decision.Reject reason ->
     `Assoc [ "kind", `String "reject"; "reason", `String reason ]
-  | Agent_sdk.Hooks.Edit input ->
+  | Decision.Edit input ->
     `Assoc [ "kind", `String "edit"; "input", input ]
 ;;
 
@@ -345,7 +345,7 @@ let approval_decision_of_yojson json =
            ~allowed:[ "kind" ]
            fields
        in
-       Ok Agent_sdk.Hooks.Approve
+       Ok Decision.Approve
      | "reject" ->
        let* () =
          reject_unknown_fields
@@ -354,7 +354,7 @@ let approval_decision_of_yojson json =
            fields
        in
        let* reason = required_string ~surface:"gate_pending.decision" "reason" fields in
-       Ok (Agent_sdk.Hooks.Reject reason)
+       Ok (Decision.Reject reason)
      | "edit" ->
        let* () =
          reject_unknown_fields
@@ -363,7 +363,7 @@ let approval_decision_of_yojson json =
            fields
        in
        let* input = required_member ~surface:"gate_pending.decision" "input" fields in
-       Ok (Agent_sdk.Hooks.Edit input)
+       Ok (Decision.Edit input)
      | other -> Error (Printf.sprintf "gate_pending.decision kind %S is unknown" other))
   | _ -> Error "gate_pending.decision must be a JSON object"
 ;;
@@ -411,9 +411,9 @@ let persisted_delivery_of_yojson ~base_path json =
     in
     let* () =
       match decision, grant_consumed with
-      | Agent_sdk.Hooks.Approve, _ -> Ok ()
-      | (Agent_sdk.Hooks.Reject _ | Agent_sdk.Hooks.Edit _), false -> Ok ()
-      | (Agent_sdk.Hooks.Reject _ | Agent_sdk.Hooks.Edit _), true ->
+      | Decision.Approve, _ -> Ok ()
+      | (Decision.Reject _ | Decision.Edit _), false -> Ok ()
+      | (Decision.Reject _ | Decision.Edit _), true ->
         Error (surface ^ ".grant_consumed is valid only for approve")
     in
     Ok { entry; decision; source; remember_rule; created_by; grant_consumed }
@@ -641,9 +641,9 @@ let non_empty_reason reason =
 ;;
 
 let approval_decision_kind_and_reason = function
-  | Agent_sdk.Hooks.Approve -> "approve", None
-  | Agent_sdk.Hooks.Reject reason -> "reject", non_empty_reason reason
-  | Agent_sdk.Hooks.Edit _ -> "edit", None
+  | Decision.Approve -> "approve", None
+  | Decision.Reject reason -> "reject", non_empty_reason reason
+  | Decision.Edit _ -> "edit", None
 ;;
 
 let keeper_audit_metric_label = function
@@ -939,11 +939,11 @@ let approved_delivery_unlocked ~base_path ~id =
        then Error (grant_workspace_mismatch ~base_path id stored_base_path)
        else
          (match delivery.decision with
-          | Agent_sdk.Hooks.Approve ->
+          | Decision.Approve ->
             if delivery.grant_consumed
             then Ok Approved_delivery_consumed
             else Ok (Approved_delivery_unconsumed delivery)
-          | Agent_sdk.Hooks.Reject _ | Agent_sdk.Hooks.Edit _ ->
+          | Decision.Reject _ | Decision.Edit _ ->
             Error (Grant_resolution_not_approved id))
      | None ->
        (match SMap.find_opt id (Atomic.get pending) with
@@ -1035,7 +1035,7 @@ let consume_approved_resolution
       ~goal_ids:entry.goal_ids
       ~source_approval_id:id
       ~decision_source:delivery.source
-      ~decision:Agent_sdk.Hooks.Approve
+      ~decision:Decision.Approve
       ();
     Ok Consumption_committed
 ;;
@@ -1430,9 +1430,9 @@ let commit_keeper_approval_resolution
 ;;
 
 let hitl_resolution_decision_of_approval_decision = function
-  | Agent_sdk.Hooks.Approve -> Keeper_event_queue.Hitl_approved
-  | Agent_sdk.Hooks.Reject rationale -> Keeper_event_queue.Hitl_rejected rationale
-  | Agent_sdk.Hooks.Edit input -> Keeper_event_queue.Hitl_edited input
+  | Decision.Approve -> Keeper_event_queue.Hitl_approved
+  | Decision.Reject rationale -> Keeper_event_queue.Hitl_rejected rationale
+  | Decision.Edit input -> Keeper_event_queue.Hitl_edited input
 ;;
 
 let deliver_resolution ~base_path (entry : pending_approval) decision =
@@ -1736,11 +1736,11 @@ let remove_delivery_from_store delivery =
 
 let approval_decision_equal left right =
   match left, right with
-  | Agent_sdk.Hooks.Approve, Agent_sdk.Hooks.Approve -> true
-  | Agent_sdk.Hooks.Reject left, Agent_sdk.Hooks.Reject right -> String.equal left right
-  | Agent_sdk.Hooks.Edit left, Agent_sdk.Hooks.Edit right -> Yojson.Safe.equal left right
-  | (Agent_sdk.Hooks.Approve | Agent_sdk.Hooks.Reject _ | Agent_sdk.Hooks.Edit _),
-    (Agent_sdk.Hooks.Approve | Agent_sdk.Hooks.Reject _ | Agent_sdk.Hooks.Edit _) ->
+  | Decision.Approve, Decision.Approve -> true
+  | Decision.Reject left, Decision.Reject right -> String.equal left right
+  | Decision.Edit left, Decision.Edit right -> Yojson.Safe.equal left right
+  | (Decision.Approve | Decision.Reject _ | Decision.Edit _),
+    (Decision.Approve | Decision.Reject _ | Decision.Edit _) ->
     false
 ;;
 
@@ -1784,7 +1784,7 @@ let remember_rule_for_entry ~base_path ?created_by (entry : pending_approval) =
 
 let remember_rule_for_delivery delivery =
   match delivery.decision, delivery.remember_rule with
-  | Agent_sdk.Hooks.Approve, true ->
+  | Decision.Approve, true ->
     (match
        remember_rule_for_entry
          ~base_path:delivery.entry.audit_base_path
@@ -1797,10 +1797,10 @@ let remember_rule_for_delivery delivery =
          { path = rule_error.path
          ; reason = rule_error.reason
          })
-  | (Agent_sdk.Hooks.Approve | Agent_sdk.Hooks.Reject _ | Agent_sdk.Hooks.Edit _),
+  | (Decision.Approve | Decision.Reject _ | Decision.Edit _),
     false ->
     Ok None
-  | (Agent_sdk.Hooks.Reject _ | Agent_sdk.Hooks.Edit _), true -> Ok None
+  | (Decision.Reject _ | Decision.Edit _), true -> Ok None
 ;;
 
 let complete_delivery delivery =
@@ -1829,12 +1829,12 @@ let complete_delivery delivery =
          Ok { remembered_rule }
        in
        (match delivery.decision with
-        | Agent_sdk.Hooks.Approve ->
+        | Decision.Approve ->
           (* Keep the resolved journal entry until the exact Gate request
              consumes it. The wake event is only a correlation message and
              cannot become a second authorization SSOT. *)
           finish ()
-        | Agent_sdk.Hooks.Reject _ | Agent_sdk.Hooks.Edit _ ->
+        | Decision.Reject _ | Decision.Edit _ ->
           (match remove_delivery_from_store delivery with
            | Error storage_error ->
              Error (Persistence_failed { approval_id = id; storage_error })
@@ -1936,7 +1936,7 @@ let install_persistence ~base_path =
 
 let resolve_with_policy
       ~id
-      ~(decision : Agent_sdk.Hooks.approval_decision)
+      ~(decision : decision)
       ?(source = Human_operator)
       ?(remember_rule = false)
       ?created_by
@@ -1953,8 +1953,8 @@ let resolve_with_policy
          | Some _ ->
            let remember_rule =
              match decision with
-             | Agent_sdk.Hooks.Approve -> remember_rule
-             | Agent_sdk.Hooks.Reject _ | Agent_sdk.Hooks.Edit _ -> false
+             | Decision.Approve -> remember_rule
+             | Decision.Reject _ | Decision.Edit _ -> false
            in
            (match
               journal_resolution
@@ -1994,7 +1994,7 @@ let resolve_with_policy
     rather than threaded from the caller: the convenience wrapper takes
     only an [id], so the entry is the authoritative workspace source
     (RFC-0274 Wave A). *)
-let resolve ~id ~(decision : Agent_sdk.Hooks.approval_decision)
+let resolve ~id ~(decision : decision)
   : (unit, resolve_error) result
   =
   match resolve_with_policy ~id ~decision () with

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -193,10 +193,10 @@ type resolve_error =
 val resolve_error_to_string : resolve_error -> string
 
 (** Commit a resolution, optionally persist an exact Always Allowed rule for
-    [Approve], then wake only the Keeper captured by the pending entry. *)
+    [Decision.Approve], then wake only the Keeper captured by the pending entry. *)
 val resolve_with_policy :
   id:string ->
-  decision:Agent_sdk.Hooks.approval_decision ->
+  decision:decision ->
   ?source:decision_source ->
   ?remember_rule:bool ->
   ?created_by:string ->
@@ -205,7 +205,7 @@ val resolve_with_policy :
 
 val resolve :
   id:string ->
-  decision:Agent_sdk.Hooks.approval_decision ->
+  decision:decision ->
   (unit, resolve_error) result
 
 (** {1 Query} *)

--- a/lib/keeper/keeper_gate.ml
+++ b/lib/keeper/keeper_gate.ml
@@ -247,9 +247,9 @@ let resolve_judgment (entry : Keeper_approval_queue.pending_approval) ~approval_
       (summary : Keeper_approval_queue.hitl_context_summary) =
   let decision =
     match summary.Keeper_approval_queue.judgment with
-    | Keeper_approval_queue.Approve -> Some Agent_sdk.Hooks.Approve
+    | Keeper_approval_queue.Approve -> Some Keeper_approval_queue.Decision.Approve
     | Keeper_approval_queue.Deny ->
-      Some (Agent_sdk.Hooks.Reject summary.rationale)
+      Some (Keeper_approval_queue.Decision.Reject summary.rationale)
     | Keeper_approval_queue.Require_human -> None
   in
   match decision with

--- a/lib/keeper_contract/dune
+++ b/lib/keeper_contract/dune
@@ -12,7 +12,6 @@
   keeper_invariant
   keeper_path_rejection)
  (libraries
-  agent_sdk
   eio
   masc.keeper_registry
   masc.keeper_runtime

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.ml
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.ml
@@ -40,7 +40,14 @@ type pending_approval =
   ; summary_status : summary_status
   }
 
-type decision = Agent_sdk.Hooks.approval_decision
+module Decision = struct
+  type t =
+    | Approve
+    | Reject of string
+    | Edit of Yojson.Safe.t
+end
+
+type decision = Decision.t
 
 type decision_source =
   | Always_allowed
@@ -84,9 +91,9 @@ let advisory_judgment_of_string = function
 ;;
 
 let approval_decision_to_string = function
-  | Agent_sdk.Hooks.Approve -> "approve"
-  | Agent_sdk.Hooks.Reject reason -> "reject:" ^ reason
-  | Agent_sdk.Hooks.Edit _ -> "edit"
+  | Decision.Approve -> "approve"
+  | Decision.Reject reason -> "reject:" ^ reason
+  | Decision.Edit _ -> "edit"
 ;;
 
 let decision_source_to_string = function

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.mli
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.mli
@@ -42,7 +42,16 @@ type pending_approval =
   ; summary_status : summary_status
   }
 
-type decision = Agent_sdk.Hooks.approval_decision
+(** Exact queue resolution. This is an outcome value, not a risk class,
+    authorization hierarchy, or provider/tool policy. *)
+module Decision : sig
+  type t =
+    | Approve
+    | Reject of string
+    | Edit of Yojson.Safe.t
+end
+
+type decision = Decision.t
 
 type decision_source =
   | Always_allowed

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -339,9 +339,9 @@ let approval_resolve_decision_name = function
   | Approval_resolve_reject _ -> approval_resolve_reject_name
 ;;
 
-let approval_resolve_decision_to_hook = function
-  | Approval_resolve_approve -> Agent_sdk.Hooks.Approve
-  | Approval_resolve_reject reason -> Agent_sdk.Hooks.Reject reason
+let approval_resolve_decision_to_queue_decision = function
+  | Approval_resolve_approve -> Keeper_approval_queue.Decision.Approve
+  | Approval_resolve_reject reason -> Keeper_approval_queue.Decision.Reject reason
 ;;
 
 let approval_resolve_decision_of_json args =
@@ -385,7 +385,7 @@ let dashboard_gate_resolve_http_json ~created_by ~(args : Yojson.Safe.t)
      | Error _ as err -> err
      | Ok decision ->
        let decision_name = approval_resolve_decision_name decision in
-       let decision = approval_resolve_decision_to_hook decision in
+       let decision = approval_resolve_decision_to_queue_decision decision in
        (match
           Keeper_approval_queue.resolve_with_policy
             ~id

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -106,7 +106,7 @@ let submit ~base_path ~keeper_name ~input =
 ;;
 
 let reject_and_cleanup id =
-  match AQ.resolve ~id ~decision:(Agent_sdk.Hooks.Reject "test cleanup") with
+  match AQ.resolve ~id ~decision:(AQ.Decision.Reject "test cleanup") with
   | Ok () -> ()
   | Error error -> Alcotest.fail (AQ.resolve_error_to_string error)
 ;;
@@ -303,7 +303,7 @@ let test_resolution_is_durable_and_origin_scoped () =
        let result =
          AQ.resolve_with_policy
            ~id
-           ~decision:Agent_sdk.Hooks.Approve
+           ~decision:AQ.Decision.Approve
            ~remember_rule:true
            ~created_by:"operator"
            ()
@@ -404,7 +404,7 @@ let test_cycle_grant_uses_exact_effect_and_is_consumed_once () =
            ~input
            ()
        in
-       (match AQ.resolve ~id:approval_id ~decision:Agent_sdk.Hooks.Approve with
+       (match AQ.resolve ~id:approval_id ~decision:AQ.Decision.Approve with
         | Ok () -> ()
         | Error error -> Alcotest.fail (AQ.resolve_error_to_string error));
        let resolution =
@@ -550,7 +550,7 @@ let test_summary_updates_never_resolve_pending_request () =
        Alcotest.(check bool) "model judgment remains pending" true
          (Option.is_some (AQ.get_pending_entry ~id));
        Alcotest.(check bool) "resolved entry cannot be updated" true
-         (match AQ.resolve ~id ~decision:(Agent_sdk.Hooks.Reject "operator denied") with
+         (match AQ.resolve ~id ~decision:(AQ.Decision.Reject "operator denied") with
           | Error error -> Alcotest.fail (AQ.resolve_error_to_string error)
           | Ok () ->
             (match AQ.attach_summary ~id summary with
@@ -1058,7 +1058,7 @@ let test_unavailable_cycle_grant_never_falls_through () =
       cleanup_dir base_path)
     (fun () ->
        let approval_id = submit ~base_path ~keeper_name ~input in
-       (match AQ.resolve ~id:approval_id ~decision:Agent_sdk.Hooks.Approve with
+       (match AQ.resolve ~id:approval_id ~decision:AQ.Decision.Approve with
         | Ok () -> ()
         | Error error -> Alcotest.fail (AQ.resolve_error_to_string error));
        let resolution =
@@ -1118,7 +1118,7 @@ let test_nonapproved_resolution_payload_is_delivered () =
        (match
           AQ.resolve
             ~id:reject_id
-            ~decision:(Agent_sdk.Hooks.Reject rationale)
+            ~decision:(AQ.Decision.Reject rationale)
         with
         | Ok () -> ()
         | Error error -> Alcotest.fail (AQ.resolve_error_to_string error));
@@ -1146,7 +1146,7 @@ let test_nonapproved_resolution_payload_is_delivered () =
        let edited_input =
          `Assoc [ "target", `String "after"; "confirmed", `Bool true ]
        in
-       (match AQ.resolve ~id:edit_id ~decision:(Agent_sdk.Hooks.Edit edited_input) with
+       (match AQ.resolve ~id:edit_id ~decision:(AQ.Decision.Edit edited_input) with
         | Ok () -> ()
         | Error error -> Alcotest.fail (AQ.resolve_error_to_string error));
        let edited =

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -338,7 +338,7 @@ let test_pending_hitl_approval_keeper_names_filters_persisted_pending () =
           ignore
             (AQ.resolve
                ~id
-               ~decision:(Agent_sdk.Hooks.Reject "test cleanup")))
+               ~decision:(AQ.Decision.Reject "test cleanup")))
         !approval_ids;
       cleanup_dir base_dir)
     (fun () ->
@@ -1009,7 +1009,7 @@ let test_sweep_reports_pending_hitl_approval () =
            ignore
              (AQ.resolve
                 ~id
-                ~decision:(Agent_sdk.Hooks.Reject "test cleanup")))
+                ~decision:(AQ.Decision.Reject "test cleanup")))
         !approval_id;
       Reg.clear ();
       Masc.Keeper_runtime.reset_test_state base_dir;
@@ -1056,7 +1056,7 @@ let test_sweep_reports_pending_hitl_approval () =
       check bool "pending HITL approval visibility emitted" true visibility_seen;
       check bool "approval remains pending after visibility sweep" true
         (AQ.has_pending_for_keeper ~keeper_name:name);
-      (match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
+      (match AQ.resolve ~id ~decision:AQ.Decision.Approve with
        | Ok () -> approval_id := None
        | Error err -> fail ("resolve failed: " ^ AQ.resolve_error_to_string err));
       check bool "resolution removes pending request" false


### PR DESCRIPTION
## 무엇을 바꾸는가

- `Agent_sdk.Hooks.approval_decision` 별칭을 제거하고 MASC Gate 큐가 `Decision.t = Approve | Reject | Edit`를 소유합니다.
- Queue, Auto Judge, dashboard resolve, supervisor/test 호출자를 동일한 MASC 타입으로 옮깁니다.
- wire JSON과 저장 형식은 변경하지 않습니다.
- `masc.keeper_contract` 서브라이브러리에서 불필요한 `agent_sdk` 의존을 제거합니다.

## 경계

이 타입은 exact Gate 요청의 resolution outcome입니다. risk class, authorization hierarchy, provider/tool 정책이 아닙니다. OAS는 MASC HITL 제품 의미를 알지 않습니다.

## 검증

- `git diff --check`
- touched OCaml parser 및 `ocamlformat --check`
- focused ac5 build: `keeper_approval_queue_rules_types.cmo`
- `lib/keeper_contract` 내부 `Agent_sdk`/`Llm_provider` 참조 0
- 전역 `Agent_sdk.Hooks.{Approve,Reject,Edit}` 및 `Hooks.approval_decision` 참조 0
- exact diff: 72 additions + 57 deletions = 129줄

Queue/Gate 전체 focused graph는 이 PR 밖의 `Request_priority` 및 runtime-MCP migration blocker에서 중단됩니다. 이 PR은 해당 실패를 green으로 주장하지 않습니다.