### PR TITLE
fix(keeper): retain post-turn memory FIFO work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 - Removed the unused permissive `Activity_feed` JSON decoder surface; the live activity API remains encode-only and its filesystem aggregation, ordering, limit, and agent-filter contracts now have dedicated regression coverage (#23960).
 
 ### Fixed
+- Per-Keeper post-turn memory work is no longer discarded when more than two
+  units overlap. Every accepted immutable unit now enters an explicit FIFO
+  consumed by one worker per Keeper; an unavailable executor returns a typed,
+  observable admission failure instead of silently dropping or running provider
+  work in the submitting turn fiber.
 - Auto Judge requests now persist the exact outer-turn causal context without interpreting it, and durable retryable judgments resume on an accepted provider attempt rather than waiting for a server restart.
 - Keeper Gate state now has a BasePath-derived `.masc/gate/` owner. A corrupt optional Always Allowed rule store degrades only exact-rule lookup, while Chat persistence/read failures remain local to Chat and no longer close unrelated Keeper lanes.
 - Prompt overrides now persist in a schema-versioned envelope bound to the SHA256 revision of each prompt body and template-variable contract. Legacy or malformed files and contract-drifted entries fail closed with observable fallback, writes use atomic replacement, and dashboard set/clear mutations commit to memory only after persistence succeeds.

--- a/lib/keeper/keeper_agent_run_post_turn_memory.ml
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.ml
@@ -30,7 +30,7 @@ let run
   (* (1) deterministic write, (2) librarian extraction, (3) compaction run on
      this keeper's memory lane (RFC-0257), detached from the turn lane. All
      three touch the keeper's memory bank (no internal lock); the lane's
-     per-keeper mutex serializes them. meta/config are immutable snapshots, so
+     per-keeper FIFO worker serializes them. meta/config are immutable snapshots, so
      using them after the turn returns does not race a later turn.
      See RFC #3646 Section 3: Det/NonDet boundary. *)
   let memory_series () =
@@ -145,15 +145,28 @@ let run
        (Keeper_meta_contract.runtime_id_of_meta meta)
        (Printexc.to_string exn))
   in
-  (* RFC-0257: detach (1)-(3) onto the per-keeper memory lane. When the executor
-     switch is not initialized (tests, early startup) the lane runs them inline,
-     so no memory work is lost. *)
-  let (_ : Keeper_memory_lane.outcome) =
-    Keeper_memory_lane.submit
-      ~base_path:config.base_path
-      ~keeper_name:meta.name
-      memory_series
-  in
+  (* RFC-0257: detach (1)-(3) onto the per-keeper memory lane. Admission failure
+     is explicit and observable; provider-backed work never falls back into the
+     submitting turn fiber. *)
+  (match
+     Keeper_memory_lane.submit
+       ~base_path:config.base_path
+       ~keeper_name:meta.name
+       memory_series
+   with
+   | Ok () -> ()
+   | Error error ->
+     Otel_metric_store.inc_counter
+       Keeper_metrics.(to_string DispatchEventFailures)
+       ~labels:
+         [ "keeper", meta.name
+         ; "site", "memory_lane_admission"
+         ; "reason", Keeper_memory_lane.admission_error_code error
+         ]
+       ();
+     Log.Keeper.error ~keeper_name:meta.name
+       "post-turn memory lane admission failed: %s"
+       (Keeper_memory_lane.admission_error_to_string error));
   (* Post-turn memory recall evidence is logged to decisions.jsonl. *)
   (try
      let used_search =

--- a/lib/keeper/keeper_memory_lane.ml
+++ b/lib/keeper/keeper_memory_lane.ml
@@ -1,35 +1,42 @@
 (** Per-keeper memory execution lane. See keeper_memory_lane.mli (RFC-0257). *)
 
+type work_item = unit -> unit
+
 type entry =
-  { mem_mu : Eio.Mutex.t
-    (* Serializes memory work within one keeper; held across a provider round
-       trip (seconds), hence the fiber-cooperative Eio.Mutex. Raw lock/unlock,
-       not [use_rw]: a raising unit must not poison the lane. *)
+  { queue : work_item Queue.t
   ; state_mu : Stdlib.Mutex.t
-    (* Guards [pending]. Critical sections never yield. *)
+    (* Guards [queue], [pending], and [worker_active]. Critical sections never
+       yield. *)
   ; mutable pending : int
+  ; mutable worker_active : bool
   }
 
-type outcome =
-  | Submitted
-  | Ran_inline
-  | Dropped
+type admission_error =
+  | Executor_not_initialized
+  | Executor_domain_mismatch
+  | Executor_stopping
+  | Worker_start_failed of exn
 
-type reservation =
-  { release_mu : Stdlib.Mutex.t
-  ; mutable released : bool
-  ; mutable switch_hook : Eio.Switch.hook option
+type executor =
+  { sw : Eio.Switch.t
+  ; owner_domain : Domain.id
   }
 
-(* Per-keeper reservation bound: 1 in-flight (holding [mem_mu]) plus 1 queued.
-   A third concurrent post-turn unit for the same keeper means turns outpace
-   extraction; the excess is best-effort and dropped rather than piling up
-   fibers. Tunable via environment for fleet-wide capacity experiments. *)
-let max_pending () =
-  Keeper_memory_bank_env.memory_env_int_logged
-    "MASC_KEEPER_MEMORY_LANE_MAX_PENDING"
-    ~default:2
-  |> max 1
+exception Worker_did_not_start
+
+let admission_error_code = function
+  | Executor_not_initialized -> "executor_not_initialized"
+  | Executor_domain_mismatch -> "executor_domain_mismatch"
+  | Executor_stopping -> "executor_stopping"
+  | Worker_start_failed _ -> "worker_start_failed"
+;;
+
+let admission_error_to_string = function
+  | Executor_not_initialized -> "memory lane executor is not initialized"
+  | Executor_domain_mismatch -> "memory lane submission came from a non-owner domain"
+  | Executor_stopping -> "memory lane executor is cancelling or finished"
+  | Worker_start_failed exn ->
+    Printf.sprintf "memory lane worker failed to start: %s" (Printexc.to_string exn)
 ;;
 
 let entries : (string, entry) Hashtbl.t = Hashtbl.create 16
@@ -39,37 +46,48 @@ let entries : (string, entry) Hashtbl.t = Hashtbl.create 16
 let registry_mu = Stdlib.Mutex.create ()
 
 (* Set once by [init] at startup, before keepers run. Guarded by [registry_mu]
-   so a reader sees the write. *)
-let executor_sw : Eio.Switch.t option ref = ref None
+   so a reader sees the write. The owner domain is part of the executor
+   capability: Eio switches may only be used from their creating domain. *)
+let executor : executor option ref = ref None
 
 let init ~sw =
-  Stdlib.Mutex.protect registry_mu (fun () -> executor_sw := Some sw)
+  Stdlib.Mutex.protect registry_mu (fun () ->
+    executor := Some { sw; owner_domain = Domain.self () })
 ;;
 
-let current_sw () = Stdlib.Mutex.protect registry_mu (fun () -> !executor_sw)
+let current_executor () = Stdlib.Mutex.protect registry_mu (fun () -> !executor)
 
 let entry_for ~base_path ~keeper_name =
   let key = Keeper_registry_types.registry_key ~base_path keeper_name in
   Stdlib.Mutex.protect registry_mu (fun () ->
     match Hashtbl.find_opt entries key with
-    | Some e -> e
+    | Some entry -> entry
     | None ->
-      let e =
-        { mem_mu = Eio.Mutex.create ()
+      let entry =
+        { queue = Queue.create ()
         ; state_mu = Stdlib.Mutex.create ()
         ; pending = 0
+        ; worker_active = false
         }
       in
-      Hashtbl.add entries key e;
-      e)
+      Hashtbl.add entries key entry;
+      entry)
 ;;
 
-let metric_name m = Keeper_metrics.(to_string m)
+let metric_name metric = Keeper_metrics.(to_string metric)
 
-let record_counter ~keeper_name metric =
+let record_counter ?(delta = 1.0) ~keeper_name metric =
   Otel_metric_store.inc_counter
     (metric_name metric)
     ~labels:[ "keeper", keeper_name ]
+    ~delta
+    ()
+;;
+
+let record_rejection ~keeper_name error =
+  Otel_metric_store.inc_counter
+    (metric_name MemoryLaneAdmissionRejected)
+    ~labels:[ "keeper", keeper_name; "reason", admission_error_code error ]
     ()
 ;;
 
@@ -80,10 +98,11 @@ let inc_pending ~keeper_name () =
     ()
 ;;
 
-let dec_pending ~keeper_name () =
+let dec_pending ?(delta = 1.0) ~keeper_name () =
   Otel_metric_store.dec_gauge
     (metric_name MemoryLanePending)
     ~labels:[ "keeper", keeper_name ]
+    ~delta
     ()
 ;;
 
@@ -101,186 +120,224 @@ let dec_in_flight ~keeper_name () =
     ()
 ;;
 
-let try_reserve ~keeper_name entry =
-  Stdlib.Mutex.protect entry.state_mu (fun () ->
-    let bound = max_pending () in
-    if entry.pending >= bound
-    then None
-    else (
+let admit ~keeper_name entry work =
+  let action =
+    Stdlib.Mutex.protect entry.state_mu (fun () ->
       entry.pending <- entry.pending + 1;
-      inc_pending ~keeper_name ();
-      Some bound))
-;;
-
-let release_reservation ~keeper_name entry =
-  Stdlib.Mutex.protect entry.state_mu (fun () ->
-    entry.pending <- entry.pending - 1;
-    dec_pending ~keeper_name ())
-;;
-
-let make_reservation () =
-  { release_mu = Stdlib.Mutex.create (); released = false; switch_hook = None }
-;;
-
-let reservation_released reservation =
-  Stdlib.Mutex.protect reservation.release_mu (fun () -> reservation.released)
-;;
-
-let release_reservation_once ~keeper_name entry reservation =
-  let should_release =
-    Stdlib.Mutex.protect reservation.release_mu (fun () ->
-      if reservation.released
-      then false
+      if entry.worker_active
+      then (
+        Queue.push work entry.queue;
+        `Enqueued)
       else (
-        reservation.released <- true;
-        true))
+        entry.worker_active <- true;
+        `Start_worker))
   in
-  if should_release then release_reservation ~keeper_name entry
+  inc_pending ~keeper_name ();
+  action
 ;;
 
-let disarm_switch_hook reservation =
-  let hook =
-    Stdlib.Mutex.protect reservation.release_mu (fun () ->
-      let hook = reservation.switch_hook in
-      reservation.switch_hook <- None;
-      hook)
+let rollback_worker_start ~keeper_name entry =
+  Stdlib.Mutex.protect entry.state_mu (fun () ->
+    entry.worker_active <- false;
+    entry.pending <- entry.pending - 1);
+  dec_pending ~keeper_name ()
+;;
+
+let finish_one ~keeper_name entry =
+  Stdlib.Mutex.protect entry.state_mu (fun () ->
+    entry.pending <- entry.pending - 1);
+  dec_pending ~keeper_name ()
+;;
+
+let take_next entry =
+  Stdlib.Mutex.protect entry.state_mu (fun () ->
+    match Queue.take_opt entry.queue with
+    | Some work -> Some work
+    | None ->
+      entry.worker_active <- false;
+      None)
+;;
+
+let cancel_queued ~keeper_name entry =
+  let cancelled =
+    Stdlib.Mutex.protect entry.state_mu (fun () ->
+      let count = Queue.length entry.queue in
+      Queue.clear entry.queue;
+      entry.pending <- entry.pending - count;
+      entry.worker_active <- false;
+      count)
   in
-  Option.iter (fun hook -> ignore (Eio.Switch.try_remove_hook hook)) hook
+  if cancelled > 0
+  then (
+    dec_pending ~keeper_name ~delta:(Float.of_int cancelled) ();
+    record_counter
+      ~keeper_name
+      ~delta:(Float.of_int cancelled)
+      MemoryLaneCancelledUnits);
+  cancelled
 ;;
 
-let protect_cleanup ~keeper_name label f =
-  try f () with
-  | exn ->
-    record_counter ~keeper_name MemoryLaneUnitFailures;
-    Log.Keeper.warn ~keeper_name
-      "memory lane cleanup failed (%s): %s"
-      label
-      (Printexc.to_string exn)
-;;
+type run_result =
+  | Continue
+  | Cancelled
 
-let release_after_run ~keeper_name entry reservation ~acquired ~in_flight =
-  if !in_flight
-  then protect_cleanup ~keeper_name "dec_in_flight" (fun () -> dec_in_flight ~keeper_name ());
-  if !acquired
-  then protect_cleanup ~keeper_name "unlock" (fun () -> Eio.Mutex.unlock entry.mem_mu);
-  protect_cleanup ~keeper_name "release_reservation" (fun () ->
-    release_reservation_once ~keeper_name entry reservation)
-;;
-
-let arm_switch_release ~keeper_name entry reservation sw =
-  let release_from_switch () =
-    protect_cleanup ~keeper_name "executor_switch_release" (fun () ->
-      release_reservation_once ~keeper_name entry reservation)
-  in
-  try
-    let hook = Eio.Switch.on_release_cancellable sw release_from_switch in
-    Stdlib.Mutex.protect reservation.release_mu (fun () ->
-      if reservation.released
-      then ignore (Eio.Switch.try_remove_hook hook)
-      else reservation.switch_hook <- Some hook)
-  with
-  | _exn ->
-    (* Finished switches can raise while running the release callback; any hook
-       registration failure means the executor cannot own this reservation. *)
-    release_from_switch ()
-;;
-
-(* Runs on a forked fiber owned by the executor switch. Holds [mem_mu] across
-   the unit. Releases the mutex (only if acquired) and the reservation on every
-   exit, including cancellation at shutdown. No exception escapes: a best-effort
-   unit must never propagate into the executor switch — that would cancel the
-   fleet. *)
-let run_unit ~keeper_name entry reservation sw f =
-  let acquired = ref false in
-  let in_flight = ref false in
-  Eio.Switch.run (fun cleanup_sw ->
-    Eio.Switch.on_release cleanup_sw (fun () ->
-      release_after_run ~keeper_name entry reservation ~acquired ~in_flight);
-      disarm_switch_hook reservation;
-      try
-        Eio.Mutex.lock entry.mem_mu;
-        (* No suspension point between [lock] returning and this assignment, so
-           cancellation cannot strand a held mutex with [acquired = false]. *)
-        acquired := true;
-        inc_in_flight ~keeper_name ();
-        in_flight := true;
-        Eio_context.with_turn_switch sw f
-      with
-      | Eio.Cancel.Cancelled _ -> () (* shutdown: silent, cleanup runs above *)
-      | exn ->
+let run_one ~keeper_name entry sw work =
+  inc_in_flight ~keeper_name ();
+  Fun.protect
+    ~finally:(fun () ->
+      dec_in_flight ~keeper_name ();
+      finish_one ~keeper_name entry)
+    (fun () ->
+      match Eio_context.with_turn_switch sw work with
+      | () -> Continue
+      | exception Eio.Cancel.Cancelled _ as exn ->
+        if Eio.Fiber.is_cancelled ()
+        then (
+          record_counter ~keeper_name MemoryLaneCancelledUnits;
+          Cancelled)
+        else (
+          (* A promise may carry [Cancelled] while this worker's own context is
+             still live. Treat that as a unit failure, not executor shutdown;
+             otherwise one foreign result could discard the rest of the FIFO. *)
+          record_counter ~keeper_name MemoryLaneUnitFailures;
+          Log.Keeper.warn ~keeper_name
+            "memory lane unit returned a foreign cancellation: %s"
+            (Printexc.to_string exn);
+          Continue)
+      | exception exn ->
         record_counter ~keeper_name MemoryLaneUnitFailures;
         Log.Keeper.warn ~keeper_name
           "memory lane unit failed: %s"
-          (Printexc.to_string exn))
+          (Printexc.to_string exn);
+        Continue)
 ;;
 
-let submit ~base_path ~keeper_name f =
-  match current_sw () with
-  | None ->
-    (* Not initialized: run inline. The caller is still inside the per-keeper
-       turn lane, so single-fiber-per-keeper memory access is preserved. A
-       raising unit is contained and counted rather than escaping. *)
-    (try f () with
-     | Eio.Cancel.Cancelled _ as e -> raise e
-     | exn ->
-       record_counter ~keeper_name MemoryLaneUnitFailures;
-       Log.Keeper.warn ~keeper_name
-         "memory lane unit failed (inline): %s"
-         (Printexc.to_string exn));
-    record_counter ~keeper_name MemoryLaneRanInline;
-    Ran_inline
-  | Some sw ->
-    let entry = entry_for ~base_path ~keeper_name in
-    (match try_reserve ~keeper_name entry with
-     | None ->
-       record_counter ~keeper_name MemoryLaneDropped;
-       Otel_metric_store.inc_counter
-         Keeper_metrics.(to_string DispatchEventFailures)
-         ~labels:[ "keeper", keeper_name; "site", "memory_lane_saturated" ]
-         ();
-       Log.Keeper.warn ~keeper_name
-         "memory lane saturated (pending>=%d): dropping post-turn memory unit"
-         (max_pending ());
-       Dropped
-     | Some _bound ->
-       let reservation = make_reservation () in
-       arm_switch_release ~keeper_name entry reservation sw;
-       if reservation_released reservation
-       then (
-         record_counter ~keeper_name MemoryLaneDropped;
-         Log.Keeper.warn ~keeper_name
-           "memory lane executor switch unavailable: dropping post-turn memory unit";
-         Dropped)
-       else (
-         try
+let rec worker_loop ~keeper_name entry sw work =
+  match run_one ~keeper_name entry sw work with
+  | Cancelled ->
+    let queued = cancel_queued ~keeper_name entry in
+    Log.Keeper.warn ~keeper_name
+      "memory lane executor cancelled: current unit cancelled, queued_units=%d"
+      queued
+  | Continue -> (
+    match Eio.Switch.get_error sw with
+    | Some _ ->
+      let queued = cancel_queued ~keeper_name entry in
+      Log.Keeper.warn ~keeper_name
+        "memory lane executor stopped after current unit: queued_units_cancelled=%d"
+        queued
+    | None -> (
+      match take_next entry with
+      | None -> ()
+      | Some next -> worker_loop ~keeper_name entry sw next))
+;;
+
+let cancel_before_first ~keeper_name entry =
+  record_counter ~keeper_name MemoryLaneCancelledUnits;
+  finish_one ~keeper_name entry;
+  let queued = cancel_queued ~keeper_name entry in
+  Log.Keeper.warn ~keeper_name
+    "memory lane executor cancelled before worker dispatch: cancelled_units=%d"
+    (queued + 1)
+;;
+
+let run_worker ~keeper_name entry sw first =
+  match Eio.Fiber.yield () with
+  | () -> (
+    try worker_loop ~keeper_name entry sw first with
+    | exn ->
+      let queued = cancel_queued ~keeper_name entry in
+      record_counter ~keeper_name MemoryLaneUnitFailures;
+      Log.Keeper.error ~keeper_name
+        "memory lane worker failed: queued_units_cancelled=%d error=%s"
+        queued
+        (Printexc.to_string exn))
+  | exception Eio.Cancel.Cancelled _ -> cancel_before_first ~keeper_name entry
+  | exception exn ->
+    finish_one ~keeper_name entry;
+    let queued = cancel_queued ~keeper_name entry in
+    record_counter ~keeper_name MemoryLaneUnitFailures;
+    Log.Keeper.error ~keeper_name
+      "memory lane worker dispatch failed: queued_units_cancelled=%d error=%s"
+      queued
+      (Printexc.to_string exn)
+;;
+
+let start_worker ~keeper_name entry sw first =
+  let started, set_started = Eio.Promise.create () in
+  match
+    Eio.Fiber.fork ~sw (fun () ->
+      Eio.Promise.resolve set_started ();
+      run_worker ~keeper_name entry sw first)
+  with
+  | () -> (
+    match Eio.Promise.peek started with
+    | Some () -> Ok ()
+    | None ->
+      let error = Worker_start_failed Worker_did_not_start in
+      rollback_worker_start ~keeper_name entry;
+      Error error)
+  | exception exn ->
+    rollback_worker_start ~keeper_name entry;
+    Error (Worker_start_failed exn)
+;;
+
+let reject ~keeper_name error =
+  record_rejection ~keeper_name error;
+  Error error
+;;
+
+let submit ~base_path ~keeper_name work =
+  match current_executor () with
+  | None -> reject ~keeper_name Executor_not_initialized
+  | Some { sw; owner_domain } ->
+    if Domain.self () <> owner_domain
+    then reject ~keeper_name Executor_domain_mismatch
+    else (
+      match Eio.Switch.get_error sw with
+      | Some _ -> reject ~keeper_name Executor_stopping
+      | None ->
+        let entry = entry_for ~base_path ~keeper_name in
+        (match admit ~keeper_name entry work with
+         | `Enqueued ->
            record_counter ~keeper_name MemoryLaneSubmitted;
-           Eio.Fiber.fork ~sw (fun () -> run_unit ~keeper_name entry reservation sw f);
-           Submitted
-         with
-         | Eio.Cancel.Cancelled _ as e ->
-           protect_cleanup ~keeper_name "fork_cancel_release" (fun () ->
-             release_reservation_once ~keeper_name entry reservation);
-           raise e
-         | exn ->
-           protect_cleanup ~keeper_name "fork_failure_release" (fun () ->
-             release_reservation_once ~keeper_name entry reservation);
-           record_counter ~keeper_name MemoryLaneUnitFailures;
-           Log.Keeper.warn ~keeper_name
-             "memory lane fork failed: %s"
-             (Printexc.to_string exn);
-           Dropped))
+           Ok ()
+         | `Start_worker -> (
+           match start_worker ~keeper_name entry sw work with
+           | Ok () ->
+             record_counter ~keeper_name MemoryLaneSubmitted;
+             Ok ()
+           | Error error -> reject ~keeper_name error)))
 ;;
 
 module For_testing = struct
   let reset () =
     Stdlib.Mutex.protect registry_mu (fun () ->
       Hashtbl.reset entries;
-      executor_sw := None)
+      executor := None)
+  ;;
+
+  let find_entry ~base_path ~keeper_name =
+    let key = Keeper_registry_types.registry_key ~base_path keeper_name in
+    Stdlib.Mutex.protect registry_mu (fun () -> Hashtbl.find_opt entries key)
   ;;
 
   let pending ~base_path ~keeper_name =
-    let key = Keeper_registry_types.registry_key ~base_path keeper_name in
-    Stdlib.Mutex.protect registry_mu (fun () -> Hashtbl.find_opt entries key)
-    |> Option.map (fun e -> Stdlib.Mutex.protect e.state_mu (fun () -> e.pending))
+    find_entry ~base_path ~keeper_name
+    |> Option.map (fun entry ->
+      Stdlib.Mutex.protect entry.state_mu (fun () -> entry.pending))
+  ;;
+
+  let queued ~base_path ~keeper_name =
+    find_entry ~base_path ~keeper_name
+    |> Option.map (fun entry ->
+      Stdlib.Mutex.protect entry.state_mu (fun () -> Queue.length entry.queue))
+  ;;
+
+  let active_workers ~base_path ~keeper_name =
+    find_entry ~base_path ~keeper_name
+    |> Option.map (fun entry ->
+      Stdlib.Mutex.protect entry.state_mu (fun () ->
+        if entry.worker_active then 1 else 0))
   ;;
 end

--- a/lib/keeper/keeper_memory_lane.ml
+++ b/lib/keeper/keeper_memory_lane.ml
@@ -188,9 +188,11 @@ let run_one ~keeper_name entry sw work =
       dec_in_flight ~keeper_name ();
       finish_one ~keeper_name entry)
     (fun () ->
-      match Eio_context.with_turn_switch sw work with
-      | () -> Continue
-      | exception Eio.Cancel.Cancelled _ as exn ->
+      try
+        Eio_context.with_turn_switch sw work;
+        Continue
+      with
+      | Eio.Cancel.Cancelled _ as exn ->
         if Eio.Fiber.is_cancelled ()
         then (
           record_counter ~keeper_name MemoryLaneCancelledUnits;
@@ -204,7 +206,7 @@ let run_one ~keeper_name entry sw work =
             "memory lane unit returned a foreign cancellation: %s"
             (Printexc.to_string exn);
           Continue)
-      | exception exn ->
+      | exn ->
         record_counter ~keeper_name MemoryLaneUnitFailures;
         Log.Keeper.warn ~keeper_name
           "memory lane unit failed: %s"
@@ -242,18 +244,19 @@ let cancel_before_first ~keeper_name entry =
 ;;
 
 let run_worker ~keeper_name entry sw first =
-  match Eio.Fiber.yield () with
-  | () -> (
-    try worker_loop ~keeper_name entry sw first with
-    | exn ->
-      let queued = cancel_queued ~keeper_name entry in
-      record_counter ~keeper_name MemoryLaneUnitFailures;
-      Log.Keeper.error ~keeper_name
-        "memory lane worker failed: queued_units_cancelled=%d error=%s"
-        queued
-        (Printexc.to_string exn))
-  | exception Eio.Cancel.Cancelled _ -> cancel_before_first ~keeper_name entry
-  | exception exn ->
+  try
+    Eio.Fiber.yield ();
+    (try worker_loop ~keeper_name entry sw first with
+     | exn ->
+       let queued = cancel_queued ~keeper_name entry in
+       record_counter ~keeper_name MemoryLaneUnitFailures;
+       Log.Keeper.error ~keeper_name
+         "memory lane worker failed: queued_units_cancelled=%d error=%s"
+         queued
+         (Printexc.to_string exn))
+  with
+  | Eio.Cancel.Cancelled _ -> cancel_before_first ~keeper_name entry
+  | exn ->
     finish_one ~keeper_name entry;
     let queued = cancel_queued ~keeper_name entry in
     record_counter ~keeper_name MemoryLaneUnitFailures;

--- a/lib/keeper/keeper_memory_lane.mli
+++ b/lib/keeper/keeper_memory_lane.mli
@@ -1,9 +1,10 @@
 (** Per-keeper memory execution lane (RFC-0257).
 
     Detaches post-turn memory work (deterministic write, librarian extraction,
-    compaction) from the keeper turn lane. Each keeper has its own mutex, so
-    memory work is serialized within a keeper and runs independently across
-    keepers. This replaces the process-global [Eio.Semaphore.make 1] in
+    compaction) from the keeper turn lane. Each keeper has an explicit FIFO
+    queue consumed by at most one worker fiber, so memory work is serialized
+    within a keeper and runs independently across keepers. This replaces the
+    process-global [Eio.Semaphore.make 1] in
     [Keeper_librarian_runtime] that previously serialized every keeper's
     librarian work fleet-wide — the opposite of the lane-per-keeper model
     (RFC-0225).
@@ -17,22 +18,28 @@
     (e.g. [Keeper_meta_contract.keeper_meta], [Workspace.config]) and never over
     mutable turn-local references.
 
-    The per-keeper reservation bound is controlled by
-    [MASC_KEEPER_MEMORY_LANE_MAX_PENDING] (default [2]). Submission outcomes
-    are counted under [masc_keeper_memory_lane_*] and per-keeper pending /
-    in-flight gauges are exported. *)
+    Every accepted unit is retained and serialized; the lane never discards
+    memory work because another unit is in flight. Admission fails explicitly
+    when the executor cannot own the work. Submission outcomes are counted
+    under [masc_keeper_memory_lane_*] and per-keeper pending / in-flight gauges
+    are exported. *)
 
-type outcome =
-  | Submitted
-      (** Forked onto the keeper's lane and serialized behind its mutex. *)
-  | Ran_inline
-      (** Executor switch not initialized; the unit ran synchronously in the
-          caller so no work is lost (tests, or startup before {!init}). A
-          raising unit is contained and emits a metric instead of escaping. *)
-  | Dropped
-      (** The keeper's lane was saturated (pending at the bound); the unit was
-          discarded. Memory extraction is best-effort, so saturation drops
-          rather than blocking the turn. The drop is counted, never silent. *)
+type admission_error =
+  | Executor_not_initialized
+      (** {!init} has not installed the long-lived executor capability. *)
+  | Executor_domain_mismatch
+      (** Submission did not occur on the Eio switch's owner domain. *)
+  | Executor_stopping
+      (** The executor switch is cancelling or has finished. *)
+  | Worker_start_failed of exn
+      (** Eio did not start the worker after the first unit was reserved. *)
+
+val admission_error_code : admission_error -> string
+(** Stable low-cardinality code for logs and metric labels. *)
+
+val admission_error_to_string : admission_error -> string
+(** Human-readable detail. Control flow must use the typed constructors, not
+    this rendering. *)
 
 val init : sw:Eio.Switch.t -> unit
 (** Record the long-lived switch that owns detached memory fibers. Call once at
@@ -42,13 +49,13 @@ val submit
   :  base_path:string
   -> keeper_name:string
   -> (unit -> unit)
-  -> outcome
-(** [submit ~base_path ~keeper_name f] runs [f] on [keeper_name]'s memory lane.
-    When the executor switch is set, [f] is forked and serialized behind that
-    keeper's mutex; over the pending bound it is dropped and counted. When the
-    executor is not initialized, [f] runs inline and any exception is contained
-    and counted rather than escaping. The bound, outcomes, and per-keeper
-    pending/in-flight state are exported as metrics. *)
+  -> (unit, admission_error) result
+(** [submit ~base_path ~keeper_name f] admits [f] to [keeper_name]'s FIFO memory
+    lane. The first accepted unit starts one worker; overlapping units queue
+    behind it without spawning additional fibers. [Ok ()] means the worker is
+    active and owns the unit. [Error reason] means the unit was not accepted;
+    callers must handle that result explicitly. Provider work never runs in the
+    submitting turn fiber. Unit exceptions are contained and counted. *)
 
 module For_testing : sig
   val reset : unit -> unit
@@ -56,4 +63,10 @@ module For_testing : sig
 
   val pending : base_path:string -> keeper_name:string -> int option
   (** Current pending count for a keeper ([None] if the keeper has no entry). *)
+
+  val queued : base_path:string -> keeper_name:string -> int option
+  (** Number of accepted units waiting behind the active unit. *)
+
+  val active_workers : base_path:string -> keeper_name:string -> int option
+  (** [0] or [1], exposing the single-worker invariant for deterministic tests. *)
 end

--- a/lib/keeper/keeper_memory_work_request.ml
+++ b/lib/keeper/keeper_memory_work_request.ml
@@ -1,0 +1,286 @@
+type t =
+  { request_id : string
+  ; keeper_name : string
+  ; generation : int
+  ; turn : int
+  ; runtime_id : string
+  ; meta : Keeper_meta_contract.keeper_meta
+  ; tool_results : Yojson.Safe.t list
+  ; librarian_messages : Agent_sdk.Types.message list
+  ; deliberation_execution : Yojson.Safe.t option
+  }
+
+let schema_version = 1
+let ( let* ) = Result.bind
+
+let request_id request = request.request_id
+let keeper_name request = request.keeper_name
+let generation request = request.generation
+let turn request = request.turn
+let runtime_id request = request.runtime_id
+let meta request = request.meta
+let tool_results request = request.tool_results
+let librarian_messages request = request.librarian_messages
+let deliberation_execution request = request.deliberation_execution
+
+let validate_fields ~context ~expected fields =
+  let rec loop seen = function
+    | [] ->
+      (match List.find_opt (fun name -> not (List.mem name seen)) expected with
+       | None -> Ok ()
+       | Some name -> Error (Printf.sprintf "%s is missing field %S" context name))
+    | (name, _) :: rest ->
+      if List.mem name seen then
+        Error (Printf.sprintf "%s has duplicate field %S" context name)
+      else if not (List.mem name expected) then
+        Error (Printf.sprintf "%s has unknown field %S" context name)
+      else
+        loop (name :: seen) rest
+  in
+  loop [] fields
+;;
+
+let field name fields =
+  match List.assoc_opt name fields with
+  | Some value -> Ok value
+  | None -> Error (Printf.sprintf "memory work request is missing field %S" name)
+;;
+
+let string_field name fields =
+  let* value = field name fields in
+  match value with
+  | `String value -> Ok value
+  | _ -> Error (Printf.sprintf "memory work request field %S must be a string" name)
+;;
+
+let int_field name fields =
+  let* value = field name fields in
+  match value with
+  | `Int value -> Ok value
+  | _ -> Error (Printf.sprintf "memory work request field %S must be an integer" name)
+;;
+
+let rec normalize_json = function
+  | `Assoc fields ->
+    fields
+    |> List.map (fun (name, value) -> name, normalize_json value)
+    |> List.stable_sort (fun (left, _) (right, _) -> String.compare left right)
+    |> fun fields -> `Assoc fields
+  | `List values -> `List (List.map normalize_json values)
+  | (`Null | `Bool _ | `Int _ | `Intlit _ | `Float _ | `String _) as value -> value
+;;
+
+let body_to_json
+      ~keeper_name
+      ~generation
+      ~turn
+      ~runtime_id
+      ~meta
+      ~tool_results
+      ~librarian_messages
+      ~deliberation_execution
+  =
+  `Assoc
+    [ "keeper_name", `String keeper_name
+    ; "generation", `Int generation
+    ; "turn", `Int turn
+    ; "runtime_id", `String runtime_id
+    ; "meta", Keeper_meta_json.meta_to_json meta
+    ; "tool_results", `List tool_results
+    ; ( "librarian_messages"
+      , `List (List.map Keeper_context_core.message_to_json librarian_messages) )
+    ; ( "deliberation_execution"
+      , Option.value ~default:`Null deliberation_execution )
+    ]
+;;
+
+let request_id_of_body body =
+  body
+  |> normalize_json
+  |> Yojson.Safe.to_string
+  |> Digestif.SHA256.digest_string
+  |> Digestif.SHA256.to_hex
+;;
+
+let validate_snapshot
+      ~keeper_name
+      ~generation
+      ~turn
+      ~runtime_id
+      ~(meta : Keeper_meta_contract.keeper_meta)
+      ~tool_results
+      ~deliberation_execution
+  =
+  if String.trim keeper_name = "" then
+    Error "memory work keeper_name must not be empty"
+  else if String.trim runtime_id = "" then
+    Error "memory work runtime_id must not be empty"
+  else if generation < 0 then
+    Error "memory work generation must not be negative"
+  else if turn < 0 then
+    Error "memory work turn must not be negative"
+  else if not (String.equal keeper_name meta.name) then
+    Error "memory work keeper_name does not match its meta snapshot"
+  else if meta.runtime.generation <> generation then
+    Error "memory work generation does not match its meta snapshot"
+  else if not (List.for_all (function `Assoc _ -> true | _ -> false) tool_results) then
+    Error "memory work tool_results must contain only typed JSON objects"
+  else
+    match deliberation_execution with
+    | None | Some (`Assoc _) -> Ok ()
+    | Some _ -> Error "memory work deliberation_execution must be a JSON object"
+;;
+
+let make
+      ~keeper_name
+      ~generation
+      ~turn
+      ~runtime_id
+      ~meta
+      ~tool_results
+      ~librarian_messages
+      ~deliberation_execution
+  =
+  let* () =
+    validate_snapshot
+      ~keeper_name
+      ~generation
+      ~turn
+      ~runtime_id
+      ~meta
+      ~tool_results
+      ~deliberation_execution
+  in
+  let body =
+    body_to_json
+      ~keeper_name
+      ~generation
+      ~turn
+      ~runtime_id
+      ~meta
+      ~tool_results
+      ~librarian_messages
+      ~deliberation_execution
+  in
+  Ok
+    { request_id = request_id_of_body body
+    ; keeper_name
+    ; generation
+    ; turn
+    ; runtime_id
+    ; meta
+    ; tool_results
+    ; librarian_messages
+    ; deliberation_execution
+    }
+;;
+
+let body_of_request request =
+  body_to_json
+    ~keeper_name:request.keeper_name
+    ~generation:request.generation
+    ~turn:request.turn
+    ~runtime_id:request.runtime_id
+    ~meta:request.meta
+    ~tool_results:request.tool_results
+    ~librarian_messages:request.librarian_messages
+    ~deliberation_execution:request.deliberation_execution
+;;
+
+let to_json request =
+  `Assoc
+    [ "schema_version", `Int schema_version
+    ; "request_id", `String request.request_id
+    ; "body", body_of_request request
+    ]
+;;
+
+let list_field name fields =
+  let* value = field name fields in
+  match value with
+  | `List values -> Ok values
+  | _ -> Error (Printf.sprintf "memory work request field %S must be a list" name)
+;;
+
+let decode_message value =
+  try
+    let message = Keeper_context_core.message_of_json value in
+    match value with
+    | `Assoc fields ->
+      (match List.assoc_opt "metadata" fields with
+       | None -> Ok message
+       | Some (`Assoc metadata) -> Ok { message with metadata }
+       | Some _ -> Error "librarian message metadata must be a JSON object")
+    | _ -> Error "librarian message must be a JSON object"
+  with
+  | exn -> Error (Printf.sprintf "invalid librarian message: %s" (Printexc.to_string exn))
+;;
+
+let decode_messages values =
+  List.fold_right
+    (fun value result ->
+       let* rest = result in
+       let* message = decode_message value in
+       Ok (message :: rest))
+    values
+    (Ok [])
+;;
+
+let of_body_json = function
+  | `Assoc fields ->
+    let expected =
+      [ "keeper_name"; "generation"; "turn"; "runtime_id"; "meta"
+      ; "tool_results"; "librarian_messages"; "deliberation_execution"
+      ]
+    in
+    let* () = validate_fields ~context:"memory work request body" ~expected fields in
+    let* keeper_name = string_field "keeper_name" fields in
+    let* generation = int_field "generation" fields in
+    let* turn = int_field "turn" fields in
+    let* runtime_id = string_field "runtime_id" fields in
+    let* meta_json = field "meta" fields in
+    let* meta = Keeper_meta_json.meta_of_json meta_json in
+    let* tool_results = list_field "tool_results" fields in
+    let* message_values = list_field "librarian_messages" fields in
+    let* librarian_messages = decode_messages message_values in
+    let* deliberation_json = field "deliberation_execution" fields in
+    let deliberation_execution =
+      match deliberation_json with
+      | `Null -> Ok None
+      | `Assoc _ as json -> Ok (Some json)
+      | _ -> Error "memory work deliberation_execution must be an object or null"
+    in
+    let* deliberation_execution = deliberation_execution in
+    make
+      ~keeper_name
+      ~generation
+      ~turn
+      ~runtime_id
+      ~meta
+      ~tool_results
+      ~librarian_messages
+      ~deliberation_execution
+  | _ -> Error "memory work request body must be a JSON object"
+;;
+
+let of_json = function
+  | `Assoc fields ->
+    let* () =
+      validate_fields
+        ~context:"memory work request"
+        ~expected:[ "schema_version"; "request_id"; "body" ]
+        fields
+    in
+    let* encoded_schema = int_field "schema_version" fields in
+    if encoded_schema <> schema_version then
+      Error (Printf.sprintf "unsupported memory work schema_version %d" encoded_schema)
+    else
+      let* encoded_id = string_field "request_id" fields in
+      let* body = field "body" fields in
+      let* request = of_body_json body in
+      if String.equal encoded_id request.request_id then
+        Ok request
+      else
+        Error "memory work request_id does not match its canonical body"
+  | _ -> Error "memory work request must be a JSON object"
+;;

--- a/lib/keeper/keeper_memory_work_request.mli
+++ b/lib/keeper/keeper_memory_work_request.mli
@@ -1,0 +1,32 @@
+(** Immutable, restart-reconstructable input for one post-turn Memory Lane unit. *)
+
+type t
+
+val schema_version : int
+val request_id : t -> string
+val keeper_name : t -> string
+val generation : t -> int
+val turn : t -> int
+val runtime_id : t -> string
+val meta : t -> Keeper_meta_contract.keeper_meta
+val tool_results : t -> Yojson.Safe.t list
+val librarian_messages : t -> Agent_sdk.Types.message list
+val deliberation_execution : t -> Yojson.Safe.t option
+
+val make :
+  keeper_name:string ->
+  generation:int ->
+  turn:int ->
+  runtime_id:string ->
+  meta:Keeper_meta_contract.keeper_meta ->
+  tool_results:Yojson.Safe.t list ->
+  librarian_messages:Agent_sdk.Types.message list ->
+  deliberation_execution:Yojson.Safe.t option ->
+  (t, string) result
+(** Validate the typed snapshot and derive [request_id] from its canonical JSON.
+    The identifier is content-derived; it is not a scheduling limit or policy. *)
+
+val to_json : t -> Yojson.Safe.t
+val of_json : Yojson.Safe.t -> (t, string) result
+(** Strict closed codec. Unknown or duplicate fields and identifier drift are
+    explicit errors. *)

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -147,8 +147,8 @@ type t =
   | MemoryLaneUnitFailures
   | MemoryConsolidations
   | MemoryLaneSubmitted
-  | MemoryLaneRanInline
-  | MemoryLaneDropped
+  | MemoryLaneAdmissionRejected
+  | MemoryLaneCancelledUnits
   | MemoryLanePending
   | MemoryLaneInFlight
   | MemoryLaneProviderSlotBusy
@@ -374,8 +374,8 @@ let to_string = function
   | MemoryLaneUnitFailures -> "masc_keeper_memory_lane_unit_failures_total"
   | MemoryConsolidations -> "masc_keeper_memory_consolidations_total"
   | MemoryLaneSubmitted -> "masc_keeper_memory_lane_submitted_total"
-  | MemoryLaneRanInline -> "masc_keeper_memory_lane_ran_inline_total"
-  | MemoryLaneDropped -> "masc_keeper_memory_lane_dropped_total"
+  | MemoryLaneAdmissionRejected -> "masc_keeper_memory_lane_admission_rejected_total"
+  | MemoryLaneCancelledUnits -> "masc_keeper_memory_lane_cancelled_units_total"
   | MemoryLanePending -> "masc_keeper_memory_lane_pending"
   | MemoryLaneInFlight -> "masc_keeper_memory_lane_in_flight"
   | MemoryLaneProviderSlotBusy -> "masc_keeper_memory_lane_provider_slot_busy_total"

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -138,8 +138,8 @@ type t =
   | MemoryLaneUnitFailures
   | MemoryConsolidations
   | MemoryLaneSubmitted
-  | MemoryLaneRanInline
-  | MemoryLaneDropped
+  | MemoryLaneAdmissionRejected
+  | MemoryLaneCancelledUnits
   | MemoryLanePending
   | MemoryLaneInFlight
   | MemoryLaneProviderSlotBusy

--- a/test/test_keeper_memory_lane.ml
+++ b/test/test_keeper_memory_lane.ml
@@ -31,7 +31,7 @@ let check_state ~keeper_name ~pending ~queued ~workers =
 ;;
 
 let metric_value metric ~labels =
-  Metrics.metric_value_or_zero Masc.Keeper_metrics.(to_string metric) ~labels ()
+  Metrics.metric_value_or_zero Keeper_metrics.(to_string metric) ~labels ()
 ;;
 
 let check_metric_delta label metric ~labels ~before expected =

--- a/test/test_keeper_memory_lane.ml
+++ b/test/test_keeper_memory_lane.ml
@@ -1,192 +1,292 @@
 (** Tests for Keeper_memory_lane (RFC-0257).
 
-    The lane detaches post-turn memory work from the keeper turn lane:
-    serialized within a keeper, independent across keepers, bounded, and
-    leak-safe on a raising unit. *)
+    The lane owns one FIFO worker per active keeper. Tests use promises for all
+    scheduling boundaries; no assertion depends on scheduler yields or mutex
+    waiter order. *)
 
 module Lane = Masc.Keeper_memory_lane
+module Metrics = Masc.Otel_metric_store
 
 exception Test_boom
 exception Cancel_lane_test
+exception Foreign_cancel
 
 let base_path = Filename.concat (Filename.get_temp_dir_name ()) "test-memory-lane"
 
-(* No executor switch set -> submit runs inline so no work is lost. *)
-let test_inline_when_uninitialized () =
+let expect_ok label = function
+  | Ok () -> ()
+  | Error error ->
+    Alcotest.failf "%s: %s" label (Lane.admission_error_to_string error)
+;;
+
+let check_state ~keeper_name ~pending ~queued ~workers =
+  let check field expected = function
+    | Some actual -> Alcotest.(check int) field expected actual
+    | None -> Alcotest.failf "%s: keeper entry missing" field
+  in
+  check "pending" pending (Lane.For_testing.pending ~base_path ~keeper_name);
+  check "queued" queued (Lane.For_testing.queued ~base_path ~keeper_name);
+  check "active workers" workers
+    (Lane.For_testing.active_workers ~base_path ~keeper_name)
+;;
+
+let metric_value metric ~labels =
+  Metrics.metric_value_or_zero Masc.Keeper_metrics.(to_string metric) ~labels ()
+;;
+
+let check_metric_delta label metric ~labels ~before expected =
+  let after = metric_value metric ~labels in
+  Alcotest.(check (float 0.0)) label expected (after -. before)
+;;
+
+let test_uninitialized_rejects_without_running () =
   Lane.For_testing.reset ();
+  let keeper_name = "uninitialized" in
+  let labels = [ "keeper", keeper_name; "reason", "executor_not_initialized" ] in
+  let before = metric_value MemoryLaneAdmissionRejected ~labels in
   let ran = ref false in
-  let outcome =
-    Lane.submit ~base_path ~keeper_name:"k1" (fun () -> ran := true)
-  in
-  Alcotest.(check bool) "unit ran inline" true !ran;
-  match outcome with
-  | Lane.Ran_inline -> ()
-  | Lane.Submitted -> Alcotest.fail "expected Ran_inline, got Submitted"
-  | Lane.Dropped -> Alcotest.fail "expected Ran_inline, got Dropped"
+  (match Lane.submit ~base_path ~keeper_name (fun () -> ran := true) with
+   | Error Lane.Executor_not_initialized -> ()
+   | Error error ->
+     Alcotest.failf "unexpected rejection: %s" (Lane.admission_error_to_string error)
+   | Ok () -> Alcotest.fail "uninitialized executor accepted work");
+  Alcotest.(check bool) "unit did not run in turn fiber" false !ran;
+  Alcotest.(check bool)
+    "no lane entry allocated"
+    true
+    (Option.is_none (Lane.For_testing.pending ~base_path ~keeper_name));
+  check_metric_delta
+    "rejection counted once"
+    MemoryLaneAdmissionRejected
+    ~labels
+    ~before
+    1.0
 ;;
 
-(* A raising unit in the inline path is contained and returns Ran_inline. *)
-let test_inline_contains_raise () =
+let test_serializes_fifo_with_one_worker () =
   Lane.For_testing.reset ();
-  let outcome =
-    Lane.submit ~base_path ~keeper_name:"k1" (fun () -> raise Test_boom)
-  in
-  match outcome with
-  | Lane.Ran_inline -> ()
-  | Lane.Submitted -> Alcotest.fail "expected Ran_inline, got Submitted"
-  | Lane.Dropped -> Alcotest.fail "expected Ran_inline, got Dropped"
-;;
-
-(* Two units for the same keeper run one after another: the second only starts
-   after the first releases the keeper's mutex. *)
-let test_serializes_within_keeper () =
-  Lane.For_testing.reset ();
+  let keeper_name = "fifo" in
   let order = ref [] in
-  let add s = order := s :: !order in
+  let add value = order := value :: !order in
   Eio_main.run (fun _env ->
     Eio.Switch.run (fun sw ->
       Lane.init ~sw;
-      let p_started, set_started = Eio.Promise.create () in
-      let p_release, set_release = Eio.Promise.create () in
-      let oa =
-        Lane.submit ~base_path ~keeper_name:"k1" (fun () ->
-          add "a-start";
-          Eio.Promise.resolve set_started ();
-          Eio.Promise.await p_release;
-          add "a-end")
-      in
-      Eio.Promise.await p_started;
-      let ob =
-        Lane.submit ~base_path ~keeper_name:"k1" (fun () -> add "b")
-      in
-      (* Let B attempt (and fail) to acquire the keeper mutex held by A. *)
-      Eio.Fiber.yield ();
-      add "before-release";
-      Eio.Promise.resolve set_release ();
-      (match oa with
-       | Lane.Submitted -> ()
-       | _ -> Alcotest.fail "unit A not submitted");
-      match ob with
-      | Lane.Submitted -> ()
-      | _ -> Alcotest.fail "unit B not submitted"));
+      let first_started, set_first_started = Eio.Promise.create () in
+      let release_first, set_release_first = Eio.Promise.create () in
+      let second_done, set_second_done = Eio.Promise.create () in
+      expect_ok "first"
+        (Lane.submit ~base_path ~keeper_name (fun () ->
+           add "first-start";
+           Eio.Promise.resolve set_first_started ();
+           Eio.Promise.await release_first;
+           add "first-end"));
+      Eio.Promise.await first_started;
+      expect_ok "second"
+        (Lane.submit ~base_path ~keeper_name (fun () ->
+           add "second";
+           Eio.Promise.resolve set_second_done ()));
+      check_state ~keeper_name ~pending:2 ~queued:1 ~workers:1;
+      Eio.Promise.resolve set_release_first ();
+      Eio.Promise.await second_done));
   Alcotest.(check (list string))
-    "B serialized behind A"
-    [ "a-start"; "before-release"; "a-end"; "b" ]
-    (List.rev !order)
+    "FIFO order"
+    [ "first-start"; "first-end"; "second" ]
+    (List.rev !order);
+  check_state ~keeper_name ~pending:0 ~queued:0 ~workers:0
 ;;
 
-(* A unit for one keeper does not block a unit for another keeper. *)
+let test_backlog_uses_one_worker_and_preserves_fifo () =
+  Lane.For_testing.reset ();
+  let keeper_name = "backlog" in
+  let count = 64 in
+  let order = ref [] in
+  let labels = [ "keeper", keeper_name ] in
+  let submitted_before = metric_value MemoryLaneSubmitted ~labels in
+  Eio_main.run (fun _env ->
+    Eio.Switch.run (fun sw ->
+      Lane.init ~sw;
+      let first_started, set_first_started = Eio.Promise.create () in
+      let release_first, set_release_first = Eio.Promise.create () in
+      let all_done, set_all_done = Eio.Promise.create () in
+      expect_ok "backlog head"
+        (Lane.submit ~base_path ~keeper_name (fun () ->
+           Eio.Promise.resolve set_first_started ();
+           Eio.Promise.await release_first));
+      Eio.Promise.await first_started;
+      for index = 0 to count - 1 do
+        expect_ok "backlog item"
+          (Lane.submit ~base_path ~keeper_name (fun () ->
+             order := index :: !order;
+             if index = count - 1 then Eio.Promise.resolve set_all_done ()))
+      done;
+      check_state ~keeper_name ~pending:(count + 1) ~queued:count ~workers:1;
+      check_metric_delta
+        "every admitted unit counted once"
+        MemoryLaneSubmitted
+        ~labels
+        ~before:submitted_before
+        (Float.of_int (count + 1));
+      Alcotest.(check (float 0.0))
+        "pending gauge includes current and queued units"
+        (Float.of_int (count + 1))
+        (metric_value MemoryLanePending ~labels);
+      Alcotest.(check (float 0.0))
+        "one unit in flight"
+        1.0
+        (metric_value MemoryLaneInFlight ~labels);
+      Eio.Promise.resolve set_release_first ();
+      Eio.Promise.await all_done));
+  Alcotest.(check (list int))
+    "explicit queue preserves submission order"
+    (List.init count Fun.id)
+    (List.rev !order);
+  check_state ~keeper_name ~pending:0 ~queued:0 ~workers:0;
+  Alcotest.(check (float 0.0))
+    "pending gauge returned to zero"
+    0.0
+    (metric_value MemoryLanePending ~labels);
+  Alcotest.(check (float 0.0))
+    "in-flight gauge returned to zero"
+    0.0
+    (metric_value MemoryLaneInFlight ~labels)
+;;
+
 let test_independent_across_keepers () =
   Lane.For_testing.reset ();
-  let order = ref [] in
-  let add s = order := s :: !order in
   Eio_main.run (fun _env ->
     Eio.Switch.run (fun sw ->
       Lane.init ~sw;
-      let p_started, set_started = Eio.Promise.create () in
-      let p_release, set_release = Eio.Promise.create () in
-      let _ =
-        Lane.submit ~base_path ~keeper_name:"k1" (fun () ->
-          Eio.Promise.resolve set_started ();
-          Eio.Promise.await p_release;
-          add "k1")
-      in
-      Eio.Promise.await p_started;
-      let _ =
-        Lane.submit ~base_path ~keeper_name:"k2" (fun () -> add "k2")
-      in
-      (* k2 runs to completion while k1 is still holding its own lane. *)
-      Eio.Fiber.yield ();
-      Eio.Fiber.yield ();
-      Alcotest.(check bool) "k2 ran while k1 blocked" true (List.mem "k2" !order);
-      Eio.Promise.resolve set_release ()));
-  Alcotest.(check (list string)) "k2 before k1" [ "k2"; "k1" ] (List.rev !order)
+      let k1_started, set_k1_started = Eio.Promise.create () in
+      let release_k1, set_release_k1 = Eio.Promise.create () in
+      let k2_done, set_k2_done = Eio.Promise.create () in
+      expect_ok "k1"
+        (Lane.submit ~base_path ~keeper_name:"independent-k1" (fun () ->
+           Eio.Promise.resolve set_k1_started ();
+           Eio.Promise.await release_k1));
+      Eio.Promise.await k1_started;
+      expect_ok "k2"
+        (Lane.submit ~base_path ~keeper_name:"independent-k2" (fun () ->
+           Eio.Promise.resolve set_k2_done ()));
+      Eio.Promise.await k2_done;
+      check_state ~keeper_name:"independent-k1" ~pending:1 ~queued:0 ~workers:1;
+      check_state ~keeper_name:"independent-k2" ~pending:0 ~queued:0 ~workers:0;
+      Eio.Promise.resolve set_release_k1 ()))
 ;;
 
