### PR TITLE
fix(keeper): make lifecycle locking Eio-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - Removed the unused permissive `Activity_feed` JSON decoder surface; the live activity API remains encode-only and its filesystem aggregation, ordering, limit, and agent-filter contracts now have dedicated regression coverage (#23960).
 
 ### Fixed
+- Keeper lifecycle reservations now use cooperative cross-context locking, so
+  TOML reconciliation can suspend during durable persistence without a second
+  Eio fiber re-locking the same OS-thread mutex.
 - Auto Judge requests now persist the exact outer-turn causal context without interpreting it, and durable retryable judgments resume on an accepted provider attempt rather than waiting for a server restart.
 - Keeper Gate state now has a BasePath-derived `.masc/gate/` owner. A corrupt optional Always Allowed rule store degrades only exact-rule lookup, while Chat persistence/read failures remain local to Chat and no longer close unrelated Keeper lanes.
 - Prompt overrides now persist in a schema-versioned envelope bound to the SHA256 revision of each prompt body and template-variable contract. Legacy or malformed files and contract-drifted entries fail closed with observable fallback, writes use atomic replacement, and dashboard set/clear mutations commit to memory only after persistence succeeds.

--- a/lib/core/cross_context_mutex.ml
+++ b/lib/core/cross_context_mutex.ml
@@ -1,0 +1,29 @@
+type t =
+  { eio_gate : Eio.Mutex.t
+  ; cross_context_mutex : Stdlib.Mutex.t
+  }
+
+let create () =
+  { eio_gate = Eio.Mutex.create ()
+  ; cross_context_mutex = Stdlib.Mutex.create ()
+  }
+;;
+
+let rec lock_cooperatively mutex =
+  if Stdlib.Mutex.try_lock mutex
+  then ()
+  else (
+    Eio.Fiber.yield ();
+    lock_cooperatively mutex)
+;;
+
+let with_lock t f =
+  match Eio_guard.execution_context () with
+  | Eio_guard.Non_eio -> Stdlib.Mutex.protect t.cross_context_mutex f
+  | Eio_guard.Eio_fiber ->
+    Eio.Mutex.use_ro t.eio_gate (fun () ->
+      lock_cooperatively t.cross_context_mutex;
+      Fun.protect
+        ~finally:(fun () -> Stdlib.Mutex.unlock t.cross_context_mutex)
+        f)
+;;

--- a/lib/core/cross_context_mutex.ml
+++ b/lib/core/cross_context_mutex.ml
@@ -14,7 +14,7 @@ let rec lock_cooperatively mutex =
   then ()
   else (
     Eio.Fiber.yield ();
-    lock_cooperatively mutex)
+    (lock_cooperatively [@tailcall]) mutex)
 ;;
 
 let with_lock t f =

