### PR TITLE
refactor(keeper): extract invocation identity leaf

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -89,6 +89,7 @@
   ;; RFC-0056 Phase 1N — Keeper_state_* deterministic FSM cluster extracted to
   ;; lib/keeper_state/. Parent still references bare Keeper_state_* modules.
   masc.keeper_registry
+  masc.keeper_invocation_types
   ;; Keeper-owned pure/type leaves extracted from lib/keeper/.
   masc.keeper_contract
   masc.keeper_hooks_oas_types

--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -532,7 +532,7 @@ let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~submission_owne
      connector user lines. Recording happens here — post
      validation/dedup ([Channel_gate.handle_inbound]), pre turn — so a
      failed or silent turn cannot drop the inbound message. The final
-     connector reply is appended below after [dispatch_stream] returns
+     connector reply is appended below after the direct-delivery stream returns
      the keeper's direct reply. The user line carries the raw [content];
      the contextualized wrapper below is turn input, not conversation
      history. *)
@@ -674,8 +674,8 @@ let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~submission_owne
     (* The admission boundary, not a route-level peek, owns the FIFO decision.
        It rechecks the durable queue after acquiring the Keeper turn slot. *)
     match
-      Keeper_tool_surface.dispatch_stream_if_free ~on_text_delta keeper_ctx
-        ~name:"masc_keeper_msg" ~args
+      Keeper_tool_surface.dispatch_keeper_msg_stream_if_free
+        ~on_text_delta keeper_ctx ~args
     with
     | `Ran result -> `Streaming result
     | `Busy admission_rejection ->

--- a/lib/keeper/keeper_invocation_contract.ml
+++ b/lib/keeper/keeper_invocation_contract.ml
@@ -222,7 +222,7 @@ let run_ref_of_json json =
 
 let run_id reference = reference.run_id
 
-let run_ref_matches_entry reference entry =
+let run_ref_matches_entry reference (entry : Keeper_msg_async.entry) =
   String.equal reference.run_id entry.Keeper_msg_async.request_id
   && String.equal
        (target_name_of_target reference.target)
@@ -346,7 +346,7 @@ let entry_result = function
     ]
 ;;
 
-let delegate_entry_to_json entry =
+let delegate_entry_to_json (entry : Keeper_msg_async.entry) =
   let contract = result_contract entry in
   let* target_name =
     Keeper_id.Keeper_name.of_string entry.Keeper_msg_async.keeper_name

--- a/lib/keeper/keeper_invocation_contract.ml
+++ b/lib/keeper/keeper_invocation_contract.ml
@@ -1,6 +1,5 @@
-type capability = Invoke_turn
-
-type target = Keeper of Keeper_id.Keeper_name.t
+type capability = Keeper_invocation_types.capability = Invoke_turn
+type target = Keeper_invocation_types.target = Keeper of Keeper_id.Keeper_name.t
 
 type request =
   { target : target
@@ -8,7 +7,7 @@ type request =
   ; prompt : string
   }
 
-type run_ref =
+type run_ref = Keeper_invocation_types.run_ref =
   { run_id : string
   ; target : target
   ; capability : capability
@@ -21,7 +20,7 @@ type submission_receipt =
       ; reason : string
       }
 
-type result_contract =
+type result_contract = Keeper_invocation_types.result_contract =
   | Awaiting_execution
   | Publication_uncertain
   | Running
@@ -132,9 +131,7 @@ let request_error_to_string = function
   | Run_ref_mismatch -> "run_ref does not identify the stored Keeper invocation"
 ;;
 
-let target_name_of_target = function
-  | Keeper name -> Keeper_id.Keeper_name.to_string name
-;;
+let target_name_of_target = Keeper_invocation_types.target_name
 
 let target_name (request : request) =
   target_name_of_target request.target
@@ -181,25 +178,8 @@ let result_contract_of_status = function
 
 let result_contract entry = result_contract_of_status entry.Keeper_msg_async.status
 
-let capability_to_string = function
-  | Invoke_turn -> "invoke_turn"
-;;
-
-let target_to_json = function
-  | Keeper name ->
-    `Assoc
-      [ "kind", `String "keeper"
-      ; "name", `String (Keeper_id.Keeper_name.to_string name)
-      ]
-;;
-
-let run_ref_to_json reference =
-  `Assoc
-    [ "run_id", `String reference.run_id
-    ; "target", target_to_json reference.target
-    ; "capability", `String (capability_to_string reference.capability)
-    ]
-;;
+let target_to_json = Keeper_invocation_types.target_to_json
+let run_ref_to_json = Keeper_invocation_types.run_ref_to_json
 
 let run_ref_of_json json =
   let* fields = object_fields ~field:"run_ref" json in
@@ -220,7 +200,8 @@ let run_ref_of_json json =
   else Ok { run_id; target; capability }
 ;;
 
-let run_id reference = reference.run_id
+let run_id = Keeper_invocation_types.run_id
+let run_ref_target_name = Keeper_invocation_types.run_ref_target_name
 
 let run_ref_matches_entry reference (entry : Keeper_msg_async.entry) =
   String.equal reference.run_id entry.Keeper_msg_async.request_id
@@ -229,16 +210,8 @@ let run_ref_matches_entry reference (entry : Keeper_msg_async.entry) =
        entry.Keeper_msg_async.keeper_name
 ;;
 
-let result_contract_to_string = function
-  | Awaiting_execution -> "awaiting_execution"
-  | Publication_uncertain -> "publication_uncertain"
-  | Running -> "running"
-  | Yielded -> "yielded"
-  | Cancellation_requested -> "cancellation_requested"
-  | Cancelled -> "cancelled"
-  | Completed -> "completed"
-  | Failed -> "failed"
-;;
+let result_contract_to_string = Keeper_invocation_types.result_contract_to_string
+let result_contract_of_string = Keeper_invocation_types.result_contract_of_string
 
 let submission_to_json (request : request) outcome =
   let common reference status contract =

--- a/lib/keeper/keeper_invocation_contract.ml
+++ b/lib/keeper/keeper_invocation_contract.ml
@@ -319,7 +319,11 @@ let delegate_submission_error_to_json request = function
 let entry_result = function
   | Keeper_msg_async.Queued | Keeper_msg_async.Running -> []
   | Keeper_msg_async.Done { body; data; _ } ->
-    [ "result", Option.value ~default:(`String body) data ]
+    [ ( "result"
+      , match data with
+        | Some value -> value
+        | None -> `String body )
+    ]
   | Keeper_msg_async.Lost { reason } ->
     [ "result", `Assoc [ "error", `String "invocation_lost"; "reason", `String reason ] ]
   | Keeper_msg_async.Cancelled { reason; cancelled_by } ->

--- a/lib/keeper/keeper_invocation_contract.ml
+++ b/lib/keeper/keeper_invocation_contract.ml
@@ -35,8 +35,66 @@ type request_error =
   | Invalid_target of string
   | Empty_prompt
   | Invalid_entry_projection
+  | Invalid_wire_value of
+      { field : string
+      ; expected : string
+      }
+  | Run_ref_mismatch
 
 let ( let* ) = Result.bind
+
+let invalid_wire_value ~field ~expected =
+  Error (Invalid_wire_value { field; expected })
+;;
+
+let object_fields ~field = function
+  | `Assoc fields -> Ok fields
+  | _ -> invalid_wire_value ~field ~expected:"object"
+;;
+
+let exact_fields ~field ~allowed fields =
+  let keys = List.map fst fields in
+  if List.length keys <> List.length (List.sort_uniq String.compare keys)
+  then invalid_wire_value ~field ~expected:"object with unique fields"
+  else
+    match List.find_opt (fun key -> not (List.mem key allowed)) keys with
+    | None -> Ok ()
+    | Some key ->
+      invalid_wire_value
+        ~field:(field ^ "." ^ key)
+        ~expected:"no undeclared field"
+;;
+
+let required_field ~field name fields =
+  match List.assoc_opt name fields with
+  | Some value -> Ok value
+  | None -> invalid_wire_value ~field:(field ^ "." ^ name) ~expected:"required field"
+;;
+
+let string_value ~field = function
+  | `String value -> Ok value
+  | _ -> invalid_wire_value ~field ~expected:"string"
+;;
+
+let target_of_json json =
+  let* fields = object_fields ~field:"target" json in
+  let* () = exact_fields ~field:"target" ~allowed:[ "kind"; "name" ] fields in
+  let* kind = required_field ~field:"target" "kind" fields in
+  let* kind = string_value ~field:"target.kind" kind in
+  let* name = required_field ~field:"target" "name" fields in
+  let* name = string_value ~field:"target.name" name in
+  if not (String.equal kind "keeper")
+  then invalid_wire_value ~field:"target.kind" ~expected:"keeper"
+  else
+    Keeper_id.Keeper_name.of_string name
+    |> Result.map (fun name -> Keeper name)
+    |> Result.map_error (fun reason -> Invalid_target reason)
+;;
+
+let capability_of_json ~field = function
+  | `String value when String.equal value "invoke_turn" -> Ok Invoke_turn
+  | _ -> invalid_wire_value ~field ~expected:"invoke_turn"
+;;
 
 let request ~keeper_name ~prompt =
   let* keeper_name =
@@ -48,15 +106,38 @@ let request ~keeper_name ~prompt =
   else Ok { target = Keeper keeper_name; capability = Invoke_turn; prompt }
 ;;
 
+let request_of_json json =
+  let* fields = object_fields ~field:"delegate" json in
+  let* () =
+    exact_fields
+      ~field:"delegate"
+      ~allowed:[ "target"; "capability"; "prompt" ]
+      fields
+  in
+  let* target_json = required_field ~field:"delegate" "target" fields in
+  let* target = target_of_json target_json in
+  let* capability_json = required_field ~field:"delegate" "capability" fields in
+  let* capability = capability_of_json ~field:"delegate.capability" capability_json in
+  let* prompt_json = required_field ~field:"delegate" "prompt" fields in
+  let* prompt = string_value ~field:"delegate.prompt" prompt_json in
+  if String.equal prompt "" then Error Empty_prompt else Ok { target; capability; prompt }
+;;
+
 let request_error_to_string = function
   | Invalid_target reason -> reason
   | Empty_prompt -> "message is required"
   | Invalid_entry_projection -> "Keeper invocation entry projection is not an object"
+  | Invalid_wire_value { field; expected } ->
+    Printf.sprintf "%s must be %s" field expected
+  | Run_ref_mismatch -> "run_ref does not identify the stored Keeper invocation"
+;;
+
+let target_name_of_target = function
+  | Keeper name -> Keeper_id.Keeper_name.to_string name
 ;;
 
 let target_name (request : request) =
-  match request.target with
-  | Keeper name -> Keeper_id.Keeper_name.to_string name
+  target_name_of_target request.target
 ;;
 
 let prompt (request : request) = request.prompt
@@ -83,8 +164,7 @@ let submission_receipt (request : request) outcome =
     Reconciliation_required { run_ref = reference; reason }
 ;;
 
-let result_contract entry =
-  match entry.Keeper_msg_async.status with
+let result_contract_of_status = function
   | Keeper_msg_async.Queued -> Awaiting_execution
   | Keeper_msg_async.Running -> Running
   | Keeper_msg_async.Cancelling _ -> Cancellation_requested
@@ -98,6 +178,8 @@ let result_contract entry =
      | Keeper_turn_outcome.Visible_reply
      | Keeper_turn_outcome.No_visible_reply -> Completed)
 ;;
+
+let result_contract entry = result_contract_of_status entry.Keeper_msg_async.status
 
 let capability_to_string = function
   | Invoke_turn -> "invoke_turn"
@@ -119,6 +201,34 @@ let run_ref_to_json reference =
     ]
 ;;
 
+let run_ref_of_json json =
+  let* fields = object_fields ~field:"run_ref" json in
+  let* () =
+    exact_fields
+      ~field:"run_ref"
+      ~allowed:[ "run_id"; "target"; "capability" ]
+      fields
+  in
+  let* run_id_json = required_field ~field:"run_ref" "run_id" fields in
+  let* run_id = string_value ~field:"run_ref.run_id" run_id_json in
+  let* target_json = required_field ~field:"run_ref" "target" fields in
+  let* target = target_of_json target_json in
+  let* capability_json = required_field ~field:"run_ref" "capability" fields in
+  let* capability = capability_of_json ~field:"run_ref.capability" capability_json in
+  if String.equal run_id ""
+  then invalid_wire_value ~field:"run_ref.run_id" ~expected:"non-empty string"
+  else Ok { run_id; target; capability }
+;;
+
+let run_id reference = reference.run_id
+
+let run_ref_matches_entry reference entry =
+  String.equal reference.run_id entry.Keeper_msg_async.request_id
+  && String.equal
+       (target_name_of_target reference.target)
+       entry.Keeper_msg_async.keeper_name
+;;
+
 let result_contract_to_string = function
   | Awaiting_execution -> "awaiting_execution"
   | Publication_uncertain -> "publication_uncertain"
@@ -131,12 +241,12 @@ let result_contract_to_string = function
 ;;
 
 let submission_to_json (request : request) outcome =
-  let common reference status result_contract =
+  let common reference status contract =
     [ "request_id", `String outcome.Keeper_msg_async.request_id
     ; "keeper_name", `String (target_name request)
     ; "status", `String status
     ; "run_ref", run_ref_to_json reference
-    ; "result_contract", `String (result_contract_to_string result_contract)
+    ; "result_contract", `String (result_contract_to_string contract)
     ]
   in
   match submission_receipt request outcome with