-(* With max_pending = 2, a third concurrent unit for one keeper is dropped. *)
-let test_saturation_drops () =
+let test_raising_unit_recovers_and_counts_once () =
   Lane.For_testing.reset ();
+  let keeper_name = "raise" in
+  let labels = [ "keeper", keeper_name ] in
+  let before = metric_value MemoryLaneUnitFailures ~labels in
   Eio_main.run (fun _env ->
     Eio.Switch.run (fun sw ->
       Lane.init ~sw;
-      let p_release, set_release = Eio.Promise.create () in
-      let o1 =
-        Lane.submit ~base_path ~keeper_name:"k1" (fun () ->
-          Eio.Promise.await p_release)
-      in
-      let o2 = Lane.submit ~base_path ~keeper_name:"k1" (fun () -> ()) in
-      let o3 = Lane.submit ~base_path ~keeper_name:"k1" (fun () -> ()) in
-      (match o1 with
-       | Lane.Submitted -> ()
-       | _ -> Alcotest.fail "o1 not submitted");
-      (match o2 with
-       | Lane.Submitted -> ()
-       | _ -> Alcotest.fail "o2 not submitted");
-      (match o3 with
-       | Lane.Dropped -> ()
-       | Lane.Submitted -> Alcotest.fail "o3 should be Dropped, got Submitted"
-       | Lane.Ran_inline -> Alcotest.fail "o3 should be Dropped, got Ran_inline");
-      Eio.Promise.resolve set_release ()))
+      expect_ok "raising unit"
+        (Lane.submit ~base_path ~keeper_name (fun () -> raise Test_boom));
+      let recovered, set_recovered = Eio.Promise.create () in
+      expect_ok "recovery unit"
+        (Lane.submit ~base_path ~keeper_name (fun () ->
+           Eio.Promise.resolve set_recovered ()));
+      Eio.Promise.await recovered));
+  check_state ~keeper_name ~pending:0 ~queued:0 ~workers:0;
+  check_metric_delta
+    "unit failure counted once"
+    MemoryLaneUnitFailures
+    ~labels
+    ~before
+    1.0
 ;;
 
