### PR TITLE
feat(keeper): replay durable completion delivery

### DIFF
--- a/lib/keeper/keeper_msg_async.ml
+++ b/lib/keeper/keeper_msg_async.ml
@@ -7,8 +7,7 @@
     Process memory owns active request workers only. Terminal entries leave the
     active index after a durable namespace move into the terminal partition and
     remain queryable by exact request id until an explicit cleanup policy
-    removes them. Startup recovery scans only the active partition; historical
-    terminal volume is not on the synchronous recovery path. *)
+    removes them. Startup recovery also resumes incomplete caller deliveries. *)
 
 open Keeper_types
 open Keeper_meta_contract
@@ -96,6 +95,7 @@ type recovery_candidate =
 
 type recovery_report =
   { candidates : recovery_candidate list
+  ; completion_deliveries : durable_terminal_proof list
   ; finalized : int
   ; cleaned : int
   ; staging_files_inspected : int
@@ -109,6 +109,7 @@ type recovery_report =
 
 and recovery_store =
   | Active_store
+  | Terminal_store
   | Atomic_staging_store
 
 and recovery_store_error =
@@ -1408,6 +1409,7 @@ let finalize_existing_terminal_source ~(entry : entry) source_path =
 
 let empty_recovery_report =
   { candidates = []
+  ; completion_deliveries = []
   ; finalized = 0
   ; cleaned = 0
   ; staging_files_inspected = 0
@@ -1444,6 +1446,7 @@ let record_error ~store ~path ~request_id ?keeper_name kind report =
     "keeper_msg_async: recovery record failed store=%s request_id=%s keeper=%s path=%s error=%s"
     (match store with
      | Active_store -> "active"
+     | Terminal_store -> "terminal"
      | Atomic_staging_store -> "atomic_staging")
     request_id
     keeper_label
@@ -1751,6 +1754,55 @@ let recover_active_record_directory ~base_path dir report =
     store_error ~store:Active_store ~path:dir (Printexc.to_string exn) report
 ;;
 
+let recover_completion_delivery_directory ~base_path report =
+  let dir = terminal_request_dir ~base_path in
+  let failed path reason report =
+    Log.Keeper.error "keeper completion recovery failed path=%s error=%s" path reason;
+    store_error ~store:Terminal_store ~path reason report
+  in
+  try
+    match Fs_compat.inspect_owned_directory_chain ~ownership_root:base_path dir with
+    | Ok Fs_compat.Owned_directory_missing -> report
+    | Error rejection ->
+      failed dir (Fs_compat.owned_directory_chain_rejection_to_string rejection) report
+    | Ok (Fs_compat.Owned_directory _) ->
+      Fs_compat.read_dir dir
+      |> List.fold_left
+           (fun report name ->
+              Eio_guard.fair_yield ();
+              match request_id_of_record_filename name with
+              | None -> report
+              | Some request_id ->
+                let path = Filename.concat dir name in
+                (try
+                   with_store_transition_lock ~base_path ~request_id (fun () ->
+                     match load_record_at_path ~base_path ~request_id path with
+                     | Found ({ status; completion_delivery = Some _; _ } as entry)
+                       when is_terminal_status status ->
+                       { report with
+                         completion_deliveries =
+                           { terminal_entry = entry } :: report.completion_deliveries
+                       }
+                     | Found { status; _ } when is_terminal_status status -> report
+                     | Found _ -> failed path "non-terminal record in terminal store" report
+                     | Unreadable reason ->
+                       let report = failed path reason report in
+                       { report with unreadable = report.unreadable + 1 }
+                     | Absent -> failed path "record disappeared during recovery" report
+                     | Rejected rejection ->
+                       failed
+                         path
+                         (access_rejection_to_json rejection |> Yojson.Safe.to_string)
+                         report)
+                 with
+                 | Eio.Cancel.Cancelled _ as exn -> raise exn
+                 | exn -> failed path (Printexc.to_string exn) report))
+           report
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> failed dir (Printexc.to_string exn) report
+;;
+
 let compare_recovery_candidate left right =
   let by_keeper =
     String.compare
@@ -1771,9 +1823,11 @@ let recover_request_records_canonical ~base_path =
   let report =
     sweep_request_staging_files ~base_path empty_recovery_report
     |> recover_active_record_directory ~base_path active_dir
+    |> recover_completion_delivery_directory ~base_path
   in
   { report with
     candidates = List.sort compare_recovery_candidate report.candidates
+  ; completion_deliveries = List.rev report.completion_deliveries
   ; store_errors = List.rev report.store_errors
   ; record_errors = List.rev report.record_errors
   }

--- a/lib/keeper/keeper_msg_async.mli
+++ b/lib/keeper/keeper_msg_async.mli
@@ -6,7 +6,7 @@
     [Queued]/[Running]/[Cancelling] workers. Terminal state is removed from memory after its
     durable record moves into the terminal partition and remains queryable by
     exact request id; no hidden age-based cleanup can erase an unobserved
-    result, and startup recovery does not scan historical terminal records. *)
+    result, while startup recovery resumes incomplete caller deliveries. *)
 
 (** {1 Types} *)
 
