### PR TITLE
fix(keeper): supersede stale shutdown admission

### DIFF
--- a/lib/keeper/keeper_shutdown_finalize.ml
+++ b/lib/keeper/keeper_shutdown_finalize.ml
@@ -622,7 +622,8 @@ let deliver_finalized_completion ~config operation =
   | Finalizing_tasks _
   | Cleanup_ready _
   | Reconciliation_required _
-  | Blocked _ -> Error Unsupported_phase
+  | Blocked _
+  | Superseded _ -> Error Unsupported_phase
 ;;
 
 let complete_cleanup ~config ~entry operation cleanup =
@@ -711,7 +712,8 @@ let run ~config ~entry operation =
   | Finalized _ -> deliver_finalized_completion ~config operation
   | Prepared
   | Reconciliation_required _
-  | Blocked _ -> Error Unsupported_phase
+  | Blocked _
+  | Superseded _ -> Error Unsupported_phase
 ;;
 
 module For_testing = struct

--- a/lib/keeper/keeper_shutdown_runtime.ml
+++ b/lib/keeper/keeper_shutdown_runtime.ml
@@ -40,16 +40,7 @@ let submit_error_to_string = function
 ;;
 
 let operation_requires_fence (operation : Keeper_shutdown_types.t) =
-  match operation.phase with
-  | Finalized { completion = Completion_pending _; _ } -> true
-  | Finalized
-      { completion = (Completion_not_requested | Completion_delivered _); _ } -> false
-  | Prepared
-  | Joined_idle
-  | Finalizing_tasks _
-  | Cleanup_ready _
-  | Reconciliation_required _
-  | Blocked _ -> true
+  Keeper_shutdown_types.requires_admission_fence operation
 ;;
 
 let restore_admission ~config ~keeper_name ~operation_id =
@@ -192,7 +183,8 @@ let finalize_if_ready ~config ~entry operation =
          (Keeper_shutdown_finalize.error_to_string error))
   | Prepared
   | Reconciliation_required _
-  | Blocked _ -> ()
+  | Blocked _
+  | Superseded _ -> ()
 ;;
 
 let run_worker ~config ~entry operation =
@@ -224,7 +216,8 @@ let run_worker ~config ~entry operation =
   | Cleanup_ready _
   | Finalized _ -> finalize_if_ready ~config ~entry operation
   | Reconciliation_required _
-  | Blocked _ -> ()
+  | Blocked _
+  | Superseded _ -> ()
 ;;
 
 type worker_start_result =
@@ -358,7 +351,8 @@ let recover_operation ~config operation =
     | Cleanup_ready _
     | Reconciliation_required _
     | Finalized _
-    | Blocked _ -> Ok operation
+    | Blocked _
+    | Superseded _ -> Ok operation
   in
   match operation_result with
   | Error _ as error -> error
@@ -372,7 +366,8 @@ let recover_operation ~config operation =
        |> Result.map_error Keeper_shutdown_finalize.error_to_string
      | Prepared
      | Reconciliation_required _
-     | Blocked _ -> Ok recovered)
+     | Blocked _
+     | Superseded _ -> Ok recovered)
 ;;
 
 let recover_at_boot ~config =

--- a/lib/keeper/keeper_shutdown_store.ml
+++ b/lib/keeper/keeper_shutdown_store.ml
@@ -11,10 +11,25 @@ type error =
       { expected : int
       ; actual : int
       }
+  | Supersession_phase_mismatch of Keeper_shutdown_types.t
+  | Supersession_intent_mismatch of Keeper_shutdown_types.t
+  | Invalid_supersession_actor of string
 
 type persist_blocked_result =
   | State_preserved of Keeper_shutdown_types.t
   | Blocked_persisted of Keeper_shutdown_types.t
+
+type supersede_blocked_result =
+  | Superseded_persisted of Keeper_shutdown_types.t
+  | Superseded_already_persisted of Keeper_shutdown_types.t
+
+type operator_metadata_supersession_token =
+  { base_path : string
+  ; keeper_name : string
+  ; operation_id : Operation_id.t
+  ; expected_revision : int
+  ; actor : string
+  }
 
 type corrupt_record =
   { keeper_name : string
@@ -43,6 +58,19 @@ let error_to_string = function
       "shutdown operation revision conflict: expected %d, actual %d"
       expected
       actual
+  | Supersession_phase_mismatch operation ->
+    Printf.sprintf
+      "shutdown operation is not an operator-supersedable blocked operation: keeper=%s operation=%s"
+      operation.keeper_name
+      (Operation_id.to_string operation.operation_id)
+  | Supersession_intent_mismatch operation ->
+    Printf.sprintf
+      "shutdown operation cleanup intent cannot be superseded by metadata update: keeper=%s operation=%s reason=%s"
+      operation.keeper_name
+      (Operation_id.to_string operation.operation_id)
+      (cleanup_reason_label operation.cleanup_intent.reason)
+  | Invalid_supersession_actor detail ->
+    Printf.sprintf "shutdown supersession actor is invalid: %s" detail
 ;;
 
 type operation_lock =
@@ -240,6 +268,14 @@ let finalization_evidence_to_json evidence =
     ]
 ;;
 
+let supersession_to_json = function
+  | Operator_metadata_update { actor } ->
+    `Assoc
+      [ "kind", `String "operator_metadata_update"
+      ; "actor", `String actor
+      ]
+;;
+
 let lane_ownership_to_json = function
   | Registered_lane lane_id ->
     `Assoc
@@ -292,6 +328,11 @@ let phase_to_json = function
     `Assoc
       [ "kind", `String "blocked"
       ; "failure", failure_to_json failure
+      ]
+  | Superseded supersession ->
+    `Assoc
+      [ "kind", `String "superseded"
+      ; "supersession", supersession_to_json supersession
       ]
 ;;
 
@@ -511,14 +552,17 @@ let completion_receipt_of_json json =
 
 type wire_schema =
   | Current_schema
+  | Shutdown_schema_v5
   | Lifecycle_schema_v4
   | Shutdown_schema_v3
 
+let shutdown_schema_v5 = 5
 let lifecycle_schema_v4 = 4
 let shutdown_schema_v3 = 3
 
 let wire_schema_of_version = function
   | version when Int.equal version schema_version -> Ok Current_schema
+  | version when Int.equal version shutdown_schema_v5 -> Ok Shutdown_schema_v5
   | version when Int.equal version lifecycle_schema_v4 -> Ok Lifecycle_schema_v4
   | version when Int.equal version shutdown_schema_v3 -> Ok Shutdown_schema_v3
   | version ->
