### PR TITLE
fix(slack): durably accept before lane handoff

### DIFF
--- a/lib/server/server_slack_in_process_gateway.ml
+++ b/lib/server/server_slack_in_process_gateway.ml
@@ -3,13 +3,11 @@
    RFC-0317 PR-3: the in-process Slack Socket Mode gateway. Mirrors
    {!Server_discord_in_process_gateway}: fork a long-running fiber that runs
    {!Slack_socket_client.run} and, for each triggered event, looks up the
-   channel→keeper binding, runs the keeper turn through
-   {!Channel_gate.handle_inbound_streaming}, and projects redacted text
-   snapshots by posting/editing one threaded Slack reply.
+   channel→keeper binding and durably accepts the exact event before the socket
+   callback returns. The connector lane then projects only the threaded ACK;
+   the durable queue consumer owns the Keeper turn and final reply.
 
    Differences from the Discord gateway:
-   - No typing indicator: Slack has no bot-typing surface, so the streaming
-     reply itself (initial post + edits) is the progress projection.
    - No ambient/wake path this pass: the FSM only surfaces policy-passing
      Message_create / App_mention and (ambient) Reaction_added. Recording
      ambient user lines and waking idle keepers on them is RFC-0317 follow-up
@@ -141,143 +139,25 @@ let metadata_bool key value = [ (key, string_of_bool value) ]
 let slack_conversation_id ~channel_id = Printf.sprintf "slack:channel:%s" channel_id
 
 (* ---------------------------------------------------------------- *)
-(* Streaming reply projection                                       *)
-(* ---------------------------------------------------------------- *)
-
-type slack_stream_reply =
-  { channel_id : string
-  ; reply_to_thread_ts : string
-      (* Slack ts of the thread root to post the reply under: the triggering
-         message's own ts for a top-level message, or the existing thread_ts
-         when the trigger already sits in a thread. *)
-  ; mutable message_ts : string option
-  ; mutable last_edit_time : float
-  ; mutable last_edited_text : string
-  ; mutable disabled : bool
-  }
-
-let make_slack_stream_reply ~channel_id ~reply_to_thread_ts =
-  { channel_id
-  ; reply_to_thread_ts
-  ; message_ts = None
-  ; last_edit_time = 0.0
-  ; last_edited_text = ""
-  ; disabled = false
-  }
-
-(* Redact provider secrets and clamp to Slack's per-message limit on a codepoint
-   boundary. Reuses the Discord REST client's pure UTF-8 splitter (the same
-   duplication-avoidance the Slack socket client already applies by reusing
-   Discord_wss_connection for transport); the [~limit] argument makes it
-   connector-neutral. *)
-let slack_stream_content snapshot =
-  let redacted = Observability_redact.redact_text snapshot in
-  let head, _ =
-    Discord_rest_client.split_at_codepoint redacted
-      ~limit:Slack_rest_client.message_text_limit
-  in
-  head
-
-let log_stream_error stage state error =
-  Log.Server.warn
-    "slack streaming %s failed (channel=%s thread=%s): %s"
-    stage state.channel_id state.reply_to_thread_ts
-    (Format.asprintf "%a" State.pp_send_error error)
-
-let publish_slack_stream_snapshot ~clock state snapshot =
-  if not state.disabled then begin
-    let content = slack_stream_content snapshot in
-    if
-      not
-        (String.equal content ""
-        || String.equal content state.last_edited_text)
-    then
-      (* Wall-clock, read once per snapshot to throttle the streaming edit
-         cadence (a minimum interval between chat.update calls); it gates I/O
-         frequency only and never branches deterministic policy. NDT-OK. *)
-      let now = Unix.gettimeofday () in
-      match state.message_ts with
-      | None -> (
-        match
-          State.send_message ~clock ~channel_id:state.channel_id ~content
-            ~reply_to_message_id:state.reply_to_thread_ts ()
-        with
-        | Ok ts ->
-          state.message_ts <- Some ts;
-          state.last_edit_time <- now;
-          state.last_edited_text <- content
-        | Error error ->
-          state.disabled <- true;
-          log_stream_error "initial send" state error)
-      | Some ts ->
-        let elapsed = now -. state.last_edit_time in
-        if elapsed >= Slack_rest_client.streaming_update_min_interval_sec then
-          match
-            State.edit_message ~clock ~channel_id:state.channel_id ~message_id:ts
-              ~content ()
-          with
-          | Ok () ->
-            state.last_edit_time <- now;
-            state.last_edited_text <- content
-          | Error error -> log_stream_error "edit" state error
-  end
-
-type stream_finish =
-  | Stream_not_started
-  | Stream_completed
-  | Stream_final_edit_failed of State.send_error
-  | Stream_overflow_send_failed of State.send_error
-
-let finish_slack_stream_reply ~clock state ~final_content =
-  match state.message_ts with
-  | None -> Stream_not_started
-  | Some ts ->
-    let redacted = Observability_redact.redact_text final_content in
-    let head, overflow =
-      Discord_rest_client.split_at_codepoint redacted
-        ~limit:Slack_rest_client.message_text_limit
-    in
-    let edit_result =
-      if String.equal head state.last_edited_text then Ok ()
-      else
-        State.edit_message ~clock ~channel_id:state.channel_id ~message_id:ts
-          ~content:head ()
-    in
-    (match edit_result with
-     | Error error ->
-       log_stream_error "final edit" state error;
-       Stream_final_edit_failed error
-     | Ok () ->
-       state.last_edited_text <- head;
-       if String.equal overflow "" then Stream_completed
-       else
-         match
-           State.send_message ~clock ~channel_id:state.channel_id
-             ~content:overflow
-             ~reply_to_message_id:state.reply_to_thread_ts ()
-         with
-         | Ok _ -> Stream_completed
-         | Error error ->
-           log_stream_error "overflow send" state error;
-           Stream_overflow_send_failed error)
-
-(* ---------------------------------------------------------------- *)
 (* Inbound delivery                                                 *)
 (* ---------------------------------------------------------------- *)
 
