### PR TITLE
refactor(runtime): use typed post-tool cooperative yield

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -68,7 +68,7 @@ type autonomous_yield_reason =
   | Durable_stimulus_waiting
 
 type autonomous_yield_boundary =
-  | Yield_immediately
+  | Scheduled_pre_admission
   | Yield_after_current_turn
 
 type autonomous_yield_request =
@@ -78,7 +78,7 @@ type autonomous_yield_request =
 
 let autonomous_yield_allowed_at_turn ~start_turn ~turn request =
   match request.boundary with
-  | Yield_immediately -> true
+  | Scheduled_pre_admission -> true
   | Yield_after_current_turn -> turn > start_turn
 ;;
 
@@ -603,64 +603,40 @@ let run_turn
          match pre_dispatch_error with
          | Some err -> Error err
          | None ->
-              (* Autonomous cooperative yield: OAS checks [exit_condition]
-                 before the first provider dispatch as well as between turns.
-                 A scheduled-idle waiting chat may preempt immediately, but a
-                 reactive chat or durable stimulus may stop this run only after
-                 [turn] advances beyond the checkpoint's [start_turn_count];
-                 otherwise the heartbeat would acknowledge the currently leased
-                 stimulus without the model ever observing it. [observed_request]
-                 bridges OAS's split bool / render callbacks and preserves the
-                 exact typed reason and boundary that made the predicate true,
-                 even if the waiting chat is cancelled before
-                 [exit_condition_result] runs. *)
-              let autonomous_yield_exit_condition,
-                  autonomous_yield_exit_condition_result =
+              (* This MASC probe is evaluated only at OAS's typed post-tool
+                 boundary. It cannot preempt the first provider call or split a
+                 tool call from its result. Scheduled pre-admission is owned by
+                 the Keeper admission layer, not this run-level hook. *)
+              let cooperative_yield_probe =
                 match autonomous_yield_requested with
-                | None -> None, None
+                | None -> None
                 | Some requested ->
-                  let observed_request = ref None in
-                  ( Some
-                      (fun (turn : int) ->
+                  Some
+                    (fun (boundary : Agent_sdk.Agent.Advanced.tool_boundary) ->
+                       try
                          match requested () with
                          | Some request
                            when autonomous_yield_allowed_at_turn
                                   ~start_turn:start_turn_count
-                                  ~turn
+                                  ~turn:boundary.turn
                                   request ->
-                           observed_request := Some request;
-                           true
-                         | Some _ | None -> false)
-                  , Some
-                      (fun (turn : int) ->
-                         match !observed_request with
-                         | Some request ->
-                           let stop_reason =
-                             stop_reason_of_autonomous_yield ~turn request
-                           in
-                           let notice =
-                             match request.reason with
-                             | Chat_waiting ->
-                               Printf.sprintf
-                                 "[yielded turn slot at turn %d to a waiting \
-                                  chat request; keeper resumes on the next \
-                                  cycle]"
-                                 turn
-                             | Durable_stimulus_waiting ->
-                               Printf.sprintf
-                                 "[yielded autonomous run at turn %d because a \
-                                  durable stimulus is waiting; checkpoint saved \
-                                  and keeper resumes on the next cycle]"
-                                 turn
-                           in
-                           stop_reason, Some notice
-                         | None ->
-                           let message =
-                             "autonomous yield result requested without a \
-                              preceding typed yield decision"
-                           in
-                           Log.Keeper.error ~keeper_name:meta.name "%s" message;
-                           invalid_arg message) )
+                           Ok
+                             (Runtime_agent.Yield
+                                (stop_reason_of_autonomous_yield
+                                   ~turn:boundary.turn
+                                   request))
+                         | Some _ | None -> Ok Runtime_agent.Continue
+                       with
+                       | Eio.Cancel.Cancelled _ as exn -> raise exn
+                       | exn ->
+                         Error
+                           (Agent_sdk.Error.Internal
+                              (Printf.sprintf
+                                 "keeper cooperative-yield probe failed: %s"
+                                 (Printexc.to_string exn))))
+              in
+              let checkpoint_sidecar =
+                ctx_work.checkpoint.Agent_sdk.Checkpoint.working_context
               in
               let checkpoint_sink (snapshot : Agent_sdk.Agent.checkpoint_snapshot) =
                 Option.iter (fun observe -> observe snapshot.stage) on_checkpoint_stage;
