### PR TITLE
refactor(keeper): hard-cut compaction token payloads

### DIFF
--- a/lib/dashboard/dashboard_http_keeper_outcomes.ml
+++ b/lib/dashboard/dashboard_http_keeper_outcomes.ml
@@ -40,7 +40,7 @@ let compute_outcomes_rollup
   List.iter
     (fun (tr : Keeper_transition_audit.transition_record) ->
       match tr.selected_event with
-      | Keeper_state_machine.Compaction_completed _ -> incr succ_compactions
+      | Keeper_state_machine.Compaction_completed -> incr succ_compactions
       | Compaction_failed _ -> incr fail_compaction
       | Handoff_completed _ -> incr succ_handoffs
       | Handoff_failed _ -> incr fail_handoff

--- a/lib/keeper/keeper_context_runtime.ml
+++ b/lib/keeper/keeper_context_runtime.ml
@@ -94,9 +94,6 @@ type compaction_event = Keeper_post_turn.compaction_event = {
   failure_reason : string option;
   trigger : Compaction_trigger.t option;
   decision : Keeper_compact_policy.compaction_decision;
-  before_tokens : int;
-  after_tokens : int;
-  saved_tokens : int;
 }
 
 type post_turn_lifecycle = Keeper_post_turn.post_turn_lifecycle = {
@@ -210,59 +207,14 @@ let dispatch_keeper_phase_event
         event
         ~error:(Printexc.to_string exn)
 
-(* #9988 Option B follow-up: centralize [Compaction_completed] dispatch
-   so both emit paths (manual recovery in [keeper_tool_surface] and automatic
-   post-turn lifecycle) share the same outcome counter + warn log.
-
-   [masc_keeper_compaction_outcome_total{keeper,outcome}] splits into
-   [outcome=ok] (real savings) and [outcome=noop] (before==after or
-   after>before).  The FSM (#9993) already refuses to clear
-   [context_overflow] in the noop branch; the counter exposes the
-   surface so dashboards/Grafana can alert on rising noop rate —
-   the operational signal for "reducer has nothing to strip, switch
-   profile or hand off". *)
-let compaction_outcome_metric = "masc_keeper_compaction_outcome_total"
-
-let () =
-  Otel_metric_store.register_counter
-    ~name:compaction_outcome_metric
-    ~help:
-      "Total Compaction_completed dispatches classified by token \
-       savings. Labels: keeper, outcome (ok = saved_tokens > 0, \
-       noop = before == after or after > before). Rising noop \
-       rate is the operational signal for \"reducer has nothing \
-       to strip, switch profile or hand off\" (#9988)."
-    ()
-
-(* Observability-only: bump the outcome counter and log the warn
-   when saved_tokens <= 0.  Split from [dispatch_compaction_completed]
-   so unit tests can verify classification without needing a full
-   [Workspace.config] / [Keeper_registry] setup. *)
-let record_compaction_outcome ~keeper_name ~before_tokens ~after_tokens =
-  let saved_tokens = before_tokens - after_tokens in
-  let outcome = if saved_tokens > 0 then "ok" else "noop" in
-  Otel_metric_store.inc_counter compaction_outcome_metric
-    ~labels:[ ("keeper", keeper_name); ("outcome", outcome) ] ();
-  if saved_tokens <= 0 then
-    Log.Keeper.warn
-      "#9988 compaction_completed but saved_tokens=%d \
-       (before=%d after=%d) keeper=%s — context_overflow will stay set \
-       (FSM noop branch).  If this repeats, switch to a stronger \
-       compaction profile or escalate to operator."
-      saved_tokens before_tokens after_tokens keeper_name
-
 let dispatch_compaction_completed
     ~(config : Workspace.config)
     ~origin
-    ~keeper_name
-    ~before_tokens
-    ~after_tokens =
-  record_compaction_outcome ~keeper_name ~before_tokens ~after_tokens;
+    ~keeper_name =
   Otel_metric_store.inc_counter Keeper_metrics.(to_string FsmEdgeTransitions)
     ~labels:[("edge", "kmc_to_ksm_compact_completed")] ();
   dispatch_keeper_phase_event ~config ~origin ~keeper_name
-    (Keeper_state_machine.Compaction_completed
-       { before_tokens; after_tokens })
+    Keeper_state_machine.Compaction_completed
 
 let dispatch_post_turn_lifecycle_events
     ~(config : Workspace.config)
@@ -296,8 +248,6 @@ let dispatch_post_turn_lifecycle_events
         ~config
         ~origin:Keeper_registry.Post_turn_lifecycle
         ~keeper_name
-        ~before_tokens:lifecycle.compaction.before_tokens
-        ~after_tokens:lifecycle.compaction.after_tokens
     end
     else
       dispatch_keeper_phase_event

--- a/lib/keeper/keeper_context_runtime.ml
+++ b/lib/keeper/keeper_context_runtime.ml
@@ -181,7 +181,18 @@ let record_lifecycle_dispatch_rejection ~keeper_name ~origin event ~error =
     (Keeper_state_machine.event_to_string event)
     error
 
-let dispatch_keeper_phase_event
+type lifecycle_dispatch_error =
+  | Transition_rejected of Keeper_state_machine.transition_error
+  | Compaction_invariant_violation of
+      Keeper_registry_types.compaction_transition_spec_violation
+
+let lifecycle_dispatch_error_to_string = function
+  | Transition_rejected error ->
+    Keeper_state_machine.transition_error_to_string error
+  | Compaction_invariant_violation violation ->
+    Keeper_registry_types.compaction_transition_spec_violation_to_tag violation
+
+let dispatch_keeper_phase_event_result
     ~(config : Workspace.config)
     ?(origin = Keeper_registry.Generic_dispatch)
     ~keeper_name
@@ -193,28 +204,41 @@ let dispatch_keeper_phase_event
       keeper_name
       event
   with
-  | Ok _ -> ()
+  | Ok _ -> Ok ()
   | Error err ->
       record_lifecycle_dispatch_rejection
         ~keeper_name
         ~origin
         event
-        ~error:(Keeper_state_machine.transition_error_to_string err)
-  | exception (Keeper_registry_types.Compaction_transition_violation _ as exn) ->
+        ~error:(Keeper_state_machine.transition_error_to_string err);
+      Error (Transition_rejected err)
+  | exception
+      (Keeper_registry_types.Compaction_transition_violation
+         { violation; _ } as exn) ->
       record_lifecycle_dispatch_rejection
         ~keeper_name
         ~origin
         event
-        ~error:(Printexc.to_string exn)
+        ~error:(Printexc.to_string exn);
+      Error (Compaction_invariant_violation violation)
+
+let dispatch_keeper_phase_event ~config ?origin ~keeper_name event =
+  dispatch_keeper_phase_event_result ~config ?origin ~keeper_name event
+  |> ignore
 
 let dispatch_compaction_completed
     ~(config : Workspace.config)
     ~origin
     ~keeper_name =
-  Otel_metric_store.inc_counter Keeper_metrics.(to_string FsmEdgeTransitions)
-    ~labels:[("edge", "kmc_to_ksm_compact_completed")] ();
-  dispatch_keeper_phase_event ~config ~origin ~keeper_name
-    Keeper_state_machine.Compaction_completed
+  match
+    dispatch_keeper_phase_event_result ~config ~origin ~keeper_name
+      Keeper_state_machine.Compaction_completed
+  with
+  | Error _ as error -> error
+  | Ok () as applied ->
+    Otel_metric_store.inc_counter Keeper_metrics.(to_string FsmEdgeTransitions)
+      ~labels:[("edge", "kmc_to_ksm_compact_completed")] ();
+    applied
 
 let dispatch_post_turn_lifecycle_events
     ~(config : Workspace.config)
@@ -248,6 +272,7 @@ let dispatch_post_turn_lifecycle_events
         ~config
         ~origin:Keeper_registry.Post_turn_lifecycle
         ~keeper_name
+      |> ignore
     end
     else
       dispatch_keeper_phase_event

--- a/lib/keeper/keeper_context_runtime.mli
+++ b/lib/keeper/keeper_context_runtime.mli
@@ -162,13 +162,27 @@ val dispatch_keeper_phase_event
   -> Keeper_state_machine.event
   -> unit
 
+type lifecycle_dispatch_error =
+  | Transition_rejected of Keeper_state_machine.transition_error
+  | Compaction_invariant_violation of
+      Keeper_registry_types.compaction_transition_spec_violation
+
+val lifecycle_dispatch_error_to_string : lifecycle_dispatch_error -> string
+
+val dispatch_keeper_phase_event_result
+  :  config:Workspace.config
+  -> ?origin:Keeper_registry.lifecycle_event_origin
+  -> keeper_name:string
+  -> Keeper_state_machine.event
+  -> (unit, lifecycle_dispatch_error) result
+
 (** Dispatch [Compaction_completed] only after the prepared checkpoint has
     been durably saved. *)
 val dispatch_compaction_completed
   :  config:Workspace.config
   -> origin:Keeper_registry.lifecycle_event_origin
   -> keeper_name:string
-  -> unit
+  -> (unit, lifecycle_dispatch_error) result
 
 val dispatch_post_turn_lifecycle_events
   :  config:Workspace.config

--- a/lib/keeper/keeper_context_runtime.mli
+++ b/lib/keeper/keeper_context_runtime.mli
@@ -84,9 +84,6 @@ type compaction_event =
   ; failure_reason : string option
   ; trigger : Compaction_trigger.t option
   ; decision : Keeper_compact_policy.compaction_decision
-  ; before_tokens : int
-  ; after_tokens : int
-  ; saved_tokens : int
   }
 
 type post_turn_lifecycle =
@@ -165,41 +162,12 @@ val dispatch_keeper_phase_event
   -> Keeper_state_machine.event
   -> unit
 
-(** Canonical metric name for the compaction outcome counter.
-
-    Labels: [("keeper", <name>); ("outcome", "ok" | "noop")].
-    Exported so tests can pin the name without hard-coding a string
-    literal.  #9988. *)
-val compaction_outcome_metric : string
-
-(** [record_compaction_outcome ~keeper_name ~before_tokens ~after_tokens]
-    emits the outcome counter and (for [saved_tokens <= 0]) a warn log,
-    without dispatching an FSM event.  Exposed for unit tests and for
-    callers that need the observability signal before/after a dispatch.  *)
-val record_compaction_outcome
-  :  keeper_name:string
-  -> before_tokens:int
-  -> after_tokens:int
-  -> unit
-
-(** [dispatch_compaction_completed ~config ~keeper_name ~before_tokens
-    ~after_tokens] dispatches a [Compaction_completed] phase event and
-    updates observability in one place.
-
-    Emits [compaction_outcome_metric] labelled with [outcome=ok] when
-    [after_tokens < before_tokens] and [outcome=noop] otherwise.  A
-    [noop] outcome also logs a warning — the FSM (#9988) keeps
-    [context_overflow] set in this case, so operators need the signal
-    to escalate profile / alert.
-
-    Explicit compaction completion paths funnel through this helper to keep
-    observability coherent. *)
+(** Dispatch [Compaction_completed] only after the prepared checkpoint has
+    been durably saved. *)
 val dispatch_compaction_completed
   :  config:Workspace.config
   -> origin:Keeper_registry.lifecycle_event_origin
   -> keeper_name:string
-  -> before_tokens:int
-  -> after_tokens:int
   -> unit
 
 val dispatch_post_turn_lifecycle_events

--- a/lib/keeper/keeper_guard.ml
+++ b/lib/keeper/keeper_guard.ml
@@ -18,7 +18,7 @@ let event_priority = function
   | Context_measured _ -> 5
   | Heartbeat_ok -> 10
   | Turn_succeeded -> 10
-  | Compaction_completed _ -> 10
+  | Compaction_completed -> 10
   | Compaction_failed _ -> 10
   | Handoff_completed _ -> 10
   | Handoff_failed _ -> 10

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -54,9 +54,6 @@ type compaction_event = {
   failure_reason : string option;
   trigger : Compaction_trigger.t option;
   decision : Keeper_compact_policy.compaction_decision;
-  before_tokens : int;
-  after_tokens : int;
-  saved_tokens : int;
 }
 
 type post_turn_lifecycle = {
@@ -445,9 +442,6 @@ let apply_post_turn_lifecycle_with_resilience_handles
             failure_reason = None;
             trigger = None;
             decision = no_checkpoint_decision;
-            before_tokens = 0;
-            after_tokens = 0;
-            saved_tokens = 0;
           };
         turn_generation = meta.runtime.generation;
         context_ratio = 0.0;
@@ -472,7 +466,6 @@ let apply_post_turn_lifecycle_with_resilience_handles
             meta
       in
       let decision = Keeper_compact_policy.Not_requested in
-      let observed_tokens = token_count ctx in
       let meta_after_compaction =
         map_runtime
           (fun rt ->
@@ -504,9 +497,6 @@ let apply_post_turn_lifecycle_with_resilience_handles
             failure_reason = None;
             trigger = None;
             decision;
-            before_tokens = observed_tokens;
-            after_tokens = observed_tokens;
-            saved_tokens = 0;
           };
         turn_generation = current_generation;
         context_ratio = context_ratio ctx;
@@ -589,7 +579,6 @@ let recover_latest_checkpoint_for_overflow_retry
   match selected with
   | None -> None
   | Some (ctx, turn_generation) ->
-      let before_tokens = token_count ctx in
       let retry_meta =
         if turn_generation = meta.runtime.generation then meta
         else map_runtime (fun rt -> { rt with generation = turn_generation }) meta
@@ -600,7 +589,6 @@ let recover_latest_checkpoint_for_overflow_retry
           ~trigger
           ctx
       in
-      let after_tokens = token_count compacted_ctx in
       match base_decision with
       | Keeper_compact_policy.Prepared prepared_trigger ->
         (try
@@ -630,9 +618,6 @@ let recover_latest_checkpoint_for_overflow_retry
                     ; failure_reason = None
                     ; trigger = Some prepared_trigger
                     ; decision
-                    ; before_tokens
-                    ; after_tokens
-                    ; saved_tokens = before_tokens - after_tokens
                     }
                 ; turn_generation
                 }

--- a/lib/keeper/keeper_post_turn.mli
+++ b/lib/keeper/keeper_post_turn.mli
@@ -25,9 +25,6 @@ type compaction_event =
   ; failure_reason : string option
   ; trigger : Compaction_trigger.t option
   ; decision : Keeper_compact_policy.compaction_decision
-  ; before_tokens : int
-  ; after_tokens : int
-  ; saved_tokens : int
   }
 
 (** Combined post-turn outcome — compaction + rollover + per-turn context

--- a/lib/keeper/keeper_registry_event_validators.ml
+++ b/lib/keeper/keeper_registry_event_validators.ml
@@ -23,7 +23,7 @@ let paired_lifecycle_origin origin event =
                "paired lifecycle event requires origin=post_turn_lifecycle%s; got %s"
                (match event with
                 | Keeper_state_machine.Compaction_started
-                | Keeper_state_machine.Compaction_completed _
+                | Keeper_state_machine.Compaction_completed
                 | Keeper_state_machine.Compaction_failed _ -> " or origin=operator_compact"
                 | _ -> "")
                (lifecycle_event_origin_to_string origin)

--- a/lib/keeper/keeper_registry_types.ml
+++ b/lib/keeper/keeper_registry_types.ml
@@ -259,7 +259,7 @@ let lifecycle_event_origin_to_string = function
 
 let is_paired_lifecycle_event = function
   | Keeper_state_machine.Compaction_started
-  | Keeper_state_machine.Compaction_completed _
+  | Keeper_state_machine.Compaction_completed
   | Keeper_state_machine.Compaction_failed _
   | Keeper_state_machine.Handoff_started
   | Keeper_state_machine.Handoff_completed _
@@ -287,7 +287,7 @@ let origin_allows_paired_lifecycle_event origin event =
          handoff half-events flow through other origins. *)
       (match event with
        | Keeper_state_machine.Compaction_started
-       | Keeper_state_machine.Compaction_completed _
+       | Keeper_state_machine.Compaction_completed
        | Keeper_state_machine.Compaction_failed _ -> true
        | _ -> false)
 ;;
@@ -304,7 +304,7 @@ let compaction_stage_of_event entry event =
   | Keeper_state_machine.Compaction_started
   | Keeper_state_machine.Auto_compact_triggered
   | Keeper_state_machine.Operator_compact_requested -> Packed Compaction_compacting
-  | Keeper_state_machine.Compaction_completed _ -> Packed Compaction_done
+  | Keeper_state_machine.Compaction_completed -> Packed Compaction_done
   | Keeper_state_machine.Compaction_failed _ -> Packed Compaction_accumulating
   | _ -> entry.compaction_stage
 ;;

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -79,6 +79,16 @@ let validation_error_data message =
     ; "message", `String message
     ]
 
+let compaction_dispatch_error_data ~stage ~checkpoint_applied error =
+  let detail = Keeper_context_runtime.lifecycle_dispatch_error_to_string error in
+  error_assoc
+    [ "error_code", `String (error_code_to_string Conflict)
+    ; "message", `String (Printf.sprintf "compaction lifecycle dispatch failed: %s" detail)
+    ; "lifecycle_stage", `String stage
+    ; "checkpoint_applied", `Bool checkpoint_applied
+    ; "dispatch_error", `String detail
+    ]
+
 let keeper_sandbox_status_fleet_names ctx =
   let registry_names =
     Keeper_registry.all ~base_path:ctx.config.base_path ()
@@ -417,8 +427,8 @@ let resolve_primary_max_context (meta : Keeper_meta_contract.keeper_meta option)
 (** Operator-initiated context compaction.
 
     Dispatches [Operator_compact_requested] to the FSM, then compacts the
-    keeper's latest checkpoint via OAS checkpoint recovery.  Returns
-    before/after token counts on success. *)
+    keeper's latest checkpoint via OAS checkpoint recovery. Returns a durable
+    apply receipt and the typed trigger on success. *)
 (* RFC-0182 §3.1 — ctx-free body for keeper_dispatch_ref path. *)
 let keeper_compact_body ~(config : Workspace.config) args : tool_result =
   match resolve_keeper_name_config ~config args with
@@ -444,71 +454,143 @@ let keeper_compact_body ~(config : Workspace.config) args : tool_result =
         (validation_error_data
            (Printf.sprintf "keeper %s is explicitly stopped" name))
     end
-    else begin
-      (* Dispatch FSM event *)
-      Keeper_context_runtime.dispatch_keeper_phase_event
-        ~config ~keeper_name:name
-        Keeper_state_machine.Operator_compact_requested;
-      (* Read meta for checkpoint access *)
-      match read_meta_resolved config name with
-      | Ok None | Error _ ->
-        tool_result_error (Printf.sprintf "keeper %s: meta unavailable for compaction" name)
-      | Ok (Some (_resolved, meta)) ->
-        let base_dir = Keeper_types_profile.session_base_dir config in
-        let checkpoint_label = "runtime" in
-        let max_tokens = resolve_primary_max_context (Some meta) in
-        Keeper_context_runtime.dispatch_keeper_phase_event
+    else
+      let dispatch_failed reason =
+        Keeper_context_runtime.dispatch_keeper_phase_event_result
           ~config ~keeper_name:name
           ~origin:Keeper_registry.Operator_compact
-          Keeper_state_machine.Compaction_started;
-        match
-          Keeper_context_runtime.recover_latest_checkpoint_for_overflow_retry
-            ~base_dir
-            ~meta
-            ~model:checkpoint_label
-            ~trigger:Compaction_trigger.Manual
-            ~primary_model_max_tokens:max_tokens
-        with
-        | Some recovery ->
-          Keeper_context_runtime.dispatch_compaction_completed
-            ~config ~keeper_name:name
-            ~origin:Keeper_registry.Operator_compact;
-          invalidate_status_cache name;
-          Otel_metric_store.inc_counter Keeper_metrics.(to_string OperatorCompact)
-            ~labels:[("keeper", name); ("result", Keeper_operator_compact_result.(to_label Ok))] ();
-          tool_result_ok_data
-            (`Assoc
-              [
-                   ("name", `String name);
-                   ("phase_before", `String phase_before);
-                   ( "phase_after"
-                   , `String
-                       (match Keeper_registry.get ~base_path:config.base_path name with
-                        | Some entry -> Keeper_state_machine.phase_to_string entry.phase
-                        | None -> "unknown") );
-                   ("applied", `Bool recovery.compaction.applied);
-                   ( "trigger"
-                   , match recovery.compaction.trigger with
-                     | Some trigger -> Compaction_trigger.to_detail_json trigger
-                     | None -> `Null );
-              ])
-        | None ->
-          (* Compaction infrastructure unavailable — emit [Compaction_failed]
-             and preserve the observed context overflow. Emitting
-             [Compaction_completed] here would be a false success signal. *)
-          Keeper_context_runtime.dispatch_keeper_phase_event
-            ~config ~keeper_name:name
-            ~origin:Keeper_registry.Operator_compact
-            (Keeper_state_machine.Compaction_failed {
-               reason = "no_valid_checkpoint";
-            });
-          Otel_metric_store.inc_counter Keeper_metrics.(to_string OperatorCompact)
-            ~labels:[("keeper", name); ("result", Keeper_operator_compact_result.(to_label No_checkpoint))] ();
-          tool_result_error
-            (Printf.sprintf
-               "keeper %s: checkpoint compaction unavailable (no valid checkpoint found)"
-               name)
-    end
+          (Keeper_state_machine.Compaction_failed { reason })
+      in
+      match
+        Keeper_context_runtime.dispatch_keeper_phase_event_result
+          ~config ~keeper_name:name
+          Keeper_state_machine.Operator_compact_requested
+      with
+      | Error error ->
+        tool_result_error_data
+          (compaction_dispatch_error_data
+             ~stage:"operator_request"
+             ~checkpoint_applied:false
+             error)
+      | Ok () ->
+        (match read_meta_resolved config name with
+         | Ok None ->
+           (match dispatch_failed "meta_unavailable" with
+            | Ok () ->
+              tool_result_error
+                (Printf.sprintf "keeper %s: meta unavailable for compaction" name)
+            | Error error ->
+              tool_result_error_data
+                (compaction_dispatch_error_data
+                   ~stage:"compaction_failed"
+                   ~checkpoint_applied:false
+                   error))
+         | Error detail ->
+           (match dispatch_failed "meta_read_failed" with
+            | Ok () ->
+              tool_result_error
+                (Printf.sprintf
+                   "keeper %s: compaction meta read failed: %s"
+                   name
+                   detail)
+            | Error error ->
+              tool_result_error_data
+                (compaction_dispatch_error_data
+                   ~stage:"compaction_failed"
+                   ~checkpoint_applied:false
+                   error))
+         | Ok (Some (_resolved, meta)) ->
+           let base_dir = Keeper_types_profile.session_base_dir config in
+           let checkpoint_label = "runtime" in
+           let max_tokens = resolve_primary_max_context (Some meta) in
+           (match
+              Keeper_context_runtime.dispatch_keeper_phase_event_result
+                ~config ~keeper_name:name
+                ~origin:Keeper_registry.Operator_compact
+                Keeper_state_machine.Compaction_started
+            with
+            | Error error ->
+              dispatch_failed "compaction_start_rejected" |> ignore;
+              tool_result_error_data
+                (compaction_dispatch_error_data
+                   ~stage:"compaction_started"
+                   ~checkpoint_applied:false
+                   error)
+            | Ok () ->
+              (match
+                 Keeper_context_runtime.recover_latest_checkpoint_for_overflow_retry
+                   ~base_dir
+                   ~meta
+                   ~model:checkpoint_label
+                   ~trigger:Compaction_trigger.Manual
+                   ~primary_model_max_tokens:max_tokens
+               with
+               | Some recovery ->
+                 (match
+                    Keeper_context_runtime.dispatch_compaction_completed
+                      ~config ~keeper_name:name
+                      ~origin:Keeper_registry.Operator_compact
+                  with
+                  | Error error ->
+                    invalidate_status_cache name;
+                    tool_result_error_data
+                      (compaction_dispatch_error_data
+                         ~stage:"compaction_completed"
+                         ~checkpoint_applied:true
+                         error)
+                  | Ok () ->
+                    invalidate_status_cache name;
+                    Otel_metric_store.inc_counter
+                      Keeper_metrics.(to_string OperatorCompact)
+                      ~labels:
+                        [ ("keeper", name)
+                        ; ( "result"
+                          , Keeper_operator_compact_result.(to_label Ok) )
+                        ]
+                      ();
+                    tool_result_ok_data
+                      (`Assoc
+                          [ "name", `String name
+                          ; "phase_before", `String phase_before
+                          ; ( "phase_after"
+                            , `String
+                                (match
+                                   Keeper_registry.get
+                                     ~base_path:config.base_path
+                                     name
+                                 with
+                                 | Some entry ->
+                                   Keeper_state_machine.phase_to_string entry.phase
+                                 | None -> "unknown") )
+                          ; "applied", `Bool recovery.compaction.applied
+                          ; ( "trigger"
+                            , match recovery.compaction.trigger with
+                              | Some trigger ->
+                                Compaction_trigger.to_detail_json trigger
+                              | None -> `Null )
+                          ]))
+               | None ->
+                 let failure_dispatch = dispatch_failed "no_valid_checkpoint" in
+                 Otel_metric_store.inc_counter
+                   Keeper_metrics.(to_string OperatorCompact)
+                   ~labels:
+                     [ ("keeper", name)
+                     ; ( "result"
+                       , Keeper_operator_compact_result.(to_label No_checkpoint) )
+                     ]
+                   ();
+                 (match failure_dispatch with
+                  | Error error ->
+                    tool_result_error_data
+                      (compaction_dispatch_error_data
+                         ~stage:"compaction_failed"
+                         ~checkpoint_applied:false
+                         error)
+                  | Ok () ->
+                    tool_result_error
+                      (Printf.sprintf
+                         "keeper %s: checkpoint compaction unavailable"
+                         name)))))
 
 let handle_keeper_compact ctx args : tool_result =
   keeper_compact_body ~config:ctx.config args

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -472,9 +472,7 @@ let keeper_compact_body ~(config : Workspace.config) args : tool_result =
         | Some recovery ->
           Keeper_context_runtime.dispatch_compaction_completed
             ~config ~keeper_name:name
