### PR TITLE
refactor(runtime): delete orphan wire overlay interface

### DIFF
--- a/lib/runtime/runtime_wire_overlay.mli
+++ b/lib/runtime/runtime_wire_overlay.mli
@@ -1,7 +1,0 @@
-(** Wire-layer overlays applied after OAS resolves a provider config. *)
-
-val apply :
-  provider_cfg:Llm_provider.Provider_config.t ->
-  Agent_sdk.Provider.config ->
-  Agent_sdk.Provider.config
-


### PR DESCRIPTION
## What\n\nDeletes the orphan `runtime_wire_overlay.mli` left after #24412 removed its implementation and callers.\n\n## Why\n\nAdding `modules_without_implementation` would falsely preserve a public contract for a module that no longer exists. Deleting the interface closes the Dune error and completes the hard cut.\n\n## Validation\n\n- exact current-main blocker reproduced from `dune build .`\n- `git diff --check`: clean\n- no implementation/callers remain\n- no green claim for the other listed OAS 0.212 closures\n\nGitHub diff: 6 deletions (<400).