### PR TITLE
feat(keeper): persist completion delivery state

### DIFF
--- a/lib/keeper/keeper_msg_async.ml
+++ b/lib/keeper/keeper_msg_async.ml
@@ -38,6 +38,10 @@ type request_status =
       ; data : Yojson.Safe.t option
       }
 
+type completion_delivery =
+  | Delivery_pending
+  | Delivery_delivered
+
 type entry =
   { request_id : string
   ; request : Keeper_invocation_types.request
@@ -46,6 +50,7 @@ type entry =
   ; status : request_status
   ; submitted_at : float
   ; completed_at : float option
+  ; completion_delivery : completion_delivery option
   }
 
 type access_rejection =
@@ -628,6 +633,12 @@ let is_terminal_status = function
   | Queued | Running | Cancelling _ -> false
 ;;
 
+let completion_delivery_for_status request status current =
+  match is_terminal_status status, Keeper_invocation_types.request_reply_to request with
+  | true, Some _ -> Some (Option.value current ~default:Delivery_pending)
+  | (false, _ | true, None) -> None
+;;
+
 let access_rejection_to_json = function
   | Invalid_base_path { reason } ->
     `Assoc
@@ -813,6 +824,13 @@ let entry_record_to_json (e : entry) : Yojson.Safe.t =
     | None -> fields
   in
   let fields =
+    match e.completion_delivery with
+    | None -> fields
+    | Some Delivery_pending -> fields @ [ "completion_delivery", `String "pending" ]
+    | Some Delivery_delivered ->
+      fields @ [ "completion_delivery", `String "delivered" ]
+  in
+  let fields =
     match e.status with
     | Done { ok; body; data } ->
       fields
@@ -837,6 +855,12 @@ let same_request_identity (left : entry) (right : entry) =
   && String.equal left.base_path right.base_path
   && String.equal left.submitted_by right.submitted_by
   && Float.equal left.submitted_at right.submitted_at
+;;
+
+let same_terminal_result left right =
+  same_request_identity left right
+  && left.status = right.status
+  && left.completed_at = right.completed_at
 ;;
 
 let string_member name json =
@@ -1003,6 +1027,19 @@ let entry_of_record_json ~base_path ~request_id:expected_request_id json :
   let* status_tag = required_string "status" json in
   let* submitted_at = required_float "submitted_at" json in
   let* status, completed_at = decode_status ~tag:status_tag json in
+  let routed_terminal =
+    is_terminal_status status
+    && Option.is_some (Keeper_invocation_types.request_reply_to request)
+  in
+  let* completion_delivery =
+    match routed_terminal, Json_util.assoc_member_opt "completion_delivery" json with
+    | true, None -> Ok (Some Delivery_pending)
+    | true, Some (`String "pending") -> Ok (Some Delivery_pending)
+    | true, Some (`String "delivered") -> Ok (Some Delivery_delivered)
+    | true, Some _ -> Error "terminal completion_delivery must be pending or delivered"
+    | false, None -> Ok None
+    | false, Some _ -> Error "non-routed request must not contain completion_delivery"
+  in
   let status_fields =
     match status with
     | Queued | Running -> []
@@ -1011,6 +1048,9 @@ let entry_of_record_json ~base_path ~request_id:expected_request_id json :
     | Cancelled _ -> [ "completed_at"; "reason"; "cancelled_by" ]
     | Persistence_failed _ -> [ "completed_at"; "attempted_status"; "reason" ]
     | Done _ -> [ "completed_at"; "ok"; "body"; "data" ]
+  in
+  let status_fields =
+    if routed_terminal then "completion_delivery" :: status_fields else status_fields
   in
   let* () = validate_record_fields ~status_fields json in
   Ok
@@ -1021,6 +1061,7 @@ let entry_of_record_json ~base_path ~request_id:expected_request_id json :
     ; status
     ; submitted_at
     ; completed_at
+    ; completion_delivery
     }
 ;;
 
@@ -1161,7 +1202,7 @@ let persist_terminal_from_source ~ops ~(entry : entry) ~source_path =
       | Found terminal_entry when not (is_terminal_status terminal_entry.status) ->
         Error (Integrity_failed Terminal_partition_nonterminal)
       | Found terminal_entry ->
-        if entry_record_to_json terminal_entry = entry_record_to_json entry
+        if same_terminal_result terminal_entry entry
         then (
           (* See lossless namespace protocol: observed cleanup failure is retried. *)
           ignore (remove_duplicate_source_unlocked ~ops ~entry source_path : bool);
@@ -1234,8 +1275,7 @@ let load_record_canonical_located ~base_path ~request_id : located_load_result =
             "conflicting request identities coexist across persistence partitions"
         | Found active_entry
           when is_terminal_status active_entry.status
-               && entry_record_to_json active_entry
-                  <> entry_record_to_json terminal_entry ->
+               && not (same_terminal_result active_entry terminal_entry) ->
           Located_unreadable
             "conflicting terminal request records coexist across persistence partitions"
         | Found _ | Absent -> Located (terminal_entry, Terminal_location)
@@ -1340,7 +1380,7 @@ let terminal_destination_state (entry : entry) =
         then Invalid_terminal_destination Terminal_conflict
         else if
           (not (is_terminal_status entry.status))
-          || entry_record_to_json terminal_entry = entry_record_to_json entry
+          || same_terminal_result terminal_entry entry
         then Cleanup_source
         else
           Invalid_terminal_destination Terminal_conflict
@@ -1776,6 +1816,7 @@ let reserve_new_request ~ops ~base_path ~submitted_by ~request =
                   ; status = Queued
                   ; submitted_at = Time_compat.now ()
                   ; completed_at = None
+                  ; completion_delivery = None
                   }
                 in
                 let key = request_key ~base_path ~submitted_by ~request_id in
@@ -1934,7 +1975,14 @@ let set_status ~ops ?(preserve_terminal = false) key status =
             Some (Time_compat.now ())
           | Queued | Running | Cancelling _ -> None
         in
-        let updated = { entry with status; completed_at } in
+        let updated =
+          { entry with
+            status
+          ; completed_at
+          ; completion_delivery =
+              completion_delivery_for_status entry.request status entry.completion_delivery
+          }
+        in
         (match
            persist_entry ~ops updated
            |> observe_persist_error ~operation:"status_update" updated
@@ -2404,6 +2452,45 @@ let load_canonical_durable_terminal ~base_path ~caller request_id =
                   | Active_location ->
                     Error
                       (Canonical_terminal_noncanonical_location entry.status))))
+;;
+
+let mark_completion_delivered proof =
+  let expected = proof.terminal_entry in
+  with_store_transition_lock
+    ~base_path:expected.base_path
+    ~request_id:expected.request_id
+    (fun () ->
+       with_entry_persistence_transaction expected (fun () ->
+         match
+           terminal_record_path
+             ~base_path:expected.base_path
+             ~request_id:expected.request_id
+         with
+         | None -> Error "Keeper completion terminal path is invalid"
+         | Some path ->
+           (match
+              load_record_at_path
+                ~base_path:expected.base_path
+                ~request_id:expected.request_id
+                path
+            with
+            | Found current when not (same_terminal_result expected current) ->
+              Error "Keeper completion terminal source changed during projection"
+            | Found { completion_delivery = Some Delivery_delivered; _ } ->
+              Ok ()
+            | Found ({ completion_delivery = Some Delivery_pending; _ } as current) ->
+              save_entry_durable
+                ~ops:production_request_ops
+                path
+                { current with completion_delivery = Some Delivery_delivered }
+              |> Result.map_error persist_error_to_string
+            | Found _ -> Error "Keeper completion terminal source is not routed"
+            | Unreadable reason -> Error ("Keeper completion terminal unreadable: " ^ reason)
+            | Absent -> Error "Keeper completion terminal source is absent"
+            | Rejected rejection ->
+              Error
+                ("Keeper completion terminal access rejected: "
+                 ^ (access_rejection_to_json rejection |> Yojson.Safe.to_string)))))
 ;;
 
 (** List only this caller lane; cross-lane rows are intentionally omitted. *)

--- a/lib/keeper/keeper_msg_async.mli
+++ b/lib/keeper/keeper_msg_async.mli
@@ -32,6 +32,10 @@ type request_status =
       ; data : Yojson.Safe.t option
       }
 
+type completion_delivery =
+  | Delivery_pending
+  | Delivery_delivered
+
 type entry =
   { request_id : string
   ; request : Keeper_invocation_types.request
@@ -40,6 +44,7 @@ type entry =
   ; status : request_status
   ; submitted_at : float
   ; completed_at : float option
+  ; completion_delivery : completion_delivery option
   }
 
 (** A request exists, but the supplied access identity does not own it (or
@@ -313,6 +318,9 @@ val load_canonical_durable_terminal :
   caller:string ->
   string ->
   (durable_terminal_proof, canonical_terminal_error) result
+
+val mark_completion_delivered :
+  durable_terminal_proof -> (unit, string) result
 
 (** Inventory persisted non-terminal request records that have no live
     in-memory worker. This is intended for server startup recovery. It does not

--- a/test/test_keeper_unified_turn_event_bus.ml
+++ b/test/test_keeper_unified_turn_event_bus.ml
@@ -358,6 +358,7 @@ let test_keeper_invocation_result_contracts () =
     ; status = Kmsg.Running
     ; submitted_at = 0.0
     ; completed_at = None
+    ; completion_delivery = None
     }
   in
   check bool "running contract is typed" true
@@ -454,6 +455,7 @@ let test_typed_keeper_invocation_wire_contract () =
     ; status = Kmsg.Running
     ; submitted_at = 0.0
     ; completed_at = None
+    ; completion_delivery = None
     }
   in
   check bool "run ref binds exact durable entry" true
@@ -580,6 +582,50 @@ let test_keeper_completion_wake_is_typed_and_idempotent () =
   | _ -> Alcotest.fail "expected one typed Keeper completion stimulus"
 ;;
 
+let test_keeper_completion_delivery_store_transition () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  with_temp_dir "keeper-completion-delivery" @@ fun base_path ->
+  Keeper_event_bus.set (Agent_sdk.Event_bus.create ());
+  let request =
+    durable_request "callee"
+    |> Keeper_invocation_types.with_reply_to ~keeper_name:"caller"
+    |> Result.get_ok
+  in
+  Fun.protect ~finally:Kmsg.For_testing.clear @@ fun () ->
+  let request_id =
+    Ops.For_testing.submit_keeper_msg_with_captured_event_bus
+      ~background_sw:sw
+      ~base_path
+      ~caller:keeper_msg_caller
+      ~request
+      ~f:(fun ?event_bus:_ _ _ ->
+        Tool_result.ok ~tool_name:"completion-delivery" ~start_time:0.0 "finished")
+      ()
+    |> function
+    | Ok { Kmsg.request_id; acceptance = Kmsg.Durably_accepted } -> request_id
+    | Ok _ | Error _ -> Alcotest.fail "Keeper completion fixture was not accepted"
+  in
+  wait_for_done ~clock:env#clock ~base_path request_id;
+  let load () =
+    Kmsg.load_canonical_durable_terminal
+      ~base_path
+      ~caller:keeper_msg_caller
+      request_id
+    |> Result.get_ok
+  in
+  let pending = load () in
+  check bool "routed terminal starts pending" true
+    ((Kmsg.durable_terminal_entry pending).completion_delivery
+     = Some Kmsg.Delivery_pending);
+  Kmsg.mark_completion_delivered pending |> Result.get_ok;
+  check bool "delivery transition is durable" true
+    ((Kmsg.durable_terminal_entry (load ())).completion_delivery
+     = Some Kmsg.Delivery_delivered);
+  check bool "stale pending proof replays idempotently" true
+    (Result.is_ok (Kmsg.mark_completion_delivered pending))
+;;
+
 let test_take_drain_cancel_clears_active_without_spin () =
   let open EB.For_testing in
   let t = EB.create ~keeper_name:"k" ~turn_id:1 () in
@@ -667,6 +713,8 @@ let () =
             test_typed_keeper_invocation_wire_contract
         ; test_case "Keeper completion wake is typed and idempotent" `Quick
             test_keeper_completion_wake_is_typed_and_idempotent
+        ; test_case "Keeper completion delivery store transition" `Quick
+            test_keeper_completion_delivery_store_transition
         ] )
     ; ( "background-drain"
       , [ test_case "continues after first poll" `Quick


### PR DESCRIPTION
## What changed

- Adds typed Delivery_pending and Delivery_delivered state to routed terminal Keeper invocation records.
- Persists the delivery state in the terminal JSON codec.
- Decodes predecessor routed terminal records without the additive field as Pending.
- Rejects completion_delivery on non-routed or non-terminal records.
- Adds an exact, monotonic mark_completion_delivered store transition under the existing per-request store and Keeper persistence locks.
- Treats Pending and Delivered as the same immutable terminal result for duplicate-partition reconciliation, while retaining exact request identity, terminal status, and completed_at checks.

## Why

This is C3a of the durable completion handshake. It establishes the source-side state machine without adding restart scanning, destination acceptance, receipt retirement, or lane waking. Those are isolated in the stacked C3b PR.

## Proof

The focused regression creates a real routed durable terminal request and verifies:
1. terminal publication starts Pending;
2. the source transition durably reloads as Delivered;
3. replaying a stale Pending proof is idempotent and cannot regress Delivered.

## Scope and size

- Base: #24710
- 153 changed lines: 148 additions, 5 deletions
- No projector or restart scanner in this PR
- No full run_ref, artifact, or terminal-result reinjection claim

## Validation

- ocamlformat check: green
- OCaml parser check for all changed ML/MLI files: green
- git diff --check: green
- Focused Dune build remains CI authority because the local wrapper is blocked by unrelated OAS pin drift; no pin bypass was used.