-            ~origin:Keeper_registry.Operator_compact
-            ~before_tokens:recovery.compaction.before_tokens
-            ~after_tokens:recovery.compaction.after_tokens;
+            ~origin:Keeper_registry.Operator_compact;
           invalidate_status_cache name;
           Otel_metric_store.inc_counter Keeper_metrics.(to_string OperatorCompact)
             ~labels:[("keeper", name); ("result", Keeper_operator_compact_result.(to_label Ok))] ();
@@ -488,8 +486,11 @@ let keeper_compact_body ~(config : Workspace.config) args : tool_result =
                        (match Keeper_registry.get ~base_path:config.base_path name with
                         | Some entry -> Keeper_state_machine.phase_to_string entry.phase
                         | None -> "unknown") );
-                   ("before_tokens", `Int recovery.compaction.before_tokens);
-                ("after_tokens", `Int recovery.compaction.after_tokens);
+                   ("applied", `Bool recovery.compaction.applied);
+                   ( "trigger"
+                   , match recovery.compaction.trigger with
+                     | Some trigger -> Compaction_trigger.to_detail_json trigger
+                     | None -> `Null );
               ])
         | None ->
           (* Compaction infrastructure unavailable — emit [Compaction_failed]

--- a/lib/keeper/keeper_unified_metrics_broadcast.ml
+++ b/lib/keeper/keeper_unified_metrics_broadcast.ml
@@ -22,9 +22,6 @@ let broadcast_lifecycle_events ~(name : string)
              ("type", `String "keeper_compaction");
              ("name", `String name);
              ("generation", `Int turn_generation);
-             ("before_tokens", `Int compaction.before_tokens);
-             ("after_tokens", `Int compaction.after_tokens);
-             ("saved_tokens", `Int compaction.saved_tokens);
              ( "trigger",
                match compaction.trigger with
                | Some trigger -> `String (Compaction_trigger.to_label trigger)
@@ -73,4 +70,3 @@ let broadcast_lifecycle_events ~(name : string)
             (Printexc.to_string exn);
           Otel_metric_store.inc_counter Keeper_metrics.(to_string MetricsSseFailures) ~labels:[("kind", Keeper_metrics_sse_failure_kind.(to_label Handoff))] ())
   | _ -> ()
-

--- a/lib/keeper/keeper_unified_metrics_snapshot.ml
+++ b/lib/keeper/keeper_unified_metrics_snapshot.ml
@@ -125,9 +125,6 @@ let append_metrics_snapshot ~(config : Workspace.config) ~(meta : keeper_meta)
         ("message_count", `Int message_count);
         ("continuity_state", `Null);
         ("compacted", `Bool compaction.applied);
-        ("compaction_before_tokens", `Int compaction.before_tokens);
-        ("compaction_after_tokens", `Int compaction.after_tokens);
-        ("compaction_saved_tokens", `Int compaction.saved_tokens);
         ("compaction_trigger",
           match compaction.trigger with
           | Some trigger -> `String (Compaction_trigger.to_label trigger)
@@ -194,26 +191,4 @@ let append_metrics_snapshot ~(config : Workspace.config) ~(meta : keeper_meta)
       ]
   in
   Dated_jsonl.append metrics_store snapshot;
-  (* #9943: a compaction trigger that produced no token reduction
-     is invisible in [masc_keeper_compactions_total] (which counts
-     trigger fires).  Emit a dedicated counter here so dashboards
-     can alert on the noop rate — production audit (2026-04-24)
-     showed 956/972 = 98.4% of compaction snapshots were silent
-     noops.  Emit only when a trigger fired and before/after match
-     at a non-zero token count; the [trigger] label uses the
-     human-readable reason already present in the snapshot. *)
-  (match compaction.trigger with
-   | Some trigger
-     when compaction.before_tokens > 0
-       && compaction.before_tokens = compaction.after_tokens ->
-       (* Closed label set (5 values) keeps the metric cardinality bound; the
-          full numerical detail is preserved in the snapshot's
-          [compaction_trigger_detail] JSON above. *)
-       Otel_metric_store.inc_counter
-         Keeper_metrics.(to_string CompactionNoop)
-         ~labels:
-           [ ("keeper", meta.name)
-           ; ("trigger", Compaction_trigger.to_label trigger)
-           ]
-         ()
-   | _ -> ())
+  ()

--- a/lib/keeper_registry/keeper_state_machine.ml
+++ b/lib/keeper_registry/keeper_state_machine.ml
@@ -164,7 +164,7 @@ let update_conditions (c : conditions) (ev : event) : conditions =
   | Context_measured { context_actions; _ } ->
     { c with context_handoff_needed = context_actions.handoff }
   | Compaction_started -> { c with compaction_active = true }
-  | Compaction_completed _ ->
+  | Compaction_completed ->
     { c with compaction_active = false; context_overflow = false }
   | Compaction_failed _ ->
     (* Leave [context_overflow] set — the overflow has not been resolved.
@@ -265,7 +265,7 @@ let entry_actions_for ~prev_phase ~new_phase ~(event : event) : entry_action lis
          | Turn_failed _
          | Context_measured _
          | Compaction_started
-         | Compaction_completed _
+         | Compaction_completed
          | Compaction_failed _
          | Context_overflow_detected _
          | Handoff_started
@@ -296,7 +296,7 @@ let entry_actions_for ~prev_phase ~new_phase ~(event : event) : entry_action lis
          | Turn_failed _
          | Context_measured _
          | Compaction_started
-         | Compaction_completed _
+         | Compaction_completed
          | Compaction_failed _
          | Handoff_started
          | Handoff_completed _
@@ -325,7 +325,7 @@ let entry_actions_for ~prev_phase ~new_phase ~(event : event) : entry_action lis
       | Turn_failed _
       | Context_measured _
       | Compaction_started
-      | Compaction_completed _
+      | Compaction_completed
       | Compaction_failed _
       | Handoff_started
       | Handoff_completed _
@@ -375,7 +375,7 @@ let entry_actions_for ~prev_phase ~new_phase ~(event : event) : entry_action lis
        let detail =
          match event with
          | Operator_resume -> "operator request"
-         | Compaction_completed _ -> "auto-compact recovered"
+         | Compaction_completed -> "auto-compact recovered"
          | Fiber_terminated _ -> "fiber recovered"
          | Heartbeat_ok
          | Heartbeat_failed _

--- a/lib/keeper_registry/keeper_state_machine.mli
+++ b/lib/keeper_registry/keeper_state_machine.mli
@@ -147,8 +147,8 @@ type event =
   | Compaction_started
     (** Emit only through the registry lifecycle origin guard. See the
         paired lifecycle contract above. *)
-  | Compaction_completed of { before_tokens : int; after_tokens : int }
-    (** Must fire in the same turn as the matching [Compaction_started]. *)
+  | Compaction_completed
+    (** Must fire after the matching [Compaction_started] and durable save. *)
   | Compaction_failed of { reason : string }
     (** Must fire in the same turn as the matching [Compaction_started]. *)
   | Handoff_started

--- a/lib/keeper_registry/keeper_state_machine_json.ml
+++ b/lib/keeper_registry/keeper_state_machine_json.ml
@@ -55,10 +55,7 @@ let event_to_json (ev : event) : Yojson.Safe.t =
             ] )
       ]
   | Compaction_started -> obj "compaction_started" []
