### PR TITLE
fix(keeper): continue ready lane drain without sleep

### DIFF
--- a/lib/keeper/keeper_composite_observer.ml
+++ b/lib/keeper/keeper_composite_observer.ml
@@ -399,6 +399,8 @@ let wake_reason_kind_and_stimuli (wake : Keeper_registry.wake_reason) : string *
   | Keeper_registry.Proactive_tick -> "proactive_tick", []
   | Keeper_registry.Woken stimuli ->
     "woken", List.map Keeper_event_queue.payload_kind_label stimuli
+  | Keeper_registry.Ready_queue_followup stimuli ->
+    "ready_queue_followup", List.map Keeper_event_queue.payload_kind_label stimuli
 
 let run_state_to_json (rs : run_state) : Yojson.Safe.t =
   match rs with

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -118,6 +118,11 @@ type ready_queue_followup =
   | Drain_ready_queue of
       { excluding : Keeper_event_queue.stimulus option }
 
+type turn_origin =
+  | Cadence_tick
+  | External_wakeup
+  | Ready_queue_drain
+
 type keepalive_turn_outcome =
   { meta : keeper_meta
   ; cycle_crashed : bool
@@ -463,6 +468,28 @@ let ready_queue_followup_of_settlement ~lease = function
     No_ready_queue_followup
 ;;
 
+let next_turn_origin ~ready_queue_followup_count ~sleep =
+  if ready_queue_followup_count > 0
+  then Some Ready_queue_drain
+  else
+    match sleep () with
+    | Keeper_keepalive_signal.Stopped -> None
+    | Keeper_keepalive_signal.Woken -> Some External_wakeup
+    | Keeper_keepalive_signal.Timeout -> Some Cadence_tick
+;;
+
+let wake_reason_of_turn_origin origin stimuli =
+  let payloads =
+    List.map
+      (fun (stimulus : Keeper_event_queue.stimulus) -> stimulus.payload)
+      stimuli
+  in
+  match origin with
+  | Cadence_tick -> Keeper_registry.Proactive_tick
+  | External_wakeup -> Keeper_registry.Woken payloads
+  | Ready_queue_drain -> Keeper_registry.Ready_queue_followup payloads
+;;
+
 (* Pure: post-turn status event derived from the registry turn-failure
    counter. Extracted from the loop body so the crashed-cycle ->
    [Turn_failed] mapping is unit-testable. *)
@@ -478,7 +505,7 @@ let run_keepalive_unified_turn
       ~pending_board_events
       ~(stop : bool Atomic.t)
       ~(proactive_warmup_elapsed : bool)
-      ~(reactive_wake : bool)
+      ~(turn_origin : turn_origin)
       ~(shared_context : Agent_sdk.Context.t)
   : keepalive_turn_outcome
   =
@@ -575,7 +602,10 @@ let run_keepalive_unified_turn
       in
       let scheduling =
         decide_keepalive_scheduling
-          ~reactive_wake
+          ~reactive_wake:
+            (match turn_origin with
+             | External_wakeup -> true
+             | Cadence_tick | Ready_queue_drain -> false)
           ~event_queue_triggers:event_intake.event_queue_triggers
           ~stop
           ~meta:meta_after_triage
@@ -742,23 +772,12 @@ let run_keepalive_unified_turn
               Some completion.channel
             | [] | [ _ ] | _ :: _ :: _ -> None
           in
-          (* #16 (38-bug campaign PR-5): [reactive_wake] tells us this cycle
-             was triggered by an external signal rather than the proactive
-             cadence tick, but by itself does not say *which* stimulus (or
-             whether the event queue drained anything at all). Pairing it
-             with [!consumed_stimuli] — already drained above, unchanged
-             until the post-turn ack/requeue below — gives
-             [mark_turn_started] a total, typed answer instead of the
-             boolean the registry previously discarded. *)
-          let wake : Keeper_registry.wake_reason =
-            if reactive_wake
-            then
-              Keeper_registry.Woken
-                (List.map
-                   (fun (stim : Keeper_event_queue.stimulus) ->
-                      stim.Keeper_event_queue.payload)
-                   !consumed_stimuli)
-            else Keeper_registry.Proactive_tick
+          (* Preserve whether this turn came from the configured cadence, an
+             external wakeup CAS, or an internal ready-lane continuation.
+             The consumed stimuli provide the exact typed cause without
+             collapsing the internal continuation into [Woken]. *)
+          let wake =
+            wake_reason_of_turn_origin turn_origin !consumed_stimuli
           in
           let cycle_outcome =
             run_keeper_cycle
@@ -932,6 +951,9 @@ let record_keepalive_stage_timing = Keeper_heartbeat_loop_snapshot_timing.record
                       consumes the wakeup via
                       [Atomic.compare_and_set wakeup true false], then
                       the loop body services the pending event.
+     LaneDrain        [next_turn_origin] observes another exact ready
+                      stimulus after settlement and continues the same
+                      Keeper lane without reading or clearing [wakeup].
      TurnComplete     turn body finishes; loop returns to next sleep
                       cycle.
      MissedWakeup     bug action — the wakeup is observed and cleared
@@ -996,12 +1018,9 @@ let run_heartbeat_loop
      no operator has modified it.  Initialized to 0.0 so the first
      cycle always reads. *)
   let last_meta_mtime = ref 0.0 in
