### PR TITLE
refactor(fusion): remove inert quorum editor

### DIFF
--- a/dashboard/src/components/fusion-settings-panel.test.ts
+++ b/dashboard/src/components/fusion-settings-panel.test.ts
@@ -6,20 +6,15 @@ const SAMPLE = `[fusion]
 enabled = true
 default_preset = "trio"
 
-[fusion.gate]
-per_hour_budget = 20
-
 [fusion.presets.trio]
 panel = ["a", "b", "c"]
 judge = "j"
-min_answered = 2
 `
 
 const SAMPLE_WITH_DUO = `${SAMPLE}
 [fusion.presets.duo]
 panel = ["a", "b"]
 judge = "j"
-min_answered = 1
 `
 
 const SAMPLE_WITH_RUNTIME_OPTIONS = `${SAMPLE}
@@ -71,24 +66,6 @@ async function mount() {
 }
 
 describe('FusionSettingsPanel', () => {
-  it('loads live config and renders the editor with the current min_answered', async () => {
-    fetchMock.mockResolvedValue(cfg({ source_text: SAMPLE }))
-    await mount()
-    const minInput = q('[data-testid="fusion-min-answered"]') as HTMLInputElement
-    expect(minInput.value).toBe('2')
-  })
-
-  it('save posts the applied runtime.toml text (min_answered in the preset table)', async () => {
-    fetchMock.mockResolvedValue(cfg({ source_text: SAMPLE }))
-    saveMock.mockResolvedValue(cfg({ ok: true, reloaded: true }))
-    await mount()
-    ;(q('[data-testid="fusion-settings-save"]') as HTMLButtonElement).click()
-    await vi.waitFor(() => expect(saveMock).toHaveBeenCalledTimes(1))
-    const posted = saveMock.mock.calls[0]?.[0] as string
-    expect(posted.split('[fusion.presets.trio]')[1]).toContain('min_answered = 2')
-    expect(runtimeRefreshMock).toHaveBeenCalledTimes(1)
-  })
-
   it('edits the active flat preset panel runtimes and judge runtime', async () => {
     fetchMock.mockResolvedValue(cfg({ source_text: SAMPLE_WITH_RUNTIME_OPTIONS }))
     saveMock.mockImplementation(async (sourceText: string) => cfg({ ok: true, reloaded: true, source_text: sourceText }))
@@ -116,18 +93,18 @@ describe('FusionSettingsPanel', () => {
     saveMock.mockResolvedValue({
       ...cfg({ ok: false }),
       message: 'Runtime config validation failed',
-      reason: 'min_answered exceeds preset panel count',
-      issues: [{ key: 'fusion.presets.trio.min_answered', message: 'must be <= 2' }],
+      reason: 'default preset does not exist',
+      issues: [{ key: 'fusion.default_preset', message: 'unknown preset' }],
     })
     await mount()
     ;(q('[data-testid="fusion-settings-save"]') as HTMLButtonElement).click()
     await vi.waitFor(() => expect(q('[data-testid="fusion-settings-error"]')).not.toBeNull())
-    expect(q('[data-testid="fusion-settings-error"]')?.textContent).toContain('fusion.presets.trio.min_answered')
-    expect(q('[data-testid="fusion-settings-error"]')?.textContent).toContain('must be <= 2')
+    expect(q('[data-testid="fusion-settings-error"]')?.textContent).toContain('fusion.default_preset')
+    expect(q('[data-testid="fusion-settings-error"]')?.textContent).toContain('unknown preset')
     expect(q('[data-testid="fusion-settings-saved"]')).toBeNull()
   })
 
-  it('uses the selected preset existing min_answered when default_preset changes', async () => {
+  it('uses the selected preset composition when default_preset changes', async () => {
     fetchMock.mockResolvedValue(cfg({ source_text: SAMPLE_WITH_DUO }))
     saveMock.mockResolvedValue(cfg({
       ok: true,
@@ -136,18 +113,14 @@ describe('FusionSettingsPanel', () => {
     }))
     await mount()
     const presetInput = q('input[type="text"]') as HTMLInputElement
-    const minInput = q('[data-testid="fusion-min-answered"]') as HTMLInputElement
-    expect(minInput.value).toBe('2')
 
     presetInput.value = 'duo'
     await fireEvent.input(presetInput)
 
-    expect(minInput.value).toBe('1')
     ;(q('[data-testid="fusion-settings-save"]') as HTMLButtonElement).click()
     await vi.waitFor(() => expect(saveMock).toHaveBeenCalledTimes(1))
     const posted = saveMock.mock.calls[0]?.[0] as string
     expect(posted).toContain('default_preset = "duo"')
-    expect(posted.split('[fusion.presets.duo]')[1]).toContain('min_answered = 1')
   })
 
   it('does not claim reload when backend saved without reload', async () => {
@@ -220,14 +193,12 @@ default_preset = "ghost"
   })
 
   it('omits the preset card when the preset declares no panel models', async () => {
-    // A preset with only min_answered has no composition to display; the card is
-    // gated on panel models so the live writer stays lane-free for such configs.
+    // A preset with no panel models has no composition to display.
     const noPanel = `[fusion]
 enabled = true
 default_preset = "trio"
 
 [fusion.presets.trio]
-min_answered = 2
 `
     fetchMock.mockResolvedValue(cfg({ source_text: noPanel }))
     await mount()
@@ -244,7 +215,6 @@ enabled = true
 default_preset = "trio"
 
 [fusion.presets.trio]
-min_answered = 2
 `
     fetchMock.mockResolvedValue(cfg({ source_text: noPanel }))
     saveMock.mockImplementation(async (sourceText: string) => cfg({ ok: true, reloaded: true, source_text: sourceText }))
@@ -254,7 +224,6 @@ min_answered = 2
     await vi.waitFor(() => expect(saveMock).toHaveBeenCalledTimes(1))
     const posted = saveMock.mock.calls[0]?.[0] as string
     const trio = posted.split('[fusion.presets.trio]')[1] ?? ''
-    expect(trio).toContain('min_answered = 2')
     expect(trio).not.toContain('panel = []')
   })
 

