### PR TITLE
refactor(runtime): hard-cut removed request priority

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -207,7 +207,6 @@ let run_turn
       ?temperature
       ?on_event
       ?(trajectory_acc : Trajectory.accumulator option)
-      ?priority
       ?(degraded_retry_applied = false)
       ?degraded_retry_runtime
       ?fallback_reason
@@ -571,9 +570,6 @@ let run_turn
         ~base_path:config.base_path
         ~keeper_name:meta.name
     in
-    let priority =
-      Option.value priority ~default:Llm_provider.Request_priority.Proactive
-    in
     ignore (Keeper_alerting_path.ensure_sandbox_bundle ~config ~meta);
     let _keeper_sandbox_root = Keeper_sandbox.host_root_abs_of_meta ~config meta in
     let keeper_visible_sandbox_root =
@@ -699,7 +695,6 @@ let run_turn
                   ~keeper_name:meta.name
                     ~goal:user_message
                     ?goal_blocks:user_blocks
-                    ~priority
                     ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
                     ?raw_trace
                     ~system_prompt:turn_system_prompt

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -122,7 +122,6 @@ end
            declaration takes precedence
     @param on_event Optional event callback
     @param trajectory_acc Optional trajectory accumulator for recording
-    @param priority Optional priority for scheduling
     @param is_retry When [true], replays current user message without persisting
     @param shared_context Optional shared OAS context for cross-turn state
     @param event_bus Optional MASC event bus *)
@@ -145,7 +144,6 @@ val run_turn
   -> ?temperature:float
   -> ?on_event:(Agent_sdk.Types.sse_event -> unit)
   -> ?trajectory_acc:Trajectory.accumulator
-  -> ?priority:Llm_provider.Request_priority.t
   -> ?degraded_retry_applied:bool
   -> ?degraded_retry_runtime:string
   -> ?fallback_reason:Keeper_error_classify.degraded_retry_reason

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -316,7 +316,6 @@ let run_named
     ~base_path
     ~goal
     ?goal_blocks
-    ?priority
     ?session_id
     ?(system_prompt = "")
     ?(tools = [])
@@ -649,7 +648,6 @@ let run_named
             ; name
             ; goal
             ; goal_blocks
-            ; priority
             ; session_id
             ; system_prompt
             ; tools

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -77,7 +77,6 @@ val run_named :
   base_path:string ->
   goal:string ->
   ?goal_blocks:Agent_sdk.Types.content_block list ->
-  ?priority:Llm_provider.Request_priority.t ->
   ?session_id:string ->
   ?system_prompt:string ->
   ?tools:Agent_sdk.Tool.t list ->

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -25,7 +25,6 @@ type try_provider_ctx =
   ; (* Agent config — fields passed through the runtime candidate boundary. *)
     goal : string
   ; goal_blocks : Agent_sdk.Types.content_block list option
-  ; priority : Llm_provider.Request_priority.t option
   ; session_id : string option
   ; system_prompt : string
   ; tools : Agent_sdk.Tool.t list
@@ -231,8 +230,7 @@ let run_try_provider
            ~tools:ctx.tools
            candidate)
             with
-            priority = ctx.priority
-          ; stream_idle_timeout_s = ctx.stream_idle_timeout_s
+            stream_idle_timeout_s = ctx.stream_idle_timeout_s
           ; body_timeout_s = ctx.body_timeout_s
           ; temperature = ctx.temperature
           ; max_turns = ctx.max_turns

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -8,7 +8,6 @@ type try_provider_ctx =
   ; name : string
   ; goal : string
   ; goal_blocks : Agent_sdk.Types.content_block list option
-  ; priority : Llm_provider.Request_priority.t option
   ; session_id : string option
   ; system_prompt : string
   ; tools : Agent_sdk.Tool.t list

--- a/lib/keeper/keeper_turn_driver_wrappers.ml
+++ b/lib/keeper/keeper_turn_driver_wrappers.ml
@@ -158,7 +158,6 @@ let run_named_with_masc_tools
     ?(keeper_name = "")
     ~goal
     ~base_path
-    ?priority
     ?(system_prompt = "")
     ~(masc_tools : Masc_domain.tool_schema list)
     ~(dispatch : name:string -> args:Yojson.Safe.t -> Tool_result.result)
@@ -187,7 +186,7 @@ let run_named_with_masc_tools
       ~input_schema:td.input_schema
       (fun input -> dispatch ~name:td.name ~args:input)
   ) masc_tools in
-  Keeper_turn_driver.run_named ~runtime_id ~keeper_name ~goal ~base_path ?priority ~system_prompt ~tools:oas_tools
+  Keeper_turn_driver.run_named ~runtime_id ~keeper_name ~goal ~base_path ~system_prompt ~tools:oas_tools
     ?max_turns
     ~max_idle_turns
     ~temperature

