### PR TITLE
fix(runtime): stamp declared provider id into Provider_config (boot-gate wipeout)

### DIFF
--- a/lib/runtime/runtime_adapter.ml
+++ b/lib/runtime/runtime_adapter.ml
@@ -309,6 +309,15 @@ let provider_config_from_declared_provider ?keep_alive ?num_ctx
        Ok
          (Llm_provider.Provider_config.make
             ~kind
+            (* [provider_id] is the runtime.toml [providers.<id>] table name. It is
+               the capability-catalog qualification key: [capability_provider_label]
+               prefers it over the wire [kind], so provider-qualified catalog rows
+               ([provider_name = "<id>"]) resolve per declared provider instead of
+               collapsing every OpenAI-compatible endpoint into the "openai_compat"
+               label (which no catalog row carries — the 2026-07-15 boot-gate
+               wipeout). OAS's own binding layer passes it the same way
+               (provider_runtime_binding.ml [runtime_binding_provider_config]). *)
+            ~provider_id:provider.id
             ~model_id:spec.api_name
             ~base_url
             ~api_key
@@ -330,6 +339,8 @@ let provider_config_from_declared_provider ?keep_alive ?num_ctx
        Ok
          (Llm_provider.Provider_config.make
             ~kind
+            (* Same capability-qualification key as the Http branch above. *)
+            ~provider_id:provider.id
             ~model_id:spec.api_name
             ~base_url:""
             ~api_key:(api_key_of_credential ?registry_entry provider.credentials)

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -1469,7 +1469,11 @@ let test_runtime_capability_gate_reports_missing_catalog_models () =
          let missing = List.hd report.missing_models in
          check string "runtime id" "custom.sample" missing.runtime_id;
          check string "provider id" "custom" missing.provider_id;
-         check string "provider label" "openai_compat" missing.provider_label;
+         (* The label is the declared [providers.custom] table name, not the
+            wire kind: the adapter stamps [Provider_config.provider_id], so the
+            missing-row diagnostic tells the operator which catalog
+            [provider_name] to add instead of the generic "openai_compat". *)
+         check string "provider label" "custom" missing.provider_label;
          check string "model id" "missing-family-123" missing.model_id;
          check bool "diagnostic names OAS catalog file" true
            (String_util.contains_substring
@@ -1480,12 +1484,13 @@ let test_runtime_capability_gate_reports_missing_catalog_models () =
            (String_util.contains_substring
               (Runtime.strict_init_error_to_string
                  (Runtime.Missing_catalog_models report))
-              "provider_label=openai_compat"))
+              "provider_label=custom"))
 
 let test_server_degraded_init_rejects_referenced_uncatalogued_runtimes () =
   let catalog =
     "[[models]]\n\
      id_prefix = \"good\"\n\
+     provider_name = \"ollama\"\n\
      base = \"ollama\"\n\
      max_context_tokens = 1024\n"
   in
@@ -1548,6 +1553,7 @@ let test_server_degraded_init_disables_unreferenced_uncatalogued_runtimes () =
   let catalog =
     "[[models]]\n\
      id_prefix = \"good\"\n\
+     provider_name = \"ollama\"\n\
      base = \"ollama\"\n\
      max_context_tokens = 1024\n"
   in
@@ -1638,6 +1644,7 @@ let test_server_degraded_init_rejects_uncatalogued_default () =
   let catalog =
     "[[models]]\n\
      id_prefix = \"good\"\n\
+     provider_name = \"ollama\"\n\
      base = \"ollama\"\n\
      max_context_tokens = 1024\n"
   in

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -854,6 +854,68 @@ let provider_cfg () =
   | Ok provider_cfg -> provider_cfg
   | Error msg -> failf "unexpected adapter error: %s" msg
 
