### PR TITLE
fix(build): set publication_recovery_provider in compact recovery test

### DIFF
--- a/test/test_keeper_compact_recovery_tool_surface.ml
+++ b/test/test_keeper_compact_recovery_tool_surface.ml
@@ -57,6 +57,8 @@ let test_missing_checkpoint_is_typed_tool_failure () =
         ; clock = Eio.Stdenv.clock env
         ; proc_mgr = None
         ; net = None
+        ; publication_recovery_provider =
+            Masc_test_deps.non_runtime_publication_recovery_provider
         }
       in
       match


### PR DESCRIPTION
## 증상

`dune build .`(dev 프로파일)이 main에서 실패:

```
File "test/test_keeper_compact_recovery_tool_surface.ml", lines 54-60:
Error: Some record fields are undefined: publication_recovery_provider
```

## 원인

`Keeper_tool_surface.context` 레코드에 필수 필드 `publication_recovery_provider`가
추가됐지만(최근 머지), `test_keeper_compact_recovery_tool_surface`의 context 리터럴은
업데이트되지 않아 레코드 필드 미정의로 컴파일이 깨졌습니다. red main 위에 머지가
계속돼 CI가 이미 red라 이 신규 파손이 묻혀 있었습니다.

## 수정

이 테스트는 `checkpoint_not_found` 실패 경로만 검증하므로 registry-backed provider가
불필요합니다. `Masc_test_deps.non_runtime_publication_recovery_provider`(무인자 상수)가
최소 정답이며, 이 스위트의 다른 `proc_mgr=None; net=None` context 리터럴들과 동일한 패턴입니다.

```
+ ; publication_recovery_provider =
+     Masc_test_deps.non_runtime_publication_recovery_provider
```

## 검증

- `dune build @check`(전 모듈 타입체크, dev 프로파일=CI와 동일 fatal-warning) **클린(exit 0)**.
  → 이 필드를 누락한 다른 사이트 없음(단일 파손 확정).
- 변경 범위: test 파일 1개, 2줄 추가. lib/런타임 무변경.

## 비고

워크어라운드 아님(red-merge가 빠뜨린 필수 필드 보충). RFC-gated subsystem 미해당(test 전용).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