@@ -155,6 +265,112 @@ let submission_to_json (request : request) outcome =
            , `String
                "Request publication is uncertain. Query masc_keeper_msg_result with this exact run_ref.run_id; do not resubmit." )
          ])
+;;
+
+let delegate_submission_to_json (request : request) outcome =
+  let common reference result_contract =
+    [ "run_ref", run_ref_to_json reference
+    ; "result_contract", `String (result_contract_to_string result_contract)
+    ]
+  in
+  match submission_receipt request outcome with
+  | Durable_run reference ->
+    `Assoc
+      (common reference Awaiting_execution
+       @ [ ( "message"
+           , `String
+               "Keeper turn accepted. The caller lane may continue; query masc_keeper_delegate_status with the exact run_ref." )
+         ])
+  | Reconciliation_required { run_ref = reference; reason } ->
+    `Assoc
+      (common reference Publication_uncertain
+       @ [ "reason", `String reason
+         ; ( "operator_instruction"
+           , `String
+               "Request publication is uncertain. Query masc_keeper_delegate_status with this exact run_ref; do not resubmit." )
+         ])
+;;
+
+let delegate_submission_error_to_json request = function
+  | Keeper_msg_async.Submit_rejected rejection ->
+    Keeper_msg_async.access_rejection_to_json rejection
+  | Keeper_msg_async.Submit_invalid_keeper_name { reason } ->
+    `Assoc [ "error", `String "invalid_target"; "message", `String reason ]
+  | Keeper_msg_async.Initial_persistence_failed { reason } ->
+    `Assoc [ "error", `String "invocation_persistence_failed"; "message", `String reason ]
+  | Keeper_msg_async.Acceptance_persistence_failed { request_id; reason } ->
+    `Assoc
+      [ "error", `String "invocation_acceptance_uncertain"
+      ; "run_ref", run_ref_to_json (run_ref request request_id)
+      ; "result_contract", `String (result_contract_to_string Publication_uncertain)
+      ; "message", `String reason
+      ]
+  | Keeper_msg_async.Background_switch_unavailable { reason } ->
+    `Assoc [ "error", `String "background_switch_unavailable"; "message", `String reason ]
+  | Keeper_msg_async.Background_fork_failed { request_id; reason } ->
+    `Assoc
+      [ "error", `String "invocation_background_start_failed"
+      ; "run_ref", run_ref_to_json (run_ref request request_id)
+      ; "result_contract", `String (result_contract_to_string Failed)
+      ; "message", `String reason
+      ]
+;;
+
+let entry_result = function
+  | Keeper_msg_async.Queued | Keeper_msg_async.Running -> []
+  | Keeper_msg_async.Done { body; data; _ } ->
+    [ "result", Option.value ~default:(`String body) data ]
+  | Keeper_msg_async.Lost { reason } ->
+    [ "result", `Assoc [ "error", `String "invocation_lost"; "reason", `String reason ] ]
+  | Keeper_msg_async.Cancelled { reason; cancelled_by } ->
+    [ ( "result"
+      , `Assoc
+          [ "reason", `String reason
+          ; "cancelled_by", `String cancelled_by
+          ] )
+    ]
+  | Keeper_msg_async.Cancelling { reason; cancelled_by } ->
+    [ ( "result"
+      , `Assoc
+          [ "reason", `String reason
+          ; "cancelled_by", `String cancelled_by
+          ] )
+    ]
+  | Keeper_msg_async.Persistence_failed { attempted_status; reason } ->
+    [ ( "result"
+      , `Assoc
+          [ "error", `String "invocation_persistence_failed"
+          ; "attempted_status", `String attempted_status
+          ; "reason", `String reason
+          ] )
+    ]
+;;
+
+let delegate_entry_to_json entry =
+  let contract = result_contract entry in
+  let* target_name =
+    Keeper_id.Keeper_name.of_string entry.Keeper_msg_async.keeper_name
+    |> Result.map_error (fun reason -> Invalid_target reason)
+  in
+  let reference =
+    { run_id = entry.request_id
+    ; target = Keeper target_name
+    ; capability = Invoke_turn
+    }
+  in
+  let timing =
+    match entry.completed_at with
+    | Some completed_at -> [ "completed_at", `Float completed_at ]
+    | None -> []
+  in
+  Ok
+    (`Assoc
+       ([ "run_ref", run_ref_to_json reference
+        ; "result_contract", `String (result_contract_to_string contract)
+        ; "submitted_at", `Float entry.submitted_at
+        ]
+        @ timing
+        @ entry_result entry.status))
 ;;
 
 let entry_to_json entry =
@@ -178,4 +394,43 @@ let entry_to_json entry =
             ; "result_contract", `String (result_contract_to_string contract)
             ]))
   | _ -> Error Invalid_entry_projection
+;;
+
+let delegate_cancellation_to_json reference result =
+  let common = [ "run_ref", run_ref_to_json reference ] in
+  let contract status =
+    [ "result_contract", `String (result_contract_to_string status) ]
+  in
+  let durability = function
+    | Keeper_msg_async.Durably_committed -> [ "durability", `String "durable" ]
+    | Keeper_msg_async.Published_unconfirmed { reason } ->
+      [ "durability", `String "publication_uncertain"; "warning", `String reason ]
+  in
+  let fields =
+    match result with
+    | Keeper_msg_async.Cancellation_requested state ->
+      contract Cancellation_requested @ durability state
+    | Keeper_msg_async.Cancel_not_found -> [ "error", `String "run_not_found" ]
+    | Keeper_msg_async.Cancel_unreadable reason ->
+      [ "error", `String "invocation_record_unreadable"; "message", `String reason ]
+    | Keeper_msg_async.Cancel_rejected rejection ->
+      [ "error", `String "invocation_access_rejected"
+      ; "reason", Keeper_msg_async.access_rejection_to_json rejection
+      ]
+    | Keeper_msg_async.Cancel_worker_ownership_unknown status ->
+      contract (result_contract_of_status status)
+      @ [ "error", `String "invocation_worker_ownership_unknown" ]
+    | Keeper_msg_async.Cancel_already_terminal status ->
+      contract (result_contract_of_status status)
+      @ [ "error", `String "invocation_already_terminal" ]
+    | Keeper_msg_async.Cancel_persistence_failed { reason } ->
+      [ "error", `String "cancellation_persistence_failed"; "message", `String reason ]
+    | Keeper_msg_async.Cancel_worker_signal_failed { durability = state; reason } ->
+      contract Cancellation_requested
+      @ durability state
+      @ [ "error", `String "cancellation_worker_signal_failed"; "message", `String reason ]
+    | Keeper_msg_async.Cancel_state_invariant_failed { reason } ->
+      [ "error", `String "cancellation_state_invariant_failed"; "message", `String reason ]
+  in
+  `Assoc (common @ fields)
 ;;

--- a/lib/keeper/keeper_invocation_contract.mli
+++ b/lib/keeper/keeper_invocation_contract.mli
@@ -10,11 +10,7 @@ type target = Keeper of Keeper_id.Keeper_name.t
 
 type request
 
-type run_ref =
-  { run_id : string
-  ; target : target
-  ; capability : capability
-  }
+type run_ref
 
 type submission_receipt =
   | Durable_run of run_ref
@@ -37,11 +33,24 @@ type request_error =
   | Invalid_target of string
   | Empty_prompt
   | Invalid_entry_projection
+  | Invalid_wire_value of
+      { field : string
+      ; expected : string
+      }
+  | Run_ref_mismatch
 
 val request : keeper_name:string -> prompt:string -> (request, request_error) result
+val request_of_json : Yojson.Safe.t -> (request, request_error) result
 val request_error_to_string : request_error -> string
 val target_name : request -> string
 val prompt : request -> string
+val target_of_json : Yojson.Safe.t -> (target, request_error) result
+val target_to_json : target -> Yojson.Safe.t
+val target_name_of_target : target -> string
+val run_ref_of_json : Yojson.Safe.t -> (run_ref, request_error) result
+val run_ref_to_json : run_ref -> Yojson.Safe.t
+val run_id : run_ref -> string
+val run_ref_matches_entry : run_ref -> Keeper_msg_async.entry -> bool
 
 val submit
   :  background_sw:Eio.Switch.t
@@ -60,6 +69,19 @@ val result_contract : Keeper_msg_async.entry -> result_contract
 val submission_to_json
   :  request -> Keeper_msg_async.submit_outcome -> Yojson.Safe.t
 
+val delegate_submission_to_json
+  :  request -> Keeper_msg_async.submit_outcome -> Yojson.Safe.t
+
+val delegate_submission_error_to_json
+  :  request -> Keeper_msg_async.submit_error -> Yojson.Safe.t
+
+val delegate_cancellation_to_json
+  :  run_ref -> Keeper_msg_async.cancel_result -> Yojson.Safe.t
+
 val entry_to_json
+  :  Keeper_msg_async.entry
+  -> (Yojson.Safe.t, request_error) result
+
+val delegate_entry_to_json
   :  Keeper_msg_async.entry
   -> (Yojson.Safe.t, request_error) result

--- a/lib/keeper/keeper_invocation_contract.mli
+++ b/lib/keeper/keeper_invocation_contract.mli
@@ -4,13 +4,13 @@
     the existing durable {!Keeper_msg_async} owner into a typed target,
     capability, run reference, and result contract. *)
 
-type capability = Invoke_turn
+type capability = Keeper_invocation_types.capability = Invoke_turn
 
-type target = Keeper of Keeper_id.Keeper_name.t
+type target = Keeper_invocation_types.target = Keeper of Keeper_id.Keeper_name.t
 
 type request
 
-type run_ref
+type run_ref = Keeper_invocation_types.run_ref
 
 type submission_receipt =
   | Durable_run of run_ref
@@ -19,7 +19,7 @@ type submission_receipt =
       ; reason : string
       }
 
-type result_contract =
+type result_contract = Keeper_invocation_types.result_contract =
   | Awaiting_execution
   | Publication_uncertain
   | Running
@@ -50,6 +50,7 @@ val target_name_of_target : target -> string
 val run_ref_of_json : Yojson.Safe.t -> (run_ref, request_error) result
 val run_ref_to_json : run_ref -> Yojson.Safe.t
 val run_id : run_ref -> string
+val run_ref_target_name : run_ref -> string
 val run_ref_matches_entry : run_ref -> Keeper_msg_async.entry -> bool
 
 val submit
@@ -65,6 +66,8 @@ val submission_receipt
   :  request -> Keeper_msg_async.submit_outcome -> submission_receipt
 
 val result_contract : Keeper_msg_async.entry -> result_contract
+val result_contract_to_string : result_contract -> string
+val result_contract_of_string : string -> result_contract option
 
 val submission_to_json
   :  request -> Keeper_msg_async.submit_outcome -> Yojson.Safe.t

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -44,6 +44,34 @@ let string_array_schema =
     ("items", `Assoc [ ("type", `String "string") ]);
   ]
 
+let closed_object_schema ~required properties =
+  `Assoc
+    [ "type", `String "object"
+    ; "properties", `Assoc properties
+    ; "required", `List (List.map (fun name -> `String name) required)
+    ; "additionalProperties", `Bool false
+    ]
+;;
+
+let keeper_invocation_target_schema =
+  closed_object_schema
+    ~required:[ "kind"; "name" ]
+    [ "kind", `Assoc [ "type", `String "string"; "enum", `List [ `String "keeper" ] ]
+    ; "name", `Assoc [ "type", `String "string" ]
+    ]
+;;
+
+let keeper_invocation_run_ref_schema =
+  closed_object_schema
+    ~required:[ "run_id"; "target"; "capability" ]
+    [ "run_id", `Assoc [ "type", `String "string" ]
+    ; "target", keeper_invocation_target_schema
+    ; ( "capability"
+      , `Assoc
+          [ "type", `String "string"; "enum", `List [ `String "invoke_turn" ] ] )
+    ]
+;;
+
 let keeper_schemas : tool_schema list = [
   {
     name = "masc_keeper_sandbox_start";
@@ -326,95 +354,36 @@ let keeper_schemas : tool_schema list = [
     ];
   };
 
-  {
-    name = "masc_keeper_msg";
-    description = "Send a message to a keeper (async). Returns immediately with a request_id. Poll masc_keeper_msg_result for the response.";
-    input_schema = `Assoc [
-      ("type", `String "object");
-      ("properties", `Assoc [
-        ("name", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Keeper handle");
-        ]);
-        ("message", `Assoc [
-          ("type", `String "string");
-          ("description", `String "User message");
-        ]);
-        ("direct_reply", `Assoc [
-          ("type", `String "boolean");
-          ("description", `String "Optional: run the turn synchronously and return the reply directly instead of queueing");
-        ]);
-        ("turn_instructions", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Optional: free-form instructions to prepend to the keeper prompt for this turn");
-        ]);
-        ("surface_context", `Assoc [
-          ("type", `String "object");
-          ("description", `String "Optional: co-view context from the dashboard ({ label, route, scene, fields }); formatted into turn instructions when turn_instructions is omitted");
-        ]);
-        ("channel", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Optional: channel label (e.g. copilot) for the chat lane");
-        ]);
-        ("channel_user_id", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Optional: external user id on the channel");
-        ]);
-        ("channel_user_name", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Optional: external user name on the channel");
-        ]);
-        ("channel_workspace_id", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Optional: operator session or workspace id for the channel");
-        ]);
-      ]);
-      ("required", `List [`String "name"; `String "message"]);
-    ];
-  };
-
-  {
-    name = "masc_keeper_msg_result";
-    description = "Poll the result of an async keeper_msg request. Returns status (queued/running/done/error) and the result when complete.";
-    input_schema = `Assoc [
-      ("type", `String "object");
-      ("properties", `Assoc [
-        ("request_id", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Request ID returned by masc_keeper_msg");
-        ]);
-      ]);
-      ("required", `List [`String "request_id"]);
-    ];
-  };
-
-  {
-    name = "masc_keeper_msg_cancel";
-    description = "Cancel a running async keeper_msg request by request_id.";
-    input_schema = `Assoc [
-      ("type", `String "object");
-      ("properties", `Assoc [
-        ("request_id", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Request ID returned by masc_keeper_msg");
-        ]);
-      ]);
-      ("required", `List [`String "request_id"]);
-    ];
-  };
-
-  {
-    name = "masc_keeper_msg_queue";
-    description = "List all pending/running async keeper_msg requests, optionally filtered by keeper_name.";
-    input_schema = `Assoc [
-      ("type", `String "object");
-      ("properties", `Assoc [
-        ("keeper_name", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Optional: filter by keeper name");
-        ]);
-      ]);
-    ];
+  { name = "masc_keeper_delegate"
+  ; description = "Submit one typed, non-blocking Keeper invocation and return its durable run_ref."
+  ; input_schema =
+      closed_object_schema
+        ~required:[ "target"; "capability"; "prompt" ]
+        [ "target", keeper_invocation_target_schema
+        ; ( "capability"
+          , `Assoc
+              [ "type", `String "string"; "enum", `List [ `String "invoke_turn" ] ] )
+        ; "prompt", `Assoc [ "type", `String "string" ]
+        ]
+  }
+; { name = "masc_keeper_delegate_status"
+  ; description = "Read one Keeper invocation using the exact typed run_ref returned at submission."
+  ; input_schema =
+      closed_object_schema
+        ~required:[ "run_ref" ]
+        [ "run_ref", keeper_invocation_run_ref_schema ]
+  }
+; { name = "masc_keeper_delegate_cancel"
+  ; description = "Request cancellation of one Keeper invocation identified by its exact typed run_ref."
+  ; input_schema =
+      closed_object_schema
+        ~required:[ "run_ref" ]
+        [ "run_ref", keeper_invocation_run_ref_schema ]
+  }
+; { name = "masc_keeper_delegate_list"
+  ; description = "List non-terminal Keeper invocations, optionally filtered by a typed Keeper target."
+  ; input_schema =
+      closed_object_schema ~required:[] [ "target", keeper_invocation_target_schema ]
   };
 
   (* masc_keeper_reconcile removed with manual_reconcile blocker system. *)

--- a/lib/keeper/keeper_tool_boundary.ml
+++ b/lib/keeper/keeper_tool_boundary.ml
@@ -65,7 +65,3 @@ let delegated_dispatch
   in
   fun ~name ~args -> dispatch ctx ~name ~args
 ;;
