### PR TITLE
feat(keeper): claim and settle durable Memory work

### DIFF
--- a/lib/keeper/keeper_memory_work_store.ml
+++ b/lib/keeper/keeper_memory_work_store.ml
@@ -13,6 +13,12 @@ type error =
       { expected : string
       ; actual : string
       }
+  | No_matching_claim of
+      { expected : string option
+      ; actual : string
+      }
+  | Invalid_terminal_outcome of string
+  | Settlement_conflict of string
   | Write_failed of
       { path : string
       ; cause : Keeper_fs.durable_write_error
@@ -21,6 +27,24 @@ type error =
 type enqueue_result =
   | Enqueued
   | Already_present
+
+type claim_result =
+  | Queue_empty
+  | Claim_busy of string
+  | Claimed of Keeper_memory_work_request.t
+
+type terminal_outcome =
+  | Completed
+  | Failed of string
+
+type settle_result =
+  | Settled
+  | Already_settled
+
+type terminal =
+  { request : Keeper_memory_work_request.t
+  ; outcome : terminal_outcome
+  }
 
 type location =
   { base_path : string
@@ -31,9 +55,11 @@ type location =
 type state =
   { keeper_name : string
   ; pending : Keeper_memory_work_request.t list
+  ; in_flight : Keeper_memory_work_request.t option
+  ; terminal : terminal list
   }
 
-let schema_version = 1
+let schema_version = 2
 let queue_filename = "memory-work-queue.json"
 let ( let* ) = Result.bind
 
@@ -49,6 +75,14 @@ let error_to_string = function
       "Memory work queue owner mismatch: expected %s, found %s"
       expected
       actual
+  | No_matching_claim { expected; actual } ->
+    Printf.sprintf
+      "Memory work claim mismatch: expected %s, found %s"
+      (Option.value ~default:"no in-flight request" expected)
+      actual
+  | Invalid_terminal_outcome detail -> "invalid Memory work outcome: " ^ detail
+  | Settlement_conflict request_id ->
+    Printf.sprintf "Memory work settlement conflicts for request %s" request_id
   | Write_failed { path; cause } ->
     Printf.sprintf
       "Memory work queue write failed at %s: %s"
@@ -82,17 +116,34 @@ let queue_path ~base_path ~keeper_name =
   resolve_location ~base_path ~keeper_name |> Result.map (fun location -> location.path)
 ;;
 
+let terminal_outcome_to_json = function
+  | Completed -> `Assoc [ "kind", `String "completed"; "detail", `Null ]
+  | Failed detail ->
+    `Assoc [ "kind", `String "failed"; "detail", `String detail ]
+;;
+
+let terminal_to_json terminal =
+  `Assoc
+    [ "request", Keeper_memory_work_request.to_json terminal.request
+    ; "outcome", terminal_outcome_to_json terminal.outcome
+    ]
+;;
+
 let state_to_json state =
   `Assoc
     [ "schema_version", `Int schema_version
     ; "keeper_name", `String state.keeper_name
     ; ( "pending"
       , `List (List.map Keeper_memory_work_request.to_json state.pending) )
+    ; ( "in_flight"
+      , match state.in_flight with
+        | None -> `Null
+        | Some request -> Keeper_memory_work_request.to_json request )
+    ; "terminal", `List (List.map terminal_to_json state.terminal)
     ]
 ;;
 
-let validate_fields fields =
-  let expected = [ "schema_version"; "keeper_name"; "pending" ] in
+let validate_fields ~expected fields =
   let rec loop seen = function
     | [] ->
       (match List.find_opt (fun name -> not (List.mem name seen)) expected with
@@ -117,7 +168,7 @@ let decode_requests values =
     (Ok [])
 ;;
 
-let validate_pending ~keeper_name requests =
+let validate_requests ~keeper_name requests =
   let rec loop seen = function
     | [] -> Ok ()
     | request :: rest ->
@@ -137,9 +188,47 @@ let validate_pending ~keeper_name requests =
   loop [] requests
 ;;
 
+let terminal_outcome_of_json = function
+  | `Assoc fields ->
+    let* () = validate_fields ~expected:[ "kind"; "detail" ] fields in
+    (match List.assoc "kind" fields, List.assoc "detail" fields with
+     | `String "completed", `Null -> Ok Completed
+     | `String "failed", `String detail when String.trim detail <> "" ->
+       Ok (Failed detail)
+     | `String "failed", `String _ -> Error "failed outcome detail must not be empty"
+     | _ -> Error "invalid terminal outcome")
+  | _ -> Error "terminal outcome must be a JSON object"
+;;
+
+let terminal_of_json = function
+  | `Assoc fields ->
+    let* () = validate_fields ~expected:[ "request"; "outcome" ] fields in
+    let* request =
+      Keeper_memory_work_request.of_json (List.assoc "request" fields)
+    in
+    let* outcome = terminal_outcome_of_json (List.assoc "outcome" fields) in
+    Ok { request; outcome }
+  | _ -> Error "terminal entry must be a JSON object"
+;;
+
+let decode_terminal values =
+  List.fold_right
+    (fun value result ->
+       let* rest = result in
+       let* terminal = terminal_of_json value in
+       Ok (terminal :: rest))
+    values
+    (Ok [])
+;;
+
 let state_of_json = function
   | `Assoc fields ->
-    let* () = validate_fields fields in
+    let* () =
+      validate_fields
+        ~expected:
+          [ "schema_version"; "keeper_name"; "pending"; "in_flight"; "terminal" ]
+        fields
+    in
     let* encoded_schema =
       match List.assoc "schema_version" fields with
       | `Int value -> Ok value
@@ -158,8 +247,23 @@ let state_of_json = function
         | `List values -> decode_requests values
         | _ -> Error "pending must be a list"
       in
-      let* () = validate_pending ~keeper_name pending in
-      Ok { keeper_name; pending }
+      let* in_flight =
+        match List.assoc "in_flight" fields with
+        | `Null -> Ok None
+        | json -> Keeper_memory_work_request.of_json json |> Result.map Option.some
+      in
+      let* terminal =
+        match List.assoc "terminal" fields with
+        | `List values -> decode_terminal values
+        | _ -> Error "terminal must be a list"
+      in
+      let requests =
+        pending
+        @ Option.to_list in_flight
+        @ List.map (fun terminal -> terminal.request) terminal
+      in
+      let* () = validate_requests ~keeper_name requests in
+      Ok { keeper_name; pending; in_flight; terminal }
   | _ -> Error "Memory work queue must be a JSON object"
 ;;
 
@@ -181,7 +285,13 @@ let load_unlocked location =
         Error
           (Owner_mismatch
              { expected = location.keeper_name; actual = state.keeper_name })
-    else Ok { keeper_name = location.keeper_name; pending = [] }
+    else
+      Ok
+        { keeper_name = location.keeper_name
+        ; pending = []
+        ; in_flight = None
+        ; terminal = []
+        }
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn ->
@@ -201,19 +311,21 @@ let with_location ~base_path ~keeper_name f =
   File_lock_eio.with_mutex location.path (fun () -> f location)
 ;;
 
+let request_id_exists state request_id =
+  List.exists
+    (fun request ->
+       String.equal request_id (Keeper_memory_work_request.request_id request))
+    (state.pending
+     @ Option.to_list state.in_flight
+     @ List.map (fun terminal -> terminal.request) state.terminal)
+;;
+
 let enqueue ~base_path request =
   let keeper_name = Keeper_memory_work_request.keeper_name request in
   with_location ~base_path ~keeper_name (fun location ->
     let* state = load_unlocked location in
     let request_id = Keeper_memory_work_request.request_id request in
-    if
-      List.exists
-        (fun queued ->
-           String.equal
-             request_id
-             (Keeper_memory_work_request.request_id queued))
-        state.pending
-    then Ok Already_present
+    if request_id_exists state request_id then Ok Already_present
     else
       let state = { state with pending = state.pending @ [ request ] } in
       let* () = save_unlocked location state in
@@ -223,4 +335,73 @@ let enqueue ~base_path request =
 let pending ~base_path ~keeper_name =
   with_location ~base_path ~keeper_name (fun location ->
     load_unlocked location |> Result.map (fun state -> state.pending))
+;;
+
+let claim_next ~base_path ~keeper_name =
+  with_location ~base_path ~keeper_name (fun location ->
+    let* state = load_unlocked location in
+    match state.in_flight, state.pending with
+    | Some request, _ ->
+      Ok (Claim_busy (Keeper_memory_work_request.request_id request))
+    | None, [] -> Ok Queue_empty
+    | None, request :: pending ->
+      let state = { state with pending; in_flight = Some request } in
+      let* () = save_unlocked location state in
+      Ok (Claimed request))
+;;
+
+let recover_in_flight ~base_path ~keeper_name =
+  with_location ~base_path ~keeper_name (fun location ->
+    load_unlocked location |> Result.map (fun state -> state.in_flight))
+;;
+
+let equal_terminal_outcome left right =
+  match left, right with
+  | Completed, Completed -> true
+  | Failed left, Failed right -> String.equal left right
+  | Completed, Failed _ | Failed _, Completed -> false
+;;
+
+let settle ~base_path ~keeper_name ~request_id outcome =
+  let* () =
+    match outcome with
+    | Completed -> Ok ()
+    | Failed detail when String.trim detail <> "" -> Ok ()
+    | Failed _ -> Error (Invalid_terminal_outcome "failure detail must not be empty")
+  in
+  with_location ~base_path ~keeper_name (fun location ->
+    let* state = load_unlocked location in
+    match
+      List.find_opt
+        (fun terminal ->
+           String.equal
+             request_id
+             (Keeper_memory_work_request.request_id terminal.request))
+        state.terminal
+    with
+    | Some terminal when equal_terminal_outcome terminal.outcome outcome ->
+      Ok Already_settled
+    | Some _ -> Error (Settlement_conflict request_id)
+    | None ->
+      (match state.in_flight with
+       | None -> Error (No_matching_claim { expected = None; actual = request_id })
+       | Some request ->
+         let expected = Keeper_memory_work_request.request_id request in
+         if not (String.equal expected request_id) then
+           Error
+             (No_matching_claim { expected = Some expected; actual = request_id })
+         else
+           let state =
+             { state with
+               in_flight = None
+             ; terminal = state.terminal @ [ { request; outcome } ]
+             }
+           in
+           let* () = save_unlocked location state in
+           Ok Settled))
+;;
+
+let terminal ~base_path ~keeper_name =
+  with_location ~base_path ~keeper_name (fun location ->
+    load_unlocked location |> Result.map (fun state -> state.terminal))
 ;;

--- a/lib/keeper/keeper_memory_work_store.mli
+++ b/lib/keeper/keeper_memory_work_store.mli
@@ -15,6 +15,12 @@ type error =
       { expected : string
       ; actual : string
       }
+  | No_matching_claim of
+      { expected : string option
+      ; actual : string
+      }
+  | Invalid_terminal_outcome of string
+  | Settlement_conflict of string
   | Write_failed of
       { path : string
       ; cause : Keeper_fs.durable_write_error
@@ -23,6 +29,24 @@ type error =
 type enqueue_result =
   | Enqueued
   | Already_present
+
+type claim_result =
+  | Queue_empty
+  | Claim_busy of string
+  | Claimed of Keeper_memory_work_request.t
+
+type terminal_outcome =
+  | Completed
+  | Failed of string
+
+type settle_result =
+  | Settled
+  | Already_settled
+
+type terminal =
+  { request : Keeper_memory_work_request.t
+  ; outcome : terminal_outcome
+  }
 
 val error_to_string : error -> string
 val queue_path : base_path:string -> keeper_name:string -> (string, error) result
@@ -39,3 +63,23 @@ val pending
   -> keeper_name:string
   -> (Keeper_memory_work_request.t list, error) result
 (** Return the persisted requests in exact admission order. *)
+
+val claim_next : base_path:string -> keeper_name:string -> (claim_result, error) result
+val recover_in_flight
+  :  base_path:string
+  -> keeper_name:string
+  -> (Keeper_memory_work_request.t option, error) result
+
+val settle
+  :  base_path:string
+  -> keeper_name:string
+  -> request_id:string
+  -> terminal_outcome
+  -> (settle_result, error) result
+(** Settle only the exact in-flight request. Replaying the same settlement is
+    idempotent; a conflicting outcome is rejected. *)
+
+val terminal
+  :  base_path:string
+  -> keeper_name:string
+  -> (terminal list, error) result

--- a/test/test_keeper_memory_write.ml
+++ b/test/test_keeper_memory_write.ml
@@ -56,7 +56,6 @@ let make_meta name =
       (`Assoc
         [ "name", `String name
         ; "trace_id", `String ("trace-" ^ name)
-        ; "goal", `String "memory contract test"
         ])
   with
   | Error error -> Alcotest.fail ("meta fixture failed: " ^ error)
@@ -321,6 +320,102 @@ let test_memory_work_store_exact_fifo () =
     | Ok _ -> Alcotest.fail "duplicate durable request was accepted")
 ;;
 
+let test_memory_work_store_claim_settle_recovery () =
+  with_temp_dir (fun base_path ->
+    let meta = make_meta "durable-memory-claim" in
+    let make_request turn =
+      Work_request.make
+        ~keeper_name:meta.name
+        ~generation:meta.runtime.generation
+        ~turn
+        ~runtime_id:(Printf.sprintf "runtime.claim.%d" turn)
+        ~meta
+        ~tool_results:[ `Assoc [ "turn", `Int turn ] ]
+        ~librarian_messages:[]
+        ~deliberation_execution:None
+      |> Result.get_ok
+    in
+    let first, second, third = make_request 1, make_request 2, make_request 3 in
+    List.iter
+      (fun request ->
+         Work_store.enqueue ~base_path request
+         |> Result.map_error Work_store.error_to_string
+         |> Result.get_ok
+         |> ignore)
+      [ first; second; third ];
+    let claim () =
+      Work_store.claim_next ~base_path ~keeper_name:meta.name
+      |> Result.map_error Work_store.error_to_string
+      |> Result.get_ok
+    in
+    (match claim () with
+     | Work_store.Claimed request ->
+       Alcotest.(check string)
+         "first claimed"
+         (Work_request.request_id first)
+         (Work_request.request_id request)
+     | Work_store.Queue_empty | Work_store.Claim_busy _ ->
+       Alcotest.fail "first request was not claimed");
+    Alcotest.(check bool)
+      "second claim cannot duplicate in-flight work"
+      true
+      (claim () = Work_store.Claim_busy (Work_request.request_id first));
+    let recovered =
+      Work_store.recover_in_flight ~base_path ~keeper_name:meta.name
+      |> Result.map_error Work_store.error_to_string
+      |> Result.get_ok
+      |> Option.get
+    in
+    Alcotest.(check string)
+      "restart recovery keeps exact claim"
+      (Work_request.request_id first)
+      (Work_request.request_id recovered);
+    let settle request outcome =
+      Work_store.settle
+        ~base_path
+        ~keeper_name:meta.name
+        ~request_id:(Work_request.request_id request)
+        outcome
+      |> Result.map_error Work_store.error_to_string
+      |> Result.get_ok
+    in
+    Alcotest.(check bool)
+      "first settled"
+      true
+      (settle first Work_store.Completed = Work_store.Settled);
+    Alcotest.(check bool)
+      "settlement replay is idempotent"
+      true
+      (settle first Work_store.Completed = Work_store.Already_settled);
+    (match
+       Work_store.settle
+         ~base_path
+         ~keeper_name:meta.name
+         ~request_id:(Work_request.request_id first)
+         (Work_store.Failed "conflicting replay")
+     with
+     | Error (Work_store.Settlement_conflict _) -> ()
+     | Error error -> Alcotest.fail (Work_store.error_to_string error)
+     | Ok _ -> Alcotest.fail "conflicting settlement was accepted");
+    (match claim () with
+     | Work_store.Claimed request ->
+       Alcotest.(check string)
+         "second claimed"
+         (Work_request.request_id second)
+         (Work_request.request_id request)
+     | Work_store.Queue_empty | Work_store.Claim_busy _ ->
+       Alcotest.fail "second request was not claimed");
+    ignore (settle second (Work_store.Failed "provider unavailable") : Work_store.settle_result);
+    match claim () with
+    | Work_store.Claimed request ->
+      Alcotest.(check string)
+        "failed unit does not block the next unit"
+        (Work_request.request_id third)
+        (Work_request.request_id request)
+    | Work_store.Queue_empty | Work_store.Claim_busy _ ->
+      Alcotest.fail "third request did not progress after failure")
+;;
+
 let () =
   Alcotest.run
     "keeper_memory_write"
@@ -349,6 +444,10 @@ let () =
             "durable work store exact FIFO"
             `Quick
             test_memory_work_store_exact_fifo
+        ; Alcotest.test_case
+            "durable work store claim settle recovery"
+            `Quick
+            test_memory_work_store_claim_settle_recovery
         ] )
     ]
 ;;


