### PR TITLE
fix(build): repair storm-merged compile errors on main

### DIFF
--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -472,7 +472,8 @@ let iter_all_result t f =
     try
       match (Unix.stat t.base_dir).st_kind with
       | Unix.S_DIR -> Ok true
-      | _ -> Error ("dated JSONL base path is not a directory: " ^ t.base_dir)
+      | Unix.S_REG | Unix.S_CHR | Unix.S_BLK | Unix.S_LNK | Unix.S_FIFO | Unix.S_SOCK ->
+        Error ("dated JSONL base path is not a directory: " ^ t.base_dir)
     with
     | Unix.Unix_error (Unix.ENOENT, _, _) -> Ok false
     | Unix.Unix_error (error, _, _) ->

--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -388,7 +388,7 @@ let load_canonical_strict path =
     (match Agent_sdk.Checkpoint.of_string content with
      | Ok checkpoint -> Ok (Some checkpoint)
      | Error error -> Error (classify_sdk_error error))
-  | exception Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
   | exception exn -> Error (Io_error (Printexc.to_string exn))
 
 let save_oas_classified_typed

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -569,7 +569,7 @@ let event_queue_reaction_evidence_with_iter ~keeper_name ~stimulus_id iter =
        | Some _
        | None -> ())
     | Some _
-    | None -> ());
+    | None -> ()) in
   iteration,
   { keeper_name
   ; stimulus_id

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -354,7 +354,7 @@ let handle_message_create ?resolved_binding ~dispatch
       ~(explicit_mentions_bot : bool)
       ~(message_reference_channel_id : string option)
       ~(message_reference_message_id : string option)
-      ~(referenced_message_author_id : string option) =
+      ~(referenced_message_author_id : string option) () =
   let binding =
     match resolved_binding with
     | Some binding -> Some binding
@@ -546,7 +546,7 @@ let on_event ?resolved_binding ~dispatch ~clock ~base_dir
       ~message_id ~author_id
       ~guild_id ~base_dir ~author_name ~content ~mentions_bot ~explicit_mentions_bot
       ~message_reference_channel_id ~message_reference_message_id
-      ~referenced_message_author_id
+      ~referenced_message_author_id ()
   | Gw.Reaction_add _ ->
     (* The previous Python sidecar used a configurable emoji
        trigger to drain pending messages. That feature is dropped in
@@ -579,7 +579,7 @@ let on_event ?resolved_binding ~dispatch ~clock ~base_dir
    on the dispatch path. *)
 let handle_ambient ?resolved_keeper_name ~base_dir
       ~(channel_id : string) ~(guild_id : string option) ~(message_id : string)
-      ~(author_id : string) ~(author_name : string option) ~(content : string) =
+      ~(author_id : string) ~(author_name : string option) ~(content : string) () =
   let keeper_name =
     match resolved_keeper_name with
     | Some keeper_name -> Some keeper_name
@@ -714,7 +714,7 @@ let on_ambient ?resolved_keeper_name ~base_dir (ev : Gw.gateway_event) =
       { channel_id; guild_id; message_id; author_id; author_name; content; _ }
     ->
     handle_ambient ?resolved_keeper_name ~base_dir ~channel_id ~guild_id
-      ~message_id ~author_id ~author_name ~content
+      ~message_id ~author_id ~author_name ~content ()
   | Gw.Ready _ | Gw.Reaction_add _ | Gw.Thread_tracked _ | Gw.Threads_bulk_tracked _ | Gw.Thread_removed _ | Gw.Ignored _ -> ()
 
 let submit_triggered_event ingress ~dispatch ~clock ~base_dir

--- a/lib/server/server_slack_in_process_gateway.ml
+++ b/lib/server/server_slack_in_process_gateway.ml
@@ -266,7 +266,7 @@ let finish_slack_stream_reply ~clock state ~final_content =
 (* ---------------------------------------------------------------- *)
 
 let handle_inbound ?resolved_binding ~dispatch ~clock ~channel_id ~thread_ts
-    ~user_id ~user_name ~text ~ts ~mentions_bot ~is_app_mention =
+    ~user_id ~user_name ~text ~ts ~mentions_bot ~is_app_mention () =
   let binding =
     match resolved_binding with
     | Some binding -> Some binding
@@ -408,13 +408,13 @@ let on_event ?resolved_binding ~dispatch ~clock (ev : Gw.slack_event) =
       Slack_observability.record_gateway_event
         ~route:Slack_observability.Triggered Slack_observability.Message_create;
       handle_inbound ?resolved_binding ~dispatch ~clock ~channel_id ~thread_ts
-        ~user_id ~user_name ~text ~ts ~mentions_bot ~is_app_mention:false)
+        ~user_id ~user_name ~text ~ts ~mentions_bot ~is_app_mention:false ())
   | Gw.App_mention { channel_id; thread_ts; user_id; text; ts } ->
     Slack_observability.record_gateway_event ~route:Slack_observability.Triggered
       Slack_observability.App_mention;
     handle_inbound ?resolved_binding ~dispatch ~clock ~channel_id ~thread_ts
       ~user_id
