### PR TITLE
refactor(keeper): observe wake payload on every turn

### DIFF
--- a/dashboard/src/components/keeper-detail-ctx-composition.ts
+++ b/dashboard/src/components/keeper-detail-ctx-composition.ts
@@ -19,7 +19,7 @@ export const ctxCompositionSearch = signal('')
 export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
   const series = keeper.metrics_series ?? []
   const points = series.filter(
-    (p: KeeperMetricPoint) => (p.ctx_composition?.display_total_tokens ?? 0) > 0,
+    (p: KeeperMetricPoint) => (p.ctx_composition?.attributed_bytes ?? 0) > 0,
   )
   if (points.length === 0) return null
 
@@ -27,23 +27,22 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
   const latestComposition = latest?.ctx_composition ?? null
   if (!latestComposition) return null
 
-  const latestTotal = latestComposition.display_total_tokens
+  const latestTotalBytes = latestComposition.attributed_bytes
   const latestActual = latestComposition.actual_input_tokens
-  const latestKnown = latestComposition.estimated_known_tokens
   const latestEntries = Object.entries(latestComposition.segments)
-    .filter(([, segment]) => (segment?.estimated_tokens ?? 0) > 0)
-    .sort(([, left], [, right]) => (right.estimated_tokens ?? 0) - (left.estimated_tokens ?? 0))
-  if (latestEntries.length === 0 || latestTotal <= 0) return null
+    .filter(([, segment]) => (segment?.bytes ?? 0) > 0)
+    .sort(([, left], [, right]) => (right.bytes ?? 0) - (left.bytes ?? 0))
+  if (latestEntries.length === 0 || latestTotalBytes <= 0) return null
   const visibleCtxEntries = filterCtxCompositionEntries(latestEntries, ctxCompositionSearch.value)
 
   const allKeys = Array.from(
     new Set(points.flatMap((point: KeeperMetricPoint) => Object.keys(point.ctx_composition?.segments ?? {}))),
   )
   const sortedKeys = allKeys
-    .filter((key) => points.some((point: KeeperMetricPoint) => (point.ctx_composition?.segments?.[key]?.estimated_tokens ?? 0) > 0))
+    .filter((key) => points.some((point: KeeperMetricPoint) => (point.ctx_composition?.segments?.[key]?.bytes ?? 0) > 0))
     .sort((left, right) => {
-      const rightLatest = latestComposition.segments[right]?.estimated_tokens ?? 0
-      const leftLatest = latestComposition.segments[left]?.estimated_tokens ?? 0
+      const rightLatest = latestComposition.segments[right]?.bytes ?? 0
+      const leftLatest = latestComposition.segments[left]?.bytes ?? 0
       if (rightLatest !== leftLatest) return rightLatest - leftLatest
       return left.localeCompare(right)
     })
@@ -56,9 +55,6 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
   const barStep = innerW / Math.max(points.length, 1)
   const barWidth = Math.max(3, Math.min(8, barStep - 1))
 
-  const knownRatio = latestTotal > 0 ? latestKnown / latestTotal : 0
-  const unattributedTokens = latestComposition.segments.unattributed?.estimated_tokens ?? 0
-
   return html`
     <div class="mb-5 v2-monitoring-panel">
       <div class="flex items-center gap-2 mb-2">
@@ -68,23 +64,20 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
       <div class="grid grid-cols-1 md:grid-cols-4 gap-3 v2-monitoring-row">
         <${DetailCard} class="md:col-span-2">
           <div class="flex items-center justify-between mb-2 gap-3">
-            <${Eyebrow}>latest turn input</${Eyebrow}>
-            <span class="text-xs font-mono tabular-nums text-[var(--color-accent-fg)]">${formatTokens(latestTotal)}</span>
+            <${Eyebrow}>attributed content bytes</${Eyebrow}>
+            <span class="text-xs font-mono tabular-nums text-[var(--color-accent-fg)]">${latestTotalBytes.toLocaleString()} bytes</span>
           </div>
           <div class="h-3 rounded-[var(--r-0)] overflow-hidden border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] flex">
             ${latestEntries.map(([key, segment]) => {
-              const pct = latestTotal > 0 ? (segment.estimated_tokens / latestTotal) * 100 : 0
+              const pct = latestTotalBytes > 0 ? (segment.bytes / latestTotalBytes) * 100 : 0
               return html`<div
-                title=${`${ctxSegmentLabel(key)} · ${formatTokens(segment.estimated_tokens)} · ${pct.toFixed(1)}%`}
+                title=${`${ctxSegmentLabel(key)} · ${segment.bytes.toLocaleString()} bytes · ${pct.toFixed(1)}%`}
                 style=${`width:${pct}%;background:${ctxSegmentColor(key)};min-width:${pct > 0 ? '1px' : '0'};`}
               ></div>`
             })}
           </div>
           <div class="mt-2 flex flex-wrap gap-2 text-3xs text-[var(--color-fg-disabled)]">
-            ${latestActual != null ? html`<span>actual ${formatTokens(latestActual)}</span>` : null}
-            <span>known ${formatTokens(latestKnown)}</span>
-            <span>${Math.round(knownRatio * 100)}% attributed</span>
-            ${unattributedTokens > 0 ? html`<span>residual ${formatTokens(unattributedTokens)}</span>` : null}
+            <span>${latestTotalBytes.toLocaleString()} exact bytes represented</span>
           </div>
         <//>
 
@@ -92,14 +85,14 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
           <${Eyebrow}>largest bucket</${Eyebrow}>
           <span class="text-sm font-medium text-[var(--color-fg-secondary)]">${ctxSegmentLabel(latestEntries[0]?.[0] ?? 'unknown')}</span>
           <span class="text-3xs font-mono text-[var(--color-fg-disabled)]">
-            ${latestEntries[0] ? `${formatTokens(latestEntries[0][1].estimated_tokens)} · ${((latestEntries[0][1].estimated_tokens / latestTotal) * 100).toFixed(1)}%` : '-'}
+            ${latestEntries[0] ? `${latestEntries[0][1].bytes.toLocaleString()} bytes · ${((latestEntries[0][1].bytes / latestTotalBytes) * 100).toFixed(1)}%` : '-'}
           </span>
         <//>
 
         <${DetailCard} class="flex flex-col justify-between">
-          <${Eyebrow}>residual</${Eyebrow}>
-          <span class="text-lg font-mono tabular-nums text-[var(--color-status-warn)]">${formatTokens(unattributedTokens)}</span>
-          <${MutedSpan}>tool schema / provider overhead / estimator gap</${MutedSpan}>
+          <${Eyebrow}>provider input</${Eyebrow}>
+          <span class="text-lg font-mono tabular-nums text-[var(--color-status-warn)]">${latestActual != null ? `${formatTokens(latestActual)} tokens` : '-'}</span>
+          <${MutedSpan}>reported separately; not byte-attributed</${MutedSpan}>
         <//>
       </div>
 
@@ -112,13 +105,13 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
           <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded-[var(--r-1)] w-full" role="img" aria-label="컨텍스트 구성 스택 히스토리" style="background:var(--bg-deepest);">
             ${points.map((point: KeeperMetricPoint, index: number) => {
               const comp = point.ctx_composition
-              if (!comp || comp.display_total_tokens <= 0) return null
+              if (!comp || comp.attributed_bytes <= 0) return null
               const x = pad + (index * barStep) + Math.max(0, (barStep - barWidth) / 2)
               let yCursor = H - pad
               return sortedKeys.map((key) => {
-                const tokens = comp.segments[key]?.estimated_tokens ?? 0
-                if (tokens <= 0) return null
-                const height = (tokens / comp.display_total_tokens) * innerH
+                const bytes = comp.segments[key]?.bytes ?? 0
+                if (bytes <= 0) return null
+                const height = (bytes / comp.attributed_bytes) * innerH
                 yCursor -= height
                 return html`<rect
                   x="${x.toFixed(1)}"
@@ -153,7 +146,7 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
           ` : null}
           <div class="flex flex-col gap-1.5 v2-monitoring-row">
             ${visibleCtxEntries.map(([key, segment]) => {
-              const pct = latestTotal > 0 ? (segment.estimated_tokens / latestTotal) * 100 : 0
+              const pct = latestTotalBytes > 0 ? (segment.bytes / latestTotalBytes) * 100 : 0
               return html`
                 <div class="flex items-center justify-between gap-2 text-2xs v2-monitoring-row">
                   <span class="inline-flex items-center gap-2 min-w-0">
@@ -161,7 +154,7 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
                     <span class="truncate text-[var(--color-fg-primary)]">${ctxSegmentLabel(key)}</span>
                   </span>
                   <span class="font-mono tabular-nums text-[var(--color-fg-disabled)] whitespace-nowrap">
-                    ${pct.toFixed(1)}% · ${formatTokens(segment.estimated_tokens)}
+                    ${pct.toFixed(1)}% · ${segment.bytes.toLocaleString()} bytes
                   </span>
                 </div>
               `

--- a/dashboard/src/components/keeper-detail-prompt-bytes.test.ts
+++ b/dashboard/src/components/keeper-detail-prompt-bytes.test.ts
@@ -1,0 +1,98 @@
+import { render } from 'preact'
+import { html } from 'htm/preact'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { Keeper, KeeperMetricPoint } from '../types'
+import { CtxCompositionPanel } from './keeper-detail-ctx-composition'
+import { PromptTelemetryPanel } from './keeper-detail-telemetry'
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+function metricPoint(overrides: Partial<KeeperMetricPoint>): KeeperMetricPoint {
+  return {
+    ts: 1,
+    context_ratio: 0,
+    context_tokens: 0,
+    context_max: 0,
+    latency_ms: null,
+    generation: 1,
+    channel: 'turn',
+    is_handoff: false,
+    is_compaction: false,
+    compaction_saved_tokens: 0,
+    compaction_trigger: null,
+    model_used: 'test-model',
+    cost_usd: 0,
+    handoff_to_model: null,
+    handoff_new_generation: null,
+    prompt_fingerprint: null,
+    prompt_metrics: null,
+    ctx_composition: null,
+    input_tokens: null,
+    output_tokens: null,
+    total_tokens: null,
+    wall_tokens_per_second: null,
+    inference_telemetry: null,
+    fallback_applied: false,
+    fallback_hops: 0,
+    fallback_from: null,
+    fallback_to: null,
+    fallback_reason: null,
+    ...overrides,
+  }
+}
+
+describe('keeper prompt byte telemetry', () => {
+  it('renders prompt measurements as bytes without token estimates', () => {
+    const container = document.createElement('div')
+    const keeper = {
+      name: 'prompt-keeper',
+      status: 'active',
+      metrics_series: [metricPoint({
+        prompt_fingerprint: 'prompt-fp',
+        prompt_metrics: {
+          fingerprint: 'prompt-fp',
+          total_bytes: 830,
+          cacheable_bytes: 512,
+          segments: {
+            system_prompt: { bytes: 512, fingerprint: 'system-fp' },
+          },
+        },
+      })],
+    } as Keeper
+
+    render(html`<${PromptTelemetryPanel} keeper=${keeper} />`, container)
+
+    expect(container.textContent).toContain('prompt bytes')
+    expect(container.textContent).toContain('latest 830 bytes')
+    expect(container.textContent).toContain('cacheable 512 bytes')
+    expect(container.textContent).not.toContain('estimated prompt tokens')
+  })
+
+  it('keeps provider tokens separate from attributed bytes', () => {
+    const container = document.createElement('div')
+    const keeper = {
+      name: 'composition-keeper',
+      status: 'active',
+      metrics_series: [metricPoint({
+        ctx_composition: {
+          actual_input_tokens: 1000,
+          attributed_bytes: 1160,
+          segments: {
+            system_prompt: { bytes: 320, fingerprint: null },
+            history_tool_result: { bytes: 840, fingerprint: null },
+          },
+        },
+      })],
+    } as Keeper
+
+    render(html`<${CtxCompositionPanel} keeper=${keeper} />`, container)
+
+    expect(container.textContent).toContain('attributed content bytes')
+    expect(container.textContent).toContain('1,160 bytes')
+    expect(container.textContent).toContain('provider input')
+    expect(container.textContent).toContain('reported separately; not byte-attributed')
+    expect(container.textContent).not.toContain('residual')
+  })
+})

--- a/dashboard/src/components/keeper-detail-telemetry.ts
+++ b/dashboard/src/components/keeper-detail-telemetry.ts
@@ -1,5 +1,5 @@
 import { html } from 'htm/preact'
-import { formatTokens, isFiniteMetricValue } from '../lib/format-number'
+import { isFiniteMetricValue } from '../lib/format-number'
 import { SPARKLINE_W, SPARKLINE_H, SPARKLINE_PAD } from '../lib/sparkline-config'
 import { CopyIdButton } from './common/copy-id-button'
 import { Eyebrow } from './common/eyebrow'
@@ -49,11 +49,11 @@ export function PromptTelemetryPanel({ keeper }: { keeper: Keeper }) {
   const latestPrompt = latest?.prompt_metrics ?? null
   const latestSegments = Object.entries(latestPrompt?.segments ?? {})
     .sort(([left], [right]) => left.localeCompare(right))
-  const promptTotals = promptPoints.map(
-    (p: KeeperMetricPoint) => p.prompt_metrics?.estimated_total_tokens ?? 0,
+  const promptBytes = promptPoints.map(
+    (p: KeeperMetricPoint) => p.prompt_metrics?.total_bytes ?? 0,
   )
-  const latestTotal = latestPrompt?.estimated_total_tokens ?? null
-  const latestCacheable = latestPrompt?.estimated_cacheable_tokens ?? null
+  const latestTotal = latestPrompt?.total_bytes ?? null
+  const latestCacheable = latestPrompt?.cacheable_bytes ?? null
   const cacheableRatio =
     latestTotal && latestCacheable != null && latestTotal > 0
       ? latestCacheable / latestTotal
@@ -71,7 +71,7 @@ export function PromptTelemetryPanel({ keeper }: { keeper: Keeper }) {
   }
 
   const W = SPARKLINE_W, H = SPARKLINE_H
-  const totalLine = miniSparkline(promptTotals)
+  const totalLine = miniSparkline(promptBytes)
 
   return html`
     <div class="mb-5 v2-monitoring-panel">
