### PR TITLE
refactor(fusion): delete inert answered quorum

### DIFF
--- a/lib/fusion_core/fusion_config.ml
+++ b/lib/fusion_core/fusion_config.ml
@@ -14,8 +14,6 @@ type config_error =
   | Missing_default_preset of string
   | Judge_panel_prompt_missing of string  (** preset 이름; JOJ 1차 심판 prompt 누락 (RFC-0283) *)
   | Duplicate_judge of string * string  (** (preset 이름, 중복 judge 정체성) (RFC-0283) *)
-  | Invalid_min_answered of string * int
-      (** (preset 이름, min_answered): policy 허용 범위 밖 *)
   | Invalid_meta_timeout of string * float
       (** (preset 이름, meta_timeout_s): 양수 유한수가 아님. *)
   | Invalid_judge_wave_budget of string * float
@@ -70,15 +68,10 @@ let parse_judge_spec (tbl : Otoml.t) : Fusion_policy.judge_spec =
       Otoml.find_opt tbl Otoml.get_float [ "max_timeout_s" ]
   }
 
-let parse_min_answered _name tbl =
-  match Otoml.find_opt tbl Otoml.get_integer [ "min_answered" ] with
-  | None -> Ok Fusion_policy.default_min_answered
-  | Some v -> Ok v
-
 (* 패널 그룹을 확정한 뒤 preset 완성 + 검증. judge_* 는 preset table에서 직접 읽는다
    (단일 심판 = simple/refine/conditional 심판이자 JOJ meta). [[...judges]] sub-table이
    있으면 JOJ 1차 심판 목록으로 파싱(없으면 []). 검증 순서: non-empty models → 패널 프롬프트 →
-   심판모델 → 패널 정체성 중복 → 1차 심판 prompt/정체성 → min_answered. *)
+   심판모델 → 패널 정체성 중복 → 1차 심판 prompt/정체성. *)
 let finish_preset name tbl (panels : Fusion_policy.panel_group list)
   : (Fusion_policy.Validated_preset.t, config_error) result =
   let judge = Otoml.find_or ~default:"" tbl Otoml.get_string [ "judge" ] in
@@ -114,33 +107,29 @@ let finish_preset name tbl (panels : Fusion_policy.panel_group list)
   let fallback_judge_model =
     Otoml.find_opt tbl Otoml.get_string [ "fallback_judge_model" ]
   in
