### PR TITLE
refactor(fusion): delete judge wave budget contract

### DIFF
--- a/dashboard/src/lib/fusion-meta.test.ts
+++ b/dashboard/src/lib/fusion-meta.test.ts
@@ -332,8 +332,8 @@ describe('normalizeFusionJudgeNodes', () => {
         role: 'meta',
         identity: 'o1',
         status: 'failed',
-        error: 'judge budget exceeded',
-        failure_code: 'budget_exceeded',
+        error: 'provider unavailable',
+        failure_code: 'provider_error',
         elapsed_s: 12.5,
         timed_out: true,
         input_tokens: 800,
@@ -343,8 +343,8 @@ describe('normalizeFusionJudgeNodes', () => {
     expect(node).toMatchObject({
       role: 'meta',
       failed: true,
-      error: 'judge budget exceeded',
-      failureCode: 'budget_exceeded',
+      error: 'provider unavailable',
+      failureCode: 'provider_error',
       elapsedS: 12.5,
       timedOut: true,
     })

--- a/docs/rfc/RFC-0306-fusion-settings-typed-editor.md
+++ b/docs/rfc/RFC-0306-fusion-settings-typed-editor.md
@@ -188,7 +188,7 @@ no longer enforces.
 - Creating/deleting whole presets from the UI (edit existing presets only); preset
   CRUD is a possible follow-up, see §7.2.
 - Per-call `timeout_s` range validation beyond what `of_preset` already checks
-  (`Bad_meta_timeout`, `Bad_judge_wave_budget`, `Bad_adaptive_factor`).
+  (`Bad_meta_timeout`, `Bad_adaptive_factor`).
 
 ## 5. Implementation plan
 

--- a/lib/fusion/fusion_orchestrator.ml
+++ b/lib/fusion/fusion_orchestrator.ml
@@ -110,8 +110,8 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
           let all_fail_error_of_runs =
             Fusion_orchestrator_judge_wave.all_fail_error_of_runs
           in
-          let with_timeout_budget_fallback =
-            Fusion_orchestrator_judge_wave.with_timeout_budget_fallback
+          let with_timeout_fallback =
+            Fusion_orchestrator_judge_wave.with_timeout_fallback
           in
           let run_fallback_judge () =
             Fusion_orchestrator_judge_wave.run_fallback_judge
@@ -135,7 +135,7 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
             | judges ->
               let firsts = run_first_judges judges in
               let firsts_with_fallback =
-                with_timeout_budget_fallback ~run_fallback_judge firsts
+                with_timeout_fallback ~run_fallback_judge firsts
               in
               let first_nodes = first_judge_nodes firsts_with_fallback in
               let ok_priors = successful_syntheses firsts_with_fallback in
@@ -199,7 +199,7 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
             | Ok _groups ->
               let firsts =
                 run_first_judges preset.Fusion_policy.judges
-                |> with_timeout_budget_fallback ~run_fallback_judge
+                |> with_timeout_fallback ~run_fallback_judge
               in
               let rec take n acc rest =
                 if n = 0

--- a/lib/fusion/fusion_orchestrator_judge_wave.ml
+++ b/lib/fusion/fusion_orchestrator_judge_wave.ml
@@ -133,14 +133,14 @@ let all_fail_error_of_runs ~fallback runs =
     (List.map (fun (_, id, result, _, _) -> id, result) runs)
 ;;
 
-let failed_timeout_or_budget (_, _, result, _, _) =
+let failed_timeout (_, _, result, _, _) =
   match result with
-  | Error (failure, _) -> Fusion_types.judge_failure_is_timeout_or_budget failure
+  | Error (failure, _) -> Fusion_types.judge_failure_is_timeout failure
   | Ok _ -> false
 ;;
 
-let with_timeout_budget_fallback ~run_fallback_judge runs =
-  if runs <> [] && List.for_all failed_timeout_or_budget runs
+let with_timeout_fallback ~run_fallback_judge runs =
+  if runs <> [] && List.for_all failed_timeout runs
   then (
     match run_fallback_judge () with
     | Some fallback -> runs @ [ fallback ]

--- a/lib/fusion/fusion_orchestrator_judge_wave.mli
+++ b/lib/fusion/fusion_orchestrator_judge_wave.mli
@@ -50,12 +50,12 @@ val all_fail_error_of_runs
   -> judge_run list
   -> Fusion_types.judge_failure * Fusion_types.usage
 
-val with_timeout_budget_fallback
+val with_timeout_fallback
   :  run_fallback_judge:(unit -> judge_run option)
   -> judge_run list
   -> judge_run list
 (** Append the configured fallback judge when the whole first-judge wave failed
-    only with timeout/budget failures. Shared by JOJ and staged JOJ so both
+    only with timeouts. Shared by JOJ and staged JOJ so both
     topologies honor [fallback_judge_model] consistently. *)
 
 val run_fallback_judge

--- a/lib/fusion_core/fusion_config.ml
+++ b/lib/fusion_core/fusion_config.ml
@@ -16,9 +16,6 @@ type config_error =
   | Duplicate_judge of string * string  (** (preset 이름, 중복 judge 정체성) (RFC-0283) *)
   | Invalid_meta_timeout of string * float
       (** (preset 이름, meta_timeout_s): 양수 유한수가 아님. *)
-  | Invalid_judge_wave_budget of string * float
-      (** (preset 이름, judge_wave_budget_s): 0 미만이거나 최장 1차 심판 타임아웃/
-          meta_timeout_s보다 작음. *)
   | Invalid_adaptive_timeout_factor of string * float
       (** (preset 이름, adaptive_timeout_factor): 1.0 미만. *)
   | Toml_type_error of string
@@ -96,11 +93,6 @@ let finish_preset name tbl (panels : Fusion_policy.panel_group list)
     | Some entries -> List.map parse_judge_spec entries
     | None -> []
   in
-  (* 1차 심판 wave 전체 wall-clock 예산. 누락 시 무제한(legacy byte-identical). *)
-  let judge_wave_budget_s =
-    Otoml.find_or ~default:Float.max_float tbl Otoml.get_float
-      [ "judge_wave_budget_s" ]
-  in
   let adaptive_timeout_factor =
     Otoml.find_or ~default:1.0 tbl Otoml.get_float [ "adaptive_timeout_factor" ]
   in
@@ -116,7 +108,6 @@ let finish_preset name tbl (panels : Fusion_policy.panel_group list)
     ; judge_max_output_tokens
     ; judges
     ; meta_timeout_s
-    ; judge_wave_budget_s
     ; adaptive_timeout_factor
     ; fallback_judge_model
     }
@@ -143,8 +134,6 @@ let finish_preset name tbl (panels : Fusion_policy.panel_group list)
            Duplicate_judge (name, id)
          | Fusion_policy.Validated_preset.Bad_meta_timeout v ->
            Invalid_meta_timeout (name, v)
-         | Fusion_policy.Validated_preset.Bad_judge_wave_budget v ->
-           Invalid_judge_wave_budget (name, v)
        | Fusion_policy.Validated_preset.Bad_adaptive_factor v ->
          Invalid_adaptive_timeout_factor (name, v))
 

--- a/lib/fusion_core/fusion_config.mli
+++ b/lib/fusion_core/fusion_config.mli
@@ -37,9 +37,6 @@ type config_error =
       (** (preset 이름, 중복 judge 정체성) — 두 JOJ 1차 심판이 같은 정체성 (RFC-0283). *)
   | Invalid_meta_timeout of string * float
       (** (preset 이름, meta_timeout_s) — 양수 유한수가 아님. *)
-  | Invalid_judge_wave_budget of string * float
-      (** (preset 이름, judge_wave_budget_s) — 0 미만이거나 최장 1차 심판 타임아웃/
-          [meta_timeout_s]보다 작음. *)
   | Invalid_adaptive_timeout_factor of string * float
       (** (preset 이름, adaptive_timeout_factor) — 1.0 미만. *)
   | Toml_type_error of string  (** 필드 타입 불일치 (Otoml.Type_error) *)

--- a/lib/fusion_core/fusion_config_json.ml
+++ b/lib/fusion_core/fusion_config_json.ml
@@ -53,7 +53,6 @@ let preset_to_yojson (p : Fusion_policy.preset) : Yojson.Safe.t =
     ; ("judge_max_output_tokens", opt_int p.Fusion_policy.judge_max_output_tokens)
     ; ("meta_timeout_s", `Float p.Fusion_policy.meta_timeout_s)
     ; ("judges", `List (List.map judge_spec_to_yojson p.Fusion_policy.judges))
-    ; ("judge_wave_budget_s", `Float p.Fusion_policy.judge_wave_budget_s)
     ; ( "adaptive_timeout_factor"
       , `Float p.Fusion_policy.adaptive_timeout_factor )
     ; ("fallback_judge_model", opt_string p.Fusion_policy.fallback_judge_model)

--- a/lib/fusion_core/fusion_policy.ml
+++ b/lib/fusion_core/fusion_policy.ml
@@ -46,8 +46,6 @@ type preset =
   ; judges : judge_spec list
       (** JOJ 1차 심판들 (RFC-0283). 기본 []; simple/refine/conditional은 무시한다.
           JOJ 위상은 런타임에 >= 2 를 요구한다. *)
-  ; judge_wave_budget_s : float
-      (** 1차 심판 wave 전체 wall-clock 예산 (초). 0=비활성(legacy). *)
   ; adaptive_timeout_factor : float
       (** 1차 심판 타임아웃 적응형 확장 계수. 1.0=확장 안 함. *)
   ; fallback_judge_model : string option
@@ -216,15 +214,12 @@ let panel_outer_timeout_of (groups : panel_group list) =
 let judge_web_tools_of ~req_web_tools (groups : panel_group list) =
   req_web_tools || List.exists (fun (g : panel_group) -> g.web_tools) groups
 
-(* 적응형 타임아웃 임계값들. [adaptive_extension_threshold]는 adaptive 확장을 끄는
+(* [adaptive_extension_threshold]는 adaptive 확장을 끄는
    factor 값(config default 1.0; 검증이 >= 1.0을 강제). 1.0은 IEEE754에서 정확히
    표현되지만, 의도를 명시하고 drift를 막기 named 상수로 둔다 — callers 도 float
    equality 비교 대신 [adaptive_timeout_enabled]를 쓴다 (CLAUDE.md §Magic Number +
-   P2#6 float-equality-as-toggle 회피). [min_effective_timeout_s]는 확장 후 effective
-   타임아웃이 이보다 작으면 즉시 실패(None)하는 하한이다. *)
+   P2#6 float-equality-as-toggle 회피). *)
 let adaptive_extension_threshold = 1.0
-
-let min_effective_timeout_s = 0.001
 
 (* [adaptive_timeout_enabled preset] — preset의 factor가 확장 임계값을 넘는가. float
    equality 대신 typed bool 토글로, callers(orchestrator)가 adaptive 재시도 분기를
@@ -232,35 +227,18 @@ let min_effective_timeout_s = 0.001
 let adaptive_timeout_enabled (p : preset) =
   p.adaptive_timeout_factor > adaptive_extension_threshold
 
-let judge_wave_budget_enabled ~wave_budget_s = wave_budget_s > 0.0
-
 (* 적응형 타임아웃: 1차 심판/재시도 호출에 사용할 effective timeout을 계산한다.
-   - factor <= [adaptive_extension_threshold] (또는 아직 타임아웃 안 됨): base_s를 wave
-     예산에 맞춰 반환.
+   - factor <= [adaptive_extension_threshold] (또는 아직 타임아웃 안 됨): base_s 반환.
    - already_timed_out && factor > [adaptive_extension_threshold]: base_s *. factor를
-     max_s로 상한, 남은 예산으로 하한해 확장된 타임아웃을 반환.
-   예산/상한이 너무 작아 [min_effective_timeout_s] 미만이면 None (즉시 실패). *)
-let adjust_judge_timeout ~base_s ~max_s ~factor ~wave_budget_s ~elapsed_s
-    ~already_timed_out : float option =
-  let budget_enabled = judge_wave_budget_enabled ~wave_budget_s in
-  let budget_allows timeout_s =
-    (not budget_enabled) || elapsed_s +. timeout_s <= wave_budget_s
-  in
+     max_s로만 상한해 확장된 타임아웃을 반환. *)
+let adjust_judge_timeout ~base_s ~max_s ~factor ~already_timed_out : float =
   if factor <= adaptive_extension_threshold || not already_timed_out
-  then if budget_allows base_s then Some base_s else None
+  then base_s
   else
     let extended = base_s *. factor in
-    let proposed =
-      match max_s with
-      | Some m -> Float.min extended m
-      | None -> extended
-    in
-    let effective =
-      if budget_enabled
-      then Float.min proposed (wave_budget_s -. elapsed_s)
-      else proposed
-    in
-    if effective < min_effective_timeout_s then None else Some effective
+    match max_s with
+    | Some m -> Float.min extended m
+    | None -> extended
 
 (* RFC-0280: 검증된 preset을 타입으로 증명한다 (Parse, don't validate).
    [Validated_preset.t = private preset]이라 외부는 필드를 읽되([preset]/coercion)
@@ -282,9 +260,6 @@ module Validated_preset = struct
     | Duplicate_judge of string  (** 두 JOJ 1차 심판이 같은 정체성(judge_id) (RFC-0283) *)
     | Bad_meta_timeout of float
         (** [meta_timeout_s]가 양수 유한수가 아님. *)
-    | Bad_judge_wave_budget of float
-        (** [judge_wave_budget_s]가 0 미만이거나, 양수인데 최장 1차 심판 타임아웃 또는
-            [meta_timeout_s]보다 작음. *)
     | Bad_adaptive_factor of float
         (** [adaptive_timeout_factor]가 1.0 미만. *)
 
@@ -328,19 +303,6 @@ module Validated_preset = struct
                   then Error (Bad_meta_timeout p.meta_timeout_s)
                   else if p.adaptive_timeout_factor < 1.0
                   then Error (Bad_adaptive_factor p.adaptive_timeout_factor)
-                  else if p.judge_wave_budget_s < 0.0
-                  then Error (Bad_judge_wave_budget p.judge_wave_budget_s)
-                  else if
-                    p.judge_wave_budget_s > 0.0
-                    && Float.is_finite p.judge_wave_budget_s
-                    && (let longest_judge =
-                          List.fold_left
-                            (fun acc (j : judge_spec) -> Float.max acc j.jtimeout_s)
-                            0.0 p.judges
-                        in
-                        p.judge_wave_budget_s < longest_judge
-                        || p.judge_wave_budget_s < p.meta_timeout_s)
-                  then Error (Bad_judge_wave_budget p.judge_wave_budget_s)
                   else Ok p)))
 
   let preset (t : t) : preset = t

--- a/lib/fusion_core/fusion_policy.mli
+++ b/lib/fusion_core/fusion_policy.mli
@@ -58,8 +58,6 @@ type preset =
   ; judges : judge_spec list
       (** JOJ 1차 심판들 (RFC-0283). 기본 []; simple/refine/conditional은 무시한다.
           JOJ 위상은 런타임에 >= 2 를 요구한다. *)
-  ; judge_wave_budget_s : float
-      (** 1차 심판 wave 전체 wall-clock 예산 (초). 0=비활성(legacy). *)
   ; adaptive_timeout_factor : float
       (** 1차 심판 타임아웃 적응형 확장 계수. 1.0=확장 안 함. *)
   ; fallback_judge_model : string option
@@ -158,25 +156,16 @@ val judge_web_tools_of : req_web_tools:bool -> panel_group list -> bool
     adaptive 재시도 분기를 판정한다. *)
 val adaptive_timeout_enabled : preset -> bool
 
-(** [judge_wave_budget_enabled ~wave_budget_s] is false only for the validated
-    legacy disabled value [0.0]. Positive finite or effectively-unbounded
-    budgets still enforce the wave cap. *)
-val judge_wave_budget_enabled : wave_budget_s:float -> bool
-
 (** 적응형 타임아웃: 1차 심판/재시도 호출에 사용할 effective timeout을 계산한다.
-    [wave_budget_s = 0.0]이면 legacy disabled budget으로 간주해 wave cap을 적용하지
-    않는다. [factor <= adaptive_extension_threshold](= 1.0)이면 [base_s]를 반환하고,
+    [factor <= adaptive_extension_threshold](= 1.0)이면 [base_s]를 반환하고,
     [already_timed_out]이고 [factor > adaptive_extension_threshold]이면 [base_s *.
-    factor]를 [max_s]로 상한·남은 예산으로 하한해 확장한다. 결과가
-    [min_effective_timeout_s](0.001s) 미만이면 [None]. *)
+    factor]를 [max_s]로만 상한해 확장한다. *)
 val adjust_judge_timeout
   :  base_s:float
   -> max_s:float option
   -> factor:float
-  -> wave_budget_s:float
-  -> elapsed_s:float
   -> already_timed_out:bool
-  -> float option
+  -> float
 
 (** RFC-0280: 검증을 통과한 preset (Parse, don't validate). [t = private preset]이라
     필드는 자유롭게 읽되([preset] 또는 coercion [(vp :> preset)]) 검증 없이 생성할 수
@@ -197,9 +186,6 @@ module Validated_preset : sig
     | Duplicate_judge of string  (** 두 JOJ 1차 심판이 같은 정체성 (RFC-0283) *)
     | Bad_meta_timeout of float
         (** [meta_timeout_s]가 양수 유한수가 아님. *)
-    | Bad_judge_wave_budget of float
-        (** [judge_wave_budget_s]가 0 미만이거나, 양수 유한인데 최장 1차 심판
-            타임아웃 또는 [meta_timeout_s]보다 작음. *)
     | Bad_adaptive_factor of float
         (** [adaptive_timeout_factor]가 1.0 미만. *)
 

--- a/lib/fusion_core/fusion_types.ml
+++ b/lib/fusion_core/fusion_types.ml
@@ -197,7 +197,7 @@ type judge_node =
 [@@deriving yojson, show, eq]
 
 (* 심판(judge) 실패의 닫힌 합. {!panel_failure}와 동형이되 심판 도메인 전용 사유
-   ([Empty_result]/[Build_error]/[Parse_error]/[Budget_exceeded])를 추가한다.
+   ([Empty_result]/[Build_error]/[Parse_error])를 추가한다.
    [Fusion_judge] 계열이 {!Agent_sdk.Error}의 [Timeout] variant를 match에서 잡아 typed로
    반환하므로, 호출자는 string substring 분류 없이 exhaustive match로 분류한다
    (CLAUDE.md §string-classifier 안티패턴 회피). [panel_failure]를 공유하지 않는 이유는
@@ -209,16 +209,11 @@ type judge_failure =
   | Empty_result
   | Build_error of string
   | Parse_error of string
-  | Budget_exceeded of string
   | Panels_unavailable of skip_reason
   | Internal_error of string
 [@@deriving yojson, show, eq]
 
 let judge_failure_is_timeout = function Timeout -> true | _ -> false
-
-let judge_failure_is_timeout_or_budget = function
-  | Timeout | Budget_exceeded _ -> true
-  | _ -> false
 
 let judge_failure_text = function
   | Timeout -> "timeout"
@@ -227,7 +222,6 @@ let judge_failure_text = function
   | Empty_result -> "judge: empty result"
   | Build_error detail -> detail
   | Parse_error detail -> detail
-  | Budget_exceeded detail -> detail
   | Panels_unavailable reason -> render_skip_reason reason
   | Internal_error detail -> detail
 
@@ -238,7 +232,6 @@ let judge_failure_tag = function
   | Empty_result -> "empty_result"
   | Build_error _ -> "build_error"
   | Parse_error _ -> "parse_error"
-  | Budget_exceeded _ -> "budget_exceeded"
   | Panels_unavailable _ -> "panels_unavailable"
   | Internal_error _ -> "internal_error"
 

--- a/lib/fusion_core/fusion_types.mli
+++ b/lib/fusion_core/fusion_types.mli
@@ -205,7 +205,7 @@ type judge_role =
 [@@deriving yojson, show, eq]
 
 (** 심판(judge) 한 명이 실패하는 방식. {!panel_failure}와 동형인 닫힌 합이되, 심판
-    도메인에만 존재하는 사유([Empty_result]/[Build_error]/[Parse_error]/[Budget_exceeded])
+    도메인에만 존재하는 사유([Empty_result]/[Build_error]/[Parse_error])
     를 추가로 담는다. [panel_failure]를 literal하게 공유하지 않는 이유: 판(panel) 전용인
     [Invalid_max_output_tokens]가 심판에서 dead variant가 되고, wave-budget SKIP을
     [Provider_error "...skipped..."] 문자열에 숨기면 orchestrator의 fallback 분류가
@@ -222,7 +222,6 @@ type judge_failure =
   | Empty_result  (** Async_agent.all 이 빈 결과를 반환 *)
   | Build_error of string  (** Fusion_oas.build_agent 실패 *)
   | Parse_error of string  (** Fusion_judge_parse.of_string 파싱 실패 *)
-  | Budget_exceeded of string  (** wave budget 초과로 심판 실행 전 SKIP *)
   | Panels_unavailable of skip_reason
       (** 패널 정족수 미달로 심판이 실행조차 되지 않음. 2026-07-01 사고에서 이
           사유가 [Internal_error] 문자열로 압축돼 모든 keeper-가시 표면이 패널
@@ -235,11 +234,6 @@ type judge_failure =
 (** [Timeout] 변형인가. {!judge_error_node}의 [timed_out] 파생처럼, 분류는 variant 자체로
     충분하므로 별도 bool 필드를 두지 않는다. *)
 val judge_failure_is_timeout : judge_failure -> bool
-
-(** [Timeout] 또는 [Budget_exceeded] 인가. orchestrator의 fallback-judge 트리거 조건:
-    1차 심판 전원이 타임아웃/예산-skip이면 fallback을 시도한다. exhaustive match로
-    string classifier([is_timeout_or_budget_error])를 대체한다. *)
-val judge_failure_is_timeout_or_budget : judge_failure -> bool
 
 (** sink/로그용 사람-가독 문자열. {!Fusion_oas.panel_failure_text}와 대칭. *)
 val judge_failure_text : judge_failure -> string

--- a/test/fusion_core/test_fusion.ml
+++ b/test/fusion_core/test_fusion.ml
@@ -46,7 +46,6 @@ let base_policy : Fusion_policy.t =
           ; judge_max_output_tokens = None
           ; meta_timeout_s = 300.0
           ; judges = []
-          ; judge_wave_budget_s = Float.max_float
           ; adaptive_timeout_factor = 1.0
           ; fallback_judge_model = None
           }
@@ -815,7 +814,7 @@ let test_config_disabled_with_preset () =
    그 변형이 발화하는지 확인한다. private 타입이라 외부는 of_preset로만 t를 만든다. *)
 let mk_preset ?(panels = [ base_group ]) ?(judge = "j") ?(judge_prompt = "synthesize")
     ?(judges = [])
-    ?(meta_timeout_s = 300.0) ?(judge_wave_budget_s = Float.max_float)
+    ?(meta_timeout_s = 300.0)
     ?(adaptive_timeout_factor = 1.0) ?(fallback_judge_model = None)
     (name : string) : Fusion_policy.preset =
   { Fusion_policy.name
@@ -826,7 +825,6 @@ let mk_preset ?(panels = [ base_group ]) ?(judge = "j") ?(judge_prompt = "synthe
   ; judge_max_output_tokens = None
   ; meta_timeout_s
   ; judges
-  ; judge_wave_budget_s
   ; adaptive_timeout_factor
   ; fallback_judge_model
   }
@@ -1340,8 +1338,8 @@ let test_panels_unavailable_failure () =
     "fusion aborted: none of 3 panels returned an answer"
     (judge_failure_text failure);
   Alcotest.(check bool) "not a timeout" false (judge_failure_is_timeout failure);
-  Alcotest.(check bool) "not timeout-or-budget (no fallback judge trigger)" false
-    (judge_failure_is_timeout_or_budget failure)
+  Alcotest.(check bool) "not a timeout (no fallback judge trigger)" false
+    (judge_failure_is_timeout failure)
 
 (* --- FUSION adaptive timeout / P0 hardening (RFC-0284-FUSION-P0) --- *)
 
@@ -1355,7 +1353,6 @@ judge = "meta"
 judge_system_prompt = "reconcile"
 judge_timeout_s = 120.0
 meta_timeout_s = 90.0
-judge_wave_budget_s = 500.0
 adaptive_timeout_factor = 2.0
 fallback_judge_model = "fallback-model"
 [[fusion.presets.adaptive.panels]]
@@ -1380,8 +1377,6 @@ let test_config_adaptive_timeout_parse () =
        let preset = raw vp in
        Alcotest.(check (float 0.001)) "meta_timeout_s" 90.0
          preset.Fusion_policy.meta_timeout_s;
-       Alcotest.(check (float 0.001)) "judge_wave_budget_s" 500.0
-         preset.Fusion_policy.judge_wave_budget_s;
        Alcotest.(check (float 0.001)) "adaptive_timeout_factor" 2.0
          preset.Fusion_policy.adaptive_timeout_factor;
        Alcotest.(check (option string)) "fallback_judge_model"
@@ -1408,9 +1403,6 @@ let test_config_adaptive_timeout_defaults () =
        Alcotest.(check (float 0.001)) "meta_timeout_s defaults to judge_timeout_s"
          preset.Fusion_policy.judge_timeout_s
          preset.Fusion_policy.meta_timeout_s;
-       Alcotest.(check bool) "judge_wave_budget_s defaults to max_float"
-         true
-         (preset.Fusion_policy.judge_wave_budget_s = Float.max_float);
        Alcotest.(check (float 0.001)) "adaptive_timeout_factor defaults to 1.0"
          1.0
          preset.Fusion_policy.adaptive_timeout_factor;
@@ -1464,67 +1456,23 @@ adaptive_timeout_factor = 0.5
          es)
   | Ok _ -> Alcotest.fail "expected Error Invalid_adaptive_timeout_factor"
 
-let test_config_invalid_judge_wave_budget () =
-  let s =
-    {|
-[fusion]
-enabled = true
-default_preset = "p"
-[fusion.presets.p]
-panel = ["a"]
-judge = "j"
-panel_system_prompt = "x"
-judge_system_prompt = "y"
-judge_wave_budget_s = 50.0
-[[fusion.presets.p.judges]]
-model = "judge-a"
-system_prompt = "lens"
-timeout_s = 100.0
-|}
-  in
-  match Fusion_config.of_toml (parse s) with
-  | Error es ->
-    Alcotest.(check bool) "Invalid_judge_wave_budget present" true
-      (List.exists
-         (function Fusion_config.Invalid_judge_wave_budget _ -> true | _ -> false)
-         es)
-  | Ok _ -> Alcotest.fail "expected Error Invalid_judge_wave_budget"
-
 let test_adjust_judge_timeout_disabled () =
-  Alcotest.(check (option (float 0.001))) "factor=1.0 within budget"
-    (Some 10.0)
+  Alcotest.(check (float 0.001)) "factor=1.0 returns base"
+    10.0
     (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:None ~factor:1.0
-       ~wave_budget_s:100.0 ~elapsed_s:5.0 ~already_timed_out:false);
-  Alcotest.(check (option (float 0.001))) "factor=1.0 over budget"
-    None
-    (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:None ~factor:1.0
-       ~wave_budget_s:14.0 ~elapsed_s:5.0 ~already_timed_out:false);
-  Alcotest.(check (option (float 0.001))) "wave budget 0 disables cap"
-    (Some 10.0)
-    (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:None ~factor:1.0
-       ~wave_budget_s:0.0 ~elapsed_s:500.0 ~already_timed_out:false)
+       ~already_timed_out:false)
 
 let test_adjust_judge_timeout_extend () =
-  (* already timed out + factor > 1.0 extends up to max_s and remaining budget. *)
-  Alcotest.(check (option (float 0.001))) "extend capped by max_s"
-    (Some 15.0)
+  Alcotest.(check (float 0.001)) "extend capped by max_s"
+    15.0
     (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:(Some 15.0)
-       ~factor:2.0 ~wave_budget_s:100.0 ~elapsed_s:5.0 ~already_timed_out:true);
-  Alcotest.(check (option (float 0.001))) "extend capped by remaining budget"
-    (Some 7.0)
-    (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:(Some 30.0)
-       ~factor:2.0 ~wave_budget_s:12.0 ~elapsed_s:5.0 ~already_timed_out:true);
-  Alcotest.(check (option (float 0.001))) "extend below 0.001 -> None"
-    None
-    (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:(Some 30.0)
-       ~factor:2.0 ~wave_budget_s:5.0 ~elapsed_s:5.0 ~already_timed_out:true)
+       ~factor:2.0 ~already_timed_out:true)
 
 let test_adjust_judge_timeout_not_yet_timed_out () =
-  (* factor > 1.0 but not yet timed out: still use base_s, just budget-check. *)
-  Alcotest.(check (option (float 0.001))) "not timed out uses base_s"
-    (Some 10.0)
+  Alcotest.(check (float 0.001)) "not timed out uses base_s"
+    10.0
     (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:(Some 5.0)
-       ~factor:2.0 ~wave_budget_s:100.0 ~elapsed_s:5.0 ~already_timed_out:false)
+       ~factor:2.0 ~already_timed_out:false)
 
 let test_judge_error_node_timed_out () =
   let timeout_node =
@@ -1535,28 +1483,11 @@ let test_judge_error_node_timed_out () =
       ; elapsed_s = 5.0
       }
   in
