### PR TITLE
refactor(fusion): stop injecting output token budgets

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -289,7 +289,7 @@
 ;; RFC-0252 standalone fusion harness: on-demand panel+judge deliberation vs
 ;; single-model baseline, side by side. Makes live LLM calls (NOT a test —
 ;; CI determinism rules forbid network calls in test/). Calls Fusion_panel.run
-;; + Fusion_judge.run directly (bypasses the orchestrator's gate/budget/sink).
+;; + Fusion_judge.run directly (bypasses the orchestrator's gate/sink).
 
 (executable
  (name fusion_run)

--- a/bin/fusion_run.ml
+++ b/bin/fusion_run.ml
@@ -123,7 +123,6 @@ let synthesize ~sw ~net ~(preset : Fusion_policy.preset) ~(prompt : string)
     ~web_tools:
       (Fusion_policy.judge_web_tools_of ~req_web_tools:false
          preset.Fusion_policy.panels)
-    ~max_tool_calls:(Fusion_policy.judge_tool_budget_of preset.Fusion_policy.panels)
     ()
   |> Result.map_error (fun (failure, _usage) ->
     Fusion_types.judge_failure_text failure)

--- a/lib/fusion/fusion_judge.ml
+++ b/lib/fusion/fusion_judge.ml
@@ -177,7 +177,7 @@ let apply_fusion_judge_output_contract provider_cfg =
    에러도 usage를 동반한다: 토큰을 태운 뒤 실패(빈 응답/파싱 실패)는 소비분을, 토큰
    소비 전 실패(빌드/실행/빈 결과/provider 에러)는 [zero_usage]를 싣는다. 호출자는
    실패 경로에서도 비용을 회계할 수 있다. *)
-let run_composed ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_model
+let run_composed ~sw ~net ~timeout_s ~judge_system_prompt ~judge_model
     ~web_tools ~prompt () :
     ( Fusion_types.judge_synthesis * Fusion_types.usage
     , Fusion_types.judge_failure * Fusion_types.usage )
@@ -185,7 +185,7 @@ let run_composed ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_mod
   let tools = if web_tools then Fusion_oas.web_tool_bundle () else [] in
   match
     Fusion_oas.build_agent ~sw ~net ~system_prompt:judge_system_prompt ~tools
-      ~timeout_s ?max_tokens
+      ~timeout_s
       ~provider_config_transform:apply_fusion_judge_output_contract
       judge_model
   with
@@ -222,28 +222,28 @@ let run_composed ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_mod
              ~prefix:"judge provider error: " e
          , Fusion_types.zero_usage ))
 
-let run ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_model ~question
+let run ~sw ~net ~timeout_s ~judge_system_prompt ~judge_model ~question
     ~panel ~web_tools () :
     ( Fusion_types.judge_synthesis * Fusion_types.usage
     , Fusion_types.judge_failure * Fusion_types.usage )
     result =
-  run_composed ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_model ~web_tools
+  run_composed ~sw ~net ~timeout_s ~judge_system_prompt ~judge_model ~web_tools
     ~prompt:(compose_prompt ~question ~panel) ()
 
-let run_refine ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_model ~question
+let run_refine ~sw ~net ~timeout_s ~judge_system_prompt ~judge_model ~question
     ~panel ~prior ~web_tools () :
     ( Fusion_types.judge_synthesis * Fusion_types.usage
     , Fusion_types.judge_failure * Fusion_types.usage )
     result =
-  run_composed ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_model ~web_tools
+  run_composed ~sw ~net ~timeout_s ~judge_system_prompt ~judge_model ~web_tools
     ~prompt:(compose_refine_prompt ~question ~panel ~prior) ()
 
-let run_meta ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_model ~question
+let run_meta ~sw ~net ~timeout_s ~judge_system_prompt ~judge_model ~question
     ~panel ~priors ~web_tools () :
     ( Fusion_types.judge_synthesis * Fusion_types.usage
     , Fusion_types.judge_failure * Fusion_types.usage )
     result =
-  run_composed ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_model ~web_tools
+  run_composed ~sw ~net ~timeout_s ~judge_system_prompt ~judge_model ~web_tools
     ~prompt:(compose_meta_prompt ~question ~panel ~priors) ()
 
 module For_testing = struct

