### PR TITLE
feat(keeper): add typed delegation run references

### DIFF
--- a/lib/keeper/keeper_invocation_contract.ml
+++ b/lib/keeper/keeper_invocation_contract.ml
@@ -222,7 +222,7 @@ let run_ref_of_json json =
 
 let run_id reference = reference.run_id
 
-let run_ref_matches_entry reference entry =
+let run_ref_matches_entry reference (entry : Keeper_msg_async.entry) =
   String.equal reference.run_id entry.Keeper_msg_async.request_id
   && String.equal
        (target_name_of_target reference.target)
@@ -346,7 +346,7 @@ let entry_result = function
     ]
 ;;
 
-let delegate_entry_to_json entry =
+let delegate_entry_to_json (entry : Keeper_msg_async.entry) =
   let contract = result_contract entry in
   let* target_name =
     Keeper_id.Keeper_name.of_string entry.Keeper_msg_async.keeper_name

--- a/lib/keeper/keeper_invocation_contract.ml
+++ b/lib/keeper/keeper_invocation_contract.ml
@@ -319,7 +319,11 @@ let delegate_submission_error_to_json request = function
 let entry_result = function
   | Keeper_msg_async.Queued | Keeper_msg_async.Running -> []
   | Keeper_msg_async.Done { body; data; _ } ->
