### PR TITLE
fix(connector): route Slack ingress by Keeper lane

### DIFF
--- a/lib/gate/connector_ingress_lane.ml
+++ b/lib/gate/connector_ingress_lane.ml
@@ -1,0 +1,143 @@
+type lane =
+  | Keeper_lane of string
+  | Connector_lane of string
+
+type event_id =
+  { source : string
+  ; opaque_id : string
+  }
+
+type failure =
+  { lane : lane
+  ; event_id : event_id
+  ; reason : string
+  }
+
+type job =
+  { event_id : event_id
+  ; run : unit -> unit
+  }
+
+type lane_state =
+  { jobs : job Queue.t
+  ; mutable scheduled : bool
+  ; mutable active : bool
+  }
+
+type t =
+  { sw : Eio.Switch.t
+  ; mutex : Stdlib.Mutex.t
+  ; condition : Eio.Condition.t
+  ; lanes : (lane, lane_state) Hashtbl.t
+  ; ready : lane Queue.t
+  ; on_failure : failure -> unit
+  }
+
+let lane_to_string = function
+  | Keeper_lane keeper_name -> "keeper:" ^ keeper_name
+  | Connector_lane connector_id -> "connector:" ^ connector_id
+;;
+
+let event_id_to_string event_id =
+  event_id.source ^ ":" ^ event_id.opaque_id
+;;
+
+let with_lock t f = Stdlib.Mutex.protect t.mutex f
+
+let report_failure t failure =
+  try t.on_failure failure with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Log.Server.error
+      "connector ingress failure observer crashed lane=%s event=%s: %s"
+      (lane_to_string failure.lane)
+      (event_id_to_string failure.event_id)
+      (Printexc.to_string exn)
+;;
+
+let run_job t lane job =
+  try job.run () with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    report_failure
+      t
+      { lane; event_id = job.event_id; reason = Printexc.to_string exn }
+;;
+
+let take_lane_job t lane state =
+  with_lock t (fun () ->
+    match Queue.take_opt state.jobs with
+    | Some job -> Some job
+    | None ->
+      state.active <- false;
+      Hashtbl.remove t.lanes lane;
+      None)
+;;
+
+let rec run_lane t lane state =
+  match take_lane_job t lane state with
+  | None -> ()
+  | Some job ->
+    run_job t lane job;
+    Eio.Fiber.yield ();
+    run_lane t lane state
+;;
+
+let take_ready_lane t =
+  with_lock t (fun () ->
+    match Queue.take_opt t.ready with
+    | None -> None
+    | Some lane ->
+      (match Hashtbl.find_opt t.lanes lane with
+       | Some state when state.scheduled && not state.active ->
+         state.scheduled <- false;
+         state.active <- true;
+         Some (lane, state)
+       | Some _ | None -> None))
+;;
+
+let rec run_dispatcher t =
+  let lane, state =
+    Eio.Condition.loop_no_mutex t.condition (fun () -> take_ready_lane t)
+  in
+  Eio.Fiber.fork ~sw:t.sw (fun () -> run_lane t lane state);
+  run_dispatcher t
+;;
+
+let create ~sw ~on_failure () =
+  let t =
+    { sw
+    ; mutex = Stdlib.Mutex.create ()
+    ; condition = Eio.Condition.create ()
+    ; lanes = Hashtbl.create 16
+    ; ready = Queue.create ()
+    ; on_failure
+    }
+  in
+  Eio.Fiber.fork ~sw (fun () -> run_dispatcher t);
+  t
+;;
+
+let submit t ~lane ~event_id run =
+  let notify =
+    with_lock t (fun () ->
+      let state =
+        match Hashtbl.find_opt t.lanes lane with
+        | Some state -> state
+        | None ->
+          let state =
+            { jobs = Queue.create (); scheduled = false; active = false }
+          in
+          Hashtbl.add t.lanes lane state;
+          state
+      in
+      Queue.add { event_id; run } state.jobs;
+      if state.active || state.scheduled
+      then false
+      else (
+        state.scheduled <- true;
+        Queue.add lane t.ready;
+        true))
+  in
+  if notify then Eio.Condition.broadcast t.condition
+;;