-
-let dispatch_stream ?on_text_delta ?on_event ctx ~name ~args =
-  Keeper_tool_surface.dispatch_stream ?on_text_delta ?on_event (to_tool_keeper_context ctx) ~name
-    ~args

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -1940,13 +1940,13 @@ let internal_descriptors : t list =
   (* ── RFC-0182 §3.1 — masc_keeper cluster ──── *)
     masc_keeper_descriptor "list" "masc_keeper_list"
       "List configured keepers with optional detailed metadata." ~readonly:true
-  ; masc_keeper_descriptor "msg_result" "masc_keeper_msg_result"
-      "Poll an async keeper_msg dispatch by request_id." ~readonly:true
+  ; masc_keeper_descriptor "delegate_status" "masc_keeper_delegate_status"
+      "Read one Keeper invocation by exact typed run_ref." ~readonly:true
       ~polling_read:true
-  ; masc_keeper_descriptor "msg_cancel" "masc_keeper_msg_cancel"
-      "Cancel a running async keeper_msg turn by request_id." ~readonly:false
-  ; masc_keeper_descriptor "msg_queue" "masc_keeper_msg_queue"
-      "List all pending/running async keeper_msg requests, optionally filtered by keeper_name." ~readonly:true
+  ; masc_keeper_descriptor "delegate_cancel" "masc_keeper_delegate_cancel"
+      "Request cancellation of one Keeper invocation by exact typed run_ref." ~readonly:false
+  ; masc_keeper_descriptor "delegate_list" "masc_keeper_delegate_list"
+      "List non-terminal Keeper invocations with an optional typed target filter." ~readonly:true
   ; masc_keeper_descriptor "compact" "masc_keeper_compact"
       "Run operator-requested context compaction on a keeper." ~readonly:false
   ; masc_keeper_descriptor "clear" "masc_keeper_clear"
@@ -1964,8 +1964,8 @@ let internal_descriptors : t list =
   ; masc_keeper_descriptor "down" "masc_keeper_down"
       "Stop keeper keepalive, optionally remove meta and session directory." ~readonly:false
   (* RFC-0182 Phase 5 PR-B: Eio-bound keeper tools (require sw + clock). *)
-  ; masc_keeper_descriptor "msg" "masc_keeper_msg"
-      "Submit an async keeper turn (returns request_id for keeper_msg_result polling)." ~readonly:false
+  ; masc_keeper_descriptor "delegate" "masc_keeper_delegate"
+      "Submit a typed non-blocking Keeper invocation and return its durable run_ref." ~readonly:false
   ; masc_keeper_descriptor "up" "masc_keeper_up"
       "Bring a keeper online (create new or update existing)." ~readonly:false
   ]

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -413,6 +413,11 @@ let handle_keeper_sandbox_stop ctx args : tool_result =
 
 let should_bootstrap_existing_keepalives name args =
   match name with
+  | "masc_keeper_delegate" ->
+      (match Keeper_invocation_contract.request_of_json args with
+       | Ok request ->
+         not (String.equal (String.trim (Keeper_invocation_contract.prompt request)) "")
+       | Error _ -> false)
   | "masc_keeper_msg" ->
       not (String.equal (String.trim (get_string args "message" "")) "")
   | _ -> false
@@ -774,7 +779,7 @@ let keeper_clear_body ~(config : Workspace.config) args : tool_result =
 let handle_keeper_clear ctx args : tool_result =
   keeper_clear_body ~config:ctx.config args
 
-let dispatch ?continuation_channel ctx ~name ~args : tool_result option =
+let dispatch ctx ~name ~args : tool_result option =
   maybe_bootstrap_existing_keepalives ctx ~name ~args;
   let ctx = resolve_ctx ctx ~name args in
   match name with
@@ -785,18 +790,29 @@ let dispatch ?continuation_channel ctx ~name ~args : tool_result option =
   | "masc_keeper_create_from_persona" -> Some (tool_result_with_tool_name ~tool_name:name (handle_keeper_create_from_persona ctx args))
   | "masc_keeper_up" -> Some (tool_result_with_tool_name ~tool_name:name (handle_keeper_up ctx args))
   | "masc_keeper_status" -> Some (tool_result_with_tool_name ~tool_name:name (handle_keeper_status ctx args))
-  | "masc_keeper_msg" ->
+  | "masc_keeper_delegate" ->
       Some
         (tool_result_with_tool_name
            ~tool_name:name
-           (handle_keeper_msg
-              ?continuation_channel
+           (Keeper_tool_surface_ops.handle_keeper_delegate
               ~submitted_by:ctx.agent_name
               ctx
               args))
-  | "masc_keeper_msg_result" -> Some (tool_result_with_tool_name ~tool_name:name (handle_keeper_msg_result ctx args))
-  | "masc_keeper_msg_cancel" -> Some (tool_result_with_tool_name ~tool_name:name (handle_keeper_msg_cancel ctx args))
-  | "masc_keeper_msg_queue" -> Some (tool_result_with_tool_name ~tool_name:name (handle_keeper_msg_queue ctx args))
+  | "masc_keeper_delegate_status" ->
+      Some
+        (tool_result_with_tool_name ~tool_name:name
+           (Keeper_tool_surface_ops.keeper_delegate_status_body
+              ~config:ctx.config ~caller:ctx.agent_name args))
+  | "masc_keeper_delegate_cancel" ->
+      Some
+        (tool_result_with_tool_name ~tool_name:name
+           (Keeper_tool_surface_ops.keeper_delegate_cancel_body
+              ~config:ctx.config ~caller:ctx.agent_name args))
+  | "masc_keeper_delegate_list" ->
+      Some
+        (tool_result_with_tool_name ~tool_name:name
+           (Keeper_tool_surface_ops.keeper_delegate_list_body
+              ~config:ctx.config ~caller:ctx.agent_name args))
   | "masc_keeper_down" -> Some (tool_result_with_tool_name ~tool_name:name (handle_keeper_down ctx args))
   | "masc_keeper_list" -> Some (tool_result_with_tool_name ~tool_name:name (handle_keeper_list ctx args))
   | "masc_keeper_persona_audit" -> Some (tool_result_with_tool_name ~tool_name:name (handle_keeper_persona_audit ctx args))
@@ -819,63 +835,53 @@ let dispatch_keeper_msg ~submitted_by ?continuation_channel ctx ~args : tool_res
     (handle_keeper_msg ?continuation_channel ~submitted_by ctx args)
 ;;
 
-(** Streaming dispatch: only handles keeper_msg with text delta forwarding.
-    Returns None for all other tool names.
-    Called from server_routes_http_keeper_stream. *)
-let dispatch_stream
+(** Private direct-delivery stream used by connector and dashboard adapters. *)
+let dispatch_keeper_msg_stream
       ?on_text_delta
       ?on_event
       ?continuation_channel
       ?on_admission_rejected
       ?on_admitted
       ctx
-      ~name
       ~args
   : tool_result option
   =
+  let name = "masc_keeper_msg" in
   maybe_bootstrap_existing_keepalives ctx ~name ~args;
   let ctx = resolve_ctx ctx ~name args in
-  match name with
-  | "masc_keeper_msg" ->
-      Some
-        (tool_result_with_tool_name
-           ~tool_name:name
-           (handle_keeper_msg_stream
-              ?on_text_delta
-              ?on_event
-              ?continuation_channel
-              ?on_admission_rejected
-              ?on_admitted
-              ctx
-              args))
-  | _ -> None
+  Some
+    (tool_result_with_tool_name
+       ~tool_name:name
+       (handle_keeper_msg_stream
+          ?on_text_delta
+          ?on_event
+          ?continuation_channel
+          ?on_admission_rejected
+          ?on_admitted
+          ctx
+          args))
 
-let dispatch_stream_if_free
+let dispatch_keeper_msg_stream_if_free
       ?on_text_delta
       ?on_event
       ?continuation_channel
       ctx
-      ~name
       ~args
   =
+  let name = "masc_keeper_msg" in
   maybe_bootstrap_existing_keepalives ctx ~name ~args;
   let ctx = resolve_ctx ctx ~name args in
-  match name with
-  | "masc_keeper_msg" ->
-      (match
-         handle_keeper_msg_stream_if_free
-           ?on_text_delta
-           ?on_event
-           ?continuation_channel
-           ctx
-           args
-       with
-       | `Busy rejection -> `Busy rejection
-       | `Ran result ->
-         `Ran
-           (Some
-              (tool_result_with_tool_name ~tool_name:name result)))
-  | _ -> `Ran None
+  match
+    handle_keeper_msg_stream_if_free
+      ?on_text_delta
+      ?on_event
+      ?continuation_channel
+      ctx
+      args
+  with
+  | `Busy rejection -> `Busy rejection
+  | `Ran result ->
+    `Ran (Some (tool_result_with_tool_name ~tool_name:name result))
 
 (* ================================================================ *)
 (* Tool_spec registration                                           *)
@@ -950,27 +956,27 @@ let () =
     match name with
     | "masc_keeper_list" ->
       Some (tool_result_with_tool_name ~tool_name:name (keeper_list_body ~config args))
-    | "masc_keeper_msg_result" ->
+    | "masc_keeper_delegate_status" ->
       Some
         (tool_result_with_tool_name
            ~tool_name:name
-           (Keeper_tool_surface_ops.keeper_msg_result_body
+           (Keeper_tool_surface_ops.keeper_delegate_status_body
               ~config
               ~caller:agent_name
               args))
-    | "masc_keeper_msg_cancel" ->
+    | "masc_keeper_delegate_cancel" ->
       Some
         (tool_result_with_tool_name
            ~tool_name:name
-           (Keeper_tool_surface_ops.keeper_msg_cancel_body
+           (Keeper_tool_surface_ops.keeper_delegate_cancel_body
               ~config
               ~caller:agent_name
               args))
-    | "masc_keeper_msg_queue" ->
+    | "masc_keeper_delegate_list" ->
       Some
         (tool_result_with_tool_name
            ~tool_name:name
-           (Keeper_tool_surface_ops.keeper_msg_queue_body
+           (Keeper_tool_surface_ops.keeper_delegate_list_body
               ~config
               ~caller:agent_name
               args))
@@ -1046,20 +1052,14 @@ let () =
     (* RFC-0182 Phase 5 PR-B: Eio-bound keeper tools.  Require both
        sw and clock from caller; gracefully fail when invoked from a
        path without Eio context. *)
-    | "masc_keeper_msg" ->
+    | "masc_keeper_delegate" ->
       (match sw, clock with
        | Some sw, Some clock ->
-         Some
-           (Keeper_tool_surface_ops.keeper_msg_body
-              ~config
-              ~agent_name
-              ~sw
-              ~clock
-              ~publication_recovery_provider
-              ?proc_mgr
-              ?net
-              args)
-       | _ -> eio_context_missing "masc_keeper_msg")
+         let ctx : _ Keeper_types_profile.context =
+           { config; agent_name; sw; clock; proc_mgr; net; publication_recovery_provider }
+         in
+         Some (Keeper_tool_surface_ops.handle_keeper_delegate ~submitted_by:agent_name ctx args)
+       | _ -> eio_context_missing "masc_keeper_delegate")
     | "masc_keeper_up" ->
       (match sw, clock with
        | Some sw, Some clock ->

--- a/lib/keeper/keeper_tool_surface.mli
+++ b/lib/keeper/keeper_tool_surface.mli
@@ -17,7 +17,6 @@ type tool_result = Keeper_types_profile.tool_result
 val schemas : Masc_domain.tool_schema list
 
 val dispatch :
-  ?continuation_channel:Keeper_continuation_channel.t ->
   _ context -> name:string -> args:Yojson.Safe.t -> tool_result option
 
 (** Internal async-message entry point for adapters whose authenticated
@@ -38,27 +37,26 @@ module For_testing : sig
     key:string -> ttl_s:float -> (unit -> Yojson.Safe.t) -> Yojson.Safe.t
 end
 
-(** Streaming dispatch: handles keeper_msg with real-time text delta callback.
+(** Private direct-delivery stream with real-time text delta callback.
     The [on_text_delta] callback receives each text fragment from the MODEL
-    as it arrives. Returns [None] for tool names other than [masc_keeper_msg].
+    as it arrives. This is not a registered tool-name dispatch surface.
 
     @since 2.110.0 *)
-val dispatch_stream :
+val dispatch_keeper_msg_stream :
   ?on_text_delta:(string -> unit) ->
   ?on_event:(Agent_sdk.Types.sse_event -> unit) ->
   ?continuation_channel:Keeper_continuation_channel.t ->
   ?on_admission_rejected:(Keeper_turn_admission.rejection -> unit) ->
   ?on_admitted:(unit -> (unit, string) result) ->
-  _ context -> name:string -> args:Yojson.Safe.t -> tool_result option
+  _ context -> args:Yojson.Safe.t -> tool_result option
 
 (** Non-blocking streaming dispatch for direct chat admission. The Keeper turn
     slot performs the authoritative post-lock durable-queue recheck; [`Busy]
     callers must route the accepted message to their deferred transport. *)
-val dispatch_stream_if_free :
+val dispatch_keeper_msg_stream_if_free :
   ?on_text_delta:(string -> unit) ->
   ?on_event:(Agent_sdk.Types.sse_event -> unit) ->
   ?continuation_channel:Keeper_continuation_channel.t ->
   _ context ->
-  name:string ->
   args:Yojson.Safe.t ->
   [ `Ran of tool_result option | `Busy of Keeper_turn_admission.rejection ]

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -614,90 +614,20 @@ let append_direct_chat_pair_if_reply ~(config : Workspace.config) ~name ~args re
         end)
 ;;
 
-(* RFC-0182 Phase 5 PR-B: ctx-free body for [masc_keeper_msg] descriptor
-   projection.  Constructs a fresh [Keeper_types_profile.context] from the
-   threaded Eio resources and delegates to the existing [Turn.preflight_*]
-   / [Turn.handle_keeper_msg] handlers. *)
-let keeper_msg_body
-      ~(config : Workspace.config)
-      ~(agent_name : string)
-      ~(sw : Eio.Switch.t)
-      ~(clock : float Eio.Time.clock_ty Eio.Resource.t)
-      ~(publication_recovery_provider :
-          Keeper_publication_recovery_availability.provider)
-      ?proc_mgr
-      ?net
-      ?continuation_channel
-      args : tool_result =
-  let keeper_ctx : _ Keeper_types_profile.context =
-    { config
-    ; agent_name
-    ; sw
-    ; clock
-    ; proc_mgr
-    ; net
-    ; publication_recovery_provider
-    }
-  in
+let submit_keeper_invocation
+      ~submitted_by
+      ~submission_to_json
+      ~submission_error_to_json
+      ~run_turn
+      ctx
+      ~request
+  =
+  let name = Keeper_invocation_contract.target_name request in
   match
