### PR TITLE
refactor(dashboard): remove estimated token telemetry

### DIFF
--- a/dashboard/src/components/keeper-detail-ctx-composition.ts
+++ b/dashboard/src/components/keeper-detail-ctx-composition.ts
@@ -19,7 +19,7 @@ export const ctxCompositionSearch = signal('')
 export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
   const series = keeper.metrics_series ?? []
   const points = series.filter(
-    (p: KeeperMetricPoint) => (p.ctx_composition?.display_total_tokens ?? 0) > 0,
+    (p: KeeperMetricPoint) => (p.ctx_composition?.attributed_bytes ?? 0) > 0,
   )
   if (points.length === 0) return null
 
@@ -27,23 +27,22 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
   const latestComposition = latest?.ctx_composition ?? null
   if (!latestComposition) return null
 
-  const latestTotal = latestComposition.display_total_tokens
+  const latestTotalBytes = latestComposition.attributed_bytes
   const latestActual = latestComposition.actual_input_tokens
-  const latestKnown = latestComposition.estimated_known_tokens
   const latestEntries = Object.entries(latestComposition.segments)
-    .filter(([, segment]) => (segment?.estimated_tokens ?? 0) > 0)
-    .sort(([, left], [, right]) => (right.estimated_tokens ?? 0) - (left.estimated_tokens ?? 0))
-  if (latestEntries.length === 0 || latestTotal <= 0) return null
+    .filter(([, segment]) => (segment?.bytes ?? 0) > 0)
+    .sort(([, left], [, right]) => (right.bytes ?? 0) - (left.bytes ?? 0))
+  if (latestEntries.length === 0 || latestTotalBytes <= 0) return null
   const visibleCtxEntries = filterCtxCompositionEntries(latestEntries, ctxCompositionSearch.value)
 
   const allKeys = Array.from(
     new Set(points.flatMap((point: KeeperMetricPoint) => Object.keys(point.ctx_composition?.segments ?? {}))),
   )
   const sortedKeys = allKeys
-    .filter((key) => points.some((point: KeeperMetricPoint) => (point.ctx_composition?.segments?.[key]?.estimated_tokens ?? 0) > 0))
+    .filter((key) => points.some((point: KeeperMetricPoint) => (point.ctx_composition?.segments?.[key]?.bytes ?? 0) > 0))
     .sort((left, right) => {
-      const rightLatest = latestComposition.segments[right]?.estimated_tokens ?? 0
-      const leftLatest = latestComposition.segments[left]?.estimated_tokens ?? 0
+      const rightLatest = latestComposition.segments[right]?.bytes ?? 0
+      const leftLatest = latestComposition.segments[left]?.bytes ?? 0
       if (rightLatest !== leftLatest) return rightLatest - leftLatest
       return left.localeCompare(right)
     })
@@ -56,9 +55,6 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
   const barStep = innerW / Math.max(points.length, 1)
   const barWidth = Math.max(3, Math.min(8, barStep - 1))
 
-  const knownRatio = latestTotal > 0 ? latestKnown / latestTotal : 0
-  const unattributedTokens = latestComposition.segments.unattributed?.estimated_tokens ?? 0
-
   return html`
     <div class="mb-5 v2-monitoring-panel">
       <div class="flex items-center gap-2 mb-2">
@@ -68,23 +64,20 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
       <div class="grid grid-cols-1 md:grid-cols-4 gap-3 v2-monitoring-row">
         <${DetailCard} class="md:col-span-2">
           <div class="flex items-center justify-between mb-2 gap-3">
-            <${Eyebrow}>latest turn input</${Eyebrow}>
-            <span class="text-xs font-mono tabular-nums text-[var(--color-accent-fg)]">${formatTokens(latestTotal)}</span>
+            <${Eyebrow}>attributed content bytes</${Eyebrow}>
+            <span class="text-xs font-mono tabular-nums text-[var(--color-accent-fg)]">${latestTotalBytes.toLocaleString()} bytes</span>
           </div>
           <div class="h-3 rounded-[var(--r-0)] overflow-hidden border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] flex">
             ${latestEntries.map(([key, segment]) => {
-              const pct = latestTotal > 0 ? (segment.estimated_tokens / latestTotal) * 100 : 0
+              const pct = latestTotalBytes > 0 ? (segment.bytes / latestTotalBytes) * 100 : 0
               return html`<div
