### PR TITLE
test(fixtures): drop removed 'goal' keeper field from test fixtures

### DIFF
--- a/test/test_dashboard_namespace_truth.ml
+++ b/test/test_dashboard_namespace_truth.ml
@@ -143,7 +143,6 @@ let create_keeper env sw state name =
         (`Assoc
           [
             ("name", `String name);
-            ("goal", `String "Dashboard keeper fixture");
             ("proactive_enabled", `Bool false);
                 ("autoboot_enabled", `Bool false);
           ])

--- a/test/test_keeper_board_attention_candidate.ml
+++ b/test/test_keeper_board_attention_candidate.ml
@@ -34,7 +34,6 @@ let meta keeper_name =
       [ "name", `String keeper_name
       ; "agent_name", `String ("keeper-" ^ keeper_name ^ "-agent")
       ; "trace_id", `String ("trace-" ^ keeper_name)
-      ; "goal", `String "Ship the active Board-related goal"
       ; "instructions", `String "Use the lane context and complete the task"
       ; "sandbox_profile", `String "local"
       ; "network_mode", `String "inherit"

--- a/test/test_keeper_fs_edit_containment.ml
+++ b/test/test_keeper_fs_edit_containment.ml
@@ -48,7 +48,6 @@ let make_meta name =
       [ "name", `String name
       ; "agent_name", `String ("agent-" ^ name)
       ; "trace_id", `String ("trace-" ^ name)
-      ; "goal", `String "write containment test"
       ; "sandbox_profile", `String "docker"
       ; "always_allow", `Bool true
       ]

--- a/test/test_keeper_local_profile_docker_playground.ml
+++ b/test/test_keeper_local_profile_docker_playground.ml
@@ -9,7 +9,6 @@ let make_meta ~name ~sandbox_profile ~network_mode =
       [ "name", `String name
       ; "agent_name", `String ("agent-" ^ name)
       ; "trace_id", `String ("trace-" ^ name)
-      ; "goal", `String "local profile routing regression"
       ; "sandbox_profile", `String (Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox_profile)
       ; "network_mode", `String (Keeper_types_profile_sandbox.network_mode_to_string network_mode)
       ]

--- a/test/test_keeper_memory_write.ml
+++ b/test/test_keeper_memory_write.ml
@@ -54,7 +54,6 @@ let make_meta name =
       (`Assoc
         [ "name", `String name
         ; "trace_id", `String ("trace-" ^ name)
-        ; "goal", `String "memory contract test"
         ])
   with
   | Error error -> Alcotest.fail ("meta fixture failed: " ^ error)

