### PR TITLE
refactor(keeper): make compaction lifecycle explicit

### DIFF
--- a/lib/keeper/keeper_registry_entry_action_dispatch.ml
+++ b/lib/keeper/keeper_registry_entry_action_dispatch.ml
@@ -1,10 +1,7 @@
 (** Entry-action dispatch observability helpers (RFC-0002).
 
     Extracted from keeper_registry.ml (lines 1507-1555) as part of the
-    godfile decomp campaign. Three pure side-effect helpers — log line
-    on a [Publish_lifecycle] entry action, Otel_metric_store-instrumented
-    lookup of a follow-up event for [Overflowed/Start_compaction], and
-    a counter bump on rejected follow-up dispatch. No registry state
+    godfile decomp campaign. Pure side-effect helpers; no registry state is
     read or written. *)
 
 let execute_observability
@@ -50,14 +47,8 @@ let followup_event_of_action
       (action : Keeper_state_machine.entry_action)
   : Keeper_state_machine.event option
   =
-  match phase, action with
-  | Keeper_state_machine.Overflowed, Start_compaction ->
-    Otel_metric_store.inc_counter
-      Keeper_metrics.(to_string FsmEdgeTransitions)
-      ~labels:[ "edge", "ksm_to_kmc_compact_trigger" ]
-      ();
-    Some Keeper_state_machine.Auto_compact_triggered
-  | _ -> None
+  let _ = phase, action in
+  None
 ;;
 
 let record_dispatch_rejection event =

--- a/lib/keeper/keeper_registry_entry_action_dispatch.mli
+++ b/lib/keeper/keeper_registry_entry_action_dispatch.mli
@@ -11,10 +11,7 @@ val execute_observability :
   ts_unix:float ->
   Keeper_state_machine.entry_action -> unit
 
-(** Map a [(phase, action)] pair to the follow-up event the dispatcher
-    should fire (currently only [Overflowed/Start_compaction] →
-    [Auto_compact_triggered], with a [metric_keeper_fsm_edge_transitions]
-    counter bump). [None] for all other pairs. *)
+(** Durable activities never synthesize a follow-up lifecycle event here. *)
 val followup_event_of_action :
   phase:Keeper_state_machine.phase ->
   Keeper_state_machine.entry_action -> Keeper_state_machine.event option

--- a/lib/keeper_registry/keeper_state_machine.ml
+++ b/lib/keeper_registry/keeper_state_machine.ml
@@ -129,14 +129,9 @@ let derive_phase (c : conditions) : phase =
   else if c.handoff_active
   then HandingOff
   else if c.compaction_active
-  then
-    Compacting
-    (* 8b. Context overflow awaiting auto-compact.
-     Transient: [entry_actions_for] emits [Start_compaction] on entry,
-     which flips [compaction_active] via [Auto_compact_triggered] and the
-     next [derive_phase] returns [Compacting]. If [compaction_active] is
-     already set (compaction already started), priority 8 wins and the
-     keeper reads as [Compacting], not [Overflowed]. *)
+  then Compacting
+  else if c.context_overflow
+  then Overflowed
   else if
     (not c.heartbeat_healthy)
     || (not c.turn_healthy)
@@ -169,32 +164,8 @@ let update_conditions (c : conditions) (ev : event) : conditions =
   | Context_measured { context_actions; _ } ->
     { c with context_handoff_needed = context_actions.handoff }
   | Compaction_started -> { c with compaction_active = true }
