### PR TITLE
feat(keeper): add typed compaction runtime failover

### DIFF
--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -250,45 +250,109 @@ let run_plan
          runtime_id detail;
        None)
 
+type candidate =
+  { runtime_id : string
+  ; provider_cfg : Llm_provider.Provider_config.t
+  }
+
+let eligible_candidate ~keeper_name (runtime : Runtime.t) =
+  let runtime_id = runtime.Runtime.id in
+  let provider_cfg = runtime.Runtime.provider_config in
+  if not (is_direct_completion_provider provider_cfg)
+  then (
+    Log.Keeper.warn ~keeper_name
+      "compaction LLM candidate skipped runtime=%s: provider does not support \
+       direct completion"
+      runtime_id;
+    None)
+  else if not (plan_schema_supported provider_cfg)
+  then (
+    Log.Keeper.warn ~keeper_name
+      "compaction LLM candidate skipped runtime=%s: provider does not support \
+       the compaction plan schema"
+      runtime_id;
+    None)
+  else Some { runtime_id; provider_cfg }
+
+let candidates_for_assignment ~keeper_name assignment_id =
+  let rec resolve_lane acc = function
+    | [] -> Some (List.rev acc)
+    | runtime_id :: rest ->
+      (match Runtime.get_runtime_by_id runtime_id with
+       | None ->
+         Log.Keeper.warn ~keeper_name
+           "compaction LLM lane candidate disappeared runtime=%s assignment=%s"
+           runtime_id assignment_id;
+         None
+       | Some runtime ->
+         let acc =
+           match eligible_candidate ~keeper_name runtime with
+           | None -> acc
+           | Some candidate -> candidate :: acc
+         in
+         resolve_lane acc rest)
+  in
+  match Runtime.resolve_assignment assignment_id with
+  | `Missing ->
+    Log.Keeper.warn ~keeper_name
+      "compaction LLM assignment resolution failed runtime=%s: not configured"
+      assignment_id;
+    None
+  | `Single_runtime runtime ->
+    Some (Option.to_list (eligible_candidate ~keeper_name runtime))
+  | `Lane lane ->
+    resolve_lane [] (Runtime_lane.ordered_candidates lane)
+
 let make ?complete ?timeout_sec ~(runtime_id : string) ~(keeper_name : string) ()
   : summarizer option
   =
-  match Eio_context.get_switch_opt (), Eio_context.get_net_opt () with
-  | Some sw, Some net ->
-    let clock = Eio_context.get_clock_opt () in
-    (match
-       Keeper_memory_runtime_resolution.provider_for_runtime
-         ~runtime_id
-     with
-     | Error err ->
-       Log.Keeper.warn ~keeper_name
-         "compaction LLM summarizer provider resolution failed runtime=%s: %s"
-         runtime_id err;
-       None
-     | Ok provider ->
-       let providers =
-         [ provider ]
-         |> List.filter is_direct_completion_provider
-         |> List.filter plan_schema_supported
-       in
-       (match providers with
-        | [] ->
-          Log.Keeper.warn ~keeper_name
-            "compaction LLM summarizer has no schema-capable direct completion \
-             provider runtime=%s"
-            runtime_id;
-          None
-        | provider_cfg :: _ ->
-          Some
-            (fun ~messages ->
-              run_plan ?complete ?clock ?timeout_sec ~keeper_name
-                ~runtime_id ~sw ~net ~provider_cfg ~messages ())))
-  | _ ->
+  match candidates_for_assignment ~keeper_name runtime_id with
+  | None -> None
+  | Some [] ->
     Log.Keeper.warn ~keeper_name
-      "compaction LLM summarizer skipped: Eio context unavailable runtime=%s"
+      "compaction LLM summarizer has no eligible candidate assignment=%s"
       runtime_id;
     None
+  | Some candidates ->
+    (match Eio_context.get_switch_opt (), Eio_context.get_net_opt () with
+     | Some sw, Some net ->
+       let clock = Eio_context.get_clock_opt () in
+       Some
+         (fun ~messages ->
+           let rec attempt = function
+             | [] ->
+               Log.Keeper.warn ~keeper_name
+                 "compaction LLM candidate chain exhausted assignment=%s"
+                 runtime_id;
+               None
+             | candidate :: rest ->
+               (match
+                  run_plan ?complete ?clock ?timeout_sec ~keeper_name
+                    ~runtime_id:candidate.runtime_id ~sw ~net
+                    ~provider_cfg:candidate.provider_cfg ~messages ()
+                with
+                | Some _ as plan ->
+                  Log.Keeper.info ~keeper_name
+                    "compaction LLM candidate succeeded assignment=%s runtime=%s"
+                    runtime_id candidate.runtime_id;
+                  plan
+                | None -> attempt rest)
+           in
+           attempt candidates)
+     | _ ->
+       List.iter
+         (fun candidate ->
+           Log.Keeper.warn ~keeper_name
+             "compaction LLM candidate skipped runtime=%s assignment=%s: Eio \
+              context unavailable"
+             candidate.runtime_id runtime_id)
+         candidates;
+       None)
 
 module For_testing = struct
   let provider_for_plan = provider_for_plan
+
+  let candidate_runtime_ids_for_assignment ~keeper_name ~runtime_id =
+    candidates_for_assignment ~keeper_name runtime_id
+    |> Option.map (List.map (fun candidate -> candidate.runtime_id))
 end

--- a/lib/keeper/keeper_compaction_llm_summarizer.mli
+++ b/lib/keeper/keeper_compaction_llm_summarizer.mli
@@ -31,9 +31,12 @@ type complete_fn =
   unit ->
   (Agent_sdk.Types.api_response, Llm_provider.Http_client.http_error) result
 
-(** [make ~runtime_id ~keeper_name ()] builds a summarizer from that exact
-    Runtime, or [None] if its Eio context or schema-capable provider is
-    unavailable. [complete]/[timeout_sec] override the call in tests. *)
+(** [make ~runtime_id ~keeper_name ()] resolves [runtime_id] as a Runtime or
+    Runtime Lane. A Runtime contributes its exact provider config; a Lane tries
+    its configured Runtime candidates in declared order until one returns a
+    valid plan. Missing, ineligible, and failed candidates are logged with
+    their Runtime id. No default Runtime is substituted. [complete]/
+    [timeout_sec] override the call in tests. *)
 val make
   :  ?complete:complete_fn
   -> ?timeout_sec:float
@@ -70,4 +73,11 @@ module For_testing : sig
   val provider_for_plan
     :  Llm_provider.Provider_config.t
     -> Llm_provider.Provider_config.t
+
+  (** Eligible Runtime ids for a Runtime/Lane assignment, in exact declaration
+      order. Provider configs are intentionally not exposed. *)
+  val candidate_runtime_ids_for_assignment
+    :  keeper_name:string
+    -> runtime_id:string
+    -> string list option
 end

--- a/test/test_compaction_llm_summarizer.ml
+++ b/test/test_compaction_llm_summarizer.ml
@@ -28,6 +28,11 @@ let temperature_runtime_toml =
    protocol = \"ollama-http\"\n\
    endpoint = \"http://localhost:11434\"\n\
    \n\
+   [providers.fallback]\n\
+   display-name = \"Fallback\"\n\
+   protocol = \"ollama-http\"\n\
+   endpoint = \"http://localhost:11435\"\n\
+   \n\
    [models.kimi_like]\n\
    api-name = \"kimi-like\"\n\
    max-context = 1024\n\
@@ -38,9 +43,15 @@ let temperature_runtime_toml =
    \n\
    [local.kimi_like]\n\
    \n\
+   [fallback.kimi_like]\n\
+   \n\
    [runtime]\n\
    default = \"local.kimi_like\"\n\
-   librarian = \"local.kimi_like\"\n"
+   librarian = \"local.kimi_like\"\n\
+   \n\
+   [runtime.lanes.compaction]\n\
+   strategy = \"ordered\"\n\
+   candidates = [\"local.kimi_like\", \"fallback.kimi_like\"]\n"
 
 let with_temperature_runtime f =
   let path = Filename.temp_file "compaction_temperature_runtime" ".toml" in
@@ -84,6 +95,17 @@ let test_provider_for_plan_preserves_temperature_omission () =
     "temperature remains omitted"
     None
     cfg.temperature
+
+let test_lane_candidates_keep_declared_order () =
+  with_temperature_runtime @@ fun _ ->
+  let actual =
+    C.For_testing.candidate_runtime_ids_for_assignment
+      ~keeper_name:"keeper-test"
+      ~runtime_id:"compaction"
+  in
+  Alcotest.(check (option (list string))) "declared candidate order"
+    (Some [ "local.kimi_like"; "fallback.kimi_like" ])
+    actual
 
 (* -- plan_of_json: valid partition accepted -- *)
 
@@ -147,8 +169,7 @@ let test_all_dropped_rejected () =
 
 (* The summary is only consumed when there are summarized indices. A blank
    summary with an empty [summarized] set is a legitimate "keep everything"
-   plan and must be accepted — rejecting it spuriously falls back to the
-   deterministic chain. *)
+   plan and must be accepted — rejecting it would spuriously fail compaction. *)
 let test_empty_summary_accepted_when_nothing_summarized () =
   let json = plan_json ~summary:"   " ~kept:[ 0; 1 ] ~summarized:[] ~dropped:[] in
   Alcotest.(check bool)
@@ -224,6 +245,8 @@ let () =
             test_provider_for_plan_preserves_runtime_temperature
         ; Alcotest.test_case "temperature omission is preserved" `Quick
             test_provider_for_plan_preserves_temperature_omission
+        ; Alcotest.test_case "lane candidates keep declared order" `Quick
+            test_lane_candidates_keep_declared_order
         ] )
     ; ( "plan_of_json"
       , [ Alcotest.test_case "valid partition accepted" `Quick test_valid_partition_accepted


### PR DESCRIPTION
## What changed

- resolve the compaction Runtime identity through the existing typed `Runtime.resolve_assignment` boundary
- use one exact Runtime directly, or attempt a declared `runtime.lanes.<id>` candidate list in its configured order
- log every ineligible, failed, selected, or exhausted candidate with its Runtime identity
- fail the whole assignment if a declared Lane candidate disappears
- add a focused runtime.toml test proving declared candidate order

## Why

MASC owns compaction and model routing. Compaction must not piggyback on the Memory librarian, infer a provider from strings or URLs, or silently select the default Runtime. Explicit Runtime Lanes already provide the typed failover contract.

## Validation

- touched OCaml files parse
- `ocamlformat` 0.29 passes
- `git diff --check`
- focused test/build attempted with the pin guard bypassed; compilation stops on existing main OAS contract drift in `runtime_model_string.ml`, `keeper_runtime_failure_route.ml`, `local_runtime_pool.ml`, and `runtime_agent_context.mli`

No green full build is claimed.