### PR TITLE
refactor(fusion): delete tool-call limit contract

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -1058,8 +1058,6 @@ panel_timeout_s = 300.0
 judge_timeout_s = 300.0
 # 패널/심판에 MASC web_search/web_fetch 도구를 주입할지 여부.
 web_tools = false
-# 패널 모델당 최대 tool 호출 수 (0 = 무제한, OpenRouter Fusion 허용 범위 0..16).
-max_tool_calls_per_panel = 0
 
 # ── JoJ-capable preset (RFC-0283 judge-of-judges) ───────────────────────────
 # masc_fusion topology="judge_of_judges"는 preset에 1차 심판 >= 2명을 요구한다
@@ -1098,7 +1096,6 @@ judge_timeout_s = 300.0
 # meta/stage-meta reducer 구조적 타임아웃. 미지정 시 judge_timeout_s와 동일.
 meta_timeout_s = 300.0
 web_tools = false
-max_tool_calls_per_panel = 0
 
 # 1차 심판 — 서로 다른 렌즈로 패널을 독립 종합한다 (JoJ requires >= 2; RFC-0283).
 # label이 정체성을 주므로 distinct lens는 distinct identity가 된다 (Duplicate_judge 회피).
@@ -1170,7 +1167,6 @@ panel_timeout_s = 300.0
 judge_timeout_s = 300.0
 meta_timeout_s = 300.0
 web_tools = false
-max_tool_calls_per_panel = 0
 
 [[fusion.presets.council.judges]]
 model = "ollama_cloud.ollama-cloud-devstral-2-123b"