+(* --- provider_id capability qualification ---
+
+   The adapter must stamp the runtime.toml [providers.<id>] table name into
+   [Provider_config.provider_id]: it is the capability-catalog qualification
+   key ([capability_provider_label] prefers it over the wire kind), and the
+   OAS contract (provider_config.mli, capabilities_for_config_model) only
+   accepts an exact provider-scoped row once a provider is declared. Without
+   it every OpenAI-compatible endpoint collapsed into the "openai_compat"
+   label, which no catalog row carries — the 2026-07-15 boot-gate wipeout
+   where all routed runtimes were reported catalog-missing. *)
+
+let with_model_catalog toml f =
+  match Llm_provider.Model_catalog.of_toml_string ~source:"inline-test-catalog" toml with
+  | Error msg -> failf "test catalog parse failed: %s" msg
+  | Ok catalog ->
+    Llm_provider.Model_catalog.set_global catalog;
+    Fun.protect ~finally:Llm_provider.Model_catalog.clear_global f
+
+let test_adapter_stamps_declared_provider_id () =
+  check
+    (option string)
+    "provider_id"
+    (Some "runpod_mtp")
+    (provider_cfg ()).provider_id
+
+let test_provider_scoped_catalog_row_resolves_for_declared_provider () =
+  with_model_catalog
+    {|
+[[models]]
+id_prefix = "qwen"
+provider_name = "runpod_mtp"
+max_context_tokens = 160000
+|}
+    (fun () ->
+       match
+         Llm_provider.Provider_config.capabilities_for_config_model (provider_cfg ())
+       with
+       | Some caps ->
+         check
+           (option int)
+           "max_context_tokens from provider-scoped row"
+           (Some 160000)
+           caps.Llm_provider.Capabilities.max_context_tokens
+       | None -> fail "provider-scoped catalog row did not resolve")
+
+let test_bare_catalog_row_stays_fail_closed_for_declared_provider () =
+  with_model_catalog
+    {|
+[[models]]
+id_prefix = "qwen"
+max_context_tokens = 160000
+|}
+    (fun () ->
+       match
+         Llm_provider.Provider_config.capabilities_for_config_model (provider_cfg ())
+       with
+       | Some _ ->
+         fail
+           "bare catalog row must not satisfy a declared provider (exact \
+            provider-scoped row required)"
+       | None -> ())
+
 (* Audit F2: TOML keep-alive / num-ctx must reach the wire-level
    Provider_config. Before the fix the adapter dropped both binding
    fields, so keep_alive fell back to OAS_OLLAMA_KEEP_ALIVE / "-1" and
@@ -1423,6 +1485,18 @@ let () =
         ] )
     ; ( "provider_config"
       , [ test_case
+            "adapter stamps declared provider id"
+            `Quick
+            test_adapter_stamps_declared_provider_id
+        ; test_case
+            "provider-scoped catalog row resolves for declared provider"
+            `Quick
+            test_provider_scoped_catalog_row_resolves_for_declared_provider
+        ; test_case
+            "bare catalog row stays fail-closed for declared provider"
+            `Quick
+            test_bare_catalog_row_stays_fail_closed_for_declared_provider
+        ; test_case
             "runtime adapter carries auth in api_key only"
             `Quick
             test_runtime_adapter_keeps_auth_out_of_headers


### PR DESCRIPTION
## 문제

2026-07-15 masc 서버 부팅이 FATAL로 거부됨:

```
Runtime.init_default_degraded failed: … cannot use degraded runtime boot because
catalog-missing runtime ids are referenced by routing config: [14개 라우팅 참조 전부]
```

라우팅된 runtime 전부(ollama_cloud/glm-coding/kimi_code/runpod_mtp/mimo/runpod_rtxa6000)가 catalog-missing으로 보고되어 BasePath ownership 거부. 최신 oas checkout 카탈로그(171 rows/17 providers)로 프로브해도 동일하게 전멸 — 스테일 카탈로그 파일 문제가 아니라 통합 결함.

## 근본 원인

`runtime_adapter.ml`의 `Provider_config.make` 호출이 `~provider_id`를 전달하지 않음.

- OAS 0.212 계약(`provider_config.mli`): "config with `provider_id` only accepts an exact provider-scoped row. Without `provider_id`, native typed provider kinds may use a provider-independent row" — 그리고 `capability_provider_label`은 `provider_id`가 없으면 wire kind 문자열로 폴백.
- masc의 provider는 대부분 `openai-compatible-http` → kind=OpenAI_compat → 라벨이 전부 `"openai_compat"`으로 붕괴 + bare row 폴백 금지(kind=OpenAI_compat은 `allow_bare_fallback=false`).
- 카탈로그의 provider-scoped rows(`provider_name = "ollama_cloud"` 등, oas models.toml에 이미 존재)는 라벨 불일치로 영원히 매칭 불가 → 어떤 카탈로그로도 게이트 통과가 불가능한 상태.
- OAS 자체 바인딩 레이어는 `~provider_id:binding.id`를 전달함(`provider_runtime_binding.ml:388`). masc adapter만 이 배선이 누락 — 0.212 다이어트의 미완 마이그레이션.

## 변경

- `provider_config_from_declared_provider`: Http/Cli 두 `make` 호출에 `~provider_id:provider.id` (runtime.toml `[providers.<id>]` 테이블명) 추가.
- 회귀 테스트 3건: provider_id 스탬프 / provider-scoped row 해석 / bare row fail-closed 유지.
- 기존 테스트 의도 보존 갱신: degraded init 픽스처 카탈로그에 `provider_name = "ollama"` 추가(새 계약 하 동일 시나리오), missing-report 테스트는 라벨을 선언된 provider명(`custom`)으로 기대 — 운영자가 카탈로그 `provider_name`에 적어야 할 바로 그 값이라 진단 정보성도 개선.

## 검증

- `test_runtime_provider_auth_headers.exe`: 39/39 green (신규 3 포함).
- `test_runtime_config_validity.exe`: 실패 세트가 main 기준선과 동일한 {1,2,3,5,7,19,33,35} — 전부 pre-existing(pre-0.212 prefix-인코딩 기대를 담은 env-coupled stale 테스트, 예: oas#2374 전환기 주석). 이 PR로 인한 회귀 0.
- `dune build @all` green.

## 후속 (별도 트랙)

1. oas models.toml에 부족한 provider-scoped rows 추가(glm-coding×glm-5-turbo, kimi_code×kimi-for-coding, runpod_mtp×qwen36 — 현재 `vllm-qwen3-mtp`로 오기입).
2. 배포 config의 스테일 fork 교체.
3. RFC: 카탈로그 overlay 병합(replace→merge), masc `[models.X.capabilities]`→`model_capabilities_override` 배선 복원, boot posture(config-plane 오류 시 control plane은 기동 + runtime lane typed Blocked + 대시보드 진단).
4. `test_runtime_config_validity`의 pre-0.212 stale 테스트 8건 재작성.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
