### PR TITLE
fix(oas): remove retired small API residues

### DIFF
--- a/lib/keeper/keeper_types_profile_toml_parser.ml
+++ b/lib/keeper/keeper_types_profile_toml_parser.ml
@@ -106,8 +106,9 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
     else Ok ()
   in
   let result =
-    Result.bind result (fun () -> runtime_assignment_result)
-    |> Result.bind (fun () -> legacy_goal_result)
+    Result.bind
+      (Result.bind result (fun () -> runtime_assignment_result))
+      (fun () -> legacy_goal_result)
   in
   Result.map
     (fun () ->

--- a/lib/keeper/keeper_unified_metrics_result.ml
+++ b/lib/keeper/keeper_unified_metrics_result.ml
@@ -137,8 +137,8 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
               else if has_validated_evidence then
                 (match validated_evidence with
                  | Some v ->
-                   Printf.sprintf "unified:validated_evidence(ok=%b,file_write=%b,evidence=%d)"
-                     v.ok v.has_file_write (List.length v.evidence)
+                   Printf.sprintf "unified:validated_evidence(ok=%b,evidence=%d)"
+                     v.ok (List.length v.evidence)
                  | None -> "unified:validated_evidence(unreachable)")
               else if not has_text then
                 "unified:"

--- a/lib/keeper/keeper_unified_metrics_support.ml
+++ b/lib/keeper/keeper_unified_metrics_support.ml
@@ -264,7 +264,7 @@ let is_noop_cycle ~has_text ~(tools_used : string list) : bool =
 let visible_run_validation (result : Keeper_agent_run.run_result) :
     Agent_sdk.Raw_trace.run_validation option =
   match result.run_validation with
-  | Some v when v.ok && (v.evidence <> [] || v.has_file_write) -> Some v
+  | Some v when v.ok && v.evidence <> [] -> Some v
   | _ -> None
 
 let telemetry_reported_of_result
@@ -305,13 +305,10 @@ let has_visible_tool_signal (result : Keeper_agent_run.run_result) : bool =
 
 let validated_evidence_preview
     (v : Agent_sdk.Raw_trace.run_validation) : string =
-  if v.has_file_write then "(validated evidence: file_write)"
-  else
-    match v.tool_names with
-    | [] -> "(validated evidence)"
-    | names ->
-      Printf.sprintf "(validated evidence: %s)"
-        (String.concat ", " names)
+  match v.tool_names with
+  | [] -> "(validated evidence)"
+  | names ->
+    Printf.sprintf "(validated evidence: %s)" (String.concat ", " names)
 
 (* RFC-0232: the scheduled-autonomous "what is this keeper doing" preview, by
    precedence. [is_visible_reply] is the typed reply-surface outcome
@@ -353,16 +350,10 @@ let accountability_evidence_refs
   let validation_refs =
     match validated_evidence with
     | Some validation ->
-        let base =
-          validation.evidence
-          |> List.map String.trim
-          |> List.filter (fun entry -> entry <> "")
-          |> List.map (fun entry -> "validation:" ^ entry)
-        in
-        if validation.has_file_write then
-          "validation:file_write" :: base
-        else
-          base
+      validation.evidence
+      |> List.map String.trim
+      |> List.filter (fun entry -> entry <> "")
+      |> List.map (fun entry -> "validation:" ^ entry)
     | None -> []
   in
   let turn_refs = [ Printf.sprintf "turn:%s:%d" trace_id turn_number ] in

--- a/lib/local/worker_container_types.ml
+++ b/lib/local/worker_container_types.ml
@@ -695,12 +695,6 @@ let merge_usage (a : Agent_sdk.Types.api_usage) (b : Agent_sdk.Types.api_usage) 
        | Some x, None | None, Some x -> Some x
        | None, None -> None) }
 
-let estimate_cost_usd ~(model_id : string)
-    (usage : Agent_sdk.Types.api_usage) : float option =
-  let pricing = Llm_provider.Pricing.pricing_for_model model_id in
-  Some (Llm_provider.Pricing.estimate_cost ~pricing
-    ~input_tokens:usage.input_tokens ~output_tokens:usage.output_tokens ())
-
 let local_worker_heartbeat_interval_sec () = Env_config.Worker.local_worker_heartbeat_sec
 
 let default_system_prompt ~worker_name ~model_id ?role

--- a/lib/local/worker_container_types.mli
+++ b/lib/local/worker_container_types.mli
@@ -25,8 +25,7 @@
     [followup_prompt], [split_top_level],
     [find_top_level_char], [parse_text_tool_args],
     [parse_text_tool_calls], [make_usage],
-    [estimate_cost_usd], [worker_session_id],
-    [worker_auth_token]) stay private.
+    [worker_session_id], [worker_auth_token]) stay private.
 
     {!Worker_container} does [include Worker_container_types]
     and reaches a few additional helpers unqualified

--- a/lib/tool_broadcast_typed.ml
+++ b/lib/tool_broadcast_typed.ml
@@ -21,8 +21,7 @@ module Float = Stdlib.Float
 module Sg = Agent_sdk.Tool_schema_gen
 
 let message_field =
-  Sg.string_field "message" ~required:true
-    ~desc:"Message content to broadcast to all agents" ()
+  Sg.string_field "message" ~desc:"Message content to broadcast to all agents" ()
 
 (* Issue #8595: dropped [format_field]. The schema field was advertised
    to LLM clients but [handle_broadcast] never read it (destructured as

--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -560,10 +560,6 @@ let validation_action ?schema ~name ~args () : Tool_dispatch.pre_hook_action =
       let reason = pass_reason ~schema:(Some schema) ~args ~prepared_args in
       emit_validation_telemetry ~tool:name ~result:"pass" ~reason;
       Tool_dispatch.Pass
-    | Agent_sdk.Tool_middleware.Proceed coerced ->
-      emit_validation_telemetry ~tool:name ~result:"pass" ~reason:"coerced";
-      Log.Tool_validation.debug "tool_input_validation coerced args for %s" name;
-      Tool_dispatch.Proceed coerced
     | Agent_sdk.Tool_middleware.Reject { message; _ } ->
       emit_validation_telemetry ~tool:name ~result:"fail" ~reason:"invalid_args";
       Log.Tool_validation.info "tool_input_validation rejected %s: %s" name message;


### PR DESCRIPTION
## Summary
- drop the removed Tool_middleware Proceed arm and dead pricing estimator
- use the current required string-field and Result.bind contracts
- remove deleted Raw_trace has_file_write projections; only explicit validation evidence remains visible

No heuristic replacement, string inference, or compatibility shim is introduced.

## Validation
- ocamlformat --check
- ocamlc -stop-after parsing
- git diff --check
- keeper tool boundary matrix
- focused lib/masc.cma build no longer reports any of the seven touched API errors; remaining failures are independent EventBus, Context Reducer, Worker, compaction-event, and lifecycle residues

## Scope
16 additions, 36 deletions.