--- a/dashboard/src/components/fusion-settings-panel.test.ts
+++ b/dashboard/src/components/fusion-settings-panel.test.ts
@@ -218,12 +218,10 @@ describe('FusionSettingsPanel', () => {
     const models = Array.from(container.querySelectorAll('[data-testid="fusion-preset-panel-model"]')).map(m => m.textContent)
     expect(models).toEqual(['a', 'b', 'c'])
     expect(q('[data-testid="fusion-preset-judge"]')?.textContent).toBe('j')
-    // SAMPLE's trio declares no timeouts/max_tool_calls → shown as '—', never fabricated.
+    // SAMPLE's trio declares no timeouts → shown as '—', never fabricated.
     const timing = q('[data-testid="fusion-preset-timing"]')?.textContent ?? ''
     expect(timing).toContain('panel_timeout —')
     expect(timing).toContain('judge_timeout —')
-    expect(timing).toContain('max_tool_calls_per_panel —')
-    expect(timing).toContain('(0 = 무제한)')
   })
 
   it('omits the preset card when the default preset has no backing section', async () => {

--- a/dashboard/src/components/fusion-settings-panel.ts
+++ b/dashboard/src/components/fusion-settings-panel.ts
@@ -324,7 +324,7 @@ export function FusionSettingsPanel() {
   const checked = (e: Event) => (e.target as HTMLInputElement).checked
 
   // Read-only view of the active preset's composition (panel models · judge ·
-  // timeouts · max_tool_calls), parsed from the same runtime.toml source the
+  // timeouts), parsed from the same runtime.toml source the
   // editor already loaded. Shown only when the default_preset resolves to a real
   // [fusion.presets.<preset>] table that actually declares panel models — a
   // preset with no panel has no composition worth displaying. The editor scalars
@@ -418,7 +418,7 @@ export function FusionSettingsPanel() {
               </div>
             </div>
             <div class="set-mcp-detail mono" data-testid="fusion-preset-timing" style=${{ marginTop: 10 }}>
-              panel_timeout ${timeoutLabel(presetView.panelTimeoutS)} · judge_timeout ${timeoutLabel(presetView.judgeTimeoutS)} · max_tool_calls_per_panel ${presetView.maxToolCallsPerPanel ?? '—'} (0 = 무제한)
+              panel_timeout ${timeoutLabel(presetView.panelTimeoutS)} · judge_timeout ${timeoutLabel(presetView.judgeTimeoutS)}
             </div>
           `
         : null}

--- a/dashboard/src/lib/fusion-preset-view.test.ts
+++ b/dashboard/src/lib/fusion-preset-view.test.ts
@@ -21,7 +21,6 @@ You are an expert panelist. Answer directly.
 """
 panel_timeout_s = 300.0
 judge_timeout_s = 250.0
-max_tool_calls_per_panel = 0
 
 [fusion.presets.quorum]
 panel = ["lens_a", "lens_b"]
@@ -38,7 +37,7 @@ describe('readFusionPresetView', () => {
     expect(readFusionPresetView(MULTILINE, 'nonexistent')).toBeNull()
   })
 
-  it('parses a multi-line panel array plus scalar judge/timeouts/max_tool_calls', () => {
+  it('parses a multi-line panel array plus scalar judge/timeouts', () => {
     const view = readFusionPresetView(MULTILINE, 'trio')
     expect(view).not.toBeNull()
     expect(view!.preset).toBe('trio')
@@ -51,7 +50,6 @@ describe('readFusionPresetView', () => {
     // Scalars are found even though a multi-line prompt string precedes them.
     expect(view!.panelTimeoutS).toBe(300)
     expect(view!.judgeTimeoutS).toBe(250)
-    expect(view!.maxToolCallsPerPanel).toBe(0)
   })
 
   it('scopes to the requested preset and does not inherit a sibling preset', () => {
@@ -61,7 +59,6 @@ describe('readFusionPresetView', () => {
     // quorum declares no timeouts → null, not the trio values.
     expect(view!.panelTimeoutS).toBeNull()
     expect(view!.judgeTimeoutS).toBeNull()
-    expect(view!.maxToolCallsPerPanel).toBeNull()
   })
 
   it('handles a single-line panel array', () => {
@@ -78,7 +75,6 @@ describe('readFusionPresetView', () => {
     expect(view!.panel).toEqual([])
     expect(view!.judge).toBeNull()
     expect(view!.panelTimeoutS).toBeNull()
-    expect(view!.maxToolCallsPerPanel).toBeNull()
   })
 
   it('flags a flat preset as not grouped', () => {
@@ -102,12 +98,10 @@ judge_system_prompt = "synthesize"
 panel = ["fast1", "fast2"]
 panel_system_prompt = "quick"
 web_tools = false
-max_tool_calls_per_panel = 0
 [[fusion.presets.mixed.panels]]
 panel = ["careful1"]
 panel_system_prompt = "deliberate"
 web_tools = true
-max_tool_calls_per_panel = 4
 panel_timeout_s = 180.0
 `
 

--- a/dashboard/src/lib/fusion-preset-view.ts
+++ b/dashboard/src/lib/fusion-preset-view.ts
@@ -1,11 +1,11 @@
 // Read-only view of a [fusion.presets.<preset>] table for the Settings fusion
-// section (keeper-v2 settings.jsx: trio preset lanes + timeout/max_tool_calls).
+// section (keeper-v2 settings.jsx: trio preset lanes + timeouts).
 //
 // This is a display-only reader — it never writes back, so it deliberately does
 // NOT live in fusion-settings.ts (whose line-surgical write path forbids
 // multi-line values). The preset `panel` value is a possibly multi-line TOML
 // array, which the scalar getRuntimeTomlKey helper cannot read; scalar keys
-// (judge / timeouts / max_tool_calls_per_panel) reuse getRuntimeTomlKey so the
+// (judge / timeouts) reuse getRuntimeTomlKey so the
 // section-scoping stays consistent with the rest of the runtime.toml tooling.
 //
 // The source text is the live runtime.toml already fetched by
@@ -29,13 +29,11 @@ export interface FusionPresetView {
   readonly judge: string | null
   readonly panelTimeoutS: number | null
   readonly judgeTimeoutS: number | null
-  readonly maxToolCallsPerPanel: number | null
 }
 
 const KEY_JUDGE = 'judge'
 const KEY_PANEL_TIMEOUT_S = 'panel_timeout_s'
 const KEY_JUDGE_TIMEOUT_S = 'judge_timeout_s'
-const KEY_MAX_TOOL_CALLS = 'max_tool_calls_per_panel'
 
 function presetSection(preset: string): string {
   return `fusion.presets.${preset}`
@@ -175,7 +173,6 @@ export function readFusionPresetView(sourceText: string, preset: string): Fusion
       judge: null,
       panelTimeoutS: null,
       judgeTimeoutS: null,
-      maxToolCallsPerPanel: null,
     }
   }
 
@@ -190,6 +187,5 @@ export function readFusionPresetView(sourceText: string, preset: string): Fusion
     judge: parseScalarString(sourceText, section, KEY_JUDGE),
     panelTimeoutS: parseScalarNumber(sourceText, section, KEY_PANEL_TIMEOUT_S),
     judgeTimeoutS: parseScalarNumber(sourceText, section, KEY_JUDGE_TIMEOUT_S),
-    maxToolCallsPerPanel: parseScalarNumber(sourceText, section, KEY_MAX_TOOL_CALLS),
   }
 }

--- a/lib/fusion/fusion_orchestrator.ml
+++ b/lib/fusion/fusion_orchestrator.ml
@@ -43,7 +43,6 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
             Fusion_policy.judge_web_tools_of ~req_web_tools:req.Fusion_types.web_tools
               groups
           in
-          let judge_max_tool_calls = Fusion_policy.judge_tool_budget_of groups in
           let run_single_judge () =
             Fusion_judge.run ~sw ~net
               ~timeout_s:preset.Fusion_policy.judge_timeout_s
@@ -106,7 +105,6 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
               ~question:req.Fusion_types.prompt
               ~clock
               ~judge_web_tools
-              ~judge_max_tool_calls
               judges
           in
           let first_judge_nodes =
@@ -137,7 +135,6 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
               ~question:req.Fusion_types.prompt
               ~clock
               ~judge_web_tools
-              ~judge_max_tool_calls
               ()
           in
           let run_judge_of_judges () =

--- a/lib/fusion/fusion_orchestrator_judge_wave.ml
+++ b/lib/fusion/fusion_orchestrator_judge_wave.ml
@@ -47,13 +47,12 @@ let run_first_judge
       ~question
       ~clock
       ~judge_web_tools
-      ~judge_max_tool_calls
       ~already_timed_out
       (j : Fusion_policy.judge_spec)
   : judge_run
   =
   let id = Fusion_policy.panelist_id ~label:j.jlabel ~model:j.jmodel in
-  let _ = preset, judge_web_tools, judge_max_tool_calls, already_timed_out in
+  let _ = preset, judge_web_tools, already_timed_out in
   let result =
     Fusion_judge.run
       ~sw
@@ -84,7 +83,6 @@ let run_first_judges
       ~question
       ~clock
       ~judge_web_tools
-      ~judge_max_tool_calls
       judges
   =
   let run_first_judge =
@@ -96,7 +94,6 @@ let run_first_judges
       ~question
       ~clock
       ~judge_web_tools
-      ~judge_max_tool_calls
   in
   let _ = max_concurrent_judges in
   Eio.Fiber.List.map
@@ -188,7 +185,6 @@ let run_fallback_judge
       ~question
       ~clock
       ~judge_web_tools
-      ~judge_max_tool_calls
       ()
   =
   match preset.Fusion_policy.fallback_judge_model with
@@ -200,7 +196,6 @@ let run_fallback_judge
       ; jlabel = "fallback"
       ; jsystem_prompt = preset.Fusion_policy.judge_system_prompt
       ; jweb_tools = judge_web_tools
-      ; jmax_tool_calls = judge_max_tool_calls
       ; jmax_output_tokens = preset.Fusion_policy.judge_max_output_tokens
       ; jtimeout_s = preset.Fusion_policy.judge_timeout_s
       ; jmax_timeout_s = None

--- a/lib/fusion/fusion_orchestrator_judge_wave.mli
+++ b/lib/fusion/fusion_orchestrator_judge_wave.mli
@@ -34,7 +34,6 @@ val run_first_judges
   -> question:string
   -> clock:clock
   -> judge_web_tools:bool
-  -> judge_max_tool_calls:int
   -> Fusion_policy.judge_spec list
   -> judge_run list
 
@@ -76,6 +75,5 @@ val run_fallback_judge
   -> question:string
   -> clock:clock
   -> judge_web_tools:bool
-  -> judge_max_tool_calls:int
   -> unit
   -> judge_run option

--- a/lib/fusion_core/fusion_config.ml
+++ b/lib/fusion_core/fusion_config.ml
@@ -12,7 +12,6 @@ type config_error =
   | Invalid_max_concurrent_panels of int
   | Invalid_max_concurrent_judges of int
   | Invalid_staged_judge_group_size of int
-  | Invalid_max_tool_calls of string * int
   | Invalid_max_output_tokens of string * int
   | Missing_default_preset of string
   | Judge_panel_prompt_missing of string  (** preset 이름; JOJ 1차 심판 prompt 누락 (RFC-0283) *)
@@ -40,7 +39,7 @@ let disabled : Fusion_policy.t =
 
 (* 패널 그룹 한 개 파싱. 그룹 sub-table(새 [[...panels]] 문법)에도, preset table
    자체(legacy flat 문법의 desugar)에도 동일하게 적용된다 — 두 문법이 같은 키
-   이름(panel/label/panel_system_prompt/web_tools/max_tool_calls_per_panel/panel_timeout_s)을
+   이름(panel/label/panel_system_prompt/web_tools/panel_timeout_s)을
    쓰므로 코드 재사용. 누락 필드는 명시적 default. label 기본 ""(정체성=model 그대로)
    → legacy flat은 label 키가 없으므로 byte-identical (RFC-0278). *)
 let parse_group (tbl : Otoml.t) : Fusion_policy.panel_group =
@@ -50,8 +49,6 @@ let parse_group (tbl : Otoml.t) : Fusion_policy.panel_group =
   ; system_prompt =
       Otoml.find_or ~default:"" tbl Otoml.get_string [ "panel_system_prompt" ]
   ; web_tools = Otoml.find_or ~default:false tbl Otoml.get_boolean [ "web_tools" ]
-  ; max_tool_calls =
-      Otoml.find_or ~default:0 tbl Otoml.get_integer [ "max_tool_calls_per_panel" ]
   ; max_output_tokens =
       Otoml.find_opt tbl Otoml.get_integer [ "max_output_tokens_per_panel" ]
   ; timeout_s =
@@ -60,7 +57,7 @@ let parse_group (tbl : Otoml.t) : Fusion_policy.panel_group =
   }
 
 (* JOJ 1차 심판 한 명 파싱 (RFC-0283). [[fusion.presets.NAME.judges]] sub-table의
-   키 model/label/system_prompt/web_tools/max_tool_calls/timeout_s를 읽는다. sub-table
+   키 model/label/system_prompt/web_tools/timeout_s를 읽는다. sub-table
    이름(judges)이 scope를 주므로 키는 비-접두. parse_group과 동형. 누락 system_prompt는
    ""로 읽혀 Validated_preset 검증에서 Judge_panel_prompt_missing으로 fail-fast된다. *)
 let parse_judge_spec (tbl : Otoml.t) : Fusion_policy.judge_spec =
