### PR TITLE
feat(keeper): persist caller lane completion routes

### DIFF
--- a/lib/keeper/keeper_invocation_contract.ml
+++ b/lib/keeper/keeper_invocation_contract.ml
@@ -112,6 +112,11 @@ let request_of_json json =
   request ~keeper_name:(Keeper_invocation_types.target_name target) ~prompt
 ;;
 
+let with_reply_to ~keeper_name request =
+  Keeper_invocation_types.with_reply_to ~keeper_name request
+  |> Result.map_error (fun reason -> Invalid_target reason)
+;;
+
 let request_error_to_string = function
   | Invalid_target reason -> reason
   | Empty_prompt -> "message is required"
@@ -128,8 +133,15 @@ let target_name (request : request) =
 
 let prompt = Keeper_invocation_types.request_prompt
 
-let submit ~background_sw ~base_path ~caller ~(request : request) ~f () =
+let reply_to_keeper_name request =
+  Keeper_invocation_types.request_reply_to request
+  |> Option.map Keeper_invocation_types.reply_to_keeper_name
+;;
+
+let submit ?on_worker_settled ~background_sw ~base_path ~caller
+    ~(request : request) ~f () =
   Keeper_msg_async.submit
+    ?on_worker_settled
     ~background_sw
     ~base_path
     ~caller

--- a/lib/keeper/keeper_invocation_contract.mli
+++ b/lib/keeper/keeper_invocation_contract.mli
@@ -40,9 +40,11 @@ type request_error =
 
 val request : keeper_name:string -> prompt:string -> (request, request_error) result
 val request_of_json : Yojson.Safe.t -> (request, request_error) result
+val with_reply_to : keeper_name:string -> request -> (request, request_error) result
 val request_error_to_string : request_error -> string
 val target_name : request -> string
 val prompt : request -> string
+val reply_to_keeper_name : request -> string option
 val target_of_json : Yojson.Safe.t -> (target, request_error) result
 val target_to_json : target -> Yojson.Safe.t
 val target_name_of_target : target -> string
@@ -66,7 +68,9 @@ val cancel :
   (Keeper_msg_async.cancel_result, request_error) result
 
 val submit
-  :  background_sw:Eio.Switch.t
+  :  ?on_worker_settled:
+       (request_id:string -> Keeper_msg_async.worker_settlement -> unit)
+  -> background_sw:Eio.Switch.t
   -> base_path:string
   -> caller:string
   -> request:request

--- a/lib/keeper/keeper_msg_async.ml
+++ b/lib/keeper/keeper_msg_async.ml
@@ -511,8 +511,8 @@ let with_keeper_persistence_lock ~base_path ~keeper_name f =
 exception CancelledByOperator
 exception Worker_preempted of string
 exception Worker_already_settled of request_status
-(* v5 hard-cuts prompt-only records: executor identity and direct replay input are durable. *)
-let record_schema_version = 5
+(* v6 hard-cuts prompt-only records and persists optional caller-lane reply routing. *)
+let record_schema_version = 6
 
 let entry_keeper_name_id (entry : entry) =
   match Keeper_invocation_types.request_target entry.request with
@@ -1537,7 +1537,7 @@ let recover_record_path ~base_path ~request_id path report =
                     "non-terminal record has no recovery provenance")
                  report) with
               failed = report.failed + 1
