### PR TITLE
fix(keeper): make approval-queue pending-store mutex fiber-safe (boot crash loop)

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -82,7 +82,19 @@ let install_error_to_string = function
 
 let pending_store_version = 2
 let pending_store_surface = "keeper_gate_pending"
-let pending_store_mu = Stdlib.Mutex.create ()
+
+(* Eio.Mutex, not Stdlib.Mutex: the pending-store critical sections run
+   [persist_snapshot_unlocked] -> [Fs_compat] file I/O, which can suspend the
+   holding fiber. With a Stdlib.Mutex, another fiber scheduled on the same
+   domain that then enters any pending-store section relocks a mutex the OS
+   thread already holds and dies with Sys_error "Mutex.lock: Resource deadlock
+   avoided" — the 2026-07-15 crash loop (HITL auto-judge on_failure ->
+   [mark_summary_failed] took the whole server down on every boot).
+   [use_rw ~protect:true] suspends the waiting fiber instead and shields the
+   critical section from cancellation. Invariant: pending-store sections never
+   call other pending-store takers (audited 2026-07-15; single-step acquire),
+   so fiber-level self-deadlock cannot occur. *)
+let pending_store_mu = Eio.Mutex.create ()
 let deliveries : persisted_delivery SMap.t Atomic.t = Atomic.make SMap.empty
 let unavailable_stores : storage_error SMap.t Atomic.t = Atomic.make SMap.empty
 
@@ -960,7 +972,7 @@ let approved_delivery_unlocked ~base_path ~id =
 ;;
 
 let approved_resolution_request ~base_path ~id =
