### PR TITLE
refactor(gate): hard-cut typed Keeper ACK

### DIFF
--- a/lib/gate/dune
+++ b/lib/gate/dune
@@ -58,6 +58,7 @@
   ; existing
   masc_config
   masc_core
+  masc.keeper_invocation_types
   masc_pulse
   masc.http_client
   masc.masc_log

--- a/lib/gate/gate_protocol.ml
+++ b/lib/gate/gate_protocol.ml
@@ -20,48 +20,23 @@ type turn_stats = {
   tokens_used : int;
 }
 
-type message_request_status =
-  | Accepted
-  | Acceptance_uncertain
-  | Queued
-  | Running
-  | Done
-  | Failed
-  | Lost
-  | Cancelled
+type message_request_tracking =
+  | Keeper_run of
+      { run_ref : Keeper_invocation_types.run_ref
+      ; result_contract : Keeper_invocation_types.result_contract
+      }
+  | Chat_receipt of { receipt_id : string }
 
 type message_request = {
-  request_id : string;
+  tracking : message_request_tracking;
   destination_type : string;
   destination_id : string;
   channel : string;
   actor_id : string option;
-  status : message_request_status;
   modalities : string list;
   transport : string option;
   metadata : (string * string) list;
 }
-
-let message_request_status_to_string = function
-  | Accepted -> "accepted"
-  | Acceptance_uncertain -> "acceptance_uncertain"
-  | Queued -> "queued"
-  | Running -> "running"
-  | Done -> "done"
-  | Failed -> "error"
-  | Lost -> "lost"
-  | Cancelled -> "cancelled"
-
-let message_request_status_of_string = function
-  | "accepted" -> Some Accepted
-  | "acceptance_uncertain" -> Some Acceptance_uncertain
-  | "queued" -> Some Queued
-  | "running" -> Some Running
-  | "done" -> Some Done
-  | "error" -> Some Failed
-  | "lost" -> Some Lost
-  | "cancelled" -> Some Cancelled
-  | _ -> None
 
 let string_list_json values =
   `List (List.map (fun value -> `String value) values)
@@ -74,14 +49,30 @@ let message_request_to_json request =
     | None -> `Null
     | Some value -> `String value
   in
