### PR TITLE
docs(rfc): use base-path runtime config SSOT

### DIFF
--- a/docs/rfc/RFC-0342-capability-catalog-overlay-and-boot-posture.md
+++ b/docs/rfc/RFC-0342-capability-catalog-overlay-and-boot-posture.md
@@ -62,7 +62,7 @@ ownership. Two defects compounded:
      radius is not.
 
 Interim state after the incident: masc#24528 restores boot, with a
-deployment-local full fork (`~/.masc/config/oas-models.toml` = upstream copy +
+deployment-local full fork (`<base-path>/.masc/config/oas-models.toml` = upstream copy +
 five alias rows, labeled `WORKAROUND … removal target: overlay RFC merge`).
 That fork is the debt this RFC removes.
 


### PR DESCRIPTION
## 문제

최신 main CI의 SSOT bypass ratchet에서 RFC-0342가 bare `~/.masc/config/oas-models.toml`을 추가해 R6 baseline이 3에서 4로 증가했습니다.

## 수정

- 런타임 config 위치를 `<base-path>/.masc/config/oas-models.toml`로 표기
- baseline 증가는 허용하지 않음

## 검증

- `bash scripts/check-ssot.sh` 통과
- `git diff --check`
- 문서-only 변경; 로컬 Dune 미실행

# ci:skip-test-coverage

문서의 경로 표기만 SSOT에 맞추는 변경으로 실행 코드가 없습니다.