### PR TITLE
fix(keeper): remove remaining wall-budget kills on LLM execution

### DIFF
--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -205,11 +205,22 @@ type 'a timeout_result =
   | Timed_out
   | Clock_unavailable
 
-let with_timeout ?clock ~timeout_sec f =
+let with_timeout ?clock ~timeout_sec:_ f =
   match clock with
   | None -> Clock_unavailable
-  | Some clock ->
-    (try Completed (Eio.Time.with_timeout_exn clock timeout_sec f) with
+  | Some _clock ->
+    (* No wall-clock budget kill (fail-open; RFC-0156 withdrew the MASC turn-budget
+       timeout policy). [timeout_sec] is NOT used to force-kill the compaction LLM call: a
+       budget that fired while a slow-but-healthy provider was still streaming
+       turned every compaction turn into kill -> None -> retry churn that never
+       produced a plan, so the completion call now runs to natural completion.
+       A genuine inner transport timeout (the provider call's own connect/idle
+       deadline raising [Eio.Time.Timeout]) is still surfaced as [Timed_out];
+       [Eio.Cancel.Cancelled] from server shutdown / parent-fiber cancel is not
+       caught here and propagates so the caller exits immediately without
+       retrying. The no-clock [Clock_unavailable] fail-closed guard (the [None]
+       arm above) is intentionally left in place. *)
+    (try Completed (f ()) with
      | Eio.Time.Timeout -> Timed_out)
 
 let run_plan

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -502,8 +502,19 @@ let messages_for_librarian (inp : Keeper_librarian.input) =
 (* http_error_message moved to Provider_http_error.to_message (SSOT,
    2026-06-24): four byte-for-output-identical copies unified. *)
 
-let with_timeout ~clock ~timeout_sec f =
-  try Some (Eio.Time.with_timeout_exn clock timeout_sec f) with
+(* WHY: run the librarian extraction to completion instead of force-killing it
+   on a wall-clock budget. Killing a legitimate in-flight provider call on a
+   deadline produced kill -> retry churn without recovering the turn. Per
+   RFC-0156 (Withdraw MASC turn-budget timeout policy) total attempt time stays
+   observable but is not a lifecycle/admission decision; a protocol-level
+   timeout is local to the call. [clock]/[timeout_sec] are retained in the
+   signature for the surrounding transport plumbing but no longer gate
+   execution — this helper no longer imposes a timeout despite its name.
+   The [Eio.Time.Timeout -> None] arm is kept so an inner-transport
+   (connect/idle/HTTP) timeout still maps to the typed [Provider_timeout];
+   [Eio.Cancel.Cancelled] is not caught here and so still propagates. *)
+let with_timeout ~clock:_ ~timeout_sec:_ f =
+  try Some (f ()) with
   | Eio.Time.Timeout -> None
 ;;
 

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -232,8 +232,12 @@ val extract_with_provider_classified
 (** Provider-backed librarian extraction. [clock] stays optional at the API
     boundary because [run_best_effort] may be called from contexts that cannot
     supply an Eio clock; [None] returns
-    {!librarian_provider_clock_unavailable_error} before provider I/O so
-    production calls cannot silently run without timeout enforcement. *)
+    {!librarian_provider_clock_unavailable_error} before provider I/O because
+    the provider call itself requires the clock. The extraction now runs to
+    completion: [timeout_sec] no longer force-kills a legitimate in-flight
+    provider call (that wall-clock kill produced kill -> retry churn; see
+    RFC-0156, Withdraw MASC turn-budget timeout policy). An inner-transport
+    (connect/idle/HTTP) timeout still surfaces as {!Provider_timeout}. *)
 
 val extract_and_append_with_provider
   :  ?complete:complete_fn

--- a/lib/keeper/keeper_memory_llm_summary.ml
+++ b/lib/keeper/keeper_memory_llm_summary.ml
@@ -168,11 +168,19 @@ type 'a timeout_result =
   | Timed_out
   | Clock_unavailable
 
-let with_timeout ?clock ~timeout_sec f =
+(* No wall-clock budget kill (fail-open; RFC-0156 withdrew the MASC turn-budget
+   timeout policy). Run [f] to natural completion instead of wrapping it in
+   [Eio.Time.with_timeout_exn]: a slow-but-healthy provider that is still
+   streaming would otherwise turn every budget expiry into kill -> error ->
+   retry churn. A genuine INNER transport timeout raised from within [f]
+   (HTTP client / connect / idle) still surfaces as [Eio.Time.Timeout] ->
+   [Timed_out]. [Eio.Cancel.Cancelled] is not caught here, so it propagates
+   unchanged. The no-clock branch stays as-is (env-not-initialised guard). *)
+let with_timeout ?clock ~timeout_sec:_ f =
   match clock with
   | None -> Clock_unavailable
