### PR TITLE
fix(keeper): separate chat recovery evidence from leases

### DIFF
--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -3358,6 +3358,11 @@ let resolve_recovery_required
                                  })
                               (apply_transaction_result
                                  ~path entry plan execution))
+                   | Some _ ->
+                     Error
+                       (Snapshot_unavailable
+                          (load_error Parse_failed ~path
+                             "recovery index contains a non-recovery receipt"))
                    | None ->
                      receipt_not_recovery_required
                        ~base_path ~path entry ~receipt_id)

--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -487,7 +487,7 @@ type queue_entry = {
   mutable pending : stored_row Sequence_map.t;
   mutable pending_count : int;
   mutable inflight : stored_row option;
-  mutable recovery_required : stored_row option;
+  mutable recovery_required : stored_row Sequence_map.t;
   mutable terminal_count : int64;
   mutable load_errors : snapshot_load_error list;
   mutable reconciliation_plan : reconciliation_plan option;
@@ -499,8 +499,8 @@ type persistence_configuration =
   | Configured of string
   | Configuration_failed of snapshot_load_error
 
-let database_schema = "keeper_chat_queue.sqlite.v2"
-let database_user_version = 2L
+let database_schema = "keeper_chat_queue.sqlite.v3"
+let database_user_version = 3L
 let database_application_id = 0x4d435151L
 let max_revision = Int64.max_int
 let database_file = "chat-queue.sqlite3"
@@ -1276,7 +1276,7 @@ let active_fifo_index_sql =
   "CREATE INDEX receipts_active_fifo ON receipts (fifo_sequence) WHERE state_kind IN ('pending', 'inflight', 'recovery_required')"
 
 let active_lease_index_sql =
-  "CREATE UNIQUE INDEX receipts_single_active_lease ON receipts ((CASE WHEN state_kind IN ('inflight', 'recovery_required') THEN 1 END))"
+  "CREATE UNIQUE INDEX receipts_single_active_lease ON receipts ((CASE WHEN state_kind = 'inflight' THEN 1 END))"
 
 let expected_schema_objects =
   [ "index", "receipts_active_fifo", active_fifo_index_sql
@@ -1629,7 +1629,7 @@ type loaded_database = {
   loaded_next_sequence : int64;
   loaded_pending : stored_row Sequence_map.t;
   loaded_inflight : stored_row option;
-  loaded_recovery_required : stored_row option;
+  loaded_recovery_required : stored_row Sequence_map.t;
   loaded_terminal_count : int64;
 }
 
@@ -1642,8 +1642,8 @@ let read_active_rows db =
         | Sqlite3.Rc.DONE -> Ok (pending, inflight, recovery_required)
         | Sqlite3.Rc.ROW ->
           let* row = decode_row_columns stmt in
-          (match row.receipt.state, inflight, recovery_required with
-           | Stored_pending _, _, _ ->
+          (match row.receipt.state, inflight with
+           | Stored_pending _, _ ->
              if Sequence_map.mem row.fifo_sequence pending
              then Error "chat queue contains duplicate FIFO positions"
              else
@@ -1651,16 +1651,19 @@ let read_active_rows db =
                  (Sequence_map.add row.fifo_sequence row pending)
                  inflight
                  recovery_required
-           | Stored_inflight _, None, None -> loop pending (Some row) None
-           | Stored_recovery_required _, None, None ->
-             loop pending None (Some row)
-           | (Stored_inflight _ | Stored_recovery_required _), _, _ ->
-             Error "chat queue contains more than one active lease receipt"
-           | (Stored_delivered _ | Stored_failed _), _, _ ->
+           | Stored_inflight _, None -> loop pending (Some row) recovery_required
+           | Stored_inflight _, Some _ ->
+             Error "chat queue contains more than one inflight receipt"
+           | Stored_recovery_required _, _ ->
+             loop
+               pending
+               inflight
+               (Sequence_map.add row.fifo_sequence row recovery_required)
+           | (Stored_delivered _ | Stored_failed _), _ ->
              Error "chat queue active index returned a terminal receipt")
         | rc -> Error (sqlite_error ~operation:"read active receipts" db rc)
       in
-      loop Sequence_map.empty None None)
+      loop Sequence_map.empty None Sequence_map.empty)
 
 let read_last_sequence db =
   with_statement db
@@ -1691,7 +1694,7 @@ let read_loaded_database db =
     let active_count =
       Sequence_map.cardinal loaded_pending
       + (if Option.is_some loaded_inflight then 1 else 0)
-      + (if Option.is_some loaded_recovery_required then 1 else 0)
+      + Sequence_map.cardinal loaded_recovery_required
     in
     let projected_row_count =
       Int64.add loaded_terminal_count (Int64.of_int active_count)
@@ -2079,7 +2082,7 @@ let create_entry
     ?(pending = Sequence_map.empty)
     ?pending_count
     ?inflight
-    ?recovery_required
+    ?(recovery_required = Sequence_map.empty)
     ?(terminal_count = 0L)
     ?(load_errors = [])
     ?reconciliation_plan
@@ -2162,11 +2165,8 @@ let remove_active_row entry row =
      entry.inflight <- None
    | None | Some _ -> ())
   ;
