### PR TITLE
test(keeper): delete prompt estimate contracts

### DIFF
--- a/dashboard/src/components/keeper-detail-ctx-composition.ts
+++ b/dashboard/src/components/keeper-detail-ctx-composition.ts
@@ -19,7 +19,7 @@ export const ctxCompositionSearch = signal('')
 export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
   const series = keeper.metrics_series ?? []
   const points = series.filter(
-    (p: KeeperMetricPoint) => (p.ctx_composition?.display_total_tokens ?? 0) > 0,
+    (p: KeeperMetricPoint) => (p.ctx_composition?.attributed_bytes ?? 0) > 0,
   )
   if (points.length === 0) return null
 
@@ -27,23 +27,22 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
   const latestComposition = latest?.ctx_composition ?? null
   if (!latestComposition) return null
 
-  const latestTotal = latestComposition.display_total_tokens
+  const latestTotalBytes = latestComposition.attributed_bytes
   const latestActual = latestComposition.actual_input_tokens
-  const latestKnown = latestComposition.estimated_known_tokens
   const latestEntries = Object.entries(latestComposition.segments)
-    .filter(([, segment]) => (segment?.estimated_tokens ?? 0) > 0)
-    .sort(([, left], [, right]) => (right.estimated_tokens ?? 0) - (left.estimated_tokens ?? 0))
-  if (latestEntries.length === 0 || latestTotal <= 0) return null
+    .filter(([, segment]) => (segment?.bytes ?? 0) > 0)
+    .sort(([, left], [, right]) => (right.bytes ?? 0) - (left.bytes ?? 0))
+  if (latestEntries.length === 0 || latestTotalBytes <= 0) return null
   const visibleCtxEntries = filterCtxCompositionEntries(latestEntries, ctxCompositionSearch.value)
 
   const allKeys = Array.from(
     new Set(points.flatMap((point: KeeperMetricPoint) => Object.keys(point.ctx_composition?.segments ?? {}))),
   )
   const sortedKeys = allKeys
-    .filter((key) => points.some((point: KeeperMetricPoint) => (point.ctx_composition?.segments?.[key]?.estimated_tokens ?? 0) > 0))
+    .filter((key) => points.some((point: KeeperMetricPoint) => (point.ctx_composition?.segments?.[key]?.bytes ?? 0) > 0))
     .sort((left, right) => {
-      const rightLatest = latestComposition.segments[right]?.estimated_tokens ?? 0
-      const leftLatest = latestComposition.segments[left]?.estimated_tokens ?? 0
+      const rightLatest = latestComposition.segments[right]?.bytes ?? 0
+      const leftLatest = latestComposition.segments[left]?.bytes ?? 0
       if (rightLatest !== leftLatest) return rightLatest - leftLatest
       return left.localeCompare(right)
     })
@@ -56,9 +55,6 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
   const barStep = innerW / Math.max(points.length, 1)
   const barWidth = Math.max(3, Math.min(8, barStep - 1))
 
-  const knownRatio = latestTotal > 0 ? latestKnown / latestTotal : 0
-  const unattributedTokens = latestComposition.segments.unattributed?.estimated_tokens ?? 0
-
   return html`
     <div class="mb-5 v2-monitoring-panel">
       <div class="flex items-center gap-2 mb-2">
@@ -68,23 +64,20 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
       <div class="grid grid-cols-1 md:grid-cols-4 gap-3 v2-monitoring-row">
         <${DetailCard} class="md:col-span-2">
           <div class="flex items-center justify-between mb-2 gap-3">
-            <${Eyebrow}>latest turn input</${Eyebrow}>
-            <span class="text-xs font-mono tabular-nums text-[var(--color-accent-fg)]">${formatTokens(latestTotal)}</span>
+            <${Eyebrow}>attributed content bytes</${Eyebrow}>
+            <span class="text-xs font-mono tabular-nums text-[var(--color-accent-fg)]">${latestTotalBytes.toLocaleString()} bytes</span>
           </div>
           <div class="h-3 rounded-[var(--r-0)] overflow-hidden border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] flex">
             ${latestEntries.map(([key, segment]) => {
-              const pct = latestTotal > 0 ? (segment.estimated_tokens / latestTotal) * 100 : 0
+              const pct = latestTotalBytes > 0 ? (segment.bytes / latestTotalBytes) * 100 : 0
               return html`<div
-                title=${`${ctxSegmentLabel(key)} · ${formatTokens(segment.estimated_tokens)} · ${pct.toFixed(1)}%`}
+                title=${`${ctxSegmentLabel(key)} · ${segment.bytes.toLocaleString()} bytes · ${pct.toFixed(1)}%`}
                 style=${`width:${pct}%;background:${ctxSegmentColor(key)};min-width:${pct > 0 ? '1px' : '0'};`}
               ></div>`
             })}
           </div>
           <div class="mt-2 flex flex-wrap gap-2 text-3xs text-[var(--color-fg-disabled)]">
-            ${latestActual != null ? html`<span>actual ${formatTokens(latestActual)}</span>` : null}
-            <span>known ${formatTokens(latestKnown)}</span>
-            <span>${Math.round(knownRatio * 100)}% attributed</span>
-            ${unattributedTokens > 0 ? html`<span>residual ${formatTokens(unattributedTokens)}</span>` : null}
+            <span>${latestTotalBytes.toLocaleString()} exact bytes represented</span>
           </div>
         <//>
 
@@ -92,14 +85,14 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
           <${Eyebrow}>largest bucket</${Eyebrow}>
           <span class="text-sm font-medium text-[var(--color-fg-secondary)]">${ctxSegmentLabel(latestEntries[0]?.[0] ?? 'unknown')}</span>
           <span class="text-3xs font-mono text-[var(--color-fg-disabled)]">
-            ${latestEntries[0] ? `${formatTokens(latestEntries[0][1].estimated_tokens)} · ${((latestEntries[0][1].estimated_tokens / latestTotal) * 100).toFixed(1)}%` : '-'}
+            ${latestEntries[0] ? `${latestEntries[0][1].bytes.toLocaleString()} bytes · ${((latestEntries[0][1].bytes / latestTotalBytes) * 100).toFixed(1)}%` : '-'}
           </span>
         <//>
 
         <${DetailCard} class="flex flex-col justify-between">
-          <${Eyebrow}>residual</${Eyebrow}>
-          <span class="text-lg font-mono tabular-nums text-[var(--color-status-warn)]">${formatTokens(unattributedTokens)}</span>
-          <${MutedSpan}>tool schema / provider overhead / estimator gap</${MutedSpan}>
+          <${Eyebrow}>provider input</${Eyebrow}>
+          <span class="text-lg font-mono tabular-nums text-[var(--color-status-warn)]">${latestActual != null ? `${formatTokens(latestActual)} tokens` : '-'}</span>
+          <${MutedSpan}>reported separately; not byte-attributed</${MutedSpan}>
         <//>
       </div>
 
@@ -112,13 +105,13 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
           <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded-[var(--r-1)] w-full" role="img" aria-label="컨텍스트 구성 스택 히스토리" style="background:var(--bg-deepest);">
             ${points.map((point: KeeperMetricPoint, index: number) => {
               const comp = point.ctx_composition
-              if (!comp || comp.display_total_tokens <= 0) return null
+              if (!comp || comp.attributed_bytes <= 0) return null
               const x = pad + (index * barStep) + Math.max(0, (barStep - barWidth) / 2)
               let yCursor = H - pad
               return sortedKeys.map((key) => {
-                const tokens = comp.segments[key]?.estimated_tokens ?? 0
-                if (tokens <= 0) return null
-                const height = (tokens / comp.display_total_tokens) * innerH
+                const bytes = comp.segments[key]?.bytes ?? 0
+                if (bytes <= 0) return null
+                const height = (bytes / comp.attributed_bytes) * innerH
                 yCursor -= height
                 return html`<rect
                   x="${x.toFixed(1)}"
