### PR TITLE
refactor(memory): return typed librarian outcomes

### DIFF
--- a/docs/spec/12-memory-systems.md
+++ b/docs/spec/12-memory-systems.md
@@ -58,10 +58,12 @@ OAS reduces active context through its checkpoint/context APIs. MASC may
 request a configured strategy and observe the outcome, but must not rewrite
 the transcript through domain-specific text parsing.
 
-Keeper memory-bank maintenance preserves provenance and reports malformed or
-dropped records. An LLM librarian may classify or summarize candidates when a
-semantic judgment is required; deterministic code may validate schemas,
-enforce storage bounds, and order records by explicit timestamps.
+Keeper memory-bank rewriting is an explicit typed Memory operation. An LLM
+librarian returns the keep, rewrite, or forget decisions; deterministic code
+only validates their schema and provenance and atomically applies that exact
+plan. Storage pressure is observable and may request the operation, but a
+threshold, priority score, or capacity rule cannot decide which memories
+survive.
 
 ## Generation and Handoff
 

--- a/lib/keeper/keeper_agent_run_post_turn_memory.ml
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.ml
@@ -68,10 +68,35 @@ let run
     ; messages = librarian_messages
     }
   in
-  Keeper_librarian_runtime.run_best_effort
-    ~runtime_id
-    ~keeper_id:meta.name
-    librarian_input;
+  let librarian_request : Keeper_librarian_runtime.operation_request =
+    { runtime_id; keeper_id = meta.name; input = librarian_input }
+  in
+  (match Keeper_librarian_runtime.execute_operation librarian_request with
+   | Ok episode ->
+     Log.Keeper.info ~keeper_name:meta.name
+       "memory os librarian wrote episode trace_id=%s generation=%d claims=%d"
+       episode.Keeper_memory_os_types.trace_id
+       episode.generation
+       (List.length episode.claims)
+   | Error error ->
+     (match error with
+      | Keeper_librarian_runtime.Provider_slot_busy _ ->
+        Otel_metric_store.inc_counter
+          Keeper_metrics.(to_string MemoryLaneProviderSlotBusy)
+          ~labels:
+            [ "keeper", meta.name
+            ; "site", Keeper_librarian_runtime.memory_os_librarian_provider_slot_site
+            ]
+          ()
+      | _ -> ());
+     Otel_metric_store.inc_counter
+       Keeper_metrics.(to_string EpisodeCreateFailures)
+       ~labels:[ "keeper", meta.name; "site", "memory_os_librarian" ]
+       ();
+     Log.Keeper.error ~keeper_name:meta.name
+       "memory os librarian operation failed runtime=%s: %s"
+       runtime_id
+       (Keeper_librarian_runtime.operation_error_to_string error));
 
   (* Advisory delegation request drafts: keep review artifact persistence on the
      same bounded post-turn memory lane as draft-skill projection, not on the

--- a/lib/keeper/keeper_agent_run_post_turn_memory.ml
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.ml
@@ -27,9 +27,9 @@ let run
       (Keeper_tool_emission_hook.accumulator_for_keeper
          meta.Keeper_meta_contract.name)
   in
-  (* (1) deterministic write, (2) librarian extraction, (3) compaction run on
-     this keeper's memory lane (RFC-0257), detached from the turn lane. All
-     three touch the keeper's memory bank (no internal lock); the lane's
+  (* (1) deterministic write and (2) LLM librarian extraction run on this
+     keeper's memory lane (RFC-0257), detached from the turn lane. Both may
+     touch the keeper's memory stores; the lane's
      per-keeper mutex serializes them. meta/config are immutable snapshots, so
      using them after the turn returns does not race a later turn.
      See RFC #3646 Section 3: Det/NonDet boundary. *)
@@ -112,40 +112,8 @@ let run
        "delegation_requests failed: %s"
        (Printexc.to_string exn));
 
-  (* Memory bank compaction: dedup + consolidate if over threshold. *)
-  (try
-     let memory_summarizer =
-       Keeper_memory_llm_summary.make
-         ~runtime_id
-         ~keeper_name:meta.name
-         ()
-     in
-     let compaction =
-       Memory.compact_if_needed
-         ?summarizer:memory_summarizer
-         config
-         meta
-     in
-     if compaction.performed
-     then
-       Log.Keeper.info ~keeper_name:meta.name
-         "memory_compacted before=%d after=%d dropped=%d"
-         compaction.before_notes
-         compaction.after_notes
-         compaction.dropped_notes
-   with
-   | Eio.Cancel.Cancelled _ as e -> raise e
-   | exn ->
-     Otel_metric_store.inc_counter
-       Keeper_metrics.(to_string DispatchEventFailures)
-       ~labels:[ "keeper", meta.name; "site", "memory_bank_compaction" ]
-       ();
-     Log.Keeper.warn ~keeper_name:meta.name
-       "runtime=%s compaction failed: %s"
-       (Keeper_meta_contract.runtime_id_of_meta meta)
-       (Printexc.to_string exn))
   in
-  (* RFC-0257: detach (1)-(3) onto the per-keeper memory lane. When the executor
+  (* RFC-0257: detach (1)-(2) onto the per-keeper memory lane. When the executor
      switch is not initialized (tests, early startup) the lane runs them inline,
      so no memory work is lost. *)
   let (_ : Keeper_memory_lane.outcome) =

--- a/lib/keeper/keeper_agent_run_post_turn_memory.mli
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.mli
@@ -1,9 +1,9 @@
 (** Post-turn memory write series for [Keeper_agent_run.run_turn].
 
-    Extracts the four post-turn side-effect stages from Step 8 body
-    (deterministic write, episodic record, compaction, quality-metrics
-    JSONL append) into a single typed boundary so that the orchestrator
-    only sees [run ~config ~meta ...].
+    Extracts deterministic writes, LLM librarian records, and quality metrics
+    from Step 8 behind [run ~config ~meta ...]. It does not rewrite or delete
+    memory-bank rows: semantic consolidation requires an explicit typed LLM
+    Memory operation, never a storage-pressure survival rule.
 
     Each sub-stage is best-effort: non-cancel exceptions are logged and
     counted, never propagated.  [Eio.Cancel.Cancelled] is re-raised. *)

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -739,101 +739,65 @@ let provider_for_runtime ~runtime_id =
   Keeper_memory_runtime_resolution.provider_for_runtime ~runtime_id
 ;;
 
-let run_best_effort ?complete ?timeout_sec ~runtime_id ~keeper_id (inp : Keeper_librarian.input) =
-  (* [cadence_due] short-circuits after [enabled]: a disabled keeper never
-     advances its cadence counter, and a not-due turn skips extraction entirely
-     (the messages remain in the window for the next due turn). The cadence
-     counter is scoped to the active trace so a rollover does not inherit the
-     previous trace's schedule. *)
-  if enabled () && cadence_due ~keeper_id ~trace_id:inp.trace_id
-  then (
-    try
-      match Eio_context.get_switch_opt (), Eio_context.get_net_opt () with
-      | Some sw, Some net ->
-        let runtime_id = runtime_id_for_librarian ~runtime_id in
-        (match provider_for_runtime ~runtime_id with
-         | Error err ->
-           Log.Keeper.warn ~keeper_name:keeper_id
-             "memory os librarian skipped runtime=%s: %s"
-             runtime_id
-             err
-         | Ok provider_cfg ->
-           if not (Keeper_memory_llm_summary.is_direct_completion_provider provider_cfg)
-           then
-             Log.Keeper.warn ~keeper_name:keeper_id
-               "memory os librarian skipped runtime=%s: provider does not support direct completion"
-               runtime_id
-           else (
-             let clock = Eio_context.get_clock_opt () in
-             let timeout_sec =
-               Option.value timeout_sec ~default:(default_timeout_sec ())
-             in
-             match clock with
-             | None ->
-               Otel_metric_store.inc_counter
-                 Keeper_metrics.(to_string EpisodeCreateFailures)
-                 ~labels:[ "keeper", keeper_id; "site", "memory_os_librarian" ]
-                 ();
-               Log.Keeper.warn ~keeper_name:keeper_id
-                 "memory os librarian failed runtime=%s: %s"
-                 runtime_id
-                 librarian_provider_clock_unavailable_error
-             | Some clock -> (
-             match
-               with_provider_slot ~keeper_id ~clock (fun () ->
-                 extract_and_append_with_provider_classified
-                   ?complete
-                   ~clock
-                   ~timeout_sec
-                   ~sw
-                   ~net
-                   ~keeper_id
-                   ~runtime_id
-                   ~provider_cfg
-                   inp)
-             with
-             | None ->
-               Otel_metric_store.inc_counter
-                 Keeper_metrics.(to_string MemoryLaneProviderSlotBusy)
-                ~labels:
-                  [ "keeper", keeper_id; "site", memory_os_librarian_provider_slot_site ]
-                 ();
-               Log.Keeper.warn ~keeper_name:keeper_id
-                 "memory os librarian skipped runtime=%s: per-keeper provider slot busy (capacity=%d)"
-                 runtime_id
-                 (per_keeper_slot_capacity ())
-             | Some (Ok episode) ->
-               cadence_record_success ~keeper_id ~trace_id:inp.trace_id;
-               Log.Keeper.info ~keeper_name:keeper_id
-                 "memory os librarian wrote episode trace_id=%s generation=%d claims=%d"
-                 episode.Keeper_memory_os_types.trace_id
-                 episode.generation
-                 (List.length episode.claims)
-             | Some (Error err) ->
-               Otel_metric_store.inc_counter
-                 Keeper_metrics.(to_string EpisodeCreateFailures)
-                 ~labels:[ "keeper", keeper_id; "site", "memory_os_librarian" ]
-                 ();
-               if should_record_cadence_backoff_after_error err
-               then cadence_record_attempt ~keeper_id ~trace_id:inp.trace_id;
-               Log.Keeper.warn ~keeper_name:keeper_id
-                 "memory os librarian failed runtime=%s: %s; cadence deferred=%b"
-                 runtime_id
-                 (extraction_error_to_string err)
-                 (should_record_cadence_backoff_after_error err))))
-      | _ ->
-        Log.Keeper.warn ~keeper_name:keeper_id
-          "memory os librarian skipped: Eio context unavailable runtime=%s"
-          runtime_id
+type operation_request =
+  { runtime_id : string
+  ; keeper_id : string
+  ; input : Keeper_librarian.input
+  }
+
+type operation_error =
+  | Eio_context_unavailable
+  | Runtime_resolution_failed of string
+  | Direct_completion_unsupported
+  | Provider_slot_busy of { capacity : int }
+  | Extraction_failed of extraction_error
+  | Unexpected_failure of string
+
+let operation_error_to_string = function
+  | Eio_context_unavailable -> "memory os librarian Eio context unavailable"
+  | Runtime_resolution_failed detail -> "memory os librarian runtime resolution failed: " ^ detail
+  | Direct_completion_unsupported ->
+    "memory os librarian provider does not support direct completion"
+  | Provider_slot_busy { capacity } ->
+    Printf.sprintf "memory os librarian provider slot busy (capacity=%d)" capacity
+  | Extraction_failed error -> extraction_error_to_string error
+  | Unexpected_failure detail -> "memory os librarian unexpected failure: " ^ detail
+;;
+
+let execute_operation ?complete ?timeout_sec (request : operation_request) =
+  try
+    match
+      ( Eio_context.get_switch_opt ()
+      , Eio_context.get_net_opt ()
+      , Eio_context.get_clock_opt () )
     with
-    | Eio.Cancel.Cancelled _ as e -> raise e
-    | exn ->
-      Otel_metric_store.inc_counter
-        Keeper_metrics.(to_string EpisodeCreateFailures)
-        ~labels:[ "keeper", keeper_id; "site", "memory_os_librarian" ]
-        ();
-      Log.Keeper.warn ~keeper_name:keeper_id
-        "memory os librarian failed runtime=%s: %s"
-        runtime_id
-        (Printexc.to_string exn))
+    | Some sw, Some net, Some clock ->
+      let runtime_id = runtime_id_for_librarian ~runtime_id:request.runtime_id in
+      (match provider_for_runtime ~runtime_id with
+       | Error detail -> Error (Runtime_resolution_failed detail)
+       | Ok provider_cfg ->
+         if not (Keeper_memory_llm_summary.is_direct_completion_provider provider_cfg)
+         then Error Direct_completion_unsupported
+         else (
+           let timeout_sec = Option.value timeout_sec ~default:(default_timeout_sec ()) in
+           match
+             with_provider_slot ~keeper_id:request.keeper_id ~clock (fun () ->
+               extract_and_append_with_provider_classified
+                 ?complete
+                 ~clock
+                 ~timeout_sec
+                 ~sw
+                 ~net
+                 ~keeper_id:request.keeper_id
+                 ~runtime_id
+                 ~provider_cfg
+                 request.input)
+           with
+           | None -> Error (Provider_slot_busy { capacity = per_keeper_slot_capacity () })
+           | Some (Error error) -> Error (Extraction_failed error)
+           | Some (Ok episode) -> Ok episode))
+    | _ -> Error Eio_context_unavailable
+  with
+  | Eio.Cancel.Cancelled _ as error -> raise error
+  | exn -> Error (Unexpected_failure (Printexc.to_string exn))
 ;;

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -46,11 +46,12 @@ val cadence_step_keyed
 
 val cadence_due : keeper_id:string -> trace_id:string -> bool
 (** Advance the persistent cadence counter for [keeper_id] by one turn and
-    report whether extraction is due now. This is what [run_best_effort] gates
-    on. The counter is keyed by [keeper_id] and stores the active [trace_id]
-    alongside it, so a handoff rollover (a new [trace_id]) resets the cadence
-    cycle in place — bounding the table to one row per keeper. First call for an
-    unseen keeper, or the first call after a rollover, is due immediately.
+    report whether extraction is due now. The counter is keyed by [keeper_id]
+    and stores the active [trace_id] alongside it, so a handoff rollover (a new
+    [trace_id]) resets the cadence cycle in place — bounding the table to one
+    row per keeper. First call for an unseen keeper, or the first call after a
+    rollover, is due immediately. Explicit operations do not consult this
+    legacy scheduler state.
 
     Uses [Eio_guard.with_mutex] so runtime fibers take a cooperative mutex while
     focused pre-Eio tests keep a direct single-threaded path. *)
@@ -230,8 +231,7 @@ val extract_with_provider_classified
   -> Keeper_librarian.input
   -> (Keeper_memory_os_types.episode, extraction_error) result
 (** Provider-backed librarian extraction. [clock] stays optional at the API
-    boundary because [run_best_effort] may be called from contexts that cannot
-    supply an Eio clock; [None] returns
+    boundary for focused callers; [None] returns
     {!librarian_provider_clock_unavailable_error} before provider I/O because
     the provider call itself requires the clock. The extraction now runs to
     completion: [timeout_sec] no longer force-kills a legitimate in-flight
@@ -263,13 +263,31 @@ val extract_and_append_with_provider_classified
   -> Keeper_librarian.input
   -> (Keeper_memory_os_types.episode, extraction_error) result
 
-val run_best_effort
+type operation_request =
+  { runtime_id : string
+  ; keeper_id : string
+  ; input : Keeper_librarian.input
+  }
+(** Immutable input for one explicitly requested LLM Memory operation. *)
+
+type operation_error =
+  | Eio_context_unavailable
+  | Runtime_resolution_failed of string
+  | Direct_completion_unsupported
+  | Provider_slot_busy of { capacity : int }
+  | Extraction_failed of extraction_error
+  | Unexpected_failure of string
+
+val operation_error_to_string : operation_error -> string
+
+val execute_operation
   :  ?complete:complete_fn
   -> ?timeout_sec:float
-  -> runtime_id:string
-  -> keeper_id:string
-  -> Keeper_librarian.input
-  -> unit
-(** Run the opt-in post-turn librarian path.
+  -> operation_request
+  -> (Keeper_memory_os_types.episode, operation_error) result
+(** Execute one explicitly requested LLM Memory operation.
 
-    Non-cancel failures are logged and counted, never raised. *)
+    This boundary does not consult the retired enable/cadence policy and never
+    converts failure into [unit]. Cancellation propagates; every other outcome
+    is returned to its caller. Durable owner-lane settlement is a separate
+    orchestration boundary and must not infer success from this call returning. *)

--- a/lib/memory.ml
+++ b/lib/memory.ml
@@ -44,8 +44,6 @@ type compaction =
   }
 
 type read_error = Keeper_memory_recall_exn_class.t
-type consolidation_summarizer = Keeper_memory_bank.memory_consolidation_summarizer
-
 type t =
   { bank_summary : summary
   ; last_compaction : compaction
@@ -108,10 +106,6 @@ let append_from_tool_results config meta ~turn ~results =
     meta
     ~turn
     ~results
-;;
-
-let compact_if_needed ?summarizer config meta =
-  Keeper_memory_bank.compact_memory_bank_if_needed ?summarizer config meta
 ;;
 
 let summary_to_json = Keeper_memory_bank.memory_summary_to_json

--- a/lib/memory.mli
+++ b/lib/memory.mli
@@ -44,8 +44,6 @@ type compaction =
   }
 
 type read_error = Keeper_memory_recall_exn_class.t
-type consolidation_summarizer = Keeper_memory_bank.memory_consolidation_summarizer
-
 type t =
   { bank_summary : summary
   ; last_compaction : compaction
@@ -89,12 +87,6 @@ val append_from_tool_results :
   turn:int ->
   results:Yojson.Safe.t list ->
   int
-
-val compact_if_needed :
-  ?summarizer:consolidation_summarizer ->
-  Workspace.config ->
-  Keeper_meta_contract.keeper_meta ->
-  compaction
 
 val summary_to_json : summary -> Yojson.Safe.t
 val compaction_to_json : compaction -> Yojson.Safe.t

--- a/test/test_keeper_librarian_retry.ml
+++ b/test/test_keeper_librarian_retry.ml
@@ -83,6 +83,18 @@ let parse_retry_error_to_string = function
 let unparseable ?raw_evidence reason =
   R.Unparseable (R.unparseable_response ?raw_evidence reason)
 
+let test_operation_returns_missing_context () =
+  let input : Lib.input = { trace_id = "typed-operation"; generation = 1; messages = [] } in
+  let request : R.operation_request =
+    { runtime_id = "typed-runtime"; keeper_id = "typed-keeper"; input }
+  in
+  match R.execute_operation request with
+  | Error R.Eio_context_unavailable -> ()
+  | Error error ->
+    Alcotest.failf "unexpected operation error: %s" (R.operation_error_to_string error)
+  | Ok _ -> Alcotest.fail "operation unexpectedly ran without an installed Eio context"
+;;
+
 let nudge_count messages =
   List.length
     (List.filter
@@ -198,7 +210,7 @@ let test_nonempty_unparseable_evidence_outlives_empty_retry () =
 (* Drive [cadence_step] sequentially from a fresh keeper (counter -1) for
    [turns] turns, collecting the [due] decision each turn. When a turn is due
    we simulate a successful extraction by resetting the counter to 0, matching
-   the behavior of [run_best_effort] calling [cadence_record_success]. *)
+   the legacy cadence table transitions around [cadence_record_success]. *)
 let run_cadence ~cadence ~turns =
   let counter = ref (-1) in
   List.init turns (fun _ ->
@@ -273,8 +285,8 @@ let test_cadence_error_backoff_policy () =
   check bool "missing provider clock does not claim a completed attempt" false
     (R.should_record_cadence_backoff_after_error R.Provider_clock_unavailable)
 
-(* [cadence_due] drives the real per-(keeper, trace) counter table (the gate
-   [run_best_effort] uses). A fresh pair is due immediately, and successful
+(* [cadence_due] drives the legacy per-(keeper, trace) counter table. A fresh
+   pair is due immediately, and successful
    structured extractions are due once per configured period. Asserted as
    period-invariants so they hold for any configured cadence. *)
 let test_cadence_due_periodic () =
@@ -537,6 +549,12 @@ let () =
   Eio_main.run @@ fun _env ->
   run "keeper_librarian_retry"
     [
+      ( "operation",
+        [ test_case
+            "missing Eio capabilities is typed failure"
+            `Quick
+            test_operation_returns_missing_context
+        ] );
       ( "parse_retry",
         [
           test_case "succeeds on first attempt" `Quick test_succeeds_first_attempt;


### PR DESCRIPTION
## Outcome

Replaces the post-turn librarian's `unit`/best-effort boundary with an immutable typed request and an explicit result.

- `operation_request` carries runtime, Keeper, and typed librarian input
- Eio capability, runtime resolution, provider capability, provider-slot, extraction, and unexpected failures are closed variants
- the production call no longer consults the env enable flag or cadence counter
- the caller records failures at ERROR and preserves the provider-slot metric
- cancellation still propagates

This PR does not claim durable settlement. The result is now available for the next stacked owner-lane queue/receipt change; returning from this function is explicitly not an acknowledgement.

## Verification

- `scripts/dune-local.sh build test/test_keeper_librarian_retry.exe`
- direct focused executable: 32/32 tests pass
- `python3 scripts/check_test_coverage.py` against stacked base — pass without waiver
- `ocamlc -stop-after parsing` on every changed OCaml file
- `ocamlformat --check` on every changed OCaml file
- `git diff --check`

Diff: 143 additions / 118 deletions.