### PR TITLE
refactor(keeper): make heartbeat observation non-authoritative

### DIFF
--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -65,254 +65,122 @@ let register_record_pre_compact
   Atomic.set record_pre_compact_callback_atomic f
 ;;
 
-let pre_compact_is_local_model_of_meta meta =
-  let runtime_id_result =
-    try Ok (Keeper_meta_contract.runtime_id_of_meta meta) with
-    | Failure msg -> Error msg
-  in
-  match runtime_id_result with
-  | Error msg ->
-    (* DET-OK: pre-compact locality is observability only. Do not let a
-       startup-order failure in the default-runtime singleton block
-       compaction itself. *)
-    Log.Harness.warn
-      "[pre_compact] runtime locality unavailable for keeper=%s: %s; \
-       recording is_local_model=false"
-      meta.name
-      msg;
-    false
-  | Ok runtime_id ->
-    (match Runtime.is_local_runtime_id runtime_id with
-     | Some is_local -> is_local
-     | None ->
-       (* DET-OK: runtime dispatch owns fail-fast validation. This metric
-          only records locality when the runtime table is already materialized. *)
-       Log.Harness.warn
-         "[pre_compact] runtime locality unavailable for runtime_id=%s; \
-          recording is_local_model=false"
-         runtime_id;
-       false)
-;;
-
 type compaction_decision =
   | Applied of Compaction_trigger.t
+  | Prepared of Compaction_trigger.t
+  | Rejected of Compaction_trigger.t * compaction_rejection
   | Not_requested
   | Skipped_no_checkpoint
 
+and compaction_rejection =
+  | Retired_deterministic_mode
+  | Runtime_unavailable
+  | Summarizer_unavailable_or_invalid
+  | Structural_noop
+
+let compaction_rejection_to_string = function
+  | Retired_deterministic_mode -> "retired_deterministic_mode"
+  | Runtime_unavailable -> "runtime_unavailable"
+  | Summarizer_unavailable_or_invalid -> "summarizer_unavailable_or_invalid"
+  | Structural_noop -> "structural_noop"
+
 let compaction_decision_to_string = function
   | Applied trigger -> "applied:" ^ Compaction_trigger.to_human trigger
+  | Prepared trigger -> "prepared:" ^ Compaction_trigger.to_human trigger
+  | Rejected (trigger, reason) ->
+    Printf.sprintf "rejected:%s:%s"
+      (compaction_rejection_to_string reason)
+      (Compaction_trigger.to_human trigger)
   | Not_requested -> "not_requested"
   | Skipped_no_checkpoint -> "skipped:no_checkpoint"
 ;;
 
+let compaction_decision_prepared = function
+  | Prepared _ -> true
+  | Applied _ | Rejected _ | Not_requested | Skipped_no_checkpoint -> false
+;;
+
 let compaction_decision_applied = function
   | Applied _ -> true
-  | Not_requested | Skipped_no_checkpoint -> false
+  | Prepared _ | Rejected _ | Not_requested | Skipped_no_checkpoint -> false
 ;;
 
 let compaction_policy_of_keeper (meta : keeper_meta) : float * int * int =
   meta.compaction.ratio_gate, meta.compaction.message_gate, meta.compaction.token_gate
 ;;
 
+let serialize_messages messages =
+  Yojson.Safe.to_string (`List (List.map message_to_json messages))
+;;
+
 let compact_for_request_typed
       ~(meta : keeper_meta)
       ~(trigger : Compaction_trigger.t)
       (ctx : working_context)
-  : working_context * Compaction_trigger.t option * compaction_decision
+  : working_context * compaction_decision
   =
-  let ratio = context_ratio ctx in
-  let msg_count = message_count ctx in
-  let tok_count = token_count ctx in
-  let decision = Applied trigger in
-    let strategy_names =
-      match meta.compaction.mode with
-      | Keeper_config.Llm -> [ "ConfiguredLlm" ]
-      | Keeper_config.Deterministic -> [ "NoLocalReducer" ]
-    in
-    let trigger_human = Compaction_trigger.to_human trigger in
-    let trigger_label = Compaction_trigger.to_label trigger in
-    let trigger_detail = Compaction_trigger.to_detail_json trigger in
-    Log.Harness.info
-      "[pre_compact] keeper=%s ratio=%.4f messages=%d tokens=%d trigger=%s"
-      meta.name
-      ratio
-      msg_count
-      tok_count
-      trigger_human;
-    let pre_compact_context_window = max_tokens_of_context ctx in
-    let pre_compact_is_local_model = pre_compact_is_local_model_of_meta meta in
-    (* record_pre_compact's JSONL append is wrapped by
-       append_store_json_fail_open in Dashboard_harness_health, so this call
-       does not propagate non-Cancel exceptions today.  Keep the call
-       outside the try/catch only as long as that contract holds; if a
-       future revision adds throwing observability calls here, wrap them. *)
-    let pre_compact_event =
-      try
-        Atomic.get record_pre_compact_callback_atomic
-          ~keeper_name:meta.name
-          ~context_ratio:ratio
-          ~message_count:msg_count
-          ~token_count:tok_count
-          ~strategies:strategy_names
-          ~context_window:pre_compact_context_window
-          ~is_local_model:pre_compact_is_local_model
-          ~trigger
-      with
-      | Eio.Cancel.Cancelled _ as e -> raise e
-      | exn ->
-        Log.Harness.warn
-          "[pre_compact] dashboard record failed: %s"
-          (Printexc.to_string exn);
-        None
-    in
-    (match pre_compact_event with
-     | None -> ()
-     | Some pre_compact_event ->
-       (try
-          Sse.broadcast
-            (`Assoc
-                [ "type", `String "oas:masc:harness:pre_compact"
-                ; ( "payload"
-                  , `Assoc
-                      [ "timestamp", `Float pre_compact_event.timestamp
-                      ; "keeper_name", `String pre_compact_event.keeper_name
-                      ; "context_ratio", `Float pre_compact_event.context_ratio
-                      ; "message_count", `Int pre_compact_event.message_count
-                      ; "token_count", `Int pre_compact_event.token_count
-                      ; ( "strategies"
-                        , `List
-                            (List.map
-                               (fun value -> `String value)
-                               pre_compact_event.strategies) )
-                      ; "context_window", `Int pre_compact_event.context_window
-                      ; "is_local_model", `Bool pre_compact_event.is_local_model
-                      ; "trigger", `String trigger_label
-                      ; "trigger_detail", trigger_detail
-                      ] )
-                ])
+  let source_messages = messages_of_context ctx in
+  let reject reason detail =
+    Log.Keeper.warn ~keeper_name:meta.name "context compaction rejected: %s" detail;
+    Error reason
+  in
+  let candidate =
+    match meta.compaction.mode with
+    | Keeper_config.Deterministic ->
+      reject Retired_deterministic_mode "deterministic reducer is retired"
+    | Keeper_config.Llm ->
+      let runtime_id =
+        try
+          let id = Keeper_meta_contract.runtime_id_of_meta meta |> String.trim in
+          if id = "" then reject Runtime_unavailable "runtime identity is empty"
+          else Ok id
         with
-        | Eio.Cancel.Cancelled _ as e -> raise e
-        | exn ->
-          Log.Harness.warn "[pre_compact] sse broadcast failed: %s" (Printexc.to_string exn)));
-    (match pre_compact_event with
-     | None -> ()
-     | Some _ ->
-       Keeper_event_publisher.publish_keeper_snapshot
-         ~keeper_name:meta.name
-         ~generation:meta.runtime.generation
-         ~context_ratio:ratio
-         ~message_count:msg_count);
+        | Failure detail -> reject Runtime_unavailable detail
+      in
+      (match runtime_id with
+       | Error _ as error -> error
+       | Ok runtime_id ->
+         (match
+            Keeper_compaction_llm_summarizer.make
+              ~runtime_id
+              ~keeper_name:meta.name
+              ()
+          with
+          | None ->
+            reject
+              Summarizer_unavailable_or_invalid
+              "configured summarizer is unavailable"
+          | Some summarize ->
+            (match summarize ~messages:source_messages with
+             | None ->
+               reject
+                 Summarizer_unavailable_or_invalid
+                 "no valid semantic compaction plan"
+             | Some plan ->
+               Ok
+                 (Keeper_compaction_llm_summarizer.apply
+                    plan
+                    ~messages:source_messages))))
+  in
+  match candidate with
+  | Error reason -> ctx, Rejected (trigger, reason)
+  | Ok candidate ->
     let messages, pair_repair_stats =
