### PR TITLE
refactor(fusion): purge numeric judge grouping policy

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -1017,8 +1017,6 @@ trigger_policy = "mention_or_thread"
 [fusion]
 enabled = true
 default_preset = "trio"
-# - staged_judge_group_size: staged_judge_of_judges의 고정 reducer group 크기.
-staged_judge_group_size = 3
 
 # 패널 프리셋. 패널 답변은 free text다. 2026-07-01 사고(ollama.com cloud가 json_schema를
 # 조용히 무시 → 패널 전멸) 이후 패널의 provider-native structured output 요구는 제거됐다
@@ -1053,17 +1051,14 @@ judge_timeout_s = 300.0
 web_tools = false
 
 # ── JoJ-capable preset (RFC-0283 judge-of-judges) ───────────────────────────
-# masc_fusion topology="judge_of_judges"는 preset에 1차 심판 >= 2명을 요구한다
-# (fusion_orchestrator.run_judge_of_judges). trio는 단일 judge라 JoJ 호출이 항상
-# "requires >= 2 judges"로 fail-closed된다 → 키퍼가 JoJ topology를 쓸 수 없었다.
-# quorum은 서로 다른 렌즈(evidence/coverage)의 1차 심판 2명을 두고, meta judge(judge=)가
-# 두 종합을 재조정한다. 키퍼 사용: masc_fusion preset="quorum" topology="judge_of_judges".
+# masc_fusion topology="judge_of_judges"는 preset의 typed judge 목록 전체를
+# 설정 순서대로 실행하고 meta judge(judge=)가 그 종합을 재조정한다.
+# quorum은 서로 다른 evidence/coverage 렌즈를 제공한다.
+# 키퍼 사용: masc_fusion preset="quorum" topology="judge_of_judges".
 # Panel models and Fusion judge/refine/meta paths request provider-native
 # structured output, so every panel and judge runtime below must declare
 # supports-structured-output=true. Distinct labels preserve lens identity while
 # the schema contract prevents config drift back to JSON-mode-only runtimes.
