### PR TITLE
refactor(keeper): hard-cut context estimator facade

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -720,8 +720,6 @@ let keepers_dashboard_json ?(compact = false) (config : Workspace.config) : Yojs
                          `Assoc [
                            ("has_checkpoint", `Bool true);
                            ("source", `String "checkpoint");
-                           ("context_ratio", `Float (Keeper_context_runtime.context_ratio c));
-                           ("context_tokens", `Int (Keeper_context_runtime.token_count c));
                            ("context_max", `Int c.max_tokens);
                            ("message_count", `Int (Keeper_context_runtime.message_count c));
                          ])

--- a/lib/inference_utils.ml
+++ b/lib/inference_utils.ml
@@ -1,6 +1,6 @@
 (** Inference_utils — inference utility functions.
 
-    Usage helpers, UTF-8 sanitization, token estimation, and
+    Usage helpers, UTF-8 sanitization, and
     concurrency diagnostics.  Extracted from the former [Runtime]
     module during the Runtime deletion refactor.
 
@@ -26,10 +26,6 @@ let int_of_env_default name ~default ~min_v ~max_v =
 (** Total tokens — delegates to OAS [Agent_sdk.Types.total_tokens] (F12 canonical
     projection consumption: OAS owns api_usage arithmetic, MASC consumes). *)
 let total_tokens = Agent_sdk.Types.total_tokens
-
-(** CJK-aware token estimate delegated to OAS Context_reducer. *)
-let estimate_tokens (s : string) : int =
-  if s = "" then 0 else Agent_sdk.Context_reducer.estimate_char_tokens s
 
 (** Zero usage marker — delegates to OAS [Agent_sdk.Types.zero_api_usage] (F4
     canonical projection consumption: removes re-spelled record literal).

--- a/lib/inference_utils.mli
+++ b/lib/inference_utils.mli
@@ -11,9 +11,6 @@ val int_of_env_default : string -> default:int -> min_v:int -> max_v:int -> int
 (** Compute total tokens from OAS api_usage. *)
 val total_tokens : Agent_sdk.Types.api_usage -> int
 
-(** CJK-aware token estimate delegated to OAS Context_reducer. *)
-val estimate_tokens : string -> int
-
 (** Zero usage marker. *)
 val zero_usage : Agent_sdk.Types.api_usage
 

--- a/lib/keeper/keeper_context_core.mli
+++ b/lib/keeper/keeper_context_core.mli
@@ -1,4 +1,4 @@
-(** Keeper working-context primitives — token counting, message
+(** Keeper working-context primitives — message
     history, OAS checkpoint conversion, JSONL persistence.
 
     Final selective-exposure .mli of the keeper subsystem (PR#3
@@ -10,17 +10,7 @@
 type working_context = Keeper_types.working_context
 type session_context = Keeper_types.session_context
 
-(** {1 Token counting} *)
-
-(** Token count of a single OAS message. *)
-val msg_tokens : Agent_sdk.Types.message -> int
-
-(** Total tokens across [system_prompt] + every message. *)
-val count_tokens : string -> Agent_sdk.Types.message list -> int
-
-val token_count : working_context -> int
 val message_count : working_context -> int
-val context_ratio : working_context -> float
 val max_tokens_of_context : working_context -> int
 
 (** Replace the working-context's [max_tokens]; mirrors the value

--- a/lib/keeper/keeper_context_core.mli
+++ b/lib/keeper/keeper_context_core.mli
@@ -46,8 +46,9 @@ val set_system_prompt :
 val append : working_context -> Agent_sdk.Types.message -> working_context
 val append_many : working_context -> Agent_sdk.Types.message list -> working_context
 
-(** Push the working-context's derived counters into the OAS
-    [Context.t] (Session scope). *)
+(** Push the exact working-context message count into the OAS [Context.t]
+    (Session scope). Provider token usage is response telemetry and is not a
+    measure of the current checkpoint's context size. *)
 val sync_oas_context : working_context -> working_context
 
 (** {1 Working-context projections} *)

--- a/lib/keeper/keeper_context_core_accessors.ml
+++ b/lib/keeper/keeper_context_core_accessors.ml
@@ -51,36 +51,6 @@ let ensure_dir path =
   (* ensure_dir returns the created path; fire-and-forget *)
   ignore (Keeper_fs.ensure_dir path)
 
-(** {1 Token Estimation Facade}
-
-    All OAS Context_reducer estimation calls in MASC pass through this
-    module.  Other keeper modules must NOT call
-    [Agent_sdk.Context_reducer.estimate_*] directly for decision-making.
-
-    @boundary-contract
-    - MASC owns: observation (context_ratio for logging, compaction strategy
-      selection, dashboard display). Token estimates are read-only signals.
-    - OAS owns: authoritative token estimation (CJK-aware, ceil-based),
-      context budget enforcement during Agent.run, compaction execution.
-    - Neither may: MASC must not add safety buffers on top of OAS estimates
-      (removed in #5053); OAS estimates must not be used as exact counts
-      for billing or hard limits. *)
-
-(** Estimate token count for a raw string (CJK-aware). *)
-let estimate_char_tokens (s : string) : int =
-  Agent_sdk.Context_reducer.estimate_char_tokens s
-
-(** CJK-aware token estimate delegated to OAS Context_reducer.
-    OAS estimator is already conservative (CJK-aware, ceil-based).
-    Prior 15% buffer (#5053) removed — it caused premature compaction
-    and masked the OAS estimator's actual accuracy. *)
-let msg_tokens (m : Agent_sdk.Types.message) : int =
-  Agent_sdk.Context_reducer.estimate_message_tokens m
-
-let count_tokens (system_prompt : string) (msgs : Agent_sdk.Types.message list) =
-  let sys_tokens = Agent_sdk.Context_reducer.estimate_char_tokens system_prompt in
-  List.fold_left (fun acc m -> acc + msg_tokens m) sys_tokens msgs
-
 let checkpoint_of_context (ctx : working_context) = ctx.checkpoint
 
 let oas_context_of_context (ctx : working_context) = ctx.checkpoint.context
@@ -118,6 +88,7 @@ let empty_runtime_checkpoint ~system_prompt ~messages ~max_tokens
     top_p = None;
     top_k = None;
     min_p = None;
+    reasoning_effort = None;
     enable_thinking = None;
     preserve_thinking = None;
     response_format = Agent_sdk.Types.Off;
@@ -128,16 +99,8 @@ let empty_runtime_checkpoint ~system_prompt ~messages ~max_tokens
     working_context = None;
   }
 
-let token_count (ctx : working_context) =
-  count_tokens (system_prompt_of_context ctx) (messages_of_context ctx)
-
 let message_count (ctx : working_context) =
   List.length (messages_of_context ctx)
-
-let context_ratio (ctx : working_context) : float =
-  let max_tokens = max_tokens_of_context ctx in
-  if max_tokens = 0 then 0.0
-  else float_of_int (token_count ctx) /. float_of_int max_tokens
 
 let create_oas_context ~eio =
   if eio then Agent_sdk.Context.create () else Agent_sdk.Context.create_sync ()

--- a/lib/keeper/keeper_context_core_accessors.ml
+++ b/lib/keeper/keeper_context_core_accessors.ml
@@ -175,18 +175,8 @@ let append_many ctx msgs =
 let sync_oas_context (ctx : working_context) : working_context =
   let context = oas_context_of_context ctx in
   let message_count = message_count ctx in
-  let token_count = token_count ctx in
-  let context_ratio =
-    let max_tokens = max_tokens_of_context ctx in
-    if max_tokens = 0 then 0.0
-    else float_of_int token_count /. float_of_int max_tokens
-  in
   Agent_sdk.Context.set_scoped context Agent_sdk.Context.Session
     "message_count" (`Int message_count);
-  Agent_sdk.Context.set_scoped context Agent_sdk.Context.Session
-    "token_count" (`Int token_count);
-  Agent_sdk.Context.set_scoped context Agent_sdk.Context.Session
-    "context_ratio" (`Float context_ratio);
   ctx
 
 let role_to_string = Message_json.role_to_string
@@ -537,7 +527,6 @@ let serialize_context (ctx : working_context) : string =
       `String
         (Inference_utils.sanitize_text_utf8 (system_prompt_of_context ctx)) );
     ("messages", `List (List.map message_to_json (messages_of_context ctx)));
-    ("token_count", `Int (token_count ctx));
     ("max_tokens", `Int (max_tokens_of_context ctx));
   ] in
   Yojson.Safe.to_string json
