### PR TITLE
fix(keeper): drop checkpoint save-path read-modify-write

### DIFF
--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -391,6 +391,67 @@ let load_canonical_strict path =
   | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
   | exception exn -> Error (Io_error (Printexc.to_string exn))
 
+(* masc P0 perf fix (checkpoint save-path read-modify-write): every save
+   transaction for one session runs under [with_session_lock_typed], which
+   serializes writers for that [canonical_path] across Eio fibers, raw
+   Domains, and other OS processes (Eio.Mutex + Stdlib.Mutex + flock -- see
+   File_lock_eio). Inside that single-writer critical section, a
+   process-local watermark is exactly as authoritative as a fresh
+   [load_canonical_strict] of the same path, because every successful write
+   updates the cache before the session lock is released. A cache miss
+   (process cold-start, or a session this process has never written) always
+   falls back to [load_canonical_strict], preserving the original
+   crash-recovery contract: RFC-0225 §3.2's "disk is the only admission
+   watermark" invariant now reads as "disk is the only watermark this
+   process has not already durably confirmed."
+
+   The per-session lock does NOT protect the cache table itself: two
+   DIFFERENT sessions' transactions run under two different lock_paths and
+   can hold their save transactions concurrently on different Domains (the
+   payload encode step already runs on the executor pool -- see
+   [Executor_pool_ref.submit_or_inline] in [Keeper_fs]), so every access to
+   [watermark_cache] -- a plain, non-domain-safe Hashtbl -- is additionally
+   guarded by a dedicated [Stdlib.Mutex.t]. A plain OS mutex (not the
+   cooperative-yield [File_lock_eio] machinery) is enough here because the
+   guarded section is always a single O(1) Hashtbl operation: it is only ever
+   held across [load_canonical_strict]'s disk I/O by NOT wrapping that call,
+   so a cache miss for one session cannot stall a concurrent cache hit for
+   another, and the brief cross-domain wait this mutex can impose is
+   negligible next to the disk read it replaces.
+
+   This does not protect against a writer bypassing [save_oas_classified]
+   entirely (e.g. an operator manually restoring a checkpoint file while the
+   server keeps running) -- rg confirms [oas_checkpoint_path] has exactly one
+   production writer in lib/ (this module); every other reference is a
+   read-only dashboard/history consumer. See the PR body for the full audit. *)
+type watermark = { session_id : string; turn_count : int }
+
+let watermark_cache : (string, watermark) Hashtbl.t = Hashtbl.create 64
+let watermark_cache_mu = Stdlib.Mutex.create ()
+
+let find_cached_watermark canonical_path =
+  Stdlib.Mutex.protect watermark_cache_mu (fun () ->
+    Hashtbl.find_opt watermark_cache canonical_path)
+
+let record_watermark canonical_path watermark =
+  Stdlib.Mutex.protect watermark_cache_mu (fun () ->
+    Hashtbl.replace watermark_cache canonical_path watermark)
+
+let known_watermark ~canonical_path
+  : (watermark option, checkpoint_load_error) result =
+  match find_cached_watermark canonical_path with
+  | Some cached -> Ok (Some cached)
+  | None ->
+    (match load_canonical_strict canonical_path with
+     | Error _ as error -> error
+     | Ok None -> Ok None
+     | Ok (Some existing) ->
+       let watermark =
+         { session_id = existing.session_id; turn_count = existing.turn_count }
+       in
+       record_watermark canonical_path watermark;
+       Ok (Some watermark))
+
 let save_oas_classified_typed
     ~(session_dir : string)
     (ckpt : Agent_sdk.Checkpoint.t)
@@ -401,7 +462,7 @@ let save_oas_classified_typed
     with_session_lock_typed ~session_dir (fun session_dir ->
       let session_id = Keeper_id.Trace_id.to_string trace_id in
       let canonical_path = oas_checkpoint_path ~session_dir ~session_id in
-      match load_canonical_strict canonical_path with
+      match known_watermark ~canonical_path with
       | Error error -> Error (Existing_checkpoint_unreadable error)
       | Ok (Some existing) when not (String.equal existing.session_id session_id) ->
         Error
@@ -424,16 +485,18 @@ let save_oas_classified_typed
              ; known_turn_count = existing.turn_count
              })
       | Ok existing ->
