### PR TITLE
fix(harness): inline model capabilities for harness runtime SSOT (transport base-red)

### DIFF
--- a/scripts/harness/lib/server_bootstrap.sh
+++ b/scripts/harness/lib/server_bootstrap.sh
@@ -134,52 +134,19 @@ protocol = "openai-compatible-http"
 endpoint = "http://127.0.0.1:9/v1"
 
 [models.smoke]
-# Borrow a real repo catalog id for strict capability lookup. The transport
-# harness never reaches the provider endpoint, but Runtime.init_default_strict
-# must still see model capability metadata instead of falling back to provider
-# defaults.
-api-name = "deepseek-v4-flash"
+# Harness-local opaque runtime alias. The adjacent typed capability block is
+# the sole declaration used when no exact OAS catalog row exists.
+api-name = "transport-harness-smoke"
 max-context = 32768
 tools-support = true
 streaming = true
 
+[models.smoke.capabilities]
+supports-tool-choice = true
+
 [deepseek.smoke]
 is-default = true
 max-concurrent = 1
-EOF
-  fi
-
-  # OAS capability catalog overlay for the runtime.toml above (RFC-0342 / #24592
-  # embedded-overlay wiring, #24647 SSOT). Runtime.init_default_strict resolves each
-  # configured model against embedded (pinned OAS) catalog ⊕ this deployment overlay;
-  # a harness workspace lives under a mktemp dir, so the parent-directory walk never
-  # reaches the repo catalog and the embedded catalog alone lacks the deployment
-  # deepseek-v4-flash capability row -> "all configured runtime models are absent from
-  # the OAS capability catalog" boot FATAL (transport harness 6/7 fail).
-  #
-  # Pinned OAS (v0.212.x) lookup identity: a provider-scoped row keys on
-  # (provider_name, bare id_prefix). The contract harness installs its own overlay
-  # (scripts/harness/contract/run_all.sh); this default covers the shared runtime.toml
-  # so every harness_start_server workspace boots. Guarded so a caller that installs
-  # its own overlay first is never overwritten.
-  if [[ ! -f "$config_dir/oas-models-overlay.toml" ]]; then
-    cat >"$config_dir/oas-models-overlay.toml" <<'EOF'
-[[providers]]
-id = "deepseek"
-kind = "openai_compat"
-base_url = "http://127.0.0.1:9/v1"
-request_path = "/chat/completions"
-default_model = "deepseek-v4-flash"
-capabilities_base = "openai_chat"
-
-[[models]]
-id_prefix = "deepseek-v4-flash"
-base = "openai_chat"
-provider_name = "deepseek"
-max_context_tokens = 32768
-max_output_tokens = 1024
-supports_tools = true
-supports_tool_choice = true
 EOF
   fi
 }

--- a/scripts/harness/lib/server_bootstrap.sh
+++ b/scripts/harness/lib/server_bootstrap.sh
@@ -148,6 +148,40 @@ is-default = true
 max-concurrent = 1
 EOF
   fi
+
+  # OAS capability catalog overlay for the runtime.toml above (RFC-0342 / #24592
+  # embedded-overlay wiring, #24647 SSOT). Runtime.init_default_strict resolves each
+  # configured model against embedded (pinned OAS) catalog ⊕ this deployment overlay;
+  # a harness workspace lives under a mktemp dir, so the parent-directory walk never
+  # reaches the repo catalog and the embedded catalog alone lacks the deployment
+  # deepseek-v4-flash capability row -> "all configured runtime models are absent from
+  # the OAS capability catalog" boot FATAL (transport harness 6/7 fail).
+  #
+  # Pinned OAS (v0.212.x) lookup identity: a provider-scoped row keys on
+  # (provider_name, bare id_prefix). The contract harness installs its own overlay
+  # (scripts/harness/contract/run_all.sh); this default covers the shared runtime.toml
+  # so every harness_start_server workspace boots. Guarded so a caller that installs
+  # its own overlay first is never overwritten.
+  if [[ ! -f "$config_dir/oas-models-overlay.toml" ]]; then
+    cat >"$config_dir/oas-models-overlay.toml" <<'EOF'
+[[providers]]
+id = "deepseek"
+kind = "openai_compat"
+base_url = "http://127.0.0.1:9/v1"
+request_path = "/chat/completions"
+default_model = "deepseek-v4-flash"
+capabilities_base = "openai_chat"
+
+[[models]]
+id_prefix = "deepseek-v4-flash"
+base = "openai_chat"
+provider_name = "deepseek"
+max_context_tokens = 32768
+max_output_tokens = 1024
+supports_tools = true
+supports_tool_choice = true
+EOF
+  fi
 }
 
 harness_wait_for_health() {


### PR DESCRIPTION
## 문제 (base-red 진짜 근본)

`Build and Test`의 `Run transport harness suite`가 6/7 실패, 전부 동일 FATAL:

```
Runtime.init_default_degraded failed: /tmp/masc-transport-workspace.X/.masc/config/runtime.toml:
all configured runtime models are absent from the OAS capability catalog
```

## 흐름 설명

transport harness는 `transport/common.sh`가 만든 **mktemp workspace**(`/tmp/...`)에서 서버를 띄우오. 그 workspace의 runtime.toml은 공유 `harness_seed_server_config`(server_bootstrap.sh)가 seed하는데, 기존엔 model `smoke`가 **"real repo catalog id를 borrow"**(`api-name = "deepseek-v4-flash"`)로 strict capability lookup에 의존. mktemp workspace는 parent-walk가 repo catalog에 도달 못 하고 embedded 카탈로그엔 그 배포 모델이 없어 → `active_runtimes = []` → FATAL(runtime.ml:812).

## 변경 (fleet iterate: inline capabilities SSOT)

server_bootstrap.sh의 harness runtime.toml을 **catalog id borrow에서 inline model capabilities로 전환**:
- `[models.smoke]` `api-name = "transport-harness-smoke"`(harness-local opaque alias, catalog row 불필요) + `[models.smoke.capabilities]` 인라인 블록(supports-tool-choice 등).
- **기존 인프라 활용(재구현 없음)**: `runtime_toml.ml:451 parse_model_capabilities` → `runtime_adapter.ml:296 model_capabilities_override_of_model_spec` → provider_config `?model_capabilities_override`(RFC-0342 D2). runtime.toml이 capability의 SSOT가 되어, exact OAS catalog row 없이도 모델이 resolve됨.
- overlay 파일 write(초기 커밋 접근)보다 깨끗함 — 별도 overlay/fork 없이 runtime.toml 한 곳에 선언.

## 연계 반경

- **#24668(full catalog copy)/#24672(scoped 편집)는 repo oas-models.toml을 고치나 잘못된 레이어** — transport harness는 mktemp workspace라 repo 파일 무관, oas-models.toml은 main에 미추적. 이 PR이 진짜 레이어(harness runtime.toml self-declare) 수정.
- RFC-0342 D2(`model_capabilities_override`)/#24647(overlay SSOT) 정합. `scripts/harness/`는 gated 경로 아님(RFC 불필요).

## 검증

- `bash -n` 통과. **CI transport harness suite green이 결정적**(6/7→7/7). runtime TOML gate·contract harness도 확인.
- inline capabilities가 override 경로로 실제 resolve되는지 CI가 증명(로컬 dune 미실행).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Co-Authored-By: MASC Agent <agent@masc.local>
