### PR TITLE
fix(build): separate poll and cancel result matches

### DIFF
--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -782,18 +782,18 @@ let keeper_delegate_cancel_body ~(config : Workspace.config) ~caller args =
       Keeper_msg_async.cancel ~base_path:config.base_path ~caller run_id
     in
     let json = Keeper_invocation_contract.delegate_cancellation_to_json reference result in
-    match result with
-    | Keeper_msg_async.Cancellation_requested _ ->
-      tool_result_ok_data json
-    | Keeper_msg_async.Cancel_not_found
-    | Keeper_msg_async.Cancel_unreadable _
-    | Keeper_msg_async.Cancel_rejected _
-    | Keeper_msg_async.Cancel_worker_ownership_unknown _
-    | Keeper_msg_async.Cancel_already_terminal _
-    | Keeper_msg_async.Cancel_persistence_failed _
-    | Keeper_msg_async.Cancel_worker_signal_failed _
-    | Keeper_msg_async.Cancel_state_invariant_failed _ ->
-      tool_result_error_data json
+    (match result with
+     | Keeper_msg_async.Cancellation_requested _ ->
+       tool_result_ok_data json
+     | Keeper_msg_async.Cancel_not_found
+     | Keeper_msg_async.Cancel_unreadable _
+     | Keeper_msg_async.Cancel_rejected _
+     | Keeper_msg_async.Cancel_worker_ownership_unknown _
+     | Keeper_msg_async.Cancel_already_terminal _
+     | Keeper_msg_async.Cancel_persistence_failed _
+     | Keeper_msg_async.Cancel_worker_signal_failed _
+     | Keeper_msg_async.Cancel_state_invariant_failed _ ->
+       tool_result_error_data json)
      | Keeper_msg_async.Absent ->
        tool_result_error_data (Keeper_invocation_contract.delegate_cancellation_to_json reference Keeper_msg_async.Cancel_not_found)
      | Keeper_msg_async.Unreadable reason ->


### PR DESCRIPTION
## 문제

`main@df548c7` Health CI에서 `keeper_tool_surface_ops.ml:797`의 `Keeper_msg_async.Absent`가 `cancel_result` constructor로 해석되어 컴파일이 중단됩니다. 외부 `poll` match와 내부 `cancel` match의 경계가 괄호 없이 결합된 것이 원인입니다.

## 수정

- 내부 `cancel_result` match를 괄호로 명시적으로 종료
- `Absent`/`Unreadable`/`Rejected`를 외부 `load_result` match에 유지

## 검증

- `ocamlc -stop-after parsing lib/keeper/keeper_tool_surface_ops.ml`
- `ocamlformat --check lib/keeper/keeper_tool_surface_ops.ml`
- `git diff --check`
- 로컬 Dune 미실행; GitHub CI를 빌드 권위로 사용

# ci:skip-test-coverage

컴파일 불가능했던 기존 두 match의 구문 소유권만 명시하며 새 실행 경로나 동작을 추가하지 않습니다. 기존 cancel/poll 테스트의 컴파일과 CI build가 직접 회귀 증거입니다.