### PR TITLE
fix(schedule): preserve durable occurrence identity

### DIFF
--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -122,6 +122,7 @@ let stimulus_id_of_event_queue (stimulus : Keeper_event_queue.stimulus) =
     "board-attention:" ^ attention.candidate_id
   | Keeper_event_queue.Board_signal _, Board_signal ->
     board_stimulus_id ~post_id:stimulus.post_id
+  | Keeper_event_queue.Schedule_due _, Schedule_due -> stimulus.post_id
   | _, kind ->
     digest_id
       "stimulus"

--- a/lib/keeper/keeper_reaction_ledger.mli
+++ b/lib/keeper/keeper_reaction_ledger.mli
@@ -53,7 +53,8 @@ val board_stimulus_id : post_id:string -> string
 (** Stable id for board-originated stimuli. *)
 
 val stimulus_id_of_event_queue : Keeper_event_queue.stimulus -> string
-(** Stable id derived from the event queue stimulus payload. *)
+(** Stable id derived from the event queue stimulus payload. Scheduled wakes
+    preserve the enclosing schedule occurrence [post_id] exactly. *)
 
 val record_event_queue_stimulus :
   base_path:string -> keeper_name:string -> Keeper_event_queue.stimulus -> unit

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -477,6 +477,7 @@ let scheduled_automation_actor = "scheduled_automation"
 
 let pending_board_event_of_scheduled_wake
       ~meta:(_ : keeper_meta)
+      ~post_id
       ~(arrived_at : float)
       (sw : Keeper_event_queue.scheduled_wake)
   : pending_board_event
