### PR TITLE
fix(build): preserve typed delegate parse errors

### DIFF
--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -687,7 +687,9 @@ let handle_keeper_msg ?continuation_channel ~submitted_by ctx args : tool_result
 let handle_keeper_delegate ~submitted_by ctx args =
   match
     let* request =
-      Keeper_invocation_contract.request_of_json args |> message_error
+      Keeper_invocation_contract.request_of_json args
+      |> Result.map_error Keeper_invocation_contract.request_error_to_string
+      |> message_error
     in
     let* request = message_error (Turn.preflight_keeper_delegate ctx request) in
     Ok


### PR DESCRIPTION
## 문제

`main@4d914a4` CI의 `keeper_tool_surface_ops.ml:690`에서 `request_error`를 문자열 전용 `message_error`에 직접 전달해 타입 오류가 발생했습니다. #24606은 앞선 8개 오류를 복구했지만 이 후속 오류는 포함하지 않았습니다.

## 수정

- `Keeper_invocation_contract.request_error_to_string`으로 typed request error를 명시적으로 변환
- 기존 `Message_error`/tool result 경계 유지

## 검증

- `ocamlc -stop-after parsing lib/keeper/keeper_tool_surface_ops.ml`
- `git diff --check`
- 로컬 Dune 미실행; GitHub CI를 빌드 권위로 사용