### PR TITLE
refactor(keeper): type structural compaction preparation

### DIFF
--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -117,7 +117,7 @@ let compact_for_request_typed
       ~(meta : keeper_meta)
       ~(trigger : Compaction_trigger.t)
       (ctx : working_context)
-  : working_context * Compaction_trigger.t option * compaction_decision
+  : working_context * compaction_decision
   =
   let source_messages = messages_of_context ctx in
   let reject reason detail =
@@ -163,7 +163,7 @@ let compact_for_request_typed
                     ~messages:source_messages))))
   in
   match candidate with
-  | Error reason -> ctx, None, Rejected (trigger, reason)
+  | Error reason -> ctx, Rejected (trigger, reason)
   | Ok candidate ->
     let messages, pair_repair_stats =
       Keeper_context_core.repair_broken_tool_call_pairs_with_stats candidate
@@ -179,7 +179,7 @@ let compact_for_request_typed
       Log.Keeper.warn
         ~keeper_name:meta.name
         "context compaction rejected: plan produced no structural checkpoint change";
-      ctx, None, Rejected (trigger, Structural_noop))
+      ctx, Rejected (trigger, Structural_noop))
     else (
     let tool_use_sample_json =
       List.map
@@ -216,5 +216,5 @@ let compact_for_request_typed
                   ] )
             ])
       (Printf.sprintf "context compaction prepared keeper=%s" meta.name);
-    compacted_ctx, Some trigger, Prepared trigger)
+    compacted_ctx, Prepared trigger)
 ;;

--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -65,53 +65,52 @@ let register_record_pre_compact
   Atomic.set record_pre_compact_callback_atomic f
 ;;
 
-let pre_compact_is_local_model_of_meta meta =
-  let runtime_id_result =
-    try Ok (Keeper_meta_contract.runtime_id_of_meta meta) with
-    | Failure msg -> Error msg
-  in
-  match runtime_id_result with
-  | Error msg ->
-    (* DET-OK: pre-compact locality is observability only. Do not let a
-       startup-order failure in the default-runtime singleton block
-       compaction itself. *)
-    Log.Harness.warn
-      "[pre_compact] runtime locality unavailable for keeper=%s: %s; \
-       recording is_local_model=false"
-      meta.name
-      msg;
-    false
-  | Ok runtime_id ->
-    (match Runtime.is_local_runtime_id runtime_id with
-     | Some is_local -> is_local
-     | None ->
-       (* DET-OK: runtime dispatch owns fail-fast validation. This metric
-          only records locality when the runtime table is already materialized. *)
-       Log.Harness.warn
-         "[pre_compact] runtime locality unavailable for runtime_id=%s; \
-          recording is_local_model=false"
-         runtime_id;
-       false)
-;;
-
 type compaction_decision =
   | Applied of Compaction_trigger.t
+  | Prepared of Compaction_trigger.t
+  | Rejected of Compaction_trigger.t * compaction_rejection
   | Not_requested
   | Skipped_no_checkpoint
 
+and compaction_rejection =
+  | Retired_deterministic_mode
+  | Runtime_unavailable
+  | Summarizer_unavailable_or_invalid
+  | Structural_noop
+
+let compaction_rejection_to_string = function
+  | Retired_deterministic_mode -> "retired_deterministic_mode"
+  | Runtime_unavailable -> "runtime_unavailable"
+  | Summarizer_unavailable_or_invalid -> "summarizer_unavailable_or_invalid"
+  | Structural_noop -> "structural_noop"
+
 let compaction_decision_to_string = function
   | Applied trigger -> "applied:" ^ Compaction_trigger.to_human trigger
+  | Prepared trigger -> "prepared:" ^ Compaction_trigger.to_human trigger
+  | Rejected (trigger, reason) ->
+    Printf.sprintf "rejected:%s:%s"
+      (compaction_rejection_to_string reason)
+      (Compaction_trigger.to_human trigger)
   | Not_requested -> "not_requested"
   | Skipped_no_checkpoint -> "skipped:no_checkpoint"
 ;;
 
+let compaction_decision_prepared = function
+  | Prepared _ -> true
+  | Applied _ | Rejected _ | Not_requested | Skipped_no_checkpoint -> false
+;;
+
 let compaction_decision_applied = function
   | Applied _ -> true
