### PR TITLE
fix(keeper): preserve Gate deferral as canonical disposition

### DIFF
--- a/lib/keeper/keeper_gate_deferred_payload.ml
+++ b/lib/keeper/keeper_gate_deferred_payload.ml
@@ -1,0 +1,45 @@
+type t =
+  { operation : string
+  ; approval_id : string
+  ; reason : Keeper_gate.deferred_reason
+  ; context : Yojson.Safe.t option
+  }
+
+let message =
+  "External effect deferred without blocking this Keeper. Continue other work; the originating Keeper lane will wake after resolution."
+;;
+
+let create ~operation ~approval_id ~reason ?context () =
+  { operation; approval_id; reason; context }
+;;
+
+let gate_json t =
+  Keeper_gate.decision_to_yojson
+    (Keeper_gate.Deferred { approval_id = t.approval_id; reason = t.reason })
+;;
+
+let data t =
+  let context_field =
+    match t.context with
+    | Some context -> [ "context", context ]
+    | None -> []
+  in
+  `Assoc
+    ([ "message", `String message
+     ; "operation", `String t.operation
+     ; "gate", gate_json t
+     ]
+     @ context_field)
+;;
+
+let to_execution t =
+  Keeper_tool_execution.deferred_data (data t)
+;;
+
+let to_tool_result ~tool_name ~start_time t =
+  Tool_result.make_deferred
+    ~tool_name
+    ~start_time
+    ~data:(data t)
+    ()
+;;

--- a/lib/keeper/keeper_gate_deferred_payload.mli
+++ b/lib/keeper/keeper_gate_deferred_payload.mli
@@ -1,0 +1,27 @@
+(** Canonical non-blocking tool result for a durable Gate deferral.
+
+    This module owns only the Gate receipt payload. The execution disposition
+    is represented exclusively by {!Tool_result.Deferred}; payload fields and
+    OAS metadata are never semantic authorities. *)
+
+type t
+
+val create
+  :  operation:string
+  -> approval_id:string
+  -> reason:Keeper_gate.deferred_reason
+  -> ?context:Yojson.Safe.t
+  -> unit
+  -> t
+
+val data : t -> Yojson.Safe.t
+
+(** Project the receipt as a canonical deferred Keeper execution. The external
+    effect did not run and the Keeper remains free to continue other work. *)
+val to_execution : t -> Keeper_tool_execution.t
+
+val to_tool_result
+  :  tool_name:string
+  -> start_time:float
+  -> t
+  -> Tool_result.result

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -257,7 +257,7 @@ let handle_tool_execute_typed
             s
           |> Exec_policy.truncate_for_log
         in
-        let typed_error_fields =
+        let typed_context_fields =
           [ "typed", `Bool true; "cmd", `String cmd_for_log ]
           @ response_cwd_field
           @ execution_location_fields cwd
@@ -270,7 +270,7 @@ let handle_tool_execute_typed
           Keeper_tool_execution.failure
             ~class_
             (error_json
-               ~fields:(typed_error_fields @ extra_fields)
+               ~fields:(typed_context_fields @ extra_fields)
                msg)
         in
         let sandbox_profile_label =
@@ -302,16 +302,13 @@ let handle_tool_execute_typed
              gate_request
          with
          | Keeper_gate.Deferred { approval_id; reason } ->
-           typed_error_json
-             ~class_:Tool_result.Workflow_rejection
-             ~extra_fields:
-               [ "error", `String "gate_deferred"
-               ; "approval_request_id", `String approval_id
-               ; "approval_queue_status", `String "pending"
-               ; "approval_nonblocking", `Bool true
-               ; "gate_reason", `String (Keeper_gate.deferred_reason_to_string reason)
-             ]
-             "External effect deferred without blocking this Keeper. Continue other work; the originating Keeper lane will wake after resolution."
+           Keeper_gate_deferred_payload.create
+             ~operation:"tool_execute"
+             ~approval_id
+             ~reason
+             ~context:(`Assoc typed_context_fields)
+             ()
+           |> Keeper_gate_deferred_payload.to_execution
          | Keeper_gate.Unavailable reason ->
            typed_error_json
              ~extra_fields:

--- a/lib/keeper/keeper_tool_filesystem_runtime.ml
+++ b/lib/keeper/keeper_tool_filesystem_runtime.ml
@@ -944,23 +944,9 @@ let decide_file_write
     }
 ;;
 
-let file_write_deferred_json ~target ~approval_id ~reason =
-  Yojson.Safe.to_string
-    (`Assoc
-       [ "error", `String "gate_deferred"
-       ; ( "message"
-         , `String
-             "External effect deferred without blocking this Keeper. Continue other work; the originating Keeper lane will wake after resolution." )
-       ; "path", `String target
-       ; "gate_request_id", `String approval_id
-       ; "gate_status", `String "pending"
-       ; "gate_nonblocking", `Bool true
-       ; "gate_reason", `String (Keeper_gate.deferred_reason_to_string reason)
-       ])
-;;
-
 type file_write_attempt =
   | Write_succeeded of string
+  | Write_deferred of Keeper_gate_deferred_payload.t
   | Write_failed of
       { payload : string
       ; class_ : Tool_result.tool_failure_class
@@ -1466,6 +1452,8 @@ let observe_append_write_outcome ~keeper_name ~target outcome =
 
 let file_write_attempt_to_execution = function
   | Write_succeeded payload -> Keeper_tool_execution.success payload
+  | Write_deferred deferred ->
+    Keeper_gate_deferred_payload.to_execution deferred
   | Write_failed { payload; class_ } -> Keeper_tool_execution.failure ~class_ payload
   | Write_failed_data { message; data; class_ } ->
     Keeper_tool_execution.failure_data ~class_ ~message data
@@ -1744,10 +1732,13 @@ let handle_file_write_with_outcome
     with
     | Keeper_gate.Deferred { approval_id; reason } ->
       Ok
-        (Write_failed
-           { payload = file_write_deferred_json ~target ~approval_id ~reason
-           ; class_ = Tool_result.Workflow_rejection
-           })
+        (Write_deferred
+           (Keeper_gate_deferred_payload.create
+              ~operation:"filesystem_write"
+              ~approval_id
+              ~reason
+              ~context:(`Assoc [ "path", `String target ])
+              ()))
     | Keeper_gate.Unavailable reason ->
       Ok
         (Write_failed

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -18,24 +18,14 @@ let handle_tools_list ~(meta : keeper_meta) ~args:_ =
   Keeper_tool_shared_runtime.keeper_tools_list_json ~meta
 ;;
 
-let external_effect_deferred_json ~approval_id ~reason =
-  Yojson.Safe.to_string
-    (`Assoc
-       [ "error", `String "gate_deferred"
-       ; "message"
-       , `String
-           "External effect deferred without blocking this Keeper. Continue other work; the originating Keeper lane will wake after resolution."
-       ; "gate_request_id", `String approval_id
-       ; "gate_status", `String "pending"
-       ; "gate_nonblocking", `Bool true
-       ; "gate_reason", `String (Keeper_gate.deferred_reason_to_string reason)
-       ])
-;;
-
 type external_gate_block =
   { payload : string
   ; failure_class : Tool_result.tool_failure_class
   }
+
+type external_gate_non_allow =
+  | Gate_deferred of Keeper_gate_deferred_payload.t
+  | Gate_unavailable of external_gate_block
 
 let external_gate_decision
       ~config
@@ -63,23 +53,27 @@ let external_gate_decision
   with
   | Keeper_gate.Deferred { approval_id; reason } ->
     Error
-      { payload = external_effect_deferred_json ~approval_id ~reason
-      ; failure_class = Tool_result.Workflow_rejection
-      }
+      (Gate_deferred
+         (Keeper_gate_deferred_payload.create
+            ~operation
+            ~approval_id
+            ~reason
+            ()))
   | Keeper_gate.Unavailable reason ->
     Error
-      { payload =
-          Yojson.Safe.to_string
-            (`Assoc
-               [ "error", `String "gate_unavailable"
-               ; "message"
-               , `String
-                   "External effect was not executed because the Gate could not durably record its decision state. This Keeper remains active and may continue other work."
-               ; "gate_reason"
-               , `String (Keeper_gate.unavailable_reason_to_string reason)
-               ])
-      ; failure_class = Tool_result.Runtime_failure
-      }
+      (Gate_unavailable
+         { payload =
+             Yojson.Safe.to_string
+               (`Assoc
+                  [ "error", `String "gate_unavailable"
+                  ; "message"
+                  , `String
+                      "External effect was not executed because the Gate could not durably record its decision state. This Keeper remains active and may continue other work."
+                  ; "gate_reason"
+                  , `String (Keeper_gate.unavailable_reason_to_string reason)
+                  ])
+         ; failure_class = Tool_result.Runtime_failure
+         })
   | Keeper_gate.Allow authorization ->
     Log.Keeper.info
       ~keeper_name:meta.name
