### PR TITLE
fix(keeper): retain retryable work in durable lane

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -257,7 +257,8 @@ let settlement_of_failure ~settled_at failure =
   | Keeper_unified_turn.Follow_failure_route ->
     (match failure.Keeper_unified_turn.route with
      | Keeper_runtime_failure_route.Retry_after_observed _ ->
-       Keeper_registry_event_queue.Ack
+       Keeper_registry_event_queue.Requeue
+         Keeper_registry_event_queue.Retry_after_observed
      | Keeper_runtime_failure_route.Rotate_now _ ->
        Keeper_registry_event_queue.Requeue Keeper_registry_event_queue.Rotate_now
      | Keeper_runtime_failure_route.Escalate_judgment

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -16,6 +16,7 @@ type requeue_reason = Keeper_event_queue_persistence.requeue_reason =
   | Cancelled
   | Cycle_crashed
   | Registration_recovery
+  | Retry_after_observed
   | Approval_grant_unconsumed
   | Approval_grant_state_unavailable
 

--- a/lib/keeper/keeper_registry_event_queue.mli
+++ b/lib/keeper/keeper_registry_event_queue.mli
@@ -15,6 +15,7 @@ type requeue_reason = Keeper_event_queue_persistence.requeue_reason =
   | Cancelled
   | Cycle_crashed
   | Registration_recovery
+  | Retry_after_observed
   | Approval_grant_unconsumed
   | Approval_grant_state_unavailable
 

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -13,6 +13,7 @@ type requeue_reason = State.requeue_reason =
   | Cancelled
   | Cycle_crashed
   | Registration_recovery
+  | Retry_after_observed
   | Approval_grant_unconsumed
   | Approval_grant_state_unavailable
 

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -17,6 +17,7 @@ type requeue_reason = Keeper_event_queue_state.requeue_reason =
   | Cancelled
   | Cycle_crashed
   | Registration_recovery
+  | Retry_after_observed
   | Approval_grant_unconsumed
   | Approval_grant_state_unavailable
 

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -10,6 +10,7 @@ type requeue_reason =
   | Cancelled
   | Cycle_crashed
   | Registration_recovery
+  | Retry_after_observed
   | Approval_grant_unconsumed
   | Approval_grant_state_unavailable
 
@@ -230,6 +231,7 @@ let requeue_reason_label = function
   | Cancelled -> "cancelled"
   | Cycle_crashed -> "cycle_crashed"
   | Registration_recovery -> "registration_recovery"
+  | Retry_after_observed -> "retry_after_observed"
   | Approval_grant_unconsumed -> "approval_grant_unconsumed"
   | Approval_grant_state_unavailable -> "approval_grant_state_unavailable"
 ;;
@@ -241,6 +243,7 @@ let requeue_reason_of_label = function
   | "cancelled" -> Ok Cancelled
   | "cycle_crashed" -> Ok Cycle_crashed
   | "registration_recovery" -> Ok Registration_recovery
+  | "retry_after_observed" -> Ok Retry_after_observed
   | "approval_grant_unconsumed" -> Ok Approval_grant_unconsumed
   | "approval_grant_state_unavailable" -> Ok Approval_grant_state_unavailable
   | label -> Error (Printf.sprintf "unknown event queue requeue reason: %s" label)
@@ -482,11 +485,14 @@ let settle ~settled_at ~lease ~settlement state =
     let pending =
       match settlement with
       | Ack -> state.pending
-      | Requeue (Approval_grant_unconsumed | Approval_grant_state_unavailable) ->
-        (* The durable one-shot grant must survive a missed exact effect or a
-           transient journal read failure, but its wake must not monopolize
-           the FIFO front. Tail requeue lets unrelated Board/Connector work
-           claim the next lane cycle. *)
+      | Requeue
+          ( Retry_after_observed
+          | Approval_grant_unconsumed
+          | Approval_grant_state_unavailable ) ->
+        (* A retryable provider failure and a durable one-shot grant both
+           retain the exact leased stimuli without monopolizing the FIFO
+           front. Unrelated Board/Connector work can claim the next lane
+           cycle before the retained work is attempted again. *)
         append_missing committed.stimuli state.pending
       | Requeue _ -> prepend_missing committed.stimuli state.pending
       | Escalate { successor = None; _ } -> state.pending

--- a/lib/keeper_runtime/keeper_event_queue_state.mli
+++ b/lib/keeper_runtime/keeper_event_queue_state.mli
@@ -17,6 +17,7 @@ type requeue_reason =
   | Cancelled
   | Cycle_crashed
   | Registration_recovery
+  | Retry_after_observed
   | Approval_grant_unconsumed
   | Approval_grant_state_unavailable
 
@@ -106,7 +107,11 @@ val settle :
   (t * settle_result, string) result
 (** Atomically project one lease disposition into pure state.  Repeating the
     same semantic settlement returns [Already_settled]; a different settlement
-    for an already-settled lease is an explicit conflict. *)
+    for an already-settled lease is an explicit conflict.
+
+    [Retry_after_observed] retains the exact leased stimuli at the pending FIFO
+    tail so unrelated work in the same lane can proceed before another
+    provider attempt. *)
 
 val recover_leases : settled_at:float -> t -> (t, string) result
 (** Requeue every active lease with [Registration_recovery], preserving claim

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -361,8 +361,10 @@ let test_failed_cycle_route_mapping () =
        ~settled_at:2.0
        retry_failure
    with
-   | Masc.Keeper_registry_event_queue.Ack -> ()
-   | _ -> Alcotest.fail "observed retry route did not acknowledge the lease");
+   | Masc.Keeper_registry_event_queue.Requeue
+       Masc.Keeper_registry_event_queue.Retry_after_observed ->
+     ()
+   | _ -> Alcotest.fail "observed retry route did not retain the leased work");
   let judgment_failure =
     turn_failure
       (Keeper_runtime_failure_route.Escalate_judgment
@@ -525,6 +527,119 @@ let read_schema path =
      | Some (`String schema) -> schema
      | _ -> Alcotest.fail "migrated state lacks schema")
   | Ok _ -> Alcotest.fail "migrated state is not an object"
+;;
+
+let test_retryable_failure_restores_exact_stimulus_at_fifo_tail () =
+  with_temp_dir "keeper-event-queue-v2-retry-tail" (fun base_path ->
+    let keeper_name = "retry_tail_keeper" in
+    let source =
+      stimulus
+        ~payload:
+          (Queue.Connector_attention
+             { event_id = "connector-event-17"
+             ; channel = Keeper_continuation_channel.unrouted "retry tail fixture"
+             })
+        "connector-source"
+        1.25
+    in
+    let unrelated = stimulus "unrelated-board-work" 2.5 in
+    Persistence.update_result ~base_path ~keeper_name (fun pending ->
+      List.fold_left Queue.enqueue pending [ source; unrelated ])
+    |> require_ok "seed retry tail queue";
+    let lease =
+      Persistence.claim_when_result
+        ~base_path
+        ~keeper_name
+        ~claimed_at:3.0
+        ~ready:(fun _ -> true)
+        ()
+      |> require_ok "claim retryable source"
+      |> require_some "retryable source lease"
+    in
+    let receipt =
+      match
+        Persistence.settle_result
+          ~base_path
+          ~keeper_name
+          ~settled_at:4.0
+          ~lease
+          ~settlement:(State.Requeue State.Retry_after_observed)
+          ()
+        |> require_ok "settle retryable source"
+      with
+      | Persistence.Settled receipt -> receipt
+      | Persistence.Already_settled _ ->
+        Alcotest.fail "first retryable settlement was already settled"
+    in
+    let restored =
+      Persistence.load_state_result ~base_path ~keeper_name
+      |> require_ok "restore retryable state"
+    in
+    (match Queue.to_list (State.pending restored) with
+     | [ next; retained ] ->
+       Alcotest.(check string)
+         "unrelated same-lane work remains first"
+         unrelated.post_id
+         next.post_id;
+       Alcotest.(check bool)
+         "restart restores the exact retained stimulus"
+         true
+         (Yojson.Safe.equal
+            (Queue.stimulus_to_yojson source)
+            (Queue.stimulus_to_yojson retained))
+     | _ -> Alcotest.fail "retryable settlement did not restore two pending stimuli");
+    let outbox_entry =
+      match State.transition_outbox restored with
+      | [ entry ] -> entry
+      | _ -> Alcotest.fail "retryable settlement must retain one transition receipt"
+    in
+    (match outbox_entry.receipt.settlement with
+     | State.Requeue State.Retry_after_observed -> ()
+     | _ -> Alcotest.fail "retryable transition lost its typed requeue reason");
+    (match outbox_entry.stimuli with
+     | [ retained ] ->
+       Alcotest.(check bool)
+         "transition outbox retains the exact leased stimulus"
+         true
+         (Yojson.Safe.equal
+            (Queue.stimulus_to_yojson source)
+            (Queue.stimulus_to_yojson retained))
+     | _ -> Alcotest.fail "retryable transition changed the leased stimulus set");
+    Persistence.mark_transition_projected_result
+      ~base_path
+      ~keeper_name
+      ~transition_id:receipt.transition_id
+    |> require_ok "project retryable transition";
+    let next_lease =
+      Persistence.claim_when_result
+        ~base_path
+        ~keeper_name
+        ~claimed_at:5.0
+        ~ready:(fun _ -> true)
+        ()
+      |> require_ok "claim unrelated work after retry"
+      |> require_some "unrelated work lease"
+    in
+    (match Persistence.lease_stimuli next_lease with
+     | [ next ] ->
+       Alcotest.(check string)
+         "unrelated work leases before the retained retry"
+         unrelated.post_id
+         next.post_id
+     | _ -> Alcotest.fail "retry fairness fixture expected one leased stimulus");
+    let after_next_claim =
+      Persistence.load_state_result ~base_path ~keeper_name
+      |> require_ok "reload retained retry after unrelated claim"
+    in
+    match Queue.to_list (State.pending after_next_claim) with
+    | [ retained ] ->
+      Alcotest.(check bool)
+        "retained retry survives the next same-lane claim"
+        true
+        (Yojson.Safe.equal
+           (Queue.stimulus_to_yojson source)
+           (Queue.stimulus_to_yojson retained))
+    | _ -> Alcotest.fail "retained retry was not left pending after peer work claimed")
 ;;
 
 let test_legacy_pair_migrates_once () =
@@ -767,7 +882,11 @@ let () =
             test_unconsumed_approval_requeues_behind_other_work
         ] )
     ; ( "persistence"
-      , [ Alcotest.test_case "legacy pair migration" `Quick test_legacy_pair_migrates_once
+      , [ Alcotest.test_case
+            "retryable failure durable FIFO tail"
+            `Quick
+            test_retryable_failure_restores_exact_stimulus_at_fifo_tail
+        ; Alcotest.test_case "legacy pair migration" `Quick test_legacy_pair_migrates_once
         ; Alcotest.test_case
             "transition outbox projection"
             `Quick


### PR DESCRIPTION
## What changed

- map typed provider retry outcomes to a durable queue requeue instead of Ack
- retain the exact leased stimulus at the FIFO tail so unrelated same-lane work can proceed first
- persist and decode the typed retry reason through state, persistence, and registry boundaries
- replace the fake Ack expectation with restart, receipt, identity, and lane-order evidence

## Why

A retryable provider failure acknowledged the active lease and permanently lost the Keeper stimulus. The Keeper stayed alive, but its exact work did not.

## Validation

- `scripts/dune-local.sh build test/test_keeper_event_queue_state_v2.exe`
- focused state route test passed
- focused persistence/restart test passed
- `ocamlformat --check` and `git diff --check`

The full executable still has one pre-existing removed `goal` fixture failure unrelated to this diff; the changed and added cases pass.