-    [ "result", Option.value ~default:(`String body) data ]
+    [ ( "result"
+      , match data with
+        | Some value -> value
+        | None -> `String body )
+    ]
   | Keeper_msg_async.Lost { reason } ->
     [ "result", `Assoc [ "error", `String "invocation_lost"; "reason", `String reason ] ]
   | Keeper_msg_async.Cancelled { reason; cancelled_by } ->

--- a/lib/keeper/keeper_invocation_contract.ml
+++ b/lib/keeper/keeper_invocation_contract.ml
@@ -35,8 +35,66 @@ type request_error =
   | Invalid_target of string
   | Empty_prompt
   | Invalid_entry_projection
+  | Invalid_wire_value of
+      { field : string
+      ; expected : string
+      }
+  | Run_ref_mismatch
 
 let ( let* ) = Result.bind
+
+let invalid_wire_value ~field ~expected =
+  Error (Invalid_wire_value { field; expected })
+;;
+
+let object_fields ~field = function
+  | `Assoc fields -> Ok fields
+  | _ -> invalid_wire_value ~field ~expected:"object"
+;;
+
+let exact_fields ~field ~allowed fields =
+  let keys = List.map fst fields in
+  if List.length keys <> List.length (List.sort_uniq String.compare keys)
+  then invalid_wire_value ~field ~expected:"object with unique fields"
+  else
+    match List.find_opt (fun key -> not (List.mem key allowed)) keys with
+    | None -> Ok ()
+    | Some key ->
+      invalid_wire_value
+        ~field:(field ^ "." ^ key)
+        ~expected:"no undeclared field"
+;;
+
+let required_field ~field name fields =
+  match List.assoc_opt name fields with
+  | Some value -> Ok value
+  | None -> invalid_wire_value ~field:(field ^ "." ^ name) ~expected:"required field"
+;;
+
+let string_value ~field = function
+  | `String value -> Ok value
+  | _ -> invalid_wire_value ~field ~expected:"string"
+;;
+
+let target_of_json json =
+  let* fields = object_fields ~field:"target" json in
+  let* () = exact_fields ~field:"target" ~allowed:[ "kind"; "name" ] fields in
+  let* kind = required_field ~field:"target" "kind" fields in
+  let* kind = string_value ~field:"target.kind" kind in
+  let* name = required_field ~field:"target" "name" fields in
+  let* name = string_value ~field:"target.name" name in
+  if not (String.equal kind "keeper")
+  then invalid_wire_value ~field:"target.kind" ~expected:"keeper"
+  else
+    Keeper_id.Keeper_name.of_string name
+    |> Result.map (fun name -> Keeper name)
+    |> Result.map_error (fun reason -> Invalid_target reason)
+;;
+
+let capability_of_json ~field = function
+  | `String value when String.equal value "invoke_turn" -> Ok Invoke_turn
+  | _ -> invalid_wire_value ~field ~expected:"invoke_turn"
+;;
 
 let request ~keeper_name ~prompt =
   let* keeper_name =
@@ -48,15 +106,38 @@ let request ~keeper_name ~prompt =
   else Ok { target = Keeper keeper_name; capability = Invoke_turn; prompt }
 ;;
 
+let request_of_json json =
+  let* fields = object_fields ~field:"delegate" json in
+  let* () =
+    exact_fields
+      ~field:"delegate"
+      ~allowed:[ "target"; "capability"; "prompt" ]
+      fields
+  in
+  let* target_json = required_field ~field:"delegate" "target" fields in
+  let* target = target_of_json target_json in
+  let* capability_json = required_field ~field:"delegate" "capability" fields in
+  let* capability = capability_of_json ~field:"delegate.capability" capability_json in
+  let* prompt_json = required_field ~field:"delegate" "prompt" fields in
+  let* prompt = string_value ~field:"delegate.prompt" prompt_json in
+  if String.equal prompt "" then Error Empty_prompt else Ok { target; capability; prompt }
+;;
+
 let request_error_to_string = function
   | Invalid_target reason -> reason
   | Empty_prompt -> "message is required"
   | Invalid_entry_projection -> "Keeper invocation entry projection is not an object"
+  | Invalid_wire_value { field; expected } ->
+    Printf.sprintf "%s must be %s" field expected
+  | Run_ref_mismatch -> "run_ref does not identify the stored Keeper invocation"
+;;
+
+let target_name_of_target = function
+  | Keeper name -> Keeper_id.Keeper_name.to_string name
 ;;
 
 let target_name (request : request) =
-  match request.target with
-  | Keeper name -> Keeper_id.Keeper_name.to_string name
+  target_name_of_target request.target
 ;;
 
 let prompt (request : request) = request.prompt
@@ -83,8 +164,7 @@ let submission_receipt (request : request) outcome =
     Reconciliation_required { run_ref = reference; reason }
 ;;
 
-let result_contract entry =
-  match entry.Keeper_msg_async.status with
+let result_contract_of_status = function
   | Keeper_msg_async.Queued -> Awaiting_execution
   | Keeper_msg_async.Running -> Running
   | Keeper_msg_async.Cancelling _ -> Cancellation_requested
@@ -98,6 +178,8 @@ let result_contract entry =
      | Keeper_turn_outcome.Visible_reply
      | Keeper_turn_outcome.No_visible_reply -> Completed)
 ;;
+
+let result_contract entry = result_contract_of_status entry.Keeper_msg_async.status
 
 let capability_to_string = function
   | Invoke_turn -> "invoke_turn"
@@ -119,6 +201,34 @@ let run_ref_to_json reference =
     ]
 ;;
 
+let run_ref_of_json json =
+  let* fields = object_fields ~field:"run_ref" json in
+  let* () =
+    exact_fields
+      ~field:"run_ref"
+      ~allowed:[ "run_id"; "target"; "capability" ]
+      fields
+  in
+  let* run_id_json = required_field ~field:"run_ref" "run_id" fields in
+  let* run_id = string_value ~field:"run_ref.run_id" run_id_json in
+  let* target_json = required_field ~field:"run_ref" "target" fields in
+  let* target = target_of_json target_json in
+  let* capability_json = required_field ~field:"run_ref" "capability" fields in
+  let* capability = capability_of_json ~field:"run_ref.capability" capability_json in
+  if String.equal run_id ""
+  then invalid_wire_value ~field:"run_ref.run_id" ~expected:"non-empty string"
+  else Ok { run_id; target; capability }
+;;
+
+let run_id reference = reference.run_id
+
+let run_ref_matches_entry reference entry =
+  String.equal reference.run_id entry.Keeper_msg_async.request_id
+  && String.equal
+       (target_name_of_target reference.target)
+       entry.Keeper_msg_async.keeper_name
+;;
+
 let result_contract_to_string = function
   | Awaiting_execution -> "awaiting_execution"
   | Publication_uncertain -> "publication_uncertain"