-  | Compaction_completed r ->
-    obj
-      "compaction_completed"
-      [ "before_tokens", `Int r.before_tokens; "after_tokens", `Int r.after_tokens ]
+  | Compaction_completed -> obj "compaction_completed" []
   | Compaction_failed r -> obj "compaction_failed" [ "reason", `String r.reason ]
   | Handoff_started -> obj "handoff_started" []
   | Handoff_completed r ->

--- a/lib/keeper_registry/keeper_state_machine_types.ml
+++ b/lib/keeper_registry/keeper_state_machine_types.ml
@@ -80,10 +80,7 @@ type event =
       ; context_actions : context_actions
       }
   | Compaction_started
-  | Compaction_completed of
-      { before_tokens : int
-      ; after_tokens : int
-      }
+  | Compaction_completed
   | Compaction_failed of { reason : string }
   | Handoff_started
   | Handoff_completed of
@@ -120,8 +117,7 @@ let event_to_string = function
   | Turn_failed r -> Printf.sprintf "turn_failed(%d)" r.consecutive
   | Context_measured r -> Printf.sprintf "context_measured(ratio=%.3f)" r.context_ratio
   | Compaction_started -> "compaction_started"
-  | Compaction_completed r ->
-    Printf.sprintf "compaction_completed(%d->%d)" r.before_tokens r.after_tokens
+  | Compaction_completed -> "compaction_completed"
   | Compaction_failed r -> Printf.sprintf "compaction_failed(%s)" r.reason
   | Handoff_started -> "handoff_started"
   | Handoff_completed r -> Printf.sprintf "handoff_completed(gen=%d)" r.generation

--- a/lib/keeper_registry/keeper_state_machine_types.mli
+++ b/lib/keeper_registry/keeper_state_machine_types.mli
@@ -47,7 +47,7 @@ type event =
       token_count : int; context_actions : context_actions;
     }
   | Compaction_started
-  | Compaction_completed of { before_tokens : int; after_tokens : int; }
+  | Compaction_completed
   | Compaction_failed of { reason : string; }
   | Handoff_started
   | Handoff_completed of { new_trace_id : string; generation : int; }

--- a/test/test_keeper_lifecycle_chaos.ml
+++ b/test/test_keeper_lifecycle_chaos.ml
@@ -134,7 +134,7 @@ let test_compaction_crash_recovery () =
   let tr = dispatch "compact" KSM.Compaction_started in
   check phase_t "2nd compaction" KSM.Compacting tr.new_phase;
   let tr = dispatch "compact"
-    (KSM.Compaction_completed { before_tokens = 100000; after_tokens = 30000 }) in
+    KSM.Compaction_completed in
   check phase_t "2nd compact → running" KSM.Running tr.new_phase;
 
   let tr = dispatch "compact"
@@ -185,7 +185,7 @@ let test_full_chaos_sequence () =
   let tr = dispatch "chaos" KSM.Compaction_started in
   check phase_t "compacting" KSM.Compacting tr.new_phase;
   let tr = dispatch "chaos"
-    (KSM.Compaction_completed { before_tokens = 100000; after_tokens = 30000 }) in
+    KSM.Compaction_completed in
   check phase_t "post-compact → running" KSM.Running tr.new_phase;
 
   let tr = dispatch "chaos" KSM.Handoff_started in

--- a/test/test_keeper_lifecycle_registry_dispatch.ml
+++ b/test/test_keeper_lifecycle_registry_dispatch.ml
@@ -151,9 +151,6 @@ let base_lifecycle ~(meta : Keeper_meta_contract.keeper_meta) : KEC.post_turn_li
         failure_reason = None;
         trigger = None;
         decision = KEC.Not_requested;
-        before_tokens = 0;
-        after_tokens = 0;
-        saved_tokens = 0;
       };
     turn_generation = meta.runtime.generation;
     context_ratio = 0.0;
@@ -285,9 +282,6 @@ let test_dispatch_post_turn_lifecycle_events_uses_workspace_base_path () =
               failure_reason = None;
               trigger = Some Compaction_trigger.Manual;
               decision = KEC.Applied Compaction_trigger.Manual;
-              before_tokens = 42;
-              after_tokens = 21;
-              saved_tokens = 21;
             };
         }
       in
@@ -344,9 +338,6 @@ let test_post_turn_compaction_runs_from_failing_health_lane () =
               failure_reason = None;
               trigger = Some Compaction_trigger.Manual;
               decision = KEC.Applied Compaction_trigger.Manual;
-              before_tokens = 42;
-              after_tokens = 21;
-              saved_tokens = 21;
             };
         }
       in
@@ -374,7 +365,7 @@ let test_compaction_completion_without_started_is_nonfatal () =
       let meta = make_keeper_meta ~name:"keeper-missing-compaction-start" () in
       ignore (KR.register ~base_path:config.base_path meta.name meta);
       let labels =
-        [ ("keeper", meta.name); ("event", "compaction_completed(42->21)") ]
+        [ ("keeper", meta.name); ("event", "compaction_completed") ]
       in
       let before =
         Masc.Otel_metric_store.get_metric_value
@@ -393,9 +384,6 @@ let test_compaction_completion_without_started_is_nonfatal () =
               failure_reason = None;
               trigger = Some Compaction_trigger.Manual;
               decision = KEC.Applied Compaction_trigger.Manual;
-              before_tokens = 42;
-              after_tokens = 21;
-              saved_tokens = 21;
             };
         }
       in
@@ -429,7 +417,7 @@ let test_post_turn_compaction_restarts_after_done_stage () =
       let config = Masc.Workspace.default_config base_dir in
       let meta = make_keeper_meta ~name:"keeper-repeat-compaction" () in
       ignore (KR.register ~base_path:config.base_path meta.name meta);
-      let lifecycle before_tokens after_tokens =
+      let lifecycle =
         {
           (base_lifecycle ~meta) with
           compaction =
@@ -440,13 +428,10 @@ let test_post_turn_compaction_restarts_after_done_stage () =
               failure_reason = None;
               trigger = Some Compaction_trigger.Manual;
               decision = KEC.Applied Compaction_trigger.Manual;
-              before_tokens;
-              after_tokens;
-              saved_tokens = before_tokens - after_tokens;
             };
         }
       in
-      let run_compaction label before_tokens after_tokens =
+      let run_compaction label =
         KEC.dispatch_keeper_phase_event
           ~config
           ~origin:KR.Post_turn_lifecycle
@@ -460,15 +445,15 @@ let test_post_turn_compaction_restarts_after_done_stage () =
         KEC.dispatch_post_turn_lifecycle_events
           ~config
           ~keeper_name:meta.name
-          (lifecycle before_tokens after_tokens);
+          lifecycle;
         match KR.get ~base_path:config.base_path meta.name with
         | Some entry ->
             check string (label ^ " completion returns running") "running"
               (KST.phase_to_string entry.phase)
         | None -> fail "expected registered keeper after compaction completion"
       in
-      run_compaction "first" 42 21;
-      run_compaction "second" 84 42)
+      run_compaction "first";
+      run_compaction "second")
 
 let test_dispatch_keeper_phase_event_rejects_unscoped_lifecycle_event () =
   let base_dir = temp_dir "keeper_lifecycle_registry_origin_guard" in

--- a/test/test_keeper_lifecycle_registry_dispatch.ml
+++ b/test/test_keeper_lifecycle_registry_dispatch.ml
@@ -511,10 +511,16 @@ let test_dispatch_keeper_phase_event_rejection_increments_metric () =
           ~labels ()
         |> Option.value ~default:0.0
       in
-      KEC.dispatch_keeper_phase_event
-        ~config
-        ~keeper_name:"missing-keeper"
-        KST.Compaction_started;
+      (match
+         KEC.dispatch_keeper_phase_event_result
+           ~config
+           ~keeper_name:"missing-keeper"
+           KST.Compaction_started
+       with
+       | Error (KEC.Transition_rejected _) -> ()
+       | Error (KEC.Compaction_invariant_violation _) ->
+         fail "missing keeper must be a transition rejection"
+       | Ok () -> fail "missing keeper lifecycle dispatch unexpectedly succeeded");
       let after =
         Masc.Otel_metric_store.get_metric_value
           Keeper_metrics.(to_string LifecycleDispatchRejections)

--- a/test/test_keeper_overflow_recovery.ml
+++ b/test/test_keeper_overflow_recovery.ml
@@ -60,7 +60,7 @@ let test_happy_path () =
   (* Compaction completes → Running (context_overflow cleared) *)
   let tr3 =
     apply_ok SM.Compacting tr2.updated_conditions
-      (SM.Compaction_completed { before_tokens = 205_000; after_tokens = 80_000 })
+      SM.Compaction_completed
   in
   check_phase SM.Running tr3.new_phase "compaction done → Running";
   check bool "context_overflow cleared" false
@@ -114,7 +114,7 @@ let test_two_consecutive_overflows () =
   in
   let tr3 =
     apply_ok SM.Compacting tr2.updated_conditions
-      (SM.Compaction_completed { before_tokens = 210_000; after_tokens = 90_000 })
+      SM.Compaction_completed
   in
   check_phase SM.Running tr3.new_phase "cycle 1 back to Running";
   (* Second overflow should be handled cleanly after the successful cycle. *)
@@ -124,18 +124,6 @@ let test_two_consecutive_overflows () =
     apply_ok SM.Overflowed tr4.updated_conditions SM.Compaction_started
   in
   check_phase SM.Compacting tr5.new_phase "cycle 2 compaction → Compacting"
-
-let test_completion_counts_are_observations () =
-  List.iter
-    (fun (before_tokens, after_tokens) ->
-      let tr1 = apply_ok SM.Running running_conds (overflow_event ()) in
-      let tr2 = apply_ok SM.Overflowed tr1.updated_conditions SM.Compaction_started in
-      let tr3 = apply_ok SM.Compacting tr2.updated_conditions
-          (SM.Compaction_completed { before_tokens; after_tokens }) in
-      check bool "completed compaction clears overflow" false
-        tr3.updated_conditions.context_overflow;
-      check_phase SM.Running tr3.new_phase "completed compaction resumes")
-    [ 180_000, 180_000; 180_000, 210_000 ]
 
 (* ── Scenario 5: heartbeat failure during Overflowed ──────── *)
 
@@ -163,7 +151,7 @@ let test_heartbeat_failure_preserved_through_overflow () =
   check_phase SM.Compacting tr3.new_phase "compact starts";
   let tr4 =
     apply_ok SM.Compacting tr3.updated_conditions
-      (SM.Compaction_completed { before_tokens = 205_000; after_tokens = 70_000 })
+      SM.Compaction_completed
   in
   (* context_overflow cleared, heartbeat_healthy=false remains → Failing *)
   check_phase SM.Failing tr4.new_phase
@@ -179,8 +167,6 @@ let () =
         test_operator_clear_returns_to_running;
       test_case "two consecutive overflows" `Quick
         test_two_consecutive_overflows;
-      test_case "completion token counts are observations" `Quick
-        test_completion_counts_are_observations;
       test_case "heartbeat failure preserved through overflow" `Quick
         test_heartbeat_failure_preserved_through_overflow;
     ]