@@ -88,15 +88,15 @@ export function PromptTelemetryPanel({ keeper }: { keeper: Keeper }) {
       <div class="grid grid-cols-1 md:grid-cols-4 gap-3 v2-monitoring-row">
         <${DetailCard} class="md:col-span-2">
           <${DetailRow}>
-            <${Eyebrow}>estimated prompt tokens</${Eyebrow}>
-            <span class="text-xs font-mono tabular-nums text-[var(--color-accent-fg)]">${latestTotal != null ? formatTokens(latestTotal) : '-'}</span>
+            <${Eyebrow}>prompt bytes</${Eyebrow}>
+            <span class="text-xs font-mono tabular-nums text-[var(--color-accent-fg)]">${latestTotal != null ? latestTotal.toLocaleString() : '-'}</span>
           </${DetailRow}>
-          <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded-[var(--r-1)] w-full" role="img" aria-label="프롬프트 토큰 추이" style="background:var(--bg-deepest);">
+          <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded-[var(--r-1)] w-full" role="img" aria-label="프롬프트 바이트 추이" style="background:var(--bg-deepest);">
             ${totalLine ? html`<polyline points="${totalLine}" fill="none" stroke="var(--amber-bright)" stroke-width="1.5"/>` : null}
           </svg>
           <div class="mt-1 flex flex-wrap gap-2 text-3xs text-[var(--color-fg-disabled)]">
-            <span>latest ${latestTotal != null ? formatTokens(latestTotal) : '-'}</span>
-            <span>cacheable ${latestCacheable != null ? formatTokens(latestCacheable) : '-'}</span>
+            <span>latest ${latestTotal != null ? `${latestTotal.toLocaleString()} bytes` : '-'}</span>
+            <span>cacheable ${latestCacheable != null ? `${latestCacheable.toLocaleString()} bytes` : '-'}</span>
             ${cacheableRatio != null ? html`<span>${Math.round(cacheableRatio * 100)}% cacheable</span>` : null}
             ${latest?.runtime_strategy
               ? html`<span>strategy ${latest.runtime_strategy}</span>`
@@ -131,11 +131,7 @@ export function PromptTelemetryPanel({ keeper }: { keeper: Keeper }) {
                   ${segment.fingerprint ? html`<${CopyIdButton} value=${segment.fingerprint} label="segment fingerprint" size=${10} />` : null}
                 </span>
               </div>
-              <div class="grid grid-cols-2 gap-2 text-xs">
-                <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2.5 py-2 v2-monitoring-card">
-                  <${Eyebrow} tone="disabled">tokens</${Eyebrow}>
-                  <div class="mt-1 font-mono tabular-nums text-[var(--color-accent-fg)]">${formatTokens(segment.estimated_tokens)}</div>
-                </div>
+              <div class="text-xs">
                 <div class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2.5 py-2 v2-monitoring-card">
                   <${Eyebrow} tone="disabled">bytes</${Eyebrow}>
                   <div class="mt-1 font-mono tabular-nums text-[var(--color-fg-secondary)]">${segment.bytes.toLocaleString()}</div>

--- a/dashboard/src/keeper-store-normalize.test.ts
+++ b/dashboard/src/keeper-store-normalize.test.ts
@@ -312,11 +312,11 @@ describe('normalizeKeepers lifecycle metrics', () => {
             prompt_fingerprint: 'prompt-fp-001',
             prompt: {
               fingerprint: 'prompt-fp-001',
-              estimated_total_tokens: 321,
-              estimated_cacheable_tokens: 144,
-              system_prompt: { bytes: 512, estimated_tokens: 144, fingerprint: 'seg-system' },
-              dynamic_context: { bytes: 220, estimated_tokens: 61, fingerprint: 'seg-dynamic' },
-              user_message: { bytes: 98, estimated_tokens: 28, fingerprint: 'seg-user' },
+              total_bytes: 830,
+              cacheable_bytes: 512,
+              system_prompt: { bytes: 512, fingerprint: 'seg-system' },
+              dynamic_context: { bytes: 220, fingerprint: 'seg-dynamic' },
+              user_message: { bytes: 98, fingerprint: 'seg-user' },
             },
           },
         ],
@@ -330,12 +330,12 @@ describe('normalizeKeepers lifecycle metrics', () => {
     expect(metric.prompt_fingerprint).toBe('prompt-fp-001')
     expect(metric.prompt_metrics).toEqual({
       fingerprint: 'prompt-fp-001',
-      estimated_total_tokens: 321,
-      estimated_cacheable_tokens: 144,
+      total_bytes: 830,
+      cacheable_bytes: 512,
       segments: {
-        system_prompt: { bytes: 512, estimated_tokens: 144, fingerprint: 'seg-system' },
-        dynamic_context: { bytes: 220, estimated_tokens: 61, fingerprint: 'seg-dynamic' },
-        user_message: { bytes: 98, estimated_tokens: 28, fingerprint: 'seg-user' },
+        system_prompt: { bytes: 512, fingerprint: 'seg-system' },
+        dynamic_context: { bytes: 220, fingerprint: 'seg-dynamic' },
+        user_message: { bytes: 98, fingerprint: 'seg-user' },
       },
     })
   })
@@ -667,14 +667,12 @@ describe('normalizeKeepers lifecycle metrics', () => {
             compacted: false,
             ctx_composition: {
               actual_input_tokens: 1000,
-              display_total_tokens: 1000,
-              estimated_known_tokens: 740,
+              attributed_bytes: 1160,
               segments: {
-                system_prompt: { bytes: 320, estimated_tokens: 120, fingerprint: null },
-                history_user: { bytes: 210, estimated_tokens: 90, fingerprint: null },
-                history_tool_use: { bytes: 90, estimated_tokens: 60, fingerprint: null },
-                history_tool_result: { bytes: 540, estimated_tokens: 330, fingerprint: null },
-                unattributed: { bytes: 0, estimated_tokens: 260, fingerprint: null },
+                system_prompt: { bytes: 320, fingerprint: null },
+                history_user: { bytes: 210, fingerprint: null },
+                history_tool_use: { bytes: 90, fingerprint: null },
+                history_tool_result: { bytes: 540, fingerprint: null },
               },
             },
           },
@@ -686,14 +684,12 @@ describe('normalizeKeepers lifecycle metrics', () => {
     const metric = keeper?.metrics_series?.[0]
     expect(metric?.ctx_composition).toEqual({
       actual_input_tokens: 1000,
-      display_total_tokens: 1000,
-      estimated_known_tokens: 740,
+      attributed_bytes: 1160,
       segments: {
-        system_prompt: { bytes: 320, estimated_tokens: 120, fingerprint: null },
-        history_user: { bytes: 210, estimated_tokens: 90, fingerprint: null },
-        history_tool_use: { bytes: 90, estimated_tokens: 60, fingerprint: null },
-        history_tool_result: { bytes: 540, estimated_tokens: 330, fingerprint: null },
-        unattributed: { bytes: 0, estimated_tokens: 260, fingerprint: null },
+        system_prompt: { bytes: 320, fingerprint: null },
+        history_user: { bytes: 210, fingerprint: null },
+        history_tool_use: { bytes: 90, fingerprint: null },
+        history_tool_result: { bytes: 540, fingerprint: null },
       },
     })
   })

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -403,18 +403,16 @@ export function normalizeKeeperTrust(raw: unknown): Keeper['trust'] {
 function normalizePromptSegments(
   raw: Record<string, unknown> | null,
   excludedKeys: Set<string>,
-): Record<string, { bytes: number; estimated_tokens: number; fingerprint: string | null }> {
-  const segments: Record<string, { bytes: number; estimated_tokens: number; fingerprint: string | null }> = {}
+): Record<string, { bytes: number; fingerprint: string | null }> {
+  const segments: Record<string, { bytes: number; fingerprint: string | null }> = {}
   if (!raw) return segments
   for (const [key, value] of Object.entries(raw)) {
     if (excludedKeys.has(key) || !isRecord(value)) continue
     const bytes = asNumber(value.bytes)
-    const estimatedTokens = asNumber(value.estimated_tokens)
     const fingerprint = typeof value.fingerprint === 'string' ? value.fingerprint : null
-    if (bytes == null && estimatedTokens == null && fingerprint == null) continue
+    if (bytes == null && fingerprint == null) continue
     segments[key] = {
       bytes: bytes ?? 0,
-      estimated_tokens: estimatedTokens ?? 0,
       fingerprint,
     }
   }
@@ -442,7 +440,7 @@ function normalizeMetricsSeries(raw: unknown): KeeperMetricPoint[] {
       const rawPrompt = isRecord(item.prompt) ? item.prompt : null
       const rawUsage = isRecord(item.usage) ? item.usage : null
       const promptSegments: NonNullable<PromptTelemetry['segments']> =
-        normalizePromptSegments(rawPrompt, new Set(['fingerprint', 'estimated_total_tokens', 'estimated_cacheable_tokens']))
+        normalizePromptSegments(rawPrompt, new Set(['fingerprint', 'total_bytes', 'cacheable_bytes']))
       const promptFingerprint =
         (typeof item.prompt_fingerprint === 'string' ? item.prompt_fingerprint : null)
         ?? (rawPrompt && typeof rawPrompt.fingerprint === 'string' ? rawPrompt.fingerprint : null)
@@ -450,8 +448,8 @@ function normalizeMetricsSeries(raw: unknown): KeeperMetricPoint[] {
         promptFingerprint != null || rawPrompt != null || Object.keys(promptSegments).length > 0
           ? {
               fingerprint: promptFingerprint,
-              estimated_total_tokens: rawPrompt ? (asNumber(rawPrompt.estimated_total_tokens) ?? null) : null,
-              estimated_cacheable_tokens: rawPrompt ? (asNumber(rawPrompt.estimated_cacheable_tokens) ?? null) : null,
+              total_bytes: rawPrompt ? (asNumber(rawPrompt.total_bytes) ?? null) : null,
+              cacheable_bytes: rawPrompt ? (asNumber(rawPrompt.cacheable_bytes) ?? null) : null,
               segments: promptSegments,
             }
           : null
@@ -464,8 +462,7 @@ function normalizeMetricsSeries(raw: unknown): KeeperMetricPoint[] {
         rawCtxComposition != null || Object.keys(ctxSegments).length > 0
           ? {
               actual_input_tokens: rawCtxComposition ? (asNumber(rawCtxComposition.actual_input_tokens) ?? null) : null,
-              display_total_tokens: rawCtxComposition ? (asNumber(rawCtxComposition.display_total_tokens) ?? 0) : 0,
-              estimated_known_tokens: rawCtxComposition ? (asNumber(rawCtxComposition.estimated_known_tokens) ?? 0) : 0,
+              attributed_bytes: rawCtxComposition ? (asNumber(rawCtxComposition.attributed_bytes) ?? 0) : 0,
               segments: ctxSegments,
             }
           : null

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -344,21 +344,19 @@ export interface InferenceTelemetry {
 
 export interface PromptSegmentTelemetry {
   bytes: number
-  estimated_tokens: number
   fingerprint: string | null
 }
 
 export interface PromptTelemetry {
   fingerprint: string | null
-  estimated_total_tokens: number | null
-  estimated_cacheable_tokens: number | null
+  total_bytes: number | null
+  cacheable_bytes: number | null
   segments: Record<string, PromptSegmentTelemetry>
 }
 
 export interface CtxCompositionTelemetry {
   actual_input_tokens: number | null
-  display_total_tokens: number
-  estimated_known_tokens: number
+  attributed_bytes: number
   segments: Record<string, PromptSegmentTelemetry>
 }
 

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -14,103 +14,97 @@ the categorization roadmap. Newly-added typed getters in
 `lib/config/env_config_*.ml` must carry nearby `@category` and
 `@ops_class` tags; existing knobs remain in the backfill lane.
 
-**Total**: 280 unique knobs across 9 modules.
+**Total**: 273 unique knobs across 9 modules.
 
-**Typed getter classification**: 39/162 tagged (`operator`: 39, `algorithm`: 0, `unclassified`: 123).
+**Typed getter classification**: 38/156 tagged (`operator`: 38, `algorithm`: 0, `unclassified`: 118).
 
 ## Env_config_core (25 knobs; typed classification 2/6)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_ADMIN_TOKEN` | string_literal | n/a | n/a | 520 | SSOT for auth env-var names (issue 8352). |
+| `MASC_ADMIN_TOKEN` | string_literal | n/a | n/a | 519 | SSOT for auth env-var names (issue 8352). |
 | `MASC_BASE_PATH` | string_literal | n/a | n/a | 372 | Env var names exposed as SSOT constants so out-of-process callers that read/write the variable by name (docker worker... |
 | `MASC_BASE_PATH_INPUT` | string_literal | n/a | n/a | 373 | Env var names exposed as SSOT constants so out-of-process callers that read/write the variable by name (docker worker... |
-| `MASC_BUILD_GIT_COMMIT` | string_literal | n/a | n/a | 567 | Git commit hash override for build identity. |
+| `MASC_BUILD_GIT_COMMIT` | string_literal | n/a | n/a | 566 | Git commit hash override for build identity. |
 | `MASC_CLUSTER_NAME` | string_literal | n/a | n/a | 276 |  |
 | `MASC_CONFIG_DIR` | string_literal | n/a | n/a | 498 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
-| `MASC_DATA_DIR` | string_literal | n/a | n/a | 511 | SSOT for the MASC_DATA_DIR env-var name (issue 8352). Overrides [<base_path>/data] as the root for runtime data ... |
-| `MASC_GIT_FETCH_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 539 | [git fetch origin] is network-bound and can stall behind a slow Docker bridge or a large remote. Default 120s gives e... |
+| `MASC_DATA_DIR` | string_literal | n/a | n/a | 510 | SSOT for the MASC_DATA_DIR env-var name (issue 8352). Overrides [<base_path>/data] as the root for runtime data stores. |
+| `MASC_GIT_FETCH_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 538 | [git fetch origin] is network-bound and can stall behind a slow Docker bridge or a large remote. Default 120s gives e... |
 | `MASC_HOST` | string_literal | n/a | n/a | 247 | SSOT for MASC_HOST / MASC_HTTP_PORT env-var names (issue 8352). Defined here so in-process readers and out-of-process... |
 | `MASC_HOST_FD_PRESSURE_POLLER_DISABLED` | typed:bool | Policies | operator | 356 | Operator policy toggle for disabling host fd pressure polling. @category Policies @ops_class operator |
 | `MASC_HOST_FD_PRESSURE_POLL_INTERVAL_SEC` | typed:float | Timeouts | operator | 362 | Operator timeout/interval knob for host fd pressure polling cadence. @category Timeouts @ops_class operator |
 | `MASC_HOST_FD_PRESSURE_STATE_FILE` | string_literal | n/a | n/a | 331 | {1 Host pressure integration} |
 | `MASC_HTTP_BASE_URL` | string_literal | n/a | n/a | 289 | SSOT for the MASC_HTTP_BASE_URL env-var name (issue 8352). Defined here (above [masc_http_base_url]) so the constant ... |
 | `MASC_HTTP_PORT` | string_literal | n/a | n/a | 248 | SSOT for MASC_HOST / MASC_HTTP_PORT env-var names (issue 8352). Defined here so in-process readers and out-of-process... |
-| `MASC_KEEPER_DEFAULT_SANDBOX_PROFILE` | typed:string | unclassified | unclassified | 578 | Default sandbox profile for keepers. Default: "local". Set to "docker" to default all keepers to containerized execut... |
-| `MASC_LOG_LEVEL` | string_literal | n/a | n/a | 544 | SSOT for logging / observability env-var names (issue 8352). |
-| `MASC_LOG_ROUTINE_LEVEL` | string_literal | n/a | n/a | 545 | SSOT for logging / observability env-var names (issue 8352). |
+| `MASC_KEEPER_DEFAULT_SANDBOX_PROFILE` | typed:string | unclassified | unclassified | 577 | Default sandbox profile for keepers. Default: "local". Set to "docker" to default all keepers to containerized execut... |
+| `MASC_LOG_LEVEL` | string_literal | n/a | n/a | 543 | SSOT for logging / observability env-var names (issue 8352). |
+| `MASC_LOG_ROUTINE_LEVEL` | string_literal | n/a | n/a | 544 | SSOT for logging / observability env-var names (issue 8352). |
 | `MASC_ORCHESTRATOR_ENABLED` | string_literal | n/a | n/a | 494 | SSOT for the MASC_ORCHESTRATOR_ENABLED env-var name (issue 8352). Referenced by feature_flag_registry catalog, env_co... |
 | `MASC_PARSE_WARN` | string_literal | n/a | n/a | 35 |  |
 | `MASC_PERSONAS_DIR` | string_literal | n/a | n/a | 499 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
-| `MASC_PUBSUB_MAX_MESSAGES` | typed:int | unclassified | unclassified | 571 | PubSub max messages per read. Default: 1000. |
+| `MASC_PUBSUB_MAX_MESSAGES` | typed:int | unclassified | unclassified | 570 | PubSub max messages per read. Default: 1000. |
 | `MASC_SYSMON_PRESSURE_STATE` | string_literal | n/a | n/a | 332 | {1 Host pressure integration} |
-| `MASC_TELEMETRY_ENABLED` | typed:bool | unclassified | unclassified | 556 | Whether telemetry tracking is enabled. Default: true. |
+| `MASC_TELEMETRY_ENABLED` | typed:bool | unclassified | unclassified | 555 | Whether telemetry tracking is enabled. Default: true. |
 | `MASC_TEST_ALLOW_HOME_BASE_PATH` | string_literal | n/a | n/a | 431 | #9903: production base-path safeguard for test executables. Without this, a test whose [MASC_BASE_PATH] override fail... |
 | `MASC_URL` | string_literal | n/a | n/a | 290 | SSOT for the MASC_HTTP_BASE_URL env-var name (issue 8352). Defined here (above [masc_http_base_url]) so the constant ... |
 
-## Env_config_keeper (59 knobs; typed classification 27/53)
+## Env_config_keeper (53 knobs; typed classification 26/47)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_CONTEXT_RATIO_HARD_CAP` | typed:float | unclassified | unclassified | 749 | {1 Context Ratio Hard Cap} Absolute ceiling for compaction ratio_gate and handoff threshold after multiplier adjustme... |
-| `MASC_DASHBOARD_HEALTH_CTX_CRITICAL` | typed:float | unclassified | unclassified | 758 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_HEALTH_CTX_WARN` | typed:float | unclassified | unclassified | 759 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_HEALTH_PENALTY_CRITICAL` | typed:float | unclassified | unclassified | 760 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_HEALTH_PENALTY_WARN` | typed:float | unclassified | unclassified | 761 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 764 |  |
-| `MASC_KEEPER_ATTEMPT_WATCHDOG_SAFETY_CAP_SEC` | typed:float | unclassified | unclassified | 637 | Deprecated compatibility knob for the removed whole-run attempt watchdog. The keeper runtime must not apply this as a... |
-| `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 689 | Total HTTP body-consumption deadline for non-streaming OAS completion calls. In agent_sdk this wraps [Complete.comple... |
+| `MASC_CONTEXT_RATIO_HARD_CAP` | typed:float | unclassified | unclassified | 656 | {1 Context Ratio Hard Cap} Absolute ceiling for compaction ratio_gate and handoff threshold after multiplier adjustme... |
+| `MASC_DASHBOARD_HEALTH_CTX_CRITICAL` | typed:float | unclassified | unclassified | 665 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_HEALTH_CTX_WARN` | typed:float | unclassified | unclassified | 666 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_HEALTH_PENALTY_CRITICAL` | typed:float | unclassified | unclassified | 667 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_HEALTH_PENALTY_WARN` | typed:float | unclassified | unclassified | 668 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 671 |  |
+| `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 596 | Total HTTP body-consumption deadline for non-streaming OAS completion calls. In agent_sdk this wraps [Complete.comple... |
 | `MASC_KEEPER_BOOTSTRAP_ENABLED` | feature_flag | n/a | n/a | 20 | Enable startup keeper bootstrap scan |
 | `MASC_KEEPER_BOOTSTRAP_LAZY_STARTUP_POLL_INTERVAL_SEC` | typed:float | unclassified | unclassified | 41 | Polling interval (seconds) for the lazy-startup wait loop in [server_bootstrap_loops.ml]. The autoboot fiber wakes up... |
 | `MASC_KEEPER_BOOTSTRAP_LISTENER_RETRY_INTERVAL_SEC` | typed:float | unclassified | unclassified | 53 | Polling interval (seconds) for the keeper-lifecycle listener retry loop in [server_bootstrap_loops.ml]. After a liste... |
 | `MASC_KEEPER_BOOTSTRAP_MAX_SCAN` | typed:int | unclassified | unclassified | 28 | Max keeper meta files to scan during bootstrap |
 | `MASC_KEEPER_BOOTSTRAP_POST_STARTUP_SETTLE_SEC` | typed:float | unclassified | unclassified | 65 | Settle delay (seconds) between lazy-startup completion and the keeper bootstrap fan-out. The autoboot fiber sleeps fo... |
 | `MASC_KEEPER_BOOTSTRAP_STALE_TURN_SEC` | typed:float | unclassified | unclassified | 24 | Keeper considered stale when last turn exceeds this threshold (seconds) |
-| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 709 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI providers need an OAS upstream chan... |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_DEFAULT_LIMIT` | typed:int | Runtime | operator | 357 | Default item limit for [GET /keepers/:name/compaction-snapshots]. Default: 25. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_LIMIT_MULTIPLIER` | typed:int | Runtime | operator | 383 | Multiplier from requested item limit to manifest files scanned. Default: 4. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_MIN_FILES` | typed:int | Runtime | operator | 373 | Minimum manifest files scanned before applying [limit * multiplier]. Default: 8. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_TAIL_MAX_LINES` | typed:int | Runtime | operator | 393 | Tail line count read from each selected manifest file. Default: 200. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MAX_LIMIT` | typed:int | Runtime | operator | 363 | Maximum accepted item limit for the compaction snapshot endpoint. Default: 100. @category Runtime @ops_class operator |
+| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 616 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI providers need an OAS upstream chan... |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_DEFAULT_LIMIT` | typed:int | Runtime | operator | 350 | Default item limit for [GET /keepers/:name/compaction-snapshots]. Default: 25. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_LIMIT_MULTIPLIER` | typed:int | Runtime | operator | 376 | Multiplier from requested item limit to manifest files scanned. Default: 4. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_MIN_FILES` | typed:int | Runtime | operator | 366 | Minimum manifest files scanned before applying [limit * multiplier]. Default: 8. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_TAIL_MAX_LINES` | typed:int | Runtime | operator | 386 | Tail line count read from each selected manifest file. Default: 200. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MAX_LIMIT` | typed:int | Runtime | operator | 356 | Maximum accepted item limit for the compaction snapshot endpoint. Default: 100. @category Runtime @ops_class operator |
 | `MASC_KEEPER_CRASH_PERSIST_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 143 | Crash persistence drain fiber wake interval in seconds. Drain fiber batches in-memory crash events and persists them ... |
 | `MASC_KEEPER_DEBUG` | feature_flag | n/a | n/a | 151 | Enable keeper debug logging. Default: false. |
-| `MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD` | typed:float | unclassified | unclassified | 157 | Daily budget for keeper deliberation (USD). Default: 0.10. Re-readable within the process. Live operator control shou... |
-| `MASC_KEEPER_DURABLE_QUEUE_STALE_SEC` | typed:float | Telemetry | operator | 531 | Durable event-queue backlog age threshold for fleet health degradation. The durable queue remains fully reported rega... |
-| `MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC` | typed:float | Timeouts | operator | 670 | OAS Agent.run inactivity deadline. This is progress-based rather than cumulative wall-clock: OAS resets the timer whe... |
-| `MASC_KEEPER_GENERATED_MEDIA_DIR_MAX_BYTES` | typed:int | Policies | operator | 480 | Maximum total bytes retained in [<masc_dir>/media] after opportunistic cleanup. Default is 500 MiB. Range: [1, 5 GiB]... |
-| `MASC_KEEPER_GENERATED_MEDIA_MAX_BYTES` | typed:int | Policies | operator | 469 | Maximum raw generated-media bytes accepted by the durable store and serve route. Default is 10 MiB. Range: [1, 50 MiB... |
-| `MASC_KEEPER_GENERATED_MEDIA_RETENTION_SEC` | typed:float | Policies | operator | 491 | Maximum generated-media file age retained by opportunistic cleanup. Default is 24 hours. Range: [1 second, 30 days]. ... |
-| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 722 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
-| `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | unclassified | unclassified | 498 | Shared: keepalive interval, read early so WorkAsHeartbeat can reference it. |
-| `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | unclassified | unclassified | 513 | Maximum seconds since last successful workspace heartbeat before presence sync is required again. Floor = keepalive i... |
-| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION` | typed:bool | Policies | operator | 331 | Per-keeper Memory OS consolidation maintenance fiber kill switch. Default: false; invalid values fail closed to false... |
-| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION_RUNTIME_ID` | typed:string | Runtime | operator | 341 | Optional runtime id override for Memory OS consolidation. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_GC` | typed:bool | Storage | operator | 320 | Per-keeper Memory OS GC maintenance fiber kill switch. Default: true; invalid values fail closed to false. Env var ac... |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN` | typed:bool | Policies | operator | 240 | Memory OS librarian post-turn extraction kill switch. Default: true; invalid values fail closed to false so malformed... |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS` | typed:int | Runtime | operator | 252 | Turns between librarian extraction attempts per keeper. Default: 3, floored to 1. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT` | typed:int | Concurrency | operator | 308 | Fleet-wide concurrency gate for librarian provider calls. Default: 1; 0 disables the gate. @category Concurrency @ops... |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES` | typed:int | Runtime | operator | 264 | Base recent-message window for librarian extraction. Default: 24, floored to 1. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_TOKENS` | typed:int | Runtime | operator | 286 | Output token cap for librarian extraction, applied as min with the provider max_tokens. Default: 4096, floored to 1. ... |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID` | typed:string | Runtime | operator | 296 | Optional runtime id override for librarian extraction. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_TIMEOUT_SEC` | typed:float | Timeouts | operator | 274 | Provider timeout for librarian extraction. Default: 600 seconds; invalid, non-positive, NaN, or infinite values fall ... |
-| `MASC_KEEPER_MEMORY_OS_RECALL` | typed:bool | Policies | operator | 228 | Memory OS recall prompt injection kill switch. Default: true; invalid values fail closed to false so malformed operat... |
+| `MASC_KEEPER_DURABLE_QUEUE_STALE_SEC` | typed:float | Telemetry | operator | 524 | Durable event-queue backlog age threshold for fleet health degradation. The durable queue remains fully reported rega... |
+| `MASC_KEEPER_GENERATED_MEDIA_DIR_MAX_BYTES` | typed:int | Policies | operator | 473 | Maximum total bytes retained in [<masc_dir>/media] after opportunistic cleanup. Default is 500 MiB. Range: [1, 5 GiB]... |
+| `MASC_KEEPER_GENERATED_MEDIA_MAX_BYTES` | typed:int | Policies | operator | 462 | Maximum raw generated-media bytes accepted by the durable store and serve route. Default is 10 MiB. Range: [1, 50 MiB... |
+| `MASC_KEEPER_GENERATED_MEDIA_RETENTION_SEC` | typed:float | Policies | operator | 484 | Maximum generated-media file age retained by opportunistic cleanup. Default is 24 hours. Range: [1 second, 30 days]. ... |
+| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 629 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
+| `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | unclassified | unclassified | 491 | Shared: keepalive interval, read early so WorkAsHeartbeat can reference it. |
+| `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | unclassified | unclassified | 506 | Maximum seconds since last successful workspace heartbeat before presence sync is required again. Floor = keepalive i... |
+| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION` | typed:bool | Policies | operator | 324 | Per-keeper Memory OS consolidation maintenance fiber kill switch. Default: false; invalid values fail closed to false... |
+| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION_RUNTIME_ID` | typed:string | Runtime | operator | 334 | Optional runtime id override for Memory OS consolidation. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_GC` | typed:bool | Storage | operator | 313 | Per-keeper Memory OS GC maintenance fiber kill switch. Default: true; invalid values fail closed to false. Env var ac... |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN` | typed:bool | Policies | operator | 233 | Memory OS librarian post-turn extraction kill switch. Default: true; invalid values fail closed to false so malformed... |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS` | typed:int | Runtime | operator | 245 | Turns between librarian extraction attempts per keeper. Default: 3, floored to 1. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT` | typed:int | Concurrency | operator | 301 | Fleet-wide concurrency gate for librarian provider calls. Default: 1; 0 disables the gate. @category Concurrency @ops... |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES` | typed:int | Runtime | operator | 257 | Base recent-message window for librarian extraction. Default: 24, floored to 1. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_TOKENS` | typed:int | Runtime | operator | 279 | Output token cap for librarian extraction, applied as min with the provider max_tokens. Default: 4096, floored to 1. ... |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID` | typed:string | Runtime | operator | 289 | Optional runtime id override for librarian extraction. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_TIMEOUT_SEC` | typed:float | Timeouts | operator | 267 | Provider timeout for librarian extraction. Default: 600 seconds; invalid, non-positive, NaN, or infinite values fall ... |
+| `MASC_KEEPER_MEMORY_OS_RECALL` | typed:bool | Policies | operator | 221 | Memory OS recall prompt injection kill switch. Default: true; invalid values fail closed to false so malformed operat... |
 | `MASC_KEEPER_METRICS_MAX_BYTES` | typed:int | unclassified | unclassified | 73 | Maximum metrics file size in bytes before rotation (default: 10MB) |
 | `MASC_KEEPER_METRICS_MAX_ROTATED` | typed:int | unclassified | unclassified | 76 | Number of rotated files to keep (default: 1, i.e. .1 only) |
-| `MASC_KEEPER_OAS_TIMEOUT_SEC` | string_literal | n/a | n/a | 598 | Per-call OAS timeout override in seconds. Legacy/env override value is clamped to the active keepalive retry/admissio... |
-| `MASC_KEEPER_PROACTIVE_MAX_ATTEMPTS` | typed:int | unclassified | unclassified | 732 | Maximum proactive generation attempts before falling back. Default: 3. Range: [1, 10]. |
-| `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | unclassified | unclassified | 552 | Interruptible sleep chunk size in seconds. Smaller = faster wakeup response but more CPU polling. Default: 2.0. Range... |
-| `MASC_KEEPER_SNAPSHOT_SEC` | typed:int | unclassified | unclassified | 161 | Keeper keepalive snapshot interval, clamped to [15, 3600]. Default: 300. |
-| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 738 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
-| `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 646 | Idle-gap timeout for streaming OAS provider responses. This bounds time between streamed lines, not total turn durati... |
-| `MASC_KEEPER_TURN_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 584 | Retry/admission budget in seconds for a single unified turn (including all retries and runtime fallbacks). This value... |
-| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_BASE_SEC` | typed:float | Timeouts | operator | 430 | Base delay before trying the next vision runtime after a failed provider attempt. A small default avoids tight failov... |
-| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_MAX_SEC` | typed:float | Timeouts | operator | 440 | Upper bound for the per-candidate vision failover delay. Range: [base, 30] seconds, so a typo cannot exceed the tool'... |
-| `MASC_KEEPER_VISION_MAX_IMAGE_BYTES` | typed:int | Policies | operator | 420 | Maximum raw image bytes accepted by the one-shot vision tool before provider-message construction. Default is 5 MiB t... |
+| `MASC_KEEPER_PROACTIVE_MAX_ATTEMPTS` | typed:int | unclassified | unclassified | 639 | Maximum proactive generation attempts before falling back. Default: 3. Range: [1, 10]. |
+| `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | unclassified | unclassified | 545 | Interruptible sleep chunk size in seconds. Smaller = faster wakeup response but more CPU polling. Default: 2.0. Range... |
+| `MASC_KEEPER_SNAPSHOT_SEC` | typed:int | unclassified | unclassified | 154 | Keeper keepalive snapshot interval, clamped to [15, 3600]. Default: 300. |
+| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 645 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
+| `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | string_literal | n/a | n/a | 556 |  |
+| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_BASE_SEC` | typed:float | Timeouts | operator | 423 | Base delay before trying the next vision runtime after a failed provider attempt. A small default avoids tight failov... |
+| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_MAX_SEC` | typed:float | Timeouts | operator | 433 | Upper bound for the per-candidate vision failover delay. Range: [base, 30] seconds, so a typo cannot exceed the tool'... |
+| `MASC_KEEPER_VISION_MAX_IMAGE_BYTES` | typed:int | Policies | operator | 413 | Maximum raw image bytes accepted by the one-shot vision tool before provider-message construction. Default is 5 MiB t... |
 | `MASC_KEEPER_WIRE_CAPTURE` | feature_flag | Policies | operator | 88 | Master switch for diagnostic MASC->OAS wire capture. Default off. @category Policies @ops_class operator |
 | `MASC_KEEPER_WIRE_CAPTURE_MAX_BYTES` | typed:int | Policies | operator | 114 | Maximum bytes for the active [<masc_root>/wire-capture/YYYY-MM/DD.jsonl] file and maximum total bytes retained below ... |
 | `MASC_KEEPER_WIRE_CAPTURE_RETENTION_DAYS` | typed:int | Policies | operator | 103 | Maximum age for [<masc_root>/wire-capture] day files retained by the diagnostic MASC->OAS wire-capture harness. Defau... |
-| `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 507 | Master switch. When true, successful Workspace.heartbeat after a unified turn counts as presence proof, allowing the ... |
-| `MASC_PAYLOAD_TELEMETRY` | typed:bool | unclassified | unclassified | 782 | Master switch for wake-payload measurement. Default off so the hot path is untouched until a baseline sweep is explic... |
+| `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 500 | Master switch. When true, successful Workspace.heartbeat after a unified turn counts as presence proof, allowing the ... |
 
 ## Env_config_keeper_supervisor (3 knobs; typed classification 2/2)
 
@@ -271,71 +265,70 @@ the categorization roadmap. Newly-added typed getters in
 |---|---|---|---|---|---|
 | `MASC_SLACK_TRIGGER_POLICY` | string_literal | n/a | n/a | 20 |  |
 
-## Env_config_snapshot (67 knobs; typed classification 0/0)
+## Env_config_snapshot (66 knobs; typed classification 0/0)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
 | `MASC_ALLOW_ANONYMOUS_MUTATIONS` | string_literal | n/a | n/a | 29 |  |
-| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 578 |  |
-| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 582 |  |
-| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 584 |  |
-| `MASC_BENCHMARK_RESULTS_DIR` | string_literal | n/a | n/a | 188 |  |
-| `MASC_CHANNEL_GATE_DEDUP_TTL_SEC` | string_literal | n/a | n/a | 274 |  |
-| `MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH` | string_literal | n/a | n/a | 276 |  |
-| `MASC_DASHBOARD_CACHE_MAX_ENTRIES` | string_literal | n/a | n/a | 190 |  |
-| `MASC_DASHBOARD_EXECUTION_REFRESH_TIMEOUT_S` | string_literal | n/a | n/a | 198 |  |
-| `MASC_DASHBOARD_TRANSPORT_HEALTH_TIMEOUT_S` | string_literal | n/a | n/a | 238 |  |
-| `MASC_DECISION_AUDIT_RING_CAPACITY` | string_literal | n/a | n/a | 292 |  |
-| `MASC_DEFAULT_MODEL` | string_literal | n/a | n/a | 532 |  |
-| `MASC_DEFAULT_PROVIDER` | string_literal | n/a | n/a | 534 |  |
-| `MASC_DISCORD_STATUS_STALE_SEC` | string_literal | n/a | n/a | 278 |  |
-| `MASC_DRIFT_COSINE_WEIGHT` | string_literal | n/a | n/a | 179 |  |
-| `MASC_DRIFT_JACCARD_WEIGHT` | string_literal | n/a | n/a | 178 |  |
-| `MASC_DRIFT_THRESHOLD` | string_literal | n/a | n/a | 177 |  |
-| `MASC_ECONOMY_ENABLED` | string_literal | n/a | n/a | 333 |  |
-| `MASC_ECONOMY_FRUGAL_THRESHOLD` | string_literal | n/a | n/a | 335 |  |
-| `MASC_ECONOMY_HUSTLE_THRESHOLD` | string_literal | n/a | n/a | 337 |  |
-| `MASC_ECONOMY_INITIAL_BALANCE` | string_literal | n/a | n/a | 339 |  |
-| `MASC_ECONOMY_REWARD_BOARD_POST` | string_literal | n/a | n/a | 341 |  |
-| `MASC_ECONOMY_REWARD_MENTION_RESPONSE` | string_literal | n/a | n/a | 343 |  |
-| `MASC_ECONOMY_REWARD_TASK_DONE` | string_literal | n/a | n/a | 345 |  |
-| `MASC_ECONOMY_REWARD_UPVOTE` | string_literal | n/a | n/a | 347 |  |
-| `MASC_EVENT_BUFFER_SIZE` | string_literal | n/a | n/a | 662 |  |
-| `MASC_GOAL_DISPATCH_RUNTIME` | string_literal | n/a | n/a | 536 |  |
+| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 566 |  |
+| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 570 |  |
+| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 572 |  |
+| `MASC_BENCHMARK_RESULTS_DIR` | string_literal | n/a | n/a | 184 |  |
+| `MASC_CHANNEL_GATE_DEDUP_TTL_SEC` | string_literal | n/a | n/a | 270 |  |
+| `MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH` | string_literal | n/a | n/a | 272 |  |
+| `MASC_DASHBOARD_CACHE_MAX_ENTRIES` | string_literal | n/a | n/a | 186 |  |
+| `MASC_DASHBOARD_EXECUTION_REFRESH_TIMEOUT_S` | string_literal | n/a | n/a | 194 |  |
+| `MASC_DASHBOARD_TRANSPORT_HEALTH_TIMEOUT_S` | string_literal | n/a | n/a | 234 |  |
+| `MASC_DECISION_AUDIT_RING_CAPACITY` | string_literal | n/a | n/a | 288 |  |
+| `MASC_DEFAULT_MODEL` | string_literal | n/a | n/a | 520 |  |
+| `MASC_DEFAULT_PROVIDER` | string_literal | n/a | n/a | 522 |  |
+| `MASC_DISCORD_STATUS_STALE_SEC` | string_literal | n/a | n/a | 274 |  |
+| `MASC_DRIFT_COSINE_WEIGHT` | string_literal | n/a | n/a | 175 |  |
+| `MASC_DRIFT_JACCARD_WEIGHT` | string_literal | n/a | n/a | 174 |  |
+| `MASC_DRIFT_THRESHOLD` | string_literal | n/a | n/a | 173 |  |
+| `MASC_ECONOMY_ENABLED` | string_literal | n/a | n/a | 329 |  |
+| `MASC_ECONOMY_FRUGAL_THRESHOLD` | string_literal | n/a | n/a | 331 |  |
+| `MASC_ECONOMY_HUSTLE_THRESHOLD` | string_literal | n/a | n/a | 333 |  |
+| `MASC_ECONOMY_INITIAL_BALANCE` | string_literal | n/a | n/a | 335 |  |
+| `MASC_ECONOMY_REWARD_BOARD_POST` | string_literal | n/a | n/a | 337 |  |
+| `MASC_ECONOMY_REWARD_MENTION_RESPONSE` | string_literal | n/a | n/a | 339 |  |
+| `MASC_ECONOMY_REWARD_TASK_DONE` | string_literal | n/a | n/a | 341 |  |
+| `MASC_ECONOMY_REWARD_UPVOTE` | string_literal | n/a | n/a | 343 |  |
+| `MASC_EVENT_BUFFER_SIZE` | string_literal | n/a | n/a | 650 |  |
+| `MASC_GOAL_DISPATCH_RUNTIME` | string_literal | n/a | n/a | 524 |  |
 | `MASC_GRPC_STREAM_MAX_BUFFER` | string_literal | n/a | n/a | 76 |  |
-| `MASC_HEBBIAN_DECAY` | string_literal | n/a | n/a | 181 |  |
-| `MASC_HEBBIAN_RATE` | string_literal | n/a | n/a | 180 |  |
+| `MASC_HEBBIAN_DECAY` | string_literal | n/a | n/a | 177 |  |
+| `MASC_HEBBIAN_RATE` | string_literal | n/a | n/a | 176 |  |
 | `MASC_HTTP_HOST` | string_literal | n/a | n/a | 21 |  |
 | `MASC_HTTP_MAX_CONNECTIONS` | string_literal | n/a | n/a | 22 |  |
-| `MASC_IMESSAGE_STATUS_STALE_SEC` | string_literal | n/a | n/a | 280 |  |
-| `MASC_KEEPER_AUTONOMOUS_MAX_TOKENS` | string_literal | n/a | n/a | 157 |  |
-| `MASC_KEEPER_COMPACT_MAX_MESSAGES` | string_literal | n/a | n/a | 148 |  |
-| `MASC_KEEPER_COMPACT_MAX_TOKENS` | string_literal | n/a | n/a | 150 |  |
-| `MASC_KEEPER_COMPACT_RATIO` | string_literal | n/a | n/a | 146 |  |
-| `MASC_KEEPER_LLM_RERANK_RUNTIME` | string_literal | n/a | n/a | 442 |  |
-| `MASC_KEEPER_TOOL_COST_MAX_USD` | string_literal | n/a | n/a | 152 |  |
-| `MASC_KEEPER_UNIFIED_MAX_TOKENS` | string_literal | n/a | n/a | 155 |  |
-| `MASC_KEEPER_UNIFIED_TEMP` | string_literal | n/a | n/a | 154 |  |
-| `MASC_LOCK_WARN_MS` | string_literal | n/a | n/a | 182 |  |
-| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 638 |  |
-| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 672 |  |
-| `MASC_ROUTING_RUNTIME` | string_literal | n/a | n/a | 538 |  |
-| `MASC_RUNTIME_ATTEMPT_LIVENESS` | string_literal | n/a | n/a | 379 |  |
-| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 680 |  |
-| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 606 |  |
-| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 608 |  |
-| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 610 |  |
-| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 612 |  |
-| `MASC_SSE_KEEPALIVE_SEC` | string_literal | n/a | n/a | 664 |  |
-| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 618 |  |
+| `MASC_IMESSAGE_STATUS_STALE_SEC` | string_literal | n/a | n/a | 276 |  |
+| `MASC_KEEPER_AUTONOMOUS_MAX_TOKENS` | string_literal | n/a | n/a | 153 |  |
+| `MASC_KEEPER_COMPACT_MAX_MESSAGES` | string_literal | n/a | n/a | 146 |  |
+| `MASC_KEEPER_COMPACT_MAX_TOKENS` | string_literal | n/a | n/a | 148 |  |
+| `MASC_KEEPER_COMPACT_RATIO` | string_literal | n/a | n/a | 144 |  |
+| `MASC_KEEPER_LLM_RERANK_RUNTIME` | string_literal | n/a | n/a | 430 |  |
+| `MASC_KEEPER_UNIFIED_MAX_TOKENS` | string_literal | n/a | n/a | 151 |  |
+| `MASC_KEEPER_UNIFIED_TEMP` | string_literal | n/a | n/a | 150 |  |
+| `MASC_LOCK_WARN_MS` | string_literal | n/a | n/a | 178 |  |
+| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 626 |  |
+| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 660 |  |
+| `MASC_ROUTING_RUNTIME` | string_literal | n/a | n/a | 526 |  |
+| `MASC_RUNTIME_ATTEMPT_LIVENESS` | string_literal | n/a | n/a | 375 |  |
+| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 668 |  |
+| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 594 |  |
+| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 596 |  |
+| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 598 |  |
+| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 600 |  |
+| `MASC_SSE_KEEPALIVE_SEC` | string_literal | n/a | n/a | 652 |  |
+| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 606 |  |
 | `MASC_TELEMETRY_MAX_BYTES` | string_literal | n/a | n/a | 48 |  |
 | `MASC_TELEMETRY_RETENTION_DAYS` | string_literal | n/a | n/a | 45 |  |
-| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 654 |  |
-| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 656 |  |
-| `MASC_TLA_TRACE` | string_literal | n/a | n/a | 140 |  |
-| `MASC_WORKER_RUNTIME_BACKEND` | string_literal | n/a | n/a | 706 |  |
-| `MASC_WORKER_RUNTIME_DOCKER_IMAGE` | string_literal | n/a | n/a | 708 |  |
-| `MASC_WORKER_RUNTIME_HOST_MCP_BASE_URL` | string_literal | n/a | n/a | 710 |  |
+| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 642 |  |
+| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 644 |  |
+| `MASC_TLA_TRACE` | string_literal | n/a | n/a | 138 |  |
+| `MASC_WORKER_RUNTIME_BACKEND` | string_literal | n/a | n/a | 694 |  |
+| `MASC_WORKER_RUNTIME_DOCKER_IMAGE` | string_literal | n/a | n/a | 696 |  |
+| `MASC_WORKER_RUNTIME_HOST_MCP_BASE_URL` | string_literal | n/a | n/a | 698 |  |
 | `MASC_WS_ACK_STALE_THRESHOLD_SEC` | string_literal | n/a | n/a | 86 |  |
 | `MASC_WS_CLIENT_BUFFER_LIMIT_BYTES` | string_literal | n/a | n/a | 83 |  |
 | `MASC_WS_MAX_INBOUND_DISPATCHES_PER_SESSION` | string_literal | n/a | n/a | 110 |  |

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -672,23 +672,6 @@ module DashboardHealth = struct
   ;;
 end
 
-(** {1 Wake-time Payload Telemetry}
-
-    Phase 0 observability for the tiered-hydration redesign (Option C).
-    When enabled, every keeper wake captures an approximation of the LLM
-    request payload size just before [Keeper_turn_driver.run_named] is invoked.
-    The record is appended to
-    [$MASC_BASE_PATH/data/keeper-wake-payload/YYYY-MM-DD.jsonl] via
-    [Dashboard_harness_health.record_wake_payload].
-
-    Cost when disabled: a single env var lookup (bool). The entire
-    measurement path is gated behind [payload_telemetry_enabled]. *)
-module KeeperTelemetry = struct
-  (** Master switch for wake-payload measurement. Default off so the hot
-      path is untouched until a baseline sweep is explicitly requested. *)
-  let payload_telemetry_enabled () = get_bool ~default:false "MASC_PAYLOAD_TELEMETRY"
-end
-
 (* MASC_KEEPER_RUNTIME_PROVIDER_ALLOWLIST (KeeperRuntimeProviderFilter) was
    deleted (audit F8): its value was threaded as [?provider_filter] into
    [Keeper_turn_driver.run_named] and [Keeper_memory_llm_summary.make], both of

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -216,9 +216,3 @@ module DashboardHealth : sig
   val penalty_warn : float
   val runtime_warning_ctx_ratio : float
 end
-
-(** {1 Wake-time payload telemetry} *)
-
-module KeeperTelemetry : sig
-  val payload_telemetry_enabled : unit -> bool
-end

--- a/lib/dashboard/dashboard_harness_health.ml
+++ b/lib/dashboard/dashboard_harness_health.ml
@@ -94,8 +94,8 @@ let runtime_warning_ctx_ratio =
 let pre_compact_store_ref : Dated_jsonl.t option Atomic.t = Atomic.make None
 let pre_compact_store_mu = Eio.Mutex.create ()
 
-(** Store for wake-time payload observations. Populated lazily on first
-    [record_wake_payload] call when [MASC_PAYLOAD_TELEMETRY] is enabled. *)
+(** Store for wake-time payload observations. Populated lazily on the first
+    [record_wake_payload] call. *)
 let wake_payload_store_ref : Dated_jsonl.t option Atomic.t = Atomic.make None
 let wake_payload_store_mu = Eio.Mutex.create ()
 

--- a/lib/keeper/keeper_agent_prompt_metrics.ml
+++ b/lib/keeper/keeper_agent_prompt_metrics.ml
@@ -7,7 +7,7 @@ module Canonical_tool = Agent_sdk.Canonical_tool
     tool guidance, direct-reply mode) that must stay in the system prompt.
     [dynamic_context] contains soft context (continuity, skill route,
     worktree changes, turn instructions) injected via OAS
-    [extra_system_context] — prepended as a User message after reduction. *)
+    [extra_system_context] at request assembly. *)
 type turn_prompt =
   { system_prompt : string
   ; dynamic_context : string
@@ -17,17 +17,14 @@ type turn_prompt =
     Bytes are stored rather than character counts because prompts are UTF-8. *)
 type prompt_segment_metrics =
   { bytes : int
-  ; estimated_tokens : int
   ; fingerprint : string option
   }
 
-(** Effective prompt metrics for a keeper turn.
-    [estimated_cacheable_tokens] tracks the system prompt portion only because
-    OAS prompt caching is enabled via [cache_system_prompt:true]. *)
+(** Effective byte metrics for a keeper turn. *)
 type prompt_metrics =
   { fingerprint : string
-  ; estimated_total_tokens : int
-  ; estimated_cacheable_tokens : int
+  ; total_bytes : int
+  ; cacheable_bytes : int
   ; system_prompt_segment : prompt_segment_metrics
   ; dynamic_context_segment : prompt_segment_metrics
   ; user_message_segment : prompt_segment_metrics
@@ -35,20 +32,17 @@ type prompt_metrics =
 
 type ctx_composition_metrics =
   { actual_input_tokens : int option
-  ; display_total_tokens : int
-  ; estimated_known_tokens : int
+  ; attributed_bytes : int
   ; segments : (string * prompt_segment_metrics) list
   }
 
 let empty_prompt_segment_metrics =
-  { bytes = 0; estimated_tokens = 0; fingerprint = None }
+  { bytes = 0; fingerprint = None }
 
 let prompt_segment_metrics_of_text (text : string) : prompt_segment_metrics =
   let text = Inference_utils.sanitize_text_utf8 text in
   {
     bytes = String.length text;
-    estimated_tokens =
-      (if text = "" then 0 else Agent_sdk.Context_reducer.estimate_char_tokens text);
     fingerprint =
       (if text = ""
        then None
@@ -74,11 +68,11 @@ let build_prompt_metrics ~(system_prompt : string) ~(dynamic_context : string)
   in
   {
     fingerprint = Digestif.SHA256.(digest_string fingerprint_input |> to_hex);
-    estimated_total_tokens =
-      (system_prompt_metrics.estimated_tokens
-       + dynamic_context_metrics.estimated_tokens
-       + user_message_metrics.estimated_tokens);
-    estimated_cacheable_tokens = system_prompt_metrics.estimated_tokens;
+    total_bytes =
+      (system_prompt_metrics.bytes
+       + dynamic_context_metrics.bytes
+       + user_message_metrics.bytes);
+    cacheable_bytes = system_prompt_metrics.bytes;
     system_prompt_segment = system_prompt_metrics;
     dynamic_context_segment = dynamic_context_metrics;
     user_message_segment = user_message_metrics;
@@ -89,7 +83,6 @@ let prompt_segment_metrics_to_json (segment : prompt_segment_metrics) :
   `Assoc
     [
       ("bytes", `Int segment.bytes);
-      ("estimated_tokens", `Int segment.estimated_tokens);
       ("fingerprint", Json_util.string_opt_to_json segment.fingerprint);
     ]
 
@@ -97,15 +90,12 @@ let prompt_metrics_to_json (metrics : prompt_metrics) : Yojson.Safe.t =
   `Assoc
     [
       ("fingerprint", `String metrics.fingerprint);
-      ("estimated_total_tokens", `Int metrics.estimated_total_tokens);
-      ("estimated_cacheable_tokens", `Int metrics.estimated_cacheable_tokens);
+      ("total_bytes", `Int metrics.total_bytes);
+      ("cacheable_bytes", `Int metrics.cacheable_bytes);
       ("system_prompt", prompt_segment_metrics_to_json metrics.system_prompt_segment);
       ("dynamic_context", prompt_segment_metrics_to_json metrics.dynamic_context_segment);
       ("user_message", prompt_segment_metrics_to_json metrics.user_message_segment);
     ]
-
-let synthetic_prompt_segment_metrics ~estimated_tokens : prompt_segment_metrics =
-  { bytes = 0; estimated_tokens; fingerprint = None }
 
 let add_segment_metric
     (totals : (string, prompt_segment_metrics) Hashtbl.t)
@@ -119,12 +109,11 @@ let add_segment_metric
   Hashtbl.replace totals bucket
     {
       bytes = prev.bytes + metric.bytes;
-      estimated_tokens = prev.estimated_tokens + metric.estimated_tokens;
       fingerprint = None;
     }
 
 let metric_of_block
-    ~(role : Agent_sdk.Types.role)
+    ~role:(_ : Agent_sdk.Types.role)
     (block : Agent_sdk.Types.content_block) : prompt_segment_metrics =
   let bytes =
     match Canonical_tool.tool_result_of_block block with
@@ -156,12 +145,7 @@ let metric_of_block
                 "keeper_agent_prompt_metrics: OAS canonical tool-call projection unavailable"
           | _ -> 0))
   in
-  let msg : Agent_sdk.Types.message = Agent_sdk.Types.make_message ~role [ block ] in
-  {
-    bytes;
-    estimated_tokens = Keeper_context_core.msg_tokens msg;
-    fingerprint = None;
-  }
+  { bytes; fingerprint = None }
 
 let history_bucket_of_block
     ~(role : Agent_sdk.Types.role)
@@ -198,7 +182,7 @@ let build_ctx_composition_metrics
   let totals : (string, prompt_segment_metrics) Hashtbl.t = Hashtbl.create 16 in
   let add_text_segment bucket text =
     let metric = prompt_segment_metrics_of_text text in
-    if metric.estimated_tokens > 0 then add_segment_metric totals ~bucket metric
+    if metric.bytes > 0 then add_segment_metric totals ~bucket metric
   in
   add_text_segment "system_prompt" system_prompt;
   add_text_segment "dynamic_context" dynamic_context;
@@ -211,7 +195,7 @@ let build_ctx_composition_metrics
         (fun block ->
           let bucket = history_bucket_of_block ~role:message.role block in
           let metric = metric_of_block ~role:message.role block in
-          if metric.estimated_tokens > 0 then add_segment_metric totals ~bucket metric)
+          if metric.bytes > 0 then add_segment_metric totals ~bucket metric)
         message.content)
     history_messages;
   let segments =
@@ -219,9 +203,9 @@ let build_ctx_composition_metrics
     |> List.of_seq
     |> List.sort (fun (left, _) (right, _) -> String.compare left right)
   in
-  let estimated_known_tokens =
+  let attributed_bytes =
     List.fold_left
-      (fun acc (_, metric) -> acc + metric.estimated_tokens)
+      (fun acc (_, metric) -> acc + metric.bytes)
       0 segments
   in
   let actual_input_tokens =
@@ -229,23 +213,9 @@ let build_ctx_composition_metrics
     | Some n when n > 0 -> Some n
     | Some _ | None -> None
   in
-  let display_total_tokens =
-    match actual_input_tokens with
-    | Some actual -> max actual estimated_known_tokens
-    | None -> estimated_known_tokens
-  in
-  let segments =
-    if display_total_tokens > estimated_known_tokens then
-      segments
-      @ [ ( "unattributed",
-            synthetic_prompt_segment_metrics
-              ~estimated_tokens:(display_total_tokens - estimated_known_tokens) ) ]
-    else segments
-  in
   {
     actual_input_tokens;
-    display_total_tokens;
-    estimated_known_tokens;
+    attributed_bytes;
     segments;
   }
 
@@ -253,8 +223,7 @@ let ctx_composition_to_json (metrics : ctx_composition_metrics) : Yojson.Safe.t 
   `Assoc
     [
       ("actual_input_tokens", Json_util.int_opt_to_json metrics.actual_input_tokens);
-      ("display_total_tokens", `Int metrics.display_total_tokens);
-      ("estimated_known_tokens", `Int metrics.estimated_known_tokens);
+      ("attributed_bytes", `Int metrics.attributed_bytes);
       ( "segments",
         `Assoc
           (List.map

--- a/lib/keeper/keeper_agent_prompt_metrics.mli
+++ b/lib/keeper/keeper_agent_prompt_metrics.mli
@@ -2,7 +2,7 @@
 
 (** Structured prompt result from [build_turn_prompt] callback.
     [system_prompt] holds hard constraints; [dynamic_context]
-    holds soft context injected via OAS [extra_system_context]. *)
+    holds soft context injected through OAS [extra_system_context]. *)
 type turn_prompt =
   { system_prompt : string
   ; dynamic_context : string
@@ -12,17 +12,14 @@ type turn_prompt =
     Bytes are stored rather than character counts because prompts are UTF-8. *)
 type prompt_segment_metrics =
   { bytes : int
-  ; estimated_tokens : int
   ; fingerprint : string option
   }
 
-(** Effective prompt metrics for a keeper turn.
-    [estimated_cacheable_tokens] tracks the system prompt portion only
-    because OAS prompt caching is enabled via [cache_system_prompt:true]. *)
+(** Effective byte metrics for a keeper turn. *)
 type prompt_metrics =
   { fingerprint : string
-  ; estimated_total_tokens : int
-  ; estimated_cacheable_tokens : int
+  ; total_bytes : int
+  ; cacheable_bytes : int
   ; system_prompt_segment : prompt_segment_metrics
   ; dynamic_context_segment : prompt_segment_metrics
   ; user_message_segment : prompt_segment_metrics
@@ -31,14 +28,13 @@ type prompt_metrics =
 (** Per-bucket attribution of an Agent.run input window. *)
 type ctx_composition_metrics =
   { actual_input_tokens : int option
-  ; display_total_tokens : int
-  ; estimated_known_tokens : int
+  ; attributed_bytes : int
   ; segments : (string * prompt_segment_metrics) list
   }
 
 val empty_prompt_segment_metrics : prompt_segment_metrics
 
-(** Compute byte/token/fingerprint for a single text segment after
+(** Compute byte count and fingerprint for a single text segment after
     UTF-8 sanitisation. *)
 val prompt_segment_metrics_of_text : string -> prompt_segment_metrics
 
@@ -52,11 +48,6 @@ val prompt_segment_metrics_to_json :
   prompt_segment_metrics -> Yojson.Safe.t
 
 val prompt_metrics_to_json : prompt_metrics -> Yojson.Safe.t
-
-(** Build a synthetic segment with [bytes=0] and no fingerprint —
-    used for the [unattributed] tail bucket. *)
-val synthetic_prompt_segment_metrics :
-  estimated_tokens:int -> prompt_segment_metrics
 
 (** Mutate [totals] by adding [metric] into [bucket]. *)
 val add_segment_metric :
@@ -75,9 +66,9 @@ val metric_of_block :
 val history_bucket_of_block :
   role:Agent_sdk.Types.role -> Agent_sdk.Types.content_block -> string
 
-(** [actual_input_tokens] is the LLM-reported input token count and is
-    only known after a provider response. Pre-call sites (prompt build)
-    must pass [None]; post-response sites pass [Some n]. *)
+(** [actual_input_tokens] is provider-reported and only known after a response.
+    It is not attributed to byte segments. [attributed_bytes] sums only the
+    exact textual/JSON components represented by [segments]. *)
 val build_ctx_composition_metrics :
   system_prompt:string ->
   dynamic_context:string ->

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -538,7 +538,7 @@ let run_turn
        let stream_idle_timeout_s =
          Keeper_runtime_resolved.stream_idle_timeout_sec ()
        in
-       Keeper_agent_run_phase0_telemetry.record_if_enabled
+       Keeper_agent_run_phase0_telemetry.record
          ~meta
          ~turn_system_prompt
          ~tools

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -404,7 +404,7 @@ let run_turn
           ]))
     Keeper_runtime_manifest.Context_compacted;
   (* Steps 5-6: turn prompt, memory/temporal context, prompt metrics,
-     user message append, token estimation — Keeper_run_prompt. *)
+     and user message append — Keeper_run_prompt. *)
   let prompt_ctx =
     Keeper_run_prompt.build_turn_context
       ~ctx
@@ -428,7 +428,6 @@ let run_turn
         { checkpoint with messages = history_messages })
       resume_oas_checkpoint
   in
-  let estimated_input_tokens = prompt_ctx.Keeper_run_prompt.estimated_input_tokens in
   let ctx_work = prompt_ctx.Keeper_run_prompt.ctx_work in
   let history_messages_digest = digest_message_texts_as_joined history_messages in
   let context_digest =
@@ -450,7 +449,6 @@ let run_turn
             ("user_message_digest", `String (digest_text user_message));
             ("history_message_count", `Int (List.length history_messages));
             ("history_messages_digest", `String history_messages_digest);
-            ("estimated_input_tokens", `Int estimated_input_tokens);
             ("context_window", `Int max_context);
             ("context_digest", `String context_digest);
           ]))
@@ -471,8 +469,6 @@ let run_turn
       ~dynamic_context
       ~history_messages
       ~prompt_metrics
-      ~estimated_input_tokens
-      ~max_context
       ~shared_context
       ~context_injector
       ~start_turn_count
@@ -501,52 +497,6 @@ let run_turn
     Turn_helpers.run_with_setup_cleanup ~cleanup:cleanup_agent_setup
     @@ fun () ->
     let tools = s.Keeper_run_tools.tools in
-    let tool_context_estimate =
-      s.Keeper_run_tools.tool_context_estimate
-    in
-    let context_window_observation =
-      Keeper_run_prompt.observe_context_window
-        ~estimated_input_tokens:
-          tool_context_estimate.estimated_input_tokens_with_tools
-        ~max_context
-    in
-    (* This aggregate estimate is observation only. It neither suppresses
-       context nor fabricates a pre-dispatch failure. OAS transports the complete
-       request and reports typed ContextOverflow; MASC owns lane compaction. *)
-    let pre_dispatch_over_context_window =
-      context_window_observation.observed_over_context_tokens > 0
-    in
-    append_manifest ~site:"context_preflight"
-      ~keeper_turn_id:manifest_keeper_turn_id
-      ~status:
-        (if pre_dispatch_over_context_window
-         then "over_context_window_observed"
-         else "ok")
-      ~decision:
-        (Keeper_runtime_manifest.with_payload_role ~payload_role:Model_input
-          (`Assoc
-            [
-              ( "prompt_estimated_input_tokens",
-                `Int estimated_input_tokens );
-              ( "tool_count",
-                `Int tool_context_estimate.tool_count );
-              ( "tool_schema_estimated_tokens",
-                `Int tool_context_estimate.tool_schema_tokens );
-              ( "estimated_input_tokens_with_tools",
-                `Int tool_context_estimate.estimated_input_tokens_with_tools );
-              ("context_window", `Int max_context);
-              ( "remaining_context_tokens",
-                `Int
-                  context_window_observation.observed_remaining_context_tokens );
-              ( "over_context_tokens",
-                `Int context_window_observation.observed_over_context_tokens );
-              ( "context_usage_ratio",
-                `Float
-                  context_window_observation.observed_context_usage_ratio );
-              ( "pre_dispatch_over_context_window",
-                `Bool pre_dispatch_over_context_window );
-            ]))
-      Keeper_runtime_manifest.Context_injected;
     let hooks = s.Keeper_run_tools.hooks in
     let model_input_projection =
       s.Keeper_run_tools.model_input_projection

--- a/lib/keeper/keeper_agent_run_phase0_telemetry.ml
+++ b/lib/keeper/keeper_agent_run_phase0_telemetry.ml
@@ -1,6 +1,6 @@
 (** Phase-0 wake-time payload telemetry, extracted from [Keeper_agent_run]. *)
 
-let record_if_enabled
+let record
     ~(meta : Keeper_meta_contract.keeper_meta)
     ~turn_system_prompt
     ~tools
@@ -10,9 +10,7 @@ let record_if_enabled
     ~max_context
     ~pre_dispatch_compacted
   =
-  if Env_config_keeper.KeeperTelemetry.payload_telemetry_enabled ()
-  then (
-    try
+  try
       let sizes =
         Keeper_wake_telemetry.compute_sizes
           ~system_prompt:turn_system_prompt
@@ -48,5 +46,5 @@ let record_if_enabled
       Log.Harness.warn
         "[wake_payload] telemetry failed keeper=%s: %s"
         meta.name
-        (Printexc.to_string exn))
+        (Printexc.to_string exn)
 ;;

--- a/lib/keeper/keeper_agent_run_phase0_telemetry.mli
+++ b/lib/keeper/keeper_agent_run_phase0_telemetry.mli
@@ -1,6 +1,6 @@
 (** Phase-0 wake payload telemetry for [Keeper_agent_run.run_turn]. *)
 
-val record_if_enabled :
+val record :
   meta:Keeper_meta_contract.keeper_meta ->
   turn_system_prompt:string ->
   tools:Agent_sdk.Tool.t list ->
@@ -10,7 +10,7 @@ val record_if_enabled :
   max_context:int ->
   pre_dispatch_compacted:bool ->
   unit
-(** Record wake-time payload sizing when [MASC_PAYLOAD_TELEMETRY] is enabled.
+(** Record wake-time payload sizing before every keeper model dispatch.
 
     The telemetry path is best-effort: cancellation is re-raised, while other
     exceptions are logged and do not abort the LLM call. *)

--- a/lib/keeper/keeper_run_prompt.ml
+++ b/lib/keeper/keeper_run_prompt.ml
@@ -44,25 +44,21 @@ let normalize_memory_fragment = Inference_utils.sanitize_text_utf8
 let sanitize_user_message = Inference_utils.sanitize_text_utf8
 
 let estimate_input_tokens
-    ~(prompt_metrics : Keeper_agent_prompt_metrics.prompt_metrics)
     ~(system_prompt : string)
     ~(dynamic_context : string)
     ~(memory_context : string)
     ~(temporal_context : string)
     ~(user_message : string)
     ~(history_messages : Agent_sdk.Types.message list) : int =
-  let composition =
-    Keeper_agent_prompt_metrics.build_ctx_composition_metrics
-      ~system_prompt
-      ~dynamic_context
-      ~memory_context
-      ~temporal_context
-      ~user_message
-      ~history_messages
-      ~actual_input_tokens:None
-  in
-  max prompt_metrics.Keeper_agent_prompt_metrics.estimated_total_tokens
-      composition.Keeper_agent_prompt_metrics.display_total_tokens
+  List.fold_left
+    (fun total text ->
+      total + Keeper_context_core_accessors.estimate_char_tokens text)
+    0
+    [ system_prompt; dynamic_context; memory_context; temporal_context; user_message ]
+  + List.fold_left
+      (fun total message -> total + Keeper_context_core.msg_tokens message)
+      0
+      history_messages
 
 let estimate_tool_schema_context
     ~(estimated_input_tokens : int)
@@ -268,7 +264,6 @@ let build_turn_context
   in
   let estimated_input_tokens =
     estimate_input_tokens
-      ~prompt_metrics
       ~system_prompt:turn_system_prompt
       ~dynamic_context
       ~memory_context

--- a/lib/keeper/keeper_run_prompt.ml
+++ b/lib/keeper/keeper_run_prompt.ml
@@ -3,7 +3,7 @@
     Takes the run context from [Keeper_run_context], calls the
     [build_turn_prompt] callback to get the final system prompt and
     dynamic context, then renders memory/temporal context, builds prompt
-    metrics, appends the user message, and estimates input tokens.
+    metrics, and appends the user message.
 
     @since 0.120.0 *)
 
@@ -14,104 +14,21 @@ type turn_prompt_context =
   ; temporal_context : string
   ; prompt_metrics : Keeper_agent_prompt_metrics.prompt_metrics
   ; history_messages : Agent_sdk.Types.message list
-  ; estimated_input_tokens : int
   ; ctx_work : Keeper_context_runtime.working_context
-  }
-
-type tool_schema_context_estimate =
-  { tool_count : int
-  ; tool_schema_tokens : int
-  ; estimated_input_tokens_with_tools : int
-  }
-
-type context_window_observation =
-  { observed_estimated_input_tokens : int
-  ; observed_context_window : int
-  ; observed_remaining_context_tokens : int
-  ; observed_over_context_tokens : int
-  ; observed_context_usage_ratio : float
   }
 
 type extra_system_context_assembly =
   { extra_system_context : string option
   ; blocks : (Prompt_block_id.t * string) list
-  ; hook_extra_system_context_estimated_tokens : int
-  ; post_hook_estimated_input_tokens : int
-  ; post_hook_context_window_observation : context_window_observation
   }
 
 let normalize_memory_fragment = Inference_utils.sanitize_text_utf8
 let sanitize_user_message = Inference_utils.sanitize_text_utf8
 
-let estimate_input_tokens
-    ~(system_prompt : string)
-    ~(dynamic_context : string)
-    ~(memory_context : string)
-    ~(temporal_context : string)
-    ~(user_message : string)
-    ~(history_messages : Agent_sdk.Types.message list) : int =
-  List.fold_left
-    (fun total text ->
-      total + Keeper_context_core_accessors.estimate_char_tokens text)
-    0
-    [ system_prompt; dynamic_context; memory_context; temporal_context; user_message ]
-  + List.fold_left
-      (fun total message -> total + Keeper_context_core.msg_tokens message)
-      0
-      history_messages
-
-let estimate_tool_schema_context
-    ~(estimated_input_tokens : int)
-    ~(tools : Agent_sdk.Tool.t list) : tool_schema_context_estimate =
-  let tool_schema_tokens =
-    tools
-    |> List.map Agent_sdk.Tool.schema_to_json
-    |> List.fold_left
-         (fun acc json ->
-            acc
-            + Keeper_context_core_accessors.estimate_char_tokens
-                (Yojson.Safe.to_string json))
-         0
-  in
-  { tool_count = List.length tools
-  ; tool_schema_tokens
-  ; estimated_input_tokens_with_tools =
-      estimated_input_tokens + tool_schema_tokens
-  }
-
-let prompt_block_accounted_in_preflight ~preflight_accounted_blocks block =
-  List.exists (Prompt_block_id.equal block) preflight_accounted_blocks
-
-let estimate_unaccounted_extra_system_context_tokens
-      ~(preflight_accounted_blocks : Prompt_block_id.t list)
-      blocks =
-  List.fold_left
-    (fun acc (block, text) ->
-       if prompt_block_accounted_in_preflight ~preflight_accounted_blocks block
-       then acc
-       else acc + Keeper_context_core_accessors.estimate_char_tokens text)
-    0
-    blocks
-
 let append_extra_system_context ctx text =
   match ctx with
   | None -> Some text
   | Some existing -> Some (existing ^ "\n\n" ^ text)
-
-let estimate_extra_system_context_tokens = function
-  | None -> 0
-  | Some text -> Keeper_context_core_accessors.estimate_char_tokens text
-
-let estimate_preflight_accounted_extra_system_context_tokens
-      ~(preflight_accounted_blocks : Prompt_block_id.t list)
-      blocks =
-  List.fold_left
-    (fun acc (block, text) ->
-       if prompt_block_accounted_in_preflight ~preflight_accounted_blocks block
-       then acc + Keeper_context_core_accessors.estimate_char_tokens text
-       else acc)
-    0
-    blocks
 
 let assembled_extra_system_context
       ~(existing_extra_system_context : string option)
@@ -121,72 +38,15 @@ let assembled_extra_system_context
     existing_extra_system_context
     included_blocks
 
-let estimate_unaccounted_assembled_extra_context_tokens
-      ~(existing_extra_system_context : string option)
-      ~(preflight_accounted_blocks : Prompt_block_id.t list)
-      ~(included_blocks : (Prompt_block_id.t * string) list) =
-  let assembled_tokens =
-    assembled_extra_system_context ~existing_extra_system_context ~included_blocks
-    |> estimate_extra_system_context_tokens
-  in
-  let preflight_accounted_tokens =
-    estimate_preflight_accounted_extra_system_context_tokens
-      ~preflight_accounted_blocks
-      included_blocks
-  in
-  max 0 (assembled_tokens - preflight_accounted_tokens)
-
-let observe_context_window ~(estimated_input_tokens : int) ~(max_context : int)
-  : context_window_observation =
-  let observed_remaining_context_tokens =
-    max 0 (max_context - estimated_input_tokens)
-  in
-  let observed_over_context_tokens =
-    max 0 (estimated_input_tokens - max_context)
-  in
-  let observed_context_usage_ratio =
-    if max_context > 0
-    then Float.of_int estimated_input_tokens /. Float.of_int max_context
-    else 0.0
-  in
-  { observed_estimated_input_tokens = estimated_input_tokens
-  ; observed_context_window = max_context
-  ; observed_remaining_context_tokens
-  ; observed_over_context_tokens
-  ; observed_context_usage_ratio
-  }
-
 let assemble_extra_system_context
-      ~(estimated_input_tokens_with_tools : int)
-      ~(max_context : int)
       ~(existing_extra_system_context : string option)
-      ~(preflight_accounted_blocks : Prompt_block_id.t list)
       ~(blocks : (Prompt_block_id.t * string) list)
   : extra_system_context_assembly =
-  let post_hook_estimate blocks =
-    estimated_input_tokens_with_tools
-    + estimate_unaccounted_assembled_extra_context_tokens
-        ~existing_extra_system_context
-        ~preflight_accounted_blocks
-        ~included_blocks:blocks
-  in
-  let hook_extra_system_context_estimated_tokens =
-    estimate_unaccounted_extra_system_context_tokens
-      ~preflight_accounted_blocks
-      blocks
-  in
-  let post_hook_estimated_input_tokens = post_hook_estimate blocks in
   { extra_system_context =
       assembled_extra_system_context
         ~existing_extra_system_context
         ~included_blocks:blocks
   ; blocks
-  ; hook_extra_system_context_estimated_tokens
-  ; post_hook_estimated_input_tokens
-  ; post_hook_context_window_observation =
-      observe_context_window
-        ~estimated_input_tokens:post_hook_estimated_input_tokens
-        ~max_context
   }
 
 let build_turn_context
@@ -262,15 +122,6 @@ let build_turn_context
       checkpoint = { ctx_work.checkpoint with messages = history_messages }
     }
   in
-  let estimated_input_tokens =
-    estimate_input_tokens
-      ~system_prompt:turn_system_prompt
-      ~dynamic_context
-      ~memory_context
-      ~temporal_context
-      ~user_message
-      ~history_messages
-  in
   let ctx_work = Keeper_context_runtime.append ctx_work user_msg in
   if not is_retry
   then
@@ -282,6 +133,5 @@ let build_turn_context
   ; temporal_context
   ; prompt_metrics
   ; history_messages
-  ; estimated_input_tokens
   ; ctx_work
   }

--- a/lib/keeper/keeper_run_prompt.mli
+++ b/lib/keeper/keeper_run_prompt.mli
@@ -3,7 +3,7 @@
     Takes the run context from [Keeper_run_context], calls the
     [build_turn_prompt] callback to get the final system prompt and
     dynamic context, then renders memory/temporal context, builds prompt
-    metrics, appends the user message, and estimates input tokens.
+    metrics, and appends the user message.
 
     @since 0.120.0 *)
 
@@ -14,30 +14,12 @@ type turn_prompt_context =
   ; temporal_context : string
   ; prompt_metrics : Keeper_agent_prompt_metrics.prompt_metrics
   ; history_messages : Agent_sdk.Types.message list
-  ; estimated_input_tokens : int
   ; ctx_work : Keeper_context_runtime.working_context
-  }
-
-type tool_schema_context_estimate =
-  { tool_count : int
-  ; tool_schema_tokens : int
-  ; estimated_input_tokens_with_tools : int
-  }
-
-type context_window_observation =
-  { observed_estimated_input_tokens : int
-  ; observed_context_window : int
-  ; observed_remaining_context_tokens : int
-  ; observed_over_context_tokens : int
-  ; observed_context_usage_ratio : float
   }
 
 type extra_system_context_assembly =
   { extra_system_context : string option
   ; blocks : (Prompt_block_id.t * string) list
-  ; hook_extra_system_context_estimated_tokens : int
-  ; post_hook_estimated_input_tokens : int
-  ; post_hook_context_window_observation : context_window_observation
   }
 
 val sanitize_user_message : string -> string
@@ -49,48 +31,13 @@ val normalize_memory_fragment : string -> string
     Trust and relevance are interpreted by the configured model, not by a
     local string deny-list. *)
 
-val estimate_input_tokens :
-  system_prompt:string ->
-  dynamic_context:string ->
-  memory_context:string ->
-  temporal_context:string ->
-  user_message:string ->
-  history_messages:Agent_sdk.Types.message list ->
-  int
-(** Shared pre-call input-token observation for manifests and request metrics.
-    It does not authorize omission, truncation, or dispatch failure. *)
-
-val estimate_tool_schema_context :
-  estimated_input_tokens:int ->
-  tools:Agent_sdk.Tool.t list ->
-  tool_schema_context_estimate
-(** Add the serialized tool-schema payload that OAS sends to providers to the
-    prompt/history estimate. This matches OAS' default full-schema disclosure. *)
-
-val estimate_unaccounted_extra_system_context_tokens :
-  preflight_accounted_blocks:Prompt_block_id.t list ->
-  (Prompt_block_id.t * string) list -> int
-(** Estimate the hook-injected [extra_system_context] blocks that were not
-    already included in the pre-dispatch prompt estimate. The caller supplies
-    [preflight_accounted_blocks] from the actual turn prompt assembly ledger;
-    this function does not maintain an internal prompt-block allowlist. *)
-
 val assemble_extra_system_context :
-  estimated_input_tokens_with_tools:int ->
-  max_context:int ->
   existing_extra_system_context:string option ->
-  preflight_accounted_blocks:Prompt_block_id.t list ->
   blocks:(Prompt_block_id.t * string) list ->
   extra_system_context_assembly
-(** Assemble every complete typed prompt block in source order. Token estimates
-    and the provider-declared context window are recorded only as observations;
-    MASC never omits a block based on an estimate. The complete request reaches
-    OAS, whose typed [ContextOverflow] and compaction path own overflow handling. *)
-
-val observe_context_window :
-  estimated_input_tokens:int -> max_context:int -> context_window_observation
-(** Observe the aggregate estimate against the provider-declared window. This
-    value has no authority over prompt assembly or dispatch. *)
+(** Assemble every complete typed prompt block in source order. No local size
+    estimate has authority over assembly or dispatch; typed provider overflow
+    is handled at the MASC lane boundary. *)
 
 val build_turn_context
   :  ctx:Keeper_run_context.run_context

--- a/lib/keeper/keeper_run_prompt.mli
+++ b/lib/keeper/keeper_run_prompt.mli
@@ -50,7 +50,6 @@ val normalize_memory_fragment : string -> string
     local string deny-list. *)
 
 val estimate_input_tokens :
-  prompt_metrics:Keeper_agent_prompt_metrics.prompt_metrics ->
   system_prompt:string ->
   dynamic_context:string ->
   memory_context:string ->

--- a/lib/keeper/keeper_run_tools.ml
+++ b/lib/keeper/keeper_run_tools.ml
@@ -62,7 +62,6 @@ type agent_setup = Keeper_run_tools_hooks.agent_setup =
       Agent_sdk.Types.message list -> Agent_sdk.Types.message list
   ; acc : hook_accumulator
   ; all_tool_names : string list
-  ; tool_context_estimate : Keeper_run_prompt.tool_schema_context_estimate
   ; receipt_turn_count_ref : int option ref
   ; receipt_model_used_ref : string option ref
   ; receipt_stop_reason_ref : Runtime_agent.stop_reason option ref

--- a/lib/keeper/keeper_run_tools.mli
+++ b/lib/keeper/keeper_run_tools.mli
@@ -58,7 +58,6 @@ type agent_setup =
       Agent_sdk.Types.message list -> Agent_sdk.Types.message list
   ; acc : hook_accumulator
   ; all_tool_names : string list
-  ; tool_context_estimate : Keeper_run_prompt.tool_schema_context_estimate
   ; receipt_turn_count_ref : int option ref
   ; receipt_model_used_ref : string option ref
   ; receipt_stop_reason_ref : Runtime_agent.stop_reason option ref
@@ -78,8 +77,6 @@ val prepare_agent_setup
   -> dynamic_context:string
   -> history_messages:Agent_sdk.Types.message list
   -> prompt_metrics:Keeper_agent_prompt_metrics.prompt_metrics
-  -> estimated_input_tokens:int
-  -> max_context:int
   -> shared_context:Agent_sdk.Context.t
   -> context_injector:Agent_sdk.Hooks.context_injector
   -> start_turn_count:int

--- a/lib/keeper/keeper_run_tools_hooks.ml
+++ b/lib/keeper/keeper_run_tools_hooks.ml
@@ -18,7 +18,6 @@ type agent_setup =
       Agent_sdk.Types.message list -> Agent_sdk.Types.message list
   ; acc : hook_accumulator
   ; all_tool_names : string list
-  ; tool_context_estimate : Keeper_run_prompt.tool_schema_context_estimate
   ; receipt_turn_count_ref : int option ref
   ; receipt_model_used_ref : string option ref
   ; receipt_stop_reason_ref : Runtime_agent.stop_reason option ref
@@ -38,9 +37,7 @@ type ctx =
   ; config : Workspace.config
   ; keeper_tools_cleanup : unit -> unit
   ; manifest_keeper_turn_id : int option
-  ; max_context : int
   ; meta : Keeper_meta_contract.keeper_meta
-  ; tool_context_estimate : Keeper_run_prompt.tool_schema_context_estimate
   ; turn_ctx_cell : Keeper_tool_call_log.turn_ctx_cell
     (* RFC-0225 §3.3: per-run carrier; written by the pre-request hook
        below, read by the post-tool hooks in Keeper_hooks_oas. *)
@@ -148,9 +145,7 @@ let assemble_hooks
   let config = ctx.config in
   let keeper_tools_cleanup = ctx.keeper_tools_cleanup in
   let manifest_keeper_turn_id = ctx.manifest_keeper_turn_id in
-  let max_context = ctx.max_context in
   let meta = ctx.meta in
-  let tool_context_estimate = ctx.tool_context_estimate in
   let turn_ctx_cell = ctx.turn_ctx_cell in
   let receipt_turn_count_ref = ctx.receipt_turn_count_ref in
   let receipt_model_used_ref = ctx.receipt_model_used_ref in
@@ -339,22 +334,13 @@ let assemble_hooks
                 let record_block block text =
                   recorded_blocks := (block, text) :: !recorded_blocks
                 in
-                let preflight_accounted_blocks = ref [] in
-                let record_preflight_accounted_block block text =
-                  record_block block text;
-                  preflight_accounted_blocks := block :: !preflight_accounted_blocks
-                in
                 (if String.trim dynamic_context <> ""
                  then
-                   record_preflight_accounted_block
-                     Prompt_block_id.Dynamic_context
-                     dynamic_context);
+                   record_block Prompt_block_id.Dynamic_context dynamic_context);
                 (match Masc_context_injector.render_temporal_summary shared_context with
                  | None -> ()
                  | Some temporal ->
-                   record_preflight_accounted_block
-                     Prompt_block_id.Temporal_summary
-                     temporal);
+                   record_block Prompt_block_id.Temporal_summary temporal);
                 let schema_filter, computed_turn_lane =
                   compute_tool_surface
                     ~turn
@@ -383,13 +369,8 @@ let assemble_hooks
                  | Some block -> record_block Prompt_block_id.Memory_os_recall block);
                 let extra_system_context_assembly =
                   Keeper_run_prompt.assemble_extra_system_context
-                    ~estimated_input_tokens_with_tools:
-                      tool_context_estimate.estimated_input_tokens_with_tools
-                    ~max_context
                     ~existing_extra_system_context:
                       current_params.extra_system_context
-                    ~preflight_accounted_blocks:
-                      (List.rev !preflight_accounted_blocks)
                     ~blocks:(List.rev !recorded_blocks)
                 in
                 let ctx = extra_system_context_assembly.extra_system_context in
@@ -506,28 +487,6 @@ let assemble_hooks
                        recorded_blocks_for_receipt;
                 acc.extra_system_context_digest <- Option.map sha256_hex ctx;
                 acc.extra_system_context_size <- Option.map String.length ctx;
-                let extra_system_context_estimated_tokens =
-                  Option.map Keeper_context_core_accessors.estimate_char_tokens ctx
-                in
-                let hook_extra_system_context_estimated_tokens =
-                  extra_system_context_assembly
-                    .hook_extra_system_context_estimated_tokens
-                in
-                let post_hook_estimated_input_tokens =
-                  extra_system_context_assembly.post_hook_estimated_input_tokens
-                in
-                let post_hook_context_window_observation =
-                  extra_system_context_assembly
-                    .post_hook_context_window_observation
-                in
-                (* The complete block sequence is already assembled into [ctx].
-                   This estimate is manifest-only: OAS receives [ctx] unchanged
-                   and owns typed ContextOverflow/compaction. *)
-                let post_hook_over_context_window =
-                  post_hook_context_window_observation
-                    .observed_over_context_tokens
-                  > 0
-                in
                 (match runtime_manifest_context, runtime_manifest_append with
                  | Some manifest_context, Some append_manifest ->
                    let post_tool_context =
@@ -540,9 +499,7 @@ let assemble_hooks
                         ~oas_turn_count:turn
                         ~runtime_id:runtime_id_string
                         ~status:
-                          (if post_hook_over_context_window
-                           then "post_hook_context_overflow"
-                           else if post_tool_context
+                          (if post_tool_context
                            then "post_tool_context_injection"
                            else "pre_tool_context_injection")
                         ~decision:
@@ -562,32 +519,6 @@ let assemble_hooks
                                ; ( "extra_system_context_computed_size",
                                    Json_util.int_opt_to_json
                                      acc.extra_system_context_size )
-                               ; ( "extra_system_context_estimated_tokens",
-                                   Json_util.int_opt_to_json
-                                     extra_system_context_estimated_tokens )
-                               ; ( "hook_extra_system_context_estimated_tokens",
-                                   `Int hook_extra_system_context_estimated_tokens )
-                               ; ( "estimated_input_tokens_with_tools",
-                                   `Int
-                                     tool_context_estimate.estimated_input_tokens_with_tools )
-                               ; ( "post_hook_estimated_input_tokens",
-                                   `Int post_hook_estimated_input_tokens )
-                               ; ( "context_window",
-                                   `Int max_context )
-                               ; ( "post_hook_remaining_context_tokens",
-                                   `Int
-                                     post_hook_context_window_observation
-                                       .observed_remaining_context_tokens )
-                               ; ( "post_hook_over_context_tokens",
-                                   `Int
-                                     post_hook_context_window_observation
-                                       .observed_over_context_tokens )
-                               ; ( "post_hook_context_usage_ratio",
-                                   `Float
-                                     post_hook_context_window_observation
-                                       .observed_context_usage_ratio )
-                               ; ( "post_hook_over_context_window",
-                                   `Bool post_hook_over_context_window )
                                ]))
                         ())
                  | _ -> ());
