### PR TITLE
refactor(runtime): purge retired execution-limit observations

### DIFF
--- a/lib/keeper/keeper_agent_run_contract_helpers.ml
+++ b/lib/keeper/keeper_agent_run_contract_helpers.ml
@@ -30,10 +30,7 @@ let observed_completion_evidence
   | Runtime_agent.Yielded_to_chat_waiting _
   | Runtime_agent.Yielded_to_durable_stimulus _ ->
     Keeper_execution_receipt.Completion_observation_unknown
-  | Runtime_agent.Completed
-  | Runtime_agent.TurnLimitObserved _
-  | Runtime_agent.ExecutionTimeoutObserved _
-  | Runtime_agent.ExecutionIdleTimeoutObserved _ ->
+  | Runtime_agent.Completed ->
     if actual_keeper_tool_names <> []
     then Keeper_execution_receipt.Completion_tool_execution_observed
     else if response_text_present

--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -159,9 +159,6 @@ let checkpoint_for_replay_persistence
        Error
          "refusing to save input-required checkpoint: messages do not match \
           pre-turn history prefix")
-  | Runtime_agent.TurnLimitObserved _
-  | Runtime_agent.ExecutionTimeoutObserved _
-  | Runtime_agent.ExecutionIdleTimeoutObserved _
   | Runtime_agent.Yielded_to_chat_waiting _
   | Runtime_agent.Yielded_to_durable_stimulus _ ->
     (* A control-boundary checkpoint retains the current-turn tool result so

--- a/lib/keeper/keeper_agent_run_response_text.ml
+++ b/lib/keeper/keeper_agent_run_response_text.ml
@@ -5,12 +5,9 @@ type finalized = {
 }
 
 let stop_reason_suppresses_visible_response = function
-  | Runtime_agent.ExecutionTimeoutObserved _
-  | Runtime_agent.ExecutionIdleTimeoutObserved _
   | Runtime_agent.Yielded_to_chat_waiting _
   | Runtime_agent.Yielded_to_durable_stimulus _ -> true
   | Runtime_agent.Completed
-  | Runtime_agent.TurnLimitObserved _
   | Runtime_agent.InputRequired _ ->
     false
 ;;

--- a/lib/keeper/keeper_execution_receipt_types.ml
+++ b/lib/keeper/keeper_execution_receipt_types.ml
@@ -199,24 +199,6 @@ type t =
 
 let stop_reason_to_string = function
   | Runtime_agent.Completed -> "completed"
-  | Runtime_agent.TurnLimitObserved { turns_used; limit } ->
-    Printf.sprintf "turn_limit_observed:turns=%d,limit=%d" turns_used limit
-  | Runtime_agent.ExecutionTimeoutObserved
-      { elapsed_sec; timeout_sec; turn_count; max_turns } ->
-    Printf.sprintf
-      "execution_timeout_observed:elapsed_sec=%.1f,timeout_sec=%.1f,turn_count=%d,max_turns=%d"
-      elapsed_sec
-      timeout_sec
-      turn_count
-      max_turns
-  | Runtime_agent.ExecutionIdleTimeoutObserved
-      { idle_sec; idle_timeout_sec; turn_count; max_turns } ->
-    Printf.sprintf
-      "execution_idle_timeout_observed:idle_sec=%.1f,idle_timeout_sec=%.1f,turn_count=%d,max_turns=%d"
-      idle_sec
-      idle_timeout_sec
-      turn_count
-      max_turns
   | Runtime_agent.Yielded_to_chat_waiting { turns_used } ->
     Printf.sprintf "yielded_to_chat_waiting:%d" turns_used
   | Runtime_agent.Yielded_to_durable_stimulus { turns_used } ->
@@ -231,10 +213,7 @@ let stop_reason_to_string = function
 let receipt_terminal_reason_code_of_stop_reason = function
   | Runtime_agent.InputRequired _ ->
     Keeper_turn_disposition.to_wire Keeper_turn_disposition.Input_required
-  | Runtime_agent.Completed
-  | Runtime_agent.TurnLimitObserved _
-  | Runtime_agent.ExecutionTimeoutObserved _
-  | Runtime_agent.ExecutionIdleTimeoutObserved _ ->
+  | Runtime_agent.Completed ->
     Keeper_turn_disposition.to_wire Keeper_turn_disposition.Success
   | ( Runtime_agent.Yielded_to_chat_waiting _
     | Runtime_agent.Yielded_to_durable_stimulus _ ) as stop_reason ->

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -151,16 +151,12 @@ let apply_accept
   =
   match run_result.stop_reason with
   | Runtime_agent.InputRequired _
-  | Runtime_agent.TurnLimitObserved _
-  | Runtime_agent.ExecutionTimeoutObserved _
-  | Runtime_agent.ExecutionIdleTimeoutObserved _
   | Runtime_agent.Yielded_to_chat_waiting _
   | Runtime_agent.Yielded_to_durable_stimulus _ ->
     (* These are typed host-control terminals, not model deliverables. Running
        the normal response accept predicate over their question/blank carrier
        would turn them into [Accept_rejected] and incorrectly rotate providers,
-       discarding typed control/observation evidence. Execution-limit
-       observations never become a MASC acceptance gate. *)
+       discarding typed control evidence. *)
     Ok run_result
   | Runtime_agent.Completed ->
     if accept run_result.response then Ok run_result

