### PR TITLE
refactor(runtime): align typed provider bindings

### DIFF
--- a/lib/runtime_model/provider_runtime_projection.ml
+++ b/lib/runtime_model/provider_runtime_projection.ml
@@ -9,7 +9,6 @@ module Runtime_binding = Agent_sdk.Provider_runtime_binding
 
 type runtime_kind =
   | Local
-  | Cli_agent
   | Direct_api
 
 type default_model_source =
@@ -57,16 +56,13 @@ let binding_auth_is_no_auth (binding : Runtime_binding.t) =
   match binding.Runtime_binding.auth with
   | Runtime_binding.No_auth -> true
   | Runtime_binding.Api_key_env _
-  | Runtime_binding.Oauth_cached_login
   | Runtime_binding.Setup_token_env _ -> false
 ;;
 
 let runtime_kind_of_binding (binding : Runtime_binding.t) =
-  match binding.Runtime_binding.transport with
-  | Runtime_binding.Http | Runtime_binding.Managed ->
-    if binding_auth_is_no_auth binding && binding_base_url_is_loopback binding
-    then Local
-    else Direct_api
+  if binding_auth_is_no_auth binding && binding_base_url_is_loopback binding
+  then Local
+  else Direct_api
 ;;
 
 let binding_labels (binding : Runtime_binding.t) =
@@ -101,7 +97,7 @@ let default_model_id_of_binding (binding : Runtime_binding.t) =
   | None ->
     (match runtime_kind_of_binding binding with
      | Local -> None
-     | Cli_agent | Direct_api -> Some "auto")
+     | Direct_api -> Some "auto")
 ;;
 
 let supported_models_of_binding (binding : Runtime_binding.t) =
@@ -207,14 +203,13 @@ let binding_auth_available (binding : Runtime_binding.t) =
   | Runtime_binding.No_auth -> true
   | Runtime_binding.Api_key_env env_name | Runtime_binding.Setup_token_env env_name ->
     env_present env_name
-  | Runtime_binding.Oauth_cached_login -> binding.Runtime_binding.available
 ;;
 
 let default_model_label_for_binding (binding : Runtime_binding.t) =
   let profile = profile_of_binding binding in
   match profile.runtime_kind with
   | Local -> Ok (profile.runtime_prefix ^ ":auto")
-  | Cli_agent | Direct_api ->
+  | Direct_api ->
     (match default_model_candidate_of_binding binding with
      | Some _ -> Ok (profile.runtime_prefix ^ ":auto")
      | None ->

--- a/lib/runtime_model/provider_runtime_projection.mli
+++ b/lib/runtime_model/provider_runtime_projection.mli
@@ -4,7 +4,6 @@ module Runtime_binding = Agent_sdk.Provider_runtime_binding
 
 type runtime_kind =
   | Local
-  | Cli_agent
   | Direct_api
 
 type default_model_source =

--- a/lib/runtime_model/runtime_model_resolve.ml
+++ b/lib/runtime_model/runtime_model_resolve.ml
@@ -91,7 +91,6 @@ let default_auto_models_for_profile (profile : Provider_runtime_projection.provi
   =
   match profile.supported_models, profile.runtime_kind with
   | _ :: _ as models, _ -> Some models
-  | [], Provider_runtime_projection.Cli_agent -> Some [ "auto" ]
   | [], (Provider_runtime_projection.Local | Provider_runtime_projection.Direct_api) ->
     None
 ;;

--- a/lib/runtime_model/runtime_provider_binding.ml
+++ b/lib/runtime_model/runtime_provider_binding.ml
@@ -55,7 +55,6 @@ let binding_auth_is_no_auth (binding : Runtime_binding.t) =
   match binding.Runtime_binding.auth with
   | Runtime_binding.No_auth -> true
   | Runtime_binding.Api_key_env _
-  | Runtime_binding.Oauth_cached_login
   | Runtime_binding.Setup_token_env _ -> false
 ;;
 
@@ -67,11 +66,9 @@ let binding_base_url_is_loopback (binding : Runtime_binding.t) =
 ;;
 
 let runtime_kind_of_binding (binding : Runtime_binding.t) =
-  match binding.Runtime_binding.transport with
-  | Runtime_binding.Http | Runtime_binding.Managed ->
-    if binding_auth_is_no_auth binding && binding_base_url_is_loopback binding
-    then "local"
-    else "direct_api"
+  if binding_auth_is_no_auth binding && binding_base_url_is_loopback binding
+  then "local"
+  else "direct_api"
 ;;
 
 let is_binding_local_openai_runtime (binding : Runtime_binding.t) =

--- a/lib/runtime_model/runtime_provider_binding.mli
+++ b/lib/runtime_model/runtime_provider_binding.mli
@@ -36,7 +36,7 @@ val binding_auth_is_no_auth : Runtime_binding.t -> bool
 val binding_base_url_is_loopback : Runtime_binding.t -> bool
 
 val runtime_kind_of_binding : Runtime_binding.t -> string
-(** ["cli_agent"] | ["local"] | ["direct_api"]. *)
+(** ["local"] | ["direct_api"]. *)
 
 val default_local_openai_runtime_provider_id : unit -> string option
 


### PR DESCRIPTION
## Why

OAS v0.212.0 narrowed Provider_runtime_binding to its actual typed HTTP provider contract. MASC still matched removed OAuth, transport, and unreachable CLI projection variants.

## What

- exhaustively match No_auth, Api_key_env, and Setup_token_env
- preserve the existing no-auth + loopback local classification
- remove the transport match whose Http and Managed arms had identical behavior
- remove the unreachable Cli_agent projection and its dead consumers
- add no vendor, URL, command, or model-name inference

## Functional preservation

The old runtime_kind producer returned only Local or Direct_api for both old transport variants. No current MASC catalog row used oauth_cached_login, and OAS v0.212 rejects that retired catalog auth shape rather than disguising it as another credential.

## Verification

- git diff --check
- ocamlformat --check on all touched files
- focused runtime-model build passes the auth and transport boundary and advances to the independent inference-default/typed-endpoint migration

# ci:skip-test-coverage

This removes constructors that OAS v0.212 cannot produce. A fixture for those deleted constructors would preserve an obsolete contract.

Diff: 9 additions, 19 deletions.