### PR TITLE
refactor(runtime): move artifact hydration to request projection

### DIFF
--- a/docs/spec/13-oas-integration.md
+++ b/docs/spec/13-oas-integration.md
@@ -54,7 +54,6 @@ graph TB
     OW[oas_worker.ml]
     WO[worker_oas.ml]
     VO[verifier_oas.ml]
-    CC[context_compact_oas.ml]
     OE[oas_events.ml]
     OSB[oas_event_bridge.ml]
     OM[oas_message.ml]
@@ -67,7 +66,6 @@ graph TB
     AG[Agent.t / Agent.run]
     BU[Builder]
     PR[Provider]
-    CR[Context_reducer]
     EB[Event_bus]
     GR[Guardrails]
     HK[Hooks]
@@ -81,7 +79,6 @@ graph TB
   WO -->|"worker lifecycle"| AG
   VO -->|"PreToolUse hook"| HK
   VO -->|"tool filter"| GR
-  CC -->|"strategy mapping"| CR
   OE -->|"Custom events"| EB
   OSB -->|"subscribe + relay"| EB
   OMR -->|"resolve labels"| CC2
@@ -99,7 +96,7 @@ graph TB
 | 단일 에이전트 실행 | `Agent.run`, `Builder`, `Hooks`, `Guardrails`, `Checkpoint` | 언제/왜/어떤 agent를 돌릴지 결정 |
 | 멀티에이전트 실행 | `Orchestrator`, `Agent_sdk_swarm.Runner` | workspace, board, workflow, policies |
 | 도구 실행 | `Tool.t`, hook lifecycle, raw trace | tool schema 정의, dispatch, auth |
-| 컨텍스트 축약 | `Context_reducer` | 어떤 전략을 언제 적용할지 결정 |
+| 컨텍스트 축약 | 없음; exact message history를 실행 | Keeper compaction, persisted-history repair, provider-bound artifact projection |
 | 이벤트 전달 | `Event_bus` | 어떤 MASC 사건을 publish할지, SSE/dashboard 연결 |
 | 장기 메모리 | 없음 | `Masc.Memory.t`, keeper memory bank, institution/procedural stores |
 | 조율 상태 | 없음 | workspace, tasks, board, keeper Gate |
@@ -125,13 +122,14 @@ type config = {
   max_tokens : int;
   temperature : float;
   hooks : Agent_sdk.Hooks.hooks option;
-  context_reducer : Agent_sdk.Context_reducer.t option;
   guardrails : Agent_sdk.Guardrails.t option;
   event_bus : Agent_sdk.Event_bus.t option;
   checkpoint_sink : Agent_sdk.Agent.checkpoint_sink option;
   session_id : string option;
   description : string option;
   initial_messages : Agent_sdk.Types.message list;
+  model_input_projection :
+    (Agent_sdk.Types.message list -> Agent_sdk.Types.message list) option;
   raw_trace : Agent_sdk.Raw_trace.t option;
   transport : Masc_grpc_transport.t;
 }
@@ -429,9 +427,11 @@ Allowed, LLM Auto Judge, 비차단 HITL 중 하나로 결정된다.
 
 ## 10. Context Compaction
 
-`context_compact_oas.ml`은 MASC 컨텍스트 전략을 OAS `Context_reducer`에 위임한다. 상세는 12-memory-systems.md 6.3절 참조.
-
-핵심: MASC `strategy` variant -> OAS `Context_reducer.strategy` 매핑. MASC-specific 로직(importance scoring, extractive summarizer)은 OAS `Custom` closure로 주입된다.
+Keeper compaction and persisted-history repair are MASC-owned. OAS receives the
+resulting exact message history without an implicit reducer. Provider-bound
+artifact hydration is a caller-owned `model_input_projection`; it changes only
+the request projection, while agent state and checkpoints retain their
+content-addressed markers.
 
 ---
 
@@ -448,7 +448,7 @@ remain MASC-owned under `Masc.Memory.t` and the `Keeper_memory_*` modules.
 | 영역 | 상태 | 설명 |
 |------|------|------|
 | Agent 실행 | Complete | `oas_worker.ml`이 모든 MODEL 호출을 Agent.run으로 라우팅 |