-  | Compaction_completed { before_tokens; after_tokens } ->
-    (* #9988: "completed" alone does not mean the overflow was resolved.
-       In production 98.4% of [Compaction_completed] events arrive with
-       [before_tokens = after_tokens] because the checkpoint reducers
-       produced no savings (no tool_result sections to strip, pure-text
-       turns, etc).  Clearing [context_overflow] unconditionally created
-       an infinite loop with [Context_overflow_detected]: the next turn
-       re-measures the same context, re-fires overflow, re-attempts a
-       noop compaction, and clears the flag again.  #9935 observed
-       45-71 imminent events/day with zero observable reduction action.
-
-       Treat [saved_tokens <= 0] as a noop: keep [context_overflow] set
-       so the next layer (operator alert, stronger compaction profile,
-       handoff) can take over. Only a real reduction clears the flag
-       and releases the retry-exhausted latch. *)
-    let saved_tokens = before_tokens - after_tokens in
-    if saved_tokens > 0
-    then
-      { c with compaction_active = false; context_overflow = false }
-    else (
-      Log.Keeper.warn
-        "[fsm] compaction_completed with no savings (before=%d after=%d); keeping \
-         context_overflow=true to avoid noop re-trigger loop"
-        before_tokens
-        after_tokens;
-      { c with compaction_active = false })
+  | Compaction_completed _ ->
+    { c with compaction_active = false; context_overflow = false }
   | Compaction_failed _ ->
     (* Leave [context_overflow] set — the overflow has not been resolved.
        The retry-exhausted latch is owned by the caller (keeper_unified_turn
@@ -243,14 +214,9 @@ let update_conditions (c : conditions) (ev : event) : conditions =
     ; credential_archived = true
     }
   | Context_overflow_detected _ ->
-    (* Hard overflow reported by the provider. The phase derivation
-       maps this to [Overflowed] (auto-compact path)
-       (if the retry latch is already set). *)
     { c with context_overflow = true }
   | Auto_compact_triggered ->
-    (* Emitted as part of [Overflowed] entry actions.  Promotes the
-       keeper into [Compacting] on the next derivation without waiting
-       for [Compaction_started] from the post-turn lifecycle. *)
+    (* Legacy explicit input. No entry action produces this event. *)
     { c with compaction_active = true }
   | Operator_compact_requested ->
     { c with compaction_active = true }
@@ -261,11 +227,8 @@ let update_conditions (c : conditions) (ev : event) : conditions =
 ;;
 
 (** Compute entry actions for a phase transition.
-    [Publish_lifecycle] is always consumed by the registry runtime.
-    [Start_compaction] is additionally consumed for the auto-compact
-    [Overflowed] path; the remaining variants stay descriptive here
-    because their side effects are still owned elsewhere
-    (post-turn lifecycle or supervisor).
+    [Publish_lifecycle] is consumed by the registry runtime; the remaining
+    variants describe work whose effects are owned by their runtime boundary.
 
     Structure (Iteration 2, /loop FSM drift hunt — Phase A-2):
     Outer match is on [new_phase] so every phase variant is exhaustively
@@ -319,13 +282,8 @@ let entry_actions_for ~prev_phase ~new_phase ~(event : event) : entry_action lis
          | Operator_compact_requested
          | Operator_clear_requested _ -> event_to_string event)
     ]
-  (* [Overflowed] entry actions: request a compaction so the registry can
-     promote the committed [Overflowed] transition into the follow-up
-     [Auto_compact_triggered] event, and publish the transition so
-     operators can see "context overflow" distinctly from generic failure. *)
   | Overflowed ->
