### PR TITLE
fix(dashboard): finish observational execution-limit hard cut

### DIFF
--- a/lib/server/server_dashboard_http_composite_claims.ml
+++ b/lib/server/server_dashboard_http_composite_claims.ml
@@ -309,51 +309,6 @@ let composite_execution_config_drift execution =
 
 let keeper_activation_readiness_json = Server_dashboard_fleet_readiness.keeper_activation_readiness_json
 
-(* Typed budget-exhausted classification.
-
-   The dashboard composite reads the wire [terminal_reason_code] field
-   from the typed execution schema. Rather than scanning substrings
-   (anti-pattern #2), we route the wire string through the typed
-   [Keeper_turn_disposition.of_wire] parser and match on the closed sum.
-   An unrecognised string falls through [Unknown _] and yields [false];
-   no permissive default, no silent accept. *)
-let execution_turn_budget_disposition execution =
-  Option.bind (json_string "terminal_reason_code" execution) (fun raw ->
-    let trimmed = String.trim raw in
-    if String.length trimmed = 0
-    then None
-    else Some (Keeper_turn_disposition.of_wire (String.lowercase_ascii trimmed)))
-;;
-
-let execution_turn_budget_disposition_of_reason reason =
-  match reason with
-  | None -> None
-  | Some raw ->
-    let trimmed = String.trim raw in
-    if String.length trimmed = 0
-    then None
-    else Some (Keeper_turn_disposition.of_wire (String.lowercase_ascii trimmed))
-;;
-
-let composite_execution_turn_budget_exhausted execution =
-  match json_string "terminal_reason_code" execution with
-  | Some raw -> Keeper_turn_disposition.is_turn_budget_exhausted_wire raw
-  | None -> false
-;;
-
-let composite_execution_budget_exhausted_pass execution =
-  string_opt_is_any (json_string "operator_disposition" execution) [ "pass" ]
-  && composite_execution_turn_budget_exhausted execution
-  &&
-  match execution_turn_budget_disposition_of_reason
-          (lower_string_opt (json_string "operator_disposition_reason" execution)) with
-  | None -> true
-  | Some Keeper_turn_disposition.Success -> true
-  | Some (Keeper_turn_disposition.Turn_budget_exhausted _) -> true
-  | Some Keeper_turn_disposition.Unknown _ -> true
-  | Some _ -> false
-;;
-
 let composite_execution_blocked execution =
   composite_execution_claim_no_eligible execution
   || string_opt_is_any (json_string "operator_disposition" execution) [ "pause_human" ]
@@ -363,7 +318,6 @@ let composite_execution_blocked execution =
         && not
              (Keeper_turn_disposition.is_success
                 (Keeper_turn_disposition.of_wire terminal))
-        && not (composite_execution_budget_exhausted_pass execution)
       | None -> false)
   ||
   match json_member "error" execution with

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -1774,6 +1774,38 @@ let test_lifecycle_event_display_values () =
         (Server_dashboard_http_execution_surfaces.paused_of_lifecycle_event name))
     cases
 
+let test_composite_blocked_ignores_observational_budget_metadata () =
+  let execution ~terminal_reason_code ~operator_disposition_reason =
+    `Assoc
+      [ "terminal_reason_code", `String terminal_reason_code
+      ; "operator_disposition", `String "pass"
+      ; "operator_disposition_reason", `String operator_disposition_reason
+      ; "error", `Null
+      ]
+  in
+  let blocked = Server_dashboard_http_composite_claims.composite_execution_blocked in
+  check bool
+    "budget observation does not block a successful execution"
+    false
+    (blocked
+       (execution
+          ~terminal_reason_code:"success"
+          ~operator_disposition_reason:"turn_budget_exhausted(3/3)"));
+  check bool
+    "removed budget terminal wire gets no legacy pass exception"
+    true
+    (blocked
+       (execution
+          ~terminal_reason_code:"turn_budget_exhausted(3/3)"
+          ~operator_disposition_reason:"success"));
+  check bool
+    "removed budget terminal wire follows the generic unknown-failure path"
+    true
+    (blocked
+       (execution
+          ~terminal_reason_code:"opaque_terminal_failure"
+          ~operator_disposition_reason:"success"))
+
 let () =
   run "dashboard_http_core"
     [
@@ -1875,6 +1907,8 @@ let () =
             test_keeper_chat_receipt_route_and_json;
           test_case "keeper chat recovery route is exact" `Quick
             test_keeper_chat_recovery_route_is_exact;
+          test_case "composite budget metadata stays observational" `Quick
+            test_composite_blocked_ignores_observational_budget_metadata;
         ] );
       ( "lifecycle event classification (#22071)",
         [ test_case "event_of_string round-trips to_string" `Quick


### PR DESCRIPTION
## Summary

- delete the dashboard composite readers for the removed `Turn_budget_exhausted` terminal disposition
- remove the legacy budget-pass exception from blocked classification
- keep budget metadata observational: canonical successful execution is not blocked by a budget observation
- treat an obsolete budget terminal wire through the ordinary unknown-terminal failure path; no compatibility parser or special case

## Why

`#24386` removed execution-budget stopping and the corresponding typed terminal constructor, but the dashboard composite still called `Keeper_turn_disposition.is_turn_budget_exhausted_wire` and matched `Turn_budget_exhausted`. Current main therefore fails to compile before downstream tests run.

This finishes that hard cut instead of restoring the deleted API or adding a string classifier.

## Validation

- OCaml 5.4.1 and 5.5.0 parse checks: pass
- ocamlformat, diff check, and OCaml comment-terminator guard: pass
- focused regression added to `test_dashboard_http_core`
- focused local Dune reached unrelated installed-OAS contract drift before the target; no compatibility shim or shared pin mutation was added
- PR CI remains the build authority
