### PR TITLE
refactor(keeper): salvage typed persona create validation from #24364

### DIFF
--- a/lib/keeper/keeper_persona.ml
+++ b/lib/keeper/keeper_persona.ml
@@ -1,12 +1,9 @@
-(** Keeper_persona — persona list and persona-backed keeper creation handlers. *)
+(** Keeper_persona — persona list handlers. *)
 
 open Tool_args
-open Keeper_types
-open Keeper_meta_contract
 open Keeper_types_profile
 open Keeper_tool_persona_runtime
 
-module Turn = Keeper_turn
 type tool_result = Keeper_types_profile.tool_result
 let persona_list_handler args : tool_result =
   let detailed = get_bool args "detailed" true in
@@ -28,47 +25,3 @@ let persona_list_handler args : tool_result =
 
 (* TEL-OK: thin wrapper — telemetry stays in [persona_list_handler]. *)
 let handle_persona_list _ctx args : tool_result = persona_list_handler args
-
-let handle_keeper_create_from_persona ctx args : tool_result =
-  match resolved_keeper_args_from_persona args with
-  | Error e -> tool_result_error ("" ^ e)
-  | Ok (persona, resolved_args) ->
-      let errors = validate_resolved_keeper_create_json resolved_args in
-      let dry_run = get_bool args "dry_run" false in
-      if dry_run then
-        let json =
-          `Assoc
-            [
-              ("persona", persona_summary_to_json persona);
-              ("ready", `Bool (errors = []));
-              ("errors", Json_util.json_string_list errors);
-              ("resolved_args", resolved_args);
-            ]
-        in
-        tool_result_ok_data json
-      else if errors <> [] then
-        tool_result_error_data
-          (`Assoc
-             [
-               ("persona", persona_summary_to_json persona);
-               ("ready", `Bool false);
-               ("errors", Json_util.json_string_list errors);
-               ("resolved_args", resolved_args);
-             ])
-      else
-        let result = Turn.handle_keeper_up ctx resolved_args in
-        if not (tool_result_success result) then
-          result
-        else begin
-          let created_json = Tool_result.data result in
-          let json =
-            `Assoc
-              [
-                ("persona", persona_summary_to_json persona);
-                ("created", `Bool true);
-                ("result", created_json);
-                ("resolved_args", resolved_args);
-              ]
-          in
-          tool_result_ok_data json
-        end

--- a/lib/keeper/keeper_persona.mli
+++ b/lib/keeper/keeper_persona.mli
@@ -1,4 +1,4 @@
-(** Keeper_persona — persona list and persona-backed keeper creation handlers. *)
+(** Keeper_persona — persona list handlers. *)
 
 type tool_result = Keeper_types_profile.tool_result
 
@@ -6,8 +6,3 @@ val handle_persona_list :
   _ Keeper_types_profile.context -> Yojson.Safe.t -> tool_result
 
 val persona_list_handler : Yojson.Safe.t -> tool_result
-
-(** Create a keeper from a persona definition. Honors a [dry_run] arg
-    that returns a preview without invoking [handle_keeper_up]. *)
-val handle_keeper_create_from_persona :
-  _ Keeper_types_profile.context -> Yojson.Safe.t -> tool_result

