### PR TITLE
fix(ci): make test runner observational only

### DIFF
--- a/.github/actions/setup-ocaml-toolchain/action.yml
+++ b/.github/actions/setup-ocaml-toolchain/action.yml
@@ -78,7 +78,7 @@ runs:
     # This explanation stays a YAML comment on purpose. GitHub echoes the whole
     # `run:` script into the job log, so a shell comment quoting the linker and
     # disk-space messages would plant those exact strings in every job log —
-    # scripts/ci-run-tests.sh matches them in disk_full_detected().
+    # scripts/ci-run-tests.sh preserves them in failure diagnostics.
     - name: Enable dune cache (Linux)
       if: runner.os == 'Linux' && inputs.dune-cache == 'true'
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -772,14 +772,6 @@ jobs:
           chmod +x dashboard/scripts/gen-sse-types.sh
           opam exec -- dashboard/scripts/gen-sse-types.sh --check
 
-      - name: Install eio-trace
-        continue-on-error: true
-        run: |
-          # Diagnostic-only. Avoid opam depexts here: GTK/cairo system
-          # packages can consume the step before the quick suite runs.
-          opam install -y --no-depexts eio-trace \
-            || echo "::warning::eio-trace install skipped"
-
       - name: Run tests (quick suite)
         id: quick_suite
         env:
@@ -807,16 +799,6 @@ jobs:
             _build/log
             _build/default/test/_build/_tests/**/*.output
             /tmp/ci-run-tests.*.log
