### PR TITLE
fix(keeper): persist compaction operation projection

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop_cycle.ml
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.ml
@@ -225,10 +225,10 @@ let run_keeper_cycle_admitted
                ~trigger
            with
            | Error failure -> `Compaction_failed failure
-           | Ok _ -> `Run (obs, true))
+           | Ok success -> `Run (obs, true, success.Keeper_manual_compaction.meta))
         | None ->
           (match failure_judgment with
-          | None -> `Run (obs, false)
+          | None -> `Run (obs, false, meta_after_triage)
           | Some request ->
             (match
                prepare_failure_judgment_turn
@@ -237,20 +237,20 @@ let run_keeper_cycle_admitted
                  ~request
                  obs
              with
-             | `Run observation -> `Run (observation, false)
+             | `Run observation -> `Run (observation, false, meta_after_triage)
              | `Settle outcome -> `Settle outcome))
       in
       match prepared with
       | `Compaction_failed failure -> `Compaction_failed failure
       | `Settle outcome -> `Judgment outcome
-      | `Run (observation, manual_compaction_applied) ->
+      | `Run (observation, manual_compaction_applied, turn_meta) ->
         `Turn
           ( Keeper_unified_turn.run_keeper_cycle
               ~config:ctx.config
-              ~meta:meta_after_triage
+              ~meta:turn_meta
               ~publication_recovery_provider:ctx.publication_recovery_provider
               ~observation
-              ~generation:meta_after_triage.runtime.generation
+              ~generation:turn_meta.runtime.generation
               ~wake
               ~channel:turn_decision.channel
               ?hitl_resolution

--- a/lib/keeper/keeper_manual_compaction.ml
+++ b/lib/keeper/keeper_manual_compaction.ml
@@ -1,6 +1,8 @@
 open Keeper_meta_contract
 type success =
-  { recovery : Keeper_context_runtime.overflow_retry_recovery }
+  { recovery : Keeper_context_runtime.overflow_retry_recovery
+  ; meta : keeper_meta
+  }
 type failure =
   | Unsupported_trigger of Compaction_trigger.t
   | Lifecycle of string * bool * Keeper_context_runtime.lifecycle_dispatch_error
@@ -13,6 +15,55 @@ type failure =
       ; failure_dispatch :
           (unit, Keeper_context_runtime.lifecycle_dispatch_error) result
       }
+  | Metadata_projection of
+      { operation_id : string
+      ; detail : string
+      ; failure_dispatch :
+          (unit, Keeper_context_runtime.lifecycle_dispatch_error) result
+      }
+
+let project_compaction_runtime ~operation_id ~applied_at ~trigger rt =
+  if Option.equal String.equal rt.last_operation_id (Some operation_id)
+  then rt
+  else
+    { rt with
+      count = rt.count + 1
+    ; last_ts = applied_at
+    ; last_operation_id = Some operation_id
+    ; last_check_ts = applied_at
+    ; last_decision =
+        Keeper_compact_policy.compaction_decision_to_string
+          (Keeper_compact_policy.Applied trigger)
+        |> compaction_runtime_decision_of_string
+    }
+;;
+
+let persist_compaction_projection ~config ~meta ~trigger recovery =
+  let operation_id = recovery.Keeper_context_runtime.operation_id in
+  let applied_at = Time_compat.now () in
+  let project meta =
+    map_compaction_rt
+      (project_compaction_runtime ~operation_id ~applied_at ~trigger)
+      meta
+  in
+  match
+    Keeper_meta_store.write_meta_with_merge
+      ~merge:(fun ~latest ~caller:_ -> project latest)
+      config
+      (project meta)
+  with
+  | Error _ as error -> error
+  | Ok () ->
+    (match Keeper_meta_store.read_meta config meta.name with
+     | Ok (Some latest)
+       when Option.equal String.equal
+              latest.runtime.compaction_rt.last_operation_id
+              (Some operation_id) ->
+       Ok latest
+     | Ok (Some _) -> Error "persisted compaction operation identity did not round-trip"
+     | Ok None -> Error "persisted compaction metadata disappeared"
+     | Error detail -> Error detail)
+;;
 let primary_max_context meta =
   let min_context = Keeper_config.min_keeper_context_tokens in
   let resolution = Keeper_context_runtime.resolve_max_context_resolution_of_meta meta in