-  let budget_node =
-    Fusion_types.Judge_failed
-      { Fusion_types.failed_role = First "j"
-      ; failure =
-          Fusion_types.Budget_exceeded "judge j skipped: would exceed wave budget"
-      ; usage = Fusion_types.zero_usage
-      ; elapsed_s = 3.0
-      }
-  in
-  match
-    ( Fusion_types.judge_outcome_of_yojson
-        (Fusion_types.judge_outcome_to_yojson timeout_node)
-    , Fusion_types.judge_outcome_of_yojson
-        (Fusion_types.judge_outcome_to_yojson budget_node) )
-  with
-  | Ok (Judge_failed n1), Ok (Judge_failed n2) ->
+  match Fusion_types.judge_outcome_of_yojson (Fusion_types.judge_outcome_to_yojson timeout_node) with
+  | Ok (Judge_failed n1) ->
     Alcotest.(check bool) "timeout node roundtrips timed_out" true
       (Fusion_types.judge_failure_is_timeout n1.failure);
-    Alcotest.(check (float 0.001)) "timeout node roundtrips elapsed_s" 5.0 n1.elapsed_s;
-    Alcotest.(check bool) "budget node roundtrips timed_out" false
-      (Fusion_types.judge_failure_is_timeout n2.failure);
-    Alcotest.(check (float 0.001)) "budget node roundtrips elapsed_s" 3.0 n2.elapsed_s
+    Alcotest.(check (float 0.001)) "timeout node roundtrips elapsed_s" 5.0 n1.elapsed_s
   | _ -> Alcotest.fail "expected Judge_failed roundtrip"
 
 let test_validated_bad_meta_timeout () =