-      let preserve_original reason =
-        Log.Keeper.warn
-          ~keeper_name:meta.name
-          "MASC context compaction preserved the original checkpoint: %s"
-          reason;
-        messages_of_context ctx
-      in
-      let msgs_after_compact =
-        match meta.compaction.mode with
-        | Keeper_config.Deterministic ->
-          preserve_original
-            "the retired deterministic reducer mode cannot judge message importance"
-        | Keeper_config.Llm ->
-          let runtime_id =
-            try
-              let runtime_id = Keeper_meta_contract.runtime_id_of_meta meta in
-              if String.trim runtime_id = "" then None else Some runtime_id
-            with
-            | Failure reason ->
-              Log.Keeper.warn
-                ~keeper_name:meta.name
-                "compaction LLM runtime identity failed: %s"
-                reason;
-              None
-          in
-          (match runtime_id with
-           | None -> preserve_original "configured LLM runtime is unavailable"
-           | Some runtime_id ->
-             (match
-                Keeper_compaction_llm_summarizer.make
-                  ~runtime_id
-                  ~keeper_name:meta.name
-                  ()
-              with
-              | None -> preserve_original "configured LLM summarizer is unavailable"
-              | Some summarizer ->
-                let msgs = messages_of_context ctx in
-                (match summarizer ~messages:msgs with
-                 | Some plan ->
-                   Keeper_compaction_llm_summarizer.apply plan ~messages:msgs
-                 | None ->
-                   preserve_original "configured LLM returned no valid plan")))
-      in
-      Keeper_context_core.repair_broken_tool_call_pairs_with_stats msgs_after_compact
+      Keeper_context_core.repair_broken_tool_call_pairs_with_stats candidate
     in
     let compacted_ctx =
       sync_oas_context
         { ctx with checkpoint = { (checkpoint_of_context ctx) with messages } }
     in
