### PR TITLE
fix(keeper): make compaction apply status truthful

### DIFF
--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -308,7 +308,10 @@ let candidates_for_assignment ~keeper_name assignment_id =
   | `Lane lane ->
     resolve_lane [] (Runtime_lane.ordered_candidates lane)
 
-let make ?complete ?timeout_sec ~(runtime_id : string) ~(keeper_name : string) ()
+type make_fn = runtime_id:string -> keeper_name:string -> unit -> summarizer option
+let make_override : make_fn option Atomic.t = Atomic.make None
+
+let make_resolved ?complete ?timeout_sec ~(runtime_id : string) ~(keeper_name : string) ()
   : summarizer option
   =
   match candidates_for_assignment ~keeper_name runtime_id with
@@ -351,10 +354,19 @@ let make ?complete ?timeout_sec ~(runtime_id : string) ~(keeper_name : string) (
              "compaction LLM candidate skipped runtime=%s assignment=%s: Eio \
               context unavailable"
              candidate.runtime_id runtime_id)
-         candidates;
+       candidates;
        None)
 
+let make ?complete ?timeout_sec ~runtime_id ~keeper_name () =
+  match Atomic.get make_override with
+  | Some override -> override ~runtime_id ~keeper_name ()
+  | None -> make_resolved ?complete ?timeout_sec ~runtime_id ~keeper_name ()
+
 module For_testing = struct
+  let with_make_override override f =
+    let previous = Atomic.exchange make_override (Some override) in
+    Fun.protect ~finally:(fun () -> Atomic.set make_override previous) f
+
   let provider_for_plan = provider_for_plan
 
   let candidate_runtime_ids_for_assignment ~keeper_name ~runtime_id =

--- a/lib/keeper/keeper_compaction_llm_summarizer.mli
+++ b/lib/keeper/keeper_compaction_llm_summarizer.mli
@@ -69,6 +69,11 @@ val apply
   -> Agent_sdk.Types.message list
 
 module For_testing : sig
+  val with_make_override
+    :  (runtime_id:string -> keeper_name:string -> unit -> summarizer option)
+    -> (unit -> 'a)
+    -> 'a
+
   (** Apply the compaction request policy while preserving the input provider
       config's exact temperature, including omission. *)
   val provider_for_plan

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -593,14 +593,17 @@ let context_of_oas_checkpoint
   sync_oas_context
     { checkpoint; max_tokens }
 
-let save_oas_checkpoint
+let save_oas_checkpoint_classified
     ~(multimodal_policy : Keeper_types_profile.multimodal_policy)
     ~(keeper_name : string)
     ~(session : session_context)
     ~(agent_name : string)
     ~(ctx : working_context)
     ~(generation : int)
-  : (Agent_sdk.Checkpoint.t, string) result =
+  : ( Agent_sdk.Checkpoint.t * Keeper_checkpoint_store.save_oas_outcome
+    , string )
+    result
+  =
   let checkpoint_context = Agent_sdk.Context.copy ~eio:true (oas_context_of_context ctx) in
   Agent_sdk.Context.set_scoped checkpoint_context Agent_sdk.Context.Session
     checkpoint_generation_key (`Int generation);
@@ -635,8 +638,33 @@ let save_oas_checkpoint
       context = checkpoint_context;
     }
   in
-  match Keeper_checkpoint_store.save_oas ~session_dir:session.session_dir checkpoint with
-  | Ok () -> Ok checkpoint
+  match
+    Keeper_checkpoint_store.save_oas_classified
+      ~session_dir:session.session_dir
+      checkpoint
+  with
+  | Ok outcome -> Ok (checkpoint, outcome)
+  | Error e -> Error e
+
+let save_oas_checkpoint
+    ~multimodal_policy
+    ~keeper_name
+    ~session
+    ~agent_name
+    ~ctx
+    ~generation
+  =
+  match
+    save_oas_checkpoint_classified
+      ~multimodal_policy
+      ~keeper_name
+      ~session
+      ~agent_name
+      ~ctx
+      ~generation
+  with
+  | Ok (checkpoint, Keeper_checkpoint_store.Saved _)
+  | Ok (checkpoint, Keeper_checkpoint_store.Stale_noop _) -> Ok checkpoint
   | Error e -> Error e
 
 let checkpoint_generation (cp : Agent_sdk.Checkpoint.t) ~(fallback : int) : int =

