### PR TITLE
feat(keeper): drain durable Memory work by owner

### DIFF
--- a/lib/keeper/keeper_agent_run_post_turn_memory.ml
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.ml
@@ -2,9 +2,97 @@
 
     Extracted from [Keeper_agent_run.run_turn] Step 8 body (RFC-0147 PR-4). *)
 
+let record_librarian_failure ~keeper_name error =
+  Otel_metric_store.inc_counter
+    Keeper_metrics.(to_string EpisodeCreateFailures)
+    ~labels:[ "keeper", keeper_name; "site", "memory_os_librarian" ]
+    ();
+  Keeper_librarian_runtime.operation_error_to_string error
+;;
+
+let execute_request ~base_path request =
+  let keeper_name = Keeper_memory_work_request.keeper_name request in
+  try
+    let config = Workspace.default_config base_path in
+    let meta = Keeper_memory_work_request.meta request in
+    let turn = Keeper_memory_work_request.turn request in
+    let notes_written =
+      Memory.append_from_tool_results
+        config
+        meta
+        ~turn
+        ~results:(Keeper_memory_work_request.tool_results request)
+    in
+    if notes_written > 0
+    then
+      Keeper_turn_telemetry.log_keeper_memory_write
+        ~keeper_name
+        ~notes_written
+        ~kinds_written:[ "long_term" ];
+    let input : Keeper_librarian.input =
+      { trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id
+      ; generation = Keeper_memory_work_request.generation request
+      ; messages = Keeper_memory_work_request.librarian_messages request
+      }
+    in
+    let operation : Keeper_librarian_runtime.operation_request =
+      { runtime_id = Keeper_memory_work_request.runtime_id request
+      ; keeper_id = keeper_name
+      ; input
+      }
+    in
+    (match Keeper_librarian_runtime.execute_operation operation with
+     | Error error -> Error (record_librarian_failure ~keeper_name error)
+     | Ok episode ->
+       Log.Keeper.info ~keeper_name
+         "memory os librarian wrote episode trace_id=%s generation=%d claims=%d"
+         episode.Keeper_memory_os_types.trace_id
+         episode.generation
+         (List.length episode.claims);
+       Ok ())
+  with
+  | Eio.Cancel.Cancelled _ as error -> raise error
+  | exn ->
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string MemoryWriteFailures)
+      ~labels:[ "keeper", keeper_name ]
+      ();
+    Error (Printexc.to_string exn)
+;;
+
+let drain_keeper ~base_path ~keeper_name =
+  match
+    Keeper_memory_work_drain.drain
+      ~base_path
+      ~keeper_name
+      ~execute:(execute_request ~base_path)
+  with
+  | Ok report ->
+    Log.Keeper.info ~keeper_name
+      "memory owner drain recovered=%d claimed=%d completed=%d failed=%d"
+      report.recovered
+      report.claimed
+      report.completed
+      report.failed
+  | Error error ->
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string DispatchEventFailures)
+      ~labels:[ "keeper", keeper_name; "site", "memory_owner_drain" ]
+      ();
+    Log.Keeper.error ~keeper_name
+      "memory owner drain failed: %s"
+      (Keeper_memory_work_drain.error_to_string error)
+;;
+
+let schedule_drain ~base_path ~keeper_name =
+  Keeper_memory_lane.submit
+    ~base_path
+    ~keeper_name
+    (fun () -> drain_keeper ~base_path ~keeper_name)
+;;
 
 let run
-  ~config
+  ~(config : Workspace.config)
   ~meta
   ~generation
   ~turn
@@ -27,80 +115,54 @@ let run
       (Keeper_tool_emission_hook.accumulator_for_keeper
          meta.Keeper_meta_contract.name)
   in