-(* A unit that raises releases the mutex and the pending slot, so the lane
-   recovers and later units run. *)
-let test_releases_on_raise () =
+let test_foreign_cancelled_result_does_not_drain_fifo () =
   Lane.For_testing.reset ();
-  let ran_after = ref false in
+  let keeper_name = "foreign-cancel" in
+  let labels = [ "keeper", keeper_name ] in
+  let failures_before = metric_value MemoryLaneUnitFailures ~labels in
+  let cancellations_before = metric_value MemoryLaneCancelledUnits ~labels in
   Eio_main.run (fun _env ->
     Eio.Switch.run (fun sw ->
       Lane.init ~sw;
-      let _ =
-        Lane.submit ~base_path ~keeper_name:"k1" (fun () -> raise Test_boom)
-      in
-      Eio.Fiber.yield ();
-      Eio.Fiber.yield ();
-      let _ =
-        Lane.submit ~base_path ~keeper_name:"k1" (fun () -> ran_after := true)
-      in
-      Eio.Fiber.yield ();
-      Eio.Fiber.yield ()));
-  Alcotest.(check bool) "lane recovered after raise" true !ran_after;
-  match Lane.For_testing.pending ~base_path ~keeper_name:"k1" with
-  | Some 0 -> ()
-  | Some n -> Alcotest.failf "pending leaked: %d" n
-  | None -> Alcotest.fail "keeper entry missing"
+      let foreign, set_foreign = Eio.Promise.create () in
+      Eio.Promise.resolve_error set_foreign (Eio.Cancel.Cancelled Foreign_cancel);
+      expect_ok "foreign cancellation"
+        (Lane.submit ~base_path ~keeper_name (fun () ->
+           Eio.Promise.await_exn foreign));
+      let next_done, set_next_done = Eio.Promise.create () in
+      expect_ok "unit after foreign cancellation"
+        (Lane.submit ~base_path ~keeper_name (fun () ->
+           Eio.Promise.resolve set_next_done ()));
+      Eio.Promise.await next_done));
+  check_metric_delta
+    "foreign cancellation is a unit failure"
+    MemoryLaneUnitFailures
+    ~labels
+    ~before:failures_before
+    1.0;
+  check_metric_delta
+    "executor cancellation counter unchanged"
+    MemoryLaneCancelledUnits
+    ~labels
+    ~before:cancellations_before
+    0.0
 ;;
 
