### PR TITLE
fix(supervisor): record real exit codes and attribute takeover kills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- The process supervisor now records the real server exit code: `|| true` before `exit_code=$?` reported every exit — including SIGSEGV (139) and SIGTERM (143) — as `code=0`; exits above 128 additionally decode the signal name. Takeover kills now leave a JSON breadcrumb next to the pid lock, the victim's SIGTERM path logs the attribution (or its absence: external sender), and the next boot reports a breadcrumb after a SIGKILL escalation.
+
 ### Removed
 - Removed automatic config-root, cwd-parent, executable-parent, and `MASC_MODEL_CATALOG` full-catalog discovery. OAS's embedded catalog is now the only base; `oas-models-overlay.toml` carries deployment-local rows, while `OAS_MODEL_CATALOG` remains an explicit operator override.
 - Removed the generic Governance pipeline, risk taxonomy, unconditional deny/operator floors, command/tool-name authorization heuristics, global resource admission blockers, and failure-derived Keeper pauses. External effects now converge on exact Always Allowed, configured LLM Auto Judge, or nonblocking HITL; objective typed input/path/sandbox invariants remain at execution boundaries.

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -603,6 +603,27 @@ let run_cmd host port cli_base_path =
   let _base_path_lease = acquire_base_path_lock ~run_dir canonical_base_path in
   acquire_pid_lock port;
   Log.init_from_env ();
+  (* Report a fresh takeover breadcrumb at boot: after a SIGKILL escalation
+     the victim could not log, so this is the only place the kill becomes
+     visible. Skip the breadcrumb this process wrote itself while reclaiming
+     the lock (the killer already logged its own WARN). *)
+  (match
+     Server_startup_takeover.read_takeover_breadcrumb
+       ~lock_path:(Server_startup_takeover.pid_lock_path port)
+       ()
+   with
+   | Server_startup_takeover.Breadcrumb_found { killer_pid = Some killer; _ }
+     when killer = Unix.getpid () -> ()
+   | Server_startup_takeover.Breadcrumb_found { breadcrumb_path; age_sec; payload; _ }
+     ->
+     Log.Server.warn
+       "[Startup] takeover breadcrumb found (%.0fs old, %s) — previous instance was killed by a takeover: %s"
+       age_sec breadcrumb_path payload
+   | Server_startup_takeover.Breadcrumb_stale _ | Server_startup_takeover.Breadcrumb_absent
+     -> ()
+   | Server_startup_takeover.Breadcrumb_unreadable { breadcrumb_path; reason } ->
+     Log.Server.warn "[Startup] takeover breadcrumb unreadable at %s: %s"
+       breadcrumb_path reason);
   let shutdown_cfg =
     match Masc.Shutdown.config_from_env_result () with
     | Ok config -> config
@@ -702,6 +723,31 @@ let run_cmd host port cli_base_path =
             Log.Server.info
               "[MASC] Received %s, shutting down gracefully (timeout=%.0fs, hard_exit=%d)..."
               signal_name force_timeout Masc.Shutdown.process_deadline_exit_code;
+            (* Signal-sender attribution for the restart-cycle investigation:
+               a takeover killer writes a breadcrumb next to the pid lock
+               right before signalling; its absence means the sender is
+               external (user, pkill, system). *)
+            (match
+               Server_startup_takeover.read_takeover_breadcrumb
+                 ~lock_path:(Server_startup_takeover.pid_lock_path port)
+                 ()
+             with
+             | Server_startup_takeover.Breadcrumb_found { age_sec; payload; _ } ->
+               Log.Server.info
+                 "[Shutdown] signal attribution: takeover breadcrumb (%.1fs old): %s"
+                 age_sec payload
+             | Server_startup_takeover.Breadcrumb_stale { age_sec; _ } ->
+               Log.Server.info
+                 "[Shutdown] signal attribution: no fresh takeover breadcrumb (stale one is %.0fs old) — sender is external (user/pkill/system)"
+                 age_sec
+             | Server_startup_takeover.Breadcrumb_absent ->
+               Log.Server.info
+                 "[Shutdown] signal attribution: no takeover breadcrumb — sender is external (user/pkill/system)"
+             | Server_startup_takeover.Breadcrumb_unreadable { breadcrumb_path; reason }
+               ->
+               Log.Server.warn
+                 "[Shutdown] signal attribution: breadcrumb unreadable at %s: %s"
+                 breadcrumb_path reason);
             (* Phase 1: Notify SSE clients *)
             let t_phase = Unix.gettimeofday () in
             let shutdown_data =

