### PR TITLE
fix(gate): fork the ingress lane dispatcher as a daemon fiber

### DIFF
--- a/lib/gate/connector_ingress_lane.ml
+++ b/lib/gate/connector_ingress_lane.ml
@@ -114,7 +114,13 @@ let create ~sw ~on_failure () =
     ; on_failure
     }
   in
-  Eio.Fiber.fork ~sw (fun () -> run_dispatcher t);
+  (* The dispatcher idles on [t.condition] between submissions, so it must be
+     a daemon fiber: a regular [Fiber.fork] would keep the owning switch open
+     forever once all non-daemon fibers finish (the switch waits for the
+     dispatcher, which waits for a broadcast that never comes). In-flight
+     lane jobs are forked as regular fibers below, so the switch still drains
+     accepted work before the daemon is cancelled. *)
+  Eio.Fiber.fork_daemon ~sw (fun () -> run_dispatcher t);
   t
 ;;
 

--- a/lib/gate/connector_ingress_lane.mli
+++ b/lib/gate/connector_ingress_lane.mli
@@ -20,6 +20,9 @@ type t
 val lane_to_string : lane -> string
 val event_id_to_string : event_id -> string
 
+(** Forks the idle dispatcher as a daemon fiber on [sw]: the switch can
+    finish once its non-daemon fibers are done, after draining any in-flight
+    lane jobs (which run as regular fibers). *)
 val create :
   sw:Eio.Switch.t ->
   on_failure:(failure -> unit) ->


### PR DESCRIPTION
## 문제

`Build and Test`의 quick suite가 #24569 이후 매 런 **2100s 타임아웃**(exit 124)으로 red입니다. #24647이 catalog FATAL 계열을 닫은 뒤에도 main run 29428286583이 동일하게 타임아웃 — 현재 main red의 유일한 잔여 원인입니다.

dune `-j1`에서 무출력 hang이라 로그로는 범인이 안 보였고, 로컬 재현 후 stall 시점 `ps` + `sample`로 특정했습니다: `test_server_slack_trigger_policy.exe`의 메인 스레드가 Eio 스케줄러 `poll()`(caml_iomux_poll)에서 ready fiber 없이 영원히 대기.

## 원인

`Connector_ingress_lane.create`(#24568에서 도입)가 무한루프 `run_dispatcher`를 **일반 `Fiber.fork`로 owning switch에 부착**합니다. dispatcher는 submission 사이에 `Eio.Condition`을 idle-wait하므로:

- 테스트처럼 스코프가 닫히는 `Switch.run`에서는 모든 assertion이 통과한 뒤에도 switch가 dispatcher 종료를 영원히 대기 → deterministic hang
- 프로덕션은 switch가 게이트웨이 수명과 같아 미발현

#24569(Slack lane 테스트 추가)가 머지된 시점에 main이 이미 catalog FATAL로 red였기 때문에, 이 hang은 **한 번도 green CI를 본 적이 없습니다** (red-merge 은폐 연쇄의 마지막 층).

## 수정

dispatcher fork를 `Fiber.fork_daemon`으로 전환 (1줄 + 계약 주석/mli doc). daemon fiber는 switch의 비-daemon fiber가 모두 끝나면 취소됩니다. in-flight lane job은 여전히 일반 fiber로 fork되므로 **수락된 작업은 drain된 후에 dispatcher가 취소** — 프로덕션 의미 보존.

`fork_daemon`은 codebase 기존 idiom입니다 (board_dispatch, pulse, server_webrtc_transport, server_ide_lsp_proxy, runtime_observation).

## 검증 (로컬, main 25a1c593b5와 대상 파일 byte-identical 트리)

| 대상 | pre-fix | post-fix |
|---|---|---|
| `test_server_slack_trigger_policy.exe` | exit 124 (hang) | 17/17 PASS, 0.008s |
| `test_discord_gateway_client.exe` | exit 124 (hang) | 4/4 PASS, 0.002s |

- `ocamlformat --check` clean (변경 2파일)
- 기존 두 테스트 바이너리의 완주 자체가 회귀 증명 (hang 재발 시 CI 타임아웃이 잡음)

## 관련

- #24665 (pre-handoff failure isolation)가 같은 파일을 수정 중이나 hunk는 겹치지 않고, 그쪽 신규 테스트들도 이 fix 없이는 동일 hang입니다.
- Refs: #24568, #24569, #24647 (base-red onion의 이전 층)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
