### PR TITLE
refactor(runtime): remove implicit sampling defaults

### DIFF
--- a/lib/keeper/keeper_adversarial_review.ml
+++ b/lib/keeper/keeper_adversarial_review.ml
@@ -92,7 +92,6 @@ let run_grounded_review ~base_path ~runtime_id (input : review_input) :
         ~goal:prompt
         ~masc_tools:[ Verifier_core.report_verdict_schema ]
         ~dispatch
-        ~temperature:Runtime_provider_defaults.deterministic_temperature
         ~approval:Approval_callbacks.auto_approve
         ~provider_config_transform:apply_report_verdict_output_schema
         ()

--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -42,20 +42,14 @@ let is_direct_completion_provider (provider_cfg : Llm_provider.Provider_config.t
   match provider_cfg.kind with
   | Anthropic | Kimi | OpenAI_compat | Ollama | Gemini | Glm | DashScope -> true
 
-let provider_for_plan ~runtime_id (provider_cfg : Llm_provider.Provider_config.t) =
+let provider_for_plan (provider_cfg : Llm_provider.Provider_config.t) =
   let max_tokens =
     match provider_cfg.max_tokens with
     | Some n when n > 0 -> Some (min n summary_max_tokens)
     | _ -> Some summary_max_tokens
   in
-  let temperature =
-    Runtime_inference.resolve_temperature
-      ~runtime_id
-      ~fallback:(fun () -> Runtime_provider_defaults.deterministic_temperature)
-  in
   { provider_cfg with
     max_tokens
-  ; temperature = Some temperature
   ; tool_choice = None
   ; disable_parallel_tool_use = true
   }
@@ -251,7 +245,7 @@ let run_plan
     ~(messages : Agent_sdk.Types.message list)
     () : compaction_plan option =
   let message_count = List.length messages in
-  let provider_cfg = provider_for_plan ~runtime_id provider_cfg in
+  let provider_cfg = provider_for_plan provider_cfg in
   let request = messages_for_plan ~messages in
   match
     with_timeout ?clock ~timeout_sec (fun () ->

--- a/lib/keeper/keeper_compaction_llm_summarizer.mli
+++ b/lib/keeper/keeper_compaction_llm_summarizer.mli
@@ -79,10 +79,9 @@ val apply
   -> Agent_sdk.Types.message list
 
 module For_testing : sig
-  (** Apply the compaction request policy while preserving the per-runtime
-      temperature override from runtime.toml. *)
+  (** Apply the compaction request policy while preserving the input provider
+      config's exact temperature, including omission. *)
   val provider_for_plan
-    :  runtime_id:string
-    -> Llm_provider.Provider_config.t
+    :  Llm_provider.Provider_config.t
     -> Llm_provider.Provider_config.t
 end

--- a/lib/keeper/keeper_failure_judge.ml
+++ b/lib/keeper/keeper_failure_judge.ml
@@ -110,7 +110,6 @@ let run ~base_path ~keeper_name request =
             ~base_path
             ~masc_tools:[]
             ~dispatch:reject_unregistered_tool
-            ~temperature:Runtime_provider_defaults.deterministic_temperature
             ~provider_config_transform:apply_output_schema
             ()
         with

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -252,7 +252,7 @@ let select_recent_messages ~max_messages messages =
   drop drop_count messages
 ;;
 
-let provider_for_librarian ~runtime_id (provider_cfg : Llm_provider.Provider_config.t) =
+let provider_for_librarian (provider_cfg : Llm_provider.Provider_config.t) =
   let configured_librarian_max_tokens = librarian_max_tokens () in
   let max_tokens =
     match provider_cfg.max_tokens with
@@ -260,15 +260,9 @@ let provider_for_librarian ~runtime_id (provider_cfg : Llm_provider.Provider_con
     | Some _ -> Some configured_librarian_max_tokens
     | None -> Some configured_librarian_max_tokens
   in
-  let temperature =
-    Runtime_inference.resolve_temperature
-      ~runtime_id
-      ~fallback:(fun () -> Runtime_provider_defaults.deterministic_temperature)
-  in
   let tuned_cfg =
     { provider_cfg with
       max_tokens
-    ; temperature = Some temperature
     ; tool_choice = None
     ; disable_parallel_tool_use = true
     ; enable_thinking = Some false
@@ -530,7 +524,7 @@ let extract_with_provider_classified
     (match messages_for_librarian inp with
      | Error msg -> Error (Prompt_render_failed msg)
      | Ok messages ->
-       let provider_cfg = provider_for_librarian ~runtime_id provider_cfg in
+       let provider_cfg = provider_for_librarian provider_cfg in
        (match
           Llm_provider.Provider_config.validate_output_schema_request provider_cfg
         with

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -112,14 +112,13 @@ val messages_for_librarian
   -> (Agent_sdk.Types.message list, string) result
 
 val provider_for_librarian
-  :  runtime_id:string
-  -> Llm_provider.Provider_config.t
+  :  Llm_provider.Provider_config.t
   -> Llm_provider.Provider_config.t
 (** Provider config specialized for episode extraction. Caps [max_tokens] at
     the librarian output budget (default 4096, overridable with
     [MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_TOKENS], floor 1) and requests the
-    structured episode output schema. The runtime model's declared temperature
-    overrides the deterministic librarian fallback. *)
+    structured episode output schema. The selected provider config's exact
+    temperature is preserved, including omission. *)
 
 val librarian_max_parse_retries : int
 (** Additional provider attempts after an initial unparseable response before

--- a/lib/keeper/keeper_memory_llm_summary.ml
+++ b/lib/keeper/keeper_memory_llm_summary.ml
@@ -61,20 +61,14 @@ let is_direct_completion_provider
   match provider_cfg.kind with
   | Anthropic | Kimi | OpenAI_compat | Ollama | Gemini | Glm | DashScope -> true
 
-let provider_for_summary ~runtime_id (provider_cfg : Llm_provider.Provider_config.t) =
+let provider_for_summary (provider_cfg : Llm_provider.Provider_config.t) =
   let max_tokens =
     match provider_cfg.max_tokens with
     | Some n when n > 0 -> Some (min n summary_max_tokens)
     | _ -> Some summary_max_tokens
   in
-  let temperature =
-    Runtime_inference.resolve_temperature
-      ~runtime_id
-      ~fallback:(fun () -> Runtime_provider_defaults.deterministic_temperature)
-  in
   { provider_cfg with
     max_tokens;
-    temperature = Some temperature;
     tool_choice = None;
     disable_parallel_tool_use = true;
   }
@@ -204,7 +198,7 @@ let summarize_with_provider
     ~trace_id
     ~texts
     () : string option =
-  let provider_cfg = provider_for_summary ~runtime_id provider_cfg in
+  let provider_cfg = provider_for_summary provider_cfg in
   let messages = messages_for_summary ~trace_id ~texts in
   let result, outcome =
     match

--- a/lib/keeper/keeper_memory_llm_summary.mli
+++ b/lib/keeper/keeper_memory_llm_summary.mli
@@ -15,11 +15,10 @@ val is_direct_completion_provider :
   Llm_provider.Provider_config.t -> bool
 
 val provider_for_summary :
-  runtime_id:string ->
   Llm_provider.Provider_config.t ->
   Llm_provider.Provider_config.t
-(** Tune the summary request while preserving a temperature declared by the
-    selected runtime model; otherwise use the deterministic subsystem fallback. *)
+(** Tune the summary request while preserving the selected provider config's
+    exact temperature, including omission. *)
 
 val summary_schema_supported : Llm_provider.Provider_config.t -> bool
 

--- a/lib/keeper/keeper_memory_os_consolidation_runtime.ml
+++ b/lib/keeper/keeper_memory_os_consolidation_runtime.ml
@@ -69,21 +69,15 @@ let with_facts_lock ?clock ~keeper_id f =
     f
 ;;
 
-let provider_for_consolidation ~runtime_id (provider_cfg : Llm_provider.Provider_config.t) =
+let provider_for_consolidation (provider_cfg : Llm_provider.Provider_config.t) =
   let max_tokens =
     match provider_cfg.max_tokens with
     | Some n when n > 0 -> Some n
     | Some _ | None -> Some consolidation_max_tokens
   in
-  let temperature =
-    Runtime_inference.resolve_temperature
-      ~runtime_id
-      ~fallback:(fun () -> Runtime_provider_defaults.deterministic_temperature)
-  in
   let tuned_cfg =
     { provider_cfg with
       Llm_provider.Provider_config.max_tokens
-    ; temperature = Some temperature
     ; tool_choice = None
     ; disable_parallel_tool_use = true
     }
@@ -168,7 +162,7 @@ let consolidate_keeper
       match messages_for_consolidation facts with
       | Error msg -> Unparseable msg
       | Ok messages ->
-        let config = provider_for_consolidation ~runtime_id provider_cfg in
+        let config = provider_for_consolidation provider_cfg in
         (match validate_provider_for_consolidation config with
          | Error msg -> Transport_failed ("consolidation provider config rejected: " ^ msg)
          | Ok () ->

--- a/lib/keeper/keeper_memory_os_consolidation_runtime.mli
+++ b/lib/keeper/keeper_memory_os_consolidation_runtime.mli
@@ -27,8 +27,7 @@ type outcome =
 
 module For_testing : sig
   val provider_for_consolidation
-    :  runtime_id:string
-    -> Llm_provider.Provider_config.t
+    :  Llm_provider.Provider_config.t
     -> Llm_provider.Provider_config.t
 end
 

--- a/lib/keeper/keeper_tool_failure_recovery_judge.ml
+++ b/lib/keeper/keeper_tool_failure_recovery_judge.ml
@@ -50,7 +50,6 @@ let invoke
     ~goal:user_prompt
     ~system_prompt
     ~max_idle_turns:0
-    ~temperature:Runtime_provider_defaults.deterministic_temperature
     ~accept:(fun response ->
       not (String.equal (String.trim (Agent_sdk.Types.text_of_response response)) ""))
     ~provider_config_transform

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -283,32 +283,22 @@ let first_runtime_after_modality_reroute ~keeper_name ~assignment_id
        to_runtime_id, rerouted)
 
 type attempt_inference_policy =
-  { attempt_temperature : float
-  ; attempt_enable_thinking : bool option
+  { attempt_enable_thinking : bool option
   ; attempt_preserve_thinking : bool option
   }
 
 let attempt_inference_policy
     ~runtime_id
-    ~fallback_temperature
     ~fallback_enable_thinking
     ()
   =
   let runtime_seed = Runtime_inference.for_runtime ~name:runtime_id in
-  let attempt_temperature =
-    Runtime_inference.resolve_temperature
-      ~runtime_id
-      ~fallback:(fun () -> fallback_temperature)
-  in
   let attempt_enable_thinking =
     match runtime_seed.thinking_enabled with
     | Some _ as enabled -> enabled
     | None -> fallback_enable_thinking
   in
-  { attempt_temperature
-  ; attempt_enable_thinking
-  ; attempt_preserve_thinking = runtime_seed.preserve_thinking
-  }
+  { attempt_enable_thinking; attempt_preserve_thinking = runtime_seed.preserve_thinking }
 
 let run_named
     ~runtime_id
@@ -324,7 +314,7 @@ let run_named
     ~max_idle_turns
     ?stream_idle_timeout_s
     ?body_timeout_s
-    ?(temperature = Runtime_provider_defaults.agent_default_temperature)
+    ?temperature
     ?(accept = fun (_ : Agent_sdk_response.api_response) -> true)
     ?hooks
     ?context_reducer
@@ -607,7 +597,6 @@ let run_named
       let inference_policy =
         attempt_inference_policy
           ~runtime_id:attempt_runtime_id
-          ~fallback_temperature:temperature
           ~fallback_enable_thinking:enable_thinking
           ()
       in
@@ -655,7 +644,7 @@ let run_named
             ; max_idle_turns
             ; stream_idle_timeout_s
             ; body_timeout_s
-            ; temperature = inference_policy.attempt_temperature
+            ; temperature
             ; accept
             ; hooks
             ; context_reducer

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -131,8 +131,7 @@ val run_named :
     The runtime loop runs inside a capacity-managed queue permit. *)
 
 type attempt_inference_policy =
-  { attempt_temperature : float
-  ; attempt_enable_thinking : bool option
+  { attempt_enable_thinking : bool option
   ; attempt_preserve_thinking : bool option
   }
 
@@ -193,7 +192,6 @@ module For_testing : sig
 
   val attempt_inference_policy :
     runtime_id:string ->
-    fallback_temperature:float ->
     fallback_enable_thinking:bool option ->
     unit ->
     attempt_inference_policy

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -33,7 +33,7 @@ type try_provider_ctx =
   ; max_idle_turns : int
   ; stream_idle_timeout_s : float option
   ; body_timeout_s : float option
-  ; temperature : float
+  ; temperature : float option
   ; accept : Agent_sdk_response.api_response -> bool
   ; hooks : Agent_sdk.Hooks.hooks option
   ; context_reducer : Agent_sdk.Context_reducer.t option
@@ -222,16 +222,25 @@ let run_try_provider
     | None -> Ok ()
   in
   let config_result =
+    let base_config =
+      Runtime_candidate.default_config
+        ~name:ctx.name
+        ~system_prompt:ctx.system_prompt
+        ~tools:ctx.tools
+        candidate
+    in
+    (* Runtime/model configuration is authoritative; the run-level value only
+       fills an omitted provider temperature. *)
+    let temperature =
+      match base_config.temperature with
+      | Some _ as configured -> configured
+      | None -> ctx.temperature
+    in
     Ok
-      { (Runtime_candidate.default_config
-           ~name:ctx.name
-           ~system_prompt:ctx.system_prompt
-           ~tools:ctx.tools
-           candidate)
-            with
-            stream_idle_timeout_s = ctx.stream_idle_timeout_s
+      { base_config with
+        stream_idle_timeout_s = ctx.stream_idle_timeout_s
           ; body_timeout_s = ctx.body_timeout_s
-          ; temperature = ctx.temperature
+          ; temperature
           ; max_turns = ctx.max_turns
           ; max_idle_turns = ctx.max_idle_turns
           ; guardrails = Some Agent_sdk.Guardrails.permissive

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -16,7 +16,7 @@ type try_provider_ctx =
   ; max_idle_turns : int
   ; stream_idle_timeout_s : float option
   ; body_timeout_s : float option
-  ; temperature : float
+  ; temperature : float option
   ; accept : Agent_sdk_response.api_response -> bool
   ; hooks : Agent_sdk.Hooks.hooks option
   ; context_reducer : Agent_sdk.Context_reducer.t option

--- a/lib/keeper/keeper_turn_driver_wrappers.ml
+++ b/lib/keeper/keeper_turn_driver_wrappers.ml
@@ -23,7 +23,7 @@ let config_for_label
     ~(system_prompt : string)
     ~(tools : Agent_sdk.Tool.t list)
     ~(max_tokens : int option)
-    ~(temperature : float)
+    ~(temperature : float option)
     ?(max_idle_turns = 3)
     ?stream_idle_timeout_s
     ?hooks
@@ -43,11 +43,18 @@ let config_for_label
     | None -> Ok provider
     | Some transform -> transform provider
   in
+  let base_config =
+    Runtime_agent.default_config ~name ~provider_cfg:provider ~system_prompt ~tools
+  in
+  (* The resolved model declaration is authoritative; a caller value only fills
+     an omitted provider temperature. *)
+  let temperature =
+    match base_config.temperature with
+    | Some _ as configured -> configured
+    | None -> temperature
+  in
   Ok
-    {
-      (Runtime_agent.default_config ~name ~provider_cfg:provider
-         ~system_prompt ~tools)
-      with
+    { base_config with
       max_tokens;
       temperature;
       max_idle_turns;
@@ -74,7 +81,7 @@ let run_model_by_label
     ?(tools = [])
     ?(max_idle_turns = 3)
     ?stream_idle_timeout_s
-    ?(temperature = Runtime_provider_defaults.agent_default_temperature)
+    ?temperature
     ?max_tokens
     ?(accept = fun (_ : Agent_sdk_response.api_response) -> true)
     ?hooks
@@ -162,7 +169,7 @@ let run_named_with_masc_tools
     ~(masc_tools : Masc_domain.tool_schema list)
     ~(dispatch : name:string -> args:Yojson.Safe.t -> Tool_result.result)
     ?stream_idle_timeout_s
-    ?(temperature = Runtime_provider_defaults.agent_default_temperature)
+    ?temperature
     ?(accept = fun (_ : Agent_sdk_response.api_response) -> true)
     ?hooks
     ?raw_trace
@@ -189,7 +196,7 @@ let run_named_with_masc_tools
   Keeper_turn_driver.run_named ~runtime_id ~keeper_name ~goal ~base_path ~system_prompt ~tools:oas_tools
     ?max_turns
     ~max_idle_turns
-    ~temperature
+    ?temperature
     ?stream_idle_timeout_s ?hooks
     ~accept
     ?compact_ratio
@@ -204,7 +211,7 @@ let run_model_with_masc_tools
     ~(masc_tools : Masc_domain.tool_schema list)
     ~(dispatch : name:string -> args:Yojson.Safe.t -> Tool_result.result)
     ?stream_idle_timeout_s
-    ?(temperature = Runtime_provider_defaults.agent_default_temperature)
+    ?temperature
     ?max_tokens
     ?hooks
     ?enable_thinking

--- a/lib/keeper/keeper_vision_tool.ml
+++ b/lib/keeper/keeper_vision_tool.ml
@@ -59,18 +59,12 @@ let truncated_of_stop_reason : Agent_sdk.Types.stop_reason -> bool = function
   | Agent_sdk.Types.UnmatchedToolCalls
   | Agent_sdk.Types.Unknown _ -> false
 
-let provider_for_vision ~runtime_id (provider_cfg : Llm_provider.Provider_config.t) =
-  let temperature =
-    Runtime_inference.resolve_temperature
-      ~runtime_id
-      ~fallback:(fun () -> Runtime_provider_defaults.deterministic_temperature)
-  in
+let provider_for_vision (provider_cfg : Llm_provider.Provider_config.t) =
   { provider_cfg with
     max_tokens =
       (match provider_cfg.max_tokens with
        | Some _ as configured -> configured
        | None -> Some vision_default_max_tokens)
-  ; temperature = Some temperature
   ; tool_choice = None
   ; disable_parallel_tool_use = true
   ; enable_thinking = Some false
@@ -406,7 +400,7 @@ let run_candidates
          in
          loop ~last_error ~attempt_index []
        | Some timeout_sec ->
-         let config = provider_for_vision ~runtime_id rt.Runtime.provider_config in
+         let config = provider_for_vision rt.Runtime.provider_config in
          (match
             with_timeout ~clock ~timeout_sec (fun () ->
               complete ~sw ~net ?clock:(Some clock) ~config ~messages ())
@@ -492,7 +486,7 @@ let run_candidates_outcome
          in
          loop ~last_error ~attempt_index []
        | Some timeout_sec ->
-         let config = provider_for_vision ~runtime_id rt.Runtime.provider_config in
+         let config = provider_for_vision rt.Runtime.provider_config in
          (match
             with_timeout ~clock ~timeout_sec (fun () ->
               complete ~sw ~net ?clock:(Some clock) ~config ~messages ())

--- a/lib/keeper/keeper_vision_tool.mli
+++ b/lib/keeper/keeper_vision_tool.mli
@@ -59,15 +59,14 @@ val message_of_request
     [data:<media_type>;base64,<data>]). *)
 
 val provider_for_vision
-  :  runtime_id:string
-  -> Llm_provider.Provider_config.t
+  :  Llm_provider.Provider_config.t
   -> Llm_provider.Provider_config.t
 (** A one-shot, non-thinking, structured-output vision config: thinking off (avoids the
     2026-06-25 gemma4 thinking-budget exhaustion that produced empty replies),
     [response_format = JsonSchema _], [output_schema = Some _],
-    [tool_choice = None], the selected runtime's declared temperature (or the
-    deterministic subsystem fallback), and a fallback [max_tokens] only when
-    the selected runtime has not configured one. *)
+    [tool_choice = None], the selected provider config's exact temperature
+    (including omission), and a fallback [max_tokens] only when the selected
+    runtime has not configured one. *)
 
 val vision_runtime_ids : unit -> string list
 (** Ordered schema-capable image runtime ids: [\[runtime\].media_failover] order

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -100,7 +100,7 @@ type config =
   max_execution_time_s : float option;
   body_timeout_s : float option;
   max_tokens : int option;
-  temperature : float;
+  temperature : float option;
   hooks : Agent_sdk.Hooks.hooks option;
   context_reducer : Agent_sdk.Context_reducer.t option;
   guardrails : Agent_sdk.Guardrails.t option;

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -78,7 +78,7 @@ type config = Runtime_agent_context.config = {
   max_execution_time_s : float option;
   body_timeout_s : float option;
   max_tokens : int option;
-  temperature : float;
+  temperature : float option;
   hooks : Agent_sdk.Hooks.hooks option;
   context_reducer : Agent_sdk.Context_reducer.t option;
   guardrails : Agent_sdk.Guardrails.t option;

--- a/lib/runtime/runtime_agent_context.ml
+++ b/lib/runtime/runtime_agent_context.ml
@@ -95,7 +95,7 @@ type config =
         never a synthesized request value. [Some n] is an explicit
         operator/profile override or a non-keeper caller's deliberate
         request budget. *)
-  ; temperature : float
+  ; temperature : float option
   ; hooks : Agent_sdk.Hooks.hooks option
   ; context_reducer : Agent_sdk.Context_reducer.t option
   ; guardrails : Agent_sdk.Guardrails.t option
@@ -181,7 +181,7 @@ let default_config
   ; max_execution_time_s = None
   ; body_timeout_s = None
   ; max_tokens = None
-  ; temperature = Runtime_provider_defaults.agent_default_temperature
+  ; temperature = provider_cfg.temperature
   ; hooks = None
   ; context_reducer = None
   ; guardrails = None
@@ -251,11 +251,15 @@ let builder_without_approval
     |> Agent_sdk.Builder.with_system_prompt config.system_prompt
     |> Agent_sdk.Builder.with_max_turns config.max_turns
     |> Agent_sdk.Builder.with_max_idle_turns config.max_idle_turns
-    |> Agent_sdk.Builder.with_temperature config.temperature
     |> Agent_sdk.Builder.with_tools config.tools
     |> Agent_sdk.Builder.with_guardrails guardrails
     |> Agent_sdk.Builder.with_missing_approval_callback_policy
          Agent_sdk.Hooks.Reject_without_callback
+  in
+  let builder =
+    match config.temperature with
+    | Some temperature -> Agent_sdk.Builder.with_temperature temperature builder
+    | None -> builder
   in
   let builder =
     (* masc#24067 / oas#2517: [None] means the request carries no
@@ -454,7 +458,7 @@ let prepare_resume ~(config : config) ~(checkpoint : Agent_sdk.Checkpoint.t)
     { checkpoint with
       Agent_sdk.Checkpoint.model = config.model_id
     ; system_prompt = Some config.system_prompt
-    ; temperature = Some config.temperature
+    ; temperature = config.temperature
     ; top_p = config.top_p
     ; top_k = config.top_k
     ; min_p = config.min_p
@@ -472,7 +476,7 @@ let prepare_resume ~(config : config) ~(checkpoint : Agent_sdk.Checkpoint.t)
     ; system_prompt = Some config.system_prompt
     ; max_tokens = config.max_tokens
     ; max_turns = max_turns_for_resume
-    ; temperature = Some config.temperature
+    ; temperature = config.temperature
     ; top_p = config.top_p
     ; top_k = config.top_k
     ; min_p = config.min_p

--- a/lib/runtime/runtime_agent_context.mli
+++ b/lib/runtime/runtime_agent_context.mli
@@ -73,7 +73,9 @@ type config = {
           validation bound, never a synthesized request value. [Some n] is
           an explicit operator/profile override or a non-keeper caller's
           deliberate request budget. *)
-  temperature : float;
+  temperature : float option;
+      (** Exact caller/model sampling declaration. [None] omits temperature and
+          leaves the selected provider's default intact. *)
   hooks : Agent_sdk.Hooks.hooks option;
   context_reducer : Agent_sdk.Context_reducer.t option;
   guardrails : Agent_sdk.Guardrails.t option;

--- a/lib/runtime/runtime_inference.ml
+++ b/lib/runtime/runtime_inference.ml
@@ -2,8 +2,7 @@
    in runtime.toml ([models.<id>.temperature], read via
    [Runtime.temperature_of_runtime_id]); when set, that value is the request
    temperature at every inference boundary for the model. Otherwise the caller's
-   subsystem fallback stands (keeper turn, deterministic compaction, or HITL
-   summary policy).
+   explicitly configured subsystem value stands.
 
    Completes the previously stubbed per-runtime [resolve_temperature] (the
    [~runtime_id:_] passthrough). Required for

--- a/lib/runtime_model/runtime_provider_defaults.ml
+++ b/lib/runtime_model/runtime_provider_defaults.ml
@@ -1,16 +1,6 @@
-(** Runtime-boundary projection for provider inference defaults. *)
-
-let agent_default_temperature =
-  Llm_provider.Constants.Inference_profile.agent_default.temperature
-;;
-
-let worker_default_temperature =
-  Llm_provider.Constants.Inference_profile.worker_default.temperature
-;;
-
-let deterministic_temperature =
-  Llm_provider.Constants.Inference_profile.deterministic.temperature
-;;
+(** Runtime-boundary projection for provider constants that remain owned by
+    OAS. Sampling defaults are intentionally absent: an omitted temperature is
+    carried as [None] so the selected provider applies its declared default. *)
 
 let max_error_body_length =
   Llm_provider.Constants.Truncation.max_error_body_length

--- a/lib/runtime_model/runtime_provider_defaults.mli
+++ b/lib/runtime_model/runtime_provider_defaults.mli
@@ -1,13 +1,7 @@
-(** Runtime-boundary projection for provider inference defaults.
+(** Runtime-boundary projection for provider constants.
 
-    OAS owns the concrete default inference profiles and truncation limits.
-    MASC callers use this module so keeper/server/worker code does not read
-    {!Llm_provider.Constants} directly. *)
-
-val agent_default_temperature : float
-
-val worker_default_temperature : float
-
-val deterministic_temperature : float
+    OAS owns the truncation limit. Sampling defaults are intentionally not
+    projected: callers either declare an exact temperature or omit it so the
+    provider applies its own default. *)
 
 val max_error_body_length : int

--- a/lib/tool_local_runtime_verify.ml
+++ b/lib/tool_local_runtime_verify.ml
@@ -108,7 +108,7 @@ let probe_chat_completion_compatible
           ~kind:Llm_provider.Provider_config.OpenAI_compat
           ~model_id ~base_url:endpoint.url
           ~request_path:Masc_network_defaults.openai_chat_completions_path
-          ~max_tokens:1 ~temperature:Runtime_provider_defaults.deterministic_temperature ()
+          ~max_tokens:1 ()
       in
       let messages : Oas_types.message list = [ Oas_types.user_msg "hi" ] in
       let run_completion () =

--- a/lib/verifier_oas.ml
+++ b/lib/verifier_oas.ml
@@ -92,7 +92,9 @@ end
     Primary path: LLM calls [report_verdict] tool with typed verdict.
     Fallback path: if LLM responds with text, parse provider-native JSON only.
 
-    The structured path is deterministic (JSON schema constrains output).
+    The structured path constrains the output shape with JSON Schema; sampling
+    remains an exact runtime/model declaration rather than an implicit judge
+    profile.
     The fallback path is strict JSON and returns Error on failure instead of
     extracting a verdict from prose. *)
 let verify (req : Core.verification_request) : (Core.verdict, string) result =
@@ -123,7 +125,6 @@ let verify (req : Core.verification_request) : (Core.verdict, string) result =
       ~goal:prompt
       ~masc_tools:[ Core.report_verdict_schema ]
       ~dispatch
-      ~temperature:Runtime_provider_defaults.deterministic_temperature
       ~approval:Approval_callbacks.auto_approve
       ~provider_config_transform:apply_report_verdict_output_schema
       ()

--- a/lib/workspace_metric_hooks.ml
+++ b/lib/workspace_metric_hooks.ml
@@ -468,7 +468,6 @@ let install () =
              ~masc_tools:[ report_tool_schema ]
              ~dispatch
              
-             ~temperature:Runtime_provider_defaults.deterministic_temperature
              ~approval:Approval_callbacks.auto_approve
              ~provider_config_transform:apply_review_verdict_output_schema
              ?sw

--- a/test/test_compaction_llm_summarizer.ml
+++ b/test/test_compaction_llm_summarizer.ml
@@ -64,12 +64,26 @@ let with_temperature_runtime f =
 let test_provider_for_plan_preserves_runtime_temperature () =
   with_temperature_runtime (fun provider_cfg ->
     let cfg =
-      C.For_testing.provider_for_plan ~runtime_id:temperature_runtime_id provider_cfg
+      C.For_testing.provider_for_plan provider_cfg
     in
     Alcotest.(check (option (float 0.0001)))
-      "runtime.toml temperature overrides deterministic compaction fallback"
+      "runtime.toml temperature is preserved"
       (Some 1.0)
       cfg.temperature)
+
+let test_provider_for_plan_preserves_temperature_omission () =
+  let provider_cfg =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.OpenAI_compat
+      ~model_id:"test-model"
+      ~base_url:"http://example.invalid"
+      ()
+  in
+  let cfg = C.For_testing.provider_for_plan provider_cfg in
+  Alcotest.(check (option (float 0.0001)))
+    "temperature remains omitted"
+    None
+    cfg.temperature
 
 (* -- plan_of_json: valid partition accepted -- *)
 
@@ -208,6 +222,8 @@ let () =
     [ ( "provider"
       , [ Alcotest.test_case "runtime temperature is authoritative" `Quick
             test_provider_for_plan_preserves_runtime_temperature
+        ; Alcotest.test_case "temperature omission is preserved" `Quick
+            test_provider_for_plan_preserves_temperature_omission
         ] )
     ; ( "plan_of_json"
       , [ Alcotest.test_case "valid partition accepted" `Quick test_valid_partition_accepted

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -831,18 +831,13 @@ let test_memory_provider_configs_use_runtime_temperature () =
     | None -> Alcotest.fail "default memory runtime should resolve"
     | Some runtime ->
       let summary =
-        Memory_summary.provider_for_summary
-          ~runtime_id:runtime.Runtime.id
-          runtime.Runtime.provider_config
+        Memory_summary.provider_for_summary runtime.Runtime.provider_config
       in
       let librarian =
-        Librarian_runtime.provider_for_librarian
-          ~runtime_id:runtime.Runtime.id
-          runtime.Runtime.provider_config
+        Librarian_runtime.provider_for_librarian runtime.Runtime.provider_config
       in
       let consolidation =
         Consolidation_runtime.For_testing.provider_for_consolidation
-          ~runtime_id:runtime.Runtime.id
           runtime.Runtime.provider_config
       in
       Alcotest.(check (option (float 0.0001)))
@@ -1168,7 +1163,6 @@ let test_librarian_max_tokens_override_env () =
      no-op while the config snapshot reported source=env. *)
   let effective_cap () =
     (Librarian_runtime.provider_for_librarian
-       ~runtime_id:unconfigured_runtime_id
        (test_provider_cfg ()))
       .Llm_provider.Provider_config.max_tokens
   in
@@ -1365,9 +1359,7 @@ let test_librarian_rejects_invalid_claims () =
 
 let test_memory_llm_summary_provider_requests_json_schema () =
   let provider_cfg =
-    Memory_summary.provider_for_summary
-      ~runtime_id:unconfigured_runtime_id
-      (test_provider_cfg ())
+    Memory_summary.provider_for_summary (test_provider_cfg ())
   in
   let expected_schema = Structured_schema.memory_bank_summary_output_schema in
   Alcotest.(check (option int))

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -345,7 +345,6 @@ let test_attempt_inference_policy_uses_attempt_runtime () =
     let lane_policy =
       Driver.For_testing.attempt_inference_policy
         ~runtime_id:"mixed"
-        ~fallback_temperature:0.25
         ~fallback_enable_thinking:None
         ()
     in
@@ -353,10 +352,6 @@ let test_attempt_inference_policy_uses_attempt_runtime () =
       "lane id has no runtime thinking policy"
       None
       lane_policy.Driver.attempt_enable_thinking;
-    Alcotest.(check (float 0.0001))
-      "lane id keeps caller temperature fallback"
-      0.25
-      lane_policy.Driver.attempt_temperature;
     Alcotest.(check (option bool))
       "lane id has no preserve thinking policy"
       None
@@ -364,7 +359,6 @@ let test_attempt_inference_policy_uses_attempt_runtime () =
     let thinking_policy =
       Driver.For_testing.attempt_inference_policy
         ~runtime_id:"thinking.reasoning_big"
-        ~fallback_temperature:0.25
         ~fallback_enable_thinking:(Some false)
         ()
     in
@@ -372,10 +366,6 @@ let test_attempt_inference_policy_uses_attempt_runtime () =
       "thinking candidate enables thinking"
       (Some true)
       thinking_policy.Driver.attempt_enable_thinking;
-    Alcotest.(check (float 0.0001))
-      "thinking candidate uses runtime temperature"
-      1.0
-      thinking_policy.Driver.attempt_temperature;
     Alcotest.(check (option bool))
       "thinking candidate preserves thinking when configured"
       (Some true)
@@ -383,7 +373,6 @@ let test_attempt_inference_policy_uses_attempt_runtime () =
     let non_thinking_policy =
       Driver.For_testing.attempt_inference_policy
         ~runtime_id:"plain.non_reasoning"
-        ~fallback_temperature:0.25
         ~fallback_enable_thinking:(Some true)
         ()
     in
@@ -391,10 +380,6 @@ let test_attempt_inference_policy_uses_attempt_runtime () =
       "non-thinking candidate forces thinking off"
       (Some false)
       non_thinking_policy.Driver.attempt_enable_thinking;
-    Alcotest.(check (float 0.0001))
-      "plain candidate keeps caller temperature fallback"
-      0.25
-      non_thinking_policy.Driver.attempt_temperature;
     Alcotest.(check (option bool))
       "non-thinking candidate disables preserve thinking"
       (Some false)

--- a/test/test_keeper_vision_tool.ml
+++ b/test/test_keeper_vision_tool.ml
@@ -245,15 +245,11 @@ let test_provider_for_vision_preserves_configured_max_tokens () =
       ()
   in
   let configured =
-    Vt.provider_for_vision
-      ~runtime_id:"test.unconfigured"
-      { base with max_tokens = Some 4096 }
+    Vt.provider_for_vision { base with max_tokens = Some 4096 }
   in
   assert (configured.max_tokens = Some 4096);
   let fallback =
-    Vt.provider_for_vision
-      ~runtime_id:"test.unconfigured"
-      { base with max_tokens = None }
+    Vt.provider_for_vision { base with max_tokens = None }
   in
   assert (fallback.max_tokens = Some Vt.vision_default_max_tokens);
   let expected_schema = Structured_schema.vision_analyze_output_schema in
@@ -629,7 +625,7 @@ let test_provider_for_vision_uses_runtime_temperature () =
        | None -> failwith "selected vision runtime should resolve"
        | Some runtime ->
          let configured =
-           Vt.provider_for_vision ~runtime_id runtime.Runtime.provider_config
+           Vt.provider_for_vision runtime.Runtime.provider_config
          in
          assert (configured.temperature = Some 1.0)))
 


### PR DESCRIPTION
## 변경
- 삭제된 OAS Inference_profile 기본값 의존을 제거합니다.
- materialized provider_config.temperature를 SSOT로 사용합니다.
- 호출자 temperature는 provider 설정이 None일 때만 명시적 fallback으로 전달합니다.
- Judge, Verifier, Memory, Vision 경로의 강제 deterministic 수치를 제거합니다.

## 경계
- 새 수치 기본값, 환경변수, endpoint fallback을 추가하지 않습니다.
- Context_reducer 제거와 Lane LLM Compaction 배선은 후속 독립 절단입니다.

## 검증
- GitHub diff 114 additions + 171 deletions = 285 lines
- git diff --check 통과
- ocamlformat check 및 변경 OCaml parse 통과
- leaf runtime_provider_defaults/runtime_inference focused build는 준비 worktree에서 통과
- 현재 재검증 wrapper는 설치 agent_sdk pin b02bc16과 repo 기대 pin 902c45d 불일치로 명시적으로 중단되었습니다. 전체 green을 주장하지 않습니다.