### PR TITLE
refactor(keeper): expose typed delegated turn entry

### DIFF
--- a/lib/keeper/keeper_invocation_contract.ml
+++ b/lib/keeper/keeper_invocation_contract.ml
@@ -222,7 +222,7 @@ let run_ref_of_json json =
 
 let run_id reference = reference.run_id
 
-let run_ref_matches_entry reference entry =
+let run_ref_matches_entry reference (entry : Keeper_msg_async.entry) =
   String.equal reference.run_id entry.Keeper_msg_async.request_id
   && String.equal
        (target_name_of_target reference.target)
@@ -346,7 +346,7 @@ let entry_result = function
     ]
 ;;
 
-let delegate_entry_to_json entry =
+let delegate_entry_to_json (entry : Keeper_msg_async.entry) =
   let contract = result_contract entry in
   let* target_name =
     Keeper_id.Keeper_name.of_string entry.Keeper_msg_async.keeper_name

--- a/lib/keeper/keeper_invocation_contract.ml
+++ b/lib/keeper/keeper_invocation_contract.ml
@@ -319,7 +319,11 @@ let delegate_submission_error_to_json request = function
 let entry_result = function
   | Keeper_msg_async.Queued | Keeper_msg_async.Running -> []
   | Keeper_msg_async.Done { body; data; _ } ->
-    [ "result", Option.value ~default:(`String body) data ]
+    [ ( "result"
+      , match data with
+        | Some value -> value
+        | None -> `String body )
+    ]
   | Keeper_msg_async.Lost { reason } ->
     [ "result", `Assoc [ "error", `String "invocation_lost"; "reason", `String reason ] ]
   | Keeper_msg_async.Cancelled { reason; cancelled_by } ->

--- a/lib/keeper/keeper_invocation_contract.ml
+++ b/lib/keeper/keeper_invocation_contract.ml
@@ -35,8 +35,66 @@ type request_error =
   | Invalid_target of string
   | Empty_prompt
   | Invalid_entry_projection
+  | Invalid_wire_value of
+      { field : string
+      ; expected : string
+      }
+  | Run_ref_mismatch
 
 let ( let* ) = Result.bind
+
+let invalid_wire_value ~field ~expected =
+  Error (Invalid_wire_value { field; expected })
+;;
+
+let object_fields ~field = function
+  | `Assoc fields -> Ok fields
+  | _ -> invalid_wire_value ~field ~expected:"object"
+;;
+
+let exact_fields ~field ~allowed fields =
+  let keys = List.map fst fields in
+  if List.length keys <> List.length (List.sort_uniq String.compare keys)
+  then invalid_wire_value ~field ~expected:"object with unique fields"
+  else
+    match List.find_opt (fun key -> not (List.mem key allowed)) keys with
+    | None -> Ok ()
+    | Some key ->
+      invalid_wire_value
+        ~field:(field ^ "." ^ key)
+        ~expected:"no undeclared field"
+;;
+
+let required_field ~field name fields =
+  match List.assoc_opt name fields with
+  | Some value -> Ok value
+  | None -> invalid_wire_value ~field:(field ^ "." ^ name) ~expected:"required field"
+;;
+
+let string_value ~field = function
+  | `String value -> Ok value
+  | _ -> invalid_wire_value ~field ~expected:"string"
+;;
+
+let target_of_json json =
+  let* fields = object_fields ~field:"target" json in
+  let* () = exact_fields ~field:"target" ~allowed:[ "kind"; "name" ] fields in
+  let* kind = required_field ~field:"target" "kind" fields in
+  let* kind = string_value ~field:"target.kind" kind in
+  let* name = required_field ~field:"target" "name" fields in
+  let* name = string_value ~field:"target.name" name in
+  if not (String.equal kind "keeper")
+  then invalid_wire_value ~field:"target.kind" ~expected:"keeper"
+  else
+    Keeper_id.Keeper_name.of_string name
+    |> Result.map (fun name -> Keeper name)
+    |> Result.map_error (fun reason -> Invalid_target reason)
+;;
+
+let capability_of_json ~field = function
+  | `String value when String.equal value "invoke_turn" -> Ok Invoke_turn
+  | _ -> invalid_wire_value ~field ~expected:"invoke_turn"
+;;
 
 let request ~keeper_name ~prompt =
   let* keeper_name =
@@ -48,15 +106,38 @@ let request ~keeper_name ~prompt =
   else Ok { target = Keeper keeper_name; capability = Invoke_turn; prompt }
 ;;
 
+let request_of_json json =
+  let* fields = object_fields ~field:"delegate" json in
+  let* () =
+    exact_fields
+      ~field:"delegate"
+      ~allowed:[ "target"; "capability"; "prompt" ]
+      fields
+  in
+  let* target_json = required_field ~field:"delegate" "target" fields in
+  let* target = target_of_json target_json in
+  let* capability_json = required_field ~field:"delegate" "capability" fields in
+  let* capability = capability_of_json ~field:"delegate.capability" capability_json in
+  let* prompt_json = required_field ~field:"delegate" "prompt" fields in
+  let* prompt = string_value ~field:"delegate.prompt" prompt_json in
+  if String.equal prompt "" then Error Empty_prompt else Ok { target; capability; prompt }
+;;
+
 let request_error_to_string = function
   | Invalid_target reason -> reason
   | Empty_prompt -> "message is required"
   | Invalid_entry_projection -> "Keeper invocation entry projection is not an object"
+  | Invalid_wire_value { field; expected } ->
+    Printf.sprintf "%s must be %s" field expected
+  | Run_ref_mismatch -> "run_ref does not identify the stored Keeper invocation"
+;;
+
+let target_name_of_target = function
+  | Keeper name -> Keeper_id.Keeper_name.to_string name
 ;;
 
 let target_name (request : request) =
-  match request.target with
-  | Keeper name -> Keeper_id.Keeper_name.to_string name
+  target_name_of_target request.target
 ;;
 
 let prompt (request : request) = request.prompt
@@ -83,8 +164,7 @@ let submission_receipt (request : request) outcome =
     Reconciliation_required { run_ref = reference; reason }
 ;;
 
-let result_contract entry =
-  match entry.Keeper_msg_async.status with
+let result_contract_of_status = function
   | Keeper_msg_async.Queued -> Awaiting_execution
   | Keeper_msg_async.Running -> Running
   | Keeper_msg_async.Cancelling _ -> Cancellation_requested
@@ -98,6 +178,8 @@ let result_contract entry =
      | Keeper_turn_outcome.Visible_reply
      | Keeper_turn_outcome.No_visible_reply -> Completed)
 ;;