-    let* name = message_error (resolve_keeper_name_config ~config args) in
-    let resolved_args = with_keeper_name args name in
-    let* request =
-      message_error (Turn.preflight_keeper_msg keeper_ctx resolved_args)
-    in
     let* background_sw =
       Keeper_msg_async.server_background_switch ()
       |> Result.map_error (fun error ->
-        Payload_error (Keeper_msg_async.submit_error_to_json error))
-    in
-    let* submission =
-      submit_keeper_msg_with_captured_event_bus
-        ~background_sw
-        ~base_path:config.base_path
-        ~caller:agent_name
-        ~request
-        ~f:(fun ?event_bus request request_sw ->
-          let worker_args = with_invocation_request resolved_args request in
-          let worker_ctx = { keeper_ctx with sw = request_sw } in
-          let result =
-            Turn.handle_keeper_msg
-              ?event_bus
-              ?continuation_channel
-              worker_ctx
-              worker_args
-          in
-          if tool_result_success result
-          then begin
-            append_direct_chat_pair_if_reply
-              ~config
-              ~name
-              ~args:worker_args
-              result;
-            invalidate_keeper_list_cache ();
-            invalidate_status_cache name
-          end;
-          result)
-        ()
-      |> Result.map_error (fun error ->
-        Payload_error (Keeper_msg_async.submit_error_to_json error))
-    in
-    Ok
-      (tool_result_ok_data
-         (submit_outcome_with_keeper_json ~request submission))
-  with
-  | Ok result -> result
-  | Error error -> tool_result_of_handler_error error
-;;
-
-let handle_keeper_msg ?continuation_channel ~submitted_by ctx args : tool_result =
-  match
-    let* name = message_error (resolve_keeper_name ctx args) in
-    let resolved_args = with_keeper_name args name in
-    let* request = message_error (Turn.preflight_keeper_msg ctx resolved_args) in
-    let* background_sw =
-      Keeper_msg_async.server_background_switch ()
-      |> Result.map_error (fun error ->
-        Payload_error (Keeper_msg_async.submit_error_to_json error))
+        Payload_error (submission_error_to_json error))
     in
     let* submission =
       submit_keeper_msg_with_captured_event_bus
@@ -706,90 +636,150 @@ let handle_keeper_msg ?continuation_channel ~submitted_by ctx args : tool_result
         ~caller:submitted_by
         ~request
         ~f:(fun ?event_bus request request_sw ->
-          let worker_args = with_invocation_request resolved_args request in
           let worker_ctx = { ctx with sw = request_sw } in
-          let result =
-            Turn.handle_keeper_msg
-              ?event_bus
-              ?continuation_channel
-              worker_ctx
-              worker_args
-          in
+          let result = run_turn ?event_bus request worker_ctx in
           if tool_result_success result
           then begin
-            append_direct_chat_pair_if_reply
-              ~config:ctx.config
-              ~name
-              ~args:worker_args
-              result;
             invalidate_keeper_list_cache ();
             invalidate_status_cache name
           end;
           result)
         ()
       |> Result.map_error (fun error ->
-        Payload_error (Keeper_msg_async.submit_error_to_json error))
+        Payload_error (submission_error_to_json error))
     in
     Ok
       (tool_result_ok_data
-         (submit_outcome_with_keeper_json ~request submission))
+         (submission_to_json request submission))
   with
   | Ok result -> result
   | Error error -> tool_result_of_handler_error error
 ;;
-(* RFC-0182 §3.1 — ctx-free body for keeper_dispatch_ref path. *)
-let keeper_msg_result_body ~(config : Workspace.config) ~caller args : tool_result =
-  let request_id = get_string args "request_id" "" in
-  if String.equal request_id "" then
-    tool_result_error_data (`Assoc [ "error", `String "request_id is required" ])
-  else
-    match Keeper_msg_async.poll ~base_path:config.base_path ~caller request_id with
+
+let handle_keeper_msg ?continuation_channel ~submitted_by ctx args : tool_result =
+  match
+    let* name = message_error (resolve_keeper_name ctx args) in
+    let worker_args = with_keeper_name args name in
+    let* request = message_error (Turn.preflight_keeper_msg ctx worker_args) in
+    Ok
+      (submit_keeper_invocation
+         ~submitted_by
+         ~submission_to_json:Keeper_invocation_contract.submission_to_json
+         ~submission_error_to_json:Keeper_msg_async.submit_error_to_json
+         ~run_turn:(fun ?event_bus request worker_ctx ->
+           let worker_args = with_invocation_request worker_args request in
+           let result =
+             Turn.handle_keeper_msg
+               ?event_bus
+               ?continuation_channel
+               worker_ctx
+               worker_args
+           in
+           append_direct_chat_pair_if_reply
+             ~config:ctx.config ~name ~args:worker_args result;
+           result)
+         ctx ~request)
+  with
+  | Ok result -> result
+  | Error error -> tool_result_of_handler_error error
+;;
+
+let handle_keeper_delegate ~submitted_by ctx args =
+  match
+    let* request =
+      Keeper_invocation_contract.request_of_json args |> message_error
+    in
+    let* request = message_error (Turn.preflight_keeper_delegate ctx request) in
+    Ok
+      (submit_keeper_invocation
+         ~submitted_by
+         ~submission_to_json:Keeper_invocation_contract.delegate_submission_to_json
+         ~submission_error_to_json:
+           (Keeper_invocation_contract.delegate_submission_error_to_json request)
+         ~run_turn:(fun ?event_bus request worker_ctx ->
+           Turn.handle_keeper_delegate ?event_bus worker_ctx request)
+         ctx
+         ~request)
+  with
+  | Ok result -> result
+  | Error error -> tool_result_of_handler_error error
+;;
+
+let run_ref_arg args =
+  match args with
+  | `Assoc [ ("run_ref", value) ] -> Keeper_invocation_contract.run_ref_of_json value
+  | _ ->
+    Error
+      (Keeper_invocation_contract.Invalid_wire_value
+         { field = "delegate_operation"; expected = "object containing only run_ref" })
+;;
+
+let run_ref_error error =
+  tool_result_error_data
+    (`Assoc
+       [ "error", `String "invalid_run_ref"
+       ; "message", `String (Keeper_invocation_contract.request_error_to_string error)
+       ])
+;;
+
+let delegate_access_rejection reference rejection =
+  let error, message =
+    match rejection with
+    | Keeper_msg_async.Invalid_base_path { reason } -> "invalid_base_path", reason
+    | Keeper_msg_async.Invalid_caller -> "invalid_caller", "caller identity is invalid"
+    | Keeper_msg_async.Invalid_request_id -> "invalid_run_ref", "run_ref.run_id is invalid"
+    | Keeper_msg_async.Caller_mismatch ->
+      "run_ref_caller_mismatch", "run_ref does not belong to the authenticated caller"
+  in
+  `Assoc
+    [ "error", `String error
+    ; "message", `String message
+    ; "run_ref", Keeper_invocation_contract.run_ref_to_json reference
+    ]
+;;
+
+let keeper_delegate_status_body ~(config : Workspace.config) ~caller args =
+  match run_ref_arg args with
+  | Error error -> run_ref_error error
+  | Ok reference ->
+    let run_id = Keeper_invocation_contract.run_id reference in
+    (match Keeper_msg_async.poll ~base_path:config.base_path ~caller run_id with
     | Keeper_msg_async.Absent ->
       tool_result_error_data
-        (`Assoc
-           [ "error", `String "request_id not found"
-           ; "request_id", `String request_id
-           ])
+        (`Assoc [ "error", `String "run_not_found"; "run_ref", Keeper_invocation_contract.run_ref_to_json reference ])
     | Keeper_msg_async.Unreadable reason ->
       tool_result_error_data
         (`Assoc
-           [ ("error", `String "request_record_unreadable")
-           ; ( "message"
-             , `String
-                 (Printf.sprintf
-                    "request record unreadable: %s — request was accepted but its \
-                     result is lost"
-                    reason) )
-           ; ("request_id", `String request_id)
+           [ "error", `String "invocation_record_unreadable"
+           ; "message", `String reason
+           ; "run_ref", Keeper_invocation_contract.run_ref_to_json reference
            ])
     | Keeper_msg_async.Rejected rejection ->
-      tool_result_error_data (Keeper_msg_async.access_rejection_to_json rejection)
+      tool_result_error_data (delegate_access_rejection reference rejection)
+    | Keeper_msg_async.Found entry
+      when not (Keeper_invocation_contract.run_ref_matches_entry reference entry) ->
+      run_ref_error Keeper_invocation_contract.Run_ref_mismatch
     | Keeper_msg_async.Found entry ->
-      (match Keeper_invocation_contract.entry_to_json entry with
+      (match Keeper_invocation_contract.delegate_entry_to_json entry with
        | Ok json -> tool_result_ok_data json
        | Error error ->
-         tool_result_error_data
-           (`Assoc
-              [ "error", `String "keeper_invocation_contract_invalid"
-              ; ( "message"
-                , `String
-                    (Keeper_invocation_contract.request_error_to_string error) )
-              ; "request_id", `String request_id
-              ]))
+         run_ref_error error))
+;;
 
-let handle_keeper_msg_result ctx args : tool_result =
-  keeper_msg_result_body ~config:ctx.config ~caller:ctx.agent_name args
-
-(* RFC-0182 §3.1 — ctx-free body for keeper_dispatch_ref path. *)
-let keeper_msg_cancel_body ~(config : Workspace.config) ~caller args : tool_result =
-  let request_id = get_string args "request_id" "" in
-  if String.equal request_id "" then
-    tool_result_error_data (`Assoc [ "error", `String "request_id is required" ])
-  else (
+let keeper_delegate_cancel_body ~(config : Workspace.config) ~caller args =
+  match run_ref_arg args with
+  | Error error -> run_ref_error error
+  | Ok reference ->
+    let run_id = Keeper_invocation_contract.run_id reference in
+    (match Keeper_msg_async.poll ~base_path:config.base_path ~caller run_id with
+     | Keeper_msg_async.Found entry
+       when not (Keeper_invocation_contract.run_ref_matches_entry reference entry) ->
+       run_ref_error Keeper_invocation_contract.Run_ref_mismatch
+     | Keeper_msg_async.Found _ ->
     let result =
-      Keeper_msg_async.cancel ~base_path:config.base_path ~caller request_id
+      Keeper_msg_async.cancel ~base_path:config.base_path ~caller run_id
     in
-    let json = Keeper_msg_async.cancel_result_to_json ~request_id result in
+    let json = Keeper_invocation_contract.delegate_cancellation_to_json reference result in
     match result with
     | Keeper_msg_async.Cancellation_requested _ ->
       tool_result_ok_data json
@@ -801,13 +791,30 @@ let keeper_msg_cancel_body ~(config : Workspace.config) ~caller args : tool_resu
     | Keeper_msg_async.Cancel_persistence_failed _
     | Keeper_msg_async.Cancel_worker_signal_failed _
     | Keeper_msg_async.Cancel_state_invariant_failed _ ->
-      tool_result_error_data json)
+      tool_result_error_data json
+     | Keeper_msg_async.Absent ->
+       tool_result_error_data (Keeper_invocation_contract.delegate_cancellation_to_json reference Keeper_msg_async.Cancel_not_found)
+     | Keeper_msg_async.Unreadable reason ->
+       tool_result_error_data (Keeper_invocation_contract.delegate_cancellation_to_json reference (Keeper_msg_async.Cancel_unreadable reason))
+     | Keeper_msg_async.Rejected rejection ->
+       tool_result_error_data (delegate_access_rejection reference rejection))
+;;
 
-let handle_keeper_msg_cancel ctx args : tool_result =
-  keeper_msg_cancel_body ~config:ctx.config ~caller:ctx.agent_name args
-
-let keeper_msg_queue_body ~(config : Workspace.config) ~caller args : tool_result =
-  let keeper_name = get_string_opt args "keeper_name" in
+let keeper_delegate_list_body ~(config : Workspace.config) ~caller args =
+  let target =
+    match args with
+    | `Assoc [] -> Ok None
+    | `Assoc [ ("target", value) ] ->
+      Keeper_invocation_contract.target_of_json value |> Result.map (fun target -> Some target)
+    | _ ->
+      Error
+        (Keeper_invocation_contract.Invalid_wire_value
+           { field = "delegate_list"; expected = "empty object or typed target" })
+  in
+  match target with
+  | Error error -> run_ref_error error
+  | Ok target ->
+  let keeper_name = Option.map Keeper_invocation_contract.target_name_of_target target in
   match
     Keeper_msg_async.list_for_keeper
       ~base_path:config.base_path
@@ -816,13 +823,19 @@ let keeper_msg_queue_body ~(config : Workspace.config) ~caller args : tool_resul
       ()
   with
   | Ok entries ->
-    let json_list = List.map Keeper_msg_async.entry_to_json entries in
-    tool_result_ok_data (`List json_list)
+    let rec project = function
+      | [] -> Ok []
+      | entry :: rest ->
+        let* json = Keeper_invocation_contract.delegate_entry_to_json entry in
+        let* rest = project rest in
+        Ok (json :: rest)
+    in
+    (match project entries with
+     | Ok json_list -> tool_result_ok_data (`List json_list)
+     | Error error -> run_ref_error error)
   | Error rejection ->
     tool_result_error_data (Keeper_msg_async.access_rejection_to_json rejection)
-
-let handle_keeper_msg_queue ctx args : tool_result =
-  keeper_msg_queue_body ~config:ctx.config ~caller:ctx.agent_name args
+;;
 
 let complete_keeper_msg_stream_result ~name result =
   if not (tool_result_success result) then result

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -219,12 +219,33 @@ let user_oas_blocks_of_args args =
       | Ok [] -> Ok None
       | Ok blocks -> Ok (Some blocks)
 
-let turn_resources_error failure =
+type invocation_surface =
+  | Direct_message
+  | Keeper_delegate
+
+let invocation_tool_name = function
+  | Direct_message -> "masc_keeper_msg"
+  | Keeper_delegate -> "masc_keeper_delegate"
+;;
+
+let invocation_turn_type = function
+  | Direct_message -> "direct"
+  | Keeper_delegate -> "delegate"
+;;
+
+let invocation_args request =
+  `Assoc
+    [ "name", `String (Keeper_invocation_contract.target_name request)
+    ; "message", `String (Keeper_invocation_contract.prompt request)
+    ]
+;;
+
+let turn_resources_error ~surface failure =
   let detail =
     Keeper_publication_recovery_scope.failure_to_string failure
   in
   tool_result_error_data
-    ~tool_name:"masc_keeper_msg"
+    ~tool_name:(invocation_tool_name surface)
     (`Assoc
        [ "error", `String "keeper_turn_resources_unavailable"
        ; "failure_class", `String "runtime_failure"
@@ -232,22 +253,17 @@ let turn_resources_error failure =
        ])
 ;;
 
-let preflight_keeper_msg ctx args :
-    (Keeper_invocation_contract.request, string) result =
-  let name = get_string args "name" "" in
-  let message = get_string args "message" "" in
-  match Keeper_invocation_contract.request ~keeper_name:name ~prompt:message with
-  | Error error ->
-    Error (Keeper_invocation_contract.request_error_to_string error)
-  | Ok request ->
+let preflight_keeper_invocation ~surface ctx args request =
+  let name = Keeper_invocation_contract.target_name request in
     let direct_reply = get_bool args "direct_reply" false in
