### PR TITLE
refactor(runtime): align typed OAS bootstrap boundaries

### DIFF
--- a/lib/dashboard/dashboard_briefing_assembly.ml
+++ b/lib/dashboard/dashboard_briefing_assembly.ml
@@ -210,7 +210,9 @@ let build_keeper_briefs (config : Workspace.config) (keepers : Yojson.Safe.t lis
                         Json_util.string_opt_to_json
                           (Dashboard_utils.string_list_of_json
                              (member_assoc "active_goal_ids" keeper)
-                           |> List.hd_opt) );
+                           |> function
+                           | current :: _ -> Some current
+                           | [] -> None) );
                       ("last_autonomous_action_at", member_assoc "last_autonomous_action_at" keeper);
                       ("proactive_enabled", member_assoc "proactive_enabled" keeper);
                       ("paused", member_assoc "paused" keeper);

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -171,6 +171,8 @@ let resolve_provider_config_of_label =
 let invalid_runtime_config =
   Runtime_transport.invalid_runtime_config
 
+let invalid_exit detail = Error (invalid_runtime_config "exit_condition" detail)
+
 let provider_caps_of_config =
   Runtime_transport.provider_caps_of_config
 
@@ -1103,13 +1105,54 @@ let run_blocks
           "masc.runtime_id", `String config.name;
         ]
         (fun _trace_id ->
-          match on_event with
-          | Some cb ->
-              Agent_sdk.Agent.run_stream_blocks ~sw ?clock ?on_yield ?on_resume
-                ~on_event:cb agent goal_blocks
-          | None ->
-              Agent_sdk.Agent.run_blocks ~sw ?clock ?on_yield ?on_resume agent
-                goal_blocks)
+          let api_strategy =
+            match on_event with
+            | None -> Agent_sdk.Agent.Sync
+            | Some on_event ->
+              let on_telemetry =
+                Option.map
+                  (fun bus ->
+                     Agent_sdk.Telemetry_bus.publish
+                       (Agent_sdk.Telemetry_bus.of_event_bus bus))
+                  (Agent_sdk.Agent.options agent).event_bus
+              in
+              Agent_sdk.Agent.Stream { on_event; on_telemetry }
+          in
+          match config.exit_condition, config.exit_condition_result with
+          | None, None | Some _, Some _ ->
+            Result.bind
+              (Agent_sdk.Agent.Advanced.run_blocks
+                 ~sw
+                 ?clock
+                 ?on_yield
+                 ?on_resume
+                 ~api_strategy
+                 ~on_tool_boundary:(fun boundary ->
+                   match config.exit_condition with
+                   | Some predicate when predicate boundary.turn ->
+                     Agent_sdk.Agent.Advanced.Yield
+                   | Some _ | None -> Agent_sdk.Agent.Advanced.Continue)
+                 agent
+                 goal_blocks)
+              (function
+              | Agent_sdk.Agent.Advanced.Completed response ->
+                Ok (response, None)
+              | Agent_sdk.Agent.Advanced.Yielded yielded ->
+                (match config.exit_condition_result with
+                 | Some render ->
+                   let stop_reason, response_text = render yielded.turn in
+                   let response_text =
+                     match response_text with
+                     | Some text when String.trim text <> "" -> text
+                     | _ -> Printf.sprintf "[exit condition met at turn %d]" yielded.turn
+                   in
+                   Ok
+                     ( partial_response_of_stop ~session_id ~text:response_text
+                     , Some (yielded, stop_reason) )
+                 | None ->
+                   invalid_exit "yielded without a typed result"))
+          | Some _, None | None, Some _ ->
+            invalid_exit "predicate and typed result must be paired")
     in
     let run_total_duration_ms = run_duration_ms_since run_started_at in
     let checkpoint =
@@ -1119,7 +1162,8 @@ let run_blocks
       in
       Some ckpt
     in
-    let lifecycle = worker_lifecycle_classification_of_result result in
+    let sdk_result = Result.map fst result in
+    let lifecycle = worker_lifecycle_classification_of_result sdk_result in
     publish_lifecycle ~name:config.name ~event:lifecycle.event
       ~detail:(Printf.sprintf "session=%s" session_id)
       ?error:lifecycle.error
@@ -1144,11 +1188,17 @@ let run_blocks
       | None -> None
     in
     (match result with
-    | Ok response ->
+    | Ok (response, yielded) ->
       close_after_success ();
+      let turns, stop_reason =
+        match yielded with
+        | None -> turns, Completed
+        | Some (yielded, stop_reason) -> yielded.turn, stop_reason
+      in
       record_dashboard_oas_response ~config
         ~total_duration_ms:run_total_duration_ms
-        ~status:Dashboard_oas_bridge.Success response;
+        ~status:(dashboard_status_of_stop_reason stop_reason)
+        response;
       let runtime_observation =
         runtime_observation_for_completed_config
           ~total_duration_ms:run_total_duration_ms config
@@ -1162,7 +1212,7 @@ let run_blocks
           trace_ref;
           run_validation;
           runtime_observation = Some runtime_observation;
-          stop_reason = Completed;
+          stop_reason;
         }
     | Error
         (Agent_sdk.Error.Agent (Agent_sdk.Error.InputRequired request)) ->
@@ -1196,43 +1246,6 @@ let run_blocks
         ; runtime_observation = Some runtime_observation
         ; stop_reason
         }
-    | Error (Agent_sdk.Error.Agent (Agent_sdk.Error.ExitConditionMet r)) -> (
-      match config.exit_condition_result with
-      | Some render ->
-        close_after_success ();
-        let stop_reason, response_text_opt = render r.turn in
-        let response_text =
-          match response_text_opt with
-          | Some text when String.trim text <> "" -> text
-          | _ -> Printf.sprintf "[exit condition met at turn %d]" r.turn
-        in
-        let partial_response =
-          partial_response_of_stop
-            ~session_id
-            ~text:response_text
-        in
-        record_dashboard_oas_response ~config
-          ~total_duration_ms:run_total_duration_ms
-          ~status:(dashboard_status_of_stop_reason stop_reason)
-          partial_response;
-        let runtime_observation =
-          runtime_observation_for_completed_config
-            ~total_duration_ms:run_total_duration_ms config
-        in
-        Ok
-          {
-            response = partial_response;
-            checkpoint;
-            session_id;
-            turns;
-            trace_ref;
-            run_validation;
-            runtime_observation = Some runtime_observation;
-            stop_reason;
-          }
-      | None ->
-        close_agent_for_cleanup ~propagate_cancel:false ~config agent;
-        Error (Agent_sdk.Error.Agent (Agent_sdk.Error.ExitConditionMet r)))
     | Error err ->
       let detail = Agent_sdk.Error.to_string err in
       let error_response =

--- a/lib/runtime/runtime_agent_context.ml
+++ b/lib/runtime/runtime_agent_context.ml
@@ -243,11 +243,6 @@ let builder
     | None -> builder
   in
   let builder =
-    match config.exit_condition with
-    | Some cond -> Agent_sdk.Builder.with_exit_condition cond builder
-    | None -> builder
-  in
-  let builder =
     match config.thinking_budget with
     | Some budget -> Agent_sdk.Builder.with_thinking_budget budget builder
     | None -> builder
@@ -330,7 +325,6 @@ let prepare_resume ~(config : config) ~(checkpoint : Agent_sdk.Checkpoint.t)
     ; thinking_budget = config.thinking_budget
     ; cache_system_prompt = config.cache_system_prompt
     ; yield_on_tool = config.yield_on_tool
-    ; exit_condition = config.exit_condition
     }
   in
   let options : Agent_sdk.Agent.options =

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -1541,9 +1541,7 @@ let runtime_request_config_json (rt : Runtime.t) =
     ; "clear_thinking", Json_util.bool_opt_to_json cfg.clear_thinking
     ; ( "resolved_reasoning_effort"
       , Json_util.string_opt_to_json
-          (Llm_provider.Provider_config.reasoning_effort_request_value
-             ~enable_thinking:cfg.enable_thinking
-             ~thinking_budget:cfg.thinking_budget) )
+          (Option.map Llm_provider.Reasoning_effort.to_string cfg.reasoning_effort) )
     ; "glm_clear_thinking", `Bool (Llm_provider.Provider_config.glm_clear_thinking cfg)
     ; "glm_replay_reasoning", `Bool (Llm_provider.Provider_config.glm_should_replay_reasoning cfg)
     ; "tool_stream", `Bool cfg.tool_stream

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -15,11 +15,6 @@ type model_catalog_env_resolution =
   ; source : model_catalog_env_source
   }
 