+
+let result_contract entry = result_contract_of_status entry.Keeper_msg_async.status
 
 let capability_to_string = function
   | Invoke_turn -> "invoke_turn"
@@ -119,6 +201,34 @@ let run_ref_to_json reference =
     ]
 ;;
 
+let run_ref_of_json json =
+  let* fields = object_fields ~field:"run_ref" json in
+  let* () =
+    exact_fields
+      ~field:"run_ref"
+      ~allowed:[ "run_id"; "target"; "capability" ]
+      fields
+  in
+  let* run_id_json = required_field ~field:"run_ref" "run_id" fields in
+  let* run_id = string_value ~field:"run_ref.run_id" run_id_json in
+  let* target_json = required_field ~field:"run_ref" "target" fields in
+  let* target = target_of_json target_json in
+  let* capability_json = required_field ~field:"run_ref" "capability" fields in
+  let* capability = capability_of_json ~field:"run_ref.capability" capability_json in
+  if String.equal run_id ""
+  then invalid_wire_value ~field:"run_ref.run_id" ~expected:"non-empty string"
+  else Ok { run_id; target; capability }
+;;
+
+let run_id reference = reference.run_id
+
+let run_ref_matches_entry reference entry =
+  String.equal reference.run_id entry.Keeper_msg_async.request_id
+  && String.equal
+       (target_name_of_target reference.target)
+       entry.Keeper_msg_async.keeper_name
+;;
+
 let result_contract_to_string = function
   | Awaiting_execution -> "awaiting_execution"
   | Publication_uncertain -> "publication_uncertain"
@@ -131,12 +241,12 @@ let result_contract_to_string = function
 ;;
 
 let submission_to_json (request : request) outcome =
-  let common reference status result_contract =
+  let common reference status contract =
     [ "request_id", `String outcome.Keeper_msg_async.request_id
     ; "keeper_name", `String (target_name request)
     ; "status", `String status
     ; "run_ref", run_ref_to_json reference
-    ; "result_contract", `String (result_contract_to_string result_contract)
+    ; "result_contract", `String (result_contract_to_string contract)
     ]
   in
   match submission_receipt request outcome with
@@ -155,6 +265,112 @@ let submission_to_json (request : request) outcome =
            , `String
                "Request publication is uncertain. Query masc_keeper_msg_result with this exact run_ref.run_id; do not resubmit." )
          ])
+;;
+
+let delegate_submission_to_json (request : request) outcome =
+  let common reference result_contract =
+    [ "run_ref", run_ref_to_json reference
+    ; "result_contract", `String (result_contract_to_string result_contract)
+    ]
+  in
+  match submission_receipt request outcome with
+  | Durable_run reference ->
+    `Assoc
+      (common reference Awaiting_execution
+       @ [ ( "message"
+           , `String
+               "Keeper turn accepted. The caller lane may continue; query masc_keeper_delegate_status with the exact run_ref." )
+         ])
+  | Reconciliation_required { run_ref = reference; reason } ->
+    `Assoc
+      (common reference Publication_uncertain
+       @ [ "reason", `String reason
+         ; ( "operator_instruction"
+           , `String
+               "Request publication is uncertain. Query masc_keeper_delegate_status with this exact run_ref; do not resubmit." )
+         ])
+;;
+
+let delegate_submission_error_to_json request = function
+  | Keeper_msg_async.Submit_rejected rejection ->
+    Keeper_msg_async.access_rejection_to_json rejection
+  | Keeper_msg_async.Submit_invalid_keeper_name { reason } ->
+    `Assoc [ "error", `String "invalid_target"; "message", `String reason ]
+  | Keeper_msg_async.Initial_persistence_failed { reason } ->
+    `Assoc [ "error", `String "invocation_persistence_failed"; "message", `String reason ]
+  | Keeper_msg_async.Acceptance_persistence_failed { request_id; reason } ->
+    `Assoc
+      [ "error", `String "invocation_acceptance_uncertain"
+      ; "run_ref", run_ref_to_json (run_ref request request_id)
+      ; "result_contract", `String (result_contract_to_string Publication_uncertain)
+      ; "message", `String reason
+      ]
+  | Keeper_msg_async.Background_switch_unavailable { reason } ->
+    `Assoc [ "error", `String "background_switch_unavailable"; "message", `String reason ]
+  | Keeper_msg_async.Background_fork_failed { request_id; reason } ->
+    `Assoc
+      [ "error", `String "invocation_background_start_failed"
+      ; "run_ref", run_ref_to_json (run_ref request request_id)
+      ; "result_contract", `String (result_contract_to_string Failed)
+      ; "message", `String reason
+      ]
+;;
+
+let entry_result = function
+  | Keeper_msg_async.Queued | Keeper_msg_async.Running -> []
+  | Keeper_msg_async.Done { body; data; _ } ->
+    [ "result", Option.value ~default:(`String body) data ]
+  | Keeper_msg_async.Lost { reason } ->
+    [ "result", `Assoc [ "error", `String "invocation_lost"; "reason", `String reason ] ]
+  | Keeper_msg_async.Cancelled { reason; cancelled_by } ->
+    [ ( "result"
+      , `Assoc
+          [ "reason", `String reason
+          ; "cancelled_by", `String cancelled_by
+          ] )
+    ]
+  | Keeper_msg_async.Cancelling { reason; cancelled_by } ->
+    [ ( "result"
+      , `Assoc
+          [ "reason", `String reason
+          ; "cancelled_by", `String cancelled_by
+          ] )
+    ]
+  | Keeper_msg_async.Persistence_failed { attempted_status; reason } ->
+    [ ( "result"
+      , `Assoc
+          [ "error", `String "invocation_persistence_failed"
+          ; "attempted_status", `String attempted_status
+          ; "reason", `String reason
+          ] )
+    ]
+;;
+
+let delegate_entry_to_json entry =
+  let contract = result_contract entry in
+  let* target_name =
+    Keeper_id.Keeper_name.of_string entry.Keeper_msg_async.keeper_name
+    |> Result.map_error (fun reason -> Invalid_target reason)
+  in
+  let reference =
+    { run_id = entry.request_id
+    ; target = Keeper target_name
+    ; capability = Invoke_turn
+    }
+  in
+  let timing =
+    match entry.completed_at with
+    | Some completed_at -> [ "completed_at", `Float completed_at ]
+    | None -> []
+  in
+  Ok
+    (`Assoc
+       ([ "run_ref", run_ref_to_json reference
+        ; "result_contract", `String (result_contract_to_string contract)
+        ; "submitted_at", `Float entry.submitted_at
+        ]
+        @ timing
+        @ entry_result entry.status))
 ;;
 
 let entry_to_json entry =
@@ -178,4 +394,43 @@ let entry_to_json entry =
             ; "result_contract", `String (result_contract_to_string contract)
             ]))
   | _ -> Error Invalid_entry_projection