@@ -613,7 +544,6 @@ let assemble_hooks
                   { current_params with
                     extra_system_context = ctx
                   ; tool_choice
-                  ; tool_filter_override = None
                   }
               | _event -> Agent_sdk.Hooks.Continue)
       }
@@ -632,7 +562,6 @@ let assemble_hooks
       ; model_input_projection
       ; acc
       ; all_tool_names
-      ; tool_context_estimate
       ; receipt_turn_count_ref
       ; receipt_model_used_ref
       ; receipt_stop_reason_ref

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -20,8 +20,6 @@ let prepare_agent_setup
       ~(dynamic_context : string)
       ~(history_messages : Agent_sdk.Types.message list)
       ~(prompt_metrics : Keeper_agent_prompt_metrics.prompt_metrics)
-      ~(estimated_input_tokens : int)
-      ~(max_context : int)
       ~(shared_context : Agent_sdk.Context.t)
       ~(context_injector : Agent_sdk.Hooks.context_injector)
       ~(start_turn_count : int)
@@ -131,9 +129,6 @@ let prepare_agent_setup
     - List.length model_visible_descriptors
     - transport_alias_count
     - invalid_schema_count
-  in
-  let tool_context_estimate =
-    Keeper_run_prompt.estimate_tool_schema_context ~estimated_input_tokens ~tools
   in
   let all_tool_names =
     List.map (fun (tool : Agent_sdk.Tool.t) -> tool.schema.name) keeper_tools
