### PR TITLE
test(keeper): purge legacy goal from namespace fixture

### DIFF
--- a/test/test_dashboard_namespace_truth.ml
+++ b/test/test_dashboard_namespace_truth.ml
@@ -143,7 +143,6 @@ let create_keeper env sw state name =
         (`Assoc
           [
             ("name", `String name);
-            ("goal", `String "Dashboard keeper fixture");
             ("proactive_enabled", `Bool false);
                 ("autoboot_enabled", `Bool false);
           ])


### PR DESCRIPTION
## Summary
- remove the retired `goal` argument from the dashboard namespace keeper fixture
- keep the test aligned with the hard-cut `masc_keeper_up` contract

## Context
PR #24513 fixed the clean-build module aliases left after #24468. Its newly compilable namespace test then exposed this final Legacy Goal residue at execution time.

## Verification
- `scripts/dune-local.sh build @test/runtest-test_dashboard_namespace_truth` (12/12)
- `opam exec -- ocamlformat --check test/test_dashboard_namespace_truth.ml`
- `git diff --check origin/main...HEAD`