### PR TITLE
refactor(schedule): type exact occurrence identity

### DIFF
--- a/dashboard/src/api/dashboard-tools-prompts.ts
+++ b/dashboard/src/api/dashboard-tools-prompts.ts
@@ -152,7 +152,7 @@ export interface DashboardScheduledAutomationActor {
 }
 
 export interface DashboardScheduledAutomationSignal {
-  signal_id: string
+  occurrence_id: string
   kind: string
   event_type?: string
   schedule_id: string

--- a/dashboard/src/components/schedule/schedule-surface.test.ts
+++ b/dashboard/src/components/schedule/schedule-surface.test.ts
@@ -55,7 +55,7 @@ function sampleAutomation(): DashboardScheduledAutomation {
     signal_count: 1,
     signals: [
       {
-        signal_id: 'sig-1',
+        occurrence_id: 'sig-1',
         kind: 'schedule.due_candidate',
         event_type: 'schedule.due_candidate',
         schedule_id: 'sched-1',

--- a/dashboard/src/components/tools/scheduled-automation-panel.test.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.test.ts
@@ -37,11 +37,11 @@ function automation(
 }
 
 function signal(
-  overrides: Partial<DashboardScheduledAutomationSignal> & { signal_id: string; schedule_id: string },
+  overrides: Partial<DashboardScheduledAutomationSignal> & { occurrence_id: string; schedule_id: string },
 ): DashboardScheduledAutomationSignal {
-  const { signal_id, schedule_id, ...rest } = overrides
+  const { occurrence_id, schedule_id, ...rest } = overrides
   return {
-    signal_id,
+    occurrence_id,
     kind: 'schedule.due_candidate',
     schedule_id,
     emitted_at_iso: '2026-06-21T00:00:00Z',
@@ -838,17 +838,17 @@ describe('ScheduledAutomationPanel', () => {
     auto.signal_count = 3
     auto.signals = [
       signal({
-        signal_id: 'sig-supported',
+        occurrence_id: 'sig-supported',
         schedule_id: 'sched-supported',
         payload_kind: 'keeper.smoke',
       }),
       signal({
-        signal_id: 'sig-unsupported',
+        occurrence_id: 'sig-unsupported',
         schedule_id: 'sched-unsupported',
         payload_kind: 'orphan_auto_release',
       }),
       signal({
-        signal_id: 'sig-unknown',
+        occurrence_id: 'sig-unknown',
         schedule_id: 'sched-unknown',
         payload_kind: 'keeper.future',
       }),
@@ -894,17 +894,17 @@ describe('ScheduledAutomationPanel', () => {
     auto.signal_count = 3
     auto.signals = [
       signal({
-        signal_id: 'sig-supported',
+        occurrence_id: 'sig-supported',
         schedule_id: 'sched-supported',
         payload_kind: 'keeper.smoke',
       }),
       signal({
-        signal_id: 'sig-unsupported-missing-row',
+        occurrence_id: 'sig-unsupported-missing-row',
         schedule_id: 'sched-unsupported-missing-row',
         payload_kind: 'orphan_auto_release',
       }),
       signal({
-        signal_id: 'sig-unknown-missing-row',
+        occurrence_id: 'sig-unknown-missing-row',
         schedule_id: 'sched-unknown-missing-row',
       }),
     ]
@@ -946,12 +946,12 @@ describe('ScheduledAutomationPanel', () => {
     auto.signal_count = 2
     auto.signals = [
       signal({
-        signal_id: 'sig-unsupported-only',
+        occurrence_id: 'sig-unsupported-only',
         schedule_id: 'sched-unsupported-only',
         payload_kind: 'orphan_auto_release',
       }),
       signal({
-        signal_id: 'sig-unknown-only',
+        occurrence_id: 'sig-unknown-only',
         schedule_id: 'sched-unknown-only',
       }),
     ]
@@ -1161,7 +1161,7 @@ describe('ScheduledAutomationPanel', () => {
     automation.signal_limit = 20
     automation.signals = [
       {
-        signal_id: 'sig-due-1',
+        occurrence_id: 'sig-due-1',
         kind: 'schedule.due_candidate',
         event_type: 'schedule.due_candidate',
         schedule_id: 'sched-run-smoke',

--- a/dashboard/src/components/tools/scheduled-automation-panel.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.ts
@@ -969,12 +969,12 @@ function DurableSignalItem({
   return html`
     <li
       class="grid grid-cols-[3.25rem_minmax(0,1fr)] items-start gap-x-3 gap-y-1 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-3 py-2 sm:grid-cols-[3.25rem_minmax(0,1fr)_auto]"
-      data-schedule-signal-id=${signal.signal_id}
+      data-schedule-signal-id=${signal.occurrence_id}
     >
       <span
         class="font-mono text-3xs text-[var(--color-fg-muted)]"
         title=${formatDateTimeKo(emittedIso)}
-        data-schedule-signal-at=${signal.signal_id}
+        data-schedule-signal-at=${signal.occurrence_id}
       >
         ${compactTimeLabel(emittedIso)}
       </span>
@@ -994,7 +994,7 @@ function DurableSignalItem({
           </button>
         </div>
         <div class="mt-1 grid gap-0.5 text-3xs text-[var(--color-fg-disabled)]">
-          <div class="truncate font-mono" title=${signal.signal_id}>${signal.signal_id}</div>
+          <div class="truncate font-mono" title=${signal.occurrence_id}>${signal.occurrence_id}</div>
           <div class="truncate" title=${formatDateTimeKo(dueIso)}>
             due ${formatDateTimeKo(dueIso)}
           </div>
@@ -1910,8 +1910,8 @@ function SchedulePrototypeSurface({
                 ${durableSignals.map(signal => {
                   const spec = statusSpecForLive(signal.kind)
                   return html`
-                    <div class="sch-sig" data-schedule-signal-id=${signal.signal_id}>
-                      <span class="sch-sig-at mono" data-schedule-signal-at=${signal.signal_id}>${compactTimeLabel(signal.emitted_at_iso ?? signal.due_at_iso ?? null)}</span>
+                    <div class="sch-sig" data-schedule-signal-id=${signal.occurrence_id}>
+                      <span class="sch-sig-at mono" data-schedule-signal-at=${signal.occurrence_id}>${compactTimeLabel(signal.emitted_at_iso ?? signal.due_at_iso ?? null)}</span>
                       <span class=${`sch-sig-kind ${spec.cls}`} data-schedule-signal-kind=${signal.kind}>${enumLabel(signal.kind || signal.event_type)}</span>
                       <button
                         type="button"

--- a/lib/schedule/dune
+++ b/lib/schedule/dune
@@ -10,6 +10,7 @@
  (wrapped false)
  (modules
   schedule_domain
+  schedule_occurrence_id
   schedule_supported_kinds
   schedule_store
   schedule_service

--- a/lib/schedule/schedule_occurrence_id.ml
+++ b/lib/schedule/schedule_occurrence_id.ml
@@ -1,0 +1,15 @@
+type t = string
+
+let stable_float value = Printf.sprintf "%.17g" value
+let protocol_tag = "schedule.due_candidate"
+
+let make ~schedule_id ~due_at ~payload_digest =
+  String.concat
+    "|"
+    [ protocol_tag; schedule_id; stable_float due_at; payload_digest ]
+  |> Digestif.SHA256.digest_string
+  |> Digestif.SHA256.to_hex
+;;
+
+let equal = String.equal
+let to_string value = value

--- a/lib/schedule/schedule_occurrence_id.mli
+++ b/lib/schedule/schedule_occurrence_id.mli
@@ -1,0 +1,11 @@
+(** Exact identity of one scheduled occurrence.
+
+    The identity is derived only from persisted schedule facts. Dispatch
+    attempts may fail and retry, but they retain the same occurrence identity. *)
+
+type t = private string
+
+val protocol_tag : string
+val make : schedule_id:string -> due_at:float -> payload_digest:string -> t
+val equal : t -> t -> bool
+val to_string : t -> string

--- a/lib/schedule/schedule_runner.ml
+++ b/lib/schedule/schedule_runner.ml
@@ -6,7 +6,7 @@ type signal_kind =
   | Due_candidate
 
 type wake_signal =
-  { signal_id : string
+  { occurrence_id : Schedule_occurrence_id.t
   ; kind : signal_kind
   ; schedule_id : string
   ; emitted_at : float
@@ -29,7 +29,8 @@ and dispatch_status =
   | Dispatch_start_rejected
 
 and dispatch_result =
-  { schedule_id : string
+  { occurrence_id : Schedule_occurrence_id.t
+  ; schedule_id : string
   ; status : dispatch_status
   ; detail : Yojson.Safe.t option
   ; error : string option
@@ -61,12 +62,13 @@ let runner_error_to_string = function
 ;;
 
 let signal_kind_to_string = function
-  | Due_candidate -> "schedule.due_candidate"
+  | Due_candidate -> Schedule_occurrence_id.protocol_tag
 ;;
 
-let signal_kind_of_string = function
-  | "schedule.due_candidate" -> Ok Due_candidate
-  | other -> Error ("unknown schedule signal kind: " ^ other)
+let signal_kind_of_string value =
+  if String.equal value Schedule_occurrence_id.protocol_tag
+  then Ok Due_candidate
+  else Error ("unknown schedule signal kind: " ^ value)
 ;;
 
 let dispatch_status_to_string = function
@@ -112,7 +114,7 @@ let assoc_field name fields =
 let wake_signal_to_yojson signal =
   `Assoc
     [ "event_type", `String (signal_kind_to_string signal.kind)
-    ; "signal_id", `String signal.signal_id
+    ; "occurrence_id", `String (Schedule_occurrence_id.to_string signal.occurrence_id)
     ; "schedule_id", `String signal.schedule_id
     ; "emitted_at", `Float signal.emitted_at
     ; "due_at", `Float signal.due_at
@@ -125,37 +127,48 @@ let wake_signal_of_yojson = function
   | `Assoc fields ->
     let* kind_name = string_field "event_type" fields in
     let* kind = signal_kind_of_string kind_name in
-    let* signal_id = string_field "signal_id" fields in
+    let* occurrence_id = string_field "occurrence_id" fields in
     let* schedule_id = string_field "schedule_id" fields in
     let* emitted_at = float_field "emitted_at" fields in
     let* due_at = float_field "due_at" fields in
     let* payload_digest = string_field "payload_digest" fields in
     let* payload = assoc_field "payload" fields in
-    Ok { signal_id; kind; schedule_id; emitted_at; due_at; payload_digest; payload }
+    let* decoded_payload = Schedule_domain.payload_of_yojson payload in
+    let actual_payload_digest = Schedule_domain.payload_digest decoded_payload in
+    let* () =
+      if String.equal payload_digest actual_payload_digest
+      then Ok ()
+      else Error "payload_digest does not match schedule occurrence payload"
+    in
+    let expected_occurrence_id =
+      Schedule_occurrence_id.make ~schedule_id ~due_at ~payload_digest
+    in
+    if String.equal occurrence_id (Schedule_occurrence_id.to_string expected_occurrence_id)
+    then
+      Ok
+        { occurrence_id = expected_occurrence_id
+        ; kind
+        ; schedule_id
+        ; emitted_at
+        ; due_at
+        ; payload_digest
+        ; payload
+        }
+    else Error "occurrence_id does not match schedule occurrence facts"
   | _ -> Error "expected schedule wake_signal object"
 ;;
 
-let sha256_string value =
-  Digestif.SHA256.(digest_string value |> to_hex)
-;;
-
-let stable_float value = Printf.sprintf "%.17g" value
-
-let signal_id kind (request : Schedule_domain.schedule_request) =
+let occurrence_id (request : Schedule_domain.schedule_request) =
   let payload_digest = Schedule_domain.payload_digest request.payload in
-  String.concat
-    "|"
-    [ signal_kind_to_string kind
-    ; request.schedule_id
-    ; stable_float request.due_at
-    ; payload_digest
-    ]
-  |> sha256_string
+  Schedule_occurrence_id.make
+    ~schedule_id:request.schedule_id
+    ~due_at:request.due_at
+    ~payload_digest
 ;;
 
 let make_signal ~now kind (request : Schedule_domain.schedule_request) =
   let payload_digest = Schedule_domain.payload_digest request.payload in
-  { signal_id = signal_id kind request
+  { occurrence_id = occurrence_id request
   ; kind
   ; schedule_id = request.schedule_id
   ; emitted_at = now
@@ -214,12 +227,13 @@ let append_new_signals config candidates =
       | [] ->
         write_seen config (List.rev !seen_rev);
         Ok (List.rev !emitted_rev)
-      | signal :: rest ->
-        if Hashtbl.mem seen_tbl signal.signal_id then loop rest
+      | (signal : wake_signal) :: rest ->
+        let occurrence_id = Schedule_occurrence_id.to_string signal.occurrence_id in
+        if Hashtbl.mem seen_tbl occurrence_id then loop rest
         else (
           let* () = append_signal config signal in
-          Hashtbl.replace seen_tbl signal.signal_id ();
-          seen_rev := signal.signal_id :: !seen_rev;
+          Hashtbl.replace seen_tbl occurrence_id ();
+          seen_rev := occurrence_id :: !seen_rev;
           emitted_rev := signal :: !emitted_rev;
           loop rest)
     in
@@ -234,13 +248,13 @@ let candidates ~now state =
   |> List.map (fun request -> request, make_signal ~now Due_candidate request)
 ;;
 
-let dispatch_result ?detail ?error schedule_id status =
-  { schedule_id; status; detail; error }
+let dispatch_result ?detail ?error occurrence_id schedule_id status =
+  { occurrence_id; schedule_id; status; detail; error }
 ;;
 
-let finish_terminal_dispatch config ~now ~schedule_id error =
+let finish_terminal_dispatch config ~now ~occurrence_id ~schedule_id error =
   match Schedule_store.fail_running config ~now ~schedule_id ~error with
-  | Ok _ -> dispatch_result ~error schedule_id Dispatch_failed
+  | Ok _ -> dispatch_result ~error occurrence_id schedule_id Dispatch_failed
   | Error err ->
     let error =
       Printf.sprintf
@@ -248,14 +262,14 @@ let finish_terminal_dispatch config ~now ~schedule_id error =
         error
         (Schedule_store.store_error_to_string err)
     in
-    dispatch_result ~error schedule_id Dispatch_failed
+    dispatch_result ~error occurrence_id schedule_id Dispatch_failed
 ;;
 
-let finish_retryable_dispatch config ~now ~schedule_id detail =
+let finish_retryable_dispatch config ~now ~occurrence_id ~schedule_id detail =
   let reason = Schedule_store.Retryable_dispatch_failure detail in
   let error = Schedule_store.running_recovery_reason_to_string reason in
   match Schedule_store.retry_running config ~now ~schedule_id ~reason with
-  | Ok _ -> dispatch_result ~error schedule_id Dispatch_failed
+  | Ok _ -> dispatch_result ~error occurrence_id schedule_id Dispatch_failed
   | Error err ->
     let error =
       Printf.sprintf
@@ -263,7 +277,7 @@ let finish_retryable_dispatch config ~now ~schedule_id detail =
         error
         (Schedule_store.store_error_to_string err)
     in
-    dispatch_result ~error schedule_id Dispatch_failed
+    dispatch_result ~error occurrence_id schedule_id Dispatch_failed
 ;;
 
 let safe_consumer_dispatch config ~now consumer signal request =
@@ -279,14 +293,16 @@ let dispatch_candidate
       config
       ~now
       consumer
-      signal
+      (signal : wake_signal)
       (request : Schedule_domain.schedule_request)
   =
   let schedule_id = request.Schedule_domain.schedule_id in
+  let occurrence_id = signal.occurrence_id in
   match consumer.accepts request with
   | Error reason ->
     (match Schedule_store.fail_due_candidate config ~now ~schedule_id ~error:reason with
-     | Ok _ -> dispatch_result ~error:reason schedule_id Dispatch_unsupported
+     | Ok _ ->
+       dispatch_result ~error:reason occurrence_id schedule_id Dispatch_unsupported
      | Error err ->
        let error =
          Printf.sprintf
@@ -294,25 +310,26 @@ let dispatch_candidate
            reason
            (Schedule_store.store_error_to_string err)
        in
-       dispatch_result ~error schedule_id Dispatch_unsupported)
+       dispatch_result ~error occurrence_id schedule_id Dispatch_unsupported)
   | Ok () ->
     (match Schedule_store.start_due_candidate config ~now ~schedule_id with
      | Error err ->
-       dispatch_result ~error:(Schedule_store.store_error_to_string err) schedule_id
-         Dispatch_start_rejected
+       dispatch_result ~error:(Schedule_store.store_error_to_string err) occurrence_id
+         schedule_id Dispatch_start_rejected
      | Ok running_request ->
        (match safe_consumer_dispatch config ~now consumer signal running_request with
         | Error (Retryable_dispatch_failure detail) ->
-          finish_retryable_dispatch config ~now ~schedule_id detail
+          finish_retryable_dispatch config ~now ~occurrence_id ~schedule_id detail
         | Error (Terminal_dispatch_rejection detail) ->
-          finish_terminal_dispatch config ~now ~schedule_id detail
+          finish_terminal_dispatch config ~now ~occurrence_id ~schedule_id detail
         | Ok detail ->
           (match Schedule_store.complete_running config ~now ~schedule_id ~detail () with
-           | Ok _ -> dispatch_result ~detail schedule_id Dispatch_succeeded
+           | Ok _ ->
+             dispatch_result ~detail occurrence_id schedule_id Dispatch_succeeded
            | Error err ->
              dispatch_result ~detail
                ~error:(Schedule_store.store_error_to_string err)
-               schedule_id Dispatch_failed)))
+               occurrence_id schedule_id Dispatch_failed)))
 ;;
 
 let dispatch_candidates config ~now consumer candidates =

--- a/lib/schedule/schedule_runner.mli
+++ b/lib/schedule/schedule_runner.mli
@@ -9,7 +9,7 @@ type signal_kind =
   | Due_candidate
 
 type wake_signal =
-  { signal_id : string
+  { occurrence_id : Schedule_occurrence_id.t
   ; kind : signal_kind
   ; schedule_id : string
   ; emitted_at : float
@@ -32,7 +32,8 @@ and dispatch_status =
   | Dispatch_start_rejected
 
 and dispatch_result =
-  { schedule_id : string
+  { occurrence_id : Schedule_occurrence_id.t
+  ; schedule_id : string
   ; status : dispatch_status
   ; detail : Yojson.Safe.t option
   ; error : string option

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -15,6 +15,27 @@ let record_schedule_runner_tick_outcome outcome =
     ()
 ;;
 
+let log_schedule_dispatch (dispatch : Schedule_runner.dispatch_result) =
+  let occurrence_id =
+    Schedule_occurrence_id.to_string dispatch.occurrence_id
+  in
+  let status = Schedule_runner.dispatch_status_to_string dispatch.status in
+  match dispatch.error with
+  | None ->
+    Log.Server.info
+      "schedule_runner: occurrence=%s schedule_id=%s dispatch=%s"
+      occurrence_id
+      dispatch.schedule_id
+      status
+  | Some error ->
+    Log.Server.warn
+      "schedule_runner: occurrence=%s schedule_id=%s dispatch=%s error=%s"
+      occurrence_id
+      dispatch.schedule_id
+      status
+      error
+;;
+
 let wake_enqueue_counts_of_dispatches dispatches =
   let module Consumers = Server_schedule_consumers in
   let bump_wake_failed
@@ -283,6 +304,7 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
                ~finished_at
                result;
              record_schedule_runner_tick_outcome "ok";
+             List.iter log_schedule_dispatch result.dispatches;
              if result.Schedule_runner.emitted <> []
                 || result.rescheduled > 0
                 || result.dispatches <> []
@@ -293,6 +315,9 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
                  (List.length result.emitted)
                  result.rescheduled
                  (List.length result.dispatches)
+             else
+               Log.Server.debug
+                 "schedule_runner: idle due_changed=0 emitted=0 rescheduled=0 dispatched=0"
            | Error err ->
              let finished_at = Time_compat.now () in
              let error = Schedule_runner.runner_error_to_string err in

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -2734,7 +2734,8 @@ let schedule_signal_payload_kind_json (signal : Schedule_runner.wake_signal) =
 let schedule_signal_dashboard_json (signal : Schedule_runner.wake_signal) =
   let kind = Schedule_runner.signal_kind_to_string signal.kind in
   `Assoc
-    [ "signal_id", `String signal.signal_id
+    [ ( "occurrence_id"
+      , `String (Schedule_occurrence_id.to_string signal.occurrence_id) )
     ; "kind", `String kind
     ; "event_type", `String kind
     ; "schedule_id", `String signal.schedule_id

--- a/lib/server/server_schedule_consumers.ml
+++ b/lib/server/server_schedule_consumers.ml
@@ -339,7 +339,7 @@ let dispatch_keeper_wake
     }
   in
   let stimulus : Keeper_event_queue.stimulus =
-    { post_id = signal.signal_id
+    { post_id = Schedule_occurrence_id.to_string signal.occurrence_id
     ; urgency
     ; arrived_at = now
     ; payload = Keeper_event_queue.Schedule_due wake

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -194,9 +194,9 @@ let tick_ok config ~now =
   | Error err -> fail (Schedule_runner.runner_error_to_string err)
 ;;
 
-let single_signal_id (result : Schedule_runner.tick_result) =
+let single_occurrence_id (result : Schedule_runner.tick_result) =
   match result.emitted with
-  | [ signal ] -> signal.signal_id
+  | [ signal ] -> Schedule_occurrence_id.to_string signal.occurrence_id
   | signals ->
     failf "expected one emitted schedule occurrence, got %d" (List.length signals)
 ;;
@@ -237,7 +237,7 @@ let test_keeper_wake_consumer_enqueues_typed_stimulus_and_succeeds_schedule () =
   @@ fun config ->
   let request = create_keeper_wake_schedule config in
   let result = tick_ok config ~now:201.0 in
-  let occurrence_id = single_signal_id result in
+  let occurrence_id = single_occurrence_id result in
   check int "one dispatch" 1 (List.length result.dispatches);
   check string "dispatch status" "succeeded"
     (Schedule_runner.dispatch_status_to_string (List.hd result.dispatches).status);
@@ -365,8 +365,8 @@ let test_recurring_wakes_keep_distinct_occurrence_ids () =
       ~recurrence:(Schedule_domain.Interval { interval_sec = 60 })
       config
   in
-  let first_id = tick_ok config ~now:201.0 |> single_signal_id in
-  let second_id = tick_ok config ~now:261.0 |> single_signal_id in
+  let first_id = tick_ok config ~now:201.0 |> single_occurrence_id in
+  let second_id = tick_ok config ~now:261.0 |> single_occurrence_id in
   check bool "recurrences have distinct identities" false (String.equal first_id second_id);
   let queued =
     Keeper_registry_event_queue.snapshot
@@ -392,7 +392,7 @@ let test_keeper_wake_durable_enqueue_failure_retries_same_occurrence () =
   write_empty_file keeper_owner_path;
   let request = create_keeper_wake_schedule config in
   let result = tick_ok config ~now:201.0 in
-  let occurrence_id = single_signal_id result in
+  let occurrence_id = single_occurrence_id result in
   (match List.hd result.dispatches with
    | { status = Schedule_runner.Dispatch_failed; error = Some message; _ } ->
      check bool "storage failure is explicit" true
@@ -515,7 +515,7 @@ let test_keeper_wake_queue_evidence_rejects_stale_occurrence () =
   let keeper_name = "schedule-keeper" in
   let base_path = config.Workspace_utils.base_path in
   let request = create_keeper_wake_schedule config in
-  let occurrence_id = tick_ok config ~now:201.0 |> single_signal_id in
+  let occurrence_id = tick_ok config ~now:201.0 |> single_occurrence_id in
   (match
      Keeper_registry_event_queue.drop_by_post_id
        ~base_path
@@ -650,7 +650,7 @@ let test_keeper_wake_dashboard_tracks_runtime_inflight_lease () =
     (fun () ->
       let request = create_keeper_wake_schedule config in
       let result = tick_ok config ~now:201.0 in
-      let occurrence_id = single_signal_id result in
+      let occurrence_id = single_occurrence_id result in
       check int "one dispatch" 1 (List.length result.dispatches);
       check string "dispatch status" "succeeded"
         (Schedule_runner.dispatch_status_to_string (List.hd result.dispatches).status);

--- a/test/test_schedule_runner.ml
+++ b/test/test_schedule_runner.ml
@@ -75,6 +75,13 @@ let check_dispatch_status label expected actual =
   check string label (dispatch_status_to_string expected) (dispatch_status_to_string actual)
 ;;
 
+let test_occurrence_id schedule_id =
+  Schedule_occurrence_id.make
+    ~schedule_id
+    ~due_at:200.0
+    ~payload_digest:"test-payload"
+;;
+
 let read_recent_signals_exn config n =
   match read_recent_signals config n with
   | Ok signals -> signals
@@ -106,6 +113,11 @@ let json_float key json =
   | Some (`Int value) -> float_of_int value
   | Some other -> failf "field %s expected float, got %s" key (Yojson.Safe.to_string other)
   | None -> failf "missing float field %s" key
+;;
+
+let replace_json_field key value = function
+  | `Assoc fields -> `Assoc ((key, value) :: List.remove_assoc key fields)
+  | json -> json
 ;;
 
 let accepting_consumer ?(accept = Ok ()) ?dispatch_result calls =
@@ -155,6 +167,11 @@ let test_tick_dispatches_due_candidate_to_success () =
   check int "one dispatch" 1 (List.length result.dispatches);
   check_dispatch_status "dispatch status" Dispatch_succeeded
     (List.hd result.dispatches).status;
+  (match result.emitted, result.dispatches with
+   | [ signal ], [ dispatch ] ->
+     check bool "dispatch keeps exact occurrence identity" true
+       (Schedule_occurrence_id.equal signal.occurrence_id dispatch.occurrence_id)
+   | _ -> fail "expected one emitted and dispatched occurrence");
   check Alcotest.(list string) "consumer called" [ request.schedule_id ] !calls;
   (match Schedule_store.get_schedule config ~schedule_id:request.schedule_id with
    | None -> fail "schedule missing after dispatch"
@@ -343,7 +360,9 @@ let test_tick_retries_same_occurrence_without_blocking_other_schedule () =
     ; dispatch =
         (fun _config ~now:_ signal request ->
            if String.equal request.schedule_id retry_request.schedule_id then (
-             retry_signal_ids := signal.signal_id :: !retry_signal_ids;
+             retry_signal_ids :=
+               Schedule_occurrence_id.to_string signal.occurrence_id
+               :: !retry_signal_ids;
              if !retry_first_attempt then (
                retry_first_attempt := false;
                Error (Retryable_dispatch_failure "queue storage unavailable"))
@@ -358,7 +377,7 @@ let test_tick_retries_same_occurrence_without_blocking_other_schedule () =
   check int "healthy schedule dispatched once" 1 !healthy_calls;
   let occurrence_id =
     match !retry_signal_ids with
-    | [ signal_id ] -> signal_id
+    | [ occurrence_id ] -> occurrence_id
     | _ -> fail "retry schedule did not dispatch exactly once"
   in
   (match Schedule_store.get_schedule config ~schedule_id:retry_request.schedule_id with
@@ -396,13 +415,40 @@ let test_recent_signal_decode_error_is_explicit () =
     (Dated_jsonl.create ~base_dir:(signals_dir config) ())
     (`Assoc
       [ "event_type", `String "schedule.due_candidate"
-      ; "signal_id", `String "malformed"
+      ; "occurrence_id", `String "malformed"
       ]);
   match read_recent_signals config 10 with
   | Ok _ -> fail "malformed durable signal was silently ignored"
   | Error error ->
     check bool "decode error identifies row" true
       (String_util.contains_substring error "schedule signal row 0")
+;;
+
+let test_occurrence_decode_rejects_tampered_facts () =
+  with_workspace
+  @@ fun config ->
+  let _request = create_ok ~schedule_id:"codec-1" config in
+  let signal =
+    tick_ok config ~now:201.0 |> fun result -> List.hd result.emitted
+  in
+  let encoded = wake_signal_to_yojson signal in
+  (match wake_signal_of_yojson encoded with
+   | Ok decoded ->
+     check bool "round trip occurrence identity" true
+       (Schedule_occurrence_id.equal signal.occurrence_id decoded.occurrence_id)
+   | Error error -> fail error);
+  let tampered_id =
+    replace_json_field "occurrence_id" (`String "tampered") encoded
+  in
+  (match wake_signal_of_yojson tampered_id with
+   | Error _ -> ()
+   | Ok _ -> fail "tampered occurrence_id was accepted");
+  let tampered_payload =
+    replace_json_field "payload" (payload_json "different payload") encoded
+  in
+  match wake_signal_of_yojson tampered_payload with
+  | Error _ -> ()
+  | Ok _ -> fail "payload facts diverging from payload_digest were accepted"
 ;;
 
 let test_runner_status_snapshot_tracks_liveness () =
@@ -420,7 +466,8 @@ let test_runner_status_snapshot_tracks_liveness () =
     ; emitted = []
     ; rescheduled = 2
     ; dispatches =
-        [ { schedule_id = "status-1"
+        [ { occurrence_id = test_occurrence_id "status-1"
+          ; schedule_id = "status-1"
           ; status = Dispatch_succeeded
           ; detail = Some (`Assoc [ "ok", `Bool true ])
           ; error = None
@@ -454,17 +501,20 @@ let test_runner_status_snapshot_tracks_liveness () =
     ; emitted = []
     ; rescheduled = 0
     ; dispatches =
-        [ { schedule_id = "status-dispatch-failed"
+        [ { occurrence_id = test_occurrence_id "status-dispatch-failed"
+          ; schedule_id = "status-dispatch-failed"
           ; status = Dispatch_failed
           ; detail = None
           ; error = Some "dispatch failed"
           }
-        ; { schedule_id = "status-dispatch-unsupported"
+        ; { occurrence_id = test_occurrence_id "status-dispatch-unsupported"
+          ; schedule_id = "status-dispatch-unsupported"
           ; status = Dispatch_unsupported
           ; detail = None
           ; error = Some "unsupported"
           }
-        ; { schedule_id = "status-dispatch-start-rejected"
+        ; { occurrence_id = test_occurrence_id "status-dispatch-start-rejected"
+          ; schedule_id = "status-dispatch-start-rejected"
           ; status = Dispatch_start_rejected
           ; detail = None
           ; error = Some "start rejected"
@@ -551,6 +601,8 @@ let () =
             test_tick_retries_same_occurrence_without_blocking_other_schedule
         ; test_case "recent signal decode error is explicit" `Quick
             test_recent_signal_decode_error_is_explicit
+        ; test_case "occurrence decode rejects tampered facts" `Quick
+            test_occurrence_decode_rejects_tampered_facts
         ] )
     ; ( "status",
         [ test_case "tracks liveness snapshot" `Quick


### PR DESCRIPTION
## Summary

- replace the untyped schedule signal ID boundary with an opaque exact occurrence identity while preserving the existing deterministic identity value
- carry the same identity through durable wake rows, dispatch outcomes, Keeper queue stimuli, and dashboard projection
- reject durable rows whose payload digest or occurrence identity diverges from the persisted occurrence facts
- log every occurrence dispatch outcome with its exact identity and expose idle ticks at debug level

Part of #24553. This PR does not add recurrence or iCalendar parsing; it establishes the product-blind occurrence boundary those adapters can target.

## Verification

- rebased onto current `origin/main` (`25a1c593b5`)
- `scripts/dune-local.sh build test/test_schedule_runner.exe`
- `./_build/default/test/test_schedule_runner.exe` — 11/11 passed
- `ocamlformat --check lib/schedule/schedule_runner.ml`
- `ocamlc -stop-after parsing -impl lib/schedule/schedule_runner.ml`
- `git diff --check`
- 291 changed lines