### PR DESCRIPTION
Stacked on #24712.

## Scope

- Hard-cut the pending snapshot to schema v2 with one atomic Keeper-local state: pending, in-flight, and terminal.
- Claim only the exact FIFO head and durably publish in-flight before returning it.
- Expose restart recovery of the exact in-flight request.
- Settle only the matching request; identical settlement replay is idempotent and a conflicting outcome is explicit.
- Preserve the full request and typed completed/failed outcome as terminal evidence with no cap.
- Treat every pending, in-flight, and terminal request identity as one uniqueness domain.
- Keep a failed unit from blocking the next FIFO item after explicit settlement.

## Deliberate non-goals

This PR does not connect the existing closure-based Memory Lane runner yet, and therefore does not claim end-to-end exactly-once Memory side effects. A crash after an external Memory write but before settlement still requires downstream operation receipts keyed by request identity.

The next children must:

1. Execute typed requests from this store instead of closure queue entries.
2. Carry request identity into each Memory write, librarian, and compaction receipt.
3. Replay in-flight/pending work at startup and project terminal observations to the dashboard.

Schema v1 is rejected explicitly rather than migrated; this stack has not shipped the v1 store as a release contract.

## Verification

- 341 insertions and 17 deletions; 358 changed lines total.
- ocamlformat check: pass.
- OCaml parser checks: pass.
- git diff --check: pass.
- Focused target build completed successfully through the repo wrapper.
- The first executable run exposed the retired main-branch `goal` fixture before reaching persistence assertions. That exact legacy fixture is removed here and independently in #24716. A rerun was not started while another bare Dune test owned the machine; CI remains the final authority.
