### PR TITLE
refactor(runtime): remove tool recovery result tail

### DIFF
--- a/lib/keeper/keeper_agent_run_contract_helpers.ml
+++ b/lib/keeper/keeper_agent_run_contract_helpers.ml
@@ -27,7 +27,6 @@ let observed_completion_evidence
   =
   match stop_reason with
   | Runtime_agent.InputRequired _
-  | Runtime_agent.ToolFailureRecoveryDeferred _
   | Runtime_agent.Yielded_to_chat_waiting _
   | Runtime_agent.Yielded_to_durable_stimulus _ ->
     Keeper_execution_receipt.Completion_observation_unknown

--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -136,12 +136,10 @@ let checkpoint_for_replay_persistence
       (checkpoint : Agent_sdk.Checkpoint.t)
   =
   match stop_reason with
-  | Runtime_agent.InputRequired _
-  | Runtime_agent.ToolFailureRecoveryDeferred _ ->
-    (* OAS attached the durable recovery receipt to the current ToolResult.
-       Blank-response canonicalization and completion-contract pruning both
-       remove that suffix, so this typed control checkpoint must preserve it
-       verbatim. Prefix validation still fails closed before persistence. *)
+  | Runtime_agent.InputRequired _ ->
+    (* The elicitation request can follow a current-turn tool result. Blank
+       response canonicalization and completion-contract pruning must not
+       remove that suffix; prefix validation still fails closed. *)
     (match
        Keeper_replay_prefix.split
          ~prefix:history_messages
@@ -155,11 +153,11 @@ let checkpoint_for_replay_persistence
          , None )
      | Ok [] ->
        Error
-         "refusing to save recovery-control checkpoint without a current-turn \
+         "refusing to save input-required checkpoint without a current-turn \
           replay suffix"
      | Error _ ->
        Error
-         "refusing to save recovery-control checkpoint: messages do not match \
+         "refusing to save input-required checkpoint: messages do not match \
           pre-turn history prefix")
   | Runtime_agent.TurnLimitObserved _
   | Runtime_agent.ExecutionTimeoutObserved _

--- a/lib/keeper/keeper_agent_run_response_text.ml
+++ b/lib/keeper/keeper_agent_run_response_text.ml
@@ -5,7 +5,6 @@ type finalized = {
 }
 
 let stop_reason_suppresses_visible_response = function
-  | Runtime_agent.ToolFailureRecoveryDeferred _
   | Runtime_agent.ExecutionTimeoutObserved _
   | Runtime_agent.ExecutionIdleTimeoutObserved _ -> true
   | Runtime_agent.Completed

--- a/lib/keeper/keeper_execution_receipt_types.ml
+++ b/lib/keeper/keeper_execution_receipt_types.ml
@@ -223,8 +223,6 @@ let stop_reason_to_string = function
     Printf.sprintf "yielded_to_durable_stimulus:%d" turns_used
   | Runtime_agent.InputRequired _ ->
     Keeper_turn_disposition.to_wire Keeper_turn_disposition.Input_required
