### PR TITLE
fix(keeper): stop wall-budget killing HITL summary LLM calls

### DIFF
--- a/lib/keeper/keeper_llm_bridge.ml
+++ b/lib/keeper/keeper_llm_bridge.ml
@@ -262,8 +262,20 @@ let run_with_timeout_and_fallback
               ; phase = None
               }))
     in
-    (try Eio.Time.with_timeout_exn clock timeout_s fn with
+    (* No wall-clock budget kill (fail-open directive; RFC-0305 non-reintroduction
+       rule). [timeout_s] is NOT used to force-kill the keeper LLM execution: a
+       bridge budget that fired at 30s while the provider legitimately needed
+       60s+ turned every HITL summary turn into kill -> Error -> retry churn that
+       burned API cost and never produced a summary. The call now runs to natural
+       completion. A genuine transport hang (dead socket, no bytes) is bounded by
+       the HTTP client's own connect/idle timeouts, not by a bridge wall budget;
+       if that inner transport itself raises [Eio.Time.Timeout] we still surface
+       it honestly below. See planning/claude-plans/oas-execution-cancellability.md. *)
+    (try fn () with
      | Eio.Time.Timeout ->
+       (* Inner transport-level timeout (the provider call's own deadline), not a
+          bridge wall budget being enforced here. Surface it as a provider timeout
+          so the operator can inspect the stream. *)
        let wall = elapsed () in
        timeout_error ~wall
      | Eio.Cancel.Cancelled inner_exn as exn ->

--- a/lib/keeper/keeper_llm_bridge.mli
+++ b/lib/keeper/keeper_llm_bridge.mli
@@ -10,13 +10,22 @@ type cancel_classification =
     classified as [Inner_timeout_cancel] so provider/runtime timeout noise stays
     separate from unknown parent cancellation. *)
 
-(** Runs a generic Eio execution (usually an OAS Agent.run or Model.call) with a strict
-    structural timeout.
+(** Runs a generic Eio execution (usually an OAS Agent.run or Model.call).
 
-    - Timeout: OAS-local context mutations are discarded (functional rollback),
-      external tool side effects are not reverted, returns [Error (Agent_sdk.Error.Api Timeout)].
+    [timeout_s] is an advisory budget only — it does NOT force-kill the
+    execution. A wall-clock budget that killed a still-streaming provider call
+    turned slow-but-healthy turns into kill -> retry churn that never produced a
+    result, so the call runs to natural completion instead (fail-open directive;
+    RFC-0305 non-reintroduction rule).
+
+    - Slow call: runs to completion and returns the function's own result; it is
+      not interrupted for overrunning [timeout_s].
+    - Inner transport timeout: if the underlying provider call raises
+      [Eio.Time.Timeout] on its own connect/idle deadline, that is surfaced as
+      [Error (Agent_sdk.Error.Api Timeout)] (OAS-local context rollback only;
+      external tool side effects are not reverted).
     - Missing Eio clock: returns [Error (Agent_sdk.Error.Internal _)] without
-      running the function because the timeout cannot be enforced.
+      running the function (the Eio environment must be initialised first).
     - Cancellation (server shutdown / parent fiber cancel): re-raises
       [Eio.Cancel.Cancelled] so the caller exits immediately without retrying.
 

--- a/test/test_keeper_llm_bridge.ml
+++ b/test/test_keeper_llm_bridge.ml
@@ -98,25 +98,26 @@ let test_env_uninitialized_domain_returns_none () =
           (Domain.join worker))))
 ;;
 
-let test_timeout_log_carries_failure_envelope () =
+let test_slow_call_is_not_wall_budget_killed () =
   Eio_main.run (fun env ->
     Eio.Switch.run (fun sw ->
       Masc_eio_env.reset_for_test ();
       Fun.protect ~finally:Masc_eio_env.reset_for_test (fun () ->
         Masc_eio_env.init ~sw ~net:(Eio.Stdenv.net env) ~clock:(Eio.Stdenv.clock env) ();
+        (* fail-open directive: a call that overruns [timeout_s] must run to
+           natural completion, not be force-killed by a bridge wall budget.
+           Regression guard for the 30s HITL-summary churn (kill -> retry). *)
         match
           Keeper_llm_bridge.run_with_timeout_and_fallback ~timeout_s:0.001 (fun () ->
             Eio.Time.sleep (Eio.Stdenv.clock env) 0.02;
             Ok "late")
         with
-        | Error (Agent_sdk.Error.Api (Timeout _)) ->
-          assert_latest_failure_envelope
-            ~label:"timeout"
-            ~needle:"OAS execution timed out"
-            ~cause_code:"provider_timeout"
-            ~operator_action:"inspect_provider_stream"
-        | Error err -> Alcotest.fail (Agent_sdk.Error.to_string err)
-        | Ok value -> Alcotest.failf "unexpected success: %s" value)))
+        | Ok "late" -> ()
+        | Ok other -> Alcotest.failf "unexpected success payload: %s" other
+        | Error err ->
+          Alcotest.failf
+            "slow call was killed instead of completing: %s"
+            (Agent_sdk.Error.to_string err))))
 ;;
 
 let test_parent_timeout_cancel_logs_info () =
