### PR TITLE
fix(discord): surface binding read failures

### DIFF
--- a/lib/gate/channel_gate_discord_state.ml
+++ b/lib/gate/channel_gate_discord_state.ml
@@ -49,6 +49,7 @@ let binding_store =
     ~binding_audit_read_path ~guild_id_field:Store.Include_event_value
 
 let read_bindings () = Store.read_bindings binding_store
+let read_bindings_result () = Store.read_bindings_result binding_store
 let binding_json = Store.binding_json
 let save_bindings bindings = Store.save_bindings binding_store bindings
 let append_audit_event event = Store.append_audit_event binding_store event
@@ -56,7 +57,7 @@ let read_recent_audit ~limit = Store.read_recent_audit binding_store ~limit
 
 (* ── Thread registry ──────────────────────────────────────────────
    Thread→parent mapping populated from THREAD_CREATE gateway events.
-   Used by [resolve_keeper_for_channel] to resolve bindings for thread
+   Used by [resolve_keeper_for_channel_result] to resolve bindings for thread
    messages whose channel_id is the thread's snowflake, not the parent
    channel's. Module-level mutable state (same pattern as [last_ready]). *)
 
@@ -478,94 +479,49 @@ type keeper_binding_resolution = {
   via_parent : bool;
 }
 
+type binding_lookup_error =
+  | Binding_store_read_failed of string
+
+let pp_binding_lookup_error formatter = function
+  | Binding_store_read_failed detail ->
+      Format.fprintf formatter "Discord binding store read failed: %s" detail
+
 let binding_for_channel bindings ~channel_id =
   List.find_map
     (fun (b : binding) ->
       if String.equal b.channel_id channel_id then Some b else None)
     bindings
 
-let resolve_keeper_for_channel ~channel_id =
+let resolve_keeper_for_channel_result ~channel_id =
   let normalized = String.trim channel_id in
-  if String.equal normalized "" then None
+  if String.equal normalized "" then Ok None
   else
-    let candidates =
-      try read_bindings ()
-      with
-      | Eio.Cancel.Cancelled _ as e -> raise e
-      | _ -> []
-    in
-    match binding_for_channel candidates ~channel_id:normalized with
-    | Some b ->
-        Some
-          {
-            keeper_name = b.keeper_name;
-            incoming_channel_id = normalized;
-            bound_channel_id = b.channel_id;
-            via_parent = false;
-          }
-    | None -> (
-        (* Thread fallback: if this channel_id is a known Discord thread,
-           try resolving via its parent channel's binding. *)
-        match parent_channel_of_thread ~channel_id:normalized with
-        | Some parent_id when parent_id <> normalized ->
-            (match binding_for_channel candidates ~channel_id:parent_id with
-             | Some b ->
-                 Some
-                   {
-                     keeper_name = b.keeper_name;
-                     incoming_channel_id = normalized;
-                     bound_channel_id = b.channel_id;
-                     via_parent = true;
-                   }
-             | None -> (
-                 (* Final fallback: names file (legacy sidecar data). *)
-                 let names_parent =
-                   try Names.resolve_parent_channel_id_for_channel ~channel_id:normalized
-                   with
-                   | Eio.Cancel.Cancelled _ as e -> raise e
-                   | _ -> None
-                 in
-                 match names_parent with
-                 | None -> None
-                 | Some names_parent ->
-                     let names_parent = String.trim names_parent in
-                     match binding_for_channel candidates ~channel_id:names_parent with
-                     | None -> None
-                     | Some b ->
-                         Some
-                           {
-                             keeper_name = b.keeper_name;
-                             incoming_channel_id = normalized;
-                             bound_channel_id = b.channel_id;
-                             via_parent = true;
-                           } ))
-        | _ -> (
-            (* No thread match — try names file (legacy sidecar data). *)
-            let parent_channel_id =
-              try Names.resolve_parent_channel_id_for_channel ~channel_id:normalized
-              with
-              | Eio.Cancel.Cancelled _ as e -> raise e
-              | _ -> None
-            in
-            match parent_channel_id with
-            | None -> None
-            | Some parent_channel_id -> (
-                let parent_channel_id = String.trim parent_channel_id in
-                match binding_for_channel candidates ~channel_id:parent_channel_id with
-                | None -> None
-                | Some b ->
-                    Some
-                      {
-                        keeper_name = b.keeper_name;
-                        incoming_channel_id = normalized;
-                        bound_channel_id = b.channel_id;
-                        via_parent = true;
-                      } )) )
-
-let keeper_for_channel ~channel_id =
-  match resolve_keeper_for_channel ~channel_id with
-  | None -> None
-  | Some resolution -> Some resolution.keeper_name
+    match read_bindings_result () with
+    | Error detail -> Error (Binding_store_read_failed detail)
+    | Ok candidates ->
+      let binding, via_parent =
+        match binding_for_channel candidates ~channel_id:normalized with
+        | Some binding -> Some binding, false
+        | None ->
+          let parent_binding =
+            Option.bind
+              (parent_channel_of_thread ~channel_id:normalized)
+              (fun parent_channel_id ->
+              if String.equal parent_channel_id normalized
+              then None
+              else binding_for_channel candidates ~channel_id:parent_channel_id)
+          in
+          parent_binding, true
+      in
+      Ok
+        (Option.map
+           (fun (binding : binding) ->
+             { keeper_name = binding.keeper_name
+             ; incoming_channel_id = normalized
+             ; bound_channel_id = binding.channel_id
+             ; via_parent
+             })
+           binding)
 
 (* RFC-0223 P2: presence surface. Both recomputed per call — no cached
    presence state. *)

--- a/lib/gate/channel_gate_discord_state.mli
+++ b/lib/gate/channel_gate_discord_state.mli
@@ -63,11 +63,6 @@ val unbind :
     that replaces the deleted [sidecars/discord-bot/] Python
     connector. *)
 
-val keeper_for_channel : channel_id:string -> string option
-(** Look up the keeper bound to a Discord channel snowflake.
-    Returns [None] when no binding exists, when the channel id is
-    blank, or when the binding store is unreadable. *)
-
 type keeper_binding_resolution = {
   keeper_name : string;
   incoming_channel_id : string;
@@ -75,11 +70,18 @@ type keeper_binding_resolution = {
   via_parent : bool;
 }
 
-val resolve_keeper_for_channel :
-  channel_id:string -> keeper_binding_resolution option
-(** Resolve the keeper for [channel_id]. Exact bindings win. If no
-    exact binding exists and [channel_id] is a Discord thread known
-    in the names side-store, its parent channel binding is used. *)
+type binding_lookup_error =
+  | Binding_store_read_failed of string
+
+val pp_binding_lookup_error : Format.formatter -> binding_lookup_error -> unit
+
+val resolve_keeper_for_channel_result :
+  channel_id:string ->
+  (keeper_binding_resolution option, binding_lookup_error) result
+(** Resolve the keeper for [channel_id]. Exact bindings win. If no exact
+    binding exists and the in-process gateway registered [channel_id] as a
+    Discord thread, its parent channel binding is used. Binding-store read
+    failures remain distinct from an unbound channel. *)
 
 val bound_channels : keeper_name:string -> string list
 (** Channel snowflakes bound to [keeper_name], freshly read from the
@@ -100,7 +102,7 @@ val record_ready : bot_user_id:string -> unit
 (** {2 Thread registry}
 
     Thread→parent channel mapping populated from THREAD_CREATE gateway
-    events. Used by {!resolve_keeper_for_channel} to resolve bindings
+    events. Used by {!resolve_keeper_for_channel_result} to resolve bindings
     for messages in Discord threads (whose [channel_id] is the thread's
     snowflake, distinct from the parent channel). *)
 

--- a/lib/gate/connector_ingress_lane.ml
+++ b/lib/gate/connector_ingress_lane.ml
@@ -72,7 +72,7 @@ let event_id_to_string event_id =
 
 let with_lock t f = Stdlib.Mutex.protect t.mutex f
 
-let report_failure t failure =
+let notify_failure t failure =
   try t.on_failure failure with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn ->
@@ -83,12 +83,19 @@ let report_failure t failure =
       (Printexc.to_string exn)
 ;;
 
+let report_failure t ~lane ~event_id ~reason =
+  let failure = { lane; event_id; reason } in
+  notify_failure t failure;
+  failure
+;;
+
 let run_isolated t ~lane ~event_id run =
   try Ok (run ()) with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn ->
-    let failure = { lane; event_id; reason = Printexc.to_string exn } in
-    report_failure t failure;
+    let failure =
+      report_failure t ~lane ~event_id ~reason:(Printexc.to_string exn)
+    in
     Error failure
 ;;
 

--- a/lib/gate/connector_ingress_lane.mli
+++ b/lib/gate/connector_ingress_lane.mli
@@ -48,6 +48,15 @@ val run_isolated :
     [on_failure] and returned as a typed error, so the transport callback can
     continue without weakening durable accept-before-return ordering. *)
 
+val report_failure :
+  t ->
+  lane:lane ->
+  event_id:event_id ->
+  reason:string ->
+  failure
+(** Report an explicit typed-boundary rejection without raising an exception.
+    The returned failure is the exact value delivered to [on_failure]. *)
+
 val submit :
   t ->
   lane:lane ->

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -333,27 +333,33 @@ let mark_attention_resolved ~base_dir ~keeper_name ~event_id ~reason =
         keeper_name event_id error
 
 let resolve_binding_for_message ~channel_id ~message_reference_channel_id =
-  match State.resolve_keeper_for_channel ~channel_id with
-  | Some resolution -> Some (resolution, [])
-  | None -> (
+  match State.resolve_keeper_for_channel_result ~channel_id with
+  | Error error -> Error error
+  | Ok (Some resolution) -> Ok (Some (resolution, []))
+  | Ok None -> (
       match message_reference_channel_id with
-      | None -> None
+      | None -> Ok None
       | Some reference_channel_id ->
           let reference_channel_id = String.trim reference_channel_id in
           if reference_channel_id = "" || String.equal reference_channel_id channel_id
-          then None
+          then Ok None
           else
-            match State.resolve_keeper_for_channel ~channel_id:reference_channel_id with
-            | None -> None
-            | Some resolution ->
-                Some
-                  ( {
-                      State.keeper_name = resolution.State.keeper_name;
-                      incoming_channel_id = channel_id;
-                      bound_channel_id = resolution.bound_channel_id;
-                      via_parent = true;
-                    },
-                    [ ("discord.binding_reference_channel_id", reference_channel_id) ] ))
+            match
+              State.resolve_keeper_for_channel_result
+                ~channel_id:reference_channel_id
+            with
+            | Error error -> Error error
+            | Ok None -> Ok None
+            | Ok (Some resolution) ->
+                Ok
+                  (Some
+                     ( { State.keeper_name = resolution.State.keeper_name
+                       ; incoming_channel_id = channel_id
+                       ; bound_channel_id = resolution.bound_channel_id
+                       ; via_parent = true
+                       }
+                     , [ ( "discord.binding_reference_channel_id"
+                         , reference_channel_id ) ] )))
 
 let accept_message_create ~resolved_binding ~dispatch_for_delivery
       ~(channel_id : string) ~(message_id : string)
@@ -568,12 +574,7 @@ let accept_event ~resolved_binding ~dispatch_for_delivery ~base_dir
 let handle_ambient ~resolved_keeper_name ~base_dir
       ~(channel_id : string) ~(guild_id : string option) ~(message_id : string)
       ~(author_id : string) ~(author_name : string option) ~(content : string) =
-  let keeper_name =
-    match resolved_keeper_name with
-    | Some keeper_name -> Some keeper_name
-    | None -> State.keeper_for_channel ~channel_id
-  in
-  match keeper_name with
+  match resolved_keeper_name with
   | None ->
     Discord_observability.record_ambient
       Discord_observability.Ambient_dropped_unbound
@@ -689,7 +690,7 @@ let handle_ambient ~resolved_keeper_name ~base_dir
         Discord_observability.Ambient_recorded
     end
 
-let on_ambient ?resolved_keeper_name ~base_dir (ev : Gw.gateway_event) =
+let on_ambient ~resolved_keeper_name ~base_dir (ev : Gw.gateway_event) =
   match ev with
   | Gw.Message_create
       { channel_id; guild_id; message_id; author_id; author_name; content; _ }
@@ -710,6 +711,22 @@ let discord_event_opaque_id : Gw.gateway_event -> string = function
   | Gw.Ignored reason -> reason
 ;;
 
+let resolve_binding_for_event ingress ~event_id resolve =
+  let lane = Connector_ingress_lane.Connector_lane State.channel in
+  match Connector_ingress_lane.run_isolated ingress ~lane ~event_id resolve with
+  | Error _ -> Error ()
+  | Ok (Error error) ->
+    let (_ : Connector_ingress_lane.failure) =
+      Connector_ingress_lane.report_failure
+        ingress
+        ~lane
+        ~event_id
+        ~reason:(Format.asprintf "%a" State.pp_binding_lookup_error error)
+    in
+    Error ()
+  | Ok (Ok resolution) -> Ok resolution
+;;
+
 let submit_triggered_event ?deliver ingress ~dispatch_for_delivery ~base_dir
     (ev : Gw.gateway_event) =
   match ev with
@@ -723,9 +740,11 @@ let submit_triggered_event ?deliver ingress ~dispatch_for_delivery ~base_dir
       }
     in
     (match
-       resolve_binding_for_message ~channel_id ~message_reference_channel_id
+       resolve_binding_for_event ingress ~event_id (fun () ->
+         resolve_binding_for_message ~channel_id ~message_reference_channel_id)
      with
-     | None ->
+     | Error () -> ()
+     | Ok None ->
        ignore
          (Connector_ingress_lane.run_isolated
             ingress
@@ -737,7 +756,7 @@ let submit_triggered_event ?deliver ingress ~dispatch_for_delivery ~base_dir
                 ~dispatch_for_delivery
                 ~base_dir
                 ev))
-     | Some ((resolution, _) as resolved_binding) ->
+     | Ok (Some ((resolution, _) as resolved_binding)) ->
        (match
           Connector_ingress_lane.run_isolated
             ingress
@@ -794,20 +813,27 @@ end
 let submit_ambient_event ingress ~base_dir (ev : Gw.gateway_event) =
   match ev with
   | Gw.Message_create { channel_id; message_id; _ } ->
-    (match State.keeper_for_channel ~channel_id with
-     | None ->
+    let event_id =
+      { Connector_ingress_lane.source = State.channel
+      ; route = Connector_ingress_lane.Ambient
+      ; phase = Connector_ingress_lane.Acceptance
+      ; opaque_id = message_id
+      }
+    in
+    (match
+       resolve_binding_for_event ingress ~event_id (fun () ->
+         State.resolve_keeper_for_channel_result ~channel_id)
+     with
+     | Error () -> ()
+     | Ok None ->
        ignore
          (Connector_ingress_lane.run_isolated
             ingress
             ~lane:(Connector_ingress_lane.Connector_lane State.channel)
-            ~event_id:
-              { source = State.channel
-              ; route = Connector_ingress_lane.Ambient
-              ; phase = Connector_ingress_lane.Acceptance
-              ; opaque_id = message_id
-              }
-            (fun () -> on_ambient ~base_dir ev))
-     | Some keeper_name ->
+            ~event_id
+            (fun () -> on_ambient ~resolved_keeper_name:None ~base_dir ev))
+     | Ok (Some resolution) ->
+       let keeper_name = resolution.State.keeper_name in
        Connector_ingress_lane.submit
          ingress
          ~lane:(Connector_ingress_lane.Keeper_lane keeper_name)
@@ -817,7 +843,8 @@ let submit_ambient_event ingress ~base_dir (ev : Gw.gateway_event) =
            ; phase = Connector_ingress_lane.Delivery
            ; opaque_id = message_id
            }
-         (fun () -> on_ambient ~resolved_keeper_name:keeper_name ~base_dir ev))
+         (fun () ->
+           on_ambient ~resolved_keeper_name:(Some keeper_name) ~base_dir ev))
   | Gw.Ready _
   | Gw.Reaction_add _
   | Gw.Thread_tracked _