+;;
+
+let delegate_cancellation_to_json reference result =
+  let common = [ "run_ref", run_ref_to_json reference ] in
+  let contract status =
+    [ "result_contract", `String (result_contract_to_string status) ]
+  in
+  let durability = function
+    | Keeper_msg_async.Durably_committed -> [ "durability", `String "durable" ]
+    | Keeper_msg_async.Published_unconfirmed { reason } ->
+      [ "durability", `String "publication_uncertain"; "warning", `String reason ]
+  in
+  let fields =
+    match result with
+    | Keeper_msg_async.Cancellation_requested state ->
+      contract Cancellation_requested @ durability state
+    | Keeper_msg_async.Cancel_not_found -> [ "error", `String "run_not_found" ]
+    | Keeper_msg_async.Cancel_unreadable reason ->
+      [ "error", `String "invocation_record_unreadable"; "message", `String reason ]
+    | Keeper_msg_async.Cancel_rejected rejection ->
+      [ "error", `String "invocation_access_rejected"
+      ; "reason", Keeper_msg_async.access_rejection_to_json rejection
+      ]
+    | Keeper_msg_async.Cancel_worker_ownership_unknown status ->
+      contract (result_contract_of_status status)
+      @ [ "error", `String "invocation_worker_ownership_unknown" ]
+    | Keeper_msg_async.Cancel_already_terminal status ->
+      contract (result_contract_of_status status)
+      @ [ "error", `String "invocation_already_terminal" ]
+    | Keeper_msg_async.Cancel_persistence_failed { reason } ->
+      [ "error", `String "cancellation_persistence_failed"; "message", `String reason ]
+    | Keeper_msg_async.Cancel_worker_signal_failed { durability = state; reason } ->
+      contract Cancellation_requested
+      @ durability state
+      @ [ "error", `String "cancellation_worker_signal_failed"; "message", `String reason ]
+    | Keeper_msg_async.Cancel_state_invariant_failed { reason } ->
+      [ "error", `String "cancellation_state_invariant_failed"; "message", `String reason ]
+  in
+  `Assoc (common @ fields)
 ;;

--- a/lib/keeper/keeper_invocation_contract.mli
+++ b/lib/keeper/keeper_invocation_contract.mli
@@ -10,11 +10,7 @@ type target = Keeper of Keeper_id.Keeper_name.t
 
 type request
 
-type run_ref =
-  { run_id : string
-  ; target : target
-  ; capability : capability
-  }
+type run_ref
 
 type submission_receipt =
   | Durable_run of run_ref
@@ -37,11 +33,24 @@ type request_error =
   | Invalid_target of string
   | Empty_prompt
   | Invalid_entry_projection
+  | Invalid_wire_value of
+      { field : string
+      ; expected : string
+      }
+  | Run_ref_mismatch
 
 val request : keeper_name:string -> prompt:string -> (request, request_error) result
+val request_of_json : Yojson.Safe.t -> (request, request_error) result
 val request_error_to_string : request_error -> string
 val target_name : request -> string
 val prompt : request -> string
+val target_of_json : Yojson.Safe.t -> (target, request_error) result
+val target_to_json : target -> Yojson.Safe.t
+val target_name_of_target : target -> string
+val run_ref_of_json : Yojson.Safe.t -> (run_ref, request_error) result
+val run_ref_to_json : run_ref -> Yojson.Safe.t
+val run_id : run_ref -> string
+val run_ref_matches_entry : run_ref -> Keeper_msg_async.entry -> bool
 
 val submit
   :  background_sw:Eio.Switch.t
@@ -60,6 +69,19 @@ val result_contract : Keeper_msg_async.entry -> result_contract
 val submission_to_json
   :  request -> Keeper_msg_async.submit_outcome -> Yojson.Safe.t
 
+val delegate_submission_to_json
+  :  request -> Keeper_msg_async.submit_outcome -> Yojson.Safe.t
+
+val delegate_submission_error_to_json
+  :  request -> Keeper_msg_async.submit_error -> Yojson.Safe.t
+
+val delegate_cancellation_to_json
+  :  run_ref -> Keeper_msg_async.cancel_result -> Yojson.Safe.t
+
 val entry_to_json
+  :  Keeper_msg_async.entry
+  -> (Yojson.Safe.t, request_error) result
+
+val delegate_entry_to_json
   :  Keeper_msg_async.entry
   -> (Yojson.Safe.t, request_error) result

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -219,12 +219,33 @@ let user_oas_blocks_of_args args =
       | Ok [] -> Ok None
       | Ok blocks -> Ok (Some blocks)
 
-let turn_resources_error failure =
+type invocation_surface =
+  | Direct_message
+  | Keeper_delegate
+
+let invocation_tool_name = function
+  | Direct_message -> "masc_keeper_msg"
+  | Keeper_delegate -> "masc_keeper_delegate"
+;;
+
+let invocation_turn_type = function
+  | Direct_message -> "direct"
+  | Keeper_delegate -> "delegate"
+;;
+
+let invocation_args request =
+  `Assoc
+    [ "name", `String (Keeper_invocation_contract.target_name request)
+    ; "message", `String (Keeper_invocation_contract.prompt request)
+    ]
+;;
+
+let turn_resources_error ~surface failure =
   let detail =
     Keeper_publication_recovery_scope.failure_to_string failure
   in
   tool_result_error_data
