### PR TITLE
refactor(schedule): make delivery wake-only and durable

### DIFF
--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -288,7 +288,7 @@ let format_scheduled_automation_summary
            Buffer.add_char ubuf '\n')
         summary.items;
       Buffer.add_string ubuf
-        "- Use masc_schedule_get for details; each consumer applies its own leaf Gate before an external effect.\n");
+        "- Use masc_schedule_get for details; a due Schedule wakes the Keeper lane and grants no effect authority.\n");
     Buffer.add_char ubuf '\n';
     Some (Buffer.contents ubuf))
 ;;

--- a/lib/schedule/schedule_supported_kinds.ml
+++ b/lib/schedule/schedule_supported_kinds.ml
@@ -18,7 +18,7 @@
 let board_post = "masc.board_post"
 let keeper_wake = "masc.keeper_wake"
 
-let supported = [ board_post; keeper_wake ]
+let supported = [ keeper_wake ]
 
 let supported_list_string () = String.concat ", " supported
 

--- a/lib/schedule/schedule_supported_kinds.ml
+++ b/lib/schedule/schedule_supported_kinds.ml
@@ -15,7 +15,6 @@
     without a validator branch stays rejected at creation as an unsupported
     kind. So a new kind needs both the list entry and a validator branch. *)
 
-let board_post = "masc.board_post"
 let keeper_wake = "masc.keeper_wake"
 
 let supported = [ keeper_wake ]

--- a/lib/schedule/schedule_supported_kinds.mli
+++ b/lib/schedule/schedule_supported_kinds.mli
@@ -6,7 +6,6 @@
     full design rationale. Neither layer reaches across the
     [lib/tool] <-> [lib/server] boundary. *)
 
-val board_post : string
 val keeper_wake : string
 
 val supported : string list

--- a/lib/schedule_payload_projection.ml
+++ b/lib/schedule_payload_projection.ml
@@ -1,9 +1,7 @@
 (* TEL-OK: pure schedule payload projection/validation. Runtime telemetry for
    unsupported creation/dispatch lives at the tool/server caller boundaries. *)
 
-type known_kind =
-  | Board_post
-  | Keeper_wake
+type known_kind = Keeper_wake
 
 type support_status =
   | Supported
@@ -46,18 +44,15 @@ let trim_nonempty value =
 ;;
 
 let known_kind_to_string = function
-  | Board_post -> Schedule_supported_kinds.board_post
   | Keeper_wake -> Schedule_supported_kinds.keeper_wake
 ;;
 
 let dispatch_tool_name = function
-  | Board_post -> Tool_name.Board_name.(to_string Board_post)
   | Keeper_wake -> Schedule_supported_kinds.keeper_wake
 ;;
 
-let known_kinds = [ Board_post; Keeper_wake ]
+let known_kinds = [ Keeper_wake ]
 let supported_payload_kinds = List.map known_kind_to_string known_kinds
-let board_post_kind = known_kind_to_string Board_post
 let keeper_wake_kind = known_kind_to_string Keeper_wake
 
 let support_status_to_string = function
@@ -81,7 +76,6 @@ let dispatch_rejection_message = function
 ;;
 
 let classify_kind = function
-  | kind when String.equal kind (known_kind_to_string Board_post) -> Some Board_post
   | kind when String.equal kind (known_kind_to_string Keeper_wake) -> Some Keeper_wake
   | _ -> None
 ;;
@@ -107,20 +101,6 @@ let optional_string_field name fields =
   | None | Some `Null -> Ok None
   | Some (`String value) -> Ok (trim_nonempty value)
   | Some _ -> Error ("expected string field: " ^ name)
-;;
-
-let optional_int_field name fields =
-  match List.assoc_opt name fields with
-  | None | Some `Null -> Ok None
-  | Some (`Int value) -> Ok (Some value)
-  | Some _ -> Error ("expected int field: " ^ name)
-;;
-
-let optional_assoc_field name fields =
-  match List.assoc_opt name fields with
-  | None | Some `Null -> Ok None
-  | Some (`Assoc _ as value) -> Ok (Some value)
-  | Some _ -> Error ("expected object field: " ^ name)
 ;;
 
 let payload_view_of_json payload =
@@ -150,42 +130,6 @@ let payload_view (request : Schedule_domain.schedule_request) =
 let kind_of_json_result payload =
   let* view = payload_view_of_json payload in
   Ok view.raw_kind
