### PR TITLE
fix(dashboard): preserve block-only keeper work

### DIFF
--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -1765,6 +1765,24 @@ describe('Keeper v2 chat blocks', () => {
     expect(trace?.textContent).toContain('result')
   })
 
+  it('renders an explicit placeholder for a redacted persisted thinking block', () => {
+    renderBlocks([{ t: 'thinking', content: '', redacted: true }])
+
+    const thinking = container.querySelector('[data-chat-block="thinking"]')
+    expect(thinking).not.toBeNull()
+    expect(thinking?.getAttribute('data-chat-thinking-redacted')).toBe('true')
+    expect(thinking?.textContent).toContain('provider 서명')
+  })
+
+  it('renders persisted non-redacted thinking content', () => {
+    renderBlocks([{ t: 'thinking', content: 'checking state', redacted: false }])
+
+    const thinking = container.querySelector('[data-chat-block="thinking"]')
+    expect(thinking).not.toBeNull()
+    expect(thinking?.getAttribute('data-chat-thinking-redacted')).toBe('false')
+    expect(thinking?.textContent).toContain('checking state')
+  })
+
   it('renders a link unfurl card with extracted hostname', () => {
     renderBlocks([
       {
@@ -3554,6 +3572,22 @@ describe('ChatMessageBubble — rich markdown rendering of assistant prose', () 
     ])
     expect(container.querySelector('[data-chat-block="voice"]')).not.toBeNull()
     expect(container.querySelector('[data-chat-block="code"]')).toBeNull()
+  })
+
+  it('does not replace persisted thinking with a markdown reparse', async () => {
+    renderEntries([
+      entry({
+        id: 'a-thinking',
+        role: 'assistant',
+        source: 'direct_assistant',
+        text: 'secondary prose with ```code``` inline',
+        blocks: [{ t: 'thinking', content: 'checked source state', redacted: false }],
+      }),
+    ])
+
+    await flushUi()
+    expect(container.querySelector('[data-chat-block="thinking"]')?.textContent).toContain('checked source state')
+    expect(container.textContent).toContain('secondary prose')
   })
 })
 

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -2127,6 +2127,29 @@ function ChatFusionCard({ boardPostId, runId, fallbackText }: { boardPostId: str
   `
 }
 
+function ChatPersistedThinkingBlock({ content, redacted }: { content: string; redacted: boolean }) {
+  if (!redacted) {
+    return html`
+      <div class="chat-block-trace" data-chat-block="thinking" data-chat-thinking-redacted="false">
+        <${ChatTraceStep} step=${{ kind: 'think', text: content }} />
+      </div>
+    `
+  }
+  return html`
+    <div class="chat-block-trace" data-chat-block="thinking" data-chat-thinking-redacted="true">
+      <div class="chat-block-tstep think">
+        <span class="chat-block-tnode"></span>
+        <div class="min-w-0 flex-1">
+          <div class="chat-block-tstep-row">
+            <span class="chat-block-tstep-kind">Thinking</span>
+          </div>
+          <div class="chat-block-tstep-text">Thinking 본문은 provider 서명으로만 제공되어 표시할 수 없습니다.</div>
+        </div>
+      </div>
+    </div>
+  `
+}
+
 function ChatBlock({ block, fallbackText }: { block: ChatBlock; fallbackText?: string }) {
   switch (block.t) {
     case 'p': return html`<${ChatTextBlock} html=${block.html} />`
@@ -2146,6 +2169,7 @@ function ChatBlock({ block, fallbackText }: { block: ChatBlock; fallbackText?: s
     case 'svg': return html`<${ChatSvgBlock} svg=${block.svg} cap=${block.cap} />`
     case 'mermaid': return html`<${ChatMermaidBlock} source=${block.source} caption=${block.caption} />`
     case 'trace': return html`<${ChatTraceBlock} trace=${block.trace} />`
+    case 'thinking': return html`<${ChatPersistedThinkingBlock} content=${block.content} redacted=${block.redacted} />`
     case 'link': return html`<${ChatLinkBlock} url=${block.url} title=${block.title} desc=${block.desc} meta=${block.meta} fav=${block.fav} kind=${block.kind} />`
     case 'broadcast': return html`<${ChatBroadcastBlock} scope=${block.scope} via=${block.via} note=${block.note} recipients=${block.recipients} />`
     case 'fusion': return html`<${ChatFusionCard} boardPostId=${block.board_post_id} runId=${block.run_id} fallbackText=${fallbackText} />`
@@ -2418,9 +2442,10 @@ function AudioPlayer({ clip }: { clip: KeeperConversationAudioClip }) {
 
 // Block types that parseMarkdownToBlocks cannot reproduce from message text:
 // synthesized voice clips, attachments, fusion deliberation cards, artifacts,
-// broadcasts, traces, shell transcripts. When an assistant/system message
+// broadcasts, traces, and shell transcripts. When an assistant/system message
 // carries one of these the server blocks are rendered as-is; otherwise the
-// prose is re-parsed richly. (Complement of the markdown-derived block set:
+// prose is re-parsed richly. (Complement of the
+// markdown-derived block set:
 // p/h4/ul/callout/table/code/mermaid/image/svg/link.)
 const CARD_BLOCK_TYPES: ReadonlySet<ChatBlock['t']> = new Set([
   'voice',
@@ -2523,10 +2548,16 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
     })()
     return () => { active = false }
   }, [shouldParseRichBlocks, entry.text])
-  const effectiveBlocks = isFailureMessage ? [] : (parsedBlocks ?? entry.blocks ?? [])
+  const persistedThinkingBlocks = (entry.blocks ?? [])
+    .filter((block): block is Extract<ChatBlock, { t: 'thinking' }> => block.t === 'thinking')
+  const renderedServerBlocks = parsedBlocks !== null
+    ? [...persistedThinkingBlocks, ...parsedBlocks]
+    : (entry.blocks ?? [])
+  const effectiveBlocks = isFailureMessage ? [] : renderedServerBlocks
   const hasEffectiveBlocks = effectiveBlocks.length > 0
+  const hasNonThinkingBlocks = effectiveBlocks.some(block => block.t !== 'thinking')
   const collapseThreshold = 1200
-  const isCollapsible = !hasEffectiveBlocks && messageLength > collapseThreshold
+  const isCollapsible = !hasNonThinkingBlocks && messageLength > collapseThreshold
   const tone = bubbleTone(entry)
   const isMessenger = variant === 'messenger'
   const detailItems = detailSummary(entry.details)
@@ -2737,7 +2768,17 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
                   diagnostic=${entry.error?.trim() ? entry.error : messageText}
                 />`
               : hasEffectiveBlocks
-              ? html`<${ChatBlocks} blocks=${effectiveBlocks} fallbackText=${entry.text} />`
+              ? html`
+                  <${ChatBlocks} blocks=${effectiveBlocks} fallbackText=${entry.text} />
+                  ${hasRealText && !hasNonThinkingBlocks
+                    ? html`
+                        <div
+                          class=${`markdown-body whitespace-pre-wrap break-words text-base leading-airy text-[var(--color-fg-primary)] ${isCollapsible && messageCollapsed ? 'max-h-96 overflow-hidden' : ''}`}
+                          dangerouslySetInnerHTML=${renderPlainLinkedHtml(messageText)}
+                        />
+                      `
+                    : null}
+                `
               : traceOwnsIntermediateText
               ? null
               : html`

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -1267,6 +1267,11 @@ describe('sendKeeperThreadMessage stream outcome', () => {
         name: 'KEEPER_QUEUE_REQUEST',
         value: { request_id: 'kmsg_echo_cancelling', status: 'queued' },
       })
+      opts.onEvent({
+        type: 'CUSTOM',
+        name: 'KEEPER_THINKING_DELTA',
+        value: { index: 0, delta: 'preserved before cancellation' },
+      })
       return new Promise<{ terminal: boolean }>((_resolve, reject) => {
         opts.signal?.addEventListener('abort', () => { reject(abortError()) }, { once: true })
       })
@@ -1284,6 +1289,11 @@ describe('sendKeeperThreadMessage stream outcome', () => {
       expect(fetchQueuedKeeperMessageResult).toHaveBeenCalledWith('kmsg_echo_cancelling')
       expect(pendingKeeperChatRequestsForKeeper('echo')).toEqual([])
     })
+    const cancelledAssistant = (keeperThreads.value.echo ?? [])
+      .find(entry => entry.role === 'assistant' && entry.delivery === 'cancelled')
+    expect(cancelledAssistant?.traceSteps).toEqual([
+      { kind: 'think', text: 'preserved before cancellation', ts: expect.any(String), oasBlockIndex: 0 },
+    ])
   })
 
   it('surfaces the actual persistence failure after a cancellation acknowledgement', async () => {

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -79,6 +79,7 @@ import {
 import {
   hasPendingKeeperChatRequest,
   pendingKeeperChatRequestsForKeeper,
+  pendingKeeperChatAssistantDraftFromEntry,
   removePendingKeeperChatRequest,
   type PendingKeeperChatRequest,
   updatePendingKeeperChatAssistantDraft,
@@ -570,6 +571,17 @@ function persistPendingAssistantDraft(
     .find(candidate => candidate.id === assistantEntryId) ?? null
   if (!entry) return
   updatePendingKeeperChatAssistantDraft(requestId, entry)
+}
+
+function withCurrentPendingAssistantDraft(
+  request: PendingKeeperChatRequest,
+  assistantEntryId: string,
+): PendingKeeperChatRequest {
+  const entry = (keeperThreads.value[request.keeperName] ?? [])
+    .find(candidate => candidate.id === assistantEntryId) ?? null
+  if (!entry) return request
+  const assistantDraft = pendingKeeperChatAssistantDraftFromEntry(entry)
+  return assistantDraft ? { ...request, assistantDraft } : request
 }
 
 let localIdCounter = 0
@@ -1294,13 +1306,13 @@ export async function sendKeeperThreadMessage(
             setRecordValue(keeperActionErrors, keeperName, message)
           } else if (controller.signal.aborted) {
             requestId = nextRequestId
-            const pendingRequest: PendingKeeperChatRequest = {
+            const pendingRequest = withCurrentPendingAssistantDraft({
               requestId: nextRequestId,
               keeperName,
               message,
               submittedAt: Date.now(),
               ...(attachments ? { attachments } : {}),
-            }
+            }, assistantId)
             upsertPendingKeeperChatRequest(pendingRequest)
             void cancelKeeperThreadRequest(keeperName, nextRequestId).then(outcome => {
               if (outcome === 'cancelling') {
@@ -1439,11 +1451,11 @@ export async function sendKeeperThreadMessage(
   } catch (err) {
     flushPendingKeeperStreamDeltas(keeperName, assistantId)
     if (isAbortError(err)) {
-      const hasDurablePendingRequest = Boolean(
-        requestId
-        && pendingKeeperChatRequestsForKeeper(keeperName)
-          .some(candidate => candidate.requestId === requestId),
-      )
+      const durablePendingRequest = requestId
+        ? pendingKeeperChatRequestsForKeeper(keeperName)
+          .find(candidate => candidate.requestId === requestId) ?? null
+        : null
+      const hasDurablePendingRequest = durablePendingRequest !== null
       const shouldAttemptServerCancel = Boolean(
         requestId && (liveSendOwnsRequest(requestId) || hasDurablePendingRequest),
       )
@@ -1453,13 +1465,14 @@ export async function sendKeeperThreadMessage(
         && !hasDurablePendingRequest,
       )
       if (shouldAttemptServerCancel && requestId) {
-        const pendingRequest: PendingKeeperChatRequest = {
+        const pendingRequest = withCurrentPendingAssistantDraft(durablePendingRequest ?? {
           requestId,
           keeperName,
           message,
           submittedAt: Date.now(),
           ...(attachments ? { attachments } : {}),
-        }
+        }, assistantId)
+        upsertPendingKeeperChatRequest(pendingRequest)
         void cancelKeeperThreadRequest(keeperName, requestId).then(outcome => {
           if (outcome === 'cancelling') {
             return handoffCancelledStreamToRequestPoll(

--- a/dashboard/src/keeper-chat-pending.ts
+++ b/dashboard/src/keeper-chat-pending.ts
@@ -173,7 +173,9 @@ function normalizeAssistantDraft(raw: unknown): PendingKeeperChatAssistantDraft 
   }
 }
 
-function assistantDraftFromEntry(entry: KeeperConversationEntry): PendingKeeperChatAssistantDraft | null {
+export function pendingKeeperChatAssistantDraftFromEntry(
+  entry: KeeperConversationEntry,
+): PendingKeeperChatAssistantDraft | null {
   if (entry.role !== 'assistant') return null
   const traceSteps = normalizeTraceSteps(entry.traceSteps)
   return {
@@ -272,7 +274,7 @@ export function updatePendingKeeperChatAssistantDraft(
   entry: KeeperConversationEntry,
 ): void {
   const id = requestId.trim()
-  const assistantDraft = assistantDraftFromEntry(entry)
+  const assistantDraft = pendingKeeperChatAssistantDraftFromEntry(entry)
   if (!id || !assistantDraft) return
   const requests = readAll()
   let found = false

--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -957,6 +957,72 @@ describe('thread history merge & persistence', () => {
     expect(entries[0]?.attachments).toHaveLength(1)
   })
 
+  it('keeps a validated redacted thinking block when assistant content is empty', () => {
+    const entries = chatHistoryEntriesFromRest('echo', [
+      {
+        id: 'thinking-only',
+        role: 'assistant',
+        content: '',
+        ts: 1_780_000_000,
+        blocks: [{ t: 'thinking', content: '', redacted: true }],
+      },
+    ])
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0]?.blocks).toEqual([{ t: 'thinking', content: '', redacted: true }])
+  })
+
+  it('keeps non-redacted thinking content when assistant content is empty', () => {
+    const entries = chatHistoryEntriesFromRest('echo', [
+      {
+        id: 'thinking-only',
+        role: 'assistant',
+        content: '',
+        ts: 1_780_000_000,
+        blocks: [{ t: 'thinking', content: 'checking state', redacted: false }],
+      },
+    ])
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0]?.blocks).toEqual([
+      { t: 'thinking', content: 'checking state', redacted: false },
+    ])
+  })
+
+  it('keeps a validated trace block when assistant content is empty', () => {
+    const entries = chatHistoryEntriesFromRest('echo', [
+      {
+        id: 'trace-only',
+        role: 'assistant',
+        content: '',
+        ts: 1_780_000_000,
+        blocks: [{ t: 'trace', trace: [{ kind: 'think', text: 'checking state' }] }],
+      },
+    ])
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0]?.blocks).toEqual([
+      { t: 'trace', trace: [{ kind: 'think', text: 'checking state' }] },
+    ])
+  })
+
+  it('keeps a validated fusion block when assistant content is empty', () => {
+    const entries = chatHistoryEntriesFromRest('echo', [
+      {
+        id: 'fusion-only',
+        role: 'assistant',
+        content: '',
+        ts: 1_780_000_000,
+        blocks: [{ t: 'fusion', board_post_id: 'post-1', run_id: 'fusion-run-1' }],
+      },
+    ])
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0]?.blocks).toEqual([
+      { t: 'fusion', board_post_id: 'post-1', run_id: 'fusion-run-1' },
+    ])
+  })
+
   it('still drops rows that have no content and no attachments', () => {
     const entries = chatHistoryEntriesFromRest('echo', [
       { role: 'user', content: '', ts: 1_780_000_000 },

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -649,6 +649,12 @@ function normalizeBlocks(raw: unknown, role: KeeperConversationRole): ChatBlock[
         const trace = normalizeTraceSteps(item.trace)
         return trace && trace.length > 0 ? { t: 'trace', trace } : null
       }
+      if (t === 'thinking') {
+        const content = typeof item.content === 'string' ? item.content : undefined
+        const redacted = item.redacted === true
+        if (content === undefined) return null
+        return { t: 'thinking', content: redacted ? '' : content, redacted }
+      }
       if (t === 'link') {
         const url = asString(item.url)
         const title = asString(item.title)
@@ -859,14 +865,15 @@ function normalizeHistoryEntry(
   const rawText = asString(raw.content) ?? asString(raw.preview) ?? ''
   const attachments = normalizeAttachments(raw.attachments)
   const audio = normalizeAudioClip(raw.audio) ?? null
-  // Accept attachment-only or audio-only rows: a user may send a file/image
-  // with no text, or the assistant may emit a synthesized voice clip with no
-  // generated text. Without this guard those persisted rows are dropped on
-  // reload even though they are renderable server-side.
-  if (!rawText && !attachments?.length && !audio) return null
+  const serverBlocks = normalizeBlocks(raw.blocks, role)
+  const hasRenderableBlocks = (serverBlocks?.length ?? 0) > 0
+  // Accept attachment-only, audio-only, and validated block-only rows. In
+  // particular, persisted thinking/trace/fusion blocks may intentionally have
+  // no visible `content`; rejecting them here erased completed work on reload.
+  if (!rawText && !attachments?.length && !audio && !hasRenderableBlocks) return null
   const source = normalizeConversationSource(raw.source, role, rawText, previousSource)
   const text = formatKeeperVisibleReply(rawText)
-  if (!text && !attachments?.length && !audio) return null
+  if (!text && !attachments?.length && !audio && !hasRenderableBlocks) return null
   const timestamp = toIsoTimestamp(raw.ts_unix) ?? toIsoTimestamp(raw.timestamp)
   const label = role === 'assistant' && keeperName ? keeperName : roleLabel(role)
   const surface = isRecord(raw.surface) ? (raw.surface as unknown as SurfaceRef) : null
@@ -884,7 +891,6 @@ function normalizeHistoryEntry(
   // semantics and must not inherit the durable-row reassurance.
   const delivery: KeeperConversationDelivery =
     asString(raw.kind) === 'transport_failure' ? 'transport_failure' : 'history'
-  const serverBlocks = normalizeBlocks(raw.blocks, role)
   const blocks = serverBlocks
     ?? ((role === 'assistant' || role === 'system') && text
       ? parseTextToChatBlocks(text)

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -739,7 +739,7 @@ describe('applyKeeperStreamEvent', () => {
     ])
   })
 
-  it('drops pending thinking deltas when aborting a live stream', () => {
+  it('preserves received thinking deltas when aborting a live stream', () => {
     assistantEntry()
     setActiveStream('sangsu', 'reply-1', new AbortController())
     applyKeeperStreamEvent('sangsu', 'reply-1', {
@@ -754,7 +754,10 @@ describe('applyKeeperStreamEvent', () => {
     const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
     expect(entry?.delivery).toBe('cancelled')
     expect(entry?.streamState).toBeNull()
-    expect(entry?.traceSteps).toBeUndefined()
+    expect(entry?.text).toBe('요청이 취소되었습니다.')
+    expect(entry?.traceSteps).toEqual([
+      { kind: 'think', text: 'half-written reasoning', ts: expect.any(String) },
+    ])
   })
 
   it('splits thinking trace steps by OAS content block index', () => {

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -115,16 +115,6 @@ function flushPendingThinkingDeltas(
   persistActiveAssistantDraft(keeperName, assistantEntryId)
 }
 
-function dropPendingThinkingDeltas(keeperName: string, assistantEntryId: string): void {
-  const key = streamEntryKey(keeperName, assistantEntryId)
-  const pending = pendingThinkingDeltas.get(key)
-  if (!pending) return
-  pendingThinkingDeltas.delete(key)
-  if (pending.flushHandle !== null) {
-    cancelStreamFlush(pending.flushHandle)
-  }
-}
-
 function flushAllPendingThinkingDeltas(): void {
   for (const key of Array.from(pendingThinkingDeltas.keys())) {
     const [keeperName, assistantEntryId] = key.split('\u0000')
@@ -346,7 +336,7 @@ export function abortKeeperThreadMessage(name: string): KeeperThreadAbortResult 
   console.debug(`[keeper-stream] aborting stream for ${keeperName}${entryId ? ` (entry=${entryId})` : ''}${requestId ? ` request=${requestId}` : ''}`)
   if (controller) controller.abort()
   if (entryId) {
-    dropPendingThinkingDeltas(keeperName, entryId)
+    flushPendingThinkingDeltas(keeperName, entryId)
     finalizeAssistantEntry(keeperName, entryId, {
       text: KEEPER_MESSAGE_CANCELLED_TEXT,
       rawText: KEEPER_MESSAGE_CANCELLED_TEXT,

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -840,6 +840,7 @@ export type ChatTraceToolStep = {
 }
 export type ChatTraceStep = ChatTraceThinkStep | ChatTraceReasonStep | ChatTraceProgressStep | ChatTraceToolStep
 export type ChatTraceBlock = { t: 'trace'; trace: ChatTraceStep[] }
+export type ChatThinkingBlock = { t: 'thinking'; content: string; redacted: boolean }
 
 export type ChatLinkBlock = { t: 'link'; url: string; title: string; desc?: string; meta?: string; fav?: string; kind?: string }
 
@@ -870,6 +871,7 @@ export type ChatBlock =
   | ChatSvgBlock
   | ChatMermaidBlock
   | ChatTraceBlock
+  | ChatThinkingBlock
   | ChatLinkBlock
   | ChatBroadcastBlock
   | ChatFusionBlock


### PR DESCRIPTION
## Summary

- retain validated thinking, trace, and fusion blocks when persisted assistant content is empty
- render persisted thinking explicitly without replacing the final assistant prose during rich-text parsing
- flush received thinking deltas on abort and carry the same typed assistant draft through cancelling-to-poll handoff
- add focused regressions for reload, renderer composition, abort, and queued cancellation handoff

## Validation

- `pnpm exec vitest run --config vitest.config.ts src/keeper-actions.test.ts src/keeper-state.test.ts src/keeper-stream.test.ts src/components/chat/primitives.test.ts --no-file-parallelism --maxWorkers=1` (332 passed)
- `pnpm typecheck`
- `git diff origin/main...HEAD --check`
- `pnpm lint` remains blocked by the pre-existing `dashboard/src/keeper-actions.ts:996` `no-nested-ternary` violation; this PR does not touch that line

## Scope

This is the loss-prevention hotfix only. It does not preserve or extend the legacy flat progress/adjacency reconstruction; recursive Run/Turn/Block/Invocation projection remains a separate hard-cut architecture change.