-        let known = Option.map (fun checkpoint -> checkpoint.Agent_sdk.Checkpoint.turn_count) existing in
+        let known = Option.map (fun (w : watermark) -> w.turn_count) existing in
         let ownership_root = Filename.dirname session_dir in
         (match
            Keeper_fs.save_json_durable_atomic
              ~ownership_root
+             ~pretty:false
              canonical_path
              (Agent_sdk.Checkpoint.to_json ckpt)
          with
          | Error error -> Error (Canonical_write_failed error)
          | Ok () ->
+           record_watermark canonical_path { session_id; turn_count = ckpt.turn_count };
            archive_oas_history_best_effort ~session_dir ckpt;
            Ok
              (Saved

--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -391,66 +391,176 @@ let load_canonical_strict path =
   | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
   | exception exn -> Error (Io_error (Printexc.to_string exn))
 
-(* masc P0 perf fix (checkpoint save-path read-modify-write): every save
-   transaction for one session runs under [with_session_lock_typed], which
-   serializes writers for that [canonical_path] across Eio fibers, raw
-   Domains, and other OS processes (Eio.Mutex + Stdlib.Mutex + flock -- see
-   File_lock_eio). Inside that single-writer critical section, a
-   process-local watermark is exactly as authoritative as a fresh
-   [load_canonical_strict] of the same path, because every successful write
-   updates the cache before the session lock is released. A cache miss
-   (process cold-start, or a session this process has never written) always
-   falls back to [load_canonical_strict], preserving the original
-   crash-recovery contract: RFC-0225 §3.2's "disk is the only admission
-   watermark" invariant now reads as "disk is the only watermark this
-   process has not already durably confirmed."
+(* masc P0 perf fix (checkpoint save-path read-modify-write): a prior
+   revision of this fix cached the watermark in a process-local Hashtbl.
+   That is exactly the structure #24561 (commit 20536cacbf, "make canonical
+   disk the watermark SSOT") deliberately removed: RFC-0225 §3.2 requires
+   the canonical file to be the *only* admission watermark, with no
+   process-local truth retained, because a process-local cache can drift
+   from disk across execution contexts (raw Domain vs Eio fiber; see the
+   companion #24548 fix distinguishing them) in ways a single process
+   cannot observe. This revision keeps that invariant: there is no
+   in-memory watermark state anywhere in this module.
 
-   The per-session lock does NOT protect the cache table itself: two
-   DIFFERENT sessions' transactions run under two different lock_paths and
-   can hold their save transactions concurrently on different Domains (the
-   payload encode step already runs on the executor pool -- see
-   [Executor_pool_ref.submit_or_inline] in [Keeper_fs]), so every access to
-   [watermark_cache] -- a plain, non-domain-safe Hashtbl -- is additionally
-   guarded by a dedicated [Stdlib.Mutex.t]. A plain OS mutex (not the
-   cooperative-yield [File_lock_eio] machinery) is enough here because the
-   guarded section is always a single O(1) Hashtbl operation: it is only ever
-   held across [load_canonical_strict]'s disk I/O by NOT wrapping that call,
-   so a cache miss for one session cannot stall a concurrent cache hit for
-   another, and the brief cross-domain wait this mutex can impose is
-   negligible next to the disk read it replaces.
+   Instead, a tiny fingerprinted sidecar file sits beside the canonical
+   checkpoint ([watermark_sidecar_path]) and is written inside the *same*
+   [with_session_lock_typed] transaction as the canonical write, so it is
+   never observed half-updated relative to canonical. It stores
+   [session_id], [turn_count], and the canonical file's own [size]/[mtime]
+   fingerprint at write time.
 
-   This does not protect against a writer bypassing [save_oas_classified]
-   entirely (e.g. an operator manually restoring a checkpoint file while the
-   server keeps running) -- rg confirms [oas_checkpoint_path] has exactly one
-   production writer in lib/ (this module); every other reference is a
-   read-only dashboard/history consumer. See the PR body for the full audit. *)
+   On the next save, [known_watermark] `stat`s the canonical file and
+   compares that fresh fingerprint against the sidecar's recorded one:
+   - Match: the sidecar's (session_id, turn_count) is trusted without
+     re-parsing the (0.7-1.37MB pretty-printed) canonical JSON.
+   - Mismatch, sidecar missing, or sidecar unparseable: falls back to the
+     original [load_canonical_strict] full parse unconditionally (the exact
+     path this module used before this fix), then re-derives the
+     fingerprint from the just-read canonical file and rewrites the
+     sidecar to heal it for the next save.
+
+   The canonical file is still the *only* source of truth: every decision
+   is re-verified against a fresh `stat` on every single call, so nothing
+   is ever trusted across process boundaries or execution contexts without
+   re-checking disk. A crash between the canonical write and the sidecar
+   write leaves a stale/absent sidecar, which the next save's fingerprint
+   check (or missing-sidecar check) detects and heals via the full-parse
+   fallback -- no special-cased recovery logic is required. *)
+
+let watermark_sidecar_path canonical_path = canonical_path ^ ".watermark.json"
+
+type sidecar_watermark =
+  { session_id : string
+  ; turn_count : int
+  ; canonical_size : int
+  ; canonical_mtime : float
+  }
+
+let sidecar_watermark_to_json (w : sidecar_watermark) : Yojson.Safe.t =
+  `Assoc
+    [ ("session_id", `String w.session_id)
+    ; ("turn_count", `Int w.turn_count)
+    ; ("canonical_size", `Int w.canonical_size)
+    ; ("canonical_mtime", `Float w.canonical_mtime)
+    ]
+
+let sidecar_watermark_of_json (json : Yojson.Safe.t) : sidecar_watermark option =
+  match
+    ( Json_util.get_string json "session_id"
+    , Json_util.get_int json "turn_count"
+    , Json_util.get_int json "canonical_size"
+    , Json_util.get_float json "canonical_mtime" )
+  with
+  | Some session_id, Some turn_count, Some canonical_size, Some canonical_mtime ->
+    Some { session_id; turn_count; canonical_size; canonical_mtime }
+  | _ -> None
+
+(* [Fs_compat.file_size]/[file_mtime] already dispatch Eio-native vs. Unix
+   fallback correctly for both Eio fibers and raw Domains ([with_fs_or_fallback]
+   catches [Stdlib.Effect.Unhandled] and retries on the blocking path), so no
+   separate execution-context check is needed here. Both return [None]
+   uniformly for "does not exist" and "stat failed for any other reason";
+   either way the caller has nothing trustworthy to fast-path against and
+   defers entirely to [load_canonical_strict], which already classifies
+   ENOENT vs. real I/O errors correctly. *)
+let canonical_fingerprint canonical_path : (int * float) option =
+  match Fs_compat.file_size canonical_path, Fs_compat.file_mtime canonical_path with
+  | Some size, Some mtime -> Some (size, mtime)
+  | _ -> None
+
+let load_sidecar_watermark sidecar_path : sidecar_watermark option =
+  match Fs_compat.load_file_opt sidecar_path with
+  | exception _ -> None
+  | None -> None
+  | Some raw ->
+    (match Yojson.Safe.from_string raw with
+     | json -> sidecar_watermark_of_json json
+     | exception _ -> None)
+
+let save_sidecar_watermark_best_effort sidecar_path (w : sidecar_watermark) : unit =
+  try Fs_compat.save_file sidecar_path (Yojson.Safe.to_string (sidecar_watermark_to_json w)) with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Log.Keeper.warn
+      "checkpoint watermark sidecar write failed for %s: %s"
+      sidecar_path (Printexc.to_string exn);
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string CheckpointFailures)
+      ~labels:
+        [ ( "site"
+          , Keeper_checkpoint_store_failure_site.(to_label Oas_watermark_sidecar) )
+        ]
+      ()
+
 type watermark = { session_id : string; turn_count : int }
 
-let watermark_cache : (string, watermark) Hashtbl.t = Hashtbl.create 64
-let watermark_cache_mu = Stdlib.Mutex.create ()
+type watermark_fast_path_miss_reason =
+  | No_canonical_file
+  | Sidecar_unusable
+  | Fingerprint_mismatch
 
-let find_cached_watermark canonical_path =
-  Stdlib.Mutex.protect watermark_cache_mu (fun () ->
-    Hashtbl.find_opt watermark_cache canonical_path)
+let watermark_fast_path_miss_reason_to_string = function
+  | No_canonical_file -> "no_canonical_file"
+  | Sidecar_unusable -> "sidecar_unusable"
+  | Fingerprint_mismatch -> "fingerprint_mismatch"
 
-let record_watermark canonical_path watermark =
-  Stdlib.Mutex.protect watermark_cache_mu (fun () ->
-    Hashtbl.replace watermark_cache canonical_path watermark)
+(* Test-only instrumentation: proves the fast path actually skips
+   [load_canonical_strict] rather than merely returning the right answer by
+   coincidence (RFC-0342-style falsifiable claim, not a production metric). *)
+module For_testing = struct
+  let full_parse_count = Atomic.make 0
+  let reset_full_parse_count () = Atomic.set full_parse_count 0
+  let get_full_parse_count () = Atomic.get full_parse_count
+end
+
+let full_parse_fallback ~canonical_path ~sidecar_path ~reason
+  : (watermark option, checkpoint_load_error) result =
+  Atomic.incr For_testing.full_parse_count;
+  Log.Keeper.info
+    "checkpoint watermark sidecar fast-path miss for %s: %s -- falling back to full parse"
+    canonical_path (watermark_fast_path_miss_reason_to_string reason);
+  Otel_metric_store.inc_counter
+    "masc_keeper_checkpoint_watermark_fastpath_miss_total"
+    ~labels:[("reason", watermark_fast_path_miss_reason_to_string reason)]
+    ();
+  match load_canonical_strict canonical_path with
+  | Error _ as error -> error
+  | Ok None -> Ok None
+  | Ok (Some existing) ->
+    let watermark =
+      { session_id = existing.session_id; turn_count = existing.turn_count }
+    in
+    (match canonical_fingerprint canonical_path with
+     | Some (size, mtime) ->
+       save_sidecar_watermark_best_effort sidecar_path
+         { session_id = watermark.session_id
+         ; turn_count = watermark.turn_count
+         ; canonical_size = size
+         ; canonical_mtime = mtime
+         }
+     | None ->
+       (* The file we just successfully read is now unstatable (deleted out
+          from under us despite the session lock, or a transient stat
+          failure). Not fatal: the sidecar is left as-is and the next save's
+          fingerprint check will simply miss again and re-heal it. *)
+       ());
+    Ok (Some watermark)
 
 let known_watermark ~canonical_path
   : (watermark option, checkpoint_load_error) result =
-  match find_cached_watermark canonical_path with
-  | Some cached -> Ok (Some cached)
-  | None ->
-    (match load_canonical_strict canonical_path with
-     | Error _ as error -> error
-     | Ok None -> Ok None
-     | Ok (Some existing) ->
-       let watermark =
-         { session_id = existing.session_id; turn_count = existing.turn_count }
-       in
-       record_watermark canonical_path watermark;
-       Ok (Some watermark))
+  let sidecar_path = watermark_sidecar_path canonical_path in
+  match canonical_fingerprint canonical_path with
+  | None -> full_parse_fallback ~canonical_path ~sidecar_path ~reason:No_canonical_file
+  | Some (size, mtime) ->
+    (match load_sidecar_watermark sidecar_path with
+     | Some sidecar
+       when Int.equal sidecar.canonical_size size
+         && Float.equal sidecar.canonical_mtime mtime ->
+       Ok (Some { session_id = sidecar.session_id; turn_count = sidecar.turn_count })
+     | Some _ ->
+       full_parse_fallback ~canonical_path ~sidecar_path ~reason:Fingerprint_mismatch
+     | None ->
+       full_parse_fallback ~canonical_path ~sidecar_path ~reason:Sidecar_unusable)
 
 let save_oas_classified_typed
     ~(session_dir : string)
@@ -496,7 +606,20 @@ let save_oas_classified_typed
          with
          | Error error -> Error (Canonical_write_failed error)
          | Ok () ->
-           record_watermark canonical_path { session_id; turn_count = ckpt.turn_count };
+           (match canonical_fingerprint canonical_path with
+            | Some (size, mtime) ->
+              save_sidecar_watermark_best_effort
+                (watermark_sidecar_path canonical_path)
+                { session_id
+                ; turn_count = ckpt.turn_count
+                ; canonical_size = size
+                ; canonical_mtime = mtime
+                }
+            | None ->
+              (* The file we just durably wrote is now unstatable. Not fatal
+                 to this save -- the next save's fingerprint check will miss
+                 (no sidecar to trust) and fall back to a full parse. *)
+              ());
            archive_oas_history_best_effort ~session_dir ckpt;
            Ok
              (Saved

--- a/lib/keeper/keeper_checkpoint_store.mli
+++ b/lib/keeper/keeper_checkpoint_store.mli
@@ -6,6 +6,16 @@
 val oas_checkpoint_path :
   session_dir:string -> session_id:string -> string
 
+(** Path of the fingerprinted watermark sidecar beside a canonical
+    checkpoint file ([<canonical_path>.watermark.json]). RFC-0225 §3.2:
+    the sidecar records [session_id], [turn_count], and the canonical
+    file's own [size]/[mtime] fingerprint at write time, so a later save
+    can skip re-parsing the full canonical JSON when the fingerprint still
+    matches. It is never treated as a source of truth on its own -- every
+    read re-verifies it against a fresh [stat] of the canonical file, and
+    any mismatch, absence, or corruption falls back to a full parse. *)
+val watermark_sidecar_path : string -> string
+
 (** [oas-snapshot-] prefix on OAS history archive entries. *)
 val oas_history_prefix : string
 
@@ -116,3 +126,16 @@ val load_oas :
   session_dir:string ->
   session_id:string ->
   (Agent_sdk.Checkpoint.t, checkpoint_load_error) result
+
+module For_testing : sig
+  (** Number of times the checkpoint watermark resolution has fallen back to
+      a full canonical-file parse (sidecar absent, corrupt, or fingerprint
+      mismatch) since the last {!reset_full_parse_count}. Exists so a test
+      can prove the sidecar fast path actually skips
+      [load_canonical_strict] rather than merely returning the right answer
+      by coincidence. *)
+  val get_full_parse_count : unit -> int
+
+  (** Reset {!get_full_parse_count} to zero. *)
+  val reset_full_parse_count : unit -> unit
+end

--- a/lib/keeper/keeper_fs.ml
+++ b/lib/keeper/keeper_fs.ml
@@ -278,6 +278,7 @@ let save_json_durable_atomic_from_with
       ?before_directory_fsync
       ?ownership_root
       ?temp_dir
+      ?(pretty = true)
       path
       json_source
   =
@@ -285,6 +286,9 @@ let save_json_durable_atomic_from_with
   (* DET-OK: an omitted staging directory means the destination directory;
      both paths are derived from the same explicit destination [path]. *)
   let temp_dir = Option.value temp_dir ~default:dir in
+  let encode json =
+    if pretty then Yojson.Safe.pretty_to_string json else Yojson.Safe.to_string json
+  in
   try
     let content =
       run_durable_write_stage
@@ -292,8 +296,7 @@ let save_json_durable_atomic_from_with
         ~before_stage
         Payload_encode
         (fun () ->
-           Executor_pool_ref.submit_or_inline (fun () ->
-             Yojson.Safe.pretty_to_string (json_source ())))
+           Executor_pool_ref.submit_or_inline (fun () -> encode (json_source ())))
     in
     let directory_lease =
       ensure_dir_durable
@@ -436,6 +439,7 @@ let save_json_durable_atomic_with
       ?before_directory_fsync
       ?ownership_root
       ?temp_dir
+      ?pretty
       path
       json
   =
@@ -444,24 +448,27 @@ let save_json_durable_atomic_with
     ?before_directory_fsync
     ?ownership_root
     ?temp_dir
+    ?pretty
     path
     (fun () -> json)
 ;;
 
-let save_json_durable_atomic ?ownership_root ?temp_dir path json =
+let save_json_durable_atomic ?ownership_root ?temp_dir ?pretty path json =
   save_json_durable_atomic_with
     ~before_stage:(fun _ -> ())
     ?ownership_root
     ?temp_dir
+    ?pretty
     path
     json
 ;;
 
-let save_json_durable_atomic_from ?ownership_root ?temp_dir path json_source =
+let save_json_durable_atomic_from ?ownership_root ?temp_dir ?pretty path json_source =
   save_json_durable_atomic_from_with
     ~before_stage:(fun _ -> ())
     ?ownership_root
     ?temp_dir
+    ?pretty
     path
     json_source
 ;;
@@ -548,6 +555,7 @@ module For_testing = struct
         ?before_directory_fsync
         ?ownership_root
         ?temp_dir
+        ?pretty
         path
         json
     =
@@ -556,6 +564,7 @@ module For_testing = struct
       ?before_directory_fsync
       ?ownership_root
       ?temp_dir
+      ?pretty
       path
       json
   ;;
@@ -565,6 +574,7 @@ module For_testing = struct
         ?before_directory_fsync
         ?ownership_root
         ?temp_dir
+        ?pretty
         path
         json_source
     =
@@ -573,6 +583,7 @@ module For_testing = struct
       ?before_directory_fsync
       ?ownership_root
       ?temp_dir
+      ?pretty
       path
       json_source
   ;;

--- a/lib/keeper/keeper_fs.mli
+++ b/lib/keeper/keeper_fs.mli
@@ -65,10 +65,15 @@ type durable_write_error =
     [ownership_root] is supplied, both directory chains must be lexically
     contained below it and symbolic-link components are rejected. The caller
     keeps that subtree process-owned while the write runs because OCaml 5.4
-    has no portable dirfd-relative rename API. *)
+    has no portable dirfd-relative rename API. [pretty] (default [true])
+    selects [Yojson.Safe.pretty_to_string] vs [Yojson.Safe.to_string]; pass
+    [~pretty:false] for machine-only artifacts that are never read directly by
+    a human (e.g. checkpoint payloads, which pretty-print to 0.7-1.4MB and are
+    only ever consumed through a JSON parser). *)
 val save_json_durable_atomic
   :  ?ownership_root:string
   -> ?temp_dir:string
+  -> ?pretty:bool
   -> string
   -> Yojson.Safe.t
   -> (unit, durable_write_error) result
@@ -77,10 +82,12 @@ val save_json_durable_atomic
     the process executor pool when it is available. [json_source] must be a
     pure closure. This keeps large queue snapshots from monopolizing the Eio
     scheduler while preserving the same atomic publication and ownership
-    contract; blocking filesystem operations still run in a systhread. *)
+    contract; blocking filesystem operations still run in a systhread. [pretty]
+    has the same meaning as on {!save_json_durable_atomic}. *)
 val save_json_durable_atomic_from
   :  ?ownership_root:string
   -> ?temp_dir:string
+  -> ?pretty:bool
   -> string
   -> (unit -> Yojson.Safe.t)
   -> (unit, durable_write_error) result
@@ -115,6 +122,7 @@ module For_testing : sig
     -> ?before_directory_fsync:(string -> unit)
     -> ?ownership_root:string
     -> ?temp_dir:string
+    -> ?pretty:bool
     -> string
     -> Yojson.Safe.t
     -> (unit, durable_write_error) result
@@ -124,6 +132,7 @@ module For_testing : sig
     -> ?before_directory_fsync:(string -> unit)
     -> ?ownership_root:string
     -> ?temp_dir:string
+    -> ?pretty:bool
     -> string
     -> (unit -> Yojson.Safe.t)
     -> (unit, durable_write_error) result

--- a/lib/keeper_failure_taxonomy/keeper_checkpoint_store_failure_site.ml
+++ b/lib/keeper_failure_taxonomy/keeper_checkpoint_store_failure_site.ml
@@ -3,10 +3,12 @@ type t =
   | Oas_save
   | Oas_delete
   | Oas_archive
+  | Oas_watermark_sidecar
 
 let to_label = function
   | Oas_cleanup -> "oas_cleanup"
   | Oas_save -> "oas_save"
   | Oas_delete -> "oas_delete"
   | Oas_archive -> "oas_archive"
+  | Oas_watermark_sidecar -> "oas_watermark_sidecar"
 ;;

--- a/lib/keeper_failure_taxonomy/keeper_checkpoint_store_failure_site.mli
+++ b/lib/keeper_failure_taxonomy/keeper_checkpoint_store_failure_site.mli
@@ -7,5 +7,6 @@ type t =
   | Oas_save (** OAS checkpoint primary save failed. *)
   | Oas_delete (** OAS checkpoint delete failed. *)
   | Oas_archive (** OAS checkpoint history archive failed. *)
+  | Oas_watermark_sidecar (** OAS checkpoint watermark sidecar write failed (best-effort; canonical write already succeeded). *)
 
 val to_label : t -> string

--- a/test/test_keeper_checkpoint_stale_guard.ml
+++ b/test/test_keeper_checkpoint_stale_guard.ml
@@ -7,11 +7,14 @@
     than the canonical checkpoint observed inside the save transaction, without
     turning that watermark hit into keeper lifecycle failure.
 
-    Also covers the checkpoint save-path read-modify-write perf fix: an
-    in-process watermark cache replaces the unconditional canonical-file
-    reload on every save (cache-miss/cache-hit semantics must match the
-    disk-only behavior above bit-for-bit), and the canonical file itself is
-    now written compact rather than pretty-printed. *)
+    Also covers the checkpoint save-path read-modify-write perf fix: a
+    fingerprinted sidecar file (size + mtime of the canonical file) lets a
+    save skip re-parsing the canonical JSON when nothing has touched it
+    since the sidecar was written, while every decision is still re-verified
+    against a fresh disk `stat` (no process-local watermark state -- see
+    #24561 / commit 20536cacbf, which removed exactly that structure for
+    this reason). The canonical file itself is now written compact rather
+    than pretty-printed. *)
 
 open Alcotest
 open Masc
@@ -113,12 +116,13 @@ let test_forward_equal_and_stale () =
     | Error _ -> fail "load after rejection failed")
 
 (* The canonical checkpoint file is still the only durable admission
-   watermark: whether a given decision is served from the in-process
-   watermark cache or backfilled from [load_canonical_strict], the disk file
-   is always the ground truth the cache mirrors. This test exercises a
-   session already warm in this process's cache (the seed save populates it);
-   [test_cache_miss_backfills_from_a_pre_existing_canonical_file] below
-   exercises the genuine cache-miss / cold-start path. *)
+   watermark (RFC-0225 §3.2). This save's stale-check happens to be served
+   by the fingerprint-matched sidecar fast path (nothing touched the
+   canonical file between the seed save and the stale check, so the sidecar
+   [size]/[mtime] fingerprint still matches) -- [test_fingerprint_match_skips_full_parse]
+   below proves that explicitly via the parse-count hook; this test only
+   asserts the observable outcome is unchanged from the pre-sidecar
+   disk-only behavior. *)
 let test_disk_is_the_watermark_ssot () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
@@ -141,63 +145,132 @@ let test_disk_is_the_watermark_ssot () =
     save_ok ~session_dir (make_checkpoint ~session_id:sid ~turn_count:9 ~marker:"v9")
       "forward save from disk SSOT")
 
-(* Cache-miss path: this process has never written this session's canonical
-   file, so it is not in the in-memory watermark cache -- a checkpoint placed
-   on disk by writing bytes directly (standing in for a different process, or
-   this process before a restart) must still be discovered and honored. *)
-let test_cache_miss_backfills_from_a_pre_existing_canonical_file () =
+(* RFC-0225 §3.2 fast path: once a session's sidecar fingerprint matches the
+   canonical file's current (size, mtime), [load_canonical_strict] must not
+   run again. A correct answer alone would not distinguish "read the
+   sidecar" from "re-parsed canonical and happened to get the same result",
+   so this asserts the parse-count hook directly. *)
+let test_fingerprint_match_skips_full_parse () =
   let session_dir = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir session_dir) (fun () ->
-    let sid = "sess-preexisting-on-disk" in
-    let path = Keeper_checkpoint_store.oas_checkpoint_path ~session_dir ~session_id:sid in
-    Fs_compat.save_file path
-      (make_checkpoint ~session_id:sid ~turn_count:8 ~marker:"v8-on-disk"
-       |> Agent_sdk.Checkpoint.to_string);
-    match
-      Keeper_checkpoint_store.save_oas_classified ~session_dir
-        (make_checkpoint ~session_id:sid ~turn_count:3 ~marker:"v3-stale")
-    with
-    | Ok (Keeper_checkpoint_store.Stale_noop
-            { incoming_turn_count; known_turn_count }) ->
-      check int "cache-miss stale incoming turn_count" 3 incoming_turn_count;
-      check int "cache-miss known turn_count backfilled from disk" 8 known_turn_count
-    | Ok (Keeper_checkpoint_store.Saved _) ->
-      fail "stale save advanced on a cache-miss backfill"
-    | Error e -> fail ("cache-miss stale save returned lifecycle failure: " ^ e))
-
-(* Cache-hit path: once a session's watermark is warm in this process, a
-   later decision for the same canonical path must not re-read the file --
-   proven behaviorally by corrupting the on-disk bytes after the cache is
-   warm and observing that both a stale rejection and a forward write still
-   succeed from the cache, instead of failing on a disk parse error. *)
-let test_cache_hit_survives_disk_corruption () =
-  let session_dir = temp_dir () in
-  Fun.protect ~finally:(fun () -> cleanup_dir session_dir) (fun () ->
-    let sid = "sess-cache-warm" in
-    let path = Keeper_checkpoint_store.oas_checkpoint_path ~session_dir ~session_id:sid in
+    let sid = "sess-fastpath" in
+    Keeper_checkpoint_store.For_testing.reset_full_parse_count ();
     save_ok ~session_dir (make_checkpoint ~session_id:sid ~turn_count:5 ~marker:"v5")
-      "seed save (warms the cache)";
-    Fs_compat.save_file path "{not-a-checkpoint-anymore";
+      "seed save (cold: no canonical file yet, so this necessarily falls back once)";
+    check int "cold seed save runs exactly one full-parse fallback" 1
+      (Keeper_checkpoint_store.For_testing.get_full_parse_count ());
+    Keeper_checkpoint_store.For_testing.reset_full_parse_count ();
+    save_ok ~session_dir (make_checkpoint ~session_id:sid ~turn_count:6 ~marker:"v6")
+      "forward save served by the sidecar fast path";
+    check int "fingerprint-matched forward save skips the full parse" 0
+      (Keeper_checkpoint_store.For_testing.get_full_parse_count ());
+    (match
+       Keeper_checkpoint_store.save_oas_classified ~session_dir
+         (make_checkpoint ~session_id:sid ~turn_count:4 ~marker:"v4-stale")
+     with
+     | Ok (Keeper_checkpoint_store.Stale_noop
+             { incoming_turn_count; known_turn_count }) ->
+       check int "fast-path stale incoming turn_count" 4 incoming_turn_count;
+       check int "fast-path known turn_count" 6 known_turn_count
+     | Ok (Keeper_checkpoint_store.Saved _) -> fail "stale save advanced via the fast path"
+     | Error e -> fail ("fast-path stale save returned lifecycle failure: " ^ e));
+    check int "fingerprint-matched stale check also skips the full parse" 0
+      (Keeper_checkpoint_store.For_testing.get_full_parse_count ()))
+
+(* Sidecar absent or corrupt: the fast path must never blindly trust a
+   missing/unparseable sidecar. Both sub-cases fall back to the ORIGINAL
+   full-parse path unconditionally (the exact path this module used before
+   this fix) and heal the sidecar afterward so the next save can use the
+   fast path again. *)
+let test_sidecar_unusable_falls_back_to_full_parse () =
+  let session_dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir session_dir) (fun () ->
+    let sid = "sess-sidecar-unusable" in
+    let sidecar_path =
+      Keeper_checkpoint_store.watermark_sidecar_path
+        (Keeper_checkpoint_store.oas_checkpoint_path ~session_dir ~session_id:sid)
+    in
+    save_ok ~session_dir (make_checkpoint ~session_id:sid ~turn_count:8 ~marker:"v8")
+      "seed save (writes canonical + sidecar)";
+    check bool "seed save writes a sidecar" true (Fs_compat.file_exists sidecar_path);
+    (* Sub-case 1: sidecar deleted outright. *)
+    Sys.remove sidecar_path;
+    Keeper_checkpoint_store.For_testing.reset_full_parse_count ();
     (match
        Keeper_checkpoint_store.save_oas_classified ~session_dir
          (make_checkpoint ~session_id:sid ~turn_count:3 ~marker:"v3-stale")
      with
      | Ok (Keeper_checkpoint_store.Stale_noop
              { incoming_turn_count; known_turn_count }) ->
-       check int "warm-cache stale incoming turn_count" 3 incoming_turn_count;
-       check int "warm-cache known turn_count served from cache" 5 known_turn_count
+       check int "sidecar-absent stale incoming turn_count" 3 incoming_turn_count;
+       check int "sidecar-absent known turn_count recovered from canonical" 8 known_turn_count
+     | Ok (Keeper_checkpoint_store.Saved _) -> fail "stale save advanced with an absent sidecar"
+     | Error e -> fail ("sidecar-absent stale save returned lifecycle failure: " ^ e));
+    check bool "sidecar-absent path ran the full-parse fallback" true
+      (Keeper_checkpoint_store.For_testing.get_full_parse_count () > 0);
+    check bool "the fallback healed the sidecar" true (Fs_compat.file_exists sidecar_path);
+    (* Sub-case 2: sidecar present but corrupt (unparseable JSON). *)
+    Fs_compat.save_file sidecar_path "{not-json";
+    Keeper_checkpoint_store.For_testing.reset_full_parse_count ();
+    (match
+       Keeper_checkpoint_store.save_oas_classified ~session_dir
+         (make_checkpoint ~session_id:sid ~turn_count:2 ~marker:"v2-stale")
+     with
+     | Ok (Keeper_checkpoint_store.Stale_noop
+             { incoming_turn_count; known_turn_count }) ->
+       check int "corrupt-sidecar stale incoming turn_count" 2 incoming_turn_count;
+       check int "corrupt-sidecar known turn_count recovered from canonical" 8 known_turn_count
+     | Ok (Keeper_checkpoint_store.Saved _) -> fail "stale save advanced with a corrupt sidecar"
+     | Error e -> fail ("corrupt-sidecar stale save returned lifecycle failure: " ^ e));
+    check bool "corrupt-sidecar path ran the full-parse fallback" true
+      (Keeper_checkpoint_store.For_testing.get_full_parse_count () > 0))
+
+(* Fingerprint mismatch: a canonical write that bypasses [save_oas_classified]
+   (a different writer, or a crash between a writer's own canonical write and
+   its sidecar update) leaves the sidecar stale relative to disk. The next
+   save must detect the (size, mtime) mismatch and recover the REAL watermark
+   from a full parse of canonical, not the stale sidecar's belief -- this is
+   exactly the drift the removed in-memory cache (#24561 / commit 20536cacbf)
+   could not detect, because it had no way to notice a canonical write it did
+   not itself perform. *)
+let test_fingerprint_mismatch_recovers_externally_written_canonical () =
+  let session_dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir session_dir) (fun () ->
+    let sid = "sess-external-write" in
+    let canonical_path =
+      Keeper_checkpoint_store.oas_checkpoint_path ~session_dir ~session_id:sid
+    in
+    save_ok ~session_dir (make_checkpoint ~session_id:sid ~turn_count:5 ~marker:"v5")
+      "seed save (sidecar now records turn_count=5)";
+    (* Simulate a different writer updating canonical directly without
+       updating the sidecar. A much longer marker guarantees the byte size
+       differs, so the fingerprint mismatch is detected regardless of
+       filesystem mtime resolution. *)
+    Fs_compat.save_file canonical_path
+      (make_checkpoint ~session_id:sid ~turn_count:9
+         ~marker:"externally-written-turn-nine-with-a-much-longer-marker-to-force-a-size-change"
+       |> Agent_sdk.Checkpoint.to_string);
+    Keeper_checkpoint_store.For_testing.reset_full_parse_count ();
+    (match
+       Keeper_checkpoint_store.save_oas_classified ~session_dir
+         (make_checkpoint ~session_id:sid ~turn_count:7
+            ~marker:"v7-would-wrongly-look-forward-against-a-stale-sidecar")
+     with
+     | Ok (Keeper_checkpoint_store.Stale_noop
+             { incoming_turn_count; known_turn_count }) ->
+       check int "incoming turn_count" 7 incoming_turn_count;
+       check int "known turn_count is the real canonical value, not the stale sidecar's" 9
+         known_turn_count
      | Ok (Keeper_checkpoint_store.Saved _) ->
-       fail "stale save advanced despite a warm cache"
-     | Error e ->
-       fail
-         ("stale save read the corrupted canonical file instead of the cache: " ^ e));
-    save_ok ~session_dir (make_checkpoint ~session_id:sid ~turn_count:6 ~marker:"v6")
-      "forward save must succeed from the cache despite corrupted disk bytes";
+       fail "turn_count=7 was wrongly accepted as forward against a stale sidecar's turn_count=5"
+     | Error e -> fail ("fingerprint-mismatch save returned lifecycle failure: " ^ e));
+    check bool "fingerprint mismatch ran the full-parse fallback" true
+      (Keeper_checkpoint_store.For_testing.get_full_parse_count () > 0);
     match Keeper_checkpoint_store.load_oas ~session_dir ~session_id:sid with
     | Ok on_disk ->
-      check int "forward save overwrote the corrupted bytes with turn_count 6" 6
+      check int "externally-written turn_count=9 remains on disk, untouched by the stale save" 9
         on_disk.Agent_sdk.Checkpoint.turn_count
-    | Error _ -> fail "load after cache-driven forward save failed")
+    | Error _ -> fail "load after fingerprint-mismatch stale rejection failed")
 
 (* The OAS per-turn pipeline builds checkpoints with an empty session_id (the
    OAS agent carries no session field). The keeper sink stamps a validated,
@@ -390,10 +463,12 @@ let () =
             test_multi_domain_writers_leave_max_turn_on_disk;
           test_case "ready runtime raw Domain saves through Unix context" `Quick
             test_ready_runtime_raw_domain_save;
-          test_case "cache miss backfills the watermark from a pre-existing canonical file"
-            `Quick test_cache_miss_backfills_from_a_pre_existing_canonical_file;
-          test_case "cache hit survives canonical file corruption" `Quick
-            test_cache_hit_survives_disk_corruption;
+          test_case "fingerprint-matched sidecar skips the full parse" `Quick
+            test_fingerprint_match_skips_full_parse;
+          test_case "absent or corrupt sidecar falls back to full parse" `Quick
+            test_sidecar_unusable_falls_back_to_full_parse;
+          test_case "fingerprint mismatch recovers an externally-written canonical" `Quick
+            test_fingerprint_mismatch_recovers_externally_written_canonical;
           test_case "canonical checkpoint is written compact and round-trips" `Quick
             test_canonical_checkpoint_is_written_compact;
         ] );

--- a/test/test_keeper_checkpoint_stale_guard.ml
+++ b/test/test_keeper_checkpoint_stale_guard.ml
@@ -5,7 +5,13 @@
     the conversation the newer lane had just saved (turn_count=1355).
     [Keeper_checkpoint_store.save_oas_classified] skips a save whose [turn_count] is older
     than the canonical checkpoint observed inside the save transaction, without
-    turning that watermark hit into keeper lifecycle failure. *)
+    turning that watermark hit into keeper lifecycle failure.
+
+    Also covers the checkpoint save-path read-modify-write perf fix: an
+    in-process watermark cache replaces the unconditional canonical-file
+    reload on every save (cache-miss/cache-hit semantics must match the
+    disk-only behavior above bit-for-bit), and the canonical file itself is
+    now written compact rather than pretty-printed. *)
 
 open Alcotest
 open Masc
