### PR TITLE
fix(keeper): route recovery through typed lane state

### DIFF
--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -225,7 +225,7 @@ let busy_ack_reply_text_queued
         receipt_id in_flight_text
   | Some operation_id, recovery_required_count ->
       Printf.sprintf
-        "%s is stopping under shutdown operation %s; your message is durably queued, but this Keeper lane also has %d receipt(s) awaiting explicit delivery recovery and cannot dispatch automatically (receipt_id=%s).%s"
+        "%s is stopping under shutdown operation %s; your message is durably queued behind the lifecycle fence. This Keeper lane also retains %d unconfirmed receipt(s) as exact recovery evidence; after the next active lane begins, your new receipt may cross that recorded boundary and no older receipt is guessed or replayed (receipt_id=%s).%s"
         keeper_name
         (Keeper_shutdown_types.Operation_id.to_string operation_id)
         recovery_required_count receipt_id in_flight_text
@@ -236,7 +236,7 @@ let busy_ack_reply_text_queued
         keeper_name receipt_id in_flight_text
   | None, recovery_required_count ->
       Printf.sprintf
-        "%s accepted your message durably, but this Keeper lane has %d receipt(s) awaiting explicit delivery recovery and cannot dispatch automatically (receipt_id=%s).%s"
+        "%s accepted your message durably. This Keeper lane retains %d unconfirmed receipt(s) as exact recovery evidence; your new receipt may cross that recorded boundary and no older receipt is guessed or replayed (receipt_id=%s).%s"
         keeper_name recovery_required_count receipt_id in_flight_text
 
 let chat_queue_message_request ~channel ~channel_user_id ~keeper_name

--- a/lib/keeper/keeper_chat_consumer.ml
+++ b/lib/keeper/keeper_chat_consumer.ml
@@ -137,10 +137,6 @@ type dispatch_state = {
   rerun_by_keeper : (string, unit) Hashtbl.t;
 }
 