@@ -252,9 +247,7 @@ let prepare_agent_setup
     ; config
     ; keeper_tools_cleanup
     ; manifest_keeper_turn_id
-    ; max_context
     ; meta
-    ; tool_context_estimate
     ; turn_ctx_cell
     ; receipt_turn_count_ref
     ; receipt_model_used_ref

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -415,15 +415,6 @@ let run_keeper_cycle
            No dynamic_context needed here. *)
                  { system_prompt; dynamic_context = "" }
                in
-               let prompt_timeout_metrics =
-                 Keeper_agent_run.build_prompt_metrics
-                   ~system_prompt
-                   ~dynamic_context:""
-                   ~user_message
-               in
-               let prompt_timeout_estimate_tokens =
-                 max 1 prompt_timeout_metrics.estimated_total_tokens
-               in
                (* 5. Run via OAS Agent.run() with transient-error retry.
                   The turn-local OAS Event_bus preserves factual
                   ToolCalled/ToolCompleted pairing and drives
@@ -730,18 +721,11 @@ let run_keeper_cycle
                     then Log.Keeper.warn
                     else Log.Keeper.error
                   in
-                  let failure_context_ratio =
-                    if final_execution.max_context <= 0
-                    then 0.0
-                    else
-                      float_of_int prompt_timeout_estimate_tokens
-                      /. float_of_int final_execution.max_context
-                  in
                   log_keeper_cycle_failed
                     ~keeper_name:meta.name
                     "%s: keeper cycle FAILED runtime=%s max_context=%d context_budget=%d \
-                     primary_budget=%d requested_override=%s estimated_input_tokens=%d \
-                     context_ratio=%.4f latency=%dms%s error=%s"
+                     primary_budget=%d requested_override=%s system_and_user_bytes=%d \
+                     latency=%dms%s error=%s"
                     meta.name
                     final_execution.runtime_id
                     final_execution.max_context
@@ -752,8 +736,7 @@ let run_keeper_cycle
                      with
                      | Some requested -> string_of_int requested
                      | None -> "none")