@@ -549,7 +538,6 @@ let deserialize_context ~eio (s : string) ~max_tokens : working_context =
     (match Json_util.assoc_member_opt "messages" json with Some (`List l) -> l | _ -> []) |> List.map message_of_json
     |> repair_broken_tool_call_pairs
   in
-  let _legacy_token_count = Json_util.get_int json "token_count" in
   let context = create_oas_context ~eio in
   let checkpoint =
     empty_runtime_checkpoint ~system_prompt ~messages ~max_tokens ~context
@@ -563,7 +551,6 @@ let context_to_json (ctx : working_context) : Yojson.Safe.t =
       `String
         (Inference_utils.sanitize_text_utf8 (system_prompt_of_context ctx)) );
     ("messages", `List (List.map message_to_json (messages_of_context ctx)));
-    ("token_count", `Int (token_count ctx));
     ("max_tokens", `Int (max_tokens_of_context ctx));
   ]
 

--- a/lib/keeper/keeper_context_layers.ml
+++ b/lib/keeper/keeper_context_layers.ml
@@ -5,7 +5,6 @@ type layer_id =
   | Current_task
   | Connected_surfaces
   | Namespace_state
-  | Context_health
   | Autonomous_trigger
   | Scheduled_automation
   | Pending_mentions
@@ -23,7 +22,6 @@ let ordered =
   ; Current_task
   ; Connected_surfaces
   ; Namespace_state
-  ; Context_health
   ; Autonomous_trigger
   ; Scheduled_automation
   ; Pending_mentions
@@ -41,13 +39,12 @@ let order_index = function
   | Current_task -> 1
   | Connected_surfaces -> 2
   | Namespace_state -> 3
-  | Context_health -> 4
-  | Autonomous_trigger -> 5
-  | Scheduled_automation -> 6
-  | Pending_mentions -> 7
-  | Scope_messages -> 8
-  | Claimable_work -> 9
-  | Board_activity -> 10
+  | Autonomous_trigger -> 4
+  | Scheduled_automation -> 5
+  | Pending_mentions -> 6
+  | Scope_messages -> 7
+  | Claimable_work -> 8
+  | Board_activity -> 9
 ;;
 
 let assemble ~content_of =

--- a/lib/keeper/keeper_context_layers.ml
+++ b/lib/keeper/keeper_context_layers.ml
@@ -5,6 +5,7 @@ type layer_id =
   | Current_task
   | Connected_surfaces
   | Namespace_state
+  | Context_health
   | Autonomous_trigger
   | Scheduled_automation
   | Pending_mentions
@@ -22,6 +23,7 @@ let ordered =
   ; Current_task
   ; Connected_surfaces
   ; Namespace_state
+  ; Context_health
   ; Autonomous_trigger
   ; Scheduled_automation
   ; Pending_mentions
@@ -39,12 +41,13 @@ let order_index = function
   | Current_task -> 1
   | Connected_surfaces -> 2
   | Namespace_state -> 3
-  | Autonomous_trigger -> 4
-  | Scheduled_automation -> 5
-  | Pending_mentions -> 6
-  | Scope_messages -> 7
-  | Claimable_work -> 8
-  | Board_activity -> 9
+  | Context_health -> 4
+  | Autonomous_trigger -> 5
+  | Scheduled_automation -> 6
+  | Pending_mentions -> 7
+  | Scope_messages -> 8
+  | Claimable_work -> 9
+  | Board_activity -> 10
 ;;
 
 let assemble ~content_of =

--- a/lib/keeper/keeper_context_layers.mli
+++ b/lib/keeper/keeper_context_layers.mli
@@ -17,7 +17,6 @@ type layer_id =
   | Current_task
   | Connected_surfaces
   | Namespace_state
-  | Context_health
   | Autonomous_trigger
   | Scheduled_automation
   | Pending_mentions

--- a/lib/keeper/keeper_context_layers.mli
+++ b/lib/keeper/keeper_context_layers.mli
@@ -17,6 +17,7 @@ type layer_id =
   | Current_task
   | Connected_surfaces
   | Namespace_state
+  | Context_health
   | Autonomous_trigger
   | Scheduled_automation
   | Pending_mentions

--- a/lib/keeper/keeper_context_runtime.ml
+++ b/lib/keeper/keeper_context_runtime.ml
@@ -21,12 +21,8 @@ type working_context = Keeper_types.working_context
 type session_context = Keeper_types.session_context
 
 let text_of_message = Keeper_context_core.text_of_message
-let msg_tokens = Keeper_context_core.msg_tokens
-let count_tokens = Keeper_context_core.count_tokens
 let max_tokens_of_context = Keeper_context_core.max_tokens_of_context
-let token_count = Keeper_context_core.token_count
 let message_count = Keeper_context_core.message_count
-let context_ratio = Keeper_context_core.context_ratio
 let checkpoint_of_context = Keeper_context_core.checkpoint_of_context
 let resume_checkpoint_of_context =
   Keeper_context_core.resume_checkpoint_of_context
@@ -94,9 +90,8 @@ type compaction_event = Keeper_post_turn.compaction_event = {
   failure_reason : string option;
   trigger : Compaction_trigger.t option;
   decision : Keeper_compact_policy.compaction_decision;
-  before_tokens : int;
-  after_tokens : int;
-  saved_tokens : int;
+  before_messages : int;
+  after_messages : int;
 }
 
 type post_turn_lifecycle = Keeper_post_turn.post_turn_lifecycle = {
@@ -107,8 +102,6 @@ type post_turn_lifecycle = Keeper_post_turn.post_turn_lifecycle = {
   handoff_failure_reason : string option;
   compaction : compaction_event;
   turn_generation : int;
-  context_ratio : float;
-  context_tokens : int;
   context_max : int;
   message_count : int;
 }
@@ -210,59 +203,17 @@ let dispatch_keeper_phase_event
         event
         ~error:(Printexc.to_string exn)
 
-(* #9988 Option B follow-up: centralize [Compaction_completed] dispatch
-   so both emit paths (manual recovery in [keeper_tool_surface] and automatic
-   post-turn lifecycle) share the same outcome counter + warn log.
-
-   [masc_keeper_compaction_outcome_total{keeper,outcome}] splits into
-   [outcome=ok] (real savings) and [outcome=noop] (before==after or
-   after>before).  The FSM (#9993) already refuses to clear
-   [context_overflow] in the noop branch; the counter exposes the
-   surface so dashboards/Grafana can alert on rising noop rate —
-   the operational signal for "reducer has nothing to strip, switch
-   profile or hand off". *)
-let compaction_outcome_metric = "masc_keeper_compaction_outcome_total"
-
-let () =
-  Otel_metric_store.register_counter
-    ~name:compaction_outcome_metric
-    ~help:
-      "Total Compaction_completed dispatches classified by token \
-       savings. Labels: keeper, outcome (ok = saved_tokens > 0, \
-       noop = before == after or after > before). Rising noop \
-       rate is the operational signal for \"reducer has nothing \
-       to strip, switch profile or hand off\" (#9988)."
-    ()
-
-(* Observability-only: bump the outcome counter and log the warn
-   when saved_tokens <= 0.  Split from [dispatch_compaction_completed]
-   so unit tests can verify classification without needing a full
-   [Workspace.config] / [Keeper_registry] setup. *)
-let record_compaction_outcome ~keeper_name ~before_tokens ~after_tokens =
-  let saved_tokens = before_tokens - after_tokens in
-  let outcome = if saved_tokens > 0 then "ok" else "noop" in
-  Otel_metric_store.inc_counter compaction_outcome_metric
-    ~labels:[ ("keeper", keeper_name); ("outcome", outcome) ] ();
-  if saved_tokens <= 0 then
-    Log.Keeper.warn
-      "#9988 compaction_completed but saved_tokens=%d \
-       (before=%d after=%d) keeper=%s — context_overflow will stay set \
-       (FSM noop branch).  If this repeats, switch to a stronger \
-       compaction profile or escalate to operator."
-      saved_tokens before_tokens after_tokens keeper_name
-
 let dispatch_compaction_completed
     ~(config : Workspace.config)
     ~origin
     ~keeper_name
-    ~before_tokens
-    ~after_tokens =
-  record_compaction_outcome ~keeper_name ~before_tokens ~after_tokens;
+    ~before_messages
+    ~after_messages =
   Otel_metric_store.inc_counter Keeper_metrics.(to_string FsmEdgeTransitions)
     ~labels:[("edge", "kmc_to_ksm_compact_completed")] ();
   dispatch_keeper_phase_event ~config ~origin ~keeper_name
     (Keeper_state_machine.Compaction_completed
-       { before_tokens; after_tokens })
+       { before_messages; after_messages })
 
 let dispatch_post_turn_lifecycle_events
     ~(config : Workspace.config)
@@ -296,8 +247,8 @@ let dispatch_post_turn_lifecycle_events
         ~config
         ~origin:Keeper_registry.Post_turn_lifecycle
         ~keeper_name
-        ~before_tokens:lifecycle.compaction.before_tokens
-        ~after_tokens:lifecycle.compaction.after_tokens
+        ~before_messages:lifecycle.compaction.before_messages
+        ~after_messages:lifecycle.compaction.after_messages
     end
     else
       dispatch_keeper_phase_event

--- a/lib/keeper/keeper_context_runtime.mli
+++ b/lib/keeper/keeper_context_runtime.mli
@@ -18,12 +18,8 @@ type session_context = Keeper_types.session_context
 (** {1 Working Context Operations} *)
 
 val text_of_message : Agent_sdk.Types.message -> string
-val msg_tokens : Agent_sdk.Types.message -> int
-val count_tokens : string -> Agent_sdk.Types.message list -> int
 val max_tokens_of_context : working_context -> int
-val token_count : working_context -> int
 val message_count : working_context -> int
-val context_ratio : working_context -> float
 val checkpoint_of_context : working_context -> Agent_sdk.Checkpoint.t
 val resume_checkpoint_of_context : working_context -> Agent_sdk.Checkpoint.t
 val oas_context_of_context : working_context -> Agent_sdk.Context.t
@@ -84,9 +80,8 @@ type compaction_event =
   ; failure_reason : string option
   ; trigger : Compaction_trigger.t option
   ; decision : Keeper_compact_policy.compaction_decision
-  ; before_tokens : int
-  ; after_tokens : int
-  ; saved_tokens : int
+  ; before_messages : int
+  ; after_messages : int
   }
 
 type post_turn_lifecycle =
@@ -97,8 +92,6 @@ type post_turn_lifecycle =
   ; handoff_failure_reason : string option
   ; compaction : compaction_event
   ; turn_generation : int
-  ; context_ratio : float
-  ; context_tokens : int
   ; context_max : int
   ; message_count : int
   }
@@ -165,41 +158,14 @@ val dispatch_keeper_phase_event
   -> Keeper_state_machine.event
   -> unit
 
-(** Canonical metric name for the compaction outcome counter.
-
-    Labels: [("keeper", <name>); ("outcome", "ok" | "noop")].
-    Exported so tests can pin the name without hard-coding a string
-    literal.  #9988. *)
-val compaction_outcome_metric : string
-
-(** [record_compaction_outcome ~keeper_name ~before_tokens ~after_tokens]
-    emits the outcome counter and (for [saved_tokens <= 0]) a warn log,
-    without dispatching an FSM event.  Exposed for unit tests and for
-    callers that need the observability signal before/after a dispatch.  *)
-val record_compaction_outcome
-  :  keeper_name:string
-  -> before_tokens:int
-  -> after_tokens:int
-  -> unit
-
-(** [dispatch_compaction_completed ~config ~keeper_name ~before_tokens
-    ~after_tokens] dispatches a [Compaction_completed] phase event and
-    updates observability in one place.
-
-    Emits [compaction_outcome_metric] labelled with [outcome=ok] when
-    [after_tokens < before_tokens] and [outcome=noop] otherwise.  A
-    [noop] outcome also logs a warning — the FSM (#9988) keeps
-    [context_overflow] set in this case, so operators need the signal
-    to escalate profile / alert.
-
-    Explicit compaction completion paths funnel through this helper to keep
-    observability coherent. *)
+(** Dispatch a [Compaction_completed] phase event with exact message counts.
+    The payload is observation only and never gates continuation. *)
 val dispatch_compaction_completed
   :  config:Workspace.config
   -> origin:Keeper_registry.lifecycle_event_origin
   -> keeper_name:string
-  -> before_tokens:int
-  -> after_tokens:int
+  -> before_messages:int
+  -> after_messages:int
   -> unit
 
 val dispatch_post_turn_lifecycle_events

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -54,9 +54,8 @@ type compaction_event = {
   failure_reason : string option;
   trigger : Compaction_trigger.t option;
   decision : Keeper_compact_policy.compaction_decision;
-  before_tokens : int;
-  after_tokens : int;
-  saved_tokens : int;
+  before_messages : int;
+  after_messages : int;
 }
 
 type post_turn_lifecycle = {
@@ -67,8 +66,6 @@ type post_turn_lifecycle = {
   handoff_failure_reason : string option;
   compaction : compaction_event;
   turn_generation : int;
-  context_ratio : float;
-  context_tokens : int;
   context_max : int;
   message_count : int;
 }
@@ -445,13 +442,10 @@ let apply_post_turn_lifecycle_with_resilience_handles
             failure_reason = None;
             trigger = None;
             decision = no_checkpoint_decision;
-            before_tokens = 0;
-            after_tokens = 0;
-            saved_tokens = 0;
-          };
+            before_messages = 0;
+            after_messages = 0;
+        };
         turn_generation = meta.runtime.generation;
-        context_ratio = 0.0;
-        context_tokens = 0;
         context_max = primary_model_max_tokens;
         message_count = 0;
       }
@@ -471,7 +465,7 @@ let apply_post_turn_lifecycle_with_resilience_handles
             (fun rt -> { rt with generation = current_generation })
             meta
       in
-      let before_tokens = token_count ctx in
+      let before_messages = message_count ctx in
       let compacted_ctx = ctx in
       let trigger = None in
       let decision = Keeper_compact_policy.Not_requested in
@@ -554,8 +548,7 @@ let apply_post_turn_lifecycle_with_resilience_handles
               (false, Some e, ctx, Some cp))
         )
       in
-      let after_tokens = token_count effective_ctx in
-      let saved_tokens = max 0 (before_tokens - after_tokens) in
+      let after_messages = message_count effective_ctx in
       let meta_after_compaction =
         map_runtime
           (fun rt ->
@@ -569,12 +562,8 @@ let apply_post_turn_lifecycle_with_resilience_handles
                   last_ts =
                     if effective_compaction_applied then now_ts
                     else rt.compaction_rt.last_ts;
-                  last_before_tokens =
-                    if effective_compaction_applied then before_tokens
-                    else rt.compaction_rt.last_before_tokens;
-                  last_after_tokens =
-                    if effective_compaction_applied then after_tokens
-                    else rt.compaction_rt.last_after_tokens;
+                  last_before_tokens = rt.compaction_rt.last_before_tokens;
+                  last_after_tokens = rt.compaction_rt.last_after_tokens;
                   last_check_ts = now_ts;
                   last_decision =
                     Keeper_compact_policy.compaction_decision_to_string
@@ -599,13 +588,10 @@ let apply_post_turn_lifecycle_with_resilience_handles
             failure_reason = compaction_failure_reason;
             trigger;
             decision;
-            before_tokens;
-            after_tokens;
-            saved_tokens;
-          };
+            before_messages;
+            after_messages;
+        };
         turn_generation = current_generation;
-        context_ratio = context_ratio effective_ctx;
-        context_tokens = token_count effective_ctx;
         context_max = max_tokens_of_context effective_ctx;
         message_count = message_count effective_ctx;
       }
@@ -684,7 +670,7 @@ let recover_latest_checkpoint_for_overflow_retry
             (with_max_tokens ctx
                (min (max_tokens_of_context ctx) primary_model_max_tokens))
       in
-      let before_tokens = token_count ctx in
+      let before_messages = message_count ctx in
       let retry_meta =
         if turn_generation = meta.runtime.generation then meta
         else map_runtime (fun rt -> { rt with generation = turn_generation }) meta
@@ -700,12 +686,11 @@ let recover_latest_checkpoint_for_overflow_retry
         | Keeper_compact_policy.Prepared trigger -> Some trigger
         | _ -> None
       in
-      let after_tokens = token_count compacted_ctx in
+      let after_messages = message_count compacted_ctx in
       let compaction_applied =
         Keeper_compact_policy.compaction_decision_prepared base_decision
       in
-      let meaningful_reduction = after_tokens < before_tokens in
-      if not (compaction_applied && meaningful_reduction) then None
+      if not compaction_applied then None
       else
         let compaction =
           {
@@ -715,9 +700,8 @@ let recover_latest_checkpoint_for_overflow_retry
             failure_reason = None;
             trigger;
             decision = base_decision;
-            before_tokens;
-            after_tokens;
-            saved_tokens = max 0 (before_tokens - after_tokens);
+            before_messages;
+            after_messages;
           }
         in
         let compacted_ctx =

--- a/lib/keeper/keeper_post_turn.mli
+++ b/lib/keeper/keeper_post_turn.mli
@@ -25,9 +25,8 @@ type compaction_event =
   ; failure_reason : string option
   ; trigger : Compaction_trigger.t option
   ; decision : Keeper_compact_policy.compaction_decision
-  ; before_tokens : int
-  ; after_tokens : int
-  ; saved_tokens : int
+  ; before_messages : int
+  ; after_messages : int
   }
 
 (** Combined post-turn outcome — compaction + rollover + per-turn context
@@ -40,8 +39,6 @@ type post_turn_lifecycle =
   ; handoff_failure_reason : string option
   ; compaction : compaction_event
   ; turn_generation : int
-  ; context_ratio : float
-  ; context_tokens : int
   ; context_max : int
   ; message_count : int
   }

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -412,8 +412,6 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
              | Some c ->
                `Assoc [
                  ("has_checkpoint", `Bool true);
-                 ("context_ratio", `Float (Keeper_context_runtime.context_ratio c));
-                 ("context_tokens", `Int (Keeper_context_runtime.token_count c));
                  ("context_max", `Int (Keeper_context_runtime.max_tokens_of_context c));
                  ("message_count", `Int (Keeper_context_runtime.message_count c));
                ]

--- a/lib/keeper/keeper_tool_memory_runtime.ml
+++ b/lib/keeper/keeper_tool_memory_runtime.ml
@@ -507,11 +507,6 @@ let keeper_context_status_json
       ~(meta : keeper_meta)
       ~(ctx_work : working_context)
   =
-  let ctx_tokens = count_context_tokens ctx_work in
-  let ctx_max = Keeper_context_runtime.max_tokens_of_context ctx_work in
-  let ctx_ratio =
-    if ctx_max = 0 then 0.0 else float_of_int ctx_tokens /. float_of_int ctx_max
-  in
   (* RFC-0149 §3.1 — route through typed Result resolver so a memory
      bank IO fault surfaces as the sibling [memory_tier_error_class]
      field instead of an empty [memory_tier_summary] that is
@@ -549,9 +544,6 @@ let keeper_context_status_json
         ([ "name", `String meta.name
          ; "trace_id", `String (Keeper_id.Trace_id.to_string meta.runtime.trace_id)
          ; "generation", `Int meta.runtime.generation
-         ; "context_ratio", `Float ctx_ratio
-         ; "context_tokens", `Int ctx_tokens
-         ; "context_max", `Int ctx_max
          ; "message_count", `Int (List.length (messages_of_context ctx_work))
          ; "last_model_used", `Null
          ]

--- a/lib/keeper/keeper_tool_shared_runtime.ml
+++ b/lib/keeper/keeper_tool_shared_runtime.ml
@@ -5,8 +5,6 @@ open Keeper_alerting
 module StringMap = Set_util.StringMap
 module StringSet = Set_util.StringSet
 
-let count_context_tokens (ctx : working_context) = Keeper_context_runtime.token_count ctx
-
 let has_json_field name fields =
   List.exists (fun (field, _) -> String.equal field name) fields
 ;;

--- a/lib/keeper/keeper_tool_shared_runtime.mli
+++ b/lib/keeper/keeper_tool_shared_runtime.mli
@@ -3,10 +3,6 @@
 
 module StringMap : Map.S with type key = string
 
-(** Total token count of a working context, delegating to
-    [Keeper_context_runtime.token_count]. *)
-val count_context_tokens : Keeper_types.working_context -> int
-
 (** Render an error JSON envelope: [{"error": <message>; ...fields}]. *)
 val error_json : ?fields:(string * Yojson.Safe.t) list -> string -> string
 

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -473,8 +473,8 @@ let keeper_compact_body ~(config : Workspace.config) args : tool_result =
           Keeper_context_runtime.dispatch_compaction_completed
             ~config ~keeper_name:name
             ~origin:Keeper_registry.Operator_compact
-            ~before_tokens:recovery.compaction.before_tokens
-            ~after_tokens:recovery.compaction.after_tokens;
+            ~before_messages:recovery.compaction.before_messages
+            ~after_messages:recovery.compaction.after_messages;
           invalidate_status_cache name;
           Otel_metric_store.inc_counter Keeper_metrics.(to_string OperatorCompact)
             ~labels:[("keeper", name); ("result", Keeper_operator_compact_result.(to_label Ok))] ();
@@ -488,8 +488,6 @@ let keeper_compact_body ~(config : Workspace.config) args : tool_result =
                        (match Keeper_registry.get ~base_path:config.base_path name with
                         | Some entry -> Keeper_state_machine.phase_to_string entry.phase
                         | None -> "unknown") );
-                   ("before_tokens", `Int recovery.compaction.before_tokens);
-                ("after_tokens", `Int recovery.compaction.after_tokens);
               ])
         | None ->
           (* Compaction infrastructure unavailable — emit [Compaction_failed]

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -893,8 +893,6 @@ let run_keeper_msg_turn_admitted
                    ~turn_generation:lifecycle.turn_generation
                    ~channel:Keeper_world_observation.Reactive
                    ~snapshot_source:"keeper_turn_msg"
-                   ~context_ratio:lifecycle.context_ratio
-                   ~context_tokens:lifecycle.context_tokens
                    ~context_max:lifecycle.context_max
                    ~message_count:lifecycle.message_count
                    ~compaction:lifecycle.compaction

--- a/lib/keeper/keeper_unified_metrics.mli
+++ b/lib/keeper/keeper_unified_metrics.mli
@@ -160,8 +160,6 @@ val append_metrics_snapshot :
   turn_generation:int ->
   channel:Keeper_world_observation.keeper_cycle_channel ->
   snapshot_source:string ->
-  context_ratio:float ->
-  context_tokens:int ->
   context_max:int ->
   message_count:int ->
   compaction:Keeper_context_runtime.compaction_event ->

--- a/lib/keeper/keeper_unified_metrics_broadcast.ml
+++ b/lib/keeper/keeper_unified_metrics_broadcast.ml
@@ -22,9 +22,6 @@ let broadcast_lifecycle_events ~(name : string)
              ("type", `String "keeper_compaction");
              ("name", `String name);
              ("generation", `Int turn_generation);
-             ("before_tokens", `Int compaction.before_tokens);
-             ("after_tokens", `Int compaction.after_tokens);
-             ("saved_tokens", `Int compaction.saved_tokens);
              ( "trigger",
                match compaction.trigger with
                | Some trigger -> `String (Compaction_trigger.to_label trigger)
@@ -73,4 +70,3 @@ let broadcast_lifecycle_events ~(name : string)
             (Printexc.to_string exn);
           Otel_metric_store.inc_counter Keeper_metrics.(to_string MetricsSseFailures) ~labels:[("kind", Keeper_metrics_sse_failure_kind.(to_label Handoff))] ())
   | _ -> ()
-

--- a/lib/keeper/keeper_unified_metrics_decision.ml
+++ b/lib/keeper/keeper_unified_metrics_decision.ml
@@ -163,7 +163,6 @@ let append_decision_record
                         observation.pending_messages)) );
               ("active_goals", `Int (List.length observation.active_goals));
               ("idle_seconds", `Int observation.idle_seconds);