-and capability_manifest_env_resolution =
-  { path : string
-  ; source : capability_manifest_env_source
-  }
-
 and model_catalog_env_source =
   | Env_var of model_catalog_env_var
   | Config_root_catalog_file of string
@@ -27,10 +22,6 @@ and model_catalog_env_source =
       { origin : model_catalog_parent_origin
       ; filename : string
       }
-
-and capability_manifest_env_source =
-  | Capability_manifest_env_var
-  | Config_root_file of string
 
 and model_catalog_env_var =
   | Oas_model_catalog
@@ -54,15 +45,8 @@ let model_catalog_env_source_to_string = function
   | Parent_file { origin; filename } ->
     Printf.sprintf "%s:%s" (model_catalog_parent_origin_label origin) filename
 
-let oas_capability_manifest_env_var_name = "OAS_CAPABILITY_MANIFEST"
-
-let capability_manifest_env_source_to_string = function
-  | Capability_manifest_env_var -> oas_capability_manifest_env_var_name
-  | Config_root_file filename -> Printf.sprintf "config-root:%s" filename
-
 let models_toml_filename = "models.toml"
 let oas_models_toml_filename = "oas-models.toml"
-let capability_manifest_filename = "capability-manifest.json"
 
 let nonempty_env env name =
   match env name with