-    ~tool_name:"masc_keeper_msg"
+    ~tool_name:(invocation_tool_name surface)
     (`Assoc
        [ "error", `String "keeper_turn_resources_unavailable"
        ; "failure_class", `String "runtime_failure"
@@ -232,22 +253,17 @@ let turn_resources_error failure =
        ])
 ;;
 
-let preflight_keeper_msg ctx args :
-    (Keeper_invocation_contract.request, string) result =
-  let name = get_string args "name" "" in
-  let message = get_string args "message" "" in
-  match Keeper_invocation_contract.request ~keeper_name:name ~prompt:message with
-  | Error error ->
-    Error (Keeper_invocation_contract.request_error_to_string error)
-  | Ok request ->
+let preflight_keeper_invocation ~surface ctx args request =
+  let name = Keeper_invocation_contract.target_name request in
     let direct_reply = get_bool args "direct_reply" false in
-    match Keeper_meta_contract.reject_removed_model_args ~tool_name:"masc_keeper_msg" args with
+    let tool_name = invocation_tool_name surface in
+    match Keeper_meta_contract.reject_removed_model_args ~tool_name args with
     | Error e -> Error e
     | Ok () ->
-    (match reject_removed_keeper_input_keys ~tool_name:"masc_keeper_msg" args with
+    (match reject_removed_keeper_input_keys ~tool_name args with
     | Error e -> Error e
     | Ok () ->
-    (match reject_removed_keeper_msg_input_keys ~tool_name:"masc_keeper_msg" args with
+    (match reject_removed_keeper_msg_input_keys ~tool_name args with
     | Error e -> Error e
     | Ok () ->
     (match user_oas_blocks_of_args args with
@@ -272,6 +288,22 @@ let preflight_keeper_msg ctx args :
           Keeper_turn_helpers.ensure_local_discovery_ready effective_models
           |> Result.map (fun () -> request))))
 
+let preflight_keeper_msg ctx args =
+  let name = get_string args "name" "" in
+  let message = get_string args "message" "" in
+  match Keeper_invocation_contract.request ~keeper_name:name ~prompt:message with
+  | Error error -> Error (Keeper_invocation_contract.request_error_to_string error)
+  | Ok request -> preflight_keeper_invocation ~surface:Direct_message ctx args request
+;;
+
+let preflight_keeper_delegate ctx request =
+  preflight_keeper_invocation
+    ~surface:Keeper_delegate
+    ctx
+    (invocation_args request)
+    request
+;;
+
 (* -- Direct-message turn FSM wrapper ---------------------------------------- *)
 
 (** Run a direct [masc_keeper_msg] turn with the same typed FSM transitions
@@ -288,7 +320,7 @@ let preflight_keeper_msg ctx args :
 
     The wrapper is intentionally thin: it does not duplicate metrics,
     receipt, or meta writes — those remain in
-    [run_keeper_msg_turn_admitted].  It only restores FSM observability so
+    [run_keeper_invocation_turn_admitted].  It only restores FSM observability so
     direct and autonomous turns share the same state-machine read model. *)
 let run_direct_turn_with_fsm ~(keeper_name : string) ~(turn_id : int) f =
   Keeper_turn_fsm.emit_transition
@@ -372,11 +404,12 @@ let run_direct_turn_with_fsm ~(keeper_name : string) ~(turn_id : int) f =
    [handle_keeper_msg] calls this directly because the validation guard
    below exits first). Do not add keeper-state mutation ahead of the
    validation guards without moving it behind the slot. *)
-let run_keeper_msg_turn_admitted
+let run_keeper_invocation_turn_admitted
       ?on_text_delta
       ?on_event
       ?event_bus
       ?continuation_channel
+      ~surface
       ctx
       args
   : tool_result
@@ -385,7 +418,7 @@ let run_keeper_msg_turn_admitted
     ~name:"keeper_turn"
     ~attrs:[
       "keeper.name", `String (get_string args "name" "");
-      "masc.turn_type", `String "direct";
+      "masc.turn_type", `String (invocation_turn_type surface);
     ]
     (fun _trace_id ->
   let on_event =
@@ -420,13 +453,14 @@ let run_keeper_msg_turn_admitted
     let direct_reply = get_bool args "direct_reply" false in
     let channel_session_key = get_string_opt args "channel_session_key" in
     let channel = get_string args "channel" "" in
-    (match Keeper_meta_contract.reject_removed_model_args ~tool_name:"masc_keeper_msg" args with
+    let tool_name = invocation_tool_name surface in
+    (match Keeper_meta_contract.reject_removed_model_args ~tool_name args with
     | Error e -> tool_result_error ("" ^ e)
     | Ok () ->
-    (match reject_removed_keeper_input_keys ~tool_name:"masc_keeper_msg" args with
+    (match reject_removed_keeper_input_keys ~tool_name args with
     | Error e -> tool_result_error ("" ^ e)
     | Ok () ->
-    (match reject_removed_keeper_msg_input_keys ~tool_name:"masc_keeper_msg" args with
+    (match reject_removed_keeper_msg_input_keys ~tool_name args with
     | Error e -> tool_result_error ("" ^ e)
     | Ok () ->
     (match user_oas_blocks_of_args args with
@@ -443,7 +477,7 @@ let run_keeper_msg_turn_admitted
            ~base_path:ctx.config.base_path
            ~keeper_name:meta0.name
        with
-       | Error failure -> turn_resources_error failure
+       | Error failure -> turn_resources_error ~surface failure
        | Ok { entry; publication_recovery } ->
       let meta = entry.meta in
       (match
@@ -1007,13 +1041,14 @@ let run_keeper_msg_turn_admitted
 
 )))))))))
 