@@ -131,12 +241,12 @@ let result_contract_to_string = function
 ;;
 
 let submission_to_json (request : request) outcome =
-  let common reference status result_contract =
+  let common reference status contract =
     [ "request_id", `String outcome.Keeper_msg_async.request_id
     ; "keeper_name", `String (target_name request)
     ; "status", `String status
     ; "run_ref", run_ref_to_json reference
-    ; "result_contract", `String (result_contract_to_string result_contract)
+    ; "result_contract", `String (result_contract_to_string contract)
     ]
   in
   match submission_receipt request outcome with
@@ -155,6 +265,112 @@ let submission_to_json (request : request) outcome =
            , `String
                "Request publication is uncertain. Query masc_keeper_msg_result with this exact run_ref.run_id; do not resubmit." )
          ])
+;;
+
+let delegate_submission_to_json (request : request) outcome =
+  let common reference result_contract =
+    [ "run_ref", run_ref_to_json reference
+    ; "result_contract", `String (result_contract_to_string result_contract)
+    ]
+  in
+  match submission_receipt request outcome with
+  | Durable_run reference ->
+    `Assoc
+      (common reference Awaiting_execution
+       @ [ ( "message"
+           , `String
+               "Keeper turn accepted. The caller lane may continue; query masc_keeper_delegate_status with the exact run_ref." )
+         ])
+  | Reconciliation_required { run_ref = reference; reason } ->
+    `Assoc
+      (common reference Publication_uncertain
+       @ [ "reason", `String reason
+         ; ( "operator_instruction"
+           , `String
+               "Request publication is uncertain. Query masc_keeper_delegate_status with this exact run_ref; do not resubmit." )
+         ])
+;;
+
+let delegate_submission_error_to_json request = function
+  | Keeper_msg_async.Submit_rejected rejection ->
+    Keeper_msg_async.access_rejection_to_json rejection
+  | Keeper_msg_async.Submit_invalid_keeper_name { reason } ->
+    `Assoc [ "error", `String "invalid_target"; "message", `String reason ]
+  | Keeper_msg_async.Initial_persistence_failed { reason } ->
+    `Assoc [ "error", `String "invocation_persistence_failed"; "message", `String reason ]
+  | Keeper_msg_async.Acceptance_persistence_failed { request_id; reason } ->
+    `Assoc
+      [ "error", `String "invocation_acceptance_uncertain"
+      ; "run_ref", run_ref_to_json (run_ref request request_id)
+      ; "result_contract", `String (result_contract_to_string Publication_uncertain)
+      ; "message", `String reason
+      ]
+  | Keeper_msg_async.Background_switch_unavailable { reason } ->
+    `Assoc [ "error", `String "background_switch_unavailable"; "message", `String reason ]
+  | Keeper_msg_async.Background_fork_failed { request_id; reason } ->
+    `Assoc
+      [ "error", `String "invocation_background_start_failed"
+      ; "run_ref", run_ref_to_json (run_ref request request_id)
+      ; "result_contract", `String (result_contract_to_string Failed)
+      ; "message", `String reason
+      ]
+;;
+
+let entry_result = function
+  | Keeper_msg_async.Queued | Keeper_msg_async.Running -> []
+  | Keeper_msg_async.Done { body; data; _ } ->
+    [ "result", Option.value ~default:(`String body) data ]
+  | Keeper_msg_async.Lost { reason } ->
+    [ "result", `Assoc [ "error", `String "invocation_lost"; "reason", `String reason ] ]
+  | Keeper_msg_async.Cancelled { reason; cancelled_by } ->
+    [ ( "result"
+      , `Assoc
+          [ "reason", `String reason
+          ; "cancelled_by", `String cancelled_by
+          ] )
+    ]
+  | Keeper_msg_async.Cancelling { reason; cancelled_by } ->
+    [ ( "result"
+      , `Assoc
+          [ "reason", `String reason
+          ; "cancelled_by", `String cancelled_by
+          ] )
+    ]
+  | Keeper_msg_async.Persistence_failed { attempted_status; reason } ->
+    [ ( "result"
+      , `Assoc
+          [ "error", `String "invocation_persistence_failed"
+          ; "attempted_status", `String attempted_status
+          ; "reason", `String reason
+          ] )
+    ]
+;;
+
+let delegate_entry_to_json entry =
+  let contract = result_contract entry in
+  let* target_name =
+    Keeper_id.Keeper_name.of_string entry.Keeper_msg_async.keeper_name
+    |> Result.map_error (fun reason -> Invalid_target reason)
+  in
+  let reference =
+    { run_id = entry.request_id
+    ; target = Keeper target_name
+    ; capability = Invoke_turn
+    }
+  in
+  let timing =
+    match entry.completed_at with
+    | Some completed_at -> [ "completed_at", `Float completed_at ]
+    | None -> []
+  in
+  Ok
+    (`Assoc
+       ([ "run_ref", run_ref_to_json reference
+        ; "result_contract", `String (result_contract_to_string contract)
+        ; "submitted_at", `Float entry.submitted_at
+        ]
+        @ timing
+        @ entry_result entry.status))
 ;;
 
 let entry_to_json entry =
@@ -178,4 +394,43 @@ let entry_to_json entry =
             ; "result_contract", `String (result_contract_to_string contract)
             ]))
   | _ -> Error Invalid_entry_projection