@@ -253,9 +254,9 @@ let () =
             `Quick
             test_env_uninitialized_domain_returns_none
         ; Alcotest.test_case
-            "timeout log carries failure envelope"
+            "slow call is not wall-budget killed"
             `Quick
-            test_timeout_log_carries_failure_envelope
+            test_slow_call_is_not_wall_budget_killed
         ; Alcotest.test_case
             "parent timeout cancel logs info"
             `Quick


### PR DESCRIPTION
## What

`keeper_llm_bridge.run_with_timeout_and_fallback` wrapped the provider call in
`Eio.Time.with_timeout_exn clock timeout_s`, force-killing any execution that
overran `timeout_s`. Its only caller is `hitl_summary_worker` (budget default
30s). Providers that legitimately need 60s+ (kimi-k2-6 and similar) were killed
every turn -> `Error` -> `on_failure ~retryable:true` -> retry, so HITL context
summaries never completed while the loop burned API cost and CPU.

Observed on the live server: 100+ `keeper_llm_bridge: OAS execution timed out
after 30.0s (budget=30s)` in a single window — the top driver of a sustained
~40% CPU runtime spin.

## Change

- Remove the wall-budget kill: `with_timeout_exn clock timeout_s fn` -> `fn ()`.
  The call runs to natural completion and returns its own result.
- Preserve `Eio.Cancel.Cancelled` re-raise (server shutdown / parent cancel —
  structured concurrency is untouched).
- Preserve genuine inner-transport `Eio.Time.Timeout` surfacing (the provider
  call's own connect/idle deadline still reports as a provider timeout).
- Genuine hangs stay bounded by the HTTP client's own connect/idle timeouts,
  not by a bridge-level wall budget (which was redundant for dead sockets and
  harmful for slow-but-streaming responses).
- `.mli` contract updated from "strict structural timeout" to advisory.
- The test that asserted the kill is rewritten as a regression guard that a
  slow call completes instead of being killed.

## Test

`dune exec test/test_keeper_llm_bridge.exe` — 8/8 pass, including the new
"slow call is not wall-budget killed".

## Rationale

Fail-open directive / RFC-0305 non-reintroduction rule: a slow or unavailable
component is a local, observed condition, never a forced kill. Sibling
wall-budget kills (`masc_oas_bridge.run_safe`, keeper
memory/compaction/consolidation/librarian/vision summarizers) are being removed
in a follow-up sweep.

WORKAROUND-WAIVED: this PR removes a wall-budget kill (the symptom-suppression
anti-pattern), it does not add a cap/cooldown/dedup/repair. No RFC-gated
subsystem is touched (keeper_llm_bridge is not credential/operator/sandbox/hooks/workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
