### PR TITLE
fix(connector): isolate Discord ingress by Keeper lane

### DIFF
--- a/lib/gate/connector_ingress_lane.ml
+++ b/lib/gate/connector_ingress_lane.ml
@@ -1,0 +1,143 @@
+type lane =
+  | Keeper_lane of string
+  | Connector_lane of string
+
+type event_id =
+  { source : string
+  ; opaque_id : string
+  }
+
+type failure =
+  { lane : lane
+  ; event_id : event_id
+  ; reason : string
+  }
+
+type job =
+  { event_id : event_id
+  ; run : unit -> unit
+  }
+
+type lane_state =
+  { jobs : job Queue.t
+  ; mutable scheduled : bool
+  ; mutable active : bool
+  }
+
+type t =
+  { sw : Eio.Switch.t
+  ; mutex : Stdlib.Mutex.t
+  ; condition : Eio.Condition.t
+  ; lanes : (lane, lane_state) Hashtbl.t
+  ; ready : lane Queue.t
+  ; on_failure : failure -> unit
+  }
+
+let lane_to_string = function
+  | Keeper_lane keeper_name -> "keeper:" ^ keeper_name
+  | Connector_lane connector_id -> "connector:" ^ connector_id
+;;
+
+let event_id_to_string event_id =
+  event_id.source ^ ":" ^ event_id.opaque_id
+;;
+
+let with_lock t f = Stdlib.Mutex.protect t.mutex f
+
+let report_failure t failure =
+  try t.on_failure failure with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Log.Server.error
+      "connector ingress failure observer crashed lane=%s event=%s: %s"
+      (lane_to_string failure.lane)
+      (event_id_to_string failure.event_id)
+      (Printexc.to_string exn)
+;;
+
+let run_job t lane job =
+  try job.run () with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    report_failure
+      t
+      { lane; event_id = job.event_id; reason = Printexc.to_string exn }
+;;
+
+let take_lane_job t lane state =
+  with_lock t (fun () ->
+    match Queue.take_opt state.jobs with
+    | Some job -> Some job
+    | None ->
+      state.active <- false;
+      Hashtbl.remove t.lanes lane;
+      None)
+;;
+
+let rec run_lane t lane state =
+  match take_lane_job t lane state with
+  | None -> ()
+  | Some job ->
+    run_job t lane job;
+    Eio.Fiber.yield ();
+    run_lane t lane state
+;;
+
+let take_ready_lane t =
+  with_lock t (fun () ->
+    match Queue.take_opt t.ready with
+    | None -> None
+    | Some lane ->
+      (match Hashtbl.find_opt t.lanes lane with
+       | Some state when state.scheduled && not state.active ->
+         state.scheduled <- false;
+         state.active <- true;
+         Some (lane, state)
+       | Some _ | None -> None))
+;;
+
+let rec run_dispatcher t =
+  let lane, state =
+    Eio.Condition.loop_no_mutex t.condition (fun () -> take_ready_lane t)
+  in
+  Eio.Fiber.fork ~sw:t.sw (fun () -> run_lane t lane state);
+  run_dispatcher t
+;;
+
+let create ~sw ~on_failure () =
+  let t =
+    { sw
+    ; mutex = Stdlib.Mutex.create ()
+    ; condition = Eio.Condition.create ()
+    ; lanes = Hashtbl.create 16
+    ; ready = Queue.create ()
+    ; on_failure
+    }
+  in
+  Eio.Fiber.fork ~sw (fun () -> run_dispatcher t);
+  t
+;;
+
+let submit t ~lane ~event_id run =
+  let notify =
+    with_lock t (fun () ->
+      let state =
+        match Hashtbl.find_opt t.lanes lane with
+        | Some state -> state
+        | None ->
+          let state =
+            { jobs = Queue.create (); scheduled = false; active = false }
+          in
+          Hashtbl.add t.lanes lane state;
+          state
+      in
+      Queue.add { event_id; run } state.jobs;
+      if state.active || state.scheduled
+      then false
+      else (
+        state.scheduled <- true;
+        Queue.add lane t.ready;
+        true))
+  in
+  if notify then Eio.Condition.broadcast t.condition
+;;