@@ -106,8 +112,13 @@ let test_forward_equal_and_stale () =
         on_disk.Agent_sdk.Checkpoint.turn_count
     | Error _ -> fail "load after rejection failed")
 
-(* Every decision reloads the canonical disk SSOT; there is no process cache to
-   reset or reconstruct after a restart. *)
+(* The canonical checkpoint file is still the only durable admission
+   watermark: whether a given decision is served from the in-process
+   watermark cache or backfilled from [load_canonical_strict], the disk file
+   is always the ground truth the cache mirrors. This test exercises a
+   session already warm in this process's cache (the seed save populates it);
+   [test_cache_miss_backfills_from_a_pre_existing_canonical_file] below
+   exercises the genuine cache-miss / cold-start path. *)
 let test_disk_is_the_watermark_ssot () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
@@ -129,6 +140,64 @@ let test_disk_is_the_watermark_ssot () =
     | Error e -> fail ("cold stale save returned lifecycle failure: " ^ e));
     save_ok ~session_dir (make_checkpoint ~session_id:sid ~turn_count:9 ~marker:"v9")
       "forward save from disk SSOT")
+
+(* Cache-miss path: this process has never written this session's canonical
+   file, so it is not in the in-memory watermark cache -- a checkpoint placed
+   on disk by writing bytes directly (standing in for a different process, or
+   this process before a restart) must still be discovered and honored. *)
+let test_cache_miss_backfills_from_a_pre_existing_canonical_file () =
+  let session_dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir session_dir) (fun () ->
+    let sid = "sess-preexisting-on-disk" in
+    let path = Keeper_checkpoint_store.oas_checkpoint_path ~session_dir ~session_id:sid in
+    Fs_compat.save_file path
+      (make_checkpoint ~session_id:sid ~turn_count:8 ~marker:"v8-on-disk"
+       |> Agent_sdk.Checkpoint.to_string);
+    match
+      Keeper_checkpoint_store.save_oas_classified ~session_dir
+        (make_checkpoint ~session_id:sid ~turn_count:3 ~marker:"v3-stale")
+    with
+    | Ok (Keeper_checkpoint_store.Stale_noop
+            { incoming_turn_count; known_turn_count }) ->
+      check int "cache-miss stale incoming turn_count" 3 incoming_turn_count;
+      check int "cache-miss known turn_count backfilled from disk" 8 known_turn_count
+    | Ok (Keeper_checkpoint_store.Saved _) ->
+      fail "stale save advanced on a cache-miss backfill"
+    | Error e -> fail ("cache-miss stale save returned lifecycle failure: " ^ e))
+
+(* Cache-hit path: once a session's watermark is warm in this process, a
+   later decision for the same canonical path must not re-read the file --
+   proven behaviorally by corrupting the on-disk bytes after the cache is
+   warm and observing that both a stale rejection and a forward write still
+   succeed from the cache, instead of failing on a disk parse error. *)
+let test_cache_hit_survives_disk_corruption () =
+  let session_dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir session_dir) (fun () ->
+    let sid = "sess-cache-warm" in
+    let path = Keeper_checkpoint_store.oas_checkpoint_path ~session_dir ~session_id:sid in
+    save_ok ~session_dir (make_checkpoint ~session_id:sid ~turn_count:5 ~marker:"v5")
+      "seed save (warms the cache)";
+    Fs_compat.save_file path "{not-a-checkpoint-anymore";
+    (match
+       Keeper_checkpoint_store.save_oas_classified ~session_dir
+         (make_checkpoint ~session_id:sid ~turn_count:3 ~marker:"v3-stale")
+     with
+     | Ok (Keeper_checkpoint_store.Stale_noop
+             { incoming_turn_count; known_turn_count }) ->
+       check int "warm-cache stale incoming turn_count" 3 incoming_turn_count;
+       check int "warm-cache known turn_count served from cache" 5 known_turn_count
+     | Ok (Keeper_checkpoint_store.Saved _) ->
+       fail "stale save advanced despite a warm cache"
+     | Error e ->
+       fail
+         ("stale save read the corrupted canonical file instead of the cache: " ^ e));
+    save_ok ~session_dir (make_checkpoint ~session_id:sid ~turn_count:6 ~marker:"v6")
+      "forward save must succeed from the cache despite corrupted disk bytes";
+    match Keeper_checkpoint_store.load_oas ~session_dir ~session_id:sid with
+    | Ok on_disk ->
+      check int "forward save overwrote the corrupted bytes with turn_count 6" 6
+        on_disk.Agent_sdk.Checkpoint.turn_count
+    | Error _ -> fail "load after cache-driven forward save failed")
 
 (* The OAS per-turn pipeline builds checkpoints with an empty session_id (the
    OAS agent carries no session field). The keeper sink stamps a validated,
@@ -242,6 +311,38 @@ let test_multi_domain_writers_leave_max_turn_on_disk () =
       check int "canonical disk retains the maximum turn" expected
         checkpoint.Agent_sdk.Checkpoint.turn_count)
 
