### PR TITLE
refactor(board): hard-cut typed Keeper ACK

### DIFF
--- a/lib/keeper/keeper_invocation_contract.ml
+++ b/lib/keeper/keeper_invocation_contract.ml
@@ -33,7 +33,6 @@ type result_contract = Keeper_invocation_types.result_contract =
 type request_error =
   | Invalid_target of string
   | Empty_prompt
-  | Invalid_entry_projection
   | Invalid_wire_value of
       { field : string
       ; expected : string
@@ -125,7 +124,6 @@ let request_of_json json =
 let request_error_to_string = function
   | Invalid_target reason -> reason
   | Empty_prompt -> "message is required"
-  | Invalid_entry_projection -> "Keeper invocation entry projection is not an object"
   | Invalid_wire_value { field; expected } ->
     Printf.sprintf "%s must be %s" field expected
   | Run_ref_mismatch -> "run_ref does not identify the stored Keeper invocation"
@@ -212,33 +210,6 @@ let run_ref_matches_entry reference (entry : Keeper_msg_async.entry) =
 
 let result_contract_to_string = Keeper_invocation_types.result_contract_to_string
 let result_contract_of_string = Keeper_invocation_types.result_contract_of_string
-
-let submission_to_json (request : request) outcome =
-  let common reference status contract =
-    [ "request_id", `String outcome.Keeper_msg_async.request_id
-    ; "keeper_name", `String (target_name request)
-    ; "status", `String status
-    ; "run_ref", run_ref_to_json reference
-    ; "result_contract", `String (result_contract_to_string contract)
-    ]
-  in
-  match submission_receipt request outcome with
-  | Durable_run reference ->
-    `Assoc
-      (common reference "queued" Awaiting_execution
-       @ [ ( "message"
-           , `String
-               "Keeper turn accepted. The caller lane may continue; query masc_keeper_msg_result with run_ref.run_id." )
-         ])
-  | Reconciliation_required { run_ref = reference; reason } ->
-    `Assoc
-      (common reference "reconciliation_required" Publication_uncertain
-       @ [ "reason", `String reason
-         ; ( "operator_instruction"
-           , `String
-               "Request publication is uncertain. Query masc_keeper_msg_result with this exact run_ref.run_id; do not resubmit." )
-         ])
-;;
 
 let delegate_submission_to_json (request : request) outcome =
   let common reference result_contract =
@@ -348,29 +319,6 @@ let delegate_entry_to_json (entry : Keeper_msg_async.entry) =
         ]
         @ timing
         @ entry_result entry.status))
-;;
-
-let entry_to_json entry =
-  let contract = result_contract entry in
-  let* target_name =
-    Keeper_id.Keeper_name.of_string entry.Keeper_msg_async.keeper_name
-    |> Result.map_error (fun reason -> Invalid_target reason)
-  in
-  let reference =
-    { run_id = entry.request_id
-    ; target = Keeper target_name
-    ; capability = Invoke_turn
-    }
-  in
-  match Keeper_msg_async.entry_to_json entry with
-  | `Assoc fields ->
-    Ok
-      (`Assoc
-         (fields
-          @ [ "run_ref", run_ref_to_json reference
-            ; "result_contract", `String (result_contract_to_string contract)
-            ]))
-  | _ -> Error Invalid_entry_projection
 ;;
 
 let delegate_cancellation_to_json reference result =

--- a/lib/keeper/keeper_invocation_contract.mli
+++ b/lib/keeper/keeper_invocation_contract.mli
@@ -32,7 +32,6 @@ type result_contract = Keeper_invocation_types.result_contract =
 type request_error =
   | Invalid_target of string
   | Empty_prompt