--- a/lib/gate/connector_ingress_lane.mli
+++ b/lib/gate/connector_ingress_lane.mli
@@ -1,0 +1,34 @@
+(** Switch-owned FIFO lanes without policy capacity, timeout, or drop paths. *)
+
+type lane =
+  | Keeper_lane of string
+  | Connector_lane of string
+
+type event_id =
+  { source : string
+  ; opaque_id : string
+  }
+
+type failure =
+  { lane : lane
+  ; event_id : event_id
+  ; reason : string
+  }
+
+type t
+
+val lane_to_string : lane -> string
+val event_id_to_string : event_id -> string
+
+val create :
+  sw:Eio.Switch.t ->
+  on_failure:(failure -> unit) ->
+  unit ->
+  t
+
+val submit :
+  t ->
+  lane:lane ->
+  event_id:event_id ->
+  (unit -> unit) ->
+  unit

--- a/lib/gate/dune
+++ b/lib/gate/dune
@@ -16,6 +16,7 @@
   channel_gate_slack_state
   channel_gate_telegram_state
   channel_gate_metrics
+  connector_ingress_lane
   discord_observability
   discord_gateway_client
   discord_gateway_state

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -343,7 +343,7 @@ let resolve_binding_for_message ~channel_id ~message_reference_channel_id =
                     },
                     [ ("discord.binding_reference_channel_id", reference_channel_id) ] ))
 
-let handle_message_create ~dispatch
+let handle_message_create ?resolved_binding ~dispatch
       ~clock
       ~(channel_id : string) ~(message_id : string)
       ~(guild_id : string option)
@@ -355,7 +355,13 @@ let handle_message_create ~dispatch
       ~(message_reference_channel_id : string option)
       ~(message_reference_message_id : string option)
       ~(referenced_message_author_id : string option) =
-  match resolve_binding_for_message ~channel_id ~message_reference_channel_id with
+  let binding =
+    match resolved_binding with
+    | Some binding -> Some binding
+    | None ->
+      resolve_binding_for_message ~channel_id ~message_reference_channel_id
+  in
+  match binding with
   | None ->
     (* No binding for this channel — drop quietly. The bot may be in
        channels it isn't bound to (e.g. server-wide guild messages). *)
@@ -514,7 +520,8 @@ let handle_message_create ~dispatch
               Discord_observability.record_reply
                 Discord_observability.Reply_send_failed))
 
-let on_event ~dispatch ~clock ~base_dir (ev : Gw.gateway_event) =
+let on_event ?resolved_binding ~dispatch ~clock ~base_dir
+    (ev : Gw.gateway_event) =
   match ev with
   | Gw.Ready { bot_user_id; _ } ->
     State.record_ready ~bot_user_id;
@@ -535,7 +542,8 @@ let on_event ~dispatch ~clock ~base_dir (ev : Gw.gateway_event) =
       } ->
     (* mentions_bot is already enforced by the trigger policy at the
        gateway-state layer; nothing extra to check here. *)
-    handle_message_create ~dispatch ~clock ~channel_id ~message_id ~author_id
+    handle_message_create ?resolved_binding ~dispatch ~clock ~channel_id
+      ~message_id ~author_id
       ~guild_id ~base_dir ~author_name ~content ~mentions_bot ~explicit_mentions_bot
       ~message_reference_channel_id ~message_reference_message_id
       ~referenced_message_author_id
@@ -569,10 +577,15 @@ let on_event ~dispatch ~clock ~base_dir (ev : Gw.gateway_event) =
    the trigger policy is still conversation the keeper sits in. Persist
    a single user line — no dispatch, no turn. Unbound channels drop, as
    on the dispatch path. *)
-let handle_ambient ~base_dir
+let handle_ambient ?resolved_keeper_name ~base_dir
       ~(channel_id : string) ~(guild_id : string option) ~(message_id : string)
       ~(author_id : string) ~(author_name : string option) ~(content : string) =
-  match State.keeper_for_channel ~channel_id with
+  let keeper_name =
+    match resolved_keeper_name with
+    | Some keeper_name -> Some keeper_name
+    | None -> State.keeper_for_channel ~channel_id
+  in
+  match keeper_name with
   | None ->
     Discord_observability.record_ambient
       Discord_observability.Ambient_dropped_unbound
@@ -695,14 +708,62 @@ let handle_ambient ~base_dir
         Discord_observability.Ambient_recorded
     end
 
-let on_ambient ~base_dir (ev : Gw.gateway_event) =
+let on_ambient ?resolved_keeper_name ~base_dir (ev : Gw.gateway_event) =
   match ev with
   | Gw.Message_create
       { channel_id; guild_id; message_id; author_id; author_name; content; _ }
     ->
