### PR TITLE
fix(keeper): resume owner lane after overflow compaction

### DIFF
--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -103,6 +103,15 @@ type compaction_evidence =
   ; after_tool_result_count : int
   }
 
+type compaction_receipt =
+  { operation_id : string
+  ; source_session_id : string
+  ; source_generation : int
+  ; source_turn_count : int
+  ; trigger : Compaction_trigger.t
+  ; evidence : compaction_evidence
+  }
+
 let compaction_evidence_to_json evidence =
   `Assoc
     [ "before_checkpoint_bytes", `Int evidence.before_checkpoint_bytes
@@ -116,6 +125,237 @@ let compaction_evidence_to_json evidence =
     ; "before_tool_result_count", `Int evidence.before_tool_result_count
     ; "after_tool_result_count", `Int evidence.after_tool_result_count
     ]
+;;
+
+let compaction_receipt_context_key = "masc_compaction_receipt_v1"
+
+let compaction_operation_id
+      ~source_session_id
+      ~source_generation
+      ~source_turn_count
+      ~trigger
+  =
+  let identity =
+    `Assoc
+      [ "schema_version", `Int 1
+      ; "source_session_id", `String source_session_id
+      ; "source_generation", `Int source_generation
+      ; "source_turn_count", `Int source_turn_count
+      ; "trigger", Compaction_trigger.to_detail_json trigger
+      ]
+    |> Yojson.Safe.to_string
+  in
+  "compaction:" ^ Digestif.SHA256.(digest_string identity |> to_hex)
+;;
+
+let compaction_receipt_to_json receipt =
+  `Assoc
+    [ "schema_version", `Int 1
+    ; "operation_id", `String receipt.operation_id
+    ; "source_session_id", `String receipt.source_session_id
+    ; "source_generation", `Int receipt.source_generation
+    ; "source_turn_count", `Int receipt.source_turn_count
+    ; "trigger", Compaction_trigger.to_detail_json receipt.trigger
+    ; ( "selected_runtime_id"
+      , Json_util.string_opt_to_json receipt.evidence.selected_runtime_id )
+    ; "evidence", compaction_evidence_to_json receipt.evidence
+    ]
+;;
+
+let compaction_receipt_of_json json =
+  let ( let* ) = Result.bind in
+  let required name fields =
+    match List.assoc_opt name fields with
+    | Some value -> Ok value
+    | None -> Error (Printf.sprintf "compaction receipt missing %s" name)
+  in
+  let int_value name = function
+    | `Int value when value >= 0 -> Ok value
+    | _ -> Error (Printf.sprintf "compaction receipt %s must be a non-negative integer" name)
+  in
+  let string_value name = function
+    | `String value when not (String.equal value "") -> Ok value
+    | _ -> Error (Printf.sprintf "compaction receipt %s must be a non-empty string" name)
+  in
+  let selected_runtime_id = function
+    | `Null -> Ok None
+    | `String value when not (String.equal value "") -> Ok (Some value)
+    | _ -> Error "compaction receipt selected_runtime_id must be null or a non-empty string"
+  in
+  let validate_fields ~surface ~allowed fields =
+    let keys = List.map fst fields in
+    match
+      List.find_opt
+        (fun key -> List.length (List.filter (String.equal key) keys) > 1)
+        keys
+    with
+    | Some key -> Error (Printf.sprintf "%s duplicates %s" surface key)
+    | None ->
+      (match List.find_opt (fun (key, _) -> not (List.mem key allowed)) fields with
+       | Some (key, _) -> Error (Printf.sprintf "%s contains unknown %s" surface key)
+       | None -> Ok ())
+  in
+  let evidence_of_fields selected_runtime_id fields =
+    let* () =
+      validate_fields
+        ~surface:"compaction receipt evidence"
+        ~allowed:
+          [ "before_checkpoint_bytes"; "after_checkpoint_bytes"
+          ; "before_message_count"; "after_message_count"
+          ; "summarized_message_count"; "dropped_message_count"
+          ; "before_tool_use_count"; "after_tool_use_count"
+          ; "before_tool_result_count"; "after_tool_result_count"
+          ]
+        fields
+    in
+    let int_field name = Result.bind (required name fields) (int_value name) in
+    let* before_checkpoint_bytes = int_field "before_checkpoint_bytes" in
+    let* after_checkpoint_bytes = int_field "after_checkpoint_bytes" in
+    let* before_message_count = int_field "before_message_count" in
+    let* after_message_count = int_field "after_message_count" in
+    let* summarized_message_count = int_field "summarized_message_count" in
+    let* dropped_message_count = int_field "dropped_message_count" in
+    let* before_tool_use_count = int_field "before_tool_use_count" in
+    let* after_tool_use_count = int_field "after_tool_use_count" in
+    let* before_tool_result_count = int_field "before_tool_result_count" in
+    let* after_tool_result_count = int_field "after_tool_result_count" in
+    let values =
+      [ before_checkpoint_bytes; after_checkpoint_bytes; before_message_count
+      ; after_message_count; summarized_message_count; dropped_message_count
+      ; before_tool_use_count; after_tool_use_count; before_tool_result_count
+      ; after_tool_result_count
+      ]
+    in
+    if List.exists (fun value -> value < 0) values
+    then Error "compaction receipt evidence values must be non-negative"
+    else
+      Ok
+        { selected_runtime_id
+        ; before_checkpoint_bytes
+        ; after_checkpoint_bytes
+        ; before_message_count
+        ; after_message_count
+        ; summarized_message_count
+        ; dropped_message_count
+        ; before_tool_use_count
+        ; after_tool_use_count
+        ; before_tool_result_count
+        ; after_tool_result_count
+        }
+  in
+  match json with
+  | `Assoc fields ->
+    let allowed =
+      [ "schema_version"; "operation_id"; "source_session_id"
+      ; "source_generation"; "source_turn_count"; "trigger"
+      ; "selected_runtime_id"; "evidence"
+      ]
+    in
+    (match validate_fields ~surface:"compaction receipt" ~allowed fields with
+     | Error _ as error -> error
+     | Ok () ->
+          let* version =
+            Result.bind (required "schema_version" fields) (int_value "schema_version")
+          in
+          if version <> 1
+          then Error (Printf.sprintf "unsupported compaction receipt schema %d" version)
+          else (
+            let* operation_id =
+              Result.bind (required "operation_id" fields) (string_value "operation_id")
+            in
+            let* source_session_id =
+              Result.bind
+                (required "source_session_id" fields)
+                (string_value "source_session_id")
+            in
+            let* source_generation =
+              Result.bind
+                (required "source_generation" fields)
+                (int_value "source_generation")
+            in
+            let* source_turn_count =
+              Result.bind
+                (required "source_turn_count" fields)
+                (int_value "source_turn_count")
+            in
+            let* trigger_json = required "trigger" fields in
+            let* trigger =
+              match Compaction_trigger.of_detail_json trigger_json with
+              | Some trigger -> Ok trigger
+              | None -> Error "compaction receipt trigger is invalid"
+            in
+            let* selected_runtime_id_json = required "selected_runtime_id" fields in
+            let* selected_runtime_id = selected_runtime_id selected_runtime_id_json in
+            let* evidence_json = required "evidence" fields in
+            let* evidence =
+              match evidence_json with
+              | `Assoc evidence_fields -> evidence_of_fields selected_runtime_id evidence_fields
+              | _ -> Error "compaction receipt evidence must be an object"
+            in
+            let expected_operation_id =
+              compaction_operation_id
+                ~source_session_id
+                ~source_generation
+                ~source_turn_count
+                ~trigger
+            in
+            if not (String.equal operation_id expected_operation_id)
+            then Error "compaction receipt operation_id does not match its typed source"
+            else
+              Ok
+                { operation_id
+                ; source_session_id
+                ; source_generation
+                ; source_turn_count
+                ; trigger
+                ; evidence
+                }))
+  | _ -> Error "compaction receipt must be an object"
+;;
+
+let with_compaction_receipt ~generation ~trigger ~evidence ctx =
+  let checkpoint = checkpoint_of_context ctx in
+  let receipt =
+    { operation_id =
+        compaction_operation_id
+          ~source_session_id:checkpoint.session_id
+          ~source_generation:generation
+          ~source_turn_count:checkpoint.turn_count
+          ~trigger
+    ; source_session_id = checkpoint.session_id
+    ; source_generation = generation
+    ; source_turn_count = checkpoint.turn_count
+    ; trigger
+    ; evidence
+    }
+  in
+  let context = Agent_sdk.Context.copy checkpoint.context in
+  Agent_sdk.Context.set_scoped
+    context
+    Agent_sdk.Context.Session
+    compaction_receipt_context_key
+    (compaction_receipt_to_json receipt);
+  { ctx with checkpoint = { checkpoint with context } }, receipt
+;;
+
+let compaction_receipt_for_request ~checkpoint ~generation ~trigger =
+  match
+    Agent_sdk.Context.get_scoped
+      checkpoint.Agent_sdk.Checkpoint.context
+      Agent_sdk.Context.Session
+      compaction_receipt_context_key
+  with
+  | None -> Ok None
+  | Some json ->
+    (match compaction_receipt_of_json json with
+     | Error _ as error -> error
+     | Ok receipt ->
+       if String.equal receipt.source_session_id checkpoint.session_id
+          && receipt.source_generation = generation
+          && receipt.source_turn_count = checkpoint.turn_count
+          && receipt.trigger = trigger
+       then Ok (Some receipt)
+       else Ok None)
 ;;
 
 type compaction_preparation =

--- a/lib/keeper/keeper_compact_policy.mli
+++ b/lib/keeper/keeper_compact_policy.mli
@@ -37,11 +37,33 @@ type compaction_evidence =
   ; before_tool_result_count : int
   ; after_tool_result_count : int
   }
+
+type compaction_receipt =
+  { operation_id : string
+  ; source_session_id : string
+  ; source_generation : int
+  ; source_turn_count : int
+  ; trigger : Compaction_trigger.t
+  ; evidence : compaction_evidence
+  }
 (** Exact structural evidence from the LLM-selected plan. Byte, message, and
     tool-block counts are measured from the actual checkpoint on both sides;
     no token estimate is synthesized. *)
 
 val compaction_evidence_to_json : compaction_evidence -> Yojson.Safe.t
+
+val with_compaction_receipt :
+  generation:int ->
+  trigger:Compaction_trigger.t ->
+  evidence:compaction_evidence ->
+  Keeper_types.working_context ->
+  Keeper_types.working_context * compaction_receipt
+
+val compaction_receipt_for_request :
+  checkpoint:Agent_sdk.Checkpoint.t ->
+  generation:int ->
+  trigger:Compaction_trigger.t ->
+  (compaction_receipt option, string) result
 (** Lossless wire projection shared by every MASC compaction producer. *)
 
 type compaction_preparation =

--- a/lib/keeper/keeper_context_runtime.ml
+++ b/lib/keeper/keeper_context_runtime.ml
@@ -109,6 +109,7 @@ type overflow_retry_recovery = Keeper_post_turn.overflow_retry_recovery = {
   checkpoint : Agent_sdk.Checkpoint.t;
   compaction : compaction_event;
   evidence : Keeper_compact_policy.compaction_evidence;
+  operation_id : string;
   turn_generation : int;
 }
 

--- a/lib/keeper/keeper_context_runtime.mli
+++ b/lib/keeper/keeper_context_runtime.mli
@@ -112,6 +112,7 @@ type overflow_retry_recovery =
   { checkpoint : Agent_sdk.Checkpoint.t
   ; compaction : compaction_event
   ; evidence : Keeper_compact_policy.compaction_evidence
+  ; operation_id : string
   ; turn_generation : int
   }
 

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -265,6 +265,9 @@ let settlement_of_failure ~settled_at failure =
   | Keeper_unified_turn.Requeue_after_context_compaction ->
     Keeper_registry_event_queue.Requeue
       Keeper_registry_event_queue.Context_compaction_retry
+  | Keeper_unified_turn.Defer_after_context_compaction_failure ->
+    Keeper_registry_event_queue.Requeue
+      Keeper_registry_event_queue.Context_compaction_retry
   | Keeper_unified_turn.Follow_failure_route ->
     (match failure.Keeper_unified_turn.route with
      | Keeper_runtime_failure_route.Retry_after_observed _ ->
@@ -285,6 +288,55 @@ let settlement_of_failure ~settled_at failure =
                   provenance
                   detail)
          })
+;;
+
+let resume_owner_lane_after_context_compaction ~base_path ~keeper_name = function
+  | Some
+      (Cycle.Failed
+        { failure =
+            { Keeper_unified_turn.source_lease_disposition =
+                Keeper_unified_turn.Requeue_after_context_compaction
+            ; _
+            }
+        ; _
+        }) ->
+    let outcome =
+      Keeper_registry.wakeup
+        ~intent:Keeper_registry.Compaction_signal
+        ~base_path
+        keeper_name
+    in
+    (match outcome with
+     | Keeper_registry.Signaled ->
+       Log.Keeper.info
+         ~keeper_name
+         "provider overflow compaction settled; owner lane resume signaled"
+     | Keeper_registry.Deferred_unregistered ->
+       Log.Keeper.warn
+         ~keeper_name
+         "provider overflow compaction settled but owner lane is unregistered"
+     | Keeper_registry.Deferred_not_running phase ->
+       Log.Keeper.warn
+         ~keeper_name
+         "provider overflow compaction settled but owner lane phase=%s"
+         (Keeper_state_machine.phase_to_string phase)
+     | Keeper_registry.Deferred_lifecycle denial ->
+       Log.Keeper.warn
+         ~keeper_name
+         "provider overflow compaction settled but owner lane lifecycle=%s"
+         (Keeper_lifecycle_admission.autonomous_denial_to_wire denial));
+    Some outcome
+  | Some
+      ( Cycle.Failed _
+      | Cycle.Completed _
+      | Cycle.Cancelled _
+      | Cycle.Skipped _
+      | Cycle.Busy _
+      | Cycle.Judgment_settled _
+      | Cycle.Manual_compaction_failed _
+      | Cycle.Manual_compaction_applied _ )
+  | None ->
+    None
 ;;
 
 let single_approved_resolution lease =
@@ -764,7 +816,13 @@ let run_keepalive_unified_turn
          (match !cycle_outcome_ref with
           | Some (Cycle.Failed { failure; _ }) ->
             (match failure.Keeper_unified_turn.source_lease_disposition with
-             | Keeper_unified_turn.Requeue_after_context_compaction
+             | Keeper_unified_turn.Requeue_after_context_compaction ->
+               resume_owner_lane_after_context_compaction
+                 ~base_path:ctx.config.base_path
+                 ~keeper_name:meta_after_triage.name
+                 !cycle_outcome_ref
+               |> ignore
+             | Keeper_unified_turn.Defer_after_context_compaction_failure
              | Keeper_unified_turn.Acknowledge_after_in_turn_handling -> ()
              | Keeper_unified_turn.Follow_failure_route ->
                (match failure.Keeper_unified_turn.route with
@@ -845,6 +903,11 @@ let run_keepalive_unified_turn
              with
              | Error message -> raise (Event_queue_settlement_failed message)
              | Ok () -> ());
+            resume_owner_lane_after_context_compaction
+              ~base_path:ctx.config.base_path
+              ~keeper_name:meta_after_triage.name
+              !cycle_outcome_ref
+            |> ignore;
             if settlement_is_ack settlement
             then
               mark_connector_attention_ignored_after_turn

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -130,6 +130,15 @@ val settlement_of_failure :
     action's new typed route remains authoritative rather than being collapsed
     into a generic judgment failure. *)
 
+val resume_owner_lane_after_context_compaction :
+  base_path:string ->
+  keeper_name:string ->
+  Keeper_heartbeat_loop_cycle.cycle_outcome option ->
+  Keeper_registry.wakeup_outcome option
+(** Signal only the owner lane after a provider-overflow compaction and its
+    source settlement are durable. Failed compaction and unrelated outcomes do
+    not wake here, preventing an immediate same-lane retry loop. *)
+
 val settlement_of_cycle_outcome :
   base_path:string ->
   settled_at:float ->

--- a/lib/keeper/keeper_manual_compaction.ml
+++ b/lib/keeper/keeper_manual_compaction.ml
@@ -49,7 +49,8 @@ let append_manifest ~config ~base_dir ~(meta : keeper_meta) recovery =
            (Keeper_runtime_manifest.with_payload_role
               ~payload_role:Keeper_runtime_manifest.Checkpoint
               (`Assoc
-                [ "trigger", `String (Compaction_trigger.to_label trigger)
+                [ "operation_id", `String recovery.operation_id
+                ; "trigger", `String (Compaction_trigger.to_label trigger)
                 ; "trigger_detail", Compaction_trigger.to_detail_json trigger
                 ; ( "exact_evidence"
                   , Keeper_compact_policy.compaction_evidence_to_json recovery.evidence )

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -72,6 +72,7 @@ type overflow_retry_recovery = {
   checkpoint : Agent_sdk.Checkpoint.t;
   compaction : compaction_event;
   evidence : Keeper_compact_policy.compaction_evidence;
+  operation_id : string;
   turn_generation : int;
 } [@@warning "-69"]
 
@@ -79,6 +80,7 @@ type compaction_recovery_error =
   | Checkpoint_load_failed of Keeper_checkpoint_store.checkpoint_load_error
   | Compaction_rejected of Keeper_compact_policy.compaction_rejection
   | Compaction_evidence_missing
+  | Compaction_receipt_invalid of string
   | Unexpected_compaction_decision of Keeper_compact_policy.compaction_decision
   | Checkpoint_superseded of {
       incoming_turn_count : int;
@@ -93,6 +95,7 @@ let compaction_recovery_error_to_tag = function
   | Compaction_rejected reason ->
     Keeper_compact_policy.compaction_rejection_to_string reason
   | Compaction_evidence_missing -> "compaction_evidence_missing"
+  | Compaction_receipt_invalid _ -> "compaction_receipt_invalid"
   | Unexpected_compaction_decision _ -> "unexpected_compaction_decision"
   | Checkpoint_superseded _ -> "checkpoint_superseded"
   | Checkpoint_save_failed _ -> "checkpoint_save_failed"
@@ -111,6 +114,8 @@ let compaction_recovery_error_to_string = function
     ^ Keeper_compact_policy.compaction_rejection_to_string reason
   | Compaction_evidence_missing ->
     "prepared compaction did not carry structural evidence"
+  | Compaction_receipt_invalid detail ->
+    "invalid durable compaction receipt: " ^ detail
   | Unexpected_compaction_decision decision ->
     "unexpected compaction decision: "
     ^ Keeper_compact_policy.compaction_decision_to_string decision
@@ -623,16 +628,50 @@ let recover_latest_checkpoint_for_overflow_retry
       if turn_generation = meta.runtime.generation then meta
       else map_runtime (fun rt -> { rt with generation = turn_generation }) meta
     in
-    let preparation =
-      Keeper_compact_policy.compact_for_request_typed
-        ~meta:retry_meta
-        ~trigger
-        ctx
-    in
-    (match preparation.decision, preparation.evidence with
+    (match
+       Keeper_compact_policy.compaction_receipt_for_request
+         ~checkpoint
+         ~generation:turn_generation
+         ~trigger
+     with
+     | Error detail -> Error (Compaction_receipt_invalid detail)
+     | Ok (Some receipt) ->
+       Log.Keeper.info
+         "compaction receipt replay keeper=%s operation_id=%s"
+         retry_meta.name
+         receipt.operation_id;
+       Ok
+         { checkpoint
+         ; compaction =
+             { attempted = true
+             ; applied = true
+             ; started_dispatched = false
+             ; failure_reason = None
+             ; trigger = Some trigger
+             ; decision = Keeper_compact_policy.Applied trigger
+             }
+         ; evidence = receipt.evidence
+         ; operation_id = receipt.operation_id
+         ; turn_generation
+         }
+     | Ok None ->
+       let preparation =
+         Keeper_compact_policy.compact_for_request_typed
+           ~meta:retry_meta
+           ~trigger
+           ctx
+       in
+       (match preparation.decision, preparation.evidence with
      | Keeper_compact_policy.Prepared _, None ->
        Error Compaction_evidence_missing
      | Keeper_compact_policy.Prepared prepared_trigger, Some evidence ->
+       let prepared_context, receipt =
+         Keeper_compact_policy.with_compaction_receipt
+           ~generation:turn_generation
+           ~trigger:prepared_trigger
+           ~evidence
+           preparation.context
+       in
        (try
           match
             commit_prepared_after_save
@@ -643,7 +682,7 @@ let recover_latest_checkpoint_for_overflow_retry
                   ~keeper_name:meta.name
                   ~session
                   ~agent_name:retry_meta.agent_name
-                  ~ctx:preparation.context
+                  ~ctx:prepared_context
                   ~generation:turn_generation
                 |> checkpoint_of_save_outcome)
           with
@@ -663,6 +702,7 @@ let recover_latest_checkpoint_for_overflow_retry
                   ; decision
                   }
               ; evidence
+              ; operation_id = receipt.operation_id
               ; turn_generation
               }
           | Error
@@ -699,7 +739,7 @@ let recover_latest_checkpoint_for_overflow_retry
      | (Keeper_compact_policy.Applied _
        | Keeper_compact_policy.Not_requested
        | Keeper_compact_policy.Skipped_no_checkpoint) as decision, _ ->
-       Error (Unexpected_compaction_decision decision))
+       Error (Unexpected_compaction_decision decision)))
 
 module For_testing = struct
   let commit_prepared_after_save = commit_prepared_after_save

--- a/lib/keeper/keeper_post_turn.mli
+++ b/lib/keeper/keeper_post_turn.mli
@@ -51,6 +51,7 @@ type overflow_retry_recovery =
   { checkpoint : Agent_sdk.Checkpoint.t
   ; compaction : compaction_event
   ; evidence : Keeper_compact_policy.compaction_evidence
+  ; operation_id : string
   ; turn_generation : int
   } [@@warning "-69"]
 
@@ -58,6 +59,7 @@ type compaction_recovery_error =
   | Checkpoint_load_failed of Keeper_checkpoint_store.checkpoint_load_error
   | Compaction_rejected of Keeper_compact_policy.compaction_rejection
   | Compaction_evidence_missing
+  | Compaction_receipt_invalid of string
   | Unexpected_compaction_decision of Keeper_compact_policy.compaction_decision
   | Checkpoint_superseded of
       { incoming_turn_count : int

--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -381,7 +381,7 @@ let decision_public_allowlist =
     ; "media_dropped_total"; "media_dropped_counts"
     ; "payload_role"; "trigger"; "trigger_detail"; "kind"; "limit_tokens"
     ; "ratio"; "threshold"; "count"
-    ; "source_requeued"; "exact_evidence"
+    ; "owner_lane_resume_requested"; "exact_evidence"
     ; "before_checkpoint_bytes"; "after_checkpoint_bytes"
     ; "before_message_count"; "after_message_count"
     ; "summarized_message_count"; "dropped_message_count"

--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -379,7 +379,7 @@ let decision_public_allowlist =
     ; "routing_action"; "routing_reason"; "degraded_runtime_id"
     ; "runtime_execution_built"
     ; "media_dropped_total"; "media_dropped_counts"
-    ; "payload_role"; "trigger"; "trigger_detail"; "kind"; "limit_tokens"
+    ; "payload_role"; "operation_id"; "trigger"; "trigger_detail"; "kind"; "limit_tokens"
     ; "ratio"; "threshold"; "count"
     ; "owner_lane_resume_requested"; "exact_evidence"
     ; "before_checkpoint_bytes"; "after_checkpoint_bytes"

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -272,7 +272,8 @@ let append_provider_overflow_manifest
           (Keeper_runtime_manifest.with_payload_role
              ~payload_role:Checkpoint
              (`Assoc
-               [ "trigger", `String (Compaction_trigger.to_label trigger)
+               [ "operation_id", `String recovery.operation_id
+               ; "trigger", `String (Compaction_trigger.to_label trigger)
                ; "trigger_detail", Compaction_trigger.to_detail_json trigger
                ; "owner_lane_resume_requested", `Bool true
                ; "error", error

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -22,6 +22,7 @@ include Keeper_unified_turn_phase_plan
 type source_lease_disposition =
   | Follow_failure_route
   | Requeue_after_context_compaction
+  | Defer_after_context_compaction_failure
   | Acknowledge_after_in_turn_handling
 
 type turn_failure =
@@ -273,7 +274,7 @@ let append_provider_overflow_manifest
              (`Assoc
                [ "trigger", `String (Compaction_trigger.to_label trigger)
                ; "trigger_detail", Compaction_trigger.to_detail_json trigger
-               ; "source_requeued", `Bool true
+               ; "owner_lane_resume_requested", `Bool true
                ; "error", error
                ; ( "exact_evidence"
                  , Keeper_compact_policy.compaction_evidence_to_json evidence )
@@ -320,12 +321,12 @@ let append_provider_overflow_manifest
              (`Assoc
                [ "trigger", `String (Compaction_trigger.to_label trigger)
                ; "trigger_detail", Compaction_trigger.to_detail_json trigger
-               ; "source_requeued", `Bool true
+               ; "owner_lane_resume_requested", `Bool false
                ; "error", `String reason
                ]))
         Keeper_runtime_manifest.Context_compacted
     in
-    Requeue_after_context_compaction, turn_state
+    Defer_after_context_compaction_failure, turn_state
 ;;
 
 let run_keeper_cycle

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -137,11 +137,15 @@ val record_streaming_cancelled_observation
 type source_lease_disposition =
   | Follow_failure_route
   | Requeue_after_context_compaction
+  | Defer_after_context_compaction_failure
   | Acknowledge_after_in_turn_handling
 (** A failed turn normally follows its typed retry/rotate/escalate route.
     [Requeue_after_context_compaction] preserves the exact source stimulus
     after MASC handled a typed provider overflow in this Keeper lane; the next
-    cycle reloads the durably compacted checkpoint.
+    cycle reloads the durably compacted checkpoint and is signaled only after
+    the source lease settles durably. [Defer_after_context_compaction_failure]
+    retains leased work at the FIFO tail without an immediate wake, so a failed
+    compaction cannot hot-loop ahead of unrelated work in the same lane.
     [Acknowledge_after_in_turn_handling] consumes only the source stimulus when
     the configured in-turn policy already handled the terminal failure; the
     cycle remains failed for receipts, counters, and heartbeat freshness. *)

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -406,15 +406,30 @@ let test_failed_cycle_route_mapping () =
         Masc.Keeper_unified_turn.Requeue_after_context_compaction
     }
   in
+  (match
+     Masc.Keeper_heartbeat_loop.settlement_of_failure
+       ~settled_at:7.0
+       compacted_failure
+   with
+   | Masc.Keeper_registry_event_queue.Requeue
+       Masc.Keeper_registry_event_queue.Context_compaction_retry ->
+     ()
+   | _ -> Alcotest.fail "context-compacted source stimulus was acknowledged");
+  let deferred_failure =
+    { compacted_failure with
+      source_lease_disposition =
+        Masc.Keeper_unified_turn.Defer_after_context_compaction_failure
+    }
+  in
   match
     Masc.Keeper_heartbeat_loop.settlement_of_failure
-      ~settled_at:7.0
-      compacted_failure
+      ~settled_at:8.0
+      deferred_failure
   with
   | Masc.Keeper_registry_event_queue.Requeue
       Masc.Keeper_registry_event_queue.Context_compaction_retry ->
     ()
-  | _ -> Alcotest.fail "context-compacted source stimulus was acknowledged"
+  | _ -> Alcotest.fail "failed compaction source stimulus was acknowledged"
 ;;
 
 let cycle_meta () =
@@ -428,6 +443,70 @@ let cycle_meta () =
   with
   | Ok meta -> meta
   | Error message -> Alcotest.failf "cycle meta fixture: %s" message
+;;
+
+let test_provider_compaction_resume_is_success_only () =
+  let base_path = Masc_test_deps.setup_test_workspace () in
+  let meta = cycle_meta () in
+  let peer =
+    { meta with
+      name = "queue-outcome-peer"
+    ; agent_name = "agent-queue-outcome-peer"
+    }
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc.Keeper_registry.unregister ~base_path meta.name;
+      Masc.Keeper_registry.unregister ~base_path peer.name;
+      Masc_test_deps.cleanup_test_workspace base_path)
+    (fun () ->
+      let owner_entry = Masc.Keeper_registry.register ~base_path meta.name meta in
+      let peer_entry = Masc.Keeper_registry.register ~base_path peer.name peer in
+      Atomic.set owner_entry.fiber_wakeup false;
+      Atomic.set peer_entry.fiber_wakeup false;
+      let cycle disposition =
+        let failure =
+          { (turn_failure
+               (Keeper_runtime_failure_route.Retry_after_observed
+                  { retry_class = Keeper_runtime_failure_route.Rate_limited
+                  ; retry_after = None
+                  })) with
+            source_lease_disposition = disposition
+          }
+        in
+        Some (Masc.Keeper_heartbeat_loop_cycle.Failed { meta; failure })
+      in
+      (match
+         Masc.Keeper_heartbeat_loop.resume_owner_lane_after_context_compaction
+           ~base_path
+           ~keeper_name:meta.name
+           (cycle Masc.Keeper_unified_turn.Requeue_after_context_compaction)
+       with
+       | Some Masc.Keeper_registry.Signaled -> ()
+       | Some _ -> Alcotest.fail "durable compaction resume was deferred"
+       | None -> Alcotest.fail "durable compaction did not request owner resume");
+      Alcotest.(check bool)
+        "owner lane wake set"
+        true
+        (Atomic.get owner_entry.fiber_wakeup);
+      Alcotest.(check bool)
+        "peer lane remains untouched"
+        false
+        (Atomic.get peer_entry.fiber_wakeup);
+      Atomic.set owner_entry.fiber_wakeup false;
+      (match
+         Masc.Keeper_heartbeat_loop.resume_owner_lane_after_context_compaction
+           ~base_path
+           ~keeper_name:meta.name
+           (cycle
+              Masc.Keeper_unified_turn.Defer_after_context_compaction_failure)
+       with
+       | None -> ()
+       | Some _ -> Alcotest.fail "failed compaction requested an immediate retry");
+      Alcotest.(check bool)
+        "failed compaction leaves owner wake clear"
+        false
+        (Atomic.get owner_entry.fiber_wakeup))
 ;;
 
 let test_applied_compaction_settles_followup_atomically () =
@@ -971,6 +1050,10 @@ let () =
             `Quick
             test_judgment_terminal_evidence_is_durable
         ; Alcotest.test_case "failed cycle route mapping" `Quick test_failed_cycle_route_mapping
+        ; Alcotest.test_case
+            "provider compaction resumes only after success"
+            `Quick
+            test_provider_compaction_resume_is_success_only
         ; Alcotest.test_case
             "applied compaction settles follow-up atomically"
             `Quick

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -251,6 +251,65 @@ let make_checkpoint () =
     ; working_context = None
     }
 
+let test_compaction_receipt_is_exact_and_immutable () =
+  let checkpoint = make_checkpoint () in
+  let evidence : Compact_policy.compaction_evidence =
+    { selected_runtime_id = Some "runtime-a"
+    ; before_checkpoint_bytes = 4096
+    ; after_checkpoint_bytes = 1024
+    ; before_message_count = 3
+    ; after_message_count = 1
+    ; summarized_message_count = 2
+    ; dropped_message_count = 0
+    ; before_tool_use_count = 0
+    ; after_tool_use_count = 0
+    ; before_tool_result_count = 0
+    ; after_tool_result_count = 0
+    }
+  in
+  let context =
+    Masc.Keeper_context_runtime.context_of_oas_checkpoint
+      checkpoint
+      ~primary_model_max_tokens:8192
+  in
+  let with_receipt, created =
+    Compact_policy.with_compaction_receipt
+      ~generation:4
+      ~trigger:Compaction_trigger.Manual
+      ~evidence
+      context
+  in
+  (match
+     Compact_policy.compaction_receipt_for_request
+       ~checkpoint
+       ~generation:4
+       ~trigger:Compaction_trigger.Manual
+   with
+   | Ok None -> ()
+   | Ok (Some _) -> fail "receipt mutation leaked into the source checkpoint"
+   | Error detail -> failf "source receipt read failed: %s" detail);
+  let persisted = Masc.Keeper_context_runtime.checkpoint_of_context with_receipt in
+  (match
+     Compact_policy.compaction_receipt_for_request
+       ~checkpoint:persisted
+       ~generation:4
+       ~trigger:Compaction_trigger.Manual
+   with
+   | Ok (Some replayed) ->
+     check string "stable operation identity" created.operation_id replayed.operation_id;
+     check int "before evidence preserved" 4096 replayed.evidence.before_checkpoint_bytes
+   | Ok None -> fail "persisted receipt did not match its exact source"
+   | Error detail -> failf "persisted receipt rejected: %s" detail);
+  match
+    Compact_policy.compaction_receipt_for_request
+      ~checkpoint:{ persisted with turn_count = persisted.turn_count + 1 }
+      ~generation:4
+      ~trigger:Compaction_trigger.Manual
+  with
+  | Ok None -> ()
+  | Ok (Some _) -> fail "receipt from an older checkpoint version was reused"
+  | Error detail -> failf "new checkpoint receipt read failed: %s" detail
+
 let test_regular_post_turn_does_not_auto_compact () =
   Eio_main.run @@ fun _env ->
   let meta = make_meta () in
@@ -506,6 +565,8 @@ let () =
     "durable compaction", [
       test_case "Prepared requires a successful checkpoint save"
         `Quick test_prepared_becomes_applied_only_after_save;
+      test_case "receipt is exact and source context remains immutable"
+        `Quick test_compaction_receipt_is_exact_and_immutable;
       test_case "regular post-turn does not auto-compact"
         `Quick test_regular_post_turn_does_not_auto_compact;
       test_case "manual compaction serializes the owner lane"


### PR DESCRIPTION
## Outcome

Provider-overflow compaction now resumes the owning Keeper lane immediately after durable source settlement instead of sleeping until the next cadence.

- separates a saved compaction from a failed compaction with typed source dispositions
- signals only the owner lane after the compacted source lease and transition outbox settle
- handles unleased proactive overflow by signaling the same owner lane directly
- leaves failed compaction work at the FIFO tail without an immediate hot-loop, so unrelated same-lane work can proceed
- replaces the premature source_requeued=true manifest claim with explicit owner_lane_resume_requested intent

## Adversarial proof

Before this change, Context_compaction_retry appended the exact leased stimulus to the durable FIFO tail, but neither settlement nor the no-lease path restored fiber_wakeup. interruptible_sleep therefore waited for cadence even though the compacted checkpoint was already durable. The same disposition was also used when compaction produced no checkpoint, so a naive wake fix would have created an immediate failure loop.

## Verification

- ocamlformat --check on all six changed OCaml files: pass
- ocamlc -stop-after parsing on changed implementations and test: pass
- git diff --check: pass
- focused Dune wrapper was not bypassed: it refused while existing bare Dune processes owned the machine-wide build lock; PR CI is the build/type-test authority
- 169 additions, 9 deletions; 178 total changed lines

## Stack

Base: #24626
