### PR TITLE
refactor(keeper): surface compaction dispatch failures

### DIFF
--- a/lib/keeper/keeper_context_runtime.ml
+++ b/lib/keeper/keeper_context_runtime.ml
@@ -181,7 +181,18 @@ let record_lifecycle_dispatch_rejection ~keeper_name ~origin event ~error =
     (Keeper_state_machine.event_to_string event)
     error
 
-let dispatch_keeper_phase_event
+type lifecycle_dispatch_error =
+  | Transition_rejected of Keeper_state_machine.transition_error
+  | Compaction_invariant_violation of
+      Keeper_registry_types.compaction_transition_spec_violation
+
+let lifecycle_dispatch_error_to_string = function
+  | Transition_rejected error ->
+    Keeper_state_machine.transition_error_to_string error
+  | Compaction_invariant_violation violation ->
+    Keeper_registry_types.compaction_transition_spec_violation_to_tag violation
+
+let dispatch_keeper_phase_event_result
     ~(config : Workspace.config)
     ?(origin = Keeper_registry.Generic_dispatch)
     ~keeper_name
@@ -193,28 +204,41 @@ let dispatch_keeper_phase_event
       keeper_name
       event
   with
-  | Ok _ -> ()
+  | Ok _ -> Ok ()
   | Error err ->
       record_lifecycle_dispatch_rejection
         ~keeper_name
         ~origin
         event
-        ~error:(Keeper_state_machine.transition_error_to_string err)
-  | exception (Keeper_registry_types.Compaction_transition_violation _ as exn) ->
+        ~error:(Keeper_state_machine.transition_error_to_string err);
+      Error (Transition_rejected err)
+  | exception
+      (Keeper_registry_types.Compaction_transition_violation
+         { violation; _ } as exn) ->
       record_lifecycle_dispatch_rejection
         ~keeper_name
         ~origin
         event
-        ~error:(Printexc.to_string exn)
+        ~error:(Printexc.to_string exn);
+      Error (Compaction_invariant_violation violation)
+
+let dispatch_keeper_phase_event ~config ?origin ~keeper_name event =
+  dispatch_keeper_phase_event_result ~config ?origin ~keeper_name event
+  |> ignore
 
 let dispatch_compaction_completed
     ~(config : Workspace.config)
     ~origin
     ~keeper_name =
-  Otel_metric_store.inc_counter Keeper_metrics.(to_string FsmEdgeTransitions)
-    ~labels:[("edge", "kmc_to_ksm_compact_completed")] ();
-  dispatch_keeper_phase_event ~config ~origin ~keeper_name
-    Keeper_state_machine.Compaction_completed
+  match
+    dispatch_keeper_phase_event_result ~config ~origin ~keeper_name
+      Keeper_state_machine.Compaction_completed
+  with
+  | Error _ as error -> error
+  | Ok () as applied ->
+    Otel_metric_store.inc_counter Keeper_metrics.(to_string FsmEdgeTransitions)
+      ~labels:[("edge", "kmc_to_ksm_compact_completed")] ();
+    applied
 
 let dispatch_post_turn_lifecycle_events
     ~(config : Workspace.config)
@@ -248,6 +272,7 @@ let dispatch_post_turn_lifecycle_events
         ~config
         ~origin:Keeper_registry.Post_turn_lifecycle
         ~keeper_name
+      |> ignore
     end
     else
       dispatch_keeper_phase_event

--- a/lib/keeper/keeper_context_runtime.mli
+++ b/lib/keeper/keeper_context_runtime.mli
@@ -162,13 +162,27 @@ val dispatch_keeper_phase_event
   -> Keeper_state_machine.event
   -> unit
 
+type lifecycle_dispatch_error =
+  | Transition_rejected of Keeper_state_machine.transition_error
+  | Compaction_invariant_violation of
+      Keeper_registry_types.compaction_transition_spec_violation
+
+val lifecycle_dispatch_error_to_string : lifecycle_dispatch_error -> string
+
+val dispatch_keeper_phase_event_result
+  :  config:Workspace.config
+  -> ?origin:Keeper_registry.lifecycle_event_origin
+  -> keeper_name:string
+  -> Keeper_state_machine.event
+  -> (unit, lifecycle_dispatch_error) result
+
 (** Dispatch [Compaction_completed] only after the prepared checkpoint has
     been durably saved. *)
 val dispatch_compaction_completed
   :  config:Workspace.config
   -> origin:Keeper_registry.lifecycle_event_origin
   -> keeper_name:string