-            })
+            }))
   | Unreadable reason ->
     { (record_error
          ~store:Active_store
@@ -2128,7 +2128,7 @@ let submit_with_ops ops ?on_accepted ?on_worker_aborted ?on_worker_settled ~back
             | None -> ()
             | Some callback ->
               Eio.Cancel.protect (fun () ->
-                try callback settlement with
+                try callback ~request_id settlement with
                 | Eio.Cancel.Cancelled _ as exn -> raise exn
                 | exn ->
                   Otel_metric_store.inc_counter

--- a/lib/keeper/keeper_msg_async.mli
+++ b/lib/keeper/keeper_msg_async.mli
@@ -104,7 +104,7 @@ type recovery_candidate =
   ; provenance : recovery_provenance
   }
 
-(** Recovery observations for canonical v4 storage only. [candidates] retain
+(** Recovery observations for canonical v6 storage only. [candidates] retain
     exact non-terminal restart provenance without mutating accepted work into
     a terminal failure. [finalized] counts
     terminal states moved from the active partition after a crash; [cleaned]
@@ -240,7 +240,7 @@ val server_background_switch : unit -> (Eio.Switch.t, submit_error) result
     explicitly supplied server-lifetime [background_sw].  The per-request
     worker switch passed to [f] is distinct: cancellation fails that switch,
     never the server root. Returns the fresh [request_id] synchronously after
-    the owner-bearing v4 request record is durably accepted. If an atomic
+    the owner-bearing v6 request record is durably accepted. If an atomic
     rename publishes the record but its directory fsync and the compensating
     rollback both fail, [Reconciliation_required] preserves the request id so
     the caller can poll instead of creating an unreachable orphan. The async
@@ -268,7 +268,8 @@ val server_background_switch : unit -> (Eio.Switch.t, submit_error) result
     delivery callback succeeds. Callback failures never escape to the server
     root switch.
 
-    [on_worker_settled] is invoked only for terminal truth that exact in-process
+    [on_worker_settled] is invoked with the exact accepted [request_id], only
+    for terminal truth that exact in-process
     poll also returns: a durably committed status, a typed volatile persistence
     overlay, or an already-existing canonical durable terminal discovered
     during an integrity conflict. Ambiguous durable evidence has no fabricated
@@ -278,7 +279,7 @@ val server_background_switch : unit -> (Eio.Switch.t, submit_error) result
 val submit
   :  ?on_accepted:(string -> (unit, string) result)
   -> ?on_worker_aborted:(worker_abort_reason -> (unit, string) result)
-  -> ?on_worker_settled:(worker_settlement -> unit)
+  -> ?on_worker_settled:(request_id:string -> worker_settlement -> unit)
   -> background_sw:Eio.Switch.t
   -> base_path:string
   -> caller:string
@@ -380,7 +381,7 @@ module For_testing : sig
     :  request_ops
     -> ?on_accepted:(string -> (unit, string) result)
     -> ?on_worker_aborted:(worker_abort_reason -> (unit, string) result)
-    -> ?on_worker_settled:(worker_settlement -> unit)
+    -> ?on_worker_settled:(request_id:string -> worker_settlement -> unit)
     -> background_sw:Eio.Switch.t
     -> base_path:string
     -> caller:string

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -33,12 +33,19 @@ let schemas = Keeper_types_profile.schemas
 type handler_error =
   | Message_error of string
   | Payload_error of Yojson.Safe.t
+  | Ambiguous_caller_identity of string * int
 
 let message_error result = Result.map_error (fun error -> Message_error error) result
 
 let tool_result_of_handler_error = function
   | Message_error message -> tool_result_error message
   | Payload_error data -> tool_result_error_data data
+  | Ambiguous_caller_identity (submitted_by, matches) ->
+    tool_result_error
+      (Printf.sprintf
+         "caller identity %S matches %d registered Keepers"
+         submitted_by
+         matches)
 ;;
 
 type json_cache = {
@@ -106,6 +113,7 @@ let rec cached_json_by_key cache_ref ~key ~ttl_s compute =
       end
 
 let submit_keeper_msg_with_captured_event_bus
+      ?on_worker_settled
       ~background_sw
       ~base_path
       ~caller
@@ -118,12 +126,142 @@ let submit_keeper_msg_with_captured_event_bus
       () =
   let event_bus = Keeper_event_bus.get () in
   Keeper_invocation_contract.submit
+    ?on_worker_settled
     ~background_sw
     ~base_path
     ~caller
     ~request
     ~f:(fun request request_sw -> f ?event_bus request request_sw)
     ()
+
+type keeper_completion_projection =
+  | Completion_not_routed
+  | Completion_not_durable
+  | Completion_enqueued
+  | Completion_already_present
+  | Completion_storage_failed of string
+
+let terminal_completion_outcome = function
+  | Keeper_msg_async.Done { ok; body; data } ->
+    let payload =
+      match data with
+      | None -> body
+      | Some value -> Yojson.Safe.to_string value
+    in
+    Some
+      (if ok
+       then Keeper_event_queue.Bg_ok payload
+       else Keeper_event_queue.Bg_failed payload)
+  | Keeper_msg_async.Lost { reason }
+  | Keeper_msg_async.Cancelled { reason; _ }
+  | Keeper_msg_async.Persistence_failed { reason; _ } ->
+    Some (Keeper_event_queue.Bg_failed reason)
+  | Keeper_msg_async.Queued
+  | Keeper_msg_async.Running
+  | Keeper_msg_async.Cancelling _ -> None
+
+let signal_completion_caller ~base_path caller_keeper =
+  match
+    Keeper_registry.wakeup
+      ~intent:Keeper_registry.Reactive_signal
+      ~base_path
+      caller_keeper
+  with
+  | Keeper_registry.Signaled -> ()
+  | Keeper_registry.Deferred_unregistered ->
+    Log.Keeper.info
+      "keeper invocation completion persisted for unregistered caller=%s"
+      caller_keeper
+  | Keeper_registry.Deferred_not_running phase ->
+    Log.Keeper.info
+      "keeper invocation completion wake deferred caller=%s phase=%s"
+      caller_keeper
+      (Keeper_state_machine.phase_to_string phase)
+  | Keeper_registry.Deferred_lifecycle denial ->
+    Log.Keeper.info
+      "keeper invocation completion wake deferred caller=%s reason=%s"
+      caller_keeper
+      (Keeper_lifecycle_admission.autonomous_denial_to_wire denial)
+
+let project_keeper_completion ~base_path ~request ~request_id settlement =
+  match Keeper_invocation_contract.reply_to_keeper_name request with
+  | None -> Completion_not_routed
+  | Some caller_keeper ->
+    (match settlement with
+     | Keeper_msg_async.Settlement_projection_error _ -> Completion_not_durable
+     | Keeper_msg_async.Status_settlement
+         { durability = Keeper_msg_async.Volatile_persistence_failure; _ } ->
+       Completion_not_durable
+     | Keeper_msg_async.Status_settlement
+         { durability = Keeper_msg_async.Durable; status; _ } ->
+       (match terminal_completion_outcome status with
+        | None -> Completion_not_durable
+        | Some bg_outcome ->
+          let completion : Keeper_event_queue.bg_job_completion =
+            { bg_run_id = request_id
+            ; bg_kind = Keeper_event_queue.Keeper_invocation
+            ; bg_outcome
+            ; bg_board_post_id = ""
+            }
+          in
+          let stimulus : Keeper_event_queue.stimulus =
+            { post_id = Keeper_event_queue.bg_job_completion_post_id completion
+            ; urgency = Keeper_event_queue.Immediate
+            ; arrived_at = Time_compat.now ()
+            ; payload = Keeper_event_queue.Bg_completed completion
+            }
+          in
+          (match
+             Keeper_registry_event_queue.enqueue_stimulus_durable_result
+               ~base_path
+               caller_keeper
+               stimulus
+           with
+           | Keeper_registry_event_queue.Stimulus_storage_error detail ->
+             Otel_metric_store.inc_counter
+               Keeper_metrics.(to_string FsFailures)
+               ~labels:
+                 [ "subsystem", "keeper_invocation_completion"
+                 ; "operation", "enqueue_caller_wake"
+                 ]
+               ();
+             Log.Keeper.error
+               "keeper invocation completion enqueue failed run_id=%s caller=%s: %s"
+               request_id
+               caller_keeper
+               detail;
+             Completion_storage_failed detail
+           | Keeper_registry_event_queue.Stimulus_enqueued ->
+             signal_completion_caller ~base_path caller_keeper;
+             Completion_enqueued
+           | Keeper_registry_event_queue.Stimulus_already_present ->
+             signal_completion_caller ~base_path caller_keeper;
+             Completion_already_present)))
+
+type registered_caller =
+  | No_registered_caller
+  | One_registered_caller of Keeper_registry.registry_entry
+  | Multiple_registered_callers of int
+
+let registered_caller ~base_path ~submitted_by =
+  match
+    Keeper_registry.all ~base_path ()
+    |> List.filter (fun (entry : Keeper_registry.registry_entry) ->
+      String.equal entry.meta.agent_name submitted_by)
+  with
+  | [] -> No_registered_caller
+  | [ entry ] -> One_registered_caller entry
+  | entries -> Multiple_registered_callers (List.length entries)
+
+let request_with_registered_reply_to ~base_path ~submitted_by request =
+  match registered_caller ~base_path ~submitted_by with
+  | No_registered_caller -> Ok request
+  | One_registered_caller entry ->
+    Keeper_invocation_contract.with_reply_to ~keeper_name:entry.name request
+    |> Result.map_error (fun error ->
+      Message_error (Keeper_invocation_contract.request_error_to_string error))
+  | Multiple_registered_callers matches ->
+    Error (Ambiguous_caller_identity (submitted_by, matches))
 
 module For_testing = struct
   let reset_keeper_list_cache () =
@@ -133,6 +271,9 @@ module For_testing = struct
     cached_json_by_key keeper_list_cache ~key ~ttl_s compute
   let submit_keeper_msg_with_captured_event_bus =
     submit_keeper_msg_with_captured_event_bus
+  let terminal_completion_outcome = terminal_completion_outcome
+  let project_keeper_completion = project_keeper_completion
+  let request_with_registered_reply_to = request_with_registered_reply_to
 end
 let annotate_keeper_json ~runtime_class json =
   match json with
@@ -626,6 +767,14 @@ let submit_keeper_invocation
     in
     let* submission =
       submit_keeper_msg_with_captured_event_bus
+        ~on_worker_settled:(fun ~request_id settlement ->
+          ignore
+            (project_keeper_completion
+               ~base_path:ctx.config.base_path
+               ~request
+               ~request_id
+               settlement
+             : keeper_completion_projection))
         ~background_sw
         ~base_path:ctx.config.base_path
         ~caller:submitted_by
@@ -684,6 +833,12 @@ let handle_keeper_delegate ~submitted_by ctx args =
   match
     let* request =
       Keeper_invocation_contract.request_of_json args |> message_error
+    in
+    let* request =
+      request_with_registered_reply_to
+        ~base_path:ctx.config.base_path
+        ~submitted_by
+        request
     in
     let* request = message_error (Turn.preflight_keeper_delegate ctx request) in
     Ok

--- a/lib/keeper_invocation_types/keeper_invocation_types.ml
+++ b/lib/keeper_invocation_types/keeper_invocation_types.ml
@@ -1,5 +1,6 @@
 type capability = Invoke_turn
 type target = Keeper of Keeper_id.Keeper_name.t
+type reply_to = Caller_keeper of Keeper_id.Keeper_name.t
 
 type input =
   | Delegated_turn of string
@@ -10,6 +11,7 @@ type request =
   { target : target
   ; capability : capability
   ; input : input
+  ; reply_to : reply_to option
   }
 
 type run_ref = { run_id : string; target : target; capability : capability }
@@ -40,6 +42,7 @@ let keeper_turn ~keeper_name ~prompt =
         { target = Keeper target_name
         ; capability = Invoke_turn
         ; input = Delegated_turn prompt
+        ; reply_to = None
         }
 ;;
 
@@ -47,7 +50,18 @@ let direct_turn ~keeper_name payload =
   let ( let* ) = Result.bind in
   let* () = Keeper_direct_invocation.validate payload in
   let* target_name = Keeper_id.Keeper_name.of_string keeper_name in
-  Ok { target = Keeper target_name; capability = Invoke_turn; input = Direct_delivery payload }
+  Ok
+    { target = Keeper target_name
+    ; capability = Invoke_turn
+    ; input = Direct_delivery payload
+    ; reply_to = None
+    }
+;;
+
+let with_reply_to ~keeper_name request =
+  Keeper_id.Keeper_name.of_string keeper_name
+  |> Result.map (fun keeper_name ->
+    { request with reply_to = Some (Caller_keeper keeper_name) })
 ;;
 
 let request_target (request : request) = request.target
@@ -65,11 +79,26 @@ let request_direct_delivery (request : request) =
   | Direct_delivery payload -> Some payload
 ;;
 
+let request_reply_to (request : request) = request.reply_to
+
+let reply_to_keeper_name = function
+  | Caller_keeper name -> Keeper_id.Keeper_name.to_string name
+;;
+
 let request_equal (left : request) (right : request) =
   match left.target, right.target, left.capability, right.capability with
   | Keeper left_name, Keeper right_name, Invoke_turn, Invoke_turn ->
     Keeper_id.Keeper_name.equal left_name right_name
     && equal_input left.input right.input
+    && Option.equal ( = ) left.reply_to right.reply_to
+;;
+
+let reply_to_to_json = function
+  | Caller_keeper name ->
+    `Assoc
+      [ "kind", `String "keeper"
+      ; "name", `String (Keeper_id.Keeper_name.to_string name)
+      ]
 ;;
 
 let request_to_json (request : request) =
@@ -77,6 +106,7 @@ let request_to_json (request : request) =
     [ "target", target_to_json request.target
     ; "capability", `String "invoke_turn"
     ; "input", input_to_yojson request.input
+    ; "reply_to", Option.fold ~none:`Null ~some:reply_to_to_json request.reply_to
     ]
 ;;
 
@@ -99,10 +129,29 @@ let required_string ~field name fields =
   | Some _ | None -> Error (Printf.sprintf "%s.%s must be a string" field name)
 ;;
 
+let reply_to_of_json = function
+  | `Null -> Ok None
+  | json ->
+    let ( let* ) = Result.bind in
+    let* fields =
+      exact_object ~field:"request.reply_to" ~expected:[ "kind"; "name" ] json
+    in
+    let* kind = required_string ~field:"request.reply_to" "kind" fields in
+    let* keeper_name = required_string ~field:"request.reply_to" "name" fields in
+    if not (String.equal kind "keeper")
+    then Error "request.reply_to.kind must be keeper"
+    else
+      Keeper_id.Keeper_name.of_string keeper_name
+      |> Result.map (fun name -> Some (Caller_keeper name))
+;;
+
 let request_of_json json =
   let ( let* ) = Result.bind in
   let* fields =
-    exact_object ~field:"request" ~expected:[ "target"; "capability"; "input" ] json
+    exact_object
+      ~field:"request"
+      ~expected:[ "target"; "capability"; "input"; "reply_to" ]
+      json
   in
   let* target_json =
     match List.assoc_opt "target" fields with
@@ -124,6 +173,12 @@ let request_of_json json =
     input_of_yojson input_json
     |> Result.map_error (fun detail -> "request.input: " ^ detail)
   in
+  let* reply_to_json =
+    match List.assoc_opt "reply_to" fields with
+    | Some value -> Ok value
+    | None -> Error "request.reply_to is required"
+  in
+  let* reply_to = reply_to_of_json reply_to_json in
   let* () =
     if input_to_yojson input = input_json
     then Ok ()
@@ -134,9 +189,12 @@ let request_of_json json =
   else if not (String.equal capability "invoke_turn")
   then Error "request.capability must be invoke_turn"
   else
-    match input with
-    | Delegated_turn prompt -> keeper_turn ~keeper_name ~prompt
-    | Direct_delivery payload -> direct_turn ~keeper_name payload
+    let* request =
+      match input with
+      | Delegated_turn prompt -> keeper_turn ~keeper_name ~prompt
+      | Direct_delivery payload -> direct_turn ~keeper_name payload
+    in
+    Ok { request with reply_to }
 ;;
 
 let run_id reference = reference.run_id

--- a/lib/keeper_invocation_types/keeper_invocation_types.mli
+++ b/lib/keeper_invocation_types/keeper_invocation_types.mli
@@ -2,6 +2,7 @@
     execution and lane admission remain in the Keeper implementation. *)
 type capability = Invoke_turn
 type target = Keeper of Keeper_id.Keeper_name.t
+type reply_to = Caller_keeper of Keeper_id.Keeper_name.t
 
 type input =
   | Delegated_turn of string
@@ -25,11 +26,14 @@ val target_name : target -> string
 val target_to_json : target -> Yojson.Safe.t
 val keeper_turn : keeper_name:string -> prompt:string -> (request, string) result
 val direct_turn : keeper_name:string -> Keeper_direct_invocation.t -> (request, string) result
+val with_reply_to : keeper_name:string -> request -> (request, string) result
 val request_target : request -> target
 val request_capability : request -> capability
 val request_target_name : request -> string
 val request_prompt : request -> string
 val request_direct_delivery : request -> Keeper_direct_invocation.t option
+val request_reply_to : request -> reply_to option
+val reply_to_keeper_name : reply_to -> string
 val request_equal : request -> request -> bool
 val request_to_json : request -> Yojson.Safe.t
 val request_of_json : Yojson.Safe.t -> (request, string) result

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -112,9 +112,9 @@ and bg_job_completion = {
   (* correlates to an optional board evidence post; "" if none was created. *)
 }
 
-and bg_job_kind = Subprocess
-      (* RFC-0290: closed sum of background job kinds (v1 = [Subprocess]); a new
-         kind forces every match to add an arm rather than defaulting. *)
+and bg_job_kind =
+  | Subprocess
+  | Keeper_invocation
 
 and hitl_resolution_decision =
   | Hitl_approved
@@ -205,9 +205,11 @@ let hitl_resolution_decision_to_string = function
 
 let bg_job_kind_to_string = function
   | Subprocess -> "subprocess"
+  | Keeper_invocation -> "keeper_invocation"
 
 let bg_job_kind_of_string = function
   | "subprocess" -> Ok Subprocess
+  | "keeper_invocation" -> Ok Keeper_invocation
   | other -> Error (Printf.sprintf "unknown bg_job_kind: %s" other)
 
 type stimulus = {

--- a/lib/keeper_runtime/keeper_event_queue.mli
+++ b/lib/keeper_runtime/keeper_event_queue.mli
@@ -129,9 +129,11 @@ and bg_job_completion = {
     [bg_board_post_id] correlates to an optional board evidence post ("" if
     none). *)
 
-and bg_job_kind = Subprocess
-(** RFC-0290: background job kinds. Closed sum (v1 = [Subprocess]); a new kind
-    forces every match to add an arm rather than defaulting. *)
+and bg_job_kind =
+  | Subprocess
+  | Keeper_invocation
+(** Background completion kinds. [Keeper_invocation] carries the terminal
+    result of a delegated Keeper turn back to its caller lane. *)
 
 and bg_job_outcome =
   | Bg_ok of string  (** result payload *)

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -1622,6 +1622,7 @@ let process_single_turn ~user_row_origin ~queued_turn
            "canonical request terminal committed while its direct transcript checkpoint remains incomplete")
   in
   let publish_committed_completion
+      ~request_id:_
       (settlement : Keeper_msg_async.worker_settlement) =
     cleanup_direct_checkpoint ();
     let completion =

--- a/test/test_keeper_chat_direct_delivery.ml
+++ b/test/test_keeper_chat_direct_delivery.ml
@@ -540,7 +540,7 @@ let start_settlement ~ops ~background_sw ~base_path ~request_id ~f =
   let submitted_request_id =
     Keeper_msg_async.For_testing.submit
       ops
-      ~on_worker_settled:(fun value ->
+      ~on_worker_settled:(fun ~request_id:_ value ->
         if Atomic.compare_and_set delivered false true
         then Eio.Promise.resolve resolve_settlement value)
       ~background_sw

--- a/test/test_keeper_msg_async_terminal_event.ml
+++ b/test/test_keeper_msg_async_terminal_event.ml
@@ -96,7 +96,7 @@ let test_operator_cancel_running_worker_invokes_on_worker_aborted () =
             ~on_worker_aborted:(fun reason ->
               aborted := reason :: !aborted;
               Ok ())
-            ~on_worker_settled:(fun settlement ->
+            ~on_worker_settled:(fun ~request_id:_ settlement ->
               settled := settlement :: !settled)
             ~background_sw:sw
             ~base_path
@@ -294,7 +294,7 @@ let test_closed_background_switch_rejects_worker_acceptance () =
                     ~on_worker_aborted:(fun reason ->
                       aborted := reason :: !aborted;
                       Ok ())
-                    ~on_worker_settled:(fun settlement ->
+                    ~on_worker_settled:(fun ~request_id:_ settlement ->
                       settled := settlement :: !settled)
                     ~background_sw:sw
                     ~base_path

--- a/test/test_keeper_mutex_coverage.ml
+++ b/test/test_keeper_mutex_coverage.ml
@@ -726,7 +726,7 @@ let test_keeper_msg_async_running_double_write_failure_is_terminal_in_memory () 
        let request_id =
          Keeper_msg_async.For_testing.submit
            request_ops
-           ~on_worker_settled:(fun settlement ->
+           ~on_worker_settled:(fun ~request_id:_ settlement ->
              settlements := settlement :: !settlements)
            ~background_sw
            ~base_path
@@ -784,7 +784,7 @@ let test_keeper_msg_async_running_write_failure_projects_durable_marker_once () 
            ~on_worker_aborted:(fun reason ->
              aborts := reason :: !aborts;
              Ok ())
-           ~on_worker_settled:(fun settlement ->
+           ~on_worker_settled:(fun ~request_id:_ settlement ->
              settlements := settlement :: !settlements)
            ~background_sw
            ~base_path
@@ -1144,7 +1144,7 @@ let test_keeper_msg_async_explicit_cancel_retries_failed_worker_signal () =
            ~on_worker_aborted:(fun reason ->
              aborts := reason :: !aborts;
              Ok ())
-           ~on_worker_settled:(fun settlement ->
+           ~on_worker_settled:(fun ~request_id:_ settlement ->
              settlements := settlement :: !settlements)
            ~background_sw:sw
            ~base_path
@@ -1599,7 +1599,7 @@ let test_keeper_msg_async_integrity_conflict_projects_canonical_terminal () =
        let request_id =
          Keeper_msg_async.For_testing.submit
            request_ops
-           ~on_worker_settled:(fun settlement ->
+           ~on_worker_settled:(fun ~request_id:_ settlement ->
              settlements := settlement :: !settlements)
            ~background_sw:sw
            ~base_path
@@ -1695,7 +1695,7 @@ let test_keeper_msg_async_integrity_ambiguity_projects_exact_poll_error () =
        let settlements = ref [] in
        let request_id =
          Keeper_msg_async.submit
-           ~on_worker_settled:(fun settlement ->
+           ~on_worker_settled:(fun ~request_id:_ settlement ->
              settlements := settlement :: !settlements)
            ~background_sw:sw
            ~base_path

--- a/test/test_keeper_unified_turn_event_bus.ml
+++ b/test/test_keeper_unified_turn_event_bus.ml
@@ -11,6 +11,25 @@ module Invocation = Masc.Keeper_invocation_contract
 module Kmsg = Masc.Keeper_msg_async
 module Ops = Masc.Keeper_tool_surface_ops
 module Turn_outcome = Masc.Keeper_turn_outcome
+module Event_queue = Masc.Keeper_event_queue
+module Registry_queue = Masc.Keeper_registry_event_queue
+
+let with_temp_dir prefix f =
+  let path = Filename.temp_file prefix "" in
+  Unix.unlink path;
+  Unix.mkdir path 0o700;
+  let rec remove target =
+    if Sys.is_directory target
+    then (
+      Sys.readdir target
+      |> Array.iter (fun name -> remove (Filename.concat target name));
+      Unix.rmdir target)
+    else Unix.unlink target
+  in
+  Fun.protect
+    ~finally:(fun () -> Masc.Keeper_registry.clear (); remove path)
+    (fun () -> f path)
+;;
 
 let dummy_event payload =
   { Agent_sdk.Event_bus.meta =
@@ -483,6 +502,84 @@ let test_typed_keeper_invocation_wire_contract () =
     (List.mem_assoc "request_id" rejection_fields)
 ;;
 
+let test_keeper_completion_wake_is_typed_and_idempotent () =
+  with_temp_dir "keeper-completion-wake" @@ fun base_path ->
+  Masc.Keeper_registry.clear ();
+  let caller_meta =
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+         [ "name", `String "caller"
+         ; "agent_name", `String "keeper-caller-agent"
+         ; "trace_id", `String "caller-completion-wake-trace"
+         ])
+    |> Result.get_ok
+  in
+  ignore (Masc.Keeper_registry.register ~base_path "caller" caller_meta);
+  let raw_request =
+    Invocation.request ~keeper_name:"callee" ~prompt:"do work" |> Result.get_ok
+  in
+  let request =
+    match
+      Ops.For_testing.request_with_registered_reply_to
+        ~base_path
+        ~submitted_by:"keeper-caller-agent"
+        raw_request
+    with
+    | Ok request -> request
+    | Error _ -> Alcotest.fail "registered caller route rejected"
+  in
+  ignore (Masc.Keeper_registry.register ~base_path "caller-shadow" caller_meta);
+  (match
+     Ops.For_testing.request_with_registered_reply_to
+       ~base_path
+       ~submitted_by:"keeper-caller-agent"
+       raw_request
+   with
+   | Error (Ops.Ambiguous_caller_identity (_, 2)) -> ()
+   | _ -> Alcotest.fail "ambiguous caller identity was not rejected");
+  let durable_request =
+    Keeper_invocation_types.keeper_turn ~keeper_name:"callee" ~prompt:"do work"
+    |> Result.get_ok
+    |> Keeper_invocation_types.with_reply_to ~keeper_name:"caller"
+    |> Result.get_ok
+    |> Keeper_invocation_types.request_to_json
+    |> Keeper_invocation_types.request_of_json
+    |> Result.get_ok
+  in
+  check (option string) "reply-to survives durable codec" (Some "caller")
+    (durable_request
+     |> Keeper_invocation_types.request_reply_to
+     |> Option.map Keeper_invocation_types.reply_to_keeper_name);
+  let success =
+    Kmsg.Status_settlement
+      { status = Kmsg.Done { ok = true; body = "finished"; data = None }
+      ; durability = Kmsg.Durable
+      ; origin = Kmsg.Transition_commit
+      }
+  in
+  let project =
+    Ops.For_testing.project_keeper_completion
+      ~base_path
+      ~request
+      ~request_id:"run-success"
+  in
+  ignore (project success : Ops.keeper_completion_projection);
+  check bool "terminal replay reuses identity" true
+    (project success = Ops.Completion_already_present);
+  check bool "failure remains typed" true
+    (Ops.For_testing.terminal_completion_outcome (Kmsg.Lost { reason = "lost" })
+     = Some (Event_queue.Bg_failed "lost"));
+  let pending = Registry_queue.snapshot ~base_path "caller" |> Event_queue.to_list in
+  check int "one completion stimulus after replay" 1 (List.length pending);
+  match pending with
+  | [ { Event_queue.payload = Event_queue.Bg_completed completion; _ } ] ->
+    check bool "typed Keeper invocation kind" true
+      (completion.bg_kind = Event_queue.Keeper_invocation);
+    check bool "typed success outcome" true
+      (completion.bg_outcome = Event_queue.Bg_ok "finished");
+  | _ -> Alcotest.fail "expected one typed Keeper completion stimulus"
+;;
+
 let test_take_drain_cancel_clears_active_without_spin () =
   let open EB.For_testing in
   let t = EB.create ~keeper_name:"k" ~turn_id:1 () in
@@ -568,6 +665,8 @@ let () =
             test_keeper_invocation_result_contracts
         ; test_case "typed Keeper invocation wire contract" `Quick
             test_typed_keeper_invocation_wire_contract
+        ; test_case "Keeper completion wake is typed and idempotent" `Quick
+            test_keeper_completion_wake_is_typed_and_idempotent
         ] )
     ; ( "background-drain"
       , [ test_case "continues after first poll" `Quick


### PR DESCRIPTION
## What

- Persist an optional typed Caller_keeper reply route in the canonical Keeper invocation record and hard-cut the durable schema to v6.
- Resolve the submitting Keeper identity as an exact 0/1/many registry relation. One match binds the caller lane; many matches fail with a typed ambiguity error before submission.
- After an in-process worker terminal outcome is durably committed, project a typed Keeper_invocation Bg_completed stimulus to only the caller Keeper queue and signal that lane.
- Reuse the stable request identity so settlement replay is idempotent and does not duplicate the caller stimulus.
- Keep the caller submission fire-and-forget, so its lane can continue other work instead of polling or blocking.
- Repair the missing recover_record_path closing parenthesis inherited from the stacked base.

## Validation

- 398 changed lines (368 additions, 30 deletions).
- ocamlformat --check: pass for all touched ML/MLI files.
- ocamlc -stop-after parsing: pass for all touched ML/MLI files.
- git diff --check: pass.
- Focused wrapper attempted: scripts/dune-local.sh build test/test_keeper_unified_turn_event_bus.exe. It correctly refused because unrelated bare dune build processes currently bypass the shared machine lock; no override or process kill was used.
- Full type/build/test authority: PR CI.

The focused test covers typed durable reply-route round trip, exact caller routing, 0/1/many ambiguity rejection, typed success/failure outcomes, and exactly-one completion after replay.

## Honest scope

This cut is a live in-process, durable-commit-triggered completion notification. It is not yet a restart-safe durable join:

1. The terminal invocation record and caller queue are two separate stores. A crash between those commits, or a queue storage error, is not replayed after restart. The next stacked cut must add a durable delivery outbox/receipt plus a restart projector.
2. The downstream world observation currently renders a bounded preview. This PR does not claim full result reinjection. The next cut must carry a typed run_ref/artifact reference and let the caller consumer join the canonical full result.
3. Synchronous acceptance or background-fork failures remain synchronous submission failures and do not emit this async completion callback.

## Stack

Base: #24677 (canonical direct-checkpoint/request-journal join).
This PR intentionally does not introduce a generic Any abstraction. It closes one typed Keeper-to-Keeper continuation slice using existing lane and background-completion contracts.