-  Stdlib.Mutex.protect pending_store_mu (fun () ->
+  Eio.Mutex.use_rw ~protect:true pending_store_mu (fun () ->
     match approved_delivery_unlocked ~base_path ~id with
     | Error _ as error -> error
     | Ok Approved_delivery_consumed -> Ok None
@@ -974,7 +986,7 @@ let approved_resolution_request ~base_path ~id =
 ;;
 
 let approved_resolution_state ~base_path ~id =
-  Stdlib.Mutex.protect pending_store_mu (fun () ->
+  Eio.Mutex.use_rw ~protect:true pending_store_mu (fun () ->
     match approved_delivery_unlocked ~base_path ~id with
     | Error _ as error -> error
     | Ok Approved_delivery_consumed -> Ok Resolution_consumed
@@ -989,7 +1001,7 @@ let consume_approved_resolution
       ~input
   =
   let result =
-    Stdlib.Mutex.protect pending_store_mu (fun () ->
+    Eio.Mutex.use_rw ~protect:true pending_store_mu (fun () ->
       match approved_delivery_unlocked ~base_path ~id with
       | Error error -> Error error
       | Ok Approved_delivery_consumed ->
@@ -1050,7 +1062,7 @@ module For_testing = struct
   let get_pending_entry ~id = SMap.find_opt id (Atomic.get pending)
 
   let reset_runtime_state () =
-    Stdlib.Mutex.protect pending_store_mu (fun () ->
+    Eio.Mutex.use_rw ~protect:true pending_store_mu (fun () ->
       Atomic.set pending SMap.empty;
       Atomic.set deliveries SMap.empty;
       Atomic.set unavailable_stores SMap.empty)
@@ -1236,7 +1248,7 @@ let get_pending_entry ~id : pending_approval option = SMap.find_opt id (Atomic.g
 (** Complete an in-flight judge exactly once. A result cannot skip the
     [Summary_pending] state or overwrite a terminal summary. *)
 let complete_summary ~id summary_status =
-  Stdlib.Mutex.protect pending_store_mu (fun () ->
+  Eio.Mutex.use_rw ~protect:true pending_store_mu (fun () ->
     let map = Atomic.get pending in
     match SMap.find_opt id map with
     | None -> Ok false
@@ -1277,7 +1289,7 @@ let publish_summary_transition ~id = function
 
 let mark_summary_pending ~id =
   let result =
-    Stdlib.Mutex.protect pending_store_mu (fun () ->
+    Eio.Mutex.use_rw ~protect:true pending_store_mu (fun () ->
     let map = Atomic.get pending in
     match SMap.find_opt id map with
     | None -> Ok false
@@ -1315,7 +1327,7 @@ let mark_summary_failed ~id ~reason ~retryable =
 
 let restart_retryable_summary ~id =
   let updated =
-    Stdlib.Mutex.protect pending_store_mu (fun () ->
+    Eio.Mutex.use_rw ~protect:true pending_store_mu (fun () ->
       let map = Atomic.get pending in
       match SMap.find_opt id map with
       | Some
@@ -1584,7 +1596,7 @@ let submit_pending
     Option.value continuation_channel ~default:(default_continuation_channel ())
   in
   let stored =
-    Stdlib.Mutex.protect pending_store_mu (fun () ->
+    Eio.Mutex.use_rw ~protect:true pending_store_mu (fun () ->
       let map = Atomic.get pending in
       match
         find_pending_id_in_map
@@ -1689,7 +1701,7 @@ type journal_error =
   | Journal_storage of storage_error
 
 let journal_resolution ~id ~decision ~source ~remember_rule ~created_by =
-  Stdlib.Mutex.protect pending_store_mu (fun () ->
+  Eio.Mutex.use_rw ~protect:true pending_store_mu (fun () ->
     let pending_map = Atomic.get pending in
     match SMap.find_opt id pending_map with
     | None -> Error Journal_not_found
@@ -1719,7 +1731,7 @@ let journal_resolution ~id ~decision ~source ~remember_rule ~created_by =
 ;;
 
 let remove_delivery_from_store delivery =
-  Stdlib.Mutex.protect pending_store_mu (fun () ->
+  Eio.Mutex.use_rw ~protect:true pending_store_mu (fun () ->
     let delivery_map = Atomic.get deliveries in
     let updated_deliveries = SMap.remove delivery.entry.id delivery_map in
     match
@@ -1849,7 +1861,7 @@ let install_persistence ~base_path =
      section below. *)
   let loaded_snapshot = load_snapshot_unlocked ~base_path in
   let installed =
-    Stdlib.Mutex.protect pending_store_mu (fun () ->
+    Eio.Mutex.use_rw ~protect:true pending_store_mu (fun () ->
       match loaded_snapshot with
       | Error storage_error ->
         mark_store_unavailable_unlocked ~base_path storage_error;

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -1168,6 +1168,11 @@ let test_nonapproved_resolution_payload_is_delivered () =
        drop_resolution ~base_path ~keeper_name edited)
 ;;
 
+(* The pending-store mutex is an Eio.Mutex (see keeper_approval_queue.ml);
+   its sections need an Eio scheduler even uncontended, so every case runs
+   inside its own event loop. *)
+let in_eio f () = Eio_main.run @@ fun _env -> f ()
+
 let () =
   Alcotest.run
     "Keeper_approval_queue"
@@ -1175,67 +1180,67 @@ let () =
       , [ Alcotest.test_case
             "submit is nonblocking and exact"
             `Quick
-            test_submit_is_nonblocking_and_exactly_deduplicated
+            (in_eio test_submit_is_nonblocking_and_exactly_deduplicated)
         ; Alcotest.test_case
             "dedup keeps distinct origins"
             `Quick
-            test_dedup_never_merges_distinct_origins
+            (in_eio test_dedup_never_merges_distinct_origins)
         ; Alcotest.test_case
             "resolution wakes only origin"
             `Quick
-            test_resolution_is_durable_and_origin_scoped
+            (in_eio test_resolution_is_durable_and_origin_scoped)
         ; Alcotest.test_case
             "cycle grant binds origin and is consumed once"
             `Quick
-            test_cycle_grant_uses_exact_effect_and_is_consumed_once
+            (in_eio test_cycle_grant_uses_exact_effect_and_is_consumed_once)
         ; Alcotest.test_case
             "summary is advisory"
             `Quick
-            test_summary_updates_never_resolve_pending_request
+            (in_eio test_summary_updates_never_resolve_pending_request)
         ; Alcotest.test_case
             "only retryable summary failure restarts"
             `Quick
-            test_only_retryable_summary_failure_restarts
+            (in_eio test_only_retryable_summary_failure_restarts)
         ; Alcotest.test_case
             "retryable Auto Judge recovery is lane-local"
             `Quick
-            test_retryable_auto_judge_recovery_is_lane_local
+            (in_eio test_retryable_auto_judge_recovery_is_lane_local)
         ; Alcotest.test_case
             "decisive summary finalizes after restart"
             `Quick
-            test_decisive_summary_finalizes_after_restart
+            (in_eio test_decisive_summary_finalizes_after_restart)
         ; Alcotest.test_case
             "interrupted judge keeps restart marker"
             `Quick
-            test_inflight_auto_judge_preserves_durable_restart_marker
+            (in_eio test_inflight_auto_judge_preserves_durable_restart_marker)
         ; Alcotest.test_case
             "malformed snapshot is explicit"
             `Quick
-            test_malformed_snapshot_fails_install_and_is_observed
+            (in_eio test_malformed_snapshot_fails_install_and_is_observed)
         ; Alcotest.test_case
             "delivery journal replays"
             `Quick
-            test_persisted_delivery_replays_before_origin_wake
+            (in_eio test_persisted_delivery_replays_before_origin_wake)
         ; Alcotest.test_case
             "one replay failure does not stop others"
             `Quick
-            test_one_delivery_replay_failure_does_not_stop_others
+            (in_eio test_one_delivery_replay_failure_does_not_stop_others)
         ; Alcotest.test_case
             "storage failure is returned"
             `Quick
-            test_submit_surfaces_storage_failure
+            (in_eio test_submit_surfaces_storage_failure)
         ; Alcotest.test_case
             "default Auto Judge defers without blocking"
             `Quick
-            test_default_auto_judge_defers_without_blocking
+            (in_eio test_default_auto_judge_defers_without_blocking)
         ; Alcotest.test_case
             "unavailable grant never falls through"
             `Quick
-            test_unavailable_cycle_grant_never_falls_through
+            (in_eio test_unavailable_cycle_grant_never_falls_through)
         ; Alcotest.test_case
             "non-approved resolution payload is delivered"
             `Quick
-            test_nonapproved_resolution_payload_is_delivered
+            (in_eio test_nonapproved_resolution_payload_is_delivered)
         ] )
     ]
 ;;

--- a/test/test_keeper_approval_queue_rules.ml
+++ b/test/test_keeper_approval_queue_rules.ml
@@ -355,6 +355,11 @@ let test_workspace_always_allow_does_not_depend_on_rule_store () =
        | Gate.Unavailable reason -> fail (Gate.unavailable_reason_to_string reason))
 ;;
 
+(* The pending-store mutex is an Eio.Mutex (see keeper_approval_queue.ml);
+   its sections need an Eio scheduler even uncontended, so every case runs
+   inside its own event loop. *)
+let in_eio f () = Eio_main.run @@ fun _env -> f ()
+
 let () =
   run
     "Keeper_approval_queue_rules"
@@ -362,40 +367,40 @@ let () =
       , [ test_case
             "matches only complete exact request"
             `Quick
-            test_rule_matches_only_complete_exact_request
+            (in_eio test_rule_matches_only_complete_exact_request)
         ; test_case "idempotent upsert" `Quick test_equivalent_upsert_is_idempotent
         ; test_case
             "Gate consumes exact persisted rule"
             `Quick
-            test_gate_allows_only_the_exact_persisted_rule
+            (in_eio test_gate_allows_only_the_exact_persisted_rule)
         ; test_case
             "unsupported persisted shape is explicit"
             `Quick
-            test_unknown_persisted_shape_is_reported_and_rejected
+            (in_eio test_unknown_persisted_shape_is_reported_and_rejected)
         ; test_case
             "duplicate persisted rules reject whole store"
             `Quick
-            test_duplicate_persisted_rules_reject_whole_store
+            (in_eio test_duplicate_persisted_rules_reject_whole_store)
         ; test_case
             "Manual mode survives exact-rule storage failure"
             `Quick
-            test_manual_mode_continues_when_rule_store_is_unavailable
+            (in_eio test_manual_mode_continues_when_rule_store_is_unavailable)
         ; test_case
             "Auto Judge survives exact-rule storage failure"
             `Quick
-            test_auto_judge_continues_when_rule_store_is_unavailable
+            (in_eio test_auto_judge_continues_when_rule_store_is_unavailable)
         ; test_case
             "invalid mode remains an explicit defer after rule storage failure"
             `Quick
-            test_invalid_mode_continues_to_explicit_defer_when_rule_store_is_unavailable
+            (in_eio test_invalid_mode_continues_to_explicit_defer_when_rule_store_is_unavailable)
         ; test_case
             "Keeper Always Allowed is independent of rule storage"
             `Quick
-            test_keeper_always_allow_does_not_depend_on_rule_store
+            (in_eio test_keeper_always_allow_does_not_depend_on_rule_store)
         ; test_case
             "workspace Always Allowed is independent of rule storage"
             `Quick
-            test_workspace_always_allow_does_not_depend_on_rule_store
+            (in_eio test_workspace_always_allow_does_not_depend_on_rule_store)
         ] )
     ]
 ;;

--- a/test/test_keeper_gate_effect_coverage.ml
+++ b/test/test_keeper_gate_effect_coverage.ml
@@ -352,6 +352,11 @@ let test_ollama_probe_leaf_requests_exact_authorization () =
   | calls -> failf "expected one authorization request, got %d" (List.length calls)
 ;;
 
+(* The pending-store mutex is an Eio.Mutex (see keeper_approval_queue.ml);
+   its sections need an Eio scheduler even uncontended, so every case runs
+   inside its own event loop. *)
+let in_eio f () = Eio_main.run @@ fun _env -> f ()
+
 let () =
   run
     "keeper_gate_effect_coverage"
@@ -359,35 +364,35 @@ let () =
       , [ test_case
             "second tool snapshot contains first tool result"
             `Quick
-            test_second_tool_snapshot_contains_first_tool_result
+            (in_eio test_second_tool_snapshot_contains_first_tool_result)
         ] )
     ; ( "keeper_effects"
       , [ test_case
             "Deferred executes no sandbox/lifecycle effect"
             `Quick
-            test_keeper_effects_defer_without_dispatch
+            (in_eio test_keeper_effects_defer_without_dispatch)
         ; test_case
             "Unavailable executes no sandbox/lifecycle effect"
             `Quick
-            test_keeper_effects_unavailable_without_dispatch
+            (in_eio test_keeper_effects_unavailable_without_dispatch)
         ; test_case
             "Allow dispatches exact sandbox/lifecycle effect"
             `Quick
-            test_keeper_effects_allow_exact_dispatch
+            (in_eio test_keeper_effects_allow_exact_dispatch)
         ] )
     ; ( "network_probe"
       , [ test_case
             "Deferred and Unavailable execute no network probe"
             `Quick
-            test_ollama_probe_defer_and_unavailable_do_not_dispatch
+            (in_eio test_ollama_probe_defer_and_unavailable_do_not_dispatch)
         ; test_case
             "Allow dispatches exact network probe"
             `Quick
-            test_ollama_probe_allow_dispatches_exact_input
+            (in_eio test_ollama_probe_allow_dispatches_exact_input)
         ; test_case
             "effect leaf requests exact authorization"
             `Quick
-            test_ollama_probe_leaf_requests_exact_authorization
+            (in_eio test_ollama_probe_leaf_requests_exact_authorization)
         ] )
     ]
 ;;


### PR DESCRIPTION
## 증상 (P0, 부팅 차단)

2026-07-15 18:13 서버 crash, 이후 **매 부팅 수 초 내 재발**하는 결정론적 crash loop:

```
[FATAL] Unhandled exception: Sys_error("Mutex.lock: Resource deadlock avoided")
  Stdlib__Mutex.protect ← Keeper_approval_queue.mark_summary_failed (keeper_approval_queue.ml:1312)
  ← Keeper_gate.spawn_claimed_auto_judge_entry.on_failure (keeper_gate.ml:328-331)
```

영속화된 `Summary_pending` approval(`appr_8bb5e3c7…`)이 부팅마다 HITL auto-judge를 재스폰 → worker와 `on_failure`(`mark_summary_failed`)가 연달아 EDEADLK → root switch를 뚫고 프로세스 전체 사망.

## 근본 원인

`pending_store_mu`가 **Stdlib.Mutex**인데, critical section 내부에서 `persist_snapshot_unlocked` → `Fs_compat` 파일 I/O(Eio backend에서 서스펜션 가능)를 수행. fiber A가 락을 쥔 채 서스펜드되면 같은 domain의 fiber B가 같은 OS 스레드에서 relock → macOS pthread가 EDEADLK(`Resource deadlock avoided`)를 던짐. 코드베이스 자체 규칙("suspension 있는 구간은 `Eio.Mutex.use_rw ~protect:true`") 위반 사례.

테스트에서 한 번도 안 터진 이유: 테스트는 Eio 스케줄러 밖에서 돌고 `Fs_compat`이 Stdlib I/O로 폴백 → 서스펜션 없음.

## 변경

- `pending_store_mu`: `Stdlib.Mutex` → `Eio.Mutex`, 11개 protect 사이트 전부 `use_rw ~protect:true`. 경합 fiber는 crash 대신 정상 대기, 구간은 cancellation으로부터 보호.
- **중첩 감사**: taker 10개 함수 전수 스캔, 상호 호출 0건 (fiber self-deadlock 불가). 정적 감사 스크립트로 확인.
- 테스트 3개 스위트(approval_queue 16, rules 10, gate_effect_coverage 7)를 케이스별 `Eio_main.run` 래핑(기존 `with_board` 관례와 동일 패턴).

## 검증

- `test_keeper_approval_queue` 16/16, `test_keeper_approval_queue_rules` 10/10, `test_keeper_gate_effect_coverage` 7/7, `test_hitl_summary_worker` 7/7, `test_keeper_approval_queue_rules_types` 5/5, `test_keeper_supervisor` green.
- `dune build @all` green, fmt clean (무관한 dune 파일들의 pre-existing fmt drift는 커밋에서 제외).
- 실기동 검증: 이 fix + #24528을 로컬 통합한 바이너리로 crash-loop 상태의 실제 base-path 부팅 예정 (poisoned approval이 안전하게 Summary_failed로 전이되는지 확인).

## 관련

- #24528 (provider_id 게이트 fix — 같은 날 발견된 별개 결함, 이 crash와 무관)
- #24533 (chat enqueue Eio boundary — 같은 계열의 Eio boundary 결함)
- RFC-0342 D4의 "config-plane 오류로 프로세스 죽이지 않기"와 별개로, 이건 keeper-plane 예외가 root switch를 뚫는 사례 — keeper crash 격리는 후속 논의 대상.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>