-  | Runtime_agent.ToolFailureRecoveryDeferred _ ->
-    "tool_failure_recovery_deferred"
 ;;
 
 (* This projects the runtime-stop axis into the receipt's terminal_reason_code
@@ -236,8 +234,7 @@ let receipt_terminal_reason_code_of_stop_reason = function
   | Runtime_agent.Completed
   | Runtime_agent.TurnLimitObserved _
   | Runtime_agent.ExecutionTimeoutObserved _
-  | Runtime_agent.ExecutionIdleTimeoutObserved _
-  | Runtime_agent.ToolFailureRecoveryDeferred _ ->
+  | Runtime_agent.ExecutionIdleTimeoutObserved _ ->
     Keeper_turn_disposition.to_wire Keeper_turn_disposition.Success
   | ( Runtime_agent.Yielded_to_chat_waiting _
     | Runtime_agent.Yielded_to_durable_stimulus _ ) as stop_reason ->

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -155,7 +155,6 @@ let apply_accept
   =
   match run_result.stop_reason with
   | Runtime_agent.InputRequired _
-  | Runtime_agent.ToolFailureRecoveryDeferred _
   | Runtime_agent.TurnLimitObserved _
   | Runtime_agent.ExecutionTimeoutObserved _
   | Runtime_agent.ExecutionIdleTimeoutObserved _ ->

--- a/lib/keeper/keeper_turn_outcome.ml
+++ b/lib/keeper/keeper_turn_outcome.ml
@@ -34,8 +34,7 @@ let of_stop_reason = function
   | Runtime_agent.Completed
   | Runtime_agent.TurnLimitObserved _ -> Visible_reply
   | Runtime_agent.Yielded_to_chat_waiting _
-  | Runtime_agent.Yielded_to_durable_stimulus _
-  | Runtime_agent.ToolFailureRecoveryDeferred _ -> Continuation_checkpoint
+  | Runtime_agent.Yielded_to_durable_stimulus _ -> Continuation_checkpoint
   | Runtime_agent.ExecutionTimeoutObserved _
   | Runtime_agent.ExecutionIdleTimeoutObserved _ -> No_visible_reply
   | Runtime_agent.InputRequired _ -> Visible_reply
@@ -45,8 +44,7 @@ let of_result_surface ~response_text = function
   | Runtime_agent.TurnLimitObserved _ ->
       if String.trim response_text = "" then No_visible_reply else Visible_reply
   | Runtime_agent.Yielded_to_chat_waiting _
-  | Runtime_agent.Yielded_to_durable_stimulus _
-  | Runtime_agent.ToolFailureRecoveryDeferred _ -> Continuation_checkpoint
+  | Runtime_agent.Yielded_to_durable_stimulus _ -> Continuation_checkpoint
   | Runtime_agent.ExecutionTimeoutObserved _
   | Runtime_agent.ExecutionIdleTimeoutObserved _ -> No_visible_reply
   | Runtime_agent.InputRequired _ -> Visible_reply

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -76,8 +76,7 @@ let terminal_outcome_of_result result =
     Terminal_done
   | Runtime_agent.InputRequired _ -> Terminal_input_required
   | Runtime_agent.Yielded_to_chat_waiting _
-  | Runtime_agent.Yielded_to_durable_stimulus _
-  | Runtime_agent.ToolFailureRecoveryDeferred _ ->
+  | Runtime_agent.Yielded_to_durable_stimulus _ ->
     Terminal_checkpoint
 ;;
 
@@ -284,8 +283,6 @@ let emit_usage_metrics_and_log
       Printf.sprintf "yielded_to_durable_stimulus(%d)" turns_used
     | Runtime_agent.InputRequired { turns_used; _ } ->
       Printf.sprintf "input_required(%d)" turns_used
-    | Runtime_agent.ToolFailureRecoveryDeferred { turns_used; _ } ->
-      Printf.sprintf "tool_failure_recovery_deferred(%d)" turns_used
   in
   let outcome_label =
     match terminal_outcome with
@@ -297,8 +294,6 @@ let emit_usage_metrics_and_log
        | Runtime_agent.Yielded_to_durable_stimulus _ ->
          "yielded_to_durable_stimulus"
        | Runtime_agent.InputRequired _ -> "input_required"
-       | Runtime_agent.ToolFailureRecoveryDeferred _ ->
-         "tool_failure_recovery_deferred"
        | Runtime_agent.Completed
        | Runtime_agent.TurnLimitObserved _
        | Runtime_agent.ExecutionTimeoutObserved _
@@ -422,7 +417,6 @@ let terminal_reason_of_outcome result = function
        Keeper_turn_terminal.of_disposition
          ~source:"runtime_stop_reason"
          Keeper_turn_disposition.Input_required
-     | Runtime_agent.ToolFailureRecoveryDeferred _
      | Runtime_agent.Completed
      | Runtime_agent.TurnLimitObserved _
      | Runtime_agent.ExecutionTimeoutObserved _
@@ -519,15 +513,6 @@ let reset_turn_failures_for_stop_reason ~config ~updated_meta result =
       "yielded autonomous run for a pending durable stimulus after %d turn(s), \
        checkpoint saved — will resume next cycle"
       turns_used;
-    reset_failure_state ()
-  | Runtime_agent.ToolFailureRecoveryDeferred
-      { turns_used; reason; tool_names } ->
-    Log.Keeper.info ~keeper_name:updated_meta.name
-      "typed tool-failure recovery deferred after %d turn(s), checkpoint saved \
-       tools=%s reason_digest=%s"
-      turns_used
-      (String.concat "," tool_names)
-      Digestif.SHA256.(digest_string reason |> to_hex);
     reset_failure_state ()
   | Runtime_agent.InputRequired { turns_used; request } ->
     Log.Keeper.info ~keeper_name:updated_meta.name

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -81,11 +81,6 @@ type stop_reason =
       turns_used : int;
       request : Agent_sdk.Error.input_required;
     }