@@ -529,7 +573,8 @@ let wire_schema_of_version = function
 
 let completion_action_supported_by_wire_schema wire_schema action =
   match wire_schema, action with
-  | Current_schema, (Dead_tombstone_reaped | Dashboard_keeper_purged) ->
+  | (Current_schema | Shutdown_schema_v5),
+    (Dead_tombstone_reaped | Dashboard_keeper_purged) ->
     true
   | Lifecycle_schema_v4, Dead_tombstone_reaped -> true
   | Shutdown_schema_v3, Dead_tombstone_reaped -> true
@@ -560,6 +605,7 @@ let finalization_evidence_of_json ~wire_schema json =
   let* accumulator_dropped =
     match wire_schema with
     | Current_schema
+    | Shutdown_schema_v5
     | Lifecycle_schema_v4 -> bool "accumulator_dropped" json
     | Shutdown_schema_v3 ->
       (* Schema 3 dropped the in-memory accumulator exactly when its
@@ -578,6 +624,18 @@ let finalization_evidence_of_json ~wire_schema json =
     ; accumulator_dropped
     ; completion
     }
+;;
+
+let supersession_of_json json =
+  let* kind = string "kind" json in
+  match kind with
+  | "operator_metadata_update" ->
+    let* actor = string "actor" json in
+    Ok (Operator_metadata_update { actor })
+  | value ->
+    Error
+      (Decode_error
+         (Printf.sprintf "unknown shutdown supersession: %S" value))
 ;;
 
 let phase_of_json ~wire_schema json =
@@ -606,6 +664,18 @@ let phase_of_json ~wire_schema json =
     let* failure_json = assoc "failure" json in
     let* failure = failure_of_json failure_json in
     Ok (Blocked failure)
+  | "superseded" ->
+    (match wire_schema with
+     | Current_schema ->
+       let* supersession_json = assoc "supersession" json in
+       let* supersession = supersession_of_json supersession_json in
+       Ok (Superseded supersession)
+     | Shutdown_schema_v5
+     | Lifecycle_schema_v4
+     | Shutdown_schema_v3 ->
+       Error
+         (Decode_error
+            "shutdown supersession is not valid before shutdown schema 6"))
   | value -> Error (Decode_error (Printf.sprintf "unknown shutdown phase: %S" value))
 ;;
 
@@ -683,6 +753,7 @@ let cleanup_reason_of_json json =
 let lane_ownership_of_versioned_json ~wire_schema json =
   match wire_schema with
   | Current_schema
+  | Shutdown_schema_v5
   | Lifecycle_schema_v4 ->
     let* lane_ownership_json = assoc "lane_ownership" json in
     lane_ownership_of_json lane_ownership_json
@@ -695,7 +766,8 @@ let lane_ownership_of_versioned_json ~wire_schema json =
 
 let cleanup_reason_of_versioned_json ~wire_schema cleanup_json =
   match wire_schema with
-  | Current_schema ->
+  | Current_schema
+  | Shutdown_schema_v5 ->
     let* cleanup_reason_json = assoc "reason" cleanup_json in
     cleanup_reason_of_json cleanup_reason_json
   | Lifecycle_schema_v4 ->
@@ -784,7 +856,13 @@ let contextualize_error operation_path = function
   | Io_error detail -> Io_error (Printf.sprintf "%s: %s" operation_path detail)
   | Identity_mismatch detail ->
     Identity_mismatch (Printf.sprintf "%s: %s" operation_path detail)
-  | (Already_exists _ | Not_found _ | Invalid_operation _ | Revision_conflict _) as error ->
+  | ( Already_exists _
+    | Not_found _
+    | Invalid_operation _
+    | Revision_conflict _
+    | Supersession_phase_mismatch _
+    | Supersession_intent_mismatch _
+    | Invalid_supersession_actor _ ) as error ->
     error
 ;;
 
@@ -875,6 +953,103 @@ let replace ~config ~expected_revision operation =
                 (Operation_id.to_string operation.operation_id))))
 ;;
 
+let prepare_operator_metadata_supersession
+      ~config
+      ~keeper_name
+      ~operation_id
+      ~actor
+  =
+  let base_path =
+    Keeper_registry_types.canonical_base_path_exn config.Workspace.base_path
+  in
+  let* actor =
+    Workspace.validate_agent_name actor
+    |> Result.map_error (fun detail -> Invalid_supersession_actor detail)
+  in
+  let* operation_path = path ~config ~keeper_name operation_id in
+  match
+    with_operation_lock ~access:Read operation_path (fun () ->
+      load_path_unlocked ~operation_path ~keeper_name ~operation_id)
+  with
+  | Error _ as error -> error
+  | Ok
+      ({ phase = Blocked _
+       ; cleanup_intent = { reason = Operator_stop_retain_meta; _ }
+       ; revision
+       ; _ } as _operation) ->
+    Ok { base_path; keeper_name; operation_id; expected_revision = revision; actor }
+  | Ok
+      ({ phase = Superseded (Operator_metadata_update _)
+       ; revision
+       ; _ } as _operation) ->
+    Ok { base_path; keeper_name; operation_id; expected_revision = revision; actor }
+  | Ok ({ phase = Blocked _; _ } as operation) ->
+    Error (Supersession_intent_mismatch operation)
+  | Ok operation -> Error (Supersession_phase_mismatch operation)
+;;
+
+let supersession_token_operation_id token = token.operation_id
+
+let supersede_blocked_operator_stop ~config ~token ~now =
+  let config_base_path =
+    Keeper_registry_types.canonical_base_path_exn config.Workspace.base_path
+  in
+  if not (String.equal config_base_path token.base_path)
+  then
+    Error
+      (Identity_mismatch
+         (Printf.sprintf
+            "supersession token BasePath mismatch: expected=%s actual=%s"
+            token.base_path
+            config_base_path))
+  else
+  let operation_path =
+    path
+      ~config
+      ~keeper_name:token.keeper_name
+      token.operation_id
+  in
+  let* operation_path = operation_path in
+  with_keeper_inventory_lock
+    ~access:Write
+    ~config
+    ~keeper_name:token.keeper_name
+    (fun () ->
+       with_operation_lock ~access:Write operation_path (fun () ->
+         match
+           load_path_unlocked
+             ~operation_path
+             ~keeper_name:token.keeper_name
+             ~operation_id:token.operation_id
+         with
+         | Error _ as error -> error
+         | Ok ({ phase = Superseded (Operator_metadata_update _); _ } as existing) ->
+           Ok (Superseded_already_persisted existing)
+         | Ok
+             ({ phase = Blocked _
+              ; cleanup_intent = { reason = Operator_stop_retain_meta; _ }
+              ; _ } as existing) ->
+           if not (Int.equal existing.revision token.expected_revision)
+           then
+             Error
+               (Revision_conflict
+                  { expected = token.expected_revision; actual = existing.revision })
+           else
+             let superseded =
+               { existing with
+                 revision = existing.revision + 1
+               ; phase = Superseded (Operator_metadata_update { actor = token.actor })
+               ; updated_at = now ()
+               }
+             in
+             Keeper_fs.save_json_atomic operation_path (to_json superseded)
+             |> Result.map_error (fun detail -> Io_error detail)
+             |> Result.map (fun () -> Superseded_persisted superseded)
+         | Ok ({ phase = Blocked _; _ } as existing) ->
+           Error (Supersession_intent_mismatch existing)
+         | Ok existing -> Error (Supersession_phase_mismatch existing)))
+;;
+
 let persist_blocked_latest ~config ~identity ~failure ~now =
   let* () = validate_operation identity in
   let* operation_path = path_for_operation ~config identity in
