### PR TITLE
feat(fs): expose exact no-follow path kind

### DIFF
--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -328,21 +328,41 @@ type path_kind =
   | Directory
   | Other
 
-let path_kind ?(follow = true) (path : string) : path_kind =
+type exact_path_kind =
+  | Exact_missing
+  | Exact_kind of Unix.file_kind
+  | Exact_unknown
+
+let exact_path_kind ?(follow = true) (path : string) : exact_path_kind =
   with_fs_or_fallback
     ~path
     ~fallback:(fun () ->
       try
         let stats = if follow then Unix.stat path else Unix.lstat path in
-        if stats.Unix.st_kind = Unix.S_DIR then Directory else Other
+        Exact_kind stats.Unix.st_kind
       with
-      | Unix.Unix_error (Unix.ENOENT, _, _) -> Missing)
+      | Unix.Unix_error (Unix.ENOENT, _, _) -> Exact_missing)
     (fun fs ->
        match Eio.Path.kind ~follow Eio.Path.(fs / path) with
-       | `Not_found -> Missing
-       | `Directory -> Directory
-       | (`Unknown | `Fifo | `Character_special | `Block_device
-         | `Regular_file | `Symbolic_link | `Socket) -> Other)
+       | `Not_found -> Exact_missing
+       | `Directory -> Exact_kind Unix.S_DIR
+       | `Fifo -> Exact_kind Unix.S_FIFO
+       | `Character_special -> Exact_kind Unix.S_CHR
+       | `Block_device -> Exact_kind Unix.S_BLK
+       | `Regular_file -> Exact_kind Unix.S_REG
+       | `Symbolic_link -> Exact_kind Unix.S_LNK
+       | `Socket -> Exact_kind Unix.S_SOCK
+       | `Unknown -> Exact_unknown)
+;;
+
+let path_kind ?(follow = true) (path : string) : path_kind =
+  match exact_path_kind ~follow path with
+  | Exact_missing -> Missing
+  | Exact_kind Unix.S_DIR -> Directory
+  | Exact_kind
+      (Unix.S_REG | Unix.S_CHR | Unix.S_BLK | Unix.S_LNK | Unix.S_FIFO
+      | Unix.S_SOCK)
+  | Exact_unknown -> Other
 ;;
 
 type owned_directory_chain_rejection = Owned_directory_chain.rejection =

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -24,15 +24,25 @@ val get_fs_opt : unit -> Eio.Fs.dir_ty Eio.Path.t option
 (** Check if Eio fs is available. *)
 val has_fs : unit -> bool
 
+type exact_path_kind =
+  | Exact_missing
+  | Exact_kind of Unix.file_kind
+  | Exact_unknown
+
+(** Eio-native exact path classification. Unlike {!path_kind}, this preserves
+    regular files, symbolic links, FIFOs, sockets, and devices as distinct
+    [Unix.file_kind] values. [follow=false] is suitable for owned-file read
+    boundaries that must reject links and special files before I/O. *)
+val exact_path_kind : ?follow:bool -> string -> exact_path_kind
+
 type path_kind =
   | Missing
   | Directory
   | Other
 
-(** Eio-native path classification with the same Unix fallback as the other
-    compatibility operations. [follow=false] classifies a symbolic link as
-    [Other] instead of classifying its target. Non-missing I/O failures remain
-    explicit. *)
+(** Coarse projection of {!exact_path_kind}. [follow=false] classifies a
+    symbolic link as [Other] instead of classifying its target. Non-missing
+    I/O failures remain explicit. *)
 val path_kind : ?follow:bool -> string -> path_kind
 
 type owned_directory_chain_rejection = Owned_directory_chain.rejection =

--- a/test/test_fs_compat.ml
+++ b/test/test_fs_compat.ml
@@ -134,10 +134,12 @@ let test_read_dir_and_path_kind_use_typed_inventory ~fs () =
   let regular = Filename.concat directory "b.json" in
   let nested = Filename.concat directory "a-dir" in
   let nested_link = Filename.concat directory "c-link" in
+  let fifo = Filename.concat directory "d-fifo" in
   Fs_compat.mkdir_p directory;
   Fs_compat.mkdir_p nested;
   Fs_compat.save_file regular "{}";
   Unix.symlink nested nested_link;
+  Unix.mkfifo fifo 0o600;
   let check_inventory implementation =
     check bool (implementation ^ " directory classified") true
       (Fs_compat.path_kind directory = Fs_compat.Directory);
@@ -149,10 +151,22 @@ let test_read_dir_and_path_kind_use_typed_inventory ~fs () =
       (Fs_compat.path_kind nested_link = Fs_compat.Directory);
     check bool (implementation ^ " symlink itself remains non-directory") true
       (Fs_compat.path_kind ~follow:false nested_link = Fs_compat.Other);
+    check bool (implementation ^ " exact regular file kind") true
+      (Fs_compat.exact_path_kind ~follow:false regular
+       = Fs_compat.Exact_kind Unix.S_REG);
+    check bool (implementation ^ " exact symlink kind") true
+      (Fs_compat.exact_path_kind ~follow:false nested_link
+       = Fs_compat.Exact_kind Unix.S_LNK);
+    check bool (implementation ^ " exact FIFO kind") true
+      (Fs_compat.exact_path_kind ~follow:false fifo
+       = Fs_compat.Exact_kind Unix.S_FIFO);
+    check bool (implementation ^ " exact missing kind") true
+      (Fs_compat.exact_path_kind (Filename.concat directory "missing")
+       = Fs_compat.Exact_missing);
     check
       (list string)
       (implementation ^ " directory inventory is deterministic")
-      [ "a-dir"; "b.json"; "c-link" ]
+      [ "a-dir"; "b.json"; "c-link"; "d-fifo" ]
       (Fs_compat.read_dir directory)
   in
   Fs_compat.clear_fs ();


### PR DESCRIPTION
## Why

`Fs_compat.path_kind` intentionally collapses every non-directory into `Other`. Blob-store reads need an exact, no-follow distinction so a FIFO, socket, device, or symlink can never be treated as a regular artifact and stall a Keeper lane.

## Change

- add typed `exact_path_kind`: missing, exact `Unix.file_kind`, or Eio unknown
- keep one SSOT by deriving the existing coarse `path_kind` from it
- verify Unix fallback and Eio parity for regular files, symlinks, FIFOs, and missing paths

## Validation

- `ocamlformat` and parse checks: pass
- `MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build lib/fs_compat/fs_compat.cma`: pass
- focused test executable reaches the current unrelated OAS hard-cut compile blocker (`Agent_sdk.Error.IdleDetected` removed); full build remains CI authority
- adversarial review: P0/P1/P2/P3 none, mergeable

Diff: 3 files, +56/-12 (68 changed lines).