@@ -672,10 +648,10 @@ let run_turn
                    checkpoint store rejects the write with "session_id must not
                    be empty" and every keeper turn dies. *)
                 let checkpoint =
-                  { snapshot.checkpoint with
-                    session_id =
-                      Keeper_id.Trace_id.to_string meta.runtime.trace_id
-                  }
+                  Runtime_oas_checkpoint.restamp
+                    ~session_id:trace_id
+                    ?checkpoint_sidecar
+                    snapshot.checkpoint
                 in
                 Keeper_checkpoint_store.save_oas
                   ~session_dir:session.session_dir
@@ -716,18 +692,13 @@ let run_turn
                     ?on_yield
                     ?on_resume
                     ~agent_ref
+                    ?checkpoint_sidecar
                     ~cache_system_prompt:true
                     ~yield_on_tool
                     ~context_injector
                     ~context:shared_context
                     ~enable_thinking:(Keeper_config.keeper_enable_thinking ())
-                      (* Mutation-boundary is native to OAS now;
-                         [exit_condition] is re-wired here solely for the typed
-                         autonomous cooperative yield above. Both callbacks are
-                         [None] on the chat lane, so chat runs to natural model
-                         completion unchanged. *)
-                    ?exit_condition:autonomous_yield_exit_condition
-                    ?exit_condition_result:autonomous_yield_exit_condition_result
+                    ?cooperative_yield_probe
                     ?oas_checkpoint:resume_oas_checkpoint
                     ?event_bus
                     ?trace_link

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -22,17 +22,16 @@ type raw_trace_sink_outcome =
   | Sink_ready of Agent_sdk.Raw_trace.t
   | Sink_degraded of Agent_sdk.Error.sdk_error
 
-(** Typed reason and boundary for an autonomous Keeper run to release its lane
-    at an OAS turn boundary. Scheduled-idle chat can yield immediately;
-    reactive chat and durable backlog yield only after the current cycle has
-    completed at least one provider turn, so a leased stimulus is never
-    acknowledged without being observed by the model. *)
+(** Typed reason and boundary for an autonomous Keeper run to release its lane.
+    Scheduled pre-admission is a separate Keeper admission concern; this
+    module's run-level probe is evaluated only after OAS completes a typed tool
+    boundary. *)
 type autonomous_yield_reason =
   | Chat_waiting
   | Durable_stimulus_waiting
 
 type autonomous_yield_boundary =
