### PR TITLE
fix(memory): make bank locks fiber-aware

### DIFF
--- a/lib/core/cross_context_mutex.ml
+++ b/lib/core/cross_context_mutex.ml
@@ -1,0 +1,64 @@
+type t =
+  { eio_gate : Eio.Mutex.t
+  ; systhread_mutex : Stdlib.Mutex.t
+  }
+
+let create () =
+  { eio_gate = Eio.Mutex.create ()
+  ; systhread_mutex = Stdlib.Mutex.create ()
+  }
+;;
+
+type execution_context =
+  | Eio_fiber
+  | Non_eio
+
+let execution_context () =
+  match Eio.Fiber.check () with
+  | () -> Eio_fiber
+  | exception Effect.Unhandled _ -> Non_eio
+;;
+
+let rec lock_systhread_mutex_cooperatively mutex =
+  if Stdlib.Mutex.try_lock mutex
+  then ()
+  else (
+    Eio.Fiber.yield ();
+    lock_systhread_mutex_cooperatively mutex)
+;;
+
+type 'a outcome =
+  | Returned of 'a
+  | Raised of exn * Printexc.raw_backtrace
+
+let with_eio_lock ~durable t f =
+  let run () =
+    lock_systhread_mutex_cooperatively t.systhread_mutex;
+    Fun.protect
+      ~finally:(fun () -> Stdlib.Mutex.unlock t.systhread_mutex)
+      (fun () -> if durable then Eio.Cancel.protect f else f ())
+  in
+  let outcome =
+    match
+      Eio.Mutex.use_ro t.eio_gate run
+    with
+    | value -> Returned value
+    | exception exn -> Raised (exn, Printexc.get_raw_backtrace ())
+  in
+  if not durable then Eio.Fiber.check ();
+  match outcome with
+  | Returned value -> value
+  | Raised (exn, backtrace) -> Printexc.raise_with_backtrace exn backtrace
+;;
+
+let with_lock t f =
+  match execution_context () with
+  | Eio_fiber -> with_eio_lock ~durable:false t f
+  | Non_eio -> Stdlib.Mutex.protect t.systhread_mutex f
+;;
+
+let with_durable_lock t f =
+  match execution_context () with
+  | Eio_fiber -> with_eio_lock ~durable:true t f
+  | Non_eio -> Stdlib.Mutex.protect t.systhread_mutex f
+;;

