### PR TITLE
refactor(keeper): trust typed provider overflow only

### DIFF
--- a/lib/keeper/keeper_turn_runtime_budget.ml
+++ b/lib/keeper/keeper_turn_runtime_budget.ml
@@ -346,20 +346,6 @@ let run_direct_no_progress_retry_loop
     ~is_retry:false
     ()
 
-type turn_event_bus_overflow =
-  Keeper_turn_runtime_budget_event_bus.turn_event_bus_overflow = {
-  estimated_tokens : int;
-  limit_tokens : int;
-}
-
-type turn_event_bus_compaction =
-  Keeper_turn_runtime_budget_event_bus.turn_event_bus_compaction = {
-  before_tokens : int;
-  after_tokens : int;
-  tokens_freed : int;
-  phase_hint : string;
-}
-
 type turn_event_bus_summary =
   Keeper_turn_runtime_budget_event_bus.turn_event_bus_summary = {
   correlation_id : string option;
@@ -367,10 +353,6 @@ type turn_event_bus_summary =
   caused_by : string option;
   event_count : int;
   payload_kinds : string list;
-  overflow_imminent : turn_event_bus_overflow option;
-  context_compact_started_count : int;
-  context_compacted_count : int;
-  last_compaction : turn_event_bus_compaction option;
 }
 
 let empty_turn_event_bus_summary =
@@ -401,114 +383,30 @@ let summarize_turn_event_bus
         | Some _ -> acc.caused_by
         | None -> evt.meta.caused_by
       in
-      let acc =
-        { acc with
-          correlation_id;
-          run_id;
-          caused_by;
-          event_count = acc.event_count + 1;
-          payload_kinds =
-            add_payload_kind acc.payload_kinds
-              (Agent_sdk.Event_bus.payload_kind evt.payload);
-        }
-      in
-      match evt.payload with
-      | Agent_sdk.Event_bus.ContextOverflowImminent
-          { estimated_tokens; limit_tokens; _ } ->
-          {
-            acc with
-            overflow_imminent =
-              Some { estimated_tokens; limit_tokens };
-          }
-      | Agent_sdk.Event_bus.ContextCompactStarted _ ->
-          {
-            acc with
-            context_compact_started_count =
-              acc.context_compact_started_count + 1;
-          }
-      | Agent_sdk.Event_bus.ContextCompacted
-          { before_tokens; after_tokens; phase; _ } ->
-          {
-            acc with
-            context_compacted_count = acc.context_compacted_count + 1;
-            last_compaction =
-              Some
-                {
-                  before_tokens;
-                  after_tokens;
-                  tokens_freed = max 0 (before_tokens - after_tokens);
-                  phase_hint = phase;
-                };
-          }
-      | _ -> acc)
+      { correlation_id;
+        run_id;
+        caused_by;
+        event_count = acc.event_count + 1;
+        payload_kinds =
+          add_payload_kind acc.payload_kinds
+            (Agent_sdk.Event_bus.payload_kind evt.payload);
+      })
     empty_turn_event_bus_summary
     events
 
 let turn_event_bus_overflow_evidence_detail
     (summary : turn_event_bus_summary) : string =
-  let option_int = function
-    | Some value -> string_of_int value
-    | None -> "none"
-  in
-  let overflow_estimated_tokens, overflow_limit_tokens =
-    match summary.overflow_imminent with
-    | Some overflow ->
-      Some overflow.estimated_tokens, Some overflow.limit_tokens
-    | None -> None, None
-  in
-  let last_compaction_detail =
-    match summary.last_compaction with
-    | None -> "last_compaction=none"
-    | Some compaction ->
-      Printf.sprintf
-        "last_compaction_before_tokens=%d,last_compaction_after_tokens=%d,\
-         last_compaction_tokens_freed=%d,last_compaction_phase=%s"
-        compaction.before_tokens
-        compaction.after_tokens
-        compaction.tokens_freed
-        compaction.phase_hint
-  in
   Printf.sprintf
-    "oas_retry_evidence(events=%d,payload_kinds=[%s],\
-     context_compact_started=%d,context_compacted=%d,%s,\
-     overflow_estimated_tokens=%s,overflow_limit_tokens=%s)"
+    "oas_retry_evidence(events=%d,payload_kinds=[%s])"
     summary.event_count
     (String.concat "," summary.payload_kinds)
-    summary.context_compact_started_count
-    summary.context_compacted_count
-    last_compaction_detail
-    (option_int overflow_estimated_tokens)
-    (option_int overflow_limit_tokens)
 
 let context_overflow_event_of_error