-# staged_judge_of_judges는 [fusion].staged_judge_group_size(=3)의 정확한 배수
-# 그룹을 요구하므로 quorum(2 judges)은 비대상 — 별도 preset 필요.
 [fusion.presets.quorum]
 panel = [
   "ollama_cloud.ollama-cloud-devstral-2-123b",
@@ -1086,11 +1081,11 @@ one resolved answer. Respond with ONLY the requested JSON object, no prose and n
 """
 panel_timeout_s = 300.0
 judge_timeout_s = 300.0
-# meta/stage-meta reducer 구조적 타임아웃. 미지정 시 judge_timeout_s와 동일.
+# meta reducer 구조적 타임아웃. 미지정 시 judge_timeout_s와 동일.
 meta_timeout_s = 300.0
 web_tools = false
 
-# 1차 심판 — 서로 다른 렌즈로 패널을 독립 종합한다 (JoJ requires >= 2; RFC-0283).
+# 1차 심판 — 서로 다른 렌즈로 패널을 독립 종합한다.
 # label이 정체성을 주므로 distinct lens는 distinct identity가 된다 (Duplicate_judge 회피).
 # Strict structured-output support is mandatory for panel and judge runtimes in
 # this seed. Some model families overlap across panel and judge lanes because the
@@ -1118,24 +1113,10 @@ Respond with ONLY the requested JSON object, no prose and no code fences.
 """
 timeout_s = 300.0
 
-# ── Staged-JoJ-capable preset (RFC-0283 staged_judge_of_judges) ──────────────
-# staged_judge_of_judges는 judge 수가 [fusion].staged_judge_group_size(=3)의
-# 정확한 배수이면서 group_size*2(=6) 이상이어야 한다 (fusion_policy.staged_judge_groups).
-# 지금까지 충족 preset이 0이라 topology가 도구 스키마에 노출되고도 모든 호출이
-# config 에러로 fail-closed되는 죽은 옵션이었다. council은 6개 lens 심판을
-# 3개씩 2 stage로 나눈다: stage 1 = evidence/coverage/risk, stage 2 =
-# feasibility/simplicity/adversarial. 각 stage meta가 그룹 종합을 만들고 최종
-# meta judge(judge=)가 stage 종합들을 재조정한다. label이 정체성을 주므로
-# 같은 모델이 다른 lens로 반복 등장해도 Duplicate_judge가 아니다 (quorum 주석과
-# 동일 계약). judge/meta 경로는 provider-native structured output을 요구하므로
-# 심판 런타임은 전부 supports-structured-output=true 선언 모델만 쓴다.
-# 비용/지연: LLM 호출 12회(panel 3 + 1차 심판 6 + stage meta 2 + 최종 meta 1).
-# 실행은 4단 순차 파이프라인(panel → 1차 심판 병렬 → stage meta 병렬 → 최종
-# meta, fusion_orchestrator run_staged_judge_of_judges)이라 각 단의
-# timeout(300s)이 누적된다 — 동시성 캡이 각 단을 한 웨이브로 소화할 때 최악
-# ~20분. 빠른 종합이 필요하면 단이 짧은 quorum/judge_of_judges 계열을 쓴다.
-# 키퍼 사용: masc_fusion preset="council" topology="staged_judge_of_judges"
-# (judge_of_judges topology도 동일 preset으로 사용 가능 — 6 lens 병렬 후 meta).
+# ── Multi-lens council preset ────────────────────────────────────────────────
+# council은 여섯 typed lens를 선언 순서대로 모두 실행한다. label이 정체성을
+# 부여하므로 같은 모델이 다른 lens로 반복 등장해도 Duplicate_judge가 아니다.
+# 키퍼 사용: masc_fusion preset="council" topology="judge_of_judges".
 [fusion.presets.council]
 panel = [
   "ollama_cloud.ollama-cloud-devstral-2-123b",
@@ -1149,10 +1130,10 @@ own view.
 """
 judge = "ollama_cloud.ollama-cloud-ministral-3-14b"
 judge_system_prompt = """
-You are the meta-judge. You are given stage syntheses, each produced by a group \
-of judges evaluating the same panel of model answers through different lenses. \
-Reconcile them: where the stages agree, state the consensus; where they diverge, \
-adjudicate with reasons; surface any blind spot that a single stage missed. \
+You are the meta-judge. You are given judge syntheses evaluating the same panel \
+of model answers through different lenses. Reconcile them: where the judges \
+agree, state the consensus; where they diverge, adjudicate with reasons; surface \
+any blind spot that a single lens missed. \
 Produce one resolved answer. Respond with ONLY the requested JSON object, no \
 prose and no code fences.
 """

--- a/docs/TOML-RELOAD-MATRIX.md
+++ b/docs/TOML-RELOAD-MATRIX.md
@@ -87,8 +87,7 @@ Operational meaning:
   watcher.
 - `[fusion]` is also read from this file by `Fusion_config_loader.load` at
   `masc_fusion` handler time. Fusion edits therefore take effect on the next
-  `masc_fusion` request, including `staged_judge_group_size`, and invalid
-  `[fusion]` config fails that request closed.
+  `masc_fusion` request, and invalid `[fusion]` config fails that request closed.
 
 ## Rules for New TOML Files
 

--- a/lib/fusion/fusion_metrics.ml
+++ b/lib/fusion/fusion_metrics.ml
@@ -17,7 +17,6 @@ let topology_label = function
   | Refine -> "refine"
   | Conditional -> "conditional"
   | Judge_of_judges -> "judge_of_judges"
-  | Staged_judge_of_judges -> "staged_judge_of_judges"
 
 let judge_role_of_outcome = function
   | Synthesized node -> node.role

--- a/lib/fusion/fusion_orchestrator.ml
+++ b/lib/fusion/fusion_orchestrator.ml
@@ -101,9 +101,6 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
           let successful_syntheses =
             Fusion_orchestrator_judge_wave.successful_syntheses
           in
-          let successful_pair_syntheses =
-            Fusion_orchestrator_judge_wave.successful_pair_syntheses
-          in
           let firsts_usage = Fusion_orchestrator_judge_wave.firsts_usage in
           let all_fail_error_of_runs =
             Fusion_orchestrator_judge_wave.all_fail_error_of_runs
@@ -124,10 +121,10 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
           in
           let run_judge_of_judges () =
             match preset.Fusion_policy.judges with
-            | [] | [ _ ] ->
+            | [] ->
               ( Error
                   ( Fusion_types.Internal_error
-                      "judge_of_judges requires >= 2 judges configured in the preset ([[fusion.presets.<name>.judges]])"
+                      "judge_of_judges requires a configured judge ([[fusion.presets.<name>.judges]])"
                   , Fusion_types.zero_usage )
               , [] )
             | judges ->
@@ -179,145 +176,6 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                                { Fusion_types.failed_role = Meta
                                ; failure
                                ; usage = meta_u
-                               ; elapsed_s
-                               }
-                           ] )))
-          in
-          let run_staged_judge_of_judges () =
-            let group_size = policy.Fusion_policy.staged_judge_group_size in
-            match
-              Fusion_policy.staged_judge_groups ~group_size preset.Fusion_policy.judges
-            with
-            | Error e ->
-              ( Error
-                  ( Fusion_types.Internal_error (Fusion_policy.staged_judge_group_error_message e)
-                  , Fusion_types.zero_usage )
-              , [] )
-            | Ok _groups ->
-              let firsts =
-                run_first_judges preset.Fusion_policy.judges
-                |> with_timeout_fallback ~run_fallback_judge
-              in
-              let rec take n acc rest =
-                if n = 0
-                then (List.rev acc, rest)
-                else
-                  match rest with
-                  | [] -> (List.rev acc, [])
-                  | x :: xs -> take (n - 1) (x :: acc) xs
-              in
-              let rec chunk_firsts acc rest =
-                match rest with
-                | [] -> List.rev acc
-                | _ ->
-                  let group, rest = take group_size [] rest in
-                  chunk_firsts (group :: acc) rest
-              in
-              let first_groups = chunk_firsts [] firsts in
-              let run_stage_meta (stage_num, stage_firsts) =
-                let stage_id = Printf.sprintf "stage-%d" stage_num in
-                let first_nodes = first_judge_nodes stage_firsts in
-                let ok_priors = successful_syntheses stage_firsts in
-                match ok_priors with
-                | [] ->
-                  let err =
-                    all_fail_error_of_runs
-                      ~fallback:
-                        (Fusion_types.Internal_error
-                           (Printf.sprintf
-                              "staged_judge_of_judges %s: no judge produced a synthesis"
-                              stage_id))
-                      stage_firsts
-                  in
-                  ((stage_id, Error err), first_nodes)
-                | (_, first_s, _) :: _ ->
-                  let firsts_usage = firsts_usage stage_firsts in
-                  let priors = List.map (fun (id, s, _) -> (id, s)) ok_priors in
-                  (match
-                        Fusion_judge.run_meta ~sw ~net
-                          ~timeout_s:preset.Fusion_policy.meta_timeout_s
-                          ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
-                          ~judge_model:preset.Fusion_policy.judge
-                          ~question:req.Fusion_types.prompt ~panel ~priors
-                          ~web_tools:judge_web_tools ()
-                      with
-                      | Ok (stage_s, stage_u) ->
-                        ( ( stage_id
-                          , Ok (stage_s, Fusion_types.add_usage firsts_usage stage_u) )
-                        , first_nodes
-                          @ [ Fusion_types.Synthesized
-                                { Fusion_types.role = Stage_meta stage_num
-                                ; synthesis = stage_s
-                                ; usage = stage_u
-                                }
-                            ] )
-                      | Error (failure, stage_u) ->
-                        Log.Keeper.warn ~keeper_name:req.Fusion_types.keeper
-                          "fusion run %s staged JOJ %s meta judge failed, keeping first judge synthesis: %s"
-                          req.Fusion_types.run_id stage_id
-                          (Fusion_types.judge_failure_text failure);
-                        let elapsed_s = elapsed_since_t0 () in
-                        ( ( stage_id
-                          , Ok (first_s, Fusion_types.add_usage firsts_usage stage_u) )
-                        , first_nodes
-                          @ [ Fusion_types.Judge_failed
-                                { Fusion_types.failed_role = Stage_meta stage_num
-                                ; failure
-                                ; usage = stage_u
-                                ; elapsed_s
-                                }
-                            ] ))
-              in
-              let indexed_groups = List.mapi (fun i group -> (i + 1, group)) first_groups in
-              let stage_runs =
-                Eio.Fiber.List.map
-                  ~max_fibers:(max 1 (List.length indexed_groups))
-                  run_stage_meta indexed_groups
-              in
-              let stage_results = List.map fst stage_runs in
-              let stage_nodes = List.concat_map snd stage_runs in
-              let ok_stages = successful_pair_syntheses stage_results in
-              (match ok_stages with
-               | [] ->
-                 let err =
-                   Fusion_types.all_fail_error
-                     ~fallback:
-                       (Fusion_types.Internal_error "staged_judge_of_judges: no stage produced a synthesis")
-                     stage_results
-                 in
-                 (Error err, stage_nodes)
-               | (_, first_stage_s, _) :: _ ->
-                 let stage_usage = Fusion_types.sum_all_usage stage_results in
-                 let priors = List.map (fun (id, s, _) -> (id, s)) ok_stages in
-                 (match
-                       Fusion_judge.run_meta ~sw ~net
-                         ~timeout_s:preset.Fusion_policy.meta_timeout_s
-                         ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
-                         ~judge_model:preset.Fusion_policy.judge
-                         ~question:req.Fusion_types.prompt ~panel ~priors
-                         ~web_tools:judge_web_tools ()
-                     with
-                     | Ok (final_s, final_u) ->
-                       ( Ok (final_s, Fusion_types.add_usage stage_usage final_u)
-                       , stage_nodes
-                         @ [ Fusion_types.Synthesized
-                               { Fusion_types.role = Final_meta
-                               ; synthesis = final_s
-                               ; usage = final_u
-                               }
-                           ] )
-                     | Error (failure, final_u) ->
-                       Log.Keeper.warn ~keeper_name:req.Fusion_types.keeper
-                         "fusion run %s staged JOJ final meta judge failed, keeping first stage synthesis: %s"
-                         req.Fusion_types.run_id
-                         (Fusion_types.judge_failure_text failure);
-                       let elapsed_s = elapsed_since_t0 () in
-                       ( Ok (first_stage_s, Fusion_types.add_usage stage_usage final_u)
-                       , stage_nodes
-                         @ [ Fusion_types.Judge_failed
-                               { Fusion_types.failed_role = Final_meta
-                               ; failure
-                               ; usage = final_u
                                ; elapsed_s
                                }
                            ] )))
@@ -381,7 +239,6 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                          { Fusion_types.role = Single; synthesis = s1; usage = u1 }
                      ] ))
             | Fusion_types.Judge_of_judges -> run_judge_of_judges ()
-            | Fusion_types.Staged_judge_of_judges -> run_staged_judge_of_judges ()
           in
           let judge = judge_full |> Result.map fst |> Result.map_error fst in
           let judge_usage =

--- a/lib/fusion/fusion_orchestrator.mli
+++ b/lib/fusion/fusion_orchestrator.mli
@@ -25,12 +25,9 @@ type outcome =
       [Refine]은 panel→judge→judge'(1차 종합 재검토)→sink, [Conditional]은 1차 판정이
       [Insufficient]일 때만 refine하고 그 외엔 [Simple]처럼 1차 종합 그대로
       ([Fusion_types.decision_warrants_escalation]), [Judge_of_judges]는 preset.judges의
-      N개(>=2) 1차 심판이 같은 패널을 병렬 독립 종합하고 preset.judge(meta)가 reconcile한다
-      (RFC-0283; judges<2면 에러, 1차 전원 실패면 첫 에러, meta 실패면 1차 첫 성공으로 degrade).
-      [Staged_judge_of_judges]는 같은 1차 심판 목록을
-      [policy.staged_judge_group_size]의 정확한 그룹들로 줄이고, 각 stage meta 결과를
-      final meta가 다시 reconcile한다. ragged/too-small judge 목록은 실행 전 에러로
-      fail-closed하며, nested [masc_fusion] 호출은 하지 않는다.
+      typed 목록 전체를 그 순서로 같은 패널에 병렬 실행하고
+      preset.judge(meta)가 reconcile한다 (RFC-0283; 빈 목록은 에러,
+      1차 전원 실패면 첫 에러, meta 실패면 1차 첫 성공으로 degrade).
       단일-심판 위상에서 1차 심판이 실패하면 [Simple]과 동일하게 에러를 전파하고,
       refine(2차)/meta 심판이 실패하면 1차 종합으로 graceful degrade한다(warn 로깅).
       refine/JOJ는 관여한 심판 usage를 모두 합산해 sink로 보낸다.

--- a/lib/fusion/fusion_orchestrator_judge_wave.ml
+++ b/lib/fusion/fusion_orchestrator_judge_wave.ml
@@ -88,7 +88,6 @@ let run_first_judges
       ~judge_web_tools
   in
   Eio.Fiber.List.map
-    ~max_fibers:(max 1 (List.length judges))
     (run_first_judge ~already_timed_out:false)
     judges
 ;;

--- a/lib/fusion/fusion_orchestrator_judge_wave.mli
+++ b/lib/fusion/fusion_orchestrator_judge_wave.mli
@@ -54,9 +54,8 @@ val with_timeout_fallback
   :  run_fallback_judge:(unit -> judge_run option)
   -> judge_run list
   -> judge_run list
-(** Append the configured fallback judge when the whole first-judge wave failed
-    only with timeouts. Shared by JOJ and staged JOJ so both
-    topologies honor [fallback_judge_model] consistently. *)
+(** Append the configured fallback judge when the complete first-judge list
+    failed only with timeouts. *)
 
 val run_fallback_judge
   :  sw:Eio.Switch.t

--- a/lib/fusion/fusion_panel.ml
+++ b/lib/fusion/fusion_panel.ml
@@ -95,7 +95,6 @@ let run ~sw ~net ~outer_timeout_s ~groups ~prompt ()
   in
   let built = List.rev built in
   let build_failures = List.rev build_failures in
-  let max_fibers = max 1 (List.length built) in
   (* 2. 모든 그룹을 하나의 Async_agent.all에 union으로 던진다 — 이종 설정은 이미 각
         agent에 baked되어 있으므로 단일 fan-out으로 충분. 외곽 run_safe는 그룹 timeout
         중 max로 전체 멈춤을 막는 상한.
@@ -107,7 +106,7 @@ let run ~sw ~net ~outer_timeout_s ~groups ~prompt ()
     match
       Masc_oas_bridge.run_safe ~caller:"fusion_panel" ~timeout_s:outer_timeout_s (fun () ->
         Ok
-          (Agent_sdk.Async_agent.all ~sw ~max_fibers
+          (Agent_sdk.Async_agent.all ~sw
              (List.map (fun (agent, _panelist, _model) -> (agent, prompt)) built)))
     with
     | Ok run_results ->

--- a/lib/fusion_core/fusion_config.ml
+++ b/lib/fusion_core/fusion_config.ml
@@ -9,7 +9,6 @@ type config_error =
   | Duplicate_panelist of string * string
   | Missing_prompt of string
   | Missing_judge_model of string
-  | Invalid_staged_judge_group_size of int
   | Missing_default_preset of string
   | Unexpected_field of string * string
       (** (config location, field): Fusion schema에 없는 필드. *)
@@ -23,7 +22,6 @@ type config_error =
 let disabled : Fusion_policy.t =
   { enabled = false
   ; default_preset = ""
-  ; staged_judge_group_size = Fusion_policy.default_staged_judge_group_size
   ; presets = []
   }
 
@@ -197,10 +195,6 @@ let parse_enabled (toml : Otoml.t) : (Fusion_policy.t, config_error list) result
   let default_preset =
     Otoml.find_or ~default:"" toml Otoml.get_string [ "fusion"; "default_preset" ]
   in
-  let staged_judge_group_size =
-    Otoml.find_or ~default:Fusion_policy.default_staged_judge_group_size toml
-      Otoml.get_integer [ "fusion"; "staged_judge_group_size" ]
-  in
   let preset_entries =
     match Otoml.find_opt toml Otoml.get_table [ "fusion"; "presets" ] with
     | Some entries -> entries
@@ -212,13 +206,6 @@ let parse_enabled (toml : Otoml.t) : (Fusion_policy.t, config_error list) result
   (* 추가 검증 — enabled일 때만 강제 (disabled면 빈 config 허용). *)
   let errors =
     if enabled && presets = [] then Empty_presets :: errors else errors
-  in
-  (* Staged JOJ uses this as an exact reducer group size.  Values below 2
-     silently degenerate the tree into pass-through, so reject them at load. *)
-  let errors =
-    if staged_judge_group_size < Fusion_policy.min_staged_judge_group_size
-    then Invalid_staged_judge_group_size staged_judge_group_size :: errors
-    else errors
   in
   (* enabled면 default_preset가 비어있지 않고 presets에 존재해야 한다. preset 생략
      호출이 default_preset로 폭빽하는데, ""는 find_preset에서 항상 None→Preset_unknown
@@ -239,14 +226,20 @@ let parse_enabled (toml : Otoml.t) : (Fusion_policy.t, config_error list) result
     Ok
       { Fusion_policy.enabled
       ; default_preset
-      ; staged_judge_group_size
       ; presets
       }
 
 let of_toml (toml : Otoml.t) : (Fusion_policy.t, config_error list) result =
   match Otoml.find_opt toml Fun.id [ "fusion" ] with
   | None -> Ok disabled
-  | Some _ ->
-    (match parse_enabled toml with
-     | result -> result
-     | exception Otoml.Type_error msg -> Error [ Toml_type_error msg ])
+  | Some fusion ->
+    (match
+       unexpected_field ~location:"fusion"
+         ~allowed:[ "enabled"; "default_preset"; "presets" ]
+         fusion
+     with
+     | Some error -> Error [ error ]
+     | None ->
+       (match parse_enabled toml with
+        | result -> result
+        | exception Otoml.Type_error msg -> Error [ Toml_type_error msg ]))

--- a/lib/fusion_core/fusion_config.mli
+++ b/lib/fusion_core/fusion_config.mli
@@ -23,8 +23,6 @@ type config_error =
       (** preset의 panel/judge system prompt가 비어있음 (코드 default 금지) *)
   | Missing_judge_model of string
       (** preset의 judge 모델 id가 비어있음 (필수, 빈 문자열 default 거부) *)
-  | Invalid_staged_judge_group_size of int
-      (** staged_judge_group_size < Fusion_policy.min_staged_judge_group_size *)
   | Missing_default_preset of string
       (** enabled인데 default_preset가 비었거나 presets에 없음. 빈 문자엏도 거부 —
           preset 생략 호출이 default_preset로 폭빽하는데 ""는 항상 Preset_unknown로
@@ -54,9 +52,8 @@ val disabled : Fusion_policy.t
       같은 model이라도 통과(same-model-different-prompt, RFC-0278).
     - panel/judge system prompt 누락 → [Error [Missing_prompt _]].
     - judge 모델 id 누락 → [Error [Missing_judge_model _]].
-    - staged_judge_group_size < 2 → [Error [Invalid_staged_judge_group_size _]].
     - default_preset가 presets에 없음 → [Error [Missing_default_preset _]].
-    - 알 수 없는 preset/panel/judge 필드 → [Error [Unexpected_field _]].
+    - 알 수 없는 fusion/preset/panel/judge 필드 → [Error [Unexpected_field _]].
     - 필드 타입 불일치 → [Error [Toml_type_error _]].
     여러 에러는 누적되어 한 번에 반환된다. *)
 val of_toml : Otoml.t -> (Fusion_policy.t, config_error list) result

--- a/lib/fusion_core/fusion_config_json.ml
+++ b/lib/fusion_core/fusion_config_json.ml
@@ -48,7 +48,6 @@ let to_yojson (c : Fusion_policy.t) : Yojson.Safe.t =
   `Assoc
     [ ("enabled", `Bool c.Fusion_policy.enabled)
     ; ("default_preset", `String c.Fusion_policy.default_preset)
-    ; ("staged_judge_group_size", `Int c.Fusion_policy.staged_judge_group_size)
     ; ( "presets"
       , `List
           (List.map

--- a/lib/fusion_core/fusion_policy.ml
+++ b/lib/fusion_core/fusion_policy.ml
@@ -37,17 +37,14 @@ type preset =
   ; judge_system_prompt : string
   ; judge_timeout_s : float
   ; meta_timeout_s : float
-      (** meta/stage-meta/final-meta 호출 구조적 타임아웃 (초). *)
+      (** meta 호출 구조적 타임아웃 (초). *)
   ; judges : judge_spec list
-      (** JOJ 1차 심판들 (RFC-0283). 기본 []; simple/refine/conditional은 무시한다.
-          JOJ 위상은 런타임에 >= 2 를 요구한다. *)
+      (** JOJ 1차 심판들 (RFC-0283). 입력 순서를 보존해 전체를 실행한다.
+          simple/refine/conditional은 무시한다. *)
   ; fallback_judge_model : string option
       (** 전원 타임아웃 시 단일 fallback 심판 모델. *)
   }
 [@@deriving show, eq]
-
-let min_staged_judge_group_size = 2
-let default_staged_judge_group_size = 3
 
 (* 패널/심판 호출 구조적 타임아웃 기본값 (preset이 명시 안 할 때). 운영 노브 —
    행동 휴리스틱이 아니므로 named SSOT 상수로 둔다 (Magic Number 회피). *)
@@ -134,63 +131,6 @@ let preset_judge_prompts_present (p : preset) =
     (fun (j : judge_spec) -> String.length (String.trim j.jsystem_prompt) > 0)
     p.judges
 
-type staged_judge_group_error =
-  | Staged_group_size_below_min of int
-  | Staged_too_few_judges of
-      { group_size : int
-      ; judges : int
-      }
-  | Staged_ragged_judges of
-      { group_size : int
-      ; judges : int
-      }
-[@@deriving show, eq]
-
-let staged_judge_group_error_message = function
-  | Staged_group_size_below_min group_size ->
-    Printf.sprintf "staged_judge_group_size must be >= %d, got %d"
-      min_staged_judge_group_size
-      group_size
-  | Staged_too_few_judges { group_size; judges } ->
-    Printf.sprintf
-      "staged_judge_of_judges requires at least two full groups: group_size=%d \
-       requires >= %d judges, got %d"
-      group_size
-      (group_size * 2)
-      judges
-  | Staged_ragged_judges { group_size; judges } ->
-    Printf.sprintf
-      "staged_judge_of_judges requires judge count divisible by \
-       staged_judge_group_size: group_size=%d, judges=%d"
-      group_size
-      judges
-
-let staged_judge_groups ~group_size judges =
-  let judge_count = List.length judges in
-  if group_size < min_staged_judge_group_size
-  then Error (Staged_group_size_below_min group_size)
-  else if judge_count < group_size * 2
-  then Error (Staged_too_few_judges { group_size; judges = judge_count })
-  else if judge_count mod group_size <> 0
-  then Error (Staged_ragged_judges { group_size; judges = judge_count })
-  else
-    let rec take n acc rest =
-      if n = 0
-      then (List.rev acc, rest)
-      else
-        match rest with
-        | [] -> (List.rev acc, [])
-        | x :: xs -> take (n - 1) (x :: acc) xs
-    in
-    let rec loop acc rest =
-      match rest with
-      | [] -> Ok (List.rev acc)
-      | _ ->
-        let group, rest = take group_size [] rest in
-        loop (group :: acc) rest
-    in
-    loop [] judges
-
 (* 외곽 run_safe 타임아웃. 하나의 Async_agent.all은 하나의 외곽 타임아웃만
    가지므로(RFC-0252-A §4.3) 그룹별 정밀 timeout은 build_agent에 반영하고 외곽은
    입력 전체가 한 wave로 실행되는 현재 구조에 맞춰 그룹 timeout 중 max로 둔다. *)
@@ -256,7 +196,6 @@ end
 type t =
   { enabled : bool
   ; default_preset : string
-  ; staged_judge_group_size : int
   ; presets : Validated_preset.t list
   }
 [@@deriving show, eq]

--- a/lib/fusion_core/fusion_policy.mli
+++ b/lib/fusion_core/fusion_policy.mli
@@ -46,23 +46,14 @@ type preset =
       (** 심판 모델 system prompt — config에서 필수(코드 default 없음). *)
   ; judge_timeout_s : float  (** 심판 호출 구조적 타임아웃 (초). *)
   ; meta_timeout_s : float
-      (** meta/stage-meta/final-meta 호출 구조적 타임아웃 (초). *)
+      (** meta 호출 구조적 타임아웃 (초). *)
   ; judges : judge_spec list
-      (** JOJ 1차 심판들 (RFC-0283). 기본 []; simple/refine/conditional은 무시한다.
-          JOJ 위상은 런타임에 >= 2 를 요구한다. *)
+      (** JOJ 1차 심판들 (RFC-0283). 입력 순서를 보존해 전체를 실행한다.
+          simple/refine/conditional은 무시한다. *)
   ; fallback_judge_model : string option
       (** 전원 타임아웃 시 단일 fallback 심판 모델. *)
   }
 [@@deriving show, eq]
-
-(** Default staged JOJ group size. A staged judge-of-judges run groups first
-    judges into fixed-size cohorts before a final meta reduction; default 3
-    expresses the common 3x3x3 shape. *)
-val default_staged_judge_group_size : int
-
-(** Smallest useful staged JOJ group size. Size 1 degenerates into a serial
-    pass-through and is rejected. *)
-val min_staged_judge_group_size : int
 
 (** 패널/심판 타임아웃 기본값 (config 미지정 시). 운영 노브 — named SSOT. *)
 val default_timeout_s : float
@@ -102,33 +93,6 @@ val preset_duplicate_judge : preset -> string option
 (** 모든 1차 심판의 system prompt(lens)가 비어있지 않은가. judges=[]면 vacuously [true]
     (simple/refine/conditional은 judges를 안 쓴다). (RFC-0283) *)
 val preset_judge_prompts_present : preset -> bool
-
-(** Staged JOJ preset grouping validation. This is runtime topology validation
-    rather than preset validation because the same preset may be valid for flat
-    JOJ while invalid for staged JOJ. *)
-type staged_judge_group_error =
-  | Staged_group_size_below_min of int
-  | Staged_too_few_judges of
-      { group_size : int
-      ; judges : int
-      }
-  | Staged_ragged_judges of
-      { group_size : int
-      ; judges : int
-      }
-[@@deriving show, eq]
-
-(** Render a staged grouping error at operator/tool boundaries. *)
-val staged_judge_group_error_message : staged_judge_group_error -> string
-
-(** Split JOJ first judges into exact staged groups. Requirements:
-    [group_size >= min_staged_judge_group_size], at least two full groups, and
-    no ragged final group. For example, 9 judges with group size 3 returns
-    three groups of three; 8 judges with group size 3 is rejected. *)
-val staged_judge_groups
-  :  group_size:int
-  -> judge_spec list
-  -> (judge_spec list list, staged_judge_group_error) result
 
 (** 외곽 run_safe 타임아웃 = 그룹 timeout 중 max. 패널은 입력 집합 전체를 구조적으로
     fan-out하므로 별도 concurrency 설정이나 가짜 wave 계산을 두지 않는다. *)
@@ -175,7 +139,6 @@ end
 type t =
   { enabled : bool
   ; default_preset : string
-  ; staged_judge_group_size : int
   ; presets : Validated_preset.t list
   }
 [@@deriving show, eq]

--- a/lib/fusion_core/fusion_types.ml
+++ b/lib/fusion_core/fusion_types.ml
@@ -308,13 +308,8 @@ type fusion_topology =
       (** panel → judge → (1차 판정이 [Insufficient]일 때만) judge'(refine) → sink.
           애매할 때만 한 단계 더 깊이; 그 외엔 1차 종합 그대로. *)
   | Judge_of_judges
-      (** panel → [N개 1차 심판] → meta-judge → sink (RFC-0283). 서로 다른 N개 1차
-          심판이 같은 패널을 독립 종합하고, meta가 reconcile. preset.judges >= 2 필요. *)
-  | Staged_judge_of_judges
-      (** panel → [N개 1차 심판] → fixed-size stage meta reducers → final meta reducer
-          → sink. preset.judges count must form at least two exact groups of
-          TOML key [staged_judge_group_size]. This is a named topology,
-          not recursive fusion; [Fusion_depth.Nested] remains denied. *)
+      (** panel → [1차 심판 전체] → meta-judge → sink (RFC-0283). 설정된
+          typed judge 목록 순서를 그대로 보존해 전체를 실행한다. *)
 [@@deriving yojson, show, eq]
 
 let fusion_topology_to_string = function
@@ -322,7 +317,6 @@ let fusion_topology_to_string = function
   | Refine -> "refine"
   | Conditional -> "conditional"
   | Judge_of_judges -> "judge_of_judges"
-  | Staged_judge_of_judges -> "staged_judge_of_judges"
 
 (* [to_string]의 역함수, 닫힌 합 밖은 [None]=fail-closed (Unknown→permissive 회피).
    keeper 입력 문자열을 typed 위상으로 parse한 뒤 exhaustive match하게 한다. round-trip은
@@ -332,11 +326,10 @@ let fusion_topology_of_string = function
   | "refine" -> Some Refine
   | "conditional" -> Some Conditional
   | "judge_of_judges" -> Some Judge_of_judges
-  | "staged_judge_of_judges" -> Some Staged_judge_of_judges
   | _ -> None
 
 let all_fusion_topologies : fusion_topology list =
-  [ Simple; Refine; Conditional; Judge_of_judges; Staged_judge_of_judges ]
+  [ Simple; Refine; Conditional; Judge_of_judges ]
 
 let all_fusion_topology_strings : string list =
   List.map fusion_topology_to_string all_fusion_topologies

--- a/lib/fusion_core/fusion_types.mli
+++ b/lib/fusion_core/fusion_types.mli
@@ -330,13 +330,8 @@ type fusion_topology =
       (** panel → judge → (1차 판정이 [Insufficient]일 때만) judge'(refine) → sink.
           애매할 때만 한 단계 더 깊이; 그 외엔 1차 종합 그대로(= Simple). *)
   | Judge_of_judges
-      (** panel → [N개 1차 심판] → meta-judge → sink (RFC-0283). 서로 다른 N개 1차
-          심판이 같은 패널을 독립 종합하고, meta가 reconcile. preset.judges >= 2 필요. *)
-  | Staged_judge_of_judges
-      (** panel → [N개 1차 심판] → fixed-size stage meta reducers → final meta reducer
-          → sink. preset.judges count must form at least two exact groups of
-          TOML key [staged_judge_group_size]. Named topology only; it does
-          not relax the nested fusion depth guard. *)
+      (** panel → [1차 심판 전체] → meta-judge → sink (RFC-0283). 설정된
+          typed judge 목록 순서를 그대로 보존해 전체를 실행한다. *)
 [@@deriving yojson, show, eq]
 
 (** 안정적 wire 문자열 ([masc_fusion] 도구 인자·로깅용). *)

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -1076,12 +1076,7 @@ let masc_fusion_schema =
          judge could not decide (verdict insufficient); otherwise returns the \
          first synthesis. \"judge_of_judges\": several distinct judges each \
          synthesise the panel independently and a meta-judge reconciles them \
-         (requires the preset to configure >= 2 judges). \
-         \"staged_judge_of_judges\": first judges are grouped by \
-         [fusion].staged_judge_group_size, each group is reconciled by a \
-         stage meta-judge, then a final meta-judge reconciles the stage \
-         results (requires at least two exact groups; ragged counts are \
-         rejected). Unknown values are rejected."
+         in their configured order. Unknown values are rejected."
     ]
 ;;
 

--- a/test/fusion_core/test_fusion.ml
+++ b/test/fusion_core/test_fusion.ml
@@ -34,7 +34,6 @@ let raw = Fusion_policy.Validated_preset.preset
 let base_policy : Fusion_policy.t =
   { Fusion_policy.enabled = true
   ; default_preset = "trio"
-  ; staged_judge_group_size = Fusion_policy.default_staged_judge_group_size
   ; presets =
       [ validated
           { Fusion_policy.name = "trio"
@@ -99,7 +98,6 @@ let valid_toml =
 [fusion]
 enabled = true
 default_preset = "trio"
-staged_judge_group_size = 3
 [fusion.presets.trio]
 web_tools = false
 panel = ["a", "b", "c"]
@@ -112,8 +110,6 @@ let test_config_valid () =
   match Fusion_config.of_toml (parse valid_toml) with
   | Ok p ->
     Alcotest.(check bool) "enabled" true p.Fusion_policy.enabled;
-    Alcotest.(check int) "staged judge group size" 3
-      p.Fusion_policy.staged_judge_group_size;
     Alcotest.(check int) "one preset" 1 (List.length p.Fusion_policy.presets);
     (match p.Fusion_policy.presets with
      | [ vp ] ->
@@ -133,9 +129,7 @@ let test_config_valid () =
 
 (* JoJ-capable preset: [[fusion.presets.X.judges]] array-of-tables 파싱 경로 (RFC-0283).
    config/runtime.toml [fusion.presets.quorum] 의 구조를 미러한다(모델 id는 placeholder).
-   topology=judge_of_judges는 orchestrator 런타임에서 judges >= 2 를 요구하므로
-   (fusion_orchestrator.run_judge_of_judges), JoJ를 키퍼가 실제로 쓰려면 judges>=2 preset이
-   shipped config에 있어야 한다. 이 테스트는 그 preset이 의존하는 TOML array-of-tables 파싱
+   이 테스트는 typed judge 목록의 TOML array-of-tables 파싱
    (Fusion_config.parse_judge_spec)을 end-to-end로 고정한다 — 기존 Validated_preset 테스트는
    OCaml-구성 judges만 다뤄 이 파싱 경로를 덮지 않는다. *)
 let joj_preset_toml =
@@ -168,8 +162,7 @@ let test_config_joj_preset_parses () =
      | [ vp ] ->
        let preset = raw vp in
        let judges = preset.Fusion_policy.judges in
-       Alcotest.(check int) "two first judges (JoJ requires >= 2)" 2
-         (List.length judges);
+       Alcotest.(check int) "fixture judges" 2 (List.length judges);
        Alcotest.(check bool) "meta judge set" true
          (String.trim preset.Fusion_policy.judge <> "");
        Alcotest.(check (list string))
@@ -549,37 +542,13 @@ judge_system_prompt = "j"
       (List.mem (Fusion_config.Missing_judge_model "p1") es)
   | Ok _ -> Alcotest.fail "expected Error Missing_judge_model"
 
-let test_config_bad_staged_judge_group_size () =
-  let s =
-    {|
-[fusion]
-enabled = true
-default_preset = "p1"
-staged_judge_group_size = 1
-[fusion.presets.p1]
-panel = ["a", "b"]
-judge = "a"
-panel_system_prompt = "p"
-judge_system_prompt = "j"
-|}
-  in
-  match Fusion_config.of_toml (parse s) with
-  | Error es ->
-    Alcotest.(check bool) "Invalid_staged_judge_group_size present" true
-      (List.mem (Fusion_config.Invalid_staged_judge_group_size 1) es)
-  | Ok _ -> Alcotest.fail "expected Error Invalid_staged_judge_group_size"
-
 (* council 프리셋 계약 (config/runtime.toml [fusion.presets.council] 미러):
-   judge 6명 = staged_judge_group_size(3)의 정확한 배수이자 >= group_size*2 —
-   staged_judge_of_judges 자격을 만족하는 최초의 shipped preset shape.
-   staged_judge_groups가 lens 입력 순서를 보존한 2 그룹을 만드는 것까지 고정해,
-   프리셋을 줄이거나(ragged) group_size를 키우는 회귀가 여기서 잡히게 한다. *)
+   typed judge 목록이 TOML 입력 순서를 그대로 보존한다. *)
 let council_shaped_toml =
   {|
 [fusion]
 enabled = true
 default_preset = "council"
-staged_judge_group_size = 3
 [fusion.presets.council]
 panel = ["pa", "pb", "pc"]
 judge = "meta-reducer"
@@ -617,7 +586,13 @@ label = "adversarial"
 system_prompt = "adversarial lens"
 |}
 
-let test_config_council_preset_is_staged_eligible () =
+let judge_labels preset =
+  List.map (fun judge -> judge.Fusion_policy.jlabel) preset.Fusion_policy.judges
+
+let council_judge_labels =
+  [ "evidence"; "coverage"; "risk"; "feasibility"; "simplicity"; "adversarial" ]
+
+let test_config_council_preserves_judge_order () =
   match Fusion_config.of_toml (parse council_shaped_toml) with
   | Error es ->
     Alcotest.failf "council fixture must parse+validate, got: %s"
@@ -626,30 +601,13 @@ let test_config_council_preset_is_staged_eligible () =
     (match p.Fusion_policy.presets with
      | [ vp ] ->
        let preset = raw vp in
-       Alcotest.(check int) "six first-round judges" 6
-         (List.length preset.Fusion_policy.judges);
-       (match
-          Fusion_policy.staged_judge_groups
-            ~group_size:p.Fusion_policy.staged_judge_group_size
-            preset.Fusion_policy.judges
-        with
-        | Error e ->
-          Alcotest.failf "council must be staged-eligible, got: %s"
-            (Fusion_policy.staged_judge_group_error_message e)
-        | Ok groups ->
-          Alcotest.(check int) "two exact stages" 2 (List.length groups);
-          Alcotest.(check (list (list string)))
-            "stage grouping preserves lens input order"
-            [ [ "evidence"; "coverage"; "risk" ]
-            ; [ "feasibility"; "simplicity"; "adversarial" ]
-            ]
-            (List.map
-               (List.map (fun j -> j.Fusion_policy.jlabel))
-               groups))
+       Alcotest.(check (list string))
+         "typed judge order"
+         council_judge_labels (judge_labels preset)
      | presets ->
        Alcotest.failf "expected exactly one preset, got %d" (List.length presets))
 
-let test_shipped_runtime_council_is_staged_eligible () =
+let test_shipped_runtime_council_preserves_judge_order () =
   let runtime_toml =
     In_channel.with_open_bin "../../config/runtime.toml" In_channel.input_all
   in
@@ -669,47 +627,9 @@ let test_shipped_runtime_council_is_staged_eligible () =
      | None -> Alcotest.fail "shipped runtime.toml has no council preset"
      | Some validated ->
        let preset = raw validated in
-       match
-         Fusion_policy.staged_judge_groups
-           ~group_size:policy.Fusion_policy.staged_judge_group_size
-           preset.Fusion_policy.judges
-       with
-       | Ok [ first_stage; second_stage ] ->
-         Alcotest.(check (list string))
-           "shipped first stage lenses"
-           [ "evidence"; "coverage"; "risk" ]
-           (List.map (fun judge -> judge.Fusion_policy.jlabel) first_stage);
-         Alcotest.(check (list string))
-           "shipped second stage lenses"
-           [ "feasibility"; "simplicity"; "adversarial" ]
-           (List.map (fun judge -> judge.Fusion_policy.jlabel) second_stage)
-       | Ok groups ->
-         Alcotest.failf "shipped council must have two stages, got %d"
-           (List.length groups)
-       | Error error ->
-         Alcotest.failf "shipped council is not staged-eligible: %s"
-           (Fusion_policy.staged_judge_group_error_message error))
-
-(* 회귀 가드: quorum 형태(2 judges)는 staged 비자격 — 이 fail-closed가 council
-   추가 전 모든 shipped preset의 상태였다. *)
-let test_config_two_judges_not_staged_eligible () =
-  let judge ~model ~label =
-    { Fusion_policy.jmodel = model
-    ; jlabel = label
-    ; jsystem_prompt = label ^ " lens"
-    ; jweb_tools = false
-    ; jtimeout_s = 300.0
-    }
-  in
-  let judges =
-    [ judge ~model:"j1" ~label:"evidence"; judge ~model:"j2" ~label:"coverage" ]
-  in
-  match Fusion_policy.staged_judge_groups ~group_size:3 judges with
-  | Error (Fusion_policy.Staged_too_few_judges { group_size = 3; judges = 2 }) -> ()
-  | Error e ->
-    Alcotest.failf "expected Staged_too_few_judges, got: %s"
-      (Fusion_policy.staged_judge_group_error_message e)
-  | Ok _ -> Alcotest.fail "two judges must not be staged-eligible"
+       Alcotest.(check (list string))
+         "shipped typed judge order"
+         council_judge_labels (judge_labels preset))
 
 let expect_unexpected_field toml expected_location expected_field =
   match Fusion_config.of_toml (parse toml) with
@@ -783,7 +703,6 @@ let seed_disabled_toml =
 [fusion]
 enabled = false
 default_preset = "trio"
-staged_judge_group_size = 3
 [fusion.presets.trio]
 web_tools = false
 panel = [
@@ -802,8 +721,6 @@ let test_config_disabled_with_preset () =
   match Fusion_config.of_toml (parse seed_disabled_toml) with
   | Ok p ->
     Alcotest.(check bool) "seed disabled" false p.Fusion_policy.enabled;
-    Alcotest.(check int) "seed staged group size" 3
-      p.Fusion_policy.staged_judge_group_size;
     Alcotest.(check int) "trio preset present" 1 (List.length p.Fusion_policy.presets);
     (match p.Fusion_policy.presets with
      | [ vp ] ->
@@ -906,42 +823,6 @@ let test_validated_duplicate_judge () =
   with
   | Error (Fusion_policy.Validated_preset.Duplicate_judge "x") -> ()
   | _ -> Alcotest.fail "expected Duplicate_judge x for same judge identity"
-
-let judge_named model = { base_judge with Fusion_policy.jmodel = model }
-
-let test_staged_judge_groups_exact_3x3 () =
-  let judges = List.init 9 (fun i -> judge_named (Printf.sprintf "j%d" (i + 1))) in
-  match Fusion_policy.staged_judge_groups ~group_size:3 judges with
-  | Ok groups ->
-    Alcotest.(check int) "three groups" 3 (List.length groups);
-    Alcotest.(check (list int)) "3x3 group sizes" [ 3; 3; 3 ]
-      (List.map List.length groups);
-    (match groups with
-     | first :: _ ->
-       (match first with
-        | j :: _ -> Alcotest.(check string) "first judge preserved" "j1" j.Fusion_policy.jmodel
-        | [] -> Alcotest.fail "first group should not be empty")
-     | [] -> Alcotest.fail "expected groups")
-  | Error e ->
-    Alcotest.failf "expected 3x3 groups, got %s"
-      (Fusion_policy.show_staged_judge_group_error e)
-
-let test_staged_judge_groups_too_few () =
-  let judges = List.init 5 (fun i -> judge_named (Printf.sprintf "j%d" (i + 1))) in
-  match Fusion_policy.staged_judge_groups ~group_size:3 judges with
-  | Error (Fusion_policy.Staged_too_few_judges { group_size = 3; judges = 5 }) -> ()
-  | _ -> Alcotest.fail "expected Staged_too_few_judges for 5 judges at group size 3"
-
-let test_staged_judge_groups_ragged () =
-  let judges = List.init 8 (fun i -> judge_named (Printf.sprintf "j%d" (i + 1))) in
-  match Fusion_policy.staged_judge_groups ~group_size:3 judges with
-  | Error (Fusion_policy.Staged_ragged_judges { group_size = 3; judges = 8 }) -> ()
-  | _ -> Alcotest.fail "expected Staged_ragged_judges for 8 judges at group size 3"
-
-let test_staged_judge_groups_bad_size () =
-  match Fusion_policy.staged_judge_groups ~group_size:1 [ judge_named "j1"; judge_named "j2" ] with
-  | Error (Fusion_policy.Staged_group_size_below_min 1) -> ()
-  | _ -> Alcotest.fail "expected Staged_group_size_below_min"
 
 (* --- JOJ 1차 심판 TOML 파싱 (RFC-0283). parse_judge_spec + finish_preset의
        [[...judges]] array-of-tables 리더를 end-to-end로 검증한다. 위 of_preset
@@ -1407,14 +1288,10 @@ let () =
         ; Alcotest.test_case "missing_default" `Quick test_config_missing_default
         ; Alcotest.test_case "missing_prompt" `Quick test_config_missing_prompt
         ; Alcotest.test_case "missing_judge_model" `Quick test_config_missing_judge_model
-        ; Alcotest.test_case "bad_staged_judge_group_size" `Quick
-            test_config_bad_staged_judge_group_size
-        ; Alcotest.test_case "council_staged_eligible" `Quick
-            test_config_council_preset_is_staged_eligible
-        ; Alcotest.test_case "shipped_runtime_council_staged_eligible" `Quick
-            test_shipped_runtime_council_is_staged_eligible
-        ; Alcotest.test_case "two_judges_not_staged_eligible" `Quick
-            test_config_two_judges_not_staged_eligible
+        ; Alcotest.test_case "council_judge_order" `Quick
+            test_config_council_preserves_judge_order
+        ; Alcotest.test_case "shipped_runtime_council_judge_order" `Quick
+            test_shipped_runtime_council_preserves_judge_order
         ; Alcotest.test_case "removed_output_budget_fields_rejected" `Quick
             test_config_rejects_removed_output_budget_fields
         ; Alcotest.test_case "empty_default_preset" `Quick test_config_empty_default_preset
@@ -1435,12 +1312,6 @@ let () =
         ; Alcotest.test_case "judge_prompt_missing" `Quick test_validated_judge_prompt_missing
         ; Alcotest.test_case "duplicate_judge" `Quick test_validated_duplicate_judge
         ; Alcotest.test_case "bad_meta_timeout" `Quick test_validated_bad_meta_timeout
-        ] )
-    ; ( "staged_judge_groups"
-      , [ Alcotest.test_case "exact_3x3" `Quick test_staged_judge_groups_exact_3x3
-        ; Alcotest.test_case "too_few" `Quick test_staged_judge_groups_too_few
-        ; Alcotest.test_case "ragged" `Quick test_staged_judge_groups_ragged
-        ; Alcotest.test_case "bad_size" `Quick test_staged_judge_groups_bad_size
         ] )
     ; ( "judge_args"
       , [ Alcotest.test_case "single_group_identity" `Quick

--- a/test/fusion_core/test_fusion.ml
+++ b/test/fusion_core/test_fusion.ml
@@ -1168,7 +1168,7 @@ let test_topology_unknown_is_none () =
 let test_topology_strings () =
   Alcotest.(check (list string))
     "all topology wire strings"
-    [ "simple"; "refine"; "conditional"; "judge_of_judges"; "staged_judge_of_judges" ]
+    [ "simple"; "refine"; "conditional"; "judge_of_judges" ]
     all_fusion_topology_strings
 
 (* Conditional 에스컬레이트 정책 — 닫힌 합 전수 값-핀. Insufficient만 escalate. *)

--- a/test/fusion_core/test_fusion_config_json.ml
+++ b/test/fusion_core/test_fusion_config_json.ml
@@ -6,7 +6,7 @@
 let parse s = Otoml.Parser.from_string s
 
 (* Mirrors config/runtime.toml [fusion.presets.quorum] structure with placeholder
-   model ids; judges >= 2 so the JoJ array-of-tables projection is exercised. *)
+   model ids so the JoJ array-of-tables projection is exercised. *)
 let joj_preset_toml =
   {|
 [fusion]

--- a/test/test_fusion_metrics.ml
+++ b/test/test_fusion_metrics.ml
@@ -21,8 +21,6 @@ let test_labels () =
     (Fusion_metrics.topology_label Fusion_types.Simple);
   check string "topology judge_of_judges" "judge_of_judges"
     (Fusion_metrics.topology_label Fusion_types.Judge_of_judges);
-  check string "topology staged_judge_of_judges" "staged_judge_of_judges"
-    (Fusion_metrics.topology_label Fusion_types.Staged_judge_of_judges);
   check string "role single" "single"
     (Fusion_metrics.judge_role_label Fusion_types.Single);
   check string "role first" "first"

--- a/test/test_fusion_wake.ml
+++ b/test/test_fusion_wake.ml
@@ -209,7 +209,6 @@ let fusion_tool_policy () : Fusion_policy.t =
   in
   { enabled = true
   ; default_preset = preset.name
-  ; staged_judge_group_size = Fusion_policy.default_staged_judge_group_size
   ; presets = [ validated_preset preset ]
   }
 ;;


### PR DESCRIPTION
## Outcome

- staged_judge_group_size/minimum/full-group/divisibility 정책·config·JSON projection을 삭제합니다.
- numeric eligibility/rejection과 그것을 증명하던 테스트를 함께 삭제합니다.
- council은 typed judge 목록 전체의 선언 순서만 검증합니다.
- panel/first-judge fan-out의 max_fibers 숫자 배선을 제거하고 입력 컬렉션 전체를 OAS/Eio 기본 fan-out에 넘깁니다.
- 제거된 fusion root key가 조용히 무시되지 않도록 [fusion] root schema의 unknown field는 Unexpected_field로 명시 실패합니다.

## Stack contract

- Parent: #24709 (C15). #24671 → #24709 → 이 PR 순서입니다.
- C15 단독의 orphan numeric config를 이 PR이 제거하며, C16까지 적용된 상태에서 selected live runtime/config/test surface의 staged numeric governance 검색 결과는 0건입니다.
- Stage_meta/Final_meta observation residue와 과거 RFC 문구 정리는 별도 작은 legacy-purge child로 분리합니다.
- Durable canonical request/channel replay는 여전히 다음 P0입니다. Recovery_required는 실제 재실행이 아닙니다.

## Verification

- Changed lines: 378 (58 additions, 320 deletions)
- ocamlformat on touched OCaml files: PASS
- ocamlc parse on touched OCaml files/interfaces: PASS
- exact staged numeric/max_fibers residue scan on live Fusion runtime/config/tests: 0
- git diff --check: PASS
- Focused Dune wrapper: /tmp/me-dune-local.lock을 다른 정상 작업(PID 94597)이 보유해 대기만 했고, 우회/kill 없이 중단했습니다. CI가 build authority이며 green으로 과장하지 않습니다.