@@ -834,7 +861,7 @@ let submit_ambient_event ingress ~base_dir (ev : Gw.gateway_event) =
            ; phase = Connector_ingress_lane.Acceptance
            ; opaque_id = discord_event_opaque_id ev
            }
-         (fun () -> on_ambient ~base_dir ev))
+         (fun () -> on_ambient ~resolved_keeper_name:None ~base_dir ev))
 ;;
 
 (* ---------------------------------------------------------------- *)

--- a/test/test_channel_gate_discord_state.ml
+++ b/test/test_channel_gate_discord_state.ml
@@ -377,13 +377,23 @@ let test_resolve_keeper_for_thread_parent_binding () =
     ignore
       (Discord_state.bind ~channel_id:"parent-1" ~keeper_name:"luna"
          ~actor_name:"dashboard");
-    match Discord_state.resolve_keeper_for_channel ~channel_id:"thread-1" with
-    | None -> fail "expected parent binding to resolve"
-    | Some resolution ->
-        check string "keeper" "luna" resolution.keeper_name;
-        check string "incoming" "thread-1" resolution.incoming_channel_id;
-        check string "bound" "parent-1" resolution.bound_channel_id;
-        check bool "via parent" true resolution.via_parent)
+    Discord_state.register_thread ~thread_id:"thread-1"
+      ~parent_channel_id:"parent-1";
+    Fun.protect
+      ~finally:(fun () -> Discord_state.unregister_thread ~thread_id:"thread-1")
+      (fun () ->
+        match
+          Discord_state.resolve_keeper_for_channel_result ~channel_id:"thread-1"
+        with
+        | Error error ->
+            fail
+              (Format.asprintf "%a" Discord_state.pp_binding_lookup_error error)
+        | Ok None -> fail "expected parent binding to resolve"
+        | Ok (Some resolution) ->
+            check string "keeper" "luna" resolution.keeper_name;
+            check string "incoming" "thread-1" resolution.incoming_channel_id;
+            check string "bound" "parent-1" resolution.bound_channel_id;
+            check bool "via parent" true resolution.via_parent))
 
 let test_resolve_keeper_exact_binding_wins_over_parent () =
   with_temp_dir @@ fun dir ->
