### PR TITLE
refactor(events): make subscriber queues explicit

### DIFF
--- a/lib/agent_sdk_metrics_bridge.ml
+++ b/lib/agent_sdk_metrics_bridge.ml
@@ -1,7 +1,14 @@
 type handle = Agent_sdk.Event_bus.subscription
 
-let subscribe ~purpose ?(filter = Agent_sdk.Event_bus.accept_all) bus =
-  Agent_sdk.Event_bus.subscribe ~filter ~purpose bus
+let subscribe ~capacity ~overflow ~purpose ?filter bus =
+  match Agent_sdk.Event_bus.subscription_config ~capacity ~overflow with
+  | Ok config -> Agent_sdk.Event_bus.subscribe ~config ?filter ~purpose bus
+  | Error (Agent_sdk.Event_bus.Non_positive_capacity capacity) ->
+    invalid_arg
+      (Printf.sprintf
+         "Event_bus subscriber %S has non-positive capacity %d"
+         purpose
+         capacity)
 ;;
 
 let drain handle =

--- a/lib/agent_sdk_metrics_bridge.mli
+++ b/lib/agent_sdk_metrics_bridge.mli
@@ -7,10 +7,14 @@
 type handle
 
 val subscribe
-  :  purpose:string
+  :  capacity:int
+  -> overflow:Agent_sdk.Event_bus.overflow
+  -> purpose:string
   -> ?filter:Agent_sdk.Event_bus.filter
   -> Agent_sdk.Event_bus.t
   -> handle
+(** Subscribe with a subscriber-owned queue contract. Invalid capacities fail
+    explicitly before the subscription is installed. *)
 
 val drain : handle -> Agent_sdk.Event_bus.event list
 val unsubscribe : Agent_sdk.Event_bus.t -> handle -> unit

--- a/lib/keeper/keeper_compact_audit.ml
+++ b/lib/keeper/keeper_compact_audit.ml
@@ -530,6 +530,8 @@ let spawn_subscriber
   in
   let sub =
     Agent_sdk_metrics_bridge.subscribe
+      ~capacity:256
+      ~overflow:Agent_sdk.Event_bus.Drop_oldest
       ~purpose:"compact_audit"
       ~filter:compaction_filter
       bus

--- a/lib/keeper/keeper_event_bridge.ml
+++ b/lib/keeper/keeper_event_bridge.ml
@@ -806,6 +806,8 @@ let start_impl ~interval_s ~sw ~clock ~(config : Workspace.config) ~bus =
   let store = ref (oas_event_store ~config) in
   let sub =
     Agent_sdk_metrics_bridge.subscribe
+      ~capacity:256
+      ~overflow:Agent_sdk.Event_bus.Drop_oldest
       ~purpose:"sse_bridge"
       ~filter:Agent_sdk.Event_bus.accept_all
       bus

--- a/lib/keeper/keeper_event_publisher.ml
+++ b/lib/keeper/keeper_event_publisher.ml
@@ -22,7 +22,8 @@
 let masc_publish event =
   match Masc_event_bus.get () with
   | Some mb -> Agent_sdk_metrics_bridge.publish mb event
-  | None -> ()
+  | None ->
+    Log.Misc.warn "MASC observation event was not published: event bus is not initialized"
 
 (** Publish a broadcast event to the shared Event_bus. *)
 let publish_broadcast ~agent_name ~content =

--- a/lib/keeper/keeper_telemetry_consumer.ml
+++ b/lib/keeper/keeper_telemetry_consumer.ml
@@ -26,11 +26,10 @@ let spawn_subscriber ~sw ~clock ~base_path ~bus =
   in
   let sub =
     Agent_sdk_metrics_bridge.subscribe
+      ~capacity:256
+      ~overflow:Agent_sdk.Event_bus.Drop_oldest
       ~purpose:"telemetry_consumer"
