### PR TITLE
fix(keeper): serialize approval persistence install

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -1084,27 +1084,6 @@ let consume_approved_resolution
     Ok Consumption_committed
 ;;
 
-module For_testing = struct
-  let reset_audit_store () =
-    Stdlib.Mutex.protect audit_stores_mu (fun () -> Hashtbl.clear audit_stores);
-    Stdlib.Mutex.protect recent_audit_cache_mu (fun () ->
-      Hashtbl.clear recent_audit_cache)
-  ;;
-
-  let get_pending_entry ~id = SMap.find_opt id (Atomic.get pending)
-  let with_pending_store_lock = with_pending_store_lock
-
-  let reset_runtime_state () =
-    with_pending_store_lock (fun () ->
-      Atomic.set pending SMap.empty;
-      Atomic.set deliveries SMap.empty;
-      Atomic.set unavailable_stores SMap.empty)
-  ;;
-
-  let pending_store_path = pending_store_path
-  let always_allowed_store_path ~base_path = rules_path ~base_path ()
-end
-
 let input_preview_of_json (json : Yojson.Safe.t) =
   (* Per-leaf marker-aware truncation: a naive [String.sub] on the
      serialized form would chop a [masc:blob ...] marker mid-field and
@@ -1886,15 +1865,16 @@ let complete_delivery delivery =
            | Ok () -> finish ())))
 ;;
 
