### PR TITLE
fix(core): recover the CJK-aware token estimator dropped by OAS 0.212.0

### DIFF
--- a/lib/core/dune
+++ b/lib/core/dune
@@ -26,6 +26,7 @@
   executable_path
   safe_identifier
   text_similarity
+  text_token_estimate
   string_util
   list_util
   set_util

--- a/lib/core/text_token_estimate.ml
+++ b/lib/core/text_token_estimate.ml
@@ -1,0 +1,28 @@
+(* Recovered verbatim from oas 902c45d2 lib/llm_provider/text_estimate.ml
+   (dropped in OAS 0.212.0). CJK-aware token estimation:
+
+   ASCII: ~4 chars per token (standard "1 token ≈ 4 characters" rule for
+   English/Latin text).
+   Multi-byte (CJK, emoji, Cyrillic, ...): ~2/3 token per character
+   (tuned against real tokenizers — Hangul and CJK ideographs typically
+   tokenize to 1-2 tokens per visible character).
+
+   Walks the input byte-by-byte, classifying each UTF-8 lead byte by its
+   high bits; continuation bytes are skipped via the lead byte's width.
+   O(n), no allocation. Returns >= 1 for any input; the empty string
+   returns 1 (avoid zero in downstream divisions). *)
+let estimate_char_tokens (s : string) : int =
+  let len = String.length s in
+  let rec loop i ascii multi =
+    if i >= len
+    then max 1 (((ascii + 3) / 4) + (((multi * 2) + 2) / 3))
+    else (
+      let byte = Char.code (String.unsafe_get s i) in
+      if byte < 0x80
+      then loop (i + 1) (ascii + 1) multi
+      else (
+        let skip = if byte >= 0xF0 then 4 else if byte >= 0xE0 then 3 else 2 in
+        loop (i + skip) ascii (multi + 1)))
+  in
+  if len = 0 then 1 else loop 0 0 0
+;;

--- a/lib/core/text_token_estimate.mli
+++ b/lib/core/text_token_estimate.mli
@@ -1,0 +1,13 @@
+(** Text → token count estimation (CJK-aware, tokenizer-free).
+
+    Recovered verbatim from the retired
+    [Agent_sdk.Llm_provider.Text_estimate] (oas 902c45d2,
+    lib/llm_provider/text_estimate.ml); OAS 0.212.0 dropped the module
+    with the rest of its implicit sizing surface, so MASC owns the
+    approximation now. Callers previously reached it through
+    [Agent_sdk.Context_reducer.estimate_char_tokens]. *)
+
+val estimate_char_tokens : string -> int
+(** ASCII ≈ 4 chars/token; multi-byte (CJK, emoji, …) ≈ 2/3 token/char.
+    O(n), no allocation. Returns [>= 1]; the empty string returns [1] so
+    downstream divisions never see zero. *)

--- a/lib/inference_utils.ml
+++ b/lib/inference_utils.ml
@@ -29,7 +29,7 @@ let total_tokens = Agent_sdk.Types.total_tokens
 
 (** CJK-aware token estimate delegated to OAS Context_reducer. *)
 let estimate_tokens (s : string) : int =
