### PR TITLE
refactor(fusion): hard-delete staged judge topology

### DIFF
--- a/lib/fusion/fusion_metrics.ml
+++ b/lib/fusion/fusion_metrics.ml
@@ -17,7 +17,6 @@ let topology_label = function
   | Refine -> "refine"
   | Conditional -> "conditional"
   | Judge_of_judges -> "judge_of_judges"
-  | Staged_judge_of_judges -> "staged_judge_of_judges"
 
 let judge_role_of_outcome = function
   | Synthesized node -> node.role

--- a/lib/fusion/fusion_orchestrator.ml
+++ b/lib/fusion/fusion_orchestrator.ml
@@ -101,9 +101,6 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
           let successful_syntheses =
             Fusion_orchestrator_judge_wave.successful_syntheses
           in
-          let successful_pair_syntheses =
-            Fusion_orchestrator_judge_wave.successful_pair_syntheses
-          in
           let firsts_usage = Fusion_orchestrator_judge_wave.firsts_usage in
           let all_fail_error_of_runs =
             Fusion_orchestrator_judge_wave.all_fail_error_of_runs
@@ -124,10 +121,10 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
           in
           let run_judge_of_judges () =
             match preset.Fusion_policy.judges with
-            | [] | [ _ ] ->
+            | [] ->
               ( Error
                   ( Fusion_types.Internal_error
-                      "judge_of_judges requires >= 2 judges configured in the preset ([[fusion.presets.<name>.judges]])"
+                      "judge_of_judges requires a configured judge ([[fusion.presets.<name>.judges]])"
                   , Fusion_types.zero_usage )
               , [] )
             | judges ->