-                    prompt_timeout_estimate_tokens
-                    failure_context_ratio
+                    (String.length system_prompt + String.length user_message)
                     latency_ms
                     (if is_server_parse_rejection
                      then " (server parse rejection, auto-recoverable)"

--- a/lib/keeper/keeper_wake_telemetry.ml
+++ b/lib/keeper/keeper_wake_telemetry.ml
@@ -5,9 +5,8 @@
     without standing up a live keeper. The functions here operate purely
     on [Agent_sdk] values and return plain records/ints; they never
     touch stores, logs, or side effects. Callers (currently
-    [Keeper_agent_run]) feed the result to
-    [Dashboard_harness_health.record_wake_payload] when
-    [MASC_PAYLOAD_TELEMETRY] is on.
+    [Keeper_agent_run]) feed every result to
+    [Dashboard_harness_health.record_wake_payload].
 
     Invariant: [result.message_count =
       List.fold_left (fun a (_, n) -> a + n) 0 result.role_counts].

--- a/test/test_keeper_prompt_metrics.ml
+++ b/test/test_keeper_prompt_metrics.ml
@@ -1,10 +1,10 @@
 (** P1-1c Harness: Keeper prompt structural metrics.
 
-    Measures system_prompt and dynamic_context token estimates after
+    Measures exact system_prompt and dynamic_context UTF-8 bytes after
     P1-1a hard/soft separation.  Validates that:
     1. system_prompt contains only hard constraints (shorter than combined)
     2. dynamic_context receives soft context elements
-    3. token budget is distributed correctly *)
+    3. byte attribution is exact *)
 
 open Alcotest
 
