### PR TITLE
fix(dashboard): rebuild stale bundle, add missing SSE kinds, boot stamp check

### DIFF
--- a/dashboard/src/schemas/sse.test.ts
+++ b/dashboard/src/schemas/sse.test.ts
@@ -1,10 +1,15 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  _testResetSseSchemaDriftLog,
   AttributionSchema,
   parseSSEMessage,
   SSEMessageSchema,
   SSEEventTypeSchema,
 } from './sse'
+
+beforeEach(() => {
+  _testResetSseSchemaDriftLog()
+})
 
 describe('SSEEventTypeSchema', () => {
   it('accepts a known event type', () => {
@@ -232,6 +237,133 @@ describe('SSEMessageSchema', () => {
   ])('rejects an incomplete Keeper chat-queue invalidation: %o', value => {
     expect(SSEMessageSchema.safeParse(value).success).toBe(false)
   })
+
+  it('accepts a goal_loop_status event with an object payload', () => {
+    const r = SSEMessageSchema.safeParse({
+      type: 'goal_loop_status',
+      payload: { overall_status: 'on_track', loop_iteration: 4 },
+      ts_unix: 1_712_000_000,
+    })
+    expect(r.success).toBe(true)
+  })
+
+  it('rejects a goal_loop_status event with a non-object payload', () => {
+    const r = SSEMessageSchema.safeParse({ type: 'goal_loop_status', payload: 'not an object' })
+    expect(r.success).toBe(false)
+  })
+
+  it('accepts a gate_mode_changed event with a null previous_mode', () => {
+    const r = SSEMessageSchema.safeParse({
+      type: 'gate_mode_changed',
+      mode: 'supervised',
+      previous_mode: null,
+      actor: 'operator',
+      changed_at: '2026-07-15T00:00:00Z',
+    })
+    expect(r.success).toBe(true)
+  })
+
+  it('accepts a gate_mode_changed event with a string previous_mode', () => {
+    const r = SSEMessageSchema.safeParse({
+      type: 'gate_mode_changed',
+      mode: 'autonomous',
+      previous_mode: 'supervised',
+      actor: 'operator',
+      changed_at: '2026-07-15T00:00:00Z',
+    })
+    expect(r.success).toBe(true)
+  })
+
+  it('rejects a gate_mode_changed event with a non-string mode', () => {
+    const r = SSEMessageSchema.safeParse({
+      type: 'gate_mode_changed',
+      mode: 1,
+      actor: 'operator',
+      changed_at: '2026-07-15T00:00:00Z',
+    })
+    expect(r.success).toBe(false)
+  })
+
+  it('accepts a masc/task_claimed event with auto-released task ids', () => {
+    const r = SSEMessageSchema.safeParse({
+      type: 'masc/task_claimed',
+      task_id: 'task-1',
+      agent_name: 'claude',
+      auto_released_task_ids: ['task-0'],
+      timestamp: 1_712_000_000,
+    })
+    expect(r.success).toBe(true)
+  })
+
+  it('accepts a masc/task_claimed event with no auto-released task ids', () => {
+    const r = SSEMessageSchema.safeParse({
+      type: 'masc/task_claimed',
+      task_id: 'task-1',
+      agent_name: 'claude',
+      auto_released_task_ids: [],
+      timestamp: 1_712_000_000,
+    })
+    expect(r.success).toBe(true)
+  })
+
+  it.each([
+    { type: 'masc/task_claimed', agent_name: 'claude', auto_released_task_ids: [] },
+    { type: 'masc/task_claimed', task_id: 'task-1', auto_released_task_ids: [] },
+    { type: 'masc/task_claimed', task_id: 'task-1', agent_name: 'claude', auto_released_task_ids: 'not-an-array' },
+    { type: 'masc/task_claimed', task_id: 'task-1', agent_name: 'claude', auto_released_task_ids: [1, 2] },
+  ])('rejects a malformed masc/task_claimed event: %o', value => {
+    expect(SSEMessageSchema.safeParse(value).success).toBe(false)
+  })
+
+  it('accepts an approval:summary_updated event with a record payload', () => {
+    const r = SSEMessageSchema.safeParse({
+      type: 'approval:summary_updated',
+      payload: { id: 'req-1', summary_status: 'approved' },
+    })
+    expect(r.success).toBe(true)
+  })
+
+  it('rejects an approval:summary_updated event with a non-object payload', () => {
+    const r = SSEMessageSchema.safeParse({ type: 'approval:summary_updated', payload: 'not an object' })
+    expect(r.success).toBe(false)
+  })
+
+  it('accepts a dashboard_yjs_update event with a string payload', () => {
+    const r = SSEMessageSchema.safeParse({
+      type: 'dashboard_yjs_update',
+      kind: 'keeper_update',
+      payload: '{"kind":"keeper_update","keeper_name":"k1"}',
+      payload_len: 42,
+      frame_base64: 'AAEAAAAAAAA=',
+      encoding: 'yjs_update_v1_base64',
+    })
+    expect(r.success).toBe(true)
+  })
+
+  it.each([
+    // record payload instead of the required JSON-encoded string
+    {
+      type: 'dashboard_yjs_update',
+      kind: 'keeper_update',
+      payload: { kind: 'keeper_update' },
+      payload_len: 10,
+      frame_base64: 'AA==',
+      encoding: 'yjs_update_v1_base64',
+    },
+    // missing frame_base64
+    { type: 'dashboard_yjs_update', kind: 'keeper_update', payload: '{}', payload_len: 2 },
+    // negative payload_len
+    {
+      type: 'dashboard_yjs_update',
+      kind: 'keeper_update',
+      payload: '{}',
+      payload_len: -1,
+      frame_base64: 'AA==',
+      encoding: 'yjs_update_v1_base64',
+    },
+  ])('rejects a malformed dashboard_yjs_update event: %o', value => {
+    expect(SSEMessageSchema.safeParse(value).success).toBe(false)
+  })
 })
 
 describe('parseSSEMessage', () => {
@@ -263,6 +395,83 @@ describe('parseSSEMessage', () => {
     })
     expect(msg).not.toBeNull()
     expect(msg?.type).toBe('fusion_run_status')
+    expect(warnSpy).not.toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+
+  it('keeps dashboard_yjs_update events instead of dropping them as schema drift', () => {
+    // Regression: before this fix, `payload` here (a JSON-stringified string)
+    // tripped the generic "payload must be a record" rule and every Yjs
+    // telemetry frame was silently dropped.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const msg = parseSSEMessage({
+      type: 'dashboard_yjs_update',
+      kind: 'keeper_update',
+      payload: '{"kind":"keeper_update","keeper_name":"k1"}',
+      payload_len: 42,
+      frame_base64: 'AAEAAAAAAAA=',
+      encoding: 'yjs_update_v1_base64',
+    })
+    expect(msg).not.toBeNull()
+    expect(msg?.type).toBe('dashboard_yjs_update')
+    expect(warnSpy).not.toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+
+  it('keeps gate_mode_changed events instead of dropping them as schema drift', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const msg = parseSSEMessage({
+      type: 'gate_mode_changed',
+      mode: 'supervised',
+      previous_mode: null,
+      actor: 'operator',
+      changed_at: '2026-07-15T00:00:00Z',
+    })
+    expect(msg).not.toBeNull()
+    expect(msg?.type).toBe('gate_mode_changed')
+    expect(warnSpy).not.toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+
+  it('keeps masc/task_claimed events so the execution panel refresh is not dropped', () => {
+    // Regression: sse-store.ts PREFIX_ROUTES already routes 'masc/task_' to
+    // the execution refresh target; it only ever saw the event if this parse
+    // boundary let it through.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const msg = parseSSEMessage({
+      type: 'masc/task_claimed',
+      task_id: 'task-1',
+      agent_name: 'claude',
+      auto_released_task_ids: [],
+      timestamp: 1_712_000_000,
+    })
+    expect(msg).not.toBeNull()
+    expect(msg?.type).toBe('masc/task_claimed')
+    expect(warnSpy).not.toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+
+  it('keeps approval:summary_updated events instead of dropping them as schema drift', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const msg = parseSSEMessage({
+      type: 'approval:summary_updated',
+      payload: { id: 'req-1', summary_status: 'approved' },
+    })
+    expect(msg).not.toBeNull()
+    expect(msg?.type).toBe('approval:summary_updated')
+    expect(warnSpy).not.toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+
+  it('keeps goal_loop_status events so the live goal-loop delta is not dropped', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const msg = parseSSEMessage({
+      type: 'goal_loop_status',
+      payload: { overall_status: 'on_track', loop_iteration: 4 },
+      ts_unix: 1_712_000_000,
+    })
+    expect(msg).not.toBeNull()
+    expect(msg?.type).toBe('goal_loop_status')
     expect(warnSpy).not.toHaveBeenCalled()
     warnSpy.mockRestore()
   })
@@ -341,6 +550,57 @@ describe('parseSSEMessage', () => {
     expect(parseSSEMessage('just a string')).toBeNull()
     expect(parseSSEMessage(42)).toBeNull()
     expect(parseSSEMessage(null)).toBeNull()
+    warnSpy.mockRestore()
+  })
+})
+
+describe('schema drift log aggregation', () => {
+  // This suite tests the log-surface throttle only. It does not test that
+  // the underlying event is dropped — that is unconditional and is covered
+  // by the SSEMessageSchema rejection tests above.
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('warns immediately on the first drift of a kind', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    parseSSEMessage({ type: 'still_not_a_real_type' })
+    expect(warnSpy).toHaveBeenCalledOnce()
+    warnSpy.mockRestore()
+  })
+
+  it('suppresses repeats of the same kind within the aggregation window', () => {
+    vi.useFakeTimers()
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    for (let i = 0; i < 5; i++) {
+      parseSSEMessage({ type: 'flooding_bad_type' })
+    }
+    // First occurrence logs immediately; the other 4 are counted, not logged.
+    expect(warnSpy).toHaveBeenCalledOnce()
+    warnSpy.mockRestore()
+  })
+
+  it('flushes one aggregated summary line when the window closes, only if repeats occurred', () => {
+    vi.useFakeTimers()
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    for (let i = 0; i < 3; i++) {
+      parseSSEMessage({ type: 'bursty_bad_type' })
+    }
+    expect(warnSpy).toHaveBeenCalledOnce()
+    vi.advanceTimersByTime(60_000)
+    expect(warnSpy).toHaveBeenCalledTimes(2)
+    expect(warnSpy.mock.calls[1]![0]).toContain('bursty_bad_type')
+    expect(warnSpy.mock.calls[1]![0]).toContain('dropped 3 in 60s')
+    warnSpy.mockRestore()
+  })
+
+  it('does not emit a second line when a kind never repeats', () => {
+    vi.useFakeTimers()
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    parseSSEMessage({ type: 'lonely_bad_type' })
+    expect(warnSpy).toHaveBeenCalledOnce()
+    vi.advanceTimersByTime(60_000)
+    expect(warnSpy).toHaveBeenCalledOnce()
     warnSpy.mockRestore()
   })
 })

--- a/dashboard/src/schemas/sse.ts
+++ b/dashboard/src/schemas/sse.ts
@@ -26,6 +26,7 @@ type SchemaLike<T> = {
 
 export const SSE_APPROVAL_PENDING_EVENT = 'approval:pending'
 export const SSE_APPROVAL_RESOLVED_EVENT = 'approval:resolved'
+export const SSE_APPROVAL_SUMMARY_UPDATED_EVENT = 'approval:summary_updated'
 
 const FIXED_SSE_EVENT_TYPES = new Set([
   'agent_bound',
@@ -74,6 +75,22 @@ const FIXED_SSE_EVENT_TYPES = new Set([
   'runtime_param_changed',
   SSE_APPROVAL_PENDING_EVENT,
   SSE_APPROVAL_RESOLVED_EVENT,
+  SSE_APPROVAL_SUMMARY_UPDATED_EVENT,
+  // RFC-0284 §3.2: goal-loop OODA status live delta. Emitted by
+  // server_dashboard_http_goal_loop_broadcast.ml. Dispatched by the
+  // hydrateDashboardSlice switch in sse-store.ts.
+  'goal_loop_status',
+  // Nonhierarchical Gate mode transitions (#24332 governance->gate refactor).
+  // Emitted by server_routes_http_routes_dashboard.ml.
+  'gate_mode_changed',
+  // Task claim notifications (#18839). Emitted by
+  // lib/task/tool_task_handlers.ml. Routed by the 'masc/task_' PREFIX_ROUTES
+  // entry in sse-store.ts.
+  'masc/task_claimed',
+  // Yjs WebSocket projection layer for live telemetry. Emitted by
+  // lib/dashboard/dashboard_yjs.ml. `payload` here is a JSON-stringified
+  // string, not a record — see the dedicated payload-shape exception below.
+  'dashboard_yjs_update',
   'project_snapshot',
   'namespace_truth_snapshot',
   'execution_snapshot',
@@ -133,6 +150,15 @@ const STRING_FIELDS = new Set([
   'model_used',
   'correlation_id',
   'run_id',
+  // gate_mode_changed
+  'mode',
+  'previous_mode',
+  'actor',
+  'changed_at',
+  // dashboard_yjs_update
+  'kind',
+  'frame_base64',
+  'encoding',
 ])
 
 const NUMBER_FIELDS = new Set([
@@ -152,6 +178,10 @@ const NUMBER_FIELDS = new Set([
   'cost_usd',
   'tool_calls_made',
   'total_turns',
+  // dashboard_yjs_update
+  'payload_len',
+  // masc/task_claimed
+  'timestamp',
 ])
 
 const BOOLEAN_FIELDS = new Set(['success', 'reacted', 'tool_io_redacted'])
@@ -305,7 +335,16 @@ export const SSEMessageSchema = schema<SSEMessage>((value) => {
     }
   }
 
-  if (value.payload != null && !isRecord(value.payload) && !value.type.startsWith(OAS_EVENT_PREFIX)) {
+  // dashboard_yjs_update carries a JSON-stringified inner event as `payload`
+  // (see lib/dashboard/dashboard_yjs.ml broadcast_update) — a string, not a
+  // record, so it is excepted from the generic payload-object rule below and
+  // validated in its own dedicated block instead.
+  if (
+    value.payload != null
+    && !isRecord(value.payload)
+    && !value.type.startsWith(OAS_EVENT_PREFIX)
+    && value.type !== 'dashboard_yjs_update'
+  ) {
     return fail('payload', 'Expected payload object')
   }
   if (value.attribution != null) {
@@ -325,6 +364,39 @@ export const SSEMessageSchema = schema<SSEMessage>((value) => {
     }
   }
 
+  if (value.type === 'masc/task_claimed') {
+    if (typeof value.task_id !== 'string' || value.task_id.trim() === '') {
+      return fail('task_id', 'Expected non-empty task_id')
+    }
+    if (typeof value.agent_name !== 'string' || value.agent_name.trim() === '') {
+      return fail('agent_name', 'Expected non-empty agent_name')
+    }
+    if (
+      !Array.isArray(value.auto_released_task_ids)
+      || !value.auto_released_task_ids.every(id => typeof id === 'string')
+    ) {
+      return fail('auto_released_task_ids', 'Expected an array of task id strings')
+    }
+  }
+
+  if (value.type === 'dashboard_yjs_update') {
+    if (typeof value.kind !== 'string' || value.kind.trim() === '') {
+      return fail('kind', 'Expected non-empty kind')
+    }
+    if (typeof value.payload !== 'string') {
+      return fail('payload', 'Expected dashboard_yjs_update payload to be a JSON-encoded string')
+    }
+    if (!Number.isSafeInteger(value.payload_len) || (value.payload_len as number) < 0) {
+      return fail('payload_len', 'Expected non-negative integer payload_len')
+    }
+    if (typeof value.frame_base64 !== 'string' || value.frame_base64.trim() === '') {
+      return fail('frame_base64', 'Expected non-empty frame_base64')
+    }
+    if (typeof value.encoding !== 'string' || value.encoding.trim() === '') {
+      return fail('encoding', 'Expected non-empty encoding')
+    }
+  }
+
   return ok(value as unknown as SSEMessage)
 })
 
@@ -340,18 +412,92 @@ export class SSESchemaDriftError extends Error {
   }
 }
 
+// ── Schema-drift log aggregation ──────────────────────────────────────────
+// A rejected event is still dropped either way — this section only bounds
+// how much console noise a burst of same-kind drops produces. It is a log
+// surface change, not a fix for the underlying drop (see PR description for
+// which of the 5 kinds fixed 2026-07 were genuine drops vs. still-invalid
+// wire data).
+
+// Aggregation window: repeats of the same drift `kind` inside this window
+// are counted instead of re-logged; the count is flushed in one summary line
+// when the window closes, but only if more than the initial occurrence
+// happened (an isolated one-off never gets a second line).
+const DRIFT_LOG_WINDOW_MS = 60_000
+// Matches the team convention of truncating raw-payload log previews rather
+// than dumping arbitrarily large objects into the console.
+const DRIFT_LOG_RAW_PREVIEW_LEN = 500
+
+interface DriftWindowState {
+  count: number
+  timer: ReturnType<typeof setTimeout>
+}
+
+const driftWindows = new Map<string, DriftWindowState>()
+
+function driftKindOf(raw: unknown): string {
+  if (isRecord(raw) && typeof raw.type === 'string' && raw.type.trim() !== '') return raw.type
+  return 'unknown'
+}
+
+function truncateRawPreview(raw: unknown): string {
+  let serialized: string
+  try {
+    serialized = JSON.stringify(raw) ?? String(raw)
+  } catch {
+    serialized = String(raw)
+  }
+  return serialized.length > DRIFT_LOG_RAW_PREVIEW_LEN
+    ? `${serialized.slice(0, DRIFT_LOG_RAW_PREVIEW_LEN)}…`
+    : serialized
+}
+
+function flushDriftWindow(kind: string, raw: unknown): void {
+  const state = driftWindows.get(kind)
+  driftWindows.delete(kind)
+  if (!state || state.count <= 1) return
+  console.warn(
+    `[SSE] schema drift, event dropped: kind=${kind} dropped ${state.count} in `
+    + `${DRIFT_LOG_WINDOW_MS / 1000}s, first_raw=${truncateRawPreview(raw)}`,
+  )
+}
+
+/** Test-only: clears aggregation windows (and their pending timers) between
+ *  test cases. Production code never calls this — window state naturally
+ *  expires after DRIFT_LOG_WINDOW_MS. */
+export function _testResetSseSchemaDriftLog(): void {
+  for (const state of driftWindows.values()) clearTimeout(state.timer)
+  driftWindows.clear()
+}
+
+function logSchemaDrift(raw: unknown, issues: readonly SchemaIssue[]): void {
+  const kind = driftKindOf(raw)
+  const existing = driftWindows.get(kind)
+  if (existing) {
+    existing.count += 1
+    return
+  }
+  driftWindows.set(kind, {
+    count: 1,
+    timer: setTimeout(() => flushDriftWindow(kind, raw), DRIFT_LOG_WINDOW_MS),
+  })
+  // Full raw payload is only useful for local debugging; in production it is
+  // replaced by a truncated preview so a single drifting kind cannot flood
+  // the console with large objects (see module doc above).
+  if (import.meta.env.DEV) {
+    console.warn('[SSE] schema drift, event dropped', { issues, raw })
+  } else {
+    console.warn(`[SSE] schema drift, event dropped: kind=${kind} first_raw=${truncateRawPreview(raw)}`)
+  }
+}
+
 /** Parse-or-drop boundary. Returns the typed message on success.
- *  On failure logs a console.warn with the drift issue and returns null;
- *  the caller drops the event. */
+ *  On failure logs a rate-limited console.warn with the drift issue and
+ *  returns null; the caller drops the event. */
 export function parseSSEMessage(raw: unknown): SSEMessage | null {
   if (isIgnorableMcpNotification(raw)) return null
   const result = SSEMessageSchema.safeParse(raw)
   if (result.success) return result.data
-  // Surface drift in dev tools without crashing the stream. Aggregate issues
-  // into one warn; keep payload visible so operators can diff server output.
-  console.warn('[SSE] schema drift, event dropped', {
-    issues: result.error.issues,
-    raw,
-  })
+  logSchemaDrift(raw, result.error.issues)
   return null
 }

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -47,6 +47,19 @@ export type SSEEventType =
   | 'runtime_param_changed'
   | 'approval:pending'
   | 'approval:resolved'
+  | 'approval:summary_updated'
+  // RFC-0284 §3.2: goal-loop OODA status live delta (see hydrateDashboardSlice
+  // in sse-store.ts). Emitted by server_dashboard_http_goal_loop_broadcast.ml.
+  | 'goal_loop_status'
+  // Nonhierarchical Gate mode transitions (#24332 governance->gate refactor).
+  // Emitted by server_routes_http_routes_dashboard.ml.
+  | 'gate_mode_changed'
+  // Task claim notifications (#18839: surfaces auto-released task ids to
+  // subscribers). Emitted by lib/task/tool_task_handlers.ml.
+  | 'masc/task_claimed'
+  // Yjs WebSocket projection layer for live telemetry. Emitted by
+  // lib/dashboard/dashboard_yjs.ml.
+  | 'dashboard_yjs_update'
   // OAS bridge events (relayed from Event_bus via oas_sse_bridge)
   | 'oas:masc:autonomy:agent_selected'
   | 'oas:masc:autonomy:agent_decision'
@@ -214,8 +227,26 @@ export interface SSEEvent {
   cost_usd?: number
   tool_calls_made?: number
   total_turns?: number
-  // OAS bridge payload (generic container for Event_bus events)
-  payload?: Record<string, unknown>
+  // OAS bridge payload (generic container for Event_bus events). Also carries
+  // the JSON-stringified Yjs update body on `dashboard_yjs_update` (a string,
+  // not a record — see `frame_base64` below for the actual CRDT frame).
+  payload?: Record<string, unknown> | string
+  // masc/task_claimed (#18839): task ids auto-released by the claim, and the
+  // wall-clock time of the claim.
+  auto_released_task_ids?: string[]
+  timestamp?: number
+  // gate_mode_changed: nonhierarchical Gate mode transition fields.
+  mode?: string
+  previous_mode?: string | null
+  actor?: string
+  changed_at?: string
+  // dashboard_yjs_update: Yjs projection envelope. `payload` (above) carries
+  // the JSON-stringified inner event; `frame_base64` carries the actual
+  // binary Yjs update frame, base64-encoded.
+  kind?: string
+  payload_len?: number
+  frame_base64?: string
+  encoding?: string
   // OAS envelope — attached to every oas:* event by oas_sse_bridge since 2.260.0.
   // Used to join events into causal chains in the dashboard journal.
   correlation_id?: string

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -996,6 +996,13 @@ let run ~sw ~env ~host ~port ~base_path ?input_base_path ~make_routes ~make_requ
   let clock, mono_clock, net, domain_mgr, proc_mgr, fs =
     init_runtime_context env
   in
+  (* 0. Dashboard bundle freshness — a stale bundle silently keeps calling
+     routes the current binary already removed (#24332 governance->gate:
+     the served SPA still called DELETE'd /api/v1/dashboard/governance for
+     3+ days because scripts/build-dashboard-if-needed.sh was never re-run
+     after the binary shipped). Cheap synchronous stat comparison; not worth
+     its own fiber. *)
+  Web_dashboard.log_bundle_freshness_warning ();
   Rate_limit.start_global_cleanup_loop ~sw ~clock;
   (* 1. HTTP socket first — Railway healthcheck can reach /health immediately *)
   let config = Server_bootstrap_http.make_http_config ~host ~port in

--- a/lib/web_dashboard.ml
+++ b/lib/web_dashboard.ml
@@ -45,6 +45,69 @@ let assets_root () =
 let index_path () =
   Filename.concat (Filename.concat (assets_root ()) "dashboard") "index.html"
 
+let build_stamp_path () =
+  Filename.concat (Filename.concat (assets_root ()) "dashboard") ".build-stamp"
+
+let mtime_of path =
+  try Some (Unix.stat path).Unix.st_mtime with
+  | Unix.Unix_error _ -> None
+
+(* Same "%04d-%02d-%02dT%02d:%02d:%02dZ" idiom as
+   Types_core.iso8601_of_unix_seconds / Log.timestamp_iso — duplicated here
+   rather than depended on to keep this module's dependency footprint
+   unchanged. *)
+let iso8601_of_unix_seconds ts =
+  let tm = Unix.gmtime ts in
+  Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
+    (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
+    tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
+
+type bundle_freshness =
+  | Fresh
+  | Stale of { stamp_mtime : float; binary_mtime : float }
+  | Missing_stamp
+
+(** Compare the dashboard bundle's [.build-stamp] mtime (touched by
+    [scripts/build-dashboard-if-needed.sh] on every successful build) against
+    the running server binary's mtime. A stamp older than the binary means a
+    new server was shipped without rebuilding the SPA — the exact drift that
+    let a removed HTTP route (#24332) keep getting called by a still-stale
+    bundle. [Missing_stamp] covers both "never built" and any stat failure on
+    the stamp path, so a broken assets_root resolution is never silently
+    treated as fresh. *)
+let bundle_freshness () =
+  match mtime_of (build_stamp_path ()) with
+  | None -> Missing_stamp
+  | Some stamp_mtime ->
+    (match mtime_of Sys.executable_name with
+     | None ->
+       (* Can't stat our own binary (unusual, e.g. exec'd via a symlink the
+          OS deleted from under us) — nothing to compare against, so this is
+          not evidence of staleness either way. *)
+       Fresh
+     | Some binary_mtime ->
+       if stamp_mtime < binary_mtime then Stale { stamp_mtime; binary_mtime }
+       else Fresh)
+
+(** Log a boot-time WARN when the served bundle is stale or missing. Never
+    silent: a missing stamp warns just as loudly as a stale one. Intended to
+    be called once during server startup (see
+    Server_runtime_bootstrap.run). *)
+let log_bundle_freshness_warning () =
+  match bundle_freshness () with
+  | Fresh -> ()
+  | Missing_stamp ->
+    Log.Dashboard.warn
+      "bundle build-stamp not found at %s — dashboard assets may be missing \
+       or unbuilt; run: cd dashboard && pnpm run build"
+      (build_stamp_path ())
+  | Stale { stamp_mtime; binary_mtime } ->
+    Log.Dashboard.warn
+      "bundle build-stamp %s older than server binary %s — run: cd dashboard \
+       && pnpm run build"
+      (iso8601_of_unix_seconds stamp_mtime)
+      (iso8601_of_unix_seconds binary_mtime)
+
 let html () =
   try
     Fs_compat.load_file (index_path ())

--- a/lib/web_dashboard.mli
+++ b/lib/web_dashboard.mli
@@ -3,6 +3,30 @@
 (** Resolve the static assets root used by both dashboard serving paths. *)
 val assets_root : unit -> string
 
+(** Path to the dashboard build stamp ([<assets_root>/dashboard/.build-stamp]),
+    touched by [scripts/build-dashboard-if-needed.sh] on every successful
+    build. *)
+val build_stamp_path : unit -> string
+
+(** Result of comparing the served bundle's build-stamp mtime against the
+    running server binary's mtime. [Missing_stamp] covers both "never built"
+    and any stat failure on the stamp path. *)
+type bundle_freshness =
+  | Fresh
+  | Stale of { stamp_mtime : float; binary_mtime : float }
+  | Missing_stamp
+
+(** Compare the dashboard bundle's build-stamp mtime against the running
+    server binary's mtime. See {!log_bundle_freshness_warning} for the
+    boot-time WARN this backs. *)
+val bundle_freshness : unit -> bundle_freshness
+
+(** Log a boot-time WARN via [Log.Dashboard.warn] when the served dashboard
+    bundle is stale (predates the running binary) or its build-stamp is
+    missing/unreadable. A no-op when the bundle is fresh. Call once during
+    server startup. *)
+val log_bundle_freshness_warning : unit -> unit
+
 (** Generate the dashboard HTML page *)
 val html : unit -> string
 

--- a/test/test_web_dashboard_coverage.ml
+++ b/test/test_web_dashboard_coverage.ml
@@ -283,6 +283,84 @@ let test_safe_asset_relative_path_rejects_absolute () =
     (Web_dashboard.is_safe_asset_relative_path "/etc/passwd")
 
 (* ============================================================
+   bundle_freshness Tests — .build-stamp vs. running binary mtime
+   ============================================================ *)
+
+(* Guaranteed older than any real build, and deliberately not 0.0: passing
+   0.0 for both atime and mtime to Unix.utimes means "set to the current
+   time" (POSIX utimes(path, NULL) semantics), not "set to the Unix epoch" —
+   an easy Stdlib-API trap that would have made this fixture a no-op. *)
+let long_ago = 1.0
+
+let with_temp_dashboard_root ?stamp_mtime f =
+  let root = make_temp_dashboard_root "freshness" "freshness-marker" in
+  Fun.protect
+    (fun () ->
+      (match stamp_mtime with
+       | None -> ()
+       | Some mtime ->
+         let stamp =
+           Filename.concat (Filename.concat (Filename.concat root "assets") "dashboard")
+             ".build-stamp"
+         in
+         write_file stamp "";
+         Unix.utimes stamp mtime mtime);
+      with_env [ ("MASC_ASSETS_DIR", Filename.concat root "assets"); ("MASC_BASE_PATH", "") ] f)
+    ~finally:(fun () ->
+      let stamp =
+        Filename.concat (Filename.concat (Filename.concat root "assets") "dashboard")
+          ".build-stamp"
+      in
+      if Sys.file_exists stamp then Sys.remove stamp;
+      cleanup_temp_dashboard_root root)
+
+let test_bundle_freshness_missing_stamp () =
+  with_temp_dashboard_root (fun () ->
+    check bool "missing stamp reported, not silently fresh" true
+      (match Web_dashboard.bundle_freshness () with
+       | Missing_stamp -> true
+       | Fresh | Stale _ -> false))
+
+let test_bundle_freshness_stale_when_stamp_predates_binary () =
+  with_temp_dashboard_root ~stamp_mtime:long_ago (fun () ->
+    check bool "stamp older than the running binary is reported stale" true
+      (match Web_dashboard.bundle_freshness () with
+       | Stale _ -> true
+       | Fresh | Missing_stamp -> false))
+
+let test_bundle_freshness_fresh_when_stamp_after_binary () =
+  (* A stamp far in the future is always newer than the test binary's real
+     build mtime — exercises the Fresh branch without needing to touch the
+     binary itself. *)
+  let far_future = Unix.gettimeofday () +. (365.0 *. 24.0 *. 3600.0) in
+  with_temp_dashboard_root ~stamp_mtime:far_future (fun () ->
+    check bool "stamp newer than the running binary is fresh" true
+      (match Web_dashboard.bundle_freshness () with
+       | Fresh -> true
+       | Stale _ | Missing_stamp -> false))
+
+let test_bundle_freshness_build_stamp_path_under_dashboard_assets () =
+  with_temp_dashboard_root (fun () ->
+    check bool "build_stamp_path lives under assets/dashboard/" true
+      (contains_substr "/dashboard/.build-stamp" (Web_dashboard.build_stamp_path ())))
+
+(* log_bundle_freshness_warning has no return value to assert on (there is no
+   existing Log capture harness in this suite) — these are smoke tests
+   confirming it does not raise in any of the three bundle_freshness states,
+   covering the Missing_stamp / Stale / Fresh match arms. *)
+let test_log_bundle_freshness_warning_does_not_raise_on_missing_stamp () =
+  with_temp_dashboard_root (fun () -> Web_dashboard.log_bundle_freshness_warning ())
+
+let test_log_bundle_freshness_warning_does_not_raise_on_stale () =
+  with_temp_dashboard_root ~stamp_mtime:long_ago (fun () ->
+    Web_dashboard.log_bundle_freshness_warning ())
+
+let test_log_bundle_freshness_warning_does_not_raise_on_fresh () =
+  let far_future = Unix.gettimeofday () +. (365.0 *. 24.0 *. 3600.0) in
+  with_temp_dashboard_root ~stamp_mtime:far_future (fun () ->
+    Web_dashboard.log_bundle_freshness_warning ())
+
+(* ============================================================
    Test Runners
    ============================================================ *)
 
@@ -316,5 +394,14 @@ let () =
       test_case "reject nested traversal" `Quick test_safe_asset_relative_path_rejects_nested_parent_traversal;
       test_case "reject empty segment" `Quick test_safe_asset_relative_path_rejects_empty_segment;
       test_case "reject absolute path" `Quick test_safe_asset_relative_path_rejects_absolute;
+    ];
+    "bundle_freshness", [
+      test_case "missing stamp" `Quick test_bundle_freshness_missing_stamp;
+      test_case "stale when stamp predates binary" `Quick test_bundle_freshness_stale_when_stamp_predates_binary;
+      test_case "fresh when stamp postdates binary" `Quick test_bundle_freshness_fresh_when_stamp_after_binary;
+      test_case "build_stamp_path under dashboard assets" `Quick test_bundle_freshness_build_stamp_path_under_dashboard_assets;
+      test_case "warn does not raise on missing stamp" `Quick test_log_bundle_freshness_warning_does_not_raise_on_missing_stamp;
+      test_case "warn does not raise on stale" `Quick test_log_bundle_freshness_warning_does_not_raise_on_stale;
+      test_case "warn does not raise on fresh" `Quick test_log_bundle_freshness_warning_does_not_raise_on_fresh;
     ];
   ]


### PR DESCRIPTION
## 근본 원인

서빙 번들(`assets/dashboard/`)이 바이너리보다 stale해지는 문제와, 그로 인한 SSE 콘솔 드랍 홍수는 같은 뿌리를 공유한다: **`scripts/build-dashboard-if-needed.sh`는 바이너리를 재빌드해도 자동으로 재실행되지 않는다.** 커밋 `7b62a87d44`(governance→gate 리팩터)가 `/api/v1/dashboard/governance` 라우트와 클라 caller(`dashboard-governance.ts`)를 함께 삭제했지만, 로컬 실행 중이던 서버는 번들을 재빌드하지 않은 채였다. 그 결과:

1. 이미 로드된 stale 클라 탭이 삭제된 라우트를 계속 호출 → 404.
2. 서버는 `runtime_param_changed`를 emit하는데 stale 번들은 옛 이름(`governance_param_changed`)만 알아 drop.
3. 신규 기능(goal-loop 라이브 델타, Gate 전환, task claim 알림, Yjs 텔레메트리, 승인 요약 갱신)이 배선된 뒤에도 **클라 스키마 화이트리스트(`dashboard/src/schemas/sse.ts`)가 갱신되지 않아** 서버가 정상적으로 emit하는 이벤트 5종이 매번 파싱 경계에서 거부되고, 매 거부마다 `console.warn`으로 raw payload 전체를 dump해 콘솔이 홍수 상태가 됨.

## 변경 사항

### 1. `dashboard/src/schemas/sse.ts` + `dashboard/src/types/sse.ts` — 누락된 SSE 이벤트 5종을 실제 서버 emit 사이트를 읽고 정확한 스키마로 추가

각 이벤트의 실제 payload 형태를 서버 소스에서 직접 확인한 근거:

| 이벤트 | 서버 emit 사이트 | payload 특이사항 |
|---|---|---|
| `masc/task_claimed` | `lib/task/tool_task_handlers.ml:565` | `auto_released_task_ids`는 문자열 배열 — 전용 검증 블록 추가 |
| `approval:summary_updated` | `lib/keeper/keeper_approval_queue.ml:670,1227` | `payload`는 record — 기존 generic 규칙으로 충분 |
| `gate_mode_changed` | `lib/server/server_routes_http_routes_dashboard.ml:420` | `previous_mode`는 nullable string |
| `goal_loop_status` | `lib/server/server_dashboard_http_goal_loop_broadcast.ml:71-81` | `payload`는 항상 Assoc(JSON object) — `dashboard_goal_loop.ml`의 모든 경로(`missing_runtime_status_json`/`invalid_status_json`/정상 read)가 `` `Assoc `` 보장 |
| `dashboard_yjs_update` | `lib/dashboard/dashboard_yjs.ml:30` | **`payload` 필드가 문자열**(JSON.stringify된 내부 이벤트)이라 기존 "payload는 record여야 한다" 규칙에 위배 — 이 타입에 한해 예외 처리 후 전용 블록으로 `payload`(string)/`payload_len`/`frame_base64`/`encoding` 검증 |

`goal_loop_status`, `gate_mode_changed`, `approval:summary_updated`는 이미 라우팅 로직이 배선되어 있었음을 확인:
- `goal_loop_status`: `sse-store.ts:708` `hydrateDashboardSlice`의 switch case가 이미 존재.
- `masc/task_claimed`: `sse-store.ts` `PREFIX_ROUTES`의 `masc/task_` 항목이 이미 execution 패널 refresh로 라우팅.
- `approval:summary_updated`, `gate_mode_changed`: 파싱 경계만 막혀 있었고, 별도 refresh 라우트는 없음(파싱 통과 후에도 UI 갱신 트리거는 없음 — "미검증/잔여 리스크" 참고).

`sse-event-type-parity.test.ts`(exact-match 라우트 전수 검사)는 영향받지 않음 — 5종 모두 `sse-store.ts`에서 `switch`/`PREFIX_ROUTES`로만 라우팅되고, 그 테스트가 검사하는 `===` exact-match 패턴에는 해당하지 않기 때문.

### 2. Drift 로그 집계 (`dashboard/src/schemas/sse.ts`)

**이건 로그 표면 정리이지, 드랍 자체의 수리가 아니다.** 스키마를 통과하지 못하는 이벤트는 여전히 드랍된다 — 위 5종은 (1)에서 화이트리스트에 추가되어 더 이상 드랍되지 않지만, 아직 알려지지 않았거나 실제로 스키마 위반인 이벤트는 계속 드랍되며, 이 변경은 그 반복 드랍이 콘솔을 매번 raw object로 채우지 않도록 60초 창 단위로 집계할 뿐이다.

- 같은 `kind`(이벤트 `type`, 없으면 `unknown`)의 첫 drift는 즉시 warn(개발 모드에선 기존처럼 `{issues, raw}` 전체, 프로덕션에선 500자 truncate된 preview).
- 같은 창(60초) 내 반복은 카운트만 하고 재로깅하지 않음.
- 창이 닫힐 때 반복이 1회라도 더 있었으면 `kind=X dropped N in 60s, first_raw=<truncated>` 형식의 요약 1줄만 flush. 반복이 없었으면 두 번째 줄 없음.
- `import.meta.env.DEV`(기존 `sse-store.ts:798`의 `import.meta.env.DEV` 패턴과 동일)로 전체 raw dump 여부를 게이팅.
- 테스트 격리를 위한 `_testResetSseSchemaDriftLog()`는 `toast.ts`의 `_testResetToasts()`와 동일한 명명 규칙을 따른 test-only export.

### 3. `lib/web_dashboard.ml`/`.mli` + `lib/server/server_runtime_bootstrap.ml` — 부팅 시 번들 staleness WARN

`Web_dashboard.build_stamp_path()`(`<assets_root>/dashboard/.build-stamp`)의 mtime을 `Sys.executable_name`(실행 중인 바이너리)의 mtime과 비교하는 `bundle_freshness()`를 추가하고, `Server_runtime_bootstrap.run`의 맨 앞(소켓 바인딩보다 먼저, 별도 fiber 없이 동기 stat 2회)에서 `log_bundle_freshness_warning()`을 호출한다.

- 번들이 바이너리보다 오래됐으면(`Stale`) WARN + ISO8601 타임스탬프 두 개.
- `.build-stamp` 자체가 없거나 stat 실패면(`Missing_stamp`) 별도로 명시적 WARN — silent하게 "fresh로 간주"하지 않음.
- 이미 이 저장소에 존재하는 client-side `bundle-staleness-banner.ts`와는 다른 계층의 문제를 다룬다: 그 배너는 "이미 로드된 탭 vs 서버가 지금 서빙 중인 index.html" 드리프트를 감지하고(서버가 신선하다고 가정), 이번 boot WARN은 "서버 자신이 서빙하는 번들 vs 서버 바이너리" 드리프트를 감지한다(서버가 stale한 파일을 계속 서빙 중인 근본 시나리오는 배너로 잡히지 않음).

## 번들 재빌드에 대한 참고

`assets/dashboard/`는 `.gitignore:72`로 전체 gitignore 처리되어 있고, `Dockerfile`/`Dockerfile.oneclick`의 `dashboard-builder` 스테이지가 매 이미지 빌드마다 `pnpm run build`를 새로 실행해 굽는다. 즉 프로덕션(Docker) 배포 경로는 이번 클라 변경으로 자동 반영되며 별도 커밋이 필요 없다. 로컬에서 `bash scripts/build-dashboard-if-needed.sh`로 실제 빌드를 돌려 통과를 확인했으나(빌드 아티팩트는 커밋하지 않음), 진단에 언급된 "3.1일 stale" 상황은 Docker 배포본이 아니라 로컬/비-Docker 실행 인스턴스(`dune exec` 직접 구동)에 해당하는 것으로 보인다 — 이번 PR의 3번 항목(boot WARN)이 정확히 그 gap을 겨냥한다.

## 테스트

- `dashboard`: `npx vitest run src/schemas/sse.test.ts src/sse-event-type-parity.test.ts` → **2 files / 80 tests pass**. 신규 5종 이벤트의 accept/reject 케이스, drift 집계 동작(즉시 1회 경고 → 반복 억제 → 창 종료 시 요약), `_testResetSseSchemaDriftLog` 격리 포함.
- `pnpm run typecheck`, `npx eslint src/schemas/sse.ts src/schemas/sse.test.ts src/types/sse.ts` → clean.
- 전체 대시보드 스위트(`pnpm test`, 우발적으로 필터 없이 전체 실행됨): **642 files / 8707 tests pass** — 회귀 없음 확인.
- `bash scripts/build-dashboard-if-needed.sh` 실제 실행 → 빌드 성공, `.build-stamp` 갱신 확인(아티팩트는 gitignore 처리되어 커밋 안 함).
- `test/test_web_dashboard_coverage.ml`에 `bundle_freshness` 테스트 그룹 추가(missing/stale/fresh 3-state + `log_bundle_freshness_warning` non-raising smoke test).

## 미검증 / 잔여 리스크

- **OCaml 빌드/테스트는 로컬에서 동시 실행 중인 다른 워크트리들과의 dune 캐시 lock contention으로 이 PR 작성 시점까지 완료되지 못했다** — 코드는 기존 관용구(`Unix.stat`+`Unix_error` 패턴, `iso8601_of_unix_seconds` 포맷, `Log.Dashboard.warn` 시그니처)를 그대로 따랐고 수기 검토는 마쳤으나, CI의 Build and Test로 최종 확인 필요.
- `approval:summary_updated`와 `gate_mode_changed`는 파싱 경계는 열렸지만 `sse-store.ts`에 전용 refresh 라우트가 없다 — 파싱 통과 후에도 승인 패널/Gate 패널이 즉시 갱신되진 않는다(폴링/재방문 시에는 최신값 반영). 이번 PR 스코프는 "서버가 emit하는 이벤트가 파싱 경계에서 드랍되지 않게 하는 것"으로 한정했고, 추가 refresh 라우팅 배선은 범위 밖 후속 작업으로 남긴다.
- 장기 근본책(atd 기반 스키마 SSOT로 OCaml emit 사이트와 TS 파서를 코드젠으로 동기화)은 RFC 후보로 분리 — 이번 PR은 5종 수동 동기화 + drift 로그 표면 정리에 한정.

## RFC / 워크어라운드 게이트

- 이번 변경은 `.claude/hooks/`, credential/identity/repo/operator 서브시스템, workflow 문서를 건드리지 않음 — RFC 발견 절차 대상 아님.
- Drift 로그 집계는 CLAUDE.md의 "Log Dedup/Demote" 억제 패턴 시그니처에 해당할 수 있어 명시: 이 집계는 **알려지지 않았거나 실제로 스키마 위반인 이벤트의 반복 드랍을 감추지 않는다** — 드랍은 그대로 발생하고, 콘솔 노출량만 줄인다. 5종 이벤트에 대한 근본 수정(화이트리스트 추가로 실제 드랍 자체를 없앰)은 이 PR의 (1)에서 이미 수행했다.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
