### PR TITLE
fix(keeper): close chat queue root inventory

### DIFF
--- a/lib/keeper/keeper_accountability.ml
+++ b/lib/keeper/keeper_accountability.ml
@@ -36,7 +36,10 @@ let keeper_decision_log_path (config : Workspace_query.config) name =
   let keepers_dir =
     Common.keepers_runtime_dir_of_base ~base_path:config.base_path
   in
-  Filename.concat keepers_dir (name ^ ".decisions.jsonl")
+  Filename.concat keepers_dir
+    (Keeper_runtime_root_entry.keeper_basename
+       ~keeper_name:name
+       Keeper_runtime_root_entry.Decision_log)
 ;;
 
 let tail_decision_log_lines_or_empty path ~max_bytes ~max_lines =

--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -515,6 +515,8 @@ let transaction_observer_for_testing :
   Atomic.make None
 let before_entry_lock_observer_for_testing : (string -> unit) option Atomic.t =
   Atomic.make None
+let inventory_classified_observer_for_testing : (unit -> unit) option Atomic.t =
+  Atomic.make None
 let transition_observer : transition_observer option Atomic.t = Atomic.make None
 
 let registry_mutex = Eio.Mutex.create ()
@@ -549,14 +551,7 @@ let notify_transition ~keeper_name ~revision =
          keeper_name revision (Printexc.to_string exn))
 
 let valid_keeper_name name =
-  let valid_char = function
-    | 'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '.' | '_' | '-' -> true
-    | _ -> false
-  in
-  (not (String.equal name ""))
-  && not (String.equal name ".")
-  && not (String.equal name "..")
-  && String.for_all valid_char name
+  Safe_identifier.is_portable_name name
 
 let keeper_directory ~base_path ~keeper_name =
   Filename.concat
@@ -3552,31 +3547,10 @@ let same_directory_identity left right =
   && left.Unix.st_dev = right.Unix.st_dev
   && left.Unix.st_ino = right.Unix.st_ino
 
-let read_owned_directory_blocking ~ownership_root path =
-  match inspect_owned_directory ~ownership_root path with
-  | Error _ as error -> error
-  | Ok Fs_compat.Owned_directory_missing -> Ok None
-  | Ok (Fs_compat.Owned_directory before) ->
-    let entries =
-      try Ok (Fs_compat.read_dir path) with
-      | exn -> Error (load_error Read_failed ~path (Printexc.to_string exn))
-    in
-    (match entries with
-     | Error _ as error -> error
-     | Ok entries ->
-       (match inspect_owned_directory ~ownership_root path with
-        | Ok (Fs_compat.Owned_directory after)
-          when same_directory_identity before after ->
-          Ok (Some entries)
-        | Ok (Fs_compat.Owned_directory _ | Fs_compat.Owned_directory_missing) ->
-          Error
-            (load_error Read_failed ~path
-               "owned Keeper directory identity changed during queue inventory")
-        | Error _ as error -> error))
-
 type keeper_directory_inventory =
   { keeper_names : string list
   ; rejected_entries : (string * snapshot_load_error) list
+  ; observed_entries : (string * Unix.stats) list
   }
 
 let classify_keeper_directory_entries_blocking entries_path entries =
@@ -3584,14 +3558,28 @@ let classify_keeper_directory_entries_blocking entries_path entries =
     (fun inventory entry_name ->
        let entry_path = Filename.concat entries_path entry_name in
        match Unix.lstat entry_path with
-       | { Unix.st_kind = Unix.S_DIR; _ } ->
-         { inventory with keeper_names = entry_name :: inventory.keeper_names }
-       | { Unix.st_kind = Unix.S_REG; _ } ->
-         (* The Keeper runtime root also owns meta JSON, decision JSONL,
-            memory JSONL, and backup files.  They are not chat queue lanes and
-            must not be interpreted as directory names. *)
-         inventory
-       | { Unix.st_kind = st_kind; _ } ->
+       | ({ Unix.st_kind = Unix.S_DIR; _ } as stats) ->
+         { inventory with
+           keeper_names = entry_name :: inventory.keeper_names
+         ; observed_entries = (entry_name, stats) :: inventory.observed_entries
+         }
+       | ({ Unix.st_kind = Unix.S_REG; _ } as stats) ->
+         (match Keeper_runtime_root_entry.classify_basename entry_name with
+          | _ :: _ ->
+            { inventory with
+              observed_entries = (entry_name, stats) :: inventory.observed_entries
+            }
+          | [] ->
+            { inventory with
+              rejected_entries =
+                ( entry_name
+                , load_error Invalid_path ~path:entry_path
+                    "Keeper chat queue inventory found an unowned regular entry"
+                )
+                :: inventory.rejected_entries
+            ; observed_entries = (entry_name, stats) :: inventory.observed_entries
+            })
+       | ({ Unix.st_kind = st_kind; _ } as stats) ->
          { inventory with
            rejected_entries =
              ( entry_name
@@ -3600,6 +3588,7 @@ let classify_keeper_directory_entries_blocking entries_path entries =
                     "Keeper chat queue inventory entry has unsupported kind %s"
                     (unix_file_kind_to_string st_kind)) )
              :: inventory.rejected_entries
+         ; observed_entries = (entry_name, stats) :: inventory.observed_entries
          }
        | exception exn ->
          { inventory with
@@ -3608,21 +3597,89 @@ let classify_keeper_directory_entries_blocking entries_path entries =
              , load_error Read_failed ~path:entry_path (Printexc.to_string exn) )
              :: inventory.rejected_entries
          })