@@ -153,7 +146,7 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
           ` : null}
           <div class="flex flex-col gap-1.5 v2-monitoring-row">
             ${visibleCtxEntries.map(([key, segment]) => {
-              const pct = latestTotal > 0 ? (segment.estimated_tokens / latestTotal) * 100 : 0
+              const pct = latestTotalBytes > 0 ? (segment.bytes / latestTotalBytes) * 100 : 0
               return html`
                 <div class="flex items-center justify-between gap-2 text-2xs v2-monitoring-row">
                   <span class="inline-flex items-center gap-2 min-w-0">
@@ -161,7 +154,7 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
                     <span class="truncate text-[var(--color-fg-primary)]">${ctxSegmentLabel(key)}</span>
                   </span>
                   <span class="font-mono tabular-nums text-[var(--color-fg-disabled)] whitespace-nowrap">
-                    ${pct.toFixed(1)}% · ${formatTokens(segment.estimated_tokens)}
+                    ${pct.toFixed(1)}% · ${segment.bytes.toLocaleString()} bytes
                   </span>
                 </div>
               `

--- a/dashboard/src/components/keeper-detail-prompt-bytes.test.ts
+++ b/dashboard/src/components/keeper-detail-prompt-bytes.test.ts
@@ -1,0 +1,98 @@
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { Keeper, KeeperMetricPoint } from '../types'
+import { CtxCompositionPanel } from './keeper-detail-ctx-composition'
+import { PromptTelemetryPanel } from './keeper-detail-telemetry'
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+function metricPoint(overrides: Partial<KeeperMetricPoint>): KeeperMetricPoint {
+  return {
+    ts: 1,
+    context_ratio: 0,
+    context_tokens: 0,
+    context_max: 0,
+    latency_ms: null,
+    generation: 1,
+    channel: 'turn',
+    is_handoff: false,
+    is_compaction: false,
+    compaction_saved_tokens: 0,
+    compaction_trigger: null,
+    model_used: 'test-model',
+    cost_usd: 0,
+    handoff_to_model: null,
+    handoff_new_generation: null,
+    prompt_fingerprint: null,
+    prompt_metrics: null,
+    ctx_composition: null,
+    input_tokens: null,
+    output_tokens: null,
+    total_tokens: null,
+    wall_tokens_per_second: null,
+    inference_telemetry: null,
+    fallback_applied: false,
+    fallback_hops: 0,
+    fallback_from: null,
+    fallback_to: null,
+    fallback_reason: null,
+    ...overrides,
+  }
+}
+
+describe('keeper prompt byte telemetry', () => {
+  it('renders prompt measurements as bytes without token estimates', () => {
+    const container = document.createElement('div')
+    const keeper = {
+      name: 'prompt-keeper',
+      status: 'active',
+      metrics_series: [metricPoint({
+        prompt_fingerprint: 'prompt-fp',
+        prompt_metrics: {
+          fingerprint: 'prompt-fp',
+          total_bytes: 830,
+          cacheable_bytes: 512,
+          segments: {
+            system_prompt: { bytes: 512, fingerprint: 'system-fp' },
+          },
+        },
+      })],
+    } as Keeper
+
+    render(html`<${PromptTelemetryPanel} keeper=${keeper} />`, container)
+
+    expect(container.textContent).toContain('prompt bytes')
+    expect(container.textContent).toContain('latest 830 bytes')
+    expect(container.textContent).toContain('cacheable 512 bytes')
+    expect(container.textContent).not.toContain('estimated prompt tokens')
+  })
+
+  it('keeps provider tokens separate from attributed bytes', () => {
+    const container = document.createElement('div')
+    const keeper = {
+      name: 'composition-keeper',
+      status: 'active',
+      metrics_series: [metricPoint({
+        ctx_composition: {
+          actual_input_tokens: 1000,
+          attributed_bytes: 1160,
+          segments: {
+            system_prompt: { bytes: 320, fingerprint: null },
+            history_tool_result: { bytes: 840, fingerprint: null },
+          },
+        },
+      })],
+    } as Keeper
+
+    render(html`<${CtxCompositionPanel} keeper=${keeper} />`, container)
+
+    expect(container.textContent).toContain('attributed content bytes')
+    expect(container.textContent).toContain('1,160 bytes')
+    expect(container.textContent).toContain('provider input')
+    expect(container.textContent).toContain('reported separately; not byte-attributed')
+    expect(container.textContent).not.toContain('residual')
+  })
+})

--- a/dashboard/src/components/keeper-detail-telemetry.ts
+++ b/dashboard/src/components/keeper-detail-telemetry.ts
@@ -1,5 +1,5 @@
 import { html } from 'htm/preact'
-import { formatTokens, isFiniteMetricValue } from '../lib/format-number'
+import { isFiniteMetricValue } from '../lib/format-number'
 import { SPARKLINE_W, SPARKLINE_H, SPARKLINE_PAD } from '../lib/sparkline-config'
 import { CopyIdButton } from './common/copy-id-button'
 import { Eyebrow } from './common/eyebrow'
@@ -49,11 +49,11 @@ export function PromptTelemetryPanel({ keeper }: { keeper: Keeper }) {
   const latestPrompt = latest?.prompt_metrics ?? null
   const latestSegments = Object.entries(latestPrompt?.segments ?? {})
     .sort(([left], [right]) => left.localeCompare(right))
-  const promptTotals = promptPoints.map(
-    (p: KeeperMetricPoint) => p.prompt_metrics?.estimated_total_tokens ?? 0,
+  const promptBytes = promptPoints.map(
+    (p: KeeperMetricPoint) => p.prompt_metrics?.total_bytes ?? 0,
   )
-  const latestTotal = latestPrompt?.estimated_total_tokens ?? null
-  const latestCacheable = latestPrompt?.estimated_cacheable_tokens ?? null
+  const latestTotal = latestPrompt?.total_bytes ?? null
+  const latestCacheable = latestPrompt?.cacheable_bytes ?? null
   const cacheableRatio =
     latestTotal && latestCacheable != null && latestTotal > 0
       ? latestCacheable / latestTotal
@@ -71,7 +71,7 @@ export function PromptTelemetryPanel({ keeper }: { keeper: Keeper }) {
   }
 
   const W = SPARKLINE_W, H = SPARKLINE_H
-  const totalLine = miniSparkline(promptTotals)
+  const totalLine = miniSparkline(promptBytes)
 
   return html`
     <div class="mb-5 v2-monitoring-panel">