-let handle_keeper_msg
+let handle_keeper_invocation
       ?on_text_delta
       ?on_event
       ?event_bus
       ?continuation_channel
       ?on_admission_rejected
       ?on_admitted
+      ~surface
       ctx
       args
   : tool_result
@@ -1027,11 +1062,12 @@ let handle_keeper_msg
   if not (validate_name name) then
     (* Invalid input cannot reach run_turn; let the admitted body produce
        its precise validation error without holding the slot. *)
-    run_keeper_msg_turn_admitted
+    run_keeper_invocation_turn_admitted
       ?on_text_delta
       ?on_event
       ?event_bus
       ?continuation_channel
+      ~surface
       ctx
       args
   else
@@ -1044,22 +1080,24 @@ let handle_keeper_msg
           | Some notify ->
             (match notify () with
              | Ok () ->
-               run_keeper_msg_turn_admitted
+               run_keeper_invocation_turn_admitted
                  ?on_text_delta
                  ?on_event
                  ?event_bus
                  ?continuation_channel
+                 ~surface
                  ctx
                  args
              | Error detail ->
                tool_result_error
                  ("keeper turn admission persistence failed: " ^ detail))
           | None ->
-            run_keeper_msg_turn_admitted
+            run_keeper_invocation_turn_admitted
               ?on_text_delta
               ?on_event
               ?event_bus
               ?continuation_channel
+              ~surface
               ctx
               args)
     with
@@ -1097,6 +1135,36 @@ let handle_keeper_msg
              waiting
              in_flight_text)
 
+let handle_keeper_msg
+      ?on_text_delta
+      ?on_event
+      ?event_bus
+      ?continuation_channel
+      ?on_admission_rejected
+      ?on_admitted
+      ctx
+      args
+  =
+  handle_keeper_invocation
+    ?on_text_delta
+    ?on_event
+    ?event_bus
+    ?continuation_channel
+    ?on_admission_rejected
+    ?on_admitted
+    ~surface:Direct_message
+    ctx
+    args
+;;
+
+let handle_keeper_delegate ?event_bus ctx request =
+  handle_keeper_invocation
+    ?event_bus
+    ~surface:Keeper_delegate
+    ctx
+    (invocation_args request)
+;;
+
 let handle_keeper_msg_if_free
       ?on_text_delta
       ?on_event
@@ -1113,11 +1181,12 @@ let handle_keeper_msg_if_free
   let name = get_string args "name" "" in
   if not (validate_name name) then
     `Ran
-      (run_keeper_msg_turn_admitted
+      (run_keeper_invocation_turn_admitted
          ?on_text_delta
          ?on_event
          ?event_bus
          ?continuation_channel
+         ~surface:Direct_message
          ctx
          args)
   else
@@ -1125,10 +1194,11 @@ let handle_keeper_msg_if_free
       ~base_path:ctx.config.base_path
       ~keeper_name:name
       (fun () ->
-        run_keeper_msg_turn_admitted
+        run_keeper_invocation_turn_admitted
           ?on_text_delta
           ?on_event
           ?event_bus
           ?continuation_channel
+          ~surface:Direct_message
           ctx
           args)

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -233,11 +233,14 @@ let invocation_turn_type = function
   | Keeper_delegate -> "delegate"
 ;;
 
-let invocation_args request =
-  `Assoc
-    [ "name", `String (Keeper_invocation_contract.target_name request)
-    ; "message", `String (Keeper_invocation_contract.prompt request)
-    ]
+let direct_invocation_request args =
+  let name = get_string args "name" "" in
+  let message = get_string args "message" "" in
+  if not (validate_name name)
+  then Error (invalid_name_error name)
+  else
+    Keeper_invocation_contract.request ~keeper_name:name ~prompt:message
+    |> Result.map_error Keeper_invocation_contract.request_error_to_string
 ;;
 
 let turn_resources_error ~surface failure =
@@ -300,7 +303,7 @@ let preflight_keeper_delegate ctx request =
   preflight_keeper_invocation
     ~surface:Keeper_delegate
     ctx