-          retention-days: 7
-
-      - name: Upload eio-trace on failure
-        if: ${{ failure() && steps.quick_suite.outcome == 'failure' }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: eio-trace-quick-suite-${{ github.run_id }}
-          path: |
-            _build/default/**/*.trace
-            /tmp/eio-trace-*
           retention-days: 7
 
       - name: Run operator control suite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -578,7 +578,6 @@ jobs:
   build:
     name: Build and Test
     runs-on: ubuntu-latest
-    timeout-minutes: 90
     needs: [pr-live-gate, changes]
     # Main-push safety-net (mirrors `dashboard` job below). Non-PR events
     # (branch push to main/develop, workflow_dispatch) always run Build and Test
@@ -597,7 +596,8 @@ jobs:
     #     every test suite are merge-blocking.
     #   - Each suite runs exactly once. scripts/ci-run-tests.sh only reports
     #     heartbeat, disk pressure, process state, and failure diagnostics.
-    #   - This job's execution boundary is the sole CI deadline for the suite.
+    #   - GitHub Actions owns the outer workflow lifecycle; this job does not
+    #     impose a second deadline on individual commands or the suite.
     steps:
       - name: Free disk space
         # ubuntu-latest starts with roughly 14 GB free but preinstalls the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -592,18 +592,12 @@ jobs:
     # not synthesize default build inputs even though `always()` keeps this
     # condition evaluable.
     if: ${{ always() && !cancelled() && needs.pr-live-gate.outputs.run_heavy == 'true' && needs.changes.result == 'success' && (needs.changes.outputs.build == 'true' || needs.pr-live-gate.outputs.live_state == 'NON_PR') }}
-    # Flake-handling policy (hard-required tests):
+    # Test execution policy (hard-required tests):
     #   - `continue-on-error` is intentionally absent: compile failures and
     #     every test suite are merge-blocking.
-    #   - Dune-based test commands (quick suite, operator-control, SSE e2e) are
-    #     run through scripts/ci-run-tests.sh, which performs one isolated-
-    #     build-dir retry for CI-only flakes (RPC lock, interface mismatch,
-    #     resource exhaustion) when CI_TEST_ALLOW_FLAKY_RETRY=1.
-    #   - Non-dune harness suites (transport, contract) get a workflow-level
-    #     shell retry wrapper below so they are not left without mitigation.
-    #   - Disk-exhaustion failures are non-retryable; the script emits explicit
-    #     repair guidance instead of masking the error.
-    # See: https://github.com/jeong-sik/masc/issues/2957
+    #   - Each suite runs exactly once. scripts/ci-run-tests.sh only reports
+    #     heartbeat, disk pressure, process state, and failure diagnostics.
+    #   - This job's execution boundary is the sole CI deadline for the suite.
     steps:
       - name: Free disk space
         # ubuntu-latest starts with roughly 14 GB free but preinstalls the
@@ -783,22 +777,16 @@ jobs:
         run: |
           # Diagnostic-only. Avoid opam depexts here: GTK/cairo system
           # packages can consume the step before the quick suite runs.
-          timeout 45s opam install -y --no-depexts eio-trace \
+          opam install -y --no-depexts eio-trace \
             || echo "::warning::eio-trace install skipped"
 
       - name: Run tests (quick suite)
         id: quick_suite
-        # scripts/ci-run-tests.sh has its own 2100s timeout and diagnostics,
-        # but this step-level bound keeps a stuck timeout/diagnostic path from
-        # holding the shared runner for the full Build and Test job budget.
-        timeout-minutes: 40
         env:
           ME_ROOT: /tmp/me
           ALCOTEST_QUICK_TESTS: "1"
           MASC_INCLUDE_OPERATOR_CONTROL: "false"
-          CI_TEST_TIMEOUT_SEC: 2100
           CI_TEST_HEARTBEAT_SEC: 30
-          CI_TEST_ALLOW_FLAKY_RETRY: "1"
           MASC_LOCAL_RUNTIMES_JSON: '[{"base_url":"http://127.0.0.1:8085","max_concurrency":4}]'
           MASC_KEEPER_MSG_TIMEOUT_MAX_SEC: "10"
           MASC_E2E_TESTS: "true"
@@ -840,9 +828,7 @@ jobs:
         env:
           ME_ROOT: /tmp/me
           ALCOTEST_QUICK_TESTS: "1"
-          CI_TEST_TIMEOUT_SEC: 600
           CI_TEST_HEARTBEAT_SEC: 15
-          CI_TEST_ALLOW_FLAKY_RETRY: "1"
           MASC_LOCAL_RUNTIMES_JSON: '[{"base_url":"http://127.0.0.1:8085","max_concurrency":4}]'
           MASC_KEEPER_MSG_TIMEOUT_MAX_SEC: "10"
           MASC_E2E_TESTS: "true"
@@ -858,9 +844,7 @@ jobs:
         if: ${{ always() && steps.build_step.outcome == 'success' }}
         env:
           ME_ROOT: /tmp/me
-          CI_TEST_TIMEOUT_SEC: 900
           CI_TEST_HEARTBEAT_SEC: 15
-          CI_TEST_ALLOW_FLAKY_RETRY: "1"
           DUNE_JOBS: 1
           MASC_E2E_TESTS: "true"
         run: |
@@ -873,9 +857,7 @@ jobs:
         if: ${{ always() && steps.build_step.outcome == 'success' }}
         env:
           ME_ROOT: /tmp/me
-          CI_TEST_TIMEOUT_SEC: 900
           CI_TEST_HEARTBEAT_SEC: 15
-          CI_TEST_ALLOW_FLAKY_RETRY: "1"
           DUNE_JOBS: 1
         run: |
           mkdir -p /tmp/me
@@ -887,37 +869,21 @@ jobs:
           chmod +x scripts/harness/transport/verify_ws.sh
           chmod +x scripts/harness/transport/verify_webrtc_signaling.sh
           chmod +x scripts/harness/lib/server_bootstrap.sh
-          run_suite() {
-            scripts/ci-run-tests.sh "bash scripts/harness/transport/run_all.sh"
-          }
-          if run_suite; then
-            exit 0
-          fi
-          echo "::warning::transport harness suite failed; retrying once"
-          run_suite
+          scripts/ci-run-tests.sh "bash scripts/harness/transport/run_all.sh"
 
       - name: Run contract harness suite
         id: contract_harness_suite
         if: ${{ always() && steps.build_step.outcome == 'success' }}
         env:
           ME_ROOT: /tmp/me
-          CI_TEST_TIMEOUT_SEC: 900
           CI_TEST_HEARTBEAT_SEC: 15
-          CI_TEST_ALLOW_FLAKY_RETRY: "1"
           DUNE_JOBS: 1
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh
           chmod +x scripts/harness/contract/run_all.sh
           chmod +x scripts/harness/lib/server_bootstrap.sh
-          run_suite() {
-            scripts/ci-run-tests.sh "scripts/harness/contract/run_all.sh"
-          }
-          if run_suite; then
-            exit 0
-          fi
-          echo "::warning::contract harness suite failed; retrying once"
-          run_suite
+          scripts/ci-run-tests.sh "scripts/harness/contract/run_all.sh"
 
       - name: Generate main release evidence bundle
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/docs/spec/15-testing.md
+++ b/docs/spec/15-testing.md
@@ -222,11 +222,9 @@ CI 테스트 실행기. 다음 기능을 제공한다:
 | 기능 | 설명 |
 |------|------|
 | Heartbeat logging | `CI_TEST_HEARTBEAT_SEC` (기본 30초) 간격으로 진행 상태 출력. "silent hang" 방지. |
-| Timeout | `CI_TEST_TIMEOUT_SEC` (기본 1200초). 초과 시 진단 덤프. |
-| Diagnostics dump | 실패/타임아웃 시 프로세스 스냅샷, 로그 파일 경로, 빌드 디렉토리 정보 출력. |
-| Clean retry | `CI_TEST_ALLOW_CLEAN_RETRY=1`이면 실패 시 clean build 후 재시도. |
-| RPC retry | `CI_TEST_ALLOW_RPC_RETRY=1`이면 RPC 관련 실패 시 재시도. |
-| Isolated build | `CI_TEST_ISOLATED_BUILD_DIR` (기본 `.ci_build`)로 격리 빌드 가능. |
+| Diagnostics dump | 실패 시 프로세스 스냅샷, 로그 파일 경로, 빌드 디렉토리 정보 출력. |
+| Disk observation | 사용 가능 공간이 임계값 아래로 내려가면 상태와 진단을 기록하되 실행을 중단하지 않는다. |
+| Single attempt | 명령을 정확히 한 번 실행하고 원래 종료 코드를 보존한다. 실행 경계는 CI job이 소유한다. |
 
 ### 6.2 실행 흐름
 

--- a/scripts/ci-run-tests.sh
+++ b/scripts/ci-run-tests.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# CI test runner with:
-# 1) periodic heartbeat logs (prevents "silent hang" confusion),
-# 2) explicit timeout,
-# 3) diagnostics dump on timeout/failure.
+# CI test observer. The workflow job owns the outer execution boundary.
+# This script reports progress and diagnostics, but never terminates or retries
+# the command it observes.
 
 mktemp_ci_log() {
   local tmp_dir="${TMPDIR:-/tmp}"
@@ -23,31 +22,31 @@ elif [[ "${GITHUB_ACTIONS:-}" != "true" && -x "scripts/dune-local.sh" ]]; then
 else
   TEST_CMD="opam exec -- dune test --root ."
 fi
-TEST_TIMEOUT_SEC="${CI_TEST_TIMEOUT_SEC:-1200}"
+
 HEARTBEAT_SEC="${CI_TEST_HEARTBEAT_SEC:-30}"
 START_EPOCH="$(date +%s)"
 TEST_LOG_FILE="${CI_TEST_LOG_FILE:-$(mktemp_ci_log)}"
 DUNE_SOURCEROOT="${DUNE_SOURCEROOT:-$(pwd -P)}"
 export DUNE_SOURCEROOT
-CI_TEST_ALLOW_CLEAN_RETRY="${CI_TEST_ALLOW_CLEAN_RETRY:-1}"
-CI_TEST_CLEAN_RETRY_DONE=0
-CI_TEST_ALLOW_RPC_RETRY="${CI_TEST_ALLOW_RPC_RETRY:-1}"
-CI_TEST_RPC_RETRY_DONE=0
-CI_TEST_ALLOW_FLAKY_RETRY="${CI_TEST_ALLOW_FLAKY_RETRY:-1}"
-CI_TEST_FLAKY_RETRY_DONE=0
-CI_TEST_DISK_FULL_GUIDANCE_DONE=0
-CI_TEST_DISK_PRESSURE_DONE=0
 CI_TEST_DISK_MIN_AVAILABLE_MB="${CI_TEST_DISK_MIN_AVAILABLE_MB:-1024}"
 CI_TEST_DISK_CHECK_SEC="${CI_TEST_DISK_CHECK_SEC:-10}"
-CI_TEST_ISOLATED_BUILD_DIR="${CI_TEST_ISOLATED_BUILD_DIR:-.ci_build}"
 CI_CONTRACT_HARNESS_ENABLED="${CI_CONTRACT_HARNESS_ENABLED:-0}"
 CI_CONTRACT_HARNESS_CMD="${CI_CONTRACT_HARNESS_CMD:-scripts/harness/contract/run_all.sh}"
-CI_CONTRACT_HARNESS_TIMEOUT_SEC="${CI_CONTRACT_HARNESS_TIMEOUT_SEC:-900}"
 ACTIVE_TEST_BUILD_DIR="${DUNE_BUILD_DIR:-_build}"
 ACTIVE_CMD_PID=""
 ACTIVE_CMD_PGID=""
 ACTIVE_LOG_TAIL_PID=""
-CI_LAST_TIMEOUT_DIAG_DONE=0
+DISK_PRESSURE_REPORTED=0
+
+if [[ -z "${HEARTBEAT_SEC}" || "${HEARTBEAT_SEC}" -le 0 ]]; then
+  HEARTBEAT_SEC=30
+fi
+if [[ -z "${CI_TEST_DISK_MIN_AVAILABLE_MB}" || "${CI_TEST_DISK_MIN_AVAILABLE_MB}" -lt 0 ]]; then
+  CI_TEST_DISK_MIN_AVAILABLE_MB=1024
+fi
+if [[ -z "${CI_TEST_DISK_CHECK_SEC}" || "${CI_TEST_DISK_CHECK_SEC}" -le 0 ]]; then
+  CI_TEST_DISK_CHECK_SEC=10
+fi
 
 iso_now() {
   date -u +"%Y-%m-%dT%H:%M:%SZ"
@@ -60,8 +59,7 @@ elapsed_sec() {
 }
 
 log_line() {
-  local line="$1"
-  printf '%s\n' "${line}" | tee -a "${TEST_LOG_FILE}"
+  printf '%s\n' "$1" | tee -a "${TEST_LOG_FILE}"
 }
 
 tmpdir_disk_usage() {
@@ -70,90 +68,13 @@ tmpdir_disk_usage() {
     | awk 'NR == 2 { print "size=" $2 " used=" $3 " avail=" $4 " capacity=" $5; found=1 } END { if (!found) print "unknown" }'
 }
 
-active_cmd_tree_pids() {
-  local root_pid="${ACTIVE_CMD_PID:-}"
-  local all_pairs=""
-  local known=()
-  local changed=1
-  local pid=""
-  local ppid=""
-
-  if [[ -z "${root_pid}" ]]; then
-    return 0
-  fi
-
-  known=("${root_pid}")
-  all_pairs="$(ps -axo pid=,ppid= 2>/dev/null || true)"
-
-  while [[ "${changed}" -eq 1 ]]; do
-    changed=0
-    while read -r pid ppid; do
-      [[ -n "${pid}" ]] || continue
-      [[ -n "${ppid}" ]] || continue
-      for candidate in "${known[@]}"; do
-        if [[ "${ppid}" = "${candidate}" ]]; then
-          local already_seen=0
-          local existing=""
-          for existing in "${known[@]}"; do
-            if [[ "${existing}" = "${pid}" ]]; then
-              already_seen=1
-              break
-            fi
-          done
-          if [[ "${already_seen}" -eq 0 ]]; then
-            known+=("${pid}")
-            changed=1
-          fi
-          break
-        fi
-      done
-    done <<< "${all_pairs}"
-  done
-
-  printf '%s\n' "${known[@]}"
-}
-
-kill_active_cmd_tree() {
-  local signal="${1:-TERM}"
-  local -a tree_pids=()
-  local pid=""
-
-  while IFS= read -r pid; do
-    [[ -n "${pid}" ]] && tree_pids+=("${pid}")
-  done < <(active_cmd_tree_pids)
-
-  if [[ "${#tree_pids[@]}" -eq 0 ]]; then
-    return 0
-  fi
-
-  local idx=0
-  for (( idx=${#tree_pids[@]}-1; idx>=0; idx-- )); do
-    kill "-${signal}" "${tree_pids[idx]}" >/dev/null 2>&1 || true
-  done
-}
-
-if [[ -z "${TEST_TIMEOUT_SEC}" || "${TEST_TIMEOUT_SEC}" -le 0 ]]; then
-  TEST_TIMEOUT_SEC=1200
-fi
-if [[ -z "${HEARTBEAT_SEC}" || "${HEARTBEAT_SEC}" -le 0 ]]; then
-  HEARTBEAT_SEC=30
-fi
-if [[ -z "${CI_TEST_DISK_MIN_AVAILABLE_MB}" || "${CI_TEST_DISK_MIN_AVAILABLE_MB}" -lt 0 ]]; then
-  CI_TEST_DISK_MIN_AVAILABLE_MB=1024
-fi
-if [[ -z "${CI_TEST_DISK_CHECK_SEC}" || "${CI_TEST_DISK_CHECK_SEC}" -le 0 ]]; then
-  CI_TEST_DISK_CHECK_SEC=10
-fi
-
 disk_available_mb() {
-  local path="${1:-${DUNE_SOURCEROOT}}"
-  df -Pm "${path}" 2>/dev/null \
+  df -Pm "${1:-${DUNE_SOURCEROOT}}" 2>/dev/null \
     | awk 'NR == 2 { print $4; found=1 } END { if (!found) print "" }'
 }
 
 disk_pressure_detected() {
   [[ "${CI_TEST_DISK_MIN_AVAILABLE_MB}" -gt 0 ]] || return 1
-
   local avail_mb=""
   avail_mb="$(disk_available_mb "${DUNE_SOURCEROOT}")"
   [[ "${avail_mb}" =~ ^[0-9]+$ ]] || return 1
@@ -172,6 +93,41 @@ disk_pressure_detail() {
   fi
 }
 
+active_cmd_tree_pids() {
+  local root_pid="${ACTIVE_CMD_PID:-}"
+  local all_pairs=""
+  local known=()
+  local changed=1
+  local pid=""
+  local ppid=""
+
+  [[ -n "${root_pid}" ]] || return 0
+  known=("${root_pid}")
+  all_pairs="$(ps -axo pid=,ppid= 2>/dev/null || true)"
+
+  while [[ "${changed}" -eq 1 ]]; do
+    changed=0
+    while read -r pid ppid; do
+      [[ -n "${pid}" && -n "${ppid}" ]] || continue
+      for candidate in "${known[@]}"; do
+        if [[ "${ppid}" = "${candidate}" ]]; then
+          local already_seen=0
+          for existing in "${known[@]}"; do
+            [[ "${existing}" = "${pid}" ]] && already_seen=1 && break
+          done
+          if [[ "${already_seen}" -eq 0 ]]; then
+            known+=("${pid}")
+            changed=1
+          fi
+          break
+        fi
+      done
+    done <<< "${all_pairs}"
+  done
+
+  printf '%s\n' "${known[@]}"
+}
+
 diag_dump() {
   local reason="${1:-unknown}"
   echo "[ci-diag] reason=${reason}"
@@ -183,9 +139,6 @@ diag_dump() {
   echo "[ci-diag] build_dir=${ACTIVE_TEST_BUILD_DIR}"
   echo "[ci-diag] active_cmd_pid=${ACTIVE_CMD_PID:-<none>}"
   echo "[ci-diag] active_cmd_pgid=${ACTIVE_CMD_PGID:-<none>}"
-  echo "[ci-diag] env DUNE_RPC=${DUNE_RPC:-<unset>}"
-
-  echo "[ci-diag] ulimit -n (open files): $(ulimit -n 2>/dev/null || echo unknown)"
   echo "[ci-diag] tmpdir usage: $(tmpdir_disk_usage)"
   echo "[ci-diag] process snapshot (dune/ocaml/test):"
   ps -eo pid,ppid,etime,%cpu,%mem,comm,args \
@@ -193,18 +146,14 @@ diag_dump() {
     | grep -v grep \
     || true
 
-  if [[ -n "${ACTIVE_CMD_PID}" || -n "${ACTIVE_CMD_PGID}" ]]; then
+  if [[ -n "${ACTIVE_CMD_PID}" ]]; then
     echo "[ci-diag] active command process tree snapshot:"
-    local tree_pids=()
+    local tree_filter=""
     local pid=""
     while IFS= read -r pid; do
-      [[ -n "${pid}" ]] && tree_pids+=("${pid}")
+      [[ -n "${pid}" ]] && tree_filter+=" ${pid} "
     done < <(active_cmd_tree_pids)
-    if [[ "${#tree_pids[@]}" -gt 0 ]]; then
-      local tree_filter=""
-      for pid in "${tree_pids[@]}"; do
-        tree_filter+=" ${pid} "
-      done
+    if [[ -n "${tree_filter}" ]]; then
       ps -axo pid=,ppid=,pgid=,etime=,%cpu=,%mem=,command= \
         | awk -v wanted="${tree_filter}" 'index(wanted, " " $1 " ") > 0 { print }' \
         || true
@@ -215,405 +164,102 @@ diag_dump() {
   if [[ -f "${dune_log}" ]]; then
     echo "[ci-diag] tail -n 120 ${dune_log}"
     tail -n 120 "${dune_log}" || true
-  else
-    echo "[ci-diag] no dune log yet: ${dune_log}"
   fi
-
   if [[ -f "${TEST_LOG_FILE}" ]]; then
-    echo "[ci-diag] started suites (latest 10):"
-    grep -n '^Testing `' "${TEST_LOG_FILE}" | tail -n 10 || true
-
-    echo "[ci-diag] failure markers (latest 20):"
-    grep -En '\[FAIL\]|FAILURE|Test Failed|Fatal error|ASSERT false|Process completed with exit code' "${TEST_LOG_FILE}" | tail -n 20 || true
-
     echo "[ci-diag] log tail -n 120 ${TEST_LOG_FILE}"
     tail -n 120 "${TEST_LOG_FILE}" || true
-  fi
-
-  local tests_root="${ACTIVE_TEST_BUILD_DIR%/}/default/test/_build/_tests"
-  if [[ -d "${tests_root}" ]]; then
-    # Sort by file mtime so diagnostic tail follows the most recently updated test.
-    local -a output_files=()
-    local -a latest_outputs=()
-    while IFS= read -r line; do
-      output_files+=("${line}")
-    done < <(find "${tests_root}" -type f -name "*.output" -print 2>/dev/null || true)
-    if [[ "${#output_files[@]}" -gt 0 ]]; then
-      while IFS= read -r line; do
-        latest_outputs+=("${line}")
-      done < <(ls -1t "${output_files[@]}" 2>/dev/null | head -n 20 || true)
-    fi
-    echo "[ci-diag] test output files (latest 20 by mtime):"
-    printf '%s\n' "${latest_outputs[@]}" || true
-
-    # Print tail of the most recently updated output file for quick signal.
-    local last_output=""
-    if [[ "${#latest_outputs[@]}" -gt 0 ]]; then
-      last_output="${latest_outputs[0]}"
-    fi
-    if [[ -n "${last_output}" && -f "${last_output}" ]]; then
-      echo "[ci-diag] tail -n 120 ${last_output}"
-      tail -n 120 "${last_output}" || true
-    fi
-  else
-    echo "[ci-diag] no test output directory yet: ${tests_root}"
   fi
 }
 
 heartbeat() {
   while true; do
-    echo "[ci-heartbeat] $(iso_now) elapsed_sec=$(elapsed_sec) dune test still running"
+    echo "[ci-heartbeat] $(iso_now) elapsed_sec=$(elapsed_sec) command still running"
     sleep "${HEARTBEAT_SEC}"
   done
 }
 
-test_cmd_needs_dune_sanitization() {
-  ([[ "${TEST_CMD}" == *"dune "* ]] || [[ "${TEST_CMD}" == *"dune-local.sh"* ]]) \
-    && [[ "${TEST_CMD}" != *"unset DUNE_RPC"* ]]
-}
-
-test_cmd_has_explicit_build_dir() {
-  [[ "${TEST_CMD}" == *"--build-dir"* ]] || [[ "${TEST_CMD}" == *"DUNE_BUILD_DIR="* ]]
-}
-
 effective_test_cmd() {
-  if test_cmd_needs_dune_sanitization; then
+  if ([[ "${TEST_CMD}" == *"dune "* ]] || [[ "${TEST_CMD}" == *"dune-local.sh"* ]]) \
+    && [[ "${TEST_CMD}" != *"unset DUNE_RPC"* ]]; then
     printf 'unset DUNE_RPC; %s' "${TEST_CMD}"
   else
     printf '%s' "${TEST_CMD}"
   fi
 }
 
-isolated_build_dir_cmd() {
-  local cmd="${1}"
-  printf 'export DUNE_BUILD_DIR=%q; %s' "${ACTIVE_TEST_BUILD_DIR}" "${cmd}"
-}
-
-cache_disabled_cmd() {
-  local cmd="${1}"
-  if [[ "${cmd}" == *"DUNE_CACHE=disabled"* ]]; then
-    printf '%s' "${cmd}"
-  else
-    printf 'export DUNE_CACHE=disabled; %s' "${cmd}"
-  fi
-}
-
-agent_sdk_interface_mismatch_detected() {
-  [[ -f "${TEST_LOG_FILE}" ]] || return 1
-  grep -Eq \
-    'Unbound module Agent_sdk|Unbound module Llm_provider|module Oas is an alias for module Agent_sdk|make inconsistent assumptions|inconsistent assumptions over interface Agent_sdk|over interface Llm_provider__|/lib/agent_sdk/[^[:space:]]+[.]cmxa' \
-    "${TEST_LOG_FILE}"
-}
-
-filtered_test_log_contains() {
-  local pattern="${1}"
-  local filtered_log=""
-  [[ -f "${TEST_LOG_FILE}" ]] || return 1
-  filtered_log="$(mktemp_ci_log)"
-  grep -Ev '(^|[[:space:]])\[OK\][[:space:]]' "${TEST_LOG_FILE}" \
-    > "${filtered_log}" || true
-  grep -Eiq "${pattern}" "${filtered_log}"
-  local status=$?
-  rm -f "${filtered_log}"
-  return "${status}"
-}
-
-disk_full_detected() {
-  filtered_test_log_contains \
-    'No space left on device|dune_trace_write[(][)]|ENOSPC|##\[warning\].*(You are running out of disk space|Free space left:[[:space:]]*[0-9]+[[:space:]]*(MB|MiB))'
-}
-
-deterministic_test_failure_detected() {
-  filtered_test_log_contains '\[FAIL\]|[[:digit:]]+ failure!|Test Failed|ASSERT '
-}
-
-native_link_failure_detected() {
-  filtered_test_log_contains \
-    'collect2: error: ld returned 1 exit status|Error: Error during linking [(]exit code [[:digit:]]+[)]|/usr/bin/ld: final link failed'
-}
-
-log_disk_full_guidance() {
-  if [[ "${CI_TEST_DISK_FULL_GUIDANCE_DONE}" -eq 1 ]]; then
-    return 0
-  fi
-
-  CI_TEST_DISK_FULL_GUIDANCE_DONE=1
-  local opam_path="${OPAM_SWITCH_PREFIX:-${HOME:-}/.opam}"
-  log_line "[ci-run] ERROR: detected disk exhaustion during dune build"
-  log_line "[ci-run] repair: df -h . ${opam_path} /tmp"
-  log_line "[ci-run] repair: bash scripts/disk-hygiene.sh --fix"
-  log_line "[ci-run] repair: bash scripts/disk-hygiene.sh --fix --reset-dune-cache # if dune cache artifacts remain inconsistent"
-}
-
-rpc_server_not_running_detected() {
-  [[ -f "${TEST_LOG_FILE}" ]] || return 1
-  grep -Eq 'RPC server not running\.|has locked the build directory\.' "${TEST_LOG_FILE}"
-}
-
-clean_current_build_dir() {
-  if [[ "${ACTIVE_TEST_BUILD_DIR}" != "_build" ]]; then
-    env DUNE_BUILD_DIR="${ACTIVE_TEST_BUILD_DIR}" dune clean --root . \
-      >> "${TEST_LOG_FILE}" 2>&1
-  else
-    dune clean --root . >> "${TEST_LOG_FILE}" 2>&1
-  fi
-}
-
-run_agent_sdk_clean_retry() {
-  CI_TEST_CLEAN_RETRY_DONE=1
-  run_cmd="$(cache_disabled_cmd "${run_cmd}")"
-  log_line "[ci-run] WARN: detected Agent_sdk/OAS artifact or interface mismatch; running dune clean and retrying once with DUNE_CACHE=disabled"
-  log_line "[ci-run] retry_command: ${run_cmd}"
-  clean_current_build_dir
-  log_line "[ci-run] retry_started_at=$(iso_now)"
-  set +e
-  run_with_timeout "${run_cmd}"
-  status=$?
-  set -e
-}
-
-run_with_timeout() {
-  local cmd="${1}"
-  local deadline=0
-  local status=0
-  local kill_grace_sec=5
-  local next_disk_check
-  next_disk_check=$(( $(date +%s) + CI_TEST_DISK_CHECK_SEC ))
-
-  ACTIVE_CMD_PID=""
-  ACTIVE_CMD_PGID=""
-  ACTIVE_LOG_TAIL_PID=""
-  CI_LAST_TIMEOUT_DIAG_DONE=0
-
-  tail -n 0 -f "${TEST_LOG_FILE}" &
-  ACTIVE_LOG_TAIL_PID=$!
-
-  bash -l -s <<< "${cmd}" >> "${TEST_LOG_FILE}" 2>&1 &
-  ACTIVE_CMD_PID=$!
-  ACTIVE_CMD_PGID="$(
-    ps -o pgid= -p "${ACTIVE_CMD_PID}" 2>/dev/null \
-      | tr -d '[:space:]'
-  )"
-
-  if [[ "${TEST_TIMEOUT_SEC}" -gt 0 ]]; then
-    deadline=$(( $(date +%s) + TEST_TIMEOUT_SEC ))
-  fi
-
-  while kill -0 "${ACTIVE_CMD_PID}" >/dev/null 2>&1; do
-    local now_epoch
-    now_epoch="$(date +%s)"
-    if [[ "${deadline}" -gt 0 ]] && [[ "$(date +%s)" -ge "${deadline}" ]]; then
-      CI_LAST_TIMEOUT_DIAG_DONE=1
-      diag_dump "timeout"
-      kill_active_cmd_tree TERM
-      sleep "${kill_grace_sec}"
-      if kill -0 "${ACTIVE_CMD_PID}" >/dev/null 2>&1; then
-        kill_active_cmd_tree KILL
-      fi
-      wait "${ACTIVE_CMD_PID}" >/dev/null 2>&1 || true
-      if [[ -n "${ACTIVE_LOG_TAIL_PID}" ]]; then
-        kill "${ACTIVE_LOG_TAIL_PID}" >/dev/null 2>&1 || true
-        wait "${ACTIVE_LOG_TAIL_PID}" >/dev/null 2>&1 || true
-      fi
-      ACTIVE_CMD_PID=""
-      ACTIVE_CMD_PGID=""
-      ACTIVE_LOG_TAIL_PID=""
-      return 124
-    fi
-    if [[ "${now_epoch}" -ge "${next_disk_check}" ]]; then
-      next_disk_check=$((now_epoch + CI_TEST_DISK_CHECK_SEC))
-      if disk_pressure_detected; then
-        CI_TEST_DISK_PRESSURE_DONE=1
-        log_line "[ci-run] ERROR: disk pressure while running test command: $(disk_pressure_detail)"
-        log_disk_full_guidance
-        diag_dump "disk_pressure"
-        kill_active_cmd_tree TERM
-        sleep "${kill_grace_sec}"
-        if kill -0 "${ACTIVE_CMD_PID}" >/dev/null 2>&1; then
-          kill_active_cmd_tree KILL
-        fi
-        wait "${ACTIVE_CMD_PID}" >/dev/null 2>&1 || true
-        if [[ -n "${ACTIVE_LOG_TAIL_PID}" ]]; then
-          kill "${ACTIVE_LOG_TAIL_PID}" >/dev/null 2>&1 || true
-          wait "${ACTIVE_LOG_TAIL_PID}" >/dev/null 2>&1 || true
-        fi
-        ACTIVE_CMD_PID=""
-        ACTIVE_CMD_PGID=""
-        ACTIVE_LOG_TAIL_PID=""
-        return 75
-      fi
-    fi
-    sleep 1
+kill_active_cmd_tree() {
+  local signal="${1:-TERM}"
+  local tree_pids=()
+  local pid=""
+  while IFS= read -r pid; do
+    [[ -n "${pid}" ]] && tree_pids+=("${pid}")
+  done < <(active_cmd_tree_pids)
+  local idx=0
+  for (( idx=${#tree_pids[@]}-1; idx>=0; idx-- )); do
+    kill "-${signal}" "${tree_pids[idx]}" >/dev/null 2>&1 || true
   done
-
-  status=0
-  wait "${ACTIVE_CMD_PID}" || status=$?
-  if [[ -n "${ACTIVE_LOG_TAIL_PID}" ]]; then
-    kill "${ACTIVE_LOG_TAIL_PID}" >/dev/null 2>&1 || true
-    wait "${ACTIVE_LOG_TAIL_PID}" >/dev/null 2>&1 || true
-  fi
-  ACTIVE_CMD_PID=""
-  ACTIVE_CMD_PGID=""
-  ACTIVE_LOG_TAIL_PID=""
-  return "${status}"
 }
 
 hb_pid=""
 cleanup() {
   if [[ -n "${ACTIVE_CMD_PID}" ]] && kill -0 "${ACTIVE_CMD_PID}" >/dev/null 2>&1; then
     kill_active_cmd_tree TERM
-    sleep 2
-    if kill -0 "${ACTIVE_CMD_PID}" >/dev/null 2>&1; then
-      kill_active_cmd_tree KILL
-    fi
     wait "${ACTIVE_CMD_PID}" >/dev/null 2>&1 || true
-    ACTIVE_CMD_PID=""
-    ACTIVE_CMD_PGID=""
   fi
-  if [[ -n "${hb_pid}" ]]; then
-    kill "${hb_pid}" >/dev/null 2>&1 || true
-    wait "${hb_pid}" >/dev/null 2>&1 || true
-  fi
-  if [[ -n "${ACTIVE_LOG_TAIL_PID}" ]]; then
-    kill "${ACTIVE_LOG_TAIL_PID}" >/dev/null 2>&1 || true
-    wait "${ACTIVE_LOG_TAIL_PID}" >/dev/null 2>&1 || true
-  fi
+  [[ -z "${hb_pid}" ]] || kill "${hb_pid}" >/dev/null 2>&1 || true
+  [[ -z "${ACTIVE_LOG_TAIL_PID}" ]] || kill "${ACTIVE_LOG_TAIL_PID}" >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
 trap 'cleanup; exit 130' INT
 trap 'cleanup; exit 143' TERM
 
+run_observed() {
+  local cmd="$1"
+  local status=0
+  local next_disk_check=$(( $(date +%s) + CI_TEST_DISK_CHECK_SEC ))
+
+  tail -n 0 -f "${TEST_LOG_FILE}" &
+  ACTIVE_LOG_TAIL_PID=$!
+  bash -l -s <<< "${cmd}" >> "${TEST_LOG_FILE}" 2>&1 &
+  ACTIVE_CMD_PID=$!
+  ACTIVE_CMD_PGID="$(ps -o pgid= -p "${ACTIVE_CMD_PID}" 2>/dev/null | tr -d '[:space:]')"
+
+  while kill -0 "${ACTIVE_CMD_PID}" >/dev/null 2>&1; do
+    local now_epoch
+    now_epoch="$(date +%s)"
+    if [[ "${now_epoch}" -ge "${next_disk_check}" ]]; then
+      next_disk_check=$((now_epoch + CI_TEST_DISK_CHECK_SEC))
+      if [[ "${DISK_PRESSURE_REPORTED}" -eq 0 ]] && disk_pressure_detected; then
+        DISK_PRESSURE_REPORTED=1
+        log_line "[ci-observe] disk_pressure $(disk_pressure_detail)"
+        diag_dump "disk_pressure_observed"
+      fi
+    fi
+    sleep 1
+  done
+
+  wait "${ACTIVE_CMD_PID}" || status=$?
+  kill "${ACTIVE_LOG_TAIL_PID}" >/dev/null 2>&1 || true
+  wait "${ACTIVE_LOG_TAIL_PID}" >/dev/null 2>&1 || true
+  ACTIVE_CMD_PID=""
+  ACTIVE_CMD_PGID=""
+  ACTIVE_LOG_TAIL_PID=""
+  return "${status}"
+}
+
 log_line "[ci-run] command: ${TEST_CMD}"
-if test_cmd_needs_dune_sanitization; then
-  log_line "[ci-run] sanitized_command: $(effective_test_cmd)"
-fi
-log_line "[ci-run] timeout_sec=${TEST_TIMEOUT_SEC} heartbeat_sec=${HEARTBEAT_SEC}"
+log_line "[ci-run] heartbeat_sec=${HEARTBEAT_SEC}"
 log_line "[ci-run] disk_min_available_mb=${CI_TEST_DISK_MIN_AVAILABLE_MB} disk_check_sec=${CI_TEST_DISK_CHECK_SEC}"
 log_line "[ci-run] started_at=$(iso_now)"
 log_line "[ci-run] log_file=${TEST_LOG_FILE}"
 log_line "[ci-run] source_root=${DUNE_SOURCEROOT}"
 
 heartbeat &
-hb_pid="$!"
+hb_pid=$!
 
-effective_cmd="$(effective_test_cmd)"
-run_cmd="${effective_cmd}"
-
-set +e
-run_with_timeout "${run_cmd}"
-status=$?
-set -e
-
-if [[ "${status}" -ne 0 ]] && disk_full_detected; then
-  log_disk_full_guidance
-fi
-if [[ "${status}" -ne 0 ]] && [[ "${CI_TEST_DISK_PRESSURE_DONE}" -eq 1 ]]; then
-  log_disk_full_guidance
-fi
-
-if [[ "${status}" -ne 0 ]] \
-  && [[ "${CI_TEST_ALLOW_RPC_RETRY}" = "1" ]] \
-  && [[ "${CI_TEST_RPC_RETRY_DONE}" -eq 0 ]] \
-  && [[ "${CI_TEST_DISK_PRESSURE_DONE}" -eq 0 ]] \
-  && test_cmd_needs_dune_sanitization \
-  && ! test_cmd_has_explicit_build_dir \
-  && rpc_server_not_running_detected; then
-  CI_TEST_RPC_RETRY_DONE=1
-  ACTIVE_TEST_BUILD_DIR="${CI_TEST_ISOLATED_BUILD_DIR}"
-  run_cmd="$(isolated_build_dir_cmd "${effective_cmd}")"
-  log_line "[ci-run] WARN: detected dune RPC/lock failure; retrying once with isolated build dir ${ACTIVE_TEST_BUILD_DIR}"
-  log_line "[ci-run] isolated_command: ${run_cmd}"
-  log_line "[ci-run] retry_started_at=$(iso_now)"
-  set +e
-  run_with_timeout "${run_cmd}"
-  status=$?
-  set -e
-fi
-
-if [[ "${status}" -ne 0 ]] \
-  && [[ "${CI_TEST_ALLOW_CLEAN_RETRY}" = "1" ]] \
-  && [[ "${CI_TEST_CLEAN_RETRY_DONE}" -eq 0 ]] \
-  && [[ "${CI_TEST_DISK_PRESSURE_DONE}" -eq 0 ]] \
-  && test_cmd_needs_dune_sanitization \
-  && agent_sdk_interface_mismatch_detected; then
-  run_agent_sdk_clean_retry
-fi
-
-if [[ "${status}" -eq 124 ]]; then
-  if [[ "${CI_LAST_TIMEOUT_DIAG_DONE}" -eq 0 ]]; then
-    diag_dump "timeout"
-  fi
-  log_line "[ci-run] ERROR: test command timed out after ${TEST_TIMEOUT_SEC}s"
-  exit 124
-fi
-
-# Flaky-test retry: if the test failed for reasons not caught by the
-# specific retry handlers above (RPC lock, interface mismatch), retry
-# once with an isolated build dir. This covers CI-only resource
-# exhaustion (fd/tmpdir) that cannot be reproduced locally.
-# See: https://github.com/jeong-sik/masc/issues/2957
-if [[ "${status}" -ne 0 ]] \
-  && [[ "${CI_TEST_ALLOW_FLAKY_RETRY}" = "1" ]] \
-  && [[ "${CI_TEST_FLAKY_RETRY_DONE}" -eq 0 ]] \
-  && [[ "${CI_TEST_RPC_RETRY_DONE}" -eq 0 ]] \
-  && [[ "${CI_TEST_CLEAN_RETRY_DONE}" -eq 0 ]] \
-  && [[ "${CI_TEST_DISK_PRESSURE_DONE}" -eq 0 ]] \
-  && test_cmd_needs_dune_sanitization \
-  && deterministic_test_failure_detected \
-  && ! disk_full_detected; then
-  log_line "[ci-run] INFO: explicit test failure detected; skipping isolated flaky retry"
-fi
-
-if [[ "${status}" -ne 0 ]] \
-  && [[ "${CI_TEST_ALLOW_FLAKY_RETRY}" = "1" ]] \
-  && [[ "${CI_TEST_FLAKY_RETRY_DONE}" -eq 0 ]] \
-  && [[ "${CI_TEST_RPC_RETRY_DONE}" -eq 0 ]] \
-  && [[ "${CI_TEST_CLEAN_RETRY_DONE}" -eq 0 ]] \
-  && [[ "${CI_TEST_DISK_PRESSURE_DONE}" -eq 0 ]] \
-  && test_cmd_needs_dune_sanitization \
-  && native_link_failure_detected \
-  && ! disk_full_detected; then
-  log_line "[ci-run] INFO: native linker failure detected; skipping isolated flaky retry"
-fi
-
-if [[ "${status}" -ne 0 ]] \
-  && [[ "${CI_TEST_ALLOW_FLAKY_RETRY}" = "1" ]] \
-  && [[ "${CI_TEST_FLAKY_RETRY_DONE}" -eq 0 ]] \
-  && [[ "${CI_TEST_RPC_RETRY_DONE}" -eq 0 ]] \
-  && [[ "${CI_TEST_CLEAN_RETRY_DONE}" -eq 0 ]] \
-  && [[ "${CI_TEST_DISK_PRESSURE_DONE}" -eq 0 ]] \
-  && test_cmd_needs_dune_sanitization \
-  && ! deterministic_test_failure_detected \
-  && ! native_link_failure_detected \
-  && ! disk_full_detected; then
-  CI_TEST_FLAKY_RETRY_DONE=1
-  diag_dump "flaky_pre_retry_${status}"
-  ACTIVE_TEST_BUILD_DIR="${CI_TEST_ISOLATED_BUILD_DIR}_flaky"
-  run_cmd="$(isolated_build_dir_cmd "${effective_cmd}")"
-  log_line "[ci-run] WARN: test failed (exit=${status}); retrying once with isolated build dir ${ACTIVE_TEST_BUILD_DIR} (flaky-test mitigation)"
-  log_line "[ci-run] flaky_retry_started_at=$(iso_now)"
-  set +e
-  run_with_timeout "${run_cmd}"
-  status=$?
-  set -e
-
-  if [[ "${status}" -ne 0 ]] && disk_full_detected; then
-    log_disk_full_guidance
-  fi
-fi
-
-if [[ "${status}" -ne 0 ]] \
-  && [[ "${CI_TEST_ALLOW_CLEAN_RETRY}" = "1" ]] \
-  && [[ "${CI_TEST_CLEAN_RETRY_DONE}" -eq 0 ]] \
-  && test_cmd_needs_dune_sanitization \
-  && agent_sdk_interface_mismatch_detected; then
-  run_agent_sdk_clean_retry
-fi
-
+status=0
+run_observed "$(effective_test_cmd)" || status=$?
 if [[ "${status}" -ne 0 ]]; then
-  if [[ "${CI_TEST_DISK_PRESSURE_DONE}" -eq 1 ]] || disk_full_detected; then
-    log_disk_full_guidance
-  fi
   diag_dump "nonzero_exit_${status}"
   log_line "[ci-run] ERROR: test command failed with exit=${status}"
   exit "${status}"
@@ -621,27 +267,13 @@ fi
 
 if [[ "${CI_CONTRACT_HARNESS_ENABLED}" = "1" ]]; then
   log_line "[ci-run] contract_harness_command: ${CI_CONTRACT_HARNESS_CMD}"
-  log_line "[ci-run] contract_harness_timeout_sec=${CI_CONTRACT_HARNESS_TIMEOUT_SEC}"
-  saved_timeout_sec="${TEST_TIMEOUT_SEC}"
-  TEST_TIMEOUT_SEC="${CI_CONTRACT_HARNESS_TIMEOUT_SEC}"
-  set +e
-  run_with_timeout "${CI_CONTRACT_HARNESS_CMD}"
-  contract_status=$?
-  set -e
-  TEST_TIMEOUT_SEC="${saved_timeout_sec}"
-
-  if [[ "${contract_status}" -eq 124 ]]; then
-    diag_dump "contract_harness_timeout"
-    log_line "[ci-run] ERROR: contract harness timed out after ${CI_CONTRACT_HARNESS_TIMEOUT_SEC}s"
-    exit 124
-  fi
-
+  contract_status=0
+  run_observed "${CI_CONTRACT_HARNESS_CMD}" || contract_status=$?
   if [[ "${contract_status}" -ne 0 ]]; then
     diag_dump "contract_harness_exit_${contract_status}"
     log_line "[ci-run] ERROR: contract harness failed with exit=${contract_status}"
     exit "${contract_status}"
   fi
-
   log_line "[ci-run] contract harness completed successfully"
 else
   log_line "[ci-run] contract harness skipped (CI_CONTRACT_HARNESS_ENABLED=${CI_CONTRACT_HARNESS_ENABLED})"

--- a/scripts/coverage_percent.sh
+++ b/scripts/coverage_percent.sh
@@ -74,7 +74,7 @@ if ! $reuse_existing; then
   mkdir -p "$coverage_dir"
   (
     cd "$root_dir"
-    CI_TEST_TIMEOUT_SEC=1200 CI_TEST_HEARTBEAT_SEC=30 \
+    CI_TEST_HEARTBEAT_SEC=30 \
       ./scripts/ci-run-tests.sh \
       "BISECT_FILE='$coverage_dir/bisect' ./scripts/dune-local.sh test --instrument-with bisect_ppx --force"
   )

--- a/scripts/feedback-loop.sh
+++ b/scripts/feedback-loop.sh
@@ -41,7 +41,7 @@ for i in $(seq 1 $ITERATIONS); do
   if [ "$RUN_FULL_TESTS" = "1" ]; then
     echo "🧪 Testing full suite..."
     TEST_OUTPUT=$(
-      CI_TEST_TIMEOUT_SEC=1200 CI_TEST_HEARTBEAT_SEC=30 \
+      CI_TEST_HEARTBEAT_SEC=30 \
         "$REPO_DIR/scripts/ci-run-tests.sh" \
         "$REPO_DIR/scripts/dune-local.sh test" 2>&1 || true
     )

--- a/scripts/improve.sh
+++ b/scripts/improve.sh
@@ -23,7 +23,7 @@ echo "1️⃣ Pre-check..."
 BEFORE_TESTS=0
 if [ "$RUN_FULL_TESTS" = "1" ]; then
   BEFORE_TESTS=$(
-    CI_TEST_TIMEOUT_SEC=1200 CI_TEST_HEARTBEAT_SEC=30 \
+    CI_TEST_HEARTBEAT_SEC=30 \
       "$REPO_DIR/scripts/ci-run-tests.sh" \
       "$REPO_DIR/scripts/dune-local.sh test" 2>&1 | grep -c "Test Successful" || echo "0"
   )
@@ -46,7 +46,7 @@ FAILED=0
 if [ "$RUN_FULL_TESTS" = "1" ]; then
   echo "3️⃣ Testing full suite..."
   TEST_OUTPUT=$(
-    CI_TEST_TIMEOUT_SEC=1200 CI_TEST_HEARTBEAT_SEC=30 \
+    CI_TEST_HEARTBEAT_SEC=30 \
       "$REPO_DIR/scripts/ci-run-tests.sh" \
       "$REPO_DIR/scripts/dune-local.sh test" 2>&1 || true
   )

--- a/test/test_ci_run_tests_script.ml
+++ b/test/test_ci_run_tests_script.ml
@@ -25,13 +25,6 @@ let contains_substring haystack needle =
 let read_file path =
   In_channel.with_open_bin path In_channel.input_all
 
-let write_file path content =
-  Out_channel.with_open_bin path (fun oc -> output_string oc content)
-
-let write_executable path content =
-  write_file path content;
-  Unix.chmod path 0o755
-
 let rec rm_rf path =
   if Sys.file_exists path then
     if Sys.is_directory path then begin
@@ -47,13 +40,6 @@ let with_temp_dir prefix f =
   Unix.mkdir dir 0o755;
   Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
 
-(* Each scenario below asserts exact Dune environment transitions. Start from
-   an explicit baseline instead of inheriting the runner's values: the Build
-   and Test job exports [DUNE_CACHE=enabled], while scenarios that exercise the
-   first attempt intentionally expect no cache override. Explicit scenario
-   overrides are applied after this removal and therefore still win. *)
-let dune_vars_controlled_by_test = [ "DUNE_BUILD_DIR"; "DUNE_CACHE"; "DUNE_RPC" ]
-
 let env_array overrides =
   let table = Hashtbl.create 64 in
   Unix.environment ()
@@ -66,7 +52,6 @@ let env_array overrides =
                String.sub entry (idx + 1) (String.length entry - idx - 1)
              in
              Hashtbl.replace table key value);
-  List.iter (Hashtbl.remove table) dune_vars_controlled_by_test;
   List.iter (fun (key, value) -> Hashtbl.replace table key value) overrides;
   Hashtbl.fold
     (fun key value acc -> Printf.sprintf "%s=%s" key value :: acc)
@@ -106,676 +91,127 @@ let run_process ?(env = []) ~cwd prog argv =
   Sys.remove err;
   (code, stdout, stderr)
 
-let make_fake_dune dir =
-  let bin_dir = Filename.concat dir "bin" in
-  Unix.mkdir bin_dir 0o755;
-  let dune_path = Filename.concat bin_dir "dune" in
-  write_file dune_path
-    {|#!/bin/sh
-set -eu
-log_file="${FAKE_DUNE_LOG:?}"
-printf '%s|%s|%s\n' "${1:-}" "${DUNE_BUILD_DIR:-}" "$(pwd)" >>"$log_file"
-if [ "${1:-}" = "--version" ]; then
-  printf '3.21.0\n'
-  exit 0
-fi
-if [ "${1:-}" = "clean" ]; then
-  exit 0
-fi
-if [ -z "${DUNE_BUILD_DIR:-}" ] || [ "${DUNE_BUILD_DIR}" = "_build" ]; then
-  printf '  [OK]          classify_exn             2   ENOSPC.\n' >&2
-  printf 'Error: RPC server not running.\n' >&2
-  exit 1
-fi
-mkdir -p "${DUNE_BUILD_DIR}/default/test/_build/_tests"
-printf 'fake ok\n' > "${DUNE_BUILD_DIR}/default/test/_build/_tests/fake.output"
-printf 'Testing `fake`.\n'
-exit 0
-|}
-  ;
-  Unix.chmod dune_path 0o755;
-  bin_dir
-
-let make_dune_test_command ~dir =
-  Printf.sprintf "dune test --root %s" dir
-
-let make_sleep_command ~dir =
-  let path = Filename.concat dir "sleep-long.sh" in
-  write_executable path "#!/bin/sh\nset -eu\nsleep 10\n";
-  path
-
 let run_ci ?(env = []) ~cwd command =
   let script = script_path () in
   run_process ~cwd ~env script [| script; command |]
 
-let make_fake_dune_flaky_then_agent_sdk_artifact_failure dir =
-  let bin_dir = Filename.concat dir "bin-interface" in
-  Unix.mkdir bin_dir 0o755;
-  let dune_path = Filename.concat bin_dir "dune" in
-  write_file dune_path
-    {|#!/bin/sh
-set -eu
-log_file="${FAKE_DUNE_LOG:?}"
-printf '%s|%s|%s|%s\n' "${1:-}" "${DUNE_BUILD_DIR:-}" "${DUNE_CACHE:-}" "$(pwd)" >>"$log_file"
-if [ "${1:-}" = "--version" ]; then
-  printf '3.21.0\n'
-  exit 0
-fi
-if [ "${1:-}" = "clean" ]; then
-  exit 0
-fi
-if [ -z "${DUNE_BUILD_DIR:-}" ] || [ "${DUNE_BUILD_DIR}" = "_build" ]; then
-  printf 'plain failure\n' >&2
-  exit 1
-fi
-if [ "${DUNE_BUILD_DIR}" = ".ci_build_flaky" ] && [ "${DUNE_CACHE:-}" != "disabled" ]; then
-  printf 'Error: File unavailable:\n' >&2
-  printf '/tmp/opam/lib/agent_sdk/llm_provider/llm_provider.cmxa\n' >&2
-  printf 'Error: Unbound module Llm_provider\n' >&2
-  exit 1
-fi
-mkdir -p "${DUNE_BUILD_DIR}/default/test/_build/_tests"
-printf 'fake ok\n' > "${DUNE_BUILD_DIR}/default/test/_build/_tests/fake.output"
-printf 'Testing `fake`.\n'
-exit 0
-|}
-  ;
-  Unix.chmod dune_path 0o755;
-  bin_dir
+let base_env log_file =
+  [
+    ("CI_TEST_HEARTBEAT_SEC", "1");
+    ("CI_TEST_DISK_MIN_AVAILABLE_MB", "0");
+    ("CI_TEST_LOG_FILE", log_file);
+    ("CI_CONTRACT_HARNESS_ENABLED", "0");
+  ]
 
-let make_fake_dune_disk_full dir =
-  let bin_dir = Filename.concat dir "bin-disk-full" in
-  Unix.mkdir bin_dir 0o755;
-  let dune_path = Filename.concat bin_dir "dune" in
-  write_file dune_path
-    {|#!/bin/sh
-set -eu
-log_file="${FAKE_DUNE_LOG:?}"
-printf '%s|%s|%s\n' "${1:-}" "${DUNE_BUILD_DIR:-}" "$(pwd)" >>"$log_file"
-if [ "${1:-}" = "--version" ]; then
-  printf '3.21.0\n'
-  exit 0
-fi
-if [ "${1:-}" = "clean" ]; then
-  exit 0
-fi
-printf 'Error: dune_trace_write(): No space left on device\n' >&2
-exit 1
-|}
-  ;
-  Unix.chmod dune_path 0o755;
-  bin_dir
+let count_lines path =
+  if not (Sys.file_exists path) then
+    0
+  else
+    read_file path |> String.split_on_char '\n'
+    |> List.filter (fun line -> String.trim line <> "")
+    |> List.length
 
-let make_fake_dune_deterministic_failure dir =
-  let bin_dir = Filename.concat dir "bin-deterministic-failure" in
-  Unix.mkdir bin_dir 0o755;
-  let dune_path = Filename.concat bin_dir "dune" in
-  write_file dune_path
-    {|#!/bin/sh
-set -eu
-log_file="${FAKE_DUNE_LOG:?}"
-printf '%s|%s|%s\n' "${1:-}" "${DUNE_BUILD_DIR:-}" "$(pwd)" >>"$log_file"
-if [ "${1:-}" = "--version" ]; then
-  printf '3.21.0\n'
-  exit 0
-fi
-if [ "${1:-}" = "clean" ]; then
-  exit 0
-fi
-printf '  [FAIL]        module-init          3   keeper all complete.\n' >&2
-printf 'ASSERT Keeper_metrics.all covers every constructor\n' >&2
-printf '1 failure! in 0.000s. 6 tests run.\n' >&2
-i=0
-while [ "$i" -lt 5000 ]; do
-  printf 'deterministic failure context %s\n' "$i" >&2
-  i=$((i + 1))
-done
-exit 1
-|}
-  ;
-  Unix.chmod dune_path 0o755;
-  bin_dir
-
-let make_fake_dune_native_link_failure dir =
-  let bin_dir = Filename.concat dir "bin-native-link-failure" in
-  Unix.mkdir bin_dir 0o755;
-  let dune_path = Filename.concat bin_dir "dune" in
-  write_file dune_path
-    {|#!/bin/sh
-set -eu
-log_file="${FAKE_DUNE_LOG:?}"
-printf '%s|%s|%s\n' "${1:-}" "${DUNE_BUILD_DIR:-}" "$(pwd)" >>"$log_file"
-if [ "${1:-}" = "--version" ]; then
-  printf '3.21.0\n'
-  exit 0
-fi
-if [ "${1:-}" = "clean" ]; then
-  exit 0
-fi
-printf 'collect2: error: ld returned 1 exit status\n' >&2
-printf 'File "caml_startup", line 1:\n' >&2
-printf 'Error: Error during linking (exit code 1)\n' >&2
-exit 1
-|}
-  ;
-  Unix.chmod dune_path 0o755;
-  bin_dir
-
-let make_fake_dune_github_disk_warning dir =
-  let bin_dir = Filename.concat dir "bin-github-disk-warning" in
-  Unix.mkdir bin_dir 0o755;
-  let dune_path = Filename.concat bin_dir "dune" in
-  write_file dune_path
-    {|#!/bin/sh
-set -eu
-log_file="${FAKE_DUNE_LOG:?}"
-printf '%s|%s|%s\n' "${1:-}" "${DUNE_BUILD_DIR:-}" "$(pwd)" >>"$log_file"
-if [ "${1:-}" = "--version" ]; then
-  printf '3.21.0\n'
-  exit 0
-fi
-if [ "${1:-}" = "clean" ]; then
-  exit 0
-fi
-printf 'collect2: error: ld returned 1 exit status\n' >&2
-printf 'Error: Error during linking (exit code 1)\n' >&2
-printf '##[warning]You are running out of disk space. The runner will stop working when the machine runs out of disk space. Free space left: 14 MB\n' >&2
-exit 1
-|}
-  ;
-  Unix.chmod dune_path 0o755;
-  bin_dir
-
-let make_fake_dune_with_low_disk_df dir =
-  let bin_dir = Filename.concat dir "bin-low-disk-df" in
-  Unix.mkdir bin_dir 0o755;
-  let dune_path = Filename.concat bin_dir "dune" in
-  write_file dune_path
-    {|#!/bin/sh
-set -eu
-log_file="${FAKE_DUNE_LOG:?}"
-printf '%s|%s|%s\n' "${1:-}" "${DUNE_BUILD_DIR:-}" "$(pwd)" >>"$log_file"
-if [ "${1:-}" = "--version" ]; then
-  printf '3.21.0\n'
-  exit 0
-fi
-if [ "${1:-}" = "clean" ]; then
-  exit 0
-fi
-trap 'exit 143' TERM
-sleep 10
-exit 0
-|}
-  ;
-  Unix.chmod dune_path 0o755;
-  let df_path = Filename.concat bin_dir "df" in
-  write_file df_path
-    {|#!/bin/sh
-case "${1:-}" in
-  -Pm)
-    printf 'Filesystem 1048576-blocks Used Available Capacity Mounted on\n'
-    printf '/dev/root 100 99 14 99%% /\n'
-    ;;
-  -h)
-    printf 'Filesystem Size Used Avail Use%% Mounted on\n'
-    printf '/dev/root 100G 99G 14M 99%% /\n'
-    ;;
-  *)
-    /bin/df "$@"
-    ;;
-esac
-|}
-  ;
-  Unix.chmod df_path 0o755;
-  bin_dir
-
-let test_rpc_retry_uses_isolated_build_dir () =
-  with_temp_dir "ci-run-tests-retry" (fun dir ->
-      let cwd = Unix.realpath dir in
-      let repo_dir = Filename.concat dir "repo" in
-      Unix.mkdir repo_dir 0o755;
-      let fake_log = Filename.concat dir "fake-dune.log" in
-      let ci_log = Filename.concat dir "ci-run-tests.log" in
-      let fake_bin = make_fake_dune dir in
-      let path =
-        Printf.sprintf "%s:%s" fake_bin
-          (match Sys.getenv_opt "PATH" with Some p -> p | None -> "")
-      in
-      let env =
-        [
-          ("PATH", path);
-          ("DUNE_BUILD_DIR", "");
-          ("FAKE_DUNE_LOG", fake_log);
-          ("CI_TEST_HEARTBEAT_SEC", "1");
-          ("CI_TEST_TIMEOUT_SEC", "30");
-          ("CI_TEST_LOG_FILE", ci_log);
-          ("CI_CONTRACT_HARNESS_ENABLED", "0");
-        ]
+let test_dune_command_is_observed_once_and_sanitized () =
+  with_temp_dir "ci-run-tests-once" (fun dir ->
+      let ci_log = Filename.concat dir "ci.log" in
+      let rpc_log = Filename.concat dir "rpc.log" in
+      let command =
+        Printf.sprintf "printf '%%s' \"${DUNE_RPC-unset}\" > %s; # dune test"
+          (Filename.quote rpc_log)
       in
       let code, stdout, stderr =
-        run_ci ~cwd:dir ~env (make_dune_test_command ~dir)
+        run_ci ~cwd:dir
+          ~env:(("DUNE_RPC", "stale-rpc") :: base_env ci_log)
+          command
       in
-      if code <> 0 then
-        failf "ci-run-tests failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout
-          stderr;
-      let ci_log_contents = read_file ci_log in
-      let observed_output =
-        String.concat "\n" [ ci_log_contents; stdout; stderr ]
-      in
-      check bool "retry warning present" true
-        (contains_substring observed_output
-           "detected dune RPC/lock failure; retrying once with isolated build dir .ci_build");
-      check bool "passing ENOSPC test name ignored" false
-        (contains_substring observed_output
-           "detected disk exhaustion during dune build");
-      check bool "isolated command exports build dir" true
-        (contains_substring observed_output
-           "isolated_command: export DUNE_BUILD_DIR=.ci_build; unset DUNE_RPC;");
-      check bool "success message present" true
-        (contains_substring stdout "tests completed successfully");
-      let log_lines =
-        read_file fake_log
-        |> String.split_on_char '\n'
-        |> List.filter (fun line -> String.trim line <> "")
-      in
-      match log_lines with
-      | [ first; second ] ->
-          check string "first attempt uses default build dir and repo cwd"
-            (Printf.sprintf "test||%s" cwd)
-            first;
-          check string "second attempt uses isolated build dir and repo cwd"
-            (Printf.sprintf "test|.ci_build|%s" cwd)
-            second
-      | _ ->
-          failf "expected exactly two dune invocations, got:\n%s"
-            (String.concat "\n" log_lines))
+      check int "success" 0 code;
+      check string "DUNE_RPC removed" "unset" (read_file rpc_log);
+      let observed = String.concat "\n" [ read_file ci_log; stdout; stderr ] in
+      check bool "success reported" true
+        (contains_substring observed "tests completed successfully"))
 
-let test_deterministic_failure_skips_flaky_retry () =
-  with_temp_dir "ci-run-tests-deterministic-failure" (fun dir ->
-      let cwd = Unix.realpath dir in
-      let repo_dir = Filename.concat dir "repo" in
-      Unix.mkdir repo_dir 0o755;
-      let fake_log = Filename.concat dir "fake-dune.log" in
-      let ci_log = Filename.concat dir "ci-run-tests.log" in
-      let fake_bin = make_fake_dune_deterministic_failure dir in
-      let path =
-        Printf.sprintf "%s:%s" fake_bin
-          (match Sys.getenv_opt "PATH" with Some p -> p | None -> "")
+let test_failure_is_not_retried () =
+  with_temp_dir "ci-run-tests-failure" (fun dir ->
+      let ci_log = Filename.concat dir "ci.log" in
+      let count_log = Filename.concat dir "count.log" in
+      let command =
+        Printf.sprintf "printf 'attempt\\n' >> %s; exit 7"
+          (Filename.quote count_log)
       in
       let env =
-        [
-          ("PATH", path);
-          ("DUNE_BUILD_DIR", "");
-          ("FAKE_DUNE_LOG", fake_log);
-          ("CI_TEST_HEARTBEAT_SEC", "1");
-          ("CI_TEST_TIMEOUT_SEC", "30");
-          ("CI_TEST_LOG_FILE", ci_log);
-          ("CI_CONTRACT_HARNESS_ENABLED", "0");
-          ("CI_TEST_ALLOW_FLAKY_RETRY", "1");
-        ]
+        ("CI_TEST_ALLOW_FLAKY_RETRY", "1")
+        :: ("CI_TEST_ALLOW_RPC_RETRY", "1")
+        :: ("CI_TEST_ALLOW_CLEAN_RETRY", "1")
+        :: base_env ci_log
       in
-      let code, stdout, stderr =
-        run_ci ~cwd:dir ~env (make_dune_test_command ~dir)
-      in
-      check int "deterministic failure exit code" 1 code;
-      let ci_log_contents = read_file ci_log in
-      let observed_output =
-        String.concat "\n" [ ci_log_contents; stdout; stderr ]
-      in
-      check bool "deterministic retry skip logged" true
-        (contains_substring observed_output
-           "explicit test failure detected; skipping isolated flaky retry");
-      check bool "flaky retry skipped" false
-        (contains_substring observed_output "flaky-test mitigation");
-      let log_lines =
-        read_file fake_log
-        |> String.split_on_char '\n'
-        |> List.filter (fun line -> String.trim line <> "")
-      in
-      match log_lines with
-      | [ first ] ->
-          check string "single attempt uses repo cwd"
-            (Printf.sprintf "test||%s" cwd)
-            first
-      | _ ->
-          failf "expected exactly one dune invocation, got:\n%s"
-            (String.concat "\n" log_lines))
+      let code, stdout, stderr = run_ci ~cwd:dir ~env command in
+      check int "original exit code" 7 code;
+      check int "one attempt" 1 (count_lines count_log);
+      let observed = String.concat "\n" [ read_file ci_log; stdout; stderr ] in
+      check bool "failure diagnostics" true
+        (contains_substring observed "[ci-diag] reason=nonzero_exit_7");
+      check bool "failure reported" true
+        (contains_substring observed "test command failed with exit=7"))
 
-let test_native_link_failure_skips_flaky_retry () =
-  with_temp_dir "ci-run-tests-native-link-failure" (fun dir ->
-      let cwd = Unix.realpath dir in
-      let repo_dir = Filename.concat dir "repo" in
-      Unix.mkdir repo_dir 0o755;
-      let fake_log = Filename.concat dir "fake-dune.log" in
-      let ci_log = Filename.concat dir "ci-run-tests.log" in
-      let fake_bin = make_fake_dune_native_link_failure dir in
-      let path =
-        Printf.sprintf "%s:%s" fake_bin
-          (match Sys.getenv_opt "PATH" with Some p -> p | None -> "")
+let test_legacy_deadline_knob_does_not_terminate_command () =
+  with_temp_dir "ci-run-tests-no-deadline" (fun dir ->
+      let ci_log = Filename.concat dir "ci.log" in
+      let done_log = Filename.concat dir "done.log" in
+      let command =
+        Printf.sprintf "sleep 2; printf 'done' > %s" (Filename.quote done_log)
+      in
+      let env = ("CI_TEST_TIMEOUT_SEC", "1") :: base_env ci_log in
+      let code, _, _ = run_ci ~cwd:dir ~env command in
+      check int "command completes" 0 code;
+      check string "completion evidence" "done" (read_file done_log))
+
+let test_contract_harness_runs_once () =
+  with_temp_dir "ci-run-tests-contract" (fun dir ->
+      let ci_log = Filename.concat dir "ci.log" in
+      let count_log = Filename.concat dir "contract.log" in
+      let contract_cmd =
+        Printf.sprintf "printf 'contract\\n' >> %s" (Filename.quote count_log)
       in
       let env =
-        [
-          ("PATH", path);
-          ("DUNE_BUILD_DIR", "");
-          ("FAKE_DUNE_LOG", fake_log);
-          ("CI_TEST_HEARTBEAT_SEC", "1");
-          ("CI_TEST_TIMEOUT_SEC", "30");
-          ("CI_TEST_LOG_FILE", ci_log);
-          ("CI_CONTRACT_HARNESS_ENABLED", "0");
-          ("CI_TEST_ALLOW_FLAKY_RETRY", "1");
-        ]
+        ("CI_CONTRACT_HARNESS_ENABLED", "1")
+        :: ("CI_CONTRACT_HARNESS_CMD", contract_cmd)
+        :: List.remove_assoc "CI_CONTRACT_HARNESS_ENABLED" (base_env ci_log)
       in
-      let code, stdout, stderr =
-        run_ci ~cwd:dir ~env (make_dune_test_command ~dir)
-      in
-      check int "native link failure exit code" 1 code;
-      let ci_log_contents = read_file ci_log in
-      let observed_output =
-        String.concat "\n" [ ci_log_contents; stdout; stderr ]
-      in
-      check bool "native link retry skip logged" true
-        (contains_substring observed_output
-           "native linker failure detected; skipping isolated flaky retry");
-      check bool "flaky retry skipped" false
-        (contains_substring observed_output "flaky-test mitigation");
-      let log_lines =
-        read_file fake_log
-        |> String.split_on_char '\n'
-        |> List.filter (fun line -> String.trim line <> "")
-      in
-      match log_lines with
-      | [ first ] ->
-          check string "single attempt uses repo cwd"
-            (Printf.sprintf "test||%s" cwd)
-            first
-      | _ ->
-          failf "expected exactly one dune invocation, got:\n%s"
-            (String.concat "\n" log_lines))
+      let code, stdout, stderr = run_ci ~cwd:dir ~env "true" in
+      check int "success" 0 code;
+      check int "one contract attempt" 1 (count_lines count_log);
+      let observed = String.concat "\n" [ read_file ci_log; stdout; stderr ] in
+      check bool "contract success reported" true
+        (contains_substring observed "contract harness completed successfully"))
 
-let test_agent_sdk_artifact_failure_after_flaky_retry_disables_cache () =
-  with_temp_dir "ci-run-tests-interface" (fun dir ->
-      let cwd = Unix.realpath dir in
-      let repo_dir = Filename.concat dir "repo" in
-      Unix.mkdir repo_dir 0o755;
-      let fake_log = Filename.concat dir "fake-dune.log" in
-      let ci_log = Filename.concat dir "ci-run-tests.log" in
-      let fake_bin = make_fake_dune_flaky_then_agent_sdk_artifact_failure dir in
-      let path =
-        Printf.sprintf "%s:%s" fake_bin
-          (match Sys.getenv_opt "PATH" with Some p -> p | None -> "")
-      in
-      let env =
-        [
-          ("PATH", path);
-          ("DUNE_BUILD_DIR", "");
-          ("FAKE_DUNE_LOG", fake_log);
-          ("CI_TEST_HEARTBEAT_SEC", "1");
-          ("CI_TEST_TIMEOUT_SEC", "30");
-          ("CI_TEST_LOG_FILE", ci_log);
-          ("CI_CONTRACT_HARNESS_ENABLED", "0");
-        ]
-      in
-      let code, stdout, stderr =
-        run_ci ~cwd:dir ~env (make_dune_test_command ~dir)
-      in
-      if code <> 0 then
-        failf "ci-run-tests failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout
-          stderr;
-      let ci_log_contents = read_file ci_log in
-      let observed_output =
-        String.concat "\n" [ ci_log_contents; stdout; stderr ]
-      in
-      check bool "flaky retry warning present" true
-        (contains_substring observed_output
-           "test failed (exit=1); retrying once with isolated build dir .ci_build_flaky");
-      check bool "agent sdk artifact warning present" true
-        (contains_substring observed_output
-           "detected Agent_sdk/OAS artifact or interface mismatch; running dune clean and retrying once with DUNE_CACHE=disabled");
-      check bool "retry command disables cache" true
-        (contains_substring observed_output
-           "retry_command: export DUNE_CACHE=disabled; export DUNE_BUILD_DIR=.ci_build_flaky; unset DUNE_RPC;");
-      let log_lines =
-        read_file fake_log
-        |> String.split_on_char '\n'
-        |> List.filter (fun line -> String.trim line <> "")
-      in
-      match log_lines with
-      | [ first; second; third; fourth ] ->
-          check string "first attempt uses default build dir"
-            (Printf.sprintf "test|||%s" cwd)
-            first;
-          check string "flaky retry uses isolated build dir without cache override"
-            (Printf.sprintf "test|.ci_build_flaky||%s" cwd)
-            second;
-          check string "clean uses isolated build dir"
-            (Printf.sprintf "clean|.ci_build_flaky||%s" cwd)
-            third;
-          check string "clean retry disables dune cache"
-            (Printf.sprintf "test|.ci_build_flaky|disabled|%s" cwd)
-            fourth
-      | _ ->
-          failf "expected exactly four dune invocations, got:\n%s"
-            (String.concat "\n" log_lines))
-
-let test_disk_full_failure_skips_flaky_retry () =
-  with_temp_dir "ci-run-tests-disk-full" (fun dir ->
-      let cwd = Unix.realpath dir in
-      let repo_dir = Filename.concat dir "repo" in
-      Unix.mkdir repo_dir 0o755;
-      let fake_log = Filename.concat dir "fake-dune.log" in
-      let ci_log = Filename.concat dir "ci-run-tests.log" in
-      let fake_bin = make_fake_dune_disk_full dir in
-      let path =
-        Printf.sprintf "%s:%s" fake_bin
-          (match Sys.getenv_opt "PATH" with Some p -> p | None -> "")
-      in
-      let env =
-        [
-          ("PATH", path);
-          ("DUNE_BUILD_DIR", "");
-          ("FAKE_DUNE_LOG", fake_log);
-          ("CI_TEST_HEARTBEAT_SEC", "1");
-          ("CI_TEST_TIMEOUT_SEC", "30");
-          ("CI_TEST_LOG_FILE", ci_log);
-          ("CI_CONTRACT_HARNESS_ENABLED", "0");
-          ("CI_TEST_ALLOW_FLAKY_RETRY", "1");
-        ]
-      in
-      let code, stdout, stderr =
-        run_ci ~cwd:dir ~env (make_dune_test_command ~dir)
-      in
-      check int "disk full exit code" 1 code;
-      let ci_log_contents = read_file ci_log in
-      let observed_output =
-        String.concat "\n" [ ci_log_contents; stdout; stderr ]
-      in
-      check bool "disk guidance present" true
-        (contains_substring observed_output
-           "detected disk exhaustion during dune build");
-      check bool "disk hygiene repair present" true
-        (contains_substring observed_output
-           "bash scripts/disk-hygiene.sh --fix");
-      check bool "flaky retry skipped" false
-        (contains_substring observed_output "flaky-test mitigation");
-      let log_lines =
-        read_file fake_log
-        |> String.split_on_char '\n'
-        |> List.filter (fun line -> String.trim line <> "")
-      in
-      match log_lines with
-      | [ first ] ->
-          check string "single attempt uses repo cwd"
-            (Printf.sprintf "test||%s" cwd)
-            first
-      | _ ->
-          failf "expected exactly one dune invocation, got:\n%s"
-            (String.concat "\n" log_lines))
-
-let test_github_disk_warning_skips_flaky_retry () =
-  with_temp_dir "ci-run-tests-gh-disk-warning" (fun dir ->
-      let cwd = Unix.realpath dir in
-      let repo_dir = Filename.concat dir "repo" in
-      Unix.mkdir repo_dir 0o755;
-      let fake_log = Filename.concat dir "fake-dune.log" in
-      let ci_log = Filename.concat dir "ci-run-tests.log" in
-      let fake_bin = make_fake_dune_github_disk_warning dir in
-      let path =
-        Printf.sprintf "%s:%s" fake_bin
-          (match Sys.getenv_opt "PATH" with Some p -> p | None -> "")
-      in
-      let env =
-        [
-          ("PATH", path);
-          ("DUNE_BUILD_DIR", "");
-          ("FAKE_DUNE_LOG", fake_log);
-          ("CI_TEST_HEARTBEAT_SEC", "1");
-          ("CI_TEST_TIMEOUT_SEC", "30");
-          ("CI_TEST_LOG_FILE", ci_log);
-          ("CI_CONTRACT_HARNESS_ENABLED", "0");
-          ("CI_TEST_ALLOW_FLAKY_RETRY", "1");
-        ]
-      in
-      let code, stdout, stderr =
-        run_ci ~cwd:dir ~env (make_dune_test_command ~dir)
-      in
-      check int "github disk warning exit code" 1 code;
-      let ci_log_contents = read_file ci_log in
-      let observed_output =
-        String.concat "\n" [ ci_log_contents; stdout; stderr ]
-      in
-      check bool "disk guidance present" true
-        (contains_substring observed_output
-           "detected disk exhaustion during dune build");
-      check bool "github runner warning preserved" true
-        (contains_substring observed_output "Free space left: 14 MB");
-      check bool "flaky retry skipped" false
-        (contains_substring observed_output "flaky-test mitigation");
-      let log_lines =
-        read_file fake_log
-        |> String.split_on_char '\n'
-        |> List.filter (fun line -> String.trim line <> "")
-      in
-      match log_lines with
-      | [ first ] ->
-          check string "single attempt uses repo cwd"
-            (Printf.sprintf "test||%s" cwd)
-            first
-      | _ ->
-          failf "expected exactly one dune invocation, got:\n%s"
-            (String.concat "\n" log_lines))
-
-let test_low_disk_df_stops_before_flaky_retry () =
-  with_temp_dir "ci-run-tests-low-disk-df" (fun dir ->
-      let cwd = Unix.realpath dir in
-      let repo_dir = Filename.concat dir "repo" in
-      Unix.mkdir repo_dir 0o755;
-      let fake_log = Filename.concat dir "fake-dune.log" in
-      let ci_log = Filename.concat dir "ci-run-tests.log" in
-      let fake_bin = make_fake_dune_with_low_disk_df dir in
-      let path =
-        Printf.sprintf "%s:%s" fake_bin
-          (match Sys.getenv_opt "PATH" with Some p -> p | None -> "")
-      in
-      let env =
-        [
-          ("PATH", path);
-          ("DUNE_BUILD_DIR", "");
-          ("FAKE_DUNE_LOG", fake_log);
-          ("CI_TEST_HEARTBEAT_SEC", "1");
-          ("CI_TEST_TIMEOUT_SEC", "30");
-          ("CI_TEST_DISK_CHECK_SEC", "1");
-          ("CI_TEST_DISK_MIN_AVAILABLE_MB", "1024");
-          ("CI_TEST_LOG_FILE", ci_log);
-          ("CI_CONTRACT_HARNESS_ENABLED", "0");
-          ("CI_TEST_ALLOW_FLAKY_RETRY", "1");
-        ]
-      in
-      let code, stdout, stderr =
-        run_ci ~cwd:dir ~env (make_dune_test_command ~dir)
-      in
-      check int "low disk pressure exit code" 75 code;
-      let ci_log_contents = read_file ci_log in
-      let observed_output =
-        String.concat "\n" [ ci_log_contents; stdout; stderr ]
-      in
-      check bool "disk pressure detail present" true
-        (contains_substring observed_output
-           "available_mb=14 min_available_mb=1024");
-      check bool "disk diagnostics present" true
-        (contains_substring observed_output "[ci-diag] reason=disk_pressure");
-      check bool "disk guidance present" true
-        (contains_substring observed_output
-           "detected disk exhaustion during dune build");
-      check bool "flaky retry skipped" false
-        (contains_substring observed_output "flaky-test mitigation");
-      let log_lines =
-        read_file fake_log
-        |> String.split_on_char '\n'
-        |> List.filter (fun line -> String.trim line <> "")
-      in
-      match log_lines with
-      | [ first ] ->
-          check string "single attempt uses repo cwd"
-            (Printf.sprintf "test||%s" cwd)
-            first
-      | _ ->
-          failf "expected exactly one dune invocation, got:\n%s"
-            (String.concat "\n" log_lines))
-
-let test_timeout_diagnostics_capture_active_process_group () =
-  with_temp_dir "ci-run-tests-timeout" (fun dir ->
-      let ci_log = Filename.concat dir "ci-run-tests.log" in
-      let env =
-        [
-          ("CI_TEST_HEARTBEAT_SEC", "1");
-          ("CI_TEST_TIMEOUT_SEC", "2");
-          ("CI_TEST_LOG_FILE", ci_log);
-          ("CI_CONTRACT_HARNESS_ENABLED", "0");
-        ]
-      in
-      let code, stdout, stderr =
-        run_ci ~cwd:dir ~env (make_sleep_command ~dir)
-      in
-      check int "timeout exit code" 124 code;
-      let ci_log_contents = read_file ci_log in
-      let observed_output =
-        String.concat "\n" [ ci_log_contents; stdout; stderr ]
-      in
-      check bool "active command pid recorded" true
-        (contains_substring observed_output "active_cmd_pid=");
-      check bool "active command pgid recorded" true
-        (contains_substring observed_output "active_cmd_pgid=");
-      check bool "process tree snapshot recorded" true
-        (contains_substring observed_output
-           "active command process tree snapshot:");
-      check bool "sleeping process captured" true
-        (contains_substring observed_output "sleep 10"
-        || contains_substring observed_output "sleep-long.sh");
-      check bool "timeout error present" true
-        (contains_substring observed_output
-           "[ci-run] ERROR: test command timed out after 2s"))
+let test_control_layers_are_absent () =
+  let script = read_file (script_path ()) in
+  List.iter
+    (fun forbidden ->
+      check bool ("absent: " ^ forbidden) false
+        (contains_substring script forbidden))
+    [
+      "CI_TEST_TIMEOUT_SEC";
+      "CI_TEST_ALLOW_FLAKY_RETRY";
+      "CI_TEST_ALLOW_RPC_RETRY";
+      "CI_TEST_ALLOW_CLEAN_RETRY";
+      "run_with_timeout";
+      "retrying once";
+    ]
 
 let () =
   run "ci_run_tests_script"
     [
       ( "script",
         [
-          test_case "rpc retry uses isolated build dir" `Quick
-            test_rpc_retry_uses_isolated_build_dir;
-          test_case "deterministic failure skips flaky retry" `Quick
-            test_deterministic_failure_skips_flaky_retry;
-          test_case "native link failure skips flaky retry" `Quick
-            test_native_link_failure_skips_flaky_retry;
-          test_case "agent sdk artifact failure after flaky retry disables cache"
-            `Quick
-            test_agent_sdk_artifact_failure_after_flaky_retry_disables_cache;
-          test_case "disk full failure skips flaky retry" `Quick
-            test_disk_full_failure_skips_flaky_retry;
-          test_case "github disk warning skips flaky retry" `Quick
-            test_github_disk_warning_skips_flaky_retry;
-          test_case "low disk df stops before flaky retry" `Quick
-            test_low_disk_df_stops_before_flaky_retry;
-          test_case "timeout diagnostics capture active process group" `Quick
-            test_timeout_diagnostics_capture_active_process_group;
+          test_case "dune command observed once and sanitized" `Quick
+            test_dune_command_is_observed_once_and_sanitized;
+          test_case "failure is not retried" `Quick test_failure_is_not_retried;
+          test_case "legacy deadline knob does not terminate command" `Quick
+            test_legacy_deadline_knob_does_not_terminate_command;
+          test_case "contract harness runs once" `Quick
+            test_contract_harness_runs_once;
+          test_case "control layers are absent" `Quick
+            test_control_layers_are_absent;
         ] );
     ]

--- a/test/test_server_slack_trigger_policy.ml
+++ b/test/test_server_slack_trigger_policy.ml
@@ -216,38 +216,41 @@ let slack_message ~ts =
 
 let test_bound_message_queues_exact_slack_ts () =
   with_temp_base (fun () ->
-    match
-      State.bind ~channel_id:"C123" ~keeper_name:"luna" ~actor_name:"test"
-    with
-    | Error detail -> fail detail
-    | Ok _ ->
-      Eio_main.run @@ fun env ->
-      Eio.Switch.run @@ fun sw ->
-      let observed, resolve_observed = Eio.Promise.create () in
-      let ingress =
-        Connector_ingress_lane.create ~sw
-          ~on_failure:(fun failure ->
-            Eio.Promise.resolve resolve_observed failure)
-          ()
-      in
-      let dispatch ~on_text_snapshot:_ ~channel:_ ~channel_user_id:_
-          ~channel_user_name:_ ~channel_workspace_id:_ ~keeper_name:_
-          ~idempotency_key:_ ~metadata:_ ~content:_ =
-        failwith "observe Slack ingress identity"
-      in
-      G.For_testing.submit_event ingress ~dispatch
-        ~clock:(Eio.Stdenv.clock env)
-        (slack_message ~ts:"1710000000.123456");
-      let failure = Eio.Promise.await observed in
-      check string "exact Slack event ts" "1710000000.123456"
-        failure.Connector_ingress_lane.event_id.opaque_id;
-      check string "typed source" "slack_triggered"
-        failure.event_id.source;
-      match failure.lane with
-      | Connector_ingress_lane.Keeper_lane keeper_name ->
-        check string "resolved Keeper lane" "luna" keeper_name
-      | Connector_ingress_lane.Connector_lane connector_id ->
-        failf "expected Keeper lane, got connector:%s" connector_id)
+    try
+      match
+        State.bind ~channel_id:"C123" ~keeper_name:"luna" ~actor_name:"test"
+      with
+      | Error detail -> fail detail
+      | Ok _ ->
+        Eio_main.run @@ fun env ->
+        Eio.Switch.run @@ fun sw ->
+        let observed, resolve_observed = Eio.Promise.create () in
+        let ingress =
+          Connector_ingress_lane.create ~sw
+            ~on_failure:(fun failure ->
+              Eio.Promise.resolve resolve_observed failure)
+            ()
+        in
+        let dispatch ~on_text_snapshot:_ ~channel:_ ~channel_user_id:_
+            ~channel_user_name:_ ~channel_workspace_id:_ ~keeper_name:_
+            ~idempotency_key:_ ~metadata:_ ~content:_ =
+          failwith "observe Slack ingress identity"
+        in
+        G.For_testing.submit_event ingress ~dispatch
+          ~clock:(Eio.Stdenv.clock env)
+          (slack_message ~ts:"1710000000.123456");
+        let failure = Eio.Promise.await observed in
+        check string "exact Slack event ts" "1710000000.123456"
+          failure.Connector_ingress_lane.event_id.opaque_id;
+        check string "typed source" "slack_triggered"
+          failure.event_id.source;
+        (match failure.lane with
+         | Connector_ingress_lane.Keeper_lane keeper_name ->
+           check string "resolved Keeper lane" "luna" keeper_name
+         | Connector_ingress_lane.Connector_lane connector_id ->
+           failf "expected Keeper lane, got connector:%s" connector_id);
+        Eio.Switch.fail sw Exit
+    with Exit -> ())
 ;;
 
 let test_binding_store_failure_does_not_enqueue () =
@@ -262,25 +265,28 @@ let test_binding_store_failure_does_not_enqueue () =
     Fun.protect
       ~finally:(fun () -> close_out_noerr out)
       (fun () -> output_string out "{not-json");
-    Eio_main.run @@ fun env ->
-    Eio.Switch.run @@ fun sw ->
-    let dispatch_called = ref false in
-    let ingress =
-      Connector_ingress_lane.create ~sw
-        ~on_failure:(fun _ -> fail "binding failure must not enqueue")
-        ()
-    in
-    let dispatch ~on_text_snapshot:_ ~channel:_ ~channel_user_id:_
-        ~channel_user_name:_ ~channel_workspace_id:_ ~keeper_name:_
-        ~idempotency_key:_ ~metadata:_ ~content:_ =
-      dispatch_called := true;
-      Gate_protocol.Unavailable_result
-    in
-    G.For_testing.submit_event ingress ~dispatch
-      ~clock:(Eio.Stdenv.clock env)
-      (slack_message ~ts:"1710000000.654321");
-    Eio.Fiber.yield ();
-    check bool "no volatile job accepted" false !dispatch_called)
+    try
+      Eio_main.run @@ fun env ->
+      Eio.Switch.run @@ fun sw ->
+      let dispatch_called = ref false in
+      let ingress =
+        Connector_ingress_lane.create ~sw
+          ~on_failure:(fun _ -> fail "binding failure must not enqueue")
+          ()
+      in
+      let dispatch ~on_text_snapshot:_ ~channel:_ ~channel_user_id:_
+          ~channel_user_name:_ ~channel_workspace_id:_ ~keeper_name:_
+          ~idempotency_key:_ ~metadata:_ ~content:_ =
+        dispatch_called := true;
+        Gate_protocol.Unavailable_result
+      in
+      G.For_testing.submit_event ingress ~dispatch
+        ~clock:(Eio.Stdenv.clock env)
+        (slack_message ~ts:"1710000000.654321");
+      Eio.Fiber.yield ();
+      check bool "no volatile job accepted" false !dispatch_called;
+      Eio.Switch.fail sw Exit
+    with Exit -> ())
 ;;
 
 let () =


### PR DESCRIPTION
## Problem

Main CI run 29428286583 killed a still-progressing, successful quick suite at exactly 2100 seconds. The final test output was OK, but the nested script deadline returned exit 124 and failed CI Gate. A later no-deadline run exposed the real non-termination: two Slack ingress tests left their switch-owned infinite dispatcher alive after assertions completed.

## Change

- use the GitHub job lifecycle as the sole outer CI execution boundary
- remove quick-suite and Build/Test job deadlines plus all per-command deadline knobs
- remove automatic RPC, clean, flaky, transport, and contract retries
- keep heartbeat, disk-pressure observation, process snapshots, and failure diagnostics
- preserve the original command exit code and execute each suite exactly once
- explicitly close the switch owned by the two Slack ingress tests after their assertions

## Verification

- bash syntax checks for all touched shell scripts
- YAML parse for ci.yml
- OCaml parser and ocamlformat checks for touched tests
- shell smoke: legacy 1-second deadline knob does not stop a 2-second command
- shell smoke: failure command executes once and preserves exit 7
- PR CI at exact head is the build and full-suite authority

Local Dune was intentionally not run; CI is the build authority.