### PR TITLE
refactor(keeper): purge retired OAS lifecycle errors

### DIFF
--- a/lib/keeper/keeper_agent_error.ml
+++ b/lib/keeper/keeper_agent_error.ml
@@ -84,10 +84,6 @@ let user_message_of_sdk_error = function
 
 type sdk_termination_semantics =
   | Provider_wall_clock_timeout
-  | Oas_execution_timeout_observed
-  | Oas_turn_limit_observed
-  | Oas_idle_detected_failure
-  | Oas_exit_condition_reached
   | Oas_guardrail_violation
   | Oas_tripwire_violation
   | Oas_input_required
@@ -99,19 +95,13 @@ let sdk_termination_semantics = function
   | Agent_sdk.Error.Provider
       (Llm_provider.Error.NetworkError { timeout_phase = Some _; _ }) ->
     Provider_wall_clock_timeout
-  | Agent_sdk.Error.Agent (Agent_sdk.Error.AgentExecutionTimeout _)
-  | Agent_sdk.Error.Agent (Agent_sdk.Error.AgentExecutionIdleTimeout _) ->
-    Oas_execution_timeout_observed
-  | Agent_sdk.Error.Agent (Agent_sdk.Error.MaxTurnsExceeded _) ->
-    Oas_turn_limit_observed
-  | Agent_sdk.Error.Agent (Agent_sdk.Error.ExitConditionMet _) ->
-    Oas_exit_condition_reached
   | Agent_sdk.Error.Agent (Agent_sdk.Error.GuardrailViolation _) ->
     Oas_guardrail_violation
   | Agent_sdk.Error.Agent (Agent_sdk.Error.TripwireViolation _) ->
     Oas_tripwire_violation
   | Agent_sdk.Error.Agent (Agent_sdk.Error.InputRequired _) -> Oas_input_required
-  | Agent_sdk.Error.Agent (Agent_sdk.Error.UnrecognizedStopReason _) ->
+  | Agent_sdk.Error.Agent (Agent_sdk.Error.UnrecognizedStopReason _)
+  | Agent_sdk.Error.Agent (Agent_sdk.Error.HookExecutionFailed _) ->
     Sdk_error_failure
   | Agent_sdk.Error.Provider _ -> Sdk_error_failure
   | Agent_sdk.Error.Api _ -> Sdk_error_failure
@@ -125,10 +115,6 @@ let sdk_termination_semantics = function
 
 let sdk_termination_semantics_to_string = function
   | Provider_wall_clock_timeout -> "provider_wall_clock_timeout"
-  | Oas_execution_timeout_observed -> "oas_execution_timeout_observed"
-  | Oas_turn_limit_observed -> "oas_turn_limit_observed"
-  | Oas_idle_detected_failure -> "oas_idle_detected_failure"
-  | Oas_exit_condition_reached -> "oas_exit_condition_reached"
   | Oas_guardrail_violation -> "oas_guardrail_violation"
   | Oas_tripwire_violation -> "oas_tripwire_violation"
   | Oas_input_required -> "oas_input_required"
@@ -166,31 +152,13 @@ let api_error_terminal_reason_code (err : Agent_sdk.Error.api_error) : string =
    Previously every Agent failure collapsed to "agent_error", mirroring
    the old Api behaviour. Memory: no-collapse-richer-enum-at-sdk-boundary. *)
 let agent_error_terminal_reason_code = function
-  | Agent_sdk.Error.MaxTurnsExceeded { turns; limit } ->
-    Printf.sprintf
-      "agent_error_max_turns_exceeded:turns=%d,limit=%d"
-      turns
-      limit
-  | Agent_sdk.Error.AgentExecutionTimeout
-      { elapsed_sec; timeout_sec; turn_count; max_turns } ->
-    Printf.sprintf
-      "agent_error_execution_timeout:elapsed_sec=%.1f,timeout_sec=%.1f,turn_count=%d,max_turns=%d"
-      elapsed_sec
-      timeout_sec
-      turn_count
-      max_turns
-  | Agent_sdk.Error.AgentExecutionIdleTimeout
-      { idle_sec; idle_timeout_sec; turn_count; max_turns } ->
-    Printf.sprintf
-      "agent_error_idle_timeout:idle_sec=%.1f,idle_timeout_sec=%.1f,turn_count=%d,max_turns=%d"
-      idle_sec
-      idle_timeout_sec
-      turn_count
-      max_turns
-  | Agent_sdk.Error.ExitConditionMet { turn } ->
-    Printf.sprintf "agent_error_exit_condition_met:turn=%d" turn
   | Agent_sdk.Error.UnrecognizedStopReason { reason } ->
     Printf.sprintf "agent_error_unrecognized_stop_reason:%s" reason