--- a/lib/keeper/keeper_context_core.mli
+++ b/lib/keeper/keeper_context_core.mli
@@ -147,8 +147,8 @@ val usage_of_response :
 val total_tokens : Agent_sdk.Types.api_usage -> int
 
 (** Save the current working context as a generation-tagged OAS checkpoint.
-    Message order and typed content are preserved exactly; OAS owns any
-    call-time context reduction. *)
+    Message order and typed content are preserved exactly. No implicit context
+    reduction is performed at this boundary. *)
 val save_oas_checkpoint :
   multimodal_policy:Keeper_types_profile.multimodal_policy ->
   keeper_name:string ->
@@ -160,6 +160,17 @@ val save_oas_checkpoint :
 (** [multimodal_policy]/[keeper_name] gate RFC §2.3 site-2 image eviction at the
     checkpoint write boundary (Store_only); required so every write path is
     compiler-forced to declare its policy (N-of-M closure). *)
+
+val save_oas_checkpoint_classified :
+  multimodal_policy:Keeper_types_profile.multimodal_policy ->
+  keeper_name:string ->
+  session:session_context ->
+  agent_name:string ->
+  ctx:working_context ->
+  generation:int ->
+  ( Agent_sdk.Checkpoint.t * Keeper_checkpoint_store.save_oas_outcome
+  , string )
+  result
 
 (** {1 OAS checkpoint inspection} *)
 

--- a/lib/keeper/keeper_context_runtime.mli
+++ b/lib/keeper/keeper_context_runtime.mli
@@ -188,10 +188,9 @@ val dispatch_post_turn_lifecycle_events
 val recover_latest_checkpoint_for_overflow_retry
   :  base_dir:string
   -> meta:keeper_meta
-  -> model:string
   -> trigger:Compaction_trigger.t
   -> primary_model_max_tokens:int
-  -> overflow_retry_recovery option
+  -> (overflow_retry_recovery, Keeper_post_turn.compaction_recovery_error) result
 
 (** {1 Trace and Board Utilities} *)
 

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -74,6 +74,48 @@ type overflow_retry_recovery = {
   turn_generation : int;
 } [@@warning "-69"]
 
+type compaction_recovery_error =
+  | Checkpoint_load_failed of Keeper_checkpoint_store.checkpoint_load_error
+  | Compaction_rejected of Keeper_compact_policy.compaction_rejection
+  | Unexpected_compaction_decision of Keeper_compact_policy.compaction_decision
+  | Checkpoint_superseded of {
+      incoming_turn_count : int;
+      known_turn_count : int;
+    }
+  | Checkpoint_save_failed of string
+
+let compaction_recovery_error_to_tag = function
+  | Checkpoint_load_failed Keeper_checkpoint_store.Not_found ->
+    "checkpoint_not_found"
+  | Checkpoint_load_failed _ -> "checkpoint_load_failed"
+  | Compaction_rejected reason ->
+    Keeper_compact_policy.compaction_rejection_to_string reason
+  | Unexpected_compaction_decision _ -> "unexpected_compaction_decision"
+  | Checkpoint_superseded _ -> "checkpoint_superseded"
+  | Checkpoint_save_failed _ -> "checkpoint_save_failed"
+
+let checkpoint_load_error_detail = function
+  | Keeper_checkpoint_store.Not_found -> "checkpoint not found"
+  | Store_error detail
+  | Parse_error detail
+  | Io_error detail
+  | Sdk_other_error detail -> detail
+
+let compaction_recovery_error_to_string = function
+  | Checkpoint_load_failed error -> checkpoint_load_error_detail error
+  | Compaction_rejected reason ->
+    "compaction rejected: "
+    ^ Keeper_compact_policy.compaction_rejection_to_string reason
+  | Unexpected_compaction_decision decision ->
+    "unexpected compaction decision: "
+    ^ Keeper_compact_policy.compaction_decision_to_string decision
+  | Checkpoint_superseded { incoming_turn_count; known_turn_count } ->
+    Printf.sprintf
+      "checkpoint superseded: incoming_turn_count=%d known_turn_count=%d"
+      incoming_turn_count
+      known_turn_count
+  | Checkpoint_save_failed detail -> detail
+
 let log_tool_pair_repair
     ~keeper_name
     ~site