-      ~user_name:None ~text ~ts ~mentions_bot:true ~is_app_mention:true
+      ~user_name:None ~text ~ts ~mentions_bot:true ~is_app_mention:true ()
   | Gw.Reaction_added _ ->
     (* Ambient this pass: reactions are not turn-starters (RFC-0317). *)
     Slack_observability.record_gateway_event ~route:Slack_observability.Ambient

--- a/test/stanzas/test_discord_gateway_client.inc
+++ b/test/stanzas/test_discord_gateway_client.inc
@@ -2,4 +2,4 @@
 (test
  (name test_discord_gateway_client)
  (modules test_discord_gateway_client)
- (libraries alcotest yojson eio_main masc.gate))
+ (libraries alcotest yojson eio eio_main masc.gate))

--- a/test/test_server_slack_trigger_policy.ml
+++ b/test/test_server_slack_trigger_policy.ml
@@ -202,7 +202,7 @@ let test_startup_error_is_operator_visible () =
 ;;
 
 let slack_message ~ts =
-  Slack_socket_client.Message_create
+  Slack_gateway_state.Message_create
     { channel_id = "C123"
     ; thread_ts = None
     ; user_id = "U123"


### PR DESCRIPTION
## 문제

main HEAD(#24570)가 `dune build`에서 **8개 컴파일 에러**로 실패합니다. 근본 원인은 2026-07-15 20:22~20:25 사이 연속 머지된 PR들(`#24549` / `#24568` / `#24569`)이 **Build and Test CI suite 미트리거**(change-detection gap) 상태로 머지되어, red main이 HEAD에 도달한 것입니다.

로컬 `_build` 캐시가 아니라 실제 코드 결함임을 확인했습니다 — origin/main 기준 fresh worktree의 clean 빌드에서도 동일하게 재현되었습니다.

## 수정 (전부 컴파일 전용, 런타임 동작 불변)

| 파일 | 에러 | 근본 | 수정 |
|------|------|------|------|
| `keeper_reaction_ledger.ml:572` | Syntax error | `let iteration = iter (...)` 뒤 `in` 누락으로 바인딩 본문 미종료 | `);` → `) in` |
| `keeper_checkpoint_store.ml:391` | Exception patterns not allowed | `as` alias가 exception pattern 밖으로 파싱됨 | `(Cancelled _ as exn)` 괄호 |
| `dated_jsonl.ml:475` | warning 4 fragile-match | `\| _ ->` catch-all | `Unix.file_kind` 나머지 6개 명시 |
| discord/slack gateway | warning 16 unerasable-optional | optional 뒤 positional 없어 `?resolved_binding`/`?resolved_keeper_name` erase 불가 | 정의 3곳 + caller 4곳에 unit `()` |
| `test_server_slack_trigger_policy.ml:205` | Unbound `Message_create` | `slack_socket_client.mli`가 constructor를 opaque alias로 재노출 | `Slack_gateway_state.Message_create` |
| `test_discord_gateway_client.inc` | Unbound module Eio | `eio_main`은 있으나 `eio`(=`Eio` 모듈) 누락 | `eio` 의존 추가 |

## 검증

- `dune build --root .` green (0 errors), origin/main #24570 기준
- 변경한 test 2개(`test_server_slack_trigger_policy`, `test_discord_gateway_client`) 로컬 실행 확인

## 참고

증상(컴파일 에러) 수정입니다. **근본은 red main을 통과시킨 CI change-detection gap**(`feedback-ci-ocaml-build-not-triggered`)이며, 이는 별도 트랙에서 다뤄야 합니다.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