--- a/lib/keeper/keeper_turn_outcome.ml
+++ b/lib/keeper/keeper_turn_outcome.ml
@@ -31,22 +31,16 @@ let wire_key = "turn_outcome"
 let turn_ref_wire_key = "turn_ref"
 
 let of_stop_reason = function
-  | Runtime_agent.Completed
-  | Runtime_agent.TurnLimitObserved _ -> Visible_reply
+  | Runtime_agent.Completed -> Visible_reply
   | Runtime_agent.Yielded_to_chat_waiting _
   | Runtime_agent.Yielded_to_durable_stimulus _ -> Continuation_checkpoint
-  | Runtime_agent.ExecutionTimeoutObserved _
-  | Runtime_agent.ExecutionIdleTimeoutObserved _ -> No_visible_reply
   | Runtime_agent.InputRequired _ -> Visible_reply
 
 let of_result_surface ~response_text = function
-  | Runtime_agent.Completed
-  | Runtime_agent.TurnLimitObserved _ ->
+  | Runtime_agent.Completed ->
       if String.trim response_text = "" then No_visible_reply else Visible_reply
   | Runtime_agent.Yielded_to_chat_waiting _
   | Runtime_agent.Yielded_to_durable_stimulus _ -> Continuation_checkpoint
-  | Runtime_agent.ExecutionTimeoutObserved _
-  | Runtime_agent.ExecutionIdleTimeoutObserved _ -> No_visible_reply
   | Runtime_agent.InputRequired _ -> Visible_reply
 
 let of_reply_payload payload =

--- a/lib/keeper/keeper_turn_outcome.mli
+++ b/lib/keeper/keeper_turn_outcome.mli
@@ -34,9 +34,7 @@ val turn_ref_wire_key : string
     ({!turn_ref_of_reply_payload}) so the wire name cannot drift. *)
 
 val of_stop_reason : Runtime_agent.stop_reason -> t
-(** Stop-reason-only classifier. [Completed] and the observational
-    [TurnLimitObserved] fact may carry model output. Execution-timeout
-    observations never manufacture visible output. Use
+(** Stop-reason-only classifier. [Completed] may carry model output. Use
     {!of_result_surface} at payload production sites where the actual
     [response_text] is available. *)
 

--- a/lib/keeper/keeper_turn_terminal_code.mli
+++ b/lib/keeper/keeper_turn_terminal_code.mli
@@ -60,8 +60,7 @@ type t =
           mcp / config / serialization / io / orchestration / a2a /
           internal). The payload is the existing parametrised wire
           format produced by [Keeper_agent_error.terminal_reason_code_of_sdk_error]
-          (e.g. ["agent_error_max_turns_exceeded:turns=10,limit=10"],
-          ["api_error_server:502"]). PR-2.5 wraps the existing typed
+          (e.g. ["api_error_server:502"]). PR-2.5 wraps the existing typed
           accessors in this variant so the typed bridge becomes a
           single source of truth for [Keeper_turn_terminal.t.code]
           field swap (PR-3). RFC-0042 §5.2 explicitly defers refining