@@ -524,113 +566,132 @@ let commit_prepared_after_save ~trigger ~save =
     Ok (checkpoint, Keeper_compact_policy.Applied trigger)
 ;;
 
+let checkpoint_of_save_outcome = function
+  | Ok (checkpoint, Keeper_checkpoint_store.Saved _) -> Ok checkpoint
+  | Ok
+      ( _,
+        Keeper_checkpoint_store.Stale_noop
+          { incoming_turn_count; known_turn_count } ) ->
+    Error (Checkpoint_superseded { incoming_turn_count; known_turn_count })
+  | Error detail -> Error (Checkpoint_save_failed detail)
+;;
+
 let recover_latest_checkpoint_for_overflow_retry
     ~(base_dir : string)
     ~(meta : keeper_meta)
-    ~(model : string)
     ~(trigger : Compaction_trigger.t)
-    ~(primary_model_max_tokens : int) : overflow_retry_recovery option =
+    ~(primary_model_max_tokens : int)
+  : (overflow_retry_recovery, compaction_recovery_error) result
+  =
   let session = create_session ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id) ~base_dir in
-  let oas_result =
+  match
     Keeper_checkpoint_store.load_oas ~session_dir:session.session_dir
       ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
-  in
-  (match oas_result with
-   | Error (Parse_error d | Store_error d | Io_error d | Sdk_other_error d) ->
-       Log.Keeper.error "keeper:%s overflow retry OAS load error: %s"
-         (Keeper_id.Trace_id.to_string meta.runtime.trace_id) d;
-       Otel_metric_store.inc_counter
-         Keeper_metrics.(to_string OasExecutionErrors)
-         ~labels:[("keeper", meta.name); ("phase", Keeper_oas_execution_error_phase.(to_label Overflow_retry_oas_load))]
-         ()
-   | Error Not_found ->
-       Log.Keeper.debug
-         "keeper:%s overflow-retry OAS checkpoint not found, starting fresh"
-         (Keeper_id.Trace_id.to_string meta.runtime.trace_id)
-   | Ok _ -> ());
-  let oas_checkpoint =
-    match oas_result with
-    | Ok v -> Some v
-    | Error Not_found -> None
-    | Error _ ->
-      Log.Keeper.warn "keeper:%s overflow-retry OAS checkpoint load failed; recovery cannot resume it"
-        (Keeper_id.Trace_id.to_string meta.runtime.trace_id);
-      None
-  in
-  let selected =
-    match oas_checkpoint with
-    | Some checkpoint ->
-        let turn_generation =
-          checkpoint_generation checkpoint ~fallback:meta.runtime.generation
-        in
-        Some
-          ( context_of_oas_checkpoint
-              checkpoint
-              ~primary_model_max_tokens,
-            turn_generation )
-    | None -> None
-  in
-  match selected with
-  | None -> None
-  | Some (ctx, turn_generation) ->
-      let retry_meta =
-        if turn_generation = meta.runtime.generation then meta
-        else map_runtime (fun rt -> { rt with generation = turn_generation }) meta
-      in
-      let compacted_ctx, base_decision =
-        Keeper_compact_policy.compact_for_request_typed
-          ~meta:retry_meta
-          ~trigger
-          ctx
-      in
-      match base_decision with
-      | Keeper_compact_policy.Prepared prepared_trigger ->
-        (try
-          (match
-             commit_prepared_after_save
-               ~trigger:prepared_trigger
-               ~save:(fun () ->
-                 save_oas_checkpoint
-                   ~multimodal_policy:meta.multimodal_policy
-                   ~keeper_name:meta.name
-                   ~session
-                   ~agent_name:retry_meta.agent_name
-                   ~ctx:compacted_ctx
-                   ~generation:turn_generation)
-           with
-          | Ok (checkpoint, decision) ->
-              Otel_metric_store.inc_counter
-                Keeper_metrics.(to_string Compactions)
-                ~labels:[ "keeper", retry_meta.name ]
-                ();
-              Some
-                { checkpoint
-                ; compaction =
-                    { attempted = true
-                    ; applied = true
-                    ; started_dispatched = false
-                    ; failure_reason = None
-                    ; trigger = Some prepared_trigger
-                    ; decision
-                    }
-                ; turn_generation
-                }
-          | Error e ->
-              Log.Keeper.error
-                "overflow retry checkpoint save failed: %s" e;
-              Otel_metric_store.inc_counter
-                Keeper_metrics.(to_string CheckpointFailures)
-                ~labels:[("keeper", retry_meta.agent_name); ("operation", "overflow_save")]
-                ();
-              None)
+  with
+  | Error Keeper_checkpoint_store.Not_found ->
+    Log.Keeper.debug
+      "keeper:%s overflow-retry OAS checkpoint not found"
+      (Keeper_id.Trace_id.to_string meta.runtime.trace_id);
+    Error (Checkpoint_load_failed Keeper_checkpoint_store.Not_found)
+  | Error
+      ((Parse_error detail | Store_error detail | Io_error detail
+       | Sdk_other_error detail) as error) ->
+    Log.Keeper.error
+      "keeper:%s overflow retry OAS load error: %s"
+      (Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+      detail;
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string OasExecutionErrors)
+      ~labels:
+        [ "keeper", meta.name
+        ; ( "phase"
+          , Keeper_oas_execution_error_phase.(to_label Overflow_retry_oas_load) )
+        ]
+      ();
+    Error (Checkpoint_load_failed error)
+  | Ok checkpoint ->
+    let turn_generation =
+      checkpoint_generation checkpoint ~fallback:meta.runtime.generation
+    in
+    let ctx = context_of_oas_checkpoint checkpoint ~primary_model_max_tokens in
+    let retry_meta =
+      if turn_generation = meta.runtime.generation then meta
+      else map_runtime (fun rt -> { rt with generation = turn_generation }) meta
+    in
+    let compacted_ctx, base_decision =
+      Keeper_compact_policy.compact_for_request_typed
+        ~meta:retry_meta
+        ~trigger
+        ctx
+    in
+    (match base_decision with
+     | Keeper_compact_policy.Prepared prepared_trigger ->
+       (try
+          match
+            commit_prepared_after_save
+              ~trigger:prepared_trigger
+              ~save:(fun () ->
+                save_oas_checkpoint_classified
+                  ~multimodal_policy:meta.multimodal_policy
+                  ~keeper_name:meta.name
+                  ~session
+                  ~agent_name:retry_meta.agent_name
+                  ~ctx:compacted_ctx
+                  ~generation:turn_generation
+                |> checkpoint_of_save_outcome)
+          with
+          | Ok (saved_checkpoint, decision) ->
+            Otel_metric_store.inc_counter
+              Keeper_metrics.(to_string Compactions)
+              ~labels:[ "keeper", retry_meta.name ]
+              ();
+            Ok
+              { checkpoint = saved_checkpoint
+              ; compaction =
+                  { attempted = true
+                  ; applied = true
+                  ; started_dispatched = false
+                  ; failure_reason = None
+                  ; trigger = Some prepared_trigger
+                  ; decision
+                  }
+              ; turn_generation
+              }
+          | Error
+              (Checkpoint_superseded
+                 { incoming_turn_count; known_turn_count } as error) ->
+            Log.Keeper.warn
+              "overflow retry checkpoint superseded: incoming_turn_count=%d known_turn_count=%d"
+              incoming_turn_count
+              known_turn_count;
+            Error error
+          | Error (Checkpoint_save_failed detail as error) ->
+            Log.Keeper.error
+              "overflow retry checkpoint save failed: %s"
+              detail;
+            Otel_metric_store.inc_counter
+              Keeper_metrics.(to_string CheckpointFailures)
+              ~labels:
+                [ "keeper", retry_meta.agent_name
+                ; "operation", "overflow_save"
+                ]
+              ();
+            Error error
+          | Error error -> Error error
         with
         | Eio.Cancel.Cancelled _ as exn -> raise exn
         | exn ->
-            log_keeper_exn
-              ~label:"overflow retry checkpoint save exception"
-              exn;
-            None)
-      | _ -> None
+          let detail = Printexc.to_string exn in
+          log_keeper_exn
+            ~label:"overflow retry checkpoint save exception"
+            exn;
+          Error (Checkpoint_save_failed detail))
+     | Keeper_compact_policy.Rejected (_, reason) ->
+       Error (Compaction_rejected reason)
+     | (Keeper_compact_policy.Applied _
+       | Keeper_compact_policy.Not_requested
+       | Keeper_compact_policy.Skipped_no_checkpoint) as decision ->
+       Error (Unexpected_compaction_decision decision))
 
 module For_testing = struct
   let commit_prepared_after_save = commit_prepared_after_save

