### PR TITLE
refactor(keeper): hard-cut compaction token payloads

### DIFF
--- a/lib/dashboard/dashboard_http_keeper_outcomes.ml
+++ b/lib/dashboard/dashboard_http_keeper_outcomes.ml
@@ -40,7 +40,7 @@ let compute_outcomes_rollup
   List.iter
     (fun (tr : Keeper_transition_audit.transition_record) ->
       match tr.selected_event with
-      | Keeper_state_machine.Compaction_completed _ -> incr succ_compactions
+      | Keeper_state_machine.Compaction_completed -> incr succ_compactions
       | Compaction_failed _ -> incr fail_compaction
       | Handoff_completed _ -> incr succ_handoffs
       | Handoff_failed _ -> incr fail_handoff

--- a/lib/keeper/keeper_context_runtime.ml
+++ b/lib/keeper/keeper_context_runtime.ml
@@ -94,9 +94,6 @@ type compaction_event = Keeper_post_turn.compaction_event = {
   failure_reason : string option;
   trigger : Compaction_trigger.t option;
   decision : Keeper_compact_policy.compaction_decision;
-  before_tokens : int;
-  after_tokens : int;
-  saved_tokens : int;
 }
 
 type post_turn_lifecycle = Keeper_post_turn.post_turn_lifecycle = {
@@ -210,59 +207,14 @@ let dispatch_keeper_phase_event
         event
         ~error:(Printexc.to_string exn)
 
-(* #9988 Option B follow-up: centralize [Compaction_completed] dispatch
-   so both emit paths (manual recovery in [keeper_tool_surface] and automatic
-   post-turn lifecycle) share the same outcome counter + warn log.
-
-   [masc_keeper_compaction_outcome_total{keeper,outcome}] splits into
-   [outcome=ok] (real savings) and [outcome=noop] (before==after or
-   after>before).  The FSM (#9993) already refuses to clear
-   [context_overflow] in the noop branch; the counter exposes the
-   surface so dashboards/Grafana can alert on rising noop rate —
-   the operational signal for "reducer has nothing to strip, switch
-   profile or hand off". *)
-let compaction_outcome_metric = "masc_keeper_compaction_outcome_total"
-
-let () =
-  Otel_metric_store.register_counter
-    ~name:compaction_outcome_metric
-    ~help:
-      "Total Compaction_completed dispatches classified by token \
-       savings. Labels: keeper, outcome (ok = saved_tokens > 0, \
-       noop = before == after or after > before). Rising noop \
-       rate is the operational signal for \"reducer has nothing \
-       to strip, switch profile or hand off\" (#9988)."
-    ()
-
-(* Observability-only: bump the outcome counter and log the warn
-   when saved_tokens <= 0.  Split from [dispatch_compaction_completed]
-   so unit tests can verify classification without needing a full
-   [Workspace.config] / [Keeper_registry] setup. *)
-let record_compaction_outcome ~keeper_name ~before_tokens ~after_tokens =
-  let saved_tokens = before_tokens - after_tokens in
-  let outcome = if saved_tokens > 0 then "ok" else "noop" in
-  Otel_metric_store.inc_counter compaction_outcome_metric
-    ~labels:[ ("keeper", keeper_name); ("outcome", outcome) ] ();
-  if saved_tokens <= 0 then
-    Log.Keeper.warn
-      "#9988 compaction_completed but saved_tokens=%d \
-       (before=%d after=%d) keeper=%s — context_overflow will stay set \
-       (FSM noop branch).  If this repeats, switch to a stronger \
-       compaction profile or escalate to operator."
-      saved_tokens before_tokens after_tokens keeper_name
-
 let dispatch_compaction_completed
     ~(config : Workspace.config)
     ~origin
-    ~keeper_name
-    ~before_tokens
-    ~after_tokens =
-  record_compaction_outcome ~keeper_name ~before_tokens ~after_tokens;
+    ~keeper_name =
   Otel_metric_store.inc_counter Keeper_metrics.(to_string FsmEdgeTransitions)
     ~labels:[("edge", "kmc_to_ksm_compact_completed")] ();
   dispatch_keeper_phase_event ~config ~origin ~keeper_name
-    (Keeper_state_machine.Compaction_completed
-       { before_tokens; after_tokens })
+    Keeper_state_machine.Compaction_completed
 
 let dispatch_post_turn_lifecycle_events
     ~(config : Workspace.config)
@@ -296,8 +248,6 @@ let dispatch_post_turn_lifecycle_events
         ~config
         ~origin:Keeper_registry.Post_turn_lifecycle
         ~keeper_name
-        ~before_tokens:lifecycle.compaction.before_tokens
-        ~after_tokens:lifecycle.compaction.after_tokens
     end
     else
       dispatch_keeper_phase_event

--- a/lib/keeper/keeper_context_runtime.mli
+++ b/lib/keeper/keeper_context_runtime.mli
@@ -84,9 +84,6 @@ type compaction_event =
   ; failure_reason : string option
   ; trigger : Compaction_trigger.t option
   ; decision : Keeper_compact_policy.compaction_decision
-  ; before_tokens : int
-  ; after_tokens : int
-  ; saved_tokens : int
   }
 
 type post_turn_lifecycle =
@@ -165,41 +162,12 @@ val dispatch_keeper_phase_event
   -> Keeper_state_machine.event
   -> unit
 
-(** Canonical metric name for the compaction outcome counter.
-
-    Labels: [("keeper", <name>); ("outcome", "ok" | "noop")].
-    Exported so tests can pin the name without hard-coding a string
-    literal.  #9988. *)
-val compaction_outcome_metric : string
-
-(** [record_compaction_outcome ~keeper_name ~before_tokens ~after_tokens]
-    emits the outcome counter and (for [saved_tokens <= 0]) a warn log,
-    without dispatching an FSM event.  Exposed for unit tests and for
-    callers that need the observability signal before/after a dispatch.  *)
-val record_compaction_outcome
-  :  keeper_name:string
-  -> before_tokens:int
-  -> after_tokens:int
-  -> unit
-
-(** [dispatch_compaction_completed ~config ~keeper_name ~before_tokens
-    ~after_tokens] dispatches a [Compaction_completed] phase event and
-    updates observability in one place.
-
-    Emits [compaction_outcome_metric] labelled with [outcome=ok] when
-    [after_tokens < before_tokens] and [outcome=noop] otherwise.  A
-    [noop] outcome also logs a warning — the FSM (#9988) keeps
-    [context_overflow] set in this case, so operators need the signal
-    to escalate profile / alert.
-
-    Explicit compaction completion paths funnel through this helper to keep
-    observability coherent. *)
+(** Dispatch [Compaction_completed] only after the prepared checkpoint has
+    been durably saved. *)
 val dispatch_compaction_completed
   :  config:Workspace.config
   -> origin:Keeper_registry.lifecycle_event_origin
   -> keeper_name:string
-  -> before_tokens:int
-  -> after_tokens:int
   -> unit
 
 val dispatch_post_turn_lifecycle_events

--- a/lib/keeper/keeper_guard.ml
+++ b/lib/keeper/keeper_guard.ml
@@ -18,7 +18,7 @@ let event_priority = function
   | Context_measured _ -> 5
   | Heartbeat_ok -> 10
   | Turn_succeeded -> 10
-  | Compaction_completed _ -> 10
+  | Compaction_completed -> 10
   | Compaction_failed _ -> 10
   | Handoff_completed _ -> 10
   | Handoff_failed _ -> 10

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -54,9 +54,6 @@ type compaction_event = {
   failure_reason : string option;
   trigger : Compaction_trigger.t option;
   decision : Keeper_compact_policy.compaction_decision;
-  before_tokens : int;
-  after_tokens : int;
-  saved_tokens : int;
 }
 
 type post_turn_lifecycle = {
@@ -445,9 +442,6 @@ let apply_post_turn_lifecycle_with_resilience_handles
             failure_reason = None;
             trigger = None;
             decision = no_checkpoint_decision;
-            before_tokens = 0;
-            after_tokens = 0;
-            saved_tokens = 0;
           };
         turn_generation = meta.runtime.generation;
         context_ratio = 0.0;
@@ -472,7 +466,6 @@ let apply_post_turn_lifecycle_with_resilience_handles
             meta
       in
       let decision = Keeper_compact_policy.Not_requested in
-      let observed_tokens = token_count ctx in
       let meta_after_compaction =
         map_runtime
           (fun rt ->
@@ -504,9 +497,6 @@ let apply_post_turn_lifecycle_with_resilience_handles
             failure_reason = None;
             trigger = None;
             decision;
-            before_tokens = observed_tokens;
-            after_tokens = observed_tokens;
-            saved_tokens = 0;
           };
         turn_generation = current_generation;
         context_ratio = context_ratio ctx;
@@ -582,7 +572,6 @@ let recover_latest_checkpoint_for_overflow_retry
   match selected with
   | None -> None
   | Some (ctx, turn_generation) ->
-      let before_tokens = token_count ctx in
       let retry_meta =
         if turn_generation = meta.runtime.generation then meta
         else map_runtime (fun rt -> { rt with generation = turn_generation }) meta
@@ -593,7 +582,6 @@ let recover_latest_checkpoint_for_overflow_retry
           ~trigger
           ctx
       in
-      let after_tokens = token_count compacted_ctx in
       match base_decision with
       | Keeper_compact_policy.Prepared prepared_trigger ->
         (try
@@ -618,9 +606,6 @@ let recover_latest_checkpoint_for_overflow_retry
                     ; failure_reason = None
                     ; trigger = Some prepared_trigger
                     ; decision = Keeper_compact_policy.Applied prepared_trigger
-                    ; before_tokens
-                    ; after_tokens
-                    ; saved_tokens = before_tokens - after_tokens
                     }
                 ; turn_generation
                 }

--- a/lib/keeper/keeper_post_turn.mli
+++ b/lib/keeper/keeper_post_turn.mli
@@ -25,9 +25,6 @@ type compaction_event =
   ; failure_reason : string option
   ; trigger : Compaction_trigger.t option
   ; decision : Keeper_compact_policy.compaction_decision
-  ; before_tokens : int
-  ; after_tokens : int
-  ; saved_tokens : int
   }
 
 (** Combined post-turn outcome — compaction + rollover + per-turn context

--- a/lib/keeper/keeper_registry_event_validators.ml
+++ b/lib/keeper/keeper_registry_event_validators.ml
@@ -23,7 +23,7 @@ let paired_lifecycle_origin origin event =
                "paired lifecycle event requires origin=post_turn_lifecycle%s; got %s"
                (match event with
                 | Keeper_state_machine.Compaction_started
-                | Keeper_state_machine.Compaction_completed _
+                | Keeper_state_machine.Compaction_completed
                 | Keeper_state_machine.Compaction_failed _ -> " or origin=operator_compact"
                 | _ -> "")
                (lifecycle_event_origin_to_string origin)

--- a/lib/keeper/keeper_registry_types.ml
+++ b/lib/keeper/keeper_registry_types.ml
@@ -259,7 +259,7 @@ let lifecycle_event_origin_to_string = function
 
 let is_paired_lifecycle_event = function
   | Keeper_state_machine.Compaction_started
-  | Keeper_state_machine.Compaction_completed _
+  | Keeper_state_machine.Compaction_completed
   | Keeper_state_machine.Compaction_failed _
   | Keeper_state_machine.Handoff_started
   | Keeper_state_machine.Handoff_completed _
@@ -287,7 +287,7 @@ let origin_allows_paired_lifecycle_event origin event =
          handoff half-events flow through other origins. *)
       (match event with
        | Keeper_state_machine.Compaction_started
-       | Keeper_state_machine.Compaction_completed _
+       | Keeper_state_machine.Compaction_completed
        | Keeper_state_machine.Compaction_failed _ -> true
        | _ -> false)
 ;;
@@ -304,7 +304,7 @@ let compaction_stage_of_event entry event =
   | Keeper_state_machine.Compaction_started
   | Keeper_state_machine.Auto_compact_triggered
   | Keeper_state_machine.Operator_compact_requested -> Packed Compaction_compacting
-  | Keeper_state_machine.Compaction_completed _ -> Packed Compaction_done
+  | Keeper_state_machine.Compaction_completed -> Packed Compaction_done
   | Keeper_state_machine.Compaction_failed _ -> Packed Compaction_accumulating
   | _ -> entry.compaction_stage
 ;;

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -472,9 +472,7 @@ let keeper_compact_body ~(config : Workspace.config) args : tool_result =
         | Some recovery ->
           Keeper_context_runtime.dispatch_compaction_completed
             ~config ~keeper_name:name
-            ~origin:Keeper_registry.Operator_compact
-            ~before_tokens:recovery.compaction.before_tokens
-            ~after_tokens:recovery.compaction.after_tokens;
+            ~origin:Keeper_registry.Operator_compact;
           invalidate_status_cache name;
           Otel_metric_store.inc_counter Keeper_metrics.(to_string OperatorCompact)
             ~labels:[("keeper", name); ("result", Keeper_operator_compact_result.(to_label Ok))] ();
@@ -488,8 +486,11 @@ let keeper_compact_body ~(config : Workspace.config) args : tool_result =
                        (match Keeper_registry.get ~base_path:config.base_path name with
                         | Some entry -> Keeper_state_machine.phase_to_string entry.phase
                         | None -> "unknown") );
-                   ("before_tokens", `Int recovery.compaction.before_tokens);
-                ("after_tokens", `Int recovery.compaction.after_tokens);
+                   ("applied", `Bool recovery.compaction.applied);
+                   ( "trigger"
+                   , match recovery.compaction.trigger with
+                     | Some trigger -> Compaction_trigger.to_detail_json trigger
+                     | None -> `Null );
               ])
         | None ->
           (* Compaction infrastructure unavailable — emit [Compaction_failed]

--- a/lib/keeper/keeper_unified_metrics_broadcast.ml
+++ b/lib/keeper/keeper_unified_metrics_broadcast.ml
@@ -22,9 +22,6 @@ let broadcast_lifecycle_events ~(name : string)
              ("type", `String "keeper_compaction");
              ("name", `String name);
              ("generation", `Int turn_generation);
-             ("before_tokens", `Int compaction.before_tokens);
-             ("after_tokens", `Int compaction.after_tokens);
-             ("saved_tokens", `Int compaction.saved_tokens);
              ( "trigger",
                match compaction.trigger with
                | Some trigger -> `String (Compaction_trigger.to_label trigger)
@@ -73,4 +70,3 @@ let broadcast_lifecycle_events ~(name : string)
             (Printexc.to_string exn);
           Otel_metric_store.inc_counter Keeper_metrics.(to_string MetricsSseFailures) ~labels:[("kind", Keeper_metrics_sse_failure_kind.(to_label Handoff))] ())
   | _ -> ()
-

--- a/lib/keeper/keeper_unified_metrics_snapshot.ml
+++ b/lib/keeper/keeper_unified_metrics_snapshot.ml
@@ -125,9 +125,6 @@ let append_metrics_snapshot ~(config : Workspace.config) ~(meta : keeper_meta)
         ("message_count", `Int message_count);
         ("continuity_state", `Null);
         ("compacted", `Bool compaction.applied);
-        ("compaction_before_tokens", `Int compaction.before_tokens);
-        ("compaction_after_tokens", `Int compaction.after_tokens);
-        ("compaction_saved_tokens", `Int compaction.saved_tokens);
         ("compaction_trigger",
           match compaction.trigger with
           | Some trigger -> `String (Compaction_trigger.to_label trigger)
@@ -194,26 +191,4 @@ let append_metrics_snapshot ~(config : Workspace.config) ~(meta : keeper_meta)
       ]
   in
   Dated_jsonl.append metrics_store snapshot;
-  (* #9943: a compaction trigger that produced no token reduction
-     is invisible in [masc_keeper_compactions_total] (which counts
-     trigger fires).  Emit a dedicated counter here so dashboards
-     can alert on the noop rate — production audit (2026-04-24)
-     showed 956/972 = 98.4% of compaction snapshots were silent
-     noops.  Emit only when a trigger fired and before/after match
-     at a non-zero token count; the [trigger] label uses the
-     human-readable reason already present in the snapshot. *)
-  (match compaction.trigger with
-   | Some trigger
-     when compaction.before_tokens > 0
-       && compaction.before_tokens = compaction.after_tokens ->
-       (* Closed label set (5 values) keeps the metric cardinality bound; the
-          full numerical detail is preserved in the snapshot's
-          [compaction_trigger_detail] JSON above. *)
-       Otel_metric_store.inc_counter
-         Keeper_metrics.(to_string CompactionNoop)
-         ~labels:
-           [ ("keeper", meta.name)
-           ; ("trigger", Compaction_trigger.to_label trigger)
-           ]
-         ()
-   | _ -> ())
+  ()

--- a/lib/keeper_registry/keeper_state_machine.ml
+++ b/lib/keeper_registry/keeper_state_machine.ml
@@ -164,7 +164,7 @@ let update_conditions (c : conditions) (ev : event) : conditions =
   | Context_measured { context_actions; _ } ->
     { c with context_handoff_needed = context_actions.handoff }
   | Compaction_started -> { c with compaction_active = true }
-  | Compaction_completed _ ->
+  | Compaction_completed ->
     { c with compaction_active = false; context_overflow = false }
   | Compaction_failed _ ->
     (* Leave [context_overflow] set — the overflow has not been resolved.
@@ -265,7 +265,7 @@ let entry_actions_for ~prev_phase ~new_phase ~(event : event) : entry_action lis
          | Turn_failed _
          | Context_measured _
          | Compaction_started
-         | Compaction_completed _
+         | Compaction_completed
          | Compaction_failed _
          | Context_overflow_detected _
          | Handoff_started
@@ -299,7 +299,7 @@ let entry_actions_for ~prev_phase ~new_phase ~(event : event) : entry_action lis
          | Turn_failed _
          | Context_measured _
          | Compaction_started
-         | Compaction_completed _
+         | Compaction_completed
          | Compaction_failed _
          | Handoff_started
          | Handoff_completed _
@@ -328,7 +328,7 @@ let entry_actions_for ~prev_phase ~new_phase ~(event : event) : entry_action lis
       | Turn_failed _
       | Context_measured _
       | Compaction_started
-      | Compaction_completed _
+      | Compaction_completed
       | Compaction_failed _
       | Handoff_started
       | Handoff_completed _
@@ -378,7 +378,7 @@ let entry_actions_for ~prev_phase ~new_phase ~(event : event) : entry_action lis
        let detail =
          match event with
          | Operator_resume -> "operator request"
-         | Compaction_completed _ -> "auto-compact recovered"
+         | Compaction_completed -> "auto-compact recovered"
          | Fiber_terminated _ -> "fiber recovered"
          | Heartbeat_ok
          | Heartbeat_failed _

--- a/lib/keeper_registry/keeper_state_machine.mli
+++ b/lib/keeper_registry/keeper_state_machine.mli
@@ -147,8 +147,8 @@ type event =
   | Compaction_started
     (** Emit only through the registry lifecycle origin guard. See the
         paired lifecycle contract above. *)
-  | Compaction_completed of { before_tokens : int; after_tokens : int }
-    (** Must fire in the same turn as the matching [Compaction_started]. *)
+  | Compaction_completed
+    (** Must fire after the matching [Compaction_started] and durable save. *)
   | Compaction_failed of { reason : string }
     (** Must fire in the same turn as the matching [Compaction_started]. *)
   | Handoff_started

--- a/lib/keeper_registry/keeper_state_machine_json.ml
+++ b/lib/keeper_registry/keeper_state_machine_json.ml
@@ -55,10 +55,7 @@ let event_to_json (ev : event) : Yojson.Safe.t =
             ] )
       ]
   | Compaction_started -> obj "compaction_started" []