-    handle_ambient ~base_dir ~channel_id ~guild_id ~message_id ~author_id
-      ~author_name ~content
+    handle_ambient ?resolved_keeper_name ~base_dir ~channel_id ~guild_id
+      ~message_id ~author_id ~author_name ~content
   | Gw.Ready _ | Gw.Reaction_add _ | Gw.Thread_tracked _ | Gw.Threads_bulk_tracked _ | Gw.Thread_removed _ | Gw.Ignored _ -> ()
+
+let submit_triggered_event ingress ~dispatch ~clock ~base_dir
+    (ev : Gw.gateway_event) =
+  match ev with
+  | Gw.Message_create
+      { channel_id; message_id; message_reference_channel_id; _ } ->
+    (match
+       resolve_binding_for_message ~channel_id ~message_reference_channel_id
+     with
+     | None -> on_event ~dispatch ~clock ~base_dir ev
+     | Some ((resolution, _) as resolved_binding) ->
+       Connector_ingress_lane.submit
+         ingress
+         ~lane:(Connector_ingress_lane.Keeper_lane resolution.State.keeper_name)
+         ~event_id:{ source = "discord_triggered"; opaque_id = message_id }
+         (fun () ->
+            on_event
+              ~resolved_binding
+              ~dispatch
+              ~clock
+              ~base_dir
+              ev))
+  | Gw.Ready _
+  | Gw.Reaction_add _
+  | Gw.Thread_tracked _
+  | Gw.Threads_bulk_tracked _
+  | Gw.Thread_removed _
+  | Gw.Ignored _ -> on_event ~dispatch ~clock ~base_dir ev
+;;
+
+let submit_ambient_event ingress ~base_dir (ev : Gw.gateway_event) =
+  match ev with
+  | Gw.Message_create { channel_id; message_id; _ } ->
+    (match State.keeper_for_channel ~channel_id with
+     | None -> on_ambient ~base_dir ev
+     | Some keeper_name ->
+       Connector_ingress_lane.submit
+         ingress
+         ~lane:(Connector_ingress_lane.Keeper_lane keeper_name)
+         ~event_id:{ source = "discord_ambient"; opaque_id = message_id }
+         (fun () -> on_ambient ~resolved_keeper_name:keeper_name ~base_dir ev))
+  | Gw.Ready _
+  | Gw.Reaction_add _
+  | Gw.Thread_tracked _
+  | Gw.Threads_bulk_tracked _
+  | Gw.Thread_removed _
+  | Gw.Ignored _ -> on_ambient ~base_dir ev
+;;
 
 (* ---------------------------------------------------------------- *)
 (* Start                                                            *)
@@ -716,6 +777,17 @@ let start ~sw ~env ~clock ~state =
   | Some token ->
     let policy = resolved_trigger_policy () in
     State.set_trigger_policy policy;
+    let ingress =
+      Connector_ingress_lane.create
+        ~sw
+        ~on_failure:(fun failure ->
+          Log.Server.error
+            "Discord ingress callback failed lane=%s event=%s: %s"
+            (Connector_ingress_lane.lane_to_string failure.lane)
+            (Connector_ingress_lane.event_id_to_string failure.event_id)
+            failure.reason)
+        ()
+    in
     let dispatch_for_config config =
       (* RFC-connector-deferred-reply-via-chat-queue: tag this dispatch as the Discord connector so a message that
          arrives while the keeper is in flight is enqueued onto
@@ -745,14 +817,15 @@ let start ~sw ~env ~clock ~state =
           ~trigger_policy:policy
           ~on_event:(fun ev ->
             let config = Mcp_server.workspace_config state in
-            on_event
+            submit_triggered_event
+              ingress
               ~dispatch:(dispatch_for_config config)
               ~clock
               ~base_dir:config.base_path
               ev)
           ~on_ambient:(fun ev ->
             let config = Mcp_server.workspace_config state in
-            on_ambient ~base_dir:config.base_path ev)
+            submit_ambient_event ingress ~base_dir:config.base_path ev)
           ()
       with
       | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/server/server_slack_in_process_gateway.ml
+++ b/lib/server/server_slack_in_process_gateway.ml
@@ -446,6 +446,10 @@ let submit_event ingress ~dispatch ~clock (ev : Gw.slack_event) =
   | Gw.Reaction_added _ | Gw.Ignored_event _ -> on_event ~dispatch ~clock ev
 ;;
 
