### PR TITLE
refactor(runtime): remove OAS approval callback carrier

### DIFF
--- a/docs/design/keeper-tool-boundary-matrix.md
+++ b/docs/design/keeper-tool-boundary-matrix.md
@@ -183,7 +183,5 @@ Each path below must appear exactly once and use one owner from the table above.
 - `lib/keeper/keeper_tools_oas_handler_telemetry.mli` - oas-tool-bridge
 - `lib/keeper/keeper_tools_oas_handler.ml` - oas-tool-bridge
 - `lib/keeper/keeper_tools_oas_handler.mli` - oas-tool-bridge
-- `lib/keeper/keeper_tool_failure_recovery_judge.ml` - oas-tool-bridge
-- `lib/keeper/keeper_tool_failure_recovery_judge.mli` - oas-tool-bridge
 - `lib/keeper/keeper_tools_oas.ml` - oas-tool-bridge
 - `lib/keeper/keeper_tools_oas.mli` - oas-tool-bridge

--- a/lib/agent_sdk_log_bridge.ml
+++ b/lib/agent_sdk_log_bridge.ml
@@ -186,8 +186,6 @@ let should_promote_warn_to_error (record : Agent_sdk.Log.record) =
   match record.level, record.module_name, record.message with
   | Warn, "agent_config", "MCP server failed" -> true
   | Warn, "agent_turn", "context_injector raised" -> true
-  | Warn, "agent_tools", "ApprovalRequired but no approval callback — executing" ->
-      true
   | _ -> false
 
 let should_demote_info_to_debug (record : Agent_sdk.Log.record) =

--- a/lib/approval_callbacks.ml
+++ b/lib/approval_callbacks.ml
@@ -1,9 +1,0 @@
-(** OAS approval callbacks shared across system-agent call sites. *)
-
-(* #7883 *)
-
-(** OAS callback used when authorization belongs to the MASC executor. It
-    prevents a second, tool-name-aware approval layer inside the SDK; concrete
-    external effects must still pass their normalized MASC Gate boundary. *)
-let auto_approve : Agent_sdk.Hooks.approval_callback =
-  Agent_sdk.Approval.(create [ always_approve ] |> as_callback)

--- a/lib/approval_callbacks.mli
+++ b/lib/approval_callbacks.mli
@@ -1,6 +1,0 @@
-(** OAS approval callbacks shared across system-agent call sites. *)
-
-val auto_approve : Agent_sdk.Hooks.approval_callback
-(** OAS callback for agents whose concrete effect executor owns the MASC Gate.
-    It avoids a second hidden SDK approval hierarchy; it does not authorize an
-    external effect by itself. *)

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -259,7 +259,6 @@ let compute_judgments
       Keeper_turn_driver_wrappers.run_named_with_masc_tools ~runtime_id
         ~base_path ~goal:prompt ~masc_tools ~dispatch
         ~accept:Keeper_tool_response.response_has_text_or_tool_progress
-        ~approval:Approval_callbacks.auto_approve
         ~provider_config_transform:apply_operator_judge_output_schema
         ()
     )

--- a/lib/keeper/keeper_adversarial_review.ml
+++ b/lib/keeper/keeper_adversarial_review.ml
@@ -92,7 +92,6 @@ let run_grounded_review ~base_path ~runtime_id (input : review_input) :
         ~goal:prompt
         ~masc_tools:[ Verifier_core.report_verdict_schema ]
         ~dispatch
-        ~approval:Approval_callbacks.auto_approve
         ~provider_config_transform:apply_report_verdict_output_schema
         ()
     with

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -289,7 +289,6 @@ let run_named
     ?context_injector
     ?context
     ?enable_thinking
-    ?approval
     ?exit_condition
     ?exit_condition_result
     ?oas_checkpoint
@@ -580,7 +579,6 @@ let run_named
             ; context
             ; enable_thinking = inference_policy.attempt_enable_thinking
             ; preserve_thinking = inference_policy.attempt_preserve_thinking
-            ; approval
             ; exit_condition
             ; exit_condition_result
             ; oas_checkpoint

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -96,7 +96,6 @@ val run_named :
   ?context_injector:Agent_sdk.Hooks.context_injector ->
   ?context:Agent_sdk.Context.t ->
   ?enable_thinking:bool ->
-  ?approval:Agent_sdk.Hooks.approval_callback ->
   ?exit_condition:(int -> bool) ->
   ?exit_condition_result:(int -> Runtime_agent.stop_reason * string option) ->
   ?oas_checkpoint:Agent_sdk.Checkpoint.t ->

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -52,7 +52,6 @@ type try_provider_ctx =
   ; context : Agent_sdk.Context.t option
   ; enable_thinking : bool option
   ; preserve_thinking : bool option