--- a/lib/fusion/fusion_judge.mli
+++ b/lib/fusion/fusion_judge.mli
@@ -20,7 +20,7 @@ val compose_prompt : question:string -> panel:Fusion_types.panel_outcome list ->
     구성해 실행하고, capability-aware output contract를 적용한 응답 텍스트를
     {!Fusion_judge_parse.of_string}으로 파싱한다.
     [web_tools=true]면 심판 에이전트에 web_search/web_fetch를 주입한다.
-    [max_tokens]는 출력 토큰 예산이다. 생략하면 Runtime_agent 기본값을 보존한다.
+    Fusion은 심판별 출력 토큰 예산을 합성하지 않는다.
     빌드/실행/빈응답/파싱 실패는 [Error (msg, usage)]. 전체는 [Masc_oas_bridge.run_safe]로
     감싼다. 성공 시 종합 + 소비 토큰 [usage]를 반환하고(panel과 대칭, 비용 회계 RFC §10),
     실패 시에도 usage를 동반한다 — 응답을 받은 뒤 실패(빈 응답/파싱 실패)는 소비분을,
@@ -30,7 +30,6 @@ val run
   :  sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> timeout_s:float
-  -> ?max_tokens:int
   -> judge_system_prompt:string
   -> judge_model:string
   -> question:string
@@ -60,7 +59,6 @@ val run_refine
   :  sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> timeout_s:float
-  -> ?max_tokens:int
   -> judge_system_prompt:string
   -> judge_model:string
   -> question:string
@@ -100,7 +98,6 @@ val run_meta
   :  sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> timeout_s:float
-  -> ?max_tokens:int
   -> judge_system_prompt:string
   -> judge_model:string
   -> question:string

--- a/lib/fusion/fusion_oas.ml
+++ b/lib/fusion/fusion_oas.ml
@@ -155,7 +155,6 @@ let build_agent
     ~system_prompt
     ?(tools = [])
     ?timeout_s
-    ?max_tokens
     ?name
     ?provider_config_transform
     (model : string)
@@ -196,26 +195,16 @@ let build_agent
            ~system_prompt
            ~tools
        in
-       let base_config = apply_timeout_budget ?timeout_s base_config in
-       let config =
-         match max_tokens with
-         | None -> Ok base_config
-         | Some n when Fusion_policy.valid_max_output_tokens (Some n) ->
-           Ok { base_config with max_tokens = Some n }
-         | Some n -> Error (Fusion_types.Invalid_max_output_tokens n)
-       in
-       match config with
-       | Error _ as err -> err
-       | Ok config ->
-         (match Runtime_agent.build ~sw ~net ~config with
-           | Ok agent -> Ok agent
-           | Error e ->
-             Error
-               ((Fusion_types.Provider_error
-                   (provider_error_detail
-                      ~runtime_id:model
-                      (Agent_sdk.Error.to_string e))
-                 : Fusion_types.panel_failure))))
+       let config = apply_timeout_budget ?timeout_s base_config in
+       (match Runtime_agent.build ~sw ~net ~config with
+        | Ok agent -> Ok agent
+        | Error e ->
+          Error
+            ((Fusion_types.Provider_error
+                (provider_error_detail
+                   ~runtime_id:model
+                   (Agent_sdk.Error.to_string e))
+              : Fusion_types.panel_failure))))
 
 module For_testing = struct
   let apply_timeout_budget = apply_timeout_budget