-type lane_activity =
-  | Dispatchable of bool
-  | Awaiting_delivery_recovery of Keeper_chat_queue.recovery_evidence
-
 let create_dispatch_state ~base_path =
   { base_path = Keeper_registry_types.canonical_base_path_exn base_path
   ; mutex = Eio.Mutex.create ()
@@ -525,23 +521,12 @@ let run ~sw ~clock ~base_path ~handle_turn =
   let ready_lane_activity keeper_name =
     match Keeper_chat_queue.lane_status ~keeper_name with
     | Error _ as error -> error
-    | Ok { health = Keeper_chat_queue.Ready; has_active; _ } ->
-      Ok (Dispatchable has_active)
-    | Ok
-        { health =
-            Keeper_chat_queue.Delivery_recovery_required
-              { receipt_id; lease_id; started_at }
-        ; _
-        } ->
-      Ok
-        (Awaiting_delivery_recovery
-           ({ receipt_id; lease_id; started_at } :
-             Keeper_chat_queue.recovery_evidence))
-    | Ok { health = Keeper_chat_queue.Unavailable error; _ } ->
+    | Ok { state = Keeper_chat_queue.Available activity; _ } -> Ok activity
+    | Ok { state = Keeper_chat_queue.Unavailable error; _ } ->
       unavailable error
     | Ok
         { revision = uncertain_revision
-        ; health = Keeper_chat_queue.Persistence_reconciliation_required
+        ; state = Keeper_chat_queue.Persistence_reconciliation_required
         ; _
         } ->
       (match Keeper_chat_queue.reconcile_persistence ~keeper_name with
@@ -554,23 +539,13 @@ let run ~sw ~clock ~base_path ~handle_turn =
            report.revision;
          (match Keeper_chat_queue.lane_status ~keeper_name with
           | Error _ as error -> error
-          | Ok { health = Keeper_chat_queue.Ready; has_active; _ } ->
-            Ok (Dispatchable has_active)
-          | Ok
-              { health =
-                  Keeper_chat_queue.Delivery_recovery_required
-                    { receipt_id; lease_id; started_at }
-              ; _
-              } ->
-            Ok
-              (Awaiting_delivery_recovery
-                 ({ receipt_id; lease_id; started_at } :
-                   Keeper_chat_queue.recovery_evidence))
-          | Ok { health = Keeper_chat_queue.Unavailable error; _ } ->
+          | Ok { state = Keeper_chat_queue.Available activity; _ } ->
+            Ok activity
+          | Ok { state = Keeper_chat_queue.Unavailable error; _ } ->
             unavailable error
           | Ok
               { revision
-              ; health = Keeper_chat_queue.Persistence_reconciliation_required
+              ; state = Keeper_chat_queue.Persistence_reconciliation_required
               ; _
               } ->
             unavailable
@@ -644,20 +619,32 @@ let run ~sw ~clock ~base_path ~handle_turn =
         release keeper_name
       | Ok _ when retry_pending_finalization dispatch_state ~keeper_name ->
         release keeper_name
-      | Ok (Awaiting_delivery_recovery evidence) ->
+      | Ok (Keeper_chat_queue.Awaiting_recovery boundary) ->
         clear_blocked_lease dispatch_state ~keeper_name;
         Log.Keeper.warn
-          "keeper_chat_consumer: lane awaits explicit delivery recovery keeper=%s receipt_id=%s lease_id=%s started_at=%.06f"
+          "keeper_chat_consumer: lane retains unresolved delivery evidence keeper=%s recovery_count=%d earliest_receipt_id=%s earliest_lease_id=%s started_at=%.06f; execution lease remains available"
           keeper_name
-          (Keeper_chat_queue.Receipt_id.to_string evidence.receipt_id)
-          evidence.lease_id
-          evidence.started_at;
+          boundary.unresolved_count
+          (Keeper_chat_queue.Receipt_id.to_string boundary.earliest.receipt_id)
+          boundary.earliest.lease_id
+          boundary.earliest.started_at;
         release keeper_name
-      | Ok (Dispatchable false) ->
+      | Ok Keeper_chat_queue.Idle
+      | Ok (Keeper_chat_queue.Lease_inflight _) ->
         clear_blocked_lease dispatch_state ~keeper_name;
         release keeper_name
-      | Ok (Dispatchable true) ->
+      | Ok (Keeper_chat_queue.Dispatchable recovery_boundary) ->
         clear_blocked_lease dispatch_state ~keeper_name;
+        Option.iter
+          (fun boundary ->
+             Log.Keeper.info
+               "keeper_chat_consumer: pending receipt crosses unresolved recovery boundary keeper=%s recovery_count=%d earliest_receipt_id=%s earliest_lease_id=%s"
+               keeper_name
+               boundary.Keeper_chat_queue.unresolved_count
+               (Keeper_chat_queue.Receipt_id.to_string
+                  boundary.earliest.receipt_id)
+               boundary.earliest.lease_id)
+          recovery_boundary;
         let admission =
           Keeper_turn_admission.snapshot_for ~base_path ~keeper_name
         in

--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -2755,68 +2755,83 @@ let inflight_count ~keeper_name =
         | Some error -> Error (Snapshot_unavailable error)
         | None -> Ok (if Option.is_some entry.inflight then 1 else 0))
 
-let has_active_receipts ~keeper_name =
-  match mutation_context ~keeper_name ~create:false with
-  | Error _ as error -> error
-  | Ok (_, _, None) -> Ok false
-  | Ok (_, _, Some entry) ->
-    with_entry_lock keeper_name entry (fun () ->
-        match first_blocking_error entry with
-        | Some error -> Error (Snapshot_unavailable error)
-        | None ->
-          Ok
-            (entry.pending_count > 0
-             || Option.is_some entry.inflight
-             || not (Sequence_map.is_empty entry.recovery_required)))
+type recovery_boundary =
+  { earliest : recovery_evidence
+  ; unresolved_count : int
+  }
 
-type lane_health =
-  | Ready
-  | Persistence_reconciliation_required
-  | Delivery_recovery_required of
-      { receipt_id : Receipt_id.t
-      ; lease_id : string
-      ; started_at : float
+type dispatch_state =
+  | Idle
+  | Dispatchable of recovery_boundary option
+  | Lease_inflight of
+      { lease_id : string
+      ; crossed_recovery_boundary : recovery_boundary option
       }
+  | Awaiting_recovery of recovery_boundary
+
+type lane_state =
+  | Available of dispatch_state
+  | Persistence_reconciliation_required
   | Unavailable of snapshot_load_error
 
 type lane_status = {
   revision : int64;
-  has_active : bool;
-  health : lane_health;
+  state : lane_state;
 }
+
+let recovery_boundary entry =
+  match Sequence_map.min_binding_opt entry.recovery_required with
+  | None -> Ok None
+  | Some (_, row) ->
+    recovery_evidence_of_row row
+    |> Result.map (fun earliest ->
+      Some
+        { earliest
+        ; unresolved_count = Sequence_map.cardinal entry.recovery_required
+        })
 
 let lane_status ~keeper_name =
   match mutation_context ~keeper_name ~create:false with
   | Error _ as error -> error
-  | Ok (_, _, None) ->
-    Ok { revision = 0L; has_active = false; health = Ready }
+  | Ok (_, _, None) -> Ok { revision = 0L; state = Available Idle }
   | Ok (_, _, Some entry) ->
     with_entry_lock keeper_name entry (fun () ->
-        let health =
+        let state =
           match entry.reconciliation_plan, entry.load_errors with
           | Some _, _ -> Persistence_reconciliation_required
           | None, error :: _ -> Unavailable error
           | None, [] ->
-            if entry.pending_count > 0 || Option.is_some entry.inflight
-            then Ready
+            if entry.pending_count <> Sequence_map.cardinal entry.pending
+            then
+              Unavailable
+                (load_error Parse_failed
+                   "pending receipt count disagrees with the FIFO projection")
             else
-              (match Sequence_map.min_binding_opt entry.recovery_required with
-               | None -> Ready
-               | Some (_, row) ->
-                 (match recovery_evidence_of_row row with
-                  | Ok { receipt_id; lease_id; started_at } ->
-                    Delivery_recovery_required { receipt_id; lease_id; started_at }
-                  | Error detail ->
-                    Unavailable (load_error Parse_failed detail)))
+              (match recovery_boundary entry with
+               | Error detail -> Unavailable (load_error Parse_failed detail)
+               | Ok boundary ->
+                 (match entry.inflight with
+                  | Some
+                      { receipt = { state = Stored_inflight { lease_id; _ }; _ }
+                      ; _
+                      } ->
+                    Available
+                      (Lease_inflight
+                         { lease_id
+                         ; crossed_recovery_boundary = boundary
+                         })
+                  | Some _ ->
+                    Unavailable
+                      (load_error Parse_failed
+                         "inflight index contains a non-inflight receipt")
+                  | None when entry.pending_count > 0 ->
+                    Available (Dispatchable boundary)
+                  | None ->
+                    (match boundary with
+                     | None -> Available Idle
+                     | Some boundary -> Available (Awaiting_recovery boundary))))
         in
-        Ok
-          { revision = entry.revision
-          ; has_active =
-              entry.pending_count > 0
-              || Option.is_some entry.inflight
-              || not (Sequence_map.is_empty entry.recovery_required)
-          ; health
-          })
+        Ok { revision = entry.revision; state })
 
 let active_receipt_of_row row =
   match row.receipt.state with

--- a/lib/keeper/keeper_chat_queue.mli
+++ b/lib/keeper/keeper_chat_queue.mli
@@ -286,26 +286,37 @@ val nack :
 
 val pending_count : keeper_name:string -> (int, mutation_error) result
 val inflight_count : keeper_name:string -> (int, mutation_error) result
-val has_active_receipts : keeper_name:string -> (bool, mutation_error) result
 
-type lane_health =
-  | Ready
-  | Persistence_reconciliation_required
-  | Delivery_recovery_required of
-      { receipt_id : Receipt_id.t
-      ; lease_id : string
-      ; started_at : float
+type recovery_boundary =
+  { earliest : recovery_evidence
+  ; unresolved_count : int
+  }
+
+type dispatch_state =
+  | Idle
+  | Dispatchable of recovery_boundary option
+  | Lease_inflight of
+      { lease_id : string
+      ; crossed_recovery_boundary : recovery_boundary option
       }
+  | Awaiting_recovery of recovery_boundary
+
+type lane_state =
+  | Available of dispatch_state
+  | Persistence_reconciliation_required
   | Unavailable of snapshot_load_error
 
 type lane_status = {
   revision : int64;
-  has_active : bool;
-  health : lane_health;
+  state : lane_state;
 }
 
-(** O(1), memory-only hot-path projection. Consumers should use this instead
-    of materializing [snapshot] before [lease_next]. *)
+(** Memory-only hot-path SSOT. [Dispatchable] and [Lease_inflight] are the
+    only states that require autonomous execution to yield to chat work.
+    [Awaiting_recovery] retains the earliest exact crash boundary and its
+    cardinality without turning evidence into an execution lease. Consumers
+    should use this closed sum instead of materializing [snapshot] or inferring
+    dispatchability from receipt counts. *)
 val lane_status : keeper_name:string -> (lane_status, mutation_error) result
 
 val snapshot : keeper_name:string -> diagnostic_snapshot

--- a/lib/keeper/keeper_turn_admission.ml
+++ b/lib/keeper/keeper_turn_admission.ml
@@ -215,19 +215,53 @@ let shutdown_rejection_snapshot slot operation_id =
     })
 ;;
 
+let autonomous_yields_to_chat
+    (status : (Keeper_chat_queue.lane_status, Keeper_chat_queue.mutation_error) result) =
+  match status with
+  | Ok
+      { Keeper_chat_queue.state =
+          Available (Dispatchable _ | Lease_inflight _)
+      ; _
+      } ->
+    true
+  | Ok
+      { state =
+          Available (Idle | Awaiting_recovery _)
+          | Persistence_reconciliation_required
+          | Unavailable _
+      ; _
+      }
+  | Error _ ->
+    false
+;;
+
+let direct_chat_requires_queue
+    (status : (Keeper_chat_queue.lane_status, Keeper_chat_queue.mutation_error) result) =
+  match status with
+  | Ok { Keeper_chat_queue.state = Available Idle; _ } -> false
+  | Ok
+      { state =
+          Available (Dispatchable _ | Lease_inflight _ | Awaiting_recovery _)
+          | Persistence_reconciliation_required
+          | Unavailable _
+      ; _
+      }
+  | Error _ ->
+    true
+;;
+
 let run_if_free ~base_path ~keeper_name f =
   let slot = slot_for ~base_path ~keeper_name in
   (* Yield to deferred work before touching the lock. [waiting > 0] implies
      the slot is held (a waiter only parks because a turn is in flight), so
      [try_lock] would fail here anyway; the explicit check keeps the
      autonomous lane from competing for a slot a parked chat is already
-     queued on. A non-empty [Keeper_chat_queue] means a busy connector
-     (Slack/Discord) or dashboard message is deferred for this keeper but
-     has not parked on the slot; the autonomous lane must yield for it too,
-     otherwise a long or back-to-back autonomous turn starves that queue
-     indefinitely (the busy-ACK loop). Reading the queue length is a
-     lock-only, non-suspending peek and is the SSOT signal that closes the
-     gap: the autonomous lane cooperates on the same backlog the consumer
+     queued on. Typed lane status marks pending work as [Dispatchable] and an
+     owned receipt as [Lease_inflight]; only these states yield, because a
+     long or back-to-back autonomous turn could otherwise starve queued work
+     (the busy-ACK loop). [Awaiting_recovery] is evidence, not work. Reading
+     this closed sum is the SSOT signal that closes the gap: the autonomous
+     lane cooperates on the same dispatchable backlog the consumer
      drains, so the consumer's [in_flight = None] window opens
      deterministically instead of racing the next autonomous cycle. A leased
      receipt remains active until its terminal decision commits, so the
@@ -237,11 +271,12 @@ let run_if_free ~base_path ~keeper_name f =
   | Some operation_id -> `Busy (Shutdown_requested operation_id)
   | None when waiting_count slot > 0 -> `Busy (Turn_busy (peek_info slot))
   | None ->
-    let snapshot = Keeper_chat_queue.snapshot ~keeper_name in
+    let queue_state = Keeper_chat_queue.lane_status ~keeper_name in
     (* Queue persistence/read failures remain typed Chat-boundary failures.
        They are not evidence of queued work and therefore cannot close an
-       otherwise independent autonomous lane. *)
-    if snapshot.pending <> [] || snapshot.inflight <> []
+       otherwise independent autonomous lane. Recovery evidence is likewise
+       not executable chat work and cannot occupy autonomous admission. *)
+    if autonomous_yields_to_chat queue_state
     then `Busy (Turn_busy (peek_info slot))
     else if Eio.Mutex.try_lock slot.turn_mu
     then
@@ -296,8 +331,8 @@ let run_chat_if_free ~base_path ~keeper_name f =
     `Busy (shutdown_rejection_snapshot slot operation_id)
   | None when waiting_count slot > 0 -> `Busy (rejection_snapshot slot)
   | None when Eio.Mutex.try_lock slot.turn_mu ->
-    let active_receipts =
-      try Keeper_chat_queue.has_active_receipts ~keeper_name with
+    let queue_state =
+      try Keeper_chat_queue.lane_status ~keeper_name with
       | exn ->
         Eio.Mutex.unlock slot.turn_mu;
         raise exn
@@ -310,8 +345,7 @@ let run_chat_if_free ~base_path ~keeper_name f =
        waiter recheck closes the equivalent increment-before-lock window for
        [run_serialized]. Queue read errors fail closed and are surfaced by the
        caller's durable-enqueue path. *)
-    if waiting_count slot > 0
-       || match active_receipts with Ok active -> active | Error _ -> true
+    if waiting_count slot > 0 || direct_chat_requires_queue queue_state
     then (
       let rejection = rejection_snapshot slot in
       Eio.Mutex.unlock slot.turn_mu;

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -30,13 +30,24 @@ let autonomous_yield_request ~base_path ~keeper_name =
     if Keeper_turn_admission.chat_waiting ~base_path ~keeper_name
     then Ok (Some Keeper_agent_run.{ reason = Chat_waiting })
     else
-      (match Keeper_chat_queue.has_active_receipts ~keeper_name with
+      (match Keeper_chat_queue.lane_status ~keeper_name with
        | Error error ->
          Error
            ("chat queue snapshot failed: "
             ^ Keeper_chat_queue.mutation_error_to_string error)
-       | Ok true -> Ok (Some Keeper_agent_run.{ reason = Chat_waiting })
-       | Ok false ->
+       | Ok
+           { state =
+               Available (Dispatchable _ | Lease_inflight _)
+           ; _
+           } ->
+         Ok (Some Keeper_agent_run.{ reason = Chat_waiting })
+       | Ok
+           { state =
+               (Persistence_reconciliation_required | Unavailable _)
+           ; _
+           } ->
+         Error "chat queue lane is unavailable for dispatch classification"
+       | Ok { state = Available (Idle | Awaiting_recovery _); _ } ->
          let pending =
            Keeper_registry_event_queue.snapshot ~base_path keeper_name
          in

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -187,12 +187,16 @@ let dashboard_busy_queue_state ~base_path ~keeper_name =
     else
       match Keeper_chat_queue.lane_status ~keeper_name with
       | Error _ -> true
-      | Ok { has_active; health = Keeper_chat_queue.Ready; _ } -> has_active
+      | Ok { state = Keeper_chat_queue.Available Keeper_chat_queue.Idle; _ } ->
+        false
       | Ok
-          { health =
-              ( Keeper_chat_queue.Persistence_reconciliation_required
-              | Keeper_chat_queue.Delivery_recovery_required _
-              | Keeper_chat_queue.Unavailable _ )
+          { state =
+              Keeper_chat_queue.Available
+                ( Keeper_chat_queue.Dispatchable _
+                | Keeper_chat_queue.Lease_inflight _
+                | Keeper_chat_queue.Awaiting_recovery _ )
+              | Keeper_chat_queue.Persistence_reconciliation_required
+              | Keeper_chat_queue.Unavailable _
           ; _
           } ->
         true
@@ -209,8 +213,10 @@ let dashboard_deferred_ack_text ~keeper_name deferred =
     Printf.sprintf
       "%s accepted your message durably (receipt_id=%s, pending_count=%d, \
        inflight_count=%d, recovery_required_count=%d). This Keeper lane has an \
-       earlier delivery whose external effect is unconfirmed; it will remain \
-       non-dispatchable until an operator resolves that exact receipt."
+       earlier delivery whose external effect is unconfirmed. That exact \
+       receipt remains isolated as recovery evidence and is never guessed or \
+       replayed; this new receipt may proceed across the recorded ordering \
+       boundary."
       keeper_name
       deferred.receipt_id
       deferred.pending_count

--- a/test/test_keeper_chat_coalescing.ml
+++ b/test/test_keeper_chat_coalescing.ml
@@ -548,17 +548,19 @@ let test_restart_requires_explicit_recovery_without_journal () =
      = [ receipt_wire receipt.receipt_id ]);
   (match Keeper_chat_queue.lane_status ~keeper_name with
    | Ok
-       { health =
-           Delivery_recovery_required
-             { receipt_id; lease_id; started_at = _ }
-       ; has_active = true
+       { state =
+           Available
+             (Awaiting_recovery
+                { earliest = { receipt_id; lease_id; started_at = _ }
+                ; unresolved_count = 1
+                })
        ; _
        } ->
-     check "O(1) lane health exposes exact recovery evidence"
+     check "typed lane state exposes exact recovery evidence"
        (Keeper_chat_queue.Receipt_id.equal receipt_id receipt.receipt_id
         && String.equal lease_id lease.lease_id)
    | Ok _ | Error _ ->
-     check "O(1) lane health exposes exact recovery evidence" false);
+     check "typed lane state exposes exact recovery evidence" false);
   (match snapshot.recovery_required with
    | [ { state = Recovery_required evidence; _ } ] ->
      check "restart preserves exact lease evidence"
@@ -652,10 +654,20 @@ let test_recovery_evidence_does_not_occupy_execution_lease () =
      && first_recovery.recovery_required_receipt_count = 1);
   let second = enqueue_exn ~keeper_name (message "second") in
   (match Keeper_chat_queue.lane_status ~keeper_name with
-   | Ok { health = Ready; has_active = true; _ } ->
-     check "pending work remains ready across a recovery boundary" true
+   | Ok
+       { state =
+           Available
+             (Dispatchable
+                (Some
+                   { earliest = { receipt_id; _ }
+                   ; unresolved_count = 1
+                   }))
+       ; _
+       } ->
+     check "pending work exposes the crossed recovery boundary"
+       (Keeper_chat_queue.Receipt_id.equal receipt_id first.receipt_id)
    | Ok _ | Error _ ->
-     check "pending work remains ready across a recovery boundary" false);
+     check "pending work exposes the crossed recovery boundary" false);
   let second_lease = lease_exn ~keeper_name in
   check "later pending receipt crosses the exact recovery boundary"
     (Keeper_chat_queue.Receipt_id.equal

--- a/test/test_keeper_turn_admission.ml
+++ b/test/test_keeper_turn_admission.ml
@@ -201,7 +201,9 @@ let test_chat_if_free_rechecks_durable_queue_after_stale_peek () =
     "Test 1c: run_chat_if_free rechecks durable receipts after a stale outer peek\n%!";
   check
     "outer precheck initially observes no active receipt"
-    (Keeper_chat_queue.has_active_receipts ~keeper_name = Ok false);
+    (match Keeper_chat_queue.lane_status ~keeper_name with
+     | Ok { state = Available Idle; _ } -> true
+     | Ok _ | Error _ -> false);
   let message : Keeper_chat_queue.queued_message =
     { content = "queued first"
     ; user_blocks = []
@@ -615,6 +617,63 @@ let test_autonomous_yields_to_queued_connector_message () =
   | `Ran _ | `Busy _ -> check "run_if_free admits again once the queue is drained" false
 ;;
 
+let test_recovery_evidence_does_not_close_autonomous_lane () =
+  reset ();
+  Printf.printf
+    "Test 10a: recovery evidence does not close autonomous execution\n%!";
+  let first =
+    match Keeper_chat_queue.enqueue ~keeper_name queued_message with
+    | Ok receipt -> receipt
+    | Error error ->
+      failwith (Keeper_chat_queue.mutation_error_to_string error)
+  in
+  (match Keeper_chat_queue.lease_next ~keeper_name with
+    | `Leased _ -> ()
+    | `Empty | `Already_leased _ | `Recovery_required _ | `Error _ ->
+      failwith "expected first chat lease");
+  Keeper_chat_queue.For_testing.reset ();
+  let report = Keeper_chat_queue.configure_persistence ~base_path in
+  check "restart preserves one recovery boundary"
+    (report.load_errors = [] && report.recovery_required_receipt_count = 1);
+  (match Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () -> "open") with
+   | `Ran "open" ->
+     check "recovery-only evidence leaves autonomous execution open" true
+   | `Ran _ | `Busy _ ->
+     check "recovery-only evidence leaves autonomous execution open" false);
+  (match Keeper_turn_admission.run_chat_if_free ~base_path ~keeper_name (fun () -> ()) with
+   | `Busy _ ->
+     check "direct chat is routed through the durable recovery boundary" true
+   | `Ran () ->
+     check "direct chat cannot overtake recovery evidence without a receipt" false);
+  let second =
+    match Keeper_chat_queue.enqueue ~keeper_name queued_message with
+    | Ok receipt -> receipt
+    | Error error ->
+      failwith (Keeper_chat_queue.mutation_error_to_string error)
+  in
+  (match Keeper_chat_queue.lane_status ~keeper_name with
+   | Ok
+       { state =
+           Available
+             (Dispatchable
+                (Some { earliest; unresolved_count = 1 }))
+       ; _
+       } ->
+     check "later work names the recovery boundary it will cross"
+       (Keeper_chat_queue.Receipt_id.equal earliest.receipt_id first.receipt_id)
+   | Ok _ | Error _ ->
+     check "later work names the recovery boundary it will cross" false);
+  (match Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () -> ()) with
+   | `Busy _ -> check "dispatchable chat work receives autonomous priority" true
+   | `Ran () -> check "autonomous work cannot overtake dispatchable chat" false);
+  match Keeper_chat_queue.lease_next ~keeper_name with
+  | `Leased lease ->
+    check "later receipt crosses the boundary under its own lease"
+      (Keeper_chat_queue.Receipt_id.equal lease.item.receipt_id second.receipt_id)
+  | `Empty | `Already_leased _ | `Recovery_required _ | `Error _ ->
+    check "later receipt crosses the boundary under its own lease" false
+;;
+
 let test_shutdown_reservation_fences_and_rolls_back () =
   reset ();
   Printf.printf "Test 11: shutdown reservation fences every turn lane\n%!";
