### PR TITLE
refactor(keeper): remove OAS tool recovery projections

### DIFF
--- a/lib/keeper/keeper_agent_error.ml
+++ b/lib/keeper/keeper_agent_error.ml
@@ -91,8 +91,6 @@ type sdk_termination_semantics =
   | Oas_guardrail_violation
   | Oas_tripwire_violation
   | Oas_input_required
-  | Oas_tool_failure_recovery_failed
-  | Oas_tool_failure_recovery_deferred
   | Sdk_error_failure
 
 let sdk_termination_semantics = function
@@ -113,10 +111,6 @@ let sdk_termination_semantics = function
   | Agent_sdk.Error.Agent (Agent_sdk.Error.TripwireViolation _) ->
     Oas_tripwire_violation
   | Agent_sdk.Error.Agent (Agent_sdk.Error.InputRequired _) -> Oas_input_required
-  | Agent_sdk.Error.Agent (Agent_sdk.Error.ToolFailureRecoveryFailed _) ->
-    Oas_tool_failure_recovery_failed
-  | Agent_sdk.Error.Agent (Agent_sdk.Error.ToolFailureRecoveryDeferred _) ->
-    Oas_tool_failure_recovery_deferred
   | Agent_sdk.Error.Agent (Agent_sdk.Error.UnrecognizedStopReason _) ->
     Sdk_error_failure
   | Agent_sdk.Error.Provider _ -> Sdk_error_failure
@@ -138,8 +132,6 @@ let sdk_termination_semantics_to_string = function
   | Oas_guardrail_violation -> "oas_guardrail_violation"
   | Oas_tripwire_violation -> "oas_tripwire_violation"
   | Oas_input_required -> "oas_input_required"
-  | Oas_tool_failure_recovery_failed -> "oas_tool_failure_recovery_failed"
-  | Oas_tool_failure_recovery_deferred -> "oas_tool_failure_recovery_deferred"
   | Sdk_error_failure -> "sdk_error_failure"
 ;;
 
@@ -205,12 +197,6 @@ let agent_error_terminal_reason_code = function
     Printf.sprintf "agent_error_tripwire_violation:tripwire=%s" tripwire
   | Agent_sdk.Error.InputRequired { request_id; question = _; _ } ->
     Printf.sprintf "agent_error_input_required:request_id=%s" request_id
-  | Agent_sdk.Error.ToolFailureRecoveryFailed { stage; detail = _ } ->
-    Printf.sprintf
-      "agent_error_tool_failure_recovery_failed:stage=%s"
-      (Agent_sdk.Error.tool_failure_recovery_stage_to_string stage)
-  | Agent_sdk.Error.ToolFailureRecoveryDeferred _ ->
-    "agent_error_tool_failure_recovery_deferred"
 ;;
 
 let network_error_kind_to_wire = function
@@ -298,10 +284,8 @@ let receipt_outcome_kind_of_sdk_error err =
   | Oas_turn_limit_observed -> `Ok
   | Oas_idle_detected_failure -> `Error
   | Oas_input_required -> `Cancelled
-  | Oas_tool_failure_recovery_deferred -> `Cancelled
   | Oas_guardrail_violation
   | Oas_tripwire_violation