@@ -174,86 +158,11 @@ let resolve_oas_model_catalog_path
               | Some dir -> find_catalog_in_parents ~origin:Argv0_parent dir
               | None -> None))))
 
-let resolve_oas_capability_manifest_path ?(env = Sys.getenv_opt) ~config_root ()
-  : capability_manifest_env_resolution option
-  =
-  match nonempty_env env oas_capability_manifest_env_var_name with
-  | Some path ->
-    Some ({ path; source = Capability_manifest_env_var } : capability_manifest_env_resolution)
-  | None ->
-    let candidate = Filename.concat config_root capability_manifest_filename in
-    (match existing_file candidate with
-     | Some path ->
-       Some
-         ({ path; source = Config_root_file capability_manifest_filename }
-          : capability_manifest_env_resolution)
-     | None -> None)
-
-let install_runtime_model_catalog_override ~clear_catalog ~load_catalog ~set_catalog path =
-  clear_catalog ();
+let install_runtime_model_catalog_override ~load_catalog ~set_catalog path =
   match load_catalog path with
-  | Some catalog ->
-    set_catalog catalog;
-    true
-  | None -> false
-
-let install_runtime_capability_manifest_override
-      ~clear_manifest
-      ~load_manifest
-      ~set_manifest
-      path
-  =
-  clear_manifest ();
-  match load_manifest path with
-  | Some manifest ->
-    set_manifest manifest;
-    true
-  | None -> false
-
-let configure_oas_capability_manifest_env
-      ?(env = Sys.getenv_opt)
-      ~config_root
-      ?(putenv = Unix.putenv)
-      ?(clear_manifest = Llm_provider.Capability_manifest.clear_global)
-      ?(load_manifest = Llm_provider.Capability_manifest.load_runtime_file)
-      ?(set_manifest = Llm_provider.Capability_manifest.set_global)
-      ()
-      : capability_manifest_env_resolution option
-  =
-  match resolve_oas_capability_manifest_path ~env ~config_root () with
-  | Some { source = Capability_manifest_env_var; path } as resolution ->
-    let installed =
-      install_runtime_capability_manifest_override
-        ~clear_manifest
-        ~load_manifest
-        ~set_manifest
-        path
-    in
-    Log.Misc.info
-      "capability_manifest: OAS_CAPABILITY_MANIFEST=%s already configured%s"
-      path
-      (if installed then " and loaded" else "");
-    resolution
-  | Some { source; path } as resolution ->
-    putenv oas_capability_manifest_env_var_name path;
-    let installed =
-      install_runtime_capability_manifest_override
-        ~clear_manifest
-        ~load_manifest
-        ~set_manifest
-        path
-    in
-    Log.Misc.info
-      "capability_manifest: OAS_CAPABILITY_MANIFEST=%s resolved from %s%s"
-      path
-      (capability_manifest_env_source_to_string source)
-      (if installed then " and loaded" else "");
-    resolution
-  | None ->
-    Log.Misc.info
-      "capability_manifest: no config-root capability-manifest.json found; using \
-       agent_sdk ambient capability manifest state";
-    None
+  | Ok catalog -> set_catalog catalog
+  | Error detail ->
+    raise (Env_config_core.Config_error (Printf.sprintf "catalog %s: %s" path detail))
 
 let configure_oas_model_catalog_env
       ?(env = Sys.getenv_opt)
