### PR TITLE
feat(keeper): type durable invocation receipts

### DIFF
--- a/docs/design/keeper-tool-boundary-matrix.md
+++ b/docs/design/keeper-tool-boundary-matrix.md
@@ -162,8 +162,6 @@ Each path below must appear exactly once and use one owner from the table above.
 - `lib/keeper/keeper_tool_policy.mli` - tool-surface-policy
 - `lib/keeper/keeper_tool_progress_identity.ml` - tool-surface-policy
 - `lib/keeper/keeper_tool_progress_identity.mli` - tool-surface-policy
-- `lib/keeper/keeper_tool_inflight.ml` - tool-surface-policy
-- `lib/keeper/keeper_tool_inflight.mli` - tool-surface-policy
 - `lib/keeper/keeper_tool_registry.ml` - tool-surface-policy
 - `lib/keeper/keeper_tool_registry.mli` - tool-surface-policy
 - `lib/keeper_tool_response/keeper_tool_response.ml` - tool-surface-policy

--- a/lib/keeper/keeper_invocation_contract.ml
+++ b/lib/keeper/keeper_invocation_contract.ml
@@ -1,0 +1,181 @@
+type capability = Invoke_turn
+
+type target = Keeper of Keeper_id.Keeper_name.t
+
+type request =
+  { target : target
+  ; capability : capability
+  ; prompt : string
+  }
+
+type run_ref =
+  { run_id : string
+  ; target : target
+  ; capability : capability
+  }
+
+type submission_receipt =
+  | Durable_run of run_ref
+  | Reconciliation_required of
+      { run_ref : run_ref
+      ; reason : string
+      }
+
+type result_contract =
+  | Awaiting_execution
+  | Publication_uncertain
+  | Running
+  | Yielded
+  | Cancellation_requested
+  | Cancelled
+  | Completed
+  | Failed
+
+type request_error =
+  | Invalid_target of string
+  | Empty_prompt
+  | Invalid_entry_projection
+
+let ( let* ) = Result.bind
+
+let request ~keeper_name ~prompt =
+  let* keeper_name =
+    Keeper_id.Keeper_name.of_string keeper_name
+    |> Result.map_error (fun reason -> Invalid_target reason)
+  in
+  if String.equal prompt ""
+  then Error Empty_prompt
+  else Ok { target = Keeper keeper_name; capability = Invoke_turn; prompt }
+;;
+
+let request_error_to_string = function
+  | Invalid_target reason -> reason
+  | Empty_prompt -> "message is required"
+  | Invalid_entry_projection -> "Keeper invocation entry projection is not an object"
+;;
+
+let target_name (request : request) =
+  match request.target with
+  | Keeper name -> Keeper_id.Keeper_name.to_string name
+;;
+
+let prompt (request : request) = request.prompt
+
+let submit ~background_sw ~base_path ~caller ~(request : request) ~f () =
+  Keeper_msg_async.submit
+    ~background_sw
+    ~base_path
+    ~caller
+    ~keeper_name:(target_name request)
+    ~f:(f request)
+    ()
+;;
+
+let run_ref (request : request) run_id =
+  { run_id; target = request.target; capability = request.capability }
+;;
+
+let submission_receipt (request : request) outcome =
+  let reference = run_ref request outcome.Keeper_msg_async.request_id in
+  match outcome.acceptance with
+  | Keeper_msg_async.Durably_accepted -> Durable_run reference
+  | Keeper_msg_async.Reconciliation_required { reason } ->
+    Reconciliation_required { run_ref = reference; reason }
+;;
+
+let result_contract entry =
+  match entry.Keeper_msg_async.status with
+  | Keeper_msg_async.Queued -> Awaiting_execution
+  | Keeper_msg_async.Running -> Running
+  | Keeper_msg_async.Cancelling _ -> Cancellation_requested
+  | Keeper_msg_async.Cancelled _ -> Cancelled
+  | Keeper_msg_async.Lost _
+  | Keeper_msg_async.Persistence_failed _
+  | Keeper_msg_async.Done { ok = false; _ } -> Failed
+  | Keeper_msg_async.Done { ok = true; data; _ } ->
+    (match Keeper_turn_outcome.of_reply_payload data with
+     | Keeper_turn_outcome.Continuation_checkpoint -> Yielded
+     | Keeper_turn_outcome.Visible_reply
+     | Keeper_turn_outcome.No_visible_reply -> Completed)
+;;
+
+let capability_to_string = function
+  | Invoke_turn -> "invoke_turn"
+;;
+
+let target_to_json = function
+  | Keeper name ->
+    `Assoc
+      [ "kind", `String "keeper"
+      ; "name", `String (Keeper_id.Keeper_name.to_string name)
+      ]
+;;
+
+let run_ref_to_json reference =
+  `Assoc
+    [ "run_id", `String reference.run_id
+    ; "target", target_to_json reference.target
+    ; "capability", `String (capability_to_string reference.capability)
+    ]
+;;
+
+let result_contract_to_string = function
+  | Awaiting_execution -> "awaiting_execution"
+  | Publication_uncertain -> "publication_uncertain"
+  | Running -> "running"
+  | Yielded -> "yielded"
+  | Cancellation_requested -> "cancellation_requested"
+  | Cancelled -> "cancelled"
+  | Completed -> "completed"
+  | Failed -> "failed"
+;;
+
+let submission_to_json (request : request) outcome =
+  let common reference status result_contract =
+    [ "request_id", `String outcome.Keeper_msg_async.request_id
+    ; "keeper_name", `String (target_name request)
+    ; "status", `String status
+    ; "run_ref", run_ref_to_json reference
+    ; "result_contract", `String (result_contract_to_string result_contract)
+    ]
+  in
+  match submission_receipt request outcome with
+  | Durable_run reference ->
+    `Assoc
+      (common reference "queued" Awaiting_execution
+       @ [ ( "message"
+           , `String
+               "Keeper turn accepted. The caller lane may continue; query masc_keeper_msg_result with run_ref.run_id." )
+         ])
+  | Reconciliation_required { run_ref = reference; reason } ->
+    `Assoc
+      (common reference "reconciliation_required" Publication_uncertain
+       @ [ "reason", `String reason
+         ; ( "operator_instruction"
+           , `String
+               "Request publication is uncertain. Query masc_keeper_msg_result with this exact run_ref.run_id; do not resubmit." )
+         ])
+;;
+
+let entry_to_json entry =
+  let contract = result_contract entry in
+  let* target_name =
+    Keeper_id.Keeper_name.of_string entry.Keeper_msg_async.keeper_name
+    |> Result.map_error (fun reason -> Invalid_target reason)
+  in
+  let reference =
+    { run_id = entry.request_id
+    ; target = Keeper target_name
+    ; capability = Invoke_turn
+    }
+  in
+  match Keeper_msg_async.entry_to_json entry with
+  | `Assoc fields ->
+    Ok
+      (`Assoc
+         (fields
+          @ [ "run_ref", run_ref_to_json reference
+            ; "result_contract", `String (result_contract_to_string contract)
+            ]))
+  | _ -> Error Invalid_entry_projection
+;;

