### PR TITLE
fix(keeper): recover provider overflow in owning lane (rescue #24565)

### DIFF
--- a/lib/compaction_trigger/compaction_trigger.ml
+++ b/lib/compaction_trigger/compaction_trigger.ml
@@ -11,12 +11,14 @@ type t =
       { count : int
       ; threshold : int
       }
+  | Provider_overflow of { limit_tokens : int option }
   | Manual
 
 let to_label = function
   | Ratio_threshold _ -> "ratio"
   | Message_count _ -> "messages"
   | Token_count _ -> "tokens"
+  | Provider_overflow _ -> "provider_overflow"
   | Manual -> "manual"
 ;;
 
@@ -26,6 +28,12 @@ let to_human = function
   | Message_count { count; threshold } ->
     Printf.sprintf "messages(%d>=%d)" count threshold
   | Token_count { count; threshold } -> Printf.sprintf "tokens(%d>=%d)" count threshold
+  | Provider_overflow { limit_tokens } ->
+    Printf.sprintf
+      "provider_overflow(limit=%s)"
+      (match limit_tokens with
+       | Some limit_tokens -> string_of_int limit_tokens
+       | None -> "unknown")
   | Manual -> "manual"
 ;;
 
@@ -38,6 +46,14 @@ let to_detail_json : t -> Yojson.Safe.t = function
       [ "kind", `String "messages"; "count", `Int count; "threshold", `Int threshold ]
   | Token_count { count; threshold } ->
     `Assoc [ "kind", `String "tokens"; "count", `Int count; "threshold", `Int threshold ]
+  | Provider_overflow { limit_tokens } ->
+    `Assoc
+      [ "kind", `String "provider_overflow"
+      ; ( "limit_tokens"
+        , match limit_tokens with
+          | Some limit_tokens -> `Int limit_tokens
+          | None -> `Null )
+      ]
   | Manual -> `Assoc [ "kind", `String "manual" ]
 ;;
 
@@ -74,6 +90,12 @@ let of_detail_json (json : Yojson.Safe.t) : t option =
        (match num_int "count", num_int "threshold" with
         | Some count, Some threshold -> Some (Token_count { count; threshold })
         | _ -> None)
+     | Some "provider_overflow" ->
+       (match List.assoc_opt "limit_tokens" fields with
+        | Some `Null | None -> Some (Provider_overflow { limit_tokens = None })
+        | Some (`Int limit_tokens) ->
+          Some (Provider_overflow { limit_tokens = Some limit_tokens })
+        | Some _ -> None)
      (* "tool_heavy" rows persist in historical JSONL; the trigger was removed
         (gate measured stored-history bulk that the OAS call-time pruner already
         bounds per call) so they parse to None like any unknown kind. *)

--- a/lib/compaction_trigger/compaction_trigger.mli
+++ b/lib/compaction_trigger/compaction_trigger.mli
@@ -2,7 +2,7 @@
 
     Replaces the prior [string] / [string option] representation in
     [compaction_event.trigger] and [pre_compact_event.trigger] so the
-    Otel_metric_store [trigger] label has bounded cardinality (4 values) while
+    Otel_metric_store [trigger] label has bounded cardinality (5 values) while
     structured numerical detail (ratio, counts, thresholds) is preserved
     in the JSON receipt via [to_detail_json]. *)
 
@@ -19,9 +19,12 @@ type t =
       { count : int
       ; threshold : int
       }
+  | Provider_overflow of { limit_tokens : int option }
+      (** Typed provider context-window overflow. [limit_tokens] is the
+          provider-declared limit when present, never an estimated count. *)
   | Manual
 
-(** Closed label set (4 values) for Otel_metric_store / SSE [trigger] label.
+(** Closed label set (5 values) for Otel_metric_store / SSE [trigger] label.
     Use this anywhere cardinality matters. *)
 val to_label : t -> string
 

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -254,6 +254,9 @@ let settlement_of_failure ~settled_at failure =
   match failure.Keeper_unified_turn.source_lease_disposition with
   | Keeper_unified_turn.Acknowledge_after_in_turn_handling ->
     Keeper_registry_event_queue.Ack
+  | Keeper_unified_turn.Requeue_after_context_compaction ->
+    Keeper_registry_event_queue.Requeue
+      Keeper_registry_event_queue.Context_compaction_retry
   | Keeper_unified_turn.Follow_failure_route ->
     (match failure.Keeper_unified_turn.route with
      | Keeper_runtime_failure_route.Retry_after_observed _ ->
@@ -721,33 +724,37 @@ let run_keepalive_unified_turn
        | None ->
          (match !cycle_outcome_ref with
           | Some (Cycle.Failed { failure; _ }) ->
-            (match failure.Keeper_unified_turn.route with
-             | Keeper_runtime_failure_route.Escalate_judgment
-                 { judgment; provenance; detail } ->
-               let successor =
-                 failure_judgment_successor
-                   ~arrived_at:(Time_compat.now ())
-                   failure
-                   judgment
-                   provenance
-                   detail
-               in
-               (match
-                  Keeper_registry_event_queue.enqueue_durable_result
-                    ~base_path:ctx.config.base_path
-                    meta_after_triage.name
-                    successor
-                with
-                | Ok () -> ()
-                | Error message ->
-                  Log.Keeper.error
-                    "registry: unleased failure judgment enqueue failed keeper=%s: %s"
-                    meta_after_triage.name
-                    message;
-                  record_settlement_failure message)
-             | Keeper_runtime_failure_route.Retry_after_observed _
-             | Keeper_runtime_failure_route.Rotate_now _ ->
-               ())
+            (match failure.Keeper_unified_turn.source_lease_disposition with
+             | Keeper_unified_turn.Requeue_after_context_compaction
+             | Keeper_unified_turn.Acknowledge_after_in_turn_handling -> ()
+             | Keeper_unified_turn.Follow_failure_route ->
+               (match failure.Keeper_unified_turn.route with
+                | Keeper_runtime_failure_route.Escalate_judgment
+                    { judgment; provenance; detail } ->
+                  let successor =
+                    failure_judgment_successor
+                      ~arrived_at:(Time_compat.now ())
+                      failure
+                      judgment
+                      provenance
+                      detail
+                  in
+                  (match
+                     Keeper_registry_event_queue.enqueue_durable_result
+                       ~base_path:ctx.config.base_path
+                       meta_after_triage.name
+                       successor
+                   with
+                   | Ok () -> ()
+                   | Error message ->
+                     Log.Keeper.error
+                       "registry: unleased failure judgment enqueue failed keeper=%s: %s"
+                       meta_after_triage.name
+                       message;
+                     record_settlement_failure message)
+                | Keeper_runtime_failure_route.Retry_after_observed _
+                | Keeper_runtime_failure_route.Rotate_now _ ->
+                  ()))
           | Some (Cycle.Judgment_settled _) ->
             record_settlement_failure
               "failure judgment completed without an owning event queue lease"

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -17,6 +17,7 @@ type requeue_reason = Keeper_event_queue_persistence.requeue_reason =
   | Cycle_crashed
   | Registration_recovery
   | Retry_after_observed
+  | Context_compaction_retry
   | Approval_grant_unconsumed
   | Approval_grant_state_unavailable
 

--- a/lib/keeper/keeper_registry_event_queue.mli
+++ b/lib/keeper/keeper_registry_event_queue.mli
@@ -16,6 +16,7 @@ type requeue_reason = Keeper_event_queue_persistence.requeue_reason =
   | Cycle_crashed
   | Registration_recovery
   | Retry_after_observed
+  | Context_compaction_retry
   | Approval_grant_unconsumed
   | Approval_grant_state_unavailable
 

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -21,6 +21,7 @@ include Keeper_unified_turn_phase_plan
 
 type source_lease_disposition =
   | Follow_failure_route
+  | Requeue_after_context_compaction
   | Acknowledge_after_in_turn_handling
 
 type turn_failure =
@@ -120,6 +121,103 @@ let user_message_with_hitl_resolution ~base_path ~user_message = function
       ; "This edit grants no authorization. Treat the edited input as operator guidance; any external effect follows the ordinary Gate independently."
       ]
   | None -> user_message
+;;
+
+let recover_provider_context_overflow_in_lane
+      ~(config : Workspace.config)
+      ~base_dir
+      ~(meta : keeper_meta)
+      ~primary_model_max_tokens
+      error
+  =
+  match context_overflow_event_of_error error with
+  | None -> Follow_failure_route
+  | Some
+      ((Keeper_state_machine.Context_overflow_detected { limit_tokens }) as
+       overflow_event) ->
+    let origin = Keeper_registry.Post_turn_lifecycle in
+    let dispatch stage event =
+      match
+        dispatch_keeper_phase_event_result
+          ~config
+          ~origin
+          ~keeper_name:meta.name
+          event
+      with
+      | Ok () -> Ok ()
+      | Error error ->
+        let detail = lifecycle_dispatch_error_to_string error in
+        Log.Keeper.error
+          ~keeper_name:meta.name
+          "provider overflow recovery lifecycle rejected stage=%s: %s"
+          stage
+          detail;
+        Error detail
+    in
+    let release_failed_lifecycle reason =
+      match
+        dispatch
+          "compaction_failed"
+          (Keeper_state_machine.Compaction_failed { reason })
+      with
+      | Ok () -> ()
+      | Error detail ->
+        Log.Keeper.error
+          ~keeper_name:meta.name
+          "provider overflow recovery could not release compaction lifecycle: %s"
+          detail
+    in
+    let fail reason =
+      record_overflow_failure ~config ~meta ~reason;
+      release_failed_lifecycle reason
+    in
+    (match dispatch "context_overflow_detected" overflow_event with
+     | Error _ -> ()
+     | Ok () ->
+       (match dispatch "compaction_started" Keeper_state_machine.Compaction_started with
+        | Error detail -> release_failed_lifecycle detail
+        | Ok () ->
+          (try
+             match
+               recover_latest_checkpoint_for_overflow_retry
+                 ~base_dir
+                 ~meta
+                 ~trigger:(Compaction_trigger.Provider_overflow { limit_tokens })
+                 ~primary_model_max_tokens
+             with
+             | Error error ->
+               fail (Keeper_post_turn.compaction_recovery_error_to_string error)
+             | Ok _ ->
+               (match
+                  dispatch_compaction_completed
+                    ~config
+                    ~origin
+                    ~keeper_name:meta.name
+                with
+                | Ok () ->
+                  Log.Keeper.info
+                    ~keeper_name:meta.name
+                    "provider overflow compaction committed; source stimulus will be requeued"
+                | Error error -> fail (lifecycle_dispatch_error_to_string error))
+           with
+           | Eio.Cancel.Cancelled _ as exn ->
+             let backtrace = Printexc.get_raw_backtrace () in
+             Eio.Cancel.protect (fun () ->
+               try release_failed_lifecycle "provider overflow compaction cancelled" with
+               | cleanup_exn ->
+                 Log.Keeper.error
+                   ~keeper_name:meta.name
+                   "provider overflow cancellation cleanup failed: %s"
+                   (Printexc.to_string cleanup_exn));
+             Printexc.raise_with_backtrace exn backtrace
+           | exn -> fail (Printexc.to_string exn))));
+    Requeue_after_context_compaction
+  | Some event ->
+    Log.Keeper.error
+      ~keeper_name:meta.name
+      "context overflow classifier returned a non-overflow event: %s"
+      (Keeper_state_machine.event_to_string event);
+    Follow_failure_route
 ;;
 
 let run_keeper_cycle
@@ -860,11 +958,23 @@ dominant source of the observed CAS race exhaustion after
                       ~boundary:Keeper_runtime_failure_route.Oas_execution
                       err
                   in
+                  let source_lease_disposition =
+                    (* The checkpoint helper reports [Ok] only after the
+                       compacted checkpoint is durably saved. The heartbeat
+                       settles the owning lease after this cycle returns, so
+                       no source stimulus is acknowledged ahead of it. *)
+                    recover_provider_context_overflow_in_lane
+                      ~config
+                      ~base_dir
+                      ~meta
+                      ~primary_model_max_tokens:final_execution.max_context
+                      err
+                  in
                   exact_failure_execution :=
                     Some
                       ( final_execution.runtime_id
                       , failure_route
-                      , Follow_failure_route );
+                      , source_lease_disposition );
                   Otel_metric_store.inc_counter
                     Keeper_metrics.(to_string FailureRoute)
                     ~labels:

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -136,8 +136,12 @@ val record_streaming_cancelled_observation
 
 type source_lease_disposition =
   | Follow_failure_route
+  | Requeue_after_context_compaction
   | Acknowledge_after_in_turn_handling
 (** A failed turn normally follows its typed retry/rotate/escalate route.
+    [Requeue_after_context_compaction] preserves the exact source stimulus
+    after MASC handled a typed provider overflow in this Keeper lane; the next
+    cycle reloads the durably compacted checkpoint.
     [Acknowledge_after_in_turn_handling] consumes only the source stimulus when
     the configured in-turn policy already handled the terminal failure; the
     cycle remains failed for receipts, counters, and heartbeat freshness. *)

--- a/lib/keeper_registry/keeper_state_machine.ml
+++ b/lib/keeper_registry/keeper_state_machine.ml
@@ -167,12 +167,11 @@ let update_conditions (c : conditions) (ev : event) : conditions =
   | Compaction_completed ->
     { c with compaction_active = false; context_overflow = false }
   | Compaction_failed _ ->
-    (* Leave [context_overflow] set — the overflow has not been resolved.
-       The retry-exhausted latch is owned by the caller (keeper_unified_turn
-       retry loop) and is promoted into this state machine via a subsequent
-       [Operator_clear_requested] or [Context_overflow_detected] after
-       the retry budget is depleted. *)
-    { c with compaction_active = false }
+    (* Durable lane settlement owns the retry. Keeping [context_overflow]
+       latched here made the Keeper non-executable, so the exact requeued work
+       could never retry. The failure remains observable through turn health
+       and receipts while this buffer-operation latch is released. *)
+    { c with compaction_active = false; context_overflow = false }
   | Handoff_started -> { c with handoff_active = true }
   | Handoff_completed _ -> { c with handoff_active = false }
   | Handoff_failed _ -> { c with handoff_active = false }

--- a/lib/keeper_registry/keeper_state_machine_mermaid.ml
+++ b/lib/keeper_registry/keeper_state_machine_mermaid.ml
@@ -53,7 +53,7 @@ let phase_to_mermaid ~(current : phase) : string =
   p "    Overflowed --> Draining : stop requested\n";
   p "    Overflowed --> Crashed : fiber death\n";
   p "    Compacting --> Running : compact done\n";
-  p "    Compacting --> Overflowed : compact failed (overflow persists)\n";
+  p "    Compacting --> Running : compact failed (Lane retry queued)\n";
   p "    Compacting --> Failing : hb fail\n";
   p "    Compacting --> Crashed : fiber death\n";
   p "    Compacting --> Draining : stop requested\n";

--- a/lib/keeper_registry/keeper_state_machine_types.ml
+++ b/lib/keeper_registry/keeper_state_machine_types.ml
@@ -286,14 +286,13 @@ let can_transition ~from_phase ~to_phase =
   | ( Overflowed
     , (Offline | Failing | Overflowed | HandingOff | Stopped | Restarting) ) ->
     false
-  (* Compacting -> Running (done, overflow cleared)
-     | Overflowed (Compaction_failed leaves context_overflow=true; the keeper
-     re-enters Overflowed and remains available for a later recovery attempt)
+  (* Compacting -> Running (done or failed; the durable Keeper Lane owns any
+     exact-source retry after failure)
      | Paused (operator pause during compaction)
      | Failing (hb fail / guardrail during)
      | Crashed (fatal) | Draining (operator stop during). *)
-  | Compacting, (Running | Overflowed | Failing | Crashed | Draining | Paused) -> true
-  | Compacting, (Offline | Compacting | HandingOff | Stopped | Restarting) -> false
+  | Compacting, (Running | Failing | Crashed | Draining | Paused) -> true
+  | Compacting, (Offline | Overflowed | Compacting | HandingOff | Stopped | Restarting) -> false
   (* HandingOff -> Running (done) | Failing | Crashed
      | Draining (operator stop during handoff)
      | Paused (operator pause during handoff) *)

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -14,6 +14,7 @@ type requeue_reason = State.requeue_reason =
   | Cycle_crashed
   | Registration_recovery
   | Retry_after_observed
+  | Context_compaction_retry
   | Approval_grant_unconsumed
   | Approval_grant_state_unavailable
 

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -18,6 +18,7 @@ type requeue_reason = Keeper_event_queue_state.requeue_reason =
   | Cycle_crashed
   | Registration_recovery
   | Retry_after_observed
+  | Context_compaction_retry
   | Approval_grant_unconsumed
   | Approval_grant_state_unavailable
 

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -11,6 +11,7 @@ type requeue_reason =
   | Cycle_crashed
   | Registration_recovery
   | Retry_after_observed
+  | Context_compaction_retry
   | Approval_grant_unconsumed
   | Approval_grant_state_unavailable
 
@@ -232,6 +233,7 @@ let requeue_reason_label = function
   | Cycle_crashed -> "cycle_crashed"
   | Registration_recovery -> "registration_recovery"
   | Retry_after_observed -> "retry_after_observed"
+  | Context_compaction_retry -> "context_compaction_retry"
   | Approval_grant_unconsumed -> "approval_grant_unconsumed"
   | Approval_grant_state_unavailable -> "approval_grant_state_unavailable"
 ;;
@@ -244,6 +246,7 @@ let requeue_reason_of_label = function
   | "cycle_crashed" -> Ok Cycle_crashed
   | "registration_recovery" -> Ok Registration_recovery
   | "retry_after_observed" -> Ok Retry_after_observed
+  | "context_compaction_retry" -> Ok Context_compaction_retry
   | "approval_grant_unconsumed" -> Ok Approval_grant_unconsumed
   | "approval_grant_state_unavailable" -> Ok Approval_grant_state_unavailable
   | label -> Error (Printf.sprintf "unknown event queue requeue reason: %s" label)
@@ -487,12 +490,12 @@ let settle ~settled_at ~lease ~settlement state =
       | Ack -> state.pending
       | Requeue
           ( Retry_after_observed
+          | Context_compaction_retry
           | Approval_grant_unconsumed
           | Approval_grant_state_unavailable ) ->
-        (* A retryable provider failure and a durable one-shot grant both
-           retain the exact leased stimuli without monopolizing the FIFO
-           front. Unrelated Board/Connector work can claim the next lane
-           cycle before the retained work is attempted again. *)
+        (* Retryable provider work, a completed context-compaction handoff,
+           and a durable one-shot grant retain the exact leased stimuli
+           without monopolizing the FIFO front. *)
         append_missing committed.stimuli state.pending
       | Requeue _ -> prepend_missing committed.stimuli state.pending
       | Escalate { successor = None; _ } -> state.pending

--- a/lib/keeper_runtime/keeper_event_queue_state.mli
+++ b/lib/keeper_runtime/keeper_event_queue_state.mli
@@ -18,6 +18,7 @@ type requeue_reason =
   | Cycle_crashed
   | Registration_recovery
   | Retry_after_observed
+  | Context_compaction_retry
   | Approval_grant_unconsumed
   | Approval_grant_state_unavailable
 
@@ -109,9 +110,9 @@ val settle :
     same semantic settlement returns [Already_settled]; a different settlement
     for an already-settled lease is an explicit conflict.
 
-    [Retry_after_observed] retains the exact leased stimuli at the pending FIFO
-    tail so unrelated work in the same lane can proceed before another
-    provider attempt. *)
+    [Retry_after_observed] and [Context_compaction_retry] retain the exact
+    leased stimuli at the pending FIFO tail so unrelated work in the same lane
+    can proceed before another provider attempt. *)
 
 val recover_leases : settled_at:float -> t -> (t, string) result
 (** Requeue every active lease with [Registration_recovery], preserving claim

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -399,7 +399,22 @@ let test_failed_cycle_route_mapping () =
        handled_failure
    with
    | Masc.Keeper_registry_event_queue.Ack -> ()
-   | _ -> Alcotest.fail "in-turn handled terminal failure was retried")
+   | _ -> Alcotest.fail "in-turn handled terminal failure was retried");
+  let compacted_failure =
+    { judgment_failure with
+      source_lease_disposition =
+        Masc.Keeper_unified_turn.Requeue_after_context_compaction
+    }
+  in
+  match
+    Masc.Keeper_heartbeat_loop.settlement_of_failure
+      ~settled_at:7.0
+      compacted_failure
+  with
+  | Masc.Keeper_registry_event_queue.Requeue
+      Masc.Keeper_registry_event_queue.Context_compaction_retry ->
+    ()
+  | _ -> Alcotest.fail "context-compacted source stimulus was acknowledged"
 ;;
 
 let cycle_meta () =
@@ -490,6 +505,40 @@ let test_unconsumed_approval_requeues_behind_other_work () =
     [ State.Approval_grant_unconsumed
     ; State.Approval_grant_state_unavailable
     ]
+;;
+
+let test_context_compaction_retry_preserves_source_identity () =
+  let source = stimulus "overflow-source" 1.0 in
+  let peer = stimulus "peer-work" 2.0 in
+  let state = State.with_pending (queue [ source; peer ]) State.empty in
+  let state, lease = claim_head state in
+  let lease = require_some "overflow source lease" lease in
+  let state, _ =
+    State.settle
+      ~settled_at:3.0
+      ~lease
+      ~settlement:(State.Requeue State.Context_compaction_retry)
+      state
+    |> require_ok "settle context-compacted source"
+  in
+  let state =
+    State.of_yojson (State.to_yojson state)
+    |> require_ok "round-trip context-compaction settlement"
+  in
+  match Queue.to_list (State.pending state), State.transition_outbox state with
+  | [ next; retained ], [ outbox ] ->
+    Alcotest.(check string)
+      "peer work remains ahead of the compacted retry"
+      peer.post_id
+      next.post_id;
+    Alcotest.(check bool)
+      "exact leased source identity is retained"
+      true
+      (Queue.stimulus_identity_equal source retained);
+    (match outbox.receipt.settlement with
+     | State.Requeue State.Context_compaction_retry -> ()
+     | _ -> Alcotest.fail "outbox lost context-compaction retry reason")
+  | _ -> Alcotest.fail "context-compaction retry changed queue topology"
 ;;
 
 let rec remove_tree path =
@@ -893,6 +942,10 @@ let () =
             "unconsumed approval yields FIFO"
             `Quick
             test_unconsumed_approval_requeues_behind_other_work
+        ; Alcotest.test_case
+            "context compaction preserves source identity"
+            `Quick
+            test_context_compaction_retry_preserves_source_identity
         ] )
     ; ( "persistence"
       , [ Alcotest.test_case

--- a/test/test_keeper_overflow_recovery.ml
+++ b/test/test_keeper_overflow_recovery.ml
@@ -2,7 +2,7 @@
 
     Scenarios mirror the five cases in the MASC-1 plan:
     1. Happy path — Running → Overflowed → Compacting → Running
-    2. Compact failed → Overflowed remains active for later recovery
+    2. Compact failed → executable again for durable Lane retry
     3. Operator clear — Overflowed → Running without passing Compacting
     4. Two consecutive overflows in one fiber lifecycle
     5. Heartbeat failure while Overflowed is preserved through recovery *)
@@ -22,6 +22,14 @@ let running_conds : SM.conditions =
 
 let overflow_event ?(limit = Some 200_000) () =
   SM.Context_overflow_detected { limit_tokens = limit }
+
+let test_provider_overflow_trigger_roundtrip () =
+  let trigger = Compaction_trigger.Provider_overflow { limit_tokens = Some 200_000 } in
+  check string "typed trigger label" "provider_overflow" (Compaction_trigger.to_label trigger);
+  match Compaction_trigger.of_detail_json (Compaction_trigger.to_detail_json trigger) with
+  | Some (Compaction_trigger.Provider_overflow { limit_tokens = Some 200_000 }) -> ()
+  | _ -> fail "typed provider overflow trigger did not round-trip"
+;;
 
 let apply_ok phase conds ev =
   match SM.apply_event ~current_phase:phase ~conditions:conds ~event:ev
@@ -68,21 +76,21 @@ let test_happy_path () =
 
 (* ── Scenario 2: compact failure remains recoverable ──────── *)
 
-let test_compact_failure_remains_overflowed () =
+let test_compact_failure_releases_lane () =
   (* Running → overflow → Overflowed *)
   let tr1 = apply_ok SM.Running running_conds (overflow_event ()) in
   (* The Lane executor explicitly starts compaction. *)
   let tr2 =
     apply_ok SM.Overflowed tr1.updated_conditions SM.Compaction_started
   in
-  (* Compaction fails — compaction_active cleared but context_overflow keeps *)
+  (* Compaction fails — durable queue settlement owns the exact retry. *)
   let tr3 =
     apply_ok SM.Compacting tr2.updated_conditions
       (SM.Compaction_failed { reason = "oas_error" })
   in
-  check_phase SM.Overflowed tr3.new_phase
-    "compact failed, context still overflowed → Overflowed again";
-  check bool "context_overflow still set" true
+  check_phase SM.Running tr3.new_phase
+    "compact failed, buffer latch released → Running";
+  check bool "context_overflow latch released" false
     tr3.updated_conditions.context_overflow;
   check bool "failure does not synthesize operator pause" false
     tr3.updated_conditions.operator_paused
@@ -160,9 +168,11 @@ let test_heartbeat_failure_preserved_through_overflow () =
 let () =
   run "keeper_overflow_recovery" [
     "overflow-lifecycle",
-    [ test_case "happy path" `Quick test_happy_path;
-      test_case "compact failure remains recoverable" `Quick
-        test_compact_failure_remains_overflowed;
+    [ test_case "provider overflow trigger codec" `Quick
+        test_provider_overflow_trigger_roundtrip;
+      test_case "happy path" `Quick test_happy_path;
+      test_case "compact failure releases Lane" `Quick
+        test_compact_failure_releases_lane;
       test_case "operator clear returns to Running" `Quick
         test_operator_clear_returns_to_running;
       test_case "two consecutive overflows" `Quick


### PR DESCRIPTION
## 목적

**길 잃은 병합 복구**: PR #24565가 base=main이 아닌 stacked 브랜치 `codex/compaction-summarizer-no-timeout-20260715`로 머지되어 **main에 도달하지 못한** 기능을 되살린다.

## 유실 확인 (main 대조 실측)

`origin/main`에서 이 기능의 핵심 심볼이 전부 부재:
- `recover_provider_context_overflow_in_lane` → 0
- `Requeue_after_context_compaction` → 0
- `Provider_overflow of { limit_tokens }` → 0

base 브랜치(`codex/compaction-summarizer-no-timeout`)는 존재하나 main에 미도달(2 commits ahead), open 자식 #24575가 물려 있어 base→main 직머지 대신 **#24565 squash 커밋만 cherry-pick으로 격리 복구**.

## 방법

`git cherry-pick a81911473d`(#24565의 base 착지 커밋) → 충돌 0, 16파일 +274/-59, 원저자(jeong-sik) 보존. base 스택의 다른 커밋(deadline 제거)은 끌어오지 않음.

## 내용

provider context overflow를 소유 lane에서 복구: `compaction_trigger`의 `Provider_overflow` variant, `keeper_unified_turn`의 `recover_provider_context_overflow_in_lane` + `Requeue_after_context_compaction` re-queue, event-queue state 확장, `test/test_keeper_overflow_recovery.ml` 회귀.

## Self-review / Done
- 변경 파일 RFC-gated 서브시스템 미포함.
- **로컬 빌드는 owner가 dune 실행 — green 확인 후 Ready.** Draft 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