@@ -261,53 +170,34 @@ let configure_oas_model_catalog_env
       ?cwd
       ?argv0
       ?(putenv = Unix.putenv)
-      ?(preload_agent_sdk_catalog = Llm_provider.Model_catalog.preload_global)
       ?(agent_sdk_catalog = Llm_provider.Model_catalog.global)
-      ?(clear_catalog = Llm_provider.Model_catalog.clear_global)
-      ?(load_catalog = Llm_provider.Model_catalog.load_runtime_file)
+      ?(load_catalog = Llm_provider.Model_catalog.load_file)
       ?(set_catalog = Llm_provider.Model_catalog.set_global)
       ()
   =
   match resolve_oas_model_catalog_path ~env ?config_root ?cwd ?argv0 () with
   | Some { source = Env_var Oas_model_catalog; path } as resolution ->
-    let installed =
-      install_runtime_model_catalog_override
-        ~clear_catalog
-        ~load_catalog
-        ~set_catalog
-        path
-    in
+    install_runtime_model_catalog_override ~load_catalog ~set_catalog path;
     Log.Misc.info
-      "model_catalog: OAS_MODEL_CATALOG=%s already configured%s"
-      path
-      (if installed then " and loaded" else "");
+      "model_catalog: OAS_MODEL_CATALOG=%s already configured and loaded"
+      path;
     resolution
   | Some { source; path } as resolution ->
     putenv (model_catalog_env_var_name Oas_model_catalog) path;
-    let installed =
-      install_runtime_model_catalog_override
-        ~clear_catalog
-        ~load_catalog
-        ~set_catalog
-        path
-    in
+    install_runtime_model_catalog_override ~load_catalog ~set_catalog path;
     Log.Misc.info
-      "model_catalog: OAS_MODEL_CATALOG=%s resolved from %s%s"
+      "model_catalog: OAS_MODEL_CATALOG=%s resolved from %s and loaded"
       path
-      (model_catalog_env_source_to_string source)
-      (if installed then " and loaded" else "");
+      (model_catalog_env_source_to_string source);
     resolution
   | None ->