-;;
-
-let board_schema_version_error ~creation schema_version =
-  if schema_version = 1
-  then Ok ()
-  else if creation
-  then Error (board_post_kind ^ " only supports payload_schema_version=1")
-  else Error (board_post_kind ^ " only supports schema_version=1")
-;;
-
-let validate_board_post_common ~content_error view =
-  let* _content =
-    match assoc_string "content" view.body with
-    | Some content -> Ok content
-    | None -> Error content_error
-  in
-  let* ttl_hours = optional_int_field "ttl_hours" view.body in
-  match ttl_hours with
-  | Some ttl when ttl < 0 -> Error "ttl_hours must be non-negative"
-  | _ -> Ok ()
-;;
-
-let validate_board_post_for_creation view =
-  let* () = board_schema_version_error ~creation:true view.schema_version in
-  validate_board_post_common
-    ~content_error:
-      (board_post_kind
-       ^ " payload requires non-empty body.content; use board_content for board schedules")
-    view
-;;
-
-let validate_board_post_for_dispatch view =
-  let* () = board_schema_version_error ~creation:false view.schema_version in
-  validate_board_post_common
-    ~content_error:"missing field: content"
-    view
 ;;
 
 let keeper_wake_schema_version_error ~creation schema_version =
@@ -230,38 +174,6 @@ let validate_request_payload_for_creation_detailed ~payload =
     (match assoc_string "kind" fields with
      | Some raw_kind ->
        (match classify_kind raw_kind with
-        | Some Board_post ->
-          let* schema_version =
-            match List.assoc_opt "schema_version" fields with
-            | Some (`Int value) -> Ok value
-            | Some _ ->
-              Error
-                (Creation_invalid_supported_payload
-                   ( Board_post
-                   , board_post_kind ^ " payload.schema_version must be an integer" ))
-            | None ->
-              Error
-                (Creation_invalid_supported_payload
-                   (Board_post, board_post_kind ^ " payload requires schema_version=1"))
-          in
-          let* body =
-            match List.assoc_opt "body" fields with
-            | Some (`Assoc body) -> Ok body
-            | Some _ ->
-              Error
-                (Creation_invalid_supported_payload
-                   (Board_post, board_post_kind ^ " payload.body must be an object"))
-            | None ->
-              Error
-                (Creation_invalid_supported_payload
-                   ( Board_post
-                   , board_post_kind
-                     ^ " payload requires object body with non-empty content; use board_content for board schedules"
-                   ))
-          in
-          validate_board_post_for_creation { raw_kind; schema_version; body }
-          |> Result.map_error (fun msg ->
-            Creation_invalid_supported_payload (Board_post, msg))
         | Some Keeper_wake ->
           let* schema_version =
             match List.assoc_opt "schema_version" fields with
@@ -306,13 +218,6 @@ let dispatch_view_detailed request =
     payload_view request |> Result.map_error (fun msg -> Dispatch_invalid_payload msg)
   in
   match classify_kind view.raw_kind with
-  | Some Board_post ->
-    let* () =
-      validate_board_post_for_dispatch view
-      |> Result.map_error (fun msg ->
-        Dispatch_invalid_supported_payload (Board_post, msg))
-    in
-    Ok (Board_post, view)
   | Some Keeper_wake ->
     let* () =
       validate_keeper_wake_for_dispatch view
@@ -383,7 +288,7 @@ let dispatch_tool_for_request request =
 
 let known_kind_contract_to_yojson kind =
   match kind with
-  | Board_post | Keeper_wake ->
+  | Keeper_wake ->
     `Assoc
       [ "kind", `String (known_kind_to_string kind)
       ; "schema_versions", `List [ `Int 1 ]
@@ -460,24 +365,10 @@ let support_summary_to_yojson schedules =
   schedules |> support_summary |> support_summary_yojson
 ;;
 
-let board_target body =
-  match assoc_string "thread_id" body, assoc_string "hearth" body with
-  | Some thread_id, _ -> Some ("thread:" ^ thread_id)
-  | None, Some hearth -> Some ("hearth:" ^ hearth)
-  | None, None -> Some "board:default"
-;;
-
 let truncate_summary text =
   String.trim text
   |> String_util.utf8_safe ~max_bytes:160 ~suffix:"..."
   |> String_util.to_string
-;;
-
-let board_summary body =
-  match assoc_string "title" body, assoc_string "content" body with
-  | Some title, _ -> Some (truncate_summary title)
-  | None, Some content -> Some (truncate_summary content)
-  | None, None -> None
 ;;
 
 let keeper_wake_target body =
@@ -498,7 +389,6 @@ let target_summary_result (request : Schedule_domain.schedule_request) =
   | Error msg -> Error msg
   | Ok view ->
     (match classify_kind view.raw_kind with
-     | Some Board_post -> Ok (board_target view.body, board_summary view.body)
      | Some Keeper_wake -> Ok (keeper_wake_target view.body, keeper_wake_summary view.body)
      | None -> Ok (None, None))
 ;;
@@ -511,9 +401,5 @@ let target_summary request =
     None, None
 ;;
 
-let view_kind (view : payload_view) = view.raw_kind
-let view_schema_version (view : payload_view) = view.schema_version
 let body_required_string view name = required_string_field name view.body
 let body_optional_string view name = optional_string_field name view.body
-let body_optional_int view name = optional_int_field name view.body
-let body_optional_assoc view name = optional_assoc_field name view.body

--- a/lib/schedule_payload_projection.mli
+++ b/lib/schedule_payload_projection.mli
@@ -4,9 +4,7 @@
     names the payload kinds MASC can understand, validates their objective
     schemas, and returns typed views for production dispatch. *)
 
