### PR TITLE
feat(dashboard): salvage typed Registry surface from #24364

### DIFF
--- a/dashboard/src/api/schemas/persona.test.ts
+++ b/dashboard/src/api/schemas/persona.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  parsePersonaListResponse,
+  PersonaCountMismatchError,
+  PersonaSchemaDriftError,
+} from './persona'
+
+const detailedPersona = {
+  persona_name: 'sonsukku',
+  display_name: '손석구',
+  role: 'reviewer',
+  trait: '집요함',
+  profile_path: '/personas/sonsukku/profile.json',
+  has_keeper_defaults: true,
+}
+
+describe('parsePersonaListResponse', () => {
+  it('decodes the detailed backend contract without compatibility aliases', () => {
+    expect(parsePersonaListResponse({ count: 1, personas: [detailedPersona] })).toEqual({
+      count: 1,
+      personas: [detailedPersona],
+    })
+  })
+
+  it.each([
+    { count: 1, personas: ['sonsukku'] },
+    { count: 1, personas: [{ ...detailedPersona, persona_name: '' }] },
+    { count: 1, personas: [{ ...detailedPersona, has_keeper_defaults: 'yes' }] },
+    { count: 0, personas: 'not-an-array' },
+  ])('rejects malformed or legacy payloads: %j', payload => {
+    expect(() => parsePersonaListResponse(payload)).toThrow(PersonaSchemaDriftError)
+  })
+
+  it('rejects a declared count that disagrees with the decoded roster', () => {
+    expect(() => parsePersonaListResponse({ count: 2, personas: [detailedPersona] }))
+      .toThrow(PersonaCountMismatchError)
+  })
+
+  it('distinguishes an empty detailed roster from schema drift', () => {
+    expect(parsePersonaListResponse({ count: 0, personas: [] })).toEqual({
+      count: 0,
+      personas: [],
+    })
+  })
+})

--- a/dashboard/src/api/schemas/persona.ts
+++ b/dashboard/src/api/schemas/persona.ts
@@ -1,0 +1,64 @@
+import {
+  array,
+  boolean,
+  integer,
+  minValue,
+  nonEmpty,
+  nullable,
+  number,
+  object,
+  pipe,
+  string,
+  type BaseIssue,
+  type InferOutput,
+} from 'valibot'
+
+import { parseOrThrow, SchemaDriftError } from './drift-error'
+
+const NonEmptyStringSchema = pipe(string(), nonEmpty())
+
+export const PersonaSummarySchema = object({
+  persona_name: NonEmptyStringSchema,
+  display_name: NonEmptyStringSchema,
+  role: nullable(string()),
+  trait: nullable(string()),
+  profile_path: NonEmptyStringSchema,
+  has_keeper_defaults: boolean(),
+})
+
+export const PersonaListResponseSchema = object({
+  count: pipe(number(), integer(), minValue(0)),
+  personas: array(PersonaSummarySchema),
+})
+
+export type PersonaSummary = Readonly<InferOutput<typeof PersonaSummarySchema>>
+export type PersonaListResponse = Readonly<{
+  count: number
+  personas: readonly PersonaSummary[]
+}>
+
+export class PersonaSchemaDriftError extends SchemaDriftError {
+  constructor(issues: readonly BaseIssue<unknown>[]) {
+    super('persona list', issues)
+  }
+}
+
+export class PersonaCountMismatchError extends Error {
+  readonly declaredCount: number
+  readonly decodedCount: number
+
+  constructor(declaredCount: number, decodedCount: number) {
+    super(`persona list count mismatch: declared ${declaredCount}, decoded ${decodedCount}`)
+    this.name = 'PersonaCountMismatchError'
+    this.declaredCount = declaredCount
+    this.decodedCount = decodedCount
+  }
+}
+
+export function parsePersonaListResponse(data: unknown): PersonaListResponse {
+  const parsed = parseOrThrow(PersonaSchemaDriftError, PersonaListResponseSchema, data)
+  if (parsed.count !== parsed.personas.length) {
+    throw new PersonaCountMismatchError(parsed.count, parsed.personas.length)
+  }
+  return parsed
+}

--- a/dashboard/src/components/copilot-dock.ts
+++ b/dashboard/src/components/copilot-dock.ts
@@ -176,6 +176,7 @@ export function getSurfaceContext(selectedKeeperId?: string | null): SurfaceCont
       ]
       break
     case 'fusion':
+    case 'registry':
     case 'settings':
       base.fields = fleetFields
       break

--- a/dashboard/src/components/dashboard-shell-tab-surface.test.ts
+++ b/dashboard/src/components/dashboard-shell-tab-surface.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import { VALID_TABS } from '../types'
+import { TAB_SURFACE } from './dashboard-shell'
+
+describe('TAB_SURFACE', () => {
+  it('resolves every routable tab to a dedicated component and label', () => {
+    const components = VALID_TABS.map(tab => {
+      const surface = TAB_SURFACE[tab]
+      expect(surface.label.length).toBeGreaterThan(0)
+      expect(surface.Component).toBeTypeOf('function')
+      return surface.Component
+    })
+
+    expect(new Set(components).size).toBe(VALID_TABS.length)
+  })
+
+  it('cannot alias an unknown tab to Overview', () => {
+    const overview = TAB_SURFACE.overview.Component
+    for (const tab of VALID_TABS) {
+      if (tab !== 'overview') expect(TAB_SURFACE[tab].Component).not.toBe(overview)
+    }
+  })
+})

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -1,6 +1,7 @@
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { lazy, Suspense } from 'preact/compat'
+import type { ComponentType } from 'preact'
 import { useEffect, useMemo } from 'preact/hooks'
 import type { GroundedVerdict, RouteState, TabId } from '../types'
 import type { DashboardCdalHealth, DashboardFleetSafetyHealth, DashboardKeeperReactionLedgerHealth, DashboardRuntimeResolution, Keeper } from '../types'