-(* Cancellation during shutdown releases both the mutex and the pending slot. *)
-let test_releases_on_cancel () =
+let test_shutdown_cancels_current_and_queued_units_observably () =
   Lane.For_testing.reset ();
+  let keeper_name = "cancel" in
+  let labels = [ "keeper", keeper_name ] in
+  let before = metric_value MemoryLaneCancelledUnits ~labels in
+  let queued_ran = ref false in
   (try
      Eio_main.run (fun _env ->
        Eio.Switch.run (fun sw ->
          Lane.init ~sw;
          let started, set_started = Eio.Promise.create () in
          let never, _set_never = Eio.Promise.create () in
-         let outcome =
-           Lane.submit ~base_path ~keeper_name:"k1" (fun () ->
-             Eio.Promise.resolve set_started ();
-             Eio.Promise.await never)
-         in
-         (match outcome with
-          | Lane.Submitted -> ()
-         | Lane.Ran_inline -> Alcotest.fail "cancel test unexpectedly ran inline"
-         | Lane.Dropped -> Alcotest.fail "cancel test unexpectedly dropped");
+         expect_ok "current"
+           (Lane.submit ~base_path ~keeper_name (fun () ->
+              Eio.Promise.resolve set_started ();
+              Eio.Promise.await never));
          Eio.Promise.await started;
+         expect_ok "queued"
+           (Lane.submit ~base_path ~keeper_name (fun () -> queued_ran := true));
+         check_state ~keeper_name ~pending:2 ~queued:1 ~workers:1;
          Eio.Switch.fail sw Cancel_lane_test))
    with
    | Cancel_lane_test -> ());
