### PR TITLE
refactor(runtime): remove implicit lifecycle limit carriers

### DIFF
--- a/lib/fusion/fusion_oas.ml
+++ b/lib/fusion/fusion_oas.ml
@@ -112,9 +112,7 @@ let apply_timeout_budget ?timeout_s (base_config : Runtime_agent.config) =
   | None -> base_config
   | Some timeout_s ->
     (* Fusion owns the structural wall-clock budget via the outer
-       Masc_oas_bridge.run_safe call. Do not arm Runtime_agent's total
-       max_execution_time_s here; it can kill an active stream with the
-       wrong failure attribution. *)
+       Masc_oas_bridge.run_safe call. *)
     { base_config with
       Runtime_agent.stream_idle_timeout_s = Some timeout_s
     ; body_timeout_s = Some timeout_s
@@ -164,7 +162,7 @@ let build_agent
     (model : string)
   : (Agent_sdk.Agent.t, Fusion_types.panel_failure) result
   =
-  let _ = max_tool_calls, max_tokens in
+  let _ = max_tool_calls in
   (* 카드명(Async_agent.all이 결과 키로 반환)은 패널 정체성([name], 예 "skeptic (claude)").
      provider 라우팅·에러 귀속은 원 [model]로 따로 한다 — 정체성과 routable model을 한
      문자열에 압축하지 않는다 (RFC-0278). [name] 미지정(judge·label 없는 panel)이면 카드명=model.
@@ -200,8 +198,18 @@ let build_agent
            ~system_prompt
            ~tools
        in
-       let config = apply_timeout_budget ?timeout_s base_config in
-       match Runtime_agent.build ~sw ~net ~config with
+       let base_config = apply_timeout_budget ?timeout_s base_config in
+       let config =
+         match max_tokens with
+         | None -> Ok base_config
+         | Some n when Fusion_policy.valid_max_output_tokens (Some n) ->
+           Ok { base_config with max_tokens = Some n }
+         | Some n -> Error (Fusion_types.Invalid_max_output_tokens n)
+       in
+       match config with
+       | Error _ as err -> err
+       | Ok config ->
+         (match Runtime_agent.build ~sw ~net ~config with
            | Ok agent -> Ok agent
            | Error e ->
              Error
@@ -209,7 +217,7 @@ let build_agent
                    (provider_error_detail
                       ~runtime_id:model
                       (Agent_sdk.Error.to_string e))
-                 : Fusion_types.panel_failure)))
+                 : Fusion_types.panel_failure))))
 
 module For_testing = struct
   let apply_timeout_budget = apply_timeout_budget