-  ; approval : Agent_sdk.Hooks.approval_callback option
   ; exit_condition : (int -> bool) option
   ; exit_condition_result : (int -> Runtime_agent.stop_reason * string option) option
   ; oas_checkpoint : Agent_sdk.Checkpoint.t option
@@ -254,7 +253,6 @@ let run_try_provider
                | None -> ctx.enable_thinking)
           ; preserve_thinking = ctx.preserve_thinking
           ; event_bus = ctx.event_bus
-          ; approval = ctx.approval
           ; exit_condition = ctx.exit_condition
           ; exit_condition_result = ctx.exit_condition_result
           ; initial_messages = ctx.initial_messages

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -33,7 +33,6 @@ type try_provider_ctx =
   ; context : Agent_sdk.Context.t option
   ; enable_thinking : bool option
   ; preserve_thinking : bool option
-  ; approval : Agent_sdk.Hooks.approval_callback option
   ; exit_condition : (int -> bool) option
   ; exit_condition_result : (int -> Runtime_agent.stop_reason * string option) option
   ; oas_checkpoint : Agent_sdk.Checkpoint.t option

--- a/lib/keeper/keeper_turn_driver_wrappers.ml
+++ b/lib/keeper/keeper_turn_driver_wrappers.ml
@@ -29,7 +29,6 @@ let config_for_label
     ?hooks
     ?enable_thinking
     ?provider_config_transform
-    ?approval
     ~(description : string option)
     () : (Runtime_agent.config, Agent_sdk.Error.sdk_error) result =
   let* provider =
@@ -60,7 +59,6 @@ let config_for_label
       hooks;
       enable_thinking;
       description;
-      approval;
     }
 
 (* RFC-0206: the runtime CLI-preflight wrapper is gone; run the attempt
@@ -169,7 +167,6 @@ let run_named_with_masc_tools
     ?on_resume
     ?transport
     ?(yield_on_tool = false)
-    ?approval
     ?(max_idle_turns = 3)
     ?provider_config_transform
     ?sw
@@ -187,7 +184,6 @@ let run_named_with_masc_tools
     ?temperature
     ?stream_idle_timeout_s ?hooks
     ~accept
-    ?approval
     ?raw_trace ?on_event ?on_yield ?on_resume 
     ?transport ~yield_on_tool ?provider_config_transform ?sw ?net ()
 

--- a/lib/keeper/keeper_turn_driver_wrappers.mli
+++ b/lib/keeper/keeper_turn_driver_wrappers.mli
@@ -53,7 +53,6 @@ val run_named_with_masc_tools :
   ?on_resume:(unit -> unit) ->
   ?transport:Masc_grpc_transport.t ->
   ?yield_on_tool:bool ->
-  ?approval:Agent_sdk.Hooks.approval_callback ->
   ?max_idle_turns:int ->
   ?provider_config_transform:
     (Llm_provider.Provider_config.t ->

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -119,7 +119,6 @@ type config =
   yield_on_tool : bool;
   context_injector : Agent_sdk.Hooks.context_injector option;
   context : Agent_sdk.Context.t option;
-  approval : Agent_sdk.Hooks.approval_callback option;
   exit_condition : (int -> bool) option;
   exit_condition_result : (int -> stop_reason * string option) option;
   thinking_budget : int option;
@@ -905,14 +904,7 @@ let build
      with
      | Error _ as e -> e
      | Ok transport ->
-      let builder =
-        Runtime_agent_context.builder_without_approval ~net ~config ?transport ()
-      in
-      let builder =
-        match config.approval with
-        | Some cb -> Agent_sdk.Builder.with_approval cb builder
-        | None -> builder
-      in
+      let builder = Runtime_agent_context.builder ~net ~config ?transport () in
       Agent_sdk.Builder.build_safe builder)
 
 let run_duration_ms_since started_at =

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -97,7 +97,6 @@ type config = Runtime_agent_context.config = {
   yield_on_tool : bool;
   context_injector : Agent_sdk.Hooks.context_injector option;
   context : Agent_sdk.Context.t option;
-  approval : Agent_sdk.Hooks.approval_callback option;
   exit_condition : (int -> bool) option;
   exit_condition_result : (int -> stop_reason * string option) option;
   thinking_budget : int option;
@@ -387,8 +386,7 @@ val build :
   config:config ->
   (Agent_sdk.Agent.t, Agent_sdk.Error.sdk_error) result
 (** Builds an [Agent_sdk.Agent.t] from a {!config} ready for a
-    fresh run over the HTTP provider transport; threads
-    [config.approval] into the OAS builder when present. *)
+    fresh run over the HTTP provider transport. *)
 
 val resume_from_checkpoint :
   sw:Eio.Switch.t ->

--- a/lib/runtime/runtime_agent_context.ml
+++ b/lib/runtime/runtime_agent_context.ml
@@ -2,8 +2,8 @@
 
     This module owns the shared [config] surface plus the pure/defaulted
     preparation logic used by both [build] and [resume_from_checkpoint].
-    [Runtime_agent] remains the public facade and still performs the
-    approval wiring and final [build_safe] / [Agent.resume] calls. *)
+    [Runtime_agent] remains the public facade for [build_safe] and
+    [Agent.resume] calls. *)
 
 (* [0] is the pinned SDK's documented unbounded sentinel (agent_sdk
    lib/base/types.mli: "[0] = no turn-count limit; positive values enforce
@@ -116,7 +116,6 @@ type config =
   ; yield_on_tool : bool
   ; context_injector : Agent_sdk.Hooks.context_injector option
   ; context : Agent_sdk.Context.t option
-  ; approval : Agent_sdk.Hooks.approval_callback option
   ; exit_condition : (int -> bool) option
   ; exit_condition_result : (int -> stop_reason * string option) option
   ; thinking_budget : int option
@@ -179,7 +178,6 @@ let default_config
   ; yield_on_tool = false
   ; context_injector = None
   ; context = None
-  ; approval = None
   ; exit_condition = None
   ; exit_condition_result = None
   ; thinking_budget = None
@@ -194,7 +192,7 @@ let default_config
 let oas_tracer_ref = Atomic.make Agent_sdk.Tracing.null
 let set_oas_tracer tracer = Atomic.set oas_tracer_ref tracer
 
-let builder_without_approval
+let builder
       ~(net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t)
       ~(config : config)
       ?transport
@@ -209,8 +207,6 @@ let builder_without_approval
     |> Agent_sdk.Builder.with_max_turns config.max_turns
     |> Agent_sdk.Builder.with_max_idle_turns config.max_idle_turns
     |> Agent_sdk.Builder.with_tools config.tools
-    |> Agent_sdk.Builder.with_missing_approval_callback_policy
-         Agent_sdk.Hooks.Reject_without_callback
   in
   let builder =
     match config.temperature with
@@ -404,9 +400,6 @@ let prepare_resume ~(config : config) ~(checkpoint : Agent_sdk.Checkpoint.t)
     ; raw_trace = config.raw_trace
     ; allowed_paths = config.allowed_paths
     ; description = config.description
-    ; approval = config.approval
-    ; missing_approval_callback_policy =
-        Agent_sdk.Hooks.Reject_without_callback
     ; on_run_complete = config.on_run_complete
     }
   in

