### PR TITLE
fix(server): overlay presence suppresses parent-directory catalog fallback

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -112,6 +112,23 @@ let argv0_parent_dir ~cwd argv0 =
   | None -> None
   | Some path -> Some (Filename.dirname path)
 
+(* RFC-0342 D1 / RFC-OAS-036: deployment-local capability deltas live in a
+   config-root overlay merged onto the embedded catalog
+   ([Model_catalog.set_global_overlay]), instead of a full-catalog fork that
+   shadows every embedded row and goes stale on each OAS release. A resolved
+   full catalog (env var or config-root file) still wins outright:
+   [Model_catalog.global] gives the [set_global] replacement precedence over
+   the overlay. *)
+let resolve_oas_model_catalog_overlay_path ?config_root () =
+  match config_root with
+  | None -> None
+  | Some root ->
+    let root = String.trim root in
+    if String.equal root "" then
+      None
+    else
+      existing_file (Filename.concat root oas_models_overlay_toml_filename)
+
 let resolve_oas_model_catalog_path
       ?(env = Sys.getenv_opt)
       ?config_root
@@ -152,12 +169,23 @@ let resolve_oas_model_catalog_path
         with
         | Some _ as found -> found
         | None ->
-          (match find_catalog_in_parents ~origin:Cwd_parent search_cwd with
-           | Some _ as found -> found
-           | None ->
-             (match argv0_parent_dir ~cwd:process_cwd argv0 with
-              | Some dir -> find_catalog_in_parents ~origin:Argv0_parent dir
-              | None -> None))))
+          (* A config-root overlay declares an embedded-based deployment
+             (RFC-0342 D1). The parent-directory walk below is a
+             checkout-dev convenience; letting it resolve a repo copy here
+             would whole-replace the embedded ⊕ overlay catalog with a file
+             that cannot know the deployment's delta rows (2026-07-15 boot
+             FATAL: argv0-parent found the masc repo oas-models.toml).
+             Explicit env vars and a config-root full catalog above still
+             take precedence over the overlay. *)
+          if Option.is_some (resolve_oas_model_catalog_overlay_path ?config_root ())
+          then None
+          else
+            (match find_catalog_in_parents ~origin:Cwd_parent search_cwd with
+             | Some _ as found -> found
+             | None ->
+               (match argv0_parent_dir ~cwd:process_cwd argv0 with
+                | Some dir -> find_catalog_in_parents ~origin:Argv0_parent dir
+                | None -> None))))
 
 let install_runtime_model_catalog_override ~load_catalog ~set_catalog path =
   match load_catalog path with
@@ -200,23 +228,6 @@ let configure_oas_model_catalog_env
      | None ->
        raise (Env_config_core.Config_error "model_catalog: OAS embedded model catalog is unavailable"));
     None
-
-(* RFC-0342 D1 / RFC-OAS-036: deployment-local capability deltas live in a
-   config-root overlay merged onto the embedded catalog
-   ([Model_catalog.set_global_overlay]), instead of a full-catalog fork that
-   shadows every embedded row and goes stale on each OAS release. A resolved
-   full catalog (env var or config-root file above) still wins outright:
-   [Model_catalog.global] gives the [set_global] replacement precedence over
-   the overlay. *)
-let resolve_oas_model_catalog_overlay_path ?config_root () =
-  match config_root with
-  | None -> None
-  | Some root ->
-    let root = String.trim root in
-    if String.equal root "" then
-      None
-    else
-      existing_file (Filename.concat root oas_models_overlay_toml_filename)
 
 let configure_oas_model_catalog_overlay
       ?config_root

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -301,6 +301,56 @@ let test_model_catalog_configuration_prefers_config_root_catalog () =
     Alcotest.(check (list string)) "load catalog" [ catalog ] (List.rev !load_calls);
     Alcotest.(check int) "set catalog override" 1 !set_calls)
 
