### PR TITLE
fix(runtime): fail loud when checkpoint resume throws

### DIFF
--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -860,6 +860,11 @@ let decide_modality_reroute_for_runtime_candidates ~(assigned : Runtime.t)
        |> List.map (fun (runtime : Runtime.t) ->
          runtime.Runtime.id, input_capabilities_of_runtime runtime))
 
+let select_agent_result ~checkpoint ~resume ~build =
+  match checkpoint with
+  | Some checkpoint -> resume checkpoint
+  | None -> build ()
+
 module For_testing = struct
   let request_runtime_fields_on_base_config =
     request_runtime_fields_on_base_config
@@ -890,6 +895,7 @@ module For_testing = struct
     validate_content_blocks_against_capabilities
   let apply_runtime_model_input_capabilities =
     apply_runtime_model_input_capabilities
+  let select_agent_result = select_agent_result
 end
 
 (* ================================================================ *)
@@ -1170,16 +1176,12 @@ let run_blocks
   publish_lifecycle ~name:config.name ~event:"build" ~detail:goal_detail
     ~attrs:(provider_lifecycle_attrs config)
     ();
-  let agent_result = match oas_checkpoint with
-    | Some checkpoint ->
-      (try resume_from_checkpoint ~sw ~net ~config ~checkpoint
-       with
-       | Eio.Cancel.Cancelled _ as e -> raise e
-       | exn ->
-         Log.Misc.warn "oas_worker %s: resume_from_checkpoint failed (%s), falling back to build"
-           config.name (Printexc.to_string exn);
-         build ~sw ~net ~config)
-    | None -> build ~sw ~net ~config
+  let agent_result =
+    select_agent_result
+      ~checkpoint:oas_checkpoint
+      ~resume:(fun checkpoint ->
+        resume_from_checkpoint ~sw ~net ~config ~checkpoint)
+      ~build:(fun () -> build ~sw ~net ~config)
   in
   match agent_result with
   | Error e ->

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -363,6 +363,12 @@ module For_testing : sig
     Runtime_schema.model_capabilities ->
     Llm_provider.Capabilities.capabilities
 
+  val select_agent_result :
+    checkpoint:'checkpoint option ->
+    resume:('checkpoint -> 'result) ->
+    build:(unit -> 'result) ->
+    'result
+
   val runtime_observation_for_completed_config :
     total_duration_ms:float -> config -> Runtime_observation.runtime_observation
 

--- a/test/test_mid_turn_resume.ml
+++ b/test/test_mid_turn_resume.ml
@@ -7,6 +7,8 @@
 
 module Oas = Agent_sdk
 
+exception Resume_failed
+
 (* ================================================================ *)
 (* Helpers                                                          *)
 (* ================================================================ *)
@@ -138,6 +140,26 @@ let test_resume_preserves_checkpoint_model () =
   Alcotest.(check string) "resumed keeps checkpoint model" "anthropic-model"
     (Agent_sdk.Types.model_to_string state.config.model)
 
+(** A persisted checkpoint is authoritative. If resume fails before returning a
+    typed result, Runtime_agent must not hide the failure by creating a fresh
+    agent with an empty conversation. *)
+let test_resume_exception_does_not_build_fresh_agent () =
+  let build_calls = ref 0 in
+  let propagated =
+    match
+      Runtime_agent.For_testing.select_agent_result
+        ~checkpoint:(Some ())
+        ~resume:(fun () -> raise Resume_failed)
+        ~build:(fun () ->
+          incr build_calls;
+          `Fresh)
+    with
+    | exception Resume_failed -> true
+    | `Fresh -> false
+  in
+  Alcotest.(check bool) "resume exception propagated" true propagated;
+  Alcotest.(check int) "fresh build not attempted" 0 !build_calls
+
 (* ================================================================ *)
 (* Runner                                                           *)
 (* ================================================================ *)
@@ -155,5 +177,7 @@ let () =
         test_multi_runtime_accumulation;
       Alcotest.test_case "resume preserves checkpoint model" `Quick
         test_resume_preserves_checkpoint_model;
+      Alcotest.test_case "resume exception never falls back to fresh agent" `Quick
+        test_resume_exception_does_not_build_fresh_agent;
     ];
   ]


### PR DESCRIPTION
## Problem
A checkpoint resume exception was caught and silently replaced with a fresh agent build. That discarded the persisted conversation and made the visible request appear to vanish after a timeout or resume fault.

## Change
- select exactly one construction path: resume when a checkpoint exists, build only when it does not
- propagate resume exceptions instead of resurrecting an empty agent
- regression-test that the exception propagates and fresh build is never called

## Scope
3 files, +42/-10. No provider inference, retry heuristic, budget gate, string classification, or compatibility fallback.

## Validation
- ocamlformat: pass
- OCaml parse check: pass
- git diff --check: pass
- focused Dune: blocked before compilation because the shared opam switch is already pinned to OAS v0.212.0 while current MASC main declares v0.211.9; CI is the build authority for this slice.