### PR TITLE
refactor(keeper): persist typed invocation requests

### DIFF
--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -2024,8 +2024,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
 
   it('resumes a pending request from storage and finalizes the transcript', async () => {
     upsertPendingKeeperChatRequest({
-      requestId: 'kmsg_echo_1',
-      keeperName: 'echo',
+      runRef: keeperRunRef('kmsg_echo_1'),
       message: '어디까지 했어?',
       submittedAt: Date.UTC(2026, 5, 15, 9, 0, 0),
     })
@@ -2062,8 +2061,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
 
   it('resumes a no-visible pending request as error instead of blank assistant text', async () => {
     upsertPendingKeeperChatRequest({
-      requestId: 'kmsg_echo_1',
-      keeperName: 'echo',
+      runRef: keeperRunRef('kmsg_echo_1'),
       message: '뭐함',
       submittedAt: Date.UTC(2026, 5, 15, 9, 0, 0),
     })
@@ -2114,14 +2112,12 @@ describe('sendKeeperThreadMessage stream outcome', () => {
   it('resumes repeated same-message sends as distinct request ids', async () => {
     const submittedAt = Date.UTC(2026, 5, 15, 9, 0, 0)
     upsertPendingKeeperChatRequest({
-      requestId: 'kmsg_echo_1',
-      keeperName: 'echo',
+      runRef: keeperRunRef('kmsg_echo_1'),
       message: 'status?',
       submittedAt,
     })
     upsertPendingKeeperChatRequest({
-      requestId: 'kmsg_echo_2',
-      keeperName: 'echo',
+      runRef: keeperRunRef('kmsg_echo_2'),
       message: 'status?',
       submittedAt,
     })
@@ -2157,8 +2153,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
 
   it('marks a recovered orphan request as lost instead of polling forever', async () => {
     upsertPendingKeeperChatRequest({
-      requestId: 'kmsg_echo_1',
-      keeperName: 'echo',
+      runRef: keeperRunRef('kmsg_echo_1'),
       message: '어디까지 했어?',
       submittedAt: Date.UTC(2026, 5, 15, 9, 0, 0),
     })
@@ -2193,8 +2188,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
 
   it('resumes a cancelled pending request without restoring an error bubble', async () => {
     upsertPendingKeeperChatRequest({
-      requestId: 'kmsg_echo_1',
-      keeperName: 'echo',
+      runRef: keeperRunRef('kmsg_echo_1'),
       message: '뭘 해야하나',
       submittedAt: Date.UTC(2026, 5, 15, 9, 0, 0),
     })
@@ -2231,8 +2225,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
 
   it('keeps the user message visible when the server no longer knows request_id', async () => {
     upsertPendingKeeperChatRequest({
-      requestId: 'kmsg_echo_1',
-      keeperName: 'echo',
+      runRef: keeperRunRef('kmsg_echo_1'),
       message: '어디까지 했어?',
       submittedAt: Date.UTC(2026, 5, 15, 9, 0, 0),
     })
@@ -2270,8 +2263,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
 
   it('finalizes the pending message as error when the poll request times out', async () => {
     upsertPendingKeeperChatRequest({
-      requestId: 'kmsg_echo_1',
-      keeperName: 'echo',
+      runRef: keeperRunRef('kmsg_echo_1'),
       message: '어디까지 했어?',
       submittedAt: Date.UTC(2026, 5, 15, 9, 0, 0),
     })
@@ -2300,8 +2292,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
       _resetChatHydrationForTests()
       _clearPendingKeeperChatRequestsForTests()
       upsertPendingKeeperChatRequest({
-        requestId: 'kmsg_echo_1',
-        keeperName: 'echo',
+        runRef: keeperRunRef('kmsg_echo_1'),
         message: '진행 상황?',
         submittedAt: Date.UTC(2026, 5, 15, 9, 0, 0),
       })
@@ -2359,8 +2350,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
       _resetChatHydrationForTests()
       _clearPendingKeeperChatRequestsForTests()
       upsertPendingKeeperChatRequest({
-        requestId: 'kmsg_echo_draft',
-        keeperName: 'echo',
+        runRef: keeperRunRef('kmsg_echo_draft'),
         message: '진행 상황?',
         submittedAt: Date.UTC(2026, 5, 15, 9, 0, 0),
         assistantDraft: {
@@ -2434,8 +2424,7 @@ describe('sendKeeperThreadMessage stream outcome', () => {
       _resetChatHydrationForTests()
       _clearPendingKeeperChatRequestsForTests()
       upsertPendingKeeperChatRequest({
-        requestId: 'kmsg_echo_2',
-        keeperName: 'echo',
+        runRef: keeperRunRef('kmsg_echo_2'),
         message: '진행 상황?',
         submittedAt: Date.UTC(2026, 5, 15, 9, 0, 0),
       })

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -27,7 +27,6 @@ import { compareKeeperQueueRevisions } from './lib/keeper-chat-receipt'
 import {
   isTerminalKeeperRunResult,
   keeperRunRefKey,
-  parseKeeperRunRef,
   parseKeeperRunTerminal,
   parseKeeperRunTracking,
   sameKeeperRunRef,
@@ -135,14 +134,6 @@ export function _resetKeeperRunCancelsForTests(): void {
 
 function releaseKeeperRunCancelTracking(reference: KeeperRunRef): void {
   pendingKeeperRunCancels.delete(keeperRunRefKey(reference))
-}
-
-function keeperRunRef(keeperName: string, runId: string) {
-  return parseKeeperRunRef({
-    run_id: runId,
-    target: { kind: 'keeper', name: keeperName },
-    capability: 'invoke_turn',
-  })
 }
 
 function markKeeperStreamSignal(keeperName: string, opts: { force?: boolean } = {}): void {
@@ -520,12 +511,14 @@ function isMissingQueuedKeeperRequestError(err: unknown): boolean {
 }
 
 function ensurePendingThreadEntries(request: PendingKeeperChatRequest): string {
-  const existing = keeperThreads.value[request.keeperName] ?? []
-  const userId = pendingUserEntryId(request.requestId)
-  const assistantId = pendingAssistantEntryId(request.requestId)
+  const keeperName = request.runRef.target.name
+  const runId = request.runRef.runId
+  const existing = keeperThreads.value[keeperName] ?? []
+  const userId = pendingUserEntryId(runId)
+  const assistantId = pendingAssistantEntryId(runId)
   const assistantDraft = request.assistantDraft
   if (!existing.some(entry => entry.id === userId)) {
-    appendThreadEntry(request.keeperName, {
+    appendThreadEntry(keeperName, {
       id: userId,
       role: 'user',
       source: 'direct_user',
@@ -535,7 +528,7 @@ function ensurePendingThreadEntries(request: PendingKeeperChatRequest): string {
       delivery: 'delivered',
       streamState: null,
       streamContract: keeperStreamContract('pending_request_store', 'client_placeholder', {
-        requestId: request.requestId,
+        requestId: runId,
         deliveryReceipt: 'no_delivery_receipt',
         reason: 'restored pending queued request from browser storage',
       }),
@@ -544,18 +537,18 @@ function ensurePendingThreadEntries(request: PendingKeeperChatRequest): string {
     })
   }
   if (!existing.some(entry => entry.id === assistantId)) {
-    appendThreadEntry(request.keeperName, {
+    appendThreadEntry(keeperName, {
       id: assistantId,
       role: 'assistant',
       source: 'direct_assistant',
-      label: request.keeperName,
+      label: keeperName,
       text: assistantDraft?.text ?? '',
       rawText: assistantDraft?.rawText ?? '',
       timestamp: assistantDraft?.timestamp ?? null,
       delivery: assistantDraft?.delivery ?? 'queued',
       streamState: assistantDraft ? assistantDraft.streamState : 'opening',
       streamContract: keeperStreamContract('pending_request_store', 'client_placeholder', {
-        requestId: request.requestId,
+        requestId: runId,
         deliveryReceipt: 'no_delivery_receipt',
         reason: 'awaiting queued request poll result',
       }),
@@ -569,14 +562,14 @@ function ensurePendingThreadEntries(request: PendingKeeperChatRequest): string {
 
 function persistPendingAssistantDraft(
   keeperName: string,
-  requestId: string | null,
+  runRef: KeeperRunRef | null,
   assistantEntryId: string,
 ): void {
-  if (!requestId) return
+  if (!runRef) return
   const entry = (keeperThreads.value[keeperName] ?? [])
     .find(candidate => candidate.id === assistantEntryId) ?? null
   if (!entry) return
-  updatePendingKeeperChatAssistantDraft(requestId, entry)
+  updatePendingKeeperChatAssistantDraft(runRef, entry)
 }
 
 let localIdCounter = 0
@@ -618,7 +611,9 @@ export function isKeeperThreadMessageSendInFlight(
 }
 
 async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest): Promise<void> {
-  const runRef = keeperRunRef(request.keeperName, request.requestId)
+  const runRef = request.runRef
+  const keeperName = runRef.target.name
+  const runId = runRef.runId
   // A live in-session send stream still owns this request (e.g. the panel
   // remounted on an SPA route change while the reply was pending). Defer to
   // it rather than minting a duplicate pending entry + a second poll loop.
@@ -628,16 +623,16 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
   if (resumingKeeperChatRequests.has(key)) return
   resumingKeeperChatRequests.add(key)
   const assistantId = ensurePendingThreadEntries(request)
-  setRecordValue(keeperSending, request.keeperName, true)
-  setRecordValue(keeperActionErrors, request.keeperName, null)
-  setRecordValue(keeperStreamStartedAt, request.keeperName, request.submittedAt)
-  markKeeperStreamSignal(request.keeperName, { force: true })
+  setRecordValue(keeperSending, keeperName, true)
+  setRecordValue(keeperActionErrors, keeperName, null)
+  setRecordValue(keeperStreamStartedAt, keeperName, request.submittedAt)
+  markKeeperStreamSignal(keeperName, { force: true })
   try {
     for (;;) {
       const result = await fetchQueuedKeeperMessageResult(
         runRef,
       )
-      markKeeperStreamSignal(request.keeperName)
+      markKeeperStreamSignal(keeperName)
       if (!isTerminalQueuedKeeperMessage(result)) {
         await sleep(PENDING_KEEPER_CHAT_POLL_MS)
         continue
@@ -672,11 +667,11 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
       } else if (isError) {
         assistantDelivery = 'error'
       }
-      finalizeAssistantEntry(request.keeperName, pendingUserEntryId(request.requestId), {
+      finalizeAssistantEntry(keeperName, pendingUserEntryId(runId), {
         delivery: userDelivery,
         error: errorMessage,
         streamContract: keeperStreamContract('queue_poll', 'queue_poll_result', {
-          requestId: request.requestId,
+          requestId: runId,
           deliveryReceipt: 'no_delivery_receipt',
           reason: errorMessage,
         }),
@@ -689,7 +684,7 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
       } else if (suppressReply) {
         assistantText = ''
       }
-      finalizeAssistantEntry(request.keeperName, assistantId, {
+      finalizeAssistantEntry(keeperName, assistantId, {
         text: assistantText,
         rawText: assistantRawText,
         delivery: assistantDelivery,
@@ -698,29 +693,29 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
         details: reply.details,
         error: errorMessage,
         streamContract: keeperStreamContract('queue_poll', 'queue_poll_result', {
-          requestId: request.requestId,
+          requestId: runId,
           deliveryReceipt: 'no_delivery_receipt',
           reason: errorMessage,
         }),
       })
-      if (errorMessage) setRecordValue(keeperActionErrors, request.keeperName, errorMessage)
-      removePendingKeeperChatRequest(request.requestId)
-      await hydrateKeeperChatHistory(request.keeperName, { force: true })
+      if (errorMessage) setRecordValue(keeperActionErrors, keeperName, errorMessage)
+      removePendingKeeperChatRequest(runRef)
+      await hydrateKeeperChatHistory(keeperName, { force: true })
       return
     }
   } catch (err) {
     if (isMissingQueuedKeeperRequestError(err)) {
-      removePendingKeeperChatRequest(request.requestId)
-      finalizeAssistantEntry(request.keeperName, pendingUserEntryId(request.requestId), {
+      removePendingKeeperChatRequest(runRef)
+      finalizeAssistantEntry(keeperName, pendingUserEntryId(runId), {
         delivery: 'error',
         error: QUEUED_KEEPER_REQUEST_LOST_MESSAGE,
         streamContract: keeperStreamContract('queue_poll', 'contract_gap', {
-          requestId: request.requestId,
+          requestId: runId,
           deliveryReceipt: 'no_delivery_receipt',
           reason: QUEUED_KEEPER_REQUEST_LOST_MESSAGE,
         }),
       })
-      finalizeAssistantEntry(request.keeperName, assistantId, {
+      finalizeAssistantEntry(keeperName, assistantId, {
         text: '',
         rawText: '',
         delivery: 'error',
@@ -728,28 +723,28 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
         timestamp: new Date().toISOString(),
         error: QUEUED_KEEPER_REQUEST_LOST_MESSAGE,
         streamContract: keeperStreamContract('queue_poll', 'contract_gap', {
-          requestId: request.requestId,
+          requestId: runId,
           deliveryReceipt: 'no_delivery_receipt',
           reason: QUEUED_KEEPER_REQUEST_LOST_MESSAGE,
         }),
       })
-      setRecordValue(keeperActionErrors, request.keeperName, QUEUED_KEEPER_REQUEST_LOST_MESSAGE)
-      await hydrateKeeperChatHistory(request.keeperName, { force: true })
+      setRecordValue(keeperActionErrors, keeperName, QUEUED_KEEPER_REQUEST_LOST_MESSAGE)
+      await hydrateKeeperChatHistory(keeperName, { force: true })
       return
     }
-    const detail = err instanceof Error ? err.message : `Failed to resume ${request.keeperName} chat request`
+    const detail = err instanceof Error ? err.message : `Failed to resume ${keeperName} chat request`
     const message = `${PENDING_KEEPER_CHAT_RESUME_FAILED_MESSAGE} (${detail})`
-    removePendingKeeperChatRequest(request.requestId)
-    finalizeAssistantEntry(request.keeperName, pendingUserEntryId(request.requestId), {
+    removePendingKeeperChatRequest(runRef)
+    finalizeAssistantEntry(keeperName, pendingUserEntryId(runId), {
       delivery: 'error',
       error: message,
       streamContract: keeperStreamContract('queue_poll', 'contract_gap', {
-        requestId: request.requestId,
+        requestId: runId,
         deliveryReceipt: 'no_delivery_receipt',
         reason: message,
       }),
     })
-    finalizeAssistantEntry(request.keeperName, assistantId, {
+    finalizeAssistantEntry(keeperName, assistantId, {
       text: '',
       rawText: '',
       delivery: 'error',
@@ -757,19 +752,19 @@ async function resumePendingKeeperChatRequest(request: PendingKeeperChatRequest)
       timestamp: new Date().toISOString(),
       error: message,
       streamContract: keeperStreamContract('queue_poll', 'contract_gap', {
-        requestId: request.requestId,
+        requestId: runId,
         deliveryReceipt: 'no_delivery_receipt',
         reason: message,
       }),
     })
-    setRecordValue(keeperActionErrors, request.keeperName, message)
-    await hydrateKeeperChatHistory(request.keeperName, { force: true })
+    setRecordValue(keeperActionErrors, keeperName, message)
+    await hydrateKeeperChatHistory(keeperName, { force: true })
   } finally {
     resumingKeeperChatRequests.delete(key)
-    if (!hasPendingKeeperChatRequest(request.keeperName)) {
-      setRecordValue(keeperSending, request.keeperName, false)
-      setRecordValue(keeperStreamStartedAt, request.keeperName, null)
-      clearKeeperStreamSignal(request.keeperName)
+    if (!hasPendingKeeperChatRequest(keeperName)) {
+      setRecordValue(keeperSending, keeperName, false)
+      setRecordValue(keeperStreamStartedAt, keeperName, null)
+      clearKeeperStreamSignal(keeperName)
     }
   }
 }
@@ -784,9 +779,8 @@ async function handoffCancelledStreamToRequestPoll(
   request: PendingKeeperChatRequest,
   localEntryIds: readonly string[],
 ): Promise<void> {
-  removeThreadEntries(request.keeperName, localEntryIds)
-  const runRef = keeperRunRef(request.keeperName, request.requestId)
-  releaseLiveSendRun(runRef)
+  removeThreadEntries(request.runRef.target.name, localEntryIds)
+  releaseLiveSendRun(request.runRef)
   await resumePendingKeeperChatRequest(request)
 }
 
@@ -1319,8 +1313,7 @@ export async function sendKeeperThreadMessage(
           if (nextRunRef && controller.signal.aborted) {
             acceptedRun.current = nextRunRef
             const pendingRequest: PendingKeeperChatRequest = {
-              requestId: nextRunRef.runId,
-              keeperName,
+              runRef: nextRunRef,
               message,
               submittedAt: Date.now(),
               ...(attachments ? { attachments } : {}),
@@ -1341,8 +1334,7 @@ export async function sendKeeperThreadMessage(
             // (and not mint a duplicate pending entry) until handoff/finally.
             claimLiveSendRun(nextRunRef)
             upsertPendingKeeperChatRequest({
-              requestId: nextRunRef.runId,
-              keeperName,
+              runRef: nextRunRef,
               message,
               submittedAt: Date.now(),
               ...(attachments ? { attachments } : {}),
@@ -1363,7 +1355,7 @@ export async function sendKeeperThreadMessage(
             } else if (isTerminalKeeperRunResult(terminal.resultContract)) {
               requestNeedsReconciliation = false
               requestTerminalSeen = true
-              removePendingKeeperChatRequest(terminal.runRef.runId)
+              removePendingKeeperChatRequest(terminal.runRef)
             } else {
               throw new Error(
                 `Keeper run terminal has nonterminal result_contract: ${terminal.resultContract}`,
@@ -1375,7 +1367,7 @@ export async function sendKeeperThreadMessage(
         if (error) {
           throw new Error(error)
         }
-        persistPendingAssistantDraft(keeperName, acceptedRun.current?.runId ?? null, assistantId)
+        persistPendingAssistantDraft(keeperName, acceptedRun.current, assistantId)
         if (event.type === 'TOOL_CALL_END') {
           toolCallEnded = true
           void hydrateKeeperToolOutputs(keeperName)
@@ -1396,8 +1388,7 @@ export async function sendKeeperThreadMessage(
         // call below is not blocked by the guard we just set.
         releaseLiveSendRun(runRef)
         await resumePendingKeeperChatRequest({
-          requestId: runRef.runId,
-          keeperName,
+          runRef,
           message,
           submittedAt: Date.now(),
           ...(attachments ? { attachments } : {}),
@@ -1443,7 +1434,7 @@ export async function sendKeeperThreadMessage(
       })
       setRecordValue(keeperActionErrors, keeperName, EMPTY_VISIBLE_REPLY_TEXT)
       if (runRef) {
-        removePendingKeeperChatRequest(runRef.runId)
+        removePendingKeeperChatRequest(runRef)
         releaseLiveSendRun(runRef)
       }
       return
@@ -1465,7 +1456,7 @@ export async function sendKeeperThreadMessage(
     })
     if (toolCallEnded) void hydrateKeeperToolOutputs(keeperName)
     if (runRef) {
-      removePendingKeeperChatRequest(runRef.runId)
+      removePendingKeeperChatRequest(runRef)
       releaseLiveSendRun(runRef)
     }
     if (finalDelivery === 'queued') {
@@ -1478,7 +1469,7 @@ export async function sendKeeperThreadMessage(
       const hasDurablePendingRequest = Boolean(
         runRef
         && pendingKeeperChatRequestsForKeeper(keeperName)
-          .some(candidate => candidate.requestId === runRef?.runId),
+          .some(candidate => sameKeeperRunRef(candidate.runRef, runRef)),
       )
       const shouldAttemptServerCancel = Boolean(
         runRef && (liveSendOwnsRun(runRef) || hasDurablePendingRequest),
@@ -1490,8 +1481,7 @@ export async function sendKeeperThreadMessage(
       )
       if (shouldAttemptServerCancel && runRef) {
         const pendingRequest: PendingKeeperChatRequest = {
-          requestId: runRef.runId,
-          keeperName,
+          runRef,
           message,
           submittedAt: Date.now(),
           ...(attachments ? { attachments } : {}),
@@ -1555,7 +1545,7 @@ export async function sendKeeperThreadMessage(
       }),
     })
     if (requestTerminalSeen && runRef) {
-      removePendingKeeperChatRequest(runRef.runId)
+      removePendingKeeperChatRequest(runRef)
       releaseLiveSendRun(runRef)
     }
     try {

--- a/dashboard/src/keeper-chat-pending.test.ts
+++ b/dashboard/src/keeper-chat-pending.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   _clearPendingKeeperChatRequestsForTests,
@@ -7,6 +7,14 @@ import {
   upsertPendingKeeperChatRequest,
 } from './keeper-chat-pending'
 
+function runRef(runId: string, keeperName = 'echo') {
+  return {
+    runId,
+    target: { kind: 'keeper', name: keeperName },
+    capability: 'invoke_turn',
+  } as const
+}
+
 describe('keeper chat pending request storage', () => {
   beforeEach(() => {
     window.localStorage.clear()
@@ -14,36 +22,41 @@ describe('keeper chat pending request storage', () => {
   })
 
   afterEach(() => {
+    vi.restoreAllMocks()
     _clearPendingKeeperChatRequestsForTests()
     window.localStorage.clear()
   })
 
-  it('preserves distinct request ids for repeated same-message sends', () => {
+  it('persists full run refs for repeated same-message sends', () => {
     const base = {
-      keeperName: 'echo',
       message: 'status?',
       submittedAt: 1_780_000_000,
     }
 
-    upsertPendingKeeperChatRequest({ ...base, requestId: 'kmsg_echo_1' })
-    upsertPendingKeeperChatRequest({ ...base, requestId: 'kmsg_echo_2' })
+    upsertPendingKeeperChatRequest({ ...base, runRef: runRef('kmsg_echo_1') })
+    upsertPendingKeeperChatRequest({ ...base, runRef: runRef('kmsg_echo_2') })
 
-    expect(pendingKeeperChatRequestsForKeeper('echo').map(request => request.requestId)).toEqual([
+    expect(pendingKeeperChatRequestsForKeeper('echo').map(request => request.runRef.runId)).toEqual([
       'kmsg_echo_1',
       'kmsg_echo_2',
     ])
+    const stored = JSON.parse(
+      window.localStorage.getItem('masc_keeper_chat_pending_requests_v2') ?? '[]',
+    ) as Array<Record<string, unknown>>
+    expect(stored[0]).toHaveProperty('run_ref')
+    expect(stored[0]).not.toHaveProperty('requestId')
+    expect(stored[0]).not.toHaveProperty('keeperName')
 
-    removePendingKeeperChatRequest('kmsg_echo_1')
+    removePendingKeeperChatRequest(runRef('kmsg_echo_1'))
 
-    expect(pendingKeeperChatRequestsForKeeper('echo').map(request => request.requestId)).toEqual([
+    expect(pendingKeeperChatRequestsForKeeper('echo').map(request => request.runRef.runId)).toEqual([
       'kmsg_echo_2',
     ])
   })
 
   it('preserves the in-flight assistant draft for page reload recovery', () => {
     upsertPendingKeeperChatRequest({
-      requestId: 'kmsg_echo_1',
-      keeperName: 'echo',
+      runRef: runRef('kmsg_echo_1'),
       message: 'status?',
       submittedAt: 1_780_000_000,
       assistantDraft: {
@@ -66,7 +79,7 @@ describe('keeper chat pending request storage', () => {
 
     expect(pendingKeeperChatRequestsForKeeper('echo')).toEqual([
       expect.objectContaining({
-        requestId: 'kmsg_echo_1',
+        runRef: runRef('kmsg_echo_1'),
         assistantDraft: expect.objectContaining({
           text: '부분 응답',
           rawText: '부분 응답',
@@ -85,5 +98,32 @@ describe('keeper chat pending request storage', () => {
         }),
       }),
     ])
+  })
+
+  it('isolates the same run id across different Keeper targets', () => {
+    const request = { message: 'status?', submittedAt: 1_780_000_000 }
+    upsertPendingKeeperChatRequest({ ...request, runRef: runRef('shared-run', 'echo') })
+    upsertPendingKeeperChatRequest({ ...request, runRef: runRef('shared-run', 'reviewer') })
+
+    removePendingKeeperChatRequest(runRef('shared-run', 'echo'))
+
+    expect(pendingKeeperChatRequestsForKeeper('echo')).toEqual([])
+    expect(pendingKeeperChatRequestsForKeeper('reviewer')).toEqual([
+      expect.objectContaining({ runRef: runRef('shared-run', 'reviewer') }),
+    ])
+  })
+
+  it('reports a malformed current-schema run ref instead of silently recovering it', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    window.localStorage.setItem('masc_keeper_chat_pending_requests_v2', JSON.stringify([{
+      run_ref: { run_id: 'broken' },
+      message: 'status?',
+      submittedAt: 1_780_000_000,
+    }]))
+
+    expect(pendingKeeperChatRequestsForKeeper('echo')).toEqual([])
+    expect(warn).toHaveBeenCalledWith(
+      '[keeper-chat-pending] rejected invalid pending request at index 0',
+    )
   })
 })

--- a/dashboard/src/keeper-chat-pending.ts
+++ b/dashboard/src/keeper-chat-pending.ts
@@ -6,6 +6,12 @@ import type {
   KeeperConversationStreamState,
 } from './types'
 import { IN_FLIGHT_DELIVERY } from './lib/keeper-delivery'
+import {
+  keeperRunRefKey,
+  keeperRunRefToWire,
+  parseKeeperRunRef,
+} from './lib/keeper-run-ref'
+import type { KeeperRunRef } from './lib/keeper-run-ref'
 
 export interface PendingKeeperChatAssistantDraft {
   text: string
@@ -18,15 +24,21 @@ export interface PendingKeeperChatAssistantDraft {
 }
 
 export interface PendingKeeperChatRequest {
-  requestId: string
-  keeperName: string
+  runRef: KeeperRunRef
   message: string
   submittedAt: number
   attachments?: KeeperConversationAttachment[]
   assistantDraft?: PendingKeeperChatAssistantDraft
 }
 
-const STORAGE_KEY = 'masc_keeper_chat_pending_requests_v1'
+const STORAGE_KEY = 'masc_keeper_chat_pending_requests_v2'
+const PENDING_REQUEST_FIELDS = [
+  'run_ref',
+  'message',
+  'submittedAt',
+  'attachments',
+  'assistantDraft',
+] as const
 const KEEPER_STREAM_STATES = [
   'opening',
   'thinking',
@@ -189,21 +201,24 @@ function assistantDraftFromEntry(entry: KeeperConversationEntry): PendingKeeperC
 
 function normalizePendingRequest(raw: unknown): PendingKeeperChatRequest | null {
   if (!isRecord(raw)) return null
-  const requestId = stringField(raw, 'requestId')
-  const keeperName = stringField(raw, 'keeperName')
+  if (Object.keys(raw).some(field => !PENDING_REQUEST_FIELDS.includes(
+    field as (typeof PENDING_REQUEST_FIELDS)[number],
+  ))) return null
+  let runRef: KeeperRunRef
+  try {
+    runRef = parseKeeperRunRef(raw.run_ref)
+  } catch {
+    return null
+  }
   const message = stringField(raw, 'message')
-  const submittedAt =
-    typeof raw.submittedAt === 'number' && Number.isFinite(raw.submittedAt)
-      ? raw.submittedAt
-      : Date.now()
-  if (!requestId || !keeperName || !message) return null
+  const submittedAt = numberValue(raw.submittedAt)
+  if (!message || submittedAt === undefined) return null
   const attachments = Array.isArray(raw.attachments)
     ? raw.attachments.map(normalizeAttachment).filter((att): att is KeeperConversationAttachment => att !== null)
     : []
   const assistantDraft = normalizeAssistantDraft(raw.assistantDraft)
   return {
-    requestId,
-    keeperName,
+    runRef,
     message,
     submittedAt,
     ...(attachments.length > 0 ? { attachments } : {}),
@@ -218,10 +233,20 @@ function readAll(): PendingKeeperChatRequest[] {
     const raw = store.getItem(STORAGE_KEY)
     if (!raw) return []
     const parsed: unknown = JSON.parse(raw)
-    if (!Array.isArray(parsed)) return []
-    return parsed
-      .map(normalizePendingRequest)
-      .filter((request): request is PendingKeeperChatRequest => request !== null)
+    if (!Array.isArray(parsed)) {
+      console.warn('[keeper-chat-pending] pending request store must be an array')
+      return []
+    }
+    const requests: PendingKeeperChatRequest[] = []
+    parsed.forEach((candidate, index) => {
+      const request = normalizePendingRequest(candidate)
+      if (request) {
+        requests.push(request)
+      } else {
+        console.warn(`[keeper-chat-pending] rejected invalid pending request at index ${index}`)
+      }
+    })
+    return requests
   } catch (err) {
     console.warn('[keeper-chat-pending] failed to read pending requests', err instanceof Error ? err.message : err)
     return []
@@ -235,7 +260,13 @@ function writeAll(requests: PendingKeeperChatRequest[]): void {
     if (requests.length === 0) {
       store.removeItem(STORAGE_KEY)
     } else {
-      store.setItem(STORAGE_KEY, JSON.stringify(requests))
+      store.setItem(STORAGE_KEY, JSON.stringify(requests.map(request => ({
+        run_ref: keeperRunRefToWire(request.runRef),
+        message: request.message,
+        submittedAt: request.submittedAt,
+        ...(request.attachments ? { attachments: request.attachments } : {}),
+        ...(request.assistantDraft ? { assistantDraft: request.assistantDraft } : {}),
+      }))))
     }
   } catch (err) {
     console.warn('[keeper-chat-pending] failed to write pending requests', err instanceof Error ? err.message : err)
@@ -245,39 +276,37 @@ function writeAll(requests: PendingKeeperChatRequest[]): void {
 export function pendingKeeperChatRequestsForKeeper(keeperName: string): PendingKeeperChatRequest[] {
   const name = keeperName.trim()
   if (!name) return []
-  return readAll().filter(request => request.keeperName === name)
+  return readAll().filter(request => request.runRef.target.name === name)
 }
 
 export function upsertPendingKeeperChatRequest(request: PendingKeeperChatRequest): void {
-  const requestId = request.requestId.trim()
-  const keeperName = request.keeperName.trim()
   const message = request.message.trim()
-  if (!requestId || !keeperName || !message) return
+  if (!message) return
   const assistantDraft = normalizeAssistantDraft(request.assistantDraft)
   const normalized: PendingKeeperChatRequest = {
-    requestId,
-    keeperName,
+    runRef: request.runRef,
     message,
     submittedAt: request.submittedAt,
     ...(request.attachments && request.attachments.length > 0 ? { attachments: request.attachments } : {}),
     ...(assistantDraft ? { assistantDraft } : {}),
   }
-  const next = readAll().filter(existing => existing.requestId !== requestId)
+  const key = keeperRunRefKey(request.runRef)
+  const next = readAll().filter(existing => keeperRunRefKey(existing.runRef) !== key)
   next.push(normalized)
   writeAll(next)
 }
 
 export function updatePendingKeeperChatAssistantDraft(
-  requestId: string,
+  reference: KeeperRunRef,
   entry: KeeperConversationEntry,
 ): void {
-  const id = requestId.trim()
   const assistantDraft = assistantDraftFromEntry(entry)
-  if (!id || !assistantDraft) return
+  if (!assistantDraft) return
+  const key = keeperRunRefKey(reference)
   const requests = readAll()
   let found = false
   const next = requests.map(request => {
-    if (request.requestId !== id) return request
+    if (keeperRunRefKey(request.runRef) !== key) return request
     found = true
     return { ...request, assistantDraft }
   })
@@ -285,10 +314,9 @@ export function updatePendingKeeperChatAssistantDraft(
   writeAll(next)
 }
 
-export function removePendingKeeperChatRequest(requestId: string): void {
-  const id = requestId.trim()
-  if (!id) return
-  writeAll(readAll().filter(request => request.requestId !== id))
+export function removePendingKeeperChatRequest(reference: KeeperRunRef): void {
+  const key = keeperRunRefKey(reference)
+  writeAll(readAll().filter(request => keeperRunRefKey(request.runRef) !== key))
 }
 
 export function hasPendingKeeperChatRequest(keeperName: string): boolean {

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -91,7 +91,7 @@ function persistActiveAssistantDraft(keeperName: string, assistantEntryId: strin
   const entry = (keeperThreads.value[keeperName] ?? [])
     .find(candidate => candidate.id === assistantEntryId) ?? null
   if (!entry) return
-  updatePendingKeeperChatAssistantDraft(runRef.runId, entry)
+  updatePendingKeeperChatAssistantDraft(runRef, entry)
 }
 
 function flushPendingThinkingDeltas(

--- a/lib/keeper/keeper_chat_direct_delivery.ml
+++ b/lib/keeper/keeper_chat_direct_delivery.ml
@@ -1528,6 +1528,13 @@ let commit_transcript_with_io io ~base_path ~identity ~now =
 
 let commit_transcript = commit_transcript_with_io production_io
 
+let request_matches_payload request payload =
+  String.equal
+    (Keeper_invocation_types.request_target_name request)
+    payload.keeper_name
+  && String.equal (Keeper_invocation_types.request_prompt request) payload.user_content
+;;
+
 let observe_async_terminal ~base_path ~(identity : t) =
   let* base_path = canonical_base_path base_path in
   let request_id_wire = Request_id.to_string identity.request_id in
@@ -1541,7 +1548,7 @@ let observe_async_terminal ~base_path ~(identity : t) =
   let entry = Keeper_msg_async.durable_terminal_entry proof in
   if
     String.equal entry.request_id request_id_wire
-    && String.equal entry.keeper_name identity.payload.keeper_name
+    && request_matches_payload entry.request identity.payload
     && String.equal entry.base_path base_path
     && String.equal entry.submitted_by identity.payload.submitted_by
   then Ok { canonical_terminal = proof; checkpoint = identity }
@@ -1555,7 +1562,7 @@ let proof_matches ~base_path (identity : t) proof =
   to_yojson proof.checkpoint = to_yojson identity
   && String.equal entry.base_path base_path
   && String.equal entry.request_id (Request_id.to_string identity.request_id)
-  && String.equal entry.keeper_name identity.payload.keeper_name
+  && request_matches_payload entry.request identity.payload
   && String.equal entry.submitted_by identity.payload.submitted_by
 ;;
 

--- a/lib/keeper/keeper_invocation_contract.ml
+++ b/lib/keeper/keeper_invocation_contract.ml
@@ -1,11 +1,6 @@
 type capability = Keeper_invocation_types.capability = Invoke_turn
 type target = Keeper_invocation_types.target = Keeper of Keeper_id.Keeper_name.t
-
-type request =
-  { target : target
-  ; capability : capability
-  ; prompt : string
-  }
+type request = Keeper_invocation_types.request
 
 type run_ref = Keeper_invocation_types.run_ref =
   { run_id : string
@@ -95,13 +90,9 @@ let capability_of_json ~field = function
 ;;
 
 let request ~keeper_name ~prompt =
-  let* keeper_name =
-    Keeper_id.Keeper_name.of_string keeper_name
-    |> Result.map_error (fun reason -> Invalid_target reason)
-  in
-  if String.equal prompt ""
-  then Error Empty_prompt
-  else Ok { target = Keeper keeper_name; capability = Invoke_turn; prompt }
+  Keeper_invocation_types.keeper_turn ~keeper_name ~prompt
+  |> Result.map_error (fun reason ->
+    if String.equal prompt "" then Empty_prompt else Invalid_target reason)
 ;;
 
 let request_of_json json =
@@ -115,10 +106,10 @@ let request_of_json json =
   let* target_json = required_field ~field:"delegate" "target" fields in
   let* target = target_of_json target_json in
   let* capability_json = required_field ~field:"delegate" "capability" fields in
-  let* capability = capability_of_json ~field:"delegate.capability" capability_json in
+  let* (_ : capability) = capability_of_json ~field:"delegate.capability" capability_json in
   let* prompt_json = required_field ~field:"delegate" "prompt" fields in
   let* prompt = string_value ~field:"delegate.prompt" prompt_json in
-  if String.equal prompt "" then Error Empty_prompt else Ok { target; capability; prompt }
+  request ~keeper_name:(Keeper_invocation_types.target_name target) ~prompt
 ;;
 
 let request_error_to_string = function
@@ -132,23 +123,26 @@ let request_error_to_string = function
 let target_name_of_target = Keeper_invocation_types.target_name
 
 let target_name (request : request) =
-  target_name_of_target request.target
+  Keeper_invocation_types.request_target_name request
 ;;
 
-let prompt (request : request) = request.prompt
+let prompt = Keeper_invocation_types.request_prompt
 
 let submit ~background_sw ~base_path ~caller ~(request : request) ~f () =
   Keeper_msg_async.submit
     ~background_sw
     ~base_path
     ~caller
-    ~keeper_name:(target_name request)
+    ~request
     ~f:(f request)
     ()
 ;;
 
 let run_ref (request : request) run_id =
-  { run_id; target = request.target; capability = request.capability }
+  { run_id
+  ; target = Keeper_invocation_types.request_target request
+  ; capability = Keeper_invocation_types.request_capability request
+  }
 ;;
 
 let submission_receipt (request : request) outcome =
@@ -205,7 +199,9 @@ let run_ref_matches_entry reference (entry : Keeper_msg_async.entry) =
   String.equal reference.run_id entry.Keeper_msg_async.request_id
   && String.equal
        (target_name_of_target reference.target)
-       entry.Keeper_msg_async.keeper_name
+       (Keeper_invocation_types.request_target_name entry.Keeper_msg_async.request)
+  && (match reference.capability, Keeper_invocation_types.request_capability entry.request with
+      | Invoke_turn, Invoke_turn -> true)
 ;;
 
 let validate_entry reference entry =
@@ -266,8 +262,6 @@ let delegate_submission_to_json (request : request) outcome =
 let delegate_submission_error_to_json request = function
   | Keeper_msg_async.Submit_rejected rejection ->
     Keeper_msg_async.access_rejection_to_json rejection
-  | Keeper_msg_async.Submit_invalid_keeper_name { reason } ->
-    `Assoc [ "error", `String "invalid_target"; "message", `String reason ]
   | Keeper_msg_async.Initial_persistence_failed { reason } ->
     `Assoc [ "error", `String "invocation_persistence_failed"; "message", `String reason ]
   | Keeper_msg_async.Acceptance_persistence_failed { request_id; reason } ->
@@ -324,14 +318,10 @@ let entry_result = function
 
 let delegate_entry_to_json (entry : Keeper_msg_async.entry) =
   let contract = result_contract entry in
-  let* target_name =
-    Keeper_id.Keeper_name.of_string entry.Keeper_msg_async.keeper_name
-    |> Result.map_error (fun reason -> Invalid_target reason)
-  in
   let reference =
     { run_id = entry.request_id
-    ; target = Keeper target_name
-    ; capability = Invoke_turn
+    ; target = Keeper_invocation_types.request_target entry.request
+    ; capability = Keeper_invocation_types.request_capability entry.request
     }
   in
   let timing =

--- a/lib/keeper/keeper_msg_async.ml
+++ b/lib/keeper/keeper_msg_async.ml
@@ -40,7 +40,7 @@ type request_status =
 
 type entry =
   { request_id : string
-  ; keeper_name : string
+  ; request : Keeper_invocation_types.request
   ; base_path : string
   ; submitted_by : string
   ; status : request_status
@@ -119,7 +119,6 @@ and recovery_record_error_kind =
 
 type submit_error =
   | Submit_rejected of access_rejection
-  | Submit_invalid_keeper_name of { reason : string }
   | Initial_persistence_failed of { reason : string }
   | Acceptance_persistence_failed of
       { request_id : string
@@ -498,7 +497,16 @@ let with_keeper_persistence_lock ~base_path ~keeper_name f =
 exception CancelledByOperator
 exception Worker_preempted of string
 exception Worker_already_settled of request_status
-let record_schema_version = 3
+let record_schema_version = 4
+
+let entry_keeper_name_id (entry : entry) =
+  match Keeper_invocation_types.request_target entry.request with
+  | Keeper_invocation_types.Keeper name -> name
+;;
+
+let entry_keeper_name (entry : entry) =
+  Keeper_id.Keeper_name.to_string (entry_keeper_name_id entry)
+;;
 
 let server_background_switch () =
   match Eio_context.get_root_switch_opt () with
@@ -658,11 +666,6 @@ let durable_terminal_entry proof = proof.terminal_entry
 
 let submit_error_to_json = function
   | Submit_rejected rejection -> access_rejection_to_json rejection
-  | Submit_invalid_keeper_name { reason } ->
-    `Assoc
-      [ "error", `String "invalid_keeper_name"
-      ; "message", `String reason
-      ]
   | Initial_persistence_failed { reason } ->
     `Assoc
       [ "error", `String "request_persistence_failed"
@@ -782,7 +785,7 @@ let entry_record_to_json (e : entry) : Yojson.Safe.t =
   let fields =
     [ "schema_version", `Int record_schema_version
     ; "request_id", `String e.request_id
-    ; "keeper_name", `String e.keeper_name
+    ; "request", Keeper_invocation_types.request_to_json e.request
     ; "base_path", `String e.base_path
     ; "submitted_by", `String e.submitted_by
     ; "status", `String (status_to_string e.status)
@@ -815,7 +818,7 @@ let entry_record_to_json (e : entry) : Yojson.Safe.t =
 
 let same_request_identity (left : entry) (right : entry) =
   String.equal left.request_id right.request_id
-  && String.equal left.keeper_name right.keeper_name
+  && Keeper_invocation_types.request_equal left.request right.request
   && String.equal left.base_path right.base_path
   && String.equal left.submitted_by right.submitted_by
   && Float.equal left.submitted_at right.submitted_at
@@ -874,7 +877,7 @@ let validate_record_fields ~status_fields json =
   let common_fields =
     [ "schema_version"
     ; "request_id"
-    ; "keeper_name"
+    ; "request"
     ; "base_path"
     ; "submitted_by"
     ; "status"
@@ -963,10 +966,10 @@ let entry_of_record_json ~base_path ~request_id:expected_request_id json :
            request_id
            expected_request_id)
   in
-  let* keeper_name = required_string "keeper_name" json in
-  let* keeper_name =
-    Keeper_id.Keeper_name.of_string keeper_name
-    |> Result.map Keeper_id.Keeper_name.to_string
+  let* request =
+    match Json_util.assoc_member_opt "request" json with
+    | Some request -> Keeper_invocation_types.request_of_json request
+    | None -> Error "record is missing required object field \"request\""
   in
   let* persisted_base_path = required_string "base_path" json in
   let* submitted_by = required_string "submitted_by" json in
@@ -997,7 +1000,7 @@ let entry_of_record_json ~base_path ~request_id:expected_request_id json :
   let* () = validate_record_fields ~status_fields json in
   Ok
     { request_id
-    ; keeper_name
+    ; request
     ; base_path = persisted_base_path
     ; submitted_by
     ; status
@@ -1076,7 +1079,6 @@ let remove_duplicate_source_unlocked ~ops ~(entry : entry) path =
 
 type persist_integrity_error =
   | Unsafe_request_id
-  | Invalid_keeper_name of string
   | Terminal_partition_nonterminal
   | Terminal_conflict
   | Terminal_unreadable of string
@@ -1092,7 +1094,6 @@ type persist_error =
 
 let persist_integrity_error_to_string = function
   | Unsafe_request_id -> "request_id is unsafe for persistence"
-  | Invalid_keeper_name reason -> reason
   | Terminal_partition_nonterminal ->
     "terminal partition contains a non-terminal request record"
   | Terminal_conflict ->
@@ -1189,13 +1190,10 @@ let persist_entry_unlocked ~ops ?source_path (entry : entry) =
 ;;
 
 let with_entry_persistence_transaction (entry : entry) f =
-  match Keeper_id.Keeper_name.of_string entry.keeper_name with
-  | Error reason -> Error (Integrity_failed (Invalid_keeper_name reason))
-  | Ok keeper_name ->
-    with_keeper_persistence_lock
-      ~base_path:entry.base_path
-      ~keeper_name
-      f
+  with_keeper_persistence_lock
+    ~base_path:entry.base_path
+    ~keeper_name:(entry_keeper_name_id entry)
+    f
 ;;
 
 let persist_entry ~ops ?source_path (entry : entry) =
@@ -1436,7 +1434,7 @@ let recover_record_path ~base_path ~request_id path report =
                ~store:Active_store
                ~path
                ~request_id
-               ~keeper_name:entry.keeper_name
+               ~keeper_name:(entry_keeper_name entry)
                Recovery_source_cleanup_failed
                report) with
             failed = report.failed + 1
@@ -1452,7 +1450,7 @@ let recover_record_path ~base_path ~request_id path report =
                ~store:Active_store
                ~path
                ~request_id
-               ~keeper_name:entry.keeper_name
+               ~keeper_name:(entry_keeper_name entry)
                (Recovery_persistence_failed (persist_error_to_string error))
                report) with
             failed = report.failed + 1
@@ -1468,7 +1466,7 @@ let recover_record_path ~base_path ~request_id path report =
             ~store:Active_store
             ~path
             ~request_id
-            ~keeper_name:entry.keeper_name
+            ~keeper_name:(entry_keeper_name entry)
             (Recovery_terminal_integrity
                (persist_integrity_error_to_string integrity_error))
             report) with
@@ -1486,7 +1484,7 @@ let recover_record_path ~base_path ~request_id path report =
                 ~store:Active_store
                 ~path
                 ~request_id
-                ~keeper_name:entry.keeper_name
+                ~keeper_name:(entry_keeper_name entry)
                 Recovery_source_cleanup_failed
                 report) with
              failed = report.failed + 1
@@ -1502,7 +1500,7 @@ let recover_record_path ~base_path ~request_id path report =
                 ~store:Active_store
                 ~path
                 ~request_id
-                ~keeper_name:entry.keeper_name
+                ~keeper_name:(entry_keeper_name entry)
                 (Recovery_persistence_failed (persist_error_to_string error))
                 report) with
              failed = report.failed + 1
@@ -1521,7 +1519,7 @@ let recover_record_path ~base_path ~request_id path report =
                 ~store:Active_store
                 ~path
                 ~request_id
-                ~keeper_name:entry.keeper_name
+                ~keeper_name:(entry_keeper_name entry)
                 (Recovery_persistence_failed reason)
                 report) with
              failed = report.failed + 1
@@ -1723,7 +1721,7 @@ let recover_lost_disk_records ~base_path () =
 
 let with_lock f = Eio.Mutex.use_rw ~protect:true mu (fun () -> f ())
 
-let reserve_new_request ~ops ~base_path ~submitted_by ~keeper_name =
+let reserve_new_request ~ops ~base_path ~submitted_by ~request =
   let rec reserve () =
     let request_id = ops.generate_request_id () in
     if not (is_safe_request_id request_id)
@@ -1742,7 +1740,7 @@ let reserve_new_request ~ops ~base_path ~submitted_by ~keeper_name =
               else
                 let entry =
                   { request_id
-                  ; keeper_name
+                  ; request
                   ; base_path
                   ; submitted_by
                   ; status = Queued
@@ -1984,18 +1982,18 @@ let runtime_cancelled_status () =
 ;;
 
 let submit_with_ops ops ?on_accepted ?on_worker_aborted ?on_worker_settled ~background_sw
-    ~base_path ~caller ~(f : Eio.Switch.t -> tool_result) ~keeper_name () :
+    ~base_path ~caller ~(f : Eio.Switch.t -> tool_result) ~request () :
     (submit_outcome, submit_error) result =
   match resolve_access_identity ~base_path ~caller with
   | Error rejection -> Error (Submit_rejected rejection)
   | Ok (base_path, submitted_by) ->
-    (match Keeper_id.Keeper_name.of_string keeper_name with
-     | Error reason -> Error (Submit_invalid_keeper_name { reason })
-     | Ok keeper_name_id ->
-    let keeper_name = Keeper_id.Keeper_name.to_string keeper_name_id in
+    let keeper_name_id =
+      match Keeper_invocation_types.request_target request with
+      | Keeper_invocation_types.Keeper name -> name
+    in
     with_keeper_submission_lock ~base_path ~keeper_name:keeper_name_id (fun () ->
     let request_id, entry, key, transition_lock =
-      reserve_new_request ~ops ~base_path ~submitted_by ~keeper_name
+      reserve_new_request ~ops ~base_path ~submitted_by ~request
     in
     let reconciliation_outcome reason =
       Ok
@@ -2279,7 +2277,7 @@ let submit_with_ops ops ?on_accepted ?on_worker_aborted ?on_worker_settled ~back
               Ok { request_id; acceptance = Durably_accepted }
             | Some cause -> background_start_failed (Printexc.to_string cause))
         | exception exn ->
-          background_start_failed (Printexc.to_string exn))))))
+          background_start_failed (Printexc.to_string exn)))))
 ;;
 
 let submit = submit_with_ops production_request_ops
@@ -2376,7 +2374,7 @@ let list_for_keeper ~base_path ~caller ?keeper_name () :
              match entry.status, keeper_name with
              | (Done _ | Lost _ | Cancelled _ | Persistence_failed _), _ -> acc
              | (Queued | Running | Cancelling _), Some name
-               when not (String.equal entry.keeper_name name) -> acc
+               when not (String.equal (entry_keeper_name entry) name) -> acc
              | (Queued | Running | Cancelling _), (Some _ | None) -> entry :: acc)
         pending
         [])
@@ -2388,7 +2386,7 @@ let list_for_keeper ~base_path ~caller ?keeper_name () :
 let entry_to_json (e : entry) : Yojson.Safe.t =
   let fields =
     [ "request_id", `String e.request_id
-    ; "keeper_name", `String e.keeper_name
+    ; "keeper_name", `String (entry_keeper_name e)
     ; "submitted_by", `String e.submitted_by
     ; "status", `String (status_to_string e.status)
     ; "submitted_at", `Float e.submitted_at

--- a/lib/keeper/keeper_msg_async.mli
+++ b/lib/keeper/keeper_msg_async.mli
@@ -34,7 +34,7 @@ type request_status =
 
 type entry =
   { request_id : string
-  ; keeper_name : string
+  ; request : Keeper_invocation_types.request
   ; base_path : string
   ; submitted_by : string
   ; status : request_status
@@ -91,7 +91,7 @@ val durable_terminal_entry : durable_terminal_proof -> entry
 (** Read-only identity/status carried by a proof.  The proof constructor stays
     private to this module. *)
 
-(** Recovery observations for canonical v3 storage only. [finalized] counts
+(** Recovery observations for canonical v4 storage only. [finalized] counts
     terminal states moved from the active partition after a crash; [cleaned]
     counts duplicate active sources removed after terminal durability was
     established. Staging counters cover only the current dedicated atomic
@@ -139,7 +139,6 @@ and recovery_record_error_kind =
 
 type submit_error =
   | Submit_rejected of access_rejection
-  | Submit_invalid_keeper_name of { reason : string }
   | Initial_persistence_failed of { reason : string }
   | Acceptance_persistence_failed of
       { request_id : string
@@ -221,11 +220,11 @@ val server_background_switch : unit -> (Eio.Switch.t, submit_error) result
     as [submit]. *)
 
 (** [submit ?on_accepted ?on_worker_aborted ~background_sw ~f
-    ~keeper_name ~base_path ~caller] forks a background daemon fiber on the
+    ~request ~base_path ~caller] forks a background daemon fiber on the
     explicitly supplied server-lifetime [background_sw].  The per-request
     worker switch passed to [f] is distinct: cancellation fails that switch,
     never the server root. Returns the fresh [request_id] synchronously after
-    the owner-bearing v3 request record is durably accepted. If an atomic
+    the owner-bearing v4 request record is durably accepted. If an atomic
     rename publishes the record but its directory fsync and the compensating
     rollback both fail, [Reconciliation_required] preserves the request id so
     the caller can poll instead of creating an unreachable orphan. The async
@@ -268,7 +267,7 @@ val submit
   -> base_path:string
   -> caller:string
   -> f:(Eio.Switch.t -> Keeper_types_profile.tool_result)
-  -> keeper_name:string
+  -> request:Keeper_invocation_types.request
   -> unit
   -> (submit_outcome, submit_error) result
 
@@ -366,7 +365,7 @@ module For_testing : sig
     -> base_path:string
     -> caller:string
     -> f:(Eio.Switch.t -> Keeper_types_profile.tool_result)
-    -> keeper_name:string
+    -> request:Keeper_invocation_types.request
     -> unit
     -> (submit_outcome, submit_error) result
 

--- a/lib/keeper_invocation_types/keeper_invocation_types.ml
+++ b/lib/keeper_invocation_types/keeper_invocation_types.ml
@@ -1,6 +1,14 @@
 type capability = Invoke_turn
 type target = Keeper of Keeper_id.Keeper_name.t
 
+type input = Prompt of string
+
+type request =
+  { target : target
+  ; capability : capability
+  ; input : input
+  }
+
 type run_ref = { run_id : string; target : target; capability : capability }
 
 type result_contract =
@@ -17,6 +25,91 @@ let target_name = function Keeper name -> Keeper_id.Keeper_name.to_string name
 
 let target_to_json target =
   `Assoc [ "kind", `String "keeper"; "name", `String (target_name target) ]
+
+let keeper_turn ~keeper_name ~prompt =
+  match Keeper_id.Keeper_name.of_string keeper_name with
+  | Error _ as error -> error
+  | Ok target_name ->
+    if String.equal prompt ""
+    then Error "request.input.prompt must be a non-empty string"
+    else
+      Ok
+        { target = Keeper target_name
+        ; capability = Invoke_turn
+        ; input = Prompt prompt
+        }
+;;
+
+let request_target request = request.target
+let request_capability request = request.capability
+let request_target_name request = target_name request.target
+let request_prompt request = match request.input with Prompt prompt -> prompt
+
+let request_equal left right =
+  match left.target, right.target, left.capability, right.capability with
+  | Keeper left_name, Keeper right_name, Invoke_turn, Invoke_turn ->
+    Keeper_id.Keeper_name.equal left_name right_name
+    && String.equal (request_prompt left) (request_prompt right)
+;;
+
+let request_to_json request =
+  `Assoc
+    [ "target", target_to_json request.target
+    ; "capability", `String "invoke_turn"
+    ; "input", `Assoc [ "prompt", `String (request_prompt request) ]
+    ]
+;;
+
+let exact_object ~field ~expected = function
+  | `Assoc fields ->
+    let names = List.map fst fields in
+    if List.length names <> List.length (List.sort_uniq String.compare names)
+    then Error (Printf.sprintf "%s contains duplicate fields" field)
+    else if
+      List.length names <> List.length expected
+      || List.exists (fun name -> not (List.mem name names)) expected
+    then Error (Printf.sprintf "%s must contain exactly %s" field (String.concat ", " expected))
+    else Ok fields
+  | _ -> Error (field ^ " must be an object")
+;;
+
+let required_string ~field name fields =
+  match List.assoc_opt name fields with
+  | Some (`String value) -> Ok value
+  | Some _ | None -> Error (Printf.sprintf "%s.%s must be a string" field name)
+;;
+
+let request_of_json json =
+  let ( let* ) = Result.bind in
+  let* fields =
+    exact_object ~field:"request" ~expected:[ "target"; "capability"; "input" ] json
+  in
+  let* target_json =
+    match List.assoc_opt "target" fields with
+    | Some value -> Ok value
+    | None -> Error "request.target is required"
+  in
+  let* target_fields =
+    exact_object ~field:"request.target" ~expected:[ "kind"; "name" ] target_json
+  in
+  let* kind = required_string ~field:"request.target" "kind" target_fields in
+  let* keeper_name = required_string ~field:"request.target" "name" target_fields in
+  let* capability = required_string ~field:"request" "capability" fields in
+  let* input_json =
+    match List.assoc_opt "input" fields with
+    | Some value -> Ok value
+    | None -> Error "request.input is required"
+  in
+  let* input_fields =
+    exact_object ~field:"request.input" ~expected:[ "prompt" ] input_json
+  in
+  let* prompt = required_string ~field:"request.input" "prompt" input_fields in
+  if not (String.equal kind "keeper")
+  then Error "request.target.kind must be keeper"
+  else if not (String.equal capability "invoke_turn")
+  then Error "request.capability must be invoke_turn"
+  else keeper_turn ~keeper_name ~prompt
+;;
 
 let run_id reference = reference.run_id
 let run_ref_target_name reference = target_name reference.target

--- a/lib/keeper_invocation_types/keeper_invocation_types.mli
+++ b/lib/keeper_invocation_types/keeper_invocation_types.mli
@@ -3,6 +3,9 @@
 type capability = Invoke_turn
 type target = Keeper of Keeper_id.Keeper_name.t
 
+type input = Prompt of string
+type request
+
 type run_ref = { run_id : string; target : target; capability : capability }
 
 type result_contract =
@@ -17,6 +20,14 @@ type result_contract =
 
 val target_name : target -> string
 val target_to_json : target -> Yojson.Safe.t
+val keeper_turn : keeper_name:string -> prompt:string -> (request, string) result
+val request_target : request -> target
+val request_capability : request -> capability
+val request_target_name : request -> string
+val request_prompt : request -> string
+val request_equal : request -> request -> bool
+val request_to_json : request -> Yojson.Safe.t
+val request_of_json : Yojson.Safe.t -> (request, string) result
 val run_id : run_ref -> string
 val run_ref_target_name : run_ref -> string
 val run_ref_to_json : run_ref -> Yojson.Safe.t

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -1940,11 +1940,18 @@ let process_single_turn ~user_row_origin ~queued_turn
     persisted
   in
   let submit_result =
-    match Keeper_msg_async.server_background_switch () with
-    | Error error ->
+    match
+      ( Keeper_msg_async.server_background_switch ()
+      , Keeper_invocation_contract.request
+          ~keeper_name:payload.name
+          ~prompt:payload.message )
+    with
+    | Error error, _ ->
         Error
           (Keeper_msg_async.submit_error_to_json error |> Yojson.Safe.to_string)
-    | Ok background_sw ->
+    | _, Error error ->
+        Error (Keeper_invocation_contract.request_error_to_string error)
+    | Ok background_sw, Ok request ->
       let on_accepted =
         if dashboard_direct_stream
         then Some on_direct_request_accepted
@@ -1957,7 +1964,7 @@ let process_single_turn ~user_row_origin ~queued_turn
         ~on_worker_settled:publish_committed_completion
         ~base_path
         ~caller:submitted_by
-        ~keeper_name:payload.name
+        ~request
         ~f:(fun request_sw ->
         let start_time = Time_compat.now () in
         let finish_projection_failure kind detail =

--- a/test/test_keeper_chat_direct_delivery.ml
+++ b/test/test_keeper_chat_direct_delivery.ml
@@ -27,6 +27,12 @@ let expect_ok = function
   | Error error -> fail (Direct.error_to_string error)
 ;;
 
+let keeper_request keeper_name =
+  match Keeper_invocation_types.keeper_turn ~keeper_name ~prompt:"소스코드를 확인해" with
+  | Ok request -> request
+  | Error reason -> fail reason
+;;
+
 let request_id wire =
   Direct.Request_id.of_string wire
   |> function
@@ -429,7 +435,7 @@ let await_settlement ~ops ~background_sw ~base_path ~request_id =
       ~background_sw
       ~base_path
       ~caller:"owner"
-      ~keeper_name:"sangsu"
+      ~request:(keeper_request "sangsu")
       ~f:(fun _request_sw -> Keeper_types_profile.tool_result_ok "completed")
       ()
     |> accepted_request_id

--- a/test/test_keeper_msg_async_terminal_event.ml
+++ b/test/test_keeper_msg_async_terminal_event.ml
@@ -27,6 +27,12 @@ let () = Mirage_crypto_rng_unix.use_default ()
 let caller = "terminal-event-test-caller"
 exception Synthetic_background_switch_closed
 
+let keeper_request keeper_name =
+  match Keeper_invocation_types.keeper_turn ~keeper_name ~prompt:"terminal event" with
+  | Ok request -> request
+  | Error reason -> fail reason
+;;
+
 let accepted_request_id = function
   | Ok
       ({ acceptance = Keeper_msg_async.Durably_accepted; request_id }
@@ -95,7 +101,7 @@ let test_operator_cancel_running_worker_invokes_on_worker_aborted () =
             ~background_sw:sw
             ~base_path
             ~caller
-            ~keeper_name:"terminal-event-operator-cancel"
+            ~request:(keeper_request "terminal-event-operator-cancel")
             ~f:(fun _request_sw ->
               f_was_called := true;
               Eio.Promise.resolve worker_started_resolver ();
@@ -164,7 +170,7 @@ let test_abort_callback_failure_does_not_fail_server_switch () =
             ~background_sw:sw
             ~base_path
             ~caller
-            ~keeper_name:"terminal-event-callback-failure"
+            ~request:(keeper_request "terminal-event-callback-failure")
             ~f:(fun _request_sw ->
               Eio.Promise.resolve worker_started_resolver ();
               Eio.Promise.await never;
@@ -215,7 +221,7 @@ let test_normal_completion_never_invokes_on_worker_aborted () =
             ~background_sw:sw
             ~base_path
             ~caller
-            ~keeper_name:"terminal-event-normal-completion"
+            ~request:(keeper_request "terminal-event-normal-completion")
             ~f:(fun _request_sw -> Keeper_types_profile.tool_result_ok "ok")
             ()
           |> accepted_request_id
@@ -244,7 +250,7 @@ let test_acceptance_failure_prevents_worker_start () =
             ~background_sw:sw
             ~base_path
             ~caller
-            ~keeper_name:"terminal-event-acceptance-failure"
+            ~request:(keeper_request "terminal-event-acceptance-failure")
             ~f:(fun _request_sw ->
               worker_called := true;
               Keeper_types_profile.tool_result_ok "unreachable")
@@ -293,7 +299,7 @@ let test_closed_background_switch_rejects_worker_acceptance () =
                     ~background_sw:sw
                     ~base_path
                     ~caller
-                    ~keeper_name:"terminal-event-closed-background-switch"
+                    ~request:(keeper_request "terminal-event-closed-background-switch")
                     ~f:(fun _request_sw ->
                       fail "worker ran on a closed background switch")
                     ())))

--- a/test/test_keeper_mutex_coverage.ml
+++ b/test/test_keeper_mutex_coverage.ml
@@ -4,6 +4,12 @@ open Masc
 let tr_ok body = Tool_result.ok ~tool_name:"keeper-test" ~start_time:0.0 body
 let caller = "keeper-msg-test-caller"
 
+let keeper_request ?(prompt = "test invocation") keeper_name =
+  match Keeper_invocation_types.keeper_turn ~keeper_name ~prompt with
+  | Ok request -> request
+  | Error reason -> Alcotest.fail reason
+;;
+
 let accepted_request_id = function
   | Ok
       ({ acceptance = Keeper_msg_async.Durably_accepted; request_id }
@@ -179,7 +185,7 @@ let test_keeper_msg_async_roundtrip () =
       ~background_sw:sw
       ~base_path
       ~caller
-      ~keeper_name:"alpha.with.dot"
+      ~request:(keeper_request ~prompt:"durable dotted request" "alpha.with.dot")
       ~f:(fun _request_sw ->
         Eio.Fiber.yield ();
         tr_ok (Yojson.Safe.to_string (`Assoc [ "kind", `String "done" ])))
@@ -193,7 +199,11 @@ let test_keeper_msg_async_roundtrip () =
     (Fs_compat.realpath base_path)
     entry.base_path;
   Alcotest.(check string) "dotted keeper name accepted" "alpha.with.dot"
-    entry.keeper_name;
+    (Keeper_invocation_types.request_target_name entry.request);
+  Alcotest.(check string)
+    "prompt persisted in typed request"
+    "durable dotted request"
+    (Keeper_invocation_types.request_prompt entry.request);
   Alcotest.(check bool)
     "request completed"
     true
@@ -241,7 +251,7 @@ let test_keeper_msg_async_list_isolates_base_paths () =
       ~background_sw:sw
       ~base_path
       ~caller
-      ~keeper_name
+      ~request:(keeper_request keeper_name)
       ~f:(fun _request_sw ->
         Eio.Promise.await release;
         tr_ok "{}")
@@ -279,7 +289,7 @@ let test_keeper_msg_async_recovers_done_from_disk () =
       ~background_sw:sw
       ~base_path
       ~caller
-      ~keeper_name:"beta"
+      ~request:(keeper_request "beta")
       ~f:(fun _request_sw ->
         Eio.Fiber.yield ();
         Tool_result.make_ok
@@ -340,7 +350,7 @@ let test_keeper_msg_async_survives_submitter_turn_switch () =
         ~background_sw:root_sw
         ~base_path
         ~caller
-        ~keeper_name:"root-lifetime"
+        ~request:(keeper_request "root-lifetime")
         ~f:(fun request_sw ->
           Atomic.set request_switch_is_turn_switch (request_sw == turn_sw);
           Eio.Promise.resolve resolve_worker_started ();
@@ -400,7 +410,7 @@ let test_keeper_msg_async_does_not_accept_failed_initial_persistence () =
            ~background_sw
            ~base_path
            ~caller
-           ~keeper_name:"initial-persist-failure"
+           ~request:(keeper_request "initial-persist-failure")
            ~f:(fun _request_sw ->
              Atomic.set worker_ran true;
              tr_ok "{}")
@@ -483,7 +493,7 @@ let test_keeper_msg_async_request_id_collision_uses_reservation_index () =
               ~background_sw:sw
               ~base_path
               ~caller
-              ~keeper_name:"reservation-first"
+              ~request:(keeper_request "reservation-first")
               ~f:(fun _ -> tr_ok "{}")
               ()));
        Fun.protect
@@ -496,7 +506,7 @@ let test_keeper_msg_async_request_id_collision_uses_reservation_index () =
                 ~background_sw:sw
                 ~base_path
                 ~caller
-                ~keeper_name:"reservation-second"
+                ~request:(keeper_request "reservation-second")
                 ~f:(fun _ -> tr_ok "{}")
                 ()
               |> accepted_request_id
@@ -549,7 +559,7 @@ let test_keeper_msg_async_initial_post_publish_failure_rolls_back () =
            ~background_sw
            ~base_path
            ~caller
-           ~keeper_name:"initial-rollback"
+           ~request:(keeper_request "initial-rollback")
            ~f:(fun _request_sw ->
              Atomic.set worker_ran true;
              tr_ok "{}")
@@ -594,7 +604,7 @@ let test_keeper_msg_async_initial_rollback_failure_preserves_request_id () =
            ~background_sw
            ~base_path
            ~caller
-           ~keeper_name:"initial-uncertain"
+           ~request:(keeper_request "initial-uncertain")
            ~f:(fun _request_sw ->
              Atomic.set worker_ran true;
              tr_ok "{}")
@@ -622,7 +632,7 @@ let test_keeper_msg_async_initial_rollback_failure_preserves_request_id () =
              ~background_sw
              ~base_path
              ~caller
-             ~keeper_name:"initial-uncertain"
+             ~request:(keeper_request "initial-uncertain")
              ~f:(fun _request_sw -> tr_ok "{}")
              ()
            |> accepted_request_id
@@ -674,7 +684,7 @@ let test_keeper_msg_async_running_double_write_failure_is_terminal_in_memory () 
            ~background_sw
            ~base_path
            ~caller
-           ~keeper_name:"running-double-write-failure"
+           ~request:(keeper_request "running-double-write-failure")
            ~f:(fun _request_sw ->
              Atomic.set worker_ran true;
              tr_ok "{}")
@@ -732,7 +742,7 @@ let test_keeper_msg_async_running_write_failure_projects_durable_marker_once () 
            ~background_sw
            ~base_path
            ~caller
-           ~keeper_name:"running-write-failure"
+           ~request:(keeper_request "running-write-failure")
            ~f:(fun _request_sw ->
              Atomic.set worker_ran true;
              tr_ok "{}")
@@ -786,7 +796,7 @@ let test_keeper_msg_async_marks_recovered_inflight_lost () =
       ~background_sw:sw
       ~base_path
       ~caller
-      ~keeper_name:"gamma"
+      ~request:(keeper_request "gamma")
       ~f:(fun _request_sw ->
         Eio.Promise.await promise;
         tr_ok "{}")
@@ -846,7 +856,7 @@ let test_keeper_msg_async_recovery_sweep_marks_only_disk_only_inflight_lost () =
       ~background_sw:sw
       ~base_path
       ~caller
-      ~keeper_name:"sweep"
+      ~request:(keeper_request "sweep")
       ~f:(fun _request_sw ->
         Eio.Promise.await promise;
         tr_ok "{}")
@@ -914,7 +924,7 @@ let test_keeper_msg_async_marks_cancelled_worker_cancelled () =
         ~background_sw:sw
         ~base_path
         ~caller
-        ~keeper_name:"cancelled"
+        ~request:(keeper_request "cancelled")
         ~f:(fun _request_sw ->
           Eio.Promise.await never;
           tr_ok "{}")
@@ -949,7 +959,7 @@ let test_keeper_msg_async_operator_cancel_is_terminal_cancelled () =
       ~background_sw:sw
       ~base_path
       ~caller
-      ~keeper_name:"operator-cancelled"
+      ~request:(keeper_request "operator-cancelled")
       ~f:(fun _request_sw ->
         Eio.Promise.await never;
         tr_ok "{}")
@@ -1025,7 +1035,7 @@ let test_keeper_msg_async_live_cancel_signals_after_post_publish_failure () =
            ~background_sw:sw
            ~base_path
            ~caller
-           ~keeper_name:"live-cancel-volatile"
+           ~request:(keeper_request "live-cancel-volatile")
            ~f:(fun _request_sw ->
              Eio.Promise.await never;
              tr_ok "{}")
@@ -1087,7 +1097,7 @@ let test_keeper_msg_async_explicit_cancel_retries_failed_worker_signal () =
            ~background_sw:sw
            ~base_path
            ~caller
-           ~keeper_name:"cancel-signal-retry"
+           ~request:(keeper_request "cancel-signal-retry")
            ~f:(fun _request_sw ->
              Eio.Promise.await never;
              tr_ok "{}")
@@ -1152,7 +1162,7 @@ let test_keeper_msg_async_terminal_record_is_durable_without_age_eviction () =
       ~background_sw:sw
       ~base_path
       ~caller
-      ~keeper_name:"delta"
+      ~request:(keeper_request "delta")
       ~f:(fun _request_sw ->
         Eio.Fiber.yield ();
         tr_ok "{}")
@@ -1251,7 +1261,7 @@ let request_record_json ?(keeper_name = "recovery-test") ?(submitted_at = 1.0)
   `Assoc
     ([ "schema_version", `Int Keeper_msg_async.For_testing.record_schema_version
      ; "request_id", `String request_id
-     ; "keeper_name", `String keeper_name
+     ; "request", Keeper_invocation_types.request_to_json (keeper_request keeper_name)
      ; "base_path", `String (Fs_compat.realpath base_path)
      ; "submitted_by", `String caller
      ; "status", `String status
@@ -1517,7 +1527,8 @@ let test_keeper_msg_async_integrity_conflict_projects_canonical_terminal () =
                     && Atomic.compare_and_set inject_terminal true false ->
                write_request_record
                  ~location:Terminal_record
-                 ~keeper_name:running.Keeper_msg_async.keeper_name
+                 ~keeper_name:
+                   (Keeper_invocation_types.request_target_name running.request)
                  ~submitted_at:running.submitted_at
                  ~base_path
                  ~request_id
@@ -1540,7 +1551,7 @@ let test_keeper_msg_async_integrity_conflict_projects_canonical_terminal () =
            ~background_sw:sw
            ~base_path
            ~caller
-           ~keeper_name:"canonical-integrity-settlement"
+           ~request:(keeper_request "canonical-integrity-settlement")
            ~f:(fun _request_sw ->
              Eio.Promise.await release;
              tr_ok {|{"worker":"result"}|})
@@ -1636,7 +1647,7 @@ let test_keeper_msg_async_integrity_ambiguity_projects_exact_poll_error () =
            ~background_sw:sw
            ~base_path
            ~caller
-           ~keeper_name:"integrity-projection-error"
+           ~request:(keeper_request "integrity-projection-error")
            ~f:(fun _request_sw ->
              Eio.Promise.await release;
              tr_ok "{}")
@@ -2293,21 +2304,21 @@ let test_keeper_persistence_claim_is_one_shot_for_process () =
        | Ok _ -> Alcotest.fail "second startup owner mutated claimed persistence")
 ;;
 
-let test_keeper_msg_async_rejects_v2_record_without_compatibility () =
+let test_keeper_msg_async_rejects_v3_record_without_compatibility () =
   with_eio_env
   @@ fun _env ->
-  let base_path = temp_dir "keeper-msg-reject-v2-" in
+  let base_path = temp_dir "keeper-msg-reject-v3-" in
   Fun.protect
     ~finally:(fun () -> rm_rf base_path)
     (fun () ->
-       let request_id = "kmsg_unsupported_v2_0_0" in
+       let request_id = "kmsg_unsupported_v3_0_0" in
        write_disk_record
          ~location:Active_record
          ~base_path
          ~request_id
          (Yojson.Safe.to_string
             (`Assoc
-                [ "schema_version", `Int 2
+                [ "schema_version", `Int 3
                 ; "request_id", `String request_id
                 ; "keeper_name", `String "alpha"
                 ; "base_path", `String (Fs_compat.realpath base_path)
@@ -2320,20 +2331,20 @@ let test_keeper_msg_async_rejects_v2_record_without_compatibility () =
           Alcotest.(check bool) "schema rejection is explicit" true
             (String.length reason > 0)
         | Keeper_msg_async.Found _ ->
-          Alcotest.fail "unsupported v2 record was decoded"
+          Alcotest.fail "unsupported v3 record was decoded"
         | Keeper_msg_async.Absent ->
-          Alcotest.fail "unsupported v2 evidence was hidden"
+          Alcotest.fail "unsupported v3 evidence was hidden"
         | Keeper_msg_async.Rejected _ ->
           Alcotest.fail "unsupported persisted schema was classified as caller input");
        let report =
          Keeper_msg_async.For_testing.recover_lost_disk_records ~base_path ()
        in
-       Alcotest.(check int) "unsupported v2 is reported unreadable" 1
+       Alcotest.(check int) "unsupported v3 is reported unreadable" 1
          report.unreadable;
        let active_path =
          require_record_path ~location:Active_record ~base_path ~request_id
        in
-       Alcotest.(check bool) "unsupported v2 evidence is preserved" true
+       Alcotest.(check bool) "unsupported v3 evidence is preserved" true
          (Sys.file_exists active_path))
 ;;
 
@@ -2397,7 +2408,7 @@ let test_keeper_msg_async_load_record_missing_status_is_unreadable () =
             (`Assoc
                 [ "schema_version", `Int Keeper_msg_async.For_testing.record_schema_version
                 ; "request_id", `String request_id
-                ; "keeper_name", `String "alpha"
+                ; "request", Keeper_invocation_types.request_to_json (keeper_request "alpha")
                 ; "base_path", `String (Fs_compat.realpath base_path)
                 ; "submitted_by", `String caller
                 ; "submitted_at", `Float 1.0
@@ -2428,7 +2439,7 @@ let test_keeper_msg_async_load_record_unknown_status_is_unreadable () =
             (`Assoc
                 [ "schema_version", `Int Keeper_msg_async.For_testing.record_schema_version
                 ; "request_id", `String request_id
-                ; "keeper_name", `String "alpha"
+                ; "request", Keeper_invocation_types.request_to_json (keeper_request "alpha")
                 ; "base_path", `String (Fs_compat.realpath base_path)
                 ; "submitted_by", `String caller
                 ; "status", `String "sideways"
@@ -2460,7 +2471,7 @@ let test_keeper_msg_async_rejects_filename_request_id_mismatch () =
             (`Assoc
                 [ "schema_version", `Int Keeper_msg_async.For_testing.record_schema_version
                 ; "request_id", `String "kmsg_different_id_0_0"
-                ; "keeper_name", `String "alpha"
+                ; "request", Keeper_invocation_types.request_to_json (keeper_request "alpha")
                 ; "base_path", `String (Fs_compat.realpath base_path)
                 ; "submitted_by", `String caller
                 ; "status", `String "queued"
@@ -2698,9 +2709,9 @@ let () =
             `Quick
             test_keeper_msg_async_load_record_absent_id
         ; test_case
-            "v2 request record is rejected without compatibility"
+            "v3 request record is rejected without compatibility"
             `Quick
-            test_keeper_msg_async_rejects_v2_record_without_compatibility
+            test_keeper_msg_async_rejects_v3_record_without_compatibility
         ; test_case
             "load_record corrupt JSON is Unreadable"
             `Quick

--- a/test/test_keeper_unified_turn_event_bus.ml
+++ b/test/test_keeper_unified_turn_event_bus.ml
@@ -241,6 +241,12 @@ let temp_dir prefix =
 
 let keeper_msg_caller = "event-bus-test-caller"
 
+let durable_request keeper_name =
+  match Keeper_invocation_types.keeper_turn ~keeper_name ~prompt:"projection" with
+  | Ok request -> request
+  | Error reason -> Alcotest.fail reason
+;;
+
 let wait_for_done ~clock ~base_path request_id =
   let rec loop remaining =
     match Kmsg.poll ~base_path ~caller:keeper_msg_caller request_id with
@@ -327,7 +333,7 @@ let require_unique_assoc label = function
 let test_keeper_invocation_result_contracts () =
   let entry : Kmsg.entry =
     { request_id = "kmsg-entry-projection"
-    ; keeper_name = "projection-keeper"
+    ; request = durable_request "projection-keeper"
     ; base_path = "/projection/base"
     ; submitted_by = "projection-caller"
     ; status = Kmsg.Running
@@ -423,7 +429,7 @@ let test_typed_keeper_invocation_wire_contract () =
   in
   let entry : Kmsg.entry =
     { request_id = "typed-run-ref"
-    ; keeper_name = "projection-keeper"
+    ; request = durable_request "projection-keeper"
     ; base_path = "/projection/base"
     ; submitted_by = "projection-caller"
     ; status = Kmsg.Running


### PR DESCRIPTION
## What

- make the current Keeper invocation an immutable typed request: target, capability, and prompt input
- persist that request as the durable `Keeper_msg_async` identity instead of duplicating `keeper_name` outside the closure-owned prompt
- hard-cut request records to schema v4; v3 is explicitly unreadable and preserved, with no migration or fallback decoder
- derive the Keeper lane key from the typed target and make direct-delivery terminal proof bind both target and prompt

## Boundary

This slice intentionally models only the executor that exists today: `Keeper + Invoke_turn + Prompt`. It does not publish Agent/Model/Tool/Fusion/Heterogeneous constructors before their executable adapters exist.

Stacked on #24642. Restart replay and typed lease ownership follow in C2.

## Verification

- `ocamlformat --check` on all 11 touched OCaml files
- `git diff --check`
- 390 changed lines (`262 + 128`)
- focused wrapper build attempted: `scripts/dune-local.sh build test/test_keeper_mutex_coverage.exe`
  - wrapper exited 75 because an unrelated bare `dune build lib/ test/deps/` process is active in the root checkout
  - that process was not interrupted; full build remains CI authority