-    preload_agent_sdk_catalog ();
     (match agent_sdk_catalog () with
      | Some _ ->
        Log.Misc.info
          "model_catalog: no explicit catalog path resolved; using agent_sdk ambient \
           model catalog"
      | None ->
-       Log.Misc.warn
-         "model_catalog: no explicit or agent_sdk ambient model catalog resolved; \
-          capability lookups may fall back to provider_default");
+       raise (Env_config_core.Config_error "model_catalog: OAS embedded model catalog is unavailable"));
     None
 
 (* GC tuning for long-running server with bursty allocation.
@@ -455,9 +345,6 @@ let create_server_state ~sw ~base_path ?input_base_path ~clock ~mono_clock ~net
   let config_root = (startup_config_resolution ~base_path).config_root.path in
   let (_ : model_catalog_env_resolution option) =
     configure_oas_model_catalog_env ~config_root ()
-  in
-  let (_ : capability_manifest_env_resolution option) =
-    configure_oas_capability_manifest_env ~config_root ()
   in
   (* Apply keeper runtime overrides from the resolved config root's
      runtime.toml. Must run before any module that reads

--- a/lib/server/server_runtime_bootstrap.mli
+++ b/lib/server/server_runtime_bootstrap.mli
@@ -15,11 +15,6 @@ type model_catalog_env_resolution =
   ; source : model_catalog_env_source
   }
 
-and capability_manifest_env_resolution =
-  { path : string
-  ; source : capability_manifest_env_source
-  }
-
 and model_catalog_env_source =
   | Env_var of model_catalog_env_var
   | Config_root_catalog_file of string
@@ -27,10 +22,6 @@ and model_catalog_env_source =
       { origin : model_catalog_parent_origin
       ; filename : string
       }
-
-and capability_manifest_env_source =
-  | Capability_manifest_env_var
-  | Config_root_file of string
 
 and model_catalog_env_var =
   | Oas_model_catalog
@@ -41,7 +32,6 @@ and model_catalog_parent_origin =
   | Argv0_parent
 
 val model_catalog_env_source_to_string : model_catalog_env_source -> string
-val capability_manifest_env_source_to_string : capability_manifest_env_source -> string
 
 val resolve_oas_model_catalog_path :
   ?env:(string -> string option) ->
@@ -51,35 +41,17 @@ val resolve_oas_model_catalog_path :
   unit ->
   model_catalog_env_resolution option
 
-val resolve_oas_capability_manifest_path :
-  ?env:(string -> string option) ->
-  config_root:string ->
-  unit ->
-  capability_manifest_env_resolution option
-
 val configure_oas_model_catalog_env :
   ?env:(string -> string option) ->
   ?config_root:string ->
   ?cwd:string ->
   ?argv0:string ->
   ?putenv:(string -> string -> unit) ->
-  ?preload_agent_sdk_catalog:(unit -> unit) ->
   ?agent_sdk_catalog:(unit -> Llm_provider.Model_catalog.t option) ->
-  ?clear_catalog:(unit -> unit) ->
-  ?load_catalog:(string -> Llm_provider.Model_catalog.t option) ->
+  ?load_catalog:(string -> (Llm_provider.Model_catalog.t, string) result) ->
   ?set_catalog:(Llm_provider.Model_catalog.t -> unit) ->
   unit ->
   model_catalog_env_resolution option
-
-val configure_oas_capability_manifest_env :
-  ?env:(string -> string option) ->
-  config_root:string ->
-  ?putenv:(string -> string -> unit) ->
-  ?clear_manifest:(unit -> unit) ->
-  ?load_manifest:(string -> Llm_provider.Capability_manifest.t option) ->
-  ?set_manifest:(Llm_provider.Capability_manifest.t -> unit) ->
-  unit ->
-  capability_manifest_env_resolution option
 
 (** {1 Runtime Context}
 

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -2232,9 +2232,6 @@ let test_runtime_run_blocks_appends_multimodal_input_to_oas_agent () =
   let config =
     { config with
       session_id = Some "multimodal-runtime-proof-session";
-      exit_condition = Some (fun _turn -> true);
-      exit_condition_result =
-        Some (fun _turn -> Runtime_agent.Completed, Some "exit proof");
     }
   in
   let agent_ref = ref None in
@@ -2249,13 +2246,11 @@ let test_runtime_run_blocks_appends_multimodal_input_to_oas_agent () =
    with
    | Ok result -> (
        match result.Runtime_agent.stop_reason with
-       | Runtime_agent.Completed -> ()
+       | Runtime_agent.Completed -> fail "invalid provider endpoint completed"
        | stop_reason ->
            failf "unexpected stop reason after exit-condition proof: %s"
              (Keeper_execution_receipt_types.stop_reason_to_string stop_reason))
-   | Error err ->
-       fail ("expected exit-condition checkpoint result: "
-             ^ Agent_sdk.Error.to_string err));
+   | Error err -> ignore (Agent_sdk.Error.to_string err));
   match !agent_ref with
   | None -> fail "expected Runtime_agent.run_blocks to expose built OAS agent"
   | Some agent -> (

--- a/test/test_keeper_turn_driver_failover.ml
+++ b/test/test_keeper_turn_driver_failover.ml
@@ -51,6 +51,7 @@ let checkpoint_with_session_id session_id : Agent_sdk.Checkpoint.t =
   ; top_p = None
   ; top_k = None
   ; min_p = None
+  ; reasoning_effort = None
   ; enable_thinking = None
   ; preserve_thinking = None
   ; response_format = Agent_sdk.Types.Off
@@ -448,19 +449,13 @@ let test_prior_checkpoint_appends_current_goal_once () =
          ~goal:current_goal
          ~session_id:prior_checkpoint.session_id
          ~oas_checkpoint:prior_checkpoint
-         ~exit_condition:(fun _turn -> true)
-         ~exit_condition_result:
-           (fun _turn -> Runtime_agent.Completed, Some "exit proof")
          ~agent_ref
          ~sw
          ~net:env#net
          ()
      with
-     | Ok _ -> ()
-     | Error err ->
-       Alcotest.failf
-         "prior-checkpoint start should complete before provider dispatch: %s"
-         (Agent_sdk.Error.to_string err));
+     | Ok _ -> Alcotest.fail "invalid provider endpoint unexpectedly completed"
+     | Error err -> ignore (Agent_sdk.Error.to_string err));
     let messages =
       match !agent_ref with
       | Some agent -> (Agent_sdk.Agent.state agent).messages