-    { keeper_names = []; rejected_entries = [] }
+    { keeper_names = []; rejected_entries = []; observed_entries = [] }
     entries
   |> fun inventory ->
   { keeper_names = List.rev inventory.keeper_names
   ; rejected_entries = List.rev inventory.rejected_entries
+  ; observed_entries = List.rev inventory.observed_entries
   }
+;;
+
+let same_entry_identity before after =
+  before.Unix.st_kind = after.Unix.st_kind
+  && before.Unix.st_dev = after.Unix.st_dev
+  && before.Unix.st_ino = after.Unix.st_ino
+;;
+
+let validate_keeper_directory_inventory_blocking path ~initial_entries inventory =
+  let final_entries = Fs_compat.read_dir path in
+  if
+    not
+      (List.equal
+         String.equal
+         (List.sort String.compare initial_entries)
+         (List.sort String.compare final_entries))
+  then Error "Keeper runtime root entries changed during queue inventory"
+  else
+    inventory.observed_entries
+    |> List.find_map (fun (entry_name, before) ->
+      let entry_path = Filename.concat path entry_name in
+      match Unix.lstat entry_path with
+      | after when same_entry_identity before after -> None
+      | _ -> Some entry_path
+      | exception _ -> Some entry_path)
+    |> function
+    | None -> Ok ()
+    | Some entry_path ->
+      Error
+        (Printf.sprintf
+           "Keeper runtime root entry identity changed during queue inventory: %s"
+           entry_path)
 ;;
 
 let read_keeper_directory_inventory ~ownership_root path =
   Eio_guard.run_in_systhread (fun () ->
-    match read_owned_directory_blocking ~ownership_root path with
+    match inspect_owned_directory ~ownership_root path with
     | Error _ as error -> error
-    | Ok None -> Ok None
-    | Ok (Some entries) ->
-      Ok (Some (classify_keeper_directory_entries_blocking path entries)))
+    | Ok Fs_compat.Owned_directory_missing -> Ok None
+    | Ok (Fs_compat.Owned_directory before) ->
+      let inventory =
+        try
+          let entries = Fs_compat.read_dir path in
+          Ok (entries, classify_keeper_directory_entries_blocking path entries)
+        with
+        | exn -> Error (load_error Read_failed ~path (Printexc.to_string exn))
+      in
+      (match inventory with
+       | Error _ as error -> error
+       | Ok (initial_entries, inventory) ->
+         Option.iter (fun observer -> observer ())
+           (Atomic.get inventory_classified_observer_for_testing);
+         let snapshot_validation =
+           try
+             validate_keeper_directory_inventory_blocking
+               path
+               ~initial_entries
+               inventory
+           with
+           | exn -> Error (Printexc.to_string exn)
+         in
+         (match snapshot_validation with
+          | Error detail -> Error (load_error Read_failed ~path detail)
+          | Ok () ->
+            (* Root identity is checked last, after the final entry-set and
+               child inode/type validation. Per-lane database loading then
+               performs its own owned-chain and regular-file identity checks. *)
+            (match inspect_owned_directory ~ownership_root path with
+             | Ok (Fs_compat.Owned_directory after)
+               when same_directory_identity before after ->
+               Ok (Some inventory)
+             | Ok (Fs_compat.Owned_directory _ | Fs_compat.Owned_directory_missing) ->
+               Error
+                 (load_error Read_failed ~path
+                    "owned Keeper directory identity changed during queue inventory")
+             | Error _ as error -> error))))
 
 let configure_persistence ~base_path =
   let claimed =
@@ -3770,6 +3827,7 @@ module For_testing = struct
     Atomic.set commit_failure_for_testing None;
     Atomic.set transaction_observer_for_testing None;
     Atomic.set before_entry_lock_observer_for_testing None;
+    Atomic.set inventory_classified_observer_for_testing None;
     Atomic.set persistence_configuration Unconfigured;
     Atomic.set global_load_errors [];
     Atomic.set transition_observer None;
@@ -3786,6 +3844,9 @@ module For_testing = struct
 
   let set_before_entry_lock_observer observer =
     Atomic.set before_entry_lock_observer_for_testing observer
+
+  let set_inventory_classified_observer observer =
+    Atomic.set inventory_classified_observer_for_testing observer
 
   let failure_kind_of_string = failure_kind_of_string
   let snapshot_path = snapshot_path

--- a/lib/keeper/keeper_chat_queue.mli
+++ b/lib/keeper/keeper_chat_queue.mli
@@ -378,6 +378,7 @@ module For_testing : sig
   val set_transaction_stage_observer :
     (transaction_stage -> unit) option -> unit
   val set_before_entry_lock_observer : (string -> unit) option -> unit
+  val set_inventory_classified_observer : (unit -> unit) option -> unit
   val failure_kind_of_string : string -> (failure_kind, string) result
   val snapshot_path : base_path:string -> keeper_name:string -> (string, string) result
   val receipt_json :

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -67,7 +67,11 @@ let persist_directive_meta_update
       ~(updated_meta : keeper_meta)
   : (unit, string) result
   =
