### PR TITLE
fix(test): supply publication_recovery_provider in restored compact-recovery context

### DIFF
--- a/test/test_keeper_compact_recovery_tool_surface.ml
+++ b/test/test_keeper_compact_recovery_tool_surface.ml
@@ -57,6 +57,9 @@ let test_missing_checkpoint_is_typed_tool_failure () =
         ; clock = Eio.Stdenv.clock env
         ; proc_mgr = None
         ; net = None
+        ; publication_recovery_provider =
+            Keeper_publication_recovery_availability.constant
+              Keeper_publication_recovery_availability.Non_runtime
         }
       in
       match


### PR DESCRIPTION
main @check의 마지막 잔여 컴파일 에러 수리(#24596 복원 테스트가 신규 필드 이전 작성). 로컬 증거: main 8fc37c9637 + 본 1줄 = `dune build @check` 클린. 러너 포화(28 queued)로 CI 지연 예상 — 로컬 검증 근거로 즉시 머지 대상.