### PR TITLE
refactor(fusion): delete adaptive timeout contract

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -289,7 +289,7 @@
 ;; RFC-0252 standalone fusion harness: on-demand panel+judge deliberation vs
 ;; single-model baseline, side by side. Makes live LLM calls (NOT a test —
 ;; CI determinism rules forbid network calls in test/). Calls Fusion_panel.run
-;; + Fusion_judge.run directly (bypasses the orchestrator's gate/budget/sink).
+;; + Fusion_judge.run directly (bypasses the orchestrator's gate/sink).
 
 (executable
  (name fusion_run)

--- a/bin/fusion_run.ml
+++ b/bin/fusion_run.ml
@@ -123,7 +123,6 @@ let synthesize ~sw ~net ~(preset : Fusion_policy.preset) ~(prompt : string)
     ~web_tools:
       (Fusion_policy.judge_web_tools_of ~req_web_tools:false
          preset.Fusion_policy.panels)
-    ~max_tool_calls:(Fusion_policy.judge_tool_budget_of preset.Fusion_policy.panels)
     ()
   |> Result.map_error (fun (failure, _usage) ->
     Fusion_types.judge_failure_text failure)

--- a/docs/rfc/RFC-0306-fusion-settings-typed-editor.md
+++ b/docs/rfc/RFC-0306-fusion-settings-typed-editor.md
@@ -187,8 +187,7 @@ no longer enforces.
 - Budget/cost/turn controls — collected, not edited (product rule).
 - Creating/deleting whole presets from the UI (edit existing presets only); preset
   CRUD is a possible follow-up, see §7.2.
-- Per-call `timeout_s` range validation beyond what `of_preset` already checks
-  (`Bad_meta_timeout`, `Bad_adaptive_factor`).
+- Per-call `timeout_s` range validation beyond `Bad_meta_timeout`.
 
 ## 5. Implementation plan
 

--- a/lib/fusion/fusion_judge.ml
+++ b/lib/fusion/fusion_judge.ml
@@ -177,7 +177,7 @@ let apply_fusion_judge_output_contract provider_cfg =
    에러도 usage를 동반한다: 토큰을 태운 뒤 실패(빈 응답/파싱 실패)는 소비분을, 토큰
    소비 전 실패(빌드/실행/빈 결과/provider 에러)는 [zero_usage]를 싣는다. 호출자는
    실패 경로에서도 비용을 회계할 수 있다. *)
-let run_composed ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_model
+let run_composed ~sw ~net ~timeout_s ~judge_system_prompt ~judge_model
     ~web_tools ~prompt () :
     ( Fusion_types.judge_synthesis * Fusion_types.usage
     , Fusion_types.judge_failure * Fusion_types.usage )
@@ -185,7 +185,7 @@ let run_composed ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_mod
   let tools = if web_tools then Fusion_oas.web_tool_bundle () else [] in
   match
     Fusion_oas.build_agent ~sw ~net ~system_prompt:judge_system_prompt ~tools
-      ~timeout_s ?max_tokens
+      ~timeout_s
       ~provider_config_transform:apply_fusion_judge_output_contract
       judge_model
   with
@@ -222,28 +222,28 @@ let run_composed ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_mod
              ~prefix:"judge provider error: " e
          , Fusion_types.zero_usage ))
 
-let run ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_model ~question
+let run ~sw ~net ~timeout_s ~judge_system_prompt ~judge_model ~question
     ~panel ~web_tools () :
     ( Fusion_types.judge_synthesis * Fusion_types.usage
     , Fusion_types.judge_failure * Fusion_types.usage )
     result =
-  run_composed ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_model ~web_tools
+  run_composed ~sw ~net ~timeout_s ~judge_system_prompt ~judge_model ~web_tools
     ~prompt:(compose_prompt ~question ~panel) ()
 
-let run_refine ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_model ~question
+let run_refine ~sw ~net ~timeout_s ~judge_system_prompt ~judge_model ~question
     ~panel ~prior ~web_tools () :
     ( Fusion_types.judge_synthesis * Fusion_types.usage
     , Fusion_types.judge_failure * Fusion_types.usage )
     result =
-  run_composed ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_model ~web_tools
+  run_composed ~sw ~net ~timeout_s ~judge_system_prompt ~judge_model ~web_tools
     ~prompt:(compose_refine_prompt ~question ~panel ~prior) ()
 
-let run_meta ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_model ~question
+let run_meta ~sw ~net ~timeout_s ~judge_system_prompt ~judge_model ~question
     ~panel ~priors ~web_tools () :
     ( Fusion_types.judge_synthesis * Fusion_types.usage
     , Fusion_types.judge_failure * Fusion_types.usage )
     result =
-  run_composed ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_model ~web_tools
+  run_composed ~sw ~net ~timeout_s ~judge_system_prompt ~judge_model ~web_tools
     ~prompt:(compose_meta_prompt ~question ~panel ~priors) ()
 
 module For_testing = struct

--- a/lib/fusion/fusion_judge.mli
+++ b/lib/fusion/fusion_judge.mli
@@ -20,7 +20,7 @@ val compose_prompt : question:string -> panel:Fusion_types.panel_outcome list ->
     구성해 실행하고, capability-aware output contract를 적용한 응답 텍스트를
     {!Fusion_judge_parse.of_string}으로 파싱한다.
     [web_tools=true]면 심판 에이전트에 web_search/web_fetch를 주입한다.
-    [max_tokens]는 출력 토큰 예산이다. 생략하면 Runtime_agent 기본값을 보존한다.
+    Fusion은 심판별 출력 토큰 예산을 합성하지 않는다.
     빌드/실행/빈응답/파싱 실패는 [Error (msg, usage)]. 전체는 [Masc_oas_bridge.run_safe]로
     감싼다. 성공 시 종합 + 소비 토큰 [usage]를 반환하고(panel과 대칭, 비용 회계 RFC §10),
     실패 시에도 usage를 동반한다 — 응답을 받은 뒤 실패(빈 응답/파싱 실패)는 소비분을,