-| Context compaction | Complete | OAS Context_reducer 직접 위임, MASC Custom closure 주입 |
+| Context compaction | Complete | Keeper compaction is MASC-owned; OAS receives exact messages without an implicit reducer |
 | Event_bus bridge | Complete | OAS native/custom events are relayed to SSE and persisted under `.masc/oas-events/` |
 | Dashboard OAS runtime health | Complete | dashboard health uses `durable replay + live tail`, not live-only counters |
 | Dashboard runtime counts | Complete | dashboard `counts` carries active runtimes and `configured_keepers` carries inventory |

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -425,6 +425,12 @@ let run_turn
   let temporal_context = prompt_ctx.Keeper_run_prompt.temporal_context in
   let prompt_metrics = prompt_ctx.Keeper_run_prompt.prompt_metrics in
   let history_messages = prompt_ctx.Keeper_run_prompt.history_messages in
+  let resume_oas_checkpoint =
+    Option.map
+      (fun (checkpoint : Agent_sdk.Checkpoint.t) ->
+        { checkpoint with messages = history_messages })
+      resume_oas_checkpoint
+  in
   let estimated_input_tokens = prompt_ctx.Keeper_run_prompt.estimated_input_tokens in
   let ctx_work = prompt_ctx.Keeper_run_prompt.ctx_work in
   let history_messages_digest = digest_message_texts_as_joined history_messages in
@@ -545,7 +551,9 @@ let run_turn
             ]))
       Keeper_runtime_manifest.Context_injected;
     let hooks = s.Keeper_run_tools.hooks in
-    let reducer = s.Keeper_run_tools.reducer in
+    let model_input_projection =
+      s.Keeper_run_tools.model_input_projection
+    in
     let acc = s.Keeper_run_tools.acc in
     let agent_ref : Agent_sdk.Agent.t option ref = ref None in
     let receipt_turn_count_ref = s.Keeper_run_tools.receipt_turn_count_ref in
@@ -704,9 +712,9 @@ let run_turn
                     ~oas_auto_context_overflow_retry:true
                     ~checkpoint_sink
                     ~initial_messages
+                    ~model_input_projection
                     ~max_turns:keeper_max_turns
                     ~hooks
-                    ~context_reducer:reducer
                     ~runtime_manifest_context
                     ~runtime_manifest_append:
                       (fun manifest ->

--- a/lib/keeper/keeper_artifact_hydrator.ml
+++ b/lib/keeper/keeper_artifact_hydrator.ml
@@ -81,16 +81,5 @@ let hydrate_messages ~store ~keep_recent
   in
   List.rev mapped
 
-let hydrate_recent ~store ~keep_recent : Agent_sdk.Context_reducer.t =
-  let strategy =
-    Agent_sdk.Context_reducer.Custom (hydrate_messages ~store ~keep_recent)
-  in
-  { Agent_sdk.Context_reducer.strategy }
-
-let reducer_from_env () =
-  match (Host_config.from_env ()).base_path with
-  | None -> None
-  | Some base_path ->
-      let store = Tool_blob_store.create ~base_path in
-      let keep_recent = keep_recent_from_env () in
-      Some (hydrate_recent ~store ~keep_recent)
+let hydrate_recent ~store ~keep_recent messages =
+  hydrate_messages ~store ~keep_recent messages

--- a/lib/keeper/keeper_artifact_hydrator.mli
+++ b/lib/keeper/keeper_artifact_hydrator.mli
@@ -1,14 +1,12 @@
-(** Lazy artifact hydrator reducer.
+(** Lazy artifact hydrator projection.
 
     Reads ToolResult blocks whose [content] is a [Tool_output.Stored]
     blob marker and re-inflates the bytes from [Tool_blob_store]
     just before the LLM call. Older messages keep their markers, which
     cap the on-disk + on-wire token cost of historical context.
 
-    Inserted at the front of the keeper's reducer pipeline (BEFORE
-    [prune_tool_outputs]) so the standard cap still applies to hydrated
-    bytes — hydration restores the most recent K, the cap then trims
-    each to the per-output budget. *)
+    Applied only to the provider-bound message projection. Persisted keeper
+    history and OAS checkpoints retain their content-addressed markers. *)
 
 val default_keep_recent : int
 
@@ -20,8 +18,9 @@ val keep_recent_from_env : unit -> int
 val hydrate_recent :
   store:Tool_blob_store.t ->
   keep_recent:int ->