+(* The canonical checkpoint file is written compact (Yojson.Safe.to_string),
+   not pretty-printed, to cut idle-CPU serialization cost. The read path is a
+   JSON parser and is format-agnostic; this test asserts the on-disk bytes are
+   actually single-line and that the round-trip through the compact encoding
+   is lossless for session identity, turn_count, and message content. *)
+let test_canonical_checkpoint_is_written_compact () =
+  let session_dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir session_dir) (fun () ->
+    let sid = "sess-compact" in
+    let path = Keeper_checkpoint_store.oas_checkpoint_path ~session_dir ~session_id:sid in
+    save_ok ~session_dir (make_checkpoint ~session_id:sid ~turn_count:7 ~marker:"compact-marker")
+      "compact save";
+    let raw = Fs_compat.load_file path in
+    check bool "canonical checkpoint bytes are single-line (compact, not pretty)"
+      true
+      (not (String.contains raw '\n'));
+    match Keeper_checkpoint_store.load_oas ~session_dir ~session_id:sid with
+    | Error _ -> fail "load after compact save failed"
+    | Ok on_disk ->
+      check string "session_id round-trips through compact encoding" sid
+        on_disk.Agent_sdk.Checkpoint.session_id;
+      check int "turn_count round-trips through compact encoding" 7
+        on_disk.Agent_sdk.Checkpoint.turn_count;
+      let marker_present =
+        List.exists
+          (fun (msg : Agent_sdk.Types.message) ->
+             String.equal (Agent_sdk.Types.text_of_message msg) "compact-marker")
+          on_disk.Agent_sdk.Checkpoint.messages
+      in
+      check bool "message content round-trips through compact encoding" true
+        marker_present)
+
 let test_ready_runtime_raw_domain_save () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