-    match Keeper_meta_contract.reject_removed_model_args ~tool_name:"masc_keeper_msg" args with
+    let tool_name = invocation_tool_name surface in
+    match Keeper_meta_contract.reject_removed_model_args ~tool_name args with
     | Error e -> Error e
     | Ok () ->
-    (match reject_removed_keeper_input_keys ~tool_name:"masc_keeper_msg" args with
+    (match reject_removed_keeper_input_keys ~tool_name args with
     | Error e -> Error e
     | Ok () ->
-    (match reject_removed_keeper_msg_input_keys ~tool_name:"masc_keeper_msg" args with
+    (match reject_removed_keeper_msg_input_keys ~tool_name args with
     | Error e -> Error e
     | Ok () ->
     (match user_oas_blocks_of_args args with
@@ -272,6 +288,22 @@ let preflight_keeper_msg ctx args :
           Keeper_turn_helpers.ensure_local_discovery_ready effective_models
           |> Result.map (fun () -> request))))
 
+let preflight_keeper_msg ctx args =
+  let name = get_string args "name" "" in
+  let message = get_string args "message" "" in
+  match Keeper_invocation_contract.request ~keeper_name:name ~prompt:message with
+  | Error error -> Error (Keeper_invocation_contract.request_error_to_string error)
+  | Ok request -> preflight_keeper_invocation ~surface:Direct_message ctx args request
+;;
+
+let preflight_keeper_delegate ctx request =
+  preflight_keeper_invocation
+    ~surface:Keeper_delegate
+    ctx
+    (invocation_args request)
+    request
+;;
+
 (* -- Direct-message turn FSM wrapper ---------------------------------------- *)
 
 (** Run a direct [masc_keeper_msg] turn with the same typed FSM transitions
@@ -288,7 +320,7 @@ let preflight_keeper_msg ctx args :
 
     The wrapper is intentionally thin: it does not duplicate metrics,
     receipt, or meta writes — those remain in
-    [run_keeper_msg_turn_admitted].  It only restores FSM observability so
+    [run_keeper_invocation_turn_admitted].  It only restores FSM observability so
     direct and autonomous turns share the same state-machine read model. *)
 let run_direct_turn_with_fsm ~(keeper_name : string) ~(turn_id : int) f =
   Keeper_turn_fsm.emit_transition
@@ -372,11 +404,12 @@ let run_direct_turn_with_fsm ~(keeper_name : string) ~(turn_id : int) f =
    [handle_keeper_msg] calls this directly because the validation guard
    below exits first). Do not add keeper-state mutation ahead of the
    validation guards without moving it behind the slot. *)
-let run_keeper_msg_turn_admitted
+let run_keeper_invocation_turn_admitted
       ?on_text_delta
       ?on_event
       ?event_bus
       ?continuation_channel
+      ~surface
       ctx
       args
   : tool_result
@@ -385,7 +418,7 @@ let run_keeper_msg_turn_admitted
     ~name:"keeper_turn"
     ~attrs:[
       "keeper.name", `String (get_string args "name" "");
-      "masc.turn_type", `String "direct";
+      "masc.turn_type", `String (invocation_turn_type surface);
     ]
     (fun _trace_id ->
   let on_event =
@@ -420,13 +453,14 @@ let run_keeper_msg_turn_admitted
     let direct_reply = get_bool args "direct_reply" false in
     let channel_session_key = get_string_opt args "channel_session_key" in
     let channel = get_string args "channel" "" in
-    (match Keeper_meta_contract.reject_removed_model_args ~tool_name:"masc_keeper_msg" args with
+    let tool_name = invocation_tool_name surface in
+    (match Keeper_meta_contract.reject_removed_model_args ~tool_name args with
     | Error e -> tool_result_error ("" ^ e)
     | Ok () ->
-    (match reject_removed_keeper_input_keys ~tool_name:"masc_keeper_msg" args with
+    (match reject_removed_keeper_input_keys ~tool_name args with
     | Error e -> tool_result_error ("" ^ e)
     | Ok () ->
-    (match reject_removed_keeper_msg_input_keys ~tool_name:"masc_keeper_msg" args with
+    (match reject_removed_keeper_msg_input_keys ~tool_name args with
     | Error e -> tool_result_error ("" ^ e)
     | Ok () ->
     (match user_oas_blocks_of_args args with
@@ -443,7 +477,7 @@ let run_keeper_msg_turn_admitted
            ~base_path:ctx.config.base_path
            ~keeper_name:meta0.name
        with
-       | Error failure -> turn_resources_error failure
+       | Error failure -> turn_resources_error ~surface failure
        | Ok { entry; publication_recovery } ->
       let meta = entry.meta in
       (match
@@ -1007,13 +1041,14 @@ let run_keeper_msg_turn_admitted
 
 )))))))))
 
-let handle_keeper_msg
+let handle_keeper_invocation
       ?on_text_delta
       ?on_event
       ?event_bus
       ?continuation_channel
       ?on_admission_rejected
       ?on_admitted
+      ~surface
       ctx
       args
   : tool_result
@@ -1027,11 +1062,12 @@ let handle_keeper_msg
   if not (validate_name name) then
     (* Invalid input cannot reach run_turn; let the admitted body produce
        its precise validation error without holding the slot. *)
-    run_keeper_msg_turn_admitted
+    run_keeper_invocation_turn_admitted
       ?on_text_delta
       ?on_event
       ?event_bus
       ?continuation_channel
+      ~surface
       ctx
       args
   else
@@ -1044,22 +1080,24 @@ let handle_keeper_msg
           | Some notify ->
             (match notify () with
              | Ok () ->
-               run_keeper_msg_turn_admitted
+               run_keeper_invocation_turn_admitted
                  ?on_text_delta
                  ?on_event
                  ?event_bus
                  ?continuation_channel
+                 ~surface
                  ctx
                  args
              | Error detail ->
                tool_result_error
                  ("keeper turn admission persistence failed: " ^ detail))
           | None ->
-            run_keeper_msg_turn_admitted
+            run_keeper_invocation_turn_admitted
               ?on_text_delta
               ?on_event
               ?event_bus
               ?continuation_channel
+              ~surface
               ctx
               args)
     with
@@ -1097,6 +1135,36 @@ let handle_keeper_msg
              waiting
              in_flight_text)
 
+let handle_keeper_msg
+      ?on_text_delta
+      ?on_event
+      ?event_bus
+      ?continuation_channel
+      ?on_admission_rejected
+      ?on_admitted
+      ctx
+      args
+  =
+  handle_keeper_invocation
+    ?on_text_delta
+    ?on_event
+    ?event_bus
+    ?continuation_channel
+    ?on_admission_rejected
+    ?on_admitted
+    ~surface:Direct_message
+    ctx
+    args
+;;
+
+let handle_keeper_delegate ?event_bus ctx request =
+  handle_keeper_invocation
+    ?event_bus
+    ~surface:Keeper_delegate
+    ctx
+    (invocation_args request)
+;;
+
 let handle_keeper_msg_if_free
       ?on_text_delta
       ?on_event
@@ -1113,11 +1181,12 @@ let handle_keeper_msg_if_free
   let name = get_string args "name" "" in
   if not (validate_name name) then
     `Ran
-      (run_keeper_msg_turn_admitted
+      (run_keeper_invocation_turn_admitted
          ?on_text_delta
          ?on_event
          ?event_bus
          ?continuation_channel
+         ~surface:Direct_message
          ctx
          args)
   else
@@ -1125,10 +1194,11 @@ let handle_keeper_msg_if_free
       ~base_path:ctx.config.base_path
       ~keeper_name:name
       (fun () ->
-        run_keeper_msg_turn_admitted
+        run_keeper_invocation_turn_admitted
           ?on_text_delta
           ?on_event
           ?event_bus
           ?continuation_channel
+          ~surface:Direct_message
           ctx
           args)

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -233,11 +233,14 @@ let invocation_turn_type = function
   | Keeper_delegate -> "delegate"
 ;;
 
-let invocation_args request =
-  `Assoc
-    [ "name", `String (Keeper_invocation_contract.target_name request)
-    ; "message", `String (Keeper_invocation_contract.prompt request)
-    ]
+let direct_invocation_request args =
+  let name = get_string args "name" "" in
+  let message = get_string args "message" "" in
+  if not (validate_name name)
+  then Error (invalid_name_error name)
+  else
+    Keeper_invocation_contract.request ~keeper_name:name ~prompt:message
+    |> Result.map_error Keeper_invocation_contract.request_error_to_string
 ;;
 
 let turn_resources_error ~surface failure =
@@ -300,7 +303,7 @@ let preflight_keeper_delegate ctx request =
   preflight_keeper_invocation
     ~surface:Keeper_delegate
     ctx
-    (invocation_args request)
+    (`Assoc [])
     request
 ;;
 
@@ -399,17 +402,16 @@ let run_direct_turn_with_fsm ~(keeper_name : string) ~(turn_id : int) f =
    or a concurrent turn can clobber the checkpoint and regress
    [total_turns] (2026-06-10 RCA, RFC-0225 §1).
 
-   Precondition: the caller holds the keeper's turn slot, OR the call
-   returns before any keeper-state read/write (the invalid-name path in
-   [handle_keeper_msg] calls this directly because the validation guard
-   below exits first). Do not add keeper-state mutation ahead of the
-   validation guards without moving it behind the slot. *)
+   Precondition: the caller holds the keeper's turn slot. Public direct-message
+   and typed-delegate entrypoints construct a valid invocation request before
+   reaching this function. *)
 let run_keeper_invocation_turn_admitted
       ?on_text_delta
       ?on_event
       ?event_bus
       ?continuation_channel
       ~surface
+      ~request
       ctx
       args
   : tool_result
@@ -417,7 +419,7 @@ let run_keeper_invocation_turn_admitted
   with_span
     ~name:"keeper_turn"
     ~attrs:[
-      "keeper.name", `String (get_string args "name" "");
+      "keeper.name", `String (Keeper_invocation_contract.target_name request);
       "masc.turn_type", `String (invocation_turn_type surface);
     ]
     (fun _trace_id ->
@@ -432,13 +434,8 @@ let run_keeper_invocation_turn_admitted
              | Agent_sdk.Types.ContentBlockDelta { delta = TextDelta text; _ } -> cb text
              | _ -> ()))
   in
-  let name = get_string args "name" "" in
-  let message = get_string args "message" "" in
-  if not (validate_name name) then
-    tool_result_error (invalid_name_error name)
-  else if message = "" then
-    tool_result_error "message is required"
-  else
+  let name = Keeper_invocation_contract.target_name request in
+  let message = Keeper_invocation_contract.prompt request in
     let turn_instructions =
       match get_string_opt args "turn_instructions" with
       | Some _ as ti -> ti
@@ -1049,6 +1046,7 @@ let handle_keeper_invocation
       ?on_admission_rejected
       ?on_admitted
       ~surface
+      ~request
       ctx
       args
   : tool_result
@@ -1058,48 +1056,38 @@ let handle_keeper_invocation
     | Some _ -> event_bus
     | None -> Keeper_event_bus.get ()
   in
-  let name = get_string args "name" "" in
-  if not (validate_name name) then
-    (* Invalid input cannot reach run_turn; let the admitted body produce
-       its precise validation error without holding the slot. *)
-    run_keeper_invocation_turn_admitted
-      ?on_text_delta
-      ?on_event
-      ?event_bus
-      ?continuation_channel
-      ~surface
-      ctx
-      args
-  else
-    match
-      Keeper_turn_admission.run_serialized
-        ~base_path:ctx.config.base_path
-        ~keeper_name:name
-        (fun () ->
-          match on_admitted with
-          | Some notify ->
-            (match notify () with
-             | Ok () ->
-               run_keeper_invocation_turn_admitted
-                 ?on_text_delta
-                 ?on_event
-                 ?event_bus
-                 ?continuation_channel
-                 ~surface
-                 ctx
-                 args
-             | Error detail ->
-               tool_result_error
-                 ("keeper turn admission persistence failed: " ^ detail))
-          | None ->
-            run_keeper_invocation_turn_admitted
-              ?on_text_delta
-              ?on_event
-              ?event_bus
-              ?continuation_channel
-              ~surface
-              ctx
-              args)
+  let name = Keeper_invocation_contract.target_name request in
+  match
+    Keeper_turn_admission.run_serialized
+      ~base_path:ctx.config.base_path
+      ~keeper_name:name
+      (fun () ->
+        match on_admitted with
+        | Some notify ->
+          (match notify () with
+           | Ok () ->
+             run_keeper_invocation_turn_admitted
+               ?on_text_delta
+               ?on_event
+               ?event_bus
+               ?continuation_channel
+               ~surface
+               ~request
+               ctx
+               args
+           | Error detail ->
+             tool_result_error
+               ("keeper turn admission persistence failed: " ^ detail))
+        | None ->
+          run_keeper_invocation_turn_admitted
+            ?on_text_delta
+            ?on_event
+            ?event_bus
+            ?continuation_channel
+            ~surface
+            ~request
+            ctx
+            args)
     with
     | `Ran result -> result
     | `Rejected
@@ -1145,24 +1133,29 @@ let handle_keeper_msg
       ctx
       args
   =
-  handle_keeper_invocation
-    ?on_text_delta
-    ?on_event
-    ?event_bus
-    ?continuation_channel
-    ?on_admission_rejected
-    ?on_admitted
-    ~surface:Direct_message
-    ctx
-    args
+  match direct_invocation_request args with
+  | Error error -> tool_result_error error
+  | Ok request ->
+    handle_keeper_invocation
+      ?on_text_delta
+      ?on_event
+      ?event_bus
+      ?continuation_channel
+      ?on_admission_rejected
+      ?on_admitted
+      ~surface:Direct_message
+      ~request
+      ctx
+      args
 ;;
 
 let handle_keeper_delegate ?event_bus ctx request =
   handle_keeper_invocation
     ?event_bus
     ~surface:Keeper_delegate
+    ~request
     ctx
-    (invocation_args request)
+    (`Assoc [])
 ;;
 
 let handle_keeper_msg_if_free
@@ -1178,18 +1171,10 @@ let handle_keeper_msg_if_free
     | Some _ -> event_bus
     | None -> Keeper_event_bus.get ()
   in
-  let name = get_string args "name" "" in
-  if not (validate_name name) then
-    `Ran
-      (run_keeper_invocation_turn_admitted
-         ?on_text_delta
-         ?on_event
-         ?event_bus
-         ?continuation_channel
-         ~surface:Direct_message
-         ctx
-         args)
-  else
+  match direct_invocation_request args with
+  | Error error -> `Ran (tool_result_error error)
+  | Ok request ->
+    let name = Keeper_invocation_contract.target_name request in
     Keeper_turn_admission.run_chat_if_free
       ~base_path:ctx.config.base_path
       ~keeper_name:name