-                title=${`${ctxSegmentLabel(key)} · ${formatTokens(segment.estimated_tokens)} · ${pct.toFixed(1)}%`}
+                title=${`${ctxSegmentLabel(key)} · ${segment.bytes.toLocaleString()} bytes · ${pct.toFixed(1)}%`}
                 style=${`width:${pct}%;background:${ctxSegmentColor(key)};min-width:${pct > 0 ? '1px' : '0'};`}
               ></div>`
             })}
           </div>
           <div class="mt-2 flex flex-wrap gap-2 text-3xs text-[var(--color-fg-disabled)]">
-            ${latestActual != null ? html`<span>actual ${formatTokens(latestActual)}</span>` : null}
-            <span>known ${formatTokens(latestKnown)}</span>
-            <span>${Math.round(knownRatio * 100)}% attributed</span>
-            ${unattributedTokens > 0 ? html`<span>residual ${formatTokens(unattributedTokens)}</span>` : null}
+            <span>${latestTotalBytes.toLocaleString()} exact bytes represented</span>
           </div>
         <//>
 
@@ -92,14 +85,14 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
           <${Eyebrow}>largest bucket</${Eyebrow}>
           <span class="text-sm font-medium text-[var(--color-fg-secondary)]">${ctxSegmentLabel(latestEntries[0]?.[0] ?? 'unknown')}</span>
           <span class="text-3xs font-mono text-[var(--color-fg-disabled)]">
-            ${latestEntries[0] ? `${formatTokens(latestEntries[0][1].estimated_tokens)} · ${((latestEntries[0][1].estimated_tokens / latestTotal) * 100).toFixed(1)}%` : '-'}
+            ${latestEntries[0] ? `${latestEntries[0][1].bytes.toLocaleString()} bytes · ${((latestEntries[0][1].bytes / latestTotalBytes) * 100).toFixed(1)}%` : '-'}
           </span>
         <//>
 
         <${DetailCard} class="flex flex-col justify-between">
-          <${Eyebrow}>residual</${Eyebrow}>
-          <span class="text-lg font-mono tabular-nums text-[var(--color-status-warn)]">${formatTokens(unattributedTokens)}</span>
-          <${MutedSpan}>tool schema / provider overhead / estimator gap</${MutedSpan}>
+          <${Eyebrow}>provider input</${Eyebrow}>
+          <span class="text-lg font-mono tabular-nums text-[var(--color-status-warn)]">${latestActual != null ? `${formatTokens(latestActual)} tokens` : '-'}</span>
+          <${MutedSpan}>reported separately; not byte-attributed</${MutedSpan}>
         <//>
       </div>
 
@@ -112,13 +105,13 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
           <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded-[var(--r-1)] w-full" role="img" aria-label="컨텍스트 구성 스택 히스토리" style="background:var(--bg-deepest);">
             ${points.map((point: KeeperMetricPoint, index: number) => {
               const comp = point.ctx_composition
-              if (!comp || comp.display_total_tokens <= 0) return null
+              if (!comp || comp.attributed_bytes <= 0) return null
               const x = pad + (index * barStep) + Math.max(0, (barStep - barWidth) / 2)
               let yCursor = H - pad
               return sortedKeys.map((key) => {
-                const tokens = comp.segments[key]?.estimated_tokens ?? 0
-                if (tokens <= 0) return null
-                const height = (tokens / comp.display_total_tokens) * innerH
+                const bytes = comp.segments[key]?.bytes ?? 0
+                if (bytes <= 0) return null
+                const height = (bytes / comp.attributed_bytes) * innerH
                 yCursor -= height
                 return html`<rect
                   x="${x.toFixed(1)}"
