### PR TITLE
refactor(dashboard): persist full Keeper run refs

### DIFF
--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -2024,8 +2024,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
 
   it('resumes a pending request from storage and finalizes the transcript', async () => {
     upsertPendingKeeperChatRequest({
-      requestId: 'kmsg_echo_1',
-      keeperName: 'echo',
+      runRef: keeperRunRef('kmsg_echo_1'),
       message: '어디까지 했어?',
       submittedAt: Date.UTC(2026, 5, 15, 9, 0, 0),
     })
@@ -2062,8 +2061,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
 
   it('resumes a no-visible pending request as error instead of blank assistant text', async () => {
     upsertPendingKeeperChatRequest({
-      requestId: 'kmsg_echo_1',
-      keeperName: 'echo',
+      runRef: keeperRunRef('kmsg_echo_1'),
       message: '뭐함',
       submittedAt: Date.UTC(2026, 5, 15, 9, 0, 0),
     })
@@ -2114,14 +2112,12 @@ describe('sendKeeperThreadMessage stream outcome', () => {
   it('resumes repeated same-message sends as distinct request ids', async () => {
     const submittedAt = Date.UTC(2026, 5, 15, 9, 0, 0)
     upsertPendingKeeperChatRequest({
-      requestId: 'kmsg_echo_1',
-      keeperName: 'echo',
+      runRef: keeperRunRef('kmsg_echo_1'),
       message: 'status?',
       submittedAt,
     })
     upsertPendingKeeperChatRequest({
-      requestId: 'kmsg_echo_2',
-      keeperName: 'echo',
+      runRef: keeperRunRef('kmsg_echo_2'),
       message: 'status?',
       submittedAt,
     })
@@ -2157,8 +2153,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
 
   it('marks a recovered orphan request as lost instead of polling forever', async () => {
     upsertPendingKeeperChatRequest({
-      requestId: 'kmsg_echo_1',
-      keeperName: 'echo',
+      runRef: keeperRunRef('kmsg_echo_1'),
       message: '어디까지 했어?',
       submittedAt: Date.UTC(2026, 5, 15, 9, 0, 0),
     })
@@ -2193,8 +2188,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
 
   it('resumes a cancelled pending request without restoring an error bubble', async () => {
     upsertPendingKeeperChatRequest({
-      requestId: 'kmsg_echo_1',
-      keeperName: 'echo',
+      runRef: keeperRunRef('kmsg_echo_1'),
       message: '뭘 해야하나',
       submittedAt: Date.UTC(2026, 5, 15, 9, 0, 0),
     })
@@ -2231,8 +2225,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
 
   it('keeps the user message visible when the server no longer knows request_id', async () => {
     upsertPendingKeeperChatRequest({
-      requestId: 'kmsg_echo_1',
-      keeperName: 'echo',
+      runRef: keeperRunRef('kmsg_echo_1'),
       message: '어디까지 했어?',
       submittedAt: Date.UTC(2026, 5, 15, 9, 0, 0),
     })
@@ -2270,8 +2263,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
 
   it('finalizes the pending message as error when the poll request times out', async () => {
     upsertPendingKeeperChatRequest({
-      requestId: 'kmsg_echo_1',
-      keeperName: 'echo',
+      runRef: keeperRunRef('kmsg_echo_1'),
       message: '어디까지 했어?',
       submittedAt: Date.UTC(2026, 5, 15, 9, 0, 0),
     })
@@ -2300,8 +2292,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
       _resetChatHydrationForTests()
       _clearPendingKeeperChatRequestsForTests()
       upsertPendingKeeperChatRequest({
-        requestId: 'kmsg_echo_1',
-        keeperName: 'echo',
+        runRef: keeperRunRef('kmsg_echo_1'),
         message: '진행 상황?',
         submittedAt: Date.UTC(2026, 5, 15, 9, 0, 0),
       })
@@ -2359,8 +2350,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
       _resetChatHydrationForTests()
       _clearPendingKeeperChatRequestsForTests()
       upsertPendingKeeperChatRequest({
-        requestId: 'kmsg_echo_draft',
-        keeperName: 'echo',
+        runRef: keeperRunRef('kmsg_echo_draft'),
         message: '진행 상황?',
         submittedAt: Date.UTC(2026, 5, 15, 9, 0, 0),
         assistantDraft: {
@@ -2434,8 +2424,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
       _resetChatHydrationForTests()
       _clearPendingKeeperChatRequestsForTests()
       upsertPendingKeeperChatRequest({
-        requestId: 'kmsg_echo_2',
-        keeperName: 'echo',
+        runRef: keeperRunRef('kmsg_echo_2'),
         message: '진행 상황?',
         submittedAt: Date.UTC(2026, 5, 15, 9, 0, 0),
       })

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -27,7 +27,6 @@ import { compareKeeperQueueRevisions } from './lib/keeper-chat-receipt'
 import {
   isTerminalKeeperRunResult,
   keeperRunRefKey,
-  parseKeeperRunRef,
   parseKeeperRunTerminal,
   parseKeeperRunTracking,
   sameKeeperRunRef,
@@ -135,14 +134,6 @@ export function _resetKeeperRunCancelsForTests(): void {
 
 function releaseKeeperRunCancelTracking(reference: KeeperRunRef): void {
   pendingKeeperRunCancels.delete(keeperRunRefKey(reference))
-}
-
-function keeperRunRef(keeperName: string, runId: string) {
-  return parseKeeperRunRef({
-    run_id: runId,
-    target: { kind: 'keeper', name: keeperName },
-    capability: 'invoke_turn',
-  })
 }
 
 function markKeeperStreamSignal(keeperName: string, opts: { force?: boolean } = {}): void {
@@ -520,12 +511,14 @@ function isMissingQueuedKeeperRequestError(err: unknown): boolean {
 }
 
 function ensurePendingThreadEntries(request: PendingKeeperChatRequest): string {
-  const existing = keeperThreads.value[request.keeperName] ?? []
-  const userId = pendingUserEntryId(request.requestId)
-  const assistantId = pendingAssistantEntryId(request.requestId)
+  const keeperName = request.runRef.target.name
+  const runId = request.runRef.runId
+  const existing = keeperThreads.value[keeperName] ?? []
+  const userId = pendingUserEntryId(runId)
+  const assistantId = pendingAssistantEntryId(runId)
   const assistantDraft = request.assistantDraft
   if (!existing.some(entry => entry.id === userId)) {
-    appendThreadEntry(request.keeperName, {
+    appendThreadEntry(keeperName, {
       id: userId,
       role: 'user',
       source: 'direct_user',
@@ -535,7 +528,7 @@ function ensurePendingThreadEntries(request: PendingKeeperChatRequest): string {
       delivery: 'delivered',
       streamState: null,
       streamContract: keeperStreamContract('pending_request_store', 'client_placeholder', {
-        requestId: request.requestId,
+        requestId: runId,
         deliveryReceipt: 'no_delivery_receipt',
         reason: 'restored pending queued request from browser storage',
       }),
@@ -544,18 +537,18 @@ function ensurePendingThreadEntries(request: PendingKeeperChatRequest): string {
     })
   }
   if (!existing.some(entry => entry.id === assistantId)) {
-    appendThreadEntry(request.keeperName, {
+    appendThreadEntry(keeperName, {
       id: assistantId,
       role: 'assistant',
       source: 'direct_assistant',
-      label: request.keeperName,
+      label: keeperName,
       text: assistantDraft?.text ?? '',
       rawText: assistantDraft?.rawText ?? '',
       timestamp: assistantDraft?.timestamp ?? null,
       delivery: assistantDraft?.delivery ?? 'queued',
       streamState: assistantDraft ? assistantDraft.streamState : 'opening',
       streamContract: keeperStreamContract('pending_request_store', 'client_placeholder', {
-        requestId: request.requestId,
+        requestId: runId,
         deliveryReceipt: 'no_delivery_receipt',
         reason: 'awaiting queued request poll result',
       }),
@@ -569,14 +562,14 @@ function ensurePendingThreadEntries(request: PendingKeeperChatRequest): string {
 
 function persistPendingAssistantDraft(
   keeperName: string,
-  requestId: string | null,
+  runRef: KeeperRunRef | null,
   assistantEntryId: string,
 ): void {
-  if (!requestId) return
+  if (!runRef) return
   const entry = (keeperThreads.value[keeperName] ?? [])
     .find(candidate => candidate.id === assistantEntryId) ?? null
   if (!entry) return
-  updatePendingKeeperChatAssistantDraft(requestId, entry)
+  updatePendingKeeperChatAssistantDraft(runRef, entry)
 }
 
 let localIdCounter = 0
@@ -618,7 +611,9 @@ export function isKeeperThreadMessageSendInFlight(
 }
 
 async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest): Promise<void> {
-  const runRef = keeperRunRef(request.keeperName, request.requestId)
+  const runRef = request.runRef
+  const keeperName = runRef.target.name
+  const runId = runRef.runId
   // A live in-session send stream still owns this request (e.g. the panel
   // remounted on an SPA route change while the reply was pending). Defer to
   // it rather than minting a duplicate pending entry + a second poll loop.
@@ -628,16 +623,16 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
   if (resumingKeeperChatRequests.has(key)) return
   resumingKeeperChatRequests.add(key)
   const assistantId = ensurePendingThreadEntries(request)
-  setRecordValue(keeperSending, request.keeperName, true)
-  setRecordValue(keeperActionErrors, request.keeperName, null)
-  setRecordValue(keeperStreamStartedAt, request.keeperName, request.submittedAt)
-  markKeeperStreamSignal(request.keeperName, { force: true })
+  setRecordValue(keeperSending, keeperName, true)
+  setRecordValue(keeperActionErrors, keeperName, null)
+  setRecordValue(keeperStreamStartedAt, keeperName, request.submittedAt)
+  markKeeperStreamSignal(keeperName, { force: true })
   try {
     for (;;) {
       const result = await fetchQueuedKeeperMessageResult(
         runRef,
       )
-      markKeeperStreamSignal(request.keeperName)
+      markKeeperStreamSignal(keeperName)
       if (!isTerminalQueuedKeeperMessage(result)) {
         await sleep(PENDING_KEEPER_CHAT_POLL_MS)
         continue
@@ -672,11 +667,11 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
       } else if (isError) {
         assistantDelivery = 'error'
       }
-      finalizeAssistantEntry(request.keeperName, pendingUserEntryId(request.requestId), {
+      finalizeAssistantEntry(keeperName, pendingUserEntryId(runId), {
         delivery: userDelivery,
         error: errorMessage,
         streamContract: keeperStreamContract('queue_poll', 'queue_poll_result', {
-          requestId: request.requestId,
+          requestId: runId,
           deliveryReceipt: 'no_delivery_receipt',
           reason: errorMessage,
         }),
@@ -689,7 +684,7 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
       } else if (suppressReply) {
         assistantText = ''
       }
-      finalizeAssistantEntry(request.keeperName, assistantId, {
+      finalizeAssistantEntry(keeperName, assistantId, {
         text: assistantText,
         rawText: assistantRawText,
         delivery: assistantDelivery,
@@ -698,29 +693,29 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
         details: reply.details,
         error: errorMessage,
         streamContract: keeperStreamContract('queue_poll', 'queue_poll_result', {
-          requestId: request.requestId,
+          requestId: runId,
           deliveryReceipt: 'no_delivery_receipt',
           reason: errorMessage,
         }),
       })
-      if (errorMessage) setRecordValue(keeperActionErrors, request.keeperName, errorMessage)
-      removePendingKeeperChatRequest(request.requestId)
-      await hydrateKeeperChatHistory(request.keeperName, { force: true })
+      if (errorMessage) setRecordValue(keeperActionErrors, keeperName, errorMessage)
+      removePendingKeeperChatRequest(runRef)
+      await hydrateKeeperChatHistory(keeperName, { force: true })
       return
     }
   } catch (err) {
     if (isMissingQueuedKeeperRequestError(err)) {
-      removePendingKeeperChatRequest(request.requestId)
-      finalizeAssistantEntry(request.keeperName, pendingUserEntryId(request.requestId), {
+      removePendingKeeperChatRequest(runRef)
+      finalizeAssistantEntry(keeperName, pendingUserEntryId(runId), {
         delivery: 'error',
         error: QUEUED_KEEPER_REQUEST_LOST_MESSAGE,
         streamContract: keeperStreamContract('queue_poll', 'contract_gap', {
-          requestId: request.requestId,
+          requestId: runId,
           deliveryReceipt: 'no_delivery_receipt',
           reason: QUEUED_KEEPER_REQUEST_LOST_MESSAGE,
         }),
       })
-      finalizeAssistantEntry(request.keeperName, assistantId, {
+      finalizeAssistantEntry(keeperName, assistantId, {
         text: '',
         rawText: '',
         delivery: 'error',
@@ -728,28 +723,28 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
         timestamp: new Date().toISOString(),
         error: QUEUED_KEEPER_REQUEST_LOST_MESSAGE,
         streamContract: keeperStreamContract('queue_poll', 'contract_gap', {
-          requestId: request.requestId,
+          requestId: runId,
           deliveryReceipt: 'no_delivery_receipt',
           reason: QUEUED_KEEPER_REQUEST_LOST_MESSAGE,
         }),
       })
-      setRecordValue(keeperActionErrors, request.keeperName, QUEUED_KEEPER_REQUEST_LOST_MESSAGE)
-      await hydrateKeeperChatHistory(request.keeperName, { force: true })
+      setRecordValue(keeperActionErrors, keeperName, QUEUED_KEEPER_REQUEST_LOST_MESSAGE)
+      await hydrateKeeperChatHistory(keeperName, { force: true })
       return
     }
-    const detail = err instanceof Error ? err.message : `Failed to resume ${request.keeperName} chat request`
+    const detail = err instanceof Error ? err.message : `Failed to resume ${keeperName} chat request`
     const message = `${PENDING_KEEPER_CHAT_RESUME_FAILED_MESSAGE} (${detail})`
-    removePendingKeeperChatRequest(request.requestId)
-    finalizeAssistantEntry(request.keeperName, pendingUserEntryId(request.requestId), {
+    removePendingKeeperChatRequest(runRef)
+    finalizeAssistantEntry(keeperName, pendingUserEntryId(runId), {
       delivery: 'error',
       error: message,
       streamContract: keeperStreamContract('queue_poll', 'contract_gap', {
-        requestId: request.requestId,
+        requestId: runId,
         deliveryReceipt: 'no_delivery_receipt',
         reason: message,
       }),
     })
-    finalizeAssistantEntry(request.keeperName, assistantId, {
+    finalizeAssistantEntry(keeperName, assistantId, {
       text: '',
       rawText: '',
       delivery: 'error',
@@ -757,19 +752,19 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
       timestamp: new Date().toISOString(),
       error: message,
       streamContract: keeperStreamContract('queue_poll', 'contract_gap', {
-        requestId: request.requestId,
+        requestId: runId,
         deliveryReceipt: 'no_delivery_receipt',
         reason: message,
       }),
     })
-    setRecordValue(keeperActionErrors, request.keeperName, message)
-    await hydrateKeeperChatHistory(request.keeperName, { force: true })
+    setRecordValue(keeperActionErrors, keeperName, message)
+    await hydrateKeeperChatHistory(keeperName, { force: true })
   } finally {
     resumingKeeperChatRequests.delete(key)
-    if (!hasPendingKeeperChatRequest(request.keeperName)) {
-      setRecordValue(keeperSending, request.keeperName, false)
-      setRecordValue(keeperStreamStartedAt, request.keeperName, null)
-      clearKeeperStreamSignal(request.keeperName)
+    if (!hasPendingKeeperChatRequest(keeperName)) {
+      setRecordValue(keeperSending, keeperName, false)
+      setRecordValue(keeperStreamStartedAt, keeperName, null)
+      clearKeeperStreamSignal(keeperName)
     }
   }
 }
@@ -784,9 +779,8 @@ async function handoffCancelledStreamToRequestPoll(
   request: PendingKeeperChatRequest,
   localEntryIds: readonly string[],
 ): Promise<void> {
-  removeThreadEntries(request.keeperName, localEntryIds)
-  const runRef = keeperRunRef(request.keeperName, request.requestId)
-  releaseLiveSendRun(runRef)
+  removeThreadEntries(request.runRef.target.name, localEntryIds)
+  releaseLiveSendRun(request.runRef)
   await resumePendingKeeperChatRequest(request)
 }
 
@@ -1319,8 +1313,7 @@ export async function sendKeeperThreadMessage(
           if (nextRunRef && controller.signal.aborted) {
             acceptedRun.current = nextRunRef
             const pendingRequest: PendingKeeperChatRequest = {
-              requestId: nextRunRef.runId,
-              keeperName,
+              runRef: nextRunRef,
               message,
               submittedAt: Date.now(),
               ...(attachments ? { attachments } : {}),
@@ -1341,8 +1334,7 @@ export async function sendKeeperThreadMessage(
             // (and not mint a duplicate pending entry) until handoff/finally.
             claimLiveSendRun(nextRunRef)
             upsertPendingKeeperChatRequest({
-              requestId: nextRunRef.runId,
-              keeperName,
+              runRef: nextRunRef,
               message,
               submittedAt: Date.now(),
               ...(attachments ? { attachments } : {}),
@@ -1363,7 +1355,7 @@ export async function sendKeeperThreadMessage(
             } else if (isTerminalKeeperRunResult(terminal.resultContract)) {
               requestNeedsReconciliation = false
               requestTerminalSeen = true
-              removePendingKeeperChatRequest(terminal.runRef.runId)
+              removePendingKeeperChatRequest(terminal.runRef)
             } else {
               throw new Error(
                 `Keeper run terminal has nonterminal result_contract: ${terminal.resultContract}`,
@@ -1375,7 +1367,7 @@ export async function sendKeeperThreadMessage(
         if (error) {
           throw new Error(error)
         }
-        persistPendingAssistantDraft(keeperName, acceptedRun.current?.runId ?? null, assistantId)
+        persistPendingAssistantDraft(keeperName, acceptedRun.current, assistantId)
         if (event.type === 'TOOL_CALL_END') {
           toolCallEnded = true
           void hydrateKeeperToolOutputs(keeperName)
@@ -1396,8 +1388,7 @@ export async function sendKeeperThreadMessage(
         // call below is not blocked by the guard we just set.
         releaseLiveSendRun(runRef)
         await resumePendingKeeperChatRequest({
-          requestId: runRef.runId,
-          keeperName,
+          runRef,
           message,
           submittedAt: Date.now(),
           ...(attachments ? { attachments } : {}),
@@ -1443,7 +1434,7 @@ export async function sendKeeperThreadMessage(
       })
       setRecordValue(keeperActionErrors, keeperName, EMPTY_VISIBLE_REPLY_TEXT)
       if (runRef) {
-        removePendingKeeperChatRequest(runRef.runId)
+        removePendingKeeperChatRequest(runRef)
         releaseLiveSendRun(runRef)
       }
       return
@@ -1465,7 +1456,7 @@ export async function sendKeeperThreadMessage(
     })
     if (toolCallEnded) void hydrateKeeperToolOutputs(keeperName)
     if (runRef) {
-      removePendingKeeperChatRequest(runRef.runId)
+      removePendingKeeperChatRequest(runRef)
       releaseLiveSendRun(runRef)
     }
     if (finalDelivery === 'queued') {
@@ -1478,7 +1469,7 @@ export async function sendKeeperThreadMessage(
       const hasDurablePendingRequest = Boolean(
         runRef
         && pendingKeeperChatRequestsForKeeper(keeperName)
-          .some(candidate => candidate.requestId === runRef?.runId),
+          .some(candidate => sameKeeperRunRef(candidate.runRef, runRef)),
       )
       const shouldAttemptServerCancel = Boolean(
         runRef && (liveSendOwnsRun(runRef) || hasDurablePendingRequest),
@@ -1490,8 +1481,7 @@ export async function sendKeeperThreadMessage(
       )
       if (shouldAttemptServerCancel && runRef) {
         const pendingRequest: PendingKeeperChatRequest = {
-          requestId: runRef.runId,
-          keeperName,
+          runRef,
           message,
           submittedAt: Date.now(),
           ...(attachments ? { attachments } : {}),
@@ -1555,7 +1545,7 @@ export async function sendKeeperThreadMessage(
       }),
     })
     if (requestTerminalSeen && runRef) {
-      removePendingKeeperChatRequest(runRef.runId)
+      removePendingKeeperChatRequest(runRef)
       releaseLiveSendRun(runRef)
     }
     try {

--- a/dashboard/src/keeper-chat-pending.test.ts
+++ b/dashboard/src/keeper-chat-pending.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   _clearPendingKeeperChatRequestsForTests,
@@ -7,6 +7,14 @@ import {
   upsertPendingKeeperChatRequest,
 } from './keeper-chat-pending'
 
+function runRef(runId: string, keeperName = 'echo') {
+  return {
+    runId,
+    target: { kind: 'keeper', name: keeperName },
+    capability: 'invoke_turn',
+  } as const
+}
+
 describe('keeper chat pending request storage', () => {
   beforeEach(() => {
     window.localStorage.clear()
@@ -14,36 +22,41 @@ describe('keeper chat pending request storage', () => {
   })
 
   afterEach(() => {
+    vi.restoreAllMocks()
     _clearPendingKeeperChatRequestsForTests()
     window.localStorage.clear()
   })
 
-  it('preserves distinct request ids for repeated same-message sends', () => {
+  it('persists full run refs for repeated same-message sends', () => {
     const base = {
-      keeperName: 'echo',
       message: 'status?',
       submittedAt: 1_780_000_000,
     }
 
-    upsertPendingKeeperChatRequest({ ...base, requestId: 'kmsg_echo_1' })
-    upsertPendingKeeperChatRequest({ ...base, requestId: 'kmsg_echo_2' })
+    upsertPendingKeeperChatRequest({ ...base, runRef: runRef('kmsg_echo_1') })
+    upsertPendingKeeperChatRequest({ ...base, runRef: runRef('kmsg_echo_2') })
 
-    expect(pendingKeeperChatRequestsForKeeper('echo').map(request => request.requestId)).toEqual([
+    expect(pendingKeeperChatRequestsForKeeper('echo').map(request => request.runRef.runId)).toEqual([
       'kmsg_echo_1',
       'kmsg_echo_2',
     ])
+    const stored = JSON.parse(
+      window.localStorage.getItem('masc_keeper_chat_pending_requests_v2') ?? '[]',
+    ) as Array<Record<string, unknown>>
+    expect(stored[0]).toHaveProperty('run_ref')
+    expect(stored[0]).not.toHaveProperty('requestId')
+    expect(stored[0]).not.toHaveProperty('keeperName')
 
-    removePendingKeeperChatRequest('kmsg_echo_1')
+    removePendingKeeperChatRequest(runRef('kmsg_echo_1'))
 
-    expect(pendingKeeperChatRequestsForKeeper('echo').map(request => request.requestId)).toEqual([
+    expect(pendingKeeperChatRequestsForKeeper('echo').map(request => request.runRef.runId)).toEqual([
       'kmsg_echo_2',
     ])
   })
 
   it('preserves the in-flight assistant draft for page reload recovery', () => {
     upsertPendingKeeperChatRequest({
-      requestId: 'kmsg_echo_1',
-      keeperName: 'echo',
+      runRef: runRef('kmsg_echo_1'),
       message: 'status?',
       submittedAt: 1_780_000_000,
       assistantDraft: {
@@ -66,7 +79,7 @@ describe('keeper chat pending request storage', () => {
 
     expect(pendingKeeperChatRequestsForKeeper('echo')).toEqual([
       expect.objectContaining({
-        requestId: 'kmsg_echo_1',
+        runRef: runRef('kmsg_echo_1'),
         assistantDraft: expect.objectContaining({
           text: '부분 응답',
           rawText: '부분 응답',
@@ -85,5 +98,32 @@ describe('keeper chat pending request storage', () => {
         }),
       }),
     ])
+  })
+
+  it('isolates the same run id across different Keeper targets', () => {
+    const request = { message: 'status?', submittedAt: 1_780_000_000 }
+    upsertPendingKeeperChatRequest({ ...request, runRef: runRef('shared-run', 'echo') })
+    upsertPendingKeeperChatRequest({ ...request, runRef: runRef('shared-run', 'reviewer') })
+
+    removePendingKeeperChatRequest(runRef('shared-run', 'echo'))
+
+    expect(pendingKeeperChatRequestsForKeeper('echo')).toEqual([])
+    expect(pendingKeeperChatRequestsForKeeper('reviewer')).toEqual([
+      expect.objectContaining({ runRef: runRef('shared-run', 'reviewer') }),
+    ])
+  })
+
+  it('reports a malformed current-schema run ref instead of silently recovering it', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    window.localStorage.setItem('masc_keeper_chat_pending_requests_v2', JSON.stringify([{
+      run_ref: { run_id: 'broken' },
+      message: 'status?',
+      submittedAt: 1_780_000_000,
+    }]))
+
+    expect(pendingKeeperChatRequestsForKeeper('echo')).toEqual([])
+    expect(warn).toHaveBeenCalledWith(
+      '[keeper-chat-pending] rejected invalid pending request at index 0',
+    )
   })
 })

--- a/dashboard/src/keeper-chat-pending.ts
+++ b/dashboard/src/keeper-chat-pending.ts
@@ -6,6 +6,12 @@ import type {
   KeeperConversationStreamState,
 } from './types'
 import { IN_FLIGHT_DELIVERY } from './lib/keeper-delivery'
+import {
+  keeperRunRefKey,
+  keeperRunRefToWire,
+  parseKeeperRunRef,
+} from './lib/keeper-run-ref'
+import type { KeeperRunRef } from './lib/keeper-run-ref'
 
 export interface PendingKeeperChatAssistantDraft {
   text: string
@@ -18,15 +24,21 @@ export interface PendingKeeperChatAssistantDraft {
 }
 
 export interface PendingKeeperChatRequest {
-  requestId: string
-  keeperName: string
+  runRef: KeeperRunRef
   message: string
   submittedAt: number
   attachments?: KeeperConversationAttachment[]
   assistantDraft?: PendingKeeperChatAssistantDraft
 }
 
-const STORAGE_KEY = 'masc_keeper_chat_pending_requests_v1'
+const STORAGE_KEY = 'masc_keeper_chat_pending_requests_v2'
+const PENDING_REQUEST_FIELDS = [
+  'run_ref',
+  'message',
+  'submittedAt',
+  'attachments',
+  'assistantDraft',
+] as const
 const KEEPER_STREAM_STATES = [
   'opening',
   'thinking',
@@ -189,21 +201,24 @@ function assistantDraftFromEntry(entry: KeeperConversationEntry): PendingKeeperC
 
 function normalizePendingRequest(raw: unknown): PendingKeeperChatRequest | null {
   if (!isRecord(raw)) return null
-  const requestId = stringField(raw, 'requestId')
-  const keeperName = stringField(raw, 'keeperName')
+  if (Object.keys(raw).some(field => !PENDING_REQUEST_FIELDS.includes(
+    field as (typeof PENDING_REQUEST_FIELDS)[number],
+  ))) return null
+  let runRef: KeeperRunRef
+  try {
+    runRef = parseKeeperRunRef(raw.run_ref)
+  } catch {
+    return null
+  }
   const message = stringField(raw, 'message')
-  const submittedAt =
-    typeof raw.submittedAt === 'number' && Number.isFinite(raw.submittedAt)
-      ? raw.submittedAt
-      : Date.now()
-  if (!requestId || !keeperName || !message) return null
+  const submittedAt = numberValue(raw.submittedAt)
+  if (!message || submittedAt === undefined) return null
   const attachments = Array.isArray(raw.attachments)
     ? raw.attachments.map(normalizeAttachment).filter((att): att is KeeperConversationAttachment => att !== null)
     : []
   const assistantDraft = normalizeAssistantDraft(raw.assistantDraft)
   return {
-    requestId,
-    keeperName,
+    runRef,
     message,
     submittedAt,
     ...(attachments.length > 0 ? { attachments } : {}),
@@ -218,10 +233,20 @@ function readAll(): PendingKeeperChatRequest[] {
     const raw = store.getItem(STORAGE_KEY)
     if (!raw) return []
     const parsed: unknown = JSON.parse(raw)
-    if (!Array.isArray(parsed)) return []
-    return parsed
-      .map(normalizePendingRequest)
-      .filter((request): request is PendingKeeperChatRequest => request !== null)
+    if (!Array.isArray(parsed)) {
+      console.warn('[keeper-chat-pending] pending request store must be an array')
+      return []
+    }
+    const requests: PendingKeeperChatRequest[] = []
+    parsed.forEach((candidate, index) => {
+      const request = normalizePendingRequest(candidate)
+      if (request) {
+        requests.push(request)
+      } else {
+        console.warn(`[keeper-chat-pending] rejected invalid pending request at index ${index}`)
+      }
+    })
+    return requests
   } catch (err) {
     console.warn('[keeper-chat-pending] failed to read pending requests', err instanceof Error ? err.message : err)
     return []
@@ -235,7 +260,13 @@ function writeAll(requests: PendingKeeperChatRequest[]): void {
     if (requests.length === 0) {
       store.removeItem(STORAGE_KEY)
     } else {
-      store.setItem(STORAGE_KEY, JSON.stringify(requests))
+      store.setItem(STORAGE_KEY, JSON.stringify(requests.map(request => ({
+        run_ref: keeperRunRefToWire(request.runRef),
+        message: request.message,
+        submittedAt: request.submittedAt,
+        ...(request.attachments ? { attachments: request.attachments } : {}),
+        ...(request.assistantDraft ? { assistantDraft: request.assistantDraft } : {}),
+      }))))
     }
   } catch (err) {
     console.warn('[keeper-chat-pending] failed to write pending requests', err instanceof Error ? err.message : err)
@@ -245,39 +276,37 @@ function writeAll(requests: PendingKeeperChatRequest[]): void {
 export function pendingKeeperChatRequestsForKeeper(keeperName: string): PendingKeeperChatRequest[] {
   const name = keeperName.trim()
   if (!name) return []
-  return readAll().filter(request => request.keeperName === name)
+  return readAll().filter(request => request.runRef.target.name === name)
 }
 
 export function upsertPendingKeeperChatRequest(request: PendingKeeperChatRequest): void {
-  const requestId = request.requestId.trim()
-  const keeperName = request.keeperName.trim()
   const message = request.message.trim()
-  if (!requestId || !keeperName || !message) return
+  if (!message) return
   const assistantDraft = normalizeAssistantDraft(request.assistantDraft)
   const normalized: PendingKeeperChatRequest = {
-    requestId,
-    keeperName,
+    runRef: request.runRef,
     message,
     submittedAt: request.submittedAt,
     ...(request.attachments && request.attachments.length > 0 ? { attachments: request.attachments } : {}),
     ...(assistantDraft ? { assistantDraft } : {}),
   }
-  const next = readAll().filter(existing => existing.requestId !== requestId)
+  const key = keeperRunRefKey(request.runRef)
+  const next = readAll().filter(existing => keeperRunRefKey(existing.runRef) !== key)
   next.push(normalized)
   writeAll(next)
 }
 
 export function updatePendingKeeperChatAssistantDraft(
-  requestId: string,
+  reference: KeeperRunRef,
   entry: KeeperConversationEntry,
 ): void {
-  const id = requestId.trim()
   const assistantDraft = assistantDraftFromEntry(entry)
-  if (!id || !assistantDraft) return
+  if (!assistantDraft) return
+  const key = keeperRunRefKey(reference)
   const requests = readAll()
   let found = false
   const next = requests.map(request => {
-    if (request.requestId !== id) return request
+    if (keeperRunRefKey(request.runRef) !== key) return request
     found = true
     return { ...request, assistantDraft }
   })
@@ -285,10 +314,9 @@ export function updatePendingKeeperChatAssistantDraft(
   writeAll(next)
 }
 
-export function removePendingKeeperChatRequest(requestId: string): void {
-  const id = requestId.trim()
-  if (!id) return
-  writeAll(readAll().filter(request => request.requestId !== id))
+export function removePendingKeeperChatRequest(reference: KeeperRunRef): void {
+  const key = keeperRunRefKey(reference)
+  writeAll(readAll().filter(request => keeperRunRefKey(request.runRef) !== key))
 }
 
 export function hasPendingKeeperChatRequest(keeperName: string): boolean {

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -91,7 +91,7 @@ function persistActiveAssistantDraft(keeperName: string, assistantEntryId: strin
   const entry = (keeperThreads.value[keeperName] ?? [])
     .find(candidate => candidate.id === assistantEntryId) ?? null
   if (!entry) return
-  updatePendingKeeperChatAssistantDraft(runRef.runId, entry)
+  updatePendingKeeperChatAssistantDraft(runRef, entry)
 }
 
 function flushPendingThinkingDeltas(


### PR DESCRIPTION
## What changed

- persist pending Keeper chat runs as the exact typed `run_ref` wire contract
- use the canonical full run-ref key for upsert, draft update, removal, resume, and handoff
- preserve in-flight assistant text/tool traces across page reloads without rebuilding identity from strings
- reject malformed current-schema records with an explicit warning

## Why

The pending-chat store previously split run identity into `requestId` and `keeperName`, then reconstructed a run reference during recovery. That duplicated the identity SSOT and allowed equal run IDs for different Keeper targets to collide.

This hard-cuts the browser persistence boundary to one immutable typed identity. There is no v1 migration, raw-ID fallback, or compatibility parser.

## Impact

- page reload recovery resumes the exact Keeper target/capability accepted by the server
- same run IDs remain isolated across different Keeper targets
- stream draft persistence and terminal cleanup address the same full run identity

## Stack

- base: #24631
- changed lines: 317 (+182/-135)

## Verification

- `pnpm typecheck`
- `pnpm exec eslint src/keeper-actions.ts src/keeper-chat-pending.ts`
- focused Vitest: 5 files, 148 tests passed
- `git diff --check`