--- a/lib/keeper/keeper_unified_metrics_result.ml
+++ b/lib/keeper/keeper_unified_metrics_result.ml
@@ -41,9 +41,7 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
   let substantive_tool_call_count = List.length tool_names in
   let has_substantive_tools = has_substantive_tool_calls tool_names in
   let has_text = String.trim result.response_text <> "" in
-  (* Visible-output preview follows the typed result surface. In particular,
-     [TurnLimitObserved] is only an observed OAS fact: MASC neither fabricates
-     continuation text nor promotes it to a lifecycle checkpoint. *)
+  (* Visible-output preview follows the typed result surface. *)
   let is_visible_reply =
     Keeper_turn_outcome.equal
       (Keeper_turn_outcome.of_result_surface

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -69,11 +69,7 @@ let acknowledge_pending_messages
 
 let terminal_outcome_of_result result =
   match result.Keeper_agent_run.stop_reason with
-  | Runtime_agent.Completed
-  | Runtime_agent.TurnLimitObserved _
-  | Runtime_agent.ExecutionTimeoutObserved _
-  | Runtime_agent.ExecutionIdleTimeoutObserved _ ->
-    Terminal_done
+  | Runtime_agent.Completed -> Terminal_done
   | Runtime_agent.InputRequired _ -> Terminal_input_required
   | Runtime_agent.Yielded_to_chat_waiting _
   | Runtime_agent.Yielded_to_durable_stimulus _ ->
@@ -269,12 +265,6 @@ let emit_usage_metrics_and_log
   let outcome_str =
     match result.Keeper_agent_run.stop_reason with
     | Runtime_agent.Completed -> "completed"
-    | Runtime_agent.TurnLimitObserved { turns_used; limit; _ } ->
-      Printf.sprintf "turn_limit_observed(%d/%d)" turns_used limit
-    | Runtime_agent.ExecutionTimeoutObserved { elapsed_sec; turn_count; _ } ->
-      Printf.sprintf "execution_timeout_observed(%.1fs/%d)" elapsed_sec turn_count
-    | Runtime_agent.ExecutionIdleTimeoutObserved { idle_sec; turn_count; _ } ->
-      Printf.sprintf "execution_idle_timeout_observed(%.1fs/%d)" idle_sec turn_count
     | Runtime_agent.Yielded_to_chat_waiting { turns_used } ->
       Printf.sprintf "yielded_to_chat_waiting(%d)" turns_used
     | Runtime_agent.Yielded_to_durable_stimulus { turns_used } ->
@@ -292,10 +282,7 @@ let emit_usage_metrics_and_log
        | Runtime_agent.Yielded_to_durable_stimulus _ ->
          "yielded_to_durable_stimulus"
        | Runtime_agent.InputRequired _ -> "input_required"
-       | Runtime_agent.Completed
-       | Runtime_agent.TurnLimitObserved _
-       | Runtime_agent.ExecutionTimeoutObserved _
-       | Runtime_agent.ExecutionIdleTimeoutObserved _ -> "success")
+       | Runtime_agent.Completed -> "success")
   in
   Otel_metric_store.inc_counter
     Keeper_metrics.(to_string Turns)
@@ -413,11 +400,7 @@ let terminal_reason_of_outcome result = function
        Keeper_turn_terminal.of_disposition
          ~source:"runtime_stop_reason"
          Keeper_turn_disposition.Input_required
-     | Runtime_agent.Completed
-     | Runtime_agent.TurnLimitObserved _
-     | Runtime_agent.ExecutionTimeoutObserved _
-     | Runtime_agent.ExecutionIdleTimeoutObserved _ ->
-       Keeper_turn_terminal.success ())
+     | Runtime_agent.Completed -> Keeper_turn_terminal.success ())
 
 let persist_terminal_turn_meta
       ~config
@@ -473,28 +456,6 @@ let reset_turn_failures_for_stop_reason ~config ~updated_meta result =
     Health.record_success ~agent_name:updated_meta.name
   in
   match result.Keeper_agent_run.stop_reason with