+module For_testing = struct
+  let submit_event = submit_event
+end
+
 (* ---------------------------------------------------------------- *)
 (* Start                                                            *)
 (* ---------------------------------------------------------------- *)

--- a/lib/server/server_slack_in_process_gateway.ml
+++ b/lib/server/server_slack_in_process_gateway.ml
@@ -265,9 +265,14 @@ let finish_slack_stream_reply ~clock state ~final_content =
 (* Inbound delivery                                                 *)
 (* ---------------------------------------------------------------- *)
 
-let handle_inbound ~dispatch ~clock ~channel_id ~thread_ts ~user_id ~user_name
-    ~text ~ts ~mentions_bot ~is_app_mention =
-  match State.resolve_keeper_for_channel ~channel_id with
+let handle_inbound ?resolved_binding ~dispatch ~clock ~channel_id ~thread_ts
+    ~user_id ~user_name ~text ~ts ~mentions_bot ~is_app_mention =
+  let binding =
+    match resolved_binding with
+    | Some binding -> Some binding
+    | None -> State.resolve_keeper_for_channel ~channel_id
+  in
+  match binding with
   | None ->
     (* No binding for this channel — drop quietly. The bot may sit in channels
        it isn't bound to. *)
@@ -387,7 +392,7 @@ let handle_inbound ~dispatch ~clock ~channel_id ~thread_ts ~user_id ~user_name
            Slack_observability.record_reply
              Slack_observability.Reply_send_failed)
 
-let on_event ~dispatch ~clock (ev : Gw.slack_event) =
+let on_event ?resolved_binding ~dispatch ~clock (ev : Gw.slack_event) =
   match ev with
   | Gw.Message_create
       { channel_id; thread_ts; user_id; user_name; text; ts; mentions_bot
@@ -402,12 +407,13 @@ let on_event ~dispatch ~clock (ev : Gw.slack_event) =
     | None ->
       Slack_observability.record_gateway_event
         ~route:Slack_observability.Triggered Slack_observability.Message_create;
-      handle_inbound ~dispatch ~clock ~channel_id ~thread_ts ~user_id ~user_name
-        ~text ~ts ~mentions_bot ~is_app_mention:false)
+      handle_inbound ?resolved_binding ~dispatch ~clock ~channel_id ~thread_ts
+        ~user_id ~user_name ~text ~ts ~mentions_bot ~is_app_mention:false)
   | Gw.App_mention { channel_id; thread_ts; user_id; text; ts } ->
     Slack_observability.record_gateway_event ~route:Slack_observability.Triggered
       Slack_observability.App_mention;
-    handle_inbound ~dispatch ~clock ~channel_id ~thread_ts ~user_id
+    handle_inbound ?resolved_binding ~dispatch ~clock ~channel_id ~thread_ts
+      ~user_id
       ~user_name:None ~text ~ts ~mentions_bot:true ~is_app_mention:true
   | Gw.Reaction_added _ ->
     (* Ambient this pass: reactions are not turn-starters (RFC-0317). *)
@@ -416,6 +422,29 @@ let on_event ~dispatch ~clock (ev : Gw.slack_event) =
   | Gw.Ignored_event _ ->
     Slack_observability.record_gateway_event ~route:Slack_observability.Control
       Slack_observability.Ignored
+
+let submit_event ingress ~dispatch ~clock (ev : Gw.slack_event) =
+  let submit ~channel_id ~event_id =
+    match State.resolve_keeper_for_channel_result ~channel_id with
+    | Error reason ->
+      Slack_observability.record_inbound_dispatch Slack_observability.Gate_error;
+      Log.Server.error
+        "Slack ingress binding unavailable channel=%s event=%s: %s"
+        channel_id event_id reason
+    | Ok None -> on_event ~dispatch ~clock ev
+    | Ok (Some resolution) ->
+      Connector_ingress_lane.submit
+        ingress
+        ~lane:(Connector_ingress_lane.Keeper_lane resolution.State.keeper_name)
+        ~event_id:{ source = "slack_triggered"; opaque_id = event_id }
+        (fun () -> on_event ~resolved_binding:resolution ~dispatch ~clock ev)
+  in
+  match ev with
+  | Gw.Message_create { bot_id = Some _; _ } -> on_event ~dispatch ~clock ev
+  | Gw.Message_create { channel_id; ts; bot_id = None; _ }
+  | Gw.App_mention { channel_id; ts; _ } -> submit ~channel_id ~event_id:ts
+  | Gw.Reaction_added _ | Gw.Ignored_event _ -> on_event ~dispatch ~clock ev
+;;
 
 (* ---------------------------------------------------------------- *)
 (* Start                                                            *)
