### PR TITLE
refactor(worker): carry exact OAS provider config

### DIFF
--- a/lib/local/worker_container.ml
+++ b/lib/local/worker_container.ml
@@ -328,27 +328,13 @@ let build_oas_mcp_tools ~sw ~auth_token ~session_id ~worker_name =
                }))
     listed_schemas
 
-(** Convert a model label to an OAS Provider.config.
-    Returns Error when the label cannot be parsed. *)
-let oas_provider_of_label (label : string) :
-    (Agent_sdk.Provider.config, string) result =
-  match Runtime_model_string.parse_model_string label with
-  | Some pc -> Ok (Agent_sdk.Provider.config_of_provider_config pc)
-  | None ->
-    let msg = Printf.sprintf "Cannot parse model label: %S (expected provider:model)" label in
-    Log.Misc.error "%s" msg;
-    Error msg
-
 (** Resolve provider from a model label string.
     Returns the provider config and model_id on success. *)
 let resolve_oas_provider_of_label (label : string) :
-    (Agent_sdk.Provider.config * string, string) result =
+    (Llm_provider.Provider_config.t * string, string) result =
   match Runtime_model_string.parse_model_string label with
   | None -> Error (Printf.sprintf "Cannot parse model: %s" label)
-  | Some pc ->
-    Ok
-      ( Agent_sdk.Provider.config_of_provider_config pc,
-        pc.Llm_provider.Provider_config.model_id )
+  | Some pc -> Ok (pc, pc.Llm_provider.Provider_config.model_id)
 
 let make_worker_meta ~base_path ~workspace_path ~worker_name
     ~mcp_session_id ~role ~selection_note ~runtime_backend
@@ -397,15 +383,14 @@ let append_worker_completion_log ~base_path ~worker_name
 
 (** Build (config, options) for Agent.resume — the continue_worker path.
     New workers use Worker_oas.build_agent (Builder pattern) instead.
-    Accepts [~provider] + [~model_id] as resolved values. *)
-let build_resume_config ~worker_name ~provider ~model_id ~system_prompt ~tools
+    The exact provider config is passed directly to [Agent.resume]. *)
+let build_resume_config ~worker_name ~model_id ~system_prompt
     ~thinking_enabled ~hooks ~raw_trace ?(periodic_callbacks = [])
     () =
   let config =
     {
-      Agent_sdk.Types.default_config with
+      (Agent_sdk.Types.default_config ~model:model_id) with
       name = worker_name;
-      model = model_id;
       system_prompt = Some system_prompt;
       enable_thinking = Some thinking_enabled;
     }
