### PR TITLE
fix(lock): make durable admission cancellable

### DIFF
--- a/lib/process/file_lock_eio.ml
+++ b/lib/process/file_lock_eio.ml
@@ -15,6 +15,44 @@ module SMap = Set_util.StringMap
 
 exception Flock_timeout of { caller : string; path : string; attempts : int }
 
+type durable_lock_phase =
+  | Open_lock_file
+  | Acquire_process_lock
+  | Release_process_lock
+
+type unix_failure =
+  { error : Unix.error
+  ; operation : string
+  ; argument : string
+  }
+
+type durable_lock_error =
+  { lock_path : string
+  ; phase : durable_lock_phase
+  ; cause : unix_failure
+  ; cleanup_failure : unix_failure option
+  }
+
+let durable_lock_phase_to_string = function
+  | Open_lock_file -> "open_lock_file"
+  | Acquire_process_lock -> "acquire_process_lock"
+  | Release_process_lock -> "release_process_lock"
+
+let durable_lock_error_to_string error =
+  let failure_to_string failure =
+    Printf.sprintf "%s(%s): %s"
+      failure.operation
+      failure.argument
+      (Unix.error_message failure.error)
+  in
+  Printf.sprintf "lock_path=%s phase=%s cause=%s%s"
+    error.lock_path
+    (durable_lock_phase_to_string error.phase)
+    (failure_to_string error.cause)
+    (match error.cleanup_failure with
+     | None -> ""
+     | Some failure -> " cleanup=" ^ failure_to_string failure)
+
 (** Observability hook fired after each [acquire_flock_retry*] attempt
     sequence completes — once on success, once on timeout.  Wired at
     startup ([lib/workspace.ml]) to a Otel_metric_store counter + histogram so
@@ -65,16 +103,18 @@ let rec atomic_update atomic f =
 
 let rec atomic_update_with_result atomic f =
   let old_val = Atomic.get atomic in
-  let new_val, result = f old_val in
+  let new_val, result, rollback = f old_val in
   if Atomic.compare_and_set atomic old_val new_val then result
   else begin
+    rollback ();
     observe_cas_retry ();
     atomic_update_with_result atomic f
   end
 
 type lock_entry = {
   mu : Eio.Mutex.t;
-  mutable last_used : float;
+  cross_context_mu : Stdlib.Mutex.t;
+  last_used : float Atomic.t;
   active : int Atomic.t;   (** Number of fibers currently holding or waiting on this mutex *)
 }
 
@@ -101,7 +141,8 @@ let prune_stale_entries () =
     if SMap.cardinal state.entries > max_lock_entries then
       let now = Time_compat.now () in
       let entries = SMap.filter (fun _path entry ->
-        Atomic.get entry.active > 0 || now -. entry.last_used <= stale_lock_seconds
+        Atomic.get entry.active > 0
+        || now -. Atomic.get entry.last_used <= stale_lock_seconds
       ) state.entries in
       publish_entries state entries
     else state
@@ -109,23 +150,30 @@ let prune_stale_entries () =
 
 (** Get or create a lock entry for the given file path.
     Increments [active] to prevent prune_stale_entries from removing
-    in-use entries (see TLA+ FileLockStarvation spec).
-    Falls back to direct Hashtbl access when no Eio context is available
-    (e.g. in unit tests that don't use Eio_main.run). *)
+    in-use entries (see TLA+ FileLockStarvation spec). *)
 let get_entry path =
   prune_stale_entries ();
   let entry =
     atomic_update_with_result table (fun state ->
       match SMap.find_opt path state.entries with
       | Some entry ->
-        entry.last_used <- Time_compat.now ();
-        (state, entry)
+        (* Publish a new version so a stale prune CAS cannot erase this reservation. *)
+        Atomic.set entry.last_used (Time_compat.now ());
+        Atomic.incr entry.active;
+        ( { state with version = state.version + 1 }
+        , entry
+        , fun () -> ignore (Atomic.fetch_and_add entry.active (-1)) )
       | None ->
-        let entry = { mu = Eio.Mutex.create (); last_used = Time_compat.now (); active = Atomic.make 0 } in
+        let entry =
+          { mu = Eio.Mutex.create ()
+          ; cross_context_mu = Stdlib.Mutex.create ()
+          ; last_used = Atomic.make (Time_compat.now ())
+          ; active = Atomic.make 1
+          }
+        in
         let entries = SMap.add path entry state.entries in
-        (publish_entries state entries, entry))
+        (publish_entries state entries, entry, Fun.id))
   in
-  Atomic.incr entry.active;
   entry
 
 let release_entry entry =
@@ -225,14 +273,31 @@ let release_flock_fd fd =
       (try Unix.lockf fd Unix.F_ULOCK 0 with Unix.Unix_error _ -> ());
       Unix.close fd)
 
