### PR TITLE
refactor(keeper): observe exact wake payload components

### DIFF
--- a/lib/dashboard/dashboard_harness_health.ml
+++ b/lib/dashboard/dashboard_harness_health.ml
@@ -35,15 +35,8 @@ type pre_compact_event =
 (** Wake-time payload observation.
 
     Captured once per keeper turn, just before [Keeper_turn_driver.run_named] fires.
-    Phase 0 baseline for the tiered-hydration redesign (Option C).
-
-    [approx_body_bytes] is a MASC-side estimate (sum of content text,
-    tool definition JSON, system prompt, plus the pending user turn).
-    It is NOT the exact HTTP body wire size — provider layers add JSON
-    structural overhead (role keys, content block wrappers, array
-    brackets, escaping). Expect the real body to be ~1.3–1.5× this
-    estimate depending on tool-call density. Use [approx_body_bytes]
-    for trend detection, not for absolute thresholds.
+    Component byte fields are exact measurements of the canonical values MASC
+    owns; they do not claim to represent a provider-specific HTTP request body.
 
     [message_count] and [role_counts] include the synthesized user turn
     that OAS will append from [~goal], matching the wire-level message
@@ -56,12 +49,10 @@ type wake_payload_event =
   ; keeper_name : string
   ; trace_id : string
   ; turn_index : int
-  ; model_id : string
   ; context_window : int
-  ; approx_body_bytes : int
   ; system_prompt_bytes : int
-  ; tool_defs_bytes : int
-  ; messages_bytes : int
+  ; tool_schema_json_bytes : int
+  ; message_content_bytes : int
   ; message_count : int
   ; role_counts : (string * int) list
   ; tool_count : int
@@ -314,8 +305,6 @@ let role_counts_of_json json : (string * int) list =
     | _ -> None)
 ;;
 
-let public_runtime_model_id = "runtime"
-
 let wake_payload_record_json (event : wake_payload_event) =
   `Assoc
     [ "record_type", `String "wake_payload"
@@ -323,12 +312,10 @@ let wake_payload_record_json (event : wake_payload_event) =
     ; "keeper_name", `String event.keeper_name
     ; "trace_id", `String event.trace_id
     ; "turn_index", `Int event.turn_index
-    ; "model_id", `String public_runtime_model_id
     ; "context_window", `Int event.context_window
-    ; "approx_body_bytes", `Int event.approx_body_bytes
     ; "system_prompt_bytes", `Int event.system_prompt_bytes
-    ; "tool_defs_bytes", `Int event.tool_defs_bytes
-    ; "messages_bytes", `Int event.messages_bytes
+    ; "tool_schema_json_bytes", `Int event.tool_schema_json_bytes
+    ; "message_content_bytes", `Int event.message_content_bytes
     ; "message_count", `Int event.message_count
     ; "role_counts", role_counts_to_json event.role_counts
     ; "tool_count", `Int event.tool_count
@@ -342,12 +329,10 @@ let wake_payload_event_json (event : wake_payload_event) =
     ; "keeper_name", `String event.keeper_name
     ; "trace_id", `String event.trace_id
     ; "turn_index", `Int event.turn_index
-    ; "model_id", `String public_runtime_model_id
     ; "context_window", `Int event.context_window
-    ; "approx_body_bytes", `Int event.approx_body_bytes
     ; "system_prompt_bytes", `Int event.system_prompt_bytes
-    ; "tool_defs_bytes", `Int event.tool_defs_bytes
-    ; "messages_bytes", `Int event.messages_bytes
+    ; "tool_schema_json_bytes", `Int event.tool_schema_json_bytes
+    ; "message_content_bytes", `Int event.message_content_bytes
     ; "message_count", `Int event.message_count
     ; "role_counts", role_counts_to_json event.role_counts
     ; "tool_count", `Int event.tool_count
@@ -365,16 +350,16 @@ let wake_payload_event_of_json json =
       ; keeper_name = string_field json "keeper_name"
       ; trace_id = string_field json "trace_id"
       ; turn_index = Safe_ops.json_int ~default:0 "turn_index" json
-      ; model_id = public_runtime_model_id
       ; context_window =
           Safe_ops.json_int
             ~default:Runtime_constants.fallback_context_window
             "context_window"
             json
-      ; approx_body_bytes = Safe_ops.json_int ~default:0 "approx_body_bytes" json
       ; system_prompt_bytes = Safe_ops.json_int ~default:0 "system_prompt_bytes" json
-      ; tool_defs_bytes = Safe_ops.json_int ~default:0 "tool_defs_bytes" json
-      ; messages_bytes = Safe_ops.json_int ~default:0 "messages_bytes" json
+      ; tool_schema_json_bytes =
+          Safe_ops.json_int ~default:0 "tool_schema_json_bytes" json
+      ; message_content_bytes =
+          Safe_ops.json_int ~default:0 "message_content_bytes" json
       ; message_count = Safe_ops.json_int ~default:0 "message_count" json
       ; role_counts = role_counts_of_json json
       ; tool_count = Safe_ops.json_int ~default:0 "tool_count" json
@@ -709,31 +694,26 @@ let record_wake_payload_at
       ~keeper_name
       ~trace_id
       ~turn_index
-      ~model_id
       ~context_window
-      ~approx_body_bytes
       ~system_prompt_bytes
-      ~tool_defs_bytes
-      ~messages_bytes
+      ~tool_schema_json_bytes
+      ~message_content_bytes
       ~message_count
       ~role_counts
       ~tool_count
       ~has_compact_happened
   =
