### PR TITLE
refactor(runtime): delete OAS compaction policy carriers

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -514,8 +514,8 @@ let run_turn
         ~max_context
     in
     (* This aggregate estimate is observation only. It neither suppresses
-       context nor fabricates a pre-dispatch failure. OAS receives the complete
-       request and owns typed ContextOverflow/compaction. *)
+       context nor fabricates a pre-dispatch failure. OAS transports the complete
+       request and reports typed ContextOverflow; MASC owns lane compaction. *)
     let pre_dispatch_over_context_window =
       context_window_observation.observed_over_context_tokens > 0
     in
@@ -707,9 +707,6 @@ let run_turn
                     ?raw_trace
                     ~system_prompt:turn_system_prompt
                     ~tools
-                    ~compact_ratio:meta.compaction.ratio_gate
-                    ~context_window_tokens:max_context
-                    ~oas_auto_context_overflow_retry:true
                     ~checkpoint_sink
                     ~initial_messages
                     ~model_input_projection

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -93,48 +93,6 @@ let project_provider_attempt_result ~replay_prefix_projection provider_result =
   { provider_result; turn_result }
 ;;
 
-type context_window_rebudget =
-  { requested_context_window : int option
-  ; final_runtime_context_window : int
-  ; resolved_context_window : int
-  ; context_window_rebudgeted : bool
-  }
-
-let resolve_context_window_tokens_after_runtime_selection
-    ~(requested_context_window : int option)
-    ~(final_runtime_context_window : int)
-    : (context_window_rebudget, Agent_sdk.Error.sdk_error) result =
-  let invalid_requested_context_window value =
-    Agent_sdk.Error.Config
-      (Agent_sdk.Error.InvalidConfig
-         { field = "context_window_tokens"
-         ; detail =
-             Printf.sprintf
-               "requested_context_window must be positive when provided (got %d)"
-               value
-         })
-  in
-  match requested_context_window with
-  | Some value when value <= 0 -> Error (invalid_requested_context_window value)
-  | Some requested ->
-    let resolved_context_window = min requested final_runtime_context_window in
-    Ok
-      { requested_context_window
-      ; final_runtime_context_window
-      ; resolved_context_window
-      ; context_window_rebudgeted =
-          (match requested_context_window with
-           | Some value when value > 0 -> value <> resolved_context_window
-           | Some _ | None -> false)
-      }
-  | None ->
-    Ok
-      { requested_context_window
-      ; final_runtime_context_window
-      ; resolved_context_window = final_runtime_context_window
-      ; context_window_rebudgeted = false
-      }
-
 let runtime_attempt_decision ~idx ~runtime_id =
   `Assoc [ ("idx", `Int idx); ("runtime_id", `String runtime_id) ]
 
@@ -329,9 +287,6 @@ let run_named
     ?(cache_system_prompt = false)
     ?(yield_on_tool = false)
     ?tool_failure_judge
-    ?compact_ratio
-    ?context_window_tokens
-    ?(oas_auto_context_overflow_retry = true)
     ?checkpoint_sink
     ?context_injector
     ?context
@@ -339,7 +294,6 @@ let run_named
     ?approval
     ?exit_condition
     ?exit_condition_result
-    ?summarizer
     ?oas_checkpoint
     ?trace_link
     ?event_bus
@@ -455,15 +409,10 @@ let run_named
     dedupe_runtimes_preserve_order (first_runtime :: remaining_runtimes)
   in
   let assigned_runtime_context_window =
-    Some (Runtime.max_context_of_runtime first_candidate)
+    Runtime.max_context_of_runtime first_candidate
   in
   let first_runtime_context_window =
     Runtime.max_context_of_runtime first_runtime
-  in
-  let* first_context_window_rebudget =
-    resolve_context_window_tokens_after_runtime_selection
-      ~requested_context_window:context_window_tokens
-      ~final_runtime_context_window:first_runtime_context_window
   in
   (match reroute_decision with
    | Runtime_agent.Reroute { reason; _ } ->
@@ -478,22 +427,8 @@ let run_named
                 ("routing_reason", `String reason);
                 ("assigned_runtime_id", `String first_candidate_id);
                 ("rerouted_runtime_id", `String first_runtime_id);