-  | ToolFailureRecoveryDeferred of {
-      turns_used : int;
-      reason : string;
-      tool_names : string list;
-    }
 
 type config =
   Runtime_agent_context.config = {
@@ -153,9 +148,6 @@ let worker_lifecycle_classification_of_result = function
   | Ok _ -> { event = "completed"; status = "completed"; error = None }
   | Error (Agent_sdk.Error.Agent (Agent_sdk.Error.MaxTurnsExceeded _)) ->
     { event = "completed"; status = "turn_limit_observed"; error = None }
-  | Error
-      (Agent_sdk.Error.Agent (Agent_sdk.Error.ToolFailureRecoveryDeferred _)) ->
-    { event = "completed"; status = "tool_failure_recovery_deferred"; error = None }
   | Error (Agent_sdk.Error.Agent (Agent_sdk.Error.InputRequired _)) ->
     { event = "completed"; status = "input_required"; error = None }
   | Error (Agent_sdk.Error.Agent (Agent_sdk.Error.AgentExecutionTimeout _)) ->
@@ -929,8 +921,6 @@ let dashboard_status_of_stop_reason = function
       Dashboard_oas_bridge.Cancelled { reason = "yielded_to_durable_stimulus" }
   | InputRequired _ ->
       Dashboard_oas_bridge.Cancelled { reason = "input_required" }
-  | ToolFailureRecoveryDeferred _ ->
-      Dashboard_oas_bridge.Cancelled { reason = "tool_failure_recovery_deferred" }
 
 let record_dashboard_oas_response ~config ~total_duration_ms ?serialization_ms
     ~status (response : Agent_sdk.Types.api_response) =
@@ -1302,41 +1292,6 @@ let run_blocks
       | None ->
         close_agent_for_cleanup ~propagate_cancel:false ~config agent;
         Error (Agent_sdk.Error.Agent (Agent_sdk.Error.ExitConditionMet r)))