@@ -69,8 +66,6 @@ let parse_judge_spec (tbl : Otoml.t) : Fusion_policy.judge_spec =
   ; jsystem_prompt =
       Otoml.find_or ~default:"" tbl Otoml.get_string [ "system_prompt" ]
   ; jweb_tools = Otoml.find_or ~default:false tbl Otoml.get_boolean [ "web_tools" ]
-  ; jmax_tool_calls =
-      Otoml.find_or ~default:0 tbl Otoml.get_integer [ "max_tool_calls" ]
   ; jmax_output_tokens = Otoml.find_opt tbl Otoml.get_integer [ "max_output_tokens" ]
   ; jtimeout_s =
       Otoml.find_or ~default:Fusion_policy.default_timeout_s tbl Otoml.get_float
@@ -87,8 +82,7 @@ let parse_min_answered _name tbl =
 (* 패널 그룹을 확정한 뒤 preset 완성 + 검증. judge_* 는 preset table에서 직접 읽는다
    (단일 심판 = simple/refine/conditional 심판이자 JOJ meta). [[...judges]] sub-table이
    있으면 JOJ 1차 심판 목록으로 파싱(없으면 []). 검증 순서: 크기(총합) → 패널 프롬프트 →
-   심판모델 → 패널 정체성 중복 → 패널 max_tool_calls → 1차 심판 prompt/정체성/max_tool_calls
-   → min_answered. *)
+   심판모델 → 패널 정체성 중복 → 1차 심판 prompt/정체성 → min_answered. *)
 let finish_preset name tbl (panels : Fusion_policy.panel_group list)
   : (Fusion_policy.Validated_preset.t, config_error) result =
   let judge = Otoml.find_or ~default:"" tbl Otoml.get_string [ "judge" ] in
@@ -156,8 +150,6 @@ let finish_preset name tbl (panels : Fusion_policy.panel_group list)
          | Fusion_policy.Validated_preset.Missing_judge_model -> Missing_judge_model name
          | Fusion_policy.Validated_preset.Duplicate_panelist id ->
            Duplicate_panelist (name, id)
-         | Fusion_policy.Validated_preset.Bad_max_tool_calls v ->
-           Invalid_max_tool_calls (name, v)
          | Fusion_policy.Validated_preset.Bad_max_output_tokens v ->
            Invalid_max_output_tokens (name, v)
          | Fusion_policy.Validated_preset.Judge_panel_prompt_missing ->

--- a/lib/fusion_core/fusion_config.mli
+++ b/lib/fusion_core/fusion_config.mli
@@ -27,8 +27,6 @@ type config_error =
   | Invalid_max_concurrent_judges of int  (** max_concurrent_judges < 1 *)
   | Invalid_staged_judge_group_size of int
       (** staged_judge_group_size < Fusion_policy.min_staged_judge_group_size *)
-  | Invalid_max_tool_calls of string * int
-      (** (preset 이름, 값) — 0..16 범위 위반 *)
   | Invalid_max_output_tokens of string * int
       (** (preset 이름, 값) — max_output_tokens override는 양수여야 함 *)
   | Missing_default_preset of string
@@ -69,7 +67,6 @@ val disabled : Fusion_policy.t
     - max_concurrent_panels < 1 → [Error [Invalid_max_concurrent_panels _]].
     - max_concurrent_judges < 1 → [Error [Invalid_max_concurrent_judges _]].
     - staged_judge_group_size < 2 → [Error [Invalid_staged_judge_group_size _]].
-    - max_tool_calls_per_panel이 0..16 범위 밖 → [Error [Invalid_max_tool_calls _]].
     - max_output_tokens override가 0 이하 → [Error [Invalid_max_output_tokens _]].
     - min_answered가 1..패널 모델 총합 범위 밖 → [Error [Invalid_min_answered _]].
     - default_preset가 presets에 없음 → [Error [Missing_default_preset _]].