-  | Yield_immediately
+  | Scheduled_pre_admission
   | Yield_after_current_turn
 
 type autonomous_yield_request = {

--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -161,15 +161,14 @@ let checkpoint_for_replay_persistence
           pre-turn history prefix")
   | Runtime_agent.TurnLimitObserved _
   | Runtime_agent.ExecutionTimeoutObserved _
-  | Runtime_agent.ExecutionIdleTimeoutObserved _ ->
-    (* An execution-limit observation has no lifecycle authority, but its OAS
-       checkpoint is still the replay SSOT. Preserve the full typed message
-       suffix (thinking, tool call, and tool result blocks) so the next cycle
-       cannot repeat already committed tools after a blank terminal payload. *)
+  | Runtime_agent.ExecutionIdleTimeoutObserved _
+  | Runtime_agent.Yielded_to_chat_waiting _
+  | Runtime_agent.Yielded_to_durable_stimulus _ ->
+    (* A control-boundary checkpoint keeps the exact current-turn replay suffix.
+       In particular, cooperative yield must retain the user input, typed tool
+       call, and tool result so the resumed cycle cannot repeat committed work. *)
     observation_replay_checkpoint ~history_messages ~session_id checkpoint
-  | ( Runtime_agent.Completed
-    | Runtime_agent.Yielded_to_chat_waiting _
-    | Runtime_agent.Yielded_to_durable_stimulus _ ) ->
+  | Runtime_agent.Completed ->
     canonical_success_replay_checkpoint
       ~history_messages
       ~session_id

--- a/lib/keeper/keeper_agent_run_response_text.ml
+++ b/lib/keeper/keeper_agent_run_response_text.ml
@@ -6,11 +6,11 @@ type finalized = {
 
 let stop_reason_suppresses_visible_response = function
   | Runtime_agent.ExecutionTimeoutObserved _
-  | Runtime_agent.ExecutionIdleTimeoutObserved _ -> true
+  | Runtime_agent.ExecutionIdleTimeoutObserved _
+  | Runtime_agent.Yielded_to_chat_waiting _
+  | Runtime_agent.Yielded_to_durable_stimulus _ -> true
   | Runtime_agent.Completed
   | Runtime_agent.TurnLimitObserved _
-  | Runtime_agent.Yielded_to_chat_waiting _
-  | Runtime_agent.Yielded_to_durable_stimulus _
   | Runtime_agent.InputRequired _ ->
     false
 ;;

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -287,8 +287,7 @@ let run_named
     ?context_injector
     ?context
     ?enable_thinking
-    ?exit_condition
-    ?exit_condition_result
+    ?cooperative_yield_probe
     ?oas_checkpoint
     ?trace_link
     ?event_bus
@@ -575,8 +574,7 @@ let run_named
             ; context
             ; enable_thinking = inference_policy.attempt_enable_thinking
             ; preserve_thinking = inference_policy.attempt_preserve_thinking
-            ; exit_condition
-            ; exit_condition_result
+            ; cooperative_yield_probe
             ; oas_checkpoint
             ; trace_link
             ; sw

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -94,8 +94,7 @@ val run_named :
   ?context_injector:Agent_sdk.Hooks.context_injector ->
   ?context:Agent_sdk.Context.t ->
   ?enable_thinking:bool ->
-  ?exit_condition:(int -> bool) ->
-  ?exit_condition_result:(int -> Runtime_agent.stop_reason * string option) ->
+  ?cooperative_yield_probe:Runtime_agent.cooperative_yield_probe ->
   ?oas_checkpoint:Agent_sdk.Checkpoint.t ->
   ?trace_link:string * string ->
   ?event_bus:Agent_sdk.Event_bus.t ->

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -50,8 +50,7 @@ type try_provider_ctx =
   ; context : Agent_sdk.Context.t option
   ; enable_thinking : bool option
   ; preserve_thinking : bool option
-  ; exit_condition : (int -> bool) option
-  ; exit_condition_result : (int -> Runtime_agent.stop_reason * string option) option
+  ; cooperative_yield_probe : Runtime_agent.cooperative_yield_probe option
   ; oas_checkpoint : Agent_sdk.Checkpoint.t option
   ; (* Eio concurrency *)
     sw : Eio.Switch.t
@@ -154,16 +153,16 @@ let apply_accept
   | Runtime_agent.InputRequired _
   | Runtime_agent.TurnLimitObserved _
   | Runtime_agent.ExecutionTimeoutObserved _
-  | Runtime_agent.ExecutionIdleTimeoutObserved _ ->
+  | Runtime_agent.ExecutionIdleTimeoutObserved _
+  | Runtime_agent.Yielded_to_chat_waiting _
+  | Runtime_agent.Yielded_to_durable_stimulus _ ->
     (* These are typed host-control terminals, not model deliverables. Running
        the normal response accept predicate over their question/blank carrier
        would turn them into [Accept_rejected] and incorrectly rotate providers,
        discarding typed control/observation evidence. Execution-limit
        observations never become a MASC acceptance gate. *)
     Ok run_result
-  | Runtime_agent.Completed
-  | Runtime_agent.Yielded_to_chat_waiting _
-  | Runtime_agent.Yielded_to_durable_stimulus _ ->
+  | Runtime_agent.Completed ->
     if accept run_result.response then Ok run_result
     else
       Error
@@ -248,8 +247,7 @@ let run_try_provider
                | None -> ctx.enable_thinking)
           ; preserve_thinking = ctx.preserve_thinking
           ; event_bus = ctx.event_bus
-          ; exit_condition = ctx.exit_condition
-          ; exit_condition_result = ctx.exit_condition_result
+          ; cooperative_yield_probe = ctx.cooperative_yield_probe
           ; initial_messages = ctx.initial_messages
           ; model_input_projection = ctx.model_input_projection
           ; raw_trace = ctx.raw_trace

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -31,8 +31,7 @@ type try_provider_ctx =
   ; context : Agent_sdk.Context.t option
   ; enable_thinking : bool option
   ; preserve_thinking : bool option
-  ; exit_condition : (int -> bool) option
-  ; exit_condition_result : (int -> Runtime_agent.stop_reason * string option) option
+  ; cooperative_yield_probe : Runtime_agent.cooperative_yield_probe option
   ; oas_checkpoint : Agent_sdk.Checkpoint.t option
   ; sw : Eio.Switch.t
   ; net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -33,7 +33,7 @@ let autonomous_yield_request ~base_path ~keeper_name ~channel =
     let boundary =
       match channel with
       | Keeper_world_observation.Scheduled_autonomous ->
-        Keeper_agent_run.Yield_immediately
+        Keeper_agent_run.Scheduled_pre_admission
       | Keeper_world_observation.Reactive ->
         Keeper_agent_run.Yield_after_current_turn
     in
@@ -216,11 +216,10 @@ let run (ctx : ctx)
                       reached via [Keeper_turn_admission.run_if_free]); the chat
                       lane runs [run_keeper_msg_turn_admitted] on a separate
                       path. So passing the yield hook here is inherently
