### PR TITLE
fix(checkpoint): make canonical disk the watermark SSOT

### DIFF
--- a/lib/core/eio_guard.ml
+++ b/lib/core/eio_guard.ml
@@ -1,4 +1,4 @@
-(** Eio_guard — Dual-mode guard for pre/post Eio runtime.
+(** Eio_guard — Dual-mode guard for Eio and non-Eio callers.
 
     Before [Eio_main.run] starts, OCaml runs single-threaded and Eio
     primitives are unavailable.  Modules that need [Eio.Mutex] or
@@ -9,13 +9,26 @@
     Call {!enable} once inside [Eio_main.run].  Uses [Atomic.t] so the
     flag is safe to read from any domain.
 
-    All guards check the [ready] flag before attempting mutex operations,
-    avoiding [Effect.Unhandled] exceptions on the normal code path. *)
+    The process-wide [ready] flag gates shared Eio mutexes. Operations that may
+    also be reached from raw Domains inspect the current execution context. *)
 
 let ready = Atomic.make false
 let enable () = Atomic.set ready true
 let disable () = Atomic.set ready false
 let is_ready () = Atomic.get ready
+
+type execution_context = Eio_fiber | Non_eio
+
+let execution_context () =
+  match Eio.Fiber.is_cancelled () with
+  | true | false -> Eio_fiber
+  | exception Effect.Unhandled _ -> Non_eio
+;;
+
+let is_eio_fiber () = execution_context () = Eio_fiber
+
+type mutex_access = Read_write | Read_only
+exception Non_eio_mutex_context of mutex_access
 
 (** {1 Mutex Guards}
 
@@ -26,18 +39,24 @@ let is_ready () = Atomic.get ready
 
 (** Read-write guard: acquires mutex if Eio is ready, runs directly otherwise. *)
 let with_mutex mutex f =
-  if Atomic.get ready then Eio.Mutex.use_rw ~protect:true mutex (fun () -> f ()) else f ()
+  match Atomic.get ready, execution_context () with
+  | false, _ -> f ()
+  | true, Eio_fiber -> Eio.Mutex.use_rw ~protect:true mutex (fun () -> f ())
+  | true, Non_eio -> raise (Non_eio_mutex_context Read_write)
 ;;
 
 (** Read-only guard: acquires read lock if Eio is ready, runs directly otherwise. *)
 let with_mutex_ro mutex f =
-  if Atomic.get ready then Eio.Mutex.use_ro mutex (fun () -> f ()) else f ()
+  match Atomic.get ready, execution_context () with
+  | false, _ -> f ()
+  | true, Eio_fiber -> Eio.Mutex.use_ro mutex (fun () -> f ())
+  | true, Non_eio -> raise (Non_eio_mutex_context Read_only)
 ;;
 
 (** {1 Systhread Guard} *)
 
-(** Run [f] in a system thread when Eio is active, or directly when
-    no Eio runtime is available (e.g. unit tests).
+(** Run [f] in a system thread from an Eio fiber, or directly from a raw Domain
+    or other non-Eio execution context.
 
     A pool system thread has no Eio effect handler.  [f] must therefore
     perform only blocking C/Unix work, never an Eio operation: anything
@@ -53,8 +72,8 @@ let with_mutex_ro mutex f =
     [use_rw] frame before control returns here — so it diagnoses the bug
     faster, it does not prevent it. *)
 let run_in_systhread f =
-  if Atomic.get ready
-  then
+  match execution_context () with
+  | Eio_fiber ->
     Eio_unix.run_in_systhread (fun () ->
       try f () with
       | Effect.Unhandled _ as exn ->
@@ -66,7 +85,7 @@ let run_in_systhread f =
               resulting Effect.Unhandled). Offload Eio-touching work via Executor_pool \
               (e.g. Executor_pool_ref.submit_or_inline), not run_in_systhread."
              (Printexc.to_string exn)))
-  else f ()
+  | Non_eio -> f ()
 ;;
 
 (** {1 Resource Cleanup}
@@ -84,24 +103,25 @@ let run_in_systhread f =
       body exception (no [Fun.Finally_raised] wrapping).
     - [Eio.Cancel.Cancelled] always propagates.
 
-    Before [enable ()], falls back to [Fun.protect] (single-threaded,
-    no Eio context available). *)
+    Outside an Eio fiber, falls back to [Fun.protect]. *)
 let protect ~finally body =
-  if Atomic.get ready
-  then
+  match execution_context () with
+  | Eio_fiber ->
     Eio.Switch.run (fun sw ->
       Eio.Switch.on_release sw finally;
       body ())
-  else Fun.protect ~finally body
+  | Non_eio -> Fun.protect ~finally body
 ;;
 
 (** Cooperatively yield without raising if the Eio scheduler is unavailable. *)
 let yield_if_ready () =
-  if Atomic.get ready then Safe_ops.protect ~default:() (fun () -> Eio.Fiber.yield ())
+  match execution_context () with
+  | Eio_fiber -> Eio.Fiber.yield ()
+  | Non_eio -> ()
 ;;
 
 let check_if_ready () =
-  if Atomic.get ready then Safe_ops.protect ~default:() (fun () -> Eio.Fiber.check ())
+  match execution_context () with Eio_fiber -> Eio.Fiber.check () | Non_eio -> ()
 ;;
 
 let fair_yield = yield_if_ready