--- a/lib/fusion_core/fusion_config_json.ml
+++ b/lib/fusion_core/fusion_config_json.ml
@@ -26,7 +26,6 @@ let panel_group_to_yojson (g : Fusion_policy.panel_group) : Yojson.Safe.t =
     ; ("label", `String g.Fusion_policy.label)
     ; ("system_prompt", `String g.Fusion_policy.system_prompt)
     ; ("web_tools", `Bool g.Fusion_policy.web_tools)
-    ; ("max_tool_calls", `Int g.Fusion_policy.max_tool_calls)
     ; ("max_output_tokens", opt_int g.Fusion_policy.max_output_tokens)
     ; ("timeout_s", `Float g.Fusion_policy.timeout_s)
     ]
@@ -39,7 +38,6 @@ let judge_spec_to_yojson (j : Fusion_policy.judge_spec) : Yojson.Safe.t =
     ; ("label", `String j.Fusion_policy.jlabel)
     ; ("system_prompt", `String j.Fusion_policy.jsystem_prompt)
     ; ("web_tools", `Bool j.Fusion_policy.jweb_tools)
-    ; ("max_tool_calls", `Int j.Fusion_policy.jmax_tool_calls)
     ; ("max_output_tokens", opt_int j.Fusion_policy.jmax_output_tokens)
     ; ("timeout_s", `Float j.Fusion_policy.jtimeout_s)
     ; ("max_timeout_s", opt_float j.Fusion_policy.jmax_timeout_s)

--- a/lib/fusion_core/fusion_policy.ml
+++ b/lib/fusion_core/fusion_policy.ml
@@ -1,7 +1,7 @@
 (* Fusion — 결정론적 발동 게이트 (구현).
    계약/문서: fusion_policy.mli, docs/rfc/RFC-0252 §6 *)
 
-(* 한 패널 그룹 — 공통 system_prompt/web_tools/max_tool_calls/timeout으로 실행되는
+(* 한 패널 그룹 — 공통 system_prompt/web_tools/timeout으로 실행되는
    모델 묶음. 한 preset이 이종(heterogeneous) 그룹 여럿을 가질 수 있다(RFC-0252-A).
    닫힌 record (option-dual 없음); preset이 [panel_group list]를 deriving하므로
    nested deriving 필수. *)
@@ -13,7 +13,6 @@ type panel_group =
           → legacy/단일-occurrence는 byte-identical. 정체성 derive는 [panelist_id]. *)
   ; system_prompt : string  (** 그룹 패널 모델 system prompt (config 필수) *)
   ; web_tools : bool  (** 그룹에 web_search/web_fetch 주입 여부 *)
-  ; max_tool_calls : int  (** 그룹 모델당 최대 tool 호출 수 (0=무제한) *)
   ; max_output_tokens : int option  (** 그룹 모델당 출력 토큰 예산 override *)
   ; timeout_s : float  (** 그룹 패널 호출 구조적 타임아웃 (초) *)
   }
@@ -27,7 +26,6 @@ type judge_spec =
   ; jlabel : string  (** 정체성 라벨 ([panelist_id]와 동형). ""면 정체성=jmodel *)
   ; jsystem_prompt : string  (** 이 1차 심판의 lens (config 필수) *)
   ; jweb_tools : bool  (** web_search/web_fetch 주입 여부 *)
-  ; jmax_tool_calls : int  (** 최대 tool 호출 수 (0=무제한) *)
   ; jmax_output_tokens : int option  (** 출력 토큰 예산 override *)
   ; jtimeout_s : float  (** 호출 구조적 타임아웃 (초) *)
   ; jmax_timeout_s : float option
@@ -66,10 +64,6 @@ let default_min_answered = min_answered_floor
 let default_max_concurrent_judges = max_panel
 let min_staged_judge_group_size = 2
 let default_staged_judge_group_size = 3
-
-(* 그룹 모델당 max_tool_calls 상한 (0..max). 0=무제한, 그 외 양수는 에이전트
-   max_turns에 근사. SSOT 상수 (Magic Number 회피, RFC-0280에서 검증을 한 곳으로 모음). *)
-let max_tool_calls_ceiling = 16
 
 let valid_max_output_tokens = function
   | None -> true
@@ -254,13 +248,6 @@ let panel_outer_timeout_of ~max_fibers (groups : panel_group list) =
 let judge_web_tools_of ~req_web_tools (groups : panel_group list) =
   req_web_tools || List.exists (fun (g : panel_group) -> g.web_tools) groups
 