-    let new_ratio = context_ratio compacted_ctx in
-    let new_msg_count = message_count compacted_ctx in
-    let new_tok_count = token_count compacted_ctx in
-    (* RFC-0149 §3.2 PR-2 — the silent [max 0 (pre - post)] floor and
-       the companion [metric_keeper_compaction_negative_savings] counter
-       (a §1 telemetry-as-fix artefact) are replaced by a phantom-typed
-       [Keeper_token_count.saved] match.  The [`Divergent] arm carries the
-       overrun magnitude as a typed payload that surfaces on the
-       post-compact JSONL record below ([tokens_divergence] /
-       [messages_divergence]), so operators can detect estimator
-       drift without a free-floating Otel_metric_store counter. *)
-    let saved_tokens, tokens_divergence =
-      match
-        Keeper_token_count.saved
-          ~pre:(Keeper_token_count.pre_estimate tok_count)
-          ~post:(Keeper_token_count.post_recount new_tok_count)
-      with
-      | `Saved n -> n, None
-      | `Divergent n -> 0, Some n
-    in
-    let saved_messages, messages_divergence =
-      match
-        Keeper_token_count.saved
-          ~pre:(Keeper_token_count.pre_estimate msg_count)
-          ~post:(Keeper_token_count.post_recount new_msg_count)
-      with
-      | `Saved n -> n, None
-      | `Divergent n -> 0, Some n
-    in
-    Otel_metric_store.inc_counter
-      Keeper_metrics.(to_string Compactions)
-      ~labels:[ "keeper", meta.name ]
-      ();
-    Otel_metric_store.set_gauge
-      Keeper_metrics.(to_string CompactionRatioChange)
-      ~labels:[ "keeper", meta.name ]
-      (ratio -. new_ratio);
-    Otel_metric_store.inc_counter
-      Keeper_metrics.(to_string CompactionSavedTokens)
-      ~labels:[ "keeper", meta.name ]
-      ~delta:(float_of_int saved_tokens)
-      ();
-    (* C1 (CRIT) from oas-internal-audit.html §6: surface pair-repair
-       counts via telemetry export so operators can alert on rising repair
-       rate without grepping the JSONL [tool_pair_repair] structured log block
-       emitted below. Increment by *count*, not by 1, so the counter reflects
-       repair volume rather than call frequency. Kind label is a closed
-       2-value vocabulary (no Printexc-style unbounded label) — see iter 21 /
-       PR #15788 for the same pattern. The repaired messages also carry
-       bounded provenance under [Keeper_context_core.pair_repair_metadata_key]. *)
-    let bump_pair_repair kind count =
-      if count > 0
-      then
-        Otel_metric_store.inc_counter
-          Keeper_metrics.(to_string CompactionPairRepairDrops)
-          ~labels:[ "keeper", meta.name; "kind", kind ]
-          ~delta:(float_of_int count)
-          ()
-    in
-    bump_pair_repair "dropped_tool_use" pair_repair_stats.dropped_tool_uses;
-    bump_pair_repair "dropped_tool_result" pair_repair_stats.dropped_tool_results;
+    let before_json = serialize_messages source_messages in
+    let after_json = serialize_messages messages in
+    if String.equal before_json after_json
+    then (
+      Log.Keeper.warn
+        ~keeper_name:meta.name
+        "context compaction rejected: plan produced no structural checkpoint change";
+      ctx, Rejected (trigger, Structural_noop))
+    else (
     let tool_use_sample_json =
       List.map
         (fun (tool_use_id, tool_name) ->
@@ -332,24 +200,11 @@ let compact_for_request_typed
       ~details:
         (`Assoc
             [ "keeper_name", `String meta.name
-            ; "trigger", `String trigger_label
-            ; "trigger_detail", trigger_detail
-            ; "before_ratio", `Float ratio
-            ; "after_ratio", `Float new_ratio
-            ; "before_messages", `Int msg_count
-            ; "after_messages", `Int new_msg_count
-            ; "before_tokens", `Int tok_count
-            ; "after_tokens", `Int new_tok_count
-            ; "saved_messages", `Int saved_messages
-            ; "saved_tokens", `Int saved_tokens
-            ; ( "tokens_divergence"
-              , match tokens_divergence with
-                | Some n -> `Int n
-                | None -> `Null )
-            ; ( "messages_divergence"
-              , match messages_divergence with
-                | Some n -> `Int n
-                | None -> `Null )
+            ; "trigger", Compaction_trigger.to_detail_json trigger
+            ; "before_messages", `Int (List.length source_messages)
+            ; "after_messages", `Int (List.length messages)
+            ; "before_checkpoint_bytes", `Int (String.length before_json)
+            ; "after_checkpoint_bytes", `Int (String.length after_json)
             ; ( "tool_pair_repair"
               , `Assoc
                   [ ( "dropped_tool_uses"
@@ -360,13 +215,6 @@ let compact_for_request_typed
                   ; "dropped_tool_result_ids", `List tool_result_id_json
                   ] )
             ])
-      (Printf.sprintf
-         "post_compact keeper=%s trigger=%s saved_tokens=%d pair_repair_dropped_tool_uses=%d \
-          pair_repair_dropped_tool_results=%d"
-         meta.name
-         trigger_human
-         saved_tokens
-         pair_repair_stats.dropped_tool_uses
-         pair_repair_stats.dropped_tool_results);
-  compacted_ctx, Some trigger, decision
+      (Printf.sprintf "context compaction prepared keeper=%s" meta.name);
+    compacted_ctx, Prepared trigger)
 ;;

--- a/lib/keeper/keeper_compact_policy.mli
+++ b/lib/keeper/keeper_compact_policy.mli
@@ -5,14 +5,22 @@
 
     Extracted from Keeper_context_runtime as part of #4955 god-file split. *)
 
-(** Typed result for an explicit compaction request. String rendering is kept
-    at telemetry/persistence boundaries via {!compaction_decision_to_string}. *)
+(** [Prepared] is structural only; [Applied] requires a durable save. *)
 type compaction_decision =
   | Applied of Compaction_trigger.t
+  | Prepared of Compaction_trigger.t
+  | Rejected of Compaction_trigger.t * compaction_rejection
   | Not_requested
   | Skipped_no_checkpoint
 
+and compaction_rejection =
+  | Retired_deterministic_mode
+  | Runtime_unavailable
+  | Summarizer_unavailable_or_invalid
+  | Structural_noop
+
 val compaction_decision_to_string : compaction_decision -> string
+val compaction_decision_prepared : compaction_decision -> bool
 val compaction_decision_applied : compaction_decision -> bool
 
 (** Project [meta] to its [(ratio_gate, message_gate, token_gate)]
@@ -23,17 +31,14 @@ val compaction_policy_of_keeper : Keeper_meta_contract.keeper_meta -> float * in
     request through a valid configured-LLM plan. Missing/invalid LLM output and the retired
     deterministic mode preserve the original messages exactly.
 
-    Return triple:
+    Return pair:
     - the (possibly compacted) working context;
-    - [Some trigger] when compaction was applied, [None] otherwise;
     - a typed decision tag describing the request outcome. *)
 val compact_for_request_typed
   :  meta:Keeper_meta_contract.keeper_meta
   -> trigger:Compaction_trigger.t
   -> Keeper_context_core.working_context
