### PR TITLE
fix(runtime): distinguish actual Eio execution context

### DIFF
--- a/lib/core/eio_guard.ml
+++ b/lib/core/eio_guard.ml
@@ -1,4 +1,4 @@
-(** Eio_guard — Dual-mode guard for pre/post Eio runtime.
+(** Eio_guard — Dual-mode guard for Eio and non-Eio callers.
 
     Before [Eio_main.run] starts, OCaml runs single-threaded and Eio
     primitives are unavailable.  Modules that need [Eio.Mutex] or
@@ -9,13 +9,26 @@
     Call {!enable} once inside [Eio_main.run].  Uses [Atomic.t] so the
     flag is safe to read from any domain.
 
-    All guards check the [ready] flag before attempting mutex operations,
-    avoiding [Effect.Unhandled] exceptions on the normal code path. *)
+    The process-wide [ready] flag gates shared Eio mutexes. Operations that may
+    also be reached from raw Domains inspect the current execution context. *)
 
 let ready = Atomic.make false
 let enable () = Atomic.set ready true
 let disable () = Atomic.set ready false
 let is_ready () = Atomic.get ready
+
+type execution_context = Eio_fiber | Non_eio
+
+let execution_context () =
+  match Eio.Fiber.is_cancelled () with
+  | true | false -> Eio_fiber
+  | exception Effect.Unhandled _ -> Non_eio
+;;
+
+let is_eio_fiber () = execution_context () = Eio_fiber
+
+type mutex_access = Read_write | Read_only
+exception Non_eio_mutex_context of mutex_access
 
 (** {1 Mutex Guards}
 
@@ -26,18 +39,24 @@ let is_ready () = Atomic.get ready
 
 (** Read-write guard: acquires mutex if Eio is ready, runs directly otherwise. *)
 let with_mutex mutex f =
-  if Atomic.get ready then Eio.Mutex.use_rw ~protect:true mutex (fun () -> f ()) else f ()
+  match Atomic.get ready, execution_context () with
+  | false, _ -> f ()
+  | true, Eio_fiber -> Eio.Mutex.use_rw ~protect:true mutex (fun () -> f ())
+  | true, Non_eio -> raise (Non_eio_mutex_context Read_write)
 ;;
 
 (** Read-only guard: acquires read lock if Eio is ready, runs directly otherwise. *)
 let with_mutex_ro mutex f =
-  if Atomic.get ready then Eio.Mutex.use_ro mutex (fun () -> f ()) else f ()
+  match Atomic.get ready, execution_context () with
+  | false, _ -> f ()
+  | true, Eio_fiber -> Eio.Mutex.use_ro mutex (fun () -> f ())
+  | true, Non_eio -> raise (Non_eio_mutex_context Read_only)
 ;;
 
 (** {1 Systhread Guard} *)
 
-(** Run [f] in a system thread when Eio is active, or directly when
-    no Eio runtime is available (e.g. unit tests).
+(** Run [f] in a system thread from an Eio fiber, or directly from a raw Domain
+    or other non-Eio execution context.
 
     A pool system thread has no Eio effect handler.  [f] must therefore
     perform only blocking C/Unix work, never an Eio operation: anything
@@ -53,8 +72,8 @@ let with_mutex_ro mutex f =
     [use_rw] frame before control returns here — so it diagnoses the bug
     faster, it does not prevent it. *)
 let run_in_systhread f =
-  if Atomic.get ready
-  then
+  match execution_context () with
+  | Eio_fiber ->
     Eio_unix.run_in_systhread (fun () ->
       try f () with
       | Effect.Unhandled _ as exn ->
@@ -66,7 +85,7 @@ let run_in_systhread f =
               resulting Effect.Unhandled). Offload Eio-touching work via Executor_pool \
               (e.g. Executor_pool_ref.submit_or_inline), not run_in_systhread."
              (Printexc.to_string exn)))
-  else f ()
+  | Non_eio -> f ()
 ;;
 
 (** {1 Resource Cleanup}
@@ -84,24 +103,25 @@ let run_in_systhread f =
       body exception (no [Fun.Finally_raised] wrapping).
     - [Eio.Cancel.Cancelled] always propagates.
 
-    Before [enable ()], falls back to [Fun.protect] (single-threaded,
-    no Eio context available). *)
+    Outside an Eio fiber, falls back to [Fun.protect]. *)
 let protect ~finally body =
-  if Atomic.get ready
-  then
+  match execution_context () with
+  | Eio_fiber ->
     Eio.Switch.run (fun sw ->
       Eio.Switch.on_release sw finally;
       body ())
-  else Fun.protect ~finally body
+  | Non_eio -> Fun.protect ~finally body
 ;;
 
 (** Cooperatively yield without raising if the Eio scheduler is unavailable. *)
 let yield_if_ready () =
-  if Atomic.get ready then Safe_ops.protect ~default:() (fun () -> Eio.Fiber.yield ())
+  match execution_context () with
+  | Eio_fiber -> Eio.Fiber.yield ()
+  | Non_eio -> ()
 ;;
 
 let check_if_ready () =