+  | Agent_sdk.Error.HookExecutionFailed { hook_name; stage; _ } ->
+    Printf.sprintf
+      "agent_error_hook_execution_failed:hook=%s,stage=%s"
+      hook_name
+      stage
   | Agent_sdk.Error.GuardrailViolation { validator; reason = _ } ->
     Printf.sprintf "agent_error_guardrail_violation:validator=%s" validator
   | Agent_sdk.Error.TripwireViolation { tripwire; reason = _ } ->
@@ -267,7 +235,7 @@ let terminal_reason_code_of_sdk_error = function
    above) wrapped in [Keeper_turn_terminal_code.Sdk_error]. PR-3 swaps
    [Keeper_turn_terminal.t.code] from [string] to [Keeper_turn_terminal_code.t]
    and uses these typed accessors at every emit site. RFC §5.2 defers the
-   sub-sum split (per-variant constructors for [MaxTurnsExceeded] etc.) to
+   sub-sum split (per-variant constructors for Agent errors) to
    a follow-up RFC. *)
 let terminal_reason_code_of_sdk_error_typed err =
   Keeper_turn_terminal_code.of_sdk_error_wire (terminal_reason_code_of_sdk_error err)
@@ -279,10 +247,7 @@ let api_error_terminal_reason_code_typed err =
 
 let receipt_outcome_kind_of_sdk_error err =
   match sdk_termination_semantics err with
