### PR TITLE
test(runtime): delete retired lifecycle observation fixtures

### DIFF
--- a/test/test_keeper_execution_receipt_observation_wire.ml
+++ b/test/test_keeper_execution_receipt_observation_wire.ml
@@ -1,12 +1,5 @@
-(* Producer contract for non-gating runtime stop observations.
-
-   Runtime stop metadata and the MASC terminal disposition are distinct axes.
-   An unexpected OAS turn-limit observation remains visible in [stop_reason]
-   while [terminal_reason_code] stays canonical success: it must not create a
-   Keeper blocker, checkpoint, claim veto, or operator follow-up action. *)
-
-(* The same boundary must keep runtime-stop and final-disposition domains
-   distinct: [Runtime_agent.Completed] remains ["completed"] in runtime
+(* Runtime-stop and final-disposition domains remain distinct:
+   [Runtime_agent.Completed] remains ["completed"] in runtime
    telemetry, while a terminal receipt projects it to canonical ["success"]. *)
 
 module D = Masc.Keeper_turn_disposition
@@ -74,57 +67,6 @@ let () =
     (match D.of_wire input_required_terminal with
      | D.Input_required -> true
      | _ -> false);
-  let turns_used = 1070 and limit = 1070 in
-  let observation_wire =
-    Receipt.stop_reason_to_string
-      (Runtime_agent.TurnLimitObserved { turns_used; limit })
-  in
-  check
-    (Printf.sprintf "turn-limit fact remains an observation (got %S)" observation_wire)
-    (String.equal
-       observation_wire
-       (Printf.sprintf "turn_limit_observed:turns=%d,limit=%d" turns_used limit));
-  let terminal_wire =
-    Receipt.receipt_terminal_reason_code_of_stop_reason
-      (Runtime_agent.TurnLimitObserved { turns_used; limit })
-  in
-  check
-    (Printf.sprintf "turn-limit observation is non-gating (got %S)" terminal_wire)
-    (String.equal terminal_wire "success");
-  check
-    "turn-limit observation projects to successful MASC disposition"
-    (D.is_success (D.of_wire terminal_wire));
-  let timeout_observations =
-    [ ( Runtime_agent.ExecutionTimeoutObserved
-          { elapsed_sec = 300.0
-          ; timeout_sec = 300.0
-          ; turn_count = 7
-          ; max_turns = Runtime_agent_context.unbounded_max_turns
-          }
-      , Printf.sprintf
-          "execution_timeout_observed:elapsed_sec=300.0,timeout_sec=300.0,turn_count=7,max_turns=%d"
-          Runtime_agent_context.unbounded_max_turns )
-    ; ( Runtime_agent.ExecutionIdleTimeoutObserved
-          { idle_sec = 120.0
-          ; idle_timeout_sec = 120.0
-          ; turn_count = 7
-          ; max_turns = Runtime_agent_context.unbounded_max_turns
-          }
-      , Printf.sprintf
-          "execution_idle_timeout_observed:idle_sec=120.0,idle_timeout_sec=120.0,turn_count=7,max_turns=%d"
-          Runtime_agent_context.unbounded_max_turns )
-    ]
-  in
-  List.iter
-    (fun (stop_reason, expected_observation) ->
-       check
-         "execution timeout keeps typed observation metadata"
-         (String.equal (Receipt.stop_reason_to_string stop_reason) expected_observation);
-       let terminal = Receipt.receipt_terminal_reason_code_of_stop_reason stop_reason in
-       check
-         "execution timeout observation has no terminal authority"
-         (D.is_success (D.of_wire terminal)))
-    timeout_observations;
   match !failures with
   | [] -> print_endline "test_keeper_execution_receipt_observation_wire: OK"
   | xs ->

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -850,21 +850,7 @@ let () =
          (entry_after_success.last_failure_reason = None);
        check
          "successful terminal turn clears turn consecutive failures"
-         (entry_after_success.turn_consecutive_failures = 0);
-       latch_stale_provider_failure ();
-       UTS.reset_turn_failures_for_stop_reason
-         ~config
-         ~updated_meta:meta
-         (run_result
-            ~stop_reason:(Runtime_agent.TurnLimitObserved { turns_used = 8; limit = 8 })
-            ());
-       let entry_after_turn_limit_observation = registered_entry () in
-       check
-         "turn-limit observation clears stale provider failure reason"
-         (entry_after_turn_limit_observation.last_failure_reason = None);
-       check
-         "turn-limit observation clears turn consecutive failures"
-         (entry_after_turn_limit_observation.turn_consecutive_failures = 0))
+         (entry_after_success.turn_consecutive_failures = 0))
 ;;
 
 let () =

--- a/test/test_keeper_unified_claim_progress.ml
+++ b/test/test_keeper_unified_claim_progress.ml
@@ -57,41 +57,6 @@ let test_empty_no_tool_response_is_no_visible_output () =
     (result ~response_text_present:true)
 ;;
 
