### PR TITLE
test(keeper): restore lost compaction-recovery regression (rescue #24490)

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -2479,6 +2479,8 @@
 
 (include stanzas/test_keeper_meta_json_config_toml_only.inc)
 
+(include stanzas/test_keeper_compact_recovery_tool_surface.inc)
+
 (test
  (name test_keeper_visible_path_projection)
  (modules test_keeper_visible_path_projection)

--- a/test/stanzas/test_keeper_compact_recovery_tool_surface.inc
+++ b/test/stanzas/test_keeper_compact_recovery_tool_surface.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_compact_recovery_tool_surface)
+ (modules test_keeper_compact_recovery_tool_surface)
+ (libraries masc_test_deps))

--- a/test/test_keeper_compact_recovery_tool_surface.ml
+++ b/test/test_keeper_compact_recovery_tool_surface.ml
@@ -1,0 +1,85 @@
+open Alcotest
+open Masc
+
+let () =
+  Server_startup_state.mark_state_ready
+    ~backend:Server_startup_state.Filesystem_backend
+  |> Result.get_ok
+
+let make_meta name =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+        [ "name", `String name
+        ; "agent_name", `String (name ^ "-agent")
+        ; "trace_id", `String (name ^ "-trace")
+        ; "allowed_paths", `List [ `String "*" ]
+        ])
+  with
+  | Ok meta -> meta
+  | Error detail -> failf "meta fixture failed: %s" detail
+
+let persisted_meta_exn config name =
+  match Keeper_meta_store.read_meta config name with
+  | Ok (Some meta) -> meta
+  | Ok None -> fail "persisted keeper meta is missing"
+  | Error detail -> failf "persisted keeper meta read failed: %s" detail
+
+let test_missing_checkpoint_is_typed_tool_failure () =
+  Eio_main.run @@ fun env ->
+  Masc_test_deps.ensure_rng_initialized ();
+  Masc_test_deps.init_eio_clock env;
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio.Switch.run @@ fun sw ->
+  let base_path = Masc_test_deps.setup_test_workspace () in
+  let keeper_name = "compact-missing-checkpoint" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_registry.unregister ~base_path keeper_name;
+      Masc_test_deps.cleanup_test_workspace base_path)
+    (fun () ->
+      let config = Workspace.default_config base_path in
+      ignore (Workspace.init config ~agent_name:(Some "operator"));
+      let meta = make_meta keeper_name in
+      (match Keeper_meta_store.write_meta config meta with
+       | Ok () -> ()
+       | Error detail -> failf "keeper meta write failed: %s" detail);
+      let persisted_meta = persisted_meta_exn config keeper_name in
+      ignore
+        (Keeper_registry.register
+           ~base_path:config.base_path
+           keeper_name
+           persisted_meta);
+      let ctx : _ Keeper_tool_surface.context =
+        { config
+        ; agent_name = "operator"
+        ; sw
+        ; clock = Eio.Stdenv.clock env
+        ; proc_mgr = None
+        ; net = None
+        }
+      in
+      match
+        Keeper_tool_surface.dispatch
+          ctx
+          ~name:"masc_keeper_compact"
+          ~args:(`Assoc [ "name", `String keeper_name ])
+      with
+      | None -> fail "masc_keeper_compact is not registered"
+      | Some (Ok _) -> fail "missing checkpoint must not report success"
+      | Some (Error failure) ->
+        check string "tool identity" "masc_keeper_compact" failure.tool_name;
+        check string "typed recovery error" "checkpoint_not_found"
+          Yojson.Safe.Util.(failure.data |> member "compaction_error" |> to_string);
+        check bool "checkpoint was not applied" false
+          Yojson.Safe.Util.(failure.data |> member "checkpoint_applied" |> to_bool))
+
+let () =
+  run "keeper_compact_recovery_tool_surface"
+    [ ( "recovery_failure"
+      , [ test_case
+            "missing checkpoint is a typed tool failure"
+            `Quick
+            test_missing_checkpoint_is_typed_tool_failure
+        ] )
+    ]


### PR DESCRIPTION
## 목적
PR #24490이 stacked base로 머지되어 **전용 회귀 테스트만 main에 유실**됨(프로덕션은 재착지). 그 테스트를 복원.

## 유실 확인
`git cat-file -e origin/main:test/test_keeper_compact_recovery_tool_surface.ml` → **missing**. 프로덕션 `compaction_recovery_error_data`는 `keeper_tool_surface.ml:82-120`에 존재.

## 변경 (test-only)
- `test/test_keeper_compact_recovery_tool_surface.ml` (85줄, #24490 tree에서 복원)
- `test/stanzas/...inc` + `test/dune` include

## 호환성
테스트 assertion(`compaction_error`/`checkpoint_applied`, tool=`masc_keeper_compact`)이 main 현재 출력과 일치 확인. 안정 하네스 심볼만 사용.

## Done
- test-only, RFC-gated 밖. **owner dune 빌드로 green 확인 후 Ready.** Draft 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)