--- a/lib/keeper/keeper_turn_driver_wrappers.mli
+++ b/lib/keeper/keeper_turn_driver_wrappers.mli
@@ -42,7 +42,6 @@ val run_named_with_masc_tools :
   ?keeper_name:string ->
   goal:string ->
   base_path:string ->
-  ?priority:Llm_provider.Request_priority.t ->
   ?system_prompt:string ->
   masc_tools:Masc_domain.tool_schema list ->
   dispatch:(name:string -> args:Yojson.Safe.t -> Tool_result.result) ->

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -93,7 +93,6 @@ type config =
   provider_cfg : Llm_provider.Provider_config.t;
   provider : Agent_sdk.Provider.config;
   model_id : string;
-  priority : Llm_provider.Request_priority.t option;
   system_prompt : string;
   tools : Agent_sdk.Tool.t list;
   max_turns : int;

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -71,7 +71,6 @@ type config = Runtime_agent_context.config = {
   provider_cfg : Llm_provider.Provider_config.t;
   provider : Agent_sdk.Provider.config;
   model_id : string;
-  priority : Llm_provider.Request_priority.t option;
   system_prompt : string;
   tools : Agent_sdk.Tool.t list;
   max_turns : int;

--- a/lib/runtime/runtime_agent_context.ml
+++ b/lib/runtime/runtime_agent_context.ml
@@ -68,7 +68,6 @@ type config =
   ; provider_cfg : Llm_provider.Provider_config.t
   ; provider : Agent_sdk.Provider.config
   ; model_id : string
-  ; priority : Llm_provider.Request_priority.t option
   ; system_prompt : string
   ; tools : Agent_sdk.Tool.t list
   ; max_turns : int
@@ -182,7 +181,6 @@ let default_config
   ; provider_cfg
   ; provider
   ; model_id = provider_cfg.model_id
-  ; priority = None
   ; system_prompt
   ; tools
   ; max_turns = default_max_turns
@@ -319,11 +317,6 @@ let builder_without_approval
   let builder =
     match config.preserve_thinking with
     | Some preserve -> Agent_sdk.Builder.with_preserve_thinking preserve builder
-    | None -> builder
-  in
-  let builder =
-    match config.priority with
-    | Some priority -> Agent_sdk.Builder.with_priority priority builder
     | None -> builder
   in
   let builder =
@@ -506,7 +499,6 @@ let prepare_resume ~(config : config) ~(checkpoint : Agent_sdk.Checkpoint.t)
     ; cache_system_prompt = config.cache_system_prompt
     ; yield_on_tool = config.yield_on_tool
     ; context_compact_ratio = config.compact_ratio
-    ; priority = config.priority
     ; exit_condition = config.exit_condition
     }
   in
@@ -529,7 +521,6 @@ let prepare_resume ~(config : config) ~(checkpoint : Agent_sdk.Checkpoint.t)
     ; missing_approval_callback_policy =
         Agent_sdk.Hooks.Reject_without_callback
     ; summarizer = config.summarizer
-    ; priority = config.priority
     ; on_run_complete = config.on_run_complete
     ; disclosure_level = config.disclosure_level
     ; disclosure_resolver = config.disclosure_resolver

--- a/lib/runtime/runtime_agent_context.mli
+++ b/lib/runtime/runtime_agent_context.mli
@@ -50,7 +50,6 @@ type config = {
   provider_cfg : Llm_provider.Provider_config.t;
   provider : Agent_sdk.Provider.config;
   model_id : string;
-  priority : Llm_provider.Request_priority.t option;
   system_prompt : string;
   tools : Agent_sdk.Tool.t list;
   max_turns : int;


### PR DESCRIPTION
## Why

OAS v0.212.0 removed Request_priority and Builder.with_priority. MASC still threaded that deleted transport hint from Keeper wrappers through Runtime_agent_context.

## What

- remove the obsolete OAS request-priority field and argument chain
- remove the implicit Proactive fallback
- keep Task/Goal/product priority contracts unchanged
- add no replacement enum, number, string, or heuristic

## Verification

- git diff --check
- ocamlformat --check on all 12 touched OCaml files
- OCaml parser check on all touched files
- rg confirms no remaining Llm_provider.Request_priority or Builder.with_priority references
- focused OAS v0.212.0 build passes this boundary and advances to the independent Agent_sdk.Context_reducer migration blocker

## Test coverage waiver

# ci:skip-test-coverage

This is a deletion-only removed-contract hard-cut. Adding a behavioral test for the deleted transport hint would preserve the obsolete contract or create a fixture-only fake green. Existing Keeper/Task/Goal priority behavior is intentionally outside this diff.

Diff: 2 additions, 29 deletions.