@@ -124,15 +175,22 @@ let run ~(config : Workspace.config) ~(meta : keeper_meta) ~trigger =
            | Ok
                ( Keeper_runtime_manifest.Appended
                | Keeper_runtime_manifest.Already_present ) ->
-             (match
-                Keeper_context_runtime.dispatch_compaction_completed
-                  ~config
-                  ~keeper_name:meta.name
-                  ~origin:Keeper_registry.Requested_compaction
-              with
-              | Error error ->
-                Error (Lifecycle ("compaction_completed", true, error))
-              | Ok () -> Ok { recovery }))))
+             (match persist_compaction_projection ~config ~meta ~trigger recovery with
+              | Error detail ->
+                let failure_dispatch = dispatch_failed "metadata_projection_failed" in
+                Error
+                  (Metadata_projection
+                     { operation_id = recovery.operation_id; detail; failure_dispatch })
+              | Ok meta ->
+                (match
+                   Keeper_context_runtime.dispatch_compaction_completed
+                     ~config
+                     ~keeper_name:meta.name
+                     ~origin:Keeper_registry.Requested_compaction
+                 with
+                 | Error error ->
+                   Error (Lifecycle ("compaction_completed", true, error))
+                 | Ok () -> Ok { recovery; meta })))))
 ;;
 
 let dispatch_result_to_string = function
@@ -161,4 +219,14 @@ let failure_to_string = function
       operation_id
       detail
       (dispatch_result_to_string failure_dispatch)
+  | Metadata_projection { operation_id; detail; failure_dispatch } ->
+    Printf.sprintf
+      "operation_id=%s checkpoint_applied=true metadata_projection=%s failure_dispatch=%s"
+      operation_id
+      detail
+      (dispatch_result_to_string failure_dispatch)
 ;;
+
+module For_testing = struct
+  let project_compaction_runtime = project_compaction_runtime
+end

--- a/lib/keeper/keeper_manual_compaction.mli
+++ b/lib/keeper/keeper_manual_compaction.mli
@@ -1,5 +1,7 @@
 type success =
-  { recovery : Keeper_context_runtime.overflow_retry_recovery }
+  { recovery : Keeper_context_runtime.overflow_retry_recovery
+  ; meta : Keeper_meta_contract.keeper_meta
+  }
 type failure =
   | Unsupported_trigger of Compaction_trigger.t
   | Lifecycle of string * bool * Keeper_context_runtime.lifecycle_dispatch_error
@@ -12,9 +14,24 @@ type failure =
       ; failure_dispatch :
           (unit, Keeper_context_runtime.lifecycle_dispatch_error) result
       }
+  | Metadata_projection of
+      { operation_id : string
+      ; detail : string
+      ; failure_dispatch :
+          (unit, Keeper_context_runtime.lifecycle_dispatch_error) result
+      }
 val run
   :  config:Workspace.config
   -> meta:Keeper_meta_contract.keeper_meta
   -> trigger:Compaction_trigger.t
   -> (success, failure) result
 val failure_to_string : failure -> string
+
+module For_testing : sig
+  val project_compaction_runtime
+    :  operation_id:string
+    -> applied_at:float
+    -> trigger:Compaction_trigger.t
+    -> Keeper_meta_contract.compaction_runtime
+    -> Keeper_meta_contract.compaction_runtime
+end

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -46,6 +46,7 @@ type compaction_runtime =
   ; last_ts : float
   ; last_before_tokens : int
   ; last_after_tokens : int
+  ; last_operation_id : string option
   ; last_check_ts : float
   ; last_decision : compaction_runtime_decision
   }

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -65,6 +65,7 @@ type compaction_runtime = {
   last_ts : float;
   last_before_tokens : int;
   last_after_tokens : int;
+  last_operation_id : string option;
   last_check_ts : float;
   last_decision : compaction_runtime_decision;
 }