-  | Provider_wall_clock_timeout | Oas_exit_condition_reached -> `Cancelled
-  | Oas_execution_timeout_observed
-  | Oas_turn_limit_observed -> `Ok
-  | Oas_idle_detected_failure -> `Error
+  | Provider_wall_clock_timeout -> `Cancelled
   | Oas_input_required -> `Cancelled
   | Oas_guardrail_violation
   | Oas_tripwire_violation

--- a/lib/keeper/keeper_agent_error.mli
+++ b/lib/keeper/keeper_agent_error.mli
@@ -21,10 +21,6 @@ val user_message_of_sdk_error : Agent_sdk.Error.sdk_error -> string
     Keeper pause, retry, or blocker authority. *)
 type sdk_termination_semantics =
   | Provider_wall_clock_timeout
-  | Oas_execution_timeout_observed
-  | Oas_turn_limit_observed
-  | Oas_idle_detected_failure
-  | Oas_exit_condition_reached
   | Oas_guardrail_violation
   | Oas_tripwire_violation
   | Oas_input_required

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -19,7 +19,6 @@ open Keeper_context_runtime
 type error_classification =
   | Transient_network
   | Transient_internal_runner
-  | Oas_execution_observed
   | Transient_rate_limit
   | Transient_capacity
   | Non_transient
@@ -94,15 +93,16 @@ let classify_error (err : Agent_sdk.Error.sdk_error) : error_classification =
   | Agent_sdk.Error.Provider (Llm_provider.Error.MissingApiKey _) -> Non_transient
   | Agent_sdk.Error.Provider (Llm_provider.Error.InvalidConfig _) -> Non_transient
   | Agent_sdk.Error.Provider (Llm_provider.Error.UnknownVariant _) -> Unclassified
-  | Agent_sdk.Error.Agent
-      ( MaxTurnsExceeded _
-      | AgentExecutionTimeout _
-      | AgentExecutionIdleTimeout _ ) ->
-      Oas_execution_observed
   | Agent_sdk.Error.Api (InvalidRequest _ | ServerError _ | AuthError _
     | AuthorizationError _
     | NotFound _ | PaymentRequired _ | ContextOverflow _) -> Non_transient
-  | Agent_sdk.Error.Agent _ | Agent_sdk.Error.Mcp _
+  | Agent_sdk.Error.Agent (HookExecutionFailed _) -> Non_transient
+  | Agent_sdk.Error.Agent
+      ( UnrecognizedStopReason _
+      | GuardrailViolation _
+      | TripwireViolation _
+      | InputRequired _ )
+  | Agent_sdk.Error.Mcp _
   | Agent_sdk.Error.Config _ | Agent_sdk.Error.Serialization _
   | Agent_sdk.Error.Io _ | Agent_sdk.Error.Orchestration _
   | Agent_sdk.Error.Internal _ -> Unclassified
@@ -718,13 +718,10 @@ let is_context_overflow (err : Agent_sdk.Error.sdk_error) : bool =
   | Agent_sdk.Error.Api (Timeout _) -> false
   | Agent_sdk.Error.Provider _ -> false
   (* Other agent error variants. *)
-  | Agent_sdk.Error.Agent (MaxTurnsExceeded _)
-  | Agent_sdk.Error.Agent (AgentExecutionTimeout _)
-  | Agent_sdk.Error.Agent (AgentExecutionIdleTimeout _)
   | Agent_sdk.Error.Agent (UnrecognizedStopReason _)
+  | Agent_sdk.Error.Agent (HookExecutionFailed _)
   | Agent_sdk.Error.Agent (GuardrailViolation _)
-  | Agent_sdk.Error.Agent (TripwireViolation _)
-  | Agent_sdk.Error.Agent (ExitConditionMet _) -> false
+  | Agent_sdk.Error.Agent (TripwireViolation _) -> false
   | Agent_sdk.Error.Agent (InputRequired _) -> false
   (* Non-API / non-Agent error families. *)
   | Agent_sdk.Error.Mcp _
@@ -735,8 +732,7 @@ let is_context_overflow (err : Agent_sdk.Error.sdk_error) : bool =
   | Agent_sdk.Error.Internal _ -> false
 
 let is_auto_recoverable_turn_error (err : Agent_sdk.Error.sdk_error) : bool =
-  classify_error err = Oas_execution_observed
-  || is_transient_network_error err
+  is_transient_network_error err
   || is_server_rejected_parse_error err
   || is_auto_recoverable_runtime_exhausted_error err
   (* Context overflow is handled explicitly by
@@ -784,13 +780,10 @@ let extract_input_required (err : Agent_sdk.Error.sdk_error)
 let is_input_required_error (err : Agent_sdk.Error.sdk_error) : bool =
   match err with
   | Agent_sdk.Error.Agent (Agent_sdk.Error.InputRequired _) -> true
-  | Agent_sdk.Error.Agent (MaxTurnsExceeded _)
-  | Agent_sdk.Error.Agent (AgentExecutionTimeout _)
-  | Agent_sdk.Error.Agent (AgentExecutionIdleTimeout _)
   | Agent_sdk.Error.Agent (UnrecognizedStopReason _)
+  | Agent_sdk.Error.Agent (HookExecutionFailed _)
   | Agent_sdk.Error.Agent (GuardrailViolation _)
-  | Agent_sdk.Error.Agent (TripwireViolation _)
-  | Agent_sdk.Error.Agent (ExitConditionMet _) -> false
+  | Agent_sdk.Error.Agent (TripwireViolation _) -> false
   | Agent_sdk.Error.Api _
   | Agent_sdk.Error.Provider _
   | Agent_sdk.Error.Mcp _

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -4,7 +4,6 @@
 type error_classification =
   | Transient_network
   | Transient_internal_runner
-  | Oas_execution_observed
   | Transient_rate_limit
   | Transient_capacity
   | Non_transient

--- a/lib/keeper/keeper_event_bridge_error_json.ml
+++ b/lib/keeper/keeper_event_bridge_error_json.ml
@@ -1,4 +1,5 @@
 let stop_reason_to_wire = Agent_sdk.Types.stop_reason_to_string
+let sha256_hex value = Digestif.SHA256.(digest_string value |> to_hex)
 
 let agent_completed_usage_fields (response : Agent_sdk.Types.api_response) =
   match response.usage with
@@ -90,10 +91,17 @@ let sdk_api_error_fields = function
 ;;
 
 let sdk_agent_error_fields = function
-  | Agent_sdk.Error.MaxTurnsExceeded { turns; limit } ->
-    [ "variant", `String "max_turns_exceeded"; "turns", `Int turns; "limit", `Int limit ]
   | Agent_sdk.Error.UnrecognizedStopReason { reason } ->
     [ "variant", `String "unrecognized_stop_reason"; "reason", `String reason ]
+  | Agent_sdk.Error.HookExecutionFailed
+      { hook_name; stage; tool_name; tool_use_id; detail } ->
+    [ "variant", `String "hook_execution_failed"
+    ; "hook_name", `String hook_name
+    ; "stage", `String stage
+    ; "tool_name", Json_util.string_opt_to_json tool_name
+    ; "tool_use_id", Json_util.string_opt_to_json tool_use_id
+    ; "detail_digest", `String (sha256_hex detail)
+    ]
   | Agent_sdk.Error.GuardrailViolation { validator; reason } ->
     [ "variant", `String "guardrail_violation"
     ; "validator", `String validator
@@ -104,29 +112,11 @@ let sdk_agent_error_fields = function
     ; "tripwire", `String tripwire
     ; "reason", `String reason
     ]
