### PR TITLE
refactor(runtime): stop passing max turn budgets

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -144,8 +144,6 @@ let raw_trace_for_dispatch
     None
 ;;
 
-let keeper_max_turns = Runtime_agent_context.unbounded_max_turns
-
 module For_testing = struct
   let sse_event_progress_kind = Turn_helpers.sse_event_progress_kind
   let sse_event_watchdog_progress_kind =
@@ -159,7 +157,6 @@ module For_testing = struct
   let raw_trace_for_dispatch = raw_trace_for_dispatch
   let autonomous_yield_allowed_at_turn = autonomous_yield_allowed_at_turn
   let stop_reason_of_autonomous_yield = stop_reason_of_autonomous_yield
-  let keeper_max_turns = keeper_max_turns
 end
 
 (** Run a single keeper turn via OAS Agent.run().
@@ -694,9 +691,8 @@ let run_turn
               in
               let call_run_named ?raw_trace ~initial_messages () =
                 (* Keeper does not impose a cumulative turn, time, token, or cost
-                   budget. OAS receives its unbounded turn sentinel; explicit
-                   cancellation and provider/tool progress boundaries settle the
-                   lane, while usage remains observational. *)
+                   budget. Explicit cancellation and provider/tool progress
+                   boundaries settle the lane, while usage remains observational. *)
                 Keeper_turn_driver.run_named
                   ~runtime_id:runtime_id_string
                   ~base_path:config.base_path
@@ -710,7 +706,6 @@ let run_turn
                     ~checkpoint_sink
                     ~initial_messages
                     ~model_input_projection
-                    ~max_turns:keeper_max_turns
                     ~hooks
                     ~runtime_manifest_context
                     ~runtime_manifest_append:
@@ -723,9 +718,7 @@ let run_turn
                          a malformed tool call (e.g. missing required arg) is
                          the keeper's own competence: OAS delivers the typed
                          validation error back to the model and the agent loop
-                         decides whether to continue. OAS defines zero as the
-                         unbounded idle-turn sentinel for this long-lived
-                         Keeper lane. *)
+                         decides whether to continue. *)
                     ~max_idle_turns:0
                     ?stream_idle_timeout_s
                     ?body_timeout_s:

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -93,8 +93,6 @@ module For_testing : sig
     -> autonomous_yield_request
     -> Runtime_agent.stop_reason
 
-  val keeper_max_turns : int
-  (** OAS-owned unbounded sentinel used explicitly for every Keeper run. *)
 end
 
 (** {1 Turn execution} *)

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -269,7 +269,6 @@ let run_named
     ?(tools = [])
     ?(initial_messages = [])
     ?model_input_projection
-    ?(max_turns = Runtime_agent_context.unbounded_max_turns)
     ~max_idle_turns
     ?stream_idle_timeout_s
     ?body_timeout_s
@@ -564,7 +563,6 @@ let run_named
             ; tools
             ; initial_messages
             ; model_input_projection
-            ; max_turns
             ; max_idle_turns
             ; stream_idle_timeout_s
             ; body_timeout_s

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -76,7 +76,6 @@ val run_named :
   ?initial_messages:Agent_sdk.Types.message list ->
   ?model_input_projection:
     (Agent_sdk.Types.message list -> Agent_sdk.Types.message list) ->
-  ?max_turns:int ->
   max_idle_turns:int ->
   ?stream_idle_timeout_s:float ->
   ?body_timeout_s:float ->

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -31,7 +31,6 @@ type try_provider_ctx =
   ; initial_messages : Agent_sdk.Types.message list
   ; model_input_projection :
       (Agent_sdk.Types.message list -> Agent_sdk.Types.message list) option
-  ; max_turns : int
   ; max_idle_turns : int
   ; stream_idle_timeout_s : float option
   ; body_timeout_s : float option
@@ -238,7 +237,6 @@ let run_try_provider
         stream_idle_timeout_s = ctx.stream_idle_timeout_s
           ; body_timeout_s = ctx.body_timeout_s
           ; temperature