@@ -118,6 +118,7 @@ type recovery_candidate =
     staging directory. *)
 type recovery_report =
   { candidates : recovery_candidate list
+  ; completion_deliveries : durable_terminal_proof list
   ; finalized : int
   ; cleaned : int
   ; staging_files_inspected : int
@@ -131,6 +132,7 @@ type recovery_report =
 
 and recovery_store =
   | Active_store
+  | Terminal_store
   | Atomic_staging_store
 
 and recovery_store_error =
@@ -324,9 +326,9 @@ val mark_completion_delivered :
 
 (** Inventory persisted non-terminal request records that have no live
     in-memory worker. This is intended for server startup recovery. It does not
-    execute, reclassify, or rewrite those records. Only the canonical active
-    partition and its dedicated atomic staging directory are scanned; the
-    terminal partition is excluded. Current-process workers remain protected
+    execute or reclassify those records. The active partition yields execution
+    candidates; routed terminal records yield caller-delivery proofs.
+    Current-process workers remain protected
     by the in-memory active table; disk-only [Queued]/[Running]/[Cancelling]
     records are returned as typed candidates for the later executor boundary. *)
 val recover_request_records :

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -183,60 +183,155 @@ let signal_completion_caller ~base_path caller_keeper =
       caller_keeper
       (Keeper_lifecycle_admission.autonomous_denial_to_wire denial)
 
-let project_keeper_completion ~base_path ~request ~request_id settlement =
-  match Keeper_invocation_contract.reply_to_keeper_name request with
-  | None -> Completion_not_routed
-  | Some caller_keeper ->
-    (match settlement with
-     | Keeper_msg_async.Settlement_projection_error _ -> Completion_not_durable
-     | Keeper_msg_async.Status_settlement
-         { durability = Keeper_msg_async.Volatile_persistence_failure; _ } ->
-       Completion_not_durable
-     | Keeper_msg_async.Status_settlement
-         { durability = Keeper_msg_async.Durable; status; _ } ->
-       (match terminal_completion_outcome status with
-        | None -> Completion_not_durable
-        | Some bg_outcome ->
-          let completion : Keeper_event_queue.bg_job_completion =
-            { bg_run_id = request_id
-            ; bg_kind = Keeper_event_queue.Keeper_invocation
-            ; bg_outcome
-            ; bg_board_post_id = ""
-            }
+let completion_stimulus (entry : Keeper_msg_async.entry) =
+  match terminal_completion_outcome entry.status, entry.completed_at with
+  | Some bg_outcome, Some arrived_at ->
+    let completion : Keeper_event_queue.bg_job_completion =
+      { bg_run_id = entry.request_id
+      ; bg_kind = Keeper_event_queue.Keeper_invocation
+      ; bg_outcome
+      ; bg_board_post_id = ""
+      }
+    in
+    Ok
+      { Keeper_event_queue.post_id =
+          Keeper_event_queue.bg_job_completion_post_id completion
+      ; urgency = Keeper_event_queue.Immediate
+      ; arrived_at
+      ; payload = Keeper_event_queue.Bg_completed completion
+      }
+  | Some _, None -> Error "Keeper completion terminal source lacks completed_at"
+  | None, _ -> Error "Keeper completion source is not terminal"
+
+let completion_storage_failure ~request_id ~caller ~operation detail =
+  Otel_metric_store.inc_counter
+    Keeper_metrics.(to_string FsFailures)
+    ~labels:[ "subsystem", "keeper_invocation_completion"; "operation", operation ]
+    ();
+  Log.Keeper.error
+    "keeper invocation completion projection failed run_id=%s caller=%s operation=%s: %s"
+    request_id caller operation detail;
+  Completion_storage_failed detail
+
+let project_durable_keeper_completion ~base_path proof =
+  let observed = Keeper_msg_async.durable_terminal_entry proof in
+  match
+    Keeper_msg_async.load_canonical_durable_terminal
+      ~base_path
+      ~caller:observed.submitted_by
+      observed.request_id
+  with
+  | Error error ->
+    completion_storage_failure
+      ~request_id:observed.request_id
+      ~caller:observed.submitted_by
+      ~operation:"reload_terminal"
+      (Keeper_msg_async.canonical_terminal_error_to_string error)
+  | Ok current_proof ->
+    let entry = Keeper_msg_async.durable_terminal_entry current_proof in
+    (match Keeper_invocation_contract.reply_to_keeper_name entry.request with
+     | None -> Completion_not_routed
+     | Some caller_keeper ->
+       (match completion_stimulus entry with
+        | Error detail ->
+          completion_storage_failure
+            ~request_id:entry.request_id
+            ~caller:caller_keeper
+            ~operation:"build_stimulus"
+            detail
+        | Ok stimulus ->
+          let retire_and_wake result =
+            match
+              Keeper_event_queue_persistence.load_state_result
+                ~base_path
+                ~keeper_name:caller_keeper
+            with
+            | Error detail ->
+              completion_storage_failure
+                ~request_id:entry.request_id
+                ~caller:caller_keeper
+                ~operation:"load_receipt"
+                detail
+            | Ok state
+              when not
+                     (List.exists
+                        (String.equal entry.request_id)
+                        (Keeper_event_queue_state.keeper_invocation_receipts state)) ->
+              Completion_already_present
+            | Ok _ ->
+              (match
+                 Keeper_registry_event_queue.forget_keeper_invocation_receipt_result
+                   ~base_path
+                   ~keeper_name:caller_keeper
+                   ~request_id:entry.request_id
+                   ~stimulus
+               with
+               | Error detail ->
+                 completion_storage_failure
+                   ~request_id:entry.request_id
+                   ~caller:caller_keeper
+                   ~operation:"retire_receipt"
+                   detail
+               | Ok () ->
+                 signal_completion_caller ~base_path caller_keeper;
+                 result)
           in
-          let stimulus : Keeper_event_queue.stimulus =
-            { post_id = Keeper_event_queue.bg_job_completion_post_id completion
-            ; urgency = Keeper_event_queue.Immediate
-            ; arrived_at = Time_compat.now ()
-            ; payload = Keeper_event_queue.Bg_completed completion
-            }
-          in
-          (match
-             Keeper_registry_event_queue.enqueue_stimulus_durable_result
-               ~base_path
-               caller_keeper
-               stimulus
-           with
-           | Keeper_registry_event_queue.Stimulus_storage_error detail ->
-             Otel_metric_store.inc_counter
-               Keeper_metrics.(to_string FsFailures)
-               ~labels:
-                 [ "subsystem", "keeper_invocation_completion"
-                 ; "operation", "enqueue_caller_wake"
-                 ]
-               ();
-             Log.Keeper.error
-               "keeper invocation completion enqueue failed run_id=%s caller=%s: %s"
-               request_id
-               caller_keeper
-               detail;
-             Completion_storage_failed detail
-           | Keeper_registry_event_queue.Stimulus_enqueued ->
-             signal_completion_caller ~base_path caller_keeper;
-             Completion_enqueued
-           | Keeper_registry_event_queue.Stimulus_already_present ->
-             signal_completion_caller ~base_path caller_keeper;
-             Completion_already_present)))
+          (match entry.completion_delivery with
+           | None -> Completion_not_routed
+           | Some Keeper_msg_async.Delivery_delivered ->
+             retire_and_wake Completion_already_present
+           | Some Keeper_msg_async.Delivery_pending ->
+             (match
+                Keeper_registry_event_queue.enqueue_keeper_invocation_completion_result
+                  ~base_path
+                  ~keeper_name:caller_keeper
+                  ~request_id:entry.request_id
+                  stimulus
+              with
+              | Keeper_registry_event_queue.Keeper_invocation_storage_error detail ->
+                completion_storage_failure
+                  ~request_id:entry.request_id
+                  ~caller:caller_keeper
+                  ~operation:"accept_caller_completion"
+                  detail
+              | (Keeper_registry_event_queue.Keeper_invocation_enqueued
+                | Keeper_registry_event_queue.Keeper_invocation_already_accepted) as
+                acceptance ->
+                (match Keeper_msg_async.mark_completion_delivered current_proof with
+                 | Error detail ->
+                   completion_storage_failure
+                     ~request_id:entry.request_id
+                     ~caller:caller_keeper
+                     ~operation:"mark_source_delivered"
+                     detail
+                 | Ok _ ->
+                   retire_and_wake
+                     (match acceptance with
+                      | Keeper_registry_event_queue.Keeper_invocation_enqueued ->
+                        Completion_enqueued
+                      | Keeper_registry_event_queue.Keeper_invocation_already_accepted ->
+                        Completion_already_present))))))
+
+let project_keeper_completion ~base_path ~submitted_by ~request_id settlement =
+  match settlement with
+  | Keeper_msg_async.Settlement_projection_error _ -> Completion_not_durable
+  | Keeper_msg_async.Status_settlement
+      { durability = Keeper_msg_async.Volatile_persistence_failure; _ } ->
+    Completion_not_durable
+  | Keeper_msg_async.Status_settlement { durability = Keeper_msg_async.Durable; _ } ->
+    (match
+       Keeper_msg_async.load_canonical_durable_terminal
+         ~base_path
+         ~caller:submitted_by
+         request_id
+     with
+     | Ok proof -> project_durable_keeper_completion ~base_path proof
+     | Error error ->
+       completion_storage_failure
+         ~request_id
+         ~caller:submitted_by
+         ~operation:"load_terminal"
+         (Keeper_msg_async.canonical_terminal_error_to_string error))
 
 type registered_caller =
   | No_registered_caller
@@ -271,8 +366,6 @@ module For_testing = struct
     cached_json_by_key keeper_list_cache ~key ~ttl_s compute
   let submit_keeper_msg_with_captured_event_bus =
     submit_keeper_msg_with_captured_event_bus
-  let terminal_completion_outcome = terminal_completion_outcome
-  let project_keeper_completion = project_keeper_completion
   let request_with_registered_reply_to = request_with_registered_reply_to
 end
 let annotate_keeper_json ~runtime_class json =
@@ -771,7 +864,7 @@ let submit_keeper_invocation
           ignore
             (project_keeper_completion
                ~base_path:ctx.config.base_path
-               ~request
+               ~submitted_by
                ~request_id
                settlement
              : keeper_completion_projection))

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -552,11 +552,13 @@ let prepare_keeper_persistence_owned ~base_path_identity ~set_phase ~config =
     Keeper_msg_async.recover_request_records ~base_path ()
   in
   let candidates = keeper_msg_recovery.candidates in