@@ -12,10 +12,7 @@ module KAR = Masc.Keeper_agent_run
 module KP = Masc.Keeper_prompt
 module KRP = Masc.Keeper_run_prompt
 
-(* CJK-aware token estimator from OAS *)
-let estimate_tokens s =
-  if s = "" then 0
-  else Agent_sdk.Context_reducer.estimate_char_tokens s
+let measure_bytes = String.length
 
 let has_in s needle =
   try ignore (Str.search_forward (Str.regexp_string needle) s 0); true
@@ -104,43 +101,47 @@ let build_combined () : string =
 let test_system_prompt_shorter_than_combined () =
   let tp = build_separated () in
   let combined = build_combined () in
-  let sys_tokens = estimate_tokens tp.system_prompt in
-  let combined_tokens = estimate_tokens combined in
-  let ratio =
-    Float.of_int sys_tokens /. Float.of_int combined_tokens
-  in
+  let system_bytes = measure_bytes tp.system_prompt in
+  let combined_bytes = measure_bytes combined in
   check bool
     (Printf.sprintf
-       "system_prompt (%d tok) < combined (%d tok), ratio=%.2f"
-       sys_tokens combined_tokens ratio)
-    true (sys_tokens < combined_tokens);
-  (* The separated system_prompt should be meaningfully shorter *)
-  check bool
-    (Printf.sprintf "ratio %.2f < 0.85 (meaningful reduction)" ratio)
-    true (ratio < 0.85)
+       "system_prompt (%d bytes) < combined (%d bytes)"
+       system_bytes combined_bytes)
+    true (system_bytes < combined_bytes)
 
 let test_dynamic_context_nonempty () =
   let tp = build_separated () in