-          ; max_turns = ctx.max_turns
           ; max_idle_turns = ctx.max_idle_turns
           ; guardrails = Some Agent_sdk.Guardrails.permissive
           ; hooks = ctx.hooks

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -14,7 +14,6 @@ type try_provider_ctx =
   ; initial_messages : Agent_sdk.Types.message list
   ; model_input_projection :
       (Agent_sdk.Types.message list -> Agent_sdk.Types.message list) option
-  ; max_turns : int
   ; max_idle_turns : int
   ; stream_idle_timeout_s : float option
   ; body_timeout_s : float option

--- a/lib/keeper/keeper_turn_driver_wrappers.ml
+++ b/lib/keeper/keeper_turn_driver_wrappers.ml
@@ -91,8 +91,7 @@ let run_model_by_label
   : (Runtime_agent.run_result, Agent_sdk.Error.sdk_error) result =
   let* config =
     config_for_label ~name:"oas-label-model" ~model_label ~system_prompt
-      ~tools ~max_tokens ~temperature
-      ~max_idle_turns ?stream_idle_timeout_s ?hooks
+      ~tools ~max_tokens ~temperature ~max_idle_turns ?stream_idle_timeout_s ?hooks
       ?enable_thinking
       ?provider_config_transform
       ~description:(Some (Printf.sprintf "model_label:%s" model_label))
@@ -172,7 +171,6 @@ let run_named_with_masc_tools
     ?transport
     ?(yield_on_tool = false)
     ?approval
-    ?max_turns
     ?(max_idle_turns = 3)
     ?provider_config_transform
     ?sw
@@ -186,7 +184,6 @@ let run_named_with_masc_tools
       (fun input -> dispatch ~name:td.name ~args:input)
   ) masc_tools in
   Keeper_turn_driver.run_named ~runtime_id ~keeper_name ~goal ~base_path ~system_prompt ~tools:oas_tools
-    ?max_turns
     ~max_idle_turns
     ?temperature
     ?stream_idle_timeout_s ?hooks

--- a/lib/keeper/keeper_turn_driver_wrappers.mli
+++ b/lib/keeper/keeper_turn_driver_wrappers.mli
@@ -54,7 +54,6 @@ val run_named_with_masc_tools :
   ?transport:Masc_grpc_transport.t ->
   ?yield_on_tool:bool ->
   ?approval:Agent_sdk.Hooks.approval_callback ->
-  ?max_turns:int ->
   ?max_idle_turns:int ->
   ?provider_config_transform:
     (Llm_provider.Provider_config.t ->

--- a/lib/local/worker_container.ml
+++ b/lib/local/worker_container.ml
@@ -399,7 +399,7 @@ let append_worker_completion_log ~base_path ~worker_name
     New workers use Worker_oas.build_agent (Builder pattern) instead.
     Accepts [~provider] + [~model_id] as resolved values. *)
 let build_resume_config ~worker_name ~provider ~model_id ~system_prompt ~tools
-    ~max_turns ~thinking_enabled ~hooks ~raw_trace ?(periodic_callbacks = [])
+    ~thinking_enabled ~hooks ~raw_trace ?(periodic_callbacks = [])
     ?(guardrails : Agent_sdk.Guardrails.t option)
     () =
   let config =
@@ -408,7 +408,6 @@ let build_resume_config ~worker_name ~provider ~model_id ~system_prompt ~tools
       name = worker_name;
       model = model_id;
       system_prompt = Some system_prompt;
-      max_turns;
       enable_thinking = Some thinking_enabled;
     }
   in
@@ -428,4 +427,3 @@ let build_resume_config ~worker_name ~provider ~model_id ~system_prompt ~tools
     }
   in
   (config, options)
-

--- a/lib/local/worker_container.mli
+++ b/lib/local/worker_container.mli
@@ -196,7 +196,6 @@ val build_resume_config :
   model_id:string ->
   system_prompt:string ->
   tools:Agent_sdk.Tool.t list ->
-  max_turns:int ->
   thinking_enabled:bool ->
   hooks:Agent_sdk.Hooks.hooks ->
   raw_trace:Agent_sdk.Raw_trace.t ->