-  if Atomic.get ready then Safe_ops.protect ~default:() (fun () -> Eio.Fiber.check ())
+  match execution_context () with Eio_fiber -> Eio.Fiber.check () | Non_eio -> ()
 ;;
 
 let fair_yield = yield_if_ready

--- a/lib/core/eio_guard.mli
+++ b/lib/core/eio_guard.mli
@@ -1,8 +1,8 @@
-(** Eio_guard — Dual-mode mutex guard for pre/post Eio runtime.
+(** Eio_guard — Dual-mode guard for Eio and non-Eio callers.
 
-    Before {!enable} is called, all guard functions execute [f] directly
-    (single-threaded, no locking needed). After {!enable}, they acquire
-    the given [Eio.Mutex.t] before running [f].
+    {!enable} records that shared Eio mutexes are live. Runtime operations
+    additionally inspect the current caller because a process-wide ready flag
+    does not give raw Domains or systhreads an Eio effect handler.
 
     Call {!enable} once inside [Eio_main.run]. *)
 
@@ -17,13 +17,26 @@ val disable : unit -> unit
 (** [true] after {!enable} has been called. *)
 val is_ready : unit -> bool
 
-(** Acquire read-write lock if Eio is ready, run [f] directly otherwise. *)
+(** Actual execution context of the current caller. [ready] is process-wide;
+    it does not imply that a raw Domain or systhread has an Eio handler. *)
+type execution_context = Eio_fiber | Non_eio
+
+val execution_context : unit -> execution_context
+val is_eio_fiber : unit -> bool
+
+type mutex_access = Read_write | Read_only
+exception Non_eio_mutex_context of mutex_access
+
+(** Acquire the read-write lock when enabled from an Eio fiber. Runs directly
+    before {!enable}; raises {!Non_eio_mutex_context} for a ready non-Eio
+    caller. *)
 val with_mutex : Eio.Mutex.t -> (unit -> 'a) -> 'a
 
-(** Acquire read-only lock if Eio is ready, run [f] directly otherwise. *)
+(** Read-only counterpart of {!with_mutex}. *)
 val with_mutex_ro : Eio.Mutex.t -> (unit -> 'a) -> 'a
 
-(** Run [f] in a system thread if Eio is ready, directly otherwise. *)
+(** Run [f] in a system thread from an Eio fiber, directly from a non-Eio
+    execution context. *)
 val run_in_systhread : (unit -> 'a) -> 'a
 
 (** Eio-aware replacement for [Fun.protect].
@@ -32,16 +45,14 @@ val run_in_systhread : (unit -> 'a) -> 'a
     so cleanup always runs and cleanup exceptions do not replace the body
     exception.  [Eio.Cancel.Cancelled] always propagates correctly.
 
-    Before {!enable}, falls back to [Fun.protect]. *)
+    Outside an Eio fiber, falls back to [Fun.protect]. *)
 val protect : finally:(unit -> unit) -> (unit -> 'a) -> 'a
 
-(** Cooperatively yield to the Eio scheduler if the runtime is active.
-    No-op before {!enable} or when called from a context where Eio cannot
-    currently yield. *)
+(** Cooperatively yield from an Eio fiber; no-op in a non-Eio context. *)
 val yield_if_ready : unit -> unit
 
-(** Check for cooperative cancellation if the Eio runtime is active.
-    No-op before {!enable} or when called from non-Eio initialization paths. *)
+(** Check cooperative cancellation from an Eio fiber; no-op in a non-Eio
+    context. *)
 val check_if_ready : unit -> unit
 
 (** Named cooperative yield for scheduler-fair keeper/runtime boundaries.

--- a/lib/core/executor_pool_ref.ml
+++ b/lib/core/executor_pool_ref.ml
@@ -22,8 +22,8 @@ let set p = Atomic.set pool (Some p)
     Inline fallback ensures callers work in tests and before server init.
     Re-raises [Eio.Cancel.Cancelled] to preserve structured concurrency. *)
 let submit_or_inline ?(weight = 1.0) f =
-  match Atomic.get pool with
-  | Some p ->
+  match Atomic.get pool, Eio_guard.execution_context () with
+  | Some p, Eio_guard.Eio_fiber ->
       (try Eio.Executor_pool.submit_exn p ~weight (fun () ->
          Eio.Switch.run (fun _sw -> f ()))
        with
@@ -32,4 +32,5 @@ let submit_or_inline ?(weight = 1.0) f =
            Log.Misc.warn "executor_pool submit failed, running inline: %s"
              (Printexc.to_string exn);
            f ())
-  | None -> f ()
+  | (Some _ | None), Eio_guard.Non_eio
+  | None, Eio_guard.Eio_fiber -> f ()

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -87,16 +87,6 @@ let pending_store_cross_context_mu = Stdlib.Mutex.create ()
 let deliveries : persisted_delivery SMap.t Atomic.t = Atomic.make SMap.empty
 let unavailable_stores : storage_error SMap.t Atomic.t = Atomic.make SMap.empty
 
-type execution_context =
-  | Eio_fiber
-  | Non_eio
-
-let execution_context () =
-  match Eio.Fiber.check () with
-  | () -> Eio_fiber
-  | exception Effect.Unhandled _ -> Non_eio
-;;
-
 let rec lock_pending_store_cooperatively () =
   if Stdlib.Mutex.try_lock pending_store_cross_context_mu
   then ()
@@ -118,9 +108,9 @@ let rec lock_pending_store_cooperatively () =
     snapshot is returned as committed rather than reported as an ambiguous
     cancelled operation. *)
 let with_pending_store_lock f =
-  match execution_context () with
-  | Non_eio -> Stdlib.Mutex.protect pending_store_cross_context_mu f
-  | Eio_fiber ->
+  match Eio_guard.execution_context () with
+  | Eio_guard.Non_eio -> Stdlib.Mutex.protect pending_store_cross_context_mu f
+  | Eio_guard.Eio_fiber ->
     Eio.Mutex.use_ro pending_store_eio_gate (fun () ->
       lock_pending_store_cooperatively ();
       Eio.Cancel.protect (fun () ->

--- a/lib/keeper/keeper_fs_durable_directory.ml
+++ b/lib/keeper/keeper_fs_durable_directory.ml
@@ -574,7 +574,7 @@ let rec ensure_with
          in
          let completion = completion_of_outcome outcome in
          let cleanup =
-           if Eio_guard.is_ready ()
+           if Eio_guard.is_eio_fiber ()
            then Eio.Cancel.protect (fun () -> release ~completion owned)
            else release ~completion owned
          in

--- a/lib/keeper_runtime/keeper_event_queue_owner_lock.ml
+++ b/lib/keeper_runtime/keeper_event_queue_owner_lock.ml
@@ -69,16 +69,6 @@ let resolve ~base_path ~keeper_name =
 let base_path owner = fst owner.owner_key
 let keeper_name owner = snd owner.owner_key
 
-type execution_context =
-  | Eio_fiber
-  | Non_eio
-
-let execution_context () =
-  match Eio.Fiber.check () with
-  | () -> Eio_fiber
-  | exception Effect.Unhandled _ -> Non_eio
-;;
-
 let rec lock_cross_context_cooperatively mutex =
   if Stdlib.Mutex.try_lock mutex
   then ()
@@ -119,13 +109,13 @@ let with_eio_lock ~check_after owner f =
 ;;
 
 let with_lock owner f =
-  match execution_context () with
-  | Eio_fiber -> with_eio_lock ~check_after:true owner f
-  | Non_eio -> Stdlib.Mutex.protect owner.cross_context_mutex f
+  match Eio_guard.execution_context () with
+  | Eio_guard.Eio_fiber -> with_eio_lock ~check_after:true owner f
+  | Eio_guard.Non_eio -> Stdlib.Mutex.protect owner.cross_context_mutex f
 ;;
 
 let with_durable_lock owner f =
-  match execution_context () with
-  | Eio_fiber -> with_eio_lock ~check_after:false owner f
-  | Non_eio -> Stdlib.Mutex.protect owner.cross_context_mutex f
+  match Eio_guard.execution_context () with
+  | Eio_guard.Eio_fiber -> with_eio_lock ~check_after:false owner f
+  | Eio_guard.Non_eio -> Stdlib.Mutex.protect owner.cross_context_mutex f
 ;;

--- a/lib/process/file_lock_eio.ml
+++ b/lib/process/file_lock_eio.ml
@@ -15,6 +15,44 @@ module SMap = Set_util.StringMap
 
 exception Flock_timeout of { caller : string; path : string; attempts : int }
 
+type durable_lock_phase =
+  | Open_lock_file
+  | Acquire_process_lock
+  | Release_process_lock
+
+type unix_failure =
+  { error : Unix.error
+  ; operation : string
+  ; argument : string
+  }
+
+type durable_lock_error =
+  { lock_path : string
+  ; phase : durable_lock_phase
+  ; cause : unix_failure
+  ; cleanup_failure : unix_failure option
+  }
+
+let durable_lock_phase_to_string = function
+  | Open_lock_file -> "open_lock_file"
+  | Acquire_process_lock -> "acquire_process_lock"
+  | Release_process_lock -> "release_process_lock"
+
+let durable_lock_error_to_string error =
+  let failure_to_string failure =
+    Printf.sprintf "%s(%s): %s"
+      failure.operation
+      failure.argument
+      (Unix.error_message failure.error)
+  in
+  Printf.sprintf "lock_path=%s phase=%s cause=%s%s"
+    error.lock_path
+    (durable_lock_phase_to_string error.phase)
+    (failure_to_string error.cause)
+    (match error.cleanup_failure with
+     | None -> ""
+     | Some failure -> " cleanup=" ^ failure_to_string failure)
+
 (** Observability hook fired after each [acquire_flock_retry*] attempt
     sequence completes — once on success, once on timeout.  Wired at
     startup ([lib/workspace.ml]) to a Otel_metric_store counter + histogram so
@@ -65,16 +103,18 @@ let rec atomic_update atomic f =
 
 let rec atomic_update_with_result atomic f =
   let old_val = Atomic.get atomic in
-  let new_val, result = f old_val in
+  let new_val, result, rollback = f old_val in
   if Atomic.compare_and_set atomic old_val new_val then result
   else begin
+    rollback ();
     observe_cas_retry ();
     atomic_update_with_result atomic f
   end
 
 type lock_entry = {
   mu : Eio.Mutex.t;
-  mutable last_used : float;
+  cross_context_mu : Stdlib.Mutex.t;
+  last_used : float Atomic.t;
   active : int Atomic.t;   (** Number of fibers currently holding or waiting on this mutex *)
 }
 
@@ -101,7 +141,8 @@ let prune_stale_entries () =
     if SMap.cardinal state.entries > max_lock_entries then
       let now = Time_compat.now () in
       let entries = SMap.filter (fun _path entry ->
-        Atomic.get entry.active > 0 || now -. entry.last_used <= stale_lock_seconds
+        Atomic.get entry.active > 0
+        || now -. Atomic.get entry.last_used <= stale_lock_seconds
       ) state.entries in
       publish_entries state entries
     else state
@@ -109,23 +150,30 @@ let prune_stale_entries () =
 
 (** Get or create a lock entry for the given file path.
     Increments [active] to prevent prune_stale_entries from removing
-    in-use entries (see TLA+ FileLockStarvation spec).
-    Falls back to direct Hashtbl access when no Eio context is available
-    (e.g. in unit tests that don't use Eio_main.run). *)
+    in-use entries (see TLA+ FileLockStarvation spec). *)
 let get_entry path =
   prune_stale_entries ();
   let entry =
     atomic_update_with_result table (fun state ->
       match SMap.find_opt path state.entries with
       | Some entry ->
-        entry.last_used <- Time_compat.now ();
-        (state, entry)
+        (* Publish a new version so a stale prune CAS cannot erase this reservation. *)
+        Atomic.set entry.last_used (Time_compat.now ());
+        Atomic.incr entry.active;
+        ( { state with version = state.version + 1 }
+        , entry
+        , fun () -> ignore (Atomic.fetch_and_add entry.active (-1)) )
       | None ->
-        let entry = { mu = Eio.Mutex.create (); last_used = Time_compat.now (); active = Atomic.make 0 } in
+        let entry =
+          { mu = Eio.Mutex.create ()
+          ; cross_context_mu = Stdlib.Mutex.create ()
+          ; last_used = Atomic.make (Time_compat.now ())
+          ; active = Atomic.make 1
+          }
+        in
         let entries = SMap.add path entry state.entries in
-        (publish_entries state entries, entry))
+        (publish_entries state entries, entry, Fun.id))
   in
-  Atomic.incr entry.active;
   entry
 
 let release_entry entry =
@@ -225,14 +273,31 @@ let release_flock_fd fd =
       (try Unix.lockf fd Unix.F_ULOCK 0 with Unix.Unix_error _ -> ());
       Unix.close fd)
 
-(** Run [f] while holding only the cooperative per-path mutex.
+let rec lock_cross_context_cooperatively mutex =
+  if Stdlib.Mutex.try_lock mutex
+  then ()
+  else (
+    Eio.Fiber.yield ();
+    lock_cross_context_cooperatively mutex)
+
+let with_entry_lock entry f =
+  match Eio_guard.execution_context () with
+  | Eio_guard.Non_eio -> Stdlib.Mutex.protect entry.cross_context_mu f
+  | Eio_guard.Eio_fiber ->
+    Eio.Mutex.use_ro entry.mu (fun () ->
+      lock_cross_context_cooperatively entry.cross_context_mu;
+      Fun.protect
+        ~finally:(fun () -> Stdlib.Mutex.unlock entry.cross_context_mu)
+        f)
+
+(** Run [f] while holding only the cross-context per-path mutex.
     Use this for in-memory backends that need single-process fiber
     serialization but do not have a real filesystem artifact to flock. *)
 let with_mutex path f =
   let entry = get_entry path in
   Common.protect ~module_name:"file_lock_eio" ~finally_label:"release_entry"
     ~finally:(fun () -> release_entry entry)
-    (fun () -> Eio_guard.with_mutex entry.mu f)
+    (fun () -> with_entry_lock entry f)
 
 (** Run [f] while holding both the cooperative Eio.Mutex and an
     OS-level flock on [path].lock. The flock uses non-blocking F_TLOCK
@@ -250,6 +315,204 @@ let with_lock ?clock path f =
       f
   in
   with_mutex path (fun () -> run_with_flock ())
+
+let unix_failure (error, operation, argument) =
+  { error; operation; argument }
+
+let close_fd_result fd =
+  try
+    run_blocking_lock_op (fun () -> Unix.close fd);
+    Ok ()
+  with
+  | Unix.Unix_error (error, operation, argument) ->
+    Error (unix_failure (error, operation, argument))
+
+let release_durable_fd_result fd =
+  let unlock =
+    try
+      run_blocking_lock_op (fun () -> Unix.lockf fd Unix.F_ULOCK 0);
+      Ok ()
+    with
+    | Unix.Unix_error (error, operation, argument) ->
+      Error (unix_failure (error, operation, argument))
+  in
+  let close = close_fd_result fd in
+  match unlock, close with
+  | Ok (), Ok () -> Ok ()
+  | Error cause, Ok ()
+  | Ok (), Error cause -> Error (cause, None)
+  | Error cause, Error cleanup_failure -> Error (cause, Some cleanup_failure)
+
+let protect_cleanup execution_context f =
+  match execution_context with
+  | Eio_guard.Eio_fiber -> Eio.Cancel.protect f
+  | Eio_guard.Non_eio -> f ()
+
+let close_fd_after_exception ~lock_path execution_context fd =
+  match protect_cleanup execution_context (fun () -> close_fd_result fd) with
+  | Ok () -> ()
+  | Error failure ->
+    Log.Misc.error
+      "file_lock_eio: fd cleanup failed lock_path=%s operation=%s argument=%s error=%s"
+      lock_path failure.operation failure.argument
+      (Unix.error_message failure.error)
+
+let release_fd_after_exception ~lock_path execution_context fd =
+  match
+    protect_cleanup execution_context (fun () -> release_durable_fd_result fd)
+  with
+  | Ok () -> ()
+  | Error (failure, cleanup_failure) ->
+    Log.Misc.error
+      "file_lock_eio: lock cleanup failed lock_path=%s operation=%s argument=%s error=%s%s"
+      lock_path failure.operation failure.argument
+      (Unix.error_message failure.error)
+      (match cleanup_failure with
+       | None -> ""
+       | Some cleanup ->
+         Printf.sprintf " cleanup_operation=%s cleanup_argument=%s cleanup_error=%s"
+           cleanup.operation cleanup.argument
+           (Unix.error_message cleanup.error))
+
+let durable_lock_error ?cleanup_failure ~lock_path ~phase cause =
+  { lock_path; phase; cause; cleanup_failure }
+
+let open_durable_lock_file ~execution_context lock_path =
+  let opened_fd = Atomic.make None in
+  let result =
+    try
+      Ok
+        (run_blocking_lock_op (fun () ->
+           let fd =
+             Unix.openfile lock_path
+               [ Unix.O_CLOEXEC; Unix.O_CREAT; Unix.O_WRONLY ] 0o644
+           in
+           Atomic.set opened_fd (Some fd);
+           fd))
+    with
+    | Unix.Unix_error (error, operation, argument) ->
+      Error (unix_failure (error, operation, argument))
+    | exn ->
+      let backtrace = Printexc.get_raw_backtrace () in
+      Option.iter
+        (close_fd_after_exception ~lock_path execution_context)
+        (Atomic.exchange opened_fd None);
+      Printexc.raise_with_backtrace exn backtrace
+  in
+  Atomic.set opened_fd None;
+  result
+
+let acquire_durable_flock ~execution_context lock_path =
+  match open_durable_lock_file ~execution_context lock_path with
+  | Error cause ->
+    Error (durable_lock_error ~lock_path ~phase:Open_lock_file cause)
+  | Ok fd ->
+    let started_at = Time_compat.now () in
+    let process_lock_held = Atomic.make false in
+    let rec acquire_eio retries =
+      match
+        try
+          run_blocking_lock_op (fun () -> Unix.lockf fd Unix.F_TLOCK 0);
+          Atomic.set process_lock_held true;
+          Ok true
+        with
+        | Unix.Unix_error ((Unix.EAGAIN | Unix.EACCES), _, _) -> Ok false
+        | Unix.Unix_error (error, operation, argument) ->
+          Error (unix_failure (error, operation, argument))
+      with
+      | Ok true ->
+        Eio.Fiber.check ();
+        observe_lock_attempt ~caller:"File_lock_eio.durable" ~retries
+          ~started_at ~outcome:"acquired";
+        Ok ()
+      | Ok false ->
+        (* POSIX record locks expose no readiness source to Eio. An unbounded
+           F_TLOCK/yield loop is the portable cancellable admission: no
+           timeout, attempt cap, sleep, or backoff policy is invented. *)
+        Eio.Fiber.yield ();
+        acquire_eio (retries + 1)
+      | Error _ as error -> error
+    in
+    let acquire () =
+      match execution_context with
+      | Eio_guard.Eio_fiber ->
+        Eio.Fiber.check ();
+        acquire_eio 0
+      | Eio_guard.Non_eio ->
+        (try
+           Unix.lockf fd Unix.F_LOCK 0;
+           Atomic.set process_lock_held true;
+           Ok ()
+         with
+         | Unix.Unix_error (error, operation, argument) ->
+           Error (unix_failure (error, operation, argument)))
+    in
+    let acquired =
+      match acquire () with
+      | result -> result
+      | exception exn ->
+        let backtrace = Printexc.get_raw_backtrace () in
+        if Atomic.get process_lock_held
+        then release_fd_after_exception ~lock_path execution_context fd
+        else close_fd_after_exception ~lock_path execution_context fd;
+        Printexc.raise_with_backtrace exn backtrace
+    in
+    (match acquired with
+     | Ok () -> Ok fd
+     | Error cause ->
+       let cleanup_failure =
+         match
+           protect_cleanup execution_context (fun () -> close_fd_result fd)
+         with
+         | Ok () -> None
+         | Error failure -> Some failure
+       in
+       Error
+         (durable_lock_error
+            ?cleanup_failure
+            ~lock_path
+            ~phase:Acquire_process_lock
+            cause))
+
+let with_durable_lock ~lock_path f =
+  with_mutex lock_path (fun () ->
+    let execution_context = Eio_guard.execution_context () in
+    match acquire_durable_flock ~execution_context lock_path with
+    | Error _ as error -> error
+    | Ok fd ->
+      let admitted () =
+        let body =
+          match f () with
+          | value -> `Returned value
+          | exception exn -> `Raised (exn, Printexc.get_raw_backtrace ())
+        in
+        let release = release_durable_fd_result fd in
+        match body, release with
+        | `Returned value, Ok () -> Ok value
+        | `Returned _, Error (cause, cleanup_failure) ->
+          Error
+            (durable_lock_error
+               ?cleanup_failure
+               ~lock_path
+               ~phase:Release_process_lock
+               cause)
+        | `Raised (exn, backtrace), Ok () ->
+          Printexc.raise_with_backtrace exn backtrace
+        | `Raised (exn, backtrace), Error (release_failure, cleanup_failure) ->
+          Log.Misc.error
+            "file_lock_eio: release failed during body exception lock_path=%s operation=%s argument=%s error=%s%s"
+            lock_path release_failure.operation release_failure.argument
+            (Unix.error_message release_failure.error)
+            (match cleanup_failure with
+             | None -> ""
+             | Some cleanup ->
+               Printf.sprintf
+                 " cleanup_operation=%s cleanup_argument=%s cleanup_error=%s"
+                 cleanup.operation cleanup.argument
+                 (Unix.error_message cleanup.error));
+          Printexc.raise_with_backtrace exn backtrace
+      in
+      protect_cleanup execution_context admitted)
 
 (** Number of tracked lock paths (for diagnostics). *)
 let lock_count () = SMap.cardinal (Atomic.get table).entries

--- a/lib/process/file_lock_eio.mli
+++ b/lib/process/file_lock_eio.mli
@@ -29,6 +29,26 @@ val stale_lock_seconds : float
 
 exception Flock_timeout of { caller : string; path : string; attempts : int }
 
+type durable_lock_phase =
+  | Open_lock_file
+  | Acquire_process_lock
+  | Release_process_lock
+
+type unix_failure =
+  { error : Unix.error
+  ; operation : string
+  ; argument : string
+  }
+
+type durable_lock_error =
+  { lock_path : string
+  ; phase : durable_lock_phase
+  ; cause : unix_failure
+  ; cleanup_failure : unix_failure option
+  }
+
+val durable_lock_error_to_string : durable_lock_error -> string
+
 (** Non-blocking [F_TLOCK] with retry. On success returns the open
     file descriptor holding the lock. On timeout closes the fd and
     raises {!Flock_timeout}. [clock] is accepted but ignored in this
@@ -86,6 +106,14 @@ val with_lock :
   string ->
   (unit -> 'a) ->
   'a
+
+(** Cross-context/process transaction lock on the explicit [lock_path]. Eio
+    admission is cooperatively cancellable and unbounded; cancellation is
+    masked only after the OS lock is held, through body execution and release.
+    The parent directory must exist. I/O failures are typed and body exceptions
+    survive cleanup errors. *)
+val with_durable_lock :
+  lock_path:string -> (unit -> 'a) -> ('a, durable_lock_error) result
 
 (** {1 Observability hook} *)
 

--- a/test/test_executor_pool_eio_mutex.ml
+++ b/test/test_executor_pool_eio_mutex.ml
@@ -87,6 +87,74 @@ let test_submit_or_inline_preserves_mutex () =
         check bool "shared mutex is not poisoned after offload" false
           (poisons mu))))
 
+let context_label = function
+  | Eio_guard.Eio_fiber -> "eio_fiber"
+  | Eio_guard.Non_eio -> "non_eio"
+
+let test_ready_raw_domain_uses_non_eio_path () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      Eio_guard.enable ();
+      Fun.protect ~finally:Eio_guard.disable (fun () ->
+        let pool =
+          Domain_pool.create ~sw ~domain_count:1 (Eio.Stdenv.domain_mgr env)
+        in
+        Executor_pool_ref.set (Domain_pool.executor_pool pool);
+        check string "main caller has Eio handler" "eio_fiber"
+          (context_label (Eio_guard.execution_context ()));
+        let raw_mutex = Eio.Mutex.create () in
+        let durable_dir = Filename.temp_file "masc-raw-domain-dir-" "" in
+        Unix.unlink durable_dir;
+        Eio.Switch.on_release sw (fun () ->
+          if Sys.file_exists durable_dir then Unix.rmdir durable_dir);
+        let caller_context, submitted_context, systhread_value, cleanup_ran,
+            mutex_rejected, directory_result =
+          Domain.spawn (fun () ->
+            let cleanup_ran = ref false in
+            let protected_value =
+              Eio_guard.protect
+                ~finally:(fun () -> cleanup_ran := true)
+                (fun () -> 17)
+            in
+            let mutex_rejected =
+              match Eio_guard.with_mutex raw_mutex (fun () -> ()) with
+              | () -> false
+              | exception
+                  Eio_guard.Non_eio_mutex_context Eio_guard.Read_write -> true
+              | exception
+                  Eio_guard.Non_eio_mutex_context Eio_guard.Read_only -> false
+            in
+            let directory_result =
+              Masc.Keeper_fs_durable_directory.ensure
+                ~before_prepare:(fun () -> ())
+                ~before_directory_fsync:(fun _ -> ())
+                durable_dir
+            in
+            ( Eio_guard.execution_context ()
+            , Executor_pool_ref.submit_or_inline Eio_guard.execution_context
+            , Eio_guard.run_in_systhread (fun () -> protected_value)
+            , !cleanup_ran
+            , mutex_rejected
+            , directory_result ))
+          |> Domain.join
+        in
+        check string "raw Domain is not inferred from global ready" "non_eio"
+          (context_label caller_context);
+        check string "raw Domain does not enter the Eio executor" "non_eio"
+          (context_label submitted_context);
+        check int "raw Domain executes blocking body directly" 17 systhread_value;
+        check bool "raw Domain cleanup uses Fun.protect" true cleanup_ran;
+        check bool "ready raw Domain cannot enter an Eio mutex" true
+          mutex_rejected;
+        (match directory_result with
+         | Ok _ -> check bool "raw Domain prepares durable directory" true
+                     (Sys.is_directory durable_dir)
+         | Error (Masc.Keeper_fs_durable_directory.Directory_chain_failed _) ->
+           fail "raw Domain durable-directory chain failed"
+         | Error (Masc.Keeper_fs_durable_directory.Operation_failed (exn, _)) ->
+           fail ("raw Domain durable-directory operation failed: "
+                 ^ Printexc.to_string exn)))))
+
 let () =
   Alcotest.run "Executor_pool_ref Eio mutex safety"
     [ ( "offload"
@@ -96,5 +164,7 @@ let () =
             test_systhread_offload_raises_actionable_failure
         ; test_case "submit_or_inline preserves the mutex (fix)" `Quick
             test_submit_or_inline_preserves_mutex
+        ; test_case "ready raw Domain uses the non-Eio path" `Quick
+            test_ready_raw_domain_uses_non_eio_path
         ] )
     ]

--- a/test/test_file_lock_eio.ml
+++ b/test/test_file_lock_eio.ml
@@ -1,5 +1,20 @@
 open Alcotest
 
+let () =
+  if Array.length Sys.argv = 3 && String.equal Sys.argv.(1) "--hold-durable-lock"
+  then (
+    let fd =
+      Unix.openfile Sys.argv.(2) [ Unix.O_CREAT; Unix.O_WRONLY ] 0o644
+    in
+    Fun.protect
+      ~finally:(fun () -> Unix.close fd)
+      (fun () ->
+        Unix.lockf fd Unix.F_LOCK 0;
+        output_char stdout 'R';
+        flush stdout;
+        ignore (input_char stdin));
+    exit 0)
+
 let cleanup_if_exists path =
   if Sys.file_exists path then
     if Sys.is_directory path then
@@ -59,6 +74,82 @@ let test_with_lock_inside_eio () =
   check int "single call" 1 !calls;
   check bool "lock table tracked" true (File_lock_eio.lock_count () >= 1)
 
+let test_durable_lock_open_failure_is_typed () =
+  with_temp_path @@ fun path ->
+  let path = Filename.concat path "missing/target" in
+  match File_lock_eio.with_durable_lock ~lock_path:path (fun () -> ()) with
+  | Ok () -> fail "durable lock unexpectedly created a missing parent tree"
+  | Error error ->
+    check bool "failure phase is lock-file open" true
+      (match error.File_lock_eio.phase with
+       | File_lock_eio.Open_lock_file -> true
+       | Acquire_process_lock | Release_process_lock -> false)
+
+let with_external_lock_holder lock_path f =
+  let ready_read, ready_write = Unix.pipe () in
+  let release_read, release_write = Unix.pipe () in
+  let pid =
+    Unix.create_process Sys.executable_name
+      [| Sys.executable_name; "--hold-durable-lock"; lock_path |]
+      release_read ready_write Unix.stderr
+  in
+  Unix.close ready_write;
+  Unix.close release_read;
+  let released = ref false in
+  let release_holder () =
+    if not !released then (
+      released := true;
+      Fun.protect
+        ~finally:(fun () -> Unix.close release_write)
+        (fun () ->
+          check int "holder release signal" 1
+            (Unix.write_substring release_write "X" 0 1)))
+  in
+  let rec wait_for_child () =
+    match Unix.waitpid [] pid with
+    | result -> result
+    | exception Unix.Unix_error (Unix.EINTR, _, _) -> wait_for_child ()
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      release_holder ();
+      ignore (wait_for_child ()))
+    (fun () ->
+      let ready = Bytes.create 1 in
+      let count = Unix.read ready_read ready 0 1 in
+      Unix.close ready_read;
+      if count <> 1 || Bytes.get ready 0 <> 'R'
+      then fail "lock holder did not start";
+      f release_holder)
+
+let test_durable_lock_wait_is_cancellable () =
+  with_temp_path @@ fun path ->
+  let lock_path = path ^ ".lock" in
+  with_external_lock_holder lock_path @@ fun release_holder ->
+  Eio_main.run @@ fun _env ->
+  let started, signal_started = Eio.Promise.create () in
+  let body_ran = ref false in
+  let outcome =
+    Eio.Fiber.first
+      (fun () ->
+        Eio.Promise.resolve signal_started ();
+        match
+          File_lock_eio.with_durable_lock ~lock_path (fun () -> body_ran := true)
+        with
+        | Ok () -> `Unexpected_admission
+        | Error error -> `Failure (File_lock_eio.durable_lock_error_to_string error))
+      (fun () ->
+        Eio.Promise.await started;
+        Eio.Fiber.yield ();
+        release_holder ();
+        `Cancelled_waiter)
+  in
+  check bool "contended body did not run" false !body_ran;
+  match outcome with
+  | `Cancelled_waiter -> ()
+  | `Unexpected_admission -> fail "cross-process lock admitted while held"
+  | `Failure detail -> fail ("lock wait failed instead of cancelling: " ^ detail)
+
 let () =
   run "file_lock_eio"
     [
@@ -68,5 +159,9 @@ let () =
           test_case "acquire_flock_retry works without Eio context" `Quick
             test_acquire_flock_retry_without_eio;
           test_case "works inside Eio context" `Quick test_with_lock_inside_eio;
+          test_case "durable lock open failure is typed" `Quick
+            test_durable_lock_open_failure_is_typed;
+          test_case "durable cross-process wait is cancellable" `Quick
+            test_durable_lock_wait_is_cancellable;
         ] );
     ]


### PR DESCRIPTION
## What changed

- Added a typed `Eio_guard.execution_context` SSOT that distinguishes the current Eio fiber from a raw Domain/systhread instead of inferring it from the process-wide ready flag.
- Routed systhread offload, cleanup, cooperative yield/check, executor submission, and durable-directory release through the actual caller context.
- Replaced the two duplicated execution-context probes in Keeper approval/event-queue locking.
- Made ready-state raw-Domain Eio-mutex misuse fail explicitly with a typed exception.
- Added a raw-Domain regression with global ready + a live executor pool, including direct blocking work, cleanup, executor bypass, and durable-directory preparation.

## Root cause and impact

`Eio_guard.is_ready ()` is process-wide. Once enabled, it remained true in raw Domains that do not have an Eio effect handler. Those callers could therefore be sent into `Eio_unix.run_in_systhread`, `Eio.Switch`, an Eio executor, or cancellation protection and fail with `Effect.Unhandled`.

After this change, Eio fibers retain cooperative/offloaded behavior, while raw Domains use their explicit non-Eio path. This is stack A and contains no checkpoint-specific behavior; cancellable checkpoint locking and stable checkpoint/purge locking follow in dependent stacks B/C.

## Validation

Fresh branch base: `672ba7693f`  
Diff: `+145/-63` (7 files; below the 400-addition PR boundary)

Passed on this exact commit:

- `ocamlformat --check` for all touched OCaml files
- `ocamlc -stop-after parsing -c` for all touched OCaml files
- `git diff --check`
- structural search confirms the execution-context implementation has one SSOT in `Eio_guard`

Local Dune was intentionally not rerun on this fresh branch because the user assigned Dune build/test authority to CI. An older pre-split e887 worktree did pass focused core/process and `lib/masc.cmxa` builds, but that is not claimed as proof for this exact commit or its new regression.