### PR TITLE
fix(connector): fork ingress dispatcher as daemon to avoid switch hang (main-red)

### DIFF
--- a/lib/gate/connector_ingress_lane.ml
+++ b/lib/gate/connector_ingress_lane.ml
@@ -114,7 +114,12 @@ let create ~sw ~on_failure () =
     ; on_failure
     }
   in
-  Eio.Fiber.fork ~sw (fun () -> run_dispatcher t);
+  (* run_dispatcher loops forever awaiting the condition; fork it as a daemon so
+     it is cancelled when the switch scope ends instead of keeping the switch
+     alive. A plain Eio.Fiber.fork left Eio.Switch.run waiting on this fiber
+     forever, so callers that scope the ingress in a short-lived switch (e.g.
+     tests) hung after their work completed. *)
+  Eio.Fiber.fork_daemon ~sw (fun () -> run_dispatcher t);
   t
 ;;
 


### PR DESCRIPTION
## 증상
main Build and Test가 `dune test` 2100s 타임아웃(exit 124)으로 red. 프로세스 스냅샷상 `test_discord_gateway_client.exe`가 34:51 동안 hang.

## 근본 원인
`Connector_ingress_lane`의 `run_dispatcher`는 lane condition을 기다리는 **종료 조건 없는 무한 루프**다. `create`에서 `Eio.Fiber.fork ~sw`로 forked되어, 호출자의 switch를 무기한 살려둔다. 따라서 `Eio.Switch.run`은 본문 작업이 끝나도 이 fiber를 영원히 기다려 반환하지 않는다. `test_discord_gateway_client`의 lane 테스트가 assertion을 모두 통과한 뒤 `Eio_main.run`이 돌아오지 못하고 hang → `dune test` 타임아웃 → main red.

이 hang은 base-red(runtime catalog identity)가 `dune test` 도달 전 컴파일/부팅 단계에서 실패시키는 동안 가려져 있다가, #24647이 base-red를 해소하면서 노출됐다. hang을 유발한 무한-루프 dispatcher는 #24568(`fix(connector): isolate Discord ingress by Keeper lane`)이 도입했다.

## 수정
dispatcher를 `Eio.Fiber.fork_daemon`으로 fork한다. daemon fiber는 switch 스코프가 끝날 때 자동 취소되며 switch를 살려두지 않는다. 프로덕션(장수 서버 switch)은 무영향이고, 단명 스코프(테스트, 정상 shutdown)는 이제 종료된다. masc 내 기존 관례와 동일(`board_dispatch.ml`, `runtime_observation.ml` 등 14파일이 백그라운드 actor를 fork_daemon으로 실행).

## 검증
- 수정 전: `test_discord_gateway_client.exe`가 `ingress_lanes` 테스트에서 hang(20s timeout 소진).
- 수정 후: `Test Successful in 0.002s. 4 tests run.` (reader_policy 2 + ingress_lanes 2 모두 pass). lane 격리/FIFO assertion은 그대로 통과 — semantics 무변경, shutdown 동작만 교정.

RFC-WAIVED: lib/gate/connector_ingress_lane 은 RFC-필수 subsystem(credential/identity/operator-control/keeper-sandbox/dashboard-credential/hooks/workflow) 목록에 없음. Eio fiber lifecycle 단일 라인 수정.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
