### PR TITLE
fix(keeper): retire finalized shutdown fences

### DIFF
--- a/lib/keeper/keeper_shutdown_runtime.ml
+++ b/lib/keeper/keeper_shutdown_runtime.ml
@@ -405,7 +405,7 @@ let recover_at_boot ~config =
      | Ok restored ->
        let corrupt_results =
          List.map
-           (fun corrupt ->
+           (fun (corrupt : Keeper_shutdown_store.corrupt_record) ->
               Error
                 (Printf.sprintf
                    "corrupt shutdown operation fenced: keeper=%s operation=%s path=%s error=%s"

--- a/lib/keeper/keeper_shutdown_runtime.ml
+++ b/lib/keeper/keeper_shutdown_runtime.ml
@@ -14,6 +14,7 @@ and worker_start_error =
 
 type restored_inventory =
   { operations : Keeper_shutdown_types.t list
+  ; retired_terminal_records : Keeper_shutdown_store.retired_terminal_record list
   ; blocked_keeper_names : string list
   ; corrupt_records : Keeper_shutdown_store.corrupt_record list
   }
@@ -62,10 +63,11 @@ let restore_admission ~config ~keeper_name ~operation_id =
 ;;
 
 let restore_inventory_admission ~config inventory =
-  let rec loop operations blocked corrupt_records = function
+  let rec loop operations retired_terminal_records blocked corrupt_records = function
     | [] ->
       Ok
         { operations = List.rev operations
+        ; retired_terminal_records = List.rev retired_terminal_records
         ; blocked_keeper_names = List.sort_uniq String.compare blocked
         ; corrupt_records = List.rev corrupt_records
         }
@@ -82,10 +84,33 @@ let restore_inventory_admission ~config inventory =
          | Ok () ->
            loop
              (operation :: operations)
+             retired_terminal_records
              (operation.keeper_name :: blocked)
              corrupt_records
              rest)
-      else loop (operation :: operations) blocked corrupt_records rest
+      else
+        loop
+          (operation :: operations)
+          retired_terminal_records
+          blocked
+          corrupt_records
+          rest
+    | Keeper_shutdown_store.Retired_terminal terminal :: rest ->
+      (match
+         Keeper_turn_admission.rollback_shutdown
+           ~base_path:config.Workspace.base_path
+           ~keeper_name:terminal.keeper_name
+           ~operation_id:terminal.operation_id
+       with
+       | Keeper_turn_admission.Shutdown_rolled_back
+       | Keeper_turn_admission.Shutdown_not_reserved
+       | Keeper_turn_admission.Shutdown_reserved_by_other _ ->
+         loop
+           operations
+           (terminal :: retired_terminal_records)
+           blocked
+           corrupt_records
+           rest)
     | Keeper_shutdown_store.Corrupt_record corrupt :: rest ->
       (match
          restore_admission
@@ -97,11 +122,12 @@ let restore_inventory_admission ~config inventory =
        | Ok () ->
          loop
            operations
+           retired_terminal_records
            (corrupt.keeper_name :: blocked)
            (corrupt :: corrupt_records)
            rest)
   in
-  loop [] [] [] inventory
+  loop [] [] [] [] inventory
 ;;
 
 let worker_mu = Eio.Mutex.create ()

--- a/lib/keeper/keeper_shutdown_runtime.mli
+++ b/lib/keeper/keeper_shutdown_runtime.mli
@@ -14,15 +14,18 @@ and worker_start_error =
 
 type restored_inventory =
   { operations : Keeper_shutdown_types.t list
+  ; retired_terminal_records : Keeper_shutdown_store.retired_terminal_record list
   ; blocked_keeper_names : string list
   ; corrupt_records : Keeper_shutdown_store.corrupt_record list
   }
 
 val submit_error_to_string : submit_error -> string
 
-(** Restore admission from owner-addressable durable inventory. Corrupt
-    payloads fence their path owner and remain explicit in [corrupt_records];
-    valid operations for unrelated Keepers remain recoverable. *)
+(** Restore admission from owner-addressable durable inventory. Verified
+    retired terminal records release only a matching in-memory fence and remain
+    explicit in [retired_terminal_records]. Corrupt payloads fence their path
+    owner and remain explicit in [corrupt_records]; valid operations for
+    unrelated Keepers remain recoverable. *)
 val restore_inventory_admission :
   config:Workspace.config ->
   Keeper_shutdown_store.inventory_entry list ->

--- a/lib/keeper/keeper_shutdown_store.ml
+++ b/lib/keeper/keeper_shutdown_store.ml
@@ -38,8 +38,23 @@ type corrupt_record =
   ; error : error
   }
 
+type retired_terminal_kind =
+  | Stale_paused_prune_completed of
+      { meta_version : int
+      ; last_updated : string
+      ; latched_reason : Keeper_latched_reason.t option
+      }
+
+type retired_terminal_record =
+  { keeper_name : string
+  ; operation_id : Operation_id.t
+  ; path : string
+  ; kind : retired_terminal_kind
+  }
+
 type inventory_entry =
   | Operation of Keeper_shutdown_types.t
+  | Retired_terminal of retired_terminal_record
   | Corrupt_record of corrupt_record
 
 let error_to_string = function
@@ -719,6 +734,100 @@ let optional_join_evidence_of_json json =
   | Error _ as error -> error
 ;;
 
+let retired_stale_paused_terminal_payload_of_json
+    ~operation_path
+    ~keeper_name:path_keeper_name
+    ~operation_id:path_operation_id
+    json
+  =
+  let* schema = int "schema_version" json in
+  let* () =
+    if Int.equal schema shutdown_schema_v5
+    then Ok ()
+    else Error (Decode_error "retired shutdown terminal must use schema 5")
+  in
+  let* keeper_name = string "keeper_name" json in
+  let* operation_id_wire = string "operation_id" json in
+  let* operation_id =
+    Operation_id.of_string operation_id_wire
+    |> Result.map_error (fun detail -> Decode_error detail)
+  in
+  let* () =
+    if
+      String.equal keeper_name path_keeper_name
+      && Operation_id.equal operation_id path_operation_id
+    then Ok ()
+    else
+      Error
+        (Identity_mismatch
+           (Printf.sprintf
+              "%s: path owner=%s operation=%s, payload owner=%s operation=%s"
+              operation_path
+              path_keeper_name
+              (Operation_id.to_string path_operation_id)
+              keeper_name
+              (Operation_id.to_string operation_id)))
+  in
+  let* cleanup_intent = assoc "cleanup_intent" json in
+  let* remove_session = bool "remove_session" cleanup_intent in
+  let* reason = assoc "reason" cleanup_intent in
+  let* reason_kind = string "kind" reason in
+  let* () =
+    if String.equal reason_kind "stale_paused_prune"
+    then Ok ()
+    else Error (Decode_error "shutdown terminal is not a retired stale paused prune")
+  in
+  let* meta_version = int "meta_version" reason in
+  let* last_updated = string "last_updated" reason in
+  let* latched_reason =
+    match assoc "latched_reason" reason with
+    | Ok `Null -> Ok None
+    | Ok reason_json ->
+      Keeper_latched_reason.Stable.of_yojson reason_json
+      |> Result.map Option.some
+      |> Result.map_error (fun detail -> Decode_error detail)
+    | Error _ as error -> error
+  in
+  let* phase = assoc "phase" json in
+  let* phase_kind = string "kind" phase in
+  let* () =
+    if String.equal phase_kind "finalized"
+    then Ok ()
+    else Error (Decode_error "retired stale paused prune is not finalized")
+  in
+  let* evidence = assoc "evidence" phase in
+  let* cleanup = assoc "cleanup" evidence in
+  let* (_settled_task_ids : Keeper_id.Task_id.t list) =
+    task_ids_field_of_json "settled_task_ids" cleanup
+  in
+  let* (_pending_confirms_removed : int) = int "pending_confirms_removed" cleanup in
+  let* meta_removed = bool "meta_removed" evidence in
+  let* session_removed = bool "session_removed" evidence in
+  let* (_registry_unregistered : bool) = bool "registry_unregistered" evidence in
+  let* accumulator_dropped = bool "accumulator_dropped" evidence in
+  let* () =
+    if meta_removed && Bool.equal session_removed remove_session && accumulator_dropped
+    then Ok ()
+    else Error (Decode_error "retired stale paused prune has invalid terminal evidence")
+  in
+  let* completion = assoc "completion" evidence in
+  let* completion_kind = string "kind" completion in
+  let* completion_action = string "action" completion in
+  let* () =
+    if
+      String.equal completion_kind "delivered"
+      && String.equal completion_action "paused_meta_pruned"
+    then Ok ()
+    else Error (Decode_error "retired stale paused prune lacks its delivered receipt")
+  in
+  Ok
+    { keeper_name
+    ; operation_id
+    ; path = operation_path
+    ; kind = Stale_paused_prune_completed { meta_version; last_updated; latched_reason }
+    }
+;;
+
 let lane_ownership_of_json json =
   let* kind = string "kind" json in
   match kind with
@@ -762,6 +871,49 @@ let lane_ownership_of_versioned_json ~wire_schema json =
     Keeper_lane.Id.of_string lane_id_wire
     |> Result.map (fun lane_id -> Registered_lane lane_id)
     |> Result.map_error (fun detail -> Decode_error detail)
+;;
+
+let retired_stale_paused_terminal_of_json
+    ~operation_path
+    ~keeper_name
+    ~operation_id
+    json
+  =
+  let* terminal =
+    retired_stale_paused_terminal_payload_of_json
+      ~operation_path
+      ~keeper_name
+      ~operation_id
+      json
+  in
+  (* A retired terminal may bypass the current cleanup-reason decoder only
+     after every other schema-5 field has passed the same typed decoders as a
+     current operation. This keeps the compatibility boundary fail-closed: a
+     damaged common field remains [Corrupt_record] and retains its exact
+     admission fence. *)
+  let* (_revision : int) = int "revision" json in
+  let* (_lane_ownership : lane_ownership) =
+    lane_ownership_of_versioned_json ~wire_schema:Shutdown_schema_v5 json
+  in
+  let* trace_id_wire = string "trace_id" json in
+  let* (_trace_id : Keeper_id.Trace_id.t) =
+    Keeper_id.Trace_id.of_string trace_id_wire
+    |> Result.map_error (fun detail -> Decode_error detail)
+  in
+  let* (_generation : int) = int "generation" json in
+  let* (_actor : string) = string "actor" json in
+  let* turn_json = assoc "turn_disposition" json in
+  let* (_turn_disposition : turn_disposition) =
+    turn_disposition_of_json turn_json
+  in
+  let* (_expected_backlog_version : int) = int "expected_backlog_version" json in
+  let* (_owned_task_ids : Keeper_id.Task_id.t list) =
+    task_ids_field_of_json "owned_task_ids" json
+  in
+  let* (_join_evidence : join_evidence option) = optional_join_evidence_of_json json in
+  let* (_created_at : string) = string "created_at" json in
+  let* (_updated_at : string) = string "updated_at" json in
+  Ok terminal
 ;;
 
 let cleanup_reason_of_versioned_json ~wire_schema cleanup_json =
@@ -892,6 +1044,28 @@ let load_path_unlocked ~operation_path ~keeper_name ~operation_id =
                 (Operation_id.to_string operation_id)
                 operation.keeper_name
                 (Operation_id.to_string operation.operation_id)))
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | Yojson.Json_error detail ->
+      Error (Decode_error (Printf.sprintf "%s: %s" operation_path detail))
+    | exn ->
+      Error
+        (Io_error
+           (Printf.sprintf "%s: %s" operation_path (Printexc.to_string exn)))
+;;
+
+let load_retired_terminal_path_unlocked ~operation_path ~keeper_name ~operation_id =
+  if not (Fs_compat.file_exists operation_path)
+  then Error (Not_found operation_path)
+  else
+    try
+      Fs_compat.load_file operation_path
+      |> Yojson.Safe.from_string
+      |> retired_stale_paused_terminal_of_json
+           ~operation_path
+           ~keeper_name
+           ~operation_id
+      |> Result.map_error (contextualize_error operation_path)
     with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
     | Yojson.Json_error detail ->
@@ -1126,19 +1300,26 @@ let scan_keeper_dir ~config ~keeper_name =
                   |> Result.map_error (fun e -> Decode_error e)
                 in
                 let operation_path = Filename.concat dir filename in
-                let loaded =
-                  with_operation_lock ~access:Read operation_path (fun () ->
-                    load_path_unlocked
-                      ~operation_path
-                      ~keeper_name
-                      ~operation_id)
-                in
                 let entry =
-                  match loaded with
-                  | Ok operation -> Operation operation
-                  | Error error ->
-                    Corrupt_record
-                      { keeper_name; operation_id; path = operation_path; error }
+                  with_operation_lock ~access:Read operation_path (fun () ->
+                    match
+                      load_path_unlocked
+                        ~operation_path
+                        ~keeper_name
+                        ~operation_id
+                    with
+                    | Ok operation -> Operation operation
+                    | Error error ->
+                      (match
+                         load_retired_terminal_path_unlocked
+                           ~operation_path
+                           ~keeper_name
+                           ~operation_id
+                       with
+                       | Ok terminal -> Retired_terminal terminal
+                       | Error _ ->
+                         Corrupt_record
+                           { keeper_name; operation_id; path = operation_path; error }))
                 in
                 Ok (entry :: entries))
            (Ok [])
@@ -1193,6 +1374,7 @@ let list_for_keeper ~config ~keeper_name =
           let* operations = result in
           match entry with
           | Operation operation -> Ok (operation :: operations)
+          | Retired_terminal _ -> Ok operations
           | Corrupt_record corrupt -> Error corrupt.error)
        (Ok [])
   |> Result.map List.rev

--- a/lib/keeper/keeper_shutdown_store.mli
+++ b/lib/keeper/keeper_shutdown_store.mli
@@ -36,8 +36,23 @@ type corrupt_record =
   ; error : error
   }
 
+type retired_terminal_kind =
+  | Stale_paused_prune_completed of
+      { meta_version : int
+      ; last_updated : string
+      ; latched_reason : Keeper_latched_reason.t option
+      }
+
+type retired_terminal_record =
+  { keeper_name : string
+  ; operation_id : Keeper_shutdown_types.Operation_id.t
+  ; path : string
+  ; kind : retired_terminal_kind
+  }
+
 type inventory_entry =
   | Operation of Keeper_shutdown_types.t
+  | Retired_terminal of retired_terminal_record
   | Corrupt_record of corrupt_record
 
 val error_to_string : error -> string
@@ -112,7 +127,9 @@ val list_for_keeper :
   keeper_name:string ->
   (Keeper_shutdown_types.t list, error) result
 
-(** Enumerate every owner-addressable operation independently. A corrupt
+(** Enumerate every owner-addressable operation independently. A verified
+    terminal record from a retired wire contract remains typed as
+    [Retired_terminal] and never re-enters the current operation model. A corrupt
     payload remains associated with the Keeper and operation identities from
     its validated directory/file path, so boot can fence only that Keeper and
     continue recovering unrelated lanes. Store entries whose path does not

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -499,7 +499,9 @@ let prepare_keeper_persistence_owned ~base_path_identity ~set_phase ~config =
        ~stage:"shutdown"
        ~started:shutdown_started
        ~examined:
-         (List.length restored.operations + List.length restored.corrupt_records)
+         (List.length restored.operations
+          + List.length restored.retired_terminal_records
+          + List.length restored.corrupt_records)
        ~failures:(List.length restored.corrupt_records)
    | Error _ ->
      observe_preparation_stage
@@ -1104,6 +1106,14 @@ let start_keeper_loops_owned
      process-local sink is still absent. *)
   fork_subsystem "keeper_shutdown_recovery" (fun () ->
     let restored = claimed_persistence.claimed_report.shutdown in
+      List.iter
+        (fun terminal ->
+           Log.Keeper.info
+             "retired terminal shutdown operation recognized without an admission fence: keeper=%s operation=%s path=%s"
+             terminal.Keeper_shutdown_store.keeper_name
+             (Keeper_shutdown_types.Operation_id.to_string terminal.operation_id)
+             terminal.path)
+        restored.retired_terminal_records;
       List.iter
         (fun corrupt ->
            Log.Keeper.error

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -1115,7 +1115,7 @@ let start_keeper_loops_owned
              terminal.path)
         restored.retired_terminal_records;
       List.iter
-        (fun corrupt ->
+        (fun (corrupt : Keeper_shutdown_store.corrupt_record) ->
            Log.Keeper.error
              "corrupt shutdown operation retained under an exact Keeper admission fence: keeper=%s operation=%s path=%s error=%s"
              corrupt.Keeper_shutdown_store.keeper_name

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -248,6 +248,49 @@ let shutdown_schema5_fixture (operation : Shutdown_types.t) =
   | _ -> fail "shutdown JSON codec did not return an object"
 ;;
 
+let retired_stale_paused_schema5_fixture (operation : Shutdown_types.t) =
+  match Shutdown_store.to_json operation with
+  | `Assoc fields ->
+    `Assoc
+      (fields
+       |> replace_assoc_field "schema_version" (`Int 5)
+       |> replace_assoc_field
+            "cleanup_intent"
+            (`Assoc
+              [ ( "reason"
+                , `Assoc
+                    [ "kind", `String "stale_paused_prune"
+                    ; "meta_version", `Int 21383
+                    ; "last_updated", `String "2026-07-11T09:04:05Z"
+                    ; "latched_reason", `Null
+                    ] )
+              ; "remove_session", `Bool false
+              ])
+       |> replace_assoc_field
+            "phase"
+            (`Assoc
+              [ "kind", `String "finalized"
+              ; ( "evidence"
+                , `Assoc
+                    [ ( "cleanup"
+                      , `Assoc
+                          [ "settled_task_ids", `List []
+                          ; "pending_confirms_removed", `Int 0
+                          ] )
+                    ; "meta_removed", `Bool true
+                    ; "session_removed", `Bool false
+                    ; "registry_unregistered", `Bool false
+                    ; "accumulator_dropped", `Bool true
+                    ; ( "completion"
+                      , `Assoc
+                          [ "kind", `String "delivered"
+                          ; "action", `String "paused_meta_pruned"
+                          ] )
+                    ] )
+              ]))
+  | _ -> fail "shutdown JSON codec did not return an object"
+;;
+
 let resolve_done_for_test reg value =
   ignore (R.resolve_done reg ~source:"test_fixture" value);
   match