@@ -1200,5 +1185,6 @@ let handle_keeper_msg_if_free
           ?event_bus
           ?continuation_channel
           ~surface:Direct_message
+          ~request
           ctx
           args)

--- a/lib/keeper/keeper_turn.mli
+++ b/lib/keeper/keeper_turn.mli
@@ -27,6 +27,12 @@ val preflight_keeper_msg :
 (** Run synchronous validation for [handle_keeper_msg] before an async wrapper
     accepts the turn for later execution. *)
 
+val preflight_keeper_delegate :
+  _ Keeper_types_profile.context ->
+  Keeper_invocation_contract.request ->
+  (Keeper_invocation_contract.request, string) result
+(** Validate one typed delegated invocation before durable submission. *)
+
 module For_testing : sig
   val direct_owner_conversation_context :
     config:Workspace.config ->
@@ -123,6 +129,13 @@ val handle_keeper_msg :
     background turn. [on_admission_rejected] receives the typed admission
     result before the legacy tool error is rendered; queue consumers use it to
     keep a leased receipt pending without matching diagnostic strings. *)
+
+val handle_keeper_delegate :
+  ?event_bus:Agent_sdk.Event_bus.t ->
+  _ Keeper_types_profile.context ->
+  Keeper_invocation_contract.request ->
+  tool_result
+(** Run a typed delegated invocation through the same serialized Keeper lane. *)
 
 val handle_keeper_msg_if_free :
   ?on_text_delta:(string -> unit) ->

--- a/lib/keeper_invocation_types/dune
+++ b/lib/keeper_invocation_types/dune
@@ -1,0 +1,5 @@
+(library
+ (name masc_keeper_invocation_types)
+ (public_name masc.keeper_invocation_types)
+ (wrapped false)
+ (libraries masc.keeper_registry yojson))

--- a/lib/keeper_invocation_types/keeper_invocation_types.ml
+++ b/lib/keeper_invocation_types/keeper_invocation_types.ml
@@ -1,0 +1,53 @@
+type capability = Invoke_turn
+type target = Keeper of Keeper_id.Keeper_name.t
+
+type run_ref = { run_id : string; target : target; capability : capability }
+
+type result_contract =
+  | Awaiting_execution
+  | Publication_uncertain
+  | Running
+  | Yielded
+  | Cancellation_requested
+  | Cancelled
+  | Completed
+  | Failed
+
+let target_name = function Keeper name -> Keeper_id.Keeper_name.to_string name
+
+let target_to_json target =
+  `Assoc [ "kind", `String "keeper"; "name", `String (target_name target) ]
+
+let run_id reference = reference.run_id
+let run_ref_target_name reference = target_name reference.target
+
+let run_ref_to_json reference =
+  `Assoc
+    [ "run_id", `String reference.run_id
+    ; "target", target_to_json reference.target
+    ; "capability", `String "invoke_turn"
+    ]
+;;
+
+let result_contract_to_string = function
+  | Awaiting_execution -> "awaiting_execution"
+  | Publication_uncertain -> "publication_uncertain"
+  | Running -> "running"
+  | Yielded -> "yielded"
+  | Cancellation_requested -> "cancellation_requested"
+  | Cancelled -> "cancelled"
+  | Completed -> "completed"
+  | Failed -> "failed"
+;;
+
+let result_contract_of_string = function
+  | "awaiting_execution" -> Some Awaiting_execution
+  | "publication_uncertain" -> Some Publication_uncertain
+  | "running" -> Some Running
+  | "yielded" -> Some Yielded
+  | "cancellation_requested" -> Some Cancellation_requested
+  | "cancelled" -> Some Cancelled
+  | "completed" -> Some Completed
+  | "failed" -> Some Failed
+  | _ -> None
+;;

--- a/lib/keeper_invocation_types/keeper_invocation_types.mli
+++ b/lib/keeper_invocation_types/keeper_invocation_types.mli
@@ -1,0 +1,24 @@
+(** Typed Keeper invocation wire identity and result vocabulary. Durable
+    execution and lane admission remain in the Keeper implementation. *)
+type capability = Invoke_turn
+type target = Keeper of Keeper_id.Keeper_name.t
+
+type run_ref = { run_id : string; target : target; capability : capability }
+
+type result_contract =
+  | Awaiting_execution
+  | Publication_uncertain
+  | Running
+  | Yielded
+  | Cancellation_requested
+  | Cancelled
+  | Completed
+  | Failed
+
+val target_name : target -> string
+val target_to_json : target -> Yojson.Safe.t
+val run_id : run_ref -> string
+val run_ref_target_name : run_ref -> string
+val run_ref_to_json : run_ref -> Yojson.Safe.t
+val result_contract_to_string : result_contract -> string
+val result_contract_of_string : string -> result_contract option

--- a/lib/keeper_tooling/keeper_tool_name.ml
+++ b/lib/keeper_tooling/keeper_tool_name.ml
@@ -35,7 +35,7 @@ type t =
   | Library_search
   | Memory_search
   | Memory_write
-  | Keeper_msg
+  | Keeper_delegate
   | Search_files
   | Surface_read
   | Surface_post
@@ -86,7 +86,7 @@ let all : t list =
   ; Library_search
   ; Memory_search
   ; Memory_write
-  ; Keeper_msg
+  ; Keeper_delegate
   ; Search_files
   ; Surface_read
   ; Surface_post
@@ -139,7 +139,7 @@ let to_string = function
   | Library_search -> "keeper_library_search"
   | Memory_search -> "keeper_memory_search"
   | Memory_write -> "keeper_memory_write"
-  | Keeper_msg -> "masc_keeper_msg"
+  | Keeper_delegate -> "masc_keeper_delegate"
   | Search_files -> "tool_search_files"
   | Surface_read -> "keeper_surface_read"
   | Surface_post -> "keeper_surface_post"
@@ -191,7 +191,7 @@ let of_string = function
   | "keeper_library_search" -> Some Library_search
   | "keeper_memory_search" -> Some Memory_search
   | "keeper_memory_write" -> Some Memory_write
-  | "masc_keeper_msg" -> Some Keeper_msg
+  | "masc_keeper_delegate" -> Some Keeper_delegate
   | "tool_search_files" -> Some Search_files
   | "keeper_surface_read" -> Some Surface_read
   | "keeper_surface_post" -> Some Surface_post

--- a/lib/keeper_tooling/keeper_tool_name.mli
+++ b/lib/keeper_tooling/keeper_tool_name.mli
@@ -33,7 +33,7 @@ type t =
   | Library_search
   | Memory_search
   | Memory_write
-  | Keeper_msg
+  | Keeper_delegate
   | Search_files
   | Surface_read
   | Surface_post

--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -220,36 +220,24 @@ let execute_keeper_action (ctx : 'a context) (request : action_request) =
         | None -> Error "payload.message is required"
       in
       let* () =
-        Keeper_meta_contract.reject_removed_model_args ~tool_name:"masc_keeper_msg"
+        Keeper_meta_contract.reject_removed_model_args ~tool_name:"masc_keeper_delegate"
           request.payload
-      in
-      let direct_reply =
-        Json_util.get_bool request.payload "direct_reply" |> Option.value ~default:false
-      in
-      let timeout_sec =
-        Json_util.get_float request.payload "timeout_sec"
-        |> Option.map (fun f -> int_of_float (Float.ceil f))
-        |> (fun o -> match o with Some n when n > 0 -> Some n | _ -> None)
       in
       let args =
         `Assoc
-          (([
-              ("name", `String name);
-              ("message", `String message);
-            ]
-            @ if direct_reply then [ ("direct_reply", `Bool true) ] else [])
-           @
-           match timeout_sec with
-           | Some value -> [ ("timeout_sec", `Int value) ]
-           | None -> [])
+          [ ( "target"
+            , `Assoc [ "kind", `String "keeper"; "name", `String name ] )
+          ; "capability", `String "invoke_turn"
+          ; "prompt", `String message
+          ]
       in
       let* result =