-let handle_inbound ?resolved_binding ~dispatch ~clock ~channel_id ~thread_ts
-    ~user_id ~user_name ~text ~ts ~mentions_bot ~is_app_mention () =
-  let binding =
-    match resolved_binding with
-    | Some binding -> Some binding
-    | None -> State.resolve_keeper_for_channel ~channel_id
-  in
-  match binding with
+type accepted_inbound =
+  { channel_id : string
+  ; reply_to_thread_ts : string
+  ; keeper_name : string
+  ; outcome : (Channel_gate.outbound_message, Channel_gate.gate_error) result
+  }
+
+let accept_inbound ~resolved_binding ~dispatch ~channel_id ~thread_ts ~user_id
+    ~user_name ~text ~ts ~mentions_bot ~is_app_mention =
+  match resolved_binding with
   | None ->
     (* No binding for this channel — drop quietly. The bot may sit in channels
        it isn't bound to. *)
     Slack_observability.record_inbound_dispatch
-      Slack_observability.Dropped_unbound
+      Slack_observability.Dropped_unbound;
+    None
   | Some resolution ->
     let keeper_name = resolution.State.keeper_name in
     (* Reply into the triggering message's thread. [thread_ts]=None is a
@@ -317,11 +197,16 @@ let handle_inbound ?resolved_binding ~dispatch ~clock ~channel_id ~thread_ts
       ; metadata
       }
     in
-    let stream_reply = make_slack_stream_reply ~channel_id ~reply_to_thread_ts in
-    let on_text_snapshot = publish_slack_stream_snapshot ~clock stream_reply in
-    (match
-       Channel_gate.handle_inbound_streaming ~dispatch ~on_text_snapshot msg
-     with
+    Some
+      { channel_id
+      ; reply_to_thread_ts
+      ; keeper_name
+      ; outcome = Channel_gate.handle_inbound ~dispatch msg
+      }
+
+let deliver_inbound ~clock accepted =
+  let { channel_id; reply_to_thread_ts; keeper_name; outcome } = accepted in
+  match outcome with
      | Error gate_err -> (
        match gate_err with
        | Channel_gate.Dispatch_unavailable ->
@@ -362,37 +247,22 @@ let handle_inbound ?resolved_binding ~dispatch ~clock ~channel_id ~thread_ts
        end
        else
          match
-           finish_slack_stream_reply ~clock stream_reply
-             ~final_content:out.content
+           State.send_message ~clock ~channel_id ~content:out.content
+             ~reply_to_message_id:reply_to_thread_ts ()
          with
-         | Stream_completed ->
+         | Ok _ ->
            Slack_observability.record_inbound_dispatch
              Slack_observability.Reply_sent;
            Slack_observability.record_reply Slack_observability.Reply_send_ok
-         | Stream_not_started | Stream_final_edit_failed _ -> (
-           match
-             State.send_message ~clock ~channel_id ~content:out.content
-               ~reply_to_message_id:reply_to_thread_ts ()
-           with
-           | Ok _ ->
-             Slack_observability.record_inbound_dispatch
-               Slack_observability.Reply_sent;
-             Slack_observability.record_reply Slack_observability.Reply_send_ok
-           | Error e ->
-             Slack_observability.record_inbound_dispatch
-               Slack_observability.Reply_send_error;
-             Slack_observability.record_reply
-               Slack_observability.Reply_send_failed;
-             Log.Server.error "slack send_message failed (channel=%s): %s"
-               channel_id
-               (Format.asprintf "%a" State.pp_send_error e))
-         | Stream_overflow_send_failed _ ->
+         | Error e ->
            Slack_observability.record_inbound_dispatch
              Slack_observability.Reply_send_error;
-           Slack_observability.record_reply
-             Slack_observability.Reply_send_failed)
+           Slack_observability.record_reply Slack_observability.Reply_send_failed;
+           Log.Server.error "slack send_message failed (channel=%s): %s"
+             channel_id
+             (Format.asprintf "%a" State.pp_send_error e)
 
-let on_event ?resolved_binding ~dispatch ~clock (ev : Gw.slack_event) =
+let accept_event ~resolved_binding ~dispatch (ev : Gw.slack_event) =
   match ev with
   | Gw.Message_create
       { channel_id; thread_ts; user_id; user_name; text; ts; mentions_bot
@@ -403,27 +273,30 @@ let on_event ?resolved_binding ~dispatch ~clock (ev : Gw.slack_event) =
          bot, including itself under the [All] policy). The loop guard lives
          here, where the outbound side is known, not in the pure FSM. *)
       Slack_observability.record_gateway_event ~route:Slack_observability.Control
-        Slack_observability.Ignored
+        Slack_observability.Ignored;
+      None
     | None ->
       Slack_observability.record_gateway_event
         ~route:Slack_observability.Triggered Slack_observability.Message_create;
-      handle_inbound ?resolved_binding ~dispatch ~clock ~channel_id ~thread_ts
-        ~user_id ~user_name ~text ~ts ~mentions_bot ~is_app_mention:false ())
+      accept_inbound ~resolved_binding ~dispatch ~channel_id ~thread_ts
+        ~user_id ~user_name ~text ~ts ~mentions_bot ~is_app_mention:false)
   | Gw.App_mention { channel_id; thread_ts; user_id; text; ts } ->
     Slack_observability.record_gateway_event ~route:Slack_observability.Triggered
       Slack_observability.App_mention;