-(** Run [f] while holding only the cooperative per-path mutex.
+let rec lock_cross_context_cooperatively mutex =
+  if Stdlib.Mutex.try_lock mutex
+  then ()
+  else (
+    Eio.Fiber.yield ();
+    lock_cross_context_cooperatively mutex)
+
+let with_entry_lock entry f =
+  match Eio_guard.execution_context () with
+  | Eio_guard.Non_eio -> Stdlib.Mutex.protect entry.cross_context_mu f
+  | Eio_guard.Eio_fiber ->
+    Eio.Mutex.use_ro entry.mu (fun () ->
+      lock_cross_context_cooperatively entry.cross_context_mu;
+      Fun.protect
+        ~finally:(fun () -> Stdlib.Mutex.unlock entry.cross_context_mu)
+        f)
+
+(** Run [f] while holding only the cross-context per-path mutex.
     Use this for in-memory backends that need single-process fiber
     serialization but do not have a real filesystem artifact to flock. *)
 let with_mutex path f =
   let entry = get_entry path in
   Common.protect ~module_name:"file_lock_eio" ~finally_label:"release_entry"
     ~finally:(fun () -> release_entry entry)
-    (fun () -> Eio_guard.with_mutex entry.mu f)
+    (fun () -> with_entry_lock entry f)
 
 (** Run [f] while holding both the cooperative Eio.Mutex and an
     OS-level flock on [path].lock. The flock uses non-blocking F_TLOCK
@@ -250,6 +315,204 @@ let with_lock ?clock path f =
       f
   in
   with_mutex path (fun () -> run_with_flock ())
+
+let unix_failure (error, operation, argument) =
+  { error; operation; argument }
+
+let close_fd_result fd =
+  try
+    run_blocking_lock_op (fun () -> Unix.close fd);
+    Ok ()
+  with
+  | Unix.Unix_error (error, operation, argument) ->
+    Error (unix_failure (error, operation, argument))
+
+let release_durable_fd_result fd =
+  let unlock =
+    try
+      run_blocking_lock_op (fun () -> Unix.lockf fd Unix.F_ULOCK 0);
+      Ok ()
+    with
+    | Unix.Unix_error (error, operation, argument) ->
+      Error (unix_failure (error, operation, argument))
+  in
+  let close = close_fd_result fd in
+  match unlock, close with
+  | Ok (), Ok () -> Ok ()
+  | Error cause, Ok ()
+  | Ok (), Error cause -> Error (cause, None)
+  | Error cause, Error cleanup_failure -> Error (cause, Some cleanup_failure)
+
+let protect_cleanup execution_context f =
+  match execution_context with
+  | Eio_guard.Eio_fiber -> Eio.Cancel.protect f
+  | Eio_guard.Non_eio -> f ()
+
+let close_fd_after_exception ~lock_path execution_context fd =
+  match protect_cleanup execution_context (fun () -> close_fd_result fd) with
+  | Ok () -> ()
+  | Error failure ->
+    Log.Misc.error
+      "file_lock_eio: fd cleanup failed lock_path=%s operation=%s argument=%s error=%s"
+      lock_path failure.operation failure.argument
+      (Unix.error_message failure.error)
+
+let release_fd_after_exception ~lock_path execution_context fd =
+  match
+    protect_cleanup execution_context (fun () -> release_durable_fd_result fd)
+  with
+  | Ok () -> ()
+  | Error (failure, cleanup_failure) ->
+    Log.Misc.error
+      "file_lock_eio: lock cleanup failed lock_path=%s operation=%s argument=%s error=%s%s"
+      lock_path failure.operation failure.argument
+      (Unix.error_message failure.error)
+      (match cleanup_failure with
+       | None -> ""
+       | Some cleanup ->
+         Printf.sprintf " cleanup_operation=%s cleanup_argument=%s cleanup_error=%s"
+           cleanup.operation cleanup.argument
+           (Unix.error_message cleanup.error))
+
+let durable_lock_error ?cleanup_failure ~lock_path ~phase cause =
+  { lock_path; phase; cause; cleanup_failure }
+
+let open_durable_lock_file ~execution_context lock_path =
+  let opened_fd = Atomic.make None in
+  let result =
+    try
+      Ok
+        (run_blocking_lock_op (fun () ->
+           let fd =
+             Unix.openfile lock_path
+               [ Unix.O_CLOEXEC; Unix.O_CREAT; Unix.O_WRONLY ] 0o644
+           in
+           Atomic.set opened_fd (Some fd);
+           fd))
+    with
+    | Unix.Unix_error (error, operation, argument) ->
+      Error (unix_failure (error, operation, argument))
+    | exn ->
+      let backtrace = Printexc.get_raw_backtrace () in
+      Option.iter
+        (close_fd_after_exception ~lock_path execution_context)
+        (Atomic.exchange opened_fd None);
+      Printexc.raise_with_backtrace exn backtrace
+  in
+  Atomic.set opened_fd None;
+  result
+
+let acquire_durable_flock ~execution_context lock_path =
+  match open_durable_lock_file ~execution_context lock_path with
+  | Error cause ->
+    Error (durable_lock_error ~lock_path ~phase:Open_lock_file cause)
+  | Ok fd ->
+    let started_at = Time_compat.now () in
+    let process_lock_held = Atomic.make false in
+    let rec acquire_eio retries =
+      match
+        try
+          run_blocking_lock_op (fun () -> Unix.lockf fd Unix.F_TLOCK 0);
+          Atomic.set process_lock_held true;
+          Ok true
+        with
+        | Unix.Unix_error ((Unix.EAGAIN | Unix.EACCES), _, _) -> Ok false
+        | Unix.Unix_error (error, operation, argument) ->
+          Error (unix_failure (error, operation, argument))
+      with
+      | Ok true ->
+        Eio.Fiber.check ();
+        observe_lock_attempt ~caller:"File_lock_eio.durable" ~retries
+          ~started_at ~outcome:"acquired";
+        Ok ()
+      | Ok false ->
+        (* POSIX record locks expose no readiness source to Eio. An unbounded
+           F_TLOCK/yield loop is the portable cancellable admission: no
+           timeout, attempt cap, sleep, or backoff policy is invented. *)
+        Eio.Fiber.yield ();
+        acquire_eio (retries + 1)
+      | Error _ as error -> error
+    in
+    let acquire () =
+      match execution_context with
+      | Eio_guard.Eio_fiber ->
+        Eio.Fiber.check ();
+        acquire_eio 0
+      | Eio_guard.Non_eio ->
+        (try
+           Unix.lockf fd Unix.F_LOCK 0;
+           Atomic.set process_lock_held true;
+           Ok ()
+         with
+         | Unix.Unix_error (error, operation, argument) ->
+           Error (unix_failure (error, operation, argument)))
+    in
+    let acquired =
+      match acquire () with
+      | result -> result
+      | exception exn ->
+        let backtrace = Printexc.get_raw_backtrace () in
+        if Atomic.get process_lock_held
+        then release_fd_after_exception ~lock_path execution_context fd
+        else close_fd_after_exception ~lock_path execution_context fd;
+        Printexc.raise_with_backtrace exn backtrace
+    in
+    (match acquired with
+     | Ok () -> Ok fd
+     | Error cause ->
+       let cleanup_failure =
+         match
+           protect_cleanup execution_context (fun () -> close_fd_result fd)
+         with
+         | Ok () -> None
+         | Error failure -> Some failure
+       in
+       Error
+         (durable_lock_error
+            ?cleanup_failure
+            ~lock_path
+            ~phase:Acquire_process_lock
+            cause))
+
+let with_durable_lock ~lock_path f =
+  with_mutex lock_path (fun () ->
+    let execution_context = Eio_guard.execution_context () in
+    match acquire_durable_flock ~execution_context lock_path with
+    | Error _ as error -> error
+    | Ok fd ->
+      let admitted () =
+        let body =
+          match f () with
+          | value -> `Returned value
+          | exception exn -> `Raised (exn, Printexc.get_raw_backtrace ())
+        in
+        let release = release_durable_fd_result fd in
+        match body, release with
+        | `Returned value, Ok () -> Ok value
+        | `Returned _, Error (cause, cleanup_failure) ->
+          Error
+            (durable_lock_error
+               ?cleanup_failure
+               ~lock_path
+               ~phase:Release_process_lock
+               cause)
+        | `Raised (exn, backtrace), Ok () ->
+          Printexc.raise_with_backtrace exn backtrace
+        | `Raised (exn, backtrace), Error (release_failure, cleanup_failure) ->
+          Log.Misc.error
+            "file_lock_eio: release failed during body exception lock_path=%s operation=%s argument=%s error=%s%s"
+            lock_path release_failure.operation release_failure.argument
+            (Unix.error_message release_failure.error)
+            (match cleanup_failure with
+             | None -> ""
+             | Some cleanup ->
+               Printf.sprintf
+                 " cleanup_operation=%s cleanup_argument=%s cleanup_error=%s"
+                 cleanup.operation cleanup.argument
+                 (Unix.error_message cleanup.error));
+          Printexc.raise_with_backtrace exn backtrace
+      in
+      protect_cleanup execution_context admitted)
 
 (** Number of tracked lock paths (for diagnostics). *)
 let lock_count () = SMap.cardinal (Atomic.get table).entries

--- a/lib/process/file_lock_eio.mli
+++ b/lib/process/file_lock_eio.mli
@@ -29,6 +29,26 @@ val stale_lock_seconds : float
 
 exception Flock_timeout of { caller : string; path : string; attempts : int }
 
+type durable_lock_phase =
+  | Open_lock_file
+  | Acquire_process_lock
+  | Release_process_lock
+
+type unix_failure =
+  { error : Unix.error
+  ; operation : string
+  ; argument : string
+  }
+
+type durable_lock_error =
+  { lock_path : string
+  ; phase : durable_lock_phase
+  ; cause : unix_failure
+  ; cleanup_failure : unix_failure option
+  }
+
+val durable_lock_error_to_string : durable_lock_error -> string
+
 (** Non-blocking [F_TLOCK] with retry. On success returns the open
     file descriptor holding the lock. On timeout closes the fd and
     raises {!Flock_timeout}. [clock] is accepted but ignored in this
@@ -86,6 +106,14 @@ val with_lock :
   string ->
   (unit -> 'a) ->
   'a
+
+(** Cross-context/process transaction lock on the explicit [lock_path]. Eio
+    admission is cooperatively cancellable and unbounded; cancellation is
+    masked only after the OS lock is held, through body execution and release.
+    The parent directory must exist. I/O failures are typed and body exceptions
+    survive cleanup errors. *)
+val with_durable_lock :
+  lock_path:string -> (unit -> 'a) -> ('a, durable_lock_error) result
 
 (** {1 Observability hook} *)
 

--- a/test/test_file_lock_eio.ml
+++ b/test/test_file_lock_eio.ml
@@ -1,5 +1,20 @@
 open Alcotest
 
+let () =
+  if Array.length Sys.argv = 3 && String.equal Sys.argv.(1) "--hold-durable-lock"
+  then (
+    let fd =
+      Unix.openfile Sys.argv.(2) [ Unix.O_CREAT; Unix.O_WRONLY ] 0o644
+    in
+    Fun.protect
+      ~finally:(fun () -> Unix.close fd)
+      (fun () ->
+        Unix.lockf fd Unix.F_LOCK 0;
+        output_char stdout 'R';
+        flush stdout;
+        ignore (input_char stdin));
+    exit 0)
+
 let cleanup_if_exists path =
   if Sys.file_exists path then
     if Sys.is_directory path then
@@ -59,6 +74,82 @@ let test_with_lock_inside_eio () =
   check int "single call" 1 !calls;
   check bool "lock table tracked" true (File_lock_eio.lock_count () >= 1)
 
+let test_durable_lock_open_failure_is_typed () =
+  with_temp_path @@ fun path ->
+  let path = Filename.concat path "missing/target" in
+  match File_lock_eio.with_durable_lock ~lock_path:path (fun () -> ()) with
+  | Ok () -> fail "durable lock unexpectedly created a missing parent tree"
+  | Error error ->
+    check bool "failure phase is lock-file open" true
+      (match error.File_lock_eio.phase with
+       | File_lock_eio.Open_lock_file -> true
+       | Acquire_process_lock | Release_process_lock -> false)
+
+let with_external_lock_holder lock_path f =
+  let ready_read, ready_write = Unix.pipe () in
+  let release_read, release_write = Unix.pipe () in
+  let pid =
+    Unix.create_process Sys.executable_name
+      [| Sys.executable_name; "--hold-durable-lock"; lock_path |]
+      release_read ready_write Unix.stderr
+  in
+  Unix.close ready_write;
+  Unix.close release_read;
+  let released = ref false in
+  let release_holder () =
+    if not !released then (
+      released := true;
+      Fun.protect
+        ~finally:(fun () -> Unix.close release_write)
+        (fun () ->
+          check int "holder release signal" 1
+            (Unix.write_substring release_write "X" 0 1)))
+  in
+  let rec wait_for_child () =
+    match Unix.waitpid [] pid with
+    | result -> result
+    | exception Unix.Unix_error (Unix.EINTR, _, _) -> wait_for_child ()
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      release_holder ();
+      ignore (wait_for_child ()))
+    (fun () ->
+      let ready = Bytes.create 1 in
+      let count = Unix.read ready_read ready 0 1 in
+      Unix.close ready_read;
+      if count <> 1 || Bytes.get ready 0 <> 'R'
+      then fail "lock holder did not start";
+      f release_holder)
+
+let test_durable_lock_wait_is_cancellable () =
+  with_temp_path @@ fun path ->
+  let lock_path = path ^ ".lock" in
+  with_external_lock_holder lock_path @@ fun release_holder ->
+  Eio_main.run @@ fun _env ->
+  let started, signal_started = Eio.Promise.create () in
+  let body_ran = ref false in
+  let outcome =
+    Eio.Fiber.first
+      (fun () ->
+        Eio.Promise.resolve signal_started ();
+        match
+          File_lock_eio.with_durable_lock ~lock_path (fun () -> body_ran := true)
+        with
+        | Ok () -> `Unexpected_admission
+        | Error error -> `Failure (File_lock_eio.durable_lock_error_to_string error))
+      (fun () ->
+        Eio.Promise.await started;
+        Eio.Fiber.yield ();
+        release_holder ();
+        `Cancelled_waiter)
+  in
+  check bool "contended body did not run" false !body_ran;
+  match outcome with
+  | `Cancelled_waiter -> ()
+  | `Unexpected_admission -> fail "cross-process lock admitted while held"
+  | `Failure detail -> fail ("lock wait failed instead of cancelling: " ^ detail)
+
 let () =
   run "file_lock_eio"
     [
@@ -68,5 +159,9 @@ let () =
           test_case "acquire_flock_retry works without Eio context" `Quick
             test_acquire_flock_retry_without_eio;
           test_case "works inside Eio context" `Quick test_with_lock_inside_eio;
+          test_case "durable lock open failure is typed" `Quick
+            test_durable_lock_open_failure_is_typed;
+          test_case "durable cross-process wait is cancellable" `Quick
+            test_durable_lock_wait_is_cancellable;
         ] );
     ]


### PR DESCRIPTION
## Stack

- Base: #24548
- This PR is the second slice of the checkpoint atomicity stack.
- Keep #24548 merged/rebased first; this PR intentionally targets `codex/actual-eio-context-20260715`.

## What changed

- adds an explicit `with_durable_lock` transaction primitive with typed open/acquire/release failures
- keeps Eio lock admission cancellable while another process owns the lock
- removes invented timeout/attempt/backoff policy from the new durable path: portable `F_TLOCK` + cooperative yield until admission or cancellation
- masks cancellation only after the OS lock is held, through body execution and release
- closes/unlocks descriptors on cancellation and preserves body exceptions when release also fails
- serializes Eio fibers and raw Domains on the same per-path entry
- makes lock-table reservations CAS-safe so stale pruning cannot erase an admitted waiter

## Regression proof

The focused test launches a separate process holding the POSIX lock, requests cancellation of the waiting fiber, then releases the holder structurally. It verifies the protected-admission regression without depending on a timing timeout: the body must never run.

## Validation

- `ocamlformat --check lib/process/file_lock_eio.ml lib/process/file_lock_eio.mli test/test_file_lock_eio.ml`
- parser checks with `ocamlc -stop-after parsing -c` for all three files
- `git diff --check`
- exact diff: 399 additions / 13 deletions

Per repository policy, no local full Dune build/test was claimed; CI is the build authority.