-    [ Start_compaction
-    ; lifecycle
+    [ lifecycle
         "overflowed"
         (match event with
          | Context_overflow_detected r ->

--- a/lib/keeper_registry/keeper_state_machine.mli
+++ b/lib/keeper_registry/keeper_state_machine.mli
@@ -28,11 +28,8 @@ type phase =
   | Offline       (** Registered but no heartbeat fiber started *)
   | Running       (** Healthy heartbeat loop executing *)
   | Failing       (** Consecutive failures detected, probing recovery *)
-  | Overflowed    (** Prompt exceeded provider max context; auto-compact
-                      pending. Transient: [entry_actions_for] emits
-                      [Start_compaction] so the next event-loop iteration
-                      derives [Compacting]. Distinguishes "context overflow"
-                      from generic [Failing] for operator observability. *)
+  | Overflowed    (** Prompt exceeded provider max context; durable lane
+                      compaction is pending. *)
   | Compacting    (** Context compaction in progress *)
   | HandingOff    (** Generation rollover in progress *)
   | Draining      (** Graceful shutdown: completing current turn *)
@@ -88,10 +85,8 @@ type conditions = {
   (** Provider rejected the most recent prompt for exceeding its max
       context window. Distinct from [context_within_budget] (soft,
       ratio-based warning): [context_overflow] is a hard failure reported
-      by the provider. Cleared by a [Compaction_completed] whose payload
-      reports real token savings ([before_tokens > after_tokens]) or by
-      an operator clear action. A noop compaction ([before = after])
-      leaves this flag set for observability and later recovery. *)
+      by the provider. Cleared by completed compaction or operator clear;
+      token counts remain observations, not lifecycle gates. *)
   credential_archived : bool;
 }
 
@@ -188,12 +183,9 @@ type event =
         diagnostics or from the drained OAS [Event_bus]
         [ContextOverflowImminent] signal for the same turn. *)
   | Auto_compact_triggered
-    (** Emitted as part of [Overflowed] entry actions to mark the
-        start of auto-recovery. Sets [compaction_active] so the next
-        [derive_phase] returns [Compacting]. *)
+    (** Legacy explicit input; no entry action produces this event. *)
   | Operator_compact_requested
-    (** Operator invoked [masc_keeper_compact] MCP tool. Behaves like
-        [Auto_compact_triggered] without requiring a preceding overflow. *)
+    (** Operator invoked [masc_keeper_compact] MCP tool. *)
   | Operator_clear_requested of { preserve_system : bool; reason : string }
     (** Operator invoked [masc_keeper_clear]. Last-resort: drops
         conversation context entirely. Bypasses [Compacting] buffer
@@ -208,9 +200,6 @@ val event_to_string : event -> string
     Runtime contract:
     - [Publish_lifecycle] is executed by the registry integration as an
       observability-only SSE/log side effect.
-    - [Start_compaction] is executed by the registry only for the
-      [Overflowed] auto-compact path, which emits
-      [Auto_compact_triggered] after the transition is committed.
     - The remaining variants remain descriptive placeholders for
       supervisor-owned work and are intentionally ignored by the registry. *)
 type entry_action =
@@ -268,7 +257,7 @@ val transition_error_to_string : transition_error -> string
     7.  Paused (operator_paused)
     8.  HandingOff (handoff_active)
     9.  Compacting (compaction_active)
-    10. Overflowed (context_overflow) -- transient, auto-compact pending
+    10. Overflowed (context_overflow) -- durable compaction pending
     11. Failing (latest health failure or structural failure observation)
     12. Running (fiber_alive)
     13. Offline (default fallback for inconsistent zero-state)

--- a/lib/keeper_registry/keeper_state_machine_types.ml
+++ b/lib/keeper_registry/keeper_state_machine_types.ml
@@ -180,9 +180,6 @@ let event_to_string = function
 (** Runtime contract mirrors [.mli]:
     - [Publish_lifecycle] is executed by the registry as an observability
       side effect.
-    - [Start_compaction] is executed by the registry only for the
-      [Overflowed] auto-compact path, which emits
-      [Auto_compact_triggered] after the transition is committed.
     - The remaining variants describe runtime-owned work and remain
       explicit phase-entry intent until that integration is unified. *)
 type entry_action =

--- a/test/test_keeper_overflow_recovery.ml
+++ b/test/test_keeper_overflow_recovery.ml
@@ -1,4 +1,4 @@
-(** Unit tests for the [Overflowed] phase + auto-compact recovery flow.
+(** Unit tests for the [Overflowed] phase and explicit compaction lifecycle.
 
     Scenarios mirror the five cases in the MASC-1 plan:
     1. Happy path — Running → Overflowed → Compacting → Running
@@ -49,17 +49,17 @@ let test_happy_path () =
   check_phase SM.Overflowed tr1.new_phase "overflow → Overflowed";
   check bool "context_overflow latched" true
     tr1.updated_conditions.context_overflow;
-  (* Entry action requests compaction *)
+  (* Durable Lane work is not synthesized as an FSM entry effect. *)
   let has_start_compaction =
     List.exists (function SM.Start_compaction -> true | _ -> false)
       tr1.entry_actions
   in
-  check bool "entry action includes Start_compaction" true has_start_compaction;
-  (* Auto-compact fires → Compacting *)
+  check bool "Overflowed does not synthesize compaction work" false has_start_compaction;
+  (* The Lane executor explicitly starts compaction. *)
   let tr2 =
-    apply_ok SM.Overflowed tr1.updated_conditions SM.Auto_compact_triggered
+    apply_ok SM.Overflowed tr1.updated_conditions SM.Compaction_started
   in
-  check_phase SM.Compacting tr2.new_phase "auto-compact → Compacting";
+  check_phase SM.Compacting tr2.new_phase "compaction start → Compacting";
   (* Compaction completes → Running (context_overflow cleared) *)
   let tr3 =
     apply_ok SM.Compacting tr2.updated_conditions
@@ -74,9 +74,9 @@ let test_happy_path () =
 let test_compact_failure_remains_overflowed () =
   (* Running → overflow → Overflowed *)
   let tr1 = apply_ok SM.Running running_conds (overflow_event ()) in
-  (* Auto-compact triggered → Compacting *)
+  (* The Lane executor explicitly starts compaction. *)
   let tr2 =
-    apply_ok SM.Overflowed tr1.updated_conditions SM.Auto_compact_triggered
+    apply_ok SM.Overflowed tr1.updated_conditions SM.Compaction_started
   in
   (* Compaction fails — compaction_active cleared but context_overflow keeps *)
   let tr3 =
@@ -113,7 +113,7 @@ let test_two_consecutive_overflows () =
   (* Run one full overflow/compact/running cycle. *)
   let tr1 = apply_ok SM.Running running_conds (overflow_event ()) in
   let tr2 =
-    apply_ok SM.Overflowed tr1.updated_conditions SM.Auto_compact_triggered
+    apply_ok SM.Overflowed tr1.updated_conditions SM.Compaction_started
   in
   let tr3 =
     apply_ok SM.Compacting tr2.updated_conditions
@@ -124,81 +124,21 @@ let test_two_consecutive_overflows () =
   let tr4 = apply_ok SM.Running tr3.updated_conditions (overflow_event ()) in
   check_phase SM.Overflowed tr4.new_phase "cycle 2 → Overflowed";
   let tr5 =
-    apply_ok SM.Overflowed tr4.updated_conditions SM.Auto_compact_triggered
+    apply_ok SM.Overflowed tr4.updated_conditions SM.Compaction_started
   in
-  check_phase SM.Compacting tr5.new_phase "cycle 2 auto-compact → Compacting"
+  check_phase SM.Compacting tr5.new_phase "cycle 2 compaction → Compacting"
 
-(* ── Scenario 4b: noop compaction (#9988) ──────────────────── *)
-
-(* Prior handler dropped the [before_tokens, after_tokens] payload and
-   cleared [context_overflow] on every [Compaction_completed].  In
-   production 98.4% of completion events carried [before = after] (pure-
-   text turns with nothing for reducers to strip), so the FSM re-entered
-   Running, the next turn re-measured, and re-fired
-   [Context_overflow_detected].  Result: 45–71 overflow events/day with
-   zero observable reduction (#9935).  The noop path now has to leave
-   the flag set. *)
-let test_noop_compaction_keeps_overflow () =
-  let tr1 = apply_ok SM.Running running_conds (overflow_event ()) in
-  let tr2 =
-    apply_ok SM.Overflowed tr1.updated_conditions SM.Auto_compact_triggered
-  in
-  let tr3 =
-    apply_ok SM.Compacting tr2.updated_conditions
-      (SM.Compaction_completed
-         { before_tokens = 200_000; after_tokens = 200_000 })
-  in
-  check bool "noop compaction does NOT clear context_overflow"
-    true tr3.updated_conditions.context_overflow;
-  check bool "noop still exits Compacting (compaction_active=false)"
-    false tr3.updated_conditions.compaction_active;
-  check_phase SM.Overflowed tr3.new_phase
-    "post-noop phase remains Overflowed, not Running"
-
-(* [after > before] (reducer added a wrapper, retry grew the payload,
-   etc.) is also degenerate — must not clear. *)
-let test_negative_savings_keeps_overflow () =
-  let tr1 = apply_ok SM.Running running_conds (overflow_event ()) in
-  let tr2 =
-    apply_ok SM.Overflowed tr1.updated_conditions SM.Auto_compact_triggered
-  in
-  let tr3 =
-    apply_ok SM.Compacting tr2.updated_conditions
-      (SM.Compaction_completed
-         { before_tokens = 200_000; after_tokens = 210_000 })
-  in
-  check bool "negative-savings compaction does NOT clear overflow"
-    true tr3.updated_conditions.context_overflow
-
-(* Noop → real savings: first keeps overflow, next cycle with real
-   reduction clears it.  Confirms the new branch is additive, not
-   blocking recovery. *)
-let test_noop_then_real_savings_clears () =
-  let tr1 = apply_ok SM.Running running_conds (overflow_event ()) in
-  let tr2 =
-    apply_ok SM.Overflowed tr1.updated_conditions SM.Auto_compact_triggered
-  in
-  let tr3 =
-    apply_ok SM.Compacting tr2.updated_conditions
-      (SM.Compaction_completed
-         { before_tokens = 180_000; after_tokens = 180_000 })
-  in
-  check bool "after noop, overflow still set"
-    true tr3.updated_conditions.context_overflow;
-  let tr4 =
-    apply_ok tr3.new_phase tr3.updated_conditions (overflow_event ())
-  in
-  let tr5 =
-    apply_ok tr4.new_phase tr4.updated_conditions SM.Auto_compact_triggered
-  in
-  let tr6 =
-    apply_ok SM.Compacting tr5.updated_conditions
-      (SM.Compaction_completed
-         { before_tokens = 180_000; after_tokens = 60_000 })
-  in
-  check_phase SM.Running tr6.new_phase "real savings → Running";
-  check bool "real savings clear context_overflow"
-    false tr6.updated_conditions.context_overflow
+let test_completion_counts_are_observations () =
+  List.iter
+    (fun (before_tokens, after_tokens) ->
+      let tr1 = apply_ok SM.Running running_conds (overflow_event ()) in
+      let tr2 = apply_ok SM.Overflowed tr1.updated_conditions SM.Compaction_started in
+      let tr3 = apply_ok SM.Compacting tr2.updated_conditions
+          (SM.Compaction_completed { before_tokens; after_tokens }) in
+      check bool "completed compaction clears overflow" false
+        tr3.updated_conditions.context_overflow;
+      check_phase SM.Running tr3.new_phase "completed compaction resumes")
+    [ 180_000, 180_000; 180_000, 210_000 ]
 
 (* ── Scenario 5: heartbeat failure during Overflowed ──────── *)
 
@@ -218,10 +158,10 @@ let test_heartbeat_failure_preserved_through_overflow () =
     "Overflowed outranks heartbeat failure";
   check bool "heartbeat unhealthy latched" false
     tr2.updated_conditions.heartbeat_healthy;
-  (* Auto-compact finishes → overflow cleared.  Heartbeat failure now
+  (* Compaction finishes → overflow cleared. Heartbeat failure now
      surfaces as Failing.  This confirms no event is swallowed. *)
   let tr3 =
-    apply_ok SM.Overflowed tr2.updated_conditions SM.Auto_compact_triggered
+    apply_ok SM.Overflowed tr2.updated_conditions SM.Compaction_started
   in
   check_phase SM.Compacting tr3.new_phase "compact starts";
   let tr4 =
@@ -231,26 +171,6 @@ let test_heartbeat_failure_preserved_through_overflow () =
   (* context_overflow cleared, heartbeat_healthy=false remains → Failing *)
   check_phase SM.Failing tr4.new_phase
     "post-compact, heartbeat failure surfaces as Failing"
-
-(* ── Scenario 6 (#9988): noop compaction must not clear overflow ──── *)
-
-let test_noop_compaction_keeps_overflow () =
-  (* Overflow detected, auto-compact runs, but reducers did not shrink
-     the context (e.g. pure-text history). before == after ⇒ the FSM
-     must NOT clear [context_overflow], otherwise the next turn will
-     re-trip the same overflow loop (#9935/#9943). *)
-  let tr1 = apply_ok SM.Running running_conds (overflow_event ()) in
-  let tr2 =
-    apply_ok SM.Overflowed tr1.updated_conditions SM.Auto_compact_triggered
-  in
-  let tr3 =
-    apply_ok SM.Compacting tr2.updated_conditions
-      (SM.Compaction_completed { before_tokens = 180_000; after_tokens = 180_000 })
-  in
-  check bool "noop compaction keeps context_overflow set" true
-    tr3.updated_conditions.context_overflow;
-  check bool "compaction_active cleared" false
-    tr3.updated_conditions.compaction_active
 
 let () =
   run "keeper_overflow_recovery" [
@@ -262,15 +182,9 @@ let () =
         test_operator_clear_returns_to_running;
       test_case "two consecutive overflows" `Quick
         test_two_consecutive_overflows;
-      test_case "noop compaction keeps overflow (#9988)" `Quick
-        test_noop_compaction_keeps_overflow;
-      test_case "negative-savings keeps overflow (#9988)" `Quick
-        test_negative_savings_keeps_overflow;
-      test_case "noop then real savings clears (#9988)" `Quick
-        test_noop_then_real_savings_clears;
+      test_case "completion token counts are observations" `Quick
+        test_completion_counts_are_observations;
       test_case "heartbeat failure preserved through overflow" `Quick
         test_heartbeat_failure_preserved_through_overflow;
-      test_case "noop compaction keeps overflow (#9988)" `Quick
-        test_noop_compaction_keeps_overflow;
     ]
   ]


### PR DESCRIPTION
## Summary
- keep provider-reported overflow visibly `Overflowed` until the Keeper Lane starts compaction
- remove the fake FSM entry effect that only flipped the phase to `Compacting`
- treat compaction before/after token counts as observations, not lifecycle authorization
- replace tests that enforced token-delta gating with the explicit Lane lifecycle contract

## Boundary
This PR does not execute compaction. It removes the false producer/state gate so the following PR can attach one durable MASC Lane executor without competing FSM behavior. OAS remains a typed fact source only.

## Validation
- `ocamlformat --check` on all changed OCaml files
- `ocamlc -stop-after parsing` on all changed `.ml`/`.mli` files
- `git diff --check`
- 48 additions / 202 deletions (250 churn)

Focused Dune validation could not acquire the shared workspace build lock. Current main CI also has an independent stale OAS pin (`902c45d`, pre-v0.212.0) whose `Agent.create` surface lacks `~provider_config`; that pin repair is being handled separately, without a compatibility shim.