-    handle_inbound ?resolved_binding ~dispatch ~clock ~channel_id ~thread_ts
+    accept_inbound ~resolved_binding ~dispatch ~channel_id ~thread_ts
       ~user_id
-      ~user_name:None ~text ~ts ~mentions_bot:true ~is_app_mention:true ()
+      ~user_name:None ~text ~ts ~mentions_bot:true ~is_app_mention:true
   | Gw.Reaction_added _ ->
     (* Ambient this pass: reactions are not turn-starters (RFC-0317). *)
     Slack_observability.record_gateway_event ~route:Slack_observability.Ambient
-      Slack_observability.Reaction_added
+      Slack_observability.Reaction_added;
+    None
   | Gw.Ignored_event _ ->
     Slack_observability.record_gateway_event ~route:Slack_observability.Control
-      Slack_observability.Ignored
+      Slack_observability.Ignored;
+    None
 
-let submit_event ingress ~dispatch ~clock (ev : Gw.slack_event) =
+let submit_event ?deliver ingress ~dispatch ~clock (ev : Gw.slack_event) =
   let submit ~channel_id ~event_id =
     match State.resolve_keeper_for_channel_result ~channel_id with
     | Error reason ->
@@ -431,34 +304,43 @@ let submit_event ingress ~dispatch ~clock (ev : Gw.slack_event) =
       Log.Server.error
         "Slack ingress binding unavailable channel=%s event=%s: %s"
         channel_id event_id reason