-  | Runtime_agent.TurnLimitObserved { turns_used; limit } ->
-    Log.Keeper.warn ~keeper_name:updated_meta.name
-      "runtime reported unexpected turn-limit observation (%d/%d); no Keeper checkpoint, blocker, retry, or follow-up action was created"
-      turns_used
-      limit;
-    reset_failure_state ()
-  | Runtime_agent.ExecutionTimeoutObserved
-      { elapsed_sec; timeout_sec; turn_count; _ } ->
-    Log.Keeper.warn ~keeper_name:updated_meta.name
-      "runtime reported unexpected execution timeout observation (elapsed=%.1fs timeout=%.1fs turns=%d); no Keeper blocker, retry, or follow-up action was created"
-      elapsed_sec
-      timeout_sec
-      turn_count;
-    reset_failure_state ()
-  | Runtime_agent.ExecutionIdleTimeoutObserved
-      { idle_sec; idle_timeout_sec; turn_count; _ } ->
-    Log.Keeper.warn ~keeper_name:updated_meta.name
-      "runtime reported unexpected execution idle-timeout observation (idle=%.1fs timeout=%.1fs turns=%d); no Keeper blocker, retry, or follow-up action was created"
-      idle_sec
-      idle_timeout_sec
-      turn_count;
-    reset_failure_state ()
   | Runtime_agent.Yielded_to_chat_waiting { turns_used } ->
     (* A clean, intentional yield to a parked chat, not a degraded outcome:
        clear turn-failure state and record health success, like a completed

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -62,19 +62,6 @@ let transport_error_kind_of_exception = function
 type stop_reason =
   Runtime_agent_context.stop_reason =
   | Completed
-  | TurnLimitObserved of { turns_used : int; limit : int }
-  | ExecutionTimeoutObserved of {
-      elapsed_sec : float;
-      timeout_sec : float;
-      turn_count : int;
-      max_turns : int;
-    }
-  | ExecutionIdleTimeoutObserved of {
-      idle_sec : float;
-      idle_timeout_sec : float;
-      turn_count : int;
-      max_turns : int;
-    }
   | Yielded_to_chat_waiting of { turns_used : int }
   | Yielded_to_durable_stimulus of { turns_used : int }
   | InputRequired of {
@@ -904,9 +891,6 @@ let run_duration_ms_since started_at =
 
 let dashboard_status_of_stop_reason = function
   | Completed -> Dashboard_oas_bridge.Success
-  | TurnLimitObserved _
-  | ExecutionTimeoutObserved _
-  | ExecutionIdleTimeoutObserved _ -> Dashboard_oas_bridge.Success
   | Yielded_to_chat_waiting _ ->
       Dashboard_oas_bridge.Cancelled { reason = "yielded_to_chat_waiting" }
   | Yielded_to_durable_stimulus _ ->

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -21,19 +21,6 @@
 
 type stop_reason = Runtime_agent_context.stop_reason =
   | Completed
-  | TurnLimitObserved of { turns_used : int; limit : int }
-  | ExecutionTimeoutObserved of {
-      elapsed_sec : float;
-      timeout_sec : float;
-      turn_count : int;
-      max_turns : int;
-    }
-  | ExecutionIdleTimeoutObserved of {
-      idle_sec : float;
-      idle_timeout_sec : float;
-      turn_count : int;
-      max_turns : int;
-    }
   | Yielded_to_chat_waiting of { turns_used : int }
   | Yielded_to_durable_stimulus of { turns_used : int }
   | InputRequired of {
@@ -53,11 +40,7 @@ type cooperative_yield_probe =
   Agent_sdk.Agent.Advanced.tool_boundary ->
   (cooperative_yield_decision, Agent_sdk.Error.sdk_error) result
 (** Why this single OAS call yielded control. [Completed] is the
-    model's success path. [TurnLimitObserved], [ExecutionTimeoutObserved],
-    and [ExecutionIdleTimeoutObserved] preserve unexpected typed OAS
-    observations; Keeper callers configure execution unbounded and must not
-    promote these observations to a checkpoint, blocker, retry, or follow-up
-    action. [Yielded_to_chat_waiting] fires when an
+    model's success path. [Yielded_to_chat_waiting] fires when an
     autonomous-lane run stopped at a turn boundary to hand the keeper's
     turn slot to a parked dashboard/connector chat request.
     [Yielded_to_durable_stimulus] fires after at least one provider turn when

--- a/lib/runtime/runtime_agent_context.ml
+++ b/lib/runtime/runtime_agent_context.ml
@@ -7,22 +7,6 @@
 
 type stop_reason =
   | Completed
-  | TurnLimitObserved of
-      { turns_used : int
-      ; limit : int
-      }
-  | ExecutionTimeoutObserved of
-      { elapsed_sec : float
-      ; timeout_sec : float
-      ; turn_count : int
-      ; max_turns : int
-      }
-  | ExecutionIdleTimeoutObserved of
-      { idle_sec : float
-      ; idle_timeout_sec : float
-      ; turn_count : int
-      ; max_turns : int
-      }
   | Yielded_to_chat_waiting of { turns_used : int }
     (* The autonomous lane's OAS run stopped at a turn boundary because a
        dashboard/connector chat request was parked on the keeper's turn slot.

--- a/lib/runtime/runtime_agent_context.mli
+++ b/lib/runtime/runtime_agent_context.mli
@@ -14,19 +14,6 @@
 (** Why a worker run terminated. *)
 type stop_reason =
   | Completed
-  | TurnLimitObserved of { turns_used : int; limit : int }
-  | ExecutionTimeoutObserved of {
-      elapsed_sec : float;
-      timeout_sec : float;
-      turn_count : int;
-      max_turns : int;
-    }
-  | ExecutionIdleTimeoutObserved of {
-      idle_sec : float;
-      idle_timeout_sec : float;
-      turn_count : int;
-      max_turns : int;
-    }
   | Yielded_to_chat_waiting of { turns_used : int }
   | Yielded_to_durable_stimulus of { turns_used : int }
   | InputRequired of {

--- a/test/test_keeper_replay_checkpoint.ml
+++ b/test/test_keeper_replay_checkpoint.ml
@@ -7,8 +7,6 @@ module Finalize = Masc.Keeper_agent_run_finalize_response.For_testing
 module Receipt = Masc.Keeper_execution_receipt
 module Replay_prefix = Masc.Keeper_replay_prefix
 
-let observed_max_turns = 10
-
 let message role content =
   Agent_sdk.Types.{ role; content; name = None; tool_call_id = None; metadata = [] }
 ;;
@@ -279,72 +277,6 @@ let test_empty_success_drops_current_turn_replay () =
     (prune_reason_to_string reason)
 ;;
 
-let test_execution_observations_preserve_tool_replay_suffix () =
-  let open Agent_sdk.Types in
-  let history =
-    [ message User [ Text "old user" ]; message Assistant [ Text "old answer" ] ]
-  in
-  let current_turn =
-    [ message User [ Text "inspect the source" ]
-    ; message Assistant
-        [ Thinking { signature = Some "sig-1"; content = "inspect repository" }
-        ; ToolUse
-            { id = "tool-1"
-            ; name = "Execute"
-            ; input = `Assoc [ "cmd", `String "git status --short" ]
-            }
-        ]
-    ; message Tool
-        [ ToolResult
-            { tool_use_id = "tool-1"
-            ; content = "clean"
-            ; outcome = Tool_succeeded
-            ; json = None
-            ; content_blocks = None
-            }
-        ]
-    ]
-  in
-  let observations =
-    [ Runtime_agent.TurnLimitObserved { turns_used = 4; limit = 4 }
-    ; Runtime_agent.ExecutionTimeoutObserved
-        { elapsed_sec = 300.0
-        ; timeout_sec = 300.0
-        ; turn_count = 4
-        ; max_turns = observed_max_turns
-        }
-    ; Runtime_agent.ExecutionIdleTimeoutObserved
-        { idle_sec = 120.0
-        ; idle_timeout_sec = 120.0
-        ; turn_count = 4
-        ; max_turns = observed_max_turns
-        }
-    ]
-  in
-  List.iter
-    (fun stop_reason ->
-       let patched, reason =
-         Finalize.checkpoint_for_replay_persistence
-           ~history_messages:history
-           ~pre_turn_working_context:None
-           ~completion_contract_result:Receipt.Completion_tool_execution_observed
-           ~session_id:"new-session"
-           ~response_text:""
-           ~stop_reason
-           (checkpoint (history @ current_turn))
-         |> expect_ok
-       in
-       Alcotest.(check bool)
-         "execution observation retains thinking/tool call/tool result"
-         true
-         (patched.messages = history @ current_turn);
-       Alcotest.(check (option string))
-         "execution observation has no replay prune reason"
-         None
-         (prune_reason_to_string reason))
-    observations
-;;
-
 let test_input_required_preserves_exact_tool_failure_suffix () =
   let open Agent_sdk.Types in
   let history =
@@ -481,10 +413,6 @@ let () =
             "empty success drops current turn"
             `Quick
             test_empty_success_drops_current_turn_replay
-        ; Alcotest.test_case
-            "execution observations preserve tool replay suffix"
-            `Quick
-            test_execution_observations_preserve_tool_replay_suffix
         ; Alcotest.test_case
             "InputRequired preserves exact tool-failure suffix"
             `Quick

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -275,9 +275,6 @@ let () =
     [ "unrelated authentication failed"
     ; "not_a_config_error"
     ; "API_ERROR_Auth"
-    ; "agent_error_max_turns_exceeded:turns=8,limit=8"
-    ; "agent_error_execution_timeout:elapsed_sec=120.0,timeout_sec=120.0,turn_count=7,max_turns=8"
-    ; "agent_error_idle_timeout:idle_sec=120.0,idle_timeout_sec=120.0,turn_count=7,max_turns=8"
     ];
   let canonical =
     R.operator_disposition

--- a/test/test_keeper_turn_disposition.ml
+++ b/test/test_keeper_turn_disposition.ml
@@ -55,9 +55,6 @@ let canonical_app_codes : (string * D.t) list =
 let runtime_wire_codes : (string * D.t) list =
   [ "api_error_overloaded", D.Provider_error (Code.Sdk_error "api_error_overloaded")
   ; "api_error_server:502", D.Provider_error (Code.Sdk_error "api_error_server:502")
-  ; ( "agent_error_max_turns_exceeded:turns=10,limit=10"
-    , D.Provider_error (Code.Sdk_error "agent_error_max_turns_exceeded:turns=10,limit=10")
-    )
   ]
 ;;
 
@@ -219,8 +216,8 @@ let runtime_codes_to_projection : (string * Code.t * D.t) list =
     , Code.Exception_unhandled "x"
     , D.Provider_error (Code.Exception_unhandled "x") )
   ; ( "Sdk"
-    , Code.Sdk_error "agent_error_max_turns_exceeded:turns=1,limit=1"
-    , D.Provider_error (Code.Sdk_error "agent_error_max_turns_exceeded:turns=1,limit=1") )
+    , Code.Sdk_error "api_error_server:502"
+    , D.Provider_error (Code.Sdk_error "api_error_server:502") )
   ]
 ;;
 

--- a/test/test_keeper_turn_outcome.ml
+++ b/test/test_keeper_turn_outcome.ml
@@ -23,7 +23,6 @@ let outcome : TO.t testable =
     TO.equal
 
 let all = [ TO.Visible_reply; TO.Continuation_checkpoint; TO.No_visible_reply ]
-let observed_max_turns = 10
 
 let test_label_round_trip () =
   List.iter
@@ -51,27 +50,6 @@ let test_of_stop_reason () =
   in
   check outcome "completed -> visible" TO.Visible_reply
     (TO.of_stop_reason Runtime_agent.Completed);
-  check outcome "turn limit observation -> visible" TO.Visible_reply
-    (TO.of_stop_reason
-       (Runtime_agent.TurnLimitObserved { turns_used = 3; limit = 3 }));
-  check outcome "execution timeout observation -> no visible reply"
-    TO.No_visible_reply
-    (TO.of_stop_reason
-       (Runtime_agent.ExecutionTimeoutObserved
-          { elapsed_sec = 300.0
-          ; timeout_sec = 300.0
-          ; turn_count = 3
-          ; max_turns = observed_max_turns
-          }));
-  check outcome "idle timeout observation -> no visible reply"
-    TO.No_visible_reply
-    (TO.of_stop_reason
-       (Runtime_agent.ExecutionIdleTimeoutObserved
-          { idle_sec = 120.0
-          ; idle_timeout_sec = 120.0
-          ; turn_count = 3
-          ; max_turns = observed_max_turns
-          }));
   check outcome "chat yield -> checkpoint" TO.Continuation_checkpoint
     (TO.of_stop_reason
        (Runtime_agent.Yielded_to_chat_waiting { turns_used = 2 }));
@@ -87,28 +65,7 @@ let test_of_result_surface () =
     (TO.of_result_surface ~response_text:"done" Runtime_agent.Completed);
   check outcome "completed with empty text -> no visible reply"
     TO.No_visible_reply
-    (TO.of_result_surface ~response_text:"   " Runtime_agent.Completed);
-  check outcome "turn limit observation with text -> visible" TO.Visible_reply
-    (TO.of_result_surface ~response_text:"done"
-       (Runtime_agent.TurnLimitObserved { turns_used = 3; limit = 3 }));
-  check outcome "execution timeout observation -> no visible reply"
-    TO.No_visible_reply
-    (TO.of_result_surface ~response_text:"ignored"
-       (Runtime_agent.ExecutionTimeoutObserved
-          { elapsed_sec = 300.0
-          ; timeout_sec = 300.0
-          ; turn_count = 3
-          ; max_turns = observed_max_turns
-          }));
-  check outcome "idle timeout observation -> no visible reply"
-    TO.No_visible_reply
-    (TO.of_result_surface ~response_text:"ignored"
-       (Runtime_agent.ExecutionIdleTimeoutObserved
-          { idle_sec = 120.0
-          ; idle_timeout_sec = 120.0
-          ; turn_count = 3
-          ; max_turns = observed_max_turns
-          }))
+    (TO.of_result_surface ~response_text:"   " Runtime_agent.Completed)
 
 let test_autonomous_yield_boundary_contract () =
   let module F = Masc.Keeper_agent_run.For_testing in

--- a/test/test_keeper_turn_terminal_disposition_field.ml
+++ b/test/test_keeper_turn_terminal_disposition_field.ml
@@ -28,8 +28,6 @@ let constructor_cases : (string * T.t) list =
   ; "of_code/runtime_stop_not_final/completed", T.of_code "completed"
   ; "of_code/sdk_error/api_error_timeout", T.of_code "api_error_timeout"
   ; "of_code/sdk_error/api_error_overloaded", T.of_code "api_error_overloaded"
-  ; ( "of_code/sdk_error/agent_error_max_turns"
-    , T.of_code "agent_error_max_turns_exceeded:turns=10,limit=10" )
   ; "of_code/unknown", T.of_code "totally_unmapped"
   ; "of_code/empty", T.of_code ""
   ; "of_code/turn_wall_clock", T.of_code "turn_wall_clock_timeout"


### PR DESCRIPTION
## Outcome

Hard-cuts the retired execution-limit observation contract from the MASC runtime.

- removes `TurnLimitObserved`, `ExecutionTimeoutObserved`, and `ExecutionIdleTimeoutObserved` from the closed runtime stop-reason type
- removes every Keeper outcome, checkpoint, receipt, metric, dashboard, and provider-accept branch that existed only for those values
- removes tests and wire fixtures that encoded the impossible legacy limit states
- preserves the live stop reasons: completed, cooperative Keeper-local yields, and typed input-required
- preserves generic typed SDK/provider error projection using a current provider-error fixture

## Why

OAS no longer imposes or emits these implicit execution limits, and current MASC production code had no constructor for the three variants. Keeping them as “observations” created a false compatibility surface, dead success paths, and tests for states the runtime cannot produce. Metrics remain observations; they no longer manufacture a parallel execution-limit lifecycle.

This PR does not change explicit provider request fields such as caller-selected output or thinking parameters. It also does not change stream/provider attempt liveness or failure reporting.

## Verification

- `scripts/dune-local.sh build test/test_keeper_turn_outcome.exe test/test_keeper_replay_checkpoint.exe` — passed
- `test_keeper_turn_outcome.exe` — 11/11 passed
- `test_keeper_replay_checkpoint.exe` — 8/8 passed
- focused build of `test_keeper_terminal_reason_typed.exe`, `test_keeper_turn_terminal_disposition_field.exe`, and `test_keeper_turn_disposition.exe` — passed
- `test_keeper_turn_terminal_disposition_field.exe` — 4/4 passed
- `test_keeper_turn_disposition.exe` — 10/10 passed
- `test_keeper_terminal_reason_typed.exe` — changed-path matrix reached 112,000 cases with 0 mismatches; the executable then hit the pre-existing removed `goal` meta fixture tracked separately by #24716
- `ocamlformat --check` on all 19 changed OCaml files
- `git diff --check`
- 299 changed lines (`+15/-284`)