@@ -289,5 +390,11 @@ let () =
             test_multi_domain_writers_leave_max_turn_on_disk;
           test_case "ready runtime raw Domain saves through Unix context" `Quick
             test_ready_runtime_raw_domain_save;
+          test_case "cache miss backfills the watermark from a pre-existing canonical file"
+            `Quick test_cache_miss_backfills_from_a_pre_existing_canonical_file;
+          test_case "cache hit survives canonical file corruption" `Quick
+            test_cache_hit_survives_disk_corruption;
+          test_case "canonical checkpoint is written compact and round-trips" `Quick
+            test_canonical_checkpoint_is_written_compact;
         ] );
     ]


### PR DESCRIPTION
## 근본 원인

체크포인트 저장 경로가 매 save마다 무조건 read-modify-write를 수행해 idle CPU를 상시 소모하고 있었다.

- `lib/keeper/keeper_checkpoint_store.ml`의 `save_oas_classified_typed`가 매 save마다 `load_canonical_strict`를 호출 → canonical 체크포인트 파일(실측 0.7–1.37MB pretty-printed JSON) 전체를 재파싱. 파싱 결과의 실사용처는 (a) `session_id` 동등성 검사, (b) `turn_count` watermark 비교, 단 두 곳뿐이었다.
- 이어서 `lib/keeper/keeper_fs.ml`의 `save_json_durable_atomic_from_with`이 전체 메시지 히스토리를 `Yojson.Safe.pretty_to_string`으로 재직렬화 + fsync.
- 턴당 최대 3회 발화(sink 3-stage) × 플릿 합산 ~0.8 saves/s 기준, idle 상태에서 파싱 ~1MB/s + pretty-print ~1MB/s가 상시 발생하고 있었다.