+;;
+
+let delegate_cancellation_to_json reference result =
+  let common = [ "run_ref", run_ref_to_json reference ] in
+  let contract status =
+    [ "result_contract", `String (result_contract_to_string status) ]
+  in
+  let durability = function
+    | Keeper_msg_async.Durably_committed -> [ "durability", `String "durable" ]
+    | Keeper_msg_async.Published_unconfirmed { reason } ->
+      [ "durability", `String "publication_uncertain"; "warning", `String reason ]
+  in
+  let fields =
+    match result with
+    | Keeper_msg_async.Cancellation_requested state ->
+      contract Cancellation_requested @ durability state
+    | Keeper_msg_async.Cancel_not_found -> [ "error", `String "run_not_found" ]
+    | Keeper_msg_async.Cancel_unreadable reason ->
+      [ "error", `String "invocation_record_unreadable"; "message", `String reason ]
+    | Keeper_msg_async.Cancel_rejected rejection ->
+      [ "error", `String "invocation_access_rejected"
+      ; "reason", Keeper_msg_async.access_rejection_to_json rejection
+      ]
+    | Keeper_msg_async.Cancel_worker_ownership_unknown status ->
+      contract (result_contract_of_status status)
+      @ [ "error", `String "invocation_worker_ownership_unknown" ]
+    | Keeper_msg_async.Cancel_already_terminal status ->
+      contract (result_contract_of_status status)
+      @ [ "error", `String "invocation_already_terminal" ]
+    | Keeper_msg_async.Cancel_persistence_failed { reason } ->
+      [ "error", `String "cancellation_persistence_failed"; "message", `String reason ]
+    | Keeper_msg_async.Cancel_worker_signal_failed { durability = state; reason } ->
+      contract Cancellation_requested
+      @ durability state
+      @ [ "error", `String "cancellation_worker_signal_failed"; "message", `String reason ]
+    | Keeper_msg_async.Cancel_state_invariant_failed { reason } ->
+      [ "error", `String "cancellation_state_invariant_failed"; "message", `String reason ]
+  in
+  `Assoc (common @ fields)
 ;;

--- a/lib/keeper/keeper_invocation_contract.mli
+++ b/lib/keeper/keeper_invocation_contract.mli
@@ -10,11 +10,7 @@ type target = Keeper of Keeper_id.Keeper_name.t
 
 type request
 
-type run_ref =
-  { run_id : string
-  ; target : target
-  ; capability : capability
-  }
+type run_ref
 
 type submission_receipt =
   | Durable_run of run_ref
@@ -37,11 +33,24 @@ type request_error =
   | Invalid_target of string
   | Empty_prompt
   | Invalid_entry_projection
+  | Invalid_wire_value of
+      { field : string
+      ; expected : string
+      }
+  | Run_ref_mismatch
 
 val request : keeper_name:string -> prompt:string -> (request, request_error) result
+val request_of_json : Yojson.Safe.t -> (request, request_error) result
 val request_error_to_string : request_error -> string
 val target_name : request -> string
 val prompt : request -> string
+val target_of_json : Yojson.Safe.t -> (target, request_error) result
+val target_to_json : target -> Yojson.Safe.t
+val target_name_of_target : target -> string
+val run_ref_of_json : Yojson.Safe.t -> (run_ref, request_error) result
+val run_ref_to_json : run_ref -> Yojson.Safe.t
+val run_id : run_ref -> string
+val run_ref_matches_entry : run_ref -> Keeper_msg_async.entry -> bool
 
 val submit
   :  background_sw:Eio.Switch.t
@@ -60,6 +69,19 @@ val result_contract : Keeper_msg_async.entry -> result_contract
 val submission_to_json
   :  request -> Keeper_msg_async.submit_outcome -> Yojson.Safe.t
 
+val delegate_submission_to_json
+  :  request -> Keeper_msg_async.submit_outcome -> Yojson.Safe.t
+
+val delegate_submission_error_to_json
+  :  request -> Keeper_msg_async.submit_error -> Yojson.Safe.t
+
+val delegate_cancellation_to_json
+  :  run_ref -> Keeper_msg_async.cancel_result -> Yojson.Safe.t
+
 val entry_to_json
+  :  Keeper_msg_async.entry
+  -> (Yojson.Safe.t, request_error) result
+
+val delegate_entry_to_json
   :  Keeper_msg_async.entry
   -> (Yojson.Safe.t, request_error) result

--- a/test/test_keeper_unified_turn_event_bus.ml
+++ b/test/test_keeper_unified_turn_event_bus.ml
@@ -439,6 +439,95 @@ let test_keeper_msg_submission_projection_has_unique_keys () =
     (Invocation.result_contract failed_entry = Invocation.Failed)
 ;;
 
+let test_typed_keeper_invocation_wire_contract () =
+  let request_json =
+    `Assoc
+      [ ( "target"
+        , `Assoc [ "kind", `String "keeper"; "name", `String "projection-keeper" ] )
+      ; "capability", `String "invoke_turn"
+      ; "prompt", `String "inspect this request"
+      ]
+  in
+  let request =
+    match Invocation.request_of_json request_json with
+    | Ok request -> request
+    | Error error -> Alcotest.fail (Invocation.request_error_to_string error)
+  in
+  check string "typed target decoded" "projection-keeper"
+    (Invocation.target_name request);
+  (match
+     Invocation.request_of_json
+       (`Assoc [ "name", `String "projection-keeper"; "message", `String "legacy" ])
+   with
+   | Error (Invocation.Invalid_wire_value _) -> ()
+   | Error error ->
+     Alcotest.failf "unexpected legacy-input rejection: %s"
+       (Invocation.request_error_to_string error)
+   | Ok _ -> Alcotest.fail "legacy name/message input must not decode");
+  let outcome : Kmsg.submit_outcome =
+    { request_id = "typed-run-ref"; acceptance = Kmsg.Durably_accepted }
+  in
+  let submission_fields =
+    Invocation.delegate_submission_to_json request outcome
+    |> require_unique_assoc "typed submission"
+  in
+  check bool "raw request id omitted" false
+    (List.mem_assoc "request_id" submission_fields);
+  check bool "legacy status omitted" false
+    (List.mem_assoc "status" submission_fields);
+  let run_ref_json =
+    match List.assoc_opt "run_ref" submission_fields with
+    | Some value -> value
+    | None -> Alcotest.fail "typed submission missing run_ref"
+  in
+  let run_ref =
+    match Invocation.run_ref_of_json run_ref_json with
+    | Ok reference -> reference
+    | Error error -> Alcotest.fail (Invocation.request_error_to_string error)
+  in
+  let entry : Kmsg.entry =
+    { request_id = "typed-run-ref"
+    ; keeper_name = "projection-keeper"
+    ; base_path = "/projection/base"
+    ; submitted_by = "projection-caller"
+    ; status = Kmsg.Running
+    ; submitted_at = 0.0
+    ; completed_at = None
+    }
+  in
+  check bool "run ref binds exact durable entry" true
+    (Invocation.run_ref_matches_entry run_ref entry);
+  let wrong_target_ref =
+    match
+      Invocation.run_ref_of_json
+        (`Assoc
+           [ "run_id", `String "typed-run-ref"
+           ; "target", `Assoc [ "kind", `String "keeper"; "name", `String "other" ]
+           ; "capability", `String "invoke_turn"
+           ])
+    with
+    | Ok reference -> reference
+    | Error error -> Alcotest.fail (Invocation.request_error_to_string error)
+  in
+  check bool "same run id cannot retarget invocation" false
+    (Invocation.run_ref_matches_entry wrong_target_ref entry);
+  let entry_fields =
+    match Invocation.delegate_entry_to_json entry with
+    | Ok json -> require_unique_assoc "typed entry" json
+    | Error error -> Alcotest.fail (Invocation.request_error_to_string error)
+  in
+  check bool "entry omits raw request id" false
+    (List.mem_assoc "request_id" entry_fields);
+  check bool "entry exposes result contract" true
+    (List.mem_assoc "result_contract" entry_fields);
+  let cancellation_fields =
+    Invocation.delegate_cancellation_to_json run_ref Kmsg.Cancel_not_found
+    |> require_unique_assoc "typed cancellation"
+  in
+  check bool "cancellation omits raw request id" false
+    (List.mem_assoc "request_id" cancellation_fields)
+;;
+
 let test_take_drain_cancel_clears_active_without_spin () =
   let open EB.For_testing in
   let t = EB.create ~keeper_name:"k" ~turn_id:1 () in
