### PR TITLE
fix(connector): reject malformed continuation routes

### DIFF
--- a/lib/keeper_runtime/keeper_continuation_channel.ml
+++ b/lib/keeper_runtime/keeper_continuation_channel.ml
@@ -143,9 +143,10 @@ let string_field name fields =
 
 let optional_string_field name fields =
   match List.assoc_opt name fields with
-  | Some (`String s) when String.trim s <> "" -> Some s
-  | Some (`String _) | Some `Null | None -> None
-  | Some _ -> None
+  | Some (`String s) when String.trim s <> "" -> Ok (Some s)
+  | Some (`String _) | Some `Null | None -> Ok None
+  | Some _ ->
+    Error (Printf.sprintf "continuation_channel: field %s must be a string or null" name)
 
 let of_yojson json =
   let* fields = assoc_fields json in
@@ -157,26 +158,27 @@ let of_yojson json =
   | "discord" ->
     let* channel_id = string_field "channel_id" fields in
     let* user_id = string_field "user_id" fields in
+    let* guild_id = optional_string_field "guild_id" fields in
+    let* parent_channel_id = optional_string_field "parent_channel_id" fields in
+    let* thread_id = optional_string_field "thread_id" fields in
     Ok
       (Discord
-         { guild_id = optional_string_field "guild_id" fields
+         { guild_id
          ; channel_id
-         ; parent_channel_id = optional_string_field "parent_channel_id" fields
-         ; thread_id = optional_string_field "thread_id" fields
+         ; parent_channel_id
+         ; thread_id
          ; user_id
          })
   | "slack" ->
-    let* channel_id =
-      match string_field "channel_id" fields with
-      | Ok value -> Ok value
-      | Error _ -> string_field "channel" fields
-    in
+    let* channel_id = string_field "channel_id" fields in
     let* user_id = string_field "user_id" fields in
+    let* team_id = optional_string_field "team_id" fields in
+    let* thread_ts = optional_string_field "thread_ts" fields in
     Ok
       (Slack
-         { team_id = optional_string_field "team_id" fields
+         { team_id
          ; channel_id
-         ; thread_ts = optional_string_field "thread_ts" fields
+         ; thread_ts
          ; user_id
          })
   | "unrouted" ->

--- a/lib/keeper_runtime/keeper_continuation_channel.ml
+++ b/lib/keeper_runtime/keeper_continuation_channel.ml
@@ -137,14 +137,18 @@ let assoc_fields = function
 
 let string_field name fields =
   match List.assoc_opt name fields with
-  | Some (`String s) -> Ok s
+  | Some (`String s) when not (String.equal (String.trim s) "") -> Ok s
+  | Some (`String _) ->
+    Error (Printf.sprintf "continuation_channel: field %s must not be blank" name)
   | Some _ -> Error (Printf.sprintf "continuation_channel: field %s must be a string" name)
   | None -> Error (Printf.sprintf "continuation_channel: missing field %s" name)
 
 let optional_string_field name fields =
   match List.assoc_opt name fields with
-  | Some (`String s) when String.trim s <> "" -> Ok (Some s)
-  | Some (`String _) | Some `Null | None -> Ok None
+  | Some (`String s) when not (String.equal (String.trim s) "") -> Ok (Some s)
+  | Some (`String _) ->
+    Error (Printf.sprintf "continuation_channel: field %s must not be blank" name)
+  | Some `Null | None -> Ok None
   | Some _ ->
     Error (Printf.sprintf "continuation_channel: field %s must be a string or null" name)
 

--- a/lib/keeper_runtime/keeper_continuation_channel.mli
+++ b/lib/keeper_runtime/keeper_continuation_channel.mli
@@ -56,6 +56,8 @@ val same_route : t -> t -> bool
 val to_yojson : t -> Yojson.Safe.t
 
 (** [of_yojson json] parses a tagged object produced by {!to_yojson}. A
-    missing or unknown ["kind"], or a missing field, is an [Error]; there is
-    no permissive default (RFC-0320 §2 fail-closed). *)
+    missing or unknown ["kind"], a missing required field, or a non-string
+    connector coordinate is an [Error]. Only absent, null, or empty optional
+    coordinates become [None]; there are no field aliases or permissive
+    defaults (RFC-0320 §2 fail-closed). *)
 val of_yojson : Yojson.Safe.t -> (t, string) result

--- a/lib/keeper_runtime/keeper_continuation_channel.mli
+++ b/lib/keeper_runtime/keeper_continuation_channel.mli
@@ -56,8 +56,8 @@ val same_route : t -> t -> bool
 val to_yojson : t -> Yojson.Safe.t
 
 (** [of_yojson json] parses a tagged object produced by {!to_yojson}. A
-    missing or unknown ["kind"], a missing required field, or a non-string
-    connector coordinate is an [Error]. Only absent, null, or empty optional
-    coordinates become [None]; there are no field aliases or permissive
-    defaults (RFC-0320 §2 fail-closed). *)
+    missing or unknown ["kind"], a missing or blank required field, or a
+    blank/non-string connector coordinate is an [Error]. Only absent or null
+    optional coordinates become [None]; there are no field aliases or
+    permissive defaults (RFC-0320 §2 fail-closed). *)
 val of_yojson : Yojson.Safe.t -> (t, string) result

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -576,12 +576,8 @@ let payload_to_yojson = function
       ]
 
 let continuation_channel_field fields =
-  match List.assoc_opt "channel" fields with
-  | None ->
-    (* Backward compat: pre-RFC-0320 persisted stimuli carry no channel; a
-       replayed legacy wake is [Unrouted] rather than a parse failure. *)
-    Ok (Keeper_continuation_channel.unrouted "legacy: channel not captured")
-  | Some json -> Keeper_continuation_channel.of_yojson json
+  let* json = required_field ~context:"stimulus.payload" "channel" fields in
+  Keeper_continuation_channel.of_yojson json
 
 let payload_of_yojson json =
   let context = "stimulus.payload" in
@@ -625,11 +621,6 @@ let payload_of_yojson json =
     let* ok = bool_field ~context "ok" fields in
     let* resolved_answer = string_field ~context "resolved_answer" fields in
     let* board_post_id = string_field ~context "board_post_id" fields in
-    (* [Fusion_completed] predates the reply-channel field and was persisted
-       without it, so a legacy snapshot row must replay as [Unrouted] rather
-       than failing the whole snapshot parse (which recovers to an empty queue,
-       dropping every co-resident stimulus). Same lenient contract as the
-       sibling [Connector_attention]/[Hitl_resolved] rows. *)
     let* channel = continuation_channel_field fields in
     Ok (Fusion_completed { run_id; ok; resolved_answer; board_post_id; channel })
   | "bg_completed" ->

--- a/test/keeper_continuation_channel/test_keeper_continuation_channel.ml
+++ b/test/keeper_continuation_channel/test_keeper_continuation_channel.ml
@@ -2,7 +2,7 @@
 
    Covers the closed-variant contract:
      - codec round-trips for every constructor,
-     - fail-closed parsing (unknown kind / missing field / non-object -> Error),
+     - fail-closed parsing (unknown kind / missing or malformed field / legacy alias -> Error),
      - the routing helpers (is_routable, kind_label, same_route). *)
 
 open Keeper_continuation_channel
@@ -46,6 +46,63 @@ let test_missing_field_is_error () =
   (* discord requires user_id *)
   expect_error "missing discord user_id"
     (`Assoc [ ("kind", `String "discord"); ("channel_id", `String "C") ])
+
+let test_optional_route_coordinates_are_strict () =
+  List.iter
+    (fun (label, json) -> expect_error label json)
+    [ ( "discord guild_id wrong type"
+      , `Assoc
+          [ "kind", `String "discord"
+          ; "channel_id", `String "C"
+          ; "user_id", `String "U"
+          ; "guild_id", `Int 1
+          ] )
+    ; ( "discord parent_channel_id wrong type"
+      , `Assoc
+          [ "kind", `String "discord"
+          ; "channel_id", `String "C"
+          ; "user_id", `String "U"
+          ; "parent_channel_id", `Bool true
+          ] )
+    ; ( "discord thread_id wrong type"
+      , `Assoc
+          [ "kind", `String "discord"
+          ; "channel_id", `String "C"
+          ; "user_id", `String "U"
+          ; "thread_id", `List []
+          ] )
+    ; ( "slack team_id wrong type"
+      , `Assoc
+          [ "kind", `String "slack"
+          ; "channel_id", `String "C"
+          ; "user_id", `String "U"
+          ; "team_id", `Assoc []
+          ] )
+    ; ( "slack thread_ts wrong type"
+      , `Assoc
+          [ "kind", `String "slack"
+          ; "channel_id", `String "C"
+          ; "user_id", `String "U"
+          ; "thread_ts", `Float 1.0
+          ] )
+    ]
+
+let test_slack_legacy_channel_alias_is_rejected () =
+  expect_error
+    "legacy channel alias"
+    (`Assoc
+       [ "kind", `String "slack"
+       ; "channel", `String "C"
+       ; "user_id", `String "U"
+       ]);
+  expect_error
+    "invalid channel_id is not masked by alias"
+    (`Assoc
+       [ "kind", `String "slack"
+       ; "channel_id", `Int 1
+       ; "channel", `String "C"
+       ; "user_id", `String "U"
+       ])
 
 let test_missing_kind_is_error () =
   expect_error "missing kind" (`Assoc [ ("thread_id", `String "t") ])
@@ -146,6 +203,8 @@ let () =
   test_codec_roundtrip ();
   test_unknown_kind_is_error ();
   test_missing_field_is_error ();
+  test_optional_route_coordinates_are_strict ();
+  test_slack_legacy_channel_alias_is_rejected ();
   test_missing_kind_is_error ();
   test_non_object_is_error ();
   test_is_routable ();

--- a/test/keeper_continuation_channel/test_keeper_continuation_channel.ml
+++ b/test/keeper_continuation_channel/test_keeper_continuation_channel.ml
@@ -43,6 +43,9 @@ let test_unknown_kind_is_error () =
 let test_missing_field_is_error () =
   (* dashboard requires thread_id *)
   expect_error "missing thread_id" (`Assoc [ ("kind", `String "dashboard") ]);
+  expect_error
+    "blank thread_id"
+    (`Assoc [ "kind", `String "dashboard"; "thread_id", `String "  " ]);
   (* discord requires user_id *)
   expect_error "missing discord user_id"
     (`Assoc [ ("kind", `String "discord"); ("channel_id", `String "C") ])
@@ -56,6 +59,13 @@ let test_optional_route_coordinates_are_strict () =
           ; "channel_id", `String "C"
           ; "user_id", `String "U"
           ; "guild_id", `Int 1
+          ] )
+    ; ( "discord guild_id blank"
+      , `Assoc
+          [ "kind", `String "discord"
+          ; "channel_id", `String "C"
+          ; "user_id", `String "U"
+          ; "guild_id", `String ""
           ] )
     ; ( "discord parent_channel_id wrong type"
       , `Assoc
@@ -84,6 +94,13 @@ let test_optional_route_coordinates_are_strict () =
           ; "channel_id", `String "C"
           ; "user_id", `String "U"
           ; "thread_ts", `Float 1.0
+          ] )
+    ; ( "slack thread_ts blank"
+      , `Assoc
+          [ "kind", `String "slack"
+          ; "channel_id", `String "C"
+          ; "user_id", `String "U"
+          ; "thread_ts", `String " "
           ] )
     ]
 

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -255,11 +255,9 @@ let () =
          ; channel = Keeper_continuation_channel.unrouted "test fixture"
          })
       "post-1");
-  (* Reply-route parity: the fusion wake serializes its originating channel,
-     and — like the sibling Connector_attention/Hitl_resolved rows — a legacy
-     Fusion_completed row persisted before the channel field existed replays as
-     [Unrouted] rather than failing the snapshot parse (a parse failure recovers
-     to an empty queue, dropping every co-resident stimulus). *)
+  (* Reply-route parity: every continuation-bearing wake serializes its exact
+     originating channel. A missing route is malformed durable state, not an
+     implicit [Unrouted] destination. *)
   (let routed : Keeper_event_queue.fusion_completion =
      { run_id = "fus-routed"
      ; ok = true
@@ -292,8 +290,8 @@ let () =
         | _ -> false)
     | Ok _ -> assert false
     | Error e -> failwith e);
-   let missing_channel_json =
-     match stimulus_to_yojson stim with
+   let without_payload_channel stimulus =
+     match stimulus_to_yojson stimulus with
      | `Assoc fields ->
        `Assoc
          (List.map
@@ -312,20 +310,30 @@ let () =
             fields)
      | other -> other
    in
-   match stimulus_of_yojson missing_channel_json with
-   | Ok { payload = Fusion_completed fc; _ } ->
-     assert (
-       match fc.channel with
-       | Keeper_continuation_channel.Unrouted { reason } ->
-         String.equal reason "legacy: channel not captured"
-       | _ -> false)
-   | Ok _ -> failwith "legacy fusion row must decode as Fusion_completed"
-   | Error e ->
-     failwith
-       (Printf.sprintf
-          "legacy fusion row without a channel key must replay Unrouted, not \
-           fail closed: %s"
-          e));
+   List.iter
+     (fun (label, stimulus) ->
+        match stimulus_of_yojson (without_payload_channel stimulus) with
+        | Error _ -> ()
+        | Ok _ -> failwith (label ^ " without channel must fail explicitly"))
+     [ "fusion completion", stim
+     ; ( "connector attention"
+       , { stim with
+           post_id = "connector-route"
+         ; payload =
+             Connector_attention
+               { event_id = "connector-route"; channel = routed.channel }
+         } )
+     ; ( "HITL resolution"
+       , { stim with
+           post_id = "hitl:approval-route"
+         ; payload =
+             Hitl_resolved
+               { approval_id = "approval-route"
+               ; decision = Hitl_approved
+               ; channel = routed.channel
+               }
+         } )
+     ]);
   assert (
     String.equal
       (fusion_completion_post_id

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -1640,45 +1640,4 @@ let () =
       in
       assert (String.equal second.post_id "bootstrap"));
 
-  (* RFC-0320 backward compat: pre-W2 persisted stimuli have no [channel] in
-     their payload and must replay as [Unrouted], not fail — a restart
-     replaying a legacy wake queue must not break. Simulate by serializing a W2
-     stimulus then stripping the [channel] field before parsing back. *)
-  (let strip_channel json =
-     match json with
-     | `Assoc top ->
-       `Assoc
-         (List.map
-            (fun (k, v) ->
-              if String.equal k "payload" then
-                ( k
-                , match v with
-                  | `Assoc p ->
-                    `Assoc
-                      (List.filter (fun (pk, _) -> not (String.equal pk "channel")) p)
-                  | other -> other )
-              else (k, v))
-            top)
-     | other -> other
-   in
-   let hitl_stim =
-     { post_id = "p-legacy"
-     ; urgency = Immediate
-     ; arrived_at = 1.0
-     ; payload =
-         Hitl_resolved
-           { approval_id = "a"
-           ; decision = Hitl_approved
-           ; channel = Keeper_continuation_channel.unrouted "seed"
-           }
-     }
-   in
-   match stimulus_of_yojson (strip_channel (stimulus_to_yojson hitl_stim)) with
-   | Ok s ->
-     (match s.payload with
-      | Hitl_resolved r ->
-        assert (not (Keeper_continuation_channel.is_routable r.channel))
-      | _ -> assert false)
-   | Error _ -> assert false);
-
   print_endline "test_keeper_event_queue: all passed"


### PR DESCRIPTION
## Summary
- reject malformed continuation route fields instead of silently dropping them
- require persisted channel coordinates for Fusion, connector-attention, and HITL wakes
- reject blank required and optional coordinates; only absent/null optional fields become `None`

## Boundary proof
- continuation routing is a closed typed decode boundary
- Slack accepts only canonical `channel_id`; no alias/string repair remains
- explicit `Unrouted` stays representable, while routed variants cannot exist without their required coordinate
- no synthetic legacy channel is created

## Verification
- `ocamlformat --check` on touched OCaml files
- `ocamlc -stop-after parsing -c` on touched OCaml files
- focused Connector/Gate stack build at the final stacked head
- `git diff --check`

Rebased onto current `main`.
