### PR TITLE
test(oas-0212): complete test-tail migration left by #24468 (dune build green)

### DIFF
--- a/test/test_dashboard_namespace_truth.ml
+++ b/test/test_dashboard_namespace_truth.ml
@@ -134,7 +134,7 @@ let create_keeper env sw state name =
       clock = Eio.Stdenv.clock env;
       proc_mgr = Some (Eio.Stdenv.process_mgr env); net = None;
       publication_recovery_registry =
-        (Mcp_server.workspace_scope_publication_recovery_registry workspace_scope);
+        (Lib.Mcp_server.workspace_scope_publication_recovery_registry workspace_scope);
     }
   in
   match

--- a/test/test_keeper_effective_meta_overlay.ml
+++ b/test/test_keeper_effective_meta_overlay.ml
@@ -436,6 +436,7 @@ sandbox_profile = "docker"
       clock = Eio.Stdenv.clock env;
       proc_mgr = None;
       net = None;
+      publication_recovery_registry = None;
     }
   in
   match Turn_setup.ensure_keeper_exists ~ctx ~name with
@@ -514,6 +515,7 @@ instructions = "missing sandbox profile"
       clock = Eio.Stdenv.clock env;
       proc_mgr = None;
       net = None;
+      publication_recovery_registry = None;
     }
   in
   let result = Turn.handle_keeper_up ctx (`Assoc [ ("name", `String name) ]) in
@@ -541,6 +543,7 @@ let test_keeper_up_rejects_missing_profile_source () =
       clock = Eio.Stdenv.clock env;
       proc_mgr = None;
       net = None;
+      publication_recovery_registry = None;
     }
   in
   let result = Turn.handle_keeper_up ctx (`Assoc [ ("name", `String name) ]) in

--- a/test/test_mcp_tool_runtime_workspace_path.ml
+++ b/test/test_mcp_tool_runtime_workspace_path.ml
@@ -1,4 +1,6 @@
 module Cases = Test_mcp_tool_matrix_cases
+module Mcp_eio = Masc.Mcp_server_eio
+module Mcp_server = Masc.Mcp_server
 
 let contains_substring text fragment =
   let text_len = String.length text in


### PR DESCRIPTION
## 목적

OAS agent_sdk 0.212.0 마이그레이션(#24468)이 test tree 대부분을 마이그레이션했으나 **3개 test 파일**이 pre-0.212 module 경로/record shape를 참조한 채 남아, 현재 main에서 `dune build @check`가 3개 에러로 실패합니다. 이 PR이 그 3개를 메워 **완전 green**으로 만듭니다.

## 변경

| 파일 | 에러 | 수정 |
|------|------|------|
| `test_dashboard_namespace_truth.ml:137` | `Unbound module Mcp_server` | `Lib.Mcp_server`로 qualify (파일이 `module Lib = Masc` alias, 다른 호출부는 전부 qualify됨 — 137행만 prefix 누락) |
| `test_mcp_tool_runtime_workspace_path.ml:60,139` | `Unbound module Mcp_server` / `Mcp_eio` | `module Mcp_server = Masc.Mcp_server` + `module Mcp_eio = Masc.Mcp_server_eio` alias 추가 (masc lib이 wrapped라 bare 참조 미해결). `test_mcp_tool_matrix_cases`/`test_mcp_server_eio` 컨벤션과 일치 |
| `test_keeper_effective_meta_overlay.ml:432-439` | `Some record fields are undefined: publication_recovery_registry` | 3개 `Profile.context` 리터럴에 `publication_recovery_registry = None` 추가 (#24475 publication recovery가 추가한 필드; sibling 리터럴은 이미 `Some _`로 설정) |

## 검증

- `dune build @check --root .` → **0 errors** (2938dd4655 = #24468 기준). 적용 전 3 errors → 적용 후 green.
- `ocamlformat --check` clean.
- 테스트 **실행**은 안 함 (컴파일/타입체크만).

## 배경

lib는 OAS 0.212로 마이그레이션됐으나 CI가 이 test들을 안 빌드해(false-green, issue #24495) red-merge로 잔재가 흘러들었습니다. #24468이 벌크 마이그레이션을 착지시켰고, 이 3개가 그 스코프에서 빠져 남은 gap입니다.

RFC-WAIVED: test-only 변경 (credential/operator/sandbox/hooks/workflow 서브시스템 무관).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
