### PR TITLE
fix(keeper): make startup recovery fiber-safe

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -82,9 +82,53 @@ let install_error_to_string = function
 
 let pending_store_version = 2
 let pending_store_surface = "keeper_gate_pending"
-let pending_store_mu = Stdlib.Mutex.create ()
+let pending_store_eio_gate = Eio.Mutex.create ()
+let pending_store_cross_context_mu = Stdlib.Mutex.create ()
 let deliveries : persisted_delivery SMap.t Atomic.t = Atomic.make SMap.empty
 let unavailable_stores : storage_error SMap.t Atomic.t = Atomic.make SMap.empty
+
+type execution_context =
+  | Eio_fiber
+  | Non_eio
+
+let execution_context () =
+  match Eio.Fiber.check () with
+  | () -> Eio_fiber
+  | exception Effect.Unhandled _ -> Non_eio
+;;
+
+let rec lock_pending_store_cooperatively () =
+  if Stdlib.Mutex.try_lock pending_store_cross_context_mu
+  then ()
+  else (
+    Eio.Fiber.yield ();
+    lock_pending_store_cooperatively ())
+;;
+
+(** Serialize one durable pending/delivery snapshot transition across both Eio
+    fibers and non-Eio callers.  A plain [Stdlib.Mutex.protect] is invalid here:
+    snapshot publication uses [Eio.Path] and may suspend while the lock is held,
+    letting another fiber on the same domain re-enter the OS mutex and raise
+    [Sys_error "Mutex.lock: Resource deadlock avoided"].
+
+    The cooperative gate ensures only one Eio fiber reaches the cross-context
+    mutex.  [use_ro] releases rather than poisons the gate when [f] raises; the
+    shared OS mutex is always released before that exception propagates.
+    Cancellation is deferred across the durable transition so a published
+    snapshot is returned as committed rather than reported as an ambiguous
+    cancelled operation. *)
+let with_pending_store_lock f =
+  match execution_context () with
+  | Non_eio -> Stdlib.Mutex.protect pending_store_cross_context_mu f
+  | Eio_fiber ->
+    Eio.Mutex.use_ro pending_store_eio_gate (fun () ->
+      lock_pending_store_cooperatively ();
+      Eio.Cancel.protect (fun () ->
+        Fun.protect
+          ~finally:(fun () ->
+            Stdlib.Mutex.unlock pending_store_cross_context_mu)
+          f))
+;;
 
 let mark_store_unavailable_unlocked ~base_path error =
   Atomic.set
@@ -960,7 +1004,7 @@ let approved_delivery_unlocked ~base_path ~id =
 ;;
 
 let approved_resolution_request ~base_path ~id =