-  (* Wake-source carry (thundering-herd fix). Records whether the most recent
-     sleep ended via an external broadcast wakeup ([Woken]) or this keeper's own
-     cadence timer ([Timeout]). Read at turn dispatch so a broadcast-driven early
-     wake does not let the GLOBAL task backlog drive a turn on every keeper at
-     once. Single-fiber owned, like the other loop-local refs above. *)
-  let last_wake_source = ref Keeper_keepalive_signal.Timeout in
+  (* Typed turn provenance. An internal ready-queue drain is distinct from the
+     external wakeup CAS and therefore never masquerades as [Woken]. *)
+  let last_turn_origin = ref Cadence_tick in
   let rec loop () =
     if Atomic.get stop
     then ()
@@ -1170,15 +1189,6 @@ let run_heartbeat_loop
                pre/post guards mirror the spec's [turn_state] transition
                "running" -> "idle". *)
             turn_running := true;
-            (* [Woken] => this cycle was triggered by an external broadcast, not
-               the keeper's own cadence; suppress global-backlog-driven turns to
-               avoid the all-keeper stampede. *)
-            let reactive_wake =
-              match !last_wake_source with
-              | Keeper_keepalive_signal.Woken -> true
-              | Keeper_keepalive_signal.Timeout | Keeper_keepalive_signal.Stopped ->
-                false
-            in
             let r =
               run_keepalive_unified_turn
                 ~ctx
@@ -1186,7 +1196,7 @@ let run_heartbeat_loop
                 ~pending_board_events
                 ~stop
                 ~proactive_warmup_elapsed
-                ~reactive_wake
+                ~turn_origin:!last_turn_origin
                 ~shared_context
             in
             Keeper_keepalive_signal.pre_turn_complete_heartbeat ~turn_running;
@@ -1268,25 +1278,26 @@ let run_heartbeat_loop
             |> Keeper_heartbeat_stimulus_intake.ready_stimulus_count ~excluding
           | Drain_ready_queue _ -> 0
         in
-        (* Carry the inter-cycle sleep result into the next iteration so the
-           turn evaluator can distinguish a broadcast wakeup ([Woken]) from this
-           keeper's configured cadence ([Timeout]). *)
-        last_wake_source :=
-          if ready_queue_followup_count > 0
-          then (
-            let absorbed_wakeup_hint = Atomic.compare_and_set wakeup true false in
-            Log.Keeper.info
-              "%s: keeper lane drain continues without heartbeat sleep ready=%d wake_hint_absorbed=%b"
-              meta_current.name
-              ready_queue_followup_count
-              absorbed_wakeup_hint;
-            Keeper_keepalive_signal.Woken)
-          else
-            Keeper_keepalive_signal.interruptible_sleep
-              ~clock:ctx.clock
-              ~stop
-              ~wakeup
-              interval;
+        (match
+           next_turn_origin
+             ~ready_queue_followup_count
+             ~sleep:(fun () ->
+               Keeper_keepalive_signal.interruptible_sleep
+                 ~clock:ctx.clock
+                 ~stop
+                 ~wakeup
+                 interval)
+         with
+         | None -> ()
+         | Some origin ->
+           (match origin with
+            | Ready_queue_drain ->
+              Log.Keeper.info
+                "%s: keeper lane drain continues without heartbeat sleep ready=%d"
+                meta_current.name
+                ready_queue_followup_count
+            | Cadence_tick | External_wakeup -> ());
+           last_turn_origin := origin);
       if Atomic.get stop then () else loop ())
   in
   loop ()

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -113,10 +113,16 @@ let run_keeper_cycle = Cycle.run_keeper_cycle
    [Turn_failed] instead of [Turn_succeeded]. Such a cycle must also
    NOT refresh the work-as-heartbeat lease; the count is observation and never
    terminates the Keeper lane. *)
-type keepalive_turn_outcome = {
-  meta : keeper_meta;
-  cycle_crashed : bool;
-}
+type ready_queue_followup =
+  | No_ready_queue_followup
+  | Drain_ready_queue of
+      { excluding : Keeper_event_queue.stimulus option }
+
+type keepalive_turn_outcome =
+  { meta : keeper_meta
+  ; cycle_crashed : bool
+  ; ready_queue_followup : ready_queue_followup
+  }
 
 exception Event_queue_settlement_failed of string
 
@@ -436,6 +442,27 @@ let settlement_is_ack = function
     false
 ;;
 