--- a/lib/runtime/runtime_agent_context.mli
+++ b/lib/runtime/runtime_agent_context.mli
@@ -90,7 +90,6 @@ type config = {
   yield_on_tool : bool;
   context_injector : Agent_sdk.Hooks.context_injector option;
   context : Agent_sdk.Context.t option;
-  approval : Agent_sdk.Hooks.approval_callback option;
   exit_condition : (int -> bool) option;
   exit_condition_result : (int -> stop_reason * string option) option;
   thinking_budget : int option;
@@ -134,21 +133,18 @@ val default_config :
     returns a {!config} populated with sensible defaults for every
     field except the four required ones.  Caller mutates fields
     in place via record copy ([{ cfg with ... }]) before passing
-    to {!builder_without_approval} or {!prepare_resume}. *)
+    to {!builder} or {!prepare_resume}. *)
 
-(** {1 Builder (no approval)} *)
+(** {1 Builder} *)
 
-val builder_without_approval :
+val builder :
   net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
   config:config ->
   ?transport:Llm_provider.Llm_transport.t ->
   unit ->
   Agent_sdk.Builder.t
-(** [builder_without_approval ~net ~config ?transport ()] builds an
-    {!Agent_sdk.Builder.t} from [config] without wiring approval
-    callbacks.  Approval wiring is the responsibility of the
-    public facade ({!Runtime_agent}) which adds the approval
-    callback before calling [Builder.build_safe]. *)
+(** [builder ~net ~config ?transport ()] builds an {!Agent_sdk.Builder.t}
+    from [config]. *)
 
 (** {1 Resume preparation} *)
 
@@ -164,7 +160,7 @@ type prepared_resume = {
     re-counting consumed turns. *)
 
 val set_oas_tracer : Agent_sdk.Tracing.t -> unit
