### PR TITLE
refactor(dashboard): consume typed Keeper run SSE

### DIFF
--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -126,6 +126,26 @@ function keeperRunRef(runId: string) {
     capability: 'invoke_turn',
   } as const
 }
+
+function keeperRunWire(runId: string) {
+  return {
+    run_id: runId,
+    target: { kind: 'keeper', name: 'echo' },
+    capability: 'invoke_turn',
+  } as const
+}
+
+function keeperQueueValue(runId: string) {
+  return {
+    tracking: {
+      kind: 'keeper_run',
+      run_ref: keeperRunWire(runId),
+      result_contract: 'awaiting_execution',
+    },
+    destination_type: 'keeper',
+    destination_id: 'echo',
+  } as const
+}
 import type { ChatBlock, KeeperConversationAttachment, KeeperStatusDetail } from './types'
 
 beforeEach(() => {
@@ -1232,7 +1252,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
       opts.onEvent({
         type: 'CUSTOM',
         name: 'KEEPER_QUEUE_REQUEST',
-        value: { request_id: 'kmsg_echo_1', status: 'queued' },
+        value: keeperQueueValue('kmsg_echo_1'),
       })
       return new Promise<{ terminal: boolean }>((_resolve, reject) => {
         opts.signal?.addEventListener('abort', () => { reject(abortError()) }, { once: true })
@@ -1282,7 +1302,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
       opts.onEvent({
         type: 'CUSTOM',
         name: 'KEEPER_QUEUE_REQUEST',
-        value: { request_id: 'kmsg_echo_cancelling', status: 'queued' },
+        value: keeperQueueValue('kmsg_echo_cancelling'),
       })
       return new Promise<{ terminal: boolean }>((_resolve, reject) => {
         opts.signal?.addEventListener('abort', () => { reject(abortError()) }, { once: true })
@@ -1333,7 +1353,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
       opts.onEvent({
         type: 'CUSTOM',
         name: 'KEEPER_QUEUE_REQUEST',
-        value: { request_id: 'kmsg_echo_cancel_persist_failure', status: 'queued' },
+        value: keeperQueueValue('kmsg_echo_cancel_persist_failure'),
       })
       return new Promise<{ terminal: boolean }>((_resolve, reject) => {
         opts.signal?.addEventListener('abort', () => { reject(abortError()) }, { once: true })
@@ -1376,7 +1396,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
       opts.onEvent({
         type: 'CUSTOM',
         name: 'KEEPER_QUEUE_REQUEST',
-        value: { request_id: 'kmsg_echo_retry', status: 'queued' },
+        value: keeperQueueValue('kmsg_echo_retry'),
       })
       return new Promise<{ terminal: boolean }>((_resolve, reject) => {
         opts.signal?.addEventListener('abort', () => { reject(abortError()) }, { once: true })
@@ -1412,7 +1432,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
       opts.onEvent({
         type: 'CUSTOM',
         name: 'KEEPER_QUEUE_REQUEST',
-        value: { request_id: 'kmsg_echo_hung_cancel', status: 'queued' },
+        value: keeperQueueValue('kmsg_echo_hung_cancel'),
       })
       return new Promise<{ terminal: boolean }>((_resolve, reject) => {
         opts.signal?.addEventListener('abort', () => { reject(abortError()) }, { once: true })
@@ -1469,7 +1489,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
         opts.onEvent({
           type: 'CUSTOM',
           name: 'KEEPER_QUEUE_REQUEST',
-          value: { request_id: 'kmsg_echo_late', status: 'queued' },
+          value: keeperQueueValue('kmsg_echo_late'),
         })
       }
       opts.signal?.addEventListener('abort', () => { reject(abortError()) }, { once: true })
@@ -1499,7 +1519,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
       opts.onEvent({
         type: 'CUSTOM',
         name: 'KEEPER_QUEUE_REQUEST',
-        value: { request_id: 'kmsg_echo_signal', status: 'running' },
+        value: keeperQueueValue('kmsg_echo_signal'),
       })
       throw abortError()
     })
@@ -1530,7 +1550,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
       opts.onEvent({
         type: 'CUSTOM',
         name: 'KEEPER_QUEUE_REQUEST',
-        value: { request_id: 'kmsg_echo_1', status: 'queued' },
+        value: keeperQueueValue('kmsg_echo_1'),
       })
       return new Promise<{ terminal: boolean }>(resolve => {
         resolveStream = resolve
@@ -1573,7 +1593,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
       opts.onEvent({
         type: 'CUSTOM',
         name: 'KEEPER_QUEUE_REQUEST',
-        value: { request_id: 'kmsg_echo_draft', status: 'queued' },
+        value: keeperQueueValue('kmsg_echo_draft'),
       })
       opts.onEvent({ type: 'TEXT_MESSAGE_START' })
       opts.onEvent({ type: 'TEXT_MESSAGE_CONTENT', delta: '부분 응답' })
@@ -1926,14 +1946,26 @@ describe('sendKeeperThreadMessage stream outcome', () => {
     expect(user?.id).not.toBe(assistant?.id)
   })
 
-  it('polls a queued request immediately when the stream cuts before terminal', async () => {
+  it.each([
+    { outcome: 'the stream cuts before terminal', terminal: false, terminalEvents: [] },
+    {
+      outcome: 'the server reports publication uncertainty',
+      terminal: true,
+      terminalEvents: [{
+        type: 'CUSTOM',
+        name: 'KEEPER_REQUEST_TERMINAL',
+        value: { run_ref: keeperRunWire('kmsg_echo_1'), result_contract: 'publication_uncertain' },
+      }] satisfies KeeperChatStreamEvent[],
+    },
+  ])('polls a queued request immediately when $outcome', async ({ terminal, terminalEvents }) => {
     streamKeeperMessage.mockImplementation(emitting([
       {
         type: 'CUSTOM',
         name: 'KEEPER_QUEUE_REQUEST',
-        value: { request_id: 'kmsg_echo_1', status: 'queued' },
+        value: keeperQueueValue('kmsg_echo_1'),
       },
-    ], false))
+      ...terminalEvents,
+    ], terminal))
     fetchQueuedKeeperMessageResult.mockResolvedValue({
       requestId: 'kmsg_echo_1',
       keeperName: 'echo',

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -24,7 +24,12 @@ import { keeperTurnOutcomeSuppressesReply } from './keeper-message'
 import { invalidateDashboardCache, refreshDashboard } from './store'
 import { isAbortError } from './lib/async-state'
 import { compareKeeperQueueRevisions } from './lib/keeper-chat-receipt'
-import { parseKeeperRunRef } from './lib/keeper-run-ref'
+import {
+  isTerminalKeeperRunResult,
+  parseKeeperRunRef,
+  parseKeeperRunTerminal,
+  parseKeeperRunTracking,
+} from './lib/keeper-run-ref'
 import type {
   ChatBlock,
   KeeperConversationAttachment,
@@ -72,7 +77,6 @@ import {
   abortKeeperThreadMessage,
   applyKeeperStreamEvent,
   flushPendingKeeperStreamDeltas,
-  TERMINAL_REQUEST_STATUSES,
 } from './keeper-stream'
 import {
   KEEPER_HISTORY_TAIL_MESSAGES,
@@ -1285,6 +1289,7 @@ export async function sendKeeperThreadMessage(
   setActiveStream(keeperName, assistantId, controller)
   let requestId: string | null = null
   let requestTerminalSeen = false
+  let requestNeedsReconciliation = false
   let toolCallEnded = false
   try {
     finalizeAssistantEntry(keeperName, localId, { delivery: 'delivered' })
@@ -1296,14 +1301,23 @@ export async function sendKeeperThreadMessage(
       onEvent: event => {
         markKeeperStreamSignal(keeperName)
         if (event.type === 'CUSTOM' && event.name === 'KEEPER_QUEUE_REQUEST') {
-          const nextRequestId = isRecord(event.value)
-            ? asString(event.value.request_id, '').trim()
-            : ''
-          if (!nextRequestId) {
-            const message = 'Keeper queue request event missing request_id; server cancel unavailable.'
+          let nextRequestId = ''
+          try {
+            const tracking = parseKeeperRunTracking(event.value)
+            if (tracking.resultContract !== 'awaiting_execution') {
+              throw new Error('Keeper queue tracking must be awaiting_execution')
+            }
+            if (tracking.runRef.target.name !== keeperName) {
+              throw new Error('Keeper queue tracking target does not match the active Keeper')
+            }
+            nextRequestId = tracking.runRef.runId
+          } catch (error) {
+            const detail = error instanceof Error ? error.message : String(error)
+            const message = `Keeper queue event has invalid typed run tracking: ${detail}`
             console.warn(`[keeper] ${message}`)
             setRecordValue(keeperActionErrors, keeperName, message)
-          } else if (controller.signal.aborted) {
+          }
+          if (nextRequestId && controller.signal.aborted) {
             requestId = nextRequestId
             const pendingRequest: PendingKeeperChatRequest = {
               requestId: nextRequestId,
@@ -1322,7 +1336,7 @@ export async function sendKeeperThreadMessage(
               }
               return undefined
             })
-          } else {
+          } else if (nextRequestId) {
             requestId = nextRequestId
             // This live send now owns the request; resume must defer to it
             // (and not mint a duplicate pending entry) until handoff/finally.
@@ -1336,14 +1350,26 @@ export async function sendKeeperThreadMessage(
             })
           }
         }
-        if (event.type === 'CUSTOM' && event.name === 'KEEPER_REQUEST_TERMINAL' && isRecord(event.value)) {
-          const terminalRequestId = asString(event.value.request_id, '').trim()
-          const status = asString(event.value.status, '').trim()
+        if (event.type === 'CUSTOM' && event.name === 'KEEPER_REQUEST_TERMINAL') {
+          const terminal = parseKeeperRunTerminal(event.value)
+          if (terminal.runRef.target.name !== keeperName) {
+            throw new Error('Keeper run terminal target does not match the active Keeper')
+          }
+          const terminalRequestId = terminal.runRef.runId
           const matchesActiveRequest =
-            Boolean(terminalRequestId) && requestId !== null && terminalRequestId === requestId
-          if (matchesActiveRequest && TERMINAL_REQUEST_STATUSES.has(status)) {
-            requestTerminalSeen = true
-            removePendingKeeperChatRequest(terminalRequestId)
+            requestId !== null && terminalRequestId === requestId
+          if (matchesActiveRequest) {
+            if (terminal.resultContract === 'publication_uncertain') {
+              requestNeedsReconciliation = true
+            } else if (isTerminalKeeperRunResult(terminal.resultContract)) {
+              requestNeedsReconciliation = false
+              requestTerminalSeen = true
+              removePendingKeeperChatRequest(terminalRequestId)
+            } else {
+              throw new Error(
+                `Keeper run terminal has nonterminal result_contract: ${terminal.resultContract}`,
+              )
+            }
           }
         }
         const error = applyKeeperStreamEvent(keeperName, assistantId, event)
@@ -1363,7 +1389,7 @@ export async function sendKeeperThreadMessage(
       (keeperThreads.value[keeperName] ?? []).find(entry => entry.id === assistantId) ?? null
     const finalText = finalEntry?.text.trim() ?? ''
 
-    if (!outcome.terminal) {
+    if (!outcome.terminal || requestNeedsReconciliation) {
       if (requestId) {
         removeThreadEntries(keeperName, [localId, assistantId])
         // Hand off to resume: release ownership FIRST so our own resume

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -31,6 +31,38 @@ function assistantEntry(): void {
   })
 }
 
+function keeperRunWire(runId: string) {
+  return {
+    run_id: runId,
+    target: { kind: 'keeper', name: 'sangsu' },
+    capability: 'invoke_turn',
+  } as const
+}
+
+function keeperQueueValue(runId: string) {
+  return {
+    tracking: {
+      kind: 'keeper_run',
+      run_ref: keeperRunWire(runId),
+      result_contract: 'awaiting_execution',
+    },
+    destination_type: 'keeper',
+    destination_id: 'sangsu',
+  } as const
+}
+
+function keeperTerminalValue(
+  runId: string,
+  resultContract: 'yielded' | 'cancelled' | 'completed' | 'failed',
+  message?: string,
+) {
+  return {
+    run_ref: keeperRunWire(runId),
+    result_contract: resultContract,
+    ...(message === undefined ? {} : { message }),
+  } as const
+}
+
 describe('applyKeeperStreamEvent', () => {
   beforeEach(() => {
     _resetKeeperStreamBuffersForTests()
@@ -78,11 +110,7 @@ describe('applyKeeperStreamEvent', () => {
     expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
       type: 'CUSTOM',
       name: 'KEEPER_QUEUE_REQUEST',
-      value: {
-        request_id: 'kmsg_sangsu_1',
-        status: 'queued',
-        modalities: ['text'],
-      },
+      value: keeperQueueValue('kmsg_sangsu_1'),
     })).toBeNull()
 
     const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
@@ -211,12 +239,7 @@ describe('applyKeeperStreamEvent', () => {
     expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
       type: 'CUSTOM',
       name: 'KEEPER_REQUEST_TERMINAL',
-      value: {
-        request_id: 'kmsg_sangsu_1',
-        status: 'error',
-        ok: false,
-        message: 'Timeout after 630.0s',
-      },
+      value: keeperTerminalValue('kmsg_sangsu_1', 'failed', 'Timeout after 630.0s'),
     })).toBe('Timeout after 630.0s')
 
     const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
@@ -232,12 +255,11 @@ describe('applyKeeperStreamEvent', () => {
     expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
       type: 'CUSTOM',
       name: 'KEEPER_REQUEST_TERMINAL',
-      value: {
-        request_id: 'kmsg_sangsu_1',
-        status: 'cancelled',
-        ok: false,
-        message: 'keeper chat stream cancelled by client',
-      },
+      value: keeperTerminalValue(
+        'kmsg_sangsu_1',
+        'cancelled',
+        'keeper chat stream cancelled by client',
+      ),
     })).toBeNull()
 
     const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
@@ -269,11 +291,7 @@ describe('applyKeeperStreamEvent', () => {
     expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
       type: 'CUSTOM',
       name: 'KEEPER_REQUEST_TERMINAL',
-      value: {
-        request_id: 'kmsg_current',
-        status: 'done',
-        ok: true,
-      },
+      value: keeperTerminalValue('kmsg_current', 'completed'),
     })).toBeNull()
     expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
       type: 'TEXT_MESSAGE_END',
@@ -294,10 +312,7 @@ describe('applyKeeperStreamEvent', () => {
     applyKeeperStreamEvent('sangsu', 'reply-1', {
       type: 'CUSTOM',
       name: 'KEEPER_QUEUE_REQUEST',
-      value: {
-        request_id: 'kmsg_current',
-        status: 'queued',
-      },
+      value: keeperQueueValue('kmsg_current'),
     })
     applyKeeperStreamEvent('sangsu', 'reply-1', {
       type: 'CUSTOM',
@@ -312,11 +327,7 @@ describe('applyKeeperStreamEvent', () => {
     expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
       type: 'CUSTOM',
       name: 'KEEPER_REQUEST_TERMINAL',
-      value: {
-        request_id: 'kmsg_current',
-        status: 'done',
-        ok: true,
-      },
+      value: keeperTerminalValue('kmsg_current', 'completed'),
     })).toBeNull()
     expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
       type: 'TEXT_MESSAGE_END',
@@ -344,11 +355,7 @@ describe('applyKeeperStreamEvent', () => {
     expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
       type: 'CUSTOM',
       name: 'KEEPER_REQUEST_TERMINAL',
-      value: {
-        request_id: 'kmsg_current',
-        status: 'done',
-        ok: true,
-      },
+      value: keeperTerminalValue('kmsg_current', 'yielded'),
     })).toBeNull()
     expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
       type: 'TEXT_MESSAGE_END',
@@ -374,11 +381,7 @@ describe('applyKeeperStreamEvent', () => {
     expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
       type: 'CUSTOM',
       name: 'KEEPER_REQUEST_TERMINAL',
-      value: {
-        request_id: 'kmsg_current',
-        status: 'done',
-        ok: true,
-      },
+      value: keeperTerminalValue('kmsg_current', 'completed'),
     })).toBeNull()
     expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
       type: 'TEXT_MESSAGE_END',
@@ -400,12 +403,7 @@ describe('applyKeeperStreamEvent', () => {
     expect(applyKeeperStreamEvent('sangsu', 'reply-1', {
       type: 'CUSTOM',
       name: 'KEEPER_REQUEST_TERMINAL',
-      value: {
-        request_id: 'kmsg_stale',
-        status: 'cancelled',
-        ok: false,
-        message: 'stale terminal',
-      },
+      value: keeperTerminalValue('kmsg_stale', 'cancelled', 'stale terminal'),
     })).toBeNull()
 
     const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
@@ -413,7 +411,7 @@ describe('applyKeeperStreamEvent', () => {
     expect(entry?.streamState).toBe('opening')
   })
 
-  it('ignores no-id terminal events while a request id is active', () => {
+  it('rejects raw terminal events while a request id is active', () => {
     assistantEntry()
     setActiveStreamRequestId('sangsu', 'kmsg_current')
 
@@ -425,7 +423,7 @@ describe('applyKeeperStreamEvent', () => {
         ok: false,
         message: 'legacy terminal without request id',
       },
-    })).toBeNull()
+    })).toContain('invalid typed identity')
 
     const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
     expect(entry?.delivery).toBe('sending')
@@ -433,7 +431,7 @@ describe('applyKeeperStreamEvent', () => {
     expect(activeStreamRequestId('sangsu')).toBe('kmsg_current')
   })
 
-  it('ignores non-terminal request status events', () => {
+  it('rejects non-terminal result contracts on terminal events', () => {
     assistantEntry()
     setActiveStreamRequestId('sangsu', 'kmsg_current')
 
@@ -441,12 +439,11 @@ describe('applyKeeperStreamEvent', () => {
       type: 'CUSTOM',
       name: 'KEEPER_REQUEST_TERMINAL',
       value: {
-        request_id: 'kmsg_current',
-        status: 'running',
-        ok: false,
+        run_ref: keeperRunWire('kmsg_current'),
+        result_contract: 'running',
         message: 'not terminal yet',
       },
-    })).toBeNull()
+    })).toBe('Keeper run terminal has nonterminal result_contract: running')
 
     const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
     expect(entry?.delivery).toBe('sending')

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -20,7 +20,6 @@ import {
   markAssistantToolTraceEnded,
   markAssistantToolTraceErrored,
   clearActiveStream,
-  clearActiveStreamRequestId,
   releaseActiveStreamRequestId,
   activeStreamEntryId,
   activeStreamRequestId,
@@ -36,9 +35,14 @@ import { toolEntryIdFromCallId } from './tool-call-output-store'
 import { STREAMING_THINKING_PREVIEW_CHARS } from './config/constants'
 import { updatePendingKeeperChatAssistantDraft } from './keeper-chat-pending'
 import { isKeeperChatReceiptId, parseKeeperQueueRevision } from './lib/keeper-chat-receipt'
+import {
+  isTerminalKeeperRunResult,
+  parseKeeperRunTerminal,
+  parseKeeperRunTracking,
+} from './lib/keeper-run-ref'
+import type { KeeperRunTracking } from './lib/keeper-run-ref'
 
 const KEEPER_MESSAGE_CANCELLED_TEXT = '요청이 취소되었습니다.'
-export const TERMINAL_REQUEST_STATUSES = new Set(['done', 'error', 'lost', 'cancelled'])
 export const KEEPER_THINKING_DELTA_FLUSH_INTERVAL_MS = 100
 
 const pendingOasToolBlockIndexes = new Map<string, number>()
@@ -671,6 +675,18 @@ export function applyKeeperStreamEvent(
         return null
       }
       if (event.name === 'KEEPER_QUEUE_REQUEST') {
+        try {
+          const tracking = parseKeeperRunTracking(event.value)
+          if (tracking.resultContract !== 'awaiting_execution') {
+            return 'Keeper queue tracking must be awaiting_execution'
+          }
+          if (tracking.runRef.target.name !== keeperName) {
+            return 'Keeper queue tracking target does not match the active Keeper'
+          }
+        } catch (error) {
+          const detail = error instanceof Error ? error.message : String(error)
+          return `Keeper queue event has invalid typed run tracking: ${detail}`
+        }
         flushPendingThinkingDeltas(keeperName, assistantEntryId)
         setAssistantStreamState(
           keeperName,
@@ -758,23 +774,52 @@ export function applyKeeperStreamEvent(
       }
       if (event.name === 'KEEPER_REQUEST_TERMINAL') {
         flushPendingThinkingDeltas(keeperName, assistantEntryId)
-        const terminal = isRecord(event.value) ? event.value : null
-        const terminalRequestId = asString(terminal?.request_id, '').trim()
+        let terminal: KeeperRunTracking
+        try {
+          terminal = parseKeeperRunTerminal(event.value)
+        } catch (error) {
+          const detail = error instanceof Error ? error.message : String(error)
+          return `Keeper run terminal has invalid typed identity: ${detail}`
+        }
+        const terminalRequestId = terminal.runRef.runId
+        if (terminal.runRef.target.name !== keeperName) {
+          return 'Keeper run terminal target does not match the active Keeper'
+        }
         const currentRequestId = activeStreamRequestId(keeperName)
-        const status = asString(terminal?.status, '').trim()
         if (currentRequestId && terminalRequestId !== currentRequestId) {
           return null
         }
-        if (!TERMINAL_REQUEST_STATUSES.has(status)) {
+        if (terminal.resultContract === 'publication_uncertain') {
+          const message = isRecord(event.value)
+            ? asString(event.value.message, '').trim()
+            : ''
+          clearPendingOasToolBlockIndexesForEntry(keeperName, assistantEntryId)
+          updateThreadEntry(keeperName, assistantEntryId, entry => ({
+            ...entry,
+            delivery: 'queued',
+            streamState: null,
+            error: null,
+            streamContract: keeperClientObservedSseStreamContract(
+              'queue_event',
+              'backend_terminal_event',
+              {
+                eventName: 'KEEPER_REQUEST_TERMINAL',
+                requestId: terminalRequestId,
+                reason: message || 'Keeper run publication requires reconciliation',
+              },
+            ),
+          }))
           return null
         }
+        if (!isTerminalKeeperRunResult(terminal.resultContract)) {
+          return `Keeper run terminal has nonterminal result_contract: ${terminal.resultContract}`
+        }
         clearPendingOasToolBlockIndexesForEntry(keeperName, assistantEntryId)
-        if (terminalRequestId) releaseActiveStreamRequestId(terminalRequestId)
-        else clearActiveStreamRequestId(keeperName)
-        const ok = terminal?.ok === true
-        if (status === 'cancelled') {
+        releaseActiveStreamRequestId(terminalRequestId)
+        const terminalValue = isRecord(event.value) ? event.value : null
+        if (terminal.resultContract === 'cancelled') {
           const message =
-            asString(terminal?.message, '').trim() || KEEPER_MESSAGE_CANCELLED_TEXT
+            asString(terminalValue?.message, '').trim() || KEEPER_MESSAGE_CANCELLED_TEXT
           updateThreadEntry(keeperName, assistantEntryId, entry => ({
             ...entry,
             text: KEEPER_MESSAGE_CANCELLED_TEXT,
@@ -789,11 +834,9 @@ export function applyKeeperStreamEvent(
           }))
           return null
         }
-        const failed =
-          !ok && ['error', 'lost'].includes(status)
-        if (failed) {
+        if (terminal.resultContract === 'failed') {
           const message =
-            asString(terminal?.message, '').trim() || 'Keeper request failed'
+            asString(terminalValue?.message, '').trim() || 'Keeper request failed'
           updateThreadEntry(keeperName, assistantEntryId, entry => ({
             ...entry,
             text: entry.text || `Keeper request failed: ${message}`,
@@ -809,7 +852,10 @@ export function applyKeeperStreamEvent(
           }))
           return message
         }
-        if (status === 'done' && terminal?.ok !== false) {
+        if (
+          terminal.resultContract === 'completed'
+          || terminal.resultContract === 'yielded'
+        ) {
           updateThreadEntry(keeperName, assistantEntryId, entry => {
             const delivery =
               entry.delivery === 'no_reply'

--- a/dashboard/src/lib/keeper-run-ref.test.ts
+++ b/dashboard/src/lib/keeper-run-ref.test.ts
@@ -6,6 +6,8 @@ import {
   keeperRunRefToWire,
   parseKeeperRunRef,
   parseKeeperRunResultContract,
+  parseKeeperRunTerminal,
+  parseKeeperRunTracking,
   sameKeeperRunRef,
 } from './keeper-run-ref'
 
@@ -55,5 +57,43 @@ describe('Keeper run reference', () => {
     expect(() => parseKeeperRunResultContract('done')).toThrow(
       'unsupported Keeper run result contract',
     )
+  })
+
+  it('decodes typed Gate tracking and terminal envelopes', () => {
+    const tracking = parseKeeperRunTracking({
+      tracking: {
+        kind: 'keeper_run',
+        run_ref: RUN_REF_WIRE,
+        result_contract: 'awaiting_execution',
+      },
+      destination_type: 'keeper',
+      destination_id: 'luna',
+    })
+    expect(tracking.runRef).toEqual(parseKeeperRunRef(RUN_REF_WIRE))
+    expect(tracking.resultContract).toBe('awaiting_execution')
+
+    const terminal = parseKeeperRunTerminal({
+      run_ref: RUN_REF_WIRE,
+      result_contract: 'yielded',
+      message: 'checkpoint',
+    })
+    expect(terminal.runRef).toEqual(tracking.runRef)
+    expect(terminal.resultContract).toBe('yielded')
+  })
+
+  it('rejects retargeted and raw terminal SSE identities', () => {
+    expect(() => parseKeeperRunTracking({
+      tracking: {
+        kind: 'keeper_run',
+        run_ref: RUN_REF_WIRE,
+        result_contract: 'running',
+      },
+      destination_type: 'keeper',
+      destination_id: 'other',
+    })).toThrow('destination must match run_ref.target')
+    expect(() => parseKeeperRunTerminal({ request_id: 'typed-run-1', status: 'done' }))
+      .toThrow('must contain run_ref, result_contract')
+    expect(() => parseKeeperRunTerminal({ run_ref: RUN_REF_WIRE, result_contract: 'failed', message: 7 }))
+      .toThrow('message must be a string')
   })
 })

--- a/dashboard/src/lib/keeper-run-ref.ts
+++ b/dashboard/src/lib/keeper-run-ref.ts
@@ -20,6 +20,11 @@ export interface KeeperRunRefWire {
   readonly capability: 'invoke_turn'
 }
 
+export interface KeeperRunTracking {
+  readonly runRef: KeeperRunRef
+  readonly resultContract: KeeperRunResultContract
+}
+
 export type KeeperRunResultContract =
   | 'awaiting_execution'
   | 'publication_uncertain'
@@ -111,6 +116,42 @@ export function parseKeeperRunResultContract(value: unknown): KeeperRunResultCon
     default:
       throw new Error(`unsupported Keeper run result contract: ${JSON.stringify(value)}`)
   }
+}
+
+export function parseKeeperRunTracking(value: unknown): KeeperRunTracking {
+  if (!isRecord(value)) throw new Error('Keeper run tracking envelope must be an object')
+  if (!isRecord(value.tracking)) throw new Error('Keeper run tracking must be an object')
+  exactFields(value.tracking, ['kind', 'run_ref', 'result_contract'], 'tracking')
+  if (value.tracking.kind !== 'keeper_run') {
+    throw new Error('tracking.kind must be keeper_run')
+  }
+  const runRef = parseKeeperRunRef(value.tracking.run_ref)
+  if (value.destination_type !== 'keeper' || value.destination_id !== runRef.target.name) {
+    throw new Error('Keeper run tracking destination must match run_ref.target')
+  }
+  return Object.freeze({
+    runRef,
+    resultContract: parseKeeperRunResultContract(value.tracking.result_contract),
+  })
+}
+
+export function parseKeeperRunTerminal(value: unknown): KeeperRunTracking {
+  if (!isRecord(value)) throw new Error('Keeper run terminal must be an object')
+  const fields = Object.keys(value)
+  if (
+    !Object.hasOwn(value, 'run_ref')
+    || !Object.hasOwn(value, 'result_contract')
+    || fields.some(field => field !== 'run_ref' && field !== 'result_contract' && field !== 'message')
+  ) {
+    throw new Error('Keeper run terminal must contain run_ref, result_contract, and optional message')
+  }
+  if (Object.hasOwn(value, 'message') && typeof value.message !== 'string') {
+    throw new Error('Keeper run terminal message must be a string')
+  }
+  return Object.freeze({
+    runRef: parseKeeperRunRef(value.run_ref),
+    resultContract: parseKeeperRunResultContract(value.result_contract),
+  })
 }
 
 export function isTerminalKeeperRunResult(contract: KeeperRunResultContract): boolean {


### PR DESCRIPTION
Stacked on #24615.

## What changed

- Decode Gate queue tracking from the exact typed `run_ref` and `result_contract` envelope.
- Decode Keeper terminal SSE from the same typed identity instead of raw `request_id`, string status, and `ok` fields.
- Verify the typed target against the active Keeper and reject malformed, retargeted, legacy, and nonterminal terminal payloads explicitly.
- Keep `publication_uncertain` runs durable and hand them to polling instead of falsely finalizing or dropping them.
- Preserve completed, yielded, cancelled, failed, rich chat, tool trace, and continuation-checkpoint behavior.

## Why

The server now publishes one typed Keeper run identity, but the dashboard still projected queue and terminal events back into legacy string contracts. That split could silently lose reconciliation work and allowed partial identities to drive cancellation and completion.

## Impact

The dashboard consumes the server's typed Keeper run contract end to end at the SSE boundary. There is no compatibility parser for raw terminal IDs or legacy status strings.

## Validation

- `pnpm typecheck`
- `pnpm exec eslint src/lib/keeper-run-ref.ts src/lib/keeper-run-ref.test.ts src/keeper-actions.ts src/keeper-actions.test.ts`
- `pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/lib/keeper-run-ref.test.ts src/keeper-stream.test.ts src/keeper-actions.test.ts src/components/keeper-shared-hydration.integration.test.ts` (148 tests)
- `git diff --check`
- Diff size: 380 changed lines