@@ -88,15 +88,15 @@ export function PromptTelemetryPanel({ keeper }: { keeper: Keeper }) {
       <div class="grid grid-cols-1 md:grid-cols-4 gap-3 v2-monitoring-row">
         <${DetailCard} class="md:col-span-2">
           <${DetailRow}>
-            <${Eyebrow}>estimated prompt tokens</${Eyebrow}>
-            <span class="text-xs font-mono tabular-nums text-[var(--color-accent-fg)]">${latestTotal != null ? formatTokens(latestTotal) : '-'}</span>
+            <${Eyebrow}>prompt bytes</${Eyebrow}>
+            <span class="text-xs font-mono tabular-nums text-[var(--color-accent-fg)]">${latestTotal != null ? latestTotal.toLocaleString() : '-'}</span>
           </${DetailRow}>
-          <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded-[var(--r-1)] w-full" role="img" aria-label="프롬프트 토큰 추이" style="background:var(--bg-deepest);">
+          <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded-[var(--r-1)] w-full" role="img" aria-label="프롬프트 바이트 추이" style="background:var(--bg-deepest);">
             ${totalLine ? html`<polyline points="${totalLine}" fill="none" stroke="var(--amber-bright)" stroke-width="1.5"/>` : null}
           </svg>
           <div class="mt-1 flex flex-wrap gap-2 text-3xs text-[var(--color-fg-disabled)]">
-            <span>latest ${latestTotal != null ? formatTokens(latestTotal) : '-'}</span>
-            <span>cacheable ${latestCacheable != null ? formatTokens(latestCacheable) : '-'}</span>
+            <span>latest ${latestTotal != null ? `${latestTotal.toLocaleString()} bytes` : '-'}</span>
+            <span>cacheable ${latestCacheable != null ? `${latestCacheable.toLocaleString()} bytes` : '-'}</span>
             ${cacheableRatio != null ? html`<span>${Math.round(cacheableRatio * 100)}% cacheable</span>` : null}
             ${latest?.runtime_strategy
               ? html`<span>strategy ${latest.runtime_strategy}</span>`
@@ -131,11 +131,7 @@ export function PromptTelemetryPanel({ keeper }: { keeper: Keeper }) {
                   ${segment.fingerprint ? html`<${CopyIdButton} value=${segment.fingerprint} label="segment fingerprint" size=${10} />` : null}
                 </span>
               </div>
-              <div class="grid grid-cols-2 gap-2 text-xs">
-                <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2.5 py-2 v2-monitoring-card">
-                  <${Eyebrow} tone="disabled">tokens</${Eyebrow}>
-                  <div class="mt-1 font-mono tabular-nums text-[var(--color-accent-fg)]">${formatTokens(segment.estimated_tokens)}</div>
-                </div>
+              <div class="text-xs">
                 <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2.5 py-2 v2-monitoring-card">
                   <${Eyebrow} tone="disabled">bytes</${Eyebrow}>
                   <div class="mt-1 font-mono tabular-nums text-[var(--color-fg-secondary)]">${segment.bytes.toLocaleString()}</div>

--- a/dashboard/src/keeper-store-normalize.test.ts
+++ b/dashboard/src/keeper-store-normalize.test.ts
@@ -312,11 +312,11 @@ describe('normalizeKeepers lifecycle metrics', () => {
             prompt_fingerprint: 'prompt-fp-001',
             prompt: {
               fingerprint: 'prompt-fp-001',
-              estimated_total_tokens: 321,
-              estimated_cacheable_tokens: 144,
-              system_prompt: { bytes: 512, estimated_tokens: 144, fingerprint: 'seg-system' },
-              dynamic_context: { bytes: 220, estimated_tokens: 61, fingerprint: 'seg-dynamic' },
-              user_message: { bytes: 98, estimated_tokens: 28, fingerprint: 'seg-user' },
+              total_bytes: 830,
+              cacheable_bytes: 512,
+              system_prompt: { bytes: 512, fingerprint: 'seg-system' },
+              dynamic_context: { bytes: 220, fingerprint: 'seg-dynamic' },
+              user_message: { bytes: 98, fingerprint: 'seg-user' },
             },
           },
         ],
@@ -330,12 +330,12 @@ describe('normalizeKeepers lifecycle metrics', () => {
     expect(metric.prompt_fingerprint).toBe('prompt-fp-001')
     expect(metric.prompt_metrics).toEqual({
       fingerprint: 'prompt-fp-001',
-      estimated_total_tokens: 321,
-      estimated_cacheable_tokens: 144,
+      total_bytes: 830,
+      cacheable_bytes: 512,
       segments: {
-        system_prompt: { bytes: 512, estimated_tokens: 144, fingerprint: 'seg-system' },
-        dynamic_context: { bytes: 220, estimated_tokens: 61, fingerprint: 'seg-dynamic' },
-        user_message: { bytes: 98, estimated_tokens: 28, fingerprint: 'seg-user' },
+        system_prompt: { bytes: 512, fingerprint: 'seg-system' },
+        dynamic_context: { bytes: 220, fingerprint: 'seg-dynamic' },
+        user_message: { bytes: 98, fingerprint: 'seg-user' },
       },
     })
   })
@@ -667,14 +667,12 @@ describe('normalizeKeepers lifecycle metrics', () => {
             compacted: false,
             ctx_composition: {
               actual_input_tokens: 1000,
-              display_total_tokens: 1000,
-              estimated_known_tokens: 740,
+              attributed_bytes: 1160,
               segments: {
-                system_prompt: { bytes: 320, estimated_tokens: 120, fingerprint: null },
-                history_user: { bytes: 210, estimated_tokens: 90, fingerprint: null },
-                history_tool_use: { bytes: 90, estimated_tokens: 60, fingerprint: null },
-                history_tool_result: { bytes: 540, estimated_tokens: 330, fingerprint: null },
-                unattributed: { bytes: 0, estimated_tokens: 260, fingerprint: null },
+                system_prompt: { bytes: 320, fingerprint: null },
+                history_user: { bytes: 210, fingerprint: null },
+                history_tool_use: { bytes: 90, fingerprint: null },
+                history_tool_result: { bytes: 540, fingerprint: null },
               },
             },
           },
@@ -686,14 +684,12 @@ describe('normalizeKeepers lifecycle metrics', () => {
     const metric = keeper?.metrics_series?.[0]
     expect(metric?.ctx_composition).toEqual({
       actual_input_tokens: 1000,
-      display_total_tokens: 1000,
-      estimated_known_tokens: 740,
+      attributed_bytes: 1160,
       segments: {
-        system_prompt: { bytes: 320, estimated_tokens: 120, fingerprint: null },
-        history_user: { bytes: 210, estimated_tokens: 90, fingerprint: null },
-        history_tool_use: { bytes: 90, estimated_tokens: 60, fingerprint: null },
-        history_tool_result: { bytes: 540, estimated_tokens: 330, fingerprint: null },
-        unattributed: { bytes: 0, estimated_tokens: 260, fingerprint: null },
+        system_prompt: { bytes: 320, fingerprint: null },
+        history_user: { bytes: 210, fingerprint: null },
+        history_tool_use: { bytes: 90, fingerprint: null },
+        history_tool_result: { bytes: 540, fingerprint: null },
       },
     })
   })

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -403,18 +403,16 @@ export function normalizeKeeperTrust(raw: unknown): Keeper['trust'] {
 function normalizePromptSegments(
   raw: Record<string, unknown> | null,
   excludedKeys: Set<string>,
-): Record<string, { bytes: number; estimated_tokens: number; fingerprint: string | null }> {
-  const segments: Record<string, { bytes: number; estimated_tokens: number; fingerprint: string | null }> = {}
+): Record<string, { bytes: number; fingerprint: string | null }> {
+  const segments: Record<string, { bytes: number; fingerprint: string | null }> = {}
   if (!raw) return segments
   for (const [key, value] of Object.entries(raw)) {
     if (excludedKeys.has(key) || !isRecord(value)) continue
     const bytes = asNumber(value.bytes)
-    const estimatedTokens = asNumber(value.estimated_tokens)
     const fingerprint = typeof value.fingerprint === 'string' ? value.fingerprint : null
-    if (bytes == null && estimatedTokens == null && fingerprint == null) continue
+    if (bytes == null && fingerprint == null) continue
     segments[key] = {
       bytes: bytes ?? 0,
-      estimated_tokens: estimatedTokens ?? 0,
       fingerprint,
     }
   }
@@ -442,7 +440,7 @@ function normalizeMetricsSeries(raw: unknown): KeeperMetricPoint[] {
       const rawPrompt = isRecord(item.prompt) ? item.prompt : null
       const rawUsage = isRecord(item.usage) ? item.usage : null
       const promptSegments: NonNullable<PromptTelemetry['segments']> =
-        normalizePromptSegments(rawPrompt, new Set(['fingerprint', 'estimated_total_tokens', 'estimated_cacheable_tokens']))
+        normalizePromptSegments(rawPrompt, new Set(['fingerprint', 'total_bytes', 'cacheable_bytes']))
       const promptFingerprint =
         (typeof item.prompt_fingerprint === 'string' ? item.prompt_fingerprint : null)
         ?? (rawPrompt && typeof rawPrompt.fingerprint === 'string' ? rawPrompt.fingerprint : null)
@@ -450,8 +448,8 @@ function normalizeMetricsSeries(raw: unknown): KeeperMetricPoint[] {
         promptFingerprint != null || rawPrompt != null || Object.keys(promptSegments).length > 0
           ? {
               fingerprint: promptFingerprint,
-              estimated_total_tokens: rawPrompt ? (asNumber(rawPrompt.estimated_total_tokens) ?? null) : null,
-              estimated_cacheable_tokens: rawPrompt ? (asNumber(rawPrompt.estimated_cacheable_tokens) ?? null) : null,
+              total_bytes: rawPrompt ? (asNumber(rawPrompt.total_bytes) ?? null) : null,
+              cacheable_bytes: rawPrompt ? (asNumber(rawPrompt.cacheable_bytes) ?? null) : null,
               segments: promptSegments,
             }
           : null
@@ -464,8 +462,7 @@ function normalizeMetricsSeries(raw: unknown): KeeperMetricPoint[] {
         rawCtxComposition != null || Object.keys(ctxSegments).length > 0
           ? {
               actual_input_tokens: rawCtxComposition ? (asNumber(rawCtxComposition.actual_input_tokens) ?? null) : null,
-              display_total_tokens: rawCtxComposition ? (asNumber(rawCtxComposition.display_total_tokens) ?? 0) : 0,
-              estimated_known_tokens: rawCtxComposition ? (asNumber(rawCtxComposition.estimated_known_tokens) ?? 0) : 0,
+              attributed_bytes: rawCtxComposition ? (asNumber(rawCtxComposition.attributed_bytes) ?? 0) : 0,
               segments: ctxSegments,
             }
           : null

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -344,21 +344,19 @@ export interface InferenceTelemetry {
 
 export interface PromptSegmentTelemetry {
   bytes: number
-  estimated_tokens: number
   fingerprint: string | null
 }
 
 export interface PromptTelemetry {
   fingerprint: string | null
-  estimated_total_tokens: number | null
-  estimated_cacheable_tokens: number | null
+  total_bytes: number | null
+  cacheable_bytes: number | null
   segments: Record<string, PromptSegmentTelemetry>
 }
 
 export interface CtxCompositionTelemetry {
   actual_input_tokens: number | null
-  display_total_tokens: number
-  estimated_known_tokens: number
+  attributed_bytes: number
   segments: Record<string, PromptSegmentTelemetry>
 }
 

--- a/lib/keeper/keeper_agent_prompt_metrics.ml
+++ b/lib/keeper/keeper_agent_prompt_metrics.ml
@@ -7,7 +7,7 @@ module Canonical_tool = Agent_sdk.Canonical_tool
     tool guidance, direct-reply mode) that must stay in the system prompt.
     [dynamic_context] contains soft context (continuity, skill route,
     worktree changes, turn instructions) injected via OAS
-    [extra_system_context] — prepended as a User message after reduction. *)
+    [extra_system_context] at request assembly. *)
 type turn_prompt =
   { system_prompt : string
   ; dynamic_context : string
@@ -17,17 +17,14 @@ type turn_prompt =
     Bytes are stored rather than character counts because prompts are UTF-8. *)
 type prompt_segment_metrics =
   { bytes : int
-  ; estimated_tokens : int
   ; fingerprint : string option
   }
 
-(** Effective prompt metrics for a keeper turn.
-    [estimated_cacheable_tokens] tracks the system prompt portion only because
-    OAS prompt caching is enabled via [cache_system_prompt:true]. *)
+(** Effective byte metrics for a keeper turn. *)
 type prompt_metrics =
   { fingerprint : string
-  ; estimated_total_tokens : int
-  ; estimated_cacheable_tokens : int
+  ; total_bytes : int
+  ; cacheable_bytes : int
   ; system_prompt_segment : prompt_segment_metrics
   ; dynamic_context_segment : prompt_segment_metrics
   ; user_message_segment : prompt_segment_metrics
@@ -35,20 +32,17 @@ type prompt_metrics =
 
 type ctx_composition_metrics =
   { actual_input_tokens : int option
-  ; display_total_tokens : int
-  ; estimated_known_tokens : int
+  ; attributed_bytes : int
   ; segments : (string * prompt_segment_metrics) list
   }
 
 let empty_prompt_segment_metrics =
-  { bytes = 0; estimated_tokens = 0; fingerprint = None }
+  { bytes = 0; fingerprint = None }
 
 let prompt_segment_metrics_of_text (text : string) : prompt_segment_metrics =
   let text = Inference_utils.sanitize_text_utf8 text in
   {
     bytes = String.length text;
-    estimated_tokens =
-      (if text = "" then 0 else Agent_sdk.Context_reducer.estimate_char_tokens text);
     fingerprint =
       (if text = ""
        then None
@@ -74,11 +68,11 @@ let build_prompt_metrics ~(system_prompt : string) ~(dynamic_context : string)
   in
   {
     fingerprint = Digestif.SHA256.(digest_string fingerprint_input |> to_hex);
-    estimated_total_tokens =
-      (system_prompt_metrics.estimated_tokens
-       + dynamic_context_metrics.estimated_tokens
-       + user_message_metrics.estimated_tokens);
-    estimated_cacheable_tokens = system_prompt_metrics.estimated_tokens;
+    total_bytes =
+      (system_prompt_metrics.bytes
+       + dynamic_context_metrics.bytes
+       + user_message_metrics.bytes);
+    cacheable_bytes = system_prompt_metrics.bytes;
     system_prompt_segment = system_prompt_metrics;
     dynamic_context_segment = dynamic_context_metrics;
     user_message_segment = user_message_metrics;
@@ -89,7 +83,6 @@ let prompt_segment_metrics_to_json (segment : prompt_segment_metrics) :
   `Assoc
     [
       ("bytes", `Int segment.bytes);
-      ("estimated_tokens", `Int segment.estimated_tokens);
       ("fingerprint", Json_util.string_opt_to_json segment.fingerprint);
     ]
 
@@ -97,15 +90,12 @@ let prompt_metrics_to_json (metrics : prompt_metrics) : Yojson.Safe.t =
   `Assoc
     [
       ("fingerprint", `String metrics.fingerprint);
-      ("estimated_total_tokens", `Int metrics.estimated_total_tokens);
-      ("estimated_cacheable_tokens", `Int metrics.estimated_cacheable_tokens);
+      ("total_bytes", `Int metrics.total_bytes);
+      ("cacheable_bytes", `Int metrics.cacheable_bytes);
       ("system_prompt", prompt_segment_metrics_to_json metrics.system_prompt_segment);
       ("dynamic_context", prompt_segment_metrics_to_json metrics.dynamic_context_segment);
       ("user_message", prompt_segment_metrics_to_json metrics.user_message_segment);
     ]
-
-let synthetic_prompt_segment_metrics ~estimated_tokens : prompt_segment_metrics =
-  { bytes = 0; estimated_tokens; fingerprint = None }
 
 let add_segment_metric
     (totals : (string, prompt_segment_metrics) Hashtbl.t)
@@ -119,12 +109,11 @@ let add_segment_metric
   Hashtbl.replace totals bucket
     {
       bytes = prev.bytes + metric.bytes;
-      estimated_tokens = prev.estimated_tokens + metric.estimated_tokens;
       fingerprint = None;
     }
 
 let metric_of_block
-    ~(role : Agent_sdk.Types.role)
+    ~role:(_ : Agent_sdk.Types.role)
     (block : Agent_sdk.Types.content_block) : prompt_segment_metrics =
   let bytes =
     match Canonical_tool.tool_result_of_block block with
@@ -156,12 +145,7 @@ let metric_of_block
                 "keeper_agent_prompt_metrics: OAS canonical tool-call projection unavailable"
           | _ -> 0))
   in
-  let msg : Agent_sdk.Types.message = Agent_sdk.Types.make_message ~role [ block ] in
-  {
-    bytes;
-    estimated_tokens = Keeper_context_core.msg_tokens msg;
-    fingerprint = None;
-  }
+  { bytes; fingerprint = None }
 
 let history_bucket_of_block
     ~(role : Agent_sdk.Types.role)
@@ -198,7 +182,7 @@ let build_ctx_composition_metrics
   let totals : (string, prompt_segment_metrics) Hashtbl.t = Hashtbl.create 16 in
   let add_text_segment bucket text =
     let metric = prompt_segment_metrics_of_text text in
-    if metric.estimated_tokens > 0 then add_segment_metric totals ~bucket metric
+    if metric.bytes > 0 then add_segment_metric totals ~bucket metric
   in
   add_text_segment "system_prompt" system_prompt;
   add_text_segment "dynamic_context" dynamic_context;
@@ -211,7 +195,7 @@ let build_ctx_composition_metrics
         (fun block ->
           let bucket = history_bucket_of_block ~role:message.role block in
           let metric = metric_of_block ~role:message.role block in
-          if metric.estimated_tokens > 0 then add_segment_metric totals ~bucket metric)
+          if metric.bytes > 0 then add_segment_metric totals ~bucket metric)
         message.content)
     history_messages;
   let segments =
@@ -219,9 +203,9 @@ let build_ctx_composition_metrics
     |> List.of_seq
     |> List.sort (fun (left, _) (right, _) -> String.compare left right)
   in
-  let estimated_known_tokens =
+  let attributed_bytes =
     List.fold_left
-      (fun acc (_, metric) -> acc + metric.estimated_tokens)
+      (fun acc (_, metric) -> acc + metric.bytes)
       0 segments
   in
   let actual_input_tokens =
@@ -229,23 +213,9 @@ let build_ctx_composition_metrics
     | Some n when n > 0 -> Some n
     | Some _ | None -> None
   in
-  let display_total_tokens =
-    match actual_input_tokens with
-    | Some actual -> max actual estimated_known_tokens
-    | None -> estimated_known_tokens
-  in
-  let segments =
-    if display_total_tokens > estimated_known_tokens then
-      segments
-      @ [ ( "unattributed",
-            synthetic_prompt_segment_metrics
-              ~estimated_tokens:(display_total_tokens - estimated_known_tokens) ) ]
-    else segments
-  in
   {
     actual_input_tokens;
-    display_total_tokens;
-    estimated_known_tokens;
+    attributed_bytes;
     segments;
   }
 
@@ -253,8 +223,7 @@ let ctx_composition_to_json (metrics : ctx_composition_metrics) : Yojson.Safe.t 
   `Assoc
     [
       ("actual_input_tokens", Json_util.int_opt_to_json metrics.actual_input_tokens);
-      ("display_total_tokens", `Int metrics.display_total_tokens);
-      ("estimated_known_tokens", `Int metrics.estimated_known_tokens);
+      ("attributed_bytes", `Int metrics.attributed_bytes);
       ( "segments",
         `Assoc
           (List.map

--- a/lib/keeper/keeper_agent_prompt_metrics.mli
+++ b/lib/keeper/keeper_agent_prompt_metrics.mli
@@ -2,7 +2,7 @@
 
 (** Structured prompt result from [build_turn_prompt] callback.
     [system_prompt] holds hard constraints; [dynamic_context]
-    holds soft context injected via OAS [extra_system_context]. *)
+    holds soft context injected through OAS [extra_system_context]. *)
 type turn_prompt =
   { system_prompt : string
   ; dynamic_context : string
@@ -12,17 +12,14 @@ type turn_prompt =
     Bytes are stored rather than character counts because prompts are UTF-8. *)
 type prompt_segment_metrics =
   { bytes : int
-  ; estimated_tokens : int
   ; fingerprint : string option
   }
 
-(** Effective prompt metrics for a keeper turn.
-    [estimated_cacheable_tokens] tracks the system prompt portion only
-    because OAS prompt caching is enabled via [cache_system_prompt:true]. *)
+(** Effective byte metrics for a keeper turn. *)
 type prompt_metrics =
   { fingerprint : string
-  ; estimated_total_tokens : int
-  ; estimated_cacheable_tokens : int
+  ; total_bytes : int
+  ; cacheable_bytes : int
   ; system_prompt_segment : prompt_segment_metrics
   ; dynamic_context_segment : prompt_segment_metrics
   ; user_message_segment : prompt_segment_metrics
@@ -31,14 +28,13 @@ type prompt_metrics =
 (** Per-bucket attribution of an Agent.run input window. *)
 type ctx_composition_metrics =
   { actual_input_tokens : int option
-  ; display_total_tokens : int
-  ; estimated_known_tokens : int
+  ; attributed_bytes : int
   ; segments : (string * prompt_segment_metrics) list
   }
 
 val empty_prompt_segment_metrics : prompt_segment_metrics
 
-(** Compute byte/token/fingerprint for a single text segment after
+(** Compute byte count and fingerprint for a single text segment after
     UTF-8 sanitisation. *)
 val prompt_segment_metrics_of_text : string -> prompt_segment_metrics
 
@@ -52,11 +48,6 @@ val prompt_segment_metrics_to_json :
   prompt_segment_metrics -> Yojson.Safe.t
 
 val prompt_metrics_to_json : prompt_metrics -> Yojson.Safe.t
-
-(** Build a synthetic segment with [bytes=0] and no fingerprint —
-    used for the [unattributed] tail bucket. *)
-val synthetic_prompt_segment_metrics :
-  estimated_tokens:int -> prompt_segment_metrics
 
 (** Mutate [totals] by adding [metric] into [bucket]. *)
 val add_segment_metric :
@@ -75,9 +66,9 @@ val metric_of_block :
 val history_bucket_of_block :
   role:Agent_sdk.Types.role -> Agent_sdk.Types.content_block -> string
 
-(** [actual_input_tokens] is the LLM-reported input token count and is
-    only known after a provider response. Pre-call sites (prompt build)
-    must pass [None]; post-response sites pass [Some n]. *)
+(** [actual_input_tokens] is provider-reported and only known after a response.
+    It is not attributed to byte segments. [attributed_bytes] sums only the
+    exact textual/JSON components represented by [segments]. *)
 val build_ctx_composition_metrics :
   system_prompt:string ->
   dynamic_context:string ->

--- a/lib/keeper/keeper_run_prompt.ml
+++ b/lib/keeper/keeper_run_prompt.ml
@@ -44,25 +44,21 @@ let normalize_memory_fragment = Inference_utils.sanitize_text_utf8
 let sanitize_user_message = Inference_utils.sanitize_text_utf8
 
 let estimate_input_tokens
-    ~(prompt_metrics : Keeper_agent_prompt_metrics.prompt_metrics)
     ~(system_prompt : string)
     ~(dynamic_context : string)
     ~(memory_context : string)
     ~(temporal_context : string)
     ~(user_message : string)
     ~(history_messages : Agent_sdk.Types.message list) : int =
-  let composition =
-    Keeper_agent_prompt_metrics.build_ctx_composition_metrics
-      ~system_prompt
-      ~dynamic_context
-      ~memory_context
-      ~temporal_context
-      ~user_message
-      ~history_messages
-      ~actual_input_tokens:None
-  in
-  max prompt_metrics.Keeper_agent_prompt_metrics.estimated_total_tokens
-      composition.Keeper_agent_prompt_metrics.display_total_tokens
+  List.fold_left
+    (fun total text ->
+      total + Keeper_context_core_accessors.estimate_char_tokens text)
+    0
+    [ system_prompt; dynamic_context; memory_context; temporal_context; user_message ]
+  + List.fold_left
+      (fun total message -> total + Keeper_context_core.msg_tokens message)
+      0
+      history_messages
 
 let estimate_tool_schema_context
     ~(estimated_input_tokens : int)
@@ -268,7 +264,6 @@ let build_turn_context
   in
   let estimated_input_tokens =
     estimate_input_tokens
-      ~prompt_metrics
       ~system_prompt:turn_system_prompt
       ~dynamic_context
       ~memory_context

--- a/lib/keeper/keeper_run_prompt.mli
+++ b/lib/keeper/keeper_run_prompt.mli
@@ -50,7 +50,6 @@ val normalize_memory_fragment : string -> string
     local string deny-list. *)
 
 val estimate_input_tokens :
-  prompt_metrics:Keeper_agent_prompt_metrics.prompt_metrics ->
   system_prompt:string ->
   dynamic_context:string ->
   memory_context:string ->

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -415,15 +415,6 @@ let run_keeper_cycle
            No dynamic_context needed here. *)
                  { system_prompt; dynamic_context = "" }
                in
-               let prompt_timeout_metrics =
-                 Keeper_agent_run.build_prompt_metrics
-                   ~system_prompt
-                   ~dynamic_context:""
-                   ~user_message
-               in
-               let prompt_timeout_estimate_tokens =
-                 max 1 prompt_timeout_metrics.estimated_total_tokens
-               in
                (* 5. Run via OAS Agent.run() with transient-error retry.
                   The turn-local OAS Event_bus preserves factual
                   ToolCalled/ToolCompleted pairing and drives
@@ -730,18 +721,11 @@ let run_keeper_cycle
                     then Log.Keeper.warn
                     else Log.Keeper.error
                   in
-                  let failure_context_ratio =
-                    if final_execution.max_context <= 0
-                    then 0.0
-                    else
-                      float_of_int prompt_timeout_estimate_tokens
-                      /. float_of_int final_execution.max_context
-                  in
                   log_keeper_cycle_failed
                     ~keeper_name:meta.name
                     "%s: keeper cycle FAILED runtime=%s max_context=%d context_budget=%d \
-                     primary_budget=%d requested_override=%s estimated_input_tokens=%d \
-                     context_ratio=%.4f latency=%dms%s error=%s"
+                     primary_budget=%d requested_override=%s system_and_user_bytes=%d \
+                     latency=%dms%s error=%s"
                     meta.name
                     final_execution.runtime_id
                     final_execution.max_context
@@ -752,8 +736,7 @@ let run_keeper_cycle
                      with
                      | Some requested -> string_of_int requested
                      | None -> "none")
-                    prompt_timeout_estimate_tokens
-                    failure_context_ratio
+                    (String.length system_prompt + String.length user_message)
                     latency_ms
                     (if is_server_parse_rejection
                      then " (server parse rejection, auto-recoverable)"

--- a/test/test_keeper_prompt_metrics.ml
+++ b/test/test_keeper_prompt_metrics.ml
@@ -1,10 +1,10 @@
 (** P1-1c Harness: Keeper prompt structural metrics.
 
-    Measures system_prompt and dynamic_context token estimates after
+    Measures exact system_prompt and dynamic_context UTF-8 bytes after
     P1-1a hard/soft separation.  Validates that:
     1. system_prompt contains only hard constraints (shorter than combined)
     2. dynamic_context receives soft context elements
-    3. token budget is distributed correctly *)
+    3. byte attribution is exact *)
 
 open Alcotest
 
@@ -12,10 +12,7 @@ module KAR = Masc.Keeper_agent_run
 module KP = Masc.Keeper_prompt
 module KRP = Masc.Keeper_run_prompt
 
-(* CJK-aware token estimator from OAS *)
-let estimate_tokens s =
-  if s = "" then 0
-  else Agent_sdk.Context_reducer.estimate_char_tokens s
+let measure_bytes = String.length
 
 let has_in s needle =
   try ignore (Str.search_forward (Str.regexp_string needle) s 0); true
@@ -104,43 +101,47 @@ let build_combined () : string =
 let test_system_prompt_shorter_than_combined () =
   let tp = build_separated () in
   let combined = build_combined () in
-  let sys_tokens = estimate_tokens tp.system_prompt in
-  let combined_tokens = estimate_tokens combined in
-  let ratio =
-    Float.of_int sys_tokens /. Float.of_int combined_tokens
-  in
+  let system_bytes = measure_bytes tp.system_prompt in
+  let combined_bytes = measure_bytes combined in
   check bool
     (Printf.sprintf
-       "system_prompt (%d tok) < combined (%d tok), ratio=%.2f"
-       sys_tokens combined_tokens ratio)
-    true (sys_tokens < combined_tokens);
-  (* The separated system_prompt should be meaningfully shorter *)
-  check bool
-    (Printf.sprintf "ratio %.2f < 0.85 (meaningful reduction)" ratio)
-    true (ratio < 0.85)
+       "system_prompt (%d bytes) < combined (%d bytes)"
+       system_bytes combined_bytes)
+    true (system_bytes < combined_bytes)
 
 let test_dynamic_context_nonempty () =
   let tp = build_separated () in
-  let dyn_tokens = estimate_tokens tp.dynamic_context in
+  let dynamic_bytes = measure_bytes tp.dynamic_context in
   check bool
-    (Printf.sprintf "dynamic_context has %d tokens (> 0)" dyn_tokens)
-    true (dyn_tokens > 0)
+    (Printf.sprintf "dynamic_context has %d bytes (> 0)" dynamic_bytes)
+    true (dynamic_bytes > 0)
 
-let test_total_tokens_preserved () =
+let test_total_bytes_preserved () =
   let tp = build_separated () in
   let combined = build_combined () in
   let separated_total =
-    estimate_tokens tp.system_prompt + estimate_tokens tp.dynamic_context
+    measure_bytes tp.system_prompt + measure_bytes tp.dynamic_context
   in
-  let combined_total = estimate_tokens combined in
-  (* Token counts should be approximately equal.
-     Small differences are expected from separator formatting. *)
-  let diff = abs (separated_total - combined_total) in
-  check bool
-    (Printf.sprintf
-       "total tokens similar: separated=%d combined=%d diff=%d"
-       separated_total combined_total diff)
-    true (diff < 50)
+  let combined_total = measure_bytes combined in
+  check int "combined adds one two-byte separator"
+    (separated_total + String.length "\n\n")
+    combined_total
+
+let test_prompt_metrics_use_exact_utf8_bytes () =
+  let metrics =
+    KAR.build_prompt_metrics
+      ~system_prompt:"도구"
+      ~dynamic_context:"x"
+      ~user_message:""
+  in
+  check int "total UTF-8 bytes" 7 metrics.total_bytes;
+  check int "cacheable UTF-8 bytes" 6 metrics.cacheable_bytes;
+  let json = KAR.prompt_metrics_to_json metrics in
+  match json with
+  | `Assoc fields ->
+      check bool "retired token estimate is absent" false
+        (List.mem_assoc "estimated_total_tokens" fields)
+  | _ -> fail "prompt metrics must serialize as an object"
 
 let test_hard_constraints_in_system_only () =
   let tp = build_separated () in
@@ -297,30 +298,7 @@ let test_user_message_sanitizer_preserves_semantic_content () =
   check bool "preserves useful user request" true
     (has_in sanitized "Please inspect the current board status.")
 
-let test_token_report () =
-  (* Emit a structured report for A/B comparison *)
-  let tp = build_separated () in
-  let combined = build_combined () in
-  let sys_tok = estimate_tokens tp.system_prompt in
-  let dyn_tok = estimate_tokens tp.dynamic_context in
-  let combined_tok = estimate_tokens combined in
-  let cache_eligible_ratio =
-    Float.of_int sys_tok /. Float.of_int (sys_tok + dyn_tok)
-  in
-  Printf.printf "\n=== P1-1c Prompt Metrics Report ===\n";
-  Printf.printf "Pre-split (combined system_prompt):  %d tokens\n" combined_tok;
-  Printf.printf "Post-split system_prompt (hard):     %d tokens\n" sys_tok;
-  Printf.printf "Post-split dynamic_context (soft):   %d tokens\n" dyn_tok;
-  Printf.printf "Post-split total:                    %d tokens\n" (sys_tok + dyn_tok);
-  Printf.printf "System prompt reduction:             %.1f%%\n"
-    ((1.0 -. Float.of_int sys_tok /. Float.of_int combined_tok) *. 100.0);
-  Printf.printf "Cache-eligible ratio (system/total): %.1f%%\n"
-    (cache_eligible_ratio *. 100.0);
-  Printf.printf "===================================\n";
-  (* This test always passes — it's a measurement, not an assertion *)
-  check pass "report emitted" () ()
-
-let test_ctx_composition_splits_history_and_residual () =
+let test_ctx_composition_splits_history_bytes () =
   let history_messages =
     [
       {
@@ -375,40 +353,44 @@ let test_ctx_composition_splits_history_and_residual () =
       ~history_messages
       ~actual_input_tokens:(Some 1000)
   in
-  let segment_tokens key =
+  let segment_bytes key =
     metrics.segments
     |> List.assoc_opt key
-    |> Option.map (fun segment -> segment.KAR.estimated_tokens)
+    |> Option.map (fun segment -> segment.KAR.bytes)
     |> Option.value ~default:0
   in
   check bool "system prompt bucket present" true
-    (segment_tokens "system_prompt" > 0);
+    (segment_bytes "system_prompt" > 0);
   check bool "history user bucket present" true
-    (segment_tokens "history_user" > 0);
+    (segment_bytes "history_user" > 0);
   check bool "history assistant text bucket present" true
-    (segment_tokens "history_assistant_text" > 0);
+    (segment_bytes "history_assistant_text" > 0);
   check bool "history tool use bucket present" true
-    (segment_tokens "history_tool_use" > 0);
+    (segment_bytes "history_tool_use" > 0);
   check bool "history tool result bucket present" true
-    (segment_tokens "history_tool_result" > 0);
-  check bool "unattributed residual added" true
-    (segment_tokens "unattributed" > 0);
-  check int "display total anchored to actual input" 1000
-    metrics.display_total_tokens
+    (segment_bytes "history_tool_result" > 0);
+  check (option int) "provider token observation remains separate" (Some 1000)
+    metrics.actual_input_tokens;
+  check int "total bytes equal segment sum"
+    (List.fold_left (fun total (_, segment) -> total + segment.KAR.bytes) 0
+       metrics.segments)
+    metrics.attributed_bytes
 
 (* ── Suite ────────────────────────────────────────────── *)
 
 let () =
   run "keeper_prompt_metrics"
     [
-      ( "token_budget",
+      ( "byte_measurement",
         [
           test_case "system_prompt shorter than combined" `Quick
             test_system_prompt_shorter_than_combined;
           test_case "dynamic_context nonempty" `Quick
             test_dynamic_context_nonempty;
-          test_case "total tokens preserved" `Quick
-            test_total_tokens_preserved;
+          test_case "total bytes preserved" `Quick
+            test_total_bytes_preserved;
+          test_case "exact UTF-8 byte metrics" `Quick
+            test_prompt_metrics_use_exact_utf8_bytes;
         ] );
       ( "separation_harness",
         [
@@ -436,14 +418,9 @@ let () =
           test_case "user message sanitizer preserves semantic content" `Quick
             test_user_message_sanitizer_preserves_semantic_content;
         ] );
-      ( "metrics_report",
-        [
-          test_case "token report (A/B baseline)" `Quick
-            test_token_report;
-        ] );
       ( "ctx_composition",
         [
-          test_case "splits history buckets and residual" `Quick
-            test_ctx_composition_splits_history_and_residual;
+          test_case "splits history byte buckets" `Quick
+            test_ctx_composition_splits_history_bytes;
         ] );
     ]

--- a/test/test_keeper_runtime_observation_boundaries.ml
+++ b/test/test_keeper_runtime_observation_boundaries.ml
@@ -115,195 +115,6 @@ let test_runtime_provider_path_has_no_cumulative_run_timeout () =
     false
     (contains_substring source "Eio.Time.with_timeout_exn clock t run_fn")
 
-let make_tool name description : Agent_sdk.Tool.t =
-  Agent_sdk.Tool.create ~name ~description ~parameters:[]
-    (fun _input -> Ok { Agent_sdk.Types.content = "ok"; _meta = None })
-
-let test_tool_schema_estimate_adds_provider_payload () =
-  let tool = make_tool "large_schema_probe" (String.make 2048 'd') in
-  let estimate =
-    Keeper_run_prompt.estimate_tool_schema_context
-      ~estimated_input_tokens:10
-      ~tools:[ tool ]
-  in
-  Alcotest.(check int) "tool count" 1 estimate.tool_count;
-  Alcotest.(check bool)
-    "tool schema contributes tokens"
-    true
-    (estimate.tool_schema_tokens > 0);
-  Alcotest.(check int)
-    "tool-inclusive estimate is prompt estimate plus schema"
-    (10 + estimate.tool_schema_tokens)
-    estimate.estimated_input_tokens_with_tools
-
-let test_hook_context_estimate_skips_base_prompt_layers () =
-  let dynamic = String.make 400 'd' in
-  let temporal = String.make 400 't' in
-  let retry = String.make 400 'r' in
-  let connected_surface = String.make 400 'u' in
-  let expected =
-    Agent_sdk.Context_reducer.estimate_char_tokens retry
-    + Agent_sdk.Context_reducer.estimate_char_tokens connected_surface
-  in
-  Alcotest.(check int)
-    "only hook-only blocks are added to the post-hook estimate"
-    expected
-    (Keeper_run_prompt.estimate_unaccounted_extra_system_context_tokens
-       ~preflight_accounted_blocks:
-         [ Prompt_block_id.Dynamic_context; Prompt_block_id.Temporal_summary ]
-       [ Prompt_block_id.Dynamic_context, dynamic
-       ; Prompt_block_id.Temporal_summary, temporal
-       ; Prompt_block_id.Retry_nudge, retry
-       ; Prompt_block_id.Connected_surface, connected_surface
-       ])
-
-let test_extra_system_context_assembly_preserves_over_window_blocks () =
-  let assembly =
-    Keeper_run_prompt.assemble_extra_system_context
-      ~estimated_input_tokens_with_tools:90
-      ~max_context:100
-      ~existing_extra_system_context:None
-      ~preflight_accounted_blocks:[ Prompt_block_id.Dynamic_context ]
-      ~blocks:
-        [ Prompt_block_id.Dynamic_context, String.make 400 'd'
-        ; Prompt_block_id.Retry_nudge, String.make 400 'r'
-        ; Prompt_block_id.Connected_surface, "short connected surface"
-        ]
-  in
-  Alcotest.(check bool)
-    "dynamic context remains because preflight already accounted it"
-    true
-    (List.exists
-       (fun (block, _) ->
-          Prompt_block_id.equal block Prompt_block_id.Dynamic_context)
-       assembly.blocks);
-  Alcotest.(check bool)
-    "oversized hook-only retry nudge is preserved"
-    true
-    (List.exists
-       (fun (block, _) -> Prompt_block_id.equal block Prompt_block_id.Retry_nudge)
-       assembly.blocks);
-  Alcotest.(check bool)
-    "later hook-only block can still fit"
-    true
-    (List.exists
-       (fun (block, _) -> Prompt_block_id.equal block Prompt_block_id.Connected_surface)
-       assembly.blocks);
-  Alcotest.(check int) "every complete block reaches OAS" 3
-    (List.length assembly.blocks);
-  let assembled =
-    match assembly.extra_system_context with
-    | Some text -> text
-    | None -> Alcotest.fail "expected complete extra_system_context"
-  in
-  Alcotest.(check string)
-    "complete block text and source order reach OAS"
-    (String.make 400 'd'
-     ^ "\n\n"
-     ^ String.make 400 'r'
-     ^ "\n\nshort connected surface")
-    assembled;
-  Alcotest.(check bool)
-    "over-window estimate remains observational"
-    true
-    (assembly.post_hook_context_window_observation
-       .observed_over_context_tokens
-     > 0)
-
-let test_extra_system_context_assembly_accounts_assembled_overhead () =
-  let dynamic = String.make 40 'd' in
-  let hook_only = String.make 40 'u' in
-  let assembly =
-    Keeper_run_prompt.assemble_extra_system_context
-      ~estimated_input_tokens_with_tools:10
-      ~max_context:1_000
-      ~existing_extra_system_context:None
-      ~preflight_accounted_blocks:[ Prompt_block_id.Dynamic_context ]
-      ~blocks:
-        [ Prompt_block_id.Dynamic_context, dynamic
-        ; Prompt_block_id.Connected_surface, hook_only
-        ]
-  in
-  let assembled =
-    match assembly.extra_system_context with
-    | Some text -> text
-    | None -> Alcotest.fail "expected assembled extra_system_context"
-  in
-  let assembled_tokens =
-    Agent_sdk.Context_reducer.estimate_char_tokens assembled
-  in
-  let preflight_accounted_tokens =
-    Agent_sdk.Context_reducer.estimate_char_tokens dynamic
-  in
-  Alcotest.(check int)
-    "post-hook estimate accounts assembled context minus preflight-accounted blocks"
-    (10 + max 0 (assembled_tokens - preflight_accounted_tokens))
-    assembly.post_hook_estimated_input_tokens
-
-let test_keeper_preflight_wires_tool_inclusive_estimate () =
-  let agent_run_source = read_file "lib/keeper/keeper_agent_run.ml" in
-  let setup_source = read_file "lib/keeper/keeper_run_tools_setup.ml" in
-  Alcotest.(check bool)
-    "keeper computes tool schema context estimate"
-    true
-    (contains_substring setup_source "estimate_tool_schema_context");
-  Alcotest.(check bool)
-    "keeper preflight uses tool-inclusive estimate"
-    true
-    (contains_substring agent_run_source "estimated_input_tokens_with_tools");
-  Alcotest.(check bool)
-    "keeper writes context preflight manifest"
-    true
-    (contains_substring agent_run_source "context_preflight")
-
-let test_context_window_observation_reports_remaining_and_overage () =
-  let within =
-    Keeper_run_prompt.observe_context_window
-      ~estimated_input_tokens:100
-      ~max_context:128
-  in
-  Alcotest.(check int) "remaining under window" 28
-    within.observed_remaining_context_tokens;
-  Alcotest.(check int) "overage under window" 0
-    within.observed_over_context_tokens;
-  Alcotest.(check (float 0.0001))
-    "ratio under window"
-    (100.0 /. 128.0)
-    within.observed_context_usage_ratio;
-  let over =
-    Keeper_run_prompt.observe_context_window
-      ~estimated_input_tokens:140
-      ~max_context:128
-  in
-  Alcotest.(check int) "remaining over window" 0
-    over.observed_remaining_context_tokens;
-  Alcotest.(check int) "overage over window" 12
-    over.observed_over_context_tokens;
-  Alcotest.(check (float 0.0001))
-    "ratio over window"
-    (140.0 /. 128.0)
-    over.observed_context_usage_ratio
-
-let test_context_preflight_manifest_records_window_delta () =
-  let source = read_file "lib/keeper/keeper_agent_run.ml" in
-  Alcotest.(check bool)
-    "context preflight records remaining tokens"
-    true
-    (contains_substring source "remaining_context_tokens");
-  Alcotest.(check bool)
-    "context preflight records overage tokens"
-    true
-    (contains_substring source "over_context_tokens");
-  Alcotest.(check bool)
-    "context preflight records usage ratio"
-    true
-    (contains_substring source "context_usage_ratio");
-  Alcotest.(check bool)
-    "context preflight has no layer priority or fractional cap policy"
-    false
-    (contains_substring source "context_layers"
-     || contains_substring source "context_layer_policy")
-
 let test_context_injection_hook_records_post_tool_ledger () =
   let agent_run_source = read_file "lib/keeper/keeper_agent_run.ml" in
   Alcotest.(check bool)
@@ -323,14 +134,6 @@ let test_context_injection_hook_records_post_tool_ledger () =
     "hook records last tool result count"
     true
     (contains_substring hook_source "last_tool_result_count");
-  Alcotest.(check bool)
-    "hook records extra system context token estimate"
-    true
-    (contains_substring hook_source "extra_system_context_estimated_tokens");
-  Alcotest.(check bool)
-    "hook observes post-hook context against context window"
-    true
-    (contains_substring hook_source "post_hook_estimated_input_tokens");
   Alcotest.(check bool)
     "hook assembles all extra context before params are adjusted"
     true
@@ -359,35 +162,6 @@ let test_context_injection_hook_records_post_tool_ledger () =
     (contains_substring hook_source "post_hook_context_window_error_ref"
      || contains_substring agent_run_source "post_hook_context_window_error_ref")
 
-let test_keeper_preflight_reuses_setup_tool_estimate () =
-  let agent_run_source = read_file "lib/keeper/keeper_agent_run.ml" in
-  Alcotest.(check bool)
-    "keeper run reads setup tool estimate"
-    true
-    (contains_substring agent_run_source "s.Keeper_run_tools.tool_context_estimate");
-  Alcotest.(check bool)
-    "keeper run does not recompute tool schemas"
-    false
-    (contains_substring agent_run_source "estimate_tool_schema_context")
-
-let test_keeper_context_estimates_use_context_facade () =
-  let prompt_source = read_file "lib/keeper/keeper_run_prompt.ml" in
-  let hook_source = read_file "lib/keeper/keeper_run_tools_hooks.ml" in
-  Alcotest.(check bool)
-    "context estimation uses keeper facade"
-    true
-    (contains_substring prompt_source
-       "Keeper_context_core_accessors.estimate_char_tokens"
-     && contains_substring hook_source
-          "Keeper_context_core_accessors.estimate_char_tokens");
-  Alcotest.(check bool)
-    "context estimation avoids direct OAS estimator calls"
-    false
-    (contains_substring prompt_source
-       "Agent_sdk.Context_reducer.estimate_char_tokens"
-     || contains_substring hook_source
-          "Agent_sdk.Context_reducer.estimate_char_tokens")
-
 let () =
   Alcotest.run "keeper_runtime_observation_boundaries"
   [
@@ -405,31 +179,7 @@ let () =
           test_keeper_oas_path_has_no_bridge_total_timeout;
         Alcotest.test_case "runtime provider path has no cumulative timeout" `Quick
           test_runtime_provider_path_has_no_cumulative_run_timeout;
-        Alcotest.test_case "tool schema estimate adds provider payload" `Quick
-          test_tool_schema_estimate_adds_provider_payload;
-        Alcotest.test_case
-          "hook context estimate skips base prompt layers"
-          `Quick
-          test_hook_context_estimate_skips_base_prompt_layers;
-        Alcotest.test_case "extra system context preserves overflow blocks" `Quick
-          test_extra_system_context_assembly_preserves_over_window_blocks;
-        Alcotest.test_case
-          "extra system context assembly accounts overhead"
-          `Quick
-          test_extra_system_context_assembly_accounts_assembled_overhead;
-        Alcotest.test_case "keeper preflight wires tool-inclusive estimate" `Quick
-          test_keeper_preflight_wires_tool_inclusive_estimate;
-        Alcotest.test_case
-          "context window observation reports remaining and overage"
-          `Quick
-          test_context_window_observation_reports_remaining_and_overage;
-        Alcotest.test_case "context preflight manifest records window delta" `Quick
-          test_context_preflight_manifest_records_window_delta;
         Alcotest.test_case "context injection hook records post-tool ledger" `Quick
           test_context_injection_hook_records_post_tool_ledger;
-        Alcotest.test_case "keeper preflight reuses setup tool estimate" `Quick
-          test_keeper_preflight_reuses_setup_tool_estimate;
-        Alcotest.test_case "keeper context estimates use context facade" `Quick
-          test_keeper_context_estimates_use_context_facade;
       ] );
   ]

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -775,8 +775,7 @@ let () =
     in
     let ctx_composition : Masc.Keeper_agent_prompt_metrics.ctx_composition_metrics =
       { actual_input_tokens = None
-      ; display_total_tokens = 0
-      ; estimated_known_tokens = 0
+      ; attributed_bytes = 0
       ; segments = []
       }
     in


### PR DESCRIPTION
## What changed

- deletes tests that preserve local prompt-token, tool-schema-token, context-ratio, and over-window estimates
- removes assertions for preflight and post-hook estimated-token manifests
- keeps typed provider timeout observations and the exact post-tool context-injection ledger test
- does not disable the test executable or alter its Dune stanza

## Why

The deleted cases validate a heuristic contract that OAS 0.212 no longer provides and MASC must not recreate. Provider typed ContextOverflow is the overflow fact; exact bytes/fingerprints remain observation.

## PR boundary

This is intentionally stacked on #24455. The diff is +0/-250.

## Validation

- ocamlformat and parse check
- git diff --check
- scripts/dune-local.sh build test/test_keeper_runtime_observation_boundaries.exe

[근거] local focused Dune build and exact diff, confirmed 2026-07-15 KST, confidence High.
