### PR TITLE
fix(keeper): continue ready lane drain without sleep

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -113,10 +113,16 @@ let run_keeper_cycle = Cycle.run_keeper_cycle
    [Turn_failed] instead of [Turn_succeeded]. Such a cycle must also
    NOT refresh the work-as-heartbeat lease; the count is observation and never
    terminates the Keeper lane. *)
-type keepalive_turn_outcome = {
-  meta : keeper_meta;
-  cycle_crashed : bool;
-}
+type ready_queue_followup =
+  | No_ready_queue_followup
+  | Drain_ready_queue of
+      { excluding : Keeper_event_queue.stimulus list }
+
+type keepalive_turn_outcome =
+  { meta : keeper_meta
+  ; cycle_crashed : bool
+  ; ready_queue_followup : ready_queue_followup
+  }
 
 exception Event_queue_settlement_failed of string
 
@@ -407,6 +413,26 @@ let settlement_is_ack = function
     false
 ;;
 
+let ready_queue_followup_of_settlement ~lease = function
+  | Keeper_registry_event_queue.Ack
+  | Keeper_registry_event_queue.Escalate _ ->
+    Drain_ready_queue { excluding = [] }
+  | Keeper_registry_event_queue.Requeue
+      ( Keeper_registry_event_queue.Rotate_now
+      | Keeper_registry_event_queue.Retry_after_observed
+      | Keeper_registry_event_queue.Approval_grant_unconsumed
+      | Keeper_registry_event_queue.Approval_grant_state_unavailable ) ->
+    Drain_ready_queue
+      { excluding = Keeper_registry_event_queue.lease_stimuli lease }
+  | Keeper_registry_event_queue.Requeue
+      ( Keeper_registry_event_queue.Cycle_busy
+      | Keeper_registry_event_queue.Turn_not_scheduled
+      | Keeper_registry_event_queue.Cancelled
+      | Keeper_registry_event_queue.Cycle_crashed
+      | Keeper_registry_event_queue.Registration_recovery ) ->
+    No_ready_queue_followup
+;;
+
 (* Pure: post-turn status event derived from the registry turn-failure
    counter. Extracted from the loop body so the crashed-cycle ->
    [Turn_failed] mapping is unit-testable. *)
@@ -427,13 +453,18 @@ let run_keepalive_unified_turn
   : keepalive_turn_outcome
   =
   if not proactive_warmup_elapsed
-  then { meta = meta_after_triage; cycle_crashed = false }
+  then
+    { meta = meta_after_triage
+    ; cycle_crashed = false
+    ; ready_queue_followup = No_ready_queue_followup
+    }
   else (
     let consumed_stimuli = ref [] in
     let claimed_lease = ref None in
     let cycle_outcome_ref = ref None in
     let lease_settled = ref false in
     let settlement_failed = ref false in
+    let ready_queue_followup = ref No_ready_queue_followup in
     let record_settlement_failure message =
       settlement_failed := true;
       match !cycle_outcome_ref with
@@ -737,7 +768,8 @@ let run_keepalive_unified_turn
                     meta_after_triage.name
                     successor
                 with
-                | Ok () -> ()
+                | Ok () ->
+                  ready_queue_followup := Drain_ready_queue { excluding = [] }
                 | Error message ->
                   Log.Keeper.error
                     "registry: unleased failure judgment enqueue failed keeper=%s: %s"
@@ -785,6 +817,8 @@ let run_keepalive_unified_turn
               ( Keeper_registry_event_queue.Settled _
               | Keeper_registry_event_queue.Already_settled _ ) ->
             lease_settled := true;
+            ready_queue_followup :=
+              ready_queue_followup_of_settlement ~lease settlement;
             (match
                project_transition_outbox
                  ~base_path:ctx.config.base_path
@@ -798,7 +832,10 @@ let run_keepalive_unified_turn
                 ~base_path:ctx.config.base_path
                 ~keeper_name:meta_after_triage.name
                 (connector_attention_event_ids_of_stimuli !consumed_stimuli)));
-      { meta = meta_after_cycle; cycle_crashed = !settlement_failed }
+      { meta = meta_after_cycle
+      ; cycle_crashed = !settlement_failed
+      ; ready_queue_followup = !ready_queue_followup
+      }
     with
     | Eio.Cancel.Cancelled _ as e ->
       let backtrace = Printexc.get_raw_backtrace () in
