### PR TITLE
fix(keeper): continue lane after compaction retry

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -429,6 +429,7 @@ let ready_queue_followup_of_settlement ~lease = function
   | Keeper_registry_event_queue.Requeue
       ( Keeper_registry_event_queue.Rotate_now
       | Keeper_registry_event_queue.Retry_after_observed
+      | Keeper_registry_event_queue.Context_compaction_retry
       | Keeper_registry_event_queue.Approval_grant_unconsumed
       | Keeper_registry_event_queue.Approval_grant_state_unavailable ) ->
     Drain_ready_queue

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -124,8 +124,9 @@ val ready_queue_followup_of_settlement
   -> Keeper_registry_event_queue.settlement
   -> ready_queue_followup
 (** Decide whether a committed settlement may immediately drain other ready
-    work. Retryable/recoverable sources are excluded for this one follow-up so
-    they cannot monopolize the lane ahead of unrelated stimuli. *)
+    work. Retryable/recoverable sources, including a source awaiting context
+    compaction retry, are excluded for this one follow-up so they cannot
+    monopolize the lane ahead of unrelated stimuli. *)
 
 (** Record a swallowed keepalive-cycle exception as a turn failure:
     increments the registry turn-failure counter (shared with

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -567,6 +567,30 @@ let test_settlement_controls_immediate_lane_drain () =
   | _ -> Alcotest.fail "busy turn slot requested an immediate retry loop"
 ;;
 
+let test_context_compaction_retry_continues_lane_drain () =
+  let source = stimulus "context-compaction-source" 1.0 in
+  let unrelated = stimulus "unrelated-ready" 2.0 in
+  let lease = lease_for source in
+  let followup =
+    Masc.Keeper_heartbeat_loop.ready_queue_followup_of_settlement
+      ~lease
+      (Masc.Keeper_registry_event_queue.Requeue
+         Masc.Keeper_registry_event_queue.Context_compaction_retry)
+  in
+  match followup with
+  | Masc.Keeper_heartbeat_loop.Drain_ready_queue { excluding = [ retained ] }
+    when Queue.stimulus_identity_equal source retained ->
+    Alcotest.(check int)
+      "compaction source does not hide unrelated ready work"
+      1
+      (Masc.Keeper_heartbeat_stimulus_intake.ready_stimulus_count
+         ~excluding:[ retained ]
+         (queue [ source; unrelated ]))
+  | _ ->
+    Alcotest.fail
+      "context-compaction retry did not exclude its source and continue lane drain"
+;;
+
 let test_unconsumed_approval_requeues_behind_other_work () =
   List.iter
     (fun reason ->
@@ -1085,6 +1109,10 @@ let () =
             "settlement controls immediate lane drain"
             `Quick
             test_settlement_controls_immediate_lane_drain
+        ; Alcotest.test_case
+            "context compaction retry continues lane drain"
+            `Quick
+            test_context_compaction_retry_continues_lane_drain
         ; Alcotest.test_case
             "unconsumed approval yields FIFO"
             `Quick


### PR DESCRIPTION
## What changed

- map `Requeue Context_compaction_retry` to the existing immediate lane-drain follow-up
- exclude the just-requeued source lease so it cannot monopolize the lane
- add a focused regression proving unrelated ready work remains drainable

## Root cause

`Context_compaction_retry` was introduced as a typed durable settlement, but `ready_queue_followup_of_settlement` did not cover it. A successful compaction-retry settlement could therefore raise `Match_failure` before the Keeper lane selected its next ready item.

## Impact

The compacted source remains durably queued at the FIFO tail while other ready work in the same Keeper lane continues. No retry count, timeout, heuristic, or cross-Keeper coordination is added.

## Verification

- `ocamlformat --inplace` on all three changed OCaml files
- `ocamlc -stop-after parsing` on implementation, interface, and focused test
- `git diff --check`
- 34 changed lines, below the 400-line PR cap
- focused Dune target requested through `scripts/dune-local.sh`, which correctly refused because the existing machine-wide bare `dune build lib/ test/deps/` process (PID 66224) owns the build; full build/test remains CI authority