-(* 심판 tool budget을 그룹들에서 derive. 0=무제한이 흡수자(어느 그룹이 무제한이면
-   심판도 무제한), 그 외엔 그룹 max. 단일 그룹이면 그 값 = 오늘의
-   max_tool_calls_per_panel (byte-identity). *)
-let judge_tool_budget_of (groups : panel_group list) =
-  if List.exists (fun (g : panel_group) -> g.max_tool_calls = 0) groups then 0
-  else List.fold_left (fun acc (g : panel_group) -> max acc g.max_tool_calls) 0 groups
-
 (* 적응형 타임아웃 임계값들. [adaptive_extension_threshold]는 adaptive 확장을 끄는
    factor 값(config default 1.0; 검증이 >= 1.0을 강제). 1.0은 IEEE754에서 정확히
    표현되지만, 의도를 명시하고 drift를 막기 named 상수로 둔다 — callers 도 float
@@ -321,8 +308,6 @@ module Validated_preset = struct
     | Missing_prompt  (** 패널 또는 심판 system prompt 비어있음 *)
     | Missing_judge_model  (** 심판 model id 비어있음 *)
     | Duplicate_panelist of string  (** 두 패널이 같은 정체성(panelist_id) *)
-    | Bad_max_tool_calls of int
-        (** 그룹 또는 JOJ 1차 심판 max_tool_calls가 0..max_tool_calls_ceiling 밖 *)
     | Bad_max_output_tokens of int
         (** 그룹/심판 출력 토큰 예산 override가 양수가 아님 *)
     | Judge_panel_prompt_missing  (** JOJ 1차 심판 system prompt 비어있음 (RFC-0283) *)
@@ -340,9 +325,8 @@ module Validated_preset = struct
         (** [adaptive_timeout_factor]가 1.0 미만. *)
 
   (* 검증 순서는 config 로드 시점과 동일(byte-identical config_error): size → 패널 prompt →
-     judge model → 패널 정체성 중복 → 패널 max_tool_calls 범위 → 패널 max_output_tokens
-     범위 → (RFC-0283) 1차 심판 prompt → 1차 심판 정체성 중복 → 1차 심판
-     max_tool_calls 범위 → 심판 max_output_tokens 범위 → min_answered.
+     judge model → 패널 정체성 중복 → 패널 max_output_tokens 범위 → (RFC-0283)
+     1차 심판 prompt → 1차 심판 정체성 중복 → 심판 max_output_tokens 범위 → min_answered.
      judges=[]면 1차 심판 관련 셋은 통과(simple/refine/conditional preset은 기존과 동일
      결과 = byte-identity). *)
   let of_preset (p : preset) : (t, invalid) result =
@@ -354,71 +338,51 @@ module Validated_preset = struct
       | Some id -> Error (Duplicate_panelist id)
       | None ->
         (match
-           List.find_opt
+           List.find_map
              (fun (g : panel_group) ->
-               g.max_tool_calls < 0 || g.max_tool_calls > max_tool_calls_ceiling)
+               match g.max_output_tokens with
+               | Some n when not (valid_max_output_tokens (Some n)) -> Some n
+               | _ -> None)
              p.panels
          with
-         | Some g -> Error (Bad_max_tool_calls g.max_tool_calls)
+         | Some n -> Error (Bad_max_output_tokens n)
          | None ->
-           (match
-              List.find_map
-                (fun (g : panel_group) ->
-                  match g.max_output_tokens with
-                  | Some n when not (valid_max_output_tokens (Some n)) -> Some n
-                  | _ -> None)
-                p.panels
-            with
-            | Some n -> Error (Bad_max_output_tokens n)
-            | None ->
-              if not (preset_judge_prompts_present p) then Error Judge_panel_prompt_missing
-              else (
-                match preset_duplicate_judge p with
-                | Some id -> Error (Duplicate_judge id)
-                | None ->
-                  (match
-                     List.find_opt
-                       (fun (j : judge_spec) ->
-                         j.jmax_tool_calls < 0
-                         || j.jmax_tool_calls > max_tool_calls_ceiling)
-                       p.judges
-                   with
-                   | Some j -> Error (Bad_max_tool_calls j.jmax_tool_calls)
-                   | None ->
-                     (match
-                        p.judge_max_output_tokens
-                        :: List.map
-                             (fun (j : judge_spec) -> j.jmax_output_tokens)
-                             p.judges
-                        |> List.find_opt (fun v -> not (valid_max_output_tokens v))
-                      with
-                      | Some (Some n) -> Error (Bad_max_output_tokens n)
-                      | Some None | None ->
-                        let total = List.length (preset_models p) in
-                        if p.min_answered < min_answered_floor
-                        then Error (Min_answered_below_min p.min_answered)
-                        else if p.min_answered > total
-                        then Error (Min_answered_above_max p.min_answered)
-                        else if
-                          not (p.meta_timeout_s > 0.0 && Float.is_finite p.meta_timeout_s)
-                        then Error (Bad_meta_timeout p.meta_timeout_s)
-                        else if p.adaptive_timeout_factor < 1.0
-                        then Error (Bad_adaptive_factor p.adaptive_timeout_factor)
-                        else if p.judge_wave_budget_s < 0.0
-                        then Error (Bad_judge_wave_budget p.judge_wave_budget_s)
-                        else if
-                          p.judge_wave_budget_s > 0.0
-                          && Float.is_finite p.judge_wave_budget_s
-                          && (let longest_judge =
-                                List.fold_left
-                                  (fun acc (j : judge_spec) ->
-                                    Float.max acc j.jtimeout_s)
-                                  0.0 p.judges
-                              in
-                              p.judge_wave_budget_s < longest_judge
-                              || p.judge_wave_budget_s < p.meta_timeout_s)
-                        then Error (Bad_judge_wave_budget p.judge_wave_budget_s)
-                        else Ok p)))))
+           if not (preset_judge_prompts_present p) then Error Judge_panel_prompt_missing
+           else (
+             match preset_duplicate_judge p with
+             | Some id -> Error (Duplicate_judge id)
+             | None ->
+               (match
+                  p.judge_max_output_tokens
+                  :: List.map (fun (j : judge_spec) -> j.jmax_output_tokens) p.judges
+                  |> List.find_opt (fun v -> not (valid_max_output_tokens v))
+                with
+                | Some (Some n) -> Error (Bad_max_output_tokens n)
+                | Some None | None ->
+                  let total = List.length (preset_models p) in
+                  if p.min_answered < min_answered_floor
+                  then Error (Min_answered_below_min p.min_answered)
+                  else if p.min_answered > total
+                  then Error (Min_answered_above_max p.min_answered)
+                  else if
+                    not (p.meta_timeout_s > 0.0 && Float.is_finite p.meta_timeout_s)
+                  then Error (Bad_meta_timeout p.meta_timeout_s)
+                  else if p.adaptive_timeout_factor < 1.0
+                  then Error (Bad_adaptive_factor p.adaptive_timeout_factor)
+                  else if p.judge_wave_budget_s < 0.0
+                  then Error (Bad_judge_wave_budget p.judge_wave_budget_s)
+                  else if
+                    p.judge_wave_budget_s > 0.0
+                    && Float.is_finite p.judge_wave_budget_s
+                    && (let longest_judge =
+                          List.fold_left
+                            (fun acc (j : judge_spec) -> Float.max acc j.jtimeout_s)
+                            0.0 p.judges
+                        in
+                        p.judge_wave_budget_s < longest_judge
+                        || p.judge_wave_budget_s < p.meta_timeout_s)
+                  then Error (Bad_judge_wave_budget p.judge_wave_budget_s)
+                  else Ok p)))
 
   let preset (t : t) : preset = t
 

--- a/lib/fusion_core/fusion_policy.mli
+++ b/lib/fusion_core/fusion_policy.mli
@@ -17,7 +17,6 @@ type panel_group =
   ; system_prompt : string
       (** 그룹 패널 모델 system prompt — config에서 필수(코드 default 없음). *)
   ; web_tools : bool  (** 그룹에 web_search/web_fetch 주입 여부. *)
-  ; max_tool_calls : int  (** 그룹 모델당 최대 tool 호출 수 (0=무제한). *)
   ; max_output_tokens : int option
       (** 그룹 모델당 출력 토큰 예산 override. [None]이면 Runtime_agent 기본값. *)
   ; timeout_s : float  (** 그룹 패널 호출 구조적 타임아웃 (초). *)
@@ -32,7 +31,6 @@ type judge_spec =
   ; jlabel : string  (** 정체성 라벨. ""면 정체성=jmodel *)
   ; jsystem_prompt : string  (** 이 1차 심판의 lens — config에서 필수(코드 default 없음). *)
   ; jweb_tools : bool  (** web_search/web_fetch 주입 여부. *)
-  ; jmax_tool_calls : int  (** 최대 tool 호출 수 (0=무제한). *)
   ; jmax_output_tokens : int option
       (** 출력 토큰 예산 override. [None]이면 Runtime_agent 기본값. *)
   ; jtimeout_s : float  (** 호출 구조적 타임아웃 (초). *)
