### PR TITLE
fix(keeper): wire chat consumer wake to queue/slot transitions (P0-A)

### DIFF
--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -1660,10 +1660,23 @@ let start_keeper_loops_owned
     let base_path = config.base_path in
     let setup =
       try
+        (* A durable queue mutation both refreshes the dashboard (SSE) and must
+           wake this consumer: [notify_transition] is a non-blocking Wake_inbox
+           post, so a message enqueued after boot is actually leased and
+           delivered instead of sitting queued until the next unrelated wake. *)
         Keeper_chat_queue.set_transition_observer
           (Some
              (fun ~keeper_name ~revision ->
-                Keeper_chat_broadcast.queue_changed ~keeper_name ~revision ()));
+                Keeper_chat_broadcast.queue_changed ~keeper_name ~revision ();
+                Keeper_chat_consumer.notify_transition ~keeper_name));
+        (* A freed turn slot (turn released / shutdown rolled back) makes the
+           lane dispatchable again; wake the consumer so any receipt that was
+           deferred while the lane was busy is re-examined. The admission
+           observer is non-blocking and its failures cannot alter admission. *)
+        Keeper_turn_admission.set_slot_transition_observer
+          (Some
+             (fun ~base_path:_ ~keeper_name ~transition:_ ->
+                Keeper_chat_consumer.notify_transition ~keeper_name));
         Ok ()
       with
       | Eio.Cancel.Cancelled _ as exn -> raise exn

--- a/test/dune
+++ b/test/dune
@@ -902,6 +902,7 @@
   test_keeper_turn_interrupt
   test_keeper_chat_consumer_delivery
   test_keeper_chat_consumer_dispatch
+  test_keeper_consumer_wake_wiring
   test_runtime_params
   test_config_dir_resolver
   test_workspace_coverage
@@ -1078,6 +1079,7 @@
   test_keeper_turn_interrupt
   test_keeper_chat_consumer_delivery
   test_keeper_chat_consumer_dispatch
+  test_keeper_consumer_wake_wiring
   test_runtime_params
   test_config_dir_resolver
   test_workspace_coverage

--- a/test/test_keeper_consumer_wake_wiring.ml
+++ b/test/test_keeper_consumer_wake_wiring.ml
@@ -1,0 +1,74 @@
+(** Regression guard for the keeper chat consumer wake wiring (P0-A).
+
+    The consumer blocks on its Wake_inbox; only [Keeper_chat_consumer
+    .notify_transition] refills it after boot. Before this guard, the
+    bootstrap installed only the SSE broadcast on the queue transition
+    observer and never installed a slot-transition observer, so a message
+    enqueued after boot received a receipt and a "queued" response but was
+    never leased or delivered — no error, no log.
+
+    [server_bootstrap_loops.ml] wires the live consumer subsystem and cannot
+    be exercised without a full server env, so this is a source guard: it
+    pins that the consumer setup installs BOTH wake paths (durable queue
+    mutation and freed turn slot) to [notify_transition]. The delivery
+    behaviour once the observers are installed is covered separately by
+    [test_keeper_chat_consumer_delivery.ml]. *)
+
+open Alcotest
+
+let target_file = "lib/server/server_bootstrap_loops.ml"
+
+let load_source rel =
+  let root =
+    match Sys.getenv_opt "DUNE_SOURCEROOT" with
+    | Some root -> root
+    | None -> Sys.getcwd ()
+  in
+  let path = Filename.concat root rel in
+  if not (Sys.file_exists path) then failwith ("source file not found: " ^ path);
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () -> In_channel.input_all ic)
+
+(* Keep only code lines: drop whole-line comments so a marker mentioned in
+   prose cannot satisfy the guard. *)
+let code_lines src =
+  String.split_on_char '\n' src
+  |> List.filter (fun line ->
+    let trimmed = String.trim line in
+    not (String.length trimmed >= 2 && String.sub trimmed 0 2 = "(*"))
+  |> String.concat "\n"
+
+let contains ~needle haystack =
+  let n = String.length needle and m = String.length haystack in
+  let rec go i = i + n <= m && (String.sub haystack i n = needle || go (i + 1)) in
+  n = 0 || go 0
+
+let test_queue_mutation_wakes_consumer () =
+  let src = code_lines (load_source target_file) in
+  (* The durable queue transition observer must wake the consumer, not only
+     refresh the dashboard over SSE. *)
+  check bool
+    "bootstrap installs Keeper_chat_consumer.notify_transition on queue mutation"
+    true
+    (contains ~needle:"Keeper_chat_consumer.notify_transition" src)
+
+let test_slot_release_wakes_consumer () =
+  let src = code_lines (load_source target_file) in
+  (* A freed turn slot must make the lane dispatchable again by waking the
+     consumer through the admission slot-transition observer. *)
+  check bool
+    "bootstrap installs Keeper_turn_admission.set_slot_transition_observer"
+    true
+    (contains ~needle:"Keeper_turn_admission.set_slot_transition_observer" src)
+
+let () =
+  run "keeper_consumer_wake_wiring"
+    [ ( "p0a_wake_paths"
+      , [ test_case "queue mutation wakes consumer" `Quick
+            test_queue_mutation_wakes_consumer
+        ; test_case "slot release wakes consumer" `Quick
+            test_slot_release_wakes_consumer
+        ] )
+    ]


### PR DESCRIPTION
## 무엇을

부팅 후 chat 컨슈머가 다시 깨어나지 않아 메시지가 조용히 미배달되던 P0-A 배선 수리. #24382/#24385/#24390이 SQLite receipt 큐를 올렸으나, 컨슈머를 깨우는 `Keeper_chat_consumer.notify_transition`을 프로덕션에서 아무도 안 불렀음.

## 왜

- bootstrap의 queue transition observer가 SSE 브로드캐스트만 하고 컨슈머는 안 깨움 → 부팅 후 enqueue된 메시지는 receipt+"queued" 응답을 받지만 lease/배달 안 됨 (에러도 로그도 없음)
- `set_slot_transition_observer`(턴 슬롯 해제 시 wake)는 프로덕션 호출자 0

## 수정

컨슈머 subsystem setup에 두 wake 경로를 배선. 둘 다 `notify_transition`(논블로킹 Wake_inbox post) 호출. slot observer는 turn/state mutex 해제 후 실행되고 실패해도 admission 불변 — 계약 준수. **이건 `test_keeper_chat_consumer_delivery.ml`이 이미 하네스에서 설치하는 정확한 배선**이며, 이 PR은 그걸 프로덕션으로 옮긴 것.

## 테스트

- 신규 `test_keeper_consumer_wake_wiring`: bootstrap이 두 wake 경로를 설치하는지 회귀 가드 (comment-line 제외 스캔)
- 배선 후 배달 동작은 기존 `test_keeper_chat_consumer_delivery.ml`이 커버

## 연계

Refs #24387 (P0-A). **P0-B(#24385 레거시 chat-queue.json 마이그레이션)는 별개, 여전히 미해소** — 이 PR은 배달 배선만 복구. 로컬 빌드 미실행(repo 규칙), CI 권위.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