-  -> unit
+  -> (unit, lifecycle_dispatch_error) result
 
 val dispatch_post_turn_lifecycle_events
   :  config:Workspace.config

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -79,6 +79,16 @@ let validation_error_data message =
     ; "message", `String message
     ]
 
+let compaction_dispatch_error_data ~stage ~checkpoint_applied error =
+  let detail = Keeper_context_runtime.lifecycle_dispatch_error_to_string error in
+  error_assoc
+    [ "error_code", `String (error_code_to_string Conflict)
+    ; "message", `String (Printf.sprintf "compaction lifecycle dispatch failed: %s" detail)
+    ; "lifecycle_stage", `String stage
+    ; "checkpoint_applied", `Bool checkpoint_applied
+    ; "dispatch_error", `String detail
+    ]
+
 let keeper_sandbox_status_fleet_names ctx =
   let registry_names =
     Keeper_registry.all ~base_path:ctx.config.base_path ()
@@ -417,8 +427,8 @@ let resolve_primary_max_context (meta : Keeper_meta_contract.keeper_meta option)
 (** Operator-initiated context compaction.
 
     Dispatches [Operator_compact_requested] to the FSM, then compacts the
-    keeper's latest checkpoint via OAS checkpoint recovery.  Returns
-    before/after token counts on success. *)
+    keeper's latest checkpoint via OAS checkpoint recovery. Returns a durable
+    apply receipt and the typed trigger on success. *)
 (* RFC-0182 §3.1 — ctx-free body for keeper_dispatch_ref path. *)
 let keeper_compact_body ~(config : Workspace.config) args : tool_result =
   match resolve_keeper_name_config ~config args with
@@ -444,71 +454,143 @@ let keeper_compact_body ~(config : Workspace.config) args : tool_result =
         (validation_error_data
            (Printf.sprintf "keeper %s is explicitly stopped" name))
     end
-    else begin
-      (* Dispatch FSM event *)
-      Keeper_context_runtime.dispatch_keeper_phase_event
-        ~config ~keeper_name:name
-        Keeper_state_machine.Operator_compact_requested;
-      (* Read meta for checkpoint access *)
-      match read_meta_resolved config name with
-      | Ok None | Error _ ->
-        tool_result_error (Printf.sprintf "keeper %s: meta unavailable for compaction" name)
-      | Ok (Some (_resolved, meta)) ->
-        let base_dir = Keeper_types_profile.session_base_dir config in
-        let checkpoint_label = "runtime" in
-        let max_tokens = resolve_primary_max_context (Some meta) in
-        Keeper_context_runtime.dispatch_keeper_phase_event
+    else
+      let dispatch_failed reason =
+        Keeper_context_runtime.dispatch_keeper_phase_event_result
           ~config ~keeper_name:name
           ~origin:Keeper_registry.Operator_compact