--- a/lib/gate/connector_ingress_lane.mli
+++ b/lib/gate/connector_ingress_lane.mli
@@ -1,0 +1,34 @@
+(** Switch-owned FIFO lanes without policy capacity, timeout, or drop paths. *)
+
+type lane =
+  | Keeper_lane of string
+  | Connector_lane of string
+
+type event_id =
+  { source : string
+  ; opaque_id : string
+  }
+
+type failure =
+  { lane : lane
+  ; event_id : event_id
+  ; reason : string
+  }
+
+type t
+
+val lane_to_string : lane -> string
+val event_id_to_string : event_id -> string
+
+val create :
+  sw:Eio.Switch.t ->
+  on_failure:(failure -> unit) ->
+  unit ->
+  t
+
+val submit :
+  t ->
+  lane:lane ->
+  event_id:event_id ->
+  (unit -> unit) ->
+  unit

--- a/lib/gate/dune
+++ b/lib/gate/dune
@@ -16,6 +16,7 @@
   channel_gate_slack_state
   channel_gate_telegram_state
   channel_gate_metrics
+  connector_ingress_lane
   discord_observability
   discord_gateway_client
   discord_gateway_state

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -343,7 +343,7 @@ let resolve_binding_for_message ~channel_id ~message_reference_channel_id =
                     },
                     [ ("discord.binding_reference_channel_id", reference_channel_id) ] ))
 
-let handle_message_create ~dispatch
+let handle_message_create ?resolved_binding ~dispatch
       ~clock
       ~(channel_id : string) ~(message_id : string)
       ~(guild_id : string option)
@@ -355,7 +355,13 @@ let handle_message_create ~dispatch
       ~(message_reference_channel_id : string option)
       ~(message_reference_message_id : string option)
       ~(referenced_message_author_id : string option) =
-  match resolve_binding_for_message ~channel_id ~message_reference_channel_id with
+  let binding =
+    match resolved_binding with
+    | Some binding -> Some binding
+    | None ->
+      resolve_binding_for_message ~channel_id ~message_reference_channel_id
+  in
+  match binding with
   | None ->
     (* No binding for this channel — drop quietly. The bot may be in
        channels it isn't bound to (e.g. server-wide guild messages). *)
@@ -514,7 +520,8 @@ let handle_message_create ~dispatch
               Discord_observability.record_reply
                 Discord_observability.Reply_send_failed))
 
-let on_event ~dispatch ~clock ~base_dir (ev : Gw.gateway_event) =
+let on_event ?resolved_binding ~dispatch ~clock ~base_dir
+    (ev : Gw.gateway_event) =
   match ev with
   | Gw.Ready { bot_user_id; _ } ->
     State.record_ready ~bot_user_id;
@@ -535,7 +542,8 @@ let on_event ~dispatch ~clock ~base_dir (ev : Gw.gateway_event) =
       } ->
     (* mentions_bot is already enforced by the trigger policy at the
        gateway-state layer; nothing extra to check here. *)
-    handle_message_create ~dispatch ~clock ~channel_id ~message_id ~author_id
+    handle_message_create ?resolved_binding ~dispatch ~clock ~channel_id
+      ~message_id ~author_id
       ~guild_id ~base_dir ~author_name ~content ~mentions_bot ~explicit_mentions_bot
       ~message_reference_channel_id ~message_reference_message_id
       ~referenced_message_author_id
@@ -569,10 +577,15 @@ let on_event ~dispatch ~clock ~base_dir (ev : Gw.gateway_event) =
    the trigger policy is still conversation the keeper sits in. Persist
    a single user line — no dispatch, no turn. Unbound channels drop, as
    on the dispatch path. *)
