### PR TITLE
fix(keeper): keep event bus polling stack bounded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
 - Keeper lifecycle reservations now use cooperative cross-context locking, so
   TOML reconciliation can suspend during durable persistence without a second
   Eio fiber re-locking the same OS-thread mutex.
+- Long-lived Keeper turn event-bus polling now uses a real tail-recursive loop;
+  polling no longer retains one exception-handler frame per cycle until CPU and
+  memory are consumed by stack scanning and GC.
 - Auto Judge requests now persist the exact outer-turn causal context without interpreting it, and durable retryable judgments resume on an accepted provider attempt rather than waiting for a server restart.
 - Keeper Gate state now has a BasePath-derived `.masc/gate/` owner. A corrupt optional Always Allowed rule store degrades only exact-rule lookup, while Chat persistence/read failures remain local to Chat and no longer close unrelated Keeper lanes.
 - Prompt overrides now persist in a schema-versioned envelope bound to the SHA256 revision of each prompt body and template-variable contract. Legacy or malformed files and contract-drifted entries fail closed with observable fallback, writes use atomic replacement, and dashboard set/clear mutations commit to memory only after persistence succeeds.

--- a/lib/keeper/keeper_unified_turn_event_bus.ml
+++ b/lib/keeper/keeper_unified_turn_event_bus.ml
@@ -203,6 +203,15 @@ let drain ?(site = "unspecified") t =
   update ()
 ;;
 
+(* Keep the recursion outside the cycle's exception handler. Calling [loop]
+   from inside [try ... with] retains one handler frame per poll and is not a
+   tail call, so a long-lived turn grows without bound until GC dominates the
+   server. This helper is shared with the regression test so that the tested
+   loop is the production loop. *)
+let rec run_background_drain_loop run_cycle =
+  if run_cycle () then run_background_drain_loop run_cycle
+;;
+
 let integrity_error t =
   (Atomic.get t.state).tracker
   |> Keeper_unified_turn_types.turn_tool_event_integrity_error
@@ -220,15 +229,15 @@ let start_background_drain ~clock t =
       Eio.Cancel.sub (fun cc ->
         match Atomic.compare_and_set t.drain_cancel Inactive (Active cc) with
         | true ->
-          let rec loop () =
+          let run_cycle () =
             try
               let _summary = drain ~site:"background_poll" t in
               Eio.Time.sleep clock (Keeper_turn_helpers.turn_event_bus_drain_interval_sec ());
-              loop ()
+              true
             with
             | Eio.Cancel.Cancelled _ ->
               (* [unsubscribe] cancels this background worker as normal teardown. *)
-              ()
+              false
             | exn ->
               Log.Keeper.warn
                 "%s: keeper_turn event-bus drain failed: %s"
@@ -242,10 +251,15 @@ let start_background_drain ~clock t =
                   ; "outcome", "exception"
                   ]
                 ();
-              Eio.Time.sleep clock (Keeper_turn_helpers.turn_event_bus_drain_interval_sec ());
-              loop ()
+              (try
+                 Eio.Time.sleep
+                   clock
+                   (Keeper_turn_helpers.turn_event_bus_drain_interval_sec ());
+                 true
+               with
+               | Eio.Cancel.Cancelled _ -> false)
           in
-          loop ()
+          run_background_drain_loop run_cycle
         | false ->
           (* [unsubscribe] has already closed the bus, or another fiber has
              already claimed the active drainer role. Either way this fiber
@@ -322,4 +336,5 @@ module For_testing = struct
       returns the displaced background drain handle (if any). Exposed so a
       unit test can assert it terminates and is idempotent on [Active]. *)
   let take_drain_cancel = take_drain_cancel
+  let run_background_drain_loop = run_background_drain_loop
 end

--- a/lib/keeper/keeper_unified_turn_event_bus.ml
+++ b/lib/keeper/keeper_unified_turn_event_bus.ml
@@ -206,10 +206,11 @@ let drain ?(site = "unspecified") t =
 (* Keep the recursion outside the cycle's exception handler. Calling [loop]
    from inside [try ... with] retains one handler frame per poll and is not a
    tail call, so a long-lived turn grows without bound until GC dominates the
-   server. This helper is shared with the regression test so that the tested
-   loop is the production loop. *)
+   server. The compiler-enforced [@tailcall] annotation prevents this call
+   from moving back under a handler frame. *)
 let rec run_background_drain_loop run_cycle =
-  if run_cycle () then run_background_drain_loop run_cycle
+  if run_cycle () then
+    (run_background_drain_loop [@tailcall]) run_cycle
 ;;
 
 let integrity_error t =
@@ -336,5 +337,4 @@ module For_testing = struct
       returns the displaced background drain handle (if any). Exposed so a
       unit test can assert it terminates and is idempotent on [Active]. *)
   let take_drain_cancel = take_drain_cancel
-  let run_background_drain_loop = run_background_drain_loop
 end

--- a/lib/keeper/keeper_unified_turn_event_bus.mli
+++ b/lib/keeper/keeper_unified_turn_event_bus.mli
@@ -72,4 +72,8 @@ module For_testing : sig
   (** The take-and-close step [unsubscribe] runs: atomically claims [Closed]
       and returns the displaced background drain handle (if any). *)
   val take_drain_cancel : t -> Eio.Cancel.t option
+
+  (** Run the production tail-recursive drain-loop driver. [run_cycle] returns
+      [true] to continue and [false] to stop. *)
+  val run_background_drain_loop : (unit -> bool) -> unit
 end