@@ -487,7 +488,7 @@ let pending_board_event_of_scheduled_wake
     | None -> Printf.sprintf "Scheduled keeper wake due (schedule %s)" sw.schedule_id
   in
   { event_kind = Schedule_due
-  ; post_id = Keeper_event_queue.schedule_due_post_id sw
+  ; post_id
   ; author = scheduled_automation_actor
   ; title
   ; preview = short_preview ~max_len:fusion_result_preview_max_len sw.message
@@ -694,7 +695,12 @@ let pending_board_event_of_stimulus
     Some
       (pending_board_event_of_bg_job_completion ~meta ~arrived_at:stimulus.arrived_at c)
   | Keeper_event_queue.Schedule_due sw ->
-    Some (pending_board_event_of_scheduled_wake ~meta ~arrived_at:stimulus.arrived_at sw)
+    Some
+      (pending_board_event_of_scheduled_wake
+         ~meta
+         ~post_id:stimulus.post_id
+         ~arrived_at:stimulus.arrived_at
+         sw)
   | Keeper_event_queue.Failure_judgment fj ->
     Some (pending_board_event_of_failure_judgment ~meta ~arrived_at:stimulus.arrived_at fj)
   | Keeper_event_queue.Goal_assigned ga ->

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -247,6 +247,7 @@ val pending_board_event_of_bg_job_completion :
 (** Build the actionable observation for a direct scheduled keeper wake. *)
 val pending_board_event_of_scheduled_wake :
   meta:Keeper_meta_contract.keeper_meta ->
+  post_id:Keeper_event_queue.post_id ->
   arrived_at:float ->
   Keeper_event_queue.scheduled_wake ->
   pending_board_event

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -182,8 +182,6 @@ let bg_job_completion_post_id (c : bg_job_completion) =
   if String.equal c.bg_board_post_id "" then "bg-run:" ^ c.bg_run_id
   else c.bg_board_post_id
 
-let schedule_due_post_id (sw : scheduled_wake) = "schedule-due:" ^ sw.schedule_id
-
 let hitl_resolution_post_id (r : hitl_resolution) = "hitl-approval:" ^ r.approval_id
 
 let failure_judgment_post_id (fj : failure_judgment) =

--- a/lib/keeper_runtime/keeper_event_queue.mli
+++ b/lib/keeper_runtime/keeper_event_queue.mli
@@ -202,9 +202,6 @@ val bg_job_completion_post_id : bg_job_completion -> post_id
 (** RFC-0290 dedup/correlation id for [Bg_completed]. Uses [bg_board_post_id]
     when the producer set it, otherwise falls back to ["bg-run:<run_id>"]. *)
 
-val schedule_due_post_id : scheduled_wake -> post_id
-(** Dedup/correlation id for [Schedule_due]: ["schedule-due:<schedule_id>"]. *)
-
 val hitl_resolution_post_id : hitl_resolution -> post_id
 (** Dedup/correlation id for [Hitl_resolved]: ["hitl-approval:<approval_id>"].
     De-dups repeat resolve wakes for the same approval within the dedup

--- a/lib/schedule/schedule_runner.ml
+++ b/lib/schedule/schedule_runner.ml
@@ -40,6 +40,7 @@ type consumer =
   ; dispatch :
       Workspace_utils.config ->
       now:float ->
+      wake_signal ->
       Schedule_domain.schedule_request ->
       (Yojson.Safe.t, string) result
   }
@@ -224,9 +225,9 @@ let append_new_signals config candidates =
   | Error msg -> Error (Signal_store_error msg)
 ;;
 
-let candidate_signals ~now state =
+let candidates ~now state =
   Schedule_store.due_execution_candidates state
-  |> List.map (make_signal ~now Due_candidate)
+  |> List.map (fun request -> request, make_signal ~now Due_candidate request)
 ;;
 
 let dispatch_result ?detail ?error schedule_id status =
@@ -246,12 +247,18 @@ let finish_failed_dispatch config ~now ~schedule_id error =
     dispatch_result ~error schedule_id Dispatch_failed
 ;;
 
-let safe_consumer_dispatch config ~now consumer request =
-  try consumer.dispatch config ~now request with
+let safe_consumer_dispatch config ~now consumer signal request =
+  try consumer.dispatch config ~now signal request with
   | exn -> Error (Printexc.to_string exn)
 ;;
 
-let dispatch_candidate config ~now consumer (request : Schedule_domain.schedule_request) =
+let dispatch_candidate
+      config
+      ~now
+      consumer
+      signal
+      (request : Schedule_domain.schedule_request)
+  =
   let schedule_id = request.Schedule_domain.schedule_id in
   match consumer.accepts request with
   | Error reason ->
@@ -271,7 +278,7 @@ let dispatch_candidate config ~now consumer (request : Schedule_domain.schedule_
        dispatch_result ~error:(Schedule_store.store_error_to_string err) schedule_id
          Dispatch_start_rejected
      | Ok running_request ->
-       (match safe_consumer_dispatch config ~now consumer running_request with
+       (match safe_consumer_dispatch config ~now consumer signal running_request with
         | Error error -> finish_failed_dispatch config ~now ~schedule_id error
         | Ok detail ->
           (match Schedule_store.complete_running config ~now ~schedule_id ~detail () with
@@ -282,9 +289,11 @@ let dispatch_candidate config ~now consumer (request : Schedule_domain.schedule_
                schedule_id Dispatch_failed)))
 ;;
 
-let dispatch_candidates config ~now consumer state =
-  Schedule_store.due_execution_candidates state
-  |> List.map (dispatch_candidate config ~now consumer)
+let dispatch_candidates config ~now consumer candidates =
+  List.map
+    (fun (request, signal) ->
+       dispatch_candidate config ~now consumer signal request)
+    candidates
 ;;
 
 let read_recent_signals config n =
@@ -303,11 +312,12 @@ let tick ?consumer config ~now =
   match Schedule_store.refresh_due config ~now with
   | Error err -> Error (Service_error (Schedule_service.Store_error err))
   | Ok (state, due_changed) ->
-    let candidate_signals = candidate_signals ~now state in
+    let candidates = candidates ~now state in
+    let candidate_signals = List.map snd candidates in
     let* emitted = append_new_signals config candidate_signals in
     (match consumer with
      | Some consumer ->
-       let dispatches = dispatch_candidates config ~now consumer state in
+       let dispatches = dispatch_candidates config ~now consumer candidates in
        Ok { due_changed; emitted; rescheduled = 0; dispatches }
      | None ->
        let schedule_ids =

--- a/lib/schedule/schedule_runner.mli
+++ b/lib/schedule/schedule_runner.mli
@@ -43,6 +43,7 @@ type consumer =
   ; dispatch :
       Workspace_utils.config ->
       now:float ->
+      wake_signal ->
       Schedule_domain.schedule_request ->
       (Yojson.Safe.t, string) result
   }

--- a/lib/server/server_schedule_consumers.ml
+++ b/lib/server/server_schedule_consumers.ml
@@ -218,7 +218,13 @@ let record_keeper_wake_stimulus ~base_path ~keeper_name stimulus =
          (Printexc.to_string exn))
 ;;
 
-let dispatch_keeper_wake config ~now (request : Schedule_domain.schedule_request) payload =
+let dispatch_keeper_wake
+      config
+      ~now
+      (signal : Schedule_runner.wake_signal)
+      (request : Schedule_domain.schedule_request)
+      payload
+  =
   let* keeper_name = body_keeper_name payload in
   let* message = Schedule_payload_projection.body_required_string payload "message" in
   let* title = Schedule_payload_projection.body_optional_string payload "title" in
@@ -239,7 +245,7 @@ let dispatch_keeper_wake config ~now (request : Schedule_domain.schedule_request
     }
   in
   let stimulus : Keeper_event_queue.stimulus =
-    { post_id = Keeper_event_queue.schedule_due_post_id wake
+    { post_id = signal.signal_id
     ; urgency
     ; arrived_at = now
     ; payload = Keeper_event_queue.Schedule_due wake
@@ -311,14 +317,14 @@ let dispatch_keeper_wake config ~now (request : Schedule_domain.schedule_request
        @ keeper_wake_reaction_ledger_status_json_fields (Some reaction_ledger_status)))
 ;;
 
-let dispatch config ~now request =
+let dispatch config ~now signal request =
   match Schedule_payload_projection.dispatch_view_detailed request with
   | Error rejection ->
     Error (Schedule_payload_projection.dispatch_rejection_message rejection)
   | Ok (kind, payload) ->
     (match kind with
      | Schedule_payload_projection.Keeper_wake ->
-       dispatch_keeper_wake config ~now request payload)
+       dispatch_keeper_wake config ~now signal request payload)
 ;;
 
 let consumer : Schedule_runner.consumer = { accepts; dispatch }

--- a/test/test_fusion_wake.ml
+++ b/test/test_fusion_wake.ml
@@ -253,7 +253,7 @@ let schedule_stimulus ?schedule_id ?due_at ?payload_digest ?title ?message ()
   : Keeper_event_queue.stimulus
   =
   let wake = scheduled_wake ?schedule_id ?due_at ?payload_digest ?title ?message () in
-  { post_id = Keeper_event_queue.schedule_due_post_id wake
+  { post_id = "schedule-occurrence:test"
   ; urgency = Keeper_event_queue.Normal
   ; arrived_at = 3000.0
   ; payload = Keeper_event_queue.Schedule_due wake
@@ -374,10 +374,11 @@ let test_scheduled_wake_is_actionable () =
   let ev : Keeper_world_observation.pending_board_event =
     Keeper_world_observation.pending_board_event_of_scheduled_wake
       ~meta
+      ~post_id:"schedule-occurrence:actionable"
       ~arrived_at:3000.0
       wake
   in
-  check string "post_id correlates to schedule" "schedule-due:sched-1" ev.post_id;
+  check string "post_id preserves occurrence" "schedule-occurrence:actionable" ev.post_id;
   check bool "preview carries schedule message" true
     (contains ~needle:"SCHEDULE-ANSWER-TOKEN" ev.preview);
   check string "schedule actor remains context" "scheduled_automation" ev.author;

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -368,8 +368,8 @@ let () =
          })
       "bg-run:bg-2");
 
-  (* Scheduled wake is a non-board stimulus with a stable schedule-derived
-     post id and a codec round-trip for restart replay. *)
+  (* Scheduled wake is a non-board stimulus whose enclosing occurrence id and
+     payload both survive restart replay. *)
   let scheduled_wake =
     { schedule_id = "sched-1"
     ; due_at = 200.0
@@ -381,17 +381,17 @@ let () =
   let schedule_payload () = Schedule_due scheduled_wake in
   assert (not (is_board_signal (schedule_payload ())));
   assert (String.equal (payload_kind_label (schedule_payload ())) "schedule_due");
-  assert (String.equal (schedule_due_post_id scheduled_wake) "schedule-due:sched-1");
   (match
      stimulus_of_yojson
        (stimulus_to_yojson
-          { post_id = schedule_due_post_id scheduled_wake
+          { post_id = "schedule-occurrence:codec"
           ; urgency = Immediate
           ; arrived_at = 5.0
           ; payload = Schedule_due scheduled_wake
           })
    with
    | Ok s ->
+     assert (String.equal s.post_id "schedule-occurrence:codec");
      (match s.payload with
       | Schedule_due wake ->
         assert (String.equal wake.schedule_id "sched-1");

--- a/test/test_keeper_reaction_ledger.ml
+++ b/test/test_keeper_reaction_ledger.ml
@@ -204,6 +204,7 @@ let test_event_queue_reaction_evidence_matches_exact_stimulus_id () =
   let stimulus = schedule_due_stimulus () in
   let unrelated = schedule_due_stimulus ~schedule_id:"sched-ledger-other" () in
   let stimulus_id = Keeper_reaction_ledger.stimulus_id_of_event_queue stimulus in
+  check string "scheduled ledger id preserves occurrence" stimulus.post_id stimulus_id;
   Keeper_reaction_ledger.record_event_queue_stimulus
     ~base_path
     ~keeper_name

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -138,12 +138,13 @@ let create_board_schedule config =
     fail ("create failed: " ^ Schedule_service.service_error_to_string err)
 ;;
 
-let create_keeper_wake_schedule config =
+let create_keeper_wake_schedule ?recurrence config =
   match
     Schedule_service.create config ~schedule_id:"keeper-wake-sched-1"
       ~requested_at:100.0 ~requested_by:(human "operator")
       ~scheduled_by:(automated "scheduler-agent") ~due_at:200.0
-      ~payload:keeper_wake_payload ~source:Schedule_domain.Operator_request ()
+      ~payload:keeper_wake_payload ~source:Schedule_domain.Operator_request
+      ?recurrence ()
   with
   | Ok request -> request
   | Error err ->
@@ -193,6 +194,13 @@ let tick_ok config ~now =
   | Error err -> fail (Schedule_runner.runner_error_to_string err)
 ;;
 
+let single_signal_id (result : Schedule_runner.tick_result) =
+  match result.emitted with
+  | [ signal ] -> signal.signal_id
+  | signals ->
+    failf "expected one emitted schedule occurrence, got %d" (List.length signals)
+;;
+
 let runner_status_json_after_dispatches (result : Schedule_runner.tick_result) =
   Schedule_runner_status.reset_for_test ();
   let wake_enqueue_counts =
@@ -229,6 +237,7 @@ let test_keeper_wake_consumer_enqueues_typed_stimulus_and_succeeds_schedule () =
   @@ fun config ->
   let request = create_keeper_wake_schedule config in
   let result = tick_ok config ~now:201.0 in
+  let occurrence_id = single_signal_id result in
   check int "one dispatch" 1 (List.length result.dispatches);
   check string "dispatch status" "succeeded"
     (Schedule_runner.dispatch_status_to_string (List.hd result.dispatches).status);
@@ -272,7 +281,7 @@ let test_keeper_wake_consumer_enqueues_typed_stimulus_and_succeeds_schedule () =
    | None -> fail "expected queued scheduled wake"
    | Some (stimulus, rest) ->
      check bool "queue rest empty" true (Keeper_event_queue.is_empty rest);
-     check string "post id" "schedule-due:keeper-wake-sched-1" stimulus.post_id;
+     check string "post id is occurrence id" occurrence_id stimulus.post_id;
      check string "urgency" "immediate"
        (Keeper_event_queue.urgency_to_string stimulus.urgency);
      check (float 0.001) "arrived_at from tick now" 201.0 stimulus.arrived_at;
@@ -309,7 +318,7 @@ let test_keeper_wake_consumer_enqueues_typed_stimulus_and_succeeds_schedule () =
       (receipt |> member "schedule_id" |> to_string);
     check string "receipt urgency" "immediate"
       (receipt |> member "urgency" |> to_string);
-    check string "receipt post id" "schedule-due:keeper-wake-sched-1"
+    check string "receipt post id" occurrence_id
       (receipt |> member "post_id" |> to_string);
     check string "receipt reaction ledger recorded" "recorded"
       (receipt |> member "reaction_ledger_status" |> to_string);
@@ -344,6 +353,28 @@ let test_keeper_wake_consumer_enqueues_typed_stimulus_and_succeeds_schedule () =
       (queue_evidence |> member "inflight_count" |> to_int);
     check int "queue evidence read errors" 0
       (queue_evidence |> member "read_errors" |> to_list |> List.length)
+;;
+
+let test_recurring_wakes_keep_distinct_occurrence_ids () =
+  with_workspace
+  @@ fun config ->
+  let _request =
+    create_keeper_wake_schedule
+      ~recurrence:(Schedule_domain.Interval { interval_sec = 60 })
+      config
+  in
+  let first_id = tick_ok config ~now:201.0 |> single_signal_id in
+  let second_id = tick_ok config ~now:261.0 |> single_signal_id in
+  check bool "recurrences have distinct identities" false (String.equal first_id second_id);
+  let queued =
+    Keeper_registry_event_queue.snapshot
+      ~base_path:config.Workspace_utils.base_path
+      "schedule-keeper"
+    |> Keeper_event_queue.to_list
+  in
+  check int "both occurrences remain queued" 2 (List.length queued);
+  check (list string) "queue preserves occurrence order" [ first_id; second_id ]
+    (List.map (fun (stimulus : Keeper_event_queue.stimulus) -> stimulus.post_id) queued)
 ;;
 
 let test_keeper_wake_durable_enqueue_failure_is_not_success () =
@@ -384,17 +415,13 @@ let test_keeper_wake_queue_evidence_rejects_stale_occurrence () =
   let keeper_name = "schedule-keeper" in
   let base_path = config.Workspace_utils.base_path in
   let request = create_keeper_wake_schedule config in
-  ignore (tick_ok config ~now:201.0 : Schedule_runner.tick_result);
-  let expected_wake : Keeper_event_queue.scheduled_wake =
-    { schedule_id = request.schedule_id
-    ; due_at = request.due_at
-    ; payload_digest = Schedule_domain.payload_digest request.payload
-    ; title = Some "Scheduled lane wake"
-    ; message = "Run the scheduled maintenance lane now."
-    }
-  in
-  let post_id = Keeper_event_queue.schedule_due_post_id expected_wake in
-  (match Keeper_registry_event_queue.drop_by_post_id ~base_path keeper_name ~post_id with
+  let occurrence_id = tick_ok config ~now:201.0 |> single_signal_id in
+  (match
+     Keeper_registry_event_queue.drop_by_post_id
+       ~base_path
+       keeper_name
+       ~post_id:occurrence_id
+   with
    | Error message -> fail ("drop failed: " ^ message)
    | Ok removed -> check int "removed current occurrence" 1 (List.length removed));
   let stale_payload_json =
@@ -424,7 +451,7 @@ let test_keeper_wake_queue_evidence_rejects_stale_occurrence () =
     }
   in
   let stale_stimulus : Keeper_event_queue.stimulus =
-    { post_id = Keeper_event_queue.schedule_due_post_id stale_wake
+    { post_id = "stale-schedule-occurrence"
     ; urgency = Keeper_event_queue.Immediate
     ; arrived_at = request.due_at +. 61.0
     ; payload = Keeper_event_queue.Schedule_due stale_wake
@@ -523,6 +550,7 @@ let test_keeper_wake_dashboard_tracks_runtime_inflight_lease () =
     (fun () ->
       let request = create_keeper_wake_schedule config in
       let result = tick_ok config ~now:201.0 in
+      let occurrence_id = single_signal_id result in
       check int "one dispatch" 1 (List.length result.dispatches);
       check string "dispatch status" "succeeded"
         (Schedule_runner.dispatch_status_to_string (List.hd result.dispatches).status);
@@ -542,8 +570,7 @@ let test_keeper_wake_dashboard_tracks_runtime_inflight_lease () =
         (pending_evidence |> member "inflight_count" |> to_int);
       let pending_receipt = pending_row |> member "dispatch_receipt" in
       let stimulus_id = pending_receipt |> member "stimulus_id" |> to_string in
-      check bool "dispatch receipt includes stimulus id" true
-        (String.starts_with ~prefix:"stimulus:" stimulus_id);
+      check string "ledger preserves occurrence id" occurrence_id stimulus_id;
       let pending_reaction_evidence =
         pending_row |> member "keeper_reaction_evidence"
       in
@@ -574,7 +601,7 @@ let test_keeper_wake_dashboard_tracks_runtime_inflight_lease () =
            | [ stimulus ] -> lease, stimulus
            | [] | _ :: _ :: _ -> fail "scheduled wake lease cardinality drifted")
       in
-      check string "leased post id" "schedule-due:keeper-wake-sched-1" leased.post_id;
+      check string "leased occurrence id" occurrence_id leased.post_id;
       (match leased.payload with
        | Keeper_event_queue.Schedule_due wake ->
          check string "leased schedule id" request.schedule_id wake.schedule_id
@@ -756,6 +783,8 @@ let () =
             test_board_post_schedule_is_rejected_without_mutation
         ; test_case "keeper wake enqueues typed stimulus" `Quick
             test_keeper_wake_consumer_enqueues_typed_stimulus_and_succeeds_schedule
+        ; test_case "recurring wakes keep distinct occurrence ids" `Quick
+            test_recurring_wakes_keep_distinct_occurrence_ids
         ; test_case "keeper wake durable enqueue failure is not success" `Quick
             test_keeper_wake_durable_enqueue_failure_is_not_success
         ; test_case "keeper wake queue evidence rejects stale occurrence" `Quick

--- a/test/test_schedule_runner.ml
+++ b/test/test_schedule_runner.ml
@@ -116,7 +116,7 @@ let accepting_consumer ?(accept = Ok ()) ?dispatch_result calls =
   in
   { accepts = (fun _request -> accept)
   ; dispatch =
-      (fun _config ~now:_ request ->
+      (fun _config ~now:_ _signal request ->
         calls := request.schedule_id :: !calls;
         dispatch_result)
   }


### PR DESCRIPTION
Stacked on #24524. Its product-blind child #24525 is already merged into the parent branch.

Each recurring schedule occurrence now keeps the durable `wake_signal.signal_id` as its sole correlation identity through Scheduler dispatch, Keeper durable queue, reaction ledger, dashboard evidence, and Keeper world observation.

The old `schedule_id`-derived helper is removed. The payload does not duplicate occurrence identity.

Focused proof:
- schedule runner: 9/9
- schedule consumer dispatch: 10/10, including two recurring occurrences queued distinctly
- Keeper event queue: pass
- Keeper reaction ledger: 21/21
- focused wrapper build, ocamlformat, diff check: green

`test_fusion_wake` keeps two pre-existing Board/RNG-path failures; its changed scheduled-wake case passes.

Diff: +101/-49 (150 changed lines).