+  let tracking =
+    match request.tracking with
+    | Keeper_run { run_ref; result_contract } ->
+      `Assoc
+        [ "kind", `String "keeper_run"
+        ; "run_ref", Keeper_invocation_types.run_ref_to_json run_ref
+        ; ( "result_contract"
+          , `String
+              (Keeper_invocation_types.result_contract_to_string result_contract) )
+        ]
+    | Chat_receipt { receipt_id } ->
+      `Assoc
+        [ "kind", `String "chat_receipt"
+        ; "receipt_id", `String receipt_id
+        ; "state", `String "queued"
+        ]
+  in
   `Assoc
     [
-      ("request_id", `String request.request_id);
+      ("tracking", tracking);
       ("destination_type", `String request.destination_type);
       ("destination_id", `String request.destination_id);
       ("channel", `String request.channel);
       ("actor_id", optional_string request.actor_id);
-      ("status", `String (message_request_status_to_string request.status));
       ("modalities", string_list_json request.modalities);
       ("transport", optional_string request.transport);
       ("metadata", string_assoc_json request.metadata);

--- a/lib/gate/gate_protocol.mli
+++ b/lib/gate/gate_protocol.mli
@@ -35,41 +35,32 @@ type turn_stats = {
   tokens_used : int;
 }
 
-(** Durable MASC message request envelope.
+(** Durable MASC message tracking envelope.
 
     This is the layer shared by dashboard chat, Connectors, and future
-    MASC<->MASC peers: a producer submits a request, receives a
-    [request_id], then observes live projections and reconciles terminal
-    state by id.  [modalities] is intentionally open-string JSON so the
+    MASC<->MASC peers. Keeper invocations carry the exact typed [run_ref] and
+    result contract; chat-queue deferrals carry their distinct typed receipt.
+    [modalities] is intentionally open-string JSON so the
     text-only dashboard path can grow into image/audio/file parts without
     another route shape. *)
-type message_request_status =
-  | Accepted
-  | Acceptance_uncertain
-  | Queued
-  | Running
-  | Done
-  | Failed
-  | Lost
-  | Cancelled
+type message_request_tracking =
+  | Keeper_run of
+      { run_ref : Keeper_invocation_types.run_ref
+      ; result_contract : Keeper_invocation_types.result_contract
+      }
+  | Chat_receipt of { receipt_id : string }
 
 type message_request = {
-  request_id : string;
+  tracking : message_request_tracking;
   destination_type : string;
   destination_id : string;
   channel : string;
   actor_id : string option;
-  status : message_request_status;
   modalities : string list;
   transport : string option;
   metadata : (string * string) list;
 }
 
-val message_request_status_to_string : message_request_status -> string
-(** Parse the canonical status labels emitted by [keeper_msg_async].
-    Unknown labels return [None] so callers fail closed instead of silently
-    treating protocol drift as acceptance. *)
-val message_request_status_of_string : string -> message_request_status option
 val message_request_to_json : message_request -> Yojson.Safe.t
 
 (** Successful response to send back to the consumer. *)

--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -28,7 +28,7 @@ type connector_kind =
       (** Every connector that is not a wired in-process inbound gateway with its
           own outbound adapter. Today this is the HTTP gate-route lane
           (imessage-bot, cli-connector) which POSTs and awaits synchronously, so
-          a busy message keeps the async [masc_keeper_msg] poll path; see
+          a busy message keeps the asynchronous typed Keeper-run path; see
           RFC-connector-deferred-reply-via-chat-queue §3.3 option (a). *)
 
 type submission_owner =
@@ -93,7 +93,7 @@ let non_empty_opt value =
     legitimate reply *without* an ACK contract (queued, running — handled
     separately by the [Streaming] arm of the dispatch match), and the
     backend could not parse the ACK contract at all (malformed JSON,
-    missing request_id, missing status, unknown future status). The
+    missing/invalid run_ref or result contract). The
     connector could not distinguish "queued" from "parse failed".
 
     Exposing the failure as a typed sum lets the dispatch site surface
@@ -101,28 +101,34 @@ let non_empty_opt value =
     rather than silently substituting the keeper's reply text. *)
 type ack_parse_failure =
   | Invalid_json of string
-  | Missing_request_id
-  | Empty_request_id
-  | Missing_status
-  | Invalid_status of string
+  | Missing_run_ref
+  | Invalid_run_ref of Keeper_invocation_contract.request_error
+  | Run_ref_target_mismatch of
+      { expected : string
+      ; actual : string
+      }
+  | Missing_result_contract
+  | Invalid_result_contract of string
 
 let ack_parse_failure_to_string = function
   | Invalid_json detail ->
       Printf.sprintf "invalid json: %s" detail
-  | Missing_request_id -> "missing request_id"
-  | Empty_request_id -> "empty request_id"
-  | Missing_status -> "missing status"
-  | Invalid_status raw ->
-      Printf.sprintf "unknown status %S (not in the closed status set)" raw
+  | Missing_run_ref -> "missing run_ref"
+  | Invalid_run_ref error ->
+    Keeper_invocation_contract.request_error_to_string error
+  | Run_ref_target_mismatch { expected; actual } ->
+    Printf.sprintf "run_ref target %S does not match expected Keeper %S" actual expected
+  | Missing_result_contract -> "missing result_contract"
+  | Invalid_result_contract raw ->
+    Printf.sprintf "unknown result_contract %S" raw
 
 (** Parse the async ACK envelope from a keeper tool response body.
 
-    Returns [Ok request] when the body is a valid JSON object with both
-    a non-empty [request_id] and a [status] that maps to one of the
-    closed [Gate_protocol.message_request_status] variants.
+    Returns [Ok request] when the body carries a valid typed [run_ref] and
+    closed Keeper invocation result contract.
 
     Returns [Error reason] otherwise. JSON parse failures are isolated
-    from the closed-sum status check so that a malformed envelope is
+    from the typed tracking check so that a malformed envelope is
     surfaced as a backend-degraded path, distinct from a legitimately
     absent ACK field. *)
 let extract_message_request_ack ~channel ~channel_user_id ~keeper_name ~metadata body :
@@ -134,47 +140,33 @@ let extract_message_request_ack ~channel ~channel_user_id ~keeper_name ~metadata
   match json with
   | Error failure -> Error failure
   | Ok json ->
-      let request_id =
-        match Json_util.get_string json "request_id" with
-        | None -> None
-        | Some value -> non_empty_opt value
-      in
-      (match request_id with
-       | None ->
-           (match Json_util.get_string json "request_id" with
-            | Some _ -> Error Empty_request_id
-            | None -> Error Missing_request_id)
-       | Some trimmed_request_id -> (
-           match Json_util.get_string json "status" with
-           | None -> Error Missing_status
-           | Some raw ->
-               let normalized = String.lowercase_ascii (String.trim raw) in
-               (match
-                  Gate_protocol.message_request_status_of_string normalized
-                with
-               | Some status ->
-                   let destination_id =
-                     match Json_util.get_string json "keeper_name" with
-                     | Some value ->
-                       (match non_empty_opt value with
-                        | Some trimmed -> trimmed
-                        | None -> keeper_name)
-                     | None -> keeper_name
-                   in
-                   let request : Gate_protocol.message_request =
-                     { request_id = trimmed_request_id
-                     ; destination_type = "keeper"
-                     ; destination_id
-                     ; channel
-                     ; actor_id = non_empty_opt channel_user_id
-                     ; status
-                     ; modalities = [ "text" ]
-                     ; transport = non_empty_opt channel
-                     ; metadata = ("status_source", "keeper_msg_async") :: metadata
-                     }
-                   in
-                   Ok request
-               | None -> Error (Invalid_status normalized))))
+    (match Json_util.assoc_member_opt "run_ref" json with
+     | None -> Error Missing_run_ref
+     | Some run_ref_json ->
+       (match Keeper_invocation_contract.run_ref_of_json run_ref_json with
+        | Error error -> Error (Invalid_run_ref error)
+        | Ok run_ref ->
+          let actual = Keeper_invocation_contract.run_ref_target_name run_ref in
+          if not (String.equal actual keeper_name)
+          then Error (Run_ref_target_mismatch { expected = keeper_name; actual })
+          else
+            match Json_util.get_string json "result_contract" with
+            | None -> Error Missing_result_contract
+            | Some raw ->
+              (match Keeper_invocation_contract.result_contract_of_string raw with
+               | None -> Error (Invalid_result_contract raw)
+               | Some result_contract ->
+                 Ok
+                   { Gate_protocol.tracking =
+                       Gate_protocol.Keeper_run { run_ref; result_contract }
+                   ; destination_type = "keeper"
+                   ; destination_id = actual
+                   ; channel
+                   ; actor_id = non_empty_opt channel_user_id
+                   ; modalities = [ "text" ]
+                   ; transport = non_empty_opt channel
+                   ; metadata = ("tracking_source", "keeper_invocation") :: metadata
+                   })))
 
 let in_flight_metadata (info : Keeper_turn_admission.in_flight_info option) =
   match info with
@@ -183,7 +175,12 @@ let in_flight_metadata (info : Keeper_turn_admission.in_flight_info option) =
       [ "in_flight_lane", Keeper_turn_admission.lane_to_string lane ]
 
 let busy_ack_reply_text ?in_flight (request : Gate_protocol.message_request) =
-  let status = Gate_protocol.message_request_status_to_string request.status in
+  let tracking =
+    match request.tracking with
+    | Gate_protocol.Keeper_run { result_contract; _ } ->
+      Keeper_invocation_contract.result_contract_to_string result_contract
+    | Gate_protocol.Chat_receipt { receipt_id } -> "queued receipt " ^ receipt_id
+  in
   let in_flight_text =
     match in_flight with
     | None -> ""
@@ -193,15 +190,14 @@ let busy_ack_reply_text ?in_flight (request : Gate_protocol.message_request) =
           (Keeper_turn_admission.lane_to_string lane)
   in
   Printf.sprintf
-    "%s is busy; your message is %s (request_id=%s).%s"
+    "%s is busy; the Keeper invocation contract is %s. Preserve the returned tracking value.%s"
     request.destination_id
-    status
-    request.request_id
+    tracking
     in_flight_text
 
 (* ACK text for the RFC-connector-deferred-reply-via-chat-queue chat-queue deferral path. The
    message was durably enqueued onto [Keeper_chat_queue], so its receipt id is
-   the correlation handle instead of a [Keeper_msg_async] poll request id. The
+   the correlation handle instead of a Keeper-run reference. The
    reply is delivered later by the serial consumer through the connector's
    outbound adapter. *)
 let busy_ack_reply_text_queued
@@ -252,16 +248,15 @@ let chat_queue_message_request ~channel ~channel_user_id ~keeper_name
         [ ( "shutdown_operation_id"
           , Keeper_shutdown_types.Operation_id.to_string operation_id ) ]
   in
-  { Gate_protocol.request_id = receipt_id
+  { Gate_protocol.tracking = Gate_protocol.Chat_receipt { receipt_id }
   ; destination_type = "keeper"
   ; destination_id = keeper_name
   ; channel
   ; actor_id = non_empty_opt channel_user_id
-  ; status = Gate_protocol.Queued
   ; modalities = [ "text" ]
   ; transport = non_empty_opt channel
   ; metadata =
-      [ "status_source", "keeper_chat_queue"
+      [ "tracking_source", "keeper_chat_queue"
       ; "receipt_id", receipt_id
       ; "queue_revision", Int64.to_string receipt.revision
       ; "pending_count", string_of_int receipt.pending_count
@@ -706,13 +701,13 @@ let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~submission_owne
                body — that collapses the queued state with a degraded
                parse path and breaks the connector's "is this queued?"
                decision. Log the parse failure with the same
-               [status_source=keeper_msg_async] surface so on-call can
+               [tracking_source=keeper_invocation] surface so on-call can
                triage whether the keeper contract regressed or the body
                was truncated mid-flight, and emit a degraded reply that
                names the parse failure without leaking the raw body. *)
             Log.Server.warn
               "channel gate async ACK parse failure (keeper=%s, lane=%s, \
-               request_id_context=%s, failure=%s): connector will see a \
+               payload_bytes=%s, failure=%s): connector will see a \
                degraded ACK, not the keeper's reply body."
               keeper_name lane (extract_reply_text body |> String.length |> string_of_int)
               (ack_parse_failure_to_string failure);
@@ -720,7 +715,7 @@ let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~submission_owne
             , Printf.sprintf
                 "%s is busy; the gate could not parse the async ACK \
                  envelope (%s). Your message was forwarded to the keeper, \
-                 but no durable request id is available. Treat this as a \
+                 but no typed tracking value is available. Treat this as a \
                  transient backend degradation rather than a queued reply."
                 keeper_name
                 (ack_parse_failure_to_string failure) )
@@ -753,7 +748,8 @@ let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~submission_owne
       let reply =
         redact_text
           (busy_ack_reply_text_queued ~admission_rejection ~keeper_name
-             ~receipt_id:message_request.request_id
+             ~receipt_id:
+               (Keeper_chat_queue.Receipt_id.to_string receipt.receipt_id)
              ~recovery_required_count:receipt.recovery_required_count)
       in
       let stats =

--- a/lib/gate_keeper_backend.mli
+++ b/lib/gate_keeper_backend.mli
@@ -20,7 +20,7 @@ type connector_kind =
     dispatch-construction time. [Discord] and [Slack] each have an in-process
     inbound gateway and an outbound adapter, so a busy message projects onto the
     chat queue; [Generic] (the HTTP gate-route lane: imessage-bot, cli-connector)
-    keeps the async [masc_keeper_msg] poll path. See
+    keeps the typed asynchronous Keeper-run tracking path. See
     RFC-connector-deferred-reply-via-chat-queue §3.2–3.3 and RFC-0317. *)
 
 type submission_owner =
@@ -163,17 +163,21 @@ val extract_turn_stats : string -> Gate_protocol.turn_stats option
 
     The Channel Gate's async dispatch path returns a JSON envelope that the
     downstream connector uses to track the keeper-side request lifecycle
-    (request_id, status, destination). Parsing this envelope is a wire
+    (run_ref, result contract, destination). Parsing this envelope is a wire
     boundary: malformed input must surface as a typed failure so the
     dispatch site can emit a deliberate degraded ACK rather than silently
     substitute the keeper's reply body. *)
 
 type ack_parse_failure =
   | Invalid_json of string
-  | Missing_request_id
-  | Empty_request_id
-  | Missing_status
-  | Invalid_status of string
+  | Missing_run_ref
+  | Invalid_run_ref of Keeper_invocation_contract.request_error
+  | Run_ref_target_mismatch of
+      { expected : string
+      ; actual : string
+      }
+  | Missing_result_contract
+  | Invalid_result_contract of string
 (** Closed-sum typed parse failure for {!extract_message_request_ack}. Each
     variant names a distinct cause so the dispatch site can log structured
     backend drift and emit a degraded ACK that names the parse failure
@@ -192,9 +196,8 @@ val extract_message_request_ack :
   string ->
   (Gate_protocol.message_request, ack_parse_failure) result
 (** Parse the async ACK envelope from a keeper tool response body.
-    Returns [Ok request] when the body is a valid JSON object with both
-    a non-empty [request_id] and a [status] that maps to one of the closed
-    [Gate_protocol.message_request_status] variants.
+    Returns [Ok request] when the body carries a valid typed [run_ref] and
+    closed Keeper invocation result contract.
     Returns [Error reason] otherwise. JSON parse failures are isolated
     from the closed-sum status check so that a malformed envelope is
     surfaced as a backend-degraded path, distinct from a legitimately

--- a/lib/keeper/keeper_invocation_contract.ml
+++ b/lib/keeper/keeper_invocation_contract.ml
@@ -33,7 +33,6 @@ type result_contract = Keeper_invocation_types.result_contract =
 type request_error =
   | Invalid_target of string
   | Empty_prompt
-  | Invalid_entry_projection
   | Invalid_wire_value of
       { field : string
       ; expected : string
@@ -125,7 +124,6 @@ let request_of_json json =
 let request_error_to_string = function
   | Invalid_target reason -> reason
   | Empty_prompt -> "message is required"
-  | Invalid_entry_projection -> "Keeper invocation entry projection is not an object"
   | Invalid_wire_value { field; expected } ->
     Printf.sprintf "%s must be %s" field expected
   | Run_ref_mismatch -> "run_ref does not identify the stored Keeper invocation"
@@ -212,33 +210,6 @@ let run_ref_matches_entry reference (entry : Keeper_msg_async.entry) =
 
 let result_contract_to_string = Keeper_invocation_types.result_contract_to_string
 let result_contract_of_string = Keeper_invocation_types.result_contract_of_string
-
-let submission_to_json (request : request) outcome =
-  let common reference status contract =
-    [ "request_id", `String outcome.Keeper_msg_async.request_id
-    ; "keeper_name", `String (target_name request)
-    ; "status", `String status
-    ; "run_ref", run_ref_to_json reference
-    ; "result_contract", `String (result_contract_to_string contract)
-    ]
-  in
-  match submission_receipt request outcome with
-  | Durable_run reference ->
-    `Assoc
-      (common reference "queued" Awaiting_execution
-       @ [ ( "message"
-           , `String
-               "Keeper turn accepted. The caller lane may continue; query masc_keeper_msg_result with run_ref.run_id." )
-         ])
-  | Reconciliation_required { run_ref = reference; reason } ->
-    `Assoc
-      (common reference "reconciliation_required" Publication_uncertain
-       @ [ "reason", `String reason
-         ; ( "operator_instruction"
-           , `String
-               "Request publication is uncertain. Query masc_keeper_msg_result with this exact run_ref.run_id; do not resubmit." )
-         ])
-;;
 
 let delegate_submission_to_json (request : request) outcome =
   let common reference result_contract =
@@ -348,29 +319,6 @@ let delegate_entry_to_json (entry : Keeper_msg_async.entry) =
         ]
         @ timing
         @ entry_result entry.status))
-;;
-
-let entry_to_json entry =
-  let contract = result_contract entry in
-  let* target_name =
-    Keeper_id.Keeper_name.of_string entry.Keeper_msg_async.keeper_name
-    |> Result.map_error (fun reason -> Invalid_target reason)
-  in
-  let reference =
-    { run_id = entry.request_id
-    ; target = Keeper target_name
-    ; capability = Invoke_turn
-    }
-  in
-  match Keeper_msg_async.entry_to_json entry with
-  | `Assoc fields ->
-    Ok
-      (`Assoc
-         (fields
-          @ [ "run_ref", run_ref_to_json reference
-            ; "result_contract", `String (result_contract_to_string contract)
-            ]))
-  | _ -> Error Invalid_entry_projection
 ;;
 
 let delegate_cancellation_to_json reference result =

--- a/lib/keeper/keeper_invocation_contract.mli
+++ b/lib/keeper/keeper_invocation_contract.mli
@@ -32,7 +32,6 @@ type result_contract = Keeper_invocation_types.result_contract =
 type request_error =
   | Invalid_target of string
   | Empty_prompt
-  | Invalid_entry_projection
   | Invalid_wire_value of
       { field : string
       ; expected : string
@@ -69,9 +68,6 @@ val result_contract : Keeper_msg_async.entry -> result_contract
 val result_contract_to_string : result_contract -> string
 val result_contract_of_string : string -> result_contract option
 
-val submission_to_json
-  :  request -> Keeper_msg_async.submit_outcome -> Yojson.Safe.t
-
 val delegate_submission_to_json
   :  request -> Keeper_msg_async.submit_outcome -> Yojson.Safe.t
 
@@ -80,10 +76,6 @@ val delegate_submission_error_to_json
 
 val delegate_cancellation_to_json
   :  run_ref -> Keeper_msg_async.cancel_result -> Yojson.Safe.t
-
-val entry_to_json
-  :  Keeper_msg_async.entry
-  -> (Yojson.Safe.t, request_error) result
 
 val delegate_entry_to_json
   :  Keeper_msg_async.entry

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -125,10 +125,6 @@ let submit_keeper_msg_with_captured_event_bus
     ~f:(fun request request_sw -> f ?event_bus request request_sw)
     ()
 
-let submit_outcome_with_keeper_json ~request outcome =
-  Keeper_invocation_contract.submission_to_json request outcome
-;;
-
 module For_testing = struct
   let reset_keeper_list_cache () =
     Atomic.set keeper_list_cache (empty_json_cache ~generation:0)
@@ -137,7 +133,6 @@ module For_testing = struct
     cached_json_by_key keeper_list_cache ~key ~ttl_s compute
   let submit_keeper_msg_with_captured_event_bus =
     submit_keeper_msg_with_captured_event_bus
-  let submit_outcome_with_keeper_json = submit_outcome_with_keeper_json
 end
 let annotate_keeper_json ~runtime_class json =
   match json with
@@ -664,8 +659,9 @@ let handle_keeper_msg ?continuation_channel ~submitted_by ctx args : tool_result
     Ok
       (submit_keeper_invocation
          ~submitted_by
-         ~submission_to_json:Keeper_invocation_contract.submission_to_json
-         ~submission_error_to_json:Keeper_msg_async.submit_error_to_json
+         ~submission_to_json:Keeper_invocation_contract.delegate_submission_to_json
+         ~submission_error_to_json:
+           (Keeper_invocation_contract.delegate_submission_error_to_json request)
          ~run_turn:(fun ?event_bus request worker_ctx ->
            let worker_args = with_invocation_request worker_args request in
            let result =

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -2387,6 +2387,28 @@ let process_single_turn ~user_row_origin ~queued_turn
              });
         None, false
   in
+  let run_ref =
+    match submit_result with
+    | Error _ -> None
+    | Ok outcome ->
+      (match
+         Keeper_invocation_contract.request
+           ~keeper_name:payload.name
+           ~prompt:payload.message
+       with
+       | Ok request ->
+         Some
+           (match Keeper_invocation_contract.submission_receipt request outcome with
+            | Keeper_invocation_contract.Durable_run run_ref -> run_ref
+            | Keeper_invocation_contract.Reconciliation_required { run_ref; _ } ->
+              run_ref)
+       | Error error ->
+         Log.Keeper.error
+           "keeper_stream: accepted request has invalid typed identity keeper=%s error=%s"
+           payload.name
+           (Keeper_invocation_contract.request_error_to_string error);
+         None)
+  in
   (match client_disconnects, request_id with
    | None, _ | _, None -> ()
    | Some (disconnect_sw, disconnects), Some request_id ->
@@ -2414,24 +2436,29 @@ let process_single_turn ~user_row_origin ~queued_turn
                push_worker_event Stream_client_disconnected
              end));
   Option.iter
-    (fun request_id ->
+    (fun run_ref ->
+       let run_id = Keeper_invocation_contract.run_id run_ref in
        Log.Keeper.info
-         "keeper_stream: queued request keeper=%s request_id=%s surface=%s"
-         payload.name request_id
+         "keeper_stream: queued request keeper=%s run_id=%s surface=%s"
+         payload.name run_id
          (if has_connector_context payload then payload.channel else "dashboard");
        Keeper_chat_events.publish events
          (Custom
             { name = "KEEPER_QUEUE_REQUEST"
             ; value =
                 Gate_protocol.message_request_to_json
-                  { request_id
+                  { tracking =
+                      Gate_protocol.Keeper_run
+                        { run_ref
+                        ; result_contract =
+                            Keeper_invocation_contract.Awaiting_execution
+                        }
                   ; destination_type = "keeper"
                   ; destination_id = payload.name
                   ; channel =
                       (if has_connector_context payload then payload.channel
                        else "dashboard")
                   ; actor_id = Some agent_name
-                  ; status = Gate_protocol.Queued
                   ; modalities = modalities_for_request payload
                   ; transport = Some "sse"
                   ; metadata =
@@ -2440,7 +2467,7 @@ let process_single_turn ~user_row_origin ~queued_turn
                       ]
                   }
             }))
-    (if durably_accepted then request_id else None);
+    (if durably_accepted then run_ref else None);
   let publish_terminal ~status ?(message = "") () =
     let message = redact_text message in
     let status_label = keeper_request_terminal_status_to_string status in

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -323,31 +323,52 @@ let non_empty_json_string_member field json =
       if value = "" then None else Some value
   | _ -> None
 
-let board_context_inference_submission_json ~post_id ~target_source tool_data =
+let board_context_inference_submission_json ~post_id ~target_keeper ~target_source
+    tool_data =
   match
-    ( non_empty_json_string_member "request_id" tool_data,
-      non_empty_json_string_member "keeper_name" tool_data,
-      non_empty_json_string_member "status" tool_data )
+    json_assoc_member "run_ref" tool_data,
+    json_assoc_member "result_contract" tool_data
   with
-  | Some request_id, Some keeper_name, Some status ->
-      let fields =
-        [
-          ("ok", `Bool true);
-          ("request_id", `String request_id);
-          ("keeper_name", `String keeper_name);
-          ("post_id", `String post_id);
-          ("status", `String status);
-          ( "target_source",
-            `String (board_context_inference_target_source_to_string target_source) );
-        ]
+  | Some run_ref_json, Some (`String result_contract_raw) ->
+    (match
+       Keeper_invocation_contract.run_ref_of_json run_ref_json,
+       Keeper_invocation_contract.result_contract_of_string result_contract_raw
+     with
+     | Ok run_ref, Some result_contract ->
+      let actual_target =
+        Keeper_invocation_contract.run_ref_target_name run_ref
       in
-      let fields =
-        match non_empty_json_string_member "message" tool_data with
-        | Some message -> fields @ [ ("message", `String message) ]
-        | None -> fields
-      in
-      Ok (`Assoc fields)
-  | _ -> Error "masc_keeper_msg returned a malformed queue submission"
+      if not (String.equal actual_target target_keeper)
+      then
+        Error
+          (Printf.sprintf
+             "Keeper invocation target %S does not match board target %S"
+             actual_target
+             target_keeper)
+      else
+        let fields =
+          [ "ok", `Bool true
+          ; "run_ref", Keeper_invocation_contract.run_ref_to_json run_ref
+          ; "post_id", `String post_id
+          ; ( "result_contract"
+            , `String
+                (Keeper_invocation_contract.result_contract_to_string
+                   result_contract) )
+          ; ( "target_source"
+            , `String
+                (board_context_inference_target_source_to_string target_source) )
+          ]
+        in
+        let fields =
+          match non_empty_json_string_member "message" tool_data with
+          | Some message -> fields @ [ ("message", `String message) ]
+          | None -> fields
+        in
+        Ok (`Assoc fields)
+     | Error error, _ ->
+       Error (Keeper_invocation_contract.request_error_to_string error)
+     | Ok _, None -> Error "invalid Keeper invocation result_contract")
+  | _ -> Error "typed Keeper invocation submission is missing tracking fields"
 
 let dispatch_board_context_inference ~state ~sw ~clock ~request ~target_keeper
     ~target_source ~(post : Board.post) ~comments =
@@ -386,7 +407,7 @@ let dispatch_board_context_inference ~state ~sw ~clock ~request ~target_keeper
   if Tool_result.is_success result
   then
     (match
-       board_context_inference_submission_json ~post_id ~target_source
+       board_context_inference_submission_json ~post_id ~target_keeper ~target_source
          (Tool_result.data result)
      with
      | Ok json -> Ok json

--- a/lib/server/server_routes_http_routes_activity.mli
+++ b/lib/server/server_routes_http_routes_activity.mli
@@ -30,3 +30,10 @@ val resolve_board_context_inference_target :
   Board.post ->
   string option ->
   (string * board_context_inference_target_source, [ `Bad_request of string | `Internal_server_error of string ]) result
+
+val board_context_inference_submission_json :
+  post_id:string ->
+  target_keeper:string ->
+  target_source:board_context_inference_target_source ->
+  Yojson.Safe.t ->
+  (Yojson.Safe.t, string) result

--- a/lib/server/server_routes_http_routes_channel_gate.ml
+++ b/lib/server/server_routes_http_routes_channel_gate.ml
@@ -49,18 +49,23 @@ module Http = Http_server_eio
       {
         "ok": true,
         "destination_id": "luna",
-        "reply": "luna is busy; your message is queued (request_id=luna-abc123).",
+        "reply": "luna is busy; preserve the returned tracking value.",
         "turn_stats": { "model_used": null, "duration_ms": 8, "tokens_used": 0 },
         "message_request": {
-          "request_id": "luna-abc123",
+          "tracking": {
+            "kind": "keeper_run",
+            "run_ref": { "run_id": "luna-abc123",
+              "target": { "kind": "keeper", "name": "luna" },
+              "capability": "invoke_turn" },
+            "result_contract": "awaiting_execution"
+          },
           "destination_type": "keeper",
           "destination_id": "luna",
           "channel": "discord",
           "actor_id": "123456789",
-          "status": "queued",
           "modalities": ["text"],
           "transport": "discord",
-          "metadata": { "status_source": "keeper_msg_async" }
+          "metadata": { "tracking_source": "keeper_invocation" }
         }
       }
     ]}

--- a/test/test_board_context_inference_resolution.ml
+++ b/test/test_board_context_inference_resolution.ml
@@ -153,6 +153,37 @@ let test_target_resolution_implicit_unregistered_author () =
          "error message"
          "target_keeper is required because board post author \"operator\" is not a registered keeper")
 
+let typed_submission keeper_name =
+  `Assoc
+    [ ( "run_ref"
+      , `Assoc
+          [ "run_id", `String "run-1"
+          ; "target", `Assoc [ "kind", `String "keeper"; "name", `String keeper_name ]
+          ; "capability", `String "invoke_turn"
+          ] )
+    ; "result_contract", `String "awaiting_execution"
+    ]
+
+let test_typed_submission_projection () =
+  let project target data =
+    Server_routes_http_routes_activity.board_context_inference_submission_json
+      ~post_id:"post-1" ~target_keeper:target
+      ~target_source:Server_routes_http_routes_activity.Explicit_target data
+  in
+  (match project "luna" (typed_submission "luna") with
+   | Ok json ->
+     let open Yojson.Safe.Util in
+     check string "run id" "run-1"
+       (json |> member "run_ref" |> member "run_id" |> to_string);
+     check bool "legacy fields absent" true
+       (json |> member "request_id" = `Null && json |> member "status" = `Null)
+   | Error error -> fail error);
+  match project "luna" (typed_submission "other") with
+  | Error error ->
+    check bool "retargeting rejected" true
+      (String_util.string_contains_substring ~needle:"does not match" error)
+  | Ok _ -> fail "expected exact board target rejection"
+
 let () =
   run "Server board context inference resolution"
     [ ( "parse_request",
@@ -163,4 +194,6 @@ let () =
         ; test_case "implicit registered author" `Quick test_target_resolution_implicit_registered_author
         ; test_case "implicit unregistered author" `Quick test_target_resolution_implicit_unregistered_author
         ] )
+    ; ( "typed_submission",
+        [ test_case "projects exact run_ref" `Quick test_typed_submission_projection ] )
     ]

--- a/test/test_channel_gate.ml
+++ b/test/test_channel_gate.ml
@@ -162,21 +162,20 @@ let mock_dispatch_unavailable ~channel:_ ~channel_user_id:_ ~channel_user_name:_
 
 let queued_request : Gate_protocol.message_request =
   {
-    request_id = "req-queued";
+    tracking = Gate_protocol.Chat_receipt { receipt_id = "receipt-queued" };
     destination_type = "keeper";
     destination_id = "luna";
     channel = "discord";
     actor_id = Some "user-1";
-    status = Gate_protocol.Queued;
     modalities = [ "text" ];
     transport = Some "discord";
-    metadata = [ ("status_source", "keeper_msg_async") ];
+    metadata = [ ("tracking_source", "keeper_chat_queue") ];
   }
 
 let mock_dispatch_queued ~channel:_ ~channel_user_id:_ ~channel_user_name:_
     ~channel_workspace_id:_ ~keeper_name:_ ~idempotency_key:_ ~metadata:_ ~content:_ =
   Gate_protocol.Reply
-    { content = "luna is busy; your message is queued (request_id=req-queued)."
+    { content = "luna is busy; your message is durably queued."
     ; structured = None
     ; stats = None
     ; message_request = Some queued_request
@@ -200,13 +199,14 @@ let test_handle_inbound_surfaces_message_request () =
   match Channel_gate.handle_inbound ~dispatch:mock_dispatch_queued msg with
   | Ok out -> (
       check string "reply content"
-        "luna is busy; your message is queued (request_id=req-queued)."
+        "luna is busy; your message is durably queued."
         out.content;
       match out.message_request with
       | Some request ->
-          check string "request id" "req-queued" request.request_id;
-          check string "status" "queued"
-            (Gate_protocol.message_request_status_to_string request.status)
+          (match request.tracking with
+           | Gate_protocol.Chat_receipt { receipt_id } ->
+             check string "chat receipt" "receipt-queued" receipt_id
+           | Gate_protocol.Keeper_run _ -> fail "expected chat receipt tracking")
       | None -> fail "expected message_request")
   | Error e -> fail (Channel_gate.gate_error_to_string e)
 

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -2679,6 +2679,29 @@ let test_extract_turn_stats_missing_returns_none () =
   let result = Gate_keeper_backend.extract_turn_stats body in
   check bool "missing fields returns None" true (result = None)
 
+let parse_keeper_ack body =
+  Gate_keeper_backend.extract_message_request_ack ~channel:"discord"
+    ~channel_user_id:"user-1" ~keeper_name:"luna" ~metadata:[] body
+
+let test_typed_keeper_ack () =
+  let body =
+    {|{"run_ref":{"run_id":"run-1","target":{"kind":"keeper","name":"luna"},"capability":"invoke_turn"},"result_contract":"awaiting_execution"}|}
+  in
+  match parse_keeper_ack body with
+  | Ok { tracking = Gate_protocol.Keeper_run { run_ref; result_contract }; _ } ->
+    check string "run id" "run-1" (Keeper_invocation_contract.run_id run_ref);
+    check bool "contract" true
+      (result_contract = Keeper_invocation_contract.Awaiting_execution)
+  | Ok _ | Error _ -> fail "expected typed Keeper-run ACK"
+
+let test_keeper_ack_rejects_retargeting () =
+  let body =
+    {|{"run_ref":{"run_id":"run-1","target":{"kind":"keeper","name":"other"},"capability":"invoke_turn"},"result_contract":"awaiting_execution"}|}
+  in
+  match parse_keeper_ack body with
+  | Error (Gate_keeper_backend.Run_ref_target_mismatch _) -> ()
+  | Ok _ | Error _ -> fail "expected exact Keeper target rejection"
+
 (* ── RFC-connector-deferred-reply-via-chat-queue connector deferred-reply routing ───────────────── *)
 
 let test_route_busy_discord_enqueues () =
@@ -2923,5 +2946,9 @@ let () =
             test_extract_turn_stats_ignores_model_only_payload;
           test_case "turn stats missing returns None" `Quick
             test_extract_turn_stats_missing_returns_none;
+        ] );
+      ( "typed_ack",
+        [ test_case "accepts exact run_ref" `Quick test_typed_keeper_ack
+        ; test_case "rejects retargeting" `Quick test_keeper_ack_rejects_retargeting
         ] );
     ]

--- a/test/test_gate_protocol.ml
+++ b/test/test_gate_protocol.ml
@@ -210,6 +210,38 @@ let test_outbound_to_json_roundtrip () =
   check bool "model redacted" true (stats |> member "model_used" = `Null);
   check int "duration" 100 (stats |> member "duration_ms" |> to_int)
 
+let test_outbound_emits_typed_keeper_tracking () =
+  let keeper_name =
+    match Keeper_id.Keeper_name.of_string "luna" with
+    | Ok name -> name
+    | Error error -> fail error
+  in
+  let run_ref : Keeper_invocation_types.run_ref =
+    { run_id = "run-123"; target = Keeper_invocation_types.Keeper keeper_name
+    ; capability = Keeper_invocation_types.Invoke_turn }
+  in
+  let message_request : Gate_protocol.message_request =
+    { tracking =
+        Gate_protocol.Keeper_run
+          { run_ref
+          ; result_contract = Keeper_invocation_types.Awaiting_execution
+          }
+    ; destination_type = "keeper"; destination_id = "luna"; channel = "slack"
+    ; actor_id = None; modalities = [ "text" ]; transport = Some "slack"
+    ; metadata = []
+    }
+  in
+  let json = Gate_protocol.message_request_to_json message_request in
+  let open Yojson.Safe.Util in
+  let tracking = json |> member "tracking" in
+  check string "tracking kind" "keeper_run" (tracking |> member "kind" |> to_string);
+  check string "run id" "run-123"
+    (tracking |> member "run_ref" |> member "run_id" |> to_string);
+  check string "contract" "awaiting_execution"
+    (tracking |> member "result_contract" |> to_string);
+  check bool "legacy fields absent" true
+    (json |> member "request_id" = `Null && json |> member "status" = `Null)
+
 let test_error_json () =
   let json = Gate_protocol.error_json "something broke" in
   let open Yojson.Safe.Util in
@@ -261,6 +293,8 @@ let () =
             test_inbound_of_json_rejects_keeper_name_only;
           test_case "outbound emits destination_id" `Quick test_outbound_emits_destination_id;
           test_case "outbound roundtrip" `Quick test_outbound_to_json_roundtrip;
+          test_case "outbound typed Keeper tracking" `Quick
+            test_outbound_emits_typed_keeper_tracking;
           test_case "error_json" `Quick test_error_json;
         ] );
       ( "strings",

--- a/test/test_keeper_busy_connector_deferred.ml
+++ b/test/test_keeper_busy_connector_deferred.ml
@@ -24,6 +24,7 @@ let check name cond =
     Printf.printf "  \xe2\x9c\x97 %s\n%!" name)
 
 let contains ~affix text = Astring.String.is_infix ~affix text
+let chat_receipt = function Gate_protocol.Chat_receipt r -> Some r.receipt_id | _ -> None
 
 let keeper_name = "busy-connector-keeper"
 
@@ -116,11 +117,11 @@ let test_busy_discord_enqueues () =
         (match reply with
          | Gate_protocol.Reply
              { message_request = Some request; content; _ } ->
-             ack_receipt_id := Some request.request_id;
-             check "busy connector ACK is queued"
-               (request.status = Gate_protocol.Queued);
-             check "busy connector ACK carries queue status source"
-               (List.assoc_opt "status_source" request.metadata
+             ack_receipt_id := chat_receipt request.tracking;
+             check "busy connector ACK carries a chat receipt"
+               (Option.is_some !ack_receipt_id);
+             check "busy connector ACK carries queue tracking source"
+               (List.assoc_opt "tracking_source" request.metadata
                 = Some "keeper_chat_queue");
              check "busy connector ACK carries queue revision"
                (List.assoc_opt "queue_revision" request.metadata <> None);
@@ -229,8 +230,8 @@ let test_unpublished_busy_slot_queues_without_resolved_meta () =
         in
         (match reply with
          | Gate_protocol.Reply { message_request = Some request; _ } ->
-           check "unpublished busy slot returns a queued ACK"
-             (request.status = Gate_protocol.Queued)
+           check "unpublished busy slot returns a chat receipt"
+             (Option.is_some (chat_receipt request.tracking))
          | Gate_protocol.Reply { message_request = None; _ }
          | Gate_protocol.Keeper_error_result _
          | Gate_protocol.Unavailable_result ->
@@ -335,7 +336,8 @@ let test_pending_receipt_prevents_direct_overtake () =
       in
       (match reply with
        | Gate_protocol.Reply { message_request = Some request; _ } ->
-         check "later connector input is queued" (request.status = Gate_protocol.Queued)
+         check "later connector input has a chat receipt"
+           (Option.is_some (chat_receipt request.tracking))
        | _ -> check "later connector input is queued" false);
       let snapshot = Keeper_chat_queue.snapshot ~keeper_name in
       check "FIFO keeps both accepted receipts pending"
@@ -382,7 +384,8 @@ let test_busy_slack_preserves_thread_context () =
       in
       (match reply with
        | Gate_protocol.Reply { message_request = Some request; _ } ->
-         check "Slack busy input is queued" (request.status = Gate_protocol.Queued)
+         check "Slack busy input has a chat receipt"
+           (Option.is_some (chat_receipt request.tracking))
        | _ -> check "Slack busy input is queued" false);
       match (Keeper_chat_queue.snapshot ~keeper_name).pending with
       | [ { message =
@@ -454,8 +457,8 @@ let test_shutdown_fenced_connector_ack
         (match reply with
          | Gate_protocol.Reply
              { message_request = Some request; content = ack_text; _ } ->
-           check (label ^ " shutdown-fenced input is durably queued")
-             (request.status = Gate_protocol.Queued);
+           check (label ^ " shutdown-fenced input has a durable chat receipt")
+             (Option.is_some (chat_receipt request.tracking));
            check (label ^ " ACK metadata carries shutdown operation id")
              (List.assoc_opt "shutdown_operation_id" request.metadata
               = Some operation_id_text);


### PR DESCRIPTION
Stacked on #24583.

## Actual protocol cut
- replace Gate message request_id/status with the closed tracking sum Keeper_run(run_ref, result_contract) or Chat_receipt
- parse the exact typed Keeper submission identity and reject target retargeting
- emit typed queue events for direct SSE submissions
- update connector ACKs and route documentation without adding aliases or dual JSON

## Preserved behavior
- Keeper_msg_async remains the durable owner
- Keeper_turn_admission remains the per-Keeper serial lane
- Discord and Slack busy delivery remains on Keeper_chat_queue
- direct rich chat and Board inference are untouched in this slice
- malformed ACKs remain explicit and observable

## Size
- total diff: 398 lines, +238/-160

## Verification
- typed Gate JSON positive proof and exact-target rejection proof
- connector chat-receipt assertions retain queue/FIFO/shutdown-fence coverage
- ocamlc parse pass for every changed .ml/.mli
- isolated Gate_protocol interface/implementation type check passed
- git diff --check passed
- focused Dune was refused by the unrelated bare Dune process; CI is build authority