-  | Some clock ->
-    (try Completed (Eio.Time.with_timeout_exn clock timeout_sec f) with
+  | Some _clock ->
+    (try Completed (f ()) with
      | Eio.Time.Timeout -> Timed_out)
 
 let record_summary_outcome

--- a/lib/keeper/keeper_memory_os_consolidation_runtime.ml
+++ b/lib/keeper/keeper_memory_os_consolidation_runtime.ml
@@ -28,11 +28,24 @@ type 'a timeout_result =
   | Timed_out
   | Clock_unavailable
 
-let with_timeout ?clock ~timeout_sec f =
+(* Fail-open per RFC-0156 (MASC turn-budget timeout policy withdrawn) / repo-owner
+   directive (mirrors [Keeper_llm_bridge]
+   @151ac9a27f): a wall-clock budget must NOT force-kill a legitimate LLM/agent
+   execution. The old [Eio.Time.with_timeout_exn] kill only produced
+   kill -> error -> retry churn on slow-but-legitimate provider calls, so [f] now
+   runs to natural completion. A genuine INNER transport timeout still raises
+   [Eio.Time.Timeout] (from the provider's own transport/idle deadlines) and is
+   surfaced as [Timed_out]. [Eio.Cancel.Cancelled] is deliberately not caught here
+   so it propagates (re-raises) to the enclosing switch. [timeout_sec] is no longer
+   consulted for a wall deadline (kept in the signature as advisory only).
+   The [None -> Clock_unavailable] fail-closed guard is retained unchanged: without
+   a clock the provider's inner transport cannot enforce its own idle/connect
+   deadlines, so the call is still refused upstream. *)
+let with_timeout ?clock ~timeout_sec:_ f =
   match clock with
   | None -> Clock_unavailable
-  | Some clock ->
-    (try Completed (Eio.Time.with_timeout_exn clock timeout_sec f) with
+  | Some _clock ->
+    (try Completed (f ()) with
      | Eio.Time.Timeout -> Timed_out)
 ;;
 

--- a/lib/keeper/keeper_memory_os_consolidation_runtime.mli
+++ b/lib/keeper/keeper_memory_os_consolidation_runtime.mli
@@ -37,9 +37,14 @@ end
     numeric fact-count threshold never suppresses model judgment. Returns the
     outcome without raising for the expected failure modes so a
     caller fiber stays alive. If [timeout_sec] is configured but no [clock] is
-    available, the provider call is refused as [Transport_failed _] rather than
-    running without a deadline. [runtime_id] remains paired with [provider_cfg]
-    so model-level temperature declarations survive request tuning. *)
+    available, the provider call is refused as [Transport_failed _] (without a
+    clock the provider's inner transport cannot enforce its idle/connect
+    deadlines). When a clock is present the call runs to natural completion:
+    [timeout_sec] is advisory and never force-kills a legitimate provider call
+    (fail-open per RFC-0156); only a genuine inner transport [Eio.Time.Timeout]
+    surfaces as [Transport_failed _]. [runtime_id] remains paired with
+    [provider_cfg] so model-level temperature declarations survive request
+    tuning. *)
 val consolidate_keeper
   :  ?complete:complete_fn
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t

--- a/lib/keeper/keeper_vision_tool.ml
+++ b/lib/keeper/keeper_vision_tool.ml
@@ -10,19 +10,33 @@ type complete_fn =
   unit ->
   (Agent_sdk.Types.api_response, Llm_provider.Http_client.http_error) result
 
-(* Mirrors Keeper_librarian_runtime.default_complete / with_timeout (neither is
-   exposed). Replicated rather than shared: two tiny consumers do not yet justify
-   a shared keeper_provider_subcall module (repetition over premature
-   abstraction); extract one if a third sub-call appears. *)
+(* Mirrors Keeper_librarian_runtime.default_complete (neither is exposed).
+   Replicated rather than shared: two tiny consumers do not yet justify a shared
+   keeper_provider_subcall module (repetition over premature abstraction);
+   extract one if a third sub-call appears. The provider-attempt wrapper below
+   deliberately diverges from the librarian's: the vision sub-call runs to
+   completion (no wall-clock kill), see [attempt_catching_transport_timeout]. *)
 let default_complete : complete_fn =
  fun ~sw ~net ?clock ~config ~messages () ->
   Llm_provider.Complete.complete ~sw ~net ?clock ~config ~messages ()
 
-(* Only [Eio.Time.Timeout] is caught here; [Eio.Cancel.Cancelled] and other
-   exceptions are intentionally propagated so caller cancellation is not
-   swallowed by the tool-level timeout handler. *)
-let with_timeout ~clock ~timeout_sec f =
-  try Some (Eio.Time.with_timeout_exn clock timeout_sec f) with
+(* RFC-0156 (withdraw MASC turn-budget timeout policy) / fail-open directive: a
+   single provider attempt runs to completion — no wall-clock budget kills it.
+   A wall-budget kill only turned a slow-but-progressing call into
+   kill -> error -> retry churn, discarding work already in flight. The
+   cumulative per-request deadline is retained, but only as a scheduling gate on
+   whether the *next* candidate runtime is started (see [remaining_timeout_sec]
+   in [run_candidates] / [run_candidates_outcome]); it never interrupts an
+   attempt that is already running.
+
+   [Eio.Time.Timeout] is still caught and mapped to [None] so a genuine
+   inner-transport timeout — the HTTP client's own connect/idle deadline, on the
+   defensive path where it escapes [complete] as an exception rather than an
+   [Error] result — fails the candidate over to the next runtime. [Eio.Cancel.Cancelled]
+   and every other exception propagate so caller/supervisor cancellation is not
+   swallowed by this handler. *)
+let attempt_catching_transport_timeout f =
+  try Some (f ()) with
   | Eio.Time.Timeout -> None
 
 let valid_timeout_sec timeout_sec =
@@ -399,10 +413,14 @@ let run_candidates
            | None -> Some (`Timeout runtime_id)
          in
          loop ~last_error ~attempt_index []
-       | Some timeout_sec ->
+       | Some _remaining ->
+         (* [_remaining] (budget left before the failover deadline) is no longer
+            used to bound the attempt: it runs to completion. The deadline is
+            consumed only by the [None] arm above, which stops starting further
+            candidates once it is exhausted. *)
          let config = provider_for_vision rt.Runtime.provider_config in
          (match
-            with_timeout ~clock ~timeout_sec (fun () ->
+            attempt_catching_transport_timeout (fun () ->
               complete ~sw ~net ?clock:(Some clock) ~config ~messages ())
           with
           | None ->
@@ -485,10 +503,14 @@ let run_candidates_outcome
            | None -> Some (`Timeout runtime_id)
          in
          loop ~last_error ~attempt_index []
-       | Some timeout_sec ->
+       | Some _remaining ->
+         (* [_remaining] (budget left before the failover deadline) is no longer
+            used to bound the attempt: it runs to completion. The deadline is
+            consumed only by the [None] arm above, which stops starting further
+            candidates once it is exhausted. *)
          let config = provider_for_vision rt.Runtime.provider_config in
          (match
-            with_timeout ~clock ~timeout_sec (fun () ->
+            attempt_catching_transport_timeout (fun () ->
               complete ~sw ~net ?clock:(Some clock) ~config ~messages ())
           with
           | None ->

--- a/lib/keeper/keeper_vision_tool.mli
+++ b/lib/keeper/keeper_vision_tool.mli
@@ -10,8 +10,11 @@
     success (the failure class the RFC targets).
 
     Mirrors the provider-sub-call shape of [Keeper_librarian_runtime]; the small
-    [complete_fn] / [with_timeout] helpers are replicated here rather than shared,
-    until a third sub-call consumer justifies extracting a common module.
+    [complete_fn] helper is replicated here rather than shared, until a third
+    sub-call consumer justifies extracting a common module. Unlike the librarian,
+    a single vision provider attempt runs to completion (no wall-clock kill,
+    RFC-0156); the per-request deadline only schedules failover to the next
+    runtime.
     Artifact filesystem I/O is offloaded through {!Eio_guard.run_in_systhread}
     when the Eio runtime is active, so durable fsync/rename work does not block
     the shared Eio domain. *)
@@ -119,11 +122,13 @@ val run_vision
   -> bytes:string
   -> unit
   -> vision_outcome
-(** The bounded one-shot vision sub-call core (runtime resolution + provider
-    call under [with_timeout] + §2.2 classification). Used by {!handle} and by
-    eager ingestion. Requires the turn clock, so eager ingestion cannot run an
-    unbounded provider call. Non-cancellation exceptions are converted to
-    [Vo_provider]; provider success with malformed structured output is
+(** The one-shot vision sub-call core (runtime resolution + provider call run to
+    completion + §2.2 classification). A single provider attempt is not
+    wall-clock killed (RFC-0156); the turn clock is required for the cumulative
+    failover deadline — which gates whether the {e next} candidate runtime is
+    started — and for the provider transport clock. Used by {!handle} and by
+    eager ingestion. Non-cancellation exceptions are converted to [Vo_provider];
+    provider success with malformed structured output is
     [Vo_invalid_structured_response], so eager ingestion can keep the turn alive
     with a typed unread placeholder. *)
 

--- a/lib/masc_oas_bridge.ml
+++ b/lib/masc_oas_bridge.ml
@@ -1,10 +1,13 @@
 (* lib/masc_oas_bridge.ml *)
 (** Centralized boundary between MASC subsystems and the OAS Agent SDK.
-    Enforces strict structural timeouts, cancellation safety, and type isolation. *)
+    Enforces cancellation safety and type isolation. Wall-clock budgets are
+    advisory only and do not force-kill execution (fail-open directive). *)
 
 (** Safe execution of a generic OAS operation.
-    Requires a domain-local Eio clock, applies timeout handling, and
-    converts [Eio.Time.Timeout] into an error result.
+    Requires a domain-local Eio clock and runs the operation to natural
+    completion; [timeout_s] is advisory and is not used to force-kill it.
+    A genuine inner transport [Eio.Time.Timeout] is converted into an error
+    result.
     [Eio.Cancel.Cancelled] is always re-raised to preserve structured concurrency.
 
     [caller] (#10094) is a free-form identifier
@@ -43,8 +46,16 @@ let run_safe ~caller ~timeout_s fn =
   | Some { Masc_eio_env.clock; _ } ->
     let t0 = Eio.Time.now clock in
     let elapsed () = Eio.Time.now clock -. t0 in
+    (* No wall-clock budget kill (fail-open; RFC-0156 withdrew the MASC turn-budget
+       timeout policy — total attempt time is observable, not a kill decision).
+       [timeout_s] is advisory only and is NOT used to force-kill the OAS
+       execution: a wall budget that fired while a provider was legitimately still
+       streaming turned slow-but-healthy calls into kill -> Error -> retry churn.
+       The call runs to natural completion. A genuine inner transport timeout (the
+       provider's own connect/idle deadline raising [Eio.Time.Timeout]) is still
+       surfaced below, and structured cancellation is still re-raised. *)
     try
-      Eio.Time.with_timeout_exn clock timeout_s fn
+      fn ()
     with
   | Eio.Time.Timeout ->
     (* #10094: per-caller timeout counter so the operator can see

--- a/test/test_masc_oas_bridge_timeout_guard.ml
+++ b/test/test_masc_oas_bridge_timeout_guard.ml
@@ -61,7 +61,9 @@ let with_eio_env f =
         f clock)))
 ;;
 
-let test_clocked_env_times_out_sleep () =
+let test_clocked_env_slow_call_not_killed () =
+  (* fail-open directive: a call that overruns [timeout_s] must run to natural
+     completion, not be force-killed by a wall budget. *)
   with_eio_env (fun clock ->
     let called = ref false in
     match
@@ -70,10 +72,10 @@ let test_clocked_env_times_out_sleep () =
         Eio.Time.sleep clock 0.05;
         Ok "late")
     with
-    | Error (Agent_sdk.Error.Api (Timeout _)) ->
-      Alcotest.(check bool) "fn was started" true !called
-    | Error err -> failwith (Agent_sdk.Error.to_string err)
-    | Ok other -> failwith ("unexpected success: " ^ other))
+    | Ok "late" -> Alcotest.(check bool) "fn ran to completion" true !called
+    | Ok other -> failwith ("unexpected success: " ^ other)
+    | Error err ->
+      failwith ("slow call was killed instead of completing: " ^ Agent_sdk.Error.to_string err))
 ;;
 
 let with_env name value f =
@@ -133,9 +135,9 @@ let () =
             `Quick
             test_missing_eio_env_fails_closed_without_calling_fn
         ; Alcotest.test_case
-            "clocked env times out sleep"
+            "clocked env slow call not killed"
             `Quick
-            test_clocked_env_times_out_sleep
+            test_clocked_env_slow_call_not_killed
         ; Alcotest.test_case
             "run_with_caller resolves env timeouts"
             `Quick


### PR DESCRIPTION
## What

Follow-up to #24555. Removes the remaining wall-clock budgets that FORCE-KILL a
legitimate LLM/agent execution across the keeper subsystems and the central OAS
bridge. A wall budget that fires while a provider is still streaming turns a
slow-but-healthy call into kill -> `Error` -> retry churn that burns API cost and
CPU and never produces a result (observed live via the HITL path fixed in #24555).

The uniform change: the LLM/provider call runs to natural completion instead of
being wrapped in `Eio.Time.with_timeout_exn clock <budget> fn`. In every case:
- `Eio.Cancel.Cancelled` (server shutdown / parent cancel) still propagates —
  structured concurrency is untouched.
- A genuine INNER transport timeout (the provider's own connect/idle deadline
  raising `Eio.Time.Timeout`) is still surfaced.
- Genuine hangs stay bounded by the HTTP client's own connect/idle timeouts, not
  by an application-level wall budget.

## Files (kill removed)

- `lib/masc_oas_bridge.ml` — `run_safe`, the central OAS boundary (`run_with_caller`
  resolves per-caller budgets 180-300s). The `invalid_arg` guard on a nan/inf/non-
  positive budget is kept (it validates a malformed value, it is not an operational
  block). Module + function docs updated. `test_masc_oas_bridge_timeout_guard.ml`
  rewritten: "clocked env slow call not killed" (6/6 pass).
- `lib/keeper/keeper_memory_llm_summary.ml` — `with_timeout` runs `f` to completion.
- `lib/keeper/keeper_compaction_llm_summarizer.ml` — same.
- `lib/keeper/keeper_memory_os_consolidation_runtime.ml` — same.
- `lib/keeper/keeper_librarian_runtime.ml` (+ `.mli`) — execution kill removed; the
  provider-slot-acquisition wait (backpressure) is preserved.
- `lib/keeper/keeper_vision_tool.ml` (+ `.mli`) — per-attempt execution kill removed
  (`with_timeout` -> `attempt_catching_transport_timeout`); the deadline-based
  FAILOVER scheduling is preserved (it decides whether the next runtime is started,
  it does not cancel an in-flight attempt).

## Deliberately NOT changed

- `lib/fusion/fusion_orchestrator_judge_wave.ml` `with_timeout_budget_fallback`:
  graceful degradation, not a kill. It operates on already-completed judge runs and
  APPENDS a fallback judge when the whole first wave failed with timeout/budget; it
  never kills an in-flight execution and re-raises `Cancelled`. The fusion adaptive
  timeout + fallback is a deliberate design (`test_fusion_adaptive_timeout.ml`).
- Transport/connect/idle timeouts (HTTP client), dashboard HTTP request bounds,
  subprocess spawn timeouts, and slot-acquisition waits — these bound I/O or
  external processes, not agent reasoning.

## Build / test

- `dune build lib/` green (warnings are errors).
- `test_masc_oas_bridge_timeout_guard.exe` 6/6; sibling module tests build green.
- Note: some keeper test suites are pre-existingly RED on `main` (unrelated to this
  PR) for two reasons found while verifying: (a) a runtime.toml/model-catalog
  temperature/lane fixture dependency in this environment; (b) 20+ test fixtures
  still emit the legacy `goal` keeper-meta field now rejected by
  `reject_removed_keeper_meta_shapes`. Both are tracked separately (see below); this
  PR does not touch them.

## Follow-ups (not in this PR)

- `lib/server/server_bootstrap_maintenance.ml` has a per-keeper memory-OS
  consolidation-tick wall-clock kill (asserted by `test_parallel_timeout_per_keeper`).
  Same pattern, different module — a separate change is needed to remove it and
  rewrite that test.
- Legacy `goal` keeper-meta field emitted by 20+ test fixtures → broad keeper test
  harness drift against the current meta contract. Dedicated cleanup ticket.

## Rationale

RFC-0156 withdrew the MASC turn-budget timeout policy: total attempt time is
observable, not a Keeper lifecycle or admission (kill) decision. Fail-open: a slow
or unavailable component is a local, observed condition, never a forced kill.

WORKAROUND-WAIVED: this PR removes wall-budget kills (the symptom-suppression
anti-pattern), it does not add any cap/cooldown/dedup/repair. No RFC-gated
subsystem is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