+let ready_queue_followup_of_settlement ~lease = function
+  | Keeper_registry_event_queue.Ack
+  | Keeper_registry_event_queue.Escalate _ ->
+    Drain_ready_queue { excluding = None }
+  | Keeper_registry_event_queue.Requeue
+      ( Keeper_registry_event_queue.Rotate_now
+      | Keeper_registry_event_queue.Retry_after_observed
+      | Keeper_registry_event_queue.Context_compaction_retry
+      | Keeper_registry_event_queue.Approval_grant_unconsumed
+      | Keeper_registry_event_queue.Approval_grant_state_unavailable ) ->
+    Drain_ready_queue
+      { excluding = Some (Keeper_registry_event_queue.lease_stimulus lease) }
+  | Keeper_registry_event_queue.Requeue
+      ( Keeper_registry_event_queue.Cycle_busy
+      | Keeper_registry_event_queue.Turn_not_scheduled
+      | Keeper_registry_event_queue.Cancelled
+      | Keeper_registry_event_queue.Cycle_crashed
+      | Keeper_registry_event_queue.Registration_recovery ) ->
+    No_ready_queue_followup
+;;
+
 (* Pure: post-turn status event derived from the registry turn-failure
    counter. Extracted from the loop body so the crashed-cycle ->
    [Turn_failed] mapping is unit-testable. *)
@@ -456,13 +483,18 @@ let run_keepalive_unified_turn
   : keepalive_turn_outcome
   =
   if not proactive_warmup_elapsed
-  then { meta = meta_after_triage; cycle_crashed = false }
+  then
+    { meta = meta_after_triage
+    ; cycle_crashed = false
+    ; ready_queue_followup = No_ready_queue_followup
+    }
   else (
     let consumed_stimuli = ref [] in
     let claimed_lease = ref None in
     let cycle_outcome_ref = ref None in
     let lease_settled = ref false in
     let settlement_failed = ref false in
+    let ready_queue_followup = ref No_ready_queue_followup in
     let record_settlement_failure message =
       settlement_failed := true;
       match !cycle_outcome_ref with
@@ -776,7 +808,8 @@ let run_keepalive_unified_turn
                        meta_after_triage.name
                        successor
                    with
-                   | Ok () -> ()
+                   | Ok () ->
+                     ready_queue_followup := Drain_ready_queue { excluding = None }
                    | Error message ->
                      Log.Keeper.error
                        "registry: unleased failure judgment enqueue failed keeper=%s: %s"
@@ -830,6 +863,8 @@ let run_keepalive_unified_turn
               ( Keeper_registry_event_queue.Settled _
               | Keeper_registry_event_queue.Already_settled _ ) ->
             lease_settled := true;
+            ready_queue_followup :=
+              ready_queue_followup_of_settlement ~lease settlement;
             (match
                project_transition_outbox
                  ~base_path:ctx.config.base_path
@@ -843,7 +878,10 @@ let run_keepalive_unified_turn
                 ~base_path:ctx.config.base_path
                 ~keeper_name:meta_after_triage.name
                 (connector_attention_event_ids_of_stimuli !consumed_stimuli)));
-      { meta = meta_after_cycle; cycle_crashed = !settlement_failed }
+      { meta = meta_after_cycle
+      ; cycle_crashed = !settlement_failed
+      ; ready_queue_followup = !ready_queue_followup
+      }
     with
     | Eio.Cancel.Cancelled _ as e ->
       let backtrace = Printexc.get_raw_backtrace () in
@@ -862,7 +900,10 @@ let run_keepalive_unified_turn
         ~base_path:ctx.config.base_path
         ~keeper_name:meta_after_triage.name
         exn;
-      { meta = meta_after_triage; cycle_crashed = true })
+      { meta = meta_after_triage
+      ; cycle_crashed = true
+      ; ready_queue_followup = No_ready_queue_followup
+      })
 ;;
 
 let refresh_work_as_heartbeat = Keeper_heartbeat_loop_refresh_work.refresh_work_as_heartbeat
@@ -1118,7 +1159,11 @@ let run_heartbeat_loop
         let t_turn_start = t_board_end in
         let turn_outcome =
           if not admitted_turn