--- a/lib/server/server_startup_takeover.ml
+++ b/lib/server/server_startup_takeover.ml
@@ -405,6 +405,114 @@ let claim_pid_file path =
   Acquired
 ;;
 
+(* ── Takeover forensics breadcrumb ──────────────────────────────────────
+   When this process signals an unresponsive incumbent to reclaim the pid
+   lock, only the killer's stderr records the decision; the victim's log ends
+   with a bare "Received SIGTERM" and the operator cannot distinguish an
+   intentional takeover from an external kill (user, pkill, system). The
+   killer therefore writes a JSON breadcrumb next to the pid lock immediately
+   before signalling. The victim reads it in its SIGTERM path, and the next
+   boot reports it after a SIGKILL escalation (a SIGKILLed victim cannot
+   log). A write failure is reported to stderr and never blocks lock
+   acquisition. *)
+
+let takeover_breadcrumb_path ~lock_path = lock_path ^ ".takeover-kill.json"
+
+let write_takeover_breadcrumb ~lock_path ~port ~target_pid ~signal_name =
+  let path = takeover_breadcrumb_path ~lock_path in
+  let payload =
+    `Assoc
+      [ (* NDT-OK: forensic evidence records the killer's identity and
+           wall-clock; no deterministic logic branches on these fields. *)
+        "killer_pid", `Int (Unix.getpid ())
+      ; "killer_argv", `String (String.concat " " (Array.to_list Sys.argv))
+      ; "target_pid", `Int target_pid
+      ; "port", `Int port
+      ; "signal", `String signal_name
+      ; "reason", `String "pid_alive_but_liveness_probe_failed"
+      ; (* NDT-OK: forensic wall-clock evidence, never branched on. *)
+        "written_at_epoch", `Float (Unix.gettimeofday ())
+      ]
+  in
+  match open_out path with
+  | oc ->
+    Eio_guard.protect
+      ~finally:(fun () -> close_out_noerr oc)
+      (fun () -> output_string oc (Yojson.Safe.to_string payload))
+  | exception Sys_error reason ->
+    Log.legacy_stderr
+      ~level:Log.Warn
+      ~module_name:"Server"
+      (Printf.sprintf "[WARN] takeover breadcrumb write failed at %s: %s" path reason)
+;;
+
+type takeover_breadcrumb =
+  { breadcrumb_path : string
+  ; age_sec : float
+  ; killer_pid : int option
+  ; payload : string
+  }
+
+type takeover_breadcrumb_read =
+  | Breadcrumb_found of takeover_breadcrumb
+  | Breadcrumb_stale of
+      { breadcrumb_path : string
+      ; age_sec : float
+      }
+  | Breadcrumb_absent
+  | Breadcrumb_unreadable of
+      { breadcrumb_path : string
+      ; reason : string
+      }
+
+(* Freshness bound for attributing a shutdown to a takeover breadcrumb.
+   Covers the supervisor restart cooldown (5 s) plus a slow boot with wide
+   margin; anything older describes a previous incident, not this signal. *)
+let takeover_breadcrumb_max_age_sec = 600.0
+
+let read_takeover_breadcrumb
+      ?(max_age_sec = takeover_breadcrumb_max_age_sec)
+      ~lock_path
+      ()
+  =
+  let path = takeover_breadcrumb_path ~lock_path in
+  match Unix.stat path with
+  | exception Unix.Unix_error (Unix.ENOENT, _, _) -> Breadcrumb_absent
+  | exception Unix.Unix_error (code, _, _) ->
+    Breadcrumb_unreadable { breadcrumb_path = path; reason = Unix.error_message code }
+  | st ->
+    (* Freshness answers "could this breadcrumb explain the signal just
+       received" — inherently a wall-clock question. *)
+    let age_sec = (* NDT-OK: forensic freshness, no replay determinism. *)
+      Unix.gettimeofday () -. st.Unix.st_mtime
+    in
+    if age_sec > max_age_sec
+    then Breadcrumb_stale { breadcrumb_path = path; age_sec }
+    else (
+      match Fs_compat.load_file path with
+      | payload ->
+        (* [killer_pid] is best-effort structure over the verbatim payload:
+           the raw JSON is always preserved and logged by callers, so a parse
+           miss degrades self-filtering, not evidence. *)
+        let killer_pid =
+          match Yojson.Safe.from_string payload with
+          | `Assoc fields ->
+            (match List.assoc_opt "killer_pid" fields with
+             | Some (`Int pid) -> Some pid
+             | _ -> None)
+          | _ -> None
+          | exception Yojson.Json_error _ -> None
+        in
+        Breadcrumb_found { breadcrumb_path = path; age_sec; killer_pid; payload }
+      | exception Sys_error reason ->
+        Breadcrumb_unreadable { breadcrumb_path = path; reason }
+      | exception End_of_file ->
+        (* [Fs_compat.load_file] sizes then reads the file; a concurrent
+           truncation between the two surfaces as [End_of_file]. *)
+        Breadcrumb_unreadable
+          { breadcrumb_path = path; reason = "truncated while reading" })
+;;
+
 let acquire_pid_lock
       ?lock_path
       ?(probe_timeout_sec = 3.0)
