### PR TITLE
refactor(keeper): plumb typed cooperative-yield probe

### DIFF
--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -289,6 +289,7 @@ let run_named
     ?enable_thinking
     ?exit_condition
     ?exit_condition_result
+    ?cooperative_yield_probe
     ?oas_checkpoint
     ?trace_link
     ?event_bus
@@ -577,6 +578,7 @@ let run_named
             ; preserve_thinking = inference_policy.attempt_preserve_thinking
             ; exit_condition
             ; exit_condition_result
+            ; cooperative_yield_probe
             ; oas_checkpoint
             ; trace_link
             ; sw

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -96,6 +96,7 @@ val run_named :
   ?enable_thinking:bool ->
   ?exit_condition:(int -> bool) ->
   ?exit_condition_result:(int -> Runtime_agent.stop_reason * string option) ->
+  ?cooperative_yield_probe:Runtime_agent.cooperative_yield_probe ->
   ?oas_checkpoint:Agent_sdk.Checkpoint.t ->
   ?trace_link:string * string ->
   ?event_bus:Agent_sdk.Event_bus.t ->

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -52,6 +52,7 @@ type try_provider_ctx =
   ; preserve_thinking : bool option
   ; exit_condition : (int -> bool) option
   ; exit_condition_result : (int -> Runtime_agent.stop_reason * string option) option
+  ; cooperative_yield_probe : Runtime_agent.cooperative_yield_probe option
   ; oas_checkpoint : Agent_sdk.Checkpoint.t option
   ; (* Eio concurrency *)
     sw : Eio.Switch.t
@@ -286,6 +287,7 @@ let run_try_provider
                 ?on_yield:ctx.on_yield
                 ?on_resume:ctx.on_resume
                 ~agent_ref:local_agent_ref
+                ?cooperative_yield_probe:ctx.cooperative_yield_probe
                 ~goal_detail:ctx.goal
                 blocks
           | None ->
@@ -298,6 +300,7 @@ let run_try_provider
                 ?on_yield:ctx.on_yield
                 ?on_resume:ctx.on_resume
                 ~agent_ref:local_agent_ref
+                ?cooperative_yield_probe:ctx.cooperative_yield_probe
                 ctx.goal
         in
         run_fn ())

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -33,6 +33,7 @@ type try_provider_ctx =
   ; preserve_thinking : bool option
   ; exit_condition : (int -> bool) option
   ; exit_condition_result : (int -> Runtime_agent.stop_reason * string option) option
+  ; cooperative_yield_probe : Runtime_agent.cooperative_yield_probe option
   ; oas_checkpoint : Agent_sdk.Checkpoint.t option
   ; sw : Eio.Switch.t
   ; net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t


### PR DESCRIPTION
## What

Thread the typed `Runtime_agent.cooperative_yield_probe` through `Keeper_turn_driver` and its provider-attempt context into both text and multimodal runtime dispatch.

This slice intentionally adds no queue policy and no string/risk classifier. It is a typed transport seam between the runtime bridge in #24469 and the exact Keeper queue producer in the follow-up.

Stacked after #24469.

## Verification

- `git diff --check 0fbdd24e9b..1e927bda2b`
- `ocamlformat --check` on the four changed OCaml files

# ci:skip-test-coverage

Coverage opt-out rationale: this seven-line slice only threads an optional typed callback unchanged. The behavioral queue/yield tests live in the consuming follow-up where the callback is constructed.

## Size

4 files, +7/-0, 7 total churn.