-    ~(fallback_tokens : int)
-    ?(turn_event_bus : turn_event_bus_summary =
-      empty_turn_event_bus_summary)
-    (err : Agent_sdk.Error.sdk_error) : Keeper_state_machine.event =
-  match turn_event_bus.overflow_imminent with
-  | Some { estimated_tokens; limit_tokens } ->
-      Keeper_state_machine.Context_overflow_detected
-        {
-          source = `Oas_signal;
-          token_count = max 0 estimated_tokens;
-          limit_tokens = Some limit_tokens;
-        }
-  | None ->
-      match err with
-      | Agent_sdk.Error.Api (ContextOverflow { limit; _ }) ->
-          Keeper_state_machine.Context_overflow_detected
-            {
-              source = `Prompt_rejected;
-              token_count = Option.value ~default:(max 0 fallback_tokens) limit;
-              limit_tokens = limit;
-            }
-      | _ ->
-          Keeper_state_machine.Context_overflow_detected
-            {
-              source = `Oas_signal;
-              token_count = max 0 fallback_tokens;
-              limit_tokens = None;
-            }
+    (err : Agent_sdk.Error.sdk_error) : Keeper_state_machine.event option =
+  match err with
+  | Agent_sdk.Error.Api (ContextOverflow { limit; _ }) ->
+    Some (Keeper_state_machine.Context_overflow_detected { limit_tokens = limit })
+  | _ -> None
 
 let record_overflow_failure
     ~(config : Workspace.config)

--- a/lib/keeper/keeper_turn_runtime_budget.ml
+++ b/lib/keeper/keeper_turn_runtime_budget.ml
@@ -394,10 +394,10 @@ let summarize_turn_event_bus
     empty_turn_event_bus_summary
     events
 
-let turn_event_bus_overflow_evidence_detail
+let turn_event_bus_evidence_detail
     (summary : turn_event_bus_summary) : string =
   Printf.sprintf
-    "oas_retry_evidence(events=%d,payload_kinds=[%s])"
+    "oas_event_evidence(events=%d,payload_kinds=[%s])"
     summary.event_count
     (String.concat "," summary.payload_kinds)
 

--- a/lib/keeper/keeper_turn_runtime_budget.mli
+++ b/lib/keeper/keeper_turn_runtime_budget.mli
@@ -170,28 +170,12 @@ val run_direct_no_progress_retry_loop :
     effects. Rotation is bounded only by the typed, finite runtime candidate
     set; no numeric Keeper budget participates in admission or retry. *)
 
-type turn_event_bus_overflow = {
-  estimated_tokens : int;
-  limit_tokens : int;
-}
-
-type turn_event_bus_compaction = {
-  before_tokens : int;
-  after_tokens : int;
-  tokens_freed : int;
-  phase_hint : string;
-}
-
 type turn_event_bus_summary = {
   correlation_id : string option;
   run_id : string option;
   caused_by : string option;
   event_count : int;
   payload_kinds : string list;
-  overflow_imminent : turn_event_bus_overflow option;
-  context_compact_started_count : int;
-  context_compacted_count : int;
-  last_compaction : turn_event_bus_compaction option;
 }
 
 val empty_turn_event_bus_summary : turn_event_bus_summary
@@ -204,14 +188,13 @@ val summarize_turn_event_bus :
 
 val turn_event_bus_overflow_evidence_detail :
   turn_event_bus_summary -> string
-(** Compact forensic string for preserving OAS compaction/retry event-bus
-    evidence inside the keeper overflow blocker detail. *)
+(** Compact forensic string for observed OAS events around a typed overflow. *)
 
 val context_overflow_event_of_error :
-  fallback_tokens:int ->
-  ?turn_event_bus:turn_event_bus_summary ->
   Agent_sdk.Error.sdk_error ->
-  Keeper_state_machine.event
+  Keeper_state_machine.event option
+(** [Some] only for typed [Api (ContextOverflow _)]. The event preserves the
+    provider-declared limit and never invents an actual input-token count. *)
 
 val record_overflow_failure :
   config:Workspace.config ->

--- a/lib/keeper/keeper_turn_runtime_budget.mli
+++ b/lib/keeper/keeper_turn_runtime_budget.mli
@@ -186,9 +186,10 @@ val merge_turn_event_bus_summary :
 val summarize_turn_event_bus :
   Agent_sdk.Event_bus.event list -> turn_event_bus_summary
 
-val turn_event_bus_overflow_evidence_detail :
+val turn_event_bus_evidence_detail :
   turn_event_bus_summary -> string
-(** Compact forensic string for observed OAS events around a typed overflow. *)
+(** Compact forensic string for observed OAS events around a typed provider
+    failure. *)
 
 val context_overflow_event_of_error :
   Agent_sdk.Error.sdk_error ->

--- a/lib/keeper/keeper_turn_runtime_budget_event_bus.ml
+++ b/lib/keeper/keeper_turn_runtime_budget_event_bus.ml
@@ -1,28 +1,8 @@
-(** Turn event-bus summary record + helpers.
+(** Turn event-bus observation summary.
 
-    Captures the within-turn observations emitted by
-    [Agent_sdk.Event_bus] — correlation/run identifiers, observed
-    overflow-imminent events, and context-compaction counters —
-    rolled up into a single [turn_event_bus_summary] record that the
-    keeper's post-turn handler attaches to the receipt.
-
-    Pure data + a left-biased merge (left wins on the
-    string-id and overflow_imminent slots; right wins on
-    last_compaction; counters sum). Verbatim extract from
-    [Keeper_turn_runtime_budget]; the parent retains transparent
-    record aliases + 2 value aliases. *)
-
-type turn_event_bus_overflow = {
-  estimated_tokens : int;
-  limit_tokens : int;
-}
-
-type turn_event_bus_compaction = {
-  before_tokens : int;
-  after_tokens : int;
-  tokens_freed : int;
-  phase_hint : string;
-}
+    OAS lifecycle events supply correlation metadata only. MASC-owned
+    compaction state must come from the lane's durable completion path,
+    never from this lossy observation bus. *)
 
 type turn_event_bus_summary = {
   correlation_id : string option;
@@ -30,10 +10,6 @@ type turn_event_bus_summary = {
   caused_by : string option;
   event_count : int;
   payload_kinds : string list;
-  overflow_imminent : turn_event_bus_overflow option;
-  context_compact_started_count : int;
-  context_compacted_count : int;
-  last_compaction : turn_event_bus_compaction option;
 }
 
 let empty_turn_event_bus_summary =
@@ -43,10 +19,6 @@ let empty_turn_event_bus_summary =
     caused_by = None;
     event_count = 0;
     payload_kinds = [];
-    overflow_imminent = None;
-    context_compact_started_count = 0;
-    context_compacted_count = 0;
-    last_compaction = None;
   }
 
 let add_payload_kind kinds kind =
@@ -73,16 +45,4 @@ let merge_turn_event_bus_summary
        | None -> right.caused_by);
     event_count = left.event_count + right.event_count;
     payload_kinds = merge_payload_kinds left.payload_kinds right.payload_kinds;
-    overflow_imminent =
-      (match right.overflow_imminent with
-       | Some _ -> right.overflow_imminent
-       | None -> left.overflow_imminent);
-    context_compact_started_count =
-      left.context_compact_started_count + right.context_compact_started_count;
-    context_compacted_count =
-      left.context_compacted_count + right.context_compacted_count;
-    last_compaction =
-      (match right.last_compaction with
-       | Some _ -> right.last_compaction
-       | None -> left.last_compaction);
   }

--- a/lib/keeper/keeper_turn_runtime_budget_event_bus.mli
+++ b/lib/keeper/keeper_turn_runtime_budget_event_bus.mli
@@ -1,16 +1,5 @@
-(** Turn event-bus summary record + helpers. *)
-
-type turn_event_bus_overflow = {
-  estimated_tokens : int;
-  limit_tokens : int;
-}
-
-type turn_event_bus_compaction = {
-  before_tokens : int;
-  after_tokens : int;
-  tokens_freed : int;
-  phase_hint : string;
-}
+(** Turn event-bus observation summary. Compaction lifecycle belongs to
+    MASC durable lane state, not the lossy OAS observation bus. *)
 
 type turn_event_bus_summary = {
   correlation_id : string option;
@@ -18,10 +7,6 @@ type turn_event_bus_summary = {
   caused_by : string option;
   event_count : int;
   payload_kinds : string list;
-  overflow_imminent : turn_event_bus_overflow option;
-  context_compact_started_count : int;
-  context_compacted_count : int;
-  last_compaction : turn_event_bus_compaction option;
 }
 
 val empty_turn_event_bus_summary : turn_event_bus_summary

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -611,14 +611,7 @@ let run_keeper_cycle
                     correlation_id
                 | None -> ());
                let event_bus_manifest_status =
-                 match turn_event_bus.correlation_id with
-                 | Some _ -> "observed"
-                 | None ->
-                   if turn_event_bus.context_compact_started_count > 0
-                      || turn_event_bus.context_compacted_count > 0
-                      || turn_event_bus.overflow_imminent <> None
-                   then "observed"
-                   else "empty"
+                 if turn_event_bus.event_count > 0 then "observed" else "empty"
                in
                let turn_state =
                  Keeper_unified_turn_manifest.append_manifest

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -19,20 +19,6 @@ val decide_degraded_retry
   -> Agent_sdk.Error.sdk_error
   -> degraded_retry_decision
 
-(** Turn-local overflow hint published by the OAS event bus before a
-    proactive compaction attempt. Exposed for regression tests. *)
-type turn_event_bus_overflow =
-  { estimated_tokens : int
-  ; limit_tokens : int
-  }
-
-type turn_event_bus_compaction =
-  { before_tokens : int
-  ; after_tokens : int
-  ; tokens_freed : int
-  ; phase_hint : string
-  }
-
 val user_message_with_hitl_resolution :
   base_path:string ->
   user_message:string ->
@@ -50,10 +36,6 @@ type turn_event_bus_summary =
   ; caused_by : string option
   ; event_count : int
   ; payload_kinds : string list
-  ; overflow_imminent : turn_event_bus_overflow option
-  ; context_compact_started_count : int
-  ; context_compacted_count : int
-  ; last_compaction : turn_event_bus_compaction option
   }
 
 (** Fold the drained OAS event-bus events for a single keeper turn into
@@ -61,8 +43,7 @@ type turn_event_bus_summary =
 val summarize_turn_event_bus : Agent_sdk.Event_bus.event list -> turn_event_bus_summary
 
 val turn_event_bus_overflow_evidence_detail : turn_event_bus_summary -> string
-(** Compact forensic string for preserving OAS compaction/retry event-bus
-    evidence inside the keeper overflow blocker detail. *)
+(** Compact forensic string for observed OAS events around a typed overflow. *)
 
 (** Turn-local tool-event pairing state used to detect event-bus integrity
     failures. Exposed for targeted tests. *)
@@ -80,13 +61,11 @@ val turn_tool_event_integrity_error
   :  turn_tool_event_tracker
   -> Agent_sdk.Error.sdk_error option
 
-(** Build the keeper overflow event from either a drained event-bus
-    signal or the structured OAS error fallback. Exposed for tests. *)
+(** Build an overflow event only from typed [Api (ContextOverflow _)].
+    Non-overflow errors return [None]. *)
 val context_overflow_event_of_error
-  :  fallback_tokens:int
-  -> ?turn_event_bus:turn_event_bus_summary
-  -> Agent_sdk.Error.sdk_error
-  -> Keeper_state_machine.event
+  :  Agent_sdk.Error.sdk_error
+  -> Keeper_state_machine.event option
 
 (** Resolve the initial keeper turn context budget from the keeper's routed
     runtime, so lifecycle context math matches the provider that will receive

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -42,7 +42,7 @@ type turn_event_bus_summary =
     the signals MASC currently consumes. *)
 val summarize_turn_event_bus : Agent_sdk.Event_bus.event list -> turn_event_bus_summary
 
-val turn_event_bus_overflow_evidence_detail : turn_event_bus_summary -> string
+val turn_event_bus_evidence_detail : turn_event_bus_summary -> string
 (** Compact forensic string for observed OAS events around a typed overflow. *)
 
 (** Turn-local tool-event pairing state used to detect event-bus integrity

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -348,7 +348,7 @@ let run (ctx : ctx)
           meta.name
           checkpoint_observed;
       match
-          Keeper_turn_runtime_budget.plan_degraded_retry_step
+          ( Keeper_turn_runtime_budget.plan_degraded_retry_step
             ~base_runtime:(runtime_id_of_meta meta)
             ~current_runtime_id:execution_runtime_id
             ~attempted_runtimes
@@ -384,9 +384,10 @@ let run (ctx : ctx)
                  Keeper_unified_turn_pre_dispatch.build_runtime_execution
                    ~meta
                    ~runtime_id)
+          , context_overflow_event_of_error err )
         with
         | Keeper_turn_runtime_budget.Degraded_retry_step_setup_failed
-            { retry = degraded_retry; reason = fallback_reason; fail_open_err } ->
+            { retry = degraded_retry; reason = fallback_reason; fail_open_err }, _ ->
              let productive_phase_elapsed_ms, retry_phase_elapsed_ms =
                current_turn_phase_elapsed_ms turn_state.retry_phase_started_at
              in
@@ -414,7 +415,7 @@ let run (ctx : ctx)
              mark_terminal_error fail_open_err;
              Error fail_open_err, turn_state
         | Keeper_turn_runtime_budget.Degraded_retry_step_prepared
-            { retry = degraded_retry; reason = fallback_reason; next = next_execution } ->
+            { retry = degraded_retry; reason = fallback_reason; next = next_execution }, _ ->
              let next_execution_runtime_id =
                next_execution.runtime_id
              in
@@ -470,8 +471,7 @@ let run (ctx : ctx)
                    next_execution_runtime_id :: attempted_runtimes
                }
                turn_state
-        | Keeper_turn_runtime_budget.Degraded_retry_step_not_allowed
-          when EC.is_context_overflow err ->
+        | Keeper_turn_runtime_budget.Degraded_retry_step_not_allowed, Some overflow_event ->
           Keeper_unified_turn_cascade_resolution.publish_cascade_resolution
             ~keeper_name:meta.name
             ~runtime_id:execution.runtime_id
@@ -483,12 +483,6 @@ let run (ctx : ctx)
             ~error_message:(Some (Agent_sdk.Error.to_string err));
           let current_turn_event_bus =
             drain_turn_event_bus ~site:"context_overflow_capture" ()
-          in
-          let overflow_event =
-            context_overflow_event_of_error
-              ~fallback_tokens:execution.max_context
-              ~turn_event_bus:current_turn_event_bus
-              err
           in
           let overflow_evidence_detail =
             turn_event_bus_overflow_evidence_detail current_turn_event_bus
@@ -517,21 +511,19 @@ let run (ctx : ctx)
               ]
             ();
           Log.Keeper.warn
-            "%s: OAS returned context overflow after its own retry \
-             path; MASC will not compact/retry within this turn — \
-             recording explicit overflow failure evidence: %s"
+            "%s: provider returned typed context overflow after runtime \
+             rotation; recording explicit lane recovery evidence: %s"
             meta.name
             (short_preview (Agent_sdk.Error.to_string err));
-          (* OAS already exhausted its own proactive + emergency compaction
-             for this turn, so MASC records the terminal failure and returns.
-             The next Keeper cycle remains available. *)
+          (* This attempt returns its typed provider error. The Keeper lifecycle
+             remains active; MASC lane compaction owns subsequent recovery. *)
           record_overflow_failure
             ~config
             ~meta
             ~reason:"context_overflow_after_oas_retry";
           mark_terminal_error err;
           Error err, turn_state
-        | Keeper_turn_runtime_budget.Degraded_retry_step_not_allowed ->
+        | Keeper_turn_runtime_budget.Degraded_retry_step_not_allowed, None ->
           Keeper_unified_turn_cascade_resolution.publish_cascade_resolution
             ~keeper_name:meta.name
             ~runtime_id:execution.runtime_id

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -476,7 +476,7 @@ let run (ctx : ctx)
             ~keeper_name:meta.name
             ~runtime_id:execution.runtime_id
             ~decision:No_degraded_retry
-            ~reason:"context_overflow_after_oas_retry"
+            ~reason:"provider_context_overflow"
             ~next_runtime:None
             ~attempt
             ~error_kind:(Some (Keeper_agent_error.sdk_error_kind err))
@@ -485,7 +485,7 @@ let run (ctx : ctx)
             drain_turn_event_bus ~site:"context_overflow_capture" ()
           in
           let overflow_evidence_detail =
-            turn_event_bus_overflow_evidence_detail current_turn_event_bus
+            turn_event_bus_evidence_detail current_turn_event_bus
           in
           let turn_state =
             { turn_state with
@@ -507,7 +507,7 @@ let run (ctx : ctx)
               [ "keeper", meta.name
               ; "phase",
                 Keeper_oas_execution_error_phase.(
-                  to_label Context_overflow_after_oas_retry)
+                  to_label Provider_context_overflow)
               ]
             ();
           Log.Keeper.warn
@@ -520,7 +520,7 @@ let run (ctx : ctx)
           record_overflow_failure
             ~config
             ~meta
-            ~reason:"context_overflow_after_oas_retry";
+            ~reason:"provider_context_overflow";
           mark_terminal_error err;
           Error err, turn_state
         | Keeper_turn_runtime_budget.Degraded_retry_step_not_allowed, None ->

--- a/lib/keeper/keeper_unified_turn_types.ml
+++ b/lib/keeper/keeper_unified_turn_types.ml
@@ -35,28 +35,6 @@ let require_last_execution_for_finalize ~keeper_name turn_state =
 let turn_event_bus_manifest_decision
       (summary : Keeper_turn_runtime_budget.turn_event_bus_summary)
   =
-  let overflow =
-    match summary.overflow_imminent with
-    | None -> `Null
-    | Some overflow ->
-      `Assoc
-        [
-          ("estimated_tokens", `Int overflow.estimated_tokens);
-          ("limit_tokens", `Int overflow.limit_tokens);
-        ]
-  in
-  let last_compaction =
-    match summary.last_compaction with
-    | None -> `Null
-    | Some compaction ->
-      `Assoc
-        [
-          ("before_tokens", `Int compaction.before_tokens);
-          ("after_tokens", `Int compaction.after_tokens);
-          ("tokens_freed", `Int compaction.tokens_freed);
-          ("phase_hint", `String compaction.phase_hint);
-        ]
-  in
   `Assoc
     [
       ("correlation_id", Json_util.string_opt_to_json summary.correlation_id);
@@ -64,11 +42,6 @@ let turn_event_bus_manifest_decision
       ("caused_by", Json_util.string_opt_to_json summary.caused_by);
       ("event_count", `Int summary.event_count);
       ("payload_kinds", Json_util.json_string_list summary.payload_kinds);
-      ("overflow_imminent", overflow);
-      ( "context_compact_started_count",
-        `Int summary.context_compact_started_count );
-      ("context_compacted_count", `Int summary.context_compacted_count);
-      ("last_compaction", last_compaction);
     ]
 ;;
 

--- a/lib/keeper_metrics/keeper_oas_execution_error_phase.ml
+++ b/lib/keeper_metrics/keeper_oas_execution_error_phase.ml
@@ -6,7 +6,7 @@ type t =
   | Persistent_escalation
   | Resilience_audit_store
   | Overflow_retry_oas_load
-  | Context_overflow_after_oas_retry
+  | Provider_context_overflow
 
 let to_label = function
   | Turn_start -> "turn_start"
@@ -16,5 +16,5 @@ let to_label = function
   | Persistent_escalation -> "persistent_escalation"
   | Resilience_audit_store -> "resilience_audit_store"
   | Overflow_retry_oas_load -> "overflow_retry_oas_load"
-  | Context_overflow_after_oas_retry -> "context_overflow_after_oas_retry"
+  | Provider_context_overflow -> "provider_context_overflow"
 ;;

--- a/lib/keeper_metrics/keeper_oas_execution_error_phase.mli
+++ b/lib/keeper_metrics/keeper_oas_execution_error_phase.mli
@@ -20,6 +20,6 @@ type t =
   | Persistent_escalation
   | Resilience_audit_store
   | Overflow_retry_oas_load
-  | Context_overflow_after_oas_retry
+  | Provider_context_overflow
 
 val to_label : t -> string

--- a/lib/keeper_registry/keeper_state_machine.ml
+++ b/lib/keeper_registry/keeper_state_machine.ml
@@ -287,12 +287,9 @@ let entry_actions_for ~prev_phase ~new_phase ~(event : event) : entry_action lis
         "overflowed"
         (match event with
          | Context_overflow_detected r ->
-           let lim =
-             match r.limit_tokens with
-             | Some n -> Printf.sprintf ",limit=%d" n
-             | None -> ""
-           in
-           Printf.sprintf "tokens=%d%s" r.token_count lim
+           (match r.limit_tokens with
+            | Some n -> Printf.sprintf "limit=%d" n
+            | None -> "limit=unknown")
          | Heartbeat_ok
          | Heartbeat_failed _
          | Turn_succeeded

--- a/lib/keeper_registry/keeper_state_machine.mli
+++ b/lib/keeper_registry/keeper_state_machine.mli
@@ -172,16 +172,10 @@ type event =
   | Supervisor_restart_attempt of { attempt : int }
   | Credential_archived
   | Context_overflow_detected of {
-      source : [`Prompt_rejected | `Oas_signal];
-      token_count : int;
       limit_tokens : int option;
     }
-    (** Provider rejected prompt for exceeding max context.
-        [`Prompt_rejected] is sourced from a failed unified turn
-        (see [Keeper_error_classify.is_context_overflow]);
-        [`Oas_signal] is sourced either from structured OAS overflow
-        diagnostics or from the drained OAS [Event_bus]
-        [ContextOverflowImminent] signal for the same turn. *)
+    (** Provider returned typed [ContextOverflow]. [limit_tokens] is only the
+        provider-declared window limit; actual input tokens remain unknown. *)
   | Auto_compact_triggered
     (** Legacy explicit input; no entry action produces this event. *)
   | Operator_compact_requested

--- a/lib/keeper_registry/keeper_state_machine_json.ml
+++ b/lib/keeper_registry/keeper_state_machine_json.ml
@@ -89,11 +89,6 @@ let event_to_json (ev : event) : Yojson.Safe.t =
     obj "supervisor_restart_attempt" [ "attempt", `Int r.attempt ]
   | Credential_archived -> obj "credential_archived" []
   | Context_overflow_detected r ->
-    let source =
-      match r.source with
-      | `Prompt_rejected -> "prompt_rejected"
-      | `Oas_signal -> "oas_signal"
-    in
     let limit_tokens =
       match r.limit_tokens with
       | Some n -> `Int n
@@ -101,10 +96,7 @@ let event_to_json (ev : event) : Yojson.Safe.t =
     in
     obj
       "context_overflow_detected"
-      [ "source", `String source
-      ; "token_count", `Int r.token_count
-      ; "limit_tokens", limit_tokens
-      ]
+      [ "limit_tokens", limit_tokens ]
   | Auto_compact_triggered -> obj "auto_compact_triggered" []
   | Operator_compact_requested -> obj "operator_compact_requested" []
   | Operator_clear_requested r ->

--- a/lib/keeper_registry/keeper_state_machine_types.ml
+++ b/lib/keeper_registry/keeper_state_machine_types.ml
@@ -105,10 +105,7 @@ type event =
   | Supervisor_restart_attempt of { attempt : int }
   | Credential_archived
   | Context_overflow_detected of
-      { source : [ `Prompt_rejected | `Oas_signal ]
-      ; token_count : int
-      ; limit_tokens : int option
-      }
+      { limit_tokens : int option }
   | Auto_compact_triggered
   | Operator_compact_requested
   | Operator_clear_requested of
@@ -151,21 +148,12 @@ let event_to_string = function
     Printf.sprintf "supervisor_restart_attempt(%d)" r.attempt
   | Credential_archived -> "credential_archived"
   | Context_overflow_detected r ->
-    let src =
-      match r.source with
-      | `Prompt_rejected -> "prompt_rejected"
-      | `Oas_signal -> "oas_signal"
-    in
     let lim =
       match r.limit_tokens with
       | Some n -> string_of_int n
       | None -> "?"
     in
-    Printf.sprintf
-      "context_overflow_detected(%s,tokens=%d,limit=%s)"
-      src
-      r.token_count
-      lim
+    Printf.sprintf "context_overflow_detected(limit=%s)" lim
   | Auto_compact_triggered -> "auto_compact_triggered"
   | Operator_compact_requested -> "operator_compact_requested"
   | Operator_clear_requested r ->

--- a/lib/keeper_registry/keeper_state_machine_types.mli
+++ b/lib/keeper_registry/keeper_state_machine_types.mli
@@ -63,10 +63,7 @@ type event =
     }
   | Supervisor_restart_attempt of { attempt : int; }
   | Credential_archived
-  | Context_overflow_detected of {
-      source : [ `Oas_signal | `Prompt_rejected ]; token_count : int;
-      limit_tokens : int option;
-    }
+  | Context_overflow_detected of { limit_tokens : int option; }
   | Auto_compact_triggered
   | Operator_compact_requested
   | Operator_clear_requested of { preserve_system : bool; reason : string; }

--- a/test/fixtures/context-overflow-qwen36-2026-06-29.env
+++ b/test/fixtures/context-overflow-qwen36-2026-06-29.env
@@ -2,4 +2,4 @@ runtime_id=ollama_cloud.stalecontext
 provider_model=qwen36-35b-a3b-mtp
 keeper_logged_max_context=524288
 oas_provider_limit=131072
-failure_shape=context_overflow_after_oas_retry
+failure_shape=provider_context_overflow

--- a/test/test_keeper_overflow_recovery.ml
+++ b/test/test_keeper_overflow_recovery.ml
@@ -20,11 +20,8 @@ let running_conds : SM.conditions =
     dead_tombstone_latched = false;
   }
 
-let overflow_event ?(tokens = 205_000) ?(limit = Some 200_000) () =
-  SM.Context_overflow_detected
-    { source = `Prompt_rejected;
-      token_count = tokens;
-      limit_tokens = limit }
+let overflow_event ?(limit = Some 200_000) () =
+  SM.Context_overflow_detected { limit_tokens = limit }
 
 let apply_ok phase conds ev =
   match SM.apply_event ~current_phase:phase ~conditions:conds ~event:ev

--- a/test/test_keeper_state_machine.ml
+++ b/test/test_keeper_state_machine.ml
@@ -2025,10 +2025,7 @@ let test_setclear_coverage () =
     ; "Credential_archived", SM.Credential_archived
     ; ( "Context_overflow_detected"
       , SM.Context_overflow_detected
-          { source = `Prompt_rejected
-          ; token_count = 205_000
-          ; limit_tokens = Some 200_000
-          } )
+          { limit_tokens = Some 200_000 } )
     ; "Auto_compact_triggered", SM.Auto_compact_triggered
     ; "Operator_compact_requested", SM.Operator_compact_requested
     ; ( "Operator_clear_requested"

--- a/test/test_keeper_state_machine_correspondence.ml
+++ b/test/test_keeper_state_machine_correspondence.ml
@@ -280,7 +280,7 @@ let canonical_events : (string * SM.event) list =
     ("SupervisorRestartAttempt", SM.Supervisor_restart_attempt { attempt = 1 });
     ( "ContextOverflowDetected",
       SM.Context_overflow_detected
-        { source = `Oas_signal; token_count = 200_000; limit_tokens = Some 200_000 } );
+        { limit_tokens = Some 200_000 } );
     ("AutoCompactTriggered", SM.Auto_compact_triggered);
     ("OperatorCompactRequested", SM.Operator_compact_requested);
     ( "OperatorClearRequested",

--- a/test/test_keeper_state_machine_pbt.ml
+++ b/test/test_keeper_state_machine_pbt.ml
@@ -70,18 +70,14 @@ let valid_events_for_phase (phase : SM.phase) (c : SM.conditions) : SM.event lis
         SM.Operator_stop { remove_meta = false };
         SM.Fiber_terminated { outcome = "crash"; provider_id = None; http_status = None };
         SM.Context_overflow_detected
-          { source = `Prompt_rejected;
-            token_count = 205000;
-            limit_tokens = Some 200000 };
+          { limit_tokens = Some 200000 };
       ]
     | SM.Failing ->
       [ SM.Heartbeat_ok; SM.Turn_succeeded;
         SM.Fiber_terminated { outcome = "crash"; provider_id = None; http_status = None };
         SM.Stop_requested; SM.Operator_pause;
         SM.Context_overflow_detected
-          { source = `Prompt_rejected;
-            token_count = 205000;
-            limit_tokens = Some 200000 };
+          { limit_tokens = Some 200000 };
       ]
     | SM.Overflowed ->
       [ SM.Auto_compact_triggered;

--- a/test/test_keeper_state_machine_preconditions.ml
+++ b/test/test_keeper_state_machine_preconditions.ml
@@ -158,7 +158,7 @@ let overflowed_conditions : SM.conditions =
 ;;
 
 (* [event_to_string] for payload-carrying events appends the payload
-   (e.g. "context_overflow_detected(prompt_rejected,...)"), so we use
+   (e.g. "context_overflow_detected(limit=...)"), so we use
    prefix match rather than equality. *)
 let assert_precondition_violation ~event_name err =
   match err with
@@ -175,7 +175,7 @@ let assert_precondition_violation ~event_name err =
 
 let overflow_event =
   SM.Context_overflow_detected
-    { source = `Prompt_rejected; token_count = 100_000; limit_tokens = Some 200_000 }
+    { limit_tokens = Some 200_000 }
 ;;
 
 let test_pre_overflow_during_compaction () =

--- a/test/test_keeper_unified_context_overflow.ml
+++ b/test/test_keeper_unified_context_overflow.ml
@@ -166,21 +166,6 @@ let test_preflight_overflow_does_not_bypass_driver_retry () =
     (contains_substring ~needle:"record_overflow_failure" execution_src)
 ;;
 
-let test_context_overflow_event_falls_back_without_event_bus_signal () =
-  match
-    UT.context_overflow_event_of_error
-      ~fallback_tokens:32_768
-      (Agent_sdk.Error.Api
-         (ContextOverflow { message = "prompt exceeds context"; limit = Some 32_768 }))
-  with
-  | KP.Context_overflow_detected
-      { source = `Prompt_rejected; token_count; limit_tokens = Some limit_tokens } ->
-    check int "fallback uses error limit" 32_768 token_count;
-    check int "fallback preserves limit" 32_768 limit_tokens
-  | event ->
-    fail ("expected prompt_rejected overflow event, got " ^ KP.event_to_string event)
-;;
-
 let () =
   run
     "keeper_unified_context_overflow"
@@ -205,10 +190,6 @@ let () =
             "preflight overflow does not bypass driver retry"
             `Quick
             test_preflight_overflow_does_not_bypass_driver_retry
-        ; test_case
-            "context_overflow_event falls back without event bus signal"
-            `Quick
-            test_context_overflow_event_falls_back_without_event_bus_signal
         ] )
     ]
 ;;