-let handle_ambient ~base_dir
+let handle_ambient ?resolved_keeper_name ~base_dir
       ~(channel_id : string) ~(guild_id : string option) ~(message_id : string)
       ~(author_id : string) ~(author_name : string option) ~(content : string) =
-  match State.keeper_for_channel ~channel_id with
+  let keeper_name =
+    match resolved_keeper_name with
+    | Some keeper_name -> Some keeper_name
+    | None -> State.keeper_for_channel ~channel_id
+  in
+  match keeper_name with
   | None ->
     Discord_observability.record_ambient
       Discord_observability.Ambient_dropped_unbound
@@ -695,14 +708,62 @@ let handle_ambient ~base_dir
         Discord_observability.Ambient_recorded
     end
 
-let on_ambient ~base_dir (ev : Gw.gateway_event) =
+let on_ambient ?resolved_keeper_name ~base_dir (ev : Gw.gateway_event) =
   match ev with
   | Gw.Message_create
       { channel_id; guild_id; message_id; author_id; author_name; content; _ }
     ->
-    handle_ambient ~base_dir ~channel_id ~guild_id ~message_id ~author_id
-      ~author_name ~content
+    handle_ambient ?resolved_keeper_name ~base_dir ~channel_id ~guild_id
+      ~message_id ~author_id ~author_name ~content
   | Gw.Ready _ | Gw.Reaction_add _ | Gw.Thread_tracked _ | Gw.Threads_bulk_tracked _ | Gw.Thread_removed _ | Gw.Ignored _ -> ()
+
+let submit_triggered_event ingress ~dispatch ~clock ~base_dir
+    (ev : Gw.gateway_event) =
+  match ev with
+  | Gw.Message_create
+      { channel_id; message_id; message_reference_channel_id; _ } ->
+    (match
+       resolve_binding_for_message ~channel_id ~message_reference_channel_id
+     with
+     | None -> on_event ~dispatch ~clock ~base_dir ev
+     | Some ((resolution, _) as resolved_binding) ->
+       Connector_ingress_lane.submit
+         ingress
+         ~lane:(Connector_ingress_lane.Keeper_lane resolution.State.keeper_name)
+         ~event_id:{ source = "discord_triggered"; opaque_id = message_id }
+         (fun () ->
+            on_event
+              ~resolved_binding
+              ~dispatch
+              ~clock
+              ~base_dir
+              ev))
+  | Gw.Ready _
+  | Gw.Reaction_add _
+  | Gw.Thread_tracked _
+  | Gw.Threads_bulk_tracked _
+  | Gw.Thread_removed _
+  | Gw.Ignored _ -> on_event ~dispatch ~clock ~base_dir ev
+;;
+
+let submit_ambient_event ingress ~base_dir (ev : Gw.gateway_event) =
+  match ev with
+  | Gw.Message_create { channel_id; message_id; _ } ->
+    (match State.keeper_for_channel ~channel_id with
+     | None -> on_ambient ~base_dir ev
+     | Some keeper_name ->
+       Connector_ingress_lane.submit
+         ingress
+         ~lane:(Connector_ingress_lane.Keeper_lane keeper_name)
+         ~event_id:{ source = "discord_ambient"; opaque_id = message_id }
+         (fun () -> on_ambient ~resolved_keeper_name:keeper_name ~base_dir ev))
+  | Gw.Ready _
+  | Gw.Reaction_add _
+  | Gw.Thread_tracked _
+  | Gw.Threads_bulk_tracked _
+  | Gw.Thread_removed _
+  | Gw.Ignored _ -> on_ambient ~base_dir ev
+;;
 
 (* ---------------------------------------------------------------- *)
 (* Start                                                            *)
@@ -716,6 +777,17 @@ let start ~sw ~env ~clock ~state =
   | Some token ->
     let policy = resolved_trigger_policy () in
     State.set_trigger_policy policy;