@@ -30,7 +30,6 @@ val run
   :  sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> timeout_s:float
-  -> ?max_tokens:int
   -> judge_system_prompt:string
   -> judge_model:string
   -> question:string
@@ -60,7 +59,6 @@ val run_refine
   :  sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> timeout_s:float
-  -> ?max_tokens:int
   -> judge_system_prompt:string
   -> judge_model:string
   -> question:string
@@ -100,7 +98,6 @@ val run_meta
   :  sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> timeout_s:float
-  -> ?max_tokens:int
   -> judge_system_prompt:string
   -> judge_model:string
   -> question:string

--- a/lib/fusion/fusion_metrics.ml
+++ b/lib/fusion/fusion_metrics.ml
@@ -12,10 +12,6 @@ let metric_fusion_invocations_total =
 let metric_fusion_judge_executions_total =
   Otel_metric_store_core.declare_counter "masc_fusion_judge_executions_total"
 
-let metric_fusion_adaptive_timeout_extensions_total =
-  Otel_metric_store_core.declare_counter
-    "masc_fusion_adaptive_timeout_extensions_total"
-
 let topology_label = function
   | Simple -> "simple"
   | Refine -> "refine"
@@ -59,9 +55,4 @@ let record_invocation ~topology outcome =
   Otel_metric_store_core.inc_counter
     metric_fusion_invocations_total
     ~labels:[ "topology", topology_label topology; "outcome", outcome_label ]
-    ()
-
-let record_adaptive_timeout () =
-  Otel_metric_store_core.inc_counter
-    metric_fusion_adaptive_timeout_extensions_total
     ()

--- a/lib/fusion/fusion_metrics.mli
+++ b/lib/fusion/fusion_metrics.mli
@@ -2,7 +2,6 @@
 
 val metric_fusion_invocations_total : string
 val metric_fusion_judge_executions_total : string
-val metric_fusion_adaptive_timeout_extensions_total : string
 
 val topology_label : Fusion_types.fusion_topology -> string
 val judge_role_label : Fusion_types.judge_role -> string