-        dispatch_keeper_json ctx ~tool_name:"masc_keeper_msg" ~args
+        dispatch_keeper_json ctx ~tool_name:"masc_keeper_delegate" ~args
       in
       Ok
         (`Assoc
           [
-            ("tool_name", `String "masc_keeper_msg");
+            ("tool_name", `String "masc_keeper_delegate");
             ("result", result);
           ])
   | _ -> Error (Printf.sprintf "not a keeper action: %s" request.action_type)

--- a/lib/operator/operator_pending_confirm.ml
+++ b/lib/operator/operator_pending_confirm.ml
@@ -336,7 +336,7 @@ let available_actions : available_action list =
     make_available_action ~action_type:"task_inject" ~tool_name:"masc_add_task"
       ~target_type:Operator_action_constants.workspace_target_type
       ~description:"Inject a backlog task into the namespace.";
-    make_available_action ~action_type:"keeper_message" ~tool_name:"masc_keeper_msg"
+    make_available_action ~action_type:"keeper_message" ~tool_name:"masc_keeper_delegate"
       ~target_type:Operator_action_constants.keeper_target_type
       ~description:"Send a direct operator message to a keeper.";
     make_available_action ~action_type:"keeper_probe" ~tool_name:"masc_keeper_status"

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -656,7 +656,7 @@ let dashboard_shell_auth_json ~(request : Httpun.Request.t) (config : Workspace.
     | Ok () ->
       (match
          ensure_strict_http_token_auth
-           ~endpoint:"HTTP tool access for masc_keeper_msg"
+           ~endpoint:"HTTP tool access for masc_keeper_delegate"
            auth_cfg
        with
        | Ok _ -> Ok ()
@@ -670,7 +670,7 @@ let dashboard_shell_auth_json ~(request : Httpun.Request.t) (config : Workspace.
       (match resolved_agent_name_result, effective_role_result with
        | Error err, _ | _, Error err -> Error err
        | Ok agent_name, Ok role ->
-         Auth.authorize_tool_for_role ~agent_name ~role ~tool_name:"masc_keeper_msg")
+         Auth.authorize_tool_for_role ~agent_name ~role ~tool_name:"masc_keeper_delegate")
   in
   let can_keeper_msg, keeper_msg_error =
     match keeper_authorization_result with

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -563,13 +563,13 @@ let execute_keeper_stream_tool
         }
       in
       match
-        Keeper_tool_surface.dispatch
+        Keeper_tool_surface.dispatch_keeper_msg
+          ~submitted_by:agent_name
           ~continuation_channel
           keeper_ctx
-          ~name:"masc_keeper_msg"
           ~args:arguments
       with
-      | Some result ->
+      | result ->
           let success = Tool_result.is_success result in
           let body = Tool_result.message result in
           let failure_class =
@@ -578,7 +578,6 @@ let execute_keeper_stream_tool
             | None -> Tool_result.Runtime_failure
           in
           success, body, failure_class
-      | None -> false, "masc_keeper_msg dispatch unavailable", Tool_result.Runtime_failure
     with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
     | Workspace.Not_initialized ->
@@ -813,7 +812,7 @@ let keeper_stream_send_event ?on_closed writer mutex closed event =
   keeper_stream_send_raw ?on_closed writer mutex closed (Ag_ui.event_to_sse event)
 
 (** Execute keeper dispatch with real-time streaming.
-    Calls [dispatch_stream] which forwards MODEL text deltas to [on_text_delta].
+    Calls the private direct-delivery stream which forwards MODEL text deltas to [on_text_delta].
     Projects the typed keeper result into the local HTTP stream response pair.
     No external timeout — keeper internal limits control duration
     (aligned with MCP path, see mcp_server_eio_call_tool.ml:139-143). *)
@@ -848,13 +847,12 @@ let execute_keeper_stream_tool_streaming
         }
       in
       match
-        Keeper_tool_surface.dispatch_stream ~on_text_delta ?on_event
+        Keeper_tool_surface.dispatch_keeper_msg_stream ~on_text_delta ?on_event
           ~on_admission_rejected:(fun rejection ->
             admission_rejection := Some rejection)
           ?on_admitted
           keeper_ctx
           ~continuation_channel
-          ~name:"masc_keeper_msg"
           ~args:arguments
       with
       | Some result ->

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -377,18 +377,21 @@ let dispatch_board_context_inference ~state ~sw ~clock ~request ~target_keeper
           board_context_inference_surface_context post comments );
       ]
   in
-  match Keeper_tool_surface.dispatch keeper_ctx ~name:"masc_keeper_msg" ~args with
-  | None -> Error (`Internal_server_error "masc_keeper_msg tool is unavailable")
-  | Some result ->
-      if Tool_result.is_success result
-      then
-        (match
-           board_context_inference_submission_json ~post_id ~target_source
-             (Tool_result.data result)
-         with
-         | Ok json -> Ok json
-         | Error msg -> Error (`Internal_server_error msg))
-      else Error (`Bad_request (Tool_result.message result))
+  let result =
+    Keeper_tool_surface.dispatch_keeper_msg
+      ~submitted_by:agent_name
+      keeper_ctx
+      ~args
+  in
+  if Tool_result.is_success result
+  then
+    (match
+       board_context_inference_submission_json ~post_id ~target_source
+         (Tool_result.data result)
+     with
+     | Ok json -> Ok json
+     | Error msg -> Error (`Internal_server_error msg))
+  else Error (`Bad_request (Tool_result.message result))
 
 let respond_board_context_inference_error request reqd ~status ~message =
   respond_json_value_with_cors ~status request reqd
@@ -722,7 +725,7 @@ let add_routes ~sw ~clock router =
        respond_board_json reqd (board_sub_boards_json ()))
 
   |> Http.Router.post "/api/v1/board/context-inference" (fun request reqd ->
-       with_tool_auth ~tool_name:"masc_keeper_msg"
+       with_tool_auth ~tool_name:"masc_keeper_delegate"
          (fun state _req reqd ->
          Http.Request.read_body_async reqd
            (handle_board_context_inference_request ~state ~sw ~clock ~request

--- a/lib/server/server_routes_http_routes_channel_gate.ml
+++ b/lib/server/server_routes_http_routes_channel_gate.ml
@@ -514,14 +514,14 @@ let add_routes ~sw ~clock router =
        ) request reqd)
 
   |> Http.Router.prefix_get "/api/v1/gate/message/requests/" (fun request reqd ->
-       with_tool_actor_auth ~tool_name:"masc_keeper_msg_result"
+       with_tool_actor_auth ~tool_name:"masc_keeper_delegate_status"
          (fun state caller _req reqd ->
            Server_routes_http_keeper_stream.handle_keeper_chat_request_result
              ~caller state request reqd)
          request reqd)
 
   |> Http.Router.prefix_post "/api/v1/gate/message/requests/" (fun request reqd ->
-       with_tool_actor_auth ~tool_name:"masc_keeper_msg_cancel"
+       with_tool_actor_auth ~tool_name:"masc_keeper_delegate_cancel"
          (fun state caller _req reqd ->
            Server_routes_http_keeper_stream.handle_keeper_chat_request_cancel
              ~caller state request reqd)

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -1627,7 +1627,7 @@ let add_routes ~sw ~clock router =
          request reqd)
 
   |> Http.Router.post "/api/v1/keepers/chat/stream" (fun request reqd ->
-       with_tool_actor_auth ~tool_name:"masc_keeper_msg" (fun state submitted_by _req reqd ->
+       with_tool_actor_auth ~tool_name:"masc_keeper_delegate" (fun state submitted_by _req reqd ->
          Http.Request.read_body_async reqd (fun body_str ->
            match parse_keeper_chat_stream_request body_str with
            | Ok payload ->
@@ -1646,13 +1646,13 @@ let add_routes ~sw ~clock router =
        ) request reqd)
 
   |> Http.Router.prefix_get "/api/v1/keepers/chat/requests/" (fun request reqd ->
-       with_tool_actor_auth ~tool_name:"masc_keeper_msg_result"
+       with_tool_actor_auth ~tool_name:"masc_keeper_delegate_status"
          (fun state caller _req reqd ->
            handle_keeper_chat_request_result ~caller state request reqd)
          request reqd)
 
   |> Http.Router.prefix_post "/api/v1/keepers/chat/requests/" (fun request reqd ->
-       with_tool_actor_auth ~tool_name:"masc_keeper_msg_cancel"
+       with_tool_actor_auth ~tool_name:"masc_keeper_delegate_cancel"
          (fun state caller _req reqd ->
            handle_keeper_chat_request_cancel ~caller state request reqd)
          request reqd)
@@ -1670,7 +1670,7 @@ let add_routes ~sw ~clock router =
          ) request reqd)
 
   |> Http.Router.post "/api/v1/keepers/turn/interrupt" (fun request reqd ->
-       with_tool_auth ~tool_name:"masc_keeper_msg" (fun state _req reqd ->
+       with_tool_auth ~tool_name:"masc_keeper_delegate_cancel" (fun state _req reqd ->
          handle_keeper_turn_interrupt state request reqd) request reqd)
 
   (* Keeper POST sub-routes. *)

--- a/lib/tool/tool_catalog.ml
+++ b/lib/tool/tool_catalog.ml
@@ -277,10 +277,10 @@ let explicit_metadata : (string * metadata) list =
     ("masc_keeper_sandbox_start", broadcast_tool);
     ("masc_keeper_sandbox_stop", mutating_tool);
     ("masc_keeper_create_from_persona", broadcast_tool);
-    ("masc_keeper_msg", broadcast_tool);
-    ("masc_keeper_msg_result", read_state_tool);
-    ("masc_keeper_msg_cancel", broadcast_tool);
-    ("masc_keeper_msg_queue", read_state_tool);
+    ("masc_keeper_delegate", broadcast_tool);
+    ("masc_keeper_delegate_status", read_state_tool);
+    ("masc_keeper_delegate_cancel", broadcast_tool);
+    ("masc_keeper_delegate_list", read_state_tool);
     ("masc_keeper_persona_audit", read_state_tool);
     ("masc_keeper_sandbox_status", read_state_tool);
     ("masc_keeper_waiting_inventory", read_state_tool);

--- a/test/test_copilot_dock_channel_wiring.ml
+++ b/test/test_copilot_dock_channel_wiring.ml
@@ -1,7 +1,7 @@
 (* Tests for dashboard Copilot Dock -> keeper chat stream wiring.
 
    Verifies the shared contract from the HTTP parser down to the
-   [masc_keeper_msg] args that [Keeper_tool_surface.dispatch_stream]
+   private direct-message args that the direct-delivery stream
    receives:
    - copilot channel label + operator workspace id parse without requiring
      an external user id;

--- a/test/test_dashboard_briefing.ml
+++ b/test/test_dashboard_briefing.ml
@@ -70,7 +70,7 @@ let write_pending_confirm config _session_id =
             ("target_type", `String "keeper");
             ("target_id", `String "fixture-keeper");
             ("payload", `Assoc [ ("reason", `String "fixture pending confirmation") ]);
-            ("delegated_tool", `String "masc_keeper_msg");
+            ("delegated_tool", `String "masc_keeper_delegate");
             ("created_at", `String (Masc_domain.now_iso ()));
             ("expires_at", `Null);
           ];

--- a/test/test_keeper_busy_dashboard_deferred.ml
+++ b/test/test_keeper_busy_dashboard_deferred.ml
@@ -103,6 +103,19 @@ let with_busy_slots ~base ~sw keeper_names f =
     f
 ;;
 
+let seed_keeper config =
+  let meta =
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+         [ "name", `String keeper_name
+         ; "agent_name", `String ("keeper-" ^ keeper_name)
+         ; "trace_id", `String ("trace-" ^ keeper_name)
+         ])
+    |> Result.get_ok
+  in
+  Keeper_meta_store.write_meta config meta |> Result.get_ok
+;;
+
 let test_busy_dashboard_enqueues () =
   Printf.printf "Test: busy dashboard dispatch enqueues onto Keeper_chat_queue\n%!";
   with_env
@@ -379,6 +392,84 @@ let test_stream_surface_preserves_typed_shutdown_rejection () =
     check "stream surface emits a typed shutdown rejection" false
 ;;
 
+let test_delegate_surface_uses_serialized_shutdown_fence () =
+  Printf.printf "Test: typed delegate uses the serialized Keeper lane\n%!";
+  with_env
+  @@ fun ~base ~clock ->
+  let operation_id = Keeper_shutdown_types.Operation_id.generate () in
+  ignore
+    (Keeper_turn_admission.begin_shutdown ~base_path:base ~keeper_name
+       ~operation_id
+      : Keeper_turn_admission.begin_shutdown_result);
+  Eio.Switch.run
+  @@ fun sw ->
+  let request =
+    Keeper_invocation_contract.request
+      ~keeper_name
+      ~prompt:"typed delegated turn"
+    |> Result.get_ok
+  in
+  let ctx : _ Keeper_types_profile.context =
+    { config = Workspace.default_config base
+    ; agent_name = "delegate-shutdown-test"
+    ; sw
+    ; clock
+    ; proc_mgr = None
+    ; net = None
+    ; publication_recovery_provider =
+        Masc_test_deps.non_runtime_publication_recovery_provider
+    }
+  in
+  let result = Keeper_turn.handle_keeper_delegate ctx request in
+  let message = Tool_result.message result in
+  check "shutdown-fenced delegate does not run" (not (Tool_result.is_success result));
+  check "delegate observes the exact shutdown owner"
+    (Astring.String.is_infix
+       ~affix:
+         ("stopping under operation "
+          ^ Keeper_shutdown_types.Operation_id.to_string operation_id)
+       message);
+  check "delegate error does not inherit the removed tool name"
+    (not (Astring.String.is_infix ~affix:"masc_keeper_msg" message))
+;;
+
+let test_delegate_resource_error_uses_typed_tool_name () =
+  Printf.printf "Test: typed delegate owns its failure identity\n%!";
+  with_env
+  @@ fun ~base ~clock ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let config = Workspace.default_config base in
+  seed_keeper config;
+  let request =
+    Keeper_invocation_contract.request
+      ~keeper_name
+      ~prompt:"typed prompt remains on the invocation"
+    |> Result.get_ok
+  in
+  let ctx : _ Keeper_types_profile.context =
+    { config
+    ; agent_name = "delegate-resource-test"
+    ; sw
+    ; clock
+    ; proc_mgr = None
+    ; net = None
+    ; publication_recovery_provider =
+        Masc_test_deps.non_runtime_publication_recovery_provider
+    }
+  in
+  let result = Keeper_turn.handle_keeper_delegate ctx request in
+  check "non-runtime resource boundary fails explicitly"
+    (not (Tool_result.is_success result));
+  check "delegate failure carries the typed tool name"
+    (String.equal "masc_keeper_delegate" (Tool_result.tool_name result));
+  check "typed prompt is not rejected as a missing legacy message"
+    (not
+       (Astring.String.is_infix
+          ~affix:"message is required"
+          (Tool_result.message result)))
+;;
+
 let () =
   test_busy_dashboard_enqueues ();
   test_free_dashboard_not_enqueued ();
@@ -388,6 +479,8 @@ let () =
   test_stream_headers_close_per_turn_response ();
   test_shutdown_fenced_dashboard_ack_preserves_cause ();
   test_stream_surface_preserves_typed_shutdown_rejection ();
+  test_delegate_surface_uses_serialized_shutdown_fence ();
+  test_delegate_resource_error_uses_typed_tool_name ();
   if !failures > 0
   then (
     Printf.printf "FAILED: %d check(s)\n%!" !failures;

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -1206,9 +1206,9 @@ let test_run_tools_setup_has_no_direct_public_mcp_catalog_read () =
    [internal_descriptors]. *)
 let cluster_projection_table =
   [ "masc_keeper_list", "tool_masc_keeper_dispatch"
-  ; "masc_keeper_msg_result", "tool_masc_keeper_dispatch"
-  ; "masc_keeper_msg_cancel", "tool_masc_keeper_dispatch"
-  ; "masc_keeper_msg_queue", "tool_masc_keeper_dispatch"
+  ; "masc_keeper_delegate_status", "tool_masc_keeper_dispatch"
+  ; "masc_keeper_delegate_cancel", "tool_masc_keeper_dispatch"
+  ; "masc_keeper_delegate_list", "tool_masc_keeper_dispatch"
   ; "masc_keeper_compact", "tool_masc_keeper_dispatch"
   ; "masc_keeper_clear", "tool_masc_keeper_dispatch"
   ; "masc_keeper_sandbox_start", "tool_masc_keeper_dispatch"
@@ -1217,7 +1217,7 @@ let cluster_projection_table =
   ; "masc_keeper_persona_audit", "tool_masc_keeper_dispatch"
   ; "masc_keeper_status", "tool_masc_keeper_dispatch"
   ; "masc_keeper_down", "tool_masc_keeper_dispatch"
-  ; "masc_keeper_msg", "tool_masc_keeper_dispatch"
+  ; "masc_keeper_delegate", "tool_masc_keeper_dispatch"
   ; "masc_keeper_up", "tool_masc_keeper_dispatch"
   ]
 ;;

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -2207,15 +2207,15 @@ let test_tool_execute_raw_cmd_requires_typed_shell_ir () =
         List.iter (check string "repeated failures stay byte-identical" first) rest
       | [] -> fail "expected dispatch outputs")
 
-let keeper_msg_input_schema () =
+let keeper_delegate_input_schema () =
   match
     List.find_opt
       (fun (schema : Masc_domain.tool_schema) ->
-        String.equal schema.name "masc_keeper_msg")
+        String.equal schema.name "masc_keeper_delegate")
       Masc.Keeper_schema.schemas
   with
   | Some schema -> schema.input_schema
-  | None -> fail "masc_keeper_msg schema missing"
+  | None -> fail "masc_keeper_delegate schema missing"
 
 let test_oas_handler_threads_eio_context_to_keeper_dispatch () =
   let dir = temp_dir "oas-handler-eio-context" in
@@ -2262,7 +2262,7 @@ let test_oas_handler_threads_eio_context_to_keeper_dispatch () =
                  ?sw ?clock ?proc_mgr:_ ?net:_ ?mcp_session_id:_
                  ?authorize_external_effect:_
                  ~name ~args:_ () ->
-              check string "keeper dispatch tool" "masc_keeper_msg" name;
+              check string "keeper dispatch tool" "masc_keeper_delegate" name;
               Atomic.set saw_turn_sw
                 (match sw with Some sw -> sw == turn_sw | None -> false);
               Atomic.set saw_clock (Option.is_some clock);
@@ -2270,11 +2270,11 @@ let test_oas_handler_threads_eio_context_to_keeper_dispatch () =
                 (observed_provider == publication_recovery.provider);
               Some
                 (Tool_result.ok ~tool_name:name ~start_time:0.0
-                   "{\"ok\":true,\"request_id\":\"test-request\"}"));
+                   "{\"ok\":true,\"run_ref\":{\"run_id\":\"test-run\"}}"));
           let handler =
             Masc.Keeper_tools_oas_handler.make_keeper_tool_handler
-              ~name:"masc_keeper_msg"
-              ~input_schema:(keeper_msg_input_schema ())
+              ~name:"masc_keeper_delegate"
+              ~input_schema:(keeper_delegate_input_schema ())
               ~config
               ~meta
               ~publication_recovery
@@ -2285,9 +2285,13 @@ let test_oas_handler_threads_eio_context_to_keeper_dispatch () =
           let result =
             handler
               (`Assoc
-                [
-                  ("name", `String "keeper-target");
-                  ("message", `String "hello");
+                [ ( "target"
+                  , `Assoc
+                      [ "kind", `String "keeper"
+                      ; "name", `String "keeper-target"
+                      ] )
+                ; "capability", `String "invoke_turn"
+                ; "prompt", `String "hello"
                 ])
           in
           check bool "handler succeeds" true (Tool_result.is_success result);

--- a/test/test_keeper_tool_matrix_cases.ml
+++ b/test/test_keeper_tool_matrix_cases.ml
@@ -510,7 +510,7 @@ let extra_guard_fragments_for_name = function
         "\"reason\":\"disabled\"";
       ]
   | "masc_library_promote" -> [ "no candidate matching" ]
-  | "masc_keeper_msg" ->
+  | "masc_keeper_delegate" ->
       [
         "keeper management tool";
         "use MCP client";
@@ -523,8 +523,9 @@ let extra_guard_fragments_for_name = function
         "docker_container_start_failed";
         "no such container";
       ]
-  | "masc_keeper_list" | "masc_keeper_msg_result"
-  | "masc_keeper_msg_cancel" | "masc_keeper_msg_queue" | "masc_keeper_status" ->
+  | "masc_keeper_list" | "masc_keeper_delegate_status"
+  | "masc_keeper_delegate_cancel" | "masc_keeper_delegate_list"
+  | "masc_keeper_status" ->
       [ "keeper management tool"; "use MCP client" ]
   | "masc_keeper_up" -> [ "server_initializing" ]
   | "tool_execute" -> [ "worktree not found" ]

--- a/test/test_keeper_tool_name.ml
+++ b/test/test_keeper_tool_name.ml
@@ -1,13 +1,13 @@
 open Alcotest
 
 let test_keeper_msg_round_trip () =
-  let name = Keeper_tool_name.to_string Keeper_tool_name.Keeper_msg in
-  check string "wire name" "masc_keeper_msg" name;
+  let name = Keeper_tool_name.to_string Keeper_tool_name.Keeper_delegate in
+  check string "wire name" "masc_keeper_delegate" name;
   check
     bool
     "typed parse"
     true
-    (Keeper_tool_name.of_string name = Some Keeper_tool_name.Keeper_msg)
+    (Keeper_tool_name.of_string name = Some Keeper_tool_name.Keeper_delegate)
 ;;
 
 let () =

--- a/test/test_keeper_tool_resolution.ml
+++ b/test/test_keeper_tool_resolution.ml
@@ -58,7 +58,9 @@ let test_descriptor_registry_admits_masc_keeper_cluster () =
           fail (Printf.sprintf
                   "%s must resolve (boot policy gate would exit 1), got Unknown (tried: %s)"
                   name (TR.string_of_tried tried)))
-    [ "masc_keeper_msg"; "masc_keeper_msg_result"; "masc_keeper_msg_cancel"; "masc_keeper_msg_queue"; "masc_keeper_list"; "masc_keeper_status" ]
+    [ "masc_keeper_delegate"; "masc_keeper_delegate_status"
+    ; "masc_keeper_delegate_cancel"; "masc_keeper_delegate_list"
+    ; "masc_keeper_list"; "masc_keeper_status" ]
 
 let test_keeper_report_state_removed () =
   match TR.resolve "keeper_report_state" with
@@ -201,10 +203,10 @@ let policy_tool_names =
       "masc_goal_upsert";
       "masc_heartbeat";
       "masc_keeper_list";
-      "masc_keeper_msg";
-      "masc_keeper_msg_result";
-      "masc_keeper_msg_cancel";
-      "masc_keeper_msg_queue";
+      "masc_keeper_delegate";
+      "masc_keeper_delegate_status";
+      "masc_keeper_delegate_cancel";
+      "masc_keeper_delegate_list";
       "masc_keeper_status";
       "masc_messages";
       "masc_plan_get";

--- a/test/test_keeper_unified_turn_event_bus.ml
+++ b/test/test_keeper_unified_turn_event_bus.ml
@@ -455,6 +455,11 @@ let test_typed_keeper_invocation_wire_contract () =
   in
   check string "typed target decoded" "projection-keeper"
     (Invocation.target_name request);
+  check string "leaf result codec" "awaiting_execution"
+    (Keeper_invocation_types.result_contract_to_string Invocation.Awaiting_execution);
+  check bool "leaf parser preserves the shared type" true
+    (Keeper_invocation_types.result_contract_of_string "running"
+     = Some Invocation.Running);
   (match
      Invocation.request_of_json
        (`Assoc [ "name", `String "projection-keeper"; "message", `String "legacy" ])

--- a/test/test_keeper_unified_turn_event_bus.ml
+++ b/test/test_keeper_unified_turn_event_bus.ml
@@ -439,6 +439,95 @@ let test_keeper_msg_submission_projection_has_unique_keys () =
     (Invocation.result_contract failed_entry = Invocation.Failed)
 ;;
 
+let test_typed_keeper_invocation_wire_contract () =
+  let request_json =
+    `Assoc
+      [ ( "target"
+        , `Assoc [ "kind", `String "keeper"; "name", `String "projection-keeper" ] )
+      ; "capability", `String "invoke_turn"
+      ; "prompt", `String "inspect this request"
+      ]
+  in
+  let request =
+    match Invocation.request_of_json request_json with
+    | Ok request -> request
+    | Error error -> Alcotest.fail (Invocation.request_error_to_string error)
+  in
+  check string "typed target decoded" "projection-keeper"
+    (Invocation.target_name request);
+  (match
+     Invocation.request_of_json
+       (`Assoc [ "name", `String "projection-keeper"; "message", `String "legacy" ])
+   with
+   | Error (Invocation.Invalid_wire_value _) -> ()
+   | Error error ->
+     Alcotest.failf "unexpected legacy-input rejection: %s"
+       (Invocation.request_error_to_string error)
+   | Ok _ -> Alcotest.fail "legacy name/message input must not decode");
+  let outcome : Kmsg.submit_outcome =
+    { request_id = "typed-run-ref"; acceptance = Kmsg.Durably_accepted }
+  in
+  let submission_fields =
+    Invocation.delegate_submission_to_json request outcome
+    |> require_unique_assoc "typed submission"
+  in
+  check bool "raw request id omitted" false
+    (List.mem_assoc "request_id" submission_fields);
+  check bool "legacy status omitted" false
+    (List.mem_assoc "status" submission_fields);
+  let run_ref_json =
+    match List.assoc_opt "run_ref" submission_fields with
+    | Some value -> value
+    | None -> Alcotest.fail "typed submission missing run_ref"
+  in
+  let run_ref =
+    match Invocation.run_ref_of_json run_ref_json with
+    | Ok reference -> reference
+    | Error error -> Alcotest.fail (Invocation.request_error_to_string error)
+  in
+  let entry : Kmsg.entry =
+    { request_id = "typed-run-ref"
+    ; keeper_name = "projection-keeper"
+    ; base_path = "/projection/base"
+    ; submitted_by = "projection-caller"
+    ; status = Kmsg.Running
+    ; submitted_at = 0.0
+    ; completed_at = None
+    }
+  in
+  check bool "run ref binds exact durable entry" true
+    (Invocation.run_ref_matches_entry run_ref entry);
+  let wrong_target_ref =
+    match
+      Invocation.run_ref_of_json
+        (`Assoc
+           [ "run_id", `String "typed-run-ref"
+           ; "target", `Assoc [ "kind", `String "keeper"; "name", `String "other" ]
+           ; "capability", `String "invoke_turn"
+           ])
+    with
+    | Ok reference -> reference
+    | Error error -> Alcotest.fail (Invocation.request_error_to_string error)
+  in
+  check bool "same run id cannot retarget invocation" false
+    (Invocation.run_ref_matches_entry wrong_target_ref entry);
+  let entry_fields =
+    match Invocation.delegate_entry_to_json entry with
+    | Ok json -> require_unique_assoc "typed entry" json
+    | Error error -> Alcotest.fail (Invocation.request_error_to_string error)
+  in
+  check bool "entry omits raw request id" false
+    (List.mem_assoc "request_id" entry_fields);
+  check bool "entry exposes result contract" true
+    (List.mem_assoc "result_contract" entry_fields);
+  let cancellation_fields =
+    Invocation.delegate_cancellation_to_json run_ref Kmsg.Cancel_not_found
+    |> require_unique_assoc "typed cancellation"
+  in
+  check bool "cancellation omits raw request id" false
+    (List.mem_assoc "request_id" cancellation_fields)
+;;
+
 let test_take_drain_cancel_clears_active_without_spin () =
   let open EB.For_testing in
   let t = EB.create ~keeper_name:"k" ~turn_id:1 () in
@@ -522,6 +611,8 @@ let () =
             test_keeper_msg_async_submit_uses_captured_event_bus
         ; test_case "keeper msg submission JSON keys are unique" `Quick
             test_keeper_msg_submission_projection_has_unique_keys
+        ; test_case "typed Keeper invocation wire contract" `Quick
+            test_typed_keeper_invocation_wire_contract
         ] )
     ; ( "background-drain"
       , [ test_case "continues after first poll" `Quick

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -87,7 +87,7 @@ let strict_success_names =
 let strict_guard_cases =
   [
     ("masc_reset", [ "confirm" ]);
-    ("masc_keeper_msg", [ "requires Eio context" ]);
+    ("masc_keeper_delegate", [ "requires Eio context" ]);
   ]
 
 let endpoint_unavailable_guard_names =
@@ -108,9 +108,9 @@ let endpoint_unavailable_guard_fragments =
 
 let generic_matrix_excluded_names =
   [
-    "masc_keeper_msg";
+    "masc_keeper_delegate";
     "masc_operator_snapshot";
-    (* Excluded: masc_keeper_msg / masc_operator_snapshot require a live
+    (* Excluded: masc_keeper_delegate / masc_operator_snapshot require a live
        keeper context to pass tag_registry validation in the standalone runner.
        TODO: wire into the matrix runner with a minimal keeper stub,
        or split into a keeper-matrix suite. *)
@@ -656,8 +656,16 @@ let field_value fixture ~tool_name field_name schema =
           "masc_keeper_up";
         ] ->
       `String "bad keeper!"
-  | "name" when tool_name = "masc_keeper_msg" ->
-      `String "bad keeper!"
+  | "target" when tool_name = "masc_keeper_delegate" ->
+      `Assoc [ "kind", `String "keeper"; "name", `String "bad keeper!" ]
+  | "run_ref"
+    when List.mem tool_name
+           [ "masc_keeper_delegate_status"; "masc_keeper_delegate_cancel" ] ->
+      `Assoc
+        [ "run_id", `String "missing-run"
+        ; "target", `Assoc [ "kind", `String "keeper"; "name", `String "tool-matrix" ]
+        ; "capability", `String "invoke_turn"
+        ]
   | "name" -> `String "tool-matrix"
   | "verification_id" -> `String (ensure_verification_request fixture)
   | "verifier" -> `String fixture.agent_name

--- a/test/test_tool_contract_truth.ml
+++ b/test/test_tool_contract_truth.ml
@@ -110,8 +110,8 @@ let test_keeper_lifecycle_front_door_is_public () =
           "masc_keeper_up";
           "masc_keeper_down";
         ];
-      check bool "async keeper msg remains hidden by default" false
-        (List.mem "masc_keeper_msg" names))
+      check bool "async keeper delegation remains hidden by default" false
+        (List.mem "masc_keeper_delegate" names))
 
 let test_selected_tools_report_contract_status () =
   Eio_main.run @@ fun env ->

--- a/test/test_tool_resolution_runtime_projection.ml
+++ b/test/test_tool_resolution_runtime_projection.ml
@@ -20,14 +20,14 @@ module TR = Masc.Keeper_tool_resolution
 let names_to_probe =
   [ "tool_execute"
   ; "tool_edit_file"
-  ; "masc_keeper_msg"
+  ; "masc_keeper_delegate"
   ; "masc_keeper_sandbox_start"
   ; "masc_status"
   ; "masc_add_task"
   ; "mcp__masc__tool_execute"
   ; "mcp__masc__masc_status"
   ; "mcp__masc__masc_broadcast"
-  ; "mcp__masc__masc_keeper_msg"
+  ; "mcp__masc__masc_keeper_delegate"
   ; "_definitely_unknown_tool_zzz"
   ; ""
   ]

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -632,22 +632,6 @@ let test_keeper_sandbox_args_allowed_for_dashboard_patch () =
   | Error msg -> Alcotest.failf "dashboard config patch should accept sandbox posture args: %s" msg
   | Ok () -> ()
 
-let test_masc_keeper_msg_schema () =
-  match find_registered_tool "masc_keeper_msg" with
-  | None -> Alcotest.fail "masc_keeper_msg not found"
-  | Some schema ->
-      match get_json_assoc "properties" schema.input_schema with
-      | Some props ->
-          Alcotest.(check bool) "omits new_goal" false
-            (List.mem_assoc "new_goal" props);
-          Alcotest.(check bool) "omits required_tools" false
-            (List.mem_assoc "required_tools" props);
-          Alcotest.(check bool) "omits required_tool_names" false
-            (List.mem_assoc "required_tool_names" props);
-          Alcotest.(check bool) "omits request-level timeout_sec" false
-            (List.mem_assoc "timeout_sec" props)
-      | None -> Alcotest.fail "masc_keeper_msg missing properties"
-
 (* keeper policy schema tests removed — policy tool schemas no longer exist *)
 
 (* ============================================================ *)
@@ -873,8 +857,6 @@ let () =
         test_keeper_sandbox_args_rejected;
       Alcotest.test_case "keeper-sandbox-args-dashboard-allowed" `Quick
         test_keeper_sandbox_args_allowed_for_dashboard_patch;
-      Alcotest.test_case "keeper-msg" `Quick
-        test_masc_keeper_msg_schema;
     ];
     "legacy_swarm_removed", [
       Alcotest.test_case "removed_from_public_schemas" `Quick

--- a/test/test_worker_container_coverage.ml
+++ b/test/test_worker_container_coverage.ml
@@ -23,17 +23,17 @@ let worker_usage ?cost_usd ~input_tokens ~output_tokens () :
 
 let test_parse_text_tool_calls_single () =
   let content =
-    {|mcp__masc__masc_keeper_msg(name="keeper-alpha", message="[local64-smoke-01] manager decide online for hybrid smoke")|}
+    {|mcp__masc__masc_keeper_delegate(target={"kind":"keeper","name":"keeper-alpha"}, capability="invoke_turn", prompt="[local64-smoke-01] manager decide online for hybrid smoke")|}
   in
   match Worker_runtime.parse_text_tool_calls content with
   | [ Agent_sdk.Types.ToolUse { name; input; _ } ] ->
-      check string "tool name" "masc_keeper_msg" name;
+      check string "tool name" "masc_keeper_delegate" name;
       let json = input in
       check string "keeper name" "keeper-alpha"
-        Yojson.Safe.Util.(json |> member "name" |> to_string);
-      check string "message"
+        Yojson.Safe.Util.(json |> member "target" |> member "name" |> to_string);
+      check string "prompt"
         "[local64-smoke-01] manager decide online for hybrid smoke"
-        Yojson.Safe.Util.(json |> member "message" |> to_string)
+        Yojson.Safe.Util.(json |> member "prompt" |> to_string)
   | _ -> fail "expected exactly one parsed tool call"
 
 let test_parse_text_tool_calls_multiple () =
@@ -43,7 +43,7 @@ let test_parse_text_tool_calls_multiple () =
 done
 </think>
 mcp__masc__masc_heartbeat()
-mcp__masc__masc_keeper_msg(name="keeper-alpha", message="[local64-smoke-02] metacog verify online for hybrid smoke")
+mcp__masc__masc_keeper_delegate(target={"kind":"keeper","name":"keeper-alpha"}, capability="invoke_turn", prompt="[local64-smoke-02] metacog verify online for hybrid smoke")
 done:local64-smoke-02
 |}
   in
@@ -53,7 +53,7 @@ done:local64-smoke-02
       check string "first tool" "masc_heartbeat" name1;
       check string "heartbeat args" "{}"
         (Yojson.Safe.to_string input1);
-      check string "second tool" "masc_keeper_msg" name2
+      check string "second tool" "masc_keeper_delegate" name2
   | _ -> fail "expected two parsed text tool calls"
 
 let test_merge_usage_preserves_present_cost () =


### PR DESCRIPTION
Stacked on #24564.

## Scope
- extract the existing typed Keeper target, capability, run_ref, and result_contract vocabulary into a dependency-leaf SSOT
- keep Keeper_invocation_contract as the execution/lane adapter over Keeper_msg_async
- expose exact target and result codecs for the following Gate protocol cut
- preserve every existing submission/status/cancellation projection in this slice

## Boundary proof
- Gate can depend on the leaf without depending on the parent Keeper implementation
- OAS remains unaware of MASC, Gate, Board, or Keeper
- no scheduler, policy, compatibility alias, status heuristic, or runtime behavior is added
- total diff: 148 lines, +106/-42

## Verification
- the existing typed invocation test now proves the shared result codec and parser type equality
- ocamlc parse pass for every changed .ml/.mli
- isolated type inference passed for keeper_invocation_types
- git diff --check passed
- focused Dune remains blocked by the unrelated bare Dune process; CI is build authority