-              ("context_ratio", `Float (Lazy.force observation.context_ratio));
               ("unclaimed_task_count", `Int observation.unclaimed_task_count);
               ("claimable_task_count", `Int observation.claimable_task_count);
               ( "claim_blocked_task_count",

--- a/lib/keeper/keeper_unified_metrics_snapshot.ml
+++ b/lib/keeper/keeper_unified_metrics_snapshot.ml
@@ -16,8 +16,6 @@ let append_metrics_snapshot ~(config : Workspace.config) ~(meta : keeper_meta)
     ~(turn_generation : int)
     ~(channel : Keeper_world_observation.keeper_cycle_channel)
     ~(snapshot_source : string)
-    ~(context_ratio : float)
-    ~(context_tokens : int)
     ~(context_max : int)
     ~(message_count : int)
     ~(compaction : Keeper_context_runtime.compaction_event)
@@ -32,12 +30,7 @@ let append_metrics_snapshot ~(config : Workspace.config) ~(meta : keeper_meta)
       ~usage_reported:result.usage_reported
       ~usage:result.usage
   in
-  (* #9953: record context_max_bucket on the neutral runtime lane so
-     dashboards can directly count drift without preserving provider/model
-     identity at the MASC boundary. *)
-  record_context_max_observation
-    ~keeper:meta.name
-    ~context_max;
+  record_context_max_observation ~keeper:meta.name ~context_max;
   let scheduled_autonomous_outcome =
     if Keeper_world_observation.is_autonomous channel then
       Some (scheduled_autonomous_outcome_for_result result)
@@ -119,15 +112,12 @@ let append_metrics_snapshot ~(config : Workspace.config) ~(meta : keeper_meta)
                (usage_trust_reasons usage_trust)) );
         ("latency_ms", `Int latency_ms);
         ("cost_usd", cost_json);