@@ -1573,14 +1504,6 @@ let test_validated_bad_adaptive_factor () =
   with
   | Error (Fusion_policy.Validated_preset.Bad_adaptive_factor 0.5) -> ()
   | _ -> Alcotest.fail "expected Bad_adaptive_factor 0.5"
-
-let test_validated_bad_judge_wave_budget () =
-  match
-    Fusion_policy.Validated_preset.of_preset
-      (mk_preset ~judge_wave_budget_s:50.0 ~judges:[ base_judge ] "bad-budget")
-  with
-  | Error (Fusion_policy.Validated_preset.Bad_judge_wave_budget 50.0) -> ()
-  | _ -> Alcotest.fail "expected Bad_judge_wave_budget 50.0"
 
 let () =
   Alcotest.run "fusion_core"
@@ -1637,8 +1560,6 @@ let () =
         ; Alcotest.test_case "invalid_meta_timeout" `Quick test_config_invalid_meta_timeout
         ; Alcotest.test_case "invalid_adaptive_factor" `Quick
             test_config_invalid_adaptive_factor
-        ; Alcotest.test_case "invalid_judge_wave_budget" `Quick
-            test_config_invalid_judge_wave_budget
         ] )
     ; ( "validated_preset"
       , [ Alcotest.test_case "ok" `Quick test_validated_ok
