### PR TITLE
fix(auth): reject malformed dashboard credentials

### DIFF
--- a/lib/auth/auth_error_kind.ml
+++ b/lib/auth/auth_error_kind.ml
@@ -64,11 +64,9 @@ let all =
   ]
 
 (* ----- Dashboard actor fallback typed surface ------------------------ *)
-(* See .mli for rationale. The two warn-message templates below are
-   byte-equivalent to the prior inline format strings in
-   [lib/server/server_auth.ml:298-302] (Outcome_none) and
-   [lib/server/server_auth.ml:340-344] (Outcome_error). The
-   token_mismatch remediation tail is reproduced verbatim because
+(* See .mli for rationale. The historical event key remains stable for
+   operational continuity, while the message now states that the actor hint
+   was rejected. The token_mismatch remediation tail is reproduced verbatim because
    operators key alerts on the literal "Remediation:" substring
    (server_auth.ml:332-339 inline rationale). *)
 
@@ -88,14 +86,12 @@ type dashboard_actor_fallback =
 let dashboard_actor_fallback_log_message fb =
   match fb.outcome with
   | Outcome_none ->
-      (* Byte-equivalent to the prior inline Printf format. The continuation
-         lines were OCaml string-literal continuations (backslash-newline +
-         leading whitespace), which the compiler concatenates into a single
-         space-joined sentence — preserved here without leading whitespace. *)
+      (* Keep the historical event prefix while stating the fail-closed
+         disposition explicitly. *)
       Printf.sprintf
         "[silent:dashboard_actor_fallback] outcome=none token_hash_prefix=%s \
-         \xe2\x80\x94 bearer token resolved to no agent, falling back to \
-         request actor hint"
+         \xe2\x80\x94 bearer token resolved to no agent; request actor hint \
+         ignored"
         fb.token_hash_prefix
   | Outcome_error { err; err_kind; actor_hint } ->
       let err_str = Masc_domain.masc_error_to_string err in
@@ -123,7 +119,7 @@ let dashboard_actor_fallback_log_message fb =
       Printf.sprintf
         "[silent:dashboard_actor_fallback] outcome=error \
          token_hash_prefix=%s err_kind=%s actor_hint=%s err=%s \xe2\x80\x94 \
-         falling back to request actor hint.%s"
+         request actor hint ignored.%s"
         fb.token_hash_prefix err_kind_label hint err_str extra_hint
 
 let dashboard_actor_fallback_metric_labels fb =

--- a/lib/auth/auth_error_kind.mli
+++ b/lib/auth/auth_error_kind.mli
@@ -31,7 +31,7 @@ val all : t list
 (** {1 Dashboard actor fallback typed surface}
 
     The dashboard actor resolution path in [lib/server/server_auth.ml]
-    falls back to the request-actor hint when the bearer token cannot be
+    rejects the request-actor hint when the bearer token cannot be
     mapped to a credential. Two structurally distinct failure modes share
     a single counter ([metric_silent_dashboard_actor_fallback]):
 
@@ -46,10 +46,9 @@ val all : t list
     sites with hardcoded format strings, so callers had no typed handle
     on *why* the fallback fired — a counter is not a fix
     (see CLAUDE.md §Workaround Rejection Bar §1 Counter-as-Fix). The
-    fallback path itself is preserved as a production safety net
-    (dashboard cannot go dark on token churn); this surface adds the
-    typed kind that downstream reducers need without removing the
-    safety net.
+    public reads remain available on token churn, but rejected credentials
+    project to the unparameterized namespace instead of adopting the request
+    hint. This surface provides the typed rejection reason.
 
     Reference: ~/Downloads/MASC Reverse Engineering Design Map.html
     §Gap "Auth identity is spread across several layers" + §개선 #2
@@ -68,7 +67,7 @@ type dashboard_actor_fallback_outcome =
       (** Token resolution raised a classified domain error. [err_kind]
           is the closed-enum classification of [err]; [actor_hint] is
           the request actor hint (header / query param) that the
-          callsite is about to fall back to, captured for the log line. *)
+          callsite rejected, captured for the log line. *)
 
 (** Full record of a single dashboard actor fallback event. *)
 type dashboard_actor_fallback =
@@ -78,11 +77,10 @@ type dashboard_actor_fallback =
             [server_auth.ml:281-291] for the security rationale. *)
   }
 
