### PR TITLE
fix(guards): re-anchor provider ratchet and nav parity after #24409/#24420

### DIFF
--- a/lib/dashboard/dashboard_nav_event.ml
+++ b/lib/dashboard/dashboard_nav_event.ml
@@ -12,6 +12,7 @@ let valid_surfaces =
   ; "overview"
   ; "monitoring"
   ; "keepers"
+  ; "registry"
   ; "board"
   ; "schedule"
   ; "fusion"

--- a/scripts/check-dashboard-nav-event-parity.sh
+++ b/scripts/check-dashboard-nav-event-parity.sh
@@ -69,10 +69,12 @@ def read(path: str) -> str:
 # --- Client side -----------------------------------------------------------
 
 def parse_valid_tabs() -> list[str]:
-    """Extract `export const VALID_TABS: TabId[] = [ ... ]` from sse.ts."""
+    """Extract `export const VALID_TABS = [ ... ]` (with or without a
+    `: TabId[]` annotation — #24409 dropped it for an `as const` array)
+    from sse.ts."""
     text = read("dashboard/src/types/sse.ts")
     m = re.search(
-        r"export\s+const\s+VALID_TABS\s*:\s*TabId\[\]\s*=\s*\[([^\]]*)\]",
+        r"export\s+const\s+VALID_TABS\s*(?::\s*TabId\[\]\s*)?=\s*\[([^\]]*)\]",
         text,
     )
     if not m:

--- a/scripts/lint/no-provider-name-hardcoding.allowlist
+++ b/scripts/lint/no-provider-name-hardcoding.allowlist
@@ -3,6 +3,6 @@
 # catalog/runtime-binding replacement task.
 #
 # Format: path:line:literal
-lib/runtime_model/provider_runtime_projection.ml:104:auto
-lib/runtime_model/provider_runtime_projection.ml:202:auto
-lib/runtime_model/provider_runtime_projection.ml:244:openrouter
+lib/runtime_model/provider_runtime_projection.ml:100:auto
+lib/runtime_model/provider_runtime_projection.ml:198:auto
+lib/runtime_model/provider_runtime_projection.ml:239:openrouter


### PR DESCRIPTION
## 무엇을

main RED 잔재 2층 복구 (16c0dcdc 시점 Lint Suite + Meta Guards 실패).

1. **Lint Suite — provider hardcoding ratchet**: allowlist가 `provider_runtime_projection.ml` 리터럴을 라인번호로 핀하는데 #24420 편집으로 3개가 이동(104→100/202→198 `auto`, 244→239 `openrouter`). 동일 리터럴, 라인만 재조준.
2. **Meta Guards — nav-event parity**: guard 정규식이 `VALID_TABS : TabId[]` 주석형만 받는데 #24409가 주석을 제거 → 양형 수용으로 수정. 파싱이 살아나자 guard 본연의 드리프트가 드러남: **#24409가 `registry` 서피스를 navigation.ts에만 추가하고 OCaml `valid_surfaces` 미러를 빠뜨림** — registry nav 이벤트가 서버 400으로 조용히 드랍되는 실결함. 서피스 추가로 완결.

## 검증

- `bash scripts/lint/no-provider-name-hardcoding.sh` → OK
- `bash scripts/check-dashboard-nav-event-parity.sh --check` → OK
- `bash scripts/ci/run-lint-suite.sh blocking` → all 26 lints passed

RFC-WAIVED: 이미 머지된 #24409/#24420에 guard/미러를 정렬하는 잔재 수복, 신규 설계 없음.

Related: masc#24391 (red-merge 연쇄 패턴).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
