### PR TITLE
refactor(keeper): hard-cut exit-condition yield

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -67,26 +67,14 @@ type autonomous_yield_reason =
   | Chat_waiting
   | Durable_stimulus_waiting
 
-type autonomous_yield_boundary =
-  | Yield_immediately
-  | Yield_after_current_turn
-
 type autonomous_yield_request =
-  { reason : autonomous_yield_reason
-  ; boundary : autonomous_yield_boundary
-  }
+  { reason : autonomous_yield_reason }
 
-let autonomous_yield_allowed_at_turn ~start_turn ~turn request =
-  match request.boundary with
-  | Yield_immediately -> true
-  | Yield_after_current_turn -> turn > start_turn
-;;
-
-let stop_reason_of_autonomous_yield ~turn request =
+let runtime_yield_reason request =
   match request.reason with
-  | Chat_waiting -> Runtime_agent.Yielded_to_chat_waiting { turns_used = turn }
+  | Chat_waiting -> Runtime_agent.Chat_waiting
   | Durable_stimulus_waiting ->
-    Runtime_agent.Yielded_to_durable_stimulus { turns_used = turn }
+    Runtime_agent.Durable_stimulus_waiting
 ;;
 
 let keeper_raw_trace_sink
@@ -155,8 +143,7 @@ module For_testing = struct
     normalize_response_text_for_finalization
   let keeper_raw_trace_sink = keeper_raw_trace_sink
   let raw_trace_for_dispatch = raw_trace_for_dispatch