-  (* (1) deterministic write and (2) LLM librarian extraction run on this
-     keeper's memory lane (RFC-0257), detached from the turn lane. Both may
-     touch the keeper's memory stores; the per-keeper FIFO worker serializes
-     them. meta/config are immutable snapshots, so
-     using them after the turn returns does not race a later turn.
-     See RFC #3646 Section 3: Det/NonDet boundary. *)
-  let memory_series () =
-  (try
-     let notes_written =
-       Memory.append_from_tool_results
-         config
-         meta
-         ~turn
-         ~results:tool_results_snapshot
-     in
-     let kinds_written =
-       if notes_written > 0 then [ "long_term" ] else []
-     in
-     if notes_written > 0
-     then
-       Keeper_turn_telemetry.log_keeper_memory_write
-         ~keeper_name:meta.name
-         ~notes_written
-         ~kinds_written
+  let deliberation_execution_json =
+    Option.map Keeper_deliberation.execution_result_to_json deliberation_execution
+  in
+  (match
+     Keeper_memory_work_request.make
+       ~keeper_name:meta.name
+       ~generation
+       ~turn
+       ~runtime_id
+       ~meta
+       ~tool_results:tool_results_snapshot
+       ~librarian_messages
+       ~deliberation_execution:deliberation_execution_json
    with
-   | exn ->
-     Log.Keeper.error ~keeper_name:meta.name
-       "memory_write failed: %s"
-       (Printexc.to_string exn);
+   | Error detail ->
      Otel_metric_store.inc_counter
-       Keeper_metrics.(to_string MemoryWriteFailures)
-       ~labels:[ "keeper", meta.name ]
-       ());
-
-  (* Memory OS librarian extraction: opt-in, provider-backed, best-effort. *)
-  let librarian_input : Keeper_librarian.input =
-    { trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id
-    ; generation
-    ; messages = librarian_messages
-    }
-  in
-  let librarian_request : Keeper_librarian_runtime.operation_request =
-    { runtime_id; keeper_id = meta.name; input = librarian_input }
-  in
-  (match Keeper_librarian_runtime.execute_operation librarian_request with
-   | Ok episode ->
-     Log.Keeper.info ~keeper_name:meta.name
-       "memory os librarian wrote episode trace_id=%s generation=%d claims=%d"
-       episode.Keeper_memory_os_types.trace_id
-       episode.generation
-       (List.length episode.claims)
-   | Error error ->
-     (match error with
-      | Keeper_librarian_runtime.Provider_slot_busy _ ->
-        Otel_metric_store.inc_counter
-          Keeper_metrics.(to_string MemoryLaneProviderSlotBusy)
-          ~labels:
-            [ "keeper", meta.name
-            ; "site", Keeper_librarian_runtime.memory_os_librarian_provider_slot_site
-            ]
-          ()
-      | _ -> ());
-     Otel_metric_store.inc_counter
-       Keeper_metrics.(to_string EpisodeCreateFailures)
-       ~labels:[ "keeper", meta.name; "site", "memory_os_librarian" ]
+       Keeper_metrics.(to_string DispatchEventFailures)
+       ~labels:[ "keeper", meta.name; "site", "memory_work_request" ]
        ();
      Log.Keeper.error ~keeper_name:meta.name
-       "memory os librarian operation failed runtime=%s: %s"
-       runtime_id
-       (Keeper_librarian_runtime.operation_error_to_string error));
+       "memory work request rejected: %s"
+       detail
+   | Ok request ->
+     (match Keeper_memory_work_store.enqueue ~base_path:config.base_path request with
+      | Error error ->
+        Otel_metric_store.inc_counter
+          Keeper_metrics.(to_string DispatchEventFailures)
+          ~labels:[ "keeper", meta.name; "site", "memory_work_enqueue" ]
+          ();
+        Log.Keeper.error ~keeper_name:meta.name
+          "memory work durable enqueue failed: %s"
+          (Keeper_memory_work_store.error_to_string error)
+      | Ok
+          ( Keeper_memory_work_store.Enqueued
+          | Keeper_memory_work_store.Already_present ) ->
+        (match schedule_drain ~base_path:config.base_path ~keeper_name:meta.name with
+         | Ok () -> ()
+         | Error error ->
+           Otel_metric_store.inc_counter
+             Keeper_metrics.(to_string DispatchEventFailures)
+             ~labels:[ "keeper", meta.name; "site", "memory_owner_drain_admission" ]
+             ();
+           Log.Keeper.error ~keeper_name:meta.name
+             "memory work is durable but owner drain admission failed: %s"
+             (Keeper_memory_lane.admission_error_to_string error))));
 
-  (* Advisory delegation request drafts: keep review artifact persistence on the
-     same bounded post-turn memory lane as draft-skill projection, not on the
-     decision-record append path. *)
+  (* Delegation projection remains an explicit artifact boundary; it is not a
+     Memory work settlement. *)
   (try
      match deliberation_execution with
      | None -> ()
@@ -137,29 +199,6 @@ let run
        "delegation_requests failed: %s"
        (Printexc.to_string exn));
 
-  in
-  (* RFC-0257: detach (1)-(2) onto the per-keeper memory lane. Admission failure
-     is explicit and observable; provider-backed work never falls back into the
-     submitting turn fiber. *)
-  (match
-     Keeper_memory_lane.submit
-       ~base_path:config.base_path
-       ~keeper_name:meta.name
-       memory_series
-   with
-   | Ok () -> ()
-   | Error error ->
-     Otel_metric_store.inc_counter
-       Keeper_metrics.(to_string DispatchEventFailures)
-       ~labels:
-         [ "keeper", meta.name
-         ; "site", "memory_lane_admission"
-         ; "reason", Keeper_memory_lane.admission_error_code error
-         ]
-       ();
-     Log.Keeper.error ~keeper_name:meta.name
-       "post-turn memory lane admission failed: %s"
-       (Keeper_memory_lane.admission_error_to_string error));
   (* Post-turn memory recall evidence is logged to decisions.jsonl. *)
   (try
      let used_search =

--- a/lib/keeper/keeper_agent_run_post_turn_memory.mli
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.mli
@@ -5,8 +5,13 @@
     memory-bank rows: semantic consolidation requires an explicit typed LLM
     Memory operation, never a storage-pressure survival rule.
 
-    Each sub-stage is best-effort: non-cancel exceptions are logged and
-    counted, never propagated.  [Eio.Cancel.Cancelled] is re-raised. *)
+    Memory work is durably admitted before the owner lane is signalled. *)
+
+val schedule_drain
+  :  base_path:string
+  -> keeper_name:string
+  -> (unit, Keeper_memory_lane.admission_error) result
+(** Signal the per-Keeper owner lane to drain already-durable Memory work. *)
 
 val run :
   config:Workspace.config ->