@@ -804,7 +799,6 @@ let test_typed_checkpoint_is_the_same_run_retry_authority () =
   let stages =
     [ Agent_sdk.Agent.After_assistant_collected
     ; Agent_sdk.Agent.After_tool_results_appended
-    ; Agent_sdk.Agent.After_retry_feedback_appended
     ]
   in
   List.iter

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -169,12 +169,6 @@ let model_catalog_resolution_source_label
   Server_runtime_bootstrap.model_catalog_env_source_to_string
     resolution.Server_runtime_bootstrap.source
 
-let capability_manifest_resolution_source_label
-    (resolution : Server_runtime_bootstrap.capability_manifest_env_resolution)
-  =
-  Server_runtime_bootstrap.capability_manifest_env_source_to_string
-    resolution.Server_runtime_bootstrap.source
-
 let test_model_catalog_resolution_prefers_explicit_env () =
   let env = function
     | "OAS_MODEL_CATALOG" -> Some "/explicit/oas-models.toml"
@@ -220,69 +214,6 @@ let test_model_catalog_resolution_prefers_explicit_env () =
 	      "/explicit/masc-models.toml"
 	      resolution.Server_runtime_bootstrap.path
 
-let test_capability_manifest_resolution_prefers_explicit_env () =
-  let env = function
-    | "OAS_CAPABILITY_MANIFEST" -> Some "/explicit/capability-manifest.json"
-    | _ -> None
-  in
-  with_temp_dir "capability-manifest-bootstrap-explicit" (fun dir ->
-    match
-      Server_runtime_bootstrap.resolve_oas_capability_manifest_path
-        ~env
-        ~config_root:dir
-        ()
-    with
-    | None -> Alcotest.fail "expected explicit OAS_CAPABILITY_MANIFEST resolution"
-    | Some resolution ->
-      Alcotest.(check string)
-        "source"
-        "OAS_CAPABILITY_MANIFEST"
-        (capability_manifest_resolution_source_label resolution);
-      Alcotest.(check string)
-        "path"
-        "/explicit/capability-manifest.json"
-        resolution.Server_runtime_bootstrap.path)
-
-let test_capability_manifest_configuration_uses_config_root_file () =
-  with_temp_dir "capability-manifest-bootstrap-config-root" (fun config_root ->
-    let manifest = Filename.concat config_root "capability-manifest.json" in
-    write_file manifest {|{"schema_version":1,"models":[]}|};
-    let putenv_calls = ref [] in
-    let clear_calls = ref 0 in
-    let load_calls = ref [] in
-    let set_calls = ref 0 in
-    let env _ = None in
-    let result =
-      Server_runtime_bootstrap.configure_oas_capability_manifest_env
-        ~env
-        ~config_root
-        ~putenv:(fun name value -> putenv_calls := (name, value) :: !putenv_calls)
-        ~clear_manifest:(fun () -> incr clear_calls)
-        ~load_manifest:(fun path ->
-          load_calls := path :: !load_calls;
-          Some [])
-        ~set_manifest:(fun (_ : Llm_provider.Capability_manifest.t) -> incr set_calls)
-        ()
-    in
-    (match result with
-     | None -> Alcotest.fail "expected config-root capability manifest resolution"
-     | Some resolution ->
-       Alcotest.(check string)
-         "source"
-         "config-root:capability-manifest.json"
-         (capability_manifest_resolution_source_label resolution);
-       Alcotest.(check string)
-         "path"
-         (canonical_path manifest)
-         (canonical_path resolution.Server_runtime_bootstrap.path));
-    Alcotest.(check (list (pair string string)))
-      "putenv"
-      [ "OAS_CAPABILITY_MANIFEST", manifest ]
-      (List.rev !putenv_calls);
-    Alcotest.(check int) "clear manifest cache" 1 !clear_calls;
-    Alcotest.(check (list string)) "load manifest" [ manifest ] (List.rev !load_calls);
-    Alcotest.(check int) "set manifest override" 1 !set_calls)
-
 let test_model_catalog_configuration_installs_resolved_catalog () =
   with_temp_dir "model-catalog-bootstrap-install" (fun dir ->
     let repo = Filename.concat dir "repo" in
@@ -294,7 +225,6 @@ let test_model_catalog_configuration_installs_resolved_catalog () =
     write_file bin "";
     write_file catalog "[[models]]\nid_prefix = \"example\"\n";
     let putenv_calls = ref [] in
-    let clear_calls = ref 0 in
     let load_calls = ref [] in
     let set_calls = ref 0 in
     let result =
@@ -303,10 +233,9 @@ let test_model_catalog_configuration_installs_resolved_catalog () =
         ~cwd
         ~argv0:bin
         ~putenv:(fun name value -> putenv_calls := (name, value) :: !putenv_calls)
-        ~clear_catalog:(fun () -> incr clear_calls)
         ~load_catalog:(fun path ->
           load_calls := path :: !load_calls;
-          Some Llm_provider.Model_catalog.empty)
+          Ok Llm_provider.Model_catalog.empty)
         ~set_catalog:(fun (_ : Llm_provider.Model_catalog.t) -> incr set_calls)
         ()
     in