@@ -17,7 +16,3 @@ val record_judge_execution : topology:Fusion_types.fusion_topology -> Fusion_typ
 val record_invocation : topology:Fusion_types.fusion_topology -> [< `Denied | `Sink_failed | `Completed ] -> unit
 (** Emit a counter increment for one fusion invocation.
     Labels: [topology], [outcome] \in {denied, sink_failed, completed}. *)
-
-val record_adaptive_timeout : unit -> unit
-(** Emit a counter increment when an adaptive timeout extension is applied to a
-    first-judge recovery pass. *)

--- a/lib/fusion/fusion_oas.ml
+++ b/lib/fusion/fusion_oas.ml
@@ -155,7 +155,6 @@ let build_agent
     ~system_prompt
     ?(tools = [])
     ?timeout_s
-    ?max_tokens
     ?name
     ?provider_config_transform
     (model : string)
@@ -196,26 +195,16 @@ let build_agent
            ~system_prompt
            ~tools
        in
-       let base_config = apply_timeout_budget ?timeout_s base_config in
-       let config =
-         match max_tokens with
-         | None -> Ok base_config
-         | Some n when Fusion_policy.valid_max_output_tokens (Some n) ->
-           Ok { base_config with max_tokens = Some n }
-         | Some n -> Error (Fusion_types.Invalid_max_output_tokens n)
-       in
-       match config with
-       | Error _ as err -> err
-       | Ok config ->
-         (match Runtime_agent.build ~sw ~net ~config with
-           | Ok agent -> Ok agent
-           | Error e ->
-             Error
-               ((Fusion_types.Provider_error
-                   (provider_error_detail
-                      ~runtime_id:model
-                      (Agent_sdk.Error.to_string e))
-                 : Fusion_types.panel_failure))))
+       let config = apply_timeout_budget ?timeout_s base_config in
+       (match Runtime_agent.build ~sw ~net ~config with
+        | Ok agent -> Ok agent
+        | Error e ->
+          Error
+            ((Fusion_types.Provider_error
+                (provider_error_detail
+                   ~runtime_id:model
+                   (Agent_sdk.Error.to_string e))
+              : Fusion_types.panel_failure))))
 
 module For_testing = struct
   let apply_timeout_budget = apply_timeout_budget

--- a/lib/fusion/fusion_oas.mli
+++ b/lib/fusion/fusion_oas.mli
@@ -8,9 +8,8 @@
 
 (** runtime_id("provider.model")로 OAS 에이전트를 빌드한다.
 
-    [tools]를 주면 패널/심판이 tool call을 할 수 있다.
-    [max_tokens]는 지정된 패널/심판 호출의 출력 토큰 예산이다. 생략하면
-    Runtime_agent 기본값을 보존한다.
+    [tools]를 주면 패널/심판이 tool call을 할 수 있다. Fusion은 호출별 출력
+    토큰 예산을 합성하지 않고 resolved runtime의 요청 설정을 그대로 보존한다.
     [timeout_s]는 OAS transport idle/body budget에만 매핑한다. Fusion의 구조적
     wall-clock budget은 호출자가 [Masc_oas_bridge.run_safe]로 소유한다.
     [name]은 에이전트 카드명 — [Async_agent.all]이 결과 키로 반환하는 패널 정체성이다
@@ -26,7 +25,6 @@ val build_agent
   -> system_prompt:string
   -> ?tools:Agent_sdk.Tool.t list
   -> ?timeout_s:float
-  -> ?max_tokens:int
   -> ?name:string
   -> ?provider_config_transform:
        (Llm_provider.Provider_config.t

--- a/lib/fusion/fusion_orchestrator.ml
+++ b/lib/fusion/fusion_orchestrator.ml
@@ -42,7 +42,6 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
           let run_single_judge () =
             Fusion_judge.run ~sw ~net
               ~timeout_s:preset.Fusion_policy.judge_timeout_s
-              ?max_tokens:preset.Fusion_policy.judge_max_output_tokens
               ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
               ~judge_model:preset.Fusion_policy.judge
               ~question:req.Fusion_types.prompt ~panel ~web_tools:judge_web_tools ()
@@ -55,7 +54,6 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
             match
               Fusion_judge.run_refine ~sw ~net
                 ~timeout_s:preset.Fusion_policy.judge_timeout_s
-                ?max_tokens:preset.Fusion_policy.judge_max_output_tokens
                 ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
                 ~judge_model:preset.Fusion_policy.judge
                 ~question:req.Fusion_types.prompt ~panel ~prior:s1
@@ -154,7 +152,6 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                  (match
                        Fusion_judge.run_meta ~sw ~net
                          ~timeout_s:preset.Fusion_policy.meta_timeout_s
-                         ?max_tokens:preset.Fusion_policy.judge_max_output_tokens
                          ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
                          ~judge_model:preset.Fusion_policy.judge
                          ~question:req.Fusion_types.prompt ~panel ~priors
@@ -239,7 +236,6 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                   (match
                         Fusion_judge.run_meta ~sw ~net
                           ~timeout_s:preset.Fusion_policy.meta_timeout_s
-                          ?max_tokens:preset.Fusion_policy.judge_max_output_tokens
                           ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
                           ~judge_model:preset.Fusion_policy.judge
                           ~question:req.Fusion_types.prompt ~panel ~priors
@@ -296,7 +292,6 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                  (match
                        Fusion_judge.run_meta ~sw ~net
                          ~timeout_s:preset.Fusion_policy.meta_timeout_s
-                         ?max_tokens:preset.Fusion_policy.judge_max_output_tokens
                          ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
                          ~judge_model:preset.Fusion_policy.judge
                          ~question:req.Fusion_types.prompt ~panel ~priors

--- a/lib/fusion/fusion_orchestrator_judge_wave.ml
+++ b/lib/fusion/fusion_orchestrator_judge_wave.ml
@@ -177,7 +177,6 @@ let run_fallback_judge
         ~sw
         ~net
         ~timeout_s:j.jtimeout_s
-        ?max_tokens:j.jmax_output_tokens
         ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
         ~judge_model:model
         ~question

--- a/lib/fusion/fusion_orchestrator_judge_wave.ml
+++ b/lib/fusion/fusion_orchestrator_judge_wave.ml
@@ -169,7 +169,6 @@ let run_fallback_judge
       ; jweb_tools = judge_web_tools
       ; jmax_output_tokens = preset.Fusion_policy.judge_max_output_tokens
       ; jtimeout_s = preset.Fusion_policy.judge_timeout_s
-      ; jmax_timeout_s = None
       }
     in
     let id = Fusion_policy.panelist_id ~label:j.jlabel ~model:j.jmodel in

--- a/lib/fusion/fusion_panel.ml
+++ b/lib/fusion/fusion_panel.ml
@@ -84,7 +84,6 @@ let run ~sw ~net ~outer_timeout_s ~groups ~prompt ()
             match
               Fusion_oas.build_agent ~sw ~net ~system_prompt:g.system_prompt ~tools
                 ~timeout_s:g.timeout_s
-                ?max_tokens:g.max_output_tokens
                 ~name:panelist model
             with
             | Ok agent -> ((agent, panelist, model) :: oks, fails)

--- a/lib/fusion_core/fusion_config.ml
+++ b/lib/fusion_core/fusion_config.ml
@@ -16,8 +16,6 @@ type config_error =
   | Duplicate_judge of string * string  (** (preset 이름, 중복 judge 정체성) (RFC-0283) *)
   | Invalid_meta_timeout of string * float
       (** (preset 이름, meta_timeout_s): 양수 유한수가 아님. *)
-  | Invalid_adaptive_timeout_factor of string * float
-      (** (preset 이름, adaptive_timeout_factor): 1.0 미만. *)
   | Toml_type_error of string
 [@@deriving show, eq]
 
@@ -61,8 +59,6 @@ let parse_judge_spec (tbl : Otoml.t) : Fusion_policy.judge_spec =
   ; jtimeout_s =
       Otoml.find_or ~default:Fusion_policy.default_timeout_s tbl Otoml.get_float
         [ "timeout_s" ]
-  ; jmax_timeout_s =
-      Otoml.find_opt tbl Otoml.get_float [ "max_timeout_s" ]
   }
 
 (* 패널 그룹을 확정한 뒤 preset 완성 + 검증. judge_* 는 preset table에서 직접 읽는다
@@ -93,9 +89,6 @@ let finish_preset name tbl (panels : Fusion_policy.panel_group list)
     | Some entries -> List.map parse_judge_spec entries
     | None -> []
   in
-  let adaptive_timeout_factor =
-    Otoml.find_or ~default:1.0 tbl Otoml.get_float [ "adaptive_timeout_factor" ]
-  in
   let fallback_judge_model =
     Otoml.find_opt tbl Otoml.get_string [ "fallback_judge_model" ]
   in
@@ -108,7 +101,6 @@ let finish_preset name tbl (panels : Fusion_policy.panel_group list)
     ; judge_max_output_tokens
     ; judges
     ; meta_timeout_s
-    ; adaptive_timeout_factor
     ; fallback_judge_model
     }
   in
@@ -134,8 +126,7 @@ let finish_preset name tbl (panels : Fusion_policy.panel_group list)
            Duplicate_judge (name, id)
          | Fusion_policy.Validated_preset.Bad_meta_timeout v ->
            Invalid_meta_timeout (name, v)
-       | Fusion_policy.Validated_preset.Bad_adaptive_factor v ->
-         Invalid_adaptive_timeout_factor (name, v))
+      )
 
 (* preset 한 명 파싱. 두 문법 분기:
    - 새 문법 [[fusion.presets.NAME.panels]] (array-of-tables) → 그룹별 파싱.

--- a/lib/fusion_core/fusion_config.mli
+++ b/lib/fusion_core/fusion_config.mli
@@ -37,8 +37,6 @@ type config_error =
       (** (preset 이름, 중복 judge 정체성) — 두 JOJ 1차 심판이 같은 정체성 (RFC-0283). *)
   | Invalid_meta_timeout of string * float
       (** (preset 이름, meta_timeout_s) — 양수 유한수가 아님. *)
-  | Invalid_adaptive_timeout_factor of string * float
-      (** (preset 이름, adaptive_timeout_factor) — 1.0 미만. *)
   | Toml_type_error of string  (** 필드 타입 불일치 (Otoml.Type_error) *)
 [@@deriving show, eq]
 

--- a/lib/fusion_core/fusion_config_json.ml
+++ b/lib/fusion_core/fusion_config_json.ml
@@ -11,10 +11,6 @@ let opt_int : int option -> Yojson.Safe.t = function
   | None -> `Null
   | Some n -> `Int n
 
-let opt_float : float option -> Yojson.Safe.t = function
-  | None -> `Null
-  | Some f -> `Float f
-
 let opt_string : string option -> Yojson.Safe.t = function
   | None -> `Null
   | Some s -> `String s
@@ -40,7 +36,6 @@ let judge_spec_to_yojson (j : Fusion_policy.judge_spec) : Yojson.Safe.t =
     ; ("web_tools", `Bool j.Fusion_policy.jweb_tools)
     ; ("max_output_tokens", opt_int j.Fusion_policy.jmax_output_tokens)
     ; ("timeout_s", `Float j.Fusion_policy.jtimeout_s)
-    ; ("max_timeout_s", opt_float j.Fusion_policy.jmax_timeout_s)
     ]
 
 let preset_to_yojson (p : Fusion_policy.preset) : Yojson.Safe.t =
@@ -53,8 +48,6 @@ let preset_to_yojson (p : Fusion_policy.preset) : Yojson.Safe.t =
     ; ("judge_max_output_tokens", opt_int p.Fusion_policy.judge_max_output_tokens)
     ; ("meta_timeout_s", `Float p.Fusion_policy.meta_timeout_s)
     ; ("judges", `List (List.map judge_spec_to_yojson p.Fusion_policy.judges))
-    ; ( "adaptive_timeout_factor"
-      , `Float p.Fusion_policy.adaptive_timeout_factor )
     ; ("fallback_judge_model", opt_string p.Fusion_policy.fallback_judge_model)
     ]
 