--- a/lib/keeper/keeper_unified_turn_event_bus.mli
+++ b/lib/keeper/keeper_unified_turn_event_bus.mli
@@ -72,8 +72,4 @@ module For_testing : sig
   (** The take-and-close step [unsubscribe] runs: atomically claims [Closed]
       and returns the displaced background drain handle (if any). *)
   val take_drain_cancel : t -> Eio.Cancel.t option
-
-  (** Run the production tail-recursive drain-loop driver. [run_cycle] returns
-      [true] to continue and [false] to stop. *)
-  val run_background_drain_loop : (unit -> bool) -> unit
 end

--- a/test/test_keeper_unified_turn_event_bus.ml
+++ b/test/test_keeper_unified_turn_event_bus.ml
@@ -583,14 +583,6 @@ let test_background_drain_continues_after_first_poll () =
        check bool "background drain keeps polling" true (wait_for_event_count 2 20))
 ;;
 
-let test_background_drain_loop_is_stack_bounded () =
-  let remaining = ref 1_000_000 in
-  EB.For_testing.run_background_drain_loop (fun () ->
-    decr remaining;
-    !remaining > 0);
-  check int "all immediate cycles complete without stack growth" 0 !remaining
-;;
-
 let () =
   Alcotest.run
     "keeper-unified-turn-event-bus"
@@ -621,8 +613,6 @@ let () =
             test_keeper_msg_submission_projection_has_unique_keys
         ; test_case "typed Keeper invocation wire contract" `Quick
             test_typed_keeper_invocation_wire_contract
-        ; test_case "background drain loop is stack bounded" `Quick
-            test_background_drain_loop_is_stack_bounded
         ] )
     ; ( "background-drain"
       , [ test_case "continues after first poll" `Quick

--- a/test/test_keeper_unified_turn_event_bus.ml
+++ b/test/test_keeper_unified_turn_event_bus.ml
@@ -583,6 +583,14 @@ let test_background_drain_continues_after_first_poll () =
        check bool "background drain keeps polling" true (wait_for_event_count 2 20))
 ;;
 
+let test_background_drain_loop_is_stack_bounded () =
+  let remaining = ref 1_000_000 in
+  EB.For_testing.run_background_drain_loop (fun () ->
+    decr remaining;
+    !remaining > 0);
+  check int "all immediate cycles complete without stack growth" 0 !remaining
+;;
+
 let () =
   Alcotest.run
     "keeper-unified-turn-event-bus"
@@ -613,6 +621,8 @@ let () =
             test_keeper_msg_submission_projection_has_unique_keys
         ; test_case "typed Keeper invocation wire contract" `Quick
             test_typed_keeper_invocation_wire_contract
+        ; test_case "background drain loop is stack bounded" `Quick
+            test_background_drain_loop_is_stack_bounded
         ] )
     ; ( "background-drain"
       , [ test_case "continues after first poll" `Quick

--- a/test/test_keeper_unified_turn_event_bus.ml
+++ b/test/test_keeper_unified_turn_event_bus.ml
@@ -548,7 +548,7 @@ let test_take_drain_cancel_clears_active_without_spin () =
     (match get_drain_cancel t with Closed -> true | _ -> false)
 ;;
 
-let test_background_drain_continues_after_first_poll () =
+let test_background_drain_continues_across_multiple_polls () =
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
   Eio_context.with_test_env
@@ -580,7 +580,9 @@ let test_background_drain_continues_after_first_poll () =
        EB.start_background_drain ~clock:env#clock t;
        check bool "first event drained" true (wait_for_event_count 1 20);
        Agent_sdk.Event_bus.publish bus (tool_called "second");
-       check bool "background drain keeps polling" true (wait_for_event_count 2 20))
+       check bool "second event drained" true (wait_for_event_count 2 20);
+       Agent_sdk.Event_bus.publish bus (tool_called "third");
+       check bool "background drain keeps polling" true (wait_for_event_count 3 20))
 ;;
 
 let () =
@@ -615,8 +617,8 @@ let () =
             test_typed_keeper_invocation_wire_contract
         ] )
     ; ( "background-drain"
-      , [ test_case "continues after first poll" `Quick
-            test_background_drain_continues_after_first_poll
+      , [ test_case "continues across multiple polls" `Quick
+            test_background_drain_continues_across_multiple_polls
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- move background event-bus loop recursion outside the cycle exception handler
- preserve cancellation and observable retry behavior without retaining handler frames
- enforce the recursive production call as a compiler-checked `[@tailcall]` instead of a test-only million-cycle loop API
- exercise repeated production polling by draining three successively published events

## Live evidence
- PID 78319 reached about 3.5 GB RSS and about 100% CPU with intermittent health connection refusal
- macOS sample showed hundreds of nested `Keeper_unified_turn_event_bus.loop` frames and GC pressure
- graceful supervisor restart recovered HTTP service temporarily; source fix is required to prevent recurrence

## Validation
- `ocamlformat --check` on touched OCaml files
- `git diff --check`
- `scripts/dune-local.sh build test/test_keeper_unified_turn_event_bus.exe`
- `_build/default/test/test_keeper_unified_turn_event_bus.exe` — 13 tests passed in 0.182s

OCaml warning 51 makes a future non-tail placement of the annotated recursive call a compile failure under this repository warning-as-error policy.