-    (invocation_args request)
+    (`Assoc [])
     request
 ;;
 
@@ -399,17 +402,16 @@ let run_direct_turn_with_fsm ~(keeper_name : string) ~(turn_id : int) f =
    or a concurrent turn can clobber the checkpoint and regress
    [total_turns] (2026-06-10 RCA, RFC-0225 §1).
 
-   Precondition: the caller holds the keeper's turn slot, OR the call
-   returns before any keeper-state read/write (the invalid-name path in
-   [handle_keeper_msg] calls this directly because the validation guard
-   below exits first). Do not add keeper-state mutation ahead of the
-   validation guards without moving it behind the slot. *)
+   Precondition: the caller holds the keeper's turn slot. Public direct-message
+   and typed-delegate entrypoints construct a valid invocation request before
+   reaching this function. *)
 let run_keeper_invocation_turn_admitted
       ?on_text_delta
       ?on_event
       ?event_bus
       ?continuation_channel
       ~surface
+      ~request
       ctx
       args
   : tool_result
@@ -417,7 +419,7 @@ let run_keeper_invocation_turn_admitted
   with_span
     ~name:"keeper_turn"
     ~attrs:[
-      "keeper.name", `String (get_string args "name" "");
+      "keeper.name", `String (Keeper_invocation_contract.target_name request);
       "masc.turn_type", `String (invocation_turn_type surface);
     ]
     (fun _trace_id ->
@@ -432,13 +434,8 @@ let run_keeper_invocation_turn_admitted
              | Agent_sdk.Types.ContentBlockDelta { delta = TextDelta text; _ } -> cb text
              | _ -> ()))
   in
-  let name = get_string args "name" "" in
-  let message = get_string args "message" "" in
-  if not (validate_name name) then
-    tool_result_error (invalid_name_error name)
-  else if message = "" then
-    tool_result_error "message is required"
-  else
+  let name = Keeper_invocation_contract.target_name request in
+  let message = Keeper_invocation_contract.prompt request in
     let turn_instructions =
       match get_string_opt args "turn_instructions" with
       | Some _ as ti -> ti
@@ -1049,6 +1046,7 @@ let handle_keeper_invocation
       ?on_admission_rejected
       ?on_admitted
       ~surface
+      ~request
       ctx
       args
   : tool_result
@@ -1058,48 +1056,38 @@ let handle_keeper_invocation
     | Some _ -> event_bus
     | None -> Keeper_event_bus.get ()
   in
-  let name = get_string args "name" "" in
-  if not (validate_name name) then
-    (* Invalid input cannot reach run_turn; let the admitted body produce
-       its precise validation error without holding the slot. *)
-    run_keeper_invocation_turn_admitted
-      ?on_text_delta
-      ?on_event
-      ?event_bus
-      ?continuation_channel
-      ~surface
-      ctx
-      args
-  else
-    match
-      Keeper_turn_admission.run_serialized
-        ~base_path:ctx.config.base_path
-        ~keeper_name:name
-        (fun () ->
-          match on_admitted with
-          | Some notify ->
-            (match notify () with
-             | Ok () ->
-               run_keeper_invocation_turn_admitted
-                 ?on_text_delta
-                 ?on_event
-                 ?event_bus
-                 ?continuation_channel
-                 ~surface
-                 ctx
-                 args
-             | Error detail ->
-               tool_result_error
-                 ("keeper turn admission persistence failed: " ^ detail))
-          | None ->
-            run_keeper_invocation_turn_admitted
-              ?on_text_delta
-              ?on_event
-              ?event_bus
-              ?continuation_channel
-              ~surface
-              ctx
-              args)
+  let name = Keeper_invocation_contract.target_name request in
+  match
+    Keeper_turn_admission.run_serialized
+      ~base_path:ctx.config.base_path
+      ~keeper_name:name
+      (fun () ->
+        match on_admitted with
+        | Some notify ->
+          (match notify () with
+           | Ok () ->
+             run_keeper_invocation_turn_admitted
+               ?on_text_delta
+               ?on_event
+               ?event_bus
+               ?continuation_channel
+               ~surface
+               ~request
+               ctx
+               args
+           | Error detail ->
+             tool_result_error
+               ("keeper turn admission persistence failed: " ^ detail))
+        | None ->
+          run_keeper_invocation_turn_admitted
+            ?on_text_delta
+            ?on_event
+            ?event_bus
+            ?continuation_channel
+            ~surface
+            ~request
+            ctx
+            args)
     with
     | `Ran result -> result
     | `Rejected
@@ -1145,24 +1133,29 @@ let handle_keeper_msg
       ctx
       args
   =
-  handle_keeper_invocation
-    ?on_text_delta
-    ?on_event
-    ?event_bus
-    ?continuation_channel
-    ?on_admission_rejected
-    ?on_admitted
-    ~surface:Direct_message
-    ctx
-    args
+  match direct_invocation_request args with
+  | Error error -> tool_result_error error
+  | Ok request ->
+    handle_keeper_invocation
+      ?on_text_delta
+      ?on_event
+      ?event_bus
+      ?continuation_channel
+      ?on_admission_rejected
+      ?on_admitted
+      ~surface:Direct_message
+      ~request
+      ctx
+      args
 ;;
 
 let handle_keeper_delegate ?event_bus ctx request =
   handle_keeper_invocation
     ?event_bus
     ~surface:Keeper_delegate
+    ~request
     ctx