--- a/test/test_keeper_state_machine.ml
+++ b/test/test_keeper_state_machine.ml
@@ -217,7 +217,7 @@ let test_apply_compaction_completed () =
     apply_ok
       ~current_phase:SM.Compacting
       ~conditions:compacting_conds
-      ~event:(SM.Compaction_completed { before_tokens = 100000; after_tokens = 50000 })
+      ~event:SM.Compaction_completed
   in
   check phase_t "Compacting -> Running" SM.Running tr.new_phase;
   check bool "compaction done" false tr.updated_conditions.compaction_active
@@ -231,7 +231,7 @@ let test_apply_compaction_completed_returns_to_failing_health_lane () =
     apply_ok
       ~current_phase:SM.Compacting
       ~conditions:compacting_conds
-      ~event:(SM.Compaction_completed { before_tokens = 100000; after_tokens = 50000 })
+      ~event:SM.Compaction_completed
   in
   check phase_t "Compacting -> Failing" SM.Failing tr.new_phase;
   check bool "compaction done" false tr.updated_conditions.compaction_active
@@ -971,7 +971,7 @@ let test_chain_happy_path () =
       ; SM.Heartbeat_ok, SM.Running
       ; SM.Heartbeat_ok, SM.Running
       ; SM.Compaction_started, SM.Compacting