--- a/lib/keeper/keeper_tool_persona_runtime.ml
+++ b/lib/keeper/keeper_tool_persona_runtime.ml
@@ -74,17 +74,152 @@ let resolved_keeper_args_to_json
   `Assoc
     (base @ allowed_paths_field @ autoboot_field)
 
-let validate_resolved_keeper_create_json (json : Yojson.Safe.t) : string list =
-  let errors = ref [] in
-  let name = Safe_ops.json_string ~default:"" "name" json in
-  let goal = Safe_ops.json_string ~default:"" "goal" json |> String.trim in
-  let mention_targets = Safe_ops.json_string_list "mention_targets" json in
-  if not (validate_name name) then
-    errors := invalid_name_error name :: !errors;
-  if goal = "" then errors := "goal is required" :: !errors;
-  if mention_targets = [] then
-    errors := "mention_targets is required" :: !errors;
-  List.rev !errors
+type create_field =
+  | Keeper_name
+  | Initial_goal
+  | Mention_targets
+
+type mention_target_error =
+  | Expected_string
+  | Empty_string
+
+type create_validation_error =
+  | Required of create_field
+  | Invalid_json_type of create_field
+  | Invalid_keeper_name of string
+  | Invalid_mention_target of
+      { index : int
+      ; reason : mention_target_error
+      }
+
+type create_validation_status =
+  | Ready
+  | Not_ready of create_validation_error list
+
+type create_validation_decision =
+  | Preview of create_validation_status
+  | Proceed
+  | Reject of create_validation_error list
+
+let create_field_wire_name = function
+  | Keeper_name -> "name"
+  | Initial_goal -> "goal"
+  | Mention_targets -> "mention_targets"
+
+let create_field_code = function
+  | Keeper_name -> "keeper_name"
+  | Initial_goal -> "initial_goal"
+  | Mention_targets -> "mention_targets"
+
+let create_field_expected_json = function
+  | Keeper_name | Initial_goal -> "non-empty string"
+  | Mention_targets -> "non-empty array of non-empty strings"
+
+let required_string field json =
+  match Safe_ops.json_member_opt (create_field_wire_name field) json with
+  | None -> Error (Required field)
+  | Some (`String value) when String.equal (String.trim value) "" ->
+      Error (Required field)
+  | Some (`String value) -> Ok value
+  | Some _ -> Error (Invalid_json_type field)
+
+let mention_target_errors json =
+  match Safe_ops.json_member_opt (create_field_wire_name Mention_targets) json with
+  | None -> [ Required Mention_targets ]
+  | Some (`List []) -> [ Required Mention_targets ]
+  | Some (`List values) ->
+      let rec collect_invalid index errors = function
+        | [] -> List.rev errors
+        | `String value :: rest ->
+            if String.equal (String.trim value) "" then
+              collect_invalid
+                (index + 1)
+                (Invalid_mention_target { index; reason = Empty_string } :: errors)
+                rest
+            else
+              collect_invalid (index + 1) errors rest
+        | _ :: rest ->
+            collect_invalid
+              (index + 1)
+              (Invalid_mention_target { index; reason = Expected_string } :: errors)
+              rest
+      in
+      collect_invalid 0 [] values
+  | Some _ -> [ Invalid_json_type Mention_targets ]
+
+let validate_resolved_keeper_create_json (json : Yojson.Safe.t) =
+  let keeper_name_error =
+    match required_string Keeper_name json with
+    | Error error -> Some error
+    | Ok name when validate_name name -> None
+    | Ok name -> Some (Invalid_keeper_name name)
+  in
+  let initial_goal_error =
+    match required_string Initial_goal json with
+    | Ok _ -> None
+    | Error error -> Some error
+  in
+  let errors =
+    List.filter_map Fun.id [ keeper_name_error; initial_goal_error ]
+    @ mention_target_errors json
+  in
+  match errors with
+  | [] -> Ok ()
+  | _ :: _ -> Error errors
+
+let decide_resolved_keeper_create ~dry_run json =
+  let status =
+    match validate_resolved_keeper_create_json json with
+    | Ok () -> Ready
+    | Error errors -> Not_ready errors
+  in
+  match dry_run, status with
+  | true, status -> Preview status
+  | false, Ready -> Proceed
+  | false, Not_ready errors -> Reject errors
+
+let create_validation_error_to_json error =
+  let code, field, message, details =
+    match error with
+    | Required field ->
+        ( create_field_code field ^ "_required"
+        , create_field_wire_name field
+        , Printf.sprintf "%s is required" (create_field_wire_name field)
+        , [] )
+    | Invalid_json_type field ->
+        ( create_field_code field ^ "_invalid_json_type"
+        , create_field_wire_name field
+        , Printf.sprintf
+            "%s must be a %s"
+            (create_field_wire_name field)
+            (create_field_expected_json field)
+        , [] )
+    | Invalid_keeper_name name ->
+        ( "keeper_name_invalid"
+        , create_field_wire_name Keeper_name
+        , invalid_name_error name
+        , [ "value", `String name ] )
+    | Invalid_mention_target { index; reason } ->
+        let code, message =
+          match reason with
+          | Expected_string ->
+              ( "mention_target_expected_string"
+              , "mention_targets entries must be strings" )
+          | Empty_string ->
+              ( "mention_target_empty"
+              , "mention_targets entries must be non-empty strings" )
+        in
+        ( code
+        , create_field_wire_name Mention_targets
+        , message
+        , [ "index", `Int index ] )
+  in
+  `Assoc
+    ([ "code", `String code; "field", `String field; "message", `String message ]
+     @ details)
+
+let create_validation_errors_to_json errors =
+  `List (List.map create_validation_error_to_json errors)
 
 let toml_escape_string value =
   let buf = Buffer.create (String.length value + 8) in

--- a/lib/keeper/keeper_tool_persona_runtime.mli
+++ b/lib/keeper/keeper_tool_persona_runtime.mli
@@ -9,7 +9,41 @@ val read_jsonl_rows :
 val find_jsonl_row_by_action_id :
   Yojson.Safe.t list -> string -> Yojson.Safe.t option
 
-val validate_resolved_keeper_create_json : Yojson.Safe.t -> string list
+type create_field =
+  | Keeper_name
+  | Initial_goal
+  | Mention_targets
+
+type mention_target_error =
+  | Expected_string
+  | Empty_string
+
+type create_validation_error =
+  | Required of create_field
+  | Invalid_json_type of create_field
+  | Invalid_keeper_name of string
+  | Invalid_mention_target of
+      { index : int
+      ; reason : mention_target_error
+      }
+
+type create_validation_status =
+  | Ready
+  | Not_ready of create_validation_error list
+
+type create_validation_decision =
+  | Preview of create_validation_status
+  | Proceed
+  | Reject of create_validation_error list
+
+val validate_resolved_keeper_create_json :
+  Yojson.Safe.t -> (unit, create_validation_error list) result
+
+val decide_resolved_keeper_create :
+  dry_run:bool -> Yojson.Safe.t -> create_validation_decision
+
+val create_validation_errors_to_json :
+  create_validation_error list -> Yojson.Safe.t
 
 val render_keeper_toml_from_resolved_args :
   Yojson.Safe.t -> (string, string) result

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -395,6 +395,18 @@ let attach_identity_reseed ?identity_reseed json =
   match identity_reseed with
   | None -> json
   | Some note -> attach_assoc_field "identity_reseed" note json
+
+let create_from_persona_validation_json ~persona ~resolved_args ~ready ~errors =
+  `Assoc
+    [ ( "persona"
+      , Keeper_tool_persona_runtime.persona_summary_to_json persona )
+    ; "created", `Bool false
+    ; "ready", `Bool ready
+    ; ( "errors"
+      , Keeper_tool_persona_runtime.create_validation_errors_to_json errors )
+    ; "resolved_args", resolved_args
+    ]
+
 let handle_keeper_create_from_persona ctx args : tool_result =
   if not Server_startup_state.((!state).state_ready) then begin
     let elapsed = Server_startup_state.elapsed_since_start () in
