### PR TITLE
fix(schedule): fence acknowledged wake occurrences

### DIFF
--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -432,6 +432,85 @@ let iter_all t f =
          days)
     months
 
+let sorted_entries_result path =
+  try Ok (Sys.readdir path |> Array.to_list |> List.sort String.compare) with
+  | Sys_error message -> Error (Printf.sprintf "failed to list %s: %s" path message)
+;;
+
+let line_error operation path line_number message =
+  Printf.sprintf "%s %s:%d: %s" operation path line_number message
+;;
+
+let iter_json_file_result path f =
+  try
+    let input = open_in_bin path in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr input)
+      (fun () ->
+         let rec loop line_number =
+           match input_line input with
+           | exception End_of_file -> Ok ()
+           | exception Sys_error message ->
+             Error (line_error "failed to read" path line_number message)
+           | line when String.trim line = "" -> loop (line_number + 1)
+           | line ->
+             (match Yojson.Safe.from_string line with
+              | json ->
+                f json;
+                loop (line_number + 1)
+              | exception Yojson.Json_error message ->
+                Error (line_error "failed to parse" path line_number message))
+         in
+         loop 1)
+  with
+  | Sys_error message -> Error (Printf.sprintf "failed to open %s: %s" path message)
+;;
+
+let iter_all_result t f =
+  let ( let* ) = Result.bind in
+  let* store_present =
+    try
+      match (Unix.stat t.base_dir).st_kind with
+      | Unix.S_DIR -> Ok true
+      | _ -> Error ("dated JSONL base path is not a directory: " ^ t.base_dir)
+    with
+    | Unix.Unix_error (Unix.ENOENT, _, _) -> Ok false
+    | Unix.Unix_error (error, _, _) ->
+      Error
+        (Printf.sprintf
+           "failed to inspect %s: %s"
+           t.base_dir
+           (Unix.error_message error))
+  in
+  if not store_present then Ok ()
+  else
+    let* months = sorted_entries_result t.base_dir in
+    let months =
+      List.filter
+        (fun name ->
+           String.length name = 7
+           && name.[4] = '-'
+           && Option.is_some (int_of_string_opt (String.sub name 0 4)))
+        months
+    in
+    let rec iter_months = function
+      | [] -> Ok ()
+      | month :: rest ->
+        let month_path = Filename.concat t.base_dir month in
+        let* days = sorted_entries_result month_path in
+        let days = List.filter (fun name -> Filename.check_suffix name ".jsonl") days in
+        let rec iter_days = function
+          | [] -> Ok ()
+          | day :: rest ->
+            let* () = iter_json_file_result (Filename.concat month_path day) f in
+            iter_days rest
+        in
+        let* () = iter_days days in
+        iter_months rest
+    in
+    iter_months months
+;;
+
 let iter_range t ~since ~until f =
   match parse_date since, parse_date until with
   | None, _ | _, None -> ()

--- a/lib/dated_jsonl/dated_jsonl.mli
+++ b/lib/dated_jsonl/dated_jsonl.mli
@@ -77,6 +77,10 @@ val iter_all : t -> (Yojson.Safe.t -> unit) -> unit
     order without loading a whole day-file into memory. Malformed rows are
     skipped, matching {!read_recent} and {!read_range}. *)
 
+val iter_all_result : t -> (Yojson.Safe.t -> unit) -> (unit, string) result
+(** Fail-loud variant of {!iter_all}. Missing stores are empty; directory,
+    file-read, and JSON parse failures are returned with their exact path. *)
+
 val iter_range : t -> since:string -> until:string -> (Yojson.Safe.t -> unit) -> unit
 (** Streaming variant of {!read_range}. Invalid dates iterate zero rows. *)
 

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -528,7 +528,7 @@ let reaction_kind_field row =
   | None -> None
 ;;
 
-let event_queue_reaction_evidence ~base_path ~keeper_name ~stimulus_id =
+let event_queue_reaction_evidence_with_iter ~keeper_name ~stimulus_id iter =
   let stimulus_seen = ref false in
   let turn_started_seen = ref false in
   let event_queue_ack_seen = ref false in
@@ -537,8 +537,7 @@ let event_queue_reaction_evidence ~base_path ~keeper_name ~stimulus_id =
   let event_queue_ack_recorded_at = ref None in
   let latest_recorded_at = ref None in
   let matched_record_count = ref 0 in