## 설계 검토 이력 (리뷰 참고용)

검토 과정에서 두 형태를 저울질했고, **fingerprinted sidecar 파일 방식을 최종안으로 확정**했다(동결됨, commit `aec4fde04b`).

1. in-memory watermark 캐시(Hashtbl, 지문 없음) — `#24561`(commit `20536cacbf`, "make canonical disk the watermark SSOT")가 의도적으로 제거했던 구조와 동일해 폐기.
2. **최종: fingerprinted sidecar 파일** (아래 상세) — in-memory 상태를 전혀 두지 않고 canonical 옆의 작은 파일에 지문을 기록. in-memory 캐시 + 지문 검증 하이브리드도 검토했으나, 두 설계 모두 안전성 속성(디스크 재검증 없이는 신뢰하지 않음)이 동등하다고 판단되어 먼저 구현·테스트·CI가 진행된 이 sidecar 버전으로 확정했다.

## 변경 사항

### 1. Fingerprinted watermark sidecar — canonical disk가 유일한 SSOT 유지

`lib/keeper/keeper_checkpoint_store.ml`에 canonical 체크포인트 옆에 초소형 sidecar 파일(`<canonical_path>.watermark.json`)을 도입했다. sidecar는 `with_session_lock_typed`의 **같은 락 트랜잭션 안에서** canonical write 직후 갱신되며, `session_id`, `turn_count`, 그리고 canonical 파일 자신의 `(size, mtime)` 지문을 기록한다.