@@ -1658,8 +1579,6 @@ let () =
         ; Alcotest.test_case "bad_meta_timeout" `Quick test_validated_bad_meta_timeout
         ; Alcotest.test_case "bad_adaptive_factor" `Quick
             test_validated_bad_adaptive_factor
-        ; Alcotest.test_case "bad_judge_wave_budget" `Quick
-            test_validated_bad_judge_wave_budget
         ] )
     ; ( "staged_judge_groups"
       , [ Alcotest.test_case "exact_3x3" `Quick test_staged_judge_groups_exact_3x3

--- a/test/test_fusion_adaptive_timeout.ml
+++ b/test/test_fusion_adaptive_timeout.ml
@@ -48,7 +48,6 @@ judge = "meta"
 judge_system_prompt = "reconcile"
 judge_timeout_s = 120.0
 meta_timeout_s = 90.0
-judge_wave_budget_s = 500.0
 adaptive_timeout_factor = 2.0
 fallback_judge_model = "fallback-model"
 [[fusion.presets.adaptive.panels]]
@@ -72,8 +71,6 @@ let test_config_adaptive_timeout_parse () =
      | [ vp ] ->
        let preset = Fusion_policy.Validated_preset.preset vp in
        check (float 0.001) "meta_timeout_s" 90.0 preset.Fusion_policy.meta_timeout_s;