-    | Ok None -> on_event ~dispatch ~clock ev
-    | Ok (Some resolution) ->
-      let lane =
-        Connector_ingress_lane.Keeper_lane resolution.State.keeper_name
-      in
-      let ingress_event_id =
-        Connector_ingress_lane.{ source = "slack_triggered"; opaque_id = event_id }
-      in
-      (match
-         Connector_ingress_lane.submit
-           ingress
-           ~lane
-           ~event_id:ingress_event_id
-           (fun () -> on_event ~resolved_binding:resolution ~dispatch ~clock ev)
-       with
-       | Ok () -> ()
-       | Error error ->
-         Log.Server.error
-           "Slack ingress submission rejected lane=%s event=%s: %s"
-           (Connector_ingress_lane.lane_to_string lane)
-           (Connector_ingress_lane.event_id_to_string ingress_event_id)
-           (Connector_ingress_lane.submit_error_to_string error))
+    | Ok resolved_binding -> (
+      match accept_event ~resolved_binding ~dispatch ev with
+      | None -> ()
+      | Some accepted ->
+        let lane = Connector_ingress_lane.Keeper_lane accepted.keeper_name in
+        let ingress_event_id =
+          Connector_ingress_lane.{ source = "slack_triggered"; opaque_id = event_id }
+        in
+        let delivery =
+          match deliver with
+          | Some deliver -> deliver
+          | None -> fun () -> deliver_inbound ~clock accepted
+        in
+        match
+          Connector_ingress_lane.submit
+            ingress
+            ~lane
+            ~event_id:ingress_event_id
+            delivery
+        with
+        | Ok () -> ()
+        | Error error ->
+          Log.Server.error
+            "Slack ingress submission rejected lane=%s event=%s: %s"
+            (Connector_ingress_lane.lane_to_string lane)
+            (Connector_ingress_lane.event_id_to_string ingress_event_id)
+            (Connector_ingress_lane.submit_error_to_string error))
   in
   match ev with
-  | Gw.Message_create { bot_id = Some _; _ } -> on_event ~dispatch ~clock ev
+  | Gw.Message_create { bot_id = Some _; _ } ->
+    (* See [accept_event]: this variant only records observability. *)
+    ignore (accept_event ~resolved_binding:None ~dispatch ev)
   | Gw.Message_create { channel_id; ts; bot_id = None; _ }
   | Gw.App_mention { channel_id; ts; _ } -> submit ~channel_id ~event_id:ts
-  | Gw.Reaction_added _ | Gw.Ignored_event _ -> on_event ~dispatch ~clock ev
+  | Gw.Reaction_added _ | Gw.Ignored_event _ ->
+    (* See [accept_event]: these variants only record observability. *)
+    ignore (accept_event ~resolved_binding:None ~dispatch ev)
 ;;
 
 module For_testing = struct
@@ -487,8 +369,8 @@ let start ~sw ~env ~state =
          detail
      | Ok policy ->
        State.clear_startup_error ();