--- a/lib/keeper/keeper_invocation_contract.mli
+++ b/lib/keeper/keeper_invocation_contract.mli
@@ -1,0 +1,65 @@
+(** Typed MASC boundary for invoking one Keeper from another tool lane.
+
+    This module owns no registry and starts no parallel scheduler. It projects
+    the existing durable {!Keeper_msg_async} owner into a typed target,
+    capability, run reference, and result contract. *)
+
+type capability = Invoke_turn
+
+type target = Keeper of Keeper_id.Keeper_name.t
+
+type request
+
+type run_ref =
+  { run_id : string
+  ; target : target
+  ; capability : capability
+  }
+
+type submission_receipt =
+  | Durable_run of run_ref
+  | Reconciliation_required of
+      { run_ref : run_ref
+      ; reason : string
+      }
+
+type result_contract =
+  | Awaiting_execution
+  | Publication_uncertain
+  | Running
+  | Yielded
+  | Cancellation_requested
+  | Cancelled
+  | Completed
+  | Failed
+
+type request_error =
+  | Invalid_target of string
+  | Empty_prompt
+  | Invalid_entry_projection
+
+val request : keeper_name:string -> prompt:string -> (request, request_error) result
+val request_error_to_string : request_error -> string
+val target_name : request -> string
+val prompt : request -> string
+
+val submit
+  :  background_sw:Eio.Switch.t
+  -> base_path:string
+  -> caller:string
+  -> request:request
+  -> f:(request -> Eio.Switch.t -> Keeper_types_profile.tool_result)
+  -> unit
+  -> (Keeper_msg_async.submit_outcome, Keeper_msg_async.submit_error) result
+
+val submission_receipt
+  :  request -> Keeper_msg_async.submit_outcome -> submission_receipt
+
+val result_contract : Keeper_msg_async.entry -> result_contract
+
+val submission_to_json
+  :  request -> Keeper_msg_async.submit_outcome -> Yojson.Safe.t
+
+val entry_to_json
+  :  Keeper_msg_async.entry
+  -> (Yojson.Safe.t, request_error) result

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -109,29 +109,24 @@ let submit_keeper_msg_with_captured_event_bus
       ~background_sw
       ~base_path
       ~caller