+let test_model_catalog_overlay_suppresses_parent_fallback () =
+  with_temp_dir "model-catalog-overlay-no-parent-fallback" (fun dir ->
+    let config_root = Filename.concat dir "config-root" in
+    let repo = Filename.concat dir "repo" in
+    let bin = Filename.concat repo "_build/default/bin/main_eio.exe" in
+    let parent_catalog = Filename.concat repo "oas-models.toml" in
+    mkdir_p config_root;
+    mkdir_p (Filename.dirname bin);
+    write_file bin "";
+    write_file parent_catalog "[[models]]\nid_prefix = \"repo-copy\"\n";
+    write_file
+      (Filename.concat config_root "oas-models-overlay.toml")
+      "[[models]]\nid_prefix = \"deployment-delta\"\n";
+    let result =
+      Server_runtime_bootstrap.resolve_oas_model_catalog_path
+        ~env:(fun _ -> None)
+        ~config_root
+        ~cwd:repo
+        ~argv0:bin
+        ()
+    in
+    Alcotest.(check bool)
+      "overlay declares embedded base; parent repo copy must not resolve"
+      true
+      (Option.is_none result))
+
+let test_model_catalog_config_root_full_catalog_wins_over_overlay () =
+  with_temp_dir "model-catalog-full-beats-overlay" (fun dir ->
+    let config_root = Filename.concat dir "config-root" in
+    let full = Filename.concat config_root "oas-models.toml" in
+    mkdir_p config_root;
+    write_file full "[[models]]\nid_prefix = \"explicit-full\"\n";
+    write_file
+      (Filename.concat config_root "oas-models-overlay.toml")
+      "[[models]]\nid_prefix = \"deployment-delta\"\n";
+    match
+      Server_runtime_bootstrap.resolve_oas_model_catalog_path
+        ~env:(fun _ -> None)
+        ~config_root
+        ~cwd:config_root
+        ~argv0:(Filename.concat config_root "main_eio.exe")
+        ()
+    with
+    | None -> Alcotest.fail "expected config-root full catalog resolution"
+    | Some resolution ->
+      Alcotest.(check string)
+        "explicit config-root full catalog still wins"
+        (canonical_path full)
+        (canonical_path resolution.Server_runtime_bootstrap.path))
+
 let test_model_catalog_overlay_installs_config_root_overlay () =
   with_temp_dir "model-catalog-overlay-install" (fun dir ->
     let config_root = Filename.concat dir "config-root" in
@@ -4713,6 +4763,12 @@ let () =
           Alcotest.test_case
             "model catalog configuration prefers config-root catalog"
             `Quick test_model_catalog_configuration_prefers_config_root_catalog;
+          Alcotest.test_case
+            "model catalog overlay suppresses parent fallback"
+            `Quick test_model_catalog_overlay_suppresses_parent_fallback;
+          Alcotest.test_case
+            "model catalog config-root full catalog wins over overlay"
+            `Quick test_model_catalog_config_root_full_catalog_wins_over_overlay;
           Alcotest.test_case
             "model catalog overlay installs config-root overlay"
             `Quick test_model_catalog_overlay_installs_config_root_overlay;


### PR DESCRIPTION
## 문제 (오늘 밤 배포 실측)

fork `oas-models.toml` 제거 후 첫 overlay 배포에서 boot FATAL 재발. 원인: config-root에 full 카탈로그가 없어지자 해석이 **argv0-parent 폴백**으로 넘어가 masc repo의 tracked `oas-models.toml`(`_build/default/` 사본)을 resolve → `set_global` full-replace가 embedded ⊕ overlay를 덮음 → 배포 alias 전멸 → supervisor crash-loop (서킷브레이커 정지). RFC-0342가 follow-up으로 적어둔 "repo 사본 제거"의 실전 발현.

## 수정

`resolve_oas_model_catalog_path`: config-root에 `oas-models-overlay.toml`이 존재하면 **parent-디렉토리 폴백만 차단**. 
- env(`OAS_MODEL_CATALOG`/`MASC_MODEL_CATALOG`)와 config-root full 카탈로그의 명시적 우선권은 유지 (full-replace 의도 보존).
- overlay 없는 dev 체크아웃은 기존 폴백 그대로 (무변화).
- 의미: overlay 선언 = "embedded 기반 배포"라는 posture이며, 체크아웃-dev 편의 폴백이 이를 가릴 수 없다.

repo 사본 자체 제거(소비처: install seed/docker-entrypoint/tests/release-evidence)는 별도 트랙 — 이 PR은 배포 semantics만 바로잡음.

## 검증 (로컬)

- 신규 테스트 2: overlay가 parent 폴백 차단 / config-root full 카탈로그는 여전히 overlay보다 우선
- 카탈로그 스위트 11/11 green (main_eio E2E 재검 진행 중, 코멘트로 기록)

Refs: RFC-0342(#24530), #24592, 오늘 FATAL 로그 `masc-restart-overlay-20260715.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
