### PR TITLE
refactor(keeper): delete retired SDK blocker classes

### DIFF
--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -119,10 +119,8 @@ type blocker_class =
         meta; stale keepers use their per-keeper watchdog blocker instead. *)
   | Sdk_context_window_exceeded
   | Sdk_unrecognized_stop_reason
-  | Sdk_idle_detected
   | Sdk_guardrail_violation
   | Sdk_tripwire_violation
-  | Sdk_exit_condition_met
   | Sdk_input_required
 
 let blocker_class_to_string = function
@@ -133,10 +131,8 @@ let blocker_class_to_string = function
   | Stale_fleet_batch -> "stale_fleet_batch"
   | Sdk_context_window_exceeded -> "sdk_context_window_exceeded"
   | Sdk_unrecognized_stop_reason -> "sdk_unrecognized_stop_reason"
-  | Sdk_idle_detected -> "sdk_idle_detected"
   | Sdk_guardrail_violation -> "sdk_guardrail_violation"
   | Sdk_tripwire_violation -> "sdk_tripwire_violation"
-  | Sdk_exit_condition_met -> "sdk_exit_condition_met"
   | Sdk_input_required -> "sdk_input_required"
 ;;
 
@@ -148,10 +144,8 @@ let blocker_class_of_serialized_string = function
   | "stale_fleet_batch" -> Some Stale_fleet_batch
   | "sdk_context_window_exceeded" -> Some Sdk_context_window_exceeded
   | "sdk_unrecognized_stop_reason" -> Some Sdk_unrecognized_stop_reason
-  | "sdk_idle_detected" -> Some Sdk_idle_detected
   | "sdk_guardrail_violation" -> Some Sdk_guardrail_violation
   | "sdk_tripwire_violation" -> Some Sdk_tripwire_violation
-  | "sdk_exit_condition_met" -> Some Sdk_exit_condition_met
   | "sdk_input_required" -> Some Sdk_input_required
   | _ -> None
 ;;

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -130,10 +130,8 @@ type blocker_class =
   | Stale_fleet_batch
   | Sdk_context_window_exceeded
   | Sdk_unrecognized_stop_reason
-  | Sdk_idle_detected
   | Sdk_guardrail_violation
   | Sdk_tripwire_violation
-  | Sdk_exit_condition_met
   | Sdk_input_required
 
 val blocker_class_to_string : blocker_class -> string

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -105,10 +105,8 @@ let disposition_of_typed_runtime_blocker_class blocker_class =
   | Keeper_meta_contract.Stale_fleet_batch
   | Keeper_meta_contract.Sdk_context_window_exceeded
   | Keeper_meta_contract.Sdk_unrecognized_stop_reason
-  | Keeper_meta_contract.Sdk_idle_detected
   | Keeper_meta_contract.Sdk_guardrail_violation
-  | Keeper_meta_contract.Sdk_tripwire_violation
-  | Keeper_meta_contract.Sdk_exit_condition_met ->
+  | Keeper_meta_contract.Sdk_tripwire_violation ->
     Keeper_turn_disposition.Unknown { raw_error = "" }
 
 let legacy_provider_runtime_blocker_disposition raw_blocker_class =

--- a/lib/keeper/keeper_status_bridge_blocker.ml
+++ b/lib/keeper/keeper_status_bridge_blocker.ml
@@ -134,10 +134,8 @@ let runtime_blocker_surface_of_typed_class ?(summary = "") (cls : blocker_class)
     | Stale_fleet_batch
     | Sdk_context_window_exceeded
     | Sdk_unrecognized_stop_reason
-    | Sdk_idle_detected
     | Sdk_guardrail_violation
     | Sdk_tripwire_violation
-    | Sdk_exit_condition_met
     | Sdk_input_required -> if summary = "" then str else summary
   in
   { blocker_class = str; summary }

--- a/test/test_blocker_class_exhaustiveness.ml
+++ b/test/test_blocker_class_exhaustiveness.ml
@@ -31,10 +31,8 @@ let all_variants : blocker_class list =
   ; Stale_fleet_batch
   ; Sdk_context_window_exceeded
   ; Sdk_unrecognized_stop_reason
-  ; Sdk_idle_detected
   ; Sdk_guardrail_violation
   ; Sdk_tripwire_violation
-  ; Sdk_exit_condition_met
   ; Sdk_input_required
   ]
 ;;


### PR DESCRIPTION
## What

- remove `Sdk_idle_detected` and `Sdk_exit_condition_met` from the Keeper blocker sum type
- delete their serialized string codec branches
- delete their dashboard summary, trust-snapshot, and exhaustiveness projections

OAS 0.212 has no corresponding agent-error constructors, so retaining these classes only preserves unreachable hierarchy and string contracts. No replacement blocker or alias is introduced.

## Verification

- 16 changed lines (1 addition, 15 deletions)
- all repository references to both constructors and wire labels are gone
- `ocamlformat`, parse checks, and `git diff --check` passed
- focused Dune object builds passed for meta contract, blocker projection, and trust snapshot

[근거] installed OAS 0.212 agent-error interface plus focused MASC object builds; checked 2026-07-15 KST; confidence High.