-    | Error
-        (Agent_sdk.Error.Agent
-           (Agent_sdk.Error.ToolFailureRecoveryDeferred
-              { reason; tool_names })) ->
-      close_after_success ();
-      let stop_reason =
-        ToolFailureRecoveryDeferred { turns_used = turns; reason; tool_names }
-      in
-      let partial_response = partial_response_of_stop ~session_id ~text:"" in
-      record_dashboard_oas_response
-        ~config
-        ~total_duration_ms:run_total_duration_ms
-        ~status:(dashboard_status_of_stop_reason stop_reason)
-        partial_response;
-      Log.Misc.info
-        "oas_worker %s: typed tool-failure recovery deferred tools=%s \
-         reason_digest=%s"
-        config.name
-        (String.concat "," tool_names)
-        (Auth.sha256_hash reason);
-      let runtime_observation =
-        runtime_observation_for_completed_config
-          ~total_duration_ms:run_total_duration_ms
-          config
-      in
-      Ok
-        { response = partial_response
-        ; checkpoint
-        ; session_id
-        ; turns
-        ; trace_ref
-        ; run_validation
-        ; runtime_observation = Some runtime_observation
-        ; stop_reason
-        }
     | Error
         (Agent_sdk.Error.Agent
            (Agent_sdk.Error.AgentExecutionTimeout r)) ->

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -40,11 +40,6 @@ type stop_reason = Runtime_agent_context.stop_reason =
       turns_used : int;
       request : Agent_sdk.Error.input_required;
     }
-  | ToolFailureRecoveryDeferred of {
-      turns_used : int;
-      reason : string;
-      tool_names : string list;
-    }
 (** Why this single OAS call yielded control. [Completed] is the
     model's success path. [TurnLimitObserved], [ExecutionTimeoutObserved],
     and [ExecutionIdleTimeoutObserved] preserve unexpected typed OAS
@@ -56,13 +51,10 @@ type stop_reason = Runtime_agent_context.stop_reason =
     [Yielded_to_durable_stimulus] fires after at least one provider turn when
     another durable event is waiting behind the event currently leased by the
     cycle. [InputRequired] means OAS returned a typed elicitation request whose
-    question and checkpoint must be surfaced without provider fallback.
-    [ToolFailureRecoveryDeferred] means the typed OAS recovery judge
-    returned control to the host without another main-provider call; its
-    [reason] is observation-only and must never drive scheduling. These typed
-    non-completion stops persist checkpoints rather than claiming a completed
-    deliverable: [InputRequired] resumes from later host input, while the yield
-    and defer variants resume through later host-owned activity boundaries. *)
+    question and checkpoint must be surfaced without provider fallback. These
+    typed non-completion stops persist checkpoints rather than claiming a
+    completed deliverable: [InputRequired] resumes from later host input, while
+    yield variants resume through later host-owned activity boundaries. *)
 
 (** {1 Config} *)
 

--- a/lib/runtime/runtime_agent_context.ml
+++ b/lib/runtime/runtime_agent_context.ml
@@ -52,16 +52,6 @@ type stop_reason =
        must surface [request.question] and persist the checkpoint before
        returning control; this is neither a provider failure nor a completed
        model deliverable. *)
-  | ToolFailureRecoveryDeferred of
-      { turns_used : int
-      ; reason : string
-      ; tool_names : string list
-      }
-    (* The OAS typed recovery judge ended this Agent.run without another main
-       provider call. [reason] is observation-only model output; scheduling
-       decisions must branch only on this constructor. The host owns the next
-       activity boundary, so this is a checkpoint yield, never a provider
-       failure or Keeper pause. *)
 
 type config =
   { name : string

--- a/lib/runtime/runtime_agent_context.mli
+++ b/lib/runtime/runtime_agent_context.mli
@@ -33,11 +33,6 @@ type stop_reason =
       turns_used : int;
       request : Agent_sdk.Error.input_required;
     }
-  | ToolFailureRecoveryDeferred of {
-      turns_used : int;
-      reason : string;
-      tool_names : string list;
-    }
 
 (** {1 Per-worker config} *)
 

--- a/test/test_keeper_replay_checkpoint.ml
+++ b/test/test_keeper_replay_checkpoint.ml
@@ -276,71 +276,6 @@ let test_empty_success_drops_current_turn_replay () =
     (prune_reason_to_string reason)
 ;;
 