-       check (float 0.001) "judge_wave_budget_s" 500.0
-         preset.Fusion_policy.judge_wave_budget_s;
        check (float 0.001) "adaptive_timeout_factor" 2.0
          preset.Fusion_policy.adaptive_timeout_factor;
        check (option string) "fallback_judge_model" (Some "fallback-model")
@@ -135,39 +132,25 @@ adaptive_timeout_factor = 0.5
   | Ok _ -> fail "expected Error Invalid_adaptive_timeout_factor"
 
 let test_adjust_judge_timeout_disabled () =
-  check (option (float 0.001)) "factor=1.0 within budget" (Some 10.0)
+  check (float 0.001) "factor=1.0 returns base" 10.0
     (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:None ~factor:1.0
-       ~wave_budget_s:100.0 ~elapsed_s:5.0 ~already_timed_out:false);
-  check (option (float 0.001)) "factor=1.0 over budget" None
-    (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:None ~factor:1.0
-       ~wave_budget_s:14.0 ~elapsed_s:5.0 ~already_timed_out:false);
-  check (option (float 0.001)) "wave budget 0 disables cap" (Some 10.0)
-    (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:None ~factor:1.0
-       ~wave_budget_s:0.0 ~elapsed_s:500.0 ~already_timed_out:false)
+       ~already_timed_out:false)
 
 let test_adjust_judge_timeout_extend () =