@@ -897,7 +1072,7 @@ let persist_blocked_latest ~config ~identity ~failure ~now =
            Error (Identity_mismatch (Operation_id.to_string identity.operation_id))
          | Ok existing ->
            (match existing.phase with
-            | Finalized _ | Blocked _ | Reconciliation_required _ ->
+            | Finalized _ | Blocked _ | Reconciliation_required _ | Superseded _ ->
               Ok (State_preserved existing)
             | Prepared | Joined_idle | Finalizing_tasks _ | Cleanup_ready _ ->
               let blocked =

--- a/lib/keeper/keeper_shutdown_store.mli
+++ b/lib/keeper/keeper_shutdown_store.mli
@@ -15,10 +15,19 @@ type error =
       { expected : int
       ; actual : int
       }
+  | Supersession_phase_mismatch of Keeper_shutdown_types.t
+  | Supersession_intent_mismatch of Keeper_shutdown_types.t
+  | Invalid_supersession_actor of string
 
 type persist_blocked_result =
   | State_preserved of Keeper_shutdown_types.t
   | Blocked_persisted of Keeper_shutdown_types.t
+
+type supersede_blocked_result =
+  | Superseded_persisted of Keeper_shutdown_types.t
+  | Superseded_already_persisted of Keeper_shutdown_types.t
+
+type operator_metadata_supersession_token
 
 type corrupt_record =
   { keeper_name : string
@@ -40,9 +49,10 @@ val path :
   (string, error) result
 
 val to_json : Keeper_shutdown_types.t -> Yojson.Safe.t
-(** Decode the current schema and deterministically upgrade schema 4 lifecycle
-    records and schema 3 shutdown records emitted by preceding deployments.
-    Unknown versions remain explicit decode failures. *)
+(** Decode the current schema and deterministically upgrade schema 5 blocked
+    records, schema 4 lifecycle records, and schema 3 shutdown records emitted
+    by preceding deployments. Unknown versions remain explicit decode
+    failures. *)
 val of_json : Yojson.Safe.t -> (Keeper_shutdown_types.t, error) result
 
 val persist_new :
@@ -55,6 +65,30 @@ val replace :
   expected_revision:int ->
   Keeper_shutdown_types.t ->
   (unit, error) result
+
+(** Bind the exact admission-owned operation identity and durable revision
+    eligible for an explicit operator metadata update. Only [Blocked] with
+    [Operator_stop_retain_meta], or an idempotent prior metadata supersession,
+    can produce a token. *)
+val prepare_operator_metadata_supersession :
+  config:Workspace.config ->
+  keeper_name:string ->
+  operation_id:Keeper_shutdown_types.Operation_id.t ->
+  actor:string ->
+  (operator_metadata_supersession_token, error) result
+
+val supersession_token_operation_id :
+  operator_metadata_supersession_token ->
+  Keeper_shutdown_types.Operation_id.t
+
+(** After the operator metadata write has durably committed, CAS the token's
+    exact [Blocked] revision to [Superseded]. Concurrent progress fails with a
+    typed revision conflict. A prior metadata supersession is idempotent. *)
+val supersede_blocked_operator_stop :
+  config:Workspace.config ->
+  token:operator_metadata_supersession_token ->
+  now:(unit -> string) ->
+  (supersede_blocked_result, error) result
 
 (** Read the latest durable revision and persist [Blocked failure] while
     holding the operation's write lock. Existing [Finalized], [Blocked], and

--- a/lib/keeper/keeper_shutdown_supersession.ml
+++ b/lib/keeper/keeper_shutdown_supersession.ml
@@ -1,0 +1,108 @@
+type t =
+  | No_shutdown_admission_token
+  | Operator_metadata_update_token of
+      Keeper_shutdown_store.operator_metadata_supersession_token
+
+type committed =
+  | No_shutdown_admission
+  | Shutdown_superseded of Keeper_shutdown_types.t
+
+type error =
+  | Preflight_failed of Keeper_shutdown_store.error
+  | Multiple_durable_shutdown_operations of
+      Keeper_shutdown_types.Operation_id.t list
+  | Metadata_committed_supersession_failed of Keeper_shutdown_store.error
+  | Metadata_committed_admission_owned_by_other of
+      Keeper_shutdown_types.Operation_id.t
+
+let error_to_string = function
+  | Preflight_failed error ->
+    Printf.sprintf
+      "keeper update refused before metadata commit: %s"
+      (Keeper_shutdown_store.error_to_string error)
+  | Multiple_durable_shutdown_operations operation_ids ->
+    Printf.sprintf
+      "keeper update refused before metadata commit: multiple durable shutdown operations require admission: %s"
+      (operation_ids
+       |> List.map Keeper_shutdown_types.Operation_id.to_string
+       |> String.concat ",")
+  | Metadata_committed_supersession_failed error ->
+    Printf.sprintf
+      "keeper metadata was updated, but blocked shutdown supersession failed; retry the explicit keeper update: %s"
+      (Keeper_shutdown_store.error_to_string error)
+  | Metadata_committed_admission_owned_by_other operation_id ->
+    Printf.sprintf
+      "keeper metadata was updated and the old shutdown was superseded, but a newer shutdown operation owns admission; retry only after resolving operation %s"
+      (Keeper_shutdown_types.Operation_id.to_string operation_id)
+;;
+
+let preflight ~config ~keeper_name ~actor =
+  let snapshot =
+    Keeper_turn_admission.snapshot_for
+      ~base_path:config.Workspace.base_path
+      ~keeper_name
+  in
+  match snapshot.snapshot_shutdown_operation_id with
+  | Some operation_id ->
+    Keeper_shutdown_store.prepare_operator_metadata_supersession
+      ~config
+      ~keeper_name
+      ~operation_id
+      ~actor
+    |> Result.map (fun token -> Operator_metadata_update_token token)
+    |> Result.map_error (fun error -> Preflight_failed error)
+  | None ->
+    (match Keeper_shutdown_store.list_for_keeper ~config ~keeper_name with
+     | Error error -> Error (Preflight_failed error)
+     | Ok operations ->
+       let requiring_fence =
+         List.filter
+           Keeper_shutdown_types.requires_admission_fence
+           operations
+       in
+       (match requiring_fence with
+        | [] -> Ok No_shutdown_admission_token
+        | [ operation ] ->
+          Keeper_shutdown_store.prepare_operator_metadata_supersession
+            ~config
+            ~keeper_name
+            ~operation_id:operation.operation_id
+            ~actor
+          |> Result.map (fun token -> Operator_metadata_update_token token)
+          |> Result.map_error (fun error -> Preflight_failed error)
+        | operations ->
+          Error
+            (Multiple_durable_shutdown_operations
+               (List.map
+                  (fun operation -> operation.Keeper_shutdown_types.operation_id)
+                  operations))))
+;;
+
+let commit_after_metadata_update ~config = function
+  | No_shutdown_admission_token -> Ok No_shutdown_admission
+  | Operator_metadata_update_token token ->
+    (match
+       Keeper_shutdown_store.supersede_blocked_operator_stop
+         ~config
+         ~token
+         ~now:Masc_domain.now_iso
+     with
+     | Error error -> Error (Metadata_committed_supersession_failed error)
+     | Ok
+         ( Keeper_shutdown_store.Superseded_persisted operation
+         | Keeper_shutdown_store.Superseded_already_persisted operation ) ->
+       let operation_id =
+         Keeper_shutdown_store.supersession_token_operation_id token
+       in
+       (match
+          Keeper_turn_admission.rollback_shutdown
+            ~base_path:config.Workspace.base_path
+            ~keeper_name:operation.keeper_name
+            ~operation_id
+        with
+        | Keeper_turn_admission.Shutdown_rolled_back
+        | Keeper_turn_admission.Shutdown_not_reserved ->
+          Ok (Shutdown_superseded operation)
+        | Keeper_turn_admission.Shutdown_reserved_by_other existing ->
+          Error (Metadata_committed_admission_owned_by_other existing)))
+;;

--- a/lib/keeper/keeper_shutdown_supersession.mli
+++ b/lib/keeper/keeper_shutdown_supersession.mli
@@ -1,0 +1,32 @@
+(** Explicit operator-intent supersession of a durable blocked shutdown.
+
+    Preflight binds the admission owner's typed operation id and durable
+    revision before metadata mutation. [commit_after_metadata_update] must be
+    called only after that metadata update has durably committed. *)
+
+type t
+
+type committed =
+  | No_shutdown_admission
+  | Shutdown_superseded of Keeper_shutdown_types.t
+
+type error =
+  | Preflight_failed of Keeper_shutdown_store.error
+  | Multiple_durable_shutdown_operations of
+      Keeper_shutdown_types.Operation_id.t list
+  | Metadata_committed_supersession_failed of Keeper_shutdown_store.error
+  | Metadata_committed_admission_owned_by_other of
+      Keeper_shutdown_types.Operation_id.t
+
+val error_to_string : error -> string
+
+val preflight :
+  config:Workspace.config ->
+  keeper_name:string ->
+  actor:string ->
+  (t, error) result
+
+val commit_after_metadata_update :
+  config:Workspace.config ->
+  t ->
+  (committed, error) result

--- a/lib/keeper/keeper_shutdown_types.ml
+++ b/lib/keeper/keeper_shutdown_types.ml
@@ -141,6 +141,9 @@ type finalization_evidence =
   ; completion : completion_receipt
   }
 
+type supersession =
+  | Operator_metadata_update of { actor : string }
+
 type phase =
   | Prepared
   | Joined_idle
@@ -149,6 +152,7 @@ type phase =
   | Reconciliation_required of active_turn
   | Finalized of finalization_evidence
   | Blocked of failure
+  | Superseded of supersession
 
 type t =
   { schema_version : int
@@ -184,8 +188,23 @@ type invariant_error =
       }
   | Required_accumulator_not_dropped
   | Finalized_completion_mismatch of cleanup_reason * completion_receipt
+  | Superseded_cleanup_reason_mismatch of cleanup_reason
 
-let schema_version = 5
+let schema_version = 6
+
+let requires_admission_fence operation =
+  match operation.phase with
+  | Finalized { completion = Completion_pending _; _ } -> true
+  | Finalized
+      { completion = (Completion_not_requested | Completion_delivered _); _ }
+  | Superseded _ -> false
+  | Prepared
+  | Joined_idle
+  | Finalizing_tasks _
+  | Cleanup_ready _
+  | Reconciliation_required _
+  | Blocked _ -> true
+;;
 
 let meta_disposition_to_string = function
   | Retain_operator_pause -> "retain_operator_pause"
@@ -272,6 +291,10 @@ let invariant_error_to_string = function
       "shutdown finalized completion mismatch: cleanup_reason=%s, completion=%s"
       (cleanup_reason_label cleanup_reason)
       (completion_receipt_kind completion)
+  | Superseded_cleanup_reason_mismatch cleanup_reason ->
+    Printf.sprintf
+      "shutdown supersession requires operator_stop_retain_meta, actual=%s"
+      (cleanup_reason_label cleanup_reason)
 ;;
 
 let validate operation =
@@ -335,6 +358,13 @@ let validate operation =
            Error
              (Finalized_completion_mismatch
                 (operation.cleanup_intent.reason, completion)))
+    | Superseded (Operator_metadata_update _) ->
+      (match operation.cleanup_intent.reason with
+       | Operator_stop_retain_meta -> Ok ()
+       | ( Operator_stop_remove_meta
+         | Dead_tombstone_cleanup
+         | Dashboard_keeper_purge _ ) as cleanup_reason ->
+         Error (Superseded_cleanup_reason_mismatch cleanup_reason))
     | Prepared
     | Joined_idle
     | Finalizing_tasks _

--- a/lib/keeper/keeper_shutdown_types.mli
+++ b/lib/keeper/keeper_shutdown_types.mli
@@ -124,6 +124,9 @@ type finalization_evidence =
   ; completion : completion_receipt
   }
 