@@ -448,6 +556,11 @@ let acquire_pid_lock
                   reclaim"
                  pid
                  port);
+            write_takeover_breadcrumb
+              ~lock_path:path
+              ~port
+              ~target_pid:pid
+              ~signal_name:"SIGTERM";
             Safe_ops.protect ~default:() (fun () -> Unix.kill pid Sys.sigterm);
             if
               not (wait_for_pid_exit ~poll_interval_sec ~timeout_sec:term_timeout_sec pid)
@@ -456,6 +569,11 @@ let acquire_pid_lock
                 ~level:Log.Warn
                 ~module_name:"Server"
                 (Printf.sprintf "[WARN] PID %d did not exit; sending SIGKILL" pid);
+              write_takeover_breadcrumb
+                ~lock_path:path
+                ~port
+                ~target_pid:pid
+                ~signal_name:"SIGKILL";
               Safe_ops.protect ~default:() (fun () -> Unix.kill pid Sys.sigkill);
               if not (wait_for_pid_exit ~poll_interval_sec ~timeout_sec:kill_wait_sec pid)
               then

--- a/lib/server/server_startup_takeover.mli
+++ b/lib/server/server_startup_takeover.mli
@@ -111,6 +111,48 @@ val acquire_pid_lock :
   int ->
   acquire_result
 
+(** Path of the takeover forensics breadcrumb derived from [lock_path]
+    (the pid-lock file the takeover contends on). *)
+val takeover_breadcrumb_path : lock_path:string -> string
+
+(** Written by the killer immediately before signalling an unresponsive
+    incumbent during [acquire_pid_lock], so the victim's SIGTERM path (or the
+    next boot, after a SIGKILL escalation) can attribute the shutdown to this
+    takeover instead of an unknown external sender. Best-effort: a write
+    failure logs a warning and never blocks lock acquisition. *)
+val write_takeover_breadcrumb :
+  lock_path:string -> port:int -> target_pid:int -> signal_name:string -> unit
+
+type takeover_breadcrumb =
+  { breadcrumb_path : string
+  ; age_sec : float
+  ; killer_pid : int option
+      (** Parsed from the payload for self-filtering at boot; [None] when the
+          payload is not the expected JSON shape. The raw [payload] is always
+          preserved for logging. *)
+  ; payload : string
+  }
+
+type takeover_breadcrumb_read =
+  | Breadcrumb_found of takeover_breadcrumb
+  | Breadcrumb_stale of
+      { breadcrumb_path : string
+      ; age_sec : float
+      }
+  | Breadcrumb_absent
+  | Breadcrumb_unreadable of
+      { breadcrumb_path : string
+      ; reason : string
+      }
+
+(** Reads the breadcrumb next to [lock_path]. [max_age_sec] (default 600 s,
+    covering the supervisor restart cooldown plus a slow boot) bounds how old
+    a breadcrumb may be to still explain the current signal; older files are
+    reported as [Breadcrumb_stale] so a previous incident is never mistaken
+    for the present one. *)
+val read_takeover_breadcrumb :
+  ?max_age_sec:float -> lock_path:string -> unit -> takeover_breadcrumb_read
+
 (** Acquire the process-lifetime owner lease below a current-UID-owned [0700]
     private directory in the explicitly supplied host run root, then establish
     and validate [<base_path>/.masc]. A group- or world-writable [run_dir] is

--- a/scripts/start-masc-supervised.sh
+++ b/scripts/start-masc-supervised.sh
@@ -66,12 +66,23 @@ while true; do
   log "starting masc"
   start_epoch=$(date +%s)
 
-  "$REPO_ROOT/start-masc.sh" "$@" || true
+  # No `set -e` is active, so a failing start-masc.sh does not abort this
+  # loop; `|| true` here would make `$?` observe `true` and record every
+  # exit — including SIGSEGV (139) and SIGTERM (143) — as code=0.
+  "$REPO_ROOT/start-masc.sh" "$@"
   exit_code=$?
   end_epoch=$(date +%s)
   uptime_s=$((end_epoch - start_epoch))
 
-  log "masc exited code=$exit_code uptime=${uptime_s}s"
+  exit_detail=""
+  if [ "$exit_code" -gt 128 ]; then
+    signal_name=$(kill -l $((exit_code - 128)) 2>/dev/null || true)
+    if [ -n "$signal_name" ]; then
+      exit_detail=" signal=SIG${signal_name}"
+    fi
+  fi
+
+  log "masc exited code=${exit_code}${exit_detail} uptime=${uptime_s}s"
 
   # Trim restart_timestamps to the sliding window.
   cutoff=$((end_epoch - WINDOW_SEC))

--- a/test/test_server_startup_takeover.ml
+++ b/test/test_server_startup_takeover.ml
@@ -266,6 +266,67 @@ let test_escalates_sigkill_for_unresponsive_holder () =
           | Server_startup_takeover.Already_running _ ->
               Alcotest.fail "unresponsive holder should be reclaimed"))
 