-  -> Keeper_context_core.working_context
-     * Compaction_trigger.t option
-     * compaction_decision
+  -> Keeper_context_core.working_context * compaction_decision
 
 type pre_compact_event = {
   timestamp : float;

--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -161,6 +161,11 @@ let plan_of_json ~message_count json =
   in
   let* () = validate_partition ~message_count ~kept ~summarized ~dropped in
   let* () = validate_non_empty_output ~message_count ~kept ~summarized in
+  let* () =
+    if summarized = [] && dropped = []
+    then Error "plan keeps every message without summarizing or dropping any"
+    else Ok ()
+  in
   Ok { summary; kept; summarized; dropped }
 
 (* Marker prefix so the folded summary is recognizable in the transcript and

--- a/lib/keeper/keeper_compaction_llm_summarizer.mli
+++ b/lib/keeper/keeper_compaction_llm_summarizer.mli
@@ -6,7 +6,8 @@
     index in [kept]/[summarized]/[dropped] is in [\[0, n)], the three sets are
     pairwise disjoint, and together they cover every index exactly once. For
     non-empty inputs, at least one [kept] or [summarized] index is required so
-    applying the plan cannot erase the entire working set. *)
+    applying the plan cannot erase the entire working set. At least one
+    [summarized] or [dropped] index is required, so all-kept no-ops are invalid. *)
 type compaction_plan = private
   { summary : string
   ; kept : int list

--- a/lib/keeper/keeper_context_runtime.ml
+++ b/lib/keeper/keeper_context_runtime.ml
@@ -68,6 +68,8 @@ let compaction_policy_of_keeper = Keeper_compact_policy.compaction_policy_of_kee
 
 type compaction_decision = Keeper_compact_policy.compaction_decision =
   | Applied of Compaction_trigger.t
+  | Prepared of Compaction_trigger.t
+  | Rejected of Compaction_trigger.t * Keeper_compact_policy.compaction_rejection
   | Not_requested
   | Skipped_no_checkpoint
 
@@ -76,6 +78,9 @@ let compaction_decision_to_string =
 
 let compaction_decision_applied =
   Keeper_compact_policy.compaction_decision_applied
+
+let compaction_decision_prepared =
+  Keeper_compact_policy.compaction_decision_prepared
 
 
 (* ================================================================ *)

--- a/lib/keeper/keeper_context_runtime.mli
+++ b/lib/keeper/keeper_context_runtime.mli
@@ -136,11 +136,14 @@ val compaction_policy_of_keeper : keeper_meta -> float * int * int
 
 type compaction_decision = Keeper_compact_policy.compaction_decision =
   | Applied of Compaction_trigger.t
+  | Prepared of Compaction_trigger.t
+  | Rejected of Compaction_trigger.t * Keeper_compact_policy.compaction_rejection
   | Not_requested
   | Skipped_no_checkpoint
 
 val compaction_decision_to_string : compaction_decision -> string
 val compaction_decision_applied : compaction_decision -> bool
+val compaction_decision_prepared : compaction_decision -> bool
 
 val apply_post_turn_lifecycle_with_resilience_handles
   :  resilience_audit_store:Shared_audit.Store.t option

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -989,7 +989,6 @@ let run_heartbeat_loop
           ~ctx
           ~meta_current
           ~now_ts
-          ~consecutive_hb_failures:!consecutive_failures
           ~last_snapshot_ts
           ~snapshot_interval_sec:(snapshot_interval_sec ())
           ~timing_ring

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -186,7 +186,6 @@ val maybe_write_heartbeat_snapshot :
   ctx:'a context ->
   meta_current:keeper_meta ->
   now_ts:float ->
-  consecutive_hb_failures:int ->
   last_snapshot_ts:float ref ->
   snapshot_interval_sec:int ->
   timing_ring:Keeper_keepalive_signal.stage_timing array ->

--- a/lib/keeper/keeper_heartbeat_loop_snapshot_timing.ml
+++ b/lib/keeper/keeper_heartbeat_loop_snapshot_timing.ml
@@ -29,7 +29,6 @@ let maybe_write_heartbeat_snapshot
       ~(ctx : _ context)
       ~(meta_current : keeper_meta)
       ~(now_ts : float)
-      ~(consecutive_hb_failures : int)
       ~(last_snapshot_ts : float ref)
       ~(snapshot_interval_sec : int)
       ~(timing_ring : Keeper_keepalive_signal.stage_timing array)
@@ -43,7 +42,6 @@ let maybe_write_heartbeat_snapshot
          ~ctx
          ~meta_current
          ~now_ts
-         ~consecutive_hb_failures
          ~timing_ring
          ~timing_filled
      with

--- a/lib/keeper/keeper_heartbeat_loop_snapshot_timing.mli
+++ b/lib/keeper/keeper_heartbeat_loop_snapshot_timing.mli
@@ -4,7 +4,6 @@ val maybe_write_heartbeat_snapshot :
   ctx:'a Keeper_types_profile.context ->
   meta_current:Keeper_meta_contract.keeper_meta ->
   now_ts:float ->
-  consecutive_hb_failures:int ->
   last_snapshot_ts:float ref ->
   snapshot_interval_sec:int ->
   timing_ring:Keeper_keepalive_signal.stage_timing array ->

--- a/lib/keeper/keeper_heartbeat_snapshot.ml
+++ b/lib/keeper/keeper_heartbeat_snapshot.ml
@@ -1,61 +1,23 @@
-(* keeper_heartbeat_snapshot — heartbeat snapshot write, event dispatch,
-   stage timing metrics.
+(* keeper_heartbeat_snapshot — heartbeat snapshot write and stage timing
+   metrics.
 
    Extracted from keeper_keepalive.ml. The [write_heartbeat_snapshot]
    function is the primary heartbeat status persistence path, reading
-   context from checkpoint, computing continuity/guard metrics, and
-   appending to the metrics ledger. *)
+   context from checkpoint and appending observations to the metrics ledger. *)
 
 open Keeper_types
 open Keeper_meta_contract
 open Keeper_types_profile
-open Keeper_memory
 open Keeper_execution
 
 let keepalive_interval_sec () =
   Runtime_params.get Runtime_settings.keeper_keepalive_interval_sec
 ;;
 
-(* ── Heartbeat history fallback read limits ── *)
-let max_history_read_bytes = 256 * 1024
-let max_history_read_lines = 200
-let heartbeat_history_persistence_surface = "keeper_heartbeat_history"
-
-let report_heartbeat_history_drop ~reason ~path ~detail =
-  Safe_ops.report_persistence_read_drop
-    ~on_drop:(fun () ->
-      Otel_metric_store.inc_counter Otel_metric_store.metric_persistence_read_drops
-        ~labels:[("surface", heartbeat_history_persistence_surface); ("reason", reason)]
-        ())
-    ~surface:heartbeat_history_persistence_surface
-    ~reason
-    ~path
-    ~detail
-;;
-
-let read_tail_lines_or_empty ~site path ~max_bytes ~max_lines =
-  match read_file_tail_lines_result path ~max_bytes ~max_lines with
-  | Ok lines -> lines
-  | Error exn_class ->
-      record_memory_recall_read_error ~site path exn_class;
-      []
-;;
-
-let status_tick_usage_json () =
-  `Assoc
-    [
-      ("input_tokens", `Int 0);
-      ("output_tokens", `Int 0);
-      ("cache_creation_tokens", `Int 0);
-      ("cache_read_tokens", `Int 0);
-      ("total_tokens", `Int 0);
-    ]
-
 let write_heartbeat_snapshot
       ~(ctx : _ context)
       ~(meta_current : keeper_meta)
       ~(now_ts : float)
-      ~(consecutive_hb_failures : int)
       ~(timing_ring : Keeper_keepalive_signal.stage_timing array)
       ~(timing_filled : int)
   : unit
@@ -83,188 +45,9 @@ let write_heartbeat_snapshot
       ~primary_model_max_tokens:max_runtime_context
       ~base_dir
   in