-                ( "assigned_context_window",
-                  match assigned_runtime_context_window with
-                  | Some value -> `Int value
-                  | None -> `Null );
-                ( "requested_context_window",
-                  match
-                    first_context_window_rebudget.requested_context_window
-                  with
-                  | Some value -> `Int value
-                  | None -> `Null );
-                ( "final_runtime_context_window",
-                  `Int first_context_window_rebudget.final_runtime_context_window );
-                ( "resolved_context_window",
-                  `Int first_context_window_rebudget.resolved_context_window );
-                ( "context_window_rebudgeted",
-                  `Bool first_context_window_rebudget.context_window_rebudgeted );
+                ("assigned_context_window", `Int assigned_runtime_context_window);
+                ("rerouted_context_window", `Int first_runtime_context_window);
               ]))
        Keeper_runtime_manifest.Runtime_routed
    | Runtime_agent.No_reroute_needed | Runtime_agent.No_capable_runtime _ -> ());
@@ -600,19 +535,7 @@ let run_named
           ~fallback_enable_thinking:enable_thinking
           ()
       in
-      let final_runtime_context_window =
-        Runtime.max_context_of_runtime runtime
-      in
-      let context_window_rebudget_res =
-        resolve_context_window_tokens_after_runtime_selection
-          ~requested_context_window:context_window_tokens
-          ~final_runtime_context_window
-      in
-      match context_window_rebudget_res with
-      | Error err -> Error err, None
-      | Ok context_window_rebudget ->
-      let context_window_tokens = Some context_window_rebudget.resolved_context_window in
-      (match
+      match
          match provider_config_transform with
          | None -> Ok runtime.Runtime.provider_config
          | Some transform -> transform runtime.Runtime.provider_config
@@ -655,9 +578,6 @@ let run_named
             ; cache_system_prompt
             ; yield_on_tool
             ; tool_failure_judge
-            ; compact_ratio
-            ; context_window_tokens
-            ; oas_auto_context_overflow_retry
             ; checkpoint_sink
             ; checkpoint_stage_observed
             ; context_injector
@@ -667,7 +587,6 @@ let run_named
             ; approval
             ; exit_condition
             ; exit_condition_result
-            ; summarizer
             ; oas_checkpoint
             ; trace_link
             ; sw
@@ -693,7 +612,7 @@ let run_named
               ~replay_prefix_projection
               provider_result
           in
-          outcomes.turn_result, checkpoint_after))
+          outcomes.turn_result, checkpoint_after)
     attempt_runtimes
 
 
@@ -720,9 +639,6 @@ module For_testing = struct
 
   let same_run_retry_allowed =
     Keeper_turn_driver_try_provider.same_run_retry_allowed
-
-  let resolve_context_window_tokens_after_runtime_selection =
-    resolve_context_window_tokens_after_runtime_selection
 
   let accept_no_progress_should_try_next =
     Keeper_turn_driver_try_runtime.accept_no_progress_should_try_next

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -62,13 +62,6 @@ val provider_attempt_started_decision :
 val provider_attempt_finished_decision :
   provider_attempt_finished_record -> Yojson.Safe.t
 
-type context_window_rebudget =
-  { requested_context_window : int option
-  ; final_runtime_context_window : int
-  ; resolved_context_window : int
-  ; context_window_rebudgeted : bool
-  }
-
 (** {1 Named runtime execution} *)
 
 val run_named :
@@ -101,9 +94,6 @@ val run_named :
   ?cache_system_prompt:bool ->
   ?yield_on_tool:bool ->
   ?tool_failure_judge:Agent_sdk.Tool_failure_recovery.judge ->
-  ?compact_ratio:float ->
-  ?context_window_tokens:int ->
-  ?oas_auto_context_overflow_retry:bool ->
   ?checkpoint_sink:Agent_sdk.Agent.checkpoint_sink ->
   ?context_injector:Agent_sdk.Hooks.context_injector ->
   ?context:Agent_sdk.Context.t ->
@@ -111,7 +101,6 @@ val run_named :
   ?approval:Agent_sdk.Hooks.approval_callback ->
   ?exit_condition:(int -> bool) ->
   ?exit_condition_result:(int -> Runtime_agent.stop_reason * string option) ->
-  ?summarizer:(Agent_sdk.Types.message list -> string) ->
   ?oas_checkpoint:Agent_sdk.Checkpoint.t ->
   ?trace_link:string * string ->
   ?event_bus:Agent_sdk.Event_bus.t ->
@@ -185,11 +174,6 @@ module For_testing : sig
 
   val media_degrade_manifest_decision :
     runtime_id:string -> (string * int) list -> Yojson.Safe.t
-
-  val resolve_context_window_tokens_after_runtime_selection :
-    requested_context_window:int option ->
-    final_runtime_context_window:int ->
-    (context_window_rebudget, Agent_sdk.Error.sdk_error) result
 
   val attempt_inference_policy :
     runtime_id:string ->

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -48,9 +48,6 @@ type try_provider_ctx =
   ; cache_system_prompt : bool
   ; yield_on_tool : bool
   ; tool_failure_judge : Agent_sdk.Tool_failure_recovery.judge option
-  ; compact_ratio : float option
-  ; context_window_tokens : int option
-  ; oas_auto_context_overflow_retry : bool
   ; checkpoint_sink : Agent_sdk.Agent.checkpoint_sink option
   ; checkpoint_stage_observed : bool Atomic.t
   ; context_injector : Agent_sdk.Hooks.context_injector option
@@ -60,7 +57,6 @@ type try_provider_ctx =
   ; approval : Agent_sdk.Hooks.approval_callback option
   ; exit_condition : (int -> bool) option
   ; exit_condition_result : (int -> Runtime_agent.stop_reason * string option) option
-  ; summarizer : (Agent_sdk.Types.message list -> string) option
   ; oas_checkpoint : Agent_sdk.Checkpoint.t option
   ; (* Eio concurrency *)
     sw : Eio.Switch.t
@@ -253,9 +249,6 @@ let run_try_provider
           ; checkpoint_sidecar = ctx.checkpoint_sidecar
           ; session_id = ctx.session_id
           ; cache_system_prompt = ctx.cache_system_prompt
-          ; compact_ratio = ctx.compact_ratio
-          ; context_window_tokens = ctx.context_window_tokens
-          ; oas_auto_context_overflow_retry = ctx.oas_auto_context_overflow_retry
           ; checkpoint_sink = Some checkpoint_sink
           ; context_injector = ctx.context_injector
           ; context = ctx.context
@@ -268,7 +261,6 @@ let run_try_provider
           ; approval = ctx.approval
           ; exit_condition = ctx.exit_condition
           ; exit_condition_result = ctx.exit_condition_result
-          ; summarizer = ctx.summarizer
           ; initial_messages = ctx.initial_messages
           ; model_input_projection = ctx.model_input_projection
           ; raw_trace = ctx.raw_trace

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -29,9 +29,6 @@ type try_provider_ctx =
   ; cache_system_prompt : bool
   ; yield_on_tool : bool
   ; tool_failure_judge : Agent_sdk.Tool_failure_recovery.judge option
-  ; compact_ratio : float option
-  ; context_window_tokens : int option
-  ; oas_auto_context_overflow_retry : bool
   ; checkpoint_sink : Agent_sdk.Agent.checkpoint_sink option
   ; checkpoint_stage_observed : bool Atomic.t
   ; context_injector : Agent_sdk.Hooks.context_injector option
@@ -41,7 +38,6 @@ type try_provider_ctx =
   ; approval : Agent_sdk.Hooks.approval_callback option
   ; exit_condition : (int -> bool) option
   ; exit_condition_result : (int -> Runtime_agent.stop_reason * string option) option
-  ; summarizer : (Agent_sdk.Types.message list -> string) option
   ; oas_checkpoint : Agent_sdk.Checkpoint.t option
   ; sw : Eio.Switch.t
   ; net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t

--- a/lib/keeper/keeper_turn_driver_wrappers.ml
+++ b/lib/keeper/keeper_turn_driver_wrappers.ml
@@ -28,7 +28,6 @@ let config_for_label
     ?stream_idle_timeout_s
     ?hooks
     ?enable_thinking
-    ?compact_ratio
     ?provider_config_transform
     ?approval
     ~(description : string option)
@@ -62,7 +61,6 @@ let config_for_label
       hooks;
       enable_thinking;
       description;
-      compact_ratio;
       approval;
     }
 
@@ -84,7 +82,6 @@ let run_model_by_label
     ?(accept = fun (_ : Agent_sdk_response.api_response) -> true)
     ?hooks
     ?enable_thinking
-    ?compact_ratio
     ?provider_config_transform
     ?on_event
     ?transport
@@ -97,7 +94,6 @@ let run_model_by_label
       ~tools ~max_tokens ~temperature
       ~max_idle_turns ?stream_idle_timeout_s ?hooks
       ?enable_thinking
-      ?compact_ratio
       ?provider_config_transform
       ~description:(Some (Printf.sprintf "model_label:%s" model_label))
       ()
@@ -175,7 +171,6 @@ let run_named_with_masc_tools
     ?on_resume
     ?transport
     ?(yield_on_tool = false)
-    ?compact_ratio
     ?approval
     ?max_turns
     ?(max_idle_turns = 3)
@@ -196,7 +191,6 @@ let run_named_with_masc_tools
     ?temperature
     ?stream_idle_timeout_s ?hooks
     ~accept
-    ?compact_ratio
     ?approval
     ?raw_trace ?on_event ?on_yield ?on_resume 
     ?transport ~yield_on_tool ?provider_config_transform ?sw ?net ()
@@ -212,7 +206,6 @@ let run_model_with_masc_tools
     ?max_tokens
     ?hooks
     ?enable_thinking
-    ?compact_ratio
     ?provider_config_transform
     ?raw_trace
     ?on_event
@@ -225,7 +218,6 @@ let run_model_with_masc_tools
     config_for_label ~name:"oas-explicit-model" ~model_label ~system_prompt
       ~tools:[] ~max_tokens ~temperature
       ?stream_idle_timeout_s ?hooks ?enable_thinking
-      ?compact_ratio
       ?provider_config_transform
       ~description:(Some (Printf.sprintf "model_label:%s" model_label))
       ()

--- a/lib/keeper/keeper_turn_driver_wrappers.mli
+++ b/lib/keeper/keeper_turn_driver_wrappers.mli
@@ -21,7 +21,6 @@ val run_model_by_label :
   ?accept:(Agent_sdk_response.api_response -> bool) ->
   ?hooks:Agent_sdk.Hooks.hooks ->
   ?enable_thinking:bool ->
-  ?compact_ratio:float ->
   ?provider_config_transform:
     (Llm_provider.Provider_config.t ->
     (Llm_provider.Provider_config.t, Agent_sdk.Error.sdk_error) result) ->
@@ -54,7 +53,6 @@ val run_named_with_masc_tools :
   ?on_resume:(unit -> unit) ->
   ?transport:Masc_grpc_transport.t ->
   ?yield_on_tool:bool ->
-  ?compact_ratio:float ->
   ?approval:Agent_sdk.Hooks.approval_callback ->
   ?max_turns:int ->
   ?max_idle_turns:int ->
@@ -81,7 +79,6 @@ val run_model_with_masc_tools :
   ?max_tokens:int ->
   ?hooks:Agent_sdk.Hooks.hooks ->
   ?enable_thinking:bool ->
-  ?compact_ratio:float ->
   ?provider_config_transform:
     (Llm_provider.Provider_config.t ->
     (Llm_provider.Provider_config.t, Agent_sdk.Error.sdk_error) result) ->

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -119,17 +119,11 @@ type config =
   cache_system_prompt : bool;
   yield_on_tool : bool;
   tool_failure_judge : Agent_sdk.Tool_failure_recovery.judge option;
-  compact_ratio : float option;
-  context_window_tokens : int option;
-  oas_auto_context_overflow_retry : bool;
   context_injector : Agent_sdk.Hooks.context_injector option;
   context : Agent_sdk.Context.t option;
   approval : Agent_sdk.Hooks.approval_callback option;
   exit_condition : (int -> bool) option;
   exit_condition_result : (int -> stop_reason * string option) option;
-  summarizer : (Agent_sdk.Types.message list -> string) option;
-      (** Custom summarizer for OAS [Budget_strategy.reduce_for_budget]
-          Emergency-phase compaction. Defaults to OAS's extractive default. *)
   thinking_budget : int option;
   top_p : float option;
   top_k : int option;
@@ -1022,7 +1016,6 @@ let resume_from_checkpoint
            ~options ~config:prepared_resume.agent_config
            ?checkpoint_sink:config.checkpoint_sink
            ?tool_failure_judge:config.tool_failure_judge
-           ~auto_context_overflow_retry:config.oas_auto_context_overflow_retry
            ()))
 
 (* ================================================================ *)

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -97,15 +97,11 @@ type config = Runtime_agent_context.config = {
   cache_system_prompt : bool;
   yield_on_tool : bool;
   tool_failure_judge : Agent_sdk.Tool_failure_recovery.judge option;
-  compact_ratio : float option;
-  context_window_tokens : int option;
-  oas_auto_context_overflow_retry : bool;
   context_injector : Agent_sdk.Hooks.context_injector option;
   context : Agent_sdk.Context.t option;
   approval : Agent_sdk.Hooks.approval_callback option;
   exit_condition : (int -> bool) option;
   exit_condition_result : (int -> stop_reason * string option) option;
-  summarizer : (Agent_sdk.Types.message list -> string) option;
   thinking_budget : int option;
   top_p : float option;
   top_k : int option;

--- a/lib/runtime/runtime_agent_context.ml
+++ b/lib/runtime/runtime_agent_context.ml
@@ -116,17 +116,11 @@ type config =
   ; cache_system_prompt : bool
   ; yield_on_tool : bool
   ; tool_failure_judge : Agent_sdk.Tool_failure_recovery.judge option
-  ; compact_ratio : float option
-  ; context_window_tokens : int option
-  ; oas_auto_context_overflow_retry : bool
   ; context_injector : Agent_sdk.Hooks.context_injector option
   ; context : Agent_sdk.Context.t option
   ; approval : Agent_sdk.Hooks.approval_callback option
   ; exit_condition : (int -> bool) option
   ; exit_condition_result : (int -> stop_reason * string option) option
-  ; summarizer : (Agent_sdk.Types.message list -> string) option
-    (** Custom summarizer for OAS [Budget_strategy.reduce_for_budget]
-          Emergency-phase compaction. Defaults to OAS's extractive default. *)
   ; thinking_budget : int option
     (** Token budget for extended thinking, forwarded to OAS
         [Builder.with_thinking_budget]. Only meaningful when
@@ -187,15 +181,11 @@ let default_config
   ; cache_system_prompt = false
   ; yield_on_tool = false
   ; tool_failure_judge = None
-  ; compact_ratio = None
-  ; context_window_tokens = None
-  ; oas_auto_context_overflow_retry = true
   ; context_injector = None
   ; context = None
   ; approval = None
   ; exit_condition = None
   ; exit_condition_result = None
-  ; summarizer = None
   ; thinking_budget = None
   ; top_p = provider_cfg.top_p
   ; top_k = provider_cfg.top_k
@@ -320,28 +310,6 @@ let builder_without_approval
     else builder
   in
   let builder =
-    match config.context_window_tokens with
-    | Some window ->
-      let compact_ratio =
-        Option.value
-          ~default:Agent_sdk.Types.default_context_compact_ratio
-          config.compact_ratio
-      in
-      Agent_sdk.Builder.with_context_thresholds
-        ~compact_ratio
-        ~context_window_tokens:window
-        builder
-    | None ->
-      (match config.compact_ratio with
-       | Some ratio -> Agent_sdk.Builder.with_context_thresholds ~compact_ratio:ratio builder
-       | None -> builder)
-  in
-  let builder =
-    Agent_sdk.Builder.with_auto_context_overflow_retry
-      config.oas_auto_context_overflow_retry
-      builder
-  in
-  let builder =
     match config.context_injector with
     | Some injector -> Agent_sdk.Builder.with_context_injector injector builder
     | None -> builder
@@ -354,11 +322,6 @@ let builder_without_approval
   let builder =
     match config.exit_condition with
     | Some cond -> Agent_sdk.Builder.with_exit_condition cond builder
-    | None -> builder
-  in
-  let builder =
-    match config.summarizer with
-    | Some s -> Agent_sdk.Builder.with_summarizer s builder
     | None -> builder
   in
   let builder =
@@ -450,7 +413,6 @@ let prepare_resume ~(config : config) ~(checkpoint : Agent_sdk.Checkpoint.t)
     ; thinking_budget = config.thinking_budget
     ; cache_system_prompt = config.cache_system_prompt
     ; yield_on_tool = config.yield_on_tool
-    ; context_compact_ratio = config.compact_ratio
     ; exit_condition = config.exit_condition
     }
   in
@@ -470,7 +432,6 @@ let prepare_resume ~(config : config) ~(checkpoint : Agent_sdk.Checkpoint.t)
     ; approval = config.approval
     ; missing_approval_callback_policy =
         Agent_sdk.Hooks.Reject_without_callback
-    ; summarizer = config.summarizer
     ; on_run_complete = config.on_run_complete
     }
   in

--- a/lib/runtime/runtime_agent_context.mli
+++ b/lib/runtime/runtime_agent_context.mli
@@ -94,18 +94,11 @@ type config = {
   cache_system_prompt : bool;
   yield_on_tool : bool;
   tool_failure_judge : Agent_sdk.Tool_failure_recovery.judge option;
-  compact_ratio : float option;
-  context_window_tokens : int option;
-      (** Input/context window basis forwarded to OAS
-          [Builder.with_context_thresholds]. Distinct from [max_tokens],
-          which limits response output tokens. *)
-  oas_auto_context_overflow_retry : bool;
   context_injector : Agent_sdk.Hooks.context_injector option;
   context : Agent_sdk.Context.t option;
   approval : Agent_sdk.Hooks.approval_callback option;
   exit_condition : (int -> bool) option;
   exit_condition_result : (int -> stop_reason * string option) option;
-  summarizer : (Agent_sdk.Types.message list -> string) option;
   thinking_budget : int option;
       (** Token budget for extended thinking, forwarded to OAS
           [Builder.with_thinking_budget]. Only meaningful when

--- a/test/test_keeper_runtime_observation_boundaries.ml
+++ b/test/test_keeper_runtime_observation_boundaries.ml
@@ -388,24 +388,6 @@ let test_keeper_context_estimates_use_context_facade () =
      || contains_substring hook_source
           "Agent_sdk.Context_reducer.estimate_char_tokens")
 
-let test_keeper_passes_context_window_to_oas_thresholds () =
-  let source = read_file "lib/keeper/keeper_agent_run.ml" in
-  Alcotest.(check bool)
-    "keeper run_named receives effective max_context as context window"
-    true
-    (contains_substring source "~context_window_tokens:max_context")
-
-let test_oas_thresholds_do_not_use_output_max_tokens_as_context_window () =
-  let source = read_file "lib/runtime/runtime_agent_context.ml" in
-  Alcotest.(check bool)
-    "thresholds use explicit context_window_tokens"
-    true
-    (contains_substring source "match config.context_window_tokens with");
-  Alcotest.(check bool)
-    "output max_tokens is not reused as context window"
-    false
-    (contains_substring source "~context_window_tokens:config.max_tokens")
-
 let () =
   Alcotest.run "keeper_runtime_observation_boundaries"
   [
@@ -449,9 +431,5 @@ let () =
           test_keeper_preflight_reuses_setup_tool_estimate;
         Alcotest.test_case "keeper context estimates use context facade" `Quick
           test_keeper_context_estimates_use_context_facade;
-        Alcotest.test_case "keeper passes context window to OAS thresholds" `Quick
-          test_keeper_passes_context_window_to_oas_thresholds;
-        Alcotest.test_case "OAS thresholds keep output max_tokens separate" `Quick
-          test_oas_thresholds_do_not_use_output_max_tokens_as_context_window;
       ] );
   ]

