### PR TITLE
refactor(runtime): delete OAS tool-surface selectors

### DIFF
--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -134,10 +134,6 @@ type config =
   top_k : int option;
   min_p : float option;
   on_run_complete : (bool -> unit) option;
-  disclosure_level : Agent_sdk.Tool.disclosure_level option;
-  disclosure_resolver
-      : (Agent_sdk.Types.tool_result list -> Agent_sdk.Tool.disclosure_level option) option;
-  tool_selector : Agent_sdk.Tool_selector.strategy option;
   checkpoint_sink : Agent_sdk.Agent.checkpoint_sink option;
 }
 

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -110,10 +110,6 @@ type config = Runtime_agent_context.config = {
   top_k : int option;
   min_p : float option;
   on_run_complete : (bool -> unit) option;
-  disclosure_level : Agent_sdk.Tool.disclosure_level option;
-  disclosure_resolver
-      : (Agent_sdk.Types.tool_result list -> Agent_sdk.Tool.disclosure_level option) option;
-  tool_selector : Agent_sdk.Tool_selector.strategy option;
   checkpoint_sink : Agent_sdk.Agent.checkpoint_sink option;
 }
 

--- a/lib/runtime/runtime_agent_context.ml
+++ b/lib/runtime/runtime_agent_context.ml
@@ -142,21 +142,6 @@ type config =
     (** Callback invoked when an OAS run finishes (success or failure).
         Forwarded to [Builder.with_on_run_complete]. Useful for emitting
         telemetry, flushing OTel spans, or finalizing receipts. *)
-  ; disclosure_level : Agent_sdk.Tool.disclosure_level option
-    (** Tool schema disclosure level forwarded to
-        [Builder.with_disclosure_level]. Controls whether full schemas
-        or minimal name+description indices are sent to the LLM.
-        [None] preserves the default (Full_schema). *)
-  ; disclosure_resolver
-      : (Agent_sdk.Types.tool_result list -> Agent_sdk.Tool.disclosure_level option) option
-    (** Per-turn resolver that adapts disclosure based on previous tool
-        results. Forwarded to [Builder.with_disclosure_resolver].
-        Overrides [disclosure_level] for the current turn when [Some]
-        is returned. *)
-  ; tool_selector : Agent_sdk.Tool_selector.strategy option
-    (** Tool selection strategy for large tool catalogs, forwarded to
-        [Builder.with_tool_selector]. When tool count exceeds ~15,
-        narrows candidates per turn before sending schemas to the LLM. *)
   ; checkpoint_sink : Agent_sdk.Agent.checkpoint_sink option
     (** Caller-owned turn-boundary checkpoint sink, forwarded to
         [Builder.with_checkpoint_sink]. Allows consumers to persist
@@ -213,9 +198,6 @@ let default_config
   ; top_k = provider_cfg.top_k
   ; min_p = provider_cfg.min_p
   ; on_run_complete = None
-  ; disclosure_level = None
-  ; disclosure_resolver = None
-  ; tool_selector = None
   ; checkpoint_sink = None
   }
 ;;
@@ -408,21 +390,6 @@ let builder_without_approval
     | None -> builder
   in
   let builder =
-    match config.disclosure_level with
-    | Some level -> Agent_sdk.Builder.with_disclosure_level level builder
-    | None -> builder
-  in
-  let builder =
-    match config.disclosure_resolver with
-    | Some resolver -> Agent_sdk.Builder.with_disclosure_resolver resolver builder
-    | None -> builder
-  in
-  let builder =
-    match config.tool_selector with
-    | Some strategy -> Agent_sdk.Builder.with_tool_selector strategy builder
-    | None -> builder
-  in
-  let builder =
     match config.checkpoint_sink with
     | Some sink -> Agent_sdk.Builder.with_checkpoint_sink sink builder
     | None -> builder
@@ -504,9 +471,6 @@ let prepare_resume ~(config : config) ~(checkpoint : Agent_sdk.Checkpoint.t)
         Agent_sdk.Hooks.Reject_without_callback
     ; summarizer = config.summarizer
     ; on_run_complete = config.on_run_complete
-    ; disclosure_level = config.disclosure_level
-    ; disclosure_resolver = config.disclosure_resolver
-    ; tool_selector = config.tool_selector
     }
   in
   { patched_checkpoint; agent_config; options }

--- a/lib/runtime/runtime_agent_context.mli
+++ b/lib/runtime/runtime_agent_context.mli
@@ -119,10 +119,6 @@ type config = {
           intact; [Some 0.0] is a no-op and some providers (Groq, GLM)
           reject the field, so leave [None] unless explicitly needed. *)
   on_run_complete : (bool -> unit) option;
-  disclosure_level : Agent_sdk.Tool.disclosure_level option;
-  disclosure_resolver
-      : (Agent_sdk.Types.tool_result list -> Agent_sdk.Tool.disclosure_level option) option;
-  tool_selector : Agent_sdk.Tool_selector.strategy option;
   checkpoint_sink : Agent_sdk.Agent.checkpoint_sink option;
 }
 (** Per-worker configuration.  60 fields — concrete record because


### PR DESCRIPTION
## What
- delete the unused `disclosure_level` runtime carrier
- delete the unused per-turn `disclosure_resolver` carrier
- delete the unused OAS `tool_selector` carrier
- remove the corresponding Builder and resume-option projections

## Why
All three values were permanently `None` and had no repository call sites. OAS v0.212 hard-deletes these heuristic tool-surface layers and sends each caller-supplied tool with its full schema. MASC already owns the exact tool list at its boundary.

## Validation
- `ocamlformat -i` on changed OCaml files
- `ocamlc -stop-after parsing` on changed OCaml files
- `git diff --check`
- `MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build lib/masc.cma` with OAS v0.212 passed this surface and stopped at the next known migration boundary: `Agent_sdk.Context_reducer` is removed in 0.212

## Current integration state
Current MASC main already uses the v0.212 exact `provider_config` resume API from #24412, while its pin file still names v0.211.9. Therefore full CI cannot be green until the remaining removed OAS surfaces and final pin update land. This PR does not hide or work around that transition state.

## Scope
4 files, 48 deletions. No compatibility shim, fallback, selector heuristic, or new limit.