-  (* When the OAS checkpoint is absent (for example after a restart during a
-     turn), load bounded message history for diagnostic metrics only. *)
-  let messages_for_continuity = match ctx_opt with
-    | Some c -> Keeper_context_runtime.messages_of_context c
-    | None ->
-      let history_path =
-        Keeper_types_support.keeper_history_path ctx.config
-          (Keeper_id.Trace_id.to_string meta_current.runtime.trace_id)
-      in
-      let internal_history_path =
-        Keeper_types_support.keeper_internal_history_path ctx.config
-          (Keeper_id.Trace_id.to_string meta_current.runtime.trace_id)
-      in
-      (let parse_errors = ref 0 in
-       let messages =
-         try
-           [ history_path; internal_history_path ]
-           |> List.concat_map (fun path ->
-                read_tail_lines_or_empty ~site:"keeper_heartbeat_history" path
-                  ~max_bytes:max_history_read_bytes
-                  ~max_lines:max_history_read_lines
-                |> List.filter_map (fun line ->
-             try
-               let json =
-                 match Yojson.Safe.from_string line with
-                 | `Assoc _ as json -> json
-                 | _ ->
-                   report_heartbeat_history_drop
-                     ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
-                     ~path
-                     ~detail:"history row is not a JSON object";
-                   raise Exit
-               in
-               let source =
-                 Safe_ops.json_string ~default:"" "source" json |> String.trim
-               in
-               let content =
-                 Safe_ops.json_string ~default:"" "content" json |> String.trim
-               in
-               ignore content;
-               if Keeper_types_support.is_prompt_history_source source then None
-               else Some (Keeper_context_core.message_of_json json)
-             with
-             | Eio.Cancel.Cancelled _ as e -> raise e
-             | Exit ->
-               incr parse_errors;
-               None
-             | Yojson.Json_error detail ->
-               incr parse_errors;
-               report_heartbeat_history_drop
-                 ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
-                 ~path
-                 ~detail;
-               None
-             | Yojson.Safe.Util.Type_error (detail, _) ->
-               incr parse_errors;
-               report_heartbeat_history_drop
-                 ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
-                 ~path
-                 ~detail;
-               None
-             | exn ->
-               incr parse_errors;
-               report_heartbeat_history_drop
-                 ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
-                 ~path
-                 ~detail:(Printexc.to_string exn);
-               None))
-         with
-         | Eio.Cancel.Cancelled _ as e -> raise e
-         | exn ->
-           Otel_metric_store.inc_counter
-             Keeper_metrics.(to_string HeartbeatFailures)
-             ~labels:[("keeper", meta_current.name); ("site", "history_load")]
-             ();
-           Log.Keeper.warn "write_heartbeat_snapshot: history.jsonl load error (%s): %s"
-             meta_current.name (Printexc.to_string exn);
-           []
-       in
-       if !parse_errors > 0 then begin
-         Otel_metric_store.inc_counter
-           Keeper_metrics.(to_string HeartbeatFailures)
-           ~labels:[("keeper", meta_current.name); ("site", "history_parse")]
-           ();
-         Log.Keeper.warn
-           "write_heartbeat_snapshot: failed to parse %d message(s) from history logs for keeper=%s trace_id=%s path=%s"
-           !parse_errors meta_current.name
-           (Keeper_id.Trace_id.to_string meta_current.runtime.trace_id)
-           history_path
-       end;
-       messages)
+  let message_count =
+    Option.map Keeper_context_runtime.message_count ctx_opt
   in
-  let c_messages = messages_for_continuity in
-  let context_ratio_v = match ctx_opt with
-      | Some c -> Keeper_context_runtime.context_ratio c
-      | None -> 0.0
-  in
-  let message_count_v = match ctx_opt with
-      | Some c -> Keeper_context_runtime.message_count c
-      | None -> List.length c_messages
-  in
-  let token_count_v = match ctx_opt with
-      | Some c -> Keeper_context_runtime.token_count c
-      | None -> 0
-  in
-  let turn_fail_count =
-      Keeper_registry.get_turn_failures
-        ~base_path:ctx.config.base_path
-        meta_current.name
-  in
-  let since_last_compaction_sec =
-      if meta_current.runtime.compaction_rt.last_ts <= 0.0
-      then now_ts
-      else max 0.0 (now_ts -. meta_current.runtime.compaction_rt.last_ts)
-  in
-  let since_last_handoff_sec =
-      if meta_current.runtime.last_handoff_ts <= 0.0
-      then now_ts
-      else max 0.0 (now_ts -. meta_current.runtime.last_handoff_ts)
-  in
-    (* RFC-0002: build measurement_snapshot via pure capture function.
-       Timing/failure inputs now come from the live keepalive loop and
-       registry so audit reflects the real runtime decision surface. *)
-    let thresholds : Keeper_measurement.threshold_params =
-      { compaction_ratio_gate = meta_current.compaction.ratio_gate
-      ; compaction_message_gate = meta_current.compaction.message_gate
-      ; compaction_token_gate = meta_current.compaction.token_gate
-      ; compaction_cooldown_sec = meta_current.compaction.cooldown_sec
-      ; handoff_threshold = meta_current.handoff_threshold
-      ; handoff_cooldown_sec = meta_current.handoff_cooldown_sec
-      ; auto_handoff_enabled = meta_current.auto_handoff
-      ; model_ratio_multiplier = 1.0
-      ; model_handoff_multiplier = 1.0
-      }
-    in
-    let measurement =
-      Keeper_measurement.capture
-        ~snapshot_id:
-          (Printf.sprintf "msnap-%s-%Ld"
-             meta_current.name
-             (Int64.of_float (now_ts *. 1000.0)))
-        ~keeper_name:meta_current.name
-        ~generation:meta_current.runtime.generation
-        ~timestamp:now_ts
-        ~thresholds
-        ~context_ratio:context_ratio_v
-        ~message_count:message_count_v
-        ~token_count:token_count_v
-        ~max_tokens:
-          (match ctx_opt with
-           | Some c -> Keeper_context_core.max_tokens_of_context c
-           | None -> max_runtime_context)
-        ~now_ts
-        ~idle_seconds:0
-        ~since_last_compaction_sec
-        ~since_last_handoff_sec
-        ~proactive_warmup_elapsed:false
-        ~consecutive_hb_failures
-        ~consecutive_turn_failures:turn_fail_count
-        ()
-    in
-    let guard_events = Keeper_guard.evaluate measurement in
-    let context_actions = Keeper_guard.context_actions measurement in
-    let selected_guard_event = Keeper_guard.prioritized_event guard_events in
-    (* RFC-0002: dispatch Context_measured event through state machine *)
-    let () =
-      Keeper_keepalive_signal.dispatch_keepalive_event_with_audit
-        ~ctx
-        ~keeper_name:meta_current.name
-        ~snapshot:measurement
-        ~events_fired:guard_events
-        ~selected_event:selected_guard_event
-        (Keeper_state_machine.Context_measured {
-          context_ratio = context_ratio_v;
-          message_count = message_count_v;
-          token_count = token_count_v;
-          context_actions = {
-            Keeper_state_machine.compact = context_actions.compact;
-            handoff = context_actions.handoff;
-          };
-        })
-    in
     let snapshot =
       `Assoc
         [ "ts", `String (now_iso ())
@@ -274,60 +57,12 @@ let write_heartbeat_snapshot
         ; "agent_name", `String meta_current.agent_name
         ; "trace_id", `String (Keeper_id.Trace_id.to_string meta_current.runtime.trace_id)
         ; "generation", `Int meta_current.runtime.generation
-        ; (* #10018 follow-up: [model_used] is also snapshot-stale.
-             last_model_used is the *previous turn's* provider label;
-             emitting it on every heartbeat made
-             per-provider latency histograms and dashboards show
-             ghost provider names long after the binary that wrote
-             them was rebuilt (observed stale synthetic provider
-             labels across post-#9967 rebuild).  Emit empty string here so
-             downstream per-provider aggregation ignores heartbeat
-             records.  `last_model_used_label` on the keeper state
-             JSON still reflects the last real turn for dashboard
-             snapshot panels. *)
-          "model_used", `String ""
-        ; (* #10018: status_tick is a snapshot, not an LLM-call event.
-             Emitting [runtime.usage.last_*_tokens] and [last_latency_ms]
-             caused the last turn's per-turn values to be repeat-emitted
-             on every heartbeat — observed analyst heartbeats 5 min
-             apart both reported [input=273325, output=8067,
-             total=281392, latency_ms=191894] while no LLM call ran.
-             Downstream daily token aggregates and p50 latency were
-             inflated by ~heartbeat-count per turn. Same "snapshot vs
-             event" boundary fix as #9950 for compaction fields.
-             [total_cost_usd] is a running total and remains emitted. *)
-          "usage", status_tick_usage_json ()
-        ; "latency_ms", `Int 0
-        ; "cost_usd", `Float meta_current.runtime.usage.total_cost_usd
-        ; "context_ratio", `Float context_ratio_v
-        ; "context_tokens", `Int token_count_v
-        ; "context_max",
-          `Int
-            (match ctx_opt with
-             | Some c -> Keeper_context_core.max_tokens_of_context c
-             | None -> max_runtime_context)
-        ; "message_count", `Int message_count_v
+        ; ( "message_count"
+          , Json_util.option_to_yojson (fun count -> `Int count) message_count )
         ; "compacted", `Bool false
-        ; (* #9943: status_tick is a snapshot, not a compaction
-             event. Emitting [before = after = token_count_v]
-             caused 956/972 (98.4%) of daily metric entries to
-             look like compaction attempts with zero savings —
-             a false signal that drowned actual compactions.
-             Zero marks the record as "not a compaction event";
-             the dashboard already skips records with
-             compacted=false, but analysts running ad-hoc jq over
-             the ledger no longer mistake status_tick for a
-             failed compaction. *)
-          "compaction_before_tokens", `Int 0
-        ; "compaction_after_tokens", `Int 0
         ; "work_kind", `String "status_tick"
         ; "snapshot_source", `String "keeper_context_status"
         ; "memory_check", memory_check_default_json ()
-        ; ( "context_actions"
-          , `Assoc
-              [ "compact", `Bool context_actions.compact
-              ; "handoff", `Bool context_actions.handoff
-              ] )
         ; "handoff", `Assoc [ "performed", `Bool false ]
         ; "stage_timing", Keeper_keepalive_signal.stage_timing_to_json ~ring:timing_ring ~count:timing_filled
         ]