-  Agent_sdk.Context_reducer.t
-(** Build a [Custom] reducer that walks the message list right-to-left
+  Agent_sdk.Types.message list ->
+  Agent_sdk.Types.message list
+(** Walk the message list right-to-left
     and hydrates the last [keep_recent] [Stored] markers it encounters.
 
     Hydration misses (sha256 not in the store) leave the marker in
@@ -29,9 +28,4 @@ val hydrate_recent :
     preview) to reason about the missing payload.
 
     Storage exceptions are caught — a corrupted store cannot break the
-    reducer pipeline. *)
-
-val reducer_from_env : unit -> Agent_sdk.Context_reducer.t option
-(** Returns a configured reducer if a blob store can be resolved from
-    [MASC_BASE_PATH], else [None]. The [None] case lets callers compose
-    the pipeline conditionally without a separate enable flag. *)
+    provider-bound projection. *)

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -58,7 +58,8 @@ type agent_setup = Keeper_run_tools_hooks.agent_setup =
   { tools : Agent_sdk.Tool.t list
   ; cleanup : unit -> unit
   ; hooks : Agent_sdk.Hooks.hooks
-  ; reducer : Agent_sdk.Context_reducer.t
+  ; model_input_projection :
+      Agent_sdk.Types.message list -> Agent_sdk.Types.message list
   ; acc : hook_accumulator
   ; all_tool_names : string list
   ; tool_context_estimate : Keeper_run_prompt.tool_schema_context_estimate

--- a/lib/keeper/keeper_run_tools.mli
+++ b/lib/keeper/keeper_run_tools.mli
@@ -54,7 +54,8 @@ type agent_setup =
   { tools : Agent_sdk.Tool.t list
   ; cleanup : unit -> unit
   ; hooks : Agent_sdk.Hooks.hooks
-  ; reducer : Agent_sdk.Context_reducer.t
+  ; model_input_projection :
+      Agent_sdk.Types.message list -> Agent_sdk.Types.message list
   ; acc : hook_accumulator
   ; all_tool_names : string list
   ; tool_context_estimate : Keeper_run_prompt.tool_schema_context_estimate

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -14,7 +14,8 @@ type agent_setup =
   { tools : Agent_sdk.Tool.t list
   ; cleanup : unit -> unit
   ; hooks : Agent_sdk.Hooks.hooks
-  ; reducer : Agent_sdk.Context_reducer.t
+  ; model_input_projection :
+      Agent_sdk.Types.message list -> Agent_sdk.Types.message list
   ; acc : hook_accumulator
   ; all_tool_names : string list
   ; tool_context_estimate : Keeper_run_prompt.tool_schema_context_estimate
@@ -618,74 +619,17 @@ let assemble_hooks
       }
     in
     let hooks = Agent_sdk.Hooks.compose ~outer:before_turn_hook ~inner:base_hooks in
-    let reducer =
-      let hydrator_steps =
-        match Keeper_artifact_hydrator.reducer_from_env () with
-        | Some r -> [ r ]
-        | None -> []
-      in
-      let repair_broken_tool_call_pairs_observed messages =
-        let repaired, stats =
-          Keeper_context_core.repair_broken_tool_call_pairs_with_stats messages
-        in
-        let record kind delta =
-          if delta > 0 then
-            Otel_metric_store.inc_counter
-              Keeper_metrics.(to_string ToolPairRepair)
-              ~labels:[ "keeper", agent_name; "kind", kind; "site", "keeper_reducer" ]
-              ~delta:(float_of_int delta)
-              ()
-        in
-        record "dropped_tool_use" stats.dropped_tool_uses;
-        record "dropped_tool_result" stats.dropped_tool_results;
-        if Keeper_context_core.tool_pair_repair_stats_changed stats then (
-          let tool_use_sample_json =
-            List.map
-              (fun (tool_use_id, tool_name) ->
-                 `Assoc
-                   [ "tool_use_id", `String tool_use_id
-                   ; "tool_name", `String tool_name
-                   ])
-              stats.dropped_tool_use_samples
-          in
-          let tool_result_id_json =
-            List.map
-              (fun tool_use_id -> `String tool_use_id)
-              stats.dropped_tool_result_ids
-          in
-          Log.Harness.emit
-            Log.Warn
-            ~details:
-              (`Assoc
-                  [ "keeper_name", `String agent_name
-                  ; "site", `String "keeper_reducer"
-                  ; "dropped_tool_uses", `Int stats.dropped_tool_uses
-                  ; "dropped_tool_results", `Int stats.dropped_tool_results
-                  ; "dropped_tool_use_samples", `List tool_use_sample_json
-                  ; "dropped_tool_result_ids", `List tool_result_id_json
-                  ])
-            (Printf.sprintf
-               "keeper_reducer_pair_repair keeper=%s dropped_tool_uses=%d \
-                dropped_tool_results=%d"
-               agent_name
-               stats.dropped_tool_uses
-               stats.dropped_tool_results));
-        repaired
-      in
-      Agent_sdk.Context_reducer.compose
-        (hydrator_steps
-         @ [ { Agent_sdk.Context_reducer.strategy =
-                 Agent_sdk.Context_reducer.Custom
-                   repair_broken_tool_call_pairs_observed
-             }
-           ; Agent_sdk.Context_reducer.merge_contiguous
-           ])
+    let model_input_projection =
+      let store = Tool_blob_store.create ~base_path:ctx.config.base_path in
+      Keeper_artifact_hydrator.hydrate_recent
+        ~store
+        ~keep_recent:(Keeper_artifact_hydrator.keep_recent_from_env ())
     in
     Ok
       { tools
       ; cleanup = keeper_tools_cleanup
       ; hooks
-      ; reducer
+      ; model_input_projection
       ; acc
       ; all_tool_names
       ; tool_context_estimate

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -310,6 +310,7 @@ let run_named
     ?(system_prompt = "")
     ?(tools = [])
     ?(initial_messages = [])
+    ?model_input_projection
     ?(max_turns = Runtime_agent_context.unbounded_max_turns)
     ~max_idle_turns
     ?stream_idle_timeout_s
@@ -317,7 +318,6 @@ let run_named
     ?temperature
     ?(accept = fun (_ : Agent_sdk_response.api_response) -> true)
     ?hooks
-    ?context_reducer
     ?raw_trace
     ?on_event
     ?on_yield
@@ -640,6 +640,7 @@ let run_named
             ; system_prompt
             ; tools
             ; initial_messages
+            ; model_input_projection
             ; max_turns
             ; max_idle_turns
             ; stream_idle_timeout_s
@@ -647,7 +648,6 @@ let run_named
             ; temperature
             ; accept
             ; hooks
-            ; context_reducer
             ; raw_trace
             ; transport_resolved
             ; allowed_paths

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -81,6 +81,8 @@ val run_named :
   ?system_prompt:string ->
   ?tools:Agent_sdk.Tool.t list ->
   ?initial_messages:Agent_sdk.Types.message list ->
+  ?model_input_projection:
+    (Agent_sdk.Types.message list -> Agent_sdk.Types.message list) ->
   ?max_turns:int ->
   max_idle_turns:int ->
   ?stream_idle_timeout_s:float ->
@@ -88,7 +90,6 @@ val run_named :
   ?temperature:float ->
   ?accept:(Agent_sdk_response.api_response -> bool) ->
   ?hooks:Agent_sdk.Hooks.hooks ->
-  ?context_reducer:Agent_sdk.Context_reducer.t ->
   ?raw_trace:Agent_sdk.Raw_trace.t ->
   ?on_event:(Agent_sdk.Types.sse_event -> unit) ->
   ?on_yield:(unit -> unit) ->

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -29,6 +29,8 @@ type try_provider_ctx =
   ; system_prompt : string
   ; tools : Agent_sdk.Tool.t list
   ; initial_messages : Agent_sdk.Types.message list
+  ; model_input_projection :
+      (Agent_sdk.Types.message list -> Agent_sdk.Types.message list) option
   ; max_turns : int
   ; max_idle_turns : int
   ; stream_idle_timeout_s : float option
@@ -36,7 +38,6 @@ type try_provider_ctx =
   ; temperature : float option
   ; accept : Agent_sdk_response.api_response -> bool
   ; hooks : Agent_sdk.Hooks.hooks option
-  ; context_reducer : Agent_sdk.Context_reducer.t option
   ; raw_trace : Agent_sdk.Raw_trace.t option
   ; trace_link : (string * string) option
   ; (* Transport *)
@@ -245,7 +246,6 @@ let run_try_provider
           ; max_idle_turns = ctx.max_idle_turns
           ; guardrails = Some Agent_sdk.Guardrails.permissive
           ; hooks = ctx.hooks
-          ; context_reducer = ctx.context_reducer
           ; description =
               Some (Printf.sprintf "runtime:%s/runtime" ctx.runtime_id)
           ; transport = ctx.transport_resolved
@@ -270,6 +270,7 @@ let run_try_provider
           ; exit_condition_result = ctx.exit_condition_result
           ; summarizer = ctx.summarizer
           ; initial_messages = ctx.initial_messages
+          ; model_input_projection = ctx.model_input_projection
           ; raw_trace = ctx.raw_trace
           ; trace_link = ctx.trace_link
           ; yield_on_tool = ctx.yield_on_tool

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -12,6 +12,8 @@ type try_provider_ctx =
   ; system_prompt : string
   ; tools : Agent_sdk.Tool.t list
   ; initial_messages : Agent_sdk.Types.message list
+  ; model_input_projection :
+      (Agent_sdk.Types.message list -> Agent_sdk.Types.message list) option
   ; max_turns : int
   ; max_idle_turns : int
   ; stream_idle_timeout_s : float option
@@ -19,7 +21,6 @@ type try_provider_ctx =
   ; temperature : float option
   ; accept : Agent_sdk_response.api_response -> bool
   ; hooks : Agent_sdk.Hooks.hooks option
-  ; context_reducer : Agent_sdk.Context_reducer.t option
   ; raw_trace : Agent_sdk.Raw_trace.t option
   ; trace_link : (string * string) option
   ; transport_resolved : Masc_grpc_transport.t

--- a/lib/keeper/keeper_turn_driver_wrappers.ml
+++ b/lib/keeper/keeper_turn_driver_wrappers.ml
@@ -27,7 +27,6 @@ let config_for_label
     ?(max_idle_turns = 3)
     ?stream_idle_timeout_s
     ?hooks
-    ?context_reducer
     ?enable_thinking
     ?compact_ratio
     ?provider_config_transform
@@ -61,7 +60,6 @@ let config_for_label
       stream_idle_timeout_s;
       guardrails = Some Agent_sdk.Guardrails.permissive;
       hooks;
-      context_reducer;
       enable_thinking;
       description;
       compact_ratio;
@@ -85,7 +83,6 @@ let run_model_by_label
     ?max_tokens
     ?(accept = fun (_ : Agent_sdk_response.api_response) -> true)
     ?hooks
-    ?context_reducer
     ?enable_thinking
     ?compact_ratio
     ?provider_config_transform
@@ -98,7 +95,7 @@ let run_model_by_label
   let* config =
     config_for_label ~name:"oas-label-model" ~model_label ~system_prompt
       ~tools ~max_tokens ~temperature
-      ~max_idle_turns ?stream_idle_timeout_s ?hooks ?context_reducer
+      ~max_idle_turns ?stream_idle_timeout_s ?hooks
       ?enable_thinking
       ?compact_ratio
       ?provider_config_transform

--- a/lib/keeper/keeper_turn_driver_wrappers.mli
+++ b/lib/keeper/keeper_turn_driver_wrappers.mli
@@ -20,7 +20,6 @@ val run_model_by_label :
   ?max_tokens:int ->
   ?accept:(Agent_sdk_response.api_response -> bool) ->
   ?hooks:Agent_sdk.Hooks.hooks ->
-  ?context_reducer:Agent_sdk.Context_reducer.t ->
   ?enable_thinking:bool ->
   ?compact_ratio:float ->
   ?provider_config_transform:

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -102,12 +102,13 @@ type config =
   max_tokens : int option;
   temperature : float option;
   hooks : Agent_sdk.Hooks.hooks option;
-  context_reducer : Agent_sdk.Context_reducer.t option;
   guardrails : Agent_sdk.Guardrails.t option;
   event_bus : Agent_sdk.Event_bus.t option;
   session_id : string option;
   description : string option;
   initial_messages : Agent_sdk.Types.message list;
+  model_input_projection
+      : (Agent_sdk.Types.message list -> Agent_sdk.Types.message list) option;
   raw_trace : Agent_sdk.Raw_trace.t option;
   trace_link : (string * string) option;
   enable_thinking : bool option;
@@ -228,6 +229,7 @@ let observed_http_transport
     ~net
     ?clock
     ?body_timeout_s
+    ?model_input_projection
     ()
   : Llm_provider.Llm_transport.t =
   (* RFC-OAS-026: stream_idle_timeout_s moved off transport construction
@@ -245,6 +247,13 @@ let observed_http_transport
       ~net
       ()
   in
+  let project_request
+      (request : Llm_provider.Llm_transport.completion_request)
+    =
+    match model_input_projection with
+    | None -> request
+    | Some project -> { request with messages = project request.messages }
+  in
   provider_http_observation_transport
     { complete_sync =
       (fun req ->
@@ -252,17 +261,27 @@ let observed_http_transport
            per turn for each provider. Removed at Phase 0 closeout. *)
         Log.Misc.debug
           "rfc0095-trace: runtime_runner http_transport.complete_sync invoked";
-        http_transport.complete_sync req);
+        http_transport.complete_sync (project_request req));
       complete_stream =
       (fun ?on_telemetry ~on_event req ->
         (* RFC-0095 Phase 0 diagnostic trace — verify which transport path is invoked
            per turn for each provider. Removed at Phase 0 closeout. *)
         Log.Misc.debug
           "rfc0095-trace: runtime_runner http_transport.complete_stream invoked";
-        http_transport.complete_stream ?on_telemetry ~on_event req);
+        http_transport.complete_stream
+          ?on_telemetry
+          ~on_event
+          (project_request req));
     }
 
-let transport_for_provider ~sw ~net ?clock ?body_timeout_s () =
+let transport_for_provider
+    ~sw
+    ~net
+    ?clock
+    ?body_timeout_s
+    ?model_input_projection
+    ()
+  =
   (* CLI subprocess transport removed (2026-05-31); every provider dispatches
      over HTTP. Runtime MCP policy is applied via the tool-lane resolver and
      per-request patching, not at transport construction, so it is no longer
@@ -275,6 +294,7 @@ let transport_for_provider ~sw ~net ?clock ?body_timeout_s () =
           ~net
           ?clock
           ?body_timeout_s
+          ?model_input_projection
           ()))
 
 let runtime_id_of_config (config : config) =
@@ -888,6 +908,7 @@ let build
          ~net
          ?clock
          ?body_timeout_s:config.body_timeout_s
+         ?model_input_projection:config.model_input_projection
          ()
      with
      | Error _ as e -> e
@@ -982,6 +1003,7 @@ let resume_from_checkpoint
          ~net
          ?clock
          ?body_timeout_s:config.body_timeout_s
+         ?model_input_projection:config.model_input_projection
          ()
      with
      | Error _ as e -> e

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -80,12 +80,13 @@ type config = Runtime_agent_context.config = {
   max_tokens : int option;
   temperature : float option;
   hooks : Agent_sdk.Hooks.hooks option;
-  context_reducer : Agent_sdk.Context_reducer.t option;
   guardrails : Agent_sdk.Guardrails.t option;
   event_bus : Agent_sdk.Event_bus.t option;
   session_id : string option;
   description : string option;
   initial_messages : Agent_sdk.Types.message list;
+  model_input_projection
+      : (Agent_sdk.Types.message list -> Agent_sdk.Types.message list) option;
   raw_trace : Agent_sdk.Raw_trace.t option;
   trace_link : (string * string) option;
   enable_thinking : bool option;

--- a/lib/runtime/runtime_agent_context.ml
+++ b/lib/runtime/runtime_agent_context.ml
@@ -97,12 +97,15 @@ type config =
         request budget. *)
   ; temperature : float option
   ; hooks : Agent_sdk.Hooks.hooks option
-  ; context_reducer : Agent_sdk.Context_reducer.t option
   ; guardrails : Agent_sdk.Guardrails.t option
   ; event_bus : Agent_sdk.Event_bus.t option
   ; session_id : string option
   ; description : string option
   ; initial_messages : Agent_sdk.Types.message list
+  ; model_input_projection :
+      (Agent_sdk.Types.message list -> Agent_sdk.Types.message list) option
+    (** Caller-owned projection applied only to provider-bound messages.
+        Agent state and checkpoints retain their canonical persisted form. *)
   ; raw_trace : Agent_sdk.Raw_trace.t option
   ; trace_link : (string * string) option
   ; enable_thinking : bool option
@@ -168,12 +171,12 @@ let default_config
   ; max_tokens = None
   ; temperature = provider_cfg.temperature
   ; hooks = None
-  ; context_reducer = None
   ; guardrails = None
   ; event_bus = None
   ; session_id = None
   ; description = None
   ; initial_messages = []
+  ; model_input_projection = None
   ; raw_trace = None
   ; trace_link = None
   ; enable_thinking = None
@@ -269,11 +272,6 @@ let builder_without_approval
   let builder =
     match config.hooks with
     | Some h -> Agent_sdk.Builder.with_hooks h builder
-    | None -> builder
-  in
-  let builder =
-    match config.context_reducer with
-    | Some r -> Agent_sdk.Builder.with_context_reducer r builder
     | None -> builder
   in
   let builder =
@@ -464,7 +462,6 @@ let prepare_resume ~(config : config) ~(checkpoint : Agent_sdk.Checkpoint.t)
     ; max_execution_time_s = config.max_execution_time_s
     ; body_timeout_s = config.body_timeout_s
     ; guardrails = guardrails_of_config config
-    ; context_reducer = config.context_reducer
     ; context_injector = config.context_injector
     ; event_bus = config.event_bus
     ; raw_trace = config.raw_trace

--- a/lib/runtime/runtime_agent_context.mli
+++ b/lib/runtime/runtime_agent_context.mli
@@ -77,12 +77,13 @@ type config = {
       (** Exact caller/model sampling declaration. [None] omits temperature and
           leaves the selected provider's default intact. *)
   hooks : Agent_sdk.Hooks.hooks option;
-  context_reducer : Agent_sdk.Context_reducer.t option;
   guardrails : Agent_sdk.Guardrails.t option;
   event_bus : Agent_sdk.Event_bus.t option;
   session_id : string option;
   description : string option;
   initial_messages : Agent_sdk.Types.message list;
+  model_input_projection
+      : (Agent_sdk.Types.message list -> Agent_sdk.Types.message list) option;
   raw_trace : Agent_sdk.Raw_trace.t option;
   trace_link : (string * string) option;
   enable_thinking : bool option;

--- a/test/test_keeper_artifact_hydrator.ml
+++ b/test/test_keeper_artifact_hydrator.ml
@@ -1,7 +1,7 @@
 (** Tests for Keeper_artifact_hydrator.
 
     Pins the contract:
-    - The reducer hydrates only the LAST [keep_recent] Stored markers.
+    - The projection hydrates only the LAST [keep_recent] Stored markers.
     - Older Stored markers stay in the message list as markers.
     - Inline blocks pass through.
     - Hydration miss (sha not in store) leaves the marker untouched —
@@ -66,11 +66,6 @@ let extract_tool_content (msg : T.message) : string =
   | [ T.ToolResult { content; _ } ] -> content
   | _ -> failwith "expected single ToolResult block"
 
-let invoke_reducer reducer messages =
-  match reducer.Agent_sdk.Context_reducer.strategy with
-  | Agent_sdk.Context_reducer.Custom f -> f messages
-  | _ -> failwith "expected Custom strategy"
-
 (* --- Basic hydration --- *)
 
 let test_hydrates_recent_marker () =
@@ -80,7 +75,7 @@ let test_hydrates_recent_marker () =
       let _sha, marker = store_a_blob store payload in
       let msg = make_tool_message ~tool_use_id:"t1" ~content:marker in
       let r = H.hydrate_recent ~store ~keep_recent:3 in
-      let result = invoke_reducer r [ msg ] in
+      let result = r [ msg ] in
       Alcotest.(check int) "single message back" 1 (List.length result);
       Alcotest.(check string) "hydrated" payload
         (extract_tool_content (List.hd result)))
@@ -115,7 +110,7 @@ let test_hydration_preserves_tool_failure_provenance () =
         }
       in
       let result =
-        invoke_reducer (H.hydrate_recent ~store ~keep_recent:1) [ msg ]
+        H.hydrate_recent ~store ~keep_recent:1 [ msg ]
       in
       match (List.hd result).content with
       | [ T.ToolResult { content; outcome; _ } ] ->
@@ -135,7 +130,7 @@ let test_keep_recent_zero_no_hydration () =
       let _sha, marker = store_a_blob store "hello payload" in
       let msg = make_tool_message ~tool_use_id:"t1" ~content:marker in
       let r = H.hydrate_recent ~store ~keep_recent:0 in
-      let result = invoke_reducer r [ msg ] in
+      let result = r [ msg ] in
       Alcotest.(check string) "marker unchanged" marker
         (extract_tool_content (List.hd result)))
 
@@ -155,7 +150,7 @@ let test_only_last_k_hydrated () =
         ]
       in
       let r = H.hydrate_recent ~store ~keep_recent:2 in
-      let result = invoke_reducer r msgs in
+      let result = r msgs in
       Alcotest.(check int) "msg count preserved" 4 (List.length result);
       let contents = List.map extract_tool_content result in
       (match contents with
@@ -177,7 +172,7 @@ let test_inline_unchanged () =
       let inline_payload = "small inline payload" in
       let msg = make_tool_message ~tool_use_id:"t1" ~content:inline_payload in
       let r = H.hydrate_recent ~store ~keep_recent:3 in
-      let result = invoke_reducer r [ msg ] in
+      let result = r [ msg ] in
       Alcotest.(check string) "inline preserved" inline_payload
         (extract_tool_content (List.hd result)))
 
@@ -194,7 +189,7 @@ let test_non_tool_result_unchanged () =
         }
       in
       let r = H.hydrate_recent ~store ~keep_recent:3 in
-      let result = invoke_reducer r [ msg ] in
+      let result = r [ msg ] in
       Alcotest.(check int) "still one block" 1
         (List.length (List.hd result).content);
       match (List.hd result).content with
@@ -219,7 +214,7 @@ let test_hydration_miss_keeps_marker () =
       in
       let msg = make_tool_message ~tool_use_id:"t1" ~content:phantom in
       let r = H.hydrate_recent ~store ~keep_recent:3 in
-      let result = invoke_reducer r [ msg ] in
+      let result = r [ msg ] in
       Alcotest.(check string) "marker untouched" phantom
         (extract_tool_content (List.hd result)))
 

--- a/test/test_tool_output_washing_e2e.ml
+++ b/test/test_tool_output_washing_e2e.ml
@@ -9,7 +9,7 @@
         \u2193 marker string
       [Agent_sdk.Types.ToolResult { content = marker }]
         \u2193 message list with marker
-      [Keeper_artifact_hydrator.hydrate_recent]   <- PR 4 (reducer)
+      [Keeper_artifact_hydrator.hydrate_recent]   <- PR 4 (projection)
         \u2193 hydrated message list
       [Server_routes_http_routes_artifacts.blob_response]   <- PR 5 (endpoint)
         \u2193 JSON envelope with full content
@@ -114,11 +114,8 @@ let test_full_flow_externalize_hydrate_serve () =
       metadata = [];
         }
       in
-      let reducer = H.hydrate_recent ~store ~keep_recent:3 in
       let hydrated_msgs =
-        match reducer.Agent_sdk.Context_reducer.strategy with
-        | Agent_sdk.Context_reducer.Custom f -> f [ msg ]
-        | _ -> Alcotest.fail "expected Custom strategy"
+        H.hydrate_recent ~store ~keep_recent:3 [ msg ]
       in
       Alcotest.(check string) "hydrated content matches original payload"
         payload
@@ -184,12 +181,7 @@ let test_recency_budget_holds_across_modules () =
           make_msg ~id:"t4" m4;
         ]
       in
-      let reducer = H.hydrate_recent ~store ~keep_recent:2 in
-      let result =
-        match reducer.Agent_sdk.Context_reducer.strategy with
-        | Agent_sdk.Context_reducer.Custom f -> f msgs
-        | _ -> Alcotest.fail "expected Custom strategy"
-      in
+      let result = H.hydrate_recent ~store ~keep_recent:2 msgs in
       let contents = List.map extract_tool_content result in
       match contents with
       | [ c1; c2; c3; c4 ] ->


### PR DESCRIPTION
## What
- hard-delete the OAS `Context_reducer` carrier from the MASC runtime and Keeper driver
- convert `Keeper_artifact_hydrator` from an OAS reducer into a pure typed message projection
- apply that projection only to provider-bound requests
- keep persisted Agent state and checkpoints in their content-addressed marker form
- align resumed checkpoints with the Keeper pre-dispatch broken-tool-pair repair
- remove the former implicit `merge_contiguous` rewrite

## Why
OAS v0.212 removes `Context_reducer` and implicit message rewriting. MASC already owns Keeper compaction and repairs persisted history before dispatch. Artifact hydration is still live behavior, but it must remain a MASC request-boundary projection rather than being deleted or reintroduced as an OAS compatibility layer.

## Correctness and performance
- fresh and resumed runs share the same repaired Keeper history
- hydration changes only the LLM request; durable markers are not expanded in checkpoints
- the blob store and projection closure are created once per Keeper run
- per provider request, hydration retains the existing linear message pass; no model/provider string matching, context budget gate, or automatic merge heuristic was added

## Validation
- `ocamlformat -i` on changed OCaml files
- `ocamlc -stop-after parsing` on changed OCaml files
- `git diff --check`
- `MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build lib/masc.cma` against OAS v0.212 passes the deleted `Context_reducer` boundary and stops at the next independent migration surface: removed `Agent_sdk.Guardrails`

## Scope
19 files, +96/-152 (248 changed lines). No compatibility shim, silent fallback, substring inference, or turn/cost/token execution limit.