-  if s = "" then 0 else Agent_sdk.Context_reducer.estimate_char_tokens s
+  if s = "" then 0 else Text_token_estimate.estimate_char_tokens s
 
 (** Zero usage marker — delegates to OAS [Agent_sdk.Types.zero_api_usage] (F4
     canonical projection consumption: removes re-spelled record literal).

--- a/lib/keeper/keeper_context_core_accessors.ml
+++ b/lib/keeper/keeper_context_core_accessors.ml
@@ -68,7 +68,7 @@ let ensure_dir path =
 
 (** Estimate token count for a raw string (CJK-aware). *)
 let estimate_char_tokens (s : string) : int =
-  Agent_sdk.Context_reducer.estimate_char_tokens s
+  Text_token_estimate.estimate_char_tokens s
 
 (** CJK-aware token estimate delegated to OAS Context_reducer.
     OAS estimator is already conservative (CJK-aware, ceil-based).
@@ -78,7 +78,7 @@ let msg_tokens (m : Agent_sdk.Types.message) : int =
   Agent_sdk.Context_reducer.estimate_message_tokens m
 
 let count_tokens (system_prompt : string) (msgs : Agent_sdk.Types.message list) =
-  let sys_tokens = Agent_sdk.Context_reducer.estimate_char_tokens system_prompt in
+  let sys_tokens = Text_token_estimate.estimate_char_tokens system_prompt in
   List.fold_left (fun acc m -> acc + msg_tokens m) sys_tokens msgs
 
 let checkpoint_of_context (ctx : working_context) = ctx.checkpoint

--- a/test/dune
+++ b/test/dune
@@ -2563,3 +2563,5 @@
 (include stanzas/test_keeper_turn_attempt_observer.inc)
 (include stanzas/test_keeper_gate_effect_coverage.inc)
 (include stanzas/test_keeper_hitl_resolution_prompt.inc)
+
+(include stanzas/test_text_token_estimate.inc)

--- a/test/stanzas/test_text_token_estimate.inc
+++ b/test/stanzas/test_text_token_estimate.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_text_token_estimate)
+ (modules test_text_token_estimate)
+ (libraries alcotest masc_core))

--- a/test/test_text_token_estimate.ml
+++ b/test/test_text_token_estimate.ml
@@ -1,0 +1,22 @@
+(** Behavioural pin for [Text_token_estimate.estimate_char_tokens]
+    (masc#24391 crossover): the estimator was recovered verbatim from the
+    retired oas [Text_estimate] (902c45d2) when OAS 0.212.0 dropped it,
+    and these vectors are the module's own upstream tests, preserved so
+    the recovered semantics cannot drift silently. *)
+
+open Alcotest
+
+let est = Text_token_estimate.estimate_char_tokens
+
+let test_vectors () =
+  check int "empty string returns 1" 1 (est "");
+  check int "pure ASCII rounds up per 4 chars (11 chars)" 3 (est "hello world");
+  check int "pure Hangul 5 chars ~ 2/3 token each" 4
+    (est "\xEC\x95\x88\xEB\x85\x95\xED\x95\x98\xEC\x84\xB8\xEC\x9A\x94");
+  check int "mixed ASCII + Hangul" 4 (est "hello \xEC\x95\x88\xEB\x85\x95");
+  check int "two 4-byte emoji" 2 (est "\xF0\x9F\x98\x80\xF0\x9F\x98\x80");
+  check bool "single ASCII char is at least 1" true (est "a" >= 1)
+
+let () =
+  run "text_token_estimate"
+    [ ("estimate_char_tokens", [ test_case "upstream vectors" `Quick test_vectors ]) ]


### PR DESCRIPTION
## 무엇을

crossover 잔여 4건 중 **Context_reducer 클러스터 2건** 수리 (masc#24391 분류 지도의 설계적 B — 실측해 보니 기계적 이식으로 충분).

- OAS 0.212.0이 `Llm_provider.Text_estimate`(+`Context_reducer` re-export)를 제거 → masc 콜사이트 2파일 3사용처 컴파일 불능.
- 직전 pin(902c45d2)의 구현을 **verbatim 이식**: `masc_core`의 `Text_token_estimate` (ASCII ~4자/토큰, 멀티바이트 ~2/3토큰/자, O(n) 바이트워커, 최소 1 보장). 발명 없음 — 원 모듈의 자체 테스트 벡터 6종도 alcotest로 보존해 의미 드리프트를 봉인.

## 안 고친 것

`exit_condition` 쌍(runtime_agent:1199 / runtime_agent_context:247)은 **#24403이 선언한 typed cooperative yield 스코프** — keeper 자율턴 yield의 라이브 메커니즘 재배선이라 해당 트랙 몫. 이 PR 머지 시 main 잔여 컴파일 에러는 그 2건만 남습니다.

## 검증

- `dune build lib/core` clean, `test_text_token_estimate` 1/1 green (로컬 switch=pin=0.212.0 일치 상태라 로컬이 정본).

Related: masc#24391 (crossover 지도), oas 0.212.0 하드컷.

RFC-WAIVED: 소멸한 upstream 유틸리티의 pin-원본 이식, 신규 설계 없음.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