-        ("context_ratio", `Float context_ratio);
-        ("context_tokens", `Int context_tokens);
         ("context_max", `Int context_max);
         ("message_count", `Int message_count);
         ("continuity_state", `Null);
         ("compacted", `Bool compaction.applied);
-        ("compaction_before_tokens", `Int compaction.before_tokens);
-        ("compaction_after_tokens", `Int compaction.after_tokens);
-        ("compaction_saved_tokens", `Int compaction.saved_tokens);
+        ("compaction_before_messages", `Int compaction.before_messages);
+        ("compaction_after_messages", `Int compaction.after_messages);
         ("compaction_trigger",
           match compaction.trigger with
           | Some trigger -> `String (Compaction_trigger.to_label trigger)
@@ -193,27 +183,4 @@ let append_metrics_snapshot ~(config : Workspace.config) ~(meta : keeper_meta)
          | None -> `Null);
       ]
   in
-  Dated_jsonl.append metrics_store snapshot;
-  (* #9943: a compaction trigger that produced no token reduction
-     is invisible in [masc_keeper_compactions_total] (which counts
-     trigger fires).  Emit a dedicated counter here so dashboards
-     can alert on the noop rate — production audit (2026-04-24)
-     showed 956/972 = 98.4% of compaction snapshots were silent
-     noops.  Emit only when a trigger fired and before/after match
-     at a non-zero token count; the [trigger] label uses the
-     human-readable reason already present in the snapshot. *)
-  (match compaction.trigger with
-   | Some trigger
-     when compaction.before_tokens > 0
-       && compaction.before_tokens = compaction.after_tokens ->
-       (* Closed label set (5 values) keeps the metric cardinality bound; the
-          full numerical detail is preserved in the snapshot's
-          [compaction_trigger_detail] JSON above. *)
-       Otel_metric_store.inc_counter
-         Keeper_metrics.(to_string CompactionNoop)
-         ~labels:
-           [ ("keeper", meta.name)
-           ; ("trigger", Compaction_trigger.to_label trigger)
-           ]
-         ()
-   | _ -> ())
+  Dated_jsonl.append metrics_store snapshot

--- a/lib/keeper/keeper_unified_metrics_snapshot.mli
+++ b/lib/keeper/keeper_unified_metrics_snapshot.mli
@@ -10,8 +10,6 @@ val append_metrics_snapshot :
   turn_generation:int ->
   channel:Keeper_world_observation.keeper_cycle_channel ->
   snapshot_source:string ->
-  context_ratio:float ->
-  context_tokens:int ->
   context_max:int ->
   message_count:int ->
   compaction:Keeper_context_runtime.compaction_event ->

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -809,7 +809,11 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
         Buffer.add_char ubuf '\n';
         Some (Buffer.contents ubuf))
       else None
-    (* 4. Autonomous trigger — lower churn than reactive inboxes. *)
+    (* 4. Context health — stable resource framing. *)
+    | Keeper_context_layers.Context_health ->
+      Some
+        (Printf.sprintf "### Context\n- Idle: %ds\n" observation.idle_seconds)
+    (* 5. Autonomous trigger — lower churn than reactive inboxes. *)
     | Keeper_context_layers.Autonomous_trigger ->
       if autonomous_trigger <> [] then
         Some
@@ -817,7 +821,7 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
           ^ String.concat "\n" autonomous_trigger
           ^ "\n")
       else None
-    (* 5. Scheduled automation — durable MASC schedule store, not OAS/provider
+    (* 6. Scheduled automation — durable MASC schedule store, not OAS/provider
        state. Shows only identifiers and execution state so payload content does
        not become trusted instruction text. *)
     | Keeper_context_layers.Scheduled_automation ->
@@ -835,7 +839,7 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
           ^ "\n\n")
       else None
     | Keeper_context_layers.Scope_messages -> None
-    (* 9. Claimable work — advisory operational guidance. Body lives at
+    (* 10. Claimable work — advisory operational guidance. Body lives at
        config/prompts/keeper.immediate_task_move.md. The OCaml side only owns
        the section header and the trailing blank line; the bullet prose stays in
        the markdown file alongside the other keeper prompts. *)
@@ -848,7 +852,7 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
               Keeper_prompt_names.immediate_task_move
           ^ "\n")
       else None
-    (* 10. Board activity — reactive trigger. All authors and post kinds share
+    (* 11. Board activity — reactive trigger. All authors and post kinds share
        one neutral observation renderer. Exact mention remains routing context;
        it never promotes Board content to instruction authority. *)
     | Keeper_context_layers.Board_activity ->

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -809,13 +809,7 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
         Buffer.add_char ubuf '\n';
         Some (Buffer.contents ubuf))
       else None
-    (* 4. Context health — stable resource framing. *)
-    | Keeper_context_layers.Context_health ->
-      Some
-        (Printf.sprintf "### Context\n- Utilization: %.0f%%\n- Idle: %ds\n"
-           (Lazy.force observation.context_ratio *. 100.0)
-           observation.idle_seconds)
-    (* 5. Autonomous trigger — lower churn than reactive inboxes. *)
+    (* 4. Autonomous trigger — lower churn than reactive inboxes. *)
     | Keeper_context_layers.Autonomous_trigger ->
       if autonomous_trigger <> [] then
         Some
@@ -823,7 +817,7 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
           ^ String.concat "\n" autonomous_trigger
           ^ "\n")
       else None
-    (* 6. Scheduled automation — durable MASC schedule store, not OAS/provider
+    (* 5. Scheduled automation — durable MASC schedule store, not OAS/provider
        state. Shows only identifiers and execution state so payload content does
        not become trusted instruction text. *)
     | Keeper_context_layers.Scheduled_automation ->
@@ -841,7 +835,7 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
           ^ "\n\n")
       else None
     | Keeper_context_layers.Scope_messages -> None
-    (* 10. Claimable work — advisory operational guidance. Body lives at
+    (* 9. Claimable work — advisory operational guidance. Body lives at
        config/prompts/keeper.immediate_task_move.md. The OCaml side only owns
        the section header and the trailing blank line; the bullet prose stays in
        the markdown file alongside the other keeper prompts. *)
@@ -854,7 +848,7 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
               Keeper_prompt_names.immediate_task_move
           ^ "\n")
       else None
-    (* 11. Board activity — reactive trigger. All authors and post kinds share
+    (* 10. Board activity — reactive trigger. All authors and post kinds share
        one neutral observation renderer. Exact mention remains routing context;
        it never promotes Board content to instruction authority. *)
     | Keeper_context_layers.Board_activity ->

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -135,8 +135,6 @@ let append_metrics_snapshot
       ~turn_generation:lifecycle.KEC.turn_generation
       ~channel
       ~snapshot_source:"keeper_unified_turn"
-      ~context_ratio:lifecycle.context_ratio
-      ~context_tokens:lifecycle.context_tokens
       ~context_max:lifecycle.context_max
       ~message_count:lifecycle.message_count
       ~compaction:lifecycle.compaction
@@ -218,7 +216,6 @@ let emit_activity_graph
                         (fun reason -> `String reason)
                         (KUM.usage_trust_reasons usage_trust)) )
                ; "turn_mode", `String turn_mode_label
-               ; "context_ratio", `Float lifecycle.KEC.context_ratio
                ]
                @ (match wall_tokens_per_second with
                   | Some v -> [ "tokens_per_second", `Float v ]

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -77,7 +77,6 @@ type world_observation =
   ; pending_board_events : pending_board_event list
   ; idle_seconds : int
   ; active_goals : string list
-  ; context_ratio : float Lazy.t
   ; unclaimed_task_count : int
   ; claimable_task_count : int
   ; failed_task_count : int
@@ -162,7 +161,6 @@ let collect_message_scope = Message_scope.collect_message_scope
 let read_backlog_counts = Inputs.read_backlog_counts
 let count_running_keeper_fibers = Inputs.count_running_keeper_fibers
 let compute_idle_seconds = Inputs.compute_idle_seconds
-let read_context_ratio = Inputs.read_context_ratio
 let board_signal_match = Board_signal.match_signal
 let check_self_comment_status = Board_signal.check_self_comment_status
 let board_signal_wake_reason = Board_signal.wake_reason
@@ -993,13 +991,6 @@ let observe
       ~config
       ~now:(Time_compat.now ())
   in
-  (* Defer the checkpoint load (file read + Yojson parse + sanitize + O(n)
-     tool-pair repair) out of [observe]. Most cycles are no-op skips where
-     the gate decides not to run; on those, [context_ratio] is never forced
-     so the checkpoint is not loaded. The post-gate Run-path consumers
-     (build_prompt, append_decision_record) force it exactly once per run
-     cycle. Verified the gate never reads it. *)
-  let context_ratio = Lazy.from_fun (fun () -> read_context_ratio ~config ~meta) in
   let pending_board_events =
     match pending_board_events with
     | Some events -> events
@@ -1013,7 +1004,6 @@ let observe
   ; pending_board_events
   ; idle_seconds
   ; active_goals = meta.active_goal_ids
-  ; context_ratio
   ; unclaimed_task_count
   ; claimable_task_count
   ; failed_task_count
@@ -1047,7 +1037,6 @@ let observe_direct_keeper_msg ~(config : Workspace.config) ~(meta : keeper_meta)
   ; pending_board_events = []
   ; idle_seconds = compute_idle_seconds ~meta
   ; active_goals = meta.active_goal_ids
-  ; context_ratio = Lazy.from_fun (fun () -> read_context_ratio ~config ~meta)
   ; unclaimed_task_count
   ; claimable_task_count
   ; failed_task_count

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -87,9 +87,6 @@ type world_observation = {
   active_goals : string list;
   (** Goal IDs currently assigned to this keeper. *)
 
-  context_ratio : float Lazy.t;
-  (** Current context window utilization [0.0, 1.0]. *)
-
   unclaimed_task_count : int;
   (** Number of unclaimed tasks in the workspace backlog. *)
 

--- a/lib/keeper/keeper_world_observation_inputs.ml
+++ b/lib/keeper/keeper_world_observation_inputs.ml
@@ -197,27 +197,3 @@ let compute_idle_seconds ~(meta : keeper_meta) : int =
   let activity_ts = List.fold_left max created_ts [ meta.runtime.proactive_rt.last_ts ] in
   if activity_ts <= 0.0 then 0 else int_of_float (max 0.0 (now_ts -. activity_ts))
 ;;
-
-(** Read context ratio from checkpoint if available. *)
-let read_context_ratio ~(config : Workspace.config) ~(meta : keeper_meta) : float =
-  try
-    let primary_max_context =
-      let resolution =
-        Keeper_context_runtime.resolve_max_context_resolution_of_meta meta
-      in
-      resolution.effective_budget
-    in
-    let base_dir = session_base_dir config in
-    let _session, ctx_opt =
-      load_context_from_checkpoint
-        ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
-        ~primary_model_max_tokens:primary_max_context
-        ~base_dir
-    in
-    match ctx_opt with
-    | Some c -> Keeper_context_runtime.context_ratio c
-    | None -> 0.0
-  with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | _ -> 0.0
-;;

--- a/lib/keeper/keeper_world_observation_inputs.mli
+++ b/lib/keeper/keeper_world_observation_inputs.mli
@@ -46,4 +46,3 @@ val count_running_keeper_fibers : config:Workspace.config -> int
     This intentionally does not read the legacy [.masc/agents/] registry; that
     registry may be empty while keeper fibers are healthy and running. *)
 val compute_idle_seconds : meta:keeper_meta -> int
-val read_context_ratio : config:Workspace.config -> meta:keeper_meta -> float

--- a/lib/keeper_registry/keeper_state_machine.mli
+++ b/lib/keeper_registry/keeper_state_machine.mli
@@ -147,7 +147,7 @@ type event =
   | Compaction_started
     (** Emit only through the registry lifecycle origin guard. See the
         paired lifecycle contract above. *)
-  | Compaction_completed of { before_tokens : int; after_tokens : int }
+  | Compaction_completed of { before_messages : int; after_messages : int }
     (** Must fire in the same turn as the matching [Compaction_started]. *)
   | Compaction_failed of { reason : string }
     (** Must fire in the same turn as the matching [Compaction_started]. *)

--- a/lib/keeper_registry/keeper_state_machine_json.ml
+++ b/lib/keeper_registry/keeper_state_machine_json.ml
@@ -55,10 +55,7 @@ let event_to_json (ev : event) : Yojson.Safe.t =
             ] )
       ]
   | Compaction_started -> obj "compaction_started" []
-  | Compaction_completed r ->
-    obj
-      "compaction_completed"
-      [ "before_tokens", `Int r.before_tokens; "after_tokens", `Int r.after_tokens ]
+  | Compaction_completed _ -> obj "compaction_completed" []
   | Compaction_failed r -> obj "compaction_failed" [ "reason", `String r.reason ]
   | Handoff_started -> obj "handoff_started" []
   | Handoff_completed r ->

--- a/lib/keeper_registry/keeper_state_machine_types.ml
+++ b/lib/keeper_registry/keeper_state_machine_types.ml
@@ -81,8 +81,8 @@ type event =
       }
   | Compaction_started
   | Compaction_completed of