-      ; ( SM.Compaction_completed { before_tokens = 90000; after_tokens = 40000 }
+      ; ( SM.Compaction_completed
         , SM.Running )
       ; SM.Handoff_started, SM.HandingOff
       ; SM.Handoff_completed { new_trace_id = "gen2"; generation = 2 }, SM.Running
@@ -1010,7 +1010,7 @@ let test_chain_operator_intervention () =
       ~init_conditions:running_conditions
       [ SM.Heartbeat_ok, SM.Running
       ; SM.Compaction_started, SM.Compacting
-      ; ( SM.Compaction_completed { before_tokens = 80000; after_tokens = 35000 }
+      ; ( SM.Compaction_completed
         , SM.Running )
       ; SM.Operator_pause, SM.Paused
       ; SM.Operator_resume, SM.Running
@@ -1052,12 +1052,12 @@ let test_chain_long_running_multi_cycle () =
       [ (* Cycle 1: compaction *)
         SM.Heartbeat_ok, SM.Running
       ; SM.Compaction_started, SM.Compacting
-      ; ( SM.Compaction_completed { before_tokens = 90000; after_tokens = 45000 }
+      ; ( SM.Compaction_completed
         , SM.Running )
       ; SM.Heartbeat_ok, SM.Running
       ; (* Cycle 2: compaction again *)
         SM.Compaction_started, SM.Compacting
-      ; ( SM.Compaction_completed { before_tokens = 85000; after_tokens = 40000 }
+      ; ( SM.Compaction_completed
         , SM.Running )
       ; (* Cycle 3: handoff (context still growing) *)
         SM.Handoff_started, SM.HandingOff
@@ -1065,7 +1065,7 @@ let test_chain_long_running_multi_cycle () =
       ; SM.Heartbeat_ok, SM.Running
       ; (* Cycle 4: compaction in new generation *)
         SM.Compaction_started, SM.Compacting
-      ; ( SM.Compaction_completed { before_tokens = 70000; after_tokens = 30000 }
+      ; ( SM.Compaction_completed
         , SM.Running )
       ; (* Cycle 5: another handoff *)
         SM.Handoff_started, SM.HandingOff
@@ -1296,7 +1296,7 @@ let test_chain_no_phoenix () =
         ; context_actions = { compact = false; handoff = false }
         }
     ; SM.Compaction_started
-    ; SM.Compaction_completed { before_tokens = 100; after_tokens = 50 }
+    ; SM.Compaction_completed
     ; SM.Compaction_failed { reason = "test" }
     ; SM.Handoff_started
     ; SM.Handoff_completed { new_trace_id = "x"; generation = 99 }
@@ -1359,7 +1359,7 @@ let test_chain_triple_restart_survives () =
       ; (* Finally stabilizes *)
         SM.Heartbeat_ok, SM.Running
       ; SM.Compaction_started, SM.Compacting
-      ; ( SM.Compaction_completed { before_tokens = 60000; after_tokens = 25000 }
+      ; ( SM.Compaction_completed
         , SM.Running )
       ; SM.Heartbeat_ok, SM.Running
       ]
@@ -1397,7 +1397,7 @@ let test_chain_maximum_turbulence () =
       ~init_conditions:running_conditions
       [ (* Compaction cycle *)
         SM.Compaction_started, SM.Compacting
-      ; ( SM.Compaction_completed { before_tokens = 90000; after_tokens = 40000 }
+      ; ( SM.Compaction_completed
         , SM.Running )
       ; (* Handoff cycle *)
         SM.Handoff_started, SM.HandingOff
@@ -1717,7 +1717,7 @@ let test_invariant_stop_requested_monotonic () =
     ; SM.Turn_succeeded
     ; SM.Turn_failed { consecutive = 1 }
     ; SM.Compaction_started
-    ; SM.Compaction_completed { before_tokens = 100; after_tokens = 50 }
+    ; SM.Compaction_completed
     ; SM.Handoff_started
     ; SM.Handoff_completed { new_trace_id = "x"; generation = 1 }
     ; SM.Operator_pause
@@ -1787,7 +1787,7 @@ let test_invariant_derive_matches_matrix () =
     ; SM.Turn_succeeded
     ; SM.Turn_failed { consecutive = 3 }
     ; SM.Compaction_started
-    ; SM.Compaction_completed { before_tokens = 100; after_tokens = 50 }
+    ; SM.Compaction_completed
     ; SM.Compaction_failed { reason = "test" }
     ; SM.Handoff_started
     ; SM.Handoff_completed { new_trace_id = "x"; generation = 1 }
@@ -2009,7 +2009,7 @@ let test_setclear_coverage () =
           } )
     ; "Compaction_started", SM.Compaction_started
     ; ( "Compaction_completed"
-      , SM.Compaction_completed { before_tokens = 100; after_tokens = 50 } )
+      , SM.Compaction_completed )
     ; "Compaction_failed", SM.Compaction_failed { reason = "test" }
     ; "Handoff_started", SM.Handoff_started
     ; "Handoff_completed", SM.Handoff_completed { new_trace_id = "x"; generation = 99 }

--- a/test/test_keeper_state_machine_correspondence.ml
+++ b/test/test_keeper_state_machine_correspondence.ml
@@ -261,10 +261,7 @@ let canonical_events : (string * SM.event) list =
             };
         } );
     ("CompactionStarted", SM.Compaction_started);
-    ( "CompactionCompletedWithSavings",
-      SM.Compaction_completed { before_tokens = 100_000; after_tokens = 50_000 } );
-    ( "CompactionCompletedNoSavings",
-      SM.Compaction_completed { before_tokens = 50_000; after_tokens = 50_000 } );
+    ("CompactionCompleted", SM.Compaction_completed);
     ("CompactionFailed", SM.Compaction_failed { reason = "test" });
     ("HandoffStarted", SM.Handoff_started);
     ( "HandoffCompleted",

--- a/test/test_keeper_state_machine_pbt.ml
+++ b/test/test_keeper_state_machine_pbt.ml
@@ -32,9 +32,7 @@ let gen_event_chaos : SM.event QCheck.Gen.t =
        context_ratio = ratio; message_count = 50;
        token_count = 5000; context_actions }));
     return SM.Compaction_started;