**save 경로**(`known_watermark`):
1. canonical 파일을 `stat`(`Fs_compat.file_size`/`file_mtime`)해 현재 지문을 구한다.
2. 지문이 없으면(파일 없음 = cold store, 또는 어떤 이유로든 stat 실패) → 전체 폴백(아래).
3. sidecar를 읽어 지문이 **일치**하면 sidecar의 `(session_id, turn_count)`를 그대로 신뢰하고 `load_canonical_strict` 호출을 생략한다.
4. sidecar가 없거나, 파싱 불가하거나, 지문이 **불일치**하면 → 기존 `load_canonical_strict` 전체 파싱 경로로 무조건 폴백(변경 전과 동일한 경로) → 성공 시 방금 읽은 canonical의 지문으로 sidecar를 재작성(치유)한다.

**핵심 불변식**: canonical 파일은 여전히 유일한 진실 공급원이다. 모든 호출은 매번 새로 `stat`한 지문과 비교하며, 어떤 execution context나 프로세스 경계를 넘어서도 아무것도 "신뢰"하지 않는다. `save_oas_classified`를 우회한 canonical 갱신(다른 writer, 또는 writer가 canonical은 썼는데 sidecar를 못 쓰고 죽은 crash window)은 다음 save에서 지문 불일치로 자동 감지되어 전체 파싱 폴백으로 복구된다 — 별도의 특수 복구 로직이 필요 없다. RFC-0225 §3.2가 요구하는 "disk가 유일한 admission watermark"가 주석이 아니라 코드로 보존된다.