-  let autonomous_yield_allowed_at_turn = autonomous_yield_allowed_at_turn
-  let stop_reason_of_autonomous_yield = stop_reason_of_autonomous_yield
+  let runtime_yield_reason = runtime_yield_reason
 end
 
 (** Run a single keeper turn via OAS Agent.run().
@@ -555,64 +542,33 @@ let run_turn
          match pre_dispatch_error with
          | Some err -> Error err
          | None ->
-              (* Autonomous cooperative yield: OAS checks [exit_condition]
-                 before the first provider dispatch as well as between turns.
-                 A scheduled-idle waiting chat may preempt immediately, but a
-                 reactive chat or durable stimulus may stop this run only after
-                 [turn] advances beyond the checkpoint's [start_turn_count];
-                 otherwise the heartbeat would acknowledge the currently leased
-                 stimulus without the model ever observing it. [observed_request]
-                 bridges OAS's split bool / render callbacks and preserves the
-                 exact typed reason and boundary that made the predicate true,
-                 even if the waiting chat is cancelled before
-                 [exit_condition_result] runs. *)
-              let autonomous_yield_exit_condition,
-                  autonomous_yield_exit_condition_result =
+              let cooperative_yield_probe =
                 match autonomous_yield_requested with
-                | None -> None, None
+                | None -> None
                 | Some requested ->
-                  let observed_request = ref None in
-                  ( Some
-                      (fun (turn : int) ->
+                  Some
+                    (fun (_ : Agent_sdk.Agent.Advanced.tool_boundary) ->
+                       try
                          match requested () with
-                         | Some request
-                           when autonomous_yield_allowed_at_turn
-                                  ~start_turn:start_turn_count
-                                  ~turn
-                                  request ->
-                           observed_request := Some request;
-                           true
-                         | Some _ | None -> false)
-                  , Some
-                      (fun (turn : int) ->
-                         match !observed_request with
-                         | Some request ->
-                           let stop_reason =
-                             stop_reason_of_autonomous_yield ~turn request
-                           in
-                           let notice =
-                             match request.reason with
-                             | Chat_waiting ->
-                               Printf.sprintf
-                                 "[yielded turn slot at turn %d to a waiting \
-                                  chat request; keeper resumes on the next \
-                                  cycle]"
-                                 turn
-                             | Durable_stimulus_waiting ->
-                               Printf.sprintf
-                                 "[yielded autonomous run at turn %d because a \
-                                  durable stimulus is waiting; checkpoint saved \
-                                  and keeper resumes on the next cycle]"
-                                 turn
-                           in
-                           stop_reason, Some notice
-                         | None ->
-                           let message =
-                             "autonomous yield result requested without a \
-                              preceding typed yield decision"
-                           in
-                           Log.Keeper.error ~keeper_name:meta.name "%s" message;
-                           invalid_arg message) )
+                         | Ok (Some request) ->
+                           Ok (Runtime_agent.Yield (runtime_yield_reason request))
+                         | Ok None -> Ok Runtime_agent.Continue
+                         | Error detail ->
+                           Error
+                             (Agent_sdk.Error.Internal
+                                ("keeper cooperative-yield snapshot failed: "
+                                 ^ detail))
+                       with
+                       | Eio.Cancel.Cancelled _ as exn -> raise exn
+                       | exn ->
+                         Error
+                           (Agent_sdk.Error.Internal
+                              (Printf.sprintf
+                                 "keeper cooperative-yield probe failed: %s"
+                                 (Printexc.to_string exn))))
+              in
+              let checkpoint_sidecar =
+                ctx_work.checkpoint.Agent_sdk.Checkpoint.working_context
               in
               let checkpoint_sink (snapshot : Agent_sdk.Agent.checkpoint_snapshot) =
                 Option.iter (fun observe -> observe snapshot.stage) on_checkpoint_stage;
@@ -627,6 +583,10 @@ let run_turn
                   { snapshot.checkpoint with
                     session_id =
                       Keeper_id.Trace_id.to_string meta.runtime.trace_id
+                  ; working_context =
+                      (match checkpoint_sidecar with
+                       | Some _ as sidecar -> sidecar
+                       | None -> snapshot.checkpoint.working_context)
                   }
                 in
                 Keeper_checkpoint_store.save_oas
@@ -668,18 +628,13 @@ let run_turn
                     ?on_yield
                     ?on_resume
                     ~agent_ref
+                    ?checkpoint_sidecar
                     ~cache_system_prompt:true
                     ~yield_on_tool
                     ~context_injector
                     ~context:shared_context
                     ~enable_thinking:(Keeper_config.keeper_enable_thinking ())
-                      (* Mutation-boundary is native to OAS now;
-                         [exit_condition] is re-wired here solely for the typed
-                         autonomous cooperative yield above. Both callbacks are
-                         [None] on the chat lane, so chat runs to natural model
-                         completion unchanged. *)
-                    ?exit_condition:autonomous_yield_exit_condition
-                    ?exit_condition_result:autonomous_yield_exit_condition_result
+                    ?cooperative_yield_probe
                     ?oas_checkpoint:resume_oas_checkpoint
                     ?event_bus
                     ?trace_link

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -22,22 +22,14 @@ type raw_trace_sink_outcome =
   | Sink_ready of Agent_sdk.Raw_trace.t
   | Sink_degraded of Agent_sdk.Error.sdk_error
 
-(** Typed reason and boundary for an autonomous Keeper run to release its lane
-    at an OAS turn boundary. Scheduled-idle chat can yield immediately;
-    reactive chat and durable backlog yield only after the current cycle has
-    completed at least one provider turn, so a leased stimulus is never
-    acknowledged without being observed by the model. *)
+(** Typed reason for an autonomous Keeper run to release its lane after OAS
+    completes a tool boundary. *)
 type autonomous_yield_reason =
   | Chat_waiting
   | Durable_stimulus_waiting
 
-type autonomous_yield_boundary =
-  | Yield_immediately
-  | Yield_after_current_turn
-
 type autonomous_yield_request = {
   reason : autonomous_yield_reason;
-  boundary : autonomous_yield_boundary;
 }
 
 module For_testing : sig
@@ -82,16 +74,9 @@ module For_testing : sig
     -> meta:Keeper_meta_contract.keeper_meta
     -> Agent_sdk.Raw_trace.t option
 
-  val autonomous_yield_allowed_at_turn
-    :  start_turn:int
-    -> turn:int
-    -> autonomous_yield_request
-    -> bool
-
-  val stop_reason_of_autonomous_yield
-    :  turn:int
-    -> autonomous_yield_request
-    -> Runtime_agent.stop_reason
+  val runtime_yield_reason
+    :  autonomous_yield_request
+    -> Runtime_agent.cooperative_yield_reason
 
 end
 
@@ -153,13 +138,10 @@ val run_turn
   -> ?continuation_channel:Keeper_continuation_channel.t
   -> ?continuation_delivery_channel:Keeper_continuation_channel.t
   -> ?hitl_resolution:Keeper_event_queue.hitl_resolution
-  -> ?autonomous_yield_requested:(unit -> autonomous_yield_request option)
-       (* Autonomous-lane hook: evaluated at each OAS agent-loop turn boundary
-          before the next model dispatch — never mid tool execution. A typed
-          request stops the run gracefully at the boundary allowed by
-          [autonomous_yield_reason], releasing the lane for queued chat or
-          durable stimulus work. Only the heartbeat-scheduled path passes it; a
-          chat turn never receives this hook. *)
+  -> ?autonomous_yield_requested:
+       (unit -> (autonomous_yield_request option, string) result)
+       (* Evaluated only after a typed OAS tool boundary. Snapshot failures
+          remain explicit errors. The chat lane never receives this hook. *)
   -> ?on_checkpoint_stage:(Agent_sdk.Agent.checkpoint_stage -> unit)
   -> unit
   -> (run_result, Agent_sdk.Error.sdk_error) result

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -287,8 +287,6 @@ let run_named
     ?context_injector
     ?context
     ?enable_thinking
-    ?exit_condition
-    ?exit_condition_result
     ?cooperative_yield_probe
     ?oas_checkpoint
     ?trace_link
@@ -576,8 +574,6 @@ let run_named
             ; context
             ; enable_thinking = inference_policy.attempt_enable_thinking
             ; preserve_thinking = inference_policy.attempt_preserve_thinking
-            ; exit_condition
-            ; exit_condition_result
             ; cooperative_yield_probe
             ; oas_checkpoint
             ; trace_link

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -94,8 +94,6 @@ val run_named :
   ?context_injector:Agent_sdk.Hooks.context_injector ->
   ?context:Agent_sdk.Context.t ->
   ?enable_thinking:bool ->
-  ?exit_condition:(int -> bool) ->
-  ?exit_condition_result:(int -> Runtime_agent.stop_reason * string option) ->
   ?cooperative_yield_probe:Runtime_agent.cooperative_yield_probe ->
   ?oas_checkpoint:Agent_sdk.Checkpoint.t ->
   ?trace_link:string * string ->

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -50,8 +50,6 @@ type try_provider_ctx =
   ; context : Agent_sdk.Context.t option
   ; enable_thinking : bool option
   ; preserve_thinking : bool option
-  ; exit_condition : (int -> bool) option
-  ; exit_condition_result : (int -> Runtime_agent.stop_reason * string option) option
   ; cooperative_yield_probe : Runtime_agent.cooperative_yield_probe option
   ; oas_checkpoint : Agent_sdk.Checkpoint.t option
   ; (* Eio concurrency *)
@@ -249,8 +247,6 @@ let run_try_provider
                | None -> ctx.enable_thinking)
           ; preserve_thinking = ctx.preserve_thinking
           ; event_bus = ctx.event_bus
