### PR TITLE
fix(auth): cap dashboard development authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Removed the unused permissive `Activity_feed` JSON decoder surface; the live activity API remains encode-only and its filesystem aggregation, ordering, limit, and agent-filter contracts now have dedicated regression coverage (#23960).
 
 ### Fixed
+- Dashboard development credentials now have a Worker authority ceiling even when a legacy Admin role remains persisted for audit. Startup no longer binds `MASC_ADMIN_TOKEN` into the initial-admin credential, fresh shared bearers fail closed without rotation, and REST/MCP command-plane tools consume typed catalog permissions instead of a generic broadcast permission.
 - Auto Judge requests now persist the exact outer-turn causal context without interpreting it, and durable retryable judgments resume on an accepted provider attempt rather than waiting for a server restart.
 - Keeper Gate state now has a BasePath-derived `.masc/gate/` owner. A corrupt optional Always Allowed rule store degrades only exact-rule lookup, while Chat persistence/read failures remain local to Chat and no longer close unrelated Keeper lanes.
 - Prompt overrides now persist in a schema-versioned envelope bound to the SHA256 revision of each prompt body and template-variable contract. Legacy or malformed files and contract-drifted entries fail closed with observable fallback, writes use atomic replacement, and dashboard set/clear mutations commit to memory only after persistence succeeds.

--- a/lib/auth/auth.ml
+++ b/lib/auth/auth.ml
@@ -8,6 +8,36 @@ open Masc_domain
 include Auth_credential_base
 include Auth_credential_token
 
+let dashboard_dev_actor_name = "dashboard"
+
+type credential_authority_state =
+  | Persisted_authority
+  | Legacy_dashboard_admin_capped
+
+type credential_authority = {
+  persisted_role : agent_role;
+  effective_role : agent_role;
+  state : credential_authority_state;
+}
+
+let credential_authority (credential : agent_credential) =
+  match credential.role with
+  | Admin when String.equal credential.agent_name dashboard_dev_actor_name ->
+    { persisted_role = Admin
+    ; effective_role = Worker
+    ; state = Legacy_dashboard_admin_capped
+    }
+  | (Worker | Admin) as persisted_role ->
+    { persisted_role
+    ; effective_role = persisted_role
+    ; state = Persisted_authority
+    }
+;;
+
+let effective_credential_role credential =
+  (credential_authority credential).effective_role
+;;
+
 let ensure_keeper_credential config ~agent_name
   : (string * agent_credential, masc_error) result
   =
@@ -173,7 +203,7 @@ let check_permission config ~agent_name ~token ~permission : (unit, masc_error) 
     match verify_optional_token config ~agent_name ~token with
     | Error e -> Error e
     | Ok (Some cred) ->
-      if has_permission cred.role permission
+      if has_permission (effective_credential_role cred) permission
       then Ok ()
       else
         Error
@@ -233,7 +263,12 @@ let record_strict_unknown_tool_denial ~agent_name ~tool_name =
 (** Check permission for a tool call *)
 let authorize_tool config ~agent_name ~token ~tool_name : (unit, masc_error) result =
   if is_known_or_internal_tool_name tool_name
-  then check_permission config ~agent_name ~token ~permission:CanBroadcast
+  then
+    check_permission
+      config
+      ~agent_name
+      ~token
+      ~permission:(Tool_catalog.required_permission tool_name)
   else (
     let () = record_strict_unknown_tool_denial ~agent_name ~tool_name in
     Error
@@ -267,7 +302,7 @@ let resolve_role_with_auth_config config ~auth_cfg ~agent_name ~token
   else (
     match verify_optional_token config ~agent_name ~token with
     | Error e -> Error e
-    | Ok (Some cred) -> Ok cred.role
+    | Ok (Some cred) -> Ok (effective_credential_role cred)
     | Ok None ->
       if auth_cfg.require_token
       then Error (Auth (Auth_error.Unauthorized
@@ -283,7 +318,8 @@ let resolve_role config ~agent_name ~token : (agent_role, masc_error) result =
 let authorize_tool_for_role ~agent_name ~role ~tool_name : (unit, masc_error) result =
   if is_known_or_internal_tool_name tool_name
   then
-    if has_permission role CanBroadcast
+    let permission = Tool_catalog.required_permission tool_name in
+    if has_permission role permission
     then Ok ()
     else Error (Auth (Auth_error.Forbidden { agent = agent_name; action = tool_name }))
   else (
@@ -367,5 +403,3 @@ let is_auth_enabled config : bool =
   let cfg = load_auth_config config in
   cfg.enabled
 ;;
-
-

--- a/lib/auth/auth.mli
+++ b/lib/auth/auth.mli
@@ -176,6 +176,29 @@ val rotate_shared_tokens_for_agents :
 val find_credential_by_token :
   string -> token:string -> (agent_credential, masc_error) result
 
+(** The dashboard development bearer is a local UI principal, never an
+    operator principal.  Older installations may still persist its credential
+    as [Admin]; authorization must preserve that fact for audit while capping
+    the authority used for permission checks to [Worker]. *)
+type credential_authority_state =
+  | Persisted_authority
+  | Legacy_dashboard_admin_capped
+
+type credential_authority = {
+  persisted_role : agent_role;
+  effective_role : agent_role;
+  state : credential_authority_state;
+}
+
+val dashboard_dev_actor_name : string
+
+val credential_authority : agent_credential -> credential_authority
+(** Project a persisted credential into the role used for authorization.
+    This is the SSOT for the dashboard dev principal's Worker ceiling. *)
+
+val effective_credential_role : agent_credential -> agent_role
+(** Convenience projection of {!credential_authority}. *)
+
 (** Structured description of which credential fields differ between two
     credentials that share the same token hash. *)
 type credential_field_diff =

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -959,7 +959,7 @@ let authorize_token_bound_permission_request ~base_path ~permission request :
                 }))
     | Some token ->
         let* cred = Auth.find_credential_by_token base_path ~token in
-        if Masc_domain.has_permission cred.role permission then
+        if Masc_domain.has_permission (Auth.effective_credential_role cred) permission then
           Ok cred.agent_name
         else
           Error

--- a/lib/server/server_routes_http_dashboard_dev_token.ml
+++ b/lib/server/server_routes_http_dashboard_dev_token.ml
@@ -4,8 +4,6 @@
     missing, and exposes the high-level [ensure_dashboard_dev_token]
     that the dashboard route handlers depend on. *)
 
-let dashboard_dev_actor_name = "dashboard"
-
 type request_error =
   | Non_loopback_request_host of string
   | Token_operation_failed of string
@@ -34,8 +32,19 @@ let dashboard_dev_token_path base_path =
     "dashboard.token"
 
 type dashboard_dev_token_candidate =
-  | Reusable of string
+  | Reusable_worker of string
+  | Reusable_legacy_admin of string
   | Rotate
+
+type dashboard_dev_token_state =
+  | Reused_worker_credential
+  | Reused_legacy_admin_credential
+  | Minted_worker_credential
+
+type ensured_dashboard_dev_token = {
+  token : string;
+  state : dashboard_dev_token_state;
+}
 
 let default_dashboard_dev_token_load path = Fs_compat.load_file path
 let dashboard_dev_token_load = Atomic.make default_dashboard_dev_token_load
@@ -52,25 +61,41 @@ let classify_dashboard_dev_token_candidate ~base_path raw :
   if String.equal trimmed "" then
     Ok Rotate
   else
-    match Auth.resolve_agent_from_token base_path ~token:trimmed with
-    | Ok owner when String.equal owner dashboard_dev_actor_name ->
-        Ok (Reusable trimmed)
-    | Ok _owner ->
-        Ok Rotate
+    match
+      Auth.verify_token base_path
+        ~agent_name:Auth.dashboard_dev_actor_name
+        ~token:trimmed
+    with
+    | Ok credential ->
+      (match Auth.find_credential_by_token base_path ~token:trimmed with
+       | Error error -> Error (Masc_domain.masc_error_to_string error)
+       | Ok owner when not (String.equal owner.agent_name Auth.dashboard_dev_actor_name) ->
+         Error
+           (Printf.sprintf
+              "dashboard dev-token resolved to a different credential owner: %s"
+              owner.agent_name)
+       | Ok _ ->
+         (match (Auth.credential_authority credential).state with
+          | Auth.Persisted_authority -> Ok (Reusable_worker trimmed)
+          | Auth.Legacy_dashboard_admin_capped ->
+            Ok (Reusable_legacy_admin trimmed)))
     | Error (Masc_domain.Auth (Masc_domain.Auth_error.InvalidToken _ | Masc_domain.Auth_error.TokenExpired _ | Masc_domain.Auth_error.Unauthorized _)) ->
         Ok Rotate
     | Error err ->
         Error (Masc_domain.masc_error_to_string err)
 
 let read_reusable_dashboard_dev_token ~base_path path :
-    (string option, string) result =
+    (ensured_dashboard_dev_token option, string) result =
   if not (Fs_compat.file_exists path) then
     Ok None
   else
     try
       match classify_dashboard_dev_token_candidate ~base_path
               ((Atomic.get dashboard_dev_token_load) path) with
-      | Ok (Reusable raw) -> Ok (Some raw)
+      | Ok (Reusable_worker token) ->
+        Ok (Some { token; state = Reused_worker_credential })
+      | Ok (Reusable_legacy_admin token) ->
+        Ok (Some { token; state = Reused_legacy_admin_credential })
       | Ok Rotate -> Ok None
       | Error msg -> Error msg
     with
@@ -90,24 +115,40 @@ let persist_dashboard_dev_token ~base_path raw : (unit, string) result =
   | exn ->
       Error (Printf.sprintf "persist dev-token: %s" (Printexc.to_string exn))
 
-let mint_dashboard_dev_token base_path : (string, string) result =
+let mint_dashboard_dev_token base_path :
+    (ensured_dashboard_dev_token, string) result =
   match
     Auth.create_token base_path
-      ~agent_name:dashboard_dev_actor_name ~role:Masc_domain.Admin
+      ~agent_name:Auth.dashboard_dev_actor_name ~role:Masc_domain.Worker
   with
   | Ok (raw, _cred) ->
       (match persist_dashboard_dev_token ~base_path raw with
-       | Ok () -> Ok raw
+       | Ok () -> Ok { token = raw; state = Minted_worker_credential }
        | Error msg -> Error msg)
   | Error err ->
       Error (Masc_domain.masc_error_to_string err)
 
-let ensure_dashboard_dev_token base_path : (string, string) result =
+let observe_dashboard_dev_token_state = function
+  | Reused_legacy_admin_credential ->
+    Log.Auth.warn
+      "dashboard dev-token reused a legacy persisted Admin credential with Worker effective authority; persisted credential and raw token remain unchanged (migration_state=legacy_admin_capped)"
+  | Reused_worker_credential | Minted_worker_credential -> ()
+;;
+
+let ensure_dashboard_dev_token_with_state base_path :
+    (ensured_dashboard_dev_token, string) result =
   let token_path = dashboard_dev_token_path base_path in
   match read_reusable_dashboard_dev_token ~base_path token_path with
   | Error msg -> Error msg
-  | Ok (Some raw) -> Ok raw
+  | Ok (Some ensured) ->
+    observe_dashboard_dev_token_state ensured.state;
+    Ok ensured
   | Ok None -> mint_dashboard_dev_token base_path
+;;
+
+let ensure_dashboard_dev_token base_path : (string, string) result =
+  ensure_dashboard_dev_token_with_state base_path
+  |> Result.map (fun ensured -> ensured.token)
 
 let ensure_dashboard_dev_token_for_authority ~request_authority ~base_path =
   let host = Server_request_authority.host request_authority in

--- a/lib/server/server_routes_http_dashboard_dev_token.mli
+++ b/lib/server/server_routes_http_dashboard_dev_token.mli
@@ -4,11 +4,28 @@ type request_error =
   | Non_loopback_request_host of string
   | Token_operation_failed of string
 
+type dashboard_dev_token_state =
+  | Reused_worker_credential
+  | Reused_legacy_admin_credential
+  | Minted_worker_credential
+
+type ensured_dashboard_dev_token = {
+  token : string;
+  state : dashboard_dev_token_state;
+}
+
 val dashboard_dev_token_path : string -> string
 val request_error_status : request_error -> Httpun.Status.t
 val request_error_code : request_error -> string
 val request_error_to_string : request_error -> string
 val ensure_dashboard_dev_token : string -> (string, string) result
+
+val ensure_dashboard_dev_token_with_state :
+  string -> (ensured_dashboard_dev_token, string) result
+(** Return the bearer together with its typed migration state.  A legacy
+    persisted Admin credential is reused without rewriting either the raw
+    token file or credential file; {!Auth.credential_authority} caps its
+    effective authority to Worker. *)
 
 val set_dashboard_dev_token_load_for_testing : (string -> string) -> unit
 (** Replace the dev-token file reader for focused failure-path tests. *)

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -1236,7 +1236,7 @@ let add_routes ~sw ~clock router =
              respond_json_value_with_cors ~status:`Bad_request request reqd (operator_error_json message)
        ) request reqd)
   |> Http.Router.post "/api/v1/operator/action" (fun request reqd ->
-       with_tool_actor_auth ~tool_name:"masc_operator_action" (fun state authorized_actor req reqd ->
+       with_token_permission_auth ~permission:Masc_domain.CanAdmin (fun state authorized_actor req reqd ->
          Http.Request.read_body_async reqd (fun body_str ->
            try
              let args = Yojson.Safe.from_string body_str in
@@ -1258,7 +1258,7 @@ let add_routes ~sw ~clock router =
          )
        ) request reqd)
   |> Http.Router.post "/api/v1/operator/confirm" (fun request reqd ->
-       with_tool_actor_auth ~tool_name:"masc_operator_confirm" (fun state authorized_actor req reqd ->
+       with_token_permission_auth ~permission:Masc_domain.CanAdmin (fun state authorized_actor req reqd ->
          Http.Request.read_body_async reqd (fun body_str ->
            try
              let args = Yojson.Safe.from_string body_str in

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -619,9 +619,7 @@ let initialize_owner_state_blocking
   bootstrap_server_state_blocking state;
   startup_recover_keeper_lifecycle_transactions state;
   startup_migrate_retired_keeper_meta_keys state;
-  sync_admin_token_env state;
-  sync_internal_keeper_token_env state;
-  sync_bootable_keeper_credentials state;
+  sync_startup_credentials state;
   let prepared_keeper_persistence =
     match
       Server_bootstrap_loops.prepare_keeper_persistence

--- a/lib/server/server_runtime_bootstrap.mli
+++ b/lib/server/server_runtime_bootstrap.mli
@@ -93,6 +93,7 @@ val warm_tool_registry_from_telemetry : Mcp_server.server_state -> unit
 val startup_prune_jsonl : Mcp_server.server_state -> unit
 val startup_migrate_keeper_histories : Mcp_server.server_state -> unit
 val sync_bootable_keeper_credentials : Mcp_server.server_state -> unit
+val sync_startup_credentials : Mcp_server.server_state -> unit
 
 type lazy_startup_execution =
   | Parallel

--- a/lib/server/server_runtime_startup_credentials.ml
+++ b/lib/server/server_runtime_startup_credentials.ml
@@ -1,56 +1,9 @@
 (* Server_runtime_startup_credentials — credential sync at server startup.
    Extracted from server_runtime_bootstrap.ml during godfile decomposition.
-   Contains admin/internal token sync, bootable keeper credential sync,
-   and shared token rotation. *)
-
-let sync_admin_token_env (state : Mcp_server.server_state) =
-  let base_path = (Mcp_server.workspace_config state).base_path in
-  let admin_agent_name =
-    match Auth.read_initial_admin base_path with
-    | Some name ->
-        let trimmed = String.trim name in
-        if trimmed <> "" then trimmed else "admin"
-    | None -> "admin"
-  in
-  match Env_config_core.admin_token_opt () with
-  | Some raw_token ->
-      let already_synced =
-        match Auth.verify_token base_path ~agent_name:admin_agent_name ~token:raw_token with
-        | Ok cred -> cred.role = Masc_domain.Admin
-        | Error _ -> false
-      in
-      (match
-         Auth.save_raw_token_credential base_path
-           ~agent_name:admin_agent_name ~role:Masc_domain.Admin ~raw_token
-       with
-       | Ok _ ->
-           if already_synced then
-             Log.Server.info
-               "startup admin token verified for %s via %s"
-               admin_agent_name Env_config_core.admin_token_env_key
-           else
-             Log.Server.warn
-               "startup admin token drift repaired for %s via %s"
-               admin_agent_name Env_config_core.admin_token_env_key
-       | Error err ->
-           Log.Server.error
-             "startup admin token sync failed for %s: %s"
-             admin_agent_name
-             (Masc_domain.masc_error_to_string err))
-  | None ->
-      (match
-         Auth.create_token base_path ~agent_name:admin_agent_name ~role:Masc_domain.Admin
-       with
-       | Ok (raw_token, _cred) ->
-           Unix.putenv Env_config_core.admin_token_env_key raw_token;
-           Log.Server.warn
-             "startup minted %s for %s because env was unset"
-             Env_config_core.admin_token_env_key admin_agent_name
-       | Error err ->
-          Log.Server.error
-             "startup admin token mint failed for %s: %s"
-             admin_agent_name
-             (Masc_domain.masc_error_to_string err))
+   Contains internal token sync, bootable keeper credential sync, and shared
+   token rotation.  Admin/workspace recovery remains owned by explicit auth
+   operations; startup must not bind MASC_ADMIN_TOKEN into an agent
+   credential. *)
 
 let sync_internal_keeper_token_env (state : Mcp_server.server_state) =
   let base_path = (Mcp_server.workspace_config state).base_path in
@@ -183,3 +136,7 @@ let sync_bootable_keeper_credentials (state : Mcp_server.server_state) =
                 (token_hash_prefix=%s): %s"
                agent_name outcome.token_hash_prefix detail))
     rotation_outcomes
+
+let sync_startup_credentials state =
+  sync_internal_keeper_token_env state;
+  sync_bootable_keeper_credentials state

--- a/lib/server/server_runtime_startup_credentials.mli
+++ b/lib/server/server_runtime_startup_credentials.mli
@@ -1,4 +1,8 @@
-val sync_admin_token_env : Mcp_server.server_state -> unit
 val sync_internal_keeper_token_env : Mcp_server.server_state -> unit
 val sync_bootable_keeper_credentials :
   Mcp_server.server_state -> unit
+
+val sync_startup_credentials : Mcp_server.server_state -> unit
+(** Synchronize the credentials owned by server startup: the internal keeper
+    transport token and bootable keeper credentials. Operator/admin authority
+    is deliberately outside this boundary. *)

--- a/lib/tool/tool_catalog.ml
+++ b/lib/tool/tool_catalog.ml
@@ -48,6 +48,7 @@ type metadata = {
   visibility : visibility;
   lifecycle : lifecycle;
   implementation_status : implementation_status;
+  required_permission : Masc_domain.permission;
   canonical_name : string option;
   replacement : string option;
   reason : string option;
@@ -121,6 +122,7 @@ let default_metadata =
     visibility = Default;
     lifecycle = Active;
     implementation_status = Real;
+    required_permission = Masc_domain.CanBroadcast;
     canonical_name = None;
     replacement = None;
     reason = None;
@@ -145,6 +147,7 @@ let hidden_active ?canonical_name ?replacement ?(allow_direct_call_when_hidden =
     visibility = Hidden;
     lifecycle = Active;
     implementation_status;
+    required_permission = Masc_domain.CanBroadcast;
     canonical_name;
     replacement;
     reason = Some reason;
@@ -180,6 +183,10 @@ let with_execution_policy
     meta
 ;;
 
+let with_required_permission required_permission meta =
+  { meta with required_permission }
+;;
+
 let readonly_tool =
   with_execution_policy
     ~readonly:true
@@ -203,7 +210,7 @@ let broadcast_tool = masc_workspace_tool
 let add_task_tool = masc_workspace_tool
 let claim_task_tool = masc_workspace_tool
 let complete_task_tool = masc_workspace_tool
-let reset_tool = mutating_tool
+let admin_tool = with_required_permission Masc_domain.CanAdmin mutating_tool
 
 let hidden_runtime_tool reason meta =
   {
@@ -248,7 +255,10 @@ let explicit_metadata : (string * metadata) list =
        masc_admin_reset, masc_gc_force, masc_workspace_delete, masc_force_unbind,
        masc_execute) removed — no dispatch path, no schema, no caller. *)
     ( "masc_operator_action",
-      hidden_active "Internal operator-action route; hidden from the public tool surface." );
+      with_required_permission
+        Masc_domain.CanAdmin
+        (hidden_active
+           "Internal operator-action route; hidden from the public tool surface.") );
     ( "masc_operator_chat_recovery_resolve",
       with_execution_policy
         ~readonly:false
@@ -257,10 +267,12 @@ let explicit_metadata : (string * metadata) list =
            ~allow_direct_call_when_hidden:false
            "Operator-profile-only exact recovery of one crash-ambiguous Keeper chat receipt.") );
     ( "masc_set_param",
-      hidden_active
-        "Internal HTTP runtime-parameter mutation route; hidden from the public tool surface." );
+      with_required_permission
+        Masc_domain.CanAdmin
+        (hidden_active
+           "Internal HTTP runtime-parameter mutation route; hidden from the public tool surface.") );
     (* Catalog-owned permissions for split/lazily registered tool modules. *)
-    ("masc_reset", reset_tool);
+    ("masc_reset", admin_tool);
     ("masc_start", with_semantic_flags ~mcp_context_required:true broadcast_tool);
     ("masc_task_history", read_state_tool);
     ("masc_add_task", add_task_tool);
@@ -284,11 +296,11 @@ let explicit_metadata : (string * metadata) list =
     ("masc_keeper_persona_audit", read_state_tool);
     ("masc_keeper_sandbox_status", read_state_tool);
     ("masc_keeper_waiting_inventory", read_state_tool);
-    ("masc_keeper_up", broadcast_tool);
-    ("masc_keeper_down", mutating_tool);
+    ("masc_keeper_up", admin_tool);
+    ("masc_keeper_down", admin_tool);
     ("masc_keeper_compact", broadcast_tool);
-    ("masc_keeper_clear", mutating_tool);
-    ("masc_keeper_reset", mutating_tool);
+    ("masc_keeper_clear", admin_tool);
+    ("masc_keeper_reset", admin_tool);
     ("masc_plan_get_task", read_state_tool);
     ("masc_plan_clear_task", broadcast_tool);
     ("masc_note_add", broadcast_tool);
@@ -302,7 +314,7 @@ let explicit_metadata : (string * metadata) list =
     ("masc_get_metrics", read_state_tool);
     ("masc_operator_snapshot", read_state_tool);
     ("masc_operator_digest", read_state_tool);
-    ("masc_operator_confirm", broadcast_tool);
+    ("masc_operator_confirm", admin_tool);
     ("masc_persona_list", read_state_tool);
     ("masc_persona_create", broadcast_tool);
     ("masc_persona_update", broadcast_tool);
@@ -324,7 +336,7 @@ let explicit_metadata : (string * metadata) list =
     ("masc_board_sub_board_create", broadcast_tool);
     ("masc_board_sub_board_update", broadcast_tool);
     ("masc_board_sub_board_delete", broadcast_tool);
-    ("masc_board_cleanup", mutating_tool);
+    ("masc_board_cleanup", admin_tool);
     ("masc_board_delete", mutating_tool);
     ("masc_tool_stats", read_state_tool);
     ("masc_pause", broadcast_tool);
@@ -434,6 +446,10 @@ let metadata name =
       ; reason = Some "Not on the external MCP discovery surface."
       }
 
+let required_permission name =
+  (metadata name).required_permission
+;;
+
 let implementation_status name =
   let meta = metadata name in
   meta.implementation_status
@@ -477,6 +493,8 @@ let metadata_to_fields name =
       ("visibility", `String (visibility_to_string meta.visibility));
       ("lifecycle", `String (lifecycle_to_string meta.lifecycle));
       ("implementationStatus", `String (implementation_status_to_string meta.implementation_status));
+      ( "requiredPermission",
+        `String (Masc_domain.permission_to_string meta.required_permission) );
     ]
   in
   let with_canonical =
@@ -507,6 +525,8 @@ let public_contract_fields name =
     [
       ( "implementationStatus",
         `String (implementation_status_to_string meta.implementation_status) );
+      ( "requiredPermission",
+        `String (Masc_domain.permission_to_string meta.required_permission) );
     ]
   in
   let with_mcp_context_required =

--- a/lib/tool/tool_catalog.mli
+++ b/lib/tool/tool_catalog.mli
@@ -20,6 +20,7 @@ type metadata = {
   visibility : visibility;
   lifecycle : lifecycle;
   implementation_status : implementation_status;
+  required_permission : Masc_domain.permission;
   canonical_name : string option;
   replacement : string option;
   reason : string option;
@@ -69,6 +70,10 @@ val is_public_mcp : string -> bool
 (** {1 Metadata lookup} *)
 
 val metadata : string -> metadata
+val required_permission : string -> Masc_domain.permission
+(** Typed authorization requirement for a tool. Unknown tools inherit the
+    catalog default, [CanBroadcast]; callers must still reject unknown tool
+    names before consulting this value. *)
 val execution_policy_of_metadata :
   tool_name:string -> metadata -> (execution_policy, execution_policy_error) result
 val execution_policy_error_to_string : execution_policy_error -> string

--- a/lib/tool_surface/tool_spec.ml
+++ b/lib/tool_surface/tool_spec.ml
@@ -101,10 +101,12 @@ let register (spec : t) =
     ~schemas:[ to_tool_schema spec ] ~tag:spec.module_tag;
   (* 2. Catalog metadata. Registration preserves the typed declaration;
      product-name membership must not override visibility. *)
+  let required_permission = Tool_catalog.required_permission spec.name in
   Tool_catalog.register_metadata spec.name
     { Tool_catalog.visibility = spec.visibility;
       lifecycle = Tool_catalog.Active;
       implementation_status = spec.implementation_status;
+      required_permission;
       canonical_name = spec.canonical_name;
       replacement = spec.replacement;
       reason = spec.reason;

--- a/lib/tool_surface/tool_spec.mli
+++ b/lib/tool_surface/tool_spec.mli
@@ -67,9 +67,13 @@ val create :
   ?title:string ->
   unit -> t
 (** Build a tool spec. The first five arguments are required (compile error
-    if omitted). All optional arguments default to fail-closed values:
-    booleans to [false], options to [None], visibility to [Default],
-    implementation_status to [Real]. *)
+    if omitted). [register] reads the typed catalog permission at registration
+    time, whose default is [CanBroadcast]. This keeps the catalog as the sole
+    permission source even when a split tool module was constructed before
+    catalog metadata was installed. Other
+    optional arguments default to fail-closed values: booleans to [false],
+    options to [None], visibility to [Default], implementation_status to
+    [Real]. *)
 
 (** {1 Registration} *)
 

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -1080,6 +1080,45 @@ let test_authorize_tool_v2_unknown_keeper_prefix_strict_denied () =
   | Error (Masc_domain.Auth (Masc_domain.Auth_error.Forbidden _)) -> ()
   | Error e -> fail (Printf.sprintf "wrong error: %s" (Masc_domain.masc_error_to_string e))
 
+let test_authorize_tool_v2_enforces_catalog_admin_permissions () =
+  [ "masc_operator_action"
+  ; "masc_operator_confirm"
+  ; "masc_reset"
+  ; "masc_set_param"
+  ; "masc_keeper_up"
+  ; "masc_keeper_down"
+  ; "masc_keeper_reset"
+  ; "masc_keeper_clear"
+  ; "masc_board_cleanup"
+  ]
+  |> List.iter (fun tool_name ->
+    (match
+       Auth.authorize_tool_for_role
+         ~agent_name:"dashboard"
+         ~role:Masc_domain.Worker
+         ~tool_name
+     with
+     | Error (Masc_domain.Auth (Masc_domain.Auth_error.Forbidden _)) -> ()
+     | Error error ->
+       failf
+         "%s returned the wrong Worker denial: %s"
+         tool_name
+         (Masc_domain.masc_error_to_string error)
+     | Ok () -> failf "%s admitted Worker authority" tool_name);
+    match
+      Auth.authorize_tool_for_role
+        ~agent_name:"operator"
+        ~role:Masc_domain.Admin
+        ~tool_name
+    with
+    | Ok () -> ()
+    | Error error ->
+      failf
+        "%s rejected Admin authority: %s"
+        tool_name
+        (Masc_domain.masc_error_to_string error))
+;;
+
 let test_tool_auth_strict_env_cannot_disable_fail_closed () =
   let result =
     with_env "MASC_TOOL_AUTH_STRICT" "0" (fun () ->
@@ -1208,6 +1247,8 @@ let () =
         `Quick test_authorize_tool_v2_unknown_internal_worker_allowed;
       test_case "strict v2 fake keeper prefix denied"
         `Quick test_authorize_tool_v2_unknown_keeper_prefix_strict_denied;
+      test_case "strict v2 catalog admin permissions"
+        `Quick test_authorize_tool_v2_enforces_catalog_admin_permissions;
       test_case "tool auth strict env cannot disable fail-closed"
         `Quick test_tool_auth_strict_env_cannot_disable_fail_closed;
     ];

--- a/test/test_board_rest_routes.ml
+++ b/test/test_board_rest_routes.ml
@@ -222,14 +222,26 @@ let test_dashboard_dev_token_can_vote_as_credential_owner () =
     with
     | Error message -> fail message
     | Ok token ->
+      (match
+         Server_auth.authorize_token_bound_permission_request
+           ~base_path
+           ~permission:Masc_domain.CanVote
+           (reaction_auth_request ~token ())
+       with
+       | Ok actor -> check string "dashboard credential owner" "dashboard" actor
+       | Error error -> fail (Masc_domain.masc_error_to_string error));
       match
         Server_auth.authorize_token_bound_permission_request
           ~base_path
-          ~permission:Masc_domain.CanVote
+          ~permission:Masc_domain.CanAdmin
           (reaction_auth_request ~token ())
       with
-      | Ok actor -> check string "dashboard credential owner" "dashboard" actor
-      | Error error -> fail (Masc_domain.masc_error_to_string error))
+      | Error (Masc_domain.Auth (Masc_domain.Auth_error.Forbidden _)) -> ()
+      | Error error ->
+        failf
+          "dashboard dev-token admin authority returned unexpected error: %s"
+          (Masc_domain.masc_error_to_string error)
+      | Ok actor -> failf "dashboard dev-token retained admin authority as %s" actor)
 
 let () =
   run

--- a/test/test_dashboard_dev_token_host_gate.ml
+++ b/test/test_dashboard_dev_token_host_gate.ml
@@ -1,5 +1,7 @@
 open Alcotest
 
+let () = Mirage_crypto_rng_unix.use_default ()
+
 module Dev_token = Server_routes_http_dashboard_dev_token
 
 let authority_exn raw =
@@ -83,9 +85,143 @@ let test_read_failure_does_not_mint_admin_credential () =
               check
                 bool
                 "read failure creates no credential store"
-                false
-                (Sys.file_exists (Common.agents_dir_from_base_path ~base_path))
+            false
+            (Sys.file_exists (Common.agents_dir_from_base_path ~base_path))
           | Ok _ -> fail "unreadable dev-token path must fail closed"))
+;;
+
+let with_temporary_base prefix f =
+  let base_path = Filename.temp_file prefix ".workspace" in
+  Sys.remove base_path;
+  Fun.protect
+    ~finally:(fun () -> Fs_compat.remove_tree base_path)
+    (fun () -> f base_path)
+;;
+
+let test_new_dashboard_dev_token_is_worker () =
+  with_temporary_base "masc-dev-token-worker-" (fun base_path ->
+    match Dev_token.ensure_dashboard_dev_token_with_state base_path with
+    | Error message -> fail message
+    | Ok ensured ->
+      check bool
+        "new token reports Worker mint"
+        true
+        (ensured.state = Dev_token.Minted_worker_credential);
+      (match Auth.find_credential_by_token base_path ~token:ensured.token with
+       | Error error -> fail (Masc_domain.masc_error_to_string error)
+       | Ok credential ->
+         check string
+           "credential owner"
+           Auth.dashboard_dev_actor_name
+           credential.agent_name;
+         check bool "persisted role is Worker" true (credential.role = Masc_domain.Worker);
+         check bool
+           "effective role is Worker"
+           true
+           (Auth.effective_credential_role credential = Masc_domain.Worker)))
+;;
+
+let test_legacy_dashboard_admin_is_reused_with_worker_authority () =
+  with_temporary_base "masc-dev-token-legacy-admin-" (fun base_path ->
+    ignore
+      (Auth.enable_auth
+         base_path
+         ~require_token:true
+         ~agent_name:"operator");
+    match
+      Auth.create_token base_path
+        ~agent_name:Auth.dashboard_dev_actor_name
+        ~role:Masc_domain.Admin
+    with
+    | Error error -> fail (Masc_domain.masc_error_to_string error)
+    | Ok (legacy_token, _credential) ->
+      Auth.save_private_text_file
+        (Dev_token.dashboard_dev_token_path base_path)
+        legacy_token;
+      (match Dev_token.ensure_dashboard_dev_token_with_state base_path with
+       | Error message -> fail message
+       | Ok ensured ->
+         check string "legacy raw token is not rotated" legacy_token ensured.token;
+         check bool
+           "legacy migration state is explicit"
+           true
+           (ensured.state = Dev_token.Reused_legacy_admin_credential);
+         (match
+            Auth.verify_token base_path
+              ~agent_name:Auth.dashboard_dev_actor_name
+              ~token:legacy_token
+          with
+          | Error error -> fail (Masc_domain.masc_error_to_string error)
+          | Ok credential ->
+            let authority = Auth.credential_authority credential in
+            check bool
+              "persisted role remains Admin for audit"
+              true
+              (authority.persisted_role = Masc_domain.Admin);
+            check bool
+              "effective role is capped to Worker"
+              true
+              (authority.effective_role = Masc_domain.Worker);
+            check bool
+              "authority state records legacy cap"
+              true
+              (authority.state = Auth.Legacy_dashboard_admin_capped));
+         [ Masc_domain.CanAdmin; Masc_domain.CanInit; Masc_domain.CanReset ]
+         |> List.iter (fun permission ->
+           match
+             Auth.check_permission base_path
+               ~agent_name:Auth.dashboard_dev_actor_name
+               ~token:(Some legacy_token)
+               ~permission
+           with
+           | Error (Masc_domain.Auth (Masc_domain.Auth_error.Forbidden _)) -> ()
+           | Error error ->
+             failf
+               "legacy dashboard Admin returned the wrong denial for %s: %s"
+               (Masc_domain.permission_to_string permission)
+               (Masc_domain.masc_error_to_string error)
+           | Ok () ->
+             failf
+               "legacy dashboard Admin retained %s authority"
+               (Masc_domain.permission_to_string permission)))
+  )
+;;
+
+let test_shared_dashboard_token_fails_closed_without_rotation () =
+  with_temporary_base "masc-dev-token-shared-" (fun base_path ->
+    ignore
+      (Auth.enable_auth
+         base_path
+         ~require_token:true
+         ~agent_name:"operator");
+    match
+      Auth.create_token base_path
+        ~agent_name:Auth.dashboard_dev_actor_name
+        ~role:Masc_domain.Admin
+    with
+    | Error error -> fail (Masc_domain.masc_error_to_string error)
+    | Ok (shared_token, dashboard_before) ->
+      (match
+         Auth.save_raw_token_credential base_path
+           ~agent_name:"admin"
+           ~role:Masc_domain.Admin
+           ~raw_token:shared_token
+       with
+       | Error error -> fail (Masc_domain.masc_error_to_string error)
+       | Ok _ -> ());
+      Auth.save_private_text_file
+        (Dev_token.dashboard_dev_token_path base_path)
+        shared_token;
+      (match Dev_token.ensure_dashboard_dev_token_with_state base_path with
+       | Ok _ -> fail "fresh shared dashboard token must fail closed"
+       | Error _ -> ());
+      match Auth.load_credential base_path Auth.dashboard_dev_actor_name with
+      | None -> fail "dashboard credential disappeared after shared-token rejection"
+      | Some dashboard_after ->
+        check string
+          "dashboard credential was not rotated"
+          dashboard_before.token
+          dashboard_after.token)
 ;;
 
 let () =
@@ -101,6 +237,18 @@ let () =
             "read failure does not mint admin credential"
             `Quick
             test_read_failure_does_not_mint_admin_credential
+        ; test_case
+            "new dashboard dev-token is Worker"
+            `Quick
+            test_new_dashboard_dev_token_is_worker
+        ; test_case
+            "legacy dashboard Admin is capped without rotation"
+            `Quick
+            test_legacy_dashboard_admin_is_reused_with_worker_authority
+        ; test_case
+            "fresh shared dashboard token fails closed without rotation"
+            `Quick
+            test_shared_dashboard_token_fails_closed_without_rotation
         ] )
     ]
 ;;

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -454,9 +454,23 @@ let main_eio_auth_header = "Authorization: Bearer " ^ main_eio_test_admin_token
 
 let main_eio_env_overrides overrides =
   merge_env_overrides
-    (("MASC_ADMIN_TOKEN", main_eio_test_admin_token)
-     :: ("MASC_INTERNAL_MCP_TOKEN", "")
+    (("MASC_INTERNAL_MCP_TOKEN", "")
      :: overrides)
+
+let seed_main_eio_admin base_path =
+  ignore
+    (Auth.enable_auth base_path ~require_token:true
+       ~agent_name:Auth.dashboard_dev_actor_name);
+  match
+    Auth.save_raw_token_credential base_path
+      ~agent_name:Auth.dashboard_dev_actor_name
+      ~role:Masc_domain.Admin
+      ~raw_token:main_eio_test_admin_token
+  with
+  | Ok _ -> ()
+  | Error error ->
+      Alcotest.failf "failed to seed main_eio admin credential: %s"
+        (Masc_domain.masc_error_to_string error)
 
 let find_main_eio_exe () =
   let root = project_root () in
@@ -3945,6 +3959,7 @@ let test_main_eio_fresh_bootstrap_and_mcp_handshake () =
       with_env "MASC_PERSONAS_DIR" None @@ fun () ->
       with_cwd (project_root ()) @@ fun () ->
       Server_runtime_bootstrap.bootstrap_base_path_config_root ~base_path:dir;
+      seed_main_eio_admin dir;
       let expected_config = Filename.concat dir ".masc/config" in
       let env =
         main_eio_env_overrides
@@ -4225,6 +4240,43 @@ let test_sync_bootable_keeper_credentials_mints_keeper_alias_token () =
       | Error err ->
           Alcotest.failf "bootable keeper token should verify exactly: %s"
             (Masc_domain.masc_error_to_string err))
+
+let test_startup_credential_sync_does_not_bind_admin_env () =
+  with_temp_dir "startup-admin-env-authority" (fun dir ->
+      with_env "OAS_MODEL_CATALOG" None @@ fun () ->
+      with_env "MASC_CONFIG_DIR" None @@ fun () ->
+      with_env "MASC_PERSONAS_DIR" None @@ fun () ->
+      with_env "MASC_INTERNAL_MCP_TOKEN" None @@ fun () ->
+      with_env "MASC_ADMIN_TOKEN" (Some "untrusted-startup-admin-token") @@ fun () ->
+      with_cwd (project_root ()) @@ fun () ->
+      Server_runtime_bootstrap.bootstrap_base_path_config_root ~base_path:dir;
+      seed_main_eio_admin dir;
+      let before =
+        match Auth.load_credential dir Auth.dashboard_dev_actor_name with
+        | Some credential -> credential
+        | None -> Alcotest.fail "missing seeded dashboard credential"
+      in
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      let clock, mono_clock, net, _domain_mgr, proc_mgr, fs =
+        Server_runtime_bootstrap.init_runtime_context env
+      in
+      Eio.Switch.run @@ fun sw ->
+      let state =
+        Server_runtime_bootstrap.create_server_state ~sw ~base_path:dir ~clock
+          ~mono_clock ~net ~proc_mgr ~fs ()
+      in
+      Server_runtime_bootstrap.bootstrap_server_state_blocking state;
+      Server_runtime_bootstrap.sync_startup_credentials state;
+      let after =
+        match Auth.load_credential dir Auth.dashboard_dev_actor_name with
+        | Some credential -> credential
+        | None -> Alcotest.fail "startup removed the dashboard credential"
+      in
+      Alcotest.(check string) "startup preserves dashboard token hash"
+        before.token after.token;
+      Alcotest.(check bool) "startup preserves persisted dashboard role" true
+        (before.role = after.role))
 
 let test_sync_bootable_keeper_credentials_rotates_shared_keeper_tokens () =
   with_temp_dir "startup-keeper-credential-rotate" (fun dir ->
@@ -4860,6 +4912,9 @@ let () =
           Alcotest.test_case
             "startup sync mints bootable keeper credentials"
             `Quick test_sync_bootable_keeper_credentials_mints_keeper_alias_token;
+          Alcotest.test_case
+            "startup credential sync does not bind MASC_ADMIN_TOKEN"
+            `Quick test_startup_credential_sync_does_not_bind_admin_env;
           Alcotest.test_case
             "startup sync rotates shared bootable keeper tokens"
             `Quick

--- a/test/test_tool_spec.ml
+++ b/test/test_tool_spec.ml
@@ -61,6 +61,33 @@ let () =
             check bool "reason present" true (Option.is_some spec.reason);
             check bool "title present" true (Option.is_some spec.title));
         ] );
