### PR TITLE
refactor(connector): move trigger policy to leaf descriptor

### DIFF
--- a/dashboard/src/api/schemas/gate-connectors.test.ts
+++ b/dashboard/src/api/schemas/gate-connectors.test.ts
@@ -24,6 +24,7 @@ describe('parseGateConnectorsData', () => {
     expect(result.connectors).toHaveLength(1)
     expect(result.connectors[0].connector_id).toBe('c1')
     expect(result.connectors[0].capabilities).toEqual([])
+    expect(result.connectors[0].trigger_policy).toBeNull()
     expect(result.connectors[0].available).toBe(false)
     expect(result.connectors[0].guild_count).toBe(0)
     expect(result.connectors[0].source_health).toEqual({
@@ -36,6 +37,16 @@ describe('parseGateConnectorsData', () => {
     expect(result.total).toBe(1)
     expect(result.active_count).toBe(1)
     expect(result.generated_at).toBe('2024-01-01T00:00:00Z')
+  })
+
+  it('projects leaf trigger policy without retaining the legacy aggregate field', () => {
+    const result = parseGateConnectorsData({
+      ...minimalOuter,
+      connectors: [{ ...minimalConnector, trigger_policy: 'all' }],
+      discord_trigger_policy: 'mention_only',
+    })
+    expect(result.connectors[0].trigger_policy).toBe('all')
+    expect('discord_trigger_policy' in result).toBe(false)
   })
 
   it('throws GateConnectorsSchemaDriftError when generated_at is empty', () => {

--- a/dashboard/src/api/schemas/gate-connectors.ts
+++ b/dashboard/src/api/schemas/gate-connectors.ts
@@ -207,6 +207,7 @@ const GateConnectorInfoRawSchema = object({
   display_name: string(),
   channel: string(),
   capabilities: fallback(array(string()), []),
+  trigger_policy: fallback(nullable(string()), null),
   status: fallback(string(), ''),
   available: fallback(boolean(), false),
   connected: fallback(boolean(), false),
@@ -252,6 +253,7 @@ export interface GateConnectorInfo {
   display_name: string
   channel: string
   capabilities: string[]
+  trigger_policy: string | null
   status: string
   available: boolean
   connected: boolean
@@ -361,6 +363,7 @@ function parseGateConnectorInfo(raw: unknown): GateConnectorInfo | null {
     display_name: outer.output.display_name,
     channel: outer.output.channel,
     capabilities: outer.output.capabilities,
+    trigger_policy: outer.output.trigger_policy,
     status: outer.output.status,
     available: outer.output.available,
     connected: outer.output.connected,
@@ -417,7 +420,6 @@ const GateConnectorsOuterSchema = object({
   connectors: optional(unknown()),
   total: fallback(number(), 0),
   active_count: fallback(number(), 0),
-  discord_trigger_policy: fallback(string(), 'unknown'),
   // Empty string is treated as drift — matches prior decoder's
   // `if (!generatedAt) return null` guard. A connectors payload
   // without a timestamp is not a useful one; the null-returning
@@ -429,7 +431,6 @@ export interface GateConnectorsData {
   connectors: GateConnectorInfo[]
   total: number
   active_count: number
-  discord_trigger_policy: string
   generated_at: string
 }
 
@@ -455,7 +456,6 @@ export function parseGateConnectorsData(data: unknown): GateConnectorsData {
     connectors,
     total: outer.total,
     active_count: outer.active_count,
-    discord_trigger_policy: outer.discord_trigger_policy,
     generated_at: outer.generated_at,
   }
 }

--- a/dashboard/src/components/connector-overview-strip.test.ts
+++ b/dashboard/src/components/connector-overview-strip.test.ts
@@ -73,6 +73,17 @@ describe('ConnectorOverviewStrip', () => {
     expect(imessageTile.textContent).toContain('Config와 Start')
   })
 
+  it('shows the Discord leaf trigger policy in the overview header', () => {
+    render(
+      html`<${ConnectorOverviewStrip}
+        connectors=${[mkConnector({ trigger_policy: 'mention_or_thread' })]}
+        keeperCount=${0}
+      />`,
+      container,
+    )
+    expect(container.textContent).toContain('trigger: mention_or_thread')
+  })
+
   it('Start All button counts only sidecars currently down', () => {
     _testResetBulkInflight()
     render(

--- a/dashboard/src/components/connector-overview-strip.ts
+++ b/dashboard/src/components/connector-overview-strip.ts
@@ -155,7 +155,6 @@ async function runBulk(
 interface OverviewProps {
   connectors: GateConnectorInfo[]
   keeperCount: number
-  discordTriggerPolicy?: string
   selectedConnectorId?: KnownConnectorId | null
   onSelectConnector?: (connectorId: KnownConnectorId) => void
   onOpenConfig?: (connectorId: KnownConnectorId) => void
@@ -758,7 +757,6 @@ function IncidentBanner({ droppedIds }: { droppedIds: string[] }) {
 export function ConnectorOverviewStrip({
   connectors,
   keeperCount,
-  discordTriggerPolicy,
   selectedConnectorId = null,
   onSelectConnector,
   onOpenConfig,
@@ -787,13 +785,14 @@ export function ConnectorOverviewStrip({
 
   const droppedIds = detectRecentDrops(stripMemory.value, connectors, Date.now())
   const summary = summarizeConnectorStrip(connectors, keeperCount)
+  const discordTriggerPolicy = findConnector(connectors, 'discord')?.trigger_policy
   return html`
     <${SurfaceCard} class="mb-4 !p-3 v2-connector-overview-strip" data-overview-strip-root>
       <${IncidentBanner} droppedIds=${droppedIds} />
       <div class="mb-3 flex flex-wrap items-center justify-between gap-2">
         <div class="flex flex-wrap items-center gap-2">
           <${StatusSummaryLine} summary=${summary} connectors=${connectors} />
-          ${discordTriggerPolicy && discordTriggerPolicy !== 'unknown'
+          ${discordTriggerPolicy
             ? html`<span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-0.5 text-3xs font-medium text-[var(--color-fg-secondary)]">trigger: ${discordTriggerPolicy}</span>`
             : null
           }

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -386,6 +386,7 @@ function placeholderConnector(connectorId: KnownConnectorId): GateConnectorInfo 
     display_name: CONNECTOR_DISPLAY_NAMES[connectorId],
     channel: connectorId,
     capabilities: ['bindings'],
+    trigger_policy: null,
     status: 'offline',
     available: false,
     connected: false,
@@ -2267,7 +2268,6 @@ export function ConnectorStatusPanel() {
                 <${ConnectorOverviewStrip}
                   connectors=${allConnectors}
                   keeperCount=${snapshot.keepers.length}
-                  discordTriggerPolicy=${snapshot.connectors?.discord_trigger_policy}
                   selectedConnectorId=${focusedConnectorId}
                   onSelectConnector=${(connectorId: KnownConnectorId) => { selectedConnectorId.value = connectorId }}
                   onOpenConfig=${(connectorId: KnownConnectorId) => {

--- a/lib/gate/channel_gate_connector.ml
+++ b/lib/gate/channel_gate_connector.ml
@@ -63,17 +63,11 @@ let connectors_json ?gate_status_json ?(audit_limit = 10) () =
         else acc)
       0 connector_jsons
   in
-  let policy_str =
-    match Channel_gate_discord_state.get_trigger_policy () with
-    | None -> "unknown"
-    | Some p -> Discord_gateway_state.trigger_policy_to_string p
-  in
   `Assoc
     [
       ("connectors", `List connector_jsons);
       ("total", `Int (List.length connectors));
       ("active_count", `Int active_count);
-      ("discord_trigger_policy", `String policy_str);
       ("generated_at",
        `String (Gate_time_util.iso8601_of_unix (Unix.gettimeofday ())));
     ]

--- a/lib/gate/channel_gate_discord_state.ml
+++ b/lib/gate/channel_gate_discord_state.ml
@@ -96,8 +96,8 @@ let unregister_thread ~thread_id =
 
 (* ── Trigger policy registry ──────────────────────────────────────
    Set once at gateway startup by [set_trigger_policy]. Read by
-   [connectors_json] for dashboard display. Same mutable-ref pattern
-   as [record_ready]. *)
+   this connector's status projection for dashboard display. Same
+   mutable-ref pattern as [record_ready]. *)
 
 let trigger_policy_ref : Discord_gateway_state.trigger_policy option ref =
   ref None
@@ -106,6 +106,12 @@ let set_trigger_policy (policy : Discord_gateway_state.trigger_policy) =
   trigger_policy_ref := Some policy
 
 let get_trigger_policy () = !trigger_policy_ref
+
+let trigger_policy_json () =
+  match get_trigger_policy () with
+  | None -> `Null
+  | Some policy ->
+    `String (Discord_gateway_state.trigger_policy_to_string policy)
 
 let string_member json key =
   Json_util.get_string_with_default json ~key ~default:""
@@ -207,6 +213,7 @@ let status_json ?(audit_limit = 10) () =
       ("error", `String error);
       ("status_source", `String "in_process_gateway");
       ("gateway_state", `String (gateway_state_label gateway_state));
+      ("trigger_policy", trigger_policy_json ());
       ("status_path", `String status_path);
       ("binding_store_path", `String binding_store_path);
       ("audit_path", `String audit_path);
@@ -331,6 +338,7 @@ let connector_json ?gate_status_json ?(audit_limit = 10) () =
       ("display_name", `String display_name);
       ("channel", `String channel);
       ("capabilities", Channel_gate_connector_capability.all_json);
+      ("trigger_policy", status |> U.member "trigger_policy");
       ("status", `String (string_member status "status"));
       ("available", `Bool (bool_member status "available"));
       ("connected", `Bool (bool_member status "connected"));

--- a/lib/keeper_runtime/keeper_continuation_channel.ml
+++ b/lib/keeper_runtime/keeper_continuation_channel.ml
@@ -143,9 +143,10 @@ let string_field name fields =
 
 let optional_string_field name fields =
   match List.assoc_opt name fields with
-  | Some (`String s) when String.trim s <> "" -> Some s
-  | Some (`String _) | Some `Null | None -> None
-  | Some _ -> None
+  | Some (`String s) when String.trim s <> "" -> Ok (Some s)
+  | Some (`String _) | Some `Null | None -> Ok None
+  | Some _ ->
+    Error (Printf.sprintf "continuation_channel: field %s must be a string or null" name)
 
 let of_yojson json =
   let* fields = assoc_fields json in
@@ -157,26 +158,27 @@ let of_yojson json =
   | "discord" ->
     let* channel_id = string_field "channel_id" fields in
     let* user_id = string_field "user_id" fields in
+    let* guild_id = optional_string_field "guild_id" fields in
+    let* parent_channel_id = optional_string_field "parent_channel_id" fields in
+    let* thread_id = optional_string_field "thread_id" fields in
     Ok
       (Discord
-         { guild_id = optional_string_field "guild_id" fields
+         { guild_id
          ; channel_id
-         ; parent_channel_id = optional_string_field "parent_channel_id" fields
-         ; thread_id = optional_string_field "thread_id" fields
+         ; parent_channel_id
+         ; thread_id
          ; user_id
          })
   | "slack" ->
-    let* channel_id =
-      match string_field "channel_id" fields with
-      | Ok value -> Ok value
-      | Error _ -> string_field "channel" fields
-    in
+    let* channel_id = string_field "channel_id" fields in
     let* user_id = string_field "user_id" fields in
+    let* team_id = optional_string_field "team_id" fields in
+    let* thread_ts = optional_string_field "thread_ts" fields in
     Ok
       (Slack
-         { team_id = optional_string_field "team_id" fields
+         { team_id
          ; channel_id
-         ; thread_ts = optional_string_field "thread_ts" fields
+         ; thread_ts
          ; user_id
          })
   | "unrouted" ->

--- a/lib/keeper_runtime/keeper_continuation_channel.ml
+++ b/lib/keeper_runtime/keeper_continuation_channel.ml
@@ -137,14 +137,18 @@ let assoc_fields = function
 
 let string_field name fields =
   match List.assoc_opt name fields with
-  | Some (`String s) -> Ok s
+  | Some (`String s) when not (String.equal (String.trim s) "") -> Ok s
+  | Some (`String _) ->
+    Error (Printf.sprintf "continuation_channel: field %s must not be blank" name)
   | Some _ -> Error (Printf.sprintf "continuation_channel: field %s must be a string" name)
   | None -> Error (Printf.sprintf "continuation_channel: missing field %s" name)
 
 let optional_string_field name fields =
   match List.assoc_opt name fields with
-  | Some (`String s) when String.trim s <> "" -> Ok (Some s)
-  | Some (`String _) | Some `Null | None -> Ok None
+  | Some (`String s) when not (String.equal (String.trim s) "") -> Ok (Some s)
+  | Some (`String _) ->
+    Error (Printf.sprintf "continuation_channel: field %s must not be blank" name)
+  | Some `Null | None -> Ok None
   | Some _ ->
     Error (Printf.sprintf "continuation_channel: field %s must be a string or null" name)
 

--- a/lib/keeper_runtime/keeper_continuation_channel.mli
+++ b/lib/keeper_runtime/keeper_continuation_channel.mli
@@ -56,6 +56,8 @@ val same_route : t -> t -> bool
 val to_yojson : t -> Yojson.Safe.t
 
 (** [of_yojson json] parses a tagged object produced by {!to_yojson}. A
-    missing or unknown ["kind"], or a missing field, is an [Error]; there is
-    no permissive default (RFC-0320 §2 fail-closed). *)
+    missing or unknown ["kind"], a missing required field, or a non-string
+    connector coordinate is an [Error]. Only absent, null, or empty optional
+    coordinates become [None]; there are no field aliases or permissive
+    defaults (RFC-0320 §2 fail-closed). *)
 val of_yojson : Yojson.Safe.t -> (t, string) result

--- a/lib/keeper_runtime/keeper_continuation_channel.mli
+++ b/lib/keeper_runtime/keeper_continuation_channel.mli
@@ -56,8 +56,8 @@ val same_route : t -> t -> bool
 val to_yojson : t -> Yojson.Safe.t
 
 (** [of_yojson json] parses a tagged object produced by {!to_yojson}. A
-    missing or unknown ["kind"], a missing required field, or a non-string
-    connector coordinate is an [Error]. Only absent, null, or empty optional
-    coordinates become [None]; there are no field aliases or permissive
-    defaults (RFC-0320 §2 fail-closed). *)
+    missing or unknown ["kind"], a missing or blank required field, or a
+    blank/non-string connector coordinate is an [Error]. Only absent or null
+    optional coordinates become [None]; there are no field aliases or
+    permissive defaults (RFC-0320 §2 fail-closed). *)
 val of_yojson : Yojson.Safe.t -> (t, string) result

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -576,12 +576,8 @@ let payload_to_yojson = function
       ]
 
 let continuation_channel_field fields =
-  match List.assoc_opt "channel" fields with
-  | None ->
-    (* Backward compat: pre-RFC-0320 persisted stimuli carry no channel; a
-       replayed legacy wake is [Unrouted] rather than a parse failure. *)
-    Ok (Keeper_continuation_channel.unrouted "legacy: channel not captured")
-  | Some json -> Keeper_continuation_channel.of_yojson json
+  let* json = required_field ~context:"stimulus.payload" "channel" fields in
+  Keeper_continuation_channel.of_yojson json
 
 let payload_of_yojson json =
   let context = "stimulus.payload" in
@@ -625,11 +621,6 @@ let payload_of_yojson json =
     let* ok = bool_field ~context "ok" fields in
     let* resolved_answer = string_field ~context "resolved_answer" fields in
     let* board_post_id = string_field ~context "board_post_id" fields in
-    (* [Fusion_completed] predates the reply-channel field and was persisted
-       without it, so a legacy snapshot row must replay as [Unrouted] rather
-       than failing the whole snapshot parse (which recovers to an empty queue,
-       dropping every co-resident stimulus). Same lenient contract as the
-       sibling [Connector_attention]/[Hitl_resolved] rows. *)
     let* channel = continuation_channel_field fields in
     Ok (Fusion_completed { run_id; ok; resolved_answer; board_post_id; channel })
   | "bg_completed" ->

--- a/test/keeper_continuation_channel/test_keeper_continuation_channel.ml
+++ b/test/keeper_continuation_channel/test_keeper_continuation_channel.ml
@@ -2,7 +2,7 @@
 
    Covers the closed-variant contract:
      - codec round-trips for every constructor,
-     - fail-closed parsing (unknown kind / missing field / non-object -> Error),
+     - fail-closed parsing (unknown kind / missing or malformed field / legacy alias -> Error),
      - the routing helpers (is_routable, kind_label, same_route). *)
 
 open Keeper_continuation_channel
@@ -46,6 +46,63 @@ let test_missing_field_is_error () =
   (* discord requires user_id *)
   expect_error "missing discord user_id"
     (`Assoc [ ("kind", `String "discord"); ("channel_id", `String "C") ])
+
+let test_optional_route_coordinates_are_strict () =
+  List.iter
+    (fun (label, json) -> expect_error label json)
+    [ ( "discord guild_id wrong type"
+      , `Assoc
+          [ "kind", `String "discord"
+          ; "channel_id", `String "C"
+          ; "user_id", `String "U"
+          ; "guild_id", `Int 1
+          ] )
+    ; ( "discord parent_channel_id wrong type"
+      , `Assoc
+          [ "kind", `String "discord"
+          ; "channel_id", `String "C"
+          ; "user_id", `String "U"
+          ; "parent_channel_id", `Bool true
+          ] )
+    ; ( "discord thread_id wrong type"
+      , `Assoc
+          [ "kind", `String "discord"
+          ; "channel_id", `String "C"
+          ; "user_id", `String "U"
+          ; "thread_id", `List []
+          ] )
+    ; ( "slack team_id wrong type"
+      , `Assoc
+          [ "kind", `String "slack"
+          ; "channel_id", `String "C"
+          ; "user_id", `String "U"
+          ; "team_id", `Assoc []
+          ] )
+    ; ( "slack thread_ts wrong type"
+      , `Assoc
+          [ "kind", `String "slack"
+          ; "channel_id", `String "C"
+          ; "user_id", `String "U"
+          ; "thread_ts", `Float 1.0
+          ] )
+    ]
+
+let test_slack_legacy_channel_alias_is_rejected () =
+  expect_error
+    "legacy channel alias"
+    (`Assoc
+       [ "kind", `String "slack"
+       ; "channel", `String "C"
+       ; "user_id", `String "U"
+       ]);
+  expect_error
+    "invalid channel_id is not masked by alias"
+    (`Assoc
+       [ "kind", `String "slack"
+       ; "channel_id", `Int 1
+       ; "channel", `String "C"
+       ; "user_id", `String "U"
+       ])
 
 let test_missing_kind_is_error () =
   expect_error "missing kind" (`Assoc [ ("thread_id", `String "t") ])
@@ -146,6 +203,8 @@ let () =
   test_codec_roundtrip ();
   test_unknown_kind_is_error ();
   test_missing_field_is_error ();
+  test_optional_route_coordinates_are_strict ();
+  test_slack_legacy_channel_alias_is_rejected ();
   test_missing_kind_is_error ();
   test_non_object_is_error ();
   test_is_routable ();

--- a/test/keeper_continuation_channel/test_keeper_continuation_channel.ml
+++ b/test/keeper_continuation_channel/test_keeper_continuation_channel.ml
@@ -43,6 +43,9 @@ let test_unknown_kind_is_error () =
 let test_missing_field_is_error () =
   (* dashboard requires thread_id *)
   expect_error "missing thread_id" (`Assoc [ ("kind", `String "dashboard") ]);
+  expect_error
+    "blank thread_id"
+    (`Assoc [ "kind", `String "dashboard"; "thread_id", `String "  " ]);
   (* discord requires user_id *)
   expect_error "missing discord user_id"
     (`Assoc [ ("kind", `String "discord"); ("channel_id", `String "C") ])
@@ -56,6 +59,13 @@ let test_optional_route_coordinates_are_strict () =
           ; "channel_id", `String "C"
           ; "user_id", `String "U"
           ; "guild_id", `Int 1
+          ] )
+    ; ( "discord guild_id blank"
+      , `Assoc
+          [ "kind", `String "discord"
+          ; "channel_id", `String "C"
+          ; "user_id", `String "U"
+          ; "guild_id", `String ""
           ] )
     ; ( "discord parent_channel_id wrong type"
       , `Assoc
@@ -84,6 +94,13 @@ let test_optional_route_coordinates_are_strict () =
           ; "channel_id", `String "C"
           ; "user_id", `String "U"
           ; "thread_ts", `Float 1.0
+          ] )
+    ; ( "slack thread_ts blank"
+      , `Assoc
+          [ "kind", `String "slack"
+          ; "channel_id", `String "C"
+          ; "user_id", `String "U"
+          ; "thread_ts", `String " "
           ] )
     ]
 

--- a/test/test_channel_gate_discord_state.ml
+++ b/test/test_channel_gate_discord_state.ml
@@ -187,6 +187,7 @@ let test_unbind_removes_existing_binding () =
 let test_connectors_json_advertises_gate_connector_descriptor () =
   with_temp_dir @@ fun dir ->
   with_discord_paths dir (fun () ->
+    Discord_state.set_trigger_policy Discord_gateway_state.All;
     ignore
       (Discord_state.bind ~channel_id:"1234567890" ~keeper_name:"luna"
          ~actor_name:"dashboard");
@@ -231,6 +232,13 @@ let test_connectors_json_advertises_gate_connector_descriptor () =
       (connector |> U.member "connector_id" |> U.to_string);
     check string "display name" "Discord"
       (connector |> U.member "display_name" |> U.to_string);
+    check string "leaf trigger policy" "all"
+      (connector |> U.member "trigger_policy" |> U.to_string);
+    (match json with
+     | `Assoc fields ->
+       check bool "aggregate has no Discord-specific field" false
+         (List.mem_assoc "discord_trigger_policy" fields)
+     | _ -> fail "expected connector aggregate object");
     check bool "bindings capability exposed" true
       (connector |> U.member "capabilities" |> U.to_list
        |> List.exists (function

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -255,11 +255,9 @@ let () =
          ; channel = Keeper_continuation_channel.unrouted "test fixture"
          })
       "post-1");
-  (* Reply-route parity: the fusion wake serializes its originating channel,
-     and — like the sibling Connector_attention/Hitl_resolved rows — a legacy
-     Fusion_completed row persisted before the channel field existed replays as
-     [Unrouted] rather than failing the snapshot parse (a parse failure recovers
-     to an empty queue, dropping every co-resident stimulus). *)
+  (* Reply-route parity: every continuation-bearing wake serializes its exact
+     originating channel. A missing route is malformed durable state, not an
+     implicit [Unrouted] destination. *)
   (let routed : Keeper_event_queue.fusion_completion =
      { run_id = "fus-routed"
      ; ok = true
@@ -292,8 +290,8 @@ let () =
         | _ -> false)
     | Ok _ -> assert false
     | Error e -> failwith e);
-   let missing_channel_json =
-     match stimulus_to_yojson stim with
+   let without_payload_channel stimulus =
+     match stimulus_to_yojson stimulus with
      | `Assoc fields ->
        `Assoc
          (List.map
@@ -312,20 +310,30 @@ let () =
             fields)
      | other -> other
    in
-   match stimulus_of_yojson missing_channel_json with
-   | Ok { payload = Fusion_completed fc; _ } ->
-     assert (
-       match fc.channel with
-       | Keeper_continuation_channel.Unrouted { reason } ->
-         String.equal reason "legacy: channel not captured"
-       | _ -> false)
-   | Ok _ -> failwith "legacy fusion row must decode as Fusion_completed"
-   | Error e ->
-     failwith
-       (Printf.sprintf
-          "legacy fusion row without a channel key must replay Unrouted, not \
-           fail closed: %s"
-          e));
+   List.iter
+     (fun (label, stimulus) ->
+        match stimulus_of_yojson (without_payload_channel stimulus) with
+        | Error _ -> ()
+        | Ok _ -> failwith (label ^ " without channel must fail explicitly"))
+     [ "fusion completion", stim
+     ; ( "connector attention"
+       , { stim with
+           post_id = "connector-route"
+         ; payload =
+             Connector_attention
+               { event_id = "connector-route"; channel = routed.channel }
+         } )
+     ; ( "HITL resolution"
+       , { stim with
+           post_id = "hitl:approval-route"
+         ; payload =
+             Hitl_resolved
+               { approval_id = "approval-route"
+               ; decision = Hitl_approved
+               ; channel = routed.channel
+               }
+         } )
+     ]);
   assert (
     String.equal
       (fusion_completion_post_id

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -1640,45 +1640,4 @@ let () =
       in
       assert (String.equal second.post_id "bootstrap"));
 
-  (* RFC-0320 backward compat: pre-W2 persisted stimuli have no [channel] in
-     their payload and must replay as [Unrouted], not fail — a restart
-     replaying a legacy wake queue must not break. Simulate by serializing a W2
-     stimulus then stripping the [channel] field before parsing back. *)
-  (let strip_channel json =
-     match json with
-     | `Assoc top ->
-       `Assoc
-         (List.map
-            (fun (k, v) ->
-              if String.equal k "payload" then
-                ( k
-                , match v with
-                  | `Assoc p ->
-                    `Assoc
-                      (List.filter (fun (pk, _) -> not (String.equal pk "channel")) p)
-                  | other -> other )
-              else (k, v))
-            top)
-     | other -> other
-   in
-   let hitl_stim =
-     { post_id = "p-legacy"
-     ; urgency = Immediate
-     ; arrived_at = 1.0
-     ; payload =
-         Hitl_resolved
-           { approval_id = "a"
-           ; decision = Hitl_approved
-           ; channel = Keeper_continuation_channel.unrouted "seed"
-           }
-     }
-   in
-   match stimulus_of_yojson (strip_channel (stimulus_to_yojson hitl_stim)) with
-   | Ok s ->
-     (match s.payload with
-      | Hitl_resolved r ->
-        assert (not (Keeper_continuation_channel.is_routable r.channel))
-      | _ -> assert false)
-   | Error _ -> assert false);
-
   print_endline "test_keeper_event_queue: all passed"


### PR DESCRIPTION
## Summary
- remove Discord trigger-policy projection from the generic connector registry
- make the Discord leaf descriptor own its exact optional trigger-policy observation
- update Dashboard decoding/rendering to consume that leaf-owned field

## Boundary proof
- the generic registry no longer imports Discord state or invents an `unknown` sentinel
- `trigger_policy` is observation-only JSON (`string | null`), not execution authority
- runtime policy remains owned by the Discord leaf

## Verification
- Dashboard schema/component tests cover `string` and `null`
- Dashboard typecheck/tests delegated to PR CI because this worktree has no installed `node_modules`
- focused Connector/Gate stack build at the final stacked head
- `git diff --check`

Stacked on #24616.
