### PR TITLE
fix(discord): durably accept before lane handoff

### DIFF
--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -343,8 +343,7 @@ let resolve_binding_for_message ~channel_id ~message_reference_channel_id =
                     },
                     [ ("discord.binding_reference_channel_id", reference_channel_id) ] ))
 
-let handle_message_create ?resolved_binding ~dispatch
-      ~clock
+let accept_message_create ~resolved_binding ~dispatch
       ~(channel_id : string) ~(message_id : string)
       ~(guild_id : string option)
       ~base_dir
@@ -355,19 +354,13 @@ let handle_message_create ?resolved_binding ~dispatch
       ~(message_reference_channel_id : string option)
       ~(message_reference_message_id : string option)
       ~(referenced_message_author_id : string option) =
-  let binding =
-    match resolved_binding with
-    | Some binding -> Some binding
-    | None ->
-      resolve_binding_for_message ~channel_id ~message_reference_channel_id
-  in
-  match binding with
+  match resolved_binding with
   | None ->
     (* No binding for this channel — drop quietly. The bot may be in
        channels it isn't bound to (e.g. server-wide guild messages). *)
     Discord_observability.record_inbound_dispatch
       Discord_observability.Dropped_unbound;
-    ()
+    None
   | Some (resolution, resolution_metadata) ->
     let keeper_name = resolution.State.keeper_name in
     let metadata =
@@ -422,16 +415,9 @@ let handle_message_create ?resolved_binding ~dispatch
       ; metadata
       }
     in