--- a/lib/keeper/keeper_post_turn.mli
+++ b/lib/keeper/keeper_post_turn.mli
@@ -53,6 +53,19 @@ type overflow_retry_recovery =
   ; turn_generation : int
   } [@@warning "-69"]
 
+type compaction_recovery_error =
+  | Checkpoint_load_failed of Keeper_checkpoint_store.checkpoint_load_error
+  | Compaction_rejected of Keeper_compact_policy.compaction_rejection
+  | Unexpected_compaction_decision of Keeper_compact_policy.compaction_decision
+  | Checkpoint_superseded of
+      { incoming_turn_count : int
+      ; known_turn_count : int
+      }
+  | Checkpoint_save_failed of string
+
+val compaction_recovery_error_to_tag : compaction_recovery_error -> string
+val compaction_recovery_error_to_string : compaction_recovery_error -> string
+
 (** End-of-turn pipeline. Preserves the checkpoint and persists the result to
     the keeper meta and dashboard surface. Explicit compaction is a separate
     request path.
@@ -102,14 +115,14 @@ val apply_post_turn_lifecycle_with_resilience_handles :
 
 (** Reload the canonical OAS checkpoint and apply an explicit typed
     compaction request. Returns a durably saved [Applied] checkpoint only for a
-    structurally changed [Prepared] candidate; otherwise returns [None]. *)
+    structurally changed [Prepared] candidate; every other outcome is a typed
+    [Error]. *)
 val recover_latest_checkpoint_for_overflow_retry :
   base_dir:string ->
   meta:Keeper_meta_contract.keeper_meta ->