-  (match entry.recovery_required with
-   | Some current
-     when Receipt_id.equal current.receipt.receipt_id row.receipt.receipt_id ->
-     entry.recovery_required <- None
-   | None | Some _ -> ())
+  entry.recovery_required <-
+    Sequence_map.remove row.fifo_sequence entry.recovery_required
 
 let add_active_row entry row =
   match row.receipt.state with
@@ -2175,7 +2175,9 @@ let add_active_row entry row =
     then entry.pending_count <- entry.pending_count + 1;
     entry.pending <- Sequence_map.add row.fifo_sequence row entry.pending
   | Stored_inflight _ -> entry.inflight <- Some row
-  | Stored_recovery_required _ -> entry.recovery_required <- Some row
+  | Stored_recovery_required _ ->
+    entry.recovery_required <-
+      Sequence_map.add row.fifo_sequence row entry.recovery_required
   | Stored_delivered _ | Stored_failed _ -> ()
 
 let set_entry_projection entry ~from_row ~to_row ~revision ~next_sequence
@@ -2281,7 +2283,7 @@ let check_entry_store ~base_path ~path entry ~allow_absent =
             && Int64.equal entry.next_sequence 0L
             && entry.pending_count = 0
             && Option.is_none entry.inflight
-            && Option.is_none entry.recovery_required
+            && Sequence_map.is_empty entry.recovery_required
             && Int64.equal entry.terminal_count 0L ->
        Ok Store_absent
      | Ok Store_absent ->
@@ -2388,9 +2390,7 @@ let enqueue_with_receipt ~keeper_name ~receipt_id message =
                                  ; inflight_count =
                                      (if Option.is_some entry.inflight then 1 else 0)
                                  ; recovery_required_count =
-                                     (if Option.is_some entry.recovery_required
-                                      then 1
-                                      else 0)
+                                     Sequence_map.cardinal entry.recovery_required
                                  }
                                , false )
                            | Ok _, Ok _ ->
@@ -2437,9 +2437,7 @@ let enqueue_with_receipt ~keeper_name ~receipt_id message =
                                     ; inflight_count =
                                         (if Option.is_some entry.inflight then 1 else 0)
                                     ; recovery_required_count =
-                                        (if Option.is_some entry.recovery_required
-                                         then 1
-                                         else 0)
+                                        Sequence_map.cardinal entry.recovery_required
                                     }
                                   , true ))
                                (apply_transaction_result ~path entry plan execution))))))
@@ -2460,6 +2458,18 @@ let enqueue ~keeper_name message =
 
 let lease_id () = Random_id.prefixed ~prefix:"lease_" ~bytes:16
 