--- a/lib/fusion/fusion_oas.mli
+++ b/lib/fusion/fusion_oas.mli
@@ -8,9 +8,8 @@
 
 (** runtime_id("provider.model")로 OAS 에이전트를 빌드한다.
 
-    [tools]를 주면 패널/심판이 tool call을 할 수 있다.
-    [max_tokens]는 지정된 패널/심판 호출의 출력 토큰 예산이다. 생략하면
-    Runtime_agent 기본값을 보존한다.
+    [tools]를 주면 패널/심판이 tool call을 할 수 있다. Fusion은 호출별 출력
+    토큰 예산을 합성하지 않고 resolved runtime의 요청 설정을 그대로 보존한다.
     [timeout_s]는 OAS transport idle/body budget에만 매핑한다. Fusion의 구조적
     wall-clock budget은 호출자가 [Masc_oas_bridge.run_safe]로 소유한다.
     [name]은 에이전트 카드명 — [Async_agent.all]이 결과 키로 반환하는 패널 정체성이다
@@ -26,7 +25,6 @@ val build_agent
   -> system_prompt:string
   -> ?tools:Agent_sdk.Tool.t list
   -> ?timeout_s:float
-  -> ?max_tokens:int
   -> ?name:string
   -> ?provider_config_transform:
        (Llm_provider.Provider_config.t

--- a/lib/fusion/fusion_orchestrator.ml
+++ b/lib/fusion/fusion_orchestrator.ml
@@ -42,7 +42,6 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
           let run_single_judge () =
             Fusion_judge.run ~sw ~net
               ~timeout_s:preset.Fusion_policy.judge_timeout_s
-              ?max_tokens:preset.Fusion_policy.judge_max_output_tokens
               ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
               ~judge_model:preset.Fusion_policy.judge
               ~question:req.Fusion_types.prompt ~panel ~web_tools:judge_web_tools ()
@@ -55,7 +54,6 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
             match
               Fusion_judge.run_refine ~sw ~net
                 ~timeout_s:preset.Fusion_policy.judge_timeout_s
-                ?max_tokens:preset.Fusion_policy.judge_max_output_tokens
                 ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
                 ~judge_model:preset.Fusion_policy.judge
                 ~question:req.Fusion_types.prompt ~panel ~prior:s1
@@ -154,7 +152,6 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                  (match
                        Fusion_judge.run_meta ~sw ~net
                          ~timeout_s:preset.Fusion_policy.meta_timeout_s
-                         ?max_tokens:preset.Fusion_policy.judge_max_output_tokens
                          ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
                          ~judge_model:preset.Fusion_policy.judge
                          ~question:req.Fusion_types.prompt ~panel ~priors
@@ -239,7 +236,6 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                   (match
                         Fusion_judge.run_meta ~sw ~net
                           ~timeout_s:preset.Fusion_policy.meta_timeout_s
-                          ?max_tokens:preset.Fusion_policy.judge_max_output_tokens
                           ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
                           ~judge_model:preset.Fusion_policy.judge
                           ~question:req.Fusion_types.prompt ~panel ~priors
@@ -296,7 +292,6 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                  (match
                        Fusion_judge.run_meta ~sw ~net
                          ~timeout_s:preset.Fusion_policy.meta_timeout_s
-                         ?max_tokens:preset.Fusion_policy.judge_max_output_tokens
                          ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
                          ~judge_model:preset.Fusion_policy.judge
                          ~question:req.Fusion_types.prompt ~panel ~priors

--- a/lib/fusion/fusion_orchestrator_judge_wave.ml
+++ b/lib/fusion/fusion_orchestrator_judge_wave.ml
@@ -177,7 +177,6 @@ let run_fallback_judge
         ~sw
         ~net
         ~timeout_s:j.jtimeout_s
-        ?max_tokens:j.jmax_output_tokens
         ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
         ~judge_model:model
         ~question

--- a/lib/fusion/fusion_panel.ml
+++ b/lib/fusion/fusion_panel.ml
@@ -84,7 +84,6 @@ let run ~sw ~net ~outer_timeout_s ~groups ~prompt ()
             match
               Fusion_oas.build_agent ~sw ~net ~system_prompt:g.system_prompt ~tools
                 ~timeout_s:g.timeout_s
-                ?max_tokens:g.max_output_tokens
                 ~name:panelist model
             with
             | Ok agent -> ((agent, panelist, model) :: oks, fails)

--- a/test/test_fusion_oas_error_detail.ml
+++ b/test/test_fusion_oas_error_detail.ml
@@ -224,7 +224,11 @@ let test_timeout_budget_sets_transport_timeouts () =
   Alcotest.(check (option (float 0.001)))
     "body timeout"
     (Some 300.0)
-    config.body_timeout_s
+    config.body_timeout_s;
+  Alcotest.(check (option int))
+    "fusion does not synthesize an output token budget"
+    None
+    config.max_tokens
 ;;
 
 let () =


### PR DESCRIPTION
## 변경\n- Fusion panel/judge/meta/fallback 호출이 per-call output token budget을 주입하지 않도록 API와 실행 배선을 hard-cut\n- standalone fusion harness에 남은 retired tool-call budget 인자 제거\n- provider stop_reason 및 usage 관측은 보존\n- 다음 stacked PR에서 이제 inert한 max_output_tokens 설정/타입/검증/대시보드 계약을 삭제\n\n## 검증\n- ocamlformat --check: PASS\n- ocamlc -stop-after parsing: PASS\n- git diff --check: PASS\n- focused Dune: 외부 bare Dune PID 66224 감지로 wrapper가 exit 75; override/중단하지 않음\n\nStacked on #24649.