### PR TITLE
refactor(keeper): preserve exact LLM compaction input

### DIFF
--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -6,17 +6,6 @@
 module Schema = Keeper_structured_output_schema
 module Int_set = Set.Make (Int)
 
-(* Bound the summary output. Larger than the memory-bank 512 because a
-   compaction summary stands in for many messages, but still capped so the
-   emergency path (a near-full context) cannot request an unbounded reply. *)
-let summary_max_tokens = 1024
-
-(* Bound the serialized working set handed to the model. A compaction fires
-   near the context limit, so the notes text must itself be bounded well below
-   the window; the model classifies by index, so truncation loses tail detail
-   but never the index mapping (the tail simply lands in [kept]). *)
-let max_notes_bytes = 24_000
-
 type compaction_plan =
   { summary : string
   ; kept : int list
@@ -43,14 +32,8 @@ let is_direct_completion_provider (provider_cfg : Llm_provider.Provider_config.t
   | Anthropic | Kimi | OpenAI_compat | Ollama | Gemini | Glm | DashScope -> true
 
 let provider_for_plan (provider_cfg : Llm_provider.Provider_config.t) =
-  let max_tokens =
-    match provider_cfg.max_tokens with
-    | Some n when n > 0 -> Some (min n summary_max_tokens)
-    | _ -> Some summary_max_tokens
-  in
   { provider_cfg with
-    max_tokens
-  ; tool_choice = None
+    tool_choice = None
   ; disable_parallel_tool_use = true
   }
   (* Full module path (not the [Schema] alias): the structured-output
@@ -80,8 +63,6 @@ let indexed_messages_text (messages : Agent_sdk.Types.message list) =
     let text = Agent_sdk.Types.text_of_message m |> String.trim in
     Printf.sprintf "[%d] %s: %s" idx role text)
   |> String.concat "\n"
-  |> String_util.utf8_safe ~max_bytes:max_notes_bytes ~suffix:"..."
-  |> String_util.to_string
 
 let messages_for_plan ~(messages : Agent_sdk.Types.message list) =
   let count = List.length messages in
@@ -134,10 +115,8 @@ let string_field key = function
 
 let ( let* ) = Result.bind
 
-(* The three index lists must together partition [0, message_count) exactly:
-   every index in range, no out-of-range, no negatives, no duplicates across
-   the union. A violation yields [Error] (caller falls back to deterministic),
-   not a silent repair — an LLM that miscounts must not drop real messages. *)
+(* The three index lists must together partition [0, message_count) exactly.
+   An invalid LLM plan is an explicit error, never a silent repair. *)
 let validate_partition ~message_count ~kept ~summarized ~dropped =
   let all = kept @ summarized @ dropped in
   let seen = Array.make message_count false in
@@ -174,12 +153,7 @@ let plan_of_json ~message_count json =
   let* kept = int_list_field Schema.compaction_plan_field_kept_indices json in
   let* summarized = int_list_field Schema.compaction_plan_field_summarized_indices json in
   let* dropped = int_list_field Schema.compaction_plan_field_dropped_indices json in
-  (* The summary stands in for the [summarized] messages; it is consumed by
-     [apply] only when [summarized] is non-empty. Requiring it non-empty
-     unconditionally would reject a legitimate "keep everything, nothing to
-     summarize" plan (summary="") and spuriously fall back to the
-     deterministic chain. So the summary must be non-empty iff it will be
-     used. *)
+  (* The summary must be non-empty exactly when [apply] will use it. *)
   let* () =
     if summarized <> [] && summary = ""
     then Error "summary must be non-empty when summarized indices are present"
@@ -279,24 +253,17 @@ let run_plan
 let make ?complete ?timeout_sec ~(runtime_id : string) ~(keeper_name : string) ()
   : summarizer option
   =
-  (* Gating lives in the caller's [meta.compaction.mode] (Llm vs
-     Deterministic). The memory-bank MASC_KEEPER_MEMORY_LLM_SUMMARY flag is a
-     different subsystem's opt-in and must not silence compaction (38-bug
-     campaign #3: the double gate kept the LLM path permanently dead). *)
   match Eio_context.get_switch_opt (), Eio_context.get_net_opt () with
   | Some sw, Some net ->
     let clock = Eio_context.get_clock_opt () in
-    let provider_runtime_id =
-      Keeper_memory_runtime_resolution.runtime_id_for_librarian ~runtime_id
-    in
     (match
        Keeper_memory_runtime_resolution.provider_for_runtime
-         ~runtime_id:provider_runtime_id
+         ~runtime_id
      with
      | Error err ->
        Log.Keeper.warn ~keeper_name
          "compaction LLM summarizer provider resolution failed runtime=%s: %s"
-         provider_runtime_id err;
+         runtime_id err;
        None
      | Ok provider ->
        let providers =
@@ -309,13 +276,13 @@ let make ?complete ?timeout_sec ~(runtime_id : string) ~(keeper_name : string) (
           Log.Keeper.warn ~keeper_name
             "compaction LLM summarizer has no schema-capable direct completion \
              provider runtime=%s"
-            provider_runtime_id;
+            runtime_id;
           None
         | provider_cfg :: _ ->
           Some
             (fun ~messages ->
               run_plan ?complete ?clock ?timeout_sec ~keeper_name
-                ~runtime_id:provider_runtime_id ~sw ~net ~provider_cfg ~messages ())))
+                ~runtime_id ~sw ~net ~provider_cfg ~messages ())))
   | _ ->
     Log.Keeper.warn ~keeper_name
       "compaction LLM summarizer skipped: Eio context unavailable runtime=%s"