-          ; exit_condition = ctx.exit_condition
-          ; exit_condition_result = ctx.exit_condition_result
           ; initial_messages = ctx.initial_messages
           ; model_input_projection = ctx.model_input_projection
           ; raw_trace = ctx.raw_trace

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -31,8 +31,6 @@ type try_provider_ctx =
   ; context : Agent_sdk.Context.t option
   ; enable_thinking : bool option
   ; preserve_thinking : bool option
-  ; exit_condition : (int -> bool) option
-  ; exit_condition_result : (int -> Runtime_agent.stop_reason * string option) option
   ; cooperative_yield_probe : Runtime_agent.cooperative_yield_probe option
   ; oas_checkpoint : Agent_sdk.Checkpoint.t option
   ; sw : Eio.Switch.t

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -23,31 +23,29 @@ type retry_loop_input =
   ; attempted_runtimes : string list
   }
 
-let autonomous_yield_request ~base_path ~keeper_name ~channel =
-  if
-    Keeper_turn_admission.chat_waiting ~base_path ~keeper_name
-    || (match Keeper_chat_queue.pending_count ~keeper_name with
-        | Ok count -> count > 0
-        | Error _ -> true)
-  then
-    let boundary =
-      match channel with
-      | Keeper_world_observation.Scheduled_autonomous ->
-        Keeper_agent_run.Yield_immediately
-      | Keeper_world_observation.Reactive ->
-        Keeper_agent_run.Yield_after_current_turn
-    in
-    Some Keeper_agent_run.{ reason = Chat_waiting; boundary }
-  else
-    let pending = Keeper_registry_event_queue.snapshot ~base_path keeper_name in
-    if Keeper_event_queue.is_empty pending
-    then None
+let autonomous_yield_request ~base_path ~keeper_name =
+  match Keeper_registry.get ~base_path keeper_name with
+  | None -> Error (Printf.sprintf "keeper not registered: %s" keeper_name)
+  | Some _ ->
+    if Keeper_turn_admission.chat_waiting ~base_path ~keeper_name
+    then Ok (Some Keeper_agent_run.{ reason = Chat_waiting })
     else