-                      lane-gated. Scheduled-idle chat can take the slot
-                      immediately; reactive chat and a durable event waiting
-                      behind the event leased by this cycle cause a checkpointed
-                      yield after at least one provider turn. A chat turn receives
-                      neither preemption hook. Both signals are read from the
+                      lane-gated. Scheduled pre-admission is handled outside this
+                      run-level probe; here every request is observed only at an
+                      OAS post-tool boundary. A chat turn receives neither
+                      preemption hook. Both signals are read from the
                       exact queues their consumers drain, so no cadence, timeout, or
                       inferred text state participates in the decision. *)
                  ~autonomous_yield_requested:(fun () ->

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -82,6 +82,13 @@ type stop_reason =
       request : Agent_sdk.Error.input_required;
     }
 
+type cooperative_yield_decision =
+  Runtime_agent_context.cooperative_yield_decision =
+  | Continue
+  | Yield of stop_reason
+
+type cooperative_yield_probe = Runtime_agent_context.cooperative_yield_probe
+
 type config =
   Runtime_agent_context.config = {
   name : string;
@@ -110,8 +117,7 @@ type config =
   yield_on_tool : bool;
   context_injector : Agent_sdk.Hooks.context_injector option;
   context : Agent_sdk.Context.t option;
-  exit_condition : (int -> bool) option;
-  exit_condition_result : (int -> stop_reason * string option) option;
+  cooperative_yield_probe : cooperative_yield_probe option;
   thinking_budget : int option;
   top_p : float option;
   top_k : int option;
@@ -1103,23 +1109,88 @@ let run_blocks
           "masc.runtime_id", `String config.name;
         ]
         (fun _trace_id ->
-          match on_event with
-          | Some cb ->
-              Agent_sdk.Agent.run_stream_blocks ~sw ?clock ?on_yield ?on_resume
-                ~on_event:cb agent goal_blocks
+          match config.cooperative_yield_probe with
           | None ->
-              Agent_sdk.Agent.run_blocks ~sw ?clock ?on_yield ?on_resume agent
-                goal_blocks)
+            (match on_event with
+             | Some cb ->
+               Agent_sdk.Agent.run_stream_blocks ~sw ?clock ?on_yield ?on_resume
+                 ~on_event:cb agent goal_blocks
+             | None ->
+               Agent_sdk.Agent.run_blocks ~sw ?clock ?on_yield ?on_resume agent
+                 goal_blocks)
+            |> Result.map (fun response -> `Completed response)
+          | Some probe ->
+            let probe_error = ref None in
+            let yield_reason = ref None in
+            let on_tool_boundary boundary =
+              match probe boundary with
+              | Ok Continue -> Agent_sdk.Agent.Advanced.Continue
+              | Ok (Yield stop_reason) ->
+                yield_reason := Some stop_reason;
+                Agent_sdk.Agent.Advanced.Yield
+              | Error error ->
+                probe_error := Some error;
+                Agent_sdk.Agent.Advanced.Yield
+            in
+            let api_strategy =
+              match on_event with
+              | None -> Agent_sdk.Agent.Sync
+              | Some on_event ->
+                let on_telemetry =
+                  Option.map
+                    (fun bus ->
+                       Agent_sdk.Telemetry_bus.publish
+                         (Agent_sdk.Telemetry_bus.of_event_bus bus))
+                    (Agent_sdk.Agent.options agent).event_bus
+                in
+                Agent_sdk.Agent.Stream { on_event; on_telemetry }
+            in
+            let advanced_result =
+              Agent_sdk.Agent.Advanced.run_blocks
+                ~sw
+                ?clock
+                ?on_yield
+                ?on_resume
+                ~api_strategy
+                ~on_tool_boundary
+                agent
+                goal_blocks
+            in
+            Result.bind advanced_result (function
+              | Agent_sdk.Agent.Advanced.Completed response ->
+                Ok (`Completed response)
+              | Agent_sdk.Agent.Advanced.Yielded yielded ->
+                (match !probe_error, !yield_reason with
+                 | Some error, _ -> Error error
+                 | None, Some stop_reason ->
+                   Ok (`Yielded (stop_reason, yielded.checkpoint))
+                 | None, None ->
+                   Error
+                     (Agent_sdk.Error.Internal
+                        "cooperative yield returned without a MASC decision"))))
     in
     let run_total_duration_ms = run_duration_ms_since run_started_at in
     let checkpoint =