-    (invocation_args request)
+    (`Assoc [])
 ;;
 
 let handle_keeper_msg_if_free
@@ -1178,18 +1171,10 @@ let handle_keeper_msg_if_free
     | Some _ -> event_bus
     | None -> Keeper_event_bus.get ()
   in
-  let name = get_string args "name" "" in
-  if not (validate_name name) then
-    `Ran
-      (run_keeper_invocation_turn_admitted
-         ?on_text_delta
-         ?on_event
-         ?event_bus
-         ?continuation_channel
-         ~surface:Direct_message
-         ctx
-         args)
-  else
+  match direct_invocation_request args with
+  | Error error -> `Ran (tool_result_error error)
+  | Ok request ->
+    let name = Keeper_invocation_contract.target_name request in
     Keeper_turn_admission.run_chat_if_free
       ~base_path:ctx.config.base_path
       ~keeper_name:name
@@ -1200,5 +1185,6 @@ let handle_keeper_msg_if_free
           ?event_bus
           ?continuation_channel
           ~surface:Direct_message
+          ~request
           ctx
           args)

--- a/lib/keeper/keeper_turn.mli
+++ b/lib/keeper/keeper_turn.mli
@@ -27,6 +27,12 @@ val preflight_keeper_msg :
 (** Run synchronous validation for [handle_keeper_msg] before an async wrapper
     accepts the turn for later execution. *)
 
+val preflight_keeper_delegate :
+  _ Keeper_types_profile.context ->
+  Keeper_invocation_contract.request ->
+  (Keeper_invocation_contract.request, string) result
+(** Validate one typed delegated invocation before durable submission. *)
+
 module For_testing : sig
   val direct_owner_conversation_context :
     config:Workspace.config ->
@@ -123,6 +129,13 @@ val handle_keeper_msg :
     background turn. [on_admission_rejected] receives the typed admission
     result before the legacy tool error is rendered; queue consumers use it to
     keep a leased receipt pending without matching diagnostic strings. *)
+
+val handle_keeper_delegate :
+  ?event_bus:Agent_sdk.Event_bus.t ->
+  _ Keeper_types_profile.context ->
+  Keeper_invocation_contract.request ->
+  tool_result
+(** Run a typed delegated invocation through the same serialized Keeper lane. *)
 
 val handle_keeper_msg_if_free :
   ?on_text_delta:(string -> unit) ->

--- a/test/test_keeper_busy_dashboard_deferred.ml
+++ b/test/test_keeper_busy_dashboard_deferred.ml
@@ -103,6 +103,19 @@ let with_busy_slots ~base ~sw keeper_names f =
     f
 ;;
 
+let seed_keeper config =
+  let meta =
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+         [ "name", `String keeper_name
+         ; "agent_name", `String ("keeper-" ^ keeper_name)
+         ; "trace_id", `String ("trace-" ^ keeper_name)
+         ])
+    |> Result.get_ok
+  in
+  Keeper_meta_store.write_meta config meta |> Result.get_ok
+;;
+
 let test_busy_dashboard_enqueues () =
   Printf.printf "Test: busy dashboard dispatch enqueues onto Keeper_chat_queue\n%!";
   with_env
@@ -379,6 +392,84 @@ let test_stream_surface_preserves_typed_shutdown_rejection () =
     check "stream surface emits a typed shutdown rejection" false
 ;;
 
+let test_delegate_surface_uses_serialized_shutdown_fence () =
+  Printf.printf "Test: typed delegate uses the serialized Keeper lane\n%!";
+  with_env
+  @@ fun ~base ~clock ->
+  let operation_id = Keeper_shutdown_types.Operation_id.generate () in
+  ignore
+    (Keeper_turn_admission.begin_shutdown ~base_path:base ~keeper_name
+       ~operation_id
+      : Keeper_turn_admission.begin_shutdown_result);
+  Eio.Switch.run
+  @@ fun sw ->
+  let request =
+    Keeper_invocation_contract.request
+      ~keeper_name
+      ~prompt:"typed delegated turn"
+    |> Result.get_ok
+  in
+  let ctx : _ Keeper_types_profile.context =
+    { config = Workspace.default_config base
+    ; agent_name = "delegate-shutdown-test"
+    ; sw
+    ; clock
+    ; proc_mgr = None
+    ; net = None
+    ; publication_recovery_provider =
+        Masc_test_deps.non_runtime_publication_recovery_provider
+    }
+  in
+  let result = Keeper_turn.handle_keeper_delegate ctx request in
+  let message = Tool_result.message result in
+  check "shutdown-fenced delegate does not run" (not (Tool_result.is_success result));
+  check "delegate observes the exact shutdown owner"
+    (Astring.String.is_infix
+       ~affix:
+         ("stopping under operation "
+          ^ Keeper_shutdown_types.Operation_id.to_string operation_id)
+       message);
+  check "delegate error does not inherit the removed tool name"
+    (not (Astring.String.is_infix ~affix:"masc_keeper_msg" message))
+;;
+
+let test_delegate_resource_error_uses_typed_tool_name () =
+  Printf.printf "Test: typed delegate owns its failure identity\n%!";
+  with_env
+  @@ fun ~base ~clock ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let config = Workspace.default_config base in
+  seed_keeper config;
+  let request =
+    Keeper_invocation_contract.request
+      ~keeper_name
+      ~prompt:"typed prompt remains on the invocation"
+    |> Result.get_ok
+  in
+  let ctx : _ Keeper_types_profile.context =
+    { config
+    ; agent_name = "delegate-resource-test"
+    ; sw
+    ; clock
+    ; proc_mgr = None
+    ; net = None
+    ; publication_recovery_provider =
+        Masc_test_deps.non_runtime_publication_recovery_provider
+    }
+  in
+  let result = Keeper_turn.handle_keeper_delegate ctx request in
+  check "non-runtime resource boundary fails explicitly"
+    (not (Tool_result.is_success result));
+  check "delegate failure carries the typed tool name"
+    (String.equal "masc_keeper_delegate" (Tool_result.tool_name result));
+  check "typed prompt is not rejected as a missing legacy message"
+    (not
+       (Astring.String.is_infix
+          ~affix:"message is required"
+          (Tool_result.message result)))
+;;
+
 let () =
   test_busy_dashboard_enqueues ();
   test_free_dashboard_not_enqueued ();
@@ -388,6 +479,8 @@ let () =
   test_stream_headers_close_per_turn_response ();
   test_shutdown_fenced_dashboard_ack_preserves_cause ();
   test_stream_surface_preserves_typed_shutdown_rejection ();