-      Some
-        Keeper_agent_run.
-          { reason = Durable_stimulus_waiting
-          ; boundary = Yield_after_current_turn
-          }
+      (match Keeper_chat_queue.has_active_receipts ~keeper_name with
+       | Error error ->
+         Error
+           ("chat queue snapshot failed: "
+            ^ Keeper_chat_queue.mutation_error_to_string error)
+       | Ok true -> Ok (Some Keeper_agent_run.{ reason = Chat_waiting })
+       | Ok false ->
+         let pending =
+           Keeper_registry_event_queue.snapshot ~base_path keeper_name
+         in
+         if Keeper_event_queue.is_empty pending
+         then Ok None
+         else
+           Ok
+             (Some
+                Keeper_agent_run.{ reason = Durable_stimulus_waiting }))
 ;;
 
 (** [run] operates on the immutable [Keeper_unified_turn_types.turn_state]
@@ -215,19 +213,13 @@ let run (ctx : ctx)
                       ([Keeper_unified_turn.run_keeper_cycle] → here, only ever
                       reached via [Keeper_turn_admission.run_if_free]); the chat
                       lane runs [run_keeper_msg_turn_admitted] on a separate
-                      path. So passing the yield hook here is inherently
-                      lane-gated. Scheduled-idle chat can take the slot
-                      immediately; reactive chat and a durable event waiting
-                      behind the event leased by this cycle cause a checkpointed
-                      yield after at least one provider turn. A chat turn receives
-                      neither preemption hook. Both signals are read from the
-                      exact queues their consumers drain, so no cadence, timeout, or
-                      inferred text state participates in the decision. *)
+                      path. Thus the probe is lane-gated and runs only at OAS's
+                      post-tool boundary. Its signals come from the exact chat
+                      receipt and durable-event queues their consumers drain. *)
                  ~autonomous_yield_requested:(fun () ->
                    autonomous_yield_request
                      ~base_path:config.base_path
-                     ~keeper_name:meta.name
-                     ~channel)
+                     ~keeper_name:meta.name)
                  ()
            with
            | Eio.Cancel.Cancelled _ as exn ->

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -122,8 +122,6 @@ type config =
   yield_on_tool : bool;
   context_injector : Agent_sdk.Hooks.context_injector option;
   context : Agent_sdk.Context.t option;
-  exit_condition : (int -> bool) option;
-  exit_condition_result : (int -> stop_reason * string option) option;
   thinking_budget : int option;
   top_p : float option;
   top_k : int option;
@@ -1039,10 +1037,6 @@ let content_blocks_detail (blocks : Agent_sdk.Types.content_block list) =
   |> String.concat "\n"
   |> String.trim
 
-type boundary_yield =
-  | Cooperative_yield of cooperative_yield_reason
-  | Legacy_exit of stop_reason
-
 let config_with_boundary_response_capture
       (config : config)
       response_ref
@@ -1089,11 +1083,9 @@ let run_blocks
   | Ok () ->
   let boundary_response = ref None in
   let config =
-    match cooperative_yield_probe, config.exit_condition with
-    | None, None -> config
-    | Some _, None | None, Some _ ->
-      config_with_boundary_response_capture config boundary_response
-    | Some _, Some _ -> config
+    match cooperative_yield_probe with
+    | None -> config
+    | Some _ -> config_with_boundary_response_capture config boundary_response
   in
   let goal_detail =
     match goal_detail with