@@ -817,7 +854,10 @@ let run_keepalive_unified_turn
         ~base_path:ctx.config.base_path
         ~keeper_name:meta_after_triage.name
         exn;
-      { meta = meta_after_triage; cycle_crashed = true })
+      { meta = meta_after_triage
+      ; cycle_crashed = true
+      ; ready_queue_followup = No_ready_queue_followup
+      })
 ;;
 
 let refresh_work_as_heartbeat = Keeper_heartbeat_loop_refresh_work.refresh_work_as_heartbeat
@@ -1076,7 +1116,11 @@ let run_heartbeat_loop
         let t_turn_start = t_board_end in
         let turn_outcome =
           if not admitted_turn
-          then { meta = meta_current; cycle_crashed = false }
+          then
+            { meta = meta_current
+            ; cycle_crashed = false
+            ; ready_queue_followup = No_ready_queue_followup
+            }
           else (
             (* Cycle 43: KeeperHeartbeat.tla TurnComplete bracket — the
                [turn_running] flag toggles around the dispatch and the
@@ -1177,15 +1221,39 @@ let run_heartbeat_loop
           ~t_turn_end
           ~t_recurring_start
           ~t_recurring_end;
+        let ready_queue_followup_count =
+          match turn_outcome.ready_queue_followup with
+          | No_ready_queue_followup -> 0
+          | Drain_ready_queue { excluding }
+            when
+              proactive_warmup_elapsed
+              && not lifecycle_blocked
+              && not turn_outcome.cycle_crashed ->
+            Keeper_registry_event_queue.snapshot
+              ~base_path:ctx.config.base_path
+              meta_current.name
+            |> Keeper_heartbeat_stimulus_intake.ready_stimulus_count ~excluding
+          | Drain_ready_queue _ -> 0
+        in
         (* Carry the inter-cycle sleep result into the next iteration so the
            turn evaluator can distinguish a broadcast wakeup ([Woken]) from this
            keeper's configured cadence ([Timeout]). *)
         last_wake_source :=
-          Keeper_keepalive_signal.interruptible_sleep
-            ~clock:ctx.clock
-            ~stop
-            ~wakeup
-            interval;
+          if ready_queue_followup_count > 0
+          then (
+            let absorbed_wakeup_hint = Atomic.compare_and_set wakeup true false in
+            Log.Keeper.info
+              "%s: keeper lane drain continues without heartbeat sleep ready=%d wake_hint_absorbed=%b"
+              meta_current.name
+              ready_queue_followup_count
+              absorbed_wakeup_hint;
+            Keeper_keepalive_signal.Woken)
+          else
+            Keeper_keepalive_signal.interruptible_sleep
+              ~clock:ctx.clock
+              ~stop
+              ~wakeup
+              interval;
       if Atomic.get stop then () else loop ())
   in
   loop ()

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -108,10 +108,24 @@ val record_provider_timeout_observation :
     unified-turn failure path uses — so the caller dispatches
     [Turn_failed]. Such a cycle must not refresh the
     work-as-heartbeat lease. *)
-type keepalive_turn_outcome = {
-  meta : keeper_meta;
-  cycle_crashed : bool;
-}
+type ready_queue_followup =
+  | No_ready_queue_followup
+  | Drain_ready_queue of
+      { excluding : Keeper_event_queue.stimulus list }
+
+type keepalive_turn_outcome =
+  { meta : keeper_meta
+  ; cycle_crashed : bool
+  ; ready_queue_followup : ready_queue_followup
+  }
+
+val ready_queue_followup_of_settlement
+  :  lease:Keeper_registry_event_queue.lease
+  -> Keeper_registry_event_queue.settlement
+  -> ready_queue_followup
+(** Decide whether a committed settlement may immediately drain other ready
+    work. Retryable/recoverable sources are excluded for this one follow-up so
+    they cannot monopolize the lane ahead of unrelated stimuli. *)
 
 (** Record a swallowed keepalive-cycle exception as a turn failure:
     increments the registry turn-failure counter (shared with

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -257,6 +257,21 @@ let stimulus_ready_for_intake (stimulus : Keeper_event_queue.stimulus) =
     true
 ;;
 
+let ready_stimulus_count ~excluding queue =
+  Keeper_event_queue.to_list queue
+  |> List.fold_left
+       (fun count stimulus ->
+          let excluded =
+            List.exists
+              (Keeper_event_queue.stimulus_identity_equal stimulus)
+              excluding
+          in
+          if (not excluded) && stimulus_ready_for_intake stimulus
+          then count + 1
+          else count)
+       0
+;;
+
 let heartbeat_event_intake
       ~ctx
       ~meta_after_triage

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.mli
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.mli
@@ -52,6 +52,14 @@ val consume_single_heartbeat_stimulus
   -> Keeper_event_queue.stimulus
   -> Keeper_world_observation.pending_board_event list
 
+val ready_stimulus_count
+  :  excluding:Keeper_event_queue.stimulus list
+  -> Keeper_event_queue.t
+  -> int
+(** Count exact typed stimuli that can be leased now, excluding identities
+    retained by the just-finished cycle. This is the queue-drain continuation
+    probe; it neither mutates the queue nor invents a time/count threshold. *)
+
 (** [heartbeat_event_intake ~ctx ~meta_after_triage
      ~pending_board_events]
     drains the Event-Layer queue (per RFC-0020 §3 Rule 4) and merges

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -439,6 +439,42 @@ let test_cancelled_and_skipped_cycles_requeue () =
   | _ -> Alcotest.fail "non-executable phase acknowledged leased work"
 ;;
 
+let test_settlement_controls_immediate_lane_drain () =
+  let source = stimulus "drain-source" 1.0 in
+  let unrelated = stimulus "unrelated-ready" 2.0 in
+  let lease = lease_for source in
+  let followup settlement =
+    Masc.Keeper_heartbeat_loop.ready_queue_followup_of_settlement
+      ~lease
+      settlement
+  in
+  (match followup Masc.Keeper_registry_event_queue.Ack with
+   | Masc.Keeper_heartbeat_loop.Drain_ready_queue { excluding = [] } -> ()
+   | _ -> Alcotest.fail "acknowledged work did not continue ready queue drain");
+  (match
+     followup
+       (Masc.Keeper_registry_event_queue.Requeue
+          Masc.Keeper_registry_event_queue.Retry_after_observed)
+   with
+   | Masc.Keeper_heartbeat_loop.Drain_ready_queue { excluding = [ retained ] }
+     when Queue.stimulus_identity_equal source retained ->
+     ()
+   | _ -> Alcotest.fail "retryable source was not excluded from immediate follow-up");
+  Alcotest.(check int)
+    "retained source does not hide unrelated ready work"
+    1
+    (Masc.Keeper_heartbeat_stimulus_intake.ready_stimulus_count
+       ~excluding:[ source ]
+       (queue [ source; unrelated ]));
+  match
+    followup
+      (Masc.Keeper_registry_event_queue.Requeue
+         Masc.Keeper_registry_event_queue.Cycle_busy)
+  with
+  | Masc.Keeper_heartbeat_loop.No_ready_queue_followup -> ()
+  | _ -> Alcotest.fail "busy turn slot requested an immediate retry loop"
+;;
+
 let test_unconsumed_approval_requeues_behind_other_work () =
   List.iter
     (fun reason ->
@@ -876,6 +912,10 @@ let () =
             "cancelled and skipped cycles requeue"
             `Quick
             test_cancelled_and_skipped_cycles_requeue
+        ; Alcotest.test_case
+            "settlement controls immediate lane drain"
+            `Quick
+            test_settlement_controls_immediate_lane_drain
         ; Alcotest.test_case
             "unconsumed approval yields FIFO"
             `Quick


### PR DESCRIPTION
## Stack

Depends on #24573.

## Why

A wake hint is an edge, not the durable queue authority. When several stimuli were already queued before one wake was consumed, the Keeper processed one lease and then slept for the full heartbeat interval even though more ready work remained. This made a nominal per-Keeper queue behave like one-item-per-heartbeat polling.

## What

- derive a typed post-settlement queue-followup decision
- continue immediately after acknowledged/escalated work when another exact ready stimulus remains
- let retryable sources move behind unrelated ready work without immediately reclaiming themselves
- never spin immediately after busy, unscheduled, cancelled, crashed, or registration-recovery settlement
- absorb the already-accounted wake hint and log every no-sleep lane continuation with exact ready count
- use no timeout, retry count, queue threshold, urgency rank, or domain-specific priority

## Proof

- focused state test pins ACK continuation, retry-source exclusion, unrelated ready work, and busy-slot no-spin behavior
- changed OCaml files pass ocamlformat, parser checks, and git diff --check
- full Dune build/test intentionally delegated to PR CI per repository workflow

## Non-goals

- does not modify provider retry/failover choice
- does not add a scheduler or connector policy
- does not bypass Keeper turn single-flight admission