@@ -97,9 +95,6 @@ val default_staged_judge_group_size : int
 (** Smallest useful staged JOJ group size. Size 1 degenerates into a serial
     pass-through and is rejected. *)
 val min_staged_judge_group_size : int
-
-(** 그룹 모델당 [max_tool_calls] 상한 (0..이 값). 0=무제한. named SSOT. *)
-val max_tool_calls_ceiling : int
 
 (** Optional max-output-token overrides must be positive when present. *)
 val valid_max_output_tokens : int option -> bool
@@ -185,10 +180,6 @@ val panel_outer_timeout_of : max_fibers:int -> panel_group list -> float
     단일 그룹이면 [req_web_tools || group.web_tools] (오늘과 byte-identical). *)
 val judge_web_tools_of : req_web_tools:bool -> panel_group list -> bool
 
-(** 심판 tool budget을 그룹들에서 derive: 0(무제한)이 흡수자, 그 외엔 그룹 max.
-    단일 그룹이면 그 그룹 [max_tool_calls] (오늘과 byte-identical). *)
-val judge_tool_budget_of : panel_group list -> int
-
 (** [adaptive_timeout_enabled preset] — preset의 [adaptive_timeout_factor]가 확장
     임계값(1.0)을 넘는가. callers(orchestrator)가 float equality 비교 없이 typed bool로
     adaptive 재시도 분기를 판정한다. *)
@@ -227,8 +218,6 @@ module Validated_preset : sig
     | Missing_prompt  (** 패널 또는 심판 system prompt 비어있음 *)
     | Missing_judge_model  (** 심판 model id 비어있음 *)
     | Duplicate_panelist of string  (** 두 패널이 같은 정체성({!panelist_id}) *)
-    | Bad_max_tool_calls of int
-        (** 그룹 또는 JOJ 1차 심판 max_tool_calls가 0..[max_tool_calls_ceiling] 밖 *)
     | Bad_max_output_tokens of int
         (** 그룹/심판 max_output_tokens override가 양수가 아님 *)
     | Judge_panel_prompt_missing  (** JOJ 1차 심판 system prompt 비어있음 (RFC-0283) *)
@@ -245,9 +234,9 @@ module Validated_preset : sig
     | Bad_adaptive_factor of float
         (** [adaptive_timeout_factor]가 1.0 미만. *)
 
-  (** 검증 순서: size → prompt → judge → 정체성 중복 → max_tool_calls →
-      max_output_tokens → 1차 심판 prompt/정체성/max_tool_calls/max_output_tokens →
-      min_answered → timeout 예산/계수. 통과 시 [Ok vp], 첫 위반에서 [Error invalid].
+  (** 검증 순서: size → prompt → judge → 정체성 중복 → max_output_tokens →
+      1차 심판 prompt/정체성/max_output_tokens → min_answered → timeout 예산/계수.
+      통과 시 [Ok vp], 첫 위반에서 [Error invalid].
       config 로드의 검증 순서와 동일. *)
   val of_preset : preset -> (t, invalid) result
 

--- a/test/fusion_core/test_fusion.ml
+++ b/test/fusion_core/test_fusion.ml
@@ -18,7 +18,6 @@ let base_group : Fusion_policy.panel_group =
   ; label = ""
   ; system_prompt = "panel"
   ; web_tools = false
-  ; max_tool_calls = 0
   ; max_output_tokens = None
   ; timeout_s = 300.0
   }
@@ -112,7 +111,6 @@ max_concurrent_judges = 4
 staged_judge_group_size = 3
 [fusion.presets.trio]
 web_tools = false
-max_tool_calls_per_panel = 0
 panel = ["a", "b", "c"]
 judge = "j"
 panel_system_prompt = "answer independently"
@@ -137,7 +135,6 @@ let test_config_valid () =
        (match preset.Fusion_policy.panels with
         | [ g ] ->
           Alcotest.(check bool) "web_tools" false g.Fusion_policy.web_tools;
-          Alcotest.(check int) "max_tool_calls" 0 g.Fusion_policy.max_tool_calls;
           Alcotest.(check (option int)) "max_output_tokens default" None
             g.Fusion_policy.max_output_tokens
         | _ -> Alcotest.fail "expected one group")
@@ -208,7 +205,6 @@ enabled = true
 default_preset = "p"
 [fusion.presets.p]
 web_tools = true
-max_tool_calls_per_panel = 4
 max_output_tokens_per_panel = 2048
 panel_timeout_s = 123.0
 panel = ["a", "b", "c"]
@@ -233,7 +229,6 @@ judge_max_output_tokens = 1024
 panel = ["a", "b", "c"]
 panel_system_prompt = "answer independently"
 web_tools = true
-max_tool_calls_per_panel = 4
 max_output_tokens_per_panel = 2048
 panel_timeout_s = 123.0
 |}
@@ -268,12 +263,10 @@ judge_system_prompt = "synthesize"
 panel = ["fast1", "fast2"]
 panel_system_prompt = "quick"
 web_tools = false
-max_tool_calls_per_panel = 0
 [[fusion.presets.mixed.panels]]
 panel = ["careful1"]
 panel_system_prompt = "deliberate"
 web_tools = true
-max_tool_calls_per_panel = 4
 panel_timeout_s = 180.0
 |}
 
@@ -290,7 +283,6 @@ let test_config_heterogeneous () =
         | [ g1; g2 ] ->
           Alcotest.(check bool) "g1 no web" false g1.Fusion_policy.web_tools;
           Alcotest.(check bool) "g2 web" true g2.Fusion_policy.web_tools;
-          Alcotest.(check int) "g2 tool budget" 4 g2.Fusion_policy.max_tool_calls;
           Alcotest.(check (option int)) "g1 default max output" None
             g1.Fusion_policy.max_output_tokens;
           Alcotest.(check (float 0.001)) "g2 timeout" 180.0 g2.Fusion_policy.timeout_s;
@@ -766,7 +758,6 @@ let test_config_two_judges_not_staged_eligible () =
     ; jlabel = label
     ; jsystem_prompt = label ^ " lens"
     ; jweb_tools = false
-    ; jmax_tool_calls = 0
     ; jmax_output_tokens = None
     ; jtimeout_s = 300.0
     ; jmax_timeout_s = None
@@ -781,29 +772,6 @@ let test_config_two_judges_not_staged_eligible () =
     Alcotest.failf "expected Staged_too_few_judges, got: %s"
       (Fusion_policy.staged_judge_group_error_message e)
   | Ok _ -> Alcotest.fail "two judges must not be staged-eligible"
