### PR TITLE
refactor(gate): hard-cut typed Keeper tracking ACK

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -89,6 +89,7 @@
   ;; RFC-0056 Phase 1N — Keeper_state_* deterministic FSM cluster extracted to
   ;; lib/keeper_state/. Parent still references bare Keeper_state_* modules.
   masc.keeper_registry
+  masc.keeper_invocation_types
   ;; Keeper-owned pure/type leaves extracted from lib/keeper/.
   masc.keeper_contract
   masc.keeper_hooks_oas_types

--- a/lib/gate/dune
+++ b/lib/gate/dune
@@ -58,6 +58,7 @@
   ; existing
   masc_config
   masc_core
+  masc.keeper_invocation_types
   masc_pulse
   masc.http_client
   masc.masc_log

--- a/lib/gate/gate_protocol.ml
+++ b/lib/gate/gate_protocol.ml
@@ -20,48 +20,23 @@ type turn_stats = {
   tokens_used : int;
 }
 
-type message_request_status =
-  | Accepted
-  | Acceptance_uncertain
-  | Queued
-  | Running
-  | Done
-  | Failed
-  | Lost
-  | Cancelled
+type message_request_tracking =
+  | Keeper_run of
+      { run_ref : Keeper_invocation_types.run_ref
+      ; result_contract : Keeper_invocation_types.result_contract
+      }
+  | Chat_receipt of { receipt_id : string }
 
 type message_request = {
-  request_id : string;
+  tracking : message_request_tracking;
   destination_type : string;
   destination_id : string;
   channel : string;
   actor_id : string option;
-  status : message_request_status;
   modalities : string list;
   transport : string option;
   metadata : (string * string) list;
 }
-
-let message_request_status_to_string = function
-  | Accepted -> "accepted"
-  | Acceptance_uncertain -> "acceptance_uncertain"
-  | Queued -> "queued"
-  | Running -> "running"
-  | Done -> "done"
-  | Failed -> "error"
-  | Lost -> "lost"
-  | Cancelled -> "cancelled"
-
-let message_request_status_of_string = function
-  | "accepted" -> Some Accepted
-  | "acceptance_uncertain" -> Some Acceptance_uncertain
-  | "queued" -> Some Queued
-  | "running" -> Some Running
-  | "done" -> Some Done
-  | "error" -> Some Failed
-  | "lost" -> Some Lost
-  | "cancelled" -> Some Cancelled
-  | _ -> None
 
 let string_list_json values =
   `List (List.map (fun value -> `String value) values)
@@ -74,14 +49,30 @@ let message_request_to_json request =
     | None -> `Null
     | Some value -> `String value
   in