-  check (option (float 0.001)) "extend capped by max_s" (Some 15.0)
+  check (float 0.001) "extend capped by max_s" 15.0
     (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:(Some 15.0)
-       ~factor:2.0 ~wave_budget_s:100.0 ~elapsed_s:5.0 ~already_timed_out:true);
-  check (option (float 0.001)) "extend capped by remaining budget" (Some 7.0)
-    (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:(Some 30.0)
-       ~factor:2.0 ~wave_budget_s:12.0 ~elapsed_s:5.0 ~already_timed_out:true);
-  check (option (float 0.001)) "extend below 0.001 -> None" None
-    (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:(Some 30.0)
-       ~factor:2.0 ~wave_budget_s:5.0 ~elapsed_s:5.0 ~already_timed_out:true)
+       ~factor:2.0 ~already_timed_out:true)
 
-let test_timeout_budget_first_wave_appends_fallback () =
+let test_timeout_first_wave_appends_fallback () =
   let fallback_calls = ref 0 in
   let fallback = ok_judge_run "fallback-model" in
   let runs =
     [ failed_judge_run "judge-a" Fusion_types.Timeout
-    ; failed_judge_run
-        "judge-b"
-        (Fusion_types.Budget_exceeded "wave budget exhausted")
+    ; failed_judge_run "judge-b" Fusion_types.Timeout
     ]
   in
   let with_fallback =