-  let store = store_for_base_path ~base_path ~keeper_name in
-  Dated_jsonl.iter_all store (fun row ->
+  let iteration = iter (fun row ->
     match string_field "stimulus_id" row with
     | Some row_stimulus_id when String.equal row_stimulus_id stimulus_id ->
       incr matched_record_count;
@@ -571,6 +570,7 @@ let event_queue_reaction_evidence ~base_path ~keeper_name ~stimulus_id =
        | None -> ())
     | Some _
     | None -> ());
+  iteration,
   { keeper_name
   ; stimulus_id
   ; stimulus_seen = !stimulus_seen
@@ -582,6 +582,22 @@ let event_queue_reaction_evidence ~base_path ~keeper_name ~stimulus_id =
   ; latest_recorded_at = !latest_recorded_at
   ; matched_record_count = !matched_record_count
   }
+;;
+
+let event_queue_reaction_evidence ~base_path ~keeper_name ~stimulus_id =
+  let store = store_for_base_path ~base_path ~keeper_name in
+  event_queue_reaction_evidence_with_iter ~keeper_name ~stimulus_id (fun note ->
+    Dated_jsonl.iter_all store note)
+  |> snd
+;;
+
+let event_queue_reaction_evidence_result ~base_path ~keeper_name ~stimulus_id =
+  let store = store_for_base_path ~base_path ~keeper_name in
+  let iteration, evidence =
+    event_queue_reaction_evidence_with_iter ~keeper_name ~stimulus_id (fun note ->
+      Dated_jsonl.iter_all_result store note)
+  in
+  Result.map (fun () -> evidence) iteration
 ;;
 
 let string_list_field name json =

--- a/lib/keeper/keeper_reaction_ledger.mli
+++ b/lib/keeper/keeper_reaction_ledger.mli
@@ -98,6 +98,14 @@ val event_queue_reaction_evidence :
     This intentionally does not use a "recent rows" limit, because dashboards
     use it to prove a specific queue stimulus was observed by the keeper. *)
 
+val event_queue_reaction_evidence_result :
+  base_path:string ->
+  keeper_name:string ->
+  stimulus_id:string ->
+  (event_queue_reaction_evidence, string) result
+(** Fail-loud exact-id scan for delivery invariants. Unlike the dashboard
+    projection above, malformed or unreadable ledger rows return [Error]. *)
+
 val record_board_cursor_ack :
   base_path:string ->
   keeper_name:string ->

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -34,7 +34,16 @@ let wake_enqueue_counts_of_dispatches dispatches =
        | Some detail ->
          (match Consumers.dispatch_receipt_of_detail detail with
           | Error _ -> counts
-          | Ok (Consumers.Keeper_wake_enqueued { reaction_ledger_status; _ }) ->
+          | Ok
+              (Consumers.Keeper_wake_enqueued
+                { occurrence_status = Consumers.Keeper_wake_already_acked; _ }) ->
+            counts
+          | Ok
+              (Consumers.Keeper_wake_enqueued
+                { occurrence_status = Consumers.Keeper_wake_awaiting_ack
+                ; reaction_ledger_status
+                ; _
+                }) ->
             let counts = bump_wake_enqueued counts in
             (match reaction_ledger_status with
              | Some (Consumers.Keeper_wake_reaction_ledger_record_failed _) ->

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -2567,6 +2567,7 @@ let schedule_keeper_queue_evidence_dashboard_json
               ; stimulus
               ; stimulus_id = _
               ; reaction_ledger_status = _
+              ; occurrence_status = _
               }) ->
           let due_at = execution.Schedule_domain.due_at in
           let payload_digest = execution.Schedule_domain.payload_digest in
@@ -2644,6 +2645,7 @@ let schedule_keeper_reaction_evidence_dashboard_json
               ; stimulus
               ; stimulus_id
               ; reaction_ledger_status = _