@@ -179,145 +176,6 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                                { Fusion_types.failed_role = Meta
                                ; failure
                                ; usage = meta_u
-                               ; elapsed_s
-                               }
-                           ] )))
-          in
-          let run_staged_judge_of_judges () =
-            let group_size = policy.Fusion_policy.staged_judge_group_size in
-            match
-              Fusion_policy.staged_judge_groups ~group_size preset.Fusion_policy.judges
-            with
-            | Error e ->
-              ( Error
-                  ( Fusion_types.Internal_error (Fusion_policy.staged_judge_group_error_message e)
-                  , Fusion_types.zero_usage )
-              , [] )
-            | Ok _groups ->
-              let firsts =
-                run_first_judges preset.Fusion_policy.judges
-                |> with_timeout_fallback ~run_fallback_judge
-              in
-              let rec take n acc rest =
-                if n = 0
-                then (List.rev acc, rest)
-                else
-                  match rest with
-                  | [] -> (List.rev acc, [])
-                  | x :: xs -> take (n - 1) (x :: acc) xs
-              in
-              let rec chunk_firsts acc rest =
-                match rest with
-                | [] -> List.rev acc
-                | _ ->
-                  let group, rest = take group_size [] rest in
-                  chunk_firsts (group :: acc) rest
-              in
-              let first_groups = chunk_firsts [] firsts in
-              let run_stage_meta (stage_num, stage_firsts) =
-                let stage_id = Printf.sprintf "stage-%d" stage_num in
-                let first_nodes = first_judge_nodes stage_firsts in
-                let ok_priors = successful_syntheses stage_firsts in
-                match ok_priors with
-                | [] ->
-                  let err =
-                    all_fail_error_of_runs
-                      ~fallback:
-                        (Fusion_types.Internal_error
-                           (Printf.sprintf
-                              "staged_judge_of_judges %s: no judge produced a synthesis"
-                              stage_id))
-                      stage_firsts
-                  in
-                  ((stage_id, Error err), first_nodes)
-                | (_, first_s, _) :: _ ->
-                  let firsts_usage = firsts_usage stage_firsts in
-                  let priors = List.map (fun (id, s, _) -> (id, s)) ok_priors in
-                  (match
-                        Fusion_judge.run_meta ~sw ~net
-                          ~timeout_s:preset.Fusion_policy.meta_timeout_s
-                          ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
-                          ~judge_model:preset.Fusion_policy.judge
-                          ~question:req.Fusion_types.prompt ~panel ~priors
-                          ~web_tools:judge_web_tools ()
-                      with
-                      | Ok (stage_s, stage_u) ->
-                        ( ( stage_id
-                          , Ok (stage_s, Fusion_types.add_usage firsts_usage stage_u) )
-                        , first_nodes
-                          @ [ Fusion_types.Synthesized
-                                { Fusion_types.role = Stage_meta stage_num
-                                ; synthesis = stage_s
-                                ; usage = stage_u
-                                }
-                            ] )
-                      | Error (failure, stage_u) ->
-                        Log.Keeper.warn ~keeper_name:req.Fusion_types.keeper
-                          "fusion run %s staged JOJ %s meta judge failed, keeping first judge synthesis: %s"
-                          req.Fusion_types.run_id stage_id
-                          (Fusion_types.judge_failure_text failure);
-                        let elapsed_s = elapsed_since_t0 () in
-                        ( ( stage_id
-                          , Ok (first_s, Fusion_types.add_usage firsts_usage stage_u) )
-                        , first_nodes
-                          @ [ Fusion_types.Judge_failed
-                                { Fusion_types.failed_role = Stage_meta stage_num
-                                ; failure
-                                ; usage = stage_u
-                                ; elapsed_s
-                                }
-                            ] ))
-              in
-              let indexed_groups = List.mapi (fun i group -> (i + 1, group)) first_groups in
-              let stage_runs =
-                Eio.Fiber.List.map
-                  ~max_fibers:(max 1 (List.length indexed_groups))
-                  run_stage_meta indexed_groups
-              in
-              let stage_results = List.map fst stage_runs in
-              let stage_nodes = List.concat_map snd stage_runs in
-              let ok_stages = successful_pair_syntheses stage_results in
-              (match ok_stages with
-               | [] ->
-                 let err =
-                   Fusion_types.all_fail_error
-                     ~fallback:
-                       (Fusion_types.Internal_error "staged_judge_of_judges: no stage produced a synthesis")
-                     stage_results
-                 in
-                 (Error err, stage_nodes)
-               | (_, first_stage_s, _) :: _ ->
-                 let stage_usage = Fusion_types.sum_all_usage stage_results in
-                 let priors = List.map (fun (id, s, _) -> (id, s)) ok_stages in
-                 (match
-                       Fusion_judge.run_meta ~sw ~net
-                         ~timeout_s:preset.Fusion_policy.meta_timeout_s
-                         ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
-                         ~judge_model:preset.Fusion_policy.judge
-                         ~question:req.Fusion_types.prompt ~panel ~priors
-                         ~web_tools:judge_web_tools ()
-                     with
-                     | Ok (final_s, final_u) ->
-                       ( Ok (final_s, Fusion_types.add_usage stage_usage final_u)
-                       , stage_nodes
-                         @ [ Fusion_types.Synthesized
-                               { Fusion_types.role = Final_meta
-                               ; synthesis = final_s
-                               ; usage = final_u
-                               }
-                           ] )
-                     | Error (failure, final_u) ->
-                       Log.Keeper.warn ~keeper_name:req.Fusion_types.keeper
-                         "fusion run %s staged JOJ final meta judge failed, keeping first stage synthesis: %s"
-                         req.Fusion_types.run_id
-                         (Fusion_types.judge_failure_text failure);
-                       let elapsed_s = elapsed_since_t0 () in
-                       ( Ok (first_stage_s, Fusion_types.add_usage stage_usage final_u)
-                       , stage_nodes
-                         @ [ Fusion_types.Judge_failed
-                               { Fusion_types.failed_role = Final_meta
-                               ; failure
-                               ; usage = final_u
                                ; elapsed_s
                                }
                            ] )))
@@ -381,7 +239,6 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                          { Fusion_types.role = Single; synthesis = s1; usage = u1 }
                      ] ))
             | Fusion_types.Judge_of_judges -> run_judge_of_judges ()
-            | Fusion_types.Staged_judge_of_judges -> run_staged_judge_of_judges ()
           in
           let judge = judge_full |> Result.map fst |> Result.map_error fst in
           let judge_usage =

--- a/lib/fusion/fusion_orchestrator.mli
+++ b/lib/fusion/fusion_orchestrator.mli
@@ -25,12 +25,9 @@ type outcome =
       [Refine]은 panel→judge→judge'(1차 종합 재검토)→sink, [Conditional]은 1차 판정이
       [Insufficient]일 때만 refine하고 그 외엔 [Simple]처럼 1차 종합 그대로
       ([Fusion_types.decision_warrants_escalation]), [Judge_of_judges]는 preset.judges의