-  let dyn_tokens = estimate_tokens tp.dynamic_context in
+  let dynamic_bytes = measure_bytes tp.dynamic_context in
   check bool
-    (Printf.sprintf "dynamic_context has %d tokens (> 0)" dyn_tokens)
-    true (dyn_tokens > 0)
+    (Printf.sprintf "dynamic_context has %d bytes (> 0)" dynamic_bytes)
+    true (dynamic_bytes > 0)
 
-let test_total_tokens_preserved () =
+let test_total_bytes_preserved () =
   let tp = build_separated () in
   let combined = build_combined () in
   let separated_total =
-    estimate_tokens tp.system_prompt + estimate_tokens tp.dynamic_context
+    measure_bytes tp.system_prompt + measure_bytes tp.dynamic_context
   in
-  let combined_total = estimate_tokens combined in
-  (* Token counts should be approximately equal.
-     Small differences are expected from separator formatting. *)
-  let diff = abs (separated_total - combined_total) in
-  check bool
-    (Printf.sprintf
-       "total tokens similar: separated=%d combined=%d diff=%d"
-       separated_total combined_total diff)
-    true (diff < 50)
+  let combined_total = measure_bytes combined in
+  check int "combined adds one two-byte separator"
+    (separated_total + String.length "\n\n")
+    combined_total
+
+let test_prompt_metrics_use_exact_utf8_bytes () =
+  let metrics =
+    KAR.build_prompt_metrics
+      ~system_prompt:"도구"
+      ~dynamic_context:"x"
+      ~user_message:""
+  in
+  check int "total UTF-8 bytes" 7 metrics.total_bytes;
+  check int "cacheable UTF-8 bytes" 6 metrics.cacheable_bytes;
+  let json = KAR.prompt_metrics_to_json metrics in
+  match json with
+  | `Assoc fields ->
+      check bool "retired token estimate is absent" false
+        (List.mem_assoc "estimated_total_tokens" fields)
+  | _ -> fail "prompt metrics must serialize as an object"
 
 let test_hard_constraints_in_system_only () =
   let tp = build_separated () in
@@ -297,30 +298,7 @@ let test_user_message_sanitizer_preserves_semantic_content () =
   check bool "preserves useful user request" true
     (has_in sanitized "Please inspect the current board status.")
 
-let test_token_report () =
-  (* Emit a structured report for A/B comparison *)
-  let tp = build_separated () in
-  let combined = build_combined () in
-  let sys_tok = estimate_tokens tp.system_prompt in
-  let dyn_tok = estimate_tokens tp.dynamic_context in
-  let combined_tok = estimate_tokens combined in
-  let cache_eligible_ratio =
-    Float.of_int sys_tok /. Float.of_int (sys_tok + dyn_tok)
-  in
-  Printf.printf "\n=== P1-1c Prompt Metrics Report ===\n";
-  Printf.printf "Pre-split (combined system_prompt):  %d tokens\n" combined_tok;
-  Printf.printf "Post-split system_prompt (hard):     %d tokens\n" sys_tok;
-  Printf.printf "Post-split dynamic_context (soft):   %d tokens\n" dyn_tok;
-  Printf.printf "Post-split total:                    %d tokens\n" (sys_tok + dyn_tok);
-  Printf.printf "System prompt reduction:             %.1f%%\n"
-    ((1.0 -. Float.of_int sys_tok /. Float.of_int combined_tok) *. 100.0);
-  Printf.printf "Cache-eligible ratio (system/total): %.1f%%\n"
-    (cache_eligible_ratio *. 100.0);
-  Printf.printf "===================================\n";
-  (* This test always passes — it's a measurement, not an assertion *)
-  check pass "report emitted" () ()
-
-let test_ctx_composition_splits_history_and_residual () =
+let test_ctx_composition_splits_history_bytes () =
   let history_messages =
     [
       {
@@ -375,40 +353,44 @@ let test_ctx_composition_splits_history_and_residual () =
       ~history_messages
       ~actual_input_tokens:(Some 1000)
   in
-  let segment_tokens key =
+  let segment_bytes key =
     metrics.segments
     |> List.assoc_opt key
-    |> Option.map (fun segment -> segment.KAR.estimated_tokens)
+    |> Option.map (fun segment -> segment.KAR.bytes)
     |> Option.value ~default:0
   in
   check bool "system prompt bucket present" true
-    (segment_tokens "system_prompt" > 0);
+    (segment_bytes "system_prompt" > 0);
   check bool "history user bucket present" true
-    (segment_tokens "history_user" > 0);
+    (segment_bytes "history_user" > 0);
   check bool "history assistant text bucket present" true
-    (segment_tokens "history_assistant_text" > 0);
+    (segment_bytes "history_assistant_text" > 0);
   check bool "history tool use bucket present" true
-    (segment_tokens "history_tool_use" > 0);
+    (segment_bytes "history_tool_use" > 0);
   check bool "history tool result bucket present" true
-    (segment_tokens "history_tool_result" > 0);
-  check bool "unattributed residual added" true
-    (segment_tokens "unattributed" > 0);
-  check int "display total anchored to actual input" 1000
-    metrics.display_total_tokens
+    (segment_bytes "history_tool_result" > 0);
+  check (option int) "provider token observation remains separate" (Some 1000)
+    metrics.actual_input_tokens;
+  check int "total bytes equal segment sum"
+    (List.fold_left (fun total (_, segment) -> total + segment.KAR.bytes) 0
+       metrics.segments)
+    metrics.attributed_bytes
 
 (* ── Suite ────────────────────────────────────────────── *)
 
 let () =
   run "keeper_prompt_metrics"
     [
-      ( "token_budget",
+      ( "byte_measurement",
         [
           test_case "system_prompt shorter than combined" `Quick
             test_system_prompt_shorter_than_combined;
           test_case "dynamic_context nonempty" `Quick
             test_dynamic_context_nonempty;
-          test_case "total tokens preserved" `Quick
-            test_total_tokens_preserved;
+          test_case "total bytes preserved" `Quick
+            test_total_bytes_preserved;
+          test_case "exact UTF-8 byte metrics" `Quick
+            test_prompt_metrics_use_exact_utf8_bytes;
         ] );
       ( "separation_harness",
         [
@@ -436,14 +418,9 @@ let () =
           test_case "user message sanitizer preserves semantic content" `Quick
             test_user_message_sanitizer_preserves_semantic_content;
         ] );
-      ( "metrics_report",
-        [
-          test_case "token report (A/B baseline)" `Quick
-            test_token_report;
-        ] );
       ( "ctx_composition",
         [
-          test_case "splits history buckets and residual" `Quick
-            test_ctx_composition_splits_history_and_residual;
+          test_case "splits history byte buckets" `Quick
+            test_ctx_composition_splits_history_bytes;
         ] );
     ]

--- a/test/test_keeper_runtime_observation_boundaries.ml
+++ b/test/test_keeper_runtime_observation_boundaries.ml
@@ -115,195 +115,6 @@ let test_runtime_provider_path_has_no_cumulative_run_timeout () =
     false
     (contains_substring source "Eio.Time.with_timeout_exn clock t run_fn")
 