@@ -522,6 +611,8 @@ let () =
             test_keeper_msg_async_submit_uses_captured_event_bus
         ; test_case "keeper msg submission JSON keys are unique" `Quick
             test_keeper_msg_submission_projection_has_unique_keys
+        ; test_case "typed Keeper invocation wire contract" `Quick
+            test_typed_keeper_invocation_wire_contract
         ] )
     ; ( "background-drain"
       , [ test_case "continues after first poll" `Quick


### PR DESCRIPTION
## What changed

- adds closed JSON decoders for typed Keeper targets, invocation requests, and durable run references
- makes `run_ref` opaque and validates the exact run id plus Keeper target against the durable entry
- adds typed submission, failure, status-entry, and cancellation projections without raw `request_id` or legacy string status fields
- preserves the currently registered `keeper_msg` family unchanged; this is the independently buildable prerequisite for the stacked atomic surface hard-cut

## Why

Goal 5 needs one typed boundary before the external tool family can be replaced atomically without a compatibility alias or a temporary loss of status, cancellation, or list functionality.

## Validation

- `ocamlformat --check lib/keeper/keeper_invocation_contract.ml lib/keeper/keeper_invocation_contract.mli test/test_keeper_unified_turn_event_bus.ml`
- `git diff --check`
- focused wrapper build was attempted but correctly refused because unrelated bare `dune build` processes were already bypassing the machine-wide wrapper lock; PR CI remains build authority

## Scope

379 additions / 11 deletions. No registry, scheduler, Keeper lane owner, or OAS contract changes.