--- a/lib/fusion_core/fusion_policy.ml
+++ b/lib/fusion_core/fusion_policy.ml
@@ -28,8 +28,6 @@ type judge_spec =
   ; jweb_tools : bool  (** web_search/web_fetch 주입 여부 *)
   ; jmax_output_tokens : int option  (** 출력 토큰 예산 override *)
   ; jtimeout_s : float  (** 호출 구조적 타임아웃 (초) *)
-  ; jmax_timeout_s : float option
-      (** 적응형 타임아웃 확장 상한. None이면 예산 내에서 factor만큼 확장. *)
   }
 [@@deriving show, eq]
 
@@ -46,8 +44,6 @@ type preset =
   ; judges : judge_spec list
       (** JOJ 1차 심판들 (RFC-0283). 기본 []; simple/refine/conditional은 무시한다.
           JOJ 위상은 런타임에 >= 2 를 요구한다. *)
-  ; adaptive_timeout_factor : float
-      (** 1차 심판 타임아웃 적응형 확장 계수. 1.0=확장 안 함. *)
   ; fallback_judge_model : string option
       (** 전원 타임아웃/예산 실패 시 단일 fallback 심판 모델. *)
   }
@@ -214,32 +210,6 @@ let panel_outer_timeout_of (groups : panel_group list) =
 let judge_web_tools_of ~req_web_tools (groups : panel_group list) =
   req_web_tools || List.exists (fun (g : panel_group) -> g.web_tools) groups
 
-(* [adaptive_extension_threshold]는 adaptive 확장을 끄는
-   factor 값(config default 1.0; 검증이 >= 1.0을 강제). 1.0은 IEEE754에서 정확히
-   표현되지만, 의도를 명시하고 drift를 막기 named 상수로 둔다 — callers 도 float
-   equality 비교 대신 [adaptive_timeout_enabled]를 쓴다 (CLAUDE.md §Magic Number +
-   P2#6 float-equality-as-toggle 회피). *)
-let adaptive_extension_threshold = 1.0
-
-(* [adaptive_timeout_enabled preset] — preset의 factor가 확장 임계값을 넘는가. float
-   equality 대신 typed bool 토글로, callers(orchestrator)가 adaptive 재시도 분기를
-   판정한다. *)
-let adaptive_timeout_enabled (p : preset) =
-  p.adaptive_timeout_factor > adaptive_extension_threshold
-
-(* 적응형 타임아웃: 1차 심판/재시도 호출에 사용할 effective timeout을 계산한다.
-   - factor <= [adaptive_extension_threshold] (또는 아직 타임아웃 안 됨): base_s 반환.
-   - already_timed_out && factor > [adaptive_extension_threshold]: base_s *. factor를
-     max_s로만 상한해 확장된 타임아웃을 반환. *)
-let adjust_judge_timeout ~base_s ~max_s ~factor ~already_timed_out : float =
-  if factor <= adaptive_extension_threshold || not already_timed_out
-  then base_s
-  else
-    let extended = base_s *. factor in
-    match max_s with
-    | Some m -> Float.min extended m
-    | None -> extended
-
 (* RFC-0280: 검증된 preset을 타입으로 증명한다 (Parse, don't validate).
    [Validated_preset.t = private preset]이라 외부는 필드를 읽되([preset]/coercion)
    검증 없이 생성할 수 없다 → invalid preset이 게이트·orchestrator로 흐를 수 없다.
@@ -260,8 +230,6 @@ module Validated_preset = struct
     | Duplicate_judge of string  (** 두 JOJ 1차 심판이 같은 정체성(judge_id) (RFC-0283) *)
     | Bad_meta_timeout of float
         (** [meta_timeout_s]가 양수 유한수가 아님. *)
-    | Bad_adaptive_factor of float
-        (** [adaptive_timeout_factor]가 1.0 미만. *)
 
   (* 검증 순서는 config 로드 시점과 동일: non-empty models → 패널 prompt →
      judge model → 패널 정체성 중복 → 패널 max_output_tokens 범위 → (RFC-0283)
@@ -301,8 +269,6 @@ module Validated_preset = struct
                   if
                     not (p.meta_timeout_s > 0.0 && Float.is_finite p.meta_timeout_s)
                   then Error (Bad_meta_timeout p.meta_timeout_s)
-                  else if p.adaptive_timeout_factor < 1.0
-                  then Error (Bad_adaptive_factor p.adaptive_timeout_factor)
                   else Ok p)))
 
   let preset (t : t) : preset = t

--- a/lib/fusion_core/fusion_policy.mli
+++ b/lib/fusion_core/fusion_policy.mli
@@ -34,8 +34,6 @@ type judge_spec =
   ; jmax_output_tokens : int option
       (** 출력 토큰 예산 override. [None]이면 Runtime_agent 기본값. *)
   ; jtimeout_s : float  (** 호출 구조적 타임아웃 (초). *)
-  ; jmax_timeout_s : float option
-      (** 적응형 타임아웃 확장 상한. None이면 예산 내에서 factor만큼 확장. *)
   }
 [@@deriving show, eq]
 
@@ -58,8 +56,6 @@ type preset =
   ; judges : judge_spec list
       (** JOJ 1차 심판들 (RFC-0283). 기본 []; simple/refine/conditional은 무시한다.
           JOJ 위상은 런타임에 >= 2 를 요구한다. *)
-  ; adaptive_timeout_factor : float
-      (** 1차 심판 타임아웃 적응형 확장 계수. 1.0=확장 안 함. *)
   ; fallback_judge_model : string option
       (** 전원 타임아웃/예산 실패 시 단일 fallback 심판 모델. *)
   }
