### PR TITLE
fix(keeper): defer overflow until manifest commits

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -257,55 +257,66 @@ let append_provider_overflow_manifest
         ~session_dir:(Filename.concat base_dir session_id)
         ~session_id
     in
-    let turn_state =
-      Keeper_unified_turn_manifest.append_manifest
-        ~config
-        ~runtime_manifest_context
-        ~turn_start
-        ~turn_state
-        ~site:"provider_overflow_compaction"
-        ~status
-        ?runtime_id:evidence.selected_runtime_id
-        ~compaction_source:"provider_overflow"
-        ~checkpoint_path
-        ~decision:
-          (Keeper_runtime_manifest.with_payload_role
-             ~payload_role:Checkpoint
-             (`Assoc
-               [ "operation_id", `String recovery.operation_id
-               ; "trigger", `String (Compaction_trigger.to_label trigger)
-               ; "trigger_detail", Compaction_trigger.to_detail_json trigger
-               ; "owner_lane_resume_requested", `Bool true
-               ; "error", error
-               ; ( "exact_evidence"
-                 , Keeper_compact_policy.compaction_evidence_to_json evidence )
-               ]))
-        Keeper_runtime_manifest.Context_compacted
-    in
-    turn_state
+    Keeper_unified_turn_manifest.append_manifest_once
+      ~operation_id:recovery.operation_id
+      ~config
+      ~runtime_manifest_context
+      ~turn_start
+      ~turn_state
+      ~status
+      ?runtime_id:evidence.selected_runtime_id
+      ~compaction_source:"provider_overflow"
+      ~checkpoint_path
+      ~decision:
+        (Keeper_runtime_manifest.with_payload_role
+           ~payload_role:Checkpoint
+           (`Assoc
+             [ "operation_id", `String recovery.operation_id
+             ; "trigger", `String (Compaction_trigger.to_label trigger)
+             ; "trigger_detail", Compaction_trigger.to_detail_json trigger
+             ; "owner_lane_resume_requested", `Bool true
+             ; "error", error
+             ; ( "exact_evidence"
+               , Keeper_compact_policy.compaction_evidence_to_json evidence )
+             ]))
+      Keeper_runtime_manifest.Context_compacted
+  in
+  let projection_result ~operation_id = function
+    | Ok turn_state -> Requeue_after_context_compaction, turn_state
+    | Error detail ->
+      Log.Keeper.error
+        ~keeper_name:runtime_manifest_context.manifest_keeper_name
+        "provider overflow compaction manifest projection failed \
+         operation_id=%s: %s"
+        operation_id
+        detail;
+      Otel_metric_store.inc_counter
+        Keeper_metrics.(to_string WriteMetaFailures)
+        ~labels:
+          [ "keeper", runtime_manifest_context.manifest_keeper_name
+          ; "phase", "provider_overflow_manifest"
+          ]
+        ();
+      Defer_after_context_compaction_failure, turn_state
   in
   match outcome with
   | Not_provider_overflow -> Follow_failure_route, turn_state
   | Provider_overflow_applied { trigger; recovery } ->
-    let turn_state =
-      append_recovery
-        ~status:"compacted"
-        ~error:`Null
-        ~trigger
-        ~recovery
-        turn_state
-    in
-    Requeue_after_context_compaction, turn_state
+    append_recovery
+      ~status:"compacted"
+      ~error:`Null
+      ~trigger
+      ~recovery
+      turn_state
+    |> projection_result ~operation_id:recovery.operation_id
   | Provider_overflow_retry { trigger; reason; recovery = Some recovery } ->
-    let turn_state =
-      append_recovery
-        ~status:"retryable_failure"
-        ~error:(`String reason)
-        ~trigger
-        ~recovery
-        turn_state
-    in
-    Requeue_after_context_compaction, turn_state
+    append_recovery
+      ~status:"retryable_failure"
+      ~error:(`String reason)
+      ~trigger
+      ~recovery
+      turn_state
+    |> projection_result ~operation_id:recovery.operation_id
   | Provider_overflow_retry { trigger; reason; recovery = None } ->
     let turn_state =
       Keeper_unified_turn_manifest.append_manifest

--- a/lib/keeper/keeper_unified_turn_manifest.ml
+++ b/lib/keeper/keeper_unified_turn_manifest.ml
@@ -9,8 +9,7 @@ open Keeper_meta_contract
 open Keeper_unified_turn_types
 open Keeper_unified_turn_phase_plan
 