@@ -1638,6 +1681,8 @@ let test_keeper_shutdown_store_isolates_corrupt_owner () =
         List.fold_left
           (fun (operations, corrupt_records) -> function
              | Shutdown_store.Operation operation -> operation :: operations, corrupt_records
+             | Shutdown_store.Retired_terminal _ ->
+               fail "corrupt-owner fixture produced a retired terminal"
              | Shutdown_store.Corrupt_record corrupt ->
                operations, corrupt :: corrupt_records)
           ([], [])
@@ -1714,6 +1759,256 @@ let test_keeper_shutdown_store_isolates_corrupt_owner () =
           true
           (recovered.phase = recoverable_operation.phase)
       | Error detail -> fail detail)
+
+let test_retired_stale_paused_terminal_releases_exact_fence () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir "retired-stale-paused-terminal" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc.Keeper_turn_admission.For_testing.reset ();
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Masc.Workspace.default_config base_dir in
+      let (_init_message : string) =
+        Masc.Workspace.init config ~agent_name:(Some "operator")
+      in
+      let backlog_version =
+        match Workspace_backlog.read_backlog_r config with
+        | Ok backlog -> backlog.version
+        | Error detail -> fail detail
+      in
+      let meta = make_meta "retired-stale-paused-owner" in
+      let operation_id = Shutdown_types.Operation_id.generate () in
+      let operation : Shutdown_types.t =
+        { schema_version = Shutdown_types.schema_version
+        ; revision = 3
+        ; operation_id
+        ; keeper_name = meta.name
+        ; lane_ownership = Shutdown_types.Dormant_meta
+        ; trace_id = meta.runtime.trace_id
+        ; generation = meta.runtime.generation
+        ; actor = "keeper-autoboot"
+        ; cleanup_intent = remove_meta_cleanup
+        ; turn_disposition = Shutdown_types.No_inflight_turn
+        ; expected_backlog_version = backlog_version
+        ; owned_task_ids = []
+        ; join_evidence = None
+        ; phase =
+            Shutdown_types.Finalized
+              { cleanup = { settled_task_ids = []; pending_confirms_removed = 0 }
+              ; meta_removed = true
+              ; session_removed = false
+              ; registry_unregistered = false
+              ; accumulator_dropped = true
+              ; completion = Shutdown_types.Completion_not_requested
+              }
+        ; created_at = "2026-07-12T09:36:07Z"
+        ; updated_at = "2026-07-12T09:36:07Z"
+        }
+      in
+      let blocked_meta = make_meta "current-blocked-owner" in
+      let blocked_operation_id = Shutdown_types.Operation_id.generate () in
+      let blocked_operation : Shutdown_types.t =
+        { operation with
+          operation_id = blocked_operation_id
+        ; keeper_name = blocked_meta.name
+        ; trace_id = blocked_meta.runtime.trace_id
+        ; cleanup_intent = retain_operator_cleanup
+        ; phase =
+            Shutdown_types.Blocked
+              { stage = Shutdown_types.Unhandled_worker
+              ; detail = "Sys_error(\"Mutex.lock: Resource deadlock avoided\")"
+              }
+        }
+      in
+      let malformed_meta = make_meta "retired-malformed-owner" in
+      let malformed_operation_id = Shutdown_types.Operation_id.generate () in
+      let malformed_operation : Shutdown_types.t =
+        { operation with
+          operation_id = malformed_operation_id
+        ; keeper_name = malformed_meta.name
+        ; trace_id = malformed_meta.runtime.trace_id
+        }
+      in
+      (match Shutdown_store.persist_new ~config operation with
+       | Ok () -> ()
+       | Error error -> fail (Shutdown_store.error_to_string error));
+      (match Shutdown_store.persist_new ~config blocked_operation with
+       | Ok () -> ()
+       | Error error -> fail (Shutdown_store.error_to_string error));
+      (match Shutdown_store.persist_new ~config malformed_operation with
+       | Ok () -> ()
+       | Error error -> fail (Shutdown_store.error_to_string error));
+      let operation_path =
+        match Shutdown_store.path ~config ~keeper_name:meta.name operation_id with
+        | Ok path -> path
+        | Error error -> fail (Shutdown_store.error_to_string error)
+      in
+      (match
+         Fs_compat.save_file_atomic
+           operation_path
+           (retired_stale_paused_schema5_fixture operation |> Yojson.Safe.to_string)
+       with
+       | Ok () -> ()
+       | Error detail -> fail detail);
+      let malformed_operation_path =
+        match
+          Shutdown_store.path
+            ~config
+            ~keeper_name:malformed_meta.name
+            malformed_operation_id
+        with
+        | Ok path -> path
+        | Error error -> fail (Shutdown_store.error_to_string error)
+      in
+      let malformed_fixture =
+        match retired_stale_paused_schema5_fixture malformed_operation with
+        | `Assoc fields -> `Assoc (replace_assoc_field "trace_id" (`Int 7) fields)
+        | _ -> fail "retired fixture did not return an object"
+      in
+      (match
+         Fs_compat.save_file_atomic
+           malformed_operation_path
+           (Yojson.Safe.to_string malformed_fixture)
+       with
+       | Ok () -> ()
+       | Error detail -> fail detail);
+      (match
+         Masc.Keeper_turn_admission.begin_shutdown
+           ~base_path:config.base_path
+           ~keeper_name:meta.name
+           ~operation_id
+       with
+       | Masc.Keeper_turn_admission.Shutdown_reserved _ -> ()
+       | Masc.Keeper_turn_admission.Shutdown_already_reserved _ ->
+         fail "retired fixture unexpectedly found an existing fence");
+      (match
+         Masc.Keeper_turn_admission.begin_shutdown
+           ~base_path:config.base_path
+           ~keeper_name:blocked_meta.name
+           ~operation_id:blocked_operation_id
+       with
+       | Masc.Keeper_turn_admission.Shutdown_reserved _ -> ()
+       | Masc.Keeper_turn_admission.Shutdown_already_reserved _ ->
+         fail "current blocked fixture unexpectedly found an existing fence");
+      (match
+         Masc.Keeper_turn_admission.begin_shutdown
+           ~base_path:config.base_path
+           ~keeper_name:malformed_meta.name
+           ~operation_id:malformed_operation_id
+       with
+       | Masc.Keeper_turn_admission.Shutdown_reserved _ -> ()
+       | Masc.Keeper_turn_admission.Shutdown_already_reserved _ ->
+         fail "malformed retired fixture unexpectedly found an existing fence");
+      let inventory =
+        match Shutdown_store.scan_inventory ~config with
+        | Ok inventory -> inventory
+        | Error error -> fail (Shutdown_store.error_to_string error)
+      in
+      let current_operations, retired_terminals, corrupt_records =
+        List.fold_left
+          (fun (operations, terminals, corrupt) -> function
+             | Shutdown_store.Operation current ->
+               current :: operations, terminals, corrupt
+             | Shutdown_store.Retired_terminal terminal ->
+               operations, terminal :: terminals, corrupt
+             | Shutdown_store.Corrupt_record record ->
+               operations, terminals, record :: corrupt)
+          ([], [], [])
+          inventory
+      in
+      (match retired_terminals with
+       | [ terminal ] ->
+         check string "retired terminal keeps path owner" meta.name terminal.keeper_name;
+         check bool
+           "retired terminal keeps operation identity"
+           true
+           (Shutdown_types.Operation_id.equal operation_id terminal.operation_id)
+       | _ -> fail "retired terminal was not isolated from current operations");
+      (match current_operations with
+       | [ current ] ->
+         check string
+           "current blocked operation remains current"
+           blocked_meta.name
+           current.keeper_name
+       | _ -> fail "current blocked operation changed inventory class");
+      (match corrupt_records with
+       | [ corrupt ] ->
+         check string
+           "malformed retired record keeps its path owner"
+           malformed_meta.name
+           corrupt.keeper_name;
+         check bool
+           "malformed retired record keeps its operation identity"
+           true
+           (Shutdown_types.Operation_id.equal
+              malformed_operation_id
+              corrupt.operation_id)
+       | _ -> fail "malformed retired record did not remain corrupt");
+      let restored =
+        match Shutdown_runtime.restore_inventory_admission ~config inventory with
+        | Ok restored -> restored
+        | Error detail -> fail detail
+      in
+      check
+        (list string)
+        "only the current blocked owner remains blocked"
+        [ blocked_meta.name; malformed_meta.name ]
+        restored.blocked_keeper_names;
+      check int "retired terminal remains observable" 1
+        (List.length restored.retired_terminal_records);
+      check bool
+        "retired terminal releases only its exact fence"
+        true
+        (Option.is_none
+           (Masc.Keeper_turn_admission.snapshot_for
+              ~base_path:config.base_path
+             ~keeper_name:meta.name)
+             .snapshot_shutdown_operation_id);
+      check
+        (option string)
+        "current blocked operation keeps its exact fence"
+        (Some (Shutdown_types.Operation_id.to_string blocked_operation_id))
+        (Option.map
+           Shutdown_types.Operation_id.to_string
+           (Masc.Keeper_turn_admission.snapshot_for
+              ~base_path:config.base_path
+              ~keeper_name:blocked_meta.name)
+             .snapshot_shutdown_operation_id);
+      check
+        (option string)
+        "malformed retired record keeps its exact fence"
+        (Some (Shutdown_types.Operation_id.to_string malformed_operation_id))
+        (Option.map
+           Shutdown_types.Operation_id.to_string
+           (Masc.Keeper_turn_admission.snapshot_for
+              ~base_path:config.base_path
+              ~keeper_name:malformed_meta.name)
+             .snapshot_shutdown_operation_id);
+      let newer_operation_id = Shutdown_types.Operation_id.generate () in
+      (match
+         Masc.Keeper_turn_admission.begin_shutdown
+           ~base_path:config.base_path
+           ~keeper_name:meta.name
+           ~operation_id:newer_operation_id
+       with
+       | Masc.Keeper_turn_admission.Shutdown_reserved _ -> ()
+       | Masc.Keeper_turn_admission.Shutdown_already_reserved _ ->
+         fail "newer shutdown fixture was already reserved");
+      (match Shutdown_runtime.restore_inventory_admission ~config inventory with
+       | Ok _ -> ()
+       | Error detail -> fail detail);
+      check
+        (option string)
+        "retired terminal does not clear a newer owner"
+        (Some (Shutdown_types.Operation_id.to_string newer_operation_id))
+        (Option.map
+           Shutdown_types.Operation_id.to_string
+           (Masc.Keeper_turn_admission.snapshot_for
+              ~base_path:config.base_path
+              ~keeper_name:meta.name)
+             .snapshot_shutdown_operation_id))
 
 let test_dashboard_purge_resolution_is_fail_closed () =
   Eio_main.run @@ fun env ->
@@ -3262,6 +3557,8 @@ let () =
         test_operator_update_supersedes_exact_blocked_shutdown;
       test_case "shutdown store isolates corrupt owner" `Quick
         test_keeper_shutdown_store_isolates_corrupt_owner;
+      test_case "retired stale paused terminal releases exact fence" `Quick
+        test_retired_stale_paused_terminal_releases_exact_fence;
       test_case "dashboard purge resolution is fail closed" `Quick
         test_dashboard_purge_resolution_is_fail_closed;
       test_case "shutdown prepare joins idle lane" `Quick


### PR DESCRIPTION
## Summary
- isolate the removed schema-5 stale_paused_prune terminal as a typed persistence-only inventory entry
- release only the matching retired operation admission fence without restoring removed cleanup behavior
- preserve current/newer shutdown owners and corrupt-record fences
- keep retired terminals observable at bootstrap without counting them as recovery failures

## Fail-closed contract
- every schema-5 common field passes the existing typed decoders before retired classification
- malformed common fields remain Corrupt_record and keep their exact admission fence
- current Blocked(unhandled_worker) operations remain current operations and continue to own admission

## Verification
- independent adversarial review: P0 0, P1 0
- ocamlformat --check
- ocamlc parse checks on all changed ML/MLI
- git diff --check
- focused Dune wrapper unavailable because unrelated bare Dune PID 66224 owns the machine-wide slot; CI is the type/runtime authority