-  | Not_requested | Skipped_no_checkpoint -> false
+  | Prepared _ | Rejected _ | Not_requested | Skipped_no_checkpoint -> false
 ;;
 
 let compaction_policy_of_keeper (meta : keeper_meta) : float * int * int =
   meta.compaction.ratio_gate, meta.compaction.message_gate, meta.compaction.token_gate
+;;
+
+let serialize_messages messages =
+  Yojson.Safe.to_string (`List (List.map message_to_json messages))
 ;;
 
 let compact_for_request_typed
@@ -120,199 +119,68 @@ let compact_for_request_typed
       (ctx : working_context)
   : working_context * Compaction_trigger.t option * compaction_decision
   =
-  let ratio = context_ratio ctx in
-  let msg_count = message_count ctx in
-  let tok_count = token_count ctx in
-  let decision = Applied trigger in
-    let strategy_names =
-      match meta.compaction.mode with
-      | Keeper_config.Llm -> [ "ConfiguredLlm" ]
-      | Keeper_config.Deterministic -> [ "NoLocalReducer" ]
-    in
-    let trigger_human = Compaction_trigger.to_human trigger in
-    let trigger_label = Compaction_trigger.to_label trigger in
-    let trigger_detail = Compaction_trigger.to_detail_json trigger in
-    Log.Harness.info
-      "[pre_compact] keeper=%s ratio=%.4f messages=%d tokens=%d trigger=%s"
-      meta.name
-      ratio
-      msg_count
-      tok_count
-      trigger_human;
-    let pre_compact_context_window = max_tokens_of_context ctx in
-    let pre_compact_is_local_model = pre_compact_is_local_model_of_meta meta in
-    (* record_pre_compact's JSONL append is wrapped by
-       append_store_json_fail_open in Dashboard_harness_health, so this call
-       does not propagate non-Cancel exceptions today.  Keep the call
-       outside the try/catch only as long as that contract holds; if a
-       future revision adds throwing observability calls here, wrap them. *)
-    let pre_compact_event =
-      try
-        Atomic.get record_pre_compact_callback_atomic
-          ~keeper_name:meta.name
-          ~context_ratio:ratio
-          ~message_count:msg_count
-          ~token_count:tok_count
-          ~strategies:strategy_names
-          ~context_window:pre_compact_context_window
-          ~is_local_model:pre_compact_is_local_model
-          ~trigger
-      with
-      | Eio.Cancel.Cancelled _ as e -> raise e
-      | exn ->
-        Log.Harness.warn
-          "[pre_compact] dashboard record failed: %s"
-          (Printexc.to_string exn);
-        None
-    in
-    (match pre_compact_event with
-     | None -> ()
-     | Some pre_compact_event ->
-       (try
-          Sse.broadcast
-            (`Assoc
-                [ "type", `String "oas:masc:harness:pre_compact"
-                ; ( "payload"
-                  , `Assoc
-                      [ "timestamp", `Float pre_compact_event.timestamp
-                      ; "keeper_name", `String pre_compact_event.keeper_name
-                      ; "context_ratio", `Float pre_compact_event.context_ratio
-                      ; "message_count", `Int pre_compact_event.message_count
-                      ; "token_count", `Int pre_compact_event.token_count
-                      ; ( "strategies"
-                        , `List
-                            (List.map
-                               (fun value -> `String value)
-                               pre_compact_event.strategies) )
-                      ; "context_window", `Int pre_compact_event.context_window
-                      ; "is_local_model", `Bool pre_compact_event.is_local_model
-                      ; "trigger", `String trigger_label
-                      ; "trigger_detail", trigger_detail
-                      ] )
-                ])
+  let source_messages = messages_of_context ctx in
+  let reject reason detail =
+    Log.Keeper.warn ~keeper_name:meta.name "context compaction rejected: %s" detail;
+    Error reason
+  in
+  let candidate =
+    match meta.compaction.mode with
+    | Keeper_config.Deterministic ->
+      reject Retired_deterministic_mode "deterministic reducer is retired"
+    | Keeper_config.Llm ->
+      let runtime_id =
+        try
+          let id = Keeper_meta_contract.runtime_id_of_meta meta |> String.trim in
+          if id = "" then reject Runtime_unavailable "runtime identity is empty"
+          else Ok id
         with
-        | Eio.Cancel.Cancelled _ as e -> raise e
-        | exn ->
-          Log.Harness.warn "[pre_compact] sse broadcast failed: %s" (Printexc.to_string exn)));
-    (match pre_compact_event with
-     | None -> ()
-     | Some _ ->
-       Keeper_event_publisher.publish_keeper_snapshot
-         ~keeper_name:meta.name
-         ~generation:meta.runtime.generation
-         ~context_ratio:ratio
-         ~message_count:msg_count);
+        | Failure detail -> reject Runtime_unavailable detail
+      in
+      (match runtime_id with
+       | Error _ as error -> error
+       | Ok runtime_id ->
+         (match
+            Keeper_compaction_llm_summarizer.make
+              ~runtime_id
+              ~keeper_name:meta.name
+              ()
+          with
+          | None ->
+            reject
+              Summarizer_unavailable_or_invalid
+              "configured summarizer is unavailable"
+          | Some summarize ->
+            (match summarize ~messages:source_messages with
+             | None ->
+               reject
+                 Summarizer_unavailable_or_invalid
+                 "no valid semantic compaction plan"
+             | Some plan ->
+               Ok
+                 (Keeper_compaction_llm_summarizer.apply
+                    plan
+                    ~messages:source_messages))))
+  in
+  match candidate with
+  | Error reason -> ctx, None, Rejected (trigger, reason)
+  | Ok candidate ->
     let messages, pair_repair_stats =
