### PR TITLE
refactor(keeper): delete retired idle provenance

### DIFF
--- a/lib/keeper_runtime/keeper_runtime_failure_route.ml
+++ b/lib/keeper_runtime/keeper_runtime_failure_route.ml
@@ -29,7 +29,6 @@ type judgment_class =
 type judgment_provenance =
   | Oas_api_error
   | Oas_provider_error
-  | Oas_agent_idle_detected of { consecutive_idle_turns : int }
   | Oas_agent_error
   | Oas_mcp_error
   | Oas_config_error
@@ -258,7 +257,6 @@ let judgment_class_label = function
 let judgment_provenance_label = function
   | Oas_api_error -> "oas_api_error"
   | Oas_provider_error -> "oas_provider_error"
-  | Oas_agent_idle_detected _ -> "oas_agent_idle_detected"
   | Oas_agent_error -> "oas_agent_error"
   | Oas_mcp_error -> "oas_mcp_error"
   | Oas_config_error -> "oas_config_error"
@@ -273,7 +271,6 @@ let judgment_provenance_label = function
 type judgment_provenance_boundary =
   | Boundary_oas_api
   | Boundary_oas_provider
-  | Boundary_oas_agent_idle
   | Boundary_oas_agent
   | Boundary_oas_mcp
   | Boundary_oas_config
@@ -288,7 +285,6 @@ type judgment_provenance_boundary =
 let judgment_provenance_boundary = function
   | Oas_api_error -> Boundary_oas_api
   | Oas_provider_error -> Boundary_oas_provider
-  | Oas_agent_idle_detected _ -> Boundary_oas_agent_idle
   | Oas_agent_error -> Boundary_oas_agent
   | Oas_mcp_error -> Boundary_oas_mcp
   | Oas_config_error -> Boundary_oas_config
@@ -308,8 +304,6 @@ let judgment_provenance_same_boundary left right =
 let judgment_provenance_to_yojson provenance =
   let kind = "kind", `String (judgment_provenance_label provenance) in
   match provenance with
-  | Oas_agent_idle_detected { consecutive_idle_turns } ->
-    `Assoc [ kind; "consecutive_idle_turns", `Int consecutive_idle_turns ]
   | Oas_api_error
   | Oas_provider_error
   | Oas_agent_error
@@ -350,21 +344,6 @@ let judgment_provenance_of_yojson = function
        provenance_without_payload fields Oas_api_error
      | Some (`String "oas_provider_error") ->
        provenance_without_payload fields Oas_provider_error