@@ -153,7 +146,7 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
           ` : null}
           <div class="flex flex-col gap-1.5 v2-monitoring-row">
             ${visibleCtxEntries.map(([key, segment]) => {
-              const pct = latestTotal > 0 ? (segment.estimated_tokens / latestTotal) * 100 : 0
+              const pct = latestTotalBytes > 0 ? (segment.bytes / latestTotalBytes) * 100 : 0
               return html`
                 <div class="flex items-center justify-between gap-2 text-2xs v2-monitoring-row">
                   <span class="inline-flex items-center gap-2 min-w-0">
@@ -161,7 +154,7 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
                     <span class="truncate text-[var(--color-fg-primary)]">${ctxSegmentLabel(key)}</span>
                   </span>
                   <span class="font-mono tabular-nums text-[var(--color-fg-disabled)] whitespace-nowrap">
-                    ${pct.toFixed(1)}% · ${formatTokens(segment.estimated_tokens)}
+                    ${pct.toFixed(1)}% · ${segment.bytes.toLocaleString()} bytes
                   </span>
                 </div>
               `

--- a/dashboard/src/components/keeper-detail-prompt-bytes.test.ts
+++ b/dashboard/src/components/keeper-detail-prompt-bytes.test.ts
@@ -1,0 +1,98 @@
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { Keeper, KeeperMetricPoint } from '../types'
+import { CtxCompositionPanel } from './keeper-detail-ctx-composition'
+import { PromptTelemetryPanel } from './keeper-detail-telemetry'
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+function metricPoint(overrides: Partial<KeeperMetricPoint>): KeeperMetricPoint {
+  return {
+    ts: 1,
+    context_ratio: 0,
+    context_tokens: 0,
+    context_max: 0,
+    latency_ms: null,
+    generation: 1,
+    channel: 'turn',
+    is_handoff: false,
+    is_compaction: false,
+    compaction_saved_tokens: 0,
+    compaction_trigger: null,
+    model_used: 'test-model',
+    cost_usd: 0,
+    handoff_to_model: null,
+    handoff_new_generation: null,
+    prompt_fingerprint: null,
+    prompt_metrics: null,
+    ctx_composition: null,
+    input_tokens: null,
+    output_tokens: null,
+    total_tokens: null,
+    wall_tokens_per_second: null,
+    inference_telemetry: null,
+    fallback_applied: false,
+    fallback_hops: 0,
+    fallback_from: null,
+    fallback_to: null,
+    fallback_reason: null,
+    ...overrides,
+  }
+}
+
+describe('keeper prompt byte telemetry', () => {
+  it('renders prompt measurements as bytes without token estimates', () => {
+    const container = document.createElement('div')
+    const keeper = {
+      name: 'prompt-keeper',
+      status: 'active',
+      metrics_series: [metricPoint({
+        prompt_fingerprint: 'prompt-fp',
+        prompt_metrics: {
+          fingerprint: 'prompt-fp',
+          total_bytes: 830,
+          cacheable_bytes: 512,
+          segments: {
+            system_prompt: { bytes: 512, fingerprint: 'system-fp' },
+          },
+        },
+      })],
+    } as Keeper
+
+    render(html`<${PromptTelemetryPanel} keeper=${keeper} />`, container)
+
+    expect(container.textContent).toContain('prompt bytes')
+    expect(container.textContent).toContain('latest 830 bytes')
+    expect(container.textContent).toContain('cacheable 512 bytes')
+    expect(container.textContent).not.toContain('estimated prompt tokens')
+  })
+
+  it('keeps provider tokens separate from attributed bytes', () => {
+    const container = document.createElement('div')
+    const keeper = {
+      name: 'composition-keeper',
+      status: 'active',
+      metrics_series: [metricPoint({
+        ctx_composition: {
+          actual_input_tokens: 1000,
+          attributed_bytes: 1160,
+          segments: {
+            system_prompt: { bytes: 320, fingerprint: null },
+            history_tool_result: { bytes: 840, fingerprint: null },
+          },
+        },
+      })],
+    } as Keeper
+
+    render(html`<${CtxCompositionPanel} keeper=${keeper} />`, container)
+
+    expect(container.textContent).toContain('attributed content bytes')
+    expect(container.textContent).toContain('1,160 bytes')
+    expect(container.textContent).toContain('provider input')
+    expect(container.textContent).toContain('reported separately; not byte-attributed')
+    expect(container.textContent).not.toContain('residual')
+  })
+})

--- a/dashboard/src/components/keeper-detail-telemetry.ts
+++ b/dashboard/src/components/keeper-detail-telemetry.ts
@@ -1,5 +1,5 @@
 import { html } from 'htm/preact'
-import { formatTokens, isFiniteMetricValue } from '../lib/format-number'
+import { isFiniteMetricValue } from '../lib/format-number'
 import { SPARKLINE_W, SPARKLINE_H, SPARKLINE_PAD } from '../lib/sparkline-config'
 import { CopyIdButton } from './common/copy-id-button'
 import { Eyebrow } from './common/eyebrow'
@@ -49,11 +49,11 @@ export function PromptTelemetryPanel({ keeper }: { keeper: Keeper }) {
   const latestPrompt = latest?.prompt_metrics ?? null
   const latestSegments = Object.entries(latestPrompt?.segments ?? {})
     .sort(([left], [right]) => left.localeCompare(right))
-  const promptTotals = promptPoints.map(
-    (p: KeeperMetricPoint) => p.prompt_metrics?.estimated_total_tokens ?? 0,
+  const promptBytes = promptPoints.map(
+    (p: KeeperMetricPoint) => p.prompt_metrics?.total_bytes ?? 0,
   )
-  const latestTotal = latestPrompt?.estimated_total_tokens ?? null
-  const latestCacheable = latestPrompt?.estimated_cacheable_tokens ?? null
+  const latestTotal = latestPrompt?.total_bytes ?? null
+  const latestCacheable = latestPrompt?.cacheable_bytes ?? null
   const cacheableRatio =
     latestTotal && latestCacheable != null && latestTotal > 0
       ? latestCacheable / latestTotal
@@ -71,7 +71,7 @@ export function PromptTelemetryPanel({ keeper }: { keeper: Keeper }) {
   }
 
   const W = SPARKLINE_W, H = SPARKLINE_H
-  const totalLine = miniSparkline(promptTotals)
+  const totalLine = miniSparkline(promptBytes)
 
   return html`
     <div class="mb-5 v2-monitoring-panel">