-      { before_tokens : int
-      ; after_tokens : int
+      { before_messages : int
+      ; after_messages : int
       }
   | Compaction_failed of { reason : string }
   | Handoff_started
@@ -121,7 +121,7 @@ let event_to_string = function
   | Context_measured r -> Printf.sprintf "context_measured(ratio=%.3f)" r.context_ratio
   | Compaction_started -> "compaction_started"
   | Compaction_completed r ->
-    Printf.sprintf "compaction_completed(%d->%d)" r.before_tokens r.after_tokens
+    Printf.sprintf "compaction_completed(%dmsg->%dmsg)" r.before_messages r.after_messages
   | Compaction_failed r -> Printf.sprintf "compaction_failed(%s)" r.reason
   | Handoff_started -> "handoff_started"
   | Handoff_completed r -> Printf.sprintf "handoff_completed(gen=%d)" r.generation

--- a/lib/keeper_registry/keeper_state_machine_types.mli
+++ b/lib/keeper_registry/keeper_state_machine_types.mli
@@ -47,7 +47,7 @@ type event =
       token_count : int; context_actions : context_actions;
     }
   | Compaction_started
-  | Compaction_completed of { before_tokens : int; after_tokens : int; }
+  | Compaction_completed of { before_messages : int; after_messages : int; }
   | Compaction_failed of { reason : string; }
   | Handoff_started
   | Handoff_completed of { new_trace_id : string; generation : int; }