--- a/test/test_keeper_unified_context_overflow.ml
+++ b/test/test_keeper_unified_context_overflow.ml
@@ -123,7 +123,7 @@ let test_overflow_failure_contract_keeps_lifecycle_active () =
     (contains_substring ~needle:"Keeper lifecycle remains active" budget_src);
   let execution_src = read_file "lib/keeper/keeper_unified_turn_execution.ml" in
   check bool "post-OAS retry overflow has dedicated phase label" true
-    (contains_substring ~needle:"Context_overflow_after_oas_retry" execution_src);
+    (contains_substring ~needle:"Provider_context_overflow" execution_src);
   check bool "post-OAS retry overflow records failure" true
     (contains_substring ~needle:"record_overflow_failure" execution_src);
   check bool "overflow path has no paused-meta override" false

--- a/test/test_keeper_unified_context_overflow.ml
+++ b/test/test_keeper_unified_context_overflow.ml
@@ -4,8 +4,6 @@ module EC = Masc.Keeper_error_classify
 module UT = Masc.Keeper_unified_turn
 module KP = Keeper_state_machine
 
-let keeper_name = "test-keeper"
-
 let source_path path =
   if Filename.is_relative path then
     match Sys.getenv_opt "DUNE_SOURCEROOT" with
@@ -168,165 +166,6 @@ let test_preflight_overflow_does_not_bypass_driver_retry () =
     (contains_substring ~needle:"record_overflow_failure" execution_src)
 ;;
 
