### PR TITLE
refactor(runtime): remove private local bindings from public seed

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -4,10 +4,9 @@
 # workspaces. Existing live config roots are preserved and must be edited
 # explicitly through the dashboard/runtime config path.
 #
-# Local Gemma 4 QAT is a canary runtime, not the fleet default. Keep the
-# default on the cloud runtime and pin only one keeper to local Ollama until
-# sustained turns prove the local box can absorb more load. OAS handles Gemma 4
-# thinking through the chat-template control token path, not Ollama think:true.
+# The public seed ships cloud/commercial providers only (Ollama Cloud, DeepSeek,
+# GLM Coding Plan). Private/local self-hosted runtimes (local Ollama, RunPod) are
+# not shipped here; keep the default on a cloud runtime.
 
 [runtime]
 default = "ollama_cloud.deepseek-v4-flash"
@@ -97,14 +96,6 @@ path = "/models"
 type = "env"
 key = "ZAI_API_KEY_SB"
 
-[providers.ollama]
-display-name = "Local Ollama"
-protocol = "ollama-http"
-endpoint = "http://localhost:11434"
-
-[providers.ollama.healthcheck]
-path = "/api/tags"
-
 [models.deepseek-v4-pro]
 api-name = "deepseek-v4-pro"
 max-context = 1000000
@@ -157,54 +148,6 @@ supports-extended-thinking = true
 supports-native-streaming = true
 supports-response-format-json = true
 supports-structured-output = false
-
-[models.gemma4-26b-a4b-qat]
-api-name = "hf.co/unsloth/gemma-4-26B-A4B-it-qat-GGUF:UD-Q4_K_XL"
-max-context = 262144
-tools-support = true
-# OAS maps this to Gemma 4's <|think|> chat-template token and omits the
-# generic Ollama top-level think field for this model family.
-thinking-support = true
-preserve-thinking = false
-streaming = true
-
-[models.gemma4-26b-a4b-qat.capabilities]
-# This runtime rides OAS native Ollama /api/chat, which does not serialize
-# tool_choice (oas backend_ollama.ml:24). Declaring true here would override
-# oas models.toml's supports_tool_choice=false (provider_runtime_binding.ml
-# applies this override last) while the transport silently drops forced tool
-# choice. Do not re-enable without a serializer path + model-side proof.
-supports-tool-choice = false
-thinking-control-format = "chat_template_token"
-thinking-control-token = "<|think|>"
-supports-native-streaming = true
-supports-top-k = true
-supports-seed = true
-supports-image-input = true
-supports-multimodal-inputs = true
-
-[models.gemma4-e2b-it-qat]
-api-name = "hf.co/unsloth/gemma-4-E2B-it-qat-GGUF:UD-Q4_K_XL"
-max-context = 131072
-tools-support = true
-# OAS maps this to Gemma 4's <|think|> chat-template token and omits the
-# generic Ollama top-level think field for this model family.
-thinking-support = true
-preserve-thinking = false
-streaming = true
-
-[models.gemma4-e2b-it-qat.capabilities]
-# This exact local model reports 131072 context and tools/vision/audio via
-# `ollama show hf.co/unsloth/gemma-4-E2B-it-qat-GGUF:UD-Q4_K_XL`.
-supports-tool-choice = false
-thinking-control-format = "chat_template_token"
-thinking-control-token = "<|think|>"
-supports-native-streaming = true
-supports-top-k = true
-supports-seed = true
-supports-image-input = true
-supports-audio-input = true
-supports-multimodal-inputs = true
 
 [ollama_cloud.deepseek-v4-flash]
 wizard-default = true
@@ -963,13 +906,6 @@ supports-multimodal-inputs = false
 
 [ollama_cloud.ollama-cloud-rnj-1-8b]
 
-[ollama.gemma4-26b-a4b-qat]
-wizard-default = true
-max-concurrent = 1
-
-[ollama.gemma4-e2b-it-qat]
-max-concurrent = 1
-
 # ── Runtime lanes (ordered failover) ─────────────────────────────────
 # A lane is an ordered list of runtime candidates. When a keeper is assigned
 # to a lane, the turn attempts candidates in order until one succeeds or the