--- a/dashboard/src/components/fusion-settings-panel.ts
+++ b/dashboard/src/components/fusion-settings-panel.ts
@@ -5,10 +5,7 @@
 // edits the [fusion] settings through
 // the pure fusion-settings helpers, and writes back via saveRuntimeTomlConfig
 // (POST /api/v1/runtime/config/raw → Runtime.save_config_text validates +
-// atomically persists + reloads). The backend is the validation SSOT: an
-// out-of-range min_answered is rejected on save and surfaced as an error here.
-// The panel also blocks malformed local form state before POST so invalid UI
-// input is not sent as a fabricated numeric value.
+// atomically persists + reloads). The backend is the validation SSOT.
 import { html } from 'htm/preact'
 import { useEffect, useRef, useState } from 'preact/hooks'
 import { fetchRuntimeTomlConfig, saveRuntimeTomlConfig } from '../api/dashboard'
@@ -16,7 +13,6 @@ import { errorToString } from '../lib/format-string'
 import {
   applyFusionPresetComposition,
   applyFusionSettings,
-  readFusionPresetMinAnswered,
   readFusionSettingsResult,
   type FusionSettings,
   type FusionSettingsParseIssue,
@@ -29,7 +25,6 @@ type EditorState = 'loading' | 'idle' | 'saving' | 'saved' | 'error'
 type FusionSettingsDraft = {
   readonly enabled: boolean
   readonly defaultPreset: string
-  readonly minAnswered: string
   readonly panel: readonly string[]
   readonly judge: string
 }
@@ -40,28 +35,17 @@ function draftFromSettings(sourceText: string, s: FusionSettings): FusionSetting
   return {
     enabled: s.enabled,
     defaultPreset: s.defaultPreset,
-    minAnswered: String(s.minAnswered),
     panel: flatPreset?.panel ?? [],
     judge: flatPreset?.judge ?? '',
   }
 }
 
-function parseDraftPositiveInt(label: string, raw: string): number | string {
-  const trimmed = raw.trim()
-  if (!/^\d+$/.test(trimmed)) return `${label}은 1 이상의 정수여야 합니다.`
-  const parsed = Number.parseInt(trimmed, 10)
-  return Number.isSafeInteger(parsed) && parsed >= 1 ? parsed : `${label}은 1 이상의 정수여야 합니다.`
-}
-
 function settingsFromDraft(draft: FusionSettingsDraft): FusionSettings | string {
   const defaultPreset = draft.defaultPreset
   if (defaultPreset !== '' && defaultPreset.trim() === '') return 'default_preset은 공백만 입력할 수 없습니다.'
-  const minAnswered = parseDraftPositiveInt('min_answered', draft.minAnswered)
-  if (typeof minAnswered === 'string') return minAnswered
   return {
     enabled: draft.enabled,
     defaultPreset,
-    minAnswered,
   }
 }
 