-  match Lane.For_testing.pending ~base_path ~keeper_name:"k1" with
-  | Some 0 -> ()
-  | Some n -> Alcotest.failf "pending leaked after cancel: %d" n
-  | None -> Alcotest.fail "keeper entry missing after cancel"
+  check_state ~keeper_name ~pending:0 ~queued:0 ~workers:0;
+  Alcotest.(check bool) "queued unit did not run" false !queued_ran;
+  check_metric_delta
+    "current and queued cancellations counted"
+    MemoryLaneCancelledUnits
+    ~labels
+    ~before
+    2.0
 ;;
 
-(* Submitting against a finished executor switch must not leak the pending
-   reservation. Eio.Fiber.fork does not raise to the caller for an off switch, so
-   the lane needs its own executor-switch release fallback. *)
-let test_finished_switch_drops_without_leak () =
+let test_cancelling_switch_rejects_without_silent_fork () =
   Lane.For_testing.reset ();
+  let ran = ref false in
+  let result = ref None in
+  (try
+     Eio_main.run (fun _env ->
+       Eio.Switch.run (fun sw ->
+         Lane.init ~sw;
+         Eio.Switch.fail sw Cancel_lane_test;
+         result := Some (Lane.submit ~base_path ~keeper_name:"stopping" (fun () -> ran := true))))
+   with
+   | Cancel_lane_test -> ());
+  (match !result with
+   | Some (Error Lane.Executor_stopping) -> ()
+   | Some (Error error) ->
+     Alcotest.failf "unexpected rejection: %s" (Lane.admission_error_to_string error)
+   | Some (Ok ()) -> Alcotest.fail "cancelling switch accepted work"
+   | None -> Alcotest.fail "missing admission result");
+  Alcotest.(check bool) "callback never ran" false !ran
+;;
+
+let test_finished_switch_rejects_without_silent_fork () =
+  Lane.For_testing.reset ();
+  let ran = ref false in
   let finished_sw = ref None in
   Eio_main.run (fun _env ->
     Eio.Switch.run (fun sw ->
@@ -198,17 +298,28 @@ let test_finished_switch_drops_without_leak () =
     | None -> Alcotest.fail "missing captured switch"
   in
   Lane.init ~sw;
-  let outcome =
-    Lane.submit ~base_path ~keeper_name:"k1" (fun () -> raise Test_boom)
-  in
-  (match outcome with
-   | Lane.Dropped -> ()
-   | Lane.Submitted -> Alcotest.fail "expected Dropped, got Submitted"
-   | Lane.Ran_inline -> Alcotest.fail "expected Dropped, got Ran_inline");
-  match Lane.For_testing.pending ~base_path ~keeper_name:"k1" with
-  | Some 0 -> ()
-  | Some n -> Alcotest.failf "pending leaked after finished switch submit: %d" n
-  | None -> Alcotest.fail "keeper entry missing after finished switch submit"
+  (match Lane.submit ~base_path ~keeper_name:"finished" (fun () -> ran := true) with
+   | Error Lane.Executor_stopping -> ()
+   | Error error ->
+     Alcotest.failf "unexpected rejection: %s" (Lane.admission_error_to_string error)
+   | Ok () -> Alcotest.fail "finished switch accepted work");
+  Alcotest.(check bool) "callback never ran" false !ran
+;;
+
+let test_executor_domain_mismatch_is_typed () =
+  Lane.For_testing.reset ();
+  Eio_main.run (fun _env ->
+    Eio.Switch.run (fun sw ->
+      Lane.init ~sw;
+      let domain =
+        Domain.spawn (fun () ->
+          Lane.submit ~base_path ~keeper_name:"wrong-domain" (fun () -> ()))
+      in
+      match Domain.join domain with
+      | Error Lane.Executor_domain_mismatch -> ()
+      | Error error ->
+        Alcotest.failf "unexpected rejection: %s" (Lane.admission_error_to_string error)
+      | Ok () -> Alcotest.fail "non-owner domain accepted work"))
 ;;
 
 let () =
@@ -216,28 +327,45 @@ let () =
     "keeper_memory_lane"
     [ ( "lane"
       , [ Alcotest.test_case
-            "inline when uninitialized"
+            "uninitialized rejects without running"
             `Quick
-            test_inline_when_uninitialized
+            test_uninitialized_rejects_without_running
         ; Alcotest.test_case
-            "inline contains raise"
+            "serializes FIFO with one worker"
             `Quick
-            test_inline_contains_raise
+            test_serializes_fifo_with_one_worker
         ; Alcotest.test_case
-            "serializes within keeper"
+            "backlog uses one worker and preserves FIFO"
             `Quick
-            test_serializes_within_keeper
+            test_backlog_uses_one_worker_and_preserves_fifo
         ; Alcotest.test_case
             "independent across keepers"
             `Quick
             test_independent_across_keepers
-        ; Alcotest.test_case "saturation drops" `Quick test_saturation_drops
-        ; Alcotest.test_case "releases on raise" `Quick test_releases_on_raise
-        ; Alcotest.test_case "releases on cancel" `Quick test_releases_on_cancel
         ; Alcotest.test_case
-            "finished switch drops without leak"
+            "raising unit recovers and counts once"
             `Quick
-            test_finished_switch_drops_without_leak
+            test_raising_unit_recovers_and_counts_once
+        ; Alcotest.test_case
+            "foreign cancellation does not drain FIFO"
+            `Quick
+            test_foreign_cancelled_result_does_not_drain_fifo
+        ; Alcotest.test_case
+            "shutdown cancellations are observable"
+            `Quick
+            test_shutdown_cancels_current_and_queued_units_observably
+        ; Alcotest.test_case
+            "cancelling switch rejects without silent fork"
+            `Quick
+            test_cancelling_switch_rejects_without_silent_fork
+        ; Alcotest.test_case
+            "finished switch rejects without silent fork"
+            `Quick
+            test_finished_switch_rejects_without_silent_fork
+        ; Alcotest.test_case
+            "executor domain mismatch is typed"
+            `Quick
+            test_executor_domain_mismatch_is_typed
         ] )
     ]
 ;;

--- a/test/test_keeper_memory_write.ml
+++ b/test/test_keeper_memory_write.ml
@@ -2,6 +2,7 @@
 
 module Runtime = Masc.Keeper_tool_memory_runtime
 module Bank = Masc.Keeper_memory_bank
+module Work_request = Masc.Keeper_memory_work_request
 
 let make_args ~kind ~title ~content =
   `Assoc
@@ -200,6 +201,56 @@ let test_source_round_trip () =
     (Bank.memory_row_source_of_string wire = source)
 ;;
 
+let test_memory_work_request_strict_round_trip () =
+  let meta = make_meta "durable-memory-work" in
+  let librarian_message =
+    let message =
+      Agent_sdk.Types.text_message Agent_sdk.Types.User "remember this"
+    in
+    { message with metadata = [ "source", `String "memory-lane-test" ] }
+  in
+  let request =
+    Work_request.make
+      ~keeper_name:meta.name
+      ~generation:meta.runtime.generation
+      ~turn:8
+      ~runtime_id:"runtime.memory"
+      ~meta
+      ~tool_results:[ `Assoc [ "kind", `String "typed-tool-result" ] ]
+      ~librarian_messages:[ librarian_message ]
+      ~deliberation_execution:None
+    |> Result.get_ok
+  in
+  let encoded = Work_request.to_json request in
+  let decoded = Work_request.of_json encoded |> Result.get_ok in
+  Alcotest.(check string)
+    "content-derived identity round trips"
+    (Work_request.request_id request)
+    (Work_request.request_id decoded);
+  Alcotest.(check string) "keeper identity" meta.name (Work_request.keeper_name decoded);
+  let decoded_messages = Work_request.librarian_messages decoded in
+  Alcotest.(check int) "one message" 1 (List.length decoded_messages);
+  Alcotest.(check int)
+    "message metadata preserved"
+    1
+    (List.length (List.hd decoded_messages).metadata);
+  let tampered =
+    match encoded with
+    | `Assoc fields ->
+      `Assoc
+        (List.map
+           (fun (name, value) ->
+              if String.equal name "request_id"
+              then name, `String "tampered"
+              else name, value)
+           fields)
+    | _ -> Alcotest.fail "request encoding must be an object"
+  in
+  match Work_request.of_json tampered with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "tampered request identity was accepted"
+;;
+
 let () =
   Alcotest.run
     "keeper_memory_write"
@@ -220,6 +271,10 @@ let () =
             `Quick
             test_tool_write_persists_typed_provenance
         ; Alcotest.test_case "source round trips" `Quick test_source_round_trip
+        ; Alcotest.test_case
+            "durable work request strict round trip"
+            `Quick
+            test_memory_work_request_strict_round_trip
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- replace per-submission mutex fibers and saturation drops with one explicit FIFO worker per Keeper
- return typed admission failures instead of inline provider fallback or silent loss
- observe submitted, rejected, cancelled, pending, in-flight, and failed units

## Verification
- ocamlformat --check on all changed OCaml files
- ocamlc -stop-after parsing on all changed OCaml files
- git diff --check
- focused scripts/dune-local.sh target was correctly refused because an unrelated bare dune PID 66224 owns the machine-wide build slot; full type/runtime proof is delegated to PR CI

## Invariants
- lane-per-Keeper; independent Keepers do not block one another
- one worker per Keeper, FIFO queue, no submission-per-fiber
- no provider work in the submitting turn fiber
- no silent admission or cancellation loss