### PR TITLE
refactor(fs): purge recovery compatibility surfaces

### DIFF
--- a/lib/dashboard/dashboard_briefing.ml
+++ b/lib/dashboard/dashboard_briefing.ml
@@ -332,8 +332,7 @@ let build_projection ?actor ~config ~sw ~clock
       net = None;
       (* Briefing projections call only snapshot/digest reads; no Keeper lane
          action is reachable through this context. *)
-      publication_recovery_provider =
-        Keeper_publication_recovery_availability.non_runtime_provider;
+      delegated_dispatch = None;
       mcp_session_id = None;
     }
   in

--- a/lib/dashboard/dashboard_briefing_sections.ml
+++ b/lib/dashboard/dashboard_briefing_sections.ml
@@ -129,8 +129,7 @@ let compute_briefing_json ~actor_name ~config ~sw ~(clock : [> float Eio.Time.cl
         proc_mgr;
         net = None;
         (* Briefing sections use the read-only snapshot projection only. *)
-        publication_recovery_provider =
-          Keeper_publication_recovery_availability.non_runtime_provider;
+        delegated_dispatch = None;
         mcp_session_id = None;
       }
     in

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -628,8 +628,7 @@ let json_render ~effective_actor ~light ~config ~sw ~clock ~proc_mgr () =
     ; net = None
     (* Execution renders call only the read-only operator snapshot projection;
        this context cannot dispatch a Keeper lane action. *)
-    ; publication_recovery_provider =
-        Keeper_publication_recovery_availability.non_runtime_provider
+    ; delegated_dispatch = None
     ; mcp_session_id = None
     }
   in

--- a/lib/fs_compat/atomic_write.ml
+++ b/lib/fs_compat/atomic_write.ml
@@ -52,11 +52,6 @@ type atomic_replace_recovery_target =
   ; permissions : Recovery.permissions
   }
 
-type publication_recovery_access = Recovery_access.t
-type publication_recovery_registry = Recovery_access.registry
-type publication_recovery_registry_error = Recovery.transition_error
-type publication_recovery_lane_open_error = Recovery_access.lane_open_error
-type publication_recovery_owner = Recovery_access.owner
 type publication_recovery_reconciliation_report =
   Capability_recovery_reconciler.report
 
@@ -106,9 +101,6 @@ type publication_recovery_reconciliation_row_kind =
   | Publication_recovery_owner_store_release_failed
   | Publication_recovery_owner_store_unavailable
   | Publication_recovery_owner_inventory_unavailable
-
-let open_publication_recovery_registry = Recovery_access.open_registry
-let publication_recovery_registry_error_to_string = Recovery.transition_error_to_string
 
 let publication_recovery_reconciliation_report_owner =
   Capability_recovery_reconciler.report_owner
@@ -210,12 +202,6 @@ let publication_recovery_reconciliation_report_to_yojson =
   Capability_recovery_reconciler.report_to_yojson
 ;;
 
-let with_publication_recovery_lane = Recovery_access.with_lane
-
-let publication_recovery_lane_open_error_to_string =
-  Recovery_access.lane_open_error_to_string
-;;
-
 let atomic_replace_recovery_target_error_to_string = function
   | Recovery_target_validation_failed error ->
     Recovery.validation_error_to_string error
@@ -300,6 +286,37 @@ type capability_write_stage =
   | Cleanup_remove_staging_directory
   | Cleanup_close_staging_directory
   | Cleanup_sync_parent
+
+type replace_dispatch_fault =
+  | Raise_before_stage of
+      { fault_stage : capability_write_stage
+      ; fault_exception : exn
+      }
+  | Remove_staging_payload_before_publish
+
+(* TEL-OK: this fiber key carries a typed test fault plan; no write occurs here. *)
+let replace_dispatch_fault_key
+      : replace_dispatch_fault Eio.Fiber.key
+  =
+  Eio.Fiber.create_key ()
+;;
+
+let no_replace_stage _ = ()
+let no_before_publish _ = ()
+(* TEL-OK: this constant only selects the no-fault callback pair. *)
+let no_replace_dispatch = no_replace_stage, no_before_publish
+
+(* TEL-OK: this lookup only selects callbacks for the typed write operation. *)
+let scoped_replace_dispatch () =
+  match Eio.Fiber.get replace_dispatch_fault_key with
+  | None -> no_replace_dispatch
+  | Some Remove_staging_payload_before_publish ->
+    no_replace_stage, Eio.Path.unlink
+  | Some (Raise_before_stage fault) ->
+    ( (fun stage ->
+        if stage = fault.fault_stage then raise fault.fault_exception)
+    , no_before_publish )
+;;
 
 type capability_write_target_effect =
   | Target_unchanged
@@ -408,7 +425,7 @@ type capability_directory_sync_error =
   }
 
 type publication_recovery_fixture_error =
-  | Fixture_lane_open_failed of publication_recovery_lane_open_error
+  | Fixture_lane_open_failed of Recovery_access.lane_open_error
   | Fixture_validation_failed of Recovery.validation_error
   | Fixture_transition_failed of Recovery.transition_error
   | Fixture_invalid_record_leaf of string
@@ -419,7 +436,7 @@ type publication_recovery_fixture_error =
 
 let publication_recovery_fixture_error_to_string = function
   | Fixture_lane_open_failed error ->
-    publication_recovery_lane_open_error_to_string error
+    Recovery_access.lane_open_error_to_string error
   | Fixture_validation_failed error -> Recovery.validation_error_to_string error
   | Fixture_transition_failed error -> Recovery.transition_error_to_string error
   | Fixture_invalid_record_leaf value ->
@@ -1239,6 +1256,7 @@ let cleanup_owned_staging_directory
 
 let replace_capability_file_with
       ~before_stage
+      ~before_publish
       ~recovery
       ~parent
       ~target:recovery_target
