### PR TITLE
refactor(keeper): return typed compaction recovery errors

### DIFF
--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -593,14 +593,17 @@ let context_of_oas_checkpoint
   sync_oas_context
     { checkpoint; max_tokens }
 
-let save_oas_checkpoint
+let save_oas_checkpoint_classified
     ~(multimodal_policy : Keeper_types_profile.multimodal_policy)
     ~(keeper_name : string)
     ~(session : session_context)
     ~(agent_name : string)
     ~(ctx : working_context)
     ~(generation : int)
-  : (Agent_sdk.Checkpoint.t, string) result =
+  : ( Agent_sdk.Checkpoint.t * Keeper_checkpoint_store.save_oas_outcome
+    , string )
+    result
+  =
   let checkpoint_context = Agent_sdk.Context.copy ~eio:true (oas_context_of_context ctx) in
   Agent_sdk.Context.set_scoped checkpoint_context Agent_sdk.Context.Session
     checkpoint_generation_key (`Int generation);
@@ -635,8 +638,33 @@ let save_oas_checkpoint
       context = checkpoint_context;
     }
   in
-  match Keeper_checkpoint_store.save_oas ~session_dir:session.session_dir checkpoint with
-  | Ok () -> Ok checkpoint
+  match
+    Keeper_checkpoint_store.save_oas_classified
+      ~session_dir:session.session_dir
+      checkpoint
+  with
+  | Ok outcome -> Ok (checkpoint, outcome)
+  | Error e -> Error e
+
+let save_oas_checkpoint
+    ~multimodal_policy
+    ~keeper_name
+    ~session
+    ~agent_name
+    ~ctx
+    ~generation
+  =
+  match
+    save_oas_checkpoint_classified
+      ~multimodal_policy
+      ~keeper_name
+      ~session
+      ~agent_name
+      ~ctx
+      ~generation
+  with
+  | Ok (checkpoint, Saved _)
+  | Ok (checkpoint, Stale_noop _) -> Ok checkpoint
   | Error e -> Error e
 
 let checkpoint_generation (cp : Agent_sdk.Checkpoint.t) ~(fallback : int) : int =

--- a/lib/keeper/keeper_context_core.mli
+++ b/lib/keeper/keeper_context_core.mli
@@ -153,8 +153,8 @@ val usage_of_response :
 val total_tokens : Agent_sdk.Types.api_usage -> int
 
 (** Save the current working context as a generation-tagged OAS checkpoint.
-    Message order and typed content are preserved exactly; OAS owns any
-    call-time context reduction. *)
+    Message order and typed content are preserved exactly. No implicit context
+    reduction is performed at this boundary. *)
 val save_oas_checkpoint :
   multimodal_policy:Keeper_types_profile.multimodal_policy ->
   keeper_name:string ->
@@ -166,6 +166,20 @@ val save_oas_checkpoint :
 (** [multimodal_policy]/[keeper_name] gate RFC §2.3 site-2 image eviction at the
     checkpoint write boundary (Store_only); required so every write path is
     compiler-forced to declare its policy (N-of-M closure). *)
+
+(** The same write with the watermark result preserved. Compaction callers use
+    this to distinguish a durable write from a checkpoint superseded by a
+    newer lane write. *)
+val save_oas_checkpoint_classified :
+  multimodal_policy:Keeper_types_profile.multimodal_policy ->
+  keeper_name:string ->
+  session:session_context ->
+  agent_name:string ->
+  ctx:working_context ->
+  generation:int ->
+  ( Agent_sdk.Checkpoint.t * Keeper_checkpoint_store.save_oas_outcome
+  , string )
+  result
 
 (** {1 OAS checkpoint inspection} *)
 

--- a/lib/keeper/keeper_context_runtime.ml
+++ b/lib/keeper/keeper_context_runtime.ml
@@ -116,6 +116,23 @@ type overflow_retry_recovery = Keeper_post_turn.overflow_retry_recovery = {
   turn_generation : int;
 }
 
+type compaction_recovery_error = Keeper_post_turn.compaction_recovery_error =
+  | Checkpoint_load_failed of Keeper_checkpoint_store.checkpoint_load_error
+  | Compaction_rejected of Keeper_compact_policy.compaction_rejection
+  | Unexpected_compaction_decision of Keeper_compact_policy.compaction_decision
+  | Checkpoint_superseded of {
+      incoming_turn_count : int;
+      known_turn_count : int;
+    }
+  | Checkpoint_save_failed of string
+  | Checkpoint_save_raised of exn
+
+let compaction_recovery_error_to_tag =
+  Keeper_post_turn.compaction_recovery_error_to_tag
+
+let compaction_recovery_error_to_string =
+  Keeper_post_turn.compaction_recovery_error_to_string
+
 type max_context_resolution = {
   requested_override : int option;
   primary_budget : int;

--- a/lib/keeper/keeper_context_runtime.mli
+++ b/lib/keeper/keeper_context_runtime.mli
@@ -119,6 +119,20 @@ type overflow_retry_recovery =
   ; turn_generation : int
   }
 
+type compaction_recovery_error = Keeper_post_turn.compaction_recovery_error =
+  | Checkpoint_load_failed of Keeper_checkpoint_store.checkpoint_load_error
+  | Compaction_rejected of Keeper_compact_policy.compaction_rejection
+  | Unexpected_compaction_decision of Keeper_compact_policy.compaction_decision
+  | Checkpoint_superseded of {
+      incoming_turn_count : int;
+      known_turn_count : int;
+    }
+  | Checkpoint_save_failed of string
+  | Checkpoint_save_raised of exn
+
+val compaction_recovery_error_to_tag : compaction_recovery_error -> string
+val compaction_recovery_error_to_string : compaction_recovery_error -> string
+
 (** {1 Checkpoint Loading} *)
 
 val load_context_from_checkpoint
@@ -193,10 +207,9 @@ val dispatch_post_turn_lifecycle_events
 val recover_latest_checkpoint_for_overflow_retry
   :  base_dir:string
   -> meta:keeper_meta
-  -> model:string
   -> trigger:Compaction_trigger.t
   -> primary_model_max_tokens:int
-  -> overflow_retry_recovery option
+  -> (overflow_retry_recovery, compaction_recovery_error) result
 
 (** {1 Trace and Board Utilities} *)
 

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -76,6 +76,55 @@ type overflow_retry_recovery = {
   turn_generation : int;
 } [@@warning "-69"]
 
+type compaction_recovery_error =
+  | Checkpoint_load_failed of Keeper_checkpoint_store.checkpoint_load_error
+  | Compaction_rejected of Keeper_compact_policy.compaction_rejection
+  | Unexpected_compaction_decision of Keeper_compact_policy.compaction_decision
+  | Checkpoint_superseded of {
+      incoming_turn_count : int;
+      known_turn_count : int;
+    }
+  | Checkpoint_save_failed of string
+  | Checkpoint_save_raised of exn
+
+let compaction_recovery_error_to_tag = function
+  | Checkpoint_load_failed Not_found -> "checkpoint_not_found"
+  | Checkpoint_load_failed _ -> "checkpoint_load_failed"
+  | Compaction_rejected Retired_deterministic_mode -> "retired_deterministic_mode"
+  | Compaction_rejected Runtime_unavailable -> "runtime_unavailable"
+  | Compaction_rejected Summarizer_unavailable_or_invalid ->
+    "summarizer_unavailable_or_invalid"
+  | Compaction_rejected Structural_noop -> "structural_noop"
+  | Unexpected_compaction_decision _ -> "unexpected_compaction_decision"
+  | Checkpoint_superseded _ -> "checkpoint_superseded"
+  | Checkpoint_save_failed _ -> "checkpoint_save_failed"
+  | Checkpoint_save_raised _ -> "checkpoint_save_raised"
+
+let checkpoint_load_error_detail = function
+  | Keeper_checkpoint_store.Not_found -> "checkpoint not found"
+  | Store_error detail
+  | Parse_error detail
+  | Io_error detail
+  | Sdk_other_error detail -> detail
+
+let compaction_recovery_error_to_string = function
+  | Checkpoint_load_failed error -> checkpoint_load_error_detail error
+  | Compaction_rejected reason ->
+    (match reason with
+     | Retired_deterministic_mode -> "deterministic compaction is retired"
+     | Runtime_unavailable -> "compaction runtime unavailable"
+     | Summarizer_unavailable_or_invalid -> "compaction plan unavailable or invalid"
+     | Structural_noop -> "compaction plan produced no structural change")
+  | Unexpected_compaction_decision decision ->
+    "unexpected decision: " ^ Keeper_compact_policy.compaction_decision_to_string decision
+  | Checkpoint_superseded { incoming_turn_count; known_turn_count } ->
+    Printf.sprintf
+      "checkpoint superseded: incoming_turn_count=%d known_turn_count=%d"
+      incoming_turn_count
+      known_turn_count
+  | Checkpoint_save_failed detail -> detail
+  | Checkpoint_save_raised exn -> Printexc.to_string exn
+
 let log_tool_pair_repair
     ~keeper_name
     ~site
@@ -526,52 +575,40 @@ let apply_post_turn_lifecycle_with_resilience_handles
 let recover_latest_checkpoint_for_overflow_retry
     ~(base_dir : string)
     ~(meta : keeper_meta)
-    ~(model : string)
     ~(trigger : Compaction_trigger.t)
-    ~(primary_model_max_tokens : int) : overflow_retry_recovery option =
+    ~(primary_model_max_tokens : int)
+  : (overflow_retry_recovery, compaction_recovery_error) result
+  =
   let session = create_session ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id) ~base_dir in
-  let oas_result =
+  match
     Keeper_checkpoint_store.load_oas ~session_dir:session.session_dir
       ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
-  in
-  (match oas_result with
-   | Error (Parse_error d | Store_error d | Io_error d | Sdk_other_error d) ->
-       Log.Keeper.error "keeper:%s overflow retry OAS load error: %s"
-         (Keeper_id.Trace_id.to_string meta.runtime.trace_id) d;
-       Otel_metric_store.inc_counter
-         Keeper_metrics.(to_string OasExecutionErrors)
-         ~labels:[("keeper", meta.name); ("phase", Keeper_oas_execution_error_phase.(to_label Overflow_retry_oas_load))]
-         ()
-   | Error Not_found ->
-       Log.Keeper.debug
-         "keeper:%s overflow-retry OAS checkpoint not found, starting fresh"
-         (Keeper_id.Trace_id.to_string meta.runtime.trace_id)
-   | Ok _ -> ());
-  let oas_checkpoint =
-    match oas_result with
-    | Ok v -> Some v
-    | Error Not_found -> None
-    | Error _ ->
-      Log.Keeper.warn "keeper:%s overflow-retry OAS checkpoint load failed; recovery cannot resume it"
-        (Keeper_id.Trace_id.to_string meta.runtime.trace_id);
-      None
-  in
-  let selected =
-    match oas_checkpoint with
-    | Some checkpoint ->
-        let turn_generation =
-          checkpoint_generation checkpoint ~fallback:meta.runtime.generation
-        in
-        Some
-          ( context_of_oas_checkpoint
-              checkpoint
-              ~primary_model_max_tokens,
-            turn_generation )
-    | None -> None
-  in
-  match selected with
-  | None -> None
-  | Some (ctx, turn_generation) ->
+  with
+  | Error Not_found ->
+    Log.Keeper.debug
+      "keeper:%s overflow-retry OAS checkpoint not found"
+      (Keeper_id.Trace_id.to_string meta.runtime.trace_id);
+    Error (Checkpoint_load_failed Not_found)
+  | Error ((Parse_error detail | Store_error detail | Io_error detail
+           | Sdk_other_error detail) as error) ->
+    Log.Keeper.error
+      "keeper:%s overflow retry OAS load error: %s"
+      (Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+      detail;
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string OasExecutionErrors)
+      ~labels:
+        [ "keeper", meta.name
+        ; ( "phase"
+          , Keeper_oas_execution_error_phase.(to_label Overflow_retry_oas_load) )
+        ]
+      ();
+    Error (Checkpoint_load_failed error)
+  | Ok checkpoint ->
+    let turn_generation =
+      checkpoint_generation checkpoint ~fallback:meta.runtime.generation
+    in
+    let ctx = context_of_oas_checkpoint checkpoint ~primary_model_max_tokens in
       let retry_meta =
         if turn_generation = meta.runtime.generation then meta
         else map_runtime (fun rt -> { rt with generation = turn_generation }) meta
@@ -585,19 +622,19 @@ let recover_latest_checkpoint_for_overflow_retry
       match base_decision with
       | Keeper_compact_policy.Prepared prepared_trigger ->
         (try
-          (match save_oas_checkpoint
+          (match save_oas_checkpoint_classified
               ~multimodal_policy:meta.multimodal_policy
               ~keeper_name:meta.name
               ~session
               ~agent_name:retry_meta.agent_name
               ~ctx:compacted_ctx ~generation:turn_generation
           with
-          | Ok checkpoint ->
+          | Ok (checkpoint, Keeper_checkpoint_store.Saved _) ->
               Otel_metric_store.inc_counter
                 Keeper_metrics.(to_string Compactions)
                 ~labels:[ "keeper", retry_meta.name ]
                 ();
-              Some
+              Ok
                 { checkpoint
                 ; compaction =
                     { attempted = true
@@ -609,6 +646,17 @@ let recover_latest_checkpoint_for_overflow_retry
                     }
                 ; turn_generation
                 }
+          | Ok
+              ( _,
+                Keeper_checkpoint_store.Stale_noop
+                  { incoming_turn_count; known_turn_count } ) ->
+            Log.Keeper.warn
+              "overflow retry checkpoint superseded: incoming_turn_count=%d known_turn_count=%d"
+              incoming_turn_count
+              known_turn_count;
+            Error
+              (Checkpoint_superseded
+                 { incoming_turn_count; known_turn_count })
           | Error e ->
               Log.Keeper.error
                 "overflow retry checkpoint save failed: %s" e;
@@ -616,12 +664,14 @@ let recover_latest_checkpoint_for_overflow_retry
                 Keeper_metrics.(to_string CheckpointFailures)
                 ~labels:[("keeper", retry_meta.agent_name); ("operation", "overflow_save")]
                 ();
-              None)
+              Error (Checkpoint_save_failed e))
         with
         | Eio.Cancel.Cancelled _ as exn -> raise exn
         | exn ->
             log_keeper_exn
               ~label:"overflow retry checkpoint save exception"
               exn;
-            None)
-      | _ -> None
+            Error (Checkpoint_save_raised exn))
+      | Keeper_compact_policy.Rejected (_, reason) ->
+        Error (Compaction_rejected reason)
+      | decision -> Error (Unexpected_compaction_decision decision)

--- a/lib/keeper/keeper_post_turn.mli
+++ b/lib/keeper/keeper_post_turn.mli
@@ -55,6 +55,20 @@ type overflow_retry_recovery =
   ; turn_generation : int
   } [@@warning "-69"]
 
+type compaction_recovery_error =
+  | Checkpoint_load_failed of Keeper_checkpoint_store.checkpoint_load_error
+  | Compaction_rejected of Keeper_compact_policy.compaction_rejection
+  | Unexpected_compaction_decision of Keeper_compact_policy.compaction_decision
+  | Checkpoint_superseded of {
+      incoming_turn_count : int;
+      known_turn_count : int;
+    }
+  | Checkpoint_save_failed of string
+  | Checkpoint_save_raised of exn
+
+val compaction_recovery_error_to_tag : compaction_recovery_error -> string
+val compaction_recovery_error_to_string : compaction_recovery_error -> string
+
 (** End-of-turn pipeline. Preserves the checkpoint and persists the result to
     the keeper meta and dashboard surface. Explicit compaction is a separate
     request path.
@@ -108,7 +122,6 @@ val apply_post_turn_lifecycle_with_resilience_handles :
 val recover_latest_checkpoint_for_overflow_retry :
   base_dir:string ->
   meta:Keeper_meta_contract.keeper_meta ->
-  model:string ->
   trigger:Compaction_trigger.t ->
   primary_model_max_tokens:int ->
-  overflow_retry_recovery option
+  (overflow_retry_recovery, compaction_recovery_error) result

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -79,15 +79,55 @@ let validation_error_data message =
     ; "message", `String message
     ]
 