+  let completion_deliveries = keeper_msg_recovery.completion_deliveries in
   observe_preparation_stage
     ~stage:"request"
     ~started:request_started
     ~examined:
       (List.length candidates
+       + List.length completion_deliveries
        + keeper_msg_recovery.finalized
        + keeper_msg_recovery.cleaned
        + keeper_msg_recovery.staging_files_inspected
@@ -568,6 +570,7 @@ let prepare_keeper_persistence_owned ~base_path_identity ~set_phase ~config =
        + List.length keeper_msg_recovery.store_errors);
   if
     candidates <> []
+    || completion_deliveries <> []
     || keeper_msg_recovery.finalized > 0
     || keeper_msg_recovery.cleaned > 0
     || keeper_msg_recovery.staging_files_inspected > 0
@@ -575,8 +578,9 @@ let prepare_keeper_persistence_owned ~base_path_identity ~set_phase ~config =
     || keeper_msg_recovery.failed > 0
   then
     Log.Keeper.warn
-      "keeper_msg_async: recovery pending=%d finalized=%d cleaned=%d staging_files_inspected=%d staging_files_deleted=%d staging_files_preserved=%d unreadable=%d failed=%d"
+      "keeper_msg_async: recovery pending=%d completion_deliveries=%d finalized=%d cleaned=%d staging_files_inspected=%d staging_files_deleted=%d staging_files_preserved=%d unreadable=%d failed=%d"
       (List.length candidates)