-let test_recovery_defer_preserves_typed_receipt_suffix () =
-  let open Agent_sdk.Types in
-  let history =
-    [ message User [ Text "old user" ]; message Assistant [ Text "old answer" ] ]
-  in
-  let receipt_metadata =
-    [ "oas.tool_failure_recovery.v1", `Assoc [ "version", `Int 1 ] ]
-  in
-  let result_message =
-    { (message Tool
-         [ ToolResult
-             { tool_use_id = "tool-1"
-             ; content = "working directory is required"
-             ; outcome =
-                 Tool_failed
-                   { failure_kind = Validation_error
-                   ; error_class = Some Deterministic
-                   }
-             ; json = None
-             ; content_blocks = None
-             }
-         ]) with
-      metadata = receipt_metadata
-    }
-  in
-  let current_turn =
-    [ message User [ Text "current user" ]
-    ; message Assistant
-        [ ToolUse
-            { id = "tool-1"
-            ; name = "Execute"
-            ; input = `Assoc [ "cmd", `String "gh pr list" ]
-            }
-        ]
-    ; result_message
-    ]
-  in
-  let patched, reason =
-    Finalize.checkpoint_for_replay_persistence
-      ~history_messages:history
-      ~pre_turn_working_context:None
-      ~completion_contract_result:Receipt.Completion_observation_unknown
-      ~session_id:"new-session"
-      ~response_text:""
-      ~stop_reason:
-        (Runtime_agent.ToolFailureRecoveryDeferred
-           { turns_used = 2
-           ; reason = "wait for repository state"
-           ; tool_names = [ "Execute" ]
-           })
-      (checkpoint (history @ current_turn))
-    |> expect_ok
-  in
-  Alcotest.(check string) "session unified" "new-session" patched.session_id;
-  Alcotest.(check int) "full recovery suffix retained" 5
-    (List.length patched.messages);
-  Alcotest.(check bool) "receipt metadata retained" true
-    (List.exists
-       (fun (message : Agent_sdk.Types.message) ->
-          message.metadata = receipt_metadata)
-       patched.messages);
-  Alcotest.(check (option string)) "no prune reason" None
-    (prune_reason_to_string reason)
-;;
-
 let test_execution_observations_preserve_tool_replay_suffix () =
   let open Agent_sdk.Types in
   let history =
@@ -407,19 +342,10 @@ let test_execution_observations_preserve_tool_replay_suffix () =
     observations
 ;;
 
-let test_recovery_ask_user_preserves_exact_typed_receipt_suffix () =
+let test_input_required_preserves_exact_tool_failure_suffix () =
   let open Agent_sdk.Types in
   let history =
     [ message User [ Text "old user" ]; message Assistant [ Text "old answer" ] ]
-  in
-  let receipt_metadata =
-    [ ( "oas.tool_failure_recovery.v1"
-      , `Assoc
-          [ "version", `Int 1
-          ; "decision", `String "ask_user"
-          ; "question", `String "Which repository should I inspect?"
-          ] )
-    ]
   in
   let current_turn =
     [ message User [ Text "inspect the source" ]
@@ -430,21 +356,19 @@ let test_recovery_ask_user_preserves_exact_typed_receipt_suffix () =
             ; input = `Assoc [ "cmd", `String "gh pr list" ]
             }
         ]
-    ; { (message Tool
-           [ ToolResult
-               { tool_use_id = "tool-ask-1"
-               ; content = "working directory is required"
-               ; outcome =
-                   Tool_failed
-                     { failure_kind = Validation_error
-                     ; error_class = Some Deterministic
-                     }
-               ; json = None
-               ; content_blocks = None
-               }
-           ]) with
-        metadata = receipt_metadata
-      }
+    ; message Tool
+        [ ToolResult
+            { tool_use_id = "tool-ask-1"
+            ; content = "working directory is required"
+            ; outcome =
+                Tool_failed
+                  { failure_kind = Validation_error
+                  ; error_class = Some Deterministic
+                  }
+            ; json = None
+            ; content_blocks = None
+            }
+        ]
     ]
   in
   let request = input_required_request () in