+      ( "required permission catalog",
+        [
+          test_case "unknown tool defaults to worker broadcast" `Quick (fun () ->
+            check bool "CanBroadcast" true
+              (Tool_catalog.required_permission "__test_unknown_permission"
+               = Masc_domain.CanBroadcast));
+          test_case "admin tools are typed catalog entries" `Quick (fun () ->
+            [ "masc_operator_action"
+            ; "masc_operator_confirm"
+            ; "masc_reset"
+            ; "masc_set_param"
+            ; "masc_keeper_up"
+            ; "masc_keeper_down"
+            ; "masc_keeper_reset"
+            ; "masc_keeper_clear"
+            ; "masc_board_cleanup"
+            ]
+            |> List.iter (fun name ->
+              check bool name true
+                (Tool_catalog.required_permission name = Masc_domain.CanAdmin)));
+          test_case "permission is published as catalog metadata" `Quick (fun () ->
+            let fields = Tool_catalog.metadata_to_fields "masc_reset" in
+            check (option string) "requiredPermission" (Some "CanAdmin")
+              (match List.assoc_opt "requiredPermission" fields with
+               | Some (`String permission) -> Some permission
+               | Some _ | None -> None));
+        ] );
       ( "register",
         [
           test_case "register populates tag_registry" `Quick (fun () ->
@@ -152,6 +179,25 @@ let () =
             let meta = Tool_catalog.metadata "__test_spec_catalog" in
             check bool "hidden" true (meta.visibility = Tool_catalog.Hidden);
             check bool "reason" true (meta.reason = Some "test hidden"));
+          test_case "register preserves late catalog admin requirement" `Quick (fun () ->
+            let name = "__test_spec_admin_inherit" in
+            let spec =
+              Tool_spec.create
+                ~name
+                ~description:"catalog permission test"
+                ~module_tag:Tool_dispatch.Mod_operator
+                ~input_schema:empty_schema
+                ~handler_binding:Tag_dispatch
+                ()
+            in
+            Tool_catalog.register_metadata
+              name
+              { Tool_catalog.default_metadata with
+                required_permission = Masc_domain.CanAdmin
+              };
+            Tool_spec.register spec;
+            check bool "catalog remains admin" true
+              (Tool_catalog.required_permission name = Masc_domain.CanAdmin));
           test_case "empty name rejected" `Quick (fun () ->
             check_raises "invalid_arg"
               (Invalid_argument "Tool_spec.register: name must not be empty")


### PR DESCRIPTION
## Summary\n\n- cap the dashboard development principal at effective Worker authority while preserving legacy persisted Admin metadata for audit\n- remove startup binding of MASC_ADMIN_TOKEN into the initial-admin credential\n- make Tool_catalog the typed permission SSOT and align Keeper lifecycle REST/MCP command-plane permissions\n- reject ambiguous shared dashboard bearers without rotating or overwriting credentials\n\nThis is the safe first slice of RFC-0340 / #24031. It deliberately does not claim crash-recoverable credential plus raw-token rotation; that remains in #24082 and #24084.\n\n## Verification\n\n- scripts/dune-local.sh build focused auth, dev-token, tool-spec, board REST, and startup targets\n- test_auth: 55 passed\n- test_dashboard_dev_token_host_gate: 6 passed\n- test_tool_spec: 17 passed\n- test_board_rest_routes: 9 passed\n- startup MASC_ADMIN_TOKEN non-binding regression: 1 passed\n- ocamlformat --check on changed OCaml files\n- git diff --check\n- adversarial current-head review: P0 0, P1 0\n\n## Runtime note\n\nThe live 8935 process remains intentionally offline because the deployed old binary reproduced unbounded memory growth. This PR does not restart it.