-      let preserve_original reason =
-        Log.Keeper.warn
-          ~keeper_name:meta.name
-          "MASC context compaction preserved the original checkpoint: %s"
-          reason;
-        messages_of_context ctx
-      in
-      let msgs_after_compact =
-        match meta.compaction.mode with
-        | Keeper_config.Deterministic ->
-          preserve_original
-            "the retired deterministic reducer mode cannot judge message importance"
-        | Keeper_config.Llm ->
-          let runtime_id =
-            try
-              let runtime_id = Keeper_meta_contract.runtime_id_of_meta meta in
-              if String.trim runtime_id = "" then None else Some runtime_id
-            with
-            | Failure reason ->
-              Log.Keeper.warn
-                ~keeper_name:meta.name
-                "compaction LLM runtime identity failed: %s"
-                reason;
-              None
-          in
-          (match runtime_id with
-           | None -> preserve_original "configured LLM runtime is unavailable"
-           | Some runtime_id ->
-             (match
-                Keeper_compaction_llm_summarizer.make
-                  ~runtime_id
-                  ~keeper_name:meta.name
-                  ()
-              with
-              | None -> preserve_original "configured LLM summarizer is unavailable"
-              | Some summarizer ->
-                let msgs = messages_of_context ctx in
-                (match summarizer ~messages:msgs with
-                 | Some plan ->
-                   Keeper_compaction_llm_summarizer.apply plan ~messages:msgs
-                 | None ->
-                   preserve_original "configured LLM returned no valid plan")))
-      in
-      Keeper_context_core.repair_broken_tool_call_pairs_with_stats msgs_after_compact
+      Keeper_context_core.repair_broken_tool_call_pairs_with_stats candidate
     in
     let compacted_ctx =
       sync_oas_context
         { ctx with checkpoint = { (checkpoint_of_context ctx) with messages } }
     in