@@ -87,31 +81,6 @@ let external_gate_decision
       operation
       (Keeper_gate.authorization_source_to_string authorization.source);
     Ok ()
-;;
-
-let with_external_gate
-      ~config
-      ~(meta : keeper_meta)
-      ?continuation_channel
-      ?gate_context
-      ?gate_grant
-      ~operation
-      ~input
-      continue
-  =
-  match
-    external_gate_decision
-      ~config
-      ~meta
-      ?continuation_channel
-      ?gate_context
-      ?gate_grant
-      ~operation
-      ~input
-      ()
-  with
-  | Ok () -> continue ()
-  | Error blocked -> blocked.payload
 ;;
 
 let with_external_gate_tool_result
@@ -136,7 +105,12 @@ let with_external_gate_tool_result
       ()
   with
   | Ok () -> continue ()
-  | Error blocked ->
+  | Error (Gate_deferred deferred) ->
+    Keeper_gate_deferred_payload.to_tool_result
+      ~tool_name:operation
+      ~start_time:(Time_compat.now ())
+      deferred
+  | Error (Gate_unavailable blocked) ->
     tool_result_error
       ~tool_name:operation
       ~class_:blocked.failure_class
@@ -165,7 +139,13 @@ let with_external_gate_tool_result_option
       ()
   with
   | Ok () -> continue ()