@@ -88,15 +88,15 @@ export function PromptTelemetryPanel({ keeper }: { keeper: Keeper }) {
       <div class="grid grid-cols-1 md:grid-cols-4 gap-3 v2-monitoring-row">
         <${DetailCard} class="md:col-span-2">
           <${DetailRow}>
-            <${Eyebrow}>estimated prompt tokens</${Eyebrow}>
-            <span class="text-xs font-mono tabular-nums text-[var(--color-accent-fg)]">${latestTotal != null ? formatTokens(latestTotal) : '-'}</span>
+            <${Eyebrow}>prompt bytes</${Eyebrow}>
+            <span class="text-xs font-mono tabular-nums text-[var(--color-accent-fg)]">${latestTotal != null ? latestTotal.toLocaleString() : '-'}</span>
           </${DetailRow}>
-          <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded-[var(--r-1)] w-full" role="img" aria-label="프롬프트 토큰 추이" style="background:var(--bg-deepest);">
+          <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded-[var(--r-1)] w-full" role="img" aria-label="프롬프트 바이트 추이" style="background:var(--bg-deepest);">
             ${totalLine ? html`<polyline points="${totalLine}" fill="none" stroke="var(--amber-bright)" stroke-width="1.5"/>` : null}
           </svg>
           <div class="mt-1 flex flex-wrap gap-2 text-3xs text-[var(--color-fg-disabled)]">
-            <span>latest ${latestTotal != null ? formatTokens(latestTotal) : '-'}</span>
-            <span>cacheable ${latestCacheable != null ? formatTokens(latestCacheable) : '-'}</span>
+            <span>latest ${latestTotal != null ? `${latestTotal.toLocaleString()} bytes` : '-'}</span>
+            <span>cacheable ${latestCacheable != null ? `${latestCacheable.toLocaleString()} bytes` : '-'}</span>
             ${cacheableRatio != null ? html`<span>${Math.round(cacheableRatio * 100)}% cacheable</span>` : null}
             ${latest?.runtime_strategy
               ? html`<span>strategy ${latest.runtime_strategy}</span>`
@@ -131,11 +131,7 @@ export function PromptTelemetryPanel({ keeper }: { keeper: Keeper }) {
                   ${segment.fingerprint ? html`<${CopyIdButton} value=${segment.fingerprint} label="segment fingerprint" size=${10} />` : null}
                 </span>
               </div>
-              <div class="grid grid-cols-2 gap-2 text-xs">
-                <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2.5 py-2 v2-monitoring-card">
-                  <${Eyebrow} tone="disabled">tokens</${Eyebrow}>
-                  <div class="mt-1 font-mono tabular-nums text-[var(--color-accent-fg)]">${formatTokens(segment.estimated_tokens)}</div>
-                </div>
+              <div class="text-xs">
                 <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2.5 py-2 v2-monitoring-card">
                   <${Eyebrow} tone="disabled">bytes</${Eyebrow}>
                   <div class="mt-1 font-mono tabular-nums text-[var(--color-fg-secondary)]">${segment.bytes.toLocaleString()}</div>

--- a/dashboard/src/keeper-store-normalize.test.ts
+++ b/dashboard/src/keeper-store-normalize.test.ts
@@ -312,11 +312,11 @@ describe('normalizeKeepers lifecycle metrics', () => {
             prompt_fingerprint: 'prompt-fp-001',
             prompt: {
               fingerprint: 'prompt-fp-001',
-              estimated_total_tokens: 321,
-              estimated_cacheable_tokens: 144,
-              system_prompt: { bytes: 512, estimated_tokens: 144, fingerprint: 'seg-system' },
-              dynamic_context: { bytes: 220, estimated_tokens: 61, fingerprint: 'seg-dynamic' },
-              user_message: { bytes: 98, estimated_tokens: 28, fingerprint: 'seg-user' },
+              total_bytes: 830,
+              cacheable_bytes: 512,
+              system_prompt: { bytes: 512, fingerprint: 'seg-system' },
+              dynamic_context: { bytes: 220, fingerprint: 'seg-dynamic' },
+              user_message: { bytes: 98, fingerprint: 'seg-user' },
             },
           },
         ],
@@ -330,12 +330,12 @@ describe('normalizeKeepers lifecycle metrics', () => {
     expect(metric.prompt_fingerprint).toBe('prompt-fp-001')
     expect(metric.prompt_metrics).toEqual({
       fingerprint: 'prompt-fp-001',
-      estimated_total_tokens: 321,
-      estimated_cacheable_tokens: 144,
+      total_bytes: 830,
+      cacheable_bytes: 512,
       segments: {
-        system_prompt: { bytes: 512, estimated_tokens: 144, fingerprint: 'seg-system' },
-        dynamic_context: { bytes: 220, estimated_tokens: 61, fingerprint: 'seg-dynamic' },
-        user_message: { bytes: 98, estimated_tokens: 28, fingerprint: 'seg-user' },
+        system_prompt: { bytes: 512, fingerprint: 'seg-system' },
+        dynamic_context: { bytes: 220, fingerprint: 'seg-dynamic' },
+        user_message: { bytes: 98, fingerprint: 'seg-user' },
       },
     })
   })
@@ -667,14 +667,12 @@ describe('normalizeKeepers lifecycle metrics', () => {
             compacted: false,
             ctx_composition: {
               actual_input_tokens: 1000,
-              display_total_tokens: 1000,
-              estimated_known_tokens: 740,
+              attributed_bytes: 1160,
               segments: {
-                system_prompt: { bytes: 320, estimated_tokens: 120, fingerprint: null },
-                history_user: { bytes: 210, estimated_tokens: 90, fingerprint: null },
-                history_tool_use: { bytes: 90, estimated_tokens: 60, fingerprint: null },
-                history_tool_result: { bytes: 540, estimated_tokens: 330, fingerprint: null },
-                unattributed: { bytes: 0, estimated_tokens: 260, fingerprint: null },
+                system_prompt: { bytes: 320, fingerprint: null },
+                history_user: { bytes: 210, fingerprint: null },
+                history_tool_use: { bytes: 90, fingerprint: null },
+                history_tool_result: { bytes: 540, fingerprint: null },
               },
             },
           },
@@ -686,14 +684,12 @@ describe('normalizeKeepers lifecycle metrics', () => {
     const metric = keeper?.metrics_series?.[0]
     expect(metric?.ctx_composition).toEqual({
       actual_input_tokens: 1000,
-      display_total_tokens: 1000,
-      estimated_known_tokens: 740,
+      attributed_bytes: 1160,
       segments: {
-        system_prompt: { bytes: 320, estimated_tokens: 120, fingerprint: null },
-        history_user: { bytes: 210, estimated_tokens: 90, fingerprint: null },
-        history_tool_use: { bytes: 90, estimated_tokens: 60, fingerprint: null },
-        history_tool_result: { bytes: 540, estimated_tokens: 330, fingerprint: null },
-        unattributed: { bytes: 0, estimated_tokens: 260, fingerprint: null },
+        system_prompt: { bytes: 320, fingerprint: null },
+        history_user: { bytes: 210, fingerprint: null },
+        history_tool_use: { bytes: 90, fingerprint: null },
+        history_tool_result: { bytes: 540, fingerprint: null },
       },
     })
   })

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -403,18 +403,16 @@ export function normalizeKeeperTrust(raw: unknown): Keeper['trust'] {
 function normalizePromptSegments(
   raw: Record<string, unknown> | null,
   excludedKeys: Set<string>,
-): Record<string, { bytes: number; estimated_tokens: number; fingerprint: string | null }> {
-  const segments: Record<string, { bytes: number; estimated_tokens: number; fingerprint: string | null }> = {}
+): Record<string, { bytes: number; fingerprint: string | null }> {
+  const segments: Record<string, { bytes: number; fingerprint: string | null }> = {}
   if (!raw) return segments
   for (const [key, value] of Object.entries(raw)) {
     if (excludedKeys.has(key) || !isRecord(value)) continue
     const bytes = asNumber(value.bytes)
-    const estimatedTokens = asNumber(value.estimated_tokens)
     const fingerprint = typeof value.fingerprint === 'string' ? value.fingerprint : null
-    if (bytes == null && estimatedTokens == null && fingerprint == null) continue
+    if (bytes == null && fingerprint == null) continue
     segments[key] = {
       bytes: bytes ?? 0,
-      estimated_tokens: estimatedTokens ?? 0,
       fingerprint,
     }
   }
@@ -442,7 +440,7 @@ function normalizeMetricsSeries(raw: unknown): KeeperMetricPoint[] {
       const rawPrompt = isRecord(item.prompt) ? item.prompt : null
       const rawUsage = isRecord(item.usage) ? item.usage : null
       const promptSegments: NonNullable<PromptTelemetry['segments']> =
-        normalizePromptSegments(rawPrompt, new Set(['fingerprint', 'estimated_total_tokens', 'estimated_cacheable_tokens']))
+        normalizePromptSegments(rawPrompt, new Set(['fingerprint', 'total_bytes', 'cacheable_bytes']))
       const promptFingerprint =
         (typeof item.prompt_fingerprint === 'string' ? item.prompt_fingerprint : null)
         ?? (rawPrompt && typeof rawPrompt.fingerprint === 'string' ? rawPrompt.fingerprint : null)
@@ -450,8 +448,8 @@ function normalizeMetricsSeries(raw: unknown): KeeperMetricPoint[] {
         promptFingerprint != null || rawPrompt != null || Object.keys(promptSegments).length > 0
           ? {
               fingerprint: promptFingerprint,
-              estimated_total_tokens: rawPrompt ? (asNumber(rawPrompt.estimated_total_tokens) ?? null) : null,
-              estimated_cacheable_tokens: rawPrompt ? (asNumber(rawPrompt.estimated_cacheable_tokens) ?? null) : null,
+              total_bytes: rawPrompt ? (asNumber(rawPrompt.total_bytes) ?? null) : null,
+              cacheable_bytes: rawPrompt ? (asNumber(rawPrompt.cacheable_bytes) ?? null) : null,
               segments: promptSegments,
             }
           : null
@@ -464,8 +462,7 @@ function normalizeMetricsSeries(raw: unknown): KeeperMetricPoint[] {
         rawCtxComposition != null || Object.keys(ctxSegments).length > 0
           ? {
               actual_input_tokens: rawCtxComposition ? (asNumber(rawCtxComposition.actual_input_tokens) ?? null) : null,
-              display_total_tokens: rawCtxComposition ? (asNumber(rawCtxComposition.display_total_tokens) ?? 0) : 0,
-              estimated_known_tokens: rawCtxComposition ? (asNumber(rawCtxComposition.estimated_known_tokens) ?? 0) : 0,
+              attributed_bytes: rawCtxComposition ? (asNumber(rawCtxComposition.attributed_bytes) ?? 0) : 0,
               segments: ctxSegments,
             }
           : null

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -344,21 +344,19 @@ export interface InferenceTelemetry {
 
 export interface PromptSegmentTelemetry {
   bytes: number
-  estimated_tokens: number
   fingerprint: string | null
 }
 
 export interface PromptTelemetry {
   fingerprint: string | null
-  estimated_total_tokens: number | null
-  estimated_cacheable_tokens: number | null
+  total_bytes: number | null
+  cacheable_bytes: number | null
   segments: Record<string, PromptSegmentTelemetry>
 }
 
 export interface CtxCompositionTelemetry {
   actual_input_tokens: number | null
-  display_total_tokens: number
-  estimated_known_tokens: number
+  attributed_bytes: number
   segments: Record<string, PromptSegmentTelemetry>
 }
 


### PR DESCRIPTION
## What

- delete estimated prompt/context token fields, normalization, labels, and charts from the dashboard
- render prompt and attributed context composition only in exact serialized bytes
- preserve provider-reported `actual_input_tokens` as a separate observation; never compare, subtract, or convert it against bytes
- add UI contract tests proving byte labels and provider-token separation

## Sequence

This is the consumer-first cut. The immediately following backend PR changes the producer contract to the same exact-byte fields and deletes the old estimator. There is no compatibility alias, null placeholder producer, or token/byte conversion.

## Verification

- 248 changed lines (163 additions, 85 deletions)
- `pnpm typecheck` passed
- focused Vitest: 40/40 passed
- `pnpm build` passed
- the four retired prompt/context estimated-token fields have zero references under `dashboard/src`

[근거] local dashboard typecheck, focused Vitest, and production build; checked 2026-07-15 KST; confidence High.