### PR TITLE
feat(keeper): queue configured compaction on owner lane

### DIFF
--- a/lib/keeper/keeper_guard.ml
+++ b/lib/keeper/keeper_guard.ml
@@ -36,30 +36,54 @@ let event_priority = function
   | Operator_clear_requested _ -> 10
   | Context_overflow_detected _ -> 10
 
+let configured_compaction_trigger
+      ~ratio_gate
+      ~message_gate
+      ~token_gate
+      ~cooldown_sec
+      ~context_ratio
+      ~message_count
+      ~token_count
+      ~since_last_compaction_sec
+  =
+  let cooldown_ok =
+    since_last_compaction_sec >= float_of_int cooldown_sec
+  in
+  if not cooldown_ok
+  then None
+  else if context_ratio >= ratio_gate
+  then
+    Some
+      (Compaction_trigger.Ratio_threshold
+         { ratio = context_ratio; threshold = ratio_gate })
+  else if message_gate > 0 && message_count >= message_gate
+  then
+    Some
+      (Compaction_trigger.Message_count
+         { count = message_count; threshold = message_gate })
+  else if token_gate > 0 && token_count >= token_gate
+  then
+    Some
+      (Compaction_trigger.Token_count
+         { count = token_count; threshold = token_gate })
+  else None
+;;
+
 let context_actions (s : measurement_snapshot) : context_actions =
   let t = s.thresholds in
-  (* Compaction: any of 3 explicit context-capacity gates.
-     NOTE(boundary): compact_tok uses raw token_count — ideally MASC would
-     use only ratio-based checks (compact_ratio). The token_gate remains
-     because it is a user-configurable compaction parameter persisted in
-     keeper meta, exposed via dashboard config panel, and referenced in 30+
-     sites. Removing it requires a cross-cutting migration. Until then,
-     token_gate=0 (the default for most profiles) disables this gate. *)
-  let compact_ratio = s.context.context_ratio >= t.compaction_ratio_gate in
-  let compact_msg =
-    t.compaction_message_gate > 0
-    && s.context.message_count >= t.compaction_message_gate
-  in
-  let compact_tok =
-    t.compaction_token_gate > 0
-    && s.context.token_count >= t.compaction_token_gate
-  in
-  let cooldown_ok =
-    s.timing.since_last_compaction_sec >= float_of_int t.compaction_cooldown_sec
-  in
   (* Handoff: context ratio above threshold *)
   let handoff_threshold = t.handoff_threshold *. t.model_handoff_multiplier in
-  { compact = (compact_ratio || compact_msg || compact_tok) && cooldown_ok
+  { compact =
+      Option.is_some
+        (configured_compaction_trigger
+           ~ratio_gate:t.compaction_ratio_gate
+           ~message_gate:t.compaction_message_gate
+           ~token_gate:t.compaction_token_gate
+           ~cooldown_sec:t.compaction_cooldown_sec
+           ~context_ratio:s.context.context_ratio
+           ~message_count:s.context.message_count
+           ~token_count:s.context.token_count
+           ~since_last_compaction_sec:s.timing.since_last_compaction_sec)
   ; handoff =
       t.auto_handoff_enabled
       && s.context.context_ratio >= handoff_threshold

--- a/lib/keeper/keeper_guard.mli
+++ b/lib/keeper/keeper_guard.mli
@@ -20,6 +20,17 @@ val context_actions :
   Keeper_measurement.measurement_snapshot ->
   Keeper_state_machine.context_actions
 
+val configured_compaction_trigger :
+  ratio_gate:float ->
+  message_gate:int ->
+  token_gate:int ->
+  cooldown_sec:int ->
+  context_ratio:float ->
+  message_count:int ->
+  token_count:int ->
+  since_last_compaction_sec:float ->
+  Compaction_trigger.t option
+
 (** Select the highest-priority event from the guard output.
     Priority: Crash > Compact > Handoff > No_transition.
     Returns [Heartbeat_ok] if the list is empty (no transitions needed). *)

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -135,6 +135,7 @@ let connector_attention_event_ids_of_stimuli stimuli =
       | Keeper_event_queue.Hitl_resolved _
       | Keeper_event_queue.Failure_judgment _
       | Keeper_event_queue.Manual_compaction_requested
+      | Keeper_event_queue.Configured_compaction_requested _
       | Keeper_event_queue.Goal_assigned _ ->
         None)
     stimuli
@@ -155,6 +156,7 @@ let record_schedule_due_turn_started_reactions ~ctx ~keeper_name stimuli =
        | Keeper_event_queue.Hitl_resolved _
        | Keeper_event_queue.Failure_judgment _
        | Keeper_event_queue.Manual_compaction_requested
+       | Keeper_event_queue.Configured_compaction_requested _
        | Keeper_event_queue.Goal_assigned _ -> ())
     stimuli
 ;;
@@ -225,6 +227,7 @@ let failure_judgment_of_stimuli = function
            | Keeper_event_queue.Connector_attention _
            | Keeper_event_queue.Hitl_resolved _
            | Keeper_event_queue.Manual_compaction_requested
+           | Keeper_event_queue.Configured_compaction_requested _
            | Keeper_event_queue.Goal_assigned _ ->
              false)
         stimuli
@@ -232,9 +235,12 @@ let failure_judgment_of_stimuli = function
     else Ok None
 ;;
 
-let manual_compaction_requested_of_stimuli = function
-  | [ { Keeper_event_queue.payload = Manual_compaction_requested; _ } ] -> true
-  | [] | [ _ ] | _ :: _ :: _ -> false
+let compaction_request_of_stimuli = function
+  | [ { Keeper_event_queue.payload = Manual_compaction_requested; _ } ] ->
+    Some Compaction_trigger.Manual
+  | [ { Keeper_event_queue.payload = Configured_compaction_requested trigger; _ } ] ->
+    Some trigger
+  | [] | [ _ ] | _ :: _ :: _ -> None
 ;;
 
 let failure_judgment_successor
@@ -333,8 +339,8 @@ let resume_owner_lane_after_context_compaction ~base_path ~keeper_name = functio
       | Cycle.Skipped _
       | Cycle.Busy _
       | Cycle.Judgment_settled _
