### PR TITLE
feat(fusion): persist completion outbox

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -1017,8 +1017,6 @@ trigger_policy = "mention_or_thread"
 [fusion]
 enabled = true
 default_preset = "trio"
-# - staged_judge_group_size: staged_judge_of_judges의 고정 reducer group 크기.
-staged_judge_group_size = 3
 
 # 패널 프리셋. 패널 답변은 free text다. 2026-07-01 사고(ollama.com cloud가 json_schema를
 # 조용히 무시 → 패널 전멸) 이후 패널의 provider-native structured output 요구는 제거됐다
@@ -1053,17 +1051,14 @@ judge_timeout_s = 300.0
 web_tools = false
 
 # ── JoJ-capable preset (RFC-0283 judge-of-judges) ───────────────────────────
-# masc_fusion topology="judge_of_judges"는 preset에 1차 심판 >= 2명을 요구한다
-# (fusion_orchestrator.run_judge_of_judges). trio는 단일 judge라 JoJ 호출이 항상
-# "requires >= 2 judges"로 fail-closed된다 → 키퍼가 JoJ topology를 쓸 수 없었다.
-# quorum은 서로 다른 렌즈(evidence/coverage)의 1차 심판 2명을 두고, meta judge(judge=)가
-# 두 종합을 재조정한다. 키퍼 사용: masc_fusion preset="quorum" topology="judge_of_judges".
+# masc_fusion topology="judge_of_judges"는 preset의 typed judge 목록 전체를
+# 설정 순서대로 실행하고 meta judge(judge=)가 그 종합을 재조정한다.
+# quorum은 서로 다른 evidence/coverage 렌즈를 제공한다.
+# 키퍼 사용: masc_fusion preset="quorum" topology="judge_of_judges".
 # Panel models and Fusion judge/refine/meta paths request provider-native
 # structured output, so every panel and judge runtime below must declare
 # supports-structured-output=true. Distinct labels preserve lens identity while
 # the schema contract prevents config drift back to JSON-mode-only runtimes.