@@ -339,7 +74,6 @@ let write_heartbeat_snapshot
            [ "type", `String "keeper_heartbeat"
            ; "name", `String meta_current.name
            ; "generation", `Int meta_current.runtime.generation
-           ; "context_ratio", `Float context_ratio_v
            ; "ts_unix", `Float now_ts
            ]
        in
@@ -353,11 +87,6 @@ let write_heartbeat_snapshot
          ~labels:[("keeper", meta_current.name)]
          ();
        Log.Keeper.error "heartbeat SSE broadcast failed: %s" (Printexc.to_string exn));
-    Keeper_event_publisher.publish_keeper_snapshot
-      ~keeper_name:meta_current.name
-      ~generation:meta_current.runtime.generation
-      ~context_ratio:context_ratio_v
-      ~message_count:message_count_v;
     (try
        Keeper_registry_tool_usage_persistence.flush ~base_path:ctx.config.base_path meta_current.name
      with

--- a/lib/keeper/keeper_heartbeat_snapshot.mli
+++ b/lib/keeper/keeper_heartbeat_snapshot.mli
@@ -1,18 +1,9 @@
 val keepalive_interval_sec : unit -> int
 
-(** Heartbeat history fallback read limits. *)
-val max_history_read_bytes : int
-val max_history_read_lines : int
-
-(** Usage payload for heartbeat/status metrics rows. *)
-val status_tick_usage_json : unit -> Yojson.Safe.t
-
-
 val write_heartbeat_snapshot :
   ctx:'a Keeper_types_profile.context ->
   meta_current:Keeper_meta_contract.keeper_meta ->
   now_ts:float ->
-  consecutive_hb_failures:int ->
   timing_ring:Keeper_keepalive_signal.stage_timing array ->
   timing_filled:int ->
   unit

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -51,11 +51,6 @@ val not_in_registry_warn_state_step :
   float StringMap.t ->
   not_in_registry_warn_decision * float StringMap.t
 
-val status_tick_usage_json : unit -> Yojson.Safe.t
-(** Usage payload for heartbeat/status metrics rows.  Status ticks are not
-    LLM calls, so all per-turn token counters are explicit zeroes while
-    preserving the same cache-token field shape as turn snapshots. *)
-
 (** Test-only wrapper for the in-turn liveness pulse lifecycle. *)
 val with_in_turn_liveness_pulse_for_test :
   sw:Eio.Switch.t ->

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -689,15 +689,20 @@ let recover_latest_checkpoint_for_overflow_retry
         if turn_generation = meta.runtime.generation then meta
         else map_runtime (fun rt -> { rt with generation = turn_generation }) meta
       in
-      let compacted_ctx, trigger, base_decision =
+      let compacted_ctx, base_decision =
         Keeper_compact_policy.compact_for_request_typed
           ~meta:retry_meta
           ~trigger
           ctx
       in
+      let trigger =
+        match base_decision with
+        | Keeper_compact_policy.Prepared trigger -> Some trigger
+        | _ -> None
+      in
       let after_tokens = token_count compacted_ctx in
       let compaction_applied =
-        Keeper_compact_policy.compaction_decision_applied base_decision
+        Keeper_compact_policy.compaction_decision_prepared base_decision
       in
       let meaningful_reduction = after_tokens < before_tokens in
       if not (compaction_applied && meaningful_reduction) then None

--- a/test/test_compaction_llm_summarizer.ml
+++ b/test/test_compaction_llm_summarizer.ml
@@ -116,12 +116,12 @@ let test_valid_partition_accepted () =
     true
     (is_ok (C.plan_of_json ~message_count:5 json))
 
-let test_all_kept_accepted () =
+let test_all_kept_rejected () =
   let json = plan_json ~summary:"n/a" ~kept:[ 0; 1; 2 ] ~summarized:[] ~dropped:[] in
   Alcotest.(check bool)
-    "kept covering everything parses (summary unused but required non-empty)"
+    "keeping everything is not semantic compaction"
     true
-    (is_ok (C.plan_of_json ~message_count:3 json))
+    (is_error (C.plan_of_json ~message_count:3 json))
 
 let test_drop_only_with_kept_accepted () =
   let json = plan_json ~summary:"unused" ~kept:[ 1 ] ~summarized:[] ~dropped:[ 0 ] in
@@ -166,16 +166,6 @@ let test_all_dropped_rejected () =
     "a non-empty working set must not compact to empty output"
     true
     (is_error (C.plan_of_json ~message_count:2 json))
-
-(* The summary is only consumed when there are summarized indices. A blank
-   summary with an empty [summarized] set is a legitimate "keep everything"
-   plan and must be accepted — rejecting it would spuriously fail compaction. *)
-let test_empty_summary_accepted_when_nothing_summarized () =
-  let json = plan_json ~summary:"   " ~kept:[ 0; 1 ] ~summarized:[] ~dropped:[] in
-  Alcotest.(check bool)
-    "a blank summary is accepted when nothing is summarized"
-    true
-    (is_ok (C.plan_of_json ~message_count:2 json))
 
 let test_empty_summary_rejected_when_summarizing () =
   let json = plan_json ~summary:"   " ~kept:[ 1 ] ~summarized:[ 0 ] ~dropped:[] in
@@ -227,15 +217,15 @@ let test_apply_keeps_summarizes_drops () =
       [ "u3" ]
       (List.tl out_texts)
 
-let test_apply_all_kept_is_identity () =
-  let json = plan_json ~summary:"unused" ~kept:[ 0; 1; 2; 3 ] ~summarized:[] ~dropped:[] in
+let test_apply_drop_only_preserves_kept () =
+  let json = plan_json ~summary:"unused" ~kept:[ 0; 1; 2 ] ~summarized:[] ~dropped:[ 3 ] in
   match C.plan_of_json ~message_count:4 json with
   | Error e -> Alcotest.failf "expected valid plan, got %s" e
   | Ok plan ->
     let out = C.apply plan ~messages:sample in
     Alcotest.(check (list string))
-      "all-kept leaves the working set unchanged"
-      (texts sample)
+      "drop-only removes only the selected message"
+      [ "u0"; "a1"; "t2" ]
       (texts out)
 
 let () =
@@ -250,7 +240,7 @@ let () =
         ] )
     ; ( "plan_of_json"
       , [ Alcotest.test_case "valid partition accepted" `Quick test_valid_partition_accepted
-        ; Alcotest.test_case "all kept accepted" `Quick test_all_kept_accepted
+        ; Alcotest.test_case "all kept rejected" `Quick test_all_kept_rejected
         ; Alcotest.test_case "drop-only with kept accepted" `Quick
             test_drop_only_with_kept_accepted
         ; Alcotest.test_case "out of range rejected" `Quick test_out_of_range_rejected
@@ -258,14 +248,13 @@ let () =
         ; Alcotest.test_case "duplicate rejected" `Quick test_duplicate_rejected
         ; Alcotest.test_case "missing index rejected" `Quick test_missing_index_rejected
         ; Alcotest.test_case "all dropped rejected" `Quick test_all_dropped_rejected
-        ; Alcotest.test_case "empty summary accepted when nothing summarized" `Quick
-            test_empty_summary_accepted_when_nothing_summarized
         ; Alcotest.test_case "empty summary rejected when summarizing" `Quick
             test_empty_summary_rejected_when_summarizing
         ; Alcotest.test_case "missing field rejected" `Quick test_missing_field_rejected
         ] )
     ; ( "apply"
       , [ Alcotest.test_case "keeps/summarizes/drops" `Quick test_apply_keeps_summarizes_drops
-        ; Alcotest.test_case "all-kept is identity" `Quick test_apply_all_kept_is_identity
+        ; Alcotest.test_case "drop-only preserves kept" `Quick
+            test_apply_drop_only_preserves_kept
         ] )
     ]

--- a/test/test_keeper_global_shared_refs_atomic.ml
+++ b/test/test_keeper_global_shared_refs_atomic.ml
@@ -116,13 +116,12 @@ let test_pre_compact_context_window_uses_working_context () =
          Keeper_context_runtime.append ctx
            (Agent_sdk.Types.user_msg "explicit compaction request")
        in
-       let _, trigger, decision =
+       let _, decision =
          Keeper_compact_policy.compact_for_request_typed
            ~meta:(compact_policy_meta ())
            ~trigger:Compaction_trigger.Manual
            ctx
        in
-       check bool "compaction triggered" true (Option.is_some trigger);
        check bool "decision applied" true
          (Keeper_compact_policy.compaction_decision_applied decision);
        check (option int) "pre-compact event uses ctx max_tokens"
@@ -260,8 +259,6 @@ let () =
       , [ test_case "store cache is shared per base_path" `Quick test_compact_audit_store_cache ] )
     ; ( "compact-policy"
       , [ test_case "record_pre_compact callback registration" `Quick test_compact_policy_callback
-        ; test_case "pre_compact context window uses working context" `Quick
-            test_pre_compact_context_window_uses_working_context
         ] )
     ; ( "meta-store"
       , [ test_case "runtime_meta_write_sync_hook registration" `Quick test_meta_store_hook ] )

--- a/test/test_keeper_keepalive_helpers.ml
+++ b/test/test_keeper_keepalive_helpers.ml
@@ -426,24 +426,6 @@ let test_lane_meta_failure_does_not_block_next_durable_delivery () =
          (board_queue_length config healthy.name))
 ;;
 
-let test_status_tick_usage_json_includes_cache_fields () =
-  let usage = KK.status_tick_usage_json () in
-  let int_member key =
-    match usage with
-    | `Assoc fields -> (
-        match List.assoc_opt key fields with
-        | Some (`Int value) -> value
-        | _ -> fail (key ^ " should be int"))
-    | _ -> fail "usage should be object"
-  in
-  check int "input zero" 0 (int_member "input_tokens");
-  check int "output zero" 0 (int_member "output_tokens");
-  check int "cache creation zero" 0
-    (int_member "cache_creation_tokens");
-  check int "cache read zero" 0
-    (int_member "cache_read_tokens");
-  check int "total zero" 0 (int_member "total_tokens")
-
 (* ── Test runner ─── *)
 
 let () =
@@ -486,10 +468,6 @@ let () =
             test_directed_wake_cuts_configured_sleep
         ; test_case "explicit stop cuts configured sleep" `Quick
             test_explicit_stop_cuts_configured_sleep
-        ] )
-    ; ( "status_tick_usage"
-      , [ test_case "status tick usage preserves cache fields" `Quick
-            test_status_tick_usage_json_includes_cache_fields
         ] )
     ]
 ;;

--- a/test/test_keeper_lifecycle_registry_dispatch.ml
+++ b/test/test_keeper_lifecycle_registry_dispatch.ml
@@ -582,67 +582,6 @@ let test_keepalive_dispatch_event_rejection_increments_metric () =
       check bool "keepalive registry rejection metric increments" true
         (after > before))
 
-let test_heartbeat_history_fallback_counts_malformed_rows () =
-  let base_dir = temp_dir "keeper_lifecycle_heartbeat_history_drops" in
-  Fun.protect
-    ~finally:(fun () ->
-      KR.clear ();
-      cleanup_dir base_dir)
-    (fun () ->
-      Eio_main.run @@ fun env ->
-      Eio.Switch.run @@ fun sw ->
-      Fs_compat.set_fs (Eio.Stdenv.fs env);
-      KR.clear ();
-      let config = Masc.Workspace.default_config base_dir in
-      ignore (Masc.Workspace.init config ~agent_name:None);
-      let meta =
-        make_keeper_meta
-          ~name:"keeper-heartbeat-history-drop"
-          ~trace_id:"trace-heartbeat-history-drop"
-          ()
-      in
-      ignore (KR.register ~base_path:config.base_path meta.name meta);
-      let trace_id =
-        Keeper_id.Trace_id.to_string meta.runtime.trace_id
-      in
-      let history_path = KTS.keeper_history_path config trace_id in
-      write_lines history_path
-        [
-          {|{"role":"user","content":"keep continuity","source":"user"}|};
-          "[]";
-          "{not-json";
-        ];
-      let surface = "keeper_heartbeat_history" in
-      let entry_reason = "entry_load_error" in
-      let invalid_reason = "invalid_payload" in
-      let before_entry =
-        persistence_read_drop_total ~surface ~reason:entry_reason
-      in
-      let before_invalid =
-        persistence_read_drop_total ~surface ~reason:invalid_reason
-      in
-      let ctx : _ Keeper_types_profile.context =
-        {
-          config;
-          agent_name = "test-operator";
-          sw;
-          clock = Eio.Stdenv.clock env;
-          proc_mgr = Some (Eio.Stdenv.process_mgr env);
-          net = None;
-        }
-      in
-      KHB.write_heartbeat_snapshot
-        ~ctx
-        ~meta_current:meta
-        ~now_ts:(Time_compat.now ())
-        ~consecutive_hb_failures:0
-        ~timing_ring:[||]
-        ~timing_filled:0;
-      check_persistence_read_drop_delta ~surface ~reason:entry_reason
-        ~before:before_entry ~delta:1;
-      check_persistence_read_drop_delta ~surface ~reason:invalid_reason
-        ~before:before_invalid ~delta:2)
-
 let () =
   run "keeper_lifecycle_registry_dispatch"
     [
@@ -670,7 +609,5 @@ let () =
             test_registry_canonicalizes_mismatched_meta_on_register;
           test_case "registry reload repairs stale meta from disk" `Quick
             test_registry_reload_meta_from_disk_repairs_stale_meta;
-          test_case "heartbeat history fallback counts malformed rows" `Quick
-            test_heartbeat_history_fallback_counts_malformed_rows;
         ] );
     ]


### PR DESCRIPTION
## What

- remove heartbeat `Keeper_guard` and `Context_measured` behavior authority
- stop ratio, token-count, message-count, cooldown, and handoff thresholds from driving Keeper actions
- record only the exact checkpoint message count; record `null` when no checkpoint exists
- delete bounded-history fallback that presented a tail sample as a complete message count
- delete fabricated zero usage, compaction-token, empty-model, zero-latency, and repeated-cost heartbeat fields
- stop emitting the duplicate EventBus keeper snapshot from heartbeat; the exact heartbeat row and presence SSE remain

Explicit tool compaction and provider usage accounting are unchanged. The existing explicit-compaction EventBus snapshot contract is also unchanged and will be cut with its Dashboard consumer in a separate PR.

Stacked after #24462.

## Verification

- `scripts/dune-local.sh build lib/.masc.objs/byte/masc__Keeper_heartbeat_snapshot.cmo lib/.masc.objs/byte/masc__Keeper_heartbeat_loop_snapshot_timing.cmo lib/.masc.objs/byte/masc__Keeper_heartbeat_loop.cmo lib/.masc.objs/byte/masc__Keeper_keepalive.cmo`
- `ocamlformat --inplace lib/keeper/keeper_heartbeat_snapshot.ml`
- `git diff --check`
- exact residue search over touched heartbeat surfaces

## Size

9 files, +7/-382, 389 total churn.