### PR TITLE
fix(keeper): log tool error results at their declared class severity

### DIFF
--- a/lib/keeper/keeper_tools_oas_handler_exec.ml
+++ b/lib/keeper/keeper_tools_oas_handler_exec.ml
@@ -93,7 +93,16 @@ let execute_with_observers
         Keeper_metrics.(to_string ToolsOasFailures)
         ~labels:[ "tool", name; "site", "error_result" ]
         ();
-      Log.Keeper.error "tool %s returned error result: %s" name detail;
+      (* Honor the declared per-class severity (Tool_result.log_level_of_
+         failure_class): Workflow_rejection / Policy_rejection / Transient_error
+         are WARN, Runtime_failure is ERROR. Hardcoding ERROR here logged
+         expected non-blocking gate deferrals (Workflow_rejection) as errors,
+         producing false alarms. Same idiom as mcp_server_eio_call_tool.ml and
+         keeper_tool_in_process_runtime.ml. *)
+      Log.Keeper.emit
+        (Tool_result.log_level_of_failure_class failure_class)
+        ~category:Log.Tool
+        (Printf.sprintf "tool %s returned error result: %s" name detail);
       let normalized_error_json =
         normalize_tool_result ~success:false ~data:producer_data raw_result
       in

--- a/test/test_tool_result.ml
+++ b/test/test_tool_result.ml
@@ -10,6 +10,30 @@ let tool_ok ?(tool_name = "") message =
   Tool_result.make_ok ~tool_name ~start_time:0.0 ~data:(`String message) ()
 ;;
 
+(* Severity policy the OAS exec-handler logger relies on: expected non-blocking
+   outcomes (Workflow_rejection — e.g. a gate deferral) log at WARN, only real
+   failures (Runtime_failure) log at ERROR. Locks the SSOT so the logger cannot
+   silently regress back to hardcoding ERROR for deferrals. *)
+let level_name : Log.level -> string = function
+  | Log.Debug -> "debug"
+  | Log.Info -> "info"
+  | Log.Warn -> "warn"
+  | Log.Error -> "error"
+;;
+
+let test_log_level_of_failure_class () =
+  let check_level expected cls =
+    Alcotest.(check string)
+      (Printf.sprintf "log level for %s" (Tool_result.tool_failure_class_to_string cls))
+      expected
+      (level_name (Tool_result.log_level_of_failure_class cls))
+  in
+  check_level "warn" Tool_result.Workflow_rejection;
+  check_level "warn" Tool_result.Policy_rejection;
+  check_level "warn" Tool_result.Transient_error;
+  check_level "error" Tool_result.Runtime_failure
+;;
+
 let test_schema tool =
   { Masc_domain.name = tool
   ; description = "test tool " ^ tool
@@ -491,6 +515,12 @@ let () =
             "done schema uses result and evidence refs"
             `Quick
             test_keeper_done_schema_uses_result_and_evidence_refs
+        ] )
+    ; ( "failure-class log severity"
+      , [ Alcotest.test_case
+            "Workflow/Policy/Transient are WARN, Runtime is ERROR"
+            `Quick
+            test_log_level_of_failure_class
         ] )
     ]
 ;;


### PR DESCRIPTION
## 목적
라이브 서버가 매 턴 **~15 가짜 ERROR**(`tool tool_execute returned error result: {...External effect deferred...}`)를 찍는 노이즈 제거. deferral은 정상 동작(비차단 승인 대기)인데 ERROR로 로깅됨.

## 근본
`keeper_tools_oas_handler_exec.ml:96`이 실패 결과를 **무조건 `Log.Keeper.error`로 하드코딩**, 이미 존재하는 class별 severity SSOT(`Tool_result.log_level_of_failure_class`: Workflow_rejection→Warn, Runtime_failure→Error)를 무시. gate deferral은 typed `Workflow_rejection`이라 정책상 WARN인데 ERROR로 찍힘.

## 변경 (1 line + 주석 + 테스트)
- 로거가 `Log.Keeper.emit (log_level_of_failure_class failure_class)` 사용 — **이미 mcp_server_eio_call_tool.ml:576·keeper_tool_in_process_runtime.ml:650이 쓰는 idiom**. typed variant 분기, string-match 0.
- 회귀 테스트(test_tool_result.ml): severity 정책 고정.
- 진짜 에러(Runtime_failure)는 ERROR 유지.

## 알려진 follow-up (범위 밖)
OnToolError 중복 로그(`keeper_hooks_oas.ml:624`)는 OAS hook이 **opaque text(typed class 없음)**라 이 방식으로 못 고침 — hook 경계에 class가 실려야 함(string-match는 코드가 의도적 거부).

## Done
- RFC-gated 밖. **owner 빌드로 green 확인 후 Ready.** Draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)