-      let ckpt =
-        build_checkpoint ~session_id
-          ?checkpoint_sidecar:config.checkpoint_sidecar agent
-      in
-      Some ckpt
+      match result with
+      | Ok (`Yielded (_, checkpoint)) ->
+        Some
+          (Runtime_oas_checkpoint.restamp
+             ~session_id
+             ?checkpoint_sidecar:config.checkpoint_sidecar
+             checkpoint)
+      | Ok (`Completed _) | Error _ ->
+        Some
+          (build_checkpoint ~session_id
+             ?checkpoint_sidecar:config.checkpoint_sidecar agent)
     in
-    let lifecycle = worker_lifecycle_classification_of_result result in
+    let lifecycle =
+      match result with
+      | Ok (`Completed response) ->
+        worker_lifecycle_classification_of_result (Ok response)
+      | Ok (`Yielded _) ->
+        { event = "completed"; status = "cooperative_yield"; error = None }
+      | Error error -> worker_lifecycle_classification_of_result (Error error)
+    in
     publish_lifecycle ~name:config.name ~event:lifecycle.event
       ~detail:(Printf.sprintf "session=%s" session_id)
       ?error:lifecycle.error
@@ -1144,7 +1215,7 @@ let run_blocks
       | None -> None
     in
     (match result with
-    | Ok response ->
+    | Ok (`Completed response) ->
       close_after_success ();
       record_dashboard_oas_response ~config
         ~total_duration_ms:run_total_duration_ms
@@ -1163,6 +1234,29 @@ let run_blocks
           run_validation;
           runtime_observation = Some runtime_observation;
           stop_reason = Completed;
+        }
+    | Ok (`Yielded (stop_reason, _)) ->
+      close_after_success ();
+      let response = partial_response_of_stop ~session_id ~text:"" in
+      record_dashboard_oas_response
+        ~config
+        ~total_duration_ms:run_total_duration_ms
+        ~status:(dashboard_status_of_stop_reason stop_reason)
+        response;
+      let runtime_observation =
+        runtime_observation_for_completed_config
+          ~total_duration_ms:run_total_duration_ms
+          config
+      in
+      Ok
+        { response
+        ; checkpoint
+        ; session_id
+        ; turns
+        ; trace_ref
+        ; run_validation
+        ; runtime_observation = Some runtime_observation
+        ; stop_reason
         }
     | Error
         (Agent_sdk.Error.Agent (Agent_sdk.Error.InputRequired request)) ->
@@ -1196,43 +1290,6 @@ let run_blocks
         ; runtime_observation = Some runtime_observation
         ; stop_reason
         }