+type supersession =
+  | Operator_metadata_update of { actor : string }
+
 type phase =
   | Prepared
   | Joined_idle
@@ -132,6 +135,7 @@ type phase =
   | Reconciliation_required of active_turn
   | Finalized of finalization_evidence
   | Blocked of failure
+  | Superseded of supersession
 
 type t =
   { schema_version : int
@@ -167,8 +171,11 @@ type invariant_error =
       }
   | Required_accumulator_not_dropped
   | Finalized_completion_mismatch of cleanup_reason * completion_receipt
+  | Superseded_cleanup_reason_mismatch of cleanup_reason
 
 val schema_version : int
+val requires_admission_fence : t -> bool
+val cleanup_reason_label : cleanup_reason -> string
 val meta_disposition_to_string : meta_disposition -> string
 val meta_disposition_of_string : string -> (meta_disposition, string) result
 val meta_disposition_of_cleanup_reason : cleanup_reason -> meta_disposition

--- a/lib/keeper/keeper_turn_lifecycle.ml
+++ b/lib/keeper/keeper_turn_lifecycle.ml
@@ -22,15 +22,7 @@ let active_operation ~config keeper_name =
   | Ok operations ->
     let active =
       List.filter
-        (fun operation ->
-           match operation.Keeper_shutdown_types.phase with
-           | Keeper_shutdown_types.Finalized _ -> false
-           | Keeper_shutdown_types.Prepared
-           | Keeper_shutdown_types.Joined_idle
-           | Keeper_shutdown_types.Finalizing_tasks _
-           | Keeper_shutdown_types.Cleanup_ready _
-           | Keeper_shutdown_types.Reconciliation_required _
-           | Keeper_shutdown_types.Blocked _ -> true)
+        Keeper_shutdown_types.requires_admission_fence
         operations
     in
     (match active with

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -268,18 +268,39 @@ let update_keeper ?(preserve_prompt_defaults = false)
                lifecycle action, so it owns pause/resume fields while taking
                cumulative counters as [max latest caller]. *)
             (match
-               write_meta_with_merge
-                 ~merge:Keeper_meta_merge.monotonic_usage_counters
-                 ctx.config
-                 updated
+               Keeper_shutdown_supersession.preflight
+                 ~config:ctx.config
+                 ~keeper_name:updated.name
+                 ~actor:ctx.agent_name
              with
-             | Error e ->
-                 Otel_metric_store.inc_counter
-                   Keeper_metrics.(to_string WriteMetaFailures)
-                   ~labels:[("keeper", updated.name); ("phase", "update_keeper")]
-                   ();
-                 tool_result_error e
-             | Ok () ->
+             | Error error ->
+               tool_result_error
+                 (Keeper_shutdown_supersession.error_to_string error)
+             | Ok supersession ->
+               (match
+                  write_meta_with_merge
+                    ~merge:Keeper_meta_merge.monotonic_usage_counters
+                    ctx.config
+                    updated
+                with
+                | Error e ->
+                    Otel_metric_store.inc_counter
+                      Keeper_metrics.(to_string WriteMetaFailures)
+                      ~labels:[("keeper", updated.name); ("phase", "update_keeper")]
+                      ();
+                    tool_result_error e
+                | Ok () ->
+                  (match
+                     Keeper_shutdown_supersession.commit_after_metadata_update
+                       ~config:ctx.config
+                       supersession
+                   with
+                   | Error error ->
+                     tool_result_error
+                       (Keeper_shutdown_supersession.error_to_string error)
+                   | Ok
+                       ( Keeper_shutdown_supersession.No_shutdown_admission
+                       | Keeper_shutdown_supersession.Shutdown_superseded _ ) ->
                (* RFC-0315 P3 W0: goals that newly entered active_goal_ids
                   wake the keeper once at the assignment edge. Enqueue is
                   durable, so the keepalive restart below delivers it on the
@@ -315,4 +336,4 @@ let update_keeper ?(preserve_prompt_defaults = false)
                   tool_result_error
                     (Printf.sprintf
                        "keeper metadata was updated but lane restart failed: %s"
-                       (start_keepalive_outcome_to_string rejected)))))
+                       (start_keepalive_outcome_to_string rejected)))))))

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -15,6 +15,7 @@ open Alcotest
 module R = Masc.Keeper_registry
 module Workspace = Masc.Workspace
 module Keeper_types_profile = Masc.Keeper_types_profile
