### PR TITLE
fix(keeper): decouple observation outbox from lane claims

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -396,27 +396,33 @@ let reaction_kind_of_settlement = function
 ;;
 
 let project_transition_outbox ~base_path ~keeper_name =
+  let rec project_entries = function
+    | [] -> Ok ()
+    | (entry : Keeper_registry_event_queue.outbox_entry) :: rest ->
+      let receipt = entry.receipt in
+      let reaction_kind = reaction_kind_of_settlement receipt.settlement in
+      (match
+         Keeper_reaction_ledger.record_event_queue_transition_reaction_result
+           ~base_path
+           ~keeper_name
+           ~reaction_kind
+           ~receipt
+           entry.stimulus
+       with
+       | Error _ as error -> error
+       | Ok () ->
+         (match
+            Keeper_registry_event_queue.mark_transition_projected_result
+              ~base_path
+              keeper_name
+              ~transition_id:receipt.transition_id
+          with
+          | Error _ as error -> error
+          | Ok () -> project_entries rest))
+  in
   match Keeper_registry_event_queue.transition_outbox_result ~base_path keeper_name with
   | Error _ as error -> error
-  | Ok [] -> Ok ()
-  | Ok [ (entry : Keeper_registry_event_queue.outbox_entry) ] ->
-    let receipt = entry.receipt in
-    let reaction_kind = reaction_kind_of_settlement receipt.settlement in
-    (match
-       Keeper_reaction_ledger.record_event_queue_transition_reaction_result
-         ~base_path
-         ~keeper_name
-         ~reaction_kind
-         ~receipt
-         entry.stimulus
-     with
-     | Error _ as error -> error
-     | Ok () ->
-       Keeper_registry_event_queue.mark_transition_projected_result
-         ~base_path
-         keeper_name
-         ~transition_id:receipt.transition_id)
-  | Ok (_ :: _ :: _) -> Error "event queue state has multiple unprojected transitions"
+  | Ok entries -> project_entries entries
 ;;
 
 let settle_claimed_lease
@@ -546,7 +552,11 @@ let run_keepalive_unified_turn
            ~keeper_name:meta_after_triage.name
        with
        | Ok () -> ()
-       | Error message -> raise (Event_queue_settlement_failed message));
+       | Error message ->
+         Log.Keeper.error
+           "registry: deferred transition projection keeper=%s: %s"
+           meta_after_triage.name
+           message);
       let event_intake =
         heartbeat_event_intake
           ~ctx
@@ -870,7 +880,11 @@ let run_keepalive_unified_turn
                  ~base_path:ctx.config.base_path
                  ~keeper_name:meta_after_triage.name
              with
-             | Error message -> raise (Event_queue_settlement_failed message)
+             | Error message ->
+               Log.Keeper.error
+                 "registry: deferred transition projection keeper=%s: %s"
+                 meta_after_triage.name
+                 message
              | Ok () -> ());
             if settlement_is_ack settlement
             then

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -92,20 +92,25 @@ let active_lease state =
 
 let mark_transition_projected ~transition_id state =
   match state.transition_outbox with
-  | [ entry ] when String.equal entry.receipt.transition_id transition_id ->
+  | entry :: transition_outbox
+    when String.equal entry.receipt.transition_id transition_id ->
     Ok
       { state with
         last_settlement = Some entry.receipt
-      ; transition_outbox = []
+      ; transition_outbox
       }
-  | [] ->
+  | [] | _ :: _ ->
     (match state.last_settlement with
      | Some receipt when String.equal receipt.transition_id transition_id -> Ok state
      | Some _ | None ->
-       Error (Printf.sprintf "event queue transition not found: %s" transition_id))
-  | [ _ ] ->
-    Error (Printf.sprintf "event queue transition not found: %s" transition_id)
-  | _ :: _ :: _ -> Error "event queue state has multiple unprojected transitions"
+       (match state.transition_outbox with
+        | [] ->
+          Error (Printf.sprintf "event queue transition not found: %s" transition_id)
+        | _ :: _ ->
+          Error
+            (Printf.sprintf
+               "event queue transition is not the oldest unprojected receipt: %s"
+               transition_id)))
 ;;
 let with_pending pending state = { state with pending }
 let with_revision revision state = { state with revision }
@@ -158,7 +163,7 @@ let make_lease ~claimed_at stimulus state =
 ;;
 
 let lease_admission_blocked state =
-  state.leases <> [] || state.transition_outbox <> []
+  state.leases <> []
 ;;
 
 let rec dequeue_first_ready ~ready skipped pending =
@@ -394,13 +399,16 @@ let receipt_for_lease ~settled_at ~settlement (lease : lease) =
 ;;
 
 let find_prior_receipt lease_id state =