@@ -740,6 +799,7 @@ let () =
   test_autonomous_yields_to_parked_chat ();
   test_idle_loop_yields_to_parked_chat ();
   test_autonomous_yields_to_queued_connector_message ();
+  test_recovery_evidence_does_not_close_autonomous_lane ();
   test_shutdown_reservation_fences_and_rolls_back ();
   test_shutdown_reservation_restores_durable_owner ();
   if !failures > 0


### PR DESCRIPTION
## Summary

- Replace raw `has_active_receipts`/`lane_health` inference with one closed typed lane SSOT:
  - `Available (Idle | Dispatchable | Lease_inflight | Awaiting_recovery)`
  - `Persistence_reconciliation_required`
  - `Unavailable`
- Make autonomous admission and cooperative yield defer only to executable chat work (`Dispatchable` or `Lease_inflight`).
- Keep recovery-only evidence observable without blocking the Keeper from running other work.
- Route direct dashboard chat through the durable queue when a recovery boundary exists, so the new receipt cannot overtake that boundary invisibly.
- Log exact recovery-boundary crossing and correct Dashboard/Gate ACKs: no guessed replay, and later receipts may proceed independently.

## Product impact

- A Keeper with an unconfirmed older delivery can continue autonomous work and dispatch newly queued chat under a distinct lease.
- Dashboard and connector users receive accurate durable-queue semantics instead of the obsolete claim that the entire Keeper lane is non-dispatchable.
- Queue persistence faults remain explicit; no timeout, TTL, budget, string classifier, or heuristic fallback was introduced.