-# staged_judge_of_judges는 [fusion].staged_judge_group_size(=3)의 정확한 배수
-# 그룹을 요구하므로 quorum(2 judges)은 비대상 — 별도 preset 필요.
 [fusion.presets.quorum]
 panel = [
   "ollama_cloud.ollama-cloud-devstral-2-123b",
@@ -1086,11 +1081,11 @@ one resolved answer. Respond with ONLY the requested JSON object, no prose and n
 """
 panel_timeout_s = 300.0
 judge_timeout_s = 300.0
-# meta/stage-meta reducer 구조적 타임아웃. 미지정 시 judge_timeout_s와 동일.
+# meta reducer 구조적 타임아웃. 미지정 시 judge_timeout_s와 동일.
 meta_timeout_s = 300.0
 web_tools = false
 
-# 1차 심판 — 서로 다른 렌즈로 패널을 독립 종합한다 (JoJ requires >= 2; RFC-0283).
+# 1차 심판 — 서로 다른 렌즈로 패널을 독립 종합한다.
 # label이 정체성을 주므로 distinct lens는 distinct identity가 된다 (Duplicate_judge 회피).
 # Strict structured-output support is mandatory for panel and judge runtimes in
 # this seed. Some model families overlap across panel and judge lanes because the
@@ -1118,24 +1113,10 @@ Respond with ONLY the requested JSON object, no prose and no code fences.
 """
 timeout_s = 300.0
 
-# ── Staged-JoJ-capable preset (RFC-0283 staged_judge_of_judges) ──────────────
-# staged_judge_of_judges는 judge 수가 [fusion].staged_judge_group_size(=3)의
-# 정확한 배수이면서 group_size*2(=6) 이상이어야 한다 (fusion_policy.staged_judge_groups).
-# 지금까지 충족 preset이 0이라 topology가 도구 스키마에 노출되고도 모든 호출이
-# config 에러로 fail-closed되는 죽은 옵션이었다. council은 6개 lens 심판을
-# 3개씩 2 stage로 나눈다: stage 1 = evidence/coverage/risk, stage 2 =
-# feasibility/simplicity/adversarial. 각 stage meta가 그룹 종합을 만들고 최종
-# meta judge(judge=)가 stage 종합들을 재조정한다. label이 정체성을 주므로
-# 같은 모델이 다른 lens로 반복 등장해도 Duplicate_judge가 아니다 (quorum 주석과
-# 동일 계약). judge/meta 경로는 provider-native structured output을 요구하므로
-# 심판 런타임은 전부 supports-structured-output=true 선언 모델만 쓴다.
-# 비용/지연: LLM 호출 12회(panel 3 + 1차 심판 6 + stage meta 2 + 최종 meta 1).
-# 실행은 4단 순차 파이프라인(panel → 1차 심판 병렬 → stage meta 병렬 → 최종
-# meta, fusion_orchestrator run_staged_judge_of_judges)이라 각 단의
-# timeout(300s)이 누적된다 — 동시성 캡이 각 단을 한 웨이브로 소화할 때 최악
-# ~20분. 빠른 종합이 필요하면 단이 짧은 quorum/judge_of_judges 계열을 쓴다.
-# 키퍼 사용: masc_fusion preset="council" topology="staged_judge_of_judges"
-# (judge_of_judges topology도 동일 preset으로 사용 가능 — 6 lens 병렬 후 meta).
+# ── Multi-lens council preset ────────────────────────────────────────────────
+# council은 여섯 typed lens를 선언 순서대로 모두 실행한다. label이 정체성을
+# 부여하므로 같은 모델이 다른 lens로 반복 등장해도 Duplicate_judge가 아니다.
+# 키퍼 사용: masc_fusion preset="council" topology="judge_of_judges".
 [fusion.presets.council]
 panel = [
   "ollama_cloud.ollama-cloud-devstral-2-123b",
@@ -1149,10 +1130,10 @@ own view.
 """
 judge = "ollama_cloud.ollama-cloud-ministral-3-14b"
 judge_system_prompt = """
-You are the meta-judge. You are given stage syntheses, each produced by a group \
-of judges evaluating the same panel of model answers through different lenses. \
-Reconcile them: where the stages agree, state the consensus; where they diverge, \
-adjudicate with reasons; surface any blind spot that a single stage missed. \
+You are the meta-judge. You are given judge syntheses evaluating the same panel \
+of model answers through different lenses. Reconcile them: where the judges \
+agree, state the consensus; where they diverge, adjudicate with reasons; surface \
+any blind spot that a single lens missed. \
 Produce one resolved answer. Respond with ONLY the requested JSON object, no \
 prose and no code fences.
 """

--- a/docs/TOML-RELOAD-MATRIX.md
+++ b/docs/TOML-RELOAD-MATRIX.md
@@ -87,8 +87,7 @@ Operational meaning:
   watcher.
 - `[fusion]` is also read from this file by `Fusion_config_loader.load` at
   `masc_fusion` handler time. Fusion edits therefore take effect on the next
-  `masc_fusion` request, including `staged_judge_group_size`, and invalid
-  `[fusion]` config fails that request closed.
+  `masc_fusion` request, and invalid `[fusion]` config fails that request closed.
 
 ## Rules for New TOML Files
 

--- a/lib/fusion/fusion_metrics.ml
+++ b/lib/fusion/fusion_metrics.ml
@@ -17,7 +17,6 @@ let topology_label = function
   | Refine -> "refine"
   | Conditional -> "conditional"
   | Judge_of_judges -> "judge_of_judges"
-  | Staged_judge_of_judges -> "staged_judge_of_judges"
 
 let judge_role_of_outcome = function
   | Synthesized node -> node.role

--- a/lib/fusion/fusion_orchestrator.ml
+++ b/lib/fusion/fusion_orchestrator.ml
@@ -101,9 +101,6 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
           let successful_syntheses =
             Fusion_orchestrator_judge_wave.successful_syntheses
           in
-          let successful_pair_syntheses =
-            Fusion_orchestrator_judge_wave.successful_pair_syntheses
-          in
           let firsts_usage = Fusion_orchestrator_judge_wave.firsts_usage in
           let all_fail_error_of_runs =
             Fusion_orchestrator_judge_wave.all_fail_error_of_runs
@@ -124,10 +121,10 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
           in
           let run_judge_of_judges () =
             match preset.Fusion_policy.judges with
-            | [] | [ _ ] ->
+            | [] ->
               ( Error
                   ( Fusion_types.Internal_error
-                      "judge_of_judges requires >= 2 judges configured in the preset ([[fusion.presets.<name>.judges]])"
+                      "judge_of_judges requires a configured judge ([[fusion.presets.<name>.judges]])"
                   , Fusion_types.zero_usage )
               , [] )
             | judges ->
@@ -179,145 +176,6 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                                { Fusion_types.failed_role = Meta
                                ; failure
                                ; usage = meta_u
-                               ; elapsed_s
-                               }
-                           ] )))
-          in
-          let run_staged_judge_of_judges () =
-            let group_size = policy.Fusion_policy.staged_judge_group_size in
-            match
-              Fusion_policy.staged_judge_groups ~group_size preset.Fusion_policy.judges
-            with
-            | Error e ->
-              ( Error
-                  ( Fusion_types.Internal_error (Fusion_policy.staged_judge_group_error_message e)
-                  , Fusion_types.zero_usage )
-              , [] )
-            | Ok _groups ->
-              let firsts =
-                run_first_judges preset.Fusion_policy.judges
-                |> with_timeout_fallback ~run_fallback_judge
-              in
-              let rec take n acc rest =
-                if n = 0
-                then (List.rev acc, rest)
-                else
-                  match rest with
-                  | [] -> (List.rev acc, [])
-                  | x :: xs -> take (n - 1) (x :: acc) xs
-              in
-              let rec chunk_firsts acc rest =
-                match rest with
-                | [] -> List.rev acc
-                | _ ->
-                  let group, rest = take group_size [] rest in
-                  chunk_firsts (group :: acc) rest
-              in
-              let first_groups = chunk_firsts [] firsts in
-              let run_stage_meta (stage_num, stage_firsts) =
-                let stage_id = Printf.sprintf "stage-%d" stage_num in
-                let first_nodes = first_judge_nodes stage_firsts in
-                let ok_priors = successful_syntheses stage_firsts in
-                match ok_priors with
-                | [] ->
-                  let err =
-                    all_fail_error_of_runs
-                      ~fallback:
-                        (Fusion_types.Internal_error
-                           (Printf.sprintf
-                              "staged_judge_of_judges %s: no judge produced a synthesis"
-                              stage_id))
-                      stage_firsts
-                  in
-                  ((stage_id, Error err), first_nodes)
-                | (_, first_s, _) :: _ ->
-                  let firsts_usage = firsts_usage stage_firsts in
-                  let priors = List.map (fun (id, s, _) -> (id, s)) ok_priors in
-                  (match
-                        Fusion_judge.run_meta ~sw ~net
-                          ~timeout_s:preset.Fusion_policy.meta_timeout_s
-                          ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
-                          ~judge_model:preset.Fusion_policy.judge
-                          ~question:req.Fusion_types.prompt ~panel ~priors
-                          ~web_tools:judge_web_tools ()
-                      with
-                      | Ok (stage_s, stage_u) ->
-                        ( ( stage_id
-                          , Ok (stage_s, Fusion_types.add_usage firsts_usage stage_u) )
-                        , first_nodes
-                          @ [ Fusion_types.Synthesized
-                                { Fusion_types.role = Stage_meta stage_num
-                                ; synthesis = stage_s
-                                ; usage = stage_u
-                                }
-                            ] )
-                      | Error (failure, stage_u) ->
-                        Log.Keeper.warn ~keeper_name:req.Fusion_types.keeper
-                          "fusion run %s staged JOJ %s meta judge failed, keeping first judge synthesis: %s"
-                          req.Fusion_types.run_id stage_id
-                          (Fusion_types.judge_failure_text failure);
-                        let elapsed_s = elapsed_since_t0 () in
-                        ( ( stage_id
-                          , Ok (first_s, Fusion_types.add_usage firsts_usage stage_u) )
-                        , first_nodes
-                          @ [ Fusion_types.Judge_failed
-                                { Fusion_types.failed_role = Stage_meta stage_num
-                                ; failure
-                                ; usage = stage_u
-                                ; elapsed_s
-                                }
-                            ] ))
-              in
-              let indexed_groups = List.mapi (fun i group -> (i + 1, group)) first_groups in
-              let stage_runs =
-                Eio.Fiber.List.map
-                  ~max_fibers:(max 1 (List.length indexed_groups))
-                  run_stage_meta indexed_groups
-              in
-              let stage_results = List.map fst stage_runs in
-              let stage_nodes = List.concat_map snd stage_runs in
-              let ok_stages = successful_pair_syntheses stage_results in
-              (match ok_stages with
-               | [] ->
-                 let err =
-                   Fusion_types.all_fail_error
-                     ~fallback:
-                       (Fusion_types.Internal_error "staged_judge_of_judges: no stage produced a synthesis")
-                     stage_results
-                 in
-                 (Error err, stage_nodes)
-               | (_, first_stage_s, _) :: _ ->
-                 let stage_usage = Fusion_types.sum_all_usage stage_results in
-                 let priors = List.map (fun (id, s, _) -> (id, s)) ok_stages in
-                 (match
-                       Fusion_judge.run_meta ~sw ~net
-                         ~timeout_s:preset.Fusion_policy.meta_timeout_s
-                         ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
-                         ~judge_model:preset.Fusion_policy.judge
-                         ~question:req.Fusion_types.prompt ~panel ~priors
-                         ~web_tools:judge_web_tools ()
-                     with
-                     | Ok (final_s, final_u) ->
-                       ( Ok (final_s, Fusion_types.add_usage stage_usage final_u)
-                       , stage_nodes
-                         @ [ Fusion_types.Synthesized
-                               { Fusion_types.role = Final_meta
-                               ; synthesis = final_s
-                               ; usage = final_u
-                               }
-                           ] )
-                     | Error (failure, final_u) ->
-                       Log.Keeper.warn ~keeper_name:req.Fusion_types.keeper
-                         "fusion run %s staged JOJ final meta judge failed, keeping first stage synthesis: %s"
-                         req.Fusion_types.run_id
-                         (Fusion_types.judge_failure_text failure);
-                       let elapsed_s = elapsed_since_t0 () in
-                       ( Ok (first_stage_s, Fusion_types.add_usage stage_usage final_u)
-                       , stage_nodes
-                         @ [ Fusion_types.Judge_failed
-                               { Fusion_types.failed_role = Final_meta
-                               ; failure
-                               ; usage = final_u
                                ; elapsed_s
                                }
                            ] )))
@@ -381,7 +239,6 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                          { Fusion_types.role = Single; synthesis = s1; usage = u1 }
                      ] ))
             | Fusion_types.Judge_of_judges -> run_judge_of_judges ()
-            | Fusion_types.Staged_judge_of_judges -> run_staged_judge_of_judges ()
           in
           let judge = judge_full |> Result.map fst |> Result.map_error fst in
           let judge_usage =

--- a/lib/fusion/fusion_orchestrator.mli
+++ b/lib/fusion/fusion_orchestrator.mli
@@ -25,12 +25,9 @@ type outcome =
       [Refine]은 panel→judge→judge'(1차 종합 재검토)→sink, [Conditional]은 1차 판정이
       [Insufficient]일 때만 refine하고 그 외엔 [Simple]처럼 1차 종합 그대로
       ([Fusion_types.decision_warrants_escalation]), [Judge_of_judges]는 preset.judges의
-      N개(>=2) 1차 심판이 같은 패널을 병렬 독립 종합하고 preset.judge(meta)가 reconcile한다
-      (RFC-0283; judges<2면 에러, 1차 전원 실패면 첫 에러, meta 실패면 1차 첫 성공으로 degrade).
-      [Staged_judge_of_judges]는 같은 1차 심판 목록을
-      [policy.staged_judge_group_size]의 정확한 그룹들로 줄이고, 각 stage meta 결과를
-      final meta가 다시 reconcile한다. ragged/too-small judge 목록은 실행 전 에러로
-      fail-closed하며, nested [masc_fusion] 호출은 하지 않는다.
+      typed 목록 전체를 그 순서로 같은 패널에 병렬 실행하고
+      preset.judge(meta)가 reconcile한다 (RFC-0283; 빈 목록은 에러,
+      1차 전원 실패면 첫 에러, meta 실패면 1차 첫 성공으로 degrade).
       단일-심판 위상에서 1차 심판이 실패하면 [Simple]과 동일하게 에러를 전파하고,
       refine(2차)/meta 심판이 실패하면 1차 종합으로 graceful degrade한다(warn 로깅).
       refine/JOJ는 관여한 심판 usage를 모두 합산해 sink로 보낸다.

--- a/lib/fusion/fusion_orchestrator_judge_wave.ml
+++ b/lib/fusion/fusion_orchestrator_judge_wave.ml
@@ -88,7 +88,6 @@ let run_first_judges
       ~judge_web_tools
   in
   Eio.Fiber.List.map
-    ~max_fibers:(max 1 (List.length judges))
     (run_first_judge ~already_timed_out:false)
     judges
 ;;

--- a/lib/fusion/fusion_orchestrator_judge_wave.mli
+++ b/lib/fusion/fusion_orchestrator_judge_wave.mli
@@ -54,9 +54,8 @@ val with_timeout_fallback
   :  run_fallback_judge:(unit -> judge_run option)
   -> judge_run list
   -> judge_run list
-(** Append the configured fallback judge when the whole first-judge wave failed
-    only with timeouts. Shared by JOJ and staged JOJ so both
-    topologies honor [fallback_judge_model] consistently. *)
+(** Append the configured fallback judge when the complete first-judge list
+    failed only with timeouts. *)
 
 val run_fallback_judge
   :  sw:Eio.Switch.t

--- a/lib/fusion/fusion_panel.ml
+++ b/lib/fusion/fusion_panel.ml
@@ -95,7 +95,6 @@ let run ~sw ~net ~outer_timeout_s ~groups ~prompt ()
   in
   let built = List.rev built in
   let build_failures = List.rev build_failures in
-  let max_fibers = max 1 (List.length built) in
   (* 2. 모든 그룹을 하나의 Async_agent.all에 union으로 던진다 — 이종 설정은 이미 각
         agent에 baked되어 있으므로 단일 fan-out으로 충분. 외곽 run_safe는 그룹 timeout
         중 max로 전체 멈춤을 막는 상한.
@@ -107,7 +106,7 @@ let run ~sw ~net ~outer_timeout_s ~groups ~prompt ()
     match
       Masc_oas_bridge.run_safe ~caller:"fusion_panel" ~timeout_s:outer_timeout_s (fun () ->
         Ok
-          (Agent_sdk.Async_agent.all ~sw ~max_fibers
+          (Agent_sdk.Async_agent.all ~sw
              (List.map (fun (agent, _panelist, _model) -> (agent, prompt)) built)))
     with
     | Ok run_results ->

--- a/lib/fusion/fusion_sink.ml
+++ b/lib/fusion/fusion_sink.ml
@@ -268,7 +268,7 @@ let judge_node_meta (o : Fusion_types.judge_outcome) : Yojson.Safe.t =
    (mirrors Keeper_chat_broadcast). An unknown run_id is a no-op. *)
 let broadcast_run_status ~registry ~run_id =
   try
-    match Fusion_run_registry.get registry ~run_id with
+    match Fusion_run_registry.get registry ~operation_id:run_id with
     | None -> ()
     | Some run ->
       Sse.broadcast
@@ -284,7 +284,7 @@ let broadcast_run_status ~registry ~run_id =
 
 let record_completion ~keeper ~run_id ?failure ?failure_code ~ok () =
   match
-    Fusion_run_registry.mark_completed (Fusion_run_registry.global ()) ~run_id
+    Fusion_run_registry.mark_completed (Fusion_run_registry.global ()) ~operation_id:run_id
       ?failure ?failure_code ~ok ()
   with
   | Ok () -> ()

--- a/lib/fusion/fusion_tool.ml
+++ b/lib/fusion/fusion_tool.ml
@@ -15,7 +15,7 @@ let status_result ~tool_name ~class_ ~ok fields =
 
 let record_completion ~keeper ~run_id ?failure ?failure_code ~ok () =
   match
-    Fusion_run_registry.mark_completed (Fusion_run_registry.global ()) ~run_id
+    Fusion_run_registry.mark_completed (Fusion_run_registry.global ()) ~operation_id:run_id
       ?failure ?failure_code ~ok ()
   with
   | Ok () -> ()
@@ -145,13 +145,14 @@ let handle_with_runner_result ~run_orchestrator ~sw ~net ~base_dir ~keeper ~now_
         ; ("reason", `String (Fusion_types.deny_reason_label reason))
         ]
     | Fusion_types.Allow allowed ->
+      let operation : Fusion_types.fusion_operation = { request = allowed; topology } in
       (* RFC-0266 §7: 진행중 가시성을 위해 fork 직전 run을 Running으로 등록한다
          (sink/실패 경로가 Completed로 갱신). Durable register가 실패하면 worker를
          시작하지 않는다. 시작했지만 복구할 receipt가 없는 상태를 만들 수 없기
          때문이다. *)
       (match
-         Fusion_run_registry.register_running (Fusion_run_registry.global ()) ~run_id
-           ~keeper ~preset ~started_at:now_unix
+         Fusion_run_registry.register_running (Fusion_run_registry.global ()) ~operation
+           ~started_at:now_unix
        with
        | Error error ->
          status_result

--- a/lib/fusion_core/dune
+++ b/lib/fusion_core/dune
@@ -10,6 +10,6 @@
  (name masc_fusion_core)
  (public_name masc.fusion_core)
  (wrapped false)
- (libraries fs_compat masc_log yojson otoml)
+ (libraries fs_compat masc_log yojson otoml threads)
  (preprocess
   (pps ppx_deriving_yojson ppx_deriving.show ppx_deriving.eq)))

--- a/lib/fusion_core/fusion_completion_outbox.ml
+++ b/lib/fusion_core/fusion_completion_outbox.ml
@@ -1,0 +1,198 @@
+module Completion_address = struct
+  type t = Address of string [@@deriving yojson, show, eq]
+
+  let of_opaque_string value = Address value
+  let to_opaque_string (Address value) = value
+end
+
+type completion_payload =
+  { content : string
+  ; evidence_ref : string option
+  }
+[@@deriving yojson, show, eq]
+
+type completion =
+  | Succeeded of completion_payload
+  | Failed of completion_payload
+[@@deriving yojson, show, eq]
+
+type item =
+  { operation_id : string
+  ; address : Completion_address.t
+  ; completion : completion
+  }
+[@@deriving show, eq]
+
+type error =
+  | Persistence_failed of { path : string; detail : string }
+  | Unknown_address of string
+  | Address_conflict of string
+  | Completion_conflict of string
+  | Unknown_completion of string
+
+type registration =
+  { operation_id : string
+  ; address : Completion_address.t
+  }
+[@@deriving yojson]
+
+type completion_event =
+  { operation_id : string
+  ; completion : completion
+  }
+[@@deriving yojson]
+
+type event =
+  | Registered_address of registration
+  | Queued_completion of completion_event
+  | Acknowledged_completion of string
+[@@deriving yojson]
+
+type register_receipt = Registered | Already_registered
+type completion_receipt = Queued | Already_pending | Already_delivered
+type acknowledgement_receipt = Acknowledged | Already_acknowledged
+
+module By_id = Map.Make (String)
+
+type state =
+  { addresses : Completion_address.t By_id.t
+  ; pending : item By_id.t
+  ; delivered : completion By_id.t
+  }
+
+type t =
+  { state : state Atomic.t
+  ; path : string option
+  ; lock : Mutex.t
+  }
+
+let empty = { addresses = By_id.empty; pending = By_id.empty; delivered = By_id.empty }
+let create ?path () = { state = Atomic.make empty; path; lock = Mutex.create () }
+
+let error_to_string = function
+  | Persistence_failed { path; detail } ->
+    Printf.sprintf "fusion completion outbox write failed for %s: %s" path detail
+  | Unknown_address id -> Printf.sprintf "fusion operation %s has no completion address" id
+  | Address_conflict id -> Printf.sprintf "fusion operation %s has a conflicting address" id
+  | Completion_conflict id -> Printf.sprintf "fusion operation %s has a conflicting completion" id
+  | Unknown_completion id -> Printf.sprintf "fusion operation %s has no pending completion" id
+;;
+
+let apply_event state = function
+  | Registered_address { operation_id; address } ->
+    (match By_id.find_opt operation_id state.addresses with
+     | None -> Ok { state with addresses = By_id.add operation_id address state.addresses }
+     | Some existing when Completion_address.equal existing address -> Ok state
+     | Some _ -> Error (Address_conflict operation_id))
+  | Queued_completion { operation_id; completion } ->
+    (match By_id.find_opt operation_id state.pending, By_id.find_opt operation_id state.delivered with
+     | Some item, _ when equal_completion item.completion completion -> Ok state
+     | Some _, _ -> Error (Completion_conflict operation_id)
+     | None, Some existing when equal_completion existing completion -> Ok state
+     | None, Some _ -> Error (Completion_conflict operation_id)
+     | None, None ->
+       (match By_id.find_opt operation_id state.addresses with
+        | None -> Error (Unknown_address operation_id)
+        | Some address ->
+          let item = { operation_id; address; completion } in
+          Ok { state with pending = By_id.add operation_id item state.pending }))
+  | Acknowledged_completion operation_id ->
+    (match By_id.find_opt operation_id state.pending with
+     | Some item ->
+       Ok
+         { state with
+           pending = By_id.remove operation_id state.pending
+         ; delivered = By_id.add operation_id item.completion state.delivered
+         }
+     | None when By_id.mem operation_id state.delivered -> Ok state
+     | None -> Error (Unknown_completion operation_id))
+;;
+
+let append t event =
+  match t.path with
+  | None -> Ok ()
+  | Some path ->
+    (try
+       Fs_compat.append_jsonl path (event_to_yojson event);
+       Ok ()
+     with
+     | exn ->
+       let error = Persistence_failed { path; detail = Printexc.to_string exn } in
+       Log.Misc.error "%s" (error_to_string error);
+       Error error)
+;;
+
+type commit = Changed of state | Unchanged of state
+
+let commit t event =
+  Mutex.protect t.lock (fun () ->
+    let before = Atomic.get t.state in
+    match apply_event before event with
+    | Error _ as error -> error
+    | Ok after when before == after -> Ok (Unchanged after)
+    | Ok after ->
+      (match append t event with
+       | Error _ as error -> error
+       | Ok () ->
+         Atomic.set t.state after;
+         Ok (Changed after)))
+;;
+
+let register_address t ~operation_id address =
+  commit t (Registered_address { operation_id; address })
+  |> Result.map (function Changed _ -> Registered | Unchanged _ -> Already_registered)
+;;
+
+let complete t ~operation_id completion =
+  commit t (Queued_completion { operation_id; completion })
+  |> Result.map (function
+    | Changed _ -> Queued
+    | Unchanged state ->
+      if By_id.mem operation_id state.delivered then Already_delivered else Already_pending)
+;;
+
+let acknowledge t ~operation_id =
+  commit t (Acknowledged_completion operation_id)
+  |> Result.map (function Changed _ -> Acknowledged | Unchanged _ -> Already_acknowledged)
+;;
+
+let pending t = Atomic.get t.state |> fun state -> By_id.bindings state.pending |> List.map snd
+
+let replay path =
+  if not (Fs_compat.file_exists path)
+  then create ~path ()
+  else (
+  let state, errors =
+    try
+      let (state, errors, _), _ =
+        Fs_compat.fold_appended_lines ~path ~from:0 ~init:(empty, [], 1)
+          ~f:(fun (state, errors, line_no) line ->
+            let parsed =
+              try event_of_yojson (Yojson.Safe.from_string line) with
+              | exn -> Error (Printexc.to_string exn)
+            in
+            match parsed with
+            | Error detail -> state, (line_no, detail) :: errors, line_no + 1
+            | Ok event ->
+              (match apply_event state event with
+               | Ok state -> state, errors, line_no + 1
+               | Error error -> state, (line_no, error_to_string error) :: errors, line_no + 1))
+      in
+      state, List.rev errors
+    with
+    | exn ->
+      Log.Misc.error "fusion completion outbox replay failed for %s: %s" path (Printexc.to_string exn);
+      empty, []
+  in
+  (match errors with
+   | [] -> ()
+   | (line_no, detail) :: _ ->
+     Log.Misc.error
+       "fusion completion outbox skipped %d invalid event(s); first=%s:%d: %s"
+       (List.length errors) path line_no detail);
+  { state = Atomic.make state; path = Some path; lock = Mutex.create () })
+;;
+
+let global_state = Atomic.make (create ())
+let global () = Atomic.get global_state
+let set_global value = Atomic.set global_state value

--- a/lib/fusion_core/fusion_completion_outbox.mli
+++ b/lib/fusion_core/fusion_completion_outbox.mli
@@ -1,0 +1,60 @@
+(** Durable, product-neutral Fusion completion delivery state. *)
+
+module Completion_address : sig
+  type t [@@deriving yojson, show, eq]
+
+  val of_opaque_string : string -> t
+  val to_opaque_string : t -> string
+  (** Fusion preserves this value exactly; only an upper adapter interprets it. *)
+end
+
+type completion_payload =
+  { content : string
+  ; evidence_ref : string option
+  }
+[@@deriving yojson, show, eq]
+
+type completion =
+  | Succeeded of completion_payload
+  | Failed of completion_payload
+[@@deriving yojson, show, eq]
+
+type item =
+  { operation_id : string
+  ; address : Completion_address.t
+  ; completion : completion
+  }
+[@@deriving show, eq]
+
+type error =
+  | Persistence_failed of { path : string; detail : string }
+  | Unknown_address of string
+  | Address_conflict of string
+  | Completion_conflict of string
+  | Unknown_completion of string
+
+val error_to_string : error -> string
+
+type register_receipt = Registered | Already_registered
+type completion_receipt = Queued | Already_pending | Already_delivered
+type acknowledgement_receipt = Acknowledged | Already_acknowledged
+
+type t
+
+val create : ?path:string -> unit -> t
+val replay : string -> t
+(** Hydrate exact addresses, pending completions, and acknowledgements. Invalid
+    JSON or impossible event order is logged and never treated as success. *)
+
+val register_address :
+  t -> operation_id:string -> Completion_address.t -> (register_receipt, error) result
+
+val complete :
+  t -> operation_id:string -> completion -> (completion_receipt, error) result
+
+val acknowledge :
+  t -> operation_id:string -> (acknowledgement_receipt, error) result
+
+val pending : t -> item list
+val global : unit -> t
+val set_global : t -> unit

--- a/lib/fusion_core/fusion_config.ml
+++ b/lib/fusion_core/fusion_config.ml
@@ -9,7 +9,6 @@ type config_error =
   | Duplicate_panelist of string * string
   | Missing_prompt of string
   | Missing_judge_model of string
-  | Invalid_staged_judge_group_size of int
   | Missing_default_preset of string
   | Unexpected_field of string * string
       (** (config location, field): Fusion schema에 없는 필드. *)
@@ -23,7 +22,6 @@ type config_error =
 let disabled : Fusion_policy.t =
   { enabled = false
   ; default_preset = ""
-  ; staged_judge_group_size = Fusion_policy.default_staged_judge_group_size
   ; presets = []
   }
 
@@ -197,10 +195,6 @@ let parse_enabled (toml : Otoml.t) : (Fusion_policy.t, config_error list) result
   let default_preset =
     Otoml.find_or ~default:"" toml Otoml.get_string [ "fusion"; "default_preset" ]
   in
-  let staged_judge_group_size =
-    Otoml.find_or ~default:Fusion_policy.default_staged_judge_group_size toml
-      Otoml.get_integer [ "fusion"; "staged_judge_group_size" ]
-  in
   let preset_entries =
     match Otoml.find_opt toml Otoml.get_table [ "fusion"; "presets" ] with
     | Some entries -> entries
@@ -212,13 +206,6 @@ let parse_enabled (toml : Otoml.t) : (Fusion_policy.t, config_error list) result
   (* 추가 검증 — enabled일 때만 강제 (disabled면 빈 config 허용). *)
   let errors =
     if enabled && presets = [] then Empty_presets :: errors else errors
-  in
-  (* Staged JOJ uses this as an exact reducer group size.  Values below 2
-     silently degenerate the tree into pass-through, so reject them at load. *)
-  let errors =
-    if staged_judge_group_size < Fusion_policy.min_staged_judge_group_size
-    then Invalid_staged_judge_group_size staged_judge_group_size :: errors
-    else errors
   in
   (* enabled면 default_preset가 비어있지 않고 presets에 존재해야 한다. preset 생략
      호출이 default_preset로 폭빽하는데, ""는 find_preset에서 항상 None→Preset_unknown
@@ -239,14 +226,20 @@ let parse_enabled (toml : Otoml.t) : (Fusion_policy.t, config_error list) result
     Ok
       { Fusion_policy.enabled
       ; default_preset
-      ; staged_judge_group_size
       ; presets
       }
 
 let of_toml (toml : Otoml.t) : (Fusion_policy.t, config_error list) result =
   match Otoml.find_opt toml Fun.id [ "fusion" ] with
   | None -> Ok disabled
-  | Some _ ->
-    (match parse_enabled toml with
-     | result -> result
-     | exception Otoml.Type_error msg -> Error [ Toml_type_error msg ])
+  | Some fusion ->
+    (match
+       unexpected_field ~location:"fusion"
+         ~allowed:[ "enabled"; "default_preset"; "presets" ]
+         fusion
+     with
+     | Some error -> Error [ error ]
+     | None ->
+       (match parse_enabled toml with
+        | result -> result
+        | exception Otoml.Type_error msg -> Error [ Toml_type_error msg ]))

--- a/lib/fusion_core/fusion_config.mli
+++ b/lib/fusion_core/fusion_config.mli
@@ -23,8 +23,6 @@ type config_error =
       (** preset의 panel/judge system prompt가 비어있음 (코드 default 금지) *)
   | Missing_judge_model of string
       (** preset의 judge 모델 id가 비어있음 (필수, 빈 문자열 default 거부) *)
-  | Invalid_staged_judge_group_size of int
-      (** staged_judge_group_size < Fusion_policy.min_staged_judge_group_size *)
   | Missing_default_preset of string
       (** enabled인데 default_preset가 비었거나 presets에 없음. 빈 문자엏도 거부 —
           preset 생략 호출이 default_preset로 폭빽하는데 ""는 항상 Preset_unknown로
@@ -54,9 +52,8 @@ val disabled : Fusion_policy.t
       같은 model이라도 통과(same-model-different-prompt, RFC-0278).
     - panel/judge system prompt 누락 → [Error [Missing_prompt _]].
     - judge 모델 id 누락 → [Error [Missing_judge_model _]].
-    - staged_judge_group_size < 2 → [Error [Invalid_staged_judge_group_size _]].
     - default_preset가 presets에 없음 → [Error [Missing_default_preset _]].
-    - 알 수 없는 preset/panel/judge 필드 → [Error [Unexpected_field _]].
+    - 알 수 없는 fusion/preset/panel/judge 필드 → [Error [Unexpected_field _]].
     - 필드 타입 불일치 → [Error [Toml_type_error _]].
     여러 에러는 누적되어 한 번에 반환된다. *)
 val of_toml : Otoml.t -> (Fusion_policy.t, config_error list) result

--- a/lib/fusion_core/fusion_config_json.ml
+++ b/lib/fusion_core/fusion_config_json.ml
@@ -48,7 +48,6 @@ let to_yojson (c : Fusion_policy.t) : Yojson.Safe.t =
   `Assoc
     [ ("enabled", `Bool c.Fusion_policy.enabled)
     ; ("default_preset", `String c.Fusion_policy.default_preset)
-    ; ("staged_judge_group_size", `Int c.Fusion_policy.staged_judge_group_size)
     ; ( "presets"
       , `List
           (List.map

--- a/lib/fusion_core/fusion_policy.ml
+++ b/lib/fusion_core/fusion_policy.ml
@@ -37,17 +37,14 @@ type preset =
   ; judge_system_prompt : string
   ; judge_timeout_s : float
   ; meta_timeout_s : float
-      (** meta/stage-meta/final-meta 호출 구조적 타임아웃 (초). *)
+      (** meta 호출 구조적 타임아웃 (초). *)
   ; judges : judge_spec list
-      (** JOJ 1차 심판들 (RFC-0283). 기본 []; simple/refine/conditional은 무시한다.
-          JOJ 위상은 런타임에 >= 2 를 요구한다. *)
+      (** JOJ 1차 심판들 (RFC-0283). 입력 순서를 보존해 전체를 실행한다.
+          simple/refine/conditional은 무시한다. *)
   ; fallback_judge_model : string option
       (** 전원 타임아웃 시 단일 fallback 심판 모델. *)
   }
 [@@deriving show, eq]
-
-let min_staged_judge_group_size = 2
-let default_staged_judge_group_size = 3
 
 (* 패널/심판 호출 구조적 타임아웃 기본값 (preset이 명시 안 할 때). 운영 노브 —
    행동 휴리스틱이 아니므로 named SSOT 상수로 둔다 (Magic Number 회피). *)
@@ -134,63 +131,6 @@ let preset_judge_prompts_present (p : preset) =
     (fun (j : judge_spec) -> String.length (String.trim j.jsystem_prompt) > 0)
     p.judges
 
-type staged_judge_group_error =
-  | Staged_group_size_below_min of int
-  | Staged_too_few_judges of
-      { group_size : int
-      ; judges : int
-      }
-  | Staged_ragged_judges of
-      { group_size : int
-      ; judges : int
-      }
-[@@deriving show, eq]
-
-let staged_judge_group_error_message = function
-  | Staged_group_size_below_min group_size ->
-    Printf.sprintf "staged_judge_group_size must be >= %d, got %d"
-      min_staged_judge_group_size
-      group_size
-  | Staged_too_few_judges { group_size; judges } ->
-    Printf.sprintf
-      "staged_judge_of_judges requires at least two full groups: group_size=%d \
-       requires >= %d judges, got %d"
-      group_size
-      (group_size * 2)
-      judges
-  | Staged_ragged_judges { group_size; judges } ->
-    Printf.sprintf
-      "staged_judge_of_judges requires judge count divisible by \
-       staged_judge_group_size: group_size=%d, judges=%d"
-      group_size
-      judges
-
-let staged_judge_groups ~group_size judges =
-  let judge_count = List.length judges in
-  if group_size < min_staged_judge_group_size
-  then Error (Staged_group_size_below_min group_size)
-  else if judge_count < group_size * 2
-  then Error (Staged_too_few_judges { group_size; judges = judge_count })
-  else if judge_count mod group_size <> 0
-  then Error (Staged_ragged_judges { group_size; judges = judge_count })
-  else
-    let rec take n acc rest =
-      if n = 0
-      then (List.rev acc, rest)
-      else
-        match rest with
-        | [] -> (List.rev acc, [])
-        | x :: xs -> take (n - 1) (x :: acc) xs
-    in
-    let rec loop acc rest =
-      match rest with
-      | [] -> Ok (List.rev acc)
-      | _ ->
-        let group, rest = take group_size [] rest in
-        loop (group :: acc) rest
-    in
-    loop [] judges
-
 (* 외곽 run_safe 타임아웃. 하나의 Async_agent.all은 하나의 외곽 타임아웃만
    가지므로(RFC-0252-A §4.3) 그룹별 정밀 timeout은 build_agent에 반영하고 외곽은
    입력 전체가 한 wave로 실행되는 현재 구조에 맞춰 그룹 timeout 중 max로 둔다. *)
@@ -256,7 +196,6 @@ end
 type t =
   { enabled : bool
   ; default_preset : string
-  ; staged_judge_group_size : int
   ; presets : Validated_preset.t list
   }
 [@@deriving show, eq]

--- a/lib/fusion_core/fusion_policy.mli
+++ b/lib/fusion_core/fusion_policy.mli
@@ -46,23 +46,14 @@ type preset =
       (** 심판 모델 system prompt — config에서 필수(코드 default 없음). *)
   ; judge_timeout_s : float  (** 심판 호출 구조적 타임아웃 (초). *)
   ; meta_timeout_s : float
-      (** meta/stage-meta/final-meta 호출 구조적 타임아웃 (초). *)
+      (** meta 호출 구조적 타임아웃 (초). *)
   ; judges : judge_spec list
-      (** JOJ 1차 심판들 (RFC-0283). 기본 []; simple/refine/conditional은 무시한다.
-          JOJ 위상은 런타임에 >= 2 를 요구한다. *)
+      (** JOJ 1차 심판들 (RFC-0283). 입력 순서를 보존해 전체를 실행한다.
+          simple/refine/conditional은 무시한다. *)
   ; fallback_judge_model : string option
       (** 전원 타임아웃 시 단일 fallback 심판 모델. *)
   }
 [@@deriving show, eq]
-
-(** Default staged JOJ group size. A staged judge-of-judges run groups first
-    judges into fixed-size cohorts before a final meta reduction; default 3
-    expresses the common 3x3x3 shape. *)
-val default_staged_judge_group_size : int
-
-(** Smallest useful staged JOJ group size. Size 1 degenerates into a serial
-    pass-through and is rejected. *)
-val min_staged_judge_group_size : int
 
 (** 패널/심판 타임아웃 기본값 (config 미지정 시). 운영 노브 — named SSOT. *)
 val default_timeout_s : float
@@ -102,33 +93,6 @@ val preset_duplicate_judge : preset -> string option
 (** 모든 1차 심판의 system prompt(lens)가 비어있지 않은가. judges=[]면 vacuously [true]
     (simple/refine/conditional은 judges를 안 쓴다). (RFC-0283) *)
 val preset_judge_prompts_present : preset -> bool
-
-(** Staged JOJ preset grouping validation. This is runtime topology validation
-    rather than preset validation because the same preset may be valid for flat
-    JOJ while invalid for staged JOJ. *)
-type staged_judge_group_error =
-  | Staged_group_size_below_min of int
-  | Staged_too_few_judges of
-      { group_size : int
-      ; judges : int
-      }
-  | Staged_ragged_judges of
-      { group_size : int
-      ; judges : int
-      }
-[@@deriving show, eq]
-
-(** Render a staged grouping error at operator/tool boundaries. *)
-val staged_judge_group_error_message : staged_judge_group_error -> string
-
-(** Split JOJ first judges into exact staged groups. Requirements:
-    [group_size >= min_staged_judge_group_size], at least two full groups, and
-    no ragged final group. For example, 9 judges with group size 3 returns
-    three groups of three; 8 judges with group size 3 is rejected. *)
-val staged_judge_groups
-  :  group_size:int
-  -> judge_spec list
-  -> (judge_spec list list, staged_judge_group_error) result
 
 (** 외곽 run_safe 타임아웃 = 그룹 timeout 중 max. 패널은 입력 집합 전체를 구조적으로
     fan-out하므로 별도 concurrency 설정이나 가짜 wave 계산을 두지 않는다. *)
@@ -175,7 +139,6 @@ end
 type t =
   { enabled : bool
   ; default_preset : string
-  ; staged_judge_group_size : int
   ; presets : Validated_preset.t list
   }
 [@@deriving show, eq]

--- a/lib/fusion_core/fusion_run_registry.ml
+++ b/lib/fusion_core/fusion_run_registry.ml
@@ -45,9 +45,7 @@ type run_status =
     }
 
 type run = {
-  run_id : string;
-  keeper : string;
-  preset : string;
+  operation : Fusion_types.fusion_operation;
   started_at : float;  (* unix seconds from the keeper clock at fork start *)
   status : run_status;
 }
@@ -95,9 +93,15 @@ let persistence_error_to_string = function
 ;;
 
 let completion_error_to_string = function
-  | Unknown_run run_id -> Printf.sprintf "unknown fusion run %s" run_id
+  | Unknown_run operation_id ->
+    Printf.sprintf "unknown fusion run %s" operation_id
   | Completion_persistence_failed error -> persistence_error_to_string error
 ;;
+
+let run_operation_id (run : run) = Fusion_types.fusion_operation_id run.operation
+let operation_id = run_operation_id
+let keeper (run : run) = run.operation.request.keeper
+let preset (run : run) = run.operation.request.preset
 
 let append_event t event =
   match t.path with
@@ -113,18 +117,25 @@ let append_event t event =
        Error error)
 ;;
 
-let register_running t ~run_id ~keeper ~preset ~started_at =
+let register_running t ~operation ~started_at =
+  let id = Fusion_types.fusion_operation_id operation in
   match
     append_event
       t
-      (Fusion_run_registry_event.Register { run_id; keeper; preset; started_at })
+      (Fusion_run_registry_event.Register { operation; started_at })
   with
   | Error _ as error -> error
   | Ok () ->
     update t (fun runs ->
-      let run = { run_id; keeper; preset; started_at; status = Running } in
-      (* defensive: a re-registered run_id replaces its prior entry *)
-      let without_dup = List.filter (fun r -> not (String.equal r.run_id run_id)) runs in
+      let run = { operation; started_at; status = Running } in
+      (* defensive: a re-registered operation id replaces its prior entry *)
+      let without_dup =
+        List.filter
+          (fun run ->
+             not
+               (String.equal (run_operation_id run) id))
+          runs
+      in
       prune (run :: without_dup));
     Ok ()
 ;;
@@ -133,17 +144,19 @@ let list_runs (t : t) : run list =
   Atomic.get t.runs |> List.sort (fun a b -> Float.compare b.started_at a.started_at)
 ;;
 
-let get (t : t) ~run_id : run option =
-  List.find_opt (fun r -> String.equal r.run_id run_id) (Atomic.get t.runs)
+let get (t : t) ~operation_id:expected : run option =
+  List.find_opt
+    (fun run -> String.equal (run_operation_id run) expected)
+    (Atomic.get t.runs)
 ;;
 
-let mark_completed (t : t) ~run_id ?failure ?failure_code ~ok () =
-  match get t ~run_id with
-  | None -> Error (Unknown_run run_id)
+let mark_completed (t : t) ~operation_id ?failure ?failure_code ~ok () =
+  match get t ~operation_id with
+  | None -> Error (Unknown_run operation_id)
   | Some _ ->
     let persisted =
       append_event t
-        (Fusion_run_registry_event.Complete { run_id; ok; failure; failure_code })
+        (Fusion_run_registry_event.Complete { operation_id; ok; failure; failure_code })
     in
     let receipt =
       match persisted with
@@ -153,7 +166,7 @@ let mark_completed (t : t) ~run_id ?failure ?failure_code ~ok () =
     update t (fun runs ->
       runs
       |> List.map (fun r ->
-           if String.equal r.run_id run_id
+           if String.equal (run_operation_id r) operation_id
            then { r with status = Completed { ok; failure; failure_code; receipt } }
            else r)
       |> prune);
@@ -178,10 +191,12 @@ let status_label = function
    keeper status tool all serialize a run through here so the field set and the
    status label never drift between surfaces. *)
 let run_to_yojson (r : run) : Yojson.Safe.t =
+  let request = r.operation.Fusion_types.request in
   let base =
-    [ ("run_id", `String r.run_id)
-    ; ("keeper", `String r.keeper)
-    ; ("preset", `String r.preset)
+    [ ("run_id", `String request.run_id)
+    ; ("keeper", `String request.keeper)
+    ; ("preset", `String request.preset)
+    ; ("topology", `String (Fusion_types.fusion_topology_to_string r.operation.topology))
     ; ("started_at", `Float r.started_at)
     ; ("status", `String (status_label r.status))
     ]
@@ -214,14 +229,19 @@ let run_to_yojson (r : run) : Yojson.Safe.t =
 
 (* Replay helpers — used to hydrate the in-memory table from disk at boot. *)
 let apply_event runs = function
-  | Fusion_run_registry_event.Register { run_id; keeper; preset; started_at } ->
-    let run = { run_id; keeper; preset; started_at; status = Running } in
-    let without_dup = List.filter (fun r -> not (String.equal r.run_id run_id)) runs in
+  | Fusion_run_registry_event.Register { operation; started_at } ->
+    let id = Fusion_types.fusion_operation_id operation in
+    let run = { operation; started_at; status = Running } in
+    let without_dup =
+      List.filter
+        (fun run -> not (String.equal (run_operation_id run) id))
+        runs
+    in
     run :: without_dup
-  | Fusion_run_registry_event.Complete { run_id; ok; failure; failure_code } ->
+  | Fusion_run_registry_event.Complete { operation_id = completed_id; ok; failure; failure_code } ->
     List.map
       (fun r ->
-         if String.equal r.run_id run_id
+         if String.equal (run_operation_id r) completed_id
          then { r with status = Completed { ok; failure; failure_code; receipt = Durable } }
          else r)
       runs
@@ -277,9 +297,7 @@ let parse_event_line ~path ~line_no line =
 let events_of_run (run : run) =
   let register =
     Fusion_run_registry_event.Register
-      { run_id = run.run_id
-      ; keeper = run.keeper
-      ; preset = run.preset
+      { operation = run.operation
       ; started_at = run.started_at
       }
   in
@@ -289,7 +307,7 @@ let events_of_run (run : run) =
   | Completed { ok; failure; failure_code; receipt = Durable } ->
     [ register
     ; Fusion_run_registry_event.Complete
-        { run_id = run.run_id; ok; failure; failure_code }
+        { operation_id = run_operation_id run; ok; failure; failure_code }
     ]
 ;;
 

--- a/lib/fusion_core/fusion_run_registry.mli
+++ b/lib/fusion_core/fusion_run_registry.mli
@@ -46,12 +46,15 @@ type run_status =
     }
 
 type run = {
-  run_id : string;
-  keeper : string;
-  preset : string;
+  operation : Fusion_types.fusion_operation;
   started_at : float;  (** unix seconds from the keeper clock at fork start *)
   status : run_status;
 }
+
+val operation_id : run -> string
+val keeper : run -> string
+val preset : run -> string
+(** Lossless projections from the canonical immutable [operation]. *)
 
 type t
 
@@ -70,22 +73,22 @@ val replay : string -> t
     the newest {!max_completed_retained}. *)
 
 val register_running :
-  t -> run_id:string -> keeper:string -> preset:string -> started_at:float
+  t -> operation:Fusion_types.fusion_operation -> started_at:float
   -> (unit, persistence_error) result
-(** Record a run as [Running]. A repeated [run_id] replaces its prior entry.
+(** Record a run as [Running]. A repeated operation identity replaces its prior entry.
     When the registry was created with a path, the durable [Register] event is
     committed before publishing in-memory state. An append failure returns
     [Error] and the run is not registered. *)
 
 val mark_completed
   :  t
-  -> run_id:string
+  -> operation_id:string
   -> ?failure:string
   -> ?failure_code:string
   -> ok:bool
   -> unit
   -> (unit, completion_error) result
-(** Transition a run to [Completed]. Unknown [run_id] is an explicit [Error]. [ok] is the
+(** Transition a run to [Completed]. Unknown operation identity is an explicit [Error]. [ok] is the
     judge/sink outcome (false for denied/sink_failed/aborted). [failure]/
     [failure_code]는 [ok=false]일 때의 사유·분류 태그 — 상태 표면(tool/HTTP/SSE)이
     사유 없이 "failed"만 보이는 opaque 실패가 되지 않게 함께 기록한다. A failed
@@ -98,8 +101,8 @@ val list_runs : t -> run list
     pruned; only older durably completed rows are retained by the history
     bound. *)
 
-val get : t -> run_id:string -> run option
-(** The run with [run_id], if still tracked. *)
+val get : t -> operation_id:string -> run option
+(** The run with [operation_id], if still tracked. *)
 
 val status_label : run_status -> string
 (** Stable wire label: [Running -> "running"], [Recovery_required ->
@@ -109,7 +112,7 @@ val status_label : run_status -> string
     [fusion_run_status] SSE event so it never drifts. *)
 
 val run_to_yojson : run -> Yojson.Safe.t
-(** Canonical per-run JSON: [{run_id, keeper, preset, started_at, status}] +
+(** Canonical per-run JSON: [{run_id, keeper, preset, topology, started_at, status}] +
     실패 시 additive [error]/[failure_code] 필드. The single serializer for
     every fusion-run surface (tool / HTTP list / SSE delta). *)
 

--- a/lib/fusion_core/fusion_run_registry_event.ml
+++ b/lib/fusion_core/fusion_run_registry_event.ml
@@ -1,37 +1,33 @@
 (* JSONL event type for fusion run registry persistence (RFC-0266 §7 Phase D).
    Each [register_running] / [mark_completed] appends one line so run history
-   survives server restart. The event type is intentionally minimal and stable;
-   adding new fields is safe because replay ignores unknown JSON keys. *)
+   survives server restart. [Register] contains the complete canonical operation;
+   replay never reconstructs an execution request from metadata or defaults. *)
 
 type t =
   | Register of
-      { run_id : string
-      ; keeper : string
-      ; preset : string
+      { operation : Fusion_types.fusion_operation
       ; started_at : float
       }
   | Complete of
-      { run_id : string
+      { operation_id : string
       ; ok : bool
       ; failure : string option
       ; failure_code : string option
       }
 
 let to_yojson = function
-  | Register { run_id; keeper; preset; started_at } ->
+  | Register { operation; started_at } ->
     `Assoc
       [ ("event", `String "register")
-      ; ("run_id", `String run_id)
-      ; ("keeper", `String keeper)
-      ; ("preset", `String preset)
+      ; ("operation", Fusion_types.fusion_operation_to_yojson operation)
       ; ("started_at", `Float started_at)
       ]
-  | Complete { run_id; ok; failure; failure_code } ->
+  | Complete { operation_id; ok; failure; failure_code } ->
     `Assoc
       (List.filter_map
          (fun (k, v) -> Option.map (fun value -> (k, value)) v)
          [ "event", Some (`String "complete")
-         ; "run_id", Some (`String run_id)
+         ; "operation_id", Some (`String operation_id)
          ; "ok", Some (`Bool ok)
          ; "failure", Option.map (fun s -> `String s) failure
          ; "failure_code", Option.map (fun s -> `String s) failure_code
@@ -84,23 +80,27 @@ let optional_string_field name fields =
          (Yojson.Safe.to_string json))
 ;;
 
+let operation_field fields =
+  let ( let* ) = Result.bind in
+  let* json = field "operation" fields in
+  Fusion_types.fusion_operation_of_yojson json
+;;
+
 let of_yojson json =
   let ( let* ) = Result.bind in
   let* fields = object_fields json in
   let* event = string_field "event" fields in
   match event with
   | "register" ->
-    let* run_id = string_field "run_id" fields in
-    let* keeper = string_field "keeper" fields in
-    let* preset = string_field "preset" fields in
+    let* operation = operation_field fields in
     let* started_at = float_field "started_at" fields in
-    Ok (Register { run_id; keeper; preset; started_at })
+    Ok (Register { operation; started_at })
   | "complete" ->
-    let* run_id = string_field "run_id" fields in
+    let* operation_id = string_field "operation_id" fields in
     let* ok = bool_field "ok" fields in
     let* failure = optional_string_field "failure" fields in
     let* failure_code = optional_string_field "failure_code" fields in
-    Ok (Complete { run_id; ok; failure; failure_code })
+    Ok (Complete { operation_id; ok; failure; failure_code })
   | other -> Error (Printf.sprintf "unknown fusion registry event %S" other)
 ;;
 

--- a/lib/fusion_core/fusion_run_registry_event.mli
+++ b/lib/fusion_core/fusion_run_registry_event.mli
@@ -6,13 +6,11 @@
 
 type t =
   | Register of
-      { run_id : string
-      ; keeper : string
-      ; preset : string
+      { operation : Fusion_types.fusion_operation
       ; started_at : float
       }
   | Complete of
-      { run_id : string
+      { operation_id : string
       ; ok : bool
       ; failure : string option
       ; failure_code : string option
@@ -22,7 +20,8 @@ val to_yojson : t -> Yojson.Safe.t
 (** Canonical JSON object for one event. *)
 
 val of_yojson : Yojson.Safe.t -> (t, string) result
-(** Parse an event from a JSON object; [Error] on unknown event kind. *)
+(** Parse an event from a JSON object; [Error] on unknown event kind or an
+    incomplete canonical operation. *)
 
 val to_jsonl : t -> string
 (** Single JSONL line (JSON object + trailing newline). *)

--- a/lib/fusion_core/fusion_types.ml
+++ b/lib/fusion_core/fusion_types.ml
@@ -308,13 +308,8 @@ type fusion_topology =
       (** panel → judge → (1차 판정이 [Insufficient]일 때만) judge'(refine) → sink.
           애매할 때만 한 단계 더 깊이; 그 외엔 1차 종합 그대로. *)
   | Judge_of_judges
-      (** panel → [N개 1차 심판] → meta-judge → sink (RFC-0283). 서로 다른 N개 1차
-          심판이 같은 패널을 독립 종합하고, meta가 reconcile. preset.judges >= 2 필요. *)
-  | Staged_judge_of_judges
-      (** panel → [N개 1차 심판] → fixed-size stage meta reducers → final meta reducer
-          → sink. preset.judges count must form at least two exact groups of
-          TOML key [staged_judge_group_size]. This is a named topology,
-          not recursive fusion; [Fusion_depth.Nested] remains denied. *)
+      (** panel → [1차 심판 전체] → meta-judge → sink (RFC-0283). 설정된
+          typed judge 목록 순서를 그대로 보존해 전체를 실행한다. *)
 [@@deriving yojson, show, eq]
 
 let fusion_topology_to_string = function
@@ -322,7 +317,6 @@ let fusion_topology_to_string = function
   | Refine -> "refine"
   | Conditional -> "conditional"
   | Judge_of_judges -> "judge_of_judges"
-  | Staged_judge_of_judges -> "staged_judge_of_judges"
 
 (* [to_string]의 역함수, 닫힌 합 밖은 [None]=fail-closed (Unknown→permissive 회피).
    keeper 입력 문자열을 typed 위상으로 parse한 뒤 exhaustive match하게 한다. round-trip은
@@ -332,11 +326,10 @@ let fusion_topology_of_string = function
   | "refine" -> Some Refine
   | "conditional" -> Some Conditional
   | "judge_of_judges" -> Some Judge_of_judges
-  | "staged_judge_of_judges" -> Some Staged_judge_of_judges
   | _ -> None
 
 let all_fusion_topologies : fusion_topology list =
-  [ Simple; Refine; Conditional; Judge_of_judges; Staged_judge_of_judges ]
+  [ Simple; Refine; Conditional; Judge_of_judges ]
 
 let all_fusion_topology_strings : string list =
   List.map fusion_topology_to_string all_fusion_topologies

--- a/lib/fusion_core/fusion_types.ml
+++ b/lib/fusion_core/fusion_types.ml
@@ -334,6 +334,14 @@ let all_fusion_topologies : fusion_topology list =
 let all_fusion_topology_strings : string list =
   List.map fusion_topology_to_string all_fusion_topologies
 
+type fusion_operation =
+  { request : fusion_request
+  ; topology : fusion_topology
+  }
+[@@deriving yojson, show, eq]
+
+let fusion_operation_id operation = operation.request.run_id
+
 (* Conditional 위상의 에스컬레이트 정책: 1차 심판 판정이 더 깊은 심의를 요하는가.
    [Insufficient](패널이 결정에 부족 = 애매)면 escalate, [Answer]/[Recommend](결론 있음)이면
    1차 종합 유지. 닫힌 합 exhaustive match(catch-all 없음) — 새 decision 변형 추가 시 여기서

--- a/lib/fusion_core/fusion_types.mli
+++ b/lib/fusion_core/fusion_types.mli
@@ -348,6 +348,19 @@ val all_fusion_topologies : fusion_topology list
 (** [all_fusion_topologies]의 wire 문자열 (도구 인자 허용값 목록). *)
 val all_fusion_topology_strings : string list
 
+(** One immutable, replayable Fusion operation. The request owns the sole
+    operation identity; topology is persisted beside it rather than inferred
+    from logs or reconstructed from defaults after restart. *)
+type fusion_operation =
+  { request : fusion_request
+  ; topology : fusion_topology
+  }
+[@@deriving yojson, show, eq]
+
+val fusion_operation_id : fusion_operation -> string
+(** The sole operation identity, projected from [request.run_id]. The event
+    schema never stores a second copy that could drift. *)
+
 (** [Conditional] 위상의 에스컬레이트 정책. 1차 심판 [decision]이 더 깊은 심의를 요하면
     [true]. v1: [Insufficient]만 [true]([Answer]/[Recommend]는 [false]). 닫힌 합
     exhaustive — 새 [judge_decision] 변형 추가 시 컴파일 에러로 정책 갱신을 강제한다. *)

--- a/lib/fusion_core/fusion_types.mli
+++ b/lib/fusion_core/fusion_types.mli
@@ -330,13 +330,8 @@ type fusion_topology =
       (** panel → judge → (1차 판정이 [Insufficient]일 때만) judge'(refine) → sink.
           애매할 때만 한 단계 더 깊이; 그 외엔 1차 종합 그대로(= Simple). *)
   | Judge_of_judges
-      (** panel → [N개 1차 심판] → meta-judge → sink (RFC-0283). 서로 다른 N개 1차
-          심판이 같은 패널을 독립 종합하고, meta가 reconcile. preset.judges >= 2 필요. *)
-  | Staged_judge_of_judges
-      (** panel → [N개 1차 심판] → fixed-size stage meta reducers → final meta reducer
-          → sink. preset.judges count must form at least two exact groups of
-          TOML key [staged_judge_group_size]. Named topology only; it does
-          not relax the nested fusion depth guard. *)
+      (** panel → [1차 심판 전체] → meta-judge → sink (RFC-0283). 설정된
+          typed judge 목록 순서를 그대로 보존해 전체를 실행한다. *)
 [@@deriving yojson, show, eq]
 
 (** 안정적 wire 문자열 ([masc_fusion] 도구 인자·로깅용). *)

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -1076,12 +1076,7 @@ let masc_fusion_schema =
          judge could not decide (verdict insufficient); otherwise returns the \
          first synthesis. \"judge_of_judges\": several distinct judges each \
          synthesise the panel independently and a meta-judge reconciles them \
-         (requires the preset to configure >= 2 judges). \
-         \"staged_judge_of_judges\": first judges are grouped by \
-         [fusion].staged_judge_group_size, each group is reconciled by a \
-         stage meta-judge, then a final meta-judge reconciles the stage \
-         results (requires at least two exact groups; ragged counts are \
-         rejected). Unknown values are rejected."
+         in their configured order. Unknown values are rejected."
     ]
 ;;
 

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -835,7 +835,7 @@ let fusion_status_json ~(registry : Fusion_run_registry.t) ~keeper ~run_id : str
      adds the tool envelope + per-keeper scoping. *)
   let run_to_yojson = Fusion_run_registry.run_to_yojson in
   let belongs_to_keeper (r : Fusion_run_registry.run) =
-    String.equal r.keeper keeper
+    String.equal (Fusion_run_registry.keeper r) keeper
   in
   let not_found () =
     Yojson.Safe.to_string
@@ -859,7 +859,7 @@ let fusion_status_json ~(registry : Fusion_run_registry.t) ~keeper ~run_id : str
          ])
   end
   else (
-    match Fusion_run_registry.get registry ~run_id with
+    match Fusion_run_registry.get registry ~operation_id:run_id with
     | Some run when belongs_to_keeper run ->
       Yojson.Safe.to_string
         (`Assoc [ "ok", `Bool true; "found", `Bool true; "run", run_to_yojson run ])

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -318,6 +318,15 @@ let create_server_state ~sw ~base_path ?input_base_path ~clock ~mono_clock ~net
     Filename.concat (Common.masc_dir_from_base_path ~base_path) "fusion-runs.jsonl"
   in
   Fusion_run_registry.set_global (Fusion_run_registry.replay registry_path);
+  (* Product-neutral completion addresses and unacknowledged payloads hydrate
+     before any upper MASC delivery adapter can drain them. *)
+  let completion_outbox_path =
+    Filename.concat
+      (Common.masc_dir_from_base_path ~base_path)
+      "fusion-completion-outbox.jsonl"
+  in
+  Fusion_completion_outbox.set_global
+    (Fusion_completion_outbox.replay completion_outbox_path);
   Mcp_eio.set_net net;
   Mcp_eio.set_clock clock;
   Eio_context.set_switch sw;

--- a/test/fusion_core/dune
+++ b/test/fusion_core/dune
@@ -3,7 +3,7 @@
 ; main masc library — runs in seconds.
 
 (tests
- (names test_fusion test_fusion_harness test_fusion_run_registry
+ (names test_fusion test_fusion_harness test_fusion_run_registry test_fusion_completion_outbox
    test_fusion_config_json)
  (deps ../../config/runtime.toml)
  (libraries alcotest otoml yojson masc.fusion_core))

--- a/test/fusion_core/test_fusion.ml
+++ b/test/fusion_core/test_fusion.ml
@@ -34,7 +34,6 @@ let raw = Fusion_policy.Validated_preset.preset
 let base_policy : Fusion_policy.t =
   { Fusion_policy.enabled = true
   ; default_preset = "trio"
-  ; staged_judge_group_size = Fusion_policy.default_staged_judge_group_size
   ; presets =
       [ validated
           { Fusion_policy.name = "trio"
@@ -99,7 +98,6 @@ let valid_toml =
 [fusion]
 enabled = true
 default_preset = "trio"
-staged_judge_group_size = 3
 [fusion.presets.trio]
 web_tools = false
 panel = ["a", "b", "c"]
@@ -112,8 +110,6 @@ let test_config_valid () =
   match Fusion_config.of_toml (parse valid_toml) with
   | Ok p ->
     Alcotest.(check bool) "enabled" true p.Fusion_policy.enabled;
-    Alcotest.(check int) "staged judge group size" 3
-      p.Fusion_policy.staged_judge_group_size;
     Alcotest.(check int) "one preset" 1 (List.length p.Fusion_policy.presets);
     (match p.Fusion_policy.presets with
      | [ vp ] ->
@@ -133,9 +129,7 @@ let test_config_valid () =
 
 (* JoJ-capable preset: [[fusion.presets.X.judges]] array-of-tables 파싱 경로 (RFC-0283).
    config/runtime.toml [fusion.presets.quorum] 의 구조를 미러한다(모델 id는 placeholder).
-   topology=judge_of_judges는 orchestrator 런타임에서 judges >= 2 를 요구하므로
-   (fusion_orchestrator.run_judge_of_judges), JoJ를 키퍼가 실제로 쓰려면 judges>=2 preset이
-   shipped config에 있어야 한다. 이 테스트는 그 preset이 의존하는 TOML array-of-tables 파싱
+   이 테스트는 typed judge 목록의 TOML array-of-tables 파싱
    (Fusion_config.parse_judge_spec)을 end-to-end로 고정한다 — 기존 Validated_preset 테스트는
    OCaml-구성 judges만 다뤄 이 파싱 경로를 덮지 않는다. *)
 let joj_preset_toml =
@@ -168,8 +162,7 @@ let test_config_joj_preset_parses () =
      | [ vp ] ->
        let preset = raw vp in
        let judges = preset.Fusion_policy.judges in
-       Alcotest.(check int) "two first judges (JoJ requires >= 2)" 2
-         (List.length judges);
+       Alcotest.(check int) "fixture judges" 2 (List.length judges);
        Alcotest.(check bool) "meta judge set" true
          (String.trim preset.Fusion_policy.judge <> "");
        Alcotest.(check (list string))
@@ -549,37 +542,13 @@ judge_system_prompt = "j"
       (List.mem (Fusion_config.Missing_judge_model "p1") es)
   | Ok _ -> Alcotest.fail "expected Error Missing_judge_model"
 
-let test_config_bad_staged_judge_group_size () =
-  let s =
-    {|
-[fusion]
-enabled = true
-default_preset = "p1"
-staged_judge_group_size = 1
-[fusion.presets.p1]
-panel = ["a", "b"]
-judge = "a"
-panel_system_prompt = "p"
-judge_system_prompt = "j"
-|}
-  in
-  match Fusion_config.of_toml (parse s) with
-  | Error es ->
-    Alcotest.(check bool) "Invalid_staged_judge_group_size present" true
-      (List.mem (Fusion_config.Invalid_staged_judge_group_size 1) es)
-  | Ok _ -> Alcotest.fail "expected Error Invalid_staged_judge_group_size"
-
 (* council 프리셋 계약 (config/runtime.toml [fusion.presets.council] 미러):
-   judge 6명 = staged_judge_group_size(3)의 정확한 배수이자 >= group_size*2 —
-   staged_judge_of_judges 자격을 만족하는 최초의 shipped preset shape.
-   staged_judge_groups가 lens 입력 순서를 보존한 2 그룹을 만드는 것까지 고정해,
-   프리셋을 줄이거나(ragged) group_size를 키우는 회귀가 여기서 잡히게 한다. *)
+   typed judge 목록이 TOML 입력 순서를 그대로 보존한다. *)
 let council_shaped_toml =
   {|
 [fusion]
 enabled = true
 default_preset = "council"
-staged_judge_group_size = 3
 [fusion.presets.council]
 panel = ["pa", "pb", "pc"]
 judge = "meta-reducer"
@@ -617,7 +586,13 @@ label = "adversarial"
 system_prompt = "adversarial lens"
 |}
 
-let test_config_council_preset_is_staged_eligible () =
+let judge_labels preset =
+  List.map (fun judge -> judge.Fusion_policy.jlabel) preset.Fusion_policy.judges
+
+let council_judge_labels =
+  [ "evidence"; "coverage"; "risk"; "feasibility"; "simplicity"; "adversarial" ]
+
+let test_config_council_preserves_judge_order () =
   match Fusion_config.of_toml (parse council_shaped_toml) with
   | Error es ->
     Alcotest.failf "council fixture must parse+validate, got: %s"
@@ -626,30 +601,13 @@ let test_config_council_preset_is_staged_eligible () =
     (match p.Fusion_policy.presets with
      | [ vp ] ->
        let preset = raw vp in
-       Alcotest.(check int) "six first-round judges" 6
-         (List.length preset.Fusion_policy.judges);
-       (match
-          Fusion_policy.staged_judge_groups
-            ~group_size:p.Fusion_policy.staged_judge_group_size
-            preset.Fusion_policy.judges
-        with
-        | Error e ->
-          Alcotest.failf "council must be staged-eligible, got: %s"
-            (Fusion_policy.staged_judge_group_error_message e)
-        | Ok groups ->
-          Alcotest.(check int) "two exact stages" 2 (List.length groups);
-          Alcotest.(check (list (list string)))
-            "stage grouping preserves lens input order"
-            [ [ "evidence"; "coverage"; "risk" ]
-            ; [ "feasibility"; "simplicity"; "adversarial" ]
-            ]
-            (List.map
-               (List.map (fun j -> j.Fusion_policy.jlabel))
-               groups))
+       Alcotest.(check (list string))
+         "typed judge order"
+         council_judge_labels (judge_labels preset)
      | presets ->
        Alcotest.failf "expected exactly one preset, got %d" (List.length presets))
 
-let test_shipped_runtime_council_is_staged_eligible () =
+let test_shipped_runtime_council_preserves_judge_order () =
   let runtime_toml =
     In_channel.with_open_bin "../../config/runtime.toml" In_channel.input_all
   in
@@ -669,47 +627,9 @@ let test_shipped_runtime_council_is_staged_eligible () =
      | None -> Alcotest.fail "shipped runtime.toml has no council preset"
      | Some validated ->
        let preset = raw validated in
-       match
-         Fusion_policy.staged_judge_groups
-           ~group_size:policy.Fusion_policy.staged_judge_group_size
-           preset.Fusion_policy.judges
-       with
-       | Ok [ first_stage; second_stage ] ->
-         Alcotest.(check (list string))
-           "shipped first stage lenses"
-           [ "evidence"; "coverage"; "risk" ]
-           (List.map (fun judge -> judge.Fusion_policy.jlabel) first_stage);
-         Alcotest.(check (list string))
-           "shipped second stage lenses"
-           [ "feasibility"; "simplicity"; "adversarial" ]
-           (List.map (fun judge -> judge.Fusion_policy.jlabel) second_stage)
-       | Ok groups ->
-         Alcotest.failf "shipped council must have two stages, got %d"
-           (List.length groups)
-       | Error error ->
-         Alcotest.failf "shipped council is not staged-eligible: %s"
-           (Fusion_policy.staged_judge_group_error_message error))
-
-(* 회귀 가드: quorum 형태(2 judges)는 staged 비자격 — 이 fail-closed가 council
-   추가 전 모든 shipped preset의 상태였다. *)
-let test_config_two_judges_not_staged_eligible () =
-  let judge ~model ~label =
-    { Fusion_policy.jmodel = model
-    ; jlabel = label
-    ; jsystem_prompt = label ^ " lens"
-    ; jweb_tools = false
-    ; jtimeout_s = 300.0
-    }
-  in
-  let judges =
-    [ judge ~model:"j1" ~label:"evidence"; judge ~model:"j2" ~label:"coverage" ]
-  in
-  match Fusion_policy.staged_judge_groups ~group_size:3 judges with
-  | Error (Fusion_policy.Staged_too_few_judges { group_size = 3; judges = 2 }) -> ()
-  | Error e ->
-    Alcotest.failf "expected Staged_too_few_judges, got: %s"
-      (Fusion_policy.staged_judge_group_error_message e)
-  | Ok _ -> Alcotest.fail "two judges must not be staged-eligible"
+       Alcotest.(check (list string))
+         "shipped typed judge order"
+         council_judge_labels (judge_labels preset))
 
 let expect_unexpected_field toml expected_location expected_field =
   match Fusion_config.of_toml (parse toml) with
@@ -783,7 +703,6 @@ let seed_disabled_toml =
 [fusion]
 enabled = false
 default_preset = "trio"
-staged_judge_group_size = 3
 [fusion.presets.trio]
 web_tools = false
 panel = [
@@ -802,8 +721,6 @@ let test_config_disabled_with_preset () =
   match Fusion_config.of_toml (parse seed_disabled_toml) with
   | Ok p ->
     Alcotest.(check bool) "seed disabled" false p.Fusion_policy.enabled;
-    Alcotest.(check int) "seed staged group size" 3
-      p.Fusion_policy.staged_judge_group_size;
     Alcotest.(check int) "trio preset present" 1 (List.length p.Fusion_policy.presets);
     (match p.Fusion_policy.presets with
      | [ vp ] ->
@@ -906,42 +823,6 @@ let test_validated_duplicate_judge () =
   with
   | Error (Fusion_policy.Validated_preset.Duplicate_judge "x") -> ()
   | _ -> Alcotest.fail "expected Duplicate_judge x for same judge identity"
-
-let judge_named model = { base_judge with Fusion_policy.jmodel = model }
-
-let test_staged_judge_groups_exact_3x3 () =
-  let judges = List.init 9 (fun i -> judge_named (Printf.sprintf "j%d" (i + 1))) in
-  match Fusion_policy.staged_judge_groups ~group_size:3 judges with
-  | Ok groups ->
-    Alcotest.(check int) "three groups" 3 (List.length groups);
-    Alcotest.(check (list int)) "3x3 group sizes" [ 3; 3; 3 ]
-      (List.map List.length groups);
-    (match groups with
-     | first :: _ ->
-       (match first with
-        | j :: _ -> Alcotest.(check string) "first judge preserved" "j1" j.Fusion_policy.jmodel
-        | [] -> Alcotest.fail "first group should not be empty")
-     | [] -> Alcotest.fail "expected groups")
-  | Error e ->
-    Alcotest.failf "expected 3x3 groups, got %s"
-      (Fusion_policy.show_staged_judge_group_error e)
-
-let test_staged_judge_groups_too_few () =
-  let judges = List.init 5 (fun i -> judge_named (Printf.sprintf "j%d" (i + 1))) in
-  match Fusion_policy.staged_judge_groups ~group_size:3 judges with
-  | Error (Fusion_policy.Staged_too_few_judges { group_size = 3; judges = 5 }) -> ()
-  | _ -> Alcotest.fail "expected Staged_too_few_judges for 5 judges at group size 3"
-
-let test_staged_judge_groups_ragged () =
-  let judges = List.init 8 (fun i -> judge_named (Printf.sprintf "j%d" (i + 1))) in
-  match Fusion_policy.staged_judge_groups ~group_size:3 judges with
-  | Error (Fusion_policy.Staged_ragged_judges { group_size = 3; judges = 8 }) -> ()
-  | _ -> Alcotest.fail "expected Staged_ragged_judges for 8 judges at group size 3"
-
-let test_staged_judge_groups_bad_size () =
-  match Fusion_policy.staged_judge_groups ~group_size:1 [ judge_named "j1"; judge_named "j2" ] with
-  | Error (Fusion_policy.Staged_group_size_below_min 1) -> ()
-  | _ -> Alcotest.fail "expected Staged_group_size_below_min"
 
 (* --- JOJ 1차 심판 TOML 파싱 (RFC-0283). parse_judge_spec + finish_preset의
        [[...judges]] array-of-tables 리더를 end-to-end로 검증한다. 위 of_preset
@@ -1407,14 +1288,10 @@ let () =
         ; Alcotest.test_case "missing_default" `Quick test_config_missing_default
         ; Alcotest.test_case "missing_prompt" `Quick test_config_missing_prompt
         ; Alcotest.test_case "missing_judge_model" `Quick test_config_missing_judge_model
-        ; Alcotest.test_case "bad_staged_judge_group_size" `Quick
-            test_config_bad_staged_judge_group_size
-        ; Alcotest.test_case "council_staged_eligible" `Quick
-            test_config_council_preset_is_staged_eligible
-        ; Alcotest.test_case "shipped_runtime_council_staged_eligible" `Quick
-            test_shipped_runtime_council_is_staged_eligible
-        ; Alcotest.test_case "two_judges_not_staged_eligible" `Quick
-            test_config_two_judges_not_staged_eligible
+        ; Alcotest.test_case "council_judge_order" `Quick
+            test_config_council_preserves_judge_order
+        ; Alcotest.test_case "shipped_runtime_council_judge_order" `Quick
+            test_shipped_runtime_council_preserves_judge_order
         ; Alcotest.test_case "removed_output_budget_fields_rejected" `Quick
             test_config_rejects_removed_output_budget_fields
         ; Alcotest.test_case "empty_default_preset" `Quick test_config_empty_default_preset
@@ -1435,12 +1312,6 @@ let () =
         ; Alcotest.test_case "judge_prompt_missing" `Quick test_validated_judge_prompt_missing
         ; Alcotest.test_case "duplicate_judge" `Quick test_validated_duplicate_judge
         ; Alcotest.test_case "bad_meta_timeout" `Quick test_validated_bad_meta_timeout
-        ] )
-    ; ( "staged_judge_groups"
-      , [ Alcotest.test_case "exact_3x3" `Quick test_staged_judge_groups_exact_3x3
-        ; Alcotest.test_case "too_few" `Quick test_staged_judge_groups_too_few
-        ; Alcotest.test_case "ragged" `Quick test_staged_judge_groups_ragged
-        ; Alcotest.test_case "bad_size" `Quick test_staged_judge_groups_bad_size
         ] )
     ; ( "judge_args"
       , [ Alcotest.test_case "single_group_identity" `Quick

--- a/test/fusion_core/test_fusion.ml
+++ b/test/fusion_core/test_fusion.ml
@@ -1168,7 +1168,7 @@ let test_topology_unknown_is_none () =
 let test_topology_strings () =
   Alcotest.(check (list string))
     "all topology wire strings"
-    [ "simple"; "refine"; "conditional"; "judge_of_judges"; "staged_judge_of_judges" ]
+    [ "simple"; "refine"; "conditional"; "judge_of_judges" ]
     all_fusion_topology_strings
 
 (* Conditional 에스컬레이트 정책 — 닫힌 합 전수 값-핀. Insufficient만 escalate. *)

--- a/test/fusion_core/test_fusion_completion_outbox.ml
+++ b/test/fusion_core/test_fusion_completion_outbox.ml
@@ -1,0 +1,95 @@
+open Alcotest
+module O = Fusion_completion_outbox
+
+let require_ok = function
+  | Ok value -> value
+  | Error error -> fail (O.error_to_string error)
+;;
+
+let payload content = O.{ content; evidence_ref = Some "board/post-1" }
+let completion content = O.Succeeded (payload content)
+let address value = O.Completion_address.of_opaque_string value
+
+let with_path f =
+  let path = Filename.temp_file "fusion-completion-outbox" ".jsonl" in
+  Fun.protect ~finally:(fun () -> try Sys.remove path with Sys_error _ -> ()) (fun () -> f path)
+;;
+
+let test_durable_lifecycle () =
+  with_path (fun path ->
+    let operation_id = "fusion-17" in
+    let expected_address = address {|{"surface":"opaque","id":"thread-9"}|} in
+    let expected_completion = completion "synthesis" in
+    Sys.remove path;
+    let outbox = O.replay path in
+    (match O.register_address outbox ~operation_id expected_address |> require_ok with
+     | O.Registered -> ()
+     | O.Already_registered -> fail "first address registration must be new");
+    (match O.register_address outbox ~operation_id expected_address |> require_ok with
+     | O.Already_registered -> ()
+     | O.Registered -> fail "same address retry must be explicit");
+    (match O.complete outbox ~operation_id expected_completion |> require_ok with
+     | O.Queued -> ()
+     | O.Already_pending | O.Already_delivered -> fail "first completion must queue");
+    let replayed = O.replay path in
+    (match O.pending replayed with
+     | [ item ] ->
+       check string "operation identity" operation_id item.operation_id;
+       check bool "exact opaque address" true
+         (O.Completion_address.equal expected_address item.address);
+       check bool "exact completion" true (O.equal_completion expected_completion item.completion)
+     | items -> failf "expected one replayed item, got %d" (List.length items));
+    (match O.complete replayed ~operation_id expected_completion |> require_ok with
+     | O.Already_pending -> ()
+     | O.Queued | O.Already_delivered -> fail "replayed completion must remain pending");
+    (match O.acknowledge replayed ~operation_id |> require_ok with
+     | O.Acknowledged -> ()
+     | O.Already_acknowledged -> fail "first acknowledgement must be new");
+    let hydrated = O.replay path in
+    check int "ack removes pending item" 0 (List.length (O.pending hydrated));
+    match O.complete hydrated ~operation_id expected_completion |> require_ok with
+    | O.Already_delivered -> ()
+    | O.Queued | O.Already_pending -> fail "acknowledged completion must not queue twice")
+;;
+
+let test_conflicts_are_typed () =
+  let outbox = O.create () in
+  let operation_id = "fusion-conflict" in
+  ignore (O.register_address outbox ~operation_id (address "route-a") |> require_ok);
+  (match O.register_address outbox ~operation_id (address "route-b") with
+   | Error (O.Address_conflict id) -> check string "address conflict id" operation_id id
+   | Error error -> fail (O.error_to_string error)
+   | Ok _ -> fail "conflicting address must not succeed");
+  ignore (O.complete outbox ~operation_id (completion "first") |> require_ok);
+  (match O.complete outbox ~operation_id (completion "second") with
+   | Error (O.Completion_conflict id) -> check string "completion conflict id" operation_id id
+   | Error error -> fail (O.error_to_string error)
+   | Ok _ -> fail "conflicting completion must not succeed");
+  match O.complete outbox ~operation_id:"missing" (completion "orphan") with
+  | Error (O.Unknown_address id) -> check string "unknown address id" "missing" id
+  | Error error -> fail (O.error_to_string error)
+  | Ok _ -> fail "completion without an address must not succeed"
+;;
+
+let test_persistence_failure_is_fail_closed () =
+  with_path (fun regular_file ->
+    let outbox = O.create ~path:(Filename.concat regular_file "outbox.jsonl") () in
+    match O.register_address outbox ~operation_id:"fusion-write-failure" (address "route") with
+    | Error (O.Persistence_failed _) ->
+      (match O.complete outbox ~operation_id:"fusion-write-failure" (completion "result") with
+       | Error (O.Unknown_address _) -> ()
+       | Error error -> fail (O.error_to_string error)
+       | Ok _ -> fail "failed registration must not publish its address")
+    | Error error -> fail (O.error_to_string error)
+    | Ok _ -> fail "an undurable address must not be reported as registered")
+;;
+
+let () =
+  run "fusion_completion_outbox"
+    [ ( "durability"
+      , [ test_case "replay exact pending and acknowledged identity" `Quick test_durable_lifecycle
+        ; test_case "conflicts are typed failures" `Quick test_conflicts_are_typed
+        ; test_case "persistence failure is fail-closed" `Quick
+            test_persistence_failure_is_fail_closed
+        ] )
+    ]

--- a/test/fusion_core/test_fusion_config_json.ml
+++ b/test/fusion_core/test_fusion_config_json.ml
@@ -6,7 +6,7 @@
 let parse s = Otoml.Parser.from_string s
 
 (* Mirrors config/runtime.toml [fusion.presets.quorum] structure with placeholder
-   model ids; judges >= 2 so the JoJ array-of-tables projection is exercised. *)
+   model ids so the JoJ array-of-tables projection is exercised. *)
 let joj_preset_toml =
   {|
 [fusion]

--- a/test/fusion_core/test_fusion_run_registry.ml
+++ b/test/fusion_core/test_fusion_run_registry.ml
@@ -6,17 +6,38 @@ module Registry = Fusion_run_registry
 module R = struct
   include Registry
 
-  let register_running_result = Registry.register_running
-  let mark_completed_result = Registry.mark_completed
+  let operation ~run_id ~keeper ~preset : Fusion_types.fusion_operation =
+    { request =
+        { run_id
+        ; keeper
+        ; prompt = "registry test"
+        ; preset
+        ; web_tools = false
+        ; depth = Fusion_types.Fusion_depth.Top
+        ; trigger = Fusion_types.Harness_eval
+        }
+    ; topology = Fusion_types.Simple
+    }
+  ;;
+
+  let register_running_result t ~run_id ~keeper ~preset ~started_at =
+    Registry.register_running t ~operation:(operation ~run_id ~keeper ~preset) ~started_at
+  ;;
+
+  let mark_completed_result t ~run_id ?failure ?failure_code ~ok () =
+    Registry.mark_completed t ~operation_id:run_id ?failure ?failure_code ~ok ()
+  ;;
+
+  let get t ~run_id = Registry.get t ~operation_id:run_id
 
   let register_running t ~run_id ~keeper ~preset ~started_at =
-    match Registry.register_running t ~run_id ~keeper ~preset ~started_at with
+    match register_running_result t ~run_id ~keeper ~preset ~started_at with
     | Ok () -> ()
     | Error error -> fail (Registry.persistence_error_to_string error)
   ;;
 
   let mark_completed t ~run_id ?failure ?failure_code ~ok () =
-    match Registry.mark_completed t ~run_id ?failure ?failure_code ~ok () with
+    match mark_completed_result t ~run_id ?failure ?failure_code ~ok () with
     | Ok () -> ()
     | Error error -> fail (Registry.completion_error_to_string error)
   ;;
@@ -49,8 +70,8 @@ let test_register_then_query () =
   R.register_running t ~run_id:"r1" ~keeper:"k" ~preset:"balanced" ~started_at:10.0;
   (match R.get t ~run_id:"r1" with
    | Some run ->
-     check string "keeper" "k" run.R.keeper;
-     check string "preset" "balanced" run.R.preset;
+     check string "keeper" "k" (R.keeper run);
+     check string "preset" "balanced" (R.preset run);
      check bool "is running" true (status_running run.R.status)
    | None -> fail "registered run must be retrievable");
   check int "one run tracked" 1 (List.length (R.list_runs t))
@@ -144,7 +165,7 @@ let test_list_newest_first () =
   R.register_running t ~run_id:"old" ~keeper:"k" ~preset:"p" ~started_at:1.0;
   R.register_running t ~run_id:"new" ~keeper:"k" ~preset:"p" ~started_at:9.0;
   match R.list_runs t with
-  | first :: _ -> check string "newest started_at first" "new" first.R.run_id
+  | first :: _ -> check string "newest started_at first" "new" (Registry.operation_id first)
   | [] -> fail "expected runs"
 ;;
 
@@ -198,8 +219,11 @@ let test_run_to_yojson_recovery_shape () =
     ~finally:(fun () -> try Sys.remove path with Sys_error _ -> ())
     (fun () ->
        Fs_compat.save_file path
-         {|{"event":"register","run_id":"r-recovery","keeper":"kx","preset":"deep","started_at":42.0}
-|};
+         (Fusion_run_registry_event.to_jsonl
+            (Fusion_run_registry_event.Register
+               { operation = R.operation ~run_id:"r-recovery" ~keeper:"kx" ~preset:"deep"
+               ; started_at = 42.0
+               }));
        let replayed = R.replay path in
        match R.get replayed ~run_id:"r-recovery" with
        | None -> fail "unfinished run must remain in recovery inventory"
@@ -226,6 +250,7 @@ let test_run_to_yojson_shape () =
     check string "run_id" "r-ser" (yojson_str j "run_id");
     check string "keeper" "kx" (yojson_str j "keeper");
     check string "preset" "deep" (yojson_str j "preset");
+    check string "topology" "simple" (yojson_str j "topology");
     check string "status label (ok=false -> failed)" "failed" (yojson_str j "status");
     (match yojson_field j "started_at" with
      | Some (`Float f) -> check (float 0.001) "started_at" 42.0 f

--- a/test/test_fusion_metrics.ml
+++ b/test/test_fusion_metrics.ml
@@ -21,8 +21,6 @@ let test_labels () =
     (Fusion_metrics.topology_label Fusion_types.Simple);
   check string "topology judge_of_judges" "judge_of_judges"
     (Fusion_metrics.topology_label Fusion_types.Judge_of_judges);
-  check string "topology staged_judge_of_judges" "staged_judge_of_judges"
-    (Fusion_metrics.topology_label Fusion_types.Staged_judge_of_judges);
   check string "role single" "single"
     (Fusion_metrics.judge_role_label Fusion_types.Single);
   check string "role first" "first"

--- a/test/test_fusion_run_registry_persist.ml
+++ b/test/test_fusion_run_registry_persist.ml
@@ -10,16 +10,36 @@ module Registry = Fusion_run_registry
 module R = struct
   include Registry
 
-  let mark_completed_result = Registry.mark_completed
+  let operation ~run_id ~keeper ~preset : Fusion_types.fusion_operation =
+    { request =
+        { run_id
+        ; keeper
+        ; prompt = "durable registry test"
+        ; preset
+        ; web_tools = true
+        ; depth = Fusion_types.Fusion_depth.Top
+        ; trigger = Fusion_types.Harness_eval
+        }
+    ; topology = Fusion_types.Judge_of_judges
+    }
+  ;;
+
+  let mark_completed_result t ~run_id ?failure ?failure_code ~ok () =
+    Registry.mark_completed t ~operation_id:run_id ?failure ?failure_code ~ok ()
+  ;;
+
+  let get t ~run_id = Registry.get t ~operation_id:run_id
 
   let register_running t ~run_id ~keeper ~preset ~started_at =
-    match Registry.register_running t ~run_id ~keeper ~preset ~started_at with
+    match
+      Registry.register_running t ~operation:(operation ~run_id ~keeper ~preset) ~started_at
+    with
     | Ok () -> ()
     | Error error -> fail (Registry.persistence_error_to_string error)
   ;;
 
   let mark_completed t ~run_id ?failure ?failure_code ~ok () =
-    match Registry.mark_completed t ~run_id ?failure ?failure_code ~ok () with
+    match mark_completed_result t ~run_id ?failure ?failure_code ~ok () with
     | Ok () -> ()
     | Error error -> fail (Registry.completion_error_to_string error)
   ;;
@@ -51,6 +71,24 @@ let fresh_path suffix =
   let path = Filename.temp_file "fusion-runs-" suffix in
   remove_if_exists path;
   path
+;;
+
+let register_event ~run_id ~keeper ~preset ~started_at =
+  Fusion_run_registry_event.Register
+    { operation = R.operation ~run_id ~keeper ~preset; started_at }
+  |> Fusion_run_registry_event.to_yojson
+  |> Yojson.Safe.to_string
+;;
+
+let complete_event ~run_id ~ok =
+  Fusion_run_registry_event.Complete
+    { operation_id = run_id
+    ; ok
+    ; failure = None
+    ; failure_code = None
+    }
+  |> Fusion_run_registry_event.to_yojson
+  |> Yojson.Safe.to_string
 ;;
 
 let field j k =
@@ -88,13 +126,22 @@ let test_persist_register_complete () =
   check int "two events + trailing newline" 3 (List.length lines);
   let event1 = parse (List.nth lines 0) in
   check string "event1 kind" "register" (str event1 "event");
-  check string "event1 run_id" "r1" (str event1 "run_id");
-  check string "event1 keeper" "k" (str event1 "keeper");
-  check string "event1 preset" "p" (str event1 "preset");
+  let persisted_operation =
+    match field event1 "operation" with
+    | Some json ->
+      (match Fusion_types.fusion_operation_of_yojson json with
+       | Ok operation -> operation
+       | Error error -> fail error)
+    | None -> fail "register event must contain its canonical operation"
+  in
+  check bool "event1 canonical operation" true
+    (Fusion_types.equal_fusion_operation
+       (R.operation ~run_id:"r1" ~keeper:"k" ~preset:"p")
+       persisted_operation);
   check (float 0.001) "event1 started_at" 1.0 (float_ event1 "started_at");
   let event2 = parse (List.nth lines 1) in
   check string "event2 kind" "complete" (str event2 "event");
-  check string "event2 run_id" "r1" (str event2 "run_id");
+  check string "event2 operation_id" "r1" (str event2 "operation_id");
   check bool "event2 ok" true (bool_ event2 "ok")
 ;;
 
@@ -172,7 +219,15 @@ let test_replay_prunes_completed () =
   check int "completed retention plus recovery row"
     (R.max_completed_retained + 1) (List.length runs);
   (match R.get t2 ~run_id:"r-running" with
-   | Some { R.status = R.Recovery_required { reason = R.Worker_process_restarted }; _ } -> ()
+   | Some
+       { R.operation
+       ; status = R.Recovery_required { reason = R.Worker_process_restarted }
+       ; _
+       } ->
+     check bool "recovery row preserves canonical operation" true
+       (Fusion_types.equal_fusion_operation
+          (R.operation ~run_id:"r-running" ~keeper:"k" ~preset:"p")
+          operation)
    | Some _ -> fail "unfinished run must be recovery-required after replay"
    | None -> fail "unfinished run must remain observable after replay");
   check bool "compacted log preserves unfinished run" true
@@ -191,21 +246,24 @@ let test_no_path_is_in_memory_only () =
   check bool "no file created" false (Sys.file_exists path)
 ;;
 
-(* (4) Replay skips malformed lines without dropping valid neighboring events. *)
+(* (4) Replay skips malformed and removed-schema lines without dropping valid
+   neighboring canonical events. The old metadata-only schema is not migrated. *)
 let test_replay_skips_malformed_lines () =
   let path = fresh_path "-malformed.jsonl" in
   Fs_compat.save_file
     path
     (String.concat
        "\n"
-	       [ {|{"event":"register","run_id":"r1","keeper":"k","preset":"p","started_at":1.0}|}
+	       [ register_event ~run_id:"r1" ~keeper:"k" ~preset:"p" ~started_at:1.0
 	       ; {|not-json|}
-	       ; {|{"event":"register","run_id":42,"keeper":"k","preset":"p","started_at":2.0}|}
-	       ; {|{"event":"complete","run_id":"r1","ok":"false"}|}
+	       ; {|{"event":"register","run_id":"r-legacy","keeper":"k","preset":"p","started_at":2.0}|}
 	       ; {|{"event":"complete","run_id":"r1","ok":false}|}
+	       ; complete_event ~run_id:"r1" ~ok:false
 	       ; ""
 	       ]);
   let t = R.replay path in
+  check bool "legacy metadata-only register is rejected" true
+    (Option.is_none (R.get t ~run_id:"r-legacy"));
   match R.get t ~run_id:"r1" with
   | Some { R.status = R.Completed { ok = false; _ }; _ } -> ()
   | Some _ -> fail "expected replayed run to be completed as failed"
@@ -216,9 +274,9 @@ let test_replay_skips_malformed_lines () =
 let test_replay_streams_and_compacts () =
   let path = fresh_path "-stream.jsonl" in
   let before =
-    {|{"event":"register","run_id":"r-stream","keeper":"k","preset":"p","started_at":1.0}|}
+    register_event ~run_id:"r-stream" ~keeper:"k" ~preset:"p" ~started_at:1.0
   in
-  let after = {|{"event":"complete","run_id":"r-stream","ok":true}|} in
+  let after = complete_event ~run_id:"r-stream" ~ok:true in
   let malformed_padding = String.make 70000 'x' in
   let content = String.concat "\n" [ before; malformed_padding; after; "" ] in
   Fs_compat.save_file
@@ -238,9 +296,9 @@ let test_replay_streams_and_compacts () =
 let test_replay_preserves_unterminated_tail () =
   let path = fresh_path "-partial-tail.jsonl" in
   let complete =
-    {|{"event":"register","run_id":"r-partial","keeper":"k","preset":"p","started_at":1.0}|}
+    register_event ~run_id:"r-partial" ~keeper:"k" ~preset:"p" ~started_at:1.0
   in
-  let partial = {|{"event":"complete","run_id":"r-partial","ok":true}|} in
+  let partial = complete_event ~run_id:"r-partial" ~ok:true in
   let content = String.concat "\n" [ complete; partial ] in
   Fs_compat.save_file
     path

--- a/test/test_fusion_status_tool.ml
+++ b/test/test_fusion_status_tool.ml
@@ -18,14 +18,33 @@ module Registry = Fusion_run_registry
 module R = struct
   include Registry
 
+  let operation ~run_id ~keeper ~preset : Fusion_types.fusion_operation =
+    { request =
+        { run_id
+        ; keeper
+        ; prompt = "status test"
+        ; preset
+        ; web_tools = false
+        ; depth = Fusion_types.Fusion_depth.Top
+        ; trigger = Fusion_types.Harness_eval
+        }
+    ; topology = Fusion_types.Simple
+    }
+  ;;
+
   let register_running t ~run_id ~keeper ~preset ~started_at =
-    match Registry.register_running t ~run_id ~keeper ~preset ~started_at with
+    match
+      Registry.register_running t ~operation:(operation ~run_id ~keeper ~preset) ~started_at
+    with
     | Ok () -> ()
     | Error error -> fail (Registry.persistence_error_to_string error)
   ;;
 
   let mark_completed t ~run_id ?failure ?failure_code ~ok () =
-    match Registry.mark_completed t ~run_id ?failure ?failure_code ~ok () with
+    match
+      Registry.mark_completed t ~operation_id:run_id ?failure ?failure_code
+        ~ok ()
+    with
     | Ok () -> ()
     | Error error -> fail (Registry.completion_error_to_string error)
   ;;

--- a/test/test_fusion_wake.ml
+++ b/test/test_fusion_wake.ml
@@ -209,7 +209,6 @@ let fusion_tool_policy () : Fusion_policy.t =
   in
   { enabled = true
   ; default_preset = preset.name
-  ; staged_judge_group_size = Fusion_policy.default_staged_judge_group_size
   ; presets = [ validated_preset preset ]
   }
 ;;

--- a/test/test_fusion_wake.ml
+++ b/test/test_fusion_wake.ml
@@ -14,12 +14,31 @@
 open Alcotest
 open Masc
 
+let fusion_operation ~run_id ~keeper ~preset : Fusion_types.fusion_operation =
+  { request =
+      { run_id
+      ; keeper
+      ; prompt = "fusion wake test"
+      ; preset
+      ; web_tools = false
+      ; depth = Fusion_types.Fusion_depth.Top
+      ; trigger = Fusion_types.Harness_eval
+      }
+  ; topology = Fusion_types.Simple
+  }
+;;
+
 let register_running_exn registry ~run_id ~keeper ~preset ~started_at =
   match
-    Fusion_run_registry.register_running registry ~run_id ~keeper ~preset ~started_at
+    Fusion_run_registry.register_running registry
+      ~operation:(fusion_operation ~run_id ~keeper ~preset) ~started_at
   with
   | Ok () -> ()
   | Error error -> fail (Fusion_run_registry.persistence_error_to_string error)
+;;
+
+let get_run registry ~run_id =
+  Fusion_run_registry.get registry ~operation_id:run_id
 ;;
 
 (* substring check without pulling in the [str] library *)
@@ -522,7 +541,7 @@ let test_emit_success_projects_board_chat_and_registry () =
        check string "chat fusion block post id" post_id block_post_id;
        check string "chat fusion block run id" run_id block_run_id
      | None -> fail "chat lane should carry a Fusion block for the board evidence");
-    match Fusion_run_registry.get (Fusion_run_registry.global ()) ~run_id with
+    match get_run (Fusion_run_registry.global ()) ~run_id with
     | Some { Fusion_run_registry.status = Completed { ok = true; _ }; _ } -> ()
     | Some { Fusion_run_registry.status = Completed { ok = false; _ }; _ } ->
       fail "fusion run should complete ok=true"
@@ -725,10 +744,10 @@ let test_tool_handle_async_success_projects_running_then_completed () =
       (contains
          ~needle:"No need to poll masc_fusion_status"
          (string_field "fusion_tool.response" response_fields "delivery"));
-    (match Fusion_run_registry.get (Fusion_run_registry.global ()) ~run_id with
-     | Some { keeper = observed_keeper; preset; status = Fusion_run_registry.Running; _ } ->
-       check string "running keeper" keeper observed_keeper;
-       check string "running preset" "unit" preset
+    (match get_run (Fusion_run_registry.global ()) ~run_id with
+     | Some ({ status = Fusion_run_registry.Running; _ } as run) ->
+       check string "running keeper" keeper (Fusion_run_registry.keeper run);
+       check string "running preset" "unit" (Fusion_run_registry.preset run)
      | Some { Fusion_run_registry.status = Completed _; _ } ->
        fail "fusion run should still be Running before the background runner is released"
      | Some { Fusion_run_registry.status = Recovery_required _; _ } ->
@@ -790,7 +809,7 @@ let test_tool_handle_async_success_projects_running_then_completed () =
        check string "chat fusion block post id" post_id block_post_id;
        check string "chat fusion block run id" run_id block_run_id
      | None -> fail "chat lane should carry a Fusion block after async completion");
-    match Fusion_run_registry.get (Fusion_run_registry.global ()) ~run_id with
+    match get_run (Fusion_run_registry.global ()) ~run_id with
     | Some { Fusion_run_registry.status = Completed { ok = true; _ }; _ } -> ()
     | Some { Fusion_run_registry.status = Completed { ok = false; _ }; _ } ->
       fail "fusion run should complete ok=true"
@@ -827,7 +846,7 @@ let test_tool_handle_does_not_start_without_durable_register () =
       (string_field "fusion_tool.persistence_failure" response "status");
     check bool "runner was not called" false !called;
     check bool "failed run was not published" true
-      (Option.is_none (Fusion_run_registry.get (Fusion_run_registry.global ()) ~run_id)))
+      (Option.is_none (get_run (Fusion_run_registry.global ()) ~run_id)))
 ;;
 
 let test_emit_board_failure_is_best_effort () =
@@ -843,7 +862,7 @@ let test_emit_board_failure_is_best_effort () =
         ~judge_usage:Fusion_types.zero_usage
     in
     check bool "board failure does not fail emit" true (Result.is_ok result);
-    (match Fusion_run_registry.get (Fusion_run_registry.global ()) ~run_id with
+    (match get_run (Fusion_run_registry.global ()) ~run_id with
      | Some run ->
        (match run.Fusion_run_registry.status with
         | Fusion_run_registry.Completed { ok = true; _ } -> ()


### PR DESCRIPTION
## Scope

- Add a Fusion-owned opaque Completion_address type. Fusion preserves bytes exactly and knows no Keeper, Connector, Discord, Slack, Dashboard, or wake type.
- Persist three typed events under one operation identity: address registration, completion queueing, and acknowledgement.
- Keep immutable Map snapshots and serialize check-append-publish mutations with a mutex; failed durable append never publishes memory state.
- Return explicit Registered/Already_registered, Queued/Already_pending/Already_delivered, and Acknowledged/Already_acknowledged receipts. Unknown addresses and conflicting addresses/completions are typed errors, not silent success.
- Hydrate the process-global outbox from BasePath .masc/fusion-completion-outbox.jsonl before an upper delivery adapter can drain it.

## Evidence

- Exact diff: 366 changed lines, comprising 364 insertions and 2 deletions.
- ocamlformat and git diff --check pass.
- All touched ML/MLI files pass parser checks.
- The new MLI, implementation, and test compile against the real project Fs_compat and Log interfaces with the installed OCaml toolchain.
- Standalone real file append/replay test: 3/3 pass. It covers exact operation/address/completion replay, acknowledged replay, explicit retry receipts, typed conflicts, unknown address, and fail-closed persistence failure.
- fusion_core boundary scans: Keeper/connector/wake vocabulary 0; environment lookup 0; string classification 0.
- Official focused wrapper was attempted and is not claimed green: agent_sdk is pinned locally at 7e7b1e703a5fa2e8a8e504b5eb8a96d0290ad164 while this repository expects b02bc16f57b18542abae17023e1a2b886cda7347. No pin-check bypass was used; CI remains build authority.

## Deliberately incomplete

This child creates and hydrates the generic durable substrate only. It does not wire Keeper_continuation_channel, wake a Keeper, or drain pending entries.

- C18b: upper MASC adapter encodes and decodes Keeper continuation channels, registers addresses before worker start, projects completion into the Keeper durable queue, and acknowledges only after that commit.
- C19: explicit recovery claim/start handshake prevents duplicate execution of replayed operations.

Stacked on #24724.