+let recovery_evidence_of_row row =
+  match row.receipt.state with
+  | Stored_recovery_required { lease_id; started_at; _ } ->
+    Ok
+      ({ receipt_id = row.receipt.receipt_id; lease_id; started_at }
+       : recovery_evidence)
+  | Stored_pending _
+  | Stored_inflight _
+  | Stored_delivered _
+  | Stored_failed _ ->
+    Error "recovery evidence index contains a non-recovery receipt"
+
 let lease_next ~keeper_name =
   match mutation_context ~keeper_name ~create:false with
   | Error error -> `Error error
@@ -2478,34 +2488,26 @@ let lease_next ~keeper_name =
                  (load_error Read_failed ~path
                     "chat queue database is absent during lease"))
           | Ok Store_present ->
-            (match entry.recovery_required, entry.inflight with
-             | ( Some
-                   { receipt =
-                       { receipt_id
-                       ; state =
-                           Stored_recovery_required
-                             { lease_id; started_at; _ }
-                       }
-                   ; _
-                   }
-               , None ) ->
-               `Recovery_required
-                 ({ receipt_id; lease_id; started_at } : recovery_evidence)
-             | Some _, _ ->
-               `Error
-                 (Snapshot_unavailable
-                    (load_error Parse_failed ~path
-                       "in-memory recovery index contains an invalid active lease"))
-             | None, Some { receipt = { state = Stored_inflight { lease_id; _ }; _ }; _ } ->
+            (match entry.inflight with
+             | Some { receipt = { state = Stored_inflight { lease_id; _ }; _ }; _ } ->
                `Already_leased lease_id
