### PR TITLE
test(keeper): purge retired goal fixture

### DIFF
--- a/test/test_keeper_memory_write.ml
+++ b/test/test_keeper_memory_write.ml
@@ -54,7 +54,6 @@ let make_meta name =
       (`Assoc
         [ "name", `String name
         ; "trace_id", `String ("trace-" ^ name)
-        ; "goal", `String "memory contract test"
         ])
   with
   | Error error -> Alcotest.fail ("meta fixture failed: " ^ error)


### PR DESCRIPTION
## What changed

- Remove the retired Keeper meta field `goal` from the Memory persistence test fixture.

## Why

The current strict Keeper meta parser explicitly rejects this removed field. As a result, every persistence test using the shared fixture failed before reaching its assertion. Keeping the field would test a deleted contract and make the suite falsely red.

This does not weaken an assertion or add compatibility parsing. It purges the legacy fixture so the tests exercise the current typed contract.

## Evidence

- Reproduced: `test_keeper_memory_write.exe` reported `removed keeper meta field is no longer supported: goal` and failed five persistence cases at fixture construction.
- `ocamlformat --check test/test_keeper_memory_write.ml`: pass.
- OCaml parser check: pass.
- `git diff --check`: pass.
- One deletion only.
- A new focused Dune invocation was not started while another bare Dune process owned the machine; CI remains the build authority.