-type known_kind =
-  | Board_post
-  | Keeper_wake
+type known_kind = Keeper_wake
 
 type support_status =
   | Supported
@@ -84,9 +82,5 @@ val target_summary_result
 
 val target_summary : Schedule_domain.schedule_request -> string option * string option
 
-val view_kind : payload_view -> string
-val view_schema_version : payload_view -> int
 val body_required_string : payload_view -> string -> (string, string) result
 val body_optional_string : payload_view -> string -> (string option, string) result
-val body_optional_int : payload_view -> string -> (int option, string) result
-val body_optional_assoc : payload_view -> string -> (Yojson.Safe.t option, string) result

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -33,7 +33,7 @@ let wake_enqueue_counts_of_dispatches dispatches =
        | None -> counts
        | Some detail ->
          (match Consumers.dispatch_receipt_of_detail detail with
-          | Error _ | Ok (Consumers.Board_post_created _) -> counts
+          | Error _ -> counts
           | Ok (Consumers.Keeper_wake_enqueued { reaction_ledger_status; _ }) ->
             let counts = bump_wake_enqueued counts in
             (match reaction_ledger_status with

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -2557,7 +2557,6 @@ let schedule_keeper_queue_evidence_dashboard_json
             [ "projection_status", `String "unrecognized_receipt"
             ; "reason", `String reason
             ]
-        | Ok Server_schedule_consumers.Board_post_created _ -> `Null
         | Ok
             (Server_schedule_consumers.Keeper_wake_enqueued
               { keeper_name
@@ -2635,7 +2634,6 @@ let schedule_keeper_reaction_evidence_dashboard_json
             [ "projection_status", `String "unrecognized_receipt"
             ; "reason", `String reason
             ]
-        | Ok Server_schedule_consumers.Board_post_created _ -> `Null
         | Ok
             (Server_schedule_consumers.Keeper_wake_enqueued
               { keeper_name

--- a/lib/server/server_schedule_consumers.ml
+++ b/lib/server/server_schedule_consumers.ml
@@ -3,7 +3,6 @@
    loop logs aggregate dispatch counts for runtime telemetry. *)
 
 let supported_payload_kinds = Schedule_payload_projection.supported_payload_kinds
-let board_post_created_kind = "masc.board_post.created"
 let keeper_wake_enqueued_kind = "masc.keeper_wake.enqueued"
 let keeper_event_queue_label = "keeper_event_queue"
 let reaction_ledger_recorded_label = "recorded"
@@ -110,11 +109,6 @@ let keeper_wake_reaction_ledger_status_json_fields = function
 ;;
 
 type dispatch_receipt =
-  | Board_post_created of
-      { post_id : string
-      ; author : string
-      ; hearth : string option
-      }
   | Keeper_wake_enqueued of
       { keeper_name : string
       ; schedule_id : string
@@ -129,13 +123,7 @@ type dispatch_receipt =
 let dispatch_receipt_of_detail = function
   | `Assoc fields ->
     let* kind = string_field "kind" fields in
-    if String.equal kind board_post_created_kind
-    then
-      let* post_id = string_field "post_id" fields in
-      let* author = string_field "author" fields in
-      let* hearth = optional_string_field "hearth" fields in
-      Ok (Board_post_created { post_id; author; hearth })
-    else if String.equal kind keeper_wake_enqueued_kind
+    if String.equal kind keeper_wake_enqueued_kind
     then
       let* keeper_name = keeper_name_field "keeper_name" fields in
       let* schedule_id = string_field "schedule_id" fields in
@@ -163,13 +151,6 @@ let dispatch_receipt_of_detail = function
 ;;
 
 let dispatch_receipt_to_yojson = function
-  | Board_post_created { post_id; author; hearth } ->
-    `Assoc
-      [ "kind", `String board_post_created_kind
-      ; "post_id", `String post_id
-      ; "author", `String author
-      ; "hearth", (match hearth with None -> `Null | Some hearth -> `String hearth)
-      ]
   | Keeper_wake_enqueued
       { keeper_name
       ; schedule_id
@@ -202,66 +183,6 @@ let accepts request =
   | Error rejection ->
     record_unsupported_payload_dispatch request rejection;
     Error (Schedule_payload_projection.dispatch_rejection_message rejection)
-;;
-
-let schedule_meta_json (request : Schedule_domain.schedule_request) payload user_meta =
-  let base =
-    [ "source", `String "scheduled_automation"
-    ; "schedule_id", `String request.schedule_id
-    ; "payload_kind", `String (Schedule_payload_projection.view_kind payload)
-    ; "payload_digest", `String (Schedule_domain.payload_digest request.payload)
-    ; "requested_by", `String request.requested_by.id
-    ; "scheduled_by", `String request.scheduled_by.id
-    ; "due_at", `Float request.due_at
-    ]
-  in
-  match user_meta with
-  | None -> `Assoc base
-  | Some meta -> `Assoc (base @ [ "payload_meta", meta ])
-;;
-
-let dispatch_board_post request payload =
-  let* content = Schedule_payload_projection.body_required_string payload "content" in
-  let* title = Schedule_payload_projection.body_optional_string payload "title" in
-  let* author = Schedule_payload_projection.body_optional_string payload "author" in
-  let* hearth = Schedule_payload_projection.body_optional_string payload "hearth" in
-  let* thread_id = Schedule_payload_projection.body_optional_string payload "thread_id" in
-  let* ttl_hours = Schedule_payload_projection.body_optional_int payload "ttl_hours" in
-  let* user_meta = Schedule_payload_projection.body_optional_assoc payload "meta" in
-  let author =
-    (* DET-OK: absent board-post author maps to the stable scheduled automation
-       actor label for auditability. *)
-    match author with
-    | None -> "schedule-bot"
-    | Some author -> author
-  in
-  let meta_json = schedule_meta_json request payload user_meta in
-  match
-    Board_dispatch.create_post
-      ~author
-      ~content
-      ?title
-      ~post_kind:Board.System_post
-      ~meta_json
-      ~visibility:Board.Internal
-      ?ttl_hours
-      ?hearth
-      ?thread_id
-      ()
-  with
-  | Error err -> Error (Board_types.show_board_error err)
-  | Ok post ->
-    let post_id = Board.Post_id.to_string post.id in
-    Ok
-      (`Assoc
-        [ "kind", `String board_post_created_kind
-        ; "post_id", `String post_id
-        ; "author", `String author
-        ; ( "hearth"
-          , match hearth with
-            | None -> `Null
-            | Some hearth -> `String hearth )
-        ])
 ;;
 
 let body_keeper_name payload =
@@ -325,10 +246,18 @@ let dispatch_keeper_wake config ~now (request : Schedule_domain.schedule_request
     }
   in
   let stimulus_id = Keeper_reaction_ledger.stimulus_id_of_event_queue stimulus in
-  Keeper_registry_event_queue.enqueue
-    ~base_path:config.Workspace_utils.base_path
-    keeper_name
-    stimulus;
+  let* () =
+    match
+      Keeper_registry_event_queue.enqueue_stimulus_durable_result
+        ~base_path:config.Workspace_utils.base_path
+        keeper_name
+        stimulus
+    with
+    | Keeper_registry_event_queue.Stimulus_storage_error detail ->
+      Error ("scheduled keeper wake durable enqueue failed: " ^ detail)
+    | Keeper_registry_event_queue.Stimulus_enqueued
+    | Keeper_registry_event_queue.Stimulus_already_present -> Ok ()
+  in
   let wakeup_outcome =
     Keeper_registry.wakeup
       ~intent:Keeper_registry.Scheduled_signal
@@ -388,7 +317,6 @@ let dispatch config ~now request =
     Error (Schedule_payload_projection.dispatch_rejection_message rejection)
   | Ok (kind, payload) ->
     (match kind with
-     | Schedule_payload_projection.Board_post -> dispatch_board_post request payload
      | Schedule_payload_projection.Keeper_wake ->
        dispatch_keeper_wake config ~now request payload)
 ;;

--- a/lib/server/server_schedule_consumers.mli
+++ b/lib/server/server_schedule_consumers.mli
@@ -5,11 +5,6 @@ type keeper_wake_reaction_ledger_status =
   | Keeper_wake_reaction_ledger_record_failed of string
 
 type dispatch_receipt =
-  | Board_post_created of
-      { post_id : string
-      ; author : string
-      ; hearth : string option
-      }
   | Keeper_wake_enqueued of
       { keeper_name : string
       ; schedule_id : string

--- a/lib/tool_schedule.ml
+++ b/lib/tool_schedule.ml
@@ -120,78 +120,6 @@ let actor_from_args args ~prefix ~default_id ~default_kind =
   else Ok Schedule_domain.{ id; kind; display_name }
 ;;
 
-let has_arg args key = Option.is_some (Json_util.assoc_member_opt key args)
-
-let has_board_convenience_args args =
-  List.exists
-    (has_arg args)
-    [ "board_content"
-    ; "board_title"
-    ; "board_hearth"
-    ; "board_author"
-    ; "board_thread_id"
-    ; "board_ttl_hours"
-    ; "board_meta"
-    ]
-;;
-
-let optional_body_string args ~arg ~field fields =
-  match string_opt args arg with
-  | None -> Ok fields
-  | Some value -> Ok ((field, `String value) :: fields)
-;;
-
-let optional_body_int args ~arg ~field fields =
-  match Json_util.assoc_member_opt arg args with
-  | None -> Ok fields
-  | Some (`Int value) -> Ok ((field, `Int value) :: fields)
-  | Some _ -> Error (arg ^ " must be an integer")
-;;
-
-let optional_nonnegative_body_int args ~arg ~field fields =
-  match Json_util.assoc_member_opt arg args with
-  | None -> Ok fields
-  | Some (`Int value) when value >= 0 -> Ok ((field, `Int value) :: fields)
-  | Some (`Int _) -> Error (arg ^ " must be non-negative")
-  | Some _ -> Error (arg ^ " must be an integer")
-;;
-
-let optional_body_object args ~arg ~field fields =
-  match Json_util.assoc_member_opt arg args with
-  | None -> Ok fields
-  | Some (`Assoc _ as value) -> Ok ((field, value) :: fields)
-  | Some _ -> Error (arg ^ " must be an object")
-;;
-
-let board_post_payload_from_args args =
-  let* content = required_string args "board_content" in
-  let schema_version =
-    (* DET-OK: board_* is a stable convenience projection for the existing
-       board-post v1 consumer. *)
-    optional_int args "payload_schema_version" |> Option.value ~default:1
-  in
-  if schema_version <> 1
-  then Error "board_* convenience fields only support payload_schema_version=1"
-  else
-    let* fields =
-      optional_body_string args ~arg:"board_title" ~field:"title"
-        [ "content", `String content ]
-    in
-    let* fields = optional_body_string args ~arg:"board_author" ~field:"author" fields in
-    let* fields = optional_body_string args ~arg:"board_hearth" ~field:"hearth" fields in
-    let* fields = optional_body_string args ~arg:"board_thread_id" ~field:"thread_id" fields in
-    let* fields =
-      optional_nonnegative_body_int args ~arg:"board_ttl_hours" ~field:"ttl_hours" fields
-    in
-    let* fields = optional_body_object args ~arg:"board_meta" ~field:"meta" fields in
-    Ok
-      (`Assoc
-        [ "kind", `String Schedule_supported_kinds.board_post
-        ; "schema_version", `Int schema_version
-        ; "body", `Assoc (List.rev fields)
-        ])
-;;
-
 let generic_payload_from_args args =
   let* kind = required_string args "payload_kind" in
   let schema_version =
@@ -212,28 +140,9 @@ let generic_payload_from_args args =
 
 let payload_from_args args =
   match Json_util.assoc_member_opt "payload" args with
-  | Some (`Assoc _ as payload) ->
-    if has_board_convenience_args args
-    then Error "use either payload or board_* convenience fields, not both"
-    else Ok payload
+  | Some (`Assoc _ as payload) -> Ok payload
   | Some _ -> Error "payload must be an object envelope"
-  | None ->
-    if has_board_convenience_args args
-    then
-      if has_arg args "payload_body"
-      then Error "use either payload_body or board_* convenience fields, not both"
-      else
-        (match string_opt args "payload_kind" with
-         | None -> board_post_payload_from_args args
-         | Some kind when String.equal kind Schedule_supported_kinds.board_post ->
-           board_post_payload_from_args args
-         | Some kind ->
-           Error
-             ("board_* convenience fields require payload_kind omitted or "
-              ^ Schedule_supported_kinds.board_post
-              ^ ", got "
-              ^ kind))
-    else generic_payload_from_args args
+  | None -> generic_payload_from_args args
 ;;
 
 let schedule_payload_unsupported_labels ~phase = [ "phase", phase ]

--- a/lib/tool_schemas/tool_schemas_schedule.ml
+++ b/lib/tool_schemas/tool_schemas_schedule.ml
@@ -87,27 +87,15 @@ let create_schema =
         "payload"
     ; string_prop
         ~description:
-          "Payload kind used when payload is omitted. Supported server consumers today: masc.board_post and masc.keeper_wake."
+          "Payload kind used when payload is omitted. The server consumer accepts masc.keeper_wake."
         "payload_kind"
     ; integer_prop
         ~description:"Payload schema version used when payload is omitted."
         "payload_schema_version"
     ; object_prop
         ~description:
-          "Payload body used when payload is omitted. For board posts, prefer the board_* convenience fields unless you need the raw envelope. For masc.keeper_wake use {keeper_name, message, optional title, optional urgency}."
+          "Payload body used when payload is omitted. For masc.keeper_wake use {keeper_name, message, optional title, optional urgency}."
         "payload_body"
-    ; string_prop
-        ~description:
-          "Convenience for scheduling a board post. When payload/payload_body are omitted, this builds payload kind masc.board_post with schema_version=1."
-        "board_content"
-    ; string_prop ~description:"Optional board-post title." "board_title"
-    ; string_prop
-        ~description:"Optional board hearth/destination for the scheduled post."
-        "board_hearth"
-    ; string_prop ~description:"Optional board post author. Defaults at dispatch time." "board_author"
-    ; string_prop ~description:"Optional board thread id." "board_thread_id"
-    ; integer_prop ~description:"Optional board post TTL in hours." "board_ttl_hours"
-    ; object_prop ~description:"Optional board post metadata object." "board_meta"
     ; string_prop ~description:"Optional stable schedule id." "schedule_id"
     ; number_prop ~description:"Optional request timestamp for replay/tests." "requested_at_unix"
     ; number_prop ~description:"Optional expiry timestamp." "expires_at_unix"
@@ -186,7 +174,7 @@ let definition ~action ~id ~name ~description ~input_schema ~read_only =
 let definitions : definition list =
   [ definition ~action:Create_request ~id:"create" ~name:"masc_schedule_create"
       ~description:
-        "Create a durable scheduled internal automation request. For 'every day at 09:00 KST', use recurrence_kind=daily, recurrence_hour=9, recurrence_minute=0, recurrence_timezone=Asia/Seoul. For 'post this to board ops every morning', use board_content plus optional board_title/board_hearth. For compact calendar rules, use recurrence_kind=cron with a 5-field recurrence_cron such as '0 9 * * 1-5'. Payload effects are authorized by their leaf tool at dispatch time."
+        "Create a durable Keeper wake request. For 'every day at 09:00 KST', use recurrence_kind=daily, recurrence_hour=9, recurrence_minute=0, recurrence_timezone=Asia/Seoul. For compact calendar rules, use recurrence_kind=cron with a 5-field recurrence_cron such as '0 9 * * 1-5'. The due request wakes its Keeper lane; it does not authorize later effects."
       ~input_schema:create_schema ~read_only:false
   ; definition ~action:List_requests ~id:"list" ~name:"masc_schedule_list"
       ~description:"List durable scheduled internal automation requests."

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -207,51 +207,21 @@ let runner_status_json_after_dispatches (result : Schedule_runner.tick_result) =
   |> Schedule_runner_status.snapshot_to_yojson ~now:201.5 ~stale_after_sec:10.0
 ;;
 
-let test_board_post_consumer_creates_post_and_succeeds_schedule () =
+let test_board_post_schedule_is_rejected_without_mutation () =
   with_workspace
   @@ fun config ->
   let request = create_board_schedule config in
-  check string "initial status" "scheduled"
-    (Schedule_domain.schedule_status_to_string request.status);
   let result = tick_ok config ~now:201.0 in
   check int "one dispatch" 1 (List.length result.dispatches);
-  check string "dispatch status" "succeeded"
+  check string "dispatch status" "unsupported"
     (Schedule_runner.dispatch_status_to_string (List.hd result.dispatches).status);
   (match Schedule_store.get_schedule config ~schedule_id:request.schedule_id with
    | None -> fail "schedule missing"
    | Some stored ->
-     check string "schedule succeeded" "succeeded"
+     check string "schedule failed" "failed"
        (Schedule_domain.schedule_status_to_string stored.status));
-  (match
-     Schedule_store.last_execution_for_schedule (Schedule_store.read_state config)
-       ~schedule_id:request.schedule_id
-   with
-   | None -> fail "missing execution record"
-   | Some execution ->
-     check string "execution status" "succeeded"
-       (Schedule_domain.execution_status_to_string execution.status);
-     (match execution.detail with
-      | Some detail ->
-        let open Yojson.Safe.Util in
-        check string "execution detail kind" "masc.board_post.created"
-          (detail |> member "kind" |> to_string)
-      | None -> fail "execution detail missing"));
-  match Board_dispatch.list_posts ~hearth:"ops" ~limit:10 () with
-  | [ post ] ->
-    check string "title" "Scheduled check-in" post.Board.title;
-    check string "content" "Daily schedule fired" post.content;
-    check string "author" "schedule-bot" (Board.Agent_id.to_string post.author);
-    (match post.meta_json with
-     | Some meta ->
-       let open Yojson.Safe.Util in
-       check string "meta source" "scheduled_automation"
-         (meta |> member "source" |> to_string);
-       check string "meta schedule" request.schedule_id
-         (meta |> member "schedule_id" |> to_string);
-       check string "payload meta" "test"
-         (meta |> member "payload_meta" |> member "purpose" |> to_string)
-     | None -> fail "expected schedule meta")
-  | posts -> failf "expected one board post, got %d" (List.length posts)
+  check int "board remains unchanged" 0
+    (List.length (Board_dispatch.list_posts ~limit:10 ()))
 ;;
 
 let test_keeper_wake_consumer_enqueues_typed_stimulus_and_succeeds_schedule () =
@@ -374,6 +344,38 @@ let test_keeper_wake_consumer_enqueues_typed_stimulus_and_succeeds_schedule () =
       (queue_evidence |> member "inflight_count" |> to_int);
     check int "queue evidence read errors" 0
       (queue_evidence |> member "read_errors" |> to_list |> List.length)
+;;
+
+let test_keeper_wake_durable_enqueue_failure_is_not_success () =
+  with_workspace
+  @@ fun config ->
+  let keeper_owner_path =
+    Filename.concat
+      (Common.keepers_runtime_dir_of_base
+         ~base_path:config.Workspace_utils.base_path)
+      "schedule-keeper"
+  in
+  mkdir_p (Filename.dirname keeper_owner_path);
+  write_empty_file keeper_owner_path;
+  let request = create_keeper_wake_schedule config in
+  let result = tick_ok config ~now:201.0 in
+  (match List.hd result.dispatches with
+   | { status = Schedule_runner.Dispatch_failed; error = Some message; _ } ->
+     check bool "storage failure is explicit" true
+       (String_util.contains_substring
+          message
+          "scheduled keeper wake durable enqueue failed")
+   | _ -> fail "durable enqueue failure must not report dispatch success");
+  (match Schedule_store.get_schedule config ~schedule_id:request.schedule_id with
+   | None -> fail "schedule missing"
+   | Some stored ->
+     check string "schedule did not report success" "failed"
+       (Schedule_domain.schedule_status_to_string stored.status));
+  check int "failed commit leaves no queued wake" 0
+    (Keeper_event_queue.length
+       (Keeper_registry_event_queue.snapshot
+          ~base_path:config.Workspace_utils.base_path
+          "schedule-keeper"))
 ;;
 
 let test_keeper_wake_queue_evidence_rejects_stale_occurrence () =
@@ -749,11 +751,13 @@ let test_keeper_wake_consumer_rejects_invalid_keeper_name () =
 
 let () =
   run "Schedule_consumer_dispatch"
-    [ ( "board_post"
-      , [ test_case "creates board post and succeeds schedule" `Quick
-            test_board_post_consumer_creates_post_and_succeeds_schedule
+    [ ( "keeper_wake"
+      , [ test_case "board post schedule is rejected without mutation" `Quick
+            test_board_post_schedule_is_rejected_without_mutation
         ; test_case "keeper wake enqueues typed stimulus" `Quick
             test_keeper_wake_consumer_enqueues_typed_stimulus_and_succeeds_schedule
+        ; test_case "keeper wake durable enqueue failure is not success" `Quick
+            test_keeper_wake_durable_enqueue_failure_is_not_success
         ; test_case "keeper wake queue evidence rejects stale occurrence" `Quick
             test_keeper_wake_queue_evidence_rejects_stale_occurrence
         ; test_case "dashboard live supported non-terminal evidence matches supported request"

--- a/test/test_schedule_tool_wiring.ml
+++ b/test/test_schedule_tool_wiring.ml
@@ -180,6 +180,28 @@ let test_create_list_get_cancel () =
      |> to_string)
 ;;
 
+let test_removed_convenience_input_does_not_synthesize_payload () =
+  with_config
+  @@ fun config ->
+  let result =
+    dispatch_exn config Tool_schemas_schedule.Create_request
+      (`Assoc
+        [ "schedule_id", `String "sched-removed-convenience"
+        ; "due_at_unix", `Float 200.0
+        ; "board_content", `String "must not become a scheduled product effect"
+        ; "requested_by_id", `String "operator"
+        ; "scheduled_by_id", `String "scheduler-agent"
+        ])
+  in
+  check bool "removed convenience input rejected" false (Tool_result.is_success result);
+  check bool "neutral payload contract names the missing field" true
+    (String_util.contains_substring
+       (Tool_result.message result)
+       "payload_kind is required");
+  check int "removed convenience input is not persisted" 0
+    (List.length (Schedule_store.read_state config).schedules)
+;;
+
 let test_unknown_payload_is_rejected_before_persistence () =
   with_config
   @@ fun config ->
@@ -329,6 +351,8 @@ let () =
     [ ( "wiring"
       , [ test_case "flat tool surface" `Quick test_flat_tool_surface
         ; test_case "create list get cancel" `Quick test_create_list_get_cancel
+        ; test_case "removed convenience input does not synthesize payload" `Quick
+            test_removed_convenience_input_does_not_synthesize_payload
         ; test_case "unknown payload rejected before persistence" `Quick
             test_unknown_payload_is_rejected_before_persistence
         ; test_case "payload contracts are schema only" `Quick

--- a/test/test_schedule_tool_wiring.ml
+++ b/test/test_schedule_tool_wiring.ml
@@ -32,11 +32,15 @@ let automated id : Schedule_domain.actor =
   { id; kind = Schedule_domain.Automated_actor; display_name = None }
 ;;
 
-let board_payload content =
+let keeper_wake_payload message =
   `Assoc
-    [ "kind", `String Schedule_supported_kinds.board_post
+    [ "kind", `String Schedule_supported_kinds.keeper_wake
     ; "schema_version", `Int 1
-    ; "body", `Assoc [ "content", `String content ]
+    ; ( "body"
+      , `Assoc
+          [ "keeper_name", `String "schedule-keeper"
+          ; "message", `String message
+          ] )
     ]
 ;;
 
@@ -67,10 +71,15 @@ let dispatch_exn config action args =
   | None -> fail ("schedule dispatch returned None: " ^ name)
 ;;
 
-let create_args ?schedule_id ?(content = "scheduled board post") () =
+let create_args ?schedule_id ?(message = "scheduled keeper wake") () =
   `Assoc
     ([ "due_at_unix", `Float 200.0
-     ; "board_content", `String content
+     ; "payload_kind", `String Schedule_supported_kinds.keeper_wake
+     ; ( "payload_body"
+       , `Assoc
+           [ "keeper_name", `String "schedule-keeper"
+           ; "message", `String message
+           ] )
      ; "requested_by_id", `String "operator"
      ; "scheduled_by_id", `String "scheduler-agent"
      ]
@@ -211,7 +220,7 @@ let test_payload_contracts_are_schema_only () =
     Schedule_payload_projection.supported_contracts_to_yojson ()
     |> Yojson.Safe.Util.to_list
   in
-  check int "two supported contracts" 2 (List.length contracts);
+  check int "one supported contract" 1 (List.length contracts);
   List.iter
     (fun contract ->
        let open Yojson.Safe.Util in
@@ -268,7 +277,7 @@ let test_due_signal_and_dashboard_projection () =
   @@ fun config ->
   let request =
     create_service_exn config ~schedule_id:"sched-signal" ~due_at:200.0
-      ~payload:(board_payload "signal me")
+      ~payload:(keeper_wake_payload "signal me")
   in
   let tick =
     match Schedule_runner.tick config ~now:201.0 with


### PR DESCRIPTION
## What changed

- remove direct Board mutation from the Scheduler consumer
- accept only typed Keeper wake payloads at the production dispatch boundary
- require durable queue commit before wakeup, reaction ledger, or success receipt
- reject persisted legacy Board schedules explicitly without mutating Board state

## Why

Scheduler owns time and occurrence signaling, not product effects or standing authority. A queue write failure was also logged and then reported as dispatch success.

## Stack

This is the effect-boundary slice. A small child PR removes the now-inaccessible legacy `board_*` parser and Board payload constant so the creation surface also becomes fully product-blind.

## Validation

- `scripts/dune-local.sh build test/test_schedule_consumer_dispatch.exe test/test_schedule_tool_wiring.exe`
- Schedule consumer dispatch: 9/9 passed
- Schedule tool wiring: 7/7 passed
- `git diff --check`

Diff: +81/-279, 360 total changed lines.