@@ -413,7 +398,6 @@ let build_resume_config ~worker_name ~provider ~model_id ~system_prompt ~tools
   let options =
     {
       Agent_sdk.Agent.default_options with
-      provider = Some provider;
       hooks;
       raw_trace = Some raw_trace;
       periodic_callbacks;

--- a/lib/local/worker_container.mli
+++ b/lib/local/worker_container.mli
@@ -8,8 +8,7 @@
     [include module type of struct include M end]
     (cycle 187 rationale).
 
-    External surface (15 entries — 11 dotted callers + 4
-    additional helpers consumed unqualified by
+    External surface (including helpers consumed unqualified by
     {!Worker_container_runners} through the runtime):
     - File paths: {!worker_container_dir},
       {!worker_raw_trace_path},
@@ -22,8 +21,7 @@
       {!evidence_session_id_of_worker_run}.
     - Tool catalogue: {!session_min_tool_names}.
     - Tool builders: {!build_oas_mcp_tools}.
-    - Provider: {!oas_provider_of_label},
-      {!resolve_oas_provider_of_label}.
+    - Provider: {!resolve_oas_provider_of_label}.
     - Audit + run helpers: {!append_worker_completion_log},
       {!build_resume_config}.
 
@@ -157,18 +155,11 @@ val build_oas_mcp_tools :
 
 (** {1 Provider resolution} *)
 
-val oas_provider_of_label :
-  string -> (Agent_sdk.Provider.config, string) result
-(** Parses a model label (e.g. ["openai:gpt-4.1"]) into an
-    {!Agent_sdk.Provider.config}.  Errors when
-    {!Runtime_model_string.parse_model_string} returns [None]. *)
-
 val resolve_oas_provider_of_label :
-  string -> (Agent_sdk.Provider.config * string, string) result
-(** Like {!oas_provider_of_label} but additionally returns
-    the parsed [model_id] so callers do not have to
-    re-parse the label to feed both fields into
-    {!build_resume_config}. *)
+  string -> (Llm_provider.Provider_config.t * string, string) result
+(** Parses a model label into the exact provider config and its declared
+    [model_id]. Errors when {!Runtime_model_string.parse_model_string}
+    returns [None]. *)
 
 (** {1 Turn-log audit trail} *)
 
@@ -192,10 +183,8 @@ val append_worker_completion_log :
 
 val build_resume_config :
   worker_name:string ->
-  provider:Agent_sdk.Provider.config ->
   model_id:string ->
   system_prompt:string ->
-  tools:Agent_sdk.Tool.t list ->
   thinking_enabled:bool ->
   hooks:Agent_sdk.Hooks.hooks ->
   raw_trace:Agent_sdk.Raw_trace.t ->
@@ -204,7 +193,7 @@ val build_resume_config :
   Agent_sdk.Types.agent_config * Agent_sdk.Agent.options
 (** Assembles the [(config, options)] pair consumed by
     [Agent_sdk.Agent.resume].  [config] inherits
-    {!Agent_sdk.Types.default_config} and overrides
-    [name] / [model] / [system_prompt] / [enable_thinking] /
-    [tool_choice = Auto]. Provider/model sampling and output defaults remain
-    OAS-owned. The concrete [tools] list is the tool-exposure SSOT. *)
+    {!Agent_sdk.Types.default_config} for the exact [model_id] and overrides
+    [name] / [system_prompt] / [enable_thinking]. Provider/model sampling and output defaults remain
+    OAS-owned. The concrete provider config is passed separately through
+    [Agent_sdk.Agent.resume ~provider_config]. *)

--- a/lib/local/worker_container_runners.ml
+++ b/lib/local/worker_container_runners.ml
@@ -35,14 +35,6 @@ let workspace_path_of_spec (spec : Worker_execution_spec.t) =
   | Some dir when String.trim dir <> "" -> dir
   | _ -> spec.base_path
 
-let effective_model_of_resume ~existing_meta spec =
-  match existing_meta with
-  | Some meta when String.trim meta.effective_model <> "" ->
-      Ok meta.effective_model
-  | _ ->
-      resolve_oas_provider_of_label spec.Worker_execution_spec.model_label
-      |> Result.map snd
-
 let dedupe_tools_by_name (tools : Agent_sdk.Tool.t list) =
   let rec loop seen acc = function
     | [] -> List.rev acc
@@ -79,21 +71,16 @@ let run_worker_oas ~sw ?net ~workspace_config:_
     let mcp_session_id =
       resolved_mcp_session_id ~base_path ~worker_name
     in
-    let existing_meta = load_worker_meta ~base_path ~worker_name in
     let checkpoint = load_worker_checkpoint ~base_path ~worker_name in
-    let* effective_model =
-      match checkpoint with
-      | Some _ -> effective_model_of_resume ~existing_meta spec
-      | None ->
-          resolve_oas_provider_of_label spec.model_label
-          |> Result.map snd
+    let* provider_config, model_id =
+      resolve_oas_provider_of_label spec.model_label
     in
     let meta =
       make_worker_meta ~base_path ~workspace_path ~worker_name
         ~mcp_session_id ~role:spec.role
         ~selection_note:spec.selection_note
         ~runtime_backend:spec.runtime_backend
-        ~effective_model ~thinking_enabled:spec.thinking_enabled
+        ~effective_model:model_id ~thinking_enabled:spec.thinking_enabled
         ~timeout_seconds:(Some spec.timeout_sec)
     in
     let* auth_token =
@@ -108,19 +95,15 @@ let run_worker_oas ~sw ?net ~workspace_config:_
     match checkpoint with
     | Some checkpoint ->
         Worker_oas.resume_worker_via_oas ~sw ~net ~base_path ~auth_token
-          ~meta ~checkpoint ~prompt:spec.prompt ~tools ~raw_trace
+          ~meta ~provider_config ~checkpoint ~prompt:spec.prompt ~tools ~raw_trace
           ?worker_run_id:spec.worker_run_id ()
     | None ->
-        let* provider, model_id =
-          resolve_oas_provider_of_label spec.model_label
-        in
         let system_prompt =
           default_system_prompt ~worker_name ~model_id
             ?role:spec.role
             ?selection_note:spec.selection_note ()
         in
         Worker_oas.run_worker_via_oas ~sw ~net ~base_path ~auth_token
-          ~meta:{ meta with effective_model = model_id }
-          ~provider ~system_prompt ~prompt:spec.prompt ~tools
+          ~meta ~provider_config ~system_prompt ~prompt:spec.prompt ~tools
           ~raw_trace
           ?worker_run_id:spec.worker_run_id ()

--- a/lib/local/worker_container_runners.mli
+++ b/lib/local/worker_container_runners.mli
@@ -11,9 +11,9 @@
     {!Worker_container_types} surfaces into scope (notably
     [list_masc_tools], [parse_text_tool_calls], [run_result]).
 
-    Internal: 6 helpers stay private — \[resolve_net\],
+    Internal helpers stay private — \[resolve_net\],
     \[build_execution_spec\],
-    \[workspace_path_of_spec\], \[effective_model_of_resume\],
+    \[workspace_path_of_spec\],
     \[dedupe_tools_by_name\], \[create_raw_trace\].  All consumed
     inside the run / preflight pipelines. *)
 