@@ -151,22 +147,6 @@ val panel_outer_timeout_of : panel_group list -> float
     단일 그룹이면 [req_web_tools || group.web_tools] (오늘과 byte-identical). *)
 val judge_web_tools_of : req_web_tools:bool -> panel_group list -> bool
 
-(** [adaptive_timeout_enabled preset] — preset의 [adaptive_timeout_factor]가 확장
-    임계값(1.0)을 넘는가. callers(orchestrator)가 float equality 비교 없이 typed bool로
-    adaptive 재시도 분기를 판정한다. *)
-val adaptive_timeout_enabled : preset -> bool
-
-(** 적응형 타임아웃: 1차 심판/재시도 호출에 사용할 effective timeout을 계산한다.
-    [factor <= adaptive_extension_threshold](= 1.0)이면 [base_s]를 반환하고,
-    [already_timed_out]이고 [factor > adaptive_extension_threshold]이면 [base_s *.
-    factor]를 [max_s]로만 상한해 확장한다. *)
-val adjust_judge_timeout
-  :  base_s:float
-  -> max_s:float option
-  -> factor:float
-  -> already_timed_out:bool
-  -> float
-
 (** RFC-0280: 검증을 통과한 preset (Parse, don't validate). [t = private preset]이라
     필드는 자유롭게 읽되([preset] 또는 coercion [(vp :> preset)]) 검증 없이 생성할 수
     없다 → invalid preset이 게이트·orchestrator로 흐를 수 없다. 검증 SSOT는
@@ -186,11 +166,9 @@ module Validated_preset : sig
     | Duplicate_judge of string  (** 두 JOJ 1차 심판이 같은 정체성 (RFC-0283) *)
     | Bad_meta_timeout of float
         (** [meta_timeout_s]가 양수 유한수가 아님. *)
-    | Bad_adaptive_factor of float
-        (** [adaptive_timeout_factor]가 1.0 미만. *)
 
   (** 검증 순서: non-empty models → prompt → judge → 정체성 중복 → max_output_tokens →
-      1차 심판 prompt/정체성/max_output_tokens → timeout 예산/계수.
+      1차 심판 prompt/정체성/max_output_tokens → meta timeout.
       통과 시 [Ok vp], 첫 위반에서 [Error invalid].
       config 로드의 검증 순서와 동일. *)
   val of_preset : preset -> (t, invalid) result

--- a/test/dune
+++ b/test/dune
@@ -786,8 +786,8 @@
 ; and sink meta JSON for failed judge nodes.
 
 (test
- (name test_fusion_adaptive_timeout)
- (modules test_fusion_adaptive_timeout)
+ (name test_fusion_judge_observation)
+ (modules test_fusion_judge_observation)
  (libraries masc_test_deps masc.fusion_core))
 
 ; RFC-0266 §7 Phase D — fusion run registry persistence: JSONL append + replay.

--- a/test/fusion_core/test_fusion.ml
+++ b/test/fusion_core/test_fusion.ml
@@ -46,7 +46,6 @@ let base_policy : Fusion_policy.t =
           ; judge_max_output_tokens = None
           ; meta_timeout_s = 300.0
           ; judges = []
-          ; adaptive_timeout_factor = 1.0
           ; fallback_judge_model = None
           }
       ]
@@ -711,7 +710,6 @@ let test_config_two_judges_not_staged_eligible () =
     ; jweb_tools = false
     ; jmax_output_tokens = None
     ; jtimeout_s = 300.0
-    ; jmax_timeout_s = None
     }
   in
   let judges =
@@ -815,7 +813,7 @@ let test_config_disabled_with_preset () =
 let mk_preset ?(panels = [ base_group ]) ?(judge = "j") ?(judge_prompt = "synthesize")
     ?(judges = [])
     ?(meta_timeout_s = 300.0)