-      ~keeper_name
-      ~(f : ?event_bus:Agent_sdk.Event_bus.t -> Eio.Switch.t -> tool_result)
+      ~request
+      ~(f :
+          ?event_bus:Agent_sdk.Event_bus.t
+          -> Keeper_invocation_contract.request
+          -> Eio.Switch.t
+          -> tool_result)
       () =
   let event_bus = Keeper_event_bus.get () in
-  Keeper_msg_async.submit
+  Keeper_invocation_contract.submit
     ~background_sw
     ~base_path
     ~caller
-    ~keeper_name
-    ~f:(fun request_sw -> f ?event_bus request_sw)
+    ~request
+    ~f:(fun request request_sw -> f ?event_bus request request_sw)
     ()
 
-let submit_outcome_with_keeper_json ~keeper_name outcome =
-  match Keeper_msg_async.submit_outcome_to_json outcome with
-  | `Assoc fields ->
-    `Assoc
-      (("keeper_name", `String keeper_name)
-       :: ( "operator_instruction"
-          , `String
-              "Keeper request publication is uncertain. Poll this exact request_id; do not resubmit."
-          )
-       :: fields)
-  | json -> json
+let submit_outcome_with_keeper_json ~request outcome =
+  Keeper_invocation_contract.submission_to_json request outcome
 ;;
 
 module For_testing = struct
@@ -366,6 +361,19 @@ let with_keeper_name args name =
   | `Assoc fields ->
       `Assoc (("name", `String name) :: List.remove_assoc "name" fields)
   | other -> other
+
+let with_invocation_request args request =
+  match args with
+  | `Assoc fields ->
+    let fields =
+      fields |> List.remove_assoc "name" |> List.remove_assoc "message"
+    in
+    `Assoc
+      (("name", `String (Keeper_invocation_contract.target_name request))
+       :: ("message", `String (Keeper_invocation_contract.prompt request))
+       :: fields)
+  | other -> other
+;;
 (* RFC-0182 §3.1 — ctx-free body for keeper_dispatch_ref path. *)
 let prepare_passive_keeper_identity_config ~(config : Workspace.config) ~(agent_name : string) args =
   let requested_name =
@@ -634,7 +642,9 @@ let keeper_msg_body
   match
     let* name = message_error (resolve_keeper_name_config ~config args) in
     let resolved_args = with_keeper_name args name in
-    let* () = message_error (Turn.preflight_keeper_msg keeper_ctx resolved_args) in
+    let* request =
+      message_error (Turn.preflight_keeper_msg keeper_ctx resolved_args)
+    in
     let* background_sw =
       Keeper_msg_async.server_background_switch ()
       |> Result.map_error (fun error ->
@@ -645,22 +655,23 @@ let keeper_msg_body
         ~background_sw
         ~base_path:config.base_path
         ~caller:agent_name
-        ~keeper_name:name
-        ~f:(fun ?event_bus request_sw ->
+        ~request
+        ~f:(fun ?event_bus request request_sw ->
+          let worker_args = with_invocation_request resolved_args request in
           let worker_ctx = { keeper_ctx with sw = request_sw } in
           let result =
             Turn.handle_keeper_msg
               ?event_bus
               ?continuation_channel
               worker_ctx
-              resolved_args
+              worker_args
           in
           if tool_result_success result
           then begin
             append_direct_chat_pair_if_reply
               ~config
               ~name
-              ~args:resolved_args
+              ~args:worker_args
               result;
             invalidate_keeper_list_cache ();
             invalidate_status_cache name
@@ -670,23 +681,9 @@ let keeper_msg_body
       |> Result.map_error (fun error ->
         Payload_error (Keeper_msg_async.submit_error_to_json error))
     in
-    (match submission.acceptance with
-     | Keeper_msg_async.Reconciliation_required _ ->
-       Ok
-         (tool_result_ok_data
-            (submit_outcome_with_keeper_json ~keeper_name:name submission))
-     | Keeper_msg_async.Durably_accepted ->
-       let json =
-         `Assoc
-           [ "request_id", `String submission.request_id
-           ; "keeper_name", `String name
-           ; "status", `String "queued"
-           ; ( "message"
-             , `String
-                 "Keeper turn submitted. Poll with keeper_msg_result." )
-           ]
-       in
-       Ok (tool_result_ok_data json))
+    Ok
+      (tool_result_ok_data
+         (submit_outcome_with_keeper_json ~request submission))
   with
   | Ok result -> result
   | Error error -> tool_result_of_handler_error error