@@ -461,7 +385,7 @@ let test_recovery_ask_user_preserves_exact_typed_receipt_suffix () =
   in
   Alcotest.(check string) "session unified" "new-session" patched.session_id;
   Alcotest.(check bool)
-    "Ask_user replay suffix is structurally unchanged"
+    "InputRequired replay suffix is structurally unchanged"
     true
     (patched.messages = history @ current_turn);
   Alcotest.(check (option string)) "no prune reason" None
@@ -556,17 +480,13 @@ let () =
             `Quick
             test_empty_success_drops_current_turn_replay
         ; Alcotest.test_case
-            "recovery defer preserves typed receipt suffix"
-            `Quick
-            test_recovery_defer_preserves_typed_receipt_suffix
-        ; Alcotest.test_case
             "execution observations preserve tool replay suffix"
             `Quick
             test_execution_observations_preserve_tool_replay_suffix
         ; Alcotest.test_case
-            "recovery Ask_user preserves exact typed receipt suffix"
+            "InputRequired preserves exact tool-failure suffix"
             `Quick
-            test_recovery_ask_user_preserves_exact_typed_receipt_suffix
+            test_input_required_preserves_exact_tool_failure_suffix
         ; Alcotest.test_case
             "media-degraded projection persists canonical checkpoint"
             `Quick

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -196,42 +196,31 @@ let test_accept_keeps_result () =
     Alcotest.failf "accepted response should pass through: %s"
       (Agent_sdk.Error.to_string err)
 
-let test_typed_recovery_control_stops_bypass_response_accept () =
+let test_input_required_bypasses_response_accept () =
   let accept_calls = ref 0 in
   let reject (_ : Agent_sdk.Types.api_response) =
     incr accept_calls;
     false
   in
   let request = input_required_request () in
-  let input_required =
+  let result =
     { (run_result ()) with
       stop_reason = Runtime_agent.InputRequired { turns_used = 2; request }
     }
   in
-  let deferred =
-    { (run_result ()) with
-      stop_reason =
-        Runtime_agent.ToolFailureRecoveryDeferred
-          { turns_used = 2; reason = "wait"; tool_names = [ "Execute" ] }
-    }
-  in
-  List.iter
-    (fun (label, result) ->
-       match
-         Masc.Keeper_turn_driver.For_testing.apply_accept
-           ~runtime_id:"runtime.reasoning-model"
-           ~accept:reject
-           result
-       with
-       | Ok _ -> ()
-       | Error error ->
-         Alcotest.failf
-           "%s control stop rotated through response acceptance: %s"
-           label
-           (Agent_sdk.Error.to_string error))
-    [ "input_required", input_required; "defer", deferred ];
+  (match
+     Masc.Keeper_turn_driver.For_testing.apply_accept
+       ~runtime_id:"runtime.reasoning-model"
+       ~accept:reject
+       result
+   with
+   | Ok _ -> ()
+   | Error error ->
+     Alcotest.failf
+       "InputRequired rotated through response acceptance: %s"
+       (Agent_sdk.Error.to_string error));
   Alcotest.(check int)
-    "typed control stops never invoke the deliverable accept predicate"
+    "InputRequired never invokes the deliverable accept predicate"
     0
     !accept_calls
 
@@ -518,36 +507,6 @@ let test_finalization_does_not_surface_hidden_reasoning () =
     "typed rejection diagnostic does not expose ReasoningDetails content"
     false
     (contains ~needle:"provider-private reasoning" reason)
-
-let test_recovery_defer_does_not_synthesize_tool_narration () =
-  let deferred =
-    { (run_result ()) with
-      stop_reason =
-        Runtime_agent.ToolFailureRecoveryDeferred
-          { turns_used = 2
-          ; reason = "wait for repository state"
-          ; tool_names = [ "Execute" ]
-          }
-    }
-  in
-  match
-    Masc.Keeper_agent_run.For_testing.normalize_response_text_for_finalization
-      ~runtime_id:"runtime.reasoning-model"
-      ~initial_messages:[]
-      ~run_result:deferred
-      ~text:""
-      ~tool_names:[ "Execute" ]
-      ()
-  with
-  | Ok text ->
-    Alcotest.(check string)
-      "control checkpoint has no synthetic assistant narration"
-      ""
-      text
-  | Error error ->
-    Alcotest.failf
-      "typed recovery checkpoint should finalize without a chat reply: %s"
-      (Agent_sdk.Error.to_string error)
 
 let test_direct_no_progress_retry_uses_runtime_decision () =
   with_direct_retry_runtime (fun () ->
@@ -1764,9 +1723,9 @@ let () =
           Alcotest.test_case "accepted response passes through" `Quick
             test_accept_keeps_result;
           Alcotest.test_case
