### PR TITLE
feat(dashboard): project exact compaction receipts

### DIFF
--- a/dashboard/src/api/dashboard-turn-records.ts
+++ b/dashboard/src/api/dashboard-turn-records.ts
@@ -222,6 +222,36 @@ export type KeeperCompactionSnapshotLinks = {
   readonly tool_call_log_path: string | null
 }
 
+export type KeeperCompactionExactEvidence = {
+  readonly before_checkpoint_bytes: number
+  readonly after_checkpoint_bytes: number
+  readonly before_message_count: number
+  readonly after_message_count: number
+  readonly summarized_message_count: number
+  readonly dropped_message_count: number
+  readonly before_tool_use_count: number
+  readonly after_tool_use_count: number
+  readonly before_tool_result_count: number
+  readonly after_tool_result_count: number
+}
+
+export type KeeperCompactionReinjectionState =
+  | 'not_linked'
+  | 'awaiting_load'
+  | 'checkpoint_not_loaded'
+  | 'loaded_not_injected'
+  | 'reinserted'
+  | 'sequence_incomplete'
+  | 'sequence_reversed'
+  | 'duplicate_receipt'
+
+export type KeeperCompactionReinjectionObservation = {
+  readonly state: KeeperCompactionReinjectionState
+  readonly keeper_turn_id: number | null
+  readonly checkpoint_loaded_receipts: number
+  readonly context_injected_receipts: number
+}
+
 export type KeeperCompactionSnapshot = {
   readonly id: string
   readonly keeper: string
@@ -240,6 +270,8 @@ export type KeeperCompactionSnapshot = {
   readonly compaction_source: string | null
   readonly status: string
   readonly links: KeeperCompactionSnapshotLinks
+  readonly exact_evidence: KeeperCompactionExactEvidence | null
+  readonly reinjection_observation: KeeperCompactionReinjectionObservation
 }
 
 export type KeeperCompactionSnapshotsResponse = {
@@ -542,6 +574,54 @@ function nullableNumber(raw: unknown): number | null {
   return asNumber(raw) ?? null
 }
 
+function decodeCompactionExactEvidence(raw: unknown): KeeperCompactionExactEvidence | null | undefined {
+  if (raw === null) return null
+  if (!isRecord(raw)) return undefined
+  const evidence = {
+    before_checkpoint_bytes: asNumber(raw.before_checkpoint_bytes),
+    after_checkpoint_bytes: asNumber(raw.after_checkpoint_bytes),
+    before_message_count: asNumber(raw.before_message_count),
+    after_message_count: asNumber(raw.after_message_count),
+    summarized_message_count: asNumber(raw.summarized_message_count),
+    dropped_message_count: asNumber(raw.dropped_message_count),
+    before_tool_use_count: asNumber(raw.before_tool_use_count),
+    after_tool_use_count: asNumber(raw.after_tool_use_count),
+    before_tool_result_count: asNumber(raw.before_tool_result_count),
+    after_tool_result_count: asNumber(raw.after_tool_result_count),
+  }
+  return Object.values(evidence).some(value => value === undefined)
+    ? undefined
+    : evidence as KeeperCompactionExactEvidence
+}
+
+const COMPACTION_REINJECTION_STATES: readonly KeeperCompactionReinjectionState[] = [
+  'not_linked',
+  'awaiting_load',
+  'checkpoint_not_loaded',
+  'loaded_not_injected',
+  'reinserted',
+  'sequence_incomplete',
+  'sequence_reversed',
+  'duplicate_receipt',
+]
+
+function decodeCompactionReinjectionObservation(
+  raw: unknown,
+): KeeperCompactionReinjectionObservation | undefined {
+  if (!isRecord(raw)) return undefined
+  const state = asString(raw.state) as KeeperCompactionReinjectionState | undefined
+  const loaded = asNumber(raw.checkpoint_loaded_receipts)
+  const injected = asNumber(raw.context_injected_receipts)
+  if (!state || !COMPACTION_REINJECTION_STATES.includes(state)
+      || loaded === undefined || injected === undefined) return undefined
+  return {
+    state,
+    keeper_turn_id: nullableNumber(raw.keeper_turn_id),
+    checkpoint_loaded_receipts: loaded,
+    context_injected_receipts: injected,
+  }
+}
+
 function decodeKeeperCompactionSnapshot(raw: unknown): KeeperCompactionSnapshot | null {
   if (!isRecord(raw)) return null
   const id = asString(raw.id)
@@ -553,6 +633,10 @@ function decodeKeeperCompactionSnapshot(raw: unknown): KeeperCompactionSnapshot 
   if (!id || !keeper || !ts_iso || !source || !trigger || !status) return null
   const runtimeId = asNullableString(raw.runtime_id)
   const compactionSource = asNullableString(raw.compaction_source)
+  const exactEvidence = decodeCompactionExactEvidence(raw.exact_evidence)
+  const reinjectionObservation =
+    decodeCompactionReinjectionObservation(raw.reinjection_observation)
+  if (exactEvidence === undefined || reinjectionObservation === undefined) return null
   return {
     id,
     keeper,
@@ -571,6 +655,8 @@ function decodeKeeperCompactionSnapshot(raw: unknown): KeeperCompactionSnapshot 
     compaction_source: compactionSource,
     status,
     links: decodeKeeperCompactionSnapshotLinks(raw.links),
+    exact_evidence: exactEvidence,
+    reinjection_observation: reinjectionObservation,
   }
 }
 

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -538,6 +538,17 @@ describe('keeper tool telemetry fetchers', () => {
             compaction_source: 'event_bus',
             status: 'observed',
             links: { receipt_path: null, checkpoint_path: null, tool_call_log_path: null },
+            exact_evidence: {
+              before_checkpoint_bytes: 4096, after_checkpoint_bytes: 1024,
+              before_message_count: 8, after_message_count: 3,
+              summarized_message_count: 4, dropped_message_count: 1,
+              before_tool_use_count: 2, after_tool_use_count: 1,
+              before_tool_result_count: 2, after_tool_result_count: 1,
+            },
+            reinjection_observation: {
+              state: 'reinserted', keeper_turn_id: 13,
+              checkpoint_loaded_receipts: 1, context_injected_receipts: 1,
+            },
           },
           {
             id: 'manifest:trace-b:context_compacted:2026-06-26T04:03:00Z',
@@ -557,6 +568,11 @@ describe('keeper tool telemetry fetchers', () => {
             compaction_source: 'pre_dispatch_hygiene',
             status: 'compacted',
             links: {},
+            exact_evidence: null,
+            reinjection_observation: {
+              state: 'not_linked', keeper_turn_id: null,
+              checkpoint_loaded_receipts: 0, context_injected_receipts: 0,
+            },
           },
         ],
       }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
@@ -569,6 +585,7 @@ describe('keeper tool telemetry fetchers', () => {
     expect(result.items[0]?.before_tokens).toBe(210000)
     expect(result.items[0]?.saved_tokens).toBe(90000)
     expect(result.items[0]?.display_runtime).toBe('oas-seoul-1')
+    expect(result.items[0]?.reinjection_observation.state).toBe('reinserted')
     expect(result.read_error_count).toBe(1)
     expect(result.read_errors).toEqual([
       { scope: 'runtime_manifest_row:/tmp/bad.jsonl:1', error: 'bad row' },

--- a/dashboard/src/components/keeper-workspace/compaction-inspector-overlay.ts
+++ b/dashboard/src/components/keeper-workspace/compaction-inspector-overlay.ts
@@ -476,6 +476,9 @@ export function CompactionInspectorOverlay({
           <div class="cmp-trigger"><span class="sub-k">트리거</span>${ev.trigger}</div>
           <div class="cmp-trigger"><span class="sub-k">수행 런타임</span><span class="mono">${ev.runtime}</span></div>
           <div class="cmp-trigger"><span class="sub-k">소스</span><span class="mono">${ev.detailSource ?? ev.source}${ev.status ? ` · ${ev.status}` : ''}</span></div>
+          ${ev.reinjection
+            ? html`<div class="cmp-trigger"><span class="sub-k">재주입 관측</span><span class="mono">${ev.reinjection.state} · load=${ev.reinjection.checkpoint_loaded_receipts} · inject=${ev.reinjection.context_injected_receipts}</span></div>`
+            : null}
           ${ev.traceId
             ? html`<div class="cmp-trigger"><span class="sub-k">trace</span><span class="mono">${ev.traceId}${ev.keeperTurnId != null ? `#${ev.keeperTurnId}` : ''}</span></div>`
             : null}
@@ -494,6 +497,15 @@ export function CompactionInspectorOverlay({
             ${ev.before.msgs != null && ev.after.msgs != null
               ? html`<${CmpStat} label="메시지" a=${ev.before.msgs} b=${ev.after.msgs} max=${Math.max(ev.before.msgs, 1)} />`
               : null}
+            ${ev.before.bytes != null && ev.after.bytes != null
+              ? html`<${CmpStat} label="checkpoint bytes" a=${ev.before.bytes} b=${ev.after.bytes} max=${Math.max(ev.before.bytes, 1)} />`
+              : null}
+            ${ev.before.toolUses != null && ev.after.toolUses != null
+              ? html`<${CmpStat} label="tool use" a=${ev.before.toolUses} b=${ev.after.toolUses} max=${Math.max(ev.before.toolUses, 1)} />`
+              : null}
+            ${ev.before.toolResults != null && ev.after.toolResults != null
+              ? html`<${CmpStat} label="tool result" a=${ev.before.toolResults} b=${ev.after.toolResults} max=${Math.max(ev.before.toolResults, 1)} />`
+              : null}
             ${ev.before.traces != null && ev.after.traces != null
               ? html`<${CmpStat} label="trace" a=${ev.before.traces} b=${ev.after.traces} max=${Math.max(ev.before.traces, 1)} />`
               : null}
@@ -501,6 +513,9 @@ export function CompactionInspectorOverlay({
 
           <div class="turn-sec">
             <h4>유지 · 요약 · 폐기</h4>
+            ${ev.summarizedCount != null || ev.droppedCount != null
+              ? html`<div class="cmp-trigger"><span class="sub-k">LLM plan</span><span class="mono">summarized=${ev.summarizedCount ?? '—'} · dropped=${ev.droppedCount ?? '—'}</span></div>`
+              : null}
             ${ev.kept.length === 0 && ev.summarized.length === 0 && ev.dropped.length === 0
               ? html`<${DataGapNote}>현재 백엔드 projection은 kept / summarized / dropped 목록을 노출하지 않습니다. 이 snapshot은 "컴팩션 이벤트 발생"과 가능한 token 계측만 증명합니다.</${DataGapNote}>`
               : html`

--- a/dashboard/src/components/keeper-workspace/compaction-snapshots.ts
+++ b/dashboard/src/components/keeper-workspace/compaction-snapshots.ts
@@ -8,11 +8,15 @@
 
 import { signal, type Signal } from '@preact/signals'
 import type { KeeperCompactionSnapshot as BackendCompactionSnapshot } from '../../api/dashboard'
+import type { KeeperCompactionReinjectionObservation } from '../../api/dashboard-turn-records'
 
 export interface CompactionSnapshotNumbers {
   readonly tok: number | null
   readonly msgs?: number | null
   readonly traces?: number | null
+  readonly bytes?: number | null
+  readonly toolUses?: number | null
+  readonly toolResults?: number | null
 }
 
 export interface CompactionSnapshot {
@@ -28,6 +32,9 @@ export interface CompactionSnapshot {
   readonly keeperTurnId?: number | null
   readonly status?: string | null
   readonly detailSource?: string | null
+  readonly summarizedCount?: number | null
+  readonly droppedCount?: number | null
+  readonly reinjection?: KeeperCompactionReinjectionObservation
   readonly kept: readonly string[]
   readonly summarized: readonly string[]
   readonly dropped: readonly string[]
@@ -83,19 +90,35 @@ function labelFromIso(iso: string): string {
 }
 
 function backendSnapshotToLocal(snapshot: BackendCompactionSnapshot): CompactionSnapshot {
+  const evidence = snapshot.exact_evidence
   return {
     id: snapshot.id,
     at: labelFromIso(snapshot.ts_iso),
     atIso: snapshot.ts_iso,
     trigger: snapshot.trigger,
     runtime: snapshot.display_runtime,
-    before: { tok: finiteNumberOrNull(snapshot.before_tokens) },
-    after: { tok: finiteNumberOrNull(snapshot.after_tokens) },
+    before: {
+      tok: finiteNumberOrNull(snapshot.before_tokens),
+      msgs: evidence?.before_message_count ?? null,
+      bytes: evidence?.before_checkpoint_bytes ?? null,
+      toolUses: evidence?.before_tool_use_count ?? null,
+      toolResults: evidence?.before_tool_result_count ?? null,
+    },
+    after: {
+      tok: finiteNumberOrNull(snapshot.after_tokens),
+      msgs: evidence?.after_message_count ?? null,
+      bytes: evidence?.after_checkpoint_bytes ?? null,
+      toolUses: evidence?.after_tool_use_count ?? null,
+      toolResults: evidence?.after_tool_result_count ?? null,
+    },
     savedTokens: finiteNumberOrNull(snapshot.saved_tokens),
     traceId: snapshot.trace_id,
     keeperTurnId: snapshot.keeper_turn_id,
     status: snapshot.status,
     detailSource: snapshot.source,
+    summarizedCount: evidence?.summarized_message_count ?? null,
+    droppedCount: evidence?.dropped_message_count ?? null,
+    reinjection: snapshot.reinjection_observation,
     kept: [],
     summarized: [],
     dropped: [],

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -108,6 +108,17 @@ vi.mock('../../api/dashboard', async (importOriginal) => {
           compaction_source: 'event_bus',
           status: 'observed',
           links: { receipt_path: null, checkpoint_path: null, tool_call_log_path: null },
+          exact_evidence: {
+            before_checkpoint_bytes: 4096, after_checkpoint_bytes: 1024,
+            before_message_count: 8, after_message_count: 3,
+            summarized_message_count: 4, dropped_message_count: 1,
+            before_tool_use_count: 2, after_tool_use_count: 1,
+            before_tool_result_count: 2, after_tool_result_count: 1,
+          },
+          reinjection_observation: {
+            state: 'reinserted', keeper_turn_id: 13,
+            checkpoint_loaded_receipts: 1, context_injected_receipts: 1,
+          },
         },
       ],
     }),
@@ -841,6 +852,9 @@ describe('KeeperWorkspaceRail', () => {
     expect(container.textContent).toContain('proactive(85%)')
     expect(container.textContent).toContain('runtime_manifest · observed')
     expect(container.textContent).toContain('trace-cmp#12')
+    expect(container.textContent).toContain('reinserted · load=1 · inject=1')
+    expect(container.textContent).toContain('checkpoint bytes')
+    expect(container.textContent).toContain('summarized=4 · dropped=1')
     const promptContext = await findByTestId('compaction-prompt-context')
     expect(fetchKeeperTurnRecords).toHaveBeenCalledWith('masc-improver', 12, expect.any(Object))
     expect(promptContext.textContent).toContain('snapshot-linked turn-record')
@@ -882,6 +896,11 @@ describe('KeeperWorkspaceRail', () => {
           compaction_source: 'pre_dispatch_hygiene',
           status: 'compacted',
           links: { receipt_path: null, checkpoint_path: null, tool_call_log_path: null },
+          exact_evidence: null,
+          reinjection_observation: {
+            state: 'not_linked', keeper_turn_id: null,
+            checkpoint_loaded_receipts: 0, context_injected_receipts: 0,
+          },
         },
       ],
     })
@@ -993,6 +1012,11 @@ describe('KeeperWorkspaceRail', () => {
         compaction_source: 'event_bus',
         status: 'observed',
         links: { receipt_path: null, checkpoint_path: null, tool_call_log_path: null },
+        exact_evidence: null,
+        reinjection_observation: {
+          state: 'not_linked', keeper_turn_id: null,
+          checkpoint_loaded_receipts: 0, context_injected_receipts: 0,
+        },
       },
     ])
 

--- a/lib/keeper_registry/keeper_runtime_manifest_types.ml
+++ b/lib/keeper_registry/keeper_runtime_manifest_types.ml
@@ -148,7 +148,11 @@ let known_unrelated_untyped_compaction_snapshot_events =
 ;;
 
 let classify_compaction_snapshot_typed_event = function
-  | Event_bus_correlated | Context_compacted -> Compaction_snapshot_relevant
+  | Event_bus_correlated
+  | Context_compacted
+  | Context_injected
+  | Checkpoint_loaded ->
+    Compaction_snapshot_relevant
   | Turn_started
   | Phase_gate_decided
   | Runtime_routed
@@ -159,8 +163,6 @@ let classify_compaction_snapshot_typed_event = function
   | Provider_lane_resolved
   | Provider_attempt_started
   | Provider_attempt_finished
-  | Context_injected
-  | Checkpoint_loaded
   | Checkpoint_saved
   | Receipt_appended
   | Turn_finished ->

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -562,6 +562,8 @@ type compaction_snapshot_item =
   ; compaction_source : string option
   ; status : string
   ; links : Yojson.Safe.t
+  ; exact_evidence : Yojson.Safe.t option
+  ; reinjection_observation : Yojson.Safe.t
   }
 
 let compaction_snapshot_item_json (item : compaction_snapshot_item) =
@@ -589,7 +591,127 @@ let compaction_snapshot_item_json (item : compaction_snapshot_item) =
     ; "compaction_source", Json_util.string_opt_to_json item.compaction_source
     ; "status", `String item.status
     ; "links", item.links
+    ; "exact_evidence", Option.value ~default:`Null item.exact_evidence
+    ; "reinjection_observation", item.reinjection_observation
     ]
+;;
+
+type compaction_reinjection_state =
+  | Not_linked
+  | Awaiting_load
+  | Checkpoint_not_loaded
+  | Loaded_not_injected
+  | Reinserted
+  | Sequence_incomplete
+  | Sequence_reversed
+  | Duplicate_receipt
+
+let compaction_reinjection_state_to_string = function
+  | Not_linked -> "not_linked"
+  | Awaiting_load -> "awaiting_load"
+  | Checkpoint_not_loaded -> "checkpoint_not_loaded"
+  | Loaded_not_injected -> "loaded_not_injected"
+  | Reinserted -> "reinserted"
+  | Sequence_incomplete -> "sequence_incomplete"
+  | Sequence_reversed -> "sequence_reversed"
+  | Duplicate_receipt -> "duplicate_receipt"
+;;
+
+let compaction_not_linked_observation_json =
+  `Assoc
+    [ "state", `String (compaction_reinjection_state_to_string Not_linked)
+    ; "keeper_turn_id", `Null
+    ; "checkpoint_loaded_receipts", `Int 0
+    ; "context_injected_receipts", `Int 0
+    ]
+;;
+
+type compaction_receipt_kind =
+  | Checkpoint_load of bool option
+  | Context_injection
+
+type compaction_receipt =
+  { index : int
+  ; keeper_turn_id : int option
+  ; kind : compaction_receipt_kind
+  }
+
+let compaction_reinjection_observation_json ~manifest_rows ~row_index row =
+  let observation state ?keeper_turn_id ~loads ~injections () =
+    `Assoc
+      [ "state", `String (compaction_reinjection_state_to_string state)
+      ; "keeper_turn_id", Json_util.int_opt_to_json keeper_turn_id
+      ; "checkpoint_loaded_receipts", `Int loads
+      ; "context_injected_receipts", `Int injections
+      ]
+  in
+  match row.Keeper_runtime_manifest.links.checkpoint_path with
+  | None -> compaction_not_linked_observation_json
+  | Some checkpoint_path ->
+    let receipts =
+      manifest_rows
+      |> List.filter_map (fun (index, candidate) ->
+        if index <= row_index
+           || not (String.equal candidate.Keeper_runtime_manifest.trace_id row.trace_id)
+           || candidate.links.checkpoint_path <> Some checkpoint_path
+        then None
+        else
+          match candidate.event with
+          | Keeper_runtime_manifest.Checkpoint_loaded ->
+            Some
+              { index
+              ; keeper_turn_id = candidate.keeper_turn_id
+              ; kind =
+                  Checkpoint_load
+                    (Json_util.get_bool
+                       candidate.decision
+                       "loaded_checkpoint_present")
+              }
+          | Keeper_runtime_manifest.Context_injected ->
+            Some
+              { index
+              ; keeper_turn_id = candidate.keeper_turn_id
+              ; kind = Context_injection
+              }
+          | _ -> None)
+    in
+    (match receipts with
+     | [] -> observation Awaiting_load ~loads:0 ~injections:0 ()
+     | first :: _ ->
+       let turn_receipts =
+         List.filter
+           (fun receipt -> receipt.keeper_turn_id = first.keeper_turn_id)
+           receipts
+       in
+       let loads, injections =
+         List.fold_left
+           (fun (loads, injections) receipt ->
+             match receipt.kind with
+             | Checkpoint_load _ -> receipt :: loads, injections
+             | Context_injection -> loads, receipt :: injections)
+           ([], [])
+           turn_receipts
+       in
+       let state =
+         match loads, injections, first.keeper_turn_id with
+         | _, _, None -> Sequence_incomplete
+         | _ :: _ :: _, _, _ | _, _ :: _ :: _, _ -> Duplicate_receipt
+         | [ { kind = Checkpoint_load (Some true); index = load_index; _ } ]
+         , [ { index = injection_index; _ } ]
+         , _ ->
+           if load_index < injection_index then Reinserted else Sequence_reversed
+         | [ { kind = Checkpoint_load (Some true); _ } ], [], _ ->
+           Loaded_not_injected
+         | [ { kind = Checkpoint_load (Some false); _ } ], [], _ ->
+           Checkpoint_not_loaded
+         | _ -> Sequence_incomplete
+       in
+       observation
+         state
+         ?keeper_turn_id:first.keeper_turn_id
+         ~loads:(List.length loads)
+         ~injections:(List.length injections)
+         ())
 ;;
 
 let compaction_saved_tokens before_tokens after_tokens =
@@ -636,6 +758,8 @@ let compaction_event_bus_snapshot_json ~keeper_id (row : Keeper_runtime_manifest
              compaction_snapshot_clock_string row.decision "compaction_source"
          ; status = row.status
          ; links = compaction_snapshot_links_json row.links
+         ; exact_evidence = None
+         ; reinjection_observation = compaction_not_linked_observation_json
          })
   | _ ->
     (match Json_util.get_int row.decision "context_compacted_count" with
@@ -667,11 +791,18 @@ let compaction_event_bus_snapshot_json ~keeper_id (row : Keeper_runtime_manifest
             ; compaction_source
             ; status = row.status
             ; links = compaction_snapshot_links_json row.links
+            ; exact_evidence = None
+            ; reinjection_observation = compaction_not_linked_observation_json
             })
      | Some _ | None -> None)
 ;;
 
-let compaction_context_snapshot_json ~keeper_id (row : Keeper_runtime_manifest.t) =
+let compaction_context_snapshot_json
+      ~keeper_id
+      ~manifest_rows
+      ~row_index
+      (row : Keeper_runtime_manifest.t)
+  =
   (* TEL-OK: read-only dashboard projection; compaction telemetry is emitted by
      the keeper runtime/event bridge that produced the manifest row. *)
   let pre_dispatch_compacted =
@@ -716,15 +847,25 @@ let compaction_context_snapshot_json ~keeper_id (row : Keeper_runtime_manifest.t
          ; compaction_source
          ; status = row.status
          ; links = compaction_snapshot_links_json row.links
+         ; exact_evidence = Json_util.assoc_member_opt "exact_evidence" row.decision
+         ; reinjection_observation =
+             compaction_reinjection_observation_json
+               ~manifest_rows
+               ~row_index
+               row
          })
 ;;
 
-let compaction_snapshot_of_manifest_row ~keeper_id (row : Keeper_runtime_manifest.t) =
+let compaction_snapshot_of_manifest_row
+      ~keeper_id
+      ~manifest_rows
+      (row_index, (row : Keeper_runtime_manifest.t))
+  =
   match row.event with
   | Keeper_runtime_manifest.Event_bus_correlated ->
     compaction_event_bus_snapshot_json ~keeper_id row
   | Keeper_runtime_manifest.Context_compacted ->
-    compaction_context_snapshot_json ~keeper_id row
+    compaction_context_snapshot_json ~keeper_id ~manifest_rows ~row_index row
   | _ -> None
 ;;
 
@@ -766,6 +907,8 @@ let keeper_meta_compaction_snapshot_json ~config ~keeper_id =
              ; compaction_source = None
              ; status = "latest"
              ; links = `Assoc []
+             ; exact_evidence = None
+             ; reinjection_observation = compaction_not_linked_observation_json
              })
       , [] )
   | Ok None -> None, []
@@ -798,12 +941,14 @@ let compaction_snapshots_json ~config ~keeper_id ~limit =
   in
   let scan_truncated = path_scan_truncated || tail_scan_truncated in
   let manifest_items =
+    let manifest_rows = List.mapi (fun index row -> index, row) manifest_rows in
     manifest_rows
     |> List.sort (fun a b ->
       Float.compare
-        (compaction_snapshot_manifest_sort_value b)
-        (compaction_snapshot_manifest_sort_value a))
-    |> List.filter_map (compaction_snapshot_of_manifest_row ~keeper_id)
+        (compaction_snapshot_manifest_sort_value (snd b))
+        (compaction_snapshot_manifest_sort_value (snd a)))
+    |> List.filter_map
+         (compaction_snapshot_of_manifest_row ~keeper_id ~manifest_rows)
     |> compaction_snapshot_take limit
   in
   let items, read_errors =

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -4204,7 +4204,9 @@ let check_compaction_snapshot_event_class label expected actual =
 
 let expected_compaction_snapshot_event_class = function
   | Runtime_manifest.Event_bus_correlated
-  | Runtime_manifest.Context_compacted ->
+  | Runtime_manifest.Context_compacted
+  | Runtime_manifest.Context_injected
+  | Runtime_manifest.Checkpoint_loaded ->
     Runtime_manifest.Compaction_snapshot_relevant
   | Runtime_manifest.Turn_started
   | Runtime_manifest.Phase_gate_decided
@@ -4216,8 +4218,6 @@ let expected_compaction_snapshot_event_class = function
   | Runtime_manifest.Provider_lane_resolved
   | Runtime_manifest.Provider_attempt_started
   | Runtime_manifest.Provider_attempt_finished
-  | Runtime_manifest.Context_injected
-  | Runtime_manifest.Checkpoint_loaded
   | Runtime_manifest.Checkpoint_saved
   | Runtime_manifest.Receipt_appended
   | Runtime_manifest.Turn_finished ->
@@ -4253,23 +4253,31 @@ let test_compaction_snapshots_json_reads_runtime_manifest () =
     let clock_refs =
       Runtime_manifest.clock_refs
         ~compaction_id:"cmp-42"
-        ~compaction_source:"event_bus"
+        ~compaction_source:"provider_overflow"
         ()
     in
     let decision =
       Runtime_manifest.with_clock_refs
         ~clock_refs
         (Runtime_manifest.with_payload_role
-           ~payload_role:Runtime_manifest.Operator_evidence
+           ~payload_role:Runtime_manifest.Checkpoint
            (`Assoc
-              [ "last_compaction"
+              [ "trigger", `String "provider_overflow"
+              ; "before_tokens", `Int 210_000
+              ; "after_tokens", `Int 120_000
+              ; ( "exact_evidence"
                 , `Assoc
-                    [ "before_tokens", `Int 210_000
-                    ; "after_tokens", `Int 120_000
-                    ; "tokens_freed", `Int 90_000
-                    ; "phase_hint", `String "proactive(85%)"
-                    ]
-              ; "context_compacted_count", `Int 1
+                    [ "before_checkpoint_bytes", `Int 4096
+                    ; "after_checkpoint_bytes", `Int 1024
+                    ; "before_message_count", `Int 8
+                    ; "after_message_count", `Int 3
+                    ; "summarized_message_count", `Int 4
+                    ; "dropped_message_count", `Int 1
+                    ; "before_tool_use_count", `Int 2
+                    ; "after_tool_use_count", `Int 1
+                    ; "before_tool_result_count", `Int 2
+                    ; "after_tool_result_count", `Int 1
+                    ] )
               ]))
     in
     let row =
@@ -4278,15 +4286,33 @@ let test_compaction_snapshots_json_reads_runtime_manifest () =
         ~keeper_name:keeper_id
         ~trace_id
         ~keeper_turn_id:12
-        ~event:Runtime_manifest.Event_bus_correlated
+        ~event:Runtime_manifest.Context_compacted
         ~runtime_id:"oas-seoul-1"
         ~status:"observed"
         ~decision
+        ~checkpoint_path:"/checkpoint/trace.json"
         ()
     in
-    (match Runtime_manifest.append config row with
-     | Ok () -> ()
-     | Error msg -> Alcotest.failf "runtime manifest append failed: %s" msg);
+    let append row =
+      Result.get_ok (Runtime_manifest.append config row)
+    in
+    append row;
+    let receipt event decision =
+      Runtime_manifest.make
+        ~ts:"2026-06-26T03:04:00Z"
+        ~keeper_name:keeper_id
+        ~trace_id
+        ~keeper_turn_id:13
+        ~event
+        ~decision
+        ~checkpoint_path:"/checkpoint/trace.json"
+        ()
+    in
+    append
+      (receipt
+         Runtime_manifest.Checkpoint_loaded
+         (`Assoc [ "loaded_checkpoint_present", `Bool true ]));
+    append (receipt Runtime_manifest.Context_injected (`Assoc []));
     let top =
       Server_dashboard_http_keeper_api.compaction_snapshots_json
         ~config
@@ -4322,7 +4348,7 @@ let test_compaction_snapshots_json_reads_runtime_manifest () =
       (json_string_field "item" item "source");
     Alcotest.(check string)
       "trigger"
-      "proactive(85%)"
+      "provider_overflow"
       (json_string_field "item" item "trigger");
     Alcotest.(check string)
       "runtime"
@@ -4341,6 +4367,11 @@ let test_compaction_snapshots_json_reads_runtime_manifest () =
       (json_string_field "item" item "compaction_id");
     let links = json_object_field "item" item "links" in
     Alcotest.(check int) "links object exists" 3 (List.length links);
+    let reinjection = json_assoc "reinjection" (List.assoc "reinjection_observation" item) in
+    Alcotest.(check string)
+      "linked reinjection"
+      "reinserted"
+      (json_string_field "reinjection" reinjection "state");
     let item_json = Yojson.Safe.to_string (`Assoc item) in
     List.iter
       (fun forbidden ->


### PR DESCRIPTION
## Outcome

The compaction inspector is now a read model over the durable Keeper runtime manifest.

- projects the exact selected Runtime plus checkpoint bytes, message counts, summarized/dropped counts, and tool-use/tool-result counts
- folds the linked Context_compacted -> Checkpoint_loaded -> Context_injected sequence in append order
- exposes awaiting_load, checkpoint_not_loaded, loaded_not_injected, reinserted, sequence_incomplete, sequence_reversed, and duplicate_receipt as distinct observed states
- never persists a dashboard-side success boolean or synthesizes reinjection success
- keeps old rows explicit with null exact evidence and not_linked observation

## Stack

Base: #24575

Diff against base: +371/-28 (399 total changed lines).

## Verification

- ocamlformat --check on changed OCaml files: pass
- git diff --check: pass
- dashboard TypeScript typecheck: pass
- focused dashboard API + Keeper rail tests: 105 passed
- focused OCaml manifest projection regression added
- Dune intentionally not run locally; CI is the build/test authority per repository workflow.