--- a/lib/fusion/fusion_oas.mli
+++ b/lib/fusion/fusion_oas.mli
@@ -9,13 +9,10 @@
 (** runtime_id("provider.model")로 OAS 에이전트를 빌드한다.
 
     [tools]를 주면 패널/심판이 tool call을 할 수 있다.
-    [max_tool_calls] > 0이면 에이전트의 [max_turns]를 해당 횟수+1로 제한해
-    OpenRouter Fusion의 per-panel tool budget을 근사한다.
     [max_tokens]는 지정된 패널/심판 호출의 출력 토큰 예산이다. 생략하면
     Runtime_agent 기본값을 보존한다.
     [timeout_s]는 OAS transport idle/body budget에만 매핑한다. Fusion의 구조적
-    wall-clock budget은 호출자가 [Masc_oas_bridge.run_safe]로 소유하며, OAS
-    [max_execution_time_s]에는 매핑하지 않는다.
+    wall-clock budget은 호출자가 [Masc_oas_bridge.run_safe]로 소유한다.
     [name]은 에이전트 카드명 — [Async_agent.all]이 결과 키로 반환하는 패널 정체성이다
     (RFC-0278: 같은 model을 다른 라벨로 구분). 미지정이면 카드명=[model]. provider
     라우팅은 카드명과 무관하게 [model]로 한다.

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -575,14 +575,11 @@ let run_turn
     let keeper_visible_sandbox_root =
       Keeper_sandbox.keeper_visible_root_abs_of_meta ~config meta
     in
-    let effective_allowed_paths = Keeper_alerting_path.effective_allowed_paths ~meta in
-    (match
-       Keeper_alerting_path.absolute_allowed_paths_result
-         ~config
-         ~allowed_paths:effective_allowed_paths
-     with
-     | Error e -> Error (Agent_sdk.Error.Internal e)
-     | Ok oas_allowed_paths ->
+    (* Tool/path confinement stays owned by MASC dispatch. Each filesystem and
+       shell operation resolves its concrete target through
+       [Keeper_alerting_path] and [Keeper_sandbox_containment]; OAS receives no
+       ambient path capability. *)
+    (
        (* OAS [stream_idle_timeout_s] bounds inter-line idle on HTTP streams
           only when the operator explicitly configures it. The deadline resets
           after each successful line, so this is gap detection, not a total run
@@ -709,12 +706,6 @@ let run_turn
                            ~site:"runtime_runtime"
                            config
                            manifest)
-                      (* No code-level tool-retry or idle-turn limit. Retrying
-                         a malformed tool call (e.g. missing required arg) is
-                         the keeper's own competence: OAS delivers the typed
-                         validation error back to the model and the agent loop
-                         decides whether to continue. *)
-                    ~max_idle_turns:0
                     ?stream_idle_timeout_s
                     ?body_timeout_s:
                       (Keeper_runtime_resolved.body_timeout_override_sec ())
@@ -725,7 +716,6 @@ let run_turn
                     ?on_yield
                     ?on_resume
                     ~agent_ref
-                    ~allowed_paths:oas_allowed_paths
                     ~cache_system_prompt:true
                     ~yield_on_tool
                     ~context_injector

--- a/lib/keeper/keeper_alerting.mli
+++ b/lib/keeper/keeper_alerting.mli
@@ -28,10 +28,6 @@ val normalize_path_for_check : string -> string
 val normalize_allowed_path_for_check :
   root:string -> string -> string option
 val is_within_root_norm : root_norm:string -> string -> bool
-val absolute_allowed_paths :
-  config:Workspace.config -> allowed_paths:string list -> string list
-val absolute_allowed_paths_result :
-  config:Workspace.config -> allowed_paths:string list -> (string list, string) result
 val resolve_keeper_target_path :
   config:Workspace.config ->
   allowed_paths:string list ->

--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -83,31 +83,6 @@ let is_within_allowed_norms ~(target_norm : string) (allowed_norms : string list
     allowed_norms
 ;;
 
-let absolute_allowed_paths ~(config : Workspace.config) ~(allowed_paths : string list)
-  : string list
-  =
-  let root = project_root_of_config config in
-  allowed_paths |> List.filter_map (normalize_allowed_path_for_check ~root)
-;;
-
-let absolute_allowed_paths_result ~(config : Workspace.config) ~(allowed_paths : string list)
-  : (string list, string) result
-  =
-  let normalized = absolute_allowed_paths ~config ~allowed_paths in
-  if allowed_paths <> [] && normalized = []
-  then
-    (* Tier A3 / Cycle 6: redact the raw [allowed_paths] list — those
-       strings frequently include host-absolute prefixes that should
-       not flow back to the LLM caller. The count is enough for the
-       caller to know "you provided N entries, none were valid". *)
-    Error
-      (Printf.sprintf
-         "allowed_paths_normalized_empty: %d entries provided, none resolved to a valid \
-          path"
-         (List.length allowed_paths))
-  else Ok normalized
-;;
-
 type confined_path =
   { root : string
   ; root_identity : resource_identity option

--- a/lib/keeper/keeper_alerting_path.mli
+++ b/lib/keeper/keeper_alerting_path.mli
@@ -36,17 +36,6 @@ val is_within_root_norm : root_norm:string -> string -> bool
 val is_within_allowed_norms :
   target_norm:string -> string list -> bool
 
-(** Project per-keeper allowed_paths to absolute, normalized paths. *)
-val absolute_allowed_paths :
-  config:Workspace.config -> allowed_paths:string list -> string list
-
-(** Like [absolute_allowed_paths] but errors when normalization
-    silently drops every entry. *)
-val absolute_allowed_paths_result :
-  config:Workspace.config ->
-  allowed_paths:string list ->
-  (string list, string) result
-
 type confined_path
 (** A path projected to one concrete allowed root. The constructor is hidden so
     callers cannot manufacture an absolute or parent-relative capability path. *)

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -269,7 +269,6 @@ let run_named
     ?(tools = [])
     ?(initial_messages = [])
     ?model_input_projection
-    ~max_idle_turns
     ?stream_idle_timeout_s
     ?body_timeout_s
     ?temperature
@@ -281,7 +280,6 @@ let run_named
     ?on_resume
     ?agent_ref
     ?transport
-    ?(allowed_paths = [])
     ?checkpoint_sidecar
     ?(cache_system_prompt = false)
     ?(yield_on_tool = false)
@@ -561,7 +559,6 @@ let run_named
             ; tools
             ; initial_messages
             ; model_input_projection
-            ; max_idle_turns
             ; stream_idle_timeout_s
             ; body_timeout_s
             ; temperature
@@ -569,7 +566,6 @@ let run_named
             ; hooks
             ; raw_trace
             ; transport_resolved
-            ; allowed_paths
             ; checkpoint_sidecar
             ; cache_system_prompt
             ; yield_on_tool

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -76,7 +76,6 @@ val run_named :
   ?initial_messages:Agent_sdk.Types.message list ->
   ?model_input_projection:
     (Agent_sdk.Types.message list -> Agent_sdk.Types.message list) ->
-  max_idle_turns:int ->
   ?stream_idle_timeout_s:float ->
   ?body_timeout_s:float ->
   ?temperature:float ->
@@ -88,7 +87,6 @@ val run_named :
   ?on_resume:(unit -> unit) ->
   ?agent_ref:Agent_sdk.Agent.t option ref ->
   ?transport:Masc_grpc_transport.t ->
-  ?allowed_paths:string list ->
   ?checkpoint_sidecar:Yojson.Safe.t ->
   ?cache_system_prompt:bool ->
   ?yield_on_tool:bool ->

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -31,7 +31,6 @@ type try_provider_ctx =
   ; initial_messages : Agent_sdk.Types.message list
   ; model_input_projection :
       (Agent_sdk.Types.message list -> Agent_sdk.Types.message list) option
-  ; max_idle_turns : int
   ; stream_idle_timeout_s : float option
   ; body_timeout_s : float option
   ; temperature : float option
@@ -42,8 +41,7 @@ type try_provider_ctx =
   ; (* Transport *)
     transport_resolved : Masc_grpc_transport.t
   ; (* Session / checkpoint *)
-    allowed_paths : string list
-  ; checkpoint_sidecar : Yojson.Safe.t option
+    checkpoint_sidecar : Yojson.Safe.t option
   ; cache_system_prompt : bool
   ; yield_on_tool : bool
   ; checkpoint_sink : Agent_sdk.Agent.checkpoint_sink option
@@ -234,12 +232,10 @@ let run_try_provider
         stream_idle_timeout_s = ctx.stream_idle_timeout_s
           ; body_timeout_s = ctx.body_timeout_s
           ; temperature
-          ; max_idle_turns = ctx.max_idle_turns
           ; hooks = ctx.hooks
           ; description =
               Some (Printf.sprintf "runtime:%s/runtime" ctx.runtime_id)
           ; transport = ctx.transport_resolved
-          ; allowed_paths = ctx.allowed_paths
           ; checkpoint_sidecar = ctx.checkpoint_sidecar
           ; session_id = ctx.session_id
           ; cache_system_prompt = ctx.cache_system_prompt

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -14,7 +14,6 @@ type try_provider_ctx =
   ; initial_messages : Agent_sdk.Types.message list
   ; model_input_projection :
       (Agent_sdk.Types.message list -> Agent_sdk.Types.message list) option
-  ; max_idle_turns : int
   ; stream_idle_timeout_s : float option
   ; body_timeout_s : float option
   ; temperature : float option
@@ -23,7 +22,6 @@ type try_provider_ctx =
   ; raw_trace : Agent_sdk.Raw_trace.t option
   ; trace_link : (string * string) option
   ; transport_resolved : Masc_grpc_transport.t
-  ; allowed_paths : string list
   ; checkpoint_sidecar : Yojson.Safe.t option
   ; cache_system_prompt : bool
   ; yield_on_tool : bool

--- a/lib/keeper/keeper_turn_driver_wrappers.ml
+++ b/lib/keeper/keeper_turn_driver_wrappers.ml
@@ -24,7 +24,6 @@ let config_for_label
     ~(tools : Agent_sdk.Tool.t list)
     ~(max_tokens : int option)
     ~(temperature : float option)
-    ?(max_idle_turns = 3)
     ?stream_idle_timeout_s
     ?hooks
     ?enable_thinking
@@ -54,7 +53,6 @@ let config_for_label
     { base_config with
       max_tokens;
       temperature;
-      max_idle_turns;
       stream_idle_timeout_s;
       hooks;
       enable_thinking;
@@ -72,7 +70,6 @@ let run_model_by_label
     ~goal
     ?(system_prompt = "")
     ?(tools = [])
-    ?(max_idle_turns = 3)
     ?stream_idle_timeout_s
     ?temperature
     ?max_tokens
@@ -88,7 +85,7 @@ let run_model_by_label
   : (Runtime_agent.run_result, Agent_sdk.Error.sdk_error) result =
   let* config =
     config_for_label ~name:"oas-label-model" ~model_label ~system_prompt
-      ~tools ~max_tokens ~temperature ~max_idle_turns ?stream_idle_timeout_s ?hooks
+      ~tools ~max_tokens ~temperature ?stream_idle_timeout_s ?hooks
       ?enable_thinking
       ?provider_config_transform
       ~description:(Some (Printf.sprintf "model_label:%s" model_label))
@@ -167,7 +164,6 @@ let run_named_with_masc_tools
     ?on_resume
     ?transport
     ?(yield_on_tool = false)
-    ?(max_idle_turns = 3)
     ?provider_config_transform
     ?sw
     ?net
@@ -180,7 +176,6 @@ let run_named_with_masc_tools
       (fun input -> dispatch ~name:td.name ~args:input)
   ) masc_tools in
   Keeper_turn_driver.run_named ~runtime_id ~keeper_name ~goal ~base_path ~system_prompt ~tools:oas_tools
-    ~max_idle_turns
     ?temperature
     ?stream_idle_timeout_s ?hooks
     ~accept

--- a/lib/keeper/keeper_turn_driver_wrappers.mli
+++ b/lib/keeper/keeper_turn_driver_wrappers.mli
@@ -14,7 +14,6 @@ val run_model_by_label :
   goal:string ->
   ?system_prompt:string ->
   ?tools:Agent_sdk.Tool.t list ->
-  ?max_idle_turns:int ->
   ?stream_idle_timeout_s:float ->
   ?temperature:float ->
   ?max_tokens:int ->
@@ -53,7 +52,6 @@ val run_named_with_masc_tools :
   ?on_resume:(unit -> unit) ->
   ?transport:Masc_grpc_transport.t ->
   ?yield_on_tool:bool ->
-  ?max_idle_turns:int ->
   ?provider_config_transform:
     (Llm_provider.Provider_config.t ->
     (Llm_provider.Provider_config.t, Agent_sdk.Error.sdk_error) result) ->

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -152,9 +152,6 @@ let run (ctx : ctx)
           (Keeper_id.Trace_id.to_string run_meta.runtime.trace_id)
         ~generation:run_generation
         ~max_context:execution.max_context
-        (* OAS defines zero as the unbounded idle-turn sentinel. This span
-           records the production Keeper contract, not a tunable threshold. *)
-        ~max_idle_turns:0
         ~channel:(Keeper_world_observation.channel_to_string channel)
         ~is_retry
         ~current_task_id:

--- a/lib/otel_genai/otel_genai.ml
+++ b/lib/otel_genai/otel_genai.ml
@@ -84,7 +84,6 @@ module Attr_key = struct
   let keeper_trace_id = register Legacy "keeper.trace_id"
   let keeper_generation = register Legacy "keeper.generation"
   let keeper_max_context = register Legacy "keeper.max_context"
-  let keeper_max_idle_turns = register Legacy "keeper.max_idle_turns"
   let keeper_channel = register Legacy "keeper.channel"
   let keeper_is_retry = register Legacy "keeper.is_retry"
   let keeper_current_task_id = register Legacy "keeper.current_task_id"
@@ -163,7 +162,6 @@ let keeper_turn_attrs
       ~trace_id
       ~generation
       ~max_context
-      ~max_idle_turns
       ~channel
       ~is_retry
       ~current_task_id
@@ -179,7 +177,6 @@ let keeper_turn_attrs
   ; Attr_key.keeper_trace_id, `String trace_id
   ; Attr_key.keeper_generation, `Int generation
   ; Attr_key.keeper_max_context, `Int max_context
-  ; Attr_key.keeper_max_idle_turns, `Int max_idle_turns
   ; Attr_key.keeper_channel, `String channel
   ; Attr_key.keeper_is_retry, `Bool is_retry
   ; Attr_key.gen_ai_operation_name, `String "invoke_agent"
@@ -207,7 +204,6 @@ let with_keeper_turn_span
       ~trace_id
       ~generation
       ~max_context
-      ~max_idle_turns
       ~channel
       ~is_retry
       ~current_task_id
@@ -224,7 +220,6 @@ let with_keeper_turn_span
         ~trace_id
         ~generation
         ~max_context
-        ~max_idle_turns
         ~channel
         ~is_retry
         ~current_task_id

--- a/lib/otel_genai/otel_genai.mli
+++ b/lib/otel_genai/otel_genai.mli
@@ -30,7 +30,6 @@ module Attr_key : sig
   val keeper_trace_id : string
   val keeper_generation : string
   val keeper_max_context : string
-  val keeper_max_idle_turns : string
   val keeper_channel : string
   val keeper_is_retry : string
   val keeper_current_task_id : string
@@ -99,7 +98,6 @@ val keeper_turn_attrs
   -> trace_id:string
   -> generation:int
   -> max_context:int
-  -> max_idle_turns:int
   -> channel:string
   -> is_retry:bool
   -> current_task_id:string option
@@ -114,7 +112,6 @@ val with_keeper_turn_span
   -> trace_id:string
   -> generation:int
   -> max_context:int
-  -> max_idle_turns:int
   -> channel:string
   -> is_retry:bool
   -> current_task_id:string option

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -89,10 +89,7 @@ type config =
   model_id : string;
   system_prompt : string;
   tools : Agent_sdk.Tool.t list;
-  max_turns : int;
-  max_idle_turns : int;
   stream_idle_timeout_s : float option;
-  max_execution_time_s : float option;
   body_timeout_s : float option;
   max_tokens : int option;
   temperature : float option;
@@ -108,7 +105,6 @@ type config =
   enable_thinking : bool option;
   preserve_thinking : bool option;
   transport : Masc_grpc_transport.t;
-  allowed_paths : string list;
   checkpoint_sidecar : Yojson.Safe.t option;
   cache_system_prompt : bool;
   yield_on_tool : bool;
@@ -957,9 +953,8 @@ let close_agent_for_cleanup ?(propagate_cancel = true) ~config agent =
     - MASC owns: per-turn config selection (model, temperature, tools,
       system_prompt), checkpoint field patching to align MASC intent with
       OAS resume semantics.
-    - OAS owns: cumulative token/cost telemetry, turn_count tracking,
-      Agent.resume state restoration, loop guard enforcement (max_turns,
-      idle).
+    - OAS owns: cumulative token/cost telemetry, turn_count tracking, and
+      Agent.resume state restoration.
     - OAS no longer enforces cost or cumulative-token budgets; cost is
       observe-only telemetry. *)
 let resume_from_checkpoint
@@ -1101,11 +1096,6 @@ let run_blocks
   let run_started_at = Unix.gettimeofday () in
   (try
     let result =
-      (* Pass the process-level Eio clock when available so agent_sdk's
-         [with_optional_timeout] can fire on hang when the caller has
-         also set [config.max_execution_time_s]. Both inputs must be
-         [Some] for the timeout to engage; absent either, behaviour is
-         historical (block until provider closes). *)
       let clock =
         match Process_eio.get_clock () with
         | Ok c -> Some c

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -64,10 +64,7 @@ type config = Runtime_agent_context.config = {
   model_id : string;
   system_prompt : string;
   tools : Agent_sdk.Tool.t list;
-  max_turns : int;
-  max_idle_turns : int;
   stream_idle_timeout_s : float option;
-  max_execution_time_s : float option;
   body_timeout_s : float option;
   max_tokens : int option;
   temperature : float option;
@@ -83,7 +80,6 @@ type config = Runtime_agent_context.config = {
   enable_thinking : bool option;
   preserve_thinking : bool option;
   transport : Masc_grpc_transport.t;
-  allowed_paths : string list;
   checkpoint_sidecar : Yojson.Safe.t option;
   cache_system_prompt : bool;
   yield_on_tool : bool;

--- a/lib/runtime/runtime_agent_context.ml
+++ b/lib/runtime/runtime_agent_context.ml
@@ -5,16 +5,6 @@
     [Runtime_agent] remains the public facade for [build_safe] and
     [Agent.resume] calls. *)
 
-(* [0] is the pinned SDK's documented unbounded sentinel (agent_sdk
-   lib/base/types.mli: "[0] = no turn-count limit; positive values enforce
-   a finite limit") and is what [Agent_sdk.Types.has_finite_max_turns]
-   tests against. The SDK exports the predicate but no named constant
-   (a name only exists in the unmerged oas#2589), so masc owns the name
-   here. If an oas release ships a named sentinel, replace this value
-   with that re-export (masc#24391 layer 2). *)
-let unbounded_max_turns = 0
-let default_max_turns = unbounded_max_turns
-
 type stop_reason =
   | Completed
   | TurnLimitObserved of
@@ -59,19 +49,7 @@ type config =
   ; model_id : string
   ; system_prompt : string
   ; tools : Agent_sdk.Tool.t list
-  ; max_turns : int
-  ; max_idle_turns : int
   ; stream_idle_timeout_s : float option
-  ; max_execution_time_s : float option
-    (** Wall-clock ceiling for one [Agent_sdk.Agent.run] / [run_stream]
-          call. When [Some s] AND a clock is available at the call site,
-          agent_sdk's [with_optional_timeout] returns
-          [Error (Api (Retry.Timeout {...}))] after [s] seconds — the
-          runtime FSM already maps [Retry.Timeout] to a fallback signal,
-          so this is the canonical knob to bound a hung [run_stream]
-          when a provider closes the connection without [end_turn].
-          Default [None] preserves the historical behaviour
-          (block indefinitely on stream-parser hang). *)
   ; body_timeout_s : float option
     (** Total HTTP body-consumption ceiling for non-streaming OAS completion
         paths. Streaming paths deliberately ignore this knob so active long
@@ -100,7 +78,6 @@ type config =
   ; enable_thinking : bool option
   ; preserve_thinking : bool option
   ; transport : Masc_grpc_transport.t
-  ; allowed_paths : string list
   ; checkpoint_sidecar : Yojson.Safe.t option
   ; cache_system_prompt : bool
   ; yield_on_tool : bool
@@ -144,10 +121,7 @@ let default_config
   ; model_id = provider_cfg.model_id
   ; system_prompt
   ; tools
-  ; max_turns = default_max_turns
-  ; max_idle_turns = 3
   ; stream_idle_timeout_s = None
-  ; max_execution_time_s = None
   ; body_timeout_s = None
   ; max_tokens = None
   ; temperature = provider_cfg.temperature
@@ -162,7 +136,6 @@ let default_config
   ; enable_thinking = None
   ; preserve_thinking = None
   ; transport = Masc_grpc_transport.from_env ()
-  ; allowed_paths = []
   ; checkpoint_sidecar = None
   ; cache_system_prompt = false
   ; yield_on_tool = false
@@ -194,8 +167,6 @@ let builder
     |> Agent_sdk.Builder.with_provider_config config.provider_cfg
     |> Agent_sdk.Builder.with_name config.name
     |> Agent_sdk.Builder.with_system_prompt config.system_prompt
-    |> Agent_sdk.Builder.with_max_turns config.max_turns
-    |> Agent_sdk.Builder.with_max_idle_turns config.max_idle_turns
     |> Agent_sdk.Builder.with_tools config.tools
   in
   let builder =
@@ -214,11 +185,6 @@ let builder
   let builder =
     match config.stream_idle_timeout_s with
     | Some timeout_s -> Agent_sdk.Builder.with_stream_idle_timeout timeout_s builder
-    | None -> builder
-  in
-  let builder =
-    match config.max_execution_time_s with
-    | Some s -> Agent_sdk.Builder.with_max_execution_time s builder
     | None -> builder
   in
   let builder =
@@ -259,11 +225,6 @@ let builder
   let builder =
     if config.yield_on_tool
     then Agent_sdk.Builder.with_yield_on_tool true builder
-    else builder
-  in
-  let builder =
-    if config.allowed_paths <> []
-    then Agent_sdk.Builder.with_allowed_paths config.allowed_paths builder
     else builder
   in
   let builder =
@@ -339,11 +300,6 @@ let prepare_resume ~(config : config) ~(checkpoint : Agent_sdk.Checkpoint.t)
   : prepared_resume
   =
 
-  let max_turns_for_resume =
-    if Agent_sdk.Types.has_finite_max_turns config.max_turns
-    then checkpoint.turn_count + config.max_turns
-    else unbounded_max_turns
-  in
   let patched_checkpoint =
     { checkpoint with
       Agent_sdk.Checkpoint.model = config.model_id
@@ -365,7 +321,6 @@ let prepare_resume ~(config : config) ~(checkpoint : Agent_sdk.Checkpoint.t)
     ; model = config.model_id
     ; system_prompt = Some config.system_prompt
     ; max_tokens = config.max_tokens
-    ; max_turns = max_turns_for_resume
     ; temperature = config.temperature
     ; top_p = config.top_p
     ; top_k = config.top_k
@@ -381,14 +336,11 @@ let prepare_resume ~(config : config) ~(checkpoint : Agent_sdk.Checkpoint.t)
   let options : Agent_sdk.Agent.options =
     { Agent_sdk.Agent.default_options with
       hooks = Option.value ~default:Agent_sdk.Hooks.empty config.hooks
-    ; max_idle_turns = config.max_idle_turns
     ; stream_idle_timeout_s = config.stream_idle_timeout_s
-    ; max_execution_time_s = config.max_execution_time_s
     ; body_timeout_s = config.body_timeout_s
     ; context_injector = config.context_injector
     ; event_bus = config.event_bus
     ; raw_trace = config.raw_trace
-    ; allowed_paths = config.allowed_paths
     ; description = config.description
     ; on_run_complete = config.on_run_complete
     }

--- a/lib/runtime/runtime_agent_context.mli
+++ b/lib/runtime/runtime_agent_context.mli
@@ -42,14 +42,7 @@ type config = {
   model_id : string;
   system_prompt : string;
   tools : Agent_sdk.Tool.t list;
-  max_turns : int;
-  max_idle_turns : int;
   stream_idle_timeout_s : float option;
-  max_execution_time_s : float option;
-      (** Wall-clock ceiling for one [Agent.run] / [run_stream] call.
-          When [Some] AND a clock is available, agent_sdk returns
-          [Retry.Timeout] after [s] seconds. Default [None] preserves
-          historical block-on-hang behaviour. *)
   body_timeout_s : float option;
       (** Total HTTP body-consumption ceiling forwarded to OAS
           [Builder.with_body_timeout] for non-streaming completion paths.
@@ -79,7 +72,6 @@ type config = {
   enable_thinking : bool option;
   preserve_thinking : bool option;
   transport : Masc_grpc_transport.t;
-  allowed_paths : string list;
   checkpoint_sidecar : Yojson.Safe.t option;
   cache_system_prompt : bool;
   yield_on_tool : bool;
@@ -111,13 +103,6 @@ type config = {
 
 (** {1 Default config builder} *)
 
-val unbounded_max_turns : int
-(** The pinned SDK's documented "no turn-count limit" sentinel ([0],
-    agent_sdk lib/base/types.mli); the value
-    {!Agent_sdk.Types.has_finite_max_turns} tests against. The SDK
-    exports the predicate but no named constant, so masc names it here
-    (masc#24391 layer 2). *)
-
 val default_config :
   name:string ->
   provider_cfg:Llm_provider.Provider_config.t ->
@@ -148,11 +133,8 @@ type prepared_resume = {
   agent_config : Agent_sdk.Types.agent_config;
   options : Agent_sdk.Agent.options;
 }
-(** Output of {!prepare_resume}.  [patched_checkpoint] has
-    runtime identity fields adjusted, and [agent_config.max_turns]
-    preserves [0] as unbounded; otherwise it is extended past the checkpoint
-    [turn_count] so resume picks up where the previous run left off without
-    re-counting consumed turns. *)
+(** Output of {!prepare_resume}. [patched_checkpoint] has runtime identity
+    fields adjusted. *)
 
 val set_oas_tracer : Agent_sdk.Tracing.t -> unit
 (** Set the OAS tracer used by {!builder}.  Called once
@@ -161,9 +143,6 @@ val set_oas_tracer : Agent_sdk.Tracing.t -> unit
 
 val prepare_resume :
   config:config -> checkpoint:Agent_sdk.Checkpoint.t -> prepared_resume
-(** [prepare_resume ~config ~checkpoint] computes the patched
-    checkpoint + agent_config + options for an
-    [Agent.resume] call.  Pure — no side effects.  The patched
-    agent config preserves {!unbounded_max_turns}; otherwise it
-    extends [config.max_turns] beyond the consumed [checkpoint.turn_count] for
-    generic finite OAS clients. Keeper callers use the unbounded sentinel. *)
+(** [prepare_resume ~config ~checkpoint] computes the patched checkpoint,
+    agent config, and options for an [Agent.resume] call. Pure — no side
+    effects. *)

--- a/test/test_fusion_oas_error_detail.ml
+++ b/test/test_fusion_oas_error_detail.ml
@@ -211,7 +211,7 @@ let test_panel_failure_yojson_round_trips_current_shapes () =
           (Fusion_types.Empty_response "empty response (stop_reason=max_tokens)")))
 ;;
 
-let test_timeout_budget_does_not_set_total_execution_ceiling () =
+let test_timeout_budget_sets_transport_timeouts () =
   let config =
     Fusion_oas.For_testing.apply_timeout_budget
       ~timeout_s:300.0
@@ -224,11 +224,7 @@ let test_timeout_budget_does_not_set_total_execution_ceiling () =
   Alcotest.(check (option (float 0.001)))
     "body timeout"
     (Some 300.0)
-    config.body_timeout_s;
-  Alcotest.(check (option (float 0.001)))
-    "no total execution ceiling"
-    None
-    config.max_execution_time_s
+    config.body_timeout_s
 ;;
 
 let () =
@@ -276,9 +272,9 @@ let () =
             `Quick
             test_panel_failure_yojson_round_trips_current_shapes
         ; Alcotest.test_case
-            "timeout budget does not arm OAS total execution ceiling"
+            "timeout budget sets transport timeouts"
             `Quick
-            test_timeout_budget_does_not_set_total_execution_ceiling
+            test_timeout_budget_sets_transport_timeouts
         ] )
     ]
 ;;

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -2231,7 +2231,6 @@ let test_runtime_run_blocks_appends_multimodal_input_to_oas_agent () =
   in
   let config =
     { config with
-      max_turns = 1;
       session_id = Some "multimodal-runtime-proof-session";
       exit_condition = Some (fun _turn -> true);
       exit_condition_result =

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -447,7 +447,6 @@ let test_prior_checkpoint_appends_current_goal_once () =
          ~base_path:(Filename.get_temp_dir_name ())
          ~goal:current_goal
          ~session_id:prior_checkpoint.session_id
-         ~max_idle_turns:0
          ~oas_checkpoint:prior_checkpoint
          ~exit_condition:(fun _turn -> true)
          ~exit_condition_result:

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -1104,106 +1104,6 @@ let test_runtime_agent_terminal_error_observation_marks_failed_attempt () =
        (Keeper_agent_error.runtime_outcome_of_observation
           (Some observation)))
 
-let test_runtime_agent_execution_limits_are_observations () =
-  let lifecycle =
-    Runtime_agent.worker_lifecycle_classification_of_result
-      (Error
-         (Agent_sdk.Error.Agent
-            (Agent_sdk.Error.MaxTurnsExceeded { turns = 24; limit = 24 })))
-  in
-  check string "event" "completed" lifecycle.event;
-  check string "status" "turn_limit_observed" lifecycle.status;
-  check (option string) "no error" None lifecycle.error;
-  let execution_timeout =
-    Runtime_agent.worker_lifecycle_classification_of_result
-      (Error
-         (Agent_sdk.Error.Agent
-            (Agent_sdk.Error.AgentExecutionTimeout
-               { elapsed_sec = 300.0
-               ; timeout_sec = 300.0
-               ; turn_count = 4
-               ; max_turns = Runtime_agent_context.unbounded_max_turns
-               })))
-  in
-  check string "execution timeout event" "completed" execution_timeout.event;
-  check string
-    "execution timeout status"
-    "agent_execution_timeout_observed"
-    execution_timeout.status;
-  check (option string) "execution timeout has no error" None execution_timeout.error;
-  let idle_timeout =
-    Runtime_agent.worker_lifecycle_classification_of_result
-      (Error
-         (Agent_sdk.Error.Agent
-            (Agent_sdk.Error.AgentExecutionIdleTimeout
-               { idle_sec = 120.0
-               ; idle_timeout_sec = 120.0
-               ; turn_count = 4
-               ; max_turns = Runtime_agent_context.unbounded_max_turns
-               })))
-  in
-  check string "idle timeout event" "completed" idle_timeout.event;
-  check string
-    "idle timeout status"
-    "agent_idle_timeout_observed"
-    idle_timeout.status;
-  check (option string) "idle timeout has no error" None idle_timeout.error
-
-let test_runtime_agent_context_uses_configured_turn_limit () =
-  let config =
-    Runtime_agent.default_config
-      ~name:"oas-runpod_mtp.qwen"
-      ~provider_cfg:(provider_cfg ())
-      ~system_prompt:""
-      ~tools:[]
-  in
-  let config = { config with max_turns = 7 } in
-  Eio_main.run (fun env ->
-    Eio.Switch.run (fun sw ->
-      let builder =
-        Runtime_agent_context.builder
-          ~net:(Eio.Stdenv.net env)
-          ~config
-          ()
-      in
-      match Agent_sdk.Builder.build_safe builder with
-      | Error err -> fail (Agent_sdk.Error.to_string err)
-      | Ok agent ->
-        check int "builder max_turns" 7
-          (Agent_sdk.Agent.state agent).config.max_turns;
-        Eio.Switch.on_release sw (fun () ->
-          Agent_sdk.Agent.close agent)));
-  let checkpoint =
-    { Agent_sdk.Checkpoint.version = Agent_sdk.Checkpoint.checkpoint_version
-    ; session_id = "session"
-    ; agent_name = "oas-runpod_mtp.qwen"
-    ; model = "qwen"
-    ; system_prompt = Some ""
-    ; messages = []
-    ; usage = Agent_sdk.Types.empty_usage
-    ; turn_count = 24
-    ; created_at = 0.0
-    ; tools = []
-    ; tool_choice = None
-    ; disable_parallel_tool_use = false
-    ; temperature = Some 0.3
-    ; top_p = None
-    ; top_k = None
-    ; min_p = None
-    ; enable_thinking = None
-    ; preserve_thinking = None
-    ; response_format = Agent_sdk.Types.default_config.response_format
-    ; thinking_budget = None
-    ; cache_system_prompt = false
-    ; context = Agent_sdk.Context.create_sync ()
-    ; mcp_sessions = []
-    ; working_context = None
-    }
-  in
-  let prepared = Runtime_agent_context.prepare_resume ~config ~checkpoint in
-  check int "resume adds fresh generic per-call turn allowance" 31
-    prepared.agent_config.max_turns
-
 let test_runtime_agent_context_preserves_max_tokens_intent () =
   Eio_main.run (fun env ->
     Eio.Switch.run (fun sw ->
@@ -1339,46 +1239,6 @@ let test_runtime_agent_context_preserves_provider_sampling_config () =
     prepared.agent_config.top_k;
   check (option (float 0.0001)) "resume agent min_p" (Some 0.07)
     prepared.agent_config.min_p
-
-let test_runtime_agent_context_preserves_unbounded_resume_budget () =
-  let config =
-    Runtime_agent.default_config
-      ~name:"oas-runpod_mtp.qwen"
-      ~provider_cfg:(provider_cfg ())
-      ~system_prompt:""
-      ~tools:[]
-  in
-  let config = { config with max_turns = Runtime_agent_context.unbounded_max_turns } in
-  let checkpoint =
-    { Agent_sdk.Checkpoint.version = Agent_sdk.Checkpoint.checkpoint_version
-    ; session_id = "session"
-    ; agent_name = "oas-runpod_mtp.qwen"
-    ; model = "qwen"
-    ; system_prompt = Some ""
-    ; messages = []
-    ; usage = Agent_sdk.Types.empty_usage
-    ; turn_count = 24
-    ; created_at = 0.0
-    ; tools = []
-    ; tool_choice = None
-    ; disable_parallel_tool_use = false
-    ; temperature = Some 0.3
-    ; top_p = None
-    ; top_k = None
-    ; min_p = None
-    ; enable_thinking = None
-    ; preserve_thinking = None
-    ; response_format = Agent_sdk.Types.default_config.response_format
-    ; thinking_budget = None
-    ; cache_system_prompt = false
-    ; context = Agent_sdk.Context.create_sync ()
-    ; mcp_sessions = []
-    ; working_context = None
-    }
-  in
-  let prepared = Runtime_agent_context.prepare_resume ~config ~checkpoint in
-  check int "resume preserves unbounded turn allowance" 0
-    prepared.agent_config.max_turns
 
 let test_runtime_agent_context_resume_patches_stale_response_format_to_base_contract () =
   let resume_schema : Yojson.Safe.t =
@@ -1657,14 +1517,6 @@ let () =
             `Quick
             test_runtime_agent_terminal_error_observation_marks_failed_attempt
         ; test_case
-            "execution limits are lifecycle observations"
-            `Quick
-            test_runtime_agent_execution_limits_are_observations
-        ; test_case
-            "runtime agent context uses configured turn limit"
-            `Quick
-            test_runtime_agent_context_uses_configured_turn_limit
-        ; test_case
             "runtime agent context preserves max_tokens intent"
             `Quick
             test_runtime_agent_context_preserves_max_tokens_intent
@@ -1676,10 +1528,6 @@ let () =
             "runtime agent context preserves provider sampling config"
             `Quick
             test_runtime_agent_context_preserves_provider_sampling_config
-        ; test_case
-            "runtime agent context preserves unbounded resume budget"
-            `Quick
-            test_runtime_agent_context_preserves_unbounded_resume_budget
         ; test_case
             "runtime agent context resume patches stale response_format to base contract"
             `Quick


### PR DESCRIPTION
## Summary
- remove max turns, idle turns, execution-time ceilings, and unbounded sentinel plumbing
- remove the retired OAS allowed_paths projection while preserving MASC path jail/sandbox containment
- remove the false Fusion max_tool_calls-to-max_turns claim
- carry only caller-explicit provider max_tokens with no inferred default

No replacement ceiling, sentinel, or budget-exhausted state is introduced.

## Validation
- ocamlformat --check on changed OCaml files
- ocamlc -stop-after parsing on changed OCaml files
- git diff --check
- keeper tool boundary matrix
- focused build advances to the separate exit_condition Host_control migration and retired lifecycle errors

## Scope
34 additions, 350 deletions; 384 total changed lines.