-let append_manifest
-      ~config
+let prepare_manifest
       ~runtime_manifest_context
       ~turn_start
       ~(turn_state : turn_state)
@@ -20,7 +19,6 @@ let append_manifest
       ?clock_refs
       ?compaction_source
       ?checkpoint_path
-      ~site
       event
   =
   let decision, manifest_seq =
@@ -53,16 +51,81 @@ let append_manifest
       in
       Some (Keeper_runtime_manifest.with_clock_refs ~clock_refs decision), manifest_seq
   in
-  Keeper_runtime_manifest.make_for_context
-    runtime_manifest_context
-    ~event
-    ?runtime_id
-    ?status
-    ?decision
-    ?checkpoint_path
-    ()
-  |> Keeper_runtime_manifest.append_best_effort ~site config;
-  { turn_state with manifest_seq }
+  ( Keeper_runtime_manifest.make_for_context
+      runtime_manifest_context
+      ~event
+      ?runtime_id
+      ?status
+      ?decision
+      ?checkpoint_path
+      ()
+  , { turn_state with manifest_seq } )
+;;
+
+let append_manifest
+      ~config
+      ~runtime_manifest_context
+      ~turn_start
+      ~turn_state
+      ?status
+      ?decision
+      ?runtime_id
+      ?clock_refs
+      ?compaction_source
+      ?checkpoint_path
+      ~site
+      event
+  =
+  let manifest, turn_state =
+    prepare_manifest
+      ~runtime_manifest_context
+      ~turn_start
+      ~turn_state
+      ?status
+      ?decision
+      ?runtime_id
+      ?clock_refs
+      ?compaction_source
+      ?checkpoint_path
+      event
+  in
+  Keeper_runtime_manifest.append_best_effort ~site config manifest;
+  turn_state
+;;
+
+let append_manifest_once
+      ~operation_id
+      ~config
+      ~runtime_manifest_context
+      ~turn_start
+      ~turn_state
+      ?status
+      ?decision
+      ?runtime_id
+      ?clock_refs
+      ?compaction_source
+      ?checkpoint_path
+      event
+  =
+  let manifest, turn_state =
+    prepare_manifest
+      ~runtime_manifest_context
+      ~turn_start
+      ~turn_state
+      ?status
+      ?decision
+      ?runtime_id
+      ?clock_refs
+      ?compaction_source
+      ?checkpoint_path
+      event
+  in
+  match Keeper_runtime_manifest.append_once ~operation_id config manifest with
+  | Ok
+      ( Keeper_runtime_manifest.Appended
+      | Keeper_runtime_manifest.Already_present ) ->
+    Ok turn_state
+  | Error _ as error -> error
 ;;
 
 let append_phase_gate_decision

--- a/lib/keeper/keeper_unified_turn_manifest.mli
+++ b/lib/keeper/keeper_unified_turn_manifest.mli
@@ -32,6 +32,23 @@ val append_manifest
     incremented [manifest_seq]. [clock_refs] is computed automatically
     when omitted. *)
 
+val append_manifest_once
+  :  operation_id:string
+  -> config:Workspace.config
+  -> runtime_manifest_context:Keeper_runtime_manifest.turn_context
+  -> turn_start:Mtime.t
+  -> turn_state:Keeper_unified_turn_types.turn_state
+  -> ?status:string
+  -> ?decision:Yojson.Safe.t
+  -> ?runtime_id:string
+  -> ?clock_refs:Yojson.Safe.t
+  -> ?compaction_source:string
+  -> ?checkpoint_path:string
+  -> Keeper_runtime_manifest.event_kind
+  -> (Keeper_unified_turn_types.turn_state, string) result
+(** Append an operation-bearing row exactly once. The immutable manifest
+    sequence advances only after the durable projection exists. *)
+
 val append_phase_gate_decision
   :  config:Workspace.config
   -> runtime_manifest_context:Keeper_runtime_manifest.turn_context

--- a/test/test_keeper_runtime_manifest_completeness.ml
+++ b/test/test_keeper_runtime_manifest_completeness.ml
@@ -26,11 +26,16 @@ let with_temp_dir f =
   let path = Filename.temp_file "runtime-manifest-once-" "" in
   Sys.remove path;
   Unix.mkdir path 0o755;