-             | None, Some _ ->
+             | Some _ ->
                `Error
                  (Snapshot_unavailable
                     (load_error Parse_failed ~path
                        "in-memory inflight index contains a non-inflight receipt"))
-             | None, None ->
+             | None ->
                (match Sequence_map.min_binding_opt entry.pending with
-                | None -> `Empty
+                | None ->
+                  (match Sequence_map.min_binding_opt entry.recovery_required with
+                   | None -> `Empty
+                   | Some (_, row) ->
+                     (match recovery_evidence_of_row row with
+                      | Ok evidence -> `Recovery_required evidence
+                      | Error detail ->
+                        `Error
+                          (Snapshot_unavailable
+                             (load_error Parse_failed ~path detail))))
                 | Some (_, row) ->
                   (match row.receipt.state with
                    | Stored_pending message ->
@@ -2765,7 +2767,7 @@ let has_active_receipts ~keeper_name =
           Ok
             (entry.pending_count > 0
              || Option.is_some entry.inflight
-             || Option.is_some entry.recovery_required))
+             || not (Sequence_map.is_empty entry.recovery_required)))
 
 type lane_health =
   | Ready
@@ -2791,37 +2793,28 @@ let lane_status ~keeper_name =
   | Ok (_, _, Some entry) ->
     with_entry_lock keeper_name entry (fun () ->
         let health =
-          match
-            entry.reconciliation_plan,
-            entry.load_errors,
-            entry.recovery_required
-          with
-          | Some _, _, _ -> Persistence_reconciliation_required
-          | None, error :: _, _ -> Unavailable error
-          | ( None
-            , []
-            , Some
-                { receipt =
-                    { receipt_id
-                    ; state =
-                        Stored_recovery_required
-                          { lease_id; started_at; _ }
-                    }
-                ; _
-                } ) ->
-            Delivery_recovery_required { receipt_id; lease_id; started_at }
-          | None, [], None -> Ready
-          | None, [], Some _ ->
-            Unavailable
-              (load_error Parse_failed
-                 "recovery index contains a non-recovery receipt")
+          match entry.reconciliation_plan, entry.load_errors with
+          | Some _, _ -> Persistence_reconciliation_required
+          | None, error :: _ -> Unavailable error
+          | None, [] ->
+            if entry.pending_count > 0 || Option.is_some entry.inflight
+            then Ready
+            else
+              (match Sequence_map.min_binding_opt entry.recovery_required with
+               | None -> Ready
+               | Some (_, row) ->
+                 (match recovery_evidence_of_row row with
+                  | Ok { receipt_id; lease_id; started_at } ->
+                    Delivery_recovery_required { receipt_id; lease_id; started_at }
+                  | Error detail ->
+                    Unavailable (load_error Parse_failed detail)))
         in
         Ok
           { revision = entry.revision
           ; has_active =
               entry.pending_count > 0
               || Option.is_some entry.inflight
-              || Option.is_some entry.recovery_required
+              || not (Sequence_map.is_empty entry.recovery_required)
           ; health
           })
 
@@ -2879,13 +2872,15 @@ let snapshot ~keeper_name =
              | Error detail -> [], [ detail ])
         in
         let recovery_required, recovery_errors =
-          match entry.recovery_required with
-          | None -> [], []
-          | Some row ->
-            (match active_receipt_of_row row with
-             | Ok receipt -> [ receipt ], []
-             | Error detail -> [], [ detail ])
+          Sequence_map.bindings entry.recovery_required
+          |> List.fold_left
+               (fun (receipts, errors) (_, row) ->
+                  match active_receipt_of_row row with
+                  | Ok receipt -> receipt :: receipts, errors
+                  | Error detail -> receipts, detail :: errors)
+               ([], [])
         in
+        let recovery_required = List.rev recovery_required in
         let projection_errors =
           List.concat [ pending_errors; inflight_errors; recovery_errors ]
           |> List.map (fun detail ->
@@ -3243,6 +3238,16 @@ let receipt_not_recovery_required
                  row
            })
 
+let find_recovery_row entry receipt_id =
+  Sequence_map.fold
+    (fun _ row found ->
+       match found with
+       | Some _ -> found
+       | None when Receipt_id.equal row.receipt.receipt_id receipt_id -> Some row
+       | None -> None)
+    entry.recovery_required
+    None
+
 let resolve_recovery_required
     ~keeper_name
     ~receipt_id
@@ -3284,7 +3289,7 @@ let resolve_recovery_required
                         ; observed_revision = entry.revision
                         })
                  else
-                   match entry.recovery_required with
+                   match find_recovery_row entry receipt_id with
                    | Some
                        ({ receipt =
                             { receipt_id = observed_receipt_id
@@ -3353,7 +3358,7 @@ let resolve_recovery_required
                                  })
                               (apply_transaction_result
                                  ~path entry plan execution))
-                   | Some _ | None ->
+                   | None ->
                      receipt_not_recovery_required
                        ~base_path ~path entry ~receipt_id)
          in
@@ -3394,7 +3399,7 @@ let entry_of_loaded_database loaded =
     ~next_sequence:loaded.loaded_next_sequence
     ~pending:loaded.loaded_pending
     ?inflight:loaded.loaded_inflight
-    ?recovery_required:loaded.loaded_recovery_required
+    ~recovery_required:loaded.loaded_recovery_required
     ~terminal_count:loaded.loaded_terminal_count
     ()
 
@@ -3410,31 +3415,15 @@ let load_keeper_lane ~base_path ~path =
   | Error detail -> Error (load_error Parse_failed ~path detail)
   | Ok loaded ->
     let entry = entry_of_loaded_database loaded in
-    (match loaded.loaded_inflight, loaded.loaded_recovery_required with
-     | None, None ->
+    (match loaded.loaded_inflight with
+     | None ->
        Ok
          { entry
-         ; recovery_required_count = 0
+         ; recovery_required_count =
+             Sequence_map.cardinal loaded.loaded_recovery_required
          ; recovery_revision = None
          }
-     | None, Some _ ->
-       Ok
-         { entry
-         ; recovery_required_count = 1
-         ; recovery_revision = None
-         }
-     | Some _, Some _ ->
-       let error =
-         load_error Recovery_failed ~path
-           "chat queue contains both inflight and recovery-required receipts"
-       in
-       entry.load_errors <- [ error ];
-       Ok
-         { entry
-         ; recovery_required_count = 1
-         ; recovery_revision = None
-         }
-     | Some before_row, None ->
+     | Some before_row ->
        (match recovery_required_state before_row with
         | Error detail ->
           let error =
@@ -3444,7 +3433,8 @@ let load_keeper_lane ~base_path ~path =
           entry.load_errors <- [ error ];
           Ok
             { entry
-            ; recovery_required_count = 0
+            ; recovery_required_count =
+                Sequence_map.cardinal entry.recovery_required
             ; recovery_revision = None
             }
         | Ok (target_state, lease_id) ->
@@ -3457,7 +3447,8 @@ let load_keeper_lane ~base_path ~path =
             entry.load_errors <- [ error ];
             Ok
               { entry
-              ; recovery_required_count = 0
+              ; recovery_required_count =
+                  Sequence_map.cardinal entry.recovery_required
               ; recovery_revision = None
               })
           else
@@ -3494,14 +3485,16 @@ let load_keeper_lane ~base_path ~path =
              | Ok revision ->
                Ok
                  { entry
-                 ; recovery_required_count = 1
+                 ; recovery_required_count =
+                     Sequence_map.cardinal entry.recovery_required
                  ; recovery_revision = Some revision
                  }
              | Error (Persist_failed { publication; _ })
                when Option.is_some (publication_evidence publication) ->
                Ok
                  { entry
-                 ; recovery_required_count = 1
+                 ; recovery_required_count =
+                     Sequence_map.cardinal entry.recovery_required
                  ; recovery_revision = Some plan.target_revision
                  }
              | Error (Persist_failed { publication = Not_published; detail }) ->
@@ -3513,7 +3506,8 @@ let load_keeper_lane ~base_path ~path =
                entry.reconciliation_plan <- Some plan;
                Ok
                  { entry
-                 ; recovery_required_count = 0
+                 ; recovery_required_count =
+                     Sequence_map.cardinal entry.recovery_required
                  ; recovery_revision = None
                  }
              | Error error ->
@@ -3525,7 +3519,8 @@ let load_keeper_lane ~base_path ~path =
                entry.reconciliation_plan <- Some plan;
                Ok
                  { entry
-                 ; recovery_required_count = 0
+                 ; recovery_required_count =
+                     Sequence_map.cardinal entry.recovery_required
                  ; recovery_revision = None
                  })))
 

--- a/lib/keeper/keeper_chat_queue.mli
+++ b/lib/keeper/keeper_chat_queue.mli
@@ -4,13 +4,17 @@
     write.  The receipt then follows exactly one closed lifecycle:
     [Pending -> Inflight -> Delivered | Failed]. On restart, [Inflight] becomes
     [Recovery_required] in the same SQLite store. From there only an explicit
-    operator decision can produce [Pending] or [Failed]. No external journal
-    participates in this lifecycle.
+    operator decision can produce [Pending] or [Failed]. Recovery evidence is
+    immutable with respect to later receipts and does not occupy the lane's
+    single execution lease. A later [Pending] receipt may therefore cross an
+    unresolved recovery boundary while the exact earlier receipt and lease
+    remain observable. No external journal participates in this lifecycle.
 
     Each lease contains exactly one receipt, so message, multimodal block,
     attachment, timestamp, provenance, and connector identity boundaries are
     preserved without delimiter-based coalescing. A crashed lease is never
-    automatically redispatched because its external effect is unproven.
+    automatically redispatched because its external effect is unproven, and
+    it never prevents a later receipt from being leased explicitly.
 
     @since 2.145.0 *)
 
@@ -246,6 +250,10 @@ val enqueue_with_receipt :
     An existing terminal receipt returns [Receipt_already_terminal]; terminal
     rows never retain message bodies and are never overwritten or redispatched. *)
 
+(** Lease the earliest pending receipt even when older recovery evidence is
+    unresolved. [`Recovery_required evidence] is returned only when no pending
+    or inflight receipt exists; [evidence] is the earliest unresolved recovery
+    boundary. *)
 val lease_next :
   keeper_name:string ->
   [ `Leased of lease

--- a/test/test_keeper_chat_coalescing.ml
+++ b/test/test_keeper_chat_coalescing.ml
@@ -637,6 +637,65 @@ let test_restart_requires_explicit_recovery_without_journal () =
    | `Empty | `Already_leased _ | `Recovery_required _ | `Error _ ->
      check "explicit requeue preserves receipt identity" false)
 
+let test_recovery_evidence_does_not_occupy_execution_lease () =
+  Printf.printf
+    "Test: unresolved recovery evidence does not occupy the execution lease\n%!";
+  with_base "keeper-chat-recovery-boundary" @@ fun base_path ->
+  let keeper_name = "recovery-boundary" in
+  ignore (configure_clean base_path : Keeper_chat_queue.configure_report);
+  let first = enqueue_exn ~keeper_name (message "first") in
+  ignore (lease_exn ~keeper_name : Keeper_chat_queue.lease);
+  Keeper_chat_queue.For_testing.reset ();
+  let first_recovery = configure base_path in
+  check "first crash preserves one recovery evidence"
+    (first_recovery.load_errors = []
+     && first_recovery.recovery_required_receipt_count = 1);
+  let second = enqueue_exn ~keeper_name (message "second") in
+  (match Keeper_chat_queue.lane_status ~keeper_name with
+   | Ok { health = Ready; has_active = true; _ } ->
+     check "pending work remains ready across a recovery boundary" true
+   | Ok _ | Error _ ->
+     check "pending work remains ready across a recovery boundary" false);
+  let second_lease = lease_exn ~keeper_name in
+  check "later pending receipt crosses the exact recovery boundary"
+    (Keeper_chat_queue.Receipt_id.equal
+       second_lease.item.receipt_id
+       second.receipt_id);
+  Keeper_chat_queue.For_testing.reset ();
+  let second_recovery = configure base_path in
+  check "a second crash preserves both recovery receipts"
+    (second_recovery.load_errors = []
+     && second_recovery.recovery_required_receipt_count = 2);
+  let snapshot = Keeper_chat_queue.snapshot ~keeper_name in
+  check "recovery evidence keeps original FIFO identity order"
+    (active_ids snapshot.recovery_required
+     = [ receipt_wire first.receipt_id; receipt_wire second.receipt_id ]);
+  let third = enqueue_exn ~keeper_name (message "third") in
+  let third_lease = lease_exn ~keeper_name in
+  check "multiple recoveries still leave one execution lease available"
+    (Keeper_chat_queue.Receipt_id.equal
+       third_lease.item.receipt_id
+       third.receipt_id);
+  (match
+     Keeper_chat_queue.finalize
+       ~keeper_name
+       ~lease_id:third_lease.lease_id
+       ~outcome:
+         (Mark_delivered
+            { completed_at = Time_compat.now (); outcome_ref = Some "third" })
+   with
+   | `Finalized receipt_id ->
+     check "later receipt finalizes independently"
+       (Keeper_chat_queue.Receipt_id.equal receipt_id third.receipt_id)
+   | `Unknown_lease | `Error _ ->
+     check "later receipt finalizes independently" false);
+  (match Keeper_chat_queue.lease_next ~keeper_name with
+   | `Recovery_required evidence ->
+     check "idle lane reports the earliest unresolved recovery evidence"
+       (Keeper_chat_queue.Receipt_id.equal evidence.receipt_id first.receipt_id)
+   | `Leased _ | `Empty | `Already_leased _ | `Error _ ->
+     check "idle lane reports the earliest unresolved recovery evidence" false)
+
 let test_legacy_json_is_not_a_queue_authority () =
   Printf.printf "Test: removed legacy JSON is never inspected as queue state\n%!";
   with_base "keeper-chat-legacy-hard-cut" @@ fun base_path ->
@@ -867,6 +926,7 @@ let () =
   test_transition_observer_outside_lock_exactly_once ();
   test_uncertain_lease_compensates_and_other_transitions_reconcile ();
   test_restart_requires_explicit_recovery_without_journal ();
+  test_recovery_evidence_does_not_occupy_execution_lease ();
   test_legacy_json_is_not_a_queue_authority ();
   test_runtime_root_typed_filename_authority ();
   test_corrupt_dotted_metadata_authority_does_not_disappear ();


### PR DESCRIPTION
## Summary

- Separate immutable crash-recovery evidence from the Keeper chat execution lease.
- Hard-cut the queue store to SQLite schema v3: only `inflight` owns the unique execution lease; recovery receipts remain FIFO-ordered evidence.
- Lease later pending receipts across unresolved recovery boundaries without guessing or replaying an earlier receipt.
- Preserve multiple crash recoveries and resolve each one by exact receipt identity.

## Product impact

- User-visible change: one unconfirmed chat delivery no longer freezes all later chat work in that Keeper lane. The unconfirmed receipt remains explicit, observable, and operator-resolvable.
- No timeout, TTL, automatic retry, heuristic, or silent fallback was added.
- Existing v2 queue databases are intentionally rejected rather than implicitly migrated; legacy compatibility is out of scope for this hard cut.

## Root cause

`recovery_required` shared the database's single-active-lease constraint with `inflight`, and `lease_next` returned recovery before pending work. A crashed receipt therefore permanently occupied the lane's execution lease and prevented later receipts from being dispatched.

## Evidence

- Added a regression covering A crash -> B dispatch -> B crash -> two ordered recovery records -> C dispatch/finalize.
- `ocamlc -stop-after parsing` passed for the implementation, interface, and regression test.
- `ocamlformat --check` passed for all changed OCaml files.
- `git diff --check` passed.
- Focused wrapper build was correctly refused because an external bare Dune process already held machine-wide build ownership: PID `66224`, `dune build lib/ test/deps/`. No lock override was used; CI remains the build authority.
- Scope: 300 changed lines (184 insertions, 116 deletions), below the 400-line stack limit.
- CI run [29419101062](https://github.com/jeong-sik/masc/actions/runs/29419101062) passed source Build, OCaml 5.5 canary, Health, Lint, ratchets, and TLA+. Its aggregate remains red because the current-main legacy OAS catalog gate rejects every configured runtime model, preventing server readiness in the Runtime TOML/SSE/transport/contract steps before the quick suite.

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 0/1
provenance: operator_proxy
stages:
  - name: focused-queue-regression
    provenance: operator_proxy
    result: blocked
    evidence: "source Build and OCaml 5.5 canary pass in CI 29419101062; focused queue execution remains blocked by external Dune PID 66224, while the full job is red on the unrelated legacy OAS catalog startup gate"
```

## GOAL LOOP ACT checklist

- [x] Observe — traced the stall to recovery evidence owning the unique active lease and preempting pending receipts.
- [x] Orient — classified as a Keeper-lane liveness defect, not a delivery retry problem.
- [x] Decide — preserve exact immutable evidence while freeing only the execution lease; no guessed redispatch.
- [x] Act — changed the queue core and one focused regression only; rollback is this commit.
- [ ] Verify — parser/format/diff checks plus CI source Build and OCaml 5.5 canary pass; the focused queue executable and aggregate CI remain blocked by external Dune ownership and the unrelated current-main legacy OAS catalog startup gate.
- [x] Loop — typed lane dispatchability and admission consumers follow in the stacked PR.

## Review evidence

- Self-reviewed for ordering, multiple recovery identity, fail-loud persistence errors, and absence of TTL/timeout/heuristic fallback.
- Cross-model review pending.

## Linked issue

- Relates to the Keeper lane liveness restoration stack.

## Variant addition checklist

- [x] **OCaml** — no public variant was added or removed in this commit.
- [x] **TypeScript** — N/A; queue-core-only change.
- [x] **TLA+ spec** — N/A; no domain literal changed.
- [x] **Event / JSON schema** — N/A; no event or JSON enum changed.
- [ ] **`make check-variants` passes** — deferred to CI because local Dune ownership is currently held by an external process.