--- a/lib/core/cross_context_mutex.mli
+++ b/lib/core/cross_context_mutex.mli
@@ -1,0 +1,21 @@
+(** A mutex shared by Eio fibers and non-Eio system-thread callers.
+
+    Eio fibers first serialize on a cooperative gate, then acquire the shared
+    system-thread mutex with [try_lock] and [Fiber.yield].  This prevents a
+    second fiber on the same Domain from recursively entering
+    [Stdlib.Mutex.lock] while another fiber is suspended inside the critical
+    section.  Non-Eio callers acquire the same system-thread mutex directly. *)
+
+type t
+
+val create : unit -> t
+
+val with_lock : t -> (unit -> 'a) -> 'a
+(** Serialize [f]. Acquisition and [f] remain cancellable for Eio callers;
+    both locks are released before cancellation or an exception propagates. *)
+
+val with_durable_lock : t -> (unit -> 'a) -> 'a
+(** Serialize a durable transition. Acquisition remains cancellable, but once
+    both locks are held cancellation is deferred until after [f] and lock
+    release. The committed result is returned without re-checking the parent
+    cancellation context at this boundary. *)

--- a/lib/core/dune
+++ b/lib/core/dune
@@ -17,6 +17,7 @@
   common
   validation
   circuit_breaker
+  cross_context_mutex
   eio_guard
   executor_pool_ref
   domain_pool

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -82,28 +82,9 @@ let install_error_to_string = function
 
 let pending_store_version = 2
 let pending_store_surface = "keeper_gate_pending"
-let pending_store_eio_gate = Eio.Mutex.create ()
-let pending_store_cross_context_mu = Stdlib.Mutex.create ()
+let pending_store_mutex = Cross_context_mutex.create ()
 let deliveries : persisted_delivery SMap.t Atomic.t = Atomic.make SMap.empty
 let unavailable_stores : storage_error SMap.t Atomic.t = Atomic.make SMap.empty
-
-type execution_context =
-  | Eio_fiber
-  | Non_eio
-
-let execution_context () =
-  match Eio.Fiber.check () with
-  | () -> Eio_fiber
-  | exception Effect.Unhandled _ -> Non_eio
-;;
-
-let rec lock_pending_store_cooperatively () =
-  if Stdlib.Mutex.try_lock pending_store_cross_context_mu
-  then ()
-  else (
-    Eio.Fiber.yield ();
-    lock_pending_store_cooperatively ())
-;;
 
 (** Serialize one durable pending/delivery snapshot transition across both Eio
     fibers and non-Eio callers.  A plain [Stdlib.Mutex.protect] is invalid here:
@@ -111,23 +92,12 @@ let rec lock_pending_store_cooperatively () =
     letting another fiber on the same domain re-enter the OS mutex and raise
     [Sys_error "Mutex.lock: Resource deadlock avoided"].
 
-    The cooperative gate ensures only one Eio fiber reaches the cross-context
-    mutex.  [use_ro] releases rather than poisons the gate when [f] raises; the
-    shared OS mutex is always released before that exception propagates.
-    Cancellation is deferred across the durable transition so a published
-    snapshot is returned as committed rather than reported as an ambiguous
-    cancelled operation. *)
+    The shared cross-context authority waits cooperatively for Eio fibers and
+    uses the same OS mutex for non-Eio callers. Cancellation is deferred across
+    the durable transition so a published snapshot is returned as committed
+    rather than reported as an ambiguous cancelled operation. *)
 let with_pending_store_lock f =
-  match execution_context () with
-  | Non_eio -> Stdlib.Mutex.protect pending_store_cross_context_mu f
-  | Eio_fiber ->
-    Eio.Mutex.use_ro pending_store_eio_gate (fun () ->
-      lock_pending_store_cooperatively ();
-      Eio.Cancel.protect (fun () ->
-        Fun.protect
-          ~finally:(fun () ->
-            Stdlib.Mutex.unlock pending_store_cross_context_mu)
-          f))
+  Cross_context_mutex.with_durable_lock pending_store_mutex f
 ;;
 
 let mark_store_unavailable_unlocked ~base_path error =
@@ -615,7 +585,7 @@ let merge_loaded_map ~surface ~existing ~loaded =
     history stays with the workspace that made the decision. *)
 let audit_stores_mu = Stdlib.Mutex.create ()
 
-let audit_io_mu = Stdlib.Mutex.create ()
+let audit_io_mutex = Cross_context_mutex.create ()
 let audit_stores : (string, Dated_jsonl.t) Hashtbl.t = Hashtbl.create 4
 
 (* Runtime trust asks for per-keeper latest audit state across the same global
@@ -806,7 +776,7 @@ let audit_approval_event
             | None -> [])
          )
     in
-    Stdlib.Mutex.protect audit_io_mu (fun () ->
+    Cross_context_mutex.with_durable_lock audit_io_mutex (fun () ->
       try
         Fs_compat.append_jsonl (audit_today_path (Dated_jsonl.base_dir store)) json;
         invalidate_recent_audit_cache_for_store store
@@ -1219,7 +1189,7 @@ let record_summary_updated ~now (entry : pending_approval) =
             ]
             @ summary_audit_extras entry)
        in