-    let stream_reply =
-      make_discord_stream_reply ~channel_id ~reply_to_message_id:message_id
-    in
-    let on_text_snapshot =
-      publish_discord_stream_snapshot stream_reply
-    in
-    (match
-       with_response_wait_typing_indicator ~clock ~channel_id (fun () ->
-         Channel_gate.handle_inbound_streaming ~dispatch ~on_text_snapshot msg)
-     with
+    let outcome = Channel_gate.handle_inbound ~dispatch msg in
+    Some (fun () ->
+     match outcome with
      | Error gate_err ->
        (match gate_err with
         | Channel_gate.Dispatch_unavailable ->
@@ -478,54 +464,36 @@ let handle_message_create ?resolved_binding ~dispatch
          Discord_observability.record_reply Discord_observability.Reply_empty
        end
        else
-         (match finish_discord_stream_reply stream_reply ~final_content:out.content with
-          | Stream_completed ->
-              (match attention_event_id with
-               | Some event_id ->
-                   mark_attention_resolved ~base_dir ~keeper_name ~event_id
-                     ~reason:"discord_reply_streamed"
-               | None -> ());
-              Discord_observability.record_inbound_dispatch
-                Discord_observability.Reply_sent;
-              Discord_observability.record_reply
-                Discord_observability.Reply_send_ok
-          | Stream_not_started | Stream_final_edit_failed _ ->
-              (match State.send_message ~channel_id ~content:out.content ~reply_to_message_id:message_id () with
-               | Ok _ ->
-                 (match attention_event_id with
-                  | Some event_id ->
-                      mark_attention_resolved ~base_dir ~keeper_name ~event_id
-                        ~reason:"discord_reply_sent"
-                  | None -> ());
-                 Discord_observability.record_inbound_dispatch
-                   Discord_observability.Reply_sent;
-                 Discord_observability.record_reply
-                   Discord_observability.Reply_send_ok
-               | Error e ->
-                 Discord_observability.record_inbound_dispatch
-                   Discord_observability.Reply_send_error;
-                 Discord_observability.record_reply
-                   Discord_observability.Reply_send_failed;
-                 Log.Server.error "discord send_message failed (channel=%s): %s"
-                   channel_id
-                   (Format.asprintf "%a" State.pp_send_error e))
-          | Stream_overflow_send_failed _ ->
-              (match attention_event_id with
-               | Some event_id ->
-                   mark_attention_resolved ~base_dir ~keeper_name ~event_id
-                     ~reason:"discord_reply_partial_overflow"
-               | None -> ());
-              Discord_observability.record_inbound_dispatch
-                Discord_observability.Reply_send_error;
-              Discord_observability.record_reply
-                Discord_observability.Reply_send_failed))
+         (match
+            State.send_message ~channel_id ~content:out.content
+              ~reply_to_message_id:message_id ()
+          with
+          | Ok _ ->
+            (match attention_event_id with
+             | Some event_id ->
+               mark_attention_resolved ~base_dir ~keeper_name ~event_id
+                 ~reason:"discord_reply_sent"
+             | None -> ());
+            Discord_observability.record_inbound_dispatch
+              Discord_observability.Reply_sent;
+            Discord_observability.record_reply
+              Discord_observability.Reply_send_ok
+          | Error e ->
+            Discord_observability.record_inbound_dispatch
+              Discord_observability.Reply_send_error;
+            Discord_observability.record_reply
+              Discord_observability.Reply_send_failed;
+            Log.Server.error "discord send_message failed (channel=%s): %s"
+              channel_id
+              (Format.asprintf "%a" State.pp_send_error e)))
 
-let on_event ?resolved_binding ~dispatch ~clock ~base_dir
+let accept_event ~resolved_binding ~dispatch ~base_dir
     (ev : Gw.gateway_event) =
   match ev with
   | Gw.Ready { bot_user_id; _ } ->
     State.record_ready ~bot_user_id;
-    Log.Server.info "Discord gateway READY (bot_user_id=%s)" bot_user_id
+    Log.Server.info "Discord gateway READY (bot_user_id=%s)" bot_user_id;
+    None
   | Gw.Message_create
       { channel_id
       ; message_id
@@ -542,7 +510,7 @@ let on_event ?resolved_binding ~dispatch ~clock ~base_dir
       } ->
     (* mentions_bot is already enforced by the trigger policy at the
        gateway-state layer; nothing extra to check here. *)
-    handle_message_create ?resolved_binding ~dispatch ~clock ~channel_id
+    accept_message_create ~resolved_binding ~dispatch ~channel_id
       ~message_id ~author_id
       ~guild_id ~base_dir ~author_name ~content ~mentions_bot ~explicit_mentions_bot
       ~message_reference_channel_id ~message_reference_message_id
@@ -551,33 +519,36 @@ let on_event ?resolved_binding ~dispatch ~clock ~base_dir
     (* The previous Python sidecar used a configurable emoji
        trigger to drain pending messages. That feature is dropped in
        the in-process gateway; re-add as a follow-up if needed. *)
-    ()
+    None
   | Gw.Thread_tracked { thread_id; parent_channel_id } ->
     State.register_thread ~thread_id ~parent_channel_id;
     Log.Server.info
       "Discord thread registered: %s -> parent %s (total=%d)"
       thread_id parent_channel_id
-      (State.registered_thread_count ())
+      (State.registered_thread_count ());
+    None
   | Gw.Threads_bulk_tracked { threads } ->
     List.iter (fun (tid, pid) -> State.register_thread ~thread_id:tid ~parent_channel_id:pid) threads;
     Log.Server.info
       "Discord guild threads bulk registered: %d threads (total=%d)"
       (List.length threads)
-      (State.registered_thread_count ())
+      (State.registered_thread_count ());
+    None
   | Gw.Thread_removed { thread_id } ->
     State.unregister_thread ~thread_id;
     Log.Server.info
       "Discord thread removed: %s (total=%d)"
       thread_id
-      (State.registered_thread_count ())
+      (State.registered_thread_count ());
+    None
   | Gw.Ignored _ ->
-    ()
+    None
 
 (* RFC-0226 ambient lane recording: a bound-channel message that failed
    the trigger policy is still conversation the keeper sits in. Persist
    a single user line — no dispatch, no turn. Unbound channels drop, as
    on the dispatch path. *)
-let handle_ambient ?resolved_keeper_name ~base_dir
+let handle_ambient ~resolved_keeper_name ~base_dir
       ~(channel_id : string) ~(guild_id : string option) ~(message_id : string)
       ~(author_id : string) ~(author_name : string option) ~(content : string) =
   let keeper_name =
@@ -713,11 +684,11 @@ let on_ambient ?resolved_keeper_name ~base_dir (ev : Gw.gateway_event) =
   | Gw.Message_create
       { channel_id; guild_id; message_id; author_id; author_name; content; _ }
     ->
-    handle_ambient ?resolved_keeper_name ~base_dir ~channel_id ~guild_id
+    handle_ambient ~resolved_keeper_name ~base_dir ~channel_id ~guild_id
       ~message_id ~author_id ~author_name ~content
   | Gw.Ready _ | Gw.Reaction_add _ | Gw.Thread_tracked _ | Gw.Threads_bulk_tracked _ | Gw.Thread_removed _ | Gw.Ignored _ -> ()
 
-let submit_triggered_event ingress ~dispatch ~clock ~base_dir
+let submit_triggered_event ?deliver ingress ~dispatch ~base_dir
     (ev : Gw.gateway_event) =
   match ev with
   | Gw.Message_create
@@ -725,26 +696,28 @@ let submit_triggered_event ingress ~dispatch ~clock ~base_dir
     (match
        resolve_binding_for_message ~channel_id ~message_reference_channel_id
      with
-     | None -> on_event ~dispatch ~clock ~base_dir ev
+     | None -> ignore (accept_event ~resolved_binding:None ~dispatch ~base_dir ev)
      | Some ((resolution, _) as resolved_binding) ->
-       Connector_ingress_lane.submit
-         ingress
-         ~lane:(Connector_ingress_lane.Keeper_lane resolution.State.keeper_name)
-         ~event_id:{ source = "discord_triggered"; opaque_id = message_id }
-         (fun () ->
-            on_event
-              ~resolved_binding
-              ~dispatch
-              ~clock
-              ~base_dir
-              ev))
+       (match accept_event ~resolved_binding ~dispatch ~base_dir ev with
+        | None -> ()
+        | Some accepted_delivery ->
+          Connector_ingress_lane.submit
+            ingress
+            ~lane:(Connector_ingress_lane.Keeper_lane resolution.State.keeper_name)
+            ~event_id:{ source = "discord_triggered"; opaque_id = message_id }
+            (Option.value deliver ~default:accepted_delivery)))
   | Gw.Ready _
   | Gw.Reaction_add _
   | Gw.Thread_tracked _
   | Gw.Threads_bulk_tracked _
   | Gw.Thread_removed _