-let install_persistence ~base_path =
-  (* Snapshot I/O and JSON parsing may yield. Keep them outside the
-     process-global commit mutex so a slow filesystem cannot block the Eio
-     domain through a contending [Stdlib.Mutex] waiter. The immutable loaded
-     maps are merged with the latest in-memory state inside the short commit
-     section below. *)
-  let loaded_snapshot = load_snapshot_unlocked ~base_path in
+let install_persistence_internal ~after_load ~base_path =
+  (* Snapshot read and installation are one transition. The hybrid pending
+     store lock serializes Eio and non-Eio callers, cooperatively gates Eio
+     waiters, and protects cancellation across the durable transition. Keeping
+     the load inside this boundary prevents a same-workspace mutation from
+     being published between the read and the replacement below. *)
   let installed =
     with_pending_store_lock (fun () ->
+      let loaded_snapshot = load_snapshot_unlocked ~base_path in
+      after_load ();
       match loaded_snapshot with
       | Error storage_error ->
         mark_store_unavailable_unlocked ~base_path storage_error;
@@ -1978,6 +1958,35 @@ let install_persistence ~base_path =
     in
     replay 0 [] loaded_deliveries
 ;;
+
+let install_persistence ~base_path =
+  install_persistence_internal ~after_load:(fun () -> ()) ~base_path
+;;
+
+module For_testing = struct
+  let reset_audit_store () =
+    Stdlib.Mutex.protect audit_stores_mu (fun () -> Hashtbl.clear audit_stores);
+    Stdlib.Mutex.protect recent_audit_cache_mu (fun () ->
+      Hashtbl.clear recent_audit_cache)
+  ;;
+
+  let get_pending_entry ~id = SMap.find_opt id (Atomic.get pending)
+  let with_pending_store_lock = with_pending_store_lock
+
+  let reset_runtime_state () =
+    with_pending_store_lock (fun () ->
+      Atomic.set pending SMap.empty;
+      Atomic.set deliveries SMap.empty;
+      Atomic.set unavailable_stores SMap.empty)
+  ;;
+
+  let install_persistence_with_after_load_hook ~base_path ~after_load =
+    install_persistence_internal ~after_load ~base_path
+  ;;
+
+  let pending_store_path = pending_store_path
+  let always_allowed_store_path ~base_path = rules_path ~base_path ()
+end
 
 let resolve_with_policy
       ~id

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -57,6 +57,9 @@ val install_error_to_string : install_error -> string
 (** Install one workspace's persisted Gate queue. The file is parsed as one
     closed snapshot: a malformed entry fails the install and is observed via
     the persistence read-drop metric; no valid-looking subset is installed.
+    Snapshot read and in-memory installation are one serialized transition, so
+    a concurrent mutation for the same workspace cannot be overwritten by the
+    loaded snapshot.
     In-flight summaries retain their durable state. Independent delivery replay
     failures are returned in [delivery_replay_failures] and never prevent later
     journals or Gate recovery from being attempted. *)
@@ -156,6 +159,10 @@ module For_testing : sig
   val reset_audit_store : unit -> unit
   val reset_runtime_state : unit -> unit
   val with_pending_store_lock : (unit -> 'a) -> 'a
+  val install_persistence_with_after_load_hook :
+    base_path:string ->
+    after_load:(unit -> unit) ->
+    (install_report, install_error) result
   val pending_store_path : base_path:string -> string
   val always_allowed_store_path : base_path:string -> string
 end

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -245,6 +245,81 @@ let install_exn ~base_path =
   | Error error -> Alcotest.fail (AQ.install_error_to_string error)
 ;;
 
+let test_install_serializes_snapshot_read_with_same_base_mutation () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      AQ.For_testing.reset_runtime_state ();
+      cleanup_dir base_path)
+    (fun () ->
+       AQ.For_testing.reset_runtime_state ();
+       write_pending_snapshot
+         ~base_path
+         (`Assoc
+            [ "version", `Int 2
+            ; "pending", `List []
+            ; "deliveries", `List []
+            ]);
+       Eio_main.run @@ fun _environment ->
+       let snapshot_loaded, signal_snapshot_loaded = Eio.Promise.create () in
+       let mutation_attempted, signal_mutation_attempted = Eio.Promise.create () in
+       let release_install, signal_release_install = Eio.Promise.create () in
+       let install_done, signal_install_done = Eio.Promise.create () in
+       let mutation_done, signal_mutation_done = Eio.Promise.create () in
+       let mutation_completed_before_release = ref false in
+       Eio.Fiber.all
+         [ (fun () ->
+             let result =
+               AQ.For_testing.install_persistence_with_after_load_hook
+                 ~base_path
+                 ~after_load:(fun () ->
+                   Eio.Promise.resolve signal_snapshot_loaded ();
+                   Eio.Promise.await release_install)
+             in
+             Eio.Promise.resolve signal_install_done result)
+         ; (fun () ->
+             Eio.Promise.await snapshot_loaded;
+             Eio.Promise.resolve signal_mutation_attempted ();
+             let id =
+               submit
+                 ~base_path
+                 ~keeper_name:"queue-install-race"
+                 ~input:(`Assoc [ "target", `String "after-load" ])
+             in
+             Eio.Promise.resolve signal_mutation_done id)
+         ; (fun () ->
+             Eio.Promise.await mutation_attempted;
+             mutation_completed_before_release :=
+               Option.is_some (Eio.Promise.peek mutation_done);
+             Eio.Promise.resolve signal_release_install ())
+         ];
+       Alcotest.(check bool)
+         "same-base mutation waits for snapshot installation"
+         false
+         !mutation_completed_before_release;
+       let report = Eio.Promise.await install_done in
+       let mutation_id = Eio.Promise.await mutation_done in
+       (match report with
+        | Error error -> Alcotest.fail (AQ.install_error_to_string error)
+        | Ok report -> Alcotest.(check int) "empty snapshot installed" 0 report.loaded_pending);
+       Alcotest.(check int) "mutation remains in memory" 1 (AQ.pending_count ());
+       Alcotest.(check bool)
+         "mutation id remains addressable"
+         true
+         (Option.is_some (AQ.get_pending_entry ~id:mutation_id));
+       let open Yojson.Safe.Util in
+       let persisted_ids =
+         read_pending_snapshot ~base_path
+         |> member "pending"
+         |> to_list
+         |> List.map (fun entry -> entry |> member "id" |> to_string)
+       in
+       Alcotest.(check bool)
+         "mutation remains in the durable snapshot"
+         true
+         (List.mem mutation_id persisted_ids))
+;;
+
 let test_submit_is_nonblocking_and_exactly_deduplicated () =
   let base_path = temp_dir () in
   let keeper_name = "queue-exact-submit" in
@@ -1204,6 +1279,10 @@ let () =
             "durable lock serializes Eio fibers"
             `Quick
             test_pending_store_lock_serializes_eio_fibers
+        ; Alcotest.test_case
+            "install serializes snapshot read with mutation"
+            `Quick
+            test_install_serializes_snapshot_read_with_same_base_mutation
         ; Alcotest.test_case
             "submit is nonblocking and exact"
             `Quick


### PR DESCRIPTION
## Summary
- serialize approval snapshot read and in-memory installation as one cross-context durable transition
- prevent a same-base submit/resolve mutation from being overwritten by a stale loaded snapshot
- add a deterministic Eio barrier regression test that proves a real submit waits until installation commits
- preserve explicit malformed-snapshot errors and delivery replay behavior

Fixes #24544

## Evidence
- ocamlformat --check passed for all touched files
- git diff --check passed
- OCaml 5.5 Mutex contract confirms protected critical sections release on return or exception and try_lock is nonblocking

## Local validation note
Focused target command: scripts/dune-local.sh build test/test_keeper_approval_queue.exe
The wrapper correctly refused to start because an unrelated bare dune build process was already active (PID 9449). It was not killed or bypassed. Full build/test remains CI-owned per repository policy.