### PR TITLE
refactor(keeper): stop reading TOML-only config keys from keeper JSON

### DIFF
--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -120,13 +120,14 @@ let parse_keeper_policy (json : Yojson.Safe.t) ~(keeper_name : string)
   match parse_sandbox_policy_fields json with
   | Error msg -> Error ("meta parse error: " ^ msg)
   | Ok (pp_sandbox_profile, pp_sandbox_image, pp_network_mode) ->
-    let pp_allowed_paths = Safe_ops.json_string_list "allowed_paths" json in
-    let pp_mention_targets =
-      Safe_ops.json_string_list "mention_targets" json |> dedupe_keep_order
-    in
-    let proactive_enabled =
-      Safe_ops.json_bool ~default:default_proactive_enabled "proactive_enabled" json
-    in
+    (* TOML-only config fields: the write side ([keeper_meta_json.ml]) omits
+       these by design, so the runtime JSON never carries them. The parser no
+       longer reads them — [ensure_keeper_meta] overlays the TOML SSOT value.
+       Neutral placeholders here keep the record total; a legacy JSON that still
+       carries one of these keys is ignored (TOML remains authoritative). *)
+    let pp_allowed_paths = [] in
+    let pp_mention_targets = [] in
+    let proactive_enabled = default_proactive_enabled in
     let env_ratio_gate, env_message_gate, env_token_gate =
       keeper_compaction_policy_from_env ()
     in
@@ -175,7 +176,8 @@ let parse_keeper_policy (json : Yojson.Safe.t) ~(keeper_name : string)
     let pp_handoff_cooldown_sec =
       Safe_ops.json_int ~default:300 "handoff_cooldown_sec" json
     in
-    let pp_always_allow = Safe_ops.json_bool_opt "always_allow" json in
+    let pp_always_allow = None in
+    (* TOML-only (see note above); overlaid by [ensure_keeper_meta]. *)
     Ok
       { pp_sandbox_profile
       ; pp_sandbox_image
@@ -345,7 +347,8 @@ let parse_keeper_state
            ();
          None)
   in
-  let ps_autoboot_enabled = Safe_ops.json_bool ~default:true "autoboot_enabled" json in
+  (* TOML-only config; overlaid by [ensure_keeper_meta]. Placeholder default. *)
+  let ps_autoboot_enabled = true in
   let ps_current_task_id =
     match Safe_ops.json_string_opt "current_task_id" json with
     | None -> None
@@ -523,10 +526,9 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
                    ; autoboot_enabled = state.ps_autoboot_enabled
                    ; current_task_id = state.ps_current_task_id
                    ; max_context_override = state.ps_max_context_override