--- a/lib/core/cross_context_mutex.mli
+++ b/lib/core/cross_context_mutex.mli
@@ -1,0 +1,12 @@
+(** Cooperative mutual exclusion shared by Eio fibers and non-Eio callers. *)
+
+type t
+
+val create : unit -> t
+
+val with_lock : t -> (unit -> 'a) -> 'a
+(** Serialize [f] across Eio fibers, system threads, and Domains.
+
+    Eio waiters yield cooperatively instead of blocking their Domain on the
+    underlying Stdlib mutex. Cancellation and callback exceptions always
+    release both gates before propagating. *)

--- a/lib/core/dune
+++ b/lib/core/dune
@@ -17,6 +17,7 @@
   common
   validation
   circuit_breaker
+  cross_context_mutex
   eio_guard
   executor_pool_ref
   domain_pool

--- a/lib/keeper/keeper_lifecycle_reservation.ml
+++ b/lib/keeper/keeper_lifecycle_reservation.ml
@@ -35,7 +35,7 @@ module Lock_table = Ephemeron.K1.Make (Lock_key)
 
 type lock_entry =
   { key : string
-  ; mutex : Mutex.t
+  ; mutex : Cross_context_mutex.t
   }
 
 (* No fleet-size guess or TTL belongs at this boundary. The entry keeps its
@@ -66,7 +66,7 @@ let lock_for_key key =
     match Lock_table.find_opt key_locks key with
     | Some entry -> entry
     | None ->
-      let entry = { key; mutex = Mutex.create () } in
+      let entry = { key; mutex = Cross_context_mutex.create () } in
       Lock_table.add key_locks key entry;
       entry)
 ;;
@@ -74,7 +74,7 @@ let lock_for_key key =
 let with_key_lock ~base_path ~keeper_name f =
   let key = canonical_key ~base_path ~keeper_name in
   let entry = lock_for_key key in
-  Mutex.protect entry.mutex (fun () ->
+  Cross_context_mutex.with_lock entry.mutex (fun () ->
     ignore entry.key;
     f ())
 ;;

--- a/lib/keeper/keeper_lifecycle_reservation.mli
+++ b/lib/keeper/keeper_lifecycle_reservation.mli
@@ -45,8 +45,9 @@ val owner_id : token -> string
 val expected_generation : token -> int
 val release : token -> release_outcome
 
-(** Serialize one ownership check plus authority mutation for this keeper key.
-    This is a per-keeper mutex, never a fleet-wide lock. *)
+(** Serialize one ownership check plus authority mutation for this keeper key
+    across Eio fibers and non-Eio callers. This is a per-keeper cooperative
+    mutex, never a fleet-wide lock. *)
 val with_key_lock :
   base_path:string ->
   keeper_name:string ->

--- a/test/dune
+++ b/test/dune
@@ -324,6 +324,7 @@
   test_keeper_turn_fsm_emit
   test_keeper_event_queue
   test_keeper_event_queue_owner_lock
+  test_cross_context_mutex
   test_keeper_event_queue_persist_poison
   test_workspace_routes_keeper
   test_workspace_tree_exclusions
@@ -647,6 +648,7 @@
   test_keeper_turn_fsm_emit
   test_keeper_event_queue
   test_keeper_event_queue_owner_lock
+  test_cross_context_mutex
   test_keeper_event_queue_persist_poison
   test_workspace_routes_keeper
   test_workspace_tree_exclusions

--- a/test/test_cross_context_mutex.ml
+++ b/test/test_cross_context_mutex.ml
@@ -1,0 +1,103 @@
+module Lock = Cross_context_mutex
+
+let rec await_atomic flag =
+  if Atomic.get flag
+  then ()
+  else (
+    Eio.Fiber.yield ();
+    await_atomic flag)
+;;
+
+let await_atomic_in_domain flag =
+  while not (Atomic.get flag) do
+    Domain.cpu_relax ()
+  done
+;;
+
+let test_eio_waiter_yields_until_owner_releases () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun sw ->
+  let lock = Lock.create () in
+  let owner_entered, resolve_owner_entered = Eio.Promise.create () in
+  let release_owner, resolve_release_owner = Eio.Promise.create () in
+  let waiter_attempted = Atomic.make false in
+  let waiter_entered = Atomic.make false in
+  let waiter_done, resolve_waiter_done = Eio.Promise.create () in
+  Eio.Fiber.fork ~sw (fun () ->
+    Lock.with_lock lock (fun () ->
+      Eio.Promise.resolve resolve_owner_entered ();
+      Eio.Promise.await release_owner));
+  Eio.Promise.await owner_entered;
+  Eio.Fiber.fork ~sw (fun () ->
+    Atomic.set waiter_attempted true;
+    Lock.with_lock lock (fun () -> Atomic.set waiter_entered true);
+    Eio.Promise.resolve resolve_waiter_done ());
+  await_atomic waiter_attempted;
+  Eio.Fiber.yield ();
+  Alcotest.(check bool) "same lock remains serialized" false (Atomic.get waiter_entered);
+  Eio.Promise.resolve resolve_release_owner ();
+  Eio.Promise.await waiter_done;
+  Alcotest.(check bool) "waiter enters after release" true (Atomic.get waiter_entered)
+;;
+
+let test_domain_owner_and_eio_waiter_share_lock () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun sw ->
+  let lock = Lock.create () in
+  let independent = Lock.create () in
+  let owner_entered = Atomic.make false in
+  let release_owner = Atomic.make false in
+  let waiter_attempted = Atomic.make false in
+  let waiter_entered = Atomic.make false in
+  let holder =
+    Domain.spawn (fun () ->
+      Lock.with_lock lock (fun () ->
+        Atomic.set owner_entered true;
+        await_atomic_in_domain release_owner))
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      Atomic.set release_owner true;
+      Domain.join holder)
+    (fun () ->
+       await_atomic owner_entered;
+       let waiter_done, resolve_waiter_done = Eio.Promise.create () in
+       Eio.Fiber.fork ~sw (fun () ->
+         Atomic.set waiter_attempted true;
+         Lock.with_lock lock (fun () -> Atomic.set waiter_entered true);
+         Eio.Promise.resolve resolve_waiter_done ());
+       await_atomic waiter_attempted;
+       Eio.Fiber.yield ();
+       Alcotest.(check bool)
+         "Eio waiter does not re-lock Domain-owned mutex"
+         false
+         (Atomic.get waiter_entered);
+       Lock.with_lock independent (fun () -> ());
+       Atomic.set release_owner true;
+       Eio.Promise.await waiter_done;
+       Alcotest.(check bool) "waiter enters after Domain release" true
+         (Atomic.get waiter_entered))
+;;
+
+let test_exception_does_not_poison_lock () =
+  Eio_main.run @@ fun _env ->
+  let lock = Lock.create () in
+  (match Lock.with_lock lock (fun () -> raise Exit) with
+   | _ -> Alcotest.fail "expected callback exception"
+   | exception Exit -> ());
+  Alcotest.(check int) "lock is reusable" 42 (Lock.with_lock lock (fun () -> 42))
+;;
+
+let () =
+  Alcotest.run
+    "cross-context-mutex"
+    [ ( "serialization"
+      , [ Alcotest.test_case "Eio waiter yields" `Quick
+            test_eio_waiter_yields_until_owner_releases
+        ; Alcotest.test_case "Domain owner excludes Eio waiter" `Quick
+            test_domain_owner_and_eio_waiter_share_lock
+        ; Alcotest.test_case "callback exception releases lock" `Quick
+            test_exception_does_not_poison_lock
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary
- add a typed cross-context mutex that cooperatively serializes Eio fibers with Domain/non-Eio callers
- replace the per-Keeper lifecycle reservation Stdlib.Mutex critical section that spans suspendable persistence
- preserve lane-per-Keeper independence with ephemeron-keyed lock ownership
- compiler-enforce stack-bounded cooperative acquisition with OCaml `[@tailcall]`
- add deterministic Eio/Eio, Domain/Eio, independent-lock, and exception-release tests

## Root cause
TOML reconcile held a `Stdlib.Mutex` while `File_lock_eio`/`Eio.Path` could suspend. Another fiber on the same Domain then re-entered the OS-thread mutex and raised `Sys_error("Mutex.lock: Resource deadlock avoided")`.

## Validation
- `ocamlformat --check` on touched OCaml files
- `ocamlc -stop-after parsing lib/core/cross_context_mutex.ml`
- `git diff --check`
- `scripts/dune-local.sh build test/test_cross_context_mutex.exe`
- `_build/default/test/test_cross_context_mutex.exe` — 3 tests passed in 0.003s