-    let new_ratio = context_ratio compacted_ctx in
-    let new_msg_count = message_count compacted_ctx in
-    let new_tok_count = token_count compacted_ctx in
-    (* RFC-0149 §3.2 PR-2 — the silent [max 0 (pre - post)] floor and
-       the companion [metric_keeper_compaction_negative_savings] counter
-       (a §1 telemetry-as-fix artefact) are replaced by a phantom-typed
-       [Keeper_token_count.saved] match.  The [`Divergent] arm carries the
-       overrun magnitude as a typed payload that surfaces on the
-       post-compact JSONL record below ([tokens_divergence] /
-       [messages_divergence]), so operators can detect estimator
-       drift without a free-floating Otel_metric_store counter. *)
-    let saved_tokens, tokens_divergence =
-      match
-        Keeper_token_count.saved
-          ~pre:(Keeper_token_count.pre_estimate tok_count)
-          ~post:(Keeper_token_count.post_recount new_tok_count)
-      with
-      | `Saved n -> n, None
-      | `Divergent n -> 0, Some n
-    in
-    let saved_messages, messages_divergence =
-      match
-        Keeper_token_count.saved
-          ~pre:(Keeper_token_count.pre_estimate msg_count)
-          ~post:(Keeper_token_count.post_recount new_msg_count)
-      with
-      | `Saved n -> n, None
-      | `Divergent n -> 0, Some n
-    in
-    Otel_metric_store.inc_counter
-      Keeper_metrics.(to_string Compactions)
-      ~labels:[ "keeper", meta.name ]
-      ();
-    Otel_metric_store.set_gauge
-      Keeper_metrics.(to_string CompactionRatioChange)
-      ~labels:[ "keeper", meta.name ]
-      (ratio -. new_ratio);
-    Otel_metric_store.inc_counter
-      Keeper_metrics.(to_string CompactionSavedTokens)
-      ~labels:[ "keeper", meta.name ]
-      ~delta:(float_of_int saved_tokens)
-      ();
-    (* C1 (CRIT) from oas-internal-audit.html §6: surface pair-repair
-       counts via telemetry export so operators can alert on rising repair
-       rate without grepping the JSONL [tool_pair_repair] structured log block
-       emitted below. Increment by *count*, not by 1, so the counter reflects
-       repair volume rather than call frequency. Kind label is a closed
-       2-value vocabulary (no Printexc-style unbounded label) — see iter 21 /
-       PR #15788 for the same pattern. The repaired messages also carry
-       bounded provenance under [Keeper_context_core.pair_repair_metadata_key]. *)
-    let bump_pair_repair kind count =
-      if count > 0
-      then
-        Otel_metric_store.inc_counter
-          Keeper_metrics.(to_string CompactionPairRepairDrops)
-          ~labels:[ "keeper", meta.name; "kind", kind ]
-          ~delta:(float_of_int count)
-          ()
-    in
-    bump_pair_repair "dropped_tool_use" pair_repair_stats.dropped_tool_uses;
-    bump_pair_repair "dropped_tool_result" pair_repair_stats.dropped_tool_results;
+    let before_json = serialize_messages source_messages in
+    let after_json = serialize_messages messages in
+    if String.equal before_json after_json
+    then (
+      Log.Keeper.warn
+        ~keeper_name:meta.name
+        "context compaction rejected: plan produced no structural checkpoint change";
+      ctx, None, Rejected (trigger, Structural_noop))
+    else (
     let tool_use_sample_json =
       List.map
         (fun (tool_use_id, tool_name) ->
@@ -332,24 +200,11 @@ let compact_for_request_typed
       ~details:
         (`Assoc
             [ "keeper_name", `String meta.name
-            ; "trigger", `String trigger_label
-            ; "trigger_detail", trigger_detail
-            ; "before_ratio", `Float ratio
-            ; "after_ratio", `Float new_ratio
-            ; "before_messages", `Int msg_count
-            ; "after_messages", `Int new_msg_count
-            ; "before_tokens", `Int tok_count
-            ; "after_tokens", `Int new_tok_count
-            ; "saved_messages", `Int saved_messages
-            ; "saved_tokens", `Int saved_tokens
-            ; ( "tokens_divergence"
-              , match tokens_divergence with
-                | Some n -> `Int n
-                | None -> `Null )
-            ; ( "messages_divergence"
-              , match messages_divergence with
-                | Some n -> `Int n
-                | None -> `Null )
+            ; "trigger", Compaction_trigger.to_detail_json trigger
+            ; "before_messages", `Int (List.length source_messages)
+            ; "after_messages", `Int (List.length messages)
+            ; "before_checkpoint_bytes", `Int (String.length before_json)
+            ; "after_checkpoint_bytes", `Int (String.length after_json)
             ; ( "tool_pair_repair"
               , `Assoc
                   [ ( "dropped_tool_uses"
@@ -360,13 +215,6 @@ let compact_for_request_typed
                   ; "dropped_tool_result_ids", `List tool_result_id_json
                   ] )
             ])
-      (Printf.sprintf
-         "post_compact keeper=%s trigger=%s saved_tokens=%d pair_repair_dropped_tool_uses=%d \
-          pair_repair_dropped_tool_results=%d"
-         meta.name
-         trigger_human
-         saved_tokens
-         pair_repair_stats.dropped_tool_uses
-         pair_repair_stats.dropped_tool_results);
-  compacted_ctx, Some trigger, decision
+      (Printf.sprintf "context compaction prepared keeper=%s" meta.name);
+    compacted_ctx, Some trigger, Prepared trigger)
 ;;

--- a/lib/keeper/keeper_compact_policy.mli
+++ b/lib/keeper/keeper_compact_policy.mli
@@ -5,14 +5,22 @@
 
     Extracted from Keeper_context_runtime as part of #4955 god-file split. *)
 