-      N개(>=2) 1차 심판이 같은 패널을 병렬 독립 종합하고 preset.judge(meta)가 reconcile한다
-      (RFC-0283; judges<2면 에러, 1차 전원 실패면 첫 에러, meta 실패면 1차 첫 성공으로 degrade).
-      [Staged_judge_of_judges]는 같은 1차 심판 목록을
-      [policy.staged_judge_group_size]의 정확한 그룹들로 줄이고, 각 stage meta 결과를
-      final meta가 다시 reconcile한다. ragged/too-small judge 목록은 실행 전 에러로
-      fail-closed하며, nested [masc_fusion] 호출은 하지 않는다.
+      typed 목록 전체를 그 순서로 같은 패널에 병렬 실행하고
+      preset.judge(meta)가 reconcile한다 (RFC-0283; 빈 목록은 에러,
+      1차 전원 실패면 첫 에러, meta 실패면 1차 첫 성공으로 degrade).
       단일-심판 위상에서 1차 심판이 실패하면 [Simple]과 동일하게 에러를 전파하고,
       refine(2차)/meta 심판이 실패하면 1차 종합으로 graceful degrade한다(warn 로깅).
       refine/JOJ는 관여한 심판 usage를 모두 합산해 sink로 보낸다.

--- a/lib/fusion_core/fusion_types.ml
+++ b/lib/fusion_core/fusion_types.ml
@@ -308,13 +308,8 @@ type fusion_topology =
       (** panel → judge → (1차 판정이 [Insufficient]일 때만) judge'(refine) → sink.
           애매할 때만 한 단계 더 깊이; 그 외엔 1차 종합 그대로. *)
   | Judge_of_judges
-      (** panel → [N개 1차 심판] → meta-judge → sink (RFC-0283). 서로 다른 N개 1차
-          심판이 같은 패널을 독립 종합하고, meta가 reconcile. preset.judges >= 2 필요. *)
-  | Staged_judge_of_judges
-      (** panel → [N개 1차 심판] → fixed-size stage meta reducers → final meta reducer
-          → sink. preset.judges count must form at least two exact groups of
-          TOML key [staged_judge_group_size]. This is a named topology,
-          not recursive fusion; [Fusion_depth.Nested] remains denied. *)
+      (** panel → [1차 심판 전체] → meta-judge → sink (RFC-0283). 설정된
+          typed judge 목록 순서를 그대로 보존해 전체를 실행한다. *)
 [@@deriving yojson, show, eq]
 
 let fusion_topology_to_string = function
@@ -322,7 +317,6 @@ let fusion_topology_to_string = function
   | Refine -> "refine"
   | Conditional -> "conditional"
   | Judge_of_judges -> "judge_of_judges"