@@ -1588,6 +1606,7 @@ let replace_capability_file_with
                Verify_target_binding
                Resource_identity_changed;
            run_stage ~before_stage Publish_replace (fun () ->
+             before_publish entry;
              try Eio.Path.rename entry target_path with
              | Eio.Cancel.Cancelled _ as cancellation ->
                target_effect := Target_state_unknown;
@@ -1965,6 +1984,7 @@ let create_capability_file_exclusive_with
 
 let replace_capability_file_through_access
       ~before_stage
+      ~before_publish
       ~recovery
       ~parent
       ~target
@@ -1978,6 +1998,7 @@ let replace_capability_file_through_access
         let result =
           replace_capability_file_with
             ~before_stage
+            ~before_publish
             ~recovery
             ~parent
             ~target
@@ -2026,8 +2047,11 @@ let replace_capability_file_through_access
 ;;
 
 let replace_capability_file ~recovery ~parent ~target content =
+  (* TEL-OK: callback selection is not an action; the write returns typed effect evidence. *)
+  let before_stage, before_publish = scoped_replace_dispatch () in
   replace_capability_file_through_access
-    ~before_stage:(fun _ -> ())
+    ~before_stage
+    ~before_publish
     ~recovery
     ~parent
     ~target
@@ -2069,6 +2093,23 @@ let sync_directory_capability directory =
 ;;
 
 module Capability_write_for_testing = struct
+  type nonrec replace_dispatch_fault = replace_dispatch_fault
+
+  (* TEL-OK: this constructor describes a scoped test fault; it performs no write. *)
+  let replace_dispatch_fault ~stage ~exception_ =
+    Raise_before_stage
+      { fault_stage = stage; fault_exception = exception_ }
+  ;;
+
+  let remove_staging_payload_before_publish () =
+    Remove_staging_payload_before_publish
+  ;;
+
+  (* TEL-OK: this installs a fiber-local test plan; the exercised write reports effects. *)
+  let with_replace_dispatch_fault fault f =
+    Eio.Fiber.with_binding replace_dispatch_fault_key fault f
+  ;;
+
   type resource_scope_callback =
     | Return_completed_rows of string list
     | Cancel_callback of exn
@@ -2274,6 +2315,7 @@ module Capability_write_for_testing = struct
     =
     replace_capability_file_through_access
       ~before_stage
+      ~before_publish:no_before_publish
       ~recovery
       ~parent
       ~target

--- a/lib/fs_compat/atomic_write.mli
+++ b/lib/fs_compat/atomic_write.mli
@@ -37,11 +37,6 @@ val open_atomic_temp_file : temp_dir:string -> unit -> string * out_channel
 
 type atomic_replace_recovery_target
 type atomic_replace_recovery_target_error
-type publication_recovery_access = Publication_recovery_access.t
-type publication_recovery_registry = Publication_recovery_access.registry
-type publication_recovery_registry_error = Capability_recovery_obligation.transition_error
-type publication_recovery_lane_open_error = Publication_recovery_access.lane_open_error
-type publication_recovery_owner = Publication_recovery_access.owner
 type publication_recovery_reconciliation_report = Capability_recovery_reconciler.report
 
 type publication_recovery_record_area =
@@ -91,16 +86,6 @@ type publication_recovery_reconciliation_row_kind =
   | Publication_recovery_owner_store_unavailable
   | Publication_recovery_owner_inventory_unavailable
 
-val open_publication_recovery_registry
-  :  sw:Eio.Switch.t
-  -> fs:Eio.Fs.dir_ty Eio.Path.t
-  -> registry_root:Eio.Fs.dir_ty Eio.Path.t
-  -> (publication_recovery_registry, publication_recovery_registry_error) result
-
-val publication_recovery_registry_error_to_string
-  :  publication_recovery_registry_error
-  -> string
-
 val publication_recovery_reconciliation_report_owner
   :  publication_recovery_reconciliation_report
   -> string
@@ -127,14 +112,6 @@ val publication_recovery_reconciliation_report_to_string
 val publication_recovery_reconciliation_report_to_yojson
   :  publication_recovery_reconciliation_report
   -> Yojson.Safe.t
-
-val with_publication_recovery_lane
-  :  registry:publication_recovery_registry
-  -> owner:string
-  -> (publication_recovery_access -> 'a)
-  -> ('a Publication_recovery_access.lane_outcome,
-      publication_recovery_lane_open_error)
-       result
 
 (** Build the immutable recovery locator projection used by
     [replace_capability_file]. The allowed-root identity is caller-certified;
@@ -328,7 +305,7 @@ exception Capability_write_cancelled of exn * capability_write_cancellation
     target-parent sync all complete. No target tree is scanned during failure
     handling. *)
 val replace_capability_file
-  :  recovery:publication_recovery_access
+  :  recovery:Publication_recovery_access.t
   -> parent:Eio.Fs.dir_ty Eio.Path.t
   -> target:atomic_replace_recovery_target
   -> string
@@ -367,6 +344,22 @@ val capability_directory_sync_error_to_string
   -> string
 
 module Capability_write_for_testing : sig
+  type replace_dispatch_fault
+
+  val replace_dispatch_fault
+    :  stage:capability_write_stage
+    -> exception_:exn
+    -> replace_dispatch_fault
+
+  val remove_staging_payload_before_publish
+    :  unit
+    -> replace_dispatch_fault
+
+  val with_replace_dispatch_fault
+    :  replace_dispatch_fault
+    -> (unit -> 'a)
+    -> 'a
+
   type resource_scope_callback =
     | Return_completed_rows of string list
     | Cancel_callback of exn
@@ -451,15 +444,15 @@ module Capability_write_for_testing : sig
     -> cleanup_evidence
 
   val single_publication_recovery_borrow_balance
-    :  registry:publication_recovery_registry
+    :  registry:Publication_recovery_access.registry
     -> owner:string
-    -> (single_borrow_evidence, publication_recovery_lane_open_error) result
+    -> (single_borrow_evidence, Publication_recovery_access.lane_open_error) result
 
   val publication_recovery_stage_name : Uuidm.t -> string
 
   val replace_capability_file
     :  before_stage:(capability_write_stage -> unit)
-    -> recovery:publication_recovery_access
+    -> recovery:Publication_recovery_access.t
     -> parent:Eio.Fs.dir_ty Eio.Path.t
     -> target:atomic_replace_recovery_target
     -> string
@@ -474,7 +467,7 @@ module Capability_write_for_testing : sig
     -> (unit, capability_write_error) result
 
   val seed_prepared_publication_recovery
-    :  registry:publication_recovery_registry
+    :  registry:Publication_recovery_access.registry
     -> owner:string
     -> operation_id:Uuidm.t
     -> allowed_root_path:string
@@ -488,7 +481,7 @@ module Capability_write_for_testing : sig
     -> (unit, publication_recovery_fixture_error) result
 
   val seed_bound_publication_recovery
-    :  registry:publication_recovery_registry
+    :  registry:Publication_recovery_access.registry
     -> owner:string
     -> operation_id:Uuidm.t
     -> allowed_root_path:string
@@ -504,7 +497,7 @@ module Capability_write_for_testing : sig
     -> (unit, publication_recovery_fixture_error) result
 
   val write_raw_publication_recovery_record
-    :  registry:publication_recovery_registry
+    :  registry:Publication_recovery_access.registry
     -> owner:string
     -> area:publication_recovery_record_area
     -> record_name:string

--- a/lib/fs_compat/capability_recovery_obligation.ml
+++ b/lib/fs_compat/capability_recovery_obligation.ml
@@ -308,6 +308,23 @@ let owner_of_string value =
 let owner_to_string = Capability_leaf.to_string
 let equal_owner = Capability_leaf.equal
 
+type lane_scope_release_fault =
+  { fault_owner : owner
+  ; fault_exception : exn
+  }
+
+let lane_scope_release_fault_key
+      : lane_scope_release_fault Eio.Fiber.key
+  =
+  Eio.Fiber.create_key ()
+;;
+
+let matching_lane_scope_release_fault owner =
+  match Eio.Fiber.get lane_scope_release_fault_key with
+  | Some fault when equal_owner owner fault.fault_owner -> Some fault
+  | None | Some _ -> None
+;;
+
 let operation_id_to_string operation_id = Uuidm.to_string operation_id
 let equal_operation_id = Uuidm.equal
 let record_name = operation_id_to_string
@@ -1711,22 +1728,29 @@ let with_store ~registry ~owner ~on_release_failure f =
   let subject = Lane_root owner in
   let outcome =
     Resource_scope.run_resource_only @@ fun sw ->
+    Option.iter
+      (fun fault ->
+         Eio.Switch.on_release sw (fun () -> raise fault.fault_exception))
+      (matching_lane_scope_release_fault owner);
     match open_store_in_scope ~sw ~registry ~owner with
     | Error _ as error -> error
     | Ok store -> Ok (f store)
   in
   let release_failure =
-    Option.map
-      (fun ({ exception_; backtrace } as raised : Resource_scope.raised) ->
-         { failure =
-             resource_scope_failure
-               ~operation:Close_directory
-               ~subject
-               raised
-         ; exception_
-         ; backtrace
-         })
-      outcome.scope_failure
+    match outcome.callback with
+    | None -> None
+    | Some _ ->
+      Option.map
+        (fun ({ exception_; backtrace } as raised : Resource_scope.raised) ->
+           { failure =
+               resource_scope_failure
+                 ~operation:Close_directory
+                 ~subject
+                 raised
+           ; exception_
+           ; backtrace
+           })
+        outcome.scope_failure
   in
   Option.iter on_release_failure release_failure;
   match outcome.callback with
@@ -3097,6 +3121,18 @@ let record_forensic_bound ~(store : store) ~(bound : bound) ~outcome =
 ;;
 
 module For_testing = struct
+  type nonrec lane_scope_release_fault = lane_scope_release_fault
+
+  let lane_scope_release_fault ~owner ~exception_ =
+    match owner_of_string owner with
+    | Error _ as error -> error
+    | Ok fault_owner -> Ok { fault_owner; fault_exception = exception_ }
+  ;;
+
+  let with_lane_scope_release_fault fault f =
+    Eio.Fiber.with_binding lane_scope_release_fault_key fault f
+  ;;
+
   let operation_id_of_uuid operation_id = operation_id
 
   let prepare_with_operation_id

--- a/lib/fs_compat/capability_recovery_obligation.mli
+++ b/lib/fs_compat/capability_recovery_obligation.mli
@@ -535,6 +535,18 @@ type inventory = inventory_row list
 val inventory : store -> (inventory, transition_error) result
 
 module For_testing : sig
+  type lane_scope_release_fault
+
+  val lane_scope_release_fault
+    :  owner:string
+    -> exception_:exn
+    -> (lane_scope_release_fault, validation_error) result
+
+  val with_lane_scope_release_fault
+    :  lane_scope_release_fault
+    -> (unit -> 'a)
+    -> 'a
+
   val operation_id_of_uuid : Uuidm.t -> operation_id
 
   val prepare_with_operation_id

--- a/lib/fs_compat/capability_write_for_testing.ml
+++ b/lib/fs_compat/capability_write_for_testing.ml
@@ -1,0 +1,13 @@
+open Fs_compat_internal
+
+let replace_capability_file =
+  Atomic_write.Capability_write_for_testing.replace_capability_file
+;;
+
+let create_capability_file_exclusive =
+  Atomic_write.Capability_write_for_testing.create_capability_file_exclusive
+;;
+
+let sync_directory_capability =
+  Atomic_write.Capability_write_for_testing.sync_directory_capability
+;;

--- a/lib/fs_compat/capability_write_for_testing.mli
+++ b/lib/fs_compat/capability_write_for_testing.mli
@@ -1,0 +1,23 @@
+(** Workspace-only typed fault boundary for capability-write feature tests.
+    This module is not installed with [masc.fs_compat]. *)
+
+val replace_capability_file
+  :  before_stage:(Fs_compat.capability_write_stage -> unit)
+  -> recovery:Fs_compat.Publication_recovery.t
+  -> parent:Eio.Fs.dir_ty Eio.Path.t
+  -> target:Fs_compat.atomic_replace_recovery_target
+  -> string
+  -> (unit, Fs_compat.capability_write_error) result
+
+val create_capability_file_exclusive
+  :  before_stage:(Fs_compat.capability_write_stage -> unit)
+  -> parent:Eio.Fs.dir_ty Eio.Path.t
+  -> leaf:string
+  -> permissions:int
+  -> string
+  -> (unit, Fs_compat.capability_write_error) result
+
+val sync_directory_capability
+  :  before_stage:(Fs_compat.capability_write_stage -> unit)
+  -> _ Eio.Path.t
+  -> (unit, Fs_compat.capability_directory_sync_error) result

--- a/lib/fs_compat/dune
+++ b/lib/fs_compat/dune
@@ -1,10 +1,10 @@
 (include_subdirs no)
 
 (library
- (name fs_compat)
- (public_name masc.fs_compat)
+ (name fs_compat_internal)
+ (package masc)
+ (wrapped true)
  (modules
-  fs_compat
   mkdir_memo
   fd_cache
   owned_directory_chain
@@ -14,18 +14,35 @@
   capability_recovery_obligation
   capability_recovery_reconciler
   publication_recovery_access
-  publication_recovery_for_testing
   atomic_write
   blocking_write
   fd_write_all
   atomic_orphan_size_class)
- (private_modules
-  eio_resource_scope
-  capability_recovery_obligation
-  capability_recovery_reconciler
-  publication_recovery_access
-  atomic_write)
  ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
  (flags
   (:standard -w +4))
- (libraries eio eio.unix unix yojson optint uuidm digestif))
+ (libraries eio eio.unix unix yojson uuidm digestif))
+
+(library
+ (name fs_compat)
+ (public_name masc.fs_compat)
+ (modules fs_compat)
+ ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
+ (flags
+  (:standard -w +4))
+ (libraries fs_compat_internal eio eio.unix unix yojson uuidm digestif))
+
+(library
+ (name fs_compat_test_support)
+ (modules publication_recovery_for_testing capability_write_for_testing)
+ (flags
+  (:standard -w +4))
+ (libraries
+  fs_compat
+  fs_compat_internal
+  eio
+  eio.unix
+  unix
+  yojson
+  uuidm
+  digestif))

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -13,6 +13,8 @@
     @since 2026-02 - Keeper Emergent Identity v2.0
 *)
 
+open Fs_compat_internal
+
 module Atomic_orphan_size_class = Atomic_orphan_size_class
 
 (** Global fs — WORM Atomic (write-once at startup, read from any domain).
@@ -254,56 +256,20 @@ type atomic_replace_recovery_target = Atomic_write.atomic_replace_recovery_targe
 type atomic_replace_recovery_target_error =
   Atomic_write.atomic_replace_recovery_target_error
 
-module Publication_recovery = Publication_recovery_access
+module Publication_recovery = struct
+  include Publication_recovery_access
 
-module Publication_recovery_test_support = Publication_recovery_for_testing
+  type lane_open_error_category =
+    | Invalid_owner_category
+    | Reconciliation_blocked_category
+    | Store_failed_category
 
-module Publication_recovery_for_testing = struct
-  include Publication_recovery_test_support
-
-  let private_registry
-        (registry : Publication_recovery.registry)
-    : Publication_recovery_test_support.registry
-    =
-    registry
-  ;;
-
-  let public_lane_release_failure
-        (failure : Publication_recovery_test_support.lane_release_failure)
-    : Publication_recovery.lane_release_failure
-    =
-    failure
+  let lane_open_error_category = function
+    | Invalid_owner _ -> Invalid_owner_category
+    | Reconciliation_blocked _ -> Reconciliation_blocked_category
+    | Store_failed _ -> Store_failed_category
   ;;
 end
-
-type publication_recovery_access = Publication_recovery.t
-type publication_recovery_registry = Publication_recovery.registry
-type publication_recovery_registry_error = Publication_recovery.registry_error
-type publication_recovery_lane_open_error = Publication_recovery.lane_open_error
-
-type publication_recovery_lane_open_error_kind =
-  | Publication_recovery_invalid_owner
-  | Publication_recovery_reconciliation_blocked
-  | Publication_recovery_store_failed
-
-let open_publication_recovery_registry = Publication_recovery.open_registry
-
-let publication_recovery_registry_error_to_string =
-  Publication_recovery.registry_error_to_string
-;;
-
-let with_publication_recovery_lane = Publication_recovery.with_lane
-
-let publication_recovery_lane_open_error_to_string =
-  Publication_recovery.lane_open_error_to_string
-;;
-
-let publication_recovery_lane_open_error_kind = function
-  | Publication_recovery.Invalid_owner _ -> Publication_recovery_invalid_owner
-  | Publication_recovery.Reconciliation_blocked _ ->
-    Publication_recovery_reconciliation_blocked
-  | Publication_recovery.Store_failed _ -> Publication_recovery_store_failed
-;;
 
 let atomic_replace_recovery_target = Atomic_write.atomic_replace_recovery_target
 
@@ -507,20 +473,6 @@ let sync_directory_capability = Atomic_write.sync_directory_capability
 let capability_directory_sync_error_to_string =
   Atomic_write.capability_directory_sync_error_to_string
 ;;
-
-module Capability_write_for_testing = struct
-  let replace_capability_file =
-    Atomic_write.Capability_write_for_testing.replace_capability_file
-  ;;
-
-  let create_capability_file_exclusive =
-    Atomic_write.Capability_write_for_testing.create_capability_file_exclusive
-  ;;
-
-  let sync_directory_capability =
-    Atomic_write.Capability_write_for_testing.sync_directory_capability
-  ;;
-end
 
 let is_atomic_orphan_name = Atomic_write.is_atomic_orphan_name
 type atomic_orphan_cleanup_scope = Atomic_write.atomic_orphan_cleanup_scope =

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -3,6 +3,8 @@
     @since 2026-02 - Keeper Emergent Identity v2.0
 *)
 
+open Fs_compat_internal
+
 module Atomic_orphan_size_class = Atomic_orphan_size_class
 
 (** #9921: raised by mutating [Fs_compat] entry points
@@ -229,16 +231,24 @@ module Capability_append_for_testing : sig
     -> capability_append_outcome
 end
 
-type atomic_replace_recovery_target
-type atomic_replace_recovery_target_error
+type atomic_replace_recovery_target = Atomic_write.atomic_replace_recovery_target
+type atomic_replace_recovery_target_error = Atomic_write.atomic_replace_recovery_target_error
 
 module Publication_recovery : sig
-  type registry
-  type t
-  type owner
-  type registry_error
-  type lane_open_error
-  type lane_release_failure
+  type registry = Fs_compat_internal.Publication_recovery_access.registry
+  type t = Fs_compat_internal.Publication_recovery_access.t
+  type owner = Fs_compat_internal.Publication_recovery_access.owner
+  type registry_error =
+    Fs_compat_internal.Publication_recovery_access.registry_error
+  type lane_open_error =
+    Fs_compat_internal.Publication_recovery_access.lane_open_error
+  type lane_release_failure =
+    Fs_compat_internal.Publication_recovery_access.lane_release_failure
+
+  type lane_open_error_category =
+    | Invalid_owner_category
+    | Reconciliation_blocked_category
+    | Store_failed_category
 
   type owner_discovery_row =
     | Discovered_owner of owner
@@ -307,64 +317,8 @@ module Publication_recovery : sig
 
   val lane_open_error_to_string : lane_open_error -> string
   val lane_release_failure_to_string : lane_release_failure -> string
+  val lane_open_error_category : lane_open_error -> lane_open_error_category
 end
-
-(** Repository-test access to the private recovery state machine. Production
-    code must use the narrow [Publication_recovery] facade above. *)
-module Publication_recovery_for_testing :
-  sig
-    include module type of Publication_recovery_for_testing
-
-    val private_registry : Publication_recovery.registry -> registry
-    val public_lane_release_failure
-      :  lane_release_failure
-      -> Publication_recovery.lane_release_failure
-  end
-
-type publication_recovery_access = Publication_recovery.t
-type publication_recovery_registry = Publication_recovery.registry
-type publication_recovery_registry_error = Publication_recovery.registry_error
-type publication_recovery_lane_open_error = Publication_recovery.lane_open_error
-
-type publication_recovery_lane_open_error_kind =
-  | Publication_recovery_invalid_owner
-  | Publication_recovery_reconciliation_blocked
-  | Publication_recovery_store_failed
-
-(** Open the process-lifetime publication recovery registry below a
-    caller-owned MASC root capability. The registry remains valid for exactly
-    the lifetime of [sw]. *)
-val open_publication_recovery_registry
-  :  sw:Eio.Switch.t
-  -> fs:Eio.Fs.dir_ty Eio.Path.t
-  -> registry_root:Eio.Fs.dir_ty Eio.Path.t
-  -> (publication_recovery_registry, publication_recovery_registry_error) result
-
-val publication_recovery_registry_error_to_string
-  :  publication_recovery_registry_error
-  -> string
-
-(** Pin one Keeper-owned publication recovery lane for the whole callback.
-    Publications borrow its store through the opaque access value. Closing
-    rejects new borrows and drains every already-started borrow without a
-    timeout or retry budget. *)
-val with_publication_recovery_lane
-  :  registry:publication_recovery_registry
-  -> owner:string
-  -> (publication_recovery_access -> 'a)
-  -> ('a Publication_recovery.lane_outcome,
-      publication_recovery_lane_open_error)
-       result
-
-val publication_recovery_lane_open_error_to_string
-  :  publication_recovery_lane_open_error
-  -> string
-
-(** Constructor-directed public classification. The category never contains
-    owner names, recovery records, paths, operation IDs, or exception text. *)
-val publication_recovery_lane_open_error_kind
-  :  publication_recovery_lane_open_error
-  -> publication_recovery_lane_open_error_kind
 
 (** Build the immutable recovery locator projection used by
     {!replace_capability_file}. *)
@@ -381,11 +335,11 @@ val atomic_replace_recovery_target_error_to_string
   :  atomic_replace_recovery_target_error
   -> string
 
-type capability_write_operation =
+type capability_write_operation = Atomic_write.capability_write_operation =
   | Atomic_replace_operation
   | Create_exclusive_operation
 
-type capability_write_stage =
+type capability_write_stage = Atomic_write.capability_write_stage =
   | Validate_leaf
   | Acquire_mutation_lease
   | Acquire_publication_lease
@@ -423,7 +377,7 @@ type capability_write_stage =
   | Cleanup_close_staging_directory
   | Cleanup_sync_parent
 
-type capability_write_target_effect =
+type capability_write_target_effect = Atomic_write.capability_write_target_effect =
   | Target_unchanged
   | Target_created
   | Target_created_incomplete
@@ -431,17 +385,19 @@ type capability_write_target_effect =
   | Target_state_unknown
 
 type capability_write_operation_failure =
+  Atomic_write.capability_write_operation_failure =
   { exception_ : exn
   ; backtrace : Printexc.raw_backtrace
   }
 
 type capability_write_payload_failure =
+  Atomic_write.capability_write_payload_failure =
   { exception_ : exn
   ; backtrace : Printexc.raw_backtrace
   ; bytes_written : int
   }
 
-type capability_write_cause =
+type capability_write_cause = Atomic_write.capability_write_cause =
   | Invalid_leaf of string
   | Invalid_recovery_target of atomic_replace_recovery_target_error
   | Mutation_contended
@@ -452,12 +408,12 @@ type capability_write_cause =
   | Payload_write_failed of capability_write_payload_failure
   | Operation_failed of capability_write_operation_failure
 
-type capability_write_failure =
+type capability_write_failure = Atomic_write.capability_write_failure =
   { stage : capability_write_stage
   ; cause : capability_write_cause
   }
 
-type capability_recovery_phase =
+type capability_recovery_phase = Atomic_write.capability_recovery_phase =
   | Recovery_validate_owner
   | Recovery_open_registry
   | Recovery_open_store
@@ -468,13 +424,14 @@ type capability_recovery_phase =
   | Recovery_discharge_bound
 
 type capability_recovery_removal_transition =
+  Atomic_write.capability_recovery_removal_transition =
   | Recovery_discharge_active
   | Recovery_discharge_owned
   | Recovery_active_to_owned
   | Recovery_active_to_forensic
   | Recovery_owned_to_forensic
 
-type capability_recovery_effect =
+type capability_recovery_effect = Atomic_write.capability_recovery_effect =
   | Recovery_no_record_change
   | Recovery_layout_may_be_incomplete
   | Recovery_layout_ready
@@ -491,7 +448,7 @@ type capability_recovery_effect =
   | Recovery_source_removal_durability_unknown of
       capability_recovery_removal_transition
 
-type capability_recovery_failure
+type capability_recovery_failure = Atomic_write.capability_recovery_failure
 
 val capability_recovery_phase_to_string : capability_recovery_phase -> string
 val capability_recovery_effect_to_string : capability_recovery_effect -> string
@@ -508,30 +465,34 @@ val capability_recovery_failure_to_string
   :  capability_recovery_failure
   -> string
 
-type capability_recovery_access_failure = Recovery_access_not_available
+type capability_recovery_access_failure =
+  Atomic_write.capability_recovery_access_failure =
+  | Recovery_access_not_available
 
 type capability_write_primary_failure =
+  Atomic_write.capability_write_primary_failure =
   | Write_primary_failure of capability_write_failure
   | Recovery_primary_failure of capability_recovery_failure
   | Recovery_access_primary_failure of capability_recovery_access_failure
 
 type capability_write_cleanup_failure =
+  Atomic_write.capability_write_cleanup_failure =
   | Write_cleanup_failure of capability_write_failure
   | Recovery_cleanup_failure of capability_recovery_failure
 
-type capability_write_error =
+type capability_write_error = Atomic_write.capability_write_error =
   { operation : capability_write_operation
   ; target_effect : capability_write_target_effect
   ; primary_failure : capability_write_primary_failure
   ; cleanup_failures : capability_write_cleanup_failure list
   }
 
-type capability_directory_sync_error =
+type capability_directory_sync_error = Atomic_write.capability_directory_sync_error =
   { failure : capability_write_failure
   ; cleanup_failures : capability_write_failure list
   }
 
-type capability_write_cancellation =
+type capability_write_cancellation = Atomic_write.capability_write_cancellation =
   { operation : capability_write_operation
   ; target_effect : capability_write_target_effect
   ; interrupted_primary_failure : capability_write_primary_failure option
@@ -544,7 +505,7 @@ exception Capability_write_cancelled of exn * capability_write_cancellation
 (** Durable replacement below an already-open target-parent capability.
     Recovery access and the immutable target projection are mandatory. *)
 val replace_capability_file
-  :  recovery:publication_recovery_access
+  :  recovery:Publication_recovery.t
   -> parent:Eio.Fs.dir_ty Eio.Path.t
   -> target:atomic_replace_recovery_target
   -> string
@@ -578,29 +539,6 @@ val sync_directory_capability
 val capability_directory_sync_error_to_string
   :  capability_directory_sync_error
   -> string
-
-module Capability_write_for_testing : sig
-  val replace_capability_file
-    :  before_stage:(capability_write_stage -> unit)
-    -> recovery:publication_recovery_access
-    -> parent:Eio.Fs.dir_ty Eio.Path.t
-    -> target:atomic_replace_recovery_target
-    -> string
-    -> (unit, capability_write_error) result
-
-  val create_capability_file_exclusive
-    :  before_stage:(capability_write_stage -> unit)
-    -> parent:Eio.Fs.dir_ty Eio.Path.t
-    -> leaf:string
-    -> permissions:int
-    -> string
-    -> (unit, capability_write_error) result
-
-  val sync_directory_capability
-    :  before_stage:(capability_write_stage -> unit)
-    -> _ Eio.Path.t
-    -> (unit, capability_directory_sync_error) result
-end
 
 (** [true] iff [name] matches the canonical [.atomic_*.tmp] pattern produced by
     this module. Exposed for tests and recovery sweeps. *)

--- a/lib/fs_compat/publication_recovery_access.ml
+++ b/lib/fs_compat/publication_recovery_access.ml
@@ -1606,21 +1606,6 @@ module For_testing = struct
        | Error error -> Error (Store_failed error))
   ;;
 
-  let lane_release_failure ~owner ~exception_ ~backtrace =
-    match Core.owner_of_string owner with
-    | Error _ as error -> error
-    | Ok owner ->
-      Ok
-        { Core.failure =
-            { operation = Core.Close_directory
-            ; subject = Core.Lane_root owner
-            ; cause = Core.Io_failed { exception_; backtrace }
-            }
-        ; exception_
-        ; backtrace
-        }
-  ;;
-
   let record_lane_store_open_failure
         ~registry
         ~owner

--- a/lib/fs_compat/publication_recovery_access.mli
+++ b/lib/fs_compat/publication_recovery_access.mli
@@ -372,16 +372,6 @@ module For_testing : sig
     -> ('a, lane_open_error) result
   (** Internal fixture boundary. Production callers must use [with_lane]. *)
 
-  val lane_release_failure
-    :  owner:string
-    -> exception_:exn
-    -> backtrace:Printexc.raw_backtrace
-    -> (lane_release_failure,
-        Capability_recovery_obligation.validation_error)
-         result
-  (** Construct exact typed lane-release evidence for product-boundary tests.
-      Production lane failures always originate from the resource scope. *)
-
   val record_lane_store_open_failure
     :  registry:registry
     -> owner:string

--- a/lib/fs_compat/publication_recovery_for_testing.ml
+++ b/lib/fs_compat/publication_recovery_for_testing.ml
@@ -1,4 +1,45 @@
+open Fs_compat_internal
+
 include Publication_recovery_access
+
+type lane_scope_release_fault =
+  Capability_recovery_obligation.For_testing.lane_scope_release_fault
+
+let lane_scope_release_fault =
+  Capability_recovery_obligation.For_testing.lane_scope_release_fault
+;;
+
+let with_lane_scope_release_fault =
+  Capability_recovery_obligation.For_testing.with_lane_scope_release_fault
+;;
+
+type replace_dispatch_fault =
+  Atomic_write.Capability_write_for_testing.replace_dispatch_fault
+
+type replace_dispatch_fault_stage =
+  | Before_publish_replace
+  | Before_parent_sync
+
+(* TEL-OK: this workspace-only constructor maps a typed test stage; no write occurs. *)
+let replace_dispatch_fault ~stage ~exception_ =
+  let stage =
+    match stage with
+    | Before_publish_replace -> Atomic_write.Publish_replace
+    | Before_parent_sync -> Atomic_write.Sync_parent
+  in
+  Atomic_write.Capability_write_for_testing.replace_dispatch_fault
+    ~stage
+    ~exception_
+;;
+
+(* TEL-OK: the internal fiber binding is exercised through the real write operation. *)
+let with_replace_dispatch_fault =
+  Atomic_write.Capability_write_for_testing.with_replace_dispatch_fault
+;;
+
+let remove_staging_payload_before_publish =
+  Atomic_write.Capability_write_for_testing.remove_staging_payload_before_publish
+;;
 
 type record_area =
   | Active

--- a/lib/fs_compat/publication_recovery_for_testing.mli
+++ b/lib/fs_compat/publication_recovery_for_testing.mli
@@ -1,10 +1,46 @@
 (** Explicit fixture and state-machine surface for repository tests.
 
     Production code must use the narrow [Fs_compat.Publication_recovery]
-    facade. A source-boundary ratchet rejects consumers below [lib/] outside
-    the two facade modules. *)
+    facade. This module belongs to a workspace-only Dune library and is not
+    installed with [masc.fs_compat]. *)
+
+open Fs_compat_internal
 
 include module type of Publication_recovery_access
+
+type lane_scope_release_fault
+
+val lane_scope_release_fault
+  :  owner:string
+  -> exception_:exn
+  -> (lane_scope_release_fault,
+      Capability_recovery_obligation.validation_error)
+       result
+
+val with_lane_scope_release_fault
+  :  lane_scope_release_fault
+  -> (unit -> 'a)
+  -> 'a
+
+type replace_dispatch_fault
+
+type replace_dispatch_fault_stage =
+  | Before_publish_replace
+  | Before_parent_sync
+
+val replace_dispatch_fault
+  :  stage:replace_dispatch_fault_stage
+  -> exception_:exn
+  -> replace_dispatch_fault
+
+val with_replace_dispatch_fault
+  :  replace_dispatch_fault
+  -> (unit -> 'a)
+  -> 'a
+
+val remove_staging_payload_before_publish
+  :  unit
+  -> replace_dispatch_fault
 
 type record_area =
   | Active

--- a/lib/keeper/keeper_publication_recovery_availability.ml
+++ b/lib/keeper/keeper_publication_recovery_availability.ml
@@ -1,7 +1,7 @@
 type availability =
   | Initializing
-  | Available of Fs_compat.publication_recovery_registry
-  | Registry_unavailable of Fs_compat.publication_recovery_registry_error
+  | Available of Fs_compat.Publication_recovery.registry
+  | Registry_unavailable of Fs_compat.Publication_recovery.registry_error
   | Initialization_crashed of Eio.Exn.with_bt
   | Non_runtime
 
@@ -9,10 +9,10 @@ type provider = unit -> availability
 
 type unavailable =
   | Runtime_initializing
-  | Runtime_registry_unavailable of Fs_compat.publication_recovery_registry_error
+  | Runtime_registry_unavailable of Fs_compat.Publication_recovery.registry_error
   | Runtime_initialization_crashed of Eio.Exn.with_bt
   | Runtime_non_runtime
-  | Lane_unavailable of Fs_compat.publication_recovery_lane_open_error
+  | Lane_unavailable of Fs_compat.Publication_recovery.lane_open_error
 
 type turn_context =
   { provider : provider
@@ -32,11 +32,13 @@ let constant availability () = availability
 let non_runtime_provider = constant Non_runtime
 
 let lane_public_category error =
-  match Fs_compat.publication_recovery_lane_open_error_kind error with
-  | Fs_compat.Publication_recovery_invalid_owner -> Public_lane_invalid_owner
-  | Fs_compat.Publication_recovery_reconciliation_blocked ->
+  match Fs_compat.Publication_recovery.lane_open_error_category error with
+  | Fs_compat.Publication_recovery.Invalid_owner_category ->
+    Public_lane_invalid_owner
+  | Fs_compat.Publication_recovery.Reconciliation_blocked_category ->
     Public_lane_reconciliation_blocked
-  | Fs_compat.Publication_recovery_store_failed -> Public_lane_store_failed
+  | Fs_compat.Publication_recovery.Store_failed_category ->
+    Public_lane_store_failed
 ;;
 
 let public_category = function
@@ -85,7 +87,7 @@ let with_access publication_recovery use =
   | Non_runtime -> Error Runtime_non_runtime
   | Available registry ->
     (match
-       Fs_compat.with_publication_recovery_lane
+       Fs_compat.Publication_recovery.with_lane
          ~registry
          ~owner:publication_recovery.keeper_name
          use
@@ -97,7 +99,7 @@ let with_access publication_recovery use =
          ~keeper_name:publication_recovery.keeper_name
          "publication recovery lane acquisition failed category=%s evidence=%s"
          (public_category_to_string category)
-         (Fs_compat.publication_recovery_lane_open_error_to_string error);
+         (Fs_compat.Publication_recovery.lane_open_error_to_string error);
        Error (Lane_unavailable error))
 ;;
 

--- a/lib/keeper/keeper_publication_recovery_availability.mli
+++ b/lib/keeper/keeper_publication_recovery_availability.mli
@@ -7,8 +7,8 @@
 
 type availability =
   | Initializing
-  | Available of Fs_compat.publication_recovery_registry
-  | Registry_unavailable of Fs_compat.publication_recovery_registry_error
+  | Available of Fs_compat.Publication_recovery.registry
+  | Registry_unavailable of Fs_compat.Publication_recovery.registry_error
   | Initialization_crashed of Eio.Exn.with_bt
   | Non_runtime
 
@@ -16,10 +16,10 @@ type provider = unit -> availability
 
 type unavailable =
   | Runtime_initializing
-  | Runtime_registry_unavailable of Fs_compat.publication_recovery_registry_error
+  | Runtime_registry_unavailable of Fs_compat.Publication_recovery.registry_error
   | Runtime_initialization_crashed of Eio.Exn.with_bt
   | Runtime_non_runtime
-  | Lane_unavailable of Fs_compat.publication_recovery_lane_open_error
+  | Lane_unavailable of Fs_compat.Publication_recovery.lane_open_error
 
 type turn_context =
   { provider : provider
@@ -31,7 +31,7 @@ val non_runtime_provider : provider
 
 val with_access
   :  turn_context
-  -> (Fs_compat.publication_recovery_access -> 'a)
+  -> (Fs_compat.Publication_recovery.t -> 'a)
   -> ('a Fs_compat.Publication_recovery.lane_outcome, unavailable) result
 (** Reads the live provider once and, only when available, borrows the exact
     owner lane for the dynamic extent of [use]. Callback exceptions and

--- a/lib/keeper/keeper_publication_recovery_scope.mli
+++ b/lib/keeper/keeper_publication_recovery_scope.mli
@@ -23,6 +23,6 @@ val resolve_turn_resources
   -> (turn_resources, failure) result
 (** Performs only the exact in-memory Keeper registry lookup. The provider is
     not read here. File edit/write dispatch re-reads it at the moment of the
-    effect and executes the write inside [with_publication_recovery_lane]'s
+    effect and executes the write inside [Fs_compat.Publication_recovery.with_lane]'s
     callback. Consequently an idle, read-only, or non-file turn performs no
     publication-recovery filesystem acquisition. *)

--- a/lib/keeper/keeper_tool_boundary.ml
+++ b/lib/keeper/keeper_tool_boundary.ml
@@ -43,6 +43,29 @@ let to_tool_keeper_context (ctx : _ context) : _ Keeper_tool_surface.context =
 let dispatch ctx ~name ~args =
   Keeper_tool_surface.dispatch (to_tool_keeper_context ctx) ~name ~args
 
+(* TEL-OK: this only closes over Keeper-owned context; dispatch remains observed downstream. *)
+let delegated_dispatch
+      ~config
+      ~agent_name
+      ~sw
+      ~clock
+      ~proc_mgr
+      ~net
+      ~publication_recovery_provider
+  =
+  let ctx =
+    create
+      ~config
+      ~agent_name
+      ~sw
+      ~clock
+      ~proc_mgr
+      ~net
+      ~publication_recovery_provider
+  in
+  fun ~name ~args -> dispatch ctx ~name ~args
+;;
+
 let dispatch_stream ?on_text_delta ?on_event ctx ~name ~args =
   Keeper_tool_surface.dispatch_stream ?on_text_delta ?on_event (to_tool_keeper_context ctx) ~name
     ~args

--- a/lib/keeper/keeper_tool_boundary.mli
+++ b/lib/keeper/keeper_tool_boundary.mli
@@ -27,3 +27,16 @@ val create :
 
 val dispatch :
   _ context -> name:string -> args:Yojson.Safe.t -> Keeper_types_profile.tool_result option
+
+val delegated_dispatch :
+  config:Workspace.config ->
+  agent_name:string ->
+  sw:Eio.Switch.t ->
+  clock:'a Eio.Time.clock ->
+  proc_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t option ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option ->
+  publication_recovery_provider:
+    Keeper_publication_recovery_availability.provider ->
+  name:string ->
+  args:Yojson.Safe.t ->
+  Keeper_types_profile.tool_result option

--- a/lib/keeper/keeper_tool_filesystem_runtime.ml
+++ b/lib/keeper/keeper_tool_filesystem_runtime.ml
@@ -489,6 +489,17 @@ and created_directory_sync_outcome =
   | Directory_sync_succeeded
   | Directory_sync_failed of Fs_compat.capability_directory_sync_error
 
+type created_directory_dispatch_fault =
+  { fault_stage : created_directory_stage
+  ; fault_exception : exn
+  }
+
+let created_directory_dispatch_fault_key
+      : created_directory_dispatch_fault Eio.Fiber.key
+  =
+  Eio.Fiber.create_key ()
+;;
+
 type append_target_effect =
   | Append_target_unchanged
   | Append_target_extended_complete
@@ -519,7 +530,7 @@ type content_write_error =
 type content_publication =
   | Recovery_independent of (unit -> (unit, content_write_error) result)
   | Recovery_guarded of
-      (Fs_compat.publication_recovery_access
+      (Fs_compat.Publication_recovery.t
        -> (unit, content_write_error) result)
 
 let append_capability ~on_cancelled file content =
@@ -563,6 +574,16 @@ let create_and_commit_directory_component
       ~parent_dir
       ~component
   =
+  let dispatch_fault = Eio.Fiber.get created_directory_dispatch_fault_key in
+  let run_directory_operation =
+    match dispatch_fault with
+    | None -> created_directory_operation
+    | Some fault ->
+      (fun stage f ->
+         created_directory_operation stage (fun () ->
+           if fault.fault_stage = stage then raise fault.fault_exception;
+           f ()))
+  in
   let unchanged primary_failure =
     ( None
     , { component
@@ -584,13 +605,13 @@ let create_and_commit_directory_component
   in
   let child = Eio.Path.(parent_dir / component) in
   match
-    created_directory_operation Create_directory (fun () ->
+    run_directory_operation Create_directory (fun () ->
       Eio.Path.mkdir ~perm:0o700 child)
   with
   | Error primary_failure -> unchanged primary_failure
   | Ok () ->
     (match
-       created_directory_operation Inspect_created_directory (fun () ->
+       run_directory_operation Inspect_created_directory (fun () ->
          Eio.Path.stat ~follow:false child)
      with
      | Error primary_failure ->
@@ -605,7 +626,7 @@ let create_and_commit_directory_component
          }
      | Ok created ->
        (match
-          created_directory_operation Acquire_directory_capability (fun () ->
+          run_directory_operation Acquire_directory_capability (fun () ->
             Eio.Path.open_dir ~sw child)
         with
         | Error primary_failure ->
@@ -614,7 +635,7 @@ let create_and_commit_directory_component
             primary_failure
         | Ok child_dir ->
           let directory_file =
-            created_directory_operation Acquire_directory_capability (fun () ->
+            run_directory_operation Acquire_directory_capability (fun () ->
               Eio.Path.open_in ~sw Eio.Path.(child_dir / "."))
           in
           let validation =
@@ -622,7 +643,7 @@ let create_and_commit_directory_component
             | Error _ as error -> error
             | Ok directory_file ->
               (match
-                 created_directory_operation
+                 run_directory_operation
                    Validate_directory_capability
                    (fun () ->
                       Eio.Path.stat ~follow:false child, Eio.File.stat directory_file)
@@ -668,7 +689,7 @@ let create_and_commit_directory_component
                    ; cause = Directory_posix_descriptor_unavailable
                    }
                | Some fd ->
-                 created_directory_operation Apply_directory_permissions (fun () ->
+                 run_directory_operation Apply_directory_permissions (fun () ->
                    Eio_unix.run_in_systhread
                      ~label:"keeper-fs-created-directory-fchmod"
                      (fun () ->
@@ -1173,6 +1194,25 @@ let created_parent_effects_json created_parents =
   `List (List.map created_directory_commit_json created_parents)
 ;;
 
+let created_directory_sync_observation_json = function
+  | Directory_sync_not_attempted -> `String "not_attempted"
+  | Directory_sync_succeeded -> `String "succeeded"
+  | Directory_sync_failed _ -> `String "failed"
+;;
+
+let created_parent_effect_observation_json commit =
+  `Assoc
+    [ ( "target_effect"
+      , `String (created_directory_target_effect_to_string commit.target_effect) )
+    ; "child_sync", created_directory_sync_observation_json commit.child_sync
+    ; "parent_sync", created_directory_sync_observation_json commit.parent_sync
+    ]
+;;
+
+let created_parent_effect_observations_json created_parents =
+  `List (List.map created_parent_effect_observation_json created_parents)
+;;
+
 let capability_write_error_payload
       ~target
       ~created_parents
@@ -1476,7 +1516,7 @@ let publication_recovery_cleanup_failed_attempt
       ( "filesystem publication committed, but publication recovery lane cleanup failed"
       , `Bool true )
     | Publication_write_effect_observed ->
-      ( "filesystem publication changed the target before the publication callback and recovery lane cleanup both failed"
+      ( "filesystem publication produced an observable filesystem effect before the publication callback and recovery lane cleanup both failed"
       , `Bool true )
     | Publication_write_not_executed ->
       ( "filesystem publication left the target unchanged, but publication recovery lane cleanup failed"
@@ -1537,13 +1577,59 @@ let finish_recovery_guarded_write
          release_failure)
 ;;
 
-let publication_execution_of_target_effect = function
-  | Fs_compat.Target_unchanged -> Publication_write_not_executed
+type publication_effect_observation =
+  | Publication_effect_absent
+  | Publication_effect_observed
+  | Publication_effect_indeterminate
+
+let join_publication_effect_observation left right =
+  match left, right with
+  | Publication_effect_observed, _ | _, Publication_effect_observed ->
+    Publication_effect_observed
+  | Publication_effect_indeterminate, _ | _, Publication_effect_indeterminate ->
+    Publication_effect_indeterminate
+  | Publication_effect_absent, Publication_effect_absent ->
+    Publication_effect_absent
+;;
+
+let publication_execution_of_effect_observation = function
+  | Publication_effect_absent -> Publication_write_not_executed
+  | Publication_effect_observed -> Publication_write_effect_observed
+  | Publication_effect_indeterminate -> Publication_write_indeterminate
+;;
+
+let publication_effect_observation_of_target_effect = function
+  | Fs_compat.Target_unchanged -> Publication_effect_absent
   | ( Fs_compat.Target_created
     | Fs_compat.Target_created_incomplete
     | Fs_compat.Target_replaced ) ->
-    Publication_write_effect_observed
-  | Fs_compat.Target_state_unknown -> Publication_write_indeterminate
+    Publication_effect_observed
+  | Fs_compat.Target_state_unknown -> Publication_effect_indeterminate
+;;
+
+let publication_effect_observation_of_directory_target_effect = function
+  | Directory_unchanged -> Publication_effect_absent
+  | (Directory_created_validated | Directory_created_requested_mode) ->
+    Publication_effect_observed
+  | Directory_state_unknown -> Publication_effect_indeterminate
+;;
+
+let publication_effect_observation_of_created_parents created_parents =
+  List.fold_left
+    (fun observation commit ->
+       join_publication_effect_observation
+         observation
+         (publication_effect_observation_of_directory_target_effect
+            commit.target_effect))
+    Publication_effect_absent
+    created_parents
+;;
+
+let publication_execution_of_error_effect ~primary ~created_parents =
+  join_publication_effect_observation
+    primary
+    (publication_effect_observation_of_created_parents created_parents)
+  |> publication_execution_of_effect_observation
 ;;
 
 let content_write_observation = function
@@ -1551,8 +1637,12 @@ let content_write_observation = function
     { execution = Publication_write_completed
     ; publication_result = `Assoc [ "outcome", `String "success" ]
     }
-  | Error (Content_write_capability { error; _ }) ->
-    { execution = publication_execution_of_target_effect error.target_effect
+  | Error (Content_write_capability { error; created_parents }) ->
+    { execution =
+        publication_execution_of_error_effect
+          ~primary:
+            (publication_effect_observation_of_target_effect error.target_effect)
+          ~created_parents
     ; publication_result =
         `Assoc
           [ "outcome", `String "failure"
@@ -1561,10 +1651,17 @@ let content_write_observation = function
             , `String
                 (Fs_compat.capability_write_target_effect_to_string
                    error.target_effect) )
+          ; ( "filesystem_created_parent_effects"
+            , created_parent_effect_observations_json created_parents )
           ]
     }
-  | Error (Content_write_directory { failed_commit; _ }) ->
-    { execution = Publication_write_not_executed
+  | Error (Content_write_directory { failed_commit; created_parents }) ->
+    { execution =
+        publication_execution_of_error_effect
+          ~primary:
+            (publication_effect_observation_of_directory_target_effect
+               failed_commit.target_effect)
+          ~created_parents
     ; publication_result =
         `Assoc
           [ "outcome", `String "failure"
@@ -1573,6 +1670,8 @@ let content_write_observation = function
             , `String
                 (created_directory_target_effect_to_string
                    failed_commit.target_effect) )
+          ; ( "filesystem_created_parent_effects"
+            , created_parent_effect_observations_json created_parents )
           ]
     }
   | Error (Content_write_append outcome) ->
@@ -2338,86 +2437,24 @@ let handle_file_write
 ;;
 
 module For_testing = struct
-  let committed_publication_release_failure
-        ~keeper_name
-        ~release_failure
-    =
-    let outcome =
-      Fs_compat.Publication_recovery.Lane_release_failed
-        { value = ()
-        ; release_failure
-        }
+  type created_directory_fault_stage =
+    | Before_create_directory
+    | Before_inspect_created_directory
+    | Before_apply_directory_permissions
+
+  type created_directory_fault = created_directory_dispatch_fault
+
+  let created_directory_fault ~stage ~exception_ =
+    let fault_stage =
+      match stage with
+      | Before_create_directory -> Create_directory
+      | Before_inspect_created_directory -> Inspect_created_directory
+      | Before_apply_directory_permissions -> Apply_directory_permissions
     in
-    match
-      finish_recovery_guarded_write
-        ~keeper_name
-        ~target:"product-contract-fixture"
-        ~observe_result:(fun () ->
-          { execution = Publication_write_completed
-          ; publication_result = `Assoc [ "outcome", `String "success" ]
-          })
-        ~finish:(fun () ->
-          Ok
-            (Write_succeeded
-               (Yojson.Safe.to_string (`Assoc [ "ok", `Bool true ]))))
-        outcome
-    with
-    | Ok attempt -> file_write_attempt_to_execution attempt
-    | Error message -> Keeper_tool_execution.failure (error_json message)
+    { fault_stage; fault_exception = exception_ }
   ;;
 
-  let failed_publication_release_failure
-        ~keeper_name
-        ~target_effect
-        ~release_failure
-    =
-    let error =
-      { Fs_compat.operation = Fs_compat.Atomic_replace_operation
-      ; target_effect
-      ; primary_failure =
-          Fs_compat.Write_primary_failure
-            { stage = Fs_compat.Sync_parent
-            ; cause = Fs_compat.Resource_identity_changed
-            }
-      ; cleanup_failures = []
-      }
-    in
-    let result =
-      Error (Content_write_capability { error; created_parents = [] })
-    in
-    let outcome =
-      Fs_compat.Publication_recovery.Lane_release_failed
-        { value = result; release_failure }
-    in
-    match
-      finish_recovery_guarded_write
-        ~keeper_name
-        ~target:"product-contract-fixture"
-        ~observe_result:content_write_observation
-        ~finish:(fun result ->
-          match result with
-          | Error (Content_write_capability { error; created_parents }) ->
-            Ok
-              (Write_failed
-                 { payload =
-                     capability_write_error_payload
-                       ~target:"product-contract-fixture"
-                       ~created_parents
-                       error
-                 ; class_ = Tool_result.Runtime_failure
-                 })
-          | Ok () ->
-            Ok
-              (Write_succeeded
-                 (Yojson.Safe.to_string (`Assoc [ "ok", `Bool true ])))
-          | Error
-              ( Content_write_message _
-              | Content_write_directory _
-              | Content_write_append _ ) ->
-            Error "unexpected product-contract fixture result")
-        outcome
-    with
-    | Ok attempt -> file_write_attempt_to_execution attempt
-    | Error message -> Keeper_tool_execution.failure (error_json message)
+  let with_created_directory_fault fault f =
+    Eio.Fiber.with_binding created_directory_dispatch_fault_key fault f
   ;;
 end

--- a/lib/keeper/keeper_tool_filesystem_runtime.mli
+++ b/lib/keeper/keeper_tool_filesystem_runtime.mli
@@ -95,19 +95,20 @@ val handle_file_write_with_outcome :
     opened root capability. *)
 
 module For_testing : sig
-  val committed_publication_release_failure
-    :  keeper_name:string
-    -> release_failure:Fs_compat.Publication_recovery.lane_release_failure
-    -> Keeper_tool_execution.t
-  (** Inject a post-callback lane release failure through the same public tool
-      result projection used after a committed production publication. *)
+  type created_directory_fault_stage =
+    | Before_create_directory
+    | Before_inspect_created_directory
+    | Before_apply_directory_permissions
 
-  val failed_publication_release_failure
-    :  keeper_name:string
-    -> target_effect:Fs_compat.capability_write_target_effect
-    -> release_failure:Fs_compat.Publication_recovery.lane_release_failure
-    -> Keeper_tool_execution.t
-  (** Project a typed atomic-publication failure together with a subsequent
-      lane release failure. This exercises preservation of the target effect
-      already observed by the capability writer. *)
+  type created_directory_fault
+
+  val created_directory_fault
+    :  stage:created_directory_fault_stage
+    -> exception_:exn
+    -> created_directory_fault
+
+  val with_created_directory_fault
+    :  created_directory_fault
+    -> (unit -> 'a)
+    -> 'a
 end

--- a/lib/mcp_server.ml
+++ b/lib/mcp_server.ml
@@ -481,7 +481,7 @@ type owner_identity_projection =
 exception Owner_identity_projection_settled_more_than_once
 
 type publication_recovery_available =
-  { registry : Fs_compat.publication_recovery_registry
+  { registry : Fs_compat.Publication_recovery.registry
   ; owner_identity_projection : owner_identity_projection Atomic.t
   }
 
@@ -489,7 +489,7 @@ type publication_recovery_runtime_state =
   | Publication_recovery_initializing
   | Publication_recovery_available of publication_recovery_available
   | Publication_recovery_unavailable of
-      Fs_compat.publication_recovery_registry_error
+      Fs_compat.Publication_recovery.registry_error
   | Publication_recovery_initialization_crashed of Eio.Exn.with_bt
   | Publication_recovery_non_runtime
 
@@ -505,7 +505,7 @@ type publication_recovery_runtime_snapshot =
       ; owner_identity_projection : owner_identity_projection
       }
   | Publication_recovery_unavailable_snapshot of
-      Fs_compat.publication_recovery_registry_error
+      Fs_compat.Publication_recovery.registry_error
   | Publication_recovery_initialization_crashed_snapshot
   | Publication_recovery_non_runtime_snapshot
 
@@ -1251,7 +1251,7 @@ let create_state_eio ~sw ~proc_mgr ~fs ~clock ~mono_clock ~net ~base_path =
     let initialization =
       try
         `Returned
-          (Fs_compat.open_publication_recovery_registry
+          (Fs_compat.Publication_recovery.open_registry
              ~sw
              ~fs
              ~registry_root)
@@ -1300,7 +1300,7 @@ let create_state_eio ~sw ~proc_mgr ~fs ~clock ~mono_clock ~net ~base_path =
              [ "registry_root", `String process_masc_root
              ; ( "error"
                , `String
-                   (Fs_compat.publication_recovery_registry_error_to_string
+                   (Fs_compat.Publication_recovery.registry_error_to_string
                       error) )
              ])
         "publication recovery registry is unavailable; publication filesystem tools fail closed"

--- a/lib/mcp_server.mli
+++ b/lib/mcp_server.mli
@@ -274,7 +274,7 @@ module For_testing : sig
 
   val publication_recovery_registry
     :  server_state
-    -> Fs_compat.publication_recovery_registry option
+    -> Fs_compat.Publication_recovery.registry option
   (** Test-only exact registry access. Production Keeper callers must carry the
       live provider and may not snapshot the registry. *)
 

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -260,8 +260,18 @@ let execute_tool_eio
                      ; clock
                      ; proc_mgr = state.Mcp_server.proc_mgr
                      ; net = state.Mcp_server.net
-                     ; publication_recovery_provider =
-                         Mcp_server.publication_recovery_availability_provider state
+                     ; delegated_dispatch =
+                         Some
+                           (Keeper_tool_boundary.delegated_dispatch
+                              ~config
+                              ~agent_name
+                              ~sw
+                              ~clock
+                              ~proc_mgr:state.Mcp_server.proc_mgr
+                              ~net:state.Mcp_server.net
+                              ~publication_recovery_provider:
+                                (Mcp_server.publication_recovery_availability_provider
+                                   state))
                      ; mcp_session_id
                      }
                    in

--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -6,23 +6,15 @@ include Operator_control_action
 let json_of_dispatch_output body =
   try Yojson.Safe.from_string body with Yojson.Json_error _ -> `String body
 
-let tool_keeper_ctx (ctx : 'a context) : _ Keeper_tool_surface.context =
-  {
-    config = ctx.config;
-    agent_name = ctx.agent_name;
-    sw = ctx.sw;
-    clock = ctx.clock;
-    proc_mgr = ctx.proc_mgr;
-    net = ctx.net;
-    publication_recovery_provider = ctx.publication_recovery_provider;
-  }
-
 let dispatch_keeper_json (ctx : 'a context) ~tool_name ~args =
-  match Keeper_tool_surface.dispatch (tool_keeper_ctx ctx) ~name:tool_name ~args with
-  | Some result when Tool_result.is_success result ->
-    Ok (json_of_dispatch_output (Tool_result.message result))
-  | Some result -> Error (Tool_result.message result)
-  | None -> Error (Printf.sprintf "%s dispatch unavailable" tool_name)
+  match ctx.delegated_dispatch with
+  | None -> Error (Printf.sprintf "%s dispatch unavailable in this context" tool_name)
+  | Some dispatch ->
+    (match dispatch ~name:tool_name ~args with
+     | Some result when Tool_result.is_success result ->
+       Ok (json_of_dispatch_output (Tool_result.message result))
+     | Some result -> Error (Tool_result.message result)
+     | None -> Error (Printf.sprintf "%s dispatch unavailable" tool_name))
 
 let resolve_keeper_meta_for_name (ctx : 'a context) ~(name : string) =
   match Keeper_meta_store.read_effective_meta_resolved ctx.config name with
@@ -251,28 +243,14 @@ let execute_keeper_action (ctx : 'a context) (request : action_request) =
            | Some value -> [ ("timeout_sec", `Int value) ]
            | None -> [])
       in
-      let keeper_ctx : _ Keeper_tool_surface.context =
-        {
-          config = ctx.config;
-          agent_name = ctx.agent_name;
-          sw = ctx.sw;
-          clock = ctx.clock;
-          proc_mgr = ctx.proc_mgr;
-          net = ctx.net;
-          publication_recovery_provider = ctx.publication_recovery_provider;
-        }
-      in
-      let* body =
-        match Keeper_tool_surface.dispatch keeper_ctx ~name:"masc_keeper_msg" ~args with
-        | Some result when Tool_result.is_success result -> Ok (Tool_result.message result)
-        | Some result -> Error (Tool_result.message result)
-        | None -> Error "masc_keeper_msg dispatch unavailable"
+      let* result =
+        dispatch_keeper_json ctx ~tool_name:"masc_keeper_msg" ~args
       in
       Ok
         (`Assoc
           [
             ("tool_name", `String "masc_keeper_msg");
-            ("result", json_of_dispatch_output body);
+            ("result", result);
           ])
   | _ -> Error (Printf.sprintf "not a keeper action: %s" request.action_type)
 

--- a/lib/operator/operator_tool.ml
+++ b/lib/operator/operator_tool.ml
@@ -411,7 +411,7 @@ let dispatch (ctx : 'a context) ~name ~args : Tool_result.result option =
       clock = ctx.clock;
       proc_mgr = ctx.proc_mgr;
       net = ctx.net;
-      publication_recovery_provider = ctx.publication_recovery_provider;
+      delegated_dispatch = ctx.delegated_dispatch;
       mcp_session_id = ctx.mcp_session_id;
     }
   in

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -1389,8 +1389,7 @@ let start_keeper_loops_owned
       ; clock
       ; proc_mgr = Some proc_mgr
       ; net = state.net
-      ; publication_recovery_provider =
-          Mcp_server.publication_recovery_availability_provider state
+      ; delegated_dispatch = None
       ; mcp_session_id = None
       }
     in

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -694,48 +694,71 @@ let dashboard_goal_detail_http_json ~(config : Workspace.config) ~goal_id : Yojs
     `Assoc [ "ok", `Bool false; "error", `String message; "goal_id", `String goal_id ]
 ;;
 
-let operator_action_http_json ~state ~sw ~clock request ~args =
-  let workspace_scope = Mcp_server.workspace_scope state in
-  let actor =
-    Server_auth.dashboard_actor_for_request
-      ~base_path:workspace_scope.config.base_path
-      request
-  in
-  let ctx : _ Operator_control.context =
-    { config = workspace_scope.config
-    ; agent_name = Option.value ~default:"dashboard" actor
-    ; sw
-    ; clock
-    ; proc_mgr = state.Mcp_server.proc_mgr
-    ; net = state.Mcp_server.net
-    ; publication_recovery_provider =
-        Mcp_server.publication_recovery_availability_provider state
-    ; mcp_session_id = None
-    }
-  in
-  Operator_control.action_json ?actor_hint:actor ctx args
+let explicit_operator_actor ~authorized_actor request =
+  match
+    Server_auth.auth_token_from_request request,
+    Server_auth.request_actor_hint request
+  with
+  | None, None -> Error "operator request actor is required"
+  | None, Some _
+  | Some _, None
+  | Some _, Some _ -> Ok authorized_actor
 ;;
 
-let operator_confirm_http_json ~state ~sw ~clock request ~args =
+let operator_control_context ~state ~sw ~clock ~config ~agent_name
+    : _ Operator_control.context
+  =
+  { config
+  ; agent_name
+  ; sw
+  ; clock
+  ; proc_mgr = state.Mcp_server.proc_mgr
+  ; net = state.Mcp_server.net
+  ; delegated_dispatch =
+      Some
+        (Keeper_tool_boundary.delegated_dispatch
+           ~config
+           ~agent_name
+           ~sw
+           ~clock
+           ~proc_mgr:state.Mcp_server.proc_mgr
+           ~net:state.Mcp_server.net
+           ~publication_recovery_provider:
+             (Mcp_server.publication_recovery_availability_provider state))
+  ; mcp_session_id = None
+  }
+;;
+
+let operator_action_http_json ~state ~sw ~clock ~authorized_actor request ~args =
   let workspace_scope = Mcp_server.workspace_scope state in
-  let actor =
-    Server_auth.dashboard_actor_for_request
-      ~base_path:workspace_scope.config.base_path
-      request
-  in
-  let ctx : _ Operator_control.context =
-    { config = workspace_scope.config
-    ; agent_name = Option.value ~default:"dashboard" actor
-    ; sw
-    ; clock
-    ; proc_mgr = state.Mcp_server.proc_mgr
-    ; net = state.Mcp_server.net
-    ; publication_recovery_provider =
-        Mcp_server.publication_recovery_availability_provider state
-    ; mcp_session_id = None
-    }
-  in
-  Operator_control.confirm_json ?actor_hint:actor ctx args
+  match explicit_operator_actor ~authorized_actor request with
+  | Error _ as error -> error
+  | Ok actor ->
+    let ctx =
+      operator_control_context
+        ~state
+        ~sw
+        ~clock
+        ~config:workspace_scope.config
+        ~agent_name:actor
+    in
+    Operator_control.action_json ~actor_hint:actor ctx args
+;;
+
+let operator_confirm_http_json ~state ~sw ~clock ~authorized_actor request ~args =
+  let workspace_scope = Mcp_server.workspace_scope state in
+  match explicit_operator_actor ~authorized_actor request with
+  | Error _ as error -> error
+  | Ok actor ->
+    let ctx =
+      operator_control_context
+        ~state
+        ~sw
+        ~clock
+        ~config:workspace_scope.config
+        ~agent_name:actor
+    in
+    Operator_control.confirm_json ~actor_hint:actor ctx args
 ;;
 
 let operator_error_json message =

--- a/lib/server/server_dashboard_http.mli
+++ b/lib/server/server_dashboard_http.mli
@@ -146,6 +146,7 @@ val operator_action_http_json :
   state:Mcp_server.server_state ->
   sw:Eio.Switch.t ->
   clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  authorized_actor:string ->
   Httpun.Request.t ->
   args:Yojson.Safe.t ->
   (Yojson.Safe.t, string) result
@@ -154,6 +155,7 @@ val operator_confirm_http_json :
   state:Mcp_server.server_state ->
   sw:Eio.Switch.t ->
   clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  authorized_actor:string ->
   Httpun.Request.t ->
   args:Yojson.Safe.t ->
   (Yojson.Safe.t, string) result

--- a/lib/server/server_dashboard_http_core_digest_refresh.ml
+++ b/lib/server/server_dashboard_http_core_digest_refresh.ml
@@ -61,8 +61,7 @@ let start_operator_digest_refresh_loop ~state ~sw ~clock =
              ; clock
              ; proc_mgr
              ; net = None
-             ; publication_recovery_provider =
-                 Mcp_server.publication_recovery_availability_provider state
+             ; delegated_dispatch = None
              ; mcp_session_id = None
              }
            in

--- a/lib/server/server_dashboard_http_core_operator_digest_http.ml
+++ b/lib/server/server_dashboard_http_core_operator_digest_http.ml
@@ -124,8 +124,7 @@ let operator_digest_http_json ~state ~sw ~clock request =
                     ; clock
                     ; proc_mgr = state.Mcp_server.proc_mgr
                     ; net = state.Mcp_server.net
-                    ; publication_recovery_provider =
-                        Mcp_server.publication_recovery_availability_provider state
+                    ; delegated_dispatch = None
                     ; mcp_session_id = None
                     }
                   in

--- a/lib/server/server_dashboard_http_core_operator_snapshot_http.ml
+++ b/lib/server/server_dashboard_http_core_operator_snapshot_http.ml
@@ -78,8 +78,7 @@ let operator_snapshot_http_json ~state ~sw ~clock request =
            ; clock
            ; proc_mgr
            ; net = None
-           ; publication_recovery_provider =
-               Mcp_server.publication_recovery_availability_provider state
+           ; delegated_dispatch = None
            ; mcp_session_id = None
            }
          in
@@ -167,8 +166,7 @@ let operator_snapshot_http_json ~state ~sw ~clock request =
                     ; clock
                     ; proc_mgr
                     ; net = state.Mcp_server.net
-                    ; publication_recovery_provider =
-                        Mcp_server.publication_recovery_availability_provider state
+                    ; delegated_dispatch = None
                     ; mcp_session_id = None
                     }
                   in

--- a/lib/server/server_dashboard_http_core_snapshot_refresh.ml
+++ b/lib/server/server_dashboard_http_core_snapshot_refresh.ml
@@ -51,8 +51,7 @@ let start_operator_snapshot_refresh_loop ~state ~sw ~clock =
              ; clock
              ; proc_mgr
              ; net = None
-             ; publication_recovery_provider =
-                 Mcp_server.publication_recovery_availability_provider state
+             ; delegated_dispatch = None
              ; mcp_session_id = None
              }
            in

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -1236,11 +1236,19 @@ let add_routes ~sw ~clock router =
              respond_json_value_with_cors ~status:`Bad_request request reqd (operator_error_json message)
        ) request reqd)
   |> Http.Router.post "/api/v1/operator/action" (fun request reqd ->
-       with_tool_auth ~tool_name:"masc_operator_action" (fun state req reqd ->
+       with_tool_actor_auth ~tool_name:"masc_operator_action" (fun state authorized_actor req reqd ->
          Http.Request.read_body_async reqd (fun body_str ->
            try
              let args = Yojson.Safe.from_string body_str in
-             match operator_action_http_json ~state ~sw ~clock req ~args with
+             match
+               operator_action_http_json
+                 ~state
+                 ~sw
+                 ~clock
+                 ~authorized_actor
+                 req
+                 ~args
+             with
              | Ok json ->
                  respond_json_value_with_cors request reqd json
              | Error message ->
@@ -1250,11 +1258,19 @@ let add_routes ~sw ~clock router =
          )
        ) request reqd)
   |> Http.Router.post "/api/v1/operator/confirm" (fun request reqd ->
-       with_tool_auth ~tool_name:"masc_operator_confirm" (fun state req reqd ->
+       with_tool_actor_auth ~tool_name:"masc_operator_confirm" (fun state authorized_actor req reqd ->
          Http.Request.read_body_async reqd (fun body_str ->
            try
              let args = Yojson.Safe.from_string body_str in
-             match operator_confirm_http_json ~state ~sw ~clock req ~args with
+             match
+               operator_confirm_http_json
+                 ~state
+                 ~sw
+                 ~clock
+                 ~authorized_actor
+                 req
+                 ~args
+             with
              | Ok json ->
                  respond_json_value_with_cors request reqd json
              | Error message ->

--- a/lib/tool_operator.ml
+++ b/lib/tool_operator.ml
@@ -5,8 +5,8 @@ type 'a context = {
   clock : 'a Eio.Time.clock;
   proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option;
   net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option;
-  publication_recovery_provider :
-    Keeper_publication_recovery_availability.provider;
+  delegated_dispatch :
+    (name:string -> args:Yojson.Safe.t -> Tool_result.result option) option;
   mcp_session_id : string option;
 }
 

--- a/lib/tool_operator.mli
+++ b/lib/tool_operator.mli
@@ -5,8 +5,8 @@ type 'a context = {
   clock : 'a Eio.Time.clock;
   proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option;
   net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option;
-  publication_recovery_provider :
-    Keeper_publication_recovery_availability.provider;
+  delegated_dispatch :
+    (name:string -> args:Yojson.Safe.t -> Tool_result.result option) option;
   mcp_session_id : string option;
 }
 

--- a/scripts/ci/check-publication-recovery-test-boundary.sh
+++ b/scripts/ci/check-publication-recovery-test-boundary.sh
@@ -3,16 +3,38 @@ set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
 
-test_facade_matches="$({
-  rg -n --no-heading \
+if ! command -v rg >/dev/null 2>&1; then
+  echo "publication recovery boundary scan requires rg" >&2
+  exit 2
+fi
+
+rg_or_empty() {
+  local output status
+  if output="$(rg "$@")"; then
+    printf '%s' "$output"
+  else
+    status=$?
+    if [[ "$status" -eq 1 ]]; then
+      return 0
+    fi
+    echo "publication recovery boundary scan failed: rg exited ${status}" >&2
+    return "$status"
+  fi
+}
+
+test_facade_candidates="$(
+  rg_or_empty -n --no-heading \
     '\bPublication_recovery_for_testing\b' \
     lib bin \
     --glob '*.ml' \
-    --glob '*.mli' \
-    | rg -v \
-        '^lib/fs_compat/(fs_compat|publication_recovery_for_testing)\.mli?:' \
-    || true
-})"
+    --glob '*.mli'
+)"
+
+test_facade_matches="$(
+  rg_or_empty -v \
+    '^lib/fs_compat/publication_recovery_for_testing\.mli?:' \
+    <<<"$test_facade_candidates"
+)"
 
 if [[ -n "$test_facade_matches" ]]; then
   echo "publication recovery test surface escaped into production code:" >&2
@@ -20,17 +42,62 @@ if [[ -n "$test_facade_matches" ]]; then
   exit 1
 fi
 
-forbidden_fixture_api_matches="$({
-  rg -n --no-heading \
-    '\b(publication_recovery_record_area|publication_recovery_fixture_error|run_publication_recovery_resource_scope|run_publication_recovery_cleanup_boundary|single_publication_recovery_borrow_balance|publication_recovery_stage_name|seed_prepared_publication_recovery|seed_bound_publication_recovery|write_raw_publication_recovery_record|public_registry)\b' \
+removed_public_test_path_matches="$(
+  rg_or_empty -n --no-heading \
+    '\bFs_compat\.(Publication_recovery_for_testing|Capability_write_for_testing)\b' \
+    lib bin test \
+    --glob '*.ml' \
+    --glob '*.mli'
+)"
+
+if [[ -n "$removed_public_test_path_matches" ]]; then
+  echo "removed publication recovery test path exists:" >&2
+  echo "$removed_public_test_path_matches" >&2
+  exit 1
+fi
+
+forbidden_fixture_api_matches="$(
+  rg_or_empty -n --no-heading \
+    '\b(Publication_recovery_for_testing|Capability_write_for_testing|publication_recovery_access|publication_recovery_registry|publication_recovery_registry_error|publication_recovery_lane_open_error|publication_recovery_lane_open_error_kind|Publication_recovery_invalid_owner|Publication_recovery_reconciliation_blocked|Publication_recovery_store_failed|open_publication_recovery_registry|publication_recovery_registry_error_to_string|with_publication_recovery_lane|publication_recovery_lane_open_error_to_string|publication_recovery_record_area|publication_recovery_fixture_error|run_publication_recovery_resource_scope|run_publication_recovery_cleanup_boundary|single_publication_recovery_borrow_balance|publication_recovery_stage_name|seed_prepared_publication_recovery|seed_bound_publication_recovery|write_raw_publication_recovery_record|public_registry)\b' \
     lib/fs_compat/fs_compat.ml \
-    lib/fs_compat/fs_compat.mli \
-    || true
-})"
+    lib/fs_compat/fs_compat.mli
+)"
 
 if [[ -n "$forbidden_fixture_api_matches" ]]; then
   echo "forbidden publication recovery fixture API exists in Fs_compat:" >&2
   echo "$forbidden_fixture_api_matches" >&2
+  exit 1
+fi
+
+test_library_source_leaks="$(
+  rg_or_empty -n --no-heading \
+    '\bFs_compat_test_support\b' \
+    lib bin \
+    --glob '*.ml' \
+    --glob '*.mli'
+)"
+
+if [[ -n "$test_library_source_leaks" ]]; then
+  echo "workspace-only fs_compat test library escaped into production code:" >&2
+  echo "$test_library_source_leaks" >&2
+  exit 1
+fi
+
+internal_library_candidates="$(
+  rg_or_empty -n --no-heading \
+    '\bFs_compat_internal\b' \
+    lib bin \
+    --glob '*.ml' \
+    --glob '*.mli'
+)"
+
+internal_library_source_leaks="$(
+  rg_or_empty -v '^lib/fs_compat/' <<<"$internal_library_candidates"
+)"
+
+if [[ -n "$internal_library_source_leaks" ]]; then
+  echo "package-private fs_compat library escaped its owning directory:" >&2
+  echo "$internal_library_source_leaks" >&2
   exit 1
 fi
 

--- a/scripts/lint/tool-keeper-boundary-ratchet.sh
+++ b/scripts/lint/tool-keeper-boundary-ratchet.sh
@@ -78,7 +78,7 @@ keeper_call_in_file() {
     }
     print join("", @o);
   ' < "$1")"
-  rg -q '\b(Agent_tool_descriptor|Agent_tool_descriptor_resolution|Agent_tool_dispatch_runtime|Keeper_tool_alias|Keeper_types_profile|Task_keeper_backend)\b|\bKeeper_[A-Za-z_]+\.[a-z]' <<<"$stripped"
+  rg -q '\b(Agent_tool_descriptor|Agent_tool_descriptor_resolution|Agent_tool_dispatch_runtime|Keeper_tool_alias|Keeper_types_profile|Task_keeper_backend)\b|\bKeeper_[A-Za-z_]+\.[a-z]|\b(open|include)[[:space:]]+(Masc\.)?(Agent_tool_descriptor|Agent_tool_descriptor_resolution|Agent_tool_dispatch_runtime|Keeper_[A-Za-z_]+|Task_keeper_backend)\b|\bmodule[[:space:]]+[A-Z][A-Za-z0-9_]*(\x27)?[[:space:]]*=[[:space:]]*(Masc\.)?(Agent_tool_descriptor|Agent_tool_descriptor_resolution|Agent_tool_dispatch_runtime|Keeper_[A-Za-z_]+|Task_keeper_backend)\b' <<<"$stripped"
 }
 
 current_callers() {

--- a/test/deps/masc_test_deps.ml
+++ b/test/deps/masc_test_deps.ml
@@ -233,12 +233,12 @@ let cleanup_test_workspace dir =
 let with_publication_recovery_registry ~sw ~fs ~registry_root f =
   let registry_root = Eio.Path.(fs / registry_root) in
   match
-    Fs_compat.open_publication_recovery_registry ~sw ~fs ~registry_root
+    Fs_compat.Publication_recovery.open_registry ~sw ~fs ~registry_root
   with
   | Error error ->
     failwith
       ("test publication recovery registry open failed: "
-       ^ Fs_compat.publication_recovery_registry_error_to_string error)
+       ^ Fs_compat.Publication_recovery.registry_error_to_string error)
   | Ok publication_recovery_registry ->
     (match
        Fs_compat.Publication_recovery.discover_owners

--- a/test/stanzas/test_eio_resource_scope.inc
+++ b/test/stanzas/test_eio_resource_scope.inc
@@ -1,4 +1,4 @@
 (test
  (name test_eio_resource_scope)
  (modules test_eio_resource_scope)
- (libraries alcotest fs_compat eio eio_main))
+ (libraries alcotest fs_compat fs_compat_test_support eio eio_main))

--- a/test/stanzas/test_fs_compat_capability_write.inc
+++ b/test/stanzas/test_fs_compat_capability_write.inc
@@ -1,4 +1,4 @@
 (test
  (name test_fs_compat_capability_write)
  (modules test_fs_compat_capability_write)
- (libraries alcotest fs_compat eio eio_main eio.unix unix))
+ (libraries alcotest fs_compat fs_compat_test_support eio eio_main eio.unix unix))

--- a/test/stanzas/test_fs_compat_publication_reconciliation.inc
+++ b/test/stanzas/test_fs_compat_publication_reconciliation.inc
@@ -1,4 +1,14 @@
 (test
  (name test_fs_compat_publication_reconciliation)
  (modules test_fs_compat_publication_reconciliation)
- (libraries alcotest fs_compat eio eio_main eio.unix unix uuidm yojson digestif))
+ (libraries
+  alcotest
+  fs_compat
+  fs_compat_test_support
+  eio
+  eio_main
+  eio.unix
+  unix
+  uuidm
+  yojson
+  digestif))

--- a/test/stanzas/test_keeper_tool_dispatch_runtime.inc
+++ b/test/stanzas/test_keeper_tool_dispatch_runtime.inc
@@ -1,4 +1,4 @@
 (test
  (name test_keeper_tool_dispatch_runtime)
  (modules test_keeper_tool_dispatch_runtime)
- (libraries masc_test_deps))
+ (libraries masc_test_deps fs_compat_test_support))

--- a/test/stanzas/test_mcp_tool_matrix.inc
+++ b/test/stanzas/test_mcp_tool_matrix.inc
@@ -12,4 +12,7 @@
  (action
   (setenv HOME ""
    (run %{test})))
- (libraries masc_test_deps keeper_tool_matrix_cases_lib))
+ (libraries
+  masc_test_deps
+  keeper_tool_matrix_cases_lib
+  fs_compat_test_support))

--- a/test/test_eio_resource_scope.ml
+++ b/test/test_eio_resource_scope.ml
@@ -1,6 +1,6 @@
 open Alcotest
 
-module Scope = Fs_compat.Publication_recovery_for_testing
+module Scope = Fs_compat_test_support.Publication_recovery_for_testing
 module Cleanup = Scope.For_testing
 
 exception Callback_cancelled

--- a/test/test_fs_compat_capability_write.ml
+++ b/test/test_fs_compat_capability_write.ml
@@ -1,5 +1,8 @@
 open Alcotest
 
+module Capability_write_test =
+  Fs_compat_test_support.Capability_write_for_testing
+
 let with_tmp_dir f =
   let path = Filename.temp_file "masc_capability_write_" ".tmp" in
   Sys.remove path;
@@ -42,13 +45,13 @@ let with_publication_recovery_access ~fs f =
   with_tmp_dir @@ fun registry_directory ->
   Eio.Switch.run @@ fun sw ->
   match
-    Fs_compat.open_publication_recovery_registry
+    Fs_compat.Publication_recovery.open_registry
       ~sw
       ~fs
       ~registry_root:Eio.Path.(fs / registry_directory)
   with
   | Error error ->
-    fail (Fs_compat.publication_recovery_registry_error_to_string error)
+    fail (Fs_compat.Publication_recovery.registry_error_to_string error)
   | Ok registry ->
     (match Fs_compat.Publication_recovery.discover_owners registry with
      | Error error ->
@@ -57,7 +60,7 @@ let with_publication_recovery_access ~fs f =
             error)
      | Ok [] ->
        (match
-          Fs_compat.with_publication_recovery_lane
+          Fs_compat.Publication_recovery.with_lane
             ~registry
             ~owner:"capability-write-test"
             f
@@ -67,7 +70,7 @@ let with_publication_recovery_access ~fs f =
           fail "publication recovery lane release failed"
         | Error error ->
           fail
-            (Fs_compat.publication_recovery_lane_open_error_to_string
+            (Fs_compat.Publication_recovery.lane_open_error_to_string
                error))
      | Ok rows ->
        failf
@@ -120,7 +123,7 @@ let replace_capability_file_for_testing
   let target =
     require_recovery_target ~allowed_root_path ~parent ~leaf ~permissions
   in
-  Fs_compat.Capability_write_for_testing.replace_capability_file
+  Capability_write_test.replace_capability_file
     ~before_stage
     ~recovery
     ~parent
@@ -644,7 +647,7 @@ let test_existing_replace_yields_to_cooperative_absent_publication ~fs () =
   let create_result, resolve_create_result = Eio.Promise.create () in
   Eio.Fiber.fork ~sw (fun () ->
     let result =
-      Fs_compat.Capability_write_for_testing.create_capability_file_exclusive
+      Capability_write_test.create_capability_file_exclusive
         ~before_stage:(function
           | Fs_compat.Inspect_open_resource ->
             Eio.Promise.resolve resolve_create_visible ();
@@ -862,7 +865,7 @@ let test_exclusive_create_visibility_remains_under_parent_lease ~fs () =
   let create_result, resolve_create_result = Eio.Promise.create () in
   Eio.Fiber.fork ~sw (fun () ->
     let result =
-      Fs_compat.Capability_write_for_testing.create_capability_file_exclusive
+      Capability_write_test.create_capability_file_exclusive
         ~before_stage:(function
           | Fs_compat.Inspect_open_resource ->
             Eio.Promise.resolve resolve_target_visible ();
@@ -1120,7 +1123,7 @@ let test_create_failure_leaves_public_leaf ~fs () =
   let target = Filename.concat directory "target" in
   with_parent_capability ~fs directory @@ fun parent ->
   (match
-     Fs_compat.Capability_write_for_testing.create_capability_file_exclusive
+     Capability_write_test.create_capability_file_exclusive
        ~before_stage:(function
          | Fs_compat.Apply_permissions -> raise Exit
          | _ -> ())
@@ -1144,7 +1147,7 @@ let test_create_parent_sync_failure_preserves_complete_effect ~fs () =
   let target = Filename.concat directory "target" in
   with_parent_capability ~fs directory @@ fun parent ->
   (match
-     Fs_compat.Capability_write_for_testing.create_capability_file_exclusive
+     Capability_write_test.create_capability_file_exclusive
        ~before_stage:(function
          | Fs_compat.Sync_parent -> raise Exit
          | _ -> ())
@@ -1271,7 +1274,7 @@ let test_create_primary_failure_survives_cleanup_cancellation ~fs () =
     try
       Eio.Cancel.sub (fun context ->
         ignore
-          (Fs_compat.Capability_write_for_testing.create_capability_file_exclusive
+          (Capability_write_test.create_capability_file_exclusive
              ~before_stage:(function
                | Fs_compat.Write_payload -> raise Exit
                | Fs_compat.Cleanup_close ->
@@ -1414,7 +1417,7 @@ let test_exclusive_create_cancellation_reports_incomplete_entry ~fs () =
     try
       Eio.Cancel.sub (fun context ->
         ignore
-          (Fs_compat.Capability_write_for_testing.create_capability_file_exclusive
+          (Capability_write_test.create_capability_file_exclusive
              ~before_stage:(function
                | Fs_compat.Apply_permissions ->
                  Eio.Cancel.cancel context Exit;
@@ -1506,7 +1509,7 @@ let test_create_commit_cancellation_reports_complete_effect ~fs () =
     try
       Eio.Cancel.sub (fun context ->
         ignore
-          (Fs_compat.Capability_write_for_testing.create_capability_file_exclusive
+          (Capability_write_test.create_capability_file_exclusive
              ~before_stage:(function
                | Fs_compat.Sync_parent -> Eio.Cancel.cancel context Exit
                | _ -> ())
@@ -1733,7 +1736,7 @@ let test_directory_sync_failure_is_typed ~fs () =
   with_tmp_dir @@ fun directory ->
   with_parent_capability ~fs directory @@ fun parent ->
   match
-    Fs_compat.Capability_write_for_testing.sync_directory_capability
+    Capability_write_test.sync_directory_capability
       ~before_stage:(function
         | Fs_compat.Sync_parent -> raise Exit
         | _ -> ())

--- a/test/test_fs_compat_publication_reconciliation.ml
+++ b/test/test_fs_compat_publication_reconciliation.ml
@@ -1,6 +1,6 @@
 open Alcotest
 
-module Recovery = Fs_compat.Publication_recovery_for_testing
+module Recovery = Fs_compat_test_support.Publication_recovery_for_testing
 
 let with_tmp_dir f =
   let path = Filename.temp_file "masc_publication_reconcile_" ".tmp" in

--- a/test/test_keeper_adversarial_review.ml
+++ b/test/test_keeper_adversarial_review.ml
@@ -38,7 +38,7 @@ let publication_recovery_registry env sw config =
     Eio.Path.(Eio.Stdenv.fs env / Masc.Workspace.masc_root_dir config)
   in
   match
-    Fs_compat.open_publication_recovery_registry
+    Fs_compat.Publication_recovery.open_registry
       ~sw
       ~fs:(Eio.Stdenv.fs env)
       ~registry_root
@@ -46,9 +46,13 @@ let publication_recovery_registry env sw config =
   | Ok registry -> registry
   | Error error ->
     fail
-      (Fs_compat.publication_recovery_registry_error_to_string error)
+      (Fs_compat.Publication_recovery.registry_error_to_string error)
 
 let operator_ctx env sw config agent_name : _ Operator_control.context =
+  let publication_recovery_provider =
+    Masc_test_deps.publication_recovery_provider
+      (publication_recovery_registry env sw config)
+  in
   {
     config;
     agent_name;
@@ -56,9 +60,16 @@ let operator_ctx env sw config agent_name : _ Operator_control.context =
     clock = Eio.Stdenv.clock env;
     proc_mgr = Some (Eio.Stdenv.process_mgr env);
     net = Some (Eio.Stdenv.net env);
-    publication_recovery_provider =
-      Masc_test_deps.publication_recovery_provider
-        (publication_recovery_registry env sw config);
+    delegated_dispatch =
+      Some
+        (Masc.Keeper_tool_boundary.delegated_dispatch
+           ~config
+           ~agent_name
+           ~sw
+           ~clock:(Eio.Stdenv.clock env)
+           ~proc_mgr:(Some (Eio.Stdenv.process_mgr env))
+           ~net:(Some (Eio.Stdenv.net env))
+           ~publication_recovery_provider);
     mcp_session_id = None;
   }
 

--- a/test/test_keeper_effective_meta_overlay.ml
+++ b/test/test_keeper_effective_meta_overlay.ml
@@ -714,7 +714,7 @@ instructions = "missing sandbox profile"
       in
       let publication_recovery_registry =
         match
-          Fs_compat.open_publication_recovery_registry
+          Fs_compat.Publication_recovery.open_registry
             ~sw
             ~fs:(Eio.Stdenv.fs env)
             ~registry_root
@@ -722,7 +722,7 @@ instructions = "missing sandbox profile"
         | Ok registry -> registry
         | Error error ->
           Alcotest.fail
-            (Fs_compat.publication_recovery_registry_error_to_string error)
+            (Fs_compat.Publication_recovery.registry_error_to_string error)
       in
       let ctx : _ Keeper_tool_surface.context =
         {

--- a/test/test_keeper_lifecycle_registry_dispatch.ml
+++ b/test/test_keeper_lifecycle_registry_dispatch.ml
@@ -39,7 +39,7 @@ let publication_recovery_registry env sw config =
     Eio.Path.(Eio.Stdenv.fs env / Masc.Workspace.masc_root_dir config)
   in
   match
-    Fs_compat.open_publication_recovery_registry
+    Fs_compat.Publication_recovery.open_registry
       ~sw
       ~fs:(Eio.Stdenv.fs env)
       ~registry_root
@@ -47,7 +47,7 @@ let publication_recovery_registry env sw config =
   | Ok registry -> registry
   | Error error ->
     fail
-      (Fs_compat.publication_recovery_registry_error_to_string error)
+      (Fs_compat.Publication_recovery.registry_error_to_string error)
 
 let write_lines path lines =
   let dir = KFS.ensure_dir (Filename.dirname path) in

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -511,7 +511,7 @@ let publication_recovery_registry env sw config =
     Eio.Path.(Eio.Stdenv.fs env / Masc.Workspace.masc_root_dir config)
   in
   match
-    Fs_compat.open_publication_recovery_registry
+    Fs_compat.Publication_recovery.open_registry
       ~sw
       ~fs:(Eio.Stdenv.fs env)
       ~registry_root
@@ -519,7 +519,7 @@ let publication_recovery_registry env sw config =
   | Ok registry -> registry
   | Error error ->
     fail
-      (Fs_compat.publication_recovery_registry_error_to_string error)
+      (Fs_compat.Publication_recovery.registry_error_to_string error)
 
 let keeper_runtime_context env sw config : _ Keeper_types_profile.context =
   { config

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -6,7 +6,9 @@ module KTD = Masc.Keeper_tool_descriptor
 module Workspace = Masc.Workspace
 module Publication_availability =
   Masc.Keeper_publication_recovery_availability
-module Recovery_test = Fs_compat.Publication_recovery_for_testing
+module Recovery_test = Fs_compat_test_support.Publication_recovery_for_testing
+module Capability_write_test =
+  Fs_compat_test_support.Capability_write_for_testing
 
 let tool_ok ?(tool_name = "") message =
   Tool_result.make_ok ~tool_name ~start_time:0.0 ~data:(`String message) ()
@@ -990,7 +992,7 @@ let test_publication_reconciliation_evidence_is_redacted () =
        in
        (match
           Recovery_test.seed_prepared
-            ~registry:(Recovery_test.private_registry registry)
+            ~registry:(registry)
             ~owner:meta.name
             ~operation_id
             ~allowed_root_path:allowed_root_sentinel
@@ -1007,7 +1009,7 @@ let test_publication_reconciliation_evidence_is_redacted () =
           fail (Recovery_test.fixture_error_to_string error));
        (match
           Recovery_test.write_raw_record
-            ~registry:(Recovery_test.private_registry registry)
+            ~registry:(registry)
             ~owner:meta.name
             ~area:Recovery_test.Forensic
             ~record_name:operation_id_text
@@ -1064,7 +1066,7 @@ let test_publication_registry_evidence_is_redacted () =
        let registry_error =
          Eio.Switch.run @@ fun sw ->
          match
-           Fs_compat.open_publication_recovery_registry
+           Fs_compat.Publication_recovery.open_registry
              ~sw
              ~fs
              ~registry_root:Eio.Path.(fs / registry_path_sentinel)
@@ -1201,7 +1203,7 @@ let test_publication_write_cancellation_releases_exact_lane () =
        let registry_root = Eio.Path.(fs / registry_dir) in
        let registry =
          match
-           Fs_compat.open_publication_recovery_registry
+           Fs_compat.Publication_recovery.open_registry
              ~sw
              ~fs
              ~registry_root
@@ -1209,7 +1211,7 @@ let test_publication_write_cancellation_releases_exact_lane () =
          | Ok registry -> registry
          | Error error ->
            fail
-             (Fs_compat.publication_recovery_registry_error_to_string error)
+             (Fs_compat.Publication_recovery.registry_error_to_string error)
        in
        (match Fs_compat.Publication_recovery.discover_owners registry with
         | Ok [] -> ()
@@ -1251,7 +1253,7 @@ let test_publication_write_cancellation_releases_exact_lane () =
             publication_recovery
             (fun publication_recovery_access ->
                Eio.Cancel.sub (fun cancellation_context ->
-                 Fs_compat.Capability_write_for_testing.replace_capability_file
+                 Capability_write_test.replace_capability_file
                    ~before_stage:(function
                      | Fs_compat.Acquire_mutation_lease ->
                        Atomic.set cancellation_hook_observed true;
@@ -1311,103 +1313,433 @@ let test_publication_write_cancellation_releases_exact_lane () =
          (read_file target_path))
 ;;
 
-let test_committed_publication_release_failure_preserves_effect_truth () =
+let test_real_publication_release_failure_preserves_effect_truth () =
   let exception Injected_release_failure of string in
-  let exception_ =
-    Injected_release_failure "private-release-failure-evidence"
-  in
-  let backtrace =
-    try raise exception_ with
-    | observed ->
-      check bool "exact injected release failure" true (observed == exception_);
-      Printexc.get_raw_backtrace ()
-  in
-  let release_failure =
-    match
-      Fs_compat.Publication_recovery_for_testing.For_testing.lane_release_failure
-        ~owner:"committed-publication"
-        ~exception_
-        ~backtrace
-    with
-    | Ok failure ->
-      Fs_compat.Publication_recovery_for_testing
-      .public_lane_release_failure
-        failure
-    | Error error ->
-      fail
-        (Fs_compat.Publication_recovery_for_testing.validation_error_to_string error)
-  in
-  let execution =
-    Masc.Keeper_tool_filesystem_runtime.For_testing
-    .committed_publication_release_failure
-      ~keeper_name:"committed-publication"
-      ~release_failure
-  in
-  (match execution.outcome with
-   | Masc.Keeper_tool_execution.Failed Tool_result.Runtime_failure -> ()
-   | Masc.Keeper_tool_execution.Failed failure_class ->
-     failf
-       "cleanup failure received wrong class: %s"
-       (Tool_result.tool_failure_class_to_string failure_class)
-   | Masc.Keeper_tool_execution.Succeeded ->
-     fail "cleanup failure was reported as success");
-  check string
-    "committed effect and cleanup failure are both explicit"
-    "filesystem publication committed, but publication recovery lane cleanup failed"
-    execution.raw_output;
-  let data =
-    match execution.data with
-    | Some data -> data
-    | None -> fail "cleanup failure omitted typed data"
-  in
-  check string
-    "typed cleanup error"
-    "publication_recovery_cleanup_failed"
-    Yojson.Safe.Util.(member "error" data |> to_string);
-  check string
-    "release phase is explicit"
-    "lane_release_failed"
-    Yojson.Safe.Util.(member "state" data |> to_string);
-  check bool
-    "committed write is never relabelled as unexecuted"
-    true
-    Yojson.Safe.Util.(member "write_executed" data |> to_bool);
-  check bool
-    "Keeper remains active after lane cleanup failure"
-    true
-    Yojson.Safe.Util.(member "keeper_active" data |> to_bool);
-  let failed_execution =
-    Masc.Keeper_tool_filesystem_runtime.For_testing
-    .failed_publication_release_failure
-      ~keeper_name:"committed-publication"
-      ~target_effect:Fs_compat.Target_replaced
-      ~release_failure
-  in
-  (match failed_execution.outcome with
-   | Masc.Keeper_tool_execution.Failed Tool_result.Runtime_failure -> ()
-   | Masc.Keeper_tool_execution.Failed failure_class ->
-     failf
-       "post-rename failure received wrong class: %s"
-       (Tool_result.tool_failure_class_to_string failure_class)
-   | Masc.Keeper_tool_execution.Succeeded ->
-     fail "post-rename failure was reported as success");
-  let failed_data =
-    match failed_execution.data with
-    | Some data -> data
-    | None -> fail "post-rename cleanup failure omitted typed data"
-  in
-  check bool
-    "post-rename callback failure preserves the executed target effect"
-    true
-    Yojson.Safe.Util.(member "write_executed" failed_data |> to_bool);
-  check string
-    "post-rename target effect remains explicit"
-    "target_replaced"
-    Yojson.Safe.Util.(
-      failed_data
-      |> member "publication_result"
-      |> member "filesystem_target_effect"
-      |> to_string)
+  let exception Injected_write_failure of string in
+  with_exec_fixture
+    ~always_allow:true
+    "keeper_tool_dispatch_release_failure_effect_truth"
+    (fun ~config ~meta ~publication_recovery:fixture_recovery ~ctx_work ->
+       let registry =
+         match fixture_recovery.provider () with
+         | Publication_availability.Available registry -> registry
+         | Publication_availability.Initializing
+         | Publication_availability.Registry_unavailable _
+         | Publication_availability.Initialization_crashed _
+         | Publication_availability.Non_runtime ->
+           fail "fixture did not provide its exact recovery registry"
+       in
+       let provider_reads = Atomic.make 0 in
+       let publication_recovery =
+         { Publication_availability.provider =
+             (fun () ->
+                Atomic.incr provider_reads;
+                Publication_availability.Available registry)
+         ; keeper_name = meta.name
+         }
+       in
+       let target = Filename.concat config.base_path "release-effect.txt" in
+       let execute_at target content =
+         KET.execute_keeper_tool_call_with_outcome
+           ~config
+           ~meta
+           ~publication_recovery
+           ~ctx_work
+           ~exec_cache:None
+           ~name:"Write"
+           ~input:
+             (`Assoc
+                [ "file_path", `String target
+                ; "content", `String content
+                ])
+           ()
+       in
+       let execute content = execute_at target content in
+       let warmup = execute "warmup" in
+       check string "warmup Write succeeds" "success"
+         (outcome_label warmup.outcome);
+       let release_fault =
+         match
+           Recovery_test.lane_scope_release_fault
+             ~owner:meta.name
+             ~exception_:
+               (Injected_release_failure
+                  "private-release-failure-evidence")
+         with
+         | Ok fault -> fault
+         | Error error ->
+           fail (Recovery_test.validation_error_to_string error)
+       in
+       let committed =
+         Recovery_test.with_lane_scope_release_fault release_fault (fun () ->
+           execute "committed")
+       in
+       (match committed.outcome with
+        | `Failure Tool_result.Runtime_failure -> ()
+        | `Failure failure_class ->
+          failf
+            "cleanup failure received wrong class: %s"
+            (Tool_result.tool_failure_class_to_string failure_class)
+        | `Success -> fail "cleanup failure was reported as success");
+       check string
+         "committed effect and cleanup failure are both explicit"
+         "filesystem publication committed, but publication recovery lane cleanup failed"
+         committed.raw_output;
+       let committed_data =
+         match committed.data with
+         | Some data -> data
+         | None -> fail "cleanup failure omitted typed data"
+       in
+       check
+         (testable Yojson.Safe.pp Yojson.Safe.equal)
+         "committed cleanup failure has the exact typed public projection"
+         (`Assoc
+            [ "error", `String "publication_recovery_cleanup_failed"
+            ; "failure_class", `String "runtime_failure"
+            ; "state", `String "lane_release_failed"
+            ; ( "detail"
+              , `String
+                  "publication recovery lane cleanup failed after the publication callback returned" )
+            ; "write_executed", `Bool true
+            ; "keeper_active", `Bool true
+            ; ( "publication_result"
+              , `Assoc [ "outcome", `String "success" ] )
+            ])
+         committed_data;
+       check string "committed bytes reached the real target" "committed"
+         (read_file target);
+       let recovered = execute "recovered" in
+       check string "same Keeper lane recovers on the next Write" "success"
+         (outcome_label recovered.outcome);
+       check string "recovered Write publishes exact bytes" "recovered"
+         (read_file target);
+       let write_fault =
+         Recovery_test.replace_dispatch_fault
+           ~stage:Recovery_test.Before_parent_sync
+           ~exception_:
+             (Injected_write_failure "private-write-failure-evidence")
+       in
+       let failed_after_replace =
+         Recovery_test.with_lane_scope_release_fault release_fault (fun () ->
+           Recovery_test.with_replace_dispatch_fault write_fault (fun () ->
+             execute "replaced-before-failure"))
+       in
+       (match failed_after_replace.outcome with
+        | `Failure Tool_result.Runtime_failure -> ()
+        | `Failure failure_class ->
+          failf
+            "post-replace cleanup failure received wrong class: %s"
+            (Tool_result.tool_failure_class_to_string failure_class)
+        | `Success -> fail "post-replace cleanup failure was reported as success");
+       check string
+         "post-replace callback and cleanup failures remain explicit"
+         "filesystem publication produced an observable filesystem effect before the publication callback and recovery lane cleanup both failed"
+         failed_after_replace.raw_output;
+       let failed_after_replace_data =
+         match failed_after_replace.data with
+         | Some data -> data
+         | None -> fail "post-replace cleanup failure omitted typed data"
+       in
+       check
+         (testable Yojson.Safe.pp Yojson.Safe.equal)
+         "post-replace cleanup failure preserves exact typed effect truth"
+         (`Assoc
+            [ "error", `String "publication_recovery_cleanup_failed"
+            ; "failure_class", `String "runtime_failure"
+            ; "state", `String "lane_release_failed"
+            ; ( "detail"
+              , `String
+                  "publication recovery lane cleanup failed after the publication callback returned" )
+            ; "write_executed", `Bool true
+            ; "keeper_active", `Bool true
+            ; ( "publication_result"
+              , `Assoc
+                  [ "outcome", `String "failure"
+                  ; "failure_class", `String "runtime_failure"
+                  ; "filesystem_target_effect", `String "target_replaced"
+                  ; "filesystem_created_parent_effects", `List []
+                  ] )
+            ])
+         failed_after_replace_data;
+       check string
+         "post-replace failure retains the bytes observed on disk"
+         "replaced-before-failure"
+         (read_file target);
+       let recovered_after_callback_failure =
+         execute "recovered-after-callback-failure"
+       in
+       check string
+         "same Keeper lane recovers after callback and cleanup failure"
+         "success"
+         (outcome_label recovered_after_callback_failure.outcome);
+       let unknown_fault =
+         Recovery_test.remove_staging_payload_before_publish ()
+       in
+       let unknown_target_effect =
+         Recovery_test.with_lane_scope_release_fault release_fault (fun () ->
+           Recovery_test.with_replace_dispatch_fault unknown_fault (fun () ->
+             execute "must-not-replace-existing-target"))
+       in
+       check string
+         "unknown target effect is not guessed as executed or unchanged"
+         "filesystem publication callback and publication recovery lane cleanup both failed"
+         unknown_target_effect.raw_output;
+       let unknown_target_effect_data =
+         match unknown_target_effect.data with
+         | Some data -> data
+         | None -> fail "unknown-target cleanup failure omitted typed data"
+       in
+       check
+         (testable Yojson.Safe.pp Yojson.Safe.equal)
+         "unknown target effect remains indeterminate in the public projection"
+         (`Assoc
+            [ "error", `String "publication_recovery_cleanup_failed"
+            ; "failure_class", `String "runtime_failure"
+            ; "state", `String "lane_release_failed"
+            ; ( "detail"
+              , `String
+                  "publication recovery lane cleanup failed after the publication callback returned" )
+            ; "write_executed", `Null
+            ; "keeper_active", `Bool true
+            ; ( "publication_result"
+              , `Assoc
+                  [ "outcome", `String "failure"
+                  ; "failure_class", `String "runtime_failure"
+                  ; "filesystem_target_effect", `String "target_state_unknown"
+                  ; "filesystem_created_parent_effects", `List []
+                  ] )
+            ])
+         unknown_target_effect_data;
+       check string
+         "failed real rename preserves the prior target bytes"
+         "recovered-after-callback-failure"
+         (read_file target);
+       let recovered_after_unknown = execute "recovered-after-unknown" in
+       check string
+         "same Keeper lane recovers after indeterminate target observation"
+         "success"
+         (outcome_label recovered_after_unknown.outcome);
+       let created_parent =
+         Filename.concat config.base_path "created-parent-effect"
+       in
+       let nested_target = Filename.concat created_parent "child.txt" in
+       let unchanged_fault =
+         Recovery_test.replace_dispatch_fault
+           ~stage:Recovery_test.Before_publish_replace
+           ~exception_:
+             (Injected_write_failure "private-before-publish-evidence")
+       in
+       let parent_effect =
+         Recovery_test.with_lane_scope_release_fault release_fault (fun () ->
+           Recovery_test.with_replace_dispatch_fault unchanged_fault (fun () ->
+             execute_at nested_target "must-not-reach-target"))
+       in
+       check string
+         "created parent remains an observed effect when target is unchanged"
+         "filesystem publication produced an observable filesystem effect before the publication callback and recovery lane cleanup both failed"
+         parent_effect.raw_output;
+       let parent_effect_data =
+         match parent_effect.data with
+         | Some data -> data
+         | None -> fail "created-parent cleanup failure omitted typed data"
+       in
+       check
+         (testable Yojson.Safe.pp Yojson.Safe.equal)
+         "created-parent effect joins with the unchanged target effect"
+         (`Assoc
+            [ "error", `String "publication_recovery_cleanup_failed"
+            ; "failure_class", `String "runtime_failure"
+            ; "state", `String "lane_release_failed"
+            ; ( "detail"
+              , `String
+                  "publication recovery lane cleanup failed after the publication callback returned" )
+            ; "write_executed", `Bool true
+            ; "keeper_active", `Bool true
+            ; ( "publication_result"
+              , `Assoc
+                  [ "outcome", `String "failure"
+                  ; "failure_class", `String "runtime_failure"
+                  ; "filesystem_target_effect", `String "target_unchanged"
+                  ; ( "filesystem_created_parent_effects"
+                    , `List
+                        [ `Assoc
+                            [ ( "target_effect"
+                              , `String "directory_created_requested_mode" )
+                            ; "child_sync", `String "succeeded"
+                            ; "parent_sync", `String "succeeded"
+                            ]
+                        ] )
+                  ] )
+            ])
+         parent_effect_data;
+       check bool "created parent remains on disk" true
+         (Sys.file_exists created_parent && Sys.is_directory created_parent);
+       check bool "failed pre-publish target remains absent" false
+         (Sys.file_exists nested_target);
+       check int "each real Write reads the provider exactly once" 8
+         (Atomic.get provider_reads))
+;;
+
+let test_real_directory_release_failure_preserves_effect_truth () =
+  let exception Injected_release_failure of string in
+  let exception Injected_directory_failure of string in
+  with_exec_fixture
+    ~always_allow:true
+    "keeper_tool_dispatch_directory_release_effect_truth"
+    (fun ~config ~meta ~publication_recovery:fixture_recovery ~ctx_work ->
+       let registry =
+         match fixture_recovery.provider () with
+         | Publication_availability.Available registry -> registry
+         | Publication_availability.Initializing
+         | Publication_availability.Registry_unavailable _
+         | Publication_availability.Initialization_crashed _
+         | Publication_availability.Non_runtime ->
+           fail "fixture did not provide its exact recovery registry"
+       in
+       let provider_reads = Atomic.make 0 in
+       let publication_recovery =
+         { Publication_availability.provider =
+             (fun () ->
+                Atomic.incr provider_reads;
+                Publication_availability.Available registry)
+         ; keeper_name = meta.name
+         }
+       in
+       let execute target content =
+         KET.execute_keeper_tool_call_with_outcome
+           ~config
+           ~meta
+           ~publication_recovery
+           ~ctx_work
+           ~exec_cache:None
+           ~name:"Write"
+           ~input:
+             (`Assoc
+                [ "file_path", `String target
+                ; "content", `String content
+                ])
+           ()
+       in
+       let warmup_target = Filename.concat config.base_path "lane-warmup.txt" in
+       let warmup = execute warmup_target "warmup" in
+       check string "directory matrix warmup succeeds" "success"
+         (outcome_label warmup.outcome);
+       let release_fault =
+         match
+           Recovery_test.lane_scope_release_fault
+             ~owner:meta.name
+             ~exception_:
+               (Injected_release_failure
+                  "private-directory-release-failure-evidence")
+         with
+         | Ok fault -> fault
+         | Error error ->
+           fail (Recovery_test.validation_error_to_string error)
+       in
+       let run_case
+             ~label
+             ~stage
+             ~expected_message
+             ~expected_target_effect
+             ~expected_write_executed
+             ~expected_directory_exists
+         =
+         let parent = Filename.concat config.base_path label in
+         let target = Filename.concat parent "child.txt" in
+         let fault =
+           Masc.Keeper_tool_filesystem_runtime.For_testing
+           .created_directory_fault
+             ~stage
+             ~exception_:(Injected_directory_failure label)
+         in
+         let result =
+           Recovery_test.with_lane_scope_release_fault release_fault (fun () ->
+             Masc.Keeper_tool_filesystem_runtime.For_testing
+             .with_created_directory_fault
+               fault
+               (fun () -> execute target "must-not-reach-target"))
+         in
+         (match result.outcome with
+          | `Failure Tool_result.Runtime_failure -> ()
+          | `Failure failure_class ->
+            failf
+              "%s returned wrong failure class: %s"
+              label
+              (Tool_result.tool_failure_class_to_string failure_class)
+          | `Success -> failf "%s unexpectedly succeeded" label);
+         check string (label ^ " message") expected_message result.raw_output;
+         let data =
+           match result.data with
+           | Some data -> data
+           | None -> failf "%s omitted typed data" label
+         in
+         check
+           (testable Yojson.Safe.pp Yojson.Safe.equal)
+           (label ^ " exact typed projection")
+           (`Assoc
+              [ "error", `String "publication_recovery_cleanup_failed"
+              ; "failure_class", `String "runtime_failure"
+              ; "state", `String "lane_release_failed"
+              ; ( "detail"
+                , `String
+                    "publication recovery lane cleanup failed after the publication callback returned" )
+              ; "write_executed", expected_write_executed
+              ; "keeper_active", `Bool true
+              ; ( "publication_result"
+                , `Assoc
+                    [ "outcome", `String "failure"
+                    ; "failure_class", `String "runtime_failure"
+                    ; ( "filesystem_directory_target_effect"
+                      , `String expected_target_effect )
+                    ; "filesystem_created_parent_effects", `List []
+                    ] )
+              ])
+           data;
+         check bool (label ^ " directory state") expected_directory_exists
+           (Sys.file_exists parent && Sys.is_directory parent);
+         check bool (label ^ " target remains absent") false
+           (Sys.file_exists target)
+       in
+       let recover_lane content =
+         let result = execute warmup_target content in
+         check string "same Keeper lane recovers between directory cases"
+           "success"
+           (outcome_label result.outcome)
+       in
+       run_case
+         ~label:"directory-unchanged"
+         ~stage:
+           Masc.Keeper_tool_filesystem_runtime.For_testing
+           .Before_create_directory
+         ~expected_message:
+           "filesystem publication left the target unchanged, but publication recovery lane cleanup failed"
+         ~expected_target_effect:"directory_unchanged"
+         ~expected_write_executed:(`Bool false)
+         ~expected_directory_exists:false;
+       recover_lane "recovered-after-directory-unchanged";
+       run_case
+         ~label:"directory-state-unknown"
+         ~stage:
+           Masc.Keeper_tool_filesystem_runtime.For_testing
+           .Before_inspect_created_directory
+         ~expected_message:
+           "filesystem publication callback and publication recovery lane cleanup both failed"
+         ~expected_target_effect:"directory_state_unknown"
+         ~expected_write_executed:`Null
+         ~expected_directory_exists:true;
+       recover_lane "recovered-after-directory-unknown";
+       run_case
+         ~label:"directory-created-validated"
+         ~stage:
+           Masc.Keeper_tool_filesystem_runtime.For_testing
+           .Before_apply_directory_permissions
+         ~expected_message:
+           "filesystem publication produced an observable filesystem effect before the publication callback and recovery lane cleanup both failed"
+         ~expected_target_effect:"directory_created_validated"
+         ~expected_write_executed:(`Bool true)
+         ~expected_directory_exists:true;
+       check int "each directory matrix Write reads the provider exactly once" 6
+         (Atomic.get provider_reads))
 ;;
 
 let test_tool_search_without_session_searcher_is_unavailable () =
@@ -2282,7 +2614,9 @@ let () =
       test_case "publication Write cancellation releases exact lane" `Quick
         test_publication_write_cancellation_releases_exact_lane;
       test_case "committed publication preserves cleanup failure truth" `Quick
-        test_committed_publication_release_failure_preserves_effect_truth;
+        test_real_publication_release_failure_preserves_effect_truth;
+      test_case "directory publication preserves cleanup failure truth" `Quick
+        test_real_directory_release_failure_preserves_effect_truth;
       test_case "tool search without session searcher is unavailable" `Quick
         test_tool_search_without_session_searcher_is_unavailable;
       test_case "tool search uses injected session searcher" `Quick

--- a/test/test_mcp_tool_runtime_workspace_path.ml
+++ b/test/test_mcp_tool_runtime_workspace_path.ml
@@ -4,7 +4,7 @@ module Keeper_publication_recovery_availability =
 
 module Mcp_eio = Masc.Mcp_server_eio
 module Mcp_server = Masc.Mcp_server
-module Recovery_test = Fs_compat.Publication_recovery_for_testing
+module Recovery_test = Fs_compat_test_support.Publication_recovery_for_testing
 
 let contains_substring text fragment =
   let text_len = String.length text in
@@ -139,18 +139,18 @@ let seed_prepared_recovery ~fs ~base_path ~owner ~operation_id =
   Eio.Switch.run
   @@ fun sw ->
   match
-    Fs_compat.open_publication_recovery_registry
+    Fs_compat.Publication_recovery.open_registry
       ~sw
       ~fs
       ~registry_root:Eio.Path.(fs / Masc.Workspace.masc_root_dir config)
   with
   | Error error ->
     Alcotest.fail
-      (Fs_compat.publication_recovery_registry_error_to_string error)
+      (Fs_compat.Publication_recovery.registry_error_to_string error)
   | Ok registry ->
     (match
        Recovery_test.seed_prepared
-         ~registry:(Recovery_test.private_registry registry)
+         ~registry:(registry)
          ~owner
          ~operation_id
          ~allowed_root_path
@@ -271,25 +271,22 @@ let test_runtime_publishes_before_open_and_discovers_without_owner_fanout () =
         nested_workspace
         initialized_scope.config.workspace_path;
       let registry = require_registry state in
-      let private_registry =
-        Fs_compat.Publication_recovery_for_testing.private_registry registry
-      in
-      Fs_compat.Publication_recovery_for_testing.For_testing.await_discovery_settlement
-        private_registry;
+      Recovery_test.For_testing.await_discovery_settlement
+        registry;
       let before_demand =
-        Fs_compat.Publication_recovery_for_testing.For_testing.snapshot
-          private_registry
+        Recovery_test.For_testing.snapshot
+          registry
       in
       Alcotest.(check int)
         "startup discovery does not prepopulate exact owners"
         0
         (List.length before_demand.owners);
       (match before_demand.discovery with
-       | Fs_compat.Publication_recovery_for_testing.Snapshot_discovery_complete rows ->
+       | Recovery_test.Snapshot_discovery_complete rows ->
          Alcotest.(check int) "both names observed" 2 (List.length rows)
-       | Fs_compat.Publication_recovery_for_testing.Snapshot_discovery_required
-       | Fs_compat.Publication_recovery_for_testing.Snapshot_discovery_running
-       | Fs_compat.Publication_recovery_for_testing.Snapshot_discovery_failed _ ->
+       | Recovery_test.Snapshot_discovery_required
+       | Recovery_test.Snapshot_discovery_running
+       | Recovery_test.Snapshot_discovery_failed _ ->
          Alcotest.fail "discovery settlement did not publish success");
       let settled_health = health state in
       Alcotest.(check bool)
@@ -306,7 +303,7 @@ let test_runtime_publishes_before_open_and_discovers_without_owner_fanout () =
            |> member "owner_identity_rejected"
            |> to_int);
       (match
-         Fs_compat.with_publication_recovery_lane
+         Fs_compat.Publication_recovery.with_lane
            ~registry
            ~owner:first_owner
            (fun _ -> ())
@@ -316,10 +313,10 @@ let test_runtime_publishes_before_open_and_discovers_without_owner_fanout () =
          Alcotest.fail "publication recovery lane release failed"
        | Error error ->
          Alcotest.fail
-           (Fs_compat.publication_recovery_lane_open_error_to_string error));
+           (Fs_compat.Publication_recovery.lane_open_error_to_string error));
       let after_demand =
-        Fs_compat.Publication_recovery_for_testing.For_testing.snapshot
-          private_registry
+        Recovery_test.For_testing.snapshot
+          registry
       in
       Alcotest.(check int)
         "one exact demand creates one owner state"
@@ -428,11 +425,8 @@ let test_lane_store_failure_degrades_and_success_recovers_health () =
       let state = create_runtime env sw ~base_path in
       Mcp_server.For_testing.await_publication_recovery_initialization state;
       let registry = require_registry state in
-      let private_registry =
-        Fs_compat.Publication_recovery_for_testing.private_registry registry
-      in
-      Fs_compat.Publication_recovery_for_testing.For_testing.await_discovery_settlement
-        private_registry;
+      Recovery_test.For_testing.await_discovery_settlement
+        registry;
       let owner = "lane-store-health" in
       let exception_ = Failure "deterministic lane store open failure" in
       let backtrace =
@@ -445,9 +439,9 @@ let test_lane_store_failure_degrades_and_success_recovers_health () =
           Printexc.get_raw_backtrace ()
       in
       (match
-         Fs_compat.Publication_recovery_for_testing.For_testing
+         Recovery_test.For_testing
          .record_lane_store_open_failure
-           ~registry:private_registry
+           ~registry
            ~owner
            ~exception_
            ~backtrace
@@ -455,7 +449,7 @@ let test_lane_store_failure_degrades_and_success_recovers_health () =
        | Ok () -> ()
        | Error error ->
          Alcotest.fail
-           (Fs_compat.Publication_recovery_for_testing.validation_error_to_string
+           (Recovery_test.validation_error_to_string
               error));
       let failed = health state in
       Alcotest.(check string)
@@ -479,15 +473,15 @@ let test_lane_store_failure_degrades_and_success_recovers_health () =
            |> to_list
            |> List.map to_string);
       (match
-         Fs_compat.Publication_recovery_for_testing.For_testing
+         Recovery_test.For_testing
          .record_lane_store_open_success
-           ~registry:private_registry
+           ~registry
            ~owner
        with
        | Ok () -> ()
        | Error error ->
          Alcotest.fail
-           (Fs_compat.Publication_recovery_for_testing.validation_error_to_string
+           (Recovery_test.validation_error_to_string
               error));
       let recovered = health state in
       Alcotest.(check string)

--- a/test/test_operator_control_actions.ml
+++ b/test/test_operator_control_actions.ml
@@ -15,7 +15,7 @@ let claim_and_start config ~agent_name ~task_id =
   | Ok _ -> ()
   | Error err -> Alcotest.fail (Masc_domain.show_masc_error err)
 
-let test_task_inject_executes_immediately () =
+let test_task_inject_executes_after_confirmation () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
   Eio.Switch.run @@ fun sw ->
@@ -49,20 +49,50 @@ let test_task_inject_executes_immediately () =
         | Ok json -> json
         | Error err -> Alcotest.fail err
       in
-      Alcotest.(check bool) "confirm required" false
+      Alcotest.(check bool) "confirm required" true
         Yojson.Safe.Util.(action_json |> member "confirm_required" |> to_bool);
-      Alcotest.(check bool) "no confirm token" true
-        (Yojson.Safe.Util.member "confirm_token" action_json = `Null);
+      let confirm_token =
+        Yojson.Safe.Util.(action_json |> member "confirm_token" |> to_string)
+      in
       let snapshot = Operator_control.snapshot_json ~actor:"operator" ctx in
       let pending_confirms =
         snapshot |> Yojson.Safe.Util.member "pending_confirms"
         |> Yojson.Safe.Util.to_list
       in
-      Alcotest.(check int) "pending confirm count" 0 (List.length pending_confirms);
-      Alcotest.(check bool) "result present" true
-        (Yojson.Safe.Util.member "result" action_json <> `Null);
+      Alcotest.(check int) "pending confirm count" 1 (List.length pending_confirms);
+      Alcotest.(check bool) "result absent before confirmation" true
+        (Yojson.Safe.Util.member "result" action_json = `Null);
       let tasks = Workspace.get_tasks_raw config in
-      Alcotest.(check int) "task injected" 1 (List.length tasks))
+      Alcotest.(check int) "task not injected before confirmation" 0
+        (List.length tasks);
+      let confirm_json =
+        Operator_control.confirm_json ctx
+          (`Assoc
+            [
+              ("actor", `String "operator");
+              ("confirm_token", `String confirm_token);
+              ("decision", `String "confirm");
+            ])
+      in
+      let confirm_json =
+        match confirm_json with
+        | Ok json -> json
+        | Error err -> Alcotest.fail err
+      in
+      Alcotest.(check string) "confirmation decision" "confirm"
+        Yojson.Safe.Util.(confirm_json |> member "decision" |> to_string);
+      Alcotest.(check bool) "result present after confirmation" true
+        (Yojson.Safe.Util.member "result" confirm_json <> `Null);
+      let snapshot = Operator_control.snapshot_json ~actor:"operator" ctx in
+      let pending_confirms =
+        snapshot |> Yojson.Safe.Util.member "pending_confirms"
+        |> Yojson.Safe.Util.to_list
+      in
+      Alcotest.(check int) "pending confirm removed" 0
+        (List.length pending_confirms);
+      let tasks = Workspace.get_tasks_raw config in
+      Alcotest.(check int) "task injected after confirmation" 1
+        (List.length tasks))
 
 let test_digest_defaults_to_workspace_target () =
   Eio_main.run @@ fun env ->
@@ -147,9 +177,9 @@ let () =
     "operator_control_actions"
     [ ( "actions"
       , [ Alcotest.test_case
-            "task inject executes immediately"
+            "task inject executes after confirmation"
             `Quick
-            test_task_inject_executes_immediately
+            test_task_inject_executes_after_confirmation
         ; Alcotest.test_case
             "digest defaults to workspace target"
             `Quick

--- a/test/test_operator_control_support.ml
+++ b/test/test_operator_control_support.ml
@@ -28,7 +28,7 @@ let publication_recovery_registry env sw config =
     Eio.Path.(Eio.Stdenv.fs env / Workspace.masc_root_dir config)
   in
   match
-    Fs_compat.open_publication_recovery_registry
+    Fs_compat.Publication_recovery.open_registry
       ~sw
       ~fs:(Eio.Stdenv.fs env)
       ~registry_root
@@ -36,7 +36,7 @@ let publication_recovery_registry env sw config =
   | Ok registry -> registry
   | Error error ->
     Alcotest.fail
-      (Fs_compat.publication_recovery_registry_error_to_string error)
+      (Fs_compat.Publication_recovery.registry_error_to_string error)
 
 let cleanup_dir dir =
   let rec rm path =
@@ -57,6 +57,10 @@ let result_field json = Yojson.Safe.Util.member "result" json
 
 let operator_ctx ?mcp_session_id env sw config agent_name :
     _ Operator_control.context =
+  let publication_recovery_provider =
+    Masc_test_deps.publication_recovery_provider
+      (publication_recovery_registry env sw config)
+  in
   {
     config;
     agent_name;
@@ -64,9 +68,16 @@ let operator_ctx ?mcp_session_id env sw config agent_name :
     clock = Eio.Stdenv.clock env;
     proc_mgr = Some (Eio.Stdenv.process_mgr env);
     net = Some (Eio.Stdenv.net env);
-    publication_recovery_provider =
-      Masc_test_deps.publication_recovery_provider
-        (publication_recovery_registry env sw config);
+    delegated_dispatch =
+      Some
+        (Masc.Keeper_tool_boundary.delegated_dispatch
+           ~config
+           ~agent_name
+           ~sw
+           ~clock:(Eio.Stdenv.clock env)
+           ~proc_mgr:(Some (Eio.Stdenv.process_mgr env))
+           ~net:(Some (Eio.Stdenv.net env))
+           ~publication_recovery_provider);
     mcp_session_id;
   }
 


### PR DESCRIPTION
## 목적

병합된 #24518과 #24521의 후속 hard cut입니다. publication recovery의 중복 public/test surface를 제거하고 실제 Keeper dispatch와 typed filesystem effect를 단일 기능 계약으로 검증합니다.

## 변경

- flat publication recovery API와 public test facade를 삭제
- 내부 구현은 package-private library, fault injection은 non-installed workspace test support로 격리
- Keeper Write 실제 dispatch를 통해 callback, target, parent-directory effect와 lane cleanup failure 조합을 검증
- Tool 계층의 Keeper 직접 참조를 제거하고 Keeper 소유 delegated dispatch를 주입
- 삭제 surface 및 Tool to Keeper 경계 우회를 막는 static ratchet 강화
- boundary scanner가 rg 미설치 또는 실행 오류를 no-match로 삼키지 않고 fail closed
- operator action과 confirm은 tool auth가 확정한 actor를 그대로 사용하고, 무토큰 및 무 actor 요청은 명시 실패
- task injection 기능 테스트를 현재 explicit confirmation 계약에 맞게 preview then confirm then execute로 정정
- healthy path에 startup scan, O(n) 탐색, lock, retry, timeout, budget or turn cap을 추가하지 않음

## 검증

- focused OCaml build: operator control actions, keeper adversarial review, MCP workspace path
- product contract tests: 137 passed
  - Eio resource scope 4
  - publication reconciliation 29
  - capability write 44
  - MCP workspace path 6
  - Keeper tool dispatch 36
  - Keeper adversarial review 14
  - operator control actions 4
- publication recovery boundary ratchet passed
- missing rg fail-closed probe passed with exit 2
- Tool to Keeper boundary ratchet passed
- telemetry coverage gate passed
- determinism contract gate passed
- ocamlformat check passed
- git diff check passed
- final hostile review: P0/P1/P2/P3 all zero

전체 dune build와 full suite의 최종 권위는 PR CI입니다.