+    let ingress =
+      Connector_ingress_lane.create
+        ~sw
+        ~on_failure:(fun failure ->
+          Log.Server.error
+            "Discord ingress callback failed lane=%s event=%s: %s"
+            (Connector_ingress_lane.lane_to_string failure.lane)
+            (Connector_ingress_lane.event_id_to_string failure.event_id)
+            failure.reason)
+        ()
+    in
     let dispatch_for_config config =
       (* RFC-connector-deferred-reply-via-chat-queue: tag this dispatch as the Discord connector so a message that
          arrives while the keeper is in flight is enqueued onto
@@ -745,14 +817,15 @@ let start ~sw ~env ~clock ~state =
           ~trigger_policy:policy
           ~on_event:(fun ev ->
             let config = Mcp_server.workspace_config state in
-            on_event
+            submit_triggered_event
+              ingress
               ~dispatch:(dispatch_for_config config)
               ~clock
               ~base_dir:config.base_path
               ev)
           ~on_ambient:(fun ev ->
             let config = Mcp_server.workspace_config state in
-            on_ambient ~base_dir:config.base_path ev)
+            submit_ambient_event ingress ~base_dir:config.base_path ev)
           ()
       with
       | Eio.Cancel.Cancelled _ as e -> raise e

--- a/test/stanzas/test_discord_gateway_client.inc
+++ b/test/stanzas/test_discord_gateway_client.inc
@@ -2,4 +2,4 @@
 (test
  (name test_discord_gateway_client)
  (modules test_discord_gateway_client)
- (libraries alcotest yojson masc.gate))
+ (libraries alcotest yojson eio_main masc.gate))

--- a/test/test_discord_gateway_client.ml
+++ b/test/test_discord_gateway_client.ml
@@ -1,6 +1,7 @@
 open Alcotest
 
 module Client = Discord_gateway_client
+module Ingress = Connector_ingress_lane
 module State = Discord_gateway_state
 
 let dummy_frame : State.frame =
@@ -34,6 +35,119 @@ let test_reader_continues_after_non_close_inputs () =
     (fun (label, input) -> check_continue label input true)
     cases
 