## Stack

- Base: #24644 — separates recovery evidence from the execution lease.
- This PR: consumes that boundary through admission, consumer, unified-turn yield, Dashboard, and Gate surfaces.

## Evidence

- Added admission regression: recovery-only state admits autonomous work, direct chat is forced through the durable boundary, and a later queued receipt regains chat priority and its own lease.
- Updated queue regressions to assert exact typed recovery-boundary identity and cardinality.
- `ocamlc -stop-after parsing` passed for all changed implementations and interface.
- `ocamlformat --check` passed for all changed OCaml files.
- `git diff --check` passed.
- Focused wrapper build was correctly refused because external bare Dune PID `66224` (`dune build lib/ test/deps/`) still owns machine-wide build execution. No override was used; CI is the build authority.
- Scope: 396 changed lines (266 insertions, 130 deletions), below the 400-line stack limit.
- CI run [29419760448](https://github.com/jeong-sik/masc/actions/runs/29419760448) passed source Build, OCaml 5.5 canary, Health, Lint, structure/SSOT ratchets, and Dashboard at head 04ffd5c8e5. Its aggregate records the same current-main legacy OAS catalog startup failure as the base PR, before focused quick-suite execution.

## Direct evidence

```yaml
schema_version: 1
direct_ratio: 0/1
provenance: operator_proxy
stages:
  - name: typed-lane-regressions
    provenance: operator_proxy
    result: blocked
    evidence: "source Build and OCaml 5.5 canary pass in CI 29419760448; focused lane execution remains blocked by external Dune PID 66224, while the full job is red on the inherited legacy OAS catalog startup gate"
```

## GOAL LOOP ACT checklist

- [x] Observe — recovery-only receipts were interpreted as executable backlog by multiple independent callers.
- [x] Orient — identified duplicate Boolean/snapshot inference as the SSOT violation behind whole-lane stalls.
- [x] Decide — expose one typed lane state and keep recovery evidence distinct from execution priority.
- [x] Act — wired the typed state through the queue consumer, admission, autonomous yield, Dashboard, and Gate ACKs.
- [ ] Verify — parser/format/diff checks plus CI source Build, OCaml 5.5 canary, Health, Lint, and Dashboard pass; focused executables and aggregate CI remain blocked by external Dune ownership and the inherited legacy OAS catalog startup gate.
- [x] Loop — remaining full Lane-per-Keeper/Fusion/Scheduler/Connector goals continue in the wider stack; this PR closes only chat recovery liveness.

## Review evidence

- Self-reviewed for fail-loud unavailable states, recovery identity/cardinality, transition-driven consumer rescheduling, direct-route ordering, and absence of retry guesses.
- Cross-model review pending.

## Linked issue

- Relates to #24644.

## Variant addition checklist

- [x] **OCaml** — replaced the queue lane variants and updated every exhaustive active-source consumer.
- [x] **TypeScript** — N/A; no serialized Dashboard union changed.
- [x] **TLA+ spec** — N/A; no TLA domain literal changed.
- [x] **Event / JSON schema** — N/A; no event or JSON enum changed.
- [ ] **`make check-variants` passes** — deferred to CI because local Dune ownership is currently held by an external process.