-let test_turn_limit_observation_is_contract_neutral () =
-  let result ?(response_text_present = false) tools =
-    KAR.Contract_helpers.observed_completion_evidence
-      ~actual_keeper_tool_names:tools
-      ~stop_reason:(Runtime_agent.TurnLimitObserved { turns_used = 60; limit = 60 })
-      ~response_text_present
-    |> Masc.Keeper_execution_receipt.completion_contract_result_to_string
-  in
-  check
-    string
-    "tool call remains positive execution evidence"
-    "tool_execution_observed"
-    (result [ "tool_execute" ]);
-  check
-    string
-    "tool evidence remains authoritative when text is also present"
-    "tool_execution_observed"
-    (result ~response_text_present:true [ "tool_execute" ]);
-  check
-    string
-    "tool identity does not change evidence classification"
-    "tool_execution_observed"
-    (result [ "keeper_task_claim" ]);
-  check
-    string
-    "completion-like names remain ordinary tool evidence"
-    "tool_execution_observed"
-    (result [ "keeper_task_done" ]);
-  check
-    string
-    "empty turn-limit observation records no visible output"
-    "no_visible_output"
-    (result [])
-;;
-
 let tool_call_detail ?(outcome = "ok") tool_name : KAR.tool_call_detail =
   { tool_name
   ; provider = "test"
@@ -137,10 +102,6 @@ let () =
             "empty no-tool response records no visible output"
             `Quick
             test_empty_no_tool_response_is_no_visible_output
-        ; test_case
-            "turn-limit observation is completion-contract neutral"
-            `Quick
-            test_turn_limit_observation_is_contract_neutral
         ; test_case
             "contract progress filters no-progress tool results"
             `Quick

--- a/test/test_keeper_wire_capture_suppression.ml
+++ b/test/test_keeper_wire_capture_suppression.ml
@@ -152,21 +152,6 @@ let test_internal_response_observation_preserves_raw_response_text () =
     finalized.response_text
 ;;
 
-let test_turn_limit_observation_preserves_response_text_by_default () =
-  let raw_response_text = "Continuation checkpoint saved; keeper remains scheduled" in
-  let finalized =
-    Response_text.finalize
-      ~completion_contract_result:Receipt.Completion_response_observed
-      ~stop_reason:(Runtime_agent.TurnLimitObserved { turns_used = 3; limit = 3 })
-      ~raw_response_text
-      ()
-  in
-  Alcotest.(check string)
-    "turn-limit observation preserves response text"
-    raw_response_text
-    finalized.response_text
-;;
-
 let test_contract_observation_finalizer_preserves_response_text_by_default () =
   let raw_response_text = "Attempted work but produced no tool call." in
   let finalized =
@@ -224,10 +209,6 @@ let () =
             "response observation preserves raw response text"
             `Quick
             test_internal_response_observation_preserves_raw_response_text
-        ; Alcotest.test_case
-            "turn-limit observation preserves by default"
-            `Quick
-            test_turn_limit_observation_preserves_response_text_by_default
         ; Alcotest.test_case
             "contract observation preserves by default"
             `Quick

--- a/test/test_model_inference_metrics.ml
+++ b/test/test_model_inference_metrics.ml
@@ -638,7 +638,7 @@ let test_coverage_diagnostics_survive_aggregation () =
         ~ts:(ts -. 5.0)
         ~provider:"glm-coding"
         ~turn_lane:"text_only"
-        ~stop_reason:"turn_limit_observed:turns=3,limit=3"
+        ~stop_reason:"completed"
         ();
     ];
     let agg = M.compute ~base_path:base ~window_minutes:60 in
@@ -656,7 +656,7 @@ let test_coverage_diagnostics_survive_aggregation () =
     let recent = List.hd s.recent_entries in
     check string "recent outcome" "success" recent.re_outcome;
     check (option string) "recent stop reason"
-      (Some "turn_limit_observed:turns=3,limit=3")
+      (Some "completed")
       recent.re_stop_reason;
     check (option string) "recent turn lane"
       (Some "text_only")


### PR DESCRIPTION
## What

- delete fixtures asserting turn-limit and execution/idle-timeout stop reasons that OAS 0.212 cannot produce
- remove the associated response-preservation, claim-progress, receipt-wire, and stale-failure-reset expectations
- keep the inference coverage test but use the current `completed` stop reason instead of a retired raw wire value

## Why this is not fake green

These tests existed only to preserve the implicit lifecycle-limit behavior we explicitly removed. No active test is weakened to accommodate a failure, and no source compatibility shim is added. This bounded deletion makes the following source/type hard-cut small enough to remain below 400 lines.

## Verification

- 140 changed lines (5 additions, 135 deletions)
- `ocamlformat`, parse checks, and `git diff --check` passed
- remaining retired stop-reason references are isolated to the next source cut plus the cooperative-yield tests already being rewritten

[근거] OAS 0.212 agent error interface and merged MASC lifecycle-adapter deletions; checked 2026-07-15 KST; confidence High.