-    (let* before = int_range 1000 100000 in
-     let* after = int_range 100 (max 101 before) in
-     return (SM.Compaction_completed { before_tokens = before; after_tokens = after }));
+    return SM.Compaction_completed;
     return (SM.Compaction_failed { reason = "pbt_test" });
     return SM.Handoff_started;
     (let* gen = int_range 1 100 in
@@ -87,7 +85,7 @@ let valid_events_for_phase (phase : SM.phase) (c : SM.conditions) : SM.event lis
         SM.Fiber_terminated { outcome = "crash"; provider_id = None; http_status = None };
       ]
     | SM.Compacting ->
-      [ SM.Compaction_completed { before_tokens = 100; after_tokens = 50 };
+      [ SM.Compaction_completed;
         SM.Compaction_failed { reason = "test" };
         SM.Heartbeat_failed { consecutive = 1 };
         SM.Fiber_terminated { outcome = "crash"; provider_id = None; http_status = None };


### PR DESCRIPTION
## 목적

OAS 0.212 이후 MASC compaction 완료 계약에서 추정 token payload를 제거하고, 완료 사실만 typed state로 전달합니다. 과거 #24479의 기반 브랜치 재작성으로 실제 diff가 부모에서 빠졌기 때문에 279 churn의 독립 후속으로 재구성합니다.

## 변경

- compaction 완료 상태와 이벤트에서 token 수치 payload 제거
- dashboard/registry/metrics 소비자를 payloadless 완료 계약으로 정렬
- token-valued 완료를 전제하던 테스트를 삭제하거나 새 계약으로 수정

## 검증

- ocamlformat --check 통과
- git diff --check 통과
- parent 대비 55 additions / 224 deletions, churn 279
- focused Dune 전체 연결은 main의 아직 미병합 OAS 0.212 exit-condition/Context_reducer 잔재에 선행 차단됨; CI에서 스택 병합 순서대로 확인

No budget gate, heuristic trigger, compatibility shim을 추가하지 않습니다.