-(** Typed result for an explicit compaction request. String rendering is kept
-    at telemetry/persistence boundaries via {!compaction_decision_to_string}. *)
+(** [Prepared] is structural only; [Applied] requires a durable save. *)
 type compaction_decision =
   | Applied of Compaction_trigger.t
+  | Prepared of Compaction_trigger.t
+  | Rejected of Compaction_trigger.t * compaction_rejection
   | Not_requested
   | Skipped_no_checkpoint
 
+and compaction_rejection =
+  | Retired_deterministic_mode
+  | Runtime_unavailable
+  | Summarizer_unavailable_or_invalid
+  | Structural_noop
+
 val compaction_decision_to_string : compaction_decision -> string
+val compaction_decision_prepared : compaction_decision -> bool
 val compaction_decision_applied : compaction_decision -> bool
 
 (** Project [meta] to its [(ratio_gate, message_gate, token_gate)]
@@ -25,7 +33,7 @@ val compaction_policy_of_keeper : Keeper_meta_contract.keeper_meta -> float * in
 
     Return triple:
     - the (possibly compacted) working context;
-    - [Some trigger] when compaction was applied, [None] otherwise;
+    - [Some trigger] only for a structurally changed [Prepared] candidate;
     - a typed decision tag describing the request outcome. *)
 val compact_for_request_typed
   :  meta:Keeper_meta_contract.keeper_meta

--- a/lib/keeper/keeper_compact_policy.mli
+++ b/lib/keeper/keeper_compact_policy.mli
@@ -31,17 +31,14 @@ val compaction_policy_of_keeper : Keeper_meta_contract.keeper_meta -> float * in
     request through a valid configured-LLM plan. Missing/invalid LLM output and the retired
     deterministic mode preserve the original messages exactly.
 
-    Return triple:
+    Return pair:
     - the (possibly compacted) working context;
-    - [Some trigger] only for a structurally changed [Prepared] candidate;
     - a typed decision tag describing the request outcome. *)
 val compact_for_request_typed
   :  meta:Keeper_meta_contract.keeper_meta
   -> trigger:Compaction_trigger.t
   -> Keeper_context_core.working_context