@@ -407,17 +419,33 @@ let handle_keeper_create_from_persona ctx args : tool_result =
         |> Result.map_error (fun e -> "" ^ e)
       in
       let dry_run = get_bool args "dry_run" false in
-      if dry_run then
+      match
+        Keeper_tool_persona_runtime.decide_resolved_keeper_create
+          ~dry_run
+          resolved_args
+      with
+      | Keeper_tool_persona_runtime.Preview status ->
+        let ready, errors =
+          match status with
+          | Keeper_tool_persona_runtime.Ready -> true, []
+          | Keeper_tool_persona_runtime.Not_ready errors -> false, errors
+        in
         Ok
           (tool_result_ok_data
-             (`Assoc
-                [
-                  ( "persona",
-                    Keeper_tool_persona_runtime.persona_summary_to_json persona );
-                  ("created", `Bool false);
-                  ("resolved_args", resolved_args);
-                ]))
-      else
+             (create_from_persona_validation_json
+                ~persona
+                ~resolved_args
+                ~ready
+                ~errors))
+      | Keeper_tool_persona_runtime.Reject errors ->
+        Ok
+          (tool_result_error_data
+             (create_from_persona_validation_json
+                ~persona
+                ~resolved_args
+                ~ready:false
+                ~errors))
+      | Keeper_tool_persona_runtime.Proceed ->
         let* _rendered_toml =
           Keeper_tool_persona_runtime.render_keeper_toml_from_resolved_args
             resolved_args