-  match state.transition_outbox with
-  | [ entry ] when String.equal entry.receipt.lease_id lease_id -> Some entry.receipt
-  | [] | [ _ ] ->
+  match
+    List.find_opt
+      (fun entry -> String.equal entry.receipt.lease_id lease_id)
+      state.transition_outbox
+  with
+  | Some entry -> Some entry.receipt
+  | None ->
     (match state.last_settlement with
      | Some receipt when String.equal receipt.lease_id lease_id -> Some receipt
      | Some _ | None -> None)
-  | _ :: _ :: _ -> None
 ;;
 
 let remove_lease lease_id leases =
@@ -467,7 +475,7 @@ let settle ~settled_at ~lease ~settlement state =
       ( { state with
           pending
         ; leases = remove_lease committed.lease_id state.leases
-        ; transition_outbox = [ outbox_entry ]
+        ; transition_outbox = state.transition_outbox @ [ outbox_entry ]
         }
       , Settled receipt )
 ;;
@@ -737,15 +745,13 @@ let validate_state state =
   then Error "event queue next lease sequence must be positive"
   else if List.length state.leases > 1
   then Error "event queue state must contain at most one active lease"
-  else if List.length state.transition_outbox > 1
-  then Error "event queue state must contain at most one unprojected transition"
-  else if state.leases <> [] && state.transition_outbox <> []
-  then Error "event queue state cannot contain both an active lease and an outbox transition"
   else if
-    match state.last_settlement, state.transition_outbox with
-    | Some receipt, [ entry ] ->
-      String.equal receipt.transition_id entry.receipt.transition_id
-    | None, _ | Some _, ([] | _ :: _ :: _) -> false
+    match state.last_settlement with
+    | None -> false
+    | Some receipt ->
+      List.exists
+        (fun entry -> String.equal receipt.transition_id entry.receipt.transition_id)
+        state.transition_outbox
   then Error "event queue last settlement duplicates the unprojected transition"
   else
     match duplicate_by (fun (lease : lease) -> lease.lease_id) state.leases with

--- a/lib/keeper_runtime/keeper_event_queue_state.mli
+++ b/lib/keeper_runtime/keeper_event_queue_state.mli
@@ -83,8 +83,10 @@ val claim_when :
   (t * lease option, string) result
 (** Lease the earliest pending stimulus accepted by [ready]. Earlier unready
     stimuli retain their exact relative position, so one unavailable HITL
-    continuation cannot block unrelated ready work in the same Keeper lane. A
-    successful claim advances the monotonic lease sequence in the same state. *)
+    continuation cannot block unrelated ready work in the same Keeper lane.
+    Durable transition receipts awaiting observation projection do not block a
+    claim. A successful claim advances the monotonic lease sequence in the same
+    state. *)
 
 val settle :
   settled_at:float ->
@@ -109,9 +111,10 @@ val active_lease : t -> lease option
     claiming new pending work. *)
 
 val mark_transition_projected : transition_id:string -> t -> (t, string) result
-(** Atomically retire a durable outbox entry after an external projector has
-    materialized its stable [event_id], retaining only the last receipt for an
-    immediate idempotent retry. Unknown transition ids fail closed. *)
+(** Atomically retire the oldest durable outbox entry after an external projector has
+    materialized its stable [event_id]. Other ordered entries remain durable;
+    the retired receipt is retained for an immediate idempotent retry. Unknown
+    transition ids fail closed. *)
 
 val remove_by_post_id :
   Keeper_event_queue.post_id -> t -> Keeper_event_queue.stimulus list * t

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -202,24 +202,25 @@ let test_requeue_and_escalation_are_total () =
     | [ entry ] -> entry.receipt
     | _ -> Alcotest.fail "retry settlement must create one outbox entry"
   in
-  let blocked_state, blocked_lease = claim_head state in
+  let claimed_state, claimed_lease = claim_head state in
   Alcotest.(check bool)
-    "unprojected outbox blocks the next claim"
+    "unprojected observation does not block the next claim"
     true
-    (Option.is_none blocked_lease);
+    (Option.is_some claimed_lease);
   Alcotest.(check (list string))
-    "blocked claim preserves pending work"
-    [ "retry" ]
-    (post_ids (State.pending blocked_state));
+    "claimed retry leaves no pending work"
+    []
+    (post_ids (State.pending claimed_state));
+  Alcotest.(check int)
+    "claim retains the unprojected receipt"
+    1
+    (List.length (State.transition_outbox claimed_state));
   let state =
-    State.mark_transition_projected
-      ~transition_id:retry_receipt.transition_id
-      blocked_state
-    |> require_ok "project retry transition"
+    State.to_yojson claimed_state
+    |> State.of_yojson
+    |> require_ok "lease and outbox codec roundtrip"
   in