-  let keeper_filename = entry.name ^ ".json" in
+  let keeper_filename =
+    Keeper_runtime_root_entry.keeper_basename
+      ~keeper_name:entry.name
+      Keeper_runtime_root_entry.Metadata
+  in
   let masc_root = Workspace_utils.masc_dir_from_base_path ~base_path:entry.base_path in
   let default_path =
     Filename.concat (Filename.concat masc_root "keepers") keeper_filename

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -42,25 +42,8 @@ let read_meta_file_path path : (Keeper_meta_contract.keeper_meta option, string)
          Error e))
 ;;
 
-(** Sidecar stem suffixes (without the trailing .json).
-    A file like [sangsu.dataset.json] has stem [sangsu.dataset]; stripping
-    [.json] and checking [String.ends_with ~suffix] on this stem filters
-    sidecars while allowing keeper names that contain dots (e.g.
-    [dot.name.json]). When adding a new sidecar kind, add its dot-prefixed
-    suffix here. *)
-let keeper_sidecar_stem_suffixes = [ ".dataset" ]
-
 let is_keeper_meta_file f =
-  if not (Filename.check_suffix f ".json")
-  then false
-  else (
-    let stem = Filename.chop_suffix f ".json" in
-    stem <> ""
-    && not
-         (List.exists
-            (fun suf ->
-               String.length stem > String.length suf && String.ends_with ~suffix:suf stem)
-            keeper_sidecar_stem_suffixes))
+  Option.is_some (Keeper_runtime_root_entry.metadata_keeper_name f)
 ;;
 
 let persisted_keeper_names_result config =
@@ -75,8 +58,7 @@ let persisted_keeper_names_result config =
   | Ok files ->
     Ok
       (files
-       |> List.filter is_keeper_meta_file
-       |> List.map Filename.remove_extension
+       |> List.filter_map Keeper_runtime_root_entry.metadata_keeper_name
        |> List.filter validate_name
        |> List.sort String.compare)
 ;;