-  | Agent_sdk.Error.ExitConditionMet { turn } ->
-    [ "variant", `String "exit_condition_met"; "turn", `Int turn ]
   | Agent_sdk.Error.InputRequired { request_id; participant_name; question; _ } ->
     [ "variant", `String "input_required"
     ; "request_id", `String request_id
     ; "participant_name", Json_util.string_opt_to_json participant_name
     ; "question", `String question
-    ]
-  | Agent_sdk.Error.AgentExecutionTimeout
-      { elapsed_sec; timeout_sec; turn_count; max_turns } ->
-    [ "variant", `String "agent_execution_timeout"
-    ; "elapsed_sec", `Float elapsed_sec
-    ; "timeout_sec", `Float timeout_sec
-    ; "turn_count", `Int turn_count
-    ; "max_turns", `Int max_turns
-    ]
-  | Agent_sdk.Error.AgentExecutionIdleTimeout
-      { idle_sec; idle_timeout_sec; turn_count; max_turns } ->
-    [ "variant", `String "agent_idle_timeout"
-    ; "idle_sec", `Float idle_sec
-    ; "idle_timeout_sec", `Float idle_timeout_sec
-    ; "turn_count", `Int turn_count
-    ; "max_turns", `Int max_turns
     ]
 ;;
 

--- a/lib/keeper/keeper_status_bridge_blocker.ml
+++ b/lib/keeper/keeper_status_bridge_blocker.ml
@@ -48,14 +48,11 @@ let blocker_class_of_sdk_error (err : Agent_sdk.Error.sdk_error) : blocker_class
   | None ->
     (match err with
      | Agent_sdk.Error.Internal _ -> None
-     | Agent_sdk.Error.Agent (Agent_sdk.Error.AgentExecutionTimeout _)
-     | Agent_sdk.Error.Agent (Agent_sdk.Error.AgentExecutionIdleTimeout _)
-     | Agent_sdk.Error.Agent (MaxTurnsExceeded _) -> None
+     | Agent_sdk.Error.Agent (HookExecutionFailed _) -> None
      | Agent_sdk.Error.Agent (UnrecognizedStopReason _) ->
        Some Sdk_unrecognized_stop_reason
      | Agent_sdk.Error.Agent (GuardrailViolation _) -> Some Sdk_guardrail_violation
      | Agent_sdk.Error.Agent (TripwireViolation _) -> Some Sdk_tripwire_violation
-     | Agent_sdk.Error.Agent (ExitConditionMet _) -> Some Sdk_exit_condition_met
      | Agent_sdk.Error.Agent (InputRequired _) -> Some Sdk_input_required
      (* Provider-level [Api] errors are surfaced via OAS retry / runtime
          layers and do not map to a typed blocker_class by themselves. *)

--- a/lib/keeper/keeper_turn_disposition.mli
+++ b/lib/keeper/keeper_turn_disposition.mli
@@ -29,8 +29,7 @@ type t =
   | External_cancel
   (** Turn cancelled before completion (operator stop, switch_keeper, …). *)
   | Input_required
-  (** Agent paused to request human input. Not a failure — a special
-          stop condition analogous to [ExitConditionMet]. Operator action:
+  (** Agent emitted a typed input request. Not a failure. Operator action:
           provide input or decline. *)
   | Turn_wall_clock_timeout (** Turn exceeded its wall-clock budget. *)
   | Runtime_attempts_exhausted

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -688,12 +688,6 @@ let run_keeper_cycle
                   let e_str = Agent_sdk.Error.to_string err in
                   let is_transient = EC.is_transient_network_error err in
                   (match err with
-                      | Agent_sdk.Error.Agent
-                          (AgentExecutionTimeout _ | AgentExecutionIdleTimeout _) ->
-                        Otel_metric_store.inc_counter
-                          Keeper_metrics.(to_string OasTimeoutClassifications)
-                          ~labels:[ "classification", "oas_execution_observed" ]
-                          ()
                       | Agent_sdk.Error.Api (Timeout _) ->
                         Otel_metric_store.inc_counter
                           Keeper_metrics.(to_string OasTimeoutClassifications)

--- a/test/sse_event/test_sse_event.ml
+++ b/test/sse_event/test_sse_event.ml
@@ -688,21 +688,23 @@ let agent_completed_ok_fields : (string * Yojson.Safe.t) list =
 let agent_completed_error_fields : (string * Yojson.Safe.t) list =
   [ "success", `Bool false
   ; "result", `String "error"
-  ; "error", `String "MaxTurnsExceeded { turns = 20; limit = 20 }"
+  ; "error", `String "HookExecutionFailed { hook_name = post_tool_use }"
   ; "usage_reported", `Bool false
   ]
 ;;
 