-     | Some (`String "oas_agent_idle_detected") ->
-       (match
-          require_exact_provenance_fields
-            [ "kind"; "consecutive_idle_turns" ]
-            fields
-        with
-        | Error _ as error -> error
-        | Ok () ->
-          (match List.assoc_opt "consecutive_idle_turns" fields with
-           | Some (`Int value) when value > 0 ->
-             Ok (Oas_agent_idle_detected { consecutive_idle_turns = value })
-           | Some (`Int _) ->
-             Error "failure judgment idle provenance count must be positive"
-           | Some _ | None ->
-             Error "failure judgment idle provenance requires an integer count"))
      | Some (`String "oas_agent_error") ->
        provenance_without_payload fields Oas_agent_error
      | Some (`String "oas_mcp_error") ->

--- a/lib/keeper_runtime/keeper_runtime_failure_route.mli
+++ b/lib/keeper_runtime/keeper_runtime_failure_route.mli
@@ -72,14 +72,11 @@ type judgment_class =
 
 (** Typed origin of a judgment request. The route class says what kind of
     decision is needed; this provenance says which execution boundary produced
-    it. [Oas_agent_idle_detected] retains the behavioral counter that was
-    previously collapsed into [Contract_violation]. [Legacy_unattributed] is a
-    decode-only state for persisted pre-provenance stimuli and is never emitted
-    by current producers. *)
+    it. [Legacy_unattributed] is a decode-only state for persisted
+    pre-provenance stimuli and is never emitted by current producers. *)
 type judgment_provenance =
   | Oas_api_error
   | Oas_provider_error
-  | Oas_agent_idle_detected of { consecutive_idle_turns : int }
   | Oas_agent_error
   | Oas_mcp_error
   | Oas_config_error

--- a/test/test_keeper_runtime_failure_route.ml
+++ b/test/test_keeper_runtime_failure_route.ml
@@ -222,7 +222,6 @@ let test_judgment_provenance_codec () =
   let values =
     [ KFR.Oas_api_error
     ; KFR.Oas_provider_error
-    ; KFR.Oas_agent_idle_detected { consecutive_idle_turns = 3 }
     ; KFR.Oas_agent_error
     ; KFR.Oas_mcp_error
     ; KFR.Oas_config_error
@@ -251,31 +250,12 @@ let test_judgment_provenance_codec () =
   (match
      KFR.judgment_provenance_of_yojson
        (`Assoc
-         [ "kind", `String "oas_agent_idle_detected"
-         ; "consecutive_idle_turns", `Int 0
-         ])
-   with
-   | Error _ -> ()
-   | Ok _ -> Alcotest.fail "zero idle count decoded");
-  (match
-     KFR.judgment_provenance_of_yojson
-       (`Assoc
          [ "kind", `String "oas_mcp_error"
          ; "unexpected", `String "ignored"
          ])
    with
    | Error _ -> ()
    | Ok _ -> Alcotest.fail "extra provenance field was silently ignored");
-  (match
-     KFR.judgment_provenance_of_yojson
-       (`Assoc
-         [ "kind", `String "oas_agent_idle_detected"
-         ; "consecutive_idle_turns", `Int 3
-         ; "unexpected", `Bool true
-         ])
-   with
-   | Error _ -> ()
-   | Ok _ -> Alcotest.fail "extra idle provenance field was silently ignored");
   match
     KFR.judgment_provenance_of_yojson
       (`Assoc [ "kind", `String "future_unregistered_boundary" ])
@@ -390,27 +370,7 @@ let test_queue_bounded_across_detail_variants () =
   Alcotest.(check bool)
     "a different judgment class is a distinct durable event"
     false
-    (Keeper_event_queue.stimulus_identity_equal first other_class);
-  let idle_stimulus count =
-    let fj : Keeper_event_queue.failure_judgment =
-      { fj_runtime_id = "glm-coding.glm-5-turbo"
-      ; fj_judgment = KFR.Contract_violation
-      ; fj_provenance =
-          KFR.Oas_agent_idle_detected { consecutive_idle_turns = count }
-      ; fj_detail = "idle loop"
-      }
-    in
-    { first with
-      post_id = Keeper_event_queue.failure_judgment_post_id fj
-    ; payload = Keeper_event_queue.Failure_judgment fj
-    }
-  in
-  Alcotest.(check bool)
-    "idle observation count is evidence, not event identity"
-    true
-    (Keeper_event_queue.stimulus_identity_equal
-       (idle_stimulus 3)
-       (idle_stimulus 4))
+    (Keeper_event_queue.stimulus_identity_equal first other_class)
 
 let () =
   Alcotest.run


### PR DESCRIPTION
## What

- remove `Oas_agent_idle_detected` from the failure-judgment provenance type
- delete its separate boundary classification and JSON encoder/decoder string branch
- delete codec and durable-event identity tests whose only producer was the removed OAS idle-limit error

The generic typed `Oas_agent_error` provenance remains for current OAS agent failures. No legacy alias or decode-only idle state remains.

## Verification

- 70 changed lines (3 additions, 67 deletions)
- repository search confirms the constructor, boundary, and wire label are gone
- `ocamlformat`, parse checks, and `git diff --check` passed
- focused `keeper_runtime_failure_route` Dune object build passed

[근거] installed OAS 0.212 agent-error interface and focused route build; checked 2026-07-15 KST; confidence High.