@@ -32,6 +37,5 @@ val run :
     [inference_telemetry] is [result.response.telemetry] from the OAS
     result; it is optional because some providers do not emit telemetry.
 
-    [deliberation_execution], when available, is persisted as advisory
-    delegation request artifacts on this post-turn memory lane rather than on
-    the decision-record append path. *)
+    [deliberation_execution], when available, is persisted at the separate
+    delegation artifact boundary. *)

--- a/lib/keeper/keeper_memory_work_drain.ml
+++ b/lib/keeper/keeper_memory_work_drain.ml
@@ -1,0 +1,79 @@
+type report =
+  { recovered : int
+  ; claimed : int
+  ; completed : int
+  ; failed : int
+  }
+
+type error =
+  | Store_error of Keeper_memory_work_store.error
+  | Concurrent_claim of string
+
+let empty = { recovered = 0; claimed = 0; completed = 0; failed = 0 }
+let ( let* ) = Result.bind
+
+let error_to_string = function
+  | Store_error error -> Keeper_memory_work_store.error_to_string error
+  | Concurrent_claim request_id ->
+    Printf.sprintf "Memory work already claimed by another owner: %s" request_id
+;;
+
+let store result = Result.map_error (fun error -> Store_error error) result
+
+let next ~base_path ~keeper_name =
+  let* recovered =
+    Keeper_memory_work_store.recover_in_flight ~base_path ~keeper_name |> store
+  in
+  match recovered with
+  | Some request -> Ok (Some (`Recovered, request))
+  | None ->
+    let* claimed =
+      Keeper_memory_work_store.claim_next ~base_path ~keeper_name |> store
+    in
+    (match claimed with
+     | Keeper_memory_work_store.Queue_empty -> Ok None
+     | Keeper_memory_work_store.Claim_busy request_id ->
+       Error (Concurrent_claim request_id)
+     | Keeper_memory_work_store.Claimed request ->
+       Ok (Some (`Claimed, request)))
+;;
+
+let execute_result execute request =
+  try execute request with
+  | Eio.Cancel.Cancelled _ as error -> raise error
+  | exn -> Error (Printexc.to_string exn)
+;;
+
+let rec loop ~base_path ~keeper_name ~execute report =
+  let* next = next ~base_path ~keeper_name in
+  match next with
+  | None -> Ok report
+  | Some (source, request) ->
+    let request_id = Keeper_memory_work_request.request_id request in
+    let execution = execute_result execute request in
+    let outcome =
+      match execution with
+      | Ok () -> Keeper_memory_work_store.Completed
+      | Error detail -> Keeper_memory_work_store.Failed detail
+    in
+    let* (_ : Keeper_memory_work_store.settle_result) =
+      Keeper_memory_work_store.settle
+        ~base_path
+        ~keeper_name
+        ~request_id
+        outcome
+      |> store
+    in
+    let report =
+      { recovered = report.recovered + (match source with `Recovered -> 1 | `Claimed -> 0)
+      ; claimed = report.claimed + (match source with `Recovered -> 0 | `Claimed -> 1)
+      ; completed = report.completed + (match execution with Ok () -> 1 | Error _ -> 0)
+      ; failed = report.failed + (match execution with Ok () -> 0 | Error _ -> 1)
+      }
+    in
+    loop ~base_path ~keeper_name ~execute report
+;;
+
+let drain ~base_path ~keeper_name ~execute =
+  loop ~base_path ~keeper_name ~execute empty
+;;