-  | Gw.Ignored _ -> on_event ~dispatch ~clock ~base_dir ev
+  | Gw.Ignored _ ->
+    ignore (accept_event ~resolved_binding:None ~dispatch ~base_dir ev)
 ;;
+
+module For_testing = struct
+  let submit_triggered_event = submit_triggered_event
+end
 
 let submit_ambient_event ingress ~base_dir (ev : Gw.gateway_event) =
   match ev with
@@ -789,20 +762,8 @@ let start ~sw ~env ~clock ~state =
         ()
     in
     let dispatch_for_config config =
-      (* RFC-connector-deferred-reply-via-chat-queue: tag this dispatch as the Discord connector so a message that
-         arrives while the keeper is in flight is enqueued onto
-         [Keeper_chat_queue] (drained by the serial consumer, delivered back to
-         the channel via [Keeper_chat_discord.adapter_loop]) rather than the
-         outbound-less async poll store ([Keeper_msg_async]). *)
-      Gate_keeper_backend.dispatch_with_text_snapshot
-        ~connector_kind:Gate_keeper_backend.Discord
-        ~submission_owner:Gate_keeper_backend.Channel_actor
-        ~sw ~clock
-        ~proc_mgr:state.Mcp_server.proc_mgr
-        ~net:state.Mcp_server.net
-        ~publication_recovery_provider:
-          (Mcp_server.publication_recovery_availability_provider state)
-        ~config
+      Gate_keeper_backend.accept_connector
+        ~connector:Gate_keeper_backend.Discord_connector ~clock ~config
     in
     let policy_label = Discord_gateway_state.trigger_policy_to_string policy in
     Log.Server.info