@@ -233,18 +217,10 @@ export function FusionSettingsPanel() {
   const patchDefaultPreset = (defaultPreset: string) => {
     const next: {
       defaultPreset: string
-      minAnswered?: string
       panel?: readonly string[]
       judge?: string
     } = { defaultPreset }
     if (source !== null) {
-      const minAnswered = readFusionPresetMinAnswered(source, defaultPreset)
-      if (typeof minAnswered === 'number') {
-        next.minAnswered = String(minAnswered)
-      } else {
-        setError(parseIssueMessage([minAnswered]))
-        setState('error')
-      }
       const nextPresetView = readFusionPresetView(source, defaultPreset)
       if (nextPresetView !== null && !nextPresetView.grouped) {
         next.panel = nextPresetView.panel
@@ -344,11 +320,6 @@ export function FusionSettingsPanel() {
       <label class="set-line">
         <span>기본 프리셋 (default_preset)</span>
         <input type="text" value=${draft.defaultPreset} onInput=${(e: Event) => patchDefaultPreset(str(e))} />
-      </label>
-      <label class="set-line">
-        <span>최소 응답 패널 (${draft.defaultPreset || '프리셋'} min_answered)</span>
-        <input type="number" step="1" data-testid="fusion-min-answered" value=${draft.minAnswered}
-          onInput=${(e: Event) => patch({ minAnswered: str(e) })} />
       </label>
       <div class="set-line">
         <button type="button" data-testid="fusion-settings-save" onClick=${onSave} disabled=${state === 'saving'}>

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -1559,7 +1559,7 @@ describe('SettingsSurface', () => {
       ok: true,
       path: MOCK_RUNTIME_PATH,
       file_name: 'runtime.toml',
-      source_text: '[fusion]\nenabled = true\ndefault_preset = "trio"\n\n[fusion.presets.trio]\nmin_answered = 2\n',
+      source_text: '[fusion]\nenabled = true\ndefault_preset = "trio"\n\n[fusion.presets.trio]\n',
       reloaded: false,
     })
     render(html`<${SettingsSurface} />`, container)
@@ -1572,7 +1572,6 @@ describe('SettingsSurface', () => {
     expect(container.querySelector('[data-testid="fusion-readonly-no-writer"]')).toBeNull()
     expect(container.querySelector('.set-card-b')?.getAttribute('data-preview-locked')).toBe('false')
     expect(container.querySelectorAll('.set-fus-lane').length).toBe(0)
-    expect(container.textContent).not.toContain('per_hour_budget')
     expect(container.textContent).not.toContain('ollama_cloud.ollama-cloud-devstral-2-123b')
   })
 

--- a/dashboard/src/lib/fusion-settings.test.ts
+++ b/dashboard/src/lib/fusion-settings.test.ts
@@ -2,38 +2,29 @@ import { describe, it, expect } from 'vitest'
 import {
   readFusionSettings,
   readFusionSettingsResult,
-  readFusionPresetMinAnswered,
   applyFusionSettings,
   applyFusionPresetComposition,
   FUSION_SETTINGS_DEFAULTS,
 } from './fusion-settings'
 
-// SAMPLE still carries a [fusion.gate] per_hour_budget line: RFC-0277 removed the
-// key from the backend, so the editor must IGNORE it (never read/write it) while
-// leaving it untouched in the file. The preservation test below pins that.
 const SAMPLE = `# live runtime config
 [fusion]
 enabled = true
 default_preset = "trio"
 
-[fusion.gate]
-per_hour_budget = 20
-
 [fusion.presets.trio]
 panel = ["a", "b", "c"]
 judge = "j"
-min_answered = 2
 
 [runtime]
 default = "x.y"
 `
 
 describe('readFusionSettings', () => {
-  it('reads [fusion] + the default preset min_answered (per_hour_budget not surfaced)', () => {
+  it('reads the writable [fusion] scalars', () => {
     expect(readFusionSettings(SAMPLE)).toEqual({
       enabled: true,
       defaultPreset: 'trio',
-      minAnswered: 2,
     })
   })
 
@@ -71,17 +62,13 @@ default_preset = "rocket\\U0001F680"
     }
   })
 
-  it('parses single-quoted default_preset and rejects unknown preset sections only when enabled', () => {
+  it('parses single-quoted and opaque default_preset values', () => {
     const singleQuoted = SAMPLE.replace('default_preset = "trio"', "default_preset = 'trio'")
     expect(readFusionSettings(singleQuoted).defaultPreset).toBe('trio')
     expect(readFusionSettings('[fusion]\nenabled = false\ndefault_preset = \'tri#o\'\n').defaultPreset).toBe('tri#o')
 
     const unknownPreset = SAMPLE.replace('default_preset = "trio"', 'default_preset = "missing"')
-    const result = readFusionSettingsResult(unknownPreset)
-    expect(result.ok).toBe(false)
-    if (!result.ok) {
-      expect(result.issues[0]?.key).toBe('fusion.presets.missing.min_answered')
-    }
+    expect(readFusionSettings(unknownPreset).defaultPreset).toBe('missing')
 
     const disabledUnknownPreset = `[fusion]
 enabled = false
@@ -90,20 +77,7 @@ default_preset = "old"
     expect(readFusionSettings(disabledUnknownPreset)).toEqual({
       enabled: false,
       defaultPreset: 'old',
-      minAnswered: 1,
     })
-  })
-
-  it('reads min_answered for a specific preset without changing default_preset', () => {
-    const withDuo = `${SAMPLE}
-[fusion.presets.duo]
-panel = ["a", "b"]
-judge = "j"
-min_answered = 1
-`
-    expect(readFusionSettings(withDuo).defaultPreset).toBe('trio')
-    expect(readFusionPresetMinAnswered(withDuo, 'duo')).toBe(1)
-    expect(readFusionPresetMinAnswered(withDuo, 'missing')).toBe(1)
   })
 })
 
@@ -112,49 +86,11 @@ describe('applyFusionSettings', () => {
     const next = applyFusionSettings(SAMPLE, {
       enabled: false,
       defaultPreset: 'trio',
-      minAnswered: 3,
     })
     expect(readFusionSettings(next)).toEqual({
       enabled: false,
       defaultPreset: 'trio',
-      minAnswered: 3,
     })
-  })
-
-  it('writes min_answered into the default preset table, not [fusion]', () => {
-    const next = applyFusionSettings(SAMPLE, { ...readFusionSettings(SAMPLE), minAnswered: 3 })
-    expect(next).toContain('[fusion.presets.trio]')
-    expect(next.split('[fusion.presets.trio]')[1]).toContain('min_answered = 3')
-    expect(next.split('[fusion]')[1]?.split('[fusion.gate]')[0]).not.toContain('min_answered')
-  })
-
-  it('never touches the removed per_hour_budget key (RFC-0277)', () => {
-    const next = applyFusionSettings(SAMPLE, readFusionSettings(SAMPLE))
-    // unchanged verbatim — the editor neither reads nor writes it
-    expect(next).toContain('per_hour_budget = 20')
-  })
-
-  it('removes stale min_answered from the previous default preset on preset switch or clear', () => {
-    const withDuo = `${SAMPLE}
-[fusion.presets.duo]
-panel = ["a", "b"]
-judge = "j"
-min_answered = 1
-`
-    const switched = applyFusionSettings(withDuo, {
-      enabled: true,
-      defaultPreset: 'duo',
-      minAnswered: 1,
-    })
-    expect(switched.split('[fusion.presets.trio]')[1]?.split('[runtime]')[0]).not.toContain('min_answered')
-    expect(switched.split('[fusion.presets.duo]')[1]).toContain('min_answered = 1')
-
-    const cleared = applyFusionSettings(SAMPLE, {
-      enabled: true,
-      defaultPreset: '',
-      minAnswered: 1,
-    })
-    expect(cleared.split('[fusion.presets.trio]')[1]?.split('[runtime]')[0]).not.toContain('min_answered')
   })
 
   it('preserves comments and untouched sections/keys', () => {
@@ -175,7 +111,6 @@ min_answered = 1
     const trio = next.split('[fusion.presets.trio]')[1]?.split('[runtime]')[0] ?? ''
     expect(trio).toContain('panel = ["a", "b", "d"]')
     expect(trio).toContain('judge = "meta.judge"')
-    expect(trio).toContain('min_answered = 2')
   })
 
   it('refuses to flatten grouped panel presets', () => {

--- a/dashboard/src/lib/fusion-settings.ts
+++ b/dashboard/src/lib/fusion-settings.ts
@@ -4,13 +4,9 @@
 // TOML parser/writer (RFC-0273 §3.2 explicitly forbids a parallel writer;
 // comments and untouched keys survive). It only parses the scalar tokens it
 // owns after getRuntimeTomlKey has isolated them. The backend
-// `Runtime.save_config_text` remains the validation SSOT (e.g. min_answered
-// range), so this layer only transforms text; malformed existing values are
+// `Runtime.save_config_text` remains the validation SSOT, so this layer only
+// transforms text; malformed existing values are
 // surfaced as parse errors instead of being rendered as plausible defaults.
-//
-// per_hour_budget is intentionally NOT exposed: RFC-0277 §3 removed the fusion
-// activation budget ([fusion.gate].per_hour_budget) from the backend, so editing
-// it would be a zombie surface (the key is no longer consumed).
 //
 // Limitation: get/setRuntimeTomlKey are line-oriented over `key = value` lines
 // inside a `[section]` (dotted section names like `fusion.presets.trio` are
@@ -24,7 +20,6 @@ import { deleteRuntimeTomlKey, getRuntimeTomlKey, setRuntimeTomlKey, setRuntimeT
 const SECTION_FUSION = 'fusion'
 const KEY_ENABLED = 'enabled'
 const KEY_DEFAULT_PRESET = 'default_preset'
-const KEY_MIN_ANSWERED = 'min_answered'
 const KEY_PANEL = 'panel'
 const KEY_JUDGE = 'judge'
 const presetSection = (preset: string): string => `${SECTION_FUSION}.presets.${preset}`
@@ -32,8 +27,6 @@ const presetSection = (preset: string): string => `${SECTION_FUSION}.presets.${p
 export interface FusionSettings {
   readonly enabled: boolean
   readonly defaultPreset: string
-  // min_answered for the default preset (RFC-0252 answered-panel quorum).
-  readonly minAnswered: number
 }
 
 export interface FusionPresetComposition {
@@ -53,12 +46,10 @@ export type FusionSettingsReadResult =
   | { readonly ok: false; readonly issues: readonly FusionSettingsParseIssue[] }
 
 // Conservative defaults used only when a key is absent from the source — they
-// mirror the parser defaults (fusion disabled, quorum 1) rather than inventing
-// permissive values.
+// mirror the parser defaults rather than inventing permissive values.
 export const FUSION_SETTINGS_DEFAULTS: FusionSettings = {
   enabled: false,
   defaultPreset: '',
-  minAnswered: 1,
 }
 
 function issue(key: string, token: string | undefined, message: string): FusionSettingsParseIssue {
@@ -74,14 +65,6 @@ function parseBoolean(token: string | undefined, fallback: boolean, key: string)
   if (token === 'true') return true
   if (token === 'false') return false
   return issue(key, token, 'expected true or false')
-}
-
-function parsePositiveInt(token: string | undefined, fallback: number, key: string): number | FusionSettingsParseIssue {
-  if (token === undefined) return fallback
-  if (!/^\d+$/.test(token)) return issue(key, token, 'expected an integer >= 1')
-  const value = Number.parseInt(token, 10)
-  if (!Number.isSafeInteger(value) || value < 1) return issue(key, token, 'expected an integer >= 1')
-  return value
 }
 
 function parseTomlUnicodeEscape(hex: string): string | null {
@@ -162,11 +145,6 @@ function parseString(token: string | undefined, fallback: string, key: string): 
   return issue(key, token, 'expected a quoted string')
 }
 
-function sectionExists(sourceText: string, sectionName: string): boolean {
-  const escaped = sectionName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-  return new RegExp(`^\\s*\\[${escaped}\\]\\s*(?:#.*)?$`, 'm').test(sourceText)
-}
-
 function hasArrayOfTables(sourceText: string, sectionName: string, child: string): boolean {
   const escaped = `${sectionName}.${child}`.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
   return new RegExp(`^\\s*\\[\\[${escaped}\\]\\]\\s*(?:#.*)?$`, 'm').test(sourceText)
@@ -202,29 +180,11 @@ export function readFusionSettingsResult(sourceText: string): FusionSettingsRead
 
   const enabled = enabledParsed as boolean
   const defaultPreset = defaultPresetParsed as string
-  const preset = defaultPreset
-  const presetExists = preset !== '' && sectionExists(sourceText, presetSection(preset))
-  if (enabled && preset !== '' && !presetExists) {
-    issues.push(issue(`${presetSection(preset)}.${KEY_MIN_ANSWERED}`, undefined, 'default_preset references a missing preset section'))
-  }
-  const minAnsweredToken = preset && presetExists
-    ? getRuntimeTomlKey(sourceText, presetSection(preset), KEY_MIN_ANSWERED)
-    : undefined
-  const minAnsweredParsed = parsePositiveInt(
-    minAnsweredToken,
-    FUSION_SETTINGS_DEFAULTS.minAnswered,
-    `${presetSection(preset || '<default>')}.${KEY_MIN_ANSWERED}`,
-  )
-  if (isParseIssue(minAnsweredParsed)) issues.push(minAnsweredParsed)
-  if (issues.length > 0) return { ok: false, issues }
-  const minAnswered = minAnsweredParsed as number
-
   return {
     ok: true,
     settings: {
       enabled,
       defaultPreset,
-      minAnswered,
     },
   }
 }
@@ -235,54 +195,22 @@ export function readFusionSettings(sourceText: string): FusionSettings {
   throw new Error(`Invalid fusion settings: ${result.issues.map(i => `${i.key}: ${i.message}`).join('; ')}`)
 }
 
-export function readFusionPresetMinAnswered(sourceText: string, preset: string): number | FusionSettingsParseIssue {
-  const trimmed = preset.trim()
-  if (trimmed === '') return FUSION_SETTINGS_DEFAULTS.minAnswered
-  const section = presetSection(trimmed)
-  if (!sectionExists(sourceText, section)) return FUSION_SETTINGS_DEFAULTS.minAnswered
-  return parsePositiveInt(
-    getRuntimeTomlKey(sourceText, section, KEY_MIN_ANSWERED),
-    FUSION_SETTINGS_DEFAULTS.minAnswered,
-    `${section}.${KEY_MIN_ANSWERED}`,
-  )
-}
-
 export function validateFusionSettings(s: FusionSettings): string[] {
   const errors: string[] = []
   if (s.defaultPreset !== '' && s.defaultPreset.trim() === '') {
     errors.push(`${KEY_DEFAULT_PRESET} must not be whitespace`)
   }
-  if (!Number.isSafeInteger(s.minAnswered) || s.minAnswered < 1) {
-    errors.push(`${KEY_MIN_ANSWERED} must be an integer >= 1`)
-  }
   return errors
 }
 
-function previousDefaultPreset(sourceText: string): string {
-  const parsed = parseString(
-    getRuntimeTomlKey(sourceText, SECTION_FUSION, KEY_DEFAULT_PRESET),
-    FUSION_SETTINGS_DEFAULTS.defaultPreset,
-    `${SECTION_FUSION}.${KEY_DEFAULT_PRESET}`,
-  )
-  return typeof parsed === 'string' ? parsed : FUSION_SETTINGS_DEFAULTS.defaultPreset
-}
-
-// Apply the settings back into the source text key-by-key. min_answered is only
-// written when a default preset is set (it lives on that preset's table). The
-// returned text is what gets POSTed to /api/v1/runtime/config/raw.
+// Apply the settings back into the source text key-by-key. The returned text is
+// what gets POSTed to /api/v1/runtime/config/raw.
 export function applyFusionSettings(sourceText: string, s: FusionSettings): string {
   const errors = validateFusionSettings(s)
   if (errors.length > 0) throw new Error(`Invalid fusion settings: ${errors.join('; ')}`)
-  const previousPreset = previousDefaultPreset(sourceText)
   let text = sourceText
   text = setRuntimeTomlKey(text, SECTION_FUSION, KEY_ENABLED, s.enabled)
   text = setRuntimeTomlKey(text, SECTION_FUSION, KEY_DEFAULT_PRESET, s.defaultPreset)
-  if (previousPreset !== '' && previousPreset !== s.defaultPreset) {
-    text = deleteRuntimeTomlKey(text, presetSection(previousPreset), KEY_MIN_ANSWERED)
-  }
-  if (s.defaultPreset !== '') {
-    text = setRuntimeTomlKey(text, presetSection(s.defaultPreset), KEY_MIN_ANSWERED, s.minAnswered)
-  }
   return text
 }
 

--- a/docs/rfc/RFC-0306-fusion-settings-typed-editor.md
+++ b/docs/rfc/RFC-0306-fusion-settings-typed-editor.md
@@ -29,7 +29,6 @@ Editable in the panel (frontend line-surgical scalar writer,
 `dashboard/src/lib/fusion-settings.ts:262-277`):
 
 - `[fusion].enabled`, `[fusion].default_preset`
-- `[fusion.presets.<default>].min_answered`
 
 Read-only display only (`dashboard/src/lib/fusion-preset-view.ts`, header comment
 "display-only reader — it never writes back"):

--- a/lib/fusion_core/fusion_config.ml
+++ b/lib/fusion_core/fusion_config.ml
@@ -14,8 +14,6 @@ type config_error =
   | Missing_default_preset of string
   | Judge_panel_prompt_missing of string  (** preset 이름; JOJ 1차 심판 prompt 누락 (RFC-0283) *)
   | Duplicate_judge of string * string  (** (preset 이름, 중복 judge 정체성) (RFC-0283) *)
-  | Invalid_min_answered of string * int
-      (** (preset 이름, min_answered): policy 허용 범위 밖 *)
   | Invalid_meta_timeout of string * float
       (** (preset 이름, meta_timeout_s): 양수 유한수가 아님. *)
   | Invalid_judge_wave_budget of string * float
@@ -70,15 +68,10 @@ let parse_judge_spec (tbl : Otoml.t) : Fusion_policy.judge_spec =
       Otoml.find_opt tbl Otoml.get_float [ "max_timeout_s" ]
   }
 
-let parse_min_answered _name tbl =
-  match Otoml.find_opt tbl Otoml.get_integer [ "min_answered" ] with
-  | None -> Ok Fusion_policy.default_min_answered
-  | Some v -> Ok v
-
 (* 패널 그룹을 확정한 뒤 preset 완성 + 검증. judge_* 는 preset table에서 직접 읽는다
    (단일 심판 = simple/refine/conditional 심판이자 JOJ meta). [[...judges]] sub-table이
    있으면 JOJ 1차 심판 목록으로 파싱(없으면 []). 검증 순서: non-empty models → 패널 프롬프트 →
-   심판모델 → 패널 정체성 중복 → 1차 심판 prompt/정체성 → min_answered. *)
+   심판모델 → 패널 정체성 중복 → 1차 심판 prompt/정체성. *)
 let finish_preset name tbl (panels : Fusion_policy.panel_group list)
   : (Fusion_policy.Validated_preset.t, config_error) result =
   let judge = Otoml.find_or ~default:"" tbl Otoml.get_string [ "judge" ] in
@@ -114,33 +107,29 @@ let finish_preset name tbl (panels : Fusion_policy.panel_group list)
   let fallback_judge_model =
     Otoml.find_opt tbl Otoml.get_string [ "fallback_judge_model" ]
   in
-  (* 런타임 quorum. 미설정 시 [default_min_answered] = 기존 동작(>= 1 응답이면 심판 실행).
-     허용 범위는 1 이상 패널 모델 총합 이하; 검증 SSOT는 Validated_preset.of_preset. *)
-  Result.bind (parse_min_answered name tbl) (fun min_answered ->
-    let p : Fusion_policy.preset =
-      { name
-      ; panels
-      ; judge
-      ; judge_system_prompt
-      ; judge_timeout_s
-      ; judge_max_output_tokens
-      ; judges
-      ; meta_timeout_s
-      ; min_answered
-      ; judge_wave_budget_s
-      ; adaptive_timeout_factor
-      ; fallback_judge_model
-      }
-    in
-    (* 검증 SSOT는 Validated_preset.of_preset (RFC-0280). config는 그 [invalid]에 preset
+  let p : Fusion_policy.preset =
+    { name
+    ; panels
+    ; judge
+    ; judge_system_prompt
+    ; judge_timeout_s
+    ; judge_max_output_tokens
+    ; judges
+    ; meta_timeout_s
+    ; judge_wave_budget_s
+    ; adaptive_timeout_factor
+    ; fallback_judge_model
+    }
+  in
+  (* 검증 SSOT는 Validated_preset.of_preset (RFC-0280). config는 그 [invalid]에 preset
      이름을 붙여 자기 [config_error]로 매핑만 한다 (운영자에게 어느 preset인지 알림).
      [open] 안 함 — invalid와 config_error가 Missing_prompt 등 동명 변형을 가져 LHS만
      full-qualify해 shadow를 피한다. *)
-    match Fusion_policy.Validated_preset.of_preset p with
-    | Ok vp -> Ok vp
-    | Error invalid ->
-      Error
-        (match invalid with
+  match Fusion_policy.Validated_preset.of_preset p with
+  | Ok vp -> Ok vp
+  | Error invalid ->
+    Error
+      (match invalid with
          | Fusion_policy.Validated_preset.Empty_panel_models -> Empty_panel_models name
          | Fusion_policy.Validated_preset.Missing_prompt -> Missing_prompt name
          | Fusion_policy.Validated_preset.Missing_judge_model -> Missing_judge_model name
@@ -152,15 +141,12 @@ let finish_preset name tbl (panels : Fusion_policy.panel_group list)
            Judge_panel_prompt_missing name
          | Fusion_policy.Validated_preset.Duplicate_judge id ->
            Duplicate_judge (name, id)
-         | Fusion_policy.Validated_preset.Min_answered_below_min v
-         | Fusion_policy.Validated_preset.Min_answered_above_max v ->
-           Invalid_min_answered (name, v)
          | Fusion_policy.Validated_preset.Bad_meta_timeout v ->
            Invalid_meta_timeout (name, v)
          | Fusion_policy.Validated_preset.Bad_judge_wave_budget v ->
            Invalid_judge_wave_budget (name, v)
-         | Fusion_policy.Validated_preset.Bad_adaptive_factor v ->
-           Invalid_adaptive_timeout_factor (name, v)))
+       | Fusion_policy.Validated_preset.Bad_adaptive_factor v ->
+         Invalid_adaptive_timeout_factor (name, v))
 
 (* preset 한 명 파싱. 두 문법 분기:
    - 새 문법 [[fusion.presets.NAME.panels]] (array-of-tables) → 그룹별 파싱.

--- a/lib/fusion_core/fusion_config.mli
+++ b/lib/fusion_core/fusion_config.mli
@@ -35,9 +35,6 @@ type config_error =
       (** preset 이름 — JOJ 1차 심판 system prompt 누락 (RFC-0283). *)
   | Duplicate_judge of string * string
       (** (preset 이름, 중복 judge 정체성) — 두 JOJ 1차 심판이 같은 정체성 (RFC-0283). *)
-  | Invalid_min_answered of string * int
-      (** (preset 이름, min_answered) — [min_answered]가 policy 허용 범위(1..패널
-          모델 총합) 밖. full-panel quorum([총합])도 명시적으로 설정할 수 있다. *)
   | Invalid_meta_timeout of string * float
       (** (preset 이름, meta_timeout_s) — 양수 유한수가 아님. *)
   | Invalid_judge_wave_budget of string * float
@@ -64,7 +61,6 @@ val disabled : Fusion_policy.t
     - judge 모델 id 누락 → [Error [Missing_judge_model _]].
     - staged_judge_group_size < 2 → [Error [Invalid_staged_judge_group_size _]].
     - max_output_tokens override가 0 이하 → [Error [Invalid_max_output_tokens _]].
-    - min_answered가 1..패널 모델 총합 범위 밖 → [Error [Invalid_min_answered _]].
     - default_preset가 presets에 없음 → [Error [Missing_default_preset _]].
     - 필드 타입 불일치 → [Error [Toml_type_error _]].
     여러 에러는 누적되어 한 번에 반환된다. *)

--- a/lib/fusion_core/fusion_config_json.ml
+++ b/lib/fusion_core/fusion_config_json.ml
@@ -53,7 +53,6 @@ let preset_to_yojson (p : Fusion_policy.preset) : Yojson.Safe.t =
     ; ("judge_max_output_tokens", opt_int p.Fusion_policy.judge_max_output_tokens)
     ; ("meta_timeout_s", `Float p.Fusion_policy.meta_timeout_s)
     ; ("judges", `List (List.map judge_spec_to_yojson p.Fusion_policy.judges))
-    ; ("min_answered", `Int p.Fusion_policy.min_answered)
     ; ("judge_wave_budget_s", `Float p.Fusion_policy.judge_wave_budget_s)
     ; ( "adaptive_timeout_factor"
       , `Float p.Fusion_policy.adaptive_timeout_factor )

--- a/lib/fusion_core/fusion_policy.ml
+++ b/lib/fusion_core/fusion_policy.ml
@@ -46,8 +46,6 @@ type preset =
   ; judges : judge_spec list
       (** JOJ 1차 심판들 (RFC-0283). 기본 []; simple/refine/conditional은 무시한다.
           JOJ 위상은 런타임에 >= 2 를 요구한다. *)
-  ; min_answered : int
-      (** 심판 실행에 필요한 응답 패널 최소 수 (런타임 quorum). 기본 1. *)
   ; judge_wave_budget_s : float
       (** 1차 심판 wave 전체 wall-clock 예산 (초). 0=비활성(legacy). *)
   ; adaptive_timeout_factor : float
@@ -57,8 +55,6 @@ type preset =
   }
 [@@deriving show, eq]
 
-let min_answered_floor = 1
-let default_min_answered = min_answered_floor
 let min_staged_judge_group_size = 2
 let default_staged_judge_group_size = 3
 
@@ -284,10 +280,6 @@ module Validated_preset = struct
         (** 그룹/심판 출력 토큰 예산 override가 양수가 아님 *)
     | Judge_panel_prompt_missing  (** JOJ 1차 심판 system prompt 비어있음 (RFC-0283) *)
     | Duplicate_judge of string  (** 두 JOJ 1차 심판이 같은 정체성(judge_id) (RFC-0283) *)
-    | Min_answered_below_min of int
-        (** [min_answered]가 하한 [min_answered_floor] 미만. *)
-    | Min_answered_above_max of int
-        (** [min_answered]가 패널 모델 총합을 초과. *)
     | Bad_meta_timeout of float
         (** [meta_timeout_s]가 양수 유한수가 아님. *)
     | Bad_judge_wave_budget of float
@@ -298,7 +290,7 @@ module Validated_preset = struct
 
   (* 검증 순서는 config 로드 시점과 동일: non-empty models → 패널 prompt →
      judge model → 패널 정체성 중복 → 패널 max_output_tokens 범위 → (RFC-0283)
-     1차 심판 prompt → 1차 심판 정체성 중복 → 심판 max_output_tokens 범위 → min_answered.
+     1차 심판 prompt → 1차 심판 정체성 중복 → 심판 max_output_tokens 범위.
      judges=[]면 1차 심판 관련 셋은 통과(simple/refine/conditional preset은 기존과 동일
      결과 = byte-identity). *)
   let of_preset (p : preset) : (t, invalid) result =
@@ -331,12 +323,7 @@ module Validated_preset = struct
                 with
                 | Some (Some n) -> Error (Bad_max_output_tokens n)
                 | Some None | None ->
-                  let total = List.length (preset_models p) in
-                  if p.min_answered < min_answered_floor
-                  then Error (Min_answered_below_min p.min_answered)
-                  else if p.min_answered > total
-                  then Error (Min_answered_above_max p.min_answered)
-                  else if
+                  if
                     not (p.meta_timeout_s > 0.0 && Float.is_finite p.meta_timeout_s)
                   then Error (Bad_meta_timeout p.meta_timeout_s)
                   else if p.adaptive_timeout_factor < 1.0

--- a/lib/fusion_core/fusion_policy.mli
+++ b/lib/fusion_core/fusion_policy.mli
@@ -58,12 +58,6 @@ type preset =
   ; judges : judge_spec list
       (** JOJ 1차 심판들 (RFC-0283). 기본 []; simple/refine/conditional은 무시한다.
           JOJ 위상은 런타임에 >= 2 를 요구한다. *)
-  ; min_answered : int
-      (** 심판을 돌리기 위해 응답해야 하는 패널 최소 수 (런타임 quorum). 기본 1.
-          [answered_of] 수가 이 값 미만이면 orchestrator는 심판을 건너뛰고
-          [judge = Error]로 완료한다 (빈 패널 종합 날조 방지).
-          허용 범위는 [1]부터 패널 모델 총합까지; full-panel quorum([총합])도
-          명시적으로 설정할 수 있다. *)
   ; judge_wave_budget_s : float
       (** 1차 심판 wave 전체 wall-clock 예산 (초). 0=비활성(legacy). *)
   ; adaptive_timeout_factor : float
@@ -72,11 +66,6 @@ type preset =
       (** 전원 타임아웃/예산 실패 시 단일 fallback 심판 모델. *)
   }
 [@@deriving show, eq]
-
-(** [min_answered] 하한과 기본값. 기본 1 = "응답 패널이 1개도 없을 때만 judge skip". *)
-val min_answered_floor : int
-
-val default_min_answered : int
 
 (** Default staged JOJ group size. A staged judge-of-judges run groups first
     judges into fixed-size cohorts before a final meta reduction; default 3
@@ -206,10 +195,6 @@ module Validated_preset : sig
         (** 그룹/심판 max_output_tokens override가 양수가 아님 *)
     | Judge_panel_prompt_missing  (** JOJ 1차 심판 system prompt 비어있음 (RFC-0283) *)
     | Duplicate_judge of string  (** 두 JOJ 1차 심판이 같은 정체성 (RFC-0283) *)
-    | Min_answered_below_min of int
-        (** [min_answered]가 하한 [min_answered_floor] 미만. *)
-    | Min_answered_above_max of int
-        (** [min_answered]가 패널 모델 총합을 초과. *)
     | Bad_meta_timeout of float
         (** [meta_timeout_s]가 양수 유한수가 아님. *)
     | Bad_judge_wave_budget of float
@@ -219,7 +204,7 @@ module Validated_preset : sig
         (** [adaptive_timeout_factor]가 1.0 미만. *)
 
   (** 검증 순서: non-empty models → prompt → judge → 정체성 중복 → max_output_tokens →
-      1차 심판 prompt/정체성/max_output_tokens → min_answered → timeout 예산/계수.
+      1차 심판 prompt/정체성/max_output_tokens → timeout 예산/계수.
       통과 시 [Ok vp], 첫 위반에서 [Error invalid].
       config 로드의 검증 순서와 동일. *)
   val of_preset : preset -> (t, invalid) result

--- a/test/fusion_core/test_fusion.ml
+++ b/test/fusion_core/test_fusion.ml
@@ -46,7 +46,6 @@ let base_policy : Fusion_policy.t =
           ; judge_max_output_tokens = None
           ; meta_timeout_s = 300.0
           ; judges = []
-          ; min_answered = Fusion_policy.default_min_answered
           ; judge_wave_budget_s = Float.max_float
           ; adaptive_timeout_factor = 1.0
           ; fallback_judge_model = None
@@ -506,34 +505,6 @@ judge_system_prompt = "synthesize"
       (List.mem (Fusion_config.Empty_panel_models "empty") es)
   | Ok _ -> Alcotest.fail "expected Error Empty_panel_models"
 
-let test_config_invalid_min_answered () =
-  let check_invalid value =
-    let s =
-      Printf.sprintf
-        {|
-[fusion]
-enabled = true
-default_preset = "p"
-[fusion.presets.p]
-panel = ["a", "b"]
-panel_system_prompt = "y"
-judge = "j"
-judge_system_prompt = "x"
-min_answered = %d
-|}
-        value
-    in
-    match Fusion_config.of_toml (parse s) with
-    | Error es ->
-      Alcotest.(check bool) "Invalid_min_answered present" true
-        (List.mem (Fusion_config.Invalid_min_answered ("p", value)) es)
-    | Ok _ -> Alcotest.fail "expected Error Invalid_min_answered"
-  in
-  check_invalid 0;
-  check_invalid (-1);
-  (* 2 panels -> max allowed is 2, so 3 is out of range *)
-  check_invalid 3
-
 let test_config_missing_default () =
   let s =
     {|
@@ -843,7 +814,7 @@ let test_config_disabled_with_preset () =
    목표 결함 하나만 두고 나머지는 유효하게 해, 검증 순서(size→prompt→judge→dup→mtc)에서
    그 변형이 발화하는지 확인한다. private 타입이라 외부는 of_preset로만 t를 만든다. *)
 let mk_preset ?(panels = [ base_group ]) ?(judge = "j") ?(judge_prompt = "synthesize")
-    ?(judges = []) ?(min_answered = Fusion_policy.default_min_answered)
+    ?(judges = [])
     ?(meta_timeout_s = 300.0) ?(judge_wave_budget_s = Float.max_float)
     ?(adaptive_timeout_factor = 1.0) ?(fallback_judge_model = None)
     (name : string) : Fusion_policy.preset =
@@ -855,7 +826,6 @@ let mk_preset ?(panels = [ base_group ]) ?(judge = "j") ?(judge_prompt = "synthe
   ; judge_max_output_tokens = None
   ; meta_timeout_s
   ; judges
-  ; min_answered
   ; judge_wave_budget_s
   ; adaptive_timeout_factor
   ; fallback_judge_model
@@ -1373,32 +1343,6 @@ let test_panels_unavailable_failure () =
   Alcotest.(check bool) "not timeout-or-budget (no fallback judge trigger)" false
     (judge_failure_is_timeout_or_budget failure)
 
-(* min_answered must be in the policy range 1..total panels (inclusive).
-   base_group has 3 models, so 0 and 4 are rejected; full-panel quorum (3) is allowed. *)
-let test_validated_bad_min_answered () =
-  let check_bad mn label =
-    match Fusion_policy.Validated_preset.of_preset (mk_preset ~min_answered:mn label) with
-    | Error (Fusion_policy.Validated_preset.Min_answered_below_min got)
-    | Error (Fusion_policy.Validated_preset.Min_answered_above_max got) ->
-      Alcotest.(check int) (label ^ " reports value") mn got
-    | _ -> Alcotest.failf "%s: expected min_answered error" label
-  in
-  check_bad 0 "min_answered=0";
-  check_bad 4 "min_answered>panels";
-  (* full-panel quorum is now allowed (3 answered required for 3 panels). *)
-  (match Fusion_policy.Validated_preset.of_preset (mk_preset ~min_answered:3 "ok3") with
-   | Ok _ -> ()
-   | Error _ -> Alcotest.fail "min_answered=3 with 3 panels should be Ok");
-  (* in-range stays Ok (3 models, require 2) *)
-  match Fusion_policy.Validated_preset.of_preset (mk_preset ~min_answered:2 "ok2") with
-  | Ok _ -> ()
-  | Error _ -> Alcotest.fail "min_answered=2 with 3 panels should be Ok"
-
-let test_min_answered_constants () =
-  Alcotest.(check int) "default_min_answered" 1 Fusion_policy.default_min_answered;
-  Alcotest.(check int) "min_answered_floor" 1 Fusion_policy.min_answered_floor
-
-
 (* --- FUSION adaptive timeout / P0 hardening (RFC-0284-FUSION-P0) --- *)
 
 let adaptive_toml =
@@ -1669,8 +1613,6 @@ let () =
         ; Alcotest.test_case "empty_presets" `Quick test_config_empty_presets
         ; Alcotest.test_case "wide_panel" `Quick test_config_wide_panel
         ; Alcotest.test_case "empty_panel_models" `Quick test_config_empty_panel_models
-        ; Alcotest.test_case "invalid_min_answered" `Quick
-            test_config_invalid_min_answered
         ; Alcotest.test_case "missing_default" `Quick test_config_missing_default
         ; Alcotest.test_case "missing_prompt" `Quick test_config_missing_prompt
         ; Alcotest.test_case "missing_judge_model" `Quick test_config_missing_judge_model
@@ -1767,9 +1709,7 @@ let () =
             test_judge_error_node_timed_out
         ] )
     ; ( "panel_guard"
-      , [ Alcotest.test_case "min_answered_range" `Quick test_validated_bad_min_answered
-        ; Alcotest.test_case "min_answered_constants" `Quick test_min_answered_constants
-        ; Alcotest.test_case "panels_unavailable_failure" `Quick
+      , [ Alcotest.test_case "panels_unavailable_failure" `Quick
             test_panels_unavailable_failure
         ] )
     ]

--- a/test/test_fusion_wake.ml
+++ b/test/test_fusion_wake.ml
@@ -198,7 +198,6 @@ let fusion_tool_policy () : Fusion_policy.t =
     ; judge_max_output_tokens = None
     ; meta_timeout_s = Fusion_policy.default_timeout_s
     ; judges = []
-    ; min_answered = Fusion_policy.default_min_answered
     ; judge_wave_budget_s = Float.max_float
     ; adaptive_timeout_factor = 1.0
     ; fallback_judge_model = None


### PR DESCRIPTION
## Outcome

Deletes the dashboard surface for Fusion's execution-inert `min_answered` quorum.

- removes the field from immutable settings state, defaults, parsing, validation, and TOML writes
- removes the numeric editor and preset-switch projection
- removes tests that preserved the deleted quorum/budget controls
- keeps backend validation as the single authority for real typed Fusion configuration
- preserves panel/judge composition editing and explicit backend rejection rendering

This is the UI-first leaf so no dashboard can write the obsolete key while the next stack deletes the OCaml/TOML/JSON contract itself.

Stack: #24584 -> #24593 -> #24599 -> #24602 -> this PR. Tracks #24579.

## Validation

- `dashboard: npx tsc --noEmit --pretty`
- `dashboard: npx vitest run src/lib/fusion-settings.test.ts src/lib/fusion-preset-view.test.ts src/components/fusion-settings-panel.test.ts src/components/settings-surface.test.ts` (80 passed)
- scoped ESLint: 0 errors (repository config ignored the five supplied paths with warnings)
- `git diff --check`

Full build/test remains CI authority.