--- a/lib/keeper/keeper_meta_json.ml
+++ b/lib/keeper/keeper_meta_json.ml
@@ -43,6 +43,8 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
     ; "last_compaction_ts", `Float rt.compaction_rt.last_ts
     ; "last_compaction_before_tokens", `Int rt.compaction_rt.last_before_tokens
     ; "last_compaction_after_tokens", `Int rt.compaction_rt.last_after_tokens
+    ; ( "last_compaction_operation_id"
+      , Json_util.string_opt_to_json rt.compaction_rt.last_operation_id )
     ; "proactive_count_total", `Int rt.proactive_rt.count_total
     ; "last_proactive_ts", `Float rt.proactive_rt.last_ts
     ; "proactive_visible_count_total", `Int rt.proactive_rt.visible_count_total
@@ -130,6 +132,7 @@ let fallback_canonical_keeper_meta_key_names =
   ; "last_compaction_ts"
   ; "last_compaction_before_tokens"
   ; "last_compaction_after_tokens"
+  ; "last_compaction_operation_id"
   ; "proactive_count_total"
   ; "last_proactive_ts"
   ; "proactive_visible_count_total"

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -219,6 +219,7 @@ let parse_compaction_runtime (json : Yojson.Safe.t) : compaction_runtime =
   ; last_ts = Safe_ops.json_float ~default:0.0 "last_compaction_ts" json
   ; last_before_tokens = Safe_ops.json_int ~default:0 "last_compaction_before_tokens" json
   ; last_after_tokens = Safe_ops.json_int ~default:0 "last_compaction_after_tokens" json
+  ; last_operation_id = Safe_ops.json_string_opt "last_compaction_operation_id" json
   ; last_check_ts = Safe_ops.json_float ~default:0.0 "last_compaction_check_ts" json
   ; last_decision =
       Safe_ops.json_string ~default:"uninitialized" "last_compaction_decision" json

--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -186,6 +186,8 @@ let handle_keeper_list ctx args : tool_result =
               ("trace_history_count", `Int trace_history_count);
               ("handoff_count_total", `Int trace_history_count);
               ("compaction_count", `Int m.runtime.compaction_rt.count);
+              ( "last_compaction_operation_id"
+              , Json_util.string_opt_to_json m.runtime.compaction_rt.last_operation_id );
               ("last_compaction_saved_tokens", `Int last_compaction_saved_tokens);
               ("compaction_profile", `String m.compaction.profile);
               ("compaction_ratio_gate", `Float compact_ratio_gate);

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -298,6 +298,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
             last_ts = 0.0;
             last_before_tokens = 0;
             last_after_tokens = 0;
+            last_operation_id = None;
             last_check_ts = now_ts;
             last_decision = compaction_runtime_decision_of_string "initialized";
           };

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -558,7 +558,7 @@ let test_applied_compaction_settles_followup_atomically () =
   | _ -> Alcotest.fail "follow-up retry replayed an already-applied compaction"
 ;;
 