@@ -820,7 +781,6 @@ let start ~sw ~env ~clock ~state =
             submit_triggered_event
               ingress
               ~dispatch:(dispatch_for_config config)
-              ~clock
               ~base_dir:config.base_path
               ev)
           ~on_ambient:(fun ev ->

--- a/lib/server/server_discord_in_process_gateway.mli
+++ b/lib/server/server_discord_in_process_gateway.mli
@@ -7,13 +7,10 @@
     1. Opens a WSS connection to Discord Gateway v10
        ({!Discord_gateway_client.run}).
     2. For each accepted [Message_create] event, looks up the
-       channel→keeper binding
-       ({!Channel_gate_discord_state.keeper_for_channel}), runs the
-       keeper turn through {!Channel_gate.handle_inbound_streaming},
-       projects redacted text snapshots by posting/editing one Discord
-       reply, and falls back to
-       {!Channel_gate_discord_state.send_message} when streaming never
-       starts or fails.
+       channel→keeper binding and durably accepts the exact source event before
+       the WSS callback returns. Network ACK delivery then runs on the
+       Keeper-scoped connector lane; the durable chat-queue consumer owns the
+       eventual Keeper turn and connector reply.
 
     Always-on by design: there is no [MASC_DISCORD_BUILTIN]-style
     toggle. The legacy Python sidecar is gone — there is no
@@ -35,6 +32,16 @@ val parse_trigger_policy : string -> Discord_gateway_client.trigger_policy
     to parse is logged via [Log.Server] and falls back to the default,
     rather than being silently coerced. Exposed for unit testing the
     config boundary. *)
+
+module For_testing : sig
+  val submit_triggered_event :
+    ?deliver:(unit -> unit) ->
+    Connector_ingress_lane.t ->
+    dispatch:Channel_gate.dispatch_fn ->
+    base_dir:string ->
+    Discord_gateway_client.gateway_event ->
+    unit
+end
 
 val start :
   sw:Eio.Switch.t ->

--- a/test/test_server_discord_trigger_policy.ml
+++ b/test/test_server_discord_trigger_policy.ml
@@ -12,6 +12,42 @@
 
 open Alcotest
 module G = Server_discord_in_process_gateway
+module State = Channel_gate_discord_state
+
+external unsetenv : string -> unit = "masc_test_unsetenv"
+
+let with_env key value f =
+  let previous = Sys.getenv_opt key in
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some previous -> Unix.putenv key previous
+      | None -> unsetenv key)
+    (fun () ->
+      Unix.putenv key value;
+      f ())
+;;
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path
+    end
+    else Sys.remove path
+;;
+
+let with_temp_dir f =
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-discord-preworker-%d-%d" (Unix.getpid ())
+         (Random.bits ()))
+  in
+  Unix.mkdir dir 0o700;
+  Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
+;;
 
 let ps p = Discord_gateway_state.trigger_policy_to_string p
 let default_str = ps G.default_trigger_policy
@@ -49,6 +85,78 @@ let test_user_only_empty_id_falls_back () =
   check string "user_only: empty id => default" default_str
     (ps (G.parse_trigger_policy "user_only:"))
 