-  Fun.protect
-    ~finally:(fun () ->
+  let rec remove path =
+    if Sys.is_directory path then (
       Sys.readdir path
-      |> Array.iter (fun name -> Sys.remove (Filename.concat path name));
+      |> Array.iter (fun name -> remove (Filename.concat path name));
       Unix.rmdir path)
+    else
+      Sys.remove path
+  in
+  Fun.protect
+    ~finally:(fun () -> remove path)
     (fun () -> f path)
 ;;
 
@@ -216,6 +221,59 @@ let test_append_once_rejects_corrupt_manifest () =
       (Fs_compat.file_exists target_path)
 ;;
 
+let empty_turn_state : Masc.Keeper_unified_turn_types.turn_state =
+  { cycle_completed = false
+  ; manifest_seq = 0
+  ; current_turn_blocker_info = None
+  ; last_execution = None
+  ; degraded_retry_info = None
+  ; runtime_rotation_attempts = []
+  ; failure_reason = None
+  ; retry_phase_started_at = None
+  }
+;;
+
+let test_manifest_once_advances_state_only_after_projection () =
+  with_temp_dir @@ fun base_path ->
+  let config = Masc.Workspace.default_config base_path in
+  let keeper_name = "projection-owner" in
+  let operation_id = "compaction-operation-3" in
+  let manifest_dir = M.base_dir config ~keeper_name in
+  Fs_compat.mkdir_p manifest_dir;
+  let corrupt_path = Filename.concat manifest_dir "corrupt.jsonl" in
+  Fs_compat.save_file corrupt_path "{not-json}\n";
+  let runtime_manifest_context : M.turn_context =
+    { manifest_keeper_name = keeper_name
+    ; manifest_agent_name = Some "projection-agent"
+    ; manifest_trace_id = "projection-trace"
+    ; manifest_generation = Some 1
+    ; manifest_keeper_turn_id = Some 1
+    }
+  in
+  let append turn_state =
+    Masc.Keeper_unified_turn_manifest.append_manifest_once
+      ~operation_id
+      ~config
+      ~runtime_manifest_context
+      ~turn_start:(Mtime_clock.now ())
+      ~turn_state
+      ~decision:(`Assoc [ "operation_id", `String operation_id ])
+      M.Context_compacted
+  in
+  (match append empty_turn_state with
+   | Ok _ -> Alcotest.fail "corrupt store committed a manifest sequence"
+   | Error _ -> ());
+  Alcotest.(check int)
+    "immutable input state is unchanged"
+    0
+    empty_turn_state.manifest_seq;
+  Sys.remove corrupt_path;
+  match append empty_turn_state with
+  | Error detail -> Alcotest.failf "valid projection failed: %s" detail
+  | Ok committed ->
+    Alcotest.(check int) "sequence advances after commit" 1 committed.manifest_seq
+;;
+
 let () =
   Alcotest.run "keeper_runtime_manifest_completeness"
     [ ( "completeness"
@@ -234,5 +292,7 @@ let () =
             test_append_once_across_trace_files
         ; Alcotest.test_case "append once rejects corrupt manifest" `Quick
             test_append_once_rejects_corrupt_manifest
+        ; Alcotest.test_case "manifest state advances after projection" `Quick
+            test_manifest_once_advances_state_only_after_projection
         ] )
     ]


### PR DESCRIPTION
## 목적

Provider context overflow가 compacted checkpoint만 저장하고 runtime manifest를 잃은 채 owner lane을 즉시 재개하지 않도록 합니다.

## 변경

- unified manifest construction을 immutable prepare 단계로 단일화
- provider overflow projection을 operation_id 기반 append_manifest_once로 전환
- manifest가 Appended 또는 Already_present일 때만 Requeue_after_context_compaction
- projection 실패는 명시적 error/metric을 남기고 Defer_after_context_compaction_failure
- 실패한 source lease는 FIFO tail에 lane-local 재큐잉되어 peer Keeper와 unrelated ready work를 막지 않음
- manifest sequence는 durable projection 성공 후에만 증가하는 회귀 테스트 추가

## 검증

- ocamlformat --check: green
- ocamlc -stop-after parsing: green
- git diff --check: green
- focused Dune은 공유 장기 Dune lock을 침범하지 않고 CI에 위임
- 271 changed lines

## Stack

#24694 -> #24701 -> #24702 -> 이 PR 순서로 부모부터 병합해야 합니다. 다음 단계는 configured/threshold overflow trigger가 owner Lane의 typed compaction stimulus로 실제 enqueue되는 배선입니다.