+module Keeper_profile_defaults = Masc.Keeper_types_profile_defaults
 module Sup = Masc.Keeper_supervisor
 module KT = Keeper_types
 module KSM = Keeper_state_machine
@@ -29,6 +30,9 @@ module Shutdown_store = Masc.Keeper_shutdown_store
 module Shutdown_prepare_join = Masc.Keeper_shutdown_prepare_join
 module Shutdown_finalize = Masc.Keeper_shutdown_finalize
 module Shutdown_runtime = Masc.Keeper_shutdown_runtime
+module Shutdown_supersession = Masc.Keeper_shutdown_supersession
+module Turn_up_args = Masc.Keeper_turn_up_args
+module Turn_up_update = Masc.Keeper_turn_up_update
 module Keeper_meta_contract = Masc.Keeper_meta_contract
 module Keeper_meta_store = Masc.Keeper_meta_store
 module Keeper_types_support = Masc.Keeper_types_support
@@ -234,6 +238,13 @@ let shutdown_schema4_fixture (operation : Shutdown_types.t) =
   match Shutdown_store.to_json operation with
   | `Assoc fields ->
     `Assoc (replace_assoc_field "schema_version" (`Int 4) fields)
+  | _ -> fail "shutdown JSON codec did not return an object"
+;;
+
+let shutdown_schema5_fixture (operation : Shutdown_types.t) =
+  match Shutdown_store.to_json operation with
+  | `Assoc fields ->
+    `Assoc (replace_assoc_field "schema_version" (`Int 5) fields)
   | _ -> fail "shutdown JSON codec did not return an object"
 ;;
 
@@ -1124,7 +1135,8 @@ let test_keeper_shutdown_store_round_trip_and_identity_guard () =
        | Shutdown_types.Cleanup_ready _
        | Shutdown_types.Reconciliation_required _
        | Shutdown_types.Finalized _
-       | Shutdown_types.Blocked _ ->
+       | Shutdown_types.Blocked _
+       | Shutdown_types.Superseded _ ->
          fail "unhandled worker failure did not persist typed blocked evidence");
       Shutdown_runtime.For_testing.persist_unhandled_failure
         ~now:Masc_domain.now_iso