-    ?(adaptive_timeout_factor = 1.0) ?(fallback_judge_model = None)
+    ?(fallback_judge_model = None)
     (name : string) : Fusion_policy.preset =
   { Fusion_policy.name
   ; panels
@@ -825,7 +823,6 @@ let mk_preset ?(panels = [ base_group ]) ?(judge = "j") ?(judge_prompt = "synthe
   ; judge_max_output_tokens = None
   ; meta_timeout_s
   ; judges
-  ; adaptive_timeout_factor
   ; fallback_judge_model
   }
 
@@ -878,7 +875,6 @@ let base_judge : Fusion_policy.judge_spec =
   ; jweb_tools = false
   ; jmax_output_tokens = None
   ; jtimeout_s = 300.0
-  ; jmax_timeout_s = None
   }
 
 (* judges=[]면 (simple/refine/conditional preset) 기존과 동일하게 유효 = byte-identity. *)
@@ -1341,76 +1337,7 @@ let test_panels_unavailable_failure () =
   Alcotest.(check bool) "not a timeout (no fallback judge trigger)" false
     (judge_failure_is_timeout failure)
 
-(* --- FUSION adaptive timeout / P0 hardening (RFC-0284-FUSION-P0) --- *)
-
-let adaptive_toml =
-  {|
-[fusion]
-enabled = true
-default_preset = "adaptive"
-[fusion.presets.adaptive]
-judge = "meta"
-judge_system_prompt = "reconcile"
-judge_timeout_s = 120.0
-meta_timeout_s = 90.0
-adaptive_timeout_factor = 2.0
-fallback_judge_model = "fallback-model"
-[[fusion.presets.adaptive.panels]]
-panel = ["p1"]
-panel_system_prompt = "answer"
-[[fusion.presets.adaptive.judges]]
-model = "judge-a"
-system_prompt = "lens A"
-timeout_s = 100.0
-max_timeout_s = 180.0
-[[fusion.presets.adaptive.judges]]
-model = "judge-b"
-system_prompt = "lens B"
-timeout_s = 110.0
-|}
-
-let test_config_adaptive_timeout_parse () =
-  match Fusion_config.of_toml (parse adaptive_toml) with
-  | Ok p ->
-    (match p.Fusion_policy.presets with
-     | [ vp ] ->
-       let preset = raw vp in
-       Alcotest.(check (float 0.001)) "meta_timeout_s" 90.0
-         preset.Fusion_policy.meta_timeout_s;
-       Alcotest.(check (float 0.001)) "adaptive_timeout_factor" 2.0
-         preset.Fusion_policy.adaptive_timeout_factor;
-       Alcotest.(check (option string)) "fallback_judge_model"
-         (Some "fallback-model")
-         preset.Fusion_policy.fallback_judge_model;
-       (match preset.Fusion_policy.judges with
-        | [ ja; _ ] ->
-          Alcotest.(check (float 0.001)) "ja timeout" 100.0 ja.Fusion_policy.jtimeout_s;
-          Alcotest.(check (option (float 0.001))) "ja max_timeout_s"
-            (Some 180.0)
-            ja.Fusion_policy.jmax_timeout_s
-        | _ -> Alcotest.fail "expected two judges")
-     | _ -> Alcotest.fail "expected exactly one preset")
-  | Error es ->
-    Alcotest.failf "expected Ok, got errors: %s"
-      (String.concat ", " (List.map Fusion_config.show_config_error es))
-
-let test_config_adaptive_timeout_defaults () =
-  match Fusion_config.of_toml (parse golden_single_group_toml) with
-  | Ok p ->
-    (match p.Fusion_policy.presets with
-     | [ vp ] ->
-       let preset = raw vp in
-       Alcotest.(check (float 0.001)) "meta_timeout_s defaults to judge_timeout_s"
-         preset.Fusion_policy.judge_timeout_s
-         preset.Fusion_policy.meta_timeout_s;
-       Alcotest.(check (float 0.001)) "adaptive_timeout_factor defaults to 1.0"
-         1.0
-         preset.Fusion_policy.adaptive_timeout_factor;
-       Alcotest.(check (option string)) "fallback_judge_model defaults to None"
-         None
-         preset.Fusion_policy.fallback_judge_model
-     | _ -> Alcotest.fail "expected one preset")
-  | Error _ -> Alcotest.fail "golden must parse Ok"
+(* --- Judge timeout observation and config validation. --- *)
 
 let test_config_invalid_meta_timeout () =
   let s =
@@ -1434,46 +1361,6 @@ meta_timeout_s = 0.0
          es)
   | Ok _ -> Alcotest.fail "expected Error Invalid_meta_timeout"
 
-let test_config_invalid_adaptive_factor () =
-  let s =
-    {|
-[fusion]
-enabled = true
-default_preset = "p"
-[fusion.presets.p]
-panel = ["a"]
-judge = "j"
-panel_system_prompt = "x"
-judge_system_prompt = "y"
-adaptive_timeout_factor = 0.5
-|}
-  in
-  match Fusion_config.of_toml (parse s) with
-  | Error es ->
-    Alcotest.(check bool) "Invalid_adaptive_timeout_factor present" true
-      (List.exists
-         (function Fusion_config.Invalid_adaptive_timeout_factor _ -> true | _ -> false)
-         es)
-  | Ok _ -> Alcotest.fail "expected Error Invalid_adaptive_timeout_factor"
-
-let test_adjust_judge_timeout_disabled () =
-  Alcotest.(check (float 0.001)) "factor=1.0 returns base"
-    10.0
-    (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:None ~factor:1.0
-       ~already_timed_out:false)
-
-let test_adjust_judge_timeout_extend () =
-  Alcotest.(check (float 0.001)) "extend capped by max_s"
-    15.0
-    (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:(Some 15.0)
-       ~factor:2.0 ~already_timed_out:true)
-
-let test_adjust_judge_timeout_not_yet_timed_out () =
-  Alcotest.(check (float 0.001)) "not timed out uses base_s"
-    10.0
-    (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:(Some 5.0)
-       ~factor:2.0 ~already_timed_out:false)
-
 let test_judge_error_node_timed_out () =
   let timeout_node =
     Fusion_types.Judge_failed