-  | Error blocked ->
+  | Error (Gate_deferred deferred) ->
+    Some
+      (Keeper_gate_deferred_payload.to_tool_result
+         ~tool_name:operation
+         ~start_time:(Time_compat.now ())
+         deferred)
+  | Error (Gate_unavailable blocked) ->
     Some
       (tool_result_error
          ~tool_name:operation
@@ -195,7 +175,9 @@ let with_external_gate_execution
       ()
   with
   | Ok () -> continue ()
-  | Error blocked ->
+  | Error (Gate_deferred deferred) ->
+    Keeper_gate_deferred_payload.to_execution deferred
+  | Error (Gate_unavailable blocked) ->
     Keeper_tool_execution.failure
       ~class_:blocked.failure_class
       blocked.payload
@@ -374,26 +356,6 @@ let connector_post_gate_input ~connector ~channel_id ~content ?blocks () =
      ; "content", `String content
      ]
      @ block_fields)
-;;
-
-let with_connector_post_gate
-      ~config
-      ~(meta : keeper_meta)
-      ?continuation_channel
-      ?gate_context
-      ?gate_grant
-      ~input
-      continue
-  =
-  with_external_gate
-    ~config
-    ~meta
-    ?continuation_channel
-    ?gate_context
-    ?gate_grant
-    ~operation:"connector_post"
-    ~input
-    continue
 ;;
 
 let with_connector_post_gate_execution

--- a/test/test_keeper_gate_effect_coverage.ml
+++ b/test/test_keeper_gate_effect_coverage.ml
@@ -36,10 +36,26 @@ let make_meta ?(always_allow = false) name =
     if always_allow then { meta with always_allow = Some true } else meta
 ;;
 
-let json_error raw =
-  Yojson.Safe.from_string raw
-  |> Yojson.Safe.Util.member "error"
-  |> Yojson.Safe.Util.to_string
+let expect_completed label (result : Keeper_tool_execution.t) =
+  match result.disposition with
+  | Tool_result.Completed () -> ()
+  | Tool_result.Deferred () | Tool_result.Failed _ -> fail (label ^ ": not completed")
+;;
+
+let expect_deferred label (result : Keeper_tool_execution.t) =
+  match result.disposition with
+  | Tool_result.Deferred () -> ()
+  | Tool_result.Completed () | Tool_result.Failed _ -> fail (label ^ ": not deferred")
+;;
+
+let expect_failed label expected (result : Keeper_tool_execution.t) =
+  match result.disposition with
+  | Tool_result.Failed actual ->
+    check string
+      label
+      (Tool_result.tool_failure_class_to_string expected)
+      (Tool_result.tool_failure_class_to_string actual)
+  | Tool_result.Completed () | Tool_result.Deferred () -> fail (label ^ ": not failed")
 ;;
 
 let with_clean_gate_runtime f =
@@ -92,10 +108,11 @@ let with_keeper_dispatch_probe f =
     let continue () =
       calls := (name, args) :: !calls;
       Some
-        (Tool_result.ok
+        (Tool_result.make_ok
            ~tool_name:name
            ~start_time:0.0
-           {|{"ok":true,"effect":"ran"}|})
+           ~data:(`Assoc [ "effect", `String "ran" ])
+           ())
     in
     match authorize_external_effect with
     | None -> continue ()
@@ -171,8 +188,8 @@ let test_keeper_effects_defer_without_dispatch () =
   List.iter
     (fun name ->
        let args = `Assoc [ "opaque", `String name ] in
-         let raw =
-           Keeper_tool_in_process_runtime.handle_masc_keeper
+         let result =
+           Keeper_tool_in_process_runtime.handle_masc_keeper_with_outcome
            ~publication_recovery_provider:publication_recovery.provider
            ~config
            ~meta
@@ -180,7 +197,7 @@ let test_keeper_effects_defer_without_dispatch () =
            ~args
            ()
        in
-       check string (name ^ " defers") "gate_deferred" (json_error raw))
+       expect_deferred (name ^ " defers") result)
     keeper_effect_names;
   check int "no Keeper effect dispatched" 0 (List.length !calls)
 ;;
@@ -198,8 +215,8 @@ let test_keeper_effects_unavailable_without_dispatch () =
   with_keeper_dispatch_probe @@ fun calls ->
   List.iter
     (fun name ->
-         let raw =
-           Keeper_tool_in_process_runtime.handle_masc_keeper
+         let result =
+           Keeper_tool_in_process_runtime.handle_masc_keeper_with_outcome
            ~publication_recovery_provider:publication_recovery.provider
            ~config
            ~meta
@@ -207,7 +224,10 @@ let test_keeper_effects_unavailable_without_dispatch () =
            ~args:(`Assoc [ "opaque", `String name ])
            ()
        in
-       check string (name ^ " unavailable") "gate_unavailable" (json_error raw))
+       expect_failed
+         (name ^ " unavailable")
+         Tool_result.Runtime_failure
+         result)
     keeper_effect_names;
   check int "unavailable Gate executes no Keeper effect" 0 (List.length !calls)
 ;;
@@ -226,8 +246,8 @@ let test_keeper_effects_allow_exact_dispatch () =
   List.iter
     (fun name ->
        let args = `Assoc [ "opaque", `String name ] in
-         let raw =
-           Keeper_tool_in_process_runtime.handle_masc_keeper
+         let result =
+           Keeper_tool_in_process_runtime.handle_masc_keeper_with_outcome
            ~publication_recovery_provider:publication_recovery.provider
            ~config
            ~meta
@@ -235,10 +255,12 @@ let test_keeper_effects_allow_exact_dispatch () =
            ~args
            ()
        in
+       expect_completed (name ^ " proceeds") result;
+       let data = Option.value ~default:`Null result.data in
        check string
          (name ^ " proceeds")
          "ran"
-         Yojson.Safe.Util.(member "effect" (Yojson.Safe.from_string raw) |> to_string))
+         Yojson.Safe.Util.(member "effect" data |> to_string))
     keeper_effect_names;
   let observed = List.rev !calls in
   check
@@ -275,23 +297,23 @@ let test_ollama_probe_defer_and_unavailable_do_not_dispatch () =
    | Error error -> fail ("failed to select manual Gate mode: " ^ error));
   let meta = make_meta "ollama-gate-deferred-keeper" in
   let deferred =
-    Keeper_tool_in_process_runtime.handle_masc_local_runtime
+    Keeper_tool_in_process_runtime.handle_masc_local_runtime_with_outcome
       ~config:deferred_config
       ~meta
       ~name:ollama_probe_name
       ~args:ollama_probe_input
       ()
   in
-  check string "probe defers" "gate_deferred" (json_error deferred);
+  expect_deferred "probe defers" deferred;
   let unavailable =
-    Keeper_tool_in_process_runtime.handle_masc_local_runtime
+    Keeper_tool_in_process_runtime.handle_masc_local_runtime_with_outcome
       ~config:(Workspace.default_config "/dev/null")
       ~meta
       ~name:ollama_probe_name
       ~args:ollama_probe_input
       ()
   in
-  check string "probe unavailable" "gate_unavailable" (json_error unavailable);
+  expect_failed "probe unavailable" Tool_result.Runtime_failure unavailable;
   ()
 ;;
 
@@ -305,15 +327,16 @@ let test_ollama_probe_allow_dispatches_exact_input () =
   Fun.protect
     ~finally:(fun () -> Keeper_registry.unregister ~base_path meta.name)
   @@ fun () ->
-  let raw =
-    Keeper_tool_in_process_runtime.handle_masc_local_runtime
+  let result =
+    Keeper_tool_in_process_runtime.handle_masc_local_runtime_with_outcome
       ~config
       ~meta
       ~name:ollama_probe_name
       ~args:ollama_probe_input
-      ()
+    ()
   in
-  let json = Yojson.Safe.from_string raw in
+  expect_completed "Always Allow proceeds" result;
+  let json = Option.value ~default:`Null result.data in
   check bool
     "Always Allow proceeds into the runtime handler"
     true

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -860,13 +860,12 @@ let test_manual_gate_defers_publication_writes_before_recovery () =
        in
        List.iter
          (fun result ->
-            check string "Manual Gate outcome" "failure"
+            check string "Manual Gate outcome" "deferred"
               (outcome_label result.KTE.disposition);
-            check string
-              "Manual Gate returns typed defer"
-              "gate_deferred"
-              Yojson.Safe.Util.
-                (member "error" (parse_json result.raw_output) |> to_string))
+            match result.KTE.disposition with
+            | Tool_result.Deferred () -> ()
+            | Tool_result.Completed () | Tool_result.Failed _ ->
+              fail "Manual Gate lost its canonical deferred disposition")
          [ overwrite; edit ];
        check int
          "Manual Gate defers publication writes before provider acquisition"
@@ -874,6 +873,78 @@ let test_manual_gate_defers_publication_writes_before_recovery () =
          (Atomic.get provider_reads);
        check string "Manual Gate preserves exact target bytes" original
          (read_file path))
+;;
+
+let test_manual_gate_deferral_stays_deferred_through_oas_bridge () =
+  with_exec_fixture
+    "keeper_tool_dispatch_manual_gate_oas_bridge"
+    (fun ~config ~meta ~publication_recovery ~ctx_work ->
+       (match
+          Masc.Keeper_gate_mode.set
+            config
+            ~actor:"test"
+            Masc.Keeper_gate_mode.Manual
+        with
+        | Ok _ -> ()
+        | Error detail -> fail ("failed to select Manual Gate mode: " ^ detail));
+       let path = Filename.concat config.base_path "manual-gate-oas.txt" in
+       let input =
+         `Assoc
+           [ "file_path", `String path
+           ; "content", `String "must remain deferred"
+           ]
+       in
+       let input_schema =
+         match KTD.descriptors_for_internal "tool_write_file" with
+         | [ descriptor ] -> descriptor.KTD.input_schema
+         | [] -> fail "missing tool_write_file descriptor"
+         | _ :: _ :: _ -> fail "duplicate tool_write_file descriptors"
+       in
+       let handler =
+         Masc.Keeper_tools_oas_handler.make_keeper_tool_handler
+           ~name:"Write"
+           ~input_schema
+           ~config
+           ~meta
+           ~publication_recovery
+           ~ctx_snapshot:ctx_work
+           ~exec_cache:None
+           ()
+       in
+       let masc_result = handler input in
+       (match masc_result with
+        | Tool_result.Deferred output ->
+          check bool
+            "producer metadata is not a semantic channel"
+            true
+            (Option.is_none output.metadata);
+          check bool
+            "payload has no duplicate disposition field"
+            true
+            Yojson.Safe.Util.(output.data |> member "disposition" = `Null);
+          check bool
+            "payload has no duplicate success field"
+            true
+            Yojson.Safe.Util.(output.data |> member "ok" = `Null);
+          check string
+            "Gate decision remains typed domain evidence"
+            "deferred"
+            Yojson.Safe.Util.
+              (output.data |> member "gate" |> member "decision" |> to_string)
+        | Tool_result.Completed _ -> fail "Gate deferral became Completed"
+        | Tool_result.Failed _ -> fail "Gate deferral became Failed");
+       (match Masc.Tool_bridge.to_oas_typed_result masc_result with
+        | Ok { _meta = Some (`Assoc fields); _ } ->
+          check (option string)
+            "OAS receives the one-way deferred projection"
+            (Some "deferred")
+            (match List.assoc_opt "masc.tool_disposition" fields with
+             | Some (`String value) -> Some value
+             | Some _ | None -> None)
+        | Ok _ -> fail "Deferred OAS projection omitted its disposition marker"
+        | Error error ->
+          fail ("Deferred crossed the OAS boundary as failure: " ^ error.message));
+       check bool "Deferred Write executed no effect" false (Sys.file_exists path))
 ;;
 
 let test_publication_initialization_crash_is_redacted () =
@@ -2146,13 +2217,12 @@ let test_manual_gate_defers_web_tools_before_network () =
               in
               List.iter
                 (fun result ->
-                   check string "Manual Gate outcome" "failure"
+                   check string "Manual Gate outcome" "deferred"
                      (outcome_label result.KTE.disposition);
-                   check string
-                     "Manual Gate returns typed defer"
-                     "gate_deferred"
-                     Yojson.Safe.Util.
-                       (member "error" (parse_json result.raw_output) |> to_string))
+                   match result.KTE.disposition with
+                   | Tool_result.Deferred () -> ()
+                   | Tool_result.Completed () | Tool_result.Failed _ ->
+                     fail "Manual Gate lost its canonical deferred disposition")
                 [ search; fetch ];
               check int "Manual Gate executes no WebFetch callback" 0 !fetch_calls)))
 