@@ -106,7 +88,8 @@ let keeper_names config =
      JSON files are scoped to the server's base_path, so test isolation works.
      Overlay keepers (from .masc/config/keepers/*.toml) are materialized to
      JSON at boot by load_or_materialize_boot_meta, so they appear here too.
-     Sidecar files (.dataset) are filtered by is_keeper_meta_file. *)
+     Every canonical root [.json] is metadata authority; retired dataset
+     exports no longer compete for the same basename. *)
   match keeper_names_result config with
   | Ok names -> names
   | Error msg ->

--- a/lib/keeper/keeper_meta_store.mli
+++ b/lib/keeper/keeper_meta_store.mli
@@ -26,12 +26,7 @@ val version_conflict_re : Re.re
 val read_meta_file_path :
   string -> (Keeper_meta_contract.keeper_meta option, string) result
 
-(** Sidecar stem suffixes (without the trailing [.json]). Files
-    matching [<name><suffix>.json] are filtered out of the keeper
-    discovery scan (e.g. [<name>.dataset.json]). *)
-val keeper_sidecar_stem_suffixes : string list
-
-(** [true] iff [f] is a [.json] file whose stem is not a sidecar. *)
+(** [true] when [f] has an exact canonical Keeper-metadata interpretation. *)
 val is_keeper_meta_file : string -> bool
 
 (** List keeper names with persisted JSON in [.masc/keepers/].

--- a/lib/keeper/keeper_runtime_root_entry.ml
+++ b/lib/keeper/keeper_runtime_root_entry.ml
@@ -1,0 +1,157 @@
+type keeper_artifact =
+  | Metadata
+  | Metrics_log
+  | Memory_log
+  | Generation_index_log
+  | Policy_log
+  | Decision_log
+  | Feedback_log
+  | Tla_trace_log
+
+type global_artifact =
+  | Alerts_log
+  | Alerts_retry_log
+  | Alerts_deadletter_log
+
+type t =
+  | Keeper of
+      { keeper_name : string
+      ; artifact : keeper_artifact
+      ; rotation : int option
+      }
+  | Global of
+      { artifact : global_artifact
+      ; rotation : int option
+      }
+
+let keeper_suffix = function
+  | Metadata -> ".json"
+  | Metrics_log -> ".metrics.jsonl"
+  | Memory_log -> ".memory.jsonl"
+  | Generation_index_log -> ".generation_index.jsonl"
+  | Policy_log -> ".policy.jsonl"
+  | Decision_log -> ".decisions.jsonl"
+  | Feedback_log -> ".feedback.jsonl"
+  | Tla_trace_log -> ".tla-trace.jsonl"
+;;
+
+let keeper_basename ~keeper_name artifact = keeper_name ^ keeper_suffix artifact
+
+let global_basename = function
+  | Alerts_log -> "_alerts.jsonl"
+  | Alerts_retry_log -> "_alerts.retry.jsonl"
+  | Alerts_deadletter_log -> "_alerts.deadletter.jsonl"
+;;
+
+let basename = function
+  | Keeper { keeper_name; artifact; rotation } ->
+    let base = keeper_basename ~keeper_name artifact in
+    Option.fold ~none:base ~some:(fun rotation -> base ^ "." ^ string_of_int rotation) rotation
+  | Global { artifact; rotation } ->
+    let base = global_basename artifact in
+    Option.fold ~none:base ~some:(fun rotation -> base ^ "." ^ string_of_int rotation) rotation
+;;
+
+type descriptor =
+  | Keeper_descriptor of
+      { artifact : keeper_artifact
+      ; rotatable : bool
+      }
+  | Global_descriptor of
+      { artifact : global_artifact
+      ; rotatable : bool
+      }
+
+(* Longest Keeper suffixes precede [.json], preserving dotted Keeper names
+   while keeping classification total and deterministic. *)
+let descriptors =
+  [ Keeper_descriptor { artifact = Generation_index_log; rotatable = true }
+  ; Global_descriptor { artifact = Alerts_deadletter_log; rotatable = true }
+  ; Global_descriptor { artifact = Alerts_retry_log; rotatable = true }
+  ; Keeper_descriptor { artifact = Decision_log; rotatable = true }
+  ; Keeper_descriptor { artifact = Feedback_log; rotatable = true }
+  ; Keeper_descriptor { artifact = Memory_log; rotatable = true }
+  ; Keeper_descriptor { artifact = Metrics_log; rotatable = true }
+  ; Keeper_descriptor { artifact = Policy_log; rotatable = true }
+  ; Keeper_descriptor { artifact = Tla_trace_log; rotatable = true }
+  ; Global_descriptor { artifact = Alerts_log; rotatable = true }
+  ; Keeper_descriptor { artifact = Metadata; rotatable = false }
+  ]
+;;
+
+let positive_decimal value =
+  not (String.equal value "")
+  && String.for_all (function '0' .. '9' -> true | _ -> false) value
+  && match int_of_string_opt value with
+     | Some value -> value > 0
+     | None -> false
+;;
+
+let split_rotation basename =
+  match String.rindex_opt basename '.' with
+  | None -> basename, None
+  | Some separator ->
+    let suffix_start = separator + 1 in
+    let suffix_length = String.length basename - suffix_start in
+    let candidate = String.sub basename suffix_start suffix_length in
+    if positive_decimal candidate
+    then
+      ( String.sub basename 0 separator
+      , Some (int_of_string candidate) )
+    else basename, None
+;;
+
+let strip_suffix value suffix =
+  if String.ends_with ~suffix value
+  then
+    Some (String.sub value 0 (String.length value - String.length suffix))
+  else None
+;;
+
+let classify_basename observed_basename =
+  let unrotated_basename, rotation = split_rotation observed_basename in
+  let candidate_if_canonical candidate =
+    if String.equal (basename candidate) observed_basename
+    then Some candidate
+    else None
+  in
+  let rec classify candidates = function
+    | [] -> List.rev candidates
+    | Keeper_descriptor { artifact; rotatable } :: rest ->
+      (match strip_suffix unrotated_basename (keeper_suffix artifact) with
+       | Some keeper_name
+         when (Option.is_none rotation || rotatable)
+              && Safe_identifier.is_portable_name keeper_name ->
+         let candidate = Keeper { keeper_name; artifact; rotation } in
+         let candidates =
+           Option.fold
+             ~none:candidates
+             ~some:(fun candidate -> candidate :: candidates)
+             (candidate_if_canonical candidate)
+         in
+         classify candidates rest
+       | Some _ | None -> classify candidates rest)
+    | Global_descriptor { artifact; rotatable } :: rest ->
+      if
+        String.equal unrotated_basename (global_basename artifact)
+        && (Option.is_none rotation || rotatable)
+      then
+        let candidate = Global { artifact; rotation } in
+        let candidates =
+          Option.fold
+            ~none:candidates
+            ~some:(fun candidate -> candidate :: candidates)
+            (candidate_if_canonical candidate)
+        in
+        classify candidates rest
+      else classify candidates rest
+  in
+  classify [] descriptors
+;;
+
+let metadata_keeper_name observed_basename =
+  classify_basename observed_basename
+  |> List.find_map (function
+    | Keeper { keeper_name; artifact = Metadata; rotation = None } -> Some keeper_name
+    | Keeper _ | Global _ -> None)
+;;

--- a/lib/keeper/keeper_runtime_root_entry.mli
+++ b/lib/keeper/keeper_runtime_root_entry.mli
@@ -1,0 +1,44 @@
+(** Typed filename authority for regular files directly under
+    [.masc/keepers].  High-cardinality lane artifacts belong below the Keeper
+    directory; these constructors are the closed set of legacy/current root
+    artifacts that runtime producers still own. *)
+
+type keeper_artifact =
+  | Metadata
+  | Metrics_log
+  | Memory_log
+  | Generation_index_log
+  | Policy_log
+  | Decision_log
+  | Feedback_log
+  | Tla_trace_log
+
+type global_artifact =
+  | Alerts_log
+  | Alerts_retry_log
+  | Alerts_deadletter_log
+
+type t =
+  | Keeper of
+      { keeper_name : string
+      ; artifact : keeper_artifact
+      ; rotation : int option
+      }
+  | Global of
+      { artifact : global_artifact
+      ; rotation : int option
+      }
+
+val keeper_basename : keeper_name:string -> keeper_artifact -> string
+val global_basename : global_artifact -> string
+val basename : t -> string
+
+(** Return every typed interpretation whose canonical renderer exactly
+    round-trips to the input. The root catalog is injective; the list shape
+    makes that invariant directly testable without a hidden descriptor-order
+    fallback. *)
+val classify_basename : string -> t list
+
+(** Exact metadata interpretation, independent of overlapping artifact
+    suffixes. *)
+val metadata_keeper_name : string -> string option

--- a/lib/keeper/keeper_shutdown_types.ml
+++ b/lib/keeper/keeper_shutdown_types.ml
@@ -56,7 +56,6 @@ type dashboard_purge_artifact =
   | Keeper_policy_log_artifact
   | Keeper_decision_log_artifact
   | Keeper_feedback_log_artifact
-  | Keeper_dataset_export_artifact
   | Keeper_runtime_directory_artifact
   | Keeper_configuration_artifact
   | Agent_artifact_bundle of string list
@@ -422,7 +421,6 @@ let dashboard_purge_artifact_plan ~keeper_name context =
   ; Keeper_policy_log_artifact
   ; Keeper_decision_log_artifact
   ; Keeper_feedback_log_artifact
-  ; Keeper_dataset_export_artifact
   ; Keeper_runtime_directory_artifact
   ; Keeper_configuration_artifact
   ; Agent_artifact_bundle agent_aliases

--- a/lib/keeper/keeper_shutdown_types.mli
+++ b/lib/keeper/keeper_shutdown_types.mli
@@ -39,7 +39,6 @@ type dashboard_purge_artifact =
   | Keeper_policy_log_artifact
   | Keeper_decision_log_artifact
   | Keeper_feedback_log_artifact
-  | Keeper_dataset_export_artifact
   | Keeper_runtime_directory_artifact
   | Keeper_configuration_artifact
   | Agent_artifact_bundle of string list

--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -247,10 +247,6 @@ let handle_keeper_list ctx args : tool_result =
                 , `String (Keeper_types_support.keeper_policy_log_path ctx.config m.name) );
                 ( "feedback"
                 , `String (Keeper_types_support.keeper_feedback_log_path ctx.config m.name) );
-                ( "dataset_export"
-                , `String
-                    (Keeper_types_support.keeper_dataset_export_path ctx.config m.name)
-                );
                 ( "session_dir"
                 , `String
                     (Keeper_types_support.keeper_session_dir

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -956,10 +956,6 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
              , `String (Keeper_types_support.keeper_policy_log_path config m.name) );
              ( "feedback"
              , `String (Keeper_types_support.keeper_feedback_log_path config m.name) );
-           ( "dataset_export"
-           , `String
-               (Keeper_types_support.keeper_dataset_export_path config m.name)
-           );
            ("session_dir", `String session_dir);
              ("generation_manifest", `String generation_manifest_path);
              ("history", `String history_path);

--- a/lib/keeper/keeper_trace_emit.ml
+++ b/lib/keeper/keeper_trace_emit.ml
@@ -37,7 +37,9 @@ let enabled () =
 let trace_path ~base_path ~keeper_name =
   Filename.concat
     (Common.keepers_runtime_dir_of_base ~base_path)
-    (keeper_name ^ ".tla-trace.jsonl")
+    (Keeper_runtime_root_entry.keeper_basename
+       ~keeper_name
+       Keeper_runtime_root_entry.Tla_trace_log)
 
 let emit_transition
     ~(keeper_name : string)

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -666,7 +666,11 @@ let keeper_dir (config : Workspace.config) =
   ensure_dir d
 
 let keeper_meta_path config name =
-  Filename.concat (keeper_dir config) (name ^ ".json")
+  Filename.concat
+    (keeper_dir config)
+    (Keeper_runtime_root_entry.keeper_basename
+       ~keeper_name:name
+       Keeper_runtime_root_entry.Metadata)
 
 let session_base_dir (config : Workspace.config) =
   let d = Filename.concat (Workspace.masc_root_dir config) "traces" in

--- a/lib/keeper/keeper_types_support.ml
+++ b/lib/keeper/keeper_types_support.ml
@@ -26,7 +26,11 @@ let ensure_api_keys_for_labels (_labels : string list) : (unit, string) result =
 
 (** Single-file metrics path kept for fallback reads. *)
 let keeper_metrics_path config name =
-  Filename.concat (keeper_dir_ config) (name ^ ".metrics.jsonl")
+  Filename.concat
+    (keeper_dir_ config)
+    (Keeper_runtime_root_entry.keeper_basename
+       ~keeper_name:name
+       Keeper_runtime_root_entry.Metrics_log)
 
 (** Date-split metrics store: [.masc/keepers/<name>/metrics/YYYY-MM/DD.jsonl].
     Cached per keeper name so all callers share the same Eio.Mutex. *)
@@ -194,10 +198,18 @@ let prune_keeper_raw_trace_turn_files config name =
   end
 
 let keeper_memory_bank_path config name =
-  Filename.concat (keeper_dir_ config) (name ^ ".memory.jsonl")
+  Filename.concat
+    (keeper_dir_ config)
+    (Keeper_runtime_root_entry.keeper_basename
+       ~keeper_name:name
+       Keeper_runtime_root_entry.Memory_log)
 
 let keeper_generation_index_path config name =
-  Filename.concat (keeper_dir_ config) (name ^ ".generation_index.jsonl")
+  Filename.concat
+    (keeper_dir_ config)
+    (Keeper_runtime_root_entry.keeper_basename
+       ~keeper_name:name
+       Keeper_runtime_root_entry.Generation_index_log)
 
 let keeper_session_dir config trace_id =
   Filename.concat (session_base_dir_ config) trace_id
@@ -223,25 +235,42 @@ let is_internal_history_source (source : string) =
   | _ -> false
 
 let keeper_policy_log_path config name =
-  Filename.concat (keeper_dir_ config) (name ^ ".policy.jsonl")
+  Filename.concat
+    (keeper_dir_ config)
+    (Keeper_runtime_root_entry.keeper_basename
+       ~keeper_name:name
+       Keeper_runtime_root_entry.Policy_log)
 
 let keeper_decision_log_path config name =
-  Filename.concat (keeper_dir_ config) (name ^ ".decisions.jsonl")
+  Filename.concat
+    (keeper_dir_ config)
+    (Keeper_runtime_root_entry.keeper_basename
+       ~keeper_name:name
+       Keeper_runtime_root_entry.Decision_log)
 
 let keeper_feedback_log_path config name =
-  Filename.concat (keeper_dir_ config) (name ^ ".feedback.jsonl")
-
-let keeper_dataset_export_path config name =
-  Filename.concat (keeper_dir_ config) (name ^ ".dataset.json")
+  Filename.concat
+    (keeper_dir_ config)
+    (Keeper_runtime_root_entry.keeper_basename
+       ~keeper_name:name
+       Keeper_runtime_root_entry.Feedback_log)
 
 let keeper_alerts_path config =
-  Filename.concat (keeper_dir_ config) "_alerts.jsonl"
+  Filename.concat
+    (keeper_dir_ config)
+    (Keeper_runtime_root_entry.global_basename Keeper_runtime_root_entry.Alerts_log)
 
 let keeper_alert_retry_path config =
-  Filename.concat (keeper_dir_ config) "_alerts.retry.jsonl"
+  Filename.concat
+    (keeper_dir_ config)
+    (Keeper_runtime_root_entry.global_basename
+       Keeper_runtime_root_entry.Alerts_retry_log)
 
 let keeper_alert_deadletter_path config =
-  Filename.concat (keeper_dir_ config) "_alerts.deadletter.jsonl"
+  Filename.concat
+    (keeper_dir_ config)
+    (Keeper_runtime_root_entry.global_basename
+       Keeper_runtime_root_entry.Alerts_deadletter_log)
 
 (** Rotate [path] if it exceeds the configured size threshold.
     Keeps at most [max_rotated] numbered backups (.1, .2, ...). *)

--- a/lib/keeper/keeper_types_support.mli
+++ b/lib/keeper/keeper_types_support.mli
@@ -91,7 +91,6 @@ val is_internal_history_source : string -> bool
 val keeper_policy_log_path : Workspace.config -> string -> string
 val keeper_decision_log_path : Workspace.config -> string -> string
 val keeper_feedback_log_path : Workspace.config -> string -> string
-val keeper_dataset_export_path : Workspace.config -> string -> string
 val keeper_alerts_path : Workspace.config -> string
 val keeper_alert_retry_path : Workspace.config -> string
 val keeper_alert_deadletter_path : Workspace.config -> string

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -379,8 +379,6 @@ let keeper_artifact_path config keeper_name artifact =
     Some (Keeper_types_support.keeper_decision_log_path config keeper_name)
   | Keeper_feedback_log_artifact ->
     Some (Keeper_types_support.keeper_feedback_log_path config keeper_name)
-  | Keeper_dataset_export_artifact ->
-    Some (Keeper_types_support.keeper_dataset_export_path config keeper_name)
   | Keeper_runtime_directory_artifact ->
     Some (Filename.concat (Keeper_fs.keeper_dir config) keeper_name)
   | Keeper_configuration_artifact ->
@@ -424,7 +422,6 @@ let purge_dashboard_keeper_artifacts config operation =
                | Keeper_policy_log_artifact
                | Keeper_decision_log_artifact
                | Keeper_feedback_log_artifact
-               | Keeper_dataset_export_artifact
                | Keeper_configuration_artifact
                | Agent_artifact_bundle _ -> ());
               Log.Keeper.debug

--- a/scripts/migrate-keeper-meta-sandbox.sh
+++ b/scripts/migrate-keeper-meta-sandbox.sh
@@ -7,7 +7,8 @@
 #   absent from the persisted meta JSON. The new strict parser refuses to load
 #   such files. This script walks the on-disk keeper meta directories, fills in
 #   the missing fields from the matching config/keepers/<name>.toml, and writes
-#   .bak alongside the modified file.
+#   backups under .masc/backups/keeper-meta-sandbox/. Runtime-root regular
+#   entries remain owned by the typed Keeper artifact catalog.
 #
 # Scope (filesystem locations searched)
 #   1. <repo>/.masc/keepers/*.json          (worktree-local persistence)
@@ -15,7 +16,7 @@
 #
 # Usage
 #   bash scripts/migrate-keeper-meta-sandbox.sh             # --dry-run (default)
-#   bash scripts/migrate-keeper-meta-sandbox.sh --apply     # write .bak + edit
+#   bash scripts/migrate-keeper-meta-sandbox.sh --apply     # write backup + edit
 #   bash scripts/migrate-keeper-meta-sandbox.sh --apply --quiet
 #   bash scripts/migrate-keeper-meta-sandbox.sh --base-path ~/me --apply
 #
@@ -102,8 +103,13 @@ default_network_for_profile() {
 
 normalize_one() {
   local meta_file="$1"
-  local name
+  local name persisted_name
   name="$(basename "$meta_file" .json)"
+  persisted_name="$(jq -r 'if (.name | type) == "string" then .name else "" end' < "$meta_file" 2>/dev/null || echo "")"
+  if [ "$persisted_name" != "$name" ]; then
+    log "  [skip] $name : JSON does not carry matching Keeper metadata name authority"
+    return 0
+  fi
 
   local has_profile has_network
   has_profile="$(jq -r 'has("sandbox_profile")' < "$meta_file" 2>/dev/null || echo "false")"
@@ -136,7 +142,11 @@ normalize_one() {
     return 0
   fi
 
-  local backup="${meta_file}.bak"
+  local masc_root backup_dir backup
+  masc_root="$(dirname "$(dirname "$meta_file")")"
+  backup_dir="${masc_root}/backups/keeper-meta-sandbox"
+  mkdir -p "$backup_dir"
+  backup="${backup_dir}/$(basename "$meta_file").bak"
   cp -p "$meta_file" "$backup"
 
   local tmp

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -2040,7 +2040,6 @@ let test_dashboard_keeper_purge_finalizes_artifacts_and_receipt () =
         ; Keeper_types_support.keeper_policy_log_path config meta.name
         ; Keeper_types_support.keeper_decision_log_path config meta.name
         ; Keeper_types_support.keeper_feedback_log_path config meta.name
-        ; Keeper_types_support.keeper_dataset_export_path config meta.name
         ]
       in
       List.iter (fun path -> write_file path "fixture") sidecar_paths;

--- a/test/test_keeper_chat_coalescing.ml
+++ b/test/test_keeper_chat_coalescing.ml
@@ -673,10 +673,129 @@ let test_runtime_files_are_not_queue_lane_directories () =
   save_text (Filename.concat keepers_dir "executor.json") "{}";
   save_text (Filename.concat keepers_dir "executor.memory.jsonl") "";
   save_text (Filename.concat keepers_dir "executor.decisions.jsonl") "";
+  save_text (Filename.concat keepers_dir "executor.decisions.jsonl.1") "";
+  save_text (Filename.concat keepers_dir "_alerts.deadletter.jsonl") "";
   let report = configure base_path in
   check "runtime files produce no queue recovery failures"
     (report.load_errors = []);
   check "runtime files restore no queue lanes"
+    (report.restored_keeper_count = 0)
+
+let test_runtime_root_typed_filename_authority () =
+  Printf.printf "Test: Keeper runtime root filenames round-trip canonically\n%!";
+  let open Keeper_runtime_root_entry in
+  let dotted_metadata = keeper_basename ~keeper_name:"dot.dataset" Metadata in
+  let dotted_interpretations = classify_basename dotted_metadata in
+  check "dotted metadata has one injective authority"
+    (match dotted_interpretations with
+     | [ Keeper
+           { keeper_name = "dot.dataset"; artifact = Metadata; rotation = None }
+       ] ->
+       true
+     | _ -> false);
+  check "exact metadata authority preserves arbitrary dotted suffixes"
+    (metadata_keeper_name dotted_metadata = Some "dot.dataset");
+  check "every typed interpretation renders to the observed basename"
+    (List.for_all
+       (fun interpretation -> String.equal (basename interpretation) dotted_metadata)
+       dotted_interpretations);
+  check "noncanonical rotated filename is rejected"
+    (classify_basename "executor.decisions.jsonl.01" = []);
+  check "TLA trace writer rotation is owned"
+    (match classify_basename "executor.tla-trace.jsonl.1" with
+     | [ Keeper
+           { keeper_name = "executor"; artifact = Tla_trace_log; rotation = Some 1 }
+       ] ->
+       true
+     | _ -> false);
+  check "metadata migration root backup is not an owned runtime artifact"
+    (classify_basename "executor.json.bak" = [])
+
+let test_corrupt_dotted_metadata_authority_does_not_disappear () =
+  Printf.printf
+    "Test: corrupt dotted metadata remains in persisted Keeper inventory\n%!";
+  with_base "keeper-chat-corrupt-dotted-meta" @@ fun base_path ->
+  let config = Workspace.default_config base_path in
+  let keepers_dir = Common.keepers_runtime_dir_of_base ~base_path in
+  Fs_compat.mkdir_p keepers_dir;
+  save_text (Filename.concat keepers_dir "corrupt.dataset.json") "not-json";
+  check "corrupt dotted metadata name remains discoverable"
+    (match Keeper_meta_store.persisted_keeper_names_result config with
+     | Ok names -> List.mem "corrupt.dataset" names
+     | Error _ -> false)
+
+let test_unowned_regular_runtime_entry_is_reported () =
+  Printf.printf
+    "Test: unowned regular Keeper runtime entries are never silently accepted\n%!";
+  with_base "keeper-chat-unowned-runtime-entry" @@ fun base_path ->
+  let keepers_dir = Common.keepers_runtime_dir_of_base ~base_path in
+  Fs_compat.mkdir_p keepers_dir;
+  let entry_name = "unexpected-queue-authority" in
+  let entry_path = Filename.concat keepers_dir entry_name in
+  save_text entry_path "not a declared Keeper runtime artifact";
+  let report = configure base_path in
+  check "unowned regular entry is reported exactly once"
+    (match report.load_errors with
+     | [ Some observed_name, error ] ->
+       String.equal observed_name entry_name
+       && error.kind = Keeper_chat_queue.Invalid_path
+       && error.path = Some entry_path
+       && String.equal error.message
+            "Keeper chat queue inventory found an unowned regular entry"
+     | _ -> false);
+  check "unowned regular entry restores no queue lane"
+    (report.restored_keeper_count = 0);
+  check "unowned root entry does not block an unrelated Keeper lane"
+    (Result.is_ok
+       (Keeper_chat_queue.enqueue ~keeper_name:"unrelated" (message "works")))
+
+let test_runtime_root_replacement_during_inventory_is_rejected () =
+  Printf.printf
+    "Test: Keeper runtime root replacement during inventory is rejected\n%!";
+  with_base "keeper-chat-runtime-root-replacement" @@ fun base_path ->
+  let keepers_dir = Common.keepers_runtime_dir_of_base ~base_path in
+  let displaced_dir = keepers_dir ^ ".displaced" in
+  Fs_compat.mkdir_p keepers_dir;
+  save_text (Filename.concat keepers_dir "executor.json") "{}";
+  Keeper_chat_queue.For_testing.set_inventory_classified_observer
+    (Some (fun () ->
+       Unix.rename keepers_dir displaced_dir;
+       Unix.mkdir keepers_dir 0o755));
+  let report = configure base_path in
+  check "runtime root replacement reports one registry error"
+    (match report.load_errors with
+     | [ None, error ] ->
+       error.kind = Keeper_chat_queue.Read_failed
+       && error.path = Some keepers_dir
+       && String.equal error.message
+            "failed to discover Keeper chat queue databases: Keeper runtime root entries changed during queue inventory"
+     | _ -> false);
+  check "runtime root replacement restores no queue lane"
+    (report.restored_keeper_count = 0)
+
+let test_runtime_root_child_replacement_during_inventory_is_rejected () =
+  Printf.printf
+    "Test: Keeper runtime root child replacement during inventory is rejected\n%!";
+  with_base "keeper-chat-runtime-root-child-replacement" @@ fun base_path ->
+  let keepers_dir = Common.keepers_runtime_dir_of_base ~base_path in
+  Fs_compat.mkdir_p keepers_dir;
+  let metadata_path = Filename.concat keepers_dir "executor.json" in
+  save_text metadata_path "{}";
+  Keeper_chat_queue.For_testing.set_inventory_classified_observer
+    (Some (fun () ->
+       Sys.remove metadata_path;
+       Unix.mkdir metadata_path 0o755));
+  let report = configure base_path in
+  check "runtime root child replacement reports one registry error"
+    (match report.load_errors with
+     | [ None, error ] ->
+       error.kind = Keeper_chat_queue.Read_failed
+       && error.path = Some keepers_dir
+       && String.equal error.message
+            ("failed to discover Keeper chat queue databases: Keeper runtime root entry identity changed during queue inventory: "
+             ^ metadata_path)
+     | _ -> false);
+  check "runtime root child replacement restores no queue lane"
     (report.restored_keeper_count = 0)
 
 let test_foreign_database_and_symlink_are_quarantined () =
@@ -749,7 +868,12 @@ let () =
   test_uncertain_lease_compensates_and_other_transitions_reconcile ();
   test_restart_requires_explicit_recovery_without_journal ();
   test_legacy_json_is_not_a_queue_authority ();
+  test_runtime_root_typed_filename_authority ();
+  test_corrupt_dotted_metadata_authority_does_not_disappear ();
   test_runtime_files_are_not_queue_lane_directories ();
+  test_unowned_regular_runtime_entry_is_reported ();
+  test_runtime_root_replacement_during_inventory_is_rejected ();
+  test_runtime_root_child_replacement_during_inventory_is_rejected ();
   test_foreign_database_and_symlink_are_quarantined ();
   test_reconcile_absent_lane_and_stage_order ();
   if !failures > 0

--- a/test/test_server_dashboard_http_legacy_keeper_inventory.ml
+++ b/test/test_server_dashboard_http_legacy_keeper_inventory.ml
@@ -94,7 +94,6 @@ let test_classifies_legacy_paths_and_dry_run_candidates () =
   ensure_dir (Filename.concat legacy "alpha");
   ensure_dir (Filename.concat legacy "alpha/metrics");
   write_file (Filename.concat legacy "alpha.json") "{}\n";
-  write_file (Filename.concat legacy "alpha.dataset.json") "{}\n";
   write_file (Filename.concat legacy "alpha/.atomic_dead.tmp") "orphan";
   write_file (Filename.concat legacy "PYEOF") "marker";
   write_file (Filename.concat legacy "alpha/old.backup") "backup";
@@ -132,10 +131,6 @@ let test_classifies_legacy_paths_and_dry_run_candidates () =
     "keeper meta json classified"
     true
     (List.mem ("alpha.json", "live") (entry_classes json));
-  Alcotest.(check bool)
-    "keeper meta sidecar stays unknown"
-    true
-    (List.mem ("alpha.dataset.json", "unknown") (entry_classes json));
   Alcotest.(check bool)
     "live metric classified"
     true


### PR DESCRIPTION
## 요약
- Keeper chat queue가 runtime root의 모든 regular file을 묵인하던 경계를 typed artifact catalog로 닫습니다.
- 알려지지 않은 regular entry는 `Invalid_path`로 관측하고 다른 Keeper lane 복구는 계속합니다.
- initial/final entry set과 child inode/type, root inode를 재검증해 inventory TOCTOU를 닫습니다.
- filename producer들을 같은 catalog로 모아 rotation/metadata authority를 SSOT화합니다.
- writer가 없는 legacy dataset export 계약은 status/purge/shutdown/path/test에서 제거합니다.

## 검증
- `ocamlc -stop-after parsing` (touched .ml)
- `ocamlformat --check` (touched .ml/.mli)
- `bash -n scripts/migrate-keeper-meta-sandbox.sh`
- `git diff --check origin/main...HEAD`
- focused Dune wrapper는 기존 bare Dune PID 66224를 감지해 exit 75로 fail-closed; CI에서 build/test 확인

Closes #24543