-          then { meta = meta_current; cycle_crashed = false }
+          then
+            { meta = meta_current
+            ; cycle_crashed = false
+            ; ready_queue_followup = No_ready_queue_followup
+            }
           else (
             (* Cycle 43: KeeperHeartbeat.tla TurnComplete bracket — the
                [turn_running] flag toggles around the dispatch and the
@@ -1209,15 +1254,39 @@ let run_heartbeat_loop
           ~t_board_end
           ~t_turn_start
           ~t_turn_end;
+        let ready_queue_followup_count =
+          match turn_outcome.ready_queue_followup with
+          | No_ready_queue_followup -> 0
+          | Drain_ready_queue { excluding }
+            when
+              proactive_warmup_elapsed
+              && not lifecycle_blocked
+              && not turn_outcome.cycle_crashed ->
+            Keeper_registry_event_queue.snapshot
+              ~base_path:ctx.config.base_path
+              meta_current.name
+            |> Keeper_heartbeat_stimulus_intake.ready_stimulus_count ~excluding
+          | Drain_ready_queue _ -> 0
+        in
         (* Carry the inter-cycle sleep result into the next iteration so the
            turn evaluator can distinguish a broadcast wakeup ([Woken]) from this
            keeper's configured cadence ([Timeout]). *)
         last_wake_source :=
-          Keeper_keepalive_signal.interruptible_sleep
-            ~clock:ctx.clock
-            ~stop
-            ~wakeup
-            interval;
+          if ready_queue_followup_count > 0
+          then (
+            let absorbed_wakeup_hint = Atomic.compare_and_set wakeup true false in
+            Log.Keeper.info
+              "%s: keeper lane drain continues without heartbeat sleep ready=%d wake_hint_absorbed=%b"
+              meta_current.name
+              ready_queue_followup_count
+              absorbed_wakeup_hint;
+            Keeper_keepalive_signal.Woken)
+          else
+            Keeper_keepalive_signal.interruptible_sleep
+              ~clock:ctx.clock
+              ~stop
+              ~wakeup
+              interval;
       if Atomic.get stop then () else loop ())
   in
   loop ()

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -108,10 +108,24 @@ val record_provider_timeout_observation :
     unified-turn failure path uses — so the caller dispatches
     [Turn_failed]. Such a cycle must not refresh the
     work-as-heartbeat lease. *)
-type keepalive_turn_outcome = {
-  meta : keeper_meta;
-  cycle_crashed : bool;
-}
+type ready_queue_followup =
+  | No_ready_queue_followup
+  | Drain_ready_queue of
+      { excluding : Keeper_event_queue.stimulus option }
+
+type keepalive_turn_outcome =
+  { meta : keeper_meta
+  ; cycle_crashed : bool
+  ; ready_queue_followup : ready_queue_followup
+  }
+
+val ready_queue_followup_of_settlement
+  :  lease:Keeper_registry_event_queue.lease
+  -> Keeper_registry_event_queue.settlement
+  -> ready_queue_followup
+(** Decide whether a committed settlement may immediately drain other ready
+    work. A retryable/recoverable source is excluded for this one follow-up so
+    it cannot monopolize the lane ahead of unrelated stimuli. *)
 
 (** Record a swallowed keepalive-cycle exception as a turn failure:
     increments the registry turn-failure counter (shared with

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -113,6 +113,11 @@ type ready_queue_followup =
   | Drain_ready_queue of
       { excluding : Keeper_event_queue.stimulus option }
 
+type turn_origin =
+  | Cadence_tick
+  | External_wakeup
+  | Ready_queue_drain
+
 type keepalive_turn_outcome =
   { meta : keeper_meta
   ; cycle_crashed : bool
@@ -126,6 +131,18 @@ val ready_queue_followup_of_settlement
 (** Decide whether a committed settlement may immediately drain other ready
     work. A retryable/recoverable source is excluded for this one follow-up so
     it cannot monopolize the lane ahead of unrelated stimuli. *)
+
+val next_turn_origin
+  :  ready_queue_followup_count:int
+  -> sleep:(unit -> Keeper_keepalive_signal.sleep_outcome)
+  -> turn_origin option
+(** Select the next cycle provenance. Ready durable work continues the lane
+    without invoking the external wakeup sleep/CAS path. *)
+
+val wake_reason_of_turn_origin
+  :  turn_origin
+  -> Keeper_event_queue.stimulus list
+  -> Keeper_registry.wake_reason
 
 (** Record a swallowed keepalive-cycle exception as a turn failure:
     increments the registry turn-failure counter (shared with
@@ -177,7 +194,7 @@ val run_keepalive_unified_turn :
   pending_board_events:Keeper_world_observation.pending_board_event list ->
   stop:bool Atomic.t ->
   proactive_warmup_elapsed:bool ->
-  reactive_wake:bool ->
+  turn_origin:turn_origin ->
   shared_context:Agent_sdk.Context.t ->
   keepalive_turn_outcome
 

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -265,6 +265,22 @@ let stimulus_ready_for_intake (stimulus : Keeper_event_queue.stimulus) =
     true
 ;;
 
+let ready_stimulus_count ~excluding queue =
+  Keeper_event_queue.to_list queue
+  |> List.fold_left
+       (fun count stimulus ->
+          let excluded =
+            match excluding with
+            | None -> false
+            | Some excluded ->
+              Keeper_event_queue.stimulus_identity_equal stimulus excluded
+          in
+          if (not excluded) && stimulus_ready_for_intake stimulus
+          then count + 1
+          else count)
+       0
+;;
+
 let heartbeat_event_intake
       ~ctx
       ~meta_after_triage

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.mli
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.mli
@@ -52,6 +52,15 @@ val consume_single_heartbeat_stimulus
   -> Keeper_event_queue.stimulus
   -> Keeper_world_observation.pending_board_event list
 
+val ready_stimulus_count
+  :  excluding:Keeper_event_queue.stimulus option
+  -> Keeper_event_queue.t
+  -> int
+(** Count exact typed stimuli that can be leased now, optionally excluding the
+    identity retained by the just-finished cycle. This is the queue-drain
+    continuation probe; it neither mutates the queue nor invents a time/count
+    threshold. *)
+
 (** [heartbeat_event_intake ~ctx ~meta_after_triage
      ~pending_board_events]
     drains the Event-Layer queue (per RFC-0020 §3 Rule 4) and merges

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -154,14 +154,6 @@ let mark_turn_finished ~base_path name =
   Option.iter
     (Keeper_transition_audit.record_completed_turn ~keeper_name:name)
     !completed_turn_to_record;
-  (* IR-1 belt-and-suspenders: reset wakeup after turn completes so a stale
-     true cannot suppress the next wakeup signal.  The primary consumer is
-     [interruptible_sleep]'s CAS, but an explicit reset here guarantees the
-     flag is clean regardless of whether the heartbeat loop's sleep path ran. *)
-  (match get ~base_path name with
-   (* tla-lint: allow-mutation: fiber signal — clear stale wakeup flag, paired with [interruptible_sleep] CAS *)
-   | Some entry -> Atomic.set entry.fiber_wakeup false
-   | None -> ());
   if changed then broadcast_composite_changed ~name ~ts_unix:now
 ;;
 

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -328,7 +328,7 @@ val prepare_turn_retry_after_compaction :
     so the composite observer reverts to idle and stamps
     [runtime.usage.last_turn_ts] for the completed turn. Idempotent —
     safe to call in finally blocks even if [mark_turn_started] was not
-    called. *)
+    called; [fiber_wakeup] remains owned by the heartbeat sleep CAS. *)
 val mark_turn_finished : base_path:string -> string -> unit
 
 (** Store or clear the live [Eio.Switch.t] for the current turn.

--- a/lib/keeper/keeper_registry_types.ml
+++ b/lib/keeper/keeper_registry_types.ml
@@ -76,10 +76,12 @@ type turn_attempt_state =
 type wake_reason =
   | Proactive_tick
   | Woken of Keeper_event_queue.stimulus_payload list
+  | Ready_queue_followup of Keeper_event_queue.stimulus_payload list
 
 let wake_reason_label = function
   | Proactive_tick -> "proactive_tick"
   | Woken _ -> "woken"
+  | Ready_queue_followup _ -> "ready_queue_followup"
 ;;
 
 type turn_measurement =

--- a/lib/keeper/keeper_registry_types.mli
+++ b/lib/keeper/keeper_registry_types.mli
@@ -388,11 +388,13 @@ type turn_attempt_state = {
 type wake_reason =
   | Proactive_tick
   | Woken of Keeper_event_queue.stimulus_payload list
+  | Ready_queue_followup of Keeper_event_queue.stimulus_payload list
 
 val wake_reason_label : wake_reason -> string
-(** Stable low-cardinality label: ["proactive_tick"] or ["woken"]. Use
-    {!Keeper_event_queue.payload_kind_label} on the carried stimuli (for
-    [Woken]) to surface the finer-grained wake cause. *)
+(** Stable low-cardinality provenance label. [Woken] is reserved for an
+    external wakeup CAS; [Ready_queue_followup] is an internal continuation of
+    the same Keeper lane. Use {!Keeper_event_queue.payload_kind_label} on the
+    carried stimuli to surface the finer-grained cause. *)
 
 type turn_measurement = {
   tm_captured_at : float;

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -444,12 +444,13 @@ let settle ~settled_at ~lease ~settlement state =
       match settlement with
       | Ack -> state.pending
       | Requeue
-          ( Retry_after_observed
+          ( Rotate_now
+          | Retry_after_observed
           | Context_compaction_retry
           | Approval_grant_unconsumed
           | Approval_grant_state_unavailable ) ->
-        (* Retryable provider work, a completed context-compaction handoff,
-           and a durable one-shot grant retain the exact leased stimuli
+        (* Provider rotation/retry, a completed context-compaction handoff,
+           and a durable one-shot grant retain the exact leased stimulus
            without monopolizing the FIFO front. *)
         append_missing [ committed.stimulus ] state.pending
       | Requeue _ -> prepend_missing [ committed.stimulus ] state.pending

--- a/lib/keeper_runtime/keeper_event_queue_state.mli
+++ b/lib/keeper_runtime/keeper_event_queue_state.mli
@@ -96,9 +96,9 @@ val settle :
     same semantic settlement returns [Already_settled]; a different settlement
     for an already-settled lease is an explicit conflict.
 
-    [Retry_after_observed] and [Context_compaction_retry] retain the exact
-    leased stimuli at the pending FIFO tail so unrelated work in the same lane
-    can proceed before another provider attempt. *)
+    [Rotate_now], [Retry_after_observed], and [Context_compaction_retry] retain
+    the exact leased stimulus at the pending FIFO tail so unrelated work in the
+    same lane can proceed before another provider attempt. *)
 
 val recover_leases : settled_at:float -> t -> (t, string) result
 (** Requeue every active lease with [Registration_recovery], preserving claim

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-07-12T22:38:15Z (HEAD: dc2ade608c)
+Generated: 2026-07-16T21:56:24Z (HEAD: 81a189fd50)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -80,7 +80,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | KeeperDecisionPipeline.tla | KeeperDecisionPipeline | manual | 2 | 1 | clean={inv:TypeOK, inv:Safety, prop:Liveness} buggy={inv:DecisionBoundaryRequiresMeasurement} | 7077b7639f77 |
 | KeeperDwellMonotone.tla | KeeperDwellMonotone | manual | 2 | 1 | clean={inv:Safety} buggy={inv:DwellNonNegative} | eb079ef5c342 |
 | KeeperEventQueue.tla | KeeperEventQueue | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | cf9b1da37ed0 |
-| KeeperHeartbeat.tla | KeeperHeartbeat | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | d143b5beae39 |
+| KeeperHeartbeat.tla | KeeperHeartbeat | manual | 2 | 1 | clean={inv:TypeOK, inv:SafetyInvariant} buggy={inv:TypeOK, inv:SafetyInvariant} | 1173162cb8cd |
 | KeeperHitlDeferred.tla | KeeperHitlDeferred | manual | 4 | 3 | clean={inv:Safety, prop:UnrelatedLaneKeepsProgressing, prop:ResolutionEventuallyConsumed} blocking-buggy={inv:DeferredImmediately} consume-buggy={inv:ResolutionConsumedAtMostOnce} wake-buggy={inv:ResolutionWakesOriginOnly} | b5b3c09a5b2e |
 | KeeperOutcomesConservation.tla | KeeperOutcomesConservation | manual | 2 | 1 | clean={inv:Safety} buggy={inv:ConservationLaw} | 0f108e4fd315 |
 | KeeperStateMachine.tla | KeeperStateMachine | manual | 2 | 1 | clean={inv:TypeOK, inv:DeadRequiresTombstone, inv:PausedRequiresOperator, inv:StoppedRequiresOperatorStop, inv:RestartingRequiresTypedIntent, prop:DeadIsForever, prop:StoppedIsForever, prop:TombstoneNeverClears} buggy={inv:TypeOK, inv:StoppedRequiresOperatorStop} | d1dee755cd34 |

--- a/specs/keeper-state-machine/KeeperHeartbeat.tla
+++ b/specs/keeper-state-machine/KeeperHeartbeat.tla
@@ -6,7 +6,8 @@
 \* [interruptible_sleep] whose [Atomic.compare_and_set wakeup true false]
 \* IS the HeartbeatTick action), [keeper_heartbeat_loop.ml]
 \* ([run_heartbeat_loop] turns every [Woken] sleep outcome into the next
-\* cycle without an intervening busy/idle/visibility policy), and
+\* cycle and [next_turn_origin] separately represents internal [LaneDrain]
+\* continuation without consuming the wakeup atomic), and
 \* [keeper_keepalive.ml] ([wakeup_keeper_by_agent_name] and
 \* [Atomic.set entry.fiber_wakeup true] on the WakeupSignal side; it
 \* re-exports [Keeper_heartbeat_loop] via [include]).
@@ -99,6 +100,13 @@ HeartbeatTick ==
     /\ turn_state' = "running"
     /\ unserved_signals' = unserved_signals - 1
 
+\* OCaml's exact ready probe is abstracted out: LaneDrain over-approximates
+\* internal transitions and proves wake safety only, not queue liveness.
+LaneDrain ==
+    /\ turn_state = "idle"
+    /\ turn_state' = "running"
+    /\ UNCHANGED << wakeup_signaled, unserved_signals >>
+
 \* The turn finishes; keeper returns to idle, ready for the next
 \* heartbeat poll.  The wakeup atomic is unaffected here.
 TurnComplete ==
@@ -128,7 +136,7 @@ MissedWakeup ==
 
 \* ── Spec wirings ───────────────────────────────────────────────
 
-Next      == WakeupSignal \/ HeartbeatTick \/ TurnComplete \/ Done
+Next      == WakeupSignal \/ HeartbeatTick \/ LaneDrain \/ TurnComplete \/ Done
 NextBuggy == Next \/ MissedWakeup
 
 Spec      == Init /\ [][Next]_vars

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -1,6 +1,9 @@
 module Queue = Keeper_event_queue
 module State = Keeper_event_queue_state
 module Persistence = Keeper_event_queue_persistence
+module Heartbeat = Masc.Keeper_heartbeat_loop
+module Intake = Masc.Keeper_heartbeat_stimulus_intake
+module Registry = Masc.Keeper_registry
 
 let require_ok label = function
   | Ok value -> value
@@ -592,52 +595,86 @@ let test_cancelled_and_skipped_cycles_requeue () =
 let test_settlement_controls_immediate_lane_drain () =
   let source = stimulus "drain-source" 1.0 in
   let unrelated = stimulus "unrelated-ready" 2.0 in
-  let lease = lease_for source in
-  let followup settlement =
-    Masc.Keeper_heartbeat_loop.ready_queue_followup_of_settlement
-      ~lease
-      settlement
+  let state = State.with_pending (queue [ source; unrelated ]) State.empty in
+  let state, lease = claim_head state in
+  let lease = require_some "drain source lease" lease in
+  let rotate = State.Requeue State.Rotate_now in
+  let state, settlement =
+    State.settle ~settled_at:3.0 ~lease ~settlement:rotate state
+    |> require_ok "rotate settlement"
   in
-  (match followup Masc.Keeper_registry_event_queue.Ack with
-   | Masc.Keeper_heartbeat_loop.Drain_ready_queue { excluding = None } -> ()
-   | _ -> Alcotest.fail "acknowledged work did not continue ready queue drain");
-  (match
-     followup
-       (Masc.Keeper_registry_event_queue.Requeue
-          Masc.Keeper_registry_event_queue.Retry_after_observed)
-   with
-   | Masc.Keeper_heartbeat_loop.Drain_ready_queue { excluding = Some retained }
-     when Queue.stimulus_identity_equal source retained ->
-     ()
-   | _ -> Alcotest.fail "retryable source was not excluded from immediate follow-up");
-  (match
-     followup
-       (Masc.Keeper_registry_event_queue.Requeue
-          Masc.Keeper_registry_event_queue.Context_compaction_retry)
-   with
-   | Masc.Keeper_heartbeat_loop.Drain_ready_queue { excluding = Some retained }
-     when Queue.stimulus_identity_equal source retained ->
-     ()
-   | _ -> Alcotest.fail "compaction retry source was not excluded from immediate follow-up");
+  let receipt =
+    match settlement with
+    | State.Settled receipt -> receipt
+    | State.Already_settled _ -> Alcotest.fail "first rotate was already settled"
+  in
+  let excluding =
+    match Heartbeat.ready_queue_followup_of_settlement ~lease rotate with
+    | Heartbeat.Drain_ready_queue { excluding } -> excluding
+    | Heartbeat.No_ready_queue_followup ->
+      Alcotest.fail "rotation did not request a ready-lane follow-up"
+  in
+  let state =
+    State.mark_transition_projected ~transition_id:receipt.transition_id state
+    |> require_ok "project rotate settlement"
+  in
   Alcotest.(check int)
-    "retained source does not hide unrelated ready work"
+    "post-settlement probe sees unrelated ready work"
     1
-    (Masc.Keeper_heartbeat_stimulus_intake.ready_stimulus_count
-       ~excluding:(Some source)
-       (queue [ source; unrelated ]));
-  Alcotest.(check int)
-    "retained source alone does not request an immediate loop"
-    0
-    (Masc.Keeper_heartbeat_stimulus_intake.ready_stimulus_count
-       ~excluding:(Some source)
-       (queue [ source ]));
+    (Intake.ready_stimulus_count ~excluding (State.pending state));
+  let state, next_lease =
+    State.claim_when ~claimed_at:4.0 ~ready:(fun _ -> true) state
+    |> require_ok "actual follow-up claim"
+  in
+  let next_lease = require_some "unrelated follow-up lease" next_lease in
+  Alcotest.(check string)
+    "actual claim follows the probe"
+    unrelated.post_id
+    next_lease.stimulus.post_id;
+  Alcotest.(check (list string))
+    "rotated source remains pending behind unrelated work"
+    [ source.post_id ]
+    (post_ids (State.pending state))
+;;
+
+let test_ready_queue_drain_has_internal_provenance_without_wakeup_cas () =
+  let base_path = Sys.getcwd () in
+  let meta = cycle_meta () in
+  let entry = Registry.register ~base_path meta.name meta in
+  Registry.mark_turn_started
+    ~base_path
+    ~wake:(Registry.Ready_queue_followup [ Queue.Bootstrap ])
+    meta.name;
+  Atomic.set entry.fiber_wakeup true;
+  Registry.mark_turn_finished ~base_path meta.name;
+  let sleep_called = ref false in
+  let origin =
+    Heartbeat.next_turn_origin
+      ~ready_queue_followup_count:1
+      ~sleep:(fun () ->
+        sleep_called := true;
+        if Atomic.compare_and_set entry.fiber_wakeup true false
+        then Masc.Keeper_keepalive_signal.Woken
+        else Masc.Keeper_keepalive_signal.Timeout)
+    |> require_some "ready queue turn origin"
+  in
+  Alcotest.(check bool)
+    "external wakeup CAS path was not entered"
+    false
+    !sleep_called;
+  Alcotest.(check bool)
+    "turn cleanup and internal drain preserve external wakeup"
+    true
+    (Atomic.get entry.fiber_wakeup);
+  Registry.unregister ~base_path meta.name;
   match
-    followup
-      (Masc.Keeper_registry_event_queue.Requeue
-         Masc.Keeper_registry_event_queue.Cycle_busy)
+    Heartbeat.wake_reason_of_turn_origin origin [ stimulus "internal-followup" 1.0 ]
   with
-  | Masc.Keeper_heartbeat_loop.No_ready_queue_followup -> ()
-  | _ -> Alcotest.fail "busy turn slot requested an immediate retry loop"
+  | Registry.Ready_queue_followup [ Queue.Bootstrap ] -> ()
+  | Registry.Ready_queue_followup _
+  | Registry.Proactive_tick
+  | Registry.Woken _ ->
+    Alcotest.fail "internal lane continuation used the wrong wake provenance"
 ;;
 
 let test_unconsumed_approval_requeues_behind_other_work () =
@@ -1058,6 +1095,10 @@ let () =
             "settlement controls immediate lane drain"
             `Quick
             test_settlement_controls_immediate_lane_drain
+        ; Alcotest.test_case
+            "ready lane drain keeps internal provenance"
+            `Quick
+            test_ready_queue_drain_has_internal_provenance_without_wakeup_cas
         ; Alcotest.test_case
             "unconsumed approval yields FIFO"
             `Quick

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -589,6 +589,57 @@ let test_cancelled_and_skipped_cycles_requeue () =
   | _ -> Alcotest.fail "non-executable phase acknowledged leased work"
 ;;
 
+let test_settlement_controls_immediate_lane_drain () =
+  let source = stimulus "drain-source" 1.0 in
+  let unrelated = stimulus "unrelated-ready" 2.0 in
+  let lease = lease_for source in
+  let followup settlement =
+    Masc.Keeper_heartbeat_loop.ready_queue_followup_of_settlement
+      ~lease
+      settlement
+  in
+  (match followup Masc.Keeper_registry_event_queue.Ack with
+   | Masc.Keeper_heartbeat_loop.Drain_ready_queue { excluding = None } -> ()
+   | _ -> Alcotest.fail "acknowledged work did not continue ready queue drain");
+  (match
+     followup
+       (Masc.Keeper_registry_event_queue.Requeue
+          Masc.Keeper_registry_event_queue.Retry_after_observed)
+   with
+   | Masc.Keeper_heartbeat_loop.Drain_ready_queue { excluding = Some retained }
+     when Queue.stimulus_identity_equal source retained ->
+     ()
+   | _ -> Alcotest.fail "retryable source was not excluded from immediate follow-up");
+  (match
+     followup
+       (Masc.Keeper_registry_event_queue.Requeue
+          Masc.Keeper_registry_event_queue.Context_compaction_retry)
+   with
+   | Masc.Keeper_heartbeat_loop.Drain_ready_queue { excluding = Some retained }
+     when Queue.stimulus_identity_equal source retained ->
+     ()
+   | _ -> Alcotest.fail "compaction retry source was not excluded from immediate follow-up");
+  Alcotest.(check int)
+    "retained source does not hide unrelated ready work"
+    1
+    (Masc.Keeper_heartbeat_stimulus_intake.ready_stimulus_count
+       ~excluding:(Some source)
+       (queue [ source; unrelated ]));
+  Alcotest.(check int)
+    "retained source alone does not request an immediate loop"
+    0
+    (Masc.Keeper_heartbeat_stimulus_intake.ready_stimulus_count
+       ~excluding:(Some source)
+       (queue [ source ]));
+  match
+    followup
+      (Masc.Keeper_registry_event_queue.Requeue
+         Masc.Keeper_registry_event_queue.Cycle_busy)
+  with
+  | Masc.Keeper_heartbeat_loop.No_ready_queue_followup -> ()
+  | _ -> Alcotest.fail "busy turn slot requested an immediate retry loop"
+;;
+
 let test_unconsumed_approval_requeues_behind_other_work () =
   List.iter
     (fun reason ->
@@ -1003,6 +1054,10 @@ let () =
             "cancelled and skipped cycles requeue"
             `Quick
             test_cancelled_and_skipped_cycles_requeue
+        ; Alcotest.test_case
+            "settlement controls immediate lane drain"
+            `Quick
+            test_settlement_controls_immediate_lane_drain
         ; Alcotest.test_case
             "unconsumed approval yields FIFO"
             `Quick


### PR DESCRIPTION
## Stack

Depends on #24628.

## Why

After a committed settlement, forcing the owner Keeper lane to sleep while another exact ready stimulus is already durable adds avoidable latency and can leave accepted connector/schedule/board work waiting for the heartbeat cadence.

## Change

- continue the same Keeper lane immediately when another durable stimulus is ready
- derive the follow-up only from the typed settlement result
- after Ack/Escalate, consider every ready pending stimulus
- after retry/rotate/compaction or unconsumed grant requeue, exclude only the exact just-requeued stimulus for one probe
- keep Busy, not-scheduled, cancellation, crash, and registration recovery on the ordinary wake path
- represent the exclusion as one optional typed stimulus, matching the exact single-stimulus lease contract

## Non-goals

- no timer threshold, max-turn, tool-round, budget, urgency sort, or count cutoff
- no cross-Keeper drain and no global worker
- no provider, Gate, Connector, or Scheduler policy change

## Verification

- `ocamlformat --check`
- `git diff --check`
- removed-list/recurring-symbol residue search: 0
- focused `main_eio` + event-queue state build passed
- event-queue state suite passed 14/14
- full build/test remains PR CI authority