@@ -696,7 +693,7 @@ let handle_keeper_msg ?continuation_channel ~submitted_by ctx args : tool_result
   match
     let* name = message_error (resolve_keeper_name ctx args) in
     let resolved_args = with_keeper_name args name in
-    let* () = message_error (Turn.preflight_keeper_msg ctx resolved_args) in
+    let* request = message_error (Turn.preflight_keeper_msg ctx resolved_args) in
     let* background_sw =
       Keeper_msg_async.server_background_switch ()
       |> Result.map_error (fun error ->
@@ -707,22 +704,23 @@ let handle_keeper_msg ?continuation_channel ~submitted_by ctx args : tool_result
         ~background_sw
         ~base_path:ctx.config.base_path
         ~caller:submitted_by
-        ~keeper_name:name
-        ~f:(fun ?event_bus request_sw ->
+        ~request
+        ~f:(fun ?event_bus request request_sw ->
+          let worker_args = with_invocation_request resolved_args request in
           let worker_ctx = { ctx with sw = request_sw } in
           let result =
             Turn.handle_keeper_msg
               ?event_bus
               ?continuation_channel
               worker_ctx
-              resolved_args
+              worker_args
           in
           if tool_result_success result
           then begin
             append_direct_chat_pair_if_reply
               ~config:ctx.config
               ~name
-              ~args:resolved_args
+              ~args:worker_args
               result;
             invalidate_keeper_list_cache ();
             invalidate_status_cache name
@@ -732,23 +730,9 @@ let handle_keeper_msg ?continuation_channel ~submitted_by ctx args : tool_result
       |> Result.map_error (fun error ->
         Payload_error (Keeper_msg_async.submit_error_to_json error))
     in
-    (match submission.acceptance with
-     | Keeper_msg_async.Reconciliation_required _ ->
-       Ok
-         (tool_result_ok_data
-            (submit_outcome_with_keeper_json ~keeper_name:name submission))
-     | Keeper_msg_async.Durably_accepted ->
-       let json =
-         `Assoc
-           [ "request_id", `String submission.request_id
-           ; "keeper_name", `String name
-           ; "status", `String "queued"
-           ; ( "message"
-             , `String
-                 "Keeper turn submitted. Poll with keeper_msg_result." )
-           ]
-       in
-       Ok (tool_result_ok_data json))
+    Ok
+      (tool_result_ok_data
+         (submit_outcome_with_keeper_json ~request submission))
   with
   | Ok result -> result
   | Error error -> tool_result_of_handler_error error
@@ -781,7 +765,17 @@ let keeper_msg_result_body ~(config : Workspace.config) ~caller args : tool_resu
     | Keeper_msg_async.Rejected rejection ->
       tool_result_error_data (Keeper_msg_async.access_rejection_to_json rejection)
     | Keeper_msg_async.Found entry ->
-      tool_result_ok_data (Keeper_msg_async.entry_to_json entry)
+      (match Keeper_invocation_contract.entry_to_json entry with
+       | Ok json -> tool_result_ok_data json
+       | Error error ->
+         tool_result_error_data
+           (`Assoc
+              [ "error", `String "keeper_invocation_contract_invalid"
+              ; ( "message"
+                , `String
+                    (Keeper_invocation_contract.request_error_to_string error) )
+              ; "request_id", `String request_id
+              ]))
 
 let handle_keeper_msg_result ctx args : tool_result =
   keeper_msg_result_body ~config:ctx.config ~caller:ctx.agent_name args

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -232,13 +232,14 @@ let turn_resources_error failure =
        ])
 ;;
 
-let preflight_keeper_msg ctx args : (unit, string) result =
+let preflight_keeper_msg ctx args :
+    (Keeper_invocation_contract.request, string) result =
   let name = get_string args "name" "" in
   let message = get_string args "message" "" in
-  if not (validate_name name) then
-    Error (invalid_name_error name)
-  else if message = "" then Error "message is required"
-  else
+  match Keeper_invocation_contract.request ~keeper_name:name ~prompt:message with
+  | Error error ->
+    Error (Keeper_invocation_contract.request_error_to_string error)
+  | Ok request ->
     let direct_reply = get_bool args "direct_reply" false in
     match Keeper_meta_contract.reject_removed_model_args ~tool_name:"masc_keeper_msg" args with
     | Error e -> Error e
@@ -268,7 +269,8 @@ let preflight_keeper_msg ctx args : (unit, string) result =
         match Keeper_types_support.ensure_api_keys_for_labels effective_models with
         | Error e -> Error e
         | Ok () ->
-          Keeper_turn_helpers.ensure_local_discovery_ready effective_models)))
+          Keeper_turn_helpers.ensure_local_discovery_ready effective_models
+          |> Result.map (fun () -> request))))
 
 (* -- Direct-message turn FSM wrapper ---------------------------------------- *)
 

--- a/lib/keeper/keeper_turn.mli
+++ b/lib/keeper/keeper_turn.mli
@@ -21,7 +21,9 @@ val handle_keeper_up : _ Keeper_types_profile.context -> Yojson.Safe.t -> tool_r
 
     @since 2.110.0 *)
 val preflight_keeper_msg :
-  _ Keeper_types_profile.context -> Yojson.Safe.t -> (unit, string) result
+  _ Keeper_types_profile.context ->
+  Yojson.Safe.t ->
+  (Keeper_invocation_contract.request, string) result
 (** Run synchronous validation for [handle_keeper_msg] before an async wrapper
     accepts the turn for later execution. *)
 

--- a/test/test_keeper_unified_turn_event_bus.ml
+++ b/test/test_keeper_unified_turn_event_bus.ml
@@ -4,9 +4,13 @@
 
 open Alcotest
 
+let () = Mirage_crypto_rng_unix.use_default ()
+
 module EB = Masc.Keeper_unified_turn_event_bus
+module Invocation = Masc.Keeper_invocation_contract
 module Kmsg = Masc.Keeper_msg_async
 module Ops = Masc.Keeper_tool_surface_ops
+module Turn_outcome = Masc.Keeper_turn_outcome
 
 let dummy_event payload =
   { Agent_sdk.Event_bus.meta =
@@ -260,6 +264,12 @@ let test_keeper_msg_async_submit_uses_captured_event_bus () =
   let captured_bus = Agent_sdk.Event_bus.create () in
   let later_bus = Agent_sdk.Event_bus.create () in
   let observed_bus = ref None in
+  let request =
+    match Invocation.request ~keeper_name:"event-bus-test" ~prompt:"run" with
+    | Ok request -> request
+    | Error error ->
+      Alcotest.fail (Invocation.request_error_to_string error)
+  in
   Keeper_event_bus.set captured_bus;
   Fun.protect
     ~finally:(fun () ->
@@ -271,8 +281,8 @@ let test_keeper_msg_async_submit_uses_captured_event_bus () =
            ~background_sw:sw
            ~base_path
            ~caller:keeper_msg_caller
-           ~keeper_name:"event-bus-test"
-           ~f:(fun ?event_bus _request_sw ->
+           ~request
+           ~f:(fun ?event_bus _request _request_sw ->
              Keeper_event_bus.set later_bus;
              observed_bus := event_bus;
              Tool_result.ok ~tool_name:"keeper-event-bus-test" ~start_time:0.0 "{}")
@@ -321,6 +331,15 @@ let test_keeper_msg_submission_projection_has_unique_keys () =
     ; acceptance = Kmsg.Reconciliation_required { reason }
     }
   in
+  let request =
+    match
+      Invocation.request
+        ~keeper_name:"projection-keeper"
+        ~prompt:"inspect this request"
+    with
+    | Ok request -> request
+    | Error error -> Alcotest.fail (Invocation.request_error_to_string error)
+  in
   let core_fields =
     Kmsg.submit_outcome_to_json outcome
     |> require_unique_assoc "core reconciliation outcome"
@@ -334,12 +353,34 @@ let test_keeper_msg_submission_projection_has_unique_keys () =
        (function `String value -> Some value | _ -> None));
   let tool_fields =
     Ops.For_testing.submit_outcome_with_keeper_json
-      ~keeper_name:"projection-keeper"
+      ~request
       outcome
     |> require_unique_assoc "tool reconciliation outcome"
   in
   check bool "operator instruction is explicit" true
     (List.mem_assoc "operator_instruction" tool_fields);
+  check bool "typed run reference is present" true
+    (List.mem_assoc "run_ref" tool_fields);
+  check
+    (option string)
+    "uncertain publication is not reported as queued"
+    (Some "publication_uncertain")
+    (match List.assoc_opt "result_contract" tool_fields with
+     | Some (`String value) -> Some value
+     | _ -> None);
+  let durable_fields =
+    Ops.For_testing.submit_outcome_with_keeper_json
+      ~request
+      { outcome with acceptance = Kmsg.Durably_accepted }
+    |> require_unique_assoc "durable tool submission outcome"
+  in
+  check
+    (option string)
+    "durable submission is queued"
+    (Some "queued")
+    (match List.assoc_opt "status" durable_fields with
+     | Some (`String value) -> Some value
+     | _ -> None);
   let entry : Kmsg.entry =
     { request_id = "kmsg-entry-projection"
     ; keeper_name = "projection-keeper"
@@ -350,14 +391,52 @@ let test_keeper_msg_submission_projection_has_unique_keys () =
     ; completed_at = None
     }
   in
+  let entry_json =
+    match Invocation.entry_to_json entry with
+    | Ok json -> json
+    | Error error -> Alcotest.fail (Invocation.request_error_to_string error)
+  in
   let entry_fields =
-    Kmsg.entry_to_json entry |> require_unique_assoc "request entry projection"
+    entry_json |> require_unique_assoc "request entry projection"
   in
   check int "entry status is projected exactly once" 1
     (List.fold_left
        (fun count (key, _) -> if String.equal key "status" then count + 1 else count)
        0
-       entry_fields)
+       entry_fields);
+  check bool "running contract is typed" true
+    (Invocation.result_contract entry = Invocation.Running);
+  let yielded_entry =
+    { entry with
+      status =
+        Kmsg.Done
+          { ok = true
+          ; body = "checkpoint"
+          ; data =
+              Some
+                (`Assoc
+                   [ ( Turn_outcome.wire_key
+                     , `String
+                         (Turn_outcome.to_label
+                            Turn_outcome.Continuation_checkpoint) )
+                   ])
+          }
+    }
+  in
+  check bool "yield is distinct from completion" true
+    (Invocation.result_contract yielded_entry = Invocation.Yielded);
+  let cancelled_entry =
+    { entry with
+      status = Kmsg.Cancelled { reason = "operator"; cancelled_by = "operator" }
+    }
+  in
+  check bool "cancel is distinct from failure" true
+    (Invocation.result_contract cancelled_entry = Invocation.Cancelled);
+  let failed_entry =
+    { entry with status = Kmsg.Done { ok = false; body = "failed"; data = None } }
+  in
+  check bool "failure is distinct from completion" true
+    (Invocation.result_contract failed_entry = Invocation.Failed)
 ;;
 
 let test_take_drain_cancel_clears_active_without_spin () =