--- a/lib/keeper/keeper_memory_work_drain.mli
+++ b/lib/keeper/keeper_memory_work_drain.mli
@@ -1,0 +1,24 @@
+(** Exact owner-lane drain over {!Keeper_memory_work_store}. *)
+
+type report =
+  { recovered : int
+  ; claimed : int
+  ; completed : int
+  ; failed : int
+  }
+
+type error =
+  | Store_error of Keeper_memory_work_store.error
+  | Concurrent_claim of string
+
+val error_to_string : error -> string
+
+val drain
+  :  base_path:string
+  -> keeper_name:string
+  -> execute:(Keeper_memory_work_request.t -> (unit, string) result)
+  -> (report, error) result
+(** Recover the exact in-flight request first, then claim and settle the durable
+    FIFO until empty. [Completed] is written only for [Ok ()]; [Error detail]
+    is durably settled as [Failed detail]. A store or settlement error stops the
+    drain with the current request still recoverable. *)

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -151,7 +151,6 @@ type t =
   | MemoryLaneCancelledUnits
   | MemoryLanePending
   | MemoryLaneInFlight
-  | MemoryLaneProviderSlotBusy
   | MemoryBankCompactionFailures
   | MemoryOsMaintenanceKeeperTimeout
   | WriteMetaCycleFailures
@@ -378,7 +377,6 @@ let to_string = function
   | MemoryLaneCancelledUnits -> "masc_keeper_memory_lane_cancelled_units_total"
   | MemoryLanePending -> "masc_keeper_memory_lane_pending"
   | MemoryLaneInFlight -> "masc_keeper_memory_lane_in_flight"
-  | MemoryLaneProviderSlotBusy -> "masc_keeper_memory_lane_provider_slot_busy_total"
   | MemoryBankCompactionFailures -> "masc_keeper_memory_bank_compaction_failures_total"
   | MemoryOsMaintenanceKeeperTimeout -> "masc_keeper_memory_os_maintenance_keeper_timeout_total"
   | WriteMetaCycleFailures -> "masc_keeper_write_meta_cycle_failures_total"

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -142,7 +142,6 @@ type t =
   | MemoryLaneCancelledUnits
   | MemoryLanePending
   | MemoryLaneInFlight
-  | MemoryLaneProviderSlotBusy
   | MemoryBankCompactionFailures
   | MemoryOsMaintenanceKeeperTimeout
   | WriteMetaCycleFailures

--- a/lib/server/server_dashboard_http_keeper_memory_health.ml
+++ b/lib/server/server_dashboard_http_keeper_memory_health.ml
@@ -11,8 +11,6 @@
     - [Keeper_memory_os_io.events_path] + file stat for events bytes.
     - [Keeper_memory_os_gc.run_gc ~dry_run:true] for explicitly expired rows
       without mutating the store.
-    - [Otel_metric_store] provider-slot-busy counters for skipped librarian
-      extraction attempts, grouped by keeper.
     - [Keeper_librarian_runtime.cadence_counter_entries] for the cadence table
       size (one fleet-wide value). *)
 
@@ -25,20 +23,17 @@ type keeper_health =
   ; events_to_facts_ratio : float
   ; ttl_expired_on_disk : int
   ; near_duplicate : int
-  ; provider_slot_busy : int
   }
 
 type alert_code =
   | Ttl_expired_on_disk
   | Near_duplicate
-  | Provider_slot_busy
 
 type alert_severity = Warn
 
 type alert_target =
   | Ttl_expired_on_disk_target
   | Near_duplicate_target