-    | Error (Agent_sdk.Error.Agent (Agent_sdk.Error.ExitConditionMet r)) -> (
-      match config.exit_condition_result with
-      | Some render ->
-        close_after_success ();
-        let stop_reason, response_text_opt = render r.turn in
-        let response_text =
-          match response_text_opt with
-          | Some text when String.trim text <> "" -> text
-          | _ -> Printf.sprintf "[exit condition met at turn %d]" r.turn
-        in
-        let partial_response =
-          partial_response_of_stop
-            ~session_id
-            ~text:response_text
-        in
-        record_dashboard_oas_response ~config
-          ~total_duration_ms:run_total_duration_ms
-          ~status:(dashboard_status_of_stop_reason stop_reason)
-          partial_response;
-        let runtime_observation =
-          runtime_observation_for_completed_config
-            ~total_duration_ms:run_total_duration_ms config
-        in
-        Ok
-          {
-            response = partial_response;
-            checkpoint;
-            session_id;
-            turns;
-            trace_ref;
-            run_validation;
-            runtime_observation = Some runtime_observation;
-            stop_reason;
-          }
-      | None ->
-        close_agent_for_cleanup ~propagate_cancel:false ~config agent;
-        Error (Agent_sdk.Error.Agent (Agent_sdk.Error.ExitConditionMet r)))
     | Error err ->
       let detail = Agent_sdk.Error.to_string err in
       let error_response =

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -40,6 +40,13 @@ type stop_reason = Runtime_agent_context.stop_reason =
       turns_used : int;
       request : Agent_sdk.Error.input_required;
     }