@@ -468,6 +497,17 @@ let start ~sw ~env ~state =
              None)
        in
        State.set_trigger_policy policy;
+       let ingress =
+         Connector_ingress_lane.create
+           ~sw
+           ~on_failure:(fun failure ->
+             Log.Server.error
+               "Slack ingress callback failed lane=%s event=%s: %s"
+               (Connector_ingress_lane.lane_to_string failure.lane)
+               (Connector_ingress_lane.event_id_to_string failure.event_id)
+               failure.reason)
+           ()
+       in
        let dispatch_for_config config =
          (* Tag this dispatch as the Slack connector so a message arriving while
             the keeper is in flight enqueues onto [Keeper_chat_queue] (drained
@@ -493,7 +533,11 @@ let start ~sw ~env ~state =
              ~trigger_policy:policy
              ~on_event:(fun ev ->
                let config = Mcp_server.workspace_config state in
-               on_event ~dispatch:(dispatch_for_config config) ~clock ev)
+               submit_event
+                 ingress
+                 ~dispatch:(dispatch_for_config config)
+                 ~clock
+                 ev)
              ()
          with
          | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/server/server_slack_in_process_gateway.mli
+++ b/lib/server/server_slack_in_process_gateway.mli
@@ -56,6 +56,15 @@ val load_trigger_policy_from_toml :
 
 val trigger_policy_load_error_to_string : trigger_policy_load_error -> string
 
+module For_testing : sig
+  val submit_event :
+    Connector_ingress_lane.t ->
+    dispatch:Channel_gate.streaming_dispatch_fn ->
+    clock:_ Eio.Time.clock ->
+    Slack_socket_client.slack_event ->
+    unit
+end
+
 val start :
   sw:Eio.Switch.t ->
   env:Eio_unix.Stdenv.base ->

--- a/test/stanzas/test_discord_gateway_client.inc
+++ b/test/stanzas/test_discord_gateway_client.inc
@@ -2,4 +2,4 @@
 (test
  (name test_discord_gateway_client)
  (modules test_discord_gateway_client)
- (libraries alcotest yojson masc.gate))
+ (libraries alcotest yojson eio_main masc.gate))

--- a/test/test_discord_gateway_client.ml
+++ b/test/test_discord_gateway_client.ml
@@ -1,6 +1,7 @@
 open Alcotest
 
 module Client = Discord_gateway_client
+module Ingress = Connector_ingress_lane
 module State = Discord_gateway_state
 
 let dummy_frame : State.frame =
@@ -34,6 +35,119 @@ let test_reader_continues_after_non_close_inputs () =
     (fun (label, input) -> check_continue label input true)
     cases
 
