### PR TITLE
refactor(keeper): make compaction decision trigger authoritative

### DIFF
--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -117,7 +117,7 @@ let compact_for_request_typed
       ~(meta : keeper_meta)
       ~(trigger : Compaction_trigger.t)
       (ctx : working_context)
-  : working_context * Compaction_trigger.t option * compaction_decision
+  : working_context * compaction_decision
   =
   let source_messages = messages_of_context ctx in
   let reject reason detail =
@@ -163,7 +163,7 @@ let compact_for_request_typed
                     ~messages:source_messages))))
   in
   match candidate with
-  | Error reason -> ctx, None, Rejected (trigger, reason)
+  | Error reason -> ctx, Rejected (trigger, reason)
   | Ok candidate ->
     let messages, pair_repair_stats =
       Keeper_context_core.repair_broken_tool_call_pairs_with_stats candidate
@@ -179,7 +179,7 @@ let compact_for_request_typed
       Log.Keeper.warn
         ~keeper_name:meta.name
         "context compaction rejected: plan produced no structural checkpoint change";
-      ctx, None, Rejected (trigger, Structural_noop))
+      ctx, Rejected (trigger, Structural_noop))
     else (
     let tool_use_sample_json =
       List.map
@@ -216,5 +216,5 @@ let compact_for_request_typed
                   ] )
             ])
       (Printf.sprintf "context compaction prepared keeper=%s" meta.name);
-    compacted_ctx, Some trigger, Prepared trigger)
+    compacted_ctx, Prepared trigger)
 ;;

--- a/lib/keeper/keeper_compact_policy.mli
+++ b/lib/keeper/keeper_compact_policy.mli
@@ -31,17 +31,14 @@ val compaction_policy_of_keeper : Keeper_meta_contract.keeper_meta -> float * in
     request through a valid configured-LLM plan. Missing/invalid LLM output and the retired
     deterministic mode preserve the original messages exactly.
 
-    Return triple:
+    Return pair:
     - the (possibly compacted) working context;
-    - [Some trigger] only for a structurally changed [Prepared] candidate;
     - a typed decision tag describing the request outcome. *)
 val compact_for_request_typed
   :  meta:Keeper_meta_contract.keeper_meta
   -> trigger:Compaction_trigger.t
   -> Keeper_context_core.working_context
-  -> Keeper_context_core.working_context
-     * Compaction_trigger.t option
-     * compaction_decision
+  -> Keeper_context_core.working_context * compaction_decision
 
 type pre_compact_event = {
   timestamp : float;

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -689,11 +689,16 @@ let recover_latest_checkpoint_for_overflow_retry
         if turn_generation = meta.runtime.generation then meta
         else map_runtime (fun rt -> { rt with generation = turn_generation }) meta
       in
-      let compacted_ctx, trigger, base_decision =
+      let compacted_ctx, base_decision =
         Keeper_compact_policy.compact_for_request_typed
           ~meta:retry_meta
           ~trigger
           ctx
+      in
+      let trigger =
+        match base_decision with
+        | Keeper_compact_policy.Prepared trigger -> Some trigger
+        | _ -> None
       in
       let after_tokens = token_count compacted_ctx in
       let compaction_applied =

--- a/test/test_keeper_global_shared_refs_atomic.ml
+++ b/test/test_keeper_global_shared_refs_atomic.ml
@@ -116,13 +116,12 @@ let test_pre_compact_context_window_uses_working_context () =
          Keeper_context_runtime.append ctx
            (Agent_sdk.Types.user_msg "explicit compaction request")
        in
-       let _, trigger, decision =
+       let _, decision =
          Keeper_compact_policy.compact_for_request_typed
            ~meta:(compact_policy_meta ())
            ~trigger:Compaction_trigger.Manual
            ctx
        in
-       check bool "compaction triggered" true (Option.is_some trigger);
        check bool "decision applied" true
          (Keeper_compact_policy.compaction_decision_applied decision);
        check (option int) "pre-compact event uses ctx max_tokens"


### PR DESCRIPTION
## 변경

컴팩션 결정의 trigger를 단일 typed SSOT로 전달해 중복 재판단을 제거합니다.

## 검증

- focused object build, ocamlformat, git diff --check

## Stack

- base: codex/oas-0212-compaction-observation-hardcut-20260715
- atomic compaction foundation stack이며 아래에서 위 순서로 병합합니다.
- 이 slice만으로 provider overflow 자동 복구가 완성됐다고 주장하지 않습니다. 동일 Lane의 durable queue/wake/checkpoint receipt 연결은 후속 Q1-Q4입니다.