-let agent_failed_error : string = "MaxTurnsExceeded { turns = 20; limit = 20 }"
-let agent_failed_error_domain : string = "max_turns"
-let agent_failed_error_code : string = "max_turns_exceeded"
+let agent_failed_error : string =
+  "HookExecutionFailed { hook_name = post_tool_use }"
+
+let agent_failed_error_domain : string = "agent"
+let agent_failed_error_code : string = "hook_execution_failed"
 let agent_failed_error_retryable : bool = false
 
 let agent_failed_error_detail : Yojson.Safe.t =
   `Assoc
-    [ "variant", `String "max_turns_exceeded"
-    ; "turns", `Int 20
-    ; "limit", `Int 20
+    [ "variant", `String "hook_execution_failed"
+    ; "hook_name", `String "post_tool_use"
+    ; "stage", `String "execute"
     ]
 ;;
 

--- a/test/test_blocker_class_exhaustiveness.ml
+++ b/test/test_blocker_class_exhaustiveness.ml
@@ -108,28 +108,21 @@ module Reg = Masc.Keeper_registry
     observation/control checkpoint for which [None] is correct. *)
 
 let all_sdk_agent_variants : (string * SdkE.sdk_error) list =
-  [ ( "AgentExecutionTimeout"
-    , SdkE.Agent
-        (SdkE.AgentExecutionTimeout
-           { elapsed_sec = 10.0; timeout_sec = 5.0; turn_count = 3; max_turns = 10 })
-    )
-  ; ( "AgentExecutionIdleTimeout"
-    , SdkE.Agent
-        (SdkE.AgentExecutionIdleTimeout
-           { idle_sec = 10.0; idle_timeout_sec = 5.0; turn_count = 3; max_turns = 10 })
-    )
-  ; ( "MaxTurnsExceeded"
-    , SdkE.Agent (SdkE.MaxTurnsExceeded { turns = 10; limit = 10 }) )
-  ; ( "UnrecognizedStopReason"
+  [ ( "UnrecognizedStopReason"
     , SdkE.Agent (SdkE.UnrecognizedStopReason { reason = "abrupt" }) )
-  ; ( "IdleDetected"
-    , SdkE.Agent (SdkE.IdleDetected { consecutive_idle_turns = 3 }) )
+  ; ( "HookExecutionFailed"
+    , SdkE.Agent
+        (SdkE.HookExecutionFailed
+           { hook_name = "post_tool_use"
+           ; stage = "execute"
+           ; tool_name = Some "Execute"
+           ; tool_use_id = Some "tool-1"
+           ; detail = "hook failed"
+           }) )
   ; ( "GuardrailViolation"
     , SdkE.Agent (SdkE.GuardrailViolation { validator = "content_filter"; reason = "toxic" }) )
   ; ( "TripwireViolation"
     , SdkE.Agent (SdkE.TripwireViolation { tripwire = "disallow_shell"; reason = "exec detected" }) )
-  ; ( "ExitConditionMet"
-    , SdkE.Agent (SdkE.ExitConditionMet { turn = 5 }) )
   ; ( "InputRequired"
     , SdkE.Agent
         (SdkE.InputRequired
@@ -144,10 +137,7 @@ let all_sdk_agent_variants : (string * SdkE.sdk_error) list =
 ;;
 
 let agent_variants_with_no_runtime_blocker =
-  [ "AgentExecutionTimeout"
-  ; "AgentExecutionIdleTimeout"
-  ; "MaxTurnsExceeded"
-  ]
+  [ "HookExecutionFailed" ]
 
 let test_all_agent_variants_classified_intentionally () =
   List.iter
@@ -175,7 +165,7 @@ let test_all_agent_variants_classified_intentionally () =
 (** Pin the Agent sub-variant count so additions are visible in diffs.
     When the SDK adds a new [Agent] sub-variant, bump this number and add it
     to [all_sdk_agent_variants]. *)
-let expected_agent_variant_count = 9
+let expected_agent_variant_count = 5
 
 let test_agent_variant_count_pin () =
   let count = List.length all_sdk_agent_variants in

--- a/test/test_keeper_execution_join.ml
+++ b/test/test_keeper_execution_join.ml
@@ -131,8 +131,21 @@ let test_agent_failed_matches_typed_sse_event () =
   let task_id = "task-failed-1" in
   let elapsed_s = 4.25 in
   let caused_by = "run-agent-started-1" in
-  let error = Agent_sdk.Error.Internal "bridge failure" in
+  let error =
+    Agent_sdk.Error.Agent
+      (Agent_sdk.Error.HookExecutionFailed
+         { hook_name = "post_tool_use"
+         ; stage = "execute"
+         ; tool_name = Some "Execute"
+         ; tool_use_id = Some "tool-1"
+         ; detail = "hook failed"
+         })
+  in
   let projection = Error_json.agent_failed_error_projection error in
+  check (option string)
+    "hook failure variant"
+    (Some "hook_execution_failed")
+    (string_of_field (member "variant" projection.error_detail));
   let actual =
     Bridge.native_event_to_json
       (mk_event

--- a/test/test_keeper_failure_judgment_contract.ml
+++ b/test/test_keeper_failure_judgment_contract.ml
@@ -155,14 +155,6 @@ let test_typed_judge_error_disposition () =
                 })
        });
   check_disposition
-    "judge idle loop terminates instead of requeueing itself"
-    (Keeper_failure_judge.Oas_error
-       { runtime_id = "structured-judge"
-       ; error =
-           Agent_sdk.Error.Agent
-             (Agent_sdk.Error.IdleDetected { consecutive_idle_turns = 15 })
-       });
-  check_disposition
     "response contract error escalates"
     (Keeper_failure_judge.Response_contract_error
        { runtime_id = "structured-judge"; detail = "invalid JSON" })

--- a/test/test_keeper_runtime_failure_route.ml
+++ b/test/test_keeper_runtime_failure_route.ml
@@ -189,22 +189,6 @@ let test_non_provider_families_judge () =
      Alcotest.failf
        "MASC-produced raw Internal must preserve its actual boundary, got %s"
        (KFR.route_kind_label other));
-  (* An idle loop is a behavioral contract judgment, not an opaque internal
-     error or lifecycle transition. *)
-  (match
-     route_of_oas_error
-       (Agent_sdk.Error.Agent
-          (Agent_sdk.Error.IdleDetected { consecutive_idle_turns = 3 }))
-   with
-   | KFR.Escalate_judgment
-       { judgment = KFR.Contract_violation
-       ; provenance = KFR.Oas_agent_idle_detected { consecutive_idle_turns = 3 }
-       ; _
-       } ->
-     ()
-   | other ->
-     Alcotest.failf "idle loop should judge contract, got %s"
-       (KFR.route_kind_label other));
   match
     route_of_oas_error
       (Agent_sdk.Error.Mcp (Agent_sdk.Error.InitializeFailed { detail = "handshake" }))

--- a/test/test_keeper_sdk_error_typed_bridge.ml
+++ b/test/test_keeper_sdk_error_typed_bridge.ml
@@ -19,8 +19,6 @@ module Code = Masc.Keeper_turn_terminal_code
 module EC = Masc.Keeper_error_classify
 module KFR = Keeper_runtime_failure_route
 module KTD = Masc.Keeper_turn_driver
-module KRB = Masc.Keeper_turn_runtime_budget
-module KSB = Masc.Keeper_status_bridge
 module RC = Runtime_candidate
 module SdkE = Agent_sdk.Error
 module Retry = Agent_sdk.Retry
@@ -69,27 +67,19 @@ let api_cases : (string * SdkE.api_error * string) list =
 
 (* All variants reached through the top-level dispatcher. *)
 let sdk_cases : (string * SdkE.sdk_error * string) list =
-  [ ( "Agent/MaxTurnsExceeded"
-    , SdkE.Agent (SdkE.MaxTurnsExceeded { turns = 10; limit = 10 })
-    , "agent_error_max_turns_exceeded:turns=10,limit=10" )
-  ; ( "Agent/AgentExecutionTimeout"
+  [ ( "Agent/HookExecutionFailed"
     , SdkE.Agent
-        (SdkE.AgentExecutionTimeout
-           { elapsed_sec = 572.5
-           ; timeout_sec = 555.0
-           ; turn_count = 24
-           ; max_turns = 340
+        (SdkE.HookExecutionFailed
+           { hook_name = "post_tool_use"
+           ; stage = "execute"
+           ; tool_name = Some "Execute"
+           ; tool_use_id = Some "tool-1"
+           ; detail = "hook failed"
            })
-    , "agent_error_execution_timeout:elapsed_sec=572.5,timeout_sec=555.0,turn_count=24,max_turns=340" )
-  ; ( "Agent/ExitConditionMet"
-    , SdkE.Agent (SdkE.ExitConditionMet { turn = 5 })
-    , "agent_error_exit_condition_met:turn=5" )
+    , "agent_error_hook_execution_failed:hook=post_tool_use,stage=execute" )
   ; ( "Agent/UnrecognizedStopReason"
     , SdkE.Agent (SdkE.UnrecognizedStopReason { reason = "abrupt" })
     , "agent_error_unrecognized_stop_reason:abrupt" )
-  ; ( "Agent/IdleDetected"
-    , SdkE.Agent (SdkE.IdleDetected { consecutive_idle_turns = 3 })
-    , "agent_error_idle_detected:consecutive_idle_turns=3" )
   ; ( "Api/Timeout"
     , SdkE.Api (Retry.Timeout { message = "60s"; phase = None })
     , "api_error_timeout" )
@@ -128,102 +118,6 @@ let test_sdk_typed_wire () =
        let actual = typed_wire (AE.terminal_reason_code_of_sdk_error_typed err) in
        Alcotest.(check string) ("sdk/" ^ label) expected actual)
     sdk_cases
-;;
-
-let test_idle_detected_receipt_is_failure () =
-  let outcome =
-    AE.receipt_outcome_kind_of_sdk_error
-      (SdkE.Agent (SdkE.IdleDetected { consecutive_idle_turns = 3 }))
-  in
-  Alcotest.(check string)
-    "IdleDetected is not cancellation"
-    "error"
-    (Masc.Keeper_execution_receipt.outcome_kind_to_string outcome)
-;;
-
-let test_execution_limit_observations_are_successful_receipts () =
-  let observations =
-    [ ( "max turns"
-      , SdkE.Agent (SdkE.MaxTurnsExceeded { turns = 10; limit = 10 }) )
-    ; ( "execution timeout"
-      , SdkE.Agent
-          (SdkE.AgentExecutionTimeout
-             { elapsed_sec = 60.0
-             ; timeout_sec = 60.0
-             ; turn_count = 2
-             ; max_turns = 10
-             }) )
-    ; ( "idle timeout"
-      , SdkE.Agent
-          (SdkE.AgentExecutionIdleTimeout
-             { idle_sec = 60.0
-             ; idle_timeout_sec = 60.0
-             ; turn_count = 2
-             ; max_turns = 10
-             }) )
-    ]
-  in
-  List.iter
-    (fun (label, error) ->
-       let outcome = AE.receipt_outcome_kind_of_sdk_error error in
-       Alcotest.(check string)
-         (label ^ " remains a successful observation")
-         "ok"
-         (Masc.Keeper_execution_receipt.outcome_kind_to_string outcome))
-    observations
-;;
-
-let test_execution_limit_observations_have_no_keeper_authority () =
-  let observations =
-    [ ( "max turns"
-      , SdkE.Agent (SdkE.MaxTurnsExceeded { turns = 10; limit = 10 }) )
-    ; ( "execution timeout"
-      , SdkE.Agent
-          (SdkE.AgentExecutionTimeout
-             { elapsed_sec = 60.0
-             ; timeout_sec = 60.0
-             ; turn_count = 2
-             ; max_turns = 10
-             }) )
-    ; ( "idle timeout"
-      , SdkE.Agent
-          (SdkE.AgentExecutionIdleTimeout
-             { idle_sec = 60.0
-             ; idle_timeout_sec = 60.0
-             ; turn_count = 2
-             ; max_turns = 10
-             }) )
-    ]
-  in
-  List.iter
-    (fun (label, error) ->
-       Alcotest.(check bool)
-         (label ^ " is typed as an OAS execution observation")
-         true
-         (EC.classify_error error = EC.Oas_execution_observed);
-       Alcotest.(check bool)
-         (label ^ " cannot increment the turn failure streak")
-         true
-         (EC.is_auto_recoverable_turn_error error);
-       Alcotest.(check bool)
-         (label ^ " grants no runtime rotation")
-         true
-         (EC.recoverable_runtime_failure_reason error = None);
-       Alcotest.(check bool)
-         (label ^ " grants no blocker")
-         true
-         (KSB.blocker_class_of_sdk_error error = None);
-       match
-         KRB.decide_degraded_retry
-           ~base_runtime:"observation.base"
-           ~effective_runtime:"observation.effective"
-           ~attempted_runtimes:[]
-           error
-       with
-       | KRB.No_degraded_retry -> ()
-       | KRB.Degraded_retry_allowed _ ->
-         Alcotest.failf "%s unexpectedly authorized degraded retry" label)
-    observations
 ;;
 
 let check_parse_split label err ~provider ~model_ ~server =
@@ -471,7 +365,6 @@ let test_soft_rate_limit_classifies_as_rate_limit () =
 let classification_to_string = function
   | EC.Transient_network -> "transient_network"
   | EC.Transient_internal_runner -> "transient_internal_runner"
-  | EC.Oas_execution_observed -> "oas_execution_observed"
   | EC.Transient_rate_limit -> "transient_rate_limit"
   | EC.Transient_capacity -> "transient_capacity"
   | EC.Non_transient -> "non_transient"
@@ -521,16 +414,6 @@ let test_static_error_classification_preserves_retry_semantics () =
     "api transport timeout"
     EC.Transient_network
     (SdkE.Api (Retry.Timeout { message = "read timed out"; phase = None }));
-  check_classification
-    "typed agent execution timeout"
-    EC.Oas_execution_observed
-    (SdkE.Agent
-       (SdkE.AgentExecutionTimeout
-          { elapsed_sec = 60.0
-          ; timeout_sec = 60.0
-          ; turn_count = 2
-          ; max_turns = 10
-          }));
   check_classification
     "internal runner tls"
     EC.Transient_internal_runner
@@ -911,18 +794,6 @@ let () =
             "all sdk_error cases produce expected wire"
             `Quick
             test_sdk_typed_wire
-        ; Alcotest.test_case
-            "IdleDetected receipt remains a failure"
-            `Quick
-            test_idle_detected_receipt_is_failure
-        ; Alcotest.test_case
-            "execution limits do not impersonate cancellation"
-            `Quick
-            test_execution_limit_observations_are_successful_receipts
-        ; Alcotest.test_case
-            "execution limits have no Keeper authority"
-            `Quick
-            test_execution_limit_observations_have_no_keeper_authority
         ] )
     ; ( "server parse rejection split"
       , [ Alcotest.test_case

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -1595,32 +1595,6 @@ let test_no_candidates_exhaustion_classifies_as_no_providers_available () =
     Alcotest.failf "expected typed keeper error, got %s"
       (Agent_sdk.Error.to_string mapped)
 
-let test_provider_turn_limit_remains_an_execution_observation () =
-  let mapped =
-    Agent_sdk.Error.Agent
-      (Agent_sdk.Error.MaxTurnsExceeded { turns = 12; limit = 12 })
-  in
-  (match mapped with
-   | Agent_sdk.Error.Agent (Agent_sdk.Error.MaxTurnsExceeded { turns; limit }) ->
-     Alcotest.(check int) "turns preserved" 12 turns;
-     Alcotest.(check int) "limit preserved" 12 limit
-   | _ ->
-     Alcotest.failf
-       "expected typed MaxTurnsExceeded observation, got %s"
-       (Agent_sdk.Error.to_string mapped));
-  Alcotest.(check bool)
-    "provider turn limit is not runtime exhaustion"
-    false
-    (Masc.Keeper_error_classify.is_runtime_exhausted_error mapped);
-  Alcotest.(check bool)
-    "provider turn limit cannot increment Keeper failure streak"
-    true
-    (Masc.Keeper_error_classify.is_auto_recoverable_turn_error mapped);
-  Alcotest.(check bool)
-    "provider turn limit grants no blocker"
-    true
-    (Masc.Keeper_status_bridge.blocker_class_of_sdk_error mapped = None)
-
 let test_capacity_failure_exhaustion_classifies_as_capacity_exhausted () =
   let mapped =
     Keeper_internal_error.sdk_error_of_masc_internal_error
@@ -1820,10 +1794,6 @@ let () =
             "no-candidates exhaustion classifies as No_providers_available"
             `Quick
             test_no_candidates_exhaustion_classifies_as_no_providers_available;
-          Alcotest.test_case
-            "provider turn limit stays an execution observation"
-            `Quick
-            test_provider_turn_limit_remains_an_execution_observation;
           Alcotest.test_case
             "capacity exhaustion classifies as retryable Runtime_exhausted"
             `Quick


### PR DESCRIPTION
## What

- remove MASC projections for OAS lifecycle constructors deleted in 0.212 (`MaxTurnsExceeded`, execution/idle timeouts, `IdleDetected`, `ExitConditionMet`)
- keep the current typed `HookExecutionFailed` failure surface, including redacted detail digest
- delete tests whose only purpose was preserving retired implicit lifecycle-limit behavior

## Boundary

No replacement ceiling, sentinel, compatibility shim, or string inference is introduced. MASC now matches the five current typed OAS agent-error variants. The remaining `runtime_agent` execution/exit-condition adapter is intentionally a separate <400-line cut.

## Verification

- 397 changed lines (76 additions, 321 deletions)
- `ocamlformat` on all changed OCaml files
- `ocamlc -stop-after parsing` on all changed OCaml files
- focused Dune object build passed for `Keeper_agent_error`, `Keeper_error_classify`, `Keeper_event_bridge_error_json`, `Keeper_status_bridge_blocker`, and `Keeper_unified_turn`

[근거] installed `agent_sdk.base` 0.212 interface at `/Users/dancer/.opam/5.5.0/lib/agent_sdk/base/error.mli`; checked 2026-07-15 KST; confidence High.