+let test_ingress_isolates_lanes_and_preserves_lane_fifo () =
+  Eio_main.run (fun _env ->
+    Eio.Switch.run (fun sw ->
+      let trace_mutex = Stdlib.Mutex.create () in
+      let trace = ref [] in
+      let record value =
+        Stdlib.Mutex.protect trace_mutex (fun () -> trace := value :: !trace)
+      in
+      let trace_snapshot () =
+        Stdlib.Mutex.protect trace_mutex (fun () -> List.rev !trace)
+      in
+      let first_started, resolve_first_started = Eio.Promise.create () in
+      let release_first, resolve_release_first = Eio.Promise.create () in
+      let second_done, resolve_second_done = Eio.Promise.create () in
+      let other_done, resolve_other_done = Eio.Promise.create () in
+      let ingress =
+        Ingress.create
+          ~sw
+          ~on_failure:(fun failure ->
+            fail
+              ("unexpected connector callback failure: " ^ failure.reason))
+          ()
+      in
+      let event opaque_id : Ingress.event_id =
+        { source = "test"; opaque_id }
+      in
+      Ingress.submit
+        ingress
+        ~lane:(Ingress.Keeper_lane "keeper-a")
+        ~event_id:(event "first")
+        (fun () ->
+           record "first-start";
+           Eio.Promise.resolve resolve_first_started ();
+           Eio.Promise.await release_first;
+           record "first-end");
+      Eio.Promise.await first_started;
+      Ingress.submit
+        ingress
+        ~lane:(Ingress.Keeper_lane "keeper-a")
+        ~event_id:(event "second")
+        (fun () ->
+           record "second";
+           Eio.Promise.resolve resolve_second_done ());
+      Ingress.submit
+        ingress
+        ~lane:(Ingress.Keeper_lane "keeper-b")
+        ~event_id:(event "other")
+        (fun () ->
+           record "other";
+           Eio.Promise.resolve resolve_other_done ());
+      Eio.Promise.await other_done;
+      check
+        bool
+        "blocked lane did not block another Keeper lane"
+        false
+        (List.mem "second" (trace_snapshot ()));
+      Eio.Promise.resolve resolve_release_first ();
+      Eio.Promise.await second_done;
+      let same_lane_trace =
+        trace_snapshot () |> List.filter (fun value -> value <> "other")
+      in
+      check
+        (list string)
+        "same Keeper lane retains connector arrival order"
+        [ "first-start"; "first-end"; "second" ]
+        same_lane_trace))
+
+let test_ingress_observes_callback_failure_and_continues () =
+  Eio_main.run (fun _env ->
+    Eio.Switch.run (fun sw ->
+      let failure_seen, resolve_failure_seen = Eio.Promise.create () in
+      let later_done, resolve_later_done = Eio.Promise.create () in
+      let observed = ref None in
+      let ingress =
+        Ingress.create
+          ~sw
+          ~on_failure:(fun failure ->
+            observed := Some failure;
+            Eio.Promise.resolve resolve_failure_seen ())
+          ()
+      in
+      let lane = Ingress.Keeper_lane "keeper-a" in
+      Ingress.submit
+        ingress
+        ~lane
+        ~event_id:{ source = "test"; opaque_id = "failed" }
+        (fun () -> failwith "callback boom");
+      Ingress.submit
+        ingress
+        ~lane
+        ~event_id:{ source = "test"; opaque_id = "later" }
+        (fun () -> Eio.Promise.resolve resolve_later_done ());
+      Eio.Promise.await failure_seen;
+      Eio.Promise.await later_done;
+      match !observed with
+      | None -> fail "callback failure was not observed"
+      | Some failure ->
+        check
+          string
+          "failure retains exact event identity"
+          "test:failed"
+          (Ingress.event_id_to_string failure.event_id);
+        check
+          string
+          "failure retains Keeper lane"
+          "keeper:keeper-a"
+          (Ingress.lane_to_string failure.lane);
+        check
+          bool
+          "failure detail is explicit"
+          true
+          (String.length failure.reason > 0)))
+
 let () =
   run "discord_gateway_client"
     [
@@ -43,5 +157,15 @@ let () =
             test_reader_stops_after_close_input
         ; test_case "continues after non-close inputs" `Quick
             test_reader_continues_after_non_close_inputs
+        ] )
+    ; ( "ingress_lanes"
+      , [ test_case
+            "blocked callback isolates lanes and preserves same-lane FIFO"
+            `Quick
+            test_ingress_isolates_lanes_and_preserves_lane_fifo
+        ; test_case
+            "callback failure is observed and later work continues"
+            `Quick
+            test_ingress_observes_callback_failure_and_continues
         ] )
     ]


### PR DESCRIPTION
## Outcome

Discord WSS protocol progress no longer executes a Keeper turn inline. Triggered and ambient message callbacks are handed to one switch-owned ingress dispatcher with exact event identity and the binding-resolved Keeper lane.

- FIFO inside one Keeper lane
- independent progress across Keeper lanes
- per-event callback failure is logged with lane and event provenance
- callback failure does not cancel the connector driver, sibling lanes, or later work
- no capacity, timeout, retry-count, risk classifier, standing grant, or drop policy
- binding is resolved before handoff and frozen for execution, so one event cannot change lanes between queueing and dispatch

This is the first Discord slice. Slack wiring, durable pre-callback ingress recovery, binding-store read errors, Gate decision provenance, and scheduled-invocation Gate proof remain separate stacked work; this PR does not claim those are complete.

## Verification

- ocamlformat --check on touched OCaml files
- ocamlc -stop-after parsing on touched OCaml files
- git diff --check
- focused tests added for blocked-lane isolation, same-lane FIFO, typed failure evidence, and continuation after callback failure
- Dune build/test intentionally left to PR CI per operator instruction

Diff: +387/-12, 399 changed lines.