@@ -1496,14 +1383,6 @@ let test_validated_bad_meta_timeout () =
   with
   | Error (Fusion_policy.Validated_preset.Bad_meta_timeout 0.0) -> ()
   | _ -> Alcotest.fail "expected Bad_meta_timeout 0.0"
-
-let test_validated_bad_adaptive_factor () =
-  match
-    Fusion_policy.Validated_preset.of_preset
-      (mk_preset ~adaptive_timeout_factor:0.5 "bad-factor")
-  with
-  | Error (Fusion_policy.Validated_preset.Bad_adaptive_factor 0.5) -> ()
-  | _ -> Alcotest.fail "expected Bad_adaptive_factor 0.5"
 
 let () =
   Alcotest.run "fusion_core"
@@ -1553,13 +1432,7 @@ let () =
         ; Alcotest.test_case "disabled_with_preset" `Quick test_config_disabled_with_preset
         ; Alcotest.test_case "judges_parse" `Quick test_config_judges_parse
         ; Alcotest.test_case "no_judges" `Quick test_config_no_judges
-        ; Alcotest.test_case "adaptive_timeout_parse" `Quick
-            test_config_adaptive_timeout_parse
-        ; Alcotest.test_case "adaptive_timeout_defaults" `Quick
-            test_config_adaptive_timeout_defaults
         ; Alcotest.test_case "invalid_meta_timeout" `Quick test_config_invalid_meta_timeout
-        ; Alcotest.test_case "invalid_adaptive_factor" `Quick
-            test_config_invalid_adaptive_factor
         ] )
     ; ( "validated_preset"
       , [ Alcotest.test_case "ok" `Quick test_validated_ok
@@ -1577,8 +1450,6 @@ let () =
         ; Alcotest.test_case "judge_bad_max_output_tokens" `Quick
             test_validated_judge_bad_max_output_tokens
         ; Alcotest.test_case "bad_meta_timeout" `Quick test_validated_bad_meta_timeout
-        ; Alcotest.test_case "bad_adaptive_factor" `Quick
-            test_validated_bad_adaptive_factor
         ] )
     ; ( "staged_judge_groups"
       , [ Alcotest.test_case "exact_3x3" `Quick test_staged_judge_groups_exact_3x3
@@ -1592,12 +1463,6 @@ let () =
         ; Alcotest.test_case "multi_group" `Quick test_judge_args_multi_group
         ; Alcotest.test_case "outer_timeout_member_count_independent" `Quick
             test_panel_outer_timeout_member_count_independent
-        ] )
-    ; ( "adaptive_timeout"
-      , [ Alcotest.test_case "disabled" `Quick test_adjust_judge_timeout_disabled
-        ; Alcotest.test_case "extend" `Quick test_adjust_judge_timeout_extend
-        ; Alcotest.test_case "not_yet_timed_out" `Quick
-            test_adjust_judge_timeout_not_yet_timed_out
         ] )
     ; ( "judge_parse"
       , [ Alcotest.test_case "valid" `Quick test_judge_valid

--- a/test/test_fusion_judge_observation.ml
+++ b/test/test_fusion_judge_observation.ml
@@ -1,6 +1,4 @@
-(* FUSION adaptive timeout / P0 hardening tests.
-   Covers: config parse/validation, pure adjust_judge_timeout semantics,
-   OTel counter emission, and sink meta JSON for failed judge nodes. *)
+(* Fusion judge fallback, timeout observation, and sink projection tests. *)
 
 open Alcotest
 open Masc
@@ -26,7 +24,6 @@ let sample_judge model : Fusion_policy.judge_spec =
   ; jweb_tools = false
   ; jmax_output_tokens = None
   ; jtimeout_s = 1.0
-  ; jmax_timeout_s = None
   }
 
 let failed_judge_run model failure :
@@ -37,54 +34,6 @@ let ok_judge_run model : Fusion_orchestrator_judge_wave.judge_run =
   sample_judge model, model, Ok (sample_synthesis, sample_usage), 0.0, false
 
 let parse s = Otoml.Parser.from_string s
-
-let adaptive_toml =
-  {|
-[fusion]
-enabled = true
-default_preset = "adaptive"
-[fusion.presets.adaptive]
-judge = "meta"
-judge_system_prompt = "reconcile"
-judge_timeout_s = 120.0
-meta_timeout_s = 90.0
-adaptive_timeout_factor = 2.0
-fallback_judge_model = "fallback-model"
-[[fusion.presets.adaptive.panels]]
-panel = ["p1"]
-panel_system_prompt = "answer"
-[[fusion.presets.adaptive.judges]]
-model = "judge-a"
-system_prompt = "lens A"
-timeout_s = 100.0
-max_timeout_s = 180.0
-[[fusion.presets.adaptive.judges]]
-model = "judge-b"
-system_prompt = "lens B"
-timeout_s = 110.0
-|}
-
-let test_config_adaptive_timeout_parse () =
-  match Fusion_config.of_toml (parse adaptive_toml) with
-  | Ok p ->
-    (match p.Fusion_policy.presets with
-     | [ vp ] ->
-       let preset = Fusion_policy.Validated_preset.preset vp in
-       check (float 0.001) "meta_timeout_s" 90.0 preset.Fusion_policy.meta_timeout_s;
-       check (float 0.001) "adaptive_timeout_factor" 2.0
-         preset.Fusion_policy.adaptive_timeout_factor;
-       check (option string) "fallback_judge_model" (Some "fallback-model")
-         preset.Fusion_policy.fallback_judge_model;
-       (match preset.Fusion_policy.judges with
-        | [ ja; _ ] ->
-          check (float 0.001) "ja timeout" 100.0 ja.Fusion_policy.jtimeout_s;
-          check (option (float 0.001)) "ja max_timeout_s" (Some 180.0)
-            ja.Fusion_policy.jmax_timeout_s
-        | _ -> fail "expected two judges")
-     | _ -> fail "expected exactly one preset")
-  | Error es ->
-    failf "expected Ok, got errors: %s"
-      (String.concat ", " (List.map Fusion_config.show_config_error es))
 
 let test_config_invalid_meta_timeout () =
   let s =
@@ -107,39 +56,6 @@ meta_timeout_s = 0.0
          (function Fusion_config.Invalid_meta_timeout _ -> true | _ -> false)
          es)
   | Ok _ -> fail "expected Error Invalid_meta_timeout"