-  (* 런타임 quorum. 미설정 시 [default_min_answered] = 기존 동작(>= 1 응답이면 심판 실행).
-     허용 범위는 1 이상 패널 모델 총합 이하; 검증 SSOT는 Validated_preset.of_preset. *)
-  Result.bind (parse_min_answered name tbl) (fun min_answered ->
-    let p : Fusion_policy.preset =
-      { name
-      ; panels
-      ; judge
-      ; judge_system_prompt
-      ; judge_timeout_s
-      ; judge_max_output_tokens
-      ; judges
-      ; meta_timeout_s
-      ; min_answered
-      ; judge_wave_budget_s
-      ; adaptive_timeout_factor
-      ; fallback_judge_model
-      }
-    in
-    (* 검증 SSOT는 Validated_preset.of_preset (RFC-0280). config는 그 [invalid]에 preset
+  let p : Fusion_policy.preset =
+    { name
+    ; panels
+    ; judge
+    ; judge_system_prompt
+    ; judge_timeout_s
+    ; judge_max_output_tokens
+    ; judges
+    ; meta_timeout_s
+    ; judge_wave_budget_s
+    ; adaptive_timeout_factor
+    ; fallback_judge_model
+    }
+  in
+  (* 검증 SSOT는 Validated_preset.of_preset (RFC-0280). config는 그 [invalid]에 preset
      이름을 붙여 자기 [config_error]로 매핑만 한다 (운영자에게 어느 preset인지 알림).
      [open] 안 함 — invalid와 config_error가 Missing_prompt 등 동명 변형을 가져 LHS만
      full-qualify해 shadow를 피한다. *)
-    match Fusion_policy.Validated_preset.of_preset p with
-    | Ok vp -> Ok vp
-    | Error invalid ->
-      Error
-        (match invalid with
+  match Fusion_policy.Validated_preset.of_preset p with
+  | Ok vp -> Ok vp
+  | Error invalid ->
+    Error
+      (match invalid with
          | Fusion_policy.Validated_preset.Empty_panel_models -> Empty_panel_models name
          | Fusion_policy.Validated_preset.Missing_prompt -> Missing_prompt name
          | Fusion_policy.Validated_preset.Missing_judge_model -> Missing_judge_model name
@@ -152,15 +141,12 @@ let finish_preset name tbl (panels : Fusion_policy.panel_group list)
            Judge_panel_prompt_missing name
          | Fusion_policy.Validated_preset.Duplicate_judge id ->
            Duplicate_judge (name, id)
-         | Fusion_policy.Validated_preset.Min_answered_below_min v
-         | Fusion_policy.Validated_preset.Min_answered_above_max v ->
-           Invalid_min_answered (name, v)
          | Fusion_policy.Validated_preset.Bad_meta_timeout v ->
            Invalid_meta_timeout (name, v)
          | Fusion_policy.Validated_preset.Bad_judge_wave_budget v ->
            Invalid_judge_wave_budget (name, v)
-         | Fusion_policy.Validated_preset.Bad_adaptive_factor v ->
-           Invalid_adaptive_timeout_factor (name, v)))
+       | Fusion_policy.Validated_preset.Bad_adaptive_factor v ->
+         Invalid_adaptive_timeout_factor (name, v))
 
 (* preset 한 명 파싱. 두 문법 분기:
    - 새 문법 [[fusion.presets.NAME.panels]] (array-of-tables) → 그룹별 파싱.

--- a/lib/fusion_core/fusion_config.mli
+++ b/lib/fusion_core/fusion_config.mli
@@ -35,9 +35,6 @@ type config_error =
       (** preset 이름 — JOJ 1차 심판 system prompt 누락 (RFC-0283). *)
   | Duplicate_judge of string * string
       (** (preset 이름, 중복 judge 정체성) — 두 JOJ 1차 심판이 같은 정체성 (RFC-0283). *)
-  | Invalid_min_answered of string * int
-      (** (preset 이름, min_answered) — [min_answered]가 policy 허용 범위(1..패널
-          모델 총합) 밖. full-panel quorum([총합])도 명시적으로 설정할 수 있다. *)
   | Invalid_meta_timeout of string * float
       (** (preset 이름, meta_timeout_s) — 양수 유한수가 아님. *)
   | Invalid_judge_wave_budget of string * float
@@ -64,7 +61,6 @@ val disabled : Fusion_policy.t
     - judge 모델 id 누락 → [Error [Missing_judge_model _]].
     - staged_judge_group_size < 2 → [Error [Invalid_staged_judge_group_size _]].
     - max_output_tokens override가 0 이하 → [Error [Invalid_max_output_tokens _]].
-    - min_answered가 1..패널 모델 총합 범위 밖 → [Error [Invalid_min_answered _]].
     - default_preset가 presets에 없음 → [Error [Missing_default_preset _]].
     - 필드 타입 불일치 → [Error [Toml_type_error _]].
     여러 에러는 누적되어 한 번에 반환된다. *)

--- a/lib/fusion_core/fusion_config_json.ml
+++ b/lib/fusion_core/fusion_config_json.ml
@@ -53,7 +53,6 @@ let preset_to_yojson (p : Fusion_policy.preset) : Yojson.Safe.t =
     ; ("judge_max_output_tokens", opt_int p.Fusion_policy.judge_max_output_tokens)
     ; ("meta_timeout_s", `Float p.Fusion_policy.meta_timeout_s)
     ; ("judges", `List (List.map judge_spec_to_yojson p.Fusion_policy.judges))
-    ; ("min_answered", `Int p.Fusion_policy.min_answered)
     ; ("judge_wave_budget_s", `Float p.Fusion_policy.judge_wave_budget_s)
     ; ( "adaptive_timeout_factor"
       , `Float p.Fusion_policy.adaptive_timeout_factor )

--- a/lib/fusion_core/fusion_policy.ml
+++ b/lib/fusion_core/fusion_policy.ml
@@ -46,8 +46,6 @@ type preset =
   ; judges : judge_spec list
       (** JOJ 1차 심판들 (RFC-0283). 기본 []; simple/refine/conditional은 무시한다.
           JOJ 위상은 런타임에 >= 2 를 요구한다. *)
-  ; min_answered : int
-      (** 심판 실행에 필요한 응답 패널 최소 수 (런타임 quorum). 기본 1. *)
   ; judge_wave_budget_s : float
       (** 1차 심판 wave 전체 wall-clock 예산 (초). 0=비활성(legacy). *)
   ; adaptive_timeout_factor : float
@@ -57,8 +55,6 @@ type preset =
   }
 [@@deriving show, eq]
 
-let min_answered_floor = 1
-let default_min_answered = min_answered_floor
 let min_staged_judge_group_size = 2
 let default_staged_judge_group_size = 3
 
@@ -284,10 +280,6 @@ module Validated_preset = struct
         (** 그룹/심판 출력 토큰 예산 override가 양수가 아님 *)
     | Judge_panel_prompt_missing  (** JOJ 1차 심판 system prompt 비어있음 (RFC-0283) *)
     | Duplicate_judge of string  (** 두 JOJ 1차 심판이 같은 정체성(judge_id) (RFC-0283) *)
-    | Min_answered_below_min of int
-        (** [min_answered]가 하한 [min_answered_floor] 미만. *)
-    | Min_answered_above_max of int
-        (** [min_answered]가 패널 모델 총합을 초과. *)
     | Bad_meta_timeout of float
         (** [meta_timeout_s]가 양수 유한수가 아님. *)
     | Bad_judge_wave_budget of float
@@ -298,7 +290,7 @@ module Validated_preset = struct
 
   (* 검증 순서는 config 로드 시점과 동일: non-empty models → 패널 prompt →
      judge model → 패널 정체성 중복 → 패널 max_output_tokens 범위 → (RFC-0283)
-     1차 심판 prompt → 1차 심판 정체성 중복 → 심판 max_output_tokens 범위 → min_answered.
+     1차 심판 prompt → 1차 심판 정체성 중복 → 심판 max_output_tokens 범위.
      judges=[]면 1차 심판 관련 셋은 통과(simple/refine/conditional preset은 기존과 동일
      결과 = byte-identity). *)
   let of_preset (p : preset) : (t, invalid) result =
@@ -331,12 +323,7 @@ module Validated_preset = struct
                 with
                 | Some (Some n) -> Error (Bad_max_output_tokens n)
                 | Some None | None ->
-                  let total = List.length (preset_models p) in
-                  if p.min_answered < min_answered_floor
-                  then Error (Min_answered_below_min p.min_answered)
-                  else if p.min_answered > total
-                  then Error (Min_answered_above_max p.min_answered)
-                  else if
+                  if
                     not (p.meta_timeout_s > 0.0 && Float.is_finite p.meta_timeout_s)
                   then Error (Bad_meta_timeout p.meta_timeout_s)
                   else if p.adaptive_timeout_factor < 1.0

--- a/lib/fusion_core/fusion_policy.mli
+++ b/lib/fusion_core/fusion_policy.mli
@@ -58,12 +58,6 @@ type preset =
   ; judges : judge_spec list
       (** JOJ 1차 심판들 (RFC-0283). 기본 []; simple/refine/conditional은 무시한다.
           JOJ 위상은 런타임에 >= 2 를 요구한다. *)
-  ; min_answered : int
-      (** 심판을 돌리기 위해 응답해야 하는 패널 최소 수 (런타임 quorum). 기본 1.
-          [answered_of] 수가 이 값 미만이면 orchestrator는 심판을 건너뛰고
-          [judge = Error]로 완료한다 (빈 패널 종합 날조 방지).
-          허용 범위는 [1]부터 패널 모델 총합까지; full-panel quorum([총합])도
-          명시적으로 설정할 수 있다. *)
   ; judge_wave_budget_s : float
       (** 1차 심판 wave 전체 wall-clock 예산 (초). 0=비활성(legacy). *)
   ; adaptive_timeout_factor : float
@@ -72,11 +66,6 @@ type preset =
       (** 전원 타임아웃/예산 실패 시 단일 fallback 심판 모델. *)
   }
 [@@deriving show, eq]
-
-(** [min_answered] 하한과 기본값. 기본 1 = "응답 패널이 1개도 없을 때만 judge skip". *)
-val min_answered_floor : int
-
-val default_min_answered : int
 
 (** Default staged JOJ group size. A staged judge-of-judges run groups first
     judges into fixed-size cohorts before a final meta reduction; default 3
@@ -206,10 +195,6 @@ module Validated_preset : sig
         (** 그룹/심판 max_output_tokens override가 양수가 아님 *)
     | Judge_panel_prompt_missing  (** JOJ 1차 심판 system prompt 비어있음 (RFC-0283) *)
     | Duplicate_judge of string  (** 두 JOJ 1차 심판이 같은 정체성 (RFC-0283) *)
-    | Min_answered_below_min of int
-        (** [min_answered]가 하한 [min_answered_floor] 미만. *)
-    | Min_answered_above_max of int
-        (** [min_answered]가 패널 모델 총합을 초과. *)
     | Bad_meta_timeout of float
         (** [meta_timeout_s]가 양수 유한수가 아님. *)
     | Bad_judge_wave_budget of float
@@ -219,7 +204,7 @@ module Validated_preset : sig
         (** [adaptive_timeout_factor]가 1.0 미만. *)
 
   (** 검증 순서: non-empty models → prompt → judge → 정체성 중복 → max_output_tokens →
-      1차 심판 prompt/정체성/max_output_tokens → min_answered → timeout 예산/계수.
+      1차 심판 prompt/정체성/max_output_tokens → timeout 예산/계수.
       통과 시 [Ok vp], 첫 위반에서 [Error invalid].
       config 로드의 검증 순서와 동일. *)
   val of_preset : preset -> (t, invalid) result

--- a/test/fusion_core/test_fusion.ml
+++ b/test/fusion_core/test_fusion.ml
@@ -46,7 +46,6 @@ let base_policy : Fusion_policy.t =
           ; judge_max_output_tokens = None
           ; meta_timeout_s = 300.0
           ; judges = []
-          ; min_answered = Fusion_policy.default_min_answered
           ; judge_wave_budget_s = Float.max_float
           ; adaptive_timeout_factor = 1.0
           ; fallback_judge_model = None
@@ -506,34 +505,6 @@ judge_system_prompt = "synthesize"
       (List.mem (Fusion_config.Empty_panel_models "empty") es)
   | Ok _ -> Alcotest.fail "expected Error Empty_panel_models"
 
-let test_config_invalid_min_answered () =
-  let check_invalid value =
-    let s =
-      Printf.sprintf
-        {|
-[fusion]
-enabled = true
-default_preset = "p"
-[fusion.presets.p]
-panel = ["a", "b"]
-panel_system_prompt = "y"
-judge = "j"
-judge_system_prompt = "x"
-min_answered = %d
-|}
-        value
-    in
-    match Fusion_config.of_toml (parse s) with
-    | Error es ->
-      Alcotest.(check bool) "Invalid_min_answered present" true
-        (List.mem (Fusion_config.Invalid_min_answered ("p", value)) es)
-    | Ok _ -> Alcotest.fail "expected Error Invalid_min_answered"
-  in
-  check_invalid 0;
-  check_invalid (-1);
-  (* 2 panels -> max allowed is 2, so 3 is out of range *)
-  check_invalid 3
-
 let test_config_missing_default () =
   let s =
     {|
@@ -843,7 +814,7 @@ let test_config_disabled_with_preset () =
    목표 결함 하나만 두고 나머지는 유효하게 해, 검증 순서(size→prompt→judge→dup→mtc)에서
    그 변형이 발화하는지 확인한다. private 타입이라 외부는 of_preset로만 t를 만든다. *)
 let mk_preset ?(panels = [ base_group ]) ?(judge = "j") ?(judge_prompt = "synthesize")
-    ?(judges = []) ?(min_answered = Fusion_policy.default_min_answered)
+    ?(judges = [])
     ?(meta_timeout_s = 300.0) ?(judge_wave_budget_s = Float.max_float)
     ?(adaptive_timeout_factor = 1.0) ?(fallback_judge_model = None)
     (name : string) : Fusion_policy.preset =
@@ -855,7 +826,6 @@ let mk_preset ?(panels = [ base_group ]) ?(judge = "j") ?(judge_prompt = "synthe
   ; judge_max_output_tokens = None
   ; meta_timeout_s
   ; judges
-  ; min_answered
   ; judge_wave_budget_s
   ; adaptive_timeout_factor
   ; fallback_judge_model
@@ -1373,32 +1343,6 @@ let test_panels_unavailable_failure () =
   Alcotest.(check bool) "not timeout-or-budget (no fallback judge trigger)" false
     (judge_failure_is_timeout_or_budget failure)
 
-(* min_answered must be in the policy range 1..total panels (inclusive).
-   base_group has 3 models, so 0 and 4 are rejected; full-panel quorum (3) is allowed. *)
-let test_validated_bad_min_answered () =
-  let check_bad mn label =
-    match Fusion_policy.Validated_preset.of_preset (mk_preset ~min_answered:mn label) with
-    | Error (Fusion_policy.Validated_preset.Min_answered_below_min got)
-    | Error (Fusion_policy.Validated_preset.Min_answered_above_max got) ->
-      Alcotest.(check int) (label ^ " reports value") mn got
-    | _ -> Alcotest.failf "%s: expected min_answered error" label
-  in
-  check_bad 0 "min_answered=0";
-  check_bad 4 "min_answered>panels";
-  (* full-panel quorum is now allowed (3 answered required for 3 panels). *)
-  (match Fusion_policy.Validated_preset.of_preset (mk_preset ~min_answered:3 "ok3") with
-   | Ok _ -> ()
-   | Error _ -> Alcotest.fail "min_answered=3 with 3 panels should be Ok");
-  (* in-range stays Ok (3 models, require 2) *)
-  match Fusion_policy.Validated_preset.of_preset (mk_preset ~min_answered:2 "ok2") with
-  | Ok _ -> ()
-  | Error _ -> Alcotest.fail "min_answered=2 with 3 panels should be Ok"
-
-let test_min_answered_constants () =
-  Alcotest.(check int) "default_min_answered" 1 Fusion_policy.default_min_answered;
-  Alcotest.(check int) "min_answered_floor" 1 Fusion_policy.min_answered_floor
-
-
 (* --- FUSION adaptive timeout / P0 hardening (RFC-0284-FUSION-P0) --- *)
 
 let adaptive_toml =
@@ -1669,8 +1613,6 @@ let () =
         ; Alcotest.test_case "empty_presets" `Quick test_config_empty_presets
         ; Alcotest.test_case "wide_panel" `Quick test_config_wide_panel
         ; Alcotest.test_case "empty_panel_models" `Quick test_config_empty_panel_models
-        ; Alcotest.test_case "invalid_min_answered" `Quick
-            test_config_invalid_min_answered
         ; Alcotest.test_case "missing_default" `Quick test_config_missing_default
         ; Alcotest.test_case "missing_prompt" `Quick test_config_missing_prompt
         ; Alcotest.test_case "missing_judge_model" `Quick test_config_missing_judge_model
@@ -1767,9 +1709,7 @@ let () =
             test_judge_error_node_timed_out
         ] )
     ; ( "panel_guard"
-      , [ Alcotest.test_case "min_answered_range" `Quick test_validated_bad_min_answered
-        ; Alcotest.test_case "min_answered_constants" `Quick test_min_answered_constants
-        ; Alcotest.test_case "panels_unavailable_failure" `Quick
+      , [ Alcotest.test_case "panels_unavailable_failure" `Quick
             test_panels_unavailable_failure
         ] )
     ]