--- a/test/test_runtime_modality_reroute.ml
+++ b/test/test_runtime_modality_reroute.ml
@@ -444,67 +444,6 @@ let test_driver_degrade_branch_emits_manifest () =
      && string_contains source "media_degrade_manifest_decision"
      && string_contains source "Keeper_runtime_manifest.Runtime_routed")
 
-let test_reroute_context_window_rebudgets_to_final_runtime () =
-  let rebudget =
-    Masc.Keeper_turn_driver.For_testing
-    .resolve_context_window_tokens_after_runtime_selection
-      ~requested_context_window:(Some 524_288)
-      ~final_runtime_context_window:131_072
-  in
-  let rebudget =
-    match rebudget with
-    | Ok rebudget -> rebudget
-    | Error err ->
-      Alcotest.failf
-        "expected context-window rebudget success, got %s"
-        (Agent_sdk.Error.to_string err)
-  in
-  check (option int) "requested window" (Some 524_288)
-    rebudget.Masc.Keeper_turn_driver.requested_context_window;
-  check int "final runtime window" 131_072
-    rebudget.final_runtime_context_window;
-  check int "resolved window clamps to final runtime" 131_072
-    rebudget.resolved_context_window;
-  check bool "rebudgeted" true rebudget.context_window_rebudgeted
-
-let test_context_window_rebudget_rejects_nonpositive_request () =
-  let assert_invalid value =
-    match
-      Masc.Keeper_turn_driver.For_testing
-      .resolve_context_window_tokens_after_runtime_selection
-        ~requested_context_window:(Some value)
-        ~final_runtime_context_window:131_072
-    with
-    | Ok rebudget ->
-      Alcotest.failf
-        "expected invalid context-window request %d to fail, got resolved=%d"
-        value
-        rebudget.resolved_context_window
-    | Error
-        (Agent_sdk.Error.Config
-           (Agent_sdk.Error.InvalidConfig { field = "context_window_tokens"; detail })) ->
-      check bool
-        ("detail mentions requested_context_window for " ^ string_of_int value)
-        true
-        (string_contains detail "requested_context_window must be positive")
-    | Error err ->
-      Alcotest.failf
-        "expected InvalidConfig for context-window request %d, got %s"
-        value
-        (Agent_sdk.Error.to_string err)
-  in
-  assert_invalid 0;
-  assert_invalid (-1)
-
-let test_driver_reroute_manifest_records_context_window_rebudget () =
-  let source = read_file "lib/keeper/keeper_turn_driver.ml" in
-  check bool "reroute branch emits context-window rebudget manifest" true
-    (string_contains source "modality_rerouted"
-     && string_contains source "requested_context_window"
-     && string_contains source "final_runtime_context_window"
-     && string_contains source "resolved_context_window"
-     && string_contains source "context_window_rebudgeted")
-
 let test_runtime_agent_oas_tool_hook_fails_typed_not_failwith () =
   let source = read_file "lib/runtime/runtime_agent.ml" in
   check bool "legacy failwith hook removed" false