-       (* One clock for the whole gateway: bounds [auth.test] at start and every
-          outbound reply send/edit, and feeds the dispatch adapter. *)
+       (* One clock for the whole gateway: bounds [auth.test], durable accept,
+          and outbound ACK sends. *)
        let clock = Eio.Stdenv.clock env in
        (* Resolve the bot's own identity for mention detection. Non-fatal:
           without it, [app_mention] events still trigger (a mention by
@@ -528,19 +410,8 @@ let start ~sw ~env ~state =
            ()
        in
        let dispatch_for_config config =
-         (* Tag this dispatch as the Slack connector so a message arriving while
-            the keeper is in flight enqueues onto [Keeper_chat_queue] (drained
-            by the serial consumer, delivered via
-            [Keeper_chat_slack.adapter_loop]) rather than the outbound-less
-            async poll store. *)
-         Gate_keeper_backend.dispatch_with_text_snapshot
-           ~connector_kind:Gate_keeper_backend.Slack
-           ~submission_owner:Gate_keeper_backend.Channel_actor
-           ~sw ~clock
-           ~proc_mgr:state.Mcp_server.proc_mgr ~net:state.Mcp_server.net
-           ~publication_recovery_provider:
-             (Mcp_server.publication_recovery_availability_provider state)
-           ~config
+         Gate_keeper_backend.accept_connector
+           ~connector:Gate_keeper_backend.Slack_connector ~clock ~config
        in
        let policy_label = Gw.trigger_policy_to_string policy in
        Log.Server.info

--- a/lib/server/server_slack_in_process_gateway.mli
+++ b/lib/server/server_slack_in_process_gateway.mli
@@ -7,11 +7,10 @@
     1. Resolves the bot identity via [auth.test] (non-fatal) and connects to
        Slack Socket Mode ({!Slack_socket_client.run}).
     2. For each triggered [Message_create] / [App_mention] event, looks up the
-       channel→keeper binding
-       ({!Channel_gate_slack_state.resolve_keeper_for_channel}), runs the keeper
-       turn through {!Channel_gate.handle_inbound_streaming}, and projects
-       redacted text snapshots by posting/editing one threaded reply via
-       {!Channel_gate_slack_state.send_message} / [edit_message].
+       channel→keeper binding and durably accepts the exact source event before
+       the socket callback returns. Network ACK delivery then runs on the
+       Keeper-scoped connector lane; the durable chat-queue consumer owns the
+       eventual Keeper turn and connector reply.
 
     Off by default: if [SLACK_APP_TOKEN] is unset the gateway logs a
     warning and skips startup; the server still boots normally. A message
@@ -58,8 +57,9 @@ val trigger_policy_load_error_to_string : trigger_policy_load_error -> string
 
 module For_testing : sig
   val submit_event :
+    ?deliver:(unit -> unit) ->
     Connector_ingress_lane.t ->
-    dispatch:Channel_gate.streaming_dispatch_fn ->
+    dispatch:Channel_gate.dispatch_fn ->
     clock:_ Eio.Time.clock ->
     Slack_socket_client.slack_event ->
     unit

--- a/test/test_server_slack_trigger_policy.ml
+++ b/test/test_server_slack_trigger_policy.ml
@@ -215,46 +215,60 @@ let slack_message ~ts =
 ;;
 
 let test_bound_message_queues_exact_slack_ts () =
-  with_temp_base (fun () ->
-    try
-      match
-        State.bind ~channel_id:"C123" ~keeper_name:"luna" ~actor_name:"test"
-      with
-      | Error detail -> fail detail
-      | Ok _ ->
-        Eio_main.run @@ fun env ->
-        Eio.Switch.run @@ fun sw ->
-        let observed, resolve_observed = Eio.Promise.create () in
-        let ingress =
-          Connector_ingress_lane.create ~sw
-            ~on_failure:(fun failure ->
-              Eio.Promise.resolve resolve_observed failure)
-            ()
-        in
-        let dispatch ~on_text_snapshot:_ ~channel:_ ~channel_user_id:_
-            ~channel_user_name:_ ~channel_workspace_id:_ ~keeper_name:_
-            ~idempotency_key:_ ~metadata:_ ~content:_ =
-          failwith "observe Slack ingress identity"
-        in
-        G.For_testing.submit_event ingress ~dispatch
-          ~clock:(Eio.Stdenv.clock env)
-          (slack_message ~ts:"1710000000.123456");
-        let failure = Eio.Promise.await observed in
-        check string "exact Slack event ts" "1710000000.123456"
-          failure.Connector_ingress_lane.event_id.opaque_id;
-        check string "typed source" "slack_triggered"
-          failure.event_id.source;
-        (match failure.lane with
-         | Connector_ingress_lane.Keeper_lane keeper_name ->
-           check string "resolved Keeper lane" "luna" keeper_name
-         | Connector_ingress_lane.Connector_lane connector_id ->
-           failf "expected Keeper lane, got connector:%s" connector_id);
-        Eio.Switch.fail sw Exit
-    with Exit -> ())
+  try
+    with_temp_base (fun () ->
+    match
+      State.bind ~channel_id:"C123" ~keeper_name:"luna" ~actor_name:"test"
+    with
+    | Error detail -> fail detail
+    | Ok _ ->
+      Eio_main.run @@ fun env ->
+      Eio.Switch.run @@ fun sw ->
+      let observed, resolve_observed = Eio.Promise.create () in
+      let ingress =
+        Connector_ingress_lane.create ~sw
+          ~on_failure:(fun failure ->
+            Eio.Promise.resolve resolve_observed failure)
+          ()
+      in
+      let accepted_before_delivery = ref false in
+      let dispatch ~channel:_ ~channel_user_id:_ ~channel_user_name:_
+          ~channel_workspace_id:_ ~keeper_name:_ ~idempotency_key:_ ~metadata:_
+          ~content:_ =
+        accepted_before_delivery := true;
+        Gate_protocol.Reply
+          { content = "queued"
+          ; structured = None
+          ; stats = None
+          ; message_request = None
+          }
+      in
+      G.For_testing.submit_event
+        ~deliver:(fun () ->
+          if not !accepted_before_delivery then
+            failwith "delivery ran before durable accept";
+          failwith "observe Slack ingress identity")
+        ingress ~dispatch
+        ~clock:(Eio.Stdenv.clock env)
+        (slack_message ~ts:"1710000000.123456");
+      check bool "accept completed before handoff" true !accepted_before_delivery;
+      let failure = Eio.Promise.await observed in
+      check string "exact Slack event ts" "1710000000.123456"
+        failure.Connector_ingress_lane.event_id.opaque_id;
+      check string "typed source" "slack_triggered"
+        failure.event_id.source;
+      (match failure.lane with
+       | Connector_ingress_lane.Keeper_lane keeper_name ->
+         check string "resolved Keeper lane" "luna" keeper_name
+       | Connector_ingress_lane.Connector_lane connector_id ->
+         failf "expected Keeper lane, got connector:%s" connector_id);
+      Eio.Switch.fail sw Exit)
+  with Exit -> ()
 ;;
 
 let test_binding_store_failure_does_not_enqueue () =
-  with_temp_base (fun () ->
+  try
+    with_temp_base (fun () ->
     let binding_path =
       Filename.concat
         (Env_config_core.base_path ())
@@ -265,28 +279,29 @@ let test_binding_store_failure_does_not_enqueue () =
     Fun.protect
       ~finally:(fun () -> close_out_noerr out)
       (fun () -> output_string out "{not-json");
-    try
-      Eio_main.run @@ fun env ->
-      Eio.Switch.run @@ fun sw ->
-      let dispatch_called = ref false in
-      let ingress =
-        Connector_ingress_lane.create ~sw
-          ~on_failure:(fun _ -> fail "binding failure must not enqueue")
-          ()
-      in
-      let dispatch ~on_text_snapshot:_ ~channel:_ ~channel_user_id:_
-          ~channel_user_name:_ ~channel_workspace_id:_ ~keeper_name:_
-          ~idempotency_key:_ ~metadata:_ ~content:_ =
-        dispatch_called := true;
-        Gate_protocol.Unavailable_result
-      in
-      G.For_testing.submit_event ingress ~dispatch
-        ~clock:(Eio.Stdenv.clock env)
-        (slack_message ~ts:"1710000000.654321");
-      Eio.Fiber.yield ();
-      check bool "no volatile job accepted" false !dispatch_called;
-      Eio.Switch.fail sw Exit
-    with Exit -> ())
+    Eio_main.run @@ fun env ->
+    Eio.Switch.run @@ fun sw ->
+    let dispatch_called = ref false in
+    let ingress =
+      Connector_ingress_lane.create ~sw
+        ~on_failure:(fun _ -> fail "binding failure must not enqueue")
+        ()
+    in
+    let dispatch ~channel:_ ~channel_user_id:_ ~channel_user_name:_
+        ~channel_workspace_id:_ ~keeper_name:_ ~idempotency_key:_ ~metadata:_
+        ~content:_ =
+      dispatch_called := true;
+      Gate_protocol.Unavailable_result
+    in
+    G.For_testing.submit_event
+      ~deliver:(fun () -> fail "binding failure must not schedule delivery")
+      ingress ~dispatch
+      ~clock:(Eio.Stdenv.clock env)
+      (slack_message ~ts:"1710000000.654321");
+    Eio.Fiber.yield ();
+    check bool "no volatile job accepted" false !dispatch_called;
+    Eio.Switch.fail sw Exit)
+  with Exit -> ()
 ;;
 
 let () =


### PR DESCRIPTION
## Outcome

Slack Socket Mode completes the typed durable connector accept before its WSS callback hands ACK delivery to process memory. The per-Keeper connector lane carries only the network ACK projection; Keeper work already lives in `Keeper_chat_queue`.

## Boundary

- resolve the typed channel-to-Keeper binding synchronously
- preserve the producer Slack ts as the connector event identity
- call `Gate_keeper_backend.accept_connector` before `Connector_ingress_lane.submit`
- keep ACK delivery and lane-submission failures isolated and explicitly observable by Keeper lane/event
- hard-delete the dead streaming projection
- preserve the latest main test-fiber termination contract

This does not move Gate effect provenance into connector code. Channel-gate process-local dedup remains separate follow-up scope.

## Evidence

- focused test asserts durable accept completes before delivery handoff
- focused test preserves exact Slack ts and resolved Keeper lane on delivery failure
- focused test asserts unreadable binding state schedules neither accept nor delivery
- `ocamlformat --check`: pass for all three touched files
- `ocamlc -stop-after parsing`: pass for both touched `.ml` files
- `git diff --check`: pass
- full Dune build/tests delegated to PR CI per repository policy

Restacked directly on current `main`; the former base #24577 and Discord sibling #24594 are already merged. Current delta: +157/-273 across 3 files.