--- a/test/test_fusion_wake.ml
+++ b/test/test_fusion_wake.ml
@@ -198,7 +198,6 @@ let fusion_tool_policy () : Fusion_policy.t =
     ; judge_max_output_tokens = None
     ; meta_timeout_s = Fusion_policy.default_timeout_s
     ; judges = []
-    ; min_answered = Fusion_policy.default_min_answered
     ; judge_wave_budget_s = Float.max_float
     ; adaptive_timeout_factor = 1.0
     ; fallback_judge_model = None


### PR DESCRIPTION
## Outcome

Hard-deletes Fusion's execution-inert `min_answered` contract.

- removes the field and numeric defaults from `Fusion_policy.preset`
- removes TOML parsing, validation errors, JSON projection, and record wiring
- removes the obsolete range tests instead of preserving the deleted behavior
- retains the real structural rule already used by the orchestrator: zero answered panels is an explicit `No_panel_answers` failure
- leaves every non-empty set of returned panel answers for the LLM Judge to evaluate, without an arbitrary N-of-M gate

Repository-wide residue scan for the deleted names is clean.

Stack: #24584 -> #24593 -> #24599 -> #24602 -> #24608 -> this PR. Tracks #24579.

## Validation

- `ocamlformat --check` on every changed `.ml`/`.mli`
- `ocamlc -stop-after parsing` on every changed `.ml`/`.mli`
- `git diff --check`
- repository-wide `min_answered`/constructor/default residue scan: clean

Focused Dune was requested through `scripts/dune-local.sh`; it correctly refused because an unrelated bare Dune build was active. No override or fake green was used. Full build/test remains CI authority.