@@ -557,12 +496,6 @@ let () =
             test_media_degrade_preserves_already_canonical_checkpoint
         ; test_case "driver degrade branch emits manifest" `Quick
             test_driver_degrade_branch_emits_manifest
-        ; test_case "reroute context window rebudgets to final runtime" `Quick
-            test_reroute_context_window_rebudgets_to_final_runtime
-        ; test_case "non-positive context window request fails closed" `Quick
-            test_context_window_rebudget_rejects_nonpositive_request
-        ; test_case "driver reroute manifest records context rebudget" `Quick
-            test_driver_reroute_manifest_records_context_window_rebudget
         ; test_case "runtime agent OAS tool hook typed failure" `Quick
             test_runtime_agent_oas_tool_hook_fails_typed_not_failwith
         ] )


### PR DESCRIPTION
## 변경
- Runtime → Keeper turn driver → provider attempt 경로의 compact_ratio, context_window_tokens, OAS auto-overflow-retry, OAS summarizer carrier를 삭제합니다.
- OAS context threshold/automatic retry builder 및 resume 배선을 삭제합니다.
- runtime 선택 뒤 context-window clamp/rebudget 정책을 삭제합니다.
- runtime context window는 routing manifest의 관측값으로만 남깁니다.
- 삭제된 OAS 정책만 고정하던 테스트를 함께 제거합니다.

## 경계
- OAS는 complete request를 운반하고 typed ContextOverflow를 반환하는 데서 끝납니다.
- LLM Compaction은 MASC Keeper Lane이 소유하며 별도 배선 PR에서 실제 연결합니다.
- 새 reducer, threshold, numeric fallback, compatibility shim은 없습니다.

## 검증
- GitHub diff 7 additions + 279 deletions = 286 lines
- git diff --check 통과
- touched OCaml ocamlformat check 및 parsing 통과
- focused Dune은 설치 agent_sdk pin drift와 다음 독립 잔여 Agent_sdk.Guardrails에서 중단되었으며 green을 주장하지 않습니다.