-let compaction_dispatch_error_data ~stage ~checkpoint_applied error =
+let compaction_dispatch_error_data
+    ?cleanup_error
+    ~stage
+    ~checkpoint_applied
+    error
+  =
   let detail = Keeper_context_runtime.lifecycle_dispatch_error_to_string error in
   error_assoc
-    [ "error_code", `String (error_code_to_string Conflict)
-    ; "message", `String (Printf.sprintf "compaction lifecycle dispatch failed: %s" detail)
-    ; "lifecycle_stage", `String stage
-    ; "checkpoint_applied", `Bool checkpoint_applied
-    ; "dispatch_error", `String detail
-    ]
+    ([ "error_code", `String (error_code_to_string Conflict)
+     ; "message", `String (Printf.sprintf "compaction lifecycle dispatch failed: %s" detail)
+     ; "lifecycle_stage", `String stage
+     ; "checkpoint_applied", `Bool checkpoint_applied
+     ; "dispatch_error", `String detail
+     ]
+     @
+     match cleanup_error with
+     | None -> []
+     | Some cleanup_error ->
+       [ ( "cleanup_dispatch_error"
+         , `String
+             (Keeper_context_runtime.lifecycle_dispatch_error_to_string
+                cleanup_error) ) ])
+
+let compaction_recovery_error_data ?dispatch_error error =
+  let tag = Keeper_context_runtime.compaction_recovery_error_to_tag error in
+  let detail = Keeper_context_runtime.compaction_recovery_error_to_string error in
+  let code =
+    match error with
+    | Keeper_context_runtime.Checkpoint_load_failed Not_found -> Not_found
+    | Compaction_rejected _ | Unexpected_compaction_decision _ ->
+      Precondition_failed
+    | Checkpoint_superseded _ -> Conflict
+    | Checkpoint_load_failed _ | Checkpoint_save_failed _
+    | Checkpoint_save_raised _ -> Internal_error
+  in
+  error_assoc
+    ([ "error_code", `String (error_code_to_string code)
+     ; "message", `String detail
+     ; "compaction_error", `String tag
+     ; "checkpoint_applied", `Bool false
+     ]
+     @
+     match dispatch_error with
+     | None -> []
+     | Some dispatch_error ->
+       [ ( "lifecycle_dispatch_error"
+         , `String
+             (Keeper_context_runtime.lifecycle_dispatch_error_to_string
+                dispatch_error) ) ])
 
 let keeper_sandbox_status_fleet_names ctx =
   let registry_names =