-  | Oas_tool_failure_recovery_failed
   | Sdk_error_failure -> `Error
 ;;
 

--- a/lib/keeper/keeper_agent_error.mli
+++ b/lib/keeper/keeper_agent_error.mli
@@ -28,8 +28,6 @@ type sdk_termination_semantics =
   | Oas_guardrail_violation
   | Oas_tripwire_violation
   | Oas_input_required
-  | Oas_tool_failure_recovery_failed
-  | Oas_tool_failure_recovery_deferred
   | Sdk_error_failure
 
 val sdk_termination_semantics

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -724,9 +724,7 @@ let is_context_overflow (err : Agent_sdk.Error.sdk_error) : bool =
   | Agent_sdk.Error.Agent (UnrecognizedStopReason _)
   | Agent_sdk.Error.Agent (GuardrailViolation _)
   | Agent_sdk.Error.Agent (TripwireViolation _)
-  | Agent_sdk.Error.Agent (ExitConditionMet _)
-  | Agent_sdk.Error.Agent (ToolFailureRecoveryFailed _)
-  | Agent_sdk.Error.Agent (ToolFailureRecoveryDeferred _) -> false
+  | Agent_sdk.Error.Agent (ExitConditionMet _) -> false
   | Agent_sdk.Error.Agent (InputRequired _) -> false
   (* Non-API / non-Agent error families. *)
   | Agent_sdk.Error.Mcp _
@@ -792,9 +790,7 @@ let is_input_required_error (err : Agent_sdk.Error.sdk_error) : bool =
   | Agent_sdk.Error.Agent (UnrecognizedStopReason _)
   | Agent_sdk.Error.Agent (GuardrailViolation _)
   | Agent_sdk.Error.Agent (TripwireViolation _)
-  | Agent_sdk.Error.Agent (ExitConditionMet _)
-  | Agent_sdk.Error.Agent (ToolFailureRecoveryFailed _)
-  | Agent_sdk.Error.Agent (ToolFailureRecoveryDeferred _) -> false
+  | Agent_sdk.Error.Agent (ExitConditionMet _) -> false
   | Agent_sdk.Error.Api _
   | Agent_sdk.Error.Provider _
   | Agent_sdk.Error.Mcp _

--- a/lib/keeper/keeper_event_bridge.ml
+++ b/lib/keeper/keeper_event_bridge.ml
@@ -41,22 +41,6 @@ let payload_agent_name payload =
      | None -> Json_util.get_string payload "keeper_name")
 ;;
 
-let tool_failure_episode_observation =
-  Agent_sdk.Tool_failure_episode.observation_to_yojson
-;;
-
-let sha256_hex value = Digestif.SHA256.(digest_string value |> to_hex)
-
-let recovery_decision_observation_fields decision =
-  match
-    Agent_sdk.Tool_failure_recovery.decision_observation_to_yojson decision
-  with
-  | `Assoc fields -> fields
-  | _ ->
-    invalid_arg
-      "keeper_event_bridge: OAS recovery decision observation must be an object"
-;;
-
 let emit_native_event_log (evt : Agent_sdk.Event_bus.event) (json : Yojson.Safe.t) =
   let log_at level message =
     Log.Oas_event.emit level ~details:json message