-       Stdlib.Mutex.protect audit_io_mu (fun () ->
+       Cross_context_mutex.with_durable_lock audit_io_mutex (fun () ->
          Fs_compat.append_jsonl (audit_today_path (Dated_jsonl.base_dir store)) json;
          invalidate_recent_audit_cache_for_store store)
    with

--- a/lib/keeper/keeper_approval_queue_rules.ml
+++ b/lib/keeper/keeper_approval_queue_rules.ml
@@ -44,12 +44,13 @@ let make_generated_id prefix =
   prefix ^ "_" ^ Uuidm.to_string uuid
 ;;
 
-(* Stdlib.Mutex: rule reads/writes are short filesystem critical sections and
-   are also reached by synchronous dashboard/test paths. Eio.Mutex requires an
-   Eio fiber context and raises Cancel.Get_context outside one. *)
-let rules_mu = Stdlib.Mutex.create ()
+(* Rule transactions include durable Eio file operations and are also reached
+   by synchronous dashboard/test callers. Both contexts therefore share one
+   cross-context authority; an OS mutex alone cannot be held across an Eio
+   suspension by two fibers on the same Domain. *)
+let rules_mutex = Cross_context_mutex.create ()
 
-let with_rules_lock f = Stdlib.Mutex.protect rules_mu f
+let with_rules_lock f = Cross_context_mutex.with_durable_lock rules_mutex f
 
 let rules_path ~base_path () =
   Keeper_gate_path.always_allowed ~base_path

--- a/lib/keeper/keeper_lifecycle_reservation.ml
+++ b/lib/keeper/keeper_lifecycle_reservation.ml
@@ -35,14 +35,17 @@ module Lock_table = Ephemeron.K1.Make (Lock_key)
 
 type lock_entry =
   { key : string
-  ; mutex : Mutex.t
+  ; mutex : Cross_context_mutex.t
   }
 
 (* No fleet-size guess or TTL belongs at this boundary. The entry keeps its
    ephemeron key reachable while a holder or waiter owns [lock_entry]; once no
-   caller references it, the table no longer retains an inactive Keeper key. *)
+   caller references it, the table no longer retains an inactive Keeper key.
+   The table mutex protects only synchronous lookup/creation. Per-key critical
+   sections may cross Eio persistence boundaries and therefore use the shared
+   fiber/system-thread mutex authority. *)
 let key_locks : lock_entry Lock_table.t = Lock_table.create 0
-let key_locks_mutex = Mutex.create ()
+let key_locks_mutex = Stdlib.Mutex.create ()
 
 let purpose_to_string = function
   | Dead_revival -> "dead_revival"
@@ -61,12 +64,12 @@ let canonical_key ~base_path ~keeper_name =
 ;;
 
 let lock_for_key key =
