### PR TITLE
fix(blob-store): reject forged and corrupt artifacts

### DIFF
--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -328,21 +328,41 @@ type path_kind =
   | Directory
   | Other
 
-let path_kind ?(follow = true) (path : string) : path_kind =
+type exact_path_kind =
+  | Exact_missing
+  | Exact_kind of Unix.file_kind
+  | Exact_unknown
+
+let exact_path_kind ?(follow = true) (path : string) : exact_path_kind =
   with_fs_or_fallback
     ~path
     ~fallback:(fun () ->
       try
         let stats = if follow then Unix.stat path else Unix.lstat path in
-        if stats.Unix.st_kind = Unix.S_DIR then Directory else Other
+        Exact_kind stats.Unix.st_kind
       with
-      | Unix.Unix_error (Unix.ENOENT, _, _) -> Missing)
+      | Unix.Unix_error (Unix.ENOENT, _, _) -> Exact_missing)
     (fun fs ->
        match Eio.Path.kind ~follow Eio.Path.(fs / path) with
-       | `Not_found -> Missing
-       | `Directory -> Directory
-       | (`Unknown | `Fifo | `Character_special | `Block_device
-         | `Regular_file | `Symbolic_link | `Socket) -> Other)
+       | `Not_found -> Exact_missing
+       | `Directory -> Exact_kind Unix.S_DIR
+       | `Fifo -> Exact_kind Unix.S_FIFO
+       | `Character_special -> Exact_kind Unix.S_CHR
+       | `Block_device -> Exact_kind Unix.S_BLK
+       | `Regular_file -> Exact_kind Unix.S_REG
+       | `Symbolic_link -> Exact_kind Unix.S_LNK
+       | `Socket -> Exact_kind Unix.S_SOCK
+       | `Unknown -> Exact_unknown)
+;;
+
+let path_kind ?(follow = true) (path : string) : path_kind =
+  match exact_path_kind ~follow path with
+  | Exact_missing -> Missing
+  | Exact_kind Unix.S_DIR -> Directory
+  | Exact_kind
+      (Unix.S_REG | Unix.S_CHR | Unix.S_BLK | Unix.S_LNK | Unix.S_FIFO
+      | Unix.S_SOCK)
+  | Exact_unknown -> Other
 ;;
 
 type owned_directory_chain_rejection = Owned_directory_chain.rejection =

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -24,15 +24,25 @@ val get_fs_opt : unit -> Eio.Fs.dir_ty Eio.Path.t option
 (** Check if Eio fs is available. *)
 val has_fs : unit -> bool
 
+type exact_path_kind =
+  | Exact_missing
+  | Exact_kind of Unix.file_kind
+  | Exact_unknown
+
+(** Eio-native exact path classification. Unlike {!path_kind}, this preserves
+    regular files, symbolic links, FIFOs, sockets, and devices as distinct
+    [Unix.file_kind] values. [follow=false] is suitable for owned-file read
+    boundaries that must reject links and special files before I/O. *)
+val exact_path_kind : ?follow:bool -> string -> exact_path_kind
+
 type path_kind =
   | Missing
   | Directory
   | Other
 
-(** Eio-native path classification with the same Unix fallback as the other
-    compatibility operations. [follow=false] classifies a symbolic link as
-    [Other] instead of classifying its target. Non-missing I/O failures remain
-    explicit. *)
+(** Coarse projection of {!exact_path_kind}. [follow=false] classifies a
+    symbolic link as [Other] instead of classifying its target. Non-missing
+    I/O failures remain explicit. *)
 val path_kind : ?follow:bool -> string -> path_kind
 
 type owned_directory_chain_rejection = Owned_directory_chain.rejection =

--- a/lib/keeper/keeper_artifact_hydrator.ml
+++ b/lib/keeper/keeper_artifact_hydrator.ml
@@ -10,22 +10,18 @@ let keep_recent_from_env () =
        | Some n when n >= 0 -> n
        | _ -> default_keep_recent)
 