-
-let test_config_invalid_adaptive_factor () =
-  let s =
-    {|
-[fusion]
-enabled = true
-default_preset = "p"
-[fusion.presets.p]
-panel = ["a"]
-judge = "j"
-panel_system_prompt = "x"
-judge_system_prompt = "y"
-adaptive_timeout_factor = 0.5
-|}
-  in
-  match Fusion_config.of_toml (parse s) with
-  | Error es ->
-    check bool "Invalid_adaptive_timeout_factor present" true
-      (List.exists
-         (function Fusion_config.Invalid_adaptive_timeout_factor _ -> true
-                 | _ -> false)
-         es)
-  | Ok _ -> fail "expected Error Invalid_adaptive_timeout_factor"
-
-let test_adjust_judge_timeout_disabled () =
-  check (float 0.001) "factor=1.0 returns base" 10.0
-    (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:None ~factor:1.0
-       ~already_timed_out:false)
-
-let test_adjust_judge_timeout_extend () =
-  check (float 0.001) "extend capped by max_s" 15.0
-    (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:(Some 15.0)
-       ~factor:2.0 ~already_timed_out:true)
 
 let test_timeout_first_wave_appends_fallback () =
   let fallback_calls = ref 0 in
@@ -179,20 +95,6 @@ let test_timeout_first_wave_skips_fallback_on_provider_error () =
   check int "fallback not called" 0 !fallback_calls;
   check int "original runs kept" 2 (List.length without_fallback)
 
-let test_record_adaptive_timeout_emits () =
-  let before =
-    Otel_metric_store.metric_value_or_zero
-      Fusion_metrics.metric_fusion_adaptive_timeout_extensions_total
-      ()
-  in
-  Fusion_metrics.record_adaptive_timeout ();
-  let after =
-    Otel_metric_store.metric_value_or_zero
-      Fusion_metrics.metric_fusion_adaptive_timeout_extensions_total
-      ()
-  in
-  check (float 0.0) "adaptive timeout counter incremented" (before +. 1.0) after
-
 let test_sink_failed_node_includes_timeout_fields () =
   let node =
     Fusion_types.Judge_failed
@@ -220,26 +122,14 @@ let test_sink_failed_node_includes_timeout_fields () =
   | _ -> fail "expected Assoc"
 
 let () =
-  run "fusion_adaptive_timeout"
+  run "fusion_judge_observation"
     [ ( "config"
-      , [ test_case "adaptive_timeout_parse" `Quick test_config_adaptive_timeout_parse
-        ; test_case "invalid_meta_timeout" `Quick test_config_invalid_meta_timeout
-        ; test_case "invalid_adaptive_factor" `Quick
-            test_config_invalid_adaptive_factor
-        ] )
-    ; ( "adjust_judge_timeout"
-      , [ test_case "disabled" `Quick test_adjust_judge_timeout_disabled
-        ; test_case "extend" `Quick test_adjust_judge_timeout_extend
-        ] )
+      , [ test_case "invalid_meta_timeout" `Quick test_config_invalid_meta_timeout ] )
     ; ( "fallback"
       , [ test_case "timeout wave appends fallback" `Quick
             test_timeout_first_wave_appends_fallback
         ; test_case "provider failure skips fallback" `Quick
             test_timeout_first_wave_skips_fallback_on_provider_error
-        ] )
-    ; ( "metrics"
-      , [ test_case "record_adaptive_timeout emits counter" `Quick
-            test_record_adaptive_timeout_emits
         ] )
     ; ( "sink"
       , [ test_case "failed_node_includes_timeout_fields" `Quick

--- a/test/test_fusion_oas_error_detail.ml
+++ b/test/test_fusion_oas_error_detail.ml
@@ -224,7 +224,11 @@ let test_timeout_budget_sets_transport_timeouts () =
   Alcotest.(check (option (float 0.001)))
     "body timeout"
     (Some 300.0)
-    config.body_timeout_s
+    config.body_timeout_s;
+  Alcotest.(check (option int))
+    "fusion does not synthesize an output token budget"
+    None
+    config.max_tokens
 ;;
 
 let () =

--- a/test/test_fusion_wake.ml
+++ b/test/test_fusion_wake.ml
@@ -198,7 +198,6 @@ let fusion_tool_policy () : Fusion_policy.t =
     ; judge_max_output_tokens = None
     ; meta_timeout_s = Fusion_policy.default_timeout_s
     ; judges = []
-    ; adaptive_timeout_factor = 1.0
     ; fallback_judge_model = None
     }
   in


### PR DESCRIPTION
## What

- delete `adaptive_timeout_factor` and per-judge `max_timeout_s` from the typed Fusion policy and TOML projection
- delete the unused adaptive timeout calculator and validation variants
- delete the dead adaptive-extension metric
- rename the remaining timeout/fallback observation test so retired policy terminology is absent
- purge tests whose only purpose was preserving adaptive deadline behavior

## Why

After #24634 and #24638, no runtime path consumes adaptive timeout settings. Keeping the fields would be an inert governance surface that could later be mistaken for execution authority. Provider/runtime owns transport liveness; Fusion records node timeout failures and continues its asynchronous graph.

## Proof

- changed lines: 356
- repository search: zero Fusion code/test/config/doc refs to `adaptive_timeout`, `jmax_timeout`, `Bad_adaptive`, or `Invalid_adaptive`
- OCaml parser/ocamlformat check: pass
- git diff --check: pass
- focused Dune wrapper intentionally refused because bare Dune PID 66224 owns the workspace; full build remains CI authority

## Stack

- base: #24634, including merged #24638