-            "typed recovery control stops bypass response acceptance"
+            "InputRequired bypasses response acceptance"
             `Quick
-            test_typed_recovery_control_stops_bypass_response_accept;
+            test_input_required_bypasses_response_accept;
           Alcotest.test_case
             "replay projection failure preserves provider success"
             `Quick
@@ -1787,10 +1746,6 @@ let () =
             "finalization does not surface hidden reasoning"
             `Quick
             test_finalization_does_not_surface_hidden_reasoning;
-          Alcotest.test_case
-            "recovery defer does not synthesize tool narration"
-            `Quick
-            test_recovery_defer_does_not_synthesize_tool_narration;
 	          Alcotest.test_case
 	            "direct no-progress retry uses runtime decision"
 	            `Quick

--- a/test/test_keeper_turn_outcome.ml
+++ b/test/test_keeper_turn_outcome.ml
@@ -77,10 +77,6 @@ let test_of_stop_reason () =
   check outcome "durable stimulus yield -> checkpoint" TO.Continuation_checkpoint
     (TO.of_stop_reason
        (Runtime_agent.Yielded_to_durable_stimulus { turns_used = 2 }));
-  check outcome "typed recovery defer -> checkpoint" TO.Continuation_checkpoint
-    (TO.of_stop_reason
-       (Runtime_agent.ToolFailureRecoveryDeferred
-          { turns_used = 2; reason = "wait"; tool_names = [ "Execute" ] }));
   check outcome "typed input required -> visible" TO.Visible_reply
     (TO.of_stop_reason
        (Runtime_agent.InputRequired { turns_used = 2; request }))
@@ -164,8 +160,7 @@ let test_autonomous_yield_boundary_contract () =
   | Runtime_agent.ExecutionTimeoutObserved _
   | Runtime_agent.ExecutionIdleTimeoutObserved _
   | Runtime_agent.Yielded_to_chat_waiting _
-  | Runtime_agent.InputRequired _
-  | Runtime_agent.ToolFailureRecoveryDeferred _ ->
+  | Runtime_agent.InputRequired _ ->
     fail "durable request mapped to the wrong stop reason"
 
 let payload fields = Some (`Assoc fields)

--- a/test/test_keeper_unified_claim_progress.ml
+++ b/test/test_keeper_unified_claim_progress.ml
@@ -92,26 +92,6 @@ let test_turn_limit_observation_is_contract_neutral () =
     (result [])
 ;;
 
