### PR TITLE
refactor(schedule): purge product-specific tool inputs

### DIFF
--- a/lib/schedule/schedule_supported_kinds.ml
+++ b/lib/schedule/schedule_supported_kinds.ml
@@ -15,7 +15,6 @@
     without a validator branch stays rejected at creation as an unsupported
     kind. So a new kind needs both the list entry and a validator branch. *)
 
-let board_post = "masc.board_post"
 let keeper_wake = "masc.keeper_wake"
 
 let supported = [ keeper_wake ]

--- a/lib/schedule/schedule_supported_kinds.mli
+++ b/lib/schedule/schedule_supported_kinds.mli
@@ -6,7 +6,6 @@
     full design rationale. Neither layer reaches across the
     [lib/tool] <-> [lib/server] boundary. *)
 
-val board_post : string
 val keeper_wake : string
 
 val supported : string list

--- a/lib/tool_schedule.ml
+++ b/lib/tool_schedule.ml
@@ -120,78 +120,6 @@ let actor_from_args args ~prefix ~default_id ~default_kind =
   else Ok Schedule_domain.{ id; kind; display_name }
 ;;
 
-let has_arg args key = Option.is_some (Json_util.assoc_member_opt key args)
-
-let has_board_convenience_args args =
-  List.exists
-    (has_arg args)
-    [ "board_content"
-    ; "board_title"
-    ; "board_hearth"
-    ; "board_author"
-    ; "board_thread_id"
-    ; "board_ttl_hours"
-    ; "board_meta"
-    ]
-;;
-
-let optional_body_string args ~arg ~field fields =
-  match string_opt args arg with
-  | None -> Ok fields
-  | Some value -> Ok ((field, `String value) :: fields)
-;;
-
-let optional_body_int args ~arg ~field fields =
-  match Json_util.assoc_member_opt arg args with
-  | None -> Ok fields
-  | Some (`Int value) -> Ok ((field, `Int value) :: fields)
-  | Some _ -> Error (arg ^ " must be an integer")
-;;
-
-let optional_nonnegative_body_int args ~arg ~field fields =
-  match Json_util.assoc_member_opt arg args with
-  | None -> Ok fields
-  | Some (`Int value) when value >= 0 -> Ok ((field, `Int value) :: fields)
-  | Some (`Int _) -> Error (arg ^ " must be non-negative")
-  | Some _ -> Error (arg ^ " must be an integer")
-;;
-
-let optional_body_object args ~arg ~field fields =
-  match Json_util.assoc_member_opt arg args with
-  | None -> Ok fields
-  | Some (`Assoc _ as value) -> Ok ((field, value) :: fields)
-  | Some _ -> Error (arg ^ " must be an object")
-;;
-
-let board_post_payload_from_args args =
-  let* content = required_string args "board_content" in
-  let schema_version =
-    (* DET-OK: board_* is a stable convenience projection for the existing
-       board-post v1 consumer. *)
-    optional_int args "payload_schema_version" |> Option.value ~default:1
-  in
-  if schema_version <> 1
-  then Error "board_* convenience fields only support payload_schema_version=1"
-  else
-    let* fields =
-      optional_body_string args ~arg:"board_title" ~field:"title"
-        [ "content", `String content ]
-    in
-    let* fields = optional_body_string args ~arg:"board_author" ~field:"author" fields in
-    let* fields = optional_body_string args ~arg:"board_hearth" ~field:"hearth" fields in
-    let* fields = optional_body_string args ~arg:"board_thread_id" ~field:"thread_id" fields in
-    let* fields =
-      optional_nonnegative_body_int args ~arg:"board_ttl_hours" ~field:"ttl_hours" fields
-    in
-    let* fields = optional_body_object args ~arg:"board_meta" ~field:"meta" fields in
-    Ok
-      (`Assoc
-        [ "kind", `String Schedule_supported_kinds.board_post
-        ; "schema_version", `Int schema_version
-        ; "body", `Assoc (List.rev fields)
-        ])
-;;
-
 let generic_payload_from_args args =
   let* kind = required_string args "payload_kind" in
   let schema_version =
@@ -212,28 +140,9 @@ let generic_payload_from_args args =
 
 let payload_from_args args =
   match Json_util.assoc_member_opt "payload" args with
-  | Some (`Assoc _ as payload) ->
-    if has_board_convenience_args args
-    then Error "use either payload or board_* convenience fields, not both"
-    else Ok payload
+  | Some (`Assoc _ as payload) -> Ok payload
   | Some _ -> Error "payload must be an object envelope"
-  | None ->
-    if has_board_convenience_args args
-    then
-      if has_arg args "payload_body"
-      then Error "use either payload_body or board_* convenience fields, not both"
-      else
-        (match string_opt args "payload_kind" with
-         | None -> board_post_payload_from_args args
-         | Some kind when String.equal kind Schedule_supported_kinds.board_post ->
-           board_post_payload_from_args args
-         | Some kind ->
-           Error
-             ("board_* convenience fields require payload_kind omitted or "
-              ^ Schedule_supported_kinds.board_post
-              ^ ", got "
-              ^ kind))
-    else generic_payload_from_args args
+  | None -> generic_payload_from_args args
 ;;
 
 let schedule_payload_unsupported_labels ~phase = [ "phase", phase ]

--- a/test/test_schedule_tool_wiring.ml
+++ b/test/test_schedule_tool_wiring.ml
@@ -180,6 +180,28 @@ let test_create_list_get_cancel () =
      |> to_string)
 ;;
 
+let test_removed_convenience_input_does_not_synthesize_payload () =
+  with_config
+  @@ fun config ->
+  let result =
+    dispatch_exn config Tool_schemas_schedule.Create_request
+      (`Assoc
+        [ "schedule_id", `String "sched-removed-convenience"
+        ; "due_at_unix", `Float 200.0
+        ; "board_content", `String "must not become a scheduled product effect"
+        ; "requested_by_id", `String "operator"
+        ; "scheduled_by_id", `String "scheduler-agent"
+        ])
+  in
+  check bool "removed convenience input rejected" false (Tool_result.is_success result);
+  check bool "neutral payload contract names the missing field" true
+    (String_util.contains_substring
+       (Tool_result.message result)
+       "payload_kind is required");
+  check int "removed convenience input is not persisted" 0
+    (List.length (Schedule_store.read_state config).schedules)
+;;
+
 let test_unknown_payload_is_rejected_before_persistence () =
   with_config
   @@ fun config ->
@@ -329,6 +351,8 @@ let () =
     [ ( "wiring"
       , [ test_case "flat tool surface" `Quick test_flat_tool_surface
         ; test_case "create list get cancel" `Quick test_create_list_get_cancel
+        ; test_case "removed convenience input does not synthesize payload" `Quick
+            test_removed_convenience_input_does_not_synthesize_payload
         ; test_case "unknown payload rejected before persistence" `Quick
             test_unknown_payload_is_rejected_before_persistence
         ; test_case "payload contracts are schema only" `Quick


### PR DESCRIPTION
Stacked on #24524.

Scheduler의 Tool 경계에서 Board 제품 의미를 완전히 제거합니다.

- `board_*` convenience parser 및 Board payload 합성 삭제
- `Schedule_supported_kinds.board_post` 삭제
- neutral `payload` 또는 `payload_kind`/`payload_body`만 허용
- 제거된 입력은 묵살하지 않고 명시 실패하며 schedule을 저장하지 않음

Focused proof:
- schedule tool wiring: 8/8
- schedule consumer dispatch: 9/9
- focused wrapper build, ocamlformat, diff check: green

Diff: +26/-95 (121 changed lines).