@@ -34,9 +34,9 @@ val run_worker_oas :
     that runs (or resumes) the worker via OAS:
 
     - Resolve net (from [?net] or {!Eio_context}).
-    - Resolve effective model from
-      {!Worker_container.load_worker_meta} when checkpoint
-      exists, otherwise from the spec.
+    - Resolve the spec's model label once into an exact provider config.
+      Cold start and resume receive the same typed value; resume fails
+      explicitly when the checkpoint model differs.
     - Build the MASC/OAS tool set and dedupe by tool name.
     - Create / open raw trace under
       [<base_path>/workers/<worker_name>/raw_trace.jsonl].

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -16,15 +16,6 @@ open Printf
 open Result.Syntax
 
 (* ================================================================ *)
-(* worker_container_meta -> OAS Masc_domain.model                          *)
-(* ================================================================ *)
-
-(** Convert an effective_model string to an OAS model identifier.
-    MASC workers use local Ollama/llama-server models, so all model IDs
-    go through Custom. *)
-let oas_model_of_effective_model (model_id : string) : string = model_id
-
-(* ================================================================ *)
 (* worker_container_meta -> OAS Masc_domain.agent_config                   *)
 (* ================================================================ *)
 
@@ -33,12 +24,12 @@ let oas_model_of_effective_model (model_id : string) : string = model_id
     MASC does not synthesize token, turn, or sampling limits. *)
 let agent_config_of_worker_meta
       (meta : Worker_container_types.worker_container_meta)
+      ~(model : string)
       ~(system_prompt : string)
   : Agent_sdk.Types.agent_config
   =
