### PR TITLE
fix(build): restore main compilation after red-merge stack (#24586)

### DIFF
--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -472,7 +472,9 @@ let iter_all_result t f =
     try
       match (Unix.stat t.base_dir).st_kind with
       | Unix.S_DIR -> Ok true
-      | _ -> Error ("dated JSONL base path is not a directory: " ^ t.base_dir)
+      | Unix.S_REG | Unix.S_CHR | Unix.S_BLK | Unix.S_LNK | Unix.S_FIFO
+      | Unix.S_SOCK ->
+        Error ("dated JSONL base path is not a directory: " ^ t.base_dir)
     with
     | Unix.Unix_error (Unix.ENOENT, _, _) -> Ok false
     | Unix.Unix_error (error, _, _) ->

--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -388,7 +388,7 @@ let load_canonical_strict path =
     (match Agent_sdk.Checkpoint.of_string content with
      | Ok checkpoint -> Ok (Some checkpoint)
      | Error error -> Error (classify_sdk_error error))
-  | exception Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
   | exception exn -> Error (Io_error (Printexc.to_string exn))
 
 let save_oas_classified_typed

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -569,7 +569,8 @@ let event_queue_reaction_evidence_with_iter ~keeper_name ~stimulus_id iter =
        | Some _
        | None -> ())
     | Some _
-    | None -> ());
+    | None -> ())
+  in
   iteration,
   { keeper_name
   ; stimulus_id

--- a/lib/keeper/keeper_shutdown_store.ml
+++ b/lib/keeper/keeper_shutdown_store.ml
@@ -988,7 +988,8 @@ let prepare_operator_metadata_supersession
   | Ok operation -> Error (Supersession_phase_mismatch operation)
 ;;
 
-let supersession_token_operation_id token = token.operation_id
+let supersession_token_operation_id (token : operator_metadata_supersession_token) =
+  token.operation_id
 
 let supersede_blocked_operator_stop ~config ~token ~now =
   let config_base_path =

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -354,7 +354,7 @@ let handle_message_create ?resolved_binding ~dispatch
       ~(explicit_mentions_bot : bool)
       ~(message_reference_channel_id : string option)
       ~(message_reference_message_id : string option)
-      ~(referenced_message_author_id : string option) =
+      ~(referenced_message_author_id : string option) () =
   let binding =
     match resolved_binding with
     | Some binding -> Some binding
@@ -546,7 +546,7 @@ let on_event ?resolved_binding ~dispatch ~clock ~base_dir
       ~message_id ~author_id
       ~guild_id ~base_dir ~author_name ~content ~mentions_bot ~explicit_mentions_bot
       ~message_reference_channel_id ~message_reference_message_id
-      ~referenced_message_author_id
+      ~referenced_message_author_id ()
   | Gw.Reaction_add _ ->
     (* The previous Python sidecar used a configurable emoji
        trigger to drain pending messages. That feature is dropped in
@@ -579,7 +579,7 @@ let on_event ?resolved_binding ~dispatch ~clock ~base_dir
    on the dispatch path. *)
 let handle_ambient ?resolved_keeper_name ~base_dir
       ~(channel_id : string) ~(guild_id : string option) ~(message_id : string)
-      ~(author_id : string) ~(author_name : string option) ~(content : string) =
+      ~(author_id : string) ~(author_name : string option) ~(content : string) () =
   let keeper_name =
     match resolved_keeper_name with
     | Some keeper_name -> Some keeper_name
@@ -714,7 +714,7 @@ let on_ambient ?resolved_keeper_name ~base_dir (ev : Gw.gateway_event) =
       { channel_id; guild_id; message_id; author_id; author_name; content; _ }
     ->
     handle_ambient ?resolved_keeper_name ~base_dir ~channel_id ~guild_id
-      ~message_id ~author_id ~author_name ~content
+      ~message_id ~author_id ~author_name ~content ()
   | Gw.Ready _ | Gw.Reaction_add _ | Gw.Thread_tracked _ | Gw.Threads_bulk_tracked _ | Gw.Thread_removed _ | Gw.Ignored _ -> ()
 
 let submit_triggered_event ingress ~dispatch ~clock ~base_dir

--- a/lib/server/server_slack_in_process_gateway.ml
+++ b/lib/server/server_slack_in_process_gateway.ml
@@ -266,7 +266,7 @@ let finish_slack_stream_reply ~clock state ~final_content =
 (* ---------------------------------------------------------------- *)
 
 let handle_inbound ?resolved_binding ~dispatch ~clock ~channel_id ~thread_ts
-    ~user_id ~user_name ~text ~ts ~mentions_bot ~is_app_mention =
+    ~user_id ~user_name ~text ~ts ~mentions_bot ~is_app_mention () =
   let binding =
     match resolved_binding with
     | Some binding -> Some binding
@@ -408,13 +408,13 @@ let on_event ?resolved_binding ~dispatch ~clock (ev : Gw.slack_event) =
       Slack_observability.record_gateway_event
         ~route:Slack_observability.Triggered Slack_observability.Message_create;
       handle_inbound ?resolved_binding ~dispatch ~clock ~channel_id ~thread_ts
-        ~user_id ~user_name ~text ~ts ~mentions_bot ~is_app_mention:false)
+        ~user_id ~user_name ~text ~ts ~mentions_bot ~is_app_mention:false ())
   | Gw.App_mention { channel_id; thread_ts; user_id; text; ts } ->
     Slack_observability.record_gateway_event ~route:Slack_observability.Triggered
       Slack_observability.App_mention;
     handle_inbound ?resolved_binding ~dispatch ~clock ~channel_id ~thread_ts
       ~user_id