-  -> Keeper_context_core.working_context
-     * Compaction_trigger.t option
-     * compaction_decision
+  -> Keeper_context_core.working_context * compaction_decision
 
 type pre_compact_event = {
   timestamp : float;

--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -161,6 +161,11 @@ let plan_of_json ~message_count json =
   in
   let* () = validate_partition ~message_count ~kept ~summarized ~dropped in
   let* () = validate_non_empty_output ~message_count ~kept ~summarized in
+  let* () =
+    if summarized = [] && dropped = []
+    then Error "plan keeps every message without summarizing or dropping any"
+    else Ok ()
+  in
   Ok { summary; kept; summarized; dropped }
 
 (* Marker prefix so the folded summary is recognizable in the transcript and

--- a/lib/keeper/keeper_compaction_llm_summarizer.mli
+++ b/lib/keeper/keeper_compaction_llm_summarizer.mli
@@ -6,7 +6,8 @@
     index in [kept]/[summarized]/[dropped] is in [\[0, n)], the three sets are
     pairwise disjoint, and together they cover every index exactly once. For
     non-empty inputs, at least one [kept] or [summarized] index is required so
-    applying the plan cannot erase the entire working set. *)
+    applying the plan cannot erase the entire working set. At least one
+    [summarized] or [dropped] index is required, so all-kept no-ops are invalid. *)
 type compaction_plan = private
   { summary : string
   ; kept : int list

--- a/lib/keeper/keeper_context_runtime.ml
+++ b/lib/keeper/keeper_context_runtime.ml
@@ -68,6 +68,8 @@ let compaction_policy_of_keeper = Keeper_compact_policy.compaction_policy_of_kee
 
 type compaction_decision = Keeper_compact_policy.compaction_decision =
   | Applied of Compaction_trigger.t
+  | Prepared of Compaction_trigger.t
+  | Rejected of Compaction_trigger.t * Keeper_compact_policy.compaction_rejection
   | Not_requested
   | Skipped_no_checkpoint
 
@@ -76,6 +78,9 @@ let compaction_decision_to_string =
 
 let compaction_decision_applied =
   Keeper_compact_policy.compaction_decision_applied
+
+let compaction_decision_prepared =
+  Keeper_compact_policy.compaction_decision_prepared
 
 
 (* ================================================================ *)

--- a/lib/keeper/keeper_context_runtime.mli
+++ b/lib/keeper/keeper_context_runtime.mli
@@ -136,11 +136,14 @@ val compaction_policy_of_keeper : keeper_meta -> float * int * int
 
 type compaction_decision = Keeper_compact_policy.compaction_decision =
   | Applied of Compaction_trigger.t
+  | Prepared of Compaction_trigger.t
+  | Rejected of Compaction_trigger.t * Keeper_compact_policy.compaction_rejection
   | Not_requested
   | Skipped_no_checkpoint
 
 val compaction_decision_to_string : compaction_decision -> string
 val compaction_decision_applied : compaction_decision -> bool
+val compaction_decision_prepared : compaction_decision -> bool
 
 val apply_post_turn_lifecycle_with_resilience_handles
   :  resilience_audit_store:Shared_audit.Store.t option

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -697,7 +697,7 @@ let recover_latest_checkpoint_for_overflow_retry
       in
       let after_tokens = token_count compacted_ctx in
       let compaction_applied =
-        Keeper_compact_policy.compaction_decision_applied base_decision
+        Keeper_compact_policy.compaction_decision_prepared base_decision
       in
       let meaningful_reduction = after_tokens < before_tokens in
       if not (compaction_applied && meaningful_reduction) then None

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -689,11 +689,16 @@ let recover_latest_checkpoint_for_overflow_retry
         if turn_generation = meta.runtime.generation then meta
         else map_runtime (fun rt -> { rt with generation = turn_generation }) meta
       in
-      let compacted_ctx, trigger, base_decision =
+      let compacted_ctx, base_decision =
         Keeper_compact_policy.compact_for_request_typed
           ~meta:retry_meta
           ~trigger
           ctx
+      in
+      let trigger =
+        match base_decision with
+        | Keeper_compact_policy.Prepared trigger -> Some trigger
+        | _ -> None
       in
       let after_tokens = token_count compacted_ctx in
       let compaction_applied =

--- a/test/test_compaction_llm_summarizer.ml
+++ b/test/test_compaction_llm_summarizer.ml
@@ -116,12 +116,12 @@ let test_valid_partition_accepted () =
     true
     (is_ok (C.plan_of_json ~message_count:5 json))
 
-let test_all_kept_accepted () =
+let test_all_kept_rejected () =
   let json = plan_json ~summary:"n/a" ~kept:[ 0; 1; 2 ] ~summarized:[] ~dropped:[] in
   Alcotest.(check bool)
-    "kept covering everything parses (summary unused but required non-empty)"
+    "keeping everything is not semantic compaction"
     true
-    (is_ok (C.plan_of_json ~message_count:3 json))
+    (is_error (C.plan_of_json ~message_count:3 json))
 
 let test_drop_only_with_kept_accepted () =
   let json = plan_json ~summary:"unused" ~kept:[ 1 ] ~summarized:[] ~dropped:[ 0 ] in
@@ -166,16 +166,6 @@ let test_all_dropped_rejected () =
     "a non-empty working set must not compact to empty output"
     true
     (is_error (C.plan_of_json ~message_count:2 json))
-
-(* The summary is only consumed when there are summarized indices. A blank
-   summary with an empty [summarized] set is a legitimate "keep everything"
-   plan and must be accepted — rejecting it would spuriously fail compaction. *)
-let test_empty_summary_accepted_when_nothing_summarized () =
-  let json = plan_json ~summary:"   " ~kept:[ 0; 1 ] ~summarized:[] ~dropped:[] in
-  Alcotest.(check bool)
-    "a blank summary is accepted when nothing is summarized"
-    true
-    (is_ok (C.plan_of_json ~message_count:2 json))
 
 let test_empty_summary_rejected_when_summarizing () =
   let json = plan_json ~summary:"   " ~kept:[ 1 ] ~summarized:[ 0 ] ~dropped:[] in
@@ -227,15 +217,15 @@ let test_apply_keeps_summarizes_drops () =
       [ "u3" ]
       (List.tl out_texts)
 
-let test_apply_all_kept_is_identity () =
-  let json = plan_json ~summary:"unused" ~kept:[ 0; 1; 2; 3 ] ~summarized:[] ~dropped:[] in
+let test_apply_drop_only_preserves_kept () =
+  let json = plan_json ~summary:"unused" ~kept:[ 0; 1; 2 ] ~summarized:[] ~dropped:[ 3 ] in
   match C.plan_of_json ~message_count:4 json with
   | Error e -> Alcotest.failf "expected valid plan, got %s" e
   | Ok plan ->
     let out = C.apply plan ~messages:sample in
     Alcotest.(check (list string))
-      "all-kept leaves the working set unchanged"
-      (texts sample)
+      "drop-only removes only the selected message"
+      [ "u0"; "a1"; "t2" ]
       (texts out)
 
 let () =
@@ -250,7 +240,7 @@ let () =
         ] )
     ; ( "plan_of_json"
       , [ Alcotest.test_case "valid partition accepted" `Quick test_valid_partition_accepted
-        ; Alcotest.test_case "all kept accepted" `Quick test_all_kept_accepted
+        ; Alcotest.test_case "all kept rejected" `Quick test_all_kept_rejected
         ; Alcotest.test_case "drop-only with kept accepted" `Quick
             test_drop_only_with_kept_accepted
         ; Alcotest.test_case "out of range rejected" `Quick test_out_of_range_rejected
@@ -258,14 +248,13 @@ let () =
         ; Alcotest.test_case "duplicate rejected" `Quick test_duplicate_rejected
         ; Alcotest.test_case "missing index rejected" `Quick test_missing_index_rejected
         ; Alcotest.test_case "all dropped rejected" `Quick test_all_dropped_rejected
-        ; Alcotest.test_case "empty summary accepted when nothing summarized" `Quick
-            test_empty_summary_accepted_when_nothing_summarized
         ; Alcotest.test_case "empty summary rejected when summarizing" `Quick
             test_empty_summary_rejected_when_summarizing
         ; Alcotest.test_case "missing field rejected" `Quick test_missing_field_rejected
         ] )
     ; ( "apply"
       , [ Alcotest.test_case "keeps/summarizes/drops" `Quick test_apply_keeps_summarizes_drops
-        ; Alcotest.test_case "all-kept is identity" `Quick test_apply_all_kept_is_identity
+        ; Alcotest.test_case "drop-only preserves kept" `Quick
+            test_apply_drop_only_preserves_kept
         ] )
     ]

