### PR TITLE
fix(runtime): wire max_context None arm to int option (main RED gate)

### DIFF
--- a/lib/runtime_model/runtime_model_string.ml
+++ b/lib/runtime_model/runtime_model_string.ml
@@ -130,7 +130,7 @@ let make_registry_config
     in
     match caps.max_context_tokens with
     | Some n -> Some n
-    | None -> entry.max_context
+    | None -> Some entry.max_context
   in
   Llm_provider.Provider_config.make
     ~kind:defaults.kind


### PR DESCRIPTION
## 무엇을

`lib/runtime_model/runtime_model_string.ml:133`의 컴파일 파손 1줄 수정. main을 RED로 묶고 있는 게이트.

## 왜

#24419가 `make_registry_config`의 `max_context` 바인딩을 `int` → `int option`으로 넓혔소:
- `Some n -> Some n` (래핑)
- 호출부 `~max_context` → `?max_context` (optional 인자)

그런데 `None` fallback arm만 **원시 `int`인 `entry.max_context`를 그대로 반환**하도록 남겨둠. OCaml 5.5가 거부:

```
Error: The field access entry.max_context has type int
       but an expression was expected of type int option
```

이 한 줄이 `Build install target` / `OCaml 5.5 Build Canary` / `Health` 게이트를 깨뜨려, 런타임 숙청 웨이브 내내 main이 RED였소(최근 10+ 커밋 Build and Test 전부 failure).

## 수정

```ocaml
-    | None -> entry.max_context
+    | None -> Some entry.max_context
```

fallback을 `Some`으로 감싸, 해석된 모델 capabilities에 `max_context_tokens`가 없을 때 `entry.max_context`를 전달하던 **#24419 이전 동작을 그대로 보존**. 컴파일 복구 외 의미 변화 없음. 전체 트리에서 동일 mismatch 사이트는 이 한 곳뿐(`rg entry.max_context lib/`).

## 성격

- 워크어라운드 아님 — #24419의 같은 표현식 내 누락된 arm을 채우는 것(단일 사이트, 산포된 N-of-M 패턴 아님).
- 새 타입/분류기/catch-all/텔레메트리 추가 없음.

## 테스트

타입 에러이므로 컴파일 자체가 증명. 로컬 dune 빌드는 repo 규칙(opam pin skew)상 미실행, CI가 권위. `entry.max_context : int` fallback 동작은 기존과 동일.

## 연계

Refs #24419 (누락 arm의 출처). main RED 게이트 해소.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