@@ -2174,6 +2244,46 @@ let test_tool_result_does_not_infer_task_fsm_rejections_from_message () =
          "expected runtime_failure, got %s"
          (Tool_result.tool_failure_class_to_string cls))
   | None -> fail "expected failure_class"
+
+let test_manual_gate_defers_tool_execute_before_process () =
+  with_exec_fixture
+    "keeper_tool_dispatch_manual_execute_gate"
+    (fun ~config ~meta ~publication_recovery ~ctx_work ->
+      (match
+         Masc.Keeper_gate_mode.set
+           config
+           ~actor:"test"
+           Masc.Keeper_gate_mode.Manual
+       with
+       | Ok _ -> ()
+       | Error detail -> fail ("failed to select Manual Gate mode: " ^ detail));
+      let marker = Filename.concat config.base_path "must-not-execute" in
+      let result =
+        KET.execute_keeper_tool_call_with_outcome
+          ~config
+          ~meta
+          ~publication_recovery
+          ~ctx_work
+          ~exec_cache:None
+          ~name:"tool_execute"
+          ~input:
+            (`Assoc
+               [ "argv", `List [ `String "touch"; `String marker ]
+               ; "cwd", `String config.base_path
+               ; "timeout_sec", `Float 5.0
+               ])
+          ()
+      in
+      (match result.KTE.disposition with
+       | Tool_result.Deferred () -> ()
+       | Tool_result.Completed () -> fail "Manual Gate executed tool_execute"
+       | Tool_result.Failed _ -> fail "Manual Gate turned tool_execute into failure");
+      let data = Option.value ~default:`Null result.KTE.data in
+      check string
+        "Gate decision remains typed domain evidence"
+        "deferred"
+        Yojson.Safe.Util.(data |> member "gate" |> member "decision" |> to_string);
+      check bool "Manual Gate starts no process" false (Sys.file_exists marker))
 
 let test_tool_execute_raw_cmd_requires_typed_shell_ir () =
   with_exec_fixture "tool_execute_raw_cmd_requires_typed_shell_ir"
@@ -2617,6 +2727,8 @@ let () =
         test_initializing_recovery_isolates_only_publication_writes;
       test_case "Manual Gate defers writes before recovery acquisition" `Quick
         test_manual_gate_defers_publication_writes_before_recovery;