@@ -402,9 +412,13 @@ let test_resolve_keeper_exact_binding_wins_over_parent () =
     ignore
       (Discord_state.bind ~channel_id:"thread-1" ~keeper_name:"sangsu"
          ~actor_name:"dashboard");
-    match Discord_state.resolve_keeper_for_channel ~channel_id:"thread-1" with
-    | None -> fail "expected exact binding to resolve"
-    | Some resolution ->
+    match
+      Discord_state.resolve_keeper_for_channel_result ~channel_id:"thread-1"
+    with
+    | Error error ->
+        fail (Format.asprintf "%a" Discord_state.pp_binding_lookup_error error)
+    | Ok None -> fail "expected exact binding to resolve"
+    | Ok (Some resolution) ->
         check string "keeper" "sangsu" resolution.keeper_name;
         check string "incoming" "thread-1" resolution.incoming_channel_id;
         check string "bound" "thread-1" resolution.bound_channel_id;

--- a/test/test_channel_gate_discord_state_in_process.ml
+++ b/test/test_channel_gate_discord_state_in_process.ml
@@ -1,6 +1,6 @@
 (* RFC-0203 Phase 3 — unit tests for the in-process gateway helpers
    added to [Channel_gate_discord_state]:
-   - [keeper_for_channel] (binding lookup)
+   - [resolve_keeper_for_channel_result] (typed binding lookup)
    - [send_error] / [pp_send_error] (typed REST error wrapper)
    - [send_message] error path with [DISCORD_BOT_TOKEN] unset
    - [edit_message] error path with [DISCORD_BOT_TOKEN] unset
@@ -16,22 +16,34 @@ let setenv k v = Unix.putenv k v
 let unsetenv k = Unix.putenv k ""
 
 (* ---------------------------------------------------------------- *)
-(* keeper_for_channel                                               *)
+(* resolve_keeper_for_channel_result                                *)
 (* ---------------------------------------------------------------- *)
 
 let test_lookup_blank_channel_id () =
-  check (option string) "empty => None" None
-    (State.keeper_for_channel ~channel_id:"")
+  match State.resolve_keeper_for_channel_result ~channel_id:"" with
+  | Ok None -> ()
+  | Ok (Some _) -> fail "blank channel resolved a Keeper"
+  | Error error ->
+      fail (Format.asprintf "%a" State.pp_binding_lookup_error error)
 
 let test_lookup_whitespace_channel_id () =
-  check (option string) "whitespace => None" None
-    (State.keeper_for_channel ~channel_id:"   ")
+  match State.resolve_keeper_for_channel_result ~channel_id:"   " with
+  | Ok None -> ()
+  | Ok (Some _) -> fail "whitespace channel resolved a Keeper"
+  | Error error ->
+      fail (Format.asprintf "%a" State.pp_binding_lookup_error error)
 
 let test_lookup_unbound_channel_returns_none () =
   (* No bind() called for this channel id and the binding store may
      be empty or missing; lookup must not raise either way. *)
-  check (option string) "no binding => None" None
-    (State.keeper_for_channel ~channel_id:"channel-id-with-no-binding")
+  match
+    State.resolve_keeper_for_channel_result
+      ~channel_id:"channel-id-with-no-binding"
+  with
+  | Ok None -> ()
+  | Ok (Some _) -> fail "unbound channel resolved a Keeper"
+  | Error error ->
+      fail (Format.asprintf "%a" State.pp_binding_lookup_error error)
 
 (* ---------------------------------------------------------------- *)
 (* send_error / pp_send_error                                       *)
@@ -109,7 +121,7 @@ let test_edit_message_without_token_returns_missing_token () =
 
 let () =
   run "channel_gate_discord_state_in_process"
-    [ ( "keeper_for_channel"
+    [ ( "resolve_keeper_for_channel_result"
       , [ test_case "blank channel id => None" `Quick
             test_lookup_blank_channel_id
         ; test_case "whitespace channel id => None" `Quick

--- a/test/test_server_discord_trigger_policy.ml
+++ b/test/test_server_discord_trigger_policy.ml
@@ -49,6 +49,13 @@ let with_temp_dir f =
   Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
 ;;
 
+let write_text path content =
+  let output = open_out_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr output)
+    (fun () -> output_string output content)
+;;
+
 let ps p = Discord_gateway_state.trigger_policy_to_string p
 let default_str = ps G.default_trigger_policy
 
@@ -249,6 +256,64 @@ let test_accept_failure_does_not_kill_discord_ingress () =
        failf "expected Keeper lane, got connector:%s" connector_id)
 ;;
 
+let test_binding_read_failure_is_observed_and_next_event_continues () =
+  with_temp_dir @@ fun base_dir ->
+  let binding_path = Filename.concat base_dir "bindings.json" in
+  with_env "MASC_DISCORD_BINDING_STORE_PATH" binding_path @@ fun () ->
+  with_env "MASC_DISCORD_BINDING_AUDIT_PATH"
+    (Filename.concat base_dir "audit.jsonl")
+  @@ fun () ->
+  with_env "MASC_DISCORD_NAMES_PATH" (Filename.concat base_dir "names.json")
+  @@ fun () ->
+  write_text binding_path "{not-json";
+  (match State.resolve_keeper_for_channel_result ~channel_id:"C123" with
+   | Error (State.Binding_store_read_failed _) -> ()
+   | Ok _ -> fail "malformed binding store was accepted");
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun sw ->
+  let observed_failure = ref None in
+  let ingress =
+    Connector_ingress_lane.create
+      ~sw
+      ~on_failure:(fun failure -> observed_failure := Some failure)
+      ()
+  in
+  let accepted = ref 0 in
+  let dispatch ~channel:_ ~channel_user_id:_ ~channel_user_name:_
+      ~channel_workspace_id:_ ~keeper_name:_ ~idempotency_key:_ ~metadata:_
+      ~content:_ =
+    incr accepted;
+    Gate_protocol.Reply
+      { content = "queued"; structured = None; stats = None; message_request = None }
+  in
+  let dispatch_for_delivery _delivery = dispatch in
+  G.For_testing.submit_triggered_event
+    ~deliver:(fun () -> ())
+    ingress ~dispatch_for_delivery ~base_dir
+    (discord_message ~message_id:"discord-binding-read-failed");
+  check int "malformed binding was not accepted as unbound" 0 !accepted;
+  (match !observed_failure with
+   | None -> fail "binding read failure was not observed"
+   | Some failure ->
+     check string "failed source event" "discord-binding-read-failed"
+       failure.Connector_ingress_lane.event_id.opaque_id;
+     check bool "triggered route" true
+       (failure.event_id.route = Connector_ingress_lane.Triggered);
+     check bool "acceptance phase" true
+       (failure.event_id.phase = Connector_ingress_lane.Acceptance);
+     (match failure.lane with
+      | Connector_ingress_lane.Connector_lane connector_id ->
+        check string "unresolved connector lane" State.channel connector_id
+      | Connector_ingress_lane.Keeper_lane keeper_name ->
+        failf "binding failure was misattributed to keeper:%s" keeper_name));
+  Yojson.Safe.to_file binding_path (`Assoc [ "C123", `String "luna" ]);
+  G.For_testing.submit_triggered_event
+    ~deliver:(fun () -> ())
+    ingress ~dispatch_for_delivery ~base_dir
+    (discord_message ~message_id:"discord-binding-read-next");
+  check int "next event was accepted" 1 !accepted
+;;
+
 let () =
   run "server_discord_trigger_policy"
     [ ( "parse_trigger_policy"
@@ -266,5 +331,7 @@ let () =
             test_durable_accept_precedes_delivery_handoff
         ; test_case "accept failure preserves next Discord event" `Quick
             test_accept_failure_does_not_kill_discord_ingress
+        ; test_case "binding read failure preserves next Discord event" `Quick
+            test_binding_read_failure_is_observed_and_next_event_continues
         ] )
     ]


### PR DESCRIPTION
## What changed

- replace Discord option-only binding resolution with a typed `Result` carrying `Binding_store_read_failed`
- run binding resolution inside the exact connector acceptance isolation boundary, then attribute typed and unexpected lookup failures to that source event
- route triggered and ambient lookup failures without stopping the gateway reader or other lanes
- remove the stale names-sidecar parent fallback; in-process thread registration remains the parent-routing SSOT
- keep unbound channels distinct from unreadable or malformed binding storage

## Why

The binding store already exposed `read_bindings_result`, but Discord re-read it through a permissive helper and caught every exception as `[]`. An unreadable store therefore looked like an ordinary unbound channel and disappeared without event/lane evidence.

## Verification

- `ocamlformat --check` on all touched OCaml files
- `ocamlc -stop-after parsing` on all touched OCaml files
- `git diff --check`
- `scripts/ci/check-ignore-without-comment-diff.sh --base origin/codex/lane-connector-gate-isolation-c1-20260715 --head HEAD`
- no new silent catch/default-empty patterns in the stacked diff
- focused Dune wrapper attempted; correctly refused with exit 75 while external bare Dune PID 66224 owns the machine-wide build slot (not killed or overridden)

## Scope

398 changed lines. Stacked on #24665. No synchronous accept, HITL, or global governance changes.