**락을 안 잡는 writer 확인**: rg로 lib/ 전수 확인 결과 `oas_checkpoint_path`(canonical 경로)의 프로덕션 writer는 `save_oas_classified(_typed)` 단 하나이며, 이는 항상 `with_session_lock_typed`를 통해서만 canonical과 sidecar를 함께 갱신한다. 다른 참조(`server_dashboard_http_keeper_api_checkpoints.ml`, `load_oas`/history 목록)는 전부 읽기 전용. `lib/local/worker_container.ml`은 완전히 다른 네임스페이스(`worker_checkpoint_path`)라 무관.

**Eio/raw Domain 안전성**: `Fs_compat.file_size`/`file_mtime`/`load_file_opt`/`save_file`은 이미 `with_fs_or_fallback`을 통해 Eio-native 경로 시도 → `Stdlib.Effect.Unhandled` 발생 시 Unix fallback으로 재시도하는 방식으로 구현되어 있어, raw Domain에서 호출해도 안전하다(별도의 "이것이 실제 Eio fiber인가" 판정이 필요 없음 — `#24548`이 다룬 바로 그 버그 클래스를 이 유틸리티 계층이 이미 흡수하고 있음).

**알려진 한계(문서화)**: sidecar 자체의 write는 best-effort(실패 시 로그+`CheckpointFailures{site=oas_watermark_sidecar}` 카운터만 증가, save 트랜잭션은 실패시키지 않음) — sidecar가 없거나 깨져도 다음 save가 자동으로 치유하므로 durable할 필요가 없다.

### 2. canonical 파일 compact 직렬화 (지시 그대로, 변경 없음)

`lib/keeper/keeper_fs.ml`의 `save_json_durable_atomic`/`save_json_durable_atomic_from`(및 `_with`, `For_testing` 변형)에 `?pretty:bool`(기본값 `true`, 기존 동작 보존) 옵션을 추가했다. `keeper_checkpoint_store.ml`의 canonical write 호출부에서만 `~pretty:false`. 다른 두 프로덕션 호출부(`keeper_msg_async.ml`, `keeper_chat_direct_delivery.ml`)는 기계 전용 durable record이지만 요청 범위를 벗어난 변경을 피하기 위해 기본값(`true`)을 유지했다. 읽기 경로는 표준 JSON 파서라 pretty/compact 무관.

## 변경 파일

- `lib/keeper/keeper_checkpoint_store.ml` — fingerprinted sidecar(`watermark_sidecar_path`/`canonical_fingerprint`/`load_sidecar_watermark`/`save_sidecar_watermark_best_effort`/`known_watermark`/`full_parse_fallback`) 도입, canonical write에 `~pretty:false` 적용, 테스트용 `For_testing.get_full_parse_count`/`reset_full_parse_count` 카운터 훅.
- `lib/keeper/keeper_checkpoint_store.mli` — `watermark_sidecar_path` 및 `For_testing` 모듈 시그니처 노출.
- `lib/keeper_failure_taxonomy/keeper_checkpoint_store_failure_site.{ml,mli}` — sidecar write 실패 사이트(`Oas_watermark_sidecar`) 추가.
- `lib/keeper/keeper_fs.ml`, `lib/keeper/keeper_fs.mli` — `save_json_durable_atomic(_from)(_with)` 및 `For_testing` 변형에 `?pretty:bool`(기본 `true`) 파라미터 추가.
- `test/test_keeper_checkpoint_stale_guard.ml` — 신규 테스트 3건 + 기존 테스트 주석 정정.

## 테스트

`test/test_keeper_checkpoint_stale_guard.ml`(dune stanza 기존, 신규 파일 없음), 신규 3건:

1. `test_fingerprint_match_skips_full_parse` — 지문 일치 시 `load_canonical_strict`가 호출되지 않음을 `For_testing.get_full_parse_count()` 카운터로 직접 증명(정답이 우연히 맞았을 가능성을 배제).
2. `test_sidecar_unusable_falls_back_to_full_parse` — sidecar 삭제 및 sidecar 손상(깨진 JSON) 두 서브케이스 모두에서 전체 파싱 폴백이 실행되고(카운터로 확인), 폴백 후 sidecar가 치유(재작성)됨을 확인.
3. `test_fingerprint_mismatch_recovers_externally_written_canonical` — API를 우회해 canonical을 직접 새 turn_count(9)로 덮어써 sidecar를 stale(turn_count=5로 기억)하게 만든 뒤, incoming turn_count=7(stale sidecar 기준으로는 forward, 실제 canonical 기준으로는 stale)로 save 시도 → 지문 불일치가 감지되어 전체 파싱으로 실제 canonical 값(9)을 복구하고 올바르게 Stale_noop 처리함을 확인 — sidecar를 그대로 신뢰했다면 발생했을 데이터 손실을 직접 반증한다.

기존 6건(`test_forward_equal_and_stale`, `test_disk_is_the_watermark_ssot`, `test_empty_session_id_rejected`, `test_invalid_existing_checkpoint_fails_closed`, `test_multi_domain_writers_leave_max_turn_on_disk`(9-Domain 동시쓰기 회귀), `test_ready_runtime_raw_domain_save`)는 동작 변경 없이 그대로 통과해야 한다 — 코드 변경 없이 주석만 갱신(`test_disk_is_the_watermark_ssot`가 이제 사실상 fast-path도 함께 검증함을 명시).

## 미검증 항목

- **로컬 dune 빌드 미실행**(요청에 따름) — CI(Build and Test)에서 컴파일 및 전체 테스트 스위트 통과 여부 확인 필요. 대신 `ocamlformat --check`, `ocamlc -stop-after parsing -c`(구문 검증)를 변경 파일 전부에 로컬 실행해 통과 확인.
- sidecar 지문을 구하는 `file_size`+`file_mtime` 두 번의 `stat` 호출 사이 이론적 TOCTOU는 존재하나, 단일 writer(세션 락 보유 중)이므로 실질적 위험은 없다고 판단해 단일 `Unix.LargeFile.stat` 재구현 대신 이미 감사된 `Fs_compat` 유틸리티 재사용을 택했다.

## RFC / 워크어라운드 체크

- 이 변경은 credential/identity/repo_manager/operator_control/dashboard-credential/`.claude/hooks`/workflow 문서 중 어느 것도 건드리지 않는다.
- 워크어라운드 시그니처(텔레메트리-as-fix, string 분류기, N-of-M, cap/cooldown/dedup/repair) 해당 없음 — 근본 원인(무조건 read-modify-write)을 제거하는 수정이며, disk-SSOT 불변식을 검증 시맨틱과 함께 그대로 유지한다.
- `bash scripts/ci/check-determinism-contract.sh` PASS 확인(신규 DET/NDT 위반 없음).
- `bash ~/me/scripts/pr-rfc-check.sh --pr-body <이 파일>` PASS 확인.
