### PR TITLE
fix(runtime): adapt max_context to OAS 0.212.0 int option catalog field

### DIFF
--- a/lib/runtime_model/runtime_model_string.ml
+++ b/lib/runtime_model/runtime_model_string.ml
@@ -130,7 +130,7 @@ let make_registry_config
     in
     match caps.max_context_tokens with
     | Some n -> Some n
-    | None -> Some entry.max_context
+    | None -> entry.max_context
   in
   Llm_provider.Provider_config.make
     ~kind:defaults.kind


### PR DESCRIPTION
OAS 0.212.0가 model-catalog `entry.max_context`를 `int` → `int option`으로 변경. `runtime_model_string`이 `Some entry.max_context`로 감싸 `int option option` 타입 에러 → `Some` 제거(entry.max_context가 이미 match가 반환하는 int option).

`dune build lib/runtime_model/` 컴파일 확인(로컬 OAS 0.212.0). 1파일 +1/−1.

## 남은 green-blocker (이 PR 아님, Codex 도메인)
`Agent_sdk.Tool_failure_recovery` 모듈 **0.212.0에서 통째 제거**(직접 대체 없음, `Provider_failure_attribution`이 별개 개념). masc의 tool-failure-recovery judge(~10파일, `keeper_tool_failure_recovery_judge` = 실기능: OAS episode 탐지 + masc provider fallback)를 **제거할지 rewire할지 = 마이그레이션 설계 결정**. 추측 시 tool-recovery 깨질 위험.

**full green = 이 PR + Tool_failure_recovery 마이그레이션**이 둘 다 착지해야 함.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>