-                   ; telemetry_feedback_enabled =
-                       Safe_ops.json_bool_opt "telemetry_feedback_enabled" json
-                   ; telemetry_feedback_window_hours =
-                       Safe_ops.json_int_opt "telemetry_feedback_window_hours" json
+                     (* TOML-only config; overlaid by [ensure_keeper_meta]. *)
+                   ; telemetry_feedback_enabled = None
+                   ; telemetry_feedback_window_hours = None
                    ; runtime = state.ps_runtime
                    ; oas_env =
                        (match Json_util.assoc_member_opt "oas_env" json with

--- a/test/deps/masc_test_deps.ml
+++ b/test/deps/masc_test_deps.ml
@@ -63,7 +63,42 @@ let meta_of_json_fixture (json : Yojson.Safe.t) =
     | `Assoc fields -> `Assoc (augment fields)
     | other -> other
   in
-  Masc.Keeper_meta_json_parse.meta_of_json json'
+  (* Production [meta_of_json] no longer reads TOML-only config keys from JSON
+     (TOML is the SSOT; the runtime JSON carries only runtime state). Focused
+     fixtures still set config inline for convenience, so this test helper
+     re-applies those keys onto the parsed record. This keeps config injection a
+     test-only concern and does not resurrect the production JSON read path. *)
+  match Masc.Keeper_meta_json_parse.meta_of_json json' with
+  | Error _ as e -> e
+  | Ok meta ->
+    let open Masc.Keeper_meta_contract in
+    let bool_opt key = Safe_ops.json_bool_opt key json' in
+    let apply_bool_opt key current =
+      match bool_opt key with Some _ as v -> v | None -> current
+    in
+    let apply_bool key current =
+      match bool_opt key with Some v -> v | None -> current
+    in
+    let apply_string_list key current =
+      match Safe_ops.json_string_list key json' with [] -> current | xs -> xs
+    in
+    Ok
+      { meta with
+        allowed_paths = apply_string_list "allowed_paths" meta.allowed_paths
+      ; mention_targets = apply_string_list "mention_targets" meta.mention_targets
+      ; proactive =
+          (match bool_opt "proactive_enabled" with
+           | Some enabled -> { enabled }
+           | None -> meta.proactive)
+      ; always_allow = apply_bool_opt "always_allow" meta.always_allow
+      ; autoboot_enabled = apply_bool "autoboot_enabled" meta.autoboot_enabled
+      ; telemetry_feedback_enabled =
+          apply_bool_opt "telemetry_feedback_enabled" meta.telemetry_feedback_enabled
+      ; telemetry_feedback_window_hours =
+          (match Safe_ops.json_int_opt "telemetry_feedback_window_hours" json' with
+           | Some _ as v -> v
+           | None -> meta.telemetry_feedback_window_hours)
+      }
 
 (** Walk up the directory tree from [Sys.getcwd()] until [dune-project] is
     found, then return that directory.

--- a/test/dune
+++ b/test/dune
@@ -2477,6 +2477,8 @@
 
 (include stanzas/test_keeper_meta_canonicalize.inc)
 
+(include stanzas/test_keeper_meta_json_config_toml_only.inc)
+
 (test
  (name test_keeper_visible_path_projection)
  (modules test_keeper_visible_path_projection)

--- a/test/stanzas/test_keeper_meta_json_config_toml_only.inc
+++ b/test/stanzas/test_keeper_meta_json_config_toml_only.inc
@@ -1,0 +1,8 @@
+; TOML-only config guard: production keeper_meta_json_parse must ignore config
+; keys in persisted JSON (keeper.json = runtime state; keeper.toml = config SSOT).
+; The test helper re-injects config for fixture convenience (test-only path).
+
+(test
+ (name test_keeper_meta_json_config_toml_only)
+ (modules test_keeper_meta_json_config_toml_only)
+ (libraries masc_test_deps))

--- a/test/test_keeper_meta_json_config_toml_only.ml
+++ b/test/test_keeper_meta_json_config_toml_only.ml
@@ -1,0 +1,95 @@
+(** TOML-only config: the production JSON parser must NOT read config keys.
+
+    keeper.json is the runtime-state store; keeper.toml is the config SSOT.
+    The write side ([keeper_meta_json.ml]) stopped emitting config keys
+    (always_allow, mention_targets, allowed_paths, proactive_enabled,
+    autoboot_enabled, telemetry_feedback_*), and the read side
+    ([keeper_meta_json_parse.ml]) must not resurrect them: a legacy JSON that
+    still carries these keys must be ignored so [ensure_keeper_meta]'s TOML
+    overlay stays authoritative. Removing the reads without this guard would let
+    a stale JSON value silently override the TOML SSOT.
+
+    The test helper [Masc_test_deps.meta_of_json_fixture] intentionally re-injects
+    these keys for fixture convenience; that path is test-only and is asserted
+    separately so the two behaviors do not drift. *)
+
+open Alcotest
+open Masc
+
+(* A JSON meta that carries every retired config key with a non-default value.
+   Runtime state (name/agent_name/trace_id/sandbox_profile) is minimal. *)
+let legacy_config_json name : Yojson.Safe.t =
+  `Assoc
+    [ ("name", `String name)
+    ; ("agent_name", `String ("agent-" ^ name))
+    ; ("trace_id", `String ("trace-" ^ name))
+    ; ("sandbox_profile", `String "docker")
+    ; (* config keys that must be ignored by the production parser *)
+      ("always_allow", `Bool true)
+    ; ("mention_targets", `List [ `String "@ghost"; `String "@legacy" ])
+    ; ("allowed_paths", `List [ `String "/legacy/path" ])
+    ; ("proactive_enabled", `Bool false)
+    ; ("autoboot_enabled", `Bool false)
+    ; ("telemetry_feedback_enabled", `Bool true)
+    ; ("telemetry_feedback_window_hours", `Int 99)
+    ]
+
+(* Production parser ignores JSON config keys -> neutral defaults. *)
+let test_production_ignores_json_config () =
+  match Keeper_meta_json_parse.meta_of_json (legacy_config_json "prod-keeper") with
+  | Error e -> Alcotest.failf "meta_of_json failed: %s" e
+  | Ok meta ->
+    let open Keeper_meta_contract in
+    check (option bool) "always_allow ignored (None)" None meta.always_allow;
+    check (list string) "mention_targets ignored ([])" [] meta.mention_targets;
+    check (list string) "allowed_paths ignored ([])" [] meta.allowed_paths;
+    (* proactive default is true; JSON's false must not win *)
+    check bool "proactive_enabled ignored (default true)" true meta.proactive.enabled;
+    (* autoboot default is true; JSON's false must not win *)
+    check bool "autoboot_enabled ignored (default true)" true meta.autoboot_enabled;
+    check
+      (option bool)
+      "telemetry_feedback_enabled ignored (None)"
+      None
+      meta.telemetry_feedback_enabled;
+    check
+      (option int)
+      "telemetry_feedback_window_hours ignored (None)"
+      None
+      meta.telemetry_feedback_window_hours
+
+(* Test helper re-injects config for fixture convenience (test-only path). *)
+let test_helper_reinjects_config () =
+  match Masc_test_deps.meta_of_json_fixture (legacy_config_json "test-keeper") with
+  | Error e -> Alcotest.failf "meta_of_json_fixture failed: %s" e
+  | Ok meta ->
+    let open Keeper_meta_contract in
+    check (option bool) "helper injects always_allow" (Some true) meta.always_allow;
+    check
+      (list string)
+      "helper injects mention_targets"
+      [ "@ghost"; "@legacy" ]
+      meta.mention_targets;
+    check (list string) "helper injects allowed_paths" [ "/legacy/path" ] meta.allowed_paths;
+    check bool "helper injects proactive_enabled" false meta.proactive.enabled;
+    check bool "helper injects autoboot_enabled" false meta.autoboot_enabled;
+    check
+      (option bool)
+      "helper injects telemetry_feedback_enabled"
+      (Some true)
+      meta.telemetry_feedback_enabled;
+    check
+      (option int)
+      "helper injects telemetry_feedback_window_hours"
+      (Some 99)
+      meta.telemetry_feedback_window_hours
+
+let () =
+  run
+    "keeper_meta_json_config_toml_only"
+    [ ( "config-is-toml-only"
+      , [ test_case "production parser ignores JSON config" `Quick
+            test_production_ignores_json_config
+        ; test_case "test helper re-injects config" `Quick test_helper_reinjects_config
+        ] )
+    ]

--- a/test/test_keeper_meta_json_config_toml_only.ml
+++ b/test/test_keeper_meta_json_config_toml_only.ml
@@ -3,7 +3,7 @@
     keeper.json is the runtime-state store; keeper.toml is the config SSOT.
     The write side ([keeper_meta_json.ml]) stopped emitting config keys
     (always_allow, mention_targets, allowed_paths, proactive_enabled,
-    autoboot_enabled, telemetry_feedback_*), and the read side
+    autoboot_enabled, telemetry_feedback_enabled/window), and the read side
     ([keeper_meta_json_parse.ml]) must not resurrect them: a legacy JSON that
     still carries these keys must be ignored so [ensure_keeper_meta]'s TOML
     overlay stays authoritative. Removing the reads without this guard would let


### PR DESCRIPTION
## 목적

keeper.json = 런타임-상태 store(매 턴 CAS write), keeper.toml = config SSOT. 프로덕션 JSON parser가 **write 측이 이미 버린** config 키를 read하던 vestigial 경로를 제거해 json을 순수 런타임 상태로 만든다.

## 배경 (적대 평가 + 라이브 실측)

- write 측(`keeper_meta_json.ml`)이 이 config 키들을 **emit 안 함**(grep emit=0) → legacy json 값은 **다음 턴 `write_meta`에서 자동 소거**. read-fallback은 업그레이드 직후 첫 로드에서만 catch하는 vestigial 경로.
- `ensure_keeper_meta`가 TOML을 overlay → toml이 authoritative. json 값은 잃을 게 없음(과거 "dual-home 데이터 손실"은 오독, RFC-0000 §3.15에서 정정).
- **라이브 fleet 실측**(base_path `/Users/dancer/me/.masc`): 14/14 keeper 전부 TOML manifest 보유, json에 이 config 키 **0건**. json-only keeper 0.

## 변경

**프로덕션** `keeper_meta_json_parse.ml` — 7개 죽은 config read 제거(→ 중립 placeholder):
`always_allow`·`mention_targets`·`allowed_paths`·`proactive_enabled`·`autoboot_enabled`·`telemetry_feedback_enabled`·`telemetry_feedback_window_hours`.
(sandbox_profile/network_mode은 기존 default-when-absent 처리 유지; multimodal_policy는 실제 round-trip이라 유지.)

**테스트 헬퍼** `masc_test_deps.ml` — `meta_of_json_fixture`가 json에서 config를 읽어 record override로 주입 → config를 json으로 주입하는 **~20개 fixture 무수정 유지**. config-from-json이 test-only 관심사로 격리(프로덕션 read 부활 아님).

**회귀 테스트** 신설 — ①프로덕션 `meta_of_json`이 json config 무시(TOML-authoritative) ②헬퍼는 fixture 재주입. 두 방향 고정.

## 범위 밖
- `mention_targets` persona↔toml overlay union화(별도 behavior 결정, 이 PR 아님).
- keeper.json 삭제(non-goal — 런타임 상태 CAS store).

## Self-review / Done 기준
- 변경 파일이 RFC-gated 서브시스템(credential/repo_manager/…) 미포함 확인.
- **로컬 빌드/테스트 검증은 owner가 dune 실행 중 — green 확인 후 Ready 전환.**
- Draft 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
