### PR TITLE
refactor(runtime): make checkpoint sink the persistence SSOT

### DIFF
--- a/docs/spec/13-oas-integration.md
+++ b/docs/spec/13-oas-integration.md
@@ -128,7 +128,7 @@ type config = {
   context_reducer : Agent_sdk.Context_reducer.t option;
   guardrails : Agent_sdk.Guardrails.t option;
   event_bus : Agent_sdk.Event_bus.t option;
-  checkpoint_dir : string option;
+  checkpoint_sink : Agent_sdk.Agent.checkpoint_sink option;
   session_id : string option;
   description : string option;
   initial_messages : Agent_sdk.Types.message list;
@@ -148,7 +148,7 @@ run(~sw, ~net, ~config, goal) -> run_result
   2. Event_bus에 "build" 이벤트 publish
   3. Builder 패턴으로 Agent.t 구성
   4. Agent.run 또는 Agent.run_stream 호출
-  5. checkpoint 저장 (checkpoint_dir 설정 시)
+  5. OAS turn boundary에서 caller-owned checkpoint_sink 호출
   6. Event_bus에 "completed"/"failed" publish
   7. Agent.close
 ```

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -342,7 +342,6 @@ let run_named
     ?compact_ratio
     ?context_window_tokens
     ?(oas_auto_context_overflow_retry = true)
-    ?checkpoint_dir
     ?checkpoint_sink
     ?context_injector
     ?context
@@ -670,7 +669,6 @@ let run_named
             ; compact_ratio
             ; context_window_tokens
             ; oas_auto_context_overflow_retry
-            ; checkpoint_dir
             ; checkpoint_sink
             ; checkpoint_stage_observed
             ; context_injector

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -103,7 +103,6 @@ val run_named :
   ?compact_ratio:float ->
   ?context_window_tokens:int ->
   ?oas_auto_context_overflow_retry:bool ->
-  ?checkpoint_dir:string ->
   ?checkpoint_sink:Agent_sdk.Agent.checkpoint_sink ->
   ?context_injector:Agent_sdk.Hooks.context_injector ->
   ?context:Agent_sdk.Context.t ->

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -50,7 +50,6 @@ type try_provider_ctx =
   ; compact_ratio : float option
   ; context_window_tokens : int option
   ; oas_auto_context_overflow_retry : bool
-  ; checkpoint_dir : string option
   ; checkpoint_sink : Agent_sdk.Agent.checkpoint_sink option
   ; checkpoint_stage_observed : bool Atomic.t
   ; context_injector : Agent_sdk.Hooks.context_injector option
@@ -248,7 +247,6 @@ let run_try_provider
           ; compact_ratio = ctx.compact_ratio
           ; context_window_tokens = ctx.context_window_tokens
           ; oas_auto_context_overflow_retry = ctx.oas_auto_context_overflow_retry
-          ; checkpoint_dir = ctx.checkpoint_dir
           ; checkpoint_sink = Some checkpoint_sink
           ; context_injector = ctx.context_injector
           ; context = ctx.context

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -31,7 +31,6 @@ type try_provider_ctx =
   ; compact_ratio : float option
   ; context_window_tokens : int option
   ; oas_auto_context_overflow_retry : bool
-  ; checkpoint_dir : string option
   ; checkpoint_sink : Agent_sdk.Agent.checkpoint_sink option
   ; checkpoint_stage_observed : bool Atomic.t
   ; context_injector : Agent_sdk.Hooks.context_injector option

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -106,7 +106,6 @@ type config =
   context_reducer : Agent_sdk.Context_reducer.t option;
   guardrails : Agent_sdk.Guardrails.t option;
   event_bus : Agent_sdk.Event_bus.t option;
-  checkpoint_dir : string option;
   session_id : string option;
   description : string option;
   initial_messages : Agent_sdk.Types.message list;
@@ -938,9 +937,6 @@ end
 (* Internal: checkpoint persistence                                  *)
 (* ================================================================ *)
 
-let persist_checkpoint =
-  Runtime_oas_checkpoint.persist_checkpoint
-
 let build_checkpoint =
   Runtime_oas_checkpoint.build_checkpoint
 
@@ -1230,13 +1226,6 @@ let run_blocks
         build_checkpoint ~session_id
           ?checkpoint_sidecar:config.checkpoint_sidecar agent
       in
-      (match config.checkpoint_dir with
-       | Some dir ->
-         (match persist_checkpoint ~dir ~session_id ckpt with
-          | Ok () -> ()
-          | Error err ->
-            Log.Misc.error "oas_worker: %s" err)
-       | None -> ());
       Some ckpt
     in
     let lifecycle = worker_lifecycle_classification_of_result result in

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -14,7 +14,7 @@
     Internal helpers stay private at this boundary
     ([invalid_runtime_config],
     [provider_supports_inline_tools],
-    [persist_checkpoint], [build_checkpoint],
+    [build_checkpoint],
     [partial_response_of_stop]). *)
 
 (** {1 Stop reason} *)
@@ -84,7 +84,6 @@ type config = Runtime_agent_context.config = {
   context_reducer : Agent_sdk.Context_reducer.t option;
   guardrails : Agent_sdk.Guardrails.t option;
   event_bus : Agent_sdk.Event_bus.t option;
-  checkpoint_dir : string option;
   session_id : string option;
   description : string option;
   initial_messages : Agent_sdk.Types.message list;

--- a/lib/runtime/runtime_agent_context.ml
+++ b/lib/runtime/runtime_agent_context.ml
@@ -101,7 +101,6 @@ type config =
   ; context_reducer : Agent_sdk.Context_reducer.t option
   ; guardrails : Agent_sdk.Guardrails.t option
   ; event_bus : Agent_sdk.Event_bus.t option
-  ; checkpoint_dir : string option
   ; session_id : string option
   ; description : string option
   ; initial_messages : Agent_sdk.Types.message list
@@ -162,8 +161,7 @@ type config =
   ; checkpoint_sink : Agent_sdk.Agent.checkpoint_sink option
     (** Caller-owned turn-boundary checkpoint sink, forwarded to
         [Builder.with_checkpoint_sink]. Allows consumers to persist
-        checkpoints at OAS turn boundaries without the full
-        checkpoint_dir filesystem path. *)
+        checkpoints at OAS turn boundaries. *)
   }
 
 let default_config
@@ -194,7 +192,6 @@ let default_config
   ; context_reducer = None
   ; guardrails = None
   ; event_bus = None
-  ; checkpoint_dir = None
   ; session_id = None
   ; description = None
   ; initial_messages = []

--- a/lib/runtime/runtime_agent_context.mli
+++ b/lib/runtime/runtime_agent_context.mli
@@ -79,7 +79,6 @@ type config = {
   context_reducer : Agent_sdk.Context_reducer.t option;
   guardrails : Agent_sdk.Guardrails.t option;
   event_bus : Agent_sdk.Event_bus.t option;
-  checkpoint_dir : string option;
   session_id : string option;
   description : string option;
   initial_messages : Agent_sdk.Types.message list;

--- a/lib/runtime/runtime_oas_checkpoint.ml
+++ b/lib/runtime/runtime_oas_checkpoint.ml
@@ -31,27 +31,6 @@ let publish_lifecycle ~name ~event ~detail ?error ?session_id ?status
                    @ optional_string_field "status" status
                    @ attrs) )))
 
-let persist_checkpoint ~dir ~session_id (ckpt : Agent_sdk.Checkpoint.t)
-    : (unit, string) result =
-  let path = Filename.concat dir (session_id ^ ".json") in
-  try
-    Fs_compat.mkdir_p dir;
-    Result.map_error
-      (fun err ->
-         Printf.sprintf "checkpoint persist failed for %s: %s" session_id err)
-      (Fs_compat.save_file_atomic path (Agent_sdk.Checkpoint.to_string ckpt))
-  with
-  (* CancelledNeverAbsorbed (KeeperOASAdvanced.tla): re-raise [Cancelled]
-     before the catch-all so a cancelled checkpoint fiber propagates the
-     cancel to its parent switch instead of returning a normal [Error]
-     result.  Absorbing it would create the spec's "zombie" — the parent
-     believes the child completed cleanly while the cancel signal is lost.
-     Regression guard: test/test_oas_checkpoint_cancelled_never_absorbed.ml *)
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | exn ->
-    Error (Printf.sprintf "checkpoint persist failed for %s: %s"
-             session_id (Printexc.to_string exn))
-
 let build_checkpoint ~session_id ?checkpoint_sidecar (agent : Agent_sdk.Agent.t) =
   match checkpoint_sidecar with
   | None -> Agent_sdk.Agent.checkpoint ~session_id agent

--- a/lib/runtime/runtime_oas_checkpoint.mli
+++ b/lib/runtime/runtime_oas_checkpoint.mli
@@ -31,17 +31,6 @@ val publish_lifecycle :
     non-sensitive structured runtime metadata such as provider
     kind, model, and endpoint path. *)
 
-val persist_checkpoint :
-  dir:string ->
-  session_id:string ->
-  Agent_sdk.Checkpoint.t ->
-  (unit, string) result
-(** Serialise [ckpt] via [Agent_sdk.Checkpoint.to_string] and write it
-    atomically (tmp → fsync → rename) to [<dir>/<session_id>.json].
-    Returns [Error msg] on I/O failure instead of raising.
-    The parent [dir] is created via [Fs_compat.mkdir_p] before
-    the write. *)
-
 val build_checkpoint :
   session_id:string ->
   ?checkpoint_sidecar:Yojson.Safe.t ->

--- a/test/test_oas_worker_exec_checkpoint.ml
+++ b/test/test_oas_worker_exec_checkpoint.ml
@@ -1,87 +1,9 @@
-(** IR-3 — checkpoint save error promotion.
-
-    [persist_checkpoint] now returns [(unit, string) result] instead of
-    raising.  This test pins:
-    1. A successful write returns [Ok ()] and the file exists on disk.
-    2. A write to a read-only directory returns [Error _], not an
-       exception. *)
+(** Runtime lifecycle observations emitted alongside OAS checkpoints. *)
 
 open Masc
 open Alcotest
 
 module CP = Runtime_oas_checkpoint
-
-let rec rm_rf path =
-  if Sys.file_exists path then
-    if Sys.is_directory path then (
-      Array.iter (fun name -> rm_rf (Filename.concat path name)) (Sys.readdir path);
-      try Unix.rmdir path with Sys_error _ -> ())
-    else
-      try Unix.unlink path with Sys_error _ -> ()
-
-let with_tmp_dir f =
-  let dir =
-    Filename.get_temp_dir_name () ^ "/ir3-test-" ^ string_of_int (Random.int 1000000)
-  in
-  Fs_compat.mkdir_p dir;
-  Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
-
-let dummy_checkpoint : Agent_sdk.Checkpoint.t =
-  {
-    Agent_sdk.Checkpoint.version = Agent_sdk.Checkpoint.checkpoint_version;
-    session_id = "ir3-test";
-    agent_name = "test-worker";
-    model = "";
-    system_prompt = None;
-    messages = [];
-    usage = Agent_sdk.Types.empty_usage;
-    turn_count = 0;
-    created_at = 0.0;
-    tools = [];
-    tool_choice = None;
-    disable_parallel_tool_use = false;
-    temperature = None;
-    top_p = None;
-    top_k = None;
-    min_p = None;
-    enable_thinking = None;
-    preserve_thinking = None;
-    response_format = Agent_sdk.Types.Off;
-    thinking_budget = None;
-    cache_system_prompt = false;
-
-    context = Agent_sdk.Context.create_sync ();
-    mcp_sessions = [];
-    working_context = None;
-  }
-
-let test_persist_checkpoint_ok () =
-  with_tmp_dir (fun dir ->
-    let result = CP.persist_checkpoint ~dir ~session_id:"s1" dummy_checkpoint in
-    check bool "persist returns Ok" true (Result.is_ok result);
-    let path = Filename.concat dir "s1.json" in
-    check bool "file exists on disk" true (Sys.file_exists path))
-
-let test_persist_checkpoint_error_on_readonly () =
-  let dir =
-    Filename.get_temp_dir_name () ^ "/ir3-ro-" ^ string_of_int (Random.int 1000000)
-  in
-  Fs_compat.mkdir_p dir;
-  Unix.chmod dir 0o444;
-  let result =
-    try CP.persist_checkpoint ~dir ~session_id:"s2" dummy_checkpoint
-    with exn ->
-      Unix.chmod dir 0o755;
-      rm_rf dir;
-      failf "persist_checkpoint raised unexpectedly: %s" (Printexc.to_string exn)
-  in
-  Unix.chmod dir 0o755;
-  rm_rf dir;
-  check bool "persist returns Error on read-only dir" true (Result.is_error result);
-  let err = Result.get_error result in
-  check bool "error message mentions session" true
-    (try ignore (Str.search_forward (Str.regexp "s2") err 0); true
-     with Not_found -> false)
 
 let custom_payload_fields expected_topic (event : Agent_sdk.Event_bus.event) =
   match event.payload with
@@ -145,12 +67,6 @@ let test_publish_lifecycle_reaches_masc_bus_with_max_tokens_intent () =
 let () =
   run "oas_worker_exec_checkpoint"
     [
-      ( "persist_checkpoint",
-        [
-          test_case "Ok on writable dir" `Quick test_persist_checkpoint_ok;
-          test_case "Error on read-only dir (IR-3)"
-            `Quick test_persist_checkpoint_error_on_readonly;
-        ] );
       ( "runtime_lifecycle",
         [
           test_case


### PR DESCRIPTION
## What
- remove the unused `checkpoint_dir` carrier from the MASC runtime/keeper path
- remove the duplicate post-run filesystem persistence path
- keep the caller-owned OAS turn-boundary `checkpoint_sink` as the sole persistence owner
- update the OAS integration spec and retire tests for the deleted persistence helper

## Why
The removed `checkpoint_dir` had no call sites. Runtime persistence already belongs to the Keeper-supplied `checkpoint_sink`; retaining a second best-effort write created duplicate ownership and logged an I/O error while the turn still returned success.

## Validation
- `ocamlformat -i` on changed OCaml files
- `ocamlc -stop-after parsing` on changed OCaml files
- `git diff --check`
- focused `scripts/dune-local.sh build test/test_oas_worker_exec_checkpoint.exe` reached the repository pin guard and stopped because the shared switch is on OAS v0.212.0 (`b02bc16...`) while current MASC main still expects v0.211.9 (`902c45d...`); CI is the build authority

## Scope
12 files, 5 insertions, 143 deletions. No compatibility path or replacement heuristic.