-let make_tool name description : Agent_sdk.Tool.t =
-  Agent_sdk.Tool.create ~name ~description ~parameters:[]
-    (fun _input -> Ok { Agent_sdk.Types.content = "ok"; _meta = None })
-
-let test_tool_schema_estimate_adds_provider_payload () =
-  let tool = make_tool "large_schema_probe" (String.make 2048 'd') in
-  let estimate =
-    Keeper_run_prompt.estimate_tool_schema_context
-      ~estimated_input_tokens:10
-      ~tools:[ tool ]
-  in
-  Alcotest.(check int) "tool count" 1 estimate.tool_count;
-  Alcotest.(check bool)
-    "tool schema contributes tokens"
-    true
-    (estimate.tool_schema_tokens > 0);
-  Alcotest.(check int)
-    "tool-inclusive estimate is prompt estimate plus schema"
-    (10 + estimate.tool_schema_tokens)
-    estimate.estimated_input_tokens_with_tools
-
-let test_hook_context_estimate_skips_base_prompt_layers () =
-  let dynamic = String.make 400 'd' in
-  let temporal = String.make 400 't' in
-  let retry = String.make 400 'r' in
-  let connected_surface = String.make 400 'u' in
-  let expected =
-    Agent_sdk.Context_reducer.estimate_char_tokens retry
-    + Agent_sdk.Context_reducer.estimate_char_tokens connected_surface
-  in
-  Alcotest.(check int)
-    "only hook-only blocks are added to the post-hook estimate"
-    expected
-    (Keeper_run_prompt.estimate_unaccounted_extra_system_context_tokens
-       ~preflight_accounted_blocks:
-         [ Prompt_block_id.Dynamic_context; Prompt_block_id.Temporal_summary ]
-       [ Prompt_block_id.Dynamic_context, dynamic
-       ; Prompt_block_id.Temporal_summary, temporal
-       ; Prompt_block_id.Retry_nudge, retry
-       ; Prompt_block_id.Connected_surface, connected_surface
-       ])
-
-let test_extra_system_context_assembly_preserves_over_window_blocks () =
-  let assembly =
-    Keeper_run_prompt.assemble_extra_system_context
-      ~estimated_input_tokens_with_tools:90
-      ~max_context:100
-      ~existing_extra_system_context:None
-      ~preflight_accounted_blocks:[ Prompt_block_id.Dynamic_context ]
-      ~blocks:
-        [ Prompt_block_id.Dynamic_context, String.make 400 'd'
-        ; Prompt_block_id.Retry_nudge, String.make 400 'r'
-        ; Prompt_block_id.Connected_surface, "short connected surface"
-        ]
-  in
-  Alcotest.(check bool)
-    "dynamic context remains because preflight already accounted it"
-    true
-    (List.exists
-       (fun (block, _) ->
-          Prompt_block_id.equal block Prompt_block_id.Dynamic_context)
-       assembly.blocks);
-  Alcotest.(check bool)
-    "oversized hook-only retry nudge is preserved"
-    true
-    (List.exists
-       (fun (block, _) -> Prompt_block_id.equal block Prompt_block_id.Retry_nudge)
-       assembly.blocks);
-  Alcotest.(check bool)
-    "later hook-only block can still fit"
-    true
-    (List.exists
-       (fun (block, _) -> Prompt_block_id.equal block Prompt_block_id.Connected_surface)
-       assembly.blocks);
-  Alcotest.(check int) "every complete block reaches OAS" 3
-    (List.length assembly.blocks);
-  let assembled =
-    match assembly.extra_system_context with
-    | Some text -> text
-    | None -> Alcotest.fail "expected complete extra_system_context"
-  in
-  Alcotest.(check string)
-    "complete block text and source order reach OAS"
-    (String.make 400 'd'
-     ^ "\n\n"
-     ^ String.make 400 'r'
-     ^ "\n\nshort connected surface")
-    assembled;
-  Alcotest.(check bool)
-    "over-window estimate remains observational"
-    true
-    (assembly.post_hook_context_window_observation
-       .observed_over_context_tokens
-     > 0)
-
-let test_extra_system_context_assembly_accounts_assembled_overhead () =
-  let dynamic = String.make 40 'd' in
-  let hook_only = String.make 40 'u' in
-  let assembly =
-    Keeper_run_prompt.assemble_extra_system_context
-      ~estimated_input_tokens_with_tools:10
-      ~max_context:1_000
-      ~existing_extra_system_context:None
-      ~preflight_accounted_blocks:[ Prompt_block_id.Dynamic_context ]
-      ~blocks:
-        [ Prompt_block_id.Dynamic_context, dynamic
-        ; Prompt_block_id.Connected_surface, hook_only
-        ]
-  in
-  let assembled =
-    match assembly.extra_system_context with
-    | Some text -> text
-    | None -> Alcotest.fail "expected assembled extra_system_context"
-  in
-  let assembled_tokens =
-    Agent_sdk.Context_reducer.estimate_char_tokens assembled
-  in
-  let preflight_accounted_tokens =
-    Agent_sdk.Context_reducer.estimate_char_tokens dynamic
-  in
-  Alcotest.(check int)
-    "post-hook estimate accounts assembled context minus preflight-accounted blocks"
-    (10 + max 0 (assembled_tokens - preflight_accounted_tokens))
-    assembly.post_hook_estimated_input_tokens
-
-let test_keeper_preflight_wires_tool_inclusive_estimate () =
-  let agent_run_source = read_file "lib/keeper/keeper_agent_run.ml" in
-  let setup_source = read_file "lib/keeper/keeper_run_tools_setup.ml" in
-  Alcotest.(check bool)
-    "keeper computes tool schema context estimate"
-    true
-    (contains_substring setup_source "estimate_tool_schema_context");
-  Alcotest.(check bool)
-    "keeper preflight uses tool-inclusive estimate"
-    true
-    (contains_substring agent_run_source "estimated_input_tokens_with_tools");
-  Alcotest.(check bool)
-    "keeper writes context preflight manifest"
-    true
-    (contains_substring agent_run_source "context_preflight")
-
-let test_context_window_observation_reports_remaining_and_overage () =
-  let within =
-    Keeper_run_prompt.observe_context_window
-      ~estimated_input_tokens:100
-      ~max_context:128
-  in
-  Alcotest.(check int) "remaining under window" 28
-    within.observed_remaining_context_tokens;
-  Alcotest.(check int) "overage under window" 0
-    within.observed_over_context_tokens;
-  Alcotest.(check (float 0.0001))
-    "ratio under window"
-    (100.0 /. 128.0)
-    within.observed_context_usage_ratio;
-  let over =
-    Keeper_run_prompt.observe_context_window
-      ~estimated_input_tokens:140
-      ~max_context:128
-  in
-  Alcotest.(check int) "remaining over window" 0
-    over.observed_remaining_context_tokens;
-  Alcotest.(check int) "overage over window" 12
-    over.observed_over_context_tokens;
-  Alcotest.(check (float 0.0001))
-    "ratio over window"
-    (140.0 /. 128.0)
-    over.observed_context_usage_ratio
-
-let test_context_preflight_manifest_records_window_delta () =
-  let source = read_file "lib/keeper/keeper_agent_run.ml" in
-  Alcotest.(check bool)
-    "context preflight records remaining tokens"
-    true
-    (contains_substring source "remaining_context_tokens");
-  Alcotest.(check bool)
-    "context preflight records overage tokens"
-    true
-    (contains_substring source "over_context_tokens");
-  Alcotest.(check bool)
-    "context preflight records usage ratio"
-    true
-    (contains_substring source "context_usage_ratio");
-  Alcotest.(check bool)
-    "context preflight has no layer priority or fractional cap policy"
-    false
-    (contains_substring source "context_layers"
-     || contains_substring source "context_layer_policy")
-
 let test_context_injection_hook_records_post_tool_ledger () =
   let agent_run_source = read_file "lib/keeper/keeper_agent_run.ml" in
   Alcotest.(check bool)
@@ -323,14 +134,6 @@ let test_context_injection_hook_records_post_tool_ledger () =
     "hook records last tool result count"
     true
     (contains_substring hook_source "last_tool_result_count");
-  Alcotest.(check bool)
-    "hook records extra system context token estimate"
-    true
-    (contains_substring hook_source "extra_system_context_estimated_tokens");
-  Alcotest.(check bool)
-    "hook observes post-hook context against context window"
-    true
-    (contains_substring hook_source "post_hook_estimated_input_tokens");
   Alcotest.(check bool)
     "hook assembles all extra context before params are adjusted"
     true
@@ -359,35 +162,6 @@ let test_context_injection_hook_records_post_tool_ledger () =
     (contains_substring hook_source "post_hook_context_window_error_ref"
      || contains_substring agent_run_source "post_hook_context_window_error_ref")
 
-let test_keeper_preflight_reuses_setup_tool_estimate () =
-  let agent_run_source = read_file "lib/keeper/keeper_agent_run.ml" in
-  Alcotest.(check bool)
-    "keeper run reads setup tool estimate"
-    true
-    (contains_substring agent_run_source "s.Keeper_run_tools.tool_context_estimate");
-  Alcotest.(check bool)
-    "keeper run does not recompute tool schemas"
-    false
-    (contains_substring agent_run_source "estimate_tool_schema_context")
-
-let test_keeper_context_estimates_use_context_facade () =
-  let prompt_source = read_file "lib/keeper/keeper_run_prompt.ml" in
-  let hook_source = read_file "lib/keeper/keeper_run_tools_hooks.ml" in
-  Alcotest.(check bool)
-    "context estimation uses keeper facade"
-    true
-    (contains_substring prompt_source
-       "Keeper_context_core_accessors.estimate_char_tokens"
-     && contains_substring hook_source
-          "Keeper_context_core_accessors.estimate_char_tokens");
-  Alcotest.(check bool)
-    "context estimation avoids direct OAS estimator calls"
-    false
-    (contains_substring prompt_source
-       "Agent_sdk.Context_reducer.estimate_char_tokens"
-     || contains_substring hook_source
-          "Agent_sdk.Context_reducer.estimate_char_tokens")
-
 let () =
   Alcotest.run "keeper_runtime_observation_boundaries"
   [
@@ -405,31 +179,7 @@ let () =
           test_keeper_oas_path_has_no_bridge_total_timeout;
         Alcotest.test_case "runtime provider path has no cumulative timeout" `Quick
           test_runtime_provider_path_has_no_cumulative_run_timeout;
-        Alcotest.test_case "tool schema estimate adds provider payload" `Quick
-          test_tool_schema_estimate_adds_provider_payload;
-        Alcotest.test_case
-          "hook context estimate skips base prompt layers"
-          `Quick
-          test_hook_context_estimate_skips_base_prompt_layers;
-        Alcotest.test_case "extra system context preserves overflow blocks" `Quick
-          test_extra_system_context_assembly_preserves_over_window_blocks;
-        Alcotest.test_case
-          "extra system context assembly accounts overhead"
-          `Quick
-          test_extra_system_context_assembly_accounts_assembled_overhead;
-        Alcotest.test_case "keeper preflight wires tool-inclusive estimate" `Quick
-          test_keeper_preflight_wires_tool_inclusive_estimate;
-        Alcotest.test_case
-          "context window observation reports remaining and overage"
-          `Quick
-          test_context_window_observation_reports_remaining_and_overage;
-        Alcotest.test_case "context preflight manifest records window delta" `Quick
-          test_context_preflight_manifest_records_window_delta;
         Alcotest.test_case "context injection hook records post-tool ledger" `Quick
           test_context_injection_hook_records_post_tool_ledger;
-        Alcotest.test_case "keeper preflight reuses setup tool estimate" `Quick
-          test_keeper_preflight_reuses_setup_tool_estimate;
-        Alcotest.test_case "keeper context estimates use context facade" `Quick
-          test_keeper_context_estimates_use_context_facade;
       ] );
   ]

--- a/test/test_keeper_runtime_observation_boundaries.ml
+++ b/test/test_keeper_runtime_observation_boundaries.ml
@@ -115,6 +115,24 @@ let test_runtime_provider_path_has_no_cumulative_run_timeout () =
     false
     (contains_substring source "Eio.Time.with_timeout_exn clock t run_fn")
 
+let test_extra_system_context_preserves_typed_blocks () =
+  let blocks =
+    [ Prompt_block_id.Dynamic_context, "dynamic"
+    ; Prompt_block_id.Retry_nudge, "retry"
+    ; Prompt_block_id.Connected_surface, "surface"
+    ]
+  in
+  let assembly =
+    Keeper_run_prompt.assemble_extra_system_context
+      ~existing_extra_system_context:(Some "existing")
+      ~blocks
+  in
+  Alcotest.(check bool) "typed blocks unchanged" true (assembly.blocks = blocks);
+  Alcotest.(check (option string))
+    "complete source order reaches OAS"
+    (Some "existing\n\ndynamic\n\nretry\n\nsurface")
+    assembly.extra_system_context
+
 let test_context_injection_hook_records_post_tool_ledger () =
   let agent_run_source = read_file "lib/keeper/keeper_agent_run.ml" in
   Alcotest.(check bool)
@@ -179,6 +197,8 @@ let () =
           test_keeper_oas_path_has_no_bridge_total_timeout;
         Alcotest.test_case "runtime provider path has no cumulative timeout" `Quick
           test_runtime_provider_path_has_no_cumulative_run_timeout;
+        Alcotest.test_case "extra system context preserves typed blocks" `Quick
+          test_extra_system_context_preserves_typed_blocks;
         Alcotest.test_case "context injection hook records post-tool ledger" `Quick
           test_context_injection_hook_records_post_tool_ledger;
       ] );

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -775,8 +775,7 @@ let () =
     in
     let ctx_composition : Masc.Keeper_agent_prompt_metrics.ctx_composition_metrics =
       { actual_input_tokens = None
-      ; display_total_tokens = 0
-      ; estimated_known_tokens = 0
+      ; attributed_bytes = 0
       ; segments = []
       }
     in

--- a/test/test_keeper_wake_telemetry.ml
+++ b/test/test_keeper_wake_telemetry.ml
@@ -174,6 +174,51 @@ let test_role_counts_are_stably_sorted () =
   check (list string) "role_counts keys are sorted for stable JSON output"
     sorted_keys keys
 
+let test_phase0_record_always_emits_observation () =
+  let meta =
+    match
+      Masc.Keeper_meta_json_parse.meta_of_json
+        (`Assoc
+          [ "name", `String "wake-observation-test"
+          ; "agent_name", `String "wake-observation-test"
+          ; "trace_id", `String "trace-wake-observation-test"
+          ])
+    with
+    | Ok meta -> meta
+    | Error err -> fail ("meta_of_json failed: " ^ err)
+  in
+  let observed = ref None in
+  let restore () =
+    Masc.Keeper_keepalive_signal.register_record_wake_payload
+      (fun ~keeper_name:_ ~trace_id:_ ~turn_index:_ ~model_id:_
+        ~context_window:_ ~approx_body_bytes:_ ~system_prompt_bytes:_
+        ~tool_defs_bytes:_ ~messages_bytes:_ ~message_count:_ ~role_counts:_
+        ~tool_count:_ ~has_compact_happened:_ -> ())
+  in
+  Fun.protect
+    ~finally:restore
+    (fun () ->
+       Masc.Keeper_keepalive_signal.register_record_wake_payload
+         (fun ~keeper_name ~trace_id:_ ~turn_index:_ ~model_id:_
+           ~context_window:_ ~approx_body_bytes:_ ~system_prompt_bytes
+           ~tool_defs_bytes:_ ~messages_bytes:_ ~message_count ~role_counts:_
+           ~tool_count:_ ~has_compact_happened:_ ->
+            observed := Some (keeper_name, system_prompt_bytes, message_count));
+       Masc.Keeper_agent_run_phase0_telemetry.record
+         ~meta
+         ~turn_system_prompt:"system"
+         ~tools:[]
+         ~history_messages:[ text_msg Types.Assistant "previous" ]
+         ~user_message:"next"
+         ~start_turn_count:3
+         ~max_context:4096
+         ~pre_dispatch_compacted:false;
+       check
+         (option (triple string int int))
+         "phase-0 emits exact observation without an admission switch"
+         (Some ("wake-observation-test", String.length "system", 2))
+         !observed)
+
 let () =
   run "Keeper_wake_telemetry"
     [
@@ -203,5 +248,10 @@ let () =
             test_role_counts_sum_matches_message_count;
           test_case "invariant holds across mixed content shapes" `Quick
             test_compute_sizes_invariant_across_shapes;
+        ] );
+      ( "phase0_record",
+        [
+          test_case "observation has no environment admission switch" `Quick
+            test_phase0_record_always_emits_observation;
         ] );
     ]


### PR DESCRIPTION
## What

- delete the `MASC_PAYLOAD_TELEMETRY` environment gate and its config module
- record wake-payload observations before every Keeper model dispatch
- keep the observation path fail-open for ordinary telemetry failures and cancellation-safe
- prove the phase-0 observation callback is invoked without an admission switch
- regenerate the runtime-tunable catalog from source

This PR changes only admission to observation. The follow-up removes approximate aggregate and ignored model carriers while preserving exact component/count observations.

The generated catalog also incorporates already-landed parent-chain env deletions; it was generated mechanically and a second generation was byte-identical.

Stacked after #24461.

## Verification

- `scripts/dune-local.sh build lib/.masc.objs/byte/masc__Keeper_wake_telemetry.cmo lib/.masc.objs/byte/masc__Keeper_agent_run_phase0_telemetry.cmo lib/.masc.objs/byte/masc__Keeper_agent_run.cmo`
- `ocamlc -stop-after parsing -c test/test_keeper_wake_telemetry.ml`
- generated `docs/runtime-tunables.md` twice with byte-identical output
- exact residue search: `MASC_PAYLOAD_TELEMETRY`, `payload_telemetry_enabled`, `KeeperTelemetry`, and `record_if_enabled` are absent
- `ocamlformat`, OCaml parse checks, and `git diff --check`

The focused test executable is currently blocked during library compilation by the known stacked-base OAS 0.212 residues (`Builder.with_exit_condition`, `MaxTurnsExceeded`, and the remaining Event_bus/Context_reducer consumers); the changed producer objects compile independently.

## Size

9 files, +167/-150, 317 total churn.