### PR TITLE
refactor(dashboard): reject malformed wake payload records

### DIFF
--- a/lib/dashboard/dashboard_harness_health.ml
+++ b/lib/dashboard/dashboard_harness_health.ml
@@ -296,18 +296,102 @@ let role_counts_to_json (counts : (string * int) list) : Yojson.Safe.t =
   `Assoc (List.map (fun (role, n) -> role, `Int n) counts)
 ;;
 
-let role_counts_of_json json : (string * int) list =
-  Safe_ops.json_assoc "role_counts" json
-  |> List.filter_map (fun (role, value) ->
-    match value with
-    | `Int n -> Some (role, n)
-    | `Intlit s -> Option.map (fun n -> role, n) (int_of_string_opt s)
-    | _ -> None)
+let ( let* ) result f = Result.bind result f
+
+let required_member fields key =
+  match List.assoc_opt key fields with
+  | Some value -> Ok value
+  | None -> Error (Printf.sprintf "missing required field %S" key)
 ;;
+
+let required_string fields key =
+  let* value = required_member fields key in
+  match value with
+  | `String value -> Ok value
+  | _ -> Error (Printf.sprintf "field %S must be a string" key)
+;;
+
+let required_non_empty_string fields key =
+  let* value = required_string fields key in
+  if String.equal value ""
+  then Error (Printf.sprintf "field %S must be non-empty" key)
+  else Ok value
+;;
+
+let int_json ~field = function
+  | `Int value -> Ok value
+  | `Intlit raw ->
+    (match int_of_string_opt raw with
+     | Some value -> Ok value
+     | None -> Error (Printf.sprintf "field %S has an invalid integer" field))
+  | _ -> Error (Printf.sprintf "field %S must be an integer" field)
+;;
+
+let required_int fields key =
+  let* value = required_member fields key in
+  int_json ~field:key value
+;;
+
+let required_nonnegative_int fields key =
+  let* value = required_int fields key in
+  if value < 0
+  then Error (Printf.sprintf "field %S must be non-negative" key)
+  else Ok value
+;;
+
+let required_positive_int fields key =
+  let* value = required_int fields key in
+  if value <= 0
+  then Error (Printf.sprintf "field %S must be positive" key)
+  else Ok value
+;;
+
+let required_float fields key =
+  let* value = required_member fields key in
+  let* value =
+    match value with
+    | `Float value -> Ok value
+    | `Int value -> Ok (Float.of_int value)
+    | `Intlit raw ->
+      (match float_of_string_opt raw with
+       | Some value -> Ok value
+       | None -> Error (Printf.sprintf "field %S has an invalid number" key))
+    | _ -> Error (Printf.sprintf "field %S must be a number" key)
+  in
+  if Float.is_finite value
+  then Ok value
+  else Error (Printf.sprintf "field %S must be finite" key)
+;;
+
+let required_bool fields key =
+  let* value = required_member fields key in
+  match value with
+  | `Bool value -> Ok value
+  | _ -> Error (Printf.sprintf "field %S must be a boolean" key)
+;;
+
+let required_role_counts fields =
+  let* value = required_member fields "role_counts" in
+  match value with
+  | `Assoc counts ->
+    List.fold_left
+      (fun result (role, value) ->
+         let* counts = result in
+         let* count = int_json ~field:("role_counts." ^ role) value in
+         if count < 0
+         then Error (Printf.sprintf "field %S must be non-negative" ("role_counts." ^ role))
+         else Ok ((role, count) :: counts))
+      (Ok [])
+      counts
+    |> Result.map List.rev
+  | _ -> Error "field \"role_counts\" must be an object of integer counts"
+;;
+
+let wake_payload_record_type = "wake_payload"
 
 let wake_payload_record_json (event : wake_payload_event) =
   `Assoc
-    [ "record_type", `String "wake_payload"
+    [ "record_type", `String wake_payload_record_type
     ; "timestamp", `Float event.timestamp
     ; "keeper_name", `String event.keeper_name
     ; "trace_id", `String event.trace_id
@@ -341,31 +425,68 @@ let wake_payload_event_json (event : wake_payload_event) =
 ;;
 
 let wake_payload_event_of_json json =
-  let record_type = string_field json "record_type" in
-  if record_type <> "" && not (String.equal record_type "wake_payload")
-  then None
-  else
-    Some
-      { timestamp = Safe_ops.json_float ~default:0.0 "timestamp" json
-      ; keeper_name = string_field json "keeper_name"
-      ; trace_id = string_field json "trace_id"
-      ; turn_index = Safe_ops.json_int ~default:0 "turn_index" json
-      ; context_window =
-          Safe_ops.json_int
-            ~default:Runtime_constants.fallback_context_window
-            "context_window"
-            json
-      ; system_prompt_bytes = Safe_ops.json_int ~default:0 "system_prompt_bytes" json
-      ; tool_schema_json_bytes =
-          Safe_ops.json_int ~default:0 "tool_schema_json_bytes" json
-      ; message_content_bytes =
-          Safe_ops.json_int ~default:0 "message_content_bytes" json
-      ; message_count = Safe_ops.json_int ~default:0 "message_count" json
-      ; role_counts = role_counts_of_json json
-      ; tool_count = Safe_ops.json_int ~default:0 "tool_count" json
-      ; has_compact_happened =
-          Safe_ops.json_bool ~default:false "has_compact_happened" json
-      }
+  match json with
+  | `Assoc fields ->
+    let* record_type = required_string fields "record_type" in
+    if not (String.equal record_type wake_payload_record_type)
+    then Error (Printf.sprintf "unexpected record_type %S" record_type)
+    else
+      let* timestamp = required_float fields "timestamp" in
+      let* keeper_name = required_non_empty_string fields "keeper_name" in
+      let* trace_id = required_non_empty_string fields "trace_id" in
+      let* turn_index = required_nonnegative_int fields "turn_index" in
+      let* context_window = required_positive_int fields "context_window" in
+      let* system_prompt_bytes = required_nonnegative_int fields "system_prompt_bytes" in
+      let* tool_schema_json_bytes =
+        required_nonnegative_int fields "tool_schema_json_bytes"
+      in
+      let* message_content_bytes =
+        required_nonnegative_int fields "message_content_bytes"
+      in
+      let* message_count = required_positive_int fields "message_count" in
+      let* role_counts = required_role_counts fields in
+      let* () =
+        let role_count_sum =
+          List.fold_left (fun sum (_, count) -> sum + count) 0 role_counts
+        in
+        if role_count_sum = message_count
+        then Ok ()
+        else
+          Error
+            (Printf.sprintf
+               "role_counts sum %d does not equal message_count %d"
+               role_count_sum
+               message_count)
+      in
+      let* tool_count = required_nonnegative_int fields "tool_count" in
+      let* has_compact_happened = required_bool fields "has_compact_happened" in
+      Ok
+        { timestamp
+        ; keeper_name
+        ; trace_id
+        ; turn_index
+        ; context_window
+        ; system_prompt_bytes
+        ; tool_schema_json_bytes
+        ; message_content_bytes
+        ; message_count
+        ; role_counts
+        ; tool_count
+        ; has_compact_happened
+        }
+  | _ -> Error "wake-payload record must be a JSON object"
+;;
+
+let wake_payload_record_identity json =
+  match json with
+  | `Assoc fields ->
+    let string_or_missing key =
+      match List.assoc_opt key fields with
+      | Some (`String value) -> value
+      | _ -> "<missing>"
+    in
+    string_or_missing "keeper_name", string_or_missing "trace_id"
+  | _ -> "<missing>", "<missing>"
 ;;
 
 let read_recent_verdicts ?since ?until ?(limit = max_recent_verdicts) ()
@@ -428,7 +549,18 @@ let read_pre_compact_events ?since ?until () =
 let read_wake_payload_events ?since ?until () =
   let records = read_store_records (get_wake_payload_store ()) ?since ?until () in
   let events : wake_payload_event list =
-    records |> List.filter_map wake_payload_event_of_json
+    records
+    |> List.filter_map (fun json ->
+      match wake_payload_event_of_json json with
+      | Ok event -> Some event
+      | Error detail ->
+        let keeper_name, trace_id = wake_payload_record_identity json in
+        Log.Harness.warn
+          "[wake_payload] rejected persisted record keeper=%s trace=%s: %s"
+          keeper_name
+          trace_id
+          detail;
+        None)
   in
   List.sort
     (fun (left : wake_payload_event) (right : wake_payload_event) ->

--- a/lib/dashboard/dashboard_harness_health.mli
+++ b/lib/dashboard/dashboard_harness_health.mli
@@ -164,7 +164,8 @@ val read_recent_verdicts_for_agents
 
 (** Returns the wake-payload samples within the
     [?since] / [?until] ISO-date window, sorted by
-    descending timestamp. *)
+    descending timestamp. Records missing required exact fields, carrying a
+    wrong JSON type, or containing malformed role counts are warned and rejected. *)
 val read_wake_payload_events
   :  ?since:string
   -> ?until:string

--- a/scripts/test_wake_payload_stats.py
+++ b/scripts/test_wake_payload_stats.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+import io
+import json
+import math
+import sys
+import unittest
+from contextlib import redirect_stderr
+
+import wake_payload_stats as stats
+
+
+def valid_record():
+    return json.loads(
+        '{"record_type":"wake_payload","timestamp":1.5,"keeper_name":"k","trace_id":"t","turn_index":1,"context_window":4096,"system_prompt_bytes":3,"tool_schema_json_bytes":4,"message_content_bytes":5,"message_count":2,"tool_count":1,"role_counts":{"user":1,"assistant":1},"has_compact_happened":false}'
+    )
+
+
+class WakePayloadStatsTest(unittest.TestCase):
+    def parse(self, records):
+        previous, warnings = sys.stdin, io.StringIO()
+        try:
+            sys.stdin = io.StringIO("".join(json.dumps(r) + "\n" for r in records))
+            with redirect_stderr(warnings):
+                parsed = list(stats.iter_records(["-"]))
+        finally:
+            sys.stdin = previous
+        return parsed, warnings.getvalue()
+
+    def test_invalid_exact_records_are_warned_and_skipped(self):
+        valid = valid_record()
+        legacy = {**valid, "tool_defs_bytes": 4, "messages_bytes": 5}
+        legacy.pop("tool_schema_json_bytes")
+        legacy.pop("message_content_bytes")
+        invalid = [
+            legacy,
+            {**valid, "system_prompt_bytes": "3"},
+            {**valid, "tool_count": True},
+            {**valid, "tool_count": -1},
+            {**valid, "role_counts": {"user": 1}},
+            {**valid, "timestamp": math.nan},
+            {**valid, "record_type": "other"},
+        ]
+        parsed, warnings = self.parse([valid, *invalid])
+        self.assertEqual([valid], parsed)
+        for expected in (
+            "tool_schema_json_bytes",
+            "must be an integer",
+            "non-negative",
+            "does not equal",
+            "finite",
+            "unexpected record_type",
+        ):
+            self.assertIn(expected, warnings)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/wake_payload_stats.py
+++ b/scripts/wake_payload_stats.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import statistics
 import sys
 from collections import defaultdict
@@ -31,6 +32,65 @@ NUMERIC_FIELDS = (
     "message_count",
     "tool_count",
 )
+REQUIRED_INTEGER_FIELDS = ("turn_index", "context_window", *NUMERIC_FIELDS)
+
+
+def warn_skip(path: str, lineno: int, detail: str) -> None:
+    print(f"[warn] {path}:{lineno} skipped ({detail})", file=sys.stderr)
+
+
+def validate_wake_payload_record(record: dict, path: str, lineno: int) -> bool:
+    for field in ("keeper_name", "trace_id"):
+        value = record.get(field)
+        if not isinstance(value, str) or not value:
+            warn_skip(path, lineno, f"{field} must be a non-empty string")
+            return False
+    timestamp = record.get("timestamp")
+    timestamp_is_finite_number = (
+        isinstance(timestamp, int) and not isinstance(timestamp, bool)
+    ) or (isinstance(timestamp, float) and math.isfinite(timestamp))
+    if not timestamp_is_finite_number:
+        warn_skip(path, lineno, "timestamp must be a finite number")
+        return False
+    for field in REQUIRED_INTEGER_FIELDS:
+        value = record.get(field)
+        if isinstance(value, bool) or not isinstance(value, int):
+            warn_skip(path, lineno, f"{field} must be an integer")
+            return False
+        if value < 0:
+            warn_skip(path, lineno, f"{field} must be non-negative")
+            return False
+    if record["context_window"] <= 0:
+        warn_skip(path, lineno, "context_window must be positive")
+        return False
+    if record["message_count"] <= 0:
+        warn_skip(path, lineno, "message_count must be positive")
+        return False
+    compacted = record.get("has_compact_happened")
+    if not isinstance(compacted, bool):
+        warn_skip(path, lineno, "has_compact_happened must be a boolean")
+        return False
+    role_counts = record.get("role_counts")
+    if not isinstance(role_counts, dict):
+        warn_skip(path, lineno, "role_counts must be an object")
+        return False
+    for role, count in role_counts.items():
+        if isinstance(count, bool) or not isinstance(count, int):
+            warn_skip(path, lineno, f"role_counts.{role} must be an integer")
+            return False
+        if count < 0:
+            warn_skip(path, lineno, f"role_counts.{role} must be non-negative")
+            return False
+    role_count_sum = sum(role_counts.values())
+    if role_count_sum != record["message_count"]:
+        warn_skip(
+            path,
+            lineno,
+            f"role_counts sum {role_count_sum} does not equal "
+            f"message_count {record['message_count']}",
+        )
+        return False
+    return True
 
 
 def iter_records(paths: Sequence[str]) -> Iterable[dict]:
@@ -59,10 +119,20 @@ def iter_records(paths: Sequence[str]) -> Iterable[dict]:
                     )
                     continue
                 if not isinstance(record, dict):
+                    warn_skip(path, lineno, "record must be a JSON object")
                     continue
-                if record.get("record_type") != "wake_payload":
+                record_type = record.get("record_type")
+                if record_type is None:
+                    warn_skip(path, lineno, "missing record_type")
                     continue
-                yield record
+                if not isinstance(record_type, str):
+                    warn_skip(path, lineno, "record_type must be a string")
+                    continue
+                if record_type != "wake_payload":
+                    warn_skip(path, lineno, f"unexpected record_type {record_type!r}")
+                    continue
+                if validate_wake_payload_record(record, path, lineno):
+                    yield record
         finally:
             if close:
                 source.close()
@@ -81,7 +151,7 @@ def summarize(name: str, records: List[dict]) -> List[str]:
     n = len(records)
     row = [name, str(n)]
     for field in NUMERIC_FIELDS:
-        vals = [int(r.get(field, 0)) for r in records]
+        vals = [r[field] for r in records]
         if not vals:
             row += ["0", "0", "0", "0"]
             continue
@@ -98,13 +168,8 @@ def average_role_counts(records: List[dict]) -> dict[str, float]:
     """Compute mean of each role's count across all records."""
     totals: dict[str, int] = defaultdict(int)
     for r in records:
-        counts = r.get("role_counts") or {}
-        if isinstance(counts, dict):
-            for role, n in counts.items():
-                try:
-                    totals[role] += int(n)
-                except (TypeError, ValueError):
-                    pass
+        for role, count in r["role_counts"].items():
+            totals[role] += count
     if not records:
         return {}
     return {role: total / len(records) for role, total in totals.items()}
@@ -133,8 +198,7 @@ def main(argv: List[str]) -> int:
 
     by_keeper: dict[str, List[dict]] = defaultdict(list)
     for r in records:
-        keeper = r.get("keeper_name") or "(unknown)"
-        by_keeper[keeper].append(r)
+        by_keeper[r["keeper_name"]].append(r)
 
     header = ["keeper", "n"]
     for field in NUMERIC_FIELDS:

--- a/test/test_dashboard_harness_health.ml
+++ b/test/test_dashboard_harness_health.ml
@@ -78,6 +78,55 @@ let test_reset_rebinds_wake_payload_store () =
   | [ event ] -> check string "trace after reset" "trace-second" event.trace_id
   | events -> failf "expected rebound store to contain one event, got %d" (List.length events)
 
+let test_wake_payload_reader_rejects_malformed_exact_records () =
+  reset_after @@ fun () ->
+  with_temp_dir "wake-payload-strict-reader" @@ fun dir ->
+  H.set_wake_payload_store_for_testing ~base_dir:dir;
+  let valid_fields =
+    [ "record_type", `String "wake_payload"
+    ; "timestamp", `Float 1.0
+    ; "keeper_name", `String "keeper-harness"
+    ; "trace_id", `String "trace-strict-reader"
+    ; "turn_index", `Int 7
+    ; "context_window", `Int 4096
+    ; "system_prompt_bytes", `Int 10
+    ; "tool_schema_json_bytes", `Int 20
+    ; "message_content_bytes", `Int 70
+    ; "message_count", `Int 3
+    ; "role_counts", `Assoc [ "user", `Int 1; "assistant", `Int 2 ]
+    ; "tool_count", `Int 4
+    ; "has_compact_happened", `Bool false
+    ]
+  in
+  let replace key value fields =
+    (key, value) :: List.remove_assoc key fields
+  in
+  let legacy_fields =
+    valid_fields
+    |> List.remove_assoc "tool_schema_json_bytes"
+    |> List.remove_assoc "message_content_bytes"
+    |> fun fields -> ("tool_defs_bytes", `Int 20) :: ("messages_bytes", `Int 70) :: fields
+  in
+  let malformed_records =
+    [ `Assoc legacy_fields
+    ; `Assoc (replace "system_prompt_bytes" (`String "10") valid_fields)
+    ; `Assoc (replace "tool_count" (`Int (-1)) valid_fields)
+    ; `Assoc (replace "role_counts" (`Assoc [ "user", `Int 1 ]) valid_fields)
+    ; `Assoc
+        (replace
+           "role_counts"
+           (`Assoc [ "user", `String "1" ])
+           valid_fields)
+    ]
+  in
+  List.iter
+    (Dated_jsonl.append (H.get_wake_payload_store ()))
+    malformed_records;
+  check int
+    "legacy, wrong numeric type, and partial role counts are rejected"
+    0
+    (List.length (H.read_wake_payload_events ()))
+
 let test_pre_compact_store_setter_records_event () =
   reset_after @@ fun () ->
   with_temp_dir "pre-compact-store" @@ fun dir ->
@@ -112,6 +161,8 @@ let () =
           test_case "wake payload round trip" `Quick test_wake_payload_store_round_trip;
           test_case "wake payload reset rebinds store" `Quick
             test_reset_rebinds_wake_payload_store;
+          test_case "malformed exact records are rejected" `Quick
+            test_wake_payload_reader_rejects_malformed_exact_records;
           test_case "pre-compact setter records event" `Quick
             test_pre_compact_store_setter_records_event;
         ] );


### PR DESCRIPTION
## Summary

- Decode persisted wake-payload rows through one required typed contract instead of defaulting absent or invalid values to zero.
- Reject and warn on legacy fields, missing fields, wrong types, negative counts, non-finite timestamps, role-count mismatches, boolean integers, and unexpected record types.
- Apply the same contract in the Python statistics reader; invalid rows are warned and skipped rather than coerced.
- Add OCaml and Python regressions for valid and malformed records.

## Atomic stack contract

This is B2 of B2 and is based directly on B1. B1 changes the producer schema; B2 changes every reader. Merge both together so no persisted row is silently reinterpreted.

## Verification

- python3 scripts/test_wake_payload_stats.py: passed.
- python3 -m unittest discover -s scripts -p test_wake_payload_stats.py: passed.
- ruff check and pyright for both Python files: passed with zero diagnostics.
- OCaml format, parser, and git diff checks passed.
- Focused linked dashboard test remains blocked by unrelated OAS 0.212 deleted-API residues already isolated in sibling migration PRs; no full-build green is claimed.

Diff: 351 additions, 46 deletions, 397 total churn.