-  | Provider_slot_busy_target
 
 type keeper_alert =
   { code : alert_code
@@ -53,15 +48,9 @@ type keeper_alert =
 let ttl_expired_on_disk_threshold = 0.0
 let near_duplicate_threshold = 0.0
 
-let provider_slot_busy_threshold = 0.0
-
-let provider_slot_busy_metric = Keeper_metrics.(to_string MemoryLaneProviderSlotBusy)
-let provider_slot_busy_site = Keeper_librarian_runtime.memory_os_librarian_provider_slot_site
-
 let alert_code_to_string = function
   | Ttl_expired_on_disk -> "ttl_expired_on_disk"
   | Near_duplicate -> "near_duplicate"
-  | Provider_slot_busy -> "provider_slot_busy"
 ;;
 
 let alert_severity_to_string = function
@@ -71,7 +60,6 @@ let alert_severity_to_string = function
 let alert_target_to_string = function
   | Ttl_expired_on_disk_target -> "ttl_expired_on_disk"
   | Near_duplicate_target -> "near_duplicate"
-  | Provider_slot_busy_target -> "provider_slot_busy"
 ;;
 
 (* Alert labels are endpoint-owned wire copy for this backend-defined diagnostic
@@ -80,7 +68,6 @@ let alert_target_to_string = function
 let alert_label = function
   | Ttl_expired_on_disk -> "TTL"
   | Near_duplicate -> "중복"
-  | Provider_slot_busy -> "슬롯"
 ;;
 
 let alert ~code ~target ~message ~value ~threshold =
@@ -109,18 +96,6 @@ let keeper_alerts h =
         ~message:"Near-duplicate Memory OS fact rows remain on disk; GC dry-run would deduplicate them."
         ~value:(float_of_int h.near_duplicate)
         ~threshold:near_duplicate_threshold
-      :: alerts
-    else alerts)
-  |> (fun alerts ->
-    if h.provider_slot_busy > 0
-    then
-      alert
-        ~code:Provider_slot_busy
-        ~target:Provider_slot_busy_target
-        ~message:
-          "Memory OS librarian provider slot was busy; extraction was skipped and remains due."
-        ~value:(float_of_int h.provider_slot_busy)
-        ~threshold:provider_slot_busy_threshold
       :: alerts
     else alerts)
   |> List.rev
@@ -163,17 +138,6 @@ let count_lines_in_file path =
 let file_size_bytes path =
   (* NDT-OK: file size is a diagnostic metric. *)
   if not (Sys.file_exists path) then 0 else (Unix.stat path).Unix.st_size
-;;
-
-let provider_slot_busy_for_keeper keeper_id =
-  (* MemoryLaneProviderSlotBusy is emitted through [inc_counter], so values are
-     integral counts even though the metric store carries floats. Keep the JSON
-     field as an int to match the rest of this count-oriented health snapshot. *)
-  Otel_metric_store.metric_value_or_zero
-    provider_slot_busy_metric
-    ~labels:[ "keeper", keeper_id; "site", provider_slot_busy_site ]
-    ()
-  |> int_of_float
 ;;
 
 let duplicate_claim_identity_rows facts =
@@ -221,7 +185,6 @@ let keeper_health ~keepers_dir ~now keeper_id =
       float_of_int events_bytes /. float_of_int (max 1 facts_bytes)
   ; ttl_expired_on_disk = gc_report.ttl_expired
   ; near_duplicate = duplicate_claim_identity_rows facts
-  ; provider_slot_busy = provider_slot_busy_for_keeper keeper_id
   }
 ;;
 
@@ -235,7 +198,6 @@ let keeper_health_entry_to_json (h, alerts) : Yojson.Safe.t =
     ; "events_to_facts_ratio", `Float h.events_to_facts_ratio
     ; "ttl_expired_on_disk", `Int h.ttl_expired_on_disk
     ; "near_duplicate", `Int h.near_duplicate
-    ; "provider_slot_busy", `Int h.provider_slot_busy
     ; "alerts", `List (List.map keeper_alert_to_json alerts)
     ]
 ;;
@@ -282,7 +244,6 @@ let keeper_memory_health_http_json ~base_path : Yojson.Safe.t =
           ; "events_bytes", `Int (sum (fun h -> h.events_bytes))
           ; "ttl_expired_on_disk", `Int (sum (fun h -> h.ttl_expired_on_disk))
           ; "near_duplicate", `Int (sum (fun h -> h.near_duplicate))
-          ; "provider_slot_busy", `Int (sum (fun h -> h.provider_slot_busy))
           ] )
     ; ( "alert_summary"
       , `Assoc
@@ -299,12 +260,10 @@ let keeper_memory_health_http_json ~base_path : Yojson.Safe.t =
                    entries) )
           ; "ttl_expired_keepers", `Int (alert_count_by_code Ttl_expired_on_disk)
           ; "near_duplicate_keepers", `Int (alert_count_by_code Near_duplicate)