-  Mutex.protect key_locks_mutex (fun () ->
+  Stdlib.Mutex.protect key_locks_mutex (fun () ->
     Lock_table.clean key_locks;
     match Lock_table.find_opt key_locks key with
     | Some entry -> entry
     | None ->
-      let entry = { key; mutex = Mutex.create () } in
+      let entry = { key; mutex = Cross_context_mutex.create () } in
       Lock_table.add key_locks key entry;
       entry)
 ;;
@@ -74,7 +77,7 @@ let lock_for_key key =
 let with_key_lock ~base_path ~keeper_name f =
   let key = canonical_key ~base_path ~keeper_name in
   let entry = lock_for_key key in
-  Mutex.protect entry.mutex (fun () ->
+  Cross_context_mutex.with_lock entry.mutex (fun () ->
     ignore entry.key;
     f ())
 ;;

--- a/lib/keeper/keeper_lifecycle_reservation.mli
+++ b/lib/keeper/keeper_lifecycle_reservation.mli
@@ -46,7 +46,8 @@ val expected_generation : token -> int
 val release : token -> release_outcome
 
 (** Serialize one ownership check plus authority mutation for this keeper key.
-    This is a per-keeper mutex, never a fleet-wide lock. *)
+    This is a per-keeper mutex, never a fleet-wide lock. Eio fibers wait
+    cooperatively while non-Eio callers share the same exclusion authority. *)
 val with_key_lock :
   base_path:string ->
   keeper_name:string ->

--- a/lib/keeper/keeper_memory_bank_selection.ml
+++ b/lib/keeper/keeper_memory_bank_selection.ml
@@ -9,21 +9,22 @@ let with_stdlib_mutex mutex f =
 ;;
 
 let memory_bank_locks_mu = Stdlib.Mutex.create ()
-let memory_bank_locks : (string, Stdlib.Mutex.t) Hashtbl.t = Hashtbl.create 64
+let memory_bank_locks : (string, Cross_context_mutex.t) Hashtbl.t =
+  Hashtbl.create 64
 
 let memory_bank_lock_for path =
   with_stdlib_mutex memory_bank_locks_mu (fun () ->
     match Hashtbl.find_opt memory_bank_locks path with
     | Some mutex -> mutex
     | None ->
-      let mutex = Stdlib.Mutex.create () in
+      let mutex = Cross_context_mutex.create () in
       Hashtbl.add memory_bank_locks path mutex;
       mutex)
 ;;
 
 let with_memory_bank_lock path f =
   let mutex = memory_bank_lock_for path in
-  with_stdlib_mutex mutex f
+  Cross_context_mutex.with_lock mutex f
 ;;
 
 (** Filter a list to unique items by a key function.

--- a/lib/keeper/keeper_memory_bank_selection.mli
+++ b/lib/keeper/keeper_memory_bank_selection.mli
@@ -77,10 +77,6 @@ val total_cap : unit -> int
 val kind_caps : unit -> (memory_kind * int) list
 val cap_for_kind : (memory_kind * int) list -> memory_kind -> int
 
-val with_stdlib_mutex : Mutex.t -> (unit -> 'a) -> 'a
-val memory_bank_locks_mu : Mutex.t
-val memory_bank_locks : (string, Mutex.t) Hashtbl.t
-val memory_bank_lock_for : string -> Mutex.t
 val with_memory_bank_lock : string -> (unit -> 'a) -> 'a
 val dedup_by_key : ('a -> string) -> 'a list -> 'a list
 val jaccard_similarity : string -> string -> float

--- a/lib/keeper/keeper_registry_setup.ml
+++ b/lib/keeper/keeper_registry_setup.ml
@@ -165,6 +165,21 @@ let decr_running_count_clamped () =
 
 (** Lock-free CAS loop for registry writes. Atomic.t used instead of Eio.Mutex for non-Eio context compatibility (#7011 pattern). *)
 
+let put_entry_authorized ~base_path name entry =
+  match validate_registry_entry ~base_path name entry with
+  | Error err ->
+    record_invalid_registry_entry ~operation:"put" ~name err;
+    Error err
+  | Ok () ->
+    let key = registry_key ~base_path name in
+    let rec loop () =
+      let current = Atomic.get registry in
+      let updated = StringMap.add key entry current in
+      if Atomic.compare_and_set registry current updated then Ok () else loop ()
+    in
+    loop ()
+;;
+
 let put_entry_internal ?lifecycle_token ~base_path name entry =
   Keeper_lifecycle_reservation.with_key_lock ~base_path ~keeper_name:name (fun () ->
     match
@@ -175,19 +190,7 @@ let put_entry_internal ?lifecycle_token ~base_path name entry =
         ()
     with
     | Error owner -> Error (Lifecycle_transaction_reserved owner)
-    | Ok () ->
-      (match validate_registry_entry ~base_path name entry with
-       | Error err ->
-         record_invalid_registry_entry ~operation:"put" ~name err;
-         Error err
-       | Ok () ->
-         let key = registry_key ~base_path name in
-         let rec loop () =
-           let current = Atomic.get registry in
-           let updated = StringMap.add key entry current in
-           if Atomic.compare_and_set registry current updated then Ok () else loop ()
-         in
-         loop ()))
+    | Ok () -> put_entry_authorized ~base_path name entry)
 ;;
 
 let put_entry ~base_path name entry = put_entry_internal ~base_path name entry
@@ -502,7 +505,7 @@ let register_with_state_result
     ; compaction_stage = Packed Compaction_accumulating
     }
   in
-  let commit () =
+  let commit_authorized () =
     (match StringMap.find_opt key (Atomic.get registry) with
      | Some prior when prior.phase = Running ->
        Otel_metric_store.inc_counter
@@ -512,31 +515,41 @@ let register_with_state_result
        Log.Keeper.warn "registry: overwriting running keeper during register name=%s" name;
        decr_running_count_clamped ()
      | Some _ | None -> ());
-    put_entry_internal ?lifecycle_token ~base_path name entry
+    put_entry_authorized ~base_path name entry
   in
   let commit_result =
-    if respect_shutdown_fence
-    then
+    Keeper_lifecycle_reservation.with_key_lock ~base_path ~keeper_name:name (fun () ->
       match
-        Keeper_turn_admission.commit_registration_if_open
+        Keeper_lifecycle_reservation.authorize
+          ?token:lifecycle_token
           ~base_path
           ~keeper_name:name
-          commit
+          ()
       with
-      | Keeper_turn_admission.Registration_shutdown_reserved operation_id ->
-        Error (Registration_shutdown_reserved operation_id)
-      | Keeper_turn_admission.Registration_committed
-          (Error (Lifecycle_transaction_reserved owner)) ->
-        Error (Registration_lifecycle_reserved owner)
-      | Keeper_turn_admission.Registration_committed (Error validation_error) ->
-        Error (Registration_invalid validation_error)
-      | Keeper_turn_admission.Registration_committed (Ok ()) -> Ok ()
-    else
-      match commit () with
-      | Ok () -> Ok ()
-      | Error (Lifecycle_transaction_reserved owner) ->
-        Error (Registration_lifecycle_reserved owner)
-      | Error validation_error -> Error (Registration_invalid validation_error)
+      | Error owner -> Error (Registration_lifecycle_reserved owner)
+      | Ok () ->
+        if respect_shutdown_fence
+        then
+          match
+            Keeper_turn_admission.commit_registration_if_open
+              ~base_path
+              ~keeper_name:name
+              commit_authorized
+          with
+          | Keeper_turn_admission.Registration_shutdown_reserved operation_id ->
+            Error (Registration_shutdown_reserved operation_id)
+          | Keeper_turn_admission.Registration_committed
+              (Error (Lifecycle_transaction_reserved owner)) ->
+            Error (Registration_lifecycle_reserved owner)
+          | Keeper_turn_admission.Registration_committed (Error validation_error) ->
+            Error (Registration_invalid validation_error)
+          | Keeper_turn_admission.Registration_committed (Ok ()) -> Ok ()
+        else
+          match commit_authorized () with
+          | Ok () -> Ok ()
+          | Error (Lifecycle_transaction_reserved owner) ->
+            Error (Registration_lifecycle_reserved owner)
+          | Error validation_error -> Error (Registration_invalid validation_error))
   in
   match commit_result with
   | Error _ as error -> error
@@ -646,11 +659,6 @@ let register_restarting ~base_path name meta
     canonicalize_registry_meta ~operation:"register_restarting" ~base_path name meta
   in
   let key = registry_key ~base_path name in
-  match
-    Keeper_lifecycle_reservation.authorize ~base_path ~keeper_name:name ()
-  with
-  | Error owner -> Error (Restart_lifecycle_reserved owner)
-  | Ok () ->
   let conditions =
     { Keeper_state_machine.default_conditions with
       restart_requested = true
@@ -716,24 +724,24 @@ let register_restarting ~base_path name meta
     then Ok new_entry
     else loop ()
   in
-  let guarded_loop () =
+  let registration =
     Keeper_lifecycle_reservation.with_key_lock ~base_path ~keeper_name:name (fun () ->
-      match
-        Keeper_lifecycle_reservation.authorize ~base_path ~keeper_name:name ()
-      with
+      match Keeper_lifecycle_reservation.authorize ~base_path ~keeper_name:name () with
       | Error owner -> Error (Restart_lifecycle_reserved owner)
-      | Ok () -> loop ())
+      | Ok () ->
+        (match
+           Keeper_turn_admission.commit_registration_if_open
+             ~base_path
+             ~keeper_name:name
+             loop
+         with
+         | Keeper_turn_admission.Registration_shutdown_reserved operation_id ->
+           Error (Restart_shutdown_reserved operation_id)
+         | Keeper_turn_admission.Registration_committed result -> result))
   in
-  match
-    Keeper_turn_admission.commit_registration_if_open
-      ~base_path
-      ~keeper_name:name
-      guarded_loop
-  with
-  | Keeper_turn_admission.Registration_shutdown_reserved operation_id ->
-    Error (Restart_shutdown_reserved operation_id)
-  | Keeper_turn_admission.Registration_committed (Error _ as error) -> error
-  | Keeper_turn_admission.Registration_committed (Ok registered) ->
+  match registration with
+  | Error _ as error -> error
+  | Ok registered ->
     Log.Keeper.info
       "registry: registering keeper name=%s base_path=%s phase=%s"
       name

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -1120,10 +1120,31 @@ let start_keeper_loops_owned
                try
                  match Keeper_shutdown_runtime.recover_operation ~config operation with
                  | Ok recovered ->
-                   Log.Keeper.info
-                     "recovered shutdown operation keeper=%s operation=%s"
-                     recovered.Keeper_shutdown_types.keeper_name
-                     (Keeper_shutdown_types.Operation_id.to_string recovered.operation_id)
+                   (match recovered.Keeper_shutdown_types.phase with
+                    | Keeper_shutdown_types.Blocked failure ->
+                      Log.Keeper.warn
+                        "shutdown recovery retained blocked admission keeper=%s operation=%s stage=%s detail=%s"
+                        recovered.keeper_name
+                        (Keeper_shutdown_types.Operation_id.to_string
+                           recovered.operation_id)
+                        (Keeper_shutdown_types.failure_stage_to_string failure.stage)
+                        failure.detail
+                    | Keeper_shutdown_types.Reconciliation_required _ ->
+                      Log.Keeper.warn
+                        "shutdown recovery retained reconciliation-required admission keeper=%s operation=%s"
+                        recovered.keeper_name
+                        (Keeper_shutdown_types.Operation_id.to_string
+                           recovered.operation_id)
+                    | Keeper_shutdown_types.Prepared
+                    | Keeper_shutdown_types.Joined_idle
+                    | Keeper_shutdown_types.Finalizing_tasks _
+                    | Keeper_shutdown_types.Cleanup_ready _
+                    | Keeper_shutdown_types.Finalized _ ->
+                      Log.Keeper.info
+                        "recovered shutdown operation keeper=%s operation=%s"
+                        recovered.keeper_name
+                        (Keeper_shutdown_types.Operation_id.to_string
+                           recovered.operation_id))
                  | Error detail ->
                    Log.Keeper.error
                      "shutdown recovery failed keeper=%s operation=%s error=%s"

--- a/test/dune
+++ b/test/dune
@@ -1880,6 +1880,8 @@
 
 (include stanzas/test_keeper_memory_bank_compaction_errors.inc)
 
+(include stanzas/test_keeper_memory_bank_fiber_lock.inc)
+
 (include stanzas/test_keeper_memory_bank_consensus_re_10399.inc)
 
 (include stanzas/test_keeper_memory_bank_consolidation_provenance.inc)

--- a/test/stanzas/test_keeper_memory_bank_fiber_lock.inc
+++ b/test/stanzas/test_keeper_memory_bank_fiber_lock.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_memory_bank_fiber_lock)
+ (modules test_keeper_memory_bank_fiber_lock)
+ (libraries masc alcotest eio_main))

--- a/test/test_keeper_memory_bank_fiber_lock.ml
+++ b/test/test_keeper_memory_bank_fiber_lock.ml
@@ -1,0 +1,140 @@
+open Masc
+
+module Selection = Keeper_memory_bank_selection
+
+exception Body_failure
+
+let test_same_domain_eio_fibers_serialize () =
+  Eio_main.run @@ fun _env ->
+  let holder_entered_p, holder_entered_r = Eio.Promise.create () in
+  let release_holder_p, release_holder_r = Eio.Promise.create () in
+  let waiter_entered_p, waiter_entered_r = Eio.Promise.create () in
+  Eio.Switch.run @@ fun sw ->
+  Eio.Fiber.fork ~sw (fun () ->
+    Selection.with_memory_bank_lock "same-path" (fun () ->
+      Eio.Promise.resolve holder_entered_r ();
+      Eio.Promise.await release_holder_p));
+  Eio.Promise.await holder_entered_p;
+  Eio.Fiber.fork ~sw (fun () ->
+    Selection.with_memory_bank_lock "same-path" (fun () ->
+      Eio.Promise.resolve waiter_entered_r ()));
+  Eio.Fiber.yield ();
+  Alcotest.(check bool)
+    "waiter remains outside while holder yields"
+    false
+    (Eio.Promise.is_resolved waiter_entered_p);
+  Eio.Promise.resolve release_holder_r ();
+  Eio.Promise.await waiter_entered_p
+;;
+
+let test_domain_holder_cancelled_waiter_releases_gate () =
+  Eio_main.run @@ fun _env ->
+  let holder_entered = Atomic.make false in
+  let release_holder = Atomic.make false in
+  let waiter_entered = Atomic.make false in
+  let holder =
+    Domain.spawn (fun () ->
+      Selection.with_memory_bank_lock "cross-context-path" (fun () ->
+        Atomic.set holder_entered true;
+        while not (Atomic.get release_holder) do
+          Domain.cpu_relax ()
+        done))
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      Atomic.set release_holder true;
+      Domain.join holder)
+    (fun () ->
+      while not (Atomic.get holder_entered) do
+        Eio.Fiber.yield ()
+      done;
+      let waiter_started = Atomic.make false in
+      let outcome =
+        Eio.Fiber.first
+          (fun () ->
+             Atomic.set waiter_started true;
+             Selection.with_memory_bank_lock "cross-context-path" (fun () ->
+               Atomic.set waiter_entered true);
+             `Entered)
+          (fun () ->
+             while not (Atomic.get waiter_started) do
+               Eio.Fiber.yield ()
+             done;
+             `Cancelled)
+      in
+      Alcotest.(check bool)
+        "contended waiter is cancelled before entry"
+        true
+        (outcome = `Cancelled && not (Atomic.get waiter_entered));
+      Atomic.set release_holder true);
+  let reacquired =
+    Selection.with_memory_bank_lock "cross-context-path" (fun () -> "reacquired")
+  in
+  Alcotest.(check string)
+    "cancelled waiter leaves no gate or system mutex ownership"
+    "reacquired"
+    reacquired
+;;
+
+let test_exception_preserves_synchronous_semantics_and_reacquires () =
+  Eio_main.run @@ fun _env ->
+  let raised =
+    match
+      Selection.with_memory_bank_lock "exception-path" (fun () ->
+        raise Body_failure)
+    with
+    | _ -> false
+    | exception Body_failure -> true
+  in
+  Alcotest.(check bool) "body exception propagates synchronously" true raised;
+  let result =
+    Selection.with_memory_bank_lock "exception-path" (fun () -> 42)
+  in
+  Alcotest.(check int) "Eio lock is reacquired after exception" 42 result
+;;
+
+let test_different_paths_are_independent () =
+  Eio_main.run @@ fun _env ->
+  let holder_entered_p, holder_entered_r = Eio.Promise.create () in
+  let release_holder_p, release_holder_r = Eio.Promise.create () in
+  let other_entered_p, other_entered_r = Eio.Promise.create () in
+  Eio.Switch.run @@ fun sw ->
+  Eio.Fiber.fork ~sw (fun () ->
+    Selection.with_memory_bank_lock "path-a" (fun () ->
+      Eio.Promise.resolve holder_entered_r ();
+      Eio.Promise.await release_holder_p));
+  Eio.Promise.await holder_entered_p;
+  Eio.Fiber.fork ~sw (fun () ->
+    Selection.with_memory_bank_lock "path-b" (fun () ->
+      Eio.Promise.resolve other_entered_r ()));
+  Eio.Promise.await other_entered_p;
+  Alcotest.(check bool)
+    "different path enters while first path remains held"
+    false
+    (Eio.Promise.is_resolved release_holder_p);
+  Eio.Promise.resolve release_holder_r ()
+;;
+
+let () =
+  Alcotest.run
+    "keeper_memory_bank_fiber_lock"
+    [ ( "cross-context"
+      , [ Alcotest.test_case
+            "same-domain Eio fibers serialize"
+            `Quick
+            test_same_domain_eio_fibers_serialize
+        ; Alcotest.test_case
+            "Domain holder and cancelled waiter do not leak"
+            `Quick
+            test_domain_holder_cancelled_waiter_releases_gate
+        ; Alcotest.test_case
+            "exception propagates and lock reacquires"
+            `Quick
+            test_exception_preserves_synchronous_semantics_and_reacquires
+        ; Alcotest.test_case
+            "different paths remain independent"
+            `Quick
+            test_different_paths_are_independent
+        ] )
+    ]
+;;

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -596,6 +596,85 @@ let test_lifecycle_reservation_is_per_keeper_and_owner_typed () =
             (not (String.equal (Reservation.owner_id first) (Reservation.owner_id other)));
           ignore (Reservation.release other : Reservation.release_outcome)))
 
+let test_lifecycle_key_lock_waits_cooperatively_between_fibers () =
+  Eio_main.run @@ fun _env ->
+  let module Reservation = Keeper_lifecycle_reservation in
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      Eio.Switch.run @@ fun sw ->
+      let first_entered_p, first_entered_r = Eio.Promise.create () in
+      let release_first_p, release_first_r = Eio.Promise.create () in
+      let second_entered_p, second_entered_r = Eio.Promise.create () in
+      Eio.Fiber.fork ~sw (fun () ->
+        Reservation.with_key_lock
+          ~base_path:base_dir
+          ~keeper_name:"same-domain-fibers"
+          (fun () ->
+             Eio.Promise.resolve first_entered_r ();
+             Eio.Promise.await release_first_p));
+      Eio.Promise.await first_entered_p;
+      Eio.Fiber.fork ~sw (fun () ->
+        Reservation.with_key_lock
+          ~base_path:base_dir
+          ~keeper_name:"same-domain-fibers"
+          (fun () -> Eio.Promise.resolve second_entered_r ()));
+      Eio.Fiber.yield ();
+      Alcotest.(check bool)
+        "second fiber waits while the first owns the key"
+        true
+        (not (Eio.Promise.is_resolved second_entered_p));
+      Eio.Promise.resolve release_first_r ();
+      Eio.Promise.await second_entered_p)
+
+let test_cross_context_durable_waiter_acquisition_is_cancellable () =
+  Eio_main.run @@ fun _env ->
+  let mutex = Cross_context_mutex.create () in
+  let holder_entered = Atomic.make false in
+  let release_holder = Atomic.make false in
+  let holder =
+    Domain.spawn (fun () ->
+      Cross_context_mutex.with_lock mutex (fun () ->
+        Atomic.set holder_entered true;
+        while not (Atomic.get release_holder) do
+          Domain.cpu_relax ()
+        done))
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      Atomic.set release_holder true;
+      Domain.join holder)
+    (fun () ->
+      while not (Atomic.get holder_entered) do
+        Eio.Fiber.yield ()
+      done;
+      let waiter_started = Atomic.make false in
+      let waiter_entered = Atomic.make false in
+      let outcome =
+        Eio.Fiber.first
+          (fun () ->
+             Atomic.set waiter_started true;
+             Cross_context_mutex.with_durable_lock mutex (fun () ->
+               Atomic.set waiter_entered true);
+             `Waiter_entered)
+          (fun () ->
+             while not (Atomic.get waiter_started) do
+               Eio.Fiber.yield ()
+             done;
+             `Cancel_waiter)
+      in
+      (match outcome with
+       | `Cancel_waiter -> ()
+       | `Waiter_entered ->
+         Alcotest.fail "durable waiter entered before the system-thread owner released");
+      Alcotest.(check bool)
+        "cancelled durable waiter never enters the critical section"
+        false
+        (Atomic.get waiter_entered);
+      Atomic.set release_holder true);
+  Cross_context_mutex.with_lock mutex (fun () -> ())
+
 let test_lifecycle_owner_gates_meta_and_registry_mutations () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
@@ -1703,6 +1782,14 @@ let () =
             "lifecycle reservations are per keeper and owner typed"
             `Quick
             test_lifecycle_reservation_is_per_keeper_and_owner_typed;
+          Alcotest.test_case
+            "lifecycle key lock waits cooperatively between fibers"
+            `Quick
+            test_lifecycle_key_lock_waits_cooperatively_between_fibers;
+          Alcotest.test_case
+            "cross-context durable waiter acquisition is cancellable"
+            `Quick
+            test_cross_context_durable_waiter_acquisition_is_cancellable;
           Alcotest.test_case
             "lifecycle owner gates durable and registry mutations"
             `Quick


### PR DESCRIPTION
## 요약
- `Keeper_memory_bank`의 per-path `Stdlib.Mutex`를 shared `Cross_context_mutex`로 교체합니다.
- global table mutex는 lock lookup/create만 보호하며 suspending I/O callback을 소유하지 않습니다.
- 동기 반환값과 예외 전파 계약은 그대로 유지합니다.
- same-Domain Eio 직렬화, Domain/Eio cancellation, 예외 후 재획득, 서로 다른 path 독립성을 회귀 테스트합니다.

## PR 관계
- #24574의 generic cross-context primitive 위에 쌓인 stacked PR입니다.
- #24574 병합 후 base를 `main`으로 전환합니다.

## 검증
- touched OCaml parser 통과
- `ocamlformat --check` 통과
- `git diff --check` 통과
- focused Dune wrapper는 기존 bare Dune PID 66224/86644를 감지해 exit 75로 fail-closed; CI에서 확인

Refs #24572