-  Alcotest.(check (list string)) "retry restored" [ "retry" ] (post_ids (State.pending state));
-  let state, lease = claim_head state in
-  let lease = require_some "escalation lease" lease in
+  let lease = require_some "escalation lease" claimed_lease in
   let judgment : Queue.failure_judgment =
     { fj_runtime_id = "runtime-a"
     ; fj_judgment = Keeper_runtime_failure_route.Contract_violation
@@ -247,9 +248,37 @@ let test_requeue_and_escalation_are_total () =
   in
   let escalation_receipt =
     match State.transition_outbox state with
-    | [ entry ] -> entry.receipt
-    | _ -> Alcotest.fail "judgment escalation must create one outbox entry"
+    | [ retry_entry; escalation_entry ] ->
+      Alcotest.(check string)
+        "outbox preserves settlement order"
+        retry_receipt.transition_id
+        retry_entry.receipt.transition_id;
+      escalation_entry.receipt
+    | _ -> Alcotest.fail "both unprojected transitions must remain durable"
   in
+  (match
+     State.mark_transition_projected
+       ~transition_id:escalation_receipt.transition_id
+       state
+   with
+   | Error _ -> ()
+   | Ok _ -> Alcotest.fail "out-of-order projection crossed the receipt boundary");
+  let state =
+    State.mark_transition_projected ~transition_id:retry_receipt.transition_id state
+    |> require_ok "project retry transition"
+  in
+  Alcotest.(check int)
+    "projecting one receipt retains the next"
+    1
+    (List.length (State.transition_outbox state));
+  let state =
+    State.mark_transition_projected ~transition_id:retry_receipt.transition_id state
+    |> require_ok "repeat projected transition with later receipt pending"
+  in
+  Alcotest.(check int)
+    "idempotent retry leaves the later receipt intact"
+    1
+    (List.length (State.transition_outbox state));
   let state =
     State.mark_transition_projected ~transition_id:escalation_receipt.transition_id state
     |> require_ok "project judgment escalation"
@@ -840,8 +869,9 @@ let test_transition_outbox_projects_with_stable_identity () =
   with_temp_dir "keeper-event-queue-v2-outbox" (fun base_path ->
     let keeper_name = "projection_keeper" in
     let source = stimulus "projected-source" 1.0 in
+    let second = stimulus "projected-second" 1.5 in
     Persistence.update_result ~base_path ~keeper_name (fun pending ->
-      Queue.enqueue pending source)
+      Queue.enqueue (Queue.enqueue pending source) second)
     |> require_ok "seed projection source";
     let lease =
       Persistence.claim_when_result
@@ -882,6 +912,30 @@ let test_transition_outbox_projects_with_stable_identity () =
      with
      | Persistence.Already_present -> ()
      | Persistence.Enqueued -> Alcotest.fail "outbox stimulus was duplicated");
+    let second_lease =
+      Persistence.claim_when_result
+        ~base_path
+        ~keeper_name
+        ~claimed_at:3.5
+        ~ready:(fun _ -> true)
+        ()
+      |> require_ok "claim while first transition awaits projection"
+      |> require_some "second projection lease"
+    in
+    ignore
+      (Persistence.settle_result
+         ~base_path
+         ~keeper_name
+         ~settled_at:4.0
+         ~lease:second_lease
+         ~settlement:State.Ack
+         ()
+       |> require_ok "settle second projection source");
+    let queued_outbox =
+      Persistence.transition_outbox_result ~base_path ~keeper_name
+      |> require_ok "load ordered transition outbox"
+    in
+    Alcotest.(check int) "two settlements await projection" 2 (List.length queued_outbox);
     Masc.Keeper_heartbeat_loop.project_transition_outbox ~base_path ~keeper_name
     |> require_ok "project transition outbox";
     let state =
@@ -908,7 +962,7 @@ let test_transition_outbox_projects_with_stable_identity () =
     let open Yojson.Safe.Util in
     Alcotest.(check int)
       "stable event id deduplicates crash replay"
-      1
+      2
       (summary |> member "event_queue_ack_count" |> to_int);
     Masc.Keeper_heartbeat_loop.project_transition_outbox ~base_path ~keeper_name
     |> require_ok "empty outbox projection is idempotent")


### PR DESCRIPTION
## Stack

Depends on #24630.

## Why

The transition outbox is durable settlement evidence for a derived reaction-ledger projector. A projector filesystem failure must remain visible and retryable, but it must not become admission authority over the owner Keeper lane.

## Change

- allow one active execution lease while older settlement receipts await projection
- append immutable single-stimulus receipts in exact settlement order
- project receipts oldest-first and reject out-of-order retirement
- preserve stable event identity so a partially completed projection retries idempotently
- allow retry of the most recently retired receipt even while later receipts remain pending
- log projection failure at the boundary and keep the durable outbox visible to health/inventory
- continue the execution lane without dropping or replacing failed projection evidence

## Invariants

- at most one active execution lease per Keeper
- exactly one typed stimulus per lease and receipt
- no TTL, retry count, timeout, budget, overwrite, or silent discard
- no cross-Keeper worker and no observation-driven execution gate

## Verification

- `ocamlformat --check`
- `git diff --check`
- legacy/multi-stimulus residue search: 0
- focused `main_eio`, queue-state, and reaction-ledger build passed
- queue-state suite passed 14/14
- reaction-ledger suite passed 21/21
- full build/test remains PR CI authority