-(* Try to fetch [sha256] from the store, returning the bytes on hit and
-   the original marker string on miss / store error. *)
-let try_hydrate ~store ~sha256 ~marker =
-  try
-    match Tool_blob_store.fetch store ~sha256 with
-    | Some bytes -> Some bytes
-    | None -> None
-  with
-  (* Issue #8619: re-raise Eio cancellation so shutdown / racing fibers
-     are not silently masked as a hydration miss. Other exceptions
-     (filesystem error, blob corruption) keep the prior degraded
-     behaviour: caller falls back to the marker string. *)
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | _ ->
-    ignore marker;
-    None
+(* Fetch [sha256] without conflating an absent blob with a storage failure.
+   A failed hydration keeps the durable marker so one corrupt artifact cannot
+   stop the Keeper lane, but the failure is always observable. *)
+let try_hydrate ~store ~sha256 =
+  match Tool_blob_store.fetch store ~sha256 with
+  | Ok bytes -> bytes
+  | Error error ->
+      Log.Misc.error
+        "keeper artifact hydration failed sha256=%S cause=%s"
+        sha256
+        (Tool_blob_store.fetch_error_to_string error);
+      None
 
 let hydrate_block ~store ~remaining
     (block : Agent_sdk.Types.content_block) : Agent_sdk.Types.content_block =
@@ -42,9 +38,7 @@ let hydrate_block ~store ~remaining
       else
         (match Tool_output.decode_from_oas result.Canonical_tool.content with
          | Tool_output.Stored { sha256; _ } ->
-             (match
-                try_hydrate ~store ~sha256 ~marker:result.Canonical_tool.content
-              with
+             (match try_hydrate ~store ~sha256 with
               | Some bytes ->
                   decr remaining;
                   Agent_sdk.Types.ToolResult

--- a/lib/keeper/keeper_artifact_hydrator.mli
+++ b/lib/keeper/keeper_artifact_hydrator.mli
@@ -27,5 +27,6 @@ val hydrate_recent :
     place; the LLM still has the metadata fields (sha256, byte count,
     preview) to reason about the missing payload.
 
-    Storage exceptions are caught — a corrupted store cannot break the
-    provider-bound projection. *)
+    Storage read errors are logged and leave the marker in place, so a
+    corrupted artifact cannot break the provider-bound projection without
+    becoming a silent failure. Cancellation propagates. *)

--- a/lib/server/server_routes_http_routes_artifacts.ml
+++ b/lib/server/server_routes_http_routes_artifacts.ml
@@ -15,19 +15,14 @@
     Errors:
       400 — malformed sha256 (not 64 hex chars)
       404 — sha256 not in store
-      503 — base path unresolvable (store unavailable) *)
+      503 — base path unresolvable or stored artifact unreadable *)
 
 open Server_utils
 open Server_auth
 
 module Http = Http_server_eio
 
-let is_valid_sha256 (s : string) : bool =
-  String.length s = 64
-  && String.for_all
-       (fun c ->
-         (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F'))
-       s
+let is_valid_sha256 value = Result.is_ok (Tool_blob_store.validate_sha256 value)
 
 let blob_response ~sha256 =
   match (Host_config.from_env ()).base_path with
@@ -42,14 +37,14 @@ let blob_response ~sha256 =
   | Some base_path ->
       let store = Tool_blob_store.create ~base_path in
       (match Tool_blob_store.fetch store ~sha256 with
-       | None ->
+       | Ok None ->
            ( `Assoc
                [
                  ("error", `String "not found");
                  ("sha256", `String sha256);
                ],
              `Not_found )
-       | Some bytes ->
+       | Ok (Some bytes) ->
            ( `Assoc
                [
                  ("sha256", `String sha256);
@@ -57,7 +52,17 @@ let blob_response ~sha256 =
                  ("mime", `String "text/plain");
                  ("content", `String bytes);
                ],
-             `OK ))
+             `OK )
+       | Error error ->
+           Log.Misc.error
+             "tool blob read failed sha256=%s cause=%s"
+             sha256
+             (Tool_blob_store.fetch_error_to_string error);
+           ( `Assoc
+               [ ("error", `String "tool blob read failed")
+               ; ("sha256", `String sha256)
+               ]
+           , `Service_unavailable ))
 
 let add_routes router =
   router