--- a/test/dune
+++ b/test/dune
@@ -164,7 +164,6 @@
   test_boundary_redaction_runtime_lane
   test_keeper_memory_summary_label_redaction
   test_keeper_tool_use_failure_counter
-  test_keeper_compaction_outcome_counter
   test_keeper_usage_trust_counter
   test_llm_metric_bridge
   test_otel_dispatch_hook
@@ -487,7 +486,6 @@
   test_boundary_redaction_runtime_lane
   test_keeper_memory_summary_label_redaction
   test_keeper_tool_use_failure_counter
-  test_keeper_compaction_outcome_counter
   test_keeper_usage_trust_counter
   test_llm_metric_bridge
   test_otel_dispatch_hook

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -247,7 +247,6 @@ let base_observation : WO.world_observation =
   ; pending_board_events = []
   ; idle_seconds = 0
   ; active_goals = []
-  ; context_ratio = lazy 0.0
   ; unclaimed_task_count = 0
   ; claimable_task_count = 0
   ; failed_task_count = 0

--- a/test/test_keeper_connector_attention_wake.ml
+++ b/test/test_keeper_connector_attention_wake.ml
@@ -123,7 +123,6 @@ let quiet_obs : WO.world_observation =
   ; pending_board_events = []
   ; idle_seconds = 0
   ; active_goals = []
-  ; context_ratio = lazy 0.0
   ; unclaimed_task_count = 0
   ; claimable_task_count = 0
   ; failed_task_count = 0

--- a/test/test_keeper_context_layers.ml
+++ b/test/test_keeper_context_layers.ml
@@ -15,7 +15,6 @@ let all_layers =
     L.Current_task;
     L.Connected_surfaces;
     L.Namespace_state;
-    L.Context_health;
     L.Autonomous_trigger;
     L.Scheduled_automation;
     L.Pending_mentions;
@@ -50,24 +49,24 @@ let test_order_index_is_injective () =
     (List.length all_layers) (List.length sorted)
 
 let test_assemble_concatenates_present_in_order () =