-let test_recovery_defer_is_not_a_runtime_failure () =
-  let result =
-    KAR.Contract_helpers.observed_completion_evidence
-      ~actual_keeper_tool_names:[ "tool_execute" ]
-      ~stop_reason:
-        (Runtime_agent.ToolFailureRecoveryDeferred
-           { turns_used = 2
-           ; reason = "wait for repository state"
-           ; tool_names = [ "Execute" ]
-           })
-      ~response_text_present:false
-    |> Masc.Keeper_execution_receipt.completion_contract_result_to_string
-  in
-  check
-    string
-    "typed control checkpoint is completion-contract neutral"
-    "unknown"
-    result
-;;
-
 let tool_call_detail ?(outcome = "ok") tool_name : KAR.tool_call_detail =
   { tool_name
   ; provider = "test"
@@ -161,10 +141,6 @@ let () =
             "turn-limit observation is completion-contract neutral"
             `Quick
             test_turn_limit_observation_is_contract_neutral
-        ; test_case
-            "recovery defer is completion-contract neutral"
-            `Quick
-            test_recovery_defer_is_not_a_runtime_failure
         ; test_case
             "contract progress filters no-progress tool results"
             `Quick

--- a/test/test_keeper_wire_capture_suppression.ml
+++ b/test/test_keeper_wire_capture_suppression.ml
@@ -182,25 +182,6 @@ let test_contract_observation_finalizer_preserves_response_text_by_default () =
     finalized.response_text
 ;;
 
-let test_recovery_defer_finalizer_drops_response_text_by_default () =
-  let finalized =
-    Response_text.finalize
-      ~completion_contract_result:Receipt.Completion_observation_unknown
-      ~stop_reason:
-        (Runtime_agent.ToolFailureRecoveryDeferred
-           { turns_used = 2
-           ; reason = "wait for repository state"
-           ; tool_names = [ "Execute" ]
-           })
-      ~raw_response_text:"No textual reply was produced. Tools invoked: Execute."
-      ()
-  in
-  Alcotest.(check string)
-    "typed recovery checkpoint never becomes a chat reply"
-    ""
-    finalized.response_text
-;;
-
 let () =
   Alcotest.run
     "keeper_wire_capture_suppression"
@@ -251,10 +232,6 @@ let () =
             "contract observation preserves by default"
             `Quick
             test_contract_observation_finalizer_preserves_response_text_by_default
-        ; Alcotest.test_case
-            "typed recovery checkpoint auto-suppresses by default"
-            `Quick
-            test_recovery_defer_finalizer_drops_response_text_by_default
         ] )
     ]
 ;;

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -1149,20 +1149,6 @@ let test_runtime_agent_execution_limits_are_observations () =
     idle_timeout.status;
   check (option string) "idle timeout has no error" None idle_timeout.error
 
-let test_runtime_agent_recovery_defer_is_control_checkpoint () =
-  let lifecycle =
-    Runtime_agent.worker_lifecycle_classification_of_result
-      (Error
-         (Agent_sdk.Error.Agent
-            (Agent_sdk.Error.ToolFailureRecoveryDeferred
-               { reason = "wait for repository state"
-               ; tool_names = [ "Execute" ]
-               })))
-  in
-  check string "event" "completed" lifecycle.event;
-  check string "status" "tool_failure_recovery_deferred" lifecycle.status;
-  check (option string) "no provider error" None lifecycle.error
-
 let test_runtime_agent_context_uses_configured_turn_limit () =
   let config =
     Runtime_agent.default_config
@@ -1674,10 +1660,6 @@ let () =
             "execution limits are lifecycle observations"
             `Quick
             test_runtime_agent_execution_limits_are_observations
-        ; test_case
-            "typed recovery defer is a control checkpoint"
-            `Quick
-            test_runtime_agent_recovery_defer_is_control_checkpoint
         ; test_case
             "runtime agent context uses configured turn limit"
             `Quick


### PR DESCRIPTION
## Summary
- delete the unreachable Runtime_agent ToolFailureRecoveryDeferred result family
- remove its Keeper checkpoint, receipt, outcome, and response projections
- preserve ordinary typed Tool_failed behavior and InputRequired checkpoint handling

No replacement recovery hierarchy or retry heuristic is added.

## Validation
- retired recovery identifiers: 0 active lib/test matches
- ocamlformat --check
- ocamlc -stop-after parsing
- git diff --check
- focused runtime build reaches the independent approval_callback residue handled by #24440

## Scope
48 additions, 336 deletions; 384 total changed lines.