@@ -97,25 +81,6 @@ let emit_native_event_log (evt : Agent_sdk.Event_bus.event) (json : Yojson.Safe.
   | Agent_sdk.Event_bus.ToolCompleted { agent_name; tool_name; _ } ->
     log_routine
       (Printf.sprintf "tool completed agent=%s tool_name=%s" agent_name tool_name)
-  | Agent_sdk.Event_bus.ToolFailureEpisodeDetected { agent_name; turn; episodes } ->
-    log
-      (Printf.sprintf
-         "typed tool failure episode detected agent=%s turn=%d episodes=%d"
-         agent_name
-         turn
-         (List.length episodes))
-  | Agent_sdk.Event_bus.ToolFailureRecoveryDecided { agent_name; turn; _ } ->
-    log
-      (Printf.sprintf
-         "typed tool failure recovery decided agent=%s turn=%d"
-         agent_name
-         turn)
-  | Agent_sdk.Event_bus.ToolFailureRecoveryJudgeFailed { agent_name; turn; _ } ->
-    log
-      (Printf.sprintf
-         "typed tool failure recovery judge failed agent=%s turn=%d"
-         agent_name
-         turn)
   | Agent_sdk.Event_bus.TurnReady { agent_name; turn; tool_names } ->
     (* [substrate:tool_surface] — deterministic per-turn snapshot of the
          tool list the LLM actually sees this turn (after guardrails,
@@ -308,56 +273,6 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
          @ execution_id_fields)
     in
     Some (wrap ~event_type:"tool_completed" ~payload ~agent_name ~tool_name ())
-  | Agent_sdk.Event_bus.ToolFailureEpisodeDetected { agent_name; turn; episodes } ->
-    let payload =
-      `Assoc
-        [ "agent_name", `String agent_name
-        ; "turn", `Int turn
-        ; "episode_count", `Int (List.length episodes)
-        ; ( "episodes"
-          , `List (List.map tool_failure_episode_observation episodes) )
-        ]
-    in
-    Some
-      (wrap
-         ~event_type:"tool_failure_episode_detected"
-         ~payload
-         ~agent_name
-         ~turn
-         ())
-  | Agent_sdk.Event_bus.ToolFailureRecoveryDecided
-      { agent_name; turn; decision } ->
-    let payload =
-      `Assoc
-        ([ "agent_name", `String agent_name; "turn", `Int turn ]
-         @ recovery_decision_observation_fields decision)
-    in
-    Some
-      (wrap
-         ~event_type:"tool_failure_recovery_decided"
-         ~payload
-         ~agent_name
-         ~turn
-         ())
-  | Agent_sdk.Event_bus.ToolFailureRecoveryJudgeFailed
-      { agent_name; turn; kind; detail } ->
-    let payload =
-      `Assoc
-        [ "agent_name", `String agent_name
-        ; "turn", `Int turn
-        ; ( "kind"
-          , `String
-              (Agent_sdk.Tool_failure_recovery.judge_error_kind_to_string kind) )
-        ; "detail_digest", `String (sha256_hex detail)
-        ]
-    in
-    Some
-      (wrap
-         ~event_type:"tool_failure_recovery_judge_failed"
-         ~payload
-         ~agent_name
-         ~turn
-         ())
   | Agent_sdk.Event_bus.TurnStarted { agent_name; turn } ->
     let payload = `Assoc [ "agent_name", `String agent_name; "turn", `Int turn ] in
     Some (wrap ~event_type:"turn_started" ~payload ~agent_name ~turn ())

--- a/lib/keeper/keeper_event_bridge_error_json.ml
+++ b/lib/keeper/keeper_event_bridge_error_json.ml
@@ -1,7 +1,5 @@
 let stop_reason_to_wire = Agent_sdk.Types.stop_reason_to_string
 
-let sha256_hex value = Digestif.SHA256.(digest_string value |> to_hex)
-
 let agent_completed_usage_fields (response : Agent_sdk.Types.api_response) =
   match response.usage with
   | None -> [ "usage_reported", `Bool false ]
@@ -113,17 +111,6 @@ let sdk_agent_error_fields = function
     ; "request_id", `String request_id
     ; "participant_name", Json_util.string_opt_to_json participant_name
     ; "question", `String question
-    ]
-  | Agent_sdk.Error.ToolFailureRecoveryFailed { stage; detail } ->
-    [ "variant", `String "tool_failure_recovery_failed"
-    ; ( "stage"
-      , `String (Agent_sdk.Error.tool_failure_recovery_stage_to_string stage) )
-    ; "detail_digest", `String (sha256_hex detail)
-    ]
-  | Agent_sdk.Error.ToolFailureRecoveryDeferred { reason; tool_names } ->
-    [ "variant", `String "tool_failure_recovery_deferred"
-    ; "reason_digest", `String (sha256_hex reason)
-    ; "tool_names", `List (List.map (fun name -> `String name) tool_names)
     ]
   | Agent_sdk.Error.AgentExecutionTimeout
       { elapsed_sec; timeout_sec; turn_count; max_turns } ->

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -124,7 +124,6 @@ type blocker_class =
   | Sdk_tripwire_violation
   | Sdk_exit_condition_met
   | Sdk_input_required
-  | Sdk_tool_failure_recovery_failed
 
 let blocker_class_to_string = function
   | Runtime_exhausted _ -> "runtime_exhausted"
@@ -139,7 +138,6 @@ let blocker_class_to_string = function
   | Sdk_tripwire_violation -> "sdk_tripwire_violation"
   | Sdk_exit_condition_met -> "sdk_exit_condition_met"
   | Sdk_input_required -> "sdk_input_required"
-  | Sdk_tool_failure_recovery_failed -> "sdk_tool_failure_recovery_failed"
 ;;
 
 let blocker_class_of_serialized_string = function
@@ -155,7 +153,6 @@ let blocker_class_of_serialized_string = function
   | "sdk_tripwire_violation" -> Some Sdk_tripwire_violation
   | "sdk_exit_condition_met" -> Some Sdk_exit_condition_met
   | "sdk_input_required" -> Some Sdk_input_required
-  | "sdk_tool_failure_recovery_failed" -> Some Sdk_tool_failure_recovery_failed
   | _ -> None
 ;;
 

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -135,7 +135,6 @@ type blocker_class =
   | Sdk_tripwire_violation
   | Sdk_exit_condition_met
   | Sdk_input_required
-  | Sdk_tool_failure_recovery_failed
 
 val blocker_class_to_string : blocker_class -> string
 (** Canonical lowercase labels.  Pinned literals — operator

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -108,9 +108,8 @@ let disposition_of_typed_runtime_blocker_class blocker_class =
   | Keeper_meta_contract.Sdk_idle_detected
   | Keeper_meta_contract.Sdk_guardrail_violation
   | Keeper_meta_contract.Sdk_tripwire_violation
-  | Keeper_meta_contract.Sdk_exit_condition_met
-  | Keeper_meta_contract.Sdk_tool_failure_recovery_failed ->
-      Keeper_turn_disposition.Unknown { raw_error = "" }
+  | Keeper_meta_contract.Sdk_exit_condition_met ->
+    Keeper_turn_disposition.Unknown { raw_error = "" }
 
 let legacy_provider_runtime_blocker_disposition raw_blocker_class =
   match raw_blocker_class with

--- a/lib/keeper/keeper_status_bridge_blocker.ml
+++ b/lib/keeper/keeper_status_bridge_blocker.ml
@@ -57,13 +57,6 @@ let blocker_class_of_sdk_error (err : Agent_sdk.Error.sdk_error) : blocker_class
      | Agent_sdk.Error.Agent (TripwireViolation _) -> Some Sdk_tripwire_violation
      | Agent_sdk.Error.Agent (ExitConditionMet _) -> Some Sdk_exit_condition_met
      | Agent_sdk.Error.Agent (InputRequired _) -> Some Sdk_input_required
-     | Agent_sdk.Error.Agent (ToolFailureRecoveryFailed _) ->
-       Some Sdk_tool_failure_recovery_failed
-     | Agent_sdk.Error.Agent (ToolFailureRecoveryDeferred _) ->
-       (* Runtime_agent converts this control result to a typed checkpoint
-          before the status bridge. If it is observed here, do not manufacture
-          a blocker class for a non-failure. *)
-       None
      (* Provider-level [Api] errors are surfaced via OAS retry / runtime
          layers and do not map to a typed blocker_class by themselves. *)
      | Agent_sdk.Error.Api _
@@ -148,8 +141,7 @@ let runtime_blocker_surface_of_typed_class ?(summary = "") (cls : blocker_class)
     | Sdk_guardrail_violation
     | Sdk_tripwire_violation
     | Sdk_exit_condition_met
-    | Sdk_input_required
-    | Sdk_tool_failure_recovery_failed -> if summary = "" then str else summary
+    | Sdk_input_required -> if summary = "" then str else summary
   in
   { blocker_class = str; summary }
 ;;

--- a/test/test_blocker_class_exhaustiveness.ml
+++ b/test/test_blocker_class_exhaustiveness.ml
@@ -36,7 +36,6 @@ let all_variants : blocker_class list =
   ; Sdk_tripwire_violation
   ; Sdk_exit_condition_met
   ; Sdk_input_required
-  ; Sdk_tool_failure_recovery_failed
   ]
 ;;
 
@@ -141,14 +140,6 @@ let all_sdk_agent_variants : (string * SdkE.sdk_error) list =
            ; timeout_s = None
            ; created_at = 0.0
            }) )