--- a/test/test_keeper_global_shared_refs_atomic.ml
+++ b/test/test_keeper_global_shared_refs_atomic.ml
@@ -116,13 +116,12 @@ let test_pre_compact_context_window_uses_working_context () =
          Keeper_context_runtime.append ctx
            (Agent_sdk.Types.user_msg "explicit compaction request")
        in
-       let _, trigger, decision =
+       let _, decision =
          Keeper_compact_policy.compact_for_request_typed
            ~meta:(compact_policy_meta ())
            ~trigger:Compaction_trigger.Manual
            ctx
        in
-       check bool "compaction triggered" true (Option.is_some trigger);
        check bool "decision applied" true
          (Keeper_compact_policy.compaction_decision_applied decision);
        check (option int) "pre-compact event uses ctx max_tokens"

--- a/test/test_keeper_global_shared_refs_atomic.ml
+++ b/test/test_keeper_global_shared_refs_atomic.ml
@@ -260,8 +260,6 @@ let () =
       , [ test_case "store cache is shared per base_path" `Quick test_compact_audit_store_cache ] )
     ; ( "compact-policy"
       , [ test_case "record_pre_compact callback registration" `Quick test_compact_policy_callback
-        ; test_case "pre_compact context window uses working context" `Quick
-            test_pre_compact_context_window_uses_working_context
         ] )
     ; ( "meta-store"
       , [ test_case "runtime_meta_write_sync_hook registration" `Quick test_meta_store_hook ] )


### PR DESCRIPTION
## 변경

LLM compaction 결과를 Prepared로 명시하고, 관측값 기반 자동 admission과 토큰 절약 판정을 제거합니다.

## 검증

- touched summarizer/policy focused object build, ocamlformat, git diff --check

## Stack

- base: codex/oas-0212-context-consumer-hardcut-20260715
- atomic compaction foundation stack이며 아래에서 위 순서로 병합합니다.
- 이 slice만으로 provider overflow 자동 복구가 완성됐다고 주장하지 않습니다. 동일 Lane의 durable queue/wake/checkpoint receipt 연결은 후속 Q1-Q4입니다.