-      ~user_name:None ~text ~ts ~mentions_bot:true ~is_app_mention:true
+      ~user_name:None ~text ~ts ~mentions_bot:true ~is_app_mention:true ()
   | Gw.Reaction_added _ ->
     (* Ambient this pass: reactions are not turn-starters (RFC-0317). *)
     Slack_observability.record_gateway_event ~route:Slack_observability.Ambient

--- a/test/stanzas/test_discord_gateway_client.inc
+++ b/test/stanzas/test_discord_gateway_client.inc
@@ -2,4 +2,4 @@
 (test
  (name test_discord_gateway_client)
  (modules test_discord_gateway_client)
- (libraries alcotest yojson eio_main masc.gate))
+ (libraries alcotest yojson eio eio_main masc.gate))

--- a/test/test_server_slack_trigger_policy.ml
+++ b/test/test_server_slack_trigger_policy.ml
@@ -202,7 +202,7 @@ let test_startup_error_is_operator_visible () =
 ;;
 
 let slack_message ~ts =
-  Slack_socket_client.Message_create
+  Slack_gateway_state.Message_create
     { channel_id = "C123"
     ; thread_ts = None
     ; user_id = "U123"


### PR DESCRIPTION
## 목적

main 컴파일 복구 (#24586). 현재 **22개 open PR 전부가 이 red에 게이트**되어 있어 최우선 처리.

## 원인

최근 red-merge 적층: #24561(keeper checkpoint/ledger/dated_jsonl), #24568/#24569(discord/slack gateway), 그리고 shutdown_store record 필드 추론 충돌. 해당 커밋들의 main CI가 완료되기 전에 후속 머지가 쌓여 `6cc44b02d` 이후 Build/Canary/Lint/Health 전멸.

## 변경 (컴파일 전용 9건, 시맨틱 불변)

| 파일 | 수리 |
|---|---|
| `keeper_reaction_ledger.ml` | `let iteration = iter (...)` 뒤 누락된 `in` 추가 (585 `;;` syntax error의 뿌리) |
| `keeper_checkpoint_store.ml` | `exception (Eio.Cancel.Cancelled _ as exn)` 괄호 — alias가 exception 패턴 밖에 걸려 있었음 |
| `keeper_shutdown_store.ml` | `supersession_token_operation_id`에 타입 주석 — 동명 필드 `operation_id`가 나중 정의된 `corrupt_record`로 추론되어 mli 계약 파손 |
| gateway 2종 | `handle_inbound`/`handle_message_create`/`handle_ambient`에 후행 `()` — 선행 optional 인자 erasure 불가(warning 16) 해소, 내부 콜사이트 4곳 갱신 |
| `dated_jsonl.ml` | `Unix.file_kind` wildcard → 전수 나열 (warning 4) |
| `test/stanzas/test_discord_gateway_client.inc` | 직접 사용하는 `eio` dep 추가 (Unbound module Eio) |
| `test_server_slack_trigger_policy.ml` | `Message_create`가 `Slack_socket_client`→`Slack_gateway_state`로 이동한 것 추적 |

## 검증

- `dune build @check` **클린** (종전: 9건 에러)
- 터치한 테스트 2종 로컬 실행 결과는 코멘트로 추가 예정 (링크 중)
- CI 정본

## 재발 방지 노트

이 파손들은 전부 "머지 시점에 해당 커밋의 main CI가 in_progress"인 상태로 적층됐습니다. 프로세스 결함(required check 대기 없는 머지)은 별도 논의 필요 — 본 PR은 복구만.

Closes #24586

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