@@ -464,6 +504,7 @@ let keeper_compact_body ~(config : Workspace.config) args : tool_result =
       match
         Keeper_context_runtime.dispatch_keeper_phase_event_result
           ~config ~keeper_name:name
+          ~origin:Keeper_registry.Operator_compact
           Keeper_state_machine.Operator_compact_requested
       with
       | Error error ->
@@ -501,7 +542,6 @@ let keeper_compact_body ~(config : Workspace.config) args : tool_result =
                    error))
          | Ok (Some (_resolved, meta)) ->
            let base_dir = Keeper_types_profile.session_base_dir config in
-           let checkpoint_label = "runtime" in
            let max_tokens = resolve_primary_max_context (Some meta) in
            (match
               Keeper_context_runtime.dispatch_keeper_phase_event_result
@@ -510,9 +550,14 @@ let keeper_compact_body ~(config : Workspace.config) args : tool_result =
                 Keeper_state_machine.Compaction_started
             with
             | Error error ->
-              dispatch_failed "compaction_start_rejected" |> ignore;
+              let cleanup_error =
+                match dispatch_failed "compaction_start_rejected" with
+                | Ok () -> None
+                | Error cleanup_error -> Some cleanup_error
+              in
               tool_result_error_data
                 (compaction_dispatch_error_data
+                   ?cleanup_error
                    ~stage:"compaction_started"
                    ~checkpoint_applied:false
                    error)
@@ -521,11 +566,10 @@ let keeper_compact_body ~(config : Workspace.config) args : tool_result =
                  Keeper_context_runtime.recover_latest_checkpoint_for_overflow_retry
                    ~base_dir
                    ~meta
-                   ~model:checkpoint_label
                    ~trigger:Compaction_trigger.Manual
                    ~primary_model_max_tokens:max_tokens
                with
-               | Some recovery ->
+               | Ok recovery ->
                  (match
                     Keeper_context_runtime.dispatch_compaction_completed
                       ~config ~keeper_name:name
@@ -553,15 +597,15 @@ let keeper_compact_body ~(config : Workspace.config) args : tool_result =
                           [ "name", `String name
                           ; "phase_before", `String phase_before
                           ; ( "phase_after"
-                            , `String
-                                (match
-                                   Keeper_registry.get
-                                     ~base_path:config.base_path
-                                     name
-                                 with
-                                 | Some entry ->
-                                   Keeper_state_machine.phase_to_string entry.phase
-                                 | None -> "unknown") )
+                            , match
+                                Keeper_registry.get
+                                  ~base_path:config.base_path
+                                  name
+                              with
+                              | Some entry ->
+                                `String
+                                  (Keeper_state_machine.phase_to_string entry.phase)
+                              | None -> `Null )
                           ; "applied", `Bool recovery.compaction.applied
                           ; ( "trigger"
                             , match recovery.compaction.trigger with
@@ -569,28 +613,32 @@ let keeper_compact_body ~(config : Workspace.config) args : tool_result =
                                 Compaction_trigger.to_detail_json trigger
                               | None -> `Null )
                           ]))
-               | None ->
-                 let failure_dispatch = dispatch_failed "no_valid_checkpoint" in
-                 Otel_metric_store.inc_counter
-                   Keeper_metrics.(to_string OperatorCompact)
-                   ~labels:
-                     [ ("keeper", name)
-                     ; ( "result"
-                       , Keeper_operator_compact_result.(to_label No_checkpoint) )
-                     ]
-                   ();
+               | Error recovery_error ->
+                 let recovery_tag =
+                   Keeper_context_runtime.compaction_recovery_error_to_tag
+                     recovery_error
+                 in
+                 let failure_dispatch = dispatch_failed recovery_tag in
+                 (match recovery_error with
+                  | Keeper_context_runtime.Checkpoint_load_failed Not_found ->
+                    Otel_metric_store.inc_counter
+                      Keeper_metrics.(to_string OperatorCompact)
+                      ~labels:
+                        [ ("keeper", name)
+                        ; ( "result"
+                          , Keeper_operator_compact_result.(to_label No_checkpoint) )
+                        ]
+                      ()
+                  | _ -> ());
                  (match failure_dispatch with
                   | Error error ->
                     tool_result_error_data
-                      (compaction_dispatch_error_data
-                         ~stage:"compaction_failed"
-                         ~checkpoint_applied:false
-                         error)
+                      (compaction_recovery_error_data
+                         ~dispatch_error:error
+                         recovery_error)
                   | Ok () ->
-                    tool_result_error
-                      (Printf.sprintf
-                         "keeper %s: checkpoint compaction unavailable"
-                         name)))))
+                    tool_result_error_data
+                      (compaction_recovery_error_data recovery_error)))))
 
 let handle_keeper_compact ctx args : tool_result =
   keeper_compact_body ~config:ctx.config args

--- a/test/test_keeper_lifecycle_chaos.ml
+++ b/test/test_keeper_lifecycle_chaos.ml
@@ -134,7 +134,7 @@ let test_compaction_crash_recovery () =
   let tr = dispatch "compact" KSM.Compaction_started in
   check phase_t "2nd compaction" KSM.Compacting tr.new_phase;
   let tr = dispatch "compact"
-    (KSM.Compaction_completed { before_tokens = 100000; after_tokens = 30000 }) in
+    KSM.Compaction_completed in
   check phase_t "2nd compact → running" KSM.Running tr.new_phase;
 
   let tr = dispatch "compact"
@@ -185,7 +185,7 @@ let test_full_chaos_sequence () =
   let tr = dispatch "chaos" KSM.Compaction_started in
   check phase_t "compacting" KSM.Compacting tr.new_phase;
   let tr = dispatch "chaos"
-    (KSM.Compaction_completed { before_tokens = 100000; after_tokens = 30000 }) in
+    KSM.Compaction_completed in
   check phase_t "post-compact → running" KSM.Running tr.new_phase;
 
   let tr = dispatch "chaos" KSM.Handoff_started in

--- a/test/test_keeper_lifecycle_registry_dispatch.ml
+++ b/test/test_keeper_lifecycle_registry_dispatch.ml
@@ -151,9 +151,6 @@ let base_lifecycle ~(meta : Keeper_meta_contract.keeper_meta) : KEC.post_turn_li
         failure_reason = None;
         trigger = None;
         decision = KEC.Not_requested;
-        before_tokens = 0;
-        after_tokens = 0;
-        saved_tokens = 0;
       };
     turn_generation = meta.runtime.generation;
     context_ratio = 0.0;
@@ -285,9 +282,6 @@ let test_dispatch_post_turn_lifecycle_events_uses_workspace_base_path () =
               failure_reason = None;
               trigger = Some Compaction_trigger.Manual;
               decision = KEC.Applied Compaction_trigger.Manual;
-              before_tokens = 42;
-              after_tokens = 21;
-              saved_tokens = 21;
             };
         }
       in
@@ -344,9 +338,6 @@ let test_post_turn_compaction_runs_from_failing_health_lane () =
               failure_reason = None;
               trigger = Some Compaction_trigger.Manual;
               decision = KEC.Applied Compaction_trigger.Manual;
-              before_tokens = 42;
-              after_tokens = 21;
-              saved_tokens = 21;
             };
         }
       in
@@ -374,7 +365,7 @@ let test_compaction_completion_without_started_is_nonfatal () =
       let meta = make_keeper_meta ~name:"keeper-missing-compaction-start" () in
       ignore (KR.register ~base_path:config.base_path meta.name meta);
       let labels =
-        [ ("keeper", meta.name); ("event", "compaction_completed(42->21)") ]
+        [ ("keeper", meta.name); ("event", "compaction_completed") ]
       in
       let before =
         Masc.Otel_metric_store.get_metric_value
@@ -393,9 +384,6 @@ let test_compaction_completion_without_started_is_nonfatal () =
               failure_reason = None;
               trigger = Some Compaction_trigger.Manual;
               decision = KEC.Applied Compaction_trigger.Manual;
-              before_tokens = 42;
-              after_tokens = 21;
-              saved_tokens = 21;
             };
         }
       in
@@ -429,7 +417,7 @@ let test_post_turn_compaction_restarts_after_done_stage () =
       let config = Masc.Workspace.default_config base_dir in
       let meta = make_keeper_meta ~name:"keeper-repeat-compaction" () in
       ignore (KR.register ~base_path:config.base_path meta.name meta);
-      let lifecycle before_tokens after_tokens =
+      let lifecycle =
         {
           (base_lifecycle ~meta) with
           compaction =
@@ -440,13 +428,10 @@ let test_post_turn_compaction_restarts_after_done_stage () =
               failure_reason = None;
               trigger = Some Compaction_trigger.Manual;
               decision = KEC.Applied Compaction_trigger.Manual;
-              before_tokens;
-              after_tokens;
-              saved_tokens = before_tokens - after_tokens;
             };
         }
       in
-      let run_compaction label before_tokens after_tokens =
+      let run_compaction label =
         KEC.dispatch_keeper_phase_event
           ~config
           ~origin:KR.Post_turn_lifecycle
@@ -460,15 +445,15 @@ let test_post_turn_compaction_restarts_after_done_stage () =
         KEC.dispatch_post_turn_lifecycle_events
           ~config
           ~keeper_name:meta.name
-          (lifecycle before_tokens after_tokens);
+          lifecycle;
         match KR.get ~base_path:config.base_path meta.name with
         | Some entry ->
             check string (label ^ " completion returns running") "running"
               (KST.phase_to_string entry.phase)
         | None -> fail "expected registered keeper after compaction completion"
       in
-      run_compaction "first" 42 21;
-      run_compaction "second" 84 42)
+      run_compaction "first";
+      run_compaction "second")
 
 let test_dispatch_keeper_phase_event_rejects_unscoped_lifecycle_event () =
   let base_dir = temp_dir "keeper_lifecycle_registry_origin_guard" in

--- a/test/test_keeper_overflow_recovery.ml
+++ b/test/test_keeper_overflow_recovery.ml
@@ -63,7 +63,7 @@ let test_happy_path () =
   (* Compaction completes → Running (context_overflow cleared) *)
   let tr3 =
     apply_ok SM.Compacting tr2.updated_conditions
-      (SM.Compaction_completed { before_tokens = 205_000; after_tokens = 80_000 })
+      SM.Compaction_completed
   in
   check_phase SM.Running tr3.new_phase "compaction done → Running";
   check bool "context_overflow cleared" false
@@ -117,7 +117,7 @@ let test_two_consecutive_overflows () =
   in
   let tr3 =
     apply_ok SM.Compacting tr2.updated_conditions
-      (SM.Compaction_completed { before_tokens = 210_000; after_tokens = 90_000 })
+      SM.Compaction_completed
   in
   check_phase SM.Running tr3.new_phase "cycle 1 back to Running";
   (* Second overflow should be handled cleanly after the successful cycle. *)
@@ -127,18 +127,6 @@ let test_two_consecutive_overflows () =
     apply_ok SM.Overflowed tr4.updated_conditions SM.Compaction_started
   in
   check_phase SM.Compacting tr5.new_phase "cycle 2 compaction → Compacting"
-
-let test_completion_counts_are_observations () =
-  List.iter
-    (fun (before_tokens, after_tokens) ->
-      let tr1 = apply_ok SM.Running running_conds (overflow_event ()) in
-      let tr2 = apply_ok SM.Overflowed tr1.updated_conditions SM.Compaction_started in
-      let tr3 = apply_ok SM.Compacting tr2.updated_conditions
-          (SM.Compaction_completed { before_tokens; after_tokens }) in
-      check bool "completed compaction clears overflow" false
-        tr3.updated_conditions.context_overflow;
-      check_phase SM.Running tr3.new_phase "completed compaction resumes")
-    [ 180_000, 180_000; 180_000, 210_000 ]
 
 (* ── Scenario 5: heartbeat failure during Overflowed ──────── *)
 
@@ -166,7 +154,7 @@ let test_heartbeat_failure_preserved_through_overflow () =
   check_phase SM.Compacting tr3.new_phase "compact starts";
   let tr4 =
     apply_ok SM.Compacting tr3.updated_conditions
-      (SM.Compaction_completed { before_tokens = 205_000; after_tokens = 70_000 })
+      SM.Compaction_completed
   in
   (* context_overflow cleared, heartbeat_healthy=false remains → Failing *)
   check_phase SM.Failing tr4.new_phase
@@ -182,8 +170,6 @@ let () =
         test_operator_clear_returns_to_running;
       test_case "two consecutive overflows" `Quick
         test_two_consecutive_overflows;
-      test_case "completion token counts are observations" `Quick
-        test_completion_counts_are_observations;
       test_case "heartbeat failure preserved through overflow" `Quick
         test_heartbeat_failure_preserved_through_overflow;
     ]

--- a/test/test_keeper_state_machine.ml
+++ b/test/test_keeper_state_machine.ml
@@ -217,7 +217,7 @@ let test_apply_compaction_completed () =
     apply_ok
       ~current_phase:SM.Compacting
       ~conditions:compacting_conds
-      ~event:(SM.Compaction_completed { before_tokens = 100000; after_tokens = 50000 })
+      ~event:SM.Compaction_completed
   in
   check phase_t "Compacting -> Running" SM.Running tr.new_phase;
   check bool "compaction done" false tr.updated_conditions.compaction_active
@@ -231,7 +231,7 @@ let test_apply_compaction_completed_returns_to_failing_health_lane () =
     apply_ok
       ~current_phase:SM.Compacting
       ~conditions:compacting_conds
-      ~event:(SM.Compaction_completed { before_tokens = 100000; after_tokens = 50000 })
+      ~event:SM.Compaction_completed
   in
   check phase_t "Compacting -> Failing" SM.Failing tr.new_phase;
   check bool "compaction done" false tr.updated_conditions.compaction_active
@@ -971,7 +971,7 @@ let test_chain_happy_path () =
       ; SM.Heartbeat_ok, SM.Running
       ; SM.Heartbeat_ok, SM.Running
       ; SM.Compaction_started, SM.Compacting
-      ; ( SM.Compaction_completed { before_tokens = 90000; after_tokens = 40000 }
+      ; ( SM.Compaction_completed
         , SM.Running )
       ; SM.Handoff_started, SM.HandingOff
       ; SM.Handoff_completed { new_trace_id = "gen2"; generation = 2 }, SM.Running
@@ -1010,7 +1010,7 @@ let test_chain_operator_intervention () =
       ~init_conditions:running_conditions
       [ SM.Heartbeat_ok, SM.Running
       ; SM.Compaction_started, SM.Compacting
-      ; ( SM.Compaction_completed { before_tokens = 80000; after_tokens = 35000 }
+      ; ( SM.Compaction_completed
         , SM.Running )
       ; SM.Operator_pause, SM.Paused
       ; SM.Operator_resume, SM.Running
@@ -1052,12 +1052,12 @@ let test_chain_long_running_multi_cycle () =
       [ (* Cycle 1: compaction *)
         SM.Heartbeat_ok, SM.Running
       ; SM.Compaction_started, SM.Compacting
-      ; ( SM.Compaction_completed { before_tokens = 90000; after_tokens = 45000 }
+      ; ( SM.Compaction_completed
         , SM.Running )
       ; SM.Heartbeat_ok, SM.Running
       ; (* Cycle 2: compaction again *)
         SM.Compaction_started, SM.Compacting
-      ; ( SM.Compaction_completed { before_tokens = 85000; after_tokens = 40000 }
+      ; ( SM.Compaction_completed
         , SM.Running )
       ; (* Cycle 3: handoff (context still growing) *)
         SM.Handoff_started, SM.HandingOff
@@ -1065,7 +1065,7 @@ let test_chain_long_running_multi_cycle () =
       ; SM.Heartbeat_ok, SM.Running
       ; (* Cycle 4: compaction in new generation *)
         SM.Compaction_started, SM.Compacting
-      ; ( SM.Compaction_completed { before_tokens = 70000; after_tokens = 30000 }
+      ; ( SM.Compaction_completed
         , SM.Running )
       ; (* Cycle 5: another handoff *)
         SM.Handoff_started, SM.HandingOff
@@ -1296,7 +1296,7 @@ let test_chain_no_phoenix () =
         ; context_actions = { compact = false; handoff = false }
         }
     ; SM.Compaction_started
-    ; SM.Compaction_completed { before_tokens = 100; after_tokens = 50 }
+    ; SM.Compaction_completed
     ; SM.Compaction_failed { reason = "test" }
     ; SM.Handoff_started
     ; SM.Handoff_completed { new_trace_id = "x"; generation = 99 }
@@ -1359,7 +1359,7 @@ let test_chain_triple_restart_survives () =
       ; (* Finally stabilizes *)
         SM.Heartbeat_ok, SM.Running
       ; SM.Compaction_started, SM.Compacting
-      ; ( SM.Compaction_completed { before_tokens = 60000; after_tokens = 25000 }
+      ; ( SM.Compaction_completed
         , SM.Running )
       ; SM.Heartbeat_ok, SM.Running
       ]
@@ -1397,7 +1397,7 @@ let test_chain_maximum_turbulence () =
       ~init_conditions:running_conditions
       [ (* Compaction cycle *)
         SM.Compaction_started, SM.Compacting
-      ; ( SM.Compaction_completed { before_tokens = 90000; after_tokens = 40000 }
+      ; ( SM.Compaction_completed
         , SM.Running )
       ; (* Handoff cycle *)
         SM.Handoff_started, SM.HandingOff
@@ -1717,7 +1717,7 @@ let test_invariant_stop_requested_monotonic () =
     ; SM.Turn_succeeded
     ; SM.Turn_failed { consecutive = 1 }
     ; SM.Compaction_started
-    ; SM.Compaction_completed { before_tokens = 100; after_tokens = 50 }
+    ; SM.Compaction_completed
     ; SM.Handoff_started
     ; SM.Handoff_completed { new_trace_id = "x"; generation = 1 }
     ; SM.Operator_pause
@@ -1787,7 +1787,7 @@ let test_invariant_derive_matches_matrix () =
     ; SM.Turn_succeeded
     ; SM.Turn_failed { consecutive = 3 }
     ; SM.Compaction_started
-    ; SM.Compaction_completed { before_tokens = 100; after_tokens = 50 }
+    ; SM.Compaction_completed
     ; SM.Compaction_failed { reason = "test" }
     ; SM.Handoff_started
     ; SM.Handoff_completed { new_trace_id = "x"; generation = 1 }
@@ -2009,7 +2009,7 @@ let test_setclear_coverage () =
           } )
     ; "Compaction_started", SM.Compaction_started
     ; ( "Compaction_completed"
-      , SM.Compaction_completed { before_tokens = 100; after_tokens = 50 } )
+      , SM.Compaction_completed )
     ; "Compaction_failed", SM.Compaction_failed { reason = "test" }
     ; "Handoff_started", SM.Handoff_started
     ; "Handoff_completed", SM.Handoff_completed { new_trace_id = "x"; generation = 99 }

--- a/test/test_keeper_state_machine_correspondence.ml
+++ b/test/test_keeper_state_machine_correspondence.ml
@@ -261,10 +261,7 @@ let canonical_events : (string * SM.event) list =
             };
         } );
     ("CompactionStarted", SM.Compaction_started);
-    ( "CompactionCompletedWithSavings",
-      SM.Compaction_completed { before_tokens = 100_000; after_tokens = 50_000 } );
-    ( "CompactionCompletedNoSavings",
-      SM.Compaction_completed { before_tokens = 50_000; after_tokens = 50_000 } );
+    ("CompactionCompleted", SM.Compaction_completed);
     ("CompactionFailed", SM.Compaction_failed { reason = "test" });
     ("HandoffStarted", SM.Handoff_started);
     ( "HandoffCompleted",

--- a/test/test_keeper_state_machine_pbt.ml
+++ b/test/test_keeper_state_machine_pbt.ml
@@ -32,9 +32,7 @@ let gen_event_chaos : SM.event QCheck.Gen.t =
        context_ratio = ratio; message_count = 50;
        token_count = 5000; context_actions }));
     return SM.Compaction_started;
-    (let* before = int_range 1000 100000 in
-     let* after = int_range 100 (max 101 before) in
-     return (SM.Compaction_completed { before_tokens = before; after_tokens = after }));
+    return SM.Compaction_completed;
     return (SM.Compaction_failed { reason = "pbt_test" });
     return SM.Handoff_started;
     (let* gen = int_range 1 100 in
@@ -91,7 +89,7 @@ let valid_events_for_phase (phase : SM.phase) (c : SM.conditions) : SM.event lis
         SM.Fiber_terminated { outcome = "crash"; provider_id = None; http_status = None };
       ]
     | SM.Compacting ->
-      [ SM.Compaction_completed { before_tokens = 100; after_tokens = 50 };
+      [ SM.Compaction_completed;
         SM.Compaction_failed { reason = "test" };
         SM.Heartbeat_failed { consecutive = 1 };
         SM.Fiber_terminated { outcome = "crash"; provider_id = None; http_status = None };


### PR DESCRIPTION
## 변경

load/rejection/save/dispatch 실패를 typed recovery error로 보존하고 stale checkpoint를 Applied로 오인하지 않게 합니다.

## 검증

- Keeper_tool_surface.cmo, Keeper_post_turn.cmo, Keeper_context_runtime.cmo, Keeper_turn_up_create.cmo, ocamlformat, git diff --check

## Stack

- base: codex/oas-0212-compaction-dispatch-result-20260715
- atomic compaction foundation stack이며 아래에서 위 순서로 병합합니다.
- 이 slice만으로 provider overflow 자동 복구가 완성됐다고 주장하지 않습니다. 동일 Lane의 durable queue/wake/checkpoint receipt 연결은 후속 Q1-Q4입니다.