@@ -1152,41 +1144,18 @@ let run_blocks
         ]
         (fun _trace_id ->
           let boundary_probe =
-            match cooperative_yield_probe, config.exit_condition with
-            | Some _, Some _ ->
-              Error
-                (Agent_sdk.Error.Config
-                   (Agent_sdk.Error.InvalidConfig
-                      { field = "cooperative_yield_probe/exit_condition"
-                      ; detail = "callbacks are mutually exclusive"
-                      }))
-            | Some probe, None ->
-              Ok
-                (Some
-                   (fun (boundary : Agent_sdk.Agent.Advanced.tool_boundary) ->
-                      Result.map
-                        (function
-                          | Continue -> None
-                          | Yield reason -> Some (Cooperative_yield reason))
-                        (probe boundary)))
-            | None, Some predicate ->
-              Ok
-                (Some
-                   (fun (boundary : Agent_sdk.Agent.Advanced.tool_boundary) ->
-                      if not (predicate boundary.Agent_sdk.Agent.Advanced.turn)
-                      then Ok None
-                      else
-                        match config.exit_condition_result with
-                        | Some render ->
-                          let stop_reason, _ = render boundary.turn in
-                          Ok (Some (Legacy_exit stop_reason))
-                        | None ->
-                          Error
-                            (Agent_sdk.Error.Internal
-                               "exit condition matched without a typed result")))
-            | None, None -> Ok None
+            match cooperative_yield_probe with
+            | None -> None
+            | Some probe ->
+              Some
+                (fun (boundary : Agent_sdk.Agent.Advanced.tool_boundary) ->
+                   Result.map
+                     (function
+                       | Continue -> None
+                       | Yield reason -> Some reason)
+                     (probe boundary))
           in
-          Result.bind boundary_probe (function
+          match boundary_probe with
             | None ->
               (match on_event with
                | Some cb ->
@@ -1262,7 +1231,7 @@ let run_blocks
                   | Some _, None ->
                     Error
                       (Agent_sdk.Error.Internal
-                         "cooperative yield returned without its provider response")))))
+                         "cooperative yield returned without its provider response"))))
     in
     let run_total_duration_ms = run_duration_ms_since run_started_at in
     let checkpoint =
@@ -1339,11 +1308,10 @@ let run_blocks
       close_after_success ();
       let stop_reason =
         match decision with
-        | Cooperative_yield Chat_waiting ->
+        | Chat_waiting ->
           Yielded_to_chat_waiting { turns_used = yielded.turn }
-        | Cooperative_yield Durable_stimulus_waiting ->
+        | Durable_stimulus_waiting ->
           Yielded_to_durable_stimulus { turns_used = yielded.turn }