-          ; "provider_slot_busy_keepers", `Int (alert_count_by_code Provider_slot_busy)
           ; ( "thresholds"
             , `Assoc
                 [ "ttl_expired_on_disk", `Float ttl_expired_on_disk_threshold
                 ; "near_duplicate", `Float near_duplicate_threshold
-                ; "provider_slot_busy", `Float provider_slot_busy_threshold
                 ] )
           ] )
     ]

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -3445,115 +3445,6 @@ let test_no_category_infers_validity () =
     (Types.Unknown "novel" :: Types.all_categories)
 ;;
 
-let with_env name value f =
-  let old = Sys.getenv_opt name in
-  Unix.putenv name value;
-  Fun.protect ~finally:(fun () -> restore_env name old) f
-;;
-
-let test_librarian_provider_slot_gate_caps_at_capacity () =
-  with_env Env_config.KeeperMemoryOs.librarian_global_slot_env_key "1" (fun () ->
-    with_eio (fun ~sw ~net:_ ~clock ->
-      (* Capacity 1: while one entrant holds the slot, a concurrent entrant drops
-         ([None]) after [provider_slot_wait_sec] instead of blocking — the #21230
-         storm-guard the per-keeper lane keeps as an optional fleet-wide gate. *)
-      let entered, resolve_entered = Eio.Promise.create () in
-      let release, resolve_release = Eio.Promise.create () in
-      let first = ref None in
-      Eio.Fiber.fork ~sw (fun () ->
-        first
-        := Some
-             (Librarian_runtime.with_provider_slot
-                ~keeper_id:"keeper-a"
-                ~clock
-                (fun () ->
-                   Eio.Promise.resolve resolve_entered ();
-                   Eio.Promise.await release;
-                   "ran")));
-      Eio.Promise.await entered;
-      let second =
-        Librarian_runtime.with_provider_slot ~keeper_id:"keeper-a" ~clock (fun () -> "ran")
-      in
-      Eio.Promise.resolve resolve_release ();
-      wait_for_ref ~clock "first slot holder" first;
-      Alcotest.(check (option string))
-        "concurrent entrant drops at capacity 1"
-        None
-        second;
-      Alcotest.(check (option (option string)))
-        "slot holder ran"
-        (Some (Some "ran"))
-        !first))
-;;
-
-let test_librarian_provider_slot_gate_disabled_at_zero () =
-  with_env Env_config.KeeperMemoryOs.librarian_global_slot_env_key "0" (fun () ->
-    with_eio (fun ~sw ~net:_ ~clock ->
-      (* Capacity 0 disables the gate: a held slot does not cap a concurrent
-         entrant — both run ([Some]). *)
-      let entered, resolve_entered = Eio.Promise.create () in
-      let release, resolve_release = Eio.Promise.create () in
-      let first = ref None in
-      Eio.Fiber.fork ~sw (fun () ->
-        first
-        := Some
-             (Librarian_runtime.with_provider_slot
-                ~keeper_id:"keeper-a"
-                ~clock
-                (fun () ->
-                   Eio.Promise.resolve resolve_entered ();
-                   Eio.Promise.await release;
-                   "ran")));
-      Eio.Promise.await entered;
-      let second =
-        Librarian_runtime.with_provider_slot ~keeper_id:"keeper-a" ~clock (fun () -> "ran")
-      in
-      Eio.Promise.resolve resolve_release ();
-      wait_for_ref ~clock "first slot holder" first;
-      Alcotest.(check (option string))
-        "gate disabled: concurrent entrant also ran"
-        (Some "ran")
-        second;
-      Alcotest.(check (option (option string)))
-        "slot holder ran"
-        (Some (Some "ran"))
-        !first))
-;;
-
-let test_librarian_provider_slot_gate_is_per_keeper () =
-  with_env Env_config.KeeperMemoryOs.librarian_global_slot_env_key "1" (fun () ->
-    with_eio (fun ~sw ~net:_ ~clock ->
-      (* Capacity 1 is per keeper: a slot held by keeper-a must not block
-         keeper-b. This is the P0-4 isolation contract. *)
-      let entered, resolve_entered = Eio.Promise.create () in
-      let release, resolve_release = Eio.Promise.create () in
-      let first = ref None in
-      Eio.Fiber.fork ~sw (fun () ->
-        first
-        := Some
-             (Librarian_runtime.with_provider_slot
-                ~keeper_id:"keeper-a"
-                ~clock
-                (fun () ->
-                   Eio.Promise.resolve resolve_entered ();
-                   Eio.Promise.await release;
-                   "ran")));
-      Eio.Promise.await entered;
-      let other_keeper =
-        Librarian_runtime.with_provider_slot ~keeper_id:"keeper-b" ~clock (fun () -> "ran")
-      in
-      Eio.Promise.resolve resolve_release ();
-      wait_for_ref ~clock "first slot holder" first;
-      Alcotest.(check (option string))
-        "different keeper runs despite capacity 1 held"
-        (Some "ran")
-        other_keeper;
-      Alcotest.(check (option (option string)))
-        "slot holder ran"
-        (Some (Some "ran"))
-        !first))
-;;
-
 (* ---------- Explicit validity only ---------- *)
 
 let test_fact_validity_uses_only_stored_value () =
@@ -4919,18 +4810,6 @@ let () =
             "unstructured fallback does not write facts"
             `Quick
             test_librarian_invalid_output_does_not_write_facts
-        ; Alcotest.test_case
-            "provider slot gate caps concurrency at capacity (#21376/#21230)"
-            `Quick
-            test_librarian_provider_slot_gate_caps_at_capacity
-        ; Alcotest.test_case
-            "provider slot gate disabled at capacity 0"
-            `Quick
-            test_librarian_provider_slot_gate_disabled_at_zero
-        ; Alcotest.test_case
-            "provider slot gate isolates keepers (P0-4)"
-            `Quick
-            test_librarian_provider_slot_gate_is_per_keeper
         ] )
     ; ( "rfc-0259 volatile"
       , [ Alcotest.test_case

--- a/test/test_keeper_memory_write.ml
+++ b/test/test_keeper_memory_write.ml
@@ -4,6 +4,7 @@ module Runtime = Masc.Keeper_tool_memory_runtime
 module Bank = Masc.Keeper_memory_bank
 module Work_request = Masc.Keeper_memory_work_request
 module Work_store = Masc.Keeper_memory_work_store
+module Work_drain = Masc.Keeper_memory_work_drain
 
 let make_args ~kind ~title ~content =
   `Assoc
@@ -416,6 +417,56 @@ let test_memory_work_store_claim_settle_recovery () =
       Alcotest.fail "third request did not progress after failure")
 ;;
 