-      ~filter:(fun (evt : Agent_sdk.Event_bus.event) ->
-        match evt.payload with
-        | Agent_sdk.Event_bus.Custom ("telemetry_event", _) -> true
-        | _ -> false)
+      ~filter:(Agent_sdk.Event_bus.filter_topic "telemetry_event")
       bus
   in
   Eio.Switch.on_release sw (fun () ->

--- a/lib/keeper/keeper_unified_turn_event_bus.ml
+++ b/lib/keeper/keeper_unified_turn_event_bus.ml
@@ -56,8 +56,10 @@ let create ?event_bus ?(on_pending_count_change = fun _ -> ()) ~keeper_name ~tur
         { event_bus
         ; event_bus_sub =
             Agent_sdk_metrics_bridge.subscribe
-           ~purpose:"keeper_turn"
-           ~filter:(Agent_sdk.Event_bus.filter_agent keeper_name)
+              ~capacity:256
+              ~overflow:Agent_sdk.Event_bus.Drop_oldest
+              ~purpose:"keeper_turn"
+              ~filter:(Agent_sdk.Event_bus.filter_agent keeper_name)
               event_bus
         }
     | None -> No_event_bus

--- a/lib/otel_runtime_observables.ml
+++ b/lib/otel_runtime_observables.ml
@@ -18,16 +18,10 @@ let metric_fd_resource_errors = "masc_fd_resource_errors_total"
 let metric_store_bytes = "masc_store_bytes"
 let metric_store_files = "masc_store_files"
 
-(* Event-bus health (#20676): under Drop_oldest the oas_runtime bus sheds
-   events silently; under Block the masc_domain bus accumulates publish
-   wait. Labels: [bus] (masc_domain | oas_runtime), [purpose] (subscriber
-   purpose, "unspecified" when absent). dropped_total sums over the
-   currently-live subscriptions, so it can step down when a subscriber
-   leaves — long-lived keeper bridges make that rare; rate() spikes at
-   churn points are acceptable against having no shed signal at all. *)
+(* Event-bus health: each subscriber owns a non-blocking queue contract.
+   Labels identify the bus, purpose, capacity, and overflow behavior. *)
 let metric_bus_subscriber_dropped = "masc_event_bus_subscriber_dropped_total"
 let metric_bus_subscriber_depth = "masc_event_bus_subscriber_depth"
-let metric_bus_publish_blocked = "masc_event_bus_publish_blocked_seconds_total"
 let metric_bus_subscribers = "masc_event_bus_subscribers"
 
 (* HTTP connection pool: the export hook for Pool_metrics.current_snapshot.
@@ -157,33 +151,45 @@ let fd_samples () =
 
 let bus_samples_of ~bus_label bus =
   let stats = Agent_sdk.Event_bus.stats bus in
-  let by_purpose =
-    (* Aggregate per purpose: several subscriptions can share one. *)
+  let by_contract =
+    (* Aggregate identical contracts so label sets stay unique. *)
     List.fold_left
       (fun acc (s : Agent_sdk.Event_bus.subscription_stats) ->
         let purpose = Option.value s.purpose ~default:"unspecified" in
-        let depth, dropped =
-          match List.assoc_opt purpose acc with
-          | Some (d, dr) -> d + s.depth, dr + s.dropped_total
-          | None -> s.depth, s.dropped_total
+        let overflow =
+          match s.overflow with
+          | Agent_sdk.Event_bus.Drop_oldest -> "drop_oldest"
+          | Agent_sdk.Event_bus.Drop_newest -> "drop_newest"
         in
-        (purpose, (depth, dropped)) :: List.remove_assoc purpose acc)
+        let key = purpose, s.capacity, overflow in
+        let count, depth, dropped =
+          match List.assoc_opt key acc with
+          | Some (n, d, dr) -> n + 1, d + s.depth, dr + s.dropped_total
+          | None -> 1, s.depth, s.dropped_total
+        in
+        (key, (count, depth, dropped)) :: List.remove_assoc key acc)
       []
       stats.subscriptions
   in
   let base = [ "bus", bus_label ] in
   gauge ~labels:base metric_bus_subscribers (Float.of_int stats.subscriber_count)
-  :: counter_labeled
-       ~labels:base
-       metric_bus_publish_blocked
-       stats.total_publish_blocked_seconds
   :: List.concat_map
-       (fun (purpose, (depth, dropped)) ->
-         let labels = ("purpose", purpose) :: base in
-         [ gauge ~labels metric_bus_subscriber_depth (Float.of_int depth)
+       (fun ((purpose, capacity, overflow), (count, depth, dropped)) ->
+         let labels =
+           [ "bus", bus_label
+           ; "purpose", purpose
+           ; "capacity", string_of_int capacity
+           ; "overflow", overflow
+           ]
+         in
+         [ gauge
+             ~labels
+             Otel_metric_store.metric_oas_bus_capacity
+             (Float.of_int (count * capacity))
+         ; gauge ~labels metric_bus_subscriber_depth (Float.of_int depth)
          ; counter_labeled ~labels metric_bus_subscriber_dropped (Float.of_int dropped)
          ])
-       by_purpose
+       by_contract
 ;;
 
 let bus_samples () =

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -1106,11 +1106,10 @@ let start_keeper_loops_owned
     ~sw ~clock ~base_path:(Env_config.base_path ()) ~bus:event_bus;
   let keeper_lifecycle_sub =
     Agent_sdk_metrics_bridge.subscribe
+      ~capacity:256
+      ~overflow:Agent_sdk.Event_bus.Drop_oldest
       ~purpose:"lifecycle_listener"
-      ~filter:(fun (evt : Agent_sdk.Event_bus.event) ->
-        match evt.payload with
-        | Agent_sdk.Event_bus.Custom ("masc.keeper.lifecycle", _) -> true
-        | _ -> false)
+      ~filter:(Agent_sdk.Event_bus.filter_topic "masc.keeper.lifecycle")
       masc_event_bus
   in
   Eio.Switch.on_release sw (fun () ->

--- a/test/dune
+++ b/test/dune
@@ -2071,6 +2071,8 @@
 
 (include stanzas/test_timeout_policy_overshoot_counter.inc)
 
+(include stanzas/test_event_bus_subscription_contract.inc)
+
 (include stanzas/test_tool_call_replay_harness.inc)
 
 (include stanzas/test_tool_diversity.inc)

--- a/test/stanzas/test_event_bus_subscription_contract.inc
+++ b/test/stanzas/test_event_bus_subscription_contract.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_event_bus_subscription_contract)
+ (modules test_event_bus_subscription_contract)
+ (libraries masc_test_deps))

--- a/test/test_event_bus_subscription_contract.ml
+++ b/test/test_event_bus_subscription_contract.ml
@@ -1,0 +1,59 @@
+open Alcotest
+
+module Bridge = Masc.Agent_sdk_metrics_bridge
+
+let event index =
+  Agent_sdk.Event_bus.mk_event
+    (Agent_sdk.Event_bus.Custom ("test.event", `Int index))
+;;
+
+let event_index (event : Agent_sdk.Event_bus.event) =
+  match event.payload with
+  | Agent_sdk.Event_bus.Custom ("test.event", `Int index) -> index
+  | _ -> fail "unexpected event payload"
+;;
+
+let subscription_stats purpose bus =
+  Agent_sdk.Event_bus.(stats bus).subscriptions
+  |> List.find (fun stats -> stats.purpose = Some purpose)
+;;
+
+let test_subscribers_own_independent_overflow () =
+  Eio_main.run (fun _env ->
+    let bus = Agent_sdk.Event_bus.create () in
+    let oldest =
+      Bridge.subscribe
+        ~capacity:2
+        ~overflow:Agent_sdk.Event_bus.Drop_oldest
+        ~purpose:"oldest"
+        bus
+    in
+    let newest =
+      Bridge.subscribe
+        ~capacity:2
+        ~overflow:Agent_sdk.Event_bus.Drop_newest
+        ~purpose:"newest"
+        bus
+    in
+    List.iter (Bridge.publish bus) [ event 1; event 2; event 3 ];
+    check (list int) "drop oldest keeps latest events" [ 2; 3 ]
+      (List.map event_index (Bridge.drain oldest));
+    check (list int) "drop newest keeps queued events" [ 1; 2 ]
+      (List.map event_index (Bridge.drain newest));
+    check int "oldest drop observed" 1 (subscription_stats "oldest" bus).dropped_total;
+    check int "newest drop observed" 1 (subscription_stats "newest" bus).dropped_total;
+    Bridge.unsubscribe bus oldest;
+    Bridge.unsubscribe bus newest)
+;;
+
+let () =
+  run
+    "event_bus_subscription_contract"
+    [ ( "subscriber_contract"
+      , [ test_case
+            "overflow is isolated per subscriber"
+            `Quick
+            test_subscribers_own_independent_overflow
+        ] )
+    ]
+;;

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -1712,13 +1712,11 @@ let test_keeper_shutdown_delivers_dead_tombstone_completion_after_receipt () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir "shutdown-dead-tombstone-completion" in
-  let completion_bus =
-    Agent_sdk.Event_bus.create
-      ~policy:Agent_sdk.Event_bus.Drop_oldest
-      ()
-  in
+  let completion_bus = Agent_sdk.Event_bus.create () in
   let completion_subscription =
-    Agent_sdk.Event_bus.subscribe
+    Masc.Agent_sdk_metrics_bridge.subscribe
+      ~capacity:256
+      ~overflow:Agent_sdk.Event_bus.Drop_oldest
       ~purpose:"dead-tombstone-completion-test"
       completion_bus
   in
@@ -1964,13 +1962,11 @@ let test_dashboard_keeper_purge_finalizes_artifacts_and_receipt () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir "dashboard-purge-finalization" in
-  let completion_bus =
-    Agent_sdk.Event_bus.create
-      ~policy:Agent_sdk.Event_bus.Drop_oldest
-      ()
-  in
+  let completion_bus = Agent_sdk.Event_bus.create () in
   let completion_subscription =
-    Agent_sdk.Event_bus.subscribe
+    Masc.Agent_sdk_metrics_bridge.subscribe
+      ~capacity:256
+      ~overflow:Agent_sdk.Event_bus.Drop_oldest
       ~purpose:"dashboard-purge-completion-test"
       completion_bus
   in

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -1282,9 +1282,7 @@ let with_reap_ready_dead_keeper name f =
        | Error err -> fail err);
       ignore (Reg.register ~base_path:config.base_path name meta);
       Reg.mark_dead ~base_path:config.base_path name ~at:0.0;
-      let completion_bus =
-        Agent_sdk.Event_bus.create ~policy:Agent_sdk.Event_bus.Drop_oldest ()
-      in
+      let completion_bus = Agent_sdk.Event_bus.create () in
       Masc_event_bus.set completion_bus;
       Subprocess_registry.register_default_cleanup_hook ();
       Shutdown_finalize.register_remove_pending_confirms_by_target

--- a/test/test_oas_bus_instrument.ml
+++ b/test/test_oas_bus_instrument.ml
@@ -8,7 +8,11 @@
 
 open Alcotest
 
-module I = Masc.Agent_sdk_metrics_bridge
+module I = struct
+  include Masc.Agent_sdk_metrics_bridge
+
+  let subscribe = subscribe ~capacity:3 ~overflow:Agent_sdk.Event_bus.Drop_oldest
+end
 
 let mk_bus () = Agent_sdk.Event_bus.create ()
 
@@ -16,10 +20,7 @@ let mk_custom_event tag =
   Agent_sdk.Event_bus.mk_event
     (Agent_sdk.Event_bus.Custom (tag, `Assoc []))
 
-let topic_filter tag : Agent_sdk.Event_bus.filter = fun evt ->
-  match evt.payload with
-  | Agent_sdk.Event_bus.Custom (t, _) -> t = tag
-  | _ -> false
+let topic_filter = Agent_sdk.Event_bus.filter_topic
 
 let run_eio f =
   Eio_main.run (fun env ->
@@ -44,7 +45,10 @@ let test_subscribe_forwards_purpose_to_oas_stats () =
     let stats = Agent_sdk.Event_bus.stats bus in
     (match stats.subscriptions with
      | [ sub_stats ] ->
-       check (option string) "oas purpose" (Some "compact_audit") sub_stats.purpose
+       check (option string) "oas purpose" (Some "compact_audit") sub_stats.purpose;
+       check int "subscriber capacity" 3 sub_stats.capacity;
+       check bool "subscriber overflow" true
+         (sub_stats.overflow = Agent_sdk.Event_bus.Drop_oldest)
      | _ -> fail "expected one OAS subscription");
     I.unsubscribe bus h)
 

--- a/test/test_oas_worker_exec_checkpoint.ml
+++ b/test/test_oas_worker_exec_checkpoint.ml
@@ -16,11 +16,13 @@ let custom_payload_fields expected_topic (event : Agent_sdk.Event_bus.event) =
 
 let test_publish_lifecycle_reaches_masc_bus_with_max_tokens_intent () =
   Eio_main.run @@ fun _env ->
-  let bus =
-    Agent_sdk.Event_bus.create ~policy:Agent_sdk.Event_bus.Drop_oldest ()
-  in
+  let bus = Agent_sdk.Event_bus.create () in
   let subscription =
-    Agent_sdk.Event_bus.subscribe ~purpose:"runtime-lifecycle-test" bus
+    Agent_sdk_metrics_bridge.subscribe
+      ~capacity:256
+      ~overflow:Agent_sdk.Event_bus.Drop_oldest
+      ~purpose:"runtime-lifecycle-test"
+      bus
   in
   Masc_event_bus.set bus;
   Fun.protect


### PR DESCRIPTION
## What

- adopt OAS 0.212 subscriber-owned queue contracts at every EventBus subscription
- replace arbitrary filter callbacks with OAS typed filters
- expose exact per-subscriber capacity, overflow, depth, and drop observations; delete the removed bus-global blocked-seconds metric
- make missing MASC bus publication explicit on every occurrence instead of silently discarding it
- prove independent `Drop_oldest` / `Drop_newest` behavior with a focused contract test

## Sequence and scope

This is EventBus cut 2/2 after #24446. It migrates the transport contract without a compatibility shim. EventBus is non-blocking and observational; any MASC state transition still driven by a drained bus event is a separate authority-boundary cut, not something this PR falsely declares solved. Deleted OAS compaction events are also handled separately by the MASC Lane compaction PR.

## Verification

- 211 changed lines (149 additions, 62 deletions)
- `ocamlformat`, parse checks, and `git diff --check` passed
- focused Dune object builds passed for the bridge, telemetry consumer, publisher, unified-turn subscriber, and OTel observables
- full link remains red only at the separately tracked deleted OAS compaction-event call sites

[근거] installed OAS 0.212 `Event_bus` typed interface and focused object builds; checked 2026-07-15 KST; confidence High.