@@ -1164,6 +1176,378 @@ let test_keeper_shutdown_store_round_trip_and_identity_guard () =
       | Error (Shutdown_store.Decode_error _) -> ()
       | Error error -> fail (Shutdown_store.error_to_string error)
       | Ok _ -> fail "unsupported shutdown schema was accepted")
+
+let test_operator_update_supersedes_exact_blocked_shutdown () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir "shutdown-supersession" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc.Keeper_turn_admission.For_testing.reset ();
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_dir in
+      let (_init_message : string) =
+        Masc.Workspace.init config ~agent_name:(Some "tester")
+      in
+      let backlog_version =
+        match Workspace_backlog.read_backlog_r config with
+        | Ok backlog -> backlog.version
+        | Error detail -> fail detail
+      in
+      let operation ~name ~reason ~phase =
+        let meta = make_meta name in
+        let now = Masc_domain.now_iso () in
+        { Shutdown_types.schema_version = Shutdown_types.schema_version
+        ; revision = 0
+        ; operation_id = Shutdown_types.Operation_id.generate ()
+        ; keeper_name = name
+        ; lane_ownership = Shutdown_types.Registered_lane (Lane.id (Lane.create ()))
+        ; trace_id = meta.runtime.trace_id
+        ; generation = meta.runtime.generation
+        ; actor = "tester"
+        ; cleanup_intent = { reason; remove_session = false }
+        ; turn_disposition = Shutdown_types.No_inflight_turn
+        ; expected_backlog_version = backlog_version
+        ; owned_task_ids = []
+        ; join_evidence = None
+        ; phase
+        ; created_at = now
+        ; updated_at = now
+        }
+      in
+      let blocked_phase =
+        Shutdown_types.Blocked
+          { stage = Shutdown_types.Record_update
+          ; detail = "operator repair required"
+          }
+      in
+      let blocked =
+        operation
+          ~name:"superseded-keeper"
+          ~reason:Shutdown_types.Operator_stop_retain_meta
+          ~phase:blocked_phase
+      in
+      (match Shutdown_store.persist_new ~config blocked with
+       | Ok () -> ()
+       | Error error -> fail (Shutdown_store.error_to_string error));
+      let blocked_path =
+        match
+          Shutdown_store.path
+            ~config
+            ~keeper_name:blocked.keeper_name
+            blocked.operation_id
+        with
+        | Ok path -> path
+        | Error error -> fail (Shutdown_store.error_to_string error)
+      in
+      (match
+         Keeper_fs.save_json_atomic
+           blocked_path
+           (shutdown_schema5_fixture blocked)
+       with
+       | Ok () -> ()
+       | Error detail -> fail detail);
+      let migrated_v5 =
+        match
+          Shutdown_store.load
+            ~config
+            ~keeper_name:blocked.keeper_name
+            blocked.operation_id
+        with
+        | Ok operation -> operation
+        | Error error -> fail (Shutdown_store.error_to_string error)
+      in
+      check int
+        "schema 5 blocked record decodes at current schema"
+        Shutdown_types.schema_version
+        migrated_v5.schema_version;
+      (match
+         Masc.Keeper_turn_admission.begin_shutdown
+           ~base_path:config.base_path
+           ~keeper_name:blocked.keeper_name
+           ~operation_id:blocked.operation_id
+       with
+       | Masc.Keeper_turn_admission.Shutdown_reserved _ -> ()
+       | Masc.Keeper_turn_admission.Shutdown_already_reserved _ ->
+         fail "fixture admission was already reserved");
+      let token =
+        match
+          Shutdown_supersession.preflight
+            ~config
+            ~keeper_name:blocked.keeper_name
+            ~actor:"tester"
+        with
+        | Ok token -> token
+        | Error error -> fail (Shutdown_supersession.error_to_string error)
+      in
+      let superseded =
+        match Shutdown_supersession.commit_after_metadata_update ~config token with
+        | Ok (Shutdown_supersession.Shutdown_superseded operation) -> operation
+        | Ok Shutdown_supersession.No_shutdown_admission ->
+          fail "blocked admission was not superseded"
+        | Error error -> fail (Shutdown_supersession.error_to_string error)
+      in
+      check int
+        "schema 5 CAS write upgrades the durable record to schema 6"
+        6
+        superseded.schema_version;
+      (match superseded.phase with
+       | Shutdown_types.Superseded
+           (Shutdown_types.Operator_metadata_update { actor }) ->
+         check string "supersession preserves validated operator actor" "tester" actor
+       | _ -> fail "blocked shutdown did not reach typed Superseded");
+      let released =
+        Masc.Keeper_turn_admission.snapshot_for
+          ~base_path:config.base_path
+          ~keeper_name:blocked.keeper_name
+      in
+      check (option string)
+        "exact superseded admission is released"
+        None
+        (Option.map
+           Shutdown_types.Operation_id.to_string
+           released.snapshot_shutdown_operation_id);
+      let persisted_json =
+        Fs_compat.load_file blocked_path |> Yojson.Safe.from_string
+      in
+      let persisted_schema =
+        match persisted_json with
+        | `Assoc fields ->
+          (match List.assoc_opt "schema_version" fields with
+           | Some (`Int version) -> version
+           | _ -> fail "persisted supersession omitted schema_version")
+        | _ -> fail "persisted supersession is not an object"
+      in
+      check int "supersession wire schema is upgraded" 6 persisted_schema;
+      let invalid_superseded =
+        { superseded with
+          operation_id = Shutdown_types.Operation_id.generate ()
+        ; cleanup_intent =
+            { reason = Shutdown_types.Operator_stop_remove_meta
+            ; remove_session = false
+            }
+        }
+      in
+      (match Shutdown_store.persist_new ~config invalid_superseded with
+       | Error
+           (Shutdown_store.Invalid_operation
+             (Shutdown_types.Superseded_cleanup_reason_mismatch _)) -> ()
+       | Error error -> fail (Shutdown_store.error_to_string error)
+       | Ok () -> fail "Superseded accepted a non-retained cleanup intent");
+      (match
+         superseded
+         |> shutdown_schema5_fixture
+         |> Shutdown_store.of_json
+       with
+       | Error (Shutdown_store.Decode_error _) -> ()
+       | Error error -> fail (Shutdown_store.error_to_string error)
+       | Ok _ -> fail "schema 5 accepted the schema 6 superseded phase");
+      (match
+         Masc.Keeper_turn_admission.restore_shutdown
+           ~base_path:config.base_path
+           ~keeper_name:blocked.keeper_name
+           ~operation_id:blocked.operation_id
+       with
+       | Masc.Keeper_turn_admission.Shutdown_restored -> ()
+       | Masc.Keeper_turn_admission.Shutdown_already_restored
+       | Masc.Keeper_turn_admission.Shutdown_restore_conflict _ ->
+         fail "crash-window admission fixture could not be restored");
+      let retry_token =
+        match
+          Shutdown_supersession.preflight
+            ~config
+            ~keeper_name:blocked.keeper_name
+            ~actor:"tester"
+        with
+        | Ok token -> token
+        | Error error -> fail (Shutdown_supersession.error_to_string error)
+      in
+      (match
+         Shutdown_supersession.commit_after_metadata_update
+           ~config
+           retry_token
+       with
+       | Ok (Shutdown_supersession.Shutdown_superseded _) -> ()
+       | Ok Shutdown_supersession.No_shutdown_admission ->
+         fail "idempotent supersession lost the exact admission owner"
+       | Error error -> fail (Shutdown_supersession.error_to_string error));
+      Masc.Keeper_turn_admission.For_testing.reset ();
+      let inventory =
+        match Shutdown_store.scan_inventory ~config with
+        | Ok inventory -> inventory
+        | Error error -> fail (Shutdown_store.error_to_string error)
+      in
+      (match Shutdown_runtime.restore_inventory_admission ~config inventory with
+       | Ok { blocked_keeper_names = []; _ } -> ()
+       | Ok restored ->
+         failf
+           "Superseded boot restore fenced keepers: %s"
+           (String.concat "," restored.blocked_keeper_names)
+       | Error detail -> fail detail);
+
+      let conflict =
+        operation
+          ~name:"supersession-conflict"
+          ~reason:Shutdown_types.Operator_stop_retain_meta
+          ~phase:blocked_phase
+      in
+      (match Shutdown_store.persist_new ~config conflict with
+       | Ok () -> ()
+       | Error error -> fail (Shutdown_store.error_to_string error));
+      ignore
+        (Masc.Keeper_turn_admission.begin_shutdown
+           ~base_path:config.base_path
+           ~keeper_name:conflict.keeper_name
+           ~operation_id:conflict.operation_id
+          : Masc.Keeper_turn_admission.begin_shutdown_result);
+      let conflict_token =
+        match
+          Shutdown_supersession.preflight
+            ~config
+            ~keeper_name:conflict.keeper_name
+            ~actor:"tester"
+        with
+        | Ok token -> token
+        | Error error -> fail (Shutdown_supersession.error_to_string error)
+      in
+      let concurrently_advanced =
+        { conflict with
+          revision = conflict.revision + 1
+        ; phase =
+            Shutdown_types.Blocked
+              { stage = Shutdown_types.Meta_update
+              ; detail = "new durable failure"
+              }
+        }
+      in
+      (match
+         Shutdown_store.replace
+           ~config
+           ~expected_revision:conflict.revision
+           concurrently_advanced
+       with
+       | Ok () -> ()
+       | Error error -> fail (Shutdown_store.error_to_string error));
+      (match
+         Shutdown_supersession.commit_after_metadata_update
+           ~config
+           conflict_token
+       with
+       | Error
+           (Shutdown_supersession.Metadata_committed_supersession_failed
+             (Shutdown_store.Revision_conflict _)) -> ()
+       | Error error -> fail (Shutdown_supersession.error_to_string error)
+       | Ok _ -> fail "stale preflight token superseded a newer revision");
+      let still_fenced =
+        Masc.Keeper_turn_admission.snapshot_for
+          ~base_path:config.base_path
+          ~keeper_name:conflict.keeper_name
+      in
+      check (option string)
+        "failed supersession leaves exact admission fenced"
+        (Some (Shutdown_types.Operation_id.to_string conflict.operation_id))
+        (Option.map
+           Shutdown_types.Operation_id.to_string
+           still_fenced.snapshot_shutdown_operation_id);
+
+      Masc.Keeper_turn_admission.For_testing.reset ();
+      let live_name = "update-blocked-admission" in
+      let live_meta = { (make_meta live_name) with paused = true } in
+      (match Keeper_meta_store.write_meta config live_meta with
+       | Ok () -> ()
+       | Error detail -> fail detail);
+      let live_blocked =
+        { (operation
+             ~name:live_name
+             ~reason:Shutdown_types.Operator_stop_retain_meta
+             ~phase:blocked_phase) with
+          trace_id = live_meta.runtime.trace_id
+        ; generation = live_meta.runtime.generation
+        }
+      in
+      (match Shutdown_store.persist_new ~config live_blocked with
+       | Ok () -> ()
+       | Error error -> fail (Shutdown_store.error_to_string error));
+      ignore
+        (Masc.Keeper_turn_admission.begin_shutdown
+           ~base_path:config.base_path
+           ~keeper_name:live_name
+           ~operation_id:live_blocked.operation_id
+          : Masc.Keeper_turn_admission.begin_shutdown_result);
+      let profile_defaults =
+        { Keeper_profile_defaults.empty_keeper_profile_defaults with
+          sandbox_profile = Some live_meta.sandbox_profile
+        }
+      in
+      let parsed : Turn_up_args.parsed_args =
+        { name = live_name
+        ; compaction_profile_opt = None
+        ; runtime_id_opt = None
+        ; allowed_paths_opt = None
+        ; autoboot_enabled_opt = None
+        ; mention_targets_opt = None
+        ; active_goal_ids_opt = None
+        ; max_context_override_opt = None
+        ; max_context_override_present = false
+        ; proactive_enabled_opt = None
+        ; compaction_ratio_gate_opt = None
+        ; compaction_message_gate_opt = None
+        ; compaction_token_gate_opt = None
+        ; compaction_cooldown_sec_opt = None
+        ; sandbox_profile_opt = None
+        ; network_mode_opt = None
+        ; auto_handoff_opt = None
+        ; handoff_threshold_opt = None
+        ; handoff_cooldown_sec_opt = None
+        ; instructions_arg = Some "new operator intent"
+        ; profile_defaults
+        ; instructions_opt = profile_defaults.instructions
+        }
+      in
+      let ctx : _ Keeper_types_profile.context =
+        { config
+        ; agent_name = "tester"
+        ; sw
+        ; clock = Eio.Stdenv.clock env
+        ; proc_mgr = None
+        ; net = None
+        ; publication_recovery_provider =
+            Masc_test_deps.non_runtime_publication_recovery_provider
+        }
+      in
+      let result = Turn_up_update.update_keeper ctx parsed live_meta in
+      check bool
+        "keeper_up restarts despite the stale blocked admission"
+        true
+        (Keeper_types_profile.tool_result_success result);
+      let live_operation =
+        match
+          Shutdown_store.load
+            ~config
+            ~keeper_name:live_name
+            live_blocked.operation_id
+        with
+        | Ok operation -> operation
+        | Error error -> fail (Shutdown_store.error_to_string error)
+      in
+      (match live_operation.phase with
+       | Shutdown_types.Superseded
+           (Shutdown_types.Operator_metadata_update { actor = "tester" }) -> ()
+       | _ -> fail "update_keeper did not supersede the blocked operator stop");
+      let live_after =
+        match Keeper_meta_store.read_meta config live_name with
+        | Ok (Some meta) -> meta
+        | Ok None -> fail "update_keeper removed retained metadata"
+        | Error detail -> fail detail
+      in
+      check bool "update_keeper persisted the new resume intent" false live_after.paused;
+      ignore
+        (Masc.Keeper_keepalive.stop_keepalive_and_await
+           ~base_path:config.base_path
+           live_name
+          : Masc.Keeper_keepalive.joined_stop_result))
 
 let test_keeper_shutdown_store_isolates_corrupt_owner () =
   Eio_main.run @@ fun env ->