-  | Compaction_completed r ->
-    obj
-      "compaction_completed"
-      [ "before_tokens", `Int r.before_tokens; "after_tokens", `Int r.after_tokens ]
+  | Compaction_completed -> obj "compaction_completed" []
   | Compaction_failed r -> obj "compaction_failed" [ "reason", `String r.reason ]
   | Handoff_started -> obj "handoff_started" []
   | Handoff_completed r ->

--- a/lib/keeper_registry/keeper_state_machine_types.ml
+++ b/lib/keeper_registry/keeper_state_machine_types.ml
@@ -80,10 +80,7 @@ type event =
       ; context_actions : context_actions
       }
   | Compaction_started
-  | Compaction_completed of
-      { before_tokens : int
-      ; after_tokens : int
-      }
+  | Compaction_completed
   | Compaction_failed of { reason : string }
   | Handoff_started
   | Handoff_completed of
@@ -123,8 +120,7 @@ let event_to_string = function
   | Turn_failed r -> Printf.sprintf "turn_failed(%d)" r.consecutive
   | Context_measured r -> Printf.sprintf "context_measured(ratio=%.3f)" r.context_ratio
   | Compaction_started -> "compaction_started"
-  | Compaction_completed r ->
-    Printf.sprintf "compaction_completed(%d->%d)" r.before_tokens r.after_tokens
+  | Compaction_completed -> "compaction_completed"
   | Compaction_failed r -> Printf.sprintf "compaction_failed(%s)" r.reason
   | Handoff_started -> "handoff_started"
   | Handoff_completed r -> Printf.sprintf "handoff_completed(gen=%d)" r.generation

--- a/lib/keeper_registry/keeper_state_machine_types.mli
+++ b/lib/keeper_registry/keeper_state_machine_types.mli
@@ -47,7 +47,7 @@ type event =
       token_count : int; context_actions : context_actions;
     }
   | Compaction_started
-  | Compaction_completed of { before_tokens : int; after_tokens : int; }
+  | Compaction_completed
   | Compaction_failed of { reason : string; }
   | Handoff_started
   | Handoff_completed of { new_trace_id : string; generation : int; }


### PR DESCRIPTION
## 변경

추정 before/after/saved token 수를 lifecycle/state payload에서 제거하고 구조적 완료 사실만 남깁니다.

## 검증

- focused state/lifecycle object builds, ocamlformat, git diff --check

## Stack

- base: codex/oas-0212-compaction-durable-core-20260715
- atomic compaction foundation stack이며 아래에서 위 순서로 병합합니다.
- 이 slice만으로 provider overflow 자동 복구가 완성됐다고 주장하지 않습니다. 동일 Lane의 durable queue/wake/checkpoint receipt 연결은 후속 Q1-Q4입니다.