+let test_memory_work_drain_exact_settlement () =
+  with_temp_dir (fun base_path ->
+    let meta = make_meta "durable-memory-drain" in
+    let make_request turn =
+      Work_request.make
+        ~keeper_name:meta.name
+        ~generation:meta.runtime.generation
+        ~turn
+        ~runtime_id:(Printf.sprintf "runtime.drain.%d" turn)
+        ~meta
+        ~tool_results:[]
+        ~librarian_messages:[]
+        ~deliberation_execution:None
+      |> Result.get_ok
+    in
+    let first, second = make_request 1, make_request 2 in
+    List.iter
+      (fun request ->
+         Work_store.enqueue ~base_path request
+         |> Result.map_error Work_store.error_to_string
+         |> Result.get_ok
+         |> ignore)
+      [ first; second ];
+    let observed = ref [] in
+    let execute request =
+      observed := Work_request.request_id request :: !observed;
+      if Work_request.turn request = 2 then Error "provider unavailable" else Ok ()
+    in
+    let report =
+      Work_drain.drain ~base_path ~keeper_name:meta.name ~execute
+      |> Result.map_error Work_drain.error_to_string
+      |> Result.get_ok
+    in
+    Alcotest.(check (list string))
+      "exact execution order"
+      (List.map Work_request.request_id [ first; second ])
+      (List.rev !observed);
+    Alcotest.(check int) "completed" 1 report.completed;
+    Alcotest.(check int) "failed" 1 report.failed;
+    let terminal =
+      Work_store.terminal ~base_path ~keeper_name:meta.name
+      |> Result.map_error Work_store.error_to_string
+      |> Result.get_ok
+    in
+    (match List.map (fun item -> item.Work_store.outcome) terminal with
+     | [ Work_store.Completed; Work_store.Failed "provider unavailable" ] -> ()
+     | _ -> Alcotest.fail "terminal outcome or order mismatch");
+    Alcotest.(check int) "both outcomes durable" 2 (List.length terminal))
+;;
+
 let () =
   Alcotest.run
     "keeper_memory_write"
@@ -448,6 +499,10 @@ let () =
             "durable work store claim settle recovery"
             `Quick
             test_memory_work_store_claim_settle_recovery
+        ; Alcotest.test_case
+            "durable work drain exact settlement"
+            `Quick
+            test_memory_work_drain_exact_settlement
         ] )
     ]
 ;;

--- a/test/test_server_dashboard_http_keeper_memory_health.ml
+++ b/test/test_server_dashboard_http_keeper_memory_health.ml
@@ -2,9 +2,6 @@
 
 module Types = Masc.Keeper_memory_os_types
 module Io = Masc.Keeper_memory_os_io
-module Metrics = Masc.Otel_metric_store
-module KeeperMetrics = Keeper_metrics
-module LibrarianRuntime = Masc.Keeper_librarian_runtime
 module Health = Server_dashboard_http_keeper_memory_health
 
 let test_now = 1_700_000_000.0
@@ -175,7 +172,6 @@ let test_reports_per_keeper_metric_values () =
     (float_field "events_to_facts_ratio" k);
   Alcotest.(check int) "nothing expired" 0 (int_field "ttl_expired_on_disk" k);
   Alcotest.(check int) "no duplicates" 0 (int_field "near_duplicate" k);
-  Alcotest.(check int) "no provider slot busy skips" 0 (int_field "provider_slot_busy" k);
   Alcotest.(check int) "no keeper alerts" 0 (List.length (list_field "alerts" k));
   Alcotest.(check int) "totals.facts" 2 (int_field "facts" (totals json));
   Alcotest.(check bool)