-  ; ( "ToolFailureRecoveryFailed"
-    , SdkE.Agent
-        (SdkE.ToolFailureRecoveryFailed
-           { stage = SdkE.Judge_response; detail = "judge unavailable" }) )
-  ; ( "ToolFailureRecoveryDeferred"
-    , SdkE.Agent
-        (SdkE.ToolFailureRecoveryDeferred
-           { reason = "wait for repository state"; tool_names = [ "Execute" ] }) )
   ]
 ;;
 
@@ -156,7 +147,6 @@ let agent_variants_with_no_runtime_blocker =
   [ "AgentExecutionTimeout"
   ; "AgentExecutionIdleTimeout"
   ; "MaxTurnsExceeded"
-  ; "ToolFailureRecoveryDeferred"
   ]
 
 let test_all_agent_variants_classified_intentionally () =
@@ -185,7 +175,7 @@ let test_all_agent_variants_classified_intentionally () =
 (** Pin the Agent sub-variant count so additions are visible in diffs.
     When the SDK adds a new [Agent] sub-variant, bump this number and add it
     to [all_sdk_agent_variants]. *)
-let expected_agent_variant_count = 11
+let expected_agent_variant_count = 9
 
 let test_agent_variant_count_pin () =
   let count = List.length all_sdk_agent_variants in