-  model:string ->
   trigger:Compaction_trigger.t ->
   primary_model_max_tokens:int ->
-  overflow_retry_recovery option
+  (overflow_retry_recovery, compaction_recovery_error) result
 
 module For_testing : sig
   (** Promote a structurally [Prepared] trigger only after [save] reports an

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -89,6 +89,45 @@ let compaction_dispatch_error_data ~stage ~checkpoint_applied error =
     ; "dispatch_error", `String detail
     ]
 
+let compaction_recovery_error_data ?dispatch_error error =
+  let tag = Keeper_post_turn.compaction_recovery_error_to_tag error in
+  let detail = Keeper_post_turn.compaction_recovery_error_to_string error in
+  let recovery_code =
+    match error with
+    | Keeper_post_turn.Checkpoint_load_failed
+        Keeper_checkpoint_store.Not_found -> Not_found
+    | Compaction_rejected Retired_deterministic_mode
+    | Compaction_rejected Runtime_identity_unavailable
+    | Compaction_rejected Structurally_unchanged
+    | Compaction_rejected Checkpoint_not_reduced ->
+      Precondition_failed
+    | Compaction_rejected Summarizer_unavailable
+    | Compaction_rejected Plan_unavailable_or_invalid
+    | Unexpected_compaction_decision _ -> Internal_error
+    | Checkpoint_superseded _ -> Conflict
+    | Checkpoint_load_failed _
+    | Checkpoint_save_failed _ -> Internal_error
+  in
+  let code =
+    match dispatch_error with
+    | None -> recovery_code
+    | Some _ -> Conflict
+  in
+  error_assoc
+    ([ "error_code", `String (error_code_to_string code)
+     ; "message", `String detail
+     ; "compaction_error", `String tag
+     ; "checkpoint_applied", `Bool false
+     ]
+     @
+     match dispatch_error with
+     | None -> []
+     | Some error ->
+       [ "recovery_error_code", `String (error_code_to_string recovery_code)
+       ; ( "lifecycle_dispatch_error"
+         , `String
+             (Keeper_context_runtime.lifecycle_dispatch_error_to_string error) ) ])
+
 let keeper_sandbox_status_fleet_names ctx =
   let registry_names =
     Keeper_registry.all ~base_path:ctx.config.base_path ()
@@ -501,7 +540,6 @@ let keeper_compact_body ~(config : Workspace.config) args : tool_result =
                    error))
          | Ok (Some (_resolved, meta)) ->
            let base_dir = Keeper_types_profile.session_base_dir config in
-           let checkpoint_label = "runtime" in
            let max_tokens = resolve_primary_max_context (Some meta) in
            (match
               Keeper_context_runtime.dispatch_keeper_phase_event_result
@@ -521,11 +559,10 @@ let keeper_compact_body ~(config : Workspace.config) args : tool_result =
                  Keeper_context_runtime.recover_latest_checkpoint_for_overflow_retry
                    ~base_dir
                    ~meta
-                   ~model:checkpoint_label
                    ~trigger:Compaction_trigger.Manual
                    ~primary_model_max_tokens:max_tokens
                with
-               | Some recovery ->
+               | Ok recovery ->
                  (match
                     Keeper_context_runtime.dispatch_compaction_completed
                       ~config ~keeper_name:name
@@ -569,28 +606,33 @@ let keeper_compact_body ~(config : Workspace.config) args : tool_result =
                                 Compaction_trigger.to_detail_json trigger
                               | None -> `Null )
                           ]))