@@ -325,7 +254,6 @@ let test_model_catalog_configuration_installs_resolved_catalog () =
       "putenv"
       [ "OAS_MODEL_CATALOG", catalog ]
       (List.rev !putenv_calls);
-    Alcotest.(check int) "clear catalog cache" 1 !clear_calls;
     Alcotest.(check (list string)) "load catalog" [ catalog ] (List.rev !load_calls);
     Alcotest.(check int) "set catalog override" 1 !set_calls)
 
@@ -338,7 +266,6 @@ let test_model_catalog_configuration_prefers_config_root_catalog () =
     mkdir_p outside;
     write_file catalog "[[models]]\nid_prefix = \"config-root-runtime\"\n";
     let putenv_calls = ref [] in
-    let clear_calls = ref 0 in
     let load_calls = ref [] in
     let set_calls = ref 0 in
     let result =
@@ -348,10 +275,9 @@ let test_model_catalog_configuration_prefers_config_root_catalog () =
         ~cwd:outside
         ~argv0:(Filename.concat outside "main_eio.exe")
         ~putenv:(fun name value -> putenv_calls := (name, value) :: !putenv_calls)
-        ~clear_catalog:(fun () -> incr clear_calls)
         ~load_catalog:(fun path ->
           load_calls := path :: !load_calls;
-          Some Llm_provider.Model_catalog.empty)
+          Ok Llm_provider.Model_catalog.empty)
         ~set_catalog:(fun (_ : Llm_provider.Model_catalog.t) -> incr set_calls)
         ()
     in
@@ -370,7 +296,6 @@ let test_model_catalog_configuration_prefers_config_root_catalog () =
       "putenv"
       [ "OAS_MODEL_CATALOG", catalog ]
       (List.rev !putenv_calls);
-    Alcotest.(check int) "clear catalog cache" 1 !clear_calls;
     Alcotest.(check (list string)) "load catalog" [ catalog ] (List.rev !load_calls);
     Alcotest.(check int) "set catalog override" 1 !set_calls)
 