--- a/test/test_keeper_execution_join.ml
+++ b/test/test_keeper_execution_join.ml
@@ -183,110 +183,6 @@ let test_authorization_errors_have_typed_projection () =
        (Llm_provider.Error.AuthorizationError
           { provider = "provider"; detail = "permission refused" }))
 
-let recovery_failed_attempt ~tool_use_id ~input ~error =
-  { Agent_sdk.Tool_failure_episode.tool_use_id = tool_use_id
-  ; tool_name = "Execute"
-  ; input
-  ; failure_kind = Agent_sdk.Types.Validation_error
-  ; error_class = Some Agent_sdk.Types.Deterministic
-  ; error
-  }
-
-let recovery_episode () : Agent_sdk.Tool_failure_episode.t =
-  { previous =
-      [ recovery_failed_attempt
-          ~tool_use_id:"tool-previous"
-          ~input:(`Assoc [ "cmd", `String "secret previous input" ])
-          ~error:"secret previous error"
-      ]
-  ; current =
-      recovery_failed_attempt
-        ~tool_use_id:"tool-current"
-        ~input:(`Assoc [ "cmd", `String "secret current input" ])
-        ~error:"secret current error"
-  }
-
-let test_tool_failure_episode_projection_omits_inputs_and_error_text () =
-  let json =
-    Bridge.native_event_to_json
-      (mk_event
-         (Agent_sdk.Event_bus.ToolFailureEpisodeDetected
-            { agent_name = "oas-r1"; turn = 3; episodes = [ recovery_episode () ] }))
-    |> Option.get
-  in
-  let episode =
-    match payload_member "episodes" json with
-    | Some (`List [ `Assoc episode ]) -> episode
-    | _ -> fail "missing tool-failure episode projection"
-  in
-  check bool "input omitted" true (List.assoc_opt "input" episode = None);
-  check bool "error prose omitted" true (List.assoc_opt "error" episode = None);
-  check bool "previous ids retained" true
-    (List.assoc_opt "previous_tool_use_ids" episode
-     = Some (`List [ `String "tool-previous" ]));
-  check (option int) "previous count retained" (Some 1)
-    (match List.assoc_opt "previous_count" episode with
-     | Some (`Int count) -> Some count
-     | _ -> None);
-  check (option string) "tool identity retained" (Some "Execute")
-    (string_of_field (List.assoc_opt "tool_name" episode))
-
-let recovery_defer_decision () =
-  Eio_main.run
-  @@ fun _env ->
-  Eio.Switch.run
-  @@ fun sw ->
-  let judge =
-    Agent_sdk.Tool_failure_recovery.create
-      ~complete:(fun ~sw:_ _request ->
-        Ok {|{"action":"defer","reason":"secret recovery reason"}|})
-  in
-  match
-    Agent_sdk.Tool_failure_recovery.decide
-      ~sw
-      ~agent_name:"oas-r1"
-      ~turn:3
-      ~episodes:[ recovery_episode () ]
-      judge
-  with
-  | Ok decision -> decision
-  | Error error ->
-    failf
-      "failed to construct validated recovery decision: %s"
-      (Agent_sdk.Tool_failure_recovery.judge_error_to_string error)
-
-let test_recovery_decision_projection_omits_model_payload () =
-  let json =
-    Bridge.native_event_to_json
-      (mk_event
-         (Agent_sdk.Event_bus.ToolFailureRecoveryDecided
-            { agent_name = "oas-r1"; turn = 3; decision = recovery_defer_decision () }))
-    |> Option.get
-  in
-  check (option string) "typed action retained" (Some "defer")
-    (string_of_field (payload_member "action" json));
-  check bool "legacy decision digest omitted" true
-    (payload_member "decision_digest" json = None);
-  check bool "model reason omitted" true (payload_member "reason" json = None)
-
-let test_recovery_judge_failure_projection_omits_detail () =
-  let json =
-    Bridge.native_event_to_json
-      (mk_event
-         (Agent_sdk.Event_bus.ToolFailureRecoveryJudgeFailed
-            { agent_name = "oas-r1"
-            ; turn = 3
-            ; kind = Agent_sdk.Tool_failure_recovery.Provider_call_failed
-            ; detail = "secret provider body"
-            }))
-    |> Option.get
-  in
-  check (option string) "typed failure kind retained" (Some "provider_call_failed")
-    (string_of_field (payload_member "kind" json));
-  check bool "detail digest retained" true
-    (Option.is_some (string_of_field (payload_member "detail_digest" json)));
-  check bool "raw detail omitted" true (payload_member "detail" json = None)
-
 let () =
   run "keeper_execution_join"
     [ ( "join_table"
@@ -308,11 +204,5 @@ let () =
             test_agent_failed_matches_typed_sse_event
         ; test_case "authorization errors have typed projection" `Quick
             test_authorization_errors_have_typed_projection
-        ; test_case "tool failure episode omits input and error prose" `Quick
-            test_tool_failure_episode_projection_omits_inputs_and_error_text
-        ; test_case "recovery decision omits model payload" `Quick
-            test_recovery_decision_projection_omits_model_payload
-        ; test_case "recovery judge failure omits raw detail" `Quick
-            test_recovery_judge_failure_projection_omits_detail
         ] )
     ]


### PR DESCRIPTION
## Summary
- remove retired ToolFailure episode/recovery Event_bus projections
- remove impossible OAS recovery error, blocker, terminal, and trust classifications
- delete tests whose only subject was the removed recovery event family

Ordinary ToolCompleted/typed Tool_failed observation remains. No replacement recovery hierarchy is introduced.

## Validation
- ocamlformat --check on all changed OCaml files
- ocamlc -stop-after parsing on all changed OCaml files
- git diff --check
- focused build remains blocked earlier by the independent approval_callback residue after #24438

## Scope
6 additions, 259 deletions.