+      (List.length completion_deliveries)
       keeper_msg_recovery.finalized
       keeper_msg_recovery.cleaned
       keeper_msg_recovery.staging_files_inspected
@@ -595,6 +599,12 @@ let prepare_keeper_persistence_owned ~base_path_identity ~set_phase ~config =
           | Keeper_msg_async.Running_before_restart -> "running"
           | Keeper_msg_async.Cancelling_before_restart _ -> "cancelling"))
     candidates;
+  List.iter
+    (fun proof ->
+       ignore
+         (Keeper_tool_surface_ops.project_durable_keeper_completion ~base_path proof
+           : Keeper_tool_surface_ops.keeper_completion_projection))
+    completion_deliveries;
   let prepared =
     { base_path = base_path_identity
     ; config

--- a/test/test_keeper_unified_turn_event_bus.ml
+++ b/test/test_keeper_unified_turn_event_bus.ml
@@ -504,7 +504,7 @@ let test_typed_keeper_invocation_wire_contract () =
     (List.mem_assoc "request_id" rejection_fields)
 ;;
 
-let test_keeper_completion_wake_is_typed_and_idempotent () =
+let test_keeper_completion_route_is_typed () =
   with_temp_dir "keeper-completion-wake" @@ fun base_path ->
   Masc.Keeper_registry.clear ();
   let caller_meta =
@@ -530,6 +530,10 @@ let test_keeper_completion_wake_is_typed_and_idempotent () =
     | Ok request -> request
     | Error _ -> Alcotest.fail "registered caller route rejected"
   in
+  check (option string) "registered caller becomes reply-to" (Some "caller")
+    (request
+     |> Keeper_invocation_types.request_reply_to
+     |> Option.map Keeper_invocation_types.reply_to_keeper_name);
   ignore (Masc.Keeper_registry.register ~base_path "caller-shadow" caller_meta);
   (match
      Ops.For_testing.request_with_registered_reply_to
@@ -552,34 +556,6 @@ let test_keeper_completion_wake_is_typed_and_idempotent () =
     (durable_request
      |> Keeper_invocation_types.request_reply_to
      |> Option.map Keeper_invocation_types.reply_to_keeper_name);
-  let success =
-    Kmsg.Status_settlement
-      { status = Kmsg.Done { ok = true; body = "finished"; data = None }
-      ; durability = Kmsg.Durable
-      ; origin = Kmsg.Transition_commit
-      }
-  in
-  let project =
-    Ops.For_testing.project_keeper_completion
-      ~base_path
-      ~request
-      ~request_id:"run-success"
-  in
-  ignore (project success : Ops.keeper_completion_projection);
-  check bool "terminal replay reuses identity" true
-    (project success = Ops.Completion_already_present);
-  check bool "failure remains typed" true
-    (Ops.For_testing.terminal_completion_outcome (Kmsg.Lost { reason = "lost" })
-     = Some (Event_queue.Bg_failed "lost"));
-  let pending = Registry_queue.snapshot ~base_path "caller" |> Event_queue.to_list in
-  check int "one completion stimulus after replay" 1 (List.length pending);
-  match pending with
-  | [ { Event_queue.payload = Event_queue.Bg_completed completion; _ } ] ->
-    check bool "typed Keeper invocation kind" true
-      (completion.bg_kind = Event_queue.Keeper_invocation);
-    check bool "typed success outcome" true
-      (completion.bg_outcome = Event_queue.Bg_ok "finished");
-  | _ -> Alcotest.fail "expected one typed Keeper completion stimulus"
 ;;
 
 let test_keeper_completion_delivery_store_transition () =
@@ -624,6 +600,76 @@ let test_keeper_completion_delivery_store_transition () =
      = Some Kmsg.Delivery_delivered);
   check bool "stale pending proof replays idempotently" true
     (Result.is_ok (Kmsg.mark_completion_delivered pending))
+;;
+
+let test_keeper_completion_restart_handshake () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  with_temp_dir "keeper-completion-handshake" @@ fun base_path ->
+  Keeper_event_bus.set (Agent_sdk.Event_bus.create ());
+  let request =
+    durable_request "callee"
+    |> Keeper_invocation_types.with_reply_to ~keeper_name:"caller"
+    |> Result.get_ok
+  in
+  Fun.protect ~finally:Kmsg.For_testing.clear @@ fun () ->
+  let request_id =
+    Ops.For_testing.submit_keeper_msg_with_captured_event_bus
+      ~background_sw:sw ~base_path ~caller:keeper_msg_caller ~request
+      ~f:(fun ?event_bus:_ _ _ ->
+        Tool_result.ok ~tool_name:"completion-handshake" ~start_time:0.0 "finished")
+      ()
+    |> function
+    | Ok { Kmsg.request_id; acceptance = Kmsg.Durably_accepted } -> request_id
+    | Ok _ | Error _ -> Alcotest.fail "Keeper completion fixture was not accepted"
+  in
+  wait_for_done ~clock:env#clock ~base_path request_id;
+  let proof =
+    match (Kmsg.recover_request_records ~base_path ()).completion_deliveries with
+    | [ proof ] -> proof
+    | _ -> Alcotest.fail "restart scanner did not recover one completion"
+  in
+  let entry = Kmsg.durable_terminal_entry proof in
+  check bool "terminal source starts pending" true
+    (entry.completion_delivery = Some Kmsg.Delivery_pending);
+  let stimulus = Ops.completion_stimulus entry |> Result.get_ok in
+  let accept () =
+    match
+      Registry_queue.enqueue_keeper_invocation_completion_result
+        ~base_path ~keeper_name:"caller" ~request_id stimulus
+    with
+    | Registry_queue.Keeper_invocation_storage_error error -> Alcotest.fail error
+    | Registry_queue.Keeper_invocation_enqueued
+    | Registry_queue.Keeper_invocation_already_accepted -> ()
+  in
+  accept ();
+  ignore
+    (Ops.project_durable_keeper_completion ~base_path proof
+      : Ops.keeper_completion_projection);
+  let fresh =
+    match (Kmsg.recover_request_records ~base_path ()).completion_deliveries with
+    | [ proof ] -> proof
+    | _ -> Alcotest.fail "restart scanner lost delivered receipt cleanup"
+  in
+  check bool "source commits delivered" true
+    ((Kmsg.durable_terminal_entry fresh).completion_delivery
+     = Some Kmsg.Delivery_delivered);
+  accept ();
+  ignore
+    (Ops.project_durable_keeper_completion ~base_path fresh
+      : Ops.keeper_completion_projection);
+  ignore
+    (Ops.project_durable_keeper_completion ~base_path proof
+      : Ops.keeper_completion_projection);
+  check int "all crash replays retain one stimulus" 1
+    (Registry_queue.snapshot ~base_path "caller" |> Event_queue.to_list |> List.length);
+  let state =
+    Masc.Keeper_event_queue_persistence.load_state_result
+      ~base_path ~keeper_name:"caller"
+    |> Result.get_ok
+  in
+  check (list string) "receipt retired after replay" []
+    (Masc.Keeper_event_queue_state.keeper_invocation_receipts state)
 ;;
 
 let test_take_drain_cancel_clears_active_without_spin () =
@@ -711,10 +757,12 @@ let () =
             test_keeper_invocation_result_contracts
         ; test_case "typed Keeper invocation wire contract" `Quick
             test_typed_keeper_invocation_wire_contract
-        ; test_case "Keeper completion wake is typed and idempotent" `Quick
-            test_keeper_completion_wake_is_typed_and_idempotent
+        ; test_case "Keeper completion route is typed" `Quick
+            test_keeper_completion_route_is_typed
         ; test_case "Keeper completion delivery store transition" `Quick
             test_keeper_completion_delivery_store_transition
+        ; test_case "Keeper completion restart handshake" `Quick
+            test_keeper_completion_restart_handshake
         ] )
     ; ( "background-drain"
       , [ test_case "continues after first poll" `Quick


### PR DESCRIPTION
## What changed

- Extends startup recovery with typed durable-terminal completion proofs.
- Projects Pending completions through the #24710 destination acceptance transaction before marking the source Delivered.
- Retires the exact request receipt and wakes only the caller Keeper lane after source convergence.
- Reuses the same durable projector for live worker completion and restart replay.
- Reloads the exact canonical terminal source before every projection, so a stale Pending proof observes Delivered rather than reaccepting consumed work.
- Logs and returns typed storage failures for reload, stimulus construction, destination acceptance, source transition, receipt load, and receipt retirement.

## Crash and replay proof

The focused regression covers the two-store boundaries:
1. destination queue and receipt committed while source remains Pending;
2. projector converges source to Delivered and retires the receipt;
3. Delivered source with a recreated receipt converges cleanup after restart;
4. replay of the stale Pending proof does not duplicate delivery;
5. final durable queue contains exactly one typed Keeper invocation stimulus and zero receipts.

## Stack

- Base: #24722, C3a source-side Pending and Delivered store transition
- This PR: C3b restart scanner and accept to Delivered to retire to caller-wake projector
- Next child, not claimed here: typed run_ref, artifact references, and full terminal result reinjection

## Scope and size

- 395 changed lines: 301 additions, 94 deletions
- One-time fair-yield terminal partition scan at startup; no global lane stop and per-record failures do not halt other records
- No budget, turn, or cost gate
- No product-specific provider or tool matching

## Validation

- ocamlformat check: green
- OCaml parser check for all changed ML and MLI files: green
- git diff --check: green
- Focused Dune wrapper stopped at unrelated local OAS pin drift after waiting for the shared lock; no pin repair or skip guard was used. CI remains build and type authority.