### PR TITLE
fix(build): restore Oauth_cached_login arms and drop a dead binding

### DIFF
--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -142,7 +142,6 @@ let assemble_hooks
   : (agent_setup, Agent_sdk.Error.sdk_error) result
   =
   let acc = ctx.acc in
-  let agent_name = ctx.agent_name in
   let compute_tool_surface = ctx.compute_tool_surface in
   let record_tool_assignment = ctx.record_tool_assignment in
   let config = ctx.config in

--- a/lib/runtime_model/provider_runtime_projection.ml
+++ b/lib/runtime_model/provider_runtime_projection.ml
@@ -56,6 +56,7 @@ let binding_auth_is_no_auth (binding : Runtime_binding.t) =
   match binding.Runtime_binding.auth with
   | Runtime_binding.No_auth -> true
   | Runtime_binding.Api_key_env _
+  | Runtime_binding.Oauth_cached_login
   | Runtime_binding.Setup_token_env _ -> false
 ;;
 
@@ -203,6 +204,7 @@ let binding_auth_available (binding : Runtime_binding.t) =
   | Runtime_binding.No_auth -> true
   | Runtime_binding.Api_key_env env_name | Runtime_binding.Setup_token_env env_name ->
     env_present env_name
+  | Runtime_binding.Oauth_cached_login -> binding.Runtime_binding.available
 ;;
 
 let default_model_label_for_binding (binding : Runtime_binding.t) =

--- a/lib/runtime_model/runtime_provider_binding.ml
+++ b/lib/runtime_model/runtime_provider_binding.ml
@@ -55,6 +55,7 @@ let binding_auth_is_no_auth (binding : Runtime_binding.t) =
   match binding.Runtime_binding.auth with
   | Runtime_binding.No_auth -> true
   | Runtime_binding.Api_key_env _
+  | Runtime_binding.Oauth_cached_login
   | Runtime_binding.Setup_token_env _ -> false
 ;;
 

--- a/scripts/lint/no-provider-name-hardcoding.allowlist
+++ b/scripts/lint/no-provider-name-hardcoding.allowlist
@@ -3,6 +3,6 @@
 # catalog/runtime-binding replacement task.
 #
 # Format: path:line:literal
-lib/runtime_model/provider_runtime_projection.ml:100:auto
-lib/runtime_model/provider_runtime_projection.ml:198:auto
-lib/runtime_model/provider_runtime_projection.ml:239:openrouter
+lib/runtime_model/provider_runtime_projection.ml:101:auto
+lib/runtime_model/provider_runtime_projection.ml:199:auto
+lib/runtime_model/provider_runtime_projection.ml:241:openrouter


### PR DESCRIPTION
## 무엇을

main tip(bb66c3f3) 컴파일 에러 5건 중 **기계적 4건** 수리. 나머지 1건은 설계 결합이라 트랙 분리(아래).

1. `provider_runtime_projection.ml` ×2 + `runtime_provider_binding.ml` ×1 — #24405가 binding-auth match를 재작성하며 기존 `Oauth_cached_login` arm을 누락 (pin v0.211.9의 SDK엔 생성자가 실존 → warning 8). **추측 없이 `ff2467261e~1`의 원래 arm을 그대로 복원**: `is_no_auth → false`, `available → binding.available`.
2. `keeper_run_tools_hooks.ml:145` — #24420이 소비자를 제거해 고아가 된 `agent_name` 바인딩 삭제 (warning 26).
3. allowlist 라인핀 재조준 (arm 삽입으로 100→101/198→199/239→241) — 같은 커밋 원자성.

## 안 고친 것 (트랙 분리)

`runtime_agent.ml:1015`의 `~provider_config`(resume) — **#24412가 drift된 로컬 agent_sdk 0.212 시그니처로 코딩**한 케이스로, pin의 resume엔 해당 파라미터가 없습니다. pre-24412 형태 복원은 그 PR의 provider-overlay 하드컷 의도를 되돌리는 것이라 #24412 트랙 몫입니다 (#24391에 기록).

## 검증

- `bash scripts/lint/no-provider-name-hardcoding.sh` → OK
- 로컬 컴파일은 switch drift(0.212, 생성자 부재)로 **역방향 에러** — 제 arm이 pin에 정확하다는 교차 증거이며, pin 기반 CI가 정본.

Related: masc#24391 (red-merge 연쇄 umbrella).

RFC-WAIVED: 이미 머지된 커밋들의 컴파일 계약 복원, 신규 설계 없음.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