@@ -80,6 +81,7 @@ const LazyIdeShell = lazy(async () => ({ default: (await import('./ide/ide-shell
 const LazyCockpit = lazy(async () => ({ default: (await import('./cockpit/cockpit')).Cockpit }))
 const LazySettingsSurface = lazy(async () => ({ default: (await import('./settings-surface')).SettingsSurface }))
 const LazyApprovals = lazy(async () => ({ default: (await import('./approvals/approvals-surface')).ApprovalsSurface }))
+const LazyRegistrySurface = lazy(async () => ({ default: (await import('./registry/registry-surface')).RegistrySurface }))
 const LazyFusionSurface = lazy(async () => ({ default: (await import('./fusion/fusion-surface')).FusionSurface }))
 
 function lazyTabFallback(label: string) {
@@ -1208,107 +1210,34 @@ export function SideRail({
   `
 }
 
-function TabContent() {
-  const tab = route.value.tab
+export const TAB_SURFACE: Readonly<
+  Record<TabId, { readonly label: string; readonly Component: ComponentType }>
+> = {
+  cockpit: { label: 'Cockpit', Component: LazyCockpit },
+  overview: { label: 'Overview', Component: LazyOverview },
+  monitoring: { label: 'Monitor', Component: LazyStatus },
+  keepers: { label: 'Keepers', Component: LazyKeeperDetailPage },
+  registry: { label: 'Registry', Component: LazyRegistrySurface },
+  board: { label: 'Board', Component: LazyBoardSurface },
+  schedule: { label: 'Schedule', Component: LazyScheduleSurface },
+  fusion: { label: 'Fusion', Component: LazyFusionSurface },
+  command: { label: 'Command', Component: LazyOperations },
+  connectors: { label: 'Connectors', Component: LazyConnectors },
+  workspace: { label: 'Work', Component: LazyWork },
+  lab: { label: 'Lab', Component: LazyLabSurface },
+  code: { label: 'Code IDE', Component: LazyIdeShell },
+  logs: { label: 'System Logs', Component: LazyLogViewer },
+  settings: { label: 'Settings', Component: LazySettingsSurface },
+  approvals: { label: 'Approvals', Component: LazyApprovals },
+}
 
-  switch (tab) {
-    case 'overview':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Overview')}>
-          <${LazyOverview} />
-        <//>
-      `
-    case 'monitoring':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Monitor')}>
-          <${LazyStatus} />
-        <//>
-      `
-    case 'keepers':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Keepers')}>
-          <${LazyKeeperDetailPage} />
-        <//>
-      `
-    case 'board':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Board')}>
-          <${LazyBoardSurface} />
-        <//>
-      `
-    case 'schedule':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Schedule')}>
-          <${LazyScheduleSurface} />
-        <//>
-      `
-    case 'approvals':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Approvals')}>
-          <${LazyApprovals} />
-        <//>
-      `
-    case 'fusion':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Fusion')}>
-          <${LazyFusionSurface} />
-        <//>
-      `
-    case 'workspace':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Work')}>
-          <${LazyWork} />
-        <//>
-      `
-    case 'command':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Command')}>
-          <${LazyOperations} />
-        <//>
-      `
-    case 'connectors':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Connectors')}>
-          <${LazyConnectors} />
-        <//>
-      `
-    case 'lab':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Lab')}>
-          <${LazyLabSurface} />
-        <//>
-      `
-    case 'cockpit':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Cockpit')}>
-          <${LazyCockpit} />
-        <//>
-      `
-    case 'code':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Code IDE')}>
-          <${LazyIdeShell} />
-        <//>
-      `
-    case 'logs':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('System Logs')}>
-          <${LazyLogViewer} />
-        <//>
-      `
-    case 'settings':
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Settings')}>
-          <${LazySettingsSurface} />
-        <//>
-      `
-    default:
-      return html`
-        <${Suspense} fallback=${lazyTabFallback('Overview')}>
-          <${LazyOverview} />
-        <//>
-      `
-  }
+function TabContent() {
+  const { label, Component } = TAB_SURFACE[route.value.tab]
+  return html`
+    <${Suspense} fallback=${lazyTabFallback(label)}>
+      <${Component} />
+    <//>
+  `
 }
 
 /** Pure: build the shareable URL for the current section. Uses

--- a/dashboard/src/components/keeper-spawn/keeper-spawn-state.test.ts
+++ b/dashboard/src/components/keeper-spawn/keeper-spawn-state.test.ts
@@ -21,8 +21,8 @@ vi.mock('../../store', () => ({
 import {
   createPersona,
   deletePersona,
-  normalizePersonaSummaries,
-  normalizePersonaSummary,
+  loadPersonas,
+  personasResource,
   spawnKeeperFromPersona,
   spawnResult,
   updatePersona,
@@ -30,64 +30,41 @@ import {
 
 afterEach(() => {
   spawnResult.value = null
+  personasResource.reset()
   vi.clearAllMocks()
 })
 
-describe('normalizePersonaSummary', () => {
-  it('accepts backend persona summary fields and keeps the handle for spawning', () => {
-    expect(
-      normalizePersonaSummary({
-        persona_name: 'sonsukku',
-        display_name: '손석구',
-        role: '무심한 로코형 동네 형',
-        trait: '건조한 농담과 낮은 텐션',
-      }),
-    ).toEqual({
-      name: 'sonsukku',
-      displayName: '손석구',
-      role: '무심한 로코형 동네 형',
-      mode: undefined,
-      description: '건조한 농담과 낮은 텐션',
+describe('loadPersonas', () => {
+  it('requests and stores only the detailed backend contract', async () => {
+    callMcpTool.mockResolvedValue(JSON.stringify({
+      count: 1,
+      personas: [{
+        persona_name: 'reviewer',
+        display_name: 'Reviewer',
+        role: null,
+        trait: 'strict',
+        profile_path: '/personas/reviewer/profile.json',
+        has_keeper_defaults: true,
+      }],
+    }))
+
+    await loadPersonas()
+
+    expect(callMcpTool).toHaveBeenCalledWith('masc_persona_list', { detailed: true })
+    expect(personasResource.state.value).toMatchObject({
+      status: 'loaded',
+      data: [{ persona_name: 'reviewer', has_keeper_defaults: true }],
     })
   })
 
-  it('falls back to existing dashboard-shaped fields when they already match', () => {
-    expect(
-      normalizePersonaSummary({
-        name: 'sangsu',
-        displayName: '상수',
-        role: '찌질한 영화감독',
-        description: '직설적이고 현실 감각 있는 동네 형',
-      }),
-    ).toEqual({
-      name: 'sangsu',
-      displayName: '상수',
-      role: '찌질한 영화감독',
-      mode: undefined,
-      description: '직설적이고 현실 감각 있는 동네 형',
-    })
-  })
-})
+  it('surfaces malformed entries through the resource error state', async () => {
+    callMcpTool.mockResolvedValue(JSON.stringify({ count: 1, personas: ['legacy-name'] }))
 
-describe('normalizePersonaSummaries', () => {
-  it('reads both wrapped and bare arrays and filters invalid entries', () => {
-    expect(
-      normalizePersonaSummaries({
-        personas: [
-          { persona_name: 'sonsukku', display_name: '손석구' },
-          { name: '' },
-          'skip-me',
-        ],
-      }),
-    ).toEqual([
-      {
-        name: 'sonsukku',
-        displayName: '손석구',
-        role: undefined,
-        mode: undefined,
-        description: undefined,
-      },
-    ])
+    await loadPersonas()
+
+    expect(personasResource.state.value).toMatchObject({
+      status: 'error',
+    })
   })
 })
 

--- a/dashboard/src/components/keeper-spawn/keeper-spawn-state.ts
+++ b/dashboard/src/components/keeper-spawn/keeper-spawn-state.ts
@@ -1,42 +1,18 @@
 import { signal, computed } from '@preact/signals'
 import { callMcpTool } from '../../api/mcp'
-import { asString, extractArray, isRecord } from '../common/normalize'
 import { showToast } from '../common/toast'
 import { createAsyncResource, getData } from '../../lib/async-state'
 import { refreshExecution, shellAuthSummary } from '../../store'
 import { dashboardAuthAccess } from '../../lib/dashboard-auth-access'
 import { errorToString } from '../../lib/format-string'
+import {
+  parsePersonaListResponse,
+  type PersonaSummary,
+} from '../../api/schemas/persona'
 
-export interface PersonaSummary {
-  name: string
-  displayName?: string
-  role?: string
-  mode?: string
-  description?: string
-}
+export type { PersonaSummary } from '../../api/schemas/persona'
 
-export function normalizePersonaSummary(raw: unknown): PersonaSummary | null {
-  if (!isRecord(raw)) return null
-
-  const name = asString(raw.persona_name) ?? asString(raw.name)
-  if (!name) return null
-
-  return {
-    name,
-    displayName: asString(raw.display_name) ?? asString(raw.displayName) ?? asString(raw.name),
-    role: asString(raw.role),
-    mode: asString(raw.mode),
-    description: asString(raw.description) ?? asString(raw.trait),
-  }
-}
-
-export function normalizePersonaSummaries(raw: unknown): PersonaSummary[] {
-  return extractArray(raw, ['personas'])
-    .map(normalizePersonaSummary)
-    .filter((persona): persona is PersonaSummary => persona !== null)
-}
-
-const personasResource = createAsyncResource<PersonaSummary[]>()
+export const personasResource = createAsyncResource<readonly PersonaSummary[]>()
 
 export const personas = computed(() => getData(personasResource.state.value) ?? [])
 export const personasLoading = computed(() => personasResource.state.value.status === 'loading')
@@ -47,10 +23,8 @@ export const personasError = computed<string | null>(() => {
 
 export async function loadPersonas(): Promise<void> {
   await personasResource.load(async () => {
-    const raw = await callMcpTool('masc_persona_list', {})
-    return normalizePersonaSummaries(JSON.parse(raw))
-  }).catch(() => {
-    showToast('페르소나 목록 로드 실패', 'error')
+    const raw = await callMcpTool('masc_persona_list', { detailed: true })
+    return parsePersonaListResponse(JSON.parse(raw)).personas
   })
 }
 

--- a/dashboard/src/components/keeper-spawn/persona-browser.test.ts
+++ b/dashboard/src/components/keeper-spawn/persona-browser.test.ts
@@ -16,13 +16,29 @@ vi.mock('../../lib/dashboard-auth-access', () => ({
 import { filterPersonas } from './persona-browser'
 import type { PersonaSummary } from './keeper-spawn-state'
 
+function persona(
+  persona_name: string,
+  display_name: string,
+  role: string | null,
+  trait: string | null,
+): PersonaSummary {
+  return {
+    persona_name,
+    display_name,
+    role,
+    trait,
+    profile_path: `/personas/${persona_name}/profile.json`,
+    has_keeper_defaults: false,
+  }
+}
+
 const sample: PersonaSummary[] = [
-  { name: 'analyst',  displayName: 'Analyst',  role: 'analysis',  mode: 'observer', description: 'inspects harness metrics' },
-  { name: 'executor', displayName: 'Executor', role: 'action',    mode: 'writer',   description: 'runs code edits' },
-  { name: 'scholar',  displayName: 'Scholar',  role: 'research',  mode: 'observer', description: 'reads papers and memory' },
-  { name: 'verifier', displayName: 'Verifier', role: 'guard',     mode: 'checker',  description: 'validates outputs' },
-  { name: 'uranium666', role: 'lab', description: 'experimental sandbox persona' },
-  { name: 'bare-persona' },
+  persona('analyst', 'Analyst', 'analysis', 'inspects harness metrics'),
+  persona('executor', 'Executor', 'action', 'runs code edits'),
+  persona('scholar', 'Scholar', 'research', 'reads papers and memory'),
+  persona('verifier', 'Verifier', 'guard', 'validates outputs'),
+  persona('uranium666', 'Uranium 666', 'lab', 'experimental sandbox persona'),
+  persona('bare-persona', 'Bare Persona', null, null),
 ]
 
 describe('filterPersonas', () => {
@@ -33,41 +49,36 @@ describe('filterPersonas', () => {
 
   it('matches case-insensitive substring on name', () => {
     const out = filterPersonas(sample, 'URANIUM')
-    expect(out.map(p => p.name)).toEqual(['uranium666'])
+    expect(out.map(p => p.persona_name)).toEqual(['uranium666'])
   })
 
-  it('matches on displayName', () => {
+  it('matches on display_name', () => {
     const out = filterPersonas(sample, 'Scholar')
-    expect(out.map(p => p.name)).toEqual(['scholar'])
+    expect(out.map(p => p.persona_name)).toEqual(['scholar'])
   })
 
   it('matches on role', () => {
     const out = filterPersonas(sample, 'research')
-    expect(out.map(p => p.name)).toEqual(['scholar'])
+    expect(out.map(p => p.persona_name)).toEqual(['scholar'])
   })
 
-  it('matches on mode', () => {
-    const out = filterPersonas(sample, 'observer')
-    expect(out.map(p => p.name)).toEqual(['analyst', 'scholar'])
-  })
-
-  it('matches on description', () => {
+  it('matches on trait', () => {
     const out = filterPersonas(sample, 'papers')
-    expect(out.map(p => p.name)).toEqual(['scholar'])
+    expect(out.map(p => p.persona_name)).toEqual(['scholar'])
   })
 
   it('trims surrounding whitespace before matching', () => {
     const out = filterPersonas(sample, '  action  ')
-    expect(out.map(p => p.name)).toEqual(['executor'])
+    expect(out.map(p => p.persona_name)).toEqual(['executor'])
   })
 
   it('returns empty array when nothing matches', () => {
     expect(filterPersonas(sample, 'no-such-token-xyz')).toEqual([])
   })
 
-  it('tolerates personas missing optional fields', () => {
+  it('matches entries whose nullable fields are absent', () => {
     const out = filterPersonas(sample, 'bare')
-    expect(out.map(p => p.name)).toEqual(['bare-persona'])
+    expect(out.map(p => p.persona_name)).toEqual(['bare-persona'])
   })
 
   it('does not mutate the input array', () => {
@@ -77,7 +88,7 @@ describe('filterPersonas', () => {
   })
 
   it('returns a fresh array (not the input) when filtering narrows rows', () => {
-    const out = filterPersonas(sample, 'observer')
+    const out = filterPersonas(sample, 'analysis')
     expect(out).not.toBe(sample)
     expect(out.length).toBeLessThan(sample.length)
   })

--- a/dashboard/src/components/keeper-spawn/persona-browser.ts
+++ b/dashboard/src/components/keeper-spawn/persona-browser.ts
@@ -18,11 +18,11 @@ function beginEdit(persona: PersonaSummary): void {
 async function confirmDelete(persona: PersonaSummary): Promise<void> {
   const confirmed = await requestConfirm({
     title: '페르소나 삭제',
-    message: `${persona.displayName ?? persona.name} 페르소나를 삭제합니까? 이 작업은 되돌릴 수 없습니다.`,
+    message: `${persona.display_name} 페르소나를 삭제합니까? 이 작업은 되돌릴 수 없습니다.`,
     tone: 'danger',
   })
   if (!confirmed) return
-  await deletePersona(persona.name)
+  await deletePersona(persona.persona_name)
 }
 
 const confirmTarget = signal<string | null>(null)
@@ -31,8 +31,8 @@ const searchQuery = signal('')
 /**
  * Pure filter for persona rows.
  *
- * - `query` is case-insensitive substring match across `name`, `displayName`,
- *   `role`, `mode`, and `description` (trimmed).
+ * - `query` is case-insensitive substring match across the detailed backend
+ *   fields `persona_name`, `display_name`, `role`, and `trait` (trimmed).
  * - Empty/whitespace-only query returns the input reference unchanged
  *   (zero-allocation fast path).
  * - Does not mutate the input array.
@@ -44,26 +44,24 @@ export function filterPersonas(
   const needle = query.trim().toLowerCase()
   if (needle === '') return rows
   return rows.filter(p => {
-    if (p.name.toLowerCase().includes(needle)) return true
-    if (p.displayName && p.displayName.toLowerCase().includes(needle)) return true
+    if (p.persona_name.toLowerCase().includes(needle)) return true
+    if (p.display_name.toLowerCase().includes(needle)) return true
     if (p.role && p.role.toLowerCase().includes(needle)) return true
-    if (p.mode && p.mode.toLowerCase().includes(needle)) return true
-    if (p.description && p.description.toLowerCase().includes(needle)) return true
+    if (p.trait && p.trait.toLowerCase().includes(needle)) return true
     return false
   })
 }
 
 function PersonaCard({ persona }: { persona: PersonaSummary }) {
-  const isConfirming = confirmTarget.value === persona.name
+  const isConfirming = confirmTarget.value === persona.persona_name
   const isSpawning = spawning.value && isConfirming
   const spawnAccess = dashboardAuthAccess(shellAuthSummary.value, 'worker')
-  const title = persona.displayName ?? persona.name
+  const title = persona.display_name
   return html`
     <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] p-4 flex flex-col gap-2 min-w-45 v2-monitoring-card">
       <div class="text-base text-[var(--color-fg-secondary)] font-medium">${title}</div>
       ${persona.role ? html`<div class="text-2xs text-[var(--color-fg-muted)]">${persona.role}</div>` : null}
-      ${persona.mode ? html`<div class="text-3xs text-[var(--color-fg-muted)]">모드: ${persona.mode}</div>` : null}
-      ${persona.description ? html`<div class="text-2xs text-[var(--color-fg-primary)] mt-1 line-clamp-2">${persona.description}</div>` : null}
+      ${persona.trait ? html`<div class="text-2xs text-[var(--color-fg-primary)] mt-1 line-clamp-2">${persona.trait}</div>` : null}
       <div class="mt-auto pt-2 flex flex-col gap-1.5">
         <div class="flex gap-1.5">
           <${ActionButton} variant="ghost" size="sm" disabled=${!spawnAccess.allowed}
@@ -79,7 +77,7 @@ function PersonaCard({ persona }: { persona: PersonaSummary }) {
             <div class="flex gap-1.5">
               <${ActionButton} variant="primary" size="sm" disabled=${isSpawning || !spawnAccess.allowed}
                 title=${spawnAccess.allowed ? undefined : spawnAccess.reason ?? undefined}
-                onClick=${() => { void spawnKeeperFromPersona(persona.name).then(() => { confirmTarget.value = null }) }}>
+                onClick=${() => { void spawnKeeperFromPersona(persona.persona_name).then(() => { confirmTarget.value = null }) }}>
                 ${isSpawning ? '생성 중...' : '시작'}<//>
               <${ActionButton} variant="ghost" size="sm" onClick=${() => { confirmTarget.value = null }}>취소<//>
             </div>
@@ -91,7 +89,7 @@ function PersonaCard({ persona }: { persona: PersonaSummary }) {
             block=${true}
             disabled=${!spawnAccess.allowed}
             title=${spawnAccess.allowed ? undefined : spawnAccess.reason ?? undefined}
-            onClick=${() => { confirmTarget.value = persona.name }}
+            onClick=${() => { confirmTarget.value = persona.persona_name }}
           >키퍼 시작<//>
         `}
       </div>
@@ -143,7 +141,7 @@ export function PersonaBrowser() {
         ? html`<p class="text-xs text-[var(--color-fg-muted)] py-4 v2-monitoring-row">검색 조건에 맞는 페르소나가 없습니다.</p>`
         : html`
           <div class="grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] gap-3 v2-monitoring-row">
-            ${visible.map(p => html`<${PersonaCard} key=${p.name} persona=${p} />`)}
+            ${visible.map(p => html`<${PersonaCard} key=${p.persona_name} persona=${p} />`)}
           </div>
         `}
       ${spawnResult.value ? html`

--- a/dashboard/src/components/keeper-spawn/persona-form.test.ts
+++ b/dashboard/src/components/keeper-spawn/persona-form.test.ts
@@ -35,11 +35,12 @@ describe('PersonaForm', () => {
 
   it('returns non-null when editingPersona is set', () => {
     editingPersona.value = {
-      name: 'test-persona',
-      displayName: 'Test',
+      persona_name: 'test-persona',
+      display_name: 'Test',
       role: 'reviewer',
-      mode: 'chat',
-      description: 'test',
+      trait: 'test',
+      profile_path: '/personas/test-persona/profile.json',
+      has_keeper_defaults: true,
     }
     const result = PersonaForm()
     expect(result).not.toBeNull()

--- a/dashboard/src/components/keeper-spawn/persona-form.ts
+++ b/dashboard/src/components/keeper-spawn/persona-form.ts
@@ -69,10 +69,10 @@ function initEdit(persona: PersonaSummary): void {
   // keeper-template fields start blank (blank = keep current on update).
   formFields.value = {
     ...emptyForm(),
-    persona_name: persona.name,
-    display_name: persona.displayName ?? '',
+    persona_name: persona.persona_name,
+    display_name: persona.display_name,
     role: persona.role ?? '',
-    trait: persona.description ?? '',
+    trait: persona.trait ?? '',
   }
   nameError.value = null
   displayNameError.value = null
@@ -129,7 +129,7 @@ async function handleSubmit(e: Event): Promise<void> {
 
   let ok: boolean
   if (editing) {
-    ok = await updatePersona(editing.name, shared)
+    ok = await updatePersona(editing.persona_name, shared)
   } else {
     // proactive_enabled has no blank state, so it is only set on create.
     ok = await createPersona({
@@ -173,7 +173,7 @@ export function PersonaForm(): any {
 
   if (!isVisible) return null
 
-  const editKey = editing ? editing.name : '__create__'
+  const editKey = editing ? editing.persona_name : '__create__'
   if (editKey !== lastEditKey) {
     lastEditKey = editKey
     if (editing) {
@@ -185,7 +185,7 @@ export function PersonaForm(): any {
 
   const f = formFields.value
   const title = isEdit
-    ? `페르소나 편집: ${editing!.displayName ?? editing!.name}`
+    ? `페르소나 편집: ${editing!.display_name}`
     : '새 페르소나 생성'
 
   const sectionLabel = (text: string) => html`

--- a/dashboard/src/components/registry/registry-surface.test.ts
+++ b/dashboard/src/components/registry/registry-surface.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Keeper } from '../../types'
+import { buildCompositeByKeeperKey } from '../../composite-signals'
+import { groupRegistryKeepers, keeperGroup } from './registry-surface'
+
+function keeper(overrides: Partial<Keeper> = {}): Keeper {
+  return { name: 'keeper', status: 'idle', ...overrides }
+}
+
+describe('keeperGroup', () => {
+  it('projects the canonical operational-state variants without a parallel lifecycle heuristic', () => {
+    expect(keeperGroup(keeper(), null)).toBe('running')
+    expect(keeperGroup(keeper({ paused: true }), null)).toBe('paused')
+    expect(keeperGroup(keeper({ status: 'unbooted' }), null)).toBe('offline')
+    expect(keeperGroup(keeper({ runtime_blocker_class: 'runtime_exhausted' }), null)).toBe('stuck')
+  })
+})
+
+describe('groupRegistryKeepers', () => {
+  it('places every keeper in exactly one group', () => {
+    const roster = [
+      keeper({ name: 'running' }),
+      keeper({ name: 'paused', paused: true }),
+      keeper({ name: 'offline', status: 'unbooted' }),
+      keeper({ name: 'stuck', runtime_blocker_class: 'runtime_exhausted' }),
+    ]
+    const grouped = groupRegistryKeepers(roster, buildCompositeByKeeperKey(null))
+    const names = Object.values(grouped).flatMap(rows => rows.map(row => row.keeper.name))
+
+    expect(names.sort()).toEqual(roster.map(row => row.name).sort())
+    expect(new Set(names).size).toBe(roster.length)
+  })
+})

--- a/dashboard/src/components/registry/registry-surface.ts
+++ b/dashboard/src/components/registry/registry-surface.ts
@@ -1,0 +1,174 @@
+import { html } from 'htm/preact'
+import { useEffect, useMemo } from 'preact/hooks'
+
+import type { Keeper } from '../../types'
+import {
+  buildCompositeByKeeperKey,
+  fleetCompositeSnapshot,
+} from '../../composite-signals'
+import { compositeSnapshotForKeeper } from '../../lib/keeper-composite-lookup'
+import {
+  deriveKeeperOperationalState,
+  type KeeperOperationalState,
+} from '../../lib/keeper-operational-state'
+import { keeperDisplayRuntime } from '../../lib/keeper-runtime-display'
+import type { AsyncState } from '../../lib/async-state'
+import type { PersonaSummary } from '../../api/schemas/persona'
+import { keepers } from '../../store'
+import {
+  loadPersonas,
+  personasResource,
+} from '../keeper-spawn/keeper-spawn-state'
+import { KeeperBadge } from '../keeper-badge'
+import { Dot, Pill, type DotState, type PillTone } from '../v2/primitives-v2'
+
+export type RegistryKeeperGroupId = KeeperOperationalState['kind']
+
+interface RegistryKeeperRow {
+  readonly keeper: Keeper
+  readonly state: KeeperOperationalState
+}
+
+interface RegistryKeeperGroup {
+  readonly id: RegistryKeeperGroupId
+  readonly label: string
+  readonly dot: DotState
+  readonly tone: PillTone
+}
+
+const KEEPER_GROUPS: Readonly<Record<RegistryKeeperGroupId, RegistryKeeperGroup>> = {
+  running: { id: 'running', label: '실행 중', dot: 'ok', tone: 'ok' },
+  stuck: { id: 'stuck', label: '차단 · 확인 필요', dot: 'bad', tone: 'bad' },
+  paused: { id: 'paused', label: '일시정지', dot: 'warn', tone: 'warn' },
+  offline: { id: 'offline', label: '중지 · 미기동', dot: 'idle', tone: 'neutral' },
+}
+
+export function keeperGroup(
+  keeper: Keeper,
+  composite: Parameters<typeof deriveKeeperOperationalState>[0]['composite'],
+): RegistryKeeperGroupId {
+  return deriveKeeperOperationalState({ keeper, composite }).kind
+}
+
+export function groupRegistryKeepers(
+  roster: readonly Keeper[],
+  compositeByKeeperKey: ReturnType<typeof buildCompositeByKeeperKey>,
+): Readonly<Record<RegistryKeeperGroupId, readonly RegistryKeeperRow[]>> {
+  const rows = roster.map(keeper => ({
+    keeper,
+    state: deriveKeeperOperationalState({
+      keeper,
+      composite: compositeSnapshotForKeeper(keeper, compositeByKeeperKey),
+    }),
+  }))
+
+  return {
+    running: rows.filter(row => row.state.kind === 'running'),
+    stuck: rows.filter(row => row.state.kind === 'stuck'),
+    paused: rows.filter(row => row.state.kind === 'paused'),
+    offline: rows.filter(row => row.state.kind === 'offline'),
+  }
+}
+
+function runtimeLabel(keeper: Keeper): string | null {
+  return keeperDisplayRuntime(keeper)?.value ?? null
+}
+
+function configuredOnly(state: KeeperOperationalState): boolean {
+  return state.kind === 'offline' && state.cause === 'unbooted'
+}
+
+function PersonaLayer({ state }: { state: AsyncState<readonly PersonaSummary[]> }) {
+  if (state.status === 'idle' || state.status === 'loading') {
+    return html`
+      <div class="reg-layer reg-personas">
+        <h3 style="margin:0 0 8px;">Persona <${Pill} tone="info">…<//></h3>
+        <p style="opacity:.6;">불러오는 중…</p>
+      </div>
+    `
+  }
+
+  if (state.status === 'error') {
+    return html`
+      <div class="reg-layer reg-personas">
+        <h3 style="margin:0 0 8px;">Persona <${Pill} tone="bad">오류<//></h3>
+        <p class="reg-error" style="color:var(--color-status-err);">persona 목록 로드 실패: ${state.message}</p>
+      </div>
+    `
+  }
+
+  return html`
+    <div class="reg-layer reg-personas">
+      <h3 style="margin:0 0 8px;">Persona <${Pill} tone="info">${state.data.length}<//></h3>
+      ${state.data.length === 0
+        ? html`<p style="opacity:.6;">등록된 persona가 없습니다.</p>`
+        : html`
+            <ul style="list-style:none;margin:0;padding:0;display:flex;flex-wrap:wrap;gap:8px;">
+              ${state.data.map(persona => html`
+                <li key=${persona.persona_name} class="reg-persona-card"
+                    style="border:1px solid var(--color-border-default);border-radius:8px;padding:8px 12px;">
+                  <strong>${persona.display_name}</strong>
+                  ${persona.trait ? html`<span style="opacity:.7;"> · ${persona.trait}</span>` : null}
+                  ${persona.has_keeper_defaults ? html` <${Pill} tone="neutral">keeper defaults<//>` : null}
+                </li>
+              `)}
+            </ul>
+          `}
+    </div>
+  `
+}
+
+export function RegistrySurface() {
+  useEffect(() => {
+    void loadPersonas()
+  }, [])
+
+  const personaState = personasResource.state.value
+  const roster = keepers.value
+  const fleetSnapshot = fleetCompositeSnapshot.value
+  const compositeByKeeperKey = useMemo(
+    () => buildCompositeByKeeperKey(fleetSnapshot),
+    [fleetSnapshot],
+  )
+  const grouped = useMemo(
+    () => groupRegistryKeepers(roster, compositeByKeeperKey),
+    [roster, compositeByKeeperKey],
+  )
+
+  return html`
+    <section class="reg-surface" style="padding:16px;display:flex;flex-direction:column;gap:20px;">
+      <${PersonaLayer} state=${personaState} />
+
+      <div class="reg-layer reg-keepers">
+        <h3 style="margin:0 0 8px;">Keeper <${Pill} tone="info">${roster.length}<//></h3>
+        ${Object.values(KEEPER_GROUPS).map(group => html`
+          <div key=${group.id} class="reg-kgroup" style="margin-bottom:12px;">
+            <h4 style="margin:0 0 6px;display:flex;align-items:center;gap:6px;">
+              <${Dot} state=${group.dot} /> ${group.label}
+              <${Pill} tone=${group.tone} count>${grouped[group.id].length}<//>
+            </h4>
+            ${grouped[group.id].length === 0
+              ? html`<p style="margin:0;opacity:.5;">없음</p>`
+              : html`
+                  <ul style="list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:4px;">
+                    ${grouped[group.id].map(row => {
+                      const runtime = runtimeLabel(row.keeper)
+                      return html`
+                        <li key=${row.keeper.name} class="reg-keeper-row"
+                            style="display:flex;align-items:center;gap:8px;">
+                          <${KeeperBadge} id=${row.keeper.name} variant="full" size="sm" />
+                          <span style="opacity:.7;font-size:12px;">
+                            ${runtime ?? '런타임 없음'}
+                          </span>
+                          ${configuredOnly(row.state) ? html`<${Pill} tone="neutral">configured<//>` : null}
+                        </li>
+                      `
+                    })}
+                  </ul>
+                `}
+          </div>
+        `)}
+      </div>
+    </section>
+  `
+}

--- a/dashboard/src/components/surface-icon.ts
+++ b/dashboard/src/components/surface-icon.ts
@@ -7,6 +7,7 @@ import {
   FlaskConical,
   Gauge,
   Home,
+  Layers,
   Plug,
   ScrollText,
   Settings,
@@ -31,6 +32,8 @@ export function SurfaceIcon({ icon, size = 16 }: SurfaceIconProps) {
       return html`<${Activity} ...${props} />`
     case 'keepers':
       return html`<${UsersRound} ...${props} />`
+    case 'registry':
+      return html`<${Layers} ...${props} />`
     case 'board':
       return html`<${SquareKanban} ...${props} />`
     case 'schedule':

--- a/dashboard/src/components/v2/icons-v2.ts
+++ b/dashboard/src/components/v2/icons-v2.ts
@@ -6,9 +6,26 @@ import type { VNode } from 'preact'
 
 type Icon = VNode
 
-export const ICONS: Readonly<Record<string, Icon>> = {
+export type IconKey =
+  | 'grid'
+  | 'users'
+  | 'layers'
+  | 'board'
+  | 'term'
+  | 'code'
+  | 'plug'
+  | 'gear'
+  | 'shield'
+  | 'target'
+  | 'monitor'
+  | 'logs'
+  | 'fusion'
+  | 'clock'
+
+export const ICONS: Readonly<Record<IconKey, Icon>> = {
   grid: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><rect x="3" y="3" width="7" height="7" rx="1.4" /><rect x="14" y="3" width="7" height="7" rx="1.4" /><rect x="3" y="14" width="7" height="7" rx="1.4" /><rect x="14" y="14" width="7" height="7" rx="1.4" /></svg>`,
   users: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="8" r="3.2" /><path d="M3.5 19c0-3 2.6-5 5.5-5s5.5 2 5.5 5" /><path d="M16.5 6.2a3 3 0 0 1 0 5.6" /><path d="M18.5 19c0-2-.8-3.6-2-4.6" /></svg>`,
+  layers: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l9 5-9 5-9-5z" /><path d="M3 13l9 5 9-5" /><path d="M3 17.5l9 5 9-5" /></svg>`,
   board: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linejoin="round"><rect x="3" y="4" width="5" height="16" rx="1.2" /><rect x="10" y="4" width="5" height="11" rx="1.2" /><rect x="17" y="4" width="4" height="14" rx="1.2" /></svg>`,
   term: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="16" rx="2.2" /><path d="M7 9l3 3-3 3" /><path d="M13 15h4" /></svg>`,
   code: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M8 6l-5 6 5 6" /><path d="M16 6l5 6-5 6" /><path d="M13.5 4l-3 16" /></svg>`,

--- a/dashboard/src/components/v2/nav-rail-v2.test.ts
+++ b/dashboard/src/components/v2/nav-rail-v2.test.ts
@@ -54,7 +54,7 @@ describe('NavRailV2 schedule item', () => {
     expect(walk).toEqual([
       'brand',
       '개요', '|',
-      'Keepers', 'Monitor', '|',
+      'Keepers', '레지스트리', 'Monitor', '|',
       '작업', '승인', '예약', '|',
       '보드', 'Fusion', '로그', '|',
       'IDE', '커넥터',

--- a/dashboard/src/components/v2/nav-rail-v2.ts
+++ b/dashboard/src/components/v2/nav-rail-v2.ts
@@ -7,24 +7,25 @@ import { html } from 'htm/preact'
 import { useState, useEffect } from 'preact/hooks'
 import { navigate, route } from '../../router'
 import type { TabId } from '../../types'
-import { ICONS, ICON_MORE } from './icons-v2'
+import { ICONS, ICON_MORE, type IconKey } from './icons-v2'
 
 interface SurfaceEntry {
   readonly tab: TabId
   readonly label: string
-  readonly icon: keyof typeof ICONS
+  readonly icon: IconKey
 }
 type NavEntry = SurfaceEntry | 'sep'
 
 // Prototype SURFACES order/labels/icons, mapped to live TabIds.
 //   prototype work→workspace, monitor→monitoring, ide→code; rest 1:1.
 // Groups mirror the 2026-07 standalone export's rail DOM: 개요 |
-// Keepers · Monitor | 작업 · 승인 · 예약 | 보드 · Fusion · 로그 |
+// Keepers · Registry · Monitor | 작업 · 승인 · 예약 | 보드 · Fusion · 로그 |
 // IDE · 커넥터 (설정 stays in the footer slot below the spacer).
-const SURFACES: readonly NavEntry[] = [
+const SURFACES = [
   { tab: 'overview', label: '개요', icon: 'grid' },
   'sep',
   { tab: 'keepers', label: 'Keepers', icon: 'users' },
+  { tab: 'registry', label: '레지스트리', icon: 'layers' },
   { tab: 'monitoring', label: 'Monitor', icon: 'monitor' },
   'sep',
   { tab: 'workspace', label: '작업', icon: 'target' },
@@ -37,26 +38,42 @@ const SURFACES: readonly NavEntry[] = [
   'sep',
   { tab: 'code', label: 'IDE', icon: 'code' },
   { tab: 'connectors', label: '커넥터', icon: 'plug' },
-]
+] as const satisfies readonly NavEntry[]
 
 export interface NavBadges {
   readonly approvals?: number
 }
 
-const SURFACE_LABEL: Readonly<Record<string, string>> = Object.fromEntries(
-  SURFACES.filter((e): e is SurfaceEntry => e !== 'sep').map((e) => [e.tab, e.label]),
-)
+type RailEntry = Exclude<(typeof SURFACES)[number], 'sep'>
+type RailTabId = RailEntry['tab']
+type NonRailTabId = Exclude<TabId, RailTabId>
 
-/** Crumb label for a tab (prototype SURFACE_LABEL); settings + unknowns fall back. */
+const SURFACE_LABEL = Object.fromEntries(
+  SURFACES.filter((entry): entry is RailEntry => entry !== 'sep')
+    .map(entry => [entry.tab, entry.label]),
+) as Readonly<Record<RailTabId, string>>
+
+const NON_RAIL_SURFACE_LABEL: Readonly<Record<NonRailTabId, string>> = {
+  cockpit: 'MASC Cockpit',
+  command: 'Command',
+  lab: 'Lab',
+  settings: '설정',
+}
+
+function isRailTab(tab: TabId): tab is RailTabId {
+  return Object.hasOwn(SURFACE_LABEL, tab)
+}
+
+/** Crumb label for a tab. The table is exhaustive over every routable tab. */
 export function surfaceLabel(tab: TabId): string {
-  return SURFACE_LABEL[tab] ?? (tab === 'settings' ? '설정' : tab)
+  return isRailTab(tab) ? SURFACE_LABEL[tab] : NON_RAIL_SURFACE_LABEL[tab]
 }
 
 // On phones the rail collapses to a bottom tab bar: the operator's daily loop
 // (home / agents / work / approvals) gets first-class tabs; the rest live behind
 // a 더보기 sheet so no tab drops below the 44px hit target (prototype shell.jsx).
 const MOBILE_PRIMARY: readonly TabId[] = ['overview', 'workspace', 'keepers', 'approvals']
-const SURFACE_ENTRIES: readonly SurfaceEntry[] = SURFACES.filter((e): e is SurfaceEntry => e !== 'sep')
+const SURFACE_ENTRIES: readonly SurfaceEntry[] = SURFACES.filter((entry): entry is RailEntry => entry !== 'sep')
 
 export function NavRailV2({ badges, mobile = false }: { badges?: NavBadges; mobile?: boolean }) {
   const active = route.value.tab

--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -64,6 +64,7 @@ describe('dashboard surface navigation', () => {
     expect(PRIMARY_DASHBOARD_SURFACES.map(surface => surface.id)).toEqual([
       'overview',
       'keepers',
+      'registry',
       'monitoring',
       'workspace',
       'approvals',
@@ -78,6 +79,7 @@ describe('dashboard surface navigation', () => {
     expect(PRIMARY_DASHBOARD_NAV_ITEMS.map(item => item.label)).toEqual([
       'Overview',
       'Keepers',
+      'Registry',
       'Monitor',
       'Work',
       'Gate',
@@ -92,7 +94,7 @@ describe('dashboard surface navigation', () => {
   })
 
   it('uses one sectionless-surface classifier for section stripping and section lookup', () => {
-    const sectionless = ['overview', 'logs', 'settings', 'keepers', 'board', 'schedule', 'approvals', 'fusion'] as const
+    const sectionless = ['overview', 'logs', 'settings', 'keepers', 'registry', 'board', 'schedule', 'approvals', 'fusion'] as const
     expect(sectionless.filter(id => isSectionlessSurface(id))).toEqual([...sectionless])
     expect(sectionItemsForTab('settings')).toEqual([])
     expect(normalizeRouteParams('settings', { section: 'legacy', surface: 'old', panel: 'theme' })).toEqual({

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -35,6 +35,7 @@ export type DashboardSurfaceIcon =
   | 'overview'
   | 'monitoring'
   | 'keepers'
+  | 'registry'
   | 'board'
   | 'schedule'
   | 'fusion'
@@ -120,6 +121,7 @@ export interface DashboardSectionNavItem {
 const V2_PRIMARY_SURFACE_IDS: ReadonlyArray<SurfaceId> = [
   'overview',
   'keepers',
+  'registry',
   'monitoring',
   'workspace',
   'approvals',
@@ -141,6 +143,7 @@ const SECTIONLESS_SURFACE_IDS: ReadonlySet<TabId> = new Set([
   'logs',
   'settings',
   'keepers',
+  'registry',
   'board',
   'schedule',
   'approvals',
@@ -186,6 +189,14 @@ export const DASHBOARD_SURFACES: DashboardNavGroup[] = [
     description: 'Dedicated keeper roster, conversation, and context workspace',
     defaultTab: 'keepers',
     tabs: ['keepers'],
+  },
+  {
+    id: 'registry',
+    label: 'Registry',
+    icon: 'registry',
+    description: 'Persona forms, keeper instances, and runtime bindings',
+    defaultTab: 'registry',
+    tabs: ['registry'],
   },
   {
     id: 'board',
@@ -312,6 +323,7 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
   // key — the Record is exhaustive over the union, so the empty entry is required.
   approvals: [],
   fusion: [],
+  registry: [],
   monitoring: [
     {
       id: 'agents',
@@ -476,10 +488,7 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
 }
 
 function validSectionIds(tab: NonHomeTabId): SurfaceSectionId[] {
-  // Total: an unknown/unmapped tab has no sections. Guards against a route
-  // whose tab is not a section-bearing surface (e.g. partial routes in tests
-  // or a not-yet-registered surface) instead of crashing on undefined.map.
-  return (DASHBOARD_SECTION_ITEMS[tab] ?? []).map(item => item.id)
+  return DASHBOARD_SECTION_ITEMS[tab].map(item => item.id)
 }
 
 export function defaultParamsForTab(tabId: TabId): Record<string, string> {
@@ -488,7 +497,7 @@ export function defaultParamsForTab(tabId: TabId): Record<string, string> {
 
 export function sectionItemsForTab(tabId: TabId): DashboardSectionNavItem[] {
   if (isSectionlessSurface(tabId)) return []
-  return DASHBOARD_SECTION_ITEMS[tabId as NonHomeTabId] ?? []
+  return DASHBOARD_SECTION_ITEMS[tabId as NonHomeTabId]
 }
 
 export function visibleSectionItemsForTab(tabId: TabId): DashboardSectionNavItem[] {

--- a/dashboard/src/dashboard-ws.test.ts
+++ b/dashboard/src/dashboard-ws.test.ts
@@ -241,6 +241,7 @@ describe('dashboardSlicesForRoute', () => {
       { tab: 'workspace', params: { section: 'board' } },
       { tab: 'monitoring', params: { section: 'agents' } },
       { tab: 'keepers', params: { keeper: 'sangsu' } },
+      { tab: 'registry', params: {} },
       { tab: 'monitoring', params: { section: 'cognition' } },
       { tab: 'monitoring', params: { section: 'fleet-health', view: 'comparison' } },
       { tab: 'command', params: {} },
@@ -293,6 +294,14 @@ describe('dashboardSlicesForRoute', () => {
     expect(dashboardSlicesForRoute({ tab: 'monitoring', params: { section: 'agents' } }))
       .toContain('composite')
     expect(dashboardSlicesForRoute({ tab: 'keepers', params: { keeper: 'sangsu' } }))
+      .toEqual([
+        'composite',
+        'execution',
+        'namespace',
+        'shell',
+        'transport',
+      ])
+    expect(dashboardSlicesForRoute({ tab: 'registry', params: {} }))
       .toEqual([
         'composite',
         'execution',

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -403,6 +403,10 @@ export function dashboardSlicesForRoute(routeState: DashboardRouteState): string
     slices.add('execution')
     slices.add('composite')
   }
+  if (routeState.tab === 'registry') {
+    slices.add('execution')
+    slices.add('composite')
+  }
   if (routeState.tab === 'board') {
     return Array.from(slices).sort()
   }

--- a/dashboard/src/tab-refresh.test.ts
+++ b/dashboard/src/tab-refresh.test.ts
@@ -73,6 +73,13 @@ describe('refreshPlanForRoute', () => {
     })).toEqual(['namespaceTruth', 'execution', 'missionSnapshot', 'activeKeeperChat'])
   })
 
+  it('hydrates the registry roster on direct entry', () => {
+    expect(refreshPlanForRoute({
+      tab: 'registry',
+      params: {},
+    })).toEqual(['namespaceTruth', 'execution', 'missionSnapshot'])
+  })
+
   it('hydrates the top-level board surface from the board store', () => {
     expect(refreshPlanForRoute({
       tab: 'board',

--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -81,6 +81,8 @@ export function refreshPlanForRoute(routeState: Pick<RouteState, 'tab' | 'params
       // reconnect: the route refresh runs after a disconnect and recovers the
       // open keeper's history when replayed events fell outside the buffer.
       return ['namespaceTruth', 'execution', 'missionSnapshot', 'activeKeeperChat']
+    case 'registry':
+      return ['namespaceTruth', 'execution', 'missionSnapshot']
     case 'board':
       return ['board']
     case 'fusion':

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -315,28 +315,12 @@ export interface RouteState {
   postId: string | null
 }
 
-export type TabId =
-  | 'cockpit'
-  | 'overview'
-  | 'monitoring'
-  | 'keepers'
-  | 'board'
-  | 'schedule'
-  | 'fusion'
-  | 'command'
-  | 'connectors'
-  | 'workspace'
-  | 'lab'
-  | 'code'
-  | 'logs'
-  | 'settings'
-  | 'approvals'
-
-export const VALID_TABS: TabId[] = [
+export const VALID_TABS = [
   'cockpit',
   'overview',
   'monitoring',
   'keepers',
+  'registry',
   'board',
   'schedule',
   'fusion',
@@ -348,4 +332,6 @@ export const VALID_TABS: TabId[] = [
   'logs',
   'settings',
   'approvals',
-]
+] as const
+
+export type TabId = typeof VALID_TABS[number]


### PR DESCRIPTION
## Summary

- add a read-only Registry surface for Persona -> Keeper -> Runtime lane visibility
- replace permissive persona normalization with one shared, typed detailed-response decoder/resource
- make tab-to-surface and v2 icon mappings compile-time total instead of silently falling back
- group keeper rows only through the canonical `deriveKeeperOperationalState` projection

This is the first current-main salvage slice from #24364. It does not carry the umbrella branch's keeper creation/meta/Goal implementation.

## Product impact

- User-visible change: operators get a Registry route that shows strictly decoded personas and keeper/runtime bindings grouped by the existing operational-state SSOT.
- Schema drift is visible as an error; malformed entries, bare-string compatibility payloads, and count mismatches are rejected instead of becoming an empty roster.
- Unknown or newly added dashboard tabs cannot render Overview by default.

## Evidence

- `cd dashboard && pnpm typecheck` — PASS
- focused Vitest set (10 files) — PASS, 160 tests
- `git diff --check` — PASS
- `pnpm lint` — existing unrelated failure at `dashboard/src/keeper-actions.ts:1021` (`no-nested-ternary`); this PR does not modify that file. Changed files already covered by the current ESLint allowlist introduce no new lint error.

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 0/2
provenance: operator_proxy
stages:
  - name: dashboard_typecheck
    provenance: operator_proxy
    result: pass
  - name: focused_vitest
    provenance: operator_proxy
    result: pass
```

## GOAL LOOP ACT checklist

- [x] Observe — #24364 mixed Registry work with keeper create/meta/Goal changes and permissive frontend normalization
- [x] Orient — salvage finding: keep Registry totality, reject duplicate lifecycle/persona projections
- [x] Decide — land the independent read-only frontend vertical slice first; exclude backend creation semantics
- [x] Act — implemented the smallest route/resource/projection slice that is independently usable
- [x] Verify — typecheck and 160 focused tests pass
- [x] Loop — remaining backend hard-cut and typed creation work stays related to #24364 and will land separately

## Review evidence

- Reimplemented against current `main` after adversarial review of #24364; no umbrella commit was cherry-picked.
- Verified the Registry grouping consumes `deriveKeeperOperationalState` and the persona list consumes one strict Valibot boundary schema.

## Linked issue

- Relates #24364

## Variant addition checklist

- [ ] **OCaml** — N/A; no OCaml variant changed
- [x] **TypeScript** — `TabId` is derived from the `VALID_TABS` tuple and exhaustive route/icon records were updated
- [ ] **TLA+ spec** — N/A; no state-machine domain changed
- [ ] **Event / JSON schema** — N/A; no event or backend JSON enum changed
- [ ] **`make check-variants` passes** — N/A; this slice adds only a dashboard route union member