### PR DESCRIPTION
## Scope

First Goal 5 vertical slice for Keeper-as-a-Tool. This does not claim the full heterogeneous composition surface.

- Adds typed Keeper target, invoke-turn capability, immutable request, durable run reference, submission receipt, and result contract.
- Reuses Keeper_msg_async as the single durable owner and the existing per-Keeper serialized turn lane; it adds no registry or scheduler.
- Makes publication uncertainty explicit instead of reporting it as queued.
- Projects running, yielded, cancellation, completed, and failed states without string inspection.
- Executes the same validated request that produced the returned run reference.
- Removes two stale boundary-matrix rows left behind by the merged inflight scaffold purge.

## Verification

- scripts/dune-local.sh build lib/masc.cmxa test/test_keeper_unified_turn_event_bus.exe
- ./_build/default/test/test_keeper_unified_turn_event_bus.exe: 12/12 passed
- scripts/ocaml-structure-ratchet.sh
- scripts/stringly-boundary-ratchet.sh
- scripts/oas-boundary-ratchet.sh
- scripts/audit-keeper-tool-boundary-matrix.sh
- git diff --check
- Diff: +396/-75 across 7 files

## Explicit next slices

- Hard-cut the legacy keeper_msg/result surface to typed delegate/status inputs.
- Add Agent, Model, Tool[], and Heterogeneous[] targets plus durable Fusion join.
- Unify exact Keeper stimulus identity with durable result join without adding duplicate wakes.
- Replace the remaining direct HTTP status projection.

Base verified against main e8870bed2f.