-  { Agent_sdk.Types.default_config with
+  { (Agent_sdk.Types.default_config ~model) with
     name = meta.worker_name
-  ; model = oas_model_of_effective_model meta.effective_model
   ; system_prompt = Some system_prompt
   ; enable_thinking = Some (Option.value ~default:false meta.thinking_enabled)
   }
@@ -71,13 +62,6 @@ let description_of_meta (meta : Worker_container_types.worker_container_meta) : 
 ;;
 
 (* ================================================================ *)
-(* OAS Provider from MASC model_spec                                 *)
-(* ================================================================ *)
-
-(** Re-use the existing provider mapping from worker_container. *)
-let oas_provider_of_label = Worker_container.oas_provider_of_label
-
-(* ================================================================ *)
 (* Build OAS Agent.t via Builder                                     *)
 (* ================================================================ *)
 
@@ -92,7 +76,7 @@ let oas_provider_of_label = Worker_container.oas_provider_of_label
 let build_agent
       ~(net : [> `Generic | `Unix ] Eio.Net.ty Eio.Resource.t)
       ~(meta : Worker_container_types.worker_container_meta)
-      ~(provider : Agent_sdk.Provider.config)
+      ~(provider_config : Llm_provider.Provider_config.t)
       ~(system_prompt : string)
       ~(tools : Agent_sdk.Tool.t list)
       ~(hooks : Agent_sdk.Hooks.hooks)
@@ -103,14 +87,19 @@ let build_agent
       ()
   : (Agent_sdk.Agent.t, string) result
   =
-  let config = agent_config_of_worker_meta meta ~system_prompt in
+  let config =
+    agent_config_of_worker_meta
+      meta
+      ~model:provider_config.model_id
+      ~system_prompt
+  in
   let builder =
     Agent_sdk.Builder.create ~net ~model:config.model
     |> Agent_sdk.Builder.with_name config.name
     |> Agent_sdk.Builder.with_system_prompt system_prompt
     |> Agent_sdk.Builder.with_enable_thinking
          (Option.value ~default:false meta.thinking_enabled)
-    |> Agent_sdk.Builder.with_provider provider
+    |> Agent_sdk.Builder.with_provider_config provider_config
     |> Agent_sdk.Builder.with_tools tools
     |> Agent_sdk.Builder.with_hooks hooks
     |> Agent_sdk.Builder.with_raw_trace raw_trace
@@ -183,13 +172,8 @@ let make_tool_tracking_hooks ?context () =
             | Agent_sdk.Hooks.PostToolUse _
             | Agent_sdk.Hooks.PostToolUseFailure _
             | Agent_sdk.Hooks.OnStop _
-            | Agent_sdk.Hooks.OnIdle _
-            | Agent_sdk.Hooks.OnIdleEscalated _
             | Agent_sdk.Hooks.OnError _
-            | Agent_sdk.Hooks.OnToolError _
-            | Agent_sdk.Hooks.PreCompact _
-            | Agent_sdk.Hooks.PostCompact _
-            | Agent_sdk.Hooks.OnContextCompacted _ -> Agent_sdk.Hooks.Continue)
+            | Agent_sdk.Hooks.OnToolError _ -> Agent_sdk.Hooks.Continue)
     ; on_error =
         Some
           (function
@@ -203,12 +187,7 @@ let make_tool_tracking_hooks ?context () =
             | Agent_sdk.Hooks.PostToolUse _
             | Agent_sdk.Hooks.PostToolUseFailure _
             | Agent_sdk.Hooks.OnStop _
-            | Agent_sdk.Hooks.OnIdle _
-            | Agent_sdk.Hooks.OnIdleEscalated _
-            | Agent_sdk.Hooks.OnToolError _
-            | Agent_sdk.Hooks.PreCompact _
-            | Agent_sdk.Hooks.PostCompact _
-            | Agent_sdk.Hooks.OnContextCompacted _ -> Agent_sdk.Hooks.Continue)
+            | Agent_sdk.Hooks.OnToolError _ -> Agent_sdk.Hooks.Continue)
     ; on_tool_error =
         Some
           (function
@@ -222,12 +201,7 @@ let make_tool_tracking_hooks ?context () =
             | Agent_sdk.Hooks.PostToolUse _
             | Agent_sdk.Hooks.PostToolUseFailure _
             | Agent_sdk.Hooks.OnStop _
-            | Agent_sdk.Hooks.OnIdle _
-            | Agent_sdk.Hooks.OnIdleEscalated _
-            | Agent_sdk.Hooks.OnError _
-            | Agent_sdk.Hooks.PreCompact _
-            | Agent_sdk.Hooks.PostCompact _
-            | Agent_sdk.Hooks.OnContextCompacted _ -> Agent_sdk.Hooks.Continue)
+            | Agent_sdk.Hooks.OnError _ -> Agent_sdk.Hooks.Continue)
     }
   in
   let hooks =
@@ -255,13 +229,8 @@ let make_tool_tracking_hooks ?context () =
                 | Agent_sdk.Hooks.PostToolUse _
                 | Agent_sdk.Hooks.PostToolUseFailure _
                 | Agent_sdk.Hooks.OnStop _
-                | Agent_sdk.Hooks.OnIdle _
-                | Agent_sdk.Hooks.OnIdleEscalated _
                 | Agent_sdk.Hooks.OnError _
-                | Agent_sdk.Hooks.OnToolError _
-                | Agent_sdk.Hooks.PreCompact _
-                | Agent_sdk.Hooks.PostCompact _
-                | Agent_sdk.Hooks.OnContextCompacted _ -> Agent_sdk.Hooks.Continue)
+                | Agent_sdk.Hooks.OnToolError _ -> Agent_sdk.Hooks.Continue)
         }
       in
       Agent_sdk.Hooks.compose ~outer:temporal ~inner:tracking