-(** Render the byte-equivalent warn-log message for a fallback event.
-    Used by the consolidated helper at the callsite; the format strings
-    match the prior inline [Log.Auth.warn] templates so otel_metric_store log
-    queries and alerting rules keyed on the [silent:dashboard_actor_fallback]
-    prefix continue to fire unchanged. *)
+(** Render the warn-log message for a rejected credential event. The
+    historical [silent:dashboard_actor_fallback] event key remains stable for
+    existing log queries, while the message explicitly states that the actor
+    hint was ignored. *)
 val dashboard_actor_fallback_log_message : dashboard_actor_fallback -> string
 
 (** Otel_metric_store counter labels for a fallback event. Always includes the

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -71,26 +71,60 @@ let bearer_token_from_header value =
 let authorization_header_name = "authorization"
 let internal_token_header_name = "x-masc-internal-token"
 
-let auth_token_from_request request =
-  match
+type request_auth_credential =
+  | Absent_credential
+  | Parsed_credential of string
+  | Malformed_credential of string
+
+let request_auth_credential_from_request request =
+  let authorization =
+    Httpun.Headers.get request.Httpun.Request.headers authorization_header_name
+  in
+  let internal =
+    Httpun.Headers.get request.Httpun.Request.headers internal_token_header_name
+  in
+  let bearer =
     Option.bind
-      (Httpun.Headers.get request.Httpun.Request.headers authorization_header_name)
-      bearer_token_from_header
-  with
-  | Some _ as token -> token
+      (Option.bind authorization bearer_token_from_header)
+      (fun token -> trim_opt (Some token))
+  in
+  match bearer with
+  | Some token -> Parsed_credential token
   | None ->
-      trim_opt
-        (Httpun.Headers.get request.Httpun.Request.headers internal_token_header_name)
+      (match internal, authorization with
+       | Some token, _ ->
+           (match trim_opt (Some token) with
+            | Some token -> Parsed_credential token
+            | None -> Malformed_credential token)
+       | None, Some raw -> Malformed_credential raw
+       | None, None -> Absent_credential)
+
+let token_of_request_auth_credential = function
+  | Parsed_credential token -> Some token
+  | Absent_credential | Malformed_credential _ -> None
+
+let auth_token_from_request request =
+  request_auth_credential_from_request request
+  |> token_of_request_auth_credential
 
 let request_carries_auth_credential request =
-  match
-    ( Httpun.Headers.get request.Httpun.Request.headers authorization_header_name
-    , Httpun.Headers.get request.Httpun.Request.headers internal_token_header_name )
-  with
-  | None, None -> false
-  | None, Some _ | Some _, None | Some _, Some _ -> true
+  match request_auth_credential_from_request request with
+  | Absent_credential -> false
+  | Parsed_credential _ | Malformed_credential _ -> true
 
-let observer_sse_query_token_from_request request =
+let malformed_request_credential_error () =
+  Masc_domain.Auth
+    (Masc_domain.Auth_error.Unauthorized
+       { reason = Missing_token
+       ; message =
+           "Request credential header did not contain a bearer or internal token."
+       })
+
+let reject_malformed_request_credential = function
+  | Malformed_credential _ -> Error (malformed_request_credential_error ())
+  | Absent_credential | Parsed_credential _ -> Ok ()
+
+let observer_sse_query_credential_from_request request =
   let path = Http_server_eio.Request.path request in
   let observer_stream_requested =
     match query_param request "sse_kind" with
@@ -103,13 +137,26 @@ let observer_sse_query_token_from_request request =
     when (observer_stream_requested && String.equal path "/mcp")
          || String.equal path "/events/presence"
          || String.equal path "/api/v1/ide/cursors/stream" ->
-      trim_opt (query_param request "token")
-  | _ -> None
+      (match query_param request "token" with
+       | None -> Absent_credential
+       | Some raw ->
+           (match trim_opt (Some raw) with
+            | Some token -> Parsed_credential token
+            | None -> Malformed_credential raw))
+  | _ -> Absent_credential
+
+let observer_sse_query_token_from_request request =
+  observer_sse_query_credential_from_request request
+  |> token_of_request_auth_credential
+
+let observer_sse_auth_credential_from_request request =
+  match request_auth_credential_from_request request with
+  | (Parsed_credential _ | Malformed_credential _) as credential -> credential
+  | Absent_credential -> observer_sse_query_credential_from_request request
 
 let observer_sse_auth_token_from_request request =
-  match auth_token_from_request request with
-  | Some _ as token -> token
-  | None -> observer_sse_query_token_from_request request
+  observer_sse_auth_credential_from_request request
+  |> token_of_request_auth_credential
 
 let agent_from_request request =
   let hdr key = Httpun.Headers.get request.Httpun.Request.headers key in
@@ -175,11 +222,16 @@ let resolve_agent_name_for_auth_raw ~base_path request ~token :
 (** Verify Bearer token for MCP endpoints *)
 let verify_mcp_auth ~base_path request =
   let auth_config = Auth.load_auth_config base_path in
+  let credential = request_auth_credential_from_request request in
   let* auth_config = ensure_strict_http_token_auth ~endpoint:"/mcp" auth_config in
+  let* () =
+    reject_malformed_request_credential credential
+    |> Result.map_error Masc_domain.masc_error_to_string
+  in
   if not auth_config.Masc_domain.enabled then
     Ok None  (* Auth disabled - allow all *)
   else
-    match auth_token_from_request request with
+    match token_of_request_auth_credential credential with
     | None when not auth_config.require_token ->
         Ok None  (* Token not required *)
     | None ->
@@ -209,11 +261,16 @@ let verify_mcp_auth ~base_path request =
 
 let verify_mcp_observer_stream_auth ~base_path request =
   let auth_config = Auth.load_auth_config base_path in
+  let credential = observer_sse_auth_credential_from_request request in
   let* auth_config = ensure_strict_http_token_auth ~endpoint:"/mcp" auth_config in
+  let* () =
+    reject_malformed_request_credential credential
+    |> Result.map_error Masc_domain.masc_error_to_string
+  in
   if not auth_config.Masc_domain.enabled then
     Ok None
   else
-    match observer_sse_auth_token_from_request request with
+    match token_of_request_auth_credential credential with
     | None when not auth_config.require_token ->
         Ok None
     | None ->
@@ -239,16 +296,19 @@ let verify_mcp_observer_stream_auth ~base_path request =
 
 let verify_operator_mcp_auth ~base_path request =
   let auth_config = Auth.load_auth_config base_path in
+  let credential = request_auth_credential_from_request request in
   if not auth_config.Masc_domain.enabled then
     Error
       "/mcp/operator requires workspace auth enabled with require_token=true."
   else if not auth_config.require_token then
     Error "/mcp/operator requires bearer token auth (require_token=true)."
   else
-    match auth_token_from_request request with
-    | None ->
+    match credential with
+    | Malformed_credential _ ->
+        Error (malformed_request_credential_error () |> Masc_domain.masc_error_to_string)
+    | Absent_credential ->
         Error "Authentication required. Use 'Authorization: Bearer <token>' header."
-    | Some token -> (
+    | Parsed_credential token -> (
         let* agent_name =
           resolve_agent_name_for_auth_raw ~base_path request ~token:(Some token)
           |> Result.map_error Masc_domain.masc_error_to_string
@@ -346,41 +406,45 @@ let stale_token_warn_log_entry_count () =
   Eio.Mutex.use_ro stale_token_warn_mu @@ fun () ->
   Hashtbl.length stale_token_warn_log
 
-let dashboard_actor_for_request ~base_path request =
-  match auth_token_from_request request with
-  | Some token -> (
+type dashboard_actor_resolution =
+  | Authenticated_actor of string
+  | Anonymous_actor_hint of string option
+  | Rejected_credential of Auth_error_kind.dashboard_actor_fallback_outcome
+
+let dashboard_token_hash_prefix_length = 8
+
+let dashboard_token_hash_prefix raw_credential =
+  String.sub
+    (Auth.sha256_hash raw_credential)
+    0
+    dashboard_token_hash_prefix_length
+
+let dashboard_actor_resolution_for_request ~base_path request =
+  match request_auth_credential_from_request request with
+  | Parsed_credential token -> (
       (* First 8 hex chars of the bearer token's SHA-256. Lets operators
-         correlate a token-mismatch fallback with the keeper credential
+         correlate a token-mismatch rejection with the keeper credential
          that holds the matching hash (see [auth.ml:677] credential
          storage). The hash itself is one-way; the prefix alone is
          insufficient to reconstruct the token but unique enough to
          pinpoint a specific credential rotation event in production
          logs (2026-04-27 incident: same hash prefix observed firing
          twice in the same second, masking which keeper was affected). *)
-      let token_hash_prefix =
-        String.sub (Auth.sha256_hash token) 0 8
-      in
+      let token_hash_prefix = dashboard_token_hash_prefix token in
       match resolve_agent_name_for_auth_raw ~base_path request ~token:(Some token) with
-      | Ok (Some agent_name) -> Some agent_name
+      | Ok (Some agent_name) -> Authenticated_actor agent_name
       | Ok None ->
-          (* PR-I: surface the silent fallback. Token did not resolve to any
-             agent, so we drop to the request actor hint (header / query
-             param), masking identity drift in the HTTP transport.
-
-             WORKAROUND-CARRYOVER: the fallback path itself is retained as a
-             production safety net — the dashboard cannot go dark on token
-             churn — but the two warn sites here and at the [Error] arm now
-             flow through [Auth_error_kind.dashboard_actor_fallback], giving
-             callers a typed handle on *why* the fallback fired. The
-             string emitted by [dashboard_actor_fallback_log_message] is
-             byte-equivalent to the prior inline format so otel_metric_store log
-             alerts keyed on the literal prefix continue to fire.
-             Reference: Reverse Engineering Design Map §개선 #2. *)
+          (* An explicit credential and an anonymous actor hint are distinct
+             trust states. Preserve the public-read availability contract by
+             returning a typed rejection that projects to the unparameterized
+             dashboard namespace; never turn the unauthenticated hint into an
+             authenticated actor. The historical metric/log key is retained so
+             existing alerts continue to surface stale credential churn. *)
           let fb : Auth_error_kind.dashboard_actor_fallback =
             { outcome = Auth_error_kind.Outcome_none; token_hash_prefix }
           in
           record_dashboard_actor_fallback fb;
-          request_actor_hint request
+          Rejected_credential Auth_error_kind.Outcome_none
       | Error err ->
           (* The previous warn line elided the actual error string and the
              request actor hint, leaving operators with a counter that only
@@ -402,8 +466,28 @@ let dashboard_actor_for_request ~base_path request =
             }
           in
           record_dashboard_actor_fallback fb;
-          request_actor_hint request)
-  | None -> request_actor_hint request
+          Rejected_credential fb.outcome)
+  | Malformed_credential raw_credential ->
+      let err = malformed_request_credential_error () in
+      let outcome =
+        Auth_error_kind.Outcome_error
+          { err
+          ; err_kind = Auth_error_kind.classify err
+          ; actor_hint = request_actor_hint request
+          }
+      in
+      record_dashboard_actor_fallback
+        { outcome
+        ; token_hash_prefix = dashboard_token_hash_prefix raw_credential
+        };
+      Rejected_credential outcome
+  | Absent_credential -> Anonymous_actor_hint (request_actor_hint request)
+
+let dashboard_actor_for_request ~base_path request =
+  match dashboard_actor_resolution_for_request ~base_path request with
+  | Authenticated_actor actor -> Some actor
+  | Anonymous_actor_hint actor_hint -> actor_hint
+  | Rejected_credential _ -> None
 
 let is_verified_internal_keeper_request ~base_path request =
   match auth_token_from_request request with
@@ -855,7 +939,8 @@ let resolve_agent_name_for_auth ~base_path request ~token :
 let authorize_permission_request ~base_path ~permission request :
     (unit, Masc_domain.masc_error) result =
   let auth_cfg = Auth.load_auth_config base_path in
-  let token = auth_token_from_request request in
+  let credential = request_auth_credential_from_request request in
+  let token = token_of_request_auth_credential credential in
   let* auth_cfg =
     ensure_strict_http_token_auth ~endpoint:"HTTP read access" auth_cfg
     |> Result.map_error (fun msg ->
@@ -863,6 +948,7 @@ let authorize_permission_request ~base_path ~permission request :
             (Masc_domain.Auth_error.Unauthorized
                { reason = Generic; message = msg }))
   in
+  let* () = reject_malformed_request_credential credential in
   let* agent_name_opt = resolve_agent_name_for_auth ~base_path request ~token in
   (* NDT-OK: pre-existing dashboard fallback for non-token dashboard reads.
      Token-bound requests without a resolved agent fail closed in the guard below. *)
@@ -888,7 +974,9 @@ let authorize_read_request ~base_path request : (unit, Masc_domain.masc_error) r
 let authorize_tool_request_with_actor ~base_path ~tool_name ~request_authority request :
     (string, Masc_domain.masc_error) result =
   let auth_cfg = Auth.load_auth_config base_path in
-  let token = auth_token_from_request request in
+  let credential = request_auth_credential_from_request request in
+  let token = token_of_request_auth_credential credential in
+  let* () = reject_malformed_request_credential credential in
   let* () =
     if Option.is_some token then Ok ()
     else ensure_same_origin_browser_request ~request_authority request

--- a/lib/server/server_auth.mli
+++ b/lib/server/server_auth.mli
@@ -122,15 +122,11 @@ val record_dashboard_actor_fallback :
 
     Consolidates the two prior inline warn sites (Ok None / Error err
     arms in [dashboard_actor_for_request]) onto a single helper. The
-    rendered log message is byte-equivalent to the prior format strings
-    — otel_metric_store log alerts keyed on the literal
-    [silent:dashboard_actor_fallback] prefix continue to fire.
+    historical [silent:dashboard_actor_fallback] event key remains stable
+    for existing otel_metric_store log alerts.
 
-    WORKAROUND-CARRYOVER: the fallback path itself remains (the
-    dashboard cannot go dark on token churn), but downstream reducers
-    now have a typed handle on *why* the fallback fired. Reference:
-    Reverse Engineering Design Map §개선 #2 (request identity state
-    machine). *)
+    The metric name is retained as an observability compatibility key,
+    but the actor resolver now rejects the hint instead of using it. *)
 
 val stale_token_warn_log_max_entries : int
 (** Ceiling on distinct token-hash prefixes retained for warn-log dedup.
@@ -140,9 +136,29 @@ val stale_token_warn_log_entry_count : unit -> int
 (** Current number of tracked token-hash prefixes. Exposed for testing that
     [record_dashboard_actor_fallback] keeps the dedup table bounded. *)
 
+type dashboard_actor_resolution =
+  | Authenticated_actor of string
+      (** Actor canonically owned by the request bearer token. *)
+  | Anonymous_actor_hint of string option
+      (** Caller-supplied hint on a request that carries no credential.
+          Public dashboard reads deliberately preserve this namespace. *)
+  | Rejected_credential of Auth_error_kind.dashboard_actor_fallback_outcome
+      (** The request carried a credential header, but it was malformed or
+          did not resolve. The accompanying request hint is diagnostic only
+          and must not become the effective actor. Endpoint authorization
+          remains a separate gate. *)
+
+val dashboard_actor_resolution_for_request :
+  base_path:string -> Httpun.Request.t -> dashboard_actor_resolution
+(** Resolve authenticated ownership, anonymous attribution, or explicit
+    credential rejection without collapsing the three states into [option]. *)
+
 val dashboard_actor_for_request :
   base_path:string -> Httpun.Request.t -> string option
-(** Resolve the dashboard actor name from the request. *)
+(** Project a dashboard actor from [dashboard_actor_resolution_for_request].
+    Invalid/expired/rejected credentials return [None]; only requests without
+    credentials may use a request actor hint. This is actor attribution, not
+    endpoint authorization. *)
 
 val is_verified_internal_keeper_request :
   base_path:string -> Httpun.Request.t -> bool

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -593,44 +593,37 @@ let dashboard_shell_auth_json ~(request : Httpun.Request.t) (config : Workspace.
      same code. *)
   let dashboard_auth_error_code = Masc_domain.dashboard_auth_error_code in
   let auth_cfg = Auth.load_auth_config config.base_path in
-  let token = auth_token_from_request request in
-  let token_credential_result =
-    match token with
-    | None -> None
-    | Some raw_token ->
-      Some (Auth.find_credential_by_token config.base_path ~token:raw_token)
+  let actor_resolution =
+    dashboard_actor_resolution_for_request ~base_path:config.base_path request
   in
+  let token = auth_token_from_request request in
   let requested_agent = request_actor_hint request in
-  let token_present = Option.is_some token in
+  let token_present =
+    match actor_resolution with
+    | Authenticated_actor _ | Rejected_credential _ -> true
+    | Anonymous_actor_hint _ -> false
+  in
   let token_valid =
-    match token_credential_result with
-    | Some (Ok _) -> true
-    | _ -> false
+    match actor_resolution with
+    | Authenticated_actor _ -> true
+    | Anonymous_actor_hint _ | Rejected_credential _ -> false
   in
   let token_agent =
-    match token_credential_result with
-    | Some (Ok cred) -> Some cred.Masc_domain.agent_name
-    | _ -> None
+    match actor_resolution with
+    | Authenticated_actor agent_name -> Some agent_name
+    | Anonymous_actor_hint _ | Rejected_credential _ -> None
   in
   let resolved_agent_name_result =
-    match token_credential_result with
-    (* Keep stale bearer tokens visible as auth failures in shell summaries instead of
-       recovering a request actor hint as the effective actor. *)
-    | Some (Error err) -> Error err
-    | _ ->
-    (match dashboard_actor_for_request ~base_path:config.base_path request with
-    | Some agent_name -> Ok agent_name
-    | None ->
-      if auth_cfg.enabled && auth_cfg.require_token && token_present
-      then
-        Error
-          (Masc_domain.Auth
-             (Masc_domain.Auth_error.Unauthorized
-                { reason = Missing_token
-                ; message = "Agent name required (X-Gate-Agent / X-MASC-Agent or token-bound \
-                             credential)"
-                }))
-      else Ok "dashboard")
+    match actor_resolution with
+    | Authenticated_actor agent_name -> Ok agent_name
+    | Anonymous_actor_hint (Some agent_name) -> Ok agent_name
+    | Anonymous_actor_hint None -> Ok "dashboard"
+    | Rejected_credential (Auth_error_kind.Outcome_error { err; _ }) -> Error err
+    | Rejected_credential Auth_error_kind.Outcome_none ->
+      Error
+        (Masc_domain.Auth
+           (Masc_domain.Auth_error.InvalidToken
+              "Bearer token did not resolve to an agent."))
   in
   let effective_agent =
     match resolved_agent_name_result with
@@ -688,13 +681,9 @@ let dashboard_shell_auth_json ~(request : Httpun.Request.t) (config : Workspace.
     | Error _ -> None
   in
   let auth_error =
-    match token_credential_result with
-    | Some (Error (Masc_domain.Auth (Masc_domain.Auth_error.InvalidToken _) as err)) ->
-      Some err
-    | Some (Error (Masc_domain.Auth (Masc_domain.Auth_error.TokenExpired _) as err)) ->
-      Some err
-    | Some (Error err) -> Some err
-    | _ ->
+    match resolved_agent_name_result with
+    | Error err -> Some err
+    | Ok _ ->
       (match keeper_authorization_result with
        | Error err -> Some err
        | Ok () -> None)

--- a/test/dune
+++ b/test/dune
@@ -1267,6 +1267,13 @@
  (modules test_server_auth_warn_log_bound)
  (libraries alcotest masc masc_server eio_main))
 
+; Dashboard actor attribution: rejected credentials cannot become anonymous hints.
+
+(test
+ (name test_server_auth_dashboard_actor_resolution)
+ (modules test_server_auth_dashboard_actor_resolution)
+ (libraries alcotest masc masc.masc_types masc_server eio_main httpun unix))
+
 ; RFC-0301 item 6: the turn-local generated-media accumulator turns stream media
 ; into reload chat blocks (image / voice / attach) via the content-addressed store.
 

--- a/test/test_auth_error_kind_dashboard_fallback.ml
+++ b/test/test_auth_error_kind_dashboard_fallback.ml
@@ -1,4 +1,4 @@
-(** Byte-equivalence + label tests for the dashboard_actor_fallback typed
+(** Rendering + label tests for the dashboard_actor_fallback typed
     surface on [Auth_error_kind].
 
     The two prior inline warn sites at [lib/server/server_auth.ml] used
@@ -6,10 +6,10 @@
     [\<newline><whitespace>] escape into a single line. Operators key
     otel_metric_store log alerts on the literal [silent:dashboard_actor_fallback]
     prefix and on the [Remediation:] substring in the [token_mismatch]
-    arm, so the consolidated helper MUST emit the byte-identical message.
+    arm, so the consolidated helper MUST preserve those stable fragments.
 
-    These tests lock the rendered string for both outcome arms against an
-    explicit hex-literal expected value, and check that the otel_metric_store
+    These tests lock the rendered rejection string for both outcome arms
+    against an explicit hex-literal expected value, and check that the otel_metric_store
     label list matches the prior call. Reference:
     [auth_error_kind.mli §Dashboard actor fallback typed surface]. *)
 
@@ -20,9 +20,9 @@ module Sda = Masc.Silent_dashboard_actor_outcome
 let with_eio_runtime f =
   Eio_main.run @@ fun _env -> f ()
 
-(* ----- Outcome_none: byte-equivalent log message --------------------- *)
+(* ----- Outcome_none: rejected-hint log message ----------------------- *)
 
-let test_outcome_none_log_message_byte_equivalent () =
+let test_outcome_none_log_message () =
   let fb : Aek.dashboard_actor_fallback =
     { outcome = Aek.Outcome_none; token_hash_prefix = "deadbeef" }
   in
@@ -30,9 +30,9 @@ let test_outcome_none_log_message_byte_equivalent () =
   let expected =
     "[silent:dashboard_actor_fallback] outcome=none \
      token_hash_prefix=deadbeef \xe2\x80\x94 bearer token resolved to no \
-     agent, falling back to request actor hint"
+     agent; request actor hint ignored"
   in
-  Alcotest.(check string) "byte-equivalent rendering" expected actual
+  Alcotest.(check string) "rejection rendering" expected actual
 
 let test_outcome_none_log_message_starts_with_alert_prefix () =
   (* Lock the [silent:dashboard_actor_fallback] prefix — otel_metric_store log
@@ -65,7 +65,7 @@ let test_outcome_none_log_message_no_leading_whitespace_after_dash () =
     true
     (Astring.String.is_infix ~affix:needle msg)
 
-(* ----- Outcome_error: byte-equivalent log message -------------------- *)
+(* ----- Outcome_error: rejected-hint log message ---------------------- *)
 
 let invalid_token_err =
   Masc_domain.Auth (Masc_domain.Auth_error.InvalidToken "stale-token-x")
@@ -118,7 +118,7 @@ let test_outcome_error_token_mismatch_renders_remediation () =
        ~affix:"localStorage masc_dashboard_token"
        msg)
 
-let test_outcome_error_token_mismatch_byte_equivalent () =
+let test_outcome_error_token_mismatch_log_message () =
   let fb : Aek.dashboard_actor_fallback =
     { outcome =
         Aek.Outcome_error
@@ -135,14 +135,14 @@ let test_outcome_error_token_mismatch_byte_equivalent () =
     Printf.sprintf
       "[silent:dashboard_actor_fallback] outcome=error \
        token_hash_prefix=feed1234 err_kind=token_mismatch \
-       actor_hint=dashboard-admin err=%s \xe2\x80\x94 falling back to \
-       request actor hint. Remediation: clear the browser's stored \
+       actor_hint=dashboard-admin err=%s \xe2\x80\x94 request actor hint \
+       ignored. Remediation: clear the browser's stored \
        dashboard token (localStorage masc_dashboard_token) or delete \
        .masc/auth/dashboard.token so a fresh token is minted on the \
        next dashboard load."
       err_str
   in
-  Alcotest.(check string) "byte-equivalent rendering" expected actual
+  Alcotest.(check string) "rejection rendering" expected actual
 
 let test_outcome_error_non_token_mismatch_no_remediation () =
   (* The remediation tail is exclusive to [Token_mismatch]. Other
@@ -170,7 +170,7 @@ let test_outcome_error_non_token_mismatch_no_remediation () =
     "ends at hint period"
     true
     (Astring.String.is_suffix
-       ~affix:"falling back to request actor hint."
+       ~affix:"request actor hint ignored."
        msg)
 
 (* ----- Otel_metric_store label correspondence ------------------------------- *)
@@ -305,16 +305,16 @@ let test_outcome_error_increments_counter_with_err_kind () =
     after
 
 let suite =
-  [ test_case "Outcome_none: byte-equivalent log message" `Quick
-      test_outcome_none_log_message_byte_equivalent
+  [ test_case "Outcome_none: rejected-hint log message" `Quick
+      test_outcome_none_log_message
   ; test_case "Outcome_none: alert prefix locked" `Quick
       test_outcome_none_log_message_starts_with_alert_prefix
   ; test_case "Outcome_none: no whitespace before em-dash" `Quick
       test_outcome_none_log_message_no_leading_whitespace_after_dash
   ; test_case "Outcome_error+Token_mismatch: remediation tail present" `Quick
       test_outcome_error_token_mismatch_renders_remediation
-  ; test_case "Outcome_error+Token_mismatch: byte-equivalent" `Quick
-      test_outcome_error_token_mismatch_byte_equivalent
+  ; test_case "Outcome_error+Token_mismatch: rejected-hint log message" `Quick
+      test_outcome_error_token_mismatch_log_message
   ; test_case "Outcome_error+other err_kind: no remediation tail" `Quick
       test_outcome_error_non_token_mismatch_no_remediation
   ; test_case "Outcome_none: otel_metric_store labels" `Quick

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -944,6 +944,36 @@ let test_dashboard_shell_auth_json_rejects_stale_token_actor_hint () =
   check bool "keeper message blocked" false
     (auth |> member "can_keeper_msg" |> to_bool)
 
+let test_dashboard_shell_auth_json_rejects_malformed_credential () =
+  with_test_env @@ fun ~env:_ ~sw:_ ~config ->
+  let cfg =
+    { Masc_domain.default_auth_config with enabled = true; require_token = false }
+  in
+  Auth.save_auth_config config.base_path cfg;
+  let json =
+    Server_dashboard_http_core.dashboard_shell_http_json
+      ~request:
+        (request_with_headers "/api/v1/dashboard/shell"
+           [ ("authorization", "Basic malformed")
+           ; ("x-masc-agent", "forged-dashboard")
+           ])
+      config
+  in
+  let open Yojson.Safe.Util in
+  let auth = json |> member "auth" in
+  check bool "credential presence retained" true
+    (auth |> member "token_present" |> to_bool);
+  check bool "malformed credential invalid" false
+    (auth |> member "token_valid" |> to_bool);
+  check bool "effective actor unavailable" true
+    (match auth |> member "effective_agent" with `Null -> true | _ -> false);
+  check bool "effective role unavailable" true
+    (match auth |> member "effective_role" with `Null -> true | _ -> false);
+  check string "malformed credential code surfaced" "missing_token"
+    (auth |> member "auth_error_code" |> to_string);
+  check bool "keeper message blocked" false
+    (auth |> member "can_keeper_msg" |> to_bool)
+
 let test_dashboard_shell_snapshot_selector_injects_auth () =
   with_test_env @@ fun ~env:_ ~sw:_ ~config ->
   Dashboard_snapshot.reset_for_test ();
@@ -1861,6 +1891,8 @@ let () =
             test_dashboard_shell_auth_json_reports_missing_token;
           test_case "shell auth rejects stale token actor hint" `Quick
             test_dashboard_shell_auth_json_rejects_stale_token_actor_hint;
+          test_case "shell auth rejects malformed credential" `Quick
+            test_dashboard_shell_auth_json_rejects_malformed_credential;
           test_case "shell snapshot selector injects auth" `Quick
             test_dashboard_shell_snapshot_selector_injects_auth;
           test_case "execution actor canonicalizes token owner" `Quick

--- a/test/test_server_auth_dashboard_actor_resolution.ml
+++ b/test/test_server_auth_dashboard_actor_resolution.ml
@@ -1,0 +1,263 @@
+(** Dashboard actor attribution keeps endpoint authorization separate while
+    refusing to reinterpret a rejected bearer token as an anonymous hint. *)
+
+open Alcotest
+
+let with_temp_base_path f =
+  let path = Filename.temp_file "masc-dashboard-actor-" "" in
+  Unix.unlink path;
+  Unix.mkdir path 0o700;
+  Fun.protect
+    ~finally:(fun () ->
+      let rec remove path =
+        match (Unix.lstat path).Unix.st_kind with
+        | Unix.S_DIR ->
+            Array.iter
+              (fun entry -> remove (Filename.concat path entry))
+              (Sys.readdir path);
+            Unix.rmdir path
+        | _ -> Unix.unlink path
+      in
+      remove path)
+    (fun () -> f path)
+
+let request ?token ~actor () =
+  let headers =
+    ("x-masc-agent", actor)
+    :: (match token with
+        | None -> []
+        | Some token -> [ ("authorization", "Bearer " ^ token) ])
+  in
+  Httpun.Request.create
+    ~headers:(Httpun.Headers.of_list headers)
+    `GET
+    "/api/v1/dashboard/briefing"
+
+let resolve ~base_path request =
+  Eio_main.run @@ fun _env ->
+  Server_auth.dashboard_actor_resolution_for_request ~base_path request
+
+let project ~base_path request =
+  Eio_main.run @@ fun _env ->
+  Server_auth.dashboard_actor_for_request ~base_path request
+
+let loopback_request_authority () =
+  match Server_request_authority.of_host_port ~host:"127.0.0.1" ~port:8935 with
+  | Ok authority -> authority
+  | Error `Malformed -> fail "failed to construct loopback request authority"
+
+let test_anonymous_public_read_preserves_hint () =
+  with_temp_base_path @@ fun base_path ->
+  let request = request ~actor:"public-reader" () in
+  (match resolve ~base_path request with
+   | Server_auth.Anonymous_actor_hint (Some actor) ->
+       check string "anonymous hint" "public-reader" actor
+   | _ -> fail "expected Anonymous_actor_hint");
+  check (option string) "public projection" (Some "public-reader")
+    (project ~base_path request)
+
+let test_rejected_credential_cannot_supply_actor_hint () =
+  with_temp_base_path @@ fun base_path ->
+  let request = request ~token:"stale-token" ~actor:"forged-actor" () in
+  (match resolve ~base_path request with
+   | Server_auth.Rejected_credential
+       (Masc.Auth_error_kind.Outcome_error
+          { err_kind = Masc.Auth_error_kind.Token_mismatch
+          ; actor_hint = Some actor_hint
+          ; _
+          }) ->
+       check string "hint retained only as diagnostic" "forged-actor" actor_hint
+   | _ -> fail "expected typed token-mismatch rejection");
+  check (option string) "rejected credential has no actor" None
+    (project ~base_path request);
+  (match
+     Server_auth.authorize_tool_request_with_actor
+       ~base_path
+       ~tool_name:"masc_broadcast"
+       ~request_authority:(loopback_request_authority ())
+       request
+   with
+   | Error (Masc_domain.Auth (Masc_domain.Auth_error.InvalidToken _)) -> ()
+   | Error err ->
+       failf "unexpected endpoint auth error: %s"
+         (Masc_domain.masc_error_to_string err)
+   | Ok actor -> failf "endpoint auth unexpectedly admitted %s" actor)
+
+let test_malformed_credential_cannot_become_anonymous () =
+  with_temp_base_path @@ fun base_path ->
+  Masc.Auth.save_auth_config
+    base_path
+    { Masc_domain.default_auth_config with enabled = true; require_token = false };
+  let request =
+    Httpun.Request.create
+      ~headers:
+        (Httpun.Headers.of_list
+           [ ("authorization", "Basic malformed")
+           ; ("x-masc-agent", "forged-actor")
+           ])
+      `GET
+      "/api/v1/dashboard/briefing"
+  in
+  (match resolve ~base_path request with
+   | Server_auth.Rejected_credential
+       (Masc.Auth_error_kind.Outcome_error
+          { err_kind = Masc.Auth_error_kind.Unauthorized
+          ; actor_hint = Some actor_hint
+          ; _
+          }) ->
+       check string "hint retained only as diagnostic" "forged-actor" actor_hint
+   | _ -> fail "expected typed malformed-credential rejection");
+  check (option string) "malformed credential has no actor" None
+    (project ~base_path request);
+  (match Server_auth.authorize_read_request ~base_path request with
+   | Error (Masc_domain.Auth (Masc_domain.Auth_error.Unauthorized _)) -> ()
+   | Error err ->
+       failf "unexpected read auth error: %s"
+         (Masc_domain.masc_error_to_string err)
+   | Ok () -> fail "malformed credential admitted to read authorization");
+  (match Server_auth.verify_mcp_auth ~base_path request with
+   | Error _ -> ()
+   | Ok _ -> fail "malformed credential admitted to optional MCP authorization");
+  (match
+     Server_auth.authorize_tool_request_with_actor
+       ~base_path
+       ~tool_name:"masc_broadcast"
+       ~request_authority:(loopback_request_authority ())
+       request
+   with
+   | Error (Masc_domain.Auth (Masc_domain.Auth_error.Unauthorized _)) -> ()
+   | Error err ->
+       failf "unexpected endpoint auth error: %s"
+         (Masc_domain.masc_error_to_string err)
+   | Ok actor -> failf "malformed credential admitted as %s" actor)
+
+let observer_request ?authorization ?internal_token ?query_token () =
+  let target =
+    match query_token with
+    | None -> "/mcp?sse_kind=observer"
+    | Some token -> "/mcp?sse_kind=observer&token=" ^ token
+  in
+  let headers =
+    []
+    |> (fun headers ->
+         match authorization with
+         | None -> headers
+         | Some value -> ("authorization", value) :: headers)
+    |> fun headers ->
+    match internal_token with
+    | None -> headers
+    | Some value -> ("x-masc-internal-token", value) :: headers
+  in
+  Httpun.Request.create ~headers:(Httpun.Headers.of_list headers) `GET target
+
+let expect_observer_rejected ~base_path request message =
+  match Server_auth.verify_mcp_observer_stream_auth ~base_path request with
+  | Error _ -> ()
+  | Ok _ -> fail message
+
+let expect_observer_admitted ~base_path request message =
+  match Server_auth.verify_mcp_observer_stream_auth ~base_path request with
+  | Ok _ -> ()
+  | Error err -> failf "%s: %s" message err
+
+let test_credential_source_precedence_and_observer_query_state () =
+  with_temp_base_path @@ fun base_path ->
+  Masc.Auth.save_auth_config
+    base_path
+    { Masc_domain.default_auth_config with enabled = true; require_token = false };
+  let save_token agent_name raw_token =
+    match
+      Masc.Auth.save_raw_token_credential
+        base_path
+        ~agent_name
+        ~role:Masc_domain.Worker
+        ~raw_token
+    with
+    | Ok _ -> ()
+    | Error err -> fail (Masc_domain.masc_error_to_string err)
+  in
+  save_token "header-owner" "header-token";
+  save_token "query-owner" "query-token";
+  let internal_only = observer_request ~internal_token:" internal-token " () in
+  check
+    (option string)
+    "internal token trimmed"
+    (Some "internal-token")
+    (Server_auth.auth_token_from_request internal_only);
+  let blank_internal = observer_request ~internal_token:"   " () in
+  check
+    (option string)
+    "blank internal is not parsed"
+    None
+    (Server_auth.auth_token_from_request blank_internal);
+  check bool "blank internal remains explicit" true
+    (Server_auth.request_carries_auth_credential blank_internal);
+  let internal_after_malformed_authorization =
+    observer_request
+      ~authorization:"Basic malformed"
+      ~internal_token:"internal-token"
+      ()
+  in
+  check
+    (option string)
+    "supported internal header retains precedence fallback"
+    (Some "internal-token")
+    (Server_auth.auth_token_from_request internal_after_malformed_authorization);
+  expect_observer_rejected
+    ~base_path
+    (observer_request
+       ~authorization:"Basic malformed"
+       ~query_token:"query-token"
+       ())
+    "malformed header must not fall back to a valid query credential";
+  expect_observer_admitted
+    ~base_path
+    (observer_request
+       ~authorization:"Bearer header-token"
+       ~query_token:""
+       ())
+    "valid header must take precedence over malformed query credential";
+  expect_observer_admitted
+    ~base_path
+    (observer_request ~query_token:"query-token" ())
+    "valid observer query credential should be admitted";
+  expect_observer_rejected
+    ~base_path
+    (observer_request ~query_token:"" ())
+    "empty observer query credential must not become anonymous"
+
+let test_authenticated_owner_overrides_request_hint () =
+  with_temp_base_path @@ fun base_path ->
+  let token = "owner-token" in
+  (match
+     Masc.Auth.save_raw_token_credential
+       base_path
+       ~agent_name:"credential-owner"
+       ~role:Masc_domain.Worker
+       ~raw_token:token
+   with
+   | Ok _ -> ()
+   | Error err -> fail (Masc_domain.masc_error_to_string err));
+  let request = request ~token ~actor:"forged-actor" () in
+  (match resolve ~base_path request with
+   | Server_auth.Authenticated_actor actor ->
+       check string "credential owner" "credential-owner" actor
+   | _ -> fail "expected Authenticated_actor");
+  check (option string) "authenticated projection" (Some "credential-owner")
+    (project ~base_path request)
+
+let () =
+  run "server_auth_dashboard_actor_resolution"
+    [ ( "resolution"
+      , [ test_case "anonymous public hint is preserved" `Quick
+            test_anonymous_public_read_preserves_hint
+        ; test_case "rejected credential fails closed" `Quick
+            test_rejected_credential_cannot_supply_actor_hint
+        ; test_case "malformed credential fails closed" `Quick
+            test_malformed_credential_cannot_become_anonymous
+        ; test_case "credential precedence and observer query state" `Quick
+            test_credential_source_precedence_and_observer_query_state
+        ; test_case "authenticated owner is canonical" `Quick
+            test_authenticated_owner_overrides_request_hint
+        ] )
+    ]


### PR DESCRIPTION
## Summary
- classify request credentials once as absent, parsed, or malformed
- prevent rejected credentials from becoming dashboard actor hints or cache/projection identities
- fail closed for malformed read, tool, MCP, and observer credentials even when token auth is optional
- project Dashboard Shell auth state from the typed actor resolution
- preserve explicit observer/header/internal precedence with focused regression coverage

## Verification
- `ocamlformat --check` on changed OCaml files
- `ocamlc -stop-after parsing` on changed OCaml files
- `git diff --check`
- focused Dune delegated to CI while the shared machine Dune lock is owned

## Review
- three adversarial passes; all discovered P1/P2 paths fixed
- final result: P0/P1/P2 = 0