-(** Set the OAS tracer used by {!builder_without_approval}.  Called once
+(** Set the OAS tracer used by {!builder}.  Called once
     at server bootstrap so OAS spans flow to the same OTLP collector as
     MASC-native telemetry.  Defaults to [Tracing.null] until set. *)
 

--- a/lib/verifier_oas.ml
+++ b/lib/verifier_oas.ml
@@ -125,7 +125,6 @@ let verify (req : Core.verification_request) : (Core.verdict, string) result =
       ~goal:prompt
       ~masc_tools:[ Core.report_verdict_schema ]
       ~dispatch
-      ~approval:Approval_callbacks.auto_approve
       ~provider_config_transform:apply_report_verdict_output_schema
       ()
   with

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -100,8 +100,6 @@ let build_agent
       ~(heartbeat_callbacks : Agent_sdk.Agent.periodic_callback list)
       ?context_injector
       ?context
-      ?(approval : Agent_sdk.Hooks.approval_callback =
-        Approval_callbacks.auto_approve)
       ()
   : (Agent_sdk.Agent.t, string) result
   =
@@ -118,8 +116,6 @@ let build_agent
     |> Agent_sdk.Builder.with_raw_trace raw_trace
     |> Agent_sdk.Builder.with_periodic_callbacks heartbeat_callbacks
     |> Agent_sdk.Builder.with_description (description_of_meta meta)
-    (* #7883 *)
-    |> Agent_sdk.Builder.with_approval approval
   in
   let builder =
     match context_injector with
@@ -401,8 +397,6 @@ and resume_worker_via_oas
       ~(tools : Agent_sdk.Tool.t list)
       ~(raw_trace : Agent_sdk.Raw_trace.t)
       ?worker_run_id
-      ?(approval : Agent_sdk.Hooks.approval_callback =
-        Approval_callbacks.auto_approve)
       ()
   : (Worker_container_types.run_result, string) result
   =
@@ -448,8 +442,6 @@ and resume_worker_via_oas
   let options =
     { options with
       Agent_sdk.Agent_types.context_injector = Some context_injector
-    ; (* #7883 *)
-      approval = Some approval
     }
   in
   let agent =

--- a/lib/worker_oas.mli
+++ b/lib/worker_oas.mli
@@ -18,7 +18,6 @@ val build_agent :
   heartbeat_callbacks:Agent_sdk.Agent.periodic_callback list ->
   ?context_injector:Agent_sdk.Hooks.context_injector ->
   ?context:Agent_sdk.Context.t ->
-  ?approval:Agent_sdk.Hooks.approval_callback ->
   unit ->
   (Agent_sdk.Agent.t, string) result
 (** [build_agent] constructs an OAS agent for the given worker meta. *)
@@ -58,7 +57,6 @@ val resume_worker_via_oas :
   tools:Agent_sdk.Tool.t list ->
   raw_trace:Agent_sdk.Raw_trace.t ->
   ?worker_run_id:string ->
-  ?approval:Agent_sdk.Hooks.approval_callback ->
   unit ->
   (Worker_container_types.run_result, string) result
 

--- a/lib/workspace_metric_hooks.ml
+++ b/lib/workspace_metric_hooks.ml
@@ -467,8 +467,6 @@ let install () =
 	             ~goal:prompt
              ~masc_tools:[ report_tool_schema ]
              ~dispatch
-             
-             ~approval:Approval_callbacks.auto_approve
              ~provider_config_transform:apply_review_verdict_output_schema
              ?sw
              ())

--- a/test/test_keeper_hooks_oas_introspection.ml
+++ b/test/test_keeper_hooks_oas_introspection.ml
@@ -155,7 +155,6 @@ let test_pre_tool_use_is_observation_only () =
   | Agent_sdk.Hooks.Continue -> ()
   | Skip -> fail "pre_tool_use timing hook returned Skip"
   | Override _ -> fail "pre_tool_use timing hook returned Override"
-  | ApprovalRequired -> fail "pre_tool_use timing hook requested approval"
   | AdjustParams _ -> fail "pre_tool_use timing hook adjusted parameters"
   | ElicitInput _ -> fail "pre_tool_use timing hook elicited input"
   | Nudge _ -> fail "pre_tool_use timing hook returned Nudge"

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -1379,8 +1379,6 @@ let execute_tools_in_env env ~tools tool_uses =
     ~agent_name:state.Agent_sdk.Types.config.Agent_sdk.Types.name
     ~turn_count:state.Agent_sdk.Types.turn_count
     ~usage:state.Agent_sdk.Types.usage
-    ~approval:opts.Agent_sdk.Agent.approval
-    ~missing_approval_callback_policy:opts.Agent_sdk.Agent.missing_approval_callback_policy
     tool_uses
 ;;
 

--- a/test/test_masc_log.ml
+++ b/test/test_masc_log.ml
@@ -172,19 +172,6 @@ let test_oas_bridge_promotes_context_injector_failures_to_error () =
   Alcotest.(check string) "context injector failure promoted" "ERROR"
     (Log.level_to_string level)
 
-let test_oas_bridge_promotes_missing_approval_callback_to_error () =
-  let level =
-    Masc.Agent_sdk_log_bridge.effective_level
-      (oas_record
-         ~level:Agent_sdk.Log.Warn
-         ~module_name:"agent_tools"
-         ~message:"ApprovalRequired but no approval callback — executing"
-         [ Agent_sdk.Log.S ("tool", "tool_execute");
-           Agent_sdk.Log.S ("agent", "demo") ])
-  in
-  Alcotest.(check string) "approval callback gap promoted" "ERROR"
-    (Log.level_to_string level)
-
 let test_oas_bridge_demotes_tool_choice_relaxation_to_debug () =
   let level =
     Masc.Agent_sdk_log_bridge.effective_level
@@ -278,9 +265,6 @@ let () =
         Alcotest.test_case
           "oas bridge promotes context injector failures"
           `Quick test_oas_bridge_promotes_context_injector_failures_to_error;
-        Alcotest.test_case
-          "oas bridge promotes missing approval callback"
-          `Quick test_oas_bridge_promotes_missing_approval_callback_to_error;
         Alcotest.test_case
           "oas bridge demotes normal tool_choice relaxation"
           `Quick test_oas_bridge_demotes_tool_choice_relaxation_to_debug;

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -1175,7 +1175,7 @@ let test_runtime_agent_context_uses_configured_turn_limit () =
   Eio_main.run (fun env ->
     Eio.Switch.run (fun sw ->
       let builder =
-        Runtime_agent_context.builder_without_approval
+        Runtime_agent_context.builder
           ~net:(Eio.Stdenv.net env)
           ~config
           ()
@@ -1231,7 +1231,7 @@ let test_runtime_agent_context_preserves_max_tokens_intent () =
         in
         let config = { config with max_tokens } in
         let builder =
-          Runtime_agent_context.builder_without_approval
+          Runtime_agent_context.builder
             ~net:(Eio.Stdenv.net env)
             ~config
             ()
@@ -1297,7 +1297,7 @@ let test_runtime_agent_context_preserves_provider_sampling_config () =
   Eio_main.run (fun env ->
     Eio.Switch.run (fun sw ->
       let builder =
-        Runtime_agent_context.builder_without_approval
+        Runtime_agent_context.builder
           ~net:(Eio.Stdenv.net env)
           ~config
           ()
@@ -1469,7 +1469,7 @@ let test_runtime_agent_context_leaves_tool_choice_unset_with_tools () =
   Eio_main.run (fun env ->
     Eio.Switch.run (fun sw ->
       let builder =
-        Runtime_agent_context.builder_without_approval
+        Runtime_agent_context.builder
           ~net:(Eio.Stdenv.net env)
           ~config
           ()

--- a/test/test_warn_root_causes.ml
+++ b/test/test_warn_root_causes.ml
@@ -350,10 +350,7 @@ let test_oas_mainline_warns_are_promoted_in_bridge () =
        {|Warn, "agent_config", "MCP server failed" -> true|});
   check bool "bridge promotes context injector failure" true
     (file_contains_pattern "lib/agent_sdk_log_bridge.ml"
-       {|Warn, "agent_turn", "context_injector raised" -> true|});
-  check bool "bridge promotes approval callback gap" true
-    (file_contains_pattern "lib/agent_sdk_log_bridge.ml"
-       {|Warn, "agent_tools", "ApprovalRequired but no approval callback — executing"|})
+       {|Warn, "agent_turn", "context_injector raised" -> true|})
 
 let test_correction_pipeline_log_preserves_detail_fields () =
   List.iter


### PR DESCRIPTION
## Summary
- remove the retired OAS approval_callback plumbing from Keeper, Runtime, and Worker paths
- delete the auto-approve adapter and stale missing-callback behavior/tests
- keep MASC Keeper Gate, Always Allowed, Auto Judge, and nonblocking HITL unchanged

This is a hard deletion of the old OAS governance bypass, not a renamed replacement.

## Validation
- retired approval callback symbols: 0 active lib/test matches
- ocamlformat --check
- ocamlc -stop-after parsing
- git diff --check
- focused runtime build advances to with_max_idle_turns and MaxTurnsExceeded residues

## Scope
16 additions, 102 deletions.