-          Keeper_state_machine.Compaction_started;
-        match
-          Keeper_context_runtime.recover_latest_checkpoint_for_overflow_retry
-            ~base_dir
-            ~meta
-            ~model:checkpoint_label
-            ~trigger:Compaction_trigger.Manual
-            ~primary_model_max_tokens:max_tokens
-        with
-        | Some recovery ->
-          Keeper_context_runtime.dispatch_compaction_completed
-            ~config ~keeper_name:name
-            ~origin:Keeper_registry.Operator_compact;
-          invalidate_status_cache name;
-          Otel_metric_store.inc_counter Keeper_metrics.(to_string OperatorCompact)
-            ~labels:[("keeper", name); ("result", Keeper_operator_compact_result.(to_label Ok))] ();
-          tool_result_ok_data
-            (`Assoc
-              [
-                   ("name", `String name);
-                   ("phase_before", `String phase_before);
-                   ( "phase_after"
-                   , `String
-                       (match Keeper_registry.get ~base_path:config.base_path name with
-                        | Some entry -> Keeper_state_machine.phase_to_string entry.phase
-                        | None -> "unknown") );
-                   ("applied", `Bool recovery.compaction.applied);
-                   ( "trigger"
-                   , match recovery.compaction.trigger with
-                     | Some trigger -> Compaction_trigger.to_detail_json trigger
-                     | None -> `Null );
-              ])
-        | None ->
-          (* Compaction infrastructure unavailable — emit [Compaction_failed]
-             and preserve the observed context overflow. Emitting
-             [Compaction_completed] here would be a false success signal. *)
-          Keeper_context_runtime.dispatch_keeper_phase_event
-            ~config ~keeper_name:name
-            ~origin:Keeper_registry.Operator_compact
-            (Keeper_state_machine.Compaction_failed {
-               reason = "no_valid_checkpoint";
-            });
-          Otel_metric_store.inc_counter Keeper_metrics.(to_string OperatorCompact)
-            ~labels:[("keeper", name); ("result", Keeper_operator_compact_result.(to_label No_checkpoint))] ();
-          tool_result_error
-            (Printf.sprintf
-               "keeper %s: checkpoint compaction unavailable (no valid checkpoint found)"
-               name)
-    end
+          (Keeper_state_machine.Compaction_failed { reason })
+      in
+      match
+        Keeper_context_runtime.dispatch_keeper_phase_event_result
+          ~config ~keeper_name:name
+          Keeper_state_machine.Operator_compact_requested
+      with
+      | Error error ->
+        tool_result_error_data
+          (compaction_dispatch_error_data
+             ~stage:"operator_request"
+             ~checkpoint_applied:false
+             error)
+      | Ok () ->
+        (match read_meta_resolved config name with
+         | Ok None ->
+           (match dispatch_failed "meta_unavailable" with
+            | Ok () ->
+              tool_result_error
+                (Printf.sprintf "keeper %s: meta unavailable for compaction" name)
+            | Error error ->
+              tool_result_error_data
+                (compaction_dispatch_error_data
+                   ~stage:"compaction_failed"
+                   ~checkpoint_applied:false
+                   error))
+         | Error detail ->
+           (match dispatch_failed "meta_read_failed" with
+            | Ok () ->
+              tool_result_error
+                (Printf.sprintf
+                   "keeper %s: compaction meta read failed: %s"
+                   name
+                   detail)
+            | Error error ->
+              tool_result_error_data
+                (compaction_dispatch_error_data
+                   ~stage:"compaction_failed"
+                   ~checkpoint_applied:false
+                   error))
+         | Ok (Some (_resolved, meta)) ->
+           let base_dir = Keeper_types_profile.session_base_dir config in
+           let checkpoint_label = "runtime" in
+           let max_tokens = resolve_primary_max_context (Some meta) in
+           (match
+              Keeper_context_runtime.dispatch_keeper_phase_event_result
+                ~config ~keeper_name:name
+                ~origin:Keeper_registry.Operator_compact
+                Keeper_state_machine.Compaction_started
+            with
+            | Error error ->
+              dispatch_failed "compaction_start_rejected" |> ignore;
+              tool_result_error_data
+                (compaction_dispatch_error_data
+                   ~stage:"compaction_started"
+                   ~checkpoint_applied:false
+                   error)
+            | Ok () ->
+              (match
+                 Keeper_context_runtime.recover_latest_checkpoint_for_overflow_retry
+                   ~base_dir
+                   ~meta
+                   ~model:checkpoint_label
+                   ~trigger:Compaction_trigger.Manual
+                   ~primary_model_max_tokens:max_tokens
+               with
+               | Some recovery ->
+                 (match
+                    Keeper_context_runtime.dispatch_compaction_completed
+                      ~config ~keeper_name:name
+                      ~origin:Keeper_registry.Operator_compact
+                  with
+                  | Error error ->
+                    invalidate_status_cache name;
+                    tool_result_error_data
+                      (compaction_dispatch_error_data
+                         ~stage:"compaction_completed"
+                         ~checkpoint_applied:true
+                         error)
+                  | Ok () ->
+                    invalidate_status_cache name;
+                    Otel_metric_store.inc_counter
+                      Keeper_metrics.(to_string OperatorCompact)
+                      ~labels:
+                        [ ("keeper", name)
+                        ; ( "result"
+                          , Keeper_operator_compact_result.(to_label Ok) )
+                        ]
+                      ();
+                    tool_result_ok_data
+                      (`Assoc
+                          [ "name", `String name
+                          ; "phase_before", `String phase_before
+                          ; ( "phase_after"
+                            , `String
+                                (match
+                                   Keeper_registry.get
+                                     ~base_path:config.base_path
+                                     name
+                                 with
+                                 | Some entry ->
+                                   Keeper_state_machine.phase_to_string entry.phase
+                                 | None -> "unknown") )
+                          ; "applied", `Bool recovery.compaction.applied
+                          ; ( "trigger"
+                            , match recovery.compaction.trigger with
+                              | Some trigger ->
+                                Compaction_trigger.to_detail_json trigger
+                              | None -> `Null )
+                          ]))
+               | None ->
+                 let failure_dispatch = dispatch_failed "no_valid_checkpoint" in
+                 Otel_metric_store.inc_counter
+                   Keeper_metrics.(to_string OperatorCompact)
+                   ~labels:
+                     [ ("keeper", name)
+                     ; ( "result"
+                       , Keeper_operator_compact_result.(to_label No_checkpoint) )
+                     ]
+                   ();
+                 (match failure_dispatch with
+                  | Error error ->
+                    tool_result_error_data
+                      (compaction_dispatch_error_data
+                         ~stage:"compaction_failed"
+                         ~checkpoint_applied:false
+                         error)
+                  | Ok () ->
+                    tool_result_error
+                      (Printf.sprintf
+                         "keeper %s: checkpoint compaction unavailable"
+                         name)))))
 
 let handle_keeper_compact ctx args : tool_result =
   keeper_compact_body ~config:ctx.config args