@@ -207,7 +206,7 @@ val build_resume_config :
 (** Assembles the [(config, options)] pair consumed by
     [Agent_sdk.Agent.resume].  [config] inherits
     {!Agent_sdk.Types.default_config} and overrides
-    [name] / [model] / [system_prompt] / [max_turns] /
-    [enable_thinking] / [tool_choice = Auto]. Provider/model sampling and
-    output defaults remain OAS-owned. [guardrails] defaults to the unrestricted
-    worker surface; the concrete [tools] list is the exposure SSOT. *)
+    [name] / [model] / [system_prompt] / [enable_thinking] /
+    [tool_choice = Auto]. Provider/model sampling and output defaults remain
+    OAS-owned. [guardrails] defaults to the unrestricted worker surface; the
+    concrete [tools] list is the exposure SSOT. *)

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -110,7 +110,6 @@ let build_agent
     Agent_sdk.Builder.create ~net ~model:config.model
     |> Agent_sdk.Builder.with_name config.name
     |> Agent_sdk.Builder.with_system_prompt system_prompt
-    |> Agent_sdk.Builder.with_max_turns config.max_turns
     |> Agent_sdk.Builder.with_enable_thinking
          (Option.value ~default:false meta.thinking_enabled)
     |> Agent_sdk.Builder.with_provider provider
@@ -433,7 +432,6 @@ and resume_worker_via_oas
       ?selection_note:meta.selection_note
       ()
   in
-  let max_turns = Runtime_agent_context.unbounded_max_turns in
   let thinking_enabled = Option.value ~default:false meta.thinking_enabled in
   let config, options =
     Worker_container.build_resume_config
@@ -442,7 +440,6 @@ and resume_worker_via_oas
       ~model_id:resume_model_id
       ~system_prompt
       ~tools
-      ~max_turns
       ~thinking_enabled
       ~hooks
       ~raw_trace

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -447,7 +447,6 @@ let test_prior_checkpoint_appends_current_goal_once () =
          ~base_path:(Filename.get_temp_dir_name ())
          ~goal:current_goal
          ~session_id:prior_checkpoint.session_id
-         ~max_turns:0
          ~max_idle_turns:0
          ~oas_checkpoint:prior_checkpoint
          ~exit_condition:(fun _turn -> true)

--- a/test/test_keeper_turn_outcome.ml
+++ b/test/test_keeper_turn_outcome.ml
@@ -168,13 +168,6 @@ let test_autonomous_yield_boundary_contract () =
   | Runtime_agent.ToolFailureRecoveryDeferred _ ->
     fail "durable request mapped to the wrong stop reason"
 
-let test_keeper_turn_limit_is_unbounded () =
-  let max_turns = Masc.Keeper_agent_run.For_testing.keeper_max_turns in
-  check bool
-    "Keeper passes OAS's unbounded turn sentinel"
-    false
-    (Agent_sdk.Types.has_finite_max_turns max_turns)
-
 let payload fields = Some (`Assoc fields)
 
 let test_payload_decode () =
@@ -357,8 +350,6 @@ let () =
           test_case "of_result_surface" `Quick test_of_result_surface;
           test_case "autonomous yield boundary contract" `Quick
             test_autonomous_yield_boundary_contract;
-          test_case "Keeper turn limit is unbounded" `Quick
-            test_keeper_turn_limit_is_unbounded;
         ] );
       ( "payload_decode",
         [


### PR DESCRIPTION
## What changed

- remove `max_turns` from Keeper turn-driver and MASC-tool wrapper call surfaces
- stop passing a max-turn budget into new and resumed OAS workers
- remove the Keeper test that asserted the retired unbounded sentinel contract

## Why

Turn count is observation, not an execution constraint. MASC callers should not request a turn budget from OAS or encode a numeric sentinel as Keeper policy.

This is step A only. Runtime-agent sentinel/Builder/resume internals and the remaining retired OAS error types are intentionally left for the next bounded hard-cut PR.

## Validation

- all touched `.ml` and `.mli` files parse
- `ocamlformat` 0.29 passes for touched files
- `git diff --check`
- focused `lib/masc.cmxa` build attempted; compilation stops at the existing `runtime_agent_context.mli:80` reference to removed `Agent_sdk.Guardrails`

No green build is claimed.