### PR TITLE
refactor(runtime): delete idle error string inference

### DIFF
--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -976,19 +976,6 @@ let build
       in
       Agent_sdk.Builder.build_safe builder)
 
-(* ================================================================ *)
-(* Idle-detail enrichment                                           *)
-(* ================================================================ *)
-
-(** Enrich an [Agent_sdk.Error.to_string] detail with the name of the most
-    recently called tool when the error is an "Idle detected" failure.
-    For all other error strings the input is returned unchanged.
-
-    Exposed at module level so it can be unit-tested independently of
-    the network-bound [run] function. *)
-let enrich_idle_detail =
-  Runtime_oas_checkpoint.enrich_idle_detail
-
 let run_duration_ms_since started_at =
   Float.max 0.0 ((Unix.gettimeofday () -. started_at) *. 1000.0)
 
@@ -1496,9 +1483,6 @@ let run_blocks
         }
     | Error err ->
       let detail = Agent_sdk.Error.to_string err in
-      let detail =
-        enrich_idle_detail detail (Agent_sdk.Agent.state agent).messages
-      in
       let error_response =
         partial_response_of_stop ~session_id ~text:detail
       in

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -394,9 +394,6 @@ val publish_lifecycle :
   ?attrs:(string * Yojson.Safe.t) list ->
   unit ->
   unit
-val enrich_idle_detail :
-  string -> Agent_sdk.Types.message list -> string
-
 (** {1 Build / resume / run} *)
 
 val build :

--- a/lib/runtime/runtime_oas_checkpoint.ml
+++ b/lib/runtime/runtime_oas_checkpoint.ml
@@ -56,35 +56,3 @@ let partial_response_of_stop
     usage = None;
     telemetry = None;
   }
-
-(** Enrich an [Agent_sdk.Error.to_string] detail with the name of the most
-    recently called tool when the error is an "Idle detected" failure.
-    For all other error strings the input is returned unchanged.
-
-    Exposed at module level so it can be unit-tested independently of
-    the network-bound [run] function. *)
-let enrich_idle_detail (detail : string) (messages : Agent_sdk.Types.message list) : string =
-  if String.starts_with ~prefix:"Idle detected" detail then
-    let last_tool =
-      let rec find = function
-        | [] -> None
-        | (m : Agent_sdk.Types.message) :: rest ->
-            let later = find rest in
-            if Option.is_some later then
-              later
-            else if m.role = Agent_sdk.Types.Assistant then
-              List.find_map
-                (fun block ->
-                  Agent_sdk.Canonical_tool.tool_call_of_block block
-                  |> Option.map (fun call -> call.Agent_sdk.Canonical_tool.name))
-                m.content
-            else
-              None
-      in
-      find messages
-    in
-    match last_tool with
-    | Some name -> Printf.sprintf "%s (tool: %s)" detail name
-    | None -> detail
-  else
-    detail

--- a/lib/runtime/runtime_oas_checkpoint.mli
+++ b/lib/runtime/runtime_oas_checkpoint.mli
@@ -57,19 +57,3 @@ val partial_response_of_stop :
     [stop_reason = EndTurn], single [Text] content block, no
     usage / telemetry. The emitted response model is the neutral [runtime]
     lane; OAS owns concrete provider/model identity. *)
-
-val enrich_idle_detail :
-  string ->
-  Agent_sdk.Types.message list ->
-  string
-(** Enrich an [Agent_sdk.Error.to_string] detail string with the name
-    of the most recently called tool when the detail starts
-    with ["Idle detected"]. For all other detail strings the
-    input is returned unchanged.
-
-    The "most recently called tool" is projected through
-    [Agent_sdk.Canonical_tool.tool_call_of_block] from the most recent
-    [Assistant] message; when no such block exists the bare detail is returned.
-
-    Exposed at module level so the test suite can exercise it
-    independently of the network-bound [run] function. *)


### PR DESCRIPTION
## What
- delete `enrich_idle_detail` and its public surface
- stop matching the rendered OAS error string for the `Idle detected` prefix
- return the canonical typed OAS error rendering to the dashboard unchanged

## Why
The deleted code inferred that the most recently observed tool caused an idle error. That inference was based on a rendered string prefix, duplicated the dashboard tool timeline, and could report false causality. OAS already exposes typed errors; MASC must not reconstruct semantics from display strings.

## Validation
- `ocamlformat -i` on changed OCaml files
- `ocamlc -stop-after parsing` on changed OCaml files
- `git diff --check`
- focused Dune wrapper was deferred because another worktree held the shared Dune lock; PR CI is the build authority

## Scope
4 files, 67 deletions. No compatibility path, fallback, or replacement heuristic.