@@ -987,12 +923,11 @@ candidates = [
 # keepers fall back to [runtime].default. Per-keeper overrides in the
 # live config (<base>/.masc/config/runtime.toml) take precedence.
 #
-# Seed only nick0cave to the local Gemma 4 canary. Other keepers use the
-# fleet default unless their live config overrides this seed.
+# No seed assignments ship in the public repo: every keeper rides
+# [runtime].default unless its live config overrides this seed.
 # Do not assign general keeper lanes to Pro here. Pro is reserved for explicit
 # judge/evaluator lanes ([runtime].cross_verifier and [fusion].judge).
 [runtime.assignments]
-nick0cave = "ollama.gemma4-26b-a4b-qat"
 # example: route a test keeper through the failover lane
 # canary = "default"
 

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -721,10 +721,8 @@ let test_repo_runtime_toml_loads () =
     check (option (float 0.0)) "Ollama Cloud connect timeout override"
       (Some 600.0)
       default.provider_config.connect_timeout_s;
-    check int "one local Gemma canary pin in seed" 1 (List.length assignments);
-    check (option string) "nick0cave Gemma canary pin"
-      (Some "ollama.gemma4-26b-a4b-qat")
-      (List.assoc_opt "nick0cave" assignments);
+    check int "public seed has no keeper assignments" 0
+      (List.length assignments);
     check int "Ollama Cloud canonical seed count"
       (List.length ollama_cloud_seed_cases)
       (List.length
@@ -735,58 +733,6 @@ let test_repo_runtime_toml_loads () =
     List.iter
       (assert_ollama_cloud_seed_runtime runtimes)
       ollama_cloud_seed_cases;
-    (match
-       List.find_opt
-         (fun (runtime : Runtime.t) ->
-            String.equal runtime.id "ollama.gemma4-26b-a4b-qat")
-         runtimes
-     with
-     | None -> fail "expected Gemma4 Ollama runtime in seed"
-     | Some runtime ->
-       check bool "Gemma4 thinking enabled" true runtime.model.thinking_support;
-       check (option bool) "Gemma4 thinking not preserved" (Some false)
-         runtime.model.preserve_thinking;
-       (match runtime.model.capabilities with
-        | Some caps ->
-          check bool "Gemma4 chat-template-token thinking control" true
-            (Runtime_schema.equal_thinking_control_format
-               caps.thinking_control_format
-               (Runtime_schema.Chat_template_token "<|think|>"));
-          (* Native Ollama /api/chat never serializes tool_choice
-             (oas backend_ollama.ml:24); declaring true here would override
-             oas models.toml false while the transport drops forced tool
-             choice. *)
-          check bool "Gemma4 forced tool_choice disabled" false
-            caps.supports_tool_choice
-        | None -> fail "expected Gemma4 capabilities"));
-    (match
-       List.find_opt
-         (fun (runtime : Runtime.t) ->
-            String.equal runtime.id "ollama.gemma4-e2b-it-qat")
-         runtimes
-     with
-     | None -> fail "expected Gemma4 E2B Ollama runtime in seed"
-     | Some runtime ->
-       check string
-         "Gemma4 E2B model api name"
-         "hf.co/unsloth/gemma-4-E2B-it-qat-GGUF:UD-Q4_K_XL"
-         runtime.model.api_name;
-       check (option int) "Gemma4 E2B context" (Some 131072) runtime.model.max_context;
-       check bool "Gemma4 E2B thinking enabled" true
-         runtime.model.thinking_support;
-       check (option bool) "Gemma4 E2B thinking not preserved" (Some false)
-         runtime.model.preserve_thinking;
-       (match runtime.model.capabilities with
-        | Some caps ->
-          check bool "Gemma4 E2B chat-template-token thinking control" true
-            (Runtime_schema.equal_thinking_control_format
-               caps.thinking_control_format
-               (Runtime_schema.Chat_template_token "<|think|>"));
-          check bool "Gemma4 E2B forced tool_choice disabled" false
-            caps.supports_tool_choice;
-          check bool "Gemma4 E2B image input" true caps.supports_image_input;
-          check bool "Gemma4 E2B audio input" true caps.supports_audio_input
-        | None -> fail "expected Gemma4 E2B capabilities"));
     (match
        List.find_opt
          (fun (runtime : Runtime.t) ->
@@ -1143,10 +1089,10 @@ let test_runtime_atomic_getters_are_consistent_after_init () =
     let ids1 = Runtime.get_runtime_ids () in
     let ids2 = Runtime.get_runtime_ids () in
     check (list string) "get_runtime_ids is stable" ids1 ids2;
-    check bool "runtime_id_for_keeper resolves through atomic cache"
+    check bool "default runtime resolves through atomic cache"
       true
-      (match Runtime.runtime_id_for_keeper "nick0cave" with
-       | Some id -> Option.is_some (Runtime.get_runtime_by_id id)
+      (match Runtime.get_default_runtime () with
+       | Some rt -> Option.is_some (Runtime.get_runtime_by_id rt.id)
        | None -> false)
 
 let test_runtime_toml_parses_optional_max_concurrent () =


### PR DESCRIPTION
## 변경

- 공개 runtime seed에서 localhost Ollama provider와 로컬 Gemma runtime 두 개를 제거합니다.
- 개인 keeper assignment nick0cave를 제거하여 공개 seed의 모든 keeper가 typed default runtime을 따르게 합니다.
- runtime validity test는 assignment 0건과 default-runtime atomic lookup을 검증합니다.

## SSOT 경계

- OAS embedded catalog가 범용 capability SSOT입니다.
- MASC config/oas-models-overlay.toml은 deployment delta만 소유합니다.
- 삭제된 oas-models.toml full fork를 되살리지 않으며 catalog 복제도 추가하지 않습니다.
- config/runtime.toml은 MASC deployment binding seed만 소유합니다.

## 검증

- scripts/dune-local.sh build test/test_runtime_config_validity.exe
- runtime TOML gate: 38/38 pass, 0.263s
- ocamlformat --check test/test_runtime_config_validity.ml
- git diff --check

[근거] 현재 #24647 merged tree와 focused local test를 2026-07-16 09:44 KST에 확인; 신뢰도 High.