### PR TITLE
test(gate): remove standing rule residue

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -1934,7 +1934,6 @@ module For_testing = struct
   ;;
 
   let pending_store_path = pending_store_path
-  let always_allowed_store_path ~base_path = rules_path ~base_path ()
 end
 
 let resolve_with_policy

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -128,7 +128,6 @@ module For_testing : sig
     after_load:(unit -> unit) ->
     (install_report, install_error) result
   val pending_store_path : base_path:string -> string
-  val always_allowed_store_path : base_path:string -> string
 end
 
 (** {1 Nonblocking submission and explicit resolution} *)

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -234,15 +234,6 @@ let write_pending_snapshot ~base_path json =
     output_string channel (Yojson.Safe.pretty_to_string json))
 ;;
 
-let delivery_json ~entry =
-  `Assoc
-    [ "entry", entry
-    ; "decision", `Assoc [ "kind", `String "approve" ]
-    ; "source", `String "human_operator"
-    ; "grant_consumed", `Bool false
-    ]
-;;
-
 let install_exn ~base_path =
   match AQ.install_persistence ~base_path with
   | Ok report -> report
@@ -436,17 +427,6 @@ let test_resolution_is_durable_and_origin_scoped () =
                ~base_path
                ~keeper_name:unrelated_keeper
                ~approval_id:id));
-       Alcotest.(check bool) "request-local approval creates no standing rule" true
-         (match
-            AQ.find_matching_rule
-              ~base_path
-              ~keeper_name
-              ~tool_name:"external-effect"
-              ~input
-              ()
-          with
-          | Ok matched -> Option.is_none matched
-          | Error error -> Alcotest.fail (AQ.rule_store_error_to_string error));
        (match
           AQ.consume_approved_resolution
             ~base_path
@@ -1080,80 +1060,6 @@ let test_persisted_delivery_replays_before_origin_wake () =
           |> member "grant_consumed"
           |> to_bool);
        drop_resolution ~base_path ~keeper_name resolution)
-;;
-
-let test_one_delivery_replay_failure_does_not_stop_others () =
-  let base_path = temp_dir () in
-  let keeper_name = "queue-independent-replay" in
-  Fun.protect
-    ~finally:(fun () ->
-      AQ.For_testing.reset_runtime_state ();
-      cleanup_dir base_path)
-    (fun () ->
-       AQ.For_testing.reset_runtime_state ();
-       let failing_id =
-         submit
-           ~base_path
-           ~keeper_name
-           ~input:(`Assoc [ "target", `String "remember-fails" ])
-       in
-       let successful_id =
-         submit
-           ~base_path
-           ~keeper_name
-           ~input:(`Assoc [ "target", `String "independent-success" ])
-       in
-       let pending_entries =
-         let open Yojson.Safe.Util in
-         read_pending_snapshot ~base_path |> member "pending" |> to_list
-       in
-       let entry_for id =
-         let open Yojson.Safe.Util in
-         match
-           List.find_opt
-             (fun json -> String.equal (json |> member "id" |> to_string) id)
-             pending_entries
-         with
-         | Some entry -> entry
-         | None -> Alcotest.fail ("missing persisted entry " ^ id)
-       in
-       write_pending_snapshot
-         ~base_path
-         (`Assoc
-            [ "version", `Int 3
-            ; "pending", `List []
-            ; ( "deliveries"
-              , `List
-                  [ delivery_json ~entry:(entry_for failing_id)
-                  ; delivery_json ~entry:(entry_for successful_id)
-                  ] )
-            ]);
-       let rules_path = AQ.For_testing.always_allowed_store_path ~base_path in
-       ensure_dir (Filename.dirname rules_path);
-       Unix.mkdir rules_path 0o755;
-       AQ.For_testing.reset_runtime_state ();
-       let report = install_exn ~base_path in
-       Alcotest.(check int) "independent delivery replayed" 1 report.replayed_deliveries;
-       Alcotest.(check int)
-         "one replay failure reported"
-         1
-         (List.length report.delivery_replay_failures);
-       Alcotest.(check string)
-         "failing approval identified"
-         failing_id
-         (List.hd report.delivery_replay_failures).approval_id;
-       Alcotest.(check bool) "later delivery reached origin" true
-         (Option.is_some
-            (durable_resolution_opt
-               ~base_path
-               ~keeper_name
-               ~approval_id:successful_id));
-       List.iter
-         (fun approval_id ->
-            match durable_resolution_opt ~base_path ~keeper_name ~approval_id with
-            | Some resolution -> drop_resolution ~base_path ~keeper_name resolution
-            | None -> ())
-         [ failing_id; successful_id ])
 ;;
 
 let test_submit_surfaces_storage_failure () =


### PR DESCRIPTION
## Summary
- remove the stale standing-rule assertion after the public rule API hard cut
- delete the unregistered rule-store replay test and its private test-only path hook
- keep exact one-shot approval grant coverage intact

## Verification
- ocamlformat --check on changed OCaml files
- ocamlc -stop-after parsing on changed OCaml files
- focused Dune wrapper correctly refused because bare Dune PID 66224 is active; CI remains build authority

## Stack
Base: #24683