+let test_ingress_isolates_lanes_and_preserves_lane_fifo () =
+  Eio_main.run (fun _env ->
+    Eio.Switch.run (fun sw ->
+      let trace_mutex = Stdlib.Mutex.create () in
+      let trace = ref [] in
+      let record value =
+        Stdlib.Mutex.protect trace_mutex (fun () -> trace := value :: !trace)
+      in
+      let trace_snapshot () =
+        Stdlib.Mutex.protect trace_mutex (fun () -> List.rev !trace)
+      in
+      let first_started, resolve_first_started = Eio.Promise.create () in
+      let release_first, resolve_release_first = Eio.Promise.create () in
+      let second_done, resolve_second_done = Eio.Promise.create () in
+      let other_done, resolve_other_done = Eio.Promise.create () in
+      let ingress =
+        Ingress.create
+          ~sw
+          ~on_failure:(fun failure ->
+            fail
+              ("unexpected connector callback failure: " ^ failure.reason))
+          ()
+      in
+      let event opaque_id : Ingress.event_id =
+        { source = "test"; opaque_id }
+      in
+      Ingress.submit
+        ingress
+        ~lane:(Ingress.Keeper_lane "keeper-a")
+        ~event_id:(event "first")
+        (fun () ->
+           record "first-start";
+           Eio.Promise.resolve resolve_first_started ();
+           Eio.Promise.await release_first;
+           record "first-end");
+      Eio.Promise.await first_started;
+      Ingress.submit
+        ingress
+        ~lane:(Ingress.Keeper_lane "keeper-a")
+        ~event_id:(event "second")
+        (fun () ->
+           record "second";
+           Eio.Promise.resolve resolve_second_done ());
+      Ingress.submit
+        ingress
+        ~lane:(Ingress.Keeper_lane "keeper-b")
+        ~event_id:(event "other")
+        (fun () ->
+           record "other";
+           Eio.Promise.resolve resolve_other_done ());
+      Eio.Promise.await other_done;
+      check
+        bool
+        "blocked lane did not block another Keeper lane"
+        false
+        (List.mem "second" (trace_snapshot ()));
+      Eio.Promise.resolve resolve_release_first ();
+      Eio.Promise.await second_done;
+      let same_lane_trace =
+        trace_snapshot () |> List.filter (fun value -> value <> "other")
+      in
+      check
+        (list string)
+        "same Keeper lane retains connector arrival order"
+        [ "first-start"; "first-end"; "second" ]
+        same_lane_trace))
+
+let test_ingress_observes_callback_failure_and_continues () =
+  Eio_main.run (fun _env ->
+    Eio.Switch.run (fun sw ->
+      let failure_seen, resolve_failure_seen = Eio.Promise.create () in
+      let later_done, resolve_later_done = Eio.Promise.create () in
+      let observed = ref None in
+      let ingress =
+        Ingress.create
+          ~sw
+          ~on_failure:(fun failure ->
+            observed := Some failure;
+            Eio.Promise.resolve resolve_failure_seen ())
+          ()
+      in
+      let lane = Ingress.Keeper_lane "keeper-a" in
+      Ingress.submit
+        ingress
+        ~lane
+        ~event_id:{ source = "test"; opaque_id = "failed" }
+        (fun () -> failwith "callback boom");
+      Ingress.submit
+        ingress
+        ~lane
+        ~event_id:{ source = "test"; opaque_id = "later" }
+        (fun () -> Eio.Promise.resolve resolve_later_done ());
+      Eio.Promise.await failure_seen;
+      Eio.Promise.await later_done;
+      match !observed with
+      | None -> fail "callback failure was not observed"
+      | Some failure ->
+        check
+          string
+          "failure retains exact event identity"
+          "test:failed"
+          (Ingress.event_id_to_string failure.event_id);
+        check
+          string
+          "failure retains Keeper lane"
+          "keeper:keeper-a"
+          (Ingress.lane_to_string failure.lane);
+        check
+          bool
+          "failure detail is explicit"
+          true
+          (String.length failure.reason > 0)))
+
 let () =
   run "discord_gateway_client"
     [
@@ -43,5 +157,15 @@ let () =
             test_reader_stops_after_close_input
         ; test_case "continues after non-close inputs" `Quick
             test_reader_continues_after_non_close_inputs
+        ] )
+    ; ( "ingress_lanes"
+      , [ test_case
+            "blocked callback isolates lanes and preserves same-lane FIFO"
+            `Quick
+            test_ingress_isolates_lanes_and_preserves_lane_fifo
+        ; test_case
+            "callback failure is observed and later work continues"
+            `Quick
+            test_ingress_observes_callback_failure_and_continues
         ] )
     ]

--- a/test/test_server_slack_trigger_policy.ml
+++ b/test/test_server_slack_trigger_policy.ml
@@ -201,6 +201,88 @@ let test_startup_error_is_operator_visible () =
              Yojson.Safe.Util.(status |> member "error" |> to_string))))
 ;;
 
+let slack_message ~ts =
+  Slack_socket_client.Message_create
+    { channel_id = "C123"
+    ; thread_ts = None
+    ; user_id = "U123"
+    ; user_name = Some "operator"
+    ; text = "wake the keeper"
+    ; ts
+    ; mentions_bot = true
+    ; bot_id = None
+    }
+;;
+
+let test_bound_message_queues_exact_slack_ts () =
+  with_temp_base (fun () ->
+    match
+      State.bind ~channel_id:"C123" ~keeper_name:"luna" ~actor_name:"test"
+    with
+    | Error detail -> fail detail
+    | Ok _ ->
+      Eio_main.run @@ fun env ->
+      Eio.Switch.run @@ fun sw ->
+      let observed, resolve_observed = Eio.Promise.create () in
+      let ingress =
+        Connector_ingress_lane.create ~sw
+          ~on_failure:(fun failure ->
+            Eio.Promise.resolve resolve_observed failure)
+          ()
+      in
+      let dispatch ~on_text_snapshot:_ ~channel:_ ~channel_user_id:_
+          ~channel_user_name:_ ~channel_workspace_id:_ ~keeper_name:_
+          ~idempotency_key:_ ~metadata:_ ~content:_ =
+        failwith "observe Slack ingress identity"
+      in
+      G.For_testing.submit_event ingress ~dispatch
+        ~clock:(Eio.Stdenv.clock env)
+        (slack_message ~ts:"1710000000.123456");
+      let failure = Eio.Promise.await observed in
+      check string "exact Slack event ts" "1710000000.123456"
+        failure.Connector_ingress_lane.event_id.opaque_id;
+      check string "typed source" "slack_triggered"
+        failure.event_id.source;
+      match failure.lane with
+      | Connector_ingress_lane.Keeper_lane keeper_name ->
+        check string "resolved Keeper lane" "luna" keeper_name
+      | Connector_ingress_lane.Connector_lane connector_id ->
+        failf "expected Keeper lane, got connector:%s" connector_id)
+;;
+
+let test_binding_store_failure_does_not_enqueue () =
+  with_temp_base (fun () ->
+    let binding_path =
+      Filename.concat
+        (Env_config_core.base_path ())
+        ".gate/runtime/slack/bindings.json"
+    in
+    Fs_compat.mkdir_p (Filename.dirname binding_path);
+    let out = open_out_bin binding_path in
+    Fun.protect
+      ~finally:(fun () -> close_out_noerr out)
+      (fun () -> output_string out "{not-json");
+    Eio_main.run @@ fun env ->
+    Eio.Switch.run @@ fun sw ->
+    let dispatch_called = ref false in
+    let ingress =
+      Connector_ingress_lane.create ~sw
+        ~on_failure:(fun _ -> fail "binding failure must not enqueue")
+        ()
+    in
+    let dispatch ~on_text_snapshot:_ ~channel:_ ~channel_user_id:_
+        ~channel_user_name:_ ~channel_workspace_id:_ ~keeper_name:_
+        ~idempotency_key:_ ~metadata:_ ~content:_ =
+      dispatch_called := true;
+      Gate_protocol.Unavailable_result
+    in
+    G.For_testing.submit_event ingress ~dispatch
+      ~clock:(Eio.Stdenv.clock env)
+      (slack_message ~ts:"1710000000.654321");
+    Eio.Fiber.yield ();
+    check bool "no volatile job accepted" false !dispatch_called)
+;;
+
 let () =
   run "server_slack_trigger_policy"
     [ ( "parse_trigger_policy"
@@ -233,5 +315,11 @@ let () =
             test_invalid_runtime_toml_policy_is_error
         ; test_case "startup error => offline with error" `Quick
             test_startup_error_is_operator_visible
+        ] )
+    ; ( "ingress handoff"
+      , [ test_case "bound message retains exact Slack ts" `Quick
+            test_bound_message_queues_exact_slack_ts
+        ; test_case "binding store failure does not enqueue" `Quick
+            test_binding_store_failure_does_not_enqueue
         ] )
     ]


### PR DESCRIPTION
## Outcome

Stacked on #24568. Slack reuses the connector-neutral ingress abstraction without adding Slack or Discord branching to the core.

- exact Slack event `ts` is retained as ingress identity
- binding is resolved through the typed result API before handoff and frozen for execution
- binding-store read failure is an explicit per-event log and Gate-error observation, not an unbound fallback
- same-Keeper FIFO and different-Keeper concurrency come from the shared #24568 contract
- bot/control/ambient events that do not invoke a Keeper remain immediate typed event handling
- focused production-path tests prove the exact `ts`/Keeper lane handoff and prove an unreadable binding store enqueues no volatile job

This PR does not add durable pre-worker recovery, Gate decision provenance, scheduler gating, or new grant semantics.

## Verification

- `ocamlformat --check` on touched files
- `ocamlc -stop-after parsing` on touched files
- `git diff --check`
- focused Slack binding-store and exact event identity tests added
- Dune build/test intentionally left to PR CI per operator instruction

Diff against parent: +153/-8.