-
-let test_config_invalid_max_tool_calls () =
-  let s =
-    {|
-[fusion]
-enabled = true
-default_preset = "p1"
-[fusion.presets.p1]
-panel = ["a", "b"]
-judge = "a"
-panel_system_prompt = "p"
-judge_system_prompt = "j"
-web_tools = true
-max_tool_calls_per_panel = 17
-|}
-  in
-  match Fusion_config.of_toml (parse s) with
-  | Error es ->
-    Alcotest.(check bool) "Invalid_max_tool_calls present" true
-      (List.exists
-         (function Fusion_config.Invalid_max_tool_calls _ -> true | _ -> false)
-         es)
-  | Ok _ -> Alcotest.fail "expected Error Invalid_max_tool_calls"
 
 let test_config_invalid_max_output_tokens () =
   let s =
@@ -862,7 +830,6 @@ max_concurrent_judges = 3
 staged_judge_group_size = 3
 [fusion.presets.trio]
 web_tools = false
-max_tool_calls_per_panel = 0
 panel = [
   "deepseek.deepseek-v4-pro",
   "glm-coding.glm-5-turbo",
@@ -951,15 +918,6 @@ let test_validated_duplicate_panelist () =
   | Error (Fusion_policy.Validated_preset.Duplicate_panelist "x") -> ()
   | _ -> Alcotest.fail "expected Duplicate_panelist x for same model no label"
 
-let test_validated_bad_max_tool_calls () =
-  let over =
-    { base_group with Fusion_policy.max_tool_calls = Fusion_policy.max_tool_calls_ceiling + 1 }
-  in
-  match Fusion_policy.Validated_preset.of_preset (mk_preset ~panels:[ over ] "mtc") with
-  | Error (Fusion_policy.Validated_preset.Bad_max_tool_calls v) ->
-    Alcotest.(check int) "over-ceiling value reported" 17 v
-  | _ -> Alcotest.fail "expected Bad_max_tool_calls over ceiling"
-
 let test_validated_bad_max_output_tokens () =
   let bad = { base_group with Fusion_policy.max_output_tokens = Some 0 } in
   match Fusion_policy.Validated_preset.of_preset (mk_preset ~panels:[ bad ] "mot") with
@@ -973,7 +931,6 @@ let base_judge : Fusion_policy.judge_spec =
   ; jlabel = ""
   ; jsystem_prompt = "lens"
   ; jweb_tools = false
-  ; jmax_tool_calls = 0
   ; jmax_output_tokens = None
   ; jtimeout_s = 300.0
   ; jmax_timeout_s = None
@@ -1007,20 +964,6 @@ let test_validated_duplicate_judge () =
   with
   | Error (Fusion_policy.Validated_preset.Duplicate_judge "x") -> ()
   | _ -> Alcotest.fail "expected Duplicate_judge x for same judge identity"
-
-let test_validated_judge_bad_max_tool_calls () =
-  let over =
-    { base_judge with
-      Fusion_policy.jmax_tool_calls = Fusion_policy.max_tool_calls_ceiling + 1
-    }
-  in
-  (* 단일 over-ceiling judge — panel-side test_validated_bad_max_tool_calls(~panels:[ over ])와
-     대칭. base_judge를 더하면 jmodel="jm" 정체성이 겹쳐 Duplicate_judge가 먼저 발동하므로,
-     max_tool_calls 검사에 도달하려면 정체성 충돌이 없어야 한다. judges는 of_preset 레벨에서
-     최소 개수 요구가 없다(JOJ <2 에러는 orchestrator 런타임 책임). *)
-  match Fusion_policy.Validated_preset.of_preset (mk_preset ~judges:[ over ] "jmtc") with
-  | Error (Fusion_policy.Validated_preset.Bad_max_tool_calls 17) -> ()
-  | _ -> Alcotest.fail "expected Bad_max_tool_calls 17 for over-ceiling judge"
 
 let test_validated_judge_bad_max_output_tokens () =
   let bad = { base_judge with Fusion_policy.jmax_output_tokens = Some (-1) } in
@@ -1067,7 +1010,7 @@ let test_staged_judge_groups_bad_size () =
 (* --- JOJ 1차 심판 TOML 파싱 (RFC-0283). parse_judge_spec + finish_preset의
        [[...judges]] array-of-tables 리더를 end-to-end로 검증한다. 위 of_preset
        검증 테스트는 OCaml record를 직접 구성해 config 레이어를 우회하므로, TOML 키
-       이름(model/label/system_prompt/web_tools/max_tool_calls/timeout_s)과 getter
+       이름(model/label/system_prompt/web_tools/timeout_s)과 getter
        매핑은 이 테스트만 커버한다 — 잘못된 키/getter는 여기서만 잡힌다. panel
        sub-table에는 동형 golden(test_config_panels_golden 등)이 있으나 judge에는
        없었다. --- *)
@@ -1087,7 +1030,6 @@ model = "judge-a"
 label = "strict"
 system_prompt = "lens A"
 web_tools = true
-max_tool_calls = 3
 max_output_tokens = 1536
 timeout_s = 222.0
 [[fusion.presets.joj.judges]]
@@ -1108,15 +1050,13 @@ let test_config_judges_parse () =
           Alcotest.(check string) "ja label" "strict" ja.Fusion_policy.jlabel;
           Alcotest.(check string) "ja prompt" "lens A" ja.Fusion_policy.jsystem_prompt;
           Alcotest.(check bool) "ja web" true ja.Fusion_policy.jweb_tools;
-          Alcotest.(check int) "ja tool budget" 3 ja.Fusion_policy.jmax_tool_calls;
           Alcotest.(check (option int)) "ja max output" (Some 1536)
             ja.Fusion_policy.jmax_output_tokens;
           Alcotest.(check (float 0.001)) "ja timeout" 222.0 ja.Fusion_policy.jtimeout_s;
-          (* judge-b: 누락 키는 find_or default 경로 (web=false / budget=0 / timeout=default). *)
+          (* judge-b: 누락 키는 find_or default 경로 (web=false / timeout=default). *)
           Alcotest.(check string) "jb model" "judge-b" jb.Fusion_policy.jmodel;
           Alcotest.(check string) "jb prompt" "lens B" jb.Fusion_policy.jsystem_prompt;
           Alcotest.(check bool) "jb web default" false jb.Fusion_policy.jweb_tools;
-          Alcotest.(check int) "jb budget default" 0 jb.Fusion_policy.jmax_tool_calls;
           Alcotest.(check (option int)) "jb max output default" None
             jb.Fusion_policy.jmax_output_tokens;
           Alcotest.(check (float 0.001)) "jb timeout default"
@@ -1149,7 +1089,6 @@ let g_web4 : Fusion_policy.panel_group =
   ; label = ""
   ; system_prompt = "p"
   ; web_tools = true
-  ; max_tool_calls = 4
   ; max_output_tokens = None
   ; timeout_s = 123.0
   }