@@ -234,52 +230,6 @@ let test_health_reports_expiry_and_exact_duplicate_identity () =
   (* dry_run must NOT rewrite the store: a fresh read still sees all 4 rows. *)
   let reread = Io.read_facts_all_for_keepers_dir ~keepers_dir ~keeper_id:"gc" in
   Alcotest.(check int) "store untouched by dry-run gc" 4 (List.length reread)
-;;
-
-let test_reports_provider_slot_busy_metric_as_alert () =
-  Eio_main.run
-  @@ fun _env ->
-  let now = test_now in
-  let base = fresh_dir "masc-memory-health-provider-slot" in
-  (* Otel_metric_store is process-global. Use a temp-derived keeper label so
-     repeated test runs in one process cannot inherit this counter cell. *)
-  let keeper_id = "slotbusy-health-" ^ Filename.basename base in
-  let keepers_dir = Config_dir_resolver.keepers_dir_for_base_path ~base_path:base in
-  Io.rewrite_facts_atomically_for_keepers_dir
-    ~keepers_dir
-    ~keeper_id
-    [ fact ~now "slot busy metric keeper fact" ];
-  Metrics.inc_counter
-    KeeperMetrics.(to_string MemoryLaneProviderSlotBusy)
-    ~labels:
-      [ "keeper", keeper_id
-      ; "site", LibrarianRuntime.memory_os_librarian_provider_slot_site
-      ]
-    ~delta:3.0
-    ();
-  let json = Health.keeper_memory_health_http_json ~base_path:base in
-  let k = keeper_obj keeper_id json in
-  Alcotest.(check int) "provider slot busy projected" 3 (int_field "provider_slot_busy" k);
-  Alcotest.(check int)
-    "totals provider slot busy"
-    3
-    (int_field "provider_slot_busy" (totals json));
-  let alerts = list_field "alerts" k in
-  Alcotest.(check (list string))
-    "provider slot alert code"
-    [ "provider_slot_busy" ]
-    (List.map (string_field "code") alerts);
-  Alcotest.(check (list string))
-    "provider slot alert target"
-    [ "provider_slot_busy" ]
-    (List.map (string_field "target") alerts);
-  Alcotest.(check (list string))
-    "provider slot alert label"
-    [ "슬롯" ]
-    (List.map (string_field "label") alerts);
-  let summary = alert_summary json in
-  Alcotest.(check int) "summary provider slot keepers" 1 (int_field "provider_slot_busy_keepers" summary);
-  Alcotest.(check int) "summary total alerts" 1 (int_field "total_alerts" summary)
 ;;
 
 let test_sorts_keepers_by_facts_bytes_desc () =
@@ -353,10 +303,6 @@ let () =
             "dry-run gc reports expired and duplicate rows"
             `Quick
             test_health_reports_expiry_and_exact_duplicate_identity
-        ; Alcotest.test_case
-            "reports provider slot busy metric as alert"
-            `Quick
-            test_reports_provider_slot_busy_metric_as_alert
         ; Alcotest.test_case
             "sorts keepers by facts_bytes descending"
             `Quick


### PR DESCRIPTION
## Stack

- Base: #24732 (`codex/memory-durable-owner-integration-c3-20260716`)
- This PR: C3a durable owner-lane drain
- Follow-up C3b: retire librarian provider-slot/cadence/env legacy and startup recovery

## What changed

- Admit each immutable post-turn Memory request to the existing `Keeper_memory_work_store` before signalling execution.
- Drain that sole durable SSOT per Keeper: recover an exact in-flight request first, otherwise claim the FIFO head.
- Settle `Completed` only after the tool-result write and typed LLM librarian operation both succeed.
- Preserve execution errors as durable `Failed detail` terminals, then continue the Keeper's FIFO.
- Keep `Keeper_memory_lane` as a single-owner drain signal/executor; an admission failure never deletes the already-durable request.
- Keep delegation projection at its separate artifact boundary.

## Invariants

- No second queue/store/scheduler was introduced.
- No queue bound, budget, cadence, risk level, or heuristic admission.
- No silent failure and no synthetic success.
- Exact diff size: 397 changed lines.

## Proof

- `scripts/dune-local.sh build test/test_keeper_memory_write.exe`
- `_build/default/test/test_keeper_memory_write.exe` — 9/9 passed
- `GITHUB_BASE_REF=codex/memory-durable-owner-integration-c3-20260716 python3 scripts/check_test_coverage.py`
- OCaml parse, `ocamlformat --check`, and `git diff --check` passed
