### PR TITLE
fix(graphql): preserve typed process failures

### DIFF
--- a/lib/graphql_client.ml
+++ b/lib/graphql_client.ml
@@ -28,6 +28,16 @@ let ensure_json_response body =
   else Ok body
 ;;
 
+let response_of_curl_process_result = function
+  | Unix.WEXITED 0, output -> ensure_json_response output
+  | Unix.WEXITED code, output ->
+    Error (Printf.sprintf "curl exited %d: %s" code output)
+  | Unix.WSIGNALED code, output ->
+    Error (Printf.sprintf "curl signaled %d: %s" code output)
+  | Unix.WSTOPPED code, output ->
+    Error (Printf.sprintf "curl stopped %d: %s" code output)
+;;
+
 (** Write auth header to temp file (keeps token out of argv).  *)
 let with_auth_header_file key f =
   if key = ""
@@ -83,34 +93,30 @@ let request_curl ~timeout_sec body =
         if Process_eio.is_initialized ()
         then (
           try
-            let output =
-              Masc_exec.Exec_gate.run_argv
-                ~actor:(Masc_exec.Agent_id.of_string "system/graphql_client_eio")
-                ~raw_source:(String.concat " " (List.map Filename.quote argv))
-                ~summary:"graphql curl fallback"
-                ~timeout_sec
-                argv
-            in
-            ensure_json_response output
-          with
-          | Eio.Cancel.Cancelled _ as e -> raise e
-          | exn -> Error (Printf.sprintf "curl: %s" (Printexc.to_string exn)))
-        else (
-          (* Unix fallback when Eio loop not started *)
-          try
-            match
+            let process_result =
               Masc_exec.Exec_gate.run_argv_with_status
                 ~actor:(Masc_exec.Agent_id.of_string "system/graphql_client_eio")
                 ~raw_source:(String.concat " " (List.map Filename.quote argv))
                 ~summary:"graphql curl fallback"
                 ~timeout_sec
                 argv
-            with
-            | Unix.WEXITED 0, output -> ensure_json_response output
-            | Unix.WEXITED code, output ->
-              Error (Printf.sprintf "curl exited %d: %s" code output)
-            | Unix.WSIGNALED code, _ -> Error (Printf.sprintf "curl signaled: %d" code)
-            | Unix.WSTOPPED code, _ -> Error (Printf.sprintf "curl stopped: %d" code)
+            in
+            response_of_curl_process_result process_result
+          with
+          | Eio.Cancel.Cancelled _ as e -> raise e
+          | exn -> Error (Printf.sprintf "curl: %s" (Printexc.to_string exn)))
+        else (
+          (* Unix fallback when Eio loop not started *)
+          try
+            let process_result =
+              Masc_exec.Exec_gate.run_argv_with_status
+                ~actor:(Masc_exec.Agent_id.of_string "system/graphql_client_eio")
+                ~raw_source:(String.concat " " (List.map Filename.quote argv))
+                ~summary:"graphql curl fallback"
+                ~timeout_sec
+                argv
+            in
+            response_of_curl_process_result process_result
           with
           | Eio.Cancel.Cancelled _ as e -> raise e
           | exn -> Error (Printexc.to_string exn))))
@@ -195,6 +201,7 @@ let request ?(timeout_sec = 10.0) ?(fallback = true) body : (string, string) res
 
 module For_testing = struct
   let is_transport_error = is_transport_error
+  let response_of_curl_process_result = response_of_curl_process_result
 end
 
 (** {1 GraphQL Response Parsing} *)

--- a/lib/graphql_client.mli
+++ b/lib/graphql_client.mli
@@ -10,6 +10,10 @@ val request : ?timeout_sec:float -> ?fallback:bool -> string -> (string, string)
 
 module For_testing : sig
   val is_transport_error : string -> bool
+
+  val response_of_curl_process_result
+    :  Unix.process_status * string
+    -> (string, string) result
 end
 
 (** {1 GraphQL Response Parsing} *)

--- a/test/test_oas_empty_response_diagnostic.ml
+++ b/test/test_oas_empty_response_diagnostic.ml
@@ -51,6 +51,67 @@ let test_http_status_is_not_transport_error () =
     (Graphql_client.For_testing.is_transport_error "HTTP 500")
 ;;
 
+let test_curl_success_preserves_json_body () =
+  let body = "{\"data\":{\"status\":\"ok\"}}" in
+  let actual =
+    Graphql_client.For_testing.response_of_curl_process_result
+      (Unix.WEXITED 0, body)
+  in
+  check (result string string) "successful body" (Ok body) actual
+;;
+
+let test_curl_timeout_is_not_a_response_body () =
+  let diagnostic = "process_eio_error: timeout after 10s" in
+  let actual =
+    Graphql_client.For_testing.response_of_curl_process_result
+      (Unix.WEXITED 124, diagnostic)
+  in
+  check
+    (result string string)
+    "typed timeout status"
+    (Error ("curl exited 124: " ^ diagnostic))
+    actual
+;;
+
+let test_curl_exit_failure_is_not_a_response_body () =
+  let output = "{\"data\":{\"stale\":true}}" in
+  let actual =
+    Graphql_client.For_testing.response_of_curl_process_result
+      (Unix.WEXITED 7, output)
+  in
+  check
+    (result string string)
+    "typed nonzero exit"
+    (Error ("curl exited 7: " ^ output))
+    actual
+;;
+
+let test_curl_signal_failure_preserves_diagnostic () =
+  let diagnostic = "curl: connection reset during shutdown" in
+  let actual =
+    Graphql_client.For_testing.response_of_curl_process_result
+      (Unix.WSIGNALED 15, diagnostic)
+  in
+  check
+    (result string string)
+    "typed signal status"
+    (Error ("curl signaled 15: " ^ diagnostic))
+    actual
+;;
+
+let test_curl_stopped_failure_preserves_diagnostic () =
+  let diagnostic = "curl: process stopped" in
+  let actual =
+    Graphql_client.For_testing.response_of_curl_process_result
+      (Unix.WSTOPPED 19, diagnostic)
+  in
+  check
+    (result string string)
+    "typed stopped status"
+    (Error ("curl stopped 19: " ^ diagnostic))
+    actual
+;;
+
 let () =
   run
     "OAS_empty_response_diagnostic"
@@ -64,6 +125,15 @@ let () =
     ; ( "transport_error"
       , [ test_case "switch wrong-domain" `Quick test_switch_wrong_domain_is_transport_error
         ; test_case "http status" `Quick test_http_status_is_not_transport_error
+        ] )
+    ; ( "curl_process_result"
+      , [ test_case "success preserves JSON" `Quick test_curl_success_preserves_json_body
+        ; test_case "timeout is failure" `Quick test_curl_timeout_is_not_a_response_body
+        ; test_case "nonzero exit is failure" `Quick test_curl_exit_failure_is_not_a_response_body
+        ; test_case "signal preserves diagnostic" `Quick
+            test_curl_signal_failure_preserves_diagnostic
+        ; test_case "stopped preserves diagnostic" `Quick
+            test_curl_stopped_failure_preserves_diagnostic
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- execute GraphQL curl fallback through the typed process-status API
- accept only `WEXITED 0` as a response body
- preserve timeout, exit, signal, and stopped diagnostics as explicit errors

## Verification
- `ocamlformat --check` on changed OCaml files
- `ocamlc -stop-after parsing` on changed OCaml files
- `git diff --check`
- focused Dune deferred to CI because the shared bare Dune build owns the local lock

## Review
- adversarial review: P0/P1 = 0
- P2 diagnostic-loss finding addressed before publication