-      | Cycle.Manual_compaction_failed _
-      | Cycle.Manual_compaction_applied _ )
+      | Cycle.Requested_compaction_failed _
+      | Cycle.Requested_compaction_applied _ )
   | None ->
     None
 ;;
@@ -374,8 +380,8 @@ let settlement_of_cycle_outcome ~base_path ~settled_at ~stop_requested ~lease ou
          Keeper_registry_event_queue.Approval_grant_state_unavailable)
   | None ->
     (match outcome with
-  | Some (Cycle.Manual_compaction_applied _ as applied) ->
-    (match Cycle.manual_compaction_followup_failure applied with
+  | Some (Cycle.Requested_compaction_applied _ as applied) ->
+    (match Cycle.requested_compaction_followup_failure applied with
      | Some
          ({ Keeper_unified_turn.source_lease_disposition =
               Keeper_unified_turn.Follow_failure_route
@@ -422,7 +428,7 @@ let settlement_of_cycle_outcome ~base_path ~settled_at ~stop_requested ~lease ou
                { judge_runtime_id; rationale }
          ; successor = None
          })
-  | Some (Cycle.Manual_compaction_failed _) ->
+  | Some (Cycle.Requested_compaction_failed _) ->
     Keeper_registry_event_queue.Requeue
       Keeper_registry_event_queue.Context_compaction_retry
   | None ->
@@ -536,8 +542,8 @@ let run_keepalive_unified_turn
           | Cycle.Skipped _
           | Cycle.Busy _
           | Cycle.Judgment_settled _
-          | Cycle.Manual_compaction_failed _
-          | Cycle.Manual_compaction_applied _ )
+          | Cycle.Requested_compaction_failed _
+          | Cycle.Requested_compaction_applied _ )
       | None ->
         record_crashed_cycle_failure
           ~base_path:ctx.config.base_path
@@ -588,8 +594,8 @@ let run_keepalive_unified_turn
         | Ok judgment -> judgment
         | Error message -> raise (Event_queue_settlement_failed message)
       in
-      let manual_compaction_requested =
-        manual_compaction_requested_of_stimuli event_intake.consumed_stimuli
+      let compaction_request =
+        compaction_request_of_stimuli event_intake.consumed_stimuli
       in
       (match event_intake.event_queue_claim_error with
        | None -> ()
@@ -801,7 +807,7 @@ let run_keepalive_unified_turn
               ~shared_context
               ~wake
               ?failure_judgment
-              ~manual_compaction_requested
+              ?compaction_request
               ()
           in
           cycle_outcome_ref := Some cycle_outcome;
@@ -855,12 +861,12 @@ let run_keepalive_unified_turn
           | Some (Cycle.Judgment_settled _) ->
             record_settlement_failure
               "failure judgment completed without an owning event queue lease"
-          | Some (Cycle.Manual_compaction_failed _) ->
+          | Some (Cycle.Requested_compaction_failed _) ->
             record_settlement_failure
-              "manual compaction failed without an owning event queue lease"
-          | Some (Cycle.Manual_compaction_applied _) ->
+              "requested compaction failed without an owning event queue lease"
+          | Some (Cycle.Requested_compaction_applied _) ->
             record_settlement_failure
-              "manual compaction completed without an owning event queue lease"
+              "requested compaction completed without an owning event queue lease"
           | Some
               ( Cycle.Completed _
               | Cycle.Cancelled _

--- a/lib/keeper/keeper_heartbeat_loop_cycle.ml
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.ml
@@ -51,11 +51,11 @@ type cycle_outcome =
       { meta : keeper_meta
       ; outcome : failure_judgment_terminal
       }
-  | Manual_compaction_failed of
+  | Requested_compaction_failed of
       { meta : keeper_meta
       ; failure : Keeper_manual_compaction.failure
       }
-  | Manual_compaction_applied of cycle_outcome
+  | Requested_compaction_applied of cycle_outcome
 
 and failure_judgment_terminal =
   | Judgment_boundary_failed of { detail : string }
@@ -71,26 +71,26 @@ let rec meta = function
   | Failed { meta; _ }
   | Busy { meta; _ }
   | Judgment_settled { meta; _ }
-  | Manual_compaction_failed { meta; _ } ->
+  | Requested_compaction_failed { meta; _ } ->
     meta
-  | Manual_compaction_applied outcome -> meta outcome
+  | Requested_compaction_applied outcome -> meta outcome
 ;;
 
 let rec turn_failure = function
   | Failed { failure; _ } -> Some failure
-  | Manual_compaction_applied outcome -> turn_failure outcome
+  | Requested_compaction_applied outcome -> turn_failure outcome
   | Completed _ | Cancelled _ | Skipped _ | Busy _
-  | Judgment_settled _ | Manual_compaction_failed _ -> None
+  | Judgment_settled _ | Requested_compaction_failed _ -> None
 ;;
 
-let manual_compaction_followup_failure = function
-  | Manual_compaction_applied outcome -> turn_failure outcome
+let requested_compaction_followup_failure = function
+  | Requested_compaction_applied outcome -> turn_failure outcome
   | Completed _ | Cancelled _ | Skipped _ | Failed _ | Busy _
-  | Judgment_settled _ | Manual_compaction_failed _ -> None
+  | Judgment_settled _ | Requested_compaction_failed _ -> None
 ;;
 
-let with_manual_compaction applied outcome =
-  if applied then Manual_compaction_applied outcome else outcome
+let with_requested_compaction applied outcome =
+  if applied then Requested_compaction_applied outcome else outcome
 ;;
 
 let record_failure_judgment_outcome
@@ -210,19 +210,24 @@ let run_keeper_cycle_admitted
       ~shared_context
       ~(wake : Keeper_registry.wake_reason)
       ?failure_judgment
-      ?(manual_compaction_requested = false)
+      ?compaction_request
       ()
   =
   let admitted_execution =
     In_turn_pulse.with_in_turn_liveness_pulse ~ctx ~meta:meta_after_triage ~stop (fun () ->
       let prepared =
-        if manual_compaction_requested
-        then
-          (match Keeper_manual_compaction.run ~config:ctx.config ~meta:meta_after_triage with
+        match compaction_request with
+        | Some trigger ->
+          (match
+             Keeper_manual_compaction.run
+               ~config:ctx.config
+               ~meta:meta_after_triage
+               ~trigger
+           with
            | Error failure -> `Compaction_failed failure
            | Ok _ -> `Run (obs, true))
-        else
-          match failure_judgment with
+        | None ->
+          (match failure_judgment with
           | None -> `Run (obs, false)
           | Some request ->
             (match
@@ -233,7 +238,7 @@ let run_keeper_cycle_admitted
                  obs
              with
              | `Run observation -> `Run (observation, false)
-             | `Settle outcome -> `Settle outcome)
+             | `Settle outcome -> `Settle outcome))
       in
       match prepared with
       | `Compaction_failed failure -> `Compaction_failed failure
@@ -264,7 +269,7 @@ let run_keeper_cycle_admitted
       ~keeper_name:meta_after_triage.name
       "manual compaction failed in owner lane: %s"
       (Keeper_manual_compaction.failure_to_string failure);
-    Manual_compaction_failed { meta = meta_after_triage; failure }
+    Requested_compaction_failed { meta = meta_after_triage; failure }
   | `Judgment outcome -> Judgment_settled { meta = meta_after_triage; outcome }
   | `Turn (Error failure, manual_compaction_applied) ->
     let err = failure.Keeper_unified_turn.error in
@@ -320,13 +325,13 @@ let run_keeper_cycle_admitted
           ();
         meta_after_triage
     in
-    with_manual_compaction manual_compaction_applied (Failed { meta; failure })
+    with_requested_compaction manual_compaction_applied (Failed { meta; failure })
   | `Turn (Ok (Keeper_unified_turn.Turn_completed updated), applied) ->
-    with_manual_compaction applied (Completed updated)
+    with_requested_compaction applied (Completed updated)
   | `Turn (Ok (Keeper_unified_turn.Turn_cancelled meta), applied) ->
-    with_manual_compaction applied (Cancelled meta)
+    with_requested_compaction applied (Cancelled meta)
   | `Turn (Ok (Keeper_unified_turn.Turn_skipped meta), applied) ->
-    with_manual_compaction applied (Skipped meta)
+    with_requested_compaction applied (Skipped meta)
 ;;
 
 let run_keeper_cycle
@@ -341,7 +346,7 @@ let run_keeper_cycle
       ~shared_context
       ~(wake : Keeper_registry.wake_reason)
       ?failure_judgment
-      ?manual_compaction_requested
+      ?compaction_request
       ()
   =
   match
@@ -357,7 +362,7 @@ let run_keeper_cycle
          ~shared_context
          ~wake
          ?failure_judgment
-         ?manual_compaction_requested
+         ?compaction_request
          ?event_bus
          ?hitl_resolution
          ?continuation_delivery_channel)

--- a/lib/keeper/keeper_heartbeat_loop_cycle.mli
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.mli
@@ -16,11 +16,11 @@ type cycle_outcome =
       { meta : Keeper_meta_contract.keeper_meta
       ; outcome : failure_judgment_terminal
       }
-  | Manual_compaction_failed of
+  | Requested_compaction_failed of
       { meta : Keeper_meta_contract.keeper_meta
       ; failure : Keeper_manual_compaction.failure
       }
-  | Manual_compaction_applied of cycle_outcome
+  | Requested_compaction_applied of cycle_outcome
 
 and failure_judgment_terminal =
   | Judgment_boundary_failed of { detail : string }
@@ -35,7 +35,7 @@ val meta : cycle_outcome -> Keeper_meta_contract.keeper_meta
     admitted.  Queue ownership must inspect the full {!cycle_outcome}; this
     projection alone is never completion evidence. *)
 
-val manual_compaction_followup_failure
+val requested_compaction_followup_failure
   :  cycle_outcome
   -> Keeper_unified_turn.turn_failure option
 (** The following-turn failure only when manual compaction already committed.
@@ -54,6 +54,6 @@ val run_keeper_cycle
   -> shared_context:Agent_sdk.Context.t
   -> wake:Keeper_registry.wake_reason
   -> ?failure_judgment:Keeper_event_queue.failure_judgment
-  -> ?manual_compaction_requested:bool
+  -> ?compaction_request:Compaction_trigger.t
   -> unit
   -> cycle_outcome

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -98,6 +98,8 @@ let event_queue_trigger_of_stimulus (stim : Keeper_event_queue.stimulus) =
     Some Keeper_world_observation.Failure_judgment_stimulus
   | Keeper_event_queue.Manual_compaction_requested ->
     Some Keeper_world_observation.Manual_compaction_stimulus
+  | Keeper_event_queue.Configured_compaction_requested _ ->
+    Some Keeper_world_observation.Configured_compaction_stimulus
   | Keeper_event_queue.Board_signal _
   | Keeper_event_queue.Board_attention _
   | Keeper_event_queue.Fusion_completed _
@@ -184,6 +186,12 @@ let consume_single_heartbeat_stimulus
   | Keeper_event_queue.Manual_compaction_requested ->
     Log.Keeper.info
       "turn entry: manual compaction request delivered (keeper=%s)"
+      meta_after_triage.name;
+    []
+  | Keeper_event_queue.Configured_compaction_requested trigger ->
+    Log.Keeper.info
+      "turn entry: configured compaction delivered trigger=%s (keeper=%s)"
+      (Compaction_trigger.to_human trigger)
       meta_after_triage.name;
     []
   | Keeper_event_queue.Bootstrap ->
@@ -285,6 +293,7 @@ let stimulus_ready_for_intake (stimulus : Keeper_event_queue.stimulus) =
   | Keeper_event_queue.Connector_attention _
   | Keeper_event_queue.Failure_judgment _
   | Keeper_event_queue.Manual_compaction_requested
+  | Keeper_event_queue.Configured_compaction_requested _
   | Keeper_event_queue.Goal_assigned _ ->
     true
 ;;

--- a/lib/keeper/keeper_manual_compaction.ml
+++ b/lib/keeper/keeper_manual_compaction.ml
@@ -2,6 +2,7 @@ open Keeper_meta_contract
 type success =
   { recovery : Keeper_context_runtime.overflow_retry_recovery }
 type failure =
+  | Unsupported_trigger of Compaction_trigger.t
   | Lifecycle of string * bool * Keeper_context_runtime.lifecycle_dispatch_error
   | Recovery of
       Keeper_post_turn.compaction_recovery_error
@@ -39,7 +40,12 @@ let append_manifest ~config ~base_dir ~(meta : keeper_meta) recovery =
       Keeper_runtime_manifest.clock_refs_for_context
         context
         ~event:Keeper_runtime_manifest.Context_compacted
-        ~compaction_source:"operator_manual"
+        ~compaction_source:
+          (match trigger with
+           | Compaction_trigger.Manual -> "operator_manual"
+           | Ratio_threshold _ | Message_count _ | Token_count _ ->
+             "configured_threshold"
+           | Provider_overflow _ -> "provider_overflow")
         ()
     in
     Keeper_runtime_manifest.make_for_context
@@ -63,11 +69,11 @@ let append_manifest ~config ~base_dir ~(meta : keeper_meta) recovery =
       ()
     |> Keeper_runtime_manifest.append_once ~operation_id:recovery.operation_id config
 ;;
-let run ~(config : Workspace.config) ~(meta : keeper_meta) =
+let run ~(config : Workspace.config) ~(meta : keeper_meta) ~trigger =
   let dispatch stage event =
     Keeper_context_runtime.dispatch_keeper_phase_event_result
       ~config
-      ~origin:Keeper_registry.Operator_compact
+      ~origin:Keeper_registry.Requested_compaction
       ~keeper_name:meta.name
       event
     |> Result.map_error (fun error ->
@@ -76,11 +82,18 @@ let run ~(config : Workspace.config) ~(meta : keeper_meta) =
   let dispatch_failed reason =
     Keeper_context_runtime.dispatch_keeper_phase_event_result
       ~config
-      ~origin:Keeper_registry.Operator_compact
+      ~origin:Keeper_registry.Requested_compaction
       ~keeper_name:meta.name
       (Keeper_state_machine.Compaction_failed { reason })
   in
-  match dispatch "operator_request" Keeper_state_machine.Operator_compact_requested with
+  let request_dispatch =
+    match trigger with
+    | Compaction_trigger.Manual ->
+      dispatch "operator_request" Keeper_state_machine.Operator_compact_requested
+    | Ratio_threshold _ | Message_count _ | Token_count _ -> Ok ()
+    | Provider_overflow _ -> Error (Unsupported_trigger trigger)
+  in
+  match request_dispatch with
   | Error _ as error -> error
   | Ok () ->
     (match dispatch "compaction_started" Keeper_state_machine.Compaction_started with
@@ -93,7 +106,7 @@ let run ~(config : Workspace.config) ~(meta : keeper_meta) =
           Keeper_context_runtime.recover_latest_checkpoint_for_overflow_retry
             ~base_dir
             ~meta
-            ~trigger:Compaction_trigger.Manual
+            ~trigger
             ~primary_model_max_tokens:(primary_max_context meta)
         with
         | Error error ->
@@ -115,7 +128,7 @@ let run ~(config : Workspace.config) ~(meta : keeper_meta) =
                 Keeper_context_runtime.dispatch_compaction_completed
                   ~config
                   ~keeper_name:meta.name
-                  ~origin:Keeper_registry.Operator_compact
+                  ~origin:Keeper_registry.Requested_compaction
               with
               | Error error ->
                 Error (Lifecycle ("compaction_completed", true, error))
@@ -128,6 +141,8 @@ let dispatch_result_to_string = function
 ;;
 
 let failure_to_string = function
+  | Unsupported_trigger trigger ->
+    Printf.sprintf "unsupported_trigger=%s" (Compaction_trigger.to_human trigger)
   | Lifecycle (stage, checkpoint_applied, error) ->
     Printf.sprintf
       "stage=%s checkpoint_applied=%b error=%s"

--- a/lib/keeper/keeper_manual_compaction.mli
+++ b/lib/keeper/keeper_manual_compaction.mli
@@ -1,6 +1,7 @@
 type success =
   { recovery : Keeper_context_runtime.overflow_retry_recovery }
 type failure =
+  | Unsupported_trigger of Compaction_trigger.t
   | Lifecycle of string * bool * Keeper_context_runtime.lifecycle_dispatch_error
   | Recovery of
       Keeper_post_turn.compaction_recovery_error
@@ -14,5 +15,6 @@ type failure =
 val run
   :  config:Workspace.config
   -> meta:Keeper_meta_contract.keeper_meta
+  -> trigger:Compaction_trigger.t
   -> (success, failure) result
 val failure_to_string : failure -> string

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -15,6 +15,7 @@ type stimulus_kind =
   | Failure_judgment
       (* RFC-0313 W2: deterministic turn-failure escalated for LLM judgment. *)
   | Manual_compaction
+  | Configured_compaction
   | Goal_assigned
       (* RFC-0315 P3 W0: goal entered active_goal_ids — assignment edge wake. *)
 
@@ -44,6 +45,7 @@ let stimulus_kind_to_string = function
   | Hitl_resolved -> "hitl_resolved"
   | Failure_judgment -> "failure_judgment"
   | Manual_compaction -> "manual_compaction"
+  | Configured_compaction -> "configured_compaction"
   | Goal_assigned -> "goal_assigned"
 ;;
 
@@ -61,6 +63,7 @@ let stimulus_kind_of_string = function
   | "hitl_resolved" -> Some Hitl_resolved
   | "failure_judgment" -> Some Failure_judgment
   | "manual_compaction" -> Some Manual_compaction
+  | "configured_compaction" -> Some Configured_compaction
   | "goal_assigned" -> Some Goal_assigned
   | _ -> None
 ;;
@@ -117,6 +120,7 @@ let stimulus_kind_of_event_queue (stimulus : Keeper_event_queue.stimulus) =
   | Keeper_event_queue.Hitl_resolved _ -> Hitl_resolved
   | Keeper_event_queue.Failure_judgment _ -> Failure_judgment
   | Keeper_event_queue.Manual_compaction_requested -> Manual_compaction
+  | Keeper_event_queue.Configured_compaction_requested _ -> Configured_compaction
   | Keeper_event_queue.Goal_assigned _ -> Goal_assigned
 ;;
 
@@ -222,6 +226,10 @@ let stimulus_payload_preview (payload : Keeper_event_queue.stimulus_payload) =
       (Keeper_runtime_failure_route.judgment_class_label fj.fj_judgment)
       (Keeper_runtime_failure_route.judgment_provenance_label fj.fj_provenance)
   | Keeper_event_queue.Manual_compaction_requested -> "manual_compaction_requested"
+  | Keeper_event_queue.Configured_compaction_requested trigger ->
+    Printf.sprintf
+      "configured_compaction_requested trigger=%s"
+      (Compaction_trigger.to_human trigger)
   | Keeper_event_queue.Goal_assigned ga ->
     Printf.sprintf
       "goal_assigned goal_id=%s assigned_by=%s"
@@ -245,6 +253,7 @@ let stimulus_json ~keeper_name (stimulus : Keeper_event_queue.stimulus) =
     | Keeper_event_queue.Hitl_resolved _
     | Keeper_event_queue.Failure_judgment _
     | Keeper_event_queue.Manual_compaction_requested
+    | Keeper_event_queue.Configured_compaction_requested _
     | Keeper_event_queue.Goal_assigned _ -> None
   in
   `Assoc
@@ -576,6 +585,7 @@ let event_queue_reaction_evidence_with_iter ~keeper_name ~stimulus_id iter =
        | None -> ())
     | Some _
     | None -> ());
+  in
   iteration,
   { keeper_name
   ; stimulus_id
@@ -997,7 +1007,8 @@ let summarize_rows ~keeper_name ~limit rows =
        | Some
            ( Board_signal | Bootstrap | Fusion_completed
            | Bg_completed | Schedule_due | Connector_attention | Hitl_resolved
-           | Failure_judgment | Manual_compaction | Goal_assigned )
+           | Failure_judgment | Manual_compaction | Configured_compaction
+           | Goal_assigned )
          -> ())
   in
   let note_payload_parse_error row =

--- a/lib/keeper/keeper_reaction_ledger.mli
+++ b/lib/keeper/keeper_reaction_ledger.mli
@@ -22,6 +22,7 @@ type stimulus_kind =
   | Failure_judgment
       (** RFC-0313 W2: deterministic turn-failure escalated for LLM judgment. *)
   | Manual_compaction
+  | Configured_compaction
   | Goal_assigned
       (** RFC-0315 P3 W0: goal entered active_goal_ids — assignment edge wake. *)
 

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -179,6 +179,7 @@ let board_attention_event_id (stimulus : Keeper_event_queue.stimulus) =
   | Keeper_event_queue.Hitl_resolved _
   | Keeper_event_queue.Failure_judgment _
   | Keeper_event_queue.Manual_compaction_requested
+  | Keeper_event_queue.Configured_compaction_requested _
   | Keeper_event_queue.Goal_assigned _ ->
     None
 ;;

--- a/lib/keeper/keeper_registry_event_validators.ml
+++ b/lib/keeper/keeper_registry_event_validators.ml
@@ -24,7 +24,7 @@ let paired_lifecycle_origin origin event =
                (match event with
                 | Keeper_state_machine.Compaction_started
                 | Keeper_state_machine.Compaction_completed
-                | Keeper_state_machine.Compaction_failed _ -> " or origin=operator_compact"
+                | Keeper_state_machine.Compaction_failed _ -> " or origin=requested_compaction"
                 | _ -> "")
                (lifecycle_event_origin_to_string origin)
          })

--- a/lib/keeper/keeper_registry_types.ml
+++ b/lib/keeper/keeper_registry_types.ml
@@ -249,12 +249,12 @@ let completed_turn_outcome_of_observation (obs : turn_observation)
 type lifecycle_event_origin =
   | Generic_dispatch
   | Post_turn_lifecycle
-  | Operator_compact
+  | Requested_compaction
 
 let lifecycle_event_origin_to_string = function
   | Generic_dispatch -> "generic_dispatch"
   | Post_turn_lifecycle -> "post_turn_lifecycle"
-  | Operator_compact -> "operator_compact"
+  | Requested_compaction -> "requested_compaction"
 ;;
 
 let is_paired_lifecycle_event = function
@@ -282,9 +282,9 @@ let origin_allows_paired_lifecycle_event origin event =
     match origin with
     | Post_turn_lifecycle -> true
     | Generic_dispatch -> false
-    | Operator_compact ->
-      (* Operator_compact authorizes only compaction half-events;
-         handoff half-events flow through other origins. *)
+    | Requested_compaction ->
+      (* Owner-lane manual/configured requests authorize only compaction
+         half-events; handoff half-events flow through other origins. *)
       (match event with
        | Keeper_state_machine.Compaction_started
        | Keeper_state_machine.Compaction_completed

--- a/lib/keeper/keeper_registry_types.mli
+++ b/lib/keeper/keeper_registry_types.mli
@@ -625,7 +625,7 @@ val completed_turn_outcome_of_observation :
 type lifecycle_event_origin =
   | Generic_dispatch
   | Post_turn_lifecycle
-  | Operator_compact
+  | Requested_compaction
 
 (** Pure converter for diagnostic / log labels. *)
 val lifecycle_event_origin_to_string : lifecycle_event_origin -> string

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -54,6 +54,71 @@ type terminal_outcome =
 type handle_result =
   | Completed of Keeper_meta_contract.keeper_meta
 
+let enqueue_configured_compaction
+      ~base_path
+      ~(meta : Keeper_meta_contract.keeper_meta)
+      ~message_count
+      ~context_tokens
+      ~max_context
+      ~now
+  =
+  match meta.compaction.mode with
+  | Keeper_config.Deterministic -> Ok None
+  | Keeper_config.Llm ->
+    let token_count = Option.value context_tokens ~default:0 in
+    let context_ratio =
+      if max_context > 0
+      then float_of_int token_count /. float_of_int max_context
+      else 0.0
+    in
+    (match
+       Keeper_guard.configured_compaction_trigger
+         ~ratio_gate:meta.compaction.ratio_gate
+         ~message_gate:meta.compaction.message_gate
+         ~token_gate:meta.compaction.token_gate
+         ~cooldown_sec:meta.compaction.cooldown_sec
+         ~context_ratio
+         ~message_count
+         ~token_count
+         ~since_last_compaction_sec:
+           (Float.max 0.0 (now -. meta.runtime.compaction_rt.last_ts))
+     with
+     | None -> Ok None
+     | Some trigger ->
+       let wake_owner () =
+         Keeper_registry.wakeup
+           ~intent:Keeper_registry.Compaction_signal
+           ~base_path
+           meta.name
+         |> ignore
+       in
+       let stimulus : Keeper_event_queue.stimulus =
+         { post_id = Keeper_event_queue.configured_compaction_post_id
+         ; urgency = Normal
+         ; arrived_at = now
+         ; payload = Configured_compaction_requested trigger
+         }
+       in
+       (match
+          Keeper_registry_event_queue.enqueue_stimulus_durable_result
+            ~base_path
+            meta.name
+            stimulus
+        with
+        | Stimulus_storage_error detail ->
+          Log.Keeper.error
+            ~keeper_name:meta.name
+            "configured compaction enqueue failed: %s"
+            detail;
+          Error detail
+        | Stimulus_enqueued ->
+          wake_owner ();
+          Ok (Some trigger)
+        | Stimulus_already_present ->
+          wake_owner ();
+          Ok (Some trigger)))
+;;
+
 let acknowledge_pending_messages
       (meta : Keeper_meta_contract.keeper_meta)
       (observation : Keeper_world_observation.world_observation)
@@ -541,6 +606,8 @@ module For_testing = struct
 
   let reset_turn_failures_for_stop_reason = reset_turn_failures_for_stop_reason
   let acknowledge_pending_messages = acknowledge_pending_messages
+
+  let enqueue_configured_compaction = enqueue_configured_compaction
 end
 
 let emit_terminal_fsm
@@ -670,6 +737,23 @@ let handle
       ~original_meta:meta
       ~updated_meta
   in
+  let context_tokens =
+    match usage_trust with
+    | Keeper_usage_trust.Usage_trusted -> Some result.usage.input_tokens
+    | Keeper_usage_trust.Usage_missing
+    | Keeper_usage_trust.Usage_untrusted _ -> None
+  in
+  (match lifecycle.checkpoint with
+   | None -> ()
+   | Some _ ->
+     enqueue_configured_compaction
+       ~base_path:config.base_path
+       ~meta:updated_meta
+       ~message_count:lifecycle.message_count
+       ~context_tokens
+       ~max_context:final_execution.max_context
+       ~now:(Time_compat.now ())
+     |> ignore);
   let tool_call_summaries =
     result.Keeper_agent_run.tool_calls
     |> List.map (fun (d : Keeper_agent_run.tool_call_detail) ->

--- a/lib/keeper/keeper_unified_turn_success.mli
+++ b/lib/keeper/keeper_unified_turn_success.mli
@@ -28,6 +28,15 @@ module For_testing : sig
     :  Keeper_meta_contract.keeper_meta
     -> Keeper_world_observation.world_observation
     -> Keeper_meta_contract.keeper_meta
+
+  val enqueue_configured_compaction
+    :  base_path:string
+    -> meta:Keeper_meta_contract.keeper_meta
+    -> message_count:int
+    -> context_tokens:int option
+    -> max_context:int
+    -> now:float
+    -> (Compaction_trigger.t option, string) result
 end
 
 type handle_result =

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -100,6 +100,7 @@ type event_queue_trigger =
   | Hitl_resolved_stimulus
   | Failure_judgment_stimulus
   | Manual_compaction_stimulus
+  | Configured_compaction_stimulus
 
 type turn_reason = Keeper_world_observation_turn_types.turn_reason =
   | Mention_pending
@@ -110,6 +111,7 @@ type turn_reason = Keeper_world_observation_turn_types.turn_reason =
   | Hitl_resolved_pending
   | Failure_judgment_pending
   | Manual_compaction_pending
+  | Configured_compaction_pending
   | Scheduled_autonomous_turn
   | Scheduled_automation_due
   | Task_backlog of
@@ -714,7 +716,8 @@ let pending_board_event_of_stimulus
   | Keeper_event_queue.Bootstrap
   | Keeper_event_queue.Connector_attention _
   | Keeper_event_queue.Hitl_resolved _
-  | Keeper_event_queue.Manual_compaction_requested ->
+  | Keeper_event_queue.Manual_compaction_requested
+  | Keeper_event_queue.Configured_compaction_requested _ ->
     (* RFC-connector-ambient-attention-wake P1: not a board event. The wake
        fires via the trigger itself; [Hitl_resolved] carries no observation to
        inject — the keeper resumes on its own state once the approval is gone
@@ -1099,6 +1102,9 @@ let keeper_cycle_decision
   let manual_compaction_control =
     List.mem Manual_compaction_stimulus event_queue_triggers
   in
+  let configured_compaction_control =
+    List.mem Configured_compaction_stimulus event_queue_triggers
+  in
   let failure_judgment_control =
     List.mem Failure_judgment_stimulus event_queue_triggers
   in
@@ -1133,6 +1139,13 @@ let keeper_cycle_decision
     { should_run = true
     ; channel = Reactive
     ; verdict = Run { reasons = Manual_compaction_pending, [] }
+    ; since_last_scheduled_autonomous = None
+    }
+  else if configured_compaction_control
+  then
+    { should_run = true
+    ; channel = Reactive
+    ; verdict = Run { reasons = Configured_compaction_pending, [] }
     ; since_last_scheduled_autonomous = None
     }
   else if failure_judgment_control

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -130,6 +130,7 @@ type event_queue_trigger =
   | Hitl_resolved_stimulus
   | Failure_judgment_stimulus
   | Manual_compaction_stimulus
+  | Configured_compaction_stimulus
 
 (** Typed reason for running a keeper cycle. Each variant corresponds to
     exactly one code path in {!keeper_cycle_decision}. *)
@@ -142,6 +143,7 @@ type turn_reason =
   | Hitl_resolved_pending
   | Failure_judgment_pending
   | Manual_compaction_pending
+  | Configured_compaction_pending
   | Scheduled_autonomous_turn
   | Scheduled_automation_due
   | Task_backlog of { unclaimed : int; failed : int }

--- a/lib/keeper_contract/keeper_world_observation_turn_types.ml
+++ b/lib/keeper_contract/keeper_world_observation_turn_types.ml
@@ -45,6 +45,7 @@ type event_queue_trigger =
           the independent judge even when the failed Keeper is unhealthy or
           its ordinary reactive lane is disabled. *)
   | Manual_compaction_stimulus
+  | Configured_compaction_stimulus
 
 type turn_reason =
   | Mention_pending
@@ -55,6 +56,7 @@ type turn_reason =
   | Hitl_resolved_pending
   | Failure_judgment_pending
   | Manual_compaction_pending
+  | Configured_compaction_pending
   | Scheduled_autonomous_turn
   | Scheduled_automation_due
   | Task_backlog of
@@ -84,6 +86,7 @@ let turn_reason_to_string = function
   | Hitl_resolved_pending -> "hitl_resolved_pending"
   | Failure_judgment_pending -> "failure_judgment_pending"
   | Manual_compaction_pending -> "manual_compaction_pending"
+  | Configured_compaction_pending -> "configured_compaction_pending"
   | Scheduled_autonomous_turn -> "scheduled_autonomous_turn"
   | Scheduled_automation_due -> "scheduled_automation_due"
   | Task_backlog _ -> "task_backlog"
@@ -97,6 +100,7 @@ let turn_reason_of_event_queue_trigger = function
   | Hitl_resolved_stimulus -> Hitl_resolved_pending
   | Failure_judgment_stimulus -> Failure_judgment_pending
   | Manual_compaction_stimulus -> Manual_compaction_pending
+  | Configured_compaction_stimulus -> Configured_compaction_pending
 ;;
 
 let skip_reason_to_string = function

--- a/lib/keeper_contract/keeper_world_observation_turn_types.mli
+++ b/lib/keeper_contract/keeper_world_observation_turn_types.mli
@@ -19,6 +19,7 @@ type event_queue_trigger =
   | Failure_judgment_stimulus
       (** Durable recovery control for a deterministic failed turn. *)
   | Manual_compaction_stimulus
+  | Configured_compaction_stimulus
 
 type turn_reason =
   | Mention_pending
@@ -29,6 +30,7 @@ type turn_reason =
   | Hitl_resolved_pending
   | Failure_judgment_pending
   | Manual_compaction_pending
+  | Configured_compaction_pending
   | Scheduled_autonomous_turn
   | Scheduled_automation_due
   | Task_backlog of

--- a/lib/keeper_registry/keeper_state_machine.mli
+++ b/lib/keeper_registry/keeper_state_machine.mli
@@ -113,7 +113,7 @@ type context_actions = {
     use [Post_turn_lifecycle], which runs synchronously at the tail of a
     keeper turn (inside [Keeper_unified_turn.run_keeper_cycle] or the
     legacy [Keeper_turn] path). Manual compaction uses the narrower
-    [Operator_compact] origin for compaction events only.
+    [Requested_compaction] origin for owner-lane compaction events only.
 
     The keepalive loop ({!Keeper_keepalive.run_heartbeat_loop}) does
     NOT explicitly gate dispatch on [phase]. It relies on the

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -77,6 +77,7 @@ type stimulus_payload =
          the stable per-(runtime, class) post_id lets queue identity dedup
          collapse repeats. *)
   | Manual_compaction_requested
+  | Configured_compaction_requested of Compaction_trigger.t
   | Goal_assigned of goal_assignment
       (* RFC-0315 P3 W0: a goal entered this keeper's [active_goal_ids]
          (keeper_up tool args or TOML reconcile). Wakes the keeper ONCE at
@@ -195,6 +196,7 @@ let failure_judgment_post_id (fj : failure_judgment) =
   ^ Keeper_runtime_failure_route.judgment_provenance_label fj.fj_provenance
 
 let manual_compaction_post_id = "manual-compaction-request"
+let configured_compaction_post_id = "configured-compaction-request"
 
 let goal_assignment_post_id (ga : goal_assignment) =
   (* Stable per goal: re-assigning the same goal before the keeper consumes
@@ -247,7 +249,7 @@ let identity_payload = function
     Goal_assigned { ga with ga_goal_title = ""; ga_assigned_by = "" }
   | ( Board_signal _ | Board_attention _ | Bootstrap | Fusion_completed _
     | Bg_completed _ | Schedule_due _ | Connector_attention _ | Hitl_resolved _
-    | Manual_compaction_requested
+    | Manual_compaction_requested | Configured_compaction_requested _
     ) as payload ->
     payload
 
@@ -265,6 +267,7 @@ let stimulus_identity_equal a b =
   match a.payload, b.payload with
   | Failure_judgment left, Failure_judgment right ->
     failure_judgment_identity_equal left right
+  | Configured_compaction_requested _, Configured_compaction_requested _ -> true
   | _ -> identity_payload a.payload = identity_payload b.payload
 
 let to_list (queue : t) : stimulus list =
@@ -351,13 +354,15 @@ let payload_kind_label = function
   | Hitl_resolved _ -> "hitl_resolved"
   | Failure_judgment _ -> "failure_judgment"
   | Manual_compaction_requested -> "manual_compaction_requested"
+  | Configured_compaction_requested _ -> "configured_compaction_requested"
   | Goal_assigned _ -> "goal_assigned"
 
 let is_board_signal = function
   | Board_signal _ | Board_attention _ -> true
   | Bootstrap | Fusion_completed _ | Bg_completed _
   | Schedule_due _ | Connector_attention _ | Hitl_resolved _
-  | Failure_judgment _ | Manual_compaction_requested | Goal_assigned _ ->
+  | Failure_judgment _ | Manual_compaction_requested
+  | Configured_compaction_requested _ | Goal_assigned _ ->
     false
 
 let drain_board_all (queue : t) : stimulus list * t =
@@ -567,6 +572,11 @@ let payload_to_yojson = function
       ]
   | Manual_compaction_requested ->
     `Assoc [ "kind", `String "manual_compaction_requested" ]
+  | Configured_compaction_requested trigger ->
+    `Assoc
+      [ "kind", `String "configured_compaction_requested"
+      ; "trigger", Compaction_trigger.to_detail_json trigger
+      ]
   | Goal_assigned ga ->
     `Assoc
       [ "kind", `String "goal_assigned"
@@ -697,6 +707,15 @@ let payload_of_yojson json =
          ; fj_detail = detail
          })
   | "manual_compaction_requested" -> Ok Manual_compaction_requested
+  | "configured_compaction_requested" ->
+    let* trigger_json = required_field ~context "trigger" fields in
+    (match Compaction_trigger.of_detail_json trigger_json with
+     | Some
+         ((Ratio_threshold _ | Message_count _ | Token_count _) as trigger) ->
+       Ok (Configured_compaction_requested trigger)
+     | Some (Manual | Provider_overflow _) ->
+       Error "configured compaction requires a threshold trigger"
+     | None -> Error "stimulus.payload.trigger is not a known compaction trigger")
   | "goal_assigned" ->
     let* goal_id = string_field ~context "goal_id" fields in
     let* goal_title = string_field ~context "goal_title" fields in

--- a/lib/keeper_runtime/keeper_event_queue.mli
+++ b/lib/keeper_runtime/keeper_event_queue.mli
@@ -93,6 +93,8 @@ type stimulus_payload =
   | Manual_compaction_requested
       (** Operator-requested MASC compaction. The tool only enqueues this
           stimulus; the owning Keeper consumes it under its turn slot. *)
+  | Configured_compaction_requested of Compaction_trigger.t
+      (** Typed configured threshold; performed by the owner Keeper lane. *)
   | Goal_assigned of goal_assignment
       (** A goal was newly added to this keeper's [active_goal_ids]. *)
 (** Closed set of stimulus kinds. Replaces the prior [payload : string] +
@@ -213,6 +215,7 @@ val hitl_resolution_post_id : hitl_resolution -> post_id
 val failure_judgment_post_id : failure_judgment -> post_id
 
 val manual_compaction_post_id : post_id
+val configured_compaction_post_id : post_id
 
 val goal_assignment_post_id : goal_assignment -> post_id
 

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -525,7 +525,7 @@ let test_applied_compaction_settles_followup_atomically () =
       ~stop_requested:false
       ~lease
       (Some
-         (Masc.Keeper_heartbeat_loop_cycle.Manual_compaction_applied
+         (Masc.Keeper_heartbeat_loop_cycle.Requested_compaction_applied
             (Masc.Keeper_heartbeat_loop_cycle.Failed { meta; failure })))
   in
   let judgment_failure =
@@ -580,7 +580,7 @@ let test_manifest_projection_failure_requeues_compaction () =
       ~settled_at:8.0
       ~stop_requested:false
       ~lease
-      (Some (Masc.Keeper_heartbeat_loop_cycle.Manual_compaction_failed { meta; failure }))
+      (Some (Masc.Keeper_heartbeat_loop_cycle.Requested_compaction_failed { meta; failure }))
   with
   | Masc.Keeper_registry_event_queue.Requeue
       Masc.Keeper_registry_event_queue.Context_compaction_retry ->

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -481,7 +481,7 @@ let test_manual_compaction_serializes_owner_lane () =
           ~turn_decision:decision
           ~shared_context:(Agent_sdk.Context.create_sync ())
           ~wake:(Masc.Keeper_registry.Woken [ Manual_compaction_requested ])
-          ~manual_compaction_requested:true
+          ~compaction_request:Compaction_trigger.Manual
           ()
       in
       (match run_cycle () with
@@ -519,7 +519,7 @@ let test_manual_compaction_serializes_owner_lane () =
           run_cycle
       in
       (match outcome with
-       | Cycle.Manual_compaction_applied _ -> ()
+       | Cycle.Requested_compaction_applied _ -> ()
        | _ -> fail "owner-lane cycle did not apply manual compaction");
       let compacted =
         Result.get_ok


### PR DESCRIPTION
## What changed

- turns explicit Keeper compaction ratio/message/token settings into an exact typed trigger
- durably enqueues that trigger on the owning Keeper queue after a successful checkpointed turn
- wakes only the owning lane after the queue commit; identical pending configured requests deduplicate
- routes manual and configured requests through the same MASC-owned LLM compaction executor
- preserves typed queue persistence, reaction evidence, lifecycle projection, and settlement/retry behavior
- rejects persisted configured payloads carrying manual/provider-overflow triggers

## Why

Configured compaction was observable guard state but did not reach the durable Keeper lane. This made the setting effectively dead and left post-turn context pressure disconnected from the existing MASC LLM compactor.

The new path keeps OAS free of reducers/autotruncation and does not introduce a budget stop, risk tier, provider string match, or fleet-wide gate.

## Stack

- base: #24705 `codex/compaction-overflow-manifest-commit-c2c-20260716`
- this PR: production owner-lane wiring (399 changed lines)
- next stacked PR: focused owner-only wake and unrelated-ready-work test

## Validation

- `ocamlc -stop-after parsing` for every changed `.ml` / `.mli`
- `ocamlformat --check` for every changed OCaml file
- `git diff --check`
- focused Dune wrapper was attempted, then stopped without bypassing the shared lock held by another worktree; CI remains the build authority