-  | Invalid_entry_projection
   | Invalid_wire_value of
       { field : string
       ; expected : string
@@ -69,9 +68,6 @@ val result_contract : Keeper_msg_async.entry -> result_contract
 val result_contract_to_string : result_contract -> string
 val result_contract_of_string : string -> result_contract option
 
-val submission_to_json
-  :  request -> Keeper_msg_async.submit_outcome -> Yojson.Safe.t
-
 val delegate_submission_to_json
   :  request -> Keeper_msg_async.submit_outcome -> Yojson.Safe.t
 
@@ -80,10 +76,6 @@ val delegate_submission_error_to_json
 
 val delegate_cancellation_to_json
   :  run_ref -> Keeper_msg_async.cancel_result -> Yojson.Safe.t
-
-val entry_to_json
-  :  Keeper_msg_async.entry
-  -> (Yojson.Safe.t, request_error) result
 
 val delegate_entry_to_json
   :  Keeper_msg_async.entry

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -125,10 +125,6 @@ let submit_keeper_msg_with_captured_event_bus
     ~f:(fun request request_sw -> f ?event_bus request request_sw)
     ()
 
-let submit_outcome_with_keeper_json ~request outcome =
-  Keeper_invocation_contract.submission_to_json request outcome
-;;
-
 module For_testing = struct
   let reset_keeper_list_cache () =
     Atomic.set keeper_list_cache (empty_json_cache ~generation:0)
@@ -137,7 +133,6 @@ module For_testing = struct
     cached_json_by_key keeper_list_cache ~key ~ttl_s compute
   let submit_keeper_msg_with_captured_event_bus =
     submit_keeper_msg_with_captured_event_bus
-  let submit_outcome_with_keeper_json = submit_outcome_with_keeper_json
 end
 let annotate_keeper_json ~runtime_class json =
   match json with
@@ -664,8 +659,9 @@ let handle_keeper_msg ?continuation_channel ~submitted_by ctx args : tool_result
     Ok
       (submit_keeper_invocation
          ~submitted_by
-         ~submission_to_json:Keeper_invocation_contract.submission_to_json
-         ~submission_error_to_json:Keeper_msg_async.submit_error_to_json
+         ~submission_to_json:Keeper_invocation_contract.delegate_submission_to_json
+         ~submission_error_to_json:
+           (Keeper_invocation_contract.delegate_submission_error_to_json request)
          ~run_turn:(fun ?event_bus request worker_ctx ->
            let worker_args = with_invocation_request worker_args request in
            let result =

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -323,31 +323,52 @@ let non_empty_json_string_member field json =
       if value = "" then None else Some value
   | _ -> None
 
-let board_context_inference_submission_json ~post_id ~target_source tool_data =
+let board_context_inference_submission_json ~post_id ~target_keeper ~target_source
+    tool_data =
   match
-    ( non_empty_json_string_member "request_id" tool_data,
-      non_empty_json_string_member "keeper_name" tool_data,
-      non_empty_json_string_member "status" tool_data )
+    json_assoc_member "run_ref" tool_data,
+    json_assoc_member "result_contract" tool_data
   with
-  | Some request_id, Some keeper_name, Some status ->
-      let fields =
-        [
-          ("ok", `Bool true);
-          ("request_id", `String request_id);
-          ("keeper_name", `String keeper_name);
-          ("post_id", `String post_id);
-          ("status", `String status);
-          ( "target_source",
-            `String (board_context_inference_target_source_to_string target_source) );
-        ]
+  | Some run_ref_json, Some (`String result_contract_raw) ->
+    (match
+       Keeper_invocation_contract.run_ref_of_json run_ref_json,
+       Keeper_invocation_contract.result_contract_of_string result_contract_raw
+     with
+     | Ok run_ref, Some result_contract ->
+      let actual_target =
+        Keeper_invocation_contract.run_ref_target_name run_ref
       in
-      let fields =
-        match non_empty_json_string_member "message" tool_data with
-        | Some message -> fields @ [ ("message", `String message) ]
-        | None -> fields
-      in
-      Ok (`Assoc fields)
-  | _ -> Error "masc_keeper_msg returned a malformed queue submission"
+      if not (String.equal actual_target target_keeper)
+      then
+        Error
+          (Printf.sprintf
+             "Keeper invocation target %S does not match board target %S"
+             actual_target
+             target_keeper)
+      else
+        let fields =
+          [ "ok", `Bool true
+          ; "run_ref", Keeper_invocation_contract.run_ref_to_json run_ref
+          ; "post_id", `String post_id
+          ; ( "result_contract"
+            , `String
+                (Keeper_invocation_contract.result_contract_to_string
+                   result_contract) )
+          ; ( "target_source"
+            , `String
+                (board_context_inference_target_source_to_string target_source) )
+          ]
+        in
+        let fields =
+          match non_empty_json_string_member "message" tool_data with
+          | Some message -> fields @ [ ("message", `String message) ]
+          | None -> fields
+        in
+        Ok (`Assoc fields)
+     | Error error, _ ->
+       Error (Keeper_invocation_contract.request_error_to_string error)
+     | Ok _, None -> Error "invalid Keeper invocation result_contract")
+  | _ -> Error "typed Keeper invocation submission is missing tracking fields"
 
 let dispatch_board_context_inference ~state ~sw ~clock ~request ~target_keeper
     ~target_source ~(post : Board.post) ~comments =
@@ -386,7 +407,7 @@ let dispatch_board_context_inference ~state ~sw ~clock ~request ~target_keeper
   if Tool_result.is_success result
   then
     (match
-       board_context_inference_submission_json ~post_id ~target_source
+       board_context_inference_submission_json ~post_id ~target_keeper ~target_source
          (Tool_result.data result)
      with
      | Ok json -> Ok json

--- a/lib/server/server_routes_http_routes_activity.mli
+++ b/lib/server/server_routes_http_routes_activity.mli
@@ -30,3 +30,10 @@ val resolve_board_context_inference_target :
   Board.post ->
   string option ->
   (string * board_context_inference_target_source, [ `Bad_request of string | `Internal_server_error of string ]) result
+
+val board_context_inference_submission_json :
+  post_id:string ->
+  target_keeper:string ->
+  target_source:board_context_inference_target_source ->
+  Yojson.Safe.t ->
+  (Yojson.Safe.t, string) result

--- a/test/test_board_context_inference_resolution.ml
+++ b/test/test_board_context_inference_resolution.ml
@@ -153,6 +153,37 @@ let test_target_resolution_implicit_unregistered_author () =
          "error message"
          "target_keeper is required because board post author \"operator\" is not a registered keeper")
 
+let typed_submission keeper_name =
+  `Assoc
+    [ ( "run_ref"
+      , `Assoc
+          [ "run_id", `String "run-1"
+          ; "target", `Assoc [ "kind", `String "keeper"; "name", `String keeper_name ]
+          ; "capability", `String "invoke_turn"
+          ] )
+    ; "result_contract", `String "awaiting_execution"
+    ]
+
+let test_typed_submission_projection () =
+  let project target data =
+    Server_routes_http_routes_activity.board_context_inference_submission_json
+      ~post_id:"post-1" ~target_keeper:target
+      ~target_source:Server_routes_http_routes_activity.Explicit_target data
+  in
+  (match project "luna" (typed_submission "luna") with
+   | Ok json ->
+     let open Yojson.Safe.Util in
+     check string "run id" "run-1"
+       (json |> member "run_ref" |> member "run_id" |> to_string);
+     check bool "legacy fields absent" true
+       (json |> member "request_id" = `Null && json |> member "status" = `Null)
+   | Error error -> fail error);
+  match project "luna" (typed_submission "other") with
+  | Error error ->
+    check bool "retargeting rejected" true
+      (String_util.string_contains_substring ~needle:"does not match" error)
+  | Ok _ -> fail "expected exact board target rejection"
+
 let () =
   run "Server board context inference resolution"
     [ ( "parse_request",
@@ -163,4 +194,6 @@ let () =
         ; test_case "implicit registered author" `Quick test_target_resolution_implicit_registered_author
         ; test_case "implicit unregistered author" `Quick test_target_resolution_implicit_unregistered_author
         ] )
+    ; ( "typed_submission",
+        [ test_case "projects exact run_ref" `Quick test_typed_submission_projection ] )
     ]


### PR DESCRIPTION
Stacked on #24587.

## Actual Board/internal cut
- make the private direct-delivery adapter emit the typed delegate submission contract
- project Board context inference ACKs only from exact run_ref plus result_contract
- reject a returned run_ref whose Keeper target differs from the resolved Board target
- delete the old request_id/status submission and entry projections plus their testing shim

## Preserved behavior
- Board surface context, direct_reply transcript behavior, and rich dashboard visibility remain unchanged
- Keeper_msg_async remains the durable owner and the same per-Keeper lane runs the turn
- no compatibility alias, fallback status, or new policy layer

## Proof
- focused Board projection test accepts exact identity, rejects retargeting, and asserts legacy fields are absent
- ocamlc parse pass for every changed .ml/.mli
- git diff --check passed
- focused Dune was refused by the unrelated bare Dune process; CI is build authority

## Size
- total diff: 177 lines, +87/-90