### PR TITLE
fix(keeper): preserve Eio boundary on first chat enqueue

### DIFF
--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -1176,6 +1176,11 @@ let ensure_owned_parent ~ownership_root path =
   | Ok _ -> validate_owned_parent ~ownership_root path
   | Error error -> Error (durable_directory_failure_to_string error)
 
+let prepare_database_parent ~ownership_root ~path ~create_if_missing =
+  if create_if_missing
+  then ensure_owned_parent ~ownership_root path
+  else Ok ()
+
 let database_sidecars path = [ path ^ "-journal"; path ^ "-wal"; path ^ "-shm" ]
 
 let validate_database_paths ~ownership_root path =
@@ -1469,11 +1474,10 @@ let close_database handle =
   combine_cleanup_error close_result identity_result
 
 let open_database ~ownership_root ~path ~create_if_missing ~schema_validation =
-  let* () =
-    if create_if_missing
-    then ensure_owned_parent ~ownership_root path
-    else validate_owned_parent ~ownership_root path
-  in
+  (* This function runs inside [Eio_guard.run_in_systhread]. Keep it limited
+     to blocking SQLite/Unix operations: directory creation is Eio-aware and
+     must be completed by [prepare_database_parent] before this boundary. *)
+  let* () = validate_owned_parent ~ownership_root path in
   let* initial = validate_database_paths ~ownership_root path in
   let missing = initial = Path_absent in
   if missing && not create_if_missing
@@ -1537,6 +1541,7 @@ let with_database
     ~path
     ~create_if_missing
     body =
+  let* () = prepare_database_parent ~ownership_root ~path ~create_if_missing in
   Eio_guard.run_in_systhread (fun () ->
       try
         let* handle =
@@ -1973,7 +1978,10 @@ let run_transaction ~ownership_root ~path ~create_if_missing plan =
   let visit stage =
     if testing_active then visit_transaction_stage stage
   in
-  Eio_guard.run_in_systhread (fun () ->
+  match prepare_database_parent ~ownership_root ~path ~create_if_missing with
+  | Error detail -> Transaction_failed (not_published_failure detail)
+  | Ok () ->
+    Eio_guard.run_in_systhread (fun () ->
       let protect_result f =
         try f () with
         | Eio.Cancel.Cancelled _ as exception_ -> raise exception_

--- a/test/test_keeper_busy_dashboard_deferred.ml
+++ b/test/test_keeper_busy_dashboard_deferred.ml
@@ -50,6 +50,10 @@ let with_env body =
     (fun () ->
       Eio_main.run
       @@ fun env ->
+      Eio.Switch.run
+      @@ fun sw ->
+      Eio_guard.enable ();
+      Eio.Switch.on_release sw Eio_guard.disable;
       Fs_compat.set_fs (Eio.Stdenv.fs env);
       let clock = Eio.Stdenv.clock env in
       let config = Workspace.default_config base in
@@ -59,9 +63,8 @@ let with_env body =
       let report = Keeper_chat_queue.configure_persistence ~base_path:base in
       check "chat queue persistence configured without load errors"
         (report.load_errors = []);
-      Eio.Switch.run (fun sw ->
-        Eio.Switch.on_release sw Keeper_chat_queue.For_testing.reset;
-        body ~base ~clock))
+      Eio.Switch.on_release sw Keeper_chat_queue.For_testing.reset;
+      body ~base ~clock)
 ;;
 
 let with_busy_slot ~base ~sw ?(keeper_name = keeper_name) f =

--- a/test/test_keeper_chat_coalescing.ml
+++ b/test/test_keeper_chat_coalescing.ml
@@ -111,6 +111,35 @@ let save_text path content =
   | Ok () -> ()
   | Error detail -> failwith detail
 
+let test_first_enqueue_with_runtime_eio_guard () =
+  Printf.printf "Test: first SQLite enqueue preserves the live Eio boundary\n%!";
+  with_base "keeper-chat-first-enqueue-eio" @@ fun base_path ->
+  let keeper_name = "first-enqueue-eio" in
+  Eio.Switch.run
+  @@ fun sw ->
+  Eio_guard.enable ();
+  Eio.Switch.on_release sw Eio_guard.disable;
+  ignore (configure_clean base_path : Keeper_chat_queue.configure_report);
+  let path = database_path ~base_path ~keeper_name in
+  check "first enqueue starts without a SQLite store" (not (Sys.file_exists path));
+  match Keeper_chat_queue.enqueue ~keeper_name (message "persist me") with
+  | Error error ->
+    fail
+      "first enqueue succeeds with the runtime Eio guard"
+      (Keeper_chat_queue.mutation_error_to_string error)
+  | Ok receipt ->
+    check "first enqueue publishes the SQLite store" (Sys.file_exists path);
+    (match
+       Keeper_chat_queue.lookup_receipt
+         ~keeper_name
+         ~receipt_id:receipt.receipt_id
+     with
+     | Ok { receipt = Some { state = Pending; _ }; revision } ->
+       check "published receipt is durably readable"
+         (Int64.equal revision receipt.revision)
+     | Ok _ | Error _ ->
+       check "published receipt is durably readable" false)
+
 let test_lifecycle_fifo_terminal_pk_and_restart () =
   Printf.printf "Test: one SQLite SSOT owns FIFO, active, and terminal rows\n%!";
   with_base "keeper-chat-sqlite-lifecycle" @@ fun base_path ->
@@ -696,6 +725,7 @@ let test_reconcile_absent_lane_and_stage_order () =
 
 let () =
   Eio_main.run @@ fun _environment ->
+  test_first_enqueue_with_runtime_eio_guard ();
   test_lifecycle_fifo_terminal_pk_and_restart ();
   test_preallocated_receipt_convergence ();
   test_transaction_publication_boundaries ();


### PR DESCRIPTION
## What changed

- prepare the BasePath-owned Keeper chat queue directory on the live Eio fiber before entering the blocking SQLite transaction
- keep `open_database` restricted to blocking SQLite/Unix work and revalidate the owned parent inside the system thread
- preserve the existing no-retry transaction and publication ambiguity contract
- run the busy Dashboard deferred-message suite with the production `Eio_guard` enabled
- add a first-store regression that proves SQLite publication and exact receipt lookup when no queue database exists

## Root cause

`run_transaction` entered `Eio_guard.run_in_systhread` before calling `open_database`. The first enqueue used `create_if_missing=true`, so `open_database` called `Keeper_fs_durable_directory.ensure`, which performs its own `run_in_systhread`. The outer system thread has no Eio effect handler, so the nested `Run_in_systhread` effect surfaced as `Effect.Unhandled` and the receipt was correctly reported as not published.

## Safety

- no public API or receipt-state change
- no transaction replay or fallback execution
- owned-parent validation still runs again after the Eio-aware preparation, closing the preparation/open race fail-closed
- failure remains typed as `Not_published`
- per-Keeper lane serialization remains unchanged

## Validation

Passed locally:

- `ocamlformat --check lib/keeper/keeper_chat_queue.ml test/test_keeper_chat_coalescing.ml test/test_keeper_busy_dashboard_deferred.ml`
- `ocamlc -stop-after parsing` for all three touched OCaml files
- `git diff --check`

Focused wrapper build was not started because the repository guard detected another session running a bare machine-wide `dune build .`. That unrelated process was left untouched. Full Dune and focused executable validation are delegated to PR CI per repository policy.