-  (* Render a label for three layers spread across the order (positions 0, 4, 10)
+  (* Render a label for three layers spread across the order (positions 0, 4, 9)
      and nothing for the rest; assemble must yield them in ordered order. *)
   let content_of = function
     | L.Active_goals -> Some "A"
-    | L.Context_health -> Some "C"
+    | L.Autonomous_trigger -> Some "T"
     | L.Board_activity -> Some "B"
     | _ -> None
   in
-  check string "present layers concatenated in ordered order" "ACB"
+  check string "present layers concatenated in ordered order" "ATB"
     (L.assemble ~content_of)
 
 let test_assemble_empty_when_all_absent () =
   check string "no layers -> empty body" "" (L.assemble ~content_of:(fun _ -> None))
 
 let test_assemble_all_present_follows_ordered () =
-  (* Each layer renders its own order index; the result must read 0..10. *)
+  (* Each layer renders its own order index; the result must read 0..9. *)
   let content_of id = Some (string_of_int (L.order_index id)) in
-  check string "every layer present -> indices in order" "012345678910"
+  check string "every layer present -> indices in order" "0123456789"
     (L.assemble ~content_of)
 
 let () =

--- a/test/test_keeper_context_layers.ml
+++ b/test/test_keeper_context_layers.ml
@@ -15,6 +15,7 @@ let all_layers =
     L.Current_task;
     L.Connected_surfaces;
     L.Namespace_state;
+    L.Context_health;
     L.Autonomous_trigger;
     L.Scheduled_automation;
     L.Pending_mentions;
@@ -49,24 +50,24 @@ let test_order_index_is_injective () =
     (List.length all_layers) (List.length sorted)
 
 let test_assemble_concatenates_present_in_order () =
-  (* Render a label for three layers spread across the order (positions 0, 4, 9)
+  (* Render a label for three layers spread across the order (positions 0, 4, 10)
      and nothing for the rest; assemble must yield them in ordered order. *)
   let content_of = function
     | L.Active_goals -> Some "A"
-    | L.Autonomous_trigger -> Some "T"
+    | L.Context_health -> Some "C"
     | L.Board_activity -> Some "B"
     | _ -> None
   in
-  check string "present layers concatenated in ordered order" "ATB"
+  check string "present layers concatenated in ordered order" "ACB"
     (L.assemble ~content_of)
 
 let test_assemble_empty_when_all_absent () =
   check string "no layers -> empty body" "" (L.assemble ~content_of:(fun _ -> None))
 
 let test_assemble_all_present_follows_ordered () =
-  (* Each layer renders its own order index; the result must read 0..9. *)
+  (* Each layer renders its own order index; the result must read 0..10. *)
   let content_of id = Some (string_of_int (L.order_index id)) in
-  check string "every layer present -> indices in order" "0123456789"
+  check string "every layer present -> indices in order" "012345678910"
     (L.assemble ~content_of)
 
 let () =

--- a/test/test_keeper_lifecycle_chaos.ml
+++ b/test/test_keeper_lifecycle_chaos.ml
@@ -134,7 +134,7 @@ let test_compaction_crash_recovery () =
   let tr = dispatch "compact" KSM.Compaction_started in
   check phase_t "2nd compaction" KSM.Compacting tr.new_phase;
   let tr = dispatch "compact"
-    (KSM.Compaction_completed { before_tokens = 100000; after_tokens = 30000 }) in
+    (KSM.Compaction_completed { before_messages = 100; after_messages = 30 }) in
   check phase_t "2nd compact → running" KSM.Running tr.new_phase;
 
   let tr = dispatch "compact"
@@ -185,7 +185,7 @@ let test_full_chaos_sequence () =
   let tr = dispatch "chaos" KSM.Compaction_started in
   check phase_t "compacting" KSM.Compacting tr.new_phase;
   let tr = dispatch "chaos"
-    (KSM.Compaction_completed { before_tokens = 100000; after_tokens = 30000 }) in
+    (KSM.Compaction_completed { before_messages = 100; after_messages = 30 }) in
   check phase_t "post-compact → running" KSM.Running tr.new_phase;
 
   let tr = dispatch "chaos" KSM.Handoff_started in

--- a/test/test_keeper_lifecycle_global_gate.ml
+++ b/test/test_keeper_lifecycle_global_gate.ml
@@ -100,7 +100,6 @@ let base_obs : WO.world_observation =
   ; pending_board_events = []
   ; idle_seconds = 0
   ; active_goals = []
-  ; context_ratio = lazy 0.0
   ; unclaimed_task_count = 0
   ; claimable_task_count = 0
   ; failed_task_count = 0

--- a/test/test_keeper_overflow_recovery.ml
+++ b/test/test_keeper_overflow_recovery.ml
@@ -60,7 +60,7 @@ let test_happy_path () =
   (* Compaction completes → Running (context_overflow cleared) *)
   let tr3 =
     apply_ok SM.Compacting tr2.updated_conditions
-      (SM.Compaction_completed { before_tokens = 205_000; after_tokens = 80_000 })
+      (SM.Compaction_completed { before_messages = 205; after_messages = 80 })
   in
   check_phase SM.Running tr3.new_phase "compaction done → Running";
   check bool "context_overflow cleared" false
@@ -114,7 +114,7 @@ let test_two_consecutive_overflows () =
   in
   let tr3 =
     apply_ok SM.Compacting tr2.updated_conditions
-      (SM.Compaction_completed { before_tokens = 210_000; after_tokens = 90_000 })
+      (SM.Compaction_completed { before_messages = 210; after_messages = 90 })
   in
   check_phase SM.Running tr3.new_phase "cycle 1 back to Running";
   (* Second overflow should be handled cleanly after the successful cycle. *)
@@ -127,11 +127,11 @@ let test_two_consecutive_overflows () =
 
 let test_completion_counts_are_observations () =
   List.iter
-    (fun (before_tokens, after_tokens) ->
+    (fun (before_messages, after_messages) ->
       let tr1 = apply_ok SM.Running running_conds (overflow_event ()) in
       let tr2 = apply_ok SM.Overflowed tr1.updated_conditions SM.Compaction_started in
       let tr3 = apply_ok SM.Compacting tr2.updated_conditions
-          (SM.Compaction_completed { before_tokens; after_tokens }) in
+          (SM.Compaction_completed { before_messages; after_messages }) in
       check bool "completed compaction clears overflow" false
         tr3.updated_conditions.context_overflow;
       check_phase SM.Running tr3.new_phase "completed compaction resumes")
@@ -163,7 +163,7 @@ let test_heartbeat_failure_preserved_through_overflow () =
   check_phase SM.Compacting tr3.new_phase "compact starts";
   let tr4 =
     apply_ok SM.Compacting tr3.updated_conditions
-      (SM.Compaction_completed { before_tokens = 205_000; after_tokens = 70_000 })
+      (SM.Compaction_completed { before_messages = 205; after_messages = 70 })
   in
   (* context_overflow cleared, heartbeat_healthy=false remains → Failing *)
   check_phase SM.Failing tr4.new_phase

--- a/test/test_keeper_prompt_external.ml
+++ b/test/test_keeper_prompt_external.ml
@@ -140,7 +140,6 @@ let task_create_observation : WO.world_observation =
     pending_board_events = [];
     idle_seconds = 1;
     active_goals = [ "goal-test-task-create" ];
-    context_ratio = lazy 0.0;
     unclaimed_task_count = 0;
     claimable_task_count = 0;
     failed_task_count = 0;

--- a/test/test_keeper_raw_task_signal_wake.ml
+++ b/test/test_keeper_raw_task_signal_wake.ml
@@ -8,7 +8,6 @@ let base_observation : WO.world_observation =
   ; pending_board_events = []
   ; idle_seconds = 0
   ; active_goals = []
-  ; context_ratio = lazy 0.0
   ; unclaimed_task_count = 0
   ; claimable_task_count = 0
   ; failed_task_count = 0

--- a/test/test_keeper_state_machine.ml
+++ b/test/test_keeper_state_machine.ml
@@ -217,7 +217,7 @@ let test_apply_compaction_completed () =
     apply_ok
       ~current_phase:SM.Compacting
       ~conditions:compacting_conds
-      ~event:(SM.Compaction_completed { before_tokens = 100000; after_tokens = 50000 })
+      ~event:(SM.Compaction_completed { before_messages = 100; after_messages = 50 })
   in
   check phase_t "Compacting -> Running" SM.Running tr.new_phase;
   check bool "compaction done" false tr.updated_conditions.compaction_active
@@ -231,7 +231,7 @@ let test_apply_compaction_completed_returns_to_failing_health_lane () =
     apply_ok
       ~current_phase:SM.Compacting
       ~conditions:compacting_conds
-      ~event:(SM.Compaction_completed { before_tokens = 100000; after_tokens = 50000 })
+      ~event:(SM.Compaction_completed { before_messages = 100; after_messages = 50 })
   in
   check phase_t "Compacting -> Failing" SM.Failing tr.new_phase;
   check bool "compaction done" false tr.updated_conditions.compaction_active
@@ -971,7 +971,7 @@ let test_chain_happy_path () =
       ; SM.Heartbeat_ok, SM.Running
       ; SM.Heartbeat_ok, SM.Running
       ; SM.Compaction_started, SM.Compacting
-      ; ( SM.Compaction_completed { before_tokens = 90000; after_tokens = 40000 }
+      ; ( SM.Compaction_completed { before_messages = 90; after_messages = 40 }
         , SM.Running )
       ; SM.Handoff_started, SM.HandingOff
       ; SM.Handoff_completed { new_trace_id = "gen2"; generation = 2 }, SM.Running
@@ -1010,7 +1010,7 @@ let test_chain_operator_intervention () =
       ~init_conditions:running_conditions
       [ SM.Heartbeat_ok, SM.Running
       ; SM.Compaction_started, SM.Compacting
-      ; ( SM.Compaction_completed { before_tokens = 80000; after_tokens = 35000 }
+      ; ( SM.Compaction_completed { before_messages = 80; after_messages = 35 }
         , SM.Running )
       ; SM.Operator_pause, SM.Paused
       ; SM.Operator_resume, SM.Running
@@ -1052,12 +1052,12 @@ let test_chain_long_running_multi_cycle () =
       [ (* Cycle 1: compaction *)
         SM.Heartbeat_ok, SM.Running
       ; SM.Compaction_started, SM.Compacting
-      ; ( SM.Compaction_completed { before_tokens = 90000; after_tokens = 45000 }
+      ; ( SM.Compaction_completed { before_messages = 90; after_messages = 45 }
         , SM.Running )
       ; SM.Heartbeat_ok, SM.Running
       ; (* Cycle 2: compaction again *)
         SM.Compaction_started, SM.Compacting
-      ; ( SM.Compaction_completed { before_tokens = 85000; after_tokens = 40000 }
+      ; ( SM.Compaction_completed { before_messages = 85; after_messages = 40 }
         , SM.Running )
       ; (* Cycle 3: handoff (context still growing) *)
         SM.Handoff_started, SM.HandingOff
@@ -1065,7 +1065,7 @@ let test_chain_long_running_multi_cycle () =
       ; SM.Heartbeat_ok, SM.Running
       ; (* Cycle 4: compaction in new generation *)
         SM.Compaction_started, SM.Compacting
-      ; ( SM.Compaction_completed { before_tokens = 70000; after_tokens = 30000 }
+      ; ( SM.Compaction_completed { before_messages = 70; after_messages = 30 }
         , SM.Running )
       ; (* Cycle 5: another handoff *)
         SM.Handoff_started, SM.HandingOff
@@ -1296,7 +1296,7 @@ let test_chain_no_phoenix () =
         ; context_actions = { compact = false; handoff = false }
         }
     ; SM.Compaction_started
-    ; SM.Compaction_completed { before_tokens = 100; after_tokens = 50 }
+    ; SM.Compaction_completed { before_messages = 100; after_messages = 50 }
     ; SM.Compaction_failed { reason = "test" }
     ; SM.Handoff_started
     ; SM.Handoff_completed { new_trace_id = "x"; generation = 99 }
@@ -1359,7 +1359,7 @@ let test_chain_triple_restart_survives () =
       ; (* Finally stabilizes *)
         SM.Heartbeat_ok, SM.Running
       ; SM.Compaction_started, SM.Compacting
-      ; ( SM.Compaction_completed { before_tokens = 60000; after_tokens = 25000 }
+      ; ( SM.Compaction_completed { before_messages = 60; after_messages = 25 }
         , SM.Running )
       ; SM.Heartbeat_ok, SM.Running
       ]
@@ -1397,7 +1397,7 @@ let test_chain_maximum_turbulence () =
       ~init_conditions:running_conditions
       [ (* Compaction cycle *)
         SM.Compaction_started, SM.Compacting
-      ; ( SM.Compaction_completed { before_tokens = 90000; after_tokens = 40000 }
+      ; ( SM.Compaction_completed { before_messages = 90; after_messages = 40 }
         , SM.Running )
       ; (* Handoff cycle *)
         SM.Handoff_started, SM.HandingOff
@@ -1717,7 +1717,7 @@ let test_invariant_stop_requested_monotonic () =
     ; SM.Turn_succeeded
     ; SM.Turn_failed { consecutive = 1 }
     ; SM.Compaction_started
-    ; SM.Compaction_completed { before_tokens = 100; after_tokens = 50 }
+    ; SM.Compaction_completed { before_messages = 100; after_messages = 50 }
     ; SM.Handoff_started
     ; SM.Handoff_completed { new_trace_id = "x"; generation = 1 }
     ; SM.Operator_pause
@@ -1787,7 +1787,7 @@ let test_invariant_derive_matches_matrix () =
     ; SM.Turn_succeeded
     ; SM.Turn_failed { consecutive = 3 }
     ; SM.Compaction_started
-    ; SM.Compaction_completed { before_tokens = 100; after_tokens = 50 }
+    ; SM.Compaction_completed { before_messages = 100; after_messages = 50 }
     ; SM.Compaction_failed { reason = "test" }
     ; SM.Handoff_started
     ; SM.Handoff_completed { new_trace_id = "x"; generation = 1 }
@@ -2009,7 +2009,7 @@ let test_setclear_coverage () =
           } )
     ; "Compaction_started", SM.Compaction_started
     ; ( "Compaction_completed"
-      , SM.Compaction_completed { before_tokens = 100; after_tokens = 50 } )
+      , SM.Compaction_completed { before_messages = 100; after_messages = 50 } )
     ; "Compaction_failed", SM.Compaction_failed { reason = "test" }
     ; "Handoff_started", SM.Handoff_started
     ; "Handoff_completed", SM.Handoff_completed { new_trace_id = "x"; generation = 99 }

--- a/test/test_keeper_state_machine_correspondence.ml
+++ b/test/test_keeper_state_machine_correspondence.ml
@@ -262,9 +262,9 @@ let canonical_events : (string * SM.event) list =
         } );
     ("CompactionStarted", SM.Compaction_started);
     ( "CompactionCompletedWithSavings",
-      SM.Compaction_completed { before_tokens = 100_000; after_tokens = 50_000 } );
+      SM.Compaction_completed { before_messages = 100; after_messages = 50 } );
     ( "CompactionCompletedNoSavings",
-      SM.Compaction_completed { before_tokens = 50_000; after_tokens = 50_000 } );
+      SM.Compaction_completed { before_messages = 50; after_messages = 50 } );
     ("CompactionFailed", SM.Compaction_failed { reason = "test" });
     ("HandoffStarted", SM.Handoff_started);
     ( "HandoffCompleted",

--- a/test/test_keeper_state_machine_pbt.ml
+++ b/test/test_keeper_state_machine_pbt.ml
@@ -34,7 +34,7 @@ let gen_event_chaos : SM.event QCheck.Gen.t =
     return SM.Compaction_started;
     (let* before = int_range 1000 100000 in
      let* after = int_range 100 (max 101 before) in
-     return (SM.Compaction_completed { before_tokens = before; after_tokens = after }));
+     return (SM.Compaction_completed { before_messages = before; after_messages = after }));
     return (SM.Compaction_failed { reason = "pbt_test" });
     return SM.Handoff_started;
     (let* gen = int_range 1 100 in
@@ -87,7 +87,7 @@ let valid_events_for_phase (phase : SM.phase) (c : SM.conditions) : SM.event lis
         SM.Fiber_terminated { outcome = "crash"; provider_id = None; http_status = None };
       ]
     | SM.Compacting ->
-      [ SM.Compaction_completed { before_tokens = 100; after_tokens = 50 };
+      [ SM.Compaction_completed { before_messages = 100; after_messages = 50 };
         SM.Compaction_failed { reason = "test" };
         SM.Heartbeat_failed { consecutive = 1 };
         SM.Fiber_terminated { outcome = "crash"; provider_id = None; http_status = None };

--- a/test/test_keeper_surface_presence_prompt.ml
+++ b/test/test_keeper_surface_presence_prompt.ml
@@ -54,7 +54,6 @@ let base_observation : WO.world_observation =
     pending_board_events = [];
     idle_seconds = 0;
     active_goals = [];
-    context_ratio = lazy 0.0;
     unclaimed_task_count = 0;
     claimable_task_count = 0;
     failed_task_count = 0;

--- a/test/test_keeper_unified_persona_block.ml
+++ b/test/test_keeper_unified_persona_block.ml
@@ -37,7 +37,6 @@ let base_observation : WO.world_observation =
     pending_board_events = [];
     idle_seconds = 0;
     active_goals = [];
-    context_ratio = lazy 0.0;
     unclaimed_task_count = 0;
     claimable_task_count = 0;
     failed_task_count = 0;

--- a/test/test_keeper_unified_verification_surface.ml
+++ b/test/test_keeper_unified_verification_surface.ml
@@ -9,7 +9,6 @@ let base_observation : WO.world_observation =
     pending_board_events = [];
     idle_seconds = 0;
     active_goals = [];
-    context_ratio = lazy 0.0;
     unclaimed_task_count = 0;
     claimable_task_count = 0;
     failed_task_count = 0;

--- a/test/test_keeper_wake_turn_context.ml
+++ b/test/test_keeper_wake_turn_context.ml
@@ -61,7 +61,6 @@ let base_observation : WO.world_observation =
     pending_board_events = [];
     idle_seconds = 0;
     active_goals = [];
-    context_ratio = lazy 0.0;
     unclaimed_task_count = 0;
     claimable_task_count = 0;
     failed_task_count = 0;


### PR DESCRIPTION
## Summary
- remove the retired token-count and context-ratio facade from keeper context runtime
- keep exact provider/catalog context limits and message counts as observation only
- keep compaction owned by the typed MASC LLM summarizer
- continue overflow recovery on the typed `Prepared` result, never on a shrink/count heuristic

## Boundary
OAS no longer owns context reduction. This slice introduces no compatibility module, thresholds, ratios, or implicit stop/pause condition.

## Size
- 32 files
- 94 insertions / 305 deletions
- exactly 399 changed lines

## Validation
- `git diff --check`
- no compiled `Agent_sdk.Context_reducer` references under `lib/**/*.ml{,i}`
- focused build: keeper context core, post-turn, context runtime, and dashboard keeper targets

## Stack
- depends on #24493
- remains Draft until the complete OAS 0.212 repair stack is green.