-               | None ->
-                 let failure_dispatch = dispatch_failed "no_valid_checkpoint" in
-                 Otel_metric_store.inc_counter
-                   Keeper_metrics.(to_string OperatorCompact)
-                   ~labels:
-                     [ ("keeper", name)
-                     ; ( "result"
-                       , Keeper_operator_compact_result.(to_label No_checkpoint) )
-                     ]
-                   ();
+               | Error recovery_error ->
+                 let recovery_tag =
+                   Keeper_post_turn.compaction_recovery_error_to_tag
+                     recovery_error
+                 in
+                 let failure_dispatch = dispatch_failed recovery_tag in
+                 (match recovery_error with
+                  | Keeper_post_turn.Checkpoint_load_failed
+                      Keeper_checkpoint_store.Not_found ->
+                    Otel_metric_store.inc_counter
+                      Keeper_metrics.(to_string OperatorCompact)
+                      ~labels:
+                        [ ("keeper", name)
+                        ; ( "result"
+                          , Keeper_operator_compact_result.(to_label No_checkpoint) )
+                        ]
+                      ()
+                  | _ -> ());
                  (match failure_dispatch with
                   | Error error ->
                     tool_result_error_data
-                      (compaction_dispatch_error_data
-                         ~stage:"compaction_failed"
-                         ~checkpoint_applied:false
-                         error)
+                      (compaction_recovery_error_data
+                         ~dispatch_error:error
+                         recovery_error)
                   | Ok () ->
-                    tool_result_error
-                      (Printf.sprintf
-                         "keeper %s: checkpoint compaction unavailable"
-                         name)))))
+                    tool_result_error_data
+                      (compaction_recovery_error_data recovery_error)))))
 
 let handle_keeper_compact ctx args : tool_result =
   keeper_compact_body ~config:ctx.config args

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -202,6 +202,7 @@ let make_meta () : Masc.Keeper_meta_contract.keeper_meta =
       (`Assoc
         [ "name", `String "post-turn-no-auto-compact"
         ; "trace_id", `String "trace-post-turn-no-auto-compact"
+        ; "compaction_mode", `String "llm"
         ])
   with
   | Ok meta -> meta