+  let tracking =
+    match request.tracking with
+    | Keeper_run { run_ref; result_contract } ->
+      `Assoc
+        [ "kind", `String "keeper_run"
+        ; "run_ref", Keeper_invocation_types.run_ref_to_json run_ref
+        ; ( "result_contract"
+          , `String
+              (Keeper_invocation_types.result_contract_to_string result_contract) )
+        ]
+    | Chat_receipt { receipt_id } ->
+      `Assoc
+        [ "kind", `String "chat_receipt"
+        ; "receipt_id", `String receipt_id
+        ; "state", `String "queued"
+        ]
+  in
   `Assoc
     [
-      ("request_id", `String request.request_id);
+      ("tracking", tracking);
       ("destination_type", `String request.destination_type);
       ("destination_id", `String request.destination_id);
       ("channel", `String request.channel);
       ("actor_id", optional_string request.actor_id);
-      ("status", `String (message_request_status_to_string request.status));
       ("modalities", string_list_json request.modalities);
       ("transport", optional_string request.transport);
       ("metadata", string_assoc_json request.metadata);

--- a/lib/gate/gate_protocol.mli
+++ b/lib/gate/gate_protocol.mli
@@ -35,41 +35,32 @@ type turn_stats = {
   tokens_used : int;
 }
 
-(** Durable MASC message request envelope.
+(** Durable MASC message tracking envelope.
 
     This is the layer shared by dashboard chat, Connectors, and future
-    MASC<->MASC peers: a producer submits a request, receives a
-    [request_id], then observes live projections and reconciles terminal
-    state by id.  [modalities] is intentionally open-string JSON so the
+    MASC<->MASC peers. Keeper invocations carry the exact typed [run_ref] and
+    result contract; chat-queue deferrals carry their distinct typed receipt.
+    [modalities] is intentionally open-string JSON so the
     text-only dashboard path can grow into image/audio/file parts without
     another route shape. *)
-type message_request_status =
-  | Accepted
-  | Acceptance_uncertain
-  | Queued
-  | Running
-  | Done
-  | Failed
-  | Lost
-  | Cancelled
+type message_request_tracking =
+  | Keeper_run of
+      { run_ref : Keeper_invocation_types.run_ref
+      ; result_contract : Keeper_invocation_types.result_contract
+      }
+  | Chat_receipt of { receipt_id : string }
 
 type message_request = {
-  request_id : string;
+  tracking : message_request_tracking;
   destination_type : string;
   destination_id : string;
   channel : string;
   actor_id : string option;
-  status : message_request_status;
   modalities : string list;
   transport : string option;
   metadata : (string * string) list;
 }
 
-val message_request_status_to_string : message_request_status -> string
-(** Parse the canonical status labels emitted by [keeper_msg_async].
-    Unknown labels return [None] so callers fail closed instead of silently
-    treating protocol drift as acceptance. *)
-val message_request_status_of_string : string -> message_request_status option
 val message_request_to_json : message_request -> Yojson.Safe.t
 
 (** Successful response to send back to the consumer. *)

--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -28,7 +28,7 @@ type connector_kind =
       (** Every connector that is not a wired in-process inbound gateway with its
           own outbound adapter. Today this is the HTTP gate-route lane
           (imessage-bot, cli-connector) which POSTs and awaits synchronously, so
-          a busy message keeps the async [masc_keeper_msg] poll path; see
+          a busy message keeps the asynchronous typed Keeper-run path; see
           RFC-connector-deferred-reply-via-chat-queue §3.3 option (a). *)
 
 type submission_owner =
@@ -93,7 +93,7 @@ let non_empty_opt value =
     legitimate reply *without* an ACK contract (queued, running — handled
     separately by the [Streaming] arm of the dispatch match), and the
     backend could not parse the ACK contract at all (malformed JSON,
-    missing request_id, missing status, unknown future status). The
+    missing/invalid run_ref or result contract). The
     connector could not distinguish "queued" from "parse failed".
 
     Exposing the failure as a typed sum lets the dispatch site surface
@@ -101,28 +101,34 @@ let non_empty_opt value =
     rather than silently substituting the keeper's reply text. *)
 type ack_parse_failure =
   | Invalid_json of string
-  | Missing_request_id
-  | Empty_request_id
-  | Missing_status
-  | Invalid_status of string
+  | Missing_run_ref
+  | Invalid_run_ref of Keeper_invocation_contract.request_error
+  | Run_ref_target_mismatch of
+      { expected : string
+      ; actual : string
+      }
+  | Missing_result_contract
+  | Invalid_result_contract of string
 
 let ack_parse_failure_to_string = function
   | Invalid_json detail ->
       Printf.sprintf "invalid json: %s" detail
-  | Missing_request_id -> "missing request_id"
-  | Empty_request_id -> "empty request_id"
-  | Missing_status -> "missing status"
-  | Invalid_status raw ->
-      Printf.sprintf "unknown status %S (not in the closed status set)" raw
+  | Missing_run_ref -> "missing run_ref"
+  | Invalid_run_ref error ->
+    Keeper_invocation_contract.request_error_to_string error
+  | Run_ref_target_mismatch { expected; actual } ->
+    Printf.sprintf "run_ref target %S does not match expected Keeper %S" actual expected
+  | Missing_result_contract -> "missing result_contract"
+  | Invalid_result_contract raw ->
+    Printf.sprintf "unknown result_contract %S" raw
 
 (** Parse the async ACK envelope from a keeper tool response body.
 
-    Returns [Ok request] when the body is a valid JSON object with both
-    a non-empty [request_id] and a [status] that maps to one of the
-    closed [Gate_protocol.message_request_status] variants.
+    Returns [Ok request] when the body carries a valid typed [run_ref] and
+    closed Keeper invocation result contract.
 
     Returns [Error reason] otherwise. JSON parse failures are isolated
-    from the closed-sum status check so that a malformed envelope is
+    from the typed tracking check so that a malformed envelope is
     surfaced as a backend-degraded path, distinct from a legitimately
     absent ACK field. *)
 let extract_message_request_ack ~channel ~channel_user_id ~keeper_name ~metadata body :
@@ -134,47 +140,33 @@ let extract_message_request_ack ~channel ~channel_user_id ~keeper_name ~metadata
   match json with
   | Error failure -> Error failure
   | Ok json ->
-      let request_id =
-        match Json_util.get_string json "request_id" with
-        | None -> None
-        | Some value -> non_empty_opt value
-      in
-      (match request_id with
-       | None ->
-           (match Json_util.get_string json "request_id" with
-            | Some _ -> Error Empty_request_id
-            | None -> Error Missing_request_id)
-       | Some trimmed_request_id -> (
-           match Json_util.get_string json "status" with
-           | None -> Error Missing_status
-           | Some raw ->
-               let normalized = String.lowercase_ascii (String.trim raw) in
-               (match
-                  Gate_protocol.message_request_status_of_string normalized
-                with
-               | Some status ->
-                   let destination_id =
-                     match Json_util.get_string json "keeper_name" with
-                     | Some value ->
-                       (match non_empty_opt value with
-                        | Some trimmed -> trimmed
-                        | None -> keeper_name)
-                     | None -> keeper_name
-                   in
-                   let request : Gate_protocol.message_request =
-                     { request_id = trimmed_request_id
-                     ; destination_type = "keeper"
-                     ; destination_id
-                     ; channel
-                     ; actor_id = non_empty_opt channel_user_id
-                     ; status
-                     ; modalities = [ "text" ]
-                     ; transport = non_empty_opt channel
-                     ; metadata = ("status_source", "keeper_msg_async") :: metadata
-                     }
-                   in
-                   Ok request
-               | None -> Error (Invalid_status normalized))))
+    (match Json_util.assoc_member_opt "run_ref" json with
+     | None -> Error Missing_run_ref
+     | Some run_ref_json ->
+       (match Keeper_invocation_contract.run_ref_of_json run_ref_json with
+        | Error error -> Error (Invalid_run_ref error)
+        | Ok run_ref ->
+          let actual = Keeper_invocation_contract.run_ref_target_name run_ref in
+          if not (String.equal actual keeper_name)
+          then Error (Run_ref_target_mismatch { expected = keeper_name; actual })
+          else
+            match Json_util.get_string json "result_contract" with
+            | None -> Error Missing_result_contract
+            | Some raw ->
+              (match Keeper_invocation_contract.result_contract_of_string raw with
+               | None -> Error (Invalid_result_contract raw)
+               | Some result_contract ->
+                 Ok
+                   { Gate_protocol.tracking =
+                       Gate_protocol.Keeper_run { run_ref; result_contract }
+                   ; destination_type = "keeper"
+                   ; destination_id = actual
+                   ; channel
+                   ; actor_id = non_empty_opt channel_user_id
+                   ; modalities = [ "text" ]
+                   ; transport = non_empty_opt channel
+                   ; metadata = ("tracking_source", "keeper_invocation") :: metadata
+                   })))
 
 let in_flight_metadata (info : Keeper_turn_admission.in_flight_info option) =
   match info with
@@ -183,7 +175,12 @@ let in_flight_metadata (info : Keeper_turn_admission.in_flight_info option) =
       [ "in_flight_lane", Keeper_turn_admission.lane_to_string lane ]
 
 let busy_ack_reply_text ?in_flight (request : Gate_protocol.message_request) =
-  let status = Gate_protocol.message_request_status_to_string request.status in
+  let tracking =
+    match request.tracking with
+    | Gate_protocol.Keeper_run { result_contract; _ } ->
+      Keeper_invocation_contract.result_contract_to_string result_contract
+    | Gate_protocol.Chat_receipt { receipt_id } -> "queued receipt " ^ receipt_id
+  in
   let in_flight_text =
     match in_flight with
     | None -> ""
@@ -193,15 +190,14 @@ let busy_ack_reply_text ?in_flight (request : Gate_protocol.message_request) =
           (Keeper_turn_admission.lane_to_string lane)
   in
   Printf.sprintf
-    "%s is busy; your message is %s (request_id=%s).%s"
+    "%s is busy; the Keeper invocation contract is %s. Preserve the returned tracking value.%s"
     request.destination_id
-    status
-    request.request_id
+    tracking
     in_flight_text
 
 (* ACK text for the RFC-connector-deferred-reply-via-chat-queue chat-queue deferral path. The
    message was durably enqueued onto [Keeper_chat_queue], so its receipt id is
-   the correlation handle instead of a [Keeper_msg_async] poll request id. The
+   the correlation handle instead of a Keeper-run reference. The
    reply is delivered later by the serial consumer through the connector's
    outbound adapter. *)
 let busy_ack_reply_text_queued
@@ -252,16 +248,15 @@ let chat_queue_message_request ~channel ~channel_user_id ~keeper_name
         [ ( "shutdown_operation_id"
           , Keeper_shutdown_types.Operation_id.to_string operation_id ) ]
   in
-  { Gate_protocol.request_id = receipt_id
+  { Gate_protocol.tracking = Gate_protocol.Chat_receipt { receipt_id }
   ; destination_type = "keeper"
   ; destination_id = keeper_name
   ; channel
   ; actor_id = non_empty_opt channel_user_id
-  ; status = Gate_protocol.Queued
   ; modalities = [ "text" ]
   ; transport = non_empty_opt channel
   ; metadata =
-      [ "status_source", "keeper_chat_queue"
+      [ "tracking_source", "keeper_chat_queue"
       ; "receipt_id", receipt_id
       ; "queue_revision", Int64.to_string receipt.revision
       ; "pending_count", string_of_int receipt.pending_count
@@ -706,13 +701,13 @@ let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~submission_owne
                body — that collapses the queued state with a degraded
                parse path and breaks the connector's "is this queued?"
                decision. Log the parse failure with the same
-               [status_source=keeper_msg_async] surface so on-call can
+               [tracking_source=keeper_invocation] surface so on-call can
                triage whether the keeper contract regressed or the body
                was truncated mid-flight, and emit a degraded reply that
                names the parse failure without leaking the raw body. *)
             Log.Server.warn
               "channel gate async ACK parse failure (keeper=%s, lane=%s, \
-               request_id_context=%s, failure=%s): connector will see a \
+               payload_bytes=%s, failure=%s): connector will see a \
                degraded ACK, not the keeper's reply body."
               keeper_name lane (extract_reply_text body |> String.length |> string_of_int)
               (ack_parse_failure_to_string failure);
@@ -720,7 +715,7 @@ let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~submission_owne
             , Printf.sprintf
                 "%s is busy; the gate could not parse the async ACK \
                  envelope (%s). Your message was forwarded to the keeper, \
-                 but no durable request id is available. Treat this as a \
+                 but no typed tracking value is available. Treat this as a \
                  transient backend degradation rather than a queued reply."
                 keeper_name
                 (ack_parse_failure_to_string failure) )
@@ -753,7 +748,8 @@ let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~submission_owne
       let reply =
         redact_text
           (busy_ack_reply_text_queued ~admission_rejection ~keeper_name
-             ~receipt_id:message_request.request_id
+             ~receipt_id:
+               (Keeper_chat_queue.Receipt_id.to_string receipt.receipt_id)
              ~recovery_required_count:receipt.recovery_required_count)
       in
       let stats =

--- a/lib/gate_keeper_backend.mli
+++ b/lib/gate_keeper_backend.mli
@@ -20,7 +20,7 @@ type connector_kind =
     dispatch-construction time. [Discord] and [Slack] each have an in-process
     inbound gateway and an outbound adapter, so a busy message projects onto the
     chat queue; [Generic] (the HTTP gate-route lane: imessage-bot, cli-connector)
-    keeps the async [masc_keeper_msg] poll path. See
+    keeps the typed asynchronous Keeper-run tracking path. See
     RFC-connector-deferred-reply-via-chat-queue §3.2–3.3 and RFC-0317. *)
 
 type submission_owner =
@@ -163,17 +163,21 @@ val extract_turn_stats : string -> Gate_protocol.turn_stats option
 
     The Channel Gate's async dispatch path returns a JSON envelope that the
     downstream connector uses to track the keeper-side request lifecycle
-    (request_id, status, destination). Parsing this envelope is a wire
+    (run_ref, result contract, destination). Parsing this envelope is a wire
     boundary: malformed input must surface as a typed failure so the
     dispatch site can emit a deliberate degraded ACK rather than silently
     substitute the keeper's reply body. *)
 
 type ack_parse_failure =
   | Invalid_json of string
-  | Missing_request_id
-  | Empty_request_id
-  | Missing_status
-  | Invalid_status of string
+  | Missing_run_ref
+  | Invalid_run_ref of Keeper_invocation_contract.request_error
+  | Run_ref_target_mismatch of
+      { expected : string
+      ; actual : string
+      }
+  | Missing_result_contract
+  | Invalid_result_contract of string
 (** Closed-sum typed parse failure for {!extract_message_request_ack}. Each
     variant names a distinct cause so the dispatch site can log structured
     backend drift and emit a degraded ACK that names the parse failure
@@ -192,9 +196,8 @@ val extract_message_request_ack :
   string ->
   (Gate_protocol.message_request, ack_parse_failure) result
 (** Parse the async ACK envelope from a keeper tool response body.
-    Returns [Ok request] when the body is a valid JSON object with both
-    a non-empty [request_id] and a [status] that maps to one of the closed
-    [Gate_protocol.message_request_status] variants.
+    Returns [Ok request] when the body carries a valid typed [run_ref] and
+    closed Keeper invocation result contract.
     Returns [Error reason] otherwise. JSON parse failures are isolated
     from the closed-sum status check so that a malformed envelope is
     surfaced as a backend-degraded path, distinct from a legitimately

--- a/lib/keeper/keeper_invocation_contract.ml
+++ b/lib/keeper/keeper_invocation_contract.ml
@@ -1,6 +1,5 @@
-type capability = Invoke_turn
-
-type target = Keeper of Keeper_id.Keeper_name.t
+type capability = Keeper_invocation_types.capability = Invoke_turn
+type target = Keeper_invocation_types.target = Keeper of Keeper_id.Keeper_name.t
 
 type request =
   { target : target
@@ -8,7 +7,7 @@ type request =
   ; prompt : string
   }
 
-type run_ref =
+type run_ref = Keeper_invocation_types.run_ref =
   { run_id : string
   ; target : target
   ; capability : capability
@@ -21,7 +20,7 @@ type submission_receipt =
       ; reason : string
       }
 
-type result_contract =
+type result_contract = Keeper_invocation_types.result_contract =
   | Awaiting_execution
   | Publication_uncertain
   | Running
@@ -34,7 +33,6 @@ type result_contract =
 type request_error =
   | Invalid_target of string
   | Empty_prompt
-  | Invalid_entry_projection
   | Invalid_wire_value of
       { field : string
       ; expected : string
@@ -126,15 +124,12 @@ let request_of_json json =
 let request_error_to_string = function
   | Invalid_target reason -> reason
   | Empty_prompt -> "message is required"
-  | Invalid_entry_projection -> "Keeper invocation entry projection is not an object"
   | Invalid_wire_value { field; expected } ->
     Printf.sprintf "%s must be %s" field expected
   | Run_ref_mismatch -> "run_ref does not identify the stored Keeper invocation"
 ;;
 
-let target_name_of_target = function
-  | Keeper name -> Keeper_id.Keeper_name.to_string name
-;;
+let target_name_of_target = Keeper_invocation_types.target_name
 
 let target_name (request : request) =
   target_name_of_target request.target
@@ -181,25 +176,8 @@ let result_contract_of_status = function
 
 let result_contract entry = result_contract_of_status entry.Keeper_msg_async.status
 
-let capability_to_string = function
-  | Invoke_turn -> "invoke_turn"
-;;
-
-let target_to_json = function
-  | Keeper name ->
-    `Assoc
-      [ "kind", `String "keeper"
-      ; "name", `String (Keeper_id.Keeper_name.to_string name)
-      ]
-;;
-
-let run_ref_to_json reference =
-  `Assoc
-    [ "run_id", `String reference.run_id
-    ; "target", target_to_json reference.target
-    ; "capability", `String (capability_to_string reference.capability)
-    ]
-;;
+let target_to_json = Keeper_invocation_types.target_to_json
+let run_ref_to_json = Keeper_invocation_types.run_ref_to_json
 
 let run_ref_of_json json =
   let* fields = object_fields ~field:"run_ref" json in
@@ -220,7 +198,8 @@ let run_ref_of_json json =
   else Ok { run_id; target; capability }
 ;;
 
-let run_id reference = reference.run_id
+let run_id = Keeper_invocation_types.run_id
+let run_ref_target_name = Keeper_invocation_types.run_ref_target_name
 
 let run_ref_matches_entry reference (entry : Keeper_msg_async.entry) =
   String.equal reference.run_id entry.Keeper_msg_async.request_id
@@ -229,43 +208,8 @@ let run_ref_matches_entry reference (entry : Keeper_msg_async.entry) =
        entry.Keeper_msg_async.keeper_name
 ;;
 
-let result_contract_to_string = function
-  | Awaiting_execution -> "awaiting_execution"
-  | Publication_uncertain -> "publication_uncertain"
-  | Running -> "running"
-  | Yielded -> "yielded"
-  | Cancellation_requested -> "cancellation_requested"
-  | Cancelled -> "cancelled"
-  | Completed -> "completed"
-  | Failed -> "failed"
-;;
-
-let submission_to_json (request : request) outcome =
-  let common reference status contract =
-    [ "request_id", `String outcome.Keeper_msg_async.request_id
-    ; "keeper_name", `String (target_name request)
-    ; "status", `String status
-    ; "run_ref", run_ref_to_json reference
-    ; "result_contract", `String (result_contract_to_string contract)
-    ]
-  in
-  match submission_receipt request outcome with
-  | Durable_run reference ->
-    `Assoc
-      (common reference "queued" Awaiting_execution
-       @ [ ( "message"
-           , `String
-               "Keeper turn accepted. The caller lane may continue; query masc_keeper_msg_result with run_ref.run_id." )
-         ])
-  | Reconciliation_required { run_ref = reference; reason } ->
-    `Assoc
-      (common reference "reconciliation_required" Publication_uncertain
-       @ [ "reason", `String reason
-         ; ( "operator_instruction"
-           , `String
-               "Request publication is uncertain. Query masc_keeper_msg_result with this exact run_ref.run_id; do not resubmit." )
-         ])
-;;
+let result_contract_to_string = Keeper_invocation_types.result_contract_to_string
+let result_contract_of_string = Keeper_invocation_types.result_contract_of_string
 
 let delegate_submission_to_json (request : request) outcome =
   let common reference result_contract =
@@ -375,29 +319,6 @@ let delegate_entry_to_json (entry : Keeper_msg_async.entry) =
         ]
         @ timing
         @ entry_result entry.status))
-;;
-
-let entry_to_json entry =
-  let contract = result_contract entry in
-  let* target_name =
-    Keeper_id.Keeper_name.of_string entry.Keeper_msg_async.keeper_name
-    |> Result.map_error (fun reason -> Invalid_target reason)
-  in
-  let reference =
-    { run_id = entry.request_id
-    ; target = Keeper target_name
-    ; capability = Invoke_turn
-    }
-  in
-  match Keeper_msg_async.entry_to_json entry with
-  | `Assoc fields ->
-    Ok
-      (`Assoc
-         (fields
-          @ [ "run_ref", run_ref_to_json reference
-            ; "result_contract", `String (result_contract_to_string contract)
-            ]))
-  | _ -> Error Invalid_entry_projection
 ;;
 
 let delegate_cancellation_to_json reference result =

--- a/lib/keeper/keeper_invocation_contract.mli
+++ b/lib/keeper/keeper_invocation_contract.mli
@@ -4,13 +4,13 @@
     the existing durable {!Keeper_msg_async} owner into a typed target,
     capability, run reference, and result contract. *)
 
-type capability = Invoke_turn
+type capability = Keeper_invocation_types.capability = Invoke_turn
 
-type target = Keeper of Keeper_id.Keeper_name.t
+type target = Keeper_invocation_types.target = Keeper of Keeper_id.Keeper_name.t
 
 type request
 
-type run_ref
+type run_ref = Keeper_invocation_types.run_ref
 
 type submission_receipt =
   | Durable_run of run_ref
@@ -19,7 +19,7 @@ type submission_receipt =
       ; reason : string
       }
 
-type result_contract =
+type result_contract = Keeper_invocation_types.result_contract =
   | Awaiting_execution
   | Publication_uncertain
   | Running
@@ -32,7 +32,6 @@ type result_contract =
 type request_error =
   | Invalid_target of string
   | Empty_prompt
-  | Invalid_entry_projection
   | Invalid_wire_value of
       { field : string
       ; expected : string
@@ -50,6 +49,7 @@ val target_name_of_target : target -> string
 val run_ref_of_json : Yojson.Safe.t -> (run_ref, request_error) result
 val run_ref_to_json : run_ref -> Yojson.Safe.t
 val run_id : run_ref -> string
+val run_ref_target_name : run_ref -> string
 val run_ref_matches_entry : run_ref -> Keeper_msg_async.entry -> bool
 
 val submit
@@ -65,9 +65,8 @@ val submission_receipt
   :  request -> Keeper_msg_async.submit_outcome -> submission_receipt
 
 val result_contract : Keeper_msg_async.entry -> result_contract
-
-val submission_to_json
-  :  request -> Keeper_msg_async.submit_outcome -> Yojson.Safe.t
+val result_contract_to_string : result_contract -> string
+val result_contract_of_string : string -> result_contract option
 
 val delegate_submission_to_json
   :  request -> Keeper_msg_async.submit_outcome -> Yojson.Safe.t
@@ -77,10 +76,6 @@ val delegate_submission_error_to_json
 
 val delegate_cancellation_to_json
   :  run_ref -> Keeper_msg_async.cancel_result -> Yojson.Safe.t
-
-val entry_to_json
-  :  Keeper_msg_async.entry
-  -> (Yojson.Safe.t, request_error) result
 
 val delegate_entry_to_json
   :  Keeper_msg_async.entry

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -125,10 +125,6 @@ let submit_keeper_msg_with_captured_event_bus
     ~f:(fun request request_sw -> f ?event_bus request request_sw)
     ()
 
-let submit_outcome_with_keeper_json ~request outcome =
-  Keeper_invocation_contract.submission_to_json request outcome
-;;
-
 module For_testing = struct
   let reset_keeper_list_cache () =
     Atomic.set keeper_list_cache (empty_json_cache ~generation:0)
@@ -137,7 +133,6 @@ module For_testing = struct
     cached_json_by_key keeper_list_cache ~key ~ttl_s compute
   let submit_keeper_msg_with_captured_event_bus =
     submit_keeper_msg_with_captured_event_bus
-  let submit_outcome_with_keeper_json = submit_outcome_with_keeper_json
 end
 let annotate_keeper_json ~runtime_class json =
   match json with
@@ -664,8 +659,9 @@ let handle_keeper_msg ?continuation_channel ~submitted_by ctx args : tool_result
     Ok
       (submit_keeper_invocation
          ~submitted_by
-         ~submission_to_json:Keeper_invocation_contract.submission_to_json
-         ~submission_error_to_json:Keeper_msg_async.submit_error_to_json
+         ~submission_to_json:Keeper_invocation_contract.delegate_submission_to_json
+         ~submission_error_to_json:
+           (Keeper_invocation_contract.delegate_submission_error_to_json request)
          ~run_turn:(fun ?event_bus request worker_ctx ->
            let worker_args = with_invocation_request worker_args request in
            let result =

--- a/lib/keeper_invocation_types/dune
+++ b/lib/keeper_invocation_types/dune
@@ -1,0 +1,5 @@
+(library
+ (name masc_keeper_invocation_types)
+ (public_name masc.keeper_invocation_types)
+ (wrapped false)
+ (libraries masc.keeper_registry yojson))

--- a/lib/keeper_invocation_types/keeper_invocation_types.ml
+++ b/lib/keeper_invocation_types/keeper_invocation_types.ml
@@ -1,0 +1,53 @@
+type capability = Invoke_turn
+type target = Keeper of Keeper_id.Keeper_name.t
+
+type run_ref = { run_id : string; target : target; capability : capability }
+
+type result_contract =
+  | Awaiting_execution
+  | Publication_uncertain
+  | Running
+  | Yielded
+  | Cancellation_requested
+  | Cancelled
+  | Completed
+  | Failed
+
+let target_name = function Keeper name -> Keeper_id.Keeper_name.to_string name
+
+let target_to_json target =
+  `Assoc [ "kind", `String "keeper"; "name", `String (target_name target) ]
+
+let run_id reference = reference.run_id
+let run_ref_target_name reference = target_name reference.target
+
+let run_ref_to_json reference =
+  `Assoc
+    [ "run_id", `String reference.run_id
+    ; "target", target_to_json reference.target
+    ; "capability", `String "invoke_turn"
+    ]
+;;
+
+let result_contract_to_string = function
+  | Awaiting_execution -> "awaiting_execution"
+  | Publication_uncertain -> "publication_uncertain"
+  | Running -> "running"
+  | Yielded -> "yielded"
+  | Cancellation_requested -> "cancellation_requested"
+  | Cancelled -> "cancelled"
+  | Completed -> "completed"
+  | Failed -> "failed"
+;;
+
+let result_contract_of_string = function
+  | "awaiting_execution" -> Some Awaiting_execution
+  | "publication_uncertain" -> Some Publication_uncertain
+  | "running" -> Some Running
+  | "yielded" -> Some Yielded
+  | "cancellation_requested" -> Some Cancellation_requested
+  | "cancelled" -> Some Cancelled
+  | "completed" -> Some Completed
+  | "failed" -> Some Failed
+  | _ -> None
+;;

--- a/lib/keeper_invocation_types/keeper_invocation_types.mli
+++ b/lib/keeper_invocation_types/keeper_invocation_types.mli
@@ -1,0 +1,24 @@
+(** Typed Keeper invocation wire identity and result vocabulary. Durable
+    execution and lane admission remain in the Keeper implementation. *)
+type capability = Invoke_turn
+type target = Keeper of Keeper_id.Keeper_name.t
+
+type run_ref = { run_id : string; target : target; capability : capability }
+
+type result_contract =
+  | Awaiting_execution
+  | Publication_uncertain
+  | Running
+  | Yielded
+  | Cancellation_requested
+  | Cancelled
+  | Completed
+  | Failed
+
+val target_name : target -> string
+val target_to_json : target -> Yojson.Safe.t
+val run_id : run_ref -> string
+val run_ref_target_name : run_ref -> string
+val run_ref_to_json : run_ref -> Yojson.Safe.t
+val result_contract_to_string : result_contract -> string
+val result_contract_of_string : string -> result_contract option

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -2387,6 +2387,28 @@ let process_single_turn ~user_row_origin ~queued_turn
              });
         None, false
   in
+  let run_ref =
+    match submit_result with
+    | Error _ -> None
+    | Ok outcome ->
+      (match
+         Keeper_invocation_contract.request
+           ~keeper_name:payload.name
+           ~prompt:payload.message
+       with
+       | Ok request ->
+         Some
+           (match Keeper_invocation_contract.submission_receipt request outcome with
+            | Keeper_invocation_contract.Durable_run run_ref -> run_ref
+            | Keeper_invocation_contract.Reconciliation_required { run_ref; _ } ->
+              run_ref)
+       | Error error ->
+         Log.Keeper.error
+           "keeper_stream: accepted request has invalid typed identity keeper=%s error=%s"
+           payload.name
+           (Keeper_invocation_contract.request_error_to_string error);
+         None)
+  in
   (match client_disconnects, request_id with
    | None, _ | _, None -> ()
    | Some (disconnect_sw, disconnects), Some request_id ->
@@ -2414,24 +2436,29 @@ let process_single_turn ~user_row_origin ~queued_turn
                push_worker_event Stream_client_disconnected
              end));
   Option.iter
-    (fun request_id ->
+    (fun run_ref ->
+       let run_id = Keeper_invocation_contract.run_id run_ref in
        Log.Keeper.info
          "keeper_stream: queued request keeper=%s request_id=%s surface=%s"
-         payload.name request_id
+         payload.name run_id
          (if has_connector_context payload then payload.channel else "dashboard");
        Keeper_chat_events.publish events
          (Custom
             { name = "KEEPER_QUEUE_REQUEST"
             ; value =
                 Gate_protocol.message_request_to_json
-                  { request_id
+                  { tracking =
+                      Gate_protocol.Keeper_run
+                        { run_ref
+                        ; result_contract =
+                            Keeper_invocation_contract.Awaiting_execution
+                        }
                   ; destination_type = "keeper"
                   ; destination_id = payload.name
                   ; channel =
                       (if has_connector_context payload then payload.channel
                        else "dashboard")
                   ; actor_id = Some agent_name
-                  ; status = Gate_protocol.Queued
                   ; modalities = modalities_for_request payload
                   ; transport = Some "sse"
                   ; metadata =
@@ -2440,7 +2467,7 @@ let process_single_turn ~user_row_origin ~queued_turn
                       ]
                   }
             }))
-    (if durably_accepted then request_id else None);
+    (if durably_accepted then run_ref else None);
   let publish_terminal ~status ?(message = "") () =
     let message = redact_text message in
     let status_label = keeper_request_terminal_status_to_string status in

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -323,31 +323,52 @@ let non_empty_json_string_member field json =
       if value = "" then None else Some value
   | _ -> None
 
-let board_context_inference_submission_json ~post_id ~target_source tool_data =
+let board_context_inference_submission_json ~post_id ~target_keeper ~target_source
+    tool_data =
   match
-    ( non_empty_json_string_member "request_id" tool_data,
-      non_empty_json_string_member "keeper_name" tool_data,
-      non_empty_json_string_member "status" tool_data )
+    json_assoc_member "run_ref" tool_data,
+    json_assoc_member "result_contract" tool_data
   with
-  | Some request_id, Some keeper_name, Some status ->
-      let fields =
-        [
-          ("ok", `Bool true);
-          ("request_id", `String request_id);
-          ("keeper_name", `String keeper_name);
-          ("post_id", `String post_id);
-          ("status", `String status);
-          ( "target_source",
-            `String (board_context_inference_target_source_to_string target_source) );
-        ]
+  | Some run_ref_json, Some (`String result_contract_raw) ->
+    (match
+       Keeper_invocation_contract.run_ref_of_json run_ref_json,
+       Keeper_invocation_contract.result_contract_of_string result_contract_raw
+     with
+     | Ok run_ref, Some result_contract ->
+      let actual_target =
+        Keeper_invocation_contract.run_ref_target_name run_ref
       in
-      let fields =
-        match non_empty_json_string_member "message" tool_data with
-        | Some message -> fields @ [ ("message", `String message) ]
-        | None -> fields
-      in
-      Ok (`Assoc fields)
-  | _ -> Error "masc_keeper_msg returned a malformed queue submission"
+      if not (String.equal actual_target target_keeper)
+      then
+        Error
+          (Printf.sprintf
+             "Keeper invocation target %S does not match board target %S"
+             actual_target
+             target_keeper)
+      else
+        let fields =
+          [ "ok", `Bool true
+          ; "run_ref", Keeper_invocation_contract.run_ref_to_json run_ref
+          ; "post_id", `String post_id
+          ; ( "result_contract"
+            , `String
+                (Keeper_invocation_contract.result_contract_to_string
+                   result_contract) )
+          ; ( "target_source"
+            , `String
+                (board_context_inference_target_source_to_string target_source) )
+          ]
+        in
+        let fields =
+          match non_empty_json_string_member "message" tool_data with
+          | Some message -> fields @ [ ("message", `String message) ]
+          | None -> fields
+        in
+        Ok (`Assoc fields)
+     | Error error, _ ->
+       Error (Keeper_invocation_contract.request_error_to_string error)
+     | Ok _, None -> Error "invalid Keeper invocation result_contract")
+  | _ -> Error "typed Keeper invocation submission is missing tracking fields"
 
 let dispatch_board_context_inference ~state ~sw ~clock ~request ~target_keeper
     ~target_source ~(post : Board.post) ~comments =
@@ -386,7 +407,7 @@ let dispatch_board_context_inference ~state ~sw ~clock ~request ~target_keeper
   if Tool_result.is_success result
   then
     (match
-       board_context_inference_submission_json ~post_id ~target_source
+       board_context_inference_submission_json ~post_id ~target_keeper ~target_source
          (Tool_result.data result)
      with
      | Ok json -> Ok json

--- a/lib/server/server_routes_http_routes_channel_gate.ml
+++ b/lib/server/server_routes_http_routes_channel_gate.ml
@@ -49,18 +49,23 @@ module Http = Http_server_eio
       {
         "ok": true,
         "destination_id": "luna",
-        "reply": "luna is busy; your message is queued (request_id=luna-abc123).",
+        "reply": "luna is busy; preserve the returned tracking value.",
         "turn_stats": { "model_used": null, "duration_ms": 8, "tokens_used": 0 },
         "message_request": {
-          "request_id": "luna-abc123",
+          "tracking": {
+            "kind": "keeper_run",
+            "run_ref": { "run_id": "luna-abc123",
+              "target": { "kind": "keeper", "name": "luna" },
+              "capability": "invoke_turn" },
+            "result_contract": "awaiting_execution"
+          },
           "destination_type": "keeper",
           "destination_id": "luna",
           "channel": "discord",
           "actor_id": "123456789",
-          "status": "queued",
           "modalities": ["text"],
           "transport": "discord",
-          "metadata": { "status_source": "keeper_msg_async" }
+          "metadata": { "tracking_source": "keeper_invocation" }
         }
       }
     ]}

--- a/test/test_channel_gate.ml
+++ b/test/test_channel_gate.ml
@@ -162,21 +162,20 @@ let mock_dispatch_unavailable ~channel:_ ~channel_user_id:_ ~channel_user_name:_
 
 let queued_request : Gate_protocol.message_request =
   {
-    request_id = "req-queued";
+    tracking = Gate_protocol.Chat_receipt { receipt_id = "receipt-queued" };
     destination_type = "keeper";
     destination_id = "luna";
     channel = "discord";
     actor_id = Some "user-1";
-    status = Gate_protocol.Queued;
     modalities = [ "text" ];
     transport = Some "discord";
-    metadata = [ ("status_source", "keeper_msg_async") ];
+    metadata = [ ("tracking_source", "keeper_chat_queue") ];
   }
 
 let mock_dispatch_queued ~channel:_ ~channel_user_id:_ ~channel_user_name:_
     ~channel_workspace_id:_ ~keeper_name:_ ~idempotency_key:_ ~metadata:_ ~content:_ =
   Gate_protocol.Reply
-    { content = "luna is busy; your message is queued (request_id=req-queued)."
+    { content = "luna is busy; your message is durably queued."
     ; structured = None
     ; stats = None
     ; message_request = Some queued_request
@@ -200,13 +199,14 @@ let test_handle_inbound_surfaces_message_request () =
   match Channel_gate.handle_inbound ~dispatch:mock_dispatch_queued msg with
   | Ok out -> (
       check string "reply content"
-        "luna is busy; your message is queued (request_id=req-queued)."
+        "luna is busy; your message is durably queued."
         out.content;
       match out.message_request with
       | Some request ->
-          check string "request id" "req-queued" request.request_id;
-          check string "status" "queued"
-            (Gate_protocol.message_request_status_to_string request.status)
+          (match request.tracking with
+           | Gate_protocol.Chat_receipt { receipt_id } ->
+             check string "chat receipt" "receipt-queued" receipt_id
+           | Gate_protocol.Keeper_run _ -> fail "expected chat receipt tracking")
       | None -> fail "expected message_request")
   | Error e -> fail (Channel_gate.gate_error_to_string e)
 

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -2699,45 +2699,54 @@ let expect_error expected actual =
 
 let test_extract_message_request_ack_accepts_well_formed_envelope () =
   let body =
-    {|{"request_id":"req-1","status":"queued","keeper_name":"luna"}|}
+    {|{"run_ref":{"run_id":"run-1","target":{"kind":"keeper","name":"luna"},"capability":"invoke_turn"},"result_contract":"awaiting_execution"}|}
   in
   match
     Gate_keeper_backend.extract_message_request_ack ~channel:"discord"
       ~channel_user_id:"user-1" ~keeper_name:"luna" ~metadata:[] body
   with
   | Ok request ->
-      check string "request_id" "req-1" request.request_id;
       check string "destination_id" "luna" request.destination_id;
       check string "channel" "discord" request.channel;
-      (match request.status with
-       | Gate_protocol.Queued -> ()
-       | _ -> fail "expected Queued status")
+      (match request.tracking with
+       | Gate_protocol.Keeper_run { run_ref; result_contract } ->
+         check string "run id" "run-1"
+           (Keeper_invocation_contract.run_id run_ref);
+         check bool "awaiting execution contract" true
+           (result_contract = Keeper_invocation_contract.Awaiting_execution)
+       | Gate_protocol.Chat_receipt _ -> fail "expected Keeper run tracking")
   | Error failure ->
       fail
         ("expected Ok request: "
          ^ Gate_keeper_backend.ack_parse_failure_to_string failure)
 
-let test_extract_message_request_ack_rejects_missing_request_id () =
-  let body = {|{"status":"queued"}|} in
-  expect_error "missing request_id"
+let test_extract_message_request_ack_rejects_missing_run_ref () =
+  let body = {|{"result_contract":"awaiting_execution"}|} in
+  expect_error "missing run_ref"
     (Gate_keeper_backend.extract_message_request_ack ~channel:"discord"
        ~channel_user_id:"user-1" ~keeper_name:"luna" ~metadata:[] body)
 
-let test_extract_message_request_ack_rejects_empty_request_id () =
-  let body = {|{"request_id":"   ","status":"queued"}|} in
-  expect_error "empty request_id"
+let test_extract_message_request_ack_rejects_target_mismatch () =
+  let body =
+    {|{"run_ref":{"run_id":"run-1","target":{"kind":"keeper","name":"other"},"capability":"invoke_turn"},"result_contract":"awaiting_execution"}|}
+  in
+  expect_error "does not match expected Keeper"
     (Gate_keeper_backend.extract_message_request_ack ~channel:"discord"
        ~channel_user_id:"user-1" ~keeper_name:"luna" ~metadata:[] body)
 
-let test_extract_message_request_ack_rejects_missing_status () =
-  let body = {|{"request_id":"req-1"}|} in
-  expect_error "missing status"
+let test_extract_message_request_ack_rejects_missing_result_contract () =
+  let body =
+    {|{"run_ref":{"run_id":"run-1","target":{"kind":"keeper","name":"luna"},"capability":"invoke_turn"}}|}
+  in
+  expect_error "missing result_contract"
     (Gate_keeper_backend.extract_message_request_ack ~channel:"discord"
        ~channel_user_id:"user-1" ~keeper_name:"luna" ~metadata:[] body)
 
-let test_extract_message_request_ack_rejects_unknown_status () =
-  let body = {|{"request_id":"req-1","status":"frobnicated"}|} in
-  expect_error "unknown status"
+let test_extract_message_request_ack_rejects_unknown_result_contract () =
+  let body =
+    {|{"run_ref":{"run_id":"run-1","target":{"kind":"keeper","name":"luna"},"capability":"invoke_turn"},"result_contract":"frobnicated"}|}
+  in
+  expect_error "unknown result_contract"
     (Gate_keeper_backend.extract_message_request_ack ~channel:"discord"
        ~channel_user_id:"user-1" ~keeper_name:"luna" ~metadata:[] body)
 
@@ -2746,38 +2755,6 @@ let test_extract_message_request_ack_rejects_invalid_json () =
   expect_error "invalid json"
     (Gate_keeper_backend.extract_message_request_ack ~channel:"discord"
        ~channel_user_id:"user-1" ~keeper_name:"luna" ~metadata:[] body)
-
-let test_extract_message_request_ack_normalizes_status_case () =
-  (* The wire contract lowercases the status before consulting the closed
-     sum. A mixed-case envelope from a future keeper should still be
-     accepted, not rejected as unknown. *)
-  let body = {|{"request_id":"req-1","status":"Running"}|} in
-  match
-    Gate_keeper_backend.extract_message_request_ack ~channel:"discord"
-      ~channel_user_id:"user-1" ~keeper_name:"luna" ~metadata:[] body
-  with
-  | Ok request ->
-      (match request.status with
-       | Gate_protocol.Running -> ()
-       | _ -> fail "expected Running status after case normalization")
-  | Error failure ->
-      fail
-        ("expected Ok after case normalization: "
-         ^ Gate_keeper_backend.ack_parse_failure_to_string failure)
-
-let test_extract_message_request_ack_falls_back_to_keeper_name () =
-  let body = {|{"request_id":"req-1","status":"done"}|} in
-  match
-    Gate_keeper_backend.extract_message_request_ack ~channel:"discord"
-      ~channel_user_id:"user-1" ~keeper_name:"luna" ~metadata:[] body
-  with
-  | Ok request ->
-      check string "destination_id falls back to keeper_name" "luna"
-        request.destination_id
-  | Error failure ->
-      fail
-        ("expected Ok with fallback keeper_name: "
-         ^ Gate_keeper_backend.ack_parse_failure_to_string failure)
 
 (* ── RFC-connector-deferred-reply-via-chat-queue connector deferred-reply routing ───────────────── *)
 
@@ -3028,19 +3005,15 @@ let () =
         [
           test_case "accepts well-formed envelope" `Quick
             test_extract_message_request_ack_accepts_well_formed_envelope;
-          test_case "rejects missing request_id" `Quick
-            test_extract_message_request_ack_rejects_missing_request_id;
-          test_case "rejects empty request_id" `Quick
-            test_extract_message_request_ack_rejects_empty_request_id;
-          test_case "rejects missing status" `Quick
-            test_extract_message_request_ack_rejects_missing_status;
-          test_case "rejects unknown status" `Quick
-            test_extract_message_request_ack_rejects_unknown_status;
+          test_case "rejects missing run_ref" `Quick
+            test_extract_message_request_ack_rejects_missing_run_ref;
+          test_case "rejects target mismatch" `Quick
+            test_extract_message_request_ack_rejects_target_mismatch;
+          test_case "rejects missing result contract" `Quick
+            test_extract_message_request_ack_rejects_missing_result_contract;
+          test_case "rejects unknown result contract" `Quick
+            test_extract_message_request_ack_rejects_unknown_result_contract;
           test_case "rejects invalid json" `Quick
             test_extract_message_request_ack_rejects_invalid_json;
-          test_case "normalizes status case" `Quick
-            test_extract_message_request_ack_normalizes_status_case;
-          test_case "falls back to keeper_name" `Quick
-            test_extract_message_request_ack_falls_back_to_keeper_name;
         ] );
     ]

--- a/test/test_gate_protocol.ml
+++ b/test/test_gate_protocol.ml
@@ -211,22 +211,35 @@ let test_outbound_to_json_roundtrip () =
   check int "duration" 100 (stats |> member "duration_ms" |> to_int)
 
 let test_outbound_to_json_includes_message_request () =
+  let run_ref =
+    match
+      Keeper_invocation_contract.run_ref_of_json
+        (`Assoc
+           [ "run_id", `String "run-123"
+           ; "target", `Assoc [ "kind", `String "keeper"; "name", `String "luna" ]
+           ; "capability", `String "invoke_turn"
+           ])
+    with
+    | Ok run_ref -> run_ref
+    | Error error -> fail (Keeper_invocation_contract.request_error_to_string error)
+  in
   let request : Gate_protocol.message_request =
     {
-      request_id = "req-123";
+      tracking =
+        Gate_protocol.Keeper_run
+          { run_ref; result_contract = Keeper_invocation_contract.Awaiting_execution };
       destination_type = "keeper";
       destination_id = "luna";
       channel = "slack";
       actor_id = Some "U123";
-      status = Gate_protocol.Queued;
       modalities = [ "text" ];
       transport = Some "slack";
-      metadata = [ ("status_source", "keeper_msg_async") ];
+      metadata = [ ("tracking_source", "keeper_invocation") ];
     }
   in
   let out : Gate_protocol.outbound_message = {
     keeper_name = "luna";
-    content = "luna is busy; your message is queued (request_id=req-123).";
+    content = "luna is busy; preserve the returned tracking value.";
     structured = None;
     turn_stats = None;
     message_request = Some request;
@@ -234,10 +247,17 @@ let test_outbound_to_json_includes_message_request () =
   let json = Gate_protocol.outbound_to_json out in
   let open Yojson.Safe.Util in
   let request_json = json |> member "message_request" in
-  check string "request id" "req-123"
-    (request_json |> member "request_id" |> to_string);
-  check string "status" "queued"
-    (request_json |> member "status" |> to_string);
+  let tracking = request_json |> member "tracking" in
+  check string "tracking kind" "keeper_run"
+    (tracking |> member "kind" |> to_string);
+  check string "run id" "run-123"
+    (tracking |> member "run_ref" |> member "run_id" |> to_string);
+  check string "result contract" "awaiting_execution"
+    (tracking |> member "result_contract" |> to_string);
+  check bool "raw request id omitted" true
+    (request_json |> member "request_id" = `Null);
+  check bool "legacy status omitted" true
+    (request_json |> member "status" = `Null);
   check string "destination id" "luna"
     (request_json |> member "destination_id" |> to_string)
 
@@ -264,26 +284,6 @@ let test_gate_error_strings () =
     (Gate_protocol.gate_error_to_string Gate_protocol.Dispatch_unavailable);
   check string "internal" "internal error"
     (Gate_protocol.gate_error_to_string (Gate_protocol.Internal "details"))
-
-let check_status_parse label raw expected =
-  check
-    (option string)
-    label
-    (Option.map Gate_protocol.message_request_status_to_string expected)
-    (Option.map Gate_protocol.message_request_status_to_string
-       (Gate_protocol.message_request_status_of_string raw))
-
-let test_message_request_status_of_string () =
-  check_status_parse "accepted" "accepted" (Some Gate_protocol.Accepted);
-  check_status_parse "acceptance uncertain" "acceptance_uncertain"
-    (Some Gate_protocol.Acceptance_uncertain);
-  check_status_parse "queued" "queued" (Some Gate_protocol.Queued);
-  check_status_parse "running" "running" (Some Gate_protocol.Running);
-  check_status_parse "done" "done" (Some Gate_protocol.Done);
-  check_status_parse "error" "error" (Some Gate_protocol.Failed);
-  check_status_parse "lost" "lost" (Some Gate_protocol.Lost);
-  check_status_parse "cancelled" "cancelled" (Some Gate_protocol.Cancelled);
-  check_status_parse "unknown fails closed" "finished" None
 
 let () =
   Alcotest.run "Gate_protocol"
@@ -320,7 +320,5 @@ let () =
         [
           test_case "validation error strings" `Quick test_validation_error_strings;
           test_case "gate error strings" `Quick test_gate_error_strings;
-          test_case "message request status parse" `Quick
-            test_message_request_status_of_string;
         ] );
     ]

--- a/test/test_keeper_busy_connector_deferred.ml
+++ b/test/test_keeper_busy_connector_deferred.ml
@@ -116,11 +116,13 @@ let test_busy_discord_enqueues () =
         (match reply with
          | Gate_protocol.Reply
              { message_request = Some request; content; _ } ->
-             ack_receipt_id := Some request.request_id;
-             check "busy connector ACK is queued"
-               (request.status = Gate_protocol.Queued);
-             check "busy connector ACK carries queue status source"
-               (List.assoc_opt "status_source" request.metadata
+             (match request.tracking with
+              | Gate_protocol.Chat_receipt { receipt_id } ->
+                ack_receipt_id := Some receipt_id
+              | Gate_protocol.Keeper_run _ ->
+                check "busy connector ACK carries a chat receipt" false);
+             check "busy connector ACK carries queue tracking source"
+               (List.assoc_opt "tracking_source" request.metadata
                 = Some "keeper_chat_queue");
              check "busy connector ACK carries queue revision"
                (List.assoc_opt "queue_revision" request.metadata <> None);
@@ -229,8 +231,10 @@ let test_unpublished_busy_slot_queues_without_resolved_meta () =
         in
         (match reply with
          | Gate_protocol.Reply { message_request = Some request; _ } ->
-           check "unpublished busy slot returns a queued ACK"
-             (request.status = Gate_protocol.Queued)
+           check "unpublished busy slot returns a chat receipt"
+             (match request.tracking with
+              | Gate_protocol.Chat_receipt _ -> true
+              | Gate_protocol.Keeper_run _ -> false)
          | Gate_protocol.Reply { message_request = None; _ }
          | Gate_protocol.Keeper_error_result _
          | Gate_protocol.Unavailable_result ->
@@ -335,7 +339,10 @@ let test_pending_receipt_prevents_direct_overtake () =
       in
       (match reply with
        | Gate_protocol.Reply { message_request = Some request; _ } ->
-         check "later connector input is queued" (request.status = Gate_protocol.Queued)
+         check "later connector input has a chat receipt"
+           (match request.tracking with
+            | Gate_protocol.Chat_receipt _ -> true
+            | Gate_protocol.Keeper_run _ -> false)
        | _ -> check "later connector input is queued" false);
       let snapshot = Keeper_chat_queue.snapshot ~keeper_name in
       check "FIFO keeps both accepted receipts pending"
@@ -382,7 +389,10 @@ let test_busy_slack_preserves_thread_context () =
       in
       (match reply with
        | Gate_protocol.Reply { message_request = Some request; _ } ->
-         check "Slack busy input is queued" (request.status = Gate_protocol.Queued)
+         check "Slack busy input has a chat receipt"
+           (match request.tracking with
+            | Gate_protocol.Chat_receipt _ -> true
+            | Gate_protocol.Keeper_run _ -> false)
        | _ -> check "Slack busy input is queued" false);
       match (Keeper_chat_queue.snapshot ~keeper_name).pending with
       | [ { message =
@@ -454,8 +464,10 @@ let test_shutdown_fenced_connector_ack
         (match reply with
          | Gate_protocol.Reply
              { message_request = Some request; content = ack_text; _ } ->
-           check (label ^ " shutdown-fenced input is durably queued")
-             (request.status = Gate_protocol.Queued);
+           check (label ^ " shutdown-fenced input has a durable chat receipt")
+             (match request.tracking with
+              | Gate_protocol.Chat_receipt _ -> true
+              | Gate_protocol.Keeper_run _ -> false);
            check (label ^ " ACK metadata carries shutdown operation id")
              (List.assoc_opt "shutdown_operation_id" request.metadata
               = Some operation_id_text);

--- a/test/test_keeper_unified_turn_event_bus.ml
+++ b/test/test_keeper_unified_turn_event_bus.ml
@@ -324,63 +324,7 @@ let require_unique_assoc label = function
   | _ -> Alcotest.fail (label ^ " must be a JSON object")
 ;;
 
-let test_keeper_msg_submission_projection_has_unique_keys () =
-  let reason = "directory fsync could not confirm publication" in
-  let outcome : Kmsg.submit_outcome =
-    { request_id = "kmsg-reconciliation-projection"
-    ; acceptance = Kmsg.Reconciliation_required { reason }
-    }
-  in
-  let request =
-    match
-      Invocation.request
-        ~keeper_name:"projection-keeper"
-        ~prompt:"inspect this request"
-    with
-    | Ok request -> request
-    | Error error -> Alcotest.fail (Invocation.request_error_to_string error)
-  in
-  let core_fields =
-    Kmsg.submit_outcome_to_json outcome
-    |> require_unique_assoc "core reconciliation outcome"
-  in
-  check
-    (option string)
-    "uncertainty reason has a dedicated field"
-    (Some reason)
-    (Option.bind
-       (List.assoc_opt "reason" core_fields)
-       (function `String value -> Some value | _ -> None));
-  let tool_fields =
-    Ops.For_testing.submit_outcome_with_keeper_json
-      ~request
-      outcome
-    |> require_unique_assoc "tool reconciliation outcome"
-  in
-  check bool "operator instruction is explicit" true
-    (List.mem_assoc "operator_instruction" tool_fields);
-  check bool "typed run reference is present" true
-    (List.mem_assoc "run_ref" tool_fields);
-  check
-    (option string)
-    "uncertain publication is not reported as queued"
-    (Some "publication_uncertain")
-    (match List.assoc_opt "result_contract" tool_fields with
-     | Some (`String value) -> Some value
-     | _ -> None);
-  let durable_fields =
-    Ops.For_testing.submit_outcome_with_keeper_json
-      ~request
-      { outcome with acceptance = Kmsg.Durably_accepted }
-    |> require_unique_assoc "durable tool submission outcome"
-  in
-  check
-    (option string)
-    "durable submission is queued"
-    (Some "queued")
-    (match List.assoc_opt "status" durable_fields with
-     | Some (`String value) -> Some value
-     | _ -> None);
+let test_keeper_invocation_result_contracts () =
   let entry : Kmsg.entry =
     { request_id = "kmsg-entry-projection"
     ; keeper_name = "projection-keeper"
@@ -391,19 +335,6 @@ let test_keeper_msg_submission_projection_has_unique_keys () =
     ; completed_at = None
     }
   in
-  let entry_json =
-    match Invocation.entry_to_json entry with
-    | Ok json -> json
-    | Error error -> Alcotest.fail (Invocation.request_error_to_string error)
-  in
-  let entry_fields =
-    entry_json |> require_unique_assoc "request entry projection"
-  in
-  check int "entry status is projected exactly once" 1
-    (List.fold_left
-       (fun count (key, _) -> if String.equal key "status" then count + 1 else count)
-       0
-       entry_fields);
   check bool "running contract is typed" true
     (Invocation.result_contract entry = Invocation.Running);
   let yielded_entry =
@@ -609,8 +540,8 @@ let () =
             test_turn_event_bus_prefers_injected_bus_over_fallback
         ; test_case "keeper msg async submit uses captured event bus" `Quick
             test_keeper_msg_async_submit_uses_captured_event_bus
-        ; test_case "keeper msg submission JSON keys are unique" `Quick
-            test_keeper_msg_submission_projection_has_unique_keys
+        ; test_case "Keeper invocation result contracts" `Quick
+            test_keeper_invocation_result_contracts
         ; test_case "typed Keeper invocation wire contract" `Quick
             test_typed_keeper_invocation_wire_contract
         ] )


### PR DESCRIPTION
Stacked on #24564.

## What changed
- replace Gate message ACK request_id/status with closed tracking: Keeper_run(run_ref, result_contract) or Chat_receipt
- move Keeper invocation wire identity into a small shared leaf so Gate never depends on the parent Keeper implementation
- make private direct delivery and Board inference emit/validate the typed Keeper contract
- remove the legacy submission/entry projections and tests whose only purpose was the deleted contract
- keep the existing Keeper_msg_async durable owner, per-Keeper admission lane, rich direct-chat surface context, and connector chat receipts

## Adversarial invariants
- no compatibility alias or dual registration
- no status normalization or unknown-to-permissive fallback
- run_ref target must equal the admitted Keeper
- malformed tracking is explicit and observable
- diff vs stack base: +398/-454

## Verification
- ocamlc parse pass for every changed .ml/.mli
- isolated type/interface check passed for keeper_invocation_types and Gate_protocol
- git diff --check passed
- focused scripts/dune-local.sh build was correctly refused because an unrelated bare dune process is holding the machine-wide policy guard; CI remains build authority