--- a/test/test_keeper_run_tools_hooks.ml
+++ b/test/test_keeper_run_tools_hooks.ml
@@ -43,7 +43,6 @@ let make_meta ?(sandbox_profile = Keeper_types_profile_sandbox.Local) name =
       [ "name", `String name
       ; "agent_name", `String ("agent-" ^ name)
       ; "trace_id", `String ("trace-" ^ name)
-      ; "goal", `String "hooks observation test"
       ; "allowed_paths", `List [ `String "*" ]
       ; ( "sandbox_profile"
         , `String

--- a/test/test_keeper_runtime_trust_snapshot.ml
+++ b/test/test_keeper_runtime_trust_snapshot.ml
@@ -83,7 +83,6 @@ let make_meta name : Masc.Keeper_meta_contract.keeper_meta =
       (`Assoc
           [ "name", `String name
           ; "trace_id", `String ("trace-" ^ name)
-          ; "goal", `String "test goal"
           ])
   with
   | Ok meta -> meta

--- a/test/test_keeper_sandbox_read_runner.ml
+++ b/test/test_keeper_sandbox_read_runner.ml
@@ -6,7 +6,6 @@ let make_meta () =
       [ "name", `String "read-runner-keeper"
       ; "agent_name", `String "agent-read-runner"
       ; "trace_id", `String "trace-read-runner"
-      ; "goal", `String "sandbox read runner mock test"
       ; "allowed_paths", `List [ `String "*" ]
       ; "sandbox_profile", `String "docker"
       ]

--- a/test/test_keeper_sandbox_runner.ml
+++ b/test/test_keeper_sandbox_runner.ml
@@ -33,7 +33,6 @@ let make_meta ~sandbox : Keeper_meta_contract.keeper_meta =
       [ "name", `String "runner-test"
       ; "agent_name", `String "runner-test-agent"
       ; "trace_id", `String "runner-test-trace"
-      ; "goal", `String "sandbox runner boundary"
       ; "allowed_paths", `List [ `String "*" ]
       ; ( "sandbox_profile",
           `String (Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox) )

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -717,7 +717,6 @@ let () =
         [ "name", `String keeper_name
         ; "agent_name", `String keeper_name
         ; "trace_id", `String "trace-checkpoint-turn-persist"
-        ; "goal", `String "Persist checkpoint turn usage"
         ])
   in
   write_meta_exn config meta;
@@ -761,7 +760,6 @@ let () =
         [ "name", `String keeper_name
         ; "agent_name", `String keeper_name
         ; "trace_id", `String "trace-success-clears-stale-provider-failure"
-        ; "goal", `String "Clear stale provider runtime failure after success"
         ])
   in
   let run_result ?(stop_reason = Runtime_agent.Completed) ()

--- a/test/test_keeper_tool_audit_snapshot.ml
+++ b/test/test_keeper_tool_audit_snapshot.ml
@@ -31,7 +31,6 @@ let make_meta name =
       (`Assoc
         [ "name", `String name
         ; "trace_id", `String ("trace-" ^ name)
-        ; "goal", `String "surface live tool audit evidence"
         ; "updated_at", `String "2026-06-03T00:00:00Z"
         ])
   with

--- a/test/test_keeper_visible_path_projection.ml
+++ b/test/test_keeper_visible_path_projection.ml
@@ -54,7 +54,6 @@ let make_meta
       [ "name", `String name
       ; "agent_name", `String ("agent-" ^ name)
       ; "trace_id", `String ("trace-" ^ name)
-      ; "goal", `String "visible path projection test"
       ; ( "sandbox_profile"
         , `String (Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox) )
       ]

--- a/test/test_keeper_vision_tool.ml
+++ b/test/test_keeper_vision_tool.ml
@@ -53,7 +53,6 @@ let make_meta name : Masc.Keeper_meta_contract.keeper_meta =
       [ "name", `String name
       ; "agent_name", `String (name ^ "-agent")
       ; "trace_id", `String (name ^ "-trace")
-      ; "goal", `String "vision tool test"
       ; "allowed_paths", `List [ `String "*" ]
       ; "sandbox_profile", `String "none"
       ]

--- a/test/test_keeper_waiting_inventory.ml
+++ b/test/test_keeper_waiting_inventory.ml
@@ -66,7 +66,6 @@ let keeper_meta_fixture keeper_name =
     (`Assoc
       [ "name", `String keeper_name
       ; "agent_name", `String keeper_name
-      ; "goal", `String "waiting inventory test"
       ; "sandbox_profile", `String "local"
       ; "network_mode", `String "inherit"
       ])

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -126,7 +126,6 @@ let make_meta name : KMC.keeper_meta =
     `Assoc
       [ "name", `String name
       ; "trace_id", `String ("test-trace-" ^ name)
-      ; "goal", `String "test goal"
       ]
   in
   match Masc_test_deps.meta_of_json_fixture json with


### PR DESCRIPTION
## 근본원인

keeper-meta 스키마가 `goal` 필드를 제거했습니다 — `Keeper_meta_json_parse`가 이제 거부(`removed keeper meta field is no longer supported: goal`)하고, `masc_keeper_up`도 tool-arg로 거부(`removed keeper args for masc_keeper_up: goal`). 하지만 다수 test fixture가 여전히 `goal`을 주입해 런타임에 base-red — 스키마 강화가 fixture에 전파되지 않았습니다.

## 변경

keeper-meta JSON fixture(14파일, 15엔트리) + `masc_keeper_up` tool-arg fixture 1개(`test_dashboard_namespace_truth.ml`)에서 `goal` 엔트리 제거. **순수 삭제 16줄, 다른 변경 없음**(조인 아티팩트 없이 clean).

## 범위 가드

keeper-meta 파싱 또는 masc_keeper_up args로 흐르는 `goal`만 제거. 정당한 `goal`은 보존 — session/briefing goal, memory-kind `~kind:"goal"`, `Goal_store`, 그리고 **거부를 검증하려 일부러 goal을 주입하는 positive-assertion 테스트**(`test_keeper_identity_parse`의 `test_legacy_goal_meta_rejected`, `test_keeper_meta_unknown_keys_warn` 등).

## 검증

- 편집된 모든 테스트에서 `goal` 거부 에러 **제거**. 15개 중 **11개 완전 통과**.
- 나머지 4개는 이 변경과 **무관한 별개 base-red**(여기서 미해결, 별도 추적):
  - `test_runtime_per_keeper_routing`: OAS provider-registry SSOT(kimi messages-http) + token-capacity
  - `test_keeper_vision_tool`: `no schema-capable image runtime configured`
  - `test_keeper_waiting_inventory`: dashboard chat-queue rows
  - `test_keeper_runtime_trust_snapshot`: `receipt_runtime_model`
- `lib/` 무변경 — 스키마 제거는 의도된 것, fixture가 따라감.
- ocamlformat은 리포지토리 전역 disable(`.ocamlformat` `disable = true`)이라 fmt CI 영향 없음.

## 관련

catalog provider_name 마이그레이션(#24672)과 **독립** — 둘 다 서로 다른 base-red 원인. main-green엔 이 두 PR + 위 4개 잔여 원인의 별도 수정이 필요합니다.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
