### PR TITLE
feat(fs): add durable publication recovery obligations

### DIFF
--- a/ci/lint-no-direct-dispatch.sh
+++ b/ci/lint-no-direct-dispatch.sh
@@ -55,9 +55,8 @@ scan 'Tool_dispatch\.dispatch(?=[\s\(])' 'Tool_dispatch.dispatch'
 scan 'Tool_dispatch\.dispatch_structured' 'Tool_dispatch.dispatch_structured'
 
 # `Tool_dispatch.run_pre_hooks` — PR-8 intentionally retained the manual
-# call inside dispatch_by_tag + dispatch_internal_keeper_runtime_tool
-# (mcp_server_eio_execute.ml:817, 999) because those helpers do
-# tag-based dispatch (not handler-registry) and re-route pre-hook
+# call inside dispatch_by_tag because it does tag-based dispatch (not
+# handler-registry) and re-routes pre-hook
 # semantics inside the Tool_telemetry.with_span wrap (PR-8 PR body
 # §"What this PR does NOT do"). Excluded from this lint by design;
 # follow-up cleanup PR may inline pre-hook chain into guarded_dispatch.

--- a/lib/dashboard/dashboard_briefing.ml
+++ b/lib/dashboard/dashboard_briefing.ml
@@ -330,6 +330,9 @@ let build_projection ?actor ~config ~sw ~clock
       clock;
       proc_mgr;
       net = None;
+      (* Briefing projections call only snapshot/digest reads; no Keeper lane
+         action is reachable through this context. *)
+      publication_recovery_registry = None;
       mcp_session_id = None;
     }
   in

--- a/lib/dashboard/dashboard_briefing_sections.ml
+++ b/lib/dashboard/dashboard_briefing_sections.ml
@@ -128,6 +128,8 @@ let compute_briefing_json ~actor_name ~config ~sw ~(clock : [> float Eio.Time.cl
         clock;
         proc_mgr;
         net = None;
+        (* Briefing sections use the read-only snapshot projection only. *)
+        publication_recovery_registry = None;
         mcp_session_id = None;
       }
     in

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -626,6 +626,9 @@ let json_render ~effective_actor ~light ~config ~sw ~clock ~proc_mgr () =
     ; clock
     ; proc_mgr
     ; net = None
+    (* Execution renders call only the read-only operator snapshot projection;
+       this context cannot dispatch a Keeper lane action. *)
+    ; publication_recovery_registry = None
     ; mcp_session_id = None
     }
   in

--- a/lib/fs_compat/atomic_write.ml
+++ b/lib/fs_compat/atomic_write.ml
@@ -38,18 +38,555 @@ let open_atomic_temp_file ~temp_dir () =
     atomic_tmp_suffix
 ;;
 
-type capability_write_intent =
-  | Atomic_replace
-  | Create_exclusive
+module Recovery = Capability_recovery_obligation
+module Recovery_access = Publication_recovery_access
+
+type atomic_replace_recovery_target_error =
+  | Recovery_target_validation_failed of Recovery.validation_error
+
+type atomic_replace_recovery_target =
+  { allowed_root_path : string
+  ; allowed_root : Recovery.identity
+  ; parent_components : string list
+  ; target_leaf : string
+  ; permissions : Recovery.permissions
+  }
+
+type publication_recovery_access = Recovery_access.t
+type publication_recovery_registry = Recovery_access.registry
+type publication_recovery_registry_error = Recovery.transition_error
+type publication_recovery_lane_open_error = Recovery_access.lane_open_error
+type publication_recovery_owner = Recovery_access.owner
+type publication_recovery_reconciliation_report =
+  Capability_recovery_reconciler.report
+
+type publication_recovery_owner_inventory_row =
+  | Publication_recovery_valid_owner of publication_recovery_owner
+  | Publication_recovery_invalid_owner_name of string
+  | Publication_recovery_unexpected_owner_kind of
+      { owner : publication_recovery_owner
+      ; kind : Eio.File.Stat.kind
+      }
+  | Publication_recovery_missing_owner_entry of publication_recovery_owner
+  | Publication_recovery_owner_entry_unavailable of
+      { owner : publication_recovery_owner
+      ; error : publication_recovery_registry_error
+      }
+
+type publication_recovery_owner_inventory_error =
+  | Publication_recovery_registry_inventory_in_progress
+  | Publication_recovery_registry_inventory_failed of
+      publication_recovery_registry_error
+
+type publication_recovery_owner_block =
+  | Publication_recovery_owner_inventory_block of
+      publication_recovery_owner_inventory_row
+  | Publication_recovery_owner_report_block of
+      publication_recovery_reconciliation_report
+  | Publication_recovery_owner_crash_block of
+      { owner : publication_recovery_owner
+      ; exception_ : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+  | Publication_recovery_owner_cancelled_block of
+      { owner : publication_recovery_owner
+      ; reason : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+  | Publication_recovery_owner_activation_rejected_block of
+      publication_recovery_owner
+
+type publication_recovery_reconciliation_error =
+  | Publication_recovery_owner_inventory_required of
+      publication_recovery_owner
+  | Publication_recovery_owner_inventory_in_progress of
+      publication_recovery_owner
+  | Publication_recovery_owner_not_in_inventory of
+      publication_recovery_owner
+  | Publication_recovery_owner_reconciliation_in_progress of
+      publication_recovery_owner
+  | Publication_recovery_owner_inventory_prevents_reconciliation of
+      publication_recovery_owner_inventory_row
+  | Publication_recovery_owner_reconciliation_crashed of
+      { owner : publication_recovery_owner
+      ; exception_ : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+  | Publication_recovery_owner_reconciliation_cancelled of
+      { owner : publication_recovery_owner
+      ; reason : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+  | Publication_recovery_owner_activation_rejected of
+      publication_recovery_owner
+
+type publication_recovery_activation_rejection_error =
+  | Publication_recovery_activation_inventory_required of
+      publication_recovery_owner
+  | Publication_recovery_activation_inventory_in_progress of
+      publication_recovery_owner
+  | Publication_recovery_activation_owner_not_in_inventory of
+      publication_recovery_owner
+  | Publication_recovery_activation_owner_reconciliation_running of
+      publication_recovery_owner
+  | Publication_recovery_activation_owner_already_ready of
+      publication_recovery_owner
+  | Publication_recovery_activation_owner_already_blocked of
+      publication_recovery_owner_block
+
+type publication_recovery_lane_reconciliation_error =
+  | Publication_recovery_reconciliation_required of
+      publication_recovery_owner
+  | Publication_recovery_reconciliation_in_progress of
+      publication_recovery_owner
+  | Publication_recovery_reconciliation_blocked of
+      publication_recovery_owner_block
+
+type publication_recovery_record_area =
+  | Publication_recovery_active
+  | Publication_recovery_owned
+  | Publication_recovery_forensic
+
+type publication_recovery_source_state =
+  | Publication_recovery_prepared_source
+  | Publication_recovery_bound_source
+
+type publication_recovery_prepared_outcome_kind =
+  | Publication_recovery_prepared_unmaterialized
+  | Publication_recovery_prepared_allowed_root_mismatch
+  | Publication_recovery_prepared_parent_mismatch
+  | Publication_recovery_prepared_unbound_stage_preserved
+
+type publication_recovery_bound_outcome_kind =
+  | Publication_recovery_bound_stage_absent
+  | Publication_recovery_bound_allowed_root_mismatch
+  | Publication_recovery_bound_parent_mismatch
+  | Publication_recovery_bound_stage_mismatch
+  | Publication_recovery_bound_stage_preserved
+
+type publication_recovery_reconciliation_row_kind =
+  | Publication_recovery_unexpected_lane_entry
+  | Publication_recovery_missing_lane_entry
+  | Publication_recovery_lane_entry_unavailable
+  | Publication_recovery_area_inventory_unavailable
+  | Publication_recovery_source_transition_capabilities_unavailable
+  | Publication_recovery_prepared_reconciled of
+      publication_recovery_prepared_outcome_kind
+  | Publication_recovery_bound_reconciled of
+      publication_recovery_bound_outcome_kind
+  | Publication_recovery_existing_forensic_record of
+      publication_recovery_source_state
+  | Publication_recovery_conflicting_source_records
+  | Publication_recovery_invalid_record_name
+  | Publication_recovery_unexpected_record_kind
+  | Publication_recovery_missing_record_entry
+  | Publication_recovery_record_entry_unavailable
+  | Publication_recovery_corrupt_record_preserved
+  | Publication_recovery_record_observation_failed
+  | Publication_recovery_record_transition_failed
+  | Publication_recovery_record_scope_release_failed
+  | Publication_recovery_owner_store_release_failed
+  | Publication_recovery_owner_store_unavailable
+  | Publication_recovery_owner_inventory_unavailable
+
+let open_publication_recovery_registry = Recovery_access.open_registry
+let publication_recovery_registry_error_to_string = Recovery.transition_error_to_string
+
+let project_owner_inventory_row = function
+  | Recovery_access.Valid_owner owner ->
+    Publication_recovery_valid_owner owner
+  | Recovery_access.Invalid_owner_name name ->
+    Publication_recovery_invalid_owner_name name
+  | Recovery_access.Unexpected_owner_kind { owner; kind } ->
+    Publication_recovery_unexpected_owner_kind { owner; kind }
+  | Recovery_access.Missing_owner_entry owner ->
+    Publication_recovery_missing_owner_entry owner
+  | Recovery_access.Owner_entry_unavailable { owner; error } ->
+    Publication_recovery_owner_entry_unavailable { owner; error }
+;;
+
+let inventory_publication_recovery_owners registry =
+  match Recovery_access.inventory_owners registry with
+  | Error Recovery_access.Registry_inventory_in_progress ->
+    Error Publication_recovery_registry_inventory_in_progress
+  | Error (Recovery_access.Registry_inventory_failed error) ->
+    Error (Publication_recovery_registry_inventory_failed error)
+  | Ok rows -> Ok (List.map project_owner_inventory_row rows)
+;;
+
+let publication_recovery_owner_to_string = Recovery_access.owner_to_string
+
+let project_owner_inventory_row_back = function
+  | Publication_recovery_valid_owner owner ->
+    Recovery_access.Valid_owner owner
+  | Publication_recovery_invalid_owner_name name ->
+    Recovery_access.Invalid_owner_name name
+  | Publication_recovery_unexpected_owner_kind { owner; kind } ->
+    Recovery_access.Unexpected_owner_kind { owner; kind }
+  | Publication_recovery_missing_owner_entry owner ->
+    Recovery_access.Missing_owner_entry owner
+  | Publication_recovery_owner_entry_unavailable { owner; error } ->
+    Recovery_access.Owner_entry_unavailable { owner; error }
+;;
+
+let project_owner_block = function
+  | Recovery_access.Owner_inventory_block row ->
+    Publication_recovery_owner_inventory_block
+      (project_owner_inventory_row row)
+  | Recovery_access.Owner_reconciliation_block report ->
+    Publication_recovery_owner_report_block report
+  | Recovery_access.Owner_reconciliation_crash
+      { owner; exception_; backtrace } ->
+    Publication_recovery_owner_crash_block
+      { owner; exception_; backtrace }
+  | Recovery_access.Owner_reconciliation_cancelled_block
+      { owner; reason; backtrace } ->
+    Publication_recovery_owner_cancelled_block
+      { owner; reason; backtrace }
+  | Recovery_access.Owner_activation_rejected_block owner ->
+    Publication_recovery_owner_activation_rejected_block owner
+;;
+
+let project_reconciliation_error = function
+  | Recovery_access.Owner_inventory_required owner ->
+    Publication_recovery_owner_inventory_required owner
+  | Recovery_access.Owner_inventory_in_progress owner ->
+    Publication_recovery_owner_inventory_in_progress owner
+  | Recovery_access.Owner_not_in_inventory owner ->
+    Publication_recovery_owner_not_in_inventory owner
+  | Recovery_access.Owner_reconciliation_in_progress owner ->
+    Publication_recovery_owner_reconciliation_in_progress owner
+  | Recovery_access.Owner_inventory_prevents_reconciliation row ->
+    Publication_recovery_owner_inventory_prevents_reconciliation
+      (project_owner_inventory_row row)
+  | Recovery_access.Owner_reconciliation_crashed
+      { owner; exception_; backtrace } ->
+    Publication_recovery_owner_reconciliation_crashed
+      { owner; exception_; backtrace }
+  | Recovery_access.Owner_reconciliation_cancelled
+      { owner; reason; backtrace } ->
+    Publication_recovery_owner_reconciliation_cancelled
+      { owner; reason; backtrace }
+  | Recovery_access.Owner_activation_rejected owner ->
+    Publication_recovery_owner_activation_rejected owner
+;;
+
+let project_activation_rejection_error = function
+  | Recovery_access.Activation_inventory_required owner ->
+    Publication_recovery_activation_inventory_required owner
+  | Recovery_access.Activation_inventory_in_progress owner ->
+    Publication_recovery_activation_inventory_in_progress owner
+  | Recovery_access.Activation_owner_not_in_inventory owner ->
+    Publication_recovery_activation_owner_not_in_inventory owner
+  | Recovery_access.Activation_owner_reconciliation_running owner ->
+    Publication_recovery_activation_owner_reconciliation_running owner
+  | Recovery_access.Activation_owner_already_ready owner ->
+    Publication_recovery_activation_owner_already_ready owner
+  | Recovery_access.Activation_owner_already_blocked block ->
+    Publication_recovery_activation_owner_already_blocked
+      (project_owner_block block)
+;;
+
+let reconcile_publication_recovery_owner ~fs ~registry ~owner =
+  match Recovery_access.reconcile_owner ~fs ~registry ~owner with
+  | Ok report -> Ok report
+  | Error error -> Error (project_reconciliation_error error)
+;;
+
+let reject_publication_recovery_owner_activation ~registry ~owner =
+  match Recovery_access.reject_owner_activation ~registry ~owner with
+  | Ok () -> Ok ()
+  | Error error -> Error (project_activation_rejection_error error)
+;;
+
+let publication_recovery_reconciliation_report_owner =
+  Capability_recovery_reconciler.report_owner
+;;
+
+let publication_recovery_reconciliation_report_is_ready =
+  Capability_recovery_reconciler.report_is_ready
+;;
+
+let publication_recovery_prepared_outcome_kind = function
+  | Capability_recovery_reconciler.Prepared_unmaterialized ->
+    Publication_recovery_prepared_unmaterialized
+  | Capability_recovery_reconciler.Prepared_allowed_root_mismatch _ ->
+    Publication_recovery_prepared_allowed_root_mismatch
+  | Capability_recovery_reconciler.Prepared_parent_mismatch _ ->
+    Publication_recovery_prepared_parent_mismatch
+  | Capability_recovery_reconciler.Prepared_unbound_stage_preserved _ ->
+    Publication_recovery_prepared_unbound_stage_preserved
+;;
+
+let publication_recovery_bound_outcome_kind = function
+  | Capability_recovery_reconciler.Bound_stage_absent _ ->
+    Publication_recovery_bound_stage_absent
+  | Capability_recovery_reconciler.Bound_allowed_root_mismatch _ ->
+    Publication_recovery_bound_allowed_root_mismatch
+  | Capability_recovery_reconciler.Bound_parent_mismatch _ ->
+    Publication_recovery_bound_parent_mismatch
+  | Capability_recovery_reconciler.Bound_stage_mismatch _ ->
+    Publication_recovery_bound_stage_mismatch
+  | Capability_recovery_reconciler.Bound_stage_preserved _ ->
+    Publication_recovery_bound_stage_preserved
+;;
+
+let publication_recovery_source_state = function
+  | Capability_recovery_reconciler.Prepared ->
+    Publication_recovery_prepared_source
+  | Capability_recovery_reconciler.Bound ->
+    Publication_recovery_bound_source
+;;
+
+let publication_recovery_reconciliation_row_kind = function
+  | Capability_recovery_reconciler.Unexpected_lane_entry _ ->
+    Publication_recovery_unexpected_lane_entry
+  | Capability_recovery_reconciler.Missing_lane_entry _ ->
+    Publication_recovery_missing_lane_entry
+  | Capability_recovery_reconciler.Lane_entry_unavailable _ ->
+    Publication_recovery_lane_entry_unavailable
+  | Capability_recovery_reconciler.Area_inventory_unavailable _ ->
+    Publication_recovery_area_inventory_unavailable
+  | Capability_recovery_reconciler.Source_transition_capabilities_unavailable _ ->
+    Publication_recovery_source_transition_capabilities_unavailable
+  | Capability_recovery_reconciler.Prepared_reconciled { outcome; _ } ->
+    Publication_recovery_prepared_reconciled
+      (publication_recovery_prepared_outcome_kind outcome)
+  | Capability_recovery_reconciler.Bound_reconciled { outcome; _ } ->
+    Publication_recovery_bound_reconciled
+      (publication_recovery_bound_outcome_kind outcome)
+  | Capability_recovery_reconciler.Existing_forensic_record
+      { source_state; _ } ->
+    Publication_recovery_existing_forensic_record
+      (publication_recovery_source_state source_state)
+  | Capability_recovery_reconciler.Conflicting_source_records _ ->
+    Publication_recovery_conflicting_source_records
+  | Capability_recovery_reconciler.Invalid_record_name _ ->
+    Publication_recovery_invalid_record_name
+  | Capability_recovery_reconciler.Unexpected_record_kind _ ->
+    Publication_recovery_unexpected_record_kind
+  | Capability_recovery_reconciler.Missing_record_entry _ ->
+    Publication_recovery_missing_record_entry
+  | Capability_recovery_reconciler.Record_entry_unavailable _ ->
+    Publication_recovery_record_entry_unavailable
+  | Capability_recovery_reconciler.Corrupt_record_preserved _ ->
+    Publication_recovery_corrupt_record_preserved
+  | Capability_recovery_reconciler.Record_observation_failed _ ->
+    Publication_recovery_record_observation_failed
+  | Capability_recovery_reconciler.Record_transition_failed _ ->
+    Publication_recovery_record_transition_failed
+  | Capability_recovery_reconciler.Record_scope_release_failed _ ->
+    Publication_recovery_record_scope_release_failed
+  | Capability_recovery_reconciler.Owner_store_release_failed _ ->
+    Publication_recovery_owner_store_release_failed
+  | Capability_recovery_reconciler.Owner_store_unavailable _ ->
+    Publication_recovery_owner_store_unavailable
+  | Capability_recovery_reconciler.Owner_inventory_unavailable _ ->
+    Publication_recovery_owner_inventory_unavailable
+;;
+
+let publication_recovery_reconciliation_report_row_kinds report =
+  report
+  |> Capability_recovery_reconciler.report_rows
+  |> List.map publication_recovery_reconciliation_row_kind
+;;
+
+let publication_recovery_reconciliation_report_to_string =
+  Capability_recovery_reconciler.report_to_string
+;;
+
+let publication_recovery_reconciliation_report_to_yojson =
+  Capability_recovery_reconciler.report_to_yojson
+;;
+
+let publication_recovery_owner_inventory_row_to_string row =
+  row
+  |> project_owner_inventory_row_back
+  |> Recovery_access.owner_inventory_row_to_string
+;;
+
+let publication_recovery_owner_inventory_error_to_string = function
+  | Publication_recovery_registry_inventory_in_progress ->
+    Recovery_access.inventory_error_to_string
+      Recovery_access.Registry_inventory_in_progress
+  | Publication_recovery_registry_inventory_failed error ->
+    Recovery_access.inventory_error_to_string
+      (Recovery_access.Registry_inventory_failed error)
+;;
+
+let publication_recovery_reconciliation_error_to_string error =
+  let internal =
+    match error with
+    | Publication_recovery_owner_inventory_required owner ->
+      Recovery_access.Owner_inventory_required owner
+    | Publication_recovery_owner_inventory_in_progress owner ->
+      Recovery_access.Owner_inventory_in_progress owner
+    | Publication_recovery_owner_not_in_inventory owner ->
+      Recovery_access.Owner_not_in_inventory owner
+    | Publication_recovery_owner_reconciliation_in_progress owner ->
+      Recovery_access.Owner_reconciliation_in_progress owner
+    | Publication_recovery_owner_inventory_prevents_reconciliation row ->
+      Recovery_access.Owner_inventory_prevents_reconciliation
+        (project_owner_inventory_row_back row)
+    | Publication_recovery_owner_reconciliation_crashed
+        { owner; exception_; backtrace } ->
+      Recovery_access.Owner_reconciliation_crashed
+        { owner; exception_; backtrace }
+    | Publication_recovery_owner_reconciliation_cancelled
+        { owner; reason; backtrace } ->
+      Recovery_access.Owner_reconciliation_cancelled
+        { owner; reason; backtrace }
+    | Publication_recovery_owner_activation_rejected owner ->
+      Recovery_access.Owner_activation_rejected owner
+  in
+  Recovery_access.reconciliation_error_to_string internal
+;;
+
+let publication_recovery_owner_block_to_string = function
+  | Publication_recovery_owner_inventory_block row ->
+    Recovery_access.owner_block_to_string
+      (Recovery_access.Owner_inventory_block
+         (project_owner_inventory_row_back row))
+  | Publication_recovery_owner_report_block report ->
+    Recovery_access.owner_block_to_string
+      (Recovery_access.Owner_reconciliation_block report)
+  | Publication_recovery_owner_crash_block
+      { owner; exception_; backtrace } ->
+    Recovery_access.owner_block_to_string
+      (Recovery_access.Owner_reconciliation_crash
+         { owner; exception_; backtrace })
+  | Publication_recovery_owner_cancelled_block
+      { owner; reason; backtrace } ->
+    Recovery_access.owner_block_to_string
+      (Recovery_access.Owner_reconciliation_cancelled_block
+         { owner; reason; backtrace })
+  | Publication_recovery_owner_activation_rejected_block owner ->
+    Recovery_access.owner_block_to_string
+      (Recovery_access.Owner_activation_rejected_block owner)
+;;
+
+let publication_recovery_activation_rejection_error_to_string = function
+  | Publication_recovery_activation_inventory_required owner ->
+    Recovery_access.activation_rejection_error_to_string
+      (Recovery_access.Activation_inventory_required owner)
+  | Publication_recovery_activation_inventory_in_progress owner ->
+    Recovery_access.activation_rejection_error_to_string
+      (Recovery_access.Activation_inventory_in_progress owner)
+  | Publication_recovery_activation_owner_not_in_inventory owner ->
+    Recovery_access.activation_rejection_error_to_string
+      (Recovery_access.Activation_owner_not_in_inventory owner)
+  | Publication_recovery_activation_owner_reconciliation_running owner ->
+    Recovery_access.activation_rejection_error_to_string
+      (Recovery_access.Activation_owner_reconciliation_running owner)
+  | Publication_recovery_activation_owner_already_ready owner ->
+    Recovery_access.activation_rejection_error_to_string
+      (Recovery_access.Activation_owner_already_ready owner)
+  | Publication_recovery_activation_owner_already_blocked block ->
+    let internal =
+      match block with
+      | Publication_recovery_owner_inventory_block row ->
+        Recovery_access.Owner_inventory_block
+          (project_owner_inventory_row_back row)
+      | Publication_recovery_owner_report_block report ->
+        Recovery_access.Owner_reconciliation_block report
+      | Publication_recovery_owner_crash_block
+          { owner; exception_; backtrace } ->
+        Recovery_access.Owner_reconciliation_crash
+          { owner; exception_; backtrace }
+      | Publication_recovery_owner_cancelled_block
+          { owner; reason; backtrace } ->
+        Recovery_access.Owner_reconciliation_cancelled_block
+          { owner; reason; backtrace }
+      | Publication_recovery_owner_activation_rejected_block owner ->
+        Recovery_access.Owner_activation_rejected_block owner
+    in
+    Recovery_access.activation_rejection_error_to_string
+      (Recovery_access.Activation_owner_already_blocked internal)
+;;
+
+let with_publication_recovery_lane = Recovery_access.with_lane
+
+let await_publication_recovery_lane_reconciliation =
+  Recovery_access.await_lane_reconciliation
+;;
+
+let publication_recovery_lane_open_error_to_string =
+  Recovery_access.lane_open_error_to_string
+;;
+
+let publication_recovery_lane_reconciliation_error = function
+  | Recovery_access.Invalid_owner _ | Recovery_access.Store_failed _ -> None
+  | Recovery_access.Reconciliation_required owner ->
+    Some (Publication_recovery_reconciliation_required owner)
+  | Recovery_access.Reconciliation_in_progress owner ->
+    Some (Publication_recovery_reconciliation_in_progress owner)
+  | Recovery_access.Reconciliation_blocked block ->
+    Some
+      (Publication_recovery_reconciliation_blocked
+         (project_owner_block block))
+;;
+
+let atomic_replace_recovery_target_error_to_string = function
+  | Recovery_target_validation_failed error ->
+    Recovery.validation_error_to_string error
+;;
+
+let atomic_replace_recovery_target
+      ~allowed_root_path
+      ~allowed_root_device
+      ~allowed_root_inode
+      ~parent_components
+      ~target_leaf
+      ~permissions
+  =
+  match
+    Recovery.identity ~dev:allowed_root_device ~ino:allowed_root_inode
+  with
+  | Error error -> Error (Recovery_target_validation_failed error)
+  | Ok allowed_root ->
+    (match Recovery.permissions_of_int permissions with
+     | Error error -> Error (Recovery_target_validation_failed error)
+     | Ok permissions ->
+       (match
+          Recovery.locator
+            ~allowed_root_path
+            ~allowed_root
+            ~parent_components
+            ~parent:allowed_root
+            ~target_leaf
+            ~initial_target:Recovery.Absent
+        with
+        | Error error -> Error (Recovery_target_validation_failed error)
+        | Ok validated ->
+          Ok
+            { allowed_root_path =
+                Recovery.locator_allowed_root_path validated
+            ; allowed_root
+            ; parent_components =
+                Recovery.locator_parent_components validated
+            ; target_leaf = Recovery.locator_target_leaf validated
+            ; permissions
+            }))
+;;
+
+type capability_write_operation =
+  | Atomic_replace_operation
+  | Create_exclusive_operation
 
 type capability_write_stage =
   | Validate_leaf
   | Acquire_mutation_lease
+  | Acquire_publication_lease
+  | Inspect_target_entry
+  | Verify_target_binding
+  | Prepare_recovery_obligation
   | Create_staging_directory
   | Inspect_staging_directory
   | Acquire_staging_directory
   | Apply_staging_directory_permissions
   | Verify_staging_directory_identity
+  | Preserve_unbound_recovery_obligation
+  | Bind_recovery_obligation
   | Create_staging_entry
   | Create_target_entry
   | Inspect_open_resource
@@ -63,6 +600,8 @@ type capability_write_stage =
   | Sync_parent
   | Remove_staging_directory
   | Close_staging_directory
+  | Discharge_prepared_recovery_obligation
+  | Discharge_bound_recovery_obligation
   | Cleanup_close
   | Cleanup_verify_identity
   | Cleanup_unlink
@@ -92,6 +631,7 @@ type capability_write_payload_failure =
 
 type capability_write_cause =
   | Invalid_leaf of string
+  | Invalid_recovery_target of atomic_replace_recovery_target_error
   | Mutation_contended
   | Posix_descriptor_unavailable
   | Unexpected_resource_kind of Eio.File.Stat.kind
@@ -105,11 +645,71 @@ type capability_write_failure =
   ; cause : capability_write_cause
   }
 
+type capability_recovery_phase =
+  | Recovery_validate_owner
+  | Recovery_open_registry
+  | Recovery_open_store
+  | Recovery_prepare
+  | Recovery_preserve_unbound
+  | Recovery_bind
+  | Recovery_discharge_prepared
+  | Recovery_discharge_bound
+
+type capability_recovery_removal_transition =
+  | Recovery_discharge_active
+  | Recovery_discharge_owned
+  | Recovery_active_to_owned
+  | Recovery_active_to_forensic
+  | Recovery_owned_to_forensic
+
+type capability_recovery_effect =
+  | Recovery_no_record_change
+  | Recovery_layout_may_be_incomplete
+  | Recovery_layout_ready
+  | Recovery_active_record_state_unknown
+  | Recovery_active_record_durable
+  | Recovery_active_record_discharged
+  | Recovery_owned_record_state_unknown_with_active
+  | Recovery_owned_record_durable_with_active
+  | Recovery_owned_record_durable
+  | Recovery_owned_record_discharged
+  | Recovery_forensic_record_state_unknown_with_source
+  | Recovery_forensic_record_durable_with_source
+  | Recovery_forensic_record_durable
+  | Recovery_source_removal_durability_unknown of
+      capability_recovery_removal_transition
+
+type recovery_failure_detail =
+  | Recovery_transition_failed of Recovery.transition_error
+  | Recovery_validation_failed of Recovery.validation_error
+  | Recovery_lane_admission_failed of Recovery_access.lane_open_error
+  | Recovery_transition_interrupted of
+      { reason : exn
+      ; cleanup_failures : Recovery.failure list
+      }
+
+type capability_recovery_failure =
+  { recovery_phase : capability_recovery_phase
+  ; recovery_effect : capability_recovery_effect
+  ; recovery_detail : recovery_failure_detail
+  }
+
+type capability_recovery_access_failure = Recovery_access_not_available
+
+type capability_write_primary_failure =
+  | Write_primary_failure of capability_write_failure
+  | Recovery_primary_failure of capability_recovery_failure
+  | Recovery_access_primary_failure of capability_recovery_access_failure
+
+type capability_write_cleanup_failure =
+  | Write_cleanup_failure of capability_write_failure
+  | Recovery_cleanup_failure of capability_recovery_failure
+
 type capability_write_error =
-  { intent : capability_write_intent
+  { operation : capability_write_operation
   ; target_effect : capability_write_target_effect
-  ; failure : capability_write_failure
-  ; cleanup_failures : capability_write_failure list
+  ; primary_failure : capability_write_primary_failure
+  ; cleanup_failures : capability_write_cleanup_failure list
   }
 
 type capability_directory_sync_error =
@@ -117,10 +717,32 @@ type capability_directory_sync_error =
   ; cleanup_failures : capability_write_failure list
   }
 
+type publication_recovery_fixture_error =
+  | Fixture_lane_open_failed of publication_recovery_lane_open_error
+  | Fixture_validation_failed of Recovery.validation_error
+  | Fixture_transition_failed of Recovery.transition_error
+  | Fixture_invalid_record_leaf of string
+  | Fixture_io_failed of
+      { exception_ : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+
+let publication_recovery_fixture_error_to_string = function
+  | Fixture_lane_open_failed error ->
+    publication_recovery_lane_open_error_to_string error
+  | Fixture_validation_failed error -> Recovery.validation_error_to_string error
+  | Fixture_transition_failed error -> Recovery.transition_error_to_string error
+  | Fixture_invalid_record_leaf value ->
+    Printf.sprintf "invalid recovery fixture record leaf %S" value
+  | Fixture_io_failed { exception_; _ } -> Printexc.to_string exception_
+;;
+
 type capability_write_cancellation =
-  { intent : capability_write_intent
+  { operation : capability_write_operation
   ; target_effect : capability_write_target_effect
-  ; cleanup_failures : capability_write_failure list
+  ; interrupted_primary_failure : capability_write_primary_failure option
+  ; interrupted_recovery : capability_recovery_failure option
+  ; cleanup_failures : capability_write_cleanup_failure list
   }
 
 exception Capability_write_failed of
@@ -131,14 +753,18 @@ exception Capability_write_cancelled of exn * capability_write_cancellation
 exception Parent_sync_cleanup_failed_on_cancellation of
   exn * capability_write_failure list
 
-let capability_write_intent_to_string = function
-  | Atomic_replace -> "atomic_replace"
-  | Create_exclusive -> "create_exclusive"
+let capability_write_operation_to_string = function
+  | Atomic_replace_operation -> "atomic_replace"
+  | Create_exclusive_operation -> "create_exclusive"
 ;;
 
 let capability_write_stage_to_string = function
   | Validate_leaf -> "validate_leaf"
   | Acquire_mutation_lease -> "acquire_mutation_lease"
+  | Acquire_publication_lease -> "acquire_publication_lease"
+  | Inspect_target_entry -> "inspect_target_entry"
+  | Verify_target_binding -> "verify_target_binding"
+  | Prepare_recovery_obligation -> "prepare_recovery_obligation"
   | Create_staging_directory -> "create_staging_directory"
   | Inspect_staging_directory -> "inspect_staging_directory"
   | Acquire_staging_directory -> "acquire_staging_directory"
@@ -146,6 +772,9 @@ let capability_write_stage_to_string = function
     "apply_staging_directory_permissions"
   | Verify_staging_directory_identity ->
     "verify_staging_directory_identity"
+  | Preserve_unbound_recovery_obligation ->
+    "preserve_unbound_recovery_obligation"
+  | Bind_recovery_obligation -> "bind_recovery_obligation"
   | Create_staging_entry -> "create_staging_entry"
   | Create_target_entry -> "create_target_entry"
   | Inspect_open_resource -> "inspect_open_resource"
@@ -159,6 +788,10 @@ let capability_write_stage_to_string = function
   | Sync_parent -> "sync_parent"
   | Remove_staging_directory -> "remove_staging_directory"
   | Close_staging_directory -> "close_staging_directory"
+  | Discharge_prepared_recovery_obligation ->
+    "discharge_prepared_recovery_obligation"
+  | Discharge_bound_recovery_obligation ->
+    "discharge_bound_recovery_obligation"
   | Cleanup_close -> "cleanup_close"
   | Cleanup_verify_identity -> "cleanup_verify_identity"
   | Cleanup_unlink -> "cleanup_unlink"
@@ -180,7 +813,12 @@ let capability_write_target_effect_to_string = function
 
 let capability_write_cause_to_string = function
   | Invalid_leaf leaf -> Printf.sprintf "invalid leaf component: %S" leaf
-  | Mutation_contended -> "another cooperative writer owns this entry"
+  | Invalid_recovery_target error ->
+    Printf.sprintf
+      "invalid recovery target: %s"
+      (atomic_replace_recovery_target_error_to_string error)
+  | Mutation_contended ->
+    "another cooperative writer owns this target or parent publication boundary"
   | Posix_descriptor_unavailable -> "POSIX descriptor unavailable"
   | Unexpected_resource_kind kind ->
     Format.asprintf "unexpected resource kind: %a" Eio.File.Stat.pp_kind kind
@@ -201,21 +839,174 @@ let capability_write_failure_to_string failure =
     (capability_write_cause_to_string failure.cause)
 ;;
 
+let capability_recovery_phase_to_string = function
+  | Recovery_validate_owner -> "validate_owner"
+  | Recovery_open_registry -> "open_registry"
+  | Recovery_open_store -> "open_store"
+  | Recovery_prepare -> "prepare"
+  | Recovery_preserve_unbound -> "preserve_unbound"
+  | Recovery_bind -> "bind"
+  | Recovery_discharge_prepared -> "discharge_prepared"
+  | Recovery_discharge_bound -> "discharge_bound"
+;;
+
+let capability_recovery_removal_transition_to_string = function
+  | Recovery_discharge_active -> "discharge_active"
+  | Recovery_discharge_owned -> "discharge_owned"
+  | Recovery_active_to_owned -> "active_to_owned"
+  | Recovery_active_to_forensic -> "active_to_forensic"
+  | Recovery_owned_to_forensic -> "owned_to_forensic"
+;;
+
+let capability_recovery_effect_of_core = function
+  | Recovery.No_record_change -> Recovery_no_record_change
+  | Recovery.Layout_may_be_incomplete -> Recovery_layout_may_be_incomplete
+  | Recovery.Layout_ready -> Recovery_layout_ready
+  | Recovery.Active_record_state_unknown ->
+    Recovery_active_record_state_unknown
+  | Recovery.Active_record_durable -> Recovery_active_record_durable
+  | Recovery.Active_record_discharged -> Recovery_active_record_discharged
+  | Recovery.Owned_record_state_unknown_with_active ->
+    Recovery_owned_record_state_unknown_with_active
+  | Recovery.Owned_record_durable_with_active ->
+    Recovery_owned_record_durable_with_active
+  | Recovery.Owned_record_durable -> Recovery_owned_record_durable
+  | Recovery.Owned_record_discharged -> Recovery_owned_record_discharged
+  | Recovery.Forensic_record_state_unknown_with_source ->
+    Recovery_forensic_record_state_unknown_with_source
+  | Recovery.Forensic_record_durable_with_source ->
+    Recovery_forensic_record_durable_with_source
+  | Recovery.Forensic_record_durable -> Recovery_forensic_record_durable
+  | Recovery.Source_removal_durability_unknown transition ->
+    let transition =
+      match transition with
+      | Recovery.Discharge_active -> Recovery_discharge_active
+      | Recovery.Discharge_owned -> Recovery_discharge_owned
+      | Recovery.Active_to_owned -> Recovery_active_to_owned
+      | Recovery.Active_to_forensic -> Recovery_active_to_forensic
+      | Recovery.Owned_to_forensic -> Recovery_owned_to_forensic
+    in
+    Recovery_source_removal_durability_unknown transition
+;;
+
+let capability_recovery_effect_to_string = function
+  | Recovery_no_record_change -> "no_record_change"
+  | Recovery_layout_may_be_incomplete -> "layout_may_be_incomplete"
+  | Recovery_layout_ready -> "layout_ready"
+  | Recovery_active_record_state_unknown -> "active_record_state_unknown"
+  | Recovery_active_record_durable -> "active_record_durable"
+  | Recovery_active_record_discharged -> "active_record_discharged"
+  | Recovery_owned_record_state_unknown_with_active ->
+    "owned_record_state_unknown_with_active"
+  | Recovery_owned_record_durable_with_active ->
+    "owned_record_durable_with_active"
+  | Recovery_owned_record_durable -> "owned_record_durable"
+  | Recovery_owned_record_discharged -> "owned_record_discharged"
+  | Recovery_forensic_record_state_unknown_with_source ->
+    "forensic_record_state_unknown_with_source"
+  | Recovery_forensic_record_durable_with_source ->
+    "forensic_record_durable_with_source"
+  | Recovery_forensic_record_durable -> "forensic_record_durable"
+  | Recovery_source_removal_durability_unknown transition ->
+    Printf.sprintf
+      "source_removal_durability_unknown(%s)"
+      (capability_recovery_removal_transition_to_string transition)
+;;
+
+let capability_recovery_failure_phase failure = failure.recovery_phase
+let capability_recovery_failure_effect failure = failure.recovery_effect
+
+let capability_recovery_failure_to_string failure =
+  let detail =
+    match failure.recovery_detail with
+    | Recovery_transition_failed error ->
+      Recovery.transition_error_to_string error
+    | Recovery_validation_failed error ->
+      Recovery.validation_error_to_string error
+    | Recovery_lane_admission_failed error ->
+      Recovery_access.lane_open_error_to_string error
+    | Recovery_transition_interrupted { reason; cleanup_failures } ->
+      let cleanup =
+        match cleanup_failures with
+        | [] -> ""
+        | failures ->
+          failures
+          |> List.map Recovery.failure_to_string
+          |> String.concat "; "
+          |> Printf.sprintf " cleanup_failures=[%s]"
+      in
+      Printf.sprintf
+        "transition interrupted reason=%s%s"
+        (Printexc.to_string reason)
+        cleanup
+  in
+  Printf.sprintf
+    "phase=%s effect=%s reason=%s"
+    (capability_recovery_phase_to_string failure.recovery_phase)
+    (capability_recovery_effect_to_string failure.recovery_effect)
+    detail
+;;
+
+let recovery_transition_failure
+      recovery_phase
+      (error : Recovery.transition_error)
+  =
+  { recovery_phase
+  ; recovery_effect = capability_recovery_effect_of_core error.Recovery.store_effect
+  ; recovery_detail = Recovery_transition_failed error
+  }
+;;
+
+let recovery_validation_failure recovery_phase error =
+  { recovery_phase
+  ; recovery_effect = Recovery_no_record_change
+  ; recovery_detail = Recovery_validation_failed error
+  }
+;;
+
+let recovery_lane_admission_failure error =
+  { recovery_phase = Recovery_open_store
+  ; recovery_effect = Recovery_no_record_change
+  ; recovery_detail = Recovery_lane_admission_failed error
+  }
+;;
+
+let recovery_interruption recovery_phase store_effect reason cleanup_failures =
+  { recovery_phase
+  ; recovery_effect = capability_recovery_effect_of_core store_effect
+  ; recovery_detail = Recovery_transition_interrupted { reason; cleanup_failures }
+  }
+;;
+
+let capability_write_primary_failure_to_string = function
+  | Write_primary_failure failure -> capability_write_failure_to_string failure
+  | Recovery_primary_failure failure ->
+    capability_recovery_failure_to_string failure
+  | Recovery_access_primary_failure Recovery_access_not_available ->
+    "publication recovery access is not available for this Keeper lane"
+;;
+
+let capability_write_cleanup_failure_to_string = function
+  | Write_cleanup_failure failure -> capability_write_failure_to_string failure
+  | Recovery_cleanup_failure failure ->
+    capability_recovery_failure_to_string failure
+;;
+
 let capability_write_error_to_string (error : capability_write_error) =
   let cleanup =
     match error.cleanup_failures with
     | [] -> ""
     | failures ->
       failures
-      |> List.map capability_write_failure_to_string
+      |> List.map capability_write_cleanup_failure_to_string
       |> String.concat "; "
       |> Printf.sprintf " cleanup_failures=[%s]"
   in
   Printf.sprintf
-    "intent=%s target_effect=%s failure=(%s)%s"
-    (capability_write_intent_to_string error.intent)
+    "operation=%s target_effect=%s failure=(%s)%s"
+    (capability_write_operation_to_string error.operation)
     (capability_write_target_effect_to_string error.target_effect)
-    (capability_write_failure_to_string error.failure)
+    (capability_write_primary_failure_to_string error.primary_failure)
     cleanup
 ;;
 
@@ -296,24 +1087,8 @@ let identity_of_open_file ~before_stage file =
     file
 ;;
 
-(* UUID entropy names an exclusive per-write staging directory;
-   correctness comes from exclusive mkdir and typed collision retry, and the
-   nonce never drives publication policy. NDT-OK *)
-let capability_staging_rng = Domain.DLS.new_key Random.State.make_self_init
-let capability_staging_directory_prefix = ".masc_atomic_stage_"
-let capability_staging_directory_suffix = ".dir"
 let capability_staging_payload_leaf = "payload"
 let capability_staging_directory_permissions = 0o700
-
-let fresh_capability_staging_directory_name () =
-  let generator = Uuidm.v4_gen (Domain.DLS.get capability_staging_rng) in
-  let nonce = generator () |> Uuidm.to_string in
-  Printf.sprintf
-    "%s%s%s"
-    capability_staging_directory_prefix
-    nonce
-    capability_staging_directory_suffix
-;;
 
 let validate_leaf ~before_stage leaf =
   run_stage ~before_stage Validate_leaf (fun () ->
@@ -518,6 +1293,137 @@ let cleanup_parent_if_dirty ~before_stage ~sw ~parent parent_dirty =
     failures
 ;;
 
+exception Capability_recovery_failed of capability_recovery_failure
+
+exception Capability_recovery_operation_cancelled of
+  exn * capability_recovery_failure
+
+let run_recovery_transition
+      ~before_stage
+      ~stage
+      ~recovery_phase
+      operation
+  =
+  try
+    run_stage ~before_stage stage (fun () -> ());
+    match operation () with
+    | Ok value -> value
+    | Error error ->
+      raise
+        (Capability_recovery_failed
+           (recovery_transition_failure recovery_phase error))
+  with
+  | Eio.Cancel.Cancelled reason ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    let original_reason, store_effect, cleanup_failures =
+      match reason with
+      | Recovery.Recovery_store_cancelled
+          (original_reason, store_effect, cleanup_failures) ->
+        original_reason, store_effect, cleanup_failures
+      | original_reason -> original_reason, Recovery.No_record_change, []
+    in
+    let interruption =
+      recovery_interruption
+        recovery_phase
+        store_effect
+        original_reason
+        cleanup_failures
+    in
+    Printexc.raise_with_backtrace
+      (Eio.Cancel.Cancelled
+         (Capability_recovery_operation_cancelled
+            (original_reason, interruption)))
+      backtrace
+;;
+
+let recovery_identity ~stage (identity : resource_identity) =
+  match Recovery.identity ~dev:identity.dev ~ino:identity.ino with
+  | Ok identity -> identity
+  | Error _ -> raise_failure stage Resource_identity_unavailable
+;;
+
+let recovery_identity_of_stat ~stage (stat : Eio.File.Stat.t) =
+  recovery_identity ~stage { dev = stat.dev; ino = stat.ino }
+;;
+
+let observe_target_entry_at ~before_stage ~stage target =
+  run_stage ~before_stage stage (fun () ->
+    try
+      let stat = Eio.Path.stat ~follow:false target in
+      (match stat.kind with
+       | `Regular_file | `Symbolic_link ->
+         Recovery.Present
+           { kind = stat.kind
+           ; identity = recovery_identity_of_stat ~stage stat
+           }
+       | kind ->
+         raise_failure stage (Unexpected_resource_kind kind))
+    with
+    | Eio.Io (Eio.Fs.E (Eio.Fs.Not_found _), _) -> Recovery.Absent)
+;;
+
+let observe_target_entry ~before_stage target =
+  observe_target_entry_at ~before_stage ~stage:Inspect_target_entry target
+;;
+
+let mutation_lease_key
+      ~(parent_stat : Eio.File.Stat.t)
+      (observation : Recovery.entry_observation)
+  =
+  match observation with
+  | Recovery.Absent ->
+    Capability_mutation_lease.Absent_target_parent
+      { parent_dev = parent_stat.dev; parent_ino = parent_stat.ino }
+  | Recovery.Present { identity; _ } ->
+    Capability_mutation_lease.Existing_target
+      { target_dev = Recovery.identity_dev identity
+      ; target_ino = Recovery.identity_ino identity
+      ; parent_dev = parent_stat.dev
+      ; parent_ino = parent_stat.ino
+      }
+;;
+
+let same_target_observation left right =
+  match left, right with
+  | Recovery.Absent, Recovery.Absent -> true
+  | ( Recovery.Present left
+    , Recovery.Present right ) ->
+    left.kind = right.kind
+    && Recovery.equal_identity left.identity right.identity
+  | Recovery.Absent, Recovery.Present _
+  | Recovery.Present _, Recovery.Absent -> false
+;;
+
+let write_cleanup_failures failures =
+  List.map (fun failure -> Write_cleanup_failure failure) failures
+;;
+
+let capture_recovery_cleanup ~recovery_phase operation =
+  try
+    match operation () with
+    | Ok _ -> []
+    | Error error ->
+      [ Recovery_cleanup_failure
+          (recovery_transition_failure recovery_phase error)
+      ]
+  with
+  | Eio.Cancel.Cancelled reason ->
+    let original_reason, store_effect, cleanup_failures =
+      match reason with
+      | Recovery.Recovery_store_cancelled
+          (original_reason, store_effect, cleanup_failures) ->
+        original_reason, store_effect, cleanup_failures
+      | original_reason -> original_reason, Recovery.No_record_change, []
+    in
+    [ Recovery_cleanup_failure
+        (recovery_interruption
+           recovery_phase
+           store_effect
+           original_reason
+           cleanup_failures)
+    ]
+;;
+
 let cleanup_owned_staging_directory
       ~before_stage
       ~sw
@@ -641,19 +1547,559 @@ let cleanup_owned_staging_directory
     !failures)
 ;;
 
-let publish_capability_file_with
+let replace_capability_file_with
+      ~before_stage
+      ~recovery
+      ~parent
+      ~target:recovery_target
+      content
+  =
+  let operation = Atomic_replace_operation in
+  let target_effect = ref Target_unchanged in
+  let callback_result = ref None in
+  try
+    let () =
+      match Capability_leaf.of_string recovery_target.target_leaf with
+      | Some _ -> ()
+      | None ->
+        raise_failure
+          Validate_leaf
+          (Invalid_recovery_target
+             (Recovery_target_validation_failed
+                (Recovery.Invalid_target_leaf recovery_target.target_leaf)))
+    in
+    Eio.Switch.run @@ fun sw ->
+    let parent_stat =
+      run_stage
+        ~before_stage:(fun _ -> ())
+        Acquire_mutation_lease
+        (fun () ->
+        let parent_stat = Eio.Path.stat ~follow:true parent in
+        if parent_stat.kind <> `Directory
+        then
+          raise_failure
+            Acquire_mutation_lease
+            (Unexpected_resource_kind parent_stat.kind);
+        parent_stat)
+    in
+    let target_path = Eio.Path.(parent / recovery_target.target_leaf) in
+    let preliminary_target = observe_target_entry ~before_stage target_path in
+    let mutation_lease =
+      run_stage ~before_stage Acquire_mutation_lease (fun () ->
+        match
+          preliminary_target
+          |> mutation_lease_key ~parent_stat
+          |> Capability_mutation_lease.try_acquire
+        with
+        | Some lease -> lease
+        | None -> raise_failure Acquire_mutation_lease Mutation_contended)
+    in
+    Eio.Switch.on_release sw (fun () ->
+      Capability_mutation_lease.release mutation_lease);
+    let initial_target = observe_target_entry ~before_stage target_path in
+    if not (same_target_observation preliminary_target initial_target)
+    then raise_failure Inspect_target_entry Resource_identity_changed;
+    let parent_identity =
+      recovery_identity_of_stat ~stage:Inspect_target_entry parent_stat
+    in
+    let locator =
+      match
+        Recovery.locator
+          ~allowed_root_path:recovery_target.allowed_root_path
+          ~allowed_root:recovery_target.allowed_root
+          ~parent_components:recovery_target.parent_components
+          ~parent:parent_identity
+          ~target_leaf:recovery_target.target_leaf
+          ~initial_target
+      with
+      | Ok locator -> locator
+      | Error error ->
+        raise_failure
+          Inspect_target_entry
+          (Invalid_recovery_target
+             (Recovery_target_validation_failed error))
+    in
+    let staging_path = ref None in
+    let staging_directory = ref None in
+    let staging_directory_file = ref None in
+    let staging_directory_identity = ref None in
+    let staging_directory_created = ref false in
+    let staging_directory_removed = ref false in
+    let payload_entry = ref None in
+    let open_file = ref None in
+    let payload_identity = ref None in
+    let payload_created = ref false in
+    let published = ref false in
+    let parent_dirty = ref false in
+    let prepared = ref None in
+    let bound = ref None in
+    let bind_started = ref false in
+    let prepared_discharge_started = ref false in
+    let bound_discharge_started = ref false in
+    let cleanup () =
+      Eio.Cancel.protect (fun () ->
+        let write_failures =
+          cleanup_owned_staging_directory
+            ~before_stage
+            ~sw
+            ~parent
+            ~staging_path
+            ~staging_directory_file
+            ~staging_directory_identity
+            ~staging_directory_created
+            ~staging_directory_removed
+            ~payload_entry
+            ~payload_file:open_file
+            ~payload_identity
+            ~payload_created
+            ~payload_published:published
+            ~parent_dirty
+        in
+        let cleanup_failures = ref (write_cleanup_failures write_failures) in
+        let exact_stage_absent_and_synced = ref false in
+        if (not !staging_directory_created) && write_failures = []
+        then (
+          let absent = ref false in
+          let inspect_failures =
+            capture_cleanup
+              ~before_stage
+              Cleanup_verify_staging_directory_identity
+              (fun () ->
+                 match !staging_path with
+                 | None -> ()
+                 | Some path ->
+                   (try ignore (Eio.Path.stat ~follow:false path) with
+                    | Eio.Io (Eio.Fs.E (Eio.Fs.Not_found _), _) ->
+                      absent := true))
+          in
+          cleanup_failures :=
+            !cleanup_failures @ write_cleanup_failures inspect_failures;
+          if !absent && inspect_failures = []
+          then (
+            let sync_failures =
+              capture_cleanup ~before_stage Cleanup_sync_parent (fun () ->
+                sync_parent_capability
+                  ~before_stage:(fun _ -> ())
+                  ~stage:Cleanup_sync_parent
+                  ~sw
+                  parent)
+            in
+            cleanup_failures :=
+              !cleanup_failures @ write_cleanup_failures sync_failures;
+            exact_stage_absent_and_synced := sync_failures = []))
+        else
+          exact_stage_absent_and_synced :=
+            !staging_directory_removed
+            && not !parent_dirty
+            && write_failures = [];
+        if !cleanup_failures = []
+           && !exact_stage_absent_and_synced
+           && !target_effect <> Target_state_unknown
+        then (
+          match !bound with
+          | Some obligation when not !bound_discharge_started ->
+            bound_discharge_started := true;
+            cleanup_failures :=
+              !cleanup_failures
+              @ capture_recovery_cleanup
+                  ~recovery_phase:Recovery_discharge_bound
+                  (fun () -> Recovery.discharge_bound ~store:recovery ~bound:obligation)
+          | None when (not !bind_started) && not !prepared_discharge_started ->
+            (match !prepared with
+             | None -> ()
+             | Some obligation ->
+               prepared_discharge_started := true;
+               cleanup_failures :=
+                 !cleanup_failures
+                 @ capture_recovery_cleanup
+                     ~recovery_phase:Recovery_discharge_prepared
+                     (fun () ->
+                        Recovery.discharge_prepared
+                          ~store:recovery
+                          ~prepared:obligation))
+          | Some _ | None -> ());
+        !cleanup_failures)
+    in
+    let error primary_failure additional =
+      let cleanup_failures = additional @ cleanup () in
+      Error
+        { operation
+        ; target_effect = !target_effect
+        ; primary_failure
+        ; cleanup_failures
+        }
+    in
+    let result =
+      try
+       let rec prepare_and_create_stage () =
+         let obligation =
+           run_recovery_transition
+             ~before_stage
+             ~stage:Prepare_recovery_obligation
+             ~recovery_phase:Recovery_prepare
+             (fun () ->
+                Recovery.prepare
+                  ~store:recovery
+                  ~locator
+                  ~permissions:recovery_target.permissions)
+         in
+         prepared := Some obligation;
+         let path =
+           Eio.Path.
+             (parent
+              / Recovery.stage_name
+                  (Recovery.prepared_operation_id obligation))
+         in
+         staging_path := Some path;
+         let creation =
+           Eio.Cancel.protect (fun () ->
+             run_stage ~before_stage Create_staging_directory (fun () ->
+               try
+                 Eio.Path.mkdir
+                   ~perm:capability_staging_directory_permissions
+                   path;
+                 staging_directory_created := true;
+                 parent_dirty := true;
+                 `Created
+               with
+               | Eio.Io (Eio.Fs.E (Eio.Fs.Already_exists _), _) ->
+                 `Collision))
+         in
+         match creation with
+         | `Created -> obligation, path
+         | `Collision ->
+           let collision =
+             run_stage ~before_stage Inspect_staging_directory (fun () ->
+               Eio.Path.stat ~follow:false path)
+           in
+           let collision_identity =
+             recovery_identity_of_stat
+               ~stage:Inspect_staging_directory
+               collision
+           in
+           ignore
+             (run_recovery_transition
+                ~before_stage
+                ~stage:Preserve_unbound_recovery_obligation
+                ~recovery_phase:Recovery_preserve_unbound
+                (fun () ->
+                   Recovery.preserve_unbound
+                     ~store:recovery
+                     ~prepared:obligation
+                     ~kind:collision.kind
+                     ~stage_identity:collision_identity));
+           prepared := None;
+           staging_path := None;
+           Eio.Fiber.check ();
+           prepare_and_create_stage ()
+       in
+       let obligation, path = prepare_and_create_stage () in
+       let created_identity =
+         run_stage ~before_stage Inspect_staging_directory (fun () ->
+           let lexical = Eio.Path.stat ~follow:false path in
+           if lexical.kind <> `Directory
+           then
+             raise_failure
+               Inspect_staging_directory
+               (Unexpected_resource_kind lexical.kind);
+           { dev = lexical.dev; ino = lexical.ino })
+       in
+       staging_directory_identity := Some created_identity;
+       run_stage ~before_stage Acquire_staging_directory (fun () ->
+         let directory = Eio.Path.open_dir ~sw path in
+         staging_directory := Some directory;
+         let directory_file =
+           Eio.Path.open_in ~sw Eio.Path.(directory / ".")
+         in
+         staging_directory_file := Some directory_file;
+         let opened = Eio.File.stat directory_file in
+         if opened.kind <> `Directory
+         then
+           raise_failure
+             Acquire_staging_directory
+             (Unexpected_resource_kind opened.kind);
+         if not (same_resource_identity created_identity opened)
+         then raise_failure Acquire_staging_directory Resource_identity_changed);
+       (match !staging_directory_file with
+        | None ->
+          raise_failure
+            Apply_staging_directory_permissions
+            Resource_identity_unavailable
+        | Some directory_file ->
+          set_open_directory_permissions ~before_stage directory_file);
+       verify_path_identity
+         ~before_stage
+         ~stage:Verify_staging_directory_identity
+         ~expected_kind:`Directory
+         path
+         staging_directory_identity;
+       bind_started := true;
+       let bound_obligation =
+         run_recovery_transition
+           ~before_stage
+           ~stage:Bind_recovery_obligation
+           ~recovery_phase:Recovery_bind
+           (fun () ->
+              Recovery.bind
+                ~store:recovery
+                ~prepared:obligation
+                ~stage_identity:
+                  (recovery_identity
+                     ~stage:Bind_recovery_obligation
+                     created_identity))
+       in
+       bound := Some bound_obligation;
+       let entry, file =
+         run_stage ~before_stage Create_staging_entry (fun () ->
+           match !staging_directory with
+           | None ->
+             raise_failure
+               Create_staging_entry
+               Resource_identity_unavailable
+           | Some directory ->
+             let entry =
+               Eio.Path.
+                 ( (directory :> Eio.Fs.dir_ty Eio.Path.t)
+                   / capability_staging_payload_leaf )
+             in
+             entry, Eio.Path.open_out ~sw ~create:(`Exclusive 0o600) entry)
+       in
+       payload_entry := Some entry;
+       open_file := Some file;
+       payload_created := true;
+       payload_identity := Some (identity_of_open_file ~before_stage file);
+       write_open_file_payload ~before_stage file content;
+       set_open_file_permissions
+         ~before_stage
+         file
+         (Recovery.permissions_to_int recovery_target.permissions);
+       run_stage ~before_stage Sync_payload (fun () -> Eio.File.sync file);
+       close_open_entry ~before_stage open_file;
+       Eio.Fiber.check ();
+       Eio.Cancel.protect (fun () ->
+         verify_entry_identity
+           ~before_stage
+           ~stage:Verify_entry_identity
+           entry
+           payload_identity;
+         let publish () =
+           let publication_target =
+             observe_target_entry_at
+               ~before_stage
+               ~stage:Verify_target_binding
+               target_path
+           in
+           if not (same_target_observation initial_target publication_target)
+           then
+             raise_failure
+               Verify_target_binding
+               Resource_identity_changed;
+           run_stage ~before_stage Publish_replace (fun () ->
+             try Eio.Path.rename entry target_path with
+             | Eio.Cancel.Cancelled _ as cancellation ->
+               target_effect := Target_state_unknown;
+               raise cancellation
+             | exception_ ->
+               let backtrace = Printexc.get_raw_backtrace () in
+               target_effect := Target_state_unknown;
+               raise
+                 (Capability_write_failed
+                    ( operation_failure
+                        Publish_replace
+                        exception_
+                        backtrace
+                    , [] )))
+         in
+         (match initial_target with
+          | Recovery.Absent -> publish ()
+          | Recovery.Present _ ->
+            let publication_lease =
+              run_stage ~before_stage Acquire_publication_lease (fun () ->
+                match
+                  Capability_mutation_lease.try_acquire
+                    (Capability_mutation_lease.Existing_publication_parent
+                       { parent_dev = parent_stat.dev
+                       ; parent_ino = parent_stat.ino
+                       })
+                with
+                | Some lease -> lease
+                | None ->
+                  raise_failure
+                    Acquire_publication_lease
+                    Mutation_contended)
+            in
+            Fun.protect
+              ~finally:(fun () ->
+                Capability_mutation_lease.release publication_lease)
+              publish);
+         published := true;
+         target_effect := Target_replaced;
+         parent_dirty := true;
+         (match !staging_directory_file with
+          | None ->
+            raise_failure
+              Sync_staging_directory
+              Resource_identity_unavailable
+          | Some directory_file ->
+            sync_open_directory_file
+              ~before_stage
+              ~stage:Sync_staging_directory
+              directory_file);
+         verify_path_identity
+           ~before_stage
+           ~stage:Verify_staging_directory_identity
+           ~expected_kind:`Directory
+           path
+           staging_directory_identity;
+         run_stage ~before_stage Remove_staging_directory (fun () ->
+           Eio.Path.rmdir path);
+         staging_directory_removed := true;
+         close_open_resource
+           ~before_stage
+           ~stage:Close_staging_directory
+           staging_directory_file;
+         sync_parent_capability ~before_stage ~stage:Sync_parent ~sw parent;
+         parent_dirty := false;
+         bound_discharge_started := true;
+         ignore
+           (run_recovery_transition
+              ~before_stage
+              ~stage:Discharge_bound_recovery_obligation
+              ~recovery_phase:Recovery_discharge_bound
+              (fun () ->
+                 Recovery.discharge_bound
+                   ~store:recovery
+                   ~bound:bound_obligation)));
+       Eio.Fiber.check ();
+       Ok ()
+     with
+     | Eio.Cancel.Cancelled reason as cancellation ->
+       let backtrace = Printexc.get_raw_backtrace () in
+       let reason, interrupted_recovery, additional =
+         match reason with
+         | Capability_recovery_operation_cancelled (reason, interruption) ->
+           reason, Some interruption, []
+         | Parent_sync_cleanup_failed_on_cancellation (reason, failures) ->
+           reason, None, write_cleanup_failures failures
+         | reason -> reason, None, []
+       in
+       let cleanup_failures = additional @ cleanup () in
+       if
+         !target_effect = Target_unchanged
+         && Option.is_none interrupted_recovery
+         && cleanup_failures = []
+       then Printexc.raise_with_backtrace cancellation backtrace
+       else
+         Printexc.raise_with_backtrace
+           (Eio.Cancel.Cancelled
+              (Capability_write_cancelled
+                 ( reason
+                 , { operation
+                   ; target_effect = !target_effect
+                   ; interrupted_primary_failure = None
+                   ; interrupted_recovery
+                   ; cleanup_failures
+                   } )))
+           backtrace
+     | Capability_recovery_failed failure ->
+       error (Recovery_primary_failure failure) []
+     | Capability_write_failed (failure, additional) ->
+       error
+         (Write_primary_failure failure)
+         (write_cleanup_failures additional)
+     | exception_ ->
+       let backtrace = Printexc.get_raw_backtrace () in
+       error
+         (Write_primary_failure
+            (operation_failure Create_staging_directory exception_ backtrace))
+         []
+    in
+    callback_result := Some result;
+    Eio.Fiber.check ();
+    result
+  with
+  | Eio.Cancel.Cancelled (Capability_write_cancelled _) as cancellation ->
+    raise cancellation
+  | Eio.Cancel.Cancelled reason as cancellation ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    (match !callback_result with
+     | Some (Error error) ->
+       Printexc.raise_with_backtrace
+         (Eio.Cancel.Cancelled
+            (Capability_write_cancelled
+               ( reason
+               , { operation
+                 ; target_effect = !target_effect
+                 ; interrupted_primary_failure = Some error.primary_failure
+                 ; interrupted_recovery = None
+                 ; cleanup_failures = error.cleanup_failures
+                 } )))
+         backtrace
+     | Some (Ok ()) | None ->
+       if !target_effect = Target_unchanged
+       then Printexc.raise_with_backtrace cancellation backtrace
+       else
+         Printexc.raise_with_backtrace
+           (Eio.Cancel.Cancelled
+              (Capability_write_cancelled
+                 ( reason
+                 , { operation
+                   ; target_effect = !target_effect
+                   ; interrupted_primary_failure = None
+                   ; interrupted_recovery = None
+                   ; cleanup_failures = []
+                   } )))
+           backtrace)
+  | Capability_write_failed (failure, cleanup_failures) ->
+    (match !callback_result with
+     | Some (Error error) ->
+       Error
+         { error with
+           cleanup_failures =
+             error.cleanup_failures
+             @ write_cleanup_failures (failure :: cleanup_failures)
+         }
+     | Some (Ok ()) | None ->
+       Error
+         { operation
+         ; target_effect = !target_effect
+         ; primary_failure = Write_primary_failure failure
+         ; cleanup_failures = write_cleanup_failures cleanup_failures
+         })
+  | exception_ ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    let release_failure = operation_failure Cleanup_close exception_ backtrace in
+    (match !callback_result with
+     | Some (Error error) ->
+       Error
+         { error with
+           cleanup_failures =
+             error.cleanup_failures
+             @ [ Write_cleanup_failure release_failure ]
+         }
+     | Some (Ok ()) | None ->
+       Error
+         { operation
+         ; target_effect = !target_effect
+         ; primary_failure = Write_primary_failure release_failure
+         ; cleanup_failures = []
+         })
+;;
+
+let create_capability_file_exclusive_with
       ~before_stage
       ~parent
       ~leaf
-      ~intent
       ~permissions
-  content
+      content
   =
+  let operation = Create_exclusive_operation in
+  let target_effect = ref Target_unchanged in
+  let callback_result = ref None in
   try
     let leaf = validate_leaf ~before_stage leaf in
-    let leaf_name = Capability_leaf.to_string leaf in
     Eio.Switch.run @@ fun sw ->
-    let target = Eio.Path.(parent / leaf_name) in
+    let target = Eio.Path.(parent / Capability_leaf.to_string leaf) in
     let mutation_lease =
       run_stage ~before_stage Acquire_mutation_lease (fun () ->
         let parent_stat = Eio.Path.stat ~follow:true parent in
@@ -664,253 +2110,60 @@ let publish_capability_file_with
             (Unexpected_resource_kind parent_stat.kind);
         match
           Capability_mutation_lease.try_acquire
-            ~parent_dev:parent_stat.dev
-            ~parent_ino:parent_stat.ino
-            ~leaf
+            (Capability_mutation_lease.Absent_target_parent
+               { parent_dev = parent_stat.dev
+               ; parent_ino = parent_stat.ino
+               })
         with
         | Some lease -> lease
         | None -> raise_failure Acquire_mutation_lease Mutation_contended)
     in
-    Fun.protect
-      ~finally:(fun () -> Capability_mutation_lease.release mutation_lease)
-    @@ fun () ->
-    let staging_path = ref None in
-    let staging_directory = ref None in
-    let staging_directory_file = ref None in
-    let staging_directory_identity = ref None in
-    let staging_directory_created = ref false in
-    let staging_directory_removed = ref false in
-    let payload_entry = ref None in
+    Eio.Switch.on_release sw (fun () ->
+      Capability_mutation_lease.release mutation_lease);
     let open_file = ref None in
     let identity = ref None in
-    let entry_created = ref false in
-    let target_effect = ref Target_unchanged in
-    let published = ref false in
     let parent_dirty = ref false in
-    let create_stage =
-      match intent with
-      | Atomic_replace -> Create_staging_directory
-      | Create_exclusive -> Create_target_entry
-    in
     let cleanup () =
-      match intent with
-      | Atomic_replace ->
-        cleanup_owned_staging_directory
-          ~before_stage
-          ~sw
-          ~parent
-          ~staging_path
-          ~staging_directory_file
-          ~staging_directory_identity
-          ~staging_directory_created
-          ~staging_directory_removed
-          ~payload_entry
-          ~payload_file:open_file
-          ~payload_identity:identity
-          ~payload_created:entry_created
-          ~payload_published:published
-          ~parent_dirty
-      | Create_exclusive ->
-        Eio.Cancel.protect (fun () ->
-          let close_failures = cleanup_open_file ~before_stage open_file in
-          close_failures
-          @ cleanup_parent_if_dirty ~before_stage ~sw ~parent parent_dirty)
+      Eio.Cancel.protect (fun () ->
+        write_cleanup_failures
+          (cleanup_open_file ~before_stage open_file
+           @ cleanup_parent_if_dirty ~before_stage ~sw ~parent parent_dirty))
     in
-    let error ~failure ~additional =
-      let cleanup_failures = additional @ cleanup () in
-      let target_effect =
-        match intent with
-        | Atomic_replace -> !target_effect
-        | Create_exclusive -> !target_effect
-      in
-      Error { intent; target_effect; failure; cleanup_failures }
+    let error failure additional =
+      Error
+        { operation
+        ; target_effect = !target_effect
+        ; primary_failure = Write_primary_failure failure
+        ; cleanup_failures = write_cleanup_failures additional @ cleanup ()
+        }
     in
-    (try
-       let create_owned_staging_directory () =
-         let rec create_fresh () =
-           let path =
-             Eio.Path.(parent / fresh_capability_staging_directory_name ())
+    let result =
+      try
+       let file =
+         Eio.Cancel.protect (fun () ->
+           let file =
+             run_stage ~before_stage Create_target_entry (fun () ->
+               Eio.Path.open_out ~sw ~create:(`Exclusive 0o600) target)
            in
-           let result =
-             Eio.Cancel.protect (fun () ->
-               let creation =
-                 run_stage ~before_stage Create_staging_directory (fun () ->
-                   try
-                     Eio.Path.mkdir
-                       ~perm:capability_staging_directory_permissions
-                       path;
-                     `Created
-                   with
-                   | Eio.Io (Eio.Fs.E (Eio.Fs.Already_exists _), _) ->
-                     `Collision)
-               in
-               match creation with
-               | `Collision -> `Collision
-               | `Created ->
-                 staging_path := Some path;
-                 staging_directory_created := true;
-                 parent_dirty := true;
-                 let created_identity =
-                   run_stage ~before_stage Inspect_staging_directory (fun () ->
-                     let lexical = Eio.Path.stat ~follow:false path in
-                     if lexical.kind <> `Directory
-                     then
-                       raise_failure
-                         Inspect_staging_directory
-                         (Unexpected_resource_kind lexical.kind);
-                     { dev = lexical.dev; ino = lexical.ino })
-                 in
-                 staging_directory_identity := Some created_identity;
-                 run_stage ~before_stage Acquire_staging_directory (fun () ->
-                   let directory = Eio.Path.open_dir ~sw path in
-                   staging_directory := Some directory;
-                   let directory_file =
-                     Eio.Path.open_in ~sw Eio.Path.(directory / ".")
-                   in
-                   staging_directory_file := Some directory_file;
-                   let opened = Eio.File.stat directory_file in
-                   if opened.kind <> `Directory
-                   then
-                     raise_failure
-                       Acquire_staging_directory
-                       (Unexpected_resource_kind opened.kind);
-                   let opened_identity =
-                     { dev = opened.dev; ino = opened.ino }
-                   in
-                   if
-                     not
-                       (Int64.equal opened_identity.dev created_identity.dev
-                        && Int64.equal opened_identity.ino created_identity.ino)
-                   then
-                     raise_failure
-                       Acquire_staging_directory
-                       Resource_identity_changed);
-                 (match !staging_directory_file with
-                  | None ->
-                    raise_failure
-                      Apply_staging_directory_permissions
-                      Resource_identity_unavailable
-                  | Some directory_file ->
-                    set_open_directory_permissions
-                      ~before_stage
-                      directory_file);
-                 verify_path_identity
-                   ~before_stage
-                   ~stage:Verify_staging_directory_identity
-                   ~expected_kind:`Directory
-                   path
-                   staging_directory_identity;
-                 `Created)
-           in
-           Eio.Fiber.check ();
-           match result with
-           | `Created -> ()
-           | `Collision -> create_fresh ()
-         in
-         create_fresh ()
+           open_file := Some file;
+           parent_dirty := true;
+           target_effect := Target_created_incomplete;
+           file)
        in
-       let entry, file =
-         match intent with
-         | Atomic_replace ->
-           create_owned_staging_directory ();
-           run_stage ~before_stage Create_staging_entry (fun () ->
-             match !staging_directory with
-             | None ->
-               raise_failure
-                 Create_staging_entry
-                 Resource_identity_unavailable
-             | Some directory ->
-               let entry =
-                 Eio.Path.
-                   ( (directory :> Eio.Fs.dir_ty Eio.Path.t)
-                     / capability_staging_payload_leaf )
-               in
-               entry, Eio.Path.open_out ~sw ~create:(`Exclusive 0o600) entry)
-         | Create_exclusive ->
-           ( target
-           , run_stage ~before_stage Create_target_entry (fun () ->
-               Eio.Path.open_out ~sw ~create:(`Exclusive 0o600) target) )
-       in
-       payload_entry := Some entry;
-       open_file := Some file;
-       entry_created := true;
-       if intent = Create_exclusive then parent_dirty := true;
-       if intent = Create_exclusive
-       then target_effect := Target_created_incomplete;
        identity := Some (identity_of_open_file ~before_stage file);
        write_open_file_payload ~before_stage file content;
        set_open_file_permissions ~before_stage file permissions;
        run_stage ~before_stage Sync_payload (fun () -> Eio.File.sync file);
        close_open_entry ~before_stage open_file;
-       (match intent with
-        | Atomic_replace ->
-          Eio.Fiber.check ();
-          Eio.Cancel.protect (fun () ->
-            run_stage ~before_stage Publish_replace (fun () -> ());
-            verify_entry_identity
-              ~before_stage
-              ~stage:Verify_entry_identity
-              entry
-              identity;
-            let () =
-              try Eio.Path.rename entry target with
-              | Eio.Cancel.Cancelled _ as cancellation ->
-                target_effect := Target_state_unknown;
-                raise cancellation
-              | exception_ ->
-                let backtrace = Printexc.get_raw_backtrace () in
-                target_effect := Target_state_unknown;
-                raise
-                  (Capability_write_failed
-                     ( operation_failure Publish_replace exception_ backtrace
-                     , [] ))
-            in
-            published := true;
-            target_effect := Target_replaced;
-            parent_dirty := true;
-            (match !staging_directory_file with
-             | None ->
-               raise_failure
-                 Sync_staging_directory
-                 Resource_identity_unavailable
-             | Some directory_file ->
-               sync_open_directory_file
-                 ~before_stage
-                 ~stage:Sync_staging_directory
-                 directory_file);
-            (match !staging_path with
-             | None ->
-               raise_failure
-                 Verify_staging_directory_identity
-                 Resource_identity_unavailable
-             | Some path ->
-               verify_path_identity
-                 ~before_stage
-                 ~stage:Verify_staging_directory_identity
-                 ~expected_kind:`Directory
-                 path
-                 staging_directory_identity;
-               run_stage ~before_stage Remove_staging_directory (fun () ->
-                 Eio.Path.rmdir path);
-               staging_directory_removed := true;
-               parent_dirty := true);
-            sync_parent_capability ~before_stage ~stage:Sync_parent ~sw parent;
-            parent_dirty := false;
-            close_open_resource
-              ~before_stage
-              ~stage:Close_staging_directory
-              staging_directory_file)
-        | Create_exclusive ->
-          verify_entry_identity
-            ~before_stage
-            ~stage:Verify_entry_identity
-            entry
-            identity;
-          published := true;
-          target_effect := Target_created;
-          Eio.Cancel.protect (fun () ->
-            sync_parent_capability ~before_stage ~stage:Sync_parent ~sw parent;
-            parent_dirty := false));
+       verify_entry_identity
+         ~before_stage
+         ~stage:Verify_entry_identity
+         target
+         identity;
+       target_effect := Target_created;
+       Eio.Cancel.protect (fun () ->
+         sync_parent_capability ~before_stage ~stage:Sync_parent ~sw parent;
+         parent_dirty := false);
        Eio.Fiber.check ();
        Ok ()
      with
@@ -919,62 +2172,180 @@ let publish_capability_file_with
        let reason, additional =
          match reason with
          | Parent_sync_cleanup_failed_on_cancellation (reason, failures) ->
-           reason, failures
+           reason, write_cleanup_failures failures
          | reason -> reason, []
        in
        let cleanup_failures = additional @ cleanup () in
-       let target_effect =
-         match intent with
-         | Atomic_replace -> !target_effect
-         | Create_exclusive -> !target_effect
-       in
-       (match target_effect, cleanup_failures with
-        | Target_unchanged, [] ->
-          Printexc.raise_with_backtrace cancellation backtrace
-        | ( Target_unchanged
-          | Target_created
-          | Target_created_incomplete
-          | Target_replaced
-          | Target_state_unknown )
-          , _ ->
+       if !target_effect = Target_unchanged && cleanup_failures = []
+       then Printexc.raise_with_backtrace cancellation backtrace
+       else
          Printexc.raise_with_backtrace
            (Eio.Cancel.Cancelled
               (Capability_write_cancelled
                  ( reason
-                 , { intent; target_effect; cleanup_failures } )))
-           backtrace)
+                 , { operation
+                   ; target_effect = !target_effect
+                   ; interrupted_primary_failure = None
+                   ; interrupted_recovery = None
+                   ; cleanup_failures
+                   } )))
+           backtrace
      | Capability_write_failed (failure, additional) ->
-       error ~failure ~additional
+       error failure additional
      | exception_ ->
        let backtrace = Printexc.get_raw_backtrace () in
        error
-         ~failure:(operation_failure create_stage exception_ backtrace)
-         ~additional:[])
+         (operation_failure Create_target_entry exception_ backtrace)
+         []
+    in
+    callback_result := Some result;
+    Eio.Fiber.check ();
+    result
   with
-  | Eio.Cancel.Cancelled _ as cancellation -> raise cancellation
+  | Eio.Cancel.Cancelled (Capability_write_cancelled _) as cancellation ->
+    raise cancellation
+  | Eio.Cancel.Cancelled reason as cancellation ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    (match !callback_result with
+     | Some (Error error) ->
+       Printexc.raise_with_backtrace
+         (Eio.Cancel.Cancelled
+            (Capability_write_cancelled
+               ( reason
+               , { operation
+                 ; target_effect = !target_effect
+                 ; interrupted_primary_failure = Some error.primary_failure
+                 ; interrupted_recovery = None
+                 ; cleanup_failures = error.cleanup_failures
+                 } )))
+         backtrace
+     | Some (Ok ()) | None ->
+       if !target_effect = Target_unchanged
+       then Printexc.raise_with_backtrace cancellation backtrace
+       else
+         Printexc.raise_with_backtrace
+           (Eio.Cancel.Cancelled
+              (Capability_write_cancelled
+                 ( reason
+                 , { operation
+                   ; target_effect = !target_effect
+                   ; interrupted_primary_failure = None
+                   ; interrupted_recovery = None
+                   ; cleanup_failures = []
+                   } )))
+           backtrace)
   | Capability_write_failed (failure, cleanup_failures) ->
-    Error
-      { intent
-      ; target_effect = Target_unchanged
-      ; failure
-      ; cleanup_failures
-      }
+    (match !callback_result with
+     | Some (Error error) ->
+       Error
+         { error with
+           cleanup_failures =
+             error.cleanup_failures
+             @ write_cleanup_failures (failure :: cleanup_failures)
+         }
+     | Some (Ok ()) | None ->
+       Error
+         { operation
+         ; target_effect = !target_effect
+         ; primary_failure = Write_primary_failure failure
+         ; cleanup_failures = write_cleanup_failures cleanup_failures
+         })
   | exception_ ->
     let backtrace = Printexc.get_raw_backtrace () in
-    Error
-      { intent
-      ; target_effect = Target_unchanged
-      ; failure = operation_failure Validate_leaf exception_ backtrace
-      ; cleanup_failures = []
-      }
+    let release_failure = operation_failure Cleanup_close exception_ backtrace in
+    (match !callback_result with
+     | Some (Error error) ->
+       Error
+         { error with
+           cleanup_failures =
+             error.cleanup_failures
+             @ [ Write_cleanup_failure release_failure ]
+         }
+     | Some (Ok ()) | None ->
+       Error
+         { operation
+         ; target_effect = !target_effect
+         ; primary_failure = Write_primary_failure release_failure
+         ; cleanup_failures = []
+         })
 ;;
 
-let publish_capability_file ~parent ~leaf ~intent ~permissions content =
-  publish_capability_file_with
+let replace_capability_file_through_access
+      ~before_stage
+      ~recovery
+      ~parent
+      ~target
+      content
+  =
+  let operation = Atomic_replace_operation in
+  let callback_result = ref None in
+  try
+    match
+      Recovery_access.with_store recovery (fun recovery ->
+        let result =
+          replace_capability_file_with
+            ~before_stage
+            ~recovery
+            ~parent
+            ~target
+            content
+        in
+        callback_result := Some result;
+        Eio.Fiber.check ();
+        result)
+    with
+    | Ok result -> result
+    | Error Recovery_access.Keeper_lane_not_available ->
+      Error
+        { operation
+        ; target_effect = Target_unchanged
+        ; primary_failure =
+            Recovery_access_primary_failure Recovery_access_not_available
+        ; cleanup_failures = []
+        }
+  with
+  | Eio.Cancel.Cancelled (Capability_write_cancelled _) as cancellation ->
+    raise cancellation
+  | Eio.Cancel.Cancelled reason as cancellation ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    (match !callback_result with
+     | None -> Printexc.raise_with_backtrace cancellation backtrace
+     | Some result ->
+       let target_effect, interrupted_primary_failure, cleanup_failures =
+         match result with
+         | Ok () -> Target_replaced, None, []
+         | Error error ->
+           ( error.target_effect
+           , Some error.primary_failure
+           , error.cleanup_failures )
+       in
+       Printexc.raise_with_backtrace
+         (Eio.Cancel.Cancelled
+            (Capability_write_cancelled
+               ( reason
+               , { operation
+                 ; target_effect
+                 ; interrupted_primary_failure
+                 ; interrupted_recovery = None
+                 ; cleanup_failures
+                 } )))
+         backtrace)
+;;
+
+let replace_capability_file ~recovery ~parent ~target content =
+  replace_capability_file_through_access
+    ~before_stage:(fun _ -> ())
+    ~recovery
+    ~parent
+    ~target
+    content
+;;
+
+let create_capability_file_exclusive ~parent ~leaf ~permissions content =
+  create_capability_file_exclusive_with
     ~before_stage:(fun _ -> ())
     ~parent
     ~leaf
-    ~intent
     ~permissions
     content
 ;;
@@ -1005,21 +2376,441 @@ let sync_directory_capability directory =
 ;;
 
 module Capability_write_for_testing = struct
-  let publish_capability_file
+  type resource_scope_callback =
+    | Return_completed_rows of string list
+    | Cancel_callback of exn
+
+  type resource_scope_evidence =
+    | Returned_rows of
+        { completed_rows : string list
+        ; release_failure : exn option
+        }
+    | Cancelled_callback of
+        { reason : exn
+        ; release_failure : exn option
+        }
+    | Raised_callback of
+        { exception_ : exn
+        ; release_failure : exn option
+        }
+
+  type reconciliation_interruption =
+    | Cancel_reconciliation of exn
+    | Crash_reconciliation of exn
+
+  type cleanup_body =
+    | Return_cleanup_value of string
+    | Raise_cleanup_body of exn
+    | Cancel_cleanup_body of exn
+
+  type observed_cleanup_failure =
+    { exception_ : exn
+    ; backtrace : Printexc.raw_backtrace
+    }
+
+  type cleanup_evidence =
+    | Cleanup_returned of string
+    | Cleanup_failed_without_cancellation of
+        { body : observed_cleanup_failure option
+        ; cleanup : observed_cleanup_failure
+        }
+    | Cancellation_primary_with_cleanup_failure of
+        { body : observed_cleanup_failure option
+        ; cancellation : observed_cleanup_failure
+        ; cleanup : observed_cleanup_failure
+        }
+    | Body_failure_during_cancellation of
+        { body : observed_cleanup_failure
+        ; cancellation : observed_cleanup_failure
+        }
+    | Cancellation_primary of observed_cleanup_failure
+    | Cleanup_boundary_raised of observed_cleanup_failure
+
+  type single_borrow_evidence =
+    | Single_borrow_balance of
+        { during_borrow : int
+        ; after_release : int
+        ; close_completed : bool
+        }
+    | Single_borrow_rejected
+    | Single_borrow_invariant of invariant_violation
+    | Single_borrow_raised of observed_cleanup_failure
+
+  and invariant_violation =
+    | Borrow_count_underflow
+    | Borrow_count_overflow
+    | Closing_without_active_borrows
+    | Closed_with_active_borrows of int
+    | Closed_without_drain_signal
+    | Drain_signal_already_resolved
+    | Inventory_finished_outside_running
+    | Reconciliation_finished_before_inventory
+    | Reconciliation_owner_not_running of string
+    | Reconciliation_settled_twice of string
+    | Reconciliation_settled_before_terminal of string
+    | Cleanup_body_outcome_lost
+
+  type owner_settlement =
+    | Owner_untracked
+    | Owner_unsettled
+    | Owner_settled
+
+  let run_publication_recovery_resource_scope ~callback ~release_failure =
+    let callback =
+      match callback with
+      | Return_completed_rows rows ->
+        Capability_recovery_reconciler.For_testing.Return_completed_rows rows
+      | Cancel_callback reason ->
+        Capability_recovery_reconciler.For_testing.Cancel_callback reason
+    in
+    match
+      Capability_recovery_reconciler.For_testing.run_resource_scope
+        ~callback
+        ~release_failure
+    with
+    | Capability_recovery_reconciler.For_testing.Returned_rows
+        { completed_rows; release_failure } ->
+      Returned_rows { completed_rows; release_failure }
+    | Capability_recovery_reconciler.For_testing.Cancelled_callback
+        { reason; release_failure } ->
+      Cancelled_callback { reason; release_failure }
+    | Capability_recovery_reconciler.For_testing.Raised_callback
+        { exception_; release_failure } ->
+      Raised_callback { exception_; release_failure }
+  ;;
+
+  let interrupt_publication_recovery_reconciliation
+        ~fs
+        ~registry
+        ~owner
+        interruption
+    =
+    let interruption =
+      match interruption with
+      | Cancel_reconciliation reason ->
+        Recovery_access.For_testing.Cancel_reconciliation reason
+      | Crash_reconciliation exception_ ->
+        Recovery_access.For_testing.Crash_reconciliation exception_
+    in
+    match
+      Recovery_access.For_testing.interrupt_reconciliation
+        ~fs
+        ~registry
+        ~owner
+        interruption
+    with
+    | Ok report -> Ok report
+    | Error error -> Error (project_reconciliation_error error)
+  ;;
+
+  let observed_cleanup_failure
+        ({ Recovery_access.For_testing.exception_; backtrace } :
+          Recovery_access.For_testing.observed_failure)
+    =
+    { exception_; backtrace }
+  ;;
+
+  let run_publication_recovery_cleanup_boundary ~body ~cleanup_failure =
+    let body =
+      match body with
+      | Return_cleanup_value value ->
+        Recovery_access.For_testing.Return_cleanup_value value
+      | Raise_cleanup_body exception_ ->
+        Recovery_access.For_testing.Raise_cleanup_body exception_
+      | Cancel_cleanup_body reason ->
+        Recovery_access.For_testing.Cancel_cleanup_body reason
+    in
+    match
+      Recovery_access.For_testing.run_cleanup_boundary
+        ~body
+        ~cleanup_failure
+    with
+    | Recovery_access.For_testing.Cleanup_returned value ->
+      Cleanup_returned value
+    | Recovery_access.For_testing.Cleanup_failed_without_cancellation
+        { body; cleanup } ->
+      Cleanup_failed_without_cancellation
+        { body = Option.map observed_cleanup_failure body
+        ; cleanup = observed_cleanup_failure cleanup
+        }
+    | Recovery_access.For_testing.Cancellation_primary_with_cleanup_failure
+        { body; cancellation; cleanup } ->
+      Cancellation_primary_with_cleanup_failure
+        { body = Option.map observed_cleanup_failure body
+        ; cancellation = observed_cleanup_failure cancellation
+        ; cleanup = observed_cleanup_failure cleanup
+        }
+    | Recovery_access.For_testing.Body_failure_during_cancellation
+        { body; cancellation } ->
+      Body_failure_during_cancellation
+        { body = observed_cleanup_failure body
+        ; cancellation = observed_cleanup_failure cancellation
+        }
+    | Recovery_access.For_testing.Cancellation_primary failure ->
+      Cancellation_primary (observed_cleanup_failure failure)
+    | Recovery_access.For_testing.Cleanup_boundary_raised failure ->
+      Cleanup_boundary_raised (observed_cleanup_failure failure)
+  ;;
+
+  let project_invariant_violation = function
+    | Recovery_access.Borrow_count_underflow -> Borrow_count_underflow
+    | Recovery_access.Borrow_count_overflow -> Borrow_count_overflow
+    | Recovery_access.Closing_without_active_borrows ->
+      Closing_without_active_borrows
+    | Recovery_access.Closed_with_active_borrows count ->
+      Closed_with_active_borrows count
+    | Recovery_access.Closed_without_drain_signal ->
+      Closed_without_drain_signal
+    | Recovery_access.Drain_signal_already_resolved ->
+      Drain_signal_already_resolved
+    | Recovery_access.Inventory_finished_outside_running ->
+      Inventory_finished_outside_running
+    | Recovery_access.Reconciliation_finished_before_inventory ->
+      Reconciliation_finished_before_inventory
+    | Recovery_access.Reconciliation_owner_not_running owner ->
+      Reconciliation_owner_not_running owner
+    | Recovery_access.Reconciliation_settled_twice owner ->
+      Reconciliation_settled_twice owner
+    | Recovery_access.Reconciliation_settled_before_terminal owner ->
+      Reconciliation_settled_before_terminal owner
+    | Recovery_access.Cleanup_body_outcome_lost -> Cleanup_body_outcome_lost
+  ;;
+
+  let single_publication_recovery_borrow_balance ~registry ~owner =
+    match Recovery_access.For_testing.single_borrow_balance ~registry ~owner with
+    | Error error -> Error error
+    | Ok
+        (Recovery_access.For_testing.Single_borrow_balance
+          { during_borrow; after_release; close_completed }) ->
+      Ok
+        (Single_borrow_balance
+           { during_borrow; after_release; close_completed })
+    | Ok Recovery_access.For_testing.Single_borrow_rejected ->
+      Ok Single_borrow_rejected
+    | Ok (Recovery_access.For_testing.Single_borrow_invariant invariant) ->
+      Ok (Single_borrow_invariant (project_invariant_violation invariant))
+    | Ok (Recovery_access.For_testing.Single_borrow_raised failure) ->
+      Ok (Single_borrow_raised (observed_cleanup_failure failure))
+  ;;
+
+  let publication_recovery_owner_settlement ~registry ~owner =
+    match Recovery_access.For_testing.owner_settlement registry owner with
+    | Recovery_access.For_testing.Owner_untracked -> Owner_untracked
+    | Recovery_access.For_testing.Owner_unsettled -> Owner_unsettled
+    | Recovery_access.For_testing.Owner_settled -> Owner_settled
+  ;;
+
+  let publication_recovery_stage_name operation_id =
+    operation_id
+    |> Recovery.For_testing.operation_id_of_uuid
+    |> Recovery.stage_name
+  ;;
+
+  let replace_capability_file
         ~before_stage
+        ~recovery
         ~parent
-        ~leaf
-        ~intent
-        ~permissions
+        ~target
         content
     =
-    publish_capability_file_with
+    replace_capability_file_through_access
       ~before_stage
+      ~recovery
       ~parent
-      ~leaf
-      ~intent
-      ~permissions
+      ~target
       content
+  ;;
+
+  let create_capability_file_exclusive =
+    create_capability_file_exclusive_with
+  ;;
+
+  let fixture_identity ~device ~inode =
+    match Recovery.identity ~dev:device ~ino:inode with
+    | Ok identity -> Ok identity
+    | Error error -> Error (Fixture_validation_failed error)
+  ;;
+
+  let fixture_locator
+        ~allowed_root_path
+        ~allowed_root
+        ~parent_components
+        ~parent
+        ~target_leaf
+    =
+    match
+      Recovery.locator
+        ~allowed_root_path
+        ~allowed_root
+        ~parent_components
+        ~parent
+        ~target_leaf
+        ~initial_target:Recovery.Absent
+    with
+    | Ok locator -> Ok locator
+    | Error error -> Error (Fixture_validation_failed error)
+  ;;
+
+  let fixture_permissions value =
+    match Recovery.permissions_of_int value with
+    | Ok permissions -> Ok permissions
+    | Error error -> Error (Fixture_validation_failed error)
+  ;;
+
+  let prepare_fixture
+        ~store
+        ~operation_id
+        ~allowed_root_path
+        ~allowed_root_device
+        ~allowed_root_inode
+        ~parent_components
+        ~parent_device
+        ~parent_inode
+        ~target_leaf
+        ~permissions
+    =
+    match
+      fixture_identity
+        ~device:allowed_root_device
+        ~inode:allowed_root_inode
+    with
+    | Error _ as error -> error
+    | Ok allowed_root ->
+      (match fixture_identity ~device:parent_device ~inode:parent_inode with
+       | Error _ as error -> error
+       | Ok parent ->
+         (match
+            fixture_locator
+              ~allowed_root_path
+              ~allowed_root
+              ~parent_components
+              ~parent
+              ~target_leaf
+          with
+          | Error _ as error -> error
+          | Ok locator ->
+            (match fixture_permissions permissions with
+             | Error _ as error -> error
+             | Ok permissions ->
+               (match
+                  Recovery.For_testing.prepare_with_operation_id
+                    ~store
+                    ~operation_id:
+                      (Recovery.For_testing.operation_id_of_uuid operation_id)
+                    ~locator
+                    ~permissions
+                with
+                | Ok prepared -> Ok prepared
+                | Error error -> Error (Fixture_transition_failed error)))))
+  ;;
+
+  let with_fixture_store ~registry ~owner f =
+    match Recovery_access.with_core_store_for_testing ~registry ~owner f with
+    | Ok result -> result
+    | Error error -> Error (Fixture_lane_open_failed error)
+  ;;
+
+  let seed_prepared_publication_recovery
+        ~registry
+        ~owner
+        ~operation_id
+        ~allowed_root_path
+        ~allowed_root_device
+        ~allowed_root_inode
+        ~parent_components
+        ~parent_device
+        ~parent_inode
+        ~target_leaf
+        ~permissions
+    =
+    with_fixture_store ~registry ~owner @@ fun store ->
+    match
+      prepare_fixture
+        ~store
+        ~operation_id
+        ~allowed_root_path
+        ~allowed_root_device
+        ~allowed_root_inode
+        ~parent_components
+        ~parent_device
+        ~parent_inode
+        ~target_leaf
+        ~permissions
+    with
+    | Ok _ -> Ok ()
+    | Error _ as error -> error
+  ;;
+
+  let seed_bound_publication_recovery
+        ~registry
+        ~owner
+        ~operation_id
+        ~allowed_root_path
+        ~allowed_root_device
+        ~allowed_root_inode
+        ~parent_components
+        ~parent_device
+        ~parent_inode
+        ~target_leaf
+        ~permissions
+        ~stage_device
+        ~stage_inode
+    =
+    with_fixture_store ~registry ~owner @@ fun store ->
+    match
+      prepare_fixture
+        ~store
+        ~operation_id
+        ~allowed_root_path
+        ~allowed_root_device
+        ~allowed_root_inode
+        ~parent_components
+        ~parent_device
+        ~parent_inode
+        ~target_leaf
+        ~permissions
+    with
+    | Error _ as error -> error
+    | Ok prepared ->
+      (match fixture_identity ~device:stage_device ~inode:stage_inode with
+       | Error _ as error -> error
+       | Ok stage_identity ->
+         (match Recovery.bind ~store ~prepared ~stage_identity with
+          | Ok _ -> Ok ()
+          | Error error -> Error (Fixture_transition_failed error)))
+  ;;
+
+  let fixture_core_area = function
+    | Publication_recovery_active -> Recovery.Active
+    | Publication_recovery_owned -> Recovery.Owned
+    | Publication_recovery_forensic -> Recovery.Forensic
+  ;;
+
+  let write_raw_publication_recovery_record
+        ~registry
+        ~owner
+        ~area
+        ~record_name
+        ~raw
+    =
+    match Capability_leaf.of_string record_name with
+    | None -> Error (Fixture_invalid_record_leaf record_name)
+    | Some _ ->
+      with_fixture_store ~registry ~owner @@ fun store ->
+      let directory =
+        Recovery.For_testing.area_directory store (fixture_core_area area)
+      in
+      (try
+         Eio.Path.save
+           ~create:(`Exclusive 0o600)
+           Eio.Path.(directory / record_name)
+           raw;
+         Ok ()
+       with
+       | Eio.Cancel.Cancelled _ as cancellation -> raise cancellation
+       | exception_ ->
+         let backtrace = Printexc.get_raw_backtrace () in
+         Error (Fixture_io_failed { exception_; backtrace }))
   ;;
 
   let sync_directory_capability = sync_directory_capability_with

--- a/lib/fs_compat/atomic_write.mli
+++ b/lib/fs_compat/atomic_write.mli
@@ -35,18 +35,291 @@ val save_file_atomic
     filename shape. The caller owns the returned channel and file. *)
 val open_atomic_temp_file : temp_dir:string -> unit -> string * out_channel
 
-type capability_write_intent =
-  | Atomic_replace
-  | Create_exclusive
+type atomic_replace_recovery_target
+type atomic_replace_recovery_target_error
+type publication_recovery_access
+type publication_recovery_registry
+type publication_recovery_registry_error
+type publication_recovery_lane_open_error
+type publication_recovery_owner
+type publication_recovery_reconciliation_report
+
+type publication_recovery_owner_inventory_row =
+  | Publication_recovery_valid_owner of publication_recovery_owner
+  | Publication_recovery_invalid_owner_name of string
+  | Publication_recovery_unexpected_owner_kind of
+      { owner : publication_recovery_owner
+      ; kind : Eio.File.Stat.kind
+      }
+  | Publication_recovery_missing_owner_entry of publication_recovery_owner
+  | Publication_recovery_owner_entry_unavailable of
+      { owner : publication_recovery_owner
+      ; error : publication_recovery_registry_error
+      }
+
+type publication_recovery_owner_inventory_error =
+  | Publication_recovery_registry_inventory_in_progress
+  | Publication_recovery_registry_inventory_failed of
+      publication_recovery_registry_error
+
+type publication_recovery_owner_block =
+  | Publication_recovery_owner_inventory_block of
+      publication_recovery_owner_inventory_row
+  | Publication_recovery_owner_report_block of
+      publication_recovery_reconciliation_report
+  | Publication_recovery_owner_crash_block of
+      { owner : publication_recovery_owner
+      ; exception_ : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+  | Publication_recovery_owner_cancelled_block of
+      { owner : publication_recovery_owner
+      ; reason : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+  | Publication_recovery_owner_activation_rejected_block of
+      publication_recovery_owner
+
+type publication_recovery_reconciliation_error =
+  | Publication_recovery_owner_inventory_required of
+      publication_recovery_owner
+  | Publication_recovery_owner_inventory_in_progress of
+      publication_recovery_owner
+  | Publication_recovery_owner_not_in_inventory of
+      publication_recovery_owner
+  | Publication_recovery_owner_reconciliation_in_progress of
+      publication_recovery_owner
+  | Publication_recovery_owner_inventory_prevents_reconciliation of
+      publication_recovery_owner_inventory_row
+  | Publication_recovery_owner_reconciliation_crashed of
+      { owner : publication_recovery_owner
+      ; exception_ : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+  | Publication_recovery_owner_reconciliation_cancelled of
+      { owner : publication_recovery_owner
+      ; reason : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+  | Publication_recovery_owner_activation_rejected of
+      publication_recovery_owner
+
+type publication_recovery_activation_rejection_error =
+  | Publication_recovery_activation_inventory_required of
+      publication_recovery_owner
+  | Publication_recovery_activation_inventory_in_progress of
+      publication_recovery_owner
+  | Publication_recovery_activation_owner_not_in_inventory of
+      publication_recovery_owner
+  | Publication_recovery_activation_owner_reconciliation_running of
+      publication_recovery_owner
+  | Publication_recovery_activation_owner_already_ready of
+      publication_recovery_owner
+  | Publication_recovery_activation_owner_already_blocked of
+      publication_recovery_owner_block
+
+type publication_recovery_lane_reconciliation_error =
+  | Publication_recovery_reconciliation_required of
+      publication_recovery_owner
+  | Publication_recovery_reconciliation_in_progress of
+      publication_recovery_owner
+  | Publication_recovery_reconciliation_blocked of
+      publication_recovery_owner_block
+
+type publication_recovery_record_area =
+  | Publication_recovery_active
+  | Publication_recovery_owned
+  | Publication_recovery_forensic
+
+type publication_recovery_source_state =
+  | Publication_recovery_prepared_source
+  | Publication_recovery_bound_source
+
+type publication_recovery_prepared_outcome_kind =
+  | Publication_recovery_prepared_unmaterialized
+  | Publication_recovery_prepared_allowed_root_mismatch
+  | Publication_recovery_prepared_parent_mismatch
+  | Publication_recovery_prepared_unbound_stage_preserved
+
+type publication_recovery_bound_outcome_kind =
+  | Publication_recovery_bound_stage_absent
+  | Publication_recovery_bound_allowed_root_mismatch
+  | Publication_recovery_bound_parent_mismatch
+  | Publication_recovery_bound_stage_mismatch
+  | Publication_recovery_bound_stage_preserved
+
+type publication_recovery_reconciliation_row_kind =
+  | Publication_recovery_unexpected_lane_entry
+  | Publication_recovery_missing_lane_entry
+  | Publication_recovery_lane_entry_unavailable
+  | Publication_recovery_area_inventory_unavailable
+  | Publication_recovery_source_transition_capabilities_unavailable
+  | Publication_recovery_prepared_reconciled of
+      publication_recovery_prepared_outcome_kind
+  | Publication_recovery_bound_reconciled of
+      publication_recovery_bound_outcome_kind
+  | Publication_recovery_existing_forensic_record of
+      publication_recovery_source_state
+  | Publication_recovery_conflicting_source_records
+  | Publication_recovery_invalid_record_name
+  | Publication_recovery_unexpected_record_kind
+  | Publication_recovery_missing_record_entry
+  | Publication_recovery_record_entry_unavailable
+  | Publication_recovery_corrupt_record_preserved
+  | Publication_recovery_record_observation_failed
+  | Publication_recovery_record_transition_failed
+  | Publication_recovery_record_scope_release_failed
+  | Publication_recovery_owner_store_release_failed
+  | Publication_recovery_owner_store_unavailable
+  | Publication_recovery_owner_inventory_unavailable
+
+val open_publication_recovery_registry
+  :  sw:Eio.Switch.t
+  -> registry_root:Eio.Fs.dir_ty Eio.Path.t
+  -> (publication_recovery_registry, publication_recovery_registry_error) result
+
+val publication_recovery_registry_error_to_string
+  :  publication_recovery_registry_error
+  -> string
+
+(** Strict startup inventory of the exact lane registry. MASC must validate
+    every [Publication_recovery_valid_owner] name through
+    [Keeper_id.Keeper_name] before passing that opaque owner to
+    {!reconcile_publication_recovery_owner}. *)
+val inventory_publication_recovery_owners
+  :  publication_recovery_registry
+  -> ( publication_recovery_owner_inventory_row list
+       , publication_recovery_owner_inventory_error )
+       result
+
+val publication_recovery_owner_to_string
+  :  publication_recovery_owner
+  -> string
+
+(** Reconcile one caller-validated owner. Target trees are never scanned or
+    mutated; only exact MASC-owned recovery records may transition to forensic.
+    The returned immutable report is clean exactly when
+    {!publication_recovery_reconciliation_report_is_ready} is [true]. *)
+val reconcile_publication_recovery_owner
+  :  fs:Eio.Fs.dir_ty Eio.Path.t
+  -> registry:publication_recovery_registry
+  -> owner:publication_recovery_owner
+  -> ( publication_recovery_reconciliation_report
+       , publication_recovery_reconciliation_error )
+       result
+
+val reject_publication_recovery_owner_activation
+  :  registry:publication_recovery_registry
+  -> owner:publication_recovery_owner
+  -> (unit, publication_recovery_activation_rejection_error) result
+
+val publication_recovery_reconciliation_report_owner
+  :  publication_recovery_reconciliation_report
+  -> string
+
+val publication_recovery_reconciliation_report_is_ready
+  :  publication_recovery_reconciliation_report
+  -> bool
+
+(** Typed, order-preserving projection of report rows for callers that need to
+    branch without parsing diagnostics. Corrupt raw payloads remain only in the
+    forensic-file SSOT; reports retain their byte count and SHA-256 identity.
+    Exact identities, exceptions, and transition errors remain retained by the
+    opaque report and its lane-block evidence. *)
+val publication_recovery_reconciliation_report_row_kinds
+  :  publication_recovery_reconciliation_report
+  -> publication_recovery_reconciliation_row_kind list
+
+val publication_recovery_reconciliation_report_to_string
+  :  publication_recovery_reconciliation_report
+  -> string
+
+(** Constructor-directed structured report projection. Callers can observe row
+    identity and nested evidence without parsing diagnostic strings. *)
+val publication_recovery_reconciliation_report_to_yojson
+  :  publication_recovery_reconciliation_report
+  -> Yojson.Safe.t
+
+val publication_recovery_owner_inventory_row_to_string
+  :  publication_recovery_owner_inventory_row
+  -> string
+
+val publication_recovery_owner_inventory_error_to_string
+  :  publication_recovery_owner_inventory_error
+  -> string
+
+val publication_recovery_reconciliation_error_to_string
+  :  publication_recovery_reconciliation_error
+  -> string
+
+val publication_recovery_owner_block_to_string
+  :  publication_recovery_owner_block
+  -> string
+
+val publication_recovery_activation_rejection_error_to_string
+  :  publication_recovery_activation_rejection_error
+  -> string
+
+val with_publication_recovery_lane
+  :  registry:publication_recovery_registry
+  -> owner:string
+  -> (publication_recovery_access -> 'a)
+  -> ('a, publication_recovery_lane_open_error) result
+
+(** Await only the exact owner's reconciliation settlement. There is no
+    timeout, polling, retry, or global activation barrier. *)
+val await_publication_recovery_lane_reconciliation
+  :  registry:publication_recovery_registry
+  -> owner:string
+  -> (unit, publication_recovery_lane_open_error) result
+
+val publication_recovery_lane_open_error_to_string
+  :  publication_recovery_lane_open_error
+  -> string
+
+(** Typed projection of the per-owner reconciliation gate. Validation and
+    store-layout failures return [None] and remain available through the
+    original lane-open error. *)
+val publication_recovery_lane_reconciliation_error
+  :  publication_recovery_lane_open_error
+  -> publication_recovery_lane_reconciliation_error option
+
+(** Build the immutable recovery locator projection used by
+    [replace_capability_file]. The allowed-root identity is caller-certified;
+    the final parent identity and initial no-follow target observation are
+    captured under the publication mutation lease. Every component and the
+    target permissions are validated before a target value is returned. *)
+val atomic_replace_recovery_target
+  :  allowed_root_path:string
+  -> allowed_root_device:int64
+  -> allowed_root_inode:int64
+  -> parent_components:string list
+  -> target_leaf:string
+  -> permissions:int
+  -> (atomic_replace_recovery_target, atomic_replace_recovery_target_error) result
+
+val atomic_replace_recovery_target_error_to_string
+  :  atomic_replace_recovery_target_error
+  -> string
+
+type capability_write_operation =
+  | Atomic_replace_operation
+  | Create_exclusive_operation
 
 type capability_write_stage =
   | Validate_leaf
   | Acquire_mutation_lease
+  | Acquire_publication_lease
+  | Inspect_target_entry
+  | Verify_target_binding
+  | Prepare_recovery_obligation
   | Create_staging_directory
   | Inspect_staging_directory
   | Acquire_staging_directory
   | Apply_staging_directory_permissions
   | Verify_staging_directory_identity
+  | Preserve_unbound_recovery_obligation
+  | Bind_recovery_obligation
   | Create_staging_entry
   | Create_target_entry
   | Inspect_open_resource
@@ -60,6 +333,8 @@ type capability_write_stage =
   | Sync_parent
   | Remove_staging_directory
   | Close_staging_directory
+  | Discharge_prepared_recovery_obligation
+  | Discharge_bound_recovery_obligation
   | Cleanup_close
   | Cleanup_verify_identity
   | Cleanup_unlink
@@ -89,6 +364,7 @@ type capability_write_payload_failure =
 
 type capability_write_cause =
   | Invalid_leaf of string
+  | Invalid_recovery_target of atomic_replace_recovery_target_error
   | Mutation_contended
   | Posix_descriptor_unavailable
   | Unexpected_resource_kind of Eio.File.Stat.kind
@@ -102,11 +378,73 @@ type capability_write_failure =
   ; cause : capability_write_cause
   }
 
+type capability_recovery_phase =
+  | Recovery_validate_owner
+  | Recovery_open_registry
+  | Recovery_open_store
+  | Recovery_prepare
+  | Recovery_preserve_unbound
+  | Recovery_bind
+  | Recovery_discharge_prepared
+  | Recovery_discharge_bound
+
+type capability_recovery_removal_transition =
+  | Recovery_discharge_active
+  | Recovery_discharge_owned
+  | Recovery_active_to_owned
+  | Recovery_active_to_forensic
+  | Recovery_owned_to_forensic
+
+type capability_recovery_effect =
+  | Recovery_no_record_change
+  | Recovery_layout_may_be_incomplete
+  | Recovery_layout_ready
+  | Recovery_active_record_state_unknown
+  | Recovery_active_record_durable
+  | Recovery_active_record_discharged
+  | Recovery_owned_record_state_unknown_with_active
+  | Recovery_owned_record_durable_with_active
+  | Recovery_owned_record_durable
+  | Recovery_owned_record_discharged
+  | Recovery_forensic_record_state_unknown_with_source
+  | Recovery_forensic_record_durable_with_source
+  | Recovery_forensic_record_durable
+  | Recovery_source_removal_durability_unknown of
+      capability_recovery_removal_transition
+
+type capability_recovery_failure
+
+val capability_recovery_phase_to_string : capability_recovery_phase -> string
+val capability_recovery_effect_to_string : capability_recovery_effect -> string
+
+val capability_recovery_failure_phase
+  :  capability_recovery_failure
+  -> capability_recovery_phase
+
+val capability_recovery_failure_effect
+  :  capability_recovery_failure
+  -> capability_recovery_effect
+
+val capability_recovery_failure_to_string
+  :  capability_recovery_failure
+  -> string
+
+type capability_recovery_access_failure = Recovery_access_not_available
+
+type capability_write_primary_failure =
+  | Write_primary_failure of capability_write_failure
+  | Recovery_primary_failure of capability_recovery_failure
+  | Recovery_access_primary_failure of capability_recovery_access_failure
+
+type capability_write_cleanup_failure =
+  | Write_cleanup_failure of capability_write_failure
+  | Recovery_cleanup_failure of capability_recovery_failure
+
 type capability_write_error =
-  { intent : capability_write_intent
+  { operation : capability_write_operation
   ; target_effect : capability_write_target_effect
-  ; failure : capability_write_failure
-  ; cleanup_failures : capability_write_failure list
+  ; primary_failure : capability_write_primary_failure
+  ; cleanup_failures : capability_write_cleanup_failure list
   }
 
 type capability_directory_sync_error =
@@ -114,52 +452,48 @@ type capability_directory_sync_error =
   ; cleanup_failures : capability_write_failure list
   }
 
+type publication_recovery_fixture_error
+
+val publication_recovery_fixture_error_to_string
+  :  publication_recovery_fixture_error
+  -> string
+
 type capability_write_cancellation =
-  { intent : capability_write_intent
+  { operation : capability_write_operation
   ; target_effect : capability_write_target_effect
-  ; cleanup_failures : capability_write_failure list
+  ; interrupted_primary_failure : capability_write_primary_failure option
+  ; interrupted_recovery : capability_recovery_failure option
+  ; cleanup_failures : capability_write_cleanup_failure list
   }
 
 exception Capability_write_cancelled of exn * capability_write_cancellation
 
-(** Publish [content] below an already-open, caller-validated directory
-    capability. No path is reopened from a process-global root.
+(** Durable replacement below an already-open target-parent capability.
+    Recovery access and the immutable target projection are mandatory. A
+    durable Prepared obligation precedes exact staging-directory creation; a
+    durable Bound obligation precedes payload creation. The Bound obligation
+    is discharged only after rename, staging-directory sync and removal, and
+    target-parent sync all complete. No target tree is scanned during failure
+    handling. *)
+val replace_capability_file
+  :  recovery:publication_recovery_access
+  -> parent:Eio.Fs.dir_ty Eio.Path.t
+  -> target:atomic_replace_recovery_target
+  -> string
+  -> (unit, capability_write_error) result
 
-    [Atomic_replace] creates a unique 0700 staging directory below [parent],
-    pins it as a directory capability, and creates a fixed private payload
-    inside that capability. It applies [permissions], fsyncs and closes the
-    payload, then cancellation-protects rename, source-directory fsync,
-    staging-directory removal, and parent fsync. The parent is synced once,
-    after removal, so that one durability barrier covers both the target rename
-    and removal of the staging entry.
-    [Create_exclusive] opens the final leaf exclusively, so the entry is
-    visible before its payload is complete. A failure before payload sync,
-    close, and identity verification completes leaves the public leaf in place
-    and reports [Target_created_incomplete]. Once those steps complete,
-    parent-sync failure reports [Target_created] while the failure stage keeps
-    the missing durability acknowledgement explicit.
-
-    Parent-fsync and cleanup failures are never downgraded to success. A
-    cancellation is re-raised after cleanup or after the protected commit; if
-    cancellation cleanup itself fails, the typed failures are preserved in
-    [Capability_write_cancelled]. Exclusive-create failures never unlink the
-    public leaf: OCaml 5.4/Eio has no conditional unlink primitive, so an
-    identity check followed by unlink would still have a swap race.
-
-    The unique directory and pinned source capability prevent cooperative MASC
-    writers from sharing a staging namespace. Its 0700 mode excludes other OS
-    users; it is not a security boundary against a hostile process running as
-    the same OS user. No legacy [.atomic_*.tmp] pathname is used by this API. *)
-val publish_capability_file
+(** Exclusive creation is physically separate from replacement and has no
+    recovery-obligation argument. Once the public leaf is created it is never
+    unlinked by failure cleanup. *)
+val create_capability_file_exclusive
   :  parent:Eio.Fs.dir_ty Eio.Path.t
   -> leaf:string
-  -> intent:capability_write_intent
   -> permissions:int
   -> string
   -> (unit, capability_write_error) result
 
 val capability_write_error_to_string : capability_write_error -> string
-val capability_write_intent_to_string : capability_write_intent -> string
+val capability_write_operation_to_string : capability_write_operation -> string
 val capability_write_stage_to_string : capability_write_stage -> string
 
 val capability_write_target_effect_to_string
@@ -181,14 +515,169 @@ val capability_directory_sync_error_to_string
   -> string
 
 module Capability_write_for_testing : sig
-  val publish_capability_file
+  type resource_scope_callback =
+    | Return_completed_rows of string list
+    | Cancel_callback of exn
+
+  type resource_scope_evidence =
+    | Returned_rows of
+        { completed_rows : string list
+        ; release_failure : exn option
+        }
+    | Cancelled_callback of
+        { reason : exn
+        ; release_failure : exn option
+        }
+    | Raised_callback of
+        { exception_ : exn
+        ; release_failure : exn option
+        }
+
+  type reconciliation_interruption =
+    | Cancel_reconciliation of exn
+    | Crash_reconciliation of exn
+
+  type cleanup_body =
+    | Return_cleanup_value of string
+    | Raise_cleanup_body of exn
+    | Cancel_cleanup_body of exn
+
+  type observed_cleanup_failure =
+    { exception_ : exn
+    ; backtrace : Printexc.raw_backtrace
+    }
+
+  type cleanup_evidence =
+    | Cleanup_returned of string
+    | Cleanup_failed_without_cancellation of
+        { body : observed_cleanup_failure option
+        ; cleanup : observed_cleanup_failure
+        }
+    | Cancellation_primary_with_cleanup_failure of
+        { body : observed_cleanup_failure option
+        ; cancellation : observed_cleanup_failure
+        ; cleanup : observed_cleanup_failure
+        }
+    | Body_failure_during_cancellation of
+        { body : observed_cleanup_failure
+        ; cancellation : observed_cleanup_failure
+        }
+    | Cancellation_primary of observed_cleanup_failure
+    | Cleanup_boundary_raised of observed_cleanup_failure
+
+  type single_borrow_evidence =
+    | Single_borrow_balance of
+        { during_borrow : int
+        ; after_release : int
+        ; close_completed : bool
+        }
+    | Single_borrow_rejected
+    | Single_borrow_invariant of invariant_violation
+    | Single_borrow_raised of observed_cleanup_failure
+
+  and invariant_violation =
+    | Borrow_count_underflow
+    | Borrow_count_overflow
+    | Closing_without_active_borrows
+    | Closed_with_active_borrows of int
+    | Closed_without_drain_signal
+    | Drain_signal_already_resolved
+    | Inventory_finished_outside_running
+    | Reconciliation_finished_before_inventory
+    | Reconciliation_owner_not_running of string
+    | Reconciliation_settled_twice of string
+    | Reconciliation_settled_before_terminal of string
+    | Cleanup_body_outcome_lost
+
+  type owner_settlement =
+    | Owner_untracked
+    | Owner_unsettled
+    | Owner_settled
+
+  val run_publication_recovery_resource_scope
+    :  callback:resource_scope_callback
+    -> release_failure:exn option
+    -> resource_scope_evidence
+
+  val interrupt_publication_recovery_reconciliation
+    :  fs:Eio.Fs.dir_ty Eio.Path.t
+    -> registry:publication_recovery_registry
+    -> owner:publication_recovery_owner
+    -> reconciliation_interruption
+    -> ( publication_recovery_reconciliation_report
+         , publication_recovery_reconciliation_error )
+         result
+
+  val run_publication_recovery_cleanup_boundary
+    :  body:cleanup_body
+    -> cleanup_failure:exn option
+    -> cleanup_evidence
+
+  val single_publication_recovery_borrow_balance
+    :  registry:publication_recovery_registry
+    -> owner:string
+    -> (single_borrow_evidence, publication_recovery_lane_open_error) result
+
+  val publication_recovery_owner_settlement
+    :  registry:publication_recovery_registry
+    -> owner:publication_recovery_owner
+    -> owner_settlement
+
+  val publication_recovery_stage_name : Uuidm.t -> string
+
+  val replace_capability_file
+    :  before_stage:(capability_write_stage -> unit)
+    -> recovery:publication_recovery_access
+    -> parent:Eio.Fs.dir_ty Eio.Path.t
+    -> target:atomic_replace_recovery_target
+    -> string
+    -> (unit, capability_write_error) result
+
+  val create_capability_file_exclusive
     :  before_stage:(capability_write_stage -> unit)
     -> parent:Eio.Fs.dir_ty Eio.Path.t
     -> leaf:string
-    -> intent:capability_write_intent
     -> permissions:int
     -> string
     -> (unit, capability_write_error) result
+
+  val seed_prepared_publication_recovery
+    :  registry:publication_recovery_registry
+    -> owner:string
+    -> operation_id:Uuidm.t
+    -> allowed_root_path:string
+    -> allowed_root_device:int64
+    -> allowed_root_inode:int64
+    -> parent_components:string list
+    -> parent_device:int64
+    -> parent_inode:int64
+    -> target_leaf:string
+    -> permissions:int
+    -> (unit, publication_recovery_fixture_error) result
+
+  val seed_bound_publication_recovery
+    :  registry:publication_recovery_registry
+    -> owner:string
+    -> operation_id:Uuidm.t
+    -> allowed_root_path:string
+    -> allowed_root_device:int64
+    -> allowed_root_inode:int64
+    -> parent_components:string list
+    -> parent_device:int64
+    -> parent_inode:int64
+    -> target_leaf:string
+    -> permissions:int
+    -> stage_device:int64
+    -> stage_inode:int64
+    -> (unit, publication_recovery_fixture_error) result
+
+  val write_raw_publication_recovery_record
+    :  registry:publication_recovery_registry
+    -> owner:string
+    -> area:publication_recovery_record_area
+    -> record_name:string
+    -> raw:string
+    -> (unit, publication_recovery_fixture_error) result
 
   val sync_directory_capability
     :  before_stage:(capability_write_stage -> unit)

--- a/lib/fs_compat/capability_mutation_lease.ml
+++ b/lib/fs_compat/capability_mutation_lease.ml
@@ -1,76 +1,117 @@
 type key =
-  { parent_dev : int64
-  ; parent_ino : int64
-  ; leaf : Capability_leaf.t
-  }
+  | Existing_target of
+      { target_dev : int64
+      ; target_ino : int64
+      ; parent_dev : int64
+      ; parent_ino : int64
+      }
+  | Absent_target_parent of
+      { parent_dev : int64
+      ; parent_ino : int64
+      }
+  | Existing_publication_parent of
+      { parent_dev : int64
+      ; parent_ino : int64
+      }
 
-module Key = struct
-  type t = key
+module Identity = struct
+  type t = int64 * int64
 
-  let equal left right =
-    Int64.equal left.parent_dev right.parent_dev
-    && Int64.equal left.parent_ino right.parent_ino
-    && Capability_leaf.equal left.leaf right.leaf
+  let equal (left_dev, left_ino) (right_dev, right_ino) =
+    Int64.equal left_dev right_dev && Int64.equal left_ino right_ino
   ;;
 
-  let hash key =
-    Hashtbl.hash
-      ( key.parent_dev
-      , key.parent_ino
-      , Capability_leaf.to_string key.leaf )
-  ;;
+  let hash = Hashtbl.hash
 end
 
-module Table = Hashtbl.Make (Key)
-
-type entry =
-  { held : bool Atomic.t
-  ; mutable users : int
-  }
+module Identity_table = Hashtbl.Make (Identity)
 
 type t =
   { key : key
-  ; entry : entry
-  ; released : bool Atomic.t
+  ; mutable released : bool
   }
 
 let registry_mutex = Stdlib.Mutex.create ()
-let registry = Table.create 0
+let existing_targets = Identity_table.create 0
+let absent_target_parents = Identity_table.create 0
+let existing_publication_counts = Identity_table.create 0
 
-let release_user key entry =
-  Stdlib.Mutex.protect registry_mutex (fun () ->
-    entry.users <- entry.users - 1;
-    if entry.users = 0
-    then
-      match Table.find_opt registry key with
-      | Some current when current == entry -> Table.remove registry key
-      | Some _ | None -> ())
+let identity ~dev ~ino = dev, ino
+
+let existing_publication_count parent =
+  Option.value (Identity_table.find_opt existing_publication_counts parent) ~default:0
 ;;
 
-let try_acquire ~parent_dev ~parent_ino ~leaf =
-  let key = { parent_dev; parent_ino; leaf } in
-  let entry =
-    Stdlib.Mutex.protect registry_mutex (fun () ->
-      match Table.find_opt registry key with
-      | Some entry ->
-        entry.users <- entry.users + 1;
-        entry
-      | None ->
-        let entry = { held = Atomic.make false; users = 1 } in
-        Table.add registry key entry;
-        entry)
-  in
-  if Atomic.compare_and_set entry.held false true
-  then Some { key; entry; released = Atomic.make false }
-  else (
-    release_user key entry;
-    None)
+let increment_existing_publication_count parent =
+  let count = existing_publication_count parent in
+  if count = max_int
+  then invalid_arg "capability mutation publication count overflow"
+  else Identity_table.replace existing_publication_counts parent (count + 1)
+;;
+
+let decrement_existing_publication_count parent =
+  match Identity_table.find_opt existing_publication_counts parent with
+  | Some 1 -> Identity_table.remove existing_publication_counts parent
+  | Some count when count > 1 ->
+    Identity_table.replace existing_publication_counts parent (count - 1)
+  | Some _ | None ->
+    invalid_arg "capability mutation publication count invariant lost"
+;;
+
+let try_acquire key =
+  Stdlib.Mutex.protect registry_mutex (fun () ->
+    match key with
+    | Existing_target
+        { target_dev; target_ino; parent_dev; parent_ino } ->
+      let target = identity ~dev:target_dev ~ino:target_ino in
+      let parent = identity ~dev:parent_dev ~ino:parent_ino in
+      if
+        Identity_table.mem absent_target_parents parent
+        || Identity_table.mem existing_targets target
+      then None
+      else (
+        Identity_table.add existing_targets target ();
+        Some { key; released = false })
+    | Absent_target_parent { parent_dev; parent_ino } ->
+      let parent = identity ~dev:parent_dev ~ino:parent_ino in
+      if
+        Identity_table.mem absent_target_parents parent
+        || existing_publication_count parent > 0
+      then None
+      else (
+        Identity_table.add absent_target_parents parent ();
+        Some { key; released = false })
+    | Existing_publication_parent { parent_dev; parent_ino } ->
+      let parent = identity ~dev:parent_dev ~ino:parent_ino in
+      if Identity_table.mem absent_target_parents parent
+      then None
+      else (
+        increment_existing_publication_count parent;
+        Some { key; released = false }))
 ;;
 
 let release lease =
-  if Atomic.compare_and_set lease.released false true
-  then (
-    Atomic.set lease.entry.held false;
-    release_user lease.key lease.entry)
-  else invalid_arg "capability mutation lease released more than once"
+  Stdlib.Mutex.protect registry_mutex (fun () ->
+    if lease.released
+    then invalid_arg "capability mutation lease released more than once"
+    else
+      match lease.key with
+      | Existing_target { target_dev; target_ino; _ } ->
+        let target = identity ~dev:target_dev ~ino:target_ino in
+        if not (Identity_table.mem existing_targets target)
+        then invalid_arg "capability mutation lease target invariant lost"
+        else (
+          Identity_table.remove existing_targets target;
+          lease.released <- true)
+      | Absent_target_parent { parent_dev; parent_ino } ->
+        let parent = identity ~dev:parent_dev ~ino:parent_ino in
+        if not (Identity_table.mem absent_target_parents parent)
+        then invalid_arg "capability mutation lease parent invariant lost"
+        else (
+          Identity_table.remove absent_target_parents parent;
+          lease.released <- true)
+      | Existing_publication_parent { parent_dev; parent_ino } ->
+        let parent = identity ~dev:parent_dev ~ino:parent_ino in
+        decrement_existing_publication_count parent;
+        lease.released <- true)
 ;;

--- a/lib/fs_compat/capability_mutation_lease.mli
+++ b/lib/fs_compat/capability_mutation_lease.mli
@@ -1,14 +1,38 @@
-(** Process-local, non-blocking serialization for one lexical entry below a
-    pinned parent directory capability. The lease is a coordination boundary
-    for cooperative MASC writers; it does not claim exclusion against external
-    processes. *)
+(** Process-local, non-blocking serialization for cooperative capability
+    writers. Existing targets are keyed globally by their no-follow resource
+    identity, so filesystem aliases share one lease without lexical
+    normalization. An absent-target lease excludes new cooperative mutations
+    below that parent until the publication protocol releases it. Existing
+    mutations that linearized first may continue. Existing replacements take a
+    short parent publication lease and reobserve their exact target binding
+    immediately before rename; exclusive create leaves collision authority to
+    the kernel. Unrelated siblings therefore remain concurrent. External
+    unlink/rename remains an observation boundary, not an exclusion claim. *)
+
+type key =
+  | Existing_target of
+      { target_dev : int64
+      ; target_ino : int64
+      ; parent_dev : int64
+      ; parent_ino : int64
+      }
+  | Absent_target_parent of
+      { parent_dev : int64
+      ; parent_ino : int64
+      }
+  | Existing_publication_parent of
+      { parent_dev : int64
+      ; parent_ino : int64
+      }
 
 type t
 
-val try_acquire
-  :  parent_dev:int64
-  -> parent_ino:int64
-  -> leaf:Capability_leaf.t
-  -> t option
+(** [try_acquire key] has one linearization point under the registry mutex.
+    Existing targets conflict with the same target identity or an absent-target
+    lease for their parent. Absent targets conflict with another absent-target
+    lease or an active existing-target publication for their parent. Existing
+    publications conflict with an absent-target lease; multiple existing-target
+    publications below the parent may coexist. *)
+val try_acquire : key -> t option
 
 val release : t -> unit

--- a/lib/fs_compat/capability_recovery_obligation.ml
+++ b/lib/fs_compat/capability_recovery_obligation.ml
@@ -1,0 +1,2786 @@
+type owner = Capability_leaf.t
+type operation_id = Uuidm.t
+type permissions = int
+
+type identity =
+  { dev : int64
+  ; ino : int64
+  }
+
+type entry_observation =
+  | Absent
+  | Present of
+      { kind : Eio.File.Stat.kind
+      ; identity : identity
+      }
+
+type locator =
+  { allowed_root_path : string
+  ; allowed_root : identity
+  ; parent_components : Capability_leaf.t list
+  ; parent : identity
+  ; target_leaf : Capability_leaf.t
+  ; initial_target : entry_observation
+  }
+
+type prepared =
+  { owner : owner
+  ; operation_id : operation_id
+  ; locator : locator
+  ; permissions : int
+  }
+
+type bound =
+  { prepared : prepared
+  ; stage_identity : identity
+  }
+
+type resource_mismatch =
+  { expected : identity
+  ; observed : entry_observation
+  }
+
+type prepared_recovery_outcome =
+  | Recovered_unmaterialized
+  | Prepared_allowed_root_mismatch of resource_mismatch
+  | Prepared_parent_mismatch of resource_mismatch
+  | Preserved_unbound_stage of
+      { kind : Eio.File.Stat.kind
+      ; identity : identity
+      }
+
+type bound_recovery_outcome =
+  | Bound_stage_absent of
+      { observed_target : entry_observation
+      }
+  | Bound_allowed_root_mismatch of resource_mismatch
+  | Bound_parent_mismatch of resource_mismatch
+  | Bound_stage_mismatch of
+      { mismatch : resource_mismatch
+      ; observed_target : entry_observation
+      }
+  | Preserved_bound_stage of
+      { kind : Eio.File.Stat.kind
+      ; identity : identity
+      ; observed_target : entry_observation
+      }
+
+type forensic_source =
+  | Prepared_source of prepared * prepared_recovery_outcome
+  | Bound_source of bound * bound_recovery_outcome
+
+type forensic = { source : forensic_source }
+
+type area =
+  | Active
+  | Owned
+  | Forensic
+
+type registry =
+  { lanes : Eio.Fs.dir_ty Eio.Path.t }
+
+type store =
+  { owner : owner
+  ; active : Eio.Fs.dir_ty Eio.Path.t
+  ; owned : Eio.Fs.dir_ty Eio.Path.t
+  ; forensic : Eio.Fs.dir_ty Eio.Path.t
+  }
+
+type validation_error =
+  | Invalid_owner of string
+  | Invalid_operation_id of string
+  | Invalid_identity of identity
+  | Invalid_allowed_root_path of string
+  | Empty_parent_path_identity_mismatch of
+      { allowed_root : identity
+      ; parent : identity
+      }
+  | Invalid_parent_component of
+      { index : int
+      ; value : string
+      }
+  | Invalid_target_leaf of string
+  | Invalid_permissions of int
+  | Invalid_record_json of
+      { exception_ : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+  | Invalid_record_shape
+  | Unsupported_record_version of int
+  | Record_state_mismatch
+  | Record_owner_mismatch of
+      { expected : owner
+      ; actual : owner
+      }
+  | Record_operation_id_mismatch of
+      { expected : operation_id
+      ; actual : operation_id
+      }
+  | Record_stage_leaf_mismatch of
+      { expected : string
+      ; actual : string
+      }
+  | Record_identity_mismatch of
+      { expected : identity
+      ; actual : identity
+      }
+  | Record_kind_mismatch of
+      { expected : Eio.File.Stat.kind
+      ; actual : Eio.File.Stat.kind
+      }
+  | Record_permissions_mismatch of
+      { expected : int
+      ; actual : int
+      }
+  | Record_outcome_observation_not_mismatch of identity
+  | Record_field_invalid of
+      { field : string
+      ; value : Yojson.Safe.t
+      }
+
+type subject =
+  | Registry_root
+  | Recovery_root
+  | Lanes_root
+  | Lane_root of owner
+  | Area of area * owner
+  | Record of area * owner * operation_id
+
+type operation =
+  | Inspect_directory
+  | Create_directory
+  | Open_directory
+  | Sync_directory
+  | Read_directory
+  | Inspect_record
+  | Open_record
+  | Read_record
+  | Decode_record
+  | Create_record
+  | Apply_permissions
+  | Write_record
+  | Sync_record
+  | Close_record
+  | Verify_record_identity
+  | Remove_record
+
+type failure_cause =
+  | Validation_failed of validation_error
+  | Io_failed of
+      { exception_ : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+  | Write_failed of
+      { exception_ : exn
+      ; backtrace : Printexc.raw_backtrace
+      ; bytes_written : int
+      }
+  | Unexpected_resource_kind of Eio.File.Stat.kind
+  | Resource_identity_changed of
+      { expected : identity
+      ; actual : identity
+      }
+  | Posix_descriptor_unavailable
+  | Existing_record_does_not_match
+  | Created_record_identity_unavailable
+  | Missing_record
+
+type failure =
+  { operation : operation
+  ; subject : subject
+  ; cause : failure_cause
+  }
+
+type transition_effect =
+  | No_record_change
+  | Layout_may_be_incomplete
+  | Layout_ready
+  | Active_record_state_unknown
+  | Active_record_durable
+  | Active_record_discharged
+  | Owned_record_state_unknown_with_active
+  | Owned_record_durable_with_active
+  | Owned_record_durable
+  | Owned_record_discharged
+  | Forensic_record_state_unknown_with_source
+  | Forensic_record_durable_with_source
+  | Forensic_record_durable
+  | Source_removal_durability_unknown of removal_transition
+
+and removal_transition =
+  | Discharge_active
+  | Discharge_owned
+  | Active_to_owned
+  | Active_to_forensic
+  | Owned_to_forensic
+
+type transition_error =
+  { store_effect : transition_effect
+  ; failure : failure
+  ; cleanup_failures : failure list
+  }
+
+exception Recovery_store_cancelled of
+  exn * transition_effect * failure list
+
+exception Store_failure of failure
+exception Record_validation_failed of validation_error
+exception Internal_unexpected_resource_kind of Eio.File.Stat.kind
+exception Internal_resource_identity_changed of identity * identity
+exception Internal_posix_descriptor_unavailable
+exception Internal_existing_record_does_not_match
+exception Internal_created_record_identity_unavailable
+exception Internal_missing_record
+exception Transition_failed of transition_error
+
+let recovery_directory_leaf = "fs-publication-recovery"
+let lanes_directory_leaf = "lanes"
+let active_directory_leaf = "active"
+let owned_directory_leaf = "owned"
+let forensic_directory_leaf = "forensic"
+let directory_permissions = 0o700
+let record_permissions = 0o600
+let record_schema = "masc.fs-publication-recovery"
+let record_version = 1
+let stage_prefix = ".masc_atomic_stage_"
+let stage_suffix = ".dir"
+
+let owner_of_string value =
+  match Capability_leaf.of_string value with
+  | Some owner -> Ok owner
+  | None -> Error (Invalid_owner value)
+;;
+
+let owner_to_string = Capability_leaf.to_string
+let equal_owner = Capability_leaf.equal
+
+let operation_id_to_string operation_id = Uuidm.to_string operation_id
+let equal_operation_id = Uuidm.equal
+let record_name = operation_id_to_string
+
+let operation_id_of_string value =
+  match Uuidm.of_string value with
+  | Some operation_id
+    when String.equal (Uuidm.to_string operation_id) value ->
+    Ok operation_id
+  | None | Some _ -> Error (Invalid_operation_id value)
+;;
+
+let stage_name operation_id =
+  Printf.sprintf
+    "%s%s%s"
+    stage_prefix
+    (operation_id_to_string operation_id)
+    stage_suffix
+;;
+
+let equal_identity (left : identity) (right : identity) =
+  Int64.equal left.dev right.dev && Int64.equal left.ino right.ino
+;;
+
+let identity_dev (identity : identity) = identity.dev
+let identity_ino (identity : identity) = identity.ino
+
+let identity ~dev ~ino =
+  let value = { dev; ino } in
+  if Int64.compare dev 0L < 0 || Int64.compare ino 0L < 0
+  then Error (Invalid_identity value)
+  else Ok value
+;;
+
+let valid_absolute_path value =
+  not (String.equal value "")
+  && not (Filename.is_relative value)
+  && not (String.contains value '\x00')
+;;
+
+let locator
+      ~allowed_root_path
+      ~allowed_root
+      ~parent_components
+      ~parent
+      ~target_leaf
+      ~initial_target
+  =
+  if not (valid_absolute_path allowed_root_path)
+  then Error (Invalid_allowed_root_path allowed_root_path)
+  else
+    let rec parse_components index parsed = function
+      | [] -> Ok (List.rev parsed)
+      | value :: rest ->
+        (match Capability_leaf.of_string value with
+         | None -> Error (Invalid_parent_component { index; value })
+         | Some component ->
+           parse_components (index + 1) (component :: parsed) rest)
+    in
+    (match parse_components 0 [] parent_components with
+     | Error _ as error -> error
+     | Ok parent_components ->
+       if parent_components = [] && not (equal_identity allowed_root parent)
+       then
+         Error
+           (Empty_parent_path_identity_mismatch { allowed_root; parent })
+       else
+         (match Capability_leaf.of_string target_leaf with
+          | None -> Error (Invalid_target_leaf target_leaf)
+          | Some target_leaf ->
+            Ok
+              { allowed_root_path
+              ; allowed_root
+              ; parent_components
+              ; parent
+              ; target_leaf
+              ; initial_target
+              }))
+;;
+
+let locator_allowed_root_path (locator : locator) = locator.allowed_root_path
+let locator_allowed_root (locator : locator) = locator.allowed_root
+
+let locator_parent_components (locator : locator) =
+  List.map Capability_leaf.to_string locator.parent_components
+;;
+
+let locator_parent (locator : locator) = locator.parent
+
+let locator_target_leaf (locator : locator) =
+  Capability_leaf.to_string locator.target_leaf
+;;
+
+let locator_initial_target (locator : locator) = locator.initial_target
+let prepared_owner (prepared : prepared) = prepared.owner
+let prepared_operation_id (prepared : prepared) = prepared.operation_id
+let prepared_locator (prepared : prepared) = prepared.locator
+let prepared_permissions (prepared : prepared) = prepared.permissions
+let bound_prepared (bound : bound) = bound.prepared
+let bound_stage_identity (bound : bound) = bound.stage_identity
+let bound_stage_name (bound : bound) = stage_name bound.prepared.operation_id
+let forensic_source (forensic : forensic) = forensic.source
+
+let forensic_owner (forensic : forensic) =
+  match forensic.source with
+  | Prepared_source (prepared, _) -> prepared.owner
+  | Bound_source (bound, _) -> bound.prepared.owner
+;;
+
+let forensic_operation_id (forensic : forensic) =
+  match forensic.source with
+  | Prepared_source (prepared, _) -> prepared.operation_id
+  | Bound_source (bound, _) -> bound.prepared.operation_id
+;;
+
+let store_owner (store : store) = store.owner
+
+let permissions_of_int permissions =
+  if permissions < 0 || permissions land lnot 0o7777 <> 0
+  then Error (Invalid_permissions permissions)
+  else Ok permissions
+;;
+
+let permissions_to_int permissions = permissions
+
+let identity_of_stat (stat : Eio.File.Stat.t) =
+  { dev = stat.dev; ino = stat.ino }
+;;
+
+let entry_observation_to_string = function
+  | Absent -> "absent"
+  | Present { kind; identity } ->
+    Format.asprintf
+      "present(kind=%a,dev=%Ld,ino=%Ld)"
+      Eio.File.Stat.pp_kind
+      kind
+      identity.dev
+      identity.ino
+;;
+
+let validation_error_to_string = function
+  | Invalid_owner value -> Printf.sprintf "invalid owner component %S" value
+  | Invalid_operation_id value ->
+    Printf.sprintf "invalid canonical operation id %S" value
+  | Invalid_identity { dev; ino } ->
+    Printf.sprintf "invalid identity dev=%Ld ino=%Ld" dev ino
+  | Invalid_allowed_root_path value ->
+    Printf.sprintf "invalid absolute allowed-root path %S" value
+  | Empty_parent_path_identity_mismatch { allowed_root; parent } ->
+    Printf.sprintf
+      "empty parent path identity mismatch allowed_root=%Ld:%Ld parent=%Ld:%Ld"
+      allowed_root.dev
+      allowed_root.ino
+      parent.dev
+      parent.ino
+  | Invalid_parent_component { index; value } ->
+    Printf.sprintf "invalid parent component index=%d value=%S" index value
+  | Invalid_target_leaf value ->
+    Printf.sprintf "invalid target leaf %S" value
+  | Invalid_permissions permissions ->
+    Printf.sprintf "invalid permissions %#o" permissions
+  | Invalid_record_json { exception_; _ } ->
+    Printf.sprintf "invalid record JSON: %s" (Printexc.to_string exception_)
+  | Invalid_record_shape -> "record has an unexpected field set or shape"
+  | Unsupported_record_version version ->
+    Printf.sprintf "unsupported record version %d" version
+  | Record_state_mismatch -> "record state does not match its store"
+  | Record_owner_mismatch { expected; actual } ->
+    Printf.sprintf
+      "record owner mismatch expected=%S actual=%S"
+      (owner_to_string expected)
+      (owner_to_string actual)
+  | Record_operation_id_mismatch { expected; actual } ->
+    Printf.sprintf
+      "record operation id mismatch expected=%s actual=%s"
+      (operation_id_to_string expected)
+      (operation_id_to_string actual)
+  | Record_stage_leaf_mismatch { expected; actual } ->
+    Printf.sprintf
+      "record stage leaf mismatch expected=%S actual=%S"
+      expected
+      actual
+  | Record_identity_mismatch { expected; actual } ->
+    Printf.sprintf
+      "record identity mismatch expected=%Ld:%Ld actual=%Ld:%Ld"
+      expected.dev
+      expected.ino
+      actual.dev
+      actual.ino
+  | Record_kind_mismatch { expected; actual } ->
+    Format.asprintf
+      "record kind mismatch expected=%a actual=%a"
+      Eio.File.Stat.pp_kind
+      expected
+      Eio.File.Stat.pp_kind
+      actual
+  | Record_permissions_mismatch { expected; actual } ->
+    Printf.sprintf
+      "record directory permissions mismatch expected=%#o actual=%#o"
+      expected
+      actual
+  | Record_outcome_observation_not_mismatch identity ->
+    Printf.sprintf
+      "recovery outcome observation still confirms directory identity=%Ld:%Ld"
+      identity.dev
+      identity.ino
+  | Record_field_invalid { field; value } ->
+    Printf.sprintf
+      "record field %S is invalid: %s"
+      field
+      (Yojson.Safe.to_string value)
+;;
+
+let raise_invalid error = raise (Record_validation_failed error)
+
+let strict_fields ~expected = function
+  | `Assoc fields ->
+    let actual_names = List.map fst fields |> List.sort String.compare in
+    let expected_names = List.sort String.compare expected in
+    if actual_names = expected_names then fields else raise_invalid Invalid_record_shape
+  | _ -> raise_invalid Invalid_record_shape
+;;
+
+let field fields name =
+  match List.assoc_opt name fields with
+  | Some value -> value
+  | None -> raise_invalid Invalid_record_shape
+;;
+
+let string_field fields name =
+  match field fields name with
+  | `String value -> value
+  | value -> raise_invalid (Record_field_invalid { field = name; value })
+;;
+
+let int_field fields name =
+  match field fields name with
+  | `Int value -> value
+  | value -> raise_invalid (Record_field_invalid { field = name; value })
+;;
+
+let validate_header fields ~state =
+  let schema = string_field fields "schema" in
+  if not (String.equal schema record_schema)
+  then
+    raise_invalid
+      (Record_field_invalid { field = "schema"; value = `String schema });
+  let version = int_field fields "version" in
+  if version <> record_version
+  then raise_invalid (Unsupported_record_version version);
+  let actual_state = string_field fields "state" in
+  if not (String.equal state actual_state)
+  then raise_invalid Record_state_mismatch
+;;
+
+let int64_to_json value = `String (Int64.to_string value)
+
+let int64_of_json ~field:name = function
+  | `String raw ->
+    (match Int64.of_string_opt raw with
+     | Some value when String.equal (Int64.to_string value) raw -> value
+     | None | Some _ ->
+       raise_invalid
+         (Record_field_invalid { field = name; value = `String raw }))
+  | value -> raise_invalid (Record_field_invalid { field = name; value })
+;;
+
+let identity_to_json (identity : identity) =
+  `Assoc
+    [ "dev", int64_to_json identity.dev
+    ; "ino", int64_to_json identity.ino
+    ]
+;;
+
+let identity_of_json ~field:name json =
+  let fields = strict_fields ~expected:[ "dev"; "ino" ] json in
+  let dev = int64_of_json ~field:(name ^ ".dev") (field fields "dev") in
+  let ino = int64_of_json ~field:(name ^ ".ino") (field fields "ino") in
+  match identity ~dev ~ino with
+  | Ok identity -> identity
+  | Error error -> raise_invalid error
+;;
+
+let kind_to_string = function
+  | `Unknown -> "unknown"
+  | `Fifo -> "fifo"
+  | `Character_special -> "character_special"
+  | `Directory -> "directory"
+  | `Block_device -> "block_device"
+  | `Regular_file -> "regular_file"
+  | `Symbolic_link -> "symbolic_link"
+  | `Socket -> "socket"
+;;
+
+let kind_of_json ~field:name = function
+  | `String "unknown" -> `Unknown
+  | `String "fifo" -> `Fifo
+  | `String "character_special" -> `Character_special
+  | `String "directory" -> `Directory
+  | `String "block_device" -> `Block_device
+  | `String "regular_file" -> `Regular_file
+  | `String "symbolic_link" -> `Symbolic_link
+  | `String "socket" -> `Socket
+  | value -> raise_invalid (Record_field_invalid { field = name; value })
+;;
+
+let observation_to_json = function
+  | Absent -> `Assoc [ "presence", `String "absent" ]
+  | Present { kind; identity } ->
+    `Assoc
+      [ "presence", `String "present"
+      ; "kind", `String (kind_to_string kind)
+      ; "identity", identity_to_json identity
+      ]
+;;
+
+let observation_of_json ~field:name json =
+  match json with
+  | `Assoc [ ("presence", `String "absent") ] -> Absent
+  | _ ->
+    let fields =
+      strict_fields ~expected:[ "presence"; "kind"; "identity" ] json
+    in
+    let presence = string_field fields "presence" in
+    if not (String.equal presence "present")
+    then
+      raise_invalid
+        (Record_field_invalid
+           { field = name ^ ".presence"; value = `String presence });
+    let kind = kind_of_json ~field:(name ^ ".kind") (field fields "kind") in
+    let identity =
+      identity_of_json ~field:(name ^ ".identity") (field fields "identity")
+    in
+    Present { kind; identity }
+;;
+
+let mismatch_to_json (mismatch : resource_mismatch) =
+  `Assoc
+    [ "expected", identity_to_json mismatch.expected
+    ; "observed", observation_to_json mismatch.observed
+    ]
+;;
+
+let mismatch_of_json ~field:name json =
+  let fields = strict_fields ~expected:[ "expected"; "observed" ] json in
+  { expected =
+      identity_of_json ~field:(name ^ ".expected") (field fields "expected")
+  ; observed = observation_of_json ~field:(name ^ ".observed") (field fields "observed")
+  }
+;;
+
+let owner_of_json fields =
+  let raw = string_field fields "owner" in
+  match owner_of_string raw with
+  | Ok owner -> owner
+  | Error error -> raise_invalid error
+;;
+
+let operation_id_of_json fields =
+  let raw = string_field fields "operation_id" in
+  match operation_id_of_string raw with
+  | Ok operation_id -> operation_id
+  | Error error -> raise_invalid error
+;;
+
+let prepared_to_json (prepared : prepared) =
+  `Assoc
+    [ "schema", `String record_schema
+    ; "version", `Int record_version
+    ; "state", `String "prepared"
+    ; "owner", `String (owner_to_string prepared.owner)
+    ; "operation_id", `String (operation_id_to_string prepared.operation_id)
+    ; "allowed_root_path", `String prepared.locator.allowed_root_path
+    ; "allowed_root", identity_to_json prepared.locator.allowed_root
+    ; ( "parent_components"
+      , `List
+          (List.map
+             (fun component -> `String (Capability_leaf.to_string component))
+             prepared.locator.parent_components) )
+    ; "parent", identity_to_json prepared.locator.parent
+    ; "target_leaf", `String (Capability_leaf.to_string prepared.locator.target_leaf)
+    ; "initial_target", observation_to_json prepared.locator.initial_target
+    ; "permissions", `Int prepared.permissions
+    ]
+;;
+
+let prepared_fields =
+  [ "schema"
+  ; "version"
+  ; "state"
+  ; "owner"
+  ; "operation_id"
+  ; "allowed_root_path"
+  ; "allowed_root"
+  ; "parent_components"
+  ; "parent"
+  ; "target_leaf"
+  ; "initial_target"
+  ; "permissions"
+  ]
+;;
+
+let prepared_of_json json =
+  let fields = strict_fields ~expected:prepared_fields json in
+  validate_header fields ~state:"prepared";
+  let owner = owner_of_json fields in
+  let operation_id = operation_id_of_json fields in
+  let allowed_root_path = string_field fields "allowed_root_path" in
+  let allowed_root =
+    identity_of_json ~field:"allowed_root" (field fields "allowed_root")
+  in
+  let parent_components =
+    match field fields "parent_components" with
+    | `List values ->
+      List.mapi
+        (fun index -> function
+           | `String value -> value
+           | value ->
+             raise_invalid
+               (Record_field_invalid
+                  { field = Printf.sprintf "parent_components[%d]" index
+                  ; value
+                  }))
+        values
+    | value ->
+      raise_invalid
+        (Record_field_invalid { field = "parent_components"; value })
+  in
+  let parent = identity_of_json ~field:"parent" (field fields "parent") in
+  let target_leaf = string_field fields "target_leaf" in
+  let initial_target =
+    observation_of_json ~field:"initial_target" (field fields "initial_target")
+  in
+  let permissions = int_field fields "permissions" in
+  let locator =
+    match
+      locator
+        ~allowed_root_path
+        ~allowed_root
+        ~parent_components
+        ~parent
+        ~target_leaf
+        ~initial_target
+    with
+    | Ok locator -> locator
+    | Error error -> raise_invalid error
+  in
+  let permissions =
+    match permissions_of_int permissions with
+    | Ok permissions -> permissions
+    | Error error -> raise_invalid error
+  in
+  { owner; operation_id; locator; permissions }
+;;
+
+let bound_to_json (bound : bound) =
+  let prepared_fields =
+    match prepared_to_json bound.prepared with
+    | `Assoc fields -> fields
+    | _ -> raise_invalid Invalid_record_shape
+  in
+  `Assoc
+    (List.map
+       (fun (name, value) ->
+          if String.equal name "state" then name, `String "bound" else name, value)
+       prepared_fields
+     @ [ "stage_name", `String (bound_stage_name bound)
+       ; "stage_identity", identity_to_json bound.stage_identity
+       ])
+;;
+
+let bound_fields = prepared_fields @ [ "stage_name"; "stage_identity" ]
+
+let bound_of_json json =
+  let fields = strict_fields ~expected:bound_fields json in
+  validate_header fields ~state:"bound";
+  let prepared_json =
+    `Assoc
+      (List.filter_map
+         (fun name ->
+            if String.equal name "state"
+            then Some (name, `String "prepared")
+            else Some (name, field fields name))
+         prepared_fields)
+  in
+  let prepared = prepared_of_json prepared_json in
+  let expected_stage_name = stage_name prepared.operation_id in
+  let actual_stage_name = string_field fields "stage_name" in
+  if not (String.equal expected_stage_name actual_stage_name)
+  then
+    raise_invalid
+      (Record_stage_leaf_mismatch
+         { expected = expected_stage_name; actual = actual_stage_name });
+  let stage_identity =
+    identity_of_json ~field:"stage_identity" (field fields "stage_identity")
+  in
+  { prepared; stage_identity }
+;;
+
+let prepared_outcome_to_json = function
+  | Recovered_unmaterialized ->
+    `Assoc [ "kind", `String "recovered_unmaterialized" ]
+  | Prepared_allowed_root_mismatch mismatch ->
+    `Assoc
+      [ "kind", `String "prepared_allowed_root_mismatch"
+      ; "mismatch", mismatch_to_json mismatch
+      ]
+  | Prepared_parent_mismatch mismatch ->
+    `Assoc
+      [ "kind", `String "prepared_parent_mismatch"
+      ; "mismatch", mismatch_to_json mismatch
+      ]
+  | Preserved_unbound_stage { kind; identity } ->
+    `Assoc
+      [ "kind", `String "preserved_unbound_stage"
+      ; "stage_kind", `String (kind_to_string kind)
+      ; "stage_identity", identity_to_json identity
+      ]
+;;
+
+let prepared_outcome_of_json json =
+  match json with
+  | `Assoc [ ("kind", `String "recovered_unmaterialized") ] ->
+    Recovered_unmaterialized
+  | _ ->
+    (match json with
+     | `Assoc fields ->
+       (match List.assoc_opt "kind" fields with
+        | Some (`String "prepared_allowed_root_mismatch") ->
+          let fields = strict_fields ~expected:[ "kind"; "mismatch" ] json in
+          Prepared_allowed_root_mismatch
+            (mismatch_of_json ~field:"mismatch" (field fields "mismatch"))
+        | Some (`String "prepared_parent_mismatch") ->
+          let fields = strict_fields ~expected:[ "kind"; "mismatch" ] json in
+          Prepared_parent_mismatch
+            (mismatch_of_json ~field:"mismatch" (field fields "mismatch"))
+        | Some (`String "preserved_unbound_stage") ->
+          let fields =
+            strict_fields
+              ~expected:[ "kind"; "stage_kind"; "stage_identity" ]
+              json
+          in
+          Preserved_unbound_stage
+            { kind =
+                kind_of_json ~field:"stage_kind" (field fields "stage_kind")
+            ; identity =
+                identity_of_json
+                  ~field:"stage_identity"
+                  (field fields "stage_identity")
+            }
+        | Some value ->
+          raise_invalid (Record_field_invalid { field = "outcome.kind"; value })
+        | None -> raise_invalid Invalid_record_shape)
+     | _ -> raise_invalid Invalid_record_shape)
+;;
+
+let bound_outcome_to_json = function
+  | Bound_stage_absent { observed_target } ->
+    `Assoc
+      [ "kind", `String "bound_stage_absent"
+      ; "observed_target", observation_to_json observed_target
+      ]
+  | Bound_allowed_root_mismatch mismatch ->
+    `Assoc
+      [ "kind", `String "bound_allowed_root_mismatch"
+      ; "mismatch", mismatch_to_json mismatch
+      ]
+  | Bound_parent_mismatch mismatch ->
+    `Assoc
+      [ "kind", `String "bound_parent_mismatch"
+      ; "mismatch", mismatch_to_json mismatch
+      ]
+  | Bound_stage_mismatch { mismatch; observed_target } ->
+    `Assoc
+      [ "kind", `String "bound_stage_mismatch"
+      ; "mismatch", mismatch_to_json mismatch
+      ; "observed_target", observation_to_json observed_target
+      ]
+  | Preserved_bound_stage { kind; identity; observed_target } ->
+    `Assoc
+      [ "kind", `String "preserved_bound_stage"
+      ; "stage_kind", `String (kind_to_string kind)
+      ; "stage_identity", identity_to_json identity
+      ; "observed_target", observation_to_json observed_target
+      ]
+;;
+
+let bound_outcome_of_json json =
+  match json with
+  | `Assoc fields ->
+    (match List.assoc_opt "kind" fields with
+     | Some (`String "bound_stage_absent") ->
+       let fields =
+         strict_fields ~expected:[ "kind"; "observed_target" ] json
+       in
+       Bound_stage_absent
+         { observed_target =
+             observation_of_json
+               ~field:"observed_target"
+               (field fields "observed_target")
+         }
+     | Some (`String "bound_allowed_root_mismatch") ->
+       let fields = strict_fields ~expected:[ "kind"; "mismatch" ] json in
+       Bound_allowed_root_mismatch
+         (mismatch_of_json ~field:"mismatch" (field fields "mismatch"))
+     | Some (`String "bound_parent_mismatch") ->
+       let fields = strict_fields ~expected:[ "kind"; "mismatch" ] json in
+       Bound_parent_mismatch
+         (mismatch_of_json ~field:"mismatch" (field fields "mismatch"))
+     | Some (`String "bound_stage_mismatch") ->
+       let fields =
+         strict_fields
+           ~expected:[ "kind"; "mismatch"; "observed_target" ]
+           json
+       in
+       Bound_stage_mismatch
+         { mismatch =
+             mismatch_of_json ~field:"mismatch" (field fields "mismatch")
+         ; observed_target =
+             observation_of_json
+               ~field:"observed_target"
+               (field fields "observed_target")
+         }
+     | Some (`String "preserved_bound_stage") ->
+       let fields =
+         strict_fields
+           ~expected:
+             [ "kind"; "stage_kind"; "stage_identity"; "observed_target" ]
+           json
+       in
+       Preserved_bound_stage
+         { kind =
+             kind_of_json
+               ~field:"stage_kind"
+               (field fields "stage_kind")
+         ; identity =
+             identity_of_json
+               ~field:"stage_identity"
+               (field fields "stage_identity")
+         ; observed_target =
+             observation_of_json
+               ~field:"observed_target"
+               (field fields "observed_target")
+         }
+     | Some value ->
+       raise_invalid (Record_field_invalid { field = "outcome.kind"; value })
+     | None -> raise_invalid Invalid_record_shape)
+  | _ -> raise_invalid Invalid_record_shape
+;;
+
+let forensic_to_json (forensic : forensic) =
+  let owner = forensic_owner forensic in
+  let operation_id = forensic_operation_id forensic in
+  let source_state, source, outcome =
+    match forensic.source with
+    | Prepared_source (prepared, outcome) ->
+      "prepared", prepared_to_json prepared, prepared_outcome_to_json outcome
+    | Bound_source (bound, outcome) ->
+      "bound", bound_to_json bound, bound_outcome_to_json outcome
+  in
+  `Assoc
+    [ "schema", `String record_schema
+    ; "version", `Int record_version
+    ; "state", `String "forensic"
+    ; "owner", `String (owner_to_string owner)
+    ; "operation_id", `String (operation_id_to_string operation_id)
+    ; "source_state", `String source_state
+    ; "source", source
+    ; "outcome", outcome
+    ]
+;;
+
+let forensic_fields =
+  [ "schema"
+  ; "version"
+  ; "state"
+  ; "owner"
+  ; "operation_id"
+  ; "source_state"
+  ; "source"
+  ; "outcome"
+  ]
+;;
+
+let validate_directory_mismatch_observation mismatch =
+  match mismatch.observed with
+  | Absent -> Ok ()
+  | Present { kind; identity }
+    when kind <> `Directory || not (equal_identity identity mismatch.expected) ->
+    Ok ()
+  | Present _ ->
+    Error (Record_outcome_observation_not_mismatch mismatch.expected)
+;;
+
+let validate_prepared_recovery_outcome (prepared : prepared) = function
+  | Recovered_unmaterialized | Preserved_unbound_stage _ -> Ok ()
+  | Prepared_allowed_root_mismatch mismatch ->
+    if equal_identity mismatch.expected prepared.locator.allowed_root
+    then validate_directory_mismatch_observation mismatch
+    else
+      Error
+        (Record_identity_mismatch
+           { expected = prepared.locator.allowed_root
+           ; actual = mismatch.expected
+           })
+  | Prepared_parent_mismatch mismatch ->
+    if equal_identity mismatch.expected prepared.locator.parent
+    then validate_directory_mismatch_observation mismatch
+    else
+      Error
+        (Record_identity_mismatch
+           { expected = prepared.locator.parent; actual = mismatch.expected })
+;;
+
+let validate_bound_recovery_outcome (bound : bound) = function
+  | Bound_stage_absent _ -> Ok ()
+  | Preserved_bound_stage { kind; identity; _ } ->
+    if kind <> `Directory
+    then Error (Record_kind_mismatch { expected = `Directory; actual = kind })
+    else if not (equal_identity identity bound.stage_identity)
+    then
+      Error
+        (Record_identity_mismatch
+           { expected = bound.stage_identity; actual = identity })
+    else Ok ()
+  | Bound_allowed_root_mismatch mismatch ->
+    if equal_identity mismatch.expected bound.prepared.locator.allowed_root
+    then validate_directory_mismatch_observation mismatch
+    else
+      Error
+        (Record_identity_mismatch
+           { expected = bound.prepared.locator.allowed_root
+           ; actual = mismatch.expected
+           })
+  | Bound_parent_mismatch mismatch ->
+    if equal_identity mismatch.expected bound.prepared.locator.parent
+    then validate_directory_mismatch_observation mismatch
+    else
+      Error
+        (Record_identity_mismatch
+           { expected = bound.prepared.locator.parent
+           ; actual = mismatch.expected
+           })
+  | Bound_stage_mismatch { mismatch; _ } ->
+    if equal_identity mismatch.expected bound.stage_identity
+    then validate_directory_mismatch_observation mismatch
+    else
+      Error
+        (Record_identity_mismatch
+           { expected = bound.stage_identity; actual = mismatch.expected })
+;;
+
+let forensic_of_json json =
+  let fields = strict_fields ~expected:forensic_fields json in
+  validate_header fields ~state:"forensic";
+  let owner = owner_of_json fields in
+  let operation_id = operation_id_of_json fields in
+  let source =
+    match string_field fields "source_state" with
+    | "prepared" ->
+      let prepared = prepared_of_json (field fields "source") in
+      let outcome = prepared_outcome_of_json (field fields "outcome") in
+      Prepared_source (prepared, outcome)
+    | "bound" ->
+      let bound = bound_of_json (field fields "source") in
+      let outcome = bound_outcome_of_json (field fields "outcome") in
+      Bound_source (bound, outcome)
+    | _ -> raise_invalid Record_state_mismatch
+  in
+  let source_owner, source_operation_id =
+    match source with
+    | Prepared_source (prepared, _) -> prepared.owner, prepared.operation_id
+    | Bound_source (bound, _) ->
+      bound.prepared.owner, bound.prepared.operation_id
+  in
+  if not (equal_owner owner source_owner)
+  then
+    raise_invalid
+      (Record_owner_mismatch { expected = owner; actual = source_owner });
+  if not (equal_operation_id operation_id source_operation_id)
+  then
+    raise_invalid
+      (Record_operation_id_mismatch
+         { expected = operation_id; actual = source_operation_id });
+  (match source with
+   | Prepared_source (prepared, outcome) ->
+     (match validate_prepared_recovery_outcome prepared outcome with
+      | Ok () -> ()
+      | Error error -> raise_invalid error)
+   | Bound_source (bound, outcome) ->
+     (match validate_bound_recovery_outcome bound outcome with
+      | Ok () -> ()
+      | Error error -> raise_invalid error));
+  { source }
+;;
+
+let encode_json json = Yojson.Safe.to_string json ^ "\n"
+
+let decode_json raw decoder =
+  try
+    let json = Yojson.Safe.from_string raw in
+    Ok (decoder json)
+  with
+  | Record_validation_failed error -> Error error
+  | exception_ ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    Error (Invalid_record_json { exception_; backtrace })
+;;
+
+let encode_prepared (prepared : prepared) =
+  prepared_to_json prepared |> encode_json
+;;
+
+let encode_bound (bound : bound) = bound_to_json bound |> encode_json
+
+let encode_forensic (forensic : forensic) =
+  forensic_to_json forensic |> encode_json
+;;
+let decode_prepared raw = decode_json raw prepared_of_json
+let decode_bound raw = decode_json raw bound_of_json
+let decode_forensic raw = decode_json raw forensic_of_json
+
+let validate_record_owner_and_id ~owner ~operation_id ~record_owner ~record_id =
+  if not (equal_owner owner record_owner)
+  then
+    Error
+      (Record_owner_mismatch { expected = owner; actual = record_owner })
+  else if not (equal_operation_id operation_id record_id)
+  then
+    Error
+      (Record_operation_id_mismatch
+         { expected = operation_id; actual = record_id })
+  else Ok ()
+;;
+
+let area_to_string = function
+  | Active -> "active"
+  | Owned -> "owned"
+  | Forensic -> "forensic"
+;;
+
+let subject_to_string = function
+  | Registry_root -> "registry_root"
+  | Recovery_root -> "recovery_root"
+  | Lanes_root -> "lanes_root"
+  | Lane_root owner -> Printf.sprintf "lane(%S)" (owner_to_string owner)
+  | Area (area, owner) ->
+    Printf.sprintf "%s(%S)" (area_to_string area) (owner_to_string owner)
+  | Record (area, owner, operation_id) ->
+    Printf.sprintf
+      "%s(%S)/%s"
+      (area_to_string area)
+      (owner_to_string owner)
+      (record_name operation_id)
+;;
+
+let operation_to_string = function
+  | Inspect_directory -> "inspect_directory"
+  | Create_directory -> "create_directory"
+  | Open_directory -> "open_directory"
+  | Sync_directory -> "sync_directory"
+  | Read_directory -> "read_directory"
+  | Inspect_record -> "inspect_record"
+  | Open_record -> "open_record"
+  | Read_record -> "read_record"
+  | Decode_record -> "decode_record"
+  | Create_record -> "create_record"
+  | Apply_permissions -> "apply_permissions"
+  | Write_record -> "write_record"
+  | Sync_record -> "sync_record"
+  | Close_record -> "close_record"
+  | Verify_record_identity -> "verify_record_identity"
+  | Remove_record -> "remove_record"
+;;
+
+let transition_effect_to_string = function
+  | No_record_change -> "no_record_change"
+  | Layout_may_be_incomplete -> "layout_may_be_incomplete"
+  | Layout_ready -> "layout_ready"
+  | Active_record_state_unknown -> "active_record_state_unknown"
+  | Active_record_durable -> "active_record_durable"
+  | Active_record_discharged -> "active_record_discharged"
+  | Owned_record_state_unknown_with_active ->
+    "owned_record_state_unknown_with_active"
+  | Owned_record_durable_with_active -> "owned_record_durable_with_active"
+  | Owned_record_durable -> "owned_record_durable"
+  | Owned_record_discharged -> "owned_record_discharged"
+  | Forensic_record_state_unknown_with_source ->
+    "forensic_record_state_unknown_with_source"
+  | Forensic_record_durable_with_source ->
+    "forensic_record_durable_with_source"
+  | Forensic_record_durable -> "forensic_record_durable"
+  | Source_removal_durability_unknown transition ->
+    let source_area, destination =
+      match transition with
+      | Discharge_active -> Active, "none"
+      | Discharge_owned -> Owned, "none"
+      | Active_to_owned -> Active, area_to_string Owned
+      | Active_to_forensic -> Active, area_to_string Forensic
+      | Owned_to_forensic -> Owned, area_to_string Forensic
+    in
+    Printf.sprintf
+      "source_removal_durability_unknown(source=%s,destination=%s)"
+      (area_to_string source_area)
+      destination
+;;
+
+let failure_to_string (failure : failure) =
+  let cause =
+    match failure.cause with
+    | Validation_failed error -> validation_error_to_string error
+    | Io_failed { exception_; _ } -> Printexc.to_string exception_
+    | Write_failed { exception_; bytes_written; _ } ->
+      Printf.sprintf
+        "write failed after bytes_written=%d: %s"
+        bytes_written
+        (Printexc.to_string exception_)
+    | Unexpected_resource_kind kind ->
+      Format.asprintf "unexpected resource kind %a" Eio.File.Stat.pp_kind kind
+    | Resource_identity_changed { expected; actual } ->
+      Printf.sprintf
+        "resource identity changed expected=%Ld:%Ld actual=%Ld:%Ld"
+        expected.dev
+        expected.ino
+        actual.dev
+        actual.ino
+    | Posix_descriptor_unavailable -> "POSIX descriptor unavailable"
+    | Existing_record_does_not_match -> "existing record does not match"
+    | Created_record_identity_unavailable ->
+      "created record identity unavailable"
+    | Missing_record -> "record is missing"
+  in
+  Printf.sprintf
+    "operation=%s subject=%s cause=%s"
+    (operation_to_string failure.operation)
+    (subject_to_string failure.subject)
+    cause
+;;
+
+let transition_error_to_string (error : transition_error) =
+  let cleanup =
+    match error.cleanup_failures with
+    | [] -> ""
+    | failures ->
+      failures
+      |> List.map failure_to_string
+      |> String.concat "; "
+      |> Printf.sprintf " cleanup_failures=[%s]"
+  in
+  Printf.sprintf
+    "effect=%s failure=(%s)%s"
+    (transition_effect_to_string error.store_effect)
+    (failure_to_string error.failure)
+    cleanup
+;;
+
+let cause_of_exception exception_ backtrace =
+  match exception_ with
+  | Record_validation_failed error -> Validation_failed error
+  | Internal_unexpected_resource_kind kind -> Unexpected_resource_kind kind
+  | Internal_resource_identity_changed (expected, actual) ->
+    Resource_identity_changed { expected; actual }
+  | Internal_posix_descriptor_unavailable -> Posix_descriptor_unavailable
+  | Internal_existing_record_does_not_match ->
+    Existing_record_does_not_match
+  | Internal_created_record_identity_unavailable ->
+    Created_record_identity_unavailable
+  | Internal_missing_record -> Missing_record
+  | exception_ -> Io_failed { exception_; backtrace }
+;;
+
+let make_failure ~operation ~subject exception_ backtrace =
+  { operation; subject; cause = cause_of_exception exception_ backtrace }
+;;
+
+let raise_io ~operation ~subject f =
+  try f () with
+  | Eio.Cancel.Cancelled _ as cancellation -> raise cancellation
+  | Store_failure _ as failure -> raise failure
+  | exception_ ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    raise
+      (Store_failure
+         (make_failure ~operation ~subject exception_ backtrace))
+;;
+
+let raise_validation ~operation ~subject validation_error =
+  raise
+    (Store_failure
+       { operation; subject; cause = Validation_failed validation_error })
+;;
+
+let transition_error ~store_effect failure =
+  { store_effect; failure; cleanup_failures = [] }
+;;
+
+let protect_result ~store_effect f =
+  try Ok (f ()) with
+  | Eio.Cancel.Cancelled _ as cancellation -> raise cancellation
+  | Transition_failed error -> Error error
+  | Store_failure failure -> Error (transition_error ~store_effect failure)
+;;
+
+let run_layout f =
+  let observed_effect = ref Layout_may_be_incomplete in
+  try
+    let value = Eio.Cancel.protect f in
+    observed_effect := Layout_ready;
+    Eio.Fiber.check ();
+    Ok value
+  with
+  | Eio.Cancel.Cancelled reason ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    Printexc.raise_with_backtrace
+      (Eio.Cancel.Cancelled
+         (Recovery_store_cancelled (reason, !observed_effect, [])))
+      backtrace
+  | Transition_failed error -> Error error
+  | Store_failure failure ->
+    Error
+      { store_effect = !observed_effect
+      ; failure
+      ; cleanup_failures = []
+      }
+;;
+
+let sync_directory ~subject directory =
+  raise_io ~operation:Sync_directory ~subject (fun () ->
+    Eio.Path.with_open_in Eio.Path.(directory / ".") @@ fun file ->
+    match Eio_unix.Resource.fd_opt file with
+    | None -> raise Internal_posix_descriptor_unavailable
+    | Some fd ->
+      Eio_unix.run_in_systhread
+        ~label:"fs-compat-recovery-directory-fsync"
+        (fun () ->
+           Eio_unix.Fd.use_exn
+             "fs-compat-recovery-directory-fsync"
+             fd
+             Unix.fsync);
+      Eio.Fiber.check ())
+;;
+
+let verify_opened_directory ~subject ~lexical_identity directory =
+  raise_io ~operation:Open_directory ~subject (fun () ->
+    Eio.Path.with_open_in Eio.Path.(directory / ".") @@ fun file ->
+    let stat = Eio.File.stat file in
+    if stat.kind <> `Directory
+    then raise (Internal_unexpected_resource_kind stat.kind);
+    let opened_identity = identity_of_stat stat in
+    if not (equal_identity lexical_identity opened_identity)
+    then
+      raise
+        (Internal_resource_identity_changed
+           (lexical_identity, opened_identity));
+    stat)
+;;
+
+let set_directory_permissions ~subject directory =
+  raise_io ~operation:Apply_permissions ~subject (fun () ->
+    Eio.Path.with_open_in Eio.Path.(directory / ".") @@ fun file ->
+    match Eio_unix.Resource.fd_opt file with
+    | None -> raise Internal_posix_descriptor_unavailable
+    | Some fd ->
+      Eio_unix.run_in_systhread
+        ~label:"fs-compat-recovery-directory-fchmod"
+        (fun () ->
+           Eio_unix.Fd.use_exn
+             "fs-compat-recovery-directory-fchmod"
+             fd
+             (fun unix_fd -> Unix.fchmod unix_fd directory_permissions));
+      Eio.Fiber.check ())
+;;
+
+let verify_directory_permissions ~subject directory =
+  let stat =
+    raise_io ~operation:Inspect_directory ~subject (fun () ->
+      Eio.Path.with_open_in Eio.Path.(directory / ".") Eio.File.stat)
+  in
+  let actual = stat.perm land 0o7777 in
+  if actual <> directory_permissions
+  then
+    raise_validation
+      ~operation:Inspect_directory
+      ~subject
+      (Record_permissions_mismatch
+         { expected = directory_permissions; actual })
+;;
+
+let prepare_directory_entry ~parent ~leaf ~subject =
+  let path = Eio.Path.(parent / leaf) in
+  let creation =
+    raise_io ~operation:Create_directory ~subject (fun () ->
+      try
+        Eio.Path.mkdir ~perm:directory_permissions path;
+        `Created
+      with
+      | Eio.Io (Eio.Fs.E (Eio.Fs.Already_exists _), _) -> `Existing)
+  in
+  let lexical =
+    raise_io ~operation:Inspect_directory ~subject (fun () ->
+      Eio.Path.stat ~follow:false path)
+  in
+  if lexical.kind <> `Directory
+  then
+    raise_validation
+      ~operation:Inspect_directory
+      ~subject
+      (Record_kind_mismatch
+         { expected = `Directory; actual = lexical.kind });
+  let lexical_identity = identity_of_stat lexical in
+  path, creation, lexical_identity
+;;
+
+let stabilize_directory
+      ~parent
+      ~parent_subject
+      ~subject
+      ~creation
+      ~lexical_identity
+      opened
+  =
+  let opened_stat =
+    verify_opened_directory ~subject ~lexical_identity opened
+  in
+  let actual_permissions = opened_stat.perm land 0o7777 in
+  (match creation with
+   | `Created ->
+     (* mkdir permissions are filtered through umask. fchmod the pinned
+        directory before either directory or parent durability is acknowledged. *)
+     set_directory_permissions ~subject opened
+   | `Existing ->
+     if actual_permissions <> directory_permissions
+     then set_directory_permissions ~subject opened);
+  (* Existing components receive the same barriers as newly created ones. A
+     previous attempt may have reached mkdir/fchmod/child-fsync but failed
+     before the parent fsync, so merely observing the path cannot prove the
+     hierarchy durable. *)
+  verify_directory_permissions ~subject opened;
+  sync_directory ~subject opened;
+  sync_directory ~subject:parent_subject parent
+;;
+
+let with_ensured_directory
+      ~parent
+      ~parent_subject
+      ~leaf
+      ~subject
+      f
+  =
+  let path, creation, lexical_identity =
+    prepare_directory_entry ~parent ~leaf ~subject
+  in
+  raise_io ~operation:Open_directory ~subject (fun () ->
+    Eio.Path.with_open_dir path @@ fun opened ->
+    let opened = (opened :> Eio.Fs.dir_ty Eio.Path.t) in
+    stabilize_directory
+      ~parent
+      ~parent_subject
+      ~subject
+      ~creation
+      ~lexical_identity
+      opened;
+    f opened)
+;;
+
+let open_ensured_directory
+      ~sw
+      ~parent
+      ~parent_subject
+      ~leaf
+      ~subject
+  =
+  let path, creation, lexical_identity =
+    prepare_directory_entry ~parent ~leaf ~subject
+  in
+  let opened =
+    raise_io ~operation:Open_directory ~subject (fun () ->
+      Eio.Path.open_dir ~sw path)
+  in
+  let opened = (opened :> Eio.Fs.dir_ty Eio.Path.t) in
+  stabilize_directory
+    ~parent
+    ~parent_subject
+    ~subject
+    ~creation
+    ~lexical_identity
+    opened;
+  opened
+;;
+
+let open_registry ~sw ~registry_root =
+  run_layout (fun () ->
+    let root_stat =
+      raise_io ~operation:Inspect_directory ~subject:Registry_root (fun () ->
+        Eio.Path.stat ~follow:true registry_root)
+    in
+    if root_stat.kind <> `Directory
+    then
+      raise_validation
+        ~operation:Inspect_directory
+        ~subject:Registry_root
+        (Record_kind_mismatch
+           { expected = `Directory; actual = root_stat.kind });
+    with_ensured_directory
+      ~parent:registry_root
+      ~parent_subject:Registry_root
+      ~leaf:recovery_directory_leaf
+      ~subject:Recovery_root
+    @@ fun recovery ->
+    let lanes =
+      open_ensured_directory
+        ~sw
+        ~parent:recovery
+        ~parent_subject:Recovery_root
+        ~leaf:lanes_directory_leaf
+        ~subject:Lanes_root
+    in
+    { lanes })
+;;
+
+type owner_inventory_row =
+  | Valid_owner of owner
+  | Invalid_owner_name of string
+  | Unexpected_owner_kind of
+      { name : string
+      ; kind : Eio.File.Stat.kind
+      }
+  | Missing_owner_entry of owner
+  | Owner_entry_unavailable of
+      { owner : owner
+      ; error : transition_error
+      }
+
+type owner_inventory = owner_inventory_row list
+
+let inventory_owners (registry : registry) =
+  protect_result ~store_effect:No_record_change (fun () ->
+    let names =
+      raise_io ~operation:Read_directory ~subject:Lanes_root (fun () ->
+        Eio.Path.read_dir registry.lanes)
+    in
+    List.map
+      (fun name ->
+         match owner_of_string name with
+         | Error _ -> Invalid_owner_name name
+         | Ok owner ->
+           (try
+              let kind =
+                raise_io
+                  ~operation:Inspect_directory
+                  ~subject:(Lane_root owner)
+                  (fun () ->
+                     Eio.Path.kind
+                       ~follow:false
+                       Eio.Path.(registry.lanes / name))
+              in
+              match kind with
+              | `Directory -> Valid_owner owner
+              | `Not_found -> Missing_owner_entry owner
+              | ( ( `Unknown
+                  | `Fifo
+                  | `Character_special
+                  | `Block_device
+                  | `Regular_file
+                  | `Symbolic_link
+                  | `Socket ) as
+                  kind ) ->
+                Unexpected_owner_kind { name; kind }
+            with
+            | Eio.Cancel.Cancelled _ as cancellation -> raise cancellation
+            | Transition_failed error ->
+              Owner_entry_unavailable { owner; error }
+            | Store_failure failure ->
+              Owner_entry_unavailable
+                { owner
+                ; error = transition_error ~store_effect:No_record_change failure
+                }))
+      names)
+;;
+
+let open_store_in_scope ~sw ~registry ~owner =
+  run_layout (fun () ->
+    with_ensured_directory
+      ~parent:registry.lanes
+      ~parent_subject:Lanes_root
+      ~leaf:(owner_to_string owner)
+      ~subject:(Lane_root owner)
+    @@ fun lane ->
+    let active =
+      open_ensured_directory
+        ~sw
+        ~parent:lane
+        ~parent_subject:(Lane_root owner)
+        ~leaf:active_directory_leaf
+        ~subject:(Area (Active, owner))
+    in
+    let owned =
+      open_ensured_directory
+        ~sw
+        ~parent:lane
+        ~parent_subject:(Lane_root owner)
+        ~leaf:owned_directory_leaf
+        ~subject:(Area (Owned, owner))
+    in
+    let forensic =
+      open_ensured_directory
+        ~sw
+        ~parent:lane
+        ~parent_subject:(Lane_root owner)
+        ~leaf:forensic_directory_leaf
+        ~subject:(Area (Forensic, owner))
+    in
+    { owner; active; owned; forensic })
+;;
+
+let with_store ~registry ~owner f =
+  Eio.Switch.run @@ fun sw ->
+  match open_store_in_scope ~sw ~registry ~owner with
+  | Error _ as error -> error
+  | Ok store -> Ok (f store)
+;;
+
+let area_directory (store : store) = function
+  | Active -> store.active
+  | Owned -> store.owned
+  | Forensic -> store.forensic
+;;
+
+let record_path (store : store) area operation_id =
+  Eio.Path.
+    (area_directory store area / record_name operation_id)
+;;
+
+let record_subject (store : store) area operation_id =
+  Record (area, store.owner, operation_id)
+;;
+
+let capture_failure ~operation ~subject f =
+  try
+    f ();
+    []
+  with
+  | Store_failure failure -> [ failure ]
+  | exception_ ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    [ make_failure ~operation ~subject exception_ backtrace ]
+;;
+
+let close_resource_failures ~subject resource =
+  capture_failure ~operation:Close_record ~subject (fun () ->
+    Eio.Resource.close resource)
+;;
+
+let read_raw_record ~store ~area ~operation_id ~store_effect =
+  let subject = record_subject store area operation_id in
+  let path = record_path store area operation_id in
+  let lexical =
+    raise_io ~operation:Inspect_record ~subject (fun () ->
+      Eio.Path.stat ~follow:false path)
+  in
+  if lexical.kind <> `Regular_file
+  then
+    raise_validation
+      ~operation:Inspect_record
+      ~subject
+      (Record_kind_mismatch
+         { expected = `Regular_file; actual = lexical.kind });
+  let lexical_identity = identity_of_stat lexical in
+  Eio.Switch.run @@ fun sw ->
+  let resource = ref None in
+  let cleanup () =
+    match !resource with
+    | None -> []
+    | Some file ->
+      resource := None;
+      close_resource_failures ~subject file
+  in
+  try
+    let file =
+      raise_io ~operation:Open_record ~subject (fun () ->
+        Eio.Path.open_in ~sw path)
+    in
+    resource := Some file;
+    let opened =
+      raise_io ~operation:Inspect_record ~subject (fun () ->
+        Eio.File.stat file)
+    in
+    if opened.kind <> `Regular_file
+    then
+      raise_validation
+        ~operation:Inspect_record
+        ~subject
+        (Record_kind_mismatch
+           { expected = `Regular_file; actual = opened.kind });
+    let opened_identity = identity_of_stat opened in
+    if not (equal_identity lexical_identity opened_identity)
+    then
+      raise_validation
+        ~operation:Verify_record_identity
+        ~subject
+        (Record_identity_mismatch
+           { expected = lexical_identity; actual = opened_identity });
+    let opened_permissions = opened.perm land 0o7777 in
+    if opened_permissions <> record_permissions
+    then
+      raise_validation
+        ~operation:Inspect_record
+        ~subject
+        (Record_permissions_mismatch
+           { expected = record_permissions; actual = opened_permissions });
+    let raw =
+      raise_io ~operation:Read_record ~subject (fun () -> Eio.Flow.read_all file)
+    in
+    let after =
+      raise_io ~operation:Verify_record_identity ~subject (fun () ->
+        Eio.File.stat file)
+    in
+    let after_identity = identity_of_stat after in
+    if after.kind <> `Regular_file
+    then
+      raise_validation
+        ~operation:Verify_record_identity
+        ~subject
+        (Record_kind_mismatch
+           { expected = `Regular_file; actual = after.kind });
+    if not (equal_identity opened_identity after_identity)
+    then
+      raise_validation
+        ~operation:Verify_record_identity
+        ~subject
+        (Record_identity_mismatch
+           { expected = opened_identity; actual = after_identity });
+    raise_io ~operation:Close_record ~subject (fun () ->
+      Eio.Resource.close file);
+    resource := None;
+    raw, opened_identity
+  with
+  | Eio.Cancel.Cancelled reason as cancellation ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    let cleanup_failures = Eio.Cancel.protect cleanup in
+    if cleanup_failures = []
+    then Printexc.raise_with_backtrace cancellation backtrace
+    else
+      Printexc.raise_with_backtrace
+        (Eio.Cancel.Cancelled
+           (Recovery_store_cancelled
+              (reason, store_effect, cleanup_failures)))
+        backtrace
+  | Store_failure failure ->
+    let cleanup_failures = Eio.Cancel.protect cleanup in
+    if cleanup_failures = []
+    then raise (Store_failure failure)
+    else
+      raise
+        (Transition_failed
+           { store_effect; failure; cleanup_failures })
+  | exception_ ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    let cleanup_failures = Eio.Cancel.protect cleanup in
+    let failure =
+      make_failure ~operation:Read_record ~subject exception_ backtrace
+    in
+    raise
+      (Transition_failed
+         { store_effect; failure; cleanup_failures })
+;;
+
+let decode_record ~store ~area ~operation_id ~decode ~owner_and_id raw =
+  let subject = record_subject store area operation_id in
+  let record =
+    match decode raw with
+    | Ok record -> record
+    | Error error ->
+      raise_validation ~operation:Decode_record ~subject error
+  in
+  let record_owner, record_id = owner_and_id record in
+  (match
+     validate_record_owner_and_id
+       ~owner:store.owner
+       ~operation_id
+       ~record_owner
+       ~record_id
+   with
+   | Ok () -> record
+   | Error error ->
+     raise_validation ~operation:Decode_record ~subject error)
+;;
+
+let read_prepared_internal ~store operation_id =
+  let raw, identity =
+    read_raw_record
+      ~store
+      ~area:Active
+      ~operation_id
+      ~store_effect:No_record_change
+  in
+  let prepared =
+    decode_record
+      ~store
+      ~area:Active
+      ~operation_id
+      ~decode:decode_prepared
+      ~owner_and_id:(fun prepared -> prepared.owner, prepared.operation_id)
+      raw
+  in
+  prepared, raw, identity
+;;
+
+let read_bound_internal ~store operation_id =
+  let raw, identity =
+    read_raw_record
+      ~store
+      ~area:Owned
+      ~operation_id
+      ~store_effect:No_record_change
+  in
+  let bound =
+    decode_record
+      ~store
+      ~area:Owned
+      ~operation_id
+      ~decode:decode_bound
+      ~owner_and_id:(fun bound ->
+        bound.prepared.owner, bound.prepared.operation_id)
+      raw
+  in
+  bound, raw, identity
+;;
+
+let read_forensic_internal ~store operation_id =
+  let raw, identity =
+    read_raw_record
+      ~store
+      ~area:Forensic
+      ~operation_id
+      ~store_effect:No_record_change
+  in
+  let forensic =
+    decode_record
+      ~store
+      ~area:Forensic
+      ~operation_id
+      ~decode:decode_forensic
+      ~owner_and_id:(fun forensic ->
+        forensic_owner forensic, forensic_operation_id forensic)
+      raw
+  in
+  forensic, raw, identity
+;;
+
+type 'a lookup =
+  | Missing
+  | Found of 'a
+
+let lookup_record ~store ~area ~operation_id read =
+  let subject = record_subject store area operation_id in
+  match
+    raise_io ~operation:Inspect_record ~subject (fun () ->
+      Eio.Path.kind ~follow:false (record_path store area operation_id))
+  with
+  | `Not_found -> Missing
+  | `Regular_file -> Found (read ())
+  | (#Eio.File.Stat.kind as kind) ->
+    raise_validation
+      ~operation:Inspect_record
+      ~subject
+      (Record_kind_mismatch { expected = `Regular_file; actual = kind })
+;;
+
+let read_prepared ~store operation_id =
+  protect_result ~store_effect:No_record_change (fun () ->
+    lookup_record ~store ~area:Active ~operation_id (fun () ->
+      let prepared, _, _ = read_prepared_internal ~store operation_id in
+      prepared))
+;;
+
+let read_bound ~store operation_id =
+  protect_result ~store_effect:No_record_change (fun () ->
+    lookup_record ~store ~area:Owned ~operation_id (fun () ->
+      let bound, _, _ = read_bound_internal ~store operation_id in
+      bound))
+;;
+
+let read_forensic ~store operation_id =
+  protect_result ~store_effect:No_record_change (fun () ->
+    lookup_record ~store ~area:Forensic ~operation_id (fun () ->
+      let forensic, _, _ = read_forensic_internal ~store operation_id in
+      forensic))
+;;
+
+let write_record_payload ~subject file raw =
+  match
+    Blocking_write.write_string
+      ~label:"fs-compat-recovery-record-write"
+      file
+      raw
+  with
+  | Ok () -> Eio.Fiber.check ()
+  | Error Blocking_write.Open_file_posix_descriptor_unavailable ->
+    let exception_ = Internal_posix_descriptor_unavailable in
+    let backtrace = Printexc.get_callstack 16 in
+    raise
+      (Store_failure
+         (make_failure ~operation:Write_record ~subject exception_ backtrace))
+  | Error
+      (Blocking_write.Open_file_operation_failed
+        { exception_; backtrace; bytes_written }) ->
+    raise
+      (Store_failure
+         { operation = Write_record
+         ; subject
+         ; cause = Write_failed { exception_; backtrace; bytes_written }
+         })
+;;
+
+let apply_record_permissions ~subject file =
+  raise_io ~operation:Apply_permissions ~subject (fun () ->
+    match Eio_unix.Resource.fd_opt file with
+    | None -> raise Internal_posix_descriptor_unavailable
+    | Some fd ->
+      Eio_unix.run_in_systhread
+        ~label:"fs-compat-recovery-record-fchmod"
+        (fun () ->
+           Eio_unix.Fd.use_exn
+             "fs-compat-recovery-record-fchmod"
+             fd
+             (fun unix_fd -> Unix.fchmod unix_fd record_permissions));
+      let stat = Eio.File.stat file in
+      let actual = stat.perm land 0o7777 in
+      if actual <> record_permissions
+      then
+        raise
+          (Record_validation_failed
+             (Record_permissions_mismatch
+                { expected = record_permissions; actual }));
+      Eio.Fiber.check ())
+;;
+
+let cleanup_created_record
+      ~store
+      ~area
+      ~operation_id
+      ~resource
+      ~created_identity
+      ~entry_created
+  =
+  let subject = record_subject store area operation_id in
+  let path = record_path store area operation_id in
+  let failures = ref [] in
+  let add more = failures := !failures @ more in
+  (match !resource with
+   | None -> ()
+   | Some file ->
+     resource := None;
+     add (close_resource_failures ~subject file));
+  let removed = ref false in
+  (match !entry_created, !created_identity with
+   | false, _ -> ()
+   | true, None ->
+       let exception_ = Internal_created_record_identity_unavailable in
+       let backtrace = Printexc.get_callstack 16 in
+       add
+         [ make_failure
+             ~operation:Verify_record_identity
+             ~subject
+             exception_
+             backtrace
+         ]
+   | true, Some expected ->
+     let identity_failures =
+       capture_failure ~operation:Verify_record_identity ~subject (fun () ->
+         let actual = Eio.Path.stat ~follow:false path in
+         if actual.kind <> `Regular_file
+         then raise (Internal_unexpected_resource_kind actual.kind);
+         let actual_identity = identity_of_stat actual in
+         if not (equal_identity expected actual_identity)
+         then
+           raise
+             (Internal_resource_identity_changed (expected, actual_identity)))
+     in
+     add identity_failures;
+     if identity_failures = []
+     then (
+       let remove_failures =
+         capture_failure ~operation:Remove_record ~subject (fun () ->
+           Eio.Path.unlink path)
+       in
+       add remove_failures;
+       if remove_failures = [] then removed := true));
+  let removal_sync_failures =
+    if not !removed
+    then []
+    else
+      capture_failure
+        ~operation:Sync_directory
+        ~subject:(Area (area, store.owner))
+        (fun () ->
+           sync_directory
+             ~subject:(Area (area, store.owner))
+             (area_directory store area))
+  in
+  add removal_sync_failures;
+  let record_absent_durable =
+    (not !entry_created) || (!removed && removal_sync_failures = [])
+  in
+  !failures, record_absent_durable
+;;
+
+type exclusive_write_result =
+  | Record_created
+  | Record_exists
+
+let create_record_exclusive
+      ~store
+      ~area
+      ~operation_id
+      ~raw
+      ~base_effect
+      ~unknown_effect
+  =
+  let subject = record_subject store area operation_id in
+  let path = record_path store area operation_id in
+  Eio.Cancel.protect @@ fun () ->
+  Eio.Switch.run @@ fun sw ->
+  let resource = ref None in
+  let created_identity = ref None in
+  let entry_created = ref false in
+  try
+    let opened =
+      try
+        Some
+          (raise_io ~operation:Create_record ~subject (fun () ->
+             Eio.Path.open_out
+               ~sw
+               ~create:(`Exclusive record_permissions)
+               path))
+      with
+      | Store_failure
+          { cause =
+              Io_failed
+                { exception_ =
+                    Eio.Io (Eio.Fs.E (Eio.Fs.Already_exists _), _)
+                ; _
+                }
+          ; _
+          } ->
+        None
+    in
+    match opened with
+    | None -> Record_exists
+    | Some file ->
+      entry_created := true;
+      resource := Some file;
+      let stat =
+        raise_io ~operation:Inspect_record ~subject (fun () ->
+          Eio.File.stat file)
+      in
+      if stat.kind <> `Regular_file
+      then
+        raise_validation
+          ~operation:Inspect_record
+          ~subject
+          (Record_kind_mismatch
+             { expected = `Regular_file; actual = stat.kind });
+      created_identity := Some (identity_of_stat stat);
+      apply_record_permissions ~subject file;
+      write_record_payload ~subject file raw;
+      raise_io ~operation:Sync_record ~subject (fun () -> Eio.File.sync file);
+      raise_io ~operation:Close_record ~subject (fun () ->
+        Eio.Resource.close file);
+      resource := None;
+      sync_directory
+        ~subject:(Area (area, store.owner))
+        (area_directory store area);
+      Record_created
+  with
+  | Eio.Cancel.Cancelled reason as cancellation ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    let cleanup_failures, record_absent_durable =
+      cleanup_created_record
+        ~store
+        ~area
+        ~operation_id
+        ~resource
+        ~created_identity
+        ~entry_created
+    in
+    let store_effect =
+      if record_absent_durable then base_effect else unknown_effect
+    in
+    if store_effect = No_record_change && cleanup_failures = []
+    then Printexc.raise_with_backtrace cancellation backtrace
+    else
+      Printexc.raise_with_backtrace
+        (Eio.Cancel.Cancelled
+           (Recovery_store_cancelled
+              (reason, store_effect, cleanup_failures)))
+        backtrace
+  | Store_failure failure ->
+    let cleanup_failures, record_absent_durable =
+      cleanup_created_record
+        ~store
+        ~area
+        ~operation_id
+        ~resource
+        ~created_identity
+        ~entry_created
+    in
+    let store_effect =
+      if record_absent_durable then base_effect else unknown_effect
+    in
+    raise (Transition_failed { store_effect; failure; cleanup_failures })
+  | exception_ ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    let cleanup_failures, record_absent_durable =
+      cleanup_created_record
+        ~store
+        ~area
+        ~operation_id
+        ~resource
+        ~created_identity
+        ~entry_created
+    in
+    let store_effect =
+      if record_absent_durable then base_effect else unknown_effect
+    in
+    let failure =
+      make_failure ~operation:Write_record ~subject exception_ backtrace
+    in
+    raise (Transition_failed { store_effect; failure; cleanup_failures })
+;;
+
+type ensure_record_result =
+  | Installed_record
+  | Existing_exact_record
+
+let ensure_exact_record
+      ~store
+      ~area
+      ~operation_id
+      ~raw
+      ~base_effect
+      ~unknown_effect
+  =
+  match
+    create_record_exclusive
+      ~store
+      ~area
+      ~operation_id
+      ~raw
+      ~base_effect
+      ~unknown_effect
+  with
+  | Record_created -> Installed_record
+  | Record_exists ->
+    let existing_raw, _ =
+      read_raw_record ~store ~area ~operation_id ~store_effect:base_effect
+    in
+    if not (String.equal raw existing_raw)
+    then (
+      let subject = record_subject store area operation_id in
+      let exception_ = Internal_existing_record_does_not_match in
+      let backtrace = Printexc.get_callstack 16 in
+      raise
+        (Store_failure
+           (make_failure ~operation:Decode_record ~subject exception_ backtrace)));
+    sync_directory
+      ~subject:(Area (area, store.owner))
+      (area_directory store area);
+    Existing_exact_record
+;;
+
+let verify_exact_source
+      ~store
+      ~area
+      ~operation_id
+      ~expected_raw
+      ~store_effect
+  =
+  let actual_raw, identity =
+    read_raw_record ~store ~area ~operation_id ~store_effect
+  in
+  if not (String.equal expected_raw actual_raw)
+  then (
+    let subject = record_subject store area operation_id in
+    let exception_ = Internal_existing_record_does_not_match in
+    let backtrace = Printexc.get_callstack 16 in
+    raise
+      (Store_failure
+         (make_failure ~operation:Decode_record ~subject exception_ backtrace)));
+  identity
+;;
+
+let remove_exact_source
+      ~store
+      ~area
+      ~operation_id
+      ~expected_raw
+      ~effect_before
+      ~removal_transition
+  =
+  Eio.Cancel.protect @@ fun () ->
+  let subject = record_subject store area operation_id in
+  let path = record_path store area operation_id in
+  let expected_identity =
+    verify_exact_source
+      ~store
+      ~area
+      ~operation_id
+      ~expected_raw
+      ~store_effect:effect_before
+  in
+  let removed = ref false in
+  try
+    let actual =
+      raise_io ~operation:Verify_record_identity ~subject (fun () ->
+        Eio.Path.stat ~follow:false path)
+    in
+    if actual.kind <> `Regular_file
+    then
+      raise_validation
+        ~operation:Verify_record_identity
+        ~subject
+        (Record_kind_mismatch
+           { expected = `Regular_file; actual = actual.kind });
+    let actual_identity = identity_of_stat actual in
+    if not (equal_identity expected_identity actual_identity)
+    then
+      raise_validation
+        ~operation:Verify_record_identity
+        ~subject
+        (Record_identity_mismatch
+           { expected = expected_identity; actual = actual_identity });
+    raise_io ~operation:Remove_record ~subject (fun () -> Eio.Path.unlink path);
+    removed := true;
+    sync_directory
+      ~subject:(Area (area, store.owner))
+      (area_directory store area)
+  with
+  | Store_failure failure ->
+    let store_effect =
+      if !removed
+      then Source_removal_durability_unknown removal_transition
+      else effect_before
+    in
+    raise
+      (Transition_failed
+         { store_effect; failure; cleanup_failures = [] })
+;;
+
+let record_kind ~store ~area ~operation_id =
+  let subject = record_subject store area operation_id in
+  raise_io ~operation:Inspect_record ~subject (fun () ->
+    Eio.Path.kind ~follow:false (record_path store area operation_id))
+;;
+
+let raise_missing_record ~store ~area ~operation_id =
+  let subject = record_subject store area operation_id in
+  let exception_ = Internal_missing_record in
+  let backtrace = Printexc.get_callstack 16 in
+  raise
+    (Store_failure
+       (make_failure ~operation:Inspect_record ~subject exception_ backtrace))
+;;
+
+let raise_existing_record_mismatch ~store ~area ~operation_id =
+  let subject = record_subject store area operation_id in
+  let exception_ = Internal_existing_record_does_not_match in
+  let backtrace = Printexc.get_callstack 16 in
+  raise
+    (Store_failure
+       (make_failure ~operation:Decode_record ~subject exception_ backtrace))
+;;
+
+let ensure_input_owner ~store ~operation_id actual_owner =
+  if not (equal_owner store.owner actual_owner)
+  then
+    raise_validation
+      ~operation:Decode_record
+      ~subject:(Record (Active, store.owner, operation_id))
+      (Record_owner_mismatch
+         { expected = store.owner; actual = actual_owner })
+;;
+
+let run_mutation ~initial_effect f =
+  let observed_effect = ref initial_effect in
+  try
+    let value = Eio.Cancel.protect (fun () -> f observed_effect) in
+    Eio.Fiber.check ();
+    Ok value
+  with
+  | Eio.Cancel.Cancelled reason as cancellation ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    if !observed_effect = No_record_change
+    then Printexc.raise_with_backtrace cancellation backtrace
+    else
+      Printexc.raise_with_backtrace
+        (Eio.Cancel.Cancelled
+           (Recovery_store_cancelled (reason, !observed_effect, [])))
+        backtrace
+  | Transition_failed error -> Error error
+  | Store_failure failure ->
+    Error
+      { store_effect = !observed_effect
+      ; failure
+      ; cleanup_failures = []
+      }
+;;
+
+(* NDT-OK: UUID entropy names an exclusively-created obligation record;
+   correctness comes from exclusive create plus exact collision handling. The
+   nonce never drives recovery or publication policy. *)
+let operation_id_rng = Domain.DLS.new_key Random.State.make_self_init
+
+let fresh_operation_id () =
+  Uuidm.v4_gen (Domain.DLS.get operation_id_rng) ()
+;;
+
+let prepare_with_operation_id_internal
+      ~store
+      ~operation_id
+      ~locator
+      ~permissions
+  =
+  let prepared = { owner = store.owner; operation_id; locator; permissions } in
+  let raw = encode_prepared prepared in
+  (match record_kind ~store ~area:Owned ~operation_id with
+   | `Not_found -> ()
+   | _ -> raise_existing_record_mismatch ~store ~area:Owned ~operation_id);
+  (match record_kind ~store ~area:Forensic ~operation_id with
+   | `Not_found -> ()
+   | _ -> raise_existing_record_mismatch ~store ~area:Forensic ~operation_id);
+  ignore
+    (ensure_exact_record
+       ~store
+       ~area:Active
+       ~operation_id
+       ~raw
+       ~base_effect:No_record_change
+       ~unknown_effect:Active_record_state_unknown);
+  prepared
+;;
+
+let prepare ~(store : store) ~(locator : locator) ~(permissions : permissions) =
+  let create_attempt () =
+    let operation_id = fresh_operation_id () in
+    let prepared = { owner = store.owner; operation_id; locator; permissions } in
+    let raw = encode_prepared prepared in
+    run_mutation ~initial_effect:No_record_change @@ fun observed_effect ->
+    match
+      create_record_exclusive
+        ~store
+        ~area:Active
+        ~operation_id
+        ~raw
+        ~base_effect:No_record_change
+        ~unknown_effect:Active_record_state_unknown
+    with
+    | Record_exists -> `Collision
+    | Record_created ->
+      observed_effect := Active_record_durable;
+      let cross_area_collision =
+        match record_kind ~store ~area:Owned ~operation_id with
+        | `Not_found ->
+          (match record_kind ~store ~area:Forensic ~operation_id with
+           | `Not_found -> false
+           | _ -> true)
+        | _ -> true
+      in
+      if not cross_area_collision
+      then `Prepared prepared
+      else (
+        remove_exact_source
+          ~store
+          ~area:Active
+          ~operation_id
+          ~expected_raw:raw
+          ~effect_before:Active_record_durable
+          ~removal_transition:Discharge_active;
+        observed_effect := Active_record_discharged;
+        `Collision)
+  in
+  let rec retry () =
+    match create_attempt () with
+    | Error _ as error -> error
+    | Ok (`Prepared prepared) -> Ok prepared
+    | Ok `Collision ->
+      (* Collision retry is intentionally outside cancellation protection. The
+         loop is meaning-based and unbounded, but it remains cancellable. *)
+      Eio.Fiber.check ();
+      retry ()
+  in
+  retry ()
+;;
+
+let bind ~(store : store) ~(prepared : prepared) ~stage_identity =
+  let operation_id = prepared.operation_id in
+  run_mutation ~initial_effect:No_record_change @@ fun observed_effect ->
+  ensure_input_owner ~store ~operation_id prepared.owner;
+  let bound = { prepared; stage_identity } in
+  let active_raw = encode_prepared prepared in
+  let owned_raw = encode_bound bound in
+  (match record_kind ~store ~area:Active ~operation_id with
+   | `Not_found ->
+     (match record_kind ~store ~area:Owned ~operation_id with
+      | `Regular_file ->
+        ignore
+          (verify_exact_source
+             ~store
+             ~area:Owned
+             ~operation_id
+             ~expected_raw:owned_raw
+             ~store_effect:Owned_record_durable);
+        (* Under this module's sole-writer protocol, an exact destination with
+           no source is reachable only after the destination barrier. Record
+           that causal state before repeating either idempotency barrier. *)
+        observed_effect :=
+          Source_removal_durability_unknown Active_to_owned;
+        sync_directory
+          ~subject:(Area (Owned, store.owner))
+          store.owned;
+        sync_directory
+          ~subject:(Area (Active, store.owner))
+          store.active;
+        observed_effect := Owned_record_durable
+      | `Not_found -> raise_missing_record ~store ~area:Active ~operation_id
+      | _ ->
+        raise_existing_record_mismatch ~store ~area:Owned ~operation_id)
+   | `Regular_file ->
+     ignore
+       (verify_exact_source
+          ~store
+          ~area:Active
+          ~operation_id
+          ~expected_raw:active_raw
+          ~store_effect:Active_record_durable);
+     observed_effect := Active_record_durable;
+     ignore
+       (ensure_exact_record
+          ~store
+          ~area:Owned
+          ~operation_id
+          ~raw:owned_raw
+          ~base_effect:Active_record_durable
+          ~unknown_effect:Owned_record_state_unknown_with_active);
+     observed_effect := Owned_record_durable_with_active;
+     remove_exact_source
+       ~store
+       ~area:Active
+       ~operation_id
+       ~expected_raw:active_raw
+       ~effect_before:Owned_record_durable_with_active
+       ~removal_transition:Active_to_owned;
+     observed_effect := Owned_record_durable
+   | _ -> raise_existing_record_mismatch ~store ~area:Active ~operation_id);
+  bound
+;;
+
+type discharge_outcome =
+  | Discharged
+  | Already_discharged
+
+let discharge_prepared ~(store : store) ~(prepared : prepared) =
+  let operation_id = prepared.operation_id in
+  run_mutation ~initial_effect:No_record_change @@ fun observed_effect ->
+  ensure_input_owner ~store ~operation_id prepared.owner;
+  match record_kind ~store ~area:Active ~operation_id with
+  | `Not_found ->
+    observed_effect :=
+      Source_removal_durability_unknown Discharge_active;
+    sync_directory
+      ~subject:(Area (Active, store.owner))
+      store.active;
+    observed_effect := Active_record_discharged;
+    Already_discharged
+  | `Regular_file ->
+    observed_effect := Active_record_durable;
+    remove_exact_source
+      ~store
+      ~area:Active
+      ~operation_id
+      ~expected_raw:(encode_prepared prepared)
+      ~effect_before:Active_record_durable
+      ~removal_transition:Discharge_active;
+    observed_effect := Active_record_discharged;
+    Discharged
+  | _ -> raise_existing_record_mismatch ~store ~area:Active ~operation_id
+;;
+
+let discharge_bound ~(store : store) ~(bound : bound) =
+  let prepared = bound.prepared in
+  let operation_id = prepared.operation_id in
+  run_mutation ~initial_effect:No_record_change @@ fun observed_effect ->
+  ensure_input_owner ~store ~operation_id prepared.owner;
+  match record_kind ~store ~area:Owned ~operation_id with
+  | `Not_found ->
+    observed_effect :=
+      Source_removal_durability_unknown Discharge_owned;
+    sync_directory
+      ~subject:(Area (Owned, store.owner))
+      store.owned;
+    observed_effect := Owned_record_discharged;
+    Already_discharged
+  | `Regular_file ->
+    observed_effect := Owned_record_durable;
+    remove_exact_source
+      ~store
+      ~area:Owned
+      ~operation_id
+      ~expected_raw:(encode_bound bound)
+      ~effect_before:Owned_record_durable
+      ~removal_transition:Discharge_owned;
+    observed_effect := Owned_record_discharged;
+    Discharged
+  | _ -> raise_existing_record_mismatch ~store ~area:Owned ~operation_id
+;;
+
+type forensic_transition_source =
+  | Active_forensic_source
+  | Owned_forensic_source
+
+let transition_to_forensic
+      ~store
+      ~operation_id
+      ~source
+      ~source_raw
+      ~forensic
+  =
+  let forensic_raw = encode_forensic forensic in
+  let source_area, source_effect, removal_transition =
+    match source with
+    | Active_forensic_source ->
+      Active, Active_record_durable, Active_to_forensic
+    | Owned_forensic_source ->
+      Owned, Owned_record_durable, Owned_to_forensic
+  in
+  run_mutation ~initial_effect:No_record_change @@ fun observed_effect ->
+  (match record_kind ~store ~area:source_area ~operation_id with
+   | `Not_found ->
+     (match record_kind ~store ~area:Forensic ~operation_id with
+      | `Regular_file ->
+        ignore
+          (verify_exact_source
+             ~store
+             ~area:Forensic
+             ~operation_id
+             ~expected_raw:forensic_raw
+             ~store_effect:Forensic_record_durable);
+        (* See [bind]: source removal follows the durable destination barrier,
+           so the exact resumed state is known before barrier repair. *)
+        observed_effect :=
+          Source_removal_durability_unknown removal_transition;
+        sync_directory
+          ~subject:(Area (Forensic, store.owner))
+          store.forensic;
+        sync_directory
+          ~subject:(Area (source_area, store.owner))
+          (area_directory store source_area);
+        observed_effect := Forensic_record_durable
+      | `Not_found ->
+        raise_missing_record ~store ~area:source_area ~operation_id
+      | _ ->
+        raise_existing_record_mismatch ~store ~area:Forensic ~operation_id)
+   | `Regular_file ->
+     ignore
+       (verify_exact_source
+          ~store
+          ~area:source_area
+          ~operation_id
+          ~expected_raw:source_raw
+          ~store_effect:source_effect);
+     observed_effect := source_effect;
+     ignore
+       (ensure_exact_record
+          ~store
+          ~area:Forensic
+          ~operation_id
+          ~raw:forensic_raw
+          ~base_effect:source_effect
+          ~unknown_effect:Forensic_record_state_unknown_with_source);
+     observed_effect := Forensic_record_durable_with_source;
+     remove_exact_source
+       ~store
+       ~area:source_area
+       ~operation_id
+       ~expected_raw:source_raw
+       ~effect_before:Forensic_record_durable_with_source
+       ~removal_transition;
+     observed_effect := Forensic_record_durable
+   | _ ->
+     raise_existing_record_mismatch ~store ~area:source_area ~operation_id);
+  forensic
+;;
+
+let record_forensic_prepared
+      ~(store : store)
+      ~(prepared : prepared)
+      ~outcome
+  =
+  let operation_id = prepared.operation_id in
+  match
+    protect_result ~store_effect:No_record_change (fun () ->
+      ensure_input_owner ~store ~operation_id prepared.owner;
+      match validate_prepared_recovery_outcome prepared outcome with
+      | Ok () -> ()
+      | Error error ->
+        raise_validation
+          ~operation:Decode_record
+          ~subject:(Record (Forensic, store.owner, operation_id))
+          error)
+  with
+  | Error _ as error -> error
+  | Ok () ->
+    let forensic = { source = Prepared_source (prepared, outcome) } in
+    transition_to_forensic
+      ~store
+      ~operation_id
+      ~source:Active_forensic_source
+      ~source_raw:(encode_prepared prepared)
+      ~forensic
+;;
+
+let preserve_unbound
+      ~(store : store)
+      ~(prepared : prepared)
+      ~kind
+      ~stage_identity
+  =
+  record_forensic_prepared
+    ~store
+    ~prepared
+    ~outcome:(Preserved_unbound_stage { kind; identity = stage_identity })
+;;
+
+let record_forensic_bound ~(store : store) ~(bound : bound) ~outcome =
+  let prepared = bound.prepared in
+  let operation_id = prepared.operation_id in
+  match
+    protect_result ~store_effect:No_record_change (fun () ->
+      ensure_input_owner ~store ~operation_id prepared.owner;
+      match validate_bound_recovery_outcome bound outcome with
+      | Ok () -> ()
+      | Error error ->
+        raise_validation
+          ~operation:Decode_record
+          ~subject:(Record (Forensic, store.owner, operation_id))
+          error)
+  with
+  | Error _ as error -> error
+  | Ok () ->
+    let forensic = { source = Bound_source (bound, outcome) } in
+    transition_to_forensic
+      ~store
+      ~operation_id
+      ~source:Owned_forensic_source
+      ~source_raw:(encode_bound bound)
+      ~forensic
+;;
+
+module For_testing = struct
+  let operation_id_of_uuid operation_id = operation_id
+
+  let prepare_with_operation_id
+        ~(store : store)
+        ~operation_id
+        ~(locator : locator)
+        ~(permissions : permissions)
+    =
+    run_mutation ~initial_effect:No_record_change @@ fun observed_effect ->
+    let prepared =
+      prepare_with_operation_id_internal
+        ~store
+        ~operation_id
+        ~locator
+        ~permissions
+    in
+    observed_effect := Active_record_durable;
+    prepared
+  ;;
+end
+
+type corrupt_record =
+  { area : area
+  ; operation_id : operation_id
+  ; raw : string
+  ; validation_error : validation_error
+  }
+
+type inventory_row =
+  | Active_record of prepared
+  | Owned_record of bound
+  | Forensic_record of forensic
+  | Invalid_record_name of
+      { area : area
+      ; name : string
+      }
+  | Unexpected_record_kind of
+      { area : area
+      ; operation_id : operation_id
+      ; kind : Eio.File.Stat.kind
+      }
+  | Missing_record_entry of
+      { area : area
+      ; operation_id : operation_id
+      }
+  | Record_entry_unavailable of
+      { area : area
+      ; operation_id : operation_id
+      ; error : transition_error
+      }
+  | Corrupt_record of corrupt_record
+
+type inventory = inventory_row list
+
+let corrupt_if_identity_invalid
+      ~store
+      ~area
+      ~operation_id
+      ~raw
+      ~record_owner
+      ~record_id
+      make_row
+  =
+  match
+    validate_record_owner_and_id
+      ~owner:store.owner
+      ~operation_id
+      ~record_owner
+      ~record_id
+  with
+  | Ok () -> make_row ()
+  | Error validation_error ->
+    Corrupt_record { area; operation_id; raw; validation_error }
+;;
+
+let inventory_regular_record ~store ~area ~operation_id =
+  let raw, _ =
+    read_raw_record
+      ~store
+      ~area
+      ~operation_id
+      ~store_effect:No_record_change
+  in
+  match area with
+  | Active ->
+    (match decode_prepared raw with
+     | Error validation_error ->
+       Corrupt_record { area; operation_id; raw; validation_error }
+     | Ok prepared ->
+       corrupt_if_identity_invalid
+         ~store
+         ~area
+         ~operation_id
+         ~raw
+         ~record_owner:prepared.owner
+         ~record_id:prepared.operation_id
+         (fun () -> Active_record prepared))
+  | Owned ->
+    (match decode_bound raw with
+     | Error validation_error ->
+       Corrupt_record { area; operation_id; raw; validation_error }
+     | Ok bound ->
+       corrupt_if_identity_invalid
+         ~store
+         ~area
+         ~operation_id
+         ~raw
+         ~record_owner:bound.prepared.owner
+         ~record_id:bound.prepared.operation_id
+         (fun () -> Owned_record bound))
+  | Forensic ->
+    (match decode_forensic raw with
+     | Error validation_error ->
+       Corrupt_record { area; operation_id; raw; validation_error }
+     | Ok forensic ->
+       corrupt_if_identity_invalid
+         ~store
+         ~area
+         ~operation_id
+         ~raw
+         ~record_owner:(forensic_owner forensic)
+         ~record_id:(forensic_operation_id forensic)
+         (fun () -> Forensic_record forensic))
+;;
+
+let inventory_area ~store area =
+  let directory = area_directory store area in
+  let subject = Area (area, store.owner) in
+  let names =
+    raise_io ~operation:Read_directory ~subject (fun () ->
+      Eio.Path.read_dir directory)
+  in
+  List.map
+    (fun name ->
+       match operation_id_of_string name with
+       | Error _ -> Invalid_record_name { area; name }
+       | Ok operation_id ->
+         (try
+            match record_kind ~store ~area ~operation_id with
+            | `Not_found -> Missing_record_entry { area; operation_id }
+            | `Regular_file ->
+              inventory_regular_record ~store ~area ~operation_id
+            | ( ( `Unknown
+                | `Fifo
+                | `Character_special
+                | `Directory
+                | `Block_device
+                | `Symbolic_link
+                | `Socket ) as
+                kind ) ->
+              Unexpected_record_kind { area; operation_id; kind }
+          with
+          | Eio.Cancel.Cancelled _ as cancellation -> raise cancellation
+          | Transition_failed error ->
+            Record_entry_unavailable { area; operation_id; error }
+          | Store_failure failure ->
+            Record_entry_unavailable
+              { area
+              ; operation_id
+              ; error = transition_error ~store_effect:No_record_change failure
+              }))
+    names
+;;
+
+let inventory store =
+  protect_result ~store_effect:No_record_change (fun () ->
+    inventory_area ~store Active
+    @ inventory_area ~store Owned
+    @ inventory_area ~store Forensic)
+;;

--- a/lib/fs_compat/capability_recovery_obligation.ml
+++ b/lib/fs_compat/capability_recovery_obligation.ml
@@ -76,16 +76,6 @@ type area =
   | Owned
   | Forensic
 
-type registry =
-  { lanes : Eio.Fs.dir_ty Eio.Path.t }
-
-type store =
-  { owner : owner
-  ; active : Eio.Fs.dir_ty Eio.Path.t
-  ; owned : Eio.Fs.dir_ty Eio.Path.t
-  ; forensic : Eio.Fs.dir_ty Eio.Path.t
-  }
-
 type validation_error =
   | Invalid_owner of string
   | Invalid_operation_id of string
@@ -143,6 +133,7 @@ type subject =
   | Recovery_root
   | Lanes_root
   | Lane_root of owner
+  | Lane_entry of owner * string
   | Area of area * owner
   | Record of area * owner * operation_id
 
@@ -150,6 +141,7 @@ type operation =
   | Inspect_directory
   | Create_directory
   | Open_directory
+  | Close_directory
   | Sync_directory
   | Read_directory
   | Inspect_record
@@ -220,6 +212,60 @@ type transition_error =
   ; cleanup_failures : failure list
   }
 
+type callback_and_release_failure =
+  { store_effect : transition_effect
+  ; callback : Eio.Exn.with_bt
+  ; release : failure
+  }
+
+exception Resource_scope_callback_and_release_failed of
+  callback_and_release_failure
+
+type registry =
+  { lanes : Eio.Fs.dir_ty Eio.Path.t }
+
+type area_capability =
+  | Area_available of Eio.Fs.dir_ty Eio.Path.t
+  | Area_unavailable of transition_error
+
+type lane_residue =
+  | Lane_residue_present of
+      { name : string
+      ; kind : Eio.File.Stat.kind
+      }
+  | Lane_residue_missing of { name : string }
+  | Lane_residue_unavailable of
+      { name : string
+      ; error : transition_error
+      }
+
+type store =
+  { owner : owner
+  ; active : area_capability
+  ; owned : area_capability
+  ; forensic : area_capability
+  ; lane_residues : lane_residue list
+  }
+
+type resource_release_failure =
+  { failure : failure
+  ; exception_ : exn
+  ; backtrace : Printexc.raw_backtrace
+  }
+
+type 'a existing_store_scope_outcome =
+  | Existing_store_scope_released of 'a
+  | Existing_store_scope_release_failed of
+      { value : 'a
+      ; release_failure : resource_release_failure
+      }
+  | Existing_store_scope_cancelled of
+      { value : 'a option
+      ; reason : exn
+      ; backtrace : Printexc.raw_backtrace
+      ; release_failure : resource_release_failure option
+      }
+
 exception Recovery_store_cancelled of
   exn * transition_effect * failure list
 
@@ -231,6 +277,7 @@ exception Internal_posix_descriptor_unavailable
 exception Internal_existing_record_does_not_match
 exception Internal_created_record_identity_unavailable
 exception Internal_missing_record
+exception Internal_resource_scope_callback_not_entered
 exception Transition_failed of transition_error
 
 let recovery_directory_leaf = "fs-publication-recovery"
@@ -1100,6 +1147,8 @@ let subject_to_string = function
   | Recovery_root -> "recovery_root"
   | Lanes_root -> "lanes_root"
   | Lane_root owner -> Printf.sprintf "lane(%S)" (owner_to_string owner)
+  | Lane_entry (owner, name) ->
+    Printf.sprintf "lane(%S)/%S" (owner_to_string owner) name
   | Area (area, owner) ->
     Printf.sprintf "%s(%S)" (area_to_string area) (owner_to_string owner)
   | Record (area, owner, operation_id) ->
@@ -1114,6 +1163,7 @@ let operation_to_string = function
   | Inspect_directory -> "inspect_directory"
   | Create_directory -> "create_directory"
   | Open_directory -> "open_directory"
+  | Close_directory -> "close_directory"
   | Sync_directory -> "sync_directory"
   | Read_directory -> "read_directory"
   | Inspect_record -> "inspect_record"
@@ -1248,6 +1298,83 @@ let raise_validation ~operation ~subject validation_error =
 
 let transition_error ~store_effect failure =
   { store_effect; failure; cleanup_failures = [] }
+;;
+
+module Resource_scope = Eio_resource_scope
+
+let resource_scope_failure ~operation ~subject
+      ({ exception_; backtrace } : Resource_scope.raised)
+  =
+  make_failure ~operation ~subject exception_ backtrace
+;;
+
+let append_cleanup_failure error failure =
+  { error with cleanup_failures = error.cleanup_failures @ [ failure ] }
+;;
+
+let cancellation_store_evidence ~default_effect reason =
+  match reason with
+  | Recovery_store_cancelled (original_reason, store_effect, cleanup_failures) ->
+    original_reason, store_effect, cleanup_failures, true
+  | original_reason -> original_reason, default_effect, [], false
+;;
+
+let raise_resource_scope_cancellation
+      ~default_effect
+      ~release_failure
+      ({ reason; backtrace } : Resource_scope.cancelled)
+  =
+  let original_reason, store_effect, cleanup_failures, had_store_evidence =
+    cancellation_store_evidence ~default_effect reason
+  in
+  let cleanup_failures =
+    match release_failure with
+    | None -> cleanup_failures
+    | Some failure -> cleanup_failures @ [ failure ]
+  in
+  let reason =
+    if had_store_evidence
+       || store_effect <> No_record_change
+       || cleanup_failures <> []
+    then
+      Recovery_store_cancelled
+        (original_reason, store_effect, cleanup_failures)
+    else original_reason
+  in
+  Printexc.raise_with_backtrace (Eio.Cancel.Cancelled reason) backtrace
+;;
+
+let raise_resource_scope_exception
+      ?release_failure
+      ~store_effect
+      ({ exception_; backtrace } : Resource_scope.raised)
+  =
+  match exception_, release_failure with
+  | Transition_failed _, None ->
+    Printexc.raise_with_backtrace exception_ backtrace
+  | Transition_failed error, Some failure ->
+    Printexc.raise_with_backtrace
+      (Transition_failed (append_cleanup_failure error failure))
+      backtrace
+  | Store_failure _, None ->
+    Printexc.raise_with_backtrace exception_ backtrace
+  | Store_failure failure, Some cleanup_failure ->
+    Printexc.raise_with_backtrace
+      (Transition_failed
+         { store_effect
+         ; failure
+         ; cleanup_failures = [ cleanup_failure ]
+         })
+      backtrace
+  | _, None -> Printexc.raise_with_backtrace exception_ backtrace
+  | _, Some cleanup_failure ->
+    Printexc.raise_with_backtrace
+      (Resource_scope_callback_and_release_failed
+         { store_effect
+         ; callback = exception_, backtrace
+         ; release = cleanup_failure
+         })
+      backtrace
 ;;
 
 let protect_result ~store_effect f =
@@ -1386,7 +1513,12 @@ let stabilize_directory
      set_directory_permissions ~subject opened
    | `Existing ->
      if actual_permissions <> directory_permissions
-     then set_directory_permissions ~subject opened);
+     then
+       raise_validation
+         ~operation:Inspect_directory
+         ~subject
+         (Record_permissions_mismatch
+            { expected = directory_permissions; actual = actual_permissions }));
   (* Existing components receive the same barriers as newly created ones. A
      previous attempt may have reached mkdir/fchmod/child-fsync but failed
      before the parent fsync, so merely observing the path cannot prove the
@@ -1478,7 +1610,7 @@ type owner_inventory_row =
   | Valid_owner of owner
   | Invalid_owner_name of string
   | Unexpected_owner_kind of
-      { name : string
+      { owner : owner
       ; kind : Eio.File.Stat.kind
       }
   | Missing_owner_entry of owner
@@ -1521,7 +1653,7 @@ let inventory_owners (registry : registry) =
                   | `Symbolic_link
                   | `Socket ) as
                   kind ) ->
-                Unexpected_owner_kind { name; kind }
+                Unexpected_owner_kind { owner; kind }
             with
             | Eio.Cancel.Cancelled _ as cancellation -> raise cancellation
             | Transition_failed error ->
@@ -1543,43 +1675,283 @@ let open_store_in_scope ~sw ~registry ~owner =
       ~subject:(Lane_root owner)
     @@ fun lane ->
     let active =
-      open_ensured_directory
-        ~sw
-        ~parent:lane
-        ~parent_subject:(Lane_root owner)
-        ~leaf:active_directory_leaf
-        ~subject:(Area (Active, owner))
+      Area_available
+        (open_ensured_directory
+           ~sw
+           ~parent:lane
+           ~parent_subject:(Lane_root owner)
+           ~leaf:active_directory_leaf
+           ~subject:(Area (Active, owner)))
     in
     let owned =
-      open_ensured_directory
-        ~sw
-        ~parent:lane
-        ~parent_subject:(Lane_root owner)
-        ~leaf:owned_directory_leaf
-        ~subject:(Area (Owned, owner))
+      Area_available
+        (open_ensured_directory
+           ~sw
+           ~parent:lane
+           ~parent_subject:(Lane_root owner)
+           ~leaf:owned_directory_leaf
+           ~subject:(Area (Owned, owner)))
     in
     let forensic =
-      open_ensured_directory
-        ~sw
-        ~parent:lane
-        ~parent_subject:(Lane_root owner)
-        ~leaf:forensic_directory_leaf
-        ~subject:(Area (Forensic, owner))
+      Area_available
+        (open_ensured_directory
+           ~sw
+           ~parent:lane
+           ~parent_subject:(Lane_root owner)
+           ~leaf:forensic_directory_leaf
+           ~subject:(Area (Forensic, owner)))
     in
-    { owner; active; owned; forensic })
+    { owner; active; owned; forensic; lane_residues = [] })
 ;;
 
 let with_store ~registry ~owner f =
-  Eio.Switch.run @@ fun sw ->
-  match open_store_in_scope ~sw ~registry ~owner with
-  | Error _ as error -> error
-  | Ok store -> Ok (f store)
+  let subject = Lane_root owner in
+  let outcome =
+    Resource_scope.run_resource_only @@ fun sw ->
+    match open_store_in_scope ~sw ~registry ~owner with
+    | Error _ as error -> error
+    | Ok store -> Ok (f store)
+  in
+  let release_failure =
+    Option.map
+      (resource_scope_failure ~operation:Close_directory ~subject)
+      outcome.scope_failure
+  in
+  match outcome.callback with
+  | None ->
+    (match outcome.parent_cancellation with
+     | Some cancellation ->
+       raise_resource_scope_cancellation
+         ~default_effect:No_record_change
+         ~release_failure:None
+         cancellation
+     | None ->
+       (match outcome.scope_failure with
+        | Some raised ->
+          raise_resource_scope_exception ~store_effect:No_record_change raised
+        | None -> raise Internal_resource_scope_callback_not_entered))
+  | Some (Resource_scope.Cancelled cancellation) ->
+    raise_resource_scope_cancellation
+      ~default_effect:No_record_change
+      ~release_failure
+      cancellation
+  | Some (Resource_scope.Raised raised) ->
+    raise_resource_scope_exception
+      ?release_failure
+      ~store_effect:No_record_change
+      raised
+  | Some (Resource_scope.Returned result) ->
+    (match outcome.parent_cancellation with
+     | Some cancellation ->
+       let default_effect =
+         match result with
+         | Ok _ -> No_record_change
+         | Error error -> error.store_effect
+       in
+       raise_resource_scope_cancellation
+         ~default_effect
+         ~release_failure
+         cancellation
+     | None ->
+       (match result, release_failure with
+        | Ok value, None -> Ok value
+        | Error error, None -> Error error
+        | Error error, Some failure ->
+          Error (append_cleanup_failure error failure)
+        | Ok _, Some failure ->
+          Error (transition_error ~store_effect:No_record_change failure)))
 ;;
 
-let area_directory (store : store) = function
+let open_existing_directory ~sw ~parent ~leaf ~subject =
+  let path = Eio.Path.(parent / leaf) in
+  let lexical =
+    raise_io ~operation:Inspect_directory ~subject (fun () ->
+      Eio.Path.stat ~follow:false path)
+  in
+  if lexical.kind <> `Directory
+  then
+    raise_validation
+      ~operation:Inspect_directory
+      ~subject
+      (Record_kind_mismatch
+         { expected = `Directory; actual = lexical.kind });
+  let lexical_identity = identity_of_stat lexical in
+  let opened =
+    raise_io ~operation:Open_directory ~subject (fun () ->
+      Eio.Path.open_dir ~sw path)
+  in
+  let opened = (opened :> Eio.Fs.dir_ty Eio.Path.t) in
+  let opened_stat =
+    verify_opened_directory ~subject ~lexical_identity opened
+  in
+  let actual_permissions = opened_stat.perm land 0o7777 in
+  if actual_permissions <> directory_permissions
+  then
+    raise_validation
+      ~operation:Inspect_directory
+      ~subject
+      (Record_permissions_mismatch
+         { expected = directory_permissions; actual = actual_permissions });
+  opened
+;;
+
+let fixed_area_leaf name =
+  String.equal name active_directory_leaf
+  || String.equal name owned_directory_leaf
+  || String.equal name forensic_directory_leaf
+;;
+
+let inspect_lane_residue ~lane ~owner name =
+  let subject = Lane_entry (owner, name) in
+  match
+    protect_result ~store_effect:No_record_change (fun () ->
+      raise_io ~operation:Inspect_directory ~subject (fun () ->
+        Eio.Path.kind ~follow:false Eio.Path.(lane / name)))
+  with
+  | Error error -> Lane_residue_unavailable { name; error }
+  | Ok `Not_found -> Lane_residue_missing { name }
+  | Ok
+      ( ( `Unknown
+        | `Fifo
+        | `Character_special
+        | `Directory
+        | `Block_device
+        | `Regular_file
+        | `Symbolic_link
+        | `Socket ) as
+        kind ) ->
+    Lane_residue_present { name; kind }
+;;
+
+let open_existing_area ~sw ~lane ~owner ~area ~leaf =
+  match
+    protect_result ~store_effect:No_record_change (fun () ->
+      open_existing_directory
+        ~sw
+        ~parent:lane
+        ~leaf
+        ~subject:(Area (area, owner)))
+  with
+  | Ok directory -> Area_available directory
+  | Error error -> Area_unavailable error
+;;
+
+let with_existing_store ~registry ~owner f =
+  let subject = Lane_root owner in
+  protect_result ~store_effect:No_record_change (fun () ->
+    let outcome =
+      Resource_scope.run_resource_only @@ fun sw ->
+      let lane =
+        open_existing_directory
+          ~sw
+          ~parent:registry.lanes
+          ~leaf:(owner_to_string owner)
+          ~subject
+      in
+      let lane_names =
+        raise_io ~operation:Read_directory ~subject (fun () ->
+          Eio.Path.read_dir lane)
+      in
+      let lane_residues =
+        List.filter_map
+          (fun name ->
+             if fixed_area_leaf name
+             then None
+             else Some (inspect_lane_residue ~lane ~owner name))
+          lane_names
+      in
+      let active =
+        open_existing_area
+          ~sw
+          ~lane
+          ~owner
+          ~area:Active
+          ~leaf:active_directory_leaf
+      in
+      let owned =
+        open_existing_area
+          ~sw
+          ~lane
+          ~owner
+          ~area:Owned
+          ~leaf:owned_directory_leaf
+      in
+      let forensic =
+        open_existing_area
+          ~sw
+          ~lane
+          ~owner
+          ~area:Forensic
+          ~leaf:forensic_directory_leaf
+      in
+      f { owner; active; owned; forensic; lane_residues }
+    in
+    let release_failure =
+      Option.map
+        (fun ({ exception_; backtrace } as raised : Resource_scope.raised) ->
+           { failure =
+               resource_scope_failure
+                 ~operation:Close_directory
+                 ~subject
+                 raised
+           ; exception_
+           ; backtrace
+           })
+        outcome.scope_failure
+    in
+    match outcome.callback with
+    | None ->
+      (match outcome.parent_cancellation with
+       | Some cancellation ->
+         Existing_store_scope_cancelled
+           { value = None
+           ; reason = cancellation.reason
+           ; backtrace = cancellation.backtrace
+           ; release_failure = None
+           }
+       | None ->
+         (match outcome.scope_failure with
+          | Some raised ->
+            raise_resource_scope_exception
+              ~store_effect:No_record_change
+              raised
+          | None -> raise Internal_resource_scope_callback_not_entered))
+    | Some (Resource_scope.Cancelled cancellation) ->
+      Existing_store_scope_cancelled
+        { value = None
+        ; reason = cancellation.reason
+        ; backtrace = cancellation.backtrace
+        ; release_failure
+        }
+    | Some (Resource_scope.Raised raised) ->
+      raise_resource_scope_exception
+        ?release_failure:(Option.map (fun failure -> failure.failure) release_failure)
+        ~store_effect:No_record_change
+        raised
+    | Some (Resource_scope.Returned value) ->
+      (match outcome.parent_cancellation, release_failure with
+       | Some cancellation, release_failure ->
+         Existing_store_scope_cancelled
+           { value = Some value
+           ; reason = cancellation.reason
+           ; backtrace = cancellation.backtrace
+           ; release_failure
+           }
+       | None, Some release_failure ->
+         Existing_store_scope_release_failed { value; release_failure }
+       | None, None -> Existing_store_scope_released value))
+;;
+
+let area_capability (store : store) = function
   | Active -> store.active
   | Owned -> store.owned
   | Forensic -> store.forensic
+;;
+
+let area_directory store area =
+  match area_capability store area with
+  | Area_available directory -> directory
+  | Area_unavailable error -> raise (Transition_failed error)
 ;;
 
 let record_path (store : store) area operation_id =
@@ -1622,103 +1994,143 @@ let read_raw_record ~store ~area ~operation_id ~store_effect =
       (Record_kind_mismatch
          { expected = `Regular_file; actual = lexical.kind });
   let lexical_identity = identity_of_stat lexical in
-  Eio.Switch.run @@ fun sw ->
-  let resource = ref None in
-  let cleanup () =
-    match !resource with
-    | None -> []
-    | Some file ->
+  let outcome =
+    Resource_scope.run_resource_only @@ fun sw ->
+    let resource = ref None in
+    let cleanup () =
+      match !resource with
+      | None -> []
+      | Some file ->
+        resource := None;
+        close_resource_failures ~subject file
+    in
+    try
+      let file =
+        raise_io ~operation:Open_record ~subject (fun () ->
+          Eio.Path.open_in ~sw path)
+      in
+      resource := Some file;
+      let opened =
+        raise_io ~operation:Inspect_record ~subject (fun () ->
+          Eio.File.stat file)
+      in
+      if opened.kind <> `Regular_file
+      then
+        raise_validation
+          ~operation:Inspect_record
+          ~subject
+          (Record_kind_mismatch
+             { expected = `Regular_file; actual = opened.kind });
+      let opened_identity = identity_of_stat opened in
+      if not (equal_identity lexical_identity opened_identity)
+      then
+        raise_validation
+          ~operation:Verify_record_identity
+          ~subject
+          (Record_identity_mismatch
+             { expected = lexical_identity; actual = opened_identity });
+      let opened_permissions = opened.perm land 0o7777 in
+      if opened_permissions <> record_permissions
+      then
+        raise_validation
+          ~operation:Inspect_record
+          ~subject
+          (Record_permissions_mismatch
+             { expected = record_permissions; actual = opened_permissions });
+      let raw =
+        raise_io ~operation:Read_record ~subject (fun () ->
+          Eio.Flow.read_all file)
+      in
+      let after =
+        raise_io ~operation:Verify_record_identity ~subject (fun () ->
+          Eio.File.stat file)
+      in
+      let after_identity = identity_of_stat after in
+      if after.kind <> `Regular_file
+      then
+        raise_validation
+          ~operation:Verify_record_identity
+          ~subject
+          (Record_kind_mismatch
+             { expected = `Regular_file; actual = after.kind });
+      if not (equal_identity opened_identity after_identity)
+      then
+        raise_validation
+          ~operation:Verify_record_identity
+          ~subject
+          (Record_identity_mismatch
+             { expected = opened_identity; actual = after_identity });
+      raise_io ~operation:Close_record ~subject (fun () ->
+        Eio.Resource.close file);
       resource := None;
-      close_resource_failures ~subject file
-  in
-  try
-    let file =
-      raise_io ~operation:Open_record ~subject (fun () ->
-        Eio.Path.open_in ~sw path)
-    in
-    resource := Some file;
-    let opened =
-      raise_io ~operation:Inspect_record ~subject (fun () ->
-        Eio.File.stat file)
-    in
-    if opened.kind <> `Regular_file
-    then
-      raise_validation
-        ~operation:Inspect_record
-        ~subject
-        (Record_kind_mismatch
-           { expected = `Regular_file; actual = opened.kind });
-    let opened_identity = identity_of_stat opened in
-    if not (equal_identity lexical_identity opened_identity)
-    then
-      raise_validation
-        ~operation:Verify_record_identity
-        ~subject
-        (Record_identity_mismatch
-           { expected = lexical_identity; actual = opened_identity });
-    let opened_permissions = opened.perm land 0o7777 in
-    if opened_permissions <> record_permissions
-    then
-      raise_validation
-        ~operation:Inspect_record
-        ~subject
-        (Record_permissions_mismatch
-           { expected = record_permissions; actual = opened_permissions });
-    let raw =
-      raise_io ~operation:Read_record ~subject (fun () -> Eio.Flow.read_all file)
-    in
-    let after =
-      raise_io ~operation:Verify_record_identity ~subject (fun () ->
-        Eio.File.stat file)
-    in
-    let after_identity = identity_of_stat after in
-    if after.kind <> `Regular_file
-    then
-      raise_validation
-        ~operation:Verify_record_identity
-        ~subject
-        (Record_kind_mismatch
-           { expected = `Regular_file; actual = after.kind });
-    if not (equal_identity opened_identity after_identity)
-    then
-      raise_validation
-        ~operation:Verify_record_identity
-        ~subject
-        (Record_identity_mismatch
-           { expected = opened_identity; actual = after_identity });
-    raise_io ~operation:Close_record ~subject (fun () ->
-      Eio.Resource.close file);
-    resource := None;
-    raw, opened_identity
-  with
-  | Eio.Cancel.Cancelled reason as cancellation ->
-    let backtrace = Printexc.get_raw_backtrace () in
-    let cleanup_failures = Eio.Cancel.protect cleanup in
-    if cleanup_failures = []
-    then Printexc.raise_with_backtrace cancellation backtrace
-    else
-      Printexc.raise_with_backtrace
-        (Eio.Cancel.Cancelled
-           (Recovery_store_cancelled
-              (reason, store_effect, cleanup_failures)))
-        backtrace
-  | Store_failure failure ->
-    let cleanup_failures = Eio.Cancel.protect cleanup in
-    if cleanup_failures = []
-    then raise (Store_failure failure)
-    else
+      raw, opened_identity
+    with
+    | Eio.Cancel.Cancelled reason as cancellation ->
+      let backtrace = Printexc.get_raw_backtrace () in
+      let cleanup_failures = Eio.Cancel.protect cleanup in
+      if cleanup_failures = []
+      then Printexc.raise_with_backtrace cancellation backtrace
+      else
+        Printexc.raise_with_backtrace
+          (Eio.Cancel.Cancelled
+             (Recovery_store_cancelled
+                (reason, store_effect, cleanup_failures)))
+          backtrace
+    | Store_failure failure ->
+      let cleanup_failures = Eio.Cancel.protect cleanup in
+      if cleanup_failures = []
+      then raise (Store_failure failure)
+      else
+        raise
+          (Transition_failed
+             { store_effect; failure; cleanup_failures })
+    | exception_ ->
+      let backtrace = Printexc.get_raw_backtrace () in
+      let cleanup_failures = Eio.Cancel.protect cleanup in
+      let failure =
+        make_failure ~operation:Read_record ~subject exception_ backtrace
+      in
       raise
         (Transition_failed
            { store_effect; failure; cleanup_failures })
-  | exception_ ->
-    let backtrace = Printexc.get_raw_backtrace () in
-    let cleanup_failures = Eio.Cancel.protect cleanup in
-    let failure =
-      make_failure ~operation:Read_record ~subject exception_ backtrace
-    in
-    raise
-      (Transition_failed
-         { store_effect; failure; cleanup_failures })
+  in
+  let release_failure =
+    Option.map
+      (resource_scope_failure ~operation:Close_record ~subject)
+      outcome.scope_failure
+  in
+  match outcome.callback with
+  | None ->
+    (match outcome.parent_cancellation with
+     | Some cancellation ->
+       raise_resource_scope_cancellation
+         ~default_effect:store_effect
+         ~release_failure:None
+         cancellation
+     | None ->
+       (match outcome.scope_failure with
+        | Some raised ->
+          raise_resource_scope_exception ~store_effect raised
+        | None -> raise Internal_resource_scope_callback_not_entered))
+  | Some (Resource_scope.Cancelled cancellation) ->
+    raise_resource_scope_cancellation
+      ~default_effect:store_effect
+      ~release_failure
+      cancellation
+  | Some (Resource_scope.Raised raised) ->
+    raise_resource_scope_exception ?release_failure ~store_effect raised
+  | Some (Resource_scope.Returned value) ->
+    (match outcome.parent_cancellation, release_failure with
+     | Some cancellation, release_failure ->
+       raise_resource_scope_cancellation
+         ~default_effect:store_effect
+         ~release_failure
+         cancellation
+     | None, Some failure ->
+       raise
+         (Transition_failed
+            { store_effect; failure; cleanup_failures = [] })
+     | None, None -> value)
 ;;
 
 let decode_record ~store ~area ~operation_id ~decode ~owner_and_id raw =
@@ -1972,118 +2384,169 @@ let create_record_exclusive
       ~operation_id
       ~raw
       ~base_effect
+      ~success_effect
       ~unknown_effect
   =
   let subject = record_subject store area operation_id in
   let path = record_path store area operation_id in
   Eio.Cancel.protect @@ fun () ->
-  Eio.Switch.run @@ fun sw ->
-  let resource = ref None in
-  let created_identity = ref None in
-  let entry_created = ref false in
-  try
-    let opened =
-      try
-        Some
-          (raise_io ~operation:Create_record ~subject (fun () ->
-             Eio.Path.open_out
-               ~sw
-               ~create:(`Exclusive record_permissions)
-               path))
-      with
-      | Store_failure
-          { cause =
-              Io_failed
-                { exception_ =
-                    Eio.Io (Eio.Fs.E (Eio.Fs.Already_exists _), _)
-                ; _
-                }
-          ; _
-          } ->
-        None
-    in
-    match opened with
-    | None -> Record_exists
-    | Some file ->
-      entry_created := true;
-      resource := Some file;
-      let stat =
-        raise_io ~operation:Inspect_record ~subject (fun () ->
-          Eio.File.stat file)
+  let outcome =
+    Resource_scope.run_resource_only @@ fun sw ->
+    let resource = ref None in
+    let created_identity = ref None in
+    let entry_created = ref false in
+    try
+      let opened =
+        try
+          Some
+            (raise_io ~operation:Create_record ~subject (fun () ->
+               Eio.Path.open_out
+                 ~sw
+                 ~create:(`Exclusive record_permissions)
+                 path))
+        with
+        | Store_failure
+            { cause =
+                Io_failed
+                  { exception_ =
+                      Eio.Io (Eio.Fs.E (Eio.Fs.Already_exists _), _)
+                  ; _
+                  }
+            ; _
+            } ->
+          None
       in
-      if stat.kind <> `Regular_file
-      then
-        raise_validation
-          ~operation:Inspect_record
-          ~subject
-          (Record_kind_mismatch
-             { expected = `Regular_file; actual = stat.kind });
-      created_identity := Some (identity_of_stat stat);
-      apply_record_permissions ~subject file;
-      write_record_payload ~subject file raw;
-      raise_io ~operation:Sync_record ~subject (fun () -> Eio.File.sync file);
-      raise_io ~operation:Close_record ~subject (fun () ->
-        Eio.Resource.close file);
-      resource := None;
-      sync_directory
-        ~subject:(Area (area, store.owner))
-        (area_directory store area);
-      Record_created
-  with
-  | Eio.Cancel.Cancelled reason as cancellation ->
-    let backtrace = Printexc.get_raw_backtrace () in
-    let cleanup_failures, record_absent_durable =
-      cleanup_created_record
-        ~store
-        ~area
-        ~operation_id
-        ~resource
-        ~created_identity
-        ~entry_created
+      match opened with
+      | None -> Record_exists
+      | Some file ->
+        entry_created := true;
+        resource := Some file;
+        let stat =
+          raise_io ~operation:Inspect_record ~subject (fun () ->
+            Eio.File.stat file)
+        in
+        if stat.kind <> `Regular_file
+        then
+          raise_validation
+            ~operation:Inspect_record
+            ~subject
+            (Record_kind_mismatch
+               { expected = `Regular_file; actual = stat.kind });
+        created_identity := Some (identity_of_stat stat);
+        apply_record_permissions ~subject file;
+        write_record_payload ~subject file raw;
+        raise_io ~operation:Sync_record ~subject (fun () -> Eio.File.sync file);
+        raise_io ~operation:Close_record ~subject (fun () ->
+          Eio.Resource.close file);
+        resource := None;
+        sync_directory
+          ~subject:(Area (area, store.owner))
+          (area_directory store area);
+        Record_created
+    with
+    | Eio.Cancel.Cancelled reason as cancellation ->
+      let backtrace = Printexc.get_raw_backtrace () in
+      let cleanup_failures, record_absent_durable =
+        cleanup_created_record
+          ~store
+          ~area
+          ~operation_id
+          ~resource
+          ~created_identity
+          ~entry_created
+      in
+      let store_effect =
+        if record_absent_durable then base_effect else unknown_effect
+      in
+      if store_effect = No_record_change && cleanup_failures = []
+      then Printexc.raise_with_backtrace cancellation backtrace
+      else
+        Printexc.raise_with_backtrace
+          (Eio.Cancel.Cancelled
+             (Recovery_store_cancelled
+                (reason, store_effect, cleanup_failures)))
+          backtrace
+    | Store_failure failure ->
+      let cleanup_failures, record_absent_durable =
+        cleanup_created_record
+          ~store
+          ~area
+          ~operation_id
+          ~resource
+          ~created_identity
+          ~entry_created
+      in
+      let store_effect =
+        if record_absent_durable then base_effect else unknown_effect
+      in
+      raise (Transition_failed { store_effect; failure; cleanup_failures })
+    | exception_ ->
+      let backtrace = Printexc.get_raw_backtrace () in
+      let cleanup_failures, record_absent_durable =
+        cleanup_created_record
+          ~store
+          ~area
+          ~operation_id
+          ~resource
+          ~created_identity
+          ~entry_created
+      in
+      let store_effect =
+        if record_absent_durable then base_effect else unknown_effect
+      in
+      let failure =
+        make_failure ~operation:Write_record ~subject exception_ backtrace
+      in
+      raise (Transition_failed { store_effect; failure; cleanup_failures })
+  in
+  let release_failure =
+    Option.map
+      (resource_scope_failure ~operation:Close_record ~subject)
+      outcome.scope_failure
+  in
+  match outcome.callback with
+  | None ->
+    (match outcome.parent_cancellation with
+     | Some cancellation ->
+       raise_resource_scope_cancellation
+         ~default_effect:base_effect
+         ~release_failure:None
+         cancellation
+     | None ->
+       (match outcome.scope_failure with
+        | Some raised ->
+          raise_resource_scope_exception ~store_effect:base_effect raised
+        | None -> raise Internal_resource_scope_callback_not_entered))
+  | Some (Resource_scope.Cancelled cancellation) ->
+    raise_resource_scope_cancellation
+      ~default_effect:base_effect
+      ~release_failure
+      cancellation
+  | Some (Resource_scope.Raised raised) ->
+    raise_resource_scope_exception
+      ?release_failure
+      ~store_effect:unknown_effect
+      raised
+  | Some (Resource_scope.Returned result) ->
+    let completed_effect =
+      match result with
+      | Record_created -> success_effect
+      | Record_exists -> base_effect
     in
-    let store_effect =
-      if record_absent_durable then base_effect else unknown_effect
-    in
-    if store_effect = No_record_change && cleanup_failures = []
-    then Printexc.raise_with_backtrace cancellation backtrace
-    else
-      Printexc.raise_with_backtrace
-        (Eio.Cancel.Cancelled
-           (Recovery_store_cancelled
-              (reason, store_effect, cleanup_failures)))
-        backtrace
-  | Store_failure failure ->
-    let cleanup_failures, record_absent_durable =
-      cleanup_created_record
-        ~store
-        ~area
-        ~operation_id
-        ~resource
-        ~created_identity
-        ~entry_created
-    in
-    let store_effect =
-      if record_absent_durable then base_effect else unknown_effect
-    in
-    raise (Transition_failed { store_effect; failure; cleanup_failures })
-  | exception_ ->
-    let backtrace = Printexc.get_raw_backtrace () in
-    let cleanup_failures, record_absent_durable =
-      cleanup_created_record
-        ~store
-        ~area
-        ~operation_id
-        ~resource
-        ~created_identity
-        ~entry_created
-    in
-    let store_effect =
-      if record_absent_durable then base_effect else unknown_effect
-    in
-    let failure =
-      make_failure ~operation:Write_record ~subject exception_ backtrace
-    in
-    raise (Transition_failed { store_effect; failure; cleanup_failures })
+    (match outcome.parent_cancellation, release_failure with
+     | Some cancellation, release_failure ->
+       raise_resource_scope_cancellation
+         ~default_effect:completed_effect
+         ~release_failure
+         cancellation
+     | None, Some failure ->
+       raise
+         (Transition_failed
+            { store_effect = completed_effect
+            ; failure
+            ; cleanup_failures = []
+            })
+     | None, None -> result)
 ;;
 
 type ensure_record_result =
@@ -2096,6 +2559,7 @@ let ensure_exact_record
       ~operation_id
       ~raw
       ~base_effect
+      ~success_effect
       ~unknown_effect
   =
   match
@@ -2105,6 +2569,7 @@ let ensure_exact_record
       ~operation_id
       ~raw
       ~base_effect
+      ~success_effect
       ~unknown_effect
   with
   | Record_created -> Installed_record
@@ -2293,6 +2758,7 @@ let prepare_with_operation_id_internal
        ~operation_id
        ~raw
        ~base_effect:No_record_change
+       ~success_effect:Active_record_durable
        ~unknown_effect:Active_record_state_unknown);
   prepared
 ;;
@@ -2310,6 +2776,7 @@ let prepare ~(store : store) ~(locator : locator) ~(permissions : permissions) =
         ~operation_id
         ~raw
         ~base_effect:No_record_change
+        ~success_effect:Active_record_durable
         ~unknown_effect:Active_record_state_unknown
     with
     | Record_exists -> `Collision
@@ -2374,10 +2841,10 @@ let bind ~(store : store) ~(prepared : prepared) ~stage_identity =
           Source_removal_durability_unknown Active_to_owned;
         sync_directory
           ~subject:(Area (Owned, store.owner))
-          store.owned;
+          (area_directory store Owned);
         sync_directory
           ~subject:(Area (Active, store.owner))
-          store.active;
+          (area_directory store Active);
         observed_effect := Owned_record_durable
       | `Not_found -> raise_missing_record ~store ~area:Active ~operation_id
       | _ ->
@@ -2398,6 +2865,7 @@ let bind ~(store : store) ~(prepared : prepared) ~stage_identity =
           ~operation_id
           ~raw:owned_raw
           ~base_effect:Active_record_durable
+          ~success_effect:Owned_record_durable_with_active
           ~unknown_effect:Owned_record_state_unknown_with_active);
      observed_effect := Owned_record_durable_with_active;
      remove_exact_source
@@ -2426,7 +2894,7 @@ let discharge_prepared ~(store : store) ~(prepared : prepared) =
       Source_removal_durability_unknown Discharge_active;
     sync_directory
       ~subject:(Area (Active, store.owner))
-      store.active;
+      (area_directory store Active);
     observed_effect := Active_record_discharged;
     Already_discharged
   | `Regular_file ->
@@ -2454,7 +2922,7 @@ let discharge_bound ~(store : store) ~(bound : bound) =
       Source_removal_durability_unknown Discharge_owned;
     sync_directory
       ~subject:(Area (Owned, store.owner))
-      store.owned;
+      (area_directory store Owned);
     observed_effect := Owned_record_discharged;
     Already_discharged
   | `Regular_file ->
@@ -2508,7 +2976,7 @@ let transition_to_forensic
           Source_removal_durability_unknown removal_transition;
         sync_directory
           ~subject:(Area (Forensic, store.owner))
-          store.forensic;
+          (area_directory store Forensic);
         sync_directory
           ~subject:(Area (source_area, store.owner))
           (area_directory store source_area);
@@ -2533,6 +3001,7 @@ let transition_to_forensic
           ~operation_id
           ~raw:forensic_raw
           ~base_effect:source_effect
+          ~success_effect:Forensic_record_durable_with_source
           ~unknown_effect:Forensic_record_state_unknown_with_source);
      observed_effect := Forensic_record_durable_with_source;
      remove_exact_source
@@ -2633,6 +3102,8 @@ module For_testing = struct
     observed_effect := Active_record_durable;
     prepared
   ;;
+
+  let area_directory = area_directory
 end
 
 type corrupt_record =
@@ -2643,6 +3114,19 @@ type corrupt_record =
   }
 
 type inventory_row =
+  | Unexpected_lane_entry of
+      { name : string
+      ; kind : Eio.File.Stat.kind
+      }
+  | Missing_lane_entry of { name : string }
+  | Lane_entry_unavailable of
+      { name : string
+      ; error : transition_error
+      }
+  | Area_inventory_unavailable of
+      { area : area
+      ; error : transition_error
+      }
   | Active_record of prepared
   | Owned_record of bound
   | Forensic_record of forensic
@@ -2778,9 +3262,30 @@ let inventory_area ~store area =
     names
 ;;
 
+let inventory_row_of_lane_residue = function
+  | Lane_residue_present { name; kind } ->
+    Unexpected_lane_entry { name; kind }
+  | Lane_residue_missing { name } -> Missing_lane_entry { name }
+  | Lane_residue_unavailable { name; error } ->
+    Lane_entry_unavailable { name; error }
+;;
+
+let inventory_area_rows ~store area =
+  try inventory_area ~store area with
+  | Eio.Cancel.Cancelled _ as cancellation -> raise cancellation
+  | Transition_failed error -> [ Area_inventory_unavailable { area; error } ]
+  | Store_failure failure ->
+    [ Area_inventory_unavailable
+        { area
+        ; error = transition_error ~store_effect:No_record_change failure
+        }
+    ]
+;;
+
 let inventory store =
   protect_result ~store_effect:No_record_change (fun () ->
-    inventory_area ~store Active
-    @ inventory_area ~store Owned
-    @ inventory_area ~store Forensic)
+    List.map inventory_row_of_lane_residue store.lane_residues
+    @ inventory_area_rows ~store Active
+    @ inventory_area_rows ~store Owned
+    @ inventory_area_rows ~store Forensic)
 ;;

--- a/lib/fs_compat/capability_recovery_obligation.mli
+++ b/lib/fs_compat/capability_recovery_obligation.mli
@@ -126,6 +126,7 @@ type subject =
   | Recovery_root
   | Lanes_root
   | Lane_root of owner
+  | Lane_entry of owner * string
   | Area of area * owner
   | Record of area * owner * operation_id
 
@@ -133,6 +134,7 @@ type operation =
   | Inspect_directory
   | Create_directory
   | Open_directory
+  | Close_directory
   | Sync_directory
   | Read_directory
   | Inspect_record
@@ -203,6 +205,18 @@ type transition_error =
   ; cleanup_failures : failure list
   }
 
+type callback_and_release_failure =
+  { store_effect : transition_effect
+  ; callback : Eio.Exn.with_bt
+  ; release : failure
+  }
+
+(** An unexpected callback exception and the exact resource-release failure
+    occurred at the same private scope. Neither cause is relabelled or
+    discarded. *)
+exception Resource_scope_callback_and_release_failed of
+  callback_and_release_failure
+
 (** Raised as the reason inside [Eio.Cancel.Cancelled] whenever cancellation is
     observed after a meaningful store effect, or when cancellation cleanup
     fails. The original reason, effect, and cleanup failures remain available. *)
@@ -270,12 +284,13 @@ val forensic_owner : forensic -> owner
 val forensic_operation_id : forensic -> operation_id
 
 (** Idempotently complete and pin the fixed registry prefix. Existing
-    components must be real 0700 directories; symbolic links and other kinds
-    are rejected. Every call repairs permissions and repeats both directory
-    and parent durability barriers, including for existing components. Retain
-    the returned registry for the process lifetime rather than reopening it on
-    the publication hot path. Only the final [lanes] capability is retained on
-    [sw]; the intermediate recovery-directory capability is short-scoped. *)
+    components must already be real 0700 directories; symbolic links, other
+    kinds, and wrong permissions are rejected without repair. Newly created
+    components are fchmodded after umask filtering. Every call repeats both
+    directory and parent durability barriers. Retain the returned registry for
+    the process lifetime rather than reopening it on the publication hot path.
+    Only the final [lanes] capability is retained on [sw]; the intermediate
+    recovery-directory capability is short-scoped. *)
 val open_registry
   :  sw:Eio.Switch.t
   -> registry_root:Eio.Fs.dir_ty Eio.Path.t
@@ -285,7 +300,7 @@ type owner_inventory_row =
   | Valid_owner of owner
   | Invalid_owner_name of string
   | Unexpected_owner_kind of
-      { name : string
+      { owner : owner
       ; kind : Eio.File.Stat.kind
       }
   | Missing_owner_entry of owner
@@ -322,6 +337,40 @@ val with_store
   -> owner:owner
   -> (store -> 'a)
   -> ('a, transition_error) result
+
+type resource_release_failure =
+  { failure : failure
+  ; exception_ : exn
+  ; backtrace : Printexc.raw_backtrace
+  }
+
+type 'a existing_store_scope_outcome =
+  | Existing_store_scope_released of 'a
+  | Existing_store_scope_release_failed of
+      { value : 'a
+      ; release_failure : resource_release_failure
+      }
+  | Existing_store_scope_cancelled of
+      { value : 'a option
+      ; reason : exn
+      ; backtrace : Printexc.raw_backtrace
+      ; release_failure : resource_release_failure option
+      }
+
+(** Pin an already-existing owner lane without creating, chmodding, syncing, or
+    otherwise repairing any registry entry. The lane and every area component
+    are observed without following symbolic links; opened capabilities are
+    checked against those exact observations. A lane failure returns [Error].
+    Each area failure is retained inside [store] so {!inventory} can report it
+    while continuing through the other areas. Startup reconciliation uses this
+    entry point so its only possible durable mutation is an explicit
+    source-record transition to an available, successfully inventoried
+    [forensic] area. *)
+val with_existing_store
+  :  registry:registry
+  -> owner:owner
+  -> (store -> 'a)
+  -> ('a existing_store_scope_outcome, transition_error) result
 
 val store_owner : store -> owner
 
@@ -422,6 +471,19 @@ type corrupt_record =
   }
 
 type inventory_row =
+  | Unexpected_lane_entry of
+      { name : string
+      ; kind : Eio.File.Stat.kind
+      }
+  | Missing_lane_entry of { name : string }
+  | Lane_entry_unavailable of
+      { name : string
+      ; error : transition_error
+      }
+  | Area_inventory_unavailable of
+      { area : area
+      ; error : transition_error
+      }
   | Active_record of prepared
   | Owned_record of bound
   | Forensic_record of forensic
@@ -447,13 +509,14 @@ type inventory_row =
 
 type inventory = inventory_row list
 
-(** Strict, non-recursive inventory of the three fixed lane stores. Invalid
-    names, non-regular entries, corrupt payloads, disappearance races, and
-    per-entry inspection/read failures are preserved as rows and enumeration
-    continues. Only failure to read an area directory itself returns [Error].
-    Each area's row order is the deterministic lexical order guaranteed by
-    [Eio.Path.read_dir]; the whole list is [Active], then [Owned], then
-    [Forensic]. *)
+(** Strict, non-recursive inventory of the exact owner lane and its three fixed
+    stores. Unexpected lane entries, unavailable areas, invalid record names,
+    non-regular records, corrupt payloads, disappearance races, and per-entry
+    inspection/read failures are preserved as rows. Failure in one area never
+    prevents inventory of the others. No entry is created, chmodded, synced,
+    removed, or otherwise repaired. Lane-residue rows retain lane lexical
+    order, followed by [Active], [Owned], and [Forensic] rows in each area's
+    lexical order. *)
 val inventory : store -> (inventory, transition_error) result
 
 module For_testing : sig
@@ -465,6 +528,8 @@ module For_testing : sig
     -> locator:locator
     -> permissions:permissions
     -> (prepared, transition_error) result
+
+  val area_directory : store -> area -> Eio.Fs.dir_ty Eio.Path.t
 end
 
 val validation_error_to_string : validation_error -> string

--- a/lib/fs_compat/capability_recovery_obligation.mli
+++ b/lib/fs_compat/capability_recovery_obligation.mli
@@ -1,0 +1,472 @@
+(** Lane-scoped durable obligations for atomic capability publication.
+
+    The caller opens and owns [registry_root]. This module is the sole owner of
+    the fixed capability-relative layout
+    [fs-publication-recovery/lanes/<owner>/{active,owned,forensic}]. It never
+    reopens an absolute path and never searches target trees for staging
+    entries.
+
+    A [Prepared] record is durable before the caller creates a staging
+    directory. [bind] then installs a full, self-contained [Bound] record that
+    includes the staging inode before removing the exact matching [Prepared]
+    record. Recovery policy remains outside this module: callers reacquire the
+    persisted allowed-root path, inject already-validated capabilities, inspect
+    only the exact derived staging leaf, and select an explicit typed forensic
+    outcome. *)
+
+type owner
+type operation_id
+
+type identity
+type permissions
+
+type locator
+type prepared
+type bound
+type forensic
+type registry
+type store
+
+type area =
+  | Active
+  | Owned
+  | Forensic
+
+type entry_observation =
+  | Absent
+  | Present of
+      { kind : Eio.File.Stat.kind
+      ; identity : identity
+      }
+
+type resource_mismatch =
+  { expected : identity
+  ; observed : entry_observation
+  }
+
+type prepared_recovery_outcome =
+  | Recovered_unmaterialized
+  | Prepared_allowed_root_mismatch of resource_mismatch
+  | Prepared_parent_mismatch of resource_mismatch
+  | Preserved_unbound_stage of
+      { kind : Eio.File.Stat.kind
+      ; identity : identity
+      }
+
+type bound_recovery_outcome =
+  | Bound_stage_absent of
+      { observed_target : entry_observation
+      }
+  | Bound_allowed_root_mismatch of resource_mismatch
+  | Bound_parent_mismatch of resource_mismatch
+  | Bound_stage_mismatch of
+      { mismatch : resource_mismatch
+      ; observed_target : entry_observation
+      }
+  | Preserved_bound_stage of
+      { kind : Eio.File.Stat.kind
+      ; identity : identity
+      ; observed_target : entry_observation
+      }
+
+type validation_error =
+  | Invalid_owner of string
+  | Invalid_operation_id of string
+  | Invalid_identity of identity
+  | Invalid_allowed_root_path of string
+  | Empty_parent_path_identity_mismatch of
+      { allowed_root : identity
+      ; parent : identity
+      }
+  | Invalid_parent_component of
+      { index : int
+      ; value : string
+      }
+  | Invalid_target_leaf of string
+  | Invalid_permissions of int
+  | Invalid_record_json of
+      { exception_ : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+  | Invalid_record_shape
+  | Unsupported_record_version of int
+  | Record_state_mismatch
+  | Record_owner_mismatch of
+      { expected : owner
+      ; actual : owner
+      }
+  | Record_operation_id_mismatch of
+      { expected : operation_id
+      ; actual : operation_id
+      }
+  | Record_stage_leaf_mismatch of
+      { expected : string
+      ; actual : string
+      }
+  | Record_identity_mismatch of
+      { expected : identity
+      ; actual : identity
+      }
+  | Record_kind_mismatch of
+      { expected : Eio.File.Stat.kind
+      ; actual : Eio.File.Stat.kind
+      }
+  | Record_permissions_mismatch of
+      { expected : int
+      ; actual : int
+      }
+  | Record_outcome_observation_not_mismatch of identity
+  | Record_field_invalid of
+      { field : string
+      ; value : Yojson.Safe.t
+      }
+
+type subject =
+  | Registry_root
+  | Recovery_root
+  | Lanes_root
+  | Lane_root of owner
+  | Area of area * owner
+  | Record of area * owner * operation_id
+
+type operation =
+  | Inspect_directory
+  | Create_directory
+  | Open_directory
+  | Sync_directory
+  | Read_directory
+  | Inspect_record
+  | Open_record
+  | Read_record
+  | Decode_record
+  | Create_record
+  | Apply_permissions
+  | Write_record
+  | Sync_record
+  | Close_record
+  | Verify_record_identity
+  | Remove_record
+
+type failure_cause =
+  | Validation_failed of validation_error
+  | Io_failed of
+      { exception_ : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+  | Write_failed of
+      { exception_ : exn
+      ; backtrace : Printexc.raw_backtrace
+      ; bytes_written : int
+      }
+  | Unexpected_resource_kind of Eio.File.Stat.kind
+  | Resource_identity_changed of
+      { expected : identity
+      ; actual : identity
+      }
+  | Posix_descriptor_unavailable
+  | Existing_record_does_not_match
+  | Created_record_identity_unavailable
+  | Missing_record
+
+type failure =
+  { operation : operation
+  ; subject : subject
+  ; cause : failure_cause
+  }
+
+type transition_effect =
+  | No_record_change
+  | Layout_may_be_incomplete
+  | Layout_ready
+  | Active_record_state_unknown
+  | Active_record_durable
+  | Active_record_discharged
+  | Owned_record_state_unknown_with_active
+  | Owned_record_durable_with_active
+  | Owned_record_durable
+  | Owned_record_discharged
+  | Forensic_record_state_unknown_with_source
+  | Forensic_record_durable_with_source
+  | Forensic_record_durable
+  | Source_removal_durability_unknown of removal_transition
+
+and removal_transition =
+  | Discharge_active
+  | Discharge_owned
+  | Active_to_owned
+  | Active_to_forensic
+  | Owned_to_forensic
+
+type transition_error =
+  { store_effect : transition_effect
+  ; failure : failure
+  ; cleanup_failures : failure list
+  }
+
+(** Raised as the reason inside [Eio.Cancel.Cancelled] whenever cancellation is
+    observed after a meaningful store effect, or when cancellation cleanup
+    fails. The original reason, effect, and cleanup failures remain available. *)
+exception Recovery_store_cancelled of
+  exn * transition_effect * failure list
+
+val owner_of_string : string -> (owner, validation_error) result
+val owner_to_string : owner -> string
+val equal_owner : owner -> owner -> bool
+
+val operation_id_to_string : operation_id -> string
+val equal_operation_id : operation_id -> operation_id -> bool
+
+(** Canonical whole registry filename. There is no prefix or suffix. *)
+val record_name : operation_id -> string
+
+(** Exact target-parent staging name, total from the operation id. *)
+val stage_name : operation_id -> string
+
+val identity : dev:int64 -> ino:int64 -> (identity, validation_error) result
+val identity_dev : identity -> int64
+val identity_ino : identity -> int64
+val equal_identity : identity -> identity -> bool
+
+val permissions_of_int : int -> (permissions, validation_error) result
+val permissions_to_int : permissions -> int
+
+(** [locator] persists the caller-certified canonical absolute
+    [allowed_root_path] exactly. This constructor proves only non-empty absolute
+    syntax; it deliberately neither calls realpath nor normalizes the value. Every
+    relative parent component and [target_leaf] is parsed through the shared
+    [Capability_leaf] contract. When [parent_components] is empty, [parent]
+    must equal [allowed_root]; non-empty traversal remains caller-certified. *)
+val locator
+  :  allowed_root_path:string
+  -> allowed_root:identity
+  -> parent_components:string list
+  -> parent:identity
+  -> target_leaf:string
+  -> initial_target:entry_observation
+  -> (locator, validation_error) result
+
+val locator_allowed_root_path : locator -> string
+val locator_allowed_root : locator -> identity
+val locator_parent_components : locator -> string list
+val locator_parent : locator -> identity
+val locator_target_leaf : locator -> string
+val locator_initial_target : locator -> entry_observation
+
+val prepared_owner : prepared -> owner
+val prepared_operation_id : prepared -> operation_id
+val prepared_locator : prepared -> locator
+val prepared_permissions : prepared -> permissions
+
+val bound_prepared : bound -> prepared
+val bound_stage_identity : bound -> identity
+val bound_stage_name : bound -> string
+
+type forensic_source =
+  | Prepared_source of prepared * prepared_recovery_outcome
+  | Bound_source of bound * bound_recovery_outcome
+
+val forensic_source : forensic -> forensic_source
+val forensic_owner : forensic -> owner
+val forensic_operation_id : forensic -> operation_id
+
+(** Idempotently complete and pin the fixed registry prefix. Existing
+    components must be real 0700 directories; symbolic links and other kinds
+    are rejected. Every call repairs permissions and repeats both directory
+    and parent durability barriers, including for existing components. Retain
+    the returned registry for the process lifetime rather than reopening it on
+    the publication hot path. Only the final [lanes] capability is retained on
+    [sw]; the intermediate recovery-directory capability is short-scoped. *)
+val open_registry
+  :  sw:Eio.Switch.t
+  -> registry_root:Eio.Fs.dir_ty Eio.Path.t
+  -> (registry, transition_error) result
+
+type owner_inventory_row =
+  | Valid_owner of owner
+  | Invalid_owner_name of string
+  | Unexpected_owner_kind of
+      { name : string
+      ; kind : Eio.File.Stat.kind
+      }
+  | Missing_owner_entry of owner
+  | Owner_entry_unavailable of
+      { owner : owner
+      ; error : transition_error
+      }
+
+type owner_inventory = owner_inventory_row list
+
+(** Strict, non-recursive inventory of [lanes]. [Invalid_owner_name] means the
+    entry fails the generic exact [Capability_leaf] grammar; MASC must still
+    parse every [Valid_owner] through its stricter [Keeper_name] type. Invalid
+    names, non-directory entries, disappearance races, and per-entry inspection
+    failures are preserved as rows and enumeration continues. Only failure to
+    read [lanes] itself returns [Error]. Row order is the deterministic lexical
+    order guaranteed by [Eio.Path.read_dir]. *)
+val inventory_owners
+  :  registry
+  -> (owner_inventory, transition_error) result
+
+(** Idempotently complete and pin one owner's fixed three-store layout inside
+    a module-owned switch, then call [f]. The intermediate lane capability is
+    short-scoped; the active, owned, and forensic capabilities remain pinned
+    for exactly the callback lifetime. Normal return, exceptions,
+    cancellation, and partial layout failure all close every capability owned
+    by that switch. Trusted callers must not return or otherwise retain [store]
+    beyond [f]. Layout failures are returned; callback exceptions and
+    cancellation propagate unchanged. A Keeper should run its whole lane
+    lifetime inside one callback rather than reopening the store per
+    publication. *)
+val with_store
+  :  registry:registry
+  -> owner:owner
+  -> (store -> 'a)
+  -> ('a, transition_error) result
+
+val store_owner : store -> owner
+
+(** Generate one operation id at the module-owned entropy boundary and durably
+    create its [Prepared] record: exclusive write, file fsync, close, then
+    active-directory fsync. A collision with any lane record generates another
+    id and retries without a cap; record existence never drives policy. *)
+val prepare
+  :  store:store
+  -> locator:locator
+  -> permissions:permissions
+  -> (prepared, transition_error) result
+
+(** Install a self-contained [Bound] record durably, then remove and fsync the
+    exact matching [Prepared] source. An exact already-installed Bound record
+    completes the transition idempotently. *)
+val bind
+  :  store:store
+  -> prepared:prepared
+  -> stage_identity:identity
+  -> (bound, transition_error) result
+
+(** Remove and fsync the exact matching active obligation after a normal
+    failure/cancellation that occurred before [bind]. *)
+type discharge_outcome =
+  | Discharged
+  | Already_discharged
+
+val discharge_prepared
+  :  store:store
+  -> prepared:prepared
+  -> (discharge_outcome, transition_error) result
+
+(** Remove and fsync the exact matching owned obligation after publication and
+    its target-parent durability barrier. *)
+val discharge_bound
+  :  store:store
+  -> bound:bound
+  -> (discharge_outcome, transition_error) result
+
+(** Preserve an unexpected pre-existing exact staging leaf without reusing or
+    deleting it. Kind and inode are both retained. The forensic record is
+    durable before the exact active source is removed. *)
+val preserve_unbound
+  :  store:store
+  -> prepared:prepared
+  -> kind:Eio.File.Stat.kind
+  -> stage_identity:identity
+  -> (forensic, transition_error) result
+
+(** Durably record an explicit Prepared recovery result, then remove the exact
+    active source. Exact matching forensic completion is idempotent. *)
+val record_forensic_prepared
+  :  store:store
+  -> prepared:prepared
+  -> outcome:prepared_recovery_outcome
+  -> (forensic, transition_error) result
+
+(** Durably record an explicit Bound recovery result, then remove the exact
+    owned source. Outcomes reached after validating the parent retain the
+    current no-follow target observation; root/parent mismatch outcomes omit it
+    because traversal must stop. Stage absence never claims a known target
+    effect or durability. [Preserved_bound_stage] keeps the stage in place and
+    retains both its recorded identity (inside [bound]) and current no-follow
+    observation. Exact matching forensic completion is idempotent. This module
+    deliberately exposes no quarantine rename: OCaml 5.4/Eio rename replaces
+    an existing destination and cannot prove never-mutate-unproven semantics. *)
+val record_forensic_bound
+  :  store:store
+  -> bound:bound
+  -> outcome:bound_recovery_outcome
+  -> (forensic, transition_error) result
+
+type 'a lookup =
+  | Missing
+  | Found of 'a
+
+val read_prepared
+  :  store:store
+  -> operation_id
+  -> (prepared lookup, transition_error) result
+
+val read_bound
+  :  store:store
+  -> operation_id
+  -> (bound lookup, transition_error) result
+
+val read_forensic
+  :  store:store
+  -> operation_id
+  -> (forensic lookup, transition_error) result
+
+type corrupt_record =
+  { area : area
+  ; operation_id : operation_id
+  ; raw : string
+  ; validation_error : validation_error
+  }
+
+type inventory_row =
+  | Active_record of prepared
+  | Owned_record of bound
+  | Forensic_record of forensic
+  | Invalid_record_name of
+      { area : area
+      ; name : string
+      }
+  | Unexpected_record_kind of
+      { area : area
+      ; operation_id : operation_id
+      ; kind : Eio.File.Stat.kind
+      }
+  | Missing_record_entry of
+      { area : area
+      ; operation_id : operation_id
+      }
+  | Record_entry_unavailable of
+      { area : area
+      ; operation_id : operation_id
+      ; error : transition_error
+      }
+  | Corrupt_record of corrupt_record
+
+type inventory = inventory_row list
+
+(** Strict, non-recursive inventory of the three fixed lane stores. Invalid
+    names, non-regular entries, corrupt payloads, disappearance races, and
+    per-entry inspection/read failures are preserved as rows and enumeration
+    continues. Only failure to read an area directory itself returns [Error].
+    Each area's row order is the deterministic lexical order guaranteed by
+    [Eio.Path.read_dir]; the whole list is [Active], then [Owned], then
+    [Forensic]. *)
+val inventory : store -> (inventory, transition_error) result
+
+module For_testing : sig
+  val operation_id_of_uuid : Uuidm.t -> operation_id
+
+  val prepare_with_operation_id
+    :  store:store
+    -> operation_id:operation_id
+    -> locator:locator
+    -> permissions:permissions
+    -> (prepared, transition_error) result
+end
+
+val validation_error_to_string : validation_error -> string
+val failure_to_string : failure -> string
+val transition_error_to_string : transition_error -> string

--- a/lib/fs_compat/capability_recovery_reconciler.ml
+++ b/lib/fs_compat/capability_recovery_reconciler.ml
@@ -1,0 +1,1977 @@
+module Core = Capability_recovery_obligation
+module Resource_scope = Eio_resource_scope
+
+type identity =
+  { device : int64
+  ; inode : int64
+  }
+
+type entry_observation =
+  | Entry_absent
+  | Entry_present of
+      { kind : Eio.File.Stat.kind
+      ; identity : identity
+      }
+
+type resource_mismatch =
+  { expected : identity
+  ; observed : entry_observation
+  }
+
+type prepared_outcome =
+  | Prepared_unmaterialized
+  | Prepared_allowed_root_mismatch of resource_mismatch
+  | Prepared_parent_mismatch of resource_mismatch
+  | Prepared_unbound_stage_preserved of
+      { kind : Eio.File.Stat.kind
+      ; identity : identity
+      }
+
+type bound_outcome =
+  | Bound_stage_absent of { observed_target : entry_observation }
+  | Bound_allowed_root_mismatch of resource_mismatch
+  | Bound_parent_mismatch of resource_mismatch
+  | Bound_stage_mismatch of
+      { mismatch : resource_mismatch
+      ; observed_target : entry_observation
+      }
+  | Bound_stage_preserved of
+      { kind : Eio.File.Stat.kind
+      ; identity : identity
+      ; observed_target : entry_observation
+      }
+
+type record_area =
+  | Active
+  | Owned
+  | Forensic
+
+type source_state =
+  | Prepared
+  | Bound
+
+type release_scope =
+  | Owner_store_scope
+  | Record_scope of
+      { source_state : source_state
+      ; operation_id : string
+      }
+
+type cleanup_failure =
+  | Core_cleanup_failure of Core.failure
+  | Scope_release_failure of
+      { scope : release_scope
+      ; exception_ : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+
+type observation_subject =
+  | Allowed_root of string
+  | Parent_component of
+      { index : int
+      ; component : string
+      }
+  | Stage_leaf of string
+  | Target_leaf of string
+
+type observation_cause =
+  | Observation_io_failed of
+      { exception_ : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+  | Observation_identity_invalid of Core.validation_error
+  | Opened_resource_kind_changed of
+      { observed : Eio.File.Stat.kind
+      ; opened : Eio.File.Stat.kind
+      }
+  | Opened_resource_identity_changed of
+      { observed : identity
+      ; opened : identity
+      }
+
+type observation_failure =
+  { subject : observation_subject
+  ; cause : observation_cause
+  }
+
+type digest_evidence =
+  { canonical_json_byte_count : int
+  ; canonical_json_sha256 : string
+  }
+
+type corrupt_validation_error_kind =
+  | Corrupt_invalid_owner
+  | Corrupt_invalid_operation_id
+  | Corrupt_invalid_identity
+  | Corrupt_invalid_allowed_root_path
+  | Corrupt_empty_parent_path_identity_mismatch
+  | Corrupt_invalid_parent_component
+  | Corrupt_invalid_target_leaf
+  | Corrupt_invalid_permissions
+  | Corrupt_invalid_record_json
+  | Corrupt_invalid_record_shape
+  | Corrupt_unsupported_record_version
+  | Corrupt_record_state_mismatch
+  | Corrupt_record_owner_mismatch
+  | Corrupt_record_operation_id_mismatch
+  | Corrupt_record_stage_leaf_mismatch
+  | Corrupt_record_identity_mismatch
+  | Corrupt_record_kind_mismatch
+  | Corrupt_record_permissions_mismatch
+  | Corrupt_record_outcome_observation_not_mismatch
+  | Corrupt_record_field_invalid
+
+type corrupt_validation_error =
+  { kind : corrupt_validation_error_kind
+  ; payload : digest_evidence option
+  }
+
+type row =
+  | Unexpected_lane_entry of
+      { name : string
+      ; kind : Eio.File.Stat.kind
+      }
+  | Missing_lane_entry of { name : string }
+  | Lane_entry_unavailable of
+      { name : string
+      ; error : Core.transition_error
+      }
+  | Area_inventory_unavailable of
+      { area : record_area
+      ; error : Core.transition_error
+      }
+  | Source_transition_capabilities_unavailable of
+      { source_state : source_state
+      ; operation_id : string
+      ; area_failures : (record_area * Core.transition_error) list
+      }
+  | Prepared_reconciled of
+      { operation_id : string
+      ; outcome : prepared_outcome
+      }
+  | Bound_reconciled of
+      { operation_id : string
+      ; outcome : bound_outcome
+      }
+  | Existing_forensic_record of
+      { operation_id : string
+      ; source_state : source_state
+      }
+  | Conflicting_source_records of
+      { operation_id : string
+      ; areas : record_area list
+      }
+  | Invalid_record_name of
+      { area : record_area
+      ; name : string
+      }
+  | Unexpected_record_kind of
+      { area : record_area
+      ; operation_id : string
+      ; kind : Eio.File.Stat.kind
+      }
+  | Missing_record_entry of
+      { area : record_area
+      ; operation_id : string
+      }
+  | Record_entry_unavailable of
+      { area : record_area
+      ; operation_id : string
+      ; error : Core.transition_error
+      }
+  | Corrupt_record_preserved of
+      { area : record_area
+      ; operation_id : string
+      ; raw_byte_count : int
+      ; raw_sha256 : string
+      ; validation_error : corrupt_validation_error
+      }
+  | Record_observation_failed of
+      { source_state : source_state
+      ; operation_id : string
+      ; failure : observation_failure
+      }
+  | Record_transition_failed of
+      { source_state : source_state
+      ; operation_id : string
+      ; error : Core.transition_error
+      }
+  | Record_scope_release_failed of
+      { source_state : source_state
+      ; operation_id : string
+      ; failure : cleanup_failure
+      }
+  | Owner_store_release_failed of cleanup_failure
+  | Owner_store_unavailable of Core.transition_error
+  | Owner_inventory_unavailable of Core.transition_error
+
+type cancellation =
+  { original_reason : exn
+  ; original_backtrace : Printexc.raw_backtrace
+  ; owner : string
+  ; completed_rows : row list
+  ; interrupted_store_effect : Core.transition_effect
+  ; cleanup_failures : cleanup_failure list
+  }
+
+exception Reconciliation_cancelled of cancellation
+exception Internal_resource_scope_callback_not_entered
+
+type record_scope_callback_and_release_failure =
+  { callback : Eio.Exn.with_bt
+  ; release : cleanup_failure
+  }
+
+exception Record_scope_callback_and_release_failed of
+  record_scope_callback_and_release_failure
+
+type report =
+  { owner : string
+  ; rows : row list
+  }
+
+let sha256 raw = Digestif.SHA256.(digest_string raw |> to_hex)
+
+let digest_json json =
+  let canonical = json |> Yojson.Safe.sort |> Yojson.Safe.to_string in
+  { canonical_json_byte_count = String.length canonical
+  ; canonical_json_sha256 = sha256 canonical
+  }
+;;
+
+let digest_payload kind json =
+  { kind; payload = Some (digest_json json) }
+;;
+
+let no_payload kind = { kind; payload = None }
+
+let core_identity_json identity =
+  `Assoc
+    [ "device", `Intlit (Int64.to_string (Core.identity_dev identity))
+    ; "inode", `Intlit (Int64.to_string (Core.identity_ino identity))
+    ]
+;;
+
+let core_kind_json kind =
+  `String (Format.asprintf "%a" Eio.File.Stat.pp_kind kind)
+;;
+
+let safe_validation_error = function
+  | Core.Invalid_owner value ->
+    digest_payload Corrupt_invalid_owner (`String value)
+  | Core.Invalid_operation_id value ->
+    digest_payload Corrupt_invalid_operation_id (`String value)
+  | Core.Invalid_identity identity ->
+    digest_payload Corrupt_invalid_identity (core_identity_json identity)
+  | Core.Invalid_allowed_root_path value ->
+    digest_payload Corrupt_invalid_allowed_root_path (`String value)
+  | Core.Empty_parent_path_identity_mismatch { allowed_root; parent } ->
+    digest_payload
+      Corrupt_empty_parent_path_identity_mismatch
+      (`Assoc
+         [ "allowed_root", core_identity_json allowed_root
+         ; "parent", core_identity_json parent
+         ])
+  | Core.Invalid_parent_component { index; value } ->
+    digest_payload
+      Corrupt_invalid_parent_component
+      (`Assoc [ "index", `Int index; "value", `String value ])
+  | Core.Invalid_target_leaf value ->
+    digest_payload Corrupt_invalid_target_leaf (`String value)
+  | Core.Invalid_permissions permissions ->
+    digest_payload Corrupt_invalid_permissions (`Int permissions)
+  | Core.Invalid_record_json { exception_; backtrace } ->
+    digest_payload
+      Corrupt_invalid_record_json
+      (`Assoc
+         [ "exception", `String (Printexc.to_string exception_)
+         ; "backtrace", `String (Printexc.raw_backtrace_to_string backtrace)
+         ])
+  | Core.Invalid_record_shape -> no_payload Corrupt_invalid_record_shape
+  | Core.Unsupported_record_version version ->
+    digest_payload Corrupt_unsupported_record_version (`Int version)
+  | Core.Record_state_mismatch -> no_payload Corrupt_record_state_mismatch
+  | Core.Record_owner_mismatch { expected; actual } ->
+    digest_payload
+      Corrupt_record_owner_mismatch
+      (`Assoc
+         [ "expected", `String (Core.owner_to_string expected)
+         ; "actual", `String (Core.owner_to_string actual)
+         ])
+  | Core.Record_operation_id_mismatch { expected; actual } ->
+    digest_payload
+      Corrupt_record_operation_id_mismatch
+      (`Assoc
+         [ "expected", `String (Core.operation_id_to_string expected)
+         ; "actual", `String (Core.operation_id_to_string actual)
+         ])
+  | Core.Record_stage_leaf_mismatch { expected; actual } ->
+    digest_payload
+      Corrupt_record_stage_leaf_mismatch
+      (`Assoc [ "expected", `String expected; "actual", `String actual ])
+  | Core.Record_identity_mismatch { expected; actual } ->
+    digest_payload
+      Corrupt_record_identity_mismatch
+      (`Assoc
+         [ "expected", core_identity_json expected
+         ; "actual", core_identity_json actual
+         ])
+  | Core.Record_kind_mismatch { expected; actual } ->
+    digest_payload
+      Corrupt_record_kind_mismatch
+      (`Assoc
+         [ "expected", core_kind_json expected
+         ; "actual", core_kind_json actual
+         ])
+  | Core.Record_permissions_mismatch { expected; actual } ->
+    digest_payload
+      Corrupt_record_permissions_mismatch
+      (`Assoc [ "expected", `Int expected; "actual", `Int actual ])
+  | Core.Record_outcome_observation_not_mismatch identity ->
+    digest_payload
+      Corrupt_record_outcome_observation_not_mismatch
+      (core_identity_json identity)
+  | Core.Record_field_invalid { field; value } ->
+    digest_payload
+      Corrupt_record_field_invalid
+      (`Assoc [ "field", `String field; "value", value ])
+;;
+
+let core_cleanup_failures failures =
+  List.map (fun failure -> Core_cleanup_failure failure) failures
+;;
+
+let scope_release_failure
+      scope
+      ({ exception_; backtrace } : Resource_scope.raised)
+  =
+  Scope_release_failure { scope; exception_; backtrace }
+;;
+
+let core_scope_release_failure scope
+      ({ exception_; backtrace; _ } : Core.resource_release_failure)
+  =
+  Scope_release_failure { scope; exception_; backtrace }
+;;
+
+let rec normalize_cancellation
+          ~owner
+          ~backtrace
+          ~default_effect
+          reason
+  =
+  match reason with
+  | Reconciliation_cancelled cancellation -> cancellation
+  | Core.Recovery_store_cancelled
+      (original_reason, interrupted_store_effect, cleanup_failures) ->
+    let cancellation =
+      normalize_cancellation
+        ~owner
+        ~backtrace
+        ~default_effect:interrupted_store_effect
+        original_reason
+    in
+    { cancellation with
+      cleanup_failures =
+        cancellation.cleanup_failures
+        @ core_cleanup_failures cleanup_failures
+    }
+  | original_reason ->
+    { original_reason
+    ; original_backtrace = backtrace
+    ; owner
+    ; completed_rows = []
+    ; interrupted_store_effect = default_effect
+    ; cleanup_failures = []
+    }
+;;
+
+let raise_reconciliation_cancellation
+      ~owner
+      ~completed_rows
+      ~default_effect
+      ~cleanup_failures
+      ({ reason; backtrace } : Resource_scope.cancelled)
+  =
+  let cancellation =
+    normalize_cancellation ~owner ~backtrace ~default_effect reason
+  in
+  let cancellation =
+    { cancellation with
+      owner
+    ; completed_rows = completed_rows @ cancellation.completed_rows
+    ; cleanup_failures =
+        cancellation.cleanup_failures @ cleanup_failures
+    }
+  in
+  Printexc.raise_with_backtrace
+    (Eio.Cancel.Cancelled (Reconciliation_cancelled cancellation))
+    backtrace
+;;
+
+type observed_entry =
+  { core : Core.entry_observation
+  ; public : entry_observation
+  }
+
+type stable_directory = Eio.Fs.dir_ty Eio.Path.t
+
+type typed_mismatch =
+  { core : Core.resource_mismatch
+  ; public : resource_mismatch
+  }
+
+type directory_result =
+  | Directory_mismatch of typed_mismatch
+  | Directory_opened of stable_directory
+
+type parent_result =
+  | Allowed_root_mismatch of typed_mismatch
+  | Parent_mismatch of typed_mismatch
+  | Parent_opened of stable_directory
+
+let identity_of_core identity =
+  { device = Core.identity_dev identity; inode = Core.identity_ino identity }
+;;
+
+let core_identity_of_stat ~subject (stat : Eio.File.Stat.t) =
+  match Core.identity ~dev:stat.dev ~ino:stat.ino with
+  | Ok identity -> Ok identity
+  | Error error ->
+    Error { subject; cause = Observation_identity_invalid error }
+;;
+
+let observation_of_stat ~subject stat : (observed_entry, observation_failure) result =
+  match core_identity_of_stat ~subject stat with
+  | Error _ as error -> error
+  | Ok identity ->
+    Ok
+      { core = Core.Present { kind = stat.kind; identity }
+      ; public =
+          Entry_present
+            { kind = stat.kind; identity = identity_of_core identity }
+      }
+;;
+
+let absent_observation : observed_entry =
+  { core = Core.Absent; public = Entry_absent }
+;;
+
+let capture_observation ~subject operation =
+  try Ok (operation ()) with
+  | Eio.Cancel.Cancelled _ as cancellation -> raise cancellation
+  | exception_ ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    Error
+      { subject
+      ; cause = Observation_io_failed { exception_; backtrace }
+      }
+;;
+
+let observe_stat ~subject path =
+  match
+    capture_observation ~subject (fun () ->
+      try Some (Eio.Path.stat ~follow:false path) with
+      | Eio.Io (Eio.Fs.E (Eio.Fs.Not_found _), _) -> None)
+  with
+  | Error _ as error -> error
+  | Ok observation -> Ok observation
+;;
+
+let observe_entry ~subject path =
+  match observe_stat ~subject path with
+  | Error _ as error -> error
+  | Ok None -> Ok absent_observation
+  | Ok (Some stat) -> observation_of_stat ~subject stat
+;;
+
+let mismatch ~expected (observed : observed_entry) : typed_mismatch =
+  let core : Core.resource_mismatch =
+    { expected; observed = observed.core }
+  in
+  { core
+  ; public = { expected = identity_of_core expected; observed = observed.public }
+  }
+;;
+
+let validate_opened_directory
+      ~sw
+      ~subject
+      ~path
+      ~(observed_stat : Eio.File.Stat.t)
+  =
+  match
+    capture_observation ~subject (fun () ->
+      let directory = Eio.Path.open_dir ~sw path in
+      let directory = (directory :> Eio.Fs.dir_ty Eio.Path.t) in
+      let opened_file = Eio.Path.open_in ~sw Eio.Path.(directory / ".") in
+      directory, Eio.File.stat opened_file)
+  with
+  | Error _ as error -> error
+  | Ok (directory, opened_stat) ->
+    if opened_stat.kind <> `Directory
+    then
+      Error
+        { subject
+        ; cause =
+            Opened_resource_kind_changed
+              { observed = observed_stat.kind; opened = opened_stat.kind }
+        }
+    else
+      (match
+         core_identity_of_stat ~subject observed_stat,
+         core_identity_of_stat ~subject opened_stat
+       with
+       | Error error, _ | _, Error error -> Error error
+       | Ok observed, Ok opened ->
+         if Core.equal_identity observed opened
+         then Ok directory
+         else
+           Error
+             { subject
+             ; cause =
+                 Opened_resource_identity_changed
+                   { observed = identity_of_core observed
+                   ; opened = identity_of_core opened
+                   }
+             })
+;;
+
+let open_expected_directory ~sw ~subject ~path ~expected =
+  match observe_stat ~subject path with
+  | Error _ as error -> error
+  | Ok None ->
+    let observed = absent_observation in
+    Ok (Directory_mismatch (mismatch ~expected observed))
+  | Ok (Some observed_stat) ->
+    (match observation_of_stat ~subject observed_stat with
+     | Error _ as error -> error
+     | Ok
+         ({ core = Core.Present { kind; identity }; _ } as observed) ->
+       if kind <> `Directory || not (Core.equal_identity expected identity)
+       then Ok (Directory_mismatch (mismatch ~expected observed))
+       else
+         (match
+            validate_opened_directory
+              ~sw
+              ~subject
+              ~path
+              ~observed_stat
+          with
+          | Error _ as error -> error
+          | Ok directory -> Ok (Directory_opened directory))
+     | Ok { core = Core.Absent; _ } ->
+       Ok (Directory_mismatch (mismatch ~expected absent_observation)))
+;;
+
+let traverse_parent ~sw ~fs locator =
+  let root_path = Core.locator_allowed_root_path locator in
+  let root_subject = Allowed_root root_path in
+  let root = Eio.Path.(fs / root_path) in
+  match
+    open_expected_directory
+      ~sw
+      ~subject:root_subject
+      ~path:root
+      ~expected:(Core.locator_allowed_root locator)
+  with
+  | Error _ as error -> error
+  | Ok (Directory_mismatch mismatch) ->
+    Ok (Allowed_root_mismatch mismatch)
+  | Ok (Directory_opened root) ->
+    let rec traverse index parent parent_subject = function
+      | [] ->
+        (match
+           capture_observation ~subject:parent_subject (fun () ->
+             Eio.Path.with_open_in Eio.Path.(parent / ".") Eio.File.stat)
+         with
+         | Error _ as error -> error
+         | Ok stat ->
+           (match core_identity_of_stat ~subject:parent_subject stat with
+            | Error _ as error -> error
+            | Ok actual ->
+              let expected = Core.locator_parent locator in
+              if stat.kind = `Directory && Core.equal_identity expected actual
+              then Ok (Parent_opened parent)
+              else
+                (match observation_of_stat ~subject:parent_subject stat with
+                 | Error _ as error -> error
+                 | Ok observed ->
+                   Ok (Parent_mismatch (mismatch ~expected observed)))))
+      | component :: rest ->
+        let subject = Parent_component { index; component } in
+        let path = Eio.Path.(parent / component) in
+        (match observe_stat ~subject path with
+         | Error _ as error -> error
+         | Ok None ->
+           Ok
+             (Parent_mismatch
+                (mismatch
+                   ~expected:(Core.locator_parent locator)
+                   absent_observation))
+         | Ok (Some observed_stat) ->
+           (match observation_of_stat ~subject observed_stat with
+            | Error _ as error -> error
+            | Ok observed when observed_stat.kind <> `Directory ->
+              Ok
+                (Parent_mismatch
+                   (mismatch
+                      ~expected:(Core.locator_parent locator)
+                      observed))
+            | Ok _ ->
+              (match
+                 validate_opened_directory
+                   ~sw
+                   ~subject
+                   ~path
+                   ~observed_stat
+               with
+               | Error _ as error -> error
+               | Ok opened ->
+                 traverse (index + 1) opened subject rest)))
+    in
+    traverse 0 root root_subject (Core.locator_parent_components locator)
+;;
+
+let record_transition_failure ~source_state ~operation_id error =
+  Record_transition_failed
+    { source_state
+    ; operation_id = Core.operation_id_to_string operation_id
+    ; error
+    }
+;;
+
+let record_observation_failure ~source_state ~operation_id failure =
+  Record_observation_failed
+    { source_state
+    ; operation_id = Core.operation_id_to_string operation_id
+    ; failure
+    }
+;;
+
+let release_failure_row ~source_state ~operation_id failure =
+  Record_scope_release_failed { source_state; operation_id; failure }
+;;
+
+let run_record_scope
+      ~store
+      ~source_state
+      ~operation_id
+      reconcile
+  =
+  let owner = Core.store_owner store |> Core.owner_to_string in
+  let operation_id_string = Core.operation_id_to_string operation_id in
+  let scope =
+    Record_scope { source_state; operation_id = operation_id_string }
+  in
+  let outcome =
+    Resource_scope.run_resource_only @@ fun sw ->
+    reconcile sw
+  in
+  let release_failure =
+    Option.map (scope_release_failure scope) outcome.scope_failure
+  in
+  let cleanup_failures = Option.to_list release_failure in
+  match outcome.callback with
+  | None ->
+    (match outcome.parent_cancellation with
+     | Some cancellation ->
+       raise_reconciliation_cancellation
+         ~owner
+         ~completed_rows:[]
+         ~default_effect:Core.No_record_change
+         ~cleanup_failures:[]
+         cancellation
+     | None ->
+       (match outcome.scope_failure with
+        | Some failure ->
+          Printexc.raise_with_backtrace failure.exception_ failure.backtrace
+        | None ->
+          raise Internal_resource_scope_callback_not_entered))
+  | Some (Resource_scope.Cancelled cancellation) ->
+    raise_reconciliation_cancellation
+      ~owner
+      ~completed_rows:[]
+      ~default_effect:Core.No_record_change
+      ~cleanup_failures
+      cancellation
+  | Some (Resource_scope.Raised failure) ->
+    (match release_failure with
+     | None ->
+       Printexc.raise_with_backtrace failure.exception_ failure.backtrace
+     | Some release ->
+       Printexc.raise_with_backtrace
+         (Record_scope_callback_and_release_failed
+            { callback = failure.exception_, failure.backtrace; release })
+         failure.backtrace)
+  | Some (Resource_scope.Returned row) ->
+    (match outcome.parent_cancellation with
+     | Some cancellation ->
+       raise_reconciliation_cancellation
+         ~owner
+         ~completed_rows:[ row ]
+         ~default_effect:Core.No_record_change
+         ~cleanup_failures
+         cancellation
+     | None ->
+       (match release_failure with
+        | None -> [ row ]
+        | Some failure ->
+          [ row
+          ; release_failure_row
+              ~source_state
+              ~operation_id:operation_id_string
+              failure
+          ]))
+;;
+
+let reconcile_prepared ~fs ~store prepared =
+  let operation_id = Core.prepared_operation_id prepared in
+  let operation_id_string = Core.operation_id_to_string operation_id in
+  let locator = Core.prepared_locator prepared in
+  run_record_scope
+    ~store
+    ~source_state:Prepared
+    ~operation_id
+  @@ fun sw ->
+  match traverse_parent ~sw ~fs locator with
+  | Error failure ->
+    record_observation_failure ~source_state:Prepared ~operation_id failure
+  | Ok (Allowed_root_mismatch mismatch) ->
+    let outcome = Core.Prepared_allowed_root_mismatch mismatch.core in
+    (match Core.record_forensic_prepared ~store ~prepared ~outcome with
+     | Ok _ ->
+       Prepared_reconciled
+         { operation_id = operation_id_string
+         ; outcome = Prepared_allowed_root_mismatch mismatch.public
+         }
+     | Error error ->
+       record_transition_failure ~source_state:Prepared ~operation_id error)
+  | Ok (Parent_mismatch mismatch) ->
+    let outcome = Core.Prepared_parent_mismatch mismatch.core in
+    (match Core.record_forensic_prepared ~store ~prepared ~outcome with
+     | Ok _ ->
+       Prepared_reconciled
+         { operation_id = operation_id_string
+         ; outcome = Prepared_parent_mismatch mismatch.public
+         }
+     | Error error ->
+       record_transition_failure ~source_state:Prepared ~operation_id error)
+  | Ok (Parent_opened parent) ->
+    let stage_name = Core.stage_name operation_id in
+    let subject = Stage_leaf stage_name in
+    let stage = Eio.Path.(parent / stage_name) in
+    (match observe_entry ~subject stage with
+     | Error failure ->
+       record_observation_failure ~source_state:Prepared ~operation_id failure
+     | Ok { core = Core.Absent; _ } ->
+       (match
+          Core.record_forensic_prepared
+            ~store
+            ~prepared
+            ~outcome:Core.Recovered_unmaterialized
+        with
+        | Ok _ ->
+          Prepared_reconciled
+            { operation_id = operation_id_string
+            ; outcome = Prepared_unmaterialized
+            }
+        | Error error ->
+          record_transition_failure
+            ~source_state:Prepared
+            ~operation_id
+            error)
+     | Ok
+         { core = Core.Present { kind; identity }; public = _ } ->
+       let outcome = Core.Preserved_unbound_stage { kind; identity } in
+       (match Core.record_forensic_prepared ~store ~prepared ~outcome with
+        | Ok _ ->
+          Prepared_reconciled
+            { operation_id = operation_id_string
+            ; outcome =
+                Prepared_unbound_stage_preserved
+                  { kind; identity = identity_of_core identity }
+            }
+        | Error error ->
+          record_transition_failure
+            ~source_state:Prepared
+            ~operation_id
+            error)
+     )
+;;
+
+let reconcile_bound ~fs ~store bound =
+  let prepared = Core.bound_prepared bound in
+  let operation_id = Core.prepared_operation_id prepared in
+  let operation_id_string = Core.operation_id_to_string operation_id in
+  let locator = Core.prepared_locator prepared in
+  run_record_scope
+    ~store
+    ~source_state:Bound
+    ~operation_id
+  @@ fun sw ->
+  match traverse_parent ~sw ~fs locator with
+  | Error failure ->
+    record_observation_failure ~source_state:Bound ~operation_id failure
+  | Ok (Allowed_root_mismatch mismatch) ->
+    let outcome = Core.Bound_allowed_root_mismatch mismatch.core in
+    (match Core.record_forensic_bound ~store ~bound ~outcome with
+     | Ok _ ->
+       Bound_reconciled
+         { operation_id = operation_id_string
+         ; outcome = Bound_allowed_root_mismatch mismatch.public
+         }
+     | Error error ->
+       record_transition_failure ~source_state:Bound ~operation_id error)
+  | Ok (Parent_mismatch mismatch) ->
+    let outcome = Core.Bound_parent_mismatch mismatch.core in
+    (match Core.record_forensic_bound ~store ~bound ~outcome with
+     | Ok _ ->
+       Bound_reconciled
+         { operation_id = operation_id_string
+         ; outcome = Bound_parent_mismatch mismatch.public
+         }
+     | Error error ->
+       record_transition_failure ~source_state:Bound ~operation_id error)
+  | Ok (Parent_opened parent) ->
+    let stage_name = Core.bound_stage_name bound in
+    let target_name = Core.locator_target_leaf locator in
+    let stage_subject = Stage_leaf stage_name in
+    let target_subject = Target_leaf target_name in
+    let stage = observe_entry ~subject:stage_subject Eio.Path.(parent / stage_name) in
+    let target = observe_entry ~subject:target_subject Eio.Path.(parent / target_name) in
+    (match stage, target with
+     | Error failure, _ | _, Error failure ->
+       record_observation_failure ~source_state:Bound ~operation_id failure
+     | Ok stage, Ok target ->
+       let core_outcome, public_outcome =
+         match stage.core with
+         | Core.Absent ->
+           ( Core.Bound_stage_absent { observed_target = target.core }
+           , Bound_stage_absent { observed_target = target.public } )
+         | Core.Present { kind; identity } ->
+           if
+             kind = `Directory
+             && Core.equal_identity identity (Core.bound_stage_identity bound)
+           then
+             ( Core.Preserved_bound_stage
+                 { kind; identity; observed_target = target.core }
+             , Bound_stage_preserved
+                 { kind
+                 ; identity = identity_of_core identity
+                 ; observed_target = target.public
+                 } )
+           else
+             let mismatch =
+               mismatch ~expected:(Core.bound_stage_identity bound) stage
+             in
+             ( Core.Bound_stage_mismatch
+                 { mismatch = mismatch.core; observed_target = target.core }
+             , Bound_stage_mismatch
+                 { mismatch = mismatch.public
+                 ; observed_target = target.public
+                 } )
+       in
+       (match Core.record_forensic_bound ~store ~bound ~outcome:core_outcome with
+        | Ok _ ->
+          Bound_reconciled
+            { operation_id = operation_id_string; outcome = public_outcome }
+        | Error error ->
+          record_transition_failure ~source_state:Bound ~operation_id error))
+;;
+
+let record_area_of_core = function
+  | Core.Active -> Active
+  | Core.Owned -> Owned
+  | Core.Forensic -> Forensic
+;;
+
+let operation_id_of_inventory_row = function
+  | Core.Unexpected_lane_entry _
+  | Core.Missing_lane_entry _
+  | Core.Lane_entry_unavailable _
+  | Core.Area_inventory_unavailable _ -> None
+  | Core.Active_record prepared ->
+    Some (Core.prepared_operation_id prepared, Active)
+  | Core.Owned_record bound ->
+    Some
+      ( Core.prepared_operation_id (Core.bound_prepared bound)
+      , Owned )
+  | Core.Forensic_record _ | Core.Invalid_record_name _ -> None
+  | Core.Unexpected_record_kind { area; operation_id; _ }
+  | Core.Missing_record_entry { area; operation_id }
+  | Core.Record_entry_unavailable { area; operation_id; _ } ->
+    Some (operation_id, record_area_of_core area)
+  | Core.Corrupt_record corrupt ->
+    Some (corrupt.operation_id, record_area_of_core corrupt.area)
+;;
+
+module Operation_map = Map.Make (String)
+
+let conflicting_source_areas inventory =
+  let add map row =
+    match operation_id_of_inventory_row row with
+    | None -> map
+    | Some (_, Forensic) -> map
+    | Some (operation_id, (Active as area))
+    | Some (operation_id, (Owned as area)) ->
+      let key = Core.operation_id_to_string operation_id in
+      let areas = Option.value ~default:[] (Operation_map.find_opt key map) in
+      Operation_map.add key (area :: areas) map
+  in
+  List.fold_left add Operation_map.empty inventory
+  |> Operation_map.filter (fun _ areas -> List.length areas > 1)
+  |> Operation_map.map List.rev
+;;
+
+let area_inventory_failures inventory =
+  List.filter_map
+    (function
+      | Core.Area_inventory_unavailable { area; error } ->
+        Some (record_area_of_core area, error)
+      | Core.Unexpected_lane_entry _
+      | Core.Missing_lane_entry _
+      | Core.Lane_entry_unavailable _
+      | Core.Active_record _
+      | Core.Owned_record _
+      | Core.Forensic_record _
+      | Core.Invalid_record_name _
+      | Core.Unexpected_record_kind _
+      | Core.Missing_record_entry _
+      | Core.Record_entry_unavailable _
+      | Core.Corrupt_record _ -> None)
+    inventory
+;;
+
+let required_area_failures required failures =
+  List.filter
+    (fun (area, _) -> List.exists (fun required -> required = area) required)
+    failures
+;;
+
+let source_transition_capabilities_unavailable
+      ~source_state
+      ~operation_id
+      ~required
+      ~area_failures
+  =
+  match required_area_failures required area_failures with
+  | [] -> None
+  | area_failures ->
+    Some
+      (Source_transition_capabilities_unavailable
+         { source_state; operation_id; area_failures })
+;;
+
+let row_of_inventory ~fs ~store ~conflicts ~area_failures = function
+  | Core.Unexpected_lane_entry { name; kind } ->
+    [ Unexpected_lane_entry { name; kind } ]
+  | Core.Missing_lane_entry { name } -> [ Missing_lane_entry { name } ]
+  | Core.Lane_entry_unavailable { name; error } ->
+    [ Lane_entry_unavailable { name; error } ]
+  | Core.Area_inventory_unavailable { area; error } ->
+    [ Area_inventory_unavailable { area = record_area_of_core area; error } ]
+  | Core.Active_record prepared ->
+    let operation_id =
+      Core.prepared_operation_id prepared |> Core.operation_id_to_string
+    in
+    (match Operation_map.find_opt operation_id conflicts with
+     | Some areas -> [ Conflicting_source_records { operation_id; areas } ]
+     | None ->
+       (match
+          source_transition_capabilities_unavailable
+            ~source_state:Prepared
+            ~operation_id
+            ~required:[ Active; Owned; Forensic ]
+            ~area_failures
+        with
+        | Some row -> [ row ]
+        | None -> reconcile_prepared ~fs ~store prepared))
+  | Core.Owned_record bound ->
+    let operation_id =
+      Core.bound_prepared bound
+      |> Core.prepared_operation_id
+      |> Core.operation_id_to_string
+    in
+    (match Operation_map.find_opt operation_id conflicts with
+     | Some areas -> [ Conflicting_source_records { operation_id; areas } ]
+     | None ->
+       (match
+          source_transition_capabilities_unavailable
+            ~source_state:Bound
+            ~operation_id
+            ~required:[ Active; Owned; Forensic ]
+            ~area_failures
+        with
+        | Some row -> [ row ]
+        | None -> reconcile_bound ~fs ~store bound))
+  | Core.Forensic_record forensic ->
+    let source_state =
+      match Core.forensic_source forensic with
+      | Core.Prepared_source _ -> Prepared
+      | Core.Bound_source _ -> Bound
+    in
+    [ Existing_forensic_record
+        { operation_id =
+            Core.forensic_operation_id forensic |> Core.operation_id_to_string
+        ; source_state
+        }
+    ]
+  | Core.Invalid_record_name { area; name } ->
+    [ Invalid_record_name { area = record_area_of_core area; name } ]
+  | Core.Unexpected_record_kind { area; operation_id; kind } ->
+    [ Unexpected_record_kind
+        { area = record_area_of_core area
+        ; operation_id = Core.operation_id_to_string operation_id
+        ; kind
+        }
+    ]
+  | Core.Missing_record_entry { area; operation_id } ->
+    [ Missing_record_entry
+        { area = record_area_of_core area
+        ; operation_id = Core.operation_id_to_string operation_id
+        }
+    ]
+  | Core.Record_entry_unavailable { area; operation_id; error } ->
+    [ Record_entry_unavailable
+        { area = record_area_of_core area
+        ; operation_id = Core.operation_id_to_string operation_id
+        ; error
+        }
+    ]
+  | Core.Corrupt_record corrupt ->
+    [ Corrupt_record_preserved
+        { area = record_area_of_core corrupt.area
+        ; operation_id = Core.operation_id_to_string corrupt.operation_id
+        ; raw_byte_count = String.length corrupt.raw
+        ; raw_sha256 = sha256 corrupt.raw
+        ; validation_error = safe_validation_error corrupt.validation_error
+        }
+    ]
+;;
+
+let reconcile_inventory_rows ~fs ~store ~owner inventory =
+  let conflicts = conflicting_source_areas inventory in
+  let area_failures = area_inventory_failures inventory in
+  let rec loop completed = function
+    | [] -> List.rev completed
+    | inventory_row :: rest ->
+      (try
+         let rows =
+           row_of_inventory
+             ~fs
+             ~store
+             ~conflicts
+             ~area_failures
+             inventory_row
+         in
+         loop (List.rev_append rows completed) rest
+       with
+       | Eio.Cancel.Cancelled reason ->
+         let backtrace = Printexc.get_raw_backtrace () in
+         raise_reconciliation_cancellation
+           ~owner
+           ~completed_rows:(List.rev completed)
+           ~default_effect:Core.No_record_change
+           ~cleanup_failures:[]
+           { reason; backtrace })
+  in
+  loop [] inventory
+;;
+
+let reconcile_owner ~fs ~registry ~owner =
+  let owner_name = Core.owner_to_string owner in
+  match
+    Core.with_existing_store ~registry ~owner (fun store ->
+      match Core.inventory store with
+      | Error error -> [ Owner_inventory_unavailable error ]
+      | Ok inventory ->
+        reconcile_inventory_rows ~fs ~store ~owner:owner_name inventory)
+  with
+  | Ok (Core.Existing_store_scope_released rows) ->
+    { owner = owner_name; rows }
+  | Ok
+      (Core.Existing_store_scope_release_failed
+        { value = rows; release_failure }) ->
+    let failure =
+      core_scope_release_failure Owner_store_scope release_failure
+    in
+    { owner = owner_name; rows = rows @ [ Owner_store_release_failed failure ] }
+  | Ok
+      (Core.Existing_store_scope_cancelled
+        { value; reason; backtrace; release_failure }) ->
+    let cleanup_failures =
+      release_failure
+      |> Option.map (core_scope_release_failure Owner_store_scope)
+      |> Option.to_list
+    in
+    raise_reconciliation_cancellation
+      ~owner:owner_name
+      ~completed_rows:(Option.value ~default:[] value)
+      ~default_effect:Core.No_record_change
+      ~cleanup_failures
+      { reason; backtrace }
+  | Error error -> { owner = owner_name; rows = [ Owner_store_unavailable error ] }
+;;
+
+let report_owner report = report.owner
+let report_rows report = report.rows
+
+let row_is_ready = function
+  | Prepared_reconciled _
+  | Bound_reconciled _
+  | Existing_forensic_record _ -> true
+  | Unexpected_lane_entry _
+  | Missing_lane_entry _
+  | Lane_entry_unavailable _
+  | Area_inventory_unavailable _
+  | Source_transition_capabilities_unavailable _
+  | Conflicting_source_records _
+  | Invalid_record_name _
+  | Unexpected_record_kind _
+  | Missing_record_entry _
+  | Record_entry_unavailable _
+  | Corrupt_record_preserved _
+  | Record_observation_failed _
+  | Record_transition_failed _
+  | Record_scope_release_failed _
+  | Owner_store_release_failed _
+  | Owner_store_unavailable _
+  | Owner_inventory_unavailable _ -> false
+;;
+
+let report_is_ready report = List.for_all row_is_ready report.rows
+
+let record_area_to_string = function
+  | Active -> "active"
+  | Owned -> "owned"
+  | Forensic -> "forensic"
+;;
+
+let source_state_to_string = function
+  | Prepared -> "prepared"
+  | Bound -> "bound"
+;;
+
+let corrupt_validation_error_kind_to_string = function
+  | Corrupt_invalid_owner -> "invalid_owner"
+  | Corrupt_invalid_operation_id -> "invalid_operation_id"
+  | Corrupt_invalid_identity -> "invalid_identity"
+  | Corrupt_invalid_allowed_root_path -> "invalid_allowed_root_path"
+  | Corrupt_empty_parent_path_identity_mismatch ->
+    "empty_parent_path_identity_mismatch"
+  | Corrupt_invalid_parent_component -> "invalid_parent_component"
+  | Corrupt_invalid_target_leaf -> "invalid_target_leaf"
+  | Corrupt_invalid_permissions -> "invalid_permissions"
+  | Corrupt_invalid_record_json -> "invalid_record_json"
+  | Corrupt_invalid_record_shape -> "invalid_record_shape"
+  | Corrupt_unsupported_record_version -> "unsupported_record_version"
+  | Corrupt_record_state_mismatch -> "record_state_mismatch"
+  | Corrupt_record_owner_mismatch -> "record_owner_mismatch"
+  | Corrupt_record_operation_id_mismatch ->
+    "record_operation_id_mismatch"
+  | Corrupt_record_stage_leaf_mismatch -> "record_stage_leaf_mismatch"
+  | Corrupt_record_identity_mismatch -> "record_identity_mismatch"
+  | Corrupt_record_kind_mismatch -> "record_kind_mismatch"
+  | Corrupt_record_permissions_mismatch -> "record_permissions_mismatch"
+  | Corrupt_record_outcome_observation_not_mismatch ->
+    "record_outcome_observation_not_mismatch"
+  | Corrupt_record_field_invalid -> "record_field_invalid"
+;;
+
+let digest_evidence_to_string = function
+  | None -> "no_payload"
+  | Some { canonical_json_byte_count; canonical_json_sha256 } ->
+    Printf.sprintf
+      "payload(canonical_json_bytes=%d,sha256=%s)"
+      canonical_json_byte_count
+      canonical_json_sha256
+;;
+
+let corrupt_validation_error_to_string error =
+  Printf.sprintf
+    "%s,%s"
+    (corrupt_validation_error_kind_to_string error.kind)
+    (digest_evidence_to_string error.payload)
+;;
+
+let release_scope_to_string = function
+  | Owner_store_scope -> "owner_store"
+  | Record_scope { source_state; operation_id } ->
+    Printf.sprintf
+      "record(%s,%s)"
+      (source_state_to_string source_state)
+      operation_id
+;;
+
+let cleanup_failure_to_string = function
+  | Core_cleanup_failure failure ->
+    Printf.sprintf "core(%s)" (Core.failure_to_string failure)
+  | Scope_release_failure { scope; exception_; _ } ->
+    Printf.sprintf
+      "scope_release(%s,%s)"
+      (release_scope_to_string scope)
+      (Printexc.to_string exception_)
+;;
+
+let observation_subject_to_string = function
+  | Allowed_root path -> Printf.sprintf "allowed_root(%S)" path
+  | Parent_component { index; component } ->
+    Printf.sprintf "parent_component(index=%d,name=%S)" index component
+  | Stage_leaf name -> Printf.sprintf "stage_leaf(%S)" name
+  | Target_leaf name -> Printf.sprintf "target_leaf(%S)" name
+;;
+
+let row_to_string = function
+  | Unexpected_lane_entry { name; kind } ->
+    Format.asprintf
+      "unexpected_lane_entry(%S,%a)"
+      name
+      Eio.File.Stat.pp_kind
+      kind
+  | Missing_lane_entry { name } ->
+    Printf.sprintf "missing_lane_entry(%S)" name
+  | Lane_entry_unavailable { name; error } ->
+    Printf.sprintf
+      "lane_entry_unavailable(%S,%s)"
+      name
+      (Core.transition_error_to_string error)
+  | Area_inventory_unavailable { area; error } ->
+    Printf.sprintf
+      "area_inventory_unavailable(%s,%s)"
+      (record_area_to_string area)
+      (Core.transition_error_to_string error)
+  | Source_transition_capabilities_unavailable
+      { source_state; operation_id; area_failures } ->
+    let areas =
+      area_failures
+      |> List.map (fun (area, _) -> record_area_to_string area)
+      |> String.concat ","
+    in
+    Printf.sprintf
+      "source_transition_capabilities_unavailable(%s,%s,[%s])"
+      (source_state_to_string source_state)
+      operation_id
+      areas
+  | Prepared_reconciled { operation_id; _ } ->
+    Printf.sprintf "prepared_reconciled(%s)" operation_id
+  | Bound_reconciled { operation_id; _ } ->
+    Printf.sprintf "bound_reconciled(%s)" operation_id
+  | Existing_forensic_record { operation_id; source_state } ->
+    Printf.sprintf
+      "existing_forensic(%s,%s)"
+      operation_id
+      (source_state_to_string source_state)
+  | Conflicting_source_records { operation_id; areas } ->
+    Printf.sprintf
+      "conflicting_sources(%s,[%s])"
+      operation_id
+      (String.concat "," (List.map record_area_to_string areas))
+  | Invalid_record_name { area; name } ->
+    Printf.sprintf
+      "invalid_record_name(%s,%S)"
+      (record_area_to_string area)
+      name
+  | Unexpected_record_kind { area; operation_id; kind } ->
+    Format.asprintf
+      "unexpected_record_kind(%s,%s,%a)"
+      (record_area_to_string area)
+      operation_id
+      Eio.File.Stat.pp_kind
+      kind
+  | Missing_record_entry { area; operation_id } ->
+    Printf.sprintf
+      "missing_record(%s,%s)"
+      (record_area_to_string area)
+      operation_id
+  | Record_entry_unavailable { area; operation_id; error } ->
+    Printf.sprintf
+      "record_unavailable(%s,%s,%s)"
+      (record_area_to_string area)
+      operation_id
+      (Core.transition_error_to_string error)
+  | Corrupt_record_preserved
+      { area; operation_id; validation_error; _ } ->
+    Printf.sprintf
+      "corrupt_record(%s,%s,%s)"
+      (record_area_to_string area)
+      operation_id
+      (corrupt_validation_error_to_string validation_error)
+  | Record_observation_failed
+      { source_state; operation_id; failure } ->
+    Printf.sprintf
+      "observation_failed(%s,%s,%s)"
+      (source_state_to_string source_state)
+      operation_id
+      (observation_subject_to_string failure.subject)
+  | Record_transition_failed { source_state; operation_id; error } ->
+    Printf.sprintf
+      "transition_failed(%s,%s,%s)"
+      (source_state_to_string source_state)
+      operation_id
+      (Core.transition_error_to_string error)
+  | Record_scope_release_failed
+      { source_state; operation_id; failure } ->
+    Printf.sprintf
+      "record_scope_release_failed(%s,%s,%s)"
+      (source_state_to_string source_state)
+      operation_id
+      (cleanup_failure_to_string failure)
+  | Owner_store_release_failed failure ->
+    Printf.sprintf
+      "owner_store_release_failed(%s)"
+      (cleanup_failure_to_string failure)
+  | Owner_store_unavailable error ->
+    Printf.sprintf
+      "owner_store_unavailable(%s)"
+      (Core.transition_error_to_string error)
+  | Owner_inventory_unavailable error ->
+    Printf.sprintf
+      "owner_inventory_unavailable(%s)"
+      (Core.transition_error_to_string error)
+;;
+
+let report_to_string report =
+  Printf.sprintf
+    "owner=%S ready=%b rows=[%s]"
+    report.owner
+    (report_is_ready report)
+    (String.concat "; " (List.map row_to_string report.rows))
+;;
+
+let file_kind_to_string kind =
+  Format.asprintf "%a" Eio.File.Stat.pp_kind kind
+;;
+
+let exception_to_yojson exception_ backtrace =
+  `Assoc
+    [ "message", `String (Printexc.to_string exception_)
+    ; "backtrace", `String (Printexc.raw_backtrace_to_string backtrace)
+    ]
+;;
+
+let identity_to_yojson identity =
+  `Assoc
+    [ "device", `Intlit (Int64.to_string identity.device)
+    ; "inode", `Intlit (Int64.to_string identity.inode)
+    ]
+;;
+
+let core_identity_to_yojson identity =
+  identity |> identity_of_core |> identity_to_yojson
+;;
+
+let entry_observation_to_yojson = function
+  | Entry_absent -> `Assoc [ "kind", `String "absent" ]
+  | Entry_present { kind; identity } ->
+    `Assoc
+      [ "kind", `String "present"
+      ; "resource_kind", `String (file_kind_to_string kind)
+      ; "identity", identity_to_yojson identity
+      ]
+;;
+
+let resource_mismatch_to_yojson mismatch =
+  `Assoc
+    [ "expected", identity_to_yojson mismatch.expected
+    ; "observed", entry_observation_to_yojson mismatch.observed
+    ]
+;;
+
+let prepared_outcome_to_yojson = function
+  | Prepared_unmaterialized ->
+    `Assoc [ "kind", `String "unmaterialized" ]
+  | Prepared_allowed_root_mismatch mismatch ->
+    `Assoc
+      [ "kind", `String "allowed_root_mismatch"
+      ; "mismatch", resource_mismatch_to_yojson mismatch
+      ]
+  | Prepared_parent_mismatch mismatch ->
+    `Assoc
+      [ "kind", `String "parent_mismatch"
+      ; "mismatch", resource_mismatch_to_yojson mismatch
+      ]
+  | Prepared_unbound_stage_preserved { kind; identity } ->
+    `Assoc
+      [ "kind", `String "unbound_stage_preserved"
+      ; "resource_kind", `String (file_kind_to_string kind)
+      ; "identity", identity_to_yojson identity
+      ]
+;;
+
+let bound_outcome_to_yojson = function
+  | Bound_stage_absent { observed_target } ->
+    `Assoc
+      [ "kind", `String "stage_absent"
+      ; "observed_target", entry_observation_to_yojson observed_target
+      ]
+  | Bound_allowed_root_mismatch mismatch ->
+    `Assoc
+      [ "kind", `String "allowed_root_mismatch"
+      ; "mismatch", resource_mismatch_to_yojson mismatch
+      ]
+  | Bound_parent_mismatch mismatch ->
+    `Assoc
+      [ "kind", `String "parent_mismatch"
+      ; "mismatch", resource_mismatch_to_yojson mismatch
+      ]
+  | Bound_stage_mismatch { mismatch; observed_target } ->
+    `Assoc
+      [ "kind", `String "stage_mismatch"
+      ; "mismatch", resource_mismatch_to_yojson mismatch
+      ; "observed_target", entry_observation_to_yojson observed_target
+      ]
+  | Bound_stage_preserved { kind; identity; observed_target } ->
+    `Assoc
+      [ "kind", `String "stage_preserved"
+      ; "resource_kind", `String (file_kind_to_string kind)
+      ; "identity", identity_to_yojson identity
+      ; "observed_target", entry_observation_to_yojson observed_target
+      ]
+;;
+
+let core_record_area_to_string = function
+  | Core.Active -> "active"
+  | Core.Owned -> "owned"
+  | Core.Forensic -> "forensic"
+;;
+
+let core_removal_transition_to_string = function
+  | Core.Discharge_active -> "discharge_active"
+  | Core.Discharge_owned -> "discharge_owned"
+  | Core.Active_to_owned -> "active_to_owned"
+  | Core.Active_to_forensic -> "active_to_forensic"
+  | Core.Owned_to_forensic -> "owned_to_forensic"
+;;
+
+let core_transition_effect_to_yojson = function
+  | Core.No_record_change -> `Assoc [ "kind", `String "no_record_change" ]
+  | Core.Layout_may_be_incomplete ->
+    `Assoc [ "kind", `String "layout_may_be_incomplete" ]
+  | Core.Layout_ready -> `Assoc [ "kind", `String "layout_ready" ]
+  | Core.Active_record_state_unknown ->
+    `Assoc [ "kind", `String "active_record_state_unknown" ]
+  | Core.Active_record_durable ->
+    `Assoc [ "kind", `String "active_record_durable" ]
+  | Core.Active_record_discharged ->
+    `Assoc [ "kind", `String "active_record_discharged" ]
+  | Core.Owned_record_state_unknown_with_active ->
+    `Assoc [ "kind", `String "owned_record_state_unknown_with_active" ]
+  | Core.Owned_record_durable_with_active ->
+    `Assoc [ "kind", `String "owned_record_durable_with_active" ]
+  | Core.Owned_record_durable ->
+    `Assoc [ "kind", `String "owned_record_durable" ]
+  | Core.Owned_record_discharged ->
+    `Assoc [ "kind", `String "owned_record_discharged" ]
+  | Core.Forensic_record_state_unknown_with_source ->
+    `Assoc
+      [ "kind", `String "forensic_record_state_unknown_with_source" ]
+  | Core.Forensic_record_durable_with_source ->
+    `Assoc [ "kind", `String "forensic_record_durable_with_source" ]
+  | Core.Forensic_record_durable ->
+    `Assoc [ "kind", `String "forensic_record_durable" ]
+  | Core.Source_removal_durability_unknown transition ->
+    `Assoc
+      [ "kind", `String "source_removal_durability_unknown"
+      ; "transition", `String (core_removal_transition_to_string transition)
+      ]
+;;
+
+let core_validation_error_to_yojson = function
+  | Core.Invalid_owner value ->
+    `Assoc [ "kind", `String "invalid_owner"; "value", `String value ]
+  | Core.Invalid_operation_id value ->
+    `Assoc
+      [ "kind", `String "invalid_operation_id"; "value", `String value ]
+  | Core.Invalid_identity identity ->
+    `Assoc
+      [ "kind", `String "invalid_identity"
+      ; "identity", core_identity_to_yojson identity
+      ]
+  | Core.Invalid_allowed_root_path value ->
+    `Assoc
+      [ "kind", `String "invalid_allowed_root_path"
+      ; "value", `String value
+      ]
+  | Core.Empty_parent_path_identity_mismatch { allowed_root; parent } ->
+    `Assoc
+      [ "kind", `String "empty_parent_path_identity_mismatch"
+      ; "allowed_root", core_identity_to_yojson allowed_root
+      ; "parent", core_identity_to_yojson parent
+      ]
+  | Core.Invalid_parent_component { index; value } ->
+    `Assoc
+      [ "kind", `String "invalid_parent_component"
+      ; "index", `Int index
+      ; "value", `String value
+      ]
+  | Core.Invalid_target_leaf value ->
+    `Assoc
+      [ "kind", `String "invalid_target_leaf"; "value", `String value ]
+  | Core.Invalid_permissions value ->
+    `Assoc
+      [ "kind", `String "invalid_permissions"; "value", `Int value ]
+  | Core.Invalid_record_json { exception_; backtrace } ->
+    `Assoc
+      [ "kind", `String "invalid_record_json"
+      ; "exception", exception_to_yojson exception_ backtrace
+      ]
+  | Core.Invalid_record_shape ->
+    `Assoc [ "kind", `String "invalid_record_shape" ]
+  | Core.Unsupported_record_version version ->
+    `Assoc
+      [ "kind", `String "unsupported_record_version"
+      ; "version", `Int version
+      ]
+  | Core.Record_state_mismatch ->
+    `Assoc [ "kind", `String "record_state_mismatch" ]
+  | Core.Record_owner_mismatch { expected; actual } ->
+    `Assoc
+      [ "kind", `String "record_owner_mismatch"
+      ; "expected", `String (Core.owner_to_string expected)
+      ; "actual", `String (Core.owner_to_string actual)
+      ]
+  | Core.Record_operation_id_mismatch { expected; actual } ->
+    `Assoc
+      [ "kind", `String "record_operation_id_mismatch"
+      ; "expected", `String (Core.operation_id_to_string expected)
+      ; "actual", `String (Core.operation_id_to_string actual)
+      ]
+  | Core.Record_stage_leaf_mismatch { expected; actual } ->
+    `Assoc
+      [ "kind", `String "record_stage_leaf_mismatch"
+      ; "expected", `String expected
+      ; "actual", `String actual
+      ]
+  | Core.Record_identity_mismatch { expected; actual } ->
+    `Assoc
+      [ "kind", `String "record_identity_mismatch"
+      ; "expected", core_identity_to_yojson expected
+      ; "actual", core_identity_to_yojson actual
+      ]
+  | Core.Record_kind_mismatch { expected; actual } ->
+    `Assoc
+      [ "kind", `String "record_kind_mismatch"
+      ; "expected", `String (file_kind_to_string expected)
+      ; "actual", `String (file_kind_to_string actual)
+      ]
+  | Core.Record_permissions_mismatch { expected; actual } ->
+    `Assoc
+      [ "kind", `String "record_permissions_mismatch"
+      ; "expected", `Int expected
+      ; "actual", `Int actual
+      ]
+  | Core.Record_outcome_observation_not_mismatch identity ->
+    `Assoc
+      [ "kind", `String "record_outcome_observation_not_mismatch"
+      ; "identity", core_identity_to_yojson identity
+      ]
+  | Core.Record_field_invalid { field; value } ->
+    `Assoc
+      [ "kind", `String "record_field_invalid"
+      ; "field", `String field
+      ; "value", value
+      ]
+;;
+
+let corrupt_validation_error_to_yojson error =
+  let payload =
+    match error.payload with
+    | None -> `Null
+    | Some { canonical_json_byte_count; canonical_json_sha256 } ->
+      `Assoc
+        [ "canonical_json_byte_count", `Int canonical_json_byte_count
+        ; "canonical_json_sha256", `String canonical_json_sha256
+        ]
+  in
+  `Assoc
+    [ ( "kind"
+      , `String (corrupt_validation_error_kind_to_string error.kind) )
+    ; "payload", payload
+    ]
+;;
+
+let core_subject_to_yojson = function
+  | Core.Registry_root -> `Assoc [ "kind", `String "registry_root" ]
+  | Core.Recovery_root -> `Assoc [ "kind", `String "recovery_root" ]
+  | Core.Lanes_root -> `Assoc [ "kind", `String "lanes_root" ]
+  | Core.Lane_root owner ->
+    `Assoc
+      [ "kind", `String "lane_root"
+      ; "owner", `String (Core.owner_to_string owner)
+      ]
+  | Core.Lane_entry (owner, name) ->
+    `Assoc
+      [ "kind", `String "lane_entry"
+      ; "owner", `String (Core.owner_to_string owner)
+      ; "name", `String name
+      ]
+  | Core.Area (area, owner) ->
+    `Assoc
+      [ "kind", `String "area"
+      ; "area", `String (core_record_area_to_string area)
+      ; "owner", `String (Core.owner_to_string owner)
+      ]
+  | Core.Record (area, owner, operation_id) ->
+    `Assoc
+      [ "kind", `String "record"
+      ; "area", `String (core_record_area_to_string area)
+      ; "owner", `String (Core.owner_to_string owner)
+      ; "operation_id", `String (Core.operation_id_to_string operation_id)
+      ]
+;;
+
+let core_operation_to_string = function
+  | Core.Inspect_directory -> "inspect_directory"
+  | Core.Create_directory -> "create_directory"
+  | Core.Open_directory -> "open_directory"
+  | Core.Close_directory -> "close_directory"
+  | Core.Sync_directory -> "sync_directory"
+  | Core.Read_directory -> "read_directory"
+  | Core.Inspect_record -> "inspect_record"
+  | Core.Open_record -> "open_record"
+  | Core.Read_record -> "read_record"
+  | Core.Decode_record -> "decode_record"
+  | Core.Create_record -> "create_record"
+  | Core.Apply_permissions -> "apply_permissions"
+  | Core.Write_record -> "write_record"
+  | Core.Sync_record -> "sync_record"
+  | Core.Close_record -> "close_record"
+  | Core.Verify_record_identity -> "verify_record_identity"
+  | Core.Remove_record -> "remove_record"
+;;
+
+let core_failure_cause_to_yojson = function
+  | Core.Validation_failed error ->
+    `Assoc
+      [ "kind", `String "validation_failed"
+      ; "error", core_validation_error_to_yojson error
+      ]
+  | Core.Io_failed { exception_; backtrace } ->
+    `Assoc
+      [ "kind", `String "io_failed"
+      ; "exception", exception_to_yojson exception_ backtrace
+      ]
+  | Core.Write_failed { exception_; backtrace; bytes_written } ->
+    `Assoc
+      [ "kind", `String "write_failed"
+      ; "exception", exception_to_yojson exception_ backtrace
+      ; "bytes_written", `Int bytes_written
+      ]
+  | Core.Unexpected_resource_kind kind ->
+    `Assoc
+      [ "kind", `String "unexpected_resource_kind"
+      ; "resource_kind", `String (file_kind_to_string kind)
+      ]
+  | Core.Resource_identity_changed { expected; actual } ->
+    `Assoc
+      [ "kind", `String "resource_identity_changed"
+      ; "expected", core_identity_to_yojson expected
+      ; "actual", core_identity_to_yojson actual
+      ]
+  | Core.Posix_descriptor_unavailable ->
+    `Assoc [ "kind", `String "posix_descriptor_unavailable" ]
+  | Core.Existing_record_does_not_match ->
+    `Assoc [ "kind", `String "existing_record_does_not_match" ]
+  | Core.Created_record_identity_unavailable ->
+    `Assoc [ "kind", `String "created_record_identity_unavailable" ]
+  | Core.Missing_record -> `Assoc [ "kind", `String "missing_record" ]
+;;
+
+let core_failure_to_yojson (failure : Core.failure) =
+  `Assoc
+    [ "operation", `String (core_operation_to_string failure.operation)
+    ; "subject", core_subject_to_yojson failure.subject
+    ; "cause", core_failure_cause_to_yojson failure.cause
+    ]
+;;
+
+let core_transition_error_to_yojson (error : Core.transition_error) =
+  `Assoc
+    [ "store_effect", core_transition_effect_to_yojson error.store_effect
+    ; "failure", core_failure_to_yojson error.failure
+    ; ( "cleanup_failures"
+      , `List (List.map core_failure_to_yojson error.cleanup_failures) )
+    ]
+;;
+
+let release_scope_to_yojson = function
+  | Owner_store_scope -> `Assoc [ "kind", `String "owner_store" ]
+  | Record_scope { source_state; operation_id } ->
+    `Assoc
+      [ "kind", `String "record"
+      ; "source_state", `String (source_state_to_string source_state)
+      ; "operation_id", `String operation_id
+      ]
+;;
+
+let cleanup_failure_to_yojson = function
+  | Core_cleanup_failure failure ->
+    `Assoc
+      [ "kind", `String "core_cleanup_failure"
+      ; "failure", core_failure_to_yojson failure
+      ]
+  | Scope_release_failure { scope; exception_; backtrace } ->
+    `Assoc
+      [ "kind", `String "scope_release_failure"
+      ; "scope", release_scope_to_yojson scope
+      ; "exception", exception_to_yojson exception_ backtrace
+      ]
+;;
+
+let observation_subject_to_yojson = function
+  | Allowed_root path ->
+    `Assoc [ "kind", `String "allowed_root"; "path", `String path ]
+  | Parent_component { index; component } ->
+    `Assoc
+      [ "kind", `String "parent_component"
+      ; "index", `Int index
+      ; "component", `String component
+      ]
+  | Stage_leaf name ->
+    `Assoc [ "kind", `String "stage_leaf"; "name", `String name ]
+  | Target_leaf name ->
+    `Assoc [ "kind", `String "target_leaf"; "name", `String name ]
+;;
+
+let observation_cause_to_yojson = function
+  | Observation_io_failed { exception_; backtrace } ->
+    `Assoc
+      [ "kind", `String "io_failed"
+      ; "exception", exception_to_yojson exception_ backtrace
+      ]
+  | Observation_identity_invalid error ->
+    `Assoc
+      [ "kind", `String "identity_invalid"
+      ; "error", core_validation_error_to_yojson error
+      ]
+  | Opened_resource_kind_changed { observed; opened } ->
+    `Assoc
+      [ "kind", `String "opened_resource_kind_changed"
+      ; "observed", `String (file_kind_to_string observed)
+      ; "opened", `String (file_kind_to_string opened)
+      ]
+  | Opened_resource_identity_changed { observed; opened } ->
+    `Assoc
+      [ "kind", `String "opened_resource_identity_changed"
+      ; "observed", identity_to_yojson observed
+      ; "opened", identity_to_yojson opened
+      ]
+;;
+
+let observation_failure_to_yojson failure =
+  `Assoc
+    [ "subject", observation_subject_to_yojson failure.subject
+    ; "cause", observation_cause_to_yojson failure.cause
+    ]
+;;
+
+let row_to_yojson = function
+  | Unexpected_lane_entry { name; kind } ->
+    `Assoc
+      [ "kind", `String "unexpected_lane_entry"
+      ; "name", `String name
+      ; "resource_kind", `String (file_kind_to_string kind)
+      ]
+  | Missing_lane_entry { name } ->
+    `Assoc [ "kind", `String "missing_lane_entry"; "name", `String name ]
+  | Lane_entry_unavailable { name; error } ->
+    `Assoc
+      [ "kind", `String "lane_entry_unavailable"
+      ; "name", `String name
+      ; "error", core_transition_error_to_yojson error
+      ]
+  | Area_inventory_unavailable { area; error } ->
+    `Assoc
+      [ "kind", `String "area_inventory_unavailable"
+      ; "area", `String (record_area_to_string area)
+      ; "error", core_transition_error_to_yojson error
+      ]
+  | Source_transition_capabilities_unavailable
+      { source_state; operation_id; area_failures } ->
+    `Assoc
+      [ "kind", `String "source_transition_capabilities_unavailable"
+      ; "source_state", `String (source_state_to_string source_state)
+      ; "operation_id", `String operation_id
+      ; ( "area_failures"
+        , `List
+            (List.map
+               (fun (area, error) ->
+                  `Assoc
+                    [ "area", `String (record_area_to_string area)
+                    ; "error", core_transition_error_to_yojson error
+                    ])
+               area_failures) )
+      ]
+  | Prepared_reconciled { operation_id; outcome } ->
+    `Assoc
+      [ "kind", `String "prepared_reconciled"
+      ; "operation_id", `String operation_id
+      ; "outcome", prepared_outcome_to_yojson outcome
+      ]
+  | Bound_reconciled { operation_id; outcome } ->
+    `Assoc
+      [ "kind", `String "bound_reconciled"
+      ; "operation_id", `String operation_id
+      ; "outcome", bound_outcome_to_yojson outcome
+      ]
+  | Existing_forensic_record { operation_id; source_state } ->
+    `Assoc
+      [ "kind", `String "existing_forensic_record"
+      ; "operation_id", `String operation_id
+      ; "source_state", `String (source_state_to_string source_state)
+      ]
+  | Conflicting_source_records { operation_id; areas } ->
+    `Assoc
+      [ "kind", `String "conflicting_source_records"
+      ; "operation_id", `String operation_id
+      ; ( "areas"
+        , `List
+            (List.map
+               (fun area -> `String (record_area_to_string area))
+               areas) )
+      ]
+  | Invalid_record_name { area; name } ->
+    `Assoc
+      [ "kind", `String "invalid_record_name"
+      ; "area", `String (record_area_to_string area)
+      ; "name", `String name
+      ]
+  | Unexpected_record_kind { area; operation_id; kind } ->
+    `Assoc
+      [ "kind", `String "unexpected_record_kind"
+      ; "area", `String (record_area_to_string area)
+      ; "operation_id", `String operation_id
+      ; "resource_kind", `String (file_kind_to_string kind)
+      ]
+  | Missing_record_entry { area; operation_id } ->
+    `Assoc
+      [ "kind", `String "missing_record_entry"
+      ; "area", `String (record_area_to_string area)
+      ; "operation_id", `String operation_id
+      ]
+  | Record_entry_unavailable { area; operation_id; error } ->
+    `Assoc
+      [ "kind", `String "record_entry_unavailable"
+      ; "area", `String (record_area_to_string area)
+      ; "operation_id", `String operation_id
+      ; "error", core_transition_error_to_yojson error
+      ]
+  | Corrupt_record_preserved
+      { area
+      ; operation_id
+      ; raw_byte_count
+      ; raw_sha256
+      ; validation_error
+      } ->
+    `Assoc
+      [ "kind", `String "corrupt_record_preserved"
+      ; "area", `String (record_area_to_string area)
+      ; "operation_id", `String operation_id
+      ; "raw_byte_count", `Int raw_byte_count
+      ; "raw_sha256", `String raw_sha256
+      ; "validation_error", corrupt_validation_error_to_yojson validation_error
+      ]
+  | Record_observation_failed
+      { source_state; operation_id; failure } ->
+    `Assoc
+      [ "kind", `String "record_observation_failed"
+      ; "source_state", `String (source_state_to_string source_state)
+      ; "operation_id", `String operation_id
+      ; "failure", observation_failure_to_yojson failure
+      ]
+  | Record_transition_failed { source_state; operation_id; error } ->
+    `Assoc
+      [ "kind", `String "record_transition_failed"
+      ; "source_state", `String (source_state_to_string source_state)
+      ; "operation_id", `String operation_id
+      ; "error", core_transition_error_to_yojson error
+      ]
+  | Record_scope_release_failed { source_state; operation_id; failure } ->
+    `Assoc
+      [ "kind", `String "record_scope_release_failed"
+      ; "source_state", `String (source_state_to_string source_state)
+      ; "operation_id", `String operation_id
+      ; "failure", cleanup_failure_to_yojson failure
+      ]
+  | Owner_store_release_failed failure ->
+    `Assoc
+      [ "kind", `String "owner_store_release_failed"
+      ; "failure", cleanup_failure_to_yojson failure
+      ]
+  | Owner_store_unavailable error ->
+    `Assoc
+      [ "kind", `String "owner_store_unavailable"
+      ; "error", core_transition_error_to_yojson error
+      ]
+  | Owner_inventory_unavailable error ->
+    `Assoc
+      [ "kind", `String "owner_inventory_unavailable"
+      ; "error", core_transition_error_to_yojson error
+      ]
+;;
+
+let report_to_yojson report =
+  `Assoc
+    [ "owner", `String report.owner
+    ; "ready", `Bool (report_is_ready report)
+    ; "rows", `List (List.map row_to_yojson report.rows)
+    ]
+;;
+
+module For_testing = struct
+  type resource_scope_callback =
+    | Return_completed_rows of string list
+    | Cancel_callback of exn
+
+  type resource_scope_evidence =
+    | Returned_rows of
+        { completed_rows : string list
+        ; release_failure : exn option
+        }
+    | Cancelled_callback of
+        { reason : exn
+        ; release_failure : exn option
+        }
+    | Raised_callback of
+        { exception_ : exn
+        ; release_failure : exn option
+        }
+
+  let run_resource_scope ~callback ~release_failure =
+    let outcome =
+      Resource_scope.run_resource_only @@ fun sw ->
+      Option.iter
+        (fun exception_ ->
+           Eio.Switch.on_release sw (fun () -> raise exception_))
+        release_failure;
+      match callback with
+      | Return_completed_rows rows -> rows
+      | Cancel_callback reason -> raise (Eio.Cancel.Cancelled reason)
+    in
+    let release_failure =
+      Option.map
+        (fun (failure : Resource_scope.raised) -> failure.exception_)
+        outcome.scope_failure
+    in
+    match outcome.callback with
+    | Some (Resource_scope.Returned completed_rows) ->
+      Returned_rows { completed_rows; release_failure }
+    | Some (Resource_scope.Cancelled { reason; _ }) ->
+      Cancelled_callback { reason; release_failure }
+    | Some (Resource_scope.Raised { exception_; _ }) ->
+      Raised_callback { exception_; release_failure }
+    | None ->
+      (match outcome.parent_cancellation with
+       | Some { reason; _ } -> Cancelled_callback { reason; release_failure }
+       | None ->
+         (match outcome.scope_failure with
+          | Some { exception_; _ } ->
+            Raised_callback { exception_; release_failure = None }
+          | None ->
+            Raised_callback
+              { exception_ = Internal_resource_scope_callback_not_entered
+              ; release_failure = None
+              }))
+  ;;
+end

--- a/lib/fs_compat/capability_recovery_reconciler.mli
+++ b/lib/fs_compat/capability_recovery_reconciler.mli
@@ -1,0 +1,295 @@
+(** Portable startup reconciliation for capability-publication obligations.
+
+    This module inventories only the exact records supplied by
+    {!Capability_recovery_obligation.inventory}. For each valid Prepared or
+    Bound source it reacquires the persisted allowed-root path below the
+    caller-provided filesystem capability, validates every opened directory
+    against a no-follow observation, and inspects only the exact derived stage
+    and target leaves. It never scans a target tree and never renames, unlinks,
+    removes, or republishes a target-tree entry. The only durable mutations it
+    can request are typed source-record transitions to [forensic]. *)
+
+module Core = Capability_recovery_obligation
+
+type identity =
+  { device : int64
+  ; inode : int64
+  }
+
+type entry_observation =
+  | Entry_absent
+  | Entry_present of
+      { kind : Eio.File.Stat.kind
+      ; identity : identity
+      }
+
+type resource_mismatch =
+  { expected : identity
+  ; observed : entry_observation
+  }
+
+type prepared_outcome =
+  | Prepared_unmaterialized
+  | Prepared_allowed_root_mismatch of resource_mismatch
+  | Prepared_parent_mismatch of resource_mismatch
+  | Prepared_unbound_stage_preserved of
+      { kind : Eio.File.Stat.kind
+      ; identity : identity
+      }
+
+type bound_outcome =
+  | Bound_stage_absent of { observed_target : entry_observation }
+  | Bound_allowed_root_mismatch of resource_mismatch
+  | Bound_parent_mismatch of resource_mismatch
+  | Bound_stage_mismatch of
+      { mismatch : resource_mismatch
+      ; observed_target : entry_observation
+      }
+  | Bound_stage_preserved of
+      { kind : Eio.File.Stat.kind
+      ; identity : identity
+      ; observed_target : entry_observation
+      }
+
+type record_area =
+  | Active
+  | Owned
+  | Forensic
+
+type source_state =
+  | Prepared
+  | Bound
+
+type release_scope =
+  | Owner_store_scope
+  | Record_scope of
+      { source_state : source_state
+      ; operation_id : string
+      }
+
+type cleanup_failure =
+  | Core_cleanup_failure of Core.failure
+  | Scope_release_failure of
+      { scope : release_scope
+      ; exception_ : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+
+type observation_subject =
+  | Allowed_root of string
+  | Parent_component of
+      { index : int
+      ; component : string
+      }
+  | Stage_leaf of string
+  | Target_leaf of string
+
+type observation_cause =
+  | Observation_io_failed of
+      { exception_ : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+  | Observation_identity_invalid of Core.validation_error
+  | Opened_resource_kind_changed of
+      { observed : Eio.File.Stat.kind
+      ; opened : Eio.File.Stat.kind
+      }
+  | Opened_resource_identity_changed of
+      { observed : identity
+      ; opened : identity
+      }
+
+type observation_failure =
+  { subject : observation_subject
+  ; cause : observation_cause
+  }
+
+type digest_evidence =
+  { canonical_json_byte_count : int
+  ; canonical_json_sha256 : string
+  }
+
+type corrupt_validation_error_kind =
+  | Corrupt_invalid_owner
+  | Corrupt_invalid_operation_id
+  | Corrupt_invalid_identity
+  | Corrupt_invalid_allowed_root_path
+  | Corrupt_empty_parent_path_identity_mismatch
+  | Corrupt_invalid_parent_component
+  | Corrupt_invalid_target_leaf
+  | Corrupt_invalid_permissions
+  | Corrupt_invalid_record_json
+  | Corrupt_invalid_record_shape
+  | Corrupt_unsupported_record_version
+  | Corrupt_record_state_mismatch
+  | Corrupt_record_owner_mismatch
+  | Corrupt_record_operation_id_mismatch
+  | Corrupt_record_stage_leaf_mismatch
+  | Corrupt_record_identity_mismatch
+  | Corrupt_record_kind_mismatch
+  | Corrupt_record_permissions_mismatch
+  | Corrupt_record_outcome_observation_not_mismatch
+  | Corrupt_record_field_invalid
+
+type corrupt_validation_error =
+  { kind : corrupt_validation_error_kind
+  ; payload : digest_evidence option
+  }
+
+type row =
+  | Unexpected_lane_entry of
+      { name : string
+      ; kind : Eio.File.Stat.kind
+      }
+  | Missing_lane_entry of { name : string }
+  | Lane_entry_unavailable of
+      { name : string
+      ; error : Core.transition_error
+      }
+  | Area_inventory_unavailable of
+      { area : record_area
+      ; error : Core.transition_error
+      }
+  | Source_transition_capabilities_unavailable of
+      { source_state : source_state
+      ; operation_id : string
+      ; area_failures : (record_area * Core.transition_error) list
+      }
+  | Prepared_reconciled of
+      { operation_id : string
+      ; outcome : prepared_outcome
+      }
+  | Bound_reconciled of
+      { operation_id : string
+      ; outcome : bound_outcome
+      }
+  | Existing_forensic_record of
+      { operation_id : string
+      ; source_state : source_state
+      }
+  | Conflicting_source_records of
+      { operation_id : string
+      ; areas : record_area list
+      }
+  | Invalid_record_name of
+      { area : record_area
+      ; name : string
+      }
+  | Unexpected_record_kind of
+      { area : record_area
+      ; operation_id : string
+      ; kind : Eio.File.Stat.kind
+      }
+  | Missing_record_entry of
+      { area : record_area
+      ; operation_id : string
+      }
+  | Record_entry_unavailable of
+      { area : record_area
+      ; operation_id : string
+      ; error : Core.transition_error
+      }
+  | Corrupt_record_preserved of
+      { area : record_area
+      ; operation_id : string
+      ; raw_byte_count : int
+      ; raw_sha256 : string
+      ; validation_error : corrupt_validation_error
+      }
+  | Record_observation_failed of
+      { source_state : source_state
+      ; operation_id : string
+      ; failure : observation_failure
+      }
+  | Record_transition_failed of
+      { source_state : source_state
+      ; operation_id : string
+      ; error : Core.transition_error
+      }
+  | Record_scope_release_failed of
+      { source_state : source_state
+      ; operation_id : string
+      ; failure : cleanup_failure
+      }
+  | Owner_store_release_failed of cleanup_failure
+  | Owner_store_unavailable of Core.transition_error
+  | Owner_inventory_unavailable of Core.transition_error
+
+type cancellation =
+  { original_reason : exn
+  ; original_backtrace : Printexc.raw_backtrace
+  ; owner : string
+  ; completed_rows : row list
+  ; interrupted_store_effect : Core.transition_effect
+  ; cleanup_failures : cleanup_failure list
+  }
+
+(** Raised only as the reason inside [Eio.Cancel.Cancelled]. The original
+    cancellation stays primary; completed rows and all Core/scope cleanup
+    failures remain typed evidence. *)
+exception Reconciliation_cancelled of cancellation
+
+type record_scope_callback_and_release_failure =
+  { callback : Eio.Exn.with_bt
+  ; release : cleanup_failure
+  }
+
+(** An unexpected callback exception and the exact resource-release failure
+    occurred at the same record scope. Neither is relabelled as observation
+    I/O. *)
+exception Record_scope_callback_and_release_failed of
+  record_scope_callback_and_release_failure
+
+type report
+
+val reconcile_owner
+  :  fs:Eio.Fs.dir_ty Eio.Path.t
+  -> registry:Core.registry
+  -> owner:Core.owner
+  -> report
+
+val report_owner : report -> string
+val report_rows : report -> row list
+
+(** [true] exactly when every source record was transitioned to forensic (or
+    was already forensic), the exact owner lane has no residue, every fixed
+    area was inventoried, and no invalid, corrupt, raced, or failed row
+    remains. *)
+val report_is_ready : report -> bool
+
+val report_to_string : report -> string
+
+(** Constructor-directed structured evidence. No diagnostic string is parsed
+    to produce this projection. Corrupt raw records remain only in their
+    forensic-file SSOT; the projection exposes byte count and SHA-256 identity.
+    Exception diagnostics, backtraces, transition effects, and cleanup
+    failures stay explicit. *)
+val report_to_yojson : report -> Yojson.Safe.t
+
+module For_testing : sig
+  type resource_scope_callback =
+    | Return_completed_rows of string list
+    | Cancel_callback of exn
+
+  type resource_scope_evidence =
+    | Returned_rows of
+        { completed_rows : string list
+        ; release_failure : exn option
+        }
+    | Cancelled_callback of
+        { reason : exn
+        ; release_failure : exn option
+        }
+    | Raised_callback of
+        { exception_ : exn
+        ; release_failure : exn option
+        }
+
+  (** Runs the real private resource-scope boundary. The optional failure is
+      raised by a real [Switch.on_release] hook after the callback outcome has
+      been captured. *)
+  val run_resource_scope
+    :  callback:resource_scope_callback
+    -> release_failure:exn option
+    -> resource_scope_evidence
+end

--- a/lib/fs_compat/dune
+++ b/lib/fs_compat/dune
@@ -10,10 +10,12 @@
   owned_directory_chain
   capability_leaf
   capability_mutation_lease
+  capability_recovery_obligation
   atomic_write
   blocking_write
   fd_write_all
   atomic_orphan_size_class)
+ (private_modules capability_recovery_obligation)
  ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
  (flags
   (:standard -w +4))

--- a/lib/fs_compat/dune
+++ b/lib/fs_compat/dune
@@ -10,13 +10,21 @@
   owned_directory_chain
   capability_leaf
   capability_mutation_lease
+  eio_resource_scope
   capability_recovery_obligation
+  capability_recovery_reconciler
+  publication_recovery_access
   atomic_write
   blocking_write
   fd_write_all
   atomic_orphan_size_class)
- (private_modules capability_recovery_obligation)
+ (private_modules
+  eio_resource_scope
+  capability_recovery_obligation
+  capability_recovery_reconciler
+  publication_recovery_access
+  atomic_write)
  ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
  (flags
   (:standard -w +4))
- (libraries eio eio.unix unix yojson optint uuidm))
+ (libraries eio eio.unix unix yojson optint uuidm digestif))

--- a/lib/fs_compat/eio_resource_scope.ml
+++ b/lib/fs_compat/eio_resource_scope.ml
@@ -1,0 +1,61 @@
+type raised =
+  { exception_ : exn
+  ; backtrace : Printexc.raw_backtrace
+  }
+
+type cancelled =
+  { reason : exn
+  ; backtrace : Printexc.raw_backtrace
+  }
+
+type 'a callback_outcome =
+  | Returned of 'a
+  | Raised of raised
+  | Cancelled of cancelled
+
+type 'a t =
+  { callback : 'a callback_outcome option
+  ; scope_failure : raised option
+  ; parent_cancellation : cancelled option
+  }
+
+let capture_callback f =
+  match f () with
+  | value -> Returned value
+  | exception Eio.Cancel.Cancelled reason ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    Cancelled { reason; backtrace }
+  | exception exception_ ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    Raised { exception_; backtrace }
+;;
+
+let capture_parent_cancellation () =
+  try
+    Eio.Fiber.check ();
+    None
+  with
+  | Eio.Cancel.Cancelled reason ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    Some { reason; backtrace }
+;;
+
+let run_resource_only f =
+  let callback = ref None in
+  let scope_failure =
+    try
+      Eio.Switch.run @@ fun sw ->
+      callback := Some (capture_callback (fun () -> f sw));
+      None
+    with
+    | exception_ ->
+      let backtrace = Printexc.get_raw_backtrace () in
+      Some { exception_; backtrace }
+  in
+  let parent_cancellation =
+    match !callback with
+    | Some (Cancelled _) -> None
+    | Some (Returned _ | Raised _) | None -> capture_parent_cancellation ()
+  in
+  { callback = !callback; scope_failure; parent_cancellation }
+;;

--- a/lib/fs_compat/eio_resource_scope.mli
+++ b/lib/fs_compat/eio_resource_scope.mli
@@ -1,0 +1,37 @@
+(** A resource-only [Eio.Switch] boundary which preserves the callback outcome
+    independently from switch release failures.
+
+    The callback may attach resources to the supplied switch, but must not
+    attach fibers. This restriction makes any exception raised after the
+    callback outcome was captured unambiguously a resource-release failure. *)
+
+type raised =
+  { exception_ : exn
+  ; backtrace : Printexc.raw_backtrace
+  }
+
+type cancelled =
+  { reason : exn
+  ; backtrace : Printexc.raw_backtrace
+  }
+
+type 'a callback_outcome =
+  | Returned of 'a
+  | Raised of raised
+  | Cancelled of cancelled
+
+type 'a t =
+  { callback : 'a callback_outcome option
+  ; scope_failure : raised option
+  ; parent_cancellation : cancelled option
+  }
+
+(** [run_resource_only f] runs [f] in a fresh switch and captures its outcome
+    before the switch releases attached resources. [callback = None] means
+    that the parent cancellation context rejected entry before [f] ran. When
+    [callback] is present, [scope_failure] is the exact exception raised while
+    the switch released resources. [parent_cancellation] records cancellation
+    observed after release without discarding a returned callback value.
+
+    [f] must not attach fibers to the switch. *)
+val run_resource_only : (Eio.Switch.t -> 'a) -> 'a t

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -249,18 +249,266 @@ let open_atomic_temp_file ~temp_dir () =
 
 let is_capability_leaf = Capability_leaf.is_valid
 
-type capability_write_intent = Atomic_write.capability_write_intent =
-  | Atomic_replace
-  | Create_exclusive
+type atomic_replace_recovery_target = Atomic_write.atomic_replace_recovery_target
+
+type atomic_replace_recovery_target_error =
+  Atomic_write.atomic_replace_recovery_target_error
+
+type publication_recovery_access = Atomic_write.publication_recovery_access
+
+type publication_recovery_registry = Atomic_write.publication_recovery_registry
+type publication_recovery_registry_error = Atomic_write.publication_recovery_registry_error
+
+type publication_recovery_lane_open_error =
+  Atomic_write.publication_recovery_lane_open_error
+
+type publication_recovery_owner = Atomic_write.publication_recovery_owner
+
+type publication_recovery_reconciliation_report =
+  Atomic_write.publication_recovery_reconciliation_report
+
+type publication_recovery_owner_inventory_row =
+  Atomic_write.publication_recovery_owner_inventory_row =
+  | Publication_recovery_valid_owner of publication_recovery_owner
+  | Publication_recovery_invalid_owner_name of string
+  | Publication_recovery_unexpected_owner_kind of
+      { owner : publication_recovery_owner
+      ; kind : Eio.File.Stat.kind
+      }
+  | Publication_recovery_missing_owner_entry of publication_recovery_owner
+  | Publication_recovery_owner_entry_unavailable of
+      { owner : publication_recovery_owner
+      ; error : publication_recovery_registry_error
+      }
+
+type publication_recovery_owner_inventory_error =
+  Atomic_write.publication_recovery_owner_inventory_error =
+  | Publication_recovery_registry_inventory_in_progress
+  | Publication_recovery_registry_inventory_failed of
+      publication_recovery_registry_error
+
+type publication_recovery_owner_block =
+  Atomic_write.publication_recovery_owner_block =
+  | Publication_recovery_owner_inventory_block of
+      publication_recovery_owner_inventory_row
+  | Publication_recovery_owner_report_block of
+      publication_recovery_reconciliation_report
+  | Publication_recovery_owner_crash_block of
+      { owner : publication_recovery_owner
+      ; exception_ : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+  | Publication_recovery_owner_cancelled_block of
+      { owner : publication_recovery_owner
+      ; reason : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+  | Publication_recovery_owner_activation_rejected_block of
+      publication_recovery_owner
+
+type publication_recovery_reconciliation_error =
+  Atomic_write.publication_recovery_reconciliation_error =
+  | Publication_recovery_owner_inventory_required of
+      publication_recovery_owner
+  | Publication_recovery_owner_inventory_in_progress of
+      publication_recovery_owner
+  | Publication_recovery_owner_not_in_inventory of
+      publication_recovery_owner
+  | Publication_recovery_owner_reconciliation_in_progress of
+      publication_recovery_owner
+  | Publication_recovery_owner_inventory_prevents_reconciliation of
+      publication_recovery_owner_inventory_row
+  | Publication_recovery_owner_reconciliation_crashed of
+      { owner : publication_recovery_owner
+      ; exception_ : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+  | Publication_recovery_owner_reconciliation_cancelled of
+      { owner : publication_recovery_owner
+      ; reason : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+  | Publication_recovery_owner_activation_rejected of
+      publication_recovery_owner
+
+type publication_recovery_activation_rejection_error =
+  Atomic_write.publication_recovery_activation_rejection_error =
+  | Publication_recovery_activation_inventory_required of
+      publication_recovery_owner
+  | Publication_recovery_activation_inventory_in_progress of
+      publication_recovery_owner
+  | Publication_recovery_activation_owner_not_in_inventory of
+      publication_recovery_owner
+  | Publication_recovery_activation_owner_reconciliation_running of
+      publication_recovery_owner
+  | Publication_recovery_activation_owner_already_ready of
+      publication_recovery_owner
+  | Publication_recovery_activation_owner_already_blocked of
+      publication_recovery_owner_block
+
+type publication_recovery_lane_reconciliation_error =
+  Atomic_write.publication_recovery_lane_reconciliation_error =
+  | Publication_recovery_reconciliation_required of
+      publication_recovery_owner
+  | Publication_recovery_reconciliation_in_progress of
+      publication_recovery_owner
+  | Publication_recovery_reconciliation_blocked of
+      publication_recovery_owner_block
+
+type publication_recovery_record_area =
+  Atomic_write.publication_recovery_record_area =
+  | Publication_recovery_active
+  | Publication_recovery_owned
+  | Publication_recovery_forensic
+
+type publication_recovery_source_state =
+  Atomic_write.publication_recovery_source_state =
+  | Publication_recovery_prepared_source
+  | Publication_recovery_bound_source
+
+type publication_recovery_prepared_outcome_kind =
+  Atomic_write.publication_recovery_prepared_outcome_kind =
+  | Publication_recovery_prepared_unmaterialized
+  | Publication_recovery_prepared_allowed_root_mismatch
+  | Publication_recovery_prepared_parent_mismatch
+  | Publication_recovery_prepared_unbound_stage_preserved
+
+type publication_recovery_bound_outcome_kind =
+  Atomic_write.publication_recovery_bound_outcome_kind =
+  | Publication_recovery_bound_stage_absent
+  | Publication_recovery_bound_allowed_root_mismatch
+  | Publication_recovery_bound_parent_mismatch
+  | Publication_recovery_bound_stage_mismatch
+  | Publication_recovery_bound_stage_preserved
+
+type publication_recovery_reconciliation_row_kind =
+  Atomic_write.publication_recovery_reconciliation_row_kind =
+  | Publication_recovery_unexpected_lane_entry
+  | Publication_recovery_missing_lane_entry
+  | Publication_recovery_lane_entry_unavailable
+  | Publication_recovery_area_inventory_unavailable
+  | Publication_recovery_source_transition_capabilities_unavailable
+  | Publication_recovery_prepared_reconciled of
+      publication_recovery_prepared_outcome_kind
+  | Publication_recovery_bound_reconciled of
+      publication_recovery_bound_outcome_kind
+  | Publication_recovery_existing_forensic_record of
+      publication_recovery_source_state
+  | Publication_recovery_conflicting_source_records
+  | Publication_recovery_invalid_record_name
+  | Publication_recovery_unexpected_record_kind
+  | Publication_recovery_missing_record_entry
+  | Publication_recovery_record_entry_unavailable
+  | Publication_recovery_corrupt_record_preserved
+  | Publication_recovery_record_observation_failed
+  | Publication_recovery_record_transition_failed
+  | Publication_recovery_record_scope_release_failed
+  | Publication_recovery_owner_store_release_failed
+  | Publication_recovery_owner_store_unavailable
+  | Publication_recovery_owner_inventory_unavailable
+
+let open_publication_recovery_registry =
+  Atomic_write.open_publication_recovery_registry
+;;
+
+let publication_recovery_registry_error_to_string =
+  Atomic_write.publication_recovery_registry_error_to_string
+;;
+
+let inventory_publication_recovery_owners =
+  Atomic_write.inventory_publication_recovery_owners
+;;
+
+let publication_recovery_owner_to_string =
+  Atomic_write.publication_recovery_owner_to_string
+;;
+
+let reconcile_publication_recovery_owner =
+  Atomic_write.reconcile_publication_recovery_owner
+;;
+
+let reject_publication_recovery_owner_activation =
+  Atomic_write.reject_publication_recovery_owner_activation
+;;
+
+let publication_recovery_reconciliation_report_owner =
+  Atomic_write.publication_recovery_reconciliation_report_owner
+;;
+
+let publication_recovery_reconciliation_report_is_ready =
+  Atomic_write.publication_recovery_reconciliation_report_is_ready
+;;
+
+let publication_recovery_reconciliation_report_row_kinds =
+  Atomic_write.publication_recovery_reconciliation_report_row_kinds
+;;
+
+let publication_recovery_reconciliation_report_to_string =
+  Atomic_write.publication_recovery_reconciliation_report_to_string
+;;
+
+let publication_recovery_reconciliation_report_to_yojson =
+  Atomic_write.publication_recovery_reconciliation_report_to_yojson
+;;
+
+let publication_recovery_owner_inventory_row_to_string =
+  Atomic_write.publication_recovery_owner_inventory_row_to_string
+;;
+
+let publication_recovery_owner_inventory_error_to_string =
+  Atomic_write.publication_recovery_owner_inventory_error_to_string
+;;
+
+let publication_recovery_reconciliation_error_to_string =
+  Atomic_write.publication_recovery_reconciliation_error_to_string
+;;
+
+let publication_recovery_owner_block_to_string =
+  Atomic_write.publication_recovery_owner_block_to_string
+;;
+
+let publication_recovery_activation_rejection_error_to_string =
+  Atomic_write.publication_recovery_activation_rejection_error_to_string
+;;
+
+let with_publication_recovery_lane = Atomic_write.with_publication_recovery_lane
+
+let await_publication_recovery_lane_reconciliation =
+  Atomic_write.await_publication_recovery_lane_reconciliation
+;;
+
+let publication_recovery_lane_open_error_to_string =
+  Atomic_write.publication_recovery_lane_open_error_to_string
+;;
+
+let publication_recovery_lane_reconciliation_error =
+  Atomic_write.publication_recovery_lane_reconciliation_error
+;;
+
+let atomic_replace_recovery_target = Atomic_write.atomic_replace_recovery_target
+
+let atomic_replace_recovery_target_error_to_string =
+  Atomic_write.atomic_replace_recovery_target_error_to_string
+;;
+
+type capability_write_operation = Atomic_write.capability_write_operation =
+  | Atomic_replace_operation
+  | Create_exclusive_operation
 
 type capability_write_stage = Atomic_write.capability_write_stage =
   | Validate_leaf
   | Acquire_mutation_lease
+  | Acquire_publication_lease
+  | Inspect_target_entry
+  | Verify_target_binding
+  | Prepare_recovery_obligation
   | Create_staging_directory
   | Inspect_staging_directory
   | Acquire_staging_directory
   | Apply_staging_directory_permissions
   | Verify_staging_directory_identity
+  | Preserve_unbound_recovery_obligation
+  | Bind_recovery_obligation
   | Create_staging_entry
   | Create_target_entry
   | Inspect_open_resource
@@ -274,6 +522,8 @@ type capability_write_stage = Atomic_write.capability_write_stage =
   | Sync_parent
   | Remove_staging_directory
   | Close_staging_directory
+  | Discharge_prepared_recovery_obligation
+  | Discharge_bound_recovery_obligation
   | Cleanup_close
   | Cleanup_verify_identity
   | Cleanup_unlink
@@ -304,6 +554,7 @@ type capability_write_payload_failure = Atomic_write.capability_write_payload_fa
 
 type capability_write_cause = Atomic_write.capability_write_cause =
   | Invalid_leaf of string
+  | Invalid_recovery_target of atomic_replace_recovery_target_error
   | Mutation_contended
   | Posix_descriptor_unavailable
   | Unexpected_resource_kind of Eio.File.Stat.kind
@@ -317,11 +568,83 @@ type capability_write_failure = Atomic_write.capability_write_failure =
   ; cause : capability_write_cause
   }
 
+type capability_recovery_phase = Atomic_write.capability_recovery_phase =
+  | Recovery_validate_owner
+  | Recovery_open_registry
+  | Recovery_open_store
+  | Recovery_prepare
+  | Recovery_preserve_unbound
+  | Recovery_bind
+  | Recovery_discharge_prepared
+  | Recovery_discharge_bound
+
+type capability_recovery_removal_transition =
+  Atomic_write.capability_recovery_removal_transition =
+  | Recovery_discharge_active
+  | Recovery_discharge_owned
+  | Recovery_active_to_owned
+  | Recovery_active_to_forensic
+  | Recovery_owned_to_forensic
+
+type capability_recovery_effect = Atomic_write.capability_recovery_effect =
+  | Recovery_no_record_change
+  | Recovery_layout_may_be_incomplete
+  | Recovery_layout_ready
+  | Recovery_active_record_state_unknown
+  | Recovery_active_record_durable
+  | Recovery_active_record_discharged
+  | Recovery_owned_record_state_unknown_with_active
+  | Recovery_owned_record_durable_with_active
+  | Recovery_owned_record_durable
+  | Recovery_owned_record_discharged
+  | Recovery_forensic_record_state_unknown_with_source
+  | Recovery_forensic_record_durable_with_source
+  | Recovery_forensic_record_durable
+  | Recovery_source_removal_durability_unknown of
+      capability_recovery_removal_transition
+
+type capability_recovery_failure = Atomic_write.capability_recovery_failure
+
+let capability_recovery_phase_to_string =
+  Atomic_write.capability_recovery_phase_to_string
+;;
+
+let capability_recovery_effect_to_string =
+  Atomic_write.capability_recovery_effect_to_string
+;;
+
+let capability_recovery_failure_phase =
+  Atomic_write.capability_recovery_failure_phase
+;;
+
+let capability_recovery_failure_effect =
+  Atomic_write.capability_recovery_failure_effect
+;;
+
+let capability_recovery_failure_to_string =
+  Atomic_write.capability_recovery_failure_to_string
+;;
+
+type capability_recovery_access_failure =
+  Atomic_write.capability_recovery_access_failure =
+  | Recovery_access_not_available
+
+type capability_write_primary_failure =
+  Atomic_write.capability_write_primary_failure =
+  | Write_primary_failure of capability_write_failure
+  | Recovery_primary_failure of capability_recovery_failure
+  | Recovery_access_primary_failure of capability_recovery_access_failure
+
+type capability_write_cleanup_failure =
+  Atomic_write.capability_write_cleanup_failure =
+  | Write_cleanup_failure of capability_write_failure
+  | Recovery_cleanup_failure of capability_recovery_failure
+
 type capability_write_error = Atomic_write.capability_write_error =
-  { intent : capability_write_intent
+  { operation : capability_write_operation
   ; target_effect : capability_write_target_effect
-  ; failure : capability_write_failure
-  ; cleanup_failures : capability_write_failure list
+  ; primary_failure : capability_write_primary_failure
+  ; cleanup_failures : capability_write_cleanup_failure list
   }
 
 type capability_directory_sync_error = Atomic_write.capability_directory_sync_error =
@@ -329,17 +652,35 @@ type capability_directory_sync_error = Atomic_write.capability_directory_sync_er
   ; cleanup_failures : capability_write_failure list
   }
 
+type publication_recovery_fixture_error =
+  Atomic_write.publication_recovery_fixture_error
+
+let publication_recovery_fixture_error_to_string =
+  Atomic_write.publication_recovery_fixture_error_to_string
+;;
+
 type capability_write_cancellation = Atomic_write.capability_write_cancellation =
-  { intent : capability_write_intent
+  { operation : capability_write_operation
   ; target_effect : capability_write_target_effect
-  ; cleanup_failures : capability_write_failure list
+  ; interrupted_primary_failure : capability_write_primary_failure option
+  ; interrupted_recovery : capability_recovery_failure option
+  ; cleanup_failures : capability_write_cleanup_failure list
   }
 
 exception Capability_write_cancelled = Atomic_write.Capability_write_cancelled
 
-let publish_capability_file = Atomic_write.publish_capability_file
+let replace_capability_file = Atomic_write.replace_capability_file
+
+let create_capability_file_exclusive =
+  Atomic_write.create_capability_file_exclusive
+;;
+
 let capability_write_error_to_string = Atomic_write.capability_write_error_to_string
-let capability_write_intent_to_string = Atomic_write.capability_write_intent_to_string
+
+let capability_write_operation_to_string =
+  Atomic_write.capability_write_operation_to_string
+;;
+
 let capability_write_stage_to_string = Atomic_write.capability_write_stage_to_string
 
 let capability_write_target_effect_to_string =
@@ -355,8 +696,136 @@ let capability_directory_sync_error_to_string =
 ;;
 
 module Capability_write_for_testing = struct
-  let publish_capability_file =
-    Atomic_write.Capability_write_for_testing.publish_capability_file
+  type resource_scope_callback =
+    Atomic_write.Capability_write_for_testing.resource_scope_callback =
+    | Return_completed_rows of string list
+    | Cancel_callback of exn
+
+  type resource_scope_evidence =
+    Atomic_write.Capability_write_for_testing.resource_scope_evidence =
+    | Returned_rows of
+        { completed_rows : string list
+        ; release_failure : exn option
+        }
+    | Cancelled_callback of
+        { reason : exn
+        ; release_failure : exn option
+        }
+    | Raised_callback of
+        { exception_ : exn
+        ; release_failure : exn option
+        }
+
+  type reconciliation_interruption =
+    Atomic_write.Capability_write_for_testing.reconciliation_interruption =
+    | Cancel_reconciliation of exn
+    | Crash_reconciliation of exn
+
+  type cleanup_body =
+    Atomic_write.Capability_write_for_testing.cleanup_body =
+    | Return_cleanup_value of string
+    | Raise_cleanup_body of exn
+    | Cancel_cleanup_body of exn
+
+  type observed_cleanup_failure =
+    Atomic_write.Capability_write_for_testing.observed_cleanup_failure =
+    { exception_ : exn
+    ; backtrace : Printexc.raw_backtrace
+    }
+
+  type cleanup_evidence =
+    Atomic_write.Capability_write_for_testing.cleanup_evidence =
+    | Cleanup_returned of string
+    | Cleanup_failed_without_cancellation of
+        { body : observed_cleanup_failure option
+        ; cleanup : observed_cleanup_failure
+        }
+    | Cancellation_primary_with_cleanup_failure of
+        { body : observed_cleanup_failure option
+        ; cancellation : observed_cleanup_failure
+        ; cleanup : observed_cleanup_failure
+        }
+    | Body_failure_during_cancellation of
+        { body : observed_cleanup_failure
+        ; cancellation : observed_cleanup_failure
+        }
+    | Cancellation_primary of observed_cleanup_failure
+    | Cleanup_boundary_raised of observed_cleanup_failure
+
+  type single_borrow_evidence =
+    Atomic_write.Capability_write_for_testing.single_borrow_evidence =
+    | Single_borrow_balance of
+        { during_borrow : int
+        ; after_release : int
+        ; close_completed : bool
+        }
+    | Single_borrow_rejected
+    | Single_borrow_invariant of invariant_violation
+    | Single_borrow_raised of observed_cleanup_failure
+
+  and invariant_violation =
+    Atomic_write.Capability_write_for_testing.invariant_violation =
+    | Borrow_count_underflow
+    | Borrow_count_overflow
+    | Closing_without_active_borrows
+    | Closed_with_active_borrows of int
+    | Closed_without_drain_signal
+    | Drain_signal_already_resolved
+    | Inventory_finished_outside_running
+    | Reconciliation_finished_before_inventory
+    | Reconciliation_owner_not_running of string
+    | Reconciliation_settled_twice of string
+    | Reconciliation_settled_before_terminal of string
+    | Cleanup_body_outcome_lost
+
+  type owner_settlement =
+    Atomic_write.Capability_write_for_testing.owner_settlement =
+    | Owner_untracked
+    | Owner_unsettled
+    | Owner_settled
+
+  let run_publication_recovery_resource_scope =
+    Atomic_write.Capability_write_for_testing.run_publication_recovery_resource_scope
+  ;;
+
+  let interrupt_publication_recovery_reconciliation =
+    Atomic_write.Capability_write_for_testing.interrupt_publication_recovery_reconciliation
+  ;;
+
+  let run_publication_recovery_cleanup_boundary =
+    Atomic_write.Capability_write_for_testing.run_publication_recovery_cleanup_boundary
+  ;;
+
+  let single_publication_recovery_borrow_balance =
+    Atomic_write.Capability_write_for_testing.single_publication_recovery_borrow_balance
+  ;;
+
+  let publication_recovery_owner_settlement =
+    Atomic_write.Capability_write_for_testing.publication_recovery_owner_settlement
+  ;;
+
+  let publication_recovery_stage_name =
+    Atomic_write.Capability_write_for_testing.publication_recovery_stage_name
+  ;;
+
+  let replace_capability_file =
+    Atomic_write.Capability_write_for_testing.replace_capability_file
+  ;;
+
+  let create_capability_file_exclusive =
+    Atomic_write.Capability_write_for_testing.create_capability_file_exclusive
+  ;;
+
+  let seed_prepared_publication_recovery =
+    Atomic_write.Capability_write_for_testing.seed_prepared_publication_recovery
+  ;;
+
+  let seed_bound_publication_recovery =
+    Atomic_write.Capability_write_for_testing.seed_bound_publication_recovery
+  ;;
+
+  let write_raw_publication_recovery_record =
+    Atomic_write.Capability_write_for_testing.write_raw_publication_recovery_record
   ;;
 
   let sync_directory_capability =
@@ -1288,66 +1757,6 @@ let rec lock_whole_file fd =
   | exception Unix.Unix_error (Unix.EINTR, _, _) -> lock_whole_file fd
 ;;
 
-module Append_inode_key = struct
-  type t = int64 * int64
-
-  let equal (left_dev, left_ino) (right_dev, right_ino) =
-    Int64.equal left_dev right_dev && Int64.equal left_ino right_ino
-  ;;
-
-  let hash = Hashtbl.hash
-end
-
-module Append_inode_table = Hashtbl.Make (Append_inode_key)
-
-type append_inode_entry =
-  { held : bool Atomic.t
-  ; mutable users : int
-  }
-
-type append_inode_lease =
-  { key : Append_inode_key.t
-  ; entry : append_inode_entry
-  }
-
-let append_inode_registry_mu = Stdlib.Mutex.create ()
-let append_inode_registry = Append_inode_table.create 0
-
-let release_append_inode_user key entry =
-  Stdlib.Mutex.protect append_inode_registry_mu (fun () ->
-    entry.users <- entry.users - 1;
-    if entry.users = 0
-    then
-      match Append_inode_table.find_opt append_inode_registry key with
-      | Some current when current == entry ->
-        Append_inode_table.remove append_inode_registry key
-      | Some _ | None -> ())
-;;
-
-let try_acquire_append_inode key =
-  let entry =
-    Stdlib.Mutex.protect append_inode_registry_mu (fun () ->
-      match Append_inode_table.find_opt append_inode_registry key with
-      | Some entry ->
-        entry.users <- entry.users + 1;
-        entry
-      | None ->
-        let entry = { held = Atomic.make false; users = 1 } in
-        Append_inode_table.add append_inode_registry key entry;
-        entry)
-  in
-  if Atomic.compare_and_set entry.held false true
-  then Some { key; entry }
-  else (
-    release_append_inode_user key entry;
-    None)
-;;
-
-let release_append_inode { key; entry } =
-  Atomic.set entry.held false;
-  release_append_inode_user key entry
-;;
-
 type capability_append_operation_failure =
   { exception_ : exn
   ; backtrace : Printexc.raw_backtrace
@@ -1355,7 +1764,6 @@ type capability_append_operation_failure =
 
 type capability_append_failure =
   | Capability_append_posix_descriptor_unavailable
-  | Capability_append_inode_contended
   | Capability_append_mutation_contended
   | Capability_append_operation_failed of capability_append_operation_failure
 
@@ -1388,10 +1796,8 @@ type capability_append_file =
 let capability_append_failure_to_string = function
   | Capability_append_posix_descriptor_unavailable ->
     "POSIX descriptor unavailable"
-  | Capability_append_inode_contended ->
-    "append inode is busy in another cooperative writer"
   | Capability_append_mutation_contended ->
-    "append entry is busy in another cooperative writer"
+    "append target identity is busy in another cooperative writer"
   | Capability_append_operation_failed { exception_; _ } ->
     Printexc.to_string exception_
 ;;
@@ -1589,9 +1995,12 @@ let append_capability_observed_with ~after_write file content =
     | Ok parent_stat ->
       (match
          Capability_mutation_lease.try_acquire
-           ~parent_dev:parent_stat.dev
-           ~parent_ino:parent_stat.ino
-           ~leaf
+           (Capability_mutation_lease.Existing_target
+              { target_dev = opened_stat.dev
+              ; target_ino = opened_stat.ino
+              ; parent_dev = parent_stat.dev
+              ; parent_ino = parent_stat.ino
+              })
        with
        | None ->
          capability_append_outcome
@@ -1619,47 +2028,31 @@ let append_capability_observed_with ~after_write file content =
                   ~target_binding:Capability_append_target_verified
                   ()
               | Some fd ->
-                (match
-                   try_acquire_append_inode
-                     (opened_stat.dev, opened_stat.ino)
+                (try
+                   Eio_unix.run_in_systhread
+                     ~label:"fs-compat-open-file-append"
+                     (fun () ->
+                        Eio_unix.Fd.use_exn
+                          "fs-compat-open-file-append"
+                          fd
+                          (fun unix_fd ->
+                             append_fd_observed
+                               ~io:capability_append_unix_io
+                               ~fd:unix_fd
+                               content))
                  with
-                 | None ->
+                 | Eio.Cancel.Cancelled _ as cancellation -> raise cancellation
+                 | exception_ ->
+                   let backtrace = Printexc.get_raw_backtrace () in
                    capability_append_outcome
                      ~requested_bytes
-                     ~write_failure:Capability_append_inode_contended
+                     ~write_failure:
+                       (Capability_append_operation_failed
+                          (capability_append_operation_failure
+                             exception_
+                             backtrace))
                      ~target_binding:Capability_append_target_verified
-                     ()
-                 | Some lease ->
-                   Fun.protect
-                     ~finally:(fun () -> release_append_inode lease)
-                     (fun () ->
-                        try
-                          Eio_unix.run_in_systhread
-                            ~label:"fs-compat-open-file-append"
-                            (fun () ->
-                               Eio_unix.Fd.use_exn
-                                 "fs-compat-open-file-append"
-                                 fd
-                                 (fun unix_fd ->
-                                    append_fd_observed
-                                      ~io:capability_append_unix_io
-                                      ~fd:unix_fd
-                                      content))
-                        with
-                        | Eio.Cancel.Cancelled _ as cancellation ->
-                          raise cancellation
-                        | exception_ ->
-                          let backtrace = Printexc.get_raw_backtrace () in
-                          capability_append_outcome
-                            ~requested_bytes
-                            ~write_failure:
-                              (Capability_append_operation_failed
-                                 (capability_append_operation_failure
-                                    exception_
-                                    backtrace))
-                            ~target_binding:
-                              Capability_append_target_verified
-                            ()))
+                     ())
             in
             after_write ();
             let target_binding =

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -156,7 +156,6 @@ type capability_append_operation_failure =
 
 type capability_append_failure =
   | Capability_append_posix_descriptor_unavailable
-  | Capability_append_inode_contended
   | Capability_append_mutation_contended
   | Capability_append_operation_failed of capability_append_operation_failure
 
@@ -197,13 +196,15 @@ val open_capability_append_file
 val capability_append_file_stat : capability_append_file -> Eio.File.Stat.t
 
 (** Append through an opaque append capability without destructive rollback.
-    Cooperative same-process mutations of the same parent/leaf and appends to
-    the same inode use non-blocking leases. The leaf-to-open-file identity is
-    checked before and after the write, so an external rename is reported
-    rather than misclassified as a visible append. External processes are an
-    observation boundary, not an exclusion guarantee. Partial bytes and their
-    fsync result remain explicit. The caller owns the next cancellation
-    checkpoint. *)
+    Cooperative same-process mutations of the same opened target identity use
+    one shared non-blocking lease without lexical-name normalization. An active
+    absent-target publication under the same parent also excludes the append,
+    covering the transition from an absent name to a visible inode. The
+    leaf-to-open-file identity is checked before and after the write, so an
+    external rename is reported rather than misclassified as a visible append.
+    External processes are an observation boundary, not an exclusion
+    guarantee. Partial bytes and their fsync result remain explicit. The caller
+    owns the next cancellation checkpoint. *)
 val append_capability_observed
   :  capability_append_file
   -> string
@@ -228,18 +229,283 @@ module Capability_append_for_testing : sig
     -> capability_append_outcome
 end
 
-type capability_write_intent =
-  | Atomic_replace
-  | Create_exclusive
+type atomic_replace_recovery_target
+type atomic_replace_recovery_target_error
+type publication_recovery_access
+type publication_recovery_registry
+type publication_recovery_registry_error
+type publication_recovery_lane_open_error
+type publication_recovery_owner
+type publication_recovery_reconciliation_report
+
+type publication_recovery_owner_inventory_row =
+  | Publication_recovery_valid_owner of publication_recovery_owner
+  | Publication_recovery_invalid_owner_name of string
+  | Publication_recovery_unexpected_owner_kind of
+      { owner : publication_recovery_owner
+      ; kind : Eio.File.Stat.kind
+      }
+  | Publication_recovery_missing_owner_entry of publication_recovery_owner
+  | Publication_recovery_owner_entry_unavailable of
+      { owner : publication_recovery_owner
+      ; error : publication_recovery_registry_error
+      }
+
+type publication_recovery_owner_inventory_error =
+  | Publication_recovery_registry_inventory_in_progress
+  | Publication_recovery_registry_inventory_failed of
+      publication_recovery_registry_error
+
+type publication_recovery_owner_block =
+  | Publication_recovery_owner_inventory_block of
+      publication_recovery_owner_inventory_row
+  | Publication_recovery_owner_report_block of
+      publication_recovery_reconciliation_report
+  | Publication_recovery_owner_crash_block of
+      { owner : publication_recovery_owner
+      ; exception_ : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+  | Publication_recovery_owner_cancelled_block of
+      { owner : publication_recovery_owner
+      ; reason : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+  | Publication_recovery_owner_activation_rejected_block of
+      publication_recovery_owner
+
+type publication_recovery_reconciliation_error =
+  | Publication_recovery_owner_inventory_required of
+      publication_recovery_owner
+  | Publication_recovery_owner_inventory_in_progress of
+      publication_recovery_owner
+  | Publication_recovery_owner_not_in_inventory of
+      publication_recovery_owner
+  | Publication_recovery_owner_reconciliation_in_progress of
+      publication_recovery_owner
+  | Publication_recovery_owner_inventory_prevents_reconciliation of
+      publication_recovery_owner_inventory_row
+  | Publication_recovery_owner_reconciliation_crashed of
+      { owner : publication_recovery_owner
+      ; exception_ : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+  | Publication_recovery_owner_reconciliation_cancelled of
+      { owner : publication_recovery_owner
+      ; reason : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+  | Publication_recovery_owner_activation_rejected of
+      publication_recovery_owner
+
+type publication_recovery_activation_rejection_error =
+  | Publication_recovery_activation_inventory_required of
+      publication_recovery_owner
+  | Publication_recovery_activation_inventory_in_progress of
+      publication_recovery_owner
+  | Publication_recovery_activation_owner_not_in_inventory of
+      publication_recovery_owner
+  | Publication_recovery_activation_owner_reconciliation_running of
+      publication_recovery_owner
+  | Publication_recovery_activation_owner_already_ready of
+      publication_recovery_owner
+  | Publication_recovery_activation_owner_already_blocked of
+      publication_recovery_owner_block
+
+type publication_recovery_lane_reconciliation_error =
+  | Publication_recovery_reconciliation_required of
+      publication_recovery_owner
+  | Publication_recovery_reconciliation_in_progress of
+      publication_recovery_owner
+  | Publication_recovery_reconciliation_blocked of
+      publication_recovery_owner_block
+
+type publication_recovery_record_area =
+  | Publication_recovery_active
+  | Publication_recovery_owned
+  | Publication_recovery_forensic
+
+type publication_recovery_source_state =
+  | Publication_recovery_prepared_source
+  | Publication_recovery_bound_source
+
+type publication_recovery_prepared_outcome_kind =
+  | Publication_recovery_prepared_unmaterialized
+  | Publication_recovery_prepared_allowed_root_mismatch
+  | Publication_recovery_prepared_parent_mismatch
+  | Publication_recovery_prepared_unbound_stage_preserved
+
+type publication_recovery_bound_outcome_kind =
+  | Publication_recovery_bound_stage_absent
+  | Publication_recovery_bound_allowed_root_mismatch
+  | Publication_recovery_bound_parent_mismatch
+  | Publication_recovery_bound_stage_mismatch
+  | Publication_recovery_bound_stage_preserved
+
+type publication_recovery_reconciliation_row_kind =
+  | Publication_recovery_unexpected_lane_entry
+  | Publication_recovery_missing_lane_entry
+  | Publication_recovery_lane_entry_unavailable
+  | Publication_recovery_area_inventory_unavailable
+  | Publication_recovery_source_transition_capabilities_unavailable
+  | Publication_recovery_prepared_reconciled of
+      publication_recovery_prepared_outcome_kind
+  | Publication_recovery_bound_reconciled of
+      publication_recovery_bound_outcome_kind
+  | Publication_recovery_existing_forensic_record of
+      publication_recovery_source_state
+  | Publication_recovery_conflicting_source_records
+  | Publication_recovery_invalid_record_name
+  | Publication_recovery_unexpected_record_kind
+  | Publication_recovery_missing_record_entry
+  | Publication_recovery_record_entry_unavailable
+  | Publication_recovery_corrupt_record_preserved
+  | Publication_recovery_record_observation_failed
+  | Publication_recovery_record_transition_failed
+  | Publication_recovery_record_scope_release_failed
+  | Publication_recovery_owner_store_release_failed
+  | Publication_recovery_owner_store_unavailable
+  | Publication_recovery_owner_inventory_unavailable
+
+(** Open the process-lifetime publication recovery registry below a
+    caller-owned MASC root capability. The registry remains valid for exactly
+    the lifetime of [sw]. *)
+val open_publication_recovery_registry
+  :  sw:Eio.Switch.t
+  -> registry_root:Eio.Fs.dir_ty Eio.Path.t
+  -> (publication_recovery_registry, publication_recovery_registry_error) result
+
+val publication_recovery_registry_error_to_string
+  :  publication_recovery_registry_error
+  -> string
+
+(** Inventory the exact lane registry. MASC must validate each valid opaque
+    owner's string through [Keeper_id.Keeper_name] before reconciliation. *)
+val inventory_publication_recovery_owners
+  :  publication_recovery_registry
+  -> ( publication_recovery_owner_inventory_row list
+       , publication_recovery_owner_inventory_error )
+       result
+
+val publication_recovery_owner_to_string
+  :  publication_recovery_owner
+  -> string
+
+(** Startup/report-only reconciliation of one caller-validated owner. The
+    target tree is never scanned or mutated. *)
+val reconcile_publication_recovery_owner
+  :  fs:Eio.Fs.dir_ty Eio.Path.t
+  -> registry:publication_recovery_registry
+  -> owner:publication_recovery_owner
+  -> ( publication_recovery_reconciliation_report
+       , publication_recovery_reconciliation_error )
+       result
+
+val reject_publication_recovery_owner_activation
+  :  registry:publication_recovery_registry
+  -> owner:publication_recovery_owner
+  -> (unit, publication_recovery_activation_rejection_error) result
+
+val publication_recovery_reconciliation_report_owner
+  :  publication_recovery_reconciliation_report
+  -> string
+
+val publication_recovery_reconciliation_report_is_ready
+  :  publication_recovery_reconciliation_report
+  -> bool
+
+val publication_recovery_reconciliation_report_row_kinds
+  :  publication_recovery_reconciliation_report
+  -> publication_recovery_reconciliation_row_kind list
+
+val publication_recovery_reconciliation_report_to_string
+  :  publication_recovery_reconciliation_report
+  -> string
+
+(** Constructor-directed structured report projection. Callers can observe row
+    identity and nested evidence without parsing diagnostic strings. *)
+val publication_recovery_reconciliation_report_to_yojson
+  :  publication_recovery_reconciliation_report
+  -> Yojson.Safe.t
+
+val publication_recovery_owner_inventory_row_to_string
+  :  publication_recovery_owner_inventory_row
+  -> string
+
+val publication_recovery_owner_inventory_error_to_string
+  :  publication_recovery_owner_inventory_error
+  -> string
+
+val publication_recovery_reconciliation_error_to_string
+  :  publication_recovery_reconciliation_error
+  -> string
+
+val publication_recovery_owner_block_to_string
+  :  publication_recovery_owner_block
+  -> string
+
+val publication_recovery_activation_rejection_error_to_string
+  :  publication_recovery_activation_rejection_error
+  -> string
+
+(** Pin one Keeper-owned publication recovery lane for the whole callback.
+    Publications borrow its store through the opaque access value. Closing
+    rejects new borrows and drains every already-started borrow without a
+    timeout or retry budget. *)
+val with_publication_recovery_lane
+  :  registry:publication_recovery_registry
+  -> owner:string
+  -> (publication_recovery_access -> 'a)
+  -> ('a, publication_recovery_lane_open_error) result
+
+(** Await only the exact owner's reconciliation settlement. There is no
+    timeout, polling, retry, or global activation barrier. *)
+val await_publication_recovery_lane_reconciliation
+  :  registry:publication_recovery_registry
+  -> owner:string
+  -> (unit, publication_recovery_lane_open_error) result
+
+val publication_recovery_lane_open_error_to_string
+  :  publication_recovery_lane_open_error
+  -> string
+
+val publication_recovery_lane_reconciliation_error
+  :  publication_recovery_lane_open_error
+  -> publication_recovery_lane_reconciliation_error option
+
+(** Build the immutable recovery locator projection used by
+    {!replace_capability_file}. *)
+val atomic_replace_recovery_target
+  :  allowed_root_path:string
+  -> allowed_root_device:int64
+  -> allowed_root_inode:int64
+  -> parent_components:string list
+  -> target_leaf:string
+  -> permissions:int
+  -> (atomic_replace_recovery_target, atomic_replace_recovery_target_error) result
+
+val atomic_replace_recovery_target_error_to_string
+  :  atomic_replace_recovery_target_error
+  -> string
+
+type capability_write_operation =
+  | Atomic_replace_operation
+  | Create_exclusive_operation
 
 type capability_write_stage =
   | Validate_leaf
   | Acquire_mutation_lease
+  | Acquire_publication_lease
+  | Inspect_target_entry
+  | Verify_target_binding
+  | Prepare_recovery_obligation
   | Create_staging_directory
   | Inspect_staging_directory
   | Acquire_staging_directory
   | Apply_staging_directory_permissions
   | Verify_staging_directory_identity
+  | Preserve_unbound_recovery_obligation
+  | Bind_recovery_obligation
   | Create_staging_entry
   | Create_target_entry
   | Inspect_open_resource
@@ -253,6 +519,8 @@ type capability_write_stage =
   | Sync_parent
   | Remove_staging_directory
   | Close_staging_directory
+  | Discharge_prepared_recovery_obligation
+  | Discharge_bound_recovery_obligation
   | Cleanup_close
   | Cleanup_verify_identity
   | Cleanup_unlink
@@ -282,6 +550,7 @@ type capability_write_payload_failure =
 
 type capability_write_cause =
   | Invalid_leaf of string
+  | Invalid_recovery_target of atomic_replace_recovery_target_error
   | Mutation_contended
   | Posix_descriptor_unavailable
   | Unexpected_resource_kind of Eio.File.Stat.kind
@@ -295,11 +564,73 @@ type capability_write_failure =
   ; cause : capability_write_cause
   }
 
+type capability_recovery_phase =
+  | Recovery_validate_owner
+  | Recovery_open_registry
+  | Recovery_open_store
+  | Recovery_prepare
+  | Recovery_preserve_unbound
+  | Recovery_bind
+  | Recovery_discharge_prepared
+  | Recovery_discharge_bound
+
+type capability_recovery_removal_transition =
+  | Recovery_discharge_active
+  | Recovery_discharge_owned
+  | Recovery_active_to_owned
+  | Recovery_active_to_forensic
+  | Recovery_owned_to_forensic
+
+type capability_recovery_effect =
+  | Recovery_no_record_change
+  | Recovery_layout_may_be_incomplete
+  | Recovery_layout_ready
+  | Recovery_active_record_state_unknown
+  | Recovery_active_record_durable
+  | Recovery_active_record_discharged
+  | Recovery_owned_record_state_unknown_with_active
+  | Recovery_owned_record_durable_with_active
+  | Recovery_owned_record_durable
+  | Recovery_owned_record_discharged
+  | Recovery_forensic_record_state_unknown_with_source
+  | Recovery_forensic_record_durable_with_source
+  | Recovery_forensic_record_durable
+  | Recovery_source_removal_durability_unknown of
+      capability_recovery_removal_transition
+
+type capability_recovery_failure
+
+val capability_recovery_phase_to_string : capability_recovery_phase -> string
+val capability_recovery_effect_to_string : capability_recovery_effect -> string
+
+val capability_recovery_failure_phase
+  :  capability_recovery_failure
+  -> capability_recovery_phase
+
+val capability_recovery_failure_effect
+  :  capability_recovery_failure
+  -> capability_recovery_effect
+
+val capability_recovery_failure_to_string
+  :  capability_recovery_failure
+  -> string
+
+type capability_recovery_access_failure = Recovery_access_not_available
+
+type capability_write_primary_failure =
+  | Write_primary_failure of capability_write_failure
+  | Recovery_primary_failure of capability_recovery_failure
+  | Recovery_access_primary_failure of capability_recovery_access_failure
+
+type capability_write_cleanup_failure =
+  | Write_cleanup_failure of capability_write_failure
+  | Recovery_cleanup_failure of capability_recovery_failure
+
 type capability_write_error =
-  { intent : capability_write_intent
+  { operation : capability_write_operation
   ; target_effect : capability_write_target_effect
-  ; failure : capability_write_failure
-  ; cleanup_failures : capability_write_failure list
+  ; primary_failure : capability_write_primary_failure
+  ; cleanup_failures : capability_write_cleanup_failure list
   }
 
 type capability_directory_sync_error =
@@ -307,28 +638,43 @@ type capability_directory_sync_error =
   ; cleanup_failures : capability_write_failure list
   }
 
+type publication_recovery_fixture_error
+
+val publication_recovery_fixture_error_to_string
+  :  publication_recovery_fixture_error
+  -> string
+
 type capability_write_cancellation =
-  { intent : capability_write_intent
+  { operation : capability_write_operation
   ; target_effect : capability_write_target_effect
-  ; cleanup_failures : capability_write_failure list
+  ; interrupted_primary_failure : capability_write_primary_failure option
+  ; interrupted_recovery : capability_recovery_failure option
+  ; cleanup_failures : capability_write_cleanup_failure list
   }
 
 exception Capability_write_cancelled of exn * capability_write_cancellation
 
-(** Publish below an already-open, caller-validated directory capability.
-    Atomic replacement and exclusive creation preserve exact permissions,
-    fsync the payload and parent, and return primary plus cleanup failures
-    without reopening the path from a global root. *)
-val publish_capability_file
+(** Durable replacement below an already-open target-parent capability.
+    Recovery access and the immutable target projection are mandatory. *)
+val replace_capability_file
+  :  recovery:publication_recovery_access
+  -> parent:Eio.Fs.dir_ty Eio.Path.t
+  -> target:atomic_replace_recovery_target
+  -> string
+  -> (unit, capability_write_error) result
+
+(** Exclusive creation is physically separate from replacement and has no
+    recovery-obligation argument. Once the public leaf is created it is never
+    unlinked by failure cleanup. *)
+val create_capability_file_exclusive
   :  parent:Eio.Fs.dir_ty Eio.Path.t
   -> leaf:string
-  -> intent:capability_write_intent
   -> permissions:int
   -> string
   -> (unit, capability_write_error) result
 
 val capability_write_error_to_string : capability_write_error -> string
-val capability_write_intent_to_string : capability_write_intent -> string
+val capability_write_operation_to_string : capability_write_operation -> string
 val capability_write_stage_to_string : capability_write_stage -> string
 
 val capability_write_target_effect_to_string
@@ -347,14 +693,169 @@ val capability_directory_sync_error_to_string
   -> string
 
 module Capability_write_for_testing : sig
-  val publish_capability_file
+  type resource_scope_callback =
+    | Return_completed_rows of string list
+    | Cancel_callback of exn
+
+  type resource_scope_evidence =
+    | Returned_rows of
+        { completed_rows : string list
+        ; release_failure : exn option
+        }
+    | Cancelled_callback of
+        { reason : exn
+        ; release_failure : exn option
+        }
+    | Raised_callback of
+        { exception_ : exn
+        ; release_failure : exn option
+        }
+
+  type reconciliation_interruption =
+    | Cancel_reconciliation of exn
+    | Crash_reconciliation of exn
+
+  type cleanup_body =
+    | Return_cleanup_value of string
+    | Raise_cleanup_body of exn
+    | Cancel_cleanup_body of exn
+
+  type observed_cleanup_failure =
+    { exception_ : exn
+    ; backtrace : Printexc.raw_backtrace
+    }
+
+  type cleanup_evidence =
+    | Cleanup_returned of string
+    | Cleanup_failed_without_cancellation of
+        { body : observed_cleanup_failure option
+        ; cleanup : observed_cleanup_failure
+        }
+    | Cancellation_primary_with_cleanup_failure of
+        { body : observed_cleanup_failure option
+        ; cancellation : observed_cleanup_failure
+        ; cleanup : observed_cleanup_failure
+        }
+    | Body_failure_during_cancellation of
+        { body : observed_cleanup_failure
+        ; cancellation : observed_cleanup_failure
+        }
+    | Cancellation_primary of observed_cleanup_failure
+    | Cleanup_boundary_raised of observed_cleanup_failure
+
+  type single_borrow_evidence =
+    | Single_borrow_balance of
+        { during_borrow : int
+        ; after_release : int
+        ; close_completed : bool
+        }
+    | Single_borrow_rejected
+    | Single_borrow_invariant of invariant_violation
+    | Single_borrow_raised of observed_cleanup_failure
+
+  and invariant_violation =
+    | Borrow_count_underflow
+    | Borrow_count_overflow
+    | Closing_without_active_borrows
+    | Closed_with_active_borrows of int
+    | Closed_without_drain_signal
+    | Drain_signal_already_resolved
+    | Inventory_finished_outside_running
+    | Reconciliation_finished_before_inventory
+    | Reconciliation_owner_not_running of string
+    | Reconciliation_settled_twice of string
+    | Reconciliation_settled_before_terminal of string
+    | Cleanup_body_outcome_lost
+
+  type owner_settlement =
+    | Owner_untracked
+    | Owner_unsettled
+    | Owner_settled
+
+  val run_publication_recovery_resource_scope
+    :  callback:resource_scope_callback
+    -> release_failure:exn option
+    -> resource_scope_evidence
+
+  val interrupt_publication_recovery_reconciliation
+    :  fs:Eio.Fs.dir_ty Eio.Path.t
+    -> registry:publication_recovery_registry
+    -> owner:publication_recovery_owner
+    -> reconciliation_interruption
+    -> ( publication_recovery_reconciliation_report
+         , publication_recovery_reconciliation_error )
+         result
+
+  val run_publication_recovery_cleanup_boundary
+    :  body:cleanup_body
+    -> cleanup_failure:exn option
+    -> cleanup_evidence
+
+  val single_publication_recovery_borrow_balance
+    :  registry:publication_recovery_registry
+    -> owner:string
+    -> (single_borrow_evidence, publication_recovery_lane_open_error) result
+
+  val publication_recovery_owner_settlement
+    :  registry:publication_recovery_registry
+    -> owner:publication_recovery_owner
+    -> owner_settlement
+
+  val publication_recovery_stage_name : Uuidm.t -> string
+
+  val replace_capability_file
+    :  before_stage:(capability_write_stage -> unit)
+    -> recovery:publication_recovery_access
+    -> parent:Eio.Fs.dir_ty Eio.Path.t
+    -> target:atomic_replace_recovery_target
+    -> string
+    -> (unit, capability_write_error) result
+
+  val create_capability_file_exclusive
     :  before_stage:(capability_write_stage -> unit)
     -> parent:Eio.Fs.dir_ty Eio.Path.t
     -> leaf:string
-    -> intent:capability_write_intent
     -> permissions:int
     -> string
     -> (unit, capability_write_error) result
+
+  val seed_prepared_publication_recovery
+    :  registry:publication_recovery_registry
+    -> owner:string
+    -> operation_id:Uuidm.t
+    -> allowed_root_path:string
+    -> allowed_root_device:int64
+    -> allowed_root_inode:int64
+    -> parent_components:string list
+    -> parent_device:int64
+    -> parent_inode:int64
+    -> target_leaf:string
+    -> permissions:int
+    -> (unit, publication_recovery_fixture_error) result
+
+  val seed_bound_publication_recovery
+    :  registry:publication_recovery_registry
+    -> owner:string
+    -> operation_id:Uuidm.t
+    -> allowed_root_path:string
+    -> allowed_root_device:int64
+    -> allowed_root_inode:int64
+    -> parent_components:string list
+    -> parent_device:int64
+    -> parent_inode:int64
+    -> target_leaf:string
+    -> permissions:int
+    -> stage_device:int64
+    -> stage_inode:int64
+    -> (unit, publication_recovery_fixture_error) result
+
+  val write_raw_publication_recovery_record
+    :  registry:publication_recovery_registry
+    -> owner:string
+    -> area:publication_recovery_record_area
+    -> record_name:string
+    -> raw:string
+    -> (unit, publication_recovery_fixture_error) result
 
   val sync_directory_capability
     :  before_stage:(capability_write_stage -> unit)

--- a/lib/fs_compat/publication_recovery_access.ml
+++ b/lib/fs_compat/publication_recovery_access.ml
@@ -1,0 +1,1126 @@
+module Core = Capability_recovery_obligation
+module Reconciler = Capability_recovery_reconciler
+
+type owner = Core.owner
+
+type owner_inventory_row =
+  | Valid_owner of owner
+  | Invalid_owner_name of string
+  | Unexpected_owner_kind of
+      { owner : owner
+      ; kind : Eio.File.Stat.kind
+      }
+  | Missing_owner_entry of owner
+  | Owner_entry_unavailable of
+      { owner : owner
+      ; error : Core.transition_error
+      }
+
+type owner_inventory = owner_inventory_row list
+
+type inventory_error =
+  | Registry_inventory_in_progress
+  | Registry_inventory_failed of Core.transition_error
+
+type owner_block =
+  | Owner_inventory_block of owner_inventory_row
+  | Owner_reconciliation_block of Reconciler.report
+  | Owner_reconciliation_crash of
+      { owner : owner
+      ; exception_ : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+  | Owner_reconciliation_cancelled_block of
+      { owner : owner
+      ; reason : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+  | Owner_activation_rejected_block of owner
+
+type reconciliation_error =
+  | Owner_inventory_required of owner
+  | Owner_inventory_in_progress of owner
+  | Owner_not_in_inventory of owner
+  | Owner_reconciliation_in_progress of owner
+  | Owner_inventory_prevents_reconciliation of owner_inventory_row
+  | Owner_reconciliation_crashed of
+      { owner : owner
+      ; exception_ : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+  | Owner_reconciliation_cancelled of
+      { owner : owner
+      ; reason : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+  | Owner_activation_rejected of owner
+
+type activation_rejection_error =
+  | Activation_inventory_required of owner
+  | Activation_inventory_in_progress of owner
+  | Activation_owner_not_in_inventory of owner
+  | Activation_owner_reconciliation_running of owner
+  | Activation_owner_already_ready of owner
+  | Activation_owner_already_blocked of owner_block
+
+type readiness =
+  | Reconciliation_pending
+  | Reconciliation_running
+  | Reconciliation_ready of Reconciler.report
+  | Reconciliation_blocked_state of owner_block
+
+type readiness_entry =
+  { readiness : readiness
+  ; settled : unit Eio.Promise.t
+  ; resolve_settled : unit Eio.Promise.u
+  }
+
+module Owner_map = Map.Make (String)
+
+type registry_phase =
+  | Inventory_required
+  | Inventory_running
+  | Inventory_complete of
+      { rows : owner_inventory
+      ; readiness : readiness_entry Owner_map.t
+      }
+
+type registry =
+  { core : Core.registry
+  ; readiness_mutex : Eio.Mutex.t
+  ; mutable registry_phase : registry_phase
+  }
+
+type access_error = Keeper_lane_not_available
+
+type lane_open_error =
+  | Invalid_owner of Core.validation_error
+  | Reconciliation_required of owner
+  | Reconciliation_in_progress of owner
+  | Reconciliation_blocked of owner_block
+  | Store_failed of Core.transition_error
+
+type invariant_violation =
+  | Borrow_count_underflow
+  | Borrow_count_overflow
+  | Closing_without_active_borrows
+  | Closed_with_active_borrows of int
+  | Closed_without_drain_signal
+  | Drain_signal_already_resolved
+  | Inventory_finished_outside_running
+  | Reconciliation_finished_before_inventory
+  | Reconciliation_owner_not_running of string
+  | Reconciliation_settled_twice of string
+  | Reconciliation_settled_before_terminal of string
+  | Cleanup_body_outcome_lost
+
+exception Invariant_violation of invariant_violation
+
+type cleanup_failure =
+  { body : Eio.Exn.with_bt option
+  ; cancellation : Eio.Exn.with_bt option
+  ; cleanup : Eio.Exn.with_bt
+  }
+
+exception Cleanup_failed of cleanup_failure
+
+type body_failed_during_cancellation =
+  { body : Eio.Exn.with_bt
+  ; cancellation : Eio.Exn.with_bt
+  }
+
+exception Body_failed_during_cancellation of
+  body_failed_during_cancellation
+
+type reconciliation_crash_terminalization_failure =
+  { reconciliation : Eio.Exn.with_bt
+  ; terminalization : Eio.Exn.with_bt
+  }
+
+exception Reconciliation_crash_terminalization_failed of
+  reconciliation_crash_terminalization_failure
+
+type reconciliation_cancellation_terminalization_failure =
+  { cancellation : Eio.Exn.with_bt
+  ; terminalization : Eio.Exn.with_bt
+  }
+
+exception Reconciliation_cancellation_terminalization_failed of
+  reconciliation_cancellation_terminalization_failure
+
+type phase =
+  | Open
+  | Closing
+  | Closed
+
+type t =
+  { store : Core.store
+  ; mutex : Eio.Mutex.t
+  ; mutable phase : phase
+  ; mutable in_flight : int
+  ; drained : unit Eio.Promise.t
+  ; resolve_drained : unit Eio.Promise.u
+  }
+
+type 'a outcome =
+  | Returned of 'a
+  | Raised of Eio.Exn.with_bt
+
+type borrow_decision =
+  | Borrowed of Core.store
+  | Borrow_rejected
+  | Borrow_invariant of invariant_violation
+
+type release_decision =
+  | Released
+  | Release_and_signal
+  | Release_invariant of invariant_violation
+
+type close_decision =
+  | Close_and_signal
+  | Await_drain
+  | Already_drained
+  | Close_invariant of invariant_violation
+
+let access_error_to_string = function
+  | Keeper_lane_not_available ->
+    "keeper lane publication recovery store is not available"
+;;
+
+let validation_error_to_string = Core.validation_error_to_string
+let transition_error_to_string = Core.transition_error_to_string
+
+let owner_to_string = Core.owner_to_string
+
+let owner_inventory_row_to_string = function
+  | Valid_owner owner ->
+    Printf.sprintf "valid_owner(%S)" (owner_to_string owner)
+  | Invalid_owner_name name ->
+    Printf.sprintf "invalid_owner_name(%S)" name
+  | Unexpected_owner_kind { owner; kind } ->
+    Format.asprintf
+      "unexpected_owner_kind(%S,%a)"
+      (owner_to_string owner)
+      Eio.File.Stat.pp_kind
+      kind
+  | Missing_owner_entry owner ->
+    Printf.sprintf "missing_owner_entry(%S)" (owner_to_string owner)
+  | Owner_entry_unavailable { owner; error } ->
+    Printf.sprintf
+      "owner_entry_unavailable(%S,%s)"
+      (owner_to_string owner)
+      (Core.transition_error_to_string error)
+;;
+
+let owner_block_to_string = function
+  | Owner_inventory_block row -> owner_inventory_row_to_string row
+  | Owner_reconciliation_block report -> Reconciler.report_to_string report
+  | Owner_reconciliation_crash { owner; exception_; _ } ->
+    Printf.sprintf
+      "owner_reconciliation_crash(%S,%s)"
+      (owner_to_string owner)
+      (Printexc.to_string exception_)
+  | Owner_reconciliation_cancelled_block { owner; reason; _ } ->
+    Printf.sprintf
+      "owner_reconciliation_cancelled(%S,%s)"
+      (owner_to_string owner)
+      (Printexc.to_string reason)
+  | Owner_activation_rejected_block owner ->
+    Printf.sprintf
+      "owner_activation_rejected(%S)"
+      (owner_to_string owner)
+;;
+
+let inventory_error_to_string = function
+  | Registry_inventory_in_progress ->
+    "publication recovery owner inventory is already in progress"
+  | Registry_inventory_failed error -> Core.transition_error_to_string error
+;;
+
+let reconciliation_error_to_string = function
+  | Owner_inventory_required owner ->
+    Printf.sprintf
+      "publication recovery owner inventory is required before reconciling owner %S"
+      (owner_to_string owner)
+  | Owner_inventory_in_progress owner ->
+    Printf.sprintf
+      "publication recovery owner inventory is in progress before reconciling owner %S"
+      (owner_to_string owner)
+  | Owner_not_in_inventory owner ->
+    Printf.sprintf
+      "publication recovery owner %S was not present in the startup inventory"
+      (owner_to_string owner)
+  | Owner_reconciliation_in_progress owner ->
+    Printf.sprintf
+      "publication recovery reconciliation is already in progress for owner %S"
+      (owner_to_string owner)
+  | Owner_inventory_prevents_reconciliation row ->
+    Printf.sprintf
+      "owner inventory prevents publication recovery reconciliation: %s"
+      (owner_inventory_row_to_string row)
+  | Owner_reconciliation_crashed { owner; exception_; _ } ->
+    Printf.sprintf
+      "publication recovery reconciliation crashed for owner %S: %s"
+      (owner_to_string owner)
+      (Printexc.to_string exception_)
+  | Owner_reconciliation_cancelled { owner; reason; _ } ->
+    Printf.sprintf
+      "publication recovery reconciliation was internally cancelled for owner %S: %s"
+      (owner_to_string owner)
+      (Printexc.to_string reason)
+  | Owner_activation_rejected owner ->
+    Printf.sprintf
+      "publication recovery activation was rejected for owner %S"
+      (owner_to_string owner)
+;;
+
+let activation_rejection_error_to_string = function
+  | Activation_inventory_required owner ->
+    Printf.sprintf
+      "publication recovery owner inventory is required before rejecting activation for owner %S"
+      (owner_to_string owner)
+  | Activation_inventory_in_progress owner ->
+    Printf.sprintf
+      "publication recovery owner inventory is in progress while rejecting activation for owner %S"
+      (owner_to_string owner)
+  | Activation_owner_not_in_inventory owner ->
+    Printf.sprintf
+      "publication recovery owner %S was not present in the startup inventory"
+      (owner_to_string owner)
+  | Activation_owner_reconciliation_running owner ->
+    Printf.sprintf
+      "publication recovery reconciliation is running while rejecting activation for owner %S"
+      (owner_to_string owner)
+  | Activation_owner_already_ready owner ->
+    Printf.sprintf
+      "publication recovery owner %S was already ready when activation rejection arrived"
+      (owner_to_string owner)
+  | Activation_owner_already_blocked block ->
+    Printf.sprintf
+      "publication recovery owner was already terminal when activation rejection arrived: %s"
+      (owner_block_to_string block)
+;;
+
+let lane_open_error_to_string = function
+  | Invalid_owner error -> Core.validation_error_to_string error
+  | Reconciliation_required owner ->
+    Printf.sprintf
+      "publication recovery reconciliation is required for owner %S"
+      (owner_to_string owner)
+  | Reconciliation_in_progress owner ->
+    Printf.sprintf
+      "publication recovery reconciliation is in progress for owner %S"
+      (owner_to_string owner)
+  | Reconciliation_blocked block ->
+    Printf.sprintf
+      "publication recovery reconciliation blocks this owner: %s"
+      (owner_block_to_string block)
+  | Store_failed error -> Core.transition_error_to_string error
+;;
+
+let open_registry ~sw ~registry_root =
+  match Core.open_registry ~sw ~registry_root with
+  | Error _ as error -> error
+  | Ok core ->
+    Ok
+      { core
+      ; readiness_mutex = Eio.Mutex.create ()
+      ; registry_phase = Inventory_required
+      }
+;;
+
+let map_owner_inventory_row = function
+  | Core.Valid_owner owner -> Valid_owner owner
+  | Core.Invalid_owner_name name -> Invalid_owner_name name
+  | Core.Unexpected_owner_kind { owner; kind } ->
+    Unexpected_owner_kind { owner; kind }
+  | Core.Missing_owner_entry owner -> Missing_owner_entry owner
+  | Core.Owner_entry_unavailable { owner; error } ->
+    Owner_entry_unavailable { owner; error }
+;;
+
+let make_readiness_entry readiness =
+  let settled, resolve_settled = Eio.Promise.create () in
+  { readiness; settled; resolve_settled }
+;;
+
+let settle_owner key resolve_settled =
+  if not (Eio.Promise.try_resolve resolve_settled ())
+  then
+    raise
+      (Invariant_violation (Reconciliation_settled_twice key))
+;;
+
+let add_inventory_readiness (readiness, terminal_resolvers) row =
+  let owner_and_readiness =
+    match row with
+    | Valid_owner owner -> Some (owner, Reconciliation_pending)
+    | Missing_owner_entry owner ->
+      Some
+        ( owner
+        , Reconciliation_blocked_state (Owner_inventory_block row) )
+    | Owner_entry_unavailable { owner; _ } ->
+      Some
+        ( owner
+        , Reconciliation_blocked_state (Owner_inventory_block row) )
+    | Unexpected_owner_kind { owner; _ } ->
+      Some
+        ( owner
+        , Reconciliation_blocked_state (Owner_inventory_block row) )
+    | Invalid_owner_name _ -> None
+  in
+  match owner_and_readiness with
+  | None -> readiness, terminal_resolvers
+  | Some (owner, replacement) ->
+    let key = owner_to_string owner in
+    let entry = make_readiness_entry replacement in
+    let terminal_resolvers =
+      match replacement with
+      | Reconciliation_blocked_state _ ->
+        (key, entry.resolve_settled) :: terminal_resolvers
+      | Reconciliation_pending
+      | Reconciliation_running
+      | Reconciliation_ready _ -> terminal_resolvers
+    in
+    Owner_map.add key entry readiness, terminal_resolvers
+;;
+
+type begin_inventory =
+  | Begin_inventory
+  | Existing_inventory of owner_inventory
+  | Inventory_already_running
+
+let begin_inventory registry =
+  Eio.Mutex.use_rw ~protect:true registry.readiness_mutex (fun () ->
+    match registry.registry_phase with
+    | Inventory_required ->
+      registry.registry_phase <- Inventory_running;
+      Begin_inventory
+    | Inventory_running -> Inventory_already_running
+    | Inventory_complete { rows; _ } -> Existing_inventory rows)
+;;
+
+let reset_interrupted_inventory registry =
+  Eio.Mutex.use_rw ~protect:true registry.readiness_mutex (fun () ->
+    match registry.registry_phase with
+    | Inventory_running -> registry.registry_phase <- Inventory_required
+    | Inventory_required | Inventory_complete _ -> ())
+;;
+
+let finish_inventory registry rows =
+  let readiness, terminal_resolvers =
+    List.fold_left
+      add_inventory_readiness
+      (Owner_map.empty, [])
+      rows
+  in
+  Eio.Mutex.use_rw ~protect:true registry.readiness_mutex (fun () ->
+    match registry.registry_phase with
+    | Inventory_running ->
+      registry.registry_phase <- Inventory_complete { rows; readiness }
+    | Inventory_required | Inventory_complete _ ->
+      raise
+        (Invariant_violation Inventory_finished_outside_running));
+  List.iter
+    (fun (key, resolve_settled) -> settle_owner key resolve_settled)
+    (List.rev terminal_resolvers)
+;;
+
+let inventory_owners registry =
+  match begin_inventory registry with
+  | Existing_inventory rows -> Ok rows
+  | Inventory_already_running -> Error Registry_inventory_in_progress
+  | Begin_inventory ->
+    (match Core.inventory_owners registry.core with
+     | Error error ->
+       reset_interrupted_inventory registry;
+       Error (Registry_inventory_failed error)
+     | Ok rows ->
+       let rows = List.map map_owner_inventory_row rows in
+       finish_inventory registry rows;
+       Ok rows
+     | exception exception_ ->
+       let backtrace = Printexc.get_raw_backtrace () in
+       reset_interrupted_inventory registry;
+       Printexc.raise_with_backtrace exception_ backtrace)
+;;
+
+type begin_reconciliation =
+  | Begin_reconciliation
+  | Existing_report of Reconciler.report
+  | Begin_reconciliation_failed of reconciliation_error
+
+let begin_reconciliation registry owner =
+  let key = owner_to_string owner in
+  Eio.Mutex.use_rw ~protect:true registry.readiness_mutex (fun () ->
+    match registry.registry_phase with
+    | Inventory_required ->
+      Begin_reconciliation_failed (Owner_inventory_required owner)
+    | Inventory_running ->
+      Begin_reconciliation_failed (Owner_inventory_in_progress owner)
+    | Inventory_complete state ->
+      (match Owner_map.find_opt key state.readiness with
+       | None -> Begin_reconciliation_failed (Owner_not_in_inventory owner)
+       | Some ({ readiness = Reconciliation_pending; _ } as entry) ->
+         registry.registry_phase <-
+           Inventory_complete
+             { state with
+               readiness =
+                 Owner_map.add
+                   key
+                   { entry with readiness = Reconciliation_running }
+                   state.readiness
+             };
+         Begin_reconciliation
+       | Some { readiness = Reconciliation_running; _ } ->
+         Begin_reconciliation_failed
+           (Owner_reconciliation_in_progress owner)
+       | Some { readiness = Reconciliation_ready report; _ } ->
+         Existing_report report
+       | Some
+           { readiness =
+               Reconciliation_blocked_state
+                 (Owner_reconciliation_block report)
+           ; _
+           } ->
+         Existing_report report
+       | Some
+           { readiness =
+               Reconciliation_blocked_state (Owner_inventory_block row)
+           ; _
+           } ->
+         Begin_reconciliation_failed
+           (Owner_inventory_prevents_reconciliation row)
+       | Some
+           { readiness =
+               Reconciliation_blocked_state
+                 (Owner_reconciliation_crash
+                   { owner; exception_; backtrace })
+           ; _
+           } ->
+         Begin_reconciliation_failed
+           (Owner_reconciliation_crashed { owner; exception_; backtrace })
+       | Some
+           { readiness =
+               Reconciliation_blocked_state
+                 (Owner_reconciliation_cancelled_block
+                   { owner; reason; backtrace })
+           ; _
+           } ->
+         Begin_reconciliation_failed
+           (Owner_reconciliation_cancelled { owner; reason; backtrace })
+       | Some
+           { readiness =
+               Reconciliation_blocked_state
+                 (Owner_activation_rejected_block owner)
+           ; _
+           } ->
+         Begin_reconciliation_failed (Owner_activation_rejected owner)))
+;;
+
+let finish_reconciliation_terminal registry owner terminal =
+  let key = owner_to_string owner in
+  let resolve_settled =
+    Eio.Mutex.use_rw ~protect:true registry.readiness_mutex (fun () ->
+      match registry.registry_phase with
+      | Inventory_complete state ->
+        (match Owner_map.find_opt key state.readiness with
+         | Some ({ readiness = Reconciliation_running; _ } as entry) ->
+           registry.registry_phase <-
+             Inventory_complete
+               { state with
+                 readiness =
+                   Owner_map.add
+                     key
+                     { entry with readiness = terminal }
+                     state.readiness
+               };
+           entry.resolve_settled
+         | None
+         | Some
+             { readiness =
+                 ( Reconciliation_pending
+                 | Reconciliation_ready _
+                 | Reconciliation_blocked_state _ )
+             ; _
+             } ->
+           raise
+             (Invariant_violation
+                (Reconciliation_owner_not_running key)))
+      | Inventory_required | Inventory_running ->
+        raise
+          (Invariant_violation Reconciliation_finished_before_inventory))
+  in
+  settle_owner key resolve_settled
+;;
+
+let finish_reconciliation registry owner report =
+  let terminal =
+    if Reconciler.report_is_ready report
+    then Reconciliation_ready report
+    else
+      Reconciliation_blocked_state
+        (Owner_reconciliation_block report)
+  in
+  finish_reconciliation_terminal registry owner terminal
+;;
+
+let finish_reconciliation_crash registry owner exception_ backtrace =
+  finish_reconciliation_terminal
+    registry
+    owner
+    (Reconciliation_blocked_state
+       (Owner_reconciliation_crash { owner; exception_; backtrace }))
+;;
+
+let finish_reconciliation_cancelled registry owner reason backtrace =
+  finish_reconciliation_terminal
+    registry
+    owner
+    (Reconciliation_blocked_state
+       (Owner_reconciliation_cancelled_block { owner; reason; backtrace }))
+;;
+
+let reset_interrupted_reconciliation registry owner =
+  let key = owner_to_string owner in
+  Eio.Mutex.use_rw ~protect:true registry.readiness_mutex (fun () ->
+    match registry.registry_phase with
+    | Inventory_complete state ->
+      (match Owner_map.find_opt key state.readiness with
+       | Some ({ readiness = Reconciliation_running; _ } as entry) ->
+         registry.registry_phase <-
+           Inventory_complete
+             { state with
+               readiness =
+                 Owner_map.add
+                   key
+                   { entry with readiness = Reconciliation_pending }
+                   state.readiness
+             }
+       | None
+       | Some
+           { readiness =
+               ( Reconciliation_pending
+               | Reconciliation_ready _
+               | Reconciliation_blocked_state _ )
+           ; _
+           } -> ())
+    | Inventory_required | Inventory_running -> ())
+;;
+
+type activation_rejection_decision =
+  | Reject_activation of string * unit Eio.Promise.u
+  | Reject_activation_failed of activation_rejection_error
+
+let reject_owner_activation ~registry ~owner =
+  let key = owner_to_string owner in
+  let decision =
+    Eio.Mutex.use_rw ~protect:true registry.readiness_mutex (fun () ->
+      match registry.registry_phase with
+      | Inventory_required ->
+        Reject_activation_failed (Activation_inventory_required owner)
+      | Inventory_running ->
+        Reject_activation_failed (Activation_inventory_in_progress owner)
+      | Inventory_complete state ->
+        (match Owner_map.find_opt key state.readiness with
+         | None ->
+           Reject_activation_failed (Activation_owner_not_in_inventory owner)
+         | Some ({ readiness = Reconciliation_pending; _ } as entry) ->
+           let block = Owner_activation_rejected_block owner in
+           registry.registry_phase <-
+             Inventory_complete
+               { state with
+                 readiness =
+                   Owner_map.add
+                     key
+                     { entry with
+                       readiness = Reconciliation_blocked_state block
+                     }
+                     state.readiness
+               };
+           Reject_activation (key, entry.resolve_settled)
+         | Some { readiness = Reconciliation_running; _ } ->
+           Reject_activation_failed
+             (Activation_owner_reconciliation_running owner)
+         | Some { readiness = Reconciliation_ready _; _ } ->
+           Reject_activation_failed (Activation_owner_already_ready owner)
+         | Some { readiness = Reconciliation_blocked_state block; _ } ->
+           Reject_activation_failed (Activation_owner_already_blocked block)))
+  in
+  match decision with
+  | Reject_activation (key, resolve_settled) ->
+    settle_owner key resolve_settled;
+    Ok ()
+  | Reject_activation_failed error -> Error error
+;;
+
+let reconcile_owner_with ~reconcile ~fs ~registry ~owner =
+  match begin_reconciliation registry owner with
+  | Existing_report report -> Ok report
+  | Begin_reconciliation_failed error -> Error error
+  | Begin_reconciliation ->
+    let report =
+      try reconcile ~fs ~registry:registry.core ~owner with
+      | Eio.Cancel.Cancelled reason as cancellation ->
+        let backtrace = Printexc.get_raw_backtrace () in
+        let current_context_cancelled =
+          match Eio.Fiber.check () with
+          | () -> false
+          | exception Eio.Cancel.Cancelled _ -> true
+        in
+        if current_context_cancelled
+        then (
+          reset_interrupted_reconciliation registry owner;
+          Printexc.raise_with_backtrace cancellation backtrace)
+        else
+          (match
+             finish_reconciliation_cancelled
+               registry
+               owner
+               reason
+               backtrace
+           with
+           | () -> Printexc.raise_with_backtrace cancellation backtrace
+           | exception terminalization_exception ->
+             let terminalization_backtrace = Printexc.get_raw_backtrace () in
+             Printexc.raise_with_backtrace
+               (Reconciliation_cancellation_terminalization_failed
+                  { cancellation = cancellation, backtrace
+                  ; terminalization =
+                      terminalization_exception, terminalization_backtrace
+                  })
+               terminalization_backtrace)
+      | exception_ ->
+        let backtrace = Printexc.get_raw_backtrace () in
+        (match
+           finish_reconciliation_crash
+             registry
+             owner
+             exception_
+             backtrace
+         with
+         | () -> Printexc.raise_with_backtrace exception_ backtrace
+         | exception terminalization_exception ->
+           let terminalization_backtrace = Printexc.get_raw_backtrace () in
+           Printexc.raise_with_backtrace
+             (Reconciliation_crash_terminalization_failed
+                { reconciliation = exception_, backtrace
+                ; terminalization =
+                    terminalization_exception, terminalization_backtrace
+                })
+             terminalization_backtrace)
+    in
+    finish_reconciliation registry owner report;
+    Ok report
+;;
+
+let reconcile_owner =
+  reconcile_owner_with ~reconcile:Reconciler.reconcile_owner
+;;
+
+let with_core_store_for_testing ~registry ~owner f =
+  match Core.owner_of_string owner with
+  | Error error -> Error (Invalid_owner error)
+  | Ok owner ->
+    (match Core.with_store ~registry:registry.core ~owner f with
+     | Ok value -> Ok value
+     | Error error -> Error (Store_failed error))
+;;
+
+let create store =
+  let drained, resolve_drained = Eio.Promise.create () in
+  { store
+  ; mutex = Eio.Mutex.create ()
+  ; phase = Open
+  ; in_flight = 0
+  ; drained
+  ; resolve_drained
+  }
+;;
+
+let capture f =
+  match f () with
+  | value -> Returned value
+  | exception exception_ ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    Raised (exception_, backtrace)
+;;
+
+let raise_with_backtrace (exception_, backtrace) =
+  Printexc.raise_with_backtrace exception_ backtrace
+;;
+
+let run_with_cleanup ~cleanup body =
+  let body_outcome = capture body in
+  let cleanup_outcome =
+    Eio.Cancel.protect (fun () -> capture cleanup)
+  in
+  let parent_outcome = capture Eio.Fiber.check in
+  let body_cancellation, body_failure =
+    match body_outcome with
+    | Raised (((Eio.Cancel.Cancelled _) as exception_), backtrace) ->
+      Some (exception_, backtrace), None
+    | Raised failure -> None, Some failure
+    | Returned _ -> None, None
+  in
+  let parent_cancellation =
+    match parent_outcome with
+    | Raised (((Eio.Cancel.Cancelled _) as exception_), backtrace) ->
+      Some (exception_, backtrace)
+    | Returned () -> None
+    | Raised failure -> raise_with_backtrace failure
+  in
+  let cancellation =
+    match body_cancellation with
+    | Some _ as cancellation -> cancellation
+    | None -> parent_cancellation
+  in
+  match cleanup_outcome, cancellation, body_failure, body_outcome with
+  | Raised cleanup, Some ((_, cancellation_backtrace) as cancellation), _, _ ->
+    Printexc.raise_with_backtrace
+      (Eio.Cancel.Cancelled
+         (Cleanup_failed { body = body_failure; cancellation = Some cancellation; cleanup }))
+      cancellation_backtrace
+  | Raised cleanup, None, body, _ ->
+    Printexc.raise_with_backtrace
+      (Cleanup_failed { body; cancellation = None; cleanup })
+      (snd cleanup)
+  | Returned (), Some ((_, cancellation_backtrace) as cancellation), Some body, _ ->
+    Printexc.raise_with_backtrace
+      (Eio.Cancel.Cancelled
+         (Body_failed_during_cancellation { body; cancellation }))
+      cancellation_backtrace
+  | Returned (), Some cancellation, None, _ -> raise_with_backtrace cancellation
+  | Returned (), None, Some body, _ -> raise_with_backtrace body
+  | Returned (), None, None, Returned value -> value
+  | Returned (), None, None, Raised _ ->
+    raise (Invariant_violation Cleanup_body_outcome_lost)
+;;
+
+let signal_drained t =
+  if not (Eio.Promise.try_resolve t.resolve_drained ())
+  then raise (Invariant_violation Drain_signal_already_resolved)
+;;
+
+let borrow t =
+  Eio.Mutex.use_rw ~protect:true t.mutex (fun () ->
+    match t.phase with
+    | Open when t.in_flight = max_int ->
+      Borrow_invariant Borrow_count_overflow
+    | Open ->
+      t.in_flight <- t.in_flight + 1;
+      Borrowed t.store
+    | Closing when t.in_flight <= 0 ->
+      Borrow_invariant Closing_without_active_borrows
+    | Closing -> Borrow_rejected
+    | Closed when t.in_flight <> 0 ->
+      Borrow_invariant (Closed_with_active_borrows t.in_flight)
+    | Closed -> Borrow_rejected)
+;;
+
+let release t =
+  let decision =
+    Eio.Mutex.use_rw ~protect:true t.mutex (fun () ->
+      if t.in_flight <= 0
+      then Release_invariant Borrow_count_underflow
+      else
+        match t.phase with
+        | Open ->
+          t.in_flight <- t.in_flight - 1;
+          Released
+        | Closing ->
+          t.in_flight <- t.in_flight - 1;
+          if t.in_flight = 0
+          then (
+            t.phase <- Closed;
+            Release_and_signal)
+          else Released
+        | Closed ->
+          Release_invariant
+            (Closed_with_active_borrows t.in_flight))
+  in
+  match decision with
+  | Released -> ()
+  | Release_and_signal -> signal_drained t
+  | Release_invariant invariant -> raise (Invariant_violation invariant)
+;;
+
+let close_and_drain t =
+  let decision =
+    Eio.Mutex.use_rw ~protect:true t.mutex (fun () ->
+      match t.phase with
+      | Open when t.in_flight < 0 ->
+        Close_invariant Borrow_count_underflow
+      | Open when t.in_flight = 0 ->
+        t.phase <- Closed;
+        Close_and_signal
+      | Open ->
+        t.phase <- Closing;
+        Await_drain
+      | Closing when t.in_flight <= 0 ->
+        Close_invariant Closing_without_active_borrows
+      | Closing -> Await_drain
+      | Closed when t.in_flight <> 0 ->
+        Close_invariant (Closed_with_active_borrows t.in_flight)
+      | Closed -> Already_drained)
+  in
+  match decision with
+  | Close_and_signal -> signal_drained t
+  | Await_drain -> Eio.Promise.await t.drained
+  | Already_drained ->
+    (match Eio.Promise.peek t.drained with
+     | Some () -> ()
+     | None -> raise (Invariant_violation Closed_without_drain_signal))
+  | Close_invariant invariant -> raise (Invariant_violation invariant)
+;;
+
+let with_store t f =
+  match borrow t with
+  | Borrow_rejected ->
+    Eio.Fiber.check ();
+    Error Keeper_lane_not_available
+  | Borrow_invariant invariant -> raise (Invariant_violation invariant)
+  | Borrowed store ->
+    run_with_cleanup
+      ~cleanup:(fun () -> release t)
+      (fun () ->
+         Eio.Fiber.check ();
+         Ok (f store))
+;;
+
+type lane_readiness =
+  | Lane_ready
+  | Lane_reconciliation_required
+  | Lane_reconciliation_running
+  | Lane_reconciliation_blocked of owner_block
+
+type lane_wait_decision =
+  | Lane_wait_ready
+  | Lane_wait_inventory_required
+  | Lane_wait_inventory_running
+  | Lane_wait_pending of unit Eio.Promise.t
+  | Lane_wait_running of unit Eio.Promise.t
+  | Lane_wait_blocked of owner_block
+
+let lane_wait_decision registry owner =
+  let key = owner_to_string owner in
+  Eio.Mutex.use_ro registry.readiness_mutex (fun () ->
+    match registry.registry_phase with
+    | Inventory_required -> Lane_wait_inventory_required
+    | Inventory_running -> Lane_wait_inventory_running
+    | Inventory_complete { readiness; _ } ->
+      (match Owner_map.find_opt key readiness with
+       | None | Some { readiness = Reconciliation_ready _; _ } ->
+         Lane_wait_ready
+       | Some { readiness = Reconciliation_pending; settled; _ } ->
+         Lane_wait_pending settled
+       | Some { readiness = Reconciliation_running; settled; _ } ->
+         Lane_wait_running settled
+       | Some
+           { readiness = Reconciliation_blocked_state block; _ } ->
+         Lane_wait_blocked block))
+;;
+
+let lane_readiness registry owner =
+  match lane_wait_decision registry owner with
+  | Lane_wait_ready -> Lane_ready
+  | Lane_wait_inventory_required | Lane_wait_pending _ ->
+    Lane_reconciliation_required
+  | Lane_wait_inventory_running | Lane_wait_running _ ->
+    Lane_reconciliation_running
+  | Lane_wait_blocked block -> Lane_reconciliation_blocked block
+;;
+
+let await_lane_reconciliation ~registry ~owner =
+  match Core.owner_of_string owner with
+  | Error error -> Error (Invalid_owner error)
+  | Ok owner ->
+    let key = owner_to_string owner in
+    let rec await_terminal settled_once =
+      match lane_wait_decision registry owner with
+      | Lane_wait_ready -> Ok ()
+      | Lane_wait_inventory_required ->
+        Error (Reconciliation_required owner)
+      | Lane_wait_inventory_running ->
+        Error (Reconciliation_in_progress owner)
+      | Lane_wait_blocked block -> Error (Reconciliation_blocked block)
+      | Lane_wait_pending settled | Lane_wait_running settled ->
+        if settled_once
+        then
+          raise
+            (Invariant_violation
+               (Reconciliation_settled_before_terminal key));
+        Eio.Promise.await settled;
+        await_terminal true
+    in
+    await_terminal false
+;;
+
+let with_lane ~registry ~owner f =
+  match Core.owner_of_string owner with
+  | Error error -> Error (Invalid_owner error)
+  | Ok owner ->
+    (match lane_readiness registry owner with
+     | Lane_reconciliation_required ->
+       Error (Reconciliation_required owner)
+     | Lane_reconciliation_running ->
+       Error (Reconciliation_in_progress owner)
+     | Lane_reconciliation_blocked block ->
+       Error (Reconciliation_blocked block)
+     | Lane_ready ->
+       (match
+          Core.with_store ~registry:registry.core ~owner (fun store ->
+            let access = create store in
+            run_with_cleanup
+              ~cleanup:(fun () -> close_and_drain access)
+              (fun () -> f access))
+        with
+        | Ok value -> Ok value
+        | Error error -> Error (Store_failed error)))
+;;
+
+module For_testing = struct
+  type reconciliation_interruption =
+    | Cancel_reconciliation of exn
+    | Crash_reconciliation of exn
+
+  type cleanup_body =
+    | Return_cleanup_value of string
+    | Raise_cleanup_body of exn
+    | Cancel_cleanup_body of exn
+
+  type observed_failure =
+    { exception_ : exn
+    ; backtrace : Printexc.raw_backtrace
+    }
+
+  type cleanup_evidence =
+    | Cleanup_returned of string
+    | Cleanup_failed_without_cancellation of
+        { body : observed_failure option
+        ; cleanup : observed_failure
+        }
+    | Cancellation_primary_with_cleanup_failure of
+        { body : observed_failure option
+        ; cancellation : observed_failure
+        ; cleanup : observed_failure
+        }
+    | Body_failure_during_cancellation of
+        { body : observed_failure
+        ; cancellation : observed_failure
+        }
+    | Cancellation_primary of observed_failure
+    | Cleanup_boundary_raised of observed_failure
+
+  type single_borrow_evidence =
+    | Single_borrow_balance of
+        { during_borrow : int
+        ; after_release : int
+        ; close_completed : bool
+        }
+    | Single_borrow_rejected
+    | Single_borrow_invariant of invariant_violation
+    | Single_borrow_raised of observed_failure
+
+  type owner_settlement =
+    | Owner_untracked
+    | Owner_unsettled
+    | Owner_settled
+
+  let observed_failure (exception_, backtrace) =
+    { exception_; backtrace }
+  ;;
+
+  let interrupt_reconciliation ~fs ~registry ~owner interruption =
+    let reconcile ~fs:_ ~registry:_ ~owner:_ =
+      match interruption with
+      | Cancel_reconciliation reason ->
+        raise (Eio.Cancel.Cancelled reason)
+      | Crash_reconciliation exception_ -> raise exception_
+    in
+    reconcile_owner_with ~reconcile ~fs ~registry ~owner
+  ;;
+
+  let run_cleanup_boundary ~body ~cleanup_failure =
+    let body () =
+      match body with
+      | Return_cleanup_value value -> value
+      | Raise_cleanup_body exception_ -> raise exception_
+      | Cancel_cleanup_body reason -> raise (Eio.Cancel.Cancelled reason)
+    in
+    let cleanup () = Option.iter raise cleanup_failure in
+    match run_with_cleanup ~cleanup body with
+    | value -> Cleanup_returned value
+    | exception
+        Eio.Cancel.Cancelled
+          (Cleanup_failed { body; cancellation = Some cancellation; cleanup }) ->
+      Cancellation_primary_with_cleanup_failure
+        { body = Option.map observed_failure body
+        ; cancellation = observed_failure cancellation
+        ; cleanup = observed_failure cleanup
+        }
+    | exception Cleanup_failed { body; cancellation = None; cleanup } ->
+      Cleanup_failed_without_cancellation
+        { body = Option.map observed_failure body
+        ; cleanup = observed_failure cleanup
+        }
+    | exception
+        Eio.Cancel.Cancelled
+          (Body_failed_during_cancellation { body; cancellation }) ->
+      Body_failure_during_cancellation
+        { body = observed_failure body
+        ; cancellation = observed_failure cancellation
+        }
+    | exception Eio.Cancel.Cancelled reason ->
+      let backtrace = Printexc.get_raw_backtrace () in
+      Cancellation_primary { exception_ = reason; backtrace }
+    | exception exception_ ->
+      let backtrace = Printexc.get_raw_backtrace () in
+      Cleanup_boundary_raised { exception_; backtrace }
+  ;;
+
+  let in_flight t =
+    Eio.Mutex.use_ro t.mutex (fun () -> t.in_flight)
+  ;;
+
+  let single_borrow_balance ~registry ~owner =
+    with_core_store_for_testing ~registry ~owner @@ fun store ->
+    let access = create store in
+    match borrow access with
+    | Borrow_rejected -> Single_borrow_rejected
+    | Borrow_invariant invariant -> Single_borrow_invariant invariant
+    | Borrowed _ ->
+      let during_borrow = in_flight access in
+      (match release access with
+       | () ->
+         let after_release = in_flight access in
+         let close_completed =
+           if after_release = 0
+           then (
+             close_and_drain access;
+             true)
+           else false
+         in
+         Single_borrow_balance
+           { during_borrow; after_release; close_completed }
+       | exception (Invariant_violation invariant) ->
+         Single_borrow_invariant invariant
+       | exception exception_ ->
+         let backtrace = Printexc.get_raw_backtrace () in
+         Single_borrow_raised { exception_; backtrace })
+  ;;
+
+  let owner_settlement registry owner =
+    let key = owner_to_string owner in
+    Eio.Mutex.use_ro registry.readiness_mutex (fun () ->
+      match registry.registry_phase with
+      | Inventory_required | Inventory_running -> Owner_untracked
+      | Inventory_complete { readiness; _ } ->
+        (match Owner_map.find_opt key readiness with
+         | None -> Owner_untracked
+         | Some { settled; _ } ->
+           (match Eio.Promise.peek settled with
+            | None -> Owner_unsettled
+            | Some () -> Owner_settled)))
+  ;;
+end

--- a/lib/fs_compat/publication_recovery_access.mli
+++ b/lib/fs_compat/publication_recovery_access.mli
@@ -1,0 +1,306 @@
+(** Lane-lifetime access to the private publication recovery store.
+
+    A lane opens one recovery store and keeps its capabilities pinned for the
+    whole callback passed to [with_lane]. Individual publications borrow that
+    store through [with_store]. Closing rejects new borrows and drains all
+    borrows already in flight before the underlying capabilities are released. *)
+
+type registry
+type t
+type owner
+
+type owner_inventory_row =
+  | Valid_owner of owner
+  | Invalid_owner_name of string
+  | Unexpected_owner_kind of
+      { owner : owner
+      ; kind : Eio.File.Stat.kind
+      }
+  | Missing_owner_entry of owner
+  | Owner_entry_unavailable of
+      { owner : owner
+      ; error : Capability_recovery_obligation.transition_error
+      }
+
+type owner_inventory = owner_inventory_row list
+
+type inventory_error =
+  | Registry_inventory_in_progress
+  | Registry_inventory_failed of Capability_recovery_obligation.transition_error
+
+type owner_block =
+  | Owner_inventory_block of owner_inventory_row
+  | Owner_reconciliation_block of Capability_recovery_reconciler.report
+  | Owner_reconciliation_crash of
+      { owner : owner
+      ; exception_ : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+  | Owner_reconciliation_cancelled_block of
+      { owner : owner
+      ; reason : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+  | Owner_activation_rejected_block of owner
+
+type reconciliation_error =
+  | Owner_inventory_required of owner
+  | Owner_inventory_in_progress of owner
+  | Owner_not_in_inventory of owner
+  | Owner_reconciliation_in_progress of owner
+  | Owner_inventory_prevents_reconciliation of owner_inventory_row
+  | Owner_reconciliation_crashed of
+      { owner : owner
+      ; exception_ : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+  | Owner_reconciliation_cancelled of
+      { owner : owner
+      ; reason : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+  | Owner_activation_rejected of owner
+
+type activation_rejection_error =
+  | Activation_inventory_required of owner
+  | Activation_inventory_in_progress of owner
+  | Activation_owner_not_in_inventory of owner
+  | Activation_owner_reconciliation_running of owner
+  | Activation_owner_already_ready of owner
+  | Activation_owner_already_blocked of owner_block
+
+type access_error = Keeper_lane_not_available
+
+type lane_open_error =
+  | Invalid_owner of Capability_recovery_obligation.validation_error
+  | Reconciliation_required of owner
+  | Reconciliation_in_progress of owner
+  | Reconciliation_blocked of owner_block
+  | Store_failed of Capability_recovery_obligation.transition_error
+
+type invariant_violation =
+  | Borrow_count_underflow
+  | Borrow_count_overflow
+  | Closing_without_active_borrows
+  | Closed_with_active_borrows of int
+  | Closed_without_drain_signal
+  | Drain_signal_already_resolved
+  | Inventory_finished_outside_running
+  | Reconciliation_finished_before_inventory
+  | Reconciliation_owner_not_running of string
+  | Reconciliation_settled_twice of string
+  | Reconciliation_settled_before_terminal of string
+  | Cleanup_body_outcome_lost
+
+(** Raised when the private lifetime state becomes internally inconsistent.
+    These states are programming errors and are never repaired silently. *)
+exception Invariant_violation of invariant_violation
+
+type cleanup_failure =
+  { body : Eio.Exn.with_bt option
+  ; cancellation : Eio.Exn.with_bt option
+  ; cleanup : Eio.Exn.with_bt
+  }
+
+(** Raised directly for a non-cancelled body, or as the reason inside
+    [Eio.Cancel.Cancelled] when cancellation remains primary. All body,
+    cancellation, and cleanup backtraces are retained. *)
+exception Cleanup_failed of cleanup_failure
+
+type body_failed_during_cancellation =
+  { body : Eio.Exn.with_bt
+  ; cancellation : Eio.Exn.with_bt
+  }
+
+exception Body_failed_during_cancellation of
+  body_failed_during_cancellation
+
+type reconciliation_crash_terminalization_failure =
+  { reconciliation : Eio.Exn.with_bt
+  ; terminalization : Eio.Exn.with_bt
+  }
+
+(** Internal terminal publication failed while retaining a reconciliation
+    crash. Both exception/backtrace pairs remain explicit. *)
+exception Reconciliation_crash_terminalization_failed of
+  reconciliation_crash_terminalization_failure
+
+type reconciliation_cancellation_terminalization_failure =
+  { cancellation : Eio.Exn.with_bt
+  ; terminalization : Eio.Exn.with_bt
+  }
+
+(** Terminal publication failed after a live-context reconciliation callback
+    raised [Cancelled]. Both exception/backtrace pairs remain explicit. *)
+exception Reconciliation_cancellation_terminalization_failed of
+  reconciliation_cancellation_terminalization_failure
+
+(** Open the process-lifetime registry below a caller-owned MASC root
+    capability. The registry remains valid for exactly the lifetime of [sw]. *)
+val open_registry
+  :  sw:Eio.Switch.t
+  -> registry_root:Eio.Fs.dir_ty Eio.Path.t
+  -> (registry, Capability_recovery_obligation.transition_error) result
+
+(** Exact, non-recursive owner inventory. The registry enters a typed global
+    inventory phase before filesystem observation, so concurrent lane opening
+    fails without waiting. The first completed inventory becomes immutable for
+    this process-lifetime registry; later callers receive those same rows.
+    Every valid owner is atomically marked as requiring reconciliation.
+    Invalid, missing, unexpected-kind, and unavailable rows remain explicit;
+    rows that identify an exact valid owner block only that owner. *)
+val inventory_owners
+  :  registry
+  -> (owner_inventory, inventory_error) result
+
+val owner_to_string : owner -> string
+
+(** Reconcile one owner previously accepted by the caller's stricter identity
+    boundary. Concurrent lane opening observes [Reconciliation_in_progress]
+    instead of waiting. A clean report marks this exact owner ready; every
+    report with unresolved evidence blocks only this owner. *)
+val reconcile_owner
+  :  fs:Eio.Fs.dir_ty Eio.Path.t
+  -> registry:registry
+  -> owner:owner
+  -> (Capability_recovery_reconciler.report, reconciliation_error) result
+
+(** Atomically terminal-block one exact Pending owner after a caller's stricter
+    activation identity boundary rejects it. The rejection reason remains at
+    the caller boundary; this API records no MASC-specific value or string. *)
+val reject_owner_activation
+  :  registry:registry
+  -> owner:owner
+  -> (unit, activation_rejection_error) result
+
+(** Internal fixture boundary. Production callers must use [with_lane]. *)
+val with_core_store_for_testing
+  :  registry:registry
+  -> owner:string
+  -> (Capability_recovery_obligation.store -> 'a)
+  -> ('a, lane_open_error) result
+
+(** Validate [owner], pin its recovery store, and call [f]. The store remains
+    pinned until [f] has returned or raised and every already-started
+    [with_store] callback has completed. No timeout, retry budget, or polling
+    policy is applied while draining. Callback exceptions and cancellation
+    remain primary. A simultaneous close failure is retained as typed
+    {!Cleanup_failed} evidence with every available backtrace. *)
+val with_lane
+  :  registry:registry
+  -> owner:string
+  -> (t -> 'a)
+  -> ('a, lane_open_error) result
+
+(** Await the exact owner's one-shot reconciliation settlement, then evaluate
+    the typed gate again. Pending/running owners wait without timeout, polling,
+    retry, or a shared-server barrier. Invalid and terminal-blocked owners
+    return immediately. *)
+val await_lane_reconciliation
+  :  registry:registry
+  -> owner:string
+  -> (unit, lane_open_error) result
+
+(** Borrow the lane store for one publication. The callback runs outside the
+    lifetime mutex. Once lane closing begins, new borrows return
+    [Keeper_lane_not_available]. Callback exceptions and cancellation
+    propagate after cancellation-safe release of the borrow. *)
+val with_store
+  :  t
+  -> (Capability_recovery_obligation.store -> 'a)
+  -> ('a, access_error) result
+
+val access_error_to_string : access_error -> string
+val lane_open_error_to_string : lane_open_error -> string
+
+val owner_inventory_row_to_string : owner_inventory_row -> string
+val inventory_error_to_string : inventory_error -> string
+val owner_block_to_string : owner_block -> string
+val reconciliation_error_to_string : reconciliation_error -> string
+val activation_rejection_error_to_string : activation_rejection_error -> string
+
+(** Exact delegations to the recovery-obligation error SSOT. *)
+val validation_error_to_string
+  :  Capability_recovery_obligation.validation_error
+  -> string
+
+val transition_error_to_string
+  :  Capability_recovery_obligation.transition_error
+  -> string
+
+module For_testing : sig
+  type reconciliation_interruption =
+    | Cancel_reconciliation of exn
+    | Crash_reconciliation of exn
+
+  type cleanup_body =
+    | Return_cleanup_value of string
+    | Raise_cleanup_body of exn
+    | Cancel_cleanup_body of exn
+
+  type observed_failure =
+    { exception_ : exn
+    ; backtrace : Printexc.raw_backtrace
+    }
+
+  type cleanup_evidence =
+    | Cleanup_returned of string
+    | Cleanup_failed_without_cancellation of
+        { body : observed_failure option
+        ; cleanup : observed_failure
+        }
+    | Cancellation_primary_with_cleanup_failure of
+        { body : observed_failure option
+        ; cancellation : observed_failure
+        ; cleanup : observed_failure
+        }
+    | Body_failure_during_cancellation of
+        { body : observed_failure
+        ; cancellation : observed_failure
+        }
+    | Cancellation_primary of observed_failure
+    | Cleanup_boundary_raised of observed_failure
+
+  type single_borrow_evidence =
+    | Single_borrow_balance of
+        { during_borrow : int
+        ; after_release : int
+        ; close_completed : bool
+        }
+    | Single_borrow_rejected
+    | Single_borrow_invariant of invariant_violation
+    | Single_borrow_raised of observed_failure
+
+  type owner_settlement =
+    | Owner_untracked
+    | Owner_unsettled
+    | Owner_settled
+
+  (** Deterministic fault injection around the production owner state machine.
+      The injected callback runs only after the exact owner moves to Running;
+      cancellation and crash handling are the same paths used by
+      {!reconcile_owner}. *)
+  val interrupt_reconciliation
+    :  fs:Eio.Fs.dir_ty Eio.Path.t
+    -> registry:registry
+    -> owner:owner
+    -> reconciliation_interruption
+    -> (Capability_recovery_reconciler.report, reconciliation_error) result
+
+  (** Executes the real lane cleanup combinator and projects its typed result
+      without relying on exception messages. *)
+  val run_cleanup_boundary
+    :  body:cleanup_body
+    -> cleanup_failure:exn option
+    -> cleanup_evidence
+
+  (** Exercises the production create/borrow/release/close path. When a release
+      leaves a non-zero count it records the imbalance and deliberately avoids
+      awaiting the impossible drain, making count leaks deterministic. *)
+  val single_borrow_balance
+    :  registry:registry
+    -> owner:string
+    -> (single_borrow_evidence, lane_open_error) result
+
+  val owner_settlement : registry -> owner -> owner_settlement
+end

--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -499,7 +499,7 @@ let persist_connector_assistant_reply ~base_dir ~keeper_name ~source ?surface
    to [None] ([dispatch]). Without the unit the optional leaks into [dispatch]'s
    inferred type and breaks the .mli signature. Do not drop the [()]. *)
 let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~submission_owner
-    ~sw ~clock ~proc_mgr ~net ~config
+    ~sw ~clock ~proc_mgr ~net ~publication_recovery_registry ~config
     ~channel ~channel_user_id ~channel_user_name ~channel_workspace_id
     ~keeper_name ~idempotency_key ~metadata ~content () =
   let keeper_name = String.trim keeper_name in
@@ -608,6 +608,7 @@ let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~submission_owne
     clock;
     proc_mgr;
     net;
+    publication_recovery_registry;
   } in
   let start_mtime = Mtime_clock.now () in
   let on_text_delta =
@@ -808,19 +809,22 @@ let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~submission_owne
    the connector-neutral [dispatch_fn] shape. Requiring the connector to name
    its kind also makes a missing wiring a compile error rather than a silent
    [Generic] default. *)
-let dispatch ~connector_kind ~submission_owner ~sw ~clock ~proc_mgr ~net ~config
+let dispatch ~connector_kind ~submission_owner ~sw ~clock ~proc_mgr ~net
+    ~publication_recovery_registry ~config
     ~channel
     ~channel_user_id ~channel_user_name ~channel_workspace_id ~keeper_name
     ~idempotency_key ~metadata ~content =
-  dispatch_core ~connector_kind ~submission_owner ~sw ~clock ~proc_mgr ~net ~config
+  dispatch_core ~connector_kind ~submission_owner ~sw ~clock ~proc_mgr ~net
+    ~publication_recovery_registry ~config
     ~channel
     ~channel_user_id ~channel_user_name ~channel_workspace_id ~keeper_name
     ~idempotency_key ~metadata ~content ()
 
 let dispatch_with_text_snapshot ~connector_kind ~submission_owner
-    ~on_text_snapshot ~sw ~clock ~proc_mgr ~net ~config ~channel ~channel_user_id
-    ~channel_user_name ~channel_workspace_id ~keeper_name ~idempotency_key
-    ~metadata ~content =
+    ~on_text_snapshot ~sw ~clock ~proc_mgr ~net ~publication_recovery_registry
+    ~config ~channel ~channel_user_id ~channel_user_name ~channel_workspace_id
+    ~keeper_name ~idempotency_key ~metadata ~content =
   dispatch_core ~connector_kind ~submission_owner ~on_text_snapshot ~sw ~clock
-    ~proc_mgr ~net ~config ~channel ~channel_user_id ~channel_user_name
-    ~channel_workspace_id ~keeper_name ~idempotency_key ~metadata ~content ()
+    ~proc_mgr ~net ~publication_recovery_registry ~config ~channel
+    ~channel_user_id ~channel_user_name ~channel_workspace_id ~keeper_name
+    ~idempotency_key ~metadata ~content ()

--- a/lib/gate_keeper_backend.mli
+++ b/lib/gate_keeper_backend.mli
@@ -52,6 +52,7 @@ val dispatch :
   clock:_ Eio.Time.clock ->
   proc_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t option ->
   net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option ->
+  publication_recovery_registry:Fs_compat.publication_recovery_registry option ->
   config:Workspace.config ->
   channel:string ->
   channel_user_id:string ->
@@ -91,6 +92,7 @@ val dispatch_with_text_snapshot :
   clock:_ Eio.Time.clock ->
   proc_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t option ->
   net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option ->
+  publication_recovery_registry:Fs_compat.publication_recovery_registry option ->
   config:Workspace.config ->
   channel:string ->
   channel_user_id:string ->

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -188,6 +188,9 @@ end
 let run_turn
       ~(config : Workspace.config)
       ~(meta : Keeper_meta_contract.keeper_meta)
+      ~(publication_recovery_registry :
+          Fs_compat.publication_recovery_registry)
+      ~(publication_recovery_access : Fs_compat.publication_recovery_access)
       ~(profile_defaults : Keeper_types_profile.keeper_profile_defaults)
       ~(turn_ctx_cell : Keeper_tool_call_log.turn_ctx_cell)
       ~(base_dir : string)
@@ -458,6 +461,8 @@ let run_turn
     Keeper_run_tools.prepare_agent_setup
       ~config
       ~meta
+      ~publication_recovery_registry
+      ~publication_recovery_access
       ?continuation_channel
       ?hitl_resolution
       ~turn_ctx_cell

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -126,6 +126,8 @@ end
 val run_turn
   :  config:Workspace.config
   -> meta:Keeper_meta_contract.keeper_meta
+  -> publication_recovery_registry:Fs_compat.publication_recovery_registry
+  -> publication_recovery_access:Fs_compat.publication_recovery_access
   -> profile_defaults:Keeper_types_profile.keeper_profile_defaults
   -> turn_ctx_cell:Keeper_tool_call_log.turn_ctx_cell
   -> base_dir:string

--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -10,6 +10,7 @@ let rejection_to_telemetry (r : keeper_path_rejection) : unit =
     match r with
     | Path_required -> "path_required"
     | Invalid_lexical_endpoint -> "invalid_lexical_endpoint"
+    | Invalid_normalized_path_projection _ -> "invalid_normalized_path_projection"
     | Allowed_paths_normalized_empty _ -> "allowed_paths_normalized_empty"
     | Outside_sandbox _ -> "out_of_roots"
   in
@@ -71,16 +72,71 @@ let normalize_allowed_path_for_check ~root path =
   allowed_path_projection ~root path |> Option.map snd
 ;;
 
+let valid_child_name = Fs_compat.is_capability_leaf
+
+type absolute_path_components =
+  { anchor : string
+  ; components : string list
+  }
+
+type allowed_root_projection =
+  { normalized_path : string
+  ; normalized_components : absolute_path_components
+  ; capability_components : absolute_path_components
+  }
+
+let absolute_path_components path =
+  if Filename.is_relative path || String.equal path ""
+  then None
+  else
+    let rec collect current components =
+      let parent = Filename.dirname current in
+      if String.equal parent current
+      then Some { anchor = current; components }
+      else
+        let component = Filename.basename current in
+        if valid_child_name component
+        then collect parent (component :: components)
+        else None
+    in
+    collect path []
+;;
+
+let rec drop_component_prefix prefix components =
+  match prefix, components with
+  | [], suffix -> Some suffix
+  | expected :: prefix_rest, actual :: components_rest
+    when String.equal expected actual ->
+    drop_component_prefix prefix_rest components_rest
+  | _ -> None
+;;
+
+let relative_components_under
+      ~(root : absolute_path_components)
+      ~(target : absolute_path_components)
+  =
+  if String.equal root.anchor target.anchor
+  then drop_component_prefix root.components target.components
+  else None
+;;
+
 let is_within_root_norm ~(root_norm : string) (path : string) : bool =
   let normalized = normalize_path_for_check path |> strip_trailing_slashes in
-  normalized = root_norm || String.starts_with ~prefix:(root_norm ^ "/") normalized
+  match absolute_path_components root_norm, absolute_path_components normalized with
+  | Some root, Some target -> Option.is_some (relative_components_under ~root ~target)
+  | None, _ | _, None -> false
 ;;
 
 let is_within_allowed_norms ~(target_norm : string) (allowed_norms : string list) : bool =
-  List.exists
-    (fun allowed_norm ->
-       target_norm = allowed_norm || String.starts_with ~prefix:(allowed_norm ^ "/") target_norm)
-    allowed_norms
+  match absolute_path_components target_norm with
+  | None -> false
+  | Some target ->
+    List.exists
+      (fun allowed_norm ->
+         match absolute_path_components allowed_norm with
+         | None -> false
+         | Some root -> Option.is_some (relative_components_under ~root ~target))
+      allowed_norms
 ;;
 
 type confined_path =
@@ -88,10 +144,11 @@ type confined_path =
   ; root_identity : resource_identity option
   ; anchor_root : string
   ; root_relative_path : string
-  ; relative_path : string
+  ; target_components : string list
+  ; endpoint_components : string list
+  ; lexical_leaf : string option
   ; host_path : string
   ; containment_path : string
-  ; endpoint_relative_path : string
   }
 
 and resource_identity =
@@ -106,7 +163,7 @@ type path_effect_operation =
   | Create_entry_exclusive
 
 type path_effect_parent_scope =
-  { relative_path : string
+  { parent_components : string list
   ; resource : resource_identity
   ; create_missing_parents : string list
   ; created_directory_permissions : int
@@ -115,8 +172,8 @@ type path_effect_parent_scope =
 type path_effect_locator =
   { root : string
   ; root_resource : resource_identity
-  ; relative_path : string
-  ; endpoint_relative_path : string
+  ; target_components : string list
+  ; endpoint_components : string list
   ; leaf : string
   ; parent : path_effect_parent_scope option
   ; target_resource : resource_identity option
@@ -124,7 +181,7 @@ type path_effect_locator =
   }
 
 and path_effect_source =
-  { relative_path : string
+  { components : string list
   ; resource : resource_identity
   }
 
@@ -134,17 +191,88 @@ type path_effect =
   ; result_file_permissions : int option
   }
 
+type path_effect_projection_error =
+  | Allowed_root_identity_unavailable of { root : string }
+  | Invalid_parent_component of
+      { index : int
+      ; value : string
+      }
+  | Invalid_missing_parent_component of
+      { index : int
+      ; value : string
+      }
+  | Target_has_no_lexical_leaf
+  | Parent_scope_does_not_cover_target of
+      { parent_components : string list
+      ; create_missing_parents : string list
+      ; target_parent_components : string list
+      }
+  | Patch_source_has_no_endpoint
+  | Recovery_target_invalid of Fs_compat.atomic_replace_recovery_target_error
+
+type atomic_replace_projection =
+  { gate_effect : path_effect
+  ; recovery_target : Fs_compat.atomic_replace_recovery_target
+  }
+
 type confined_path_endpoint =
   | Lexical_entry
   | Follow_referent
 
+let relative_path_of_components = function
+  | [] -> "."
+  | components -> String.concat Filename.dir_sep components
+;;
+
 let confined_root (target : confined_path) = target.root
 let confined_anchor_root (target : confined_path) = target.anchor_root
 let confined_root_relative_path (target : confined_path) = target.root_relative_path
-let confined_relative_path (target : confined_path) = target.relative_path
+let confined_relative_components (target : confined_path) = target.target_components
+let confined_relative_path (target : confined_path) =
+  relative_path_of_components target.target_components
+;;
 let confined_host_path (target : confined_path) = target.host_path
 let confined_containment_path (target : confined_path) = target.containment_path
-let confined_endpoint_relative_path (target : confined_path) = target.endpoint_relative_path
+let confined_endpoint_components (target : confined_path) = target.endpoint_components
+let confined_endpoint_relative_path (target : confined_path) =
+  relative_path_of_components target.endpoint_components
+;;
+
+let path_effect_projection_error_to_string = function
+  | Allowed_root_identity_unavailable { root } ->
+    Printf.sprintf
+      "filesystem allowed root identity unavailable for Gate effect: %s"
+      root
+  | Invalid_parent_component { index; value } ->
+    Printf.sprintf
+      "filesystem effect parent component %d is invalid: %S"
+      index
+      value
+  | Invalid_missing_parent_component { index; value } ->
+    Printf.sprintf
+      "filesystem effect missing-parent component %d is invalid: %S"
+      index
+      value
+  | Target_has_no_lexical_leaf ->
+    "filesystem effect target has no lexical leaf"
+  | Parent_scope_does_not_cover_target
+      { parent_components
+      ; create_missing_parents
+      ; target_parent_components
+      } ->
+    Printf.sprintf
+      "filesystem effect parent scope does not cover target: parent=%s missing=%s target_parent=%s"
+      (relative_path_of_components parent_components)
+      (relative_path_of_components create_missing_parents)
+      (relative_path_of_components target_parent_components)
+  | Patch_source_has_no_endpoint ->
+    "filesystem patch source has no confined endpoint"
+  | Recovery_target_invalid error ->
+    Fs_compat.atomic_replace_recovery_target_error_to_string error
+;;
+
+let atomic_replace_gate_effect projection = projection.gate_effect
+let atomic_replace_recovery_target projection = projection.recovery_target
 
 let resource_identity_of_unix_path path =
   try
@@ -194,48 +322,71 @@ let verify_confined_root_capability target root_dir =
      | Eio.Io _ as exn -> Error (Printexc.to_string exn))
 ;;
 
-let valid_relative_parent_path path =
-  Filename.is_relative path && not (String.equal path "")
+let validate_components ~invalid components =
+  let rec loop index = function
+    | [] -> Ok components
+    | component :: rest ->
+      if valid_child_name component
+      then loop (index + 1) rest
+      else Error (invalid ~index ~value:component)
+  in
+  loop 0 components
 ;;
 
-let valid_child_name = Fs_compat.is_capability_leaf
-
 let path_effect_parent_scope
-      ~relative_path
+      ~parent_components
       ~(resource : Eio.File.Stat.t)
       ~create_missing_parents
       ~created_directory_permissions
   =
-  if not (valid_relative_parent_path relative_path)
-  then Error "filesystem effect parent path must be non-empty and relative"
-  else
-    match List.find_opt (fun name -> not (valid_child_name name)) create_missing_parents with
-    | Some invalid ->
-      Error
-        (Printf.sprintf
-           "filesystem effect missing-parent component is invalid: %S"
-           invalid)
-    | None ->
-      Ok
-        { relative_path
-        ; resource = resource_identity_of_eio_stat resource
-        ; create_missing_parents
-        ; created_directory_permissions
-        }
+  match
+    validate_components
+      ~invalid:(fun ~index ~value -> Invalid_parent_component { index; value })
+      parent_components
+  with
+  | Error _ as error -> error
+  | Ok parent_components ->
+    (match
+       validate_components
+         ~invalid:(fun ~index ~value ->
+           Invalid_missing_parent_component { index; value })
+         create_missing_parents
+     with
+     | Error _ as error -> error
+     | Ok create_missing_parents ->
+       Ok
+         { parent_components
+         ; resource = resource_identity_of_eio_stat resource
+         ; create_missing_parents
+         ; created_directory_permissions
+         })
 ;;
 
-let append_child parent child =
-  if String.equal parent "." then child else Filename.concat parent child
+let split_last components =
+  match List.rev components with
+  | [] -> None
+  | leaf :: reversed_parent -> Some (List.rev reversed_parent, leaf)
 ;;
 
 let parent_scope_covers_target
       (parent : path_effect_parent_scope)
       (target : confined_path)
   =
-  let covered_parent =
-    List.fold_left append_child parent.relative_path parent.create_missing_parents
-  in
-  String.equal covered_parent (Filename.dirname target.relative_path)
+  match split_last target.target_components with
+  | None -> Error Target_has_no_lexical_leaf
+  | Some (target_parent_components, _leaf) ->
+    let projected_parent_components =
+      parent.parent_components @ parent.create_missing_parents
+    in
+    if List.equal String.equal projected_parent_components target_parent_components
+    then Ok ()
+    else
+      Error
+        (Parent_scope_does_not_cover_target
+           { parent_components = parent.parent_components
+           ; create_missing_parents = parent.create_missing_parents
+           ; target_parent_components
+           })
 ;;
 
 let path_effect
@@ -248,61 +399,109 @@ let path_effect
   =
   match target.root_identity with
   | None ->
-    Error
-      (Printf.sprintf
-         "filesystem allowed root identity unavailable for Gate effect: %s"
-         target.root)
+    Error (Allowed_root_identity_unavailable { root = target.root })
   | Some root_resource ->
     (match parent with
-     | Some scope when not (parent_scope_covers_target scope target) ->
-       Error
-         (Printf.sprintf
-            "filesystem effect parent scope does not cover target: parent=%s target=%s"
-            scope.relative_path
-            target.relative_path)
-     | _ ->
-       Ok
-         { operation
-         ; locator =
-             { root = target.root
-             ; root_resource
-             ; relative_path = target.relative_path
-             ; endpoint_relative_path = target.endpoint_relative_path
-             ; leaf = Filename.basename target.relative_path
-             ; parent
-             ; target_resource
-             ; source
-             }
-         ; result_file_permissions
-         })
+     | Some scope ->
+       (match parent_scope_covers_target scope target with
+        | Error _ as error -> error
+        | Ok () ->
+          (match target.lexical_leaf with
+           | None -> Error Target_has_no_lexical_leaf
+           | Some leaf ->
+             Ok
+               { operation
+               ; locator =
+                   { root = target.root
+                   ; root_resource
+                   ; target_components = target.target_components
+                   ; endpoint_components = target.endpoint_components
+                   ; leaf
+                   ; parent
+                   ; target_resource
+                   ; source
+                   }
+               ; result_file_permissions
+               }))
+     | None ->
+       (match target.lexical_leaf with
+        | None -> Error Target_has_no_lexical_leaf
+        | Some leaf ->
+          Ok
+            { operation
+            ; locator =
+                { root = target.root
+                ; root_resource
+                ; target_components = target.target_components
+                ; endpoint_components = target.endpoint_components
+                ; leaf
+                ; parent
+                ; target_resource
+                ; source
+                }
+            ; result_file_permissions
+            }))
+;;
+
+let atomic_replace_projection
+      ~operation
+      ~parent
+      ?source
+      ~result_file_permissions
+      target
+  =
+  match
+    path_effect
+      ~operation
+      ~parent
+      ?source
+      ~result_file_permissions:(Some result_file_permissions)
+      target
+  with
+  | Error _ as error -> error
+  | Ok gate_effect ->
+    let root_resource = gate_effect.locator.root_resource in
+    let parent_components =
+      parent.parent_components @ parent.create_missing_parents
+    in
+    (match
+       Fs_compat.atomic_replace_recovery_target
+         ~allowed_root_path:target.root
+         ~allowed_root_device:root_resource.device
+         ~allowed_root_inode:root_resource.inode
+         ~parent_components
+         ~target_leaf:gate_effect.locator.leaf
+         ~permissions:result_file_permissions
+     with
+     | Error error -> Error (Recovery_target_invalid error)
+     | Ok recovery_target -> Ok { gate_effect; recovery_target })
 ;;
 
 let atomic_replace_effect ~parent ~result_file_permissions target =
-  path_effect
+  atomic_replace_projection
     ~operation:Atomic_replace_entry
     ~parent
-    ~result_file_permissions:(Some result_file_permissions)
+    ~result_file_permissions
     target
 ;;
 
 let patch_then_atomic_replace_effect
       ~parent
-      ~source_relative_path
       ~(source_resource : Eio.File.Stat.t)
       ~result_file_permissions
-      target
+      (target : confined_path)
   =
-  if String.equal source_relative_path "" || not (Filename.is_relative source_relative_path)
-  then Error "filesystem patch source path must be non-empty and relative"
-  else
-    path_effect
+  match target.endpoint_components with
+  | [] -> Error Patch_source_has_no_endpoint
+  | components ->
+    atomic_replace_projection
       ~operation:Patch_then_atomic_replace_entry
       ~parent
       ~source:
-        { relative_path = source_relative_path
+        { components
         ; resource = resource_identity_of_eio_stat source_resource
         }
-      ~result_file_permissions:(Some result_file_permissions)
+      ~result_file_permissions
       target
 ;;
 
@@ -343,7 +542,9 @@ let path_effect_to_yojson gate_effect =
     | Some parent ->
       [ ( "parent"
         , `Assoc
-            [ "relative_path", `String parent.relative_path
+            [ ( "relative_path"
+              , `String
+                  (relative_path_of_components parent.parent_components) )
             ; "resource", resource_identity_to_yojson parent.resource
             ; ( "create_missing_parents"
               , `List
@@ -370,7 +571,8 @@ let path_effect_to_yojson gate_effect =
     | Some source ->
       [ ( "source"
         , `Assoc
-            [ "relative_path", `String source.relative_path
+            [ ( "relative_path"
+              , `String (relative_path_of_components source.components) )
             ; "resource", resource_identity_to_yojson source.resource
             ] )
       ]
@@ -386,6 +588,12 @@ let path_effect_to_yojson gate_effect =
             ] )
       ]
   in
+  let relative_path =
+    relative_path_of_components gate_effect.locator.target_components
+  in
+  let endpoint_relative_path =
+    relative_path_of_components gate_effect.locator.endpoint_components
+  in
   `Assoc
     ([ "operation", `String (path_effect_operation_to_string gate_effect.operation)
      ; ( "locator"
@@ -393,9 +601,8 @@ let path_effect_to_yojson gate_effect =
            ([ "kind", `String "confined_path"
             ; "root", `String gate_effect.locator.root
             ; "root_resource", resource_identity_to_yojson gate_effect.locator.root_resource
-            ; "relative_path", `String gate_effect.locator.relative_path
-            ; ( "endpoint_relative_path"
-              , `String gate_effect.locator.endpoint_relative_path )
+            ; "relative_path", `String relative_path
+            ; "endpoint_relative_path", `String endpoint_relative_path
             ; "leaf", `String gate_effect.locator.leaf
             ]
             @ parent
@@ -403,16 +610,6 @@ let path_effect_to_yojson gate_effect =
             @ source) )
      ]
      @ result)
-;;
-
-let relative_path_within_root ~(root_norm : string) ~(target_norm : string) =
-  if String.equal root_norm target_norm
-  then "."
-  else
-    String.sub
-      target_norm
-      (String.length root_norm + 1)
-      (String.length target_norm - String.length root_norm - 1)
 ;;
 
 let normalize_confined_endpoint endpoint candidate =
@@ -451,80 +648,141 @@ let resolve_keeper_confined_path
     match normalize_confined_endpoint endpoint candidate with
     | Error rejection -> Error rejection
     | Ok target_norm ->
-      let project_root_path = strip_trailing_slashes root in
       let project_root_norm = normalize_path_for_check_stripped root in
-      let allowed_roots =
-        if allowed_paths = []
-        then [ strip_trailing_slashes root, project_root_norm ]
-        else
-          List.filter_map
-            (allowed_path_projection ~root)
-            allowed_paths
-      in
-      (match allowed_roots with
-       | [] ->
-         Error (Allowed_paths_normalized_empty { count = List.length allowed_paths })
-       | _ ->
-         (match
-         List.find_opt
-           (fun (_allowed_path, allowed_norm) ->
-              target_norm = allowed_norm
-              || String.starts_with ~prefix:(allowed_norm ^ "/") target_norm)
-           allowed_roots
-       with
-       | None -> Error (Outside_sandbox { raw })
-       | Some (allowed_path, root_norm) ->
-         let candidate_path = strip_trailing_slashes candidate in
-         let endpoint_relative_path =
-           relative_path_within_root ~root_norm ~target_norm
+      (match absolute_path_components project_root_norm with
+       | None ->
+         Error
+           (Invalid_normalized_path_projection { path = project_root_norm })
+       | Some project_root_components ->
+         let allowed_roots =
+           let projected_roots =
+             if allowed_paths = []
+             then [ project_root_norm, project_root_norm ]
+             else List.filter_map (allowed_path_projection ~root) allowed_paths
+           in
+           List.filter_map
+             (fun (capability_path, normalized_path) ->
+                match absolute_path_components normalized_path with
+                | None -> None
+                | Some normalized_components ->
+                  let capability_path =
+                    match
+                      normalize_confined_endpoint Lexical_entry capability_path
+                    with
+                    | Ok lexical_path -> lexical_path
+                    | Error Invalid_lexical_endpoint -> normalized_path
+                    | Error
+                        ( Path_required
+                        | Invalid_normalized_path_projection _
+                        | Allowed_paths_normalized_empty _
+                        | Outside_sandbox _ ) ->
+                      normalized_path
+                  in
+                  let capability_components =
+                    Option.value
+                      ~default:normalized_components
+                      (absolute_path_components capability_path)
+                  in
+                  Some
+                    { normalized_path
+                    ; normalized_components
+                    ; capability_components
+                    })
+             projected_roots
          in
-         if endpoint = Lexical_entry && String.equal endpoint_relative_path "."
-         then Error Invalid_lexical_endpoint
-         else
-         let relative_path =
-           if candidate_path = allowed_path
-              || String.starts_with ~prefix:(allowed_path ^ "/") candidate_path
-           then
-             relative_path_within_root
-               ~root_norm:allowed_path
-               ~target_norm:candidate_path
-           else relative_path_within_root ~root_norm ~target_norm
-         in
-         let anchor_root, root_relative_path =
-           if allowed_path = project_root_path
-              || String.starts_with ~prefix:(project_root_path ^ "/") allowed_path
-           then
-             ( project_root_norm
-             , relative_path_within_root
-                 ~root_norm:project_root_path
-                 ~target_norm:allowed_path )
-           else if root_norm = project_root_norm
-              || String.starts_with ~prefix:(project_root_norm ^ "/") root_norm
-           then
-             ( project_root_norm
-             , relative_path_within_root
-                 ~root_norm:project_root_norm
-                 ~target_norm:root_norm )
-           else (
-             let parent = Filename.dirname root_norm in
-             if String.equal parent root_norm
-             then root_norm, "."
-             else
-               ( parent
-               , relative_path_within_root
-                   ~root_norm:parent
-                   ~target_norm:root_norm ))
-         in
-         Ok
-           { root = root_norm
-           ; root_identity = resource_identity_of_unix_path root_norm
-           ; anchor_root
-           ; root_relative_path
-           ; relative_path
-           ; host_path = candidate
-           ; containment_path = target_norm
-           ; endpoint_relative_path
-           })))
+         (match allowed_roots with
+          | [] ->
+            Error
+              (Allowed_paths_normalized_empty
+                 { count = List.length allowed_paths })
+          | _ ->
+            (match absolute_path_components target_norm with
+             | None ->
+               Error
+                 (Invalid_normalized_path_projection { path = target_norm })
+             | Some endpoint_absolute ->
+               (match
+                  List.find_map
+                    (fun root_projection ->
+                       relative_components_under
+                         ~root:root_projection.normalized_components
+                         ~target:endpoint_absolute
+                       |> Option.map (fun endpoint_components ->
+                         root_projection, endpoint_components))
+                    allowed_roots
+                with
+                | None -> Error (Outside_sandbox { raw })
+                | Some (root_projection, endpoint_components) ->
+                  if endpoint = Lexical_entry && endpoint_components = []
+                  then Error Invalid_lexical_endpoint
+                  else
+                    let target_components =
+                      match
+                        normalize_confined_endpoint Lexical_entry candidate
+                      with
+                      | Error Invalid_lexical_endpoint -> endpoint_components
+                      | Error
+                          ( Path_required
+                          | Invalid_normalized_path_projection _
+                          | Allowed_paths_normalized_empty _
+                          | Outside_sandbox _ ) ->
+                        endpoint_components
+                      | Ok lexical_norm ->
+                        (match absolute_path_components lexical_norm with
+                         | None -> endpoint_components
+                         | Some lexical_absolute ->
+                           Option.value
+                             ~default:endpoint_components
+                             (relative_components_under
+                                ~root:
+                                  root_projection.normalized_components
+                                ~target:lexical_absolute))
+                    in
+                    let lexical_leaf =
+                      split_last target_components |> Option.map snd
+                    in
+                    let anchor_root, root_relative_path =
+                      match
+                        relative_components_under
+                          ~root:project_root_components
+                          ~target:root_projection.capability_components
+                      with
+                      | Some capability_components ->
+                        ( project_root_norm
+                        , relative_path_of_components capability_components )
+                      | None ->
+                        (match
+                           relative_components_under
+                             ~root:project_root_components
+                             ~target:root_projection.normalized_components
+                         with
+                         | Some root_components ->
+                           ( project_root_norm
+                           , relative_path_of_components root_components )
+                         | None ->
+                           (match
+                              split_last
+                                root_projection.normalized_components.components
+                            with
+                            | None -> root_projection.normalized_path, "."
+                            | Some (_parent_components, leaf) ->
+                              ( Filename.dirname
+                                  root_projection.normalized_path
+                              , leaf )))
+                    in
+                    Ok
+                      { root = root_projection.normalized_path
+                      ; root_identity =
+                          resource_identity_of_unix_path
+                            root_projection.normalized_path
+                      ; anchor_root
+                      ; root_relative_path
+                      ; target_components
+                      ; endpoint_components
+                      ; lexical_leaf
+                      ; host_path = candidate
+                      ; containment_path = target_norm
+                      })))))
 ;;
 
 let resolve_keeper_path_within_allowed_roots ~config ~allowed_paths ~raw_path =

--- a/lib/keeper/keeper_alerting_path.mli
+++ b/lib/keeper/keeper_alerting_path.mli
@@ -68,17 +68,54 @@ type path_effect_parent_scope
     exact lexical directory segments that do not exist yet and may therefore
     be created only after Gate allows the composite operation. *)
 
+type path_effect_projection_error =
+  | Allowed_root_identity_unavailable of { root : string }
+  | Invalid_parent_component of
+      { index : int
+      ; value : string
+      }
+  | Invalid_missing_parent_component of
+      { index : int
+      ; value : string
+      }
+  | Target_has_no_lexical_leaf
+  | Parent_scope_does_not_cover_target of
+      { parent_components : string list
+      ; create_missing_parents : string list
+      ; target_parent_components : string list
+      }
+  | Patch_source_has_no_endpoint
+  | Recovery_target_invalid of Fs_compat.atomic_replace_recovery_target_error
+(** Typed projection failures. In particular, recovery-target validation is
+    retained as the abstract filesystem-layer error rather than flattened to a
+    string and reconstructed by matching text. *)
+
+type atomic_replace_projection
+(** One inseparable Gate/recovery projection for a single atomic replacement.
+    The hidden constructor prevents a Gate effect for one target from being
+    paired with the durable recovery locator for another. *)
+
+val path_effect_projection_error_to_string :
+  path_effect_projection_error -> string
+
 val confined_root : confined_path -> string
 val confined_anchor_root : confined_path -> string
 val confined_root_relative_path : confined_path -> string
+val confined_relative_components : confined_path -> string list
+(** Validated lexical components relative to [confined_root]. This is the
+    component SSOT for capability traversal; callers must not split the string
+    returned by [confined_relative_path] to reconstruct it. *)
 val confined_relative_path : confined_path -> string
 val confined_host_path : confined_path -> string
 val confined_containment_path : confined_path -> string
 (** Canonical containment projection computed exactly once by the resolver
     using the requested endpoint semantics. *)
+val confined_endpoint_components : confined_path -> string list
+(** Validated canonical endpoint components relative to [confined_root]. This
+    is the endpoint SSOT for capability traversal and patch-source identity. *)
 val confined_endpoint_relative_path : confined_path -> string
-(** The same endpoint projection relative to [confined_root], suitable for
-    opening the already-confined referent through the root capability. *)
+(** Display projection derived from [confined_endpoint_components]. Callers
+    must not split this string to reconstruct capability traversal. *)
 
 val verify_confined_root_capability :
   confined_path -> _ Eio.Path.t -> (unit, string) result
@@ -87,34 +124,36 @@ val verify_confined_root_capability :
     is an explicit error; there is no string-path fallback. *)
 
 val path_effect_parent_scope :
-  relative_path:string ->
+  parent_components:string list ->
   resource:Eio.File.Stat.t ->
   create_missing_parents:string list ->
   created_directory_permissions:int ->
-  (path_effect_parent_scope, string) result
-(** Build a checked parent scope. [relative_path] is relative to the selected
-    root capability. [create_missing_parents] contains individual lexical
-    child names, in creation order; absolute paths, separators, [.], and [..]
-    are rejected. [created_directory_permissions] is the exact mode applied to
-    every listed directory and included in the Gate projection. *)
+  (path_effect_parent_scope, path_effect_projection_error) result
+(** Build a checked parent scope. [parent_components] is the already-traversed
+    path relative to the selected root capability; an empty list names the
+    root itself. [create_missing_parents] contains individual lexical child
+    names, in creation order. Both lists are validated as capability leaf
+    components and retained as the scope SSOT; the JSON [relative_path] is
+    derived from [parent_components]. [created_directory_permissions] is the
+    exact mode applied to every listed directory and included in the Gate
+    projection. *)
 
 val atomic_replace_effect :
   parent:path_effect_parent_scope ->
   result_file_permissions:int ->
   confined_path ->
-  (path_effect, string) result
+  (atomic_replace_projection, path_effect_projection_error) result
 val patch_then_atomic_replace_effect :
   parent:path_effect_parent_scope ->
-  source_relative_path:string ->
   source_resource:Eio.File.Stat.t ->
   result_file_permissions:int ->
   confined_path ->
-  (path_effect, string) result
+  (atomic_replace_projection, path_effect_projection_error) result
 val create_entry_exclusive_effect :
   parent:path_effect_parent_scope ->
   result_file_permissions:int ->
   confined_path ->
-  (path_effect, string) result
+  (path_effect, path_effect_projection_error) result
 (** Describe operations whose destination is the lexical directory entry.
     [result_file_permissions] is the exact mode applied to the replacement
     resource before it is renamed. A replaced symlink or missing entry becomes
@@ -122,13 +161,21 @@ val create_entry_exclusive_effect :
     preserve its pre-Gate mode by supplying that value. *)
 
 val append_pinned_resource_effect :
-  confined_path -> Eio.File.Stat.t -> (path_effect, string) result
+  confined_path ->
+  Eio.File.Stat.t ->
+  (path_effect, path_effect_projection_error) result
 (** Describe append on the already-open file resource represented by the
     supplied stat. This is deliberately the only constructor for a pinned
     effect, so append cannot accidentally degrade to a post-Gate path lookup. *)
 
 val path_effect_to_yojson : path_effect -> Yojson.Safe.t
 (** Stable, complete Gate input projection. *)
+
+val atomic_replace_gate_effect : atomic_replace_projection -> path_effect
+val atomic_replace_recovery_target :
+  atomic_replace_projection -> Fs_compat.atomic_replace_recovery_target
+(** Exact paired projections consumed by Gate and the filesystem writer. No
+    equivalent recovery-target accessor exists for append or exclusive create. *)
 
 val resolve_keeper_confined_path :
   config:Workspace.config ->
@@ -137,13 +184,13 @@ val resolve_keeper_confined_path :
   raw_path:string ->
   (confined_path, keeper_path_rejection) result
 (** Resolve a Keeper path to an allowed root plus a path relative to that root.
-    The string projection selects the capability and is not the I/O boundary;
-    callers must open [confined_anchor_root], descend through
-    [confined_root_relative_path] with [Eio.Path.open_dir], and perform all
-    filesystem operations on [confined_relative_path]. [endpoint] makes final
-    leaf containment explicit: atomic replacement uses [Lexical_entry], while
-    operations that read or mutate an existing referent use [Follow_referent].
-    After opening the root, callers must run
+    Target and endpoint string projections are observability views and are not
+    the I/O boundary; capability traversal uses
+    [confined_relative_components] or [confined_endpoint_components]
+    according to the operation. [endpoint]
+    makes final leaf containment explicit: atomic replacement uses
+    [Lexical_entry], while operations that read or mutate an existing referent
+    use [Follow_referent]. After opening the root, callers must run
     [verify_confined_root_capability] before Gate evaluation.
 
     For roots inside the project, the project root is the anchor. The project

--- a/lib/keeper/keeper_heartbeat_loop_cycle.ml
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.ml
@@ -207,6 +207,7 @@ let run_keeper_cycle_admitted
           (Keeper_unified_turn.run_keeper_cycle
              ~config:ctx.config
              ~meta:meta_after_triage
+             ~publication_recovery_registry:ctx.publication_recovery_registry
              ~observation
              ~generation:meta_after_triage.runtime.generation
              ~wake

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -1045,11 +1045,38 @@ let start_keepalive
         let record_completed_lane () =
           record_stopped (if Atomic.get stop then "manual stop" else "normal exit")
         in
+        let record_lane_exception ?backtrace exn =
+          Otel_metric_store.inc_counter
+            Keeper_metrics.(to_string HeartbeatFailures)
+            ~labels:[ "keeper", live_meta.name; "phase", "lane_crash" ]
+            ();
+          Log.Keeper.emit
+            Log.Error
+            ~category:Log.Heartbeat
+            ~details:
+              (`Assoc
+                (("keeper", `String live_meta.name)
+                 :: ("error", `String (Printexc.to_string exn))
+                 :: (match backtrace with
+                     | None -> []
+                     | Some backtrace ->
+                       [ ( "backtrace"
+                         , `String (Printexc.raw_backtrace_to_string backtrace) ) ])))
+            (Printf.sprintf
+               "keeper lane for %s crashed: %s"
+               live_meta.name
+               (Printexc.to_string exn));
+          record_crash (Keeper_registry.Exception (Printexc.to_string exn))
+        in
         let terminalize_lane = function
           | Keeper_lane.Completed -> record_completed_lane ()
           | Keeper_lane.Shutdown_before_start ->
             record_stopped "shutdown requested before lane start"
           | Keeper_lane.Shutdown_requested -> record_stopped "shutdown requested"
+          | Keeper_lane.Shutdown_cancel_failed failure ->
+            record_lane_exception
+              ~backtrace:failure.backtrace
+              failure.cause
           | Keeper_lane.Cancelled_by_parent _ ->
             if Atomic.get stop || Shutdown.is_shutting_down_global ()
             then record_stopped "cancelled during shutdown"
@@ -1064,24 +1091,7 @@ let start_keepalive
           | Keeper_lane.Failed exn ->
             if Atomic.get stop
             then record_stopped "manual stop"
-            else (
-              Otel_metric_store.inc_counter
-                Keeper_metrics.(to_string HeartbeatFailures)
-                ~labels:[ "keeper", live_meta.name; "phase", "lane_crash" ]
-                ();
-              Log.Keeper.emit
-                Log.Error
-                ~category:Log.Heartbeat
-                ~details:
-                  (`Assoc
-                    [ "keeper", `String live_meta.name
-                    ; "error", `String (Printexc.to_string exn)
-                    ])
-                (Printf.sprintf
-                   "keeper lane for %s crashed: %s"
-                   live_meta.name
-                   (Printexc.to_string exn));
-              record_crash (Keeper_registry.Exception (Printexc.to_string exn)))
+            else record_lane_exception exn
         in
         (* Lane cleanup is declared outside [run] because [Keeper_lane.fork]
            invokes it only after the run scope and all child fibers join. *)
@@ -1144,6 +1154,10 @@ let start_keepalive
            Keeper_lane.fork
              ~sw:ctx.sw
              reg.lane
+             ~with_run_scope:
+               (Keeper_publication_recovery_scope.with_lane_scope
+                  ~registry:ctx.publication_recovery_registry
+                  ~entry:reg)
              ~run:(fun lane_sw ->
         let ctx = { ctx with sw = lane_sw } in
         (* The sidecar is part of this Keeper lane. It cannot outlive the

--- a/lib/keeper/keeper_lane.ml
+++ b/lib/keeper/keeper_lane.ml
@@ -1,7 +1,13 @@
+type shutdown_cancel_failure =
+  { cause : exn
+  ; backtrace : Printexc.raw_backtrace
+  }
+
 type outcome =
   | Completed
   | Shutdown_before_start
   | Shutdown_requested
+  | Shutdown_cancel_failed of shutdown_cancel_failure
   | Cancelled_by_parent of exn
   | Failed of exn
 
@@ -10,15 +16,30 @@ type exit =
   ; cleanup_error : string option
   }
 
+type cancellation_control =
+  { context : Eio.Cancel.t
+  ; owner_domain : Domain.id
+  }
+
 type state =
   | Not_started
   | Starting
-  | Running of Eio.Switch.t
+  | Running of cancellation_control
   | Cancellation_requested
   | Finalizing
   | Exited
 
 exception Shutdown_cancel
+exception Shutdown_cancel_failure of shutdown_cancel_failure
+
+type cancellation_origin =
+  | Shutdown_request
+  | External_cancel of exn
+
+let classify_cancellation_cause = function
+  | Shutdown_cancel -> Shutdown_request
+  | cause -> External_cancel cause
+;;
 
 module Id = struct
   type t = string
@@ -57,11 +78,6 @@ type t =
   ; state : state Atomic.t
   ; exited_p : exit Eio.Promise.t
   ; exited_r : exit Eio.Promise.u
-  ; shutdown_requested : bool Atomic.t
-    (* Set once [request_cancel] is called (shutdown of this lane). Lets a
-       supervised body distinguish an operator-sanctioned shutdown cancel
-       from a parent/restart cancel after the fact, since both surface as
-       [Eio.Cancel.Cancelled]. *)
   }
 
 type start_error =
@@ -73,7 +89,9 @@ type cancel_result =
   | Cancel_requested
   | Cancel_already_requested
   | Cancel_already_exiting
-  | Cancel_signal_failed of exn
+  | Cancel_wrong_domain
+  | Cancel_not_committed of exn
+  | Cancel_committed_with_failure of exn
 
 let start_error_to_string = function
   | Already_started -> "lane already started"
@@ -87,7 +105,6 @@ let create () =
   ; state = Atomic.make Not_started
   ; exited_p
   ; exited_r
-  ; shutdown_requested = Atomic.make false
   }
 ;;
 
@@ -95,7 +112,6 @@ let id t = t.id
 let exited t = t.exited_p
 let peek_exit t = Eio.Promise.peek t.exited_p
 let await_exit t = Eio.Promise.await t.exited_p
-let shutdown_requested t = Atomic.get t.shutdown_requested
 
 let rec claim_start t =
   if Atomic.compare_and_set t.state Not_started Starting
@@ -111,16 +127,17 @@ type attach_result =
   | Scope_attached
   | Cancel_before_attach
 
-let rec attach_scope t lane_sw =
+let rec attach_control t context =
   let current = Atomic.get t.state in
   match current with
   | Starting ->
-    if Atomic.compare_and_set t.state current (Running lane_sw)
+    let control = { context; owner_domain = Domain.self () } in
+    if Atomic.compare_and_set t.state current (Running control)
     then Scope_attached
-    else attach_scope t lane_sw
+    else attach_control t context
   | Cancellation_requested -> Cancel_before_attach
   | Not_started | Running _ | Finalizing | Exited ->
-    invalid_arg "Keeper_lane.attach_scope: invalid lane state"
+    invalid_arg "Keeper_lane.attach_control: invalid lane state"
 ;;
 
 let cleanup_result cleanup outcome =
@@ -163,10 +180,6 @@ let resolve_exit_without_cleanup t outcome =
 ;;
 
 let rec request_cancel t =
-  (* Record that a shutdown cancel was requested for this lane before we touch
-     the state, so a supervised body's cancellation handler can tell this apart
-     from a parent/restart cancel even if the state races to [Exited]. *)
-  Atomic.set t.shutdown_requested true;
   let current = Atomic.get t.state in
   match current with
   | Not_started ->
@@ -182,23 +195,37 @@ let rec request_cancel t =
     if Atomic.compare_and_set t.state current Cancellation_requested
     then Cancel_requested
     else request_cancel t
-  | Running lane_sw ->
-    if Atomic.compare_and_set t.state current Cancellation_requested
-    then
-      (try
-         Eio.Switch.fail lane_sw Shutdown_cancel;
-         Cancel_requested
-       with
-       | Eio.Cancel.Cancelled _ as exn -> raise exn
-       | exn ->
-         let _ = Atomic.compare_and_set t.state Cancellation_requested current in
-         Cancel_signal_failed exn)
-    else request_cancel t
+  | Running control ->
+    if Domain.self () <> control.owner_domain
+    then Cancel_wrong_domain
+    else
+      (match Eio.Cancel.get_error control.context with
+       | Some _ -> Cancel_already_exiting
+       | None ->
+         if Atomic.compare_and_set t.state current Cancellation_requested
+         then
+           (try
+              Eio.Cancel.cancel control.context Shutdown_cancel;
+              Cancel_requested
+            with
+            | exn ->
+              (match Eio.Cancel.get_error control.context with
+               | Some (Eio.Cancel.Cancelled _) -> Cancel_committed_with_failure exn
+               | None ->
+                 let _ =
+                   Atomic.compare_and_set
+                     t.state
+                     Cancellation_requested
+                     (Running control)
+                 in
+                 Cancel_not_committed exn
+               | Some _ -> Cancel_not_committed exn))
+         else request_cancel t)
   | Cancellation_requested -> Cancel_already_requested
   | Finalizing | Exited -> Cancel_already_exiting
 ;;
 
-let fork ~sw t ~run ~cleanup =
+let fork ~sw t ~with_run_scope ~run ~cleanup =
   match claim_start t with
   | Error _ as error -> error
   | Ok () ->
@@ -208,15 +235,43 @@ let fork ~sw t ~run ~cleanup =
          Atomic.set started true;
          let outcome =
            try
-             Eio.Switch.run (fun lane_sw ->
-               match attach_scope t lane_sw with
-               | Scope_attached -> run lane_sw
-               | Cancel_before_attach ->
-                 Eio.Switch.fail lane_sw Shutdown_cancel;
-                 Eio.Switch.check lane_sw);
+             (* Attach a cancellation scope before [with_run_scope] can wait
+                for an external readiness promise. The actual lane switch is
+                nested inside the run scope so every lane child still joins
+                before that scope releases its resources. *)
+             Eio.Cancel.sub (fun control ->
+               try
+                 match attach_control t control with
+                 | Cancel_before_attach ->
+                   Eio.Cancel.cancel control Shutdown_cancel;
+                   Eio.Cancel.check control
+                 | Scope_attached ->
+                   Eio.Cancel.check control;
+                   with_run_scope (fun () ->
+                     Eio.Switch.run (fun lane_sw -> run lane_sw));
+                   Eio.Cancel.check control
+               with
+               | exn ->
+                 let backtrace = Printexc.get_raw_backtrace () in
+                 (match Eio.Cancel.get_error control, exn with
+                  | ( Some (Eio.Cancel.Cancelled Shutdown_cancel)
+                    , Eio.Cancel.Cancelled Shutdown_cancel ) ->
+                    Printexc.raise_with_backtrace exn backtrace
+                  | Some (Eio.Cancel.Cancelled Shutdown_cancel), exn ->
+                    let cause =
+                      match exn with
+                      | Eio.Cancel.Cancelled cause -> cause
+                      | exn -> exn
+                    in
+                    Printexc.raise_with_backtrace
+                      (Shutdown_cancel_failure { cause; backtrace })
+                      backtrace
+                  | (Some _ | None), exn ->
+                    Printexc.raise_with_backtrace exn backtrace));
              Completed
            with
-           | Shutdown_cancel -> Shutdown_requested
+           | Shutdown_cancel_failure failure -> Shutdown_cancel_failed failure
+           | Eio.Cancel.Cancelled Shutdown_cancel -> Shutdown_requested
            | Eio.Cancel.Cancelled cause -> Cancelled_by_parent cause
            | exn -> Failed exn
          in

--- a/lib/keeper/keeper_lane.mli
+++ b/lib/keeper/keeper_lane.mli
@@ -1,8 +1,11 @@
 (** One structured-concurrency lane owned by one Keeper registry entry.
 
-    The lane switch is created inside the forked fiber.  [exited] resolves
-    only after [Eio.Switch.run] has joined every child fiber and released
-    every resource attached to that switch. *)
+    A cancellation context is attached as soon as the forked fiber starts,
+    before the run-scope admission boundary can wait. The child-owning lane
+    switch is nested inside that run scope. [exited] therefore resolves only
+    after every child has joined and every full-lane resource has been
+    released, while an individual cancellation can also interrupt a blocked
+    admission. *)
 
 type t
 
@@ -14,10 +17,16 @@ module Id : sig
   val equal : t -> t -> bool
 end
 
+type shutdown_cancel_failure =
+  { cause : exn
+  ; backtrace : Printexc.raw_backtrace
+  }
+
 type outcome =
   | Completed
   | Shutdown_before_start
   | Shutdown_requested
+  | Shutdown_cancel_failed of shutdown_cancel_failure
   | Cancelled_by_parent of exn
   | Failed of exn
 
@@ -25,6 +34,10 @@ type exit =
   { outcome : outcome
   ; cleanup_error : string option
   }
+
+type cancellation_origin =
+  | Shutdown_request
+  | External_cancel of exn
 
 type start_error =
   | Already_started
@@ -35,7 +48,9 @@ type cancel_result =
   | Cancel_requested
   | Cancel_already_requested
   | Cancel_already_exiting
-  | Cancel_signal_failed of exn
+  | Cancel_wrong_domain
+  | Cancel_not_committed of exn
+  | Cancel_committed_with_failure of exn
 
 val start_error_to_string : start_error -> string
 
@@ -45,27 +60,36 @@ val id : t -> Id.t
 val fork :
   sw:Eio.Switch.t ->
   t ->
+  with_run_scope:((unit -> unit) -> unit) ->
   run:(Eio.Switch.t -> unit) ->
   cleanup:(outcome -> (unit, string) result) ->
   (unit, start_error) result
 (** A fork rejected by an already-cancelling Eio switch returns
     [Error (Fork_failed _)] and resolves [exited]. Cleanup and exit resolution
-    are exact-once even if switch cancellation races the child start. *)
+    are exact-once even if switch cancellation races the child start.
+    [with_run_scope] must own every resource whose lifetime is the full Keeper
+    lane; it wraps the child-owning lane switch itself, so it returns only
+    after all lane children have joined. The separately attached cancellation
+    context makes cancellation total before admission completes without
+    recording a competing switch failure that could erase release evidence. *)
 
 (** Resolve a lane for which the launch gate rejected the fiber before it
     started.  This keeps the join contract total for every registry entry. *)
 val reject_before_start : t -> reason:exn -> (unit, start_error) result
 
 (** Request cancellation of this exact lane scope. The request is remembered
-    even if the fiber has not attached its switch yet. This does not join; use
-    [await_exit] for that boundary. *)
+    even if the fiber has not attached its cancellation context yet. This does
+    not join; use [await_exit] for that boundary. A cancellation callback can
+    fail after Eio has committed the context to cancellation; that distinct
+    result must not be retried as if no signal had been delivered. Eio owns
+    attached cancellation contexts per domain, so a request from another
+    domain is rejected without changing a running lane. *)
 val request_cancel : t -> cancel_result
 
-val shutdown_requested : t -> bool
-(** [true] once [request_cancel] has been called on this lane. Lets a
-    supervised body classify a resulting [Eio.Cancel.Cancelled] as an
-    operator-sanctioned shutdown (graceful stop) rather than a parent/restart
-    cancel, since both surface as the same exception. *)
+val classify_cancellation_cause : exn -> cancellation_origin
+(** Classify the payload of [Eio.Cancel.Cancelled] by exact exception identity.
+    Supervised lane bodies use this instead of inferring cancellation origin
+    from lifecycle timing or exception text. *)
 
 val exited : t -> exit Eio.Promise.t
 val peek_exit : t -> exit option

--- a/lib/keeper/keeper_publication_recovery_scope.ml
+++ b/lib/keeper/keeper_publication_recovery_scope.ml
@@ -1,0 +1,133 @@
+type failure =
+  | Registry_not_provided
+  | Registry_entry_not_found of
+      { base_path : string
+      ; keeper_name : string
+      }
+  | Registry_entry_unhealthy of Keeper_registry.registry_entry_health
+  | Lane_open_failed of Fs_compat.publication_recovery_lane_open_error
+  | Access_already_attached
+  | Access_not_attached
+  | Body_and_detach_failed of
+      { body : exn
+      ; body_backtrace : Printexc.raw_backtrace
+      ; detach : failure
+      }
+
+exception Scope_failed of failure
+exception Scope_detach_failed_on_cancellation of exn * failure
+
+let rec failure_to_string = function
+  | Registry_not_provided ->
+    "publication recovery registry is not present in this Keeper runtime context"
+  | Registry_entry_not_found { base_path; keeper_name } ->
+    Printf.sprintf
+      "Keeper publication recovery registry entry is not present: base_path=%S keeper=%S"
+      base_path
+      keeper_name
+  | Registry_entry_unhealthy health ->
+    Printf.sprintf
+      "Keeper publication recovery registry entry is unhealthy: %s"
+      (Keeper_registry.registry_entry_validation_error_to_string health)
+  | Lane_open_failed error ->
+    Fs_compat.publication_recovery_lane_open_error_to_string error
+  | Access_already_attached ->
+    "publication recovery access is already attached to this Keeper lane"
+  | Access_not_attached ->
+    "publication recovery access is not attached to this Keeper lane"
+  | Body_and_detach_failed { body; detach; _ } ->
+    Printf.sprintf
+      "Keeper lane body failed and publication recovery access could not detach: body=%s; detach=%s"
+      (Printexc.to_string body)
+      (failure_to_string detach)
+;;
+
+type turn_resources =
+  { entry : Keeper_registry.registry_entry
+  ; registry : Fs_compat.publication_recovery_registry
+  ; access : Fs_compat.publication_recovery_access
+  }
+
+let resolve_turn_resources ~registry ~base_path ~keeper_name =
+  match registry with
+  | None -> Error Registry_not_provided
+  | Some registry ->
+    (match Keeper_registry.get_with_health ~base_path keeper_name with
+     | None ->
+       Error (Registry_entry_not_found { base_path; keeper_name })
+     | Some (entry, Keeper_registry.Healthy) ->
+       (match Keeper_registry.publication_recovery_access entry with
+        | None -> Error Access_not_attached
+        | Some access -> Ok { entry; registry; access })
+     | Some (_, health) -> Error (Registry_entry_unhealthy health))
+;;
+
+let detach entry =
+  match Keeper_registry.detach_publication_recovery_access entry with
+  | Ok () -> Ok ()
+  | Error Keeper_registry.Publication_recovery_not_attached ->
+    Error Access_not_attached
+;;
+
+let run_attached ~entry ~access body =
+  match Keeper_registry.attach_publication_recovery_access entry access with
+  | Error Keeper_registry.Publication_recovery_already_attached ->
+    raise (Scope_failed Access_already_attached)
+  | Ok () ->
+    (match body () with
+     | value ->
+       (match detach entry with
+        | Ok () -> value
+        | Error failure -> raise (Scope_failed failure))
+     | exception (Eio.Cancel.Cancelled reason as cancellation) ->
+       let backtrace = Printexc.get_raw_backtrace () in
+       (match detach entry with
+        | Ok () -> Printexc.raise_with_backtrace cancellation backtrace
+        | Error failure ->
+          Printexc.raise_with_backtrace
+            (Eio.Cancel.Cancelled
+               (Scope_detach_failed_on_cancellation (reason, failure)))
+            backtrace)
+     | exception body ->
+       let body_backtrace = Printexc.get_raw_backtrace () in
+       (match detach entry with
+        | Ok () -> Printexc.raise_with_backtrace body body_backtrace
+        | Error failure ->
+          raise
+            (Scope_failed
+               (Body_and_detach_failed
+                  { body; body_backtrace; detach = failure }))))
+;;
+
+let with_lane_scope ~registry ~entry body =
+  match registry with
+  | None -> raise (Scope_failed Registry_not_provided)
+  | Some registry ->
+    (match
+       Fs_compat.await_publication_recovery_lane_reconciliation
+         ~registry
+         ~owner:entry.Keeper_registry.name
+     with
+     | Error error -> raise (Scope_failed (Lane_open_failed error))
+     | Ok () ->
+       (match
+          Fs_compat.with_publication_recovery_lane
+            ~registry
+            ~owner:entry.Keeper_registry.name
+            (fun access -> run_attached ~entry ~access body)
+        with
+        | Ok value -> value
+        | Error error -> raise (Scope_failed (Lane_open_failed error))))
+;;
+
+let () =
+  Printexc.register_printer (function
+    | Scope_failed failure -> Some (failure_to_string failure)
+    | Scope_detach_failed_on_cancellation (reason, failure) ->
+      Some
+        (Printf.sprintf
+           "publication recovery detach failed during cancellation: reason=%s failure=%s"
+           (Printexc.to_string reason)
+           (failure_to_string failure))
+    | _ -> None)
+;;

--- a/lib/keeper/keeper_publication_recovery_scope.mli
+++ b/lib/keeper/keeper_publication_recovery_scope.mli
@@ -1,0 +1,49 @@
+(** Binds one durable publication-recovery store to one Keeper lane lifetime. *)
+
+type failure =
+  | Registry_not_provided
+  | Registry_entry_not_found of
+      { base_path : string
+      ; keeper_name : string
+      }
+  | Registry_entry_unhealthy of Keeper_registry.registry_entry_health
+  | Lane_open_failed of Fs_compat.publication_recovery_lane_open_error
+  | Access_already_attached
+  | Access_not_attached
+  | Body_and_detach_failed of
+      { body : exn
+      ; body_backtrace : Printexc.raw_backtrace
+      ; detach : failure
+      }
+
+exception Scope_failed of failure
+exception Scope_detach_failed_on_cancellation of exn * failure
+
+val failure_to_string : failure -> string
+
+type turn_resources =
+  { entry : Keeper_registry.registry_entry
+  ; registry : Fs_compat.publication_recovery_registry
+  ; access : Fs_compat.publication_recovery_access
+  }
+
+val resolve_turn_resources
+  :  registry:Fs_compat.publication_recovery_registry option
+  -> base_path:string
+  -> keeper_name:string
+  -> (turn_resources, failure) result
+(** Performs one exact registry-entry lookup at the admitted turn boundary.
+    The returned immutable capabilities are then threaded through the turn;
+    individual tools neither repeat the lookup nor reopen the lane store. *)
+
+val with_lane_scope :
+  registry:Fs_compat.publication_recovery_registry option ->
+  entry:Keeper_registry.registry_entry ->
+  (unit -> 'a) ->
+  'a
+(** [with_lane_scope] first awaits exactly [entry.name]'s one-shot
+    reconciliation settlement, then opens that lane store, publishes its opaque
+    access on the exact registry entry, runs [body], detaches the access, and
+    only then allows the store to close. It never waits on another owner, a
+    timeout, or a global activation barrier. Cancellation and a simultaneous
+    detach invariant failure retain both causes. *)

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -9,6 +9,47 @@ open Keeper_types_profile
 
 include Keeper_registry_setup
 
+type publication_recovery_attach_error = Publication_recovery_already_attached
+type publication_recovery_detach_error = Publication_recovery_not_attached
+
+let rec attach_publication_recovery_access
+          (entry : registry_entry)
+          access
+  =
+  let current = Atomic.get entry.publication_recovery_lane_state in
+  match current with
+  | Publication_recovery_attached _ ->
+    Error Publication_recovery_already_attached
+  | Publication_recovery_detached ->
+    if
+      Atomic.compare_and_set
+        entry.publication_recovery_lane_state
+        current
+        (Publication_recovery_attached access)
+    then Ok ()
+    else attach_publication_recovery_access entry access
+;;
+
+let publication_recovery_access (entry : registry_entry) =
+  match Atomic.get entry.publication_recovery_lane_state with
+  | Publication_recovery_detached -> None
+  | Publication_recovery_attached access -> Some access
+;;
+
+let rec detach_publication_recovery_access (entry : registry_entry) =
+  let current = Atomic.get entry.publication_recovery_lane_state in
+  match current with
+  | Publication_recovery_detached -> Error Publication_recovery_not_attached
+  | Publication_recovery_attached _ ->
+    if
+      Atomic.compare_and_set
+        entry.publication_recovery_lane_state
+        current
+        Publication_recovery_detached
+    then Ok ()
+    else detach_publication_recovery_access entry
+;;
+
 
 let set_turn_phase ~base_path name (turn_phase : packed_turn_phase) =
   (* RFC-0072 Phase 4b + Phase 5: dispatch via [resolve_turn_phase_transition]

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -18,6 +18,22 @@ open Keeper_types_profile
     [Keeper_registry.packed_turn_phase] etc. unchanged. *)
 include module type of Keeper_registry_types
 
+type publication_recovery_attach_error = Publication_recovery_already_attached
+type publication_recovery_detach_error = Publication_recovery_not_attached
+
+val attach_publication_recovery_access :
+  registry_entry ->
+  Fs_compat.publication_recovery_access ->
+  (unit, publication_recovery_attach_error) result
+
+val publication_recovery_access :
+  registry_entry -> Fs_compat.publication_recovery_access option
+
+val detach_publication_recovery_access :
+  registry_entry -> (unit, publication_recovery_detach_error) result
+(** These transitions mutate only the exact entry-local atomic. They never
+    look up by name and never reopen a recovery store. *)
+
 (** [validate_turn_phase_transition] stays in Keeper_registry because its
     implementation depends on [Keeper_fsm_guard_runtime], not a pure type-level
     dependency. *)

--- a/lib/keeper/keeper_registry_setup.ml
+++ b/lib/keeper/keeper_registry_setup.ml
@@ -476,6 +476,8 @@ let register_with_state_result
     ; started_at = Time_compat.now ()
     ; grpc_close = Atomic.make None
     ; lane = Keeper_lane.create ()
+    ; publication_recovery_lane_state =
+        Atomic.make Publication_recovery_detached
     ; done_p
     ; done_r
     ; restart_count = 0
@@ -683,6 +685,8 @@ let register_restarting ~base_path name meta
     ; started_at = Time_compat.now ()
     ; grpc_close = Atomic.make None
     ; lane = Keeper_lane.create ()
+    ; publication_recovery_lane_state =
+        Atomic.make Publication_recovery_detached
     ; done_p
     ; done_r
     ; restart_count = 0

--- a/lib/keeper/keeper_registry_types.ml
+++ b/lib/keeper/keeper_registry_types.ml
@@ -97,6 +97,10 @@ type lifecycle_reservation_snapshot =
   ; purpose : lifecycle_transaction_purpose
   }
 
+type publication_recovery_lane_state =
+  | Publication_recovery_detached
+  | Publication_recovery_attached of Fs_compat.publication_recovery_access
+
 type registry_entry =
   { base_path : string
   ; name : string
@@ -111,6 +115,8 @@ type registry_entry =
   ; started_at : float
   ; grpc_close : (unit -> unit) option Atomic.t
   ; lane : Keeper_lane.t
+  ; publication_recovery_lane_state :
+      publication_recovery_lane_state Atomic.t
   ; done_p : done_resolution Eio.Promise.t
   ; done_r : done_resolution Eio.Promise.u
   ; restart_count : int

--- a/lib/keeper/keeper_registry_types.mli
+++ b/lib/keeper/keeper_registry_types.mli
@@ -417,6 +417,10 @@ type lifecycle_reservation_snapshot =
   ; purpose : lifecycle_transaction_purpose
   }
 
+type publication_recovery_lane_state =
+  | Publication_recovery_detached
+  | Publication_recovery_attached of Fs_compat.publication_recovery_access
+
 type registry_entry = {
   base_path : string;
       (** Canonical workspace identity from
@@ -441,6 +445,10 @@ type registry_entry = {
   lane : Keeper_lane.t;
       (** Structured-concurrency scope owned by this exact registry entry.
           Its exit promise is the authoritative lane join signal. *)
+  publication_recovery_lane_state : publication_recovery_lane_state Atomic.t;
+      (** Exact lane-lifetime recovery capability. It is attached before the
+          lane switch starts and detached only after that switch has joined
+          every child. Reads never reopen a store. *)
   done_p : done_resolution Eio.Promise.t;
   done_r : done_resolution Eio.Promise.u;
       (** Completion resolver owned by {!resolve_done}. Runtime callers must

--- a/lib/keeper/keeper_run_tools.mli
+++ b/lib/keeper/keeper_run_tools.mli
@@ -68,6 +68,8 @@ type agent_setup =
 val prepare_agent_setup
   :  config:Workspace.config
   -> meta:Keeper_meta_contract.keeper_meta
+  -> publication_recovery_registry:Fs_compat.publication_recovery_registry
+  -> publication_recovery_access:Fs_compat.publication_recovery_access
   -> turn_ctx_cell:Keeper_tool_call_log.turn_ctx_cell
   -> ctx_work:working_context
   -> session:Keeper_types.session_context

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -11,6 +11,9 @@ open Keeper_agent_prompt_metrics
 let prepare_agent_setup
       ~(config : Workspace.config)
       ~(meta : Keeper_meta_contract.keeper_meta)
+      ~(publication_recovery_registry :
+          Fs_compat.publication_recovery_registry)
+      ~(publication_recovery_access : Fs_compat.publication_recovery_access)
       ~(turn_ctx_cell : Keeper_tool_call_log.turn_ctx_cell)
       ~(ctx_work : working_context)
       ~(session : Keeper_types.session_context)
@@ -88,6 +91,8 @@ let prepare_agent_setup
     Keeper_tools_oas_bundle.make_tool_bundle
       ~config
       ~meta
+      ~publication_recovery_registry
+      ~publication_recovery_access
       ~ctx_snapshot
       ~search_fn:(fun () -> !local_search_fn_ref ())
       ?continuation_channel

--- a/lib/keeper/keeper_shutdown_prepare_join.ml
+++ b/lib/keeper/keeper_shutdown_prepare_join.ml
@@ -180,6 +180,8 @@ let lane_outcome = function
   | Keeper_lane.Completed -> Lane_completed
   | Keeper_lane.Shutdown_before_start -> Lane_shutdown_requested
   | Keeper_lane.Shutdown_requested -> Lane_shutdown_requested
+  | Keeper_lane.Shutdown_cancel_failed failure ->
+    Lane_failed (Printexc.to_string failure.cause)
   | Keeper_lane.Cancelled_by_parent exn ->
     Lane_cancelled_by_parent (Printexc.to_string exn)
   | Keeper_lane.Failed exn -> Lane_failed (Printexc.to_string exn)
@@ -364,8 +366,15 @@ let join_prepared ~config ~(entry : Keeper_registry.registry_entry) ~operation =
      | Some detail -> cancellation_error ~config operation Turn_cancel detail
      | None ->
        (match Keeper_lane.request_cancel current.lane with
-        | Keeper_lane.Cancel_signal_failed exn ->
+        | Keeper_lane.Cancel_not_committed exn
+        | Keeper_lane.Cancel_committed_with_failure exn ->
           cancellation_error ~config operation Lane_cancel (Printexc.to_string exn)
+        | Keeper_lane.Cancel_wrong_domain ->
+          cancellation_error
+            ~config
+            operation
+            Lane_cancel
+            "lane cancellation requested from a non-owning domain"
         | Keeper_lane.Cancel_requested
         | Keeper_lane.Cancel_already_requested
         | Keeper_lane.Cancel_already_exiting ->
@@ -391,6 +400,7 @@ let join_prepared ~config ~(entry : Keeper_registry.registry_entry) ~operation =
                   detail)
            | Keeper_lane.Completed
            | Keeper_lane.Shutdown_requested
+           | Keeper_lane.Shutdown_cancel_failed _
            | Keeper_lane.Cancelled_by_parent _
            | Keeper_lane.Failed _ -> ());
           let terminal_result = Eio.Promise.await current.done_p in

--- a/lib/keeper/keeper_supervisor_launch.ml
+++ b/lib/keeper/keeper_supervisor_launch.ml
@@ -119,6 +119,10 @@ let launch_supervised_fiber_body
         Keeper_lane.fork
           ~sw:ctx.sw
           reg.lane
+          ~with_run_scope:
+            (Keeper_publication_recovery_scope.with_lane_scope
+               ~registry:ctx.publication_recovery_registry
+               ~entry:reg)
           ~run:body
           ~cleanup:(fun _ -> Ok ())
       with
@@ -212,17 +216,12 @@ let launch_supervised_fiber_body
     fork_body (fun lane_sw ->
       let ctx = { ctx with sw = lane_sw } in
       let resolved = Atomic.make false in
-      (* Issue #18901 follow-up: distinguish parent-cancellation from
-         genuine missed-resolution in the finally branch. The body's
-         try/with re-raises [Eio.Cancel.Cancelled] (line 281 area)
-         which then propagates to the surrounding switch, leaving the
-         finally to fire with [resolved=false]. Without this flag the
-         finally cannot tell whether the unresolved drop was a parent
-         cancel (supervisor restart, sibling failure) or a real
-         missed-resolution bug — both collapsed into [Unexpected].
-         Setting the flag from the cancel handler keeps the typed
-         [fiber_drop_cause] payload accurate. *)
+      (* Preserve the exact typed cancellation origin after the supervised
+         body consumes [Eio.Cancel.Cancelled]. The finally branch can then
+         distinguish an operator lane shutdown from parent cancellation and
+         from a genuine missed-resolution bug. *)
       let cancelled_by_parent = Atomic.make false in
+      let cancelled_by_shutdown_request = Atomic.make false in
       let resolve_done ~source value =
         if not (Atomic.get resolved) then
           (* Issue #18335: the keepalive layer (keeper_keepalive.ml:760-791)
@@ -294,8 +293,11 @@ let launch_supervised_fiber_body
                    "normal exit"
                    ()
            with
-           | Eio.Cancel.Cancelled _ ->
-             Atomic.set cancelled_by_parent true;
+           | Eio.Cancel.Cancelled cause ->
+             (match Keeper_lane.classify_cancellation_cause cause with
+              | Keeper_lane.Shutdown_request ->
+                Atomic.set cancelled_by_shutdown_request true
+              | Keeper_lane.External_cancel _ -> Atomic.set cancelled_by_parent true);
              (* Do NOT re-raise Cancelled in a forked fiber, as it cancels the parent switch. *)
              ()
            | exn ->
@@ -394,18 +396,12 @@ let launch_supervised_fiber_body
                   (resolve_done
                      ~source:"supervisor_shutdown_cleanup"
                      (`Crashed "shutdown")))
-              else if Keeper_lane.shutdown_requested reg.lane
+              else if Atomic.get cancelled_by_shutdown_request
               then (
-                (* Codex #24135 finding 1: operator-sanctioned shutdown of this
-                   supervised keeper. [Keeper_shutdown_prepare_join] called
-                   [Keeper_lane.request_cancel], which failed the lane switch
-                   with [Shutdown_cancel]; the body caught the resulting
-                   cancellation and set [cancelled_by_parent]. Global shutdown
-                   is not in progress, so without this branch the keeper would
-                   fall through to the parent-cancel path and be
-                   crashed/tombstoned. A requested shutdown is a graceful stop:
-                   record it as [Stopped] exactly like the normal-exit path so
-                   the operator observes a joined stop, not a crash. *)
+                (* Exact exception identity distinguishes an operator lane
+                   shutdown from parent cancellation. A requested shutdown is
+                   a graceful stop, so the operator observes a joined stop
+                   rather than a crash/tombstone. *)
                 Log.Keeper.info
                   "%s: fiber stopped by shutdown request (graceful, not a crash)"
                   meta.name;

--- a/lib/keeper/keeper_tool_boundary.ml
+++ b/lib/keeper/keeper_tool_boundary.ml
@@ -7,10 +7,26 @@ type 'a context = {
   clock : 'a Eio.Time.clock;
   proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option;
   net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option;
+  publication_recovery_registry : Fs_compat.publication_recovery_registry option;
 }
 
-let create ~config ~agent_name ~sw ~clock ~proc_mgr ~net =
-  { config; agent_name; sw; clock; proc_mgr; net }
+let create
+      ~config
+      ~agent_name
+      ~sw
+      ~clock
+      ~proc_mgr
+      ~net
+      ~publication_recovery_registry
+  =
+  { config
+  ; agent_name
+  ; sw
+  ; clock
+  ; proc_mgr
+  ; net
+  ; publication_recovery_registry
+  }
 
 let to_tool_keeper_context (ctx : _ context) : _ Keeper_tool_surface.context =
   {
@@ -20,6 +36,7 @@ let to_tool_keeper_context (ctx : _ context) : _ Keeper_tool_surface.context =
     clock = ctx.clock;
     proc_mgr = ctx.proc_mgr;
     net = ctx.net;
+    publication_recovery_registry = ctx.publication_recovery_registry;
   }
 
 let dispatch ctx ~name ~args =

--- a/lib/keeper/keeper_tool_boundary.mli
+++ b/lib/keeper/keeper_tool_boundary.mli
@@ -10,6 +10,7 @@ type 'a context = {
   clock : 'a Eio.Time.clock;
   proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option;
   net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option;
+  publication_recovery_registry : Fs_compat.publication_recovery_registry option;
 }
 
 val create :
@@ -19,6 +20,7 @@ val create :
   clock:'a Eio.Time.clock ->
   proc_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t option ->
   net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option ->
+  publication_recovery_registry:Fs_compat.publication_recovery_registry option ->
   'a context
 
 val dispatch :

--- a/lib/keeper/keeper_tool_dispatch_runtime.ml
+++ b/lib/keeper/keeper_tool_dispatch_runtime.ml
@@ -150,6 +150,9 @@ let descriptor_route_invariant_error ~keeper_name ~tool_name descriptor =
 let execute_keeper_tool_call_with_outcome
       ~(config : Workspace.config)
       ~(meta : keeper_meta)
+      ~(publication_recovery_registry :
+          Fs_compat.publication_recovery_registry)
+      ~(publication_recovery_access : Fs_compat.publication_recovery_access)
       ~(ctx_work : working_context)
       ?turn_sandbox_factory
       ~(exec_cache : Masc_exec.Exec_cache.t option)
@@ -170,31 +173,6 @@ let execute_keeper_tool_call_with_outcome
   : executed_tool_result
   =
   let args = input in
-  let meta =
-    match Keeper_registry.get_with_health ~base_path:config.base_path meta.name with
-    | Some (entry, Keeper_registry.Healthy) -> entry.meta
-    | Some (_, health) ->
-      let reason_label =
-        match health with
-        | Keeper_registry.Healthy -> "healthy"
-        | Keeper_registry.Meta_validation_failed _ -> "meta_validation_failed"
-        | Keeper_registry.Lifecycle_transaction_reserved _ ->
-          "lifecycle_transaction_reserved"
-        | Keeper_registry.Required_field_missing _ -> "required_field_missing"
-        | Keeper_registry.Base_path_mismatch _ -> "base_path_mismatch"
-        | Keeper_registry.Name_mismatch _ -> "name_mismatch"
-      in
-      Otel_metric_store.inc_counter
-        Keeper_metrics.(to_string RegistryInvalidEntry)
-        ~labels:
-          [ "operation", "tool_dispatch_fallback"
-          ; "name", meta.name
-          ; "reason", reason_label
-          ]
-        ();
-      meta
-    | None -> meta
-  in
   let effective_search_fn =
          match search_fn with
          | Some f -> f
@@ -204,6 +182,8 @@ let execute_keeper_tool_call_with_outcome
          Keeper_tool_runtime.
                        { config
                        ; meta
+                       ; publication_recovery_registry
+                       ; publication_recovery_access
                        ; ctx_work
                        ; turn_sandbox_factory
                        ; exec_cache
@@ -277,6 +257,9 @@ let execute_keeper_tool_call_with_outcome
 let execute_keeper_tool_call
       ~(config : Workspace.config)
       ~(meta : keeper_meta)
+      ~(publication_recovery_registry :
+          Fs_compat.publication_recovery_registry)
+      ~(publication_recovery_access : Fs_compat.publication_recovery_access)
       ~(ctx_work : working_context)
       ?turn_sandbox_factory
       ~(exec_cache : Masc_exec.Exec_cache.t option)
@@ -290,7 +273,9 @@ let execute_keeper_tool_call
     execute_keeper_tool_call_with_outcome
       ~config
       ~meta
-                  ~ctx_work
+      ~publication_recovery_registry
+      ~publication_recovery_access
+      ~ctx_work
                   ?turn_sandbox_factory
                   ~exec_cache
       ?search_fn

--- a/lib/keeper/keeper_tool_dispatch_runtime.mli
+++ b/lib/keeper/keeper_tool_dispatch_runtime.mli
@@ -79,6 +79,8 @@ val registered_handler_schema_names : unit -> string list
 val execute_keeper_tool_call_with_outcome
   :  config:Workspace.config
   -> meta:keeper_meta
+  -> publication_recovery_registry:Fs_compat.publication_recovery_registry
+  -> publication_recovery_access:Fs_compat.publication_recovery_access
   -> ctx_work:working_context
   -> ?turn_sandbox_factory:Keeper_sandbox_factory.t
   -> exec_cache:Masc_exec.Exec_cache.t option
@@ -95,10 +97,16 @@ val execute_keeper_tool_call_with_outcome
   -> input:Yojson.Safe.t
   -> unit
   -> executed_tool_result
+(** [meta] is the immutable metadata of the exact registry entry admitted at
+    the turn-resource boundary. Dispatch never resolves the Keeper name again;
+    callers preserve the entry, recovery registry, and lane access as one
+    physical resource snapshot. *)
 
 val execute_keeper_tool_call
   :  config:Workspace.config
   -> meta:keeper_meta
+  -> publication_recovery_registry:Fs_compat.publication_recovery_registry
+  -> publication_recovery_access:Fs_compat.publication_recovery_access
   -> ctx_work:working_context
   -> ?turn_sandbox_factory:Keeper_sandbox_factory.t
   -> exec_cache:Masc_exec.Exec_cache.t option

--- a/lib/keeper/keeper_tool_filesystem_runtime.ml
+++ b/lib/keeper/keeper_tool_filesystem_runtime.ml
@@ -110,14 +110,9 @@ type read_file_attempt =
 let handle_read_file_with_outcome
       ~(turn_sandbox_factory : Keeper_sandbox_factory.t option)
       ~(config : Workspace.config)
-      ~(keeper_name : string)
+      ~(meta : Keeper_meta_contract.keeper_meta)
       ~(args : Yojson.Safe.t)
   =
-  match find_registry_meta ~keeper_name ~source_layer:"fs_resolver" with
-  | None ->
-    Keeper_tool_execution.failure
-      (error_json (Printf.sprintf "keeper not found in registry: %s" keeper_name))
-  | Some meta ->
   let path = Safe_ops.json_string ~default:"" "path" args in
   let max_bytes =
     Safe_ops.json_int ~default:read_file_default_max_bytes "max_bytes" args
@@ -204,11 +199,11 @@ let handle_read_file_with_outcome
          (error_json ~fields:[ "path", `String target ] msg))
 ;;
 
-let handle_read_file ~turn_sandbox_factory ~config ~keeper_name ~args =
+let handle_read_file ~turn_sandbox_factory ~config ~meta ~args =
   (handle_read_file_with_outcome
      ~turn_sandbox_factory
      ~config
-     ~keeper_name
+     ~meta
      ~args).raw_output
 ;;
 
@@ -428,20 +423,24 @@ let same_file_resource (left : Eio.File.Stat.t) (right : Eio.File.Stat.t) =
 
 let replacement_file_permissions ~parent_dir ~leaf =
   let target = Eio.Path.(parent_dir / leaf) in
-  match Eio.Path.kind ~follow:false target with
-  | `Not_found | `Symbolic_link -> Ok created_file_permissions
-  | `Regular_file -> Ok (Eio.Path.stat ~follow:false target).perm
-  | (`Block_device
-    | `Character_special
-    | `Directory
-    | `Fifo
-    | `Socket
-    | `Unknown) as kind ->
-    Error
-      (Fmt.str
-         "filesystem atomic replacement target must be a regular file, symbolic link, or missing entry; found %a"
-         Eio.File.Stat.pp_kind
-         kind)
+  try
+    let resource = Eio.Path.stat ~follow:false target in
+    match resource.kind with
+    | `Symbolic_link -> Ok created_file_permissions
+    | `Regular_file -> Ok resource.perm
+    | (`Block_device
+      | `Character_special
+      | `Directory
+      | `Fifo
+      | `Socket
+      | `Unknown) as kind ->
+      Error
+        (Fmt.str
+           "filesystem atomic replacement target must be a regular file, symbolic link, or missing entry; found %a"
+           Eio.File.Stat.pp_kind
+           kind)
+  with
+  | Eio.Io (Eio.Fs.E (Eio.Fs.Not_found _), _) -> Ok created_file_permissions
 ;;
 
 let load_open_file file =
@@ -507,8 +506,14 @@ type append_write_outcome = Fs_compat.capability_append_outcome =
 
 type content_write_error =
   | Content_write_message of string
-  | Content_write_capability of Fs_compat.capability_write_error
-  | Content_write_directory of created_directory_commit
+  | Content_write_capability of
+      { error : Fs_compat.capability_write_error
+      ; created_parents : created_directory_commit list
+      }
+  | Content_write_directory of
+      { failed_commit : created_directory_commit
+      ; created_parents : created_directory_commit list
+      }
   | Content_write_append of append_write_outcome
 
 let append_capability ~on_cancelled file content =
@@ -704,64 +709,99 @@ let create_and_commit_directory_component
                } ))))
 ;;
 
-let rec with_created_parent_directories
-          ~on_cancelled
-          ~permissions
-          parent_dir
-          missing_parents
-          f
+let with_created_parent_directories
+      ~on_interrupted
+      ~permissions
+      parent_dir
+      missing_parents
+      f
   =
-  match missing_parents with
-  | [] -> f parent_dir
-  | component :: rest ->
-    Eio.Switch.run @@ fun sw ->
-    let child_dir, commit =
-      Eio.Cancel.protect (fun () ->
-        create_and_commit_directory_component
-          ~sw
-          ~permissions
-          ~parent_dir
-          ~component)
-    in
-    (try Eio.Fiber.check () with
-     | Eio.Cancel.Cancelled _ as cancellation ->
-       on_cancelled commit;
-       raise cancellation);
-    (match child_dir with
-     | None -> Error (Content_write_directory commit)
-     | Some child_dir ->
-       with_created_parent_directories
-         ~on_cancelled
-         ~permissions
-         child_dir
-         rest
-         f)
+  let rec loop created_parents_rev parent_dir missing_parents =
+    match missing_parents with
+    | [] -> f ~created_parents:(List.rev created_parents_rev) parent_dir
+    | component :: rest ->
+      Eio.Switch.run @@ fun sw ->
+      let child_dir, commit =
+        Eio.Cancel.protect (fun () ->
+          create_and_commit_directory_component
+            ~sw
+            ~permissions
+            ~parent_dir
+            ~component)
+      in
+      (try Eio.Fiber.check () with
+       | Eio.Cancel.Cancelled _ as cancellation ->
+         on_interrupted commit;
+         raise cancellation);
+      (match child_dir with
+       | None ->
+         Error
+           (Content_write_directory
+              { failed_commit = commit
+              ; created_parents = List.rev created_parents_rev
+              })
+       | Some child_dir ->
+         (try loop (commit :: created_parents_rev) child_dir rest with
+          | exception_ ->
+            let backtrace = Printexc.get_raw_backtrace () in
+            on_interrupted commit;
+            Printexc.raise_with_backtrace exception_ backtrace))
+  in
+  loop [] parent_dir missing_parents
 ;;
 
 let rec with_deepest_existing_parent
-          parent
-          parent_relative_path
-          missing_parents
+          parent_dir
+          traversed_components_rev
+          remaining_components
           f
   =
-  Eio.Switch.run @@ fun sw ->
-  match
-    try Ok (Eio.Path.open_dir ~sw parent) with
-    | Eio.Io (Eio.Fs.E (Eio.Fs.Not_found _), _) -> Error `Missing
-  with
-  | Ok parent_dir ->
-    f ~parent_dir ~parent_relative_path ~missing_parents
-  | Error `Missing ->
-    (match Eio.Path.split parent with
-     | None ->
-       Error
-         "filesystem capability acquisition failed: no existing parent directory"
-     | Some (ancestor, missing_component) ->
+  match remaining_components with
+  | [] ->
+    f
+      ~parent_dir
+      ~parent_components:(List.rev traversed_components_rev)
+      ~missing_parents:[]
+  | component :: rest ->
+    Eio.Switch.run @@ fun sw ->
+    (match
+       try Ok (Eio.Path.open_dir ~sw Eio.Path.(parent_dir / component)) with
+       | Eio.Io (Eio.Fs.E (Eio.Fs.Not_found _), _) -> Error `Missing
+     with
+     | Ok child_dir ->
        with_deepest_existing_parent
-         ancestor
-         (Filename.dirname parent_relative_path)
-         (missing_component :: missing_parents)
-         f)
+         child_dir
+         (component :: traversed_components_rev)
+         rest
+         f
+     | Error `Missing ->
+       f
+         ~parent_dir
+         ~parent_components:(List.rev traversed_components_rev)
+         ~missing_parents:remaining_components)
+;;
+
+let rec with_open_directory_components ~on_missing parent_dir components f =
+  match components with
+  | [] -> f parent_dir
+  | component :: rest ->
+    Eio.Switch.run @@ fun sw ->
+    (match
+       try Ok (Eio.Path.open_dir ~sw Eio.Path.(parent_dir / component)) with
+       | Eio.Io (Eio.Fs.E (Eio.Fs.Not_found _), _) -> Error `Missing
+     with
+     | Error `Missing -> on_missing ()
+     | Ok child_dir ->
+       with_open_directory_components ~on_missing child_dir rest f)
+;;
+
+let rec split_leaf_components = function
+  | [] -> None
+  | [ leaf ] -> Some ([], leaf)
+  | component :: rest ->
+    Option.map
+      (fun (parent, leaf) -> component :: parent, leaf)
+      (split_leaf_components rest)
 ;;
 
 let with_confined_write_parent confined f =
@@ -775,25 +815,25 @@ let with_confined_write_parent confined f =
        let root_relative_path =
          Keeper_alerting_path.confined_root_relative_path confined
        in
-       let relative_path =
-         Keeper_alerting_path.confined_relative_path confined
+       let target_components =
+         Keeper_alerting_path.confined_relative_components confined
        in
        let with_root root_dir =
          let* () =
            Keeper_alerting_path.verify_confined_root_capability confined root_dir
          in
-         match Eio.Path.split Eio.Path.(root_dir / relative_path) with
+         match split_leaf_components target_components with
          | None -> Error "filesystem target has no writable leaf"
-         | Some (parent, leaf) ->
+         | Some (parent_components, leaf) ->
            with_deepest_existing_parent
-             parent
-             (Filename.dirname relative_path)
+             root_dir
              []
-             (fun ~parent_dir ~parent_relative_path ~missing_parents ->
+             parent_components
+             (fun ~parent_dir ~parent_components ~missing_parents ->
                 f
                   ~root_dir
                   ~parent_dir
-                  ~parent_relative_path
+                  ~parent_components
                   ~missing_parents
                   ~leaf)
        in
@@ -905,6 +945,7 @@ let capability_write_failure_json
     | Fs_compat.Payload_write_failed { bytes_written; _ } ->
       [ "bytes_written", `Int bytes_written ]
     | ( Fs_compat.Invalid_leaf _
+      | Fs_compat.Invalid_recovery_target _
       | Fs_compat.Mutation_contended
       | Fs_compat.Posix_descriptor_unavailable
       | Fs_compat.Unexpected_resource_kind _
@@ -921,24 +962,50 @@ let capability_write_failure_json
      @ cause_fields)
 ;;
 
-let capability_write_error_payload
-      ~target
-      (error : Fs_compat.capability_write_error)
-  =
-  error_json
-    ~fields:
-      [ "path", `String target
-      ; ( "filesystem_write_intent"
-        , `String (Fs_compat.capability_write_intent_to_string error.intent) )
-      ; ( "filesystem_target_effect"
-        , `String
-            (Fs_compat.capability_write_target_effect_to_string
-               error.target_effect) )
-      ; "filesystem_failure", capability_write_failure_json error.failure
-      ; ( "filesystem_cleanup_failures"
-        , `List (List.map capability_write_failure_json error.cleanup_failures) )
+let capability_recovery_failure_json failure =
+  `Assoc
+    [ ( "phase"
+      , `String
+          (Fs_compat.capability_recovery_phase_to_string
+             (Fs_compat.capability_recovery_failure_phase failure)) )
+    ; ( "effect"
+      , `String
+          (Fs_compat.capability_recovery_effect_to_string
+             (Fs_compat.capability_recovery_failure_effect failure)) )
+    ; "detail", `String (Fs_compat.capability_recovery_failure_to_string failure)
+    ]
+;;
+
+let capability_write_primary_failure_json = function
+  | Fs_compat.Write_primary_failure failure ->
+    `Assoc
+      [ "kind", `String "write"
+      ; "failure", capability_write_failure_json failure
       ]
-    "Filesystem publication failed; target effect and cleanup outcome are reported explicitly."
+  | Fs_compat.Recovery_primary_failure failure ->
+    `Assoc
+      [ "kind", `String "recovery"
+      ; "failure", capability_recovery_failure_json failure
+      ]
+  | Fs_compat.Recovery_access_primary_failure
+      Fs_compat.Recovery_access_not_available ->
+    `Assoc
+      [ "kind", `String "recovery_access"
+      ; "failure", `String "recovery_access_not_available"
+      ]
+;;
+
+let capability_write_cleanup_failure_json = function
+  | Fs_compat.Write_cleanup_failure failure ->
+    `Assoc
+      [ "kind", `String "write"
+      ; "failure", capability_write_failure_json failure
+      ]
+  | Fs_compat.Recovery_cleanup_failure failure ->
+    `Assoc
+      [ "kind", `String "recovery"
+      ; "failure", capability_recovery_failure_json failure
+      ]
 ;;
 
 let observe_capability_write_failure_backtrace
@@ -965,6 +1032,7 @@ let observe_capability_write_failure_backtrace
       (Printexc.to_string exception_)
       (Printexc.raw_backtrace_to_string backtrace)
   | ( Fs_compat.Invalid_leaf _
+    | Fs_compat.Invalid_recovery_target _
     | Fs_compat.Mutation_contended
     | Fs_compat.Posix_descriptor_unavailable
     | Fs_compat.Unexpected_resource_kind _
@@ -972,17 +1040,49 @@ let observe_capability_write_failure_backtrace
     | Fs_compat.Resource_identity_changed ) -> ()
 ;;
 
+let observe_capability_recovery_failure ~keeper_name ~target failure =
+  Log.Keeper.error
+    ~keeper_name
+    "WRITE_AUDIT: filesystem recovery transition failed path=%s phase=%s effect=%s failure=%s"
+    target
+    (Fs_compat.capability_recovery_phase_to_string
+       (Fs_compat.capability_recovery_failure_phase failure))
+    (Fs_compat.capability_recovery_effect_to_string
+       (Fs_compat.capability_recovery_failure_effect failure))
+    (Fs_compat.capability_recovery_failure_to_string failure)
+;;
+
+let observe_capability_write_primary_failure ~keeper_name ~target = function
+  | Fs_compat.Write_primary_failure failure ->
+    observe_capability_write_failure_backtrace ~keeper_name ~target failure
+  | Fs_compat.Recovery_primary_failure failure ->
+    observe_capability_recovery_failure ~keeper_name ~target failure
+  | Fs_compat.Recovery_access_primary_failure
+      Fs_compat.Recovery_access_not_available ->
+    Log.Keeper.error
+      ~keeper_name
+      "WRITE_AUDIT: filesystem recovery access unavailable path=%s"
+      target
+;;
+
+let observe_capability_write_cleanup_failure ~keeper_name ~target = function
+  | Fs_compat.Write_cleanup_failure failure ->
+    observe_capability_write_failure_backtrace ~keeper_name ~target failure
+  | Fs_compat.Recovery_cleanup_failure failure ->
+    observe_capability_recovery_failure ~keeper_name ~target failure
+;;
+
 let observe_capability_write_error
       ~keeper_name
       ~target
       (error : Fs_compat.capability_write_error)
   =
-  observe_capability_write_failure_backtrace
+  observe_capability_write_primary_failure
     ~keeper_name
     ~target
-    error.Fs_compat.failure;
+    error.Fs_compat.primary_failure;
   List.iter
-    (observe_capability_write_failure_backtrace ~keeper_name ~target)
+    (observe_capability_write_cleanup_failure ~keeper_name ~target)
     error.cleanup_failures
 ;;
 
@@ -1042,10 +1142,58 @@ let created_directory_sync_outcome_json = function
       ]
 ;;
 
-let created_directory_commit_payload ~target commit =
+let created_directory_commit_json commit =
+  `Assoc
+    [ "component", `String commit.component
+    ; ( "target_effect"
+      , `String (created_directory_target_effect_to_string commit.target_effect) )
+    ; ( "primary_failure"
+      , match commit.primary_failure with
+        | None -> `Null
+        | Some failure -> created_directory_failure_json failure )
+    ; "child_sync", created_directory_sync_outcome_json commit.child_sync
+    ; "parent_sync", created_directory_sync_outcome_json commit.parent_sync
+    ]
+;;
+
+let created_parent_effects_json created_parents =
+  `List (List.map created_directory_commit_json created_parents)
+;;
+
+let capability_write_error_payload
+      ~target
+      ~created_parents
+      (error : Fs_compat.capability_write_error)
+  =
   error_json
     ~fields:
       [ "path", `String target
+      ; ( "filesystem_write_operation"
+        , `String
+            (Fs_compat.capability_write_operation_to_string error.operation) )
+      ; ( "filesystem_target_effect"
+        , `String
+            (Fs_compat.capability_write_target_effect_to_string
+               error.target_effect) )
+      ; ( "filesystem_created_parent_effects"
+        , created_parent_effects_json created_parents )
+      ; ( "filesystem_primary_failure"
+        , capability_write_primary_failure_json error.primary_failure )
+      ; ( "filesystem_cleanup_failures"
+        , `List
+            (List.map
+               capability_write_cleanup_failure_json
+               error.cleanup_failures) )
+      ]
+    "Filesystem publication failed; target effect and cleanup outcome are reported explicitly."
+;;
+
+let created_directory_commit_payload ~target ~created_parents commit =
+  error_json
+    ~fields:
+      [ "path", `String target
+      ; ( "filesystem_created_parent_effects"
+        , created_parent_effects_json created_parents )
       ; "filesystem_directory_component", `String commit.component
       ; ( "filesystem_directory_target_effect"
         , `String
@@ -1241,7 +1389,6 @@ let observe_append_write_outcome ~keeper_name ~target outcome =
        (Printexc.raw_backtrace_to_string backtrace)
    | ( None
      | Some Fs_compat.Capability_append_posix_descriptor_unavailable
-     | Some Fs_compat.Capability_append_inode_contended
      | Some Fs_compat.Capability_append_mutation_contended ) -> ());
   let observe_operation_failure
         label
@@ -1272,18 +1419,14 @@ let file_write_attempt_to_execution = function
 let handle_file_write_with_outcome
       ~(turn_sandbox_factory : Keeper_sandbox_factory.t option)
       ~(config : Workspace.config)
-      ~(keeper_name : string)
+      ~(meta : Keeper_meta_contract.keeper_meta)
+      ~(publication_recovery_access : Fs_compat.publication_recovery_access)
       ?continuation_channel
       ?gate_context
       ?gate_grant
       ~(args : Yojson.Safe.t)
       ()
   =
-  match find_registry_meta ~keeper_name ~source_layer:"fs_resolver" with
-  | None ->
-    Keeper_tool_execution.failure
-      (error_json (Printf.sprintf "keeper not found in registry: %s" keeper_name))
-  | Some meta ->
   let via_field =
     match turn_sandbox_factory with
     | Some _ ->
@@ -1340,17 +1483,43 @@ let handle_file_write_with_outcome
     try f () with
     | Eio.Cancel.Cancelled
         (Fs_compat.Capability_write_cancelled (reason, cancellation)) as e ->
+      let interrupted_primary =
+        match cancellation.interrupted_primary_failure with
+        | None -> `Null
+        | Some failure -> capability_write_primary_failure_json failure
+      in
+      let interrupted_recovery =
+        match cancellation.interrupted_recovery with
+        | None -> `Null
+        | Some failure -> capability_recovery_failure_json failure
+      in
       Log.Keeper.error
         ~keeper_name:meta.name
-        "WRITE_AUDIT: filesystem publication cancelled after observable state transition path=%s intent=%s target_effect=%s cleanup_failures=%d reason=%s"
+        "WRITE_AUDIT: filesystem publication cancelled after observable state transition path=%s operation=%s target_effect=%s interrupted_primary=%s interrupted_recovery=%s cleanup_failures=%s reason=%s"
         target
-        (Fs_compat.capability_write_intent_to_string cancellation.intent)
+        (Fs_compat.capability_write_operation_to_string cancellation.operation)
         (Fs_compat.capability_write_target_effect_to_string
            cancellation.target_effect)
-        (List.length cancellation.cleanup_failures)
+        (Yojson.Safe.to_string interrupted_primary)
+        (Yojson.Safe.to_string interrupted_recovery)
+        (Yojson.Safe.to_string
+           (`List
+               (List.map
+                  capability_write_cleanup_failure_json
+                  cancellation.cleanup_failures)))
         (Printexc.to_string reason);
+      Option.iter
+        (observe_capability_write_primary_failure
+           ~keeper_name:meta.name
+           ~target)
+        cancellation.interrupted_primary_failure;
+      Option.iter
+        (observe_capability_recovery_failure
+           ~keeper_name:meta.name
+           ~target)
+        cancellation.interrupted_recovery;
       List.iter
-        (observe_capability_write_failure_backtrace
+        (observe_capability_write_cleanup_failure
            ~keeper_name:meta.name
            ~target)
         cancellation.cleanup_failures;
@@ -1393,21 +1562,35 @@ let handle_file_write_with_outcome
     @@ fun () ->
     match write () with
     | Error (Content_write_message message) -> Error message
-    | Error (Content_write_capability error) ->
+    | Error (Content_write_capability { error; created_parents }) ->
+      List.iter
+        (observe_created_directory_commit
+           ~keeper_name:meta.name
+           ~target)
+        created_parents;
       observe_capability_write_error ~keeper_name:meta.name ~target error;
       Ok
         (Write_failed
-           { payload = capability_write_error_payload ~target error
+           { payload = capability_write_error_payload ~target ~created_parents error
            ; class_ = Tool_result.Runtime_failure
            })
-    | Error (Content_write_directory commit) ->
+    | Error (Content_write_directory { failed_commit; created_parents }) ->
+      List.iter
+        (observe_created_directory_commit
+           ~keeper_name:meta.name
+           ~target)
+        created_parents;
       observe_created_directory_commit
         ~keeper_name:meta.name
         ~target
-        commit;
+        failed_commit;
       Ok
         (Write_failed
-           { payload = created_directory_commit_payload ~target commit
+           { payload =
+               created_directory_commit_payload
+                 ~target
+                 ~created_parents
+                 failed_commit
            ; class_ = Tool_result.Runtime_failure
            })
     | Error (Content_write_append outcome) ->
@@ -1450,12 +1633,13 @@ let handle_file_write_with_outcome
                    @ ide_observation_failure_fields ide_observation_error
                    @ via_field))))
   in
-  let parent_effect_scope ~parent_dir ~parent_relative_path ~missing_parents =
+  let parent_effect_scope ~parent_dir ~parent_components ~missing_parents =
     Keeper_alerting_path.path_effect_parent_scope
-      ~relative_path:parent_relative_path
+      ~parent_components
       ~resource:(Eio.Path.stat ~follow:true parent_dir)
       ~create_missing_parents:missing_parents
       ~created_directory_permissions
+    |> Result.map_error Keeper_alerting_path.path_effect_projection_error_to_string
   in
   let handle_atomic_content_write ~mode_label ~make_effect =
     match
@@ -1473,35 +1657,42 @@ let handle_file_write_with_outcome
           check_invariant_sandbox_isolation ~turn_sandbox_factory ~confined
         in
         with_confined_write_parent confined
-        @@ fun ~root_dir:_ ~parent_dir ~parent_relative_path ~missing_parents ~leaf ->
+        @@ fun ~root_dir:_ ~parent_dir ~parent_components ~missing_parents ~leaf ->
         let* parent =
-          parent_effect_scope ~parent_dir ~parent_relative_path ~missing_parents
+          parent_effect_scope ~parent_dir ~parent_components ~missing_parents
         in
         let* result_file_permissions =
           if missing_parents = []
           then replacement_file_permissions ~parent_dir ~leaf
           else Ok created_file_permissions
         in
-        let* gate_effect =
+        let* projection =
           make_effect ~parent ~result_file_permissions confined
+          |> Result.map_error Keeper_alerting_path.path_effect_projection_error_to_string
+        in
+        let gate_effect =
+          Keeper_alerting_path.atomic_replace_gate_effect projection
+        in
+        let recovery_target =
+          Keeper_alerting_path.atomic_replace_recovery_target projection
         in
         finish_content_write ~target ~mode_label ~gate_effect (fun () ->
           with_created_parent_directories
-            ~on_cancelled:
+            ~on_interrupted:
               (observe_created_directory_commit
                  ~keeper_name:meta.name
                  ~target)
             ~permissions:created_directory_permissions
             parent_dir
             missing_parents
-          @@ fun final_parent ->
-          Fs_compat.publish_capability_file
+          @@ fun ~created_parents final_parent ->
+          Fs_compat.replace_capability_file
+            ~recovery:publication_recovery_access
             ~parent:final_parent
-            ~leaf
-            ~intent:Fs_compat.Atomic_replace
-            ~permissions:result_file_permissions
+            ~target:recovery_target
             content
-          |> Result.map_error (fun error -> Content_write_capability error))
+          |> Result.map_error (fun error ->
+            Content_write_capability { error; created_parents }))
       in
       (match run () with
        | Ok attempt -> file_write_attempt_to_execution attempt
@@ -1526,46 +1717,52 @@ let handle_file_write_with_outcome
           check_invariant_sandbox_isolation ~turn_sandbox_factory ~confined
         in
         with_confined_write_parent confined
-        @@ fun ~root_dir ~parent_dir ~parent_relative_path ~missing_parents ~leaf ->
+        @@ fun ~root_dir ~parent_dir ~parent_components ~missing_parents ~leaf ->
         let create_missing_entry () =
           let* parent =
-            parent_effect_scope ~parent_dir ~parent_relative_path ~missing_parents
+            parent_effect_scope ~parent_dir ~parent_components ~missing_parents
           in
           let* gate_effect =
             Keeper_alerting_path.create_entry_exclusive_effect
               ~parent
               ~result_file_permissions:created_file_permissions
               confined
+            |> Result.map_error Keeper_alerting_path.path_effect_projection_error_to_string
           in
           finish_content_write ~target ~mode_label ~gate_effect (fun () ->
             with_created_parent_directories
-              ~on_cancelled:
+              ~on_interrupted:
                 (observe_created_directory_commit
                    ~keeper_name:meta.name
                    ~target)
               ~permissions:created_directory_permissions
               parent_dir
               missing_parents
-            @@ fun final_parent ->
-            Fs_compat.publish_capability_file
+            @@ fun ~created_parents final_parent ->
+            Fs_compat.create_capability_file_exclusive
               ~parent:final_parent
               ~leaf
-              ~intent:Fs_compat.Create_exclusive
               ~permissions:created_file_permissions
               content
-            |> Result.map_error (fun error -> Content_write_capability error))
+            |> Result.map_error (fun error ->
+              Content_write_capability { error; created_parents }))
         in
         if missing_parents <> []
         then create_missing_entry ()
         else
-          let endpoint_relative_path =
-            Keeper_alerting_path.confined_endpoint_relative_path confined
+          let endpoint_components =
+            Keeper_alerting_path.confined_endpoint_components confined
           in
-          Eio.Switch.run @@ fun sw ->
-          (match Eio.Path.split Eio.Path.(root_dir / endpoint_relative_path) with
+          (match split_leaf_components endpoint_components with
            | None -> Error "filesystem append endpoint has no writable leaf"
-           | Some (endpoint_parent, endpoint_leaf) ->
-             let endpoint_parent_dir = Eio.Path.open_dir ~sw endpoint_parent in
+           | Some (endpoint_parent_components, endpoint_leaf) ->
+             with_open_directory_components
+               ~on_missing:(fun () ->
+                 Error "filesystem append endpoint parent does not exist")
+               root_dir
+               endpoint_parent_components
+             @@ fun endpoint_parent_dir ->
+             Eio.Switch.run @@ fun sw ->
              (match
                 Fs_compat.open_capability_append_file
                   ~sw
@@ -1596,6 +1793,8 @@ let handle_file_write_with_outcome
                     Keeper_alerting_path.append_pinned_resource_effect
                       confined
                       stat
+                    |> Result.map_error
+                         Keeper_alerting_path.path_effect_projection_error_to_string
                   in
                   finish_content_write ~target ~mode_label ~gate_effect (fun () ->
                     append_capability
@@ -1665,24 +1864,43 @@ let handle_file_write_with_outcome
                 @@ fun () ->
                 match write updated with
                 | Error (Content_write_message message) -> Error message
-                | Error (Content_write_capability error) ->
+                | Error (Content_write_capability { error; created_parents }) ->
+                  List.iter
+                    (observe_created_directory_commit
+                       ~keeper_name:meta.name
+                       ~target)
+                    created_parents;
                   observe_capability_write_error
                     ~keeper_name:meta.name
                     ~target
                     error;
                   Ok
                     (Write_failed
-                       { payload = capability_write_error_payload ~target error
+                       { payload =
+                           capability_write_error_payload
+                             ~target
+                             ~created_parents
+                             error
                        ; class_ = Tool_result.Runtime_failure
                        })
-                | Error (Content_write_directory commit) ->
+                | Error
+                    (Content_write_directory { failed_commit; created_parents }) ->
+                  List.iter
+                    (observe_created_directory_commit
+                       ~keeper_name:meta.name
+                       ~target)
+                    created_parents;
                   observe_created_directory_commit
                     ~keeper_name:meta.name
                     ~target
-                    commit;
+                    failed_commit;
                   Ok
                     (Write_failed
-                       { payload = created_directory_commit_payload ~target commit
+                       { payload =
+                           created_directory_commit_payload
+                             ~target
+                             ~created_parents
+                             failed_commit
                        ; class_ = Tool_result.Runtime_failure
                        })
                 | Error (Content_write_append outcome) ->
@@ -1731,7 +1949,6 @@ let handle_file_write_with_outcome
               in
               let patch_current
                     ~parent
-                    ~source_relative_path
                     ~source_resource
                     ~result_file_permissions
                     current
@@ -1740,15 +1957,26 @@ let handle_file_write_with_outcome
                 let* updated, occurrences =
                   apply_patch ~old_string ~new_string ~replace_all current
                 in
-                let* gate_effect =
+                let* projection =
                   Keeper_alerting_path.patch_then_atomic_replace_effect
                     ~parent
-                    ~source_relative_path
                     ~source_resource
                     ~result_file_permissions
                     confined
+                  |> Result.map_error
+                       Keeper_alerting_path.path_effect_projection_error_to_string
                 in
-                finish_write ~gate_effect ~updated ~occurrences write
+                let gate_effect =
+                  Keeper_alerting_path.atomic_replace_gate_effect projection
+                in
+                let recovery_target =
+                  Keeper_alerting_path.atomic_replace_recovery_target projection
+                in
+                finish_write
+                  ~gate_effect
+                  ~updated
+                  ~occurrences
+                  (write ~recovery_target)
               in
               let missing_target () =
                 Ok
@@ -1765,59 +1993,67 @@ let handle_file_write_with_outcome
                   check_invariant_sandbox_isolation ~turn_sandbox_factory ~confined
                 in
                 with_confined_write_parent confined
-                @@ fun ~root_dir ~parent_dir ~parent_relative_path ~missing_parents ~leaf ->
+                @@ fun ~root_dir ~parent_dir ~parent_components ~missing_parents ~leaf ->
                 if missing_parents <> []
                 then missing_target ()
                 else
-                  let source_relative_path =
-                    Keeper_alerting_path.confined_endpoint_relative_path confined
+                  let endpoint_components =
+                    Keeper_alerting_path.confined_endpoint_components confined
                   in
-                  let confined_source = Eio.Path.(root_dir / source_relative_path) in
-                  (match Eio.Path.kind ~follow:true confined_source with
-                   | `Not_found -> missing_target ()
-                   | `Regular_file ->
-                     Eio.Path.with_open_in confined_source @@ fun source_file ->
-                     let source_resource = Eio.File.stat source_file in
-                     if source_resource.kind <> `Regular_file
-                     then Error "filesystem patch source changed before capability acquisition"
-                     else
-                       let current = load_open_file source_file in
-                       let* result_file_permissions =
-                         replacement_file_permissions ~parent_dir ~leaf
-                       in
-                       let* parent =
-                         parent_effect_scope
-                           ~parent_dir
-                           ~parent_relative_path
-                           ~missing_parents:[]
-                       in
-                       patch_current
-                         ~parent
-                         ~source_relative_path
-                         ~source_resource
-                         ~result_file_permissions
-                         current
-                         (fun updated ->
-                            Fs_compat.publish_capability_file
-                              ~parent:parent_dir
-                              ~leaf
-                              ~intent:Fs_compat.Atomic_replace
-                              ~permissions:result_file_permissions
-                              updated
-                            |> Result.map_error (fun error ->
-                              Content_write_capability error))
-                   | (`Block_device
-                     | `Character_special
-                     | `Directory
-                     | `Fifo
-                     | `Socket
-                     | `Symbolic_link
-                     | `Unknown) as kind ->
-                     Error
-                       (Fmt.str
-                          "filesystem patch target must resolve to a regular file; found %a"
-                          Eio.File.Stat.pp_kind
-                          kind))
+                  (match split_leaf_components endpoint_components with
+                   | None -> Error "filesystem patch source has no readable leaf"
+                   | Some (source_parent_components, source_leaf) ->
+                     with_open_directory_components
+                       ~on_missing:missing_target
+                       root_dir
+                       source_parent_components
+                     @@ fun source_parent_dir ->
+                     Eio.Switch.run @@ fun sw ->
+                     (match
+                        try
+                          Ok
+                            (Eio.Path.open_in
+                               ~sw
+                               Eio.Path.(source_parent_dir / source_leaf))
+                        with
+                        | Eio.Io (Eio.Fs.E (Eio.Fs.Not_found _), _) ->
+                          Error `Missing
+                      with
+                      | Error `Missing -> missing_target ()
+                      | Ok source_file ->
+                        let source_resource = Eio.File.stat source_file in
+                        if source_resource.kind <> `Regular_file
+                        then
+                          Error
+                            (Fmt.str
+                               "filesystem patch target must resolve to a regular file; found %a"
+                               Eio.File.Stat.pp_kind
+                               source_resource.kind)
+                        else
+                          let current = load_open_file source_file in
+                          let* result_file_permissions =
+                            replacement_file_permissions ~parent_dir ~leaf
+                          in
+                          let* parent =
+                            parent_effect_scope
+                              ~parent_dir
+                              ~parent_components
+                              ~missing_parents:[]
+                          in
+                          patch_current
+                            ~parent
+                            ~source_resource
+                            ~result_file_permissions
+                            current
+                            (fun ~recovery_target updated ->
+                               Fs_compat.replace_capability_file
+                                 ~recovery:publication_recovery_access
+                                 ~parent:parent_dir
+                                 ~target:recovery_target
+                                 updated
+                               |> Result.map_error (fun error ->
+                                 Content_write_capability
+                                   { error; created_parents = [] }))))
               in
               (match run () with
                | Ok attempt -> file_write_attempt_to_execution attempt
@@ -1835,7 +2071,8 @@ let handle_file_write_with_outcome
 let handle_file_write
       ~turn_sandbox_factory
       ~config
-      ~keeper_name
+      ~meta
+      ~publication_recovery_access
       ?continuation_channel
       ?gate_context
       ?gate_grant
@@ -1845,7 +2082,8 @@ let handle_file_write
   (handle_file_write_with_outcome
      ~turn_sandbox_factory
      ~config
-     ~keeper_name
+     ~meta
+     ~publication_recovery_access
      ?continuation_channel
      ?gate_context
      ?gate_grant

--- a/lib/keeper/keeper_tool_filesystem_runtime.mli
+++ b/lib/keeper/keeper_tool_filesystem_runtime.mli
@@ -44,21 +44,22 @@ val valid_fs_write_mode_strings : string list
 val handle_read_file :
   turn_sandbox_factory:Keeper_sandbox_factory.t option ->
   config:Workspace.config ->
-  keeper_name:string ->
+  meta:Keeper_meta_contract.keeper_meta ->
   args:Yojson.Safe.t ->
   string
 
 val handle_read_file_with_outcome :
   turn_sandbox_factory:Keeper_sandbox_factory.t option ->
   config:Workspace.config ->
-  keeper_name:string ->
+  meta:Keeper_meta_contract.keeper_meta ->
   args:Yojson.Safe.t ->
   Keeper_tool_execution.t
 
 val handle_file_write :
   turn_sandbox_factory:Keeper_sandbox_factory.t option ->
   config:Workspace.config ->
-  keeper_name:string ->
+  meta:Keeper_meta_contract.keeper_meta ->
+  publication_recovery_access:Fs_compat.publication_recovery_access ->
   ?continuation_channel:Keeper_continuation_channel.t ->
   ?gate_context:(unit -> Keeper_gate.causal_context) ->
   ?gate_grant:Keeper_gate.cycle_grant ->
@@ -69,7 +70,8 @@ val handle_file_write :
 val handle_file_write_with_outcome :
   turn_sandbox_factory:Keeper_sandbox_factory.t option ->
   config:Workspace.config ->
-  keeper_name:string ->
+  meta:Keeper_meta_contract.keeper_meta ->
+  publication_recovery_access:Fs_compat.publication_recovery_access ->
   ?continuation_channel:Keeper_continuation_channel.t ->
   ?gate_context:(unit -> Keeper_gate.causal_context) ->
   ?gate_grant:Keeper_gate.cycle_grant ->

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -957,6 +957,8 @@ let handle_masc_surface_audit ~args =
    [Keeper_tool_surface] / [Keeper_tool_surface_ops] / [Keeper_status_detail] handlers
    that the registered ref delegates to. *)
 let handle_masc_keeper_with_outcome
+      ~(publication_recovery_registry :
+          Fs_compat.publication_recovery_registry)
       ?sw
       ?clock
       ?proc_mgr
@@ -985,6 +987,7 @@ let handle_masc_keeper_with_outcome
   !Keeper_dispatch_ref.dispatch
       ~config
       ~agent_name:meta.agent_name
+      ~publication_recovery_registry:(Some publication_recovery_registry)
       ?sw
       ?clock
       ?proc_mgr
@@ -998,6 +1001,8 @@ let handle_masc_keeper_with_outcome
 ;;
 
 let handle_masc_keeper
+      ~(publication_recovery_registry :
+          Fs_compat.publication_recovery_registry)
       ?sw
       ?clock
       ?proc_mgr
@@ -1013,6 +1018,7 @@ let handle_masc_keeper
       ()
   =
   (handle_masc_keeper_with_outcome
+     ~publication_recovery_registry
      ?sw
      ?clock
      ?proc_mgr

--- a/lib/keeper/keeper_tool_in_process_runtime.mli
+++ b/lib/keeper/keeper_tool_in_process_runtime.mli
@@ -269,7 +269,8 @@ val handle_analyze_image_with_outcome
     module load.  Receives [meta] so callers like [masc_keeper_status]
     can resolve the "self" target when the [name] argument is empty. *)
 val handle_masc_keeper
-  :  ?sw:Eio.Switch.t
+  :  publication_recovery_registry:Fs_compat.publication_recovery_registry
+  -> ?sw:Eio.Switch.t
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
   -> ?proc_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t
   -> ?net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
@@ -285,7 +286,8 @@ val handle_masc_keeper
   -> string
 
 val handle_masc_keeper_with_outcome
-  :  ?sw:Eio.Switch.t
+  :  publication_recovery_registry:Fs_compat.publication_recovery_registry
+  -> ?sw:Eio.Switch.t
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
   -> ?proc_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t
   -> ?net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t

--- a/lib/keeper/keeper_tool_runtime.ml
+++ b/lib/keeper/keeper_tool_runtime.ml
@@ -13,6 +13,8 @@ open Keeper_tool_descriptor
 type context =
   { config : Workspace.config
   ; meta : Keeper_meta_contract.keeper_meta
+  ; publication_recovery_registry : Fs_compat.publication_recovery_registry
+  ; publication_recovery_access : Fs_compat.publication_recovery_access
   ; ctx_work : Keeper_types.working_context
   ; turn_sandbox_factory : Keeper_sandbox_factory.t option
   ; exec_cache : Masc_exec.Exec_cache.t option
@@ -48,14 +50,15 @@ let handle_filesystem ctx descriptor args =
       (Keeper_tool_filesystem_runtime.handle_read_file_with_outcome
          ~turn_sandbox_factory:ctx.turn_sandbox_factory
          ~config:ctx.config
-         ~keeper_name:ctx.meta.name
+         ~meta:ctx.meta
          ~args)
   | Tool_edit_file | Tool_write_file ->
     Some
       (Keeper_tool_filesystem_runtime.handle_file_write_with_outcome
          ~turn_sandbox_factory:ctx.turn_sandbox_factory
          ~config:ctx.config
-         ~keeper_name:ctx.meta.name
+         ~meta:ctx.meta
+         ~publication_recovery_access:ctx.publication_recovery_access
          ?continuation_channel:ctx.continuation_channel
          ?gate_context:ctx.gate_context
          ?gate_grant:ctx.gate_grant
@@ -349,6 +352,7 @@ let handle_in_process ctx descriptor args =
   | Tool_masc_keeper_dispatch ->
     Some
       (Keeper_tool_in_process_runtime.handle_masc_keeper_with_outcome
+         ~publication_recovery_registry:ctx.publication_recovery_registry
          ?sw:ctx.sw
          ?clock:ctx.clock
          ?proc_mgr:ctx.proc_mgr

--- a/lib/keeper/keeper_tool_runtime.mli
+++ b/lib/keeper/keeper_tool_runtime.mli
@@ -12,6 +12,8 @@
 type context =
   { config : Workspace.config
   ; meta : Keeper_meta_contract.keeper_meta
+  ; publication_recovery_registry : Fs_compat.publication_recovery_registry
+  ; publication_recovery_access : Fs_compat.publication_recovery_access
   ; ctx_work : Keeper_types.working_context
   ; turn_sandbox_factory : Keeper_sandbox_factory.t option
   ; exec_cache : Masc_exec.Exec_cache.t option

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -816,7 +816,7 @@ let eio_context_missing tool_name =
 
 let () =
   Keeper_dispatch_ref.dispatch
-  := fun ~config ~agent_name ?sw ?clock ?proc_mgr ?net ?mcp_session_id:_ ?authorize_external_effect ~name ~args () ->
+  := fun ~config ~agent_name ~publication_recovery_registry ?sw ?clock ?proc_mgr ?net ?mcp_session_id:_ ?authorize_external_effect ~name ~args () ->
     let run_external_effect continue =
       match authorize_external_effect with
       | None -> continue ()
@@ -870,7 +870,14 @@ let () =
       (match sw, clock with
        | Some sw, Some clock ->
          let ctx : _ Keeper_types_profile.context =
-           { config; agent_name; sw; clock; proc_mgr; net }
+           { config
+           ; agent_name
+           ; sw
+           ; clock
+           ; proc_mgr
+           ; net
+           ; publication_recovery_registry
+           }
          in
          Some
            (tool_result_with_tool_name
@@ -893,7 +900,14 @@ let () =
       (match sw, clock with
        | Some sw, Some clock ->
          let ctx : _ Keeper_types_profile.context =
-           { config; agent_name; sw; clock; proc_mgr; net }
+           { config
+           ; agent_name
+           ; sw
+           ; clock
+           ; proc_mgr
+           ; net
+           ; publication_recovery_registry
+           }
          in
          run_external_effect (fun () ->
            Keeper_tool_surface_ops.invalidate_keeper_list_cache ();
@@ -916,6 +930,7 @@ let () =
               ~agent_name
               ~sw
               ~clock
+              ~publication_recovery_registry
               ?proc_mgr
               ?net
               args)
@@ -929,6 +944,7 @@ let () =
               ~agent_name
               ~sw
               ~clock
+              ~publication_recovery_registry
               ?proc_mgr
               ?net
               args)

--- a/lib/keeper/keeper_tool_surface.mli
+++ b/lib/keeper/keeper_tool_surface.mli
@@ -8,6 +8,7 @@ type 'a context = 'a Keeper_types_profile.context = {
   clock : 'a Eio.Time.clock;
   proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option;
   net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option;
+  publication_recovery_registry : Fs_compat.publication_recovery_registry option;
 }
 
 type tool_result = Keeper_types_profile.tool_result

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -24,6 +24,7 @@ type 'a context = 'a Keeper_types_profile.context = {
   clock : 'a Eio.Time.clock;
   proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option;
   net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option;
+  publication_recovery_registry : Fs_compat.publication_recovery_registry option;
 }
 type tool_result = Keeper_types_profile.tool_result
 let schemas = Keeper_types_profile.schemas
@@ -466,11 +467,20 @@ let keeper_up_body
       ~(agent_name : string)
       ~(sw : Eio.Switch.t)
       ~(clock : float Eio.Time.clock_ty Eio.Resource.t)
+      ~(publication_recovery_registry :
+          Fs_compat.publication_recovery_registry option)
       ?proc_mgr
       ?net
       args : tool_result =
   let keeper_ctx : _ Keeper_types_profile.context =
-    { config; agent_name; sw; clock; proc_mgr; net }
+    { config
+    ; agent_name
+    ; sw
+    ; clock
+    ; proc_mgr
+    ; net
+    ; publication_recovery_registry
+    }
   in
   with_keeper_startup_gate (fun () -> execute_keeper_up keeper_ctx args)
 ;;
@@ -604,12 +614,21 @@ let keeper_msg_body
       ~(agent_name : string)
       ~(sw : Eio.Switch.t)
       ~(clock : float Eio.Time.clock_ty Eio.Resource.t)
+      ~(publication_recovery_registry :
+          Fs_compat.publication_recovery_registry option)
       ?proc_mgr
       ?net
       ?continuation_channel
       args : tool_result =
   let keeper_ctx : _ Keeper_types_profile.context =
-    { config; agent_name; sw; clock; proc_mgr; net }
+    { config
+    ; agent_name
+    ; sw
+    ; clock
+    ; proc_mgr
+    ; net
+    ; publication_recovery_registry
+    }
   in
   match
     let* name = message_error (resolve_keeper_name_config ~config args) in

--- a/lib/keeper/keeper_tools_oas_bundle.ml
+++ b/lib/keeper/keeper_tools_oas_bundle.ml
@@ -30,6 +30,9 @@ let task_state_hint ~(config : Workspace.config) ~(meta : Keeper_meta_contract.k
 let make_tool_bundle
       ~(config : Workspace.config)
       ~(meta : Keeper_meta_contract.keeper_meta)
+      ~(publication_recovery_registry :
+          Fs_compat.publication_recovery_registry)
+      ~(publication_recovery_access : Fs_compat.publication_recovery_access)
       ~(ctx_snapshot : Keeper_types.working_context)
       ?search_fn
       ?clock
@@ -86,8 +89,10 @@ let make_tool_bundle
                  ~name:internal
                  ~input_schema:descriptor.input_schema
                  ~config
-                   ~meta
-                   ~ctx_snapshot
+                 ~meta
+                 ~publication_recovery_registry
+                 ~publication_recovery_access
+                 ~ctx_snapshot
                    ?turn_sandbox_factory
                  ~exec_cache
                  ?search_fn
@@ -137,12 +142,23 @@ let make_tool_bundle
 let make_tools
       ~(config : Workspace.config)
       ~(meta : Keeper_meta_contract.keeper_meta)
+      ~(publication_recovery_registry :
+          Fs_compat.publication_recovery_registry)
+      ~(publication_recovery_access : Fs_compat.publication_recovery_access)
       ~(ctx_snapshot : Keeper_types.working_context)
       ?search_fn
       ?clock
       ()
   : Agent_sdk.Tool.t list
   =
-  (make_tool_bundle ~config ~meta ~ctx_snapshot ?search_fn ?clock ())
+  (make_tool_bundle
+     ~config
+     ~meta
+     ~publication_recovery_registry
+     ~publication_recovery_access
+     ~ctx_snapshot
+     ?search_fn
+     ?clock
+     ())
     .tools
 ;;

--- a/lib/keeper/keeper_tools_oas_bundle.mli
+++ b/lib/keeper/keeper_tools_oas_bundle.mli
@@ -7,6 +7,8 @@
 val make_tool_bundle
   :  config:Workspace.config
   -> meta:Keeper_meta_contract.keeper_meta
+  -> publication_recovery_registry:Fs_compat.publication_recovery_registry
+  -> publication_recovery_access:Fs_compat.publication_recovery_access
   -> ctx_snapshot:Keeper_types.working_context
   -> ?search_fn:(unit -> Keeper_tool_execution.t)
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
@@ -20,6 +22,8 @@ val make_tool_bundle
 val make_tools
   :  config:Workspace.config
   -> meta:Keeper_meta_contract.keeper_meta
+  -> publication_recovery_registry:Fs_compat.publication_recovery_registry
+  -> publication_recovery_access:Fs_compat.publication_recovery_access
   -> ctx_snapshot:Keeper_types.working_context
   -> ?search_fn:(unit -> Keeper_tool_execution.t)
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t

--- a/lib/keeper/keeper_tools_oas_handler.ml
+++ b/lib/keeper/keeper_tools_oas_handler.ml
@@ -14,6 +14,9 @@ let make_keeper_tool_handler
       ~(input_schema : Yojson.Safe.t)
       ~(config : Workspace.config)
       ~(meta : Keeper_meta_contract.keeper_meta)
+      ~(publication_recovery_registry :
+          Fs_compat.publication_recovery_registry)
+      ~(publication_recovery_access : Fs_compat.publication_recovery_access)
       ~(ctx_snapshot : Keeper_types.working_context)
       ?turn_sandbox_factory
       ~(exec_cache : Masc_exec.Exec_cache.t option)
@@ -138,6 +141,8 @@ let make_keeper_tool_handler
               ~name
               ~config
               ~meta
+              ~publication_recovery_registry
+              ~publication_recovery_access
               ~ctx_snapshot
               ?turn_sandbox_factory
               ~exec_cache

--- a/lib/keeper/keeper_tools_oas_handler.mli
+++ b/lib/keeper/keeper_tools_oas_handler.mli
@@ -22,6 +22,8 @@ val make_keeper_tool_handler
   -> input_schema:Yojson.Safe.t
   -> config:Workspace.config
   -> meta:Keeper_meta_contract.keeper_meta
+  -> publication_recovery_registry:Fs_compat.publication_recovery_registry
+  -> publication_recovery_access:Fs_compat.publication_recovery_access
   -> ctx_snapshot:Keeper_types.working_context
   -> ?turn_sandbox_factory:Keeper_sandbox_factory.t
   -> exec_cache:Masc_exec.Exec_cache.t option

--- a/lib/keeper/keeper_tools_oas_handler_exec.ml
+++ b/lib/keeper/keeper_tools_oas_handler_exec.ml
@@ -7,6 +7,9 @@ let execute_with_observers
       ~(name : string)
       ~(config : Workspace.config)
       ~(meta : Keeper_meta_contract.keeper_meta)
+      ~(publication_recovery_registry :
+          Fs_compat.publication_recovery_registry)
+      ~(publication_recovery_access : Fs_compat.publication_recovery_access)
       ~(ctx_snapshot : Keeper_types.working_context)
       ?turn_sandbox_factory
       ~(exec_cache : Masc_exec.Exec_cache.t option)
@@ -30,7 +33,9 @@ let execute_with_observers
         Keeper_tool_dispatch_runtime.execute_keeper_tool_call_with_outcome
           ~config
           ~meta
-            ~ctx_work:ctx_snapshot
+          ~publication_recovery_registry
+          ~publication_recovery_access
+          ~ctx_work:ctx_snapshot
             ?turn_sandbox_factory
             ~exec_cache
           ?search_fn

--- a/lib/keeper/keeper_tools_oas_handler_exec.mli
+++ b/lib/keeper/keeper_tools_oas_handler_exec.mli
@@ -10,6 +10,8 @@ val execute_with_observers
   :  name:string
   -> config:Workspace.config
   -> meta:Keeper_meta_contract.keeper_meta
+  -> publication_recovery_registry:Fs_compat.publication_recovery_registry
+  -> publication_recovery_access:Fs_compat.publication_recovery_access
   -> ctx_snapshot:Keeper_types.working_context
   -> ?turn_sandbox_factory:Keeper_sandbox_factory.t
   -> exec_cache:Masc_exec.Exec_cache.t option

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -219,6 +219,19 @@ let user_oas_blocks_of_args args =
       | Ok [] -> Ok None
       | Ok blocks -> Ok (Some blocks)
 
+let publication_recovery_turn_error failure =
+  let detail =
+    Keeper_publication_recovery_scope.failure_to_string failure
+  in
+  tool_result_error_data
+    ~tool_name:"masc_keeper_msg"
+    (`Assoc
+       [ "error", `String "keeper_publication_recovery_access_unavailable"
+       ; "failure_class", `String "runtime_failure"
+       ; "detail", `String detail
+       ])
+;;
+
 let preflight_keeper_msg ctx args : (unit, string) result =
   let name = get_string args "name" "" in
   let message = get_string args "message" "" in
@@ -423,9 +436,21 @@ let run_keeper_msg_turn_admitted
     | Error e -> tool_result_error ("" ^ e)
     | Ok meta0 ->
       (match
-         Keeper_unified_turn_pre_dispatch.load_profile_defaults
+         Keeper_publication_recovery_scope.resolve_turn_resources
+           ~registry:ctx.publication_recovery_registry
            ~base_path:ctx.config.base_path
            ~keeper_name:meta0.name
+       with
+       | Error failure -> publication_recovery_turn_error failure
+       | Ok { entry
+            ; registry = publication_recovery_registry
+            ; access = publication_recovery_access
+            } ->
+      let meta = entry.meta in
+      (match
+         Keeper_unified_turn_pre_dispatch.load_profile_defaults
+           ~base_path:ctx.config.base_path
+           ~keeper_name:meta.name
        with
        | Error err -> tool_result_error (Agent_sdk.Error.to_string err)
        | Ok profile_defaults ->
@@ -438,14 +463,14 @@ let run_keeper_msg_turn_admitted
         Option.map
           (Keeper_vision_ingest.evict_blocks
              ~mode:Keeper_vision_ingest.Eager
-             ~policy:meta0.multimodal_policy
-             ~keeper_name:meta0.name)
+             ~policy:meta.multimodal_policy
+             ~keeper_name:meta.name)
           user_blocks
       in
       let turn_task_id = Printf.sprintf "keeper_turn_%s_%d"
         name (int_of_float (Time_compat.now () *. 1000.0)) in
-      let keeper_turn_id = meta0.runtime.usage.total_turns + 1 in
-      (* RFC-0233 §7: mint the turn's join key ONCE from the pre-turn meta0 —
+      let keeper_turn_id = meta.runtime.usage.total_turns + 1 in
+      (* RFC-0233 §7: mint the turn's join key ONCE from the exact admitted meta —
          the same (trace_id, total_turns + 1) snapshot the Turn_record writer
          stamps (keeper_agent_run.ml:250-251 receives this very meta via the
          run_turn call below). Threaded into reply_json; never re-derived at
@@ -455,12 +480,11 @@ let run_keeper_msg_turn_admitted
          (RFC §7.2 mint-once, thread down). *)
       let turn_ref =
         Ids.Turn_ref.make
-          ~trace_id:(Keeper_id.Trace_id.to_string meta0.runtime.trace_id)
+          ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
           ~absolute_turn:keeper_turn_id
       in
       let turn_tracker = Progress.start_tracking ~task_id:turn_task_id ~total_steps:5 () in
       Progress.Tracker.step turn_tracker ~message:"Preparing keeper turn configuration" ();
-      let meta = meta0 in
       match resolve_turn_runtime_id meta with
       | Error e ->
         Progress.stop_tracking turn_task_id;
@@ -771,6 +795,8 @@ let run_keeper_msg_turn_admitted
 			                              Keeper_agent_run.run_turn
 			                                ~config:ctx.config
 			                                ~meta
+			                                ~publication_recovery_registry
+			                                ~publication_recovery_access
 			                                ~profile_defaults
 			                                ~turn_ctx_cell
 		                                ~base_dir
@@ -983,7 +1009,7 @@ let run_keeper_msg_turn_admitted
               in
               tool_result_ok_data reply_json
 
-))))))))
+)))))))))
 
 let handle_keeper_msg
       ?on_text_delta

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -19,6 +19,7 @@ type 'a context = {
   clock: 'a Eio.Time.clock;
   proc_mgr: Eio_unix.Process.mgr_ty Eio.Resource.t option;
   net: [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option;
+  publication_recovery_registry: Fs_compat.publication_recovery_registry option;
 }
 
 type tool_result = Tool_result.result

--- a/lib/keeper/keeper_types_profile.mli
+++ b/lib/keeper/keeper_types_profile.mli
@@ -15,6 +15,8 @@ type 'a context =
   ; clock : 'a Eio.Time.clock
   ; proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option
   ; net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option
+  ; publication_recovery_registry :
+      Fs_compat.publication_recovery_registry option
   }
 
 type tool_result = Tool_result.result

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -125,6 +125,8 @@ let user_message_with_hitl_resolution ~base_path ~user_message = function
 let run_keeper_cycle
       ~(config : Workspace.config)
       ~(meta : keeper_meta)
+      ~(publication_recovery_registry :
+          Fs_compat.publication_recovery_registry option)
       ~(observation : Keeper_world_observation.world_observation)
       ~(generation : int)
       ~(wake : Keeper_registry.wake_reason)
@@ -137,6 +139,35 @@ let run_keeper_cycle
       ()
   : (turn_success, turn_failure) result
   =
+  match
+    Keeper_publication_recovery_scope.resolve_turn_resources
+      ~registry:publication_recovery_registry
+      ~base_path:config.base_path
+      ~keeper_name:meta.name
+  with
+  | Error failure ->
+    let error =
+      Agent_sdk.Error.Config
+        (Agent_sdk.Error.InvalidConfig
+           { field = "keeper.publication_recovery_access"
+           ; detail =
+               Keeper_publication_recovery_scope.failure_to_string failure
+           })
+    in
+    Error
+      { error
+      ; runtime_id = Keeper_meta_contract.runtime_id_of_meta meta
+      ; route =
+          Keeper_runtime_failure_route.route_of_error
+            ~boundary:Keeper_runtime_failure_route.Masc_execution
+            error
+      ; source_lease_disposition = Follow_failure_route
+      }
+  | Ok { entry
+       ; registry = publication_recovery_registry
+       ; access = publication_recovery_access
+       } ->
+  let meta = entry.meta in
   (* Spec navigation: see specs/keeper-state-machine/KeeperTaskAcquisition.tla
      (Cycle 8/Tier B2, PR #11412).  Action mapping:
      SubmitTask=external producers, AssignTask=channel decision below,
@@ -567,6 +598,8 @@ let run_keeper_cycle
                            ; turn_ctx_cell
                            ; observation
                            ; profile_defaults
+                           ; publication_recovery_registry
+                           ; publication_recovery_access
                            ; shared_context
                            ; trajectory_acc
                            ; turn_id = keeper_turn_id

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -164,6 +164,8 @@ type turn_success =
 val run_keeper_cycle
   :  config:Workspace.config
   -> meta:Keeper_meta_contract.keeper_meta
+  -> publication_recovery_registry:
+       Fs_compat.publication_recovery_registry option
   -> observation:Keeper_world_observation.world_observation
   -> generation:int
   -> wake:Keeper_registry.wake_reason

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -79,6 +79,8 @@ type ctx =
   ; turn_ctx_cell : Keeper_tool_call_log.turn_ctx_cell
   ; observation : Keeper_world_observation.world_observation
   ; profile_defaults : Keeper_types_profile.keeper_profile_defaults
+  ; publication_recovery_registry : Fs_compat.publication_recovery_registry
+  ; publication_recovery_access : Fs_compat.publication_recovery_access
   ; shared_context : Agent_sdk.Context.t option
   ; trajectory_acc : Trajectory.accumulator
   ; turn_id : int
@@ -110,6 +112,8 @@ let run (ctx : ctx)
       ; build_turn_prompt
       ; trajectory_acc
       ; profile_defaults
+      ; publication_recovery_registry
+      ; publication_recovery_access
       ; cleanup
       ; drain_turn_event_bus
       ; event_bus
@@ -175,6 +179,8 @@ let run (ctx : ctx)
                Keeper_agent_run.run_turn
                  ~config
                  ~meta:run_meta
+                 ~publication_recovery_registry
+                 ~publication_recovery_access
                  ~profile_defaults
                  ?continuation_delivery_channel
                  ?hitl_resolution

--- a/lib/keeper_contract/keeper_path_rejection.ml
+++ b/lib/keeper_contract/keeper_path_rejection.ml
@@ -3,6 +3,7 @@
 type keeper_path_rejection =
   | Path_required
   | Invalid_lexical_endpoint
+  | Invalid_normalized_path_projection of { path : string }
   | Allowed_paths_normalized_empty of { count : int }
   | Outside_sandbox of { raw : string }
 
@@ -10,6 +11,10 @@ let rejection_to_user_message = function
   | Path_required -> "path_required"
   | Invalid_lexical_endpoint ->
     "invalid_lexical_endpoint: path must name a file entry other than '.' or '..'"
+  | Invalid_normalized_path_projection { path } ->
+    Printf.sprintf
+      "invalid_normalized_path_projection: normalized path cannot be projected into lexical components: %s"
+      path
   | Allowed_paths_normalized_empty { count } ->
     Printf.sprintf
       "allowed_paths_normalized_empty: %d entries provided, none resolved to a \

--- a/lib/keeper_contract/keeper_path_rejection.mli
+++ b/lib/keeper_contract/keeper_path_rejection.mli
@@ -3,6 +3,7 @@
 type keeper_path_rejection =
   | Path_required
   | Invalid_lexical_endpoint
+  | Invalid_normalized_path_projection of { path : string }
   | Allowed_paths_normalized_empty of { count : int }
   | Outside_sandbox of { raw : string }
 

--- a/lib/keeper_dispatch_ref.ml
+++ b/lib/keeper_dispatch_ref.ml
@@ -13,6 +13,8 @@ type external_effect_authorizer =
 let dispatch
   : (config:Workspace.config
      -> agent_name:string
+     -> publication_recovery_registry:
+          Fs_compat.publication_recovery_registry option
      -> ?sw:Eio.Switch.t
      -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
      -> ?proc_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t
@@ -25,7 +27,7 @@ let dispatch
      -> Tool_result.result option)
       ref
   =
-  ref (fun ~config:_ ~agent_name:_ ?sw:_ ?clock:_ ?proc_mgr:_ ?net:_ ?mcp_session_id:_ ?authorize_external_effect:_ ~name ~args:_ () ->
+  ref (fun ~config:_ ~agent_name:_ ~publication_recovery_registry:_ ?sw:_ ?clock:_ ?proc_mgr:_ ?net:_ ?mcp_session_id:_ ?authorize_external_effect:_ ~name ~args:_ () ->
     failwith
       (Printf.sprintf
          "keeper_dispatch_ref: dispatch called for tool %S before boot registration — \

--- a/lib/keeper_dispatch_ref.mli
+++ b/lib/keeper_dispatch_ref.mli
@@ -19,7 +19,10 @@
     [?sw] / [?clock] / [?proc_mgr] / [?net] / [?mcp_session_id] for
     Eio-bound tools (masc_keeper_msg, masc_keeper_up,
     masc_keeper_sandbox_status, masc_keeper_create_from_persona).
-    Existing registrations accept and ignore them.  The trailing
+    [publication_recovery_registry] is an explicit process-bound capability:
+    [None] is valid only for context-free/test dispatch, while live Eio server
+    paths provide the process registry. Existing registrations accept and
+    ignore the optional Eio resources. The trailing
     [unit] argument is required so the OCaml compiler can determine
     when the optional defaults apply. *)
 
@@ -35,6 +38,8 @@ type external_effect_authorizer =
 val dispatch
   : (config:Workspace.config
      -> agent_name:string
+     -> publication_recovery_registry:
+          Fs_compat.publication_recovery_registry option
      -> ?sw:Eio.Switch.t
      -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
      -> ?proc_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t

--- a/lib/mcp_server.ml
+++ b/lib/mcp_server.ml
@@ -473,9 +473,75 @@ let schema_markdown =
     "CAS guard: expected_version == backlog.version";
   ]
 
+type publication_recovery_activation_row =
+  | Publication_recovery_owner_pending of { owner : string }
+  | Publication_recovery_owner_running of { owner : string }
+  | Publication_recovery_owner_report of
+      Fs_compat.publication_recovery_reconciliation_report
+  | Publication_recovery_owner_identity_rejected of
+      { owner : string
+      ; error : string
+      }
+  | Publication_recovery_owner_reconciliation_failed of
+      { owner : string
+      ; error : Fs_compat.publication_recovery_reconciliation_error
+      }
+  | Publication_recovery_owner_reconciliation_crashed of
+      { owner : string
+      ; exception_ : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+  | Publication_recovery_owner_cancelled of
+      { owner : string
+      ; reason : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+  | Publication_recovery_owner_inventory_issue of
+      Fs_compat.publication_recovery_owner_inventory_row
+
+type publication_recovery_activation_slot =
+  { row : publication_recovery_activation_row Atomic.t
+  ; completion : unit Eio.Promise.t
+  }
+
+type publication_recovery_observation_event =
+  | Publication_recovery_inventory_activation
+  | Publication_recovery_inventory_terminal
+  | Publication_recovery_owner_terminal of { owner : string }
+
+type publication_recovery_observation_failure =
+  { event : publication_recovery_observation_event
+  ; exception_ : exn
+  ; backtrace : Printexc.raw_backtrace
+  }
+
+type publication_recovery_activation_report =
+  { slots : publication_recovery_activation_slot list
+  ; observation_failures :
+      publication_recovery_observation_failure list Atomic.t
+  }
+
+type publication_recovery_runtime =
+  { registry : Fs_compat.publication_recovery_registry
+  ; activation_report : publication_recovery_activation_report
+  }
+
+(** The active workspace and its publication-recovery runtime are one atomic
+    fact. Keeping the config, registry, and activation report in separate
+    fields would allow a workspace switch to publish a torn generation. *)
+type workspace_scope =
+  { config : Workspace.config
+  ; publication_recovery : publication_recovery_runtime option
+  }
+
+type workspace_runtime =
+  { process_masc_root : string
+  ; scope : workspace_scope Atomic.t
+  }
+
 (** MCP Server state *)
 type server_state = {
-  workspace_config: Workspace.config Atomic.t;  (* Atomic swap so workspace-switch tools update without data races. *)
+  workspace_runtime: workspace_runtime;
   session_registry: Session.registry;
   on_sse_broadcast: (Yojson.Safe.t -> unit) option Atomic.t;  (* SSE push callback, Atomic for cross-fiber visibility *)
   sw: Eio.Switch.t option; (* Request/runtime fibers for HTTP/MCP handlers *)
@@ -486,31 +552,739 @@ type server_state = {
   net: Eio_context.eio_net option; (* For network calls - P3a: replaces global ref *)
 }
 
-let workspace_config state = Atomic.get state.workspace_config
-let set_workspace_config state config = Atomic.set state.workspace_config config
+type workspace_switch_error =
+  | Workspace_masc_root_mismatch of
+      { runtime_root : string
+      ; requested_root : string
+      }
 
-let create_state ~base_path =
-  let config = Workspace.default_config base_path in
-  let registry = Session.create () in
-  (* Wire notification harness: subscription events → session queues *)
-  Subscriptions.set_session_push_fn (fun event ->
-    Session.push_notification_to_active_agents registry ~event
-  );
-  let state = {
-    workspace_config = Atomic.make config;
-    session_registry = registry;
-    on_sse_broadcast = Atomic.make None;
-    sw = None;
-    proc_mgr = None;
-    fs = None;
-    clock = None;
-    mono_clock = None;
-    net = None;
-  } in
-  Board_tool.set_agent_lookup (fun name ->
-    try Workspace.is_agent_session_bound (workspace_config state) ~agent_name:name
-    with Sys_error _ | Not_found | Invalid_argument _ -> false);
-  state
+let workspace_switch_error_to_string = function
+  | Workspace_masc_root_mismatch { runtime_root; requested_root } ->
+    Printf.sprintf
+      "workspace MASC root mismatch: runtime=%s requested=%s"
+      runtime_root
+      requested_root
+;;
+
+type publication_recovery_activation_error =
+  | Publication_recovery_registry_unavailable of
+      Fs_compat.publication_recovery_registry_error
+  | Publication_recovery_inventory_unavailable of
+      Fs_compat.publication_recovery_owner_inventory_error
+  | Publication_recovery_owner_activation_rejection_failed of
+      { owner : Fs_compat.publication_recovery_owner
+      ; keeper_identity_error : string
+      ; rejection_error :
+          Fs_compat.publication_recovery_activation_rejection_error
+      }
+
+let publication_recovery_activation_error_to_string = function
+  | Publication_recovery_registry_unavailable error ->
+    "publication recovery registry unavailable: "
+    ^ Fs_compat.publication_recovery_registry_error_to_string error
+  | Publication_recovery_inventory_unavailable error ->
+    "publication recovery owner inventory unavailable: "
+    ^ Fs_compat.publication_recovery_owner_inventory_error_to_string error
+  | Publication_recovery_owner_activation_rejection_failed
+      { owner; keeper_identity_error; rejection_error } ->
+    Printf.sprintf
+      "publication recovery owner %S failed MASC identity validation (%s), \
+       but its activation rejection could not be settled: %s"
+      (Fs_compat.publication_recovery_owner_to_string owner)
+      keeper_identity_error
+      (Fs_compat.publication_recovery_activation_rejection_error_to_string
+         rejection_error)
+;;
+
+exception Publication_recovery_activation_failed of
+  publication_recovery_activation_error
+
+let () =
+  Printexc.register_printer (function
+    | Publication_recovery_activation_failed error ->
+      Some (publication_recovery_activation_error_to_string error)
+    | _ -> None)
+;;
+
+let workspace_scope state = Atomic.get state.workspace_runtime.scope
+let workspace_config state = (workspace_scope state).config
+
+let workspace_scope_publication_recovery_registry scope =
+  Option.map
+    (fun runtime -> runtime.registry)
+    scope.publication_recovery
+;;
+
+let workspace_scope_publication_recovery_report scope =
+  Option.map
+    (fun runtime -> runtime.activation_report)
+    scope.publication_recovery
+;;
+
+let publication_recovery_activation_report_rows report =
+  List.map
+    (fun slot -> Atomic.get slot.row)
+    report.slots
+;;
+
+let rec record_publication_recovery_observation_failure report failure =
+  let current = Atomic.get report.observation_failures in
+  if
+    not
+      (Atomic.compare_and_set
+         report.observation_failures
+         current
+         (failure :: current))
+  then record_publication_recovery_observation_failure report failure
+;;
+
+let observe_publication_recovery_event report ~event observe =
+  match observe () with
+  | () -> ()
+  | exception (Eio.Cancel.Cancelled _ as exception_) ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    record_publication_recovery_observation_failure
+      report
+      { event; exception_; backtrace };
+    Printexc.raise_with_backtrace exception_ backtrace
+  | exception exception_ ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    record_publication_recovery_observation_failure
+      report
+      { event; exception_; backtrace }
+;;
+
+let publication_recovery_owner_inventory_row_to_yojson = function
+  | Fs_compat.Publication_recovery_valid_owner owner ->
+    `Assoc
+      [ "kind", `String "valid_owner"
+      ; ( "owner"
+        , `String (Fs_compat.publication_recovery_owner_to_string owner) )
+      ]
+  | Fs_compat.Publication_recovery_invalid_owner_name name ->
+    `Assoc
+      [ "kind", `String "invalid_owner_name"
+      ; "name", `String name
+      ]
+  | Fs_compat.Publication_recovery_unexpected_owner_kind { owner; kind } ->
+    `Assoc
+      [ "kind", `String "unexpected_owner_kind"
+      ; ( "owner"
+        , `String (Fs_compat.publication_recovery_owner_to_string owner) )
+      ; ( "resource_kind"
+        , `String (Format.asprintf "%a" Eio.File.Stat.pp_kind kind) )
+      ]
+  | Fs_compat.Publication_recovery_missing_owner_entry owner ->
+    `Assoc
+      [ "kind", `String "missing_owner_entry"
+      ; ( "owner"
+        , `String (Fs_compat.publication_recovery_owner_to_string owner) )
+      ]
+  | Fs_compat.Publication_recovery_owner_entry_unavailable { owner; error } ->
+    `Assoc
+      [ "kind", `String "owner_entry_unavailable"
+      ; ( "owner"
+        , `String (Fs_compat.publication_recovery_owner_to_string owner) )
+      ; ( "error"
+        , `String
+            (Fs_compat.publication_recovery_registry_error_to_string error) )
+      ]
+;;
+
+let publication_recovery_reconciliation_error_to_yojson = function
+  | Fs_compat.Publication_recovery_owner_inventory_required owner ->
+    `Assoc
+      [ "kind", `String "owner_inventory_required"
+      ; ( "owner"
+        , `String (Fs_compat.publication_recovery_owner_to_string owner) )
+      ]
+  | Fs_compat.Publication_recovery_owner_inventory_in_progress owner ->
+    `Assoc
+      [ "kind", `String "owner_inventory_in_progress"
+      ; ( "owner"
+        , `String (Fs_compat.publication_recovery_owner_to_string owner) )
+      ]
+  | Fs_compat.Publication_recovery_owner_not_in_inventory owner ->
+    `Assoc
+      [ "kind", `String "owner_not_in_inventory"
+      ; ( "owner"
+        , `String (Fs_compat.publication_recovery_owner_to_string owner) )
+      ]
+  | Fs_compat.Publication_recovery_owner_reconciliation_in_progress owner ->
+    `Assoc
+      [ "kind", `String "owner_reconciliation_in_progress"
+      ; ( "owner"
+        , `String (Fs_compat.publication_recovery_owner_to_string owner) )
+      ]
+  | Fs_compat.Publication_recovery_owner_inventory_prevents_reconciliation row ->
+    `Assoc
+      [ "kind", `String "owner_inventory_prevents_reconciliation"
+      ; "inventory", publication_recovery_owner_inventory_row_to_yojson row
+      ]
+  | Fs_compat.Publication_recovery_owner_reconciliation_crashed
+      { owner; exception_; backtrace } ->
+    `Assoc
+      [ "kind", `String "owner_reconciliation_crashed"
+      ; ( "owner"
+        , `String (Fs_compat.publication_recovery_owner_to_string owner) )
+      ; "exception", `String (Printexc.to_string exception_)
+      ; ( "backtrace"
+        , `String (Printexc.raw_backtrace_to_string backtrace) )
+      ]
+  | Fs_compat.Publication_recovery_owner_reconciliation_cancelled
+      { owner; reason; backtrace } ->
+    `Assoc
+      [ "kind", `String "owner_reconciliation_cancelled"
+      ; ( "owner"
+        , `String (Fs_compat.publication_recovery_owner_to_string owner) )
+      ; "reason", `String (Printexc.to_string reason)
+      ; ( "backtrace"
+        , `String (Printexc.raw_backtrace_to_string backtrace) )
+      ]
+  | Fs_compat.Publication_recovery_owner_activation_rejected owner ->
+    `Assoc
+      [ "kind", `String "owner_activation_rejected"
+      ; ( "owner"
+        , `String (Fs_compat.publication_recovery_owner_to_string owner) )
+      ]
+;;
+
+let publication_recovery_activation_row_to_yojson = function
+  | Publication_recovery_owner_pending { owner } ->
+    `Assoc
+      [ "kind", `String "owner_pending"
+      ; "owner", `String owner
+      ]
+  | Publication_recovery_owner_running { owner } ->
+    `Assoc
+      [ "kind", `String "owner_running"
+      ; "owner", `String owner
+      ]
+  | Publication_recovery_owner_report report ->
+    `Assoc
+      [ ( "kind"
+        , `String "owner_report" )
+      ; ( "report"
+        , Fs_compat.publication_recovery_reconciliation_report_to_yojson
+            report )
+      ]
+  | Publication_recovery_owner_identity_rejected { owner; error } ->
+    `Assoc
+      [ "kind", `String "owner_identity_rejected"
+      ; "owner", `String owner
+      ; "error", `String error
+      ]
+  | Publication_recovery_owner_reconciliation_failed { owner; error } ->
+    `Assoc
+      [ "kind", `String "owner_reconciliation_failed"
+      ; "owner", `String owner
+      ; "error", publication_recovery_reconciliation_error_to_yojson error
+      ]
+  | Publication_recovery_owner_reconciliation_crashed
+      { owner; exception_; backtrace } ->
+    `Assoc
+      [ "kind", `String "owner_reconciliation_crashed"
+      ; "owner", `String owner
+      ; "exception", `String (Printexc.to_string exception_)
+      ; ( "backtrace"
+        , `String (Printexc.raw_backtrace_to_string backtrace) )
+      ]
+  | Publication_recovery_owner_cancelled { owner; reason; backtrace } ->
+    `Assoc
+      [ "kind", `String "owner_cancelled"
+      ; "owner", `String owner
+      ; "reason", `String (Printexc.to_string reason)
+      ; ( "backtrace"
+        , `String (Printexc.raw_backtrace_to_string backtrace) )
+      ]
+  | Publication_recovery_owner_inventory_issue row ->
+    `Assoc
+      [ "kind", `String "owner_inventory_issue"
+      ; "inventory", publication_recovery_owner_inventory_row_to_yojson row
+      ]
+;;
+
+type publication_recovery_activation_health_counts =
+  { owner_pending : int
+  ; owner_running : int
+  ; owner_ready : int
+  ; owner_reconciliation_blocked : int
+  ; owner_identity_rejected : int
+  ; owner_reconciliation_failed : int
+  ; owner_reconciliation_crashed : int
+  ; owner_reconciliation_cancelled : int
+  ; owner_inventory_issue : int
+  }
+
+let empty_publication_recovery_activation_health_counts =
+  { owner_pending = 0
+  ; owner_running = 0
+  ; owner_ready = 0
+  ; owner_reconciliation_blocked = 0
+  ; owner_identity_rejected = 0
+  ; owner_reconciliation_failed = 0
+  ; owner_reconciliation_crashed = 0
+  ; owner_reconciliation_cancelled = 0
+  ; owner_inventory_issue = 0
+  }
+;;
+
+let add_publication_recovery_activation_health_row counts = function
+  | Publication_recovery_owner_pending _ ->
+    { counts with owner_pending = counts.owner_pending + 1 }
+  | Publication_recovery_owner_running _ ->
+    { counts with owner_running = counts.owner_running + 1 }
+  | Publication_recovery_owner_report report ->
+    if Fs_compat.publication_recovery_reconciliation_report_is_ready report
+    then { counts with owner_ready = counts.owner_ready + 1 }
+    else
+      { counts with
+        owner_reconciliation_blocked =
+          counts.owner_reconciliation_blocked + 1
+      }
+  | Publication_recovery_owner_identity_rejected _ ->
+    { counts with
+      owner_identity_rejected = counts.owner_identity_rejected + 1
+    }
+  | Publication_recovery_owner_reconciliation_failed _ ->
+    { counts with
+      owner_reconciliation_failed = counts.owner_reconciliation_failed + 1
+    }
+  | Publication_recovery_owner_reconciliation_crashed _ ->
+    { counts with
+      owner_reconciliation_crashed = counts.owner_reconciliation_crashed + 1
+    }
+  | Publication_recovery_owner_cancelled _ ->
+    { counts with
+      owner_reconciliation_cancelled =
+        counts.owner_reconciliation_cancelled + 1
+    }
+  | Publication_recovery_owner_inventory_issue _ ->
+    { counts with owner_inventory_issue = counts.owner_inventory_issue + 1 }
+;;
+
+type publication_recovery_observation_health_counts =
+  { inventory_activation : int
+  ; inventory_terminal : int
+  ; owner_terminal : int
+  }
+
+let empty_publication_recovery_observation_health_counts =
+  { inventory_activation = 0; inventory_terminal = 0; owner_terminal = 0 }
+;;
+
+let add_publication_recovery_observation_health_failure counts failure =
+  match failure.event with
+  | Publication_recovery_inventory_activation ->
+    { counts with inventory_activation = counts.inventory_activation + 1 }
+  | Publication_recovery_inventory_terminal ->
+    { counts with inventory_terminal = counts.inventory_terminal + 1 }
+  | Publication_recovery_owner_terminal _ ->
+    { counts with owner_terminal = counts.owner_terminal + 1 }
+;;
+
+let publication_recovery_activation_report_to_health_yojson report =
+  let rows = publication_recovery_activation_report_rows report in
+  let counts =
+    List.fold_left
+      add_publication_recovery_activation_health_row
+      empty_publication_recovery_activation_health_counts
+      rows
+  in
+  let observation_failures = Atomic.get report.observation_failures in
+  let observation_counts =
+    List.fold_left
+      add_publication_recovery_observation_health_failure
+      empty_publication_recovery_observation_health_counts
+      observation_failures
+  in
+  let in_progress_count = counts.owner_pending + counts.owner_running in
+  let blocking_count =
+    counts.owner_reconciliation_blocked
+    + counts.owner_identity_rejected
+    + counts.owner_reconciliation_failed
+    + counts.owner_reconciliation_crashed
+    + counts.owner_reconciliation_cancelled
+    + counts.owner_inventory_issue
+  in
+  let observation_failure_count = List.length observation_failures in
+  let status =
+    if blocking_count > 0
+    then Health_status.Blocked
+    else if observation_failure_count > 0
+    then Health_status.Degraded
+    else if in_progress_count > 0
+    then Health_status.Warming
+    else Health_status.Ok
+  in
+  let status_reason_fields =
+    [ ( counts.owner_reconciliation_blocked
+      , "owner_reconciliation_blocked" )
+    ; counts.owner_identity_rejected, "owner_identity_rejected"
+    ; counts.owner_reconciliation_failed, "owner_reconciliation_failed"
+    ; counts.owner_reconciliation_crashed, "owner_reconciliation_crashed"
+    ; counts.owner_reconciliation_cancelled, "owner_reconciliation_cancelled"
+    ; counts.owner_inventory_issue, "owner_inventory_issue"
+    ; ( observation_counts.inventory_activation
+      , "inventory_activation_observation_failed" )
+    ; ( observation_counts.inventory_terminal
+      , "inventory_terminal_observation_failed" )
+    ; ( observation_counts.owner_terminal
+      , "owner_terminal_observation_failed" )
+    ]
+  in
+  let status_reasons =
+    List.filter_map
+      (fun (count, reason) -> if count > 0 then Some (`String reason) else None)
+      status_reason_fields
+  in
+  `Assoc
+    [ "status", `String (Health_status.to_string status)
+    ; "blocking", `Bool (blocking_count > 0)
+    ; ( "operator_action_required"
+      , `Bool (blocking_count > 0 || observation_failure_count > 0) )
+    ; "row_count", `Int (List.length rows)
+    ; "in_progress_count", `Int in_progress_count
+    ; "blocking_count", `Int blocking_count
+    ; "observation_failure_count", `Int observation_failure_count
+    ; "status_reasons", `List status_reasons
+    ; ( "row_counts"
+      , `Assoc
+          [ "owner_pending", `Int counts.owner_pending
+          ; "owner_running", `Int counts.owner_running
+          ; "owner_ready", `Int counts.owner_ready
+          ; ( "owner_reconciliation_blocked"
+            , `Int counts.owner_reconciliation_blocked )
+          ; "owner_identity_rejected", `Int counts.owner_identity_rejected
+          ; ( "owner_reconciliation_failed"
+            , `Int counts.owner_reconciliation_failed )
+          ; ( "owner_reconciliation_crashed"
+            , `Int counts.owner_reconciliation_crashed )
+          ; ( "owner_reconciliation_cancelled"
+            , `Int counts.owner_reconciliation_cancelled )
+          ; "owner_inventory_issue", `Int counts.owner_inventory_issue
+          ] )
+    ; ( "observation_failure_counts"
+      , `Assoc
+          [ ( "inventory_activation"
+            , `Int observation_counts.inventory_activation )
+          ; "inventory_terminal", `Int observation_counts.inventory_terminal
+          ; "owner_terminal", `Int observation_counts.owner_terminal
+          ] )
+    ]
+;;
+
+let publication_recovery_activation_row_log_level = function
+  | Publication_recovery_owner_report report
+    when Fs_compat.publication_recovery_reconciliation_report_is_ready report ->
+    Log.Info
+  | Publication_recovery_owner_reconciliation_crashed _ -> Log.Error
+  | Publication_recovery_owner_pending _
+  | Publication_recovery_owner_running _ -> Log.Debug
+  | Publication_recovery_owner_report _
+  | Publication_recovery_owner_identity_rejected _
+  | Publication_recovery_owner_reconciliation_failed _
+  | Publication_recovery_owner_cancelled _
+  | Publication_recovery_owner_inventory_issue _ -> Log.Warn
+;;
+
+let publication_recovery_activation_row_observation_event = function
+  | Publication_recovery_owner_pending { owner }
+  | Publication_recovery_owner_running { owner }
+  | Publication_recovery_owner_identity_rejected { owner; _ }
+  | Publication_recovery_owner_reconciliation_failed { owner; _ }
+  | Publication_recovery_owner_reconciliation_crashed { owner; _ }
+  | Publication_recovery_owner_cancelled { owner; _ } ->
+    Publication_recovery_owner_terminal { owner }
+  | Publication_recovery_owner_report report ->
+    Publication_recovery_owner_terminal
+      { owner =
+          Fs_compat.publication_recovery_reconciliation_report_owner report
+      }
+  | Publication_recovery_owner_inventory_issue _ ->
+    Publication_recovery_inventory_terminal
+;;
+
+let observe_publication_recovery_activation_row
+    report
+    ~registry_root
+    row
+  =
+  let event = publication_recovery_activation_row_observation_event row in
+  observe_publication_recovery_event
+    report
+    ~event
+    (fun () ->
+      Log.Server.emit
+        (publication_recovery_activation_row_log_level row)
+        ~category:Log.Boundary
+        ~details:
+          (`Assoc
+             [ "registry_root", `String registry_root
+             ; ( "activation"
+               , publication_recovery_activation_row_to_yojson row )
+             ])
+        "publication recovery owner activation reached a terminal state")
+;;
+
+type publication_recovery_activation_job =
+  { owner : Fs_compat.publication_recovery_owner
+  ; owner_name : string
+  ; slot : publication_recovery_activation_slot
+  ; resolve_completion : unit Eio.Promise.u
+  }
+
+let create_complete_publication_recovery_activation_slot row =
+  let completion, resolve_completion = Eio.Promise.create () in
+  Eio.Promise.resolve resolve_completion ();
+  { row = Atomic.make row; completion }
+;;
+
+let create_pending_publication_recovery_activation_slot ~owner =
+  let completion, resolve_completion = Eio.Promise.create () in
+  ( { row = Atomic.make (Publication_recovery_owner_pending { owner })
+    ; completion
+    }
+  , resolve_completion )
+;;
+
+let prepare_publication_recovery_activation ~registry inventory =
+  let add_inventory_row
+      (slots, jobs, scheduled_owner_count, initial_terminal_count)
+      inventory_row
+    =
+    match inventory_row with
+    | Fs_compat.Publication_recovery_valid_owner owner ->
+      let owner_name =
+        Fs_compat.publication_recovery_owner_to_string owner
+      in
+      (match Keeper_id.Keeper_name.of_string owner_name with
+       | Error error ->
+         (match
+            Fs_compat.reject_publication_recovery_owner_activation
+              ~registry
+              ~owner
+          with
+          | Error rejection_error ->
+            raise
+              (Publication_recovery_activation_failed
+                 (Publication_recovery_owner_activation_rejection_failed
+                    { owner
+                    ; keeper_identity_error = error
+                    ; rejection_error
+                    }))
+          | Ok () ->
+            let slot =
+              create_complete_publication_recovery_activation_slot
+                (Publication_recovery_owner_identity_rejected
+                   { owner = owner_name; error })
+            in
+            ( slot :: slots
+            , jobs
+            , scheduled_owner_count
+            , initial_terminal_count + 1 ))
+       | Ok _ ->
+         let slot, resolve_completion =
+           create_pending_publication_recovery_activation_slot
+             ~owner:owner_name
+         in
+         let job = { owner; owner_name; slot; resolve_completion } in
+         ( slot :: slots
+         , job :: jobs
+         , scheduled_owner_count + 1
+         , initial_terminal_count ))
+    | ( Fs_compat.Publication_recovery_invalid_owner_name _
+      | Fs_compat.Publication_recovery_unexpected_owner_kind _
+      | Fs_compat.Publication_recovery_missing_owner_entry _
+      | Fs_compat.Publication_recovery_owner_entry_unavailable _ ) as row ->
+      let slot =
+        create_complete_publication_recovery_activation_slot
+          (Publication_recovery_owner_inventory_issue row)
+      in
+      ( slot :: slots
+      , jobs
+      , scheduled_owner_count
+      , initial_terminal_count + 1 )
+  in
+  let slots, jobs, scheduled_owner_count, initial_terminal_count =
+    List.fold_left
+      add_inventory_row
+      ([], [], 0, 0)
+      inventory
+  in
+  let activation_report =
+    { slots = List.rev slots; observation_failures = Atomic.make [] }
+  in
+  ( { registry; activation_report }
+  , List.rev jobs
+  , scheduled_owner_count
+  , initial_terminal_count )
+;;
+
+let publication_recovery_activation_crashed ~owner exception_ backtrace =
+  Publication_recovery_owner_reconciliation_crashed
+    { owner; exception_; backtrace }
+;;
+
+let run_publication_recovery_activation_job
+    ~fs
+    ~registry
+    ~registry_root
+    ~activation_report
+    job
+  =
+  Atomic.set
+    job.slot.row
+    (Publication_recovery_owner_running { owner = job.owner_name });
+  let terminal_row =
+    match
+      Fs_compat.reconcile_publication_recovery_owner
+        ~fs
+        ~registry
+        ~owner:job.owner
+    with
+    | exception (Eio.Cancel.Cancelled _ as exception_) -> raise exception_
+    | exception exception_ ->
+      let backtrace = Printexc.get_raw_backtrace () in
+      publication_recovery_activation_crashed
+        ~owner:job.owner_name
+        exception_
+        backtrace
+    | Ok report -> Publication_recovery_owner_report report
+    | Error error ->
+      Publication_recovery_owner_reconciliation_failed
+        { owner = job.owner_name; error }
+  in
+  Atomic.set job.slot.row terminal_row;
+  Eio.Promise.resolve job.resolve_completion ();
+  observe_publication_recovery_activation_row
+    activation_report
+    ~registry_root
+    terminal_row
+;;
+
+let run_isolated_publication_recovery_activation_job
+    ~fs
+    ~registry
+    ~registry_root
+    ~activation_report
+    job
+  =
+  match
+    run_publication_recovery_activation_job
+      ~fs
+      ~registry
+      ~registry_root
+      ~activation_report
+      job
+  with
+  | () -> ()
+  | exception Eio.Cancel.Cancelled reason ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    let current_context_cancelled =
+      match Eio.Fiber.check () with
+      | () -> false
+      | exception Eio.Cancel.Cancelled _ -> true
+    in
+    let terminal_row =
+      Publication_recovery_owner_cancelled
+        { owner = job.owner_name; reason; backtrace }
+    in
+    let published =
+      Eio.Cancel.protect (fun () ->
+        match Eio.Promise.peek job.slot.completion with
+        | Some () -> false
+        | None ->
+          Atomic.set job.slot.row terminal_row;
+          Eio.Promise.resolve job.resolve_completion ();
+          true)
+    in
+    if published && not current_context_cancelled
+    then
+      observe_publication_recovery_activation_row
+        activation_report
+        ~registry_root
+        terminal_row
+;;
+
+let validate_workspace_config state config =
+  let requested_root = Workspace.masc_root_dir config in
+  let runtime_root = state.workspace_runtime.process_masc_root in
+  if String.equal requested_root runtime_root
+  then Ok ()
+  else
+    Error (Workspace_masc_root_mismatch { runtime_root; requested_root })
+;;
+
+let set_workspace_config state config =
+  match validate_workspace_config state config with
+  | Error _ as error -> error
+  | Ok () ->
+    let current_scope = workspace_scope state in
+    Atomic.set
+      state.workspace_runtime.scope
+      { config; publication_recovery = current_scope.publication_recovery };
+    Ok ()
+;;
+
+let agent_session_bound_or_observe_failure state ~agent_name =
+  match
+    Workspace.is_agent_session_bound
+      (workspace_config state)
+      ~agent_name
+  with
+  | is_bound -> is_bound
+  | exception ((Sys_error _ | Not_found | Invalid_argument _) as exception_) ->
+    let backtrace = Printexc.get_raw_backtrace () in
+    Log.Server.emit
+      Log.Warn
+      ~category:Log.Boundary
+      ~details:
+        (`Assoc
+           [ "agent_name", `String agent_name
+           ; "exception", `String (Printexc.to_string exception_)
+           ; ( "backtrace"
+             , `String (Printexc.raw_backtrace_to_string backtrace) )
+           ])
+      "board agent-session lookup failed";
+    false
+;;
+
+module For_testing = struct
+  let create_state ~base_path =
+    let config = Workspace.default_config base_path in
+    let registry = Session.create () in
+    (* Wire notification harness: subscription events → session queues *)
+    Subscriptions.set_session_push_fn (fun event ->
+      Session.push_notification_to_active_agents registry ~event
+    );
+    let state =
+      { workspace_runtime =
+          { process_masc_root = Workspace.masc_root_dir config
+          ; scope = Atomic.make { config; publication_recovery = None }
+          }
+      ; session_registry = registry
+      ; on_sse_broadcast = Atomic.make None
+      ; sw = None
+      ; proc_mgr = None
+      ; fs = None
+      ; clock = None
+      ; mono_clock = None
+      ; net = None
+      }
+    in
+    Board_tool.set_agent_lookup (fun name ->
+      agent_session_bound_or_observe_failure state ~agent_name:name);
+    state
+  ;;
+
+  let await_publication_recovery_activation report =
+    List.iter
+      (fun slot -> Eio.Promise.await slot.completion)
+      report.slots;
+    publication_recovery_activation_report_rows report
+  ;;
+end
 
 (** Create state with Eio context. *)
 let create_state_eio ~sw ~proc_mgr ~fs ~clock ~mono_clock ~net ~base_path =
@@ -555,8 +1329,46 @@ let create_state_eio ~sw ~proc_mgr ~fs ~clock ~mono_clock ~net ~base_path =
     Session.push_notification_to_active_agents registry ~event
   );
   Keeper_supervisor.set_global_switch sw;
+  let process_masc_root = Workspace.masc_root_dir config in
+  let publication_recovery_registry =
+    let registry_root = Eio.Path.(fs / process_masc_root) in
+    match
+      Fs_compat.open_publication_recovery_registry
+        ~sw
+        ~registry_root
+    with
+    | Ok registry -> registry
+    | Error error ->
+      raise
+        (Publication_recovery_activation_failed
+           (Publication_recovery_registry_unavailable error))
+  in
+  let publication_recovery_inventory =
+    match
+      Fs_compat.inventory_publication_recovery_owners
+        publication_recovery_registry
+    with
+    | Ok inventory -> inventory
+    | Error error ->
+      raise
+        (Publication_recovery_activation_failed
+           (Publication_recovery_inventory_unavailable error))
+  in
+  let ( publication_recovery
+      , activation_jobs
+      , scheduled_owner_count
+      , initial_terminal_count ) =
+    prepare_publication_recovery_activation
+      ~registry:publication_recovery_registry
+      publication_recovery_inventory
+  in
   let state = {
-    workspace_config = Atomic.make config;
+    workspace_runtime =
+      { process_masc_root
+      ; scope =
+          Atomic.make
+            { config; publication_recovery = Some publication_recovery }
+      };
     session_registry = registry;
     on_sse_broadcast = Atomic.make None;
     sw = Some sw;
@@ -566,10 +1378,39 @@ let create_state_eio ~sw ~proc_mgr ~fs ~clock ~mono_clock ~net ~base_path =
     mono_clock = Some mono_clock;
     net = Some net;
   } in
+  observe_publication_recovery_event
+    publication_recovery.activation_report
+    ~event:Publication_recovery_inventory_activation
+    (fun () ->
+      Log.Server.emit
+        (if initial_terminal_count = 0 then Log.Info else Log.Warn)
+        ~category:Log.Boundary
+        ~details:
+          (`Assoc
+             [ "registry_root", `String process_masc_root
+             ; ( "inventory_row_count"
+               , `Int (List.length publication_recovery_inventory) )
+             ; "scheduled_owner_count", `Int scheduled_owner_count
+             ; "initial_terminal_count", `Int initial_terminal_count
+             ])
+        "publication recovery owner inventory activated");
+  (* Initial terminal inventory rows are retained exactly in the activation
+     report and projected by full health. One summary emission avoids an
+     O(owner-count) sequence of synchronous log-sink flushes before the server
+     can publish its state and start independent owner jobs. *)
+  List.iter
+    (fun job ->
+      Eio.Fiber.fork ~sw (fun () ->
+        run_isolated_publication_recovery_activation_job
+          ~fs
+          ~registry:publication_recovery_registry
+          ~registry_root:process_masc_root
+          ~activation_report:publication_recovery.activation_report
+          job))
+    activation_jobs;
   (* Agent-to-agent board feedback lookup follows the active workspace. *)
   Board_tool.set_agent_lookup (fun name ->
-    try Workspace.is_agent_session_bound (workspace_config state) ~agent_name:name
-    with Sys_error _ | Not_found | Invalid_argument _ -> false);
+    agent_session_bound_or_observe_failure state ~agent_name:name);
   state
 
 (** Register SSE broadcast callback *)

--- a/lib/mcp_server.mli
+++ b/lib/mcp_server.mli
@@ -14,8 +14,8 @@
       themed-SVG icon helper.
     - {b Server state} — the runtime record threaded
       through every request handler.  [Eio.Switch.t] and
-      friends are kept optional so the legacy non-Eio path
-      ({!create_state}) still compiles.
+      friends are kept optional for explicit pure test/replay
+      construction through {!For_testing.create_state}.
     - {b SSE broadcast} — atomic callback ref consumed by
       the HTTP / SSE transport.
 
@@ -172,8 +172,48 @@ val schema_markdown : string
 
 (** {1 Server state} *)
 
-type server_state = {
-  workspace_config : Workspace.config Atomic.t;
+type publication_recovery_activation_row =
+  | Publication_recovery_owner_pending of { owner : string }
+  | Publication_recovery_owner_running of { owner : string }
+  | Publication_recovery_owner_report of
+      Fs_compat.publication_recovery_reconciliation_report
+  | Publication_recovery_owner_identity_rejected of
+      { owner : string
+      ; error : string
+      }
+  | Publication_recovery_owner_reconciliation_failed of
+      { owner : string
+      ; error : Fs_compat.publication_recovery_reconciliation_error
+      }
+  | Publication_recovery_owner_reconciliation_crashed of
+      { owner : string
+      ; exception_ : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+  | Publication_recovery_owner_cancelled of
+      { owner : string
+      ; reason : exn
+      ; backtrace : Printexc.raw_backtrace
+      }
+  | Publication_recovery_owner_inventory_issue of
+      Fs_compat.publication_recovery_owner_inventory_row
+
+type publication_recovery_activation_report
+
+type publication_recovery_runtime
+
+type workspace_scope =
+  { config : Workspace.config
+  ; publication_recovery : publication_recovery_runtime option
+  }
+(** One immutable snapshot of the active workspace, exact recovery registry,
+    and its retained activation report. [None] exists only in
+    {!For_testing.create_state}. *)
+
+type workspace_runtime
+
+type server_state = private {
+  workspace_runtime : workspace_runtime;
   session_registry : Session.registry;
   on_sse_broadcast :
     (Yojson.Safe.t -> unit) option Atomic.t;
@@ -185,23 +225,86 @@ type server_state = {
   net : Eio_context.eio_net option;
 }
 (** Runtime state threaded through every request handler.
-    [workspace_config] is stored in an atomic reference so
-    workspace-switch tools can swap backends without tearing reads
-    in concurrent request/background fibers.  Eio handles are
-    [option] because the legacy non-Eio bootstrap ({!create_state})
-    still needs to construct a state without an active switch. *)
+    The opaque [workspace_runtime] owns the one atomic scope and the
+    process-fixed MASC root, so callers can observe snapshots but cannot
+    mutate the cell directly. Eio handles are [option] because
+    {!For_testing.create_state} supports pure replay and test harnesses without
+    an active switch. *)
+
+val workspace_scope : server_state -> workspace_scope
+(** Current immutable workspace runtime snapshot. *)
 
 val workspace_config : server_state -> Workspace.config
 (** Current workspace configuration. *)
 
-val set_workspace_config : server_state -> Workspace.config -> unit
-(** Atomically replace the active workspace configuration. *)
+val workspace_scope_publication_recovery_registry :
+  workspace_scope -> Fs_compat.publication_recovery_registry option
 
-val create_state : base_path:string -> server_state
-(** Legacy bootstrap.  Every Eio handle is [None]; the
-    server runs without proc-mgr / fs / clock / net.
-    Used by tools that need a state-shaped value but no
-    runtime fibers (test fixtures, replay harnesses). *)
+val workspace_scope_publication_recovery_report :
+  workspace_scope -> publication_recovery_activation_report option
+
+val publication_recovery_activation_report_rows :
+  publication_recovery_activation_report ->
+  publication_recovery_activation_row list
+(** Immutable snapshot of every activation slot at the instant of the call. *)
+
+val publication_recovery_activation_report_to_health_yojson :
+  publication_recovery_activation_report -> Yojson.Safe.t
+(** Public-health projection. It exposes only typed aggregate counts and
+    status categories; owner identities, filesystem paths, exceptions,
+    backtraces, and nested reconciliation evidence remain internal. *)
+
+type workspace_switch_error =
+  | Workspace_masc_root_mismatch of
+      { runtime_root : string
+      ; requested_root : string
+      }
+
+val workspace_switch_error_to_string : workspace_switch_error -> string
+
+type publication_recovery_activation_error =
+  | Publication_recovery_registry_unavailable of
+      Fs_compat.publication_recovery_registry_error
+  | Publication_recovery_inventory_unavailable of
+      Fs_compat.publication_recovery_owner_inventory_error
+  | Publication_recovery_owner_activation_rejection_failed of
+      { owner : Fs_compat.publication_recovery_owner
+      ; keeper_identity_error : string
+      ; rejection_error :
+          Fs_compat.publication_recovery_activation_rejection_error
+      }
+
+val publication_recovery_activation_error_to_string :
+  publication_recovery_activation_error -> string
+
+val validate_workspace_config :
+  server_state -> Workspace.config -> (unit, workspace_switch_error) result
+(** Pure process-root validation shared by workspace preparation and
+    {!set_workspace_config}. *)
+
+val set_workspace_config :
+  server_state -> Workspace.config -> (unit, workspace_switch_error) result
+(** Atomically replace only the active workspace projection. The requested
+    {!Workspace.masc_root_dir} must exactly equal the process-fixed runtime
+    root; a mismatch is typed and leaves the previous scope unchanged. This
+    function performs no filesystem I/O. *)
+
+module For_testing : sig
+  val create_state : base_path:string -> server_state
+  (** Non-runtime state. Every Eio handle and the publication registry are
+      [None]. This constructor is isolated from the production bootstrap
+      surface. *)
+
+  val await_publication_recovery_activation :
+    publication_recovery_activation_report ->
+    publication_recovery_activation_row list
+  (** Await every exact slot-completion promise without timeout, polling, or a
+      retry budget, then return one immutable row snapshot. Cancellation of
+      the calling fiber propagates. *)
+end
+
+exception Publication_recovery_activation_failed of
+  publication_recovery_activation_error
 
 val create_state_eio :
   sw:Eio.Switch.t ->
@@ -215,7 +318,9 @@ val create_state_eio :
 (** Production bootstrap.  Wires every Eio handle into
     [Some], starts the [Session] actor consumer, starts
     the {!Runtime_observation} actor, and installs the
-    Subscriptions notification harness. *)
+    Subscriptions notification harness. Publication recovery opens and
+    inventories one process-lifetime registry synchronously, then reconciles
+    each valid owner in an independent child fiber. *)
 
 (** {1 SSE broadcast} *)
 

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -34,12 +34,13 @@ let get_clock_opt () = Eio_context.get_clock_opt ()
 (** {1 State Construction} *)
 let get_clock () = Eio_context.get_clock ()
 
-let create_state ?test_mode ~base_path () =
-  let state = Mcp_server.create_state ~base_path in
-  (match test_mode with
-   | Some true -> Auth.disable_auth base_path
-   | _ -> ());
-  state
+module For_testing = struct
+  let create_state ~base_path () =
+    let state = Mcp_server.For_testing.create_state ~base_path in
+    Auth.disable_auth base_path;
+    state
+  ;;
+end
 
 let create_state_eio ~sw ~proc_mgr ~fs ~clock ~mono_clock ~net ~base_path =
   Mcp_server.create_state_eio

--- a/lib/mcp_server_eio.mli
+++ b/lib/mcp_server_eio.mli
@@ -64,12 +64,11 @@ val get_clock : unit -> (float Eio.Time.clock_ty Eio.Resource.t, string) result
 
 (** {1 State Management} *)
 
-(** Create server state (synchronous, no effect)
-    @param test_mode When [true], disable workspace authentication so
-    unit tests can exercise handlers without provisioning credentials.
-    Production callers must leave this unset.
-    @param base_path Workspace/base path; MASC data lives under [<base_path>/.masc]. *)
-val create_state : ?test_mode:bool -> base_path:string -> unit -> server_state
+module For_testing : sig
+  val create_state : base_path:string -> unit -> server_state
+  (** Create non-runtime state and explicitly disable workspace authentication.
+      This constructor is isolated from the production bootstrap surface. *)
+end
 
 (** Create server state with Eio context.
 
@@ -122,6 +121,7 @@ val handle_request :
 val execute_tool_eio :
   sw:Eio.Switch.t ->
   clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  workspace_scope:Mcp_server.workspace_scope ->
   ?profile:tool_profile ->
   ?mcp_session_id:string ->
   ?auth_token:string ->

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -454,6 +454,14 @@ let resolve_managed_agent_call ?mcp_session_id params =
 let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
     ~broadcast_tools_list_changed ~sw ~clock ?(profile = Full) ?mcp_session_id
     ?auth_token ?(internal_keeper_runtime = false) state id params =
+  (* The active workspace is an admission fact for this call.  In particular,
+     [masc_start] may publish a new current scope while executing, but the
+     initiating call and every post-execution observation remain attributed to
+     this source scope. *)
+  let workspace_scope : Mcp_server.workspace_scope =
+    Mcp_server.workspace_scope state
+  in
+  let config = workspace_scope.config in
   let make_response = Mcp_transport_protocol.make_response in
   let (name, arguments) =
     match profile with
@@ -474,6 +482,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
       execute_tool_eio
         ~sw
         ~clock
+        ~workspace_scope
         ?profile:(Some profile)
         ?mcp_session_id
         ?auth_token
@@ -555,7 +564,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
       Some (Printf.sprintf "duration_ms=%d|detail=%s" duration_ms truncated)
   in
   let otel_trace_id = Otel_spans.current_trace_id () in
-  Audit_log.log_tool_call (Mcp_server.workspace_config state)
+  Audit_log.log_tool_call config
     ~agent_id:agent_name ~tool_name:name ~success ~error_msg:error_detail
     ?trace_id:otel_trace_id ();
   if not success then (
@@ -584,13 +593,18 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
       (Printf.sprintf "tool call failed: %s — %s" name
          (Option.value ~default:"(no detail)" error_detail)));
 
-  (* Classify call source: Keeper_internal if the resolved agent_name matches
-     a registered keeper (keeper-internal dispatch via cli_agent runtime),
-     otherwise External_mcp (true external MCP client).  Sound partial:
-     missing identity falls through to External_mcp.  Issue #8915. *)
+  (* Classify call source: Keeper_internal only when the resolved agent_name
+     matches a keeper in the admission workspace.  A process-global lookup
+     could select an identically named keeper from the newly current scope
+     after [masc_start], tearing tool-usage persistence from this call's
+     observation generation.  Missing identity falls through to External_mcp.
+     Issue #8915. *)
   let keeper_entry =
     if String.length agent_name = 0 then None
-    else Keeper_registry_lookup.find_by_agent_name agent_name
+    else
+      Keeper_registry.all ~base_path:config.base_path ()
+      |> List.find_opt (fun (entry : Keeper_registry.registry_entry) ->
+        String.equal entry.meta.agent_name agent_name)
   in
   let source : Tool_registry.call_source =
     match keeper_entry with
@@ -622,7 +636,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
   if telemetry_enabled then
     (match state.Mcp_server.fs with
      | Some fs ->
-         (try Telemetry_eio.track_tool_called ~fs (Mcp_server.workspace_config state)
+         (try Telemetry_eio.track_tool_called ~fs config
                 ~tool_name:name ~agent_id:agent_name ~success ~duration_ms
                 ~source:(Tool_registry.string_of_source source)
                 ?session_id:telemetry_session_id
@@ -699,7 +713,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
   (* Emit activity graph event for tool call — enables real-time dashboard tracking *)
   (try
     (* fire-and-forget: activity graph emission must not change the tool-call result. *)
-    ignore (Activity_graph.emit (Mcp_server.workspace_config state)
+    ignore (Activity_graph.emit config
       ~actor:(Activity_graph.entity ~kind:"agent" agent_name)
       ~subject:(Activity_graph.entity ~kind:"tool" name)
       ~kind:

--- a/lib/mcp_server_eio_call_tool.mli
+++ b/lib/mcp_server_eio_call_tool.mli
@@ -109,6 +109,7 @@ val handle_call_tool_eio :
   execute_tool_eio:
     (sw:'sw ->
      clock:([> float Eio.Time.clock_ty ] as 'clk) Eio.Resource.t ->
+     workspace_scope:Mcp_server.workspace_scope ->
      ?profile:Mcp_server_eio_types.tool_profile ->
      ?mcp_session_id:string ->
      ?auth_token:'auth ->
@@ -141,8 +142,12 @@ val handle_call_tool_eio :
     when the call is known to alter the tool catalogue
     (long-running mutations, etc).
 
-    The dispatcher invokes the concrete tool exactly once, times that
-    execution for telemetry, and on the keeper-runtime path threads
+    The handler captures one immutable {!Mcp_server.workspace_scope} at
+    admission.  The dispatcher and all post-execution workspace-scoped
+    observations use that exact generation even when the tool changes the
+    server's current workspace.  The dispatcher invokes the concrete tool
+    exactly once, times that execution for telemetry, and on the
+    keeper-runtime path threads
     {!record_runtime_mcp_keeper_tool_trace} into the
     success / failure branches.
 

--- a/lib/mcp_server_eio_caller_identity.ml
+++ b/lib/mcp_server_eio_caller_identity.ml
@@ -17,7 +17,6 @@ type t = {
   token : string option;
   has_explicit_agent_name : bool;
   verified_internal_keeper_runtime : bool;
-  internal_keeper_runtime_tool : bool;
   owner_keeper_identity : owner_keeper_identity option;
   mode_gate_error : string option;
 }
@@ -250,11 +249,6 @@ let resolve ~(config : Workspace_utils_backend_setup.config) ~tool_name ~argumen
     | Some raw -> Auth.verify_internal_keeper_token config.base_path ~token:raw
     | None -> false
   in
-  (* The Agent_internal surface was empty (agent_internal_surface_tools = []),
-     so this flag was already always [false].  Surface deleted in the
-     surface-cut refactor; flag retained because [mcp_server_eio_execute]
-     reads it to skip the direct-call block for internal keeper runtimes. *)
-  let internal_keeper_runtime_tool = false in
   let owner_keeper_identity =
     match token with
     | None -> None
@@ -269,8 +263,6 @@ let resolve ~(config : Workspace_utils_backend_setup.config) ~tool_name ~argumen
   in
   let mode_gate_error =
     if
-      (not internal_keeper_runtime_tool)
-      &&
       match direct_call_authority with
       | Restricted_profile -> false
       | Catalog_policy -> not (Tool_catalog.allow_direct_call tool_name)
@@ -300,7 +292,6 @@ let resolve ~(config : Workspace_utils_backend_setup.config) ~tool_name ~argumen
     token;
     has_explicit_agent_name;
     verified_internal_keeper_runtime;
-    internal_keeper_runtime_tool;
     owner_keeper_identity;
     mode_gate_error;
   }

--- a/lib/mcp_server_eio_caller_identity.mli
+++ b/lib/mcp_server_eio_caller_identity.mli
@@ -32,7 +32,6 @@ type t = {
   token : string option;
   has_explicit_agent_name : bool;
   verified_internal_keeper_runtime : bool;
-  internal_keeper_runtime_tool : bool;
   owner_keeper_identity : owner_keeper_identity option;
   mode_gate_error : string option;
 }

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -19,36 +19,10 @@ let resolve_bind_state ~workspace_initialized ~bind_required ~agent_name ~check_
   && check_join agent_name
 ;;
 
-let cleanup_internal_keeper_runtime_resource ~during_exception ~label cleanup =
-  try cleanup () with
-  | Eio.Cancel.Cancelled _ as e when not during_exception -> raise e
-  | exn ->
-    Log.Mcp.warn
-      "internal keeper runtime %s cleanup failed%s: %s"
-      label
-      (if during_exception then " while preserving primary exception" else "")
-      (Printexc.to_string exn)
-;;
-
-let run_with_cleanup_preserving_primary ~cleanup f =
-  match f () with
-  | result ->
-    cleanup ~during_exception:false ();
-    result
-  | exception exn ->
-    let bt = Printexc.get_raw_backtrace () in
-    cleanup ~during_exception:true ();
-    Printexc.raise_with_backtrace exn bt
-;;
-
-module For_testing = struct
-  let cleanup_internal_keeper_runtime_resource = cleanup_internal_keeper_runtime_resource
-  let run_with_cleanup_preserving_primary = run_with_cleanup_preserving_primary
-end
-
 let execute_tool_eio
       ~sw
       ~clock
+      ~(workspace_scope : Mcp_server.workspace_scope)
       ?(profile = Mcp_server_eio_tool_profile.Full)
       ?mcp_session_id
       ?auth_token
@@ -67,7 +41,7 @@ let execute_tool_eio
   Eio_context.set_clock clock;
   (* Otel_metric_store: count every inbound tool call *)
   Otel_metric_store.record_request ();
-  let config = (Mcp_server.workspace_config state) in
+  let config = workspace_scope.config in
   let registry = state.Mcp_server.session_registry in
   (* Fix 3: Cache workspace_initialized to avoid repeated stat syscalls. *)
   let workspace_init_cached = Workspace.is_initialized config in
@@ -106,9 +80,6 @@ let execute_tool_eio
   in
   let agent_name = caller_identity.agent_name in
   let token = caller_identity.token in
-  let internal_keeper_runtime_tool =
-    caller_identity.internal_keeper_runtime_tool
-  in
   let owner_keeper_identity = caller_identity.owner_keeper_identity in
   let mode_gate_error = caller_identity.mode_gate_error in
   (* Cache resolved agent_name for this session (Fix 4), carrying the
@@ -268,6 +239,8 @@ let execute_tool_eio
                 ~clock
                 ~proc_mgr:state.Mcp_server.proc_mgr
                 ~net:state.Mcp_server.net
+                ~publication_recovery_registry:
+                  (Mcp_server.workspace_scope_publication_recovery_registry workspace_scope)
             in
             (* Dispatch a single module by tag — creates only that module's context.
      Pre-hooks may coerce arguments (e.g. OAS type coercion: "42" -> 42).
@@ -287,6 +260,8 @@ let execute_tool_eio
                      ; clock
                      ; proc_mgr = state.Mcp_server.proc_mgr
                      ; net = state.Mcp_server.net
+                     ; publication_recovery_registry =
+                         (Mcp_server.workspace_scope_publication_recovery_registry workspace_scope)
                      ; mcp_session_id
                      }
                    in
@@ -328,15 +303,18 @@ let execute_tool_eio
                      ~name
                      ~args:coerced_args
                  | Mod_agent_timeline ->
+                   let caller_is_registered_keeper =
+                     Keeper_registry.all ~base_path:config.base_path ()
+                     |> List.exists
+                          (fun (entry : Keeper_registry.registry_entry) ->
+                            String.equal entry.name agent_name
+                            || String.equal entry.meta.agent_name agent_name)
+                   in
                    Tool_agent_timeline.dispatch
                      ~load_chat:(fun ~agent_name:requested_agent_name ->
                        if
                          Keeper_identity.is_keeper_principal_agent_name agent_name
-                         || Option.is_some
-                              (Keeper_registry_lookup.find_by_name agent_name)
-                         || Option.is_some
-                              (Keeper_registry_lookup.find_by_agent_name
-                                 agent_name)
+                         || caller_is_registered_keeper
                        then
                          Keeper_chat_timeline_source.lines_for_self
                            ~base_dir:config.base_path
@@ -430,148 +408,10 @@ let execute_tool_eio
                   (String.concat ", " xs)
                   reason
             in
-            let internal_keeper_meta_of_agent () =
-              match Keeper_registry_lookup.find_by_agent_name agent_name with
-              | Some (entry : Keeper_registry.registry_entry)
-                when String.equal entry.base_path config.base_path -> Ok entry.meta
-              | Some _ | None ->
-                let candidates =
-                  [ Keeper_identity.canonical_keeper_name_from_agent_name agent_name
-                  ; Keeper_identity.canonical_keeper_name agent_name
-                  ]
-                  |> List.filter_map (function
-                    | Some value when String.trim value <> "" -> Some (String.trim value)
-                    | _ -> None)
-                  |> List.sort_uniq String.compare
-                in
-                let rec loop = function
-                  | [] ->
-                    Error
-                      (Printf.sprintf
-                         "Internal keeper runtime request is not bound to a known keeper \
-                          agent: %s"
-                         agent_name)
-                  | candidate :: rest ->
-                    (match Keeper_meta_store.read_meta_resolved config candidate with
-                     | Ok (Some (_resolved_name, meta)) -> Ok meta
-                     | Ok None -> loop rest
-                     | Error msg -> Error msg)
-                in
-                loop candidates
-            in
-            let dispatch_internal_keeper_runtime_tool () =
-              let start_time = Time_compat.now () in
-              match Tool_dispatch.run_pre_hooks ~name ~args:arguments with
-              | Some blocked, _ -> Some blocked
-              | None, coerced_args ->
-                (match internal_keeper_meta_of_agent () with
-                 | Error msg ->
-                   (* RFC-0189: agent_name has no matching registered
-                      keeper (or base_path mismatch).  Caller can
-                      address by registering the keeper / fixing the
-                      agent invocation context.  Same semantic family
-                      as tool_task_handlers' "Agent '%s' is not a
-                      member of this workspace" — [Workflow_rejection]. *)
-                   Some
-                     (Tool_result.error
-                        ~failure_class:(Some Tool_result.Workflow_rejection)
-                        ~tool_name:name ~start_time msg)
-                 | Ok meta ->
-                   let ctx_work =
-                     Keeper_context_runtime.create
-                       ~eio:true
-                       ~system_prompt:""
-                       ~max_tokens:(Keeper_config.keeper_unified_max_tokens ())
-                   in
-                               let turn_sandbox_factory =
-                                 Some (Keeper_sandbox_factory.create ~config ~meta ())
-                               in
-                               let cleanup_one ~during_exception label = function
-                                 | None -> ()
-                     | Some factory ->
-                       cleanup_internal_keeper_runtime_resource
-                         ~during_exception
-                         ~label
-                         (fun () -> Keeper_sandbox_factory.cleanup factory)
-                               in
-                               let cleanup ~during_exception () =
-                                 cleanup_one ~during_exception "sandbox" turn_sandbox_factory
-                               in
-                   let exec_cache = Some (Masc_exec.Exec_cache.create ()) in
-                   let result =
-                     run_with_cleanup_preserving_primary ~cleanup (fun () ->
-                       Keeper_tool_dispatch_runtime.execute_keeper_tool_call_with_outcome
-                         ~config
-                         ~meta
-                                     ~ctx_work
-                                     ?turn_sandbox_factory
-                                     ~exec_cache
-                         (* RFC-0182 Phase 5 PR-A.2: thread Eio
-                            resources from execute_tool_eio scope. *)
-                         ~sw
-                         ~clock
-                         ?mcp_session_id
-                         ~name
-                         ~input:coerced_args
-                         ())
-                   in
-                   Some
-                     (match result.Keeper_tool_dispatch_runtime.outcome with
-                      | `Success ->
-                        Tool_result.make_ok
-                          ~tool_name:name
-                          ~start_time
-                          ~data:
-                            (Option.value
-                               ~default:(`String result.raw_output)
-                               result.data)
-                          ()
-                      | `Failure failure_class ->
-                        Tool_result.make_err
-                          ~tool_name:name
-                          ~class_:failure_class
-                          ~start_time
-                          ~data:
-                            (Option.value
-                               ~default:(`String result.raw_output)
-                               result.data)
-                          result.raw_output))
-            in
             (* Primary dispatch: mint token at I/O boundary, then O(1) tag lookup.
      Tool_token validates the name exists in the tag registry (Parse, Don't
      Validate). If mint fails, the tool is truly unknown. *)
-            (* RFC-0084 §1.1 + §2.2 (PR-8) — MCP server tag/internal-keeper
-               dispatch paths wrap their existing run_pre_hooks + handler
-               chains with Tool_telemetry.with_span so every MCP-originated
-               tool call emits the telemetry 4-tuple (Span / Metric /
-               trace_id; audit slot via [with_non_public_tool_audit] below).
-               This brings MCP-originated calls to behavioural parity with
-               the keeper turn migration in PR-7. *)
-            let dispatch_internal_with_telemetry () =
-              let result, _outcome =
-                Tool_telemetry.with_span ~force_new_trace_id:true ~surface:"mcp" ~tool_name:name (fun _trace_id_thunk ->
-                  let r = dispatch_internal_keeper_runtime_tool () in
-                  (* Route through the shared dispatch finalizer so MCP
-                     internal-keeper-runtime calls run the same result
-                     transformer and dispatch observers as keeper turn calls. *)
-                  let r = Tool_dispatch_emit.finalize_from_handler r in
-                  let outcome =
-                    match r with
-                    | Some _ -> "handled"
-                    | None -> "no_handler"
-                  in
-                  r, outcome)
-              in
-              result
-            in
-            match
-              if internal_keeper_runtime_tool
-              then dispatch_internal_with_telemetry ()
-              else None
-            with
-            | Some result -> with_non_public_tool_audit ~agent_name result
-            | None ->
-              (match Tool_dispatch.mint_token ~name with
+            match Tool_dispatch.mint_token ~name with
                | Error reason ->
                  with_non_public_tool_audit
                    ~agent_name
@@ -588,8 +428,8 @@ let execute_tool_eio
                    let result, _outcome =
                      Tool_telemetry.with_span ~force_new_trace_id:true ~surface:"mcp" ~tool_name:name (fun _trace_id_thunk ->
                        let r = dispatch_by_tag tag in
-                       (* Keep external MCP tools/call on the same
-                          post-dispatch contract as internal keeper calls. *)
+                       (* Keep MCP tools/call on the shared post-dispatch
+                          transformer and observer contract. *)
                        let r = Tool_dispatch_emit.finalize_from_handler r in
                        let outcome =
                          match r with
@@ -613,7 +453,7 @@ let execute_tool_eio
                       ~agent_name
                       (runtime_error_result
                          ~tool_name:name
-                         (Printf.sprintf "Unknown tool: %s (registry inconsistency)" name)))))
+                         (Printf.sprintf "Unknown tool: %s (registry inconsistency)" name))))
 ;;
 
 (* RFC-0182 §3.1 — register Tool_workspace.dispatch with the dependency

--- a/lib/mcp_server_eio_execute.mli
+++ b/lib/mcp_server_eio_execute.mli
@@ -38,26 +38,12 @@ val resolve_bind_state :
   bool
 (** Test hook for the bind-required guard's read decision. *)
 
-(** {1 Test hooks} *)
-
-module For_testing : sig
-  val cleanup_internal_keeper_runtime_resource :
-    during_exception:bool -> label:string -> (unit -> unit) -> unit
-  (** Runs one internal keeper runtime cleanup action.  Non-cancellation
-      cleanup failures are logged and suppressed; cancellation is propagated
-      only when cleanup is not running behind a primary exception. *)
-
-  val run_with_cleanup_preserving_primary :
-    cleanup:(during_exception:bool -> unit -> unit) -> (unit -> 'a) -> 'a
-  (** Runs [f] and then [cleanup].  If [f] raises, cleanup runs on the
-      exception path and the original exception/backtrace is re-raised. *)
-end
-
 (** {1 [tools/call] inner dispatcher} *)
 
 val execute_tool_eio :
   sw:Eio.Switch.t ->
   clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  workspace_scope:Mcp_server.workspace_scope ->
   ?profile:Mcp_server_eio_types.tool_profile ->
   ?mcp_session_id:string ->
   ?auth_token:string ->
@@ -73,6 +59,10 @@ val execute_tool_eio :
     failure classification.  The wrapper layer
     {!Mcp_server_eio_call_tool.handle_call_tool_eio}
     composes the final JSON-RPC envelope around it.
+
+    [workspace_scope] is the immutable workspace generation captured by the
+    caller at admission.  The dispatcher never re-reads the mutable server
+    state's current workspace while executing the call.
 
     Side effects on the request scope:
     - Refreshes [Eio_context.set_switch] / [set_clock] so

--- a/lib/mcp_tool_runtime_workspace.ml
+++ b/lib/mcp_tool_runtime_workspace.ml
@@ -88,6 +88,16 @@ let expand_start_path ~config path =
   else Ok path
 ;;
 
+type workspace_setup_error =
+  | Workspace_request_rejected of string
+  | Workspace_runtime_failed of Mcp_server.workspace_switch_error
+
+let activate_workspace state config =
+  match Mcp_server.set_workspace_config state config with
+  | Ok () -> Ok config
+  | Error error -> Error (Workspace_runtime_failed error)
+;;
+
 (** masc_start — compound onboarding (set project root + bind session + optional task) *)
 let handle_start ~tool_name ~start_time (ctx : context) : Tool_result.result option =
   let config = ctx.config in
@@ -104,33 +114,48 @@ let handle_start ~tool_name ~start_time (ctx : context) : Tool_result.result opt
       if Workspace.is_initialized (Mcp_server.workspace_config state) then
         Ok config
       else
-        Error "path is required when no project scope is set. Provide the project directory path."
+        Error
+          (Workspace_request_rejected
+             "path is required when no project scope is set. Provide the project directory path.")
     end else begin
       match expand_start_path ~config path with
-      | Error _ as err -> err
+      | Error error -> Error (Workspace_request_rejected error)
       | Ok expanded ->
         if not (Sys.file_exists expanded && Sys.is_directory expanded) then
-          Error (Printf.sprintf "Directory not found: %s" expanded)
+          Error
+            (Workspace_request_rejected
+               (Printf.sprintf "Directory not found: %s" expanded))
         else begin
           let cfg = Workspace.default_config expanded in
-          if Workspace.is_initialized cfg then begin
-            Mcp_server.set_workspace_config state cfg;
-            Ok cfg
-          end else begin
-            let _msg = Workspace.init cfg ~agent_name:None in
-            Mcp_server.set_workspace_config state cfg;
-            Ok cfg
-          end
+          match Mcp_server.validate_workspace_config state cfg with
+          | Error error -> Error (Workspace_runtime_failed error)
+          | Ok () ->
+            if Workspace.is_initialized cfg then
+              activate_workspace state cfg
+            else begin
+              let _msg = Workspace.init cfg ~agent_name:None in
+              activate_workspace state cfg
+            end
         end
     end
   in
   match workspace_result with
-  | Error e ->
+  | Error (Workspace_request_rejected error) ->
       (* workspace_result Error sources are all caller-input rejections:
          missing [path] argument or non-existent directory. *)
       Some
         (runtime_err_workflow ~tool_name ~start_time
-           (Printf.sprintf "masc_start failed while setting project scope: %s" e))
+           (Printf.sprintf
+              "masc_start failed while setting project scope: %s"
+              error))
+  | Error (Workspace_runtime_failed error) ->
+    Some
+      (runtime_err_runtime
+         ~tool_name
+         ~start_time
+         (Printf.sprintf
+            "masc_start failed while setting project scope: %s"
+            (Mcp_server.workspace_switch_error_to_string error)))
   | Ok active_config ->
     (* Step 2: bind session (idempotent) *)
     let session_binding_result =

--- a/lib/mcp_tool_runtime_workspace.mli
+++ b/lib/mcp_tool_runtime_workspace.mli
@@ -35,10 +35,11 @@ val handle_start :
 
     {2 Three-step pipeline}
 
-    1. **Set project root**: validates the directory exists,
-       initialises {!Workspace} when not already initialised, and
-       atomically swaps the active workspace config via
-       {!Mcp_server.set_workspace_config}.
+    1. **Set workspace projection**: validates the directory exists and that
+       its exact MASC root equals the process-fixed runtime root, initialises
+       {!Workspace} when not already initialised, then atomically swaps the
+       workspace projection while reusing the one publication-recovery runtime
+       via {!Mcp_server.set_workspace_config}.
     2. **Bind agent session**: idempotent when already bound.
        Failure surfaces as a startup error.
     3. **Optional task creation**: when [task_title] non-empty,

--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -14,6 +14,7 @@ let tool_keeper_ctx (ctx : 'a context) : _ Keeper_tool_surface.context =
     clock = ctx.clock;
     proc_mgr = ctx.proc_mgr;
     net = ctx.net;
+    publication_recovery_registry = ctx.publication_recovery_registry;
   }
 
 let dispatch_keeper_json (ctx : 'a context) ~tool_name ~args =
@@ -258,6 +259,7 @@ let execute_keeper_action (ctx : 'a context) (request : action_request) =
           clock = ctx.clock;
           proc_mgr = ctx.proc_mgr;
           net = ctx.net;
+          publication_recovery_registry = ctx.publication_recovery_registry;
         }
       in
       let* body =

--- a/lib/operator/operator_tool.ml
+++ b/lib/operator/operator_tool.ml
@@ -418,6 +418,7 @@ let dispatch (ctx : 'a context) ~name ~args : Tool_result.result option =
       clock = ctx.clock;
       proc_mgr = ctx.proc_mgr;
       net = ctx.net;
+      publication_recovery_registry = ctx.publication_recovery_registry;
       mcp_session_id = ctx.mcp_session_id;
     }
   in

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -926,6 +926,7 @@ let () =
 
 let start_keeper_loops_owned
       ~claimed_persistence
+      ~workspace_scope
       ~sw
       ~clock
       ~net
@@ -952,7 +953,7 @@ let start_keeper_loops_owned
         Log.Server.error "subsystem %s crashed: %s" name (Printexc.to_string exn))
       f
   in
-  let config = claimed_persistence.claimed_config in
+  let config = workspace_scope.Mcp_server.config in
   (* [claimed_persistence] can only be constructed by the typed one-shot claim
      boundary before readiness publication. No late exception can turn an
      already-visible HTTP state into a degraded bootstrap. *)
@@ -1382,19 +1383,21 @@ let start_keeper_loops_owned
   let operator_judge_dispatch = make_judge_dispatch ~actor:"operator-judge" in
   fork_subsystem "operator_judge" (fun () ->
     let operator_judge_ctx : _ Operator_control.context =
-      { config = (Mcp_server.workspace_config state)
+      { config = workspace_scope.config
       ; agent_name = "operator-judge"
       ; sw
       ; clock
       ; proc_mgr = Some proc_mgr
       ; net = state.net
+      ; publication_recovery_registry =
+          (Mcp_server.workspace_scope_publication_recovery_registry workspace_scope)
       ; mcp_session_id = None
       }
     in
     Dashboard_operator_judge.start
       ~sw
       ~clock
-      ~config:(Mcp_server.workspace_config state)
+      ~config:workspace_scope.config
       ~masc_tools:judge_masc_tools
       ~dispatch:operator_judge_dispatch
       ~build_facts:(fun () ->
@@ -1422,7 +1425,6 @@ let start_keeper_loops_owned
       Log.Keeper.info "autoboot: lazy startup complete; keeper bootstrap will start last";
       (* Brief delay so other subsystems (SSE, board, orchestrator) settle first. *)
       Eio.Time.sleep clock Env_config_keeper.KeeperBootstrap.post_startup_settle_sec;
-      let config = claimed_persistence.claimed_config in
       let masc_root = Workspace.masc_root_dir config in
       let keeper_dir = Keeper_fs.keeper_dir config in
       let shutdown_blocked_names =
@@ -1450,6 +1452,8 @@ let start_keeper_loops_owned
         ; clock
         ; proc_mgr = Some proc_mgr
         ; net = state.net
+        ; publication_recovery_registry =
+            (Mcp_server.workspace_scope_publication_recovery_registry workspace_scope)
         }
       in
       Log.Keeper.info "autoboot: %d keeper(s) to boot" (List.length names);
@@ -1507,6 +1511,8 @@ let start_keeper_loops_owned
                 ; clock
                 ; proc_mgr = Some proc_mgr
                 ; net = state.net
+                ; publication_recovery_registry =
+                    (Mcp_server.workspace_scope_publication_recovery_registry workspace_scope)
                 }
               in
               let launch_outcome =
@@ -1892,7 +1898,8 @@ let start_keeper_loops
       ~proc_mgr
       (state : Mcp_server.server_state)
   =
-  let state_config = Mcp_server.workspace_config state in
+  let workspace_scope = Mcp_server.workspace_scope state in
+  let state_config = workspace_scope.config in
   (* Claim has already committed admission. Mask cancellation only across the
      second BasePath validation and [Claimed -> Starting] CAS so a cancelled
      startup cannot strand a claimed token. The long-running startup body is
@@ -1907,6 +1914,7 @@ let start_keeper_loops
       match
         start_keeper_loops_owned
           ~claimed_persistence
+          ~workspace_scope
           ~sw
           ~clock
           ~net

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -698,18 +698,21 @@ let dashboard_goal_detail_http_json ~(config : Workspace.config) ~goal_id : Yojs
 ;;
 
 let operator_action_http_json ~state ~sw ~clock request ~args =
+  let workspace_scope = Mcp_server.workspace_scope state in
   let actor =
     Server_auth.dashboard_actor_for_request
-      ~base_path:(Mcp_server.workspace_config state).base_path
+      ~base_path:workspace_scope.config.base_path
       request
   in
   let ctx : _ Operator_control.context =
-    { config = (Mcp_server.workspace_config state)
+    { config = workspace_scope.config
     ; agent_name = Option.value ~default:"dashboard" actor
     ; sw
     ; clock
     ; proc_mgr = state.Mcp_server.proc_mgr
     ; net = state.Mcp_server.net
+    ; publication_recovery_registry =
+        (Mcp_server.workspace_scope_publication_recovery_registry workspace_scope)
     ; mcp_session_id = None
     }
   in
@@ -717,18 +720,21 @@ let operator_action_http_json ~state ~sw ~clock request ~args =
 ;;
 
 let operator_confirm_http_json ~state ~sw ~clock request ~args =
+  let workspace_scope = Mcp_server.workspace_scope state in
   let actor =
     Server_auth.dashboard_actor_for_request
-      ~base_path:(Mcp_server.workspace_config state).base_path
+      ~base_path:workspace_scope.config.base_path
       request
   in
   let ctx : _ Operator_control.context =
-    { config = (Mcp_server.workspace_config state)
+    { config = workspace_scope.config
     ; agent_name = Option.value ~default:"dashboard" actor
     ; sw
     ; clock
     ; proc_mgr = state.Mcp_server.proc_mgr
     ; net = state.Mcp_server.net
+    ; publication_recovery_registry =
+        (Mcp_server.workspace_scope_publication_recovery_registry workspace_scope)
     ; mcp_session_id = None
     }
   in

--- a/lib/server/server_dashboard_http_core_digest_refresh.ml
+++ b/lib/server/server_dashboard_http_core_digest_refresh.ml
@@ -38,7 +38,8 @@ module Core_operator = Server_dashboard_http_core_operator
 module Core_operator_query = Server_dashboard_http_core_operator_query
 
 let start_operator_digest_refresh_loop ~state ~sw ~clock =
-  let config = (Mcp_server.workspace_config state) in
+  let workspace_scope = Mcp_server.workspace_scope state in
+  let config = workspace_scope.config in
   let proc_mgr = state.Mcp_server.proc_mgr in
   let net, mono_clock = Core_runtime.state_dashboard_runtime_caps state in
   let compute () =
@@ -60,6 +61,8 @@ let start_operator_digest_refresh_loop ~state ~sw ~clock =
              ; clock
              ; proc_mgr
              ; net = None
+             ; publication_recovery_registry =
+                 (Mcp_server.workspace_scope_publication_recovery_registry workspace_scope)
              ; mcp_session_id = None
              }
            in

--- a/lib/server/server_dashboard_http_core_operator_digest_http.ml
+++ b/lib/server/server_dashboard_http_core_operator_digest_http.ml
@@ -42,7 +42,8 @@ module Core_operator_query = Server_dashboard_http_core_operator_query
 open Server_dashboard_http_runtime_support
 
 let operator_digest_http_json ~state ~sw ~clock request =
-  let config = (Mcp_server.workspace_config state) in
+  let workspace_scope = Mcp_server.workspace_scope state in
+  let config = workspace_scope.config in
   let net, mono_clock = Core_runtime.state_dashboard_runtime_caps state in
   let actor =
     dashboard_actor_for_request ~base_path:config.base_path request
@@ -123,6 +124,8 @@ let operator_digest_http_json ~state ~sw ~clock request =
                     ; clock
                     ; proc_mgr = state.Mcp_server.proc_mgr
                     ; net = state.Mcp_server.net
+                    ; publication_recovery_registry =
+                        (Mcp_server.workspace_scope_publication_recovery_registry workspace_scope)
                     ; mcp_session_id = None
                     }
                   in

--- a/lib/server/server_dashboard_http_core_operator_snapshot_http.ml
+++ b/lib/server/server_dashboard_http_core_operator_snapshot_http.ml
@@ -44,7 +44,8 @@ module Core_operator_query = Server_dashboard_http_core_operator_query
 open Server_dashboard_http_runtime_support
 
 let operator_snapshot_http_json ~state ~sw ~clock request =
-  let config = (Mcp_server.workspace_config state) in
+  let workspace_scope = Mcp_server.workspace_scope state in
+  let config = workspace_scope.config in
   let proc_mgr = state.Mcp_server.proc_mgr in
   let net, mono_clock = Core_runtime.state_dashboard_runtime_caps state in
   let actor =
@@ -77,6 +78,8 @@ let operator_snapshot_http_json ~state ~sw ~clock request =
            ; clock
            ; proc_mgr
            ; net = None
+           ; publication_recovery_registry =
+               (Mcp_server.workspace_scope_publication_recovery_registry workspace_scope)
            ; mcp_session_id = None
            }
          in
@@ -164,6 +167,8 @@ let operator_snapshot_http_json ~state ~sw ~clock request =
                     ; clock
                     ; proc_mgr
                     ; net = state.Mcp_server.net
+                    ; publication_recovery_registry =
+                        (Mcp_server.workspace_scope_publication_recovery_registry workspace_scope)
                     ; mcp_session_id = None
                     }
                   in

--- a/lib/server/server_dashboard_http_core_snapshot_refresh.ml
+++ b/lib/server/server_dashboard_http_core_snapshot_refresh.ml
@@ -28,7 +28,8 @@ module Core_operator = Server_dashboard_http_core_operator
 module Core_operator_query = Server_dashboard_http_core_operator_query
 
 let start_operator_snapshot_refresh_loop ~state ~sw ~clock =
-  let config = (Mcp_server.workspace_config state) in
+  let workspace_scope = Mcp_server.workspace_scope state in
+  let config = workspace_scope.config in
   let proc_mgr = state.Mcp_server.proc_mgr in
   let net, mono_clock = Core_runtime.state_dashboard_runtime_caps state in
   let compute () =
@@ -50,6 +51,8 @@ let start_operator_snapshot_refresh_loop ~state ~sw ~clock =
              ; clock
              ; proc_mgr
              ; net = None
+             ; publication_recovery_registry =
+                 (Mcp_server.workspace_scope_publication_recovery_registry workspace_scope)
              ; mcp_session_id = None
              }
            in

--- a/lib/server/server_dashboard_http_keeper_api_lifecycle_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_lifecycle_post.ml
@@ -117,7 +117,8 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
   if String.length name = 0 then
     respond_error reqd "keeper name is required"
   else
-    let config = (Mcp_server.workspace_config state) in
+    let workspace_scope = Mcp_server.workspace_scope state in
+    let config = workspace_scope.config in
     let resolve_keeper_agent_name () =
       match Keeper_registry_lookup.find_by_name name with
       | Some entry -> Some entry.meta.agent_name
@@ -232,6 +233,7 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
         clock;
         proc_mgr = state.Mcp_server.proc_mgr;
         net = state.Mcp_server.net;
+        publication_recovery_registry = (Mcp_server.workspace_scope_publication_recovery_registry workspace_scope);
       }
     in
     let args_result =

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -666,7 +666,8 @@ let handle_keeper_config_post ~sw ~clock state agent_name req reqd body_str =
   if String.length name = 0 then
     respond_error reqd "keeper name is required"
   else
-    let config = (Mcp_server.workspace_config state) in
+    let workspace_scope = Mcp_server.workspace_scope state in
+    let config = workspace_scope.config in
     match Keeper_meta_store.read_meta config name with
     | Error msg -> respond_error ~status:`Not_found reqd msg
     | Ok None ->
@@ -711,6 +712,8 @@ let handle_keeper_config_post ~sw ~clock state agent_name req reqd body_str =
                           clock;
                           proc_mgr = state.Mcp_server.proc_mgr;
                           net = state.Mcp_server.net;
+                          publication_recovery_registry =
+                            (Mcp_server.workspace_scope_publication_recovery_registry workspace_scope);
                         }
                       in
                       (match
@@ -893,13 +896,15 @@ let directive_action_to_string = function
 
 let keeper_ctx_of_dashboard_state ~sw ~clock state agent_name :
     _ Keeper_tool_surface.context =
+  let workspace_scope = Mcp_server.workspace_scope state in
   {
-    config = Mcp_server.workspace_config state;
+    config = workspace_scope.config;
     agent_name;
     sw;
     clock;
     proc_mgr = state.Mcp_server.proc_mgr;
     net = state.Mcp_server.net;
+    publication_recovery_registry = (Mcp_server.workspace_scope_publication_recovery_registry workspace_scope);
   }
 
 let meta_with_directive_paused_state

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -716,7 +716,7 @@ let start ~sw ~env ~clock ~state =
   | Some token ->
     let policy = resolved_trigger_policy () in
     State.set_trigger_policy policy;
-    let dispatch =
+    let dispatch_for_scope workspace_scope =
       (* RFC-connector-deferred-reply-via-chat-queue: tag this dispatch as the Discord connector so a message that
          arrives while the keeper is in flight is enqueued onto
          [Keeper_chat_queue] (drained by the serial consumer, delivered back to
@@ -728,7 +728,9 @@ let start ~sw ~env ~clock ~state =
         ~sw ~clock
         ~proc_mgr:state.Mcp_server.proc_mgr
         ~net:state.Mcp_server.net
-        ~config:(Mcp_server.workspace_config state)
+        ~publication_recovery_registry:
+          (Mcp_server.workspace_scope_publication_recovery_registry workspace_scope)
+        ~config:workspace_scope.config
     in
     let policy_label = Discord_gateway_state.trigger_policy_to_string policy in
     Log.Server.info
@@ -742,18 +744,15 @@ let start ~sw ~env ~clock ~state =
           ~intents:default_intents
           ~trigger_policy:policy
           ~on_event:(fun ev ->
-            (* Read base_path per event: [workspace_config] is mutable
-               (workspace-switch tools swap it). *)
+            let workspace_scope = Mcp_server.workspace_scope state in
             on_event
-              ~dispatch
+              ~dispatch:(dispatch_for_scope workspace_scope)
               ~clock
-              ~base_dir:(Mcp_server.workspace_config state).base_path
+              ~base_dir:workspace_scope.config.base_path
               ev)
           ~on_ambient:(fun ev ->
-            (* Read base_path per event: [workspace_config] is mutable
-               (workspace-switch tools swap it). *)
-            on_ambient
-              ~base_dir:(Mcp_server.workspace_config state).base_path ev)
+            let workspace_scope = Mcp_server.workspace_scope state in
+            on_ambient ~base_dir:workspace_scope.config.base_path ev)
           ()
       with
       | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/server/server_routes_http_common.mli
+++ b/lib/server/server_routes_http_common.mli
@@ -16,7 +16,7 @@
 
     The module aliases at the top of the .ml are reached
     unqualified by the indirect consumers
-    (e.g. [Mcp_eio.create_state] in
+    (e.g. [Mcp_eio.create_state_eio] in
     [server_runtime_bootstrap], [Sse.X] across many
     modules). *)
 

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -545,17 +545,21 @@ let execute_keeper_stream_tool
       ~arguments
       ~continuation_channel
   =
+  let workspace_scope = Mcp_server.workspace_scope state in
+  let config = workspace_scope.config in
   let start_time = Eio.Time.now clock in
   let success, body, failure_class =
     try
       let keeper_ctx : _ Keeper_tool_surface.context =
         {
-          config = (Mcp_server.workspace_config state);
+          config;
           agent_name;
           sw;
           clock;
           proc_mgr = state.Mcp_server.proc_mgr;
           net = state.Mcp_server.net;
+          publication_recovery_registry =
+            (Mcp_server.workspace_scope_publication_recovery_registry workspace_scope);
         }
       in
       match
@@ -592,7 +596,7 @@ let execute_keeper_stream_tool
     if success then None
     else Some (keeper_tool_failure_error_detail ~duration_ms ~error_body:body)
   in
-  Audit_log.log_tool_call (Mcp_server.workspace_config state)
+  Audit_log.log_tool_call config
     ~agent_id:agent_name ~tool_name:"masc_keeper_msg" ~success ~error_msg:error_detail ();
   if not success then
     Log.Keeper.emit Log.Error
@@ -613,7 +617,7 @@ let execute_keeper_stream_tool
            let telemetry_failure_class =
              if success then None else Some failure_class
            in
-           Telemetry_eio.track_tool_called ~fs (Mcp_server.workspace_config state)
+           Telemetry_eio.track_tool_called ~fs config
              ~tool_name:"masc_keeper_msg" ~agent_id:agent_name ~success ~duration_ms
              ~source:(Tool_registry.string_of_source Agent_internal)
              ?failure_class:telemetry_failure_class
@@ -825,18 +829,22 @@ let execute_keeper_stream_tool_streaming
       ~continuation_channel
       ~on_text_delta
   =
+  let workspace_scope = Mcp_server.workspace_scope state in
+  let config = workspace_scope.config in
   let start_time = Eio.Time.now clock in
   let admission_rejection = ref None in
   let success, body, failure_class =
     try
       let keeper_ctx : _ Keeper_tool_surface.context =
         {
-          config = (Mcp_server.workspace_config state);
+          config;
           agent_name;
           sw;
           clock;
           proc_mgr = state.Mcp_server.proc_mgr;
           net = state.Mcp_server.net;
+          publication_recovery_registry =
+            (Mcp_server.workspace_scope_publication_recovery_registry workspace_scope);
         }
       in
       match
@@ -879,7 +887,7 @@ let execute_keeper_stream_tool_streaming
         if success then None
         else Some (keeper_tool_failure_error_detail ~duration_ms ~error_body:body)
       in
-      Audit_log.log_tool_call (Mcp_server.workspace_config state)
+      Audit_log.log_tool_call config
         ~agent_id:agent_name ~tool_name:"masc_keeper_msg" ~success
         ~error_msg:error_detail ();
       if not success then
@@ -901,8 +909,7 @@ let execute_keeper_stream_tool_streaming
                let telemetry_failure_class =
                  if success then None else Some failure_class
                in
-               Telemetry_eio.track_tool_called ~fs
-                 (Mcp_server.workspace_config state)
+               Telemetry_eio.track_tool_called ~fs config
                  ~tool_name:"masc_keeper_msg" ~agent_id:agent_name ~success
                  ~duration_ms
                  ~source:(Tool_registry.string_of_source Agent_internal)
@@ -929,17 +936,21 @@ let execute_keeper_stream_tool_streaming_if_free
       ~continuation_channel
       ~on_text_delta
   =
+  let workspace_scope = Mcp_server.workspace_scope state in
+  let config = workspace_scope.config in
   let start_time = Eio.Time.now clock in
   let outcome =
     try
       let keeper_ctx : _ Keeper_tool_surface.context =
         {
-          config = (Mcp_server.workspace_config state);
+          config;
           agent_name;
           sw;
           clock;
           proc_mgr = state.Mcp_server.proc_mgr;
           net = state.Mcp_server.net;
+          publication_recovery_registry =
+            (Mcp_server.workspace_scope_publication_recovery_registry workspace_scope);
         }
       in
       match
@@ -982,7 +993,7 @@ let execute_keeper_stream_tool_streaming_if_free
         if success then None
         else Some (keeper_tool_failure_error_detail ~duration_ms ~error_body:body)
       in
-      Audit_log.log_tool_call (Mcp_server.workspace_config state)
+      Audit_log.log_tool_call config
         ~agent_id:agent_name ~tool_name:"masc_keeper_msg" ~success
         ~error_msg:error_detail ();
       if not success then
@@ -1004,8 +1015,7 @@ let execute_keeper_stream_tool_streaming_if_free
                let telemetry_failure_class =
                  if success then None else Some failure_class
                in
-               Telemetry_eio.track_tool_called ~fs
-                 (Mcp_server.workspace_config state)
+               Telemetry_eio.track_tool_called ~fs config
                  ~tool_name:"masc_keeper_msg" ~agent_id:agent_name ~success
                  ~duration_ms ~source:(Tool_registry.string_of_source Agent_internal)
                  ?failure_class:telemetry_failure_class

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -351,7 +351,8 @@ let board_context_inference_submission_json ~post_id ~target_source tool_data =
 
 let dispatch_board_context_inference ~state ~sw ~clock ~request ~target_keeper
     ~target_source ~(post : Board.post) ~comments =
-  let config = Mcp_server.workspace_config state in
+  let workspace_scope = Mcp_server.workspace_scope state in
+  let config = workspace_scope.config in
   let agent_name = board_tool_agent_name_from_request request in
   let keeper_ctx : _ Keeper_tool_surface.context =
     {
@@ -361,6 +362,7 @@ let dispatch_board_context_inference ~state ~sw ~clock ~request ~target_keeper
       clock;
       proc_mgr = state.Mcp_server.proc_mgr;
       net = state.Mcp_server.net;
+      publication_recovery_registry = (Mcp_server.workspace_scope_publication_recovery_registry workspace_scope);
     }
   in
   let post_id = Board.Post_id.to_string post.id in

--- a/lib/server/server_routes_http_routes_channel_gate.ml
+++ b/lib/server/server_routes_http_routes_channel_gate.ml
@@ -138,6 +138,7 @@ let request_elapsed_ms request_started =
 let handle_gate_message ~sw ~clock ~submitted_by state request reqd =
   Http.Request.read_body_async reqd (fun body_str ->
     let request_started = Unix.gettimeofday () in
+    let workspace_scope = Mcp_server.workspace_scope state in
     let dispatch =
       (* RFC-connector-deferred-reply-via-chat-queue: the HTTP gate route is the convergence point for sidecar
          connectors (imessage-bot, cli-connector) that POST and await the reply
@@ -150,7 +151,9 @@ let handle_gate_message ~sw ~clock ~submitted_by state request reqd =
         ~sw ~clock
         ~proc_mgr:state.Mcp_server.proc_mgr
         ~net:state.Mcp_server.net
-        ~config:(Mcp_server.workspace_config state)
+        ~publication_recovery_registry:
+          (Mcp_server.workspace_scope_publication_recovery_registry workspace_scope)
+        ~config:workspace_scope.config
     in
     let result =
       try
@@ -283,13 +286,15 @@ let handle_gate_connector_status _state request reqd =
             (C.status_json ~audit_limit ()))
 
 let gate_keeper_ctx ~sw ~clock state =
+  let workspace_scope = Mcp_server.workspace_scope state in
   {
-    Keeper_tool_surface.config = (Mcp_server.workspace_config state);
+    Keeper_tool_surface.config = workspace_scope.config;
     agent_name = "gate:connector";
     sw;
     clock;
     proc_mgr = state.Mcp_server.proc_mgr;
     net = state.Mcp_server.net;
+    publication_recovery_registry = (Mcp_server.workspace_scope_publication_recovery_registry workspace_scope);
   }
 
 let keeper_exists ~sw ~clock state keeper_name =

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -380,11 +380,12 @@ let health_status_rank = Health_status.rank_string
 let max_health_status = Health_status.max_string
 
 let full_health_operator_summary ~keeper_fleet_safety
-    ~keeper_identity_drift_json ~reaction_ledger_json ~turn_admission_json
-    ~board_event_collection_json ~keeper_event_queue_json
-    ~runtime_startup_degradation_json ~keeper_config_schema_status
-    ~keeper_config_schema_blocking ~keeper_config_schema_terminal_reason
-    ~keeper_config_operator_action_required ~lazy_task_boot_guard_fires_total =
+    ~keeper_identity_drift_json ~publication_recovery_activation_json
+    ~reaction_ledger_json ~turn_admission_json ~board_event_collection_json
+    ~keeper_event_queue_json ~runtime_startup_degradation_json
+    ~keeper_config_schema_status ~keeper_config_schema_blocking
+    ~keeper_config_schema_terminal_reason ~keeper_config_operator_action_required
+    ~lazy_task_boot_guard_fires_total =
   let status = ref "ok" in
   let reasons = ref [] in
   let note_status component json fallback_reason =
@@ -426,6 +427,10 @@ let full_health_operator_summary ~keeper_fleet_safety
     (assoc_string_opt "blocker" keeper_fleet_safety);
   note_status "keeper_identity_drift" keeper_identity_drift_json
     (assoc_string_opt "terminal_reason" keeper_identity_drift_json);
+  note_status
+    "publication_recovery_activation"
+    publication_recovery_activation_json
+    (assoc_string_opt "reason" publication_recovery_activation_json);
   note_status "keeper_reaction_ledger" reaction_ledger_json None;
   note_status "keeper_turn_admission" turn_admission_json None;
   note_status "keeper_board_event_collection" board_event_collection_json None;
@@ -488,10 +493,11 @@ let make_health_json ?(listener = "http/1.1") ?section_timings_ref
   let phase_snapshot = keeper_phase_snapshot ?base_path () in
   let phase_counts = phase_snapshot.counts in
   let keeper_fibers = phase_counts.running in
+  let server_state = current_server_state_opt () in
   (* Single-pass fleet meta scan: reads each keeper meta file once,
      shared by paused-keepers and fleet-safety sections. *)
   let fleet_meta_scan =
-    match current_server_state_opt () with
+    match server_state with
     | Some state ->
       Some (keeper_fleet_meta_scan (Mcp_server.workspace_config state))
     | None -> None
@@ -499,7 +505,7 @@ let make_health_json ?(listener = "http/1.1") ?section_timings_ref
   let keeper_identity_drift_json =
     compute_section ~name:"keeper_identity_drift" ?section_timings_ref
       (fun () ->
-        match current_server_state_opt () with
+        match server_state with
         | Some state ->
           keeper_identity_drift_health_json (Mcp_server.workspace_config state)
         | None ->
@@ -522,6 +528,34 @@ let make_health_json ?(listener = "http/1.1") ?section_timings_ref
               ("meta_without_config_names", `List []);
               ("next_action", `String "none");
             ])
+  in
+  let publication_recovery_activation_json =
+    compute_section
+      ~name:"publication_recovery_activation"
+      ?section_timings_ref
+      (fun () ->
+        match server_state with
+        | None ->
+          `Assoc
+            [ "status", `String "unavailable"
+            ; "operator_action_required", `Bool false
+            ; "reason", `String "server_state_not_ready"
+            ]
+        | Some state ->
+          let workspace_scope = Mcp_server.workspace_scope state in
+          (match
+             Mcp_server.workspace_scope_publication_recovery_report
+               workspace_scope
+           with
+           | None ->
+             `Assoc
+               [ "status", `String "unavailable"
+               ; "operator_action_required", `Bool false
+               ; "reason", `String "non_runtime_state"
+               ]
+           | Some report ->
+             Mcp_server.publication_recovery_activation_report_to_health_yojson
+               report)
   in
   let paused_keepers_json =
     compute_section ~name:"paused_keepers" ?section_timings_ref
@@ -591,6 +625,7 @@ let make_health_json ?(listener = "http/1.1") ?section_timings_ref
     full_health_operator_summary
       ~keeper_fleet_safety
       ~keeper_identity_drift_json
+      ~publication_recovery_activation_json
       ~reaction_ledger_json
       ~turn_admission_json
       ~board_event_collection_json
@@ -645,6 +680,7 @@ let make_health_json ?(listener = "http/1.1") ?section_timings_ref
     ("server_hibernation", Server_hibernation.status_json ());
     ("keeper_fleet_safety", keeper_fleet_safety);
     ("keeper_identity_drift", keeper_identity_drift_json);
+    ("publication_recovery_activation", publication_recovery_activation_json);
     ("keeper_reaction_ledger", reaction_ledger_json);
     ("keeper_turn_admission", turn_admission_json);
     ("keeper_board_event_collection", board_event_collection_json);
@@ -750,6 +786,7 @@ let full_health_cached_field_names =
     "disk_observation";
     "keeper_fleet_safety";
     "keeper_identity_drift";
+    "publication_recovery_activation";
     "keeper_reaction_ledger";
     "keeper_turn_admission";
     "keeper_board_event_collection";
@@ -813,6 +850,12 @@ let full_health_placeholder_fields ?error ?(component_timed_out = false)
           ("next_action", `String "none");
           ("component_timed_out", `Bool component_timed_out);
         ] );
+    ( "publication_recovery_activation",
+      full_health_component_placeholder
+        ?error
+        ~component_timed_out
+        ~status
+        "publication_recovery_activation" );
     ( "keeper_reaction_ledger",
       full_health_component_placeholder ?error ~component_timed_out ~status
         "keeper_reaction_ledger" );

--- a/lib/server/server_routes_http_runtime.mli
+++ b/lib/server/server_routes_http_runtime.mli
@@ -118,8 +118,8 @@ val health_path_diagnostics :
   unit -> Server_base_path_diagnostics.t
 (** [health_path_diagnostics ()] resolves the base-path
     diagnostics for the [/health] response.  When the runtime
-    state is initialised, reads from
-    [state.workspace_config.base_path]; otherwise falls back to the
+    state is initialised, reads the immutable snapshot returned by
+    [Mcp_server.workspace_config]; otherwise falls back to the
     default base path computed from env. *)
 
 val make_health_json :
@@ -144,7 +144,8 @@ val make_health_json :
     [overall_status] / [operator_action_required] /
     [operator_action_reasons] /
     [keeper_fibers] / [fd_observation] / [fd_accountant] / [disk_observation] /
-    [keeper_fleet_safety] / [keeper_reaction_ledger] / [paused_keepers] /
+    [keeper_fleet_safety] / [publication_recovery_activation] /
+    [keeper_reaction_ledger] / [paused_keepers] /
     [keeper_config_error_count] / [keeper_config_errors] /
     [keeper_config_unknown_key_count] / [keeper_config_unknown_keys] /
     [keeper_config_schema_status] / [keeper_config_schema_blocking] /

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -1324,8 +1324,13 @@ let run ~sw ~env ~host ~port ~base_path ?input_base_path ~make_routes ~make_requ
           try Yojson.Safe.from_string args_json
           with Yojson.Json_error _ -> `Assoc []
         in
+        let workspace_scope = Mcp_server.workspace_scope state in
         let result =
-          Mcp_server_eio_execute.execute_tool_eio ~sw ~clock state
+          Mcp_server_eio_execute.execute_tool_eio
+            ~sw
+            ~clock
+            ~workspace_scope
+            state
             ~name:tool_name ~arguments
         in
         let success = Tool_result.is_success result

--- a/lib/server/server_slack_in_process_gateway.ml
+++ b/lib/server/server_slack_in_process_gateway.ml
@@ -468,7 +468,7 @@ let start ~sw ~env ~state =
              None)
        in
        State.set_trigger_policy policy;
-       let dispatch =
+       let dispatch_for_scope workspace_scope =
          (* Tag this dispatch as the Slack connector so a message arriving while
             the keeper is in flight enqueues onto [Keeper_chat_queue] (drained
             by the serial consumer, delivered via
@@ -479,7 +479,9 @@ let start ~sw ~env ~state =
            ~submission_owner:Gate_keeper_backend.Channel_actor
            ~sw ~clock
            ~proc_mgr:state.Mcp_server.proc_mgr ~net:state.Mcp_server.net
-           ~config:(Mcp_server.workspace_config state)
+           ~publication_recovery_registry:
+             (Mcp_server.workspace_scope_publication_recovery_registry workspace_scope)
+           ~config:workspace_scope.config
        in
        let policy_label = Gw.trigger_policy_to_string policy in
        Log.Server.info
@@ -489,7 +491,9 @@ let start ~sw ~env ~state =
          try
            Slack_socket_client.run ~sw ~env ~bot_user_id ~app_token
              ~trigger_policy:policy
-             ~on_event:(fun ev -> on_event ~dispatch ~clock ev)
+             ~on_event:(fun ev ->
+               let workspace_scope = Mcp_server.workspace_scope state in
+               on_event ~dispatch:(dispatch_for_scope workspace_scope) ~clock ev)
              ()
          with
          | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/tool_operator.ml
+++ b/lib/tool_operator.ml
@@ -5,6 +5,8 @@ type 'a context = {
   clock : 'a Eio.Time.clock;
   proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option;
   net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option;
+  publication_recovery_registry :
+    Fs_compat.publication_recovery_registry option;
   mcp_session_id : string option;
 }
 

--- a/lib/tool_operator.mli
+++ b/lib/tool_operator.mli
@@ -5,6 +5,8 @@ type 'a context = {
   clock : 'a Eio.Time.clock;
   proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option;
   net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option;
+  publication_recovery_registry :
+    Fs_compat.publication_recovery_registry option;
   mcp_session_id : string option;
 }
 

--- a/lib/tool_surface/tool_dispatch_emit.mli
+++ b/lib/tool_surface/tool_dispatch_emit.mli
@@ -1,7 +1,7 @@
 (** RFC-0085 PR-5 — Unified dispatch post-processing helper.
 
     Every dispatch path (keeper [guarded_dispatch], MCP [dispatch_by_tag],
-    MCP [dispatch_internal_keeper_runtime_tool], inline workspace) must call
+    inline workspace) must call
     one of these after the handler completes so the five typed observers
     fire uniformly regardless of which path produced the result. *)
 

--- a/test/deps/masc_test_deps.ml
+++ b/test/deps/masc_test_deps.ml
@@ -225,6 +225,57 @@ let cleanup_test_workspace dir =
   in
   try rm_rf dir with _ -> ()
 
+(** Run a test callback with a fresh publication-recovery registry and the same
+    capability lifetime shape as a live Keeper lane. Existing startup state is
+    rejected instead of duplicating the production reconciliation policy in a
+    test helper; startup reconciliation has its own integration tests.
+    [registry_root] is owned by the caller and must outlive [sw]. *)
+let with_publication_recovery_lane
+      ~sw
+      ~fs
+      ~registry_root
+      ~owner
+      f
+  =
+  let registry_root = Eio.Path.(fs / registry_root) in
+  match Fs_compat.open_publication_recovery_registry ~sw ~registry_root with
+  | Error error ->
+    failwith
+      ("test publication recovery registry open failed: "
+       ^ Fs_compat.publication_recovery_registry_error_to_string error)
+  | Ok publication_recovery_registry ->
+    (match
+       Fs_compat.inventory_publication_recovery_owners
+         publication_recovery_registry
+     with
+     | Error error ->
+       failwith
+         ("test publication recovery inventory failed: "
+          ^ Fs_compat.publication_recovery_owner_inventory_error_to_string
+              error)
+     | Ok [] ->
+       (match
+          Fs_compat.with_publication_recovery_lane
+            ~registry:publication_recovery_registry
+            ~owner
+            (fun publication_recovery_access ->
+               f ~publication_recovery_registry ~publication_recovery_access)
+        with
+        | Ok value -> value
+        | Error error ->
+          failwith
+            ("test publication recovery lane open failed: "
+             ^ Fs_compat.publication_recovery_lane_open_error_to_string
+                 error))
+     | Ok rows ->
+       failwith
+         ("fresh test publication recovery registry contains owners: "
+          ^ String.concat
+              "; "
+              (List.map
+                 Fs_compat.publication_recovery_owner_inventory_row_to_string
+                 rows)))
+
 let rng_initialized = Atomic.make false
 
 let ensure_rng_initialized () =

--- a/test/dune
+++ b/test/dune
@@ -2167,7 +2167,7 @@
 
 ; RFC-0084 PR-8 — MCP server telemetry wrap parity. Constants-only
 ; (no lib dependency): pins the outcome label vocabulary and wrap site
-; count for mcp_server_eio_execute.ml:1065 + :1083 wraps. Real wrap
+; count for the mcp_server_eio_execute.ml tag-dispatch wrap. Real wrap
 ; behaviour is unit-tested in test_guarded_dispatch_telemetry (PR-3).
 
 (test
@@ -2178,7 +2178,7 @@
 ; RFC-0084 PR-9 — Tag-dispatch fallback telemetry wrap. Final entry for
 ; 4-tuple propagation: brings keeper-turn + MCP + tag-dispatch to 3/3 =
 ; 100% per RFC-0084 §2.1 North Star. Constants-only: pins outcome vocab
-; parity with PR-7 + PR-8, cumulative wrap site count (5), and the
+; parity with PR-7 + PR-8, cumulative wrap site count (4), and the
 ; entries-covered = 3 invariant.
 
 (test
@@ -2564,3 +2564,5 @@
 (include stanzas/test_keeper_gate_effect_coverage.inc)
 (include stanzas/test_keeper_hitl_resolution_prompt.inc)
 (include stanzas/test_fs_compat_capability_write.inc)
+(include stanzas/test_fs_compat_publication_reconciliation.inc)
+(include stanzas/test_eio_resource_scope.inc)

--- a/test/stanzas/test_eio_resource_scope.inc
+++ b/test/stanzas/test_eio_resource_scope.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_eio_resource_scope)
+ (modules test_eio_resource_scope)
+ (libraries alcotest fs_compat eio eio_main))

--- a/test/stanzas/test_fs_compat_publication_reconciliation.inc
+++ b/test/stanzas/test_fs_compat_publication_reconciliation.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_fs_compat_publication_reconciliation)
+ (modules test_fs_compat_publication_reconciliation)
+ (libraries alcotest fs_compat eio eio_main eio.unix unix uuidm yojson digestif))

--- a/test/test_code_navigation_eio.ml
+++ b/test/test_code_navigation_eio.ml
@@ -117,7 +117,7 @@ let test_code_search_basic () =
   with_eio_context env sw @@ fun () ->
 
   with_code_fixture @@ fun base_path ->
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   prepare_code_surface ~clock ~sw state;
 
   (* Search for "ripgrep" in codebase *)
@@ -196,7 +196,7 @@ let test_code_symbols_basic () =
   with_eio_context env sw @@ fun () ->
 
   with_code_fixture @@ fun base_path ->
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   prepare_code_surface ~clock ~sw state;
 
   (* Extract symbols from a real file *)
@@ -249,7 +249,7 @@ let test_code_read_basic () =
   with_eio_context env sw @@ fun () ->
 
   with_code_fixture @@ fun base_path ->
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   prepare_code_surface ~clock ~sw state;
 
   (* Read first 10 lines of a file *)
@@ -315,7 +315,7 @@ let test_code_read_offset_limit () =
   with_eio_context env sw @@ fun () ->
 
   with_code_fixture @@ fun base_path ->
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   prepare_code_surface ~clock ~sw state;
 
   (* Read lines 10-20 *)

--- a/test/test_completion_trust_harness.ml
+++ b/test/test_completion_trust_harness.ml
@@ -82,13 +82,26 @@ let with_ws name fn =
     (fun () ->
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
+      Eio.Switch.run @@ fun sw ->
       let config = Masc.Workspace.default_config dir in
       let meta = make_meta () in
       ignore (Masc.Keeper_registry.register ~base_path:config.base_path meta.name meta);
       Fun.protect
         ~finally:(fun () ->
           Masc.Keeper_registry.unregister ~base_path:config.base_path meta.name)
-        (fun () -> fn ~config ~meta ~ctx_work:(make_ctx ())))
+        (fun () ->
+          Masc_test_deps.with_publication_recovery_lane
+            ~sw
+            ~fs:(Eio.Stdenv.fs env)
+            ~registry_root:dir
+            ~owner:meta.name
+            (fun ~publication_recovery_registry ~publication_recovery_access ->
+               fn
+                 ~config
+                 ~meta
+                 ~publication_recovery_registry
+                 ~publication_recovery_access
+                 ~ctx_work:(make_ctx ()))))
 
 let outcome_label = function
   | `Success -> "success"
@@ -127,6 +140,8 @@ let attempt_done
       ?(evidence_refs = [ "trace:completion-trust-harness" ])
       ~config
       ~meta
+      ~publication_recovery_registry
+      ~publication_recovery_access
       ~ctx_work
       ~task_id
       ~result
@@ -135,6 +150,8 @@ let attempt_done
   KET.execute_keeper_tool_call_with_outcome
     ~config
     ~meta
+    ~publication_recovery_registry
+    ~publication_recovery_access
     ~ctx_work
     ~exec_cache:None
     ~name:"keeper_task_done"
@@ -158,10 +175,19 @@ let seed_trace_evidence ~config trace_id =
   write_file path
     {|{"type":"completion_trust_evidence","turn":0,"trace_id":"test"}|}
 
-let claim_via_dispatch ~config ~meta ~ctx_work ~task_id =
+let claim_via_dispatch
+      ~config
+      ~meta
+      ~publication_recovery_registry
+      ~publication_recovery_access
+      ~ctx_work
+      ~task_id
+  =
   KET.execute_keeper_tool_call_with_outcome
     ~config
     ~meta
+    ~publication_recovery_registry
+    ~publication_recovery_access
     ~ctx_work
     ~exec_cache:None
     ~name:"keeper_task_claim"
@@ -170,7 +196,9 @@ let claim_via_dispatch ~config ~meta ~ctx_work ~task_id =
 
 (* Test A — non-owner completion is denied (RFC-0262 axis-2 ownership gate). *)
 let test_completion_denied_for_non_owner () =
-  with_ws "completion_trust_non_owner" (fun ~config ~meta ~ctx_work ->
+  with_ws "completion_trust_non_owner"
+    (fun ~config ~meta ~publication_recovery_registry
+         ~publication_recovery_access ~ctx_work ->
     ignore (Workspace.init config ~agent_name:(Some meta.agent_name));
     ignore
       (Workspace.add_task config ~title:"foreign-owned task" ~priority:1
@@ -191,7 +219,8 @@ let test_completion_denied_for_non_owner () =
     (* attack: caller (non-owner) tries to complete it, with substantive notes so
        the reject is unambiguously about ownership, not note length. *)
     let result =
-      attempt_done ~config ~meta ~ctx_work ~task_id:"task-001"
+      attempt_done ~config ~meta ~publication_recovery_registry
+        ~publication_recovery_access ~ctx_work ~task_id:"task-001"
         ~result:"I finished another agent's task on their behalf"
         ()
     in
@@ -211,14 +240,17 @@ let test_completion_denied_for_non_owner () =
 
 (* Test B — completion of an unclaimed (Todo) task is denied. *)
 let test_completion_denied_when_unclaimed () =
-  with_ws "completion_trust_unclaimed" (fun ~config ~meta ~ctx_work ->
+  with_ws "completion_trust_unclaimed"
+    (fun ~config ~meta ~publication_recovery_registry
+         ~publication_recovery_access ~ctx_work ->
     ignore (Workspace.init config ~agent_name:(Some meta.agent_name));
     ignore
       (Workspace.add_task config ~title:"never claimed" ~priority:1
          ~description:"still in the backlog");
     (* task-001 is Todo; nobody claimed it. *)
     let result =
-      attempt_done ~config ~meta ~ctx_work ~task_id:"task-001"
+      attempt_done ~config ~meta ~publication_recovery_registry
+        ~publication_recovery_access ~ctx_work ~task_id:"task-001"
         ~result:"pretending an unclaimed backlog item is finished"
         ()
     in
@@ -239,18 +271,25 @@ let test_completion_denied_when_unclaimed () =
 
 (* Local note length and evidence shape never decide completion. *)
 let test_short_notes_without_evidence_follow_llm_approval () =
-  with_ws "completion_llm_short_notes" (fun ~config ~meta ~ctx_work ->
+  with_ws "completion_llm_short_notes"
+    (fun ~config ~meta ~publication_recovery_registry
+         ~publication_recovery_access ~ctx_work ->
     reviewer_response := Reviewer_verdict AR.Approve;
     ignore (Workspace.init config ~agent_name:(Some meta.agent_name));
     ignore
       (Workspace.add_task config ~title:"caller's own task" ~priority:1
          ~description:"the LLM reviews even a short completion claim");
-    let claim = claim_via_dispatch ~config ~meta ~ctx_work ~task_id:"task-001" in
+    let claim =
+      claim_via_dispatch ~config ~meta ~publication_recovery_registry
+        ~publication_recovery_access ~ctx_work ~task_id:"task-001"
+    in
     check string "self-claim succeeds" "success" (outcome_label claim.KET.outcome);
     let result =
       attempt_done
         ~config
         ~meta
+        ~publication_recovery_registry
+        ~publication_recovery_access
         ~ctx_work
         ~task_id:"task-001"
         ~result:"done"
@@ -273,19 +312,26 @@ let test_short_notes_without_evidence_follow_llm_approval () =
 
 
 let test_completion_with_evidence_refs_succeeds () =
-  with_ws "completion_trust_evidence_refs" (fun ~config ~meta ~ctx_work ->
+  with_ws "completion_trust_evidence_refs"
+    (fun ~config ~meta ~publication_recovery_registry
+         ~publication_recovery_access ~ctx_work ->
     reviewer_response := Reviewer_verdict AR.Approve;
     ignore (Workspace.init config ~agent_name:(Some meta.agent_name));
     ignore
       (Workspace.add_task config ~title:"complete with evidence refs" ~priority:1
          ~description:"claimed by the caller and completed with trusted proof");
-    let claim = claim_via_dispatch ~config ~meta ~ctx_work ~task_id:"task-001" in
+    let claim =
+      claim_via_dispatch ~config ~meta ~publication_recovery_registry
+        ~publication_recovery_access ~ctx_work ~task_id:"task-001"
+    in
     check string "self-claim precondition succeeds" "success" (outcome_label claim.KET.outcome);
     seed_trace_evidence ~config "completion-trust-harness";
     let result =
       attempt_done
         ~config
         ~meta
+        ~publication_recovery_registry
+        ~publication_recovery_access
         ~ctx_work
         ~task_id:"task-001"
         ~result:"Implemented the deliverable and saved trace:completion-trust-harness evidence."
@@ -314,18 +360,25 @@ let test_completion_with_evidence_refs_succeeds () =
 (* An LLM rejection leaves only this task active; a later approval can
    complete it without changing evidence shape. *)
 let test_llm_rejection_keeps_task_active_then_approval_completes () =
-  with_ws "completion_llm_reject_then_approve" (fun ~config ~meta ~ctx_work ->
+  with_ws "completion_llm_reject_then_approve"
+    (fun ~config ~meta ~publication_recovery_registry
+         ~publication_recovery_access ~ctx_work ->
     ignore (Workspace.init config ~agent_name:(Some meta.agent_name));
     ignore
       (Workspace.add_task config ~title:"LLM reviewed completion" ~priority:1
          ~description:"completion follows the evaluator verdict");
-    let claim = claim_via_dispatch ~config ~meta ~ctx_work ~task_id:"task-001" in
+    let claim =
+      claim_via_dispatch ~config ~meta ~publication_recovery_registry
+        ~publication_recovery_access ~ctx_work ~task_id:"task-001"
+    in
     check string "self-claim succeeds" "success" (outcome_label claim.KET.outcome);
     reviewer_response := Reviewer_verdict (AR.Reject "deliverable is not complete");
     let rejected =
       attempt_done
         ~config
         ~meta
+        ~publication_recovery_registry
+        ~publication_recovery_access
         ~ctx_work
         ~task_id:"task-001"
         ~result:"Completed the deliverable."
@@ -346,6 +399,8 @@ let test_llm_rejection_keeps_task_active_then_approval_completes () =
       attempt_done
         ~config
         ~meta
+        ~publication_recovery_registry
+        ~publication_recovery_access
         ~ctx_work
         ~task_id:"task-001"
         ~result:"Completed the deliverable."
@@ -367,18 +422,25 @@ let test_llm_rejection_keeps_task_active_then_approval_completes () =
     | None -> fail "task-001 missing after approved retry")
 
 let test_unavailable_evaluator_keeps_task_active () =
-  with_ws "completion_llm_unavailable" (fun ~config ~meta ~ctx_work ->
+  with_ws "completion_llm_unavailable"
+    (fun ~config ~meta ~publication_recovery_registry
+         ~publication_recovery_access ~ctx_work ->
     ignore (Workspace.init config ~agent_name:(Some meta.agent_name));
     ignore
       (Workspace.add_task config ~title:"unavailable evaluator" ~priority:1
          ~description:"must stay active without an LLM verdict");
-    let claim = claim_via_dispatch ~config ~meta ~ctx_work ~task_id:"task-001" in
+    let claim =
+      claim_via_dispatch ~config ~meta ~publication_recovery_registry
+        ~publication_recovery_access ~ctx_work ~task_id:"task-001"
+    in
     check string "self-claim succeeds" "success" (outcome_label claim.KET.outcome);
     reviewer_response := Reviewer_unavailable;
     let result =
       attempt_done
         ~config
         ~meta
+        ~publication_recovery_registry
+        ~publication_recovery_access
         ~ctx_work
         ~task_id:"task-001"
         ~result:"Completed the deliverable."
@@ -398,12 +460,17 @@ let test_unavailable_evaluator_keeps_task_active () =
 (* Positive lifecycle control: a keeper claiming its own backlog task is
    accepted on the same dispatch path. *)
 let test_legitimate_claim_succeeds () =
-  with_ws "completion_trust_positive_claim" (fun ~config ~meta ~ctx_work ->
+  with_ws "completion_trust_positive_claim"
+    (fun ~config ~meta ~publication_recovery_registry
+         ~publication_recovery_access ~ctx_work ->
     ignore (Workspace.init config ~agent_name:(Some meta.agent_name));
     ignore
       (Workspace.add_task config ~title:"claimable task" ~priority:1
          ~description:"unowned backlog work");
-    let result = claim_via_dispatch ~config ~meta ~ctx_work ~task_id:"task-001" in
+    let result =
+      claim_via_dispatch ~config ~meta ~publication_recovery_registry
+        ~publication_recovery_access ~ctx_work ~task_id:"task-001"
+    in
     check string "legitimate claim outcome" "success" (outcome_label result.KET.outcome);
     match assignee_of config "task-001" with
     | Some assignee -> check string "claimed task is owned by the caller" meta.agent_name assignee

--- a/test/test_dashboard_briefing.ml
+++ b/test/test_dashboard_briefing.ml
@@ -189,7 +189,7 @@ let test_dashboard_briefing_http_full_contract () =
          Both dashboard-level and operator snapshot caches must be invalidated. *)
       Dashboard_cache.invalidate_all ();
       Operator_control.invalidate_snapshot_cache ();
-      let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
+      let state = Lib.Mcp_server_eio.For_testing.create_state ~base_path:dir () in
       let json =
         Server_dashboard_http.dashboard_briefing_http_json
           ~state
@@ -214,7 +214,7 @@ let test_dashboard_briefing_http_default_bootstraps_first_success () =
       let config = Workspace_utils.default_config dir in
       let session_id = "ts-mission-http-default-001" in
       seed_workspace config session_id;
-      let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
+      let state = Lib.Mcp_server_eio.For_testing.create_state ~base_path:dir () in
       let json =
         Server_dashboard_http.dashboard_briefing_http_json
           ~state
@@ -248,7 +248,7 @@ let test_dashboard_briefing_keeper_tool_audit_fallback () =
       seed_workspace config session_id;
       Dashboard_cache.invalidate_all ();
       Operator_control.invalidate_snapshot_cache ();
-      let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
+      let state = Lib.Mcp_server_eio.For_testing.create_state ~base_path:dir () in
       let json =
         Server_dashboard_http.dashboard_briefing_http_json
           ~state
@@ -288,10 +288,10 @@ let test_dashboard_briefing_http_cache_isolation () =
       seed_workspace config_a session_a;
       seed_workspace config_b session_b;
       let state_a =
-        Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir_a ()
+        Lib.Mcp_server_eio.For_testing.create_state ~base_path:dir_a ()
       in
       let state_b =
-        Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir_b ()
+        Lib.Mcp_server_eio.For_testing.create_state ~base_path:dir_b ()
       in
       let request =
         request ("/api/v1/dashboard/briefing?agent_name=" ^ actor)

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -613,7 +613,7 @@ let test_dashboard_query_cache_key_encodes_delimiter_values () =
 let test_operator_snapshot_default_route_exposes_provenance () =
   with_test_env @@ fun ~env ~sw ~config ->
   let state =
-    Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:config.base_path ()
+    Lib.Mcp_server_eio.For_testing.create_state ~base_path:config.base_path ()
   in
   let seed =
     `Assoc
@@ -659,7 +659,7 @@ let test_operator_snapshot_default_route_exposes_provenance () =
 let test_operator_digest_default_route_exposes_provenance () =
   with_test_env @@ fun ~env ~sw ~config ->
   let state =
-    Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:config.base_path ()
+    Lib.Mcp_server_eio.For_testing.create_state ~base_path:config.base_path ()
   in
   let seed =
     `Assoc
@@ -1000,7 +1000,7 @@ let test_execution_actor_for_request_canonicalizes_token_owner () =
 let test_dashboard_execution_force_refresh_bypasses_default_cache () =
   with_test_env @@ fun ~env ~sw ~config ->
   let state =
-    Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:config.base_path ()
+    Lib.Mcp_server_eio.For_testing.create_state ~base_path:config.base_path ()
   in
   let seed =
     `Assoc
@@ -1036,7 +1036,7 @@ let test_dashboard_execution_force_refresh_bypasses_default_cache () =
 let test_dashboard_execution_trust_default_route_uses_cached_surface () =
   with_test_env @@ fun ~env ~sw ~config ->
   let state =
-    Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:config.base_path ()
+    Lib.Mcp_server_eio.For_testing.create_state ~base_path:config.base_path ()
   in
   let seed =
     `Assoc
@@ -1595,7 +1595,7 @@ let test_telemetry_summary_snapshot_wire_falls_back_when_empty () =
    [test_dashboard_namespace_truth.ml] integration coverage. *)
 
 let test_project_snapshot_wire_returns_snapshot_when_populated () =
-  with_test_env @@ fun ~env ~sw ~config:_ ->
+  with_test_env @@ fun ~env ~sw ~config ->
   Dashboard_snapshot.reset_for_test ();
   let marker =
     `Assoc [ "namespace_truth_marker", `String "from-snapshot" ]
@@ -1605,7 +1605,9 @@ let test_project_snapshot_wire_returns_snapshot_when_populated () =
        ~shell:`Null ~tools:`Null
        ~namespace_truth:marker ~telemetry_summary:`Null ());
   let clock = Eio.Stdenv.clock env in
-  let state = Lib.Mcp_server.create_state ~base_path:"/tmp/rfc-0138-step3" in
+  let state =
+    Lib.Mcp_server.For_testing.create_state ~base_path:config.base_path
+  in
   let req = request "/api/v1/dashboard/project-snapshot" in
   let timing = Server_timing.create () in
   let json =
@@ -1631,7 +1633,7 @@ let assoc_has key = function
 
 let test_dashboard_bootstrap_omits_eager_goal_tree () =
   with_test_env @@ fun ~env ~sw ~config ->
-  let state = Lib.Mcp_server.create_state ~base_path:config.base_path in
+  let state = Lib.Mcp_server.For_testing.create_state ~base_path:config.base_path in
   let clock = Eio.Stdenv.clock env in
   let req = request "/api/v1/dashboard/bootstrap" in
   let json = Server_dashboard_http.dashboard_bootstrap_http_json ~state ~sw ~clock req in

--- a/test/test_dashboard_namespace_truth.ml
+++ b/test/test_dashboard_namespace_truth.ml
@@ -124,14 +124,17 @@ let expire_execution_warmup () =
   surface.last_attempt_unix <- Some stale_attempt_ts;
   surface.last_attempt_at <- Some "stale_attempt_for_test"
 
-let create_keeper env sw config name =
+let create_keeper env sw state name =
+  let workspace_scope = Lib.Mcp_server.workspace_scope state in
   let ctx : _ Lib.Keeper_tool_surface.context =
     {
-      config;
+      config = workspace_scope.config;
       agent_name = "tester";
       sw;
       clock = Eio.Stdenv.clock env;
       proc_mgr = Some (Eio.Stdenv.process_mgr env); net = None;
+      publication_recovery_registry =
+        (Mcp_server.workspace_scope_publication_recovery_registry workspace_scope);
     }
   in
   match
@@ -156,7 +159,7 @@ let test_dashboard_namespace_truth_empty_workspace () =
     (fun () ->
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
-      let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
+      let state = Lib.Mcp_server_eio.For_testing.create_state ~base_path:dir () in
       Eio.Switch.run (fun sw ->
         warm_execution_cache ();
         let json =
@@ -222,7 +225,7 @@ let test_dashboard_namespace_truth_execution_fixture () =
     (fun () ->
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
-      let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
+      let state = Lib.Mcp_server_eio.For_testing.create_state ~base_path:dir () in
       warm_execution_cache ();
       Eio.Switch.run (fun sw ->
         let json =
@@ -247,7 +250,7 @@ let test_dashboard_namespace_truth_empty_workspace_focus_label () =
     (fun () ->
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
-      let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
+      let state = Lib.Mcp_server_eio.For_testing.create_state ~base_path:dir () in
       warm_execution_cache ();
       Eio.Switch.run (fun sw ->
         let json =
@@ -274,21 +277,31 @@ let test_dashboard_namespace_truth_keeper_only_workspace_not_reported_empty () =
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
       let module Mcp_server = Lib.Mcp_server in
-      let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
-      let config = (Mcp_server.workspace_config state) in
-      ignore (Lib.Workspace.init config ~agent_name:None);
-      ignore
-        (Lib.Workspace.bind_session config
-           ~agent_name:"keeper-sangsu-agent"
-           ~agent_type_override:(Some "keeper")
-           ~capabilities:["keeper"]
-           ());
       Eio.Switch.run (fun sw ->
+        Lib.Auth.disable_auth dir;
+        let state =
+          Lib.Mcp_server_eio.create_state_eio
+            ~sw
+            ~proc_mgr:(Eio.Stdenv.process_mgr env)
+            ~fs:(Eio.Stdenv.fs env)
+            ~clock:(Eio.Stdenv.clock env)
+            ~mono_clock:(Eio.Stdenv.mono_clock env)
+            ~net:(Eio.Stdenv.net env)
+            ~base_path:dir
+        in
+        let config = Mcp_server.workspace_config state in
+        ignore (Lib.Workspace.init config ~agent_name:None);
+        ignore
+          (Lib.Workspace.bind_session config
+             ~agent_name:"keeper-sangsu-agent"
+             ~agent_type_override:(Some "keeper")
+             ~capabilities:["keeper"]
+             ());
         Fun.protect
           ~finally:(fun () ->
             Lib.Keeper_keepalive.stop_keepalive "sangsu")
           (fun () ->
-            create_keeper env sw config "sangsu";
+            create_keeper env sw state "sangsu";
             warm_execution_cache ();
             let json =
               Server_dashboard_http.dashboard_namespace_truth_http_json
@@ -319,27 +332,37 @@ let test_dashboard_namespace_truth_mixed_runtime_counts () =
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
       let module Mcp_server = Lib.Mcp_server in
-      let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
-      let config = (Mcp_server.workspace_config state) in
-      ignore (Lib.Workspace.init config ~agent_name:None);
-      ignore
-        (Lib.Workspace.bind_session config
-           ~agent_name:"codex-test-agent"
-           ~agent_type_override:(Some "codex")
-           ~capabilities:["typescript"]
-           ());
-      ignore
-        (Lib.Workspace.bind_session config
-           ~agent_name:"keeper-sangsu-agent"
-           ~agent_type_override:(Some "keeper")
-           ~capabilities:["keeper"]
-           ());
       Eio.Switch.run (fun sw ->
+        Lib.Auth.disable_auth dir;
+        let state =
+          Lib.Mcp_server_eio.create_state_eio
+            ~sw
+            ~proc_mgr:(Eio.Stdenv.process_mgr env)
+            ~fs:(Eio.Stdenv.fs env)
+            ~clock:(Eio.Stdenv.clock env)
+            ~mono_clock:(Eio.Stdenv.mono_clock env)
+            ~net:(Eio.Stdenv.net env)
+            ~base_path:dir
+        in
+        let config = Mcp_server.workspace_config state in
+        ignore (Lib.Workspace.init config ~agent_name:None);
+        ignore
+          (Lib.Workspace.bind_session config
+             ~agent_name:"codex-test-agent"
+             ~agent_type_override:(Some "codex")
+             ~capabilities:["typescript"]
+             ());
+        ignore
+          (Lib.Workspace.bind_session config
+             ~agent_name:"keeper-sangsu-agent"
+             ~agent_type_override:(Some "keeper")
+             ~capabilities:["keeper"]
+             ());
         Fun.protect
           ~finally:(fun () ->
             Lib.Keeper_keepalive.stop_keepalive "sangsu")
           (fun () ->
-            create_keeper env sw config "sangsu";
+            create_keeper env sw state "sangsu";
             warm_execution_cache ();
             let json =
               Server_dashboard_http.dashboard_namespace_truth_http_json
@@ -366,7 +389,7 @@ let test_operator_pending_confirm_shape_matches_namespace_truth () =
     (fun () ->
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
-      let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
+      let state = Lib.Mcp_server_eio.For_testing.create_state ~base_path:dir () in
       warm_execution_cache ();
       Eio.Switch.run (fun sw ->
         let json =
@@ -392,7 +415,7 @@ let test_namespace_truth_cached_snapshot_matches_http_projection_blocks () =
     (fun () ->
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
-      let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
+      let state = Lib.Mcp_server_eio.For_testing.create_state ~base_path:dir () in
       warm_execution_cache ();
       Server_dashboard_http.warm_shell_cache state;
       Eio.Switch.run (fun sw ->
@@ -428,7 +451,7 @@ let test_dashboard_namespace_truth_warm_request_uses_stale_shell () =
     (fun () ->
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
-      let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
+      let state = Lib.Mcp_server_eio.For_testing.create_state ~base_path:dir () in
       let config = Lib.Mcp_server.workspace_config state in
       warm_execution_cache ();
       let cached_shell =
@@ -490,7 +513,7 @@ let test_dashboard_namespace_truth_cold_cache_falls_back_to_partial_truth () =
     (fun () ->
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
-      let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
+      let state = Lib.Mcp_server_eio.For_testing.create_state ~base_path:dir () in
       expire_execution_warmup ();
       Eio.Switch.run (fun sw ->
         let json =
@@ -520,7 +543,7 @@ let test_last_good_shell_fallback_preserves_counts () =
     (fun () ->
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
-      let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
+      let state = Lib.Mcp_server_eio.For_testing.create_state ~base_path:dir () in
       ignore (Lib.Workspace.init (Lib.Mcp_server.workspace_config state) ~agent_name:None);
       warm_execution_cache ();
       (* Warm the shell cache so last_good_shell gets populated. *)

--- a/test/test_eio_resource_scope.ml
+++ b/test/test_eio_resource_scope.ml
@@ -1,0 +1,126 @@
+open Alcotest
+
+module Scope = Fs_compat.Capability_write_for_testing
+
+exception Callback_cancelled
+exception Release_failed
+exception Body_failed
+
+let check_release_failure = function
+  | Some Release_failed -> ()
+  | Some failure ->
+    failf "unexpected release failure: %s" (Printexc.to_string failure)
+  | None -> fail "release failure was not retained"
+;;
+
+let test_callback_cancellation_precedes_release_failure () =
+  Eio_main.run @@ fun _ ->
+  let outcome =
+    Scope.run_publication_recovery_resource_scope
+      ~callback:(Scope.Cancel_callback Callback_cancelled)
+      ~release_failure:(Some Release_failed)
+  in
+  (match outcome with
+   | Scope.Cancelled_callback
+       { reason = Callback_cancelled; release_failure } ->
+     check_release_failure release_failure
+   | Scope.Cancelled_callback { reason; _ } ->
+     failf "unexpected cancellation reason: %s" (Printexc.to_string reason)
+   | Scope.Returned_rows _ | Scope.Raised_callback _ ->
+     fail "callback cancellation was not retained")
+;;
+
+let test_returned_callback_survives_release_failure () =
+  Eio_main.run @@ fun _ ->
+  let outcome =
+    Scope.run_publication_recovery_resource_scope
+      ~callback:(Scope.Return_completed_rows [ "completed-row" ])
+      ~release_failure:(Some Release_failed)
+  in
+  match outcome with
+  | Scope.Returned_rows { completed_rows; release_failure } ->
+    check (list string)
+      "completed rows retain order"
+      [ "completed-row" ]
+      completed_rows;
+    check_release_failure release_failure
+  | Scope.Cancelled_callback _ | Scope.Raised_callback _ ->
+    fail "returned callback value was not retained"
+;;
+
+let test_lane_cleanup_retains_cancellation_and_release_failure () =
+  Eio_main.run @@ fun _ ->
+  match
+    Scope.run_publication_recovery_cleanup_boundary
+      ~body:(Scope.Cancel_cleanup_body Callback_cancelled)
+      ~cleanup_failure:(Some Release_failed)
+  with
+  | Scope.Cancellation_primary_with_cleanup_failure
+      { body = None
+      ; cancellation = { exception_ = Eio.Cancel.Cancelled Callback_cancelled; _ }
+      ; cleanup = { exception_ = Release_failed; _ }
+      } -> ()
+  | Scope.Cancellation_primary_with_cleanup_failure
+      { body; cancellation; cleanup } ->
+    failf
+      "wrong typed cleanup evidence: body=%b cancellation=%s cleanup=%s"
+      (Option.is_some body)
+      (Printexc.to_string cancellation.exception_)
+      (Printexc.to_string cleanup.exception_)
+  | Scope.Cleanup_returned _
+  | Scope.Cleanup_failed_without_cancellation _
+  | Scope.Body_failure_during_cancellation _
+  | Scope.Cancellation_primary _
+  | Scope.Cleanup_boundary_raised _ ->
+    fail "lane cleanup lost cancellation or release evidence"
+;;
+
+let test_lane_cleanup_retains_body_and_release_failure () =
+  Eio_main.run @@ fun _ ->
+  match
+    Scope.run_publication_recovery_cleanup_boundary
+      ~body:(Scope.Raise_cleanup_body Body_failed)
+      ~cleanup_failure:(Some Release_failed)
+  with
+  | Scope.Cleanup_failed_without_cancellation
+      { body = Some { exception_ = Body_failed; _ }
+      ; cleanup = { exception_ = Release_failed; _ }
+      } -> ()
+  | Scope.Cleanup_failed_without_cancellation { body; cleanup } ->
+    failf
+      "wrong body/cleanup evidence: body=%s cleanup=%s"
+      (match body with
+       | None -> "none"
+       | Some failure -> Printexc.to_string failure.exception_)
+      (Printexc.to_string cleanup.exception_)
+  | Scope.Cleanup_returned _
+  | Scope.Cancellation_primary_with_cleanup_failure _
+  | Scope.Body_failure_during_cancellation _
+  | Scope.Cancellation_primary _
+  | Scope.Cleanup_boundary_raised _ ->
+    fail "lane cleanup lost body or release evidence"
+;;
+
+let () =
+  run
+    "Eio resource-only scope"
+    [ ( "release evidence"
+      , [ test_case
+            "callback cancellation remains primary"
+            `Quick
+            test_callback_cancellation_precedes_release_failure
+        ; test_case
+            "returned callback survives release failure"
+            `Quick
+            test_returned_callback_survives_release_failure
+        ; test_case
+            "lane cleanup retains cancellation and release failure"
+            `Quick
+            test_lane_cleanup_retains_cancellation_and_release_failure
+        ; test_case
+            "lane cleanup retains body and release failure"
+            `Quick
+            test_lane_cleanup_retains_body_and_release_failure
+        ] )
+    ]
+;;

--- a/test/test_fs_compat_capability_write.ml
+++ b/test/test_fs_compat_capability_write.ml
@@ -38,6 +38,110 @@ let with_parent_capability ~fs directory f =
   Eio.Path.with_open_dir Eio.Path.(fs / directory) f
 ;;
 
+let with_publication_recovery_access ~fs f =
+  with_tmp_dir @@ fun registry_directory ->
+  Eio.Switch.run @@ fun sw ->
+  match
+    Fs_compat.open_publication_recovery_registry
+      ~sw
+      ~registry_root:Eio.Path.(fs / registry_directory)
+  with
+  | Error error ->
+    fail (Fs_compat.publication_recovery_registry_error_to_string error)
+  | Ok registry ->
+    (match Fs_compat.inventory_publication_recovery_owners registry with
+     | Error error ->
+       fail
+         (Fs_compat.publication_recovery_owner_inventory_error_to_string
+            error)
+     | Ok [] ->
+       (match
+          Fs_compat.with_publication_recovery_lane
+            ~registry
+            ~owner:"capability-write-test"
+            f
+        with
+        | Ok value -> value
+        | Error error ->
+          fail
+            (Fs_compat.publication_recovery_lane_open_error_to_string
+               error))
+     | Ok rows ->
+       failf
+         "fresh publication recovery fixture unexpectedly contained owners: %s"
+         (String.concat
+            "; "
+            (List.map
+               Fs_compat.publication_recovery_owner_inventory_row_to_string
+               rows)))
+;;
+
+let with_replace_context ~fs directory f =
+  with_parent_capability ~fs directory @@ fun parent ->
+  with_publication_recovery_access ~fs @@ fun recovery ->
+  f parent recovery
+;;
+
+let require_recovery_target ~allowed_root_path ~parent ~leaf ~permissions =
+  let root = Eio.Path.stat ~follow:true parent in
+  match
+    Fs_compat.atomic_replace_recovery_target
+      ~allowed_root_path
+      ~allowed_root_device:root.dev
+      ~allowed_root_inode:root.ino
+      ~parent_components:[]
+      ~target_leaf:leaf
+      ~permissions
+  with
+  | Ok target -> target
+  | Error error ->
+    fail (Fs_compat.atomic_replace_recovery_target_error_to_string error)
+;;
+
+let replace_capability_file ~recovery ~allowed_root_path ~parent ~leaf ~permissions content =
+  let target =
+    require_recovery_target ~allowed_root_path ~parent ~leaf ~permissions
+  in
+  Fs_compat.replace_capability_file ~recovery ~parent ~target content
+;;
+
+let replace_capability_file_for_testing
+      ~before_stage
+      ~recovery
+      ~allowed_root_path
+      ~parent
+      ~leaf
+      ~permissions
+      content
+  =
+  let target =
+    require_recovery_target ~allowed_root_path ~parent ~leaf ~permissions
+  in
+  Fs_compat.Capability_write_for_testing.replace_capability_file
+    ~before_stage
+    ~recovery
+    ~parent
+    ~target
+    content
+;;
+
+let require_write_primary_failure (error : Fs_compat.capability_write_error) =
+  match error.primary_failure with
+  | Fs_compat.Write_primary_failure failure -> failure
+  | Fs_compat.Recovery_primary_failure failure ->
+    fail (Fs_compat.capability_recovery_failure_to_string failure)
+  | Fs_compat.Recovery_access_primary_failure _ ->
+    fail "publication recovery access unexpectedly unavailable"
+;;
+
+let has_write_cleanup_stage stage (error : Fs_compat.capability_write_error) =
+  List.exists
+    (function
+      | Fs_compat.Write_cleanup_failure failure -> failure.stage = stage
+      | Fs_compat.Recovery_cleanup_failure _ -> false)
+    error.cleanup_failures
+;;
+
 let require_ok = function
   | Ok () -> ()
   | Error error -> fail (Fs_compat.capability_write_error_to_string error)
@@ -53,12 +157,13 @@ let test_atomic_replace_preserves_requested_mode ~fs () =
   let target = Filename.concat directory "target" in
   write_file target "old";
   Unix.chmod target 0o751;
-  with_parent_capability ~fs directory @@ fun parent ->
+  with_replace_context ~fs directory @@ fun parent recovery ->
   require_ok
-    (Fs_compat.publish_capability_file
+    (replace_capability_file
+       ~recovery
+       ~allowed_root_path:directory
        ~parent
        ~leaf:"target"
-       ~intent:Fs_compat.Atomic_replace
        ~permissions:0o751
        "new");
   check string "payload replaced" "new" (read_file target);
@@ -73,12 +178,13 @@ let test_atomic_replace_replaces_symlink_not_referent ~fs () =
   let target = Filename.concat directory "target" in
   write_file referent "referent";
   Unix.symlink "referent" target;
-  with_parent_capability ~fs directory @@ fun parent ->
+  with_replace_context ~fs directory @@ fun parent recovery ->
   require_ok
-    (Fs_compat.publish_capability_file
+    (replace_capability_file
+       ~recovery
+       ~allowed_root_path:directory
        ~parent
        ~leaf:"target"
-       ~intent:Fs_compat.Atomic_replace
        ~permissions:0o640
        "replacement");
   check string "referent unchanged" "referent" (read_file referent);
@@ -90,15 +196,49 @@ let test_atomic_replace_writes_complete_large_payload ~fs () =
   with_tmp_dir @@ fun directory ->
   let target = Filename.concat directory "target" in
   let payload = String.init ((1024 * 1024) + 17) (fun index -> Char.chr (index mod 251)) in
-  with_parent_capability ~fs directory @@ fun parent ->
+  with_replace_context ~fs directory @@ fun parent recovery ->
   require_ok
-    (Fs_compat.publish_capability_file
+    (replace_capability_file
+       ~recovery
+       ~allowed_root_path:directory
        ~parent
        ~leaf:"target"
-       ~intent:Fs_compat.Atomic_replace
        ~permissions:0o640
        payload);
   check string "all bytes written" payload (read_file target)
+;;
+
+let test_atomic_replace_uses_typed_parent_components ~fs () =
+  with_tmp_dir @@ fun directory ->
+  let nested_directory = Filename.concat directory "nested" in
+  let target_path = Filename.concat nested_directory "target" in
+  Unix.mkdir nested_directory 0o700;
+  write_file target_path "old";
+  with_parent_capability ~fs directory @@ fun allowed_root ->
+  let allowed_root_stat = Eio.Path.stat ~follow:true allowed_root in
+  Eio.Path.with_open_dir Eio.Path.(allowed_root / "nested") @@ fun parent ->
+  with_publication_recovery_access ~fs @@ fun recovery ->
+  let target =
+    match
+      Fs_compat.atomic_replace_recovery_target
+        ~allowed_root_path:directory
+        ~allowed_root_device:allowed_root_stat.dev
+        ~allowed_root_inode:allowed_root_stat.ino
+        ~parent_components:[ "nested" ]
+        ~target_leaf:"target"
+        ~permissions:0o640
+    with
+    | Ok target -> target
+    | Error error ->
+      fail (Fs_compat.atomic_replace_recovery_target_error_to_string error)
+  in
+  require_ok
+    (Fs_compat.replace_capability_file
+       ~recovery
+       ~parent
+       ~target
+       "new");
+  check string "nested target replaced" "new" (read_file target_path)
 ;;
 
 let test_atomic_replace_owns_restrictive_staging_directory ~fs () =
@@ -106,9 +246,9 @@ let test_atomic_replace_owns_restrictive_staging_directory ~fs () =
   let target = Filename.concat directory "target" in
   write_file target "old";
   let observed_mode = ref None in
-  with_parent_capability ~fs directory @@ fun parent ->
+  with_replace_context ~fs directory @@ fun parent recovery ->
   require_ok
-    (Fs_compat.Capability_write_for_testing.publish_capability_file
+    (replace_capability_file_for_testing
        ~before_stage:(function
          | Fs_compat.Create_staging_entry ->
            let staging = only_entry_except directory [ "target" ] in
@@ -117,9 +257,10 @@ let test_atomic_replace_owns_restrictive_staging_directory ~fs () =
            then fail "staging entry is not a directory";
            observed_mode := Some (stat.st_perm land 0o777)
          | _ -> ())
+       ~recovery
+       ~allowed_root_path:directory
        ~parent
        ~leaf:"target"
-       ~intent:Fs_compat.Atomic_replace
        ~permissions:0o640
        "new");
   check (option int) "staging directory has exact restrictive mode" (Some 0o700)
@@ -128,26 +269,28 @@ let test_atomic_replace_owns_restrictive_staging_directory ~fs () =
     (directory_entries directory)
 ;;
 
-let test_publish_preflight_failure_keeps_known_target_state ~fs () =
+let test_replace_preflight_failure_keeps_known_target_state ~fs () =
   with_tmp_dir @@ fun directory ->
   let target = Filename.concat directory "target" in
   write_file target "old";
-  with_parent_capability ~fs directory @@ fun parent ->
+  with_replace_context ~fs directory @@ fun parent recovery ->
   (match
-     Fs_compat.Capability_write_for_testing.publish_capability_file
+     replace_capability_file_for_testing
        ~before_stage:(function
          | Fs_compat.Publish_replace -> raise Exit
          | _ -> ())
+       ~recovery
+       ~allowed_root_path:directory
        ~parent
        ~leaf:"target"
-       ~intent:Fs_compat.Atomic_replace
        ~permissions:0o640
        "new"
    with
    | Ok () -> fail "fault-injected publish preflight unexpectedly succeeded"
    | Error error ->
+     let failure = require_write_primary_failure error in
      check bool "pre-rename failure stage retained" true
-       (error.failure.stage = Fs_compat.Publish_replace);
+       (failure.stage = Fs_compat.Publish_replace);
      check bool "pre-rename target is known unchanged" true
        (error.target_effect = Fs_compat.Target_unchanged));
   check string "old target retained" "old" (read_file target);
@@ -155,16 +298,16 @@ let test_publish_preflight_failure_keeps_known_target_state ~fs () =
     (directory_entries directory)
 ;;
 
-let test_publish_preflight_detects_payload_leaf_swap ~fs () =
+let test_replace_preflight_detects_payload_leaf_swap ~fs () =
   with_tmp_dir @@ fun directory ->
   let target = Filename.concat directory "target" in
   write_file target "old";
   let replacement_payload = ref None in
-  with_parent_capability ~fs directory @@ fun parent ->
+  with_replace_context ~fs directory @@ fun parent recovery ->
   (match
-     Fs_compat.Capability_write_for_testing.publish_capability_file
+     replace_capability_file_for_testing
        ~before_stage:(function
-         | Fs_compat.Publish_replace ->
+         | Fs_compat.Verify_entry_identity ->
            let staging = only_entry_except directory [ "target" ] in
            let staging_path = Filename.concat directory staging in
            let payload = Filename.concat staging_path "payload" in
@@ -172,16 +315,18 @@ let test_publish_preflight_detects_payload_leaf_swap ~fs () =
            write_file payload "replacement";
            replacement_payload := Some payload
          | _ -> ())
+       ~recovery
+       ~allowed_root_path:directory
        ~parent
        ~leaf:"target"
-       ~intent:Fs_compat.Atomic_replace
        ~permissions:0o640
        "new"
    with
    | Ok () -> fail "payload-leaf replacement was published"
    | Error error ->
+     let failure = require_write_primary_failure error in
      check bool "payload identity swap detected" true
-       (error.failure.stage = Fs_compat.Verify_entry_identity);
+       (failure.stage = Fs_compat.Verify_entry_identity);
      check bool "target remained known unchanged" true
        (error.target_effect = Fs_compat.Target_unchanged));
   check string "old target retained after payload swap" "old" (read_file target);
@@ -195,9 +340,9 @@ let test_staging_name_swap_does_not_redirect_pinned_payload ~fs () =
   let displaced = Filename.concat directory "displaced" in
   write_file target "old";
   let replacement = ref None in
-  with_parent_capability ~fs directory @@ fun parent ->
+  with_replace_context ~fs directory @@ fun parent recovery ->
   (match
-     Fs_compat.Capability_write_for_testing.publish_capability_file
+     replace_capability_file_for_testing
        ~before_stage:(function
          | Fs_compat.Publish_replace ->
            let staging = only_entry_except directory [ "target" ] in
@@ -206,16 +351,18 @@ let test_staging_name_swap_does_not_redirect_pinned_payload ~fs () =
            Unix.mkdir staging_path 0o700;
            replacement := Some staging_path
          | _ -> ())
+       ~recovery
+       ~allowed_root_path:directory
        ~parent
        ~leaf:"target"
-       ~intent:Fs_compat.Atomic_replace
        ~permissions:0o640
        "new"
    with
    | Ok () -> fail "staging-name replacement was not observed"
    | Error error ->
+     let failure = require_write_primary_failure error in
      check bool "replacement detected before directory removal" true
-       (error.failure.stage = Fs_compat.Verify_staging_directory_identity);
+       (failure.stage = Fs_compat.Verify_staging_directory_identity);
      check bool "payload still published from pinned capability" true
        (error.target_effect = Fs_compat.Target_replaced));
   check string "pinned payload reached target" "new" (read_file target);
@@ -225,26 +372,29 @@ let test_staging_name_swap_does_not_redirect_pinned_payload ~fs () =
     (Sys.is_directory displaced)
 ;;
 
-let test_append_and_replace_share_nonblocking_entry_lease ~fs () =
+let test_append_and_replace_share_existing_target_lease ~fs () =
   with_tmp_dir @@ fun directory ->
   let target = Filename.concat directory "target" in
+  let target_alias = Filename.concat directory "target-alias" in
   write_file target "old";
-  with_parent_capability ~fs directory @@ fun parent ->
+  Unix.link target target_alias;
+  with_replace_context ~fs directory @@ fun parent recovery ->
   Eio.Switch.run @@ fun sw ->
   let writer_entered, resolve_writer_entered = Eio.Promise.create () in
   let release_writer, resolve_release_writer = Eio.Promise.create () in
   let writer_result, resolve_writer_result = Eio.Promise.create () in
   Eio.Fiber.fork ~sw (fun () ->
     let result =
-      Fs_compat.Capability_write_for_testing.publish_capability_file
+      replace_capability_file_for_testing
         ~before_stage:(function
           | Fs_compat.Create_staging_directory ->
             Eio.Promise.resolve resolve_writer_entered ();
             Eio.Promise.await release_writer
           | _ -> ())
+        ~recovery
+        ~allowed_root_path:directory
         ~parent
         ~leaf:"target"
-        ~intent:Fs_compat.Atomic_replace
         ~permissions:0o640
         "replacement"
     in
@@ -256,7 +406,7 @@ let test_append_and_replace_share_nonblocking_entry_lease ~fs () =
       Fs_compat.open_capability_append_file
         ~sw:append_sw
         ~parent
-        ~leaf:"target"
+        ~leaf:"target-alias"
       |> require_append_file
     in
     let alias_rejected =
@@ -271,7 +421,7 @@ let test_append_and_replace_share_nonblocking_entry_lease ~fs () =
     in
     Fs_compat.append_capability_observed file "append", alias_rejected
   in
-  check bool "append immediately reports entry contention" true
+  check bool "hard-link alias reports target identity contention" true
     (append_outcome.write_failure
      = Some Fs_compat.Capability_append_mutation_contended);
   check int "contended append writes no bytes" 0 append_outcome.bytes_written;
@@ -294,10 +444,526 @@ let test_append_and_replace_share_nonblocking_entry_lease ~fs () =
     in
     Fs_compat.append_capability_observed file "after-release"
   in
-  check bool "atomic writer releases the entry lease" true
+  check bool "atomic writer releases the target identity lease" true
     (Option.is_none append_after_release.write_failure);
   check string "replacement completes before the later append"
     "replacementafter-release"
+    (read_file target)
+;;
+
+let test_hard_link_replaces_share_existing_target_lease ~fs () =
+  with_tmp_dir @@ fun directory ->
+  let target = Filename.concat directory "target" in
+  let target_alias = Filename.concat directory "target-alias" in
+  write_file target "old";
+  Unix.link target target_alias;
+  with_replace_context ~fs directory @@ fun parent recovery ->
+  Eio.Switch.run @@ fun sw ->
+  let writer_entered, resolve_writer_entered = Eio.Promise.create () in
+  let release_writer, resolve_release_writer = Eio.Promise.create () in
+  let writer_result, resolve_writer_result = Eio.Promise.create () in
+  Eio.Fiber.fork ~sw (fun () ->
+    let result =
+      replace_capability_file_for_testing
+        ~before_stage:(function
+          | Fs_compat.Create_staging_directory ->
+            Eio.Promise.resolve resolve_writer_entered ();
+            Eio.Promise.await release_writer
+          | _ -> ())
+        ~recovery
+        ~allowed_root_path:directory
+        ~parent
+        ~leaf:"target"
+        ~permissions:0o640
+        "replacement"
+    in
+    Eio.Promise.resolve resolve_writer_result result);
+  Eio.Promise.await writer_entered;
+  (match
+     replace_capability_file
+       ~recovery
+       ~allowed_root_path:directory
+       ~parent
+       ~leaf:"target-alias"
+       ~permissions:0o640
+       "alias-replacement"
+   with
+   | Ok () -> fail "hard-link alias bypassed the existing-target lease"
+   | Error error ->
+     let failure = require_write_primary_failure error in
+     check bool "hard-link replace reports target identity contention" true
+       (failure.stage = Fs_compat.Acquire_mutation_lease
+        && failure.cause = Fs_compat.Mutation_contended));
+  check string "both names retain the old inode while paused" "old"
+    (read_file target_alias);
+  Eio.Promise.resolve resolve_release_writer ();
+  Eio.Promise.await writer_result |> require_ok;
+  require_ok
+    (replace_capability_file
+       ~recovery
+       ~allowed_root_path:directory
+       ~parent
+       ~leaf:"target-alias"
+       ~permissions:0o640
+       "alias-replacement");
+  check string "first replace publishes its payload" "replacement"
+    (read_file target);
+  check string "released inode lease permits the alias replace"
+    "alias-replacement"
+    (read_file target_alias)
+;;
+
+let test_replace_reobserves_binding_after_lease_acquisition ~fs () =
+  with_tmp_dir @@ fun directory ->
+  let target = Filename.concat directory "target" in
+  let displaced = Filename.concat directory "displaced" in
+  write_file target "old";
+  let swapped = ref false in
+  with_replace_context ~fs directory @@ fun parent recovery ->
+  (match
+     replace_capability_file_for_testing
+       ~before_stage:(function
+         | Fs_compat.Acquire_mutation_lease when not !swapped ->
+           swapped := true;
+           Unix.rename target displaced;
+           write_file target "external-replacement"
+         | _ -> ())
+       ~recovery
+       ~allowed_root_path:directory
+       ~parent
+       ~leaf:"target"
+       ~permissions:0o640
+       "writer-payload"
+   with
+   | Ok () -> fail "replace accepted a binding changed before lease acquisition"
+   | Error error ->
+     let failure = require_write_primary_failure error in
+     check bool "binding drift is explicit after lease acquisition" true
+       (failure.stage = Fs_compat.Inspect_target_entry
+        && failure.cause = Fs_compat.Resource_identity_changed);
+     check bool "writer reports no target mutation" true
+       (error.target_effect = Fs_compat.Target_unchanged));
+  check bool "test changed the binding at the acquisition boundary" true !swapped;
+  check string "new binding remains untouched" "external-replacement"
+    (read_file target);
+  check string "displaced preliminary inode remains untouched" "old"
+    (read_file displaced);
+  check (list string) "no staging state was created before binding validation"
+    [ "displaced"; "target" ]
+    (directory_entries directory);
+  require_ok
+    (replace_capability_file
+       ~recovery
+       ~allowed_root_path:directory
+       ~parent
+       ~leaf:"target"
+       ~permissions:0o640
+       "after-release");
+  check string "failed validation released its preliminary inode lease"
+    "after-release"
+    (read_file target)
+;;
+
+let test_existing_replace_reobserves_binding_at_publication ~fs () =
+  with_tmp_dir @@ fun directory ->
+  let target = Filename.concat directory "target" in
+  write_file target "old";
+  let unlinked = ref false in
+  with_replace_context ~fs directory @@ fun parent recovery ->
+  (match
+     replace_capability_file_for_testing
+       ~before_stage:(function
+         | Fs_compat.Acquire_publication_lease when not !unlinked ->
+           unlinked := true;
+           Unix.unlink target
+         | _ -> ())
+       ~recovery
+       ~allowed_root_path:directory
+       ~parent
+       ~leaf:"target"
+       ~permissions:0o640
+       "writer-payload"
+   with
+   | Ok () -> fail "existing replace republished over an externally unlinked target"
+   | Error error ->
+     let failure = require_write_primary_failure error in
+     check bool "final target reobservation reports exact binding drift" true
+       (failure.stage = Fs_compat.Verify_target_binding
+        && failure.cause = Fs_compat.Resource_identity_changed);
+     check bool "failed final validation reports no publication" true
+       (error.target_effect = Fs_compat.Target_unchanged));
+  check bool "test removed the target before the publication guard" true
+    !unlinked;
+  check bool "old replace did not recreate the unlinked name" false
+    (Sys.file_exists target);
+  check (list string) "failed publication cleaned its staging state" []
+    (directory_entries directory);
+  require_ok
+    (Fs_compat.create_capability_file_exclusive
+       ~parent
+       ~leaf:"target"
+       ~permissions:0o640
+       "after-release");
+  check string "publication guard releases after final validation failure"
+    "after-release"
+    (read_file target)
+;;
+
+let test_existing_replace_yields_to_cooperative_absent_publication ~fs () =
+  with_tmp_dir @@ fun directory ->
+  let target = Filename.concat directory "target" in
+  write_file target "old";
+  with_replace_context ~fs directory @@ fun parent recovery ->
+  Eio.Switch.run @@ fun sw ->
+  let stale_at_guard, resolve_stale_at_guard = Eio.Promise.create () in
+  let release_stale_guard, resolve_release_stale_guard = Eio.Promise.create () in
+  let stale_result, resolve_stale_result = Eio.Promise.create () in
+  Eio.Fiber.fork ~sw (fun () ->
+    let result =
+      replace_capability_file_for_testing
+        ~before_stage:(function
+          | Fs_compat.Acquire_publication_lease ->
+            Eio.Promise.resolve resolve_stale_at_guard ();
+            Eio.Promise.await release_stale_guard
+          | _ -> ())
+        ~recovery
+        ~allowed_root_path:directory
+        ~parent
+        ~leaf:"target"
+        ~permissions:0o640
+        "stale-replacement"
+    in
+    Eio.Promise.resolve resolve_stale_result result);
+  Eio.Promise.await stale_at_guard;
+  Unix.unlink target;
+  let create_visible, resolve_create_visible = Eio.Promise.create () in
+  let release_create, resolve_release_create = Eio.Promise.create () in
+  let create_result, resolve_create_result = Eio.Promise.create () in
+  Eio.Fiber.fork ~sw (fun () ->
+    let result =
+      Fs_compat.Capability_write_for_testing.create_capability_file_exclusive
+        ~before_stage:(function
+          | Fs_compat.Inspect_open_resource ->
+            Eio.Promise.resolve resolve_create_visible ();
+            Eio.Promise.await release_create
+          | _ -> ())
+        ~parent
+        ~leaf:"target"
+        ~permissions:0o640
+        "cooperative-publication"
+    in
+    Eio.Promise.resolve resolve_create_result result);
+  Eio.Promise.await create_visible;
+  Eio.Promise.resolve resolve_release_stale_guard ();
+  (match Eio.Promise.await stale_result with
+   | Ok () -> fail "stale replace crossed a cooperative absent publication"
+   | Error error ->
+     let failure = require_write_primary_failure error in
+     check bool "stale replace reports short publication contention" true
+       (failure.stage = Fs_compat.Acquire_publication_lease
+        && failure.cause = Fs_compat.Mutation_contended);
+     check bool "stale replace reports no target effect" true
+       (error.target_effect = Fs_compat.Target_unchanged));
+  Eio.Promise.resolve resolve_release_create ();
+  Eio.Promise.await create_result |> require_ok;
+  check string "cooperative absent writer retains the public target"
+    "cooperative-publication"
+    (read_file target);
+  check (list string) "stale writer cleaned its private staging state"
+    [ "target" ]
+    (directory_entries directory)
+;;
+
+let test_absent_replace_reobserves_binding_at_publication ~fs () =
+  with_tmp_dir @@ fun directory ->
+  let target = Filename.concat directory "target" in
+  let inserted = ref false in
+  with_replace_context ~fs directory @@ fun parent recovery ->
+  (match
+     replace_capability_file_for_testing
+       ~before_stage:(function
+         | Fs_compat.Verify_target_binding when not !inserted ->
+           inserted := true;
+           write_file target "external"
+         | _ -> ())
+       ~recovery
+       ~allowed_root_path:directory
+       ~parent
+       ~leaf:"target"
+       ~permissions:0o640
+       "writer-payload"
+   with
+   | Ok () -> fail "absent replace overwrote a target inserted before publication"
+   | Error error ->
+     let failure = require_write_primary_failure error in
+     check bool "absent publication reobserves the exact target binding" true
+       (failure.stage = Fs_compat.Verify_target_binding
+        && failure.cause = Fs_compat.Resource_identity_changed);
+     check bool "inserted target remains outside writer effects" true
+       (error.target_effect = Fs_compat.Target_unchanged));
+  check bool "test inserted the target at final observation" true !inserted;
+  check string "external target is not overwritten" "external"
+    (read_file target);
+  check (list string) "failed absent publication cleans staging" [ "target" ]
+    (directory_entries directory)
+;;
+
+let test_existing_publication_guard_blocks_absent_sibling ~fs () =
+  with_tmp_dir @@ fun directory ->
+  let target = Filename.concat directory "target" in
+  let sibling = Filename.concat directory "sibling" in
+  write_file target "old";
+  with_replace_context ~fs directory @@ fun parent recovery ->
+  Eio.Switch.run @@ fun sw ->
+  let guard_held, resolve_guard_held = Eio.Promise.create () in
+  let release_guard, resolve_release_guard = Eio.Promise.create () in
+  let writer_result, resolve_writer_result = Eio.Promise.create () in
+  Eio.Fiber.fork ~sw (fun () ->
+    let result =
+      replace_capability_file_for_testing
+        ~before_stage:(function
+          | Fs_compat.Verify_target_binding ->
+            Eio.Promise.resolve resolve_guard_held ();
+            Eio.Promise.await release_guard
+          | _ -> ())
+        ~recovery
+        ~allowed_root_path:directory
+        ~parent
+        ~leaf:"target"
+        ~permissions:0o640
+        "replacement"
+    in
+    Eio.Promise.resolve resolve_writer_result result);
+  Eio.Promise.await guard_held;
+  (match
+     Fs_compat.create_capability_file_exclusive
+       ~parent
+       ~leaf:"sibling"
+       ~permissions:0o640
+       "sibling"
+   with
+   | Ok () -> fail "absent sibling crossed an active publication guard"
+   | Error error ->
+     let failure = require_write_primary_failure error in
+     check bool "short publication guard reports parent contention" true
+       (failure.stage = Fs_compat.Acquire_mutation_lease
+        && failure.cause = Fs_compat.Mutation_contended));
+  check bool "contended sibling remains absent" false
+    (Sys.file_exists sibling);
+  Eio.Promise.resolve resolve_release_guard ();
+  Eio.Promise.await writer_result |> require_ok;
+  require_ok
+    (Fs_compat.create_capability_file_exclusive
+       ~parent
+       ~leaf:"sibling"
+       ~permissions:0o640
+       "sibling");
+  check string "publication completed after releasing the guard" "replacement"
+    (read_file target);
+  check string "absent sibling proceeds after the short guard" "sibling"
+    (read_file sibling)
+;;
+
+let test_absent_replace_blocks_visible_and_absent_sibling_mutations ~fs () =
+  with_tmp_dir @@ fun directory ->
+  let target = Filename.concat directory "target" in
+  let sibling = Filename.concat directory "sibling" in
+  with_replace_context ~fs directory @@ fun parent recovery ->
+  Eio.Switch.run @@ fun sw ->
+  let published, resolve_published = Eio.Promise.create () in
+  let release_writer, resolve_release_writer = Eio.Promise.create () in
+  let writer_result, resolve_writer_result = Eio.Promise.create () in
+  Eio.Fiber.fork ~sw (fun () ->
+    let result =
+      replace_capability_file_for_testing
+        ~before_stage:(function
+          | Fs_compat.Sync_staging_directory ->
+            Eio.Promise.resolve resolve_published ();
+            Eio.Promise.await release_writer
+          | _ -> ())
+        ~recovery
+        ~allowed_root_path:directory
+        ~parent
+        ~leaf:"target"
+        ~permissions:0o640
+        "replacement"
+    in
+    Eio.Promise.resolve resolve_writer_result result);
+  Eio.Promise.await published;
+  check string "absent replace has published before the pause" "replacement"
+    (read_file target);
+  let append_outcome =
+    Eio.Switch.run @@ fun append_sw ->
+    let file =
+      Fs_compat.open_capability_append_file
+        ~sw:append_sw
+        ~parent
+        ~leaf:"target"
+      |> require_append_file
+    in
+    Fs_compat.append_capability_observed file "append"
+  in
+  check bool "published inode remains covered by the absent-parent lease" true
+    (append_outcome.write_failure
+     = Some Fs_compat.Capability_append_mutation_contended);
+  (match
+     replace_capability_file
+       ~recovery
+       ~allowed_root_path:directory
+       ~parent
+       ~leaf:"target"
+       ~permissions:0o640
+       "contending-replace"
+   with
+   | Ok () -> fail "published absent replace admitted an existing-target replace"
+   | Error error ->
+     let failure = require_write_primary_failure error in
+     check bool "published target replace reports parent transition contention"
+       true
+       (failure.stage = Fs_compat.Acquire_mutation_lease
+        && failure.cause = Fs_compat.Mutation_contended));
+  (match
+     Fs_compat.create_capability_file_exclusive
+       ~parent
+       ~leaf:"sibling"
+       ~permissions:0o640
+       "sibling"
+   with
+   | Ok () -> fail "absent sibling bypassed the absent-parent lease"
+   | Error error ->
+     let failure = require_write_primary_failure error in
+     check bool "absent sibling reports the same parent contention" true
+       (failure.stage = Fs_compat.Acquire_mutation_lease
+        && failure.cause = Fs_compat.Mutation_contended));
+  check bool "contended absent sibling was not created" false
+    (Sys.file_exists sibling);
+  Eio.Promise.resolve resolve_release_writer ();
+  Eio.Promise.await writer_result |> require_ok;
+  require_ok
+    (Fs_compat.create_capability_file_exclusive
+       ~parent
+       ~leaf:"sibling"
+       ~permissions:0o640
+       "sibling");
+  check string "absent-parent lease releases after replace completion" "sibling"
+    (read_file sibling)
+;;
+
+let test_exclusive_create_visibility_remains_under_parent_lease ~fs () =
+  with_tmp_dir @@ fun directory ->
+  let target = Filename.concat directory "target" in
+  with_replace_context ~fs directory @@ fun parent recovery ->
+  Eio.Switch.run @@ fun sw ->
+  let target_visible, resolve_target_visible = Eio.Promise.create () in
+  let release_create, resolve_release_create = Eio.Promise.create () in
+  let create_result, resolve_create_result = Eio.Promise.create () in
+  Eio.Fiber.fork ~sw (fun () ->
+    let result =
+      Fs_compat.Capability_write_for_testing.create_capability_file_exclusive
+        ~before_stage:(function
+          | Fs_compat.Inspect_open_resource ->
+            Eio.Promise.resolve resolve_target_visible ();
+            Eio.Promise.await release_create
+          | _ -> ())
+        ~parent
+        ~leaf:"target"
+        ~permissions:0o640
+        "created"
+    in
+    Eio.Promise.resolve resolve_create_result result);
+  Eio.Promise.await target_visible;
+  check bool "exclusive target is visible before payload write" true
+    (Sys.file_exists target);
+  let append_outcome =
+    Eio.Switch.run @@ fun append_sw ->
+    let file =
+      Fs_compat.open_capability_append_file
+        ~sw:append_sw
+        ~parent
+        ~leaf:"target"
+      |> require_append_file
+    in
+    Fs_compat.append_capability_observed file "append"
+  in
+  check bool "append cannot enter the visible incomplete create" true
+    (append_outcome.write_failure
+     = Some Fs_compat.Capability_append_mutation_contended);
+  (match
+     replace_capability_file
+       ~recovery
+       ~allowed_root_path:directory
+       ~parent
+       ~leaf:"target"
+       ~permissions:0o640
+       "replacement"
+   with
+   | Ok () -> fail "replace entered a visible incomplete exclusive create"
+   | Error error ->
+     let failure = require_write_primary_failure error in
+     check bool "replace reports the create transition contention" true
+       (failure.stage = Fs_compat.Acquire_mutation_lease
+        && failure.cause = Fs_compat.Mutation_contended));
+  Eio.Promise.resolve resolve_release_create ();
+  Eio.Promise.await create_result |> require_ok;
+  check string "exclusive creator completes without interleaved mutation"
+    "created"
+    (read_file target)
+;;
+
+let test_existing_target_lease_allows_absent_sibling_progress ~fs () =
+  with_tmp_dir @@ fun directory ->
+  let target = Filename.concat directory "target" in
+  let sibling = Filename.concat directory "sibling" in
+  let replacement_sibling = Filename.concat directory "replacement-sibling" in
+  write_file target "old";
+  with_replace_context ~fs directory @@ fun parent recovery ->
+  Eio.Switch.run @@ fun sw ->
+  let writer_entered, resolve_writer_entered = Eio.Promise.create () in
+  let release_writer, resolve_release_writer = Eio.Promise.create () in
+  let writer_result, resolve_writer_result = Eio.Promise.create () in
+  Eio.Fiber.fork ~sw (fun () ->
+    let result =
+      replace_capability_file_for_testing
+        ~before_stage:(function
+          | Fs_compat.Create_staging_directory ->
+            Eio.Promise.resolve resolve_writer_entered ();
+            Eio.Promise.await release_writer
+          | _ -> ())
+        ~recovery
+        ~allowed_root_path:directory
+        ~parent
+        ~leaf:"target"
+        ~permissions:0o640
+        "replacement"
+    in
+    Eio.Promise.resolve resolve_writer_result result);
+  Eio.Promise.await writer_entered;
+  require_ok
+    (Fs_compat.create_capability_file_exclusive
+       ~parent
+       ~leaf:"sibling"
+       ~permissions:0o640
+       "sibling");
+  require_ok
+    (replace_capability_file
+       ~recovery
+       ~allowed_root_path:directory
+       ~parent
+       ~leaf:"replacement-sibling"
+       ~permissions:0o640
+       "replacement-sibling");
+  check string "exclusive create progresses beside existing target mutation"
+    "sibling"
+    (read_file sibling);
+  check string "absent replace progresses beside existing target mutation"
+    "replacement-sibling"
+    (read_file replacement_sibling);
+  check string "paused existing target remains unchanged" "old"
+    (read_file target);
+  Eio.Promise.resolve resolve_release_writer ();
+  Eio.Promise.await writer_result |> require_ok;
+  check string "existing target completes after sibling publications"
+    "replacement"
     (read_file target)
 ;;
 
@@ -305,7 +971,7 @@ let test_append_lease_blocks_replace_then_releases ~fs () =
   with_tmp_dir @@ fun directory ->
   let target = Filename.concat directory "target" in
   write_file target "old";
-  with_parent_capability ~fs directory @@ fun parent ->
+  with_replace_context ~fs directory @@ fun parent recovery ->
   Eio.Switch.run @@ fun sw ->
   let file =
     Fs_compat.open_capability_append_file ~sw ~parent ~leaf:"target"
@@ -326,18 +992,20 @@ let test_append_lease_blocks_replace_then_releases ~fs () =
     Eio.Promise.resolve resolve_append_result outcome);
   Eio.Promise.await append_entered;
   (match
-     Fs_compat.publish_capability_file
+     replace_capability_file
+       ~recovery
+       ~allowed_root_path:directory
        ~parent
        ~leaf:"target"
-       ~intent:Fs_compat.Atomic_replace
        ~permissions:0o640
        "replacement"
    with
    | Ok () -> fail "replace bypassed the append entry lease"
    | Error error ->
+     let failure = require_write_primary_failure error in
      check bool "replace reports immediate entry contention" true
-       (error.failure.stage = Fs_compat.Acquire_mutation_lease
-        && error.failure.cause = Fs_compat.Mutation_contended));
+       (failure.stage = Fs_compat.Acquire_mutation_lease
+        && failure.cause = Fs_compat.Mutation_contended));
   check string "append bytes remain visible while its lease is held"
     "old-append"
     (read_file target);
@@ -346,10 +1014,11 @@ let test_append_lease_blocks_replace_then_releases ~fs () =
   check bool "append completes on the pinned target" true
     (append_outcome.target_binding = Fs_compat.Capability_append_target_verified);
   require_ok
-    (Fs_compat.publish_capability_file
+    (replace_capability_file
+       ~recovery
+       ~allowed_root_path:directory
        ~parent
        ~leaf:"target"
-       ~intent:Fs_compat.Atomic_replace
        ~permissions:0o640
        "replacement");
   check string "replace succeeds after append releases the lease"
@@ -363,42 +1032,46 @@ let test_independent_targets_progress_without_global_io_serialization ~fs () =
   let target_b = Filename.concat directory "target-b" in
   write_file target_a "old-a";
   write_file target_b "old-b";
-  with_parent_capability ~fs directory @@ fun parent ->
+  with_replace_context ~fs directory @@ fun parent recovery ->
   Eio.Switch.run @@ fun sw ->
   let writer_a_entered, resolve_writer_a_entered = Eio.Promise.create () in
   let release_writer_a, resolve_release_writer_a = Eio.Promise.create () in
   let writer_a_result, resolve_writer_a_result = Eio.Promise.create () in
   Eio.Fiber.fork ~sw (fun () ->
     let result =
-      Fs_compat.Capability_write_for_testing.publish_capability_file
+      replace_capability_file_for_testing
         ~before_stage:(function
           | Fs_compat.Create_staging_directory ->
             Eio.Promise.resolve resolve_writer_a_entered ();
             Eio.Promise.await release_writer_a
           | _ -> ())
+        ~recovery
+        ~allowed_root_path:directory
         ~parent
         ~leaf:"target-a"
-        ~intent:Fs_compat.Atomic_replace
         ~permissions:0o640
         "new-a"
     in
     Eio.Promise.resolve resolve_writer_a_result result);
   Eio.Promise.await writer_a_entered;
-  require_ok
-    (Fs_compat.publish_capability_file
+  let writer_b_result =
+    replace_capability_file
+       ~recovery
+       ~allowed_root_path:directory
        ~parent
        ~leaf:"target-b"
-       ~intent:Fs_compat.Atomic_replace
        ~permissions:0o640
-       "new-b");
-  check string "independent target completes while target A is paused"
-    "new-b"
-    (read_file target_b);
+       "new-b"
+  in
+  let target_b_while_a_paused = read_file target_b in
   check string "paused target remains unchanged" "old-a" (read_file target_a);
   Eio.Promise.resolve resolve_release_writer_a ();
-  (match Eio.Promise.await writer_a_result with
-   | Ok () -> ()
-   | Error error -> fail (Fs_compat.capability_write_error_to_string error));
+  let writer_a_result = Eio.Promise.await writer_a_result in
+  require_ok writer_b_result;
+  require_ok writer_a_result;
+  check string "independent target completes while target A is paused"
+    "new-b"
+    target_b_while_a_paused;
   check string "paused target completes after release" "new-a"
     (read_file target_a)
 ;;
@@ -409,17 +1082,17 @@ let test_create_exclusive_does_not_overwrite ~fs () =
   write_file target "existing";
   with_parent_capability ~fs directory @@ fun parent ->
   (match
-     Fs_compat.publish_capability_file
+     Fs_compat.create_capability_file_exclusive
        ~parent
        ~leaf:"target"
-       ~intent:Fs_compat.Create_exclusive
        ~permissions:0o644
        "new"
    with
    | Ok () -> fail "exclusive create overwrote an existing entry"
    | Error error ->
+     let failure = require_write_primary_failure error in
      check bool "failure is create stage" true
-       (error.failure.stage = Fs_compat.Create_target_entry);
+       (failure.stage = Fs_compat.Create_target_entry);
      check bool "target is known unchanged" true
        (error.target_effect = Fs_compat.Target_unchanged));
   check string "existing payload retained" "existing" (read_file target)
@@ -430,10 +1103,9 @@ let test_create_exclusive_success ~fs () =
   let target = Filename.concat directory "target" in
   with_parent_capability ~fs directory @@ fun parent ->
   require_ok
-    (Fs_compat.publish_capability_file
+    (Fs_compat.create_capability_file_exclusive
        ~parent
        ~leaf:"target"
-       ~intent:Fs_compat.Create_exclusive
        ~permissions:0o640
        "created");
   check string "payload created" "created" (read_file target);
@@ -445,13 +1117,12 @@ let test_create_failure_leaves_public_leaf ~fs () =
   let target = Filename.concat directory "target" in
   with_parent_capability ~fs directory @@ fun parent ->
   (match
-     Fs_compat.Capability_write_for_testing.publish_capability_file
+     Fs_compat.Capability_write_for_testing.create_capability_file_exclusive
        ~before_stage:(function
          | Fs_compat.Apply_permissions -> raise Exit
          | _ -> ())
        ~parent
        ~leaf:"target"
-       ~intent:Fs_compat.Create_exclusive
        ~permissions:0o644
        "partial"
    with
@@ -470,20 +1141,20 @@ let test_create_parent_sync_failure_preserves_complete_effect ~fs () =
   let target = Filename.concat directory "target" in
   with_parent_capability ~fs directory @@ fun parent ->
   (match
-     Fs_compat.Capability_write_for_testing.publish_capability_file
+     Fs_compat.Capability_write_for_testing.create_capability_file_exclusive
        ~before_stage:(function
          | Fs_compat.Sync_parent -> raise Exit
          | _ -> ())
        ~parent
        ~leaf:"target"
-       ~intent:Fs_compat.Create_exclusive
        ~permissions:0o640
        "complete"
    with
    | Ok () -> fail "fault-injected parent sync unexpectedly succeeded"
    | Error error ->
+     let failure = require_write_primary_failure error in
      check bool "failure remains parent sync" true
-       (error.failure.stage = Fs_compat.Sync_parent);
+       (failure.stage = Fs_compat.Sync_parent);
      check bool "lexical target is complete" true
        (error.target_effect = Fs_compat.Target_created));
   check string "complete payload is inspectable" "complete" (read_file target);
@@ -495,22 +1166,24 @@ let test_parent_fsync_failure_is_not_success ~fs () =
   with_tmp_dir @@ fun directory ->
   let target = Filename.concat directory "target" in
   write_file target "old";
-  with_parent_capability ~fs directory @@ fun parent ->
+  with_replace_context ~fs directory @@ fun parent recovery ->
   (match
-     Fs_compat.Capability_write_for_testing.publish_capability_file
+     replace_capability_file_for_testing
        ~before_stage:(function
          | Fs_compat.Sync_parent -> raise Exit
          | _ -> ())
+       ~recovery
+       ~allowed_root_path:directory
        ~parent
        ~leaf:"target"
-       ~intent:Fs_compat.Atomic_replace
        ~permissions:0o644
        "new"
    with
    | Ok () -> fail "parent fsync failure was downgraded to success"
    | Error error ->
+     let failure = require_write_primary_failure error in
      check bool "exact failure stage" true
-       (error.failure.stage = Fs_compat.Sync_parent);
+       (failure.stage = Fs_compat.Sync_parent);
      check bool "rename effect retained" true
        (error.target_effect = Fs_compat.Target_replaced));
   check string "rename completed before fsync failure" "new" (read_file target)
@@ -518,27 +1191,26 @@ let test_parent_fsync_failure_is_not_success ~fs () =
 
 let test_primary_and_cleanup_failures_are_preserved ~fs () =
   with_tmp_dir @@ fun directory ->
-  with_parent_capability ~fs directory @@ fun parent ->
+  with_replace_context ~fs directory @@ fun parent recovery ->
   (match
-     Fs_compat.Capability_write_for_testing.publish_capability_file
+     replace_capability_file_for_testing
        ~before_stage:(function
          | Fs_compat.Write_payload | Fs_compat.Cleanup_unlink -> raise Exit
          | _ -> ())
+       ~recovery
+       ~allowed_root_path:directory
        ~parent
        ~leaf:"target"
-       ~intent:Fs_compat.Atomic_replace
        ~permissions:0o644
        "payload"
    with
    | Ok () -> fail "fault-injected write unexpectedly succeeded"
    | Error error ->
+     let failure = require_write_primary_failure error in
      check bool "primary write stage retained" true
-       (error.failure.stage = Fs_compat.Write_payload);
+       (failure.stage = Fs_compat.Write_payload);
      check bool "cleanup failure retained" true
-       (List.exists
-          (fun (failure : Fs_compat.capability_write_failure) ->
-            failure.stage = Fs_compat.Cleanup_unlink)
-          error.cleanup_failures));
+       (has_write_cleanup_stage Fs_compat.Cleanup_unlink error));
   let entries = directory_entries directory in
   check int "fault injection left one observable staging directory" 1
     (List.length entries);
@@ -546,24 +1218,109 @@ let test_primary_and_cleanup_failures_are_preserved ~fs () =
     (Sys.is_directory (Filename.concat directory (List.hd entries)))
 ;;
 
-let test_precommit_cancellation_cleans_staging ~fs () =
+let test_replace_primary_failure_survives_cleanup_cancellation ~fs () =
   with_tmp_dir @@ fun directory ->
-  let target = Filename.concat directory "target" in
-  write_file target "old";
-  with_parent_capability ~fs directory @@ fun parent ->
-  let cancelled =
+  with_replace_context ~fs directory @@ fun parent recovery ->
+  let cancellation =
     try
       Eio.Cancel.sub (fun context ->
         ignore
-          (Fs_compat.Capability_write_for_testing.publish_capability_file
+          (replace_capability_file_for_testing
              ~before_stage:(function
-               | Fs_compat.Write_payload ->
+               | Fs_compat.Write_payload -> raise Exit
+               | Fs_compat.Cleanup_close ->
+                 Eio.Cancel.cancel context Exit;
+                 Eio.Fiber.check ()
+               | _ -> ())
+             ~recovery
+             ~allowed_root_path:directory
+             ~parent
+             ~leaf:"target"
+             ~permissions:0o644
+             "payload"
+           : (unit, Fs_compat.capability_write_error) result));
+      None
+    with
+    | Eio.Cancel.Cancelled
+        (Fs_compat.Capability_write_cancelled (_, cancellation)) ->
+      Some cancellation
+    | Eio.Cancel.Cancelled _ ->
+      fail "replace cleanup cancellation lost the interrupted write failure"
+  in
+  match cancellation with
+  | None -> fail "replace cleanup cancellation was swallowed"
+  | Some cancellation ->
+    (match cancellation.interrupted_primary_failure with
+     | Some (Fs_compat.Write_primary_failure failure) ->
+       check bool "replace interrupted primary stage" true
+         (failure.stage = Fs_compat.Write_payload)
+     | Some (Fs_compat.Recovery_primary_failure failure) ->
+       fail (Fs_compat.capability_recovery_failure_to_string failure)
+     | Some (Fs_compat.Recovery_access_primary_failure _) ->
+       fail "replace reported recovery access as the interrupted primary"
+     | None -> fail "replace omitted the interrupted write failure")
+;;
+
+let test_create_primary_failure_survives_cleanup_cancellation ~fs () =
+  with_tmp_dir @@ fun directory ->
+  with_parent_capability ~fs directory @@ fun parent ->
+  let cancellation =
+    try
+      Eio.Cancel.sub (fun context ->
+        ignore
+          (Fs_compat.Capability_write_for_testing.create_capability_file_exclusive
+             ~before_stage:(function
+               | Fs_compat.Write_payload -> raise Exit
+               | Fs_compat.Cleanup_close ->
                  Eio.Cancel.cancel context Exit;
                  Eio.Fiber.check ()
                | _ -> ())
              ~parent
              ~leaf:"target"
-             ~intent:Fs_compat.Atomic_replace
+             ~permissions:0o644
+             "payload"
+           : (unit, Fs_compat.capability_write_error) result));
+      None
+    with
+    | Eio.Cancel.Cancelled
+        (Fs_compat.Capability_write_cancelled (_, cancellation)) ->
+      Some cancellation
+    | Eio.Cancel.Cancelled _ ->
+      fail "create cleanup cancellation lost the interrupted write failure"
+  in
+  match cancellation with
+  | None -> fail "create cleanup cancellation was swallowed"
+  | Some cancellation ->
+    (match cancellation.interrupted_primary_failure with
+     | Some (Fs_compat.Write_primary_failure failure) ->
+       check bool "create interrupted primary stage" true
+         (failure.stage = Fs_compat.Write_payload)
+     | Some (Fs_compat.Recovery_primary_failure failure) ->
+       fail (Fs_compat.capability_recovery_failure_to_string failure)
+     | Some (Fs_compat.Recovery_access_primary_failure _) ->
+       fail "create reported recovery access as the interrupted primary"
+     | None -> fail "create omitted the interrupted write failure")
+;;
+
+let test_precommit_cancellation_cleans_staging ~fs () =
+  with_tmp_dir @@ fun directory ->
+  let target = Filename.concat directory "target" in
+  write_file target "old";
+  with_replace_context ~fs directory @@ fun parent recovery ->
+  let cancelled =
+    try
+      Eio.Cancel.sub (fun context ->
+        ignore
+          (replace_capability_file_for_testing
+             ~before_stage:(function
+               | Fs_compat.Write_payload ->
+                 Eio.Cancel.cancel context Exit;
+                 Eio.Fiber.check ()
+               | _ -> ())
+             ~recovery
+             ~allowed_root_path:directory
+             ~parent
+             ~leaf:"target"
              ~permissions:0o644
              "new"
            : (unit, Fs_compat.capability_write_error) result));
@@ -581,18 +1338,19 @@ let test_pending_payload_sync_cancellation_does_not_publish ~fs () =
   with_tmp_dir @@ fun directory ->
   let target = Filename.concat directory "target" in
   write_file target "old";
-  with_parent_capability ~fs directory @@ fun parent ->
+  with_replace_context ~fs directory @@ fun parent recovery ->
   let cancelled =
     try
       Eio.Cancel.sub (fun context ->
         ignore
-          (Fs_compat.Capability_write_for_testing.publish_capability_file
+          (replace_capability_file_for_testing
              ~before_stage:(function
                | Fs_compat.Close_payload -> Eio.Cancel.cancel context Exit
                | _ -> ())
+             ~recovery
+             ~allowed_root_path:directory
              ~parent
              ~leaf:"target"
-             ~intent:Fs_compat.Atomic_replace
              ~permissions:0o644
              "new"
            : (unit, Fs_compat.capability_write_error) result));
@@ -609,9 +1367,9 @@ let test_pending_payload_sync_cancellation_does_not_publish ~fs () =
 let test_cleanup_identity_failure_never_unlinks_unknown_payload ~fs () =
   with_tmp_dir @@ fun directory ->
   let swapped_payload = ref None in
-  with_parent_capability ~fs directory @@ fun parent ->
+  with_replace_context ~fs directory @@ fun parent recovery ->
   (match
-     Fs_compat.Capability_write_for_testing.publish_capability_file
+     replace_capability_file_for_testing
        ~before_stage:(function
          | Fs_compat.Write_payload -> raise Exit
          | Fs_compat.Cleanup_verify_identity ->
@@ -622,9 +1380,10 @@ let test_cleanup_identity_failure_never_unlinks_unknown_payload ~fs () =
            write_file payload "replacement";
            swapped_payload := Some payload
          | _ -> ())
+       ~recovery
+       ~allowed_root_path:directory
        ~parent
        ~leaf:"target"
-       ~intent:Fs_compat.Atomic_replace
        ~permissions:0o644
        "new"
    with
@@ -632,9 +1391,11 @@ let test_cleanup_identity_failure_never_unlinks_unknown_payload ~fs () =
    | Error error ->
      check bool "identity drift retained as cleanup failure" true
        (List.exists
-          (fun (failure : Fs_compat.capability_write_failure) ->
-            failure.stage = Fs_compat.Cleanup_verify_identity
-            && failure.cause = Fs_compat.Resource_identity_changed)
+          (function
+            | Fs_compat.Write_cleanup_failure failure ->
+              failure.stage = Fs_compat.Cleanup_verify_identity
+              && failure.cause = Fs_compat.Resource_identity_changed
+            | Fs_compat.Recovery_cleanup_failure _ -> false)
           error.cleanup_failures);
      check bool "unknown payload was not unlinked" true
        (Option.fold ~none:false ~some:Sys.file_exists !swapped_payload));
@@ -646,11 +1407,11 @@ let test_exclusive_create_cancellation_reports_incomplete_entry ~fs () =
   with_tmp_dir @@ fun directory ->
   let target = Filename.concat directory "target" in
   with_parent_capability ~fs directory @@ fun parent ->
-  let observed_effect =
+  let cancellation =
     try
       Eio.Cancel.sub (fun context ->
         ignore
-          (Fs_compat.Capability_write_for_testing.publish_capability_file
+          (Fs_compat.Capability_write_for_testing.create_capability_file_exclusive
              ~before_stage:(function
                | Fs_compat.Apply_permissions ->
                  Eio.Cancel.cancel context Exit;
@@ -658,7 +1419,6 @@ let test_exclusive_create_cancellation_reports_incomplete_entry ~fs () =
                | _ -> ())
              ~parent
              ~leaf:"target"
-             ~intent:Fs_compat.Create_exclusive
              ~permissions:0o644
              "partial"
            : (unit, Fs_compat.capability_write_error) result));
@@ -666,13 +1426,24 @@ let test_exclusive_create_cancellation_reports_incomplete_entry ~fs () =
     with
     | Eio.Cancel.Cancelled
         (Fs_compat.Capability_write_cancelled (_, cancellation)) ->
-      Some cancellation.target_effect
+      Some cancellation
     | Eio.Cancel.Cancelled _ -> fail "typed create cancellation state was lost"
   in
   check (option bool) "incomplete creation effect observed" (Some true)
     (Option.map
-       (fun target_effect -> target_effect = Fs_compat.Target_created_incomplete)
-       observed_effect);
+       (fun (cancellation : Fs_compat.capability_write_cancellation) ->
+          cancellation.target_effect = Fs_compat.Target_created_incomplete)
+       cancellation);
+  check (option bool) "create operation retained" (Some true)
+    (Option.map
+       (fun (cancellation : Fs_compat.capability_write_cancellation) ->
+          cancellation.operation = Fs_compat.Create_exclusive_operation)
+       cancellation);
+  check (option bool) "no primary failure was interrupted" (Some true)
+    (Option.map
+       (fun (cancellation : Fs_compat.capability_write_cancellation) ->
+          Option.is_none cancellation.interrupted_primary_failure)
+       cancellation);
   check bool "incomplete public leaf retained" true (Sys.file_exists target);
   check string "written content remains inspectable" "partial" (read_file target)
 ;;
@@ -681,26 +1452,44 @@ let test_commit_cancellation_finishes_durable_replace ~fs () =
   with_tmp_dir @@ fun directory ->
   let target = Filename.concat directory "target" in
   write_file target "old";
-  with_parent_capability ~fs directory @@ fun parent ->
-  let cancelled =
+  with_replace_context ~fs directory @@ fun parent recovery ->
+  let cancellation =
     try
       Eio.Cancel.sub (fun context ->
         ignore
-          (Fs_compat.Capability_write_for_testing.publish_capability_file
+          (replace_capability_file_for_testing
              ~before_stage:(function
                | Fs_compat.Publish_replace -> Eio.Cancel.cancel context Exit
                | _ -> ())
+             ~recovery
+             ~allowed_root_path:directory
              ~parent
              ~leaf:"target"
-             ~intent:Fs_compat.Atomic_replace
              ~permissions:0o644
              "new"
            : (unit, Fs_compat.capability_write_error) result));
-      false
+      None
     with
-    | Eio.Cancel.Cancelled _ -> true
+    | Eio.Cancel.Cancelled
+        (Fs_compat.Capability_write_cancelled (_, cancellation)) ->
+      Some cancellation
+    | Eio.Cancel.Cancelled _ -> fail "typed replace commit state was lost"
   in
-  check bool "cancellation propagated after commit" true cancelled;
+  check (option bool) "replace effect retained after cancellation" (Some true)
+    (Option.map
+       (fun (cancellation : Fs_compat.capability_write_cancellation) ->
+          cancellation.target_effect = Fs_compat.Target_replaced)
+       cancellation);
+  check (option bool) "replace operation retained" (Some true)
+    (Option.map
+       (fun (cancellation : Fs_compat.capability_write_cancellation) ->
+          cancellation.operation = Fs_compat.Atomic_replace_operation)
+       cancellation);
+  check (option bool) "no write primary was interrupted" (Some true)
+    (Option.map
+       (fun (cancellation : Fs_compat.capability_write_cancellation) ->
+          Option.is_none cancellation.interrupted_primary_failure)
+       cancellation);
   check string "protected replace completed" "new" (read_file target);
   check (list string) "no staging orphan" [ "target" ]
     (directory_entries directory)
@@ -710,17 +1499,16 @@ let test_create_commit_cancellation_reports_complete_effect ~fs () =
   with_tmp_dir @@ fun directory ->
   let target = Filename.concat directory "target" in
   with_parent_capability ~fs directory @@ fun parent ->
-  let observed_effect =
+  let cancellation =
     try
       Eio.Cancel.sub (fun context ->
         ignore
-          (Fs_compat.Capability_write_for_testing.publish_capability_file
+          (Fs_compat.Capability_write_for_testing.create_capability_file_exclusive
              ~before_stage:(function
                | Fs_compat.Sync_parent -> Eio.Cancel.cancel context Exit
                | _ -> ())
              ~parent
              ~leaf:"target"
-             ~intent:Fs_compat.Create_exclusive
              ~permissions:0o640
              "complete"
            : (unit, Fs_compat.capability_write_error) result));
@@ -728,40 +1516,214 @@ let test_create_commit_cancellation_reports_complete_effect ~fs () =
     with
     | Eio.Cancel.Cancelled
         (Fs_compat.Capability_write_cancelled (_, cancellation)) ->
-      Some cancellation.target_effect
+      Some cancellation
     | Eio.Cancel.Cancelled _ -> fail "typed create commit state was lost"
   in
   check (option bool) "complete creation effect observed" (Some true)
     (Option.map
-       (fun target_effect -> target_effect = Fs_compat.Target_created)
-       observed_effect);
+       (fun (cancellation : Fs_compat.capability_write_cancellation) ->
+          cancellation.target_effect = Fs_compat.Target_created)
+       cancellation);
+  check (option bool) "create operation retained" (Some true)
+    (Option.map
+       (fun (cancellation : Fs_compat.capability_write_cancellation) ->
+          cancellation.operation = Fs_compat.Create_exclusive_operation)
+       cancellation);
+  check (option bool) "no primary failure was interrupted" (Some true)
+    (Option.map
+       (fun (cancellation : Fs_compat.capability_write_cancellation) ->
+          Option.is_none cancellation.interrupted_primary_failure)
+       cancellation);
   check string "protected create completed" "complete" (read_file target)
 ;;
 
-let test_rejects_non_leaf_path ~fs () =
+let test_split_writes_reject_non_leaf_path ~fs () =
   with_tmp_dir @@ fun directory ->
   with_parent_capability ~fs directory @@ fun parent ->
+  let root = Eio.Path.stat ~follow:true parent in
   let sibling = "escape-" ^ Filename.basename directory in
   let invalid_leaves =
     [ ""; "."; ".."; "nested/leaf"; "../" ^ sibling; Filename.concat directory "absolute" ]
   in
   List.iter
     (fun leaf ->
+      (match
+         Fs_compat.atomic_replace_recovery_target
+           ~allowed_root_path:directory
+           ~allowed_root_device:root.dev
+           ~allowed_root_inode:root.ino
+           ~parent_components:[]
+           ~target_leaf:leaf
+           ~permissions:0o644
+       with
+       | Ok _ -> failf "replace projection accepted non-leaf path: %S" leaf
+       | Error _ -> ());
       match
-        Fs_compat.publish_capability_file
+        Fs_compat.create_capability_file_exclusive
           ~parent
           ~leaf
-          ~intent:Fs_compat.Atomic_replace
           ~permissions:0o644
           "payload"
       with
-      | Ok () -> failf "non-leaf path was accepted: %S" leaf
+      | Ok () -> failf "exclusive create accepted non-leaf path: %S" leaf
       | Error error ->
+        let failure = require_write_primary_failure error in
         check bool ("validation stage for " ^ leaf) true
-          (error.failure.stage = Fs_compat.Validate_leaf))
+          (failure.stage = Fs_compat.Validate_leaf))
     invalid_leaves;
   check bool "unique outside entry absent" false
     (Sys.file_exists (Filename.concat (Filename.dirname directory) sibling))
+;;
+
+let test_replace_rejects_directory_and_fifo_targets ~fs () =
+  with_tmp_dir @@ fun directory ->
+  let directory_target = Filename.concat directory "directory-target" in
+  let fifo_target = Filename.concat directory "fifo-target" in
+  Unix.mkdir directory_target 0o700;
+  Unix.mkfifo fifo_target 0o600;
+  with_replace_context ~fs directory @@ fun parent recovery ->
+  List.iter
+    (fun (leaf, expected_kind) ->
+      match
+        replace_capability_file
+          ~recovery
+          ~allowed_root_path:directory
+          ~parent
+          ~leaf
+          ~permissions:0o640
+          "replacement"
+      with
+      | Ok () -> failf "replace accepted unsupported target kind: %s" leaf
+      | Error error ->
+        let failure = require_write_primary_failure error in
+        check bool (leaf ^ " rejected during target inspection") true
+          (failure.stage = Fs_compat.Inspect_target_entry);
+        check bool (leaf ^ " retains exact target kind") true
+          (failure.cause = Fs_compat.Unexpected_resource_kind expected_kind);
+        check bool (leaf ^ " remains unchanged") true
+          (error.target_effect = Fs_compat.Target_unchanged))
+    [ "directory-target", `Directory; "fifo-target", `Fifo ];
+  check bool "directory target remains a directory" true
+    (Sys.is_directory directory_target);
+  check bool "fifo target remains a fifo" true
+    ((Unix.lstat fifo_target).st_kind = Unix.S_FIFO)
+;;
+
+let test_recovery_transition_cancellation_is_typed ~fs () =
+  with_tmp_dir @@ fun directory ->
+  let target = Filename.concat directory "target" in
+  write_file target "old";
+  with_replace_context ~fs directory @@ fun parent recovery ->
+  let cancellation =
+    try
+      Eio.Cancel.sub (fun context ->
+        ignore
+          (replace_capability_file_for_testing
+             ~before_stage:(function
+               | Fs_compat.Prepare_recovery_obligation ->
+                 Eio.Cancel.cancel context Exit;
+                 Eio.Fiber.check ()
+               | _ -> ())
+             ~recovery
+             ~allowed_root_path:directory
+             ~parent
+             ~leaf:"target"
+             ~permissions:0o640
+             "new"
+           : (unit, Fs_compat.capability_write_error) result));
+      fail "recovery transition cancellation was swallowed"
+    with
+    | Eio.Cancel.Cancelled
+        (Fs_compat.Capability_write_cancelled (_, cancellation)) ->
+      cancellation
+    | Eio.Cancel.Cancelled _ ->
+      fail "recovery transition cancellation lost its typed state"
+  in
+  check bool "replace operation retained" true
+    (cancellation.operation = Fs_compat.Atomic_replace_operation);
+  (match cancellation.interrupted_recovery with
+   | None -> fail "recovery transition interruption was omitted"
+   | Some interruption ->
+     check bool "exact recovery phase retained" true
+       (Fs_compat.capability_recovery_failure_phase interruption
+        = Fs_compat.Recovery_prepare);
+     check bool "pre-transition cancellation records no mutation" true
+       (Fs_compat.capability_recovery_failure_effect interruption
+        = Fs_compat.Recovery_no_record_change));
+  check bool "no write primary was interrupted" true
+    (Option.is_none cancellation.interrupted_primary_failure);
+  check string "target remains unchanged" "old" (read_file target);
+  check (list string) "no staging entry was created" [ "target" ]
+    (directory_entries directory)
+;;
+
+let test_closed_recovery_access_is_explicit_primary_failure ~fs () =
+  let closed_access = ref None in
+  with_publication_recovery_access ~fs (fun access ->
+    closed_access := Some access);
+  with_tmp_dir @@ fun directory ->
+  let target = Filename.concat directory "target" in
+  write_file target "old";
+  with_parent_capability ~fs directory @@ fun parent ->
+  let recovery =
+    match !closed_access with
+    | Some recovery -> recovery
+    | None -> fail "test recovery access was not captured"
+  in
+  match
+    replace_capability_file
+      ~recovery
+      ~allowed_root_path:directory
+      ~parent
+      ~leaf:"target"
+      ~permissions:0o640
+      "new"
+  with
+  | Ok () -> fail "replace used a closed Keeper recovery lane"
+  | Error error ->
+    check bool "replace operation retained" true
+      (error.operation = Fs_compat.Atomic_replace_operation);
+    check bool "closed lane leaves target unchanged" true
+      (error.target_effect = Fs_compat.Target_unchanged);
+    (match error.primary_failure with
+     | Fs_compat.Recovery_access_primary_failure
+         Fs_compat.Recovery_access_not_available -> ()
+     | Fs_compat.Write_primary_failure failure ->
+       fail (Fs_compat.capability_write_failure_to_string failure)
+     | Fs_compat.Recovery_primary_failure failure ->
+       fail (Fs_compat.capability_recovery_failure_to_string failure));
+    check string "closed lane cannot mutate target" "old" (read_file target)
+;;
+
+let test_staging_capability_close_failure_retains_replace_effect ~fs () =
+  with_tmp_dir @@ fun directory ->
+  let target = Filename.concat directory "target" in
+  write_file target "old";
+  with_replace_context ~fs directory @@ fun parent recovery ->
+  match
+    replace_capability_file_for_testing
+      ~before_stage:(function
+        | Fs_compat.Close_staging_directory -> raise Exit
+        | _ -> ())
+      ~recovery
+      ~allowed_root_path:directory
+      ~parent
+      ~leaf:"target"
+      ~permissions:0o640
+      "new"
+  with
+  | Ok () -> fail "fault-injected staging close unexpectedly succeeded"
+  | Error error ->
+    let failure = require_write_primary_failure error in
+    check bool "replace operation retained" true
+      (error.operation = Fs_compat.Atomic_replace_operation);
+    check bool "staging close is the primary stage" true
+      (failure.stage = Fs_compat.Close_staging_directory);
+    check bool "published target effect survives capability close failure" true
+      (error.target_effect = Fs_compat.Target_replaced);
+    check string "published content remains visible" "new" (read_file target);
+    check (list string) "staging path remains removed" [ "target" ]
+      (directory_entries directory)
 ;;
 
 let test_directory_sync_failure_is_typed ~fs () =
@@ -924,16 +1886,39 @@ let () =
             (test_atomic_replace_replaces_symlink_not_referent ~fs)
         ; test_case "large payload complete" `Quick
             (test_atomic_replace_writes_complete_large_payload ~fs)
+        ; test_case "typed parent components" `Quick
+            (test_atomic_replace_uses_typed_parent_components ~fs)
         ; test_case "owned restrictive staging directory" `Quick
             (test_atomic_replace_owns_restrictive_staging_directory ~fs)
-        ; test_case "publish preflight keeps target state" `Quick
-            (test_publish_preflight_failure_keeps_known_target_state ~fs)
-        ; test_case "publish preflight detects payload swap" `Quick
-            (test_publish_preflight_detects_payload_leaf_swap ~fs)
+        ; test_case "replace preflight keeps target state" `Quick
+            (test_replace_preflight_failure_keeps_known_target_state ~fs)
+        ; test_case "replace preflight detects payload swap" `Quick
+            (test_replace_preflight_detects_payload_leaf_swap ~fs)
         ; test_case "pinned staging payload resists name swap" `Quick
             (test_staging_name_swap_does_not_redirect_pinned_payload ~fs)
-        ; test_case "append and replace share entry lease" `Quick
-            (test_append_and_replace_share_nonblocking_entry_lease ~fs)
+        ; test_case "append and replace share target identity lease" `Quick
+            (test_append_and_replace_share_existing_target_lease ~fs)
+        ; test_case "hard-link replaces share target identity lease" `Quick
+            (test_hard_link_replaces_share_existing_target_lease ~fs)
+        ; test_case "replace reobserves binding after lease acquisition" `Quick
+            (test_replace_reobserves_binding_after_lease_acquisition ~fs)
+        ; test_case "existing replace reobserves binding at publication" `Quick
+            (test_existing_replace_reobserves_binding_at_publication ~fs)
+        ; test_case "existing replace yields to absent publication" `Quick
+            (test_existing_replace_yields_to_cooperative_absent_publication
+               ~fs)
+        ; test_case "absent replace reobserves binding at publication" `Quick
+            (test_absent_replace_reobserves_binding_at_publication ~fs)
+        ; test_case "existing publication guard blocks absent sibling" `Quick
+            (test_existing_publication_guard_blocks_absent_sibling ~fs)
+        ; test_case "absent replace covers publication transition" `Quick
+            (test_absent_replace_blocks_visible_and_absent_sibling_mutations
+               ~fs)
+        ; test_case "exclusive create covers visibility transition" `Quick
+            (test_exclusive_create_visibility_remains_under_parent_lease ~fs)
+        ; test_case "existing target permits absent sibling progress" `Quick
+            (test_existing_target_lease_allows_absent_sibling_progress
+               ~fs)
         ; test_case "append lease blocks replace then releases" `Quick
             (test_append_lease_blocks_replace_then_releases ~fs)
         ; test_case "independent targets progress concurrently" `Quick
@@ -951,6 +1936,10 @@ let () =
             (test_parent_fsync_failure_is_not_success ~fs)
         ; test_case "primary plus cleanup failures" `Quick
             (test_primary_and_cleanup_failures_are_preserved ~fs)
+        ; test_case "replace primary plus cleanup cancellation" `Quick
+            (test_replace_primary_failure_survives_cleanup_cancellation ~fs)
+        ; test_case "create primary plus cleanup cancellation" `Quick
+            (test_create_primary_failure_survives_cleanup_cancellation ~fs)
         ; test_case "precommit cancellation" `Quick
             (test_precommit_cancellation_cleans_staging ~fs)
         ; test_case "pending payload sync cancellation" `Quick
@@ -963,8 +1952,16 @@ let () =
             (test_commit_cancellation_finishes_durable_replace ~fs)
         ; test_case "exclusive create commit cancellation" `Quick
             (test_create_commit_cancellation_reports_complete_effect ~fs)
-        ; test_case "leaf validation" `Quick
-            (test_rejects_non_leaf_path ~fs)
+        ; test_case "split write leaf validation" `Quick
+            (test_split_writes_reject_non_leaf_path ~fs)
+        ; test_case "replace rejects directory and fifo targets" `Quick
+            (test_replace_rejects_directory_and_fifo_targets ~fs)
+        ; test_case "recovery transition cancellation is typed" `Quick
+            (test_recovery_transition_cancellation_is_typed ~fs)
+        ; test_case "closed recovery access is explicit" `Quick
+            (test_closed_recovery_access_is_explicit_primary_failure ~fs)
+        ; test_case "staging close retains replace effect" `Quick
+            (test_staging_capability_close_failure_retains_replace_effect ~fs)
         ; test_case "directory sync typed failure" `Quick
             (test_directory_sync_failure_is_typed ~fs)
         ; test_case "large capability append" `Quick

--- a/test/test_fs_compat_publication_reconciliation.ml
+++ b/test/test_fs_compat_publication_reconciliation.ml
@@ -1,0 +1,1328 @@
+open Alcotest
+
+let with_tmp_dir f =
+  let path = Filename.temp_file "masc_publication_reconcile_" ".tmp" in
+  Sys.remove path;
+  Unix.mkdir path 0o755;
+  Fun.protect ~finally:(fun () -> Fs_compat.remove_tree path) (fun () -> f path)
+;;
+
+let operation_id value =
+  match Uuidm.of_string value with
+  | Some operation_id -> operation_id
+  | None -> failf "invalid test UUID %S" value
+;;
+
+let with_registry ~fs ~registry_root f =
+  Eio.Switch.run @@ fun sw ->
+  match
+    Fs_compat.open_publication_recovery_registry
+      ~sw
+      ~registry_root:Eio.Path.(fs / registry_root)
+  with
+  | Ok registry -> f registry
+  | Error error ->
+    fail (Fs_compat.publication_recovery_registry_error_to_string error)
+;;
+
+let require_fixture = function
+  | Ok () -> ()
+  | Error error ->
+    fail (Fs_compat.publication_recovery_fixture_error_to_string error)
+;;
+
+let inventory_owner registry expected_name =
+  let rows =
+    match Fs_compat.inventory_publication_recovery_owners registry with
+    | Ok rows -> rows
+    | Error error ->
+      fail
+        (Fs_compat.publication_recovery_owner_inventory_error_to_string
+           error)
+  in
+  match
+    List.filter_map
+      (function
+        | Fs_compat.Publication_recovery_valid_owner owner
+          when String.equal
+                 (Fs_compat.publication_recovery_owner_to_string owner)
+                 expected_name ->
+          Some owner
+        | Fs_compat.Publication_recovery_valid_owner _
+        | Fs_compat.Publication_recovery_invalid_owner_name _
+        | Fs_compat.Publication_recovery_unexpected_owner_kind _
+        | Fs_compat.Publication_recovery_missing_owner_entry _
+        | Fs_compat.Publication_recovery_owner_entry_unavailable _ -> None)
+      rows
+  with
+  | [ owner ] -> owner
+  | owners ->
+    failf
+      "expected exactly one owner %S, got %d"
+      expected_name
+      (List.length owners)
+;;
+
+let reconcile ~fs registry owner =
+  match
+    Fs_compat.reconcile_publication_recovery_owner
+      ~fs
+      ~registry
+      ~owner
+  with
+  | Ok report -> report
+  | Error error ->
+    fail
+      (Fs_compat.publication_recovery_reconciliation_error_to_string error)
+;;
+
+let seed_prepared
+      ~registry
+      ~owner
+      ~operation_id
+      ~allowed_root_path
+      ~allowed_root_device
+      ~allowed_root_inode
+  =
+  Fs_compat.Capability_write_for_testing.seed_prepared_publication_recovery
+    ~registry
+    ~owner
+    ~operation_id
+    ~allowed_root_path
+    ~allowed_root_device
+    ~allowed_root_inode
+    ~parent_components:[]
+    ~parent_device:allowed_root_device
+    ~parent_inode:allowed_root_inode
+    ~target_leaf:"target.json"
+    ~permissions:0o600
+  |> require_fixture
+;;
+
+let report_kinds report =
+  Fs_compat.publication_recovery_reconciliation_report_row_kinds report
+;;
+
+let report_ready report =
+  Fs_compat.publication_recovery_reconciliation_report_is_ready report
+;;
+
+let report_text report =
+  Fs_compat.publication_recovery_reconciliation_report_to_string report
+;;
+
+(* The test intentionally pins the fixed layout documented by
+   [Capability_recovery_obligation]; production traversal never reconstructs
+   this path. *)
+let owner_lane_path ~registry_root ~owner =
+  List.fold_left
+    Filename.concat
+    registry_root
+    [ "fs-publication-recovery"; "lanes"; owner ]
+;;
+
+let owner_area_path ~registry_root ~owner area =
+  Filename.concat (owner_lane_path ~registry_root ~owner) area
+;;
+
+let report_has_kind expected report =
+  List.exists (( = ) expected) (report_kinds report)
+;;
+
+let test_prepared_absent_becomes_forensic () =
+  with_tmp_dir @@ fun temp_root ->
+  Eio_main.run @@ fun env ->
+  let fs = Eio.Stdenv.fs env in
+  let allowed_root_path = Unix.realpath temp_root in
+  let root = Eio.Path.stat ~follow:false Eio.Path.(fs / allowed_root_path) in
+  let registry_root = Filename.concat temp_root "registry" in
+  Unix.mkdir registry_root 0o700;
+  let owner_name = "prepared-absent" in
+  with_registry ~fs ~registry_root @@ fun registry ->
+  seed_prepared
+    ~registry
+    ~owner:owner_name
+    ~operation_id:(operation_id "11111111-1111-4111-8111-111111111111")
+    ~allowed_root_path
+    ~allowed_root_device:root.dev
+    ~allowed_root_inode:root.ino;
+  let owner = inventory_owner registry owner_name in
+  (match
+     Fs_compat.with_publication_recovery_lane
+       ~registry
+       ~owner:owner_name
+       (fun _ -> ())
+   with
+   | Error error ->
+     (match
+        Fs_compat.publication_recovery_lane_reconciliation_error error
+      with
+      | Some
+          (Fs_compat.Publication_recovery_reconciliation_required blocked) ->
+        check string
+          "exact pending owner"
+          owner_name
+          (Fs_compat.publication_recovery_owner_to_string blocked)
+      | Some
+          ( Fs_compat.Publication_recovery_reconciliation_in_progress _
+          | Fs_compat.Publication_recovery_reconciliation_blocked _ )
+      | None ->
+        fail
+          (Fs_compat.publication_recovery_lane_open_error_to_string error))
+   | Ok () -> fail "pending owner was admitted before reconciliation");
+  let report = reconcile ~fs registry owner in
+  check bool "ready" true (report_ready report);
+  (match report_kinds report with
+   | [ Fs_compat.Publication_recovery_prepared_reconciled
+         Fs_compat.Publication_recovery_prepared_unmaterialized ] -> ()
+   | _ -> fail (report_text report));
+  match
+    Fs_compat.with_publication_recovery_lane
+      ~registry
+      ~owner:owner_name
+      (fun _ -> ())
+  with
+  | Ok () -> ()
+  | Error error ->
+    fail (Fs_compat.publication_recovery_lane_open_error_to_string error)
+;;
+
+let test_bound_stage_is_preserved () =
+  with_tmp_dir @@ fun temp_root ->
+  Eio_main.run @@ fun env ->
+  let fs = Eio.Stdenv.fs env in
+  let allowed_root_path = Unix.realpath temp_root in
+  let root_path = Eio.Path.(fs / allowed_root_path) in
+  let root = Eio.Path.stat ~follow:false root_path in
+  let registry_root = Filename.concat temp_root "registry" in
+  Unix.mkdir registry_root 0o700;
+  let owner_name = "bound-stage" in
+  let operation_id = operation_id "22222222-2222-4222-8222-222222222222" in
+  let stage_name =
+    Fs_compat.Capability_write_for_testing.publication_recovery_stage_name
+      operation_id
+  in
+  let stage_path = Eio.Path.(root_path / stage_name) in
+  Eio.Path.mkdir ~perm:0o700 stage_path;
+  let stage = Eio.Path.stat ~follow:false stage_path in
+  let target_file = Filename.concat allowed_root_path "target.json" in
+  let target_content = "operator-owned-target-sentinel" in
+  Out_channel.with_open_bin target_file (fun channel ->
+    Out_channel.output_string channel target_content);
+  let target_path = Eio.Path.(root_path / "target.json") in
+  let target_before = Eio.Path.stat ~follow:false target_path in
+  with_registry ~fs ~registry_root @@ fun registry ->
+  Fs_compat.Capability_write_for_testing.seed_bound_publication_recovery
+    ~registry
+    ~owner:owner_name
+    ~operation_id
+    ~allowed_root_path
+    ~allowed_root_device:root.dev
+    ~allowed_root_inode:root.ino
+    ~parent_components:[]
+    ~parent_device:root.dev
+    ~parent_inode:root.ino
+    ~target_leaf:"target.json"
+    ~permissions:0o600
+    ~stage_device:stage.dev
+    ~stage_inode:stage.ino
+  |> require_fixture;
+  let owner = inventory_owner registry owner_name in
+  let report = reconcile ~fs registry owner in
+  check bool "ready" true (report_ready report);
+  (match report_kinds report with
+   | [ Fs_compat.Publication_recovery_bound_reconciled
+         Fs_compat.Publication_recovery_bound_stage_preserved ] -> ()
+   | _ -> fail (report_text report));
+  check bool
+    "stage remains in target parent"
+    true
+    (Eio.Path.is_directory stage_path);
+  let target_after = Eio.Path.stat ~follow:false target_path in
+  check int64 "target device unchanged" target_before.dev target_after.dev;
+  check int64 "target inode unchanged" target_before.ino target_after.ino;
+  check string
+    "target content unchanged"
+    target_content
+    (In_channel.with_open_bin target_file In_channel.input_all)
+;;
+
+let test_allowed_root_identity_mismatch_is_forensic () =
+  with_tmp_dir @@ fun temp_root ->
+  Eio_main.run @@ fun env ->
+  let fs = Eio.Stdenv.fs env in
+  let allowed_root_path = Unix.realpath temp_root in
+  let root = Eio.Path.stat ~follow:false Eio.Path.(fs / allowed_root_path) in
+  let registry_root = Filename.concat temp_root "registry" in
+  Unix.mkdir registry_root 0o700;
+  let owner_name = "root-mismatch" in
+  with_registry ~fs ~registry_root @@ fun registry ->
+  seed_prepared
+    ~registry
+    ~owner:owner_name
+    ~operation_id:(operation_id "33333333-3333-4333-8333-333333333333")
+    ~allowed_root_path
+    ~allowed_root_device:root.dev
+    ~allowed_root_inode:Int64.(add root.ino 1L);
+  let owner = inventory_owner registry owner_name in
+  let report = reconcile ~fs registry owner in
+  check bool "mismatch source resolved" true (report_ready report);
+  match report_kinds report with
+  | [ Fs_compat.Publication_recovery_prepared_reconciled
+        Fs_compat.Publication_recovery_prepared_allowed_root_mismatch ] -> ()
+  | _ -> fail (report_text report)
+;;
+
+let write_raw ~registry ~owner ~area ~record_name raw =
+  Fs_compat.Capability_write_for_testing.write_raw_publication_recovery_record
+    ~registry
+    ~owner
+    ~area
+    ~record_name
+    ~raw
+  |> require_fixture
+;;
+
+let test_corrupt_and_invalid_rows_block_only_owner () =
+  with_tmp_dir @@ fun temp_root ->
+  Eio_main.run @@ fun env ->
+  let fs = Eio.Stdenv.fs env in
+  let registry_root = Filename.concat temp_root "registry" in
+  Unix.mkdir registry_root 0o700;
+  let owner_name = "corrupt-owner" in
+  with_registry ~fs ~registry_root @@ fun registry ->
+  write_raw
+    ~registry
+    ~owner:owner_name
+    ~area:Fs_compat.Publication_recovery_active
+    ~record_name:"44444444-4444-4444-8444-444444444444"
+    "{not-json";
+  write_raw
+    ~registry
+    ~owner:owner_name
+    ~area:Fs_compat.Publication_recovery_active
+    ~record_name:"not-a-canonical-uuid"
+    "foreign";
+  let owner = inventory_owner registry owner_name in
+  let report = reconcile ~fs registry owner in
+  check bool "blocked" false (report_ready report);
+  let corrupt, invalid =
+    List.fold_left
+      (fun (corrupt, invalid) -> function
+         | Fs_compat.Publication_recovery_corrupt_record_preserved ->
+           true, invalid
+         | Fs_compat.Publication_recovery_invalid_record_name -> corrupt, true
+         | Fs_compat.Publication_recovery_prepared_reconciled _
+         | Fs_compat.Publication_recovery_bound_reconciled _
+         | Fs_compat.Publication_recovery_existing_forensic_record _
+         | Fs_compat.Publication_recovery_unexpected_lane_entry
+         | Fs_compat.Publication_recovery_missing_lane_entry
+         | Fs_compat.Publication_recovery_lane_entry_unavailable
+         | Fs_compat.Publication_recovery_area_inventory_unavailable
+         | Fs_compat.Publication_recovery_source_transition_capabilities_unavailable
+         | Fs_compat.Publication_recovery_conflicting_source_records
+         | Fs_compat.Publication_recovery_unexpected_record_kind
+         | Fs_compat.Publication_recovery_missing_record_entry
+         | Fs_compat.Publication_recovery_record_entry_unavailable
+         | Fs_compat.Publication_recovery_record_observation_failed
+         | Fs_compat.Publication_recovery_record_transition_failed
+         | Fs_compat.Publication_recovery_record_scope_release_failed
+         | Fs_compat.Publication_recovery_owner_store_release_failed
+         | Fs_compat.Publication_recovery_owner_store_unavailable
+         | Fs_compat.Publication_recovery_owner_inventory_unavailable ->
+           corrupt, invalid)
+      (false, false)
+      (report_kinds report)
+  in
+  check bool "corrupt row explicit" true corrupt;
+  check bool "invalid row explicit" true invalid;
+  (match
+     Fs_compat.with_publication_recovery_lane
+       ~registry
+       ~owner:owner_name
+       (fun _ -> ())
+   with
+   | Error error ->
+     (match
+        Fs_compat.publication_recovery_lane_reconciliation_error error
+      with
+      | Some (Fs_compat.Publication_recovery_reconciliation_blocked _) -> ()
+      | Some
+          ( Fs_compat.Publication_recovery_reconciliation_required _
+          | Fs_compat.Publication_recovery_reconciliation_in_progress _ )
+      | None ->
+        fail
+          (Fs_compat.publication_recovery_lane_open_error_to_string error))
+   | Ok () -> fail "blocked owner was admitted");
+  match
+    Fs_compat.with_publication_recovery_lane
+      ~registry
+      ~owner:"unrelated-owner"
+      (fun _ -> ())
+  with
+  | Ok () -> ()
+  | Error error ->
+    failf
+      "unrelated owner was blocked: %s"
+      (Fs_compat.publication_recovery_lane_open_error_to_string error)
+;;
+
+let test_transition_failure_is_explicit () =
+  with_tmp_dir @@ fun temp_root ->
+  Eio_main.run @@ fun env ->
+  let fs = Eio.Stdenv.fs env in
+  let allowed_root_path = Unix.realpath temp_root in
+  let root = Eio.Path.stat ~follow:false Eio.Path.(fs / allowed_root_path) in
+  let registry_root = Filename.concat temp_root "registry" in
+  Unix.mkdir registry_root 0o700;
+  let owner_name = "transition-failure" in
+  let operation_id = operation_id "55555555-5555-4555-8555-555555555555" in
+  with_registry ~fs ~registry_root @@ fun registry ->
+  seed_prepared
+    ~registry
+    ~owner:owner_name
+    ~operation_id
+    ~allowed_root_path
+    ~allowed_root_device:root.dev
+    ~allowed_root_inode:root.ino;
+  write_raw
+    ~registry
+    ~owner:owner_name
+    ~area:Fs_compat.Publication_recovery_forensic
+    ~record_name:(Uuidm.to_string operation_id)
+    "{not-the-derived-forensic-record";
+  let owner = inventory_owner registry owner_name in
+  let report = reconcile ~fs registry owner in
+  check bool "blocked" false (report_ready report);
+  check bool
+    "transition failure explicit"
+    true
+    (List.exists
+       (function
+         | Fs_compat.Publication_recovery_record_transition_failed -> true
+         | Fs_compat.Publication_recovery_prepared_reconciled _
+         | Fs_compat.Publication_recovery_bound_reconciled _
+         | Fs_compat.Publication_recovery_existing_forensic_record _
+         | Fs_compat.Publication_recovery_unexpected_lane_entry
+         | Fs_compat.Publication_recovery_missing_lane_entry
+         | Fs_compat.Publication_recovery_lane_entry_unavailable
+         | Fs_compat.Publication_recovery_area_inventory_unavailable
+         | Fs_compat.Publication_recovery_source_transition_capabilities_unavailable
+         | Fs_compat.Publication_recovery_conflicting_source_records
+         | Fs_compat.Publication_recovery_invalid_record_name
+         | Fs_compat.Publication_recovery_unexpected_record_kind
+         | Fs_compat.Publication_recovery_missing_record_entry
+         | Fs_compat.Publication_recovery_record_entry_unavailable
+         | Fs_compat.Publication_recovery_corrupt_record_preserved
+         | Fs_compat.Publication_recovery_record_observation_failed
+         | Fs_compat.Publication_recovery_record_scope_release_failed
+         | Fs_compat.Publication_recovery_owner_store_release_failed
+         | Fs_compat.Publication_recovery_owner_store_unavailable
+         | Fs_compat.Publication_recovery_owner_inventory_unavailable -> false)
+       (report_kinds report))
+;;
+
+let test_missing_area_preserves_sources_and_continues_inventory () =
+  with_tmp_dir @@ fun temp_root ->
+  Eio_main.run @@ fun env ->
+  let fs = Eio.Stdenv.fs env in
+  let allowed_root_path = Unix.realpath temp_root in
+  let root = Eio.Path.stat ~follow:false Eio.Path.(fs / allowed_root_path) in
+  let registry_root = Filename.concat temp_root "registry" in
+  Unix.mkdir registry_root 0o700;
+  let owner_name = "missing-forensic" in
+  let prepared_id = operation_id "66666666-6666-4666-8666-666666666666" in
+  with_registry ~fs ~registry_root @@ fun registry ->
+  seed_prepared
+    ~registry
+    ~owner:owner_name
+    ~operation_id:prepared_id
+    ~allowed_root_path
+    ~allowed_root_device:root.dev
+    ~allowed_root_inode:root.ino;
+  write_raw
+    ~registry
+    ~owner:owner_name
+    ~area:Fs_compat.Publication_recovery_owned
+    ~record_name:"77777777-7777-4777-8777-777777777777"
+    "{corrupt-owned";
+  let forensic_path =
+    owner_area_path ~registry_root ~owner:owner_name "forensic"
+  in
+  Unix.rmdir forensic_path;
+  let active_record =
+    Filename.concat
+      (owner_area_path ~registry_root ~owner:owner_name "active")
+      (Uuidm.to_string prepared_id)
+  in
+  let owner = inventory_owner registry owner_name in
+  let report = reconcile ~fs registry owner in
+  check bool "owner remains blocked" false (report_ready report);
+  check bool
+    "missing forensic area is explicit"
+    true
+    (report_has_kind
+       Fs_compat.Publication_recovery_area_inventory_unavailable
+       report);
+  check bool
+    "prepared source retains unavailable transition evidence"
+    true
+    (report_has_kind
+       Fs_compat.Publication_recovery_source_transition_capabilities_unavailable
+       report);
+  check bool
+    "owned area continued to corrupt record"
+    true
+    (report_has_kind
+       Fs_compat.Publication_recovery_corrupt_record_preserved
+       report);
+  check bool "prepared source remains" true (Sys.file_exists active_record);
+  check bool "missing area was not recreated" false (Sys.file_exists forensic_path)
+;;
+
+let test_counterpart_area_unavailable_preserves_prepared_source () =
+  with_tmp_dir @@ fun temp_root ->
+  Eio_main.run @@ fun env ->
+  let fs = Eio.Stdenv.fs env in
+  let allowed_root_path = Unix.realpath temp_root in
+  let root = Eio.Path.stat ~follow:false Eio.Path.(fs / allowed_root_path) in
+  let registry_root = Filename.concat temp_root "registry" in
+  Unix.mkdir registry_root 0o700;
+  let owner_name = "counterpart-owned-unavailable" in
+  let prepared_id = operation_id "88888888-8888-4888-8888-888888888888" in
+  with_registry ~fs ~registry_root @@ fun registry ->
+  seed_prepared
+    ~registry
+    ~owner:owner_name
+    ~operation_id:prepared_id
+    ~allowed_root_path
+    ~allowed_root_device:root.dev
+    ~allowed_root_inode:root.ino;
+  let owned_path = owner_area_path ~registry_root ~owner:owner_name "owned" in
+  Unix.rmdir owned_path;
+  let active_record =
+    Filename.concat
+      (owner_area_path ~registry_root ~owner:owner_name "active")
+      (Uuidm.to_string prepared_id)
+  in
+  let forensic_record =
+    Filename.concat
+      (owner_area_path ~registry_root ~owner:owner_name "forensic")
+      (Uuidm.to_string prepared_id)
+  in
+  let owner = inventory_owner registry owner_name in
+  let report = reconcile ~fs registry owner in
+  check bool "owner remains blocked" false (report_ready report);
+  check bool
+    "counterpart area failure is explicit"
+    true
+    (report_has_kind
+       Fs_compat.Publication_recovery_area_inventory_unavailable
+       report);
+  check bool
+    "source transition is fenced"
+    true
+    (report_has_kind
+       Fs_compat.Publication_recovery_source_transition_capabilities_unavailable
+       report);
+  check bool "prepared source remains" true (Sys.file_exists active_record);
+  check bool "forensic record was not created" false (Sys.file_exists forensic_record);
+  check bool "missing counterpart was not recreated" false (Sys.file_exists owned_path)
+;;
+
+let test_unexpected_lane_entry_is_preserved_and_blocks_owner () =
+  with_tmp_dir @@ fun temp_root ->
+  Eio_main.run @@ fun env ->
+  let fs = Eio.Stdenv.fs env in
+  let registry_root = Filename.concat temp_root "registry" in
+  Unix.mkdir registry_root 0o700;
+  let owner_name = "lane-residue" in
+  with_registry ~fs ~registry_root @@ fun registry ->
+  write_raw
+    ~registry
+    ~owner:owner_name
+    ~area:Fs_compat.Publication_recovery_active
+    ~record_name:"not-a-record"
+    "source-sentinel";
+  let residue_path =
+    Filename.concat
+      (owner_lane_path ~registry_root ~owner:owner_name)
+      "operator-residue"
+  in
+  let residue_content = "operator-owned-lane-sentinel" in
+  Out_channel.with_open_bin residue_path (fun channel ->
+    Out_channel.output_string channel residue_content);
+  let residue_before = Unix.lstat residue_path in
+  let owner = inventory_owner registry owner_name in
+  let report = reconcile ~fs registry owner in
+  check bool "owner remains blocked" false (report_ready report);
+  check bool
+    "lane residue is explicit"
+    true
+    (report_has_kind Fs_compat.Publication_recovery_unexpected_lane_entry report);
+  let residue_after = Unix.lstat residue_path in
+  check int "residue inode unchanged" residue_before.st_ino residue_after.st_ino;
+  check string
+    "residue content unchanged"
+    residue_content
+    (In_channel.with_open_bin residue_path In_channel.input_all)
+;;
+
+let test_wrong_area_permissions_are_not_repaired () =
+  with_tmp_dir @@ fun temp_root ->
+  Eio_main.run @@ fun env ->
+  let fs = Eio.Stdenv.fs env in
+  let registry_root = Filename.concat temp_root "registry" in
+  Unix.mkdir registry_root 0o700;
+  let owner_name = "wrong-area-mode" in
+  with_registry ~fs ~registry_root @@ fun registry ->
+  write_raw
+    ~registry
+    ~owner:owner_name
+    ~area:Fs_compat.Publication_recovery_active
+    ~record_name:"not-a-record"
+    "source-sentinel";
+  let owned_path = owner_area_path ~registry_root ~owner:owner_name "owned" in
+  Unix.chmod owned_path 0o750;
+  let owner = inventory_owner registry owner_name in
+  let report = reconcile ~fs registry owner in
+  check bool "owner remains blocked" false (report_ready report);
+  check bool
+    "wrong permission area is explicit"
+    true
+    (report_has_kind
+       Fs_compat.Publication_recovery_area_inventory_unavailable
+       report);
+  check bool
+    "active area still inventoried"
+    true
+    (report_has_kind Fs_compat.Publication_recovery_invalid_record_name report);
+  check int
+    "startup reconciliation did not chmod"
+    0o750
+    ((Unix.stat owned_path).st_perm land 0o7777)
+;;
+
+let test_existing_registry_permissions_are_not_repaired () =
+  with_tmp_dir @@ fun temp_root ->
+  Eio_main.run @@ fun env ->
+  let fs = Eio.Stdenv.fs env in
+  let registry_root = Filename.concat temp_root "registry" in
+  Unix.mkdir registry_root 0o700;
+  with_registry ~fs ~registry_root (fun _ -> ());
+  let recovery_root =
+    Filename.concat registry_root "fs-publication-recovery"
+  in
+  Unix.chmod recovery_root 0o750;
+  let result =
+    Eio.Switch.run @@ fun sw ->
+    Fs_compat.open_publication_recovery_registry
+      ~sw
+      ~registry_root:Eio.Path.(fs / registry_root)
+  in
+  (match result with
+   | Error _ -> ()
+   | Ok _ -> fail "wrong-mode existing registry was silently repaired");
+  check int
+    "existing registry mode unchanged"
+    0o750
+    ((Unix.stat recovery_root).st_perm land 0o7777)
+;;
+
+let test_existing_lane_permissions_are_not_repaired () =
+  with_tmp_dir @@ fun temp_root ->
+  Eio_main.run @@ fun env ->
+  let fs = Eio.Stdenv.fs env in
+  let registry_root = Filename.concat temp_root "registry" in
+  Unix.mkdir registry_root 0o700;
+  let owner_name = "wrong-existing-lane-mode" in
+  with_registry ~fs ~registry_root @@ fun registry ->
+  write_raw
+    ~registry
+    ~owner:owner_name
+    ~area:Fs_compat.Publication_recovery_active
+    ~record_name:"not-a-record"
+    "source-sentinel";
+  let lane = owner_lane_path ~registry_root ~owner:owner_name in
+  Unix.chmod lane 0o750;
+  let result =
+    Fs_compat.Capability_write_for_testing.write_raw_publication_recovery_record
+      ~registry
+      ~owner:owner_name
+      ~area:Fs_compat.Publication_recovery_active
+      ~record_name:"second-record"
+      ~raw:"must-not-be-written"
+  in
+  (match result with
+   | Error _ -> ()
+   | Ok () -> fail "wrong-mode existing lane was silently repaired");
+  check int
+    "existing lane mode unchanged"
+    0o750
+    ((Unix.stat lane).st_perm land 0o7777);
+  check bool
+    "second record was not written"
+    false
+    (Sys.file_exists
+       (Filename.concat
+          (owner_area_path ~registry_root ~owner:owner_name "active")
+          "second-record"))
+;;
+
+let test_exact_owner_await_resolves_after_reconciliation () =
+  with_tmp_dir @@ fun temp_root ->
+  Eio_main.run @@ fun env ->
+  let fs = Eio.Stdenv.fs env in
+  let allowed_root_path = Unix.realpath temp_root in
+  let root = Eio.Path.stat ~follow:false Eio.Path.(fs / allowed_root_path) in
+  let registry_root = Filename.concat temp_root "registry" in
+  Unix.mkdir registry_root 0o700;
+  let owner_name = "await-ready-owner" in
+  with_registry ~fs ~registry_root @@ fun registry ->
+  seed_prepared
+    ~registry
+    ~owner:owner_name
+    ~operation_id:(operation_id "99999999-9999-4999-8999-999999999999")
+    ~allowed_root_path
+    ~allowed_root_device:root.dev
+    ~allowed_root_inode:root.ino;
+  let owner = inventory_owner registry owner_name in
+  let waiter_started, resolve_waiter_started = Eio.Promise.create () in
+  let waiter_result, resolve_waiter_result = Eio.Promise.create () in
+  Eio.Fiber.both
+    (fun () ->
+       Eio.Promise.resolve resolve_waiter_started ();
+       Eio.Promise.resolve
+         resolve_waiter_result
+         (Fs_compat.await_publication_recovery_lane_reconciliation
+            ~registry
+            ~owner:owner_name))
+    (fun () ->
+       Eio.Promise.await waiter_started;
+       check bool
+         "pending owner await is suspended"
+         true
+         (Option.is_none (Eio.Promise.peek waiter_result));
+       let report = reconcile ~fs registry owner in
+       check bool "reconciled owner ready" true (report_ready report));
+  match Eio.Promise.await waiter_result with
+  | Ok () -> ()
+  | Error error ->
+    fail
+      (Fs_compat.publication_recovery_lane_open_error_to_string error)
+;;
+
+let test_single_borrow_drains_exactly_once () =
+  with_tmp_dir @@ fun temp_root ->
+  Eio_main.run @@ fun env ->
+  let fs = Eio.Stdenv.fs env in
+  let allowed_root_path = Unix.realpath temp_root in
+  let root = Eio.Path.stat ~follow:false Eio.Path.(fs / allowed_root_path) in
+  let registry_root = Filename.concat temp_root "registry" in
+  Unix.mkdir registry_root 0o700;
+  let owner_name = "single-borrow-owner" in
+  with_registry ~fs ~registry_root @@ fun registry ->
+  seed_prepared
+    ~registry
+    ~owner:owner_name
+    ~operation_id:(operation_id "dddddddd-dddd-4ddd-8ddd-dddddddddddd")
+    ~allowed_root_path
+    ~allowed_root_device:root.dev
+    ~allowed_root_inode:root.ino;
+  let owner = inventory_owner registry owner_name in
+  let report = reconcile ~fs registry owner in
+  check bool "owner ready before borrow" true (report_ready report);
+  match
+    Fs_compat.Capability_write_for_testing.single_publication_recovery_borrow_balance
+      ~registry
+      ~owner:owner_name
+  with
+  | Ok
+      (Fs_compat.Capability_write_for_testing.Single_borrow_balance
+        { during_borrow; after_release; close_completed }) ->
+    check int "one borrow increments once" 1 during_borrow;
+    check int "one release drains to zero" 0 after_release;
+    check bool "zero-count close completes" true close_completed
+  | Ok Fs_compat.Capability_write_for_testing.Single_borrow_rejected ->
+    fail "fresh open access rejected its first borrow"
+  | Ok (Fs_compat.Capability_write_for_testing.Single_borrow_invariant _) ->
+    fail "fresh single borrow reached an invariant violation"
+  | Ok (Fs_compat.Capability_write_for_testing.Single_borrow_raised failure) ->
+    failf
+      "fresh single borrow raised: %s"
+      (Printexc.to_string failure.exception_)
+  | Error error ->
+    fail
+      (Fs_compat.publication_recovery_lane_open_error_to_string error)
+;;
+
+let test_live_context_cancellation_is_terminal_and_typed () =
+  with_tmp_dir @@ fun temp_root ->
+  Eio_main.run @@ fun env ->
+  let fs = Eio.Stdenv.fs env in
+  let allowed_root_path = Unix.realpath temp_root in
+  let root = Eio.Path.stat ~follow:false Eio.Path.(fs / allowed_root_path) in
+  let registry_root = Filename.concat temp_root "registry" in
+  Unix.mkdir registry_root 0o700;
+  let owner_name = "live-cancelled-owner" in
+  with_registry ~fs ~registry_root @@ fun registry ->
+  seed_prepared
+    ~registry
+    ~owner:owner_name
+    ~operation_id:(operation_id "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+    ~allowed_root_path
+    ~allowed_root_device:root.dev
+    ~allowed_root_inode:root.ino;
+  let owner = inventory_owner registry owner_name in
+  let reason = Failure "deterministic live-context cancellation" in
+  (match
+     Fs_compat.Capability_write_for_testing.interrupt_publication_recovery_reconciliation
+       ~fs
+       ~registry
+       ~owner
+       (Fs_compat.Capability_write_for_testing.Cancel_reconciliation reason)
+   with
+   | exception Eio.Cancel.Cancelled observed ->
+     check bool "original cancellation reason" true (observed == reason)
+   | Ok _ -> fail "cancelled reconciliation returned a report"
+   | Error error ->
+     fail
+       (Fs_compat.publication_recovery_reconciliation_error_to_string error));
+  (match
+     Fs_compat.Capability_write_for_testing.publication_recovery_owner_settlement
+       ~registry
+       ~owner
+   with
+   | Fs_compat.Capability_write_for_testing.Owner_settled -> ()
+   | Fs_compat.Capability_write_for_testing.Owner_untracked
+   | Fs_compat.Capability_write_for_testing.Owner_unsettled ->
+     fail "live-context cancellation did not settle its exact owner");
+  (match
+     Fs_compat.await_publication_recovery_lane_reconciliation
+       ~registry
+       ~owner:owner_name
+   with
+   | Error error ->
+     (match
+        Fs_compat.publication_recovery_lane_reconciliation_error error
+      with
+      | Some
+          (Fs_compat.Publication_recovery_reconciliation_blocked
+            (Fs_compat.Publication_recovery_owner_cancelled_block
+              { owner = blocked_owner; reason = blocked_reason; _ })) ->
+        check string
+          "exact cancelled owner"
+          owner_name
+          (Fs_compat.publication_recovery_owner_to_string blocked_owner);
+        check bool "exact cancellation reason" true (blocked_reason == reason)
+      | Some
+          ( Fs_compat.Publication_recovery_reconciliation_required _
+          | Fs_compat.Publication_recovery_reconciliation_in_progress _
+          | Fs_compat.Publication_recovery_reconciliation_blocked
+              ( Fs_compat.Publication_recovery_owner_inventory_block _
+              | Fs_compat.Publication_recovery_owner_report_block _
+              | Fs_compat.Publication_recovery_owner_crash_block _
+              | Fs_compat.Publication_recovery_owner_activation_rejected_block _ ) )
+      | None ->
+        fail
+          (Fs_compat.publication_recovery_lane_open_error_to_string error))
+   | Ok () -> fail "live-context cancelled owner was admitted");
+  match
+    Fs_compat.reconcile_publication_recovery_owner ~fs ~registry ~owner
+  with
+  | Error
+      (Fs_compat.Publication_recovery_owner_reconciliation_cancelled
+        { owner = cancelled_owner; reason = cancelled_reason; _ }) ->
+    check string
+      "terminal cancelled owner"
+      owner_name
+      (Fs_compat.publication_recovery_owner_to_string cancelled_owner);
+    check bool "terminal cancellation reason" true (cancelled_reason == reason)
+  | Error error ->
+    fail
+      (Fs_compat.publication_recovery_reconciliation_error_to_string error)
+  | Ok _ -> fail "live-context cancelled owner was silently retried"
+;;
+
+let test_parent_cancellation_returns_owner_to_pending () =
+  with_tmp_dir @@ fun temp_root ->
+  Eio_main.run @@ fun env ->
+  let fs = Eio.Stdenv.fs env in
+  let allowed_root_path = Unix.realpath temp_root in
+  let root = Eio.Path.stat ~follow:false Eio.Path.(fs / allowed_root_path) in
+  let registry_root = Filename.concat temp_root "registry" in
+  Unix.mkdir registry_root 0o700;
+  let owner_name = "parent-cancelled-owner" in
+  with_registry ~fs ~registry_root @@ fun registry ->
+  seed_prepared
+    ~registry
+    ~owner:owner_name
+    ~operation_id:(operation_id "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee")
+    ~allowed_root_path
+    ~allowed_root_device:root.dev
+    ~allowed_root_inode:root.ino;
+  let owner = inventory_owner registry owner_name in
+  let reason = Failure "deterministic parent cancellation" in
+  (match
+     Eio.Cancel.sub @@ fun context ->
+     Eio.Cancel.cancel context reason;
+     Fs_compat.Capability_write_for_testing.interrupt_publication_recovery_reconciliation
+       ~fs
+       ~registry
+       ~owner
+       (Fs_compat.Capability_write_for_testing.Cancel_reconciliation reason)
+   with
+   | exception Eio.Cancel.Cancelled observed ->
+     check bool "original parent cancellation reason" true (observed == reason)
+   | Ok _ -> fail "parent-cancelled reconciliation returned a report"
+   | Error error ->
+     fail
+       (Fs_compat.publication_recovery_reconciliation_error_to_string error));
+  (match
+     Fs_compat.Capability_write_for_testing.publication_recovery_owner_settlement
+       ~registry
+       ~owner
+   with
+   | Fs_compat.Capability_write_for_testing.Owner_unsettled -> ()
+   | Fs_compat.Capability_write_for_testing.Owner_untracked
+   | Fs_compat.Capability_write_for_testing.Owner_settled ->
+     fail "parent cancellation incorrectly settled its exact owner");
+  let waiter_started, resolve_waiter_started = Eio.Promise.create () in
+  let waiter_result, resolve_waiter_result = Eio.Promise.create () in
+  Eio.Fiber.both
+    (fun () ->
+       Eio.Promise.resolve resolve_waiter_started ();
+       Eio.Promise.resolve
+         resolve_waiter_result
+         (Fs_compat.await_publication_recovery_lane_reconciliation
+            ~registry
+            ~owner:owner_name))
+    (fun () ->
+       Eio.Promise.await waiter_started;
+       check bool
+         "parent-cancelled owner await remains suspended"
+         true
+         (Option.is_none (Eio.Promise.peek waiter_result));
+       let report = reconcile ~fs registry owner in
+       check bool "retry reaches terminal ready" true (report_ready report));
+  match Eio.Promise.await waiter_result with
+  | Ok () -> ()
+  | Error error ->
+    fail
+      (Fs_compat.publication_recovery_lane_open_error_to_string error)
+;;
+
+let test_activation_rejection_terminally_blocks_exact_owner () =
+  with_tmp_dir @@ fun temp_root ->
+  Eio_main.run @@ fun env ->
+  let fs = Eio.Stdenv.fs env in
+  let allowed_root_path = Unix.realpath temp_root in
+  let root = Eio.Path.stat ~follow:false Eio.Path.(fs / allowed_root_path) in
+  let registry_root = Filename.concat temp_root "registry" in
+  Unix.mkdir registry_root 0o700;
+  let owner_name = "activation-rejected-owner" in
+  with_registry ~fs ~registry_root @@ fun registry ->
+  seed_prepared
+    ~registry
+    ~owner:owner_name
+    ~operation_id:(operation_id "ffffffff-ffff-4fff-8fff-ffffffffffff")
+    ~allowed_root_path
+    ~allowed_root_device:root.dev
+    ~allowed_root_inode:root.ino;
+  let owner = inventory_owner registry owner_name in
+  (match
+     Fs_compat.reject_publication_recovery_owner_activation
+       ~registry
+       ~owner
+   with
+   | Ok () -> ()
+   | Error error ->
+     fail
+       (Fs_compat.publication_recovery_activation_rejection_error_to_string
+          error));
+  (match
+     Fs_compat.Capability_write_for_testing.publication_recovery_owner_settlement
+       ~registry
+       ~owner
+   with
+   | Fs_compat.Capability_write_for_testing.Owner_settled -> ()
+   | Fs_compat.Capability_write_for_testing.Owner_untracked
+   | Fs_compat.Capability_write_for_testing.Owner_unsettled ->
+     fail "activation rejection did not settle its exact owner");
+  (match
+     Fs_compat.await_publication_recovery_lane_reconciliation
+       ~registry
+       ~owner:owner_name
+   with
+   | Error error ->
+     (match
+        Fs_compat.publication_recovery_lane_reconciliation_error error
+      with
+      | Some
+          (Fs_compat.Publication_recovery_reconciliation_blocked
+            (Fs_compat.Publication_recovery_owner_activation_rejected_block
+              blocked_owner)) ->
+        check string
+          "exact activation-rejected owner"
+          owner_name
+          (Fs_compat.publication_recovery_owner_to_string blocked_owner)
+      | Some
+          ( Fs_compat.Publication_recovery_reconciliation_required _
+          | Fs_compat.Publication_recovery_reconciliation_in_progress _
+          | Fs_compat.Publication_recovery_reconciliation_blocked
+              ( Fs_compat.Publication_recovery_owner_inventory_block _
+              | Fs_compat.Publication_recovery_owner_report_block _
+              | Fs_compat.Publication_recovery_owner_crash_block _
+              | Fs_compat.Publication_recovery_owner_cancelled_block _ ) )
+      | None ->
+        fail
+          (Fs_compat.publication_recovery_lane_open_error_to_string error))
+   | Ok () -> fail "activation-rejected owner was admitted");
+  match
+    Fs_compat.reconcile_publication_recovery_owner ~fs ~registry ~owner
+  with
+  | Error (Fs_compat.Publication_recovery_owner_activation_rejected rejected) ->
+    check string
+      "reconciliation remains terminally rejected"
+      owner_name
+      (Fs_compat.publication_recovery_owner_to_string rejected)
+  | Error error ->
+    fail
+      (Fs_compat.publication_recovery_reconciliation_error_to_string error)
+  | Ok _ -> fail "activation-rejected owner was silently reconciled"
+;;
+
+let test_crashed_reconciliation_is_terminal_and_typed () =
+  with_tmp_dir @@ fun temp_root ->
+  Eio_main.run @@ fun env ->
+  let fs = Eio.Stdenv.fs env in
+  let allowed_root_path = Unix.realpath temp_root in
+  let root = Eio.Path.stat ~follow:false Eio.Path.(fs / allowed_root_path) in
+  let registry_root = Filename.concat temp_root "registry" in
+  Unix.mkdir registry_root 0o700;
+  let owner_name = "crashed-owner" in
+  with_registry ~fs ~registry_root @@ fun registry ->
+  seed_prepared
+    ~registry
+    ~owner:owner_name
+    ~operation_id:(operation_id "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")
+    ~allowed_root_path
+    ~allowed_root_device:root.dev
+    ~allowed_root_inode:root.ino;
+  let owner = inventory_owner registry owner_name in
+  let crash = Failure "deterministic reconciliation crash" in
+  (match
+     Fs_compat.Capability_write_for_testing.interrupt_publication_recovery_reconciliation
+       ~fs
+       ~registry
+       ~owner
+       (Fs_compat.Capability_write_for_testing.Crash_reconciliation crash)
+   with
+   | exception observed when observed == crash -> ()
+   | exception observed ->
+     failf "unexpected crash propagated: %s" (Printexc.to_string observed)
+   | Ok _ -> fail "crashed reconciliation returned a report"
+   | Error error ->
+     fail
+       (Fs_compat.publication_recovery_reconciliation_error_to_string error));
+  (match
+     Fs_compat.await_publication_recovery_lane_reconciliation
+       ~registry
+       ~owner:owner_name
+   with
+   | Error error ->
+     (match
+        Fs_compat.publication_recovery_lane_reconciliation_error error
+      with
+      | Some
+          (Fs_compat.Publication_recovery_reconciliation_blocked
+            (Fs_compat.Publication_recovery_owner_crash_block
+              { owner = blocked_owner; exception_; _ })) ->
+        check string
+          "exact crashed owner"
+          owner_name
+          (Fs_compat.publication_recovery_owner_to_string blocked_owner);
+        check bool "exact crash retained" true (exception_ == crash)
+      | Some
+          ( Fs_compat.Publication_recovery_reconciliation_required _
+          | Fs_compat.Publication_recovery_reconciliation_in_progress _
+          | Fs_compat.Publication_recovery_reconciliation_blocked
+              ( Fs_compat.Publication_recovery_owner_inventory_block _
+              | Fs_compat.Publication_recovery_owner_report_block _
+              | Fs_compat.Publication_recovery_owner_cancelled_block _
+              | Fs_compat.Publication_recovery_owner_activation_rejected_block _ ) )
+      | None ->
+        fail
+          (Fs_compat.publication_recovery_lane_open_error_to_string error))
+   | Ok () -> fail "crashed owner was admitted");
+  match
+    Fs_compat.reconcile_publication_recovery_owner ~fs ~registry ~owner
+  with
+  | Error
+      (Fs_compat.Publication_recovery_owner_reconciliation_crashed
+        { owner = crashed_owner; exception_; _ }) ->
+    check string
+      "terminal error owner"
+      owner_name
+      (Fs_compat.publication_recovery_owner_to_string crashed_owner);
+    check bool "terminal error retains crash" true (exception_ == crash)
+  | Error error ->
+    fail
+      (Fs_compat.publication_recovery_reconciliation_error_to_string error)
+  | Ok _ -> fail "crashed owner reconciliation was silently retried"
+;;
+
+let require_json_field name = function
+  | `Assoc fields ->
+    (match List.assoc_opt name fields with
+     | Some value -> value
+     | None -> failf "structured report omitted field %S" name)
+  | json ->
+    failf
+      "expected JSON object while reading %S, got %s"
+      name
+      (Yojson.Safe.to_string json)
+;;
+
+let contains_exact_substring ~needle haystack =
+  let needle_length = String.length needle in
+  let haystack_length = String.length haystack in
+  let rec search index =
+    if index + needle_length > haystack_length
+    then false
+    else if String.sub haystack index needle_length = needle
+    then true
+    else search (index + 1)
+  in
+  needle_length = 0 || search 0
+;;
+
+let test_structured_report_preserves_corrupt_evidence () =
+  with_tmp_dir @@ fun temp_root ->
+  Eio_main.run @@ fun env ->
+  let fs = Eio.Stdenv.fs env in
+  let registry_root = Filename.concat temp_root "registry" in
+  Unix.mkdir registry_root 0o700;
+  let owner_name = "structured-corrupt-owner" in
+  let secret = "operator-secret-must-remain-forensic-only" in
+  let record_name = "cccccccc-cccc-4ccc-8ccc-cccccccccccc" in
+  let raw =
+    Yojson.Safe.to_string
+      (`Assoc
+         [ "schema", `String "masc.fs-publication-recovery"
+         ; "version", `Int 1
+         ; "state", `String "prepared"
+         ; "owner", `Assoc [ "secret", `String secret ]
+         ; "operation_id", `String record_name
+         ; "allowed_root_path", `String "/unused"
+         ; ( "allowed_root"
+           , `Assoc [ "dev", `String "1"; "ino", `String "1" ] )
+         ; "parent_components", `List []
+         ; "parent", `Assoc [ "dev", `String "1"; "ino", `String "1" ]
+         ; "target_leaf", `String "target.json"
+         ; "initial_target", `Assoc [ "presence", `String "absent" ]
+         ; "permissions", `Int 0o600
+         ])
+  in
+  with_registry ~fs ~registry_root @@ fun registry ->
+  write_raw
+    ~registry
+    ~owner:owner_name
+    ~area:Fs_compat.Publication_recovery_active
+    ~record_name
+    raw;
+  let owner = inventory_owner registry owner_name in
+  let report = reconcile ~fs registry owner in
+  let json =
+    Fs_compat.publication_recovery_reconciliation_report_to_yojson report
+  in
+  let json_text = Yojson.Safe.to_string json in
+  check bool
+    "structured report excludes crafted secret"
+    false
+    (contains_exact_substring ~needle:secret json_text);
+  check bool
+    "diagnostic report excludes crafted secret"
+    false
+    (contains_exact_substring ~needle:secret (report_text report));
+  check bool
+    "structured report excludes forensic raw payload"
+    false
+    (contains_exact_substring ~needle:raw json_text);
+  check (option string)
+    "structured owner"
+    (Some owner_name)
+    (match require_json_field "owner" json with
+     | `String owner -> Some owner
+     | _ -> None);
+  check bool
+    "structured readiness"
+    false
+    (match require_json_field "ready" json with
+     | `Bool ready -> ready
+     | value ->
+       failf
+         "structured ready field has wrong shape: %s"
+         (Yojson.Safe.to_string value));
+  let rows =
+    match require_json_field "rows" json with
+    | `List rows -> rows
+    | value ->
+      failf
+        "structured rows field has wrong shape: %s"
+        (Yojson.Safe.to_string value)
+  in
+  let corrupt =
+    List.find_opt
+      (fun row ->
+         match require_json_field "kind" row with
+         | `String "corrupt_record_preserved" -> true
+         | `String _ -> false
+         | value ->
+           failf
+             "structured row kind has wrong shape: %s"
+             (Yojson.Safe.to_string value))
+      rows
+  in
+  match corrupt with
+  | None -> fail "structured report omitted corrupt record row"
+  | Some corrupt ->
+    check bool
+      "structured report does not duplicate raw record"
+      true
+      (match corrupt with
+       | `Assoc fields -> Option.is_none (List.assoc_opt "raw" fields)
+       | _ -> false);
+    check int
+      "structured raw byte count"
+      (String.length raw)
+      (match require_json_field "raw_byte_count" corrupt with
+       | `Int value -> value
+       | value ->
+         failf
+           "structured raw byte count has wrong shape: %s"
+           (Yojson.Safe.to_string value));
+    check (option string)
+      "structured raw SHA-256"
+      (Some Digestif.SHA256.(digest_string raw |> to_hex))
+      (match require_json_field "raw_sha256" corrupt with
+       | `String value -> Some value
+       | _ -> None);
+    check (option string)
+      "structured operation id"
+      (Some record_name)
+      (match require_json_field "operation_id" corrupt with
+       | `String value -> Some value
+       | _ -> None);
+    let validation_error = require_json_field "validation_error" corrupt in
+    check (option string)
+      "typed corrupt validation kind"
+      (Some "record_field_invalid")
+      (match require_json_field "kind" validation_error with
+       | `String value -> Some value
+       | _ -> None);
+    let payload = require_json_field "payload" validation_error in
+    let canonical_payload =
+      `Assoc
+        [ "field", `String "owner"
+        ; "value", `Assoc [ "secret", `String secret ]
+        ]
+      |> Yojson.Safe.sort
+      |> Yojson.Safe.to_string
+    in
+    check int
+      "canonical validation payload byte count"
+      (String.length canonical_payload)
+      (match require_json_field "canonical_json_byte_count" payload with
+       | `Int value -> value
+       | value ->
+         failf
+           "validation payload byte count has wrong shape: %s"
+           (Yojson.Safe.to_string value));
+    check (option string)
+      "canonical validation payload SHA-256"
+      (Some Digestif.SHA256.(digest_string canonical_payload |> to_hex))
+      (match require_json_field "canonical_json_sha256" payload with
+       | `String value -> Some value
+       | _ -> None)
+;;
+
+let () =
+  run
+    "fs_compat publication reconciliation"
+    [ ( "startup reconciliation"
+      , [ test_case
+            "prepared absent becomes forensic"
+            `Quick
+            test_prepared_absent_becomes_forensic
+        ; test_case
+            "bound stage is preserved"
+            `Quick
+            test_bound_stage_is_preserved
+        ; test_case
+            "allowed root identity mismatch is forensic"
+            `Quick
+            test_allowed_root_identity_mismatch_is_forensic
+        ; test_case
+            "corrupt and invalid rows block only owner"
+            `Quick
+            test_corrupt_and_invalid_rows_block_only_owner
+        ; test_case
+            "transition failure is explicit"
+            `Quick
+            test_transition_failure_is_explicit
+        ; test_case
+            "missing area preserves sources and continues inventory"
+            `Quick
+            test_missing_area_preserves_sources_and_continues_inventory
+        ; test_case
+            "counterpart area unavailable preserves prepared source"
+            `Quick
+            test_counterpart_area_unavailable_preserves_prepared_source
+        ; test_case
+            "unexpected lane entry is preserved and blocks owner"
+            `Quick
+            test_unexpected_lane_entry_is_preserved_and_blocks_owner
+        ; test_case
+            "wrong area permissions are not repaired"
+            `Quick
+            test_wrong_area_permissions_are_not_repaired
+        ; test_case
+            "existing registry permissions are not repaired"
+            `Quick
+            test_existing_registry_permissions_are_not_repaired
+        ; test_case
+            "existing lane permissions are not repaired"
+            `Quick
+            test_existing_lane_permissions_are_not_repaired
+        ; test_case
+            "exact owner await resolves after reconciliation"
+            `Quick
+            test_exact_owner_await_resolves_after_reconciliation
+        ; test_case
+            "single borrow drains exactly once"
+            `Quick
+            test_single_borrow_drains_exactly_once
+        ; test_case
+            "live-context cancellation is terminal and typed"
+            `Quick
+            test_live_context_cancellation_is_terminal_and_typed
+        ; test_case
+            "parent cancellation returns owner to pending"
+            `Quick
+            test_parent_cancellation_returns_owner_to_pending
+        ; test_case
+            "activation rejection terminally blocks exact owner"
+            `Quick
+            test_activation_rejection_terminally_blocks_exact_owner
+        ; test_case
+            "crashed reconciliation is terminal and typed"
+            `Quick
+            test_crashed_reconciliation_is_terminal_and_typed
+        ; test_case
+            "structured report preserves corrupt evidence"
+            `Quick
+            test_structured_report_preserves_corrupt_evidence
+        ] )
+    ]
+;;

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -102,6 +102,18 @@ let cleanup_dir dir =
   in
   try rm dir with _ -> ()
 
+let publication_recovery_registry env sw config =
+  let registry_root =
+    Eio.Path.(Eio.Stdenv.fs env / Workspace.masc_root_dir config)
+  in
+  match
+    Fs_compat.open_publication_recovery_registry ~sw ~registry_root
+  with
+  | Ok registry -> Some registry
+  | Error error ->
+    fail
+      (Fs_compat.publication_recovery_registry_error_to_string error)
+
 let make_meta name =
   let json = `Assoc [
     ("name", `String name);
@@ -552,6 +564,7 @@ let test_fresh_presence_preserves_turn_failures () =
           clock = Eio.Stdenv.clock env;
           proc_mgr = None;
           net = None;
+          publication_recovery_registry = None;
         }
       in
       let meta = make_meta "fresh-presence-turn-failure" in
@@ -653,6 +666,8 @@ let test_direct_start_keepalive_resolves_done_on_stop () =
           clock = Eio.Stdenv.clock env;
           proc_mgr = Some (Eio.Stdenv.process_mgr env);
           net = None;
+          publication_recovery_registry =
+            publication_recovery_registry env sw config;
         }
       in
       seed_keeper_sandbox_profile ~base_dir keeper_name;
@@ -692,6 +707,7 @@ let test_keeper_lane_join_waits_for_children_and_cleanup () =
      Lane.fork
        ~sw:parent_sw
        lane
+       ~with_run_scope:(fun run -> run ())
        ~run:(fun lane_sw ->
          Eio.Fiber.fork ~sw:lane_sw (fun () ->
            Eio.Promise.await release_p;
@@ -713,6 +729,10 @@ let test_keeper_lane_join_waits_for_children_and_cleanup () =
    | Lane.Completed -> ()
    | Lane.Shutdown_before_start -> fail "unexpected shutdown before lane start"
    | Lane.Shutdown_requested -> fail "unexpected lane shutdown"
+   | Lane.Shutdown_cancel_failed failure ->
+     fail
+       ("unexpected shutdown cancellation failure: "
+        ^ Printexc.to_string failure.cause)
    | Lane.Cancelled_by_parent cause ->
      fail ("unexpected parent cancellation: " ^ Printexc.to_string cause)
    | Lane.Failed exn -> fail ("unexpected lane failure: " ^ Printexc.to_string exn));
@@ -723,6 +743,101 @@ let test_keeper_lane_join_waits_for_children_and_cleanup () =
     (Atomic.get cleanup_observed_child);
   check (option string) "cleanup succeeded" None exit.cleanup_error
 
+let test_keeper_lane_cancel_interrupts_blocked_run_scope () =
+  Eio_main.run
+  @@ fun _env ->
+  Eio.Switch.run
+  @@ fun parent_sw ->
+  let lane = Lane.create () in
+  let scope_entered, resolve_scope_entered = Eio.Promise.create () in
+  let never_resolved, _ = Eio.Promise.create () in
+  let run_called = Atomic.make false in
+  (match
+     Lane.fork
+       ~sw:parent_sw
+       lane
+       ~with_run_scope:(fun _run ->
+         Eio.Promise.resolve resolve_scope_entered ();
+         Eio.Promise.await never_resolved)
+       ~run:(fun _lane_sw -> Atomic.set run_called true)
+       ~cleanup:(fun _ -> Ok ())
+   with
+   | Ok () -> ()
+   | Error error -> fail (Lane.start_error_to_string error));
+  Eio.Promise.await scope_entered;
+  (match Lane.request_cancel lane with
+   | Lane.Cancel_requested -> ()
+   | Lane.Cancel_already_requested ->
+     fail "lane cancellation was already requested"
+   | Lane.Cancel_already_exiting -> fail "lane exited before cancellation"
+   | Lane.Cancel_wrong_domain -> fail "lane cancellation crossed domains"
+   | Lane.Cancel_not_committed exn
+   | Lane.Cancel_committed_with_failure exn ->
+     fail ("lane cancellation failed: " ^ Printexc.to_string exn));
+  let exit = Lane.await_exit lane in
+  (match exit.outcome with
+   | Lane.Shutdown_requested -> ()
+   | Lane.Completed -> fail "blocked run scope completed after cancellation"
+   | Lane.Shutdown_before_start ->
+     fail "lane was cancelled before its scope started"
+   | Lane.Shutdown_cancel_failed failure ->
+     fail
+       ("operator cancellation cleanup failed: "
+        ^ Printexc.to_string failure.cause)
+   | Lane.Cancelled_by_parent cause ->
+     fail
+       ("operator cancellation was classified as parent cancellation: "
+        ^ Printexc.to_string cause)
+   | Lane.Failed exn ->
+     fail
+       ("blocked run scope failed instead of cancelling: "
+        ^ Printexc.to_string exn));
+  check bool "run body was never admitted" false (Atomic.get run_called)
+
+let test_keeper_lane_preserves_enriched_shutdown_cancellation () =
+  let exception Detach_failed in
+  Eio_main.run
+  @@ fun _env ->
+  Eio.Switch.run
+  @@ fun parent_sw ->
+  let lane = Lane.create () in
+  let scope_entered, resolve_scope_entered = Eio.Promise.create () in
+  let never_resolved, _ = Eio.Promise.create () in
+  (match
+     Lane.fork
+       ~sw:parent_sw
+       lane
+       ~with_run_scope:(fun _run ->
+         Eio.Promise.resolve resolve_scope_entered ();
+         try Eio.Promise.await never_resolved with
+         | Eio.Cancel.Cancelled _ -> raise (Eio.Cancel.Cancelled Detach_failed))
+       ~run:(fun _lane_sw -> fail "run body crossed blocked admission")
+       ~cleanup:(fun _ -> Ok ())
+   with
+   | Ok () -> ()
+   | Error error -> fail (Lane.start_error_to_string error));
+  Eio.Promise.await scope_entered;
+  (match Lane.request_cancel lane with
+   | Lane.Cancel_requested -> ()
+   | Lane.Cancel_already_requested -> fail "cancellation was already requested"
+   | Lane.Cancel_already_exiting -> fail "lane exited before cancellation"
+   | Lane.Cancel_wrong_domain -> fail "lane cancellation crossed domains"
+   | Lane.Cancel_not_committed exn
+   | Lane.Cancel_committed_with_failure exn ->
+     fail ("lane cancellation signal failed: " ^ Printexc.to_string exn));
+  match (Lane.await_exit lane).outcome with
+  | Lane.Shutdown_cancel_failed { cause = Detach_failed; _ } -> ()
+  | Lane.Shutdown_cancel_failed failure ->
+    fail
+      ("wrong enriched cancellation cause: " ^ Printexc.to_string failure.cause)
+  | Lane.Completed -> fail "enriched cancellation completed normally"
+  | Lane.Shutdown_before_start -> fail "enriched cancellation happened before start"
+  | Lane.Shutdown_requested -> fail "enriched cancellation evidence was erased"
+  | Lane.Cancelled_by_parent cause ->
+    fail ("enriched cancellation became parent cancellation: " ^ Printexc.to_string cause)
+  | Lane.Failed exn ->
+    fail ("enriched cancellation became a generic failure: " ^ Printexc.to_string exn)
+
 let test_keeper_lane_surfaces_cleanup_failure () =
   Eio_main.run @@ fun _env ->
   Eio.Switch.run @@ fun parent_sw ->
@@ -731,6 +846,7 @@ let test_keeper_lane_surfaces_cleanup_failure () =
      Lane.fork
        ~sw:parent_sw
        lane
+       ~with_run_scope:(fun run -> run ())
        ~run:(fun _lane_sw -> ())
        ~cleanup:(fun _outcome -> Error "cleanup evidence")
    with
@@ -756,25 +872,17 @@ let test_keeper_lane_identity_is_typed_and_unique () =
   | Ok decoded -> check bool "lane id round-trip" true (Lane.Id.equal first_id decoded)
   | Error detail -> fail detail
 
-(* Codex #24135 finding 1 (predicate half): [request_cancel] records a shutdown
-   request so a supervised body can classify the resulting cancellation as an
-   operator shutdown (graceful stop) rather than a parent/restart cancel. The
-   supervised-body routing that consumes this flag is covered by review against
-   the tested normal-exit path (a full fork+cancel finally harness is not
-   available: the supervisor tests mock [supervise_keepalive]). *)
-let test_lane_records_shutdown_request_on_cancel () =
+let test_lane_cancel_before_start_is_joinable () =
   Eio_main.run @@ fun _env ->
   let lane = Lane.create () in
-  check bool "fresh lane has no shutdown request" false
-    (Lane.shutdown_requested lane);
   (match Lane.request_cancel lane with
    | Lane.Cancel_requested -> ()
    | Lane.Cancel_already_requested
    | Lane.Cancel_already_exiting
-   | Lane.Cancel_signal_failed _ ->
+   | Lane.Cancel_wrong_domain
+   | Lane.Cancel_not_committed _
+   | Lane.Cancel_committed_with_failure _ ->
      fail "expected request_cancel to be accepted on a fresh lane");
-  check bool "request_cancel records the shutdown request" true
-    (Lane.shutdown_requested lane);
   match Lane.await_exit lane with
   | { outcome = Lane.Shutdown_before_start; _ } -> ()
   | { outcome = _; _ } ->
@@ -785,26 +893,55 @@ let test_keeper_lane_cancel_is_lane_local_and_joinable () =
   Eio.Switch.run @@ fun parent_sw ->
   let lane = Lane.create () in
   let never_p, _never_r = Eio.Promise.create () in
+  let observed_origin = Atomic.make None in
   (match
      Lane.fork
        ~sw:parent_sw
        lane
-       ~run:(fun _lane_sw -> Eio.Promise.await never_p)
+       ~with_run_scope:(fun run -> run ())
+       ~run:(fun _lane_sw ->
+         try Eio.Promise.await never_p with
+         | Eio.Cancel.Cancelled cause ->
+           Atomic.set observed_origin (Some (Lane.classify_cancellation_cause cause)))
        ~cleanup:(fun _outcome -> Ok ())
    with
    | Ok () -> ()
    | Error error -> fail (Lane.start_error_to_string error));
   Eio.Fiber.yield ();
+  (match Domain.join (Domain.spawn (fun () -> Lane.request_cancel lane)) with
+   | Lane.Cancel_wrong_domain -> ()
+   | Lane.Cancel_requested -> fail "cross-domain cancellation mutated the lane"
+   | Lane.Cancel_already_requested ->
+     fail "cross-domain cancellation observed a committed request"
+   | Lane.Cancel_already_exiting -> fail "lane exited during cross-domain probe"
+   | Lane.Cancel_not_committed exn
+   | Lane.Cancel_committed_with_failure exn ->
+     fail ("cross-domain cancellation touched Eio state: " ^ Printexc.to_string exn));
+  check bool
+    "cross-domain rejection leaves lane running"
+    true
+    (Option.is_none (Lane.peek_exit lane));
   (match Lane.request_cancel lane with
    | Lane.Cancel_requested -> ()
    | Lane.Cancel_already_requested
    | Lane.Cancel_already_exiting
-   | Lane.Cancel_signal_failed _ -> fail "first lane cancellation was not accepted");
+   | Lane.Cancel_wrong_domain
+   | Lane.Cancel_not_committed _
+   | Lane.Cancel_committed_with_failure _ ->
+     fail "first lane cancellation was not accepted");
   let exit = Lane.await_exit lane in
+  (match Atomic.get observed_origin with
+   | Some Lane.Shutdown_request -> ()
+   | Some (Lane.External_cancel cause) ->
+     fail ("lane body observed external cancellation: " ^ Printexc.to_string cause)
+   | None -> fail "lane body did not observe cancellation origin");
   match exit.outcome with
   | Lane.Shutdown_requested -> ()
   | Lane.Shutdown_before_start -> fail "running lane reported pre-start shutdown"
   | Lane.Completed -> fail "cancelled lane reported normal completion"
+  | Lane.Shutdown_cancel_failed failure ->
+    fail
+      ("lane shutdown cancellation failed: " ^ Printexc.to_string failure.cause)
   | Lane.Cancelled_by_parent cause ->
     fail ("lane cancellation escaped to parent: " ^ Printexc.to_string cause)
   | Lane.Failed exn -> fail ("lane cancellation failed: " ^ Printexc.to_string exn)
@@ -1437,6 +1574,7 @@ let test_keeper_shutdown_prepare_joins_idle_lane () =
          Lane.fork
            ~sw:parent_sw
            entry.lane
+           ~with_run_scope:(fun run -> run ())
            ~run:(fun _lane_sw -> Eio.Promise.await never_p)
            ~cleanup:(fun _outcome ->
              (match R.dispatch_event_exact entry KSM.Stop_requested with
@@ -2417,6 +2555,7 @@ let test_start_keepalive_denies_dead_tombstone_before_registration () =
         ; clock = Eio.Stdenv.clock env
         ; proc_mgr = Some (Eio.Stdenv.process_mgr env)
         ; net = None
+        ; publication_recovery_registry = None
         }
       in
       (match Masc.Keeper_keepalive.start_keepalive ctx meta with
@@ -2458,6 +2597,8 @@ let test_start_keepalive_preserves_unresolved_failing_entry () =
           clock = Eio.Stdenv.clock env;
           proc_mgr = Some (Eio.Stdenv.process_mgr env);
           net = None;
+          publication_recovery_registry =
+            publication_recovery_registry env sw config;
         }
       in
       seed_keeper_sandbox_profile ~base_dir keeper_name;
@@ -2504,6 +2645,8 @@ let test_start_keepalive_reclaims_finished_failing_entry () =
           clock = Eio.Stdenv.clock env;
           proc_mgr = Some (Eio.Stdenv.process_mgr env);
           net = None;
+          publication_recovery_registry =
+            publication_recovery_registry env sw config;
         }
       in
       seed_keeper_sandbox_profile ~base_dir keeper_name;
@@ -2818,14 +2961,18 @@ let () =
         test_direct_start_keepalive_resolves_done_on_stop;
       test_case "lane join waits for children and cleanup" `Quick
         test_keeper_lane_join_waits_for_children_and_cleanup;
+      test_case "lane cancellation interrupts blocked run scope" `Quick
+        test_keeper_lane_cancel_interrupts_blocked_run_scope;
+      test_case "lane preserves enriched shutdown cancellation" `Quick
+        test_keeper_lane_preserves_enriched_shutdown_cancellation;
       test_case "lane join surfaces cleanup failure" `Quick
         test_keeper_lane_surfaces_cleanup_failure;
       test_case "lane identity is typed and unique" `Quick
         test_keeper_lane_identity_is_typed_and_unique;
       test_case "lane cancellation is local and joinable" `Quick
         test_keeper_lane_cancel_is_lane_local_and_joinable;
-      test_case "lane records shutdown request on cancel" `Quick
-        test_lane_records_shutdown_request_on_cancel;
+      test_case "lane cancel before start is joinable" `Quick
+        test_lane_cancel_before_start_is_joinable;
       test_case "shutdown store round-trip and identity guard" `Quick
         test_keeper_shutdown_store_round_trip_and_identity_guard;
       test_case "shutdown store isolates corrupt owner" `Quick

--- a/test/test_keeper_adversarial_review.ml
+++ b/test/test_keeper_adversarial_review.ml
@@ -33,6 +33,16 @@ let ensure_fs env =
   Masc_test_deps.init_eio_clock env;
   if not (Fs_compat.has_fs ()) then Fs_compat.set_fs (Eio.Stdenv.fs env)
 
+let publication_recovery_registry env sw config =
+  let registry_root =
+    Eio.Path.(Eio.Stdenv.fs env / Masc.Workspace.masc_root_dir config)
+  in
+  match Fs_compat.open_publication_recovery_registry ~sw ~registry_root with
+  | Ok registry -> registry
+  | Error error ->
+    fail
+      (Fs_compat.publication_recovery_registry_error_to_string error)
+
 let operator_ctx env sw config agent_name : _ Operator_control.context =
   {
     config;
@@ -41,6 +51,8 @@ let operator_ctx env sw config agent_name : _ Operator_control.context =
     clock = Eio.Stdenv.clock env;
     proc_mgr = Some (Eio.Stdenv.process_mgr env);
     net = Some (Eio.Stdenv.net env);
+    publication_recovery_registry =
+      Some (publication_recovery_registry env sw config);
     mcp_session_id = None;
   }
 

--- a/test/test_keeper_busy_connector_deferred.ml
+++ b/test/test_keeper_busy_connector_deferred.ml
@@ -100,7 +100,8 @@ let test_busy_discord_enqueues () =
             Gate_keeper_backend.dispatch
               ~connector_kind:Gate_keeper_backend.Discord
               ~submission_owner:Gate_keeper_backend.Channel_actor
-              ~sw ~clock ~proc_mgr:None ~net:None ~config
+              ~sw ~clock ~proc_mgr:None ~net:None
+              ~publication_recovery_registry:None ~config
               ~channel:"discord" ~channel_user_id:"user-42"
               ~channel_user_name:"Tester" ~channel_workspace_id:"chan-777"
               ~keeper_name ~idempotency_key:"discord-msg-777"
@@ -215,7 +216,8 @@ let test_unpublished_busy_slot_queues_without_resolved_meta () =
             Gate_keeper_backend.dispatch
               ~connector_kind:Gate_keeper_backend.Discord
               ~submission_owner:Gate_keeper_backend.Channel_actor
-              ~sw ~clock ~proc_mgr:None ~net:None ~config
+              ~sw ~clock ~proc_mgr:None ~net:None
+              ~publication_recovery_registry:None ~config
               ~channel:"discord" ~channel_user_id:"user-unpublished"
               ~channel_user_name:"Tester" ~channel_workspace_id:"chan-unpublished"
               ~keeper_name ~idempotency_key:"discord-msg-unpublished"
@@ -262,7 +264,8 @@ let test_busy_discord_persist_failure_is_explicit () =
             Gate_keeper_backend.dispatch
               ~connector_kind:Gate_keeper_backend.Discord
               ~submission_owner:Gate_keeper_backend.Channel_actor
-              ~sw ~clock ~proc_mgr:None ~net:None ~config
+              ~sw ~clock ~proc_mgr:None ~net:None
+              ~publication_recovery_registry:None ~config
               ~channel:"discord" ~channel_user_id:"user-42"
               ~channel_user_name:"Tester" ~channel_workspace_id:"chan-777"
               ~keeper_name ~idempotency_key:"discord-msg-persist-fail"
@@ -315,7 +318,8 @@ let test_pending_receipt_prevents_direct_overtake () =
         Gate_keeper_backend.dispatch
           ~connector_kind:Gate_keeper_backend.Discord
           ~submission_owner:Gate_keeper_backend.Channel_actor
-          ~sw ~clock ~proc_mgr:None ~net:None ~config
+          ~sw ~clock ~proc_mgr:None ~net:None
+          ~publication_recovery_registry:None ~config
           ~channel:"discord" ~channel_user_id:"user-42"
           ~channel_user_name:"Tester" ~channel_workspace_id:"chan-777"
           ~keeper_name ~idempotency_key:"discord-msg-778"
@@ -355,7 +359,8 @@ let test_busy_slack_preserves_thread_context () =
           Gate_keeper_backend.dispatch
             ~connector_kind:Gate_keeper_backend.Slack
             ~submission_owner:Gate_keeper_backend.Channel_actor
-            ~sw ~clock ~proc_mgr:None ~net:None ~config
+            ~sw ~clock ~proc_mgr:None ~net:None
+            ~publication_recovery_registry:None ~config
             ~channel:"slack" ~channel_user_id:"U-42"
             ~channel_user_name:"Slack User" ~channel_workspace_id:"C-777"
             ~keeper_name ~idempotency_key:"slack-msg-171.001"
@@ -427,7 +432,8 @@ let test_shutdown_fenced_connector_ack
           Gate_keeper_backend.dispatch
             ~connector_kind
             ~submission_owner:Gate_keeper_backend.Channel_actor
-            ~sw ~clock ~proc_mgr:None ~net:None ~config
+            ~sw ~clock ~proc_mgr:None ~net:None
+            ~publication_recovery_registry:None ~config
             ~channel ~channel_user_id ~channel_user_name ~channel_workspace_id
             ~keeper_name
             ~idempotency_key:("shutdown-fenced-" ^ String.lowercase_ascii label)

--- a/test/test_keeper_busy_dashboard_deferred.ml
+++ b/test/test_keeper_busy_dashboard_deferred.ml
@@ -351,6 +351,7 @@ let test_stream_surface_preserves_typed_shutdown_rejection () =
     ; clock
     ; proc_mgr = None
     ; net = None
+    ; publication_recovery_registry = None
     }
   in
   let observed = ref None in

--- a/test/test_keeper_effective_meta_overlay.ml
+++ b/test/test_keeper_effective_meta_overlay.ml
@@ -703,6 +703,18 @@ instructions = "missing sandbox profile"
     (fun () ->
       Eio_main.run @@ fun env ->
       Eio.Switch.run @@ fun sw ->
+      let registry_root =
+        Eio.Path.(Eio.Stdenv.fs env / Workspace.masc_root_dir config)
+      in
+      let publication_recovery_registry =
+        match
+          Fs_compat.open_publication_recovery_registry ~sw ~registry_root
+        with
+        | Ok registry -> registry
+        | Error error ->
+          Alcotest.fail
+            (Fs_compat.publication_recovery_registry_error_to_string error)
+      in
       let ctx : _ Keeper_tool_surface.context =
         {
           config;
@@ -711,6 +723,8 @@ instructions = "missing sandbox profile"
           clock = Eio.Stdenv.clock env;
           proc_mgr = None;
           net = None;
+          publication_recovery_registry =
+            Some publication_recovery_registry;
         }
       in
       match

--- a/test/test_keeper_fs_edit_containment.ml
+++ b/test/test_keeper_fs_edit_containment.ml
@@ -61,17 +61,20 @@ let make_meta name =
 let with_eio_fs f =
   Eio_main.run
   @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio.Switch.run
+  @@ fun sw ->
+  let fs = Eio.Stdenv.fs env in
+  Fs_compat.set_fs fs;
   Process_eio.init
     ~cwd_default:(Eio.Stdenv.cwd env)
     ~proc_mgr:(Eio.Stdenv.process_mgr env)
     ~clock:(Eio.Stdenv.clock env);
-  f ()
+  f ~fs ~sw ()
 ;;
 
 let setup f =
   with_eio_fs
-  @@ fun () ->
+  @@ fun ~fs ~sw () ->
   let base = temp_dir () in
   ensure_dir (Filename.concat base Common.masc_dirname);
   Fun.protect
@@ -85,7 +88,28 @@ let setup f =
        let (_registered : Keeper_registry.registry_entry) =
          Keeper_registry.register ~base_path:base meta.name meta
        in
-       f ~config ~meta ~playground)
+       let registry =
+         match
+           Fs_compat.open_publication_recovery_registry
+             ~sw
+             ~registry_root:Eio.Path.(fs / Workspace.masc_root_dir config)
+         with
+         | Ok registry -> registry
+         | Error error ->
+           Alcotest.fail
+             (Fs_compat.publication_recovery_registry_error_to_string error)
+       in
+       match
+         Fs_compat.with_publication_recovery_lane
+           ~registry
+           ~owner:meta.name
+           (fun publication_recovery_access ->
+              f ~config ~meta ~playground ~publication_recovery_access)
+       with
+       | Ok value -> value
+       | Error error ->
+         Alcotest.fail
+           (Fs_compat.publication_recovery_lane_open_error_to_string error))
 ;;
 
 let parse raw = Yojson.Safe.from_string raw
@@ -96,7 +120,7 @@ let parse_ok raw =
 
 let test_docker_write_allows_explicit_root () =
   setup
-  @@ fun ~config ~meta ~playground:_ ->
+  @@ fun ~config ~meta ~playground:_ ~publication_recovery_access ->
   let meta = { meta with allowed_paths = [ config.base_path ] } in
   Keeper_registry.update_meta ~base_path:config.base_path meta.name meta;
   let path = Filename.concat config.base_path "root-write.txt" in
@@ -104,7 +128,8 @@ let test_docker_write_allows_explicit_root () =
     Keeper_tool_filesystem_runtime.handle_file_write
       ~turn_sandbox_factory:None
       ~config
-      ~keeper_name:meta.name
+      ~meta
+      ~publication_recovery_access
       ~args:
         (`Assoc
             [ "path", `String path
@@ -119,14 +144,15 @@ let test_docker_write_allows_explicit_root () =
 
 let test_docker_write_allows_playground () =
   setup
-  @@ fun ~config ~meta ~playground ->
+  @@ fun ~config ~meta ~playground ~publication_recovery_access ->
   let path = Filename.concat playground "mind/allowed.txt" in
   ensure_dir (Filename.dirname path);
   let raw =
     Keeper_tool_filesystem_runtime.handle_file_write
       ~turn_sandbox_factory:None
       ~config
-      ~keeper_name:meta.name
+      ~meta
+      ~publication_recovery_access
       ~args:
         (`Assoc
             [ "path", `String path

--- a/test/test_keeper_fs_edit_patch.ml
+++ b/test/test_keeper_fs_edit_patch.ml
@@ -60,15 +60,17 @@ let make_meta ?(sandbox = Keeper_types_profile_sandbox.Local) name =
 
 let with_eio_fs f =
   Eio_main.run @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio.Switch.run @@ fun sw ->
+  let fs = Eio.Stdenv.fs env in
+  Fs_compat.set_fs fs;
   Process_eio.init
     ~cwd_default:(Eio.Stdenv.cwd env)
     ~proc_mgr:(Eio.Stdenv.process_mgr env)
     ~clock:(Eio.Stdenv.clock env);
-  f ()
+  f ~fs ~sw ()
 
 let setup ?(sandbox = Keeper_types_profile_sandbox.Local) f =
-  with_eio_fs @@ fun () ->
+  with_eio_fs @@ fun ~fs ~sw () ->
   let base = temp_dir () in
   ensure_dir (Filename.concat base Common.masc_dirname);
   Fun.protect ~finally:(fun () -> cleanup_dir base) @@ fun () ->
@@ -78,7 +80,28 @@ let setup ?(sandbox = Keeper_types_profile_sandbox.Local) f =
   let playground = Masc.Keeper_sandbox.host_root_abs_of_meta ~config meta in
   ensure_dir playground;
   ignore (Keeper_registry.register ~base_path:base meta.name meta);
-  f ~config ~meta ~playground
+  let registry =
+    match
+      Fs_compat.open_publication_recovery_registry
+        ~sw
+        ~registry_root:Eio.Path.(fs / Workspace.masc_root_dir config)
+    with
+    | Ok registry -> registry
+    | Error error ->
+      Alcotest.fail
+        (Fs_compat.publication_recovery_registry_error_to_string error)
+  in
+  match
+    Fs_compat.with_publication_recovery_lane
+      ~registry
+      ~owner:meta.name
+      (fun publication_recovery_access ->
+         f ~config ~meta ~playground ~publication_recovery_access)
+  with
+  | Ok value -> value
+  | Error error ->
+    Alcotest.fail
+      (Fs_compat.publication_recovery_lane_open_error_to_string error)
 
 let parse raw = Yojson.Safe.from_string raw
 
@@ -104,12 +127,19 @@ let parse_write_region_observation_error raw =
 
 let permissions path = (Unix.lstat path).Unix.st_perm
 
-let public_fs_edit_call ~public ~config ~(meta : Keeper_meta_contract.keeper_meta) args =
+let public_fs_edit_call
+      ~public
+      ~config
+      ~(meta : Keeper_meta_contract.keeper_meta)
+      ~publication_recovery_access
+      args
+  =
   let args = Keeper_tool_alias.translate_input ~public args in
   Keeper_tool_filesystem_runtime.handle_file_write
     ~turn_sandbox_factory:None
     ~config
-    ~keeper_name:meta.name
+    ~meta
+    ~publication_recovery_access
     ~args
     ()
 
@@ -157,11 +187,15 @@ let with_turn_sandbox_factory ~enabled ~config ~meta f =
 (* ── Tests ───────────────────────────────────────────────────────── *)
 
 let test_patch_unique_match () =
-  setup @@ fun ~config ~meta ~playground ->
+  setup @@ fun ~config ~meta ~playground ~publication_recovery_access ->
   let path = Filename.concat playground "src.ml" in
   Fs_compat.save_file path "let x = 1\nlet y = 2\n";
   let raw =
-    Keeper_tool_filesystem_runtime.handle_file_write ~turn_sandbox_factory:None ~config ~keeper_name:meta.name
+    Keeper_tool_filesystem_runtime.handle_file_write
+      ~turn_sandbox_factory:None
+      ~config
+      ~meta
+      ~publication_recovery_access
       ~args:
         (`Assoc
           [
@@ -180,11 +214,15 @@ let test_patch_unique_match () =
     "let x = 42\nlet y = 2\n" after
 
 let test_patch_no_match_errors () =
-  setup @@ fun ~config ~meta ~playground ->
+  setup @@ fun ~config ~meta ~playground ~publication_recovery_access ->
   let path = Filename.concat playground "src.ml" in
   Fs_compat.save_file path "let x = 1\n";
   let raw =
-    Keeper_tool_filesystem_runtime.handle_file_write ~turn_sandbox_factory:None ~config ~keeper_name:meta.name
+    Keeper_tool_filesystem_runtime.handle_file_write
+      ~turn_sandbox_factory:None
+      ~config
+      ~meta
+      ~publication_recovery_access
       ~args:
         (`Assoc
           [
@@ -211,11 +249,15 @@ let test_patch_no_match_errors () =
          loop 0)
 
 let test_patch_multiple_matches_without_replace_all_errors () =
-  setup @@ fun ~config ~meta ~playground ->
+  setup @@ fun ~config ~meta ~playground ~publication_recovery_access ->
   let path = Filename.concat playground "src.ml" in
   Fs_compat.save_file path "x = 1\nx = 1\nx = 1\n";
   let raw =
-    Keeper_tool_filesystem_runtime.handle_file_write ~turn_sandbox_factory:None ~config ~keeper_name:meta.name
+    Keeper_tool_filesystem_runtime.handle_file_write
+      ~turn_sandbox_factory:None
+      ~config
+      ~meta
+      ~publication_recovery_access
       ~args:
         (`Assoc
           [
@@ -232,11 +274,15 @@ let test_patch_multiple_matches_without_replace_all_errors () =
     "x = 1\nx = 1\nx = 1\n" after
 
 let test_patch_replace_all () =
-  setup @@ fun ~config ~meta ~playground ->
+  setup @@ fun ~config ~meta ~playground ~publication_recovery_access ->
   let path = Filename.concat playground "src.ml" in
   Fs_compat.save_file path "x = 1\nx = 1\nx = 1\n";
   let raw =
-    Keeper_tool_filesystem_runtime.handle_file_write ~turn_sandbox_factory:None ~config ~keeper_name:meta.name
+    Keeper_tool_filesystem_runtime.handle_file_write
+      ~turn_sandbox_factory:None
+      ~config
+      ~meta
+      ~publication_recovery_access
       ~args:
         (`Assoc
           [
@@ -255,11 +301,15 @@ let test_patch_replace_all () =
     "x = 2\nx = 2\nx = 2\n" (Fs_compat.load_file path)
 
 let test_patch_empty_old_string_errors () =
-  setup @@ fun ~config ~meta ~playground ->
+  setup @@ fun ~config ~meta ~playground ~publication_recovery_access ->
   let path = Filename.concat playground "src.ml" in
   Fs_compat.save_file path "let x = 1\n";
   let raw =
-    Keeper_tool_filesystem_runtime.handle_file_write ~turn_sandbox_factory:None ~config ~keeper_name:meta.name
+    Keeper_tool_filesystem_runtime.handle_file_write
+      ~turn_sandbox_factory:None
+      ~config
+      ~meta
+      ~publication_recovery_access
       ~args:
         (`Assoc
           [
@@ -275,10 +325,14 @@ let test_patch_empty_old_string_errors () =
     (Option.is_some (parse_error raw))
 
 let test_patch_missing_file_errors () =
-  setup @@ fun ~config ~meta ~playground ->
+  setup @@ fun ~config ~meta ~playground ~publication_recovery_access ->
   let path = Filename.concat playground "ghost.ml" in
   let raw =
-    Keeper_tool_filesystem_runtime.handle_file_write ~turn_sandbox_factory:None ~config ~keeper_name:meta.name
+    Keeper_tool_filesystem_runtime.handle_file_write
+      ~turn_sandbox_factory:None
+      ~config
+      ~meta
+      ~publication_recovery_access
       ~args:
         (`Assoc
           [
@@ -292,11 +346,15 @@ let test_patch_missing_file_errors () =
   Alcotest.(check bool) "ok=false" false (parse_ok raw)
 
 let test_patch_delete_via_empty_new_string () =
-  setup @@ fun ~config ~meta ~playground ->
+  setup @@ fun ~config ~meta ~playground ~publication_recovery_access ->
   let path = Filename.concat playground "src.ml" in
   Fs_compat.save_file path "keep me\nDELETE_ME\nkeep me too\n";
   let raw =
-    Keeper_tool_filesystem_runtime.handle_file_write ~turn_sandbox_factory:None ~config ~keeper_name:meta.name
+    Keeper_tool_filesystem_runtime.handle_file_write
+      ~turn_sandbox_factory:None
+      ~config
+      ~meta
+      ~publication_recovery_access
       ~args:
         (`Assoc
           [
@@ -313,10 +371,14 @@ let test_patch_delete_via_empty_new_string () =
 
 let test_overwrite_unchanged_by_patch_addition () =
   (* Regression: introducing Patch must not break existing overwrite. *)
-  setup @@ fun ~config ~meta ~playground ->
+  setup @@ fun ~config ~meta ~playground ~publication_recovery_access ->
   let path = Filename.concat playground "new.txt" in
   let raw =
-    Keeper_tool_filesystem_runtime.handle_file_write ~turn_sandbox_factory:None ~config ~keeper_name:meta.name
+    Keeper_tool_filesystem_runtime.handle_file_write
+      ~turn_sandbox_factory:None
+      ~config
+      ~meta
+      ~publication_recovery_access
       ~args:
         (`Assoc
           [
@@ -331,7 +393,7 @@ let test_overwrite_unchanged_by_patch_addition () =
     "fresh" (Fs_compat.load_file path)
 
 let test_atomic_writes_preserve_existing_executable_permissions () =
-  setup @@ fun ~config ~meta ~playground ->
+  setup @@ fun ~config ~meta ~playground ~publication_recovery_access ->
   let run ~label ~initial ~args ~expected =
     let path = Filename.concat playground (label ^ ".sh") in
     Fs_compat.save_file path initial;
@@ -340,7 +402,8 @@ let test_atomic_writes_preserve_existing_executable_permissions () =
       Keeper_tool_filesystem_runtime.handle_file_write
         ~turn_sandbox_factory:None
         ~config
-        ~keeper_name:meta.name
+        ~meta
+        ~publication_recovery_access
         ~args:(`Assoc (("path", `String path) :: args))
         ()
     in
@@ -371,7 +434,7 @@ let test_atomic_writes_preserve_existing_executable_permissions () =
     ~expected:"#!/bin/sh\nexit 0\n"
 
 let test_created_entries_have_exact_authorized_permissions () =
-  setup @@ fun ~config ~meta ~playground ->
+  setup @@ fun ~config ~meta ~playground ~publication_recovery_access ->
   let parent = Filename.concat playground "created-parent" in
   let nested = Filename.concat parent "nested" in
   let path = Filename.concat nested "created.txt" in
@@ -385,7 +448,8 @@ let test_created_entries_have_exact_authorized_permissions () =
          Keeper_tool_filesystem_runtime.handle_file_write
            ~turn_sandbox_factory:None
            ~config
-           ~keeper_name:meta.name
+           ~meta
+           ~publication_recovery_access
            ~args:
              (`Assoc
                 [ "path", `String path
@@ -401,7 +465,7 @@ let test_created_entries_have_exact_authorized_permissions () =
   Alcotest.(check int) "created file mode is exact" 0o644 (permissions path)
 
 let test_patch_symlink_result_is_regular_0644 () =
-  setup @@ fun ~config ~meta ~playground ->
+  setup @@ fun ~config ~meta ~playground ~publication_recovery_access ->
   let referent = Filename.concat playground "patch-referent.txt" in
   let leaf = Filename.concat playground "patch-link.txt" in
   Fs_compat.save_file referent "value=before\n";
@@ -411,7 +475,8 @@ let test_patch_symlink_result_is_regular_0644 () =
     Keeper_tool_filesystem_runtime.handle_file_write
       ~turn_sandbox_factory:None
       ~config
-      ~keeper_name:meta.name
+      ~meta
+      ~publication_recovery_access
       ~args:
         (`Assoc
            [ "path", `String leaf
@@ -436,7 +501,8 @@ let test_patch_symlink_result_is_regular_0644 () =
     (permissions referent)
 
 let test_outside_referent_endpoint_semantics ~sandbox ~with_runtime () =
-  setup ~sandbox @@ fun ~config ~meta ~playground ->
+  setup ~sandbox
+  @@ fun ~config ~meta ~playground ~publication_recovery_access ->
   with_turn_sandbox_factory ~enabled:with_runtime ~config ~meta
   @@ fun turn_sandbox_factory ->
   let outside_dir = Filename.concat config.Workspace.base_path "outside-referents" in
@@ -450,7 +516,8 @@ let test_outside_referent_endpoint_semantics ~sandbox ~with_runtime () =
       Keeper_tool_filesystem_runtime.handle_file_write
         ~turn_sandbox_factory
         ~config
-        ~keeper_name:meta.name
+        ~meta
+        ~publication_recovery_access
         ~args:(`Assoc (("path", `String leaf) :: args))
         ()
     in
@@ -490,7 +557,7 @@ let test_outside_referent_endpoint_semantics ~sandbox ~with_runtime () =
     ~expected_leaf_content:"outside-append-outside-symlink"
 
 let test_append_inside_symlink_uses_canonical_referent_capability () =
-  setup @@ fun ~config ~meta ~playground ->
+  setup @@ fun ~config ~meta ~playground ~publication_recovery_access ->
   let referent_dir = Filename.concat playground "append-referent" in
   let lexical_dir = Filename.concat playground "append-link" in
   ensure_dir referent_dir;
@@ -503,7 +570,8 @@ let test_append_inside_symlink_uses_canonical_referent_capability () =
     Keeper_tool_filesystem_runtime.handle_file_write
       ~turn_sandbox_factory:None
       ~config
-      ~keeper_name:meta.name
+      ~meta
+      ~publication_recovery_access
       ~args:
         (`Assoc
            [ "path", `String lexical
@@ -525,7 +593,8 @@ let test_symlink_component_swap_cannot_escape_allowed_root
       ~with_runtime
       ()
   =
-  setup ~sandbox @@ fun ~config ~meta ~playground ->
+  setup ~sandbox
+  @@ fun ~config ~meta ~playground ~publication_recovery_access ->
   with_turn_sandbox_factory ~enabled:with_runtime ~config ~meta
   @@ fun turn_sandbox_factory ->
   let outside = Filename.concat config.Workspace.base_path "outside-write-targets" in
@@ -558,7 +627,8 @@ let test_symlink_component_swap_cannot_escape_allowed_root
       Keeper_tool_filesystem_runtime.handle_file_write
         ~turn_sandbox_factory
         ~config
-        ~keeper_name:meta.name
+        ~meta
+        ~publication_recovery_access
         ~gate_context
         ~args:(`Assoc (args_for target))
         ()
@@ -618,7 +688,8 @@ let test_sandbox_root_swap_after_open_keeps_pinned_capability
       ~with_runtime
       ()
   =
-  setup ~sandbox @@ fun ~config ~meta ~playground ->
+  setup ~sandbox
+  @@ fun ~config ~meta ~playground ~publication_recovery_access ->
   with_turn_sandbox_factory ~enabled:with_runtime ~config ~meta
   @@ fun turn_sandbox_factory ->
   let playground = Keeper_alerting_path.strip_trailing_slashes playground in
@@ -638,7 +709,8 @@ let test_sandbox_root_swap_after_open_keeps_pinned_capability
     Keeper_tool_filesystem_runtime.handle_file_write
       ~turn_sandbox_factory
       ~config
-      ~keeper_name:meta.name
+      ~meta
+      ~publication_recovery_access
       ~gate_context
       ~args:
         (`Assoc
@@ -662,7 +734,7 @@ let test_sandbox_root_swap_after_open_keeps_pinned_capability
 
 let test_docker_runtime_leaf_swap_preserves_exact_effect () =
   setup ~sandbox:Keeper_types_profile_sandbox.Docker
-  @@ fun ~config ~meta ~playground ->
+  @@ fun ~config ~meta ~playground ~publication_recovery_access ->
   with_turn_sandbox_factory ~enabled:true ~config ~meta
   @@ fun turn_sandbox_factory ->
   let outside = Filename.concat config.Workspace.base_path "leaf-swap-outside" in
@@ -693,7 +765,8 @@ let test_docker_runtime_leaf_swap_preserves_exact_effect () =
       Keeper_tool_filesystem_runtime.handle_file_write
         ~turn_sandbox_factory
         ~config
-        ~keeper_name:meta.name
+        ~meta
+        ~publication_recovery_access
         ~gate_context
         ~args:(`Assoc (("path", `String target) :: args))
         ()
@@ -756,7 +829,8 @@ let test_docker_runtime_leaf_swap_preserves_exact_effect () =
     Keeper_tool_filesystem_runtime.handle_file_write
       ~turn_sandbox_factory
       ~config
-      ~keeper_name:meta.name
+      ~meta
+      ~publication_recovery_access
       ~gate_context
       ~args:
         (`Assoc
@@ -774,11 +848,12 @@ let test_docker_runtime_leaf_swap_preserves_exact_effect () =
     (Fs_compat.load_file outside_target)
 
 let check_invalid_mode_is_rejected ~label ~mode ~expected_error =
-  setup @@ fun ~config ~meta ~playground ->
+  setup @@ fun ~config ~meta ~playground ~publication_recovery_access ->
   let path = Filename.concat playground (label ^ ".txt") in
   let raw =
     Keeper_tool_filesystem_runtime.handle_file_write ~turn_sandbox_factory:None ~config
-      ~keeper_name:meta.name
+      ~meta
+      ~publication_recovery_access
       ~args:
         (`Assoc
           [
@@ -807,7 +882,7 @@ let test_tab_only_mode_is_rejected () =
     ~expected_error:"mode must be one of [overwrite, append, patch], got \"\\t\"."
 
 let test_public_edit_file_uses_explicit_repo_path () =
-  setup @@ fun ~config ~meta ~playground ->
+  setup @@ fun ~config ~meta ~playground ~publication_recovery_access ->
   let repo = seed_single_playground_repo ~config ~meta playground in
   let path = Filename.concat repo "lib/src.ml" in
   ensure_dir (Filename.dirname path);
@@ -817,6 +892,7 @@ let test_public_edit_file_uses_explicit_repo_path () =
       ~public:"Edit"
       ~config
       ~meta
+      ~publication_recovery_access
       (`Assoc
         [
           ("file_path", `String "repos/masc/lib/src.ml");
@@ -829,7 +905,7 @@ let test_public_edit_file_uses_explicit_repo_path () =
     "let x = 2\n" (Fs_compat.load_file path)
 
 let test_public_write_file_uses_explicit_repo_path () =
-  setup @@ fun ~config ~meta ~playground ->
+  setup @@ fun ~config ~meta ~playground ~publication_recovery_access ->
   let repo = seed_single_playground_repo ~config ~meta playground in
   let path = Filename.concat repo "lib/generated.ml" in
   let raw =
@@ -837,6 +913,7 @@ let test_public_write_file_uses_explicit_repo_path () =
       ~public:"Write"
       ~config
       ~meta
+      ~publication_recovery_access
       (`Assoc
         [
           ("file_path", `String "repos/masc/lib/generated.ml");
@@ -848,14 +925,15 @@ let test_public_write_file_uses_explicit_repo_path () =
     "let generated = true\n" (Fs_compat.load_file path)
 
 let test_write_file_surfaces_missing_ide_observation_sink () =
-  setup @@ fun ~config ~meta ~playground ->
+  setup @@ fun ~config ~meta ~playground ~publication_recovery_access ->
   Agent_observation.reset_for_testing ();
   let path = Filename.concat playground "observed.ml" in
   let raw =
     Keeper_tool_filesystem_runtime.handle_file_write
       ~turn_sandbox_factory:None
       ~config
-      ~keeper_name:meta.name
+      ~meta
+      ~publication_recovery_access
       ~args:
         (`Assoc
           [ "path", `String path
@@ -873,7 +951,7 @@ let test_write_file_surfaces_missing_ide_observation_sink () =
     (parse_write_region_observation_error raw)
 
 let test_write_file_sanitizes_ide_observation_sink_failure () =
-  setup @@ fun ~config ~meta ~playground ->
+  setup @@ fun ~config ~meta ~playground ~publication_recovery_access ->
   Agent_observation.reset_for_testing ();
   Agent_observation.register_write_region_sink (fun _ ->
     Error Agent_observation.Write_region_sink_failed);
@@ -885,7 +963,8 @@ let test_write_file_sanitizes_ide_observation_sink_failure () =
          Keeper_tool_filesystem_runtime.handle_file_write
            ~turn_sandbox_factory:None
            ~config
-           ~keeper_name:meta.name
+           ~meta
+           ~publication_recovery_access
            ~args:
              (`Assoc
                [ "path", `String path

--- a/test/test_keeper_gate_effect_coverage.ml
+++ b/test/test_keeper_gate_effect_coverage.ml
@@ -49,12 +49,25 @@ let with_clean_gate_runtime f =
     f
 ;;
 
+let with_publication_recovery_registry ~registry_root ~owner f =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  Masc_test_deps.with_publication_recovery_lane
+    ~sw
+    ~fs:(Eio.Stdenv.fs env)
+    ~registry_root
+    ~owner
+    (fun ~publication_recovery_registry ~publication_recovery_access:_ ->
+       f publication_recovery_registry)
+;;
+
 let with_keeper_dispatch_probe f =
   let original = !Keeper_dispatch_ref.dispatch in
   let calls = ref [] in
   let dispatch
         ~config:_
         ~agent_name:_
+        ~publication_recovery_registry:_
         ?sw:_
         ?clock:_
         ?proc_mgr:_
@@ -139,12 +152,17 @@ let test_keeper_effects_defer_without_dispatch () =
    | Ok _ -> ()
    | Error error -> fail ("failed to select manual Gate mode: " ^ error));
   let meta = make_meta "gate-deferred-keeper" in
+  with_publication_recovery_registry
+    ~registry_root:base_path
+    ~owner:meta.name
+  @@ fun publication_recovery_registry ->
   with_keeper_dispatch_probe @@ fun calls ->
   List.iter
     (fun name ->
        let args = `Assoc [ "opaque", `String name ] in
        let raw =
          Keeper_tool_in_process_runtime.handle_masc_keeper
+           ~publication_recovery_registry
            ~config
            ~meta
            ~name
@@ -160,11 +178,18 @@ let test_keeper_effects_unavailable_without_dispatch () =
   with_clean_gate_runtime @@ fun () ->
   let config = Workspace.default_config "/dev/null" in
   let meta = make_meta "gate-unavailable-keeper" in
+  let registry_root = temp_dir "keeper-gate-unavailable-registry" in
+  Fun.protect ~finally:(fun () -> remove_tree registry_root) @@ fun () ->
+  with_publication_recovery_registry
+    ~registry_root
+    ~owner:meta.name
+  @@ fun publication_recovery_registry ->
   with_keeper_dispatch_probe @@ fun calls ->
   List.iter
     (fun name ->
        let raw =
          Keeper_tool_in_process_runtime.handle_masc_keeper
+           ~publication_recovery_registry
            ~config
            ~meta
            ~name
@@ -182,12 +207,17 @@ let test_keeper_effects_allow_exact_dispatch () =
   Fun.protect ~finally:(fun () -> remove_tree base_path) @@ fun () ->
   let config = Workspace.default_config base_path in
   let meta = make_meta ~always_allow:true "gate-allow-keeper" in
+  with_publication_recovery_registry
+    ~registry_root:base_path
+    ~owner:meta.name
+  @@ fun publication_recovery_registry ->
   with_keeper_dispatch_probe @@ fun calls ->
   List.iter
     (fun name ->
        let args = `Assoc [ "opaque", `String name ] in
        let raw =
          Keeper_tool_in_process_runtime.handle_masc_keeper
+           ~publication_recovery_registry
            ~config
            ~meta
            ~name

--- a/test/test_keeper_lifecycle_registry_dispatch.ml
+++ b/test/test_keeper_lifecycle_registry_dispatch.ml
@@ -13,6 +13,7 @@ module KST = Keeper_state_machine
 module KFS = Masc.Keeper_fs
 module KTS = Masc.Keeper_types_support
 module P = Masc.Otel_metric_store
+module Publication_scope = Masc.Keeper_publication_recovery_scope
 
 let temp_dir prefix =
   let dir = Filename.temp_file prefix "" in
@@ -30,6 +31,18 @@ let cleanup_dir dir =
         Unix.unlink path
   in
   try rm dir with _ -> ()
+
+let publication_recovery_registry env sw config =
+  let registry_root =
+    Eio.Path.(Eio.Stdenv.fs env / Masc.Workspace.masc_root_dir config)
+  in
+  match
+    Fs_compat.open_publication_recovery_registry ~sw ~registry_root
+  with
+  | Ok registry -> registry
+  | Error error ->
+    fail
+      (Fs_compat.publication_recovery_registry_error_to_string error)
 
 let write_lines path lines =
   let dir = KFS.ensure_dir (Filename.dirname path) in
@@ -558,6 +571,7 @@ let test_keepalive_dispatch_event_rejection_increments_metric () =
           clock = Eio.Stdenv.clock env;
           proc_mgr = Some (Eio.Stdenv.process_mgr env);
           net = None;
+          publication_recovery_registry = None;
         }
       in
       let labels =
@@ -582,6 +596,150 @@ let test_keepalive_dispatch_event_rejection_increments_metric () =
       check bool "keepalive registry rejection metric increments" true
         (after > before))
 
+let test_publication_recovery_scope_binds_exact_lane_resources () =
+  let base_dir = temp_dir "keeper_publication_recovery_scope" in
+  Fun.protect
+    ~finally:(fun () ->
+      KR.clear ();
+      cleanup_dir base_dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      KR.clear ();
+      let config = Masc.Workspace.default_config base_dir in
+      ignore
+        (Masc.Workspace.init config ~agent_name:(Some "test-operator"));
+      let keeper_name = "publication-scope-exact-lane" in
+      let meta = make_keeper_meta ~name:keeper_name () in
+      let entry = KR.register ~base_path:config.base_path keeper_name meta in
+      Eio.Switch.run @@ fun sw ->
+      let registry = publication_recovery_registry env sw config in
+      check bool "lane access begins detached" true
+        (Option.is_none (KR.publication_recovery_access entry));
+      Publication_scope.with_lane_scope
+        ~registry:(Some registry)
+        ~entry
+        (fun () ->
+          let attached_access =
+            match KR.publication_recovery_access entry with
+            | Some access -> access
+            | None -> fail "lane scope did not attach recovery access"
+          in
+          match
+            Publication_scope.resolve_turn_resources
+              ~registry:(Some registry)
+              ~base_path:config.base_path
+              ~keeper_name
+          with
+          | Error failure ->
+            fail (Publication_scope.failure_to_string failure)
+          | Ok resources ->
+            check bool "turn resolves exact registry entry" true
+              (resources.entry == entry);
+            check bool "turn resolves process registry" true
+              (resources.registry == registry);
+            check bool "turn resolves attached lane access" true
+              (resources.access == attached_access));
+      check bool "lane access detaches before scope returns" true
+        (Option.is_none (KR.publication_recovery_access entry));
+      match
+        Publication_scope.resolve_turn_resources
+          ~registry:(Some registry)
+          ~base_path:config.base_path
+          ~keeper_name
+      with
+      | Error Publication_scope.Access_not_attached -> ()
+      | Error failure ->
+        failf
+          "detached entry returned wrong failure: %s"
+          (Publication_scope.failure_to_string failure)
+      | Ok _ -> fail "detached entry unexpectedly resolved turn resources")
+
+let test_publication_recovery_scope_preserves_typed_lookup_failures () =
+  let base_dir = temp_dir "keeper_publication_recovery_failures" in
+  Fun.protect
+    ~finally:(fun () ->
+      KR.clear ();
+      cleanup_dir base_dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      KR.clear ();
+      let config = Masc.Workspace.default_config base_dir in
+      ignore
+        (Masc.Workspace.init config ~agent_name:(Some "test-operator"));
+      let keeper_name = "publication-scope-failures" in
+      let expect_failure label expected = function
+        | Error failure when expected failure -> ()
+        | Error failure ->
+          failf
+            "%s returned wrong failure: %s"
+            label
+            (Publication_scope.failure_to_string failure)
+        | Ok _ -> failf "%s unexpectedly resolved turn resources" label
+      in
+      expect_failure
+        "missing process registry"
+        (function
+          | Publication_scope.Registry_not_provided -> true
+          | _ -> false)
+        (Publication_scope.resolve_turn_resources
+           ~registry:None
+           ~base_path:config.base_path
+           ~keeper_name);
+      Eio.Switch.run @@ fun sw ->
+      let registry = publication_recovery_registry env sw config in
+      expect_failure
+        "missing keeper entry"
+        (function
+          | Publication_scope.Registry_entry_not_found
+              { base_path; keeper_name = missing_name } ->
+            String.equal base_path config.base_path
+            && String.equal missing_name keeper_name
+          | _ -> false)
+        (Publication_scope.resolve_turn_resources
+           ~registry:(Some registry)
+           ~base_path:config.base_path
+           ~keeper_name);
+      let entry =
+        KR.register
+          ~base_path:config.base_path
+          keeper_name
+          (make_keeper_meta ~name:keeper_name ())
+      in
+      expect_failure
+        "detached keeper entry"
+        (function
+          | Publication_scope.Access_not_attached -> true
+          | _ -> false)
+        (Publication_scope.resolve_turn_resources
+           ~registry:(Some registry)
+           ~base_path:config.base_path
+           ~keeper_name);
+      let corrupted =
+        { entry with
+          meta =
+            { entry.meta with
+              runtime = { entry.meta.runtime with generation = -1 }
+            }
+        }
+      in
+      KR.For_testing.unsafe_put_entry
+        ~base_path:config.base_path
+        keeper_name
+        corrupted;
+      expect_failure
+        "unhealthy keeper entry"
+        (function
+          | Publication_scope.Registry_entry_unhealthy
+              (KR.Required_field_missing { field }) ->
+            String.equal field "generation"
+          | _ -> false)
+        (Publication_scope.resolve_turn_resources
+           ~registry:(Some registry)
+           ~base_path:config.base_path
+           ~keeper_name))
+
 let () =
   run "keeper_lifecycle_registry_dispatch"
     [
@@ -603,6 +761,10 @@ let () =
             test_dispatch_keeper_phase_event_rejection_increments_metric;
           test_case "keepalive event rejection increments metric" `Quick
             test_keepalive_dispatch_event_rejection_increments_metric;
+          test_case "publication recovery scope binds exact lane resources" `Quick
+            test_publication_recovery_scope_binds_exact_lane_resources;
+          test_case "publication recovery scope preserves typed lookup failures" `Quick
+            test_publication_recovery_scope_preserves_typed_lookup_failures;
           test_case "registry rejects mismatched meta update" `Quick
             test_registry_rejects_meta_name_mismatch_update;
           test_case "registry canonicalizes mismatched meta on register" `Quick

--- a/test/test_keeper_path_containment_objective.ml
+++ b/test/test_keeper_path_containment_objective.ml
@@ -136,7 +136,7 @@ let test_atomic_replace_effect_uses_lexical_symlink_leaf () =
        Eio.Path.with_open_dir Eio.Path.(fs / base) @@ fun root ->
        let parent =
          Keeper_alerting_path.path_effect_parent_scope
-           ~relative_path:"."
+           ~parent_components:[]
            ~resource:(Eio.Path.stat ~follow:true root)
            ~create_missing_parents:[]
            ~created_directory_permissions:0o755
@@ -148,8 +148,14 @@ let test_atomic_replace_effect_uses_lexical_symlink_leaf () =
             ~result_file_permissions:0o644
             confined
         with
-        | Error error -> failf "atomic effect projection failed: %s" error
-        | Ok gate_effect ->
+        | Error error ->
+          failf
+            "atomic effect projection failed: %s"
+            (Keeper_alerting_path.path_effect_projection_error_to_string error)
+        | Ok projection ->
+          let gate_effect =
+            Keeper_alerting_path.atomic_replace_gate_effect projection
+          in
           let json = Keeper_alerting_path.path_effect_to_yojson gate_effect in
           check string "Gate operation matches rename semantics"
             "atomic_replace_entry"
@@ -193,18 +199,21 @@ let test_missing_parent_effect_is_complete () =
        Eio.Path.with_open_dir Eio.Path.(fs / base) @@ fun root ->
        let parent =
          Keeper_alerting_path.path_effect_parent_scope
-           ~relative_path:"."
+           ~parent_components:[]
            ~resource:(Eio.Path.stat ~follow:true root)
            ~create_missing_parents:[ "missing"; "nested" ]
            ~created_directory_permissions:0o755
          |> Result.get_ok
        in
-       let gate_effect =
+       let projection =
          Keeper_alerting_path.atomic_replace_effect
            ~parent
            ~result_file_permissions:0o644
            confined
          |> Result.get_ok
+       in
+       let gate_effect =
+         Keeper_alerting_path.atomic_replace_gate_effect projection
        in
        let missing =
          Keeper_alerting_path.path_effect_to_yojson gate_effect
@@ -218,6 +227,99 @@ let test_missing_parent_effect_is_complete () =
        in
        check (list (pair string int)) "Gate sees every parent and exact mode it may create"
          [ "missing", 0o755; "nested", 0o755 ] missing)
+;;
+
+let test_component_containment_rejects_sibling_prefix () =
+  with_roots @@ fun ~base ~outside:_ ->
+  let root_norm = Keeper_alerting_path.normalize_path_for_check_stripped base in
+  let sibling = base ^ "-sibling/file.txt" in
+  check bool "sibling string prefix is not containment" false
+    (Keeper_alerting_path.is_within_root_norm ~root_norm sibling)
+;;
+
+let test_dotdot_is_normalized_before_component_projection () =
+  with_roots @@ fun ~base ~outside:_ ->
+  let nested = Filename.concat base "nested" in
+  Unix.mkdir nested 0o755;
+  let requested = Filename.concat nested "../file.txt" in
+  match
+    Keeper_alerting_path.resolve_keeper_confined_path
+      ~config:(Workspace.default_config base)
+      ~allowed_paths:[]
+      ~endpoint:Keeper_alerting_path.Lexical_entry
+      ~raw_path:requested
+  with
+  | Error rejection ->
+    failf
+      "dotdot projection failed: %s"
+      (Keeper_path_rejection.rejection_to_user_message rejection)
+  | Ok confined ->
+    check (list string) "component SSOT contains no reparsed dotdot"
+      [ "file.txt" ]
+      (Keeper_alerting_path.confined_relative_components confined)
+;;
+
+let test_patch_source_uses_endpoint_components () =
+  with_roots @@ fun ~base ~outside:_ ->
+  let actual = Filename.concat base "actual" in
+  Unix.mkdir actual 0o755;
+  let actual_file = Filename.concat actual "file.txt" in
+  Fs_compat.save_file actual_file "referent";
+  let requested = Filename.concat base "link.txt" in
+  Unix.symlink actual_file requested;
+  match
+    Keeper_alerting_path.resolve_keeper_confined_path
+      ~config:(Workspace.default_config base)
+      ~allowed_paths:[]
+      ~endpoint:Keeper_alerting_path.Follow_referent
+      ~raw_path:requested
+  with
+  | Error rejection ->
+    failf
+      "patch source projection failed: %s"
+      (Keeper_path_rejection.rejection_to_user_message rejection)
+  | Ok confined ->
+    check (list string) "endpoint component SSOT follows the referent"
+      [ "actual"; "file.txt" ]
+      (Keeper_alerting_path.confined_endpoint_components confined);
+    (match Fs_compat.get_fs_opt () with
+     | None -> fail "Eio filesystem capability is unavailable"
+     | Some fs ->
+       Eio.Path.with_open_dir Eio.Path.(fs / base) @@ fun root ->
+       let parent =
+         Keeper_alerting_path.path_effect_parent_scope
+           ~parent_components:[]
+           ~resource:(Eio.Path.stat ~follow:true root)
+           ~create_missing_parents:[]
+           ~created_directory_permissions:0o755
+         |> Result.get_ok
+       in
+       let source_resource =
+         Eio.Path.stat ~follow:true Eio.Path.(root / "actual" / "file.txt")
+       in
+       let projection =
+         Keeper_alerting_path.patch_then_atomic_replace_effect
+           ~parent
+           ~source_resource
+           ~result_file_permissions:0o644
+           confined
+         |> Result.get_ok
+       in
+       let json =
+         projection
+         |> Keeper_alerting_path.atomic_replace_gate_effect
+         |> Keeper_alerting_path.path_effect_to_yojson
+       in
+       check string "replacement keeps lexical target" "link.txt"
+         Yojson.Safe.Util.
+           (json |> member "locator" |> member "relative_path" |> to_string);
+       check string "patch source is the resolved endpoint" "actual/file.txt"
+         Yojson.Safe.Util.
+           (json
+            |> member "locator"
+            |> member "source"
+            |> member "relative_path"
+            |> to_string))
 ;;
 
 let test_external_root_swap_fails_capability_identity () =
@@ -317,6 +419,14 @@ let () =
             `Quick
             test_symlink_escape_requires_explicit_root
         ; test_case
+            "sibling prefix is not containment"
+            `Quick
+            test_component_containment_rejects_sibling_prefix
+        ; test_case
+            "dotdot is normalized before projection"
+            `Quick
+            test_dotdot_is_normalized_before_component_projection
+        ; test_case
             "lexical endpoint requires a file entry"
             `Quick
             test_lexical_endpoint_requires_file_entry
@@ -324,6 +434,10 @@ let () =
             "atomic effect identity uses lexical symlink leaf"
             `Quick
             test_atomic_replace_effect_uses_lexical_symlink_leaf
+          ; test_case
+              "patch source uses endpoint components"
+              `Quick
+              test_patch_source_uses_endpoint_components
           ; test_case
             "external root swap fails capability identity"
             `Quick

--- a/test/test_keeper_path_rejection.ml
+++ b/test/test_keeper_path_rejection.ml
@@ -8,6 +8,10 @@ let test_messages_are_direct_projections () =
   check string "invalid lexical endpoint"
     "invalid_lexical_endpoint: path must name a file entry other than '.' or '..'"
     (R.rejection_to_user_message R.Invalid_lexical_endpoint);
+  check string "invalid normalized projection"
+    "invalid_normalized_path_projection: normalized path cannot be projected into lexical components: /tmp/../target"
+    (R.rejection_to_user_message
+       (R.Invalid_normalized_path_projection { path = "/tmp/../target" }));
   check string "invalid allowed roots"
     "allowed_paths_normalized_empty: 2 entries provided, none resolved to a valid path"
     (R.rejection_to_user_message (R.Allowed_paths_normalized_empty { count = 2 }));

--- a/test/test_keeper_registry_hardening.ml
+++ b/test/test_keeper_registry_hardening.ml
@@ -1,8 +1,7 @@
 (** P0 keeper registry hardening tests.
 
-    Verify typed validation errors on put/update, health-aware get, and the
-    tool-dispatch fallback path that uses the original meta when the registry
-    entry is corrupted. *)
+    Verify typed validation errors on put/update, health-aware get, and exact
+    turn-resource identity across same-name registry entry replacement. *)
 
 open Alcotest
 
@@ -158,6 +157,7 @@ let test_lane_fork_rejects_cancelling_switch () =
           (Lane.fork
              ~sw
              lane
+             ~with_run_scope:(fun run -> run ())
              ~run:(fun _ -> Atomic.set run_called true)
              ~cleanup:(fun _ ->
                Atomic.incr cleanup_calls;
@@ -304,44 +304,110 @@ let contains_substring text needle =
   needle_len = 0 || loop 0
 ;;
 
-let test_tool_dispatch_fallback_uses_original_meta () =
-  let dir = temp_dir "registry_fallback" in
+let test_tool_dispatch_preserves_exact_meta_after_replacement () =
+  let dir = temp_dir "registry_exact_turn_meta" in
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
        Eio_main.run @@ fun env ->
        Fs_compat.set_fs (Eio.Stdenv.fs env);
+       Eio.Switch.run @@ fun sw ->
        let config = Masc.Workspace.default_config dir in
-       let meta = make_meta "fallback-keeper" in
+       let meta =
+         { (make_meta "fallback-keeper") with
+           allowed_paths = [ config.base_path ]
+         }
+       in
+       let evidence = "exact-turn-meta-evidence" in
+       let evidence_path = Filename.concat config.base_path "exact-meta.txt" in
+       Out_channel.with_open_bin evidence_path (fun channel ->
+         Out_channel.output_string channel evidence);
        let ctx_work =
          Masc.Keeper_context_runtime.create ~eio:false ~system_prompt:"test"
            ~max_tokens:4000
        in
-       ignore (KR.register ~base_path:config.base_path meta.name meta);
+       let original_entry =
+         KR.register ~base_path:config.base_path meta.name meta
+       in
        Fun.protect
          ~finally:(fun () -> KR.unregister ~base_path:config.base_path meta.name)
          (fun () ->
+            Masc_test_deps.with_publication_recovery_lane
+              ~sw
+              ~fs:(Eio.Stdenv.fs env)
+              ~registry_root:dir
+              ~owner:meta.name
+              (fun ~publication_recovery_registry
+                   ~publication_recovery_access ->
+            (match
+               KR.attach_publication_recovery_access
+                 original_entry
+                 publication_recovery_access
+             with
+             | Ok () -> ()
+             | Error KR.Publication_recovery_already_attached ->
+               fail "original entry recovery access was already attached");
+            Fun.protect
+              ~finally:(fun () ->
+                match KR.detach_publication_recovery_access original_entry with
+                | Ok () -> ()
+                | Error KR.Publication_recovery_not_attached ->
+                  fail "original entry recovery access detached unexpectedly")
+              (fun () ->
+            let exact_resources =
+              match
+                Masc.Keeper_publication_recovery_scope.resolve_turn_resources
+                  ~registry:(Some publication_recovery_registry)
+                  ~base_path:config.base_path
+                  ~keeper_name:meta.name
+              with
+              | Ok resources -> resources
+              | Error failure ->
+                fail
+                  (Masc.Keeper_publication_recovery_scope.failure_to_string
+                     failure)
+            in
+            let replacement_meta =
+              { meta with
+                allowed_paths = [ Filename.concat config.base_path "other" ]
+              }
+            in
+            let replacement =
+              KR.register
+                ~base_path:config.base_path
+                replacement_meta.name
+                replacement_meta
+            in
             (match KR.get_with_health ~base_path:config.base_path meta.name with
-             | None -> fail "registered entry not found"
-             | Some (entry, _) ->
-               let corrupted_meta = { entry.meta with name = "wrong-name" } in
-               let corrupted = { entry with meta = corrupted_meta } in
-               KR.For_testing.unsafe_put_entry ~base_path:config.base_path meta.name corrupted);
+             | Some (current, KR.Healthy) ->
+               check bool "healthy replacement installed" true (current == replacement)
+             | Some (_, health) ->
+               fail
+                 ("replacement is unhealthy: "
+                  ^ KR.registry_entry_validation_error_to_string health)
+             | None -> fail "replacement entry not found");
             let result =
               KET.execute_keeper_tool_call_with_outcome
                 ~config
-                ~meta
+                ~meta:exact_resources.entry.meta
+                ~publication_recovery_registry:exact_resources.registry
+                ~publication_recovery_access:exact_resources.access
                 ~ctx_work
                 ~exec_cache:None
                 ~name:"Read"
-                ~input:(`Assoc [ ("file_path", `String "dune-project") ])
+                ~input:(`Assoc [ ("file_path", `String "exact-meta.txt") ])
                 ()
             in
+            let content =
+              Yojson.Safe.from_string result.raw_output
+              |> Yojson.Safe.Util.member "content"
+              |> Yojson.Safe.Util.to_string
+            in
             check
-              bool
-              "fallback used original meta (Read not denied by corrupted registry entry)"
-              false
-              (contains_substring result.raw_output "\"error\":\"tool_not_allowed\"")))
+              string
+              "dispatch uses exact admitted meta, not same-name replacement meta"
+              evidence
+              content))))
 ;;
 
 let () =
@@ -398,9 +464,9 @@ let () =
             `Quick
             test_wakeup_denies_dead_tombstone_without_signaling
         ] )
-    ; ( "tool_dispatch_fallback"
-      , [ test_case "uses original meta on corrupted registry entry" `Quick
-            test_tool_dispatch_fallback_uses_original_meta
+    ; ( "tool_dispatch_exact_resources"
+      , [ test_case "preserves exact meta after healthy entry replacement" `Quick
+            test_tool_dispatch_preserves_exact_meta_after_replacement
         ] )
     ]
 ;;

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -506,14 +506,27 @@ let test_missing_persona_without_profile_or_toml_is_error () =
      | Sup.Persona_drift_error -> true
      | Sup.Persona_drift_warn -> false)
 
+let publication_recovery_registry env sw config =
+  let registry_root =
+    Eio.Path.(Eio.Stdenv.fs env / Masc.Workspace.masc_root_dir config)
+  in
+  match
+    Fs_compat.open_publication_recovery_registry ~sw ~registry_root
+  with
+  | Ok registry -> Some registry
+  | Error error ->
+    fail
+      (Fs_compat.publication_recovery_registry_error_to_string error)
+
 let keeper_runtime_context env sw config : _ Keeper_types_profile.context =
-  {
-    config;
-    agent_name = supervisor_agent_name;
-    sw;
-    clock = Eio.Stdenv.clock env;
-    proc_mgr = Some (Eio.Stdenv.process_mgr env);
-    net = Some (Eio.Stdenv.net env);
+  { config
+  ; agent_name = supervisor_agent_name
+  ; sw
+  ; clock = Eio.Stdenv.clock env
+  ; proc_mgr = Some (Eio.Stdenv.process_mgr env)
+  ; net = Some (Eio.Stdenv.net env)
+  ; publication_recovery_registry =
+      publication_recovery_registry env sw config
   }
 
 let latest_log_seq () =
@@ -969,6 +982,8 @@ let test_sweep_does_not_synthesize_gate_from_runtime_blocker () =
           clock = Eio.Stdenv.clock env;
           proc_mgr = Some (Eio.Stdenv.process_mgr env);
           net = Some (Eio.Stdenv.net env);
+          publication_recovery_registry =
+            publication_recovery_registry env sw config;
         }
       in
       let pending_before = AQ.pending_count () in
@@ -1099,6 +1114,8 @@ let test_restart_path_emits_attempt_and_started_outcome_metrics () =
           clock = Eio.Stdenv.clock env;
           proc_mgr = Some (Eio.Stdenv.process_mgr env);
           net = Some (Eio.Stdenv.net env);
+          publication_recovery_registry =
+            publication_recovery_registry env sw config;
         }
       in
       sweep_and_recover_no_materialize ctx;
@@ -1158,6 +1175,8 @@ let test_restart_path_emits_meta_unavailable_outcome_metric () =
           clock = Eio.Stdenv.clock env;
           proc_mgr = Some (Eio.Stdenv.process_mgr env);
           net = Some (Eio.Stdenv.net env);
+          publication_recovery_registry =
+            publication_recovery_registry env sw config;
         }
       in
       sweep_and_recover_no_materialize ctx;
@@ -1231,6 +1250,8 @@ let test_restart_denies_persisted_dead_tombstone () =
         ; clock = Eio.Stdenv.clock env
         ; proc_mgr = Some (Eio.Stdenv.process_mgr env)
         ; net = Some (Eio.Stdenv.net env)
+        ; publication_recovery_registry =
+            publication_recovery_registry env sw config
         }
       in
       sweep_and_recover_no_materialize ctx;
@@ -1298,6 +1319,8 @@ let with_reap_ready_dead_keeper name f =
           ; clock = Eio.Stdenv.clock env
           ; proc_mgr = Some (Eio.Stdenv.process_mgr env)
           ; net = Some (Eio.Stdenv.net env)
+          ; publication_recovery_registry =
+              publication_recovery_registry env sw config
           }
         in
         sweep_and_recover_no_materialize ctx
@@ -1380,6 +1403,8 @@ let test_legacy_stale_fleet_batch_routes_to_restart () =
           clock = Eio.Stdenv.clock env;
           proc_mgr = Some (Eio.Stdenv.process_mgr env);
           net = Some (Eio.Stdenv.net env);
+          publication_recovery_registry =
+            publication_recovery_registry env sw config;
         }
       in
       sweep_and_recover_no_materialize ctx;
@@ -1497,6 +1522,8 @@ let test_launch_rejected_terminal_state_does_not_announce_running () =
           clock = Eio.Stdenv.clock env;
           proc_mgr = Some (Eio.Stdenv.process_mgr env);
           net = Some (Eio.Stdenv.net env);
+          publication_recovery_registry =
+            publication_recovery_registry env sw config;
         }
       in
       Sup.with_restart_launch_noop_for_test (fun () ->
@@ -1561,6 +1588,8 @@ let test_launch_fork_rejection_does_not_announce_running () =
           clock = Eio.Stdenv.clock env;
           proc_mgr = Some (Eio.Stdenv.process_mgr env);
           net = Some (Eio.Stdenv.net env);
+          publication_recovery_registry =
+            publication_recovery_registry env sw config;
         }
       in
       (match
@@ -1609,6 +1638,8 @@ let test_fork_rejection_preserves_replacement_lane () =
         ; clock = Eio.Stdenv.clock env
         ; proc_mgr = Some (Eio.Stdenv.process_mgr env)
         ; net = Some (Eio.Stdenv.net env)
+        ; publication_recovery_registry =
+            publication_recovery_registry env sw config
         }
       in
       (match
@@ -1659,6 +1690,8 @@ let test_fork_rejection_unregisters_non_terminalizable_owner () =
         ; clock = Eio.Stdenv.clock env
         ; proc_mgr = Some (Eio.Stdenv.process_mgr env)
         ; net = Some (Eio.Stdenv.net env)
+        ; publication_recovery_registry =
+            publication_recovery_registry env sw config
         }
       in
       (match
@@ -1698,6 +1731,8 @@ let test_sweep_waits_for_lane_join_before_unregister () =
         ; clock = Eio.Stdenv.clock env
         ; proc_mgr = Some (Eio.Stdenv.process_mgr env)
         ; net = Some (Eio.Stdenv.net env)
+        ; publication_recovery_registry =
+            publication_recovery_registry env sw config
         }
       in
       sweep_and_recover_no_materialize ctx;
@@ -1772,6 +1807,8 @@ let test_idle_duration_never_stops_keeper () =
           clock = Eio.Stdenv.clock env;
           proc_mgr = Some (Eio.Stdenv.process_mgr env);
           net = Some (Eio.Stdenv.net env);
+          publication_recovery_registry =
+            publication_recovery_registry env sw config;
         }
       in
       sweep_and_recover_no_materialize ctx;
@@ -1827,6 +1864,8 @@ let test_non_storm_crashed_restarts_normally () =
           clock = Eio.Stdenv.clock env;
           proc_mgr = Some (Eio.Stdenv.process_mgr env);
           net = Some (Eio.Stdenv.net env);
+          publication_recovery_registry =
+            publication_recovery_registry env sw config;
         }
       in
       sweep_and_recover_no_materialize ctx;
@@ -1884,7 +1923,15 @@ let test_persisted_blocker_survives_unregister () =
       Reg.set_failure_reason ~base_path:config.base_path name
         (Some (Reg.Stale_termination_storm { count = 5 }));
       let ctx : _ Keeper_types_profile.context =
-        { config; agent_name = supervisor_agent_name; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env); net = Some (Eio.Stdenv.net env) }
+        { config
+        ; agent_name = supervisor_agent_name
+        ; sw
+        ; clock = Eio.Stdenv.clock env
+        ; proc_mgr = Some (Eio.Stdenv.process_mgr env)
+        ; net = Some (Eio.Stdenv.net env)
+        ; publication_recovery_registry =
+            publication_recovery_registry env sw config
+        }
       in
       sweep_and_recover_no_materialize ctx;
       

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -1306,8 +1306,16 @@ let test_masc_task_set_goal_is_described_and_dispatched () =
    [Keeper_tool_surface] is forgotten. *)
 let test_keeper_dispatch_ref_reaches_every_keeper_descriptor () =
   with_temp_dir "keeper_dispatch_gap" (fun dir ->
+    Eio_main.run @@ fun env ->
+    Eio.Switch.run @@ fun sw ->
     let config = Workspace.default_config dir in
     let agent_name = "test-agent" in
+    Masc_test_deps.with_publication_recovery_lane
+      ~sw
+      ~fs:(Eio.Stdenv.fs env)
+      ~registry_root:dir
+      ~owner:agent_name
+    @@ fun ~publication_recovery_registry ~publication_recovery_access:_ ->
     let keeper_descriptors =
       Descriptor.all_descriptors ()
       |> List.filter (fun d ->
@@ -1320,7 +1328,13 @@ let test_keeper_dispatch_ref_reaches_every_keeper_descriptor () =
         (fun d ->
            let name = d.Descriptor.internal_name in
            match
-             !Keeper_dispatch_ref.dispatch ~config ~agent_name ~name ~args:(`Assoc []) ()
+             !Keeper_dispatch_ref.dispatch
+               ~config
+               ~agent_name
+               ~publication_recovery_registry:(Some publication_recovery_registry)
+               ~name
+               ~args:(`Assoc [])
+               ()
            with
            | Some _ -> None
            | None -> Some name)

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -82,6 +82,7 @@ let with_exec_fixture ?(process = false) ?(always_allow = false) name fn =
     (fun () ->
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
+      Eio.Switch.run @@ fun sw ->
       if process
       then
         Process_eio.init
@@ -97,7 +98,19 @@ let with_exec_fixture ?(process = false) ?(always_allow = false) name fn =
       Fun.protect
         ~finally:(fun () ->
           Masc.Keeper_registry.unregister ~base_path:config.base_path meta.name)
-        (fun () -> fn ~config ~meta ~ctx_work:(make_ctx ())))
+        (fun () ->
+          Masc_test_deps.with_publication_recovery_lane
+            ~sw
+            ~fs:(Eio.Stdenv.fs env)
+            ~registry_root:dir
+            ~owner:meta.name
+            (fun ~publication_recovery_registry ~publication_recovery_access ->
+               fn
+                 ~config
+                 ~meta
+                 ~publication_recovery_registry
+                 ~publication_recovery_access
+                 ~ctx_work:(make_ctx ()))))
 
 let contains_substring text needle =
   let text_len = String.length text in
@@ -181,11 +194,14 @@ let check_success_result label result =
 let test_public_read_rejects_unsupported_range_fields () =
   with_exec_fixture
     "keeper_tool_dispatch_runtime_read_rejects_range_fields"
-    (fun ~config ~meta ~ctx_work ->
+    (fun ~config ~meta ~publication_recovery_registry
+         ~publication_recovery_access ~ctx_work ->
       let result =
         KET.execute_keeper_tool_call_with_outcome
           ~config
           ~meta
+          ~publication_recovery_registry
+          ~publication_recovery_access
           ~ctx_work
           ~exec_cache:None
           ~name:"Read"
@@ -221,11 +237,14 @@ let test_public_read_rejects_unsupported_range_fields () =
 let test_public_read_rejects_offset_without_enrichment () =
   with_exec_fixture
     "keeper_tool_dispatch_runtime_read_rejects_offset"
-    (fun ~config ~meta ~ctx_work ->
+    (fun ~config ~meta ~publication_recovery_registry
+         ~publication_recovery_access ~ctx_work ->
       let result =
         KET.execute_keeper_tool_call_with_outcome
           ~config
           ~meta
+          ~publication_recovery_registry
+          ~publication_recovery_access
           ~ctx_work
           ~exec_cache:None
           ~name:"Read"
@@ -506,7 +525,8 @@ let test_keeper_tools_list_json_uses_typed_groups () =
 
 let test_execute_with_outcome_missing_file_is_failure () =
   with_exec_fixture "keeper_tool_dispatch_runtime_missing_file"
-    (fun ~config ~meta ~ctx_work ->
+    (fun ~config ~meta ~publication_recovery_registry
+         ~publication_recovery_access ~ctx_work ->
       let repo_dir =
         Filename.concat
           (Filename.concat (KES.keeper_playground_root ~config ~meta) "repos")
@@ -515,7 +535,8 @@ let test_execute_with_outcome_missing_file_is_failure () =
       mkdir_p (Filename.concat repo_dir ".git");
       let result =
         KET.execute_keeper_tool_call_with_outcome
-          ~config ~meta ~ctx_work ~exec_cache:None
+          ~config ~meta ~publication_recovery_registry
+          ~publication_recovery_access ~ctx_work ~exec_cache:None
           ~name:"Read"
           ~input:(`Assoc [ ("file_path", `String "config/runtime.toml") ])
           ()
@@ -534,10 +555,12 @@ let test_execute_with_outcome_missing_file_is_failure () =
 
 let test_tool_search_without_session_searcher_is_unavailable () =
   with_exec_fixture "keeper_tool_dispatch_runtime_search_unavailable"
-    (fun ~config ~meta ~ctx_work ->
+    (fun ~config ~meta ~publication_recovery_registry
+         ~publication_recovery_access ~ctx_work ->
       let result =
         KET.execute_keeper_tool_call_with_outcome
-          ~config ~meta ~ctx_work ~exec_cache:None
+          ~config ~meta ~publication_recovery_registry
+          ~publication_recovery_access ~ctx_work ~exec_cache:None
           ~name:"keeper_tool_search"
           ~input:(`Assoc [])
           ()
@@ -553,7 +576,8 @@ let test_tool_search_without_session_searcher_is_unavailable () =
 
 let test_tool_search_uses_exact_injected_searcher () =
   with_exec_fixture "keeper_tool_dispatch_runtime_injected_search"
-    (fun ~config ~meta ~ctx_work ->
+    (fun ~config ~meta ~publication_recovery_registry
+         ~publication_recovery_access ~ctx_work ->
       let observed = ref false in
       let search_fn () =
         observed := true;
@@ -566,7 +590,8 @@ let test_tool_search_uses_exact_injected_searcher () =
       in
       let result =
         KET.execute_keeper_tool_call_with_outcome
-          ~config ~meta ~ctx_work ~exec_cache:None ~search_fn
+          ~config ~meta ~publication_recovery_registry
+          ~publication_recovery_access ~ctx_work ~exec_cache:None ~search_fn
           ~name:"keeper_tool_search"
           ~input:(`Assoc [])
           ()
@@ -583,7 +608,8 @@ let test_model_visible_local_tools_dispatch_to_runtime_handlers () =
     ~process:true
     ~always_allow:true
     "keeper_tool_dispatch_runtime_model_tools"
-    (fun ~config ~meta ~ctx_work ->
+    (fun ~config ~meta ~publication_recovery_registry
+         ~publication_recovery_access ~ctx_work ->
       let playground = KES.keeper_default_write_root ~config ~meta in
       let visible_file_path = "model-visible.txt" in
       let file_path = Filename.concat playground visible_file_path in
@@ -591,6 +617,8 @@ let test_model_visible_local_tools_dispatch_to_runtime_handlers () =
         KET.execute_keeper_tool_call_with_outcome
           ~config
           ~meta
+          ~publication_recovery_registry
+          ~publication_recovery_access
           ~ctx_work
           ~exec_cache:None
           ~name
@@ -657,7 +685,8 @@ let test_model_visible_local_tools_dispatch_to_runtime_handlers () =
 
 let test_keeper_task_claim_accepts_specific_task_id () =
   with_exec_fixture "keeper_tool_dispatch_specific_task_claim"
-    (fun ~config ~meta ~ctx_work ->
+    (fun ~config ~meta ~publication_recovery_registry
+         ~publication_recovery_access ~ctx_work ->
       ignore (Workspace.init config ~agent_name:(Some meta.agent_name));
       ignore
         (Workspace.add_task config ~title:"higher priority task" ~priority:1
@@ -669,6 +698,8 @@ let test_keeper_task_claim_accepts_specific_task_id () =
         KET.execute_keeper_tool_call_with_outcome
           ~config
           ~meta
+          ~publication_recovery_registry
+          ~publication_recovery_access
           ~ctx_work
           ~exec_cache:None
           ~name:"keeper_task_claim"
@@ -701,11 +732,14 @@ let test_keeper_task_claim_accepts_specific_task_id () =
 
 let test_unknown_tool_returns_exact_error () =
   with_exec_fixture "keeper_tool_dispatch_runtime_unknown_tool"
-    (fun ~config ~meta ~ctx_work ->
+    (fun ~config ~meta ~publication_recovery_registry
+         ~publication_recovery_access ~ctx_work ->
       let result =
         KET.execute_keeper_tool_call_with_outcome
           ~config
           ~meta
+          ~publication_recovery_registry
+          ~publication_recovery_access
           ~ctx_work
           ~exec_cache:None
           ~name:"Glob"
@@ -725,7 +759,8 @@ let test_unknown_tool_returns_exact_error () =
 
 let test_model_visible_web_search_dispatches_to_misc_runtime () =
   with_exec_fixture ~always_allow:true "keeper_tool_dispatch_web_search"
-    (fun ~config ~meta ~ctx_work ->
+    (fun ~config ~meta ~publication_recovery_registry
+         ~publication_recovery_access ~ctx_work ->
       Masc.Tool_misc.with_web_search_simulation_for_test
         ~outcomes:
           [
@@ -743,6 +778,8 @@ let test_model_visible_web_search_dispatches_to_misc_runtime () =
             KET.execute_keeper_tool_call_with_outcome
               ~config
               ~meta
+              ~publication_recovery_registry
+              ~publication_recovery_access
               ~ctx_work
               ~exec_cache:None
               ~name:"WebSearch"
@@ -778,7 +815,8 @@ let test_model_visible_web_search_dispatches_to_misc_runtime () =
 
 let test_model_visible_web_fetch_dispatches_to_misc_runtime () =
   with_exec_fixture ~always_allow:true "keeper_tool_dispatch_web_fetch"
-    (fun ~config ~meta ~ctx_work ->
+    (fun ~config ~meta ~publication_recovery_registry
+         ~publication_recovery_access ~ctx_work ->
       let requested_url = "https://example.com/model-web-fetch" in
       let html =
         {|
@@ -811,6 +849,8 @@ let test_model_visible_web_fetch_dispatches_to_misc_runtime () =
             KET.execute_keeper_tool_call_with_outcome
               ~config
               ~meta
+              ~publication_recovery_registry
+              ~publication_recovery_access
               ~ctx_work
               ~exec_cache:None
               ~name:"WebFetch"
@@ -854,7 +894,8 @@ let test_public_masc_web_fetch_reaches_localhost_after_gate () =
   with_exec_fixture
     ~always_allow:true
     "keeper_tool_dispatch_web_fetch_reaches_localhost"
-    (fun ~config ~meta ~ctx_work ->
+    (fun ~config ~meta ~publication_recovery_registry
+         ~publication_recovery_access ~ctx_work ->
       Masc.Tool_misc.with_web_fetch_http_get_for_test
         (fun ~timeout_sec:_ ~headers:_ ~max_response_bytes:_ url ->
           check string "local url forwarded" "http://127.0.0.1:8935/health" url;
@@ -864,6 +905,8 @@ let test_public_masc_web_fetch_reaches_localhost_after_gate () =
             KET.execute_keeper_tool_call_with_outcome
               ~config
               ~meta
+              ~publication_recovery_registry
+              ~publication_recovery_access
               ~ctx_work
               ~exec_cache:None
               ~name:"WebFetch"
@@ -876,7 +919,8 @@ let test_public_masc_web_fetch_reaches_localhost_after_gate () =
 
 let test_manual_gate_defers_web_tools_before_network () =
   with_exec_fixture "keeper_tool_dispatch_manual_web_gate"
-    (fun ~config ~meta ~ctx_work ->
+    (fun ~config ~meta ~publication_recovery_registry
+         ~publication_recovery_access ~ctx_work ->
       (match
          Masc.Keeper_gate_mode.set
            config
@@ -901,6 +945,8 @@ let test_manual_gate_defers_web_tools_before_network () =
                 KET.execute_keeper_tool_call_with_outcome
                   ~config
                   ~meta
+                  ~publication_recovery_registry
+                  ~publication_recovery_access
                   ~ctx_work
                   ~exec_cache:None
                   ~name:"WebSearch"
@@ -911,6 +957,8 @@ let test_manual_gate_defers_web_tools_before_network () =
                 KET.execute_keeper_tool_call_with_outcome
                   ~config
                   ~meta
+                  ~publication_recovery_registry
+                  ~publication_recovery_access
                   ~ctx_work
                   ~exec_cache:None
                   ~name:"WebFetch"
@@ -962,7 +1010,8 @@ let test_tool_result_or_error_preserves_failure_class () =
 
 let test_tool_execute_raw_cmd_requires_typed_shell_ir () =
   with_exec_fixture "tool_execute_raw_cmd_requires_typed_shell_ir"
-    (fun ~config ~meta ~ctx_work ->
+    (fun ~config ~meta ~publication_recovery_registry
+         ~publication_recovery_access ~ctx_work ->
       let input =
         `Assoc
           [ ( "cmd"
@@ -971,7 +1020,8 @@ let test_tool_execute_raw_cmd_requires_typed_shell_ir () =
       in
       let run () =
         KET.execute_keeper_tool_call
-          ~config ~meta ~ctx_work ~exec_cache:None
+          ~config ~meta ~publication_recovery_registry
+          ~publication_recovery_access ~ctx_work ~exec_cache:None
           ~name:"tool_execute" ~input ()
       in
       let outputs = List.init 4 (fun _ -> run ()) in
@@ -1016,22 +1066,35 @@ let test_oas_handler_threads_eio_context_to_keeper_dispatch () =
       let config = Workspace.default_config dir in
       let meta = make_meta () in
       ignore (Masc.Keeper_registry.register ~base_path:config.base_path meta.name meta);
+      Masc_test_deps.with_publication_recovery_lane
+        ~sw:root_sw
+        ~fs:(Eio.Stdenv.fs env)
+        ~registry_root:dir
+        ~owner:meta.name
+        (fun ~publication_recovery_registry ~publication_recovery_access ->
       let previous_dispatch = !(Masc.Keeper_dispatch_ref.dispatch) in
       let saw_turn_sw = Atomic.make false in
       let saw_clock = Atomic.make false in
+      let saw_registry = Atomic.make false in
       Fun.protect
         ~finally:(fun () ->
           Masc.Keeper_dispatch_ref.dispatch := previous_dispatch;
           Masc.Keeper_registry.unregister ~base_path:config.base_path meta.name)
         (fun () ->
           Masc.Keeper_dispatch_ref.dispatch :=
-            (fun ~config:_ ~agent_name:_ ?sw ?clock ?proc_mgr:_ ?net:_ ?mcp_session_id:_
+            (fun ~config:_ ~agent_name:_
+                 ~publication_recovery_registry:observed_registry
+                 ?sw ?clock ?proc_mgr:_ ?net:_ ?mcp_session_id:_
                  ?authorize_external_effect:_
                  ~name ~args:_ () ->
               check string "keeper dispatch tool" "masc_keeper_msg" name;
               Atomic.set saw_turn_sw
                 (match sw with Some sw -> sw == turn_sw | None -> false);
               Atomic.set saw_clock (Option.is_some clock);
+              Atomic.set saw_registry
+                (match observed_registry with
+                 | Some registry -> registry == publication_recovery_registry
+                 | None -> false);
               Some
                 (Tool_result.ok ~tool_name:name ~start_time:0.0
                    "{\"ok\":true,\"request_id\":\"test-request\"}"));
@@ -1041,6 +1104,8 @@ let test_oas_handler_threads_eio_context_to_keeper_dispatch () =
               ~input_schema:(keeper_msg_input_schema ())
               ~config
               ~meta
+              ~publication_recovery_registry
+              ~publication_recovery_access
               ~ctx_snapshot:(make_ctx ())
               ~exec_cache:None
               ()
@@ -1055,7 +1120,8 @@ let test_oas_handler_threads_eio_context_to_keeper_dispatch () =
           in
           check bool "handler succeeds" true (Tool_result.is_success result);
           check bool "turn switch reaches keeper dispatch" true (Atomic.get saw_turn_sw);
-          check bool "clock reaches keeper dispatch" true (Atomic.get saw_clock)))
+          check bool "clock reaches keeper dispatch" true (Atomic.get saw_clock);
+          check bool "registry reaches keeper dispatch" true (Atomic.get saw_registry))))
 
 let registered_dispatch_probe_tool = "test_keeper_registered_dispatch_probe"
 
@@ -1110,10 +1176,14 @@ let register_typed_outcome_probe name make_result =
 
 let execute_registered_probe ~fixture ~name ~make_result =
   register_typed_outcome_probe name make_result;
-  with_exec_fixture fixture (fun ~config ~meta ~ctx_work ->
+  with_exec_fixture fixture
+    (fun ~config ~meta ~publication_recovery_registry
+         ~publication_recovery_access ~ctx_work ->
     KET.execute_keeper_tool_call_with_outcome
       ~config
       ~meta
+      ~publication_recovery_registry
+      ~publication_recovery_access
       ~ctx_work
       ~exec_cache:None
       ~name
@@ -1186,7 +1256,8 @@ let test_registered_tool_dispatch_without_masc_prefix () =
   check bool "probe has no masc_ prefix" false
     (String.starts_with ~prefix:"masc_" registered_dispatch_probe_tool);
   with_exec_fixture "keeper_tool_dispatch_registered_dispatch"
-    (fun ~config ~meta ~ctx_work:_ ->
+    (fun ~config ~meta ~publication_recovery_registry:_
+         ~publication_recovery_access:_ ~ctx_work:_ ->
       match
         Masc.Keeper_tool_registered_runtime.handle_registered_tool_with_outcome
           ~config
@@ -1205,7 +1276,8 @@ let test_registered_tool_dispatch_without_masc_prefix () =
 let test_registered_dispatch_preserves_workflow_failure_class () =
   register_workflow_rejection_probe ();
   with_exec_fixture "keeper_tool_dispatch_registered_workflow_rejection"
-    (fun ~config ~meta ~ctx_work:_ ->
+    (fun ~config ~meta ~publication_recovery_registry:_
+         ~publication_recovery_access:_ ~ctx_work:_ ->
       match
         Masc.Keeper_tool_registered_runtime.handle_registered_tool_with_outcome
           ~config
@@ -1316,11 +1388,14 @@ let check_bundle_has_no_inferred_descriptor ~msg tools name =
 let test_model_visible_tools_do_not_infer_oas_descriptors () =
   with_exec_fixture
     "model_visible_oas_descriptors"
-    (fun ~config ~meta ~ctx_work:_ ->
+    (fun ~config ~meta ~publication_recovery_registry
+         ~publication_recovery_access ~ctx_work:_ ->
        let tools =
          Masc.Keeper_tools_oas_bundle.make_tools
            ~config
            ~meta
+           ~publication_recovery_registry
+           ~publication_recovery_access
            ~ctx_snapshot:(make_ctx ())
            ()
        in

--- a/test/test_keeper_tool_matrix.ml
+++ b/test/test_keeper_tool_matrix.ml
@@ -364,6 +364,8 @@ let test_keeper_oas_bundle_materializes_masc_fusion_tool () =
     ~finally:(fun () ->
       if Sys.file_exists marker then Cases.cleanup_dir marker)
     (fun () ->
+      Eio_main.run @@ fun env ->
+      Eio.Switch.run @@ fun sw ->
       let config = Masc.Workspace.default_config marker in
       let meta = Cases.make_meta ~name:"keeper-fusion-schema" () in
       let ctx_snapshot =
@@ -372,8 +374,16 @@ let test_keeper_oas_bundle_materializes_masc_fusion_tool () =
           ~system_prompt:"keeper fusion schema regression"
           ~max_tokens:4000
       in
+      Masc_test_deps.with_publication_recovery_lane
+        ~sw
+        ~fs:(Eio.Stdenv.fs env)
+        ~registry_root:marker
+        ~owner:meta.name
+      @@ fun ~publication_recovery_registry ~publication_recovery_access ->
       let tools =
-        Masc.Keeper_tools_oas_bundle.make_tools ~config ~meta ~ctx_snapshot ()
+        Masc.Keeper_tools_oas_bundle.make_tools
+          ~config ~meta ~publication_recovery_registry
+          ~publication_recovery_access ~ctx_snapshot ()
       in
       let names =
         List.map (fun (tool : Agent_sdk.Tool.t) -> tool.schema.name) tools

--- a/test/test_keeper_tool_matrix_cases.ml
+++ b/test/test_keeper_tool_matrix_cases.ml
@@ -124,7 +124,9 @@ let init_keeper_bridge =
       Masc.Keeper_tool_shared_runtime.tag_dispatch_fn := Masc.Keeper_tag_dispatch.dispatch;
       KET.inject_masc_schemas Masc.Config.raw_all_tool_schemas)
 
-let make_meta ?(name = "keeper-tool-matrix") () =
+let keeper_matrix_owner = "keeper-tool-matrix"
+
+let make_meta ?(name = keeper_matrix_owner) () =
   match
     Masc_test_deps.meta_of_json_fixture
       (`Assoc
@@ -152,7 +154,18 @@ let all_keeper_tool_names =
   all_keeper_tool_schemas_raw ()
   |> List.map (fun (schema : Masc_domain.tool_schema) -> schema.name)
 
-let make_fixture sw ~proc_mgr ~fs ~net ~mono_clock clock ~base_path init_mode =
+let make_fixture
+      sw
+      ~proc_mgr
+      ~fs
+      ~net
+      ~mono_clock
+      clock
+      ~base_path
+      ~publication_recovery_registry
+      ~publication_recovery_access
+      init_mode
+  =
   init_keeper_bridge ();
   let generic =
     Generic.make_fixture sw ~proc_mgr ~fs ~net ~mono_clock clock ~base_path init_mode
@@ -171,7 +184,15 @@ let make_fixture sw ~proc_mgr ~fs ~net ~mono_clock clock ~base_path init_mode =
   Masc.Keeper_registry.clear ();
   ignore (Masc.Keeper_registry.register ~base_path meta.name meta);
   ignore (Masc.Keeper_registry.register ~base_path "tool-matrix" meta);
-  let tools = KTO.make_tools ~config ~meta ~ctx_snapshot () in
+  let tools =
+    KTO.make_tools
+      ~config
+      ~meta
+      ~publication_recovery_registry
+      ~publication_recovery_access
+      ~ctx_snapshot
+      ()
+  in
   (match init_mode with
    | Init_joined ->
        (* Bind under both the raw meta name (used by masc_* tools called
@@ -634,24 +655,44 @@ let run_case sw ~proc_mgr ~fs ~net ~mono_clock clock
         Unix.putenv "HOME" base_path;
         try
           let case = case_for_name schema.Masc_domain.name in
+          Masc_test_deps.with_publication_recovery_lane
+            ~sw
+            ~fs
+            ~registry_root:base_path
+            ~owner:keeper_matrix_owner
+          @@ fun ~publication_recovery_registry ~publication_recovery_access ->
           let fixture =
-            make_fixture sw ~proc_mgr ~fs ~net ~mono_clock clock ~base_path
+            make_fixture
+              sw
+              ~proc_mgr
+              ~fs
+              ~net
+              ~mono_clock
+              clock
+              ~base_path
+              ~publication_recovery_registry
+              ~publication_recovery_access
               case.init_mode
           in
           case.prepare fixture;
           let args = case.arguments fixture schema in
           match find_tool fixture schema.Masc_domain.name with
           | None ->
-              Error
-                (Printf.sprintf "missing keeper Tool.t for %s" schema.Masc_domain.name)
+            Error
+              (Printf.sprintf
+                 "missing keeper Tool.t for %s"
+                 schema.Masc_domain.name)
           | Some tool ->
-              let outcome = Tool.execute tool args in
-              if String.equal schema.Masc_domain.name "masc_heartbeat_start" then
-                Heartbeat.list ()
-                |> List.iter (fun (hb : Heartbeat.t) ->
-                       ignore (Heartbeat.stop hb.id));
-              evaluate_expectation ~name:schema.Masc_domain.name case.expectation
-                outcome
+            let outcome = Tool.execute tool args in
+            if String.equal schema.Masc_domain.name "masc_heartbeat_start"
+            then
+              Heartbeat.list ()
+              |> List.iter (fun (hb : Heartbeat.t) ->
+                   ignore (Heartbeat.stop hb.id));
+            evaluate_expectation
+              ~name:schema.Masc_domain.name
+              case.expectation
+              outcome
         with exn ->
           Error
             (Printf.sprintf "%s raised during keeper case: %s"

--- a/test/test_keeper_visible_path_projection.ml
+++ b/test/test_keeper_visible_path_projection.ml
@@ -67,17 +67,20 @@ let make_meta
 let with_eio_fs f =
   Eio_main.run
   @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio.Switch.run
+  @@ fun sw ->
+  let fs = Eio.Stdenv.fs env in
+  Fs_compat.set_fs fs;
   Process_eio.init
     ~cwd_default:(Eio.Stdenv.cwd env)
     ~proc_mgr:(Eio.Stdenv.process_mgr env)
     ~clock:(Eio.Stdenv.clock env);
-  f ()
+  f ~fs ~sw ()
 ;;
 
 let setup ?sandbox ?always_allow f =
   with_eio_fs
-  @@ fun () ->
+  @@ fun ~fs ~sw () ->
   let base = temp_dir () in
   ensure_dir (Filename.concat base Common.masc_dirname);
   Fun.protect
@@ -89,7 +92,28 @@ let setup ?sandbox ?always_allow f =
        let playground = Keeper_sandbox.host_root_abs_of_meta ~config meta in
        ensure_dir playground;
        ignore (Keeper_registry.register ~base_path:base meta.name meta);
-       f ~config ~meta ~playground)
+       let registry =
+         match
+           Fs_compat.open_publication_recovery_registry
+             ~sw
+             ~registry_root:Eio.Path.(fs / Workspace.masc_root_dir config)
+         with
+         | Ok registry -> registry
+         | Error error ->
+           Alcotest.fail
+             (Fs_compat.publication_recovery_registry_error_to_string error)
+       in
+       match
+         Fs_compat.with_publication_recovery_lane
+           ~registry
+           ~owner:meta.name
+           (fun publication_recovery_access ->
+              f ~config ~meta ~playground ~publication_recovery_access)
+       with
+       | Ok value -> value
+       | Error error ->
+         Alcotest.fail
+           (Fs_compat.publication_recovery_lane_open_error_to_string error))
 ;;
 
 let parse raw = Yojson.Safe.from_string raw
@@ -135,7 +159,7 @@ let allow_repo ~config ~(meta : Masc.Keeper_meta_contract.keeper_meta) repo_id =
 
 let test_visible_mind_read_resolves_to_private_storage () =
   setup
-  @@ fun ~config ~meta ~playground ->
+  @@ fun ~config ~meta ~playground ~publication_recovery_access:_ ->
   let target = Filename.concat playground "mind/README.md" in
   write_file target "visible mind\n";
   match
@@ -150,7 +174,7 @@ let test_visible_mind_read_resolves_to_private_storage () =
 
 let test_absolute_playground_path_is_allowed () =
   setup
-  @@ fun ~config ~meta ~playground ->
+  @@ fun ~config ~meta ~playground ~publication_recovery_access:_ ->
   let target = Filename.concat playground "mind/README.md" in
   write_file target "private storage fixture\n";
   (match
@@ -166,7 +190,7 @@ let test_absolute_playground_path_is_allowed () =
 
 let test_relative_path_does_not_depend_on_project_root_allowlist () =
   setup
-  @@ fun ~config ~meta ~playground ->
+  @@ fun ~config ~meta ~playground ~publication_recovery_access:_ ->
   let target = Filename.concat playground "mind/README.md" in
   let project_root_meta = { meta with allowed_paths = [ "mind" ] } in
   match
@@ -181,7 +205,7 @@ let test_relative_path_does_not_depend_on_project_root_allowlist () =
 
 let test_relative_parent_escape_is_rejected () =
   setup
-  @@ fun ~config ~meta ~playground:_ ->
+  @@ fun ~config ~meta ~playground:_ ~publication_recovery_access:_ ->
   match
     Keeper_tool_shared_runtime.resolve_keeper_read_path
       ~config
@@ -194,7 +218,7 @@ let test_relative_parent_escape_is_rejected () =
 
 let test_read_with_visible_repo_cwd_and_relative_file_path () =
   setup
-  @@ fun ~config ~meta ~playground ->
+  @@ fun ~config ~meta ~playground ~publication_recovery_access:_ ->
   allow_repo ~config ~meta "masc";
   let target = Filename.concat playground "repos/masc/README.md" in
   write_file target "repo readme\n";
@@ -202,7 +226,7 @@ let test_read_with_visible_repo_cwd_and_relative_file_path () =
     Keeper_tool_filesystem_runtime.handle_read_file
       ~turn_sandbox_factory:None
       ~config
-      ~keeper_name:meta.name
+      ~meta
       ~args:
         (`Assoc
             [ "cwd", `String "repos/masc"
@@ -219,7 +243,7 @@ let test_read_with_visible_repo_cwd_and_relative_file_path () =
 
 let test_repository_backlog_file_is_readable () =
   setup
-  @@ fun ~config ~meta ~playground ->
+  @@ fun ~config ~meta ~playground ~publication_recovery_access:_ ->
   allow_repo ~config ~meta "masc";
   let target = Filename.concat playground "repos/masc/docs/backlog.json" in
   write_file target {|{"scope":"repository fixture"}|};
@@ -227,7 +251,7 @@ let test_repository_backlog_file_is_readable () =
     Keeper_tool_filesystem_runtime.handle_read_file
       ~turn_sandbox_factory:None
       ~config
-      ~keeper_name:meta.name
+      ~meta
       ~args:
         (`Assoc
             [ "path", `String "repos/masc/docs/backlog.json"
@@ -245,13 +269,13 @@ let test_repository_backlog_file_is_readable () =
    repository or retry advice at the dispatch boundary. *)
 let test_repo_prefixed_missing_read_preserves_exact_input () =
   setup
-  @@ fun ~config ~meta ~playground:_ ->
+  @@ fun ~config ~meta ~playground:_ ~publication_recovery_access:_ ->
   allow_repo ~config ~meta "masc";
   let raw =
     Keeper_tool_filesystem_runtime.handle_read_file
       ~turn_sandbox_factory:None
       ~config
-      ~keeper_name:meta.name
+      ~meta
       ~args:
         (`Assoc
             [ "path", `String "repos/masc/lib/keeper/does_not_exist_xyz.ml"
@@ -270,12 +294,13 @@ let test_repo_prefixed_missing_read_preserves_exact_input () =
 
 let test_write_visible_mind_path () =
   setup ~sandbox:Keeper_types_profile_sandbox.Docker ~always_allow:true
-  @@ fun ~config ~meta ~playground ->
+  @@ fun ~config ~meta ~playground ~publication_recovery_access ->
   let raw =
     Keeper_tool_filesystem_runtime.handle_file_write
       ~turn_sandbox_factory:None
       ~config
-      ~keeper_name:meta.name
+      ~meta
+      ~publication_recovery_access
       ~args:
         (`Assoc
             [ "path", `String "mind/allowed.txt"

--- a/test/test_mcp_auth_gate.ml
+++ b/test/test_mcp_auth_gate.ml
@@ -2,9 +2,9 @@
 
     These tests exercise the typed authentication requirement that is applied
     to every JSON-RPC method before its handler runs.  They deliberately
-    re-enable workspace authentication after {!Mcp_server_eio.create_state}
-    because [create_state ~test_mode:true] disables auth to keep the bulk of
-    existing handler tests lightweight.
+    re-enable workspace authentication after
+    {!Mcp_server_eio.For_testing.create_state} because that test-only
+    constructor explicitly disables auth to keep handler tests lightweight.
 *)
 
 open Alcotest
@@ -99,7 +99,7 @@ let has_result response =
 
 let setup_auth_workspace () =
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   ignore (Masc.Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
   let raw_token =
     match Masc.Auth.create_token base_path ~agent_name:"test-agent" ~role:Masc_domain.Worker with

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -335,7 +335,7 @@ let resource_mime_type_exn response =
 
 let test_create_state () =
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   Alcotest.(check string) "base_path preserved"
     base_path (Mcp_server.workspace_config state).base_path;
   cleanup_dir base_path
@@ -343,7 +343,7 @@ let test_create_state () =
 let test_type_compatibility () =
   (* Verify Mcp_server_eio.server_state is same type as Mcp_server.server_state *)
   let base_path = temp_dir () in
-  let state : Mcp_eio.server_state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state : Mcp_eio.server_state = Mcp_eio.For_testing.create_state ~base_path () in
   let state2 : Mcp.server_state = state in  (* Type unification at compile time *)
   (* Verify the unified type preserves field access *)
   Alcotest.(check string) "base_path via unified type" base_path (Mcp_server.workspace_config state2).base_path;
@@ -501,7 +501,7 @@ let test_handle_request_initialize () =
   Eio.Switch.run @@ fun sw ->
 
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
 
   let request = Yojson.Safe.to_string (`Assoc [
     ("jsonrpc", `String "2.0");
@@ -545,7 +545,7 @@ let test_handle_request_initialize_rejects_unsupported_protocol_version () =
   Eio.Switch.run @@ fun sw ->
 
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
 
   let request = Yojson.Safe.to_string (`Assoc [
     ("jsonrpc", `String "2.0");
@@ -574,7 +574,7 @@ let test_handle_request_server_discover_2026 () =
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   let request =
     Yojson.Safe.to_string
       (`Assoc
@@ -633,7 +633,7 @@ let test_handle_request_tools_list () =
   Eio.Switch.run @@ fun sw ->
 
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   let first_page = tools_list_response ~clock ~sw state in
 
   let tools = tools_list_all ~clock ~sw state in
@@ -717,7 +717,7 @@ let test_handle_request_initialize_operator_profile () =
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   let request = Yojson.Safe.to_string (`Assoc [
     ("jsonrpc", `String "2.0");
     ("id", `Int 11);
@@ -757,7 +757,7 @@ let test_handle_request_tools_list_operator_profile () =
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   let request = Yojson.Safe.to_string (`Assoc [
     ("jsonrpc", `String "2.0");
     ("id", `Int 12);
@@ -850,7 +850,7 @@ let test_handle_request_initialize_managed_profile () =
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   let request = Yojson.Safe.to_string (`Assoc [
     ("jsonrpc", `String "2.0");
     ("id", `Int 111);
@@ -890,7 +890,7 @@ let test_handle_request_tools_list_managed_profile () =
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   let request = Yojson.Safe.to_string (`Assoc [
     ("jsonrpc", `String "2.0");
     ("id", `Int 112);
@@ -948,10 +948,12 @@ let test_handle_request_tools_call_managed_profile_rejects_hidden_claim_alias ()
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   let sid = "mcp-managed-alias-claim" in
   let init_result =
-    Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
+    Mcp_eio.execute_tool_eio ~sw ~clock
+      ~workspace_scope:(Mcp_server.workspace_scope state)
+      ~mcp_session_id:sid state
       ~name:"masc_init" ~arguments:(`Assoc [])
   in
   (* masc_init and setup join are not under test here; initialise the workspace
@@ -1016,7 +1018,7 @@ let test_handle_request_tools_call_missing_params_records_duration () =
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   let sid = "mcp-missing-params-duration" in
   let request =
     Yojson.Safe.to_string
@@ -1068,7 +1070,7 @@ let test_handle_request_tools_call_managed_translation_error_records_duration ()
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   let sid = "mcp-managed-translation-duration" in
   let request =
     Yojson.Safe.to_string
@@ -1126,11 +1128,13 @@ let test_handle_request_tools_call_transition_claim_guidance () =
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   Masc.Auth.disable_auth base_path;
   let sid = "mcp-transition-claim-guidance" in
   let init_result =
-    Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
+    Mcp_eio.execute_tool_eio ~sw ~clock
+      ~workspace_scope:(Mcp_server.workspace_scope state)
+      ~mcp_session_id:sid state
       ~name:"masc_init" ~arguments:(`Assoc [])
   in
   (* masc_init and setup join are not under test here; initialise the workspace
@@ -1183,11 +1187,13 @@ let test_handle_request_tools_call_transition_done_requires_llm_verdict () =
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   Masc.Auth.disable_auth base_path;
   let sid = "mcp-transition-done-guidance" in
   let init_result =
-    Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
+    Mcp_eio.execute_tool_eio ~sw ~clock
+      ~workspace_scope:(Mcp_server.workspace_scope state)
+      ~mcp_session_id:sid state
       ~name:"masc_init" ~arguments:(`Assoc [])
   in
   (* masc_init and setup join are not under test here; initialise the workspace
@@ -1201,7 +1207,9 @@ let test_handle_request_tools_call_transition_done_requires_llm_verdict () =
     (Masc.Workspace.add_task (Mcp_server.workspace_config state) ~title:"transition-done"
        ~priority:2 ~description:"");
   let claim_result =
-    Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
+    Mcp_eio.execute_tool_eio ~sw ~clock
+      ~workspace_scope:(Mcp_server.workspace_scope state)
+      ~mcp_session_id:sid state
       ~name:"masc_transition"
       ~arguments:
         (`Assoc
@@ -1269,11 +1277,13 @@ let test_handle_request_tools_call_transition_claim_requires_action () =
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   Masc.Auth.disable_auth base_path;
   let sid = "mcp-deprecated-claim-alias" in
   let init_result =
-    Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
+    Mcp_eio.execute_tool_eio ~sw ~clock
+      ~workspace_scope:(Mcp_server.workspace_scope state)
+      ~mcp_session_id:sid state
       ~name:"masc_init" ~arguments:(`Assoc [])
   in
   (* masc_init and setup join are not under test here; initialise the workspace
@@ -1321,7 +1331,7 @@ let test_handle_request_tools_call_operator_profile_rejects_non_operator () =
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   let request = Yojson.Safe.to_string (`Assoc [
     ("jsonrpc", `String "2.0");
     ("id", `Int 13);
@@ -1353,7 +1363,7 @@ let test_handle_request_tools_list_rejects_nonstandard_names_filter () =
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   let request = Yojson.Safe.to_string (`Assoc [
     ("jsonrpc", `String "2.0");
     ("id", `Int 120);
@@ -1385,7 +1395,7 @@ let test_handle_request_tools_list_with_placeholder_flag () =
     Eio.Switch.run @@ fun sw ->
 
     let base_path = temp_dir () in
-    let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+    let state = Mcp_eio.For_testing.create_state ~base_path () in
     let tools = tools_list_all ~clock ~sw state in
     let names =
       tools
@@ -1408,7 +1418,7 @@ let test_handle_request_tools_list_include_hidden_metadata () =
   Eio.Switch.run @@ fun sw ->
 
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   let tools = tools_list_all ~clock ~sw state in
   let status_tool = find_tool_exn tools "masc_status" in
   Alcotest.(check bool) "standard tools expose title" true
@@ -1439,7 +1449,7 @@ let _test_handle_request_tools_list_hides_internal_tool_by_default () =
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   let tools = tools_list_all ~clock ~sw state in
   Alcotest.(check bool) "internal tool hidden from public surface" false
     (List.exists
@@ -1458,7 +1468,7 @@ let test_handle_request_tools_list_include_usage_metadata () =
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   let request = Yojson.Safe.to_string (`Assoc [
     ("jsonrpc", `String "2.0");
     ("id", `Int 121);
@@ -1558,7 +1568,7 @@ let test_execute_tool_generated_agent_name_uses_token_identity () =
   Eio.Switch.run @@ fun sw ->
 
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   ignore (Masc.Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
   let raw_token =
     match Masc.Auth.create_token base_path ~agent_name:"stable-admin" ~role:Masc_domain.Admin with
@@ -1567,7 +1577,9 @@ let test_execute_tool_generated_agent_name_uses_token_identity () =
   in
 
   let status_result =
-    Mcp_eio.execute_tool_eio ~sw ~clock ~auth_token:raw_token state
+    Mcp_eio.execute_tool_eio ~sw ~clock
+      ~workspace_scope:(Mcp_server.workspace_scope state)
+      ~auth_token:raw_token state
       ~name:"masc_auth_status"
       ~arguments:(`Assoc [("agent_name", `String "dashboard-eager-manta")])
   in
@@ -1636,7 +1648,7 @@ let test_execute_tool_explicit_generated_alias_claim_next_not_rewritten_by_token
   Eio.Switch.run @@ fun sw ->
 
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   ignore (Masc.Workspace.init (Mcp_server.workspace_config state) ~agent_name:None);
   ignore (Masc.Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
   let raw_token =
@@ -1649,7 +1661,9 @@ let test_execute_tool_explicit_generated_alias_claim_next_not_rewritten_by_token
     (Masc.Workspace.add_task (Mcp_server.workspace_config state) ~title:"explicit-alias-claim-next"
        ~priority:2 ~description:"");
   let result =
-    Mcp_eio.execute_tool_eio ~sw ~clock ~auth_token:raw_token state
+    Mcp_eio.execute_tool_eio ~sw ~clock
+      ~workspace_scope:(Mcp_server.workspace_scope state)
+      ~auth_token:raw_token state
       ~name:"keeper_task_claim"
       ~arguments:(`Assoc [ ("agent_name", `String "dashboard-eager-manta") ])
   in
@@ -1667,7 +1681,7 @@ let test_execute_tool_explicit_generated_alias_transition_not_rewritten_by_token
   Eio.Switch.run @@ fun sw ->
 
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   ignore (Masc.Workspace.init (Mcp_server.workspace_config state) ~agent_name:None);
   ignore (Masc.Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
   let raw_token =
@@ -1680,7 +1694,9 @@ let test_execute_tool_explicit_generated_alias_transition_not_rewritten_by_token
     (Masc.Workspace.add_task (Mcp_server.workspace_config state) ~title:"explicit-alias-transition"
        ~priority:2 ~description:"");
   let result =
-    Mcp_eio.execute_tool_eio ~sw ~clock ~auth_token:raw_token state
+    Mcp_eio.execute_tool_eio ~sw ~clock
+      ~workspace_scope:(Mcp_server.workspace_scope state)
+      ~auth_token:raw_token state
       ~name:"masc_transition"
       ~arguments:
         (`Assoc
@@ -1705,7 +1721,7 @@ let test_execute_tool_hyphenated_generated_alias_claim_next_rejected_without_mut
   Eio.Switch.run @@ fun sw ->
 
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   ignore (Masc.Workspace.init (Mcp_server.workspace_config state) ~agent_name:None);
   ignore (Masc.Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
   let raw_token =
@@ -1717,7 +1733,9 @@ let test_execute_tool_hyphenated_generated_alias_claim_next_rejected_without_mut
     (Masc.Workspace.add_task (Mcp_server.workspace_config state) ~title:"hyphenated-generated-alias-claim-next"
        ~priority:2 ~description:"");
   let result =
-    Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:"sid-hyphenated-generated-alias"
+    Mcp_eio.execute_tool_eio ~sw ~clock
+      ~workspace_scope:(Mcp_server.workspace_scope state)
+      ~mcp_session_id:"sid-hyphenated-generated-alias"
       ~auth_token:raw_token state
       ~name:"keeper_task_claim"
       ~arguments:(`Assoc [ ("agent_name", `String "qa-king-warm-heron") ])
@@ -1742,7 +1760,7 @@ let test_execute_tool_claim_next_requires_auth_before_mutation () =
   Eio.Switch.run @@ fun sw ->
 
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   ignore (Masc.Workspace.init (Mcp_server.workspace_config state) ~agent_name:None);
   ignore (Masc.Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
   ignore (Masc.Workspace.bind_session (Mcp_server.workspace_config state) ~agent_name:"uncredentialed-agent" ~capabilities:[] ());
@@ -1750,7 +1768,9 @@ let test_execute_tool_claim_next_requires_auth_before_mutation () =
     (Masc.Workspace.add_task (Mcp_server.workspace_config state) ~title:"claim-next-auth-preflight"
        ~priority:2 ~description:"");
   let result =
-    Mcp_eio.execute_tool_eio ~sw ~clock state
+    Mcp_eio.execute_tool_eio ~sw ~clock
+      ~workspace_scope:(Mcp_server.workspace_scope state)
+      state
       ~name:"keeper_task_claim"
       ~arguments:(`Assoc [ ("agent_name", `String "uncredentialed-agent") ])
   in
@@ -1770,7 +1790,7 @@ let test_execute_tool_transition_requires_auth_before_mutation () =
   Eio.Switch.run @@ fun sw ->
 
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   ignore (Masc.Workspace.init (Mcp_server.workspace_config state) ~agent_name:None);
   ignore (Masc.Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
   ignore (Masc.Workspace.bind_session (Mcp_server.workspace_config state) ~agent_name:"uncredentialed-agent" ~capabilities:[] ());
@@ -1778,7 +1798,9 @@ let test_execute_tool_transition_requires_auth_before_mutation () =
     (Masc.Workspace.add_task (Mcp_server.workspace_config state) ~title:"transition-auth-preflight"
        ~priority:2 ~description:"");
   let result =
-    Mcp_eio.execute_tool_eio ~sw ~clock state
+    Mcp_eio.execute_tool_eio ~sw ~clock
+      ~workspace_scope:(Mcp_server.workspace_scope state)
+      state
       ~name:"masc_transition"
       ~arguments:
         (`Assoc
@@ -1804,7 +1826,7 @@ let test_execute_tool_add_task_with_admin_token_without_join () =
   Eio.Switch.run @@ fun sw ->
 
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   ignore (Masc.Workspace.init (Mcp_server.workspace_config state) ~agent_name:None);
   ignore (Masc.Auth.enable_auth base_path ~require_token:true ~agent_name:"bootstrap-admin");
   let raw_token =
@@ -1813,7 +1835,9 @@ let test_execute_tool_add_task_with_admin_token_without_join () =
     | Error e -> Alcotest.fail (Masc_domain.masc_error_to_string e)
   in
   let result =
-    Mcp_eio.execute_tool_eio ~sw ~clock ~auth_token:raw_token state
+    Mcp_eio.execute_tool_eio ~sw ~clock
+      ~workspace_scope:(Mcp_server.workspace_scope state)
+      ~auth_token:raw_token state
       ~name:"masc_add_task"
       ~arguments:
         (`Assoc
@@ -1919,7 +1943,7 @@ let test_handle_request_invalid_json () =
   Eio.Switch.run @@ fun sw ->
 
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
 
   let response = Mcp_eio.handle_request ~clock ~sw state "not valid json {{{" in
 
@@ -1942,7 +1966,7 @@ let test_handle_request_tools_call_board_post_structured_content () =
   Eio_context.set_switch sw;
 
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   ignore (Masc.Workspace.init (Mcp_server.workspace_config state) ~agent_name:None);
   let request = Yojson.Safe.to_string (`Assoc [
     ("jsonrpc", `String "2.0");
@@ -1978,7 +2002,7 @@ let test_handle_request_tools_call_logs_structured_mcp_details () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_path)
     (fun () ->
-      let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+      let state = Mcp_eio.For_testing.create_state ~base_path () in
       ignore (Masc.Workspace.init (Mcp_server.workspace_config state) ~agent_name:None);
       let request =
         Yojson.Safe.to_string
@@ -2053,7 +2077,7 @@ let test_handle_request_tools_call_records_keeper_usage_for_public_mcp () =
       ignore
         (Keeper_registry.register ~base_path keeper_name
            (make_keeper_meta ~agent_name:keeper_agent_name keeper_name));
-      let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+      let state = Mcp_eio.For_testing.create_state ~base_path () in
       ignore (Masc.Workspace.init (Mcp_server.workspace_config state) ~agent_name:None);
       let request =
         Yojson.Safe.to_string
@@ -2096,7 +2120,7 @@ let test_handle_request_tools_call_blocks_keeper_internal_tool () =
   Eio.Switch.run @@ fun sw ->
 
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   let request = Yojson.Safe.to_string (`Assoc [
     ("jsonrpc", `String "2.0");
     ("id", `Int 118);
@@ -2150,7 +2174,7 @@ let test_handle_request_tools_list_internal_keeper_runtime_hides_keeper_internal
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_path)
     (fun () ->
-      let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+      let state = Mcp_eio.For_testing.create_state ~base_path () in
       let token = Masc.Auth.ensure_internal_keeper_token base_path in
       let request = Yojson.Safe.to_string (`Assoc [
         ("jsonrpc", `String "2.0");
@@ -2195,7 +2219,7 @@ let test_handle_request_tools_call_internal_keeper_runtime_rejects_retired_execu
       ignore
         (Keeper_registry.register ~base_path keeper_name
            (make_keeper_meta ~agent_name:keeper_agent_name keeper_name));
-      let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+      let state = Mcp_eio.For_testing.create_state ~base_path () in
       let token = Masc.Auth.ensure_internal_keeper_token base_path in
       let request = Yojson.Safe.to_string (`Assoc [
         ("jsonrpc", `String "2.0");
@@ -2233,36 +2257,13 @@ let test_handle_request_tools_call_internal_keeper_runtime_rejects_retired_execu
       Alcotest.(check bool) "mentions registry inconsistency" true
         (contains_substring msg "registry inconsistency"))
 
-let test_internal_keeper_runtime_cleanup_preserves_primary_exception () =
-  let module T = Masc.Mcp_server_eio_execute.For_testing in
-  let cleanup_called = ref false in
-  let cleanup ~during_exception () =
-    T.cleanup_internal_keeper_runtime_resource ~during_exception
-      ~label:"test sandbox" (fun () ->
-        cleanup_called := true;
-        failwith "cleanup failed")
-  in
-  let observed =
-    try
-      ignore
-        (T.run_with_cleanup_preserving_primary ~cleanup (fun () ->
-             failwith "tool failed"));
-      None
-    with
-    | Failure message -> Some message
-    | exn -> Some (Printexc.to_string exn)
-  in
-  Alcotest.(check (option string)) "primary tool exception surfaces"
-    (Some "tool failed") observed;
-  Alcotest.(check bool) "cleanup ran on exception path" true !cleanup_called
-
 let test_handle_request_batch_rejected () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   let request =
     Yojson.Safe.to_string
       (`List
@@ -2288,7 +2289,7 @@ let test_handle_request_jsonrpc_response_returns_null () =
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   let request =
     Yojson.Safe.to_string
       (`Assoc
@@ -2309,7 +2310,7 @@ let test_handle_request_method_not_found () =
   Eio.Switch.run @@ fun sw ->
 
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
 
   let request = Yojson.Safe.to_string (`Assoc [
     ("jsonrpc", `String "2.0");
@@ -2338,7 +2339,7 @@ let test_handle_request_tools_list_rejects_empty_cursor () =
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   let request =
     Yojson.Safe.to_string
       (`Assoc
@@ -2362,7 +2363,7 @@ let test_handle_request_tools_list_rejects_tier_field () =
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   let request =
     Yojson.Safe.to_string
       (`Assoc
@@ -2385,7 +2386,7 @@ let test_handle_request_resources_list_rejects_unknown_field () =
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   let request =
     Yojson.Safe.to_string
       (`Assoc
@@ -2408,7 +2409,7 @@ let test_handle_request_resources_templates_rejects_invalid_cursor () =
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   let request =
     Yojson.Safe.to_string
       (`Assoc
@@ -2436,7 +2437,7 @@ let test_handle_request_prompts_list_rejects_invalid_cursor () =
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   let request =
     Yojson.Safe.to_string
       (`Assoc
@@ -2464,7 +2465,7 @@ let test_handle_request_prompts_list_non_empty () =
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   let request =
     Yojson.Safe.to_string
       (`Assoc
@@ -2497,7 +2498,7 @@ let test_handle_request_prompts_list_cursor () =
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   let cursor = Base64.encode_string "prompts:1" in
   let request =
     Yojson.Safe.to_string
@@ -2530,7 +2531,7 @@ let test_handle_request_prompts_get_tool_help () =
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   let request =
     Yojson.Safe.to_string
       (`Assoc
@@ -2582,7 +2583,7 @@ let test_handle_request_resources_list_includes_tool_help () =
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   let resources = resources_list_all ~clock ~sw state [] in
   let tool_help_index_present =
     List.exists
@@ -2600,7 +2601,7 @@ let test_handle_request_resources_list_paginates () =
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   let request =
     Yojson.Safe.to_string
       (`Assoc
@@ -2636,7 +2637,7 @@ let test_handle_request_tools_list_paginates () =
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   let first_page = tools_list_response ~clock ~sw state in
   let first_tools = tools_from_response first_page in
   let cursor =
@@ -2685,7 +2686,7 @@ let test_handle_request_tool_help_resource_read () =
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   let request =
     Yojson.Safe.to_string
       (`Assoc
@@ -2721,7 +2722,7 @@ let test_handle_request_resources_read_matrix () =
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   ignore (Masc.Workspace.init (Mcp_server.workspace_config state) ~agent_name:(Some "fixture-root"));
   let ensure_dir path =
     if not (Sys.file_exists path) then Unix.mkdir path 0o755
@@ -2810,7 +2811,7 @@ let test_handle_request_resources_subscribe_requires_session () =
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   let request =
     Yojson.Safe.to_string
       (`Assoc
@@ -2835,7 +2836,7 @@ let test_handle_request_dashboard_ping_requires_session () =
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   let request =
     Yojson.Safe.to_string
       (`Assoc
@@ -2859,7 +2860,7 @@ let test_handle_request_dashboard_ping_reports_unknown_ws_session () =
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   let request =
     Yojson.Safe.to_string
       (`Assoc
@@ -2890,7 +2891,7 @@ let test_handle_request_resources_subscribe_roundtrip () =
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   let subscribe_request =
     Yojson.Safe.to_string
       (`Assoc
@@ -3033,8 +3034,6 @@ let eio_tests = [
     test_handle_request_tools_list_internal_keeper_runtime_hides_keeper_internal_tools;
   "handle tools/call internal keeper runtime rejects retired execute", `Quick,
     test_handle_request_tools_call_internal_keeper_runtime_rejects_retired_execute;
-  "internal keeper runtime cleanup preserves primary exception", `Quick,
-    test_internal_keeper_runtime_cleanup_preserves_primary_exception;
   "handle invalid json", `Quick, test_handle_request_invalid_json;
   "handle method not found", `Quick, test_handle_request_method_not_found;
   (* TRPG tool tests removed — modules archived *)

--- a/test/test_mcp_server_eio_call_tool.ml
+++ b/test/test_mcp_server_eio_call_tool.ml
@@ -101,7 +101,7 @@ let with_call_tool_state f =
     (fun () ->
       let config = Masc.Workspace.default_config base_path in
       ignore (Masc.Workspace.init config ~agent_name:(Some "projection-test"));
-      let state = Masc.Mcp_server_eio.create_state ~test_mode:true ~base_path () in
+      let state = Masc.Mcp_server_eio.For_testing.create_state ~base_path () in
       f env sw state)
 ;;
 
@@ -111,6 +111,7 @@ let call_with_result ~env ~sw state result =
       (fun
         ~sw:_
         ~clock:_
+        ~workspace_scope:_
         ?profile:_
         ?mcp_session_id:_
         ?auth_token:_
@@ -250,7 +251,7 @@ let test_handle_call_executes_transient_failure_once () =
     (fun () ->
       let config = Masc.Workspace.default_config base_path in
       ignore (Masc.Workspace.init config ~agent_name:(Some "single-call-test"));
-      let state = Masc.Mcp_server_eio.create_state ~test_mode:true ~base_path () in
+      let state = Masc.Mcp_server_eio.For_testing.create_state ~base_path () in
       let calls = ref 0 in
       let response =
         Masc.Mcp_server_eio_call_tool.handle_call_tool_eio
@@ -258,6 +259,7 @@ let test_handle_call_executes_transient_failure_once () =
             (fun
               ~sw:_
               ~clock:_
+              ~workspace_scope:_
               ?profile:_
               ?mcp_session_id:_
               ?auth_token:_
@@ -290,8 +292,92 @@ let test_handle_call_executes_transient_failure_once () =
         (response
          |> U.member "result"
          |> U.member "_meta"
-         |> U.member "attempts"
-         |> U.to_int))
+        |> U.member "attempts"
+        |> U.to_int))
+
+let test_call_captures_admission_scope_across_workspace_switch () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let root = temp_dir () in
+  let destination_workspace = Filename.concat root "destination-workspace" in
+  Unix.mkdir destination_workspace 0o755;
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir root)
+    (fun () ->
+      let source_config = Masc.Workspace.default_config root in
+      let destination_config =
+        { source_config with workspace_path = destination_workspace }
+      in
+      ignore
+        (Masc.Workspace.init
+           source_config
+           ~agent_name:(Some "scope-admission-test"));
+      let state =
+        Masc.Mcp_server_eio.For_testing.create_state ~base_path:root ()
+      in
+      let admission_scope = Masc.Mcp_server.workspace_scope state in
+      let executed_scope = ref None in
+      let response =
+        Masc.Mcp_server_eio_call_tool.handle_call_tool_eio
+          ~execute_tool_eio:
+            (fun
+              ~sw:_
+              ~clock:_
+              ~workspace_scope
+              ?profile:_
+              ?mcp_session_id:_
+              ?auth_token:_
+              ?internal_keeper_runtime:_
+              callback_state
+              ~name
+              ~arguments:_
+            ->
+              executed_scope := Some workspace_scope;
+              (match
+                 Masc.Mcp_server.set_workspace_config
+                   callback_state
+                   destination_config
+               with
+               | Ok () -> ()
+               | Error error ->
+                 fail
+                   (Masc.Mcp_server.workspace_switch_error_to_string error));
+              Tool_result.make_ok
+                ~tool_name:name
+                ~start_time:0.0
+                ~data:(`String "workspace switched")
+                ())
+          ~maybe_emit_resource_notifications:(fun ~success:_ ~tool_name:_ -> ())
+          ~broadcast_tools_list_changed:(fun () -> ())
+          ~sw
+          ~clock:(Eio.Stdenv.clock env)
+          state
+          (`Int 41)
+          (`Assoc
+            [ "name", `String "masc_status"
+            ; ( "arguments"
+              , `Assoc [ "_agent_name", `String "scope-admission-test" ] )
+            ])
+      in
+      check string "tool call succeeds" "ok"
+        (result_envelope response |> U.member "status" |> U.to_string);
+      let callback_scope =
+        match !executed_scope with
+        | Some scope -> scope
+        | None -> fail "execute callback did not receive workspace scope"
+      in
+      check bool "execute receives exact admission scope object" true
+        (callback_scope == admission_scope);
+      check string "server process root stays fixed"
+        source_config.base_path
+        (Masc.Mcp_server.workspace_config state).base_path;
+      check string "server current workspace projection moved"
+        destination_workspace
+        (Masc.Mcp_server.workspace_config state).workspace_path)
+;;
 
 let test_activity_payload_sanitizes_invalid_utf8 () =
   let payload =
@@ -642,6 +728,8 @@ let () =
             test_typed_outcome_alone_controls_projection;
           test_case "transient failure executes once" `Quick
             test_handle_call_executes_transient_failure_once;
+          test_case "captures admission scope across workspace switch" `Quick
+            test_call_captures_admission_scope_across_workspace_switch;
           test_case "activity payload sanitizes invalid UTF-8" `Quick
             test_activity_payload_sanitizes_invalid_utf8;
           test_case "records MCP server operation duration metric" `Quick

--- a/test/test_mcp_server_eio_tool_dispatch.ml
+++ b/test/test_mcp_server_eio_tool_dispatch.ml
@@ -54,10 +54,15 @@ let test_execute_tool_help_tool () =
   let clock = Eio.Stdenv.clock env in
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let state = Mcp_eio.For_testing.create_state ~base_path () in
   let raw_token = create_admin_token base_path in
   let result =
-    Mcp_eio.execute_tool_eio ~sw ~clock ~auth_token:raw_token state
+    Mcp_eio.execute_tool_eio
+      ~sw
+      ~clock
+      ~workspace_scope:(Mcp_server.workspace_scope state)
+      ~auth_token:raw_token
+      state
       ~name:"masc_tool_help"
       ~arguments:(`Assoc [ ("tool_name", `String "masc_status") ])
   in
@@ -93,11 +98,16 @@ let test_execute_tool_tag_dispatch_respects_pre_hooks () =
                  ; duration_ms = 0.0
                  })
           else Tool_dispatch.Pass);
-      let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+      let state = Mcp_eio.For_testing.create_state ~base_path () in
       let raw_token = create_admin_token base_path in
       let _workspace_path = Masc.Workspace.masc_dir (Mcp_server.workspace_config state) in
       let hook_result =
-        Mcp_eio.execute_tool_eio ~sw ~clock ~auth_token:raw_token state
+        Mcp_eio.execute_tool_eio
+          ~sw
+          ~clock
+          ~workspace_scope:(Mcp_server.workspace_scope state)
+          ~auth_token:raw_token
+          state
           ~name:"masc_tool_help"
           ~arguments:(`Assoc [ ("tool_name", `String "masc_status") ])
       in
@@ -121,7 +131,7 @@ let test_tool_metadata_does_not_gate_heartbeat () =
       Tool_catalog.register_metadata tool_name original_metadata;
       cleanup_dir base_path)
     (fun () ->
-      let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+      let state = Mcp_eio.For_testing.create_state ~base_path () in
       let config = Mcp_server.workspace_config state in
       let agent_name = "heartbeat-test-agent" in
       ignore (Masc.Workspace.init config ~agent_name:(Some agent_name));
@@ -152,6 +162,7 @@ let test_tool_metadata_does_not_gate_heartbeat () =
           (Mcp_eio.execute_tool_eio
              ~sw
              ~clock
+             ~workspace_scope:(Mcp_server.workspace_scope state)
              ~auth_token:raw_token
              state
              ~name:tool_name

--- a/test/test_mcp_telemetry.ml
+++ b/test/test_mcp_telemetry.ml
@@ -9,8 +9,8 @@ open Alcotest
     Tool_operator, Tool_local_runtime, ...) rather than handler-registry
     dispatch.
 
-    Instead, PR-8 wraps the two MCP caller sites (mcp_server_eio_execute
-    .ml:1065 and :1083) with Tool_telemetry.with_span directly. This
+    Instead, PR-8 wraps the MCP tag-dispatch caller site with
+    Tool_telemetry.with_span directly. This
     test verifies the wrapper invariants hold: the with_span call
     produces a 4-tuple emission shape identical to the keeper-turn path.
 
@@ -47,15 +47,13 @@ let test_no_handler_label_present () =
     (List.mem "no_handler" pinned_mcp_outcome_labels)
 ;;
 
-let pinned_mcp_wrap_sites = 2
+let pinned_mcp_wrap_sites = 1
 
 let test_mcp_wrap_site_count () =
-  (* Exactly two wrap sites: dispatch_internal_keeper_runtime_tool +
-     dispatch_by_tag. Future caller additions must update this pin. *)
+  (* The MCP execute surface has one live dispatch path: dispatch_by_tag. *)
   (check int)
-    "MCP server telemetry wrap sites \
-     (RFC-0084 §2.2 PR-8; mcp_server_eio_execute.ml :1065 + :1083)"
-    2
+    "MCP server telemetry wrap sites (RFC-0084 §2.2 PR-8; tag dispatch)"
+    1
     pinned_mcp_wrap_sites
 ;;
 

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -291,7 +291,10 @@ let setup_git_repo base_path =
   sandbox_dir
 
 let execute_tool fixture ~name ~arguments =
-  Mcp_eio.execute_tool_eio ~sw:fixture.sw ~clock:fixture.clock
+  Mcp_eio.execute_tool_eio
+    ~sw:fixture.sw
+    ~clock:fixture.clock
+    ~workspace_scope:(Mcp_server.workspace_scope fixture.state)
     ~auth_token:fixture.auth_token
     ~mcp_session_id:fixture.sid fixture.state ~name ~arguments
 

--- a/test/test_mcp_tool_runtime_workspace_path.ml
+++ b/test/test_mcp_tool_runtime_workspace_path.ml
@@ -57,6 +57,313 @@ let test_masc_start_tilde_rejects_empty_initial_home () =
         (contains_substring message "HOME is required to expand '~'"))
 ;;
 
+let require_registry (scope : Mcp_server.workspace_scope) =
+  match Mcp_server.workspace_scope_publication_recovery_registry scope with
+  | Some registry -> registry
+  | None -> Alcotest.fail "Eio workspace scope omitted its recovery registry"
+;;
+
+let require_activation_report (scope : Mcp_server.workspace_scope) =
+  match Mcp_server.workspace_scope_publication_recovery_report scope with
+  | Some report -> report
+  | None -> Alcotest.fail "Eio workspace scope omitted its recovery report"
+;;
+
+let require_uuid value =
+  match Uuidm.of_string value with
+  | Some operation_id -> operation_id
+  | None -> Alcotest.failf "invalid fixture UUID %S" value
+;;
+
+let seed_prepared_recovery
+      ~fs
+      ~base_path
+      ~owner
+      ~operation_id
+  =
+  let config = Masc.Workspace.default_config base_path in
+  ignore (Masc.Workspace.init config ~agent_name:None);
+  let allowed_root_path = Unix.realpath config.base_path in
+  let allowed_root =
+    Eio.Path.stat ~follow:false Eio.Path.(fs / allowed_root_path)
+  in
+  Eio.Switch.run
+  @@ fun sw ->
+  match
+    Fs_compat.open_publication_recovery_registry
+      ~sw
+      ~registry_root:Eio.Path.(fs / Masc.Workspace.masc_root_dir config)
+  with
+  | Error error ->
+    Alcotest.fail
+      (Fs_compat.publication_recovery_registry_error_to_string error)
+  | Ok registry ->
+    (match
+       Fs_compat.Capability_write_for_testing.seed_prepared_publication_recovery
+         ~registry
+         ~owner
+         ~operation_id
+         ~allowed_root_path
+         ~allowed_root_device:allowed_root.dev
+         ~allowed_root_inode:allowed_root.ino
+         ~parent_components:[]
+         ~parent_device:allowed_root.dev
+         ~parent_inode:allowed_root.ino
+         ~target_leaf:"target.json"
+         ~permissions:0o600
+     with
+     | Ok () -> ()
+     | Error error ->
+       Alcotest.fail
+         (Fs_compat.publication_recovery_fixture_error_to_string error))
+;;
+
+let test_workspace_switch_reuses_process_recovery_runtime () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let first_base = Cases.temp_dir "mcp-scope-first-" in
+  let second_base = Cases.temp_dir "mcp-scope-second-" in
+  let nested_workspace = Filename.concat first_base "nested-workspace" in
+  Fun.protect
+    ~finally:(fun () ->
+      Cases.cleanup_dir first_base;
+      Cases.cleanup_dir second_base)
+    (fun () ->
+      Unix.mkdir nested_workspace 0o700;
+      let fs = Eio.Stdenv.fs env in
+      Fs_compat.set_fs fs;
+      let state =
+        Mcp_eio.create_state_eio
+          ~sw
+          ~proc_mgr:(Eio.Stdenv.process_mgr env)
+          ~fs
+          ~clock:(Eio.Stdenv.clock env)
+          ~mono_clock:(Eio.Stdenv.mono_clock env)
+          ~net:(Eio.Stdenv.net env)
+          ~base_path:first_base
+      in
+      let first_scope = Mcp_server.workspace_scope state in
+      let first_registry = require_registry first_scope in
+      let first_report = require_activation_report first_scope in
+      let same_root_config =
+        { first_scope.config with workspace_path = nested_workspace }
+      in
+      (match Mcp_server.set_workspace_config state same_root_config with
+       | Ok () -> ()
+       | Error error ->
+         Alcotest.fail
+           (Mcp_server.workspace_switch_error_to_string error));
+      let nested_scope = Mcp_server.workspace_scope state in
+      Alcotest.(check string)
+        "workspace projection changed"
+        nested_workspace
+        nested_scope.config.workspace_path;
+      Alcotest.(check bool)
+        "same MASC root reuses the exact process registry"
+        true
+        (require_registry nested_scope == first_registry);
+      Alcotest.(check bool)
+        "same MASC root reuses the exact activation report"
+        true
+        (require_activation_report nested_scope == first_report);
+      let public_health =
+        Mcp_server.publication_recovery_activation_report_to_health_yojson
+          first_report
+      in
+      Alcotest.(check string)
+        "empty activation is healthy"
+        "ok"
+        Yojson.Safe.Util.(public_health |> member "status" |> to_string);
+      Alcotest.(check bool)
+        "empty activation needs no operator"
+        false
+        Yojson.Safe.Util.
+          (public_health |> member "operator_action_required" |> to_bool);
+      Alcotest.(check int)
+        "empty activation has no rows"
+        0
+        Yojson.Safe.Util.(public_health |> member "row_count" |> to_int);
+      let second_config = Masc.Workspace.default_config second_base in
+      (match Mcp_server.set_workspace_config state second_config with
+       | Error
+           (Mcp_server.Workspace_masc_root_mismatch
+              { runtime_root; requested_root }) ->
+         Alcotest.(check string)
+           "runtime root is exact"
+           (Masc.Workspace.masc_root_dir first_scope.config)
+           runtime_root;
+         Alcotest.(check string)
+           "requested root is exact"
+           (Masc.Workspace.masc_root_dir second_config)
+           requested_root
+       | Ok () -> Alcotest.fail "different MASC root was accepted");
+      Alcotest.(check bool)
+        "root mismatch leaves the prior scope object unchanged"
+        true
+        (Mcp_server.workspace_scope state == nested_scope))
+;;
+
+let test_runtime_start_tracks_async_owner_activation () =
+  Eio_main.run
+  @@ fun env ->
+  let base_path = Cases.temp_dir "mcp-recovery-activation-" in
+  Fun.protect
+    ~finally:(fun () -> Cases.cleanup_dir base_path)
+    (fun () ->
+      let fs = Eio.Stdenv.fs env in
+      Fs_compat.set_fs fs;
+      let valid_owner = "startup-valid-owner" in
+      let rejected_owner = "startup owner with spaces" in
+      seed_prepared_recovery
+        ~fs
+        ~base_path
+        ~owner:valid_owner
+        ~operation_id:
+          (require_uuid "66666666-6666-4666-8666-666666666666");
+      seed_prepared_recovery
+        ~fs
+        ~base_path
+        ~owner:rejected_owner
+        ~operation_id:
+          (require_uuid "77777777-7777-4777-8777-777777777777");
+      Eio.Switch.run
+      @@ fun sw ->
+      let state =
+        Mcp_eio.create_state_eio
+          ~sw
+          ~proc_mgr:(Eio.Stdenv.process_mgr env)
+          ~fs
+          ~clock:(Eio.Stdenv.clock env)
+          ~mono_clock:(Eio.Stdenv.mono_clock env)
+          ~net:(Eio.Stdenv.net env)
+          ~base_path
+      in
+      let scope = Mcp_server.workspace_scope state in
+      let report = require_activation_report scope in
+      let activation_rows =
+        Mcp_server.For_testing.await_publication_recovery_activation report
+      in
+      let valid_ready, rejected_explicit, unsettled =
+        List.fold_left
+          (fun (valid_ready, rejected_explicit, unsettled) -> function
+             | Mcp_server.Publication_recovery_owner_report owner_report ->
+               let is_valid_owner =
+                 String.equal
+                   valid_owner
+                   (Fs_compat.publication_recovery_reconciliation_report_owner
+                      owner_report)
+               in
+               ( valid_ready
+                 || is_valid_owner
+                    && Fs_compat.publication_recovery_reconciliation_report_is_ready
+                         owner_report
+               , rejected_explicit
+               , unsettled )
+             | Mcp_server.Publication_recovery_owner_identity_rejected
+                 { owner; _ } ->
+               valid_ready,
+               rejected_explicit || String.equal rejected_owner owner,
+               unsettled
+             | Mcp_server.Publication_recovery_owner_pending _
+             | Mcp_server.Publication_recovery_owner_running _ ->
+               valid_ready, rejected_explicit, true
+             | Mcp_server.Publication_recovery_owner_reconciliation_failed _
+             | Mcp_server.Publication_recovery_owner_reconciliation_crashed _
+             | Mcp_server.Publication_recovery_owner_cancelled _
+             | Mcp_server.Publication_recovery_owner_inventory_issue _ ->
+               valid_ready, rejected_explicit, unsettled)
+          (false, false, false)
+          activation_rows
+      in
+      Alcotest.(check bool) "valid owner reconciled" true valid_ready;
+      Alcotest.(check bool)
+        "MASC owner rejection retained"
+        true
+        rejected_explicit;
+      Alcotest.(check bool)
+        "exact activation await leaves no pending row"
+        false
+        unsettled;
+      let public_health =
+        Mcp_server.publication_recovery_activation_report_to_health_yojson
+          report
+      in
+      Alcotest.(check string)
+        "rejected activation blocks public health"
+        "blocked"
+        Yojson.Safe.Util.(public_health |> member "status" |> to_string);
+      Alcotest.(check bool)
+        "rejected activation requires operator action"
+        true
+        Yojson.Safe.Util.
+          (public_health |> member "operator_action_required" |> to_bool);
+      Alcotest.(check int)
+        "public health aggregates the rejected owner"
+        1
+        Yojson.Safe.Util.
+          (public_health
+           |> member "row_counts"
+           |> member "owner_identity_rejected"
+           |> to_int);
+      Alcotest.(check bool)
+        "public health omits exact activation rows"
+        true
+        Yojson.Safe.Util.(public_health |> member "rows" = `Null);
+      let registry = require_registry scope in
+      (match
+         Fs_compat.with_publication_recovery_lane
+           ~registry
+           ~owner:valid_owner
+           (fun _ -> ())
+       with
+       | Ok () -> ()
+       | Error error ->
+         Alcotest.fail
+           (Fs_compat.publication_recovery_lane_open_error_to_string error));
+      (match
+         Fs_compat.with_publication_recovery_lane
+           ~registry
+           ~owner:rejected_owner
+           (fun _ -> ())
+       with
+       | Error error ->
+         (match
+            Fs_compat.publication_recovery_lane_reconciliation_error error
+          with
+          | Some
+              (Fs_compat.Publication_recovery_reconciliation_blocked
+                (Fs_compat.Publication_recovery_owner_activation_rejected_block
+                  owner)) ->
+            Alcotest.(check string)
+              "rejected owner remains fenced"
+              rejected_owner
+              (Fs_compat.publication_recovery_owner_to_string owner)
+          | Some
+              ( Fs_compat.Publication_recovery_reconciliation_required _
+              | Fs_compat.Publication_recovery_reconciliation_in_progress _
+              | Fs_compat.Publication_recovery_reconciliation_blocked
+                  ( Fs_compat.Publication_recovery_owner_inventory_block _
+                  | Fs_compat.Publication_recovery_owner_report_block _
+                  | Fs_compat.Publication_recovery_owner_crash_block _
+                  | Fs_compat.Publication_recovery_owner_cancelled_block _ ) )
+          | None ->
+            Alcotest.fail
+              (Fs_compat.publication_recovery_lane_open_error_to_string error))
+       | Ok () -> Alcotest.fail "MASC-rejected owner was admitted");
+      match
+        Fs_compat.with_publication_recovery_lane
+          ~registry
+          ~owner:"unrelated-owner"
+          (fun _ -> ())
+      with
+      | Ok () -> ()
+      | Error error ->
+        Alcotest.fail
+          (Fs_compat.publication_recovery_lane_open_error_to_string error))
+;;
+
 let () =
   Mirage_crypto_rng_unix.use_default ();
   Alcotest.run
@@ -66,6 +373,14 @@ let () =
             "rejects tilde expansion when initial HOME is empty"
             `Quick
             test_masc_start_tilde_rejects_empty_initial_home
+        ; Alcotest.test_case
+            "reuses one recovery runtime and rejects another MASC root"
+            `Quick
+            test_workspace_switch_reuses_process_recovery_runtime
+        ; Alcotest.test_case
+            "tracks async owner activation and fences rejected owners"
+            `Quick
+            test_runtime_start_tracks_async_owner_activation
         ] )
     ]
 ;;

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -218,6 +218,8 @@ let test_snapshot_prefers_metrics_context_truth_over_usage_counters () =
           clock = Eio.Stdenv.clock env;
           proc_mgr = Some (Eio.Stdenv.process_mgr env);
           net = None;
+          publication_recovery_registry =
+            Some (publication_recovery_registry env sw config);
         }
       in
       let keeper_name = "ctx-truth" in
@@ -373,6 +375,8 @@ let test_keeper_up_clears_dead_tombstone_resume_state () =
       clock = Eio.Stdenv.clock env;
       proc_mgr = Some (Eio.Stdenv.process_mgr env);
       net = None;
+      publication_recovery_registry =
+        Some (publication_recovery_registry env sw config);
     }
   in
   let read_meta label =
@@ -769,6 +773,8 @@ let test_dead_revival_launch_failure_rolls_back_both_authorities () =
         ; clock = Eio.Stdenv.clock env
         ; proc_mgr = Some (Eio.Stdenv.process_mgr env)
         ; net = None
+        ; publication_recovery_registry =
+            Some (publication_recovery_registry env sw config)
         }
       in
       (match Keeper_dead_revival_transaction.revive ctx ~original ~candidate with
@@ -969,6 +975,8 @@ let test_digest_workspace_includes_keeper_runtime_attention () =
           clock = Eio.Stdenv.clock env;
           proc_mgr = Some (Eio.Stdenv.process_mgr env);
           net = None;
+          publication_recovery_registry =
+            Some (publication_recovery_registry env sw config);
         }
       in
       let ok, _ =
@@ -1075,6 +1083,8 @@ let test_lightweight_snapshot_preserves_receipt_latest_causal_event () =
           clock = Eio.Stdenv.clock env;
           proc_mgr = Some (Eio.Stdenv.process_mgr env);
           net = None;
+          publication_recovery_registry =
+            Some (publication_recovery_registry env sw config);
         }
       in
       let ok, _ =
@@ -1347,6 +1357,8 @@ let test_snapshot_lightweight_summary_keeps_tool_audit () =
           clock = Eio.Stdenv.clock env;
           proc_mgr = Some (Eio.Stdenv.process_mgr env);
           net = None;
+          publication_recovery_registry =
+            Some (publication_recovery_registry env sw config);
         }
       in
       let keeper_name = "lightweight-audit" in
@@ -1458,6 +1470,8 @@ let test_snapshot_lightweight_summary_keeps_recent_tools_distinct_from_latest ()
           clock = Eio.Stdenv.clock env;
           proc_mgr = Some (Eio.Stdenv.process_mgr env);
           net = None;
+          publication_recovery_registry =
+            Some (publication_recovery_registry env sw config);
         }
       in
       let keeper_name = "lightweight-recent-tools" in

--- a/test/test_operator_control_support.ml
+++ b/test/test_operator_control_support.ml
@@ -23,6 +23,16 @@ let ensure_fs env =
      capability would leak a dead scheduler resource into later cases. *)
   Fs_compat.set_fs (Eio.Stdenv.fs env)
 
+let publication_recovery_registry env sw config =
+  let registry_root =
+    Eio.Path.(Eio.Stdenv.fs env / Workspace.masc_root_dir config)
+  in
+  match Fs_compat.open_publication_recovery_registry ~sw ~registry_root with
+  | Ok registry -> registry
+  | Error error ->
+    Alcotest.fail
+      (Fs_compat.publication_recovery_registry_error_to_string error)
+
 let cleanup_dir dir =
   let rec rm path =
     if Sys.file_exists path then
@@ -49,6 +59,8 @@ let operator_ctx ?mcp_session_id env sw config agent_name :
     clock = Eio.Stdenv.clock env;
     proc_mgr = Some (Eio.Stdenv.process_mgr env);
     net = Some (Eio.Stdenv.net env);
+    publication_recovery_registry =
+      Some (publication_recovery_registry env sw config);
     mcp_session_id;
   }
 

--- a/test/test_server_ide_http.ml
+++ b/test/test_server_ide_http.ml
@@ -297,7 +297,7 @@ let annotation_count router path =
 
 let setup_state base_path =
   save_auth_config base_path;
-  let state = Masc.Mcp_server.create_state ~base_path in
+  let state = Masc.Mcp_server.For_testing.create_state ~base_path in
   Server_auth.server_state := Some state;
   state
 ;;

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1111,13 +1111,13 @@ let test_constructor_is_pure () =
       let agents_dir = Workspace.agents_dir (Workspace.default_config dir) in
       Fs_compat.mkdir_p agents_dir;
       write_file (Filename.concat agents_dir "alice.json") "{}";
-      let state = Mcp_server.create_state ~base_path:dir in
+      let state = Mcp_server.For_testing.create_state ~base_path:dir in
       Alcotest.(check int) "constructor does not restore persisted sessions" 0
         (List.length (Session.connected_agents state.Mcp_server.session_registry)))
 
 let test_restore_persisted_sessions_uses_flat_agents_dir () =
   with_temp_dir "startup-scope" (fun dir ->
-      let state = Mcp_server.create_state ~base_path:dir in
+      let state = Mcp_server.For_testing.create_state ~base_path:dir in
       let agents = Workspace.agents_dir (Mcp_server.workspace_config state) in
       Fs_compat.mkdir_p agents;
       write_file (Filename.concat agents "test-agent.json") "{}";
@@ -1401,7 +1401,7 @@ let test_health_json_surfaces_durable_paused_keepers () =
           Server_auth.server_state := previous_state;
           Config_dir_resolver.reset ())
         (fun () ->
-          let state = Mcp_server.create_state ~base_path:dir in
+          let state = Mcp_server.For_testing.create_state ~base_path:dir in
           Server_auth.server_state := Some state;
           let config = (Mcp_server.workspace_config state) in
           write_keeper_meta_exn config
@@ -1438,13 +1438,24 @@ let test_health_json_surfaces_durable_paused_keepers () =
           let disk_observation = json |> member "disk_observation" in
           let runtime_truth = json |> member "runtime_truth" in
           let fleet_safety = json |> member "keeper_fleet_safety" in
+          let publication_recovery =
+            json |> member "publication_recovery_activation"
+          in
           let reaction_ledger = json |> member "keeper_reaction_ledger" in
           let durable_names =
             paused |> member "durable_names" |> to_list |> List.map to_string
           in
 	          let names = paused |> member "names" |> to_list |> List.map to_string in
-	          Alcotest.(check int) "durable paused count" 1
-	            (paused |> member "durable_count" |> to_int);
+          Alcotest.(check int) "durable paused count" 1
+            (paused |> member "durable_count" |> to_int);
+          Alcotest.(check string)
+            "pure test state exposes unavailable recovery activation"
+            "unavailable"
+            (publication_recovery |> member "status" |> to_string);
+          Alcotest.(check string)
+            "pure test state names its missing runtime"
+            "non_runtime_state"
+            (publication_recovery |> member "reason" |> to_string);
 	          Alcotest.(check int) "registry paused count" 0
 	            (paused |> member "registry_paused_count" |> to_int);
 	          Alcotest.(check string) "legacy running count semantics"
@@ -1588,7 +1599,7 @@ let test_health_json_observes_keeper_turn_admission_work () =
         Server_auth.server_state := previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
-        let state = Mcp_server.create_state ~base_path:dir in
+        let state = Mcp_server.For_testing.create_state ~base_path:dir in
         Server_auth.server_state := Some state;
         let keeper_name = "example" in
         Eio.Switch.run (fun sw ->
@@ -1662,7 +1673,7 @@ let test_health_json_surfaces_board_event_collection_failure () =
         Server_auth.server_state := previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
-        let state = Mcp_server.create_state ~base_path:dir in
+        let state = Mcp_server.For_testing.create_state ~base_path:dir in
         Server_auth.server_state := Some state;
         let keeper_name = "example" in
         Keeper_heartbeat_loop_board_events.For_testing.record_collection_failure
@@ -1731,7 +1742,7 @@ let test_keeper_identity_drift_health_json_surfaces_config_meta_split () =
         Server_auth.server_state := previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
-        let state = Mcp_server.create_state ~base_path:dir in
+        let state = Mcp_server.For_testing.create_state ~base_path:dir in
         Server_auth.server_state := Some state;
         let config = Mcp_server.workspace_config state in
         write_keeper_meta_exn config
@@ -1798,7 +1809,7 @@ let test_keeper_identity_drift_treats_explicit_autoboot_base_as_materializable
         Server_auth.server_state := previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
-        let state = Mcp_server.create_state ~base_path:dir in
+        let state = Mcp_server.For_testing.create_state ~base_path:dir in
         Server_auth.server_state := Some state;
         let config = Mcp_server.workspace_config state in
         write_keeper_meta_exn config
@@ -1832,7 +1843,7 @@ let test_health_json_reports_unclassified_timeout_pause_without_mutation () =
         Server_auth.server_state := previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
-        let state = Mcp_server.create_state ~base_path:dir in
+        let state = Mcp_server.For_testing.create_state ~base_path:dir in
         Server_auth.server_state := Some state;
         let config = (Mcp_server.workspace_config state) in
         let timeout_paused =
@@ -1884,7 +1895,7 @@ let test_health_json_reports_dormant_task_owner_as_advisory () =
         Server_auth.server_state := previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
-        let state = Mcp_server.create_state ~base_path:dir in
+        let state = Mcp_server.For_testing.create_state ~base_path:dir in
         Server_auth.server_state := Some state;
         let config = Mcp_server.workspace_config state in
         let executor =
@@ -1960,7 +1971,7 @@ let test_health_json_ignores_stale_active_task_alias_when_agent_executable () =
         Server_auth.server_state := previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
-        let state = Mcp_server.create_state ~base_path:dir in
+        let state = Mcp_server.For_testing.create_state ~base_path:dir in
         Server_auth.server_state := Some state;
         let config = Mcp_server.workspace_config state in
         let executor =
@@ -2055,7 +2066,7 @@ let test_health_json_degrades_on_active_task_owner_without_keeper_binding () =
         Server_auth.server_state := previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
-        let state = Mcp_server.create_state ~base_path:dir in
+        let state = Mcp_server.For_testing.create_state ~base_path:dir in
         Server_auth.server_state := Some state;
         let config = Mcp_server.workspace_config state in
         let assignee = "missing-keeper-agent" in
@@ -2140,7 +2151,7 @@ let test_health_json_reports_non_keeper_active_task_owner_as_advisory () =
         Server_auth.server_state := previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
-        let state = Mcp_server.create_state ~base_path:dir in
+        let state = Mcp_server.For_testing.create_state ~base_path:dir in
         Server_auth.server_state := Some state;
         let config = Mcp_server.workspace_config state in
         let assignee = "codex-mcp-client" in
@@ -2217,7 +2228,7 @@ let test_health_json_preserves_active_task_owner_meta_read_error () =
         Server_auth.server_state := previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
-        let state = Mcp_server.create_state ~base_path:dir in
+        let state = Mcp_server.For_testing.create_state ~base_path:dir in
         Server_auth.server_state := Some state;
         let config = Mcp_server.workspace_config state in
         write_file (Keeper_types_profile.keeper_meta_path config "broken")
@@ -2359,7 +2370,7 @@ let test_health_json_degrades_when_reaction_capacity_below_target () =
         Server_auth.server_state := previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
-        let state = Mcp_server.create_state ~base_path:dir in
+        let state = Mcp_server.For_testing.create_state ~base_path:dir in
         Server_auth.server_state := Some state;
         let config = (Mcp_server.workspace_config state) in
         let paused =
@@ -2499,7 +2510,7 @@ let test_health_json_blocked_count_matches_blocked_names_with_non_target_capacit
         Server_auth.server_state := previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
-        let state = Mcp_server.create_state ~base_path:dir in
+        let state = Mcp_server.For_testing.create_state ~base_path:dir in
         Server_auth.server_state := Some state;
         let config = Mcp_server.workspace_config state in
         let target_running =
@@ -2548,7 +2559,7 @@ let test_health_json_exposes_disabled_keeper_bootstrap_blocker () =
         Server_auth.server_state := previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
-        let state = Mcp_server.create_state ~base_path:dir in
+        let state = Mcp_server.For_testing.create_state ~base_path:dir in
         Server_auth.server_state := Some state;
         let config = (Mcp_server.workspace_config state) in
         let phase_counts :
@@ -2617,7 +2628,7 @@ let test_health_json_ignores_persisted_only_keeper_for_capacity_target () =
         Server_auth.server_state := previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
-        let state = Mcp_server.create_state ~base_path:dir in
+        let state = Mcp_server.For_testing.create_state ~base_path:dir in
         Server_auth.server_state := Some state;
         let config = (Mcp_server.workspace_config state) in
         write_keeper_meta_exn config
@@ -2658,7 +2669,7 @@ let test_health_json_explains_phase_paused_capacity_blocker () =
         Server_auth.server_state := previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
-        let state = Mcp_server.create_state ~base_path:dir in
+        let state = Mcp_server.For_testing.create_state ~base_path:dir in
         Server_auth.server_state := Some state;
         let config = (Mcp_server.workspace_config state) in
         let phase_paused =
@@ -2704,7 +2715,7 @@ let test_health_json_exposes_dead_keeper_registry_cause () =
         Server_auth.server_state := previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
-        let state = Mcp_server.create_state ~base_path:dir in
+        let state = Mcp_server.For_testing.create_state ~base_path:dir in
         Server_auth.server_state := Some state;
         let config = (Mcp_server.workspace_config state) in
         let phase_dead =
@@ -2793,7 +2804,7 @@ let test_health_json_explains_terminal_capacity_blocker
         Server_auth.server_state := previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
-        let state = Mcp_server.create_state ~base_path:dir in
+        let state = Mcp_server.For_testing.create_state ~base_path:dir in
         Server_auth.server_state := Some state;
         let config = Mcp_server.workspace_config state in
         let terminal = make_keeper_meta ~name:keeper_name ~trace_id () in
@@ -2877,7 +2888,7 @@ let test_health_json_distinguishes_failing_executable_keepers () =
         Server_auth.server_state := previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
-        let state = Mcp_server.create_state ~base_path:dir in
+        let state = Mcp_server.For_testing.create_state ~base_path:dir in
         Server_auth.server_state := Some state;
         let config = (Mcp_server.workspace_config state) in
         let paused =
@@ -2933,7 +2944,7 @@ let test_health_json_explains_nonrecoverable_failing_keeper () =
         Server_auth.server_state := previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
-        let state = Mcp_server.create_state ~base_path:dir in
+        let state = Mcp_server.For_testing.create_state ~base_path:dir in
         Server_auth.server_state := Some state;
         let config = (Mcp_server.workspace_config state) in
         let failing =
@@ -3004,7 +3015,7 @@ let test_health_json_redacts_registry_failure_reason () =
         Server_auth.server_state := previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
-        let state = Mcp_server.create_state ~base_path:dir in
+        let state = Mcp_server.For_testing.create_state ~base_path:dir in
         Server_auth.server_state := Some state;
         let config = Mcp_server.workspace_config state in
         let failing =
@@ -3079,7 +3090,7 @@ let test_health_json_uses_crash_log_when_restore_clears_failure_reason () =
         Server_auth.server_state := previous_state;
         Config_dir_resolver.reset ())
       (fun () ->
-        let state = Mcp_server.create_state ~base_path:dir in
+        let state = Mcp_server.For_testing.create_state ~base_path:dir in
         Server_auth.server_state := Some state;
         let config = Mcp_server.workspace_config state in
         let restored =
@@ -3141,7 +3152,7 @@ let test_health_json_reaction_ledger_cursor_sweep_clears_pending () =
           Config_dir_resolver.reset ())
         (fun () ->
         Config_dir_resolver.reset ();
-        let state = Mcp_server.create_state ~base_path:dir in
+        let state = Mcp_server.For_testing.create_state ~base_path:dir in
         Server_auth.server_state := Some state;
         let config = (Mcp_server.workspace_config state) in
         write_keeper_meta_exn config
@@ -3391,7 +3402,7 @@ let test_health_response_full_query_uses_snapshot_cache () =
           Config_dir_resolver.reset ();
           Server_routes_http_runtime.For_testing.reset_full_health_snapshot ())
         (fun () ->
-          Server_auth.server_state := Some (Mcp_server.create_state ~base_path:dir);
+          Server_auth.server_state := Some (Mcp_server.For_testing.create_state ~base_path:dir);
           let request = Httpun.Request.create `GET "/health?full=1" in
           let first =
             Server_routes_http_runtime.make_health_response_json request
@@ -3417,6 +3428,12 @@ let test_health_response_full_query_uses_snapshot_cache () =
             (match first |> member "keeper_reaction_ledger" with
              | `Assoc _ -> true
              | _ -> false);
+          Alcotest.(check bool)
+            "full health response keeps recovery activation shape"
+            true
+            (match first |> member "publication_recovery_activation" with
+             | `Assoc _ -> true
+             | _ -> false);
           Server_routes_http_runtime.For_testing.refresh_full_health_snapshot_now
             request;
           let refreshed =
@@ -3436,7 +3453,12 @@ let test_health_response_full_query_uses_snapshot_cache () =
             true
             (match refreshed |> member "keeper_reaction_ledger" with
              | `Assoc _ -> true
-             | _ -> false)))
+             | _ -> false);
+          Alcotest.(check string)
+            "refreshed full health keeps recovery activation"
+            "unavailable"
+            (refreshed |> member "publication_recovery_activation"
+             |> member "status" |> to_string)))
 
 let test_full_health_refresh_timing_uses_dedicated_budget () =
   let interval_sec, timeout_sec, ttl_sec =
@@ -3678,7 +3700,7 @@ let test_mcp_transport_requires_explicit_readiness () =
        Server_startup_state.mark_blocking ~backend_mode:"filesystem";
        Server_auth.server_state :=
          Some
-           (Mcp_server.create_state
+           (Mcp_server.For_testing.create_state
               ~base_path:(Filename.get_temp_dir_name ()));
        let deps = Server_routes_http_common.mcp_transport_http_deps () in
        Alcotest.(check bool)

--- a/test/test_tag_dispatch_typed.ml
+++ b/test/test_tag_dispatch_typed.ml
@@ -18,18 +18,17 @@ open Alcotest
 
 let pinned_tag_dispatch_outcome_labels = [ "handled"; "no_handler" ]
 
-let pinned_total_telemetry_wrap_sites_across_entries = 5
+let pinned_total_telemetry_wrap_sites_across_entries = 4
 (** Cumulative wrap sites after PR-9:
     - PR-7 keeper turn: keeper_tool_registered_runtime.ml:164 + :218     (2 sites)
-    - PR-8 MCP server: mcp_server_eio_execute.ml:1065 + :1083 (2 sites)
+    - PR-8 MCP server: mcp_server_eio_execute.ml tag dispatch             (1 site)
     - PR-9 tag-dispatch fallback: keeper_tool_registered_runtime.ml:180+   (1 site)
-    Total: 5 wrap sites covering all three dispatch entries. *)
+    Total: 4 wrap sites covering all three dispatch entries. *)
 
 let pinned_dispatch_entries_covered = 3
 (** RFC-0084 §1.1 enumerates 3 dispatch entries:
     - Keeper turn (handler-registry dispatch)
-    - MCP server (tag-based dispatch via dispatch_by_tag /
-      dispatch_internal_keeper_runtime_tool)
+    - MCP server (tag-based dispatch via dispatch_by_tag)
     - Tag-dispatch fallback (keeper_tag_dispatch.ml /
       Keeper_tool_shared_runtime.tag_dispatch_fn)
     PR-9 brings all 3 to telemetry parity. *)
@@ -59,8 +58,8 @@ let test_no_handler_label_present () =
 let test_cumulative_wrap_site_count () =
   (check int)
     "cumulative Tool_telemetry.with_span wrap sites across 3 dispatch entries \
-     (PR-7 = 2, PR-8 = 2, PR-9 = 1; total 5)"
-    5
+     (PR-7 = 2, PR-8 = 1, PR-9 = 1; total 4)"
+    4
     pinned_total_telemetry_wrap_sites_across_entries
 ;;
 

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -1132,7 +1132,7 @@ let test_board_curation_submit_roundtrips_to_read () =
     Yojson.Safe.Util.(read_json |> member "summary" |> to_string)
 
 let mcp_runtime_board_dispatch ~sw ~clock name args =
-  let state = Mcp_server.create_state ~base_path:_test_base_path in
+  let state = Mcp_server.For_testing.create_state ~base_path:_test_base_path in
   Mcp_tool_runtime_board.dispatch ~config:(Mcp_server.workspace_config state)
     ~agent_name:"mcp-runtime-curator" ~arguments:args ~state ~sw ~clock ~name
     ~start_time:(Unix.gettimeofday ())

--- a/test/test_tool_contract_truth.ml
+++ b/test/test_tool_contract_truth.ml
@@ -80,7 +80,7 @@ let test_public_tools_expose_only_truthful_statuses () =
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base_path) (fun () ->
-      let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+      let state = Mcp_eio.For_testing.create_state ~base_path () in
       let tools = tools_list_response ~clock ~sw state |> response_tools in
       List.iter
         (fun tool ->
@@ -97,7 +97,7 @@ let test_keeper_lifecycle_front_door_is_public () =
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base_path) (fun () ->
-      let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+      let state = Mcp_eio.For_testing.create_state ~base_path () in
       let tools = tools_list_response ~clock ~sw state |> response_tools in
       let names = tool_names tools in
       List.iter
@@ -120,7 +120,7 @@ let test_selected_tools_report_contract_status () =
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base_path) (fun () ->
-      let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+      let state = Mcp_eio.For_testing.create_state ~base_path () in
       let tools =
         tools_list_response ~clock ~sw ~include_hidden:true
           ~names:

--- a/test/test_verify_handoff_tool.ml
+++ b/test/test_verify_handoff_tool.ml
@@ -32,9 +32,14 @@ let test_verify_handoff_removed_from_registry () =
   Eio.Switch.run @@ fun sw ->
   let base_path = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir base_path) (fun () ->
-      let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+      let state = Mcp_eio.For_testing.create_state ~base_path () in
       let result =
-        Mcp_eio.execute_tool_eio ~sw ~clock state ~name:"masc_verify_handoff"
+        Mcp_eio.execute_tool_eio
+          ~sw
+          ~clock
+          ~workspace_scope:(Masc.Mcp_server.workspace_scope state)
+          state
+          ~name:"masc_verify_handoff"
           ~arguments:
             (`Assoc
               [

--- a/test/test_warn_root_causes.ml
+++ b/test/test_warn_root_causes.ml
@@ -44,6 +44,16 @@ let require_write_ok label = function
   | Ok () -> ()
   | Error msg -> failf "%s: %s" label msg
 
+let with_publication_recovery_lane ~registry_root ~owner f =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  Masc_test_deps.with_publication_recovery_lane
+    ~sw
+    ~fs:(Eio.Stdenv.fs env)
+    ~registry_root
+    ~owner
+    f
+
 let make_meta ?(name = "test-keeper") () : Keeper_meta_contract.keeper_meta =
   match Masc_test_deps.meta_of_json_fixture
     (`Assoc [("name", `String name); ("agent_name", `String name);
@@ -72,8 +82,12 @@ let test_web_alias_bundle_visible_without_injected_masc_schema () =
         Keeper_context_runtime.create ~eio:false ~system_prompt:"test"
           ~max_tokens:4000
       in
+      with_publication_recovery_lane ~registry_root:dir ~owner:meta.name
+      @@ fun ~publication_recovery_registry ~publication_recovery_access ->
       let bundle =
-        Keeper_tools_oas_bundle.make_tool_bundle ~config ~meta ~ctx_snapshot ()
+        Keeper_tools_oas_bundle.make_tool_bundle
+          ~config ~meta ~publication_recovery_registry
+          ~publication_recovery_access ~ctx_snapshot ()
       in
       Fun.protect
         ~finally:bundle.cleanup
@@ -116,8 +130,12 @@ let test_fusion_default_descriptor_is_bundle_visible () =
         Keeper_context_runtime.create ~eio:false ~system_prompt:"test"
           ~max_tokens:4000
       in
+      with_publication_recovery_lane ~registry_root:dir ~owner:meta.name
+      @@ fun ~publication_recovery_registry ~publication_recovery_access ->
       let bundle =
-        Keeper_tools_oas_bundle.make_tool_bundle ~config ~meta ~ctx_snapshot ()
+        Keeper_tools_oas_bundle.make_tool_bundle
+          ~config ~meta ~publication_recovery_registry
+          ~publication_recovery_access ~ctx_snapshot ()
       in
       Fun.protect
         ~finally:bundle.cleanup
@@ -145,8 +163,12 @@ let test_bundle_exactly_matches_model_visible_descriptors () =
       let ctx_snapshot =
         Keeper_context_runtime.create ~eio:false ~system_prompt:"test" ~max_tokens:4000
       in
+      with_publication_recovery_lane ~registry_root:dir ~owner:meta.name
+      @@ fun ~publication_recovery_registry ~publication_recovery_access ->
       let bundle =
-        Keeper_tools_oas_bundle.make_tool_bundle ~config ~meta ~ctx_snapshot ()
+        Keeper_tools_oas_bundle.make_tool_bundle
+          ~config ~meta ~publication_recovery_registry
+          ~publication_recovery_access ~ctx_snapshot ()
       in
       Fun.protect
         ~finally:bundle.cleanup
@@ -196,8 +218,12 @@ let test_missing_current_task_reconciled_before_transition_hint () =
         Keeper_context_runtime.create ~eio:false ~system_prompt:"test"
           ~max_tokens:4000
       in
+      with_publication_recovery_lane ~registry_root:dir ~owner:meta.name
+      @@ fun ~publication_recovery_registry ~publication_recovery_access ->
       let bundle =
-        Keeper_tools_oas_bundle.make_tool_bundle ~config ~meta ~ctx_snapshot ()
+        Keeper_tools_oas_bundle.make_tool_bundle
+          ~config ~meta ~publication_recovery_registry
+          ~publication_recovery_access ~ctx_snapshot ()
       in
       Fun.protect
         ~finally:bundle.cleanup
@@ -235,8 +261,12 @@ let test_tool_bundle_does_not_emit_full_universe_assignment () =
         Keeper_context_runtime.create ~eio:false ~system_prompt:"test"
           ~max_tokens:4000
       in
+      with_publication_recovery_lane ~registry_root:dir ~owner:meta.name
+      @@ fun ~publication_recovery_registry ~publication_recovery_access ->
       let bundle =
-        Keeper_tools_oas_bundle.make_tool_bundle ~config ~meta ~ctx_snapshot ()
+        Keeper_tools_oas_bundle.make_tool_bundle
+          ~config ~meta ~publication_recovery_registry
+          ~publication_recovery_access ~ctx_snapshot ()
       in
       Fun.protect
         ~finally:bundle.cleanup


### PR DESCRIPTION
## Summary

- add a private, lane-scoped durable obligation store for capability atomic publication
- persist strict Prepared -> Bound -> Forensic transitions with exact file and directory durability barriers
- preserve typed failure, cleanup, cancellation, partial-byte, inventory, and resource-identity evidence
- keep target-tree recovery report-only: no rename, unlink, rmdir, quarantine, substring scan, age rule, retry cap, timeout, or budget gate
- keep registry and lane directory capabilities scoped so intermediate and partial-open FDs do not accumulate

## Stack

- Depends on #24475
- Tracks #24467
- This is a reviewable foundation Draft, not standalone merge-ready functionality. The next stacked PR makes recovery mandatory for `Atomic_replace`, splits `Create_exclusive`, and adds production-path/SIGKILL tests.

## Verification

- `MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build lib/fs_compat/fs_compat.cmxa`
- `ocamlformat --check lib/fs_compat/capability_recovery_obligation.ml lib/fs_compat/capability_recovery_obligation.mli`
- `git diff --check codex/capability-atomic-ssot-20260714...HEAD`
