### PR TITLE
docs(rfc): add reproducible RFC-0000 HTML renderer

### DIFF
--- a/docs/rfc/RFC-0000-MASTER-ROADMAP.css
+++ b/docs/rfc/RFC-0000-MASTER-ROADMAP.css
@@ -1,0 +1,12 @@
+:root { color-scheme: light dark; --bg:#fff; --fg:#1f2328; --muted:#59636e; --border:#d0d7de; --panel:#f6f8fa; --accent:#0969da; }
+@media (prefers-color-scheme:dark) { :root { --bg:#0d1117; --fg:#e6edf3; --muted:#9da7b3; --border:#30363d; --panel:#161b22; --accent:#58a6ff; } }
+body { max-width:980px; margin:0 auto; padding:2rem 1.5rem 5rem; background:var(--bg); color:var(--fg); font:16px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; }
+a { color:var(--accent); }
+h1,h2 { border-bottom:1px solid var(--border); padding-bottom:.35rem; }
+h1,h2,h3 { line-height:1.3; margin-top:2rem; }
+blockquote,#TOC,pre { background:var(--panel); border:1px solid var(--border); border-radius:8px; padding:.8rem 1rem; }
+blockquote { margin-left:0; color:var(--muted); }
+code { background:var(--panel); border-radius:4px; padding:.12rem .3rem; }
+pre,table { overflow-x:auto; } pre code { padding:0; }
+table { border-collapse:collapse; display:block; width:100%; } th,td { border:1px solid var(--border); padding:.5rem .65rem; text-align:left; vertical-align:top; } th { background:var(--panel); }
+nav ul { padding-left:1.35rem; } @media (max-width:640px) { body { padding:1rem .8rem 3rem; font-size:15px; } }

--- a/scripts/generate-master-roadmap-html.sh
+++ b/scripts/generate-master-roadmap-html.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -eu
+
+[ "$#" -eq 1 ] || { echo "usage: $0 OUTPUT.html" >&2; exit 64; }
+
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(CDPATH='' cd -- "$script_dir/.." && pwd)
+source_file="$repo_root/docs/rfc/RFC-0000-MASTER-ROADMAP.md"
+style_file="$repo_root/docs/rfc/RFC-0000-MASTER-ROADMAP.css"
+output_file=$1
+
+mkdir -p -- "$(dirname -- "$output_file")"
+pandoc --from=gfm --to=html5 --standalone --section-divs \
+  --toc --toc-depth=3 --embed-resources --css="$style_file" \
+  --output="$output_file" "$source_file"


### PR DESCRIPTION
## What changed

- add a small responsive stylesheet for `docs/rfc/RFC-0000-MASTER-ROADMAP.md`
- add a reproducible standalone HTML renderer using Pandoc
- preserve the 889-line RFC already merged by #24515 without replacing or rewriting it

## Conflict resolution

The former branch was based on the pre-#24515 roadmap stack and attempted to replace the merged RFC with a 362-line alternative. It also carried unrelated `fs_compat` and dashboard-test differences from an older base.

This branch is rebuilt directly on current `main`. Only the two independently useful rendering assets survive; the compressed Markdown and unrelated code/test drift are removed.

The renderer uses `--from=gfm`. The previous `--from=markdown` form parsed explicit `<a name=...>` lines and following headings as one paragraph, leaving the generated TOC broken.

## Validation

- `shellcheck scripts/generate-master-roadmap-html.sh`
- `sh -n scripts/generate-master-roadmap-html.sh`
- generated a 173,325-byte standalone HTML file from the current 889-line RFC
- validated 98 unique internal references against 185 `id`/`name` targets: 0 missing
- confirmed 15 rendered `h2` headings
- `git diff --check`

Docs-only: 2 files, 27 additions. No runtime or test changes.

[근거] current `origin/main`, PR #24515 merge, generated HTML/anchor validation; 확인일시 2026-07-15 KST; 신뢰도 High.