-        | Legacy_exit stop_reason -> stop_reason
       in
       record_dashboard_oas_response
         ~config

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -97,8 +97,6 @@ type config = Runtime_agent_context.config = {
   yield_on_tool : bool;
   context_injector : Agent_sdk.Hooks.context_injector option;
   context : Agent_sdk.Context.t option;
-  exit_condition : (int -> bool) option;
-  exit_condition_result : (int -> stop_reason * string option) option;
   thinking_budget : int option;
   top_p : float option;
   top_k : int option;

--- a/lib/runtime/runtime_agent_context.ml
+++ b/lib/runtime/runtime_agent_context.ml
@@ -83,8 +83,6 @@ type config =
   ; yield_on_tool : bool
   ; context_injector : Agent_sdk.Hooks.context_injector option
   ; context : Agent_sdk.Context.t option
-  ; exit_condition : (int -> bool) option
-  ; exit_condition_result : (int -> stop_reason * string option) option
   ; thinking_budget : int option
     (** Token budget for extended thinking, forwarded to OAS
         [Builder.with_thinking_budget]. Only meaningful when
@@ -141,8 +139,6 @@ let default_config
   ; yield_on_tool = false
   ; context_injector = None
   ; context = None
-  ; exit_condition = None
-  ; exit_condition_result = None
   ; thinking_budget = None
   ; top_p = provider_cfg.top_p
   ; top_k = provider_cfg.top_k

--- a/lib/runtime/runtime_agent_context.mli
+++ b/lib/runtime/runtime_agent_context.mli
@@ -77,8 +77,6 @@ type config = {
   yield_on_tool : bool;
   context_injector : Agent_sdk.Hooks.context_injector option;
   context : Agent_sdk.Context.t option;
-  exit_condition : (int -> bool) option;
-  exit_condition_result : (int -> stop_reason * string option) option;
   thinking_budget : int option;
       (** Token budget for extended thinking, forwarded to OAS
           [Builder.with_thinking_budget]. Only meaningful when

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -1334,10 +1334,11 @@ let () =
            Masc.Keeper_unified_turn_execution.autonomous_yield_request
              ~base_path
              ~keeper_name
-             ~channel:Masc.Keeper_world_observation.Scheduled_autonomous
          with
-         | None -> ()
-         | Some _ ->
+         | Ok None -> ()
+         | Error error ->
+           Alcotest.failf "empty queue snapshot failed: %s" error
+         | Ok (Some _) ->
            Alcotest.fail "empty work queues must not request an autonomous yield");
         Masc.Keeper_registry_event_queue.enqueue
           ~base_path
@@ -1347,15 +1348,16 @@ let () =
           Masc.Keeper_unified_turn_execution.autonomous_yield_request
             ~base_path
             ~keeper_name
-            ~channel:Masc.Keeper_world_observation.Reactive
         with
-        | Some
-            { Masc.Keeper_agent_run.reason =
-                Masc.Keeper_agent_run.Durable_stimulus_waiting
-            ; boundary = Masc.Keeper_agent_run.Yield_after_current_turn
-            } ->
+        | Ok
+            (Some
+               { Masc.Keeper_agent_run.reason =
+                   Masc.Keeper_agent_run.Durable_stimulus_waiting
+               }) ->
           ()
-        | None | Some _ ->
+        | Error error ->
+          Alcotest.failf "durable queue snapshot failed: %s" error
+        | Ok None | Ok (Some _) ->
           Alcotest.fail "pending durable stimulus must request a typed yield"));
 
   (* --- critical delivery: durable enqueue succeeds before registration and

--- a/test/test_keeper_turn_admission.ml
+++ b/test/test_keeper_turn_admission.ml
@@ -502,8 +502,8 @@ let test_idle_loop_yields_to_parked_chat () =
        per-turn-boundary exit check. Each iteration yields (a turn boundary)
        and inspects [chat_waiting]; a parked chat ends the loop early, the
        admission slot releases, and the chat admits by direct handoff. This
-       harnesses the admission-level contract; the SDK-level [exit_condition]
-       wiring in [Keeper_agent_run] drives the real loop the same way. *)
+       harnesses the admission-level contract; the production path checks the
+       same queue at OAS's typed post-tool boundary. *)
     Eio.Fiber.fork ~sw (fun () ->
       match
         Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () ->

--- a/test/test_keeper_turn_outcome.ml
+++ b/test/test_keeper_turn_outcome.ml
@@ -111,57 +111,20 @@ let test_of_result_surface () =
 
 let test_autonomous_yield_boundary_contract () =
   let module F = Masc.Keeper_agent_run.For_testing in
-  let start_turn = 11570 in
-  let immediate_chat : Masc.Keeper_agent_run.autonomous_yield_request =
-    { reason = Masc.Keeper_agent_run.Chat_waiting
-    ; boundary = Masc.Keeper_agent_run.Yield_immediately
-    }
-  in
-  let reactive_chat : Masc.Keeper_agent_run.autonomous_yield_request =
-    { reason = Masc.Keeper_agent_run.Chat_waiting
-    ; boundary = Masc.Keeper_agent_run.Yield_after_current_turn
-    }
+  let chat : Masc.Keeper_agent_run.autonomous_yield_request =
+    { reason = Masc.Keeper_agent_run.Chat_waiting }
   in
   let durable_stimulus : Masc.Keeper_agent_run.autonomous_yield_request =
-    { reason = Masc.Keeper_agent_run.Durable_stimulus_waiting
-    ; boundary = Masc.Keeper_agent_run.Yield_after_current_turn
-    }
+    { reason = Masc.Keeper_agent_run.Durable_stimulus_waiting }
   in
-  check bool "chat may yield before first provider dispatch" true
-    (F.autonomous_yield_allowed_at_turn
-       ~start_turn
-       ~turn:start_turn
-       immediate_chat);
-  check bool "reactive chat cannot skip the leased stimulus" false
-    (F.autonomous_yield_allowed_at_turn
-       ~start_turn
-       ~turn:start_turn
-       reactive_chat);
-  check bool "durable backlog cannot skip the leased stimulus" false
-    (F.autonomous_yield_allowed_at_turn
-       ~start_turn
-       ~turn:start_turn
-       durable_stimulus);
-  check bool "durable backlog yields after one provider turn" true
-    (F.autonomous_yield_allowed_at_turn
-       ~start_turn
-       ~turn:(start_turn + 1)
-       durable_stimulus);
-  match
-    F.stop_reason_of_autonomous_yield
-      ~turn:(start_turn + 1)
-      durable_stimulus
-  with
-  | Runtime_agent.Yielded_to_durable_stimulus { turns_used } ->
-    check int "typed durable yield carries the OAS turn" (start_turn + 1)
-      turns_used
-  | Runtime_agent.Completed
-  | Runtime_agent.TurnLimitObserved _
-  | Runtime_agent.ExecutionTimeoutObserved _
-  | Runtime_agent.ExecutionIdleTimeoutObserved _
-  | Runtime_agent.Yielded_to_chat_waiting _
-  | Runtime_agent.InputRequired _ ->
-    fail "durable request mapped to the wrong stop reason"
+  (match F.runtime_yield_reason chat with
+   | Runtime_agent.Chat_waiting -> ()
+   | Runtime_agent.Durable_stimulus_waiting ->
+     fail "chat request mapped to the durable reason");
+  match F.runtime_yield_reason durable_stimulus with
+  | Runtime_agent.Durable_stimulus_waiting -> ()
+  | Runtime_agent.Chat_waiting ->
+    fail "durable request mapped to the chat reason"
 
 let payload fields = Some (`Assoc fields)
 


### PR DESCRIPTION
## What

- Hard-delete MASC's removed OAS exit-condition coupling: `exit_condition`, `exit_condition_result`, `ExitConditionMet`, `Legacy_exit`, and the boundary/turn-count admission heuristic.
- Derive pending work only from exact lane facts: Keeper chat admission, active chat receipts, and a validated durable event-queue snapshot.
- Return queue snapshot/registry failures explicitly instead of treating unknown state as pending or silently continuing.
- Yield only at the OAS typed post-tool boundary while preserving checkpoint/tool-result replay data.

The deterministic layer does not judge task semantics, terminate the Keeper, pause other lanes, or apply risk/budget/string heuristics. It only transports exact lane handoff facts; the resumed Keeper LLM decides the next semantic action.

## Focused verification

```sh
scripts/dune-local.sh build lib/runtime/.masc_runtime.objs/byte/runtime_agent.cmo
scripts/dune-local.sh build \
  lib/.masc.objs/byte/masc__Keeper_agent_run.cmo \
  lib/.masc.objs/byte/masc__Keeper_turn_driver.cmo \
  lib/.masc.objs/byte/masc__Keeper_turn_driver_try_provider.cmo \
  lib/.masc.objs/byte/masc__Keeper_unified_turn_execution.cmo
git diff --check
```

All changed `.ml`/`.mli` files also pass parsing and `ocamlformat --check`. Focused tests cover empty queues, exact durable queued stimuli, explicit queue errors, and typed chat/durable reason projection.

## Baseline block (not claimed green)

Building `test/test_keeper_turn_outcome.exe` is currently blocked before the focused executable links by unrelated current-main OAS 0.212 residue:

- `lib/inference_utils.ml:32`: deleted `Agent_sdk.Context_reducer`
- `lib/keeper/keeper_context_core_accessors.ml:71`: deleted `Agent_sdk.Context_reducer`

Those files are outside this slice and are being repaired separately. No fake full-build green is claimed here.

## Slice

- Base: #24469 (`8bdb6870467a37122538eadae19a451989a107fa`)
- Diff: `+112 / -270` (`382` changed lines)