+              ; occurrence_status = _
               }) ->
           let base_fields =
             [ "source", `String "keeper_reaction_ledger"

--- a/lib/server/server_schedule_consumers.ml
+++ b/lib/server/server_schedule_consumers.ml
@@ -10,6 +10,12 @@ let reaction_ledger_record_failed_label = "record_failed"
 
 let ( let* ) = Result.bind
 
+let terminal_dispatch_result result =
+  Result.map_error
+    (fun detail -> Schedule_runner.Terminal_dispatch_rejection detail)
+    result
+;;
+
 let unsupported_payload_labels ~phase = [ "phase", phase ]
 
 let record_unsupported_payload_dispatch _request rejection =
@@ -108,6 +114,21 @@ let keeper_wake_reaction_ledger_status_json_fields = function
     ]
 ;;
 
+type keeper_wake_occurrence_status =
+  | Keeper_wake_awaiting_ack
+  | Keeper_wake_already_acked
+
+let keeper_wake_occurrence_status_to_string = function
+  | Keeper_wake_awaiting_ack -> "awaiting_ack"
+  | Keeper_wake_already_acked -> "already_acked"
+;;
+
+let keeper_wake_occurrence_status_of_string = function
+  | "awaiting_ack" -> Ok Keeper_wake_awaiting_ack
+  | "already_acked" -> Ok Keeper_wake_already_acked
+  | value -> Error ("unsupported occurrence_status: " ^ value)
+;;
+
 type dispatch_receipt =
   | Keeper_wake_enqueued of
       { keeper_name : string
@@ -118,6 +139,7 @@ type dispatch_receipt =
       ; stimulus : string
       ; stimulus_id : string option
       ; reaction_ledger_status : keeper_wake_reaction_ledger_status option
+      ; occurrence_status : keeper_wake_occurrence_status
       }
 
 let dispatch_receipt_of_detail = function
@@ -135,6 +157,10 @@ let dispatch_receipt_of_detail = function
       let* reaction_ledger_status =
         keeper_wake_reaction_ledger_status_of_fields fields
       in
+      let* occurrence_status =
+        let* value = string_field "occurrence_status" fields in
+        keeper_wake_occurrence_status_of_string value
+      in
       Ok
         (Keeper_wake_enqueued
            { keeper_name
@@ -145,6 +171,7 @@ let dispatch_receipt_of_detail = function
            ; stimulus
            ; stimulus_id
            ; reaction_ledger_status
+           ; occurrence_status
            })
     else Error ("unsupported schedule dispatch receipt kind: " ^ kind)
   | _ -> Error "schedule dispatch receipt detail must be an object"
@@ -160,6 +187,7 @@ let dispatch_receipt_to_yojson = function
       ; stimulus
       ; stimulus_id
       ; reaction_ledger_status
+      ; occurrence_status
       } ->
     `Assoc
       ([ "kind", `String keeper_wake_enqueued_kind
@@ -173,6 +201,8 @@ let dispatch_receipt_to_yojson = function
        ; "schedule_id", `String schedule_id
        ; "urgency", `String urgency
        ; "post_id", `String post_id
+       ; ( "occurrence_status"
+         , `String (keeper_wake_occurrence_status_to_string occurrence_status) )
        ]
        @ keeper_wake_reaction_ledger_status_json_fields reaction_ledger_status)
 ;;
@@ -218,6 +248,64 @@ let record_keeper_wake_stimulus ~base_path ~keeper_name stimulus =
          (Printexc.to_string exn))
 ;;
 
+type keeper_wake_acceptance =
+  | Wake_required
+  | Already_drained
+
+let retryable_dispatch_failure detail =
+  Error (Schedule_runner.Retryable_dispatch_failure detail)
+;;
+
+let reaction_evidence_result ~base_path ~keeper_name ~stimulus_id =
+  try
+    Keeper_reaction_ledger.event_queue_reaction_evidence_result
+      ~base_path
+      ~keeper_name
+      ~stimulus_id
+    |> Result.map_error (fun detail ->
+      "failed to read keeper reaction ledger stimulus: " ^ detail)
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Error
+      (Printf.sprintf
+         "failed to read keeper reaction ledger stimulus: %s"
+         (Printexc.to_string exn))
+;;
+
+let accept_keeper_wake_occurrence
+      ~base_path
+      ~keeper_name
+      ~stimulus_id
+      stimulus
+  =
+  match reaction_evidence_result ~base_path ~keeper_name ~stimulus_id with
+  | Error detail -> retryable_dispatch_failure detail
+  | Ok evidence when evidence.event_queue_ack_seen ->
+    (* The transition projector appends this exact-id ACK before retiring its
+       outbox entry. It is therefore the durable terminal occurrence fence,
+       independent of pending/lease/outbox retention. *)
+    Ok Already_drained
+  | Ok evidence ->
+    (match
+       Keeper_registry_event_queue.enqueue_stimulus_durable_result
+         ~base_path
+         keeper_name
+         stimulus
+     with
+     | Keeper_registry_event_queue.Stimulus_storage_error detail ->
+       retryable_dispatch_failure
+         ("scheduled keeper wake durable enqueue failed: " ^ detail)
+     | Keeper_registry_event_queue.Stimulus_enqueued
+     | Keeper_registry_event_queue.Stimulus_already_present ->
+       if evidence.stimulus_seen then Ok Wake_required
+       else
+         (match record_keeper_wake_stimulus ~base_path ~keeper_name stimulus with
+          | Keeper_wake_reaction_ledger_recorded -> Ok Wake_required
+          | Keeper_wake_reaction_ledger_record_failed detail ->
+            retryable_dispatch_failure detail))
+;;
+
 let dispatch_keeper_wake
       config
       ~now
@@ -225,10 +313,16 @@ let dispatch_keeper_wake
       (request : Schedule_domain.schedule_request)
       payload
   =
-  let* keeper_name = body_keeper_name payload in
-  let* message = Schedule_payload_projection.body_required_string payload "message" in
-  let* title = Schedule_payload_projection.body_optional_string payload "title" in
-  let* urgency = body_keeper_wake_urgency payload in
+  let* keeper_name = terminal_dispatch_result (body_keeper_name payload) in
+  let* message =
+    terminal_dispatch_result
+      (Schedule_payload_projection.body_required_string payload "message")
+  in
+  let* title =
+    terminal_dispatch_result
+      (Schedule_payload_projection.body_optional_string payload "title")
+  in
+  let* urgency = terminal_dispatch_result (body_keeper_wake_urgency payload) in
   let urgency =
     urgency
     (* DET-OK: absent masc.keeper_wake urgency is the schema-v1 default;
@@ -252,57 +346,43 @@ let dispatch_keeper_wake
     }
   in
   let stimulus_id = Keeper_reaction_ledger.stimulus_id_of_event_queue stimulus in
-  let* () =
-    match
-      Keeper_registry_event_queue.enqueue_stimulus_durable_result
-        ~base_path:config.Workspace_utils.base_path
-        keeper_name
-        stimulus
-    with
-    | Keeper_registry_event_queue.Stimulus_storage_error detail ->
-      Error ("scheduled keeper wake durable enqueue failed: " ^ detail)
-    | Keeper_registry_event_queue.Stimulus_enqueued
-    | Keeper_registry_event_queue.Stimulus_already_present -> Ok ()
+  let base_path = config.Workspace_utils.base_path in
+  let* acceptance =
+    accept_keeper_wake_occurrence ~base_path ~keeper_name ~stimulus_id stimulus
   in
-  let wakeup_outcome =
-    Keeper_registry.wakeup
-      ~intent:Keeper_registry.Scheduled_signal
-      ~base_path:config.Workspace_utils.base_path
-      keeper_name
+  let occurrence_status =
+    match acceptance with
+    | Wake_required -> Keeper_wake_awaiting_ack
+    | Already_drained -> Keeper_wake_already_acked
   in
-  (match wakeup_outcome with
-   | Keeper_registry.Signaled -> ()
-   | Keeper_registry.Deferred_unregistered ->
-     Log.Keeper.info
-       "schedule stimulus queued for unregistered keeper schedule_id=%s keeper=%s"
-       request.schedule_id
-       keeper_name
-   | Keeper_registry.Deferred_not_running phase ->
-     Log.Keeper.info
-       "schedule stimulus queued without runnable fiber schedule_id=%s keeper=%s phase=%s"
-       request.schedule_id
-       keeper_name
-       (Keeper_state_machine.phase_to_string phase)
-   | Keeper_registry.Deferred_lifecycle denial ->
-     Log.Keeper.info
-       "schedule stimulus queued but lifecycle admission deferred wake schedule_id=%s keeper=%s reason=%s"
-       request.schedule_id
-       keeper_name
-       (Keeper_lifecycle_admission.autonomous_denial_to_wire denial));
-  let reaction_ledger_status =
-    record_keeper_wake_stimulus
-      ~base_path:config.Workspace_utils.base_path
-      ~keeper_name
-      stimulus
-  in
-  (match reaction_ledger_status with
-   | Keeper_wake_reaction_ledger_recorded -> ()
-   | Keeper_wake_reaction_ledger_record_failed reason ->
-     Log.Keeper.warn
-       "schedule keeper wake reaction ledger append failed schedule_id=%s keeper=%s: %s"
-       request.schedule_id
-       keeper_name
-       reason);
+  (match acceptance with
+   | Already_drained -> ()
+   | Wake_required ->
+     let wakeup_outcome =
+       Keeper_registry.wakeup
+         ~intent:Keeper_registry.Scheduled_signal
+         ~base_path
+         keeper_name
+     in
+     (match wakeup_outcome with
+      | Keeper_registry.Signaled -> ()
+      | Keeper_registry.Deferred_unregistered ->
+        Log.Keeper.info
+          "schedule stimulus queued for unregistered keeper schedule_id=%s keeper=%s"
+          request.schedule_id
+          keeper_name
+      | Keeper_registry.Deferred_not_running phase ->
+        Log.Keeper.info
+          "schedule stimulus queued without runnable fiber schedule_id=%s keeper=%s phase=%s"
+          request.schedule_id
+          keeper_name
+          (Keeper_state_machine.phase_to_string phase)
+      | Keeper_registry.Deferred_lifecycle denial ->
+        Log.Keeper.info
+          "schedule stimulus queued but lifecycle admission deferred wake schedule_id=%s keeper=%s reason=%s"
+          request.schedule_id
+          keeper_name
+          (Keeper_lifecycle_admission.autonomous_denial_to_wire denial)));
   Ok
     (`Assoc
       ([ "kind", `String keeper_wake_enqueued_kind
@@ -313,14 +393,19 @@ let dispatch_keeper_wake
        ; "schedule_id", `String request.schedule_id
        ; "urgency", `String (Keeper_event_queue.urgency_to_string urgency)
        ; "post_id", `String stimulus.post_id
+       ; ( "occurrence_status"
+         , `String (keeper_wake_occurrence_status_to_string occurrence_status) )
        ]
-       @ keeper_wake_reaction_ledger_status_json_fields (Some reaction_ledger_status)))
+       @ keeper_wake_reaction_ledger_status_json_fields
+           (Some Keeper_wake_reaction_ledger_recorded)))
 ;;
 
 let dispatch config ~now signal request =
   match Schedule_payload_projection.dispatch_view_detailed request with
   | Error rejection ->
-    Error (Schedule_payload_projection.dispatch_rejection_message rejection)
+    Error
+      (Schedule_runner.Terminal_dispatch_rejection
+         (Schedule_payload_projection.dispatch_rejection_message rejection))
   | Ok (kind, payload) ->
     (match kind with
      | Schedule_payload_projection.Keeper_wake ->

--- a/lib/server/server_schedule_consumers.mli
+++ b/lib/server/server_schedule_consumers.mli
@@ -4,6 +4,10 @@ type keeper_wake_reaction_ledger_status =
   | Keeper_wake_reaction_ledger_recorded
   | Keeper_wake_reaction_ledger_record_failed of string
 
+type keeper_wake_occurrence_status =
+  | Keeper_wake_awaiting_ack
+  | Keeper_wake_already_acked
+
 type dispatch_receipt =
   | Keeper_wake_enqueued of
       { keeper_name : string
@@ -14,6 +18,7 @@ type dispatch_receipt =
       ; stimulus : string
       ; stimulus_id : string option
       ; reaction_ledger_status : keeper_wake_reaction_ledger_status option
+      ; occurrence_status : keeper_wake_occurrence_status
       }
 
 val dispatch_receipt_of_detail :

--- a/test/test_dated_jsonl.ml
+++ b/test/test_dated_jsonl.ml
@@ -238,6 +238,14 @@ let test_iter_all_chronological_skips_malformed () =
   Dated_jsonl.iter_all store (fun json -> seen := json_i json :: !seen);
   check (list int) "iter_all chronological" [ 1; 2; 3 ] (List.rev !seen)
 
+let test_iter_all_result_rejects_malformed () =
+  let dir = tmpdir "dated_jsonl_iter_all_result" in
+  write_dated_file dir "2026-01" "01" [ {|{"i":1}|}; "not-json" ];
+  let store = Dated_jsonl.create ~base_dir:dir () in
+  match Dated_jsonl.iter_all_result store ignore with
+  | Ok () -> fail "strict iteration silently skipped malformed JSON"
+  | Error _ -> ()
+
 let test_iter_range_chronological () =
   let dir = tmpdir "dated_jsonl_iter_range" in
   write_dated_file dir "2026-01" "01" [ {|{"i":1}|} ];
@@ -370,6 +378,8 @@ let () =
           test_case "range_recent returns newest n in window" `Quick test_read_range_recent;
           test_case "iter_all chronological" `Quick
             test_iter_all_chronological_skips_malformed;
+          test_case "iter_all result rejects malformed" `Quick
+            test_iter_all_result_rejects_malformed;
           test_case "iter_range chronological" `Quick test_iter_range_chronological;
         ] );
       ( "prune",

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -308,6 +308,8 @@ let test_keeper_wake_consumer_enqueues_typed_stimulus_and_succeeds_schedule () =
       (receipt |> member "projection_status" |> to_string);
     check string "receipt kind" "masc.keeper_wake.enqueued"
       (receipt |> member "kind" |> to_string);
+    check string "receipt occurrence awaits ack" "awaiting_ack"
+      (receipt |> member "occurrence_status" |> to_string);
     check string "receipt queue" "keeper_event_queue"
       (receipt |> member "queue" |> to_string);
     check string "receipt stimulus" "schedule_due"
@@ -377,7 +379,7 @@ let test_recurring_wakes_keep_distinct_occurrence_ids () =
     (List.map (fun (stimulus : Keeper_event_queue.stimulus) -> stimulus.post_id) queued)
 ;;
 
-let test_keeper_wake_durable_enqueue_failure_is_not_success () =
+let test_keeper_wake_durable_enqueue_failure_retries_same_occurrence () =
   with_workspace
   @@ fun config ->
   let keeper_owner_path =
@@ -390,6 +392,7 @@ let test_keeper_wake_durable_enqueue_failure_is_not_success () =
   write_empty_file keeper_owner_path;
   let request = create_keeper_wake_schedule config in
   let result = tick_ok config ~now:201.0 in
+  let occurrence_id = single_signal_id result in
   (match List.hd result.dispatches with
    | { status = Schedule_runner.Dispatch_failed; error = Some message; _ } ->
      check bool "storage failure is explicit" true
@@ -400,13 +403,110 @@ let test_keeper_wake_durable_enqueue_failure_is_not_success () =
   (match Schedule_store.get_schedule config ~schedule_id:request.schedule_id with
    | None -> fail "schedule missing"
    | Some stored ->
-     check string "schedule did not report success" "failed"
+     check string "schedule remains retryable" "due"
        (Schedule_domain.schedule_status_to_string stored.status));
   check int "failed commit leaves no queued wake" 0
     (Keeper_event_queue.length
        (Keeper_registry_event_queue.snapshot
           ~base_path:config.Workspace_utils.base_path
-          "schedule-keeper"))
+          "schedule-keeper"));
+  Sys.remove keeper_owner_path;
+  let retried = tick_ok config ~now:202.0 in
+  check int "signal log is not duplicated" 0 (List.length retried.emitted);
+  (match List.hd retried.dispatches with
+   | { status = Schedule_runner.Dispatch_succeeded; _ } -> ()
+   | _ -> fail "next sequential tick did not retry the durable enqueue");
+  let queued =
+    Keeper_registry_event_queue.snapshot
+      ~base_path:config.Workspace_utils.base_path
+      "schedule-keeper"
+    |> Keeper_event_queue.to_list
+  in
+  check (list string) "retry preserves occurrence id" [ occurrence_id ]
+    (List.map (fun (stimulus : Keeper_event_queue.stimulus) -> stimulus.post_id) queued)
+;;
+
+let test_acked_occurrence_recovery_does_not_enqueue_or_wake_again () =
+  with_workspace
+  @@ fun config ->
+  let keeper_name = "schedule-keeper" in
+  let base_path = config.Workspace_utils.base_path in
+  let entry =
+    Keeper_registry.register ~base_path keeper_name (keeper_meta_for_name keeper_name)
+  in
+  Fun.protect
+    ~finally:(fun () -> Keeper_registry.unregister ~base_path keeper_name)
+    (fun () ->
+      let request = create_keeper_wake_schedule config in
+      let signal =
+        match Schedule_runner.tick config ~now:201.0 with
+        | Ok { emitted = [ signal ]; _ } -> signal
+        | Ok _ -> fail "expected one durable schedule signal"
+        | Error err -> fail (Schedule_runner.runner_error_to_string err)
+      in
+      let running =
+        match
+          Schedule_store.start_due_candidate
+            config
+            ~now:201.5
+            ~schedule_id:request.schedule_id
+        with
+        | Ok running -> running
+        | Error err -> fail (Schedule_store.store_error_to_string err)
+      in
+      Atomic.set entry.fiber_wakeup false;
+      (match
+         Server_schedule_consumers.consumer.dispatch config ~now:202.0 signal running
+       with
+       | Ok _ -> ()
+       | Error _ -> fail "initial schedule occurrence dispatch failed");
+      check bool "initial dispatch wakes lane" true (Atomic.get entry.fiber_wakeup);
+      let lease =
+        match
+          Keeper_registry_event_queue.claim_when_result
+            ~base_path
+            keeper_name
+            ~claimed_at:202.5
+            ~ready:(fun _ -> true)
+        with
+        | Ok (Some lease) -> lease
+        | Ok None -> fail "scheduled occurrence was not queued"
+        | Error detail -> fail detail
+      in
+      (match
+         Keeper_registry_event_queue.settle_result
+           ~base_path
+           keeper_name
+           ~settled_at:203.0
+           ~lease
+           ~settlement:Keeper_registry_event_queue.Ack
+       with
+       | Ok (Keeper_registry_event_queue.Settled _)
+       | Ok (Keeper_registry_event_queue.Already_settled _) -> ()
+       | Error detail -> fail detail);
+      (match Keeper_heartbeat_loop.project_transition_outbox ~base_path ~keeper_name with
+       | Ok () -> ()
+       | Error detail -> fail detail);
+      (match Schedule_store.get_schedule config ~schedule_id:request.schedule_id with
+       | Some stored ->
+         check string "crash window leaves schedule running" "running"
+           (Schedule_domain.schedule_status_to_string stored.status)
+       | None -> fail "running schedule disappeared before recovery");
+      (match Schedule_store.recover_running_on_startup config ~now:204.0 with
+       | Ok (_, 1) -> ()
+       | Ok (_, recovered) -> failf "expected one recovered schedule, got %d" recovered
+       | Error err -> fail (Schedule_store.store_error_to_string err));
+      Atomic.set entry.fiber_wakeup false;
+      let retried = tick_ok config ~now:205.0 in
+      check bool "retry sends no second wake" false (Atomic.get entry.fiber_wakeup);
+      (match List.hd retried.dispatches with
+       | { detail = Some detail; _ } ->
+         check string "retry observes terminal ack" "already_acked"
+           Yojson.Safe.Util.(detail |> member "occurrence_status" |> to_string)
+       | _ -> fail "retry completion receipt missing");
+      check int "retry enqueues no second occurrence" 0
+        (Keeper_registry_event_queue.snapshot ~base_path keeper_name
+         |> Keeper_event_queue.length))
 ;;
 
 let test_keeper_wake_queue_evidence_rejects_stale_occurrence () =
@@ -687,7 +787,7 @@ let test_keeper_wake_dashboard_tracks_runtime_inflight_lease () =
         (acked_reaction_evidence |> member "matched_record_count" |> to_int))
 ;;
 
-let test_keeper_wake_ledger_failure_keeps_dispatch_success_visible () =
+let test_keeper_wake_ledger_failure_is_retryable () =
   with_workspace
   @@ fun config ->
   let keeper_name = "schedule-keeper" in
@@ -702,44 +802,18 @@ let test_keeper_wake_ledger_failure_keeps_dispatch_success_visible () =
   let request = create_keeper_wake_schedule config in
   let result = tick_ok config ~now:201.0 in
   check int "one dispatch" 1 (List.length result.dispatches);
-  check string "dispatch status stays succeeded" "succeeded"
+  check string "dispatch reports retryable failure" "failed"
     (Schedule_runner.dispatch_status_to_string (List.hd result.dispatches).status);
-  let runner_status = runner_status_json_after_dispatches result in
-  let runner_counts =
-    Yojson.Safe.Util.(runner_status |> member "last_counts")
-  in
-  check string "ledger failure degrades runner health" "degraded"
-    Yojson.Safe.Util.(runner_status |> member "status" |> to_string);
-  check int "ledger failure still counts wake enqueue" 1
-    Yojson.Safe.Util.(runner_counts |> member "wake_enqueued" |> to_int);
-  check int "ledger failure increments wake failure" 1
-    Yojson.Safe.Util.(runner_counts |> member "wake_failed" |> to_int);
   (match Schedule_store.get_schedule config ~schedule_id:request.schedule_id with
    | None -> fail "schedule missing"
    | Some stored ->
-     check string "schedule succeeded" "succeeded"
+     check string "schedule remains due" "due"
        (Schedule_domain.schedule_status_to_string stored.status));
-  check int "wake remains durably queued" 1
-    (Keeper_event_queue.length
-       (Keeper_registry_event_queue.snapshot ~base_path keeper_name));
-  let dashboard =
-    Server_dashboard_http_runtime_info.scheduled_automation_dashboard_json config
-  in
-  let open Yojson.Safe.Util in
-  let row = dashboard_schedule_row_exn dashboard ~schedule_id:request.schedule_id in
-  let receipt = row |> member "dispatch_receipt" in
-  check string "receipt recognized" "recognized"
-    (receipt |> member "projection_status" |> to_string);
-  check string "ledger failure visible" "record_failed"
-    (receipt |> member "reaction_ledger_status" |> to_string);
-  check bool "ledger failure reason visible" true
-    (String.length (receipt |> member "reaction_ledger_error" |> to_string) > 0);
-  let queue_evidence = row |> member "keeper_queue_evidence" in
-  check string "queue evidence still matched" "matched_pending"
-    (queue_evidence |> member "projection_status" |> to_string);
-  let reaction_evidence = row |> member "keeper_reaction_evidence" in
-  check string "reaction ledger miss visible" "not_found"
-    (reaction_evidence |> member "projection_status" |> to_string)
+  (match (List.hd result.dispatches).error with
+   | Some detail ->
+     check bool "ledger failure is explicit" true
+       (String_util.contains_substring detail "keeper reaction ledger")
+   | None -> fail "ledger failure detail missing")
 ;;
 
 let test_keeper_wake_consumer_rejects_invalid_keeper_name () =
@@ -785,8 +859,10 @@ let () =
             test_keeper_wake_consumer_enqueues_typed_stimulus_and_succeeds_schedule
         ; test_case "recurring wakes keep distinct occurrence ids" `Quick
             test_recurring_wakes_keep_distinct_occurrence_ids
-        ; test_case "keeper wake durable enqueue failure is not success" `Quick
-            test_keeper_wake_durable_enqueue_failure_is_not_success
+        ; test_case "keeper wake durable enqueue retries same occurrence" `Quick
+            test_keeper_wake_durable_enqueue_failure_retries_same_occurrence
+        ; test_case "acked occurrence recovery does not enqueue or wake again" `Quick
+            test_acked_occurrence_recovery_does_not_enqueue_or_wake_again
         ; test_case "keeper wake queue evidence rejects stale occurrence" `Quick
             test_keeper_wake_queue_evidence_rejects_stale_occurrence
         ; test_case "dashboard live supported non-terminal evidence matches supported request"
@@ -797,8 +873,8 @@ let () =
             test_dashboard_live_supported_non_terminal_evidence_reports_absent_supported_payloads
         ; test_case "keeper wake dashboard tracks runtime inflight lease" `Quick
             test_keeper_wake_dashboard_tracks_runtime_inflight_lease
-        ; test_case "keeper wake ledger failure keeps dispatch success visible" `Quick
-            test_keeper_wake_ledger_failure_keeps_dispatch_success_visible
+        ; test_case "keeper wake ledger failure is retryable" `Quick
+            test_keeper_wake_ledger_failure_is_retryable
         ; test_case "keeper wake rejects invalid keeper name" `Quick
             test_keeper_wake_consumer_rejects_invalid_keeper_name
         ] )


### PR DESCRIPTION
## Stack C/3 — acknowledged occurrence fence

Depends on #24550 (and transitively #24549).

- Treats the exact ACK reaction-ledger row keyed by schedule `signal_id` as the durable terminal tombstone.
- Records ACK evidence before retiring the transition outbox entry.
- After ACK + projection + startup recovery, retry observes the exact tombstone and skips both enqueue and wake.
- Before ACK, retry still uses full durable queue-state dedup and can wake the owning Keeper lane as required.
- Makes reaction-ledger reads strict on this invariant path; malformed/read failures become typed retryable failures rather than silent success.
- Emits truthful typed receipt state: `awaiting_ack` or `already_acked`, without fabricating enqueue metrics on replay.
- Adds a regression covering dispatch → lease ACK → outbox projection → startup recovery → retry, proving no second wake and no queued duplicate.

The scheduler remains product-blind. This introduces no TTL, cap, arbitrary retry count, heuristic risk level, or new governance store.

## Verification

- Incremental stack diff: 10 files, +394/-100 (below the requested 400-addition boundary).
- `ocamlformat --check` passed for changed OCaml files.
- `git diff --check` passed.
- Static ratchets found no new `failwith`, `assert false`, `Obj.magic`, TODO/stub markers, implicit execution limits, budget exhaustion, hard-forbidden, or risk-level symbols.
- Local Dune was intentionally not rerun per project instruction; PR CI is the build authority.