-let test_manifest_projection_failure_requeues_compaction () =
+let test_metadata_projection_failure_requeues_compaction () =
   let lease =
     lease_for
       (stimulus
@@ -568,9 +568,9 @@ let test_manifest_projection_failure_requeues_compaction () =
   in
   let meta = cycle_meta () in
   let failure =
-    Masc.Keeper_manual_compaction.Manifest_projection
+    Masc.Keeper_manual_compaction.Metadata_projection
       { operation_id = "compaction-operation"
-      ; detail = "manifest store unavailable"
+      ; detail = "metadata store unavailable"
       ; failure_dispatch = Ok ()
       }
   in
@@ -585,7 +585,7 @@ let test_manifest_projection_failure_requeues_compaction () =
   | Masc.Keeper_registry_event_queue.Requeue
       Masc.Keeper_registry_event_queue.Context_compaction_retry ->
     ()
-  | _ -> Alcotest.fail "manifest projection failure acknowledged compacted source"
+  | _ -> Alcotest.fail "metadata projection failure acknowledged compacted source"
 ;;
 
 let test_cancelled_and_skipped_cycles_requeue () =
@@ -1089,9 +1089,9 @@ let () =
             `Quick
             test_applied_compaction_settles_followup_atomically
         ; Alcotest.test_case
-            "manifest projection failure requeues compaction"
+            "metadata projection failure requeues compaction"
             `Quick
-            test_manifest_projection_failure_requeues_compaction
+            test_metadata_projection_failure_requeues_compaction
         ; Alcotest.test_case
             "cancelled and skipped cycles requeue"
             `Quick

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -420,6 +420,25 @@ let test_configured_compaction_wakes_only_owner_and_preserves_ready_work () =
       | [ { Queue.payload = Configured_compaction_requested _; _ } ] -> ()
       | _ -> fail "ready claim consumed or lost configured compaction")
 
+let test_compaction_runtime_projection_is_operation_idempotent () =
+  let meta = make_meta () in
+  let trigger =
+    Compaction_trigger.Message_count { count = 3; threshold = 2 }
+  in
+  let project =
+    Masc.Keeper_manual_compaction.For_testing.project_compaction_runtime
+      ~operation_id:"compaction:exact-operation"
+      ~applied_at:123.0
+      ~trigger
+  in
+  let first = project meta.runtime.compaction_rt in
+  let replay = project first in
+  check int "operation increments once" (meta.runtime.compaction_rt.count + 1) first.count;
+  check (option string) "operation identity persisted"
+    (Some "compaction:exact-operation")
+    first.last_operation_id;
+  check bool "same operation replay is immutable" true (first = replay)
+
 let only_compaction_manifest config meta =
   let trace_id = Masc.Keeper_id.Trace_id.to_string meta.runtime.trace_id in
   Masc.Keeper_runtime_manifest.path_for_trace
@@ -651,6 +670,8 @@ let () =
         `Quick test_regular_post_turn_does_not_auto_compact;
       test_case "configured compaction wakes only owner and preserves ready work"
         `Quick test_configured_compaction_wakes_only_owner_and_preserves_ready_work;
+      test_case "compaction metadata projection is operation-idempotent"
+        `Quick test_compaction_runtime_projection_is_operation_idempotent;
       test_case "manual compaction serializes the owner lane"
         `Quick test_manual_compaction_serializes_owner_lane;
     ];


### PR DESCRIPTION
## What changed

- persists the exact compaction receipt `operation_id` in Keeper runtime metadata
- projects `count`, `last_ts`, `last_check_ts`, and applied decision immutably once per operation
- makes CAS retries and source-stimulus replays idempotent by comparing the exact operation identity
- reads the committed metadata back before continuing the owner turn, so that turn cannot overwrite the projection with its stale pre-compaction snapshot
- turns metadata write/read failure into a typed requested-compaction failure; the owning source lease is requeued rather than acknowledged
- exposes the operation identity in persisted meta and status JSON

## Why

#24714 made configured thresholds actionable, but the existing requested-compaction runner did not update `compaction_rt.last_ts`. After an Ack, the next completed turn could therefore enqueue another configured request despite the configured cooldown.

This patch binds the cooldown observation to the same durable operation identity already stored in the checkpoint receipt and manifest. It uses no token estimate, global mutable correction, string matching, or fleet-wide state.

## Stack

- #24714 production configured owner-lane wiring
- #24715 owner-only wake / ready-queue isolation proof
- this PR: exact operation projection and cooldown closeout (161 changed lines)

## Validation

- parser check for every changed `.ml` / `.mli`
- `ocamlformat --check` for every changed OCaml file
- `git diff --check`
- focused tests added for operation-idempotent immutable projection and metadata-projection failure requeue
- repo wrapper correctly refused to start while bare Dune processes from other worktrees were active; no bypass was used, CI remains build authority