@@ -69,14 +74,21 @@ let add_routes router =
            | None ->
                respond_public_read_json_value ~status:`Bad_request request reqd
                  (`Assoc [ ("error", `String "sha256 path parameter required") ])
-           | Some raw when not (is_valid_sha256 raw) ->
-               respond_public_read_json_value ~status:`Bad_request request reqd
-                 (`Assoc
-                    [
-                      ("error", `String "invalid sha256");
-                      ("reason", `String "expected 64-char lowercase hex");
-                    ])
-           | Some sha256 ->
-               let json, status = blob_response ~sha256 in
-               respond_public_read_json_value ~status request reqd json)
+           | Some raw ->
+               (match Tool_blob_store.validate_sha256 raw with
+                | Error invalid ->
+                    respond_public_read_json_value
+                      ~status:`Bad_request
+                      request
+                      reqd
+                      (`Assoc
+                         [ ("error", `String "invalid sha256")
+                         ; ( "reason",
+                             `String
+                               (Tool_blob_store.invalid_sha256_to_string invalid)
+                           )
+                         ])
+                | Ok () ->
+                    let json, status = blob_response ~sha256:raw in
+                    respond_public_read_json_value ~status request reqd json))
          request reqd)

--- a/lib/server/server_routes_http_routes_artifacts.mli
+++ b/lib/server/server_routes_http_routes_artifacts.mli
@@ -15,21 +15,14 @@
     ]}
 
     Errors:
-    - 400 — malformed sha256 (not 64 hex chars)
+    - 400 — malformed sha256 (not 64 lowercase hex chars)
     - 404 — sha256 not in store
     - 503 — base path unresolvable (store unavailable) *)
 
 val is_valid_sha256 : string -> bool
-(** [true] iff [s] is exactly 64 chars long and every char is in
-    the lower / upper hex range ([0-9a-fA-F]). The route handler
-    rejects requests whose path parameter fails this check with
-    400 before touching the blob store, so the validation
-    surfaces as a contract guard for path-traversal and
-    fixed-length markers. *)
+(** Shared exact lowercase SHA-256 validation used by the route guard. *)
 
-val blob_response :
-  sha256:string ->
-  Yojson.Safe.t * Httpun.Status.t
+val blob_response : sha256:string -> Yojson.Safe.t * Httpun.Status.t
 (** Look up [sha256] in the on-disk blob store
     ([${MASC_BASE_PATH}/.masc/tool_blobs/]) and return the
     JSON envelope plus the HTTP status code:
@@ -41,8 +34,8 @@ val blob_response :
     - [`Service_unavailable] when [Env_config_core.base_path_opt]
       returns [None] (no [MASC_BASE_PATH], no store root).
 
-    The function never raises — every failure path produces a
-    JSON envelope with an [error] field. *)
+    Store inspection, read, and integrity failures return
+    [`Service_unavailable]. Cancellation propagates. *)
 
 val add_routes :
   Http_server_eio.Router.t ->

--- a/lib/tool_blob_store/tool_blob_store.ml
+++ b/lib/tool_blob_store/tool_blob_store.ml
@@ -2,6 +2,75 @@ module SS = Set_util.StringSet
 
 type t = { root : string } [@@unboxed]
 
+type invalid_sha256 =
+  | Invalid_sha256_length of { actual : int }
+  | Invalid_sha256_character of { index : int; found : char }
+
+let validate_sha256 value =
+  let rec validate_character index =
+    if index = String.length value then Ok ()
+    else
+      let found = String.unsafe_get value index in
+      if (found >= '0' && found <= '9') || (found >= 'a' && found <= 'f')
+      then validate_character (index + 1)
+      else Error (Invalid_sha256_character { index; found })
+  in
+  let actual = String.length value in
+  if actual <> 64 then Error (Invalid_sha256_length { actual })
+  else validate_character 0
+
+let invalid_sha256_to_string = function
+  | Invalid_sha256_length { actual } ->
+      Printf.sprintf
+        "expected 64 lowercase hexadecimal characters, got length %d"
+        actual
+  | Invalid_sha256_character { index; found } ->
+      Printf.sprintf
+        "expected lowercase hexadecimal character at index %d, got %C"
+        index
+        found
+
+type fetch_error =
+  | Invalid_sha256 of invalid_sha256
+  | Inspect_failed of { path : string; cause : exn }
+  | Unexpected_file_kind of {
+      path : string;
+      kind : Fs_compat.exact_path_kind;
+    }
+  | Read_failed of { path : string; cause : exn }
+  | Integrity_mismatch of {
+      path : string;
+      expected : string;
+      actual : string;
+    }
+
+let fetch_error_to_string = function
+  | Invalid_sha256 invalid -> invalid_sha256_to_string invalid
+  | Inspect_failed { path; cause } ->
+      Printf.sprintf "inspect failed path=%s cause=%s" path (Printexc.to_string cause)
+  | Unexpected_file_kind { path; kind } ->
+      let kind_name =
+        match kind with
+        | Fs_compat.Exact_missing -> "missing"
+        | Fs_compat.Exact_unknown -> "unknown"
+        | Fs_compat.Exact_kind Unix.S_REG -> "regular"
+        | Fs_compat.Exact_kind Unix.S_DIR -> "directory"
+        | Fs_compat.Exact_kind Unix.S_CHR -> "character-device"
+        | Fs_compat.Exact_kind Unix.S_BLK -> "block-device"
+        | Fs_compat.Exact_kind Unix.S_LNK -> "symbolic-link"
+        | Fs_compat.Exact_kind Unix.S_FIFO -> "fifo"
+        | Fs_compat.Exact_kind Unix.S_SOCK -> "socket"
+      in
+      Printf.sprintf "expected regular blob file path=%s kind=%s" path kind_name
+  | Read_failed { path; cause } ->
+      Printf.sprintf "read failed path=%s cause=%s" path (Printexc.to_string cause)
+  | Integrity_mismatch { path; expected; actual } ->
+      Printf.sprintf
+        "integrity mismatch path=%s expected=%s actual=%s"
+        path
+        expected
+        actual
+
 let preview_max = 200
 
 let make_preview bytes =
@@ -40,35 +109,55 @@ let rec mkdir_p p =
 
 let ensure_parent_dir path = mkdir_p (Filename.dirname path)
 
+let inspect_path path =
+  Safe_ops.handle
+    (fun () -> Ok (Fs_compat.exact_path_kind ~follow:false path))
+    (fun cause -> Error (Inspect_failed { path; cause }))
+
+let read_path path =
+  Safe_ops.handle
+    (fun () -> Ok (Fs_compat.load_file path))
+    (fun cause -> Error (Read_failed { path; cause }))
+
+let fetch t ~sha256 =
+  match validate_sha256 sha256 with
+  | Error invalid -> Error (Invalid_sha256 invalid)
+  | Ok () ->
+      let path = shard_path t sha256 in
+      (match inspect_path path with
+       | Error _ as error -> error
+       | Ok Fs_compat.Exact_missing -> Ok None
+       | Ok (Fs_compat.Exact_kind Unix.S_REG) ->
+           (match read_path path with
+            | Error _ as error -> error
+            | Ok bytes ->
+                let actual = Digestif.SHA256.(digest_string bytes |> to_hex) in
+                if String.equal sha256 actual then Ok (Some bytes)
+                else Error (Integrity_mismatch { path; expected = sha256; actual }))
+       | Ok
+           ((Fs_compat.Exact_kind
+               (Unix.S_DIR | Unix.S_CHR | Unix.S_BLK | Unix.S_LNK | Unix.S_FIFO
+               | Unix.S_SOCK)
+             | Fs_compat.Exact_unknown) as kind) ->
+           Error (Unexpected_file_kind { path; kind }))
+
 let put t ~bytes ~mime =
   let sha256 = Digestif.SHA256.(digest_string bytes |> to_hex) in
   let path = shard_path t sha256 in
-  if not (Fs_compat.file_exists path) then begin
-    ensure_parent_dir path;
-    (* Propagate a failed write instead of swallowing it. Returning [Stored]
-       after [save_file_atomic] failed produced a blob marker for bytes that
-       were never persisted, so the keeper permanently lost the full tool
-       output (only the preview survived). The sole caller,
-       [Tool_bridge.maybe_externalize], already catches storage failures and
-       falls back to the inline bytes (its docstring promises exactly this);
-       raising here is what activates that fallback. *)
-    match Fs_compat.save_file_atomic path bytes with
-    | Ok () -> ()
-    | Error msg ->
-        raise (Sys_error (Printf.sprintf "tool_blob_store.put: %s" msg))
-  end;
+  ensure_parent_dir path;
+  (* An authoritative atomic rewrite avoids reading and hashing a second full
+     copy on idempotent puts, and repairs any corrupt prior bytes at this
+     content address. Concurrent writers have byte-identical payloads. *)
+  (match Fs_compat.save_file_atomic path bytes with
+   | Ok () -> ()
+   | Error msg ->
+       raise (Sys_error (Printf.sprintf "tool_blob_store.put: %s" msg)));
   Tool_output.Stored {
     sha256;
     bytes = String.length bytes;
     preview = make_preview bytes;
     mime;
   }
-
-let fetch t ~sha256 =
-  let path = shard_path t sha256 in
-  if Fs_compat.file_exists path then
-    Safe_ops.protect ~default:None (fun () -> Some (Fs_compat.load_file path))
-  else None
 
 let list_all t =
   if not (Sys.file_exists t.root) then []

--- a/lib/tool_blob_store/tool_blob_store.mli
+++ b/lib/tool_blob_store/tool_blob_store.mli
@@ -9,6 +9,29 @@
 
 type t
 
+type invalid_sha256 =
+  | Invalid_sha256_length of { actual : int }
+  | Invalid_sha256_character of { index : int; found : char }
+
+val validate_sha256 : string -> (unit, invalid_sha256) result
+val invalid_sha256_to_string : invalid_sha256 -> string
+
+type fetch_error =
+  | Invalid_sha256 of invalid_sha256
+  | Inspect_failed of { path : string; cause : exn }
+  | Unexpected_file_kind of {
+      path : string;
+      kind : Fs_compat.exact_path_kind;
+    }
+  | Read_failed of { path : string; cause : exn }
+  | Integrity_mismatch of {
+      path : string;
+      expected : string;
+      actual : string;
+    }
+
+val fetch_error_to_string : fetch_error -> string
+
 val create : base_path:string -> t
 (** Create a blob store rooted at [base_path/.masc/tool_blobs/].
     Directory creation is lazy (happens on first [put]). *)
@@ -23,14 +46,18 @@ val put : t -> bytes:string -> mime:string -> Tool_output.t
     [preview] is the first ~200 sanitized chars of [bytes] (control bytes
     replaced with [?], whitespace collapsed to spaces).
 
-    Idempotent: re-putting the same bytes is a no-op (file already exists).
+    Idempotent: re-putting the same bytes atomically rewrites the same content
+    address, repairing any corrupt prior bytes without a duplicate read/hash.
 
     @raises Sys_error if the blob write fails (disk full, EACCES, ...). Callers
     that must not lose bytes should catch this and fall back to the inline
     payload rather than emitting a marker for bytes that were never persisted. *)
 
-val fetch : t -> sha256:string -> string option
-(** Retrieve bytes by sha256. Returns [None] if not in store. *)
+val fetch : t -> sha256:string -> (string option, fetch_error) result
+(** Validate and retrieve bytes by sha256. Returns [Ok None] only when the
+    validated path is absent. Validation, inspection, path-kind, read, and
+    content-integrity failures are distinct typed errors. Cancellation
+    propagates. *)
 
 val list_all : t -> string list
 (** List all sha256 hashes currently in the store. O(n) in store size.

--- a/test/test_artifacts_endpoint.ml
+++ b/test/test_artifacts_endpoint.ml
@@ -39,10 +39,10 @@ let with_temp_base_path f =
 (* --- sha256 validation --- *)
 
 let test_valid_sha256 () =
-  Alcotest.(check bool) "exact 64 hex" true
+  Alcotest.(check bool) "exact 64 lowercase hex" true
     (A.is_valid_sha256
        "abc1234567890123456789012345678901234567890123456789012345678901");
-  Alcotest.(check bool) "uppercase hex" true
+  Alcotest.(check bool) "uppercase hex" false
     (A.is_valid_sha256
        "ABC1234567890123456789012345678901234567890123456789012345678901");
   Alcotest.(check bool) "63 chars" false

--- a/test/test_fs_compat.ml
+++ b/test/test_fs_compat.ml
@@ -134,10 +134,12 @@ let test_read_dir_and_path_kind_use_typed_inventory ~fs () =
   let regular = Filename.concat directory "b.json" in
   let nested = Filename.concat directory "a-dir" in
   let nested_link = Filename.concat directory "c-link" in
+  let fifo = Filename.concat directory "d-fifo" in
   Fs_compat.mkdir_p directory;
   Fs_compat.mkdir_p nested;
   Fs_compat.save_file regular "{}";
   Unix.symlink nested nested_link;
+  Unix.mkfifo fifo 0o600;
   let check_inventory implementation =
     check bool (implementation ^ " directory classified") true
       (Fs_compat.path_kind directory = Fs_compat.Directory);
@@ -149,10 +151,22 @@ let test_read_dir_and_path_kind_use_typed_inventory ~fs () =
       (Fs_compat.path_kind nested_link = Fs_compat.Directory);
     check bool (implementation ^ " symlink itself remains non-directory") true
       (Fs_compat.path_kind ~follow:false nested_link = Fs_compat.Other);
+    check bool (implementation ^ " exact regular file kind") true
+      (Fs_compat.exact_path_kind ~follow:false regular
+       = Fs_compat.Exact_kind Unix.S_REG);
+    check bool (implementation ^ " exact symlink kind") true
+      (Fs_compat.exact_path_kind ~follow:false nested_link
+       = Fs_compat.Exact_kind Unix.S_LNK);
+    check bool (implementation ^ " exact FIFO kind") true
+      (Fs_compat.exact_path_kind ~follow:false fifo
+       = Fs_compat.Exact_kind Unix.S_FIFO);
+    check bool (implementation ^ " exact missing kind") true
+      (Fs_compat.exact_path_kind (Filename.concat directory "missing")
+       = Fs_compat.Exact_missing);
     check
       (list string)
       (implementation ^ " directory inventory is deterministic")
-      [ "a-dir"; "b.json"; "c-link" ]
+      [ "a-dir"; "b.json"; "c-link"; "d-fifo" ]
       (Fs_compat.read_dir directory)
   in
   Fs_compat.clear_fs ();

--- a/test/test_tool_blob_store.ml
+++ b/test/test_tool_blob_store.ml
@@ -14,6 +14,12 @@ module O = Tool_output
 
 (* --- Helpers --- *)
 
+let fetch_ok store ~sha256 =
+  match B.fetch store ~sha256 with
+  | Ok value -> value
+  | Error error ->
+      Alcotest.failf "fetch failed: %s" (B.fetch_error_to_string error)
+
 let with_temp_dir f =
   let dir = Filename.temp_file "masc_blob_test" "" in
   Sys.remove dir;
@@ -134,17 +140,21 @@ let test_put_then_fetch () =
       match stored with
       | O.Stored { sha256; _ } -> (
           match B.fetch store ~sha256 with
-          | Some bytes ->
+          | Ok (Some bytes) ->
               Alcotest.(check string) "round-trip bytes" payload bytes
-          | None -> Alcotest.fail "fetch returned None")
+          | Ok None -> Alcotest.fail "fetch returned None"
+          | Error error ->
+              Alcotest.failf "fetch failed: %s" (B.fetch_error_to_string error))
       | O.Inline _ -> Alcotest.fail "put returned Inline")
 
 let test_fetch_miss () =
   with_temp_dir (fun dir ->
       let store = B.create ~base_path:dir in
       match B.fetch store ~sha256:(String.make 64 '0') with
-      | None -> ()
-      | Some _ -> Alcotest.fail "expected None for unknown sha")
+      | Ok None -> ()
+      | Ok (Some _) -> Alcotest.fail "expected None for unknown sha"
+      | Error error ->
+          Alcotest.failf "fetch failed: %s" (B.fetch_error_to_string error))
 
 let test_idempotent_put () =
   (* Same content twice = same sha = same path, no error. *)
@@ -198,7 +208,7 @@ let test_gc_deletes_unkept () =
       Alcotest.(check (option string))
         "kept blob still fetchable"
         (Some "keep me")
-        (B.fetch store ~sha256:keep))
+        (fetch_ok store ~sha256:keep))
 
 let test_gc_empty_keep_clears_all () =
   with_temp_dir (fun dir ->
@@ -230,7 +240,7 @@ let test_repeated_put_no_dup () =
       let sha = List.hd (B.list_all store) in
       Alcotest.(check (option string))
         "fetched content matches" (Some payload)
-        (B.fetch store ~sha256:sha))
+        (fetch_ok store ~sha256:sha))
 
 (* --- Storage-failure contract --- *)
 
@@ -250,6 +260,78 @@ let test_put_raises_on_unwritable_store () =
   in
   (try Sys.remove file with _ -> ());
   Alcotest.(check bool) "put raises on unwritable store" true raised
+
+let test_fetch_rejects_non_regular_paths () =
+  with_temp_dir (fun dir ->
+      let store = B.create ~base_path:dir in
+      let assert_rejected character expected_kind create_path =
+        let sha256 = String.make 64 character in
+        let shard_dir =
+          Filename.concat (B.root_dir store) (String.make 2 character)
+        in
+        Fs_compat.mkdir_p shard_dir;
+        let path = Filename.concat shard_dir sha256 in
+        create_path path;
+        match B.fetch store ~sha256 with
+        | Error (B.Unexpected_file_kind { kind = Fs_compat.Exact_kind kind; _ }) ->
+            Alcotest.(check bool) "exact non-regular kind" true (kind = expected_kind)
+        | Error error ->
+            Alcotest.failf "unexpected fetch error: %s" (B.fetch_error_to_string error)
+        | Ok _ -> Alcotest.fail "non-regular path reached blob read"
+      in
+      let target = Filename.concat dir "symlink-target" in
+      Fs_compat.save_file target "outside blob store";
+      assert_rejected 'a' Unix.S_DIR (fun path -> Unix.mkdir path 0o755);
+      assert_rejected 'b' Unix.S_FIFO (fun path -> Unix.mkfifo path 0o600);
+      assert_rejected 'c' Unix.S_LNK (fun path -> Unix.symlink target path))
+
+let test_fetch_reports_inspection_failure () =
+  let base_path = Filename.temp_file "masc_blob_parent_file" "" in
+  let store = B.create ~base_path in
+  let sha256 = String.make 64 'b' in
+  let result = B.fetch store ~sha256 in
+  (try Sys.remove base_path with _ -> ());
+  match result with
+  | Error (B.Inspect_failed _) -> ()
+  | Error error ->
+      Alcotest.failf
+        "unexpected fetch error: %s"
+        (B.fetch_error_to_string error)
+  | Ok None -> Alcotest.fail "structural store failure was reported as missing"
+  | Ok (Some _) -> Alcotest.fail "structural store failure returned bytes"
+
+let test_fetch_reports_integrity_mismatch () =
+  with_temp_dir (fun dir ->
+      let store = B.create ~base_path:dir in
+      let original = "content-addressed bytes" in
+      match B.put store ~bytes:original ~mime:"text/plain" with
+      | O.Inline _ -> Alcotest.fail "put returned Inline"
+      | O.Stored { sha256; _ } ->
+          let path =
+            Filename.concat
+              (Filename.concat (B.root_dir store) (String.sub sha256 0 2))
+              sha256
+          in
+          Fs_compat.save_file path "tampered bytes";
+          (match B.fetch store ~sha256 with
+           | Error (B.Integrity_mismatch _) -> ()
+           | Error error ->
+               Alcotest.failf
+                 "unexpected fetch error: %s"
+                 (B.fetch_error_to_string error)
+           | Ok None -> Alcotest.fail "tampered blob was reported as missing"
+           | Ok (Some _) -> Alcotest.fail "tampered blob passed digest verification"))
+
+let test_sha256_rejects_path_component () =
+  with_temp_dir (fun dir ->
+      let store = B.create ~base_path:dir in
+      match B.fetch store ~sha256:("../" ^ String.make 61 'a') with
+      | Error (B.Invalid_sha256 _) -> ()
+      | Error error ->
+          Alcotest.failf
+            "unexpected fetch error: %s"
+            (B.fetch_error_to_string error)
+      | Ok _ -> Alcotest.fail "path-like digest reached blob lookup")
 
 (* --- Entry point --- *)
 
@@ -293,5 +375,13 @@ let () =
         [
           Alcotest.test_case "put raises on unwritable store" `Quick
             test_put_raises_on_unwritable_store;
+          Alcotest.test_case "fetch rejects non-regular paths" `Quick
+            test_fetch_rejects_non_regular_paths;
+          Alcotest.test_case "fetch reports inspection failure" `Quick
+            test_fetch_reports_inspection_failure;
+          Alcotest.test_case "fetch reports integrity mismatch" `Quick
+            test_fetch_reports_integrity_mismatch;
+          Alcotest.test_case "sha256 rejects path component" `Quick
+            test_sha256_rejects_path_component;
         ] );
     ]


### PR DESCRIPTION
## Why

A forged ToolResult blob marker could pass an unchecked path component into the Keeper hydration path. Existing reads also collapsed storage failures into misses and accepted corrupt or special-file entries. That combination could leak local bytes, repeat broken hydration, or stall a Keeper lane.

## Change

- exact lowercase 64-hex validation before path construction
- exhaustive typed errors for validation, inspection, file kind, read, and integrity
- no-follow regular-file-only reads; reject directory, FIFO, symlink, socket, and devices before payload I/O
- rehash fetched bytes against the content address
- preserve Eio cancellation through `Safe_ops.handle`
- return explicit HTTP 503 and observable Keeper errors instead of miss/silent fallback
- atomically rewrite authoritative bytes on put, avoiding duplicate full read+rehash and repairing corruption

## Validation

- core blob-store leaf focused build: pass
- ocamlformat, parse, diff-check: pass
- regressions cover path-shaped digest, structural ENOTDIR, directory/FIFO/symlink rejection, and digest tampering
- total diff vs stacked base: 8 files, +291/-85 = 376 changed lines

## Stack

Depends on #24428 for the exact Eio/Unix no-follow path-kind SSOT. Merge #24428 first; then retarget this PR to `main`.