@@ -439,7 +364,6 @@ let test_model_catalog_resolution_resolves_relative_argv0_from_process_cwd () =
 let test_model_catalog_configuration_delegates_to_agent_sdk_ambient () =
   with_temp_dir "model-catalog-bootstrap-agent-sdk" (fun dir ->
     let putenv_calls = ref [] in
-    let preload_calls = ref 0 in
     let env _ = None in
     let result =
       Server_runtime_bootstrap.configure_oas_model_catalog_env
@@ -447,12 +371,10 @@ let test_model_catalog_configuration_delegates_to_agent_sdk_ambient () =
         ~cwd:dir
         ~argv0:(Filename.concat dir "main_eio.exe")
         ~putenv:(fun name value -> putenv_calls := (name, value) :: !putenv_calls)
-        ~preload_agent_sdk_catalog:(fun () -> incr preload_calls)
         ~agent_sdk_catalog:(fun () -> Some Llm_provider.Model_catalog.empty)
         ()
     in
     Alcotest.(check bool) "no explicit path resolution" true (Option.is_none result);
-    Alcotest.(check int) "preload called once" 1 !preload_calls;
     Alcotest.(check int) "does not write OAS_MODEL_CATALOG" 0
       (List.length !putenv_calls))
 
@@ -4703,12 +4625,6 @@ let () =
           Alcotest.test_case
             "model catalog resolution prefers explicit env"
             `Quick test_model_catalog_resolution_prefers_explicit_env;
-          Alcotest.test_case
-            "capability manifest resolution prefers explicit env"
-            `Quick test_capability_manifest_resolution_prefers_explicit_env;
-          Alcotest.test_case
-            "capability manifest configuration uses config root"
-            `Quick test_capability_manifest_configuration_uses_config_root_file;
           Alcotest.test_case
             "model catalog configuration installs resolved catalog"
             `Quick test_model_catalog_configuration_installs_resolved_catalog;


### PR DESCRIPTION
## What changed

- route the existing MASC exit predicate through OAS `Agent.Advanced.run_blocks` and hard-delete the removed `Builder.with_exit_condition` / `ExitConditionMet` bridge
- project `resolved_reasoning_effort` from the exact typed `Provider_config.reasoning_effort` request value; it is not inferred from thinking flags or budgets
- hard-delete the obsolete capability-manifest runtime env/resolver/loader surface and its tests
- load explicit model catalogs through the current OAS `Model_catalog.load_file` result contract, raise a typed configuration failure on parse errors, and replace global catalog state only after a successful parse
- replace the unavailable `List.hd_opt` call with an exact head match
- remove stale test fixtures that used the deleted pre-dispatch exit hook as a provider stub while retaining their multimodal and checkpoint-state assertions

## Why

OAS 0.212 removed the implicit exit-condition and capability-manifest runtime contracts. MASC still referenced those deleted APIs, so the runtime/server cone could not compile. The old catalog override also cleared global state before knowing whether the replacement parsed successfully.

This is the small current-main bootstrap repair and supersedes the implementation direction in #24477. It does not close or modify that PR.

## Boundary note

The pre-existing `OAS_MODEL_CATALOG` env and cwd/argv catalog resolution remains in this slice only to keep the repair coherent under the 399-line PR boundary. That behavior is existing debt and is **not endorsed here**; the later env/cwd catalog hard-cut remains a separate change.

No execution budget, turn cap, timeout, heuristic fallback, or compatibility shim is introduced.

## Validation

- `scripts/dune-local.sh build lib/runtime/masc_runtime.cmxa lib/server/masc_server.cmxa test/test_server_runtime_bootstrap.exe test/test_gate_keeper_backend.exe test/test_keeper_turn_driver_failover.exe`
- `test_server_runtime_bootstrap.exe ... bootstrap 0-5` — 6/6 passed
- `test_gate_keeper_backend.exe ... helpers 57` — 1/1 passed
- `test_keeper_turn_driver_failover.exe ... runtime_lane_resolution 10,15` — 2/2 passed
- `ocamlformat --check`
- `git diff --check`

Diff: 9 files, +85/-314 = 399 changed lines.