-    Fusion_orchestrator_judge_wave.with_timeout_budget_fallback
+    Fusion_orchestrator_judge_wave.with_timeout_fallback
       ~run_fallback_judge:(fun () ->
         incr fallback_calls;
         Some fallback)
@@ -179,7 +162,7 @@ let test_timeout_budget_first_wave_appends_fallback () =
   | (_, id, Ok _, _, _) :: _ -> check string "fallback id" "fallback-model" id
   | _ -> fail "expected appended successful fallback"
 
-let test_timeout_budget_first_wave_skips_fallback_on_provider_error () =
+let test_timeout_first_wave_skips_fallback_on_provider_error () =
   let fallback_calls = ref 0 in
   let runs =
     [ failed_judge_run "judge-a" Fusion_types.Timeout
@@ -187,7 +170,7 @@ let test_timeout_budget_first_wave_skips_fallback_on_provider_error () =
     ]
   in
   let without_fallback =
-    Fusion_orchestrator_judge_wave.with_timeout_budget_fallback
+    Fusion_orchestrator_judge_wave.with_timeout_fallback
       ~run_fallback_judge:(fun () ->
         incr fallback_calls;
         Some (ok_judge_run "fallback-model"))
@@ -249,10 +232,10 @@ let () =
         ; test_case "extend" `Quick test_adjust_judge_timeout_extend
         ] )
     ; ( "fallback"
-      , [ test_case "timeout/budget wave appends fallback" `Quick
-            test_timeout_budget_first_wave_appends_fallback
+      , [ test_case "timeout wave appends fallback" `Quick
+            test_timeout_first_wave_appends_fallback
         ; test_case "provider failure skips fallback" `Quick
-            test_timeout_budget_first_wave_skips_fallback_on_provider_error
+            test_timeout_first_wave_skips_fallback_on_provider_error
         ] )
     ; ( "metrics"
       , [ test_case "record_adaptive_timeout emits counter" `Quick

--- a/test/test_fusion_wake.ml
+++ b/test/test_fusion_wake.ml
@@ -198,7 +198,6 @@ let fusion_tool_policy () : Fusion_policy.t =
     ; judge_max_output_tokens = None
     ; meta_timeout_s = Fusion_policy.default_timeout_s
     ; judges = []
-    ; judge_wave_budget_s = Float.max_float
     ; adaptive_timeout_factor = 1.0
     ; fallback_judge_model = None
     }


### PR DESCRIPTION
## What

- delete `judge_wave_budget_s` from the typed Fusion preset, TOML parser, validation, and dashboard projection
- delete the `Budget_exceeded` judge failure and timeout-or-budget fallback classifier
- remove elapsed/shared-budget inputs from adaptive timeout calculation; it can no longer skip a judge
- purge tests and docs whose purpose was to preserve the retired wave-budget contract

## Why

#24634 removes the behavior-changing execution gate. This stacked hard-cut removes its now-inert public/config contract so it cannot be re-wired later or mistaken for an active product policy. Elapsed time remains execution evidence.

## Proof

- changed lines: 291
- repository-wide Fusion search: no `judge_wave_budget_s`, `Budget_exceeded`, `budget_exceeded`, or timeout-budget fallback residue outside unrelated shutdown/token-budget history
- OCaml parser/ocamlformat check: pass
- git diff --check: pass
- focused Dune wrapper intentionally refused because bare Dune PID 66224 owns the workspace; full build remains CI authority
- dashboard package dependencies are absent in this fresh worktree, so focused Vitest/ESLint execution is deferred to CI rather than fabricating a local green

## Stack

- base: #24634