+let discord_message ~message_id =
+  Discord_gateway_client.Message_create
+    { channel_id = "C123"
+    ; guild_id = Some "G123"
+    ; message_id
+    ; author_id = "U123"
+    ; author_name = Some "operator"
+    ; content = "wake the keeper"
+    ; raw_content = "wake the keeper"
+    ; resolved_mentions = []
+    ; mention_user_ids = []
+    ; mentions_bot = true
+    ; explicit_mentions_bot = true
+    ; author_is_bot = false
+    ; message_reference_channel_id = None
+    ; message_reference_message_id = None
+    ; referenced_message_author_id = None
+    }
+;;
+
+let test_durable_accept_precedes_delivery_handoff () =
+  with_temp_dir @@ fun base_dir ->
+  with_env "MASC_DISCORD_BINDING_STORE_PATH"
+    (Filename.concat base_dir "bindings.json")
+  @@ fun () ->
+  with_env "MASC_DISCORD_BINDING_AUDIT_PATH"
+    (Filename.concat base_dir "audit.jsonl")
+  @@ fun () ->
+  with_env "MASC_DISCORD_NAMES_PATH" (Filename.concat base_dir "names.json")
+  @@ fun () ->
+  (match State.bind ~channel_id:"C123" ~keeper_name:"luna" ~actor_name:"test" with
+   | Error detail -> fail detail
+   | Ok _ -> ());
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun sw ->
+  let observed, resolve_observed = Eio.Promise.create () in
+  let ingress =
+    Connector_ingress_lane.create ~sw
+      ~on_failure:(fun failure -> Eio.Promise.resolve resolve_observed failure)
+      ()
+  in
+  let accepted_before_delivery = ref false in
+  let dispatch ~channel:_ ~channel_user_id:_ ~channel_user_name:_
+      ~channel_workspace_id:_ ~keeper_name:_ ~idempotency_key:_ ~metadata:_
+      ~content:_ =
+    accepted_before_delivery := true;
+    Gate_protocol.Reply
+      { content = "queued"
+      ; structured = None
+      ; stats = None
+      ; message_request = None
+      }
+  in
+  G.For_testing.submit_triggered_event
+    ~deliver:(fun () ->
+      if not !accepted_before_delivery then
+        failwith "delivery ran before durable accept";
+      failwith "observe Discord ingress identity")
+    ingress ~dispatch ~base_dir
+    (discord_message ~message_id:"discord-exact-123");
+  check bool "accept completed before handoff" true !accepted_before_delivery;
+  let failure = Eio.Promise.await observed in
+  check string "exact Discord message id" "discord-exact-123"
+    failure.Connector_ingress_lane.event_id.opaque_id;
+  check string "typed source" "discord_triggered" failure.event_id.source;
+  match failure.lane with
+  | Connector_ingress_lane.Keeper_lane keeper_name ->
+    check string "resolved Keeper lane" "luna" keeper_name
+  | Connector_ingress_lane.Connector_lane connector_id ->
+    failf "expected Keeper lane, got connector:%s" connector_id
+;;
+
 let () =
   run "server_discord_trigger_policy"
     [ ( "parse_trigger_policy"
@@ -60,5 +168,9 @@ let () =
             test_unknown_falls_back_to_default
         ; test_case "user_only empty id => default" `Quick
             test_user_only_empty_id_falls_back
+        ] )
+    ; ( "ingress handoff"
+      , [ test_case "durable accept precedes Discord delivery" `Quick
+            test_durable_accept_precedes_delivery_handoff
         ] )
     ]


### PR DESCRIPTION
## Outcome

Discord Gateway now completes the typed durable connector accept before its WSS callback hands anything to process memory. The per-Keeper connector lane carries only the network ACK projection; Keeper work already lives in Keeper_chat_queue.

## Boundary

- resolve the typed channel-to-Keeper binding synchronously
- preserve the producer Discord message id as the connector event identity
- call Gate_keeper_backend.accept_connector before Connector_ingress_lane.submit
- keep ACK delivery failures isolated and observable by exact Keeper lane/event
- replace optional binding ambiguity with an explicit resolved-binding option contract
- stop routing triggered connector work through the direct streaming/full-turn adapter

This PR does not move Gate effect provenance into connector code. Process-local Channel_gate dedup, the legacy Discord binding fallback, and now-unused direct streaming helpers remain explicit follow-up cleanup.

## Evidence

- focused test asserts accept completes before delivery handoff
- focused test preserves exact Discord message id and resolved Keeper lane on delivery failure
- ocamlformat check: pass
- OCaml parser check for all three touched files: pass
- git diff --check: pass
- full Dune build/tests: delegated to PR CI per repository policy

Changed lines: +187/-108 (295 total).

Stacked on #24582, which is stacked on #24577. The stack-owned #24577 Result.map type error and #24582 Slack event-constructor error were corrected at their originating commits before this child was rebased. Existing unrelated main failures are intentionally not mixed into this PR.