-  Stdlib.Mutex.protect pending_store_mu (fun () ->
+  with_pending_store_lock (fun () ->
     match approved_delivery_unlocked ~base_path ~id with
     | Error _ as error -> error
     | Ok Approved_delivery_consumed -> Ok None
@@ -974,7 +1018,7 @@ let approved_resolution_request ~base_path ~id =
 ;;
 
 let approved_resolution_state ~base_path ~id =
-  Stdlib.Mutex.protect pending_store_mu (fun () ->
+  with_pending_store_lock (fun () ->
     match approved_delivery_unlocked ~base_path ~id with
     | Error _ as error -> error
     | Ok Approved_delivery_consumed -> Ok Resolution_consumed
@@ -989,7 +1033,7 @@ let consume_approved_resolution
       ~input
   =
   let result =
-    Stdlib.Mutex.protect pending_store_mu (fun () ->
+    with_pending_store_lock (fun () ->
       match approved_delivery_unlocked ~base_path ~id with
       | Error error -> Error error
       | Ok Approved_delivery_consumed ->
@@ -1048,9 +1092,10 @@ module For_testing = struct
   ;;
 
   let get_pending_entry ~id = SMap.find_opt id (Atomic.get pending)
+  let with_pending_store_lock = with_pending_store_lock
 
   let reset_runtime_state () =
-    Stdlib.Mutex.protect pending_store_mu (fun () ->
+    with_pending_store_lock (fun () ->
       Atomic.set pending SMap.empty;
       Atomic.set deliveries SMap.empty;
       Atomic.set unavailable_stores SMap.empty)
@@ -1236,7 +1281,7 @@ let get_pending_entry ~id : pending_approval option = SMap.find_opt id (Atomic.g
 (** Complete an in-flight judge exactly once. A result cannot skip the
     [Summary_pending] state or overwrite a terminal summary. *)
 let complete_summary ~id summary_status =
-  Stdlib.Mutex.protect pending_store_mu (fun () ->
+  with_pending_store_lock (fun () ->
     let map = Atomic.get pending in
     match SMap.find_opt id map with
     | None -> Ok false
@@ -1277,7 +1322,7 @@ let publish_summary_transition ~id = function
 
 let mark_summary_pending ~id =
   let result =
-    Stdlib.Mutex.protect pending_store_mu (fun () ->
+    with_pending_store_lock (fun () ->
     let map = Atomic.get pending in
     match SMap.find_opt id map with
     | None -> Ok false
@@ -1315,7 +1360,7 @@ let mark_summary_failed ~id ~reason ~retryable =
 
 let restart_retryable_summary ~id =
   let updated =
-    Stdlib.Mutex.protect pending_store_mu (fun () ->
+    with_pending_store_lock (fun () ->
       let map = Atomic.get pending in
       match SMap.find_opt id map with
       | Some
@@ -1584,7 +1629,7 @@ let submit_pending
     Option.value continuation_channel ~default:(default_continuation_channel ())
   in
   let stored =
-    Stdlib.Mutex.protect pending_store_mu (fun () ->
+    with_pending_store_lock (fun () ->
       let map = Atomic.get pending in
       match
         find_pending_id_in_map
@@ -1689,7 +1734,7 @@ type journal_error =
   | Journal_storage of storage_error
 
 let journal_resolution ~id ~decision ~source ~remember_rule ~created_by =
-  Stdlib.Mutex.protect pending_store_mu (fun () ->
+  with_pending_store_lock (fun () ->
     let pending_map = Atomic.get pending in
     match SMap.find_opt id pending_map with
     | None -> Error Journal_not_found
@@ -1719,7 +1764,7 @@ let journal_resolution ~id ~decision ~source ~remember_rule ~created_by =
 ;;
 
 let remove_delivery_from_store delivery =
-  Stdlib.Mutex.protect pending_store_mu (fun () ->
+  with_pending_store_lock (fun () ->
     let delivery_map = Atomic.get deliveries in
     let updated_deliveries = SMap.remove delivery.entry.id delivery_map in
     match
@@ -1849,7 +1894,7 @@ let install_persistence ~base_path =
      section below. *)
   let loaded_snapshot = load_snapshot_unlocked ~base_path in
   let installed =
-    Stdlib.Mutex.protect pending_store_mu (fun () ->
+    with_pending_store_lock (fun () ->
       match loaded_snapshot with
       | Error storage_error ->
         mark_store_unavailable_unlocked ~base_path storage_error;

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -155,6 +155,7 @@ val list_recent_resolved_json :
 module For_testing : sig
   val reset_audit_store : unit -> unit
   val reset_runtime_state : unit -> unit
+  val with_pending_store_lock : (unit -> 'a) -> 'a
   val pending_store_path : base_path:string -> string
   val always_allowed_store_path : base_path:string -> string
 end

--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -3574,9 +3574,55 @@ let read_owned_directory_blocking ~ownership_root path =
                "owned Keeper directory identity changed during queue inventory")
         | Error _ as error -> error))
 
-let read_owned_directory ~ownership_root path =
+type keeper_directory_inventory =
+  { keeper_names : string list
+  ; rejected_entries : (string * snapshot_load_error) list
+  }
+
+let classify_keeper_directory_entries_blocking entries_path entries =
+  List.fold_left
+    (fun inventory entry_name ->
+       let entry_path = Filename.concat entries_path entry_name in
+       match Unix.lstat entry_path with
+       | { Unix.st_kind = Unix.S_DIR; _ } ->
+         { inventory with keeper_names = entry_name :: inventory.keeper_names }
+       | { Unix.st_kind = Unix.S_REG; _ } ->
+         (* The Keeper runtime root also owns meta JSON, decision JSONL,
+            memory JSONL, and backup files.  They are not chat queue lanes and
+            must not be interpreted as directory names. *)
+         inventory
+       | { Unix.st_kind = st_kind; _ } ->
+         { inventory with
+           rejected_entries =
+             ( entry_name
+             , load_error Invalid_path ~path:entry_path
+                 (Printf.sprintf
+                    "Keeper chat queue inventory entry has unsupported kind %s"
+                    (unix_file_kind_to_string st_kind)) )
+             :: inventory.rejected_entries
+         }
+       | exception exn ->
+         { inventory with
+           rejected_entries =
+             ( entry_name
+             , load_error Read_failed ~path:entry_path (Printexc.to_string exn) )
+             :: inventory.rejected_entries
+         })
+    { keeper_names = []; rejected_entries = [] }
+    entries
+  |> fun inventory ->
+  { keeper_names = List.rev inventory.keeper_names
+  ; rejected_entries = List.rev inventory.rejected_entries
+  }
+;;
+
+let read_keeper_directory_inventory ~ownership_root path =
   Eio_guard.run_in_systhread (fun () ->
-      read_owned_directory_blocking ~ownership_root path)
+    match read_owned_directory_blocking ~ownership_root path with
+    | Error _ as error -> error
+    | Ok None -> Ok None
+    | Ok (Some entries) ->
+      Ok (Some (classify_keeper_directory_entries_blocking path entries)))
 
 let configure_persistence ~base_path =
   let claimed =
@@ -3626,9 +3672,19 @@ let configure_persistence ~base_path =
                 (create_entry ~load_errors:[ error ] ()))
       in
       let keeper_names =
-        match read_owned_directory ~ownership_root:base_path keepers_dir with
+        match
+          read_keeper_directory_inventory
+            ~ownership_root:base_path
+            keepers_dir
+        with
         | Ok None -> []
-        | Ok (Some names) -> List.sort String.compare names
+        | Ok (Some inventory) ->
+          List.iter
+            (fun (entry_name, error) ->
+               reported_errors :=
+                 (Some entry_name, error) :: !reported_errors)
+            inventory.rejected_entries;
+          List.sort String.compare inventory.keeper_names
         | Error error ->
           let error =
             { error with

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -111,6 +111,34 @@ let reject_and_cleanup id =
   | Error error -> Alcotest.fail (AQ.resolve_error_to_string error)
 ;;
 
+let test_pending_store_lock_serializes_eio_fibers () =
+  Eio_main.run @@ fun _environment ->
+  let first_entered, signal_first_entered = Eio.Promise.create () in
+  let second_attempted, signal_second_attempted = Eio.Promise.create () in
+  let release_first, signal_release_first = Eio.Promise.create () in
+  let order = ref [] in
+  Eio.Fiber.all
+    [ (fun () ->
+        AQ.For_testing.with_pending_store_lock (fun () ->
+          order := "first_entered" :: !order;
+          Eio.Promise.resolve signal_first_entered ();
+          Eio.Promise.await release_first;
+          order := "first_released" :: !order))
+    ; (fun () ->
+        Eio.Promise.await first_entered;
+        Eio.Promise.resolve signal_second_attempted ();
+        AQ.For_testing.with_pending_store_lock (fun () ->
+          order := "second_entered" :: !order))
+    ; (fun () ->
+        Eio.Promise.await second_attempted;
+        Eio.Promise.resolve signal_release_first ())
+    ];
+  Alcotest.(check (list string))
+    "second fiber enters only after the yielding durable transition releases"
+    [ "first_entered"; "first_released"; "second_entered" ]
+    (List.rev !order)
+;;
+
 let test_dedup_never_merges_distinct_origins () =
   let base_path = temp_dir () in
   let keeper_name = "queue-distinct-origin" in
@@ -1173,6 +1201,10 @@ let () =
     "Keeper_approval_queue"
     [ ( "nonhierarchical queue"
       , [ Alcotest.test_case
+            "durable lock serializes Eio fibers"
+            `Quick
+            test_pending_store_lock_serializes_eio_fibers
+        ; Alcotest.test_case
             "submit is nonblocking and exact"
             `Quick
             test_submit_is_nonblocking_and_exactly_deduplicated

--- a/test/test_keeper_chat_coalescing.ml
+++ b/test/test_keeper_chat_coalescing.ml
@@ -664,6 +664,21 @@ let test_legacy_json_is_not_a_queue_authority () =
     (Result.is_ok
        (Keeper_chat_queue.enqueue ~keeper_name:healthy_keeper (message "works")))
 
+let test_runtime_files_are_not_queue_lane_directories () =
+  Printf.printf
+    "Test: Keeper runtime files are not interpreted as queue lane directories\n%!";
+  with_base "keeper-chat-runtime-files" @@ fun base_path ->
+  let keepers_dir = Common.keepers_runtime_dir_of_base ~base_path in
+  Fs_compat.mkdir_p keepers_dir;
+  save_text (Filename.concat keepers_dir "executor.json") "{}";
+  save_text (Filename.concat keepers_dir "executor.memory.jsonl") "";
+  save_text (Filename.concat keepers_dir "executor.decisions.jsonl") "";
+  let report = configure base_path in
+  check "runtime files produce no queue recovery failures"
+    (report.load_errors = []);
+  check "runtime files restore no queue lanes"
+    (report.restored_keeper_count = 0)
+
 let test_foreign_database_and_symlink_are_quarantined () =
   Printf.printf "Test: foreign schema and symlink path never become queue SSOT\n%!";
   let foreign_case base_path =
@@ -734,6 +749,7 @@ let () =
   test_uncertain_lease_compensates_and_other_transitions_reconcile ();
   test_restart_requires_explicit_recovery_without_journal ();
   test_legacy_json_is_not_a_queue_authority ();
+  test_runtime_files_are_not_queue_lane_directories ();
   test_foreign_database_and_symlink_are_quarantined ();
   test_reconcile_absent_lane_and_stage_order ();
   if !failures > 0


### PR DESCRIPTION
## Summary

- serialize durable Gate pending/delivery transitions across Eio fibers and non-Eio callers without holding a blocking mutex across a fiber suspension
- keep cancellation outside the durable publication boundary so committed snapshots are not reported ambiguously
- inventory only Keeper directories as chat queue lanes; ordinary runtime JSON/JSONL files are no longer treated as lane names
- add deterministic Eio contention and runtime-file inventory regressions

## Live reproduction

At 2026-07-15 18:16 KST startup, two recovered Auto Judge workers entered Gate summary persistence concurrently and terminated the server with Sys_error("Mutex.lock: Resource deadlock avoided"). The same startup scan treated 78 regular files under .masc/keepers as queue directories.

## Verification

- ocamlformat --check on all five touched files
- ocamlc -stop-after parsing on all five touched files
- git diff --check
- focused local Dune was requested twice through scripts/dune-local.sh, but the repository guard refused while unrelated bare Dune builds were live; CI is the build authority for this change