--- a/lib/core/eio_guard.mli
+++ b/lib/core/eio_guard.mli
@@ -1,8 +1,8 @@
-(** Eio_guard — Dual-mode mutex guard for pre/post Eio runtime.
+(** Eio_guard — Dual-mode guard for Eio and non-Eio callers.
 
-    Before {!enable} is called, all guard functions execute [f] directly
-    (single-threaded, no locking needed). After {!enable}, they acquire
-    the given [Eio.Mutex.t] before running [f].
+    {!enable} records that shared Eio mutexes are live. Runtime operations
+    additionally inspect the current caller because a process-wide ready flag
+    does not give raw Domains or systhreads an Eio effect handler.
 
     Call {!enable} once inside [Eio_main.run]. *)
 
@@ -17,13 +17,26 @@ val disable : unit -> unit
 (** [true] after {!enable} has been called. *)
 val is_ready : unit -> bool
 
-(** Acquire read-write lock if Eio is ready, run [f] directly otherwise. *)
+(** Actual execution context of the current caller. [ready] is process-wide;
+    it does not imply that a raw Domain or systhread has an Eio handler. *)
+type execution_context = Eio_fiber | Non_eio
+
+val execution_context : unit -> execution_context
+val is_eio_fiber : unit -> bool
+
+type mutex_access = Read_write | Read_only
+exception Non_eio_mutex_context of mutex_access
+
+(** Acquire the read-write lock when enabled from an Eio fiber. Runs directly
+    before {!enable}; raises {!Non_eio_mutex_context} for a ready non-Eio
+    caller. *)
 val with_mutex : Eio.Mutex.t -> (unit -> 'a) -> 'a
 
-(** Acquire read-only lock if Eio is ready, run [f] directly otherwise. *)
+(** Read-only counterpart of {!with_mutex}. *)
 val with_mutex_ro : Eio.Mutex.t -> (unit -> 'a) -> 'a
 
-(** Run [f] in a system thread if Eio is ready, directly otherwise. *)
+(** Run [f] in a system thread from an Eio fiber, directly from a non-Eio
+    execution context. *)
 val run_in_systhread : (unit -> 'a) -> 'a
 
 (** Eio-aware replacement for [Fun.protect].
@@ -32,16 +45,14 @@ val run_in_systhread : (unit -> 'a) -> 'a
     so cleanup always runs and cleanup exceptions do not replace the body
     exception.  [Eio.Cancel.Cancelled] always propagates correctly.
 
-    Before {!enable}, falls back to [Fun.protect]. *)
+    Outside an Eio fiber, falls back to [Fun.protect]. *)
 val protect : finally:(unit -> unit) -> (unit -> 'a) -> 'a
 
-(** Cooperatively yield to the Eio scheduler if the runtime is active.
-    No-op before {!enable} or when called from a context where Eio cannot
-    currently yield. *)
+(** Cooperatively yield from an Eio fiber; no-op in a non-Eio context. *)
 val yield_if_ready : unit -> unit
 
-(** Check for cooperative cancellation if the Eio runtime is active.
-    No-op before {!enable} or when called from non-Eio initialization paths. *)
+(** Check cooperative cancellation from an Eio fiber; no-op in a non-Eio
+    context. *)
 val check_if_ready : unit -> unit
 
 (** Named cooperative yield for scheduler-fair keeper/runtime boundaries.

--- a/lib/core/executor_pool_ref.ml
+++ b/lib/core/executor_pool_ref.ml
@@ -22,8 +22,8 @@ let set p = Atomic.set pool (Some p)
     Inline fallback ensures callers work in tests and before server init.
     Re-raises [Eio.Cancel.Cancelled] to preserve structured concurrency. *)
 let submit_or_inline ?(weight = 1.0) f =
-  match Atomic.get pool with
-  | Some p ->
+  match Atomic.get pool, Eio_guard.execution_context () with
+  | Some p, Eio_guard.Eio_fiber ->
       (try Eio.Executor_pool.submit_exn p ~weight (fun () ->
          Eio.Switch.run (fun _sw -> f ()))
        with
@@ -32,4 +32,5 @@ let submit_or_inline ?(weight = 1.0) f =
            Log.Misc.warn "executor_pool submit failed, running inline: %s"
              (Printexc.to_string exn);
            f ())
-  | None -> f ()
+  | (Some _ | None), Eio_guard.Non_eio
+  | None, Eio_guard.Eio_fiber -> f ()

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -579,9 +579,8 @@ let run_turn
                    session_id (the OAS agent carries no session field), so the
                    sink must stamp the keeper's own session identity before
                    persisting. [meta.runtime.trace_id] is a validated,
-                   non-empty [Trace_id.t]; without this restamp the OAS
-                   checkpoint store rejects the write with "session_id must not
-                   be empty" and every keeper turn dies. *)
+                   non-empty [Trace_id.t]; without this restamp the checkpoint
+                   transaction rejects an invalid persistence identity. *)
                 let checkpoint =
                   { snapshot.checkpoint with
                     session_id =
@@ -592,9 +591,13 @@ let run_turn
                        | None -> snapshot.checkpoint.working_context)
                   }
                 in
-                Keeper_checkpoint_store.save_oas
-                  ~session_dir:session.session_dir
-                  checkpoint
+                match
+                  Keeper_checkpoint_store.save_oas_classified
+                    ~session_dir:session.session_dir
+                    checkpoint
+                with
+                | Ok _ -> Ok ()
+                | Error _ as error -> error
               in
               let call_run_named ?raw_trace ~initial_messages () =
                 (* Keeper does not impose a cumulative turn, time, token, or cost

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -87,16 +87,6 @@ let pending_store_cross_context_mu = Stdlib.Mutex.create ()
 let deliveries : persisted_delivery SMap.t Atomic.t = Atomic.make SMap.empty
 let unavailable_stores : storage_error SMap.t Atomic.t = Atomic.make SMap.empty
 
-type execution_context =
-  | Eio_fiber
-  | Non_eio
-
-let execution_context () =
-  match Eio.Fiber.check () with
-  | () -> Eio_fiber
-  | exception Effect.Unhandled _ -> Non_eio
-;;
-
 let rec lock_pending_store_cooperatively () =
   if Stdlib.Mutex.try_lock pending_store_cross_context_mu
   then ()
@@ -118,9 +108,9 @@ let rec lock_pending_store_cooperatively () =
     snapshot is returned as committed rather than reported as an ambiguous
     cancelled operation. *)
 let with_pending_store_lock f =
-  match execution_context () with
-  | Non_eio -> Stdlib.Mutex.protect pending_store_cross_context_mu f
-  | Eio_fiber ->
+  match Eio_guard.execution_context () with
+  | Eio_guard.Non_eio -> Stdlib.Mutex.protect pending_store_cross_context_mu f
+  | Eio_guard.Eio_fiber ->
     Eio.Mutex.use_ro pending_store_eio_gate (fun () ->
       lock_pending_store_cooperatively ();
       Eio.Cancel.protect (fun () ->

--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -138,63 +138,6 @@ let delete_oas_history_files ~(session_dir : string) ~(snapshot_ids : string lis
     snapshot_ids
   |> fun (deleted, missing) -> (List.rev deleted, List.rev missing)
 
-(* Unguarded write body. Public [save_oas] (defined after [load_oas]
-   below) wraps this with the RFC-0225 §3.2 stale-write guard. *)
-let save_oas_unguarded ~(session_dir : string) (ckpt : Agent_sdk.Checkpoint.t)
-  : (unit, string) result =
-  if String.length ckpt.session_id = 0 then
-    (* Fail loud at the persistence boundary: a checkpoint with an empty
-       session_id is unpersistable. The primary Eio path already rejects it
-       ([Checkpoint_store.save] validates session_id), but the non-Eio
-       [fallback] below would otherwise silently write "<session_dir>/.json"
-       and drop the checkpoint. Callers must stamp a validated, non-empty
-       session_id (the keeper trace_id) before persisting. *)
-    Error "save_oas: refusing checkpoint with empty session_id"
-  else
-  let fallback () =
-    match Keeper_fs.save_atomic
-      (oas_checkpoint_path ~session_dir ~session_id:ckpt.session_id)
-      (Agent_sdk.Checkpoint.to_string ckpt) with
-    | Ok () ->
-      (try save_oas_history ~session_dir ckpt with
-       | Eio.Cancel.Cancelled _ as e -> raise e
-       | exn ->
-           Log.Keeper.warn "OAS snapshot archive write failed for %s: %s"
-             ckpt.session_id (Printexc.to_string exn);
-           Otel_metric_store.inc_counter
-             Keeper_metrics.(to_string CheckpointFailures)
-             ~labels:[("site", Keeper_checkpoint_store_failure_site.(to_label Oas_archive_fallback))]
-             ());
-      Ok ()
-    | Error msg -> Error msg
-  in
-  try
-    ignore (Keeper_fs.ensure_dir session_dir);
-    match Fs_compat.get_fs_opt () with
-    | Some fs when Eio_guard.is_ready () ->
-        let dir = Eio.Path.(fs / session_dir) in
-        (match Agent_sdk.Checkpoint_store.create dir with
-         | Ok store -> (
-             match Agent_sdk.Checkpoint_store.save store ckpt with
-             | Ok () ->
-                 (try save_oas_history ~session_dir ckpt with
-                  | Eio.Cancel.Cancelled _ as e -> raise e
-                  | exn ->
-                      Log.Keeper.warn "OAS snapshot archive write failed for %s: %s"
-                        ckpt.session_id (Printexc.to_string exn);
-                      Otel_metric_store.inc_counter
-                        Keeper_metrics.(to_string CheckpointFailures)
-                        ~labels:[("site", Keeper_checkpoint_store_failure_site.(to_label Oas_archive_primary))]
-                        ());
-                 Ok ()
-             | Error err -> Error (Agent_sdk.Error.to_string err))
-         | Error err -> Error (Agent_sdk.Error.to_string err))
-    | Some _ | None ->
-        fallback ()
-  with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | exn -> Error (Printf.sprintf "save_oas: %s" (Printexc.to_string exn))
-
 (* Delta Checkpoint Shadow-Apply removed: Agent_sdk.Checkpoint.delta
    type was removed upstream. Functions had zero callers. *)
 
@@ -274,7 +217,7 @@ let load_oas ~(session_dir : string) ~(session_id : string) :
     else Error Not_found
   in
   match Fs_compat.get_fs_opt () with
-  | Some fs when Eio_guard.is_ready () ->
+  | Some fs when Eio_guard.is_eio_fiber () ->
       let dir = Eio.Path.(fs / session_dir) in
       (match Agent_sdk.Checkpoint_store.create dir with
        | Ok store ->
@@ -294,39 +237,10 @@ let load_oas ~(session_dir : string) ~(session_id : string) :
   | Some _ | None ->
       fallback ()
 
-(* ── RFC-0225 §3.2: stale checkpoint write guard ─────────────────────
-   Two writers for the same session are last-writer-wins on disk; a
-   stale writer (e.g. a lane that resumed from an older snapshot)
-   overwrote the conversation the newer writer had just persisted
-   (2026-06-10 voice incident: oas turn_count 1355 clobbered by 1324).
-   The checkpoint carrier is OAS-owned, so the version is tracked on
-   the MASC side: a process-local map of the highest turn_count saved
-   per checkpoint path, backfilled from disk once per session. *)
-
-let last_saved_oas_turn_count_mu = Stdlib.Mutex.create ()
-let last_saved_oas_turn_count : (string, int) Hashtbl.t = Hashtbl.create 16
-
-let known_oas_turn_count ~session_dir ~session_id =
-  let key = oas_checkpoint_path ~session_dir ~session_id in
-  let cached =
-    (* Stdlib mutex on purpose: the critical section is a pure Hashtbl
-       lookup, never yields. Disk backfill happens outside the lock. *)
-    Stdlib.Mutex.protect last_saved_oas_turn_count_mu (fun () ->
-      Hashtbl.find_opt last_saved_oas_turn_count key)
-  in
-  match cached with
-  | Some _ as hit -> hit
-  | None ->
-    (match load_oas ~session_dir ~session_id with
-     | Ok existing -> Some existing.turn_count
-     | Error _ -> None)
-
-let record_saved_oas_turn_count ~session_dir ~session_id turn_count =
-  let key = oas_checkpoint_path ~session_dir ~session_id in
-  Stdlib.Mutex.protect last_saved_oas_turn_count_mu (fun () ->
-    match Hashtbl.find_opt last_saved_oas_turn_count key with
-    | Some known when known >= turn_count -> ()
-    | Some _ | None -> Hashtbl.replace last_saved_oas_turn_count key turn_count)
+(* ── RFC-0225 §3.2: disk-SSOT monotonic checkpoint transaction ──────
+   One stable per-session lock covers canonical disk load, comparison,
+   durable publication, and history capture. The canonical file is the only
+   admission watermark; no process-local checkpoint truth is retained. *)
 
 type save_oas_relation = [ `Cold | `Forward | `Equal ]
 
@@ -340,42 +254,194 @@ let save_relation ~known ~incoming =
   | Some previous when incoming > previous -> `Forward
   | Some _ -> `Equal
 
+type unix_failure =
+  { error : Unix.error
+  ; operation : string
+  ; argument : string
+  }
+
+type directory_failure =
+  | Directory_unix_failure of unix_failure
+  | Directory_other_failure of string
+
+type save_oas_error =
+  | Invalid_session_id of string
+  | Session_directory_unavailable of directory_failure
+  | Existing_checkpoint_unreadable of checkpoint_load_error
+  | Canonical_write_failed of Keeper_fs.durable_write_error
+  | Transaction_lock_failed of File_lock_eio.durable_lock_error
+
+let checkpoint_load_error_to_string = function
+  | Not_found -> "checkpoint not found"
+  | Store_error detail
+  | Parse_error detail
+  | Io_error detail
+  | Sdk_other_error detail -> detail
+
+let save_oas_error_to_string = function
+  | Invalid_session_id reason -> reason
+  | Session_directory_unavailable (Directory_unix_failure failure) ->
+    Printf.sprintf "checkpoint session directory unavailable: %s(%s): %s"
+      failure.operation failure.argument (Unix.error_message failure.error)
+  | Session_directory_unavailable (Directory_other_failure detail) ->
+    "checkpoint session directory unavailable: " ^ detail
+  | Existing_checkpoint_unreadable error ->
+    "existing checkpoint unreadable: " ^ checkpoint_load_error_to_string error
+  | Canonical_write_failed error ->
+    "canonical checkpoint write failed: "
+    ^ Keeper_fs.durable_write_error_to_string error
+  | Transaction_lock_failed error ->
+    "checkpoint transaction lock failed: "
+    ^ File_lock_eio.durable_lock_error_to_string error
+
+let canonical_session_location session_dir =
+  let parent = Filename.dirname session_dir in
+  try
+    Fs_compat.mkdir_p parent;
+    let parent =
+      Eio_guard.run_in_systhread (fun () ->
+        let parent = Unix.realpath parent in
+        if (Unix.stat parent).Unix.st_kind <> Unix.S_DIR
+        then
+          raise
+            (Unix.Unix_error
+               (Unix.ENOTDIR, "checkpoint_session_parent", parent));
+        parent)
+    in
+    Ok (Filename.concat parent (Filename.basename session_dir))
+  with
+  | Unix.Unix_error (error, operation, argument) ->
+    Error
+      (Session_directory_unavailable
+         (Directory_unix_failure { error; operation; argument }))
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Error
+      (Session_directory_unavailable
+         (Directory_other_failure (Printexc.to_string exn)))
+
+let with_session_lock_typed ~session_dir f =
+  match canonical_session_location session_dir with
+  | Error _ as error -> error
+  | Ok session_dir ->
+    let lock_path = session_dir ^ ".checkpoint.lock" in
+    (match File_lock_eio.with_durable_lock ~lock_path (fun () -> f session_dir) with
+     | Ok result -> result
+     | Error error -> Error (Transaction_lock_failed error))
+
+let with_session_lock ~session_dir f =
+  with_session_lock_typed ~session_dir (fun session_dir -> Ok (f session_dir))
+  |> Result.map_error save_oas_error_to_string
+
+let archive_oas_history_best_effort ~session_dir ckpt =
+  try save_oas_history ~session_dir ckpt with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Log.Keeper.warn "OAS snapshot archive write failed for %s: %s"
+      ckpt.session_id (Printexc.to_string exn);
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string CheckpointFailures)
+      ~labels:
+        [ ( "site"
+          , Keeper_checkpoint_store_failure_site.(to_label Oas_archive) )
+        ]
+      ()
+
+let load_canonical_strict path =
+  let unix_error error operation argument =
+    Io_error
+      (Printf.sprintf "%s(%s): %s"
+         operation argument (Unix.error_message error))
+  in
+  let read () =
+    match Unix.lstat path with
+    | exception Unix.Unix_error (Unix.ENOENT, _, _) -> Ok None
+    | exception Unix.Unix_error (error, operation, argument) ->
+      Error (unix_error error operation argument)
+    | stat when stat.Unix.st_kind <> Unix.S_REG ->
+      Error (Io_error ("canonical checkpoint is not a regular file: " ^ path))
+    | _ ->
+      (try
+         let buffer = Buffer.create 4096 in
+         let bytes = Bytes.create 65536 in
+         let rec read_fd fd =
+           match Unix.read fd bytes 0 (Bytes.length bytes) with
+           | 0 -> Buffer.contents buffer
+           | count ->
+             Buffer.add_subbytes buffer bytes 0 count;
+             read_fd fd
+           | exception Unix.Unix_error (Unix.EINTR, _, _) -> read_fd fd
+         in
+         let fd = Unix.openfile path [ Unix.O_CLOEXEC; Unix.O_RDONLY ] 0 in
+         let content =
+           Fun.protect ~finally:(fun () -> Unix.close fd) (fun () -> read_fd fd)
+         in
+         Ok (Some content)
+       with
+       | Unix.Unix_error (error, operation, argument) ->
+         Error (unix_error error operation argument))
+  in
+  match Eio_guard.run_in_systhread read with
+  | Ok None -> Ok None
+  | Error _ as error -> error
+  | Ok (Some content) ->
+    (match Agent_sdk.Checkpoint.of_string content with
+     | Ok checkpoint -> Ok (Some checkpoint)
+     | Error error -> Error (classify_sdk_error error))
+  | exception Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exception exn -> Error (Io_error (Printexc.to_string exn))
+
+let save_oas_classified_typed
+    ~(session_dir : string)
+    (ckpt : Agent_sdk.Checkpoint.t)
+  : (save_oas_outcome, save_oas_error) result =
+  match Keeper_id.Trace_id.of_string ckpt.session_id with
+  | Error reason -> Error (Invalid_session_id reason)
+  | Ok trace_id ->
+    with_session_lock_typed ~session_dir (fun session_dir ->
+      let session_id = Keeper_id.Trace_id.to_string trace_id in
+      let canonical_path = oas_checkpoint_path ~session_dir ~session_id in
+      match load_canonical_strict canonical_path with
+      | Error error -> Error (Existing_checkpoint_unreadable error)
+      | Ok (Some existing) when not (String.equal existing.session_id session_id) ->
+        Error
+          (Existing_checkpoint_unreadable
+             (Store_error
+                (Printf.sprintf
+                   "canonical checkpoint identity mismatch: expected=%s actual=%s"
+                   session_id existing.session_id)))
+      | Ok (Some existing) when ckpt.turn_count < existing.turn_count ->
+        Log.Keeper.warn
+          "stale OAS checkpoint write skipped for %s: incoming turn_count=%d, last saved=%d"
+          ckpt.session_id ckpt.turn_count existing.turn_count;
+        Otel_metric_store.inc_counter
+          "masc_keeper_checkpoint_stale_noop_total"
+          ~labels:[("site", "store_watermark")]
+          ();
+        Ok
+          (Stale_noop
+             { incoming_turn_count = ckpt.turn_count
+             ; known_turn_count = existing.turn_count
+             })
+      | Ok existing ->
+        let known = Option.map (fun checkpoint -> checkpoint.Agent_sdk.Checkpoint.turn_count) existing in
+        let ownership_root = Filename.dirname session_dir in
+        (match
+           Keeper_fs.save_json_durable_atomic
+             ~ownership_root
+             canonical_path
+             (Agent_sdk.Checkpoint.to_json ckpt)
+         with
+         | Error error -> Error (Canonical_write_failed error)
+         | Ok () ->
+           archive_oas_history_best_effort ~session_dir ckpt;
+           Ok
+             (Saved
+                { relation = save_relation ~known ~incoming:ckpt.turn_count
+                ; turn_count = ckpt.turn_count
+                })))
+
 let save_oas_classified ~(session_dir : string) (ckpt : Agent_sdk.Checkpoint.t)
   : (save_oas_outcome, string) result =
-  let known = known_oas_turn_count ~session_dir ~session_id:ckpt.session_id in
-  match known with
-  | Some known when ckpt.turn_count < known ->
-    Log.Keeper.warn
-      "stale OAS checkpoint write skipped for %s: incoming turn_count=%d, last saved=%d"
-      ckpt.session_id ckpt.turn_count known;
-    Otel_metric_store.inc_counter
-      "masc_keeper_checkpoint_stale_noop_total"
-      ~labels:[("site", "store_watermark")]
-      ();
-    Ok (Stale_noop
-          { incoming_turn_count = ckpt.turn_count
-          ; known_turn_count = known
-          })
-  | Some _ | None ->
-    (match save_oas_unguarded ~session_dir ckpt with
-     | Ok () ->
-       record_saved_oas_turn_count
-         ~session_dir ~session_id:ckpt.session_id ckpt.turn_count;
-       Ok
-         (Saved
-            { relation = save_relation ~known ~incoming:ckpt.turn_count
-            ; turn_count = ckpt.turn_count
-            })
-     | Error _ as e -> e)
-
-let save_oas ~(session_dir : string) (ckpt : Agent_sdk.Checkpoint.t)
-  : (unit, string) result =
-  match save_oas_classified ~session_dir ckpt with
-  | Ok (Saved _) | Ok (Stale_noop _) -> Ok ()
-  | Error _ as e -> e
-
-module For_testing = struct
-  let reset_stale_write_guard () =
-    Stdlib.Mutex.protect last_saved_oas_turn_count_mu (fun () ->
-      Hashtbl.reset last_saved_oas_turn_count)
-end
+  save_oas_classified_typed ~session_dir ckpt
+  |> Result.map_error save_oas_error_to_string

--- a/lib/keeper/keeper_checkpoint_store.mli
+++ b/lib/keeper/keeper_checkpoint_store.mli
@@ -59,27 +59,28 @@ type save_oas_outcome =
   | Saved of { relation : save_oas_relation; turn_count : int }
   | Stale_noop of { incoming_turn_count : int; known_turn_count : int }
 
-(** Save [ckpt] via the OAS Checkpoint_store when an Eio FS is
-    available; falls back to atomic file write otherwise. Always
-    appends to the OAS history archive on success.
+(** Save [ckpt] in one locked disk-SSOT transaction. A missing [session_dir]
+    is created by the durable writer, retaining the public create-first contract.
+    [Saved] means payload, rename, and parent-directory fsync succeeded; history
+    is observed best effort.
 
     RFC-0225 §3.2 checkpoint watermark: returns [Ok Stale_noop] when
-    [ckpt.turn_count] is older than the last checkpoint saved for the
-    same session. A stale writer must not clobber a conversation the
-    newer writer already persisted, but this is not a keeper lifecycle
-    failure. Equal turn_count re-saves pass. *)
+    [ckpt.turn_count] is older than the canonical checkpoint currently on disk.
+    A stale writer must not clobber a conversation the newer writer already
+    persisted, but this is not a keeper lifecycle failure. Equal turn_count
+    re-saves pass. A corrupt or unreadable existing checkpoint fails closed and
+    is never treated as a cold store. *)
 val save_oas_classified :
   session_dir:string ->
   Agent_sdk.Checkpoint.t ->
   (save_oas_outcome, string) result
 
-(** Compatibility wrapper around {!save_oas_classified}. [Saved] and
-    [Stale_noop] both return [Ok ()]; only real store/IO failures return
-    [Error]. *)
-val save_oas :
-  session_dir:string ->
-  Agent_sdk.Checkpoint.t ->
-  (unit, string) result
+(** Run [f] under the stable checkpoint lock for [session_dir]. The lock inode
+    is a sibling of the session subtree, so deleting/recreating that subtree
+    cannot replace it. [f] receives the canonical session location used to
+    derive the lock, keeping the lock and mutation on one path identity. *)
+val with_session_lock :
+  session_dir:string -> (string -> 'a) -> ('a, string) result
 
 (** Load failure classification used by callers to distinguish
     cold-start absence from real I/O / parse / SDK errors. *)
@@ -115,9 +116,3 @@ val load_oas :
   session_dir:string ->
   session_id:string ->
   (Agent_sdk.Checkpoint.t, checkpoint_load_error) result
-
-module For_testing : sig
-  val reset_stale_write_guard : unit -> unit
-  (** Clear the process-local last-saved turn_count map so tests that
-      reuse session ids across temp dirs start from a cold state. *)
-end

--- a/lib/keeper/keeper_fs_durable_directory.ml
+++ b/lib/keeper/keeper_fs_durable_directory.ml
@@ -574,7 +574,7 @@ let rec ensure_with
          in
          let completion = completion_of_outcome outcome in
          let cleanup =
-           if Eio_guard.is_ready ()
+           if Eio_guard.is_eio_fiber ()
            then Eio.Cancel.protect (fun () -> release ~completion owned)
            else release ~completion owned
          in

--- a/lib/keeper/keeper_shutdown_finalize.ml
+++ b/lib/keeper/keeper_shutdown_finalize.ml
@@ -529,11 +529,22 @@ let remove_meta_file ~config operation =
 
 let remove_session_dir ~config operation =
   if operation.cleanup_intent.remove_session
-  then
-    remove_tree
-      (Filename.concat
-         (Keeper_types_profile.session_base_dir config)
-         (Keeper_id.Trace_id.to_string operation.trace_id))
+  then (
+    let session_dir =
+      Filename.concat
+        (Keeper_types_profile.session_base_dir config)
+        (Keeper_id.Trace_id.to_string operation.trace_id)
+    in
+    match
+      Keeper_checkpoint_store.with_session_lock ~session_dir (fun session_dir ->
+        match remove_tree session_dir with
+        | Error _ as error -> error
+        | Ok () ->
+          Keeper_fs_durable_directory.invalidate session_dir;
+          Ok ())
+    with
+    | Error _ as error -> error
+    | Ok result -> result)
   else Ok ()
 ;;
 

--- a/lib/keeper_failure_taxonomy/keeper_checkpoint_store_failure_site.ml
+++ b/lib/keeper_failure_taxonomy/keeper_checkpoint_store_failure_site.ml
@@ -2,13 +2,11 @@ type t =
   | Oas_cleanup
   | Oas_save
   | Oas_delete
-  | Oas_archive_fallback
-  | Oas_archive_primary
+  | Oas_archive
 
 let to_label = function
   | Oas_cleanup -> "oas_cleanup"
   | Oas_save -> "oas_save"
   | Oas_delete -> "oas_delete"
-  | Oas_archive_fallback -> "oas_archive_fallback"
-  | Oas_archive_primary -> "oas_archive_primary"
+  | Oas_archive -> "oas_archive"
 ;;

--- a/lib/keeper_failure_taxonomy/keeper_checkpoint_store_failure_site.mli
+++ b/lib/keeper_failure_taxonomy/keeper_checkpoint_store_failure_site.mli
@@ -1,19 +1,11 @@
 (** Keeper_checkpoint_store_failure_site — closed sum for [site] label on
     [metric_keeper_checkpoint_failures] when emitted from the
-    checkpoint-store layer (5 sites in keeper_checkpoint_store.ml).
-
-    NOTE: the underlying metric is shared with
-    {!Keeper_checkpoint_failure_operation} but emits use the legacy [site]
-    label key (kept verbatim to preserve Grafana dashboard queries
-    that select on `site=...`).  A follow-up RFC could harmonise the
-    label key to a single [operation] across both call sites once
-    dashboards are migrated. *)
+    checkpoint-store layer. *)
 
 type t =
   | Oas_cleanup (** OAS checkpoint cleanup pass failed. *)
   | Oas_save (** OAS checkpoint primary save failed. *)
   | Oas_delete (** OAS checkpoint delete failed. *)
-  | Oas_archive_fallback (** Archive-tier fallback save failed. *)
-  | Oas_archive_primary (** Archive-tier primary save failed. *)
+  | Oas_archive (** OAS checkpoint history archive failed. *)
 
 val to_label : t -> string

--- a/lib/keeper_runtime/keeper_event_queue_owner_lock.ml
+++ b/lib/keeper_runtime/keeper_event_queue_owner_lock.ml
@@ -69,16 +69,6 @@ let resolve ~base_path ~keeper_name =
 let base_path owner = fst owner.owner_key
 let keeper_name owner = snd owner.owner_key
 
-type execution_context =
-  | Eio_fiber
-  | Non_eio
-
-let execution_context () =
-  match Eio.Fiber.check () with
-  | () -> Eio_fiber
-  | exception Effect.Unhandled _ -> Non_eio
-;;
-
 let rec lock_cross_context_cooperatively mutex =
   if Stdlib.Mutex.try_lock mutex
   then ()
@@ -119,13 +109,13 @@ let with_eio_lock ~check_after owner f =
 ;;
 
 let with_lock owner f =
-  match execution_context () with
-  | Eio_fiber -> with_eio_lock ~check_after:true owner f
-  | Non_eio -> Stdlib.Mutex.protect owner.cross_context_mutex f
+  match Eio_guard.execution_context () with
+  | Eio_guard.Eio_fiber -> with_eio_lock ~check_after:true owner f
+  | Eio_guard.Non_eio -> Stdlib.Mutex.protect owner.cross_context_mutex f
 ;;
 
 let with_durable_lock owner f =
-  match execution_context () with
-  | Eio_fiber -> with_eio_lock ~check_after:false owner f
-  | Non_eio -> Stdlib.Mutex.protect owner.cross_context_mutex f
+  match Eio_guard.execution_context () with
+  | Eio_guard.Eio_fiber -> with_eio_lock ~check_after:false owner f
+  | Eio_guard.Non_eio -> Stdlib.Mutex.protect owner.cross_context_mutex f
 ;;

--- a/lib/process/file_lock_eio.ml
+++ b/lib/process/file_lock_eio.ml
@@ -15,6 +15,44 @@ module SMap = Set_util.StringMap
 
 exception Flock_timeout of { caller : string; path : string; attempts : int }
 
+type durable_lock_phase =
+  | Open_lock_file
+  | Acquire_process_lock
+  | Release_process_lock
+
+type unix_failure =
+  { error : Unix.error
+  ; operation : string
+  ; argument : string
+  }
+
+type durable_lock_error =
+  { lock_path : string
+  ; phase : durable_lock_phase
+  ; cause : unix_failure
+  ; cleanup_failure : unix_failure option
+  }
+
+let durable_lock_phase_to_string = function
+  | Open_lock_file -> "open_lock_file"
+  | Acquire_process_lock -> "acquire_process_lock"
+  | Release_process_lock -> "release_process_lock"
+
+let durable_lock_error_to_string error =
+  let failure_to_string failure =
+    Printf.sprintf "%s(%s): %s"
+      failure.operation
+      failure.argument
+      (Unix.error_message failure.error)
+  in
+  Printf.sprintf "lock_path=%s phase=%s cause=%s%s"
+    error.lock_path
+    (durable_lock_phase_to_string error.phase)
+    (failure_to_string error.cause)
+    (match error.cleanup_failure with
+     | None -> ""
+     | Some failure -> " cleanup=" ^ failure_to_string failure)
+
 (** Observability hook fired after each [acquire_flock_retry*] attempt
     sequence completes — once on success, once on timeout.  Wired at
     startup ([lib/workspace.ml]) to a Otel_metric_store counter + histogram so
@@ -65,16 +103,18 @@ let rec atomic_update atomic f =
 
 let rec atomic_update_with_result atomic f =
   let old_val = Atomic.get atomic in
-  let new_val, result = f old_val in
+  let new_val, result, rollback = f old_val in
   if Atomic.compare_and_set atomic old_val new_val then result
   else begin
+    rollback ();
     observe_cas_retry ();
     atomic_update_with_result atomic f
   end
 
 type lock_entry = {
   mu : Eio.Mutex.t;
-  mutable last_used : float;
+  cross_context_mu : Stdlib.Mutex.t;
+  last_used : float Atomic.t;
   active : int Atomic.t;   (** Number of fibers currently holding or waiting on this mutex *)
 }
 
@@ -101,7 +141,8 @@ let prune_stale_entries () =
     if SMap.cardinal state.entries > max_lock_entries then
       let now = Time_compat.now () in
       let entries = SMap.filter (fun _path entry ->
-        Atomic.get entry.active > 0 || now -. entry.last_used <= stale_lock_seconds
+        Atomic.get entry.active > 0
+        || now -. Atomic.get entry.last_used <= stale_lock_seconds
       ) state.entries in
       publish_entries state entries
     else state
@@ -109,23 +150,30 @@ let prune_stale_entries () =
 
 (** Get or create a lock entry for the given file path.
     Increments [active] to prevent prune_stale_entries from removing
-    in-use entries (see TLA+ FileLockStarvation spec).
-    Falls back to direct Hashtbl access when no Eio context is available
-    (e.g. in unit tests that don't use Eio_main.run). *)
+    in-use entries (see TLA+ FileLockStarvation spec). *)
 let get_entry path =
   prune_stale_entries ();
   let entry =
     atomic_update_with_result table (fun state ->
       match SMap.find_opt path state.entries with
       | Some entry ->
-        entry.last_used <- Time_compat.now ();
-        (state, entry)
+        (* Publish a new version so a stale prune CAS cannot erase this reservation. *)
+        Atomic.set entry.last_used (Time_compat.now ());
+        Atomic.incr entry.active;
+        ( { state with version = state.version + 1 }
+        , entry
+        , fun () -> ignore (Atomic.fetch_and_add entry.active (-1)) )
       | None ->
-        let entry = { mu = Eio.Mutex.create (); last_used = Time_compat.now (); active = Atomic.make 0 } in
+        let entry =
+          { mu = Eio.Mutex.create ()
+          ; cross_context_mu = Stdlib.Mutex.create ()
+          ; last_used = Atomic.make (Time_compat.now ())
+          ; active = Atomic.make 1
+          }
+        in
         let entries = SMap.add path entry state.entries in
-        (publish_entries state entries, entry))
+        (publish_entries state entries, entry, Fun.id))
   in
-  Atomic.incr entry.active;
   entry
 
 let release_entry entry =
@@ -225,14 +273,31 @@ let release_flock_fd fd =
       (try Unix.lockf fd Unix.F_ULOCK 0 with Unix.Unix_error _ -> ());
       Unix.close fd)
 
-(** Run [f] while holding only the cooperative per-path mutex.
+let rec lock_cross_context_cooperatively mutex =
+  if Stdlib.Mutex.try_lock mutex
+  then ()
+  else (
+    Eio.Fiber.yield ();
+    lock_cross_context_cooperatively mutex)
+
+let with_entry_lock entry f =
+  match Eio_guard.execution_context () with
+  | Eio_guard.Non_eio -> Stdlib.Mutex.protect entry.cross_context_mu f
+  | Eio_guard.Eio_fiber ->
+    Eio.Mutex.use_ro entry.mu (fun () ->
+      lock_cross_context_cooperatively entry.cross_context_mu;
+      Fun.protect
+        ~finally:(fun () -> Stdlib.Mutex.unlock entry.cross_context_mu)
+        f)
+
+(** Run [f] while holding only the cross-context per-path mutex.
     Use this for in-memory backends that need single-process fiber
     serialization but do not have a real filesystem artifact to flock. *)
 let with_mutex path f =
   let entry = get_entry path in
   Common.protect ~module_name:"file_lock_eio" ~finally_label:"release_entry"
     ~finally:(fun () -> release_entry entry)
-    (fun () -> Eio_guard.with_mutex entry.mu f)
+    (fun () -> with_entry_lock entry f)
 
 (** Run [f] while holding both the cooperative Eio.Mutex and an
     OS-level flock on [path].lock. The flock uses non-blocking F_TLOCK
@@ -250,6 +315,204 @@ let with_lock ?clock path f =
       f
   in
   with_mutex path (fun () -> run_with_flock ())
+
+let unix_failure (error, operation, argument) =
+  { error; operation; argument }
+
+let close_fd_result fd =
+  try
+    run_blocking_lock_op (fun () -> Unix.close fd);
+    Ok ()
+  with
+  | Unix.Unix_error (error, operation, argument) ->
+    Error (unix_failure (error, operation, argument))
+
+let release_durable_fd_result fd =
+  let unlock =
+    try
+      run_blocking_lock_op (fun () -> Unix.lockf fd Unix.F_ULOCK 0);
+      Ok ()
+    with
+    | Unix.Unix_error (error, operation, argument) ->
+      Error (unix_failure (error, operation, argument))
+  in
+  let close = close_fd_result fd in
+  match unlock, close with
+  | Ok (), Ok () -> Ok ()
+  | Error cause, Ok ()
+  | Ok (), Error cause -> Error (cause, None)
+  | Error cause, Error cleanup_failure -> Error (cause, Some cleanup_failure)
+
+let protect_cleanup execution_context f =
+  match execution_context with
+  | Eio_guard.Eio_fiber -> Eio.Cancel.protect f
+  | Eio_guard.Non_eio -> f ()
+
+let close_fd_after_exception ~lock_path execution_context fd =
+  match protect_cleanup execution_context (fun () -> close_fd_result fd) with
+  | Ok () -> ()
+  | Error failure ->
+    Log.Misc.error
+      "file_lock_eio: fd cleanup failed lock_path=%s operation=%s argument=%s error=%s"
+      lock_path failure.operation failure.argument
+      (Unix.error_message failure.error)
+
+let release_fd_after_exception ~lock_path execution_context fd =
+  match
+    protect_cleanup execution_context (fun () -> release_durable_fd_result fd)
+  with
+  | Ok () -> ()
+  | Error (failure, cleanup_failure) ->
+    Log.Misc.error
+      "file_lock_eio: lock cleanup failed lock_path=%s operation=%s argument=%s error=%s%s"
+      lock_path failure.operation failure.argument
+      (Unix.error_message failure.error)
+      (match cleanup_failure with
+       | None -> ""
+       | Some cleanup ->
+         Printf.sprintf " cleanup_operation=%s cleanup_argument=%s cleanup_error=%s"
+           cleanup.operation cleanup.argument
+           (Unix.error_message cleanup.error))
+
+let durable_lock_error ?cleanup_failure ~lock_path ~phase cause =
+  { lock_path; phase; cause; cleanup_failure }
+
+let open_durable_lock_file ~execution_context lock_path =
+  let opened_fd = Atomic.make None in
+  let result =
+    try
+      Ok
+        (run_blocking_lock_op (fun () ->
+           let fd =
+             Unix.openfile lock_path
+               [ Unix.O_CLOEXEC; Unix.O_CREAT; Unix.O_WRONLY ] 0o644
+           in
+           Atomic.set opened_fd (Some fd);
+           fd))
+    with
+    | Unix.Unix_error (error, operation, argument) ->
+      Error (unix_failure (error, operation, argument))
+    | exn ->
+      let backtrace = Printexc.get_raw_backtrace () in
+      Option.iter
+        (close_fd_after_exception ~lock_path execution_context)
+        (Atomic.exchange opened_fd None);
+      Printexc.raise_with_backtrace exn backtrace
+  in
+  Atomic.set opened_fd None;
+  result
+
+let acquire_durable_flock ~execution_context lock_path =
+  match open_durable_lock_file ~execution_context lock_path with
+  | Error cause ->
+    Error (durable_lock_error ~lock_path ~phase:Open_lock_file cause)
+  | Ok fd ->
+    let started_at = Time_compat.now () in
+    let process_lock_held = Atomic.make false in
+    let rec acquire_eio retries =
+      match
+        try
+          run_blocking_lock_op (fun () -> Unix.lockf fd Unix.F_TLOCK 0);
+          Atomic.set process_lock_held true;
+          Ok true
+        with
+        | Unix.Unix_error ((Unix.EAGAIN | Unix.EACCES), _, _) -> Ok false
+        | Unix.Unix_error (error, operation, argument) ->
+          Error (unix_failure (error, operation, argument))
+      with
+      | Ok true ->
+        Eio.Fiber.check ();
+        observe_lock_attempt ~caller:"File_lock_eio.durable" ~retries
+          ~started_at ~outcome:"acquired";
+        Ok ()
+      | Ok false ->
+        (* POSIX record locks expose no readiness source to Eio. An unbounded
+           F_TLOCK/yield loop is the portable cancellable admission: no
+           timeout, attempt cap, sleep, or backoff policy is invented. *)
+        Eio.Fiber.yield ();
+        acquire_eio (retries + 1)
+      | Error _ as error -> error
+    in
+    let acquire () =
+      match execution_context with
+      | Eio_guard.Eio_fiber ->
+        Eio.Fiber.check ();
+        acquire_eio 0
+      | Eio_guard.Non_eio ->
+        (try
+           Unix.lockf fd Unix.F_LOCK 0;
+           Atomic.set process_lock_held true;
+           Ok ()
+         with
+         | Unix.Unix_error (error, operation, argument) ->
+           Error (unix_failure (error, operation, argument)))
+    in
+    let acquired =
+      match acquire () with
+      | result -> result
+      | exception exn ->
+        let backtrace = Printexc.get_raw_backtrace () in
+        if Atomic.get process_lock_held
+        then release_fd_after_exception ~lock_path execution_context fd
+        else close_fd_after_exception ~lock_path execution_context fd;
+        Printexc.raise_with_backtrace exn backtrace
+    in
+    (match acquired with
+     | Ok () -> Ok fd
+     | Error cause ->
+       let cleanup_failure =
+         match
+           protect_cleanup execution_context (fun () -> close_fd_result fd)
+         with
+         | Ok () -> None
+         | Error failure -> Some failure
+       in
+       Error
+         (durable_lock_error
+            ?cleanup_failure
+            ~lock_path
+            ~phase:Acquire_process_lock
+            cause))
+
+let with_durable_lock ~lock_path f =
+  with_mutex lock_path (fun () ->
+    let execution_context = Eio_guard.execution_context () in
+    match acquire_durable_flock ~execution_context lock_path with
+    | Error _ as error -> error
+    | Ok fd ->
+      let admitted () =
+        let body =
+          match f () with
+          | value -> `Returned value
+          | exception exn -> `Raised (exn, Printexc.get_raw_backtrace ())
+        in
+        let release = release_durable_fd_result fd in
+        match body, release with
+        | `Returned value, Ok () -> Ok value
+        | `Returned _, Error (cause, cleanup_failure) ->
+          Error
+            (durable_lock_error
+               ?cleanup_failure
+               ~lock_path
+               ~phase:Release_process_lock
+               cause)
+        | `Raised (exn, backtrace), Ok () ->
+          Printexc.raise_with_backtrace exn backtrace
+        | `Raised (exn, backtrace), Error (release_failure, cleanup_failure) ->
+          Log.Misc.error
+            "file_lock_eio: release failed during body exception lock_path=%s operation=%s argument=%s error=%s%s"
+            lock_path release_failure.operation release_failure.argument
+            (Unix.error_message release_failure.error)
+            (match cleanup_failure with
+             | None -> ""
+             | Some cleanup ->
+               Printf.sprintf
+                 " cleanup_operation=%s cleanup_argument=%s cleanup_error=%s"
+                 cleanup.operation cleanup.argument
+                 (Unix.error_message cleanup.error));
+          Printexc.raise_with_backtrace exn backtrace
+      in
+      protect_cleanup execution_context admitted)
 
 (** Number of tracked lock paths (for diagnostics). *)
 let lock_count () = SMap.cardinal (Atomic.get table).entries

--- a/lib/process/file_lock_eio.mli
+++ b/lib/process/file_lock_eio.mli
@@ -29,6 +29,26 @@ val stale_lock_seconds : float
 
 exception Flock_timeout of { caller : string; path : string; attempts : int }
 
+type durable_lock_phase =
+  | Open_lock_file
+  | Acquire_process_lock
+  | Release_process_lock
+
+type unix_failure =
+  { error : Unix.error
+  ; operation : string
+  ; argument : string
+  }
+
+type durable_lock_error =
+  { lock_path : string
+  ; phase : durable_lock_phase
+  ; cause : unix_failure
+  ; cleanup_failure : unix_failure option
+  }
+
+val durable_lock_error_to_string : durable_lock_error -> string
+
 (** Non-blocking [F_TLOCK] with retry. On success returns the open
     file descriptor holding the lock. On timeout closes the fd and
     raises {!Flock_timeout}. [clock] is accepted but ignored in this
@@ -86,6 +106,14 @@ val with_lock :
   string ->
   (unit -> 'a) ->
   'a
+
+(** Cross-context/process transaction lock on the explicit [lock_path]. Eio
+    admission is cooperatively cancellable and unbounded; cancellation is
+    masked only after the OS lock is held, through body execution and release.
+    The parent directory must exist. I/O failures are typed and body exceptions
+    survive cleanup errors. *)
+val with_durable_lock :
+  lock_path:string -> (unit -> 'a) -> ('a, durable_lock_error) result
 
 (** {1 Observability hook} *)
 

--- a/test/stanzas/test_keeper_checkpoint_stale_guard.inc
+++ b/test/stanzas/test_keeper_checkpoint_stale_guard.inc
@@ -1,4 +1,4 @@
-; RFC-0225 §3.2: save_oas refuses checkpoint writes whose turn_count is
+; RFC-0225 §3.2: the checkpoint transaction refuses writes whose turn_count is
 ; older than the last saved one (stale-writer clobber guard, 2026-06-10
 ; voice incident).
 

--- a/test/test_executor_pool_eio_mutex.ml
+++ b/test/test_executor_pool_eio_mutex.ml
@@ -87,6 +87,74 @@ let test_submit_or_inline_preserves_mutex () =
         check bool "shared mutex is not poisoned after offload" false
           (poisons mu))))
 
+let context_label = function
+  | Eio_guard.Eio_fiber -> "eio_fiber"
+  | Eio_guard.Non_eio -> "non_eio"
+
+let test_ready_raw_domain_uses_non_eio_path () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      Eio_guard.enable ();
+      Fun.protect ~finally:Eio_guard.disable (fun () ->
+        let pool =
+          Domain_pool.create ~sw ~domain_count:1 (Eio.Stdenv.domain_mgr env)
+        in
+        Executor_pool_ref.set (Domain_pool.executor_pool pool);
+        check string "main caller has Eio handler" "eio_fiber"
+          (context_label (Eio_guard.execution_context ()));
+        let raw_mutex = Eio.Mutex.create () in
+        let durable_dir = Filename.temp_file "masc-raw-domain-dir-" "" in
+        Unix.unlink durable_dir;
+        Eio.Switch.on_release sw (fun () ->
+          if Sys.file_exists durable_dir then Unix.rmdir durable_dir);
+        let caller_context, submitted_context, systhread_value, cleanup_ran,
+            mutex_rejected, directory_result =
+          Domain.spawn (fun () ->
+            let cleanup_ran = ref false in
+            let protected_value =
+              Eio_guard.protect
+                ~finally:(fun () -> cleanup_ran := true)
+                (fun () -> 17)
+            in
+            let mutex_rejected =
+              match Eio_guard.with_mutex raw_mutex (fun () -> ()) with
+              | () -> false
+              | exception
+                  Eio_guard.Non_eio_mutex_context Eio_guard.Read_write -> true
+              | exception
+                  Eio_guard.Non_eio_mutex_context Eio_guard.Read_only -> false
+            in
+            let directory_result =
+              Masc.Keeper_fs_durable_directory.ensure
+                ~before_prepare:(fun () -> ())
+                ~before_directory_fsync:(fun _ -> ())
+                durable_dir
+            in
+            ( Eio_guard.execution_context ()
+            , Executor_pool_ref.submit_or_inline Eio_guard.execution_context
+            , Eio_guard.run_in_systhread (fun () -> protected_value)
+            , !cleanup_ran
+            , mutex_rejected
+            , directory_result ))
+          |> Domain.join
+        in
+        check string "raw Domain is not inferred from global ready" "non_eio"
+          (context_label caller_context);
+        check string "raw Domain does not enter the Eio executor" "non_eio"
+          (context_label submitted_context);
+        check int "raw Domain executes blocking body directly" 17 systhread_value;
+        check bool "raw Domain cleanup uses Fun.protect" true cleanup_ran;
+        check bool "ready raw Domain cannot enter an Eio mutex" true
+          mutex_rejected;
+        (match directory_result with
+         | Ok _ -> check bool "raw Domain prepares durable directory" true
+                     (Sys.is_directory durable_dir)
+         | Error (Masc.Keeper_fs_durable_directory.Directory_chain_failed _) ->
+           fail "raw Domain durable-directory chain failed"
+         | Error (Masc.Keeper_fs_durable_directory.Operation_failed (exn, _)) ->
+           fail ("raw Domain durable-directory operation failed: "
+                 ^ Printexc.to_string exn)))))
+
 let () =
   Alcotest.run "Executor_pool_ref Eio mutex safety"
     [ ( "offload"
@@ -96,5 +164,7 @@ let () =
             test_systhread_offload_raises_actionable_failure
         ; test_case "submit_or_inline preserves the mutex (fix)" `Quick
             test_submit_or_inline_preserves_mutex
+        ; test_case "ready raw Domain uses the non-Eio path" `Quick
+            test_ready_raw_domain_uses_non_eio_path
         ] )
     ]

--- a/test/test_file_lock_eio.ml
+++ b/test/test_file_lock_eio.ml
@@ -1,5 +1,20 @@
 open Alcotest
 
+let () =
+  if Array.length Sys.argv = 3 && String.equal Sys.argv.(1) "--hold-durable-lock"
+  then (
+    let fd =
+      Unix.openfile Sys.argv.(2) [ Unix.O_CREAT; Unix.O_WRONLY ] 0o644
+    in
+    Fun.protect
+      ~finally:(fun () -> Unix.close fd)
+      (fun () ->
+        Unix.lockf fd Unix.F_LOCK 0;
+        output_char stdout 'R';
+        flush stdout;
+        ignore (input_char stdin));
+    exit 0)
+
 let cleanup_if_exists path =
   if Sys.file_exists path then
     if Sys.is_directory path then
@@ -59,6 +74,82 @@ let test_with_lock_inside_eio () =
   check int "single call" 1 !calls;
   check bool "lock table tracked" true (File_lock_eio.lock_count () >= 1)
 
+let test_durable_lock_open_failure_is_typed () =
+  with_temp_path @@ fun path ->
+  let path = Filename.concat path "missing/target" in
+  match File_lock_eio.with_durable_lock ~lock_path:path (fun () -> ()) with
+  | Ok () -> fail "durable lock unexpectedly created a missing parent tree"
+  | Error error ->
+    check bool "failure phase is lock-file open" true
+      (match error.File_lock_eio.phase with
+       | File_lock_eio.Open_lock_file -> true
+       | Acquire_process_lock | Release_process_lock -> false)
+
+let with_external_lock_holder lock_path f =
+  let ready_read, ready_write = Unix.pipe () in
+  let release_read, release_write = Unix.pipe () in
+  let pid =
+    Unix.create_process Sys.executable_name
+      [| Sys.executable_name; "--hold-durable-lock"; lock_path |]
+      release_read ready_write Unix.stderr
+  in
+  Unix.close ready_write;
+  Unix.close release_read;
+  let released = ref false in
+  let release_holder () =
+    if not !released then (
+      released := true;
+      Fun.protect
+        ~finally:(fun () -> Unix.close release_write)
+        (fun () ->
+          check int "holder release signal" 1
+            (Unix.write_substring release_write "X" 0 1)))
+  in
+  let rec wait_for_child () =
+    match Unix.waitpid [] pid with
+    | result -> result
+    | exception Unix.Unix_error (Unix.EINTR, _, _) -> wait_for_child ()
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      release_holder ();
+      ignore (wait_for_child ()))
+    (fun () ->
+      let ready = Bytes.create 1 in
+      let count = Unix.read ready_read ready 0 1 in
+      Unix.close ready_read;
+      if count <> 1 || Bytes.get ready 0 <> 'R'
+      then fail "lock holder did not start";
+      f release_holder)
+
+let test_durable_lock_wait_is_cancellable () =
+  with_temp_path @@ fun path ->
+  let lock_path = path ^ ".lock" in
+  with_external_lock_holder lock_path @@ fun release_holder ->
+  Eio_main.run @@ fun _env ->
+  let started, signal_started = Eio.Promise.create () in
+  let body_ran = ref false in
+  let outcome =
+    Eio.Fiber.first
+      (fun () ->
+        Eio.Promise.resolve signal_started ();
+        match
+          File_lock_eio.with_durable_lock ~lock_path (fun () -> body_ran := true)
+        with
+        | Ok () -> `Unexpected_admission
+        | Error error -> `Failure (File_lock_eio.durable_lock_error_to_string error))
+      (fun () ->
+        Eio.Promise.await started;
+        Eio.Fiber.yield ();
+        release_holder ();
+        `Cancelled_waiter)
+  in
+  check bool "contended body did not run" false !body_ran;
+  match outcome with
+  | `Cancelled_waiter -> ()
+  | `Unexpected_admission -> fail "cross-process lock admitted while held"
+  | `Failure detail -> fail ("lock wait failed instead of cancelling: " ^ detail)
+
 let () =
   run "file_lock_eio"
     [
@@ -68,5 +159,9 @@ let () =
           test_case "acquire_flock_retry works without Eio context" `Quick
             test_acquire_flock_retry_without_eio;
           test_case "works inside Eio context" `Quick test_with_lock_inside_eio;
+          test_case "durable lock open failure is typed" `Quick
+            test_durable_lock_open_failure_is_typed;
+          test_case "durable cross-process wait is cancellable" `Quick
+            test_durable_lock_wait_is_cancellable;
         ] );
     ]

--- a/test/test_keeper_checkpoint_stale_guard.ml
+++ b/test/test_keeper_checkpoint_stale_guard.ml
@@ -1,11 +1,11 @@
-(** RFC-0225 §3.2: stale OAS checkpoint writes are no-op.
+(** RFC-0225 §3.2: stale OAS checkpoint writes are a disk-SSOT no-op.
 
     Two writers for the same session are last-writer-wins on disk; the
     2026-06-10 voice incident had a stale lane (turn_count=1324) clobber
     the conversation the newer lane had just saved (turn_count=1355).
-    [Keeper_checkpoint_store.save_oas] now skips a save whose [turn_count]
-    is older than the last one saved for the session without turning that
-    watermark hit into keeper lifecycle failure. *)
+    [Keeper_checkpoint_store.save_oas_classified] skips a save whose [turn_count] is older
+    than the canonical checkpoint observed inside the save transaction, without
+    turning that watermark hit into keeper lifecycle failure. *)
 
 open Alcotest
 open Masc
@@ -16,14 +16,14 @@ let () =
   |> Result.get_ok
 
 let temp_dir () =
-  let dir = Filename.temp_file "test_ckpt_stale_guard_" "" in
-  Unix.unlink dir;
-  Unix.mkdir dir 0o755;
-  dir
+  let root = Filename.temp_file "test_ckpt_stale_guard_" "" in
+  Unix.unlink root;
+  Unix.mkdir root 0o755;
+  let session_dir = Filename.concat root "session" in
+  Unix.mkdir session_dir 0o755;
+  session_dir
 
-let ensure_fs env =
-  if not (Fs_compat.has_fs ()) then
-    Fs_compat.set_fs (Eio.Stdenv.fs env)
+let ensure_fs env = Fs_compat.set_fs (Eio.Stdenv.fs env)
 
 let cleanup_dir dir =
   let rec rm path =
@@ -34,7 +34,7 @@ let cleanup_dir dir =
       else
         Unix.unlink path
   in
-  try rm dir with _ -> ()
+  try rm (Filename.dirname dir) with _ -> ()
 
 let make_checkpoint ~session_id ~turn_count ~marker =
   let messages = [
@@ -73,15 +73,14 @@ let make_checkpoint ~session_id ~turn_count ~marker =
   }
 
 let save_ok ~session_dir ckpt label =
-  match Keeper_checkpoint_store.save_oas ~session_dir ckpt with
-  | Ok () -> ()
+  match Keeper_checkpoint_store.save_oas_classified ~session_dir ckpt with
+  | Ok _ -> ()
   | Error e -> fail (label ^ " unexpectedly failed: " ^ e)
 
 let test_forward_equal_and_stale () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
   Eio.Switch.run @@ fun _sw ->
-  Keeper_checkpoint_store.For_testing.reset_stale_write_guard ();
   let session_dir = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir session_dir) (fun () ->
     let sid = "sess-guard" in
@@ -107,19 +106,16 @@ let test_forward_equal_and_stale () =
         on_disk.Agent_sdk.Checkpoint.turn_count
     | Error _ -> fail "load after rejection failed")
 
-(* Cold start: the process-local map is empty but the disk already has a
-   newer checkpoint — the guard must backfill from disk and still refuse. *)
-let test_cold_start_backfills_from_disk () =
+(* Every decision reloads the canonical disk SSOT; there is no process cache to
+   reset or reconstruct after a restart. *)
+let test_disk_is_the_watermark_ssot () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
   Eio.Switch.run @@ fun _sw ->
-  Keeper_checkpoint_store.For_testing.reset_stale_write_guard ();
   let session_dir = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir session_dir) (fun () ->
     let sid = "sess-cold" in
     save_ok ~session_dir (make_checkpoint ~session_id:sid ~turn_count:8 ~marker:"v8") "seed save";
-    (* Simulate a process restart: in-memory knowledge is gone. *)
-    Keeper_checkpoint_store.For_testing.reset_stale_write_guard ();
     (match
        Keeper_checkpoint_store.save_oas_classified ~session_dir
          (make_checkpoint ~session_id:sid ~turn_count:3 ~marker:"v3-stale")
@@ -130,35 +126,33 @@ let test_cold_start_backfills_from_disk () =
        check int "cold known turn_count backfilled from disk" 8 known_turn_count
      | Ok (Keeper_checkpoint_store.Saved _) ->
        fail "stale save advanced after cold start"
-     | Error e -> fail ("cold stale save returned lifecycle failure: " ^ e));
+    | Error e -> fail ("cold stale save returned lifecycle failure: " ^ e));
     save_ok ~session_dir (make_checkpoint ~session_id:sid ~turn_count:9 ~marker:"v9")
-      "forward save after cold start")
-
-let string_contains ~needle haystack =
-  let nlen = String.length needle and hlen = String.length haystack in
-  let rec at i = i + nlen <= hlen && (String.sub haystack i nlen = needle || at (i + 1)) in
-  nlen = 0 || at 0
+      "forward save from disk SSOT")
 
 (* The OAS per-turn pipeline builds checkpoints with an empty session_id (the
    OAS agent carries no session field). The keeper sink stamps a validated,
-   non-empty trace_id before persisting; [save_oas] fails loud on an empty
+   non-empty trace_id before persisting; the store fails loud on an empty
    session_id rather than letting the non-Eio fallback silently write
    "<session_dir>/.json" and drop the checkpoint. *)
 let test_empty_session_id_rejected () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
   Eio.Switch.run @@ fun _sw ->
-  Keeper_checkpoint_store.For_testing.reset_stale_write_guard ();
   let session_dir = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir session_dir) (fun () ->
     (match
-       Keeper_checkpoint_store.save_oas ~session_dir
+       Keeper_checkpoint_store.save_oas_classified ~session_dir
          (make_checkpoint ~session_id:"" ~turn_count:1 ~marker:"empty")
      with
-     | Ok () -> fail "save_oas accepted an empty session_id"
+     | Ok _ -> fail "checkpoint store accepted an empty session_id"
      | Error msg ->
-       check bool "error names the empty session_id" true
-         (string_contains ~needle:"empty session_id" msg));
+       let expected =
+         match Keeper_id.Trace_id.of_string "" with
+         | Ok _ -> fail "Trace_id parser accepted an empty identifier"
+         | Error reason -> reason
+       in
+       check string "error is the typed trace-id rejection" expected msg);
     (* The silent non-Eio fallback would have written "<session_dir>/.json". *)
     check bool "no orphan .json written for empty session_id" false
       (Sys.file_exists (Filename.concat session_dir ".json"));
@@ -172,16 +166,128 @@ let test_empty_session_id_rejected () =
         on_disk.Agent_sdk.Checkpoint.session_id
     | Error _ -> fail "load after stamped save failed")
 
+let test_invalid_existing_checkpoint_fails_closed () =
+  let session_dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir session_dir) (fun () ->
+    let session_id = "sess-corrupt" in
+    let path =
+      Keeper_checkpoint_store.oas_checkpoint_path ~session_dir ~session_id
+    in
+    let corrupt = "{not-a-checkpoint" in
+    Fs_compat.save_file path corrupt;
+    (match
+       Keeper_checkpoint_store.save_oas_classified
+         ~session_dir
+         (make_checkpoint ~session_id ~turn_count:9 ~marker:"must-not-write")
+     with
+     | Error _ -> ()
+     | Ok _ -> fail "corrupt existing checkpoint was treated as a cold store");
+    check string "corrupt canonical bytes remain untouched" corrupt
+      (Fs_compat.load_file path);
+    let mismatched =
+      make_checkpoint ~session_id:"another-session" ~turn_count:10
+        ~marker:"wrong-identity"
+      |> Agent_sdk.Checkpoint.to_string
+    in
+    Fs_compat.save_file path mismatched;
+    (match
+       Keeper_checkpoint_store.save_oas_classified
+         ~session_dir
+         (make_checkpoint ~session_id ~turn_count:11 ~marker:"must-not-replace")
+     with
+     | Error _ -> ()
+     | Ok _ -> fail "mismatched checkpoint identity was overwritten");
+    check string "mismatched canonical bytes remain untouched" mismatched
+      (Fs_compat.load_file path))
+
+let test_multi_domain_writers_leave_max_turn_on_disk () =
+  let session_dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir session_dir) (fun () ->
+    let session_id = "sess-domains" in
+    save_ok
+      ~session_dir
+      (make_checkpoint ~session_id ~turn_count:0 ~marker:"seed")
+      "seed save";
+    let turns = [ 4; 1; 8; 3; 7; 2; 9; 6; 5 ] in
+    let writer_count = List.length turns in
+    let ready = Atomic.make 0 in
+    let start = Atomic.make false in
+    let writer turn_count =
+      Atomic.incr ready;
+      while not (Atomic.get start) do
+        Domain.cpu_relax ()
+      done;
+      Keeper_checkpoint_store.save_oas_classified
+        ~session_dir
+        (make_checkpoint
+           ~session_id
+           ~turn_count
+           ~marker:(Printf.sprintf "v%d" turn_count))
+    in
+    let domains = List.map (fun turn -> Domain.spawn (fun () -> writer turn)) turns in
+    while Atomic.get ready <> writer_count do
+      Domain.cpu_relax ()
+    done;
+    Atomic.set start true;
+    List.iter
+      (fun domain ->
+        match Domain.join domain with
+        | Ok _ -> ()
+        | Error error -> fail ("concurrent checkpoint save failed: " ^ error))
+      domains;
+    let expected = List.fold_left max min_int turns in
+    match Keeper_checkpoint_store.load_oas ~session_dir ~session_id with
+    | Error _ -> fail "load after concurrent saves failed"
+    | Ok checkpoint ->
+      check int "canonical disk retains the maximum turn" expected
+        checkpoint.Agent_sdk.Checkpoint.turn_count)
+
+let test_ready_runtime_raw_domain_save () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let pool = Domain_pool.create ~sw ~domain_count:1 (Eio.Stdenv.domain_mgr env) in
+  Executor_pool_ref.set (Domain_pool.executor_pool pool);
+  Eio_guard.enable ();
+  Fun.protect ~finally:Eio_guard.disable @@ fun () ->
+  let base_dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_dir) @@ fun () ->
+  let session_id = "raw-domain-ready" in
+  let session_dir = Filename.concat base_dir "new-session" in
+  let result =
+    Domain.spawn (fun () ->
+      Keeper_checkpoint_store.save_oas_classified ~session_dir
+        (make_checkpoint ~session_id ~turn_count:11 ~marker:"raw-domain"))
+    |> Domain.join
+  in
+  (match result with
+   | Ok (Keeper_checkpoint_store.Saved _) -> ()
+   | Ok (Keeper_checkpoint_store.Stale_noop _) -> fail "new raw-domain save was stale"
+   | Error detail -> fail ("ready-state raw-domain save failed: " ^ detail));
+  check bool "save retains create-first session contract" true
+    (Sys.file_exists session_dir);
+  check bool "stable lock is outside removable session subtree" true
+    (Sys.file_exists (session_dir ^ ".checkpoint.lock"));
+  match Keeper_checkpoint_store.load_oas ~session_dir ~session_id with
+  | Error _ -> fail "raw-domain checkpoint did not round-trip"
+  | Ok checkpoint -> check int "raw-domain turn persisted" 11 checkpoint.turn_count
+
 let () =
   run "Keeper_checkpoint_store checkpoint watermark (RFC-0225 §3.2)"
     [
-      ( "save_oas guard",
+      ( "checkpoint transaction",
         [
           test_case "forward and equal saves pass, stale save is no-op" `Quick
             test_forward_equal_and_stale;
-          test_case "cold start backfills last turn_count from disk" `Quick
-            test_cold_start_backfills_from_disk;
+          test_case "canonical disk is the watermark SSOT" `Quick
+            test_disk_is_the_watermark_ssot;
           test_case "empty session_id is refused, not silently dropped" `Quick
             test_empty_session_id_rejected;
+          test_case "invalid canonical checkpoint fails closed" `Quick
+            test_invalid_existing_checkpoint_fails_closed;
+          test_case "multi-domain writers leave max turn on disk" `Quick
+            test_multi_domain_writers_leave_max_turn_on_disk;
+          test_case "ready runtime raw Domain saves through Unix context" `Quick
+            test_ready_runtime_raw_domain_save;
         ] );
     ]

--- a/test/test_keeper_replay_checkpoint.ml
+++ b/test/test_keeper_replay_checkpoint.ml
@@ -431,7 +431,6 @@ let test_media_degraded_projection_persists_canonical_checkpoint () =
     |> expect_ok
   in
   with_temp_dir (fun session_dir ->
-    Masc.Keeper_checkpoint_store.For_testing.reset_stale_write_guard ();
     (match
        Masc.Keeper_checkpoint_store.save_oas_classified
          ~session_dir


### PR DESCRIPTION
## Stack

- Base: #24557
- This is the third checkpoint-atomicity slice and intentionally targets `codex/cancellable-durable-lock-20260715`.
- Merge/rebase #24548, then #24557, before this PR.

## What changed

- removes the process-local checkpoint watermark cache; the canonical checkpoint file is now the only admission SSOT
- executes strict load, monotonic comparison, durable atomic publication, and history capture under one stable per-session transaction lock
- derives the lock only from the canonical session path; its inode lives beside the removable session subtree
- wires shutdown session purge through that same lock and canonical path
- treats only typed `ENOENT` as a cold store
- fails closed for corrupt/unreadable/non-regular checkpoints and mismatched embedded session identities
- uses strict payload fsync + rename + parent-directory fsync for canonical publication
- routes raw Domains through Unix I/O even when the process-wide Eio runtime and executor pool are live
- hard-deletes the obsolete `save_oas` wrapper, test-only cache reset, and primary/fallback archive metric split

History archive failure remains explicit best-effort: warning + checkpoint-failure metric, without weakening canonical publication.

## Regression proof

Focused tests cover:

- forward/equal/stale classification from disk
- invalid session identity rejection
- corrupt and identity-mismatched canonical files remaining untouched
- nine concurrent raw-Domain writers leaving the maximum turn on disk
- raw-Domain saving while Eio and an executor pool are live
- create-first session behavior and stable lock placement outside the removable subtree

## Validation

- `ocamlformat --check` on all changed OCaml files
- parser checks with `ocamlc -stop-after parsing -c` on all changed OCaml files
- `git diff --check`
- structural searches confirm no process watermark/cache-reset/`save_oas` legacy remains
- exact diff: 382 additions / 212 deletions

Per repository policy, no local full Dune build/test was claimed; CI is the build authority.