@@ -1165,20 +1104,12 @@ let test_judge_args_single_group_identity () =
        [ { g_web4 with Fusion_policy.web_tools = false } ]);
   Alcotest.(check bool) "judge web = req||group, req=true overrides" true
     (Fusion_policy.judge_web_tools_of ~req_web_tools:true
-       [ { g_web4 with Fusion_policy.web_tools = false } ]);
-  Alcotest.(check int) "judge tool budget = sole group" 4
-    (Fusion_policy.judge_tool_budget_of groups)
+       [ { g_web4 with Fusion_policy.web_tools = false } ])
 
 let test_judge_args_multi_group () =
-  let g_unlimited = { g_web4 with Fusion_policy.models = [ "x" ]; max_tool_calls = 0 } in
   let g_slow = { g_web4 with Fusion_policy.models = [ "y" ]; timeout_s = 200.0 } in
   Alcotest.(check (float 0.001)) "outer timeout = max over groups (single wave)" 200.0
-    (Fusion_policy.panel_outer_timeout_of ~max_fibers:2 [ g_web4; g_slow ]);
-  Alcotest.(check int) "judge tool budget: 0 (unlimited) absorbs" 0
-    (Fusion_policy.judge_tool_budget_of [ g_web4; g_unlimited ]);
-  Alcotest.(check int) "judge tool budget: max when none unlimited" 4
-    (Fusion_policy.judge_tool_budget_of
-       [ { g_web4 with Fusion_policy.models = [ "z" ]; max_tool_calls = 2 }; g_web4 ])
+    (Fusion_policy.panel_outer_timeout_of ~max_fibers:2 [ g_web4; g_slow ])
 
 (* --- outer timeout wave math: ceil(총원/max_fibers) 웨이브 × max timeout.
        2026-07-01 사고 회귀 가드: 라이브 config(3패널, max_concurrent_panels=2,
@@ -1785,8 +1716,6 @@ let () =
             test_shipped_runtime_council_is_staged_eligible
         ; Alcotest.test_case "two_judges_not_staged_eligible" `Quick
             test_config_two_judges_not_staged_eligible
-        ; Alcotest.test_case "invalid_max_tool_calls" `Quick
-            test_config_invalid_max_tool_calls
         ; Alcotest.test_case "invalid_max_output_tokens" `Quick
             test_config_invalid_max_output_tokens
         ; Alcotest.test_case "empty_default_preset" `Quick test_config_empty_default_preset
@@ -1809,15 +1738,12 @@ let () =
         ; Alcotest.test_case "missing_prompt" `Quick test_validated_missing_prompt
         ; Alcotest.test_case "missing_judge" `Quick test_validated_missing_judge
         ; Alcotest.test_case "duplicate_panelist" `Quick test_validated_duplicate_panelist
-        ; Alcotest.test_case "bad_max_tool_calls" `Quick test_validated_bad_max_tool_calls
         ; Alcotest.test_case "bad_max_output_tokens" `Quick
             test_validated_bad_max_output_tokens
         ; Alcotest.test_case "judges_empty_ok" `Quick test_validated_judges_empty_ok
         ; Alcotest.test_case "judges_ok" `Quick test_validated_judges_ok
         ; Alcotest.test_case "judge_prompt_missing" `Quick test_validated_judge_prompt_missing
         ; Alcotest.test_case "duplicate_judge" `Quick test_validated_duplicate_judge
-        ; Alcotest.test_case "judge_bad_max_tool_calls" `Quick
-            test_validated_judge_bad_max_tool_calls
         ; Alcotest.test_case "judge_bad_max_output_tokens" `Quick
             test_validated_judge_bad_max_output_tokens
         ; Alcotest.test_case "bad_meta_timeout" `Quick test_validated_bad_meta_timeout

--- a/test/test_fusion_adaptive_timeout.ml
+++ b/test/test_fusion_adaptive_timeout.ml
@@ -24,7 +24,6 @@ let sample_judge model : Fusion_policy.judge_spec =
   ; jlabel = ""
   ; jsystem_prompt = "judge"
   ; jweb_tools = false
-  ; jmax_tool_calls = 0
   ; jmax_output_tokens = None
   ; jtimeout_s = 1.0
   ; jmax_timeout_s = None

--- a/test/test_fusion_wake.ml
+++ b/test/test_fusion_wake.ml
@@ -185,7 +185,6 @@ let fusion_tool_policy () : Fusion_policy.t =
     ; label = "panel"
     ; system_prompt = "panel system prompt"
     ; web_tools = false
-    ; max_tool_calls = 0
     ; max_output_tokens = None
     ; timeout_s = Fusion_policy.default_timeout_s
     }


### PR DESCRIPTION
## What changed

- Deleted Fusion `max_tool_calls` / `jmax_tool_calls` fields from immutable panel and judge policy records.
- Deleted the TOML parser, validation errors, ceiling, judge-budget derivation, JSON/dashboard projection, and checked-in runtime values for that contract.
- Deleted tests whose purpose was to preserve the removed restriction, while retaining panel identity, prompt, model, timeout, and output-shape coverage.

## Why

The parent PR proves the value was never applied by the OAS builder. Keeping a parsed and validated no-op limit created a false product promise and a future path back to turn governance. Fusion membership and tool behavior should come from typed Keeper/LLM composition; actual usage remains observable.

This is stack 2 of #24579 and is based on #24584. No legacy parser or dashboard compatibility projection is retained.

## Product impact

- Existing panel, Judge, Judge-of-Judges, web-tool, async completion, and result-observation paths remain.
- Old `max_tool_calls_per_panel` TOML entries become irrelevant because the key and its display surface are deliberately removed.
- The remaining `max_tool_calls` name belongs only to the isolated tool-quality benchmark scoring schema, not Keeper/Fusion execution.

## Validation

- `ocamlformat --check` for every touched OCaml file
- `ocamlc -stop-after parsing` for every touched OCaml implementation/interface
- `npx tsc --noEmit --pretty`
- `npx vitest run src/lib/fusion-preset-view.test.ts src/components/fusion-settings-panel.test.ts` — 27 passed
- `git diff --check`
- static search confirms the deleted Fusion contract is absent from production/config/dashboard/Fusion tests

Full Dune build is intentionally delegated to PR CI.