-let test_summarize_turn_event_bus_extracts_overflow_signal () =
-  let events =
-    [ Agent_sdk.Event_bus.mk_event
-        ~correlation_id:"cid-123"
-        ~run_id:"run-1"
-        (Agent_sdk.Event_bus.TurnStarted { agent_name = keeper_name; turn = 1 })
-    ; Agent_sdk.Event_bus.mk_event
-        ~correlation_id:"cid-123"
-        ~run_id:"run-1"
-        (Agent_sdk.Event_bus.ContextOverflowImminent
-           { agent_name = keeper_name
-           ; estimated_tokens = 205_000
-           ; limit_tokens = 200_000
-           ; ratio = 1.025
-           })
-    ]
-  in
-  let summary = UT.summarize_turn_event_bus events in
-  check int "event count" 2 summary.event_count;
-  check
-    (list string)
-    "payload kinds"
-    [ "turn_started"; "context_overflow_imminent" ]
-    summary.payload_kinds;
-  check
-    (option string)
-    "correlation id from first event"
-    (Some "cid-123")
-    summary.correlation_id;
-  check (option string) "run id from first event" (Some "run-1") summary.run_id;
-  check int "no compact started" 0 summary.context_compact_started_count;
-  check int "no compacted" 0 summary.context_compacted_count;
-  match summary.overflow_imminent with
-  | Some overflow ->
-    check int "estimated tokens" 205_000 overflow.estimated_tokens;
-    check int "limit tokens" 200_000 overflow.limit_tokens
-  | None -> fail "expected overflow_imminent summary"
-;;
-
-let test_summarize_turn_event_bus_extracts_compaction_signal () =
-  let events =
-    [ Agent_sdk.Event_bus.mk_event
-        ~correlation_id:"cid-compact"
-        ~run_id:"run-compact-start"
-        ~caused_by:"parent-run"
-        (Agent_sdk.Event_bus.ContextCompactStarted
-           { agent_name = keeper_name; trigger = "proactive" })
-    ; Agent_sdk.Event_bus.mk_event
-        ~correlation_id:"cid-compact"
-        ~run_id:"run-compact-done"
-        (Agent_sdk.Event_bus.ContextCompacted
-           { agent_name = keeper_name
-           ; before_tokens = 210_000
-           ; after_tokens = 120_000
-           ; phase = "proactive(85%)"
-           })
-    ]
-  in
-  let summary = UT.summarize_turn_event_bus events in
-  check int "compaction event count" 2 summary.event_count;
-  check
-    (list string)
-    "compaction payload kinds"
-    [ "context_compact_started"; "context_compacted" ]
-    summary.payload_kinds;
-  check
-    (option string)
-    "compaction correlation"
-    (Some "cid-compact")
-    summary.correlation_id;
-  check (option string) "compaction first run id" (Some "run-compact-start") summary.run_id;
-  check (option string) "compaction caused_by" (Some "parent-run") summary.caused_by;
-  check int "compact started count" 1 summary.context_compact_started_count;
-  check int "compacted count" 1 summary.context_compacted_count;
-  match summary.last_compaction with
-  | Some compaction ->
-    check int "before tokens" 210_000 compaction.before_tokens;
-    check int "after tokens" 120_000 compaction.after_tokens;
-    check int "tokens freed" 90_000 compaction.tokens_freed;
-    check string "phase hint" "proactive(85%)" compaction.phase_hint
-  | None -> fail "expected last compaction summary"
-;;
-
-let test_overflow_evidence_detail_preserves_oas_retry_attempts () =
-  let events =
-    [ Agent_sdk.Event_bus.mk_event
-        ~correlation_id:"cid-retry"
-        ~run_id:"run-compact-start-1"
-        (Agent_sdk.Event_bus.ContextCompactStarted
-           { agent_name = keeper_name; trigger = "proactive" })
-    ; Agent_sdk.Event_bus.mk_event
-        ~correlation_id:"cid-retry"
-        ~run_id:"run-compact-start-2"
-        (Agent_sdk.Event_bus.ContextCompactStarted
-           { agent_name = keeper_name; trigger = "emergency_retry" })
-    ; Agent_sdk.Event_bus.mk_event
-        ~correlation_id:"cid-retry"
-        ~run_id:"run-compact-done"
-        (Agent_sdk.Event_bus.ContextCompacted
-           { agent_name = keeper_name
-           ; before_tokens = 220_000
-           ; after_tokens = 130_000
-           ; phase = "emergency_retry"
-           })
-    ; Agent_sdk.Event_bus.mk_event
-        ~correlation_id:"cid-retry"
-        ~run_id:"run-overflow"
-        (Agent_sdk.Event_bus.ContextOverflowImminent
-           { agent_name = keeper_name
-           ; estimated_tokens = 180_000
-           ; limit_tokens = 131_072
-           ; ratio = 1.37
-           })
-    ]
-  in
-  let summary = UT.summarize_turn_event_bus events in
-  let detail = UT.turn_event_bus_overflow_evidence_detail summary in
-  check bool "detail carries compact start count" true
-    (contains_substring ~needle:"context_compact_started=2" detail);
-  check bool "detail carries compact done count" true
-    (contains_substring ~needle:"context_compacted=1" detail);
-  check bool "detail carries emergency retry phase" true
-    (contains_substring ~needle:"last_compaction_phase=emergency_retry" detail);
-  check bool "detail carries final provider limit" true
-    (contains_substring ~needle:"overflow_limit_tokens=131072" detail);
-  let execution_src = read_file "lib/keeper/keeper_unified_turn_execution.ml" in
-  check bool "execution writes OAS retry evidence into blocker detail" true
-    (contains_substring
-       ~needle:"turn_event_bus_overflow_evidence_detail"
-       execution_src)
-;;
-
-let test_context_overflow_event_prefers_event_bus_signal () =
-  let turn_event_bus : UT.turn_event_bus_summary =
-    { correlation_id = Some "cid-123"
-    ; run_id = Some "run-1"
-    ; caused_by = None
-    ; event_count = 1
-    ; payload_kinds = [ "context_overflow_imminent" ]
-    ; overflow_imminent = Some { estimated_tokens = 205_000; limit_tokens = 200_000 }
-    ; context_compact_started_count = 0
-    ; context_compacted_count = 0
-    ; last_compaction = None
-    }
-  in
-  match
-    UT.context_overflow_event_of_error
-      ~fallback_tokens:32_768
-      ~turn_event_bus
-      (Agent_sdk.Error.Api
-         (ContextOverflow { message = "prompt exceeds context"; limit = Some 32_768 }))
-  with
-  | KP.Context_overflow_detected
-      { source = `Oas_signal; token_count; limit_tokens = Some limit_tokens } ->
-    check int "estimated tokens win" 205_000 token_count;
-    check int "event bus limit wins" 200_000 limit_tokens
-  | event -> fail ("expected oas_signal overflow event, got " ^ KP.event_to_string event)
-;;
-
 let test_context_overflow_event_falls_back_without_event_bus_signal () =
   match
     UT.context_overflow_event_of_error
@@ -366,22 +205,6 @@ let () =
             "preflight overflow does not bypass driver retry"
             `Quick
             test_preflight_overflow_does_not_bypass_driver_retry
-        ; test_case
-            "summarize_turn_event_bus extracts overflow signal"
-            `Quick
-            test_summarize_turn_event_bus_extracts_overflow_signal
-        ; test_case
-            "summarize_turn_event_bus extracts compaction signal"
-            `Quick
-            test_summarize_turn_event_bus_extracts_compaction_signal
-        ; test_case
-            "overflow evidence detail preserves OAS retry attempts"
-            `Quick
-            test_overflow_evidence_detail_preserves_oas_retry_attempts
-        ; test_case
-            "context_overflow_event prefers event bus signal"
-            `Quick
-            test_context_overflow_event_prefers_event_bus_signal
         ; test_case
             "context_overflow_event falls back without event bus signal"
             `Quick


### PR DESCRIPTION
## What changed

- accepts only typed provider `Api (ContextOverflow _)` as a context-overflow fact
- deletes fallback token counts, estimated overflow payloads, and OAS compaction-event evidence
- removes compaction lifecycle fields from the generic OAS event summary
- reduces the Keeper overflow event to the provider-declared optional limit
- names the terminal turn failure `provider_context_overflow` instead of implying an OAS retry path
- updates the state-machine and overflow fixtures to the typed shape

## Boundary

OAS returns a typed provider error. MASC records that fact at the lane boundary; MASC does not invent a token count or infer overflow from an observation event. Subsequent durable compaction/reinjection remains MASC lane work.

## Verification

- `scripts/dune-local.sh build lib/keeper_metrics/keeper_metrics.cmxa lib/.masc.objs/byte/masc__Keeper_turn_runtime_budget.cmo`
- focused state-machine and overflow object builds after the full stack is composed
- `ocamlformat --inplace` on changed OCaml files
- `git diff --check`
- exact residue search for fallback token and OAS retry terminology

[근거] local focused builds and exact source audit, confirmed 2026-07-15 KST, confidence High.