+  test_delegate_surface_uses_serialized_shutdown_fence ();
+  test_delegate_resource_error_uses_typed_tool_name ();
   if !failures > 0
   then (
     Printf.printf "FAILED: %d check(s)\n%!" !failures;

--- a/test/test_keeper_unified_turn_event_bus.ml
+++ b/test/test_keeper_unified_turn_event_bus.ml
@@ -439,6 +439,95 @@ let test_keeper_msg_submission_projection_has_unique_keys () =
     (Invocation.result_contract failed_entry = Invocation.Failed)
 ;;
 
+let test_typed_keeper_invocation_wire_contract () =
+  let request_json =
+    `Assoc
+      [ ( "target"
+        , `Assoc [ "kind", `String "keeper"; "name", `String "projection-keeper" ] )
+      ; "capability", `String "invoke_turn"
+      ; "prompt", `String "inspect this request"
+      ]
+  in
+  let request =
+    match Invocation.request_of_json request_json with
+    | Ok request -> request
+    | Error error -> Alcotest.fail (Invocation.request_error_to_string error)
+  in
+  check string "typed target decoded" "projection-keeper"
+    (Invocation.target_name request);
+  (match
+     Invocation.request_of_json
+       (`Assoc [ "name", `String "projection-keeper"; "message", `String "legacy" ])
+   with
+   | Error (Invocation.Invalid_wire_value _) -> ()
+   | Error error ->
+     Alcotest.failf "unexpected legacy-input rejection: %s"
+       (Invocation.request_error_to_string error)
+   | Ok _ -> Alcotest.fail "legacy name/message input must not decode");
+  let outcome : Kmsg.submit_outcome =
+    { request_id = "typed-run-ref"; acceptance = Kmsg.Durably_accepted }
+  in
+  let submission_fields =
+    Invocation.delegate_submission_to_json request outcome
+    |> require_unique_assoc "typed submission"
+  in
+  check bool "raw request id omitted" false
+    (List.mem_assoc "request_id" submission_fields);
+  check bool "legacy status omitted" false
+    (List.mem_assoc "status" submission_fields);
+  let run_ref_json =
+    match List.assoc_opt "run_ref" submission_fields with
+    | Some value -> value
+    | None -> Alcotest.fail "typed submission missing run_ref"
+  in
+  let run_ref =
+    match Invocation.run_ref_of_json run_ref_json with
+    | Ok reference -> reference
+    | Error error -> Alcotest.fail (Invocation.request_error_to_string error)
+  in
+  let entry : Kmsg.entry =
+    { request_id = "typed-run-ref"
+    ; keeper_name = "projection-keeper"
+    ; base_path = "/projection/base"
+    ; submitted_by = "projection-caller"
+    ; status = Kmsg.Running
+    ; submitted_at = 0.0
+    ; completed_at = None
+    }
+  in
+  check bool "run ref binds exact durable entry" true
+    (Invocation.run_ref_matches_entry run_ref entry);
+  let wrong_target_ref =
+    match
+      Invocation.run_ref_of_json
+        (`Assoc
+           [ "run_id", `String "typed-run-ref"
+           ; "target", `Assoc [ "kind", `String "keeper"; "name", `String "other" ]
+           ; "capability", `String "invoke_turn"
+           ])
+    with
+    | Ok reference -> reference
+    | Error error -> Alcotest.fail (Invocation.request_error_to_string error)
+  in
+  check bool "same run id cannot retarget invocation" false
+    (Invocation.run_ref_matches_entry wrong_target_ref entry);
+  let entry_fields =
+    match Invocation.delegate_entry_to_json entry with
+    | Ok json -> require_unique_assoc "typed entry" json
+    | Error error -> Alcotest.fail (Invocation.request_error_to_string error)
+  in
+  check bool "entry omits raw request id" false
+    (List.mem_assoc "request_id" entry_fields);
+  check bool "entry exposes result contract" true
+    (List.mem_assoc "result_contract" entry_fields);
+  let cancellation_fields =
+    Invocation.delegate_cancellation_to_json run_ref Kmsg.Cancel_not_found
+    |> require_unique_assoc "typed cancellation"
+  in
+  check bool "cancellation omits raw request id" false
+    (List.mem_assoc "request_id" cancellation_fields)
+;;
+
 let test_take_drain_cancel_clears_active_without_spin () =
   let open EB.For_testing in
   let t = EB.create ~keeper_name:"k" ~turn_id:1 () in
@@ -522,6 +611,8 @@ let () =
             test_keeper_msg_async_submit_uses_captured_event_bus
         ; test_case "keeper msg submission JSON keys are unique" `Quick
             test_keeper_msg_submission_projection_has_unique_keys
+        ; test_case "typed Keeper invocation wire contract" `Quick
+            test_typed_keeper_invocation_wire_contract
         ] )
     ; ( "background-drain"
       , [ test_case "continues after first poll" `Quick


### PR DESCRIPTION
## Summary
- add typed `preflight_keeper_delegate` and `handle_keeper_delegate` entrypoints over `Keeper_invocation_contract.request`
- drive admitted execution directly from the opaque request target/prompt rather than reconstructing the removed public message payload
- project turn labels and resource failures from a closed internal invocation-surface type, so delegated runs do not inherit `masc_keeper_msg` telemetry/error identity
- preserve the existing per-Keeper serialized lane and shutdown fence

## Boundary
This PR changes no registered tool name or schema. It is the internal boundary layer required before the external delegate surface can replace the old message tools without a compatibility shim.

Stacked on #24554.

## Verification
- focused production-contract tests prove the typed target selects the exact shutdown-fenced Keeper lane, the typed prompt is accepted without a legacy `message` field, and resource failures carry `masc_keeper_delegate`
- all changed OCaml files: `ocamlformat --check`
- `git diff --check`
- focused local Dune build was not started because unrelated bare Dune processes currently bypass the repository wrapper lock; PR CI is the build authority

Diff: 247 additions / 85 deletions.