--- a/lib/keeper/keeper_compaction_llm_summarizer.mli
+++ b/lib/keeper/keeper_compaction_llm_summarizer.mli
@@ -1,18 +1,6 @@
-(** LLM-backed keeper context compaction (RFC-0313-adjacent W2).
-
-    Default compaction path, selected per keeper via [meta.compaction.mode]
-    ([Llm] unless overridden). Requests a structured {!compaction_plan} from a
-    librarian-lane provider that classifies each working-set message (by
-    0-based index) into kept / summarized / dropped, plus one [summary] prose
-    block standing in for the summarized indices.
-
-    Fail-closed by construction: {!make} returns [None] (caller falls back to
-    the deterministic chain) whenever the Eio context is unavailable, no
-    schema-capable direct-completion provider resolves, or the produced plan
-    is structurally invalid. This mirrors {!Keeper_memory_llm_summary.make};
-    it never lies about effects — the provider call happens inside the
-    fiber-local Eio context captured at construction, and the summarizer type
-    stays synchronous+total. *)
+(** LLM-backed Keeper context compaction. The exact caller-supplied Runtime
+    produces a structured {!compaction_plan}; unavailable providers and invalid
+    plans fail explicitly as [None]. *)
 
 (** A validated compaction plan over a working set of [n] messages. Every
     index in [kept]/[summarized]/[dropped] is in [\[0, n)], the three sets are
@@ -43,11 +31,9 @@ type complete_fn =
   unit ->
   (Agent_sdk.Types.api_response, Llm_provider.Http_client.http_error) result
 
-(** [make ~runtime_id ~keeper_name ()] builds a summarizer bound to the
-    librarian lane resolved from [runtime_id], or [None] if the Eio context
-    or a schema-capable provider is unavailable. The caller treats [None] as
-    "use the deterministic chain". [complete]/[timeout_sec] override the
-    provider call and deadline (tests). *)
+(** [make ~runtime_id ~keeper_name ()] builds a summarizer from that exact
+    Runtime, or [None] if its Eio context or schema-capable provider is
+    unavailable. [complete]/[timeout_sec] override the call in tests. *)
 val make
   :  ?complete:complete_fn
   -> ?timeout_sec:float


### PR DESCRIPTION
## What changed

- pass the complete Keeper checkpoint message projection to the MASC LLM compactor
- preserve the selected Runtime identity instead of substituting the Memory librarian Runtime
- stop overriding the configured provider output size with a fixed compaction value
- remove stale deterministic-fallback contract text

## Why

MASC owns compaction. The LLM must judge the actual Lane context through the explicitly selected Runtime; byte truncation, fixed output limits, and implicit Runtime substitution are heuristic policy and can silently discard context.

## Validation

- `git diff --check`
- `ocamlformat --check` for both changed files
- focused `scripts/dune-local.sh build lib/masc.cma` attempted; the normal wrapper stopped on OAS pin drift (`b02bc16` installed vs `902c45d` expected)
- with the pin guard bypassed, compilation stopped before these files at the existing `runtime_agent_context.mli:80` reference to removed `Agent_sdk.Guardrails`

No green build is claimed.