-  | Staged_judge_of_judges -> "staged_judge_of_judges"
 
 (* [to_string]의 역함수, 닫힌 합 밖은 [None]=fail-closed (Unknown→permissive 회피).
    keeper 입력 문자열을 typed 위상으로 parse한 뒤 exhaustive match하게 한다. round-trip은
@@ -332,11 +326,10 @@ let fusion_topology_of_string = function
   | "refine" -> Some Refine
   | "conditional" -> Some Conditional
   | "judge_of_judges" -> Some Judge_of_judges
-  | "staged_judge_of_judges" -> Some Staged_judge_of_judges
   | _ -> None
 
 let all_fusion_topologies : fusion_topology list =
-  [ Simple; Refine; Conditional; Judge_of_judges; Staged_judge_of_judges ]
+  [ Simple; Refine; Conditional; Judge_of_judges ]
 
 let all_fusion_topology_strings : string list =
   List.map fusion_topology_to_string all_fusion_topologies

--- a/lib/fusion_core/fusion_types.mli
+++ b/lib/fusion_core/fusion_types.mli
@@ -330,13 +330,8 @@ type fusion_topology =
       (** panel → judge → (1차 판정이 [Insufficient]일 때만) judge'(refine) → sink.
           애매할 때만 한 단계 더 깊이; 그 외엔 1차 종합 그대로(= Simple). *)
   | Judge_of_judges
-      (** panel → [N개 1차 심판] → meta-judge → sink (RFC-0283). 서로 다른 N개 1차
-          심판이 같은 패널을 독립 종합하고, meta가 reconcile. preset.judges >= 2 필요. *)
-  | Staged_judge_of_judges
-      (** panel → [N개 1차 심판] → fixed-size stage meta reducers → final meta reducer
-          → sink. preset.judges count must form at least two exact groups of
-          TOML key [staged_judge_group_size]. Named topology only; it does
-          not relax the nested fusion depth guard. *)
+      (** panel → [1차 심판 전체] → meta-judge → sink (RFC-0283). 설정된
+          typed judge 목록 순서를 그대로 보존해 전체를 실행한다. *)
 [@@deriving yojson, show, eq]
 
 (** 안정적 wire 문자열 ([masc_fusion] 도구 인자·로깅용). *)

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -1076,12 +1076,7 @@ let masc_fusion_schema =
          judge could not decide (verdict insufficient); otherwise returns the \
          first synthesis. \"judge_of_judges\": several distinct judges each \
          synthesise the panel independently and a meta-judge reconciles them \
-         (requires the preset to configure >= 2 judges). \
-         \"staged_judge_of_judges\": first judges are grouped by \
-         [fusion].staged_judge_group_size, each group is reconciled by a \
-         stage meta-judge, then a final meta-judge reconciles the stage \
-         results (requires at least two exact groups; ragged counts are \
-         rejected). Unknown values are rejected."
+         in their configured order. Unknown values are rejected."
     ]
 ;;
 

--- a/test/fusion_core/test_fusion.ml
+++ b/test/fusion_core/test_fusion.ml
@@ -1168,7 +1168,7 @@ let test_topology_unknown_is_none () =
 let test_topology_strings () =
   Alcotest.(check (list string))
     "all topology wire strings"
-    [ "simple"; "refine"; "conditional"; "judge_of_judges"; "staged_judge_of_judges" ]
+    [ "simple"; "refine"; "conditional"; "judge_of_judges" ]
     all_fusion_topology_strings
 
 (* Conditional 에스컬레이트 정책 — 닫힌 합 전수 값-핀. Insufficient만 escalate. *)

--- a/test/test_fusion_metrics.ml
+++ b/test/test_fusion_metrics.ml
@@ -21,8 +21,6 @@ let test_labels () =
     (Fusion_metrics.topology_label Fusion_types.Simple);
   check string "topology judge_of_judges" "judge_of_judges"
     (Fusion_metrics.topology_label Fusion_types.Judge_of_judges);
-  check string "topology staged_judge_of_judges" "staged_judge_of_judges"
-    (Fusion_metrics.topology_label Fusion_types.Staged_judge_of_judges);
   check string "role single" "single"
     (Fusion_metrics.judge_role_label Fusion_types.Single);
   check string "role first" "first"


### PR DESCRIPTION
## Outcome

- staged_judge_of_judges wire/type/runtime arm을 삭제합니다.
- judge_of_judges는 preset의 typed judge 목록 전체를 설정 순서대로 실행합니다.
- 임의의 judges >= 2 조건도 제거하고, 구조적으로 빈 목록만 명시 실패합니다.

## Stack contract

- Parent: #24671. Parent를 먼저 병합한 뒤 이 PR을 main으로 retarget해야 합니다.
- 이 C15 단독 상태에서는 staged_judge_group_size 설정/validator가 orphan transitional residue로 남습니다. 런타임 topology에는 더 이상 쓰이지 않지만, numeric governance 0건 완료는 바로 다음 C16까지 필요합니다.
- Durable canonical request/channel replay는 이번 범위가 아니며 다음 P0로 남습니다. Recovery_required 관측을 실제 재실행으로 과장하지 않습니다.

## Verification

- Changed lines: 190 (12 additions, 178 deletions)
- ocamlformat on touched OCaml files: PASS
- ocamlc parse on touched OCaml files/interfaces: PASS
- git diff --check: PASS
- Focused/full Dune: 다른 세션의 bare Dune PID가 있어 repo wrapper가 실행을 거부한 상태이며 우회하거나 fake green을 만들지 않았습니다. CI가 build authority입니다.