+let test_breadcrumb_round_trip_and_freshness () =
+  with_temp_dir "startup-takeover-breadcrumb" (fun dir ->
+      let path = lock_path dir in
+      (match Server_startup_takeover.read_takeover_breadcrumb ~lock_path:path () with
+       | Server_startup_takeover.Breadcrumb_absent -> ()
+       | _ -> Alcotest.fail "expected no breadcrumb before any takeover");
+      Server_startup_takeover.write_takeover_breadcrumb ~lock_path:path ~port:8935
+        ~target_pid:4242 ~signal_name:"SIGTERM";
+      (match Server_startup_takeover.read_takeover_breadcrumb ~lock_path:path () with
+       | Server_startup_takeover.Breadcrumb_found { killer_pid; payload; age_sec; _ }
+         ->
+           Alcotest.(check (option int)) "killer pid is self"
+             (Some (Unix.getpid ())) killer_pid;
+           Alcotest.(check bool) "fresh" true (age_sec < 60.0);
+           Alcotest.(check bool) "payload names target and signal" true
+             (match Yojson.Safe.from_string payload with
+              | `Assoc fields ->
+                  List.assoc_opt "target_pid" fields = Some (`Int 4242)
+                  && List.assoc_opt "signal" fields = Some (`String "SIGTERM")
+              | _ -> false)
+       | _ -> Alcotest.fail "expected a fresh breadcrumb after write");
+      let breadcrumb_path =
+        Server_startup_takeover.takeover_breadcrumb_path ~lock_path:path
+      in
+      let past = Unix.gettimeofday () -. 3600.0 in
+      Unix.utimes breadcrumb_path past past;
+      match Server_startup_takeover.read_takeover_breadcrumb ~lock_path:path () with
+      | Server_startup_takeover.Breadcrumb_stale { age_sec; _ } ->
+          Alcotest.(check bool) "stale age reported" true (age_sec > 600.0)
+      | _ -> Alcotest.fail "expected an hour-old breadcrumb to be stale")
+
+let test_breadcrumb_written_when_takeover_kills () =
+  with_temp_dir "startup-takeover-breadcrumb-kill" (fun dir ->
+      with_forever_process ~argv0:"main_eio.exe" ~ignore_sigterm:true (fun pid ->
+          let path = lock_path dir in
+          write_file path (Printf.sprintf "%d\n" pid);
+          let port = find_free_port () in
+          match
+            Server_startup_takeover.acquire_pid_lock ~lock_path:path
+              ~probe_timeout_sec:0.1 ~term_timeout_sec:0.05 ~kill_wait_sec:0.2
+              ~poll_interval_sec:0.01 port
+          with
+          | Server_startup_takeover.Acquired -> (
+              match
+                Server_startup_takeover.read_takeover_breadcrumb ~lock_path:path ()
+              with
+              | Server_startup_takeover.Breadcrumb_found { killer_pid; payload; _ }
+                ->
+                  Alcotest.(check (option int)) "killer pid is self"
+                    (Some (Unix.getpid ())) killer_pid;
+                  Alcotest.(check bool)
+                    "escalation recorded SIGKILL against the holder" true
+                    (match Yojson.Safe.from_string payload with
+                     | `Assoc fields ->
+                         List.assoc_opt "signal" fields = Some (`String "SIGKILL")
+                         && List.assoc_opt "target_pid" fields = Some (`Int pid)
+                     | _ -> false)
+              | _ -> Alcotest.fail "takeover kill must leave a breadcrumb")
+          | Server_startup_takeover.Already_running _ ->
+              Alcotest.fail "unresponsive holder should be reclaimed"))
+
 let test_base_path_lock_rejects_concurrent_lease () =
   with_base_and_run "startup-takeover-base-path-live"
     (fun ~base_path ~run_dir ->
@@ -1068,6 +1129,10 @@ let () =
             test_tolerates_invalid_pid_file;
           Alcotest.test_case "unresponsive holder escalates to sigkill" `Quick
             test_escalates_sigkill_for_unresponsive_holder;
+          Alcotest.test_case "breadcrumb round-trips and ages out" `Quick
+            test_breadcrumb_round_trip_and_freshness;
+          Alcotest.test_case "takeover kill leaves a breadcrumb" `Quick
+            test_breadcrumb_written_when_takeover_kills;
           Alcotest.test_case "concurrent BasePath lease blocks takeover" `Quick
             test_base_path_lock_rejects_concurrent_lease;
           Alcotest.test_case "stale base-path owner is reclaimed" `Quick


### PR DESCRIPTION
## 요약

2026-07-15 성능 붕괴 조사(전체 진단: `~/me/reports/masc-perf-rootcause-20260716.md`)에서 확인된 관측 결함 2건을 수리합니다. 재시작 사이클(당일 5회: 외부 SIGTERM 4 + sqlite GC finalizer SIGSEGV 1)의 원인 계측이 다른 P0 수리들의 효과 측정 전제입니다.

### 1. supervisor가 exit code를 항상 0으로 기록

`scripts/start-masc-supervised.sh`가 `start-masc.sh "$@" || true` 다음 줄에서 `exit_code=$?`를 읽어 — `$?`는 `true`의 종료값 — **SIGSEGV(139)·SIGTERM(143)을 포함한 모든 종료가 `code=0`으로 기록**되었습니다. 실증: 07-15 23:32 SIGSEGV 크래시(macOS DiagnosticReports `main_eio.exe-2026-07-15-233214.ips`)가 supervisor 로그에는 `code=0 uptime=432s`로 남음. 스크립트에 `set -e`가 없어 `|| true`는 애초에 불필요했습니다. 128 초과 종료코드는 시그널명(`signal=SIGTERM` 등)도 함께 기록합니다.

### 2. SIGTERM 발신자 무귀속

victim 로그는 `Received SIGTERM`으로 끝나 의도된 takeover(`acquire_pid_lock`의 unresponsive-incumbent reclaim)와 외부 kill(사용자/pkill/시스템)을 구분할 수 없었습니다. 수리:

- **killer 자백**: `acquire_pid_lock`이 SIGTERM/SIGKILL 직전에 pid lock 옆 `<lock>.takeover-kill.json`에 killer pid/argv/대상/시그널/사유/시각 기록 (best-effort, 실패 시 WARN — lock 획득을 막지 않음)
- **victim 귀속 로그**: SIGTERM 수신 시 신선한(≤600s) breadcrumb을 읽어 로그, 없으면 `sender is external` 명시
- **부팅 귀속 로그**: SIGKILL 에스컬레이션으로 죽은 victim은 로그 불가 → 다음 부팅이 breadcrumb을 보고 (자기 자신이 쓴 것은 killer_pid로 필터)

## 변경 파일

- `scripts/start-masc-supervised.sh` — exit code 캡처 수리 + 시그널 디코드
- `lib/server/server_startup_takeover.ml`/`.mli` — breadcrumb writer/reader (`takeover_breadcrumb_read` closed sum: Found/Stale/Absent/Unreadable, silent failure 없음)
- `bin/main_eio.ml` — 종료/부팅 귀속 로그
- `test/test_server_startup_takeover.ml` — round-trip+신선도 판정 테스트, 실제 takeover kill 경로의 breadcrumb 증명 테스트
- `CHANGELOG.md`

## 검증

- `bash -n scripts/start-masc-supervised.sh` 통과
- `Fs_compat.load_file` 예외 계약 확인(`with_io`가 `Eio.Io`→`Sys_error` 번역, `End_of_file` truncation 분기도 명시 처리)
- 로컬 dune 미실행 (repo 방침: CI 빌드) — Build and Test에는 알려진 base-red(catalog harness, #24647 트랙)가 있어 컴파일 성공 여부는 "서버 runtime init 도달" 기준으로 판별 필요

## 미검증 / 후속

- SIGTERM 발신자의 실제 확정은 이 계측이 배포된 뒤 다음 재시작 사건에서 로그로 판별 (takeover 가설 vs 외부 발신)
- sqlite stmt lifecycle SIGSEGV(P0-2), 2s 스냅샷 루프(P0-4)는 별도 PR

RFC-WAIVED: 관측/포렌식 결함 수리로 아키텍처 변경 없음 (credential/identity/repo/operator/sandbox 무관)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)