--- a/test/test_keeper_lifecycle_registry_dispatch.ml
+++ b/test/test_keeper_lifecycle_registry_dispatch.ml
@@ -511,10 +511,16 @@ let test_dispatch_keeper_phase_event_rejection_increments_metric () =
           ~labels ()
         |> Option.value ~default:0.0
       in
-      KEC.dispatch_keeper_phase_event
-        ~config
-        ~keeper_name:"missing-keeper"
-        KST.Compaction_started;
+      (match
+         KEC.dispatch_keeper_phase_event_result
+           ~config
+           ~keeper_name:"missing-keeper"
+           KST.Compaction_started
+       with
+       | Error (KEC.Transition_rejected _) -> ()
+       | Error (KEC.Compaction_invariant_violation _) ->
+         fail "missing keeper must be a transition rejection"
+       | Ok () -> fail "missing keeper lifecycle dispatch unexpectedly succeeded");
       let after =
         Masc.Otel_metric_store.get_metric_value
           Keeper_metrics.(to_string LifecycleDispatchRejections)


### PR DESCRIPTION
## 변경

컴팩션 lifecycle dispatch를 Result로 바꾸고 start/complete 실패를 tool 경계까지 typed error로 명시적으로 노출합니다. 실패를 성공처럼 소비하거나 숨기지 않습니다.

## 검증

- typed lifecycle rejection 회귀 테스트 포함
- ocamlformat --check 통과
- OCaml parse 통과
- git diff --check 통과
- parent 대비 206 additions / 79 deletions, churn 285
- focused Dune 전체 연결은 main의 아직 미병합 OAS 0.212 exit-condition/Context_reducer 잔재에 선행 차단됨

## Stack

- base: codex/oas-0212-compaction-token-payload-v2-20260715 (#24488)
- 이 slice만으로 provider overflow 자동 복구가 완성됐다고 주장하지 않습니다. 동일 Lane durable queue/wake/checkpoint receipt 연결은 후속 Q1-Q4입니다.
- budget gate, heuristic trigger, compatibility shim 없음.