+
+type cooperative_yield_decision =
+  Runtime_agent_context.cooperative_yield_decision =
+  | Continue
+  | Yield of stop_reason
+
+type cooperative_yield_probe = Runtime_agent_context.cooperative_yield_probe
 (** Why this single OAS call yielded control. [Completed] is the
     model's success path. [TurnLimitObserved], [ExecutionTimeoutObserved],
     and [ExecutionIdleTimeoutObserved] preserve unexpected typed OAS
@@ -85,8 +92,7 @@ type config = Runtime_agent_context.config = {
   yield_on_tool : bool;
   context_injector : Agent_sdk.Hooks.context_injector option;
   context : Agent_sdk.Context.t option;
-  exit_condition : (int -> bool) option;
-  exit_condition_result : (int -> stop_reason * string option) option;
+  cooperative_yield_probe : cooperative_yield_probe option;
   thinking_budget : int option;
   top_p : float option;
   top_k : int option;

--- a/lib/runtime/runtime_agent_context.ml
+++ b/lib/runtime/runtime_agent_context.ml
@@ -43,6 +43,14 @@ type stop_reason =
        returning control; this is neither a provider failure nor a completed
        model deliverable. *)
 
+type cooperative_yield_decision =
+  | Continue
+  | Yield of stop_reason
+
+type cooperative_yield_probe =
+  Agent_sdk.Agent.Advanced.tool_boundary ->
+  (cooperative_yield_decision, Agent_sdk.Error.sdk_error) result
+
 type config =
   { name : string
   ; provider_cfg : Llm_provider.Provider_config.t
@@ -83,8 +91,7 @@ type config =
   ; yield_on_tool : bool
   ; context_injector : Agent_sdk.Hooks.context_injector option
   ; context : Agent_sdk.Context.t option
-  ; exit_condition : (int -> bool) option
-  ; exit_condition_result : (int -> stop_reason * string option) option
+  ; cooperative_yield_probe : cooperative_yield_probe option
   ; thinking_budget : int option
     (** Token budget for extended thinking, forwarded to OAS
         [Builder.with_thinking_budget]. Only meaningful when
@@ -141,8 +148,7 @@ let default_config
   ; yield_on_tool = false
   ; context_injector = None
   ; context = None
-  ; exit_condition = None
-  ; exit_condition_result = None
+  ; cooperative_yield_probe = None
   ; thinking_budget = None
   ; top_p = provider_cfg.top_p
   ; top_k = provider_cfg.top_k
@@ -243,11 +249,6 @@ let builder
     | None -> builder
   in
   let builder =
-    match config.exit_condition with
-    | Some cond -> Agent_sdk.Builder.with_exit_condition cond builder
-    | None -> builder
-  in
-  let builder =
     match config.thinking_budget with
     | Some budget -> Agent_sdk.Builder.with_thinking_budget budget builder
     | None -> builder
@@ -330,7 +331,6 @@ let prepare_resume ~(config : config) ~(checkpoint : Agent_sdk.Checkpoint.t)
     ; thinking_budget = config.thinking_budget
     ; cache_system_prompt = config.cache_system_prompt
     ; yield_on_tool = config.yield_on_tool
-    ; exit_condition = config.exit_condition
     }
   in
   let options : Agent_sdk.Agent.options =

--- a/lib/runtime/runtime_agent_context.mli
+++ b/lib/runtime/runtime_agent_context.mli
@@ -34,6 +34,14 @@ type stop_reason =
       request : Agent_sdk.Error.input_required;
     }
 
+type cooperative_yield_decision =
+  | Continue
+  | Yield of stop_reason
+
+type cooperative_yield_probe =
+  Agent_sdk.Agent.Advanced.tool_boundary ->
+  (cooperative_yield_decision, Agent_sdk.Error.sdk_error) result
+
 (** {1 Per-worker config} *)
 
 type config = {
@@ -77,8 +85,7 @@ type config = {
   yield_on_tool : bool;
   context_injector : Agent_sdk.Hooks.context_injector option;
   context : Agent_sdk.Context.t option;
-  exit_condition : (int -> bool) option;
-  exit_condition_result : (int -> stop_reason * string option) option;
+  cooperative_yield_probe : cooperative_yield_probe option;
   thinking_budget : int option;
       (** Token budget for extended thinking, forwarded to OAS
           [Builder.with_thinking_budget]. Only meaningful when

--- a/lib/runtime/runtime_oas_checkpoint.ml
+++ b/lib/runtime/runtime_oas_checkpoint.ml
@@ -43,6 +43,16 @@ let build_checkpoint ~session_id ?checkpoint_sidecar (agent : Agent_sdk.Agent.t)
         ~mcp_clients:(Agent_sdk.Agent.options agent).mcp_clients
         ()
 
+let restamp ~session_id ?checkpoint_sidecar checkpoint =
+  { checkpoint with
+    Agent_sdk.Checkpoint.session_id
+  ; working_context =
+      (match checkpoint_sidecar with
+       | Some _ as sidecar -> sidecar
+       | None -> checkpoint.Agent_sdk.Checkpoint.working_context)
+  }
+;;
+
 let partial_response_of_stop
     ~(session_id : string)
     ~(text : string)

--- a/lib/runtime/runtime_oas_checkpoint.mli
+++ b/lib/runtime/runtime_oas_checkpoint.mli
@@ -48,6 +48,14 @@ val build_checkpoint :
     used when masc wants to attach extra worker-side state
     that the SDK's default capture does not include. *)
 
+val restamp :
+  session_id:string ->
+  ?checkpoint_sidecar:Yojson.Safe.t ->
+  Agent_sdk.Checkpoint.t ->
+  Agent_sdk.Checkpoint.t
+(** Restore MASC's trace identity and optional working-context sidecar on an
+    OAS checkpoint without rebuilding its message history. *)
+
 val partial_response_of_stop :
   session_id:string ->
   text:string ->

--- a/test/test_keeper_replay_checkpoint.ml
+++ b/test/test_keeper_replay_checkpoint.ml
@@ -316,6 +316,8 @@ let test_execution_observations_preserve_tool_replay_suffix () =
         ; turn_count = 4
         ; max_turns = Runtime_agent_context.unbounded_max_turns
         }
+    ; Runtime_agent.Yielded_to_chat_waiting { turns_used = 4 }
+    ; Runtime_agent.Yielded_to_durable_stimulus { turns_used = 4 }
     ]
   in
   List.iter

--- a/test/test_keeper_turn_outcome.ml
+++ b/test/test_keeper_turn_outcome.ml
@@ -114,7 +114,7 @@ let test_autonomous_yield_boundary_contract () =
   let start_turn = 11570 in
   let immediate_chat : Masc.Keeper_agent_run.autonomous_yield_request =
     { reason = Masc.Keeper_agent_run.Chat_waiting
-    ; boundary = Masc.Keeper_agent_run.Yield_immediately
+    ; boundary = Masc.Keeper_agent_run.Scheduled_pre_admission
     }
   in
   let reactive_chat : Masc.Keeper_agent_run.autonomous_yield_request =
@@ -127,7 +127,7 @@ let test_autonomous_yield_boundary_contract () =
     ; boundary = Masc.Keeper_agent_run.Yield_after_current_turn
     }
   in
-  check bool "chat may yield before first provider dispatch" true
+  check bool "scheduled request remains eligible at a completed boundary" true
     (F.autonomous_yield_allowed_at_turn
        ~start_turn
        ~turn:start_turn


### PR DESCRIPTION
## What changed

- drives cooperative Keeper yield from OAS 0.212 typed post-tool boundary
- preserves the exact checkpoint suffix and restamps it through the single runtime checkpoint SSOT
- removes synthetic provider responses and stale immediate/pre-provider yield claims
- propagates probe errors and cancellation explicitly

## Why

The Keeper lane must yield only at a real tool boundary without reintroducing turn, idle, timeout, or budget limits. This keeps the OAS boundary generic while MASC owns lane scheduling and reinjection.

## PR boundary

This is intentionally stacked on #24448. The predecessor contains only the 125-line deleted-lifecycle adapter hard-cut; this PR contains 394 churn and will be retargeted to main after #24448 merges.

## Validation

- git diff --cached --check
- exact diff: +223/-171 = 394 churn
- scripts/dune-local.sh build lib/runtime/masc_runtime.cmxa

[근거] local git diff plus focused Dune wrapper, confirmed 2026-07-15 KST, confidence High.