--- a/test/dune
+++ b/test/dune
@@ -325,6 +325,7 @@
   test_keeper_classifier_helper
   test_keeper_unified_persona_block
   test_persona_crud_profile_shape
+  test_keeper_create_validate
   test_turn_id_propagation
   test_auth_strict_mode
   test_keeper_turn_fsm_emit
@@ -654,6 +655,7 @@
   test_keeper_classifier_helper
   test_keeper_unified_persona_block
   test_persona_crud_profile_shape
+  test_keeper_create_validate
   test_turn_id_propagation
   test_auth_strict_mode
   test_keeper_turn_fsm_emit

--- a/test/test_keeper_create_validate.ml
+++ b/test/test_keeper_create_validate.ml
@@ -1,0 +1,140 @@
+(** Typed pre-boot validation for [masc_keeper_create_from_persona]. *)
+
+open Masc
+
+module Runtime = Keeper_tool_persona_runtime
+
+let pp_error formatter error =
+  Runtime.create_validation_errors_to_json [ error ]
+  |> Yojson.Safe.to_string
+  |> Format.pp_print_string formatter
+
+let validation_error = Alcotest.testable pp_error ( = )
+let validation_errors = Alcotest.list validation_error
+
+let valid_args =
+  `Assoc
+    [ "name", `String "valid-name"
+    ; "goal", `String "do the thing"
+    ; "mention_targets", `List [ `String "valid-name" ]
+    ]
+
+let check_validation_error expected json =
+  match Runtime.validate_resolved_keeper_create_json json with
+  | Ok () -> Alcotest.fail "validation unexpectedly passed"
+  | Error actual -> Alcotest.check validation_errors "typed errors" expected actual
+
+let test_missing_fields () =
+  check_validation_error
+    [ Runtime.Required Runtime.Keeper_name
+    ; Runtime.Required Runtime.Initial_goal
+    ; Runtime.Required Runtime.Mention_targets
+    ]
+    (`Assoc [])
+
+let test_valid_args_decisions () =
+  Alcotest.(check bool)
+    "validation passes"
+    true
+    (Result.is_ok (Runtime.validate_resolved_keeper_create_json valid_args));
+  Alcotest.(check bool)
+    "dry run previews ready"
+    true
+    (Runtime.decide_resolved_keeper_create ~dry_run:true valid_args
+     = Runtime.Preview Runtime.Ready);
+  Alcotest.(check bool)
+    "real create proceeds"
+    true
+    (Runtime.decide_resolved_keeper_create ~dry_run:false valid_args
+     = Runtime.Proceed)
+
+let test_invalid_name () =
+  let invalid_name = "bad name/with sep" in
+  check_validation_error
+    [ Runtime.Invalid_keeper_name invalid_name ]
+    (`Assoc
+       [ "name", `String invalid_name
+       ; "goal", `String "goal"
+       ; "mention_targets", `List [ `String "target" ]
+       ])
+
+let test_malformed_fields () =
+  let errors =
+    [ Runtime.Invalid_json_type Runtime.Initial_goal
+    ; Runtime.Invalid_mention_target
+        { index = 1; reason = Runtime.Expected_string }
+    ; Runtime.Invalid_mention_target
+        { index = 2; reason = Runtime.Empty_string }
+    ]
+  in
+  let json =
+    `Assoc
+      [ "name", `String "valid-name"
+      ; "goal", `Int 1
+      ; "mention_targets", `List [ `String "target"; `Null; `String " " ]
+      ]
+  in
+  check_validation_error errors json;
+  Alcotest.(check bool)
+    "dry run exposes typed rejection"
+    true
+    (Runtime.decide_resolved_keeper_create ~dry_run:true json
+     = Runtime.Preview (Runtime.Not_ready errors));
+  Alcotest.(check bool)
+    "real create rejects before boot"
+    true
+    (Runtime.decide_resolved_keeper_create ~dry_run:false json
+     = Runtime.Reject errors)
+
+let test_empty_mention_target () =
+  check_validation_error
+    [ Runtime.Invalid_mention_target
+        { index = 0; reason = Runtime.Empty_string }
+    ]
+    (`Assoc
+       [ "name", `String "valid-name"
+       ; "goal", `String "goal"
+       ; "mention_targets", `List [ `String "  " ]
+       ])
+
+let test_error_json () =
+  let actual =
+    Runtime.create_validation_errors_to_json
+      [ Runtime.Required Runtime.Initial_goal
+      ; Runtime.Invalid_mention_target
+          { index = 2; reason = Runtime.Empty_string }
+      ]
+  in
+  let expected =
+    `List
+      [ `Assoc
+          [ "code", `String "initial_goal_required"
+          ; "field", `String "goal"
+          ; "message", `String "goal is required"
+          ]
+      ; `Assoc
+          [ "code", `String "mention_target_empty"
+          ; "field", `String "mention_targets"
+          ; ( "message"
+            , `String "mention_targets entries must be non-empty strings" )
+          ; "index", `Int 2
+          ]
+      ]
+  in
+  Alcotest.(check string)
+    "stable structured error boundary"
+    (Yojson.Safe.to_string expected)
+    (Yojson.Safe.to_string actual)
+
+let () =
+  Alcotest.run
+    "keeper_create_validate"
+    [ ( "validation"
+      , [ Alcotest.test_case "missing fields" `Quick test_missing_fields
+        ; Alcotest.test_case "valid decisions" `Quick test_valid_args_decisions
+        ; Alcotest.test_case "invalid name" `Quick test_invalid_name
+        ; Alcotest.test_case "malformed fields" `Quick test_malformed_fields
+        ; Alcotest.test_case "empty mention target" `Quick test_empty_mention_target
+        ; Alcotest.test_case "structured error json" `Quick test_error_json
+        ] )
+    ]


### PR DESCRIPTION
## Summary

- salvage the typed pre-boot validation concept from #24364 onto current `main`
- share one closed validation decision between dry-run preview and real create
- return structured validation objects instead of matching or transporting error strings
- delete the unreachable duplicate persona-create handler from `Keeper_persona`

This deliberately excludes keeper-create expansion, `no_boot`, meta/Goal changes, reservation, and legacy compatibility. Those require separate current-main cuts.

## Product impact

- User-visible change: invalid `masc_keeper_create_from_persona` arguments are rejected before render/boot with stable `{code, field, message, ...}` objects; dry-run reports the same typed decision without side effects.

## Evidence

- `ocamlformat --check ...` — PASS
- `ocamlc -stop-after parsing -c ...` — PASS on every touched OCaml source/interface/test
- `bash scripts/check-variants.sh` — PASS
- `git diff --check` — PASS
- `scripts/dune-local.sh build test/test_keeper_create_validate.exe` — BLOCKED before Dune by the repo pin guard: installed OAS `b02bc16f...`, expected `902c45d2...`; the shared opam switch was not mutated and the guard was not bypassed
- focused Alcotest coverage includes missing fields, invalid names, all malformed mention-target indexes, dry-run/real decisions, and exact structured boundary JSON

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 0/0
provenance: n/a
stages: []
```

## GOAL LOOP ACT checklist

- [x] Observe — #24364 contains a mutable string-list validator and duplicate handler paths
- [x] Orient — the salvageable unit is the pre-boot validation boundary, not the umbrella create/meta/Goal rewrite
- [x] Decide — closed variants plus one pure decision function keep dry-run and real execution semantically identical
- [x] Act — changed only the persona runtime boundary, live handler, dead duplicate surface, and focused test registration
- [x] Verify — formatter, parser, variant guard, and diff checks pass; focused Dune build is explicitly pin-blocked and CI remains type authority
- [x] Loop — remaining #24364 concepts stay excluded for separate current-main PRs

## Review evidence

- Self-review: checked call-site uniqueness, exhaustive variant matches, no mutable validation accumulator, no substring assertions, and no retained duplicate handler.

## Linked issue

- Relates #24364

## Variant addition checklist

- [x] **OCaml** — variants are declared identically in `.ml`/`.mli`; all matches are exhaustive without wildcard fallback
- [ ] **TypeScript** — N/A: no dashboard union represents internal validation decisions
- [ ] **TLA+ spec** — N/A: no lifecycle domain changes
- [x] **Event / JSON schema** — typed errors are serialized at the tool boundary and asserted structurally in Alcotest; no enum registry applies
- [x] **`make check-variants` passes** — `bash scripts/check-variants.sh` PASS
