### PR TITLE
refactor(memory): hard-cut heuristic bank compaction

### DIFF
--- a/docs/spec/12-memory-systems.md
+++ b/docs/spec/12-memory-systems.md
@@ -58,10 +58,12 @@ OAS reduces active context through its checkpoint/context APIs. MASC may
 request a configured strategy and observe the outcome, but must not rewrite
 the transcript through domain-specific text parsing.
 
-Keeper memory-bank maintenance preserves provenance and reports malformed or
-dropped records. An LLM librarian may classify or summarize candidates when a
-semantic judgment is required; deterministic code may validate schemas,
-enforce storage bounds, and order records by explicit timestamps.
+Keeper memory-bank rewriting is an explicit typed Memory operation. An LLM
+librarian returns the keep, rewrite, or forget decisions; deterministic code
+only validates their schema and provenance and atomically applies that exact
+plan. Storage pressure is observable and may request the operation, but a
+threshold, priority score, or capacity rule cannot decide which memories
+survive.
 
 ## Generation and Handoff
 

--- a/lib/keeper/keeper_agent_run_post_turn_memory.ml
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.ml
@@ -27,9 +27,9 @@ let run
       (Keeper_tool_emission_hook.accumulator_for_keeper
          meta.Keeper_meta_contract.name)
   in
-  (* (1) deterministic write, (2) librarian extraction, (3) compaction run on
-     this keeper's memory lane (RFC-0257), detached from the turn lane. All
-     three touch the keeper's memory bank (no internal lock); the lane's
+  (* (1) deterministic write and (2) LLM librarian extraction run on this
+     keeper's memory lane (RFC-0257), detached from the turn lane. Both may
+     touch the keeper's memory stores; the lane's
      per-keeper mutex serializes them. meta/config are immutable snapshots, so
      using them after the turn returns does not race a later turn.
      See RFC #3646 Section 3: Det/NonDet boundary. *)
@@ -112,40 +112,8 @@ let run
        "delegation_requests failed: %s"
        (Printexc.to_string exn));
 
-  (* Memory bank compaction: dedup + consolidate if over threshold. *)
-  (try
-     let memory_summarizer =
-       Keeper_memory_llm_summary.make
-         ~runtime_id
-         ~keeper_name:meta.name
-         ()
-     in
-     let compaction =
-       Memory.compact_if_needed
-         ?summarizer:memory_summarizer
-         config
-         meta
-     in
-     if compaction.performed
-     then
-       Log.Keeper.info ~keeper_name:meta.name
-         "memory_compacted before=%d after=%d dropped=%d"
-         compaction.before_notes
-         compaction.after_notes
-         compaction.dropped_notes
-   with
-   | Eio.Cancel.Cancelled _ as e -> raise e
-   | exn ->
-     Otel_metric_store.inc_counter
-       Keeper_metrics.(to_string DispatchEventFailures)
-       ~labels:[ "keeper", meta.name; "site", "memory_bank_compaction" ]
-       ();
-     Log.Keeper.warn ~keeper_name:meta.name
-       "runtime=%s compaction failed: %s"
-       (Keeper_meta_contract.runtime_id_of_meta meta)
-       (Printexc.to_string exn))
   in
-  (* RFC-0257: detach (1)-(3) onto the per-keeper memory lane. When the executor
+  (* RFC-0257: detach (1)-(2) onto the per-keeper memory lane. When the executor
      switch is not initialized (tests, early startup) the lane runs them inline,
      so no memory work is lost. *)
   let (_ : Keeper_memory_lane.outcome) =

--- a/lib/keeper/keeper_agent_run_post_turn_memory.mli
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.mli
@@ -1,9 +1,9 @@
 (** Post-turn memory write series for [Keeper_agent_run.run_turn].
 
-    Extracts the four post-turn side-effect stages from Step 8 body
-    (deterministic write, episodic record, compaction, quality-metrics
-    JSONL append) into a single typed boundary so that the orchestrator
-    only sees [run ~config ~meta ...].
+    Extracts deterministic writes, LLM librarian records, and quality metrics
+    from Step 8 behind [run ~config ~meta ...]. It does not rewrite or delete
+    memory-bank rows: semantic consolidation requires an explicit typed LLM
+    Memory operation, never a storage-pressure survival rule.
 
     Each sub-stage is best-effort: non-cancel exceptions are logged and
     counted, never propagated.  [Eio.Cancel.Cancelled] is re-raised. *)


### PR DESCRIPTION
## Outcome

Hard-cuts the only production invocation of heuristic Keeper memory-bank compaction.

- removes automatic threshold/priority/cap-driven bank rewriting from the post-turn path
- keeps durable tool-result writes and the LLM librarian boundary intact
- records the target contract: storage pressure may request a typed LLM Memory operation, but cannot decide what survives

This intentionally does **not** add a placeholder operation or an always-success settlement. Facade removal and the typed LLM operation/result are separate stacked PRs.

## Why

The removed path selected, merged, ranked, and dropped memories using configured byte/note thresholds, kind caps, generation/source bonuses, and priority scores. Those are policy heuristics, not an objective domain contract. They were also invoked after every turn through a best-effort lane and could fail without affecting settlement.

## Verification

- `python3 scripts/check_test_coverage.py` — pass without waiver
- `ocamlc -stop-after parsing` on every changed OCaml file
- `ocamlformat --check` on every changed OCaml file
- `git diff --check`
- focused `lib/masc.cmxa` build was already green before the deletion-only split; current full CI owns the rebased head

Diff: 14 additions / 44 deletions. No new executable branch is introduced; the covered-code additions are replacement contract comments, so the repository coverage checker passes on the actual diff without test deletion or opt-out.