@@ -1508,7 +1892,8 @@ let test_keeper_shutdown_prepare_joins_idle_lane () =
        | Shutdown_types.Cleanup_ready _
        | Shutdown_types.Reconciliation_required _
        | Shutdown_types.Finalized _
-       | Shutdown_types.Blocked _ -> fail "idle lane did not reach Joined_idle");
+       | Shutdown_types.Blocked _
+       | Shutdown_types.Superseded _ -> fail "idle lane did not reach Joined_idle");
       check bool
         "shutdown operation records lane join evidence"
         true
@@ -1569,7 +1954,8 @@ let test_keeper_shutdown_prepare_joins_not_started_lane () =
        | Shutdown_types.Cleanup_ready _
        | Shutdown_types.Reconciliation_required _
        | Shutdown_types.Finalized _
-       | Shutdown_types.Blocked _ -> fail "not-started lane did not reach Joined_idle");
+       | Shutdown_types.Blocked _
+       | Shutdown_types.Superseded _ -> fail "not-started lane did not reach Joined_idle");
       (match Lane.peek_exit entry.lane with
        | Some { outcome = Lane.Shutdown_before_start; cleanup_error = None } -> ()
        | Some _ -> fail "not-started lane recorded the wrong exit evidence"
@@ -1712,7 +2098,8 @@ let test_keeper_shutdown_finalizes_idle_operation () =
        | Shutdown_types.Finalizing_tasks _
        | Shutdown_types.Cleanup_ready _
        | Shutdown_types.Reconciliation_required _
-       | Shutdown_types.Blocked _ -> fail "shutdown did not reach Finalized");
+       | Shutdown_types.Blocked _
+       | Shutdown_types.Superseded _ -> fail "shutdown did not reach Finalized");
       (match
          Masc.Keeper_turn_admission.begin_shutdown
            ~base_path:config.base_path
@@ -1859,7 +2246,8 @@ let test_keeper_shutdown_delivers_dead_tombstone_completion_after_receipt () =
        | Shutdown_types.Cleanup_ready _
        | Shutdown_types.Reconciliation_required _
        | Shutdown_types.Blocked _
-       | Shutdown_types.Finalized _ ->
+       | Shutdown_types.Finalized _
+       | Shutdown_types.Superseded _ ->
          fail "completion outage did not retain a pending durable receipt");
       check int "pending receipt did not fire hook" 0 !hook_deliveries;
       (match
@@ -1927,7 +2315,8 @@ let test_keeper_shutdown_delivers_dead_tombstone_completion_after_receipt () =
        | Shutdown_types.Cleanup_ready _
        | Shutdown_types.Reconciliation_required _
        | Shutdown_types.Blocked _
-       | Shutdown_types.Finalized _ ->
+       | Shutdown_types.Finalized _
+       | Shutdown_types.Superseded _ ->
           fail "dead tombstone completion receipt was not delivered");
       check int "Tombstone_reaped delivered once" 1 !hook_deliveries;
       (match Masc.Agent_sdk_metrics_bridge.drain completion_subscription with
@@ -2870,6 +3259,8 @@ let () =
         test_lane_cancel_before_start_is_joinable;
       test_case "shutdown store round-trip and identity guard" `Quick
         test_keeper_shutdown_store_round_trip_and_identity_guard;
+      test_case "operator update supersedes exact blocked shutdown" `Quick
+        test_operator_update_supersedes_exact_blocked_shutdown;
       test_case "shutdown store isolates corrupt owner" `Quick
         test_keeper_shutdown_store_isolates_corrupt_owner;
       test_case "dashboard purge resolution is fail closed" `Quick


### PR DESCRIPTION
## 요약
- operator metadata update가 stale `Blocked + Operator_stop_retain_meta` shutdown을 typed `Superseded` terminal phase로 끝낼 수 있게 합니다.
- preflight token은 canonical BasePath, Keeper, exact operation id, revision, validated actor를 결합합니다.
- metadata CAS가 성공한 뒤에만 durable supersession CAS를 수행하고, 그 뒤 exact admission owner만 release합니다.
- crash-window 재시도는 idempotent하며 newer owner/CAS conflict는 fence를 유지하고 partial commit을 명시합니다.
- shutdown wire schema를 v6으로 올리고 v5 record를 명시적으로 upgrade합니다.
- `requires_admission_fence`를 phase 정책 SSOT로 사용해 boot/runtime/lifecycle 판단을 일치시킵니다.

## 회귀 검증
- 실제 `update_keeper`가 stale blocked admission을 supersede한 뒤 lane restart에 성공
- schema v5 Blocked → schema v6 Superseded CAS
- exact release, crash-window retry, boot no-fence
- stale revision conflict가 admission을 유지하고 metadata partial commit을 명시
- wrong cleanup intent 및 old-schema Superseded decode 거부

## 로컬 검증
- touched OCaml parser 통과
- `ocamlformat --check` 통과
- `git diff --check origin/main...HEAD` 통과
- focused Dune wrapper는 기존 bare Dune PID 66224를 감지해 exit 75로 fail-closed; CI에서 build/test 확인

Refs #24556
Closes #24562