-  let model_id = public_runtime_model_id in
   (* Project World Building: Broadcast live Yjs telemetry *)
-  Dashboard_yjs.broadcast_keeper_telemetry ~keeper_name ~trace_id ~turn_index ~model_id;
+  Dashboard_yjs.broadcast_keeper_telemetry ~keeper_name ~trace_id ~turn_index;
   let event =
     { timestamp
     ; keeper_name
     ; trace_id
     ; turn_index
-    ; model_id
     ; context_window
-    ; approx_body_bytes
     ; system_prompt_bytes
-    ; tool_defs_bytes
-    ; messages_bytes
+    ; tool_schema_json_bytes
+    ; message_content_bytes
     ; message_count
     ; role_counts
     ; tool_count
@@ -752,12 +732,10 @@ let record_wake_payload
       ~keeper_name
       ~trace_id
       ~turn_index
-      ~model_id
       ~context_window
-      ~approx_body_bytes
       ~system_prompt_bytes
-      ~tool_defs_bytes
-      ~messages_bytes
+      ~tool_schema_json_bytes
+      ~message_content_bytes
       ~message_count
       ~role_counts
       ~tool_count
@@ -768,12 +746,10 @@ let record_wake_payload
     ~keeper_name
     ~trace_id
     ~turn_index
-    ~model_id
     ~context_window
-    ~approx_body_bytes
     ~system_prompt_bytes
-    ~tool_defs_bytes
-    ~messages_bytes
+    ~tool_schema_json_bytes
+    ~message_content_bytes
     ~message_count
     ~role_counts
     ~tool_count
@@ -895,8 +871,8 @@ let json ~(config : Workspace.config) ?since ?until () =
 ;;
 
 let () =
-  Keeper_keepalive_signal.register_record_wake_payload (fun ~keeper_name ~trace_id ~turn_index ~model_id ~context_window ~approx_body_bytes ~system_prompt_bytes ~tool_defs_bytes ~messages_bytes ~message_count ~role_counts ~tool_count ~has_compact_happened ->
-    ignore (record_wake_payload ~keeper_name ~trace_id ~turn_index ~model_id ~context_window ~approx_body_bytes ~system_prompt_bytes ~tool_defs_bytes ~messages_bytes ~message_count ~role_counts ~tool_count ~has_compact_happened)
+  Keeper_keepalive_signal.register_record_wake_payload (fun ~keeper_name ~trace_id ~turn_index ~context_window ~system_prompt_bytes ~tool_schema_json_bytes ~message_content_bytes ~message_count ~role_counts ~tool_count ~has_compact_happened ->
+    ignore (record_wake_payload ~keeper_name ~trace_id ~turn_index ~context_window ~system_prompt_bytes ~tool_schema_json_bytes ~message_content_bytes ~message_count ~role_counts ~tool_count ~has_compact_happened)
   );
 
   Keeper_compact_policy.register_record_pre_compact (fun ~keeper_name ~context_ratio ~message_count ~token_count ~strategies ~context_window ~is_local_model ~trigger ->

--- a/lib/dashboard/dashboard_harness_health.ml
+++ b/lib/dashboard/dashboard_harness_health.ml
@@ -872,7 +872,12 @@ let json ~(config : Workspace.config) ?since ?until () =
 
 let () =
   Keeper_keepalive_signal.register_record_wake_payload (fun ~keeper_name ~trace_id ~turn_index ~context_window ~system_prompt_bytes ~tool_schema_json_bytes ~message_content_bytes ~message_count ~role_counts ~tool_count ~has_compact_happened ->
-    ignore (record_wake_payload ~keeper_name ~trace_id ~turn_index ~context_window ~system_prompt_bytes ~tool_schema_json_bytes ~message_content_bytes ~message_count ~role_counts ~tool_count ~has_compact_happened)
+    let (_recorded : wake_payload_event) =
+      record_wake_payload ~keeper_name ~trace_id ~turn_index ~context_window
+        ~system_prompt_bytes ~tool_schema_json_bytes ~message_content_bytes
+        ~message_count ~role_counts ~tool_count ~has_compact_happened
+    in
+    ()
   );
 
   Keeper_compact_policy.register_record_pre_compact (fun ~keeper_name ~context_ratio ~message_count ~token_count ~strategies ~context_window ~is_local_model ~trigger ->

--- a/lib/dashboard/dashboard_harness_health.mli
+++ b/lib/dashboard/dashboard_harness_health.mli
@@ -67,20 +67,18 @@ type pre_compact_event =
 
 (** Wake-time payload observation captured once per
     keeper turn (just before [Keeper_turn_driver.run_named]
-    fires).  [approx_body_bytes] is a MASC-side estimate;
-    expect the real HTTP body to be ~1.3–1.5× this.
+    fires). Component byte fields measure the exact canonical values
+    MASC owns, not a provider-specific HTTP request body.
     Reached as a type by [keeper_agent_run]. *)
 type wake_payload_event =
   { timestamp : float
   ; keeper_name : string
   ; trace_id : string
   ; turn_index : int
-  ; model_id : string
   ; context_window : int
-  ; approx_body_bytes : int
   ; system_prompt_bytes : int
-  ; tool_defs_bytes : int
-  ; messages_bytes : int
+  ; tool_schema_json_bytes : int
+  ; message_content_bytes : int
   ; message_count : int
   ; role_counts : (string * int) list
   ; tool_count : int
@@ -122,19 +120,16 @@ val record_pre_compact_at
 
 (** Records one wake-time payload sample and returns the
     constructed event.  Threaded by [keeper_agent_run] /
-    [keeper_wake_telemetry] (and indirectly by
-    [env_config_keeper]); callers may reach the
+    [keeper_wake_telemetry]; callers may reach the
     [wake_payload_event] fields directly. *)
 val record_wake_payload
   :  keeper_name:string
   -> trace_id:string
   -> turn_index:int
-  -> model_id:string
   -> context_window:int
-  -> approx_body_bytes:int
   -> system_prompt_bytes:int
-  -> tool_defs_bytes:int
-  -> messages_bytes:int
+  -> tool_schema_json_bytes:int
+  -> message_content_bytes:int
   -> message_count:int
   -> role_counts:(string * int) list
   -> tool_count:int

--- a/lib/dashboard/dashboard_yjs.ml
+++ b/lib/dashboard/dashboard_yjs.ml
@@ -41,7 +41,7 @@ let broadcast_update ~kind payload =
       Log.Dashboard.warn "dashboard Yjs SSE broadcast failed: %s"
         (Printexc.to_string exn)
 
-let broadcast_keeper_telemetry ~keeper_name ~trace_id ~turn_index ~model_id:_ =
+let broadcast_keeper_telemetry ~keeper_name ~trace_id ~turn_index =
   let payload =
     `Assoc
       [
@@ -49,7 +49,6 @@ let broadcast_keeper_telemetry ~keeper_name ~trace_id ~turn_index ~model_id:_ =
         ("keeper_name", `String keeper_name);
         ("trace_id", `String trace_id);
         ("turn_index", `Int turn_index);
-        ("model_id", `String "runtime");
       ]
     |> Yojson.Safe.to_string
   in

--- a/lib/dashboard/dashboard_yjs.mli
+++ b/lib/dashboard/dashboard_yjs.mli
@@ -8,15 +8,13 @@ val frame_update : string -> string
     varint, followed by the payload itself.  Pure function — the byte
     layout is the wire contract pinned by [test_dashboard_yjs]. *)
 
-(** [broadcast_keeper_telemetry ~keeper_name ~trace_id ~turn_index ~model_id]
+(** [broadcast_keeper_telemetry ~keeper_name ~trace_id ~turn_index]
     publishes a keeper Yjs telemetry update to dashboard observer sessions.
-    [model_id] is accepted for legacy call sites but redacted to the neutral
-    ["runtime"] lane in the payload. Delivery is synchronous and best-effort
-    through the in-process SSE observer fanout; exceptions from disconnected
-    observers are logged, while cancellation is propagated. *)
+    Delivery is synchronous and best-effort through the in-process SSE observer
+    fanout; exceptions from disconnected observers are logged, while cancellation
+    is propagated. *)
 val frame_update : string -> string
 (** Encode a payload into the Yjs binary sync-protocol frame format. *)
 
 val broadcast_keeper_telemetry :
-  keeper_name:string -> trace_id:string -> turn_index:int -> model_id:string -> unit
-
+  keeper_name:string -> trace_id:string -> turn_index:int -> unit

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -543,10 +543,12 @@ let run_turn
          ~turn_system_prompt
          ~tools
          ~history_messages
+         ?user_blocks
          ~user_message
          ~start_turn_count
          ~max_context
-         ~pre_dispatch_compacted;
+         ~pre_dispatch_compacted
+         ();
        (* Section 3: Dispatch — call Keeper_turn_driver.run_named / Agent.run. *)
        let pre_dispatch_error = pre_dispatch_checkpoint_error in
        let turn_result =

--- a/lib/keeper/keeper_agent_run_phase0_telemetry.ml
+++ b/lib/keeper/keeper_agent_run_phase0_telemetry.ml
@@ -1,14 +1,16 @@
-(** Phase-0 wake-time payload telemetry, extracted from [Keeper_agent_run]. *)
+(** Wake-time payload observation, extracted from [Keeper_agent_run]. *)
 
 let record
     ~(meta : Keeper_meta_contract.keeper_meta)
     ~turn_system_prompt
     ~tools
     ~history_messages
+    ?user_blocks
     ~user_message
     ~start_turn_count
     ~max_context
     ~pre_dispatch_compacted
+    ()
   =
   try
       let sizes =
@@ -16,35 +18,30 @@ let record
           ~system_prompt:turn_system_prompt
           ~tools
           ~history_messages
+          ?user_blocks
           ~user_message
-      in
-      let model_id =
-        match Keeper_model_labels.configured_model_labels_of_meta meta with
-        | m :: _ -> m
-        | [] -> "auto"
+          ()
       in
       let () =
         Keeper_keepalive_signal.record_wake_payload
           ~keeper_name:meta.name
           ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
           ~turn_index:start_turn_count
-          ~model_id
           ~context_window:max_context
-          ~approx_body_bytes:sizes.approx_body_bytes
           ~system_prompt_bytes:sizes.system_prompt_bytes
-          ~tool_defs_bytes:sizes.tool_defs_bytes
-          ~messages_bytes:sizes.messages_bytes
+          ~tool_schema_json_bytes:sizes.tool_schema_json_bytes
+          ~message_content_bytes:sizes.message_content_bytes
           ~message_count:sizes.message_count
           ~role_counts:sizes.role_counts
           ~tool_count:sizes.tool_count
           ~has_compact_happened:pre_dispatch_compacted
       in
       ()
-    with
-    | Eio.Cancel.Cancelled _ as e -> raise e
-    | exn ->
-      Log.Harness.warn
-        "[wake_payload] telemetry failed keeper=%s: %s"
-        meta.name
-        (Printexc.to_string exn)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    Log.Harness.warn
+      "[wake_payload] observation failed keeper=%s: %s"
+      meta.name
+      (Printexc.to_string exn)
 ;;

--- a/lib/keeper/keeper_agent_run_phase0_telemetry.mli
+++ b/lib/keeper/keeper_agent_run_phase0_telemetry.mli
@@ -1,16 +1,18 @@
-(** Phase-0 wake payload telemetry for [Keeper_agent_run.run_turn]. *)
+(** Wake payload observation for [Keeper_agent_run.run_turn]. *)
 
 val record :
   meta:Keeper_meta_contract.keeper_meta ->
   turn_system_prompt:string ->
   tools:Agent_sdk.Tool.t list ->
   history_messages:Agent_sdk.Types.message list ->
+  ?user_blocks:Agent_sdk.Types.content_block list ->
   user_message:string ->
   start_turn_count:int ->
   max_context:int ->
   pre_dispatch_compacted:bool ->
+  unit ->
   unit
-(** Record wake-time payload sizing before every keeper model dispatch.
+(** Record exact wake-time component bytes on every turn.
 
-    The telemetry path is best-effort: cancellation is re-raised, while other
+    The observation path is best-effort: cancellation is re-raised, while other
     exceptions are logged and do not abort the LLM call. *)

--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -31,12 +31,10 @@ let record_wake_payload_callback
     : (keeper_name:string ->
        trace_id:string ->
        turn_index:int ->
-       model_id:string ->
        context_window:int ->
-       approx_body_bytes:int ->
        system_prompt_bytes:int ->
-       tool_defs_bytes:int ->
-       messages_bytes:int ->
+       tool_schema_json_bytes:int ->
+       message_content_bytes:int ->
        message_count:int ->
        role_counts:(string * int) list ->
        tool_count:int ->
@@ -45,30 +43,27 @@ let record_wake_payload_callback
       Atomic.t
   =
   Atomic.make
-    (fun ~keeper_name:_
+    (fun ~keeper_name
       ~trace_id:_
       ~turn_index:_
-      ~model_id:_
       ~context_window:_
-      ~approx_body_bytes:_
       ~system_prompt_bytes:_
-      ~tool_defs_bytes:_
-      ~messages_bytes:_
+      ~tool_schema_json_bytes:_
+      ~message_content_bytes:_
       ~message_count:_
       ~role_counts:_
       ~tool_count:_
-      ~has_compact_happened:_ -> ())
+      ~has_compact_happened:_ ->
+      Log.Keeper.warn "wake-payload observer unavailable: keeper=%s" keeper_name)
 
 let record_wake_payload
     ~keeper_name
     ~trace_id
     ~turn_index
-    ~model_id
     ~context_window
-    ~approx_body_bytes
     ~system_prompt_bytes
-    ~tool_defs_bytes
-    ~messages_bytes
+    ~tool_schema_json_bytes
+    ~message_content_bytes
     ~message_count
     ~role_counts
     ~tool_count
@@ -78,12 +73,10 @@ let record_wake_payload
     ~keeper_name
     ~trace_id
     ~turn_index
-    ~model_id
     ~context_window
-    ~approx_body_bytes
     ~system_prompt_bytes
-    ~tool_defs_bytes
-    ~messages_bytes
+    ~tool_schema_json_bytes
+    ~message_content_bytes
     ~message_count
     ~role_counts
     ~tool_count

--- a/lib/keeper/keeper_keepalive_signal.mli
+++ b/lib/keeper/keeper_keepalive_signal.mli
@@ -14,12 +14,10 @@ val record_wake_payload :
   keeper_name:string ->
   trace_id:string ->
   turn_index:int ->
-  model_id:string ->
   context_window:int ->
-  approx_body_bytes:int ->
   system_prompt_bytes:int ->
-  tool_defs_bytes:int ->
-  messages_bytes:int ->
+  tool_schema_json_bytes:int ->
+  message_content_bytes:int ->
   message_count:int ->
   role_counts:(string * int) list ->
   tool_count:int ->
@@ -30,12 +28,10 @@ val register_record_wake_payload :
   (keeper_name:string ->
    trace_id:string ->
    turn_index:int ->
-   model_id:string ->
    context_window:int ->
-   approx_body_bytes:int ->
    system_prompt_bytes:int ->
-   tool_defs_bytes:int ->
-   messages_bytes:int ->
+   tool_schema_json_bytes:int ->
+   message_content_bytes:int ->
    message_count:int ->
    role_counts:(string * int) list ->
    tool_count:int ->

--- a/lib/keeper/keeper_wake_telemetry.ml
+++ b/lib/keeper/keeper_wake_telemetry.ml
@@ -74,15 +74,16 @@ let role_counts_with_pending_user
     (history_messages : Agent_sdk.Types.message list) :
     (string * int) list =
   let tbl = Hashtbl.create 5 in
+  let increment_role key =
+    match Hashtbl.find_opt tbl key with
+    | None -> Hashtbl.add tbl key 1
+    | Some count -> Hashtbl.replace tbl key (count + 1)
+  in
   List.iter
     (fun (m : Agent_sdk.Types.message) ->
-      let key = role_key m.role in
-      let cur = Hashtbl.find_opt tbl key |> Option.value ~default:0 in
-      Hashtbl.replace tbl key (cur + 1))
+      increment_role (role_key m.role))
     history_messages;
-  let user_key = role_key Agent_sdk.Types.User in
-  let cur = Hashtbl.find_opt tbl user_key |> Option.value ~default:0 in
-  Hashtbl.replace tbl user_key (cur + 1);
+  increment_role (role_key Agent_sdk.Types.User);
   Hashtbl.fold (fun k v acc -> (k, v) :: acc) tbl []
   |> List.sort (fun (a, _) (b, _) -> String.compare a b)
 

--- a/lib/keeper/keeper_wake_telemetry.ml
+++ b/lib/keeper/keeper_wake_telemetry.ml
@@ -1,5 +1,4 @@
-(** Pure byte-size and role-count estimation for keeper wake-time
-    payload telemetry.
+(** Pure byte-size and role-count observation for keeper wake-time payloads.
 
     Extracted from [Keeper_agent_run] so the arithmetic is unit-testable
     without standing up a live keeper. The functions here operate purely
@@ -11,16 +10,14 @@
     Invariant: [result.message_count =
       List.fold_left (fun a (_, n) -> a + n) 0 result.role_counts].
     Both include the pending user turn that OAS will synthesize from
-    [~goal], so downstream p95 analysis matches the wire-level view
-    the LLM actually receives. *)
+    [~goal_blocks] when present, or [~goal] otherwise. *)
 
 module Canonical_tool = Agent_sdk.Canonical_tool
 
 type sizes = {
   system_prompt_bytes : int;
-  tool_defs_bytes : int;
-  messages_bytes : int;
-  approx_body_bytes : int;
+  tool_schema_json_bytes : int;
+  message_content_bytes : int;
   message_count : int;
   role_counts : (string * int) list;
   tool_count : int;
@@ -57,12 +54,12 @@ let bytes_of_content_block (block : Agent_sdk.Types.content_block) : int =
       | Agent_sdk.Types.Document { data; _ }
       | Agent_sdk.Types.Audio { data; _ } -> String.length data))
 
-let bytes_of_message (m : Agent_sdk.Types.message) : int =
+let bytes_of_message_content (m : Agent_sdk.Types.message) : int =
   List.fold_left
     (fun acc b -> acc + bytes_of_content_block b)
     0 m.content
 
-let estimate_tool_defs_bytes (tools : Agent_sdk.Tool.t list) : int =
+let bytes_of_tool_schema_json (tools : Agent_sdk.Tool.t list) : int =
   List.fold_left
     (fun acc t ->
       acc
@@ -83,8 +80,9 @@ let role_counts_with_pending_user
       let cur = Hashtbl.find_opt tbl key |> Option.value ~default:0 in
       Hashtbl.replace tbl key (cur + 1))
     history_messages;
-  let cur = Hashtbl.find_opt tbl "user" |> Option.value ~default:0 in
-  Hashtbl.replace tbl "user" (cur + 1);
+  let user_key = role_key Agent_sdk.Types.User in
+  let cur = Hashtbl.find_opt tbl user_key |> Option.value ~default:0 in
+  Hashtbl.replace tbl user_key (cur + 1);
   Hashtbl.fold (fun k v acc -> (k, v) :: acc) tbl []
   |> List.sort (fun (a, _) (b, _) -> String.compare a b)
 
@@ -92,26 +90,33 @@ let compute_sizes
     ~(system_prompt : string)
     ~(tools : Agent_sdk.Tool.t list)
     ~(history_messages : Agent_sdk.Types.message list)
-    ~(user_message : string) : sizes =
+    ?user_blocks
+    ~(user_message : string)
+    () : sizes =
   let system_prompt_bytes = String.length system_prompt in
-  let tool_defs_bytes = estimate_tool_defs_bytes tools in
-  let history_bytes =
+  let tool_schema_json_bytes = bytes_of_tool_schema_json tools in
+  let history_content_bytes =
     List.fold_left
-      (fun acc m -> acc + bytes_of_message m)
+      (fun acc m -> acc + bytes_of_message_content m)
       0 history_messages
   in
-  let user_message_bytes = String.length user_message in
-  let messages_bytes = history_bytes + user_message_bytes in
-  let approx_body_bytes =
-    system_prompt_bytes + tool_defs_bytes + messages_bytes
+  let pending_user_blocks =
+    match user_blocks with
+    | Some blocks -> blocks
+    | None -> [ Agent_sdk.Types.Text user_message ]
   in
+  let pending_user_content_bytes =
+    List.fold_left
+      (fun acc block -> acc + bytes_of_content_block block)
+      0 pending_user_blocks
+  in
+  let message_content_bytes = history_content_bytes + pending_user_content_bytes in
   let role_counts = role_counts_with_pending_user history_messages in
   let message_count = List.length history_messages + 1 in
   {
     system_prompt_bytes;
-    tool_defs_bytes;
-    messages_bytes;
-    approx_body_bytes;
+    tool_schema_json_bytes;
+    message_content_bytes;
     message_count;
     role_counts;
     tool_count = List.length tools;

--- a/lib/keeper/keeper_wake_telemetry.mli
+++ b/lib/keeper/keeper_wake_telemetry.mli
@@ -1,12 +1,11 @@
-(** Pure byte-size and role-count estimation for keeper wake-time
-    payload telemetry. Unit-testable building block for
+(** Pure byte-size and role-count observation for keeper wake-time payloads.
+    Unit-testable building block for
     [Keeper_agent_run] telemetry hook. *)
 
 type sizes = {
   system_prompt_bytes : int;
-  tool_defs_bytes : int;
-  messages_bytes : int;
-  approx_body_bytes : int;
+  tool_schema_json_bytes : int;
+  message_content_bytes : int;
   message_count : int;
   role_counts : (string * int) list;
   tool_count : int;
@@ -16,23 +15,30 @@ val role_key : Agent_sdk.Types.role -> string
 
 val bytes_of_content_block : Agent_sdk.Types.content_block -> int
 
-val bytes_of_message : Agent_sdk.Types.message -> int
+val bytes_of_message_content : Agent_sdk.Types.message -> int
 
-val estimate_tool_defs_bytes : Agent_sdk.Tool.t list -> int
+val bytes_of_tool_schema_json : Agent_sdk.Tool.t list -> int
 
 val role_counts_with_pending_user :
   Agent_sdk.Types.message list -> (string * int) list
 
-(** Compute payload-size estimates and role distribution for a keeper
-    turn about to invoke [Keeper_turn_driver.run_named]. The result assumes OAS
-    will synthesize a new User message from [~user_message] and append
-    it after [~history_messages]; therefore [message_count] and
-    [role_counts] include that pending user turn.
+(** Compute exact component-content byte counts and role distribution for a keeper
+    turn about to invoke [Keeper_turn_driver.run_named]. OAS will synthesize the
+    pending User message from [~user_blocks] when present, otherwise from
+    [~user_message]; [message_count] and [role_counts] include that turn.
+
+    These are exact byte counts of the canonical component values MASC owns,
+    not an estimate of a provider-specific HTTP request body. In particular,
+    [message_content_bytes] excludes message role, name, and provider metadata;
+    [tool_schema_json_bytes] sums each canonical tool schema JSON value without
+    claiming provider request-array overhead.
 
     Invariant: [message_count = sum_of_role_counts result.role_counts]. *)
 val compute_sizes :
   system_prompt:string ->
   tools:Agent_sdk.Tool.t list ->
   history_messages:Agent_sdk.Types.message list ->
+  ?user_blocks:Agent_sdk.Types.content_block list ->
   user_message:string ->
+  unit ->
   sizes

--- a/scripts/wake_payload_stats.py
+++ b/scripts/wake_payload_stats.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""Summarize keeper wake-payload telemetry JSONL files.
+"""Summarize exact keeper wake-payload component observations.
 
-Phase 0 aggregator for the tiered-hydration redesign. Consumes records
-emitted by [Dashboard_harness_health.record_wake_payload] and prints
-per-keeper and overall distribution (p50, p95, max, mean) of the key
-payload-size fields in TSV.
+Consumes records emitted by [Dashboard_harness_health.record_wake_payload]
+and prints per-keeper and overall distributions (p50, p95, max, mean) of
+exact component byte counts and message/tool counts in TSV. Message bytes cover
+content blocks only; tool bytes cover canonical schema JSON values only.
 
 Usage:
     wake_payload_stats.py <path-to-jsonl> [<more> ...]
@@ -25,10 +25,9 @@ from typing import Iterable, List, Sequence
 
 
 NUMERIC_FIELDS = (
-    "approx_body_bytes",
     "system_prompt_bytes",
-    "tool_defs_bytes",
-    "messages_bytes",
+    "tool_schema_json_bytes",
+    "message_content_bytes",
     "message_count",
     "tool_count",
 )
@@ -113,7 +112,7 @@ def average_role_counts(records: List[dict]) -> dict[str, float]:
 
 def main(argv: List[str]) -> int:
     parser = argparse.ArgumentParser(
-        description="Summarize keeper wake-payload telemetry JSONL files.",
+        description="Summarize exact keeper wake-payload component observations.",
     )
     parser.add_argument(
         "paths",

--- a/test/test_dashboard_harness_health.ml
+++ b/test/test_dashboard_harness_health.ml
@@ -36,12 +36,10 @@ let record_wake_payload ~trace_id =
     ~keeper_name:"keeper-harness"
     ~trace_id
     ~turn_index:7
-    ~model_id:"provider/private-model"
     ~context_window:4096
-    ~approx_body_bytes:100
     ~system_prompt_bytes:10
-    ~tool_defs_bytes:20
-    ~messages_bytes:70
+    ~tool_schema_json_bytes:20
+    ~message_content_bytes:70
     ~message_count:3
     ~role_counts:[ "user", 1; "assistant", 2 ]
     ~tool_count:4
@@ -59,7 +57,9 @@ let test_wake_payload_store_round_trip () =
     check string "trace" "trace-round-trip" event.trace_id;
     check int "turn index" 7 event.turn_index;
     check int "context window" 4096 event.context_window;
-    check int "approx bytes" 100 event.approx_body_bytes;
+    check int "system prompt bytes" 10 event.system_prompt_bytes;
+    check int "tool schema JSON bytes" 20 event.tool_schema_json_bytes;
+    check int "message content bytes" 70 event.message_content_bytes;
     check int "tool count" 4 event.tool_count;
     check bool "compact flag" false event.has_compact_happened
   | events ->

--- a/test/test_keeper_global_shared_refs_atomic.ml
+++ b/test/test_keeper_global_shared_refs_atomic.ml
@@ -181,24 +181,22 @@ let test_keepalive_signal_callbacks () =
     { Keeper_keepalive_signal.f = (fun ~ctx:_ ~m:_ ~stop:_ -> None) };
   (* Wake payload. *)
   let wake_called = ref false in
-  Keeper_keepalive_signal.register_record_wake_payload (fun ~keeper_name:_ ~trace_id:_ ~turn_index:_ ~model_id:_ ~context_window:_ ~approx_body_bytes:_ ~system_prompt_bytes:_ ~tool_defs_bytes:_ ~messages_bytes:_ ~message_count:_ ~role_counts:_ ~tool_count:_ ~has_compact_happened:_ ->
+  Keeper_keepalive_signal.register_record_wake_payload (fun ~keeper_name:_ ~trace_id:_ ~turn_index:_ ~context_window:_ ~system_prompt_bytes:_ ~tool_schema_json_bytes:_ ~message_content_bytes:_ ~message_count:_ ~role_counts:_ ~tool_count:_ ~has_compact_happened:_ ->
     wake_called := true);
   Keeper_keepalive_signal.record_wake_payload
     ~keeper_name:"k"
     ~trace_id:"t"
     ~turn_index:0
-    ~model_id:"m"
     ~context_window:4096
-    ~approx_body_bytes:0
     ~system_prompt_bytes:0
-    ~tool_defs_bytes:0
-    ~messages_bytes:0
+    ~tool_schema_json_bytes:0
+    ~message_content_bytes:0
     ~message_count:0
     ~role_counts:[]
     ~tool_count:0
     ~has_compact_happened:false;
   check bool "wake payload callback invoked" true !wake_called;
-  Keeper_keepalive_signal.register_record_wake_payload (fun ~keeper_name:_ ~trace_id:_ ~turn_index:_ ~model_id:_ ~context_window:_ ~approx_body_bytes:_ ~system_prompt_bytes:_ ~tool_defs_bytes:_ ~messages_bytes:_ ~message_count:_ ~role_counts:_ ~tool_count:_ ~has_compact_happened:_ -> ());
+  Keeper_keepalive_signal.register_record_wake_payload (fun ~keeper_name:_ ~trace_id:_ ~turn_index:_ ~context_window:_ ~system_prompt_bytes:_ ~tool_schema_json_bytes:_ ~message_content_bytes:_ ~message_count:_ ~role_counts:_ ~tool_count:_ ~has_compact_happened:_ -> ());
   (* Tool skipped. *)
   let skipped = ref false in
   Keeper_keepalive_signal.register_record_tool_skipped (fun ~keeper_name:_ ~tool_name:_ ~reason_code:_ -> skipped := true);

--- a/test/test_keeper_wake_telemetry.ml
+++ b/test/test_keeper_wake_telemetry.ml
@@ -39,7 +39,7 @@ let sum_counts counts =
 
 let test_text_only_message () =
   let m = text_msg Types.User "hello" in
-  check int "text length only" 5 (WT.bytes_of_message m)
+  check int "text length only" 5 (WT.bytes_of_message_content m)
 
 let test_tool_use_bytes () =
   let m = tool_use_msg "abc" "grep" (`Assoc [ ("q", `String "foo") ]) in
@@ -48,13 +48,13 @@ let test_tool_use_bytes () =
     + String.length "grep"
     + String.length (Yojson.Safe.to_string (`Assoc [ ("q", `String "foo") ]))
   in
-  check int "tool_use bytes" expected (WT.bytes_of_message m)
+  check int "tool_use bytes" expected (WT.bytes_of_message_content m)
 
 let test_tool_result_bytes () =
   let m = tool_result_msg ~tool_use_id:"abc" ~content:"hello world" in
   check int "tool_result bytes"
     (String.length "abc" + String.length "hello world")
-    (WT.bytes_of_message m)
+    (WT.bytes_of_message_content m)
 
 let test_thinking_and_redacted () =
   let m : Types.message =
@@ -72,7 +72,7 @@ let test_thinking_and_redacted () =
   in
   check int "thinking uses content; redacted uses literal length"
     (String.length "ponder" + String.length "redacted-blob")
-    (WT.bytes_of_message m)
+    (WT.bytes_of_message_content m)
 
 let test_role_key_mapping () =
   check string "system -> system" "system" (WT.role_key Types.System);
@@ -100,6 +100,7 @@ let test_role_counts_sum_matches_message_count () =
   let sizes =
     WT.compute_sizes ~system_prompt:"" ~tools:[] ~history_messages:history
       ~user_message:"third"
+      ()
   in
   check int "message_count equals sum of role_counts" sizes.message_count
     (sum_counts sizes.role_counts);
@@ -120,13 +121,34 @@ let test_compute_sizes_bytes_breakdown () =
   let sizes =
     WT.compute_sizes ~system_prompt:"sys" ~tools ~history_messages:history
       ~user_message:"CCCC" (* 4 bytes *)
+      ()
   in
   check int "system_prompt_bytes" 3 sizes.system_prompt_bytes;
-  check int "tool_defs_bytes (empty)" 0 sizes.tool_defs_bytes;
-  check int "messages_bytes (1 + 2 + 4)" 7 sizes.messages_bytes;
-  check int "approx_body_bytes = sp + tools + msgs" (3 + 0 + 7)
-    sizes.approx_body_bytes;
+  check int "tool_schema_json_bytes (empty)" 0 sizes.tool_schema_json_bytes;
+  check int "message_content_bytes (1 + 2 + 4)" 7 sizes.message_content_bytes;
   check int "tool_count" 0 sizes.tool_count
+
+let test_compute_sizes_uses_structured_pending_user_blocks () =
+  let user_blocks =
+    [ Types.Image
+        { media_type = "image/png"; data = "abc123"; source_type = Types.Base64 }
+    ; Types.Text "describe"
+    ]
+  in
+  let sizes =
+    WT.compute_sizes
+      ~system_prompt:""
+      ~tools:[]
+      ~history_messages:[]
+      ~user_blocks
+      ~user_message:"display-only fallback must not be counted"
+      ()
+  in
+  check int
+    "structured blocks replace the display-only fallback"
+    (String.length "abc123" + String.length "describe")
+    sizes.message_content_bytes;
+  check int "pending structured input is one User message" 1 sizes.message_count
 
 let test_compute_sizes_invariant_across_shapes () =
   (* Random-ish mixtures: every call must satisfy the invariant. *)
@@ -151,6 +173,7 @@ let test_compute_sizes_invariant_across_shapes () =
       let sizes =
         WT.compute_sizes ~system_prompt:"p" ~tools:[] ~history_messages:history
           ~user_message:"u"
+          ()
       in
       check int
         (Printf.sprintf
@@ -190,19 +213,17 @@ let test_phase0_record_always_emits_observation () =
   let observed = ref None in
   let restore () =
     Masc.Keeper_keepalive_signal.register_record_wake_payload
-      (fun ~keeper_name:_ ~trace_id:_ ~turn_index:_ ~model_id:_
-        ~context_window:_ ~approx_body_bytes:_ ~system_prompt_bytes:_
-        ~tool_defs_bytes:_ ~messages_bytes:_ ~message_count:_ ~role_counts:_
-        ~tool_count:_ ~has_compact_happened:_ -> ())
+      (fun ~keeper_name:_ ~trace_id:_ ~turn_index:_ ~context_window:_
+        ~system_prompt_bytes:_ ~tool_schema_json_bytes:_ ~message_content_bytes:_
+        ~message_count:_ ~role_counts:_ ~tool_count:_ ~has_compact_happened:_ -> ())
   in
   Fun.protect
     ~finally:restore
     (fun () ->
        Masc.Keeper_keepalive_signal.register_record_wake_payload
-         (fun ~keeper_name ~trace_id:_ ~turn_index:_ ~model_id:_
-           ~context_window:_ ~approx_body_bytes:_ ~system_prompt_bytes
-           ~tool_defs_bytes:_ ~messages_bytes:_ ~message_count ~role_counts:_
-           ~tool_count:_ ~has_compact_happened:_ ->
+         (fun ~keeper_name ~trace_id:_ ~turn_index:_ ~context_window:_
+           ~system_prompt_bytes ~tool_schema_json_bytes:_ ~message_content_bytes:_
+           ~message_count ~role_counts:_ ~tool_count:_ ~has_compact_happened:_ ->
             observed := Some (keeper_name, system_prompt_bytes, message_count));
        Masc.Keeper_agent_run_phase0_telemetry.record
          ~meta
@@ -212,7 +233,8 @@ let test_phase0_record_always_emits_observation () =
          ~user_message:"next"
          ~start_turn_count:3
          ~max_context:4096
-         ~pre_dispatch_compacted:false;
+         ~pre_dispatch_compacted:false
+         ();
        check
          (option (triple string int int))
          "phase-0 emits exact observation without an admission switch"
@@ -222,7 +244,7 @@ let test_phase0_record_always_emits_observation () =
 let () =
   run "Keeper_wake_telemetry"
     [
-      ( "bytes_of_message",
+      ( "bytes_of_message_content",
         [
           test_case "text-only content" `Quick test_text_only_message;
           test_case "tool_use serialization bytes" `Quick test_tool_use_bytes;
@@ -244,6 +266,8 @@ let () =
         [
           test_case "byte breakdown matches inputs" `Quick
             test_compute_sizes_bytes_breakdown;
+          test_case "structured pending User blocks win over fallback text" `Quick
+            test_compute_sizes_uses_structured_pending_user_blocks;
           test_case "role_counts sum matches message_count" `Quick
             test_role_counts_sum_matches_message_count;
           test_case "invariant holds across mixed content shapes" `Quick


### PR DESCRIPTION
## Summary

- Remove the fabricated aggregate request-size estimate and the hard-coded runtime model identity.
- Observe exact byte lengths for MASC-owned system prompt, canonical tool schema JSON, and message content values.
- Count structured pending user blocks, including multimodal data, instead of the display-only text fallback.
- Keep wake payload data observational only; it never admits, pauses, or stops a Keeper lane.

## Atomic stack contract

This is B1 of B2. B2 changes persisted-record decoding to the new exact schema and rejects malformed or legacy rows instead of silently decoding missing fields as zero. Merge B1 and B2 together; do not deploy B1 alone.

## Verification

- Focused producer object build passed for Keeper_wake_telemetry, Keeper_agent_run_phase0_telemetry, and Keeper_agent_run.
- OCaml format, parser, and git diff checks passed.
- Focused linked dashboard test remains blocked by unrelated OAS 0.212 deleted-API residues already isolated in sibling migration PRs; no full-build green is claimed.

Diff: 177 additions, 187 deletions, 364 total churn.