@@ -335,7 +304,7 @@ let rec run_worker_via_oas
           ~(base_path : string)
           ~(auth_token : string option)
           ~(meta : Worker_container_types.worker_container_meta)
-          ~(provider : Agent_sdk.Provider.config)
+          ~(provider_config : Llm_provider.Provider_config.t)
           ~(system_prompt : string)
           ~(prompt : string)
           ~(tools : Agent_sdk.Tool.t list)
@@ -359,7 +328,7 @@ let rec run_worker_via_oas
     build_agent
       ~net
       ~meta
-      ~provider
+      ~provider_config
       ~system_prompt
       ~tools
       ~hooks
@@ -392,6 +361,7 @@ and resume_worker_via_oas
       ~(base_path : string)
       ~(auth_token : string option)
       ~(meta : Worker_container_types.worker_container_meta)
+      ~(provider_config : Llm_provider.Provider_config.t)
       ~(checkpoint : Agent_sdk.Checkpoint.t)
       ~(prompt : string)
       ~(tools : Agent_sdk.Tool.t list)
@@ -412,10 +382,15 @@ and resume_worker_via_oas
     make_tool_tracking_hooks ~context:shared_context ()
   in
   let resume_model_id = resume_model_id_of_checkpoint meta checkpoint in
-  let* resume_provider =
-    oas_provider_of_label (resume_model_id)
-    |> Result.map_error (fun e ->
-      Printf.sprintf "checkpoint resume (model %S): %s" resume_model_id e)
+  let* () =
+    if String.equal resume_model_id provider_config.model_id
+    then Ok ()
+    else
+      Error
+        (Printf.sprintf
+           "checkpoint model %S does not match requested provider model %S"
+           resume_model_id
+           provider_config.model_id)
   in
   let system_prompt =
     Worker_container_types.default_system_prompt
@@ -429,10 +404,8 @@ and resume_worker_via_oas
   let config, options =
     Worker_container.build_resume_config
       ~worker_name
-      ~provider:resume_provider
       ~model_id:resume_model_id
       ~system_prompt
-      ~tools
       ~thinking_enabled
       ~hooks
       ~raw_trace
@@ -450,6 +423,7 @@ and resume_worker_via_oas
       ~checkpoint
       ~tools
       ~options
+      ~provider_config
       ~config
       ~context:shared_context
       ()

--- a/lib/worker_oas.mli
+++ b/lib/worker_oas.mli
@@ -10,7 +10,7 @@
 val build_agent :
   net:([ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t) ->
   meta:Worker_container_types.worker_container_meta ->
-  provider:Agent_sdk.Provider.config ->
+  provider_config:Llm_provider.Provider_config.t ->
   system_prompt:string ->
   tools:Agent_sdk.Tool.t list ->
   hooks:Agent_sdk.Hooks.hooks ->
@@ -37,7 +37,7 @@ val run_worker_via_oas :
   base_path:string ->
   auth_token:string option ->
   meta:Worker_container_types.worker_container_meta ->
-  provider:Agent_sdk.Provider.config ->
+  provider_config:Llm_provider.Provider_config.t ->
   system_prompt:string ->
   prompt:string ->
   tools:Agent_sdk.Tool.t list ->
@@ -52,6 +52,7 @@ val resume_worker_via_oas :
   base_path:string ->
   auth_token:string option ->
   meta:Worker_container_types.worker_container_meta ->
+  provider_config:Llm_provider.Provider_config.t ->
   checkpoint:Agent_sdk.Checkpoint.t ->
   prompt:string ->
   tools:Agent_sdk.Tool.t list ->


### PR DESCRIPTION
## Summary
- carry exact Llm_provider.Provider_config.t through Worker cold start and resume
- use Builder.with_provider_config and Agent.resume ~provider_config
- remove lossy Provider.config conversion, local-llama identity inference, and retired hook carriers
- fail explicitly when checkpoint and requested model identity disagree

No URL/model/env inference or compatibility shim is added.

## Validation
- ocamlformat and parsing on changed files
- git diff --check
- focused Worker_oas and Worker_container_runners bytecode builds pass against OAS v0.212.0

## Scope
55 additions, 124 deletions.