+      test_case "Manual Gate deferral stays deferred through OAS bridge" `Quick
+        test_manual_gate_deferral_stays_deferred_through_oas_bridge;
       test_case "initialization crash is redacted from tool output" `Quick
         test_publication_initialization_crash_is_redacted;
       test_case "reconciliation evidence is redacted from tool output" `Quick
@@ -2651,6 +2763,8 @@ let () =
         test_manual_gate_defers_web_tools_before_network;
       test_case "task FSM errors require explicit failure_class" `Quick
         test_tool_result_does_not_infer_task_fsm_rejections_from_message;
+      test_case "Manual Gate defers tool_execute before process" `Quick
+        test_manual_gate_defers_tool_execute_before_process;
       test_case "tool_execute raw cmd requires typed Shell IR" `Quick
         test_tool_execute_raw_cmd_requires_typed_shell_ir;
       test_case "OAS handler threads Eio context to keeper dispatch" `Quick


### PR DESCRIPTION
## Dependency
- Depends on #24749, which defines Tool_result.disposition as the MASC semantic SSOT and removes the duplicate OAS outcome envelope.

## Summary
- preserve Gate deferral as canonical Tool_result.Deferred through Keeper dispatch
- keep the typed Gate receipt limited to operation, approval id, reason, and optional context
- remove payload and producer-metadata outcome authorities
- keep Gate Unavailable as Runtime_failure
- execute no filesystem, process, Keeper lifecycle, or network effect while deferred
- remove the unused raw connector Gate helpers and the old Workflow_rejection modeling

## Boundary
- MASC owns Gate and Deferred semantics
- OAS receives only the one-way masc.tool_disposition=deferred projection required because its result type has no Deferred constructor
- MASC never parses that OAS metadata back into semantic state

## Verification
- scripts/dune-local.sh build lib/masc.cmxa test/test_keeper_gate_effect_coverage.exe test/test_keeper_tool_dispatch_runtime.exe
- keeper_gate_effect_coverage: 7 passed
- Keeper_tool_dispatch_runtime: 37 passed
- ocamlformat and git diff checks passed
- SSOT, silent-failure, enum-string, determinism, MASC/OAS boundary, and hardcoding audits passed