@@ -214,7 +215,11 @@ let make_checkpoint () =
     ; agent_name = "post-turn-no-auto-compact"
     ; model = "test-model"
     ; system_prompt = None
-    ; messages = [ Agent_sdk.Types.text_message Agent_sdk.Types.User "keep this turn" ]
+    ; messages =
+        [ Agent_sdk.Types.text_message Agent_sdk.Types.User "keep"
+        ; Agent_sdk.Types.text_message Agent_sdk.Types.Assistant (String.make 2048 'x')
+        ; Agent_sdk.Types.text_message Agent_sdk.Types.User (String.make 2048 'y')
+        ]
     ; usage = Agent_sdk.Types.empty_usage
     ; turn_count = 7
     ; created_at = 1_700_000_000.0
@@ -266,6 +271,94 @@ let test_regular_post_turn_does_not_auto_compact () =
     check bool "checkpoint messages retained exactly" true
       (retained.messages = checkpoint.messages)
 
+let no_pre_compact
+    ~keeper_name:_ ~checkpoint_bytes:_ ~message_count:_ ~strategies:_ ~trigger:_ =
+  None
+
+let test_stale_compaction_is_not_applied () =
+  Eio_main.run @@ fun env ->
+  Masc_test_deps.init_eio_clock env;
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio.Switch.run @@ fun sw ->
+  let base_path = Masc_test_deps.setup_test_workspace () in
+  let meta, checkpoint = make_meta (), make_checkpoint () in
+  Fun.protect
+    ~finally:(fun () ->
+      Compact_policy.register_record_pre_compact no_pre_compact;
+      Masc.Keeper_registry.unregister ~base_path meta.name;
+      Masc_test_deps.cleanup_test_workspace base_path)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_path in
+      ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+      let runtime_path =
+        Filename.concat (Masc_test_deps.find_project_root ()) "config/runtime.toml"
+      in
+      Result.get_ok (Runtime.init_default ~config_path:runtime_path);
+      Result.get_ok (Masc.Keeper_meta_store.write_meta config meta);
+      ignore (Masc.Keeper_registry.register ~base_path meta.name meta);
+      let session =
+        Masc.Keeper_context_core.create_session
+          ~session_id:checkpoint.session_id
+          ~base_dir:(Masc.Keeper_types_profile.session_base_dir config)
+      in
+      let save checkpoint =
+        Masc.Keeper_checkpoint_store.save_oas_classified
+          ~session_dir:session.session_dir checkpoint
+        |> Result.get_ok |> ignore
+      in
+      save checkpoint;
+      Compact_policy.register_record_pre_compact
+        (fun ~keeper_name:_ ~checkpoint_bytes:_ ~message_count:_ ~strategies:_
+             ~trigger:_ -> save { checkpoint with turn_count = 9 }; None);
+      let plan =
+        Masc.Keeper_compaction_llm_summarizer.plan_of_json
+          ~message_count:3
+          (`Assoc
+             [ "summary", `String "unused"
+             ; "kept_indices", `List [ `Int 0 ]
+             ; "summarized_indices", `List []
+             ; "dropped_indices", `List [ `Int 1; `Int 2 ]
+             ])
+        |> Result.get_ok
+      in
+      let compactions () =
+        Masc.Otel_metric_store.metric_value_or_zero
+          Keeper_metrics.(to_string Compactions)
+          ~labels:[ "keeper", meta.name ] ()
+      in
+      let before = compactions () in
+      let ctx : _ Masc.Keeper_tool_surface.context =
+        { config; agent_name = "operator"; sw; clock = Eio.Stdenv.clock env
+        ; proc_mgr = None; net = None
+        ; publication_recovery_provider =
+            Masc_test_deps.non_runtime_publication_recovery_provider
+        }
+      in
+      let result =
+        Masc.Keeper_compaction_llm_summarizer.For_testing.with_make_override
+          (fun ~runtime_id:_ ~keeper_name:_ () -> Some (fun ~messages:_ -> Some plan))
+          (fun () -> Masc.Keeper_tool_surface.dispatch ctx ~name:"masc_keeper_compact"
+              ~args:(`Assoc [ "name", `String meta.name ]))
+      in
+      (match result with
+       | Some (Error failure) ->
+         check string "typed conflict" "conflict"
+           Yojson.Safe.Util.(failure.data |> member "error_code" |> to_string);
+         check string "stale cause" "checkpoint_superseded"
+           Yojson.Safe.Util.(failure.data |> member "compaction_error" |> to_string)
+       | Some (Ok _) -> fail "stale compaction reported tool success"
+       | None -> fail "masc_keeper_compact is not registered");
+      check (float 0.) "applied counter unchanged" before (compactions ());
+      check int "newer checkpoint retained" 9
+        (Result.get_ok (Masc.Keeper_checkpoint_store.load_oas
+           ~session_dir:session.session_dir ~session_id:checkpoint.session_id)).turn_count;
+      match Masc.Keeper_registry.get ~base_path meta.name with
+      | Some entry ->
+        check int "only request/start/failure dispatched" 3 entry.transition_seq;
+        check string "no completed stage" "Compaction_accumulating"
+          (Masc.Keeper_registry.packed_compaction_stage_label entry.compaction_stage)
+      | None -> fail "registered keeper disappeared")
+
 let () =
   run "RFC-0065 §3.2.3 WireinOrderPinned (OCaml-side guard)" [
     "WireinOrderPinned", [
@@ -277,6 +370,8 @@ let () =
     "durable compaction", [
       test_case "Prepared requires a successful checkpoint save"
         `Quick test_prepared_becomes_applied_only_after_save;
+      test_case "stale tool compaction is not applied"
+        `Quick test_stale_compaction_is_not_applied;
       test_case "regular post-turn does not auto-compact"
         `Quick test_regular_post_turn_does_not_auto_compact;
     ];


### PR DESCRIPTION
S2a of the MASC-owned compaction stack.

This PR makes the existing save result truthful without claiming atomic checkpoint CAS:

- only `Keeper_checkpoint_store.Saved` becomes `Applied`
- `Stale_noop` becomes typed `checkpoint_superseded` conflict
- load/store/exception paths are explicit errors
- failed recovery emits no `Compaction_completed`, no success result, and no `Compactions` increment
- lifecycle cleanup failure escalates the top-level code to `conflict` while retaining the original recovery code/tag/detail
- compaction decision matching is exhaustive and cancellation is re-raised

Focused proof:
- `test_keeper_post_turn_wirein_order`: 5/5, including the actual `masc_keeper_compact` stale path
- `test_keeper_checkpoint_stale_guard`: 3/3
- focused wrapper build, ocamlformat, diff check: green

Known dependency: checkpoint compare/write is still not linearizable across concurrent writers. S2b will replace the process watermark with a disk-SSOT atomic transaction and multi-domain proof before this stack is called complete.

Diff: +398/-132.