### PR TITLE
feat(keeper): join delegated terminal results

### DIFF
--- a/lib/keeper/keeper_context_layers.ml
+++ b/lib/keeper/keeper_context_layers.ml
@@ -10,6 +10,7 @@ type layer_id =
   | Pending_mentions
   | Scope_messages
   | Claimable_work
+  | Keeper_invocation_results
   | Board_activity
 
 (* Prefix-cache ordering: emit larger, more stable sections first so providers
@@ -27,6 +28,7 @@ let ordered =
   ; Pending_mentions
   ; Scope_messages
   ; Claimable_work
+  ; Keeper_invocation_results
   ; Board_activity
   ]
 ;;
@@ -44,7 +46,8 @@ let order_index = function
   | Pending_mentions -> 6
   | Scope_messages -> 7
   | Claimable_work -> 8
-  | Board_activity -> 9
+  | Keeper_invocation_results -> 9
+  | Board_activity -> 10
 ;;
 
 let assemble ~content_of =

--- a/lib/keeper/keeper_context_layers.mli
+++ b/lib/keeper/keeper_context_layers.mli
@@ -22,6 +22,7 @@ type layer_id =
   | Pending_mentions
   | Scope_messages
   | Claimable_work
+  | Keeper_invocation_results
   | Board_activity
 
 val ordered : layer_id list

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -52,6 +52,7 @@ let record_event_queue_stimulus_turn_started =
 
 type heartbeat_event_intake = Stimulus_intake.heartbeat_event_intake = {
   pending_board_events : Keeper_world_observation.pending_board_event list;
+  keeper_invocation_joins : Keeper_event_queue.keeper_invocation_join list;
   consumed_stimulus_count : int;
   consumed_stimuli : Keeper_event_queue.stimulus list;
   claimed_lease : Keeper_registry_event_queue.lease option;
@@ -505,6 +506,7 @@ let run_keepalive_unified_turn
       let obs =
         Keeper_world_observation.observe
           ~pending_board_events:(Some pending_board_events)
+          ~keeper_invocation_joins:event_intake.keeper_invocation_joins
           ~config:ctx.config
           ~meta:meta_after_triage
       in

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -56,6 +56,7 @@ val with_in_turn_liveness_pulse :
 
 type heartbeat_event_intake = {
   pending_board_events : Keeper_world_observation.pending_board_event list;
+  keeper_invocation_joins : Keeper_event_queue.keeper_invocation_join list;
   consumed_stimulus_count : int;
   consumed_stimuli : Keeper_event_queue.stimulus list;
   claimed_lease : Keeper_registry_event_queue.lease option;

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -61,6 +61,7 @@ let record_event_queue_stimulus_turn_started ~ctx ~keeper_name stimulus =
 
 type heartbeat_event_intake = {
   pending_board_events : Keeper_world_observation.pending_board_event list;
+  keeper_invocation_joins : Keeper_event_queue.keeper_invocation_join list;
   consumed_stimulus_count : int;
   consumed_stimuli : Keeper_event_queue.stimulus list;
   claimed_lease : Keeper_registry_event_queue.lease option;
@@ -96,6 +97,9 @@ let event_queue_trigger_of_stimulus (stim : Keeper_event_queue.stimulus) =
     Some Keeper_world_observation.Hitl_resolved_stimulus
   | Keeper_event_queue.Failure_judgment _ ->
     Some Keeper_world_observation.Failure_judgment_stimulus
+  | Keeper_event_queue.Bg_completed
+      { bg_kind = Keeper_event_queue.Keeper_invocation; _ } ->
+    Some Keeper_world_observation.Keeper_invocation_completed_stimulus
   | Keeper_event_queue.Board_signal _
   | Keeper_event_queue.Board_attention _
   | Keeper_event_queue.Fusion_completed _
@@ -149,7 +153,10 @@ let consume_single_heartbeat_stimulus
        | Keeper_event_queue.Bg_ok _ -> true
        | Keeper_event_queue.Bg_failed _ -> false)
       meta_after_triage.name;
-    pending_board_event_of_stimulus ~meta_after_triage stim |> Option.to_list
+    (match c.bg_kind with
+     | Keeper_event_queue.Subprocess ->
+       pending_board_event_of_stimulus ~meta_after_triage stim |> Option.to_list
+     | Keeper_event_queue.Keeper_invocation -> [])
   | Keeper_event_queue.Schedule_due sw ->
     Log.Keeper.info
       "turn entry: scheduled wake delivered schedule_id=%s due_at=%.3f (keeper=%s)"
@@ -343,6 +350,18 @@ let heartbeat_event_intake
   in
   let consumed_stimulus_count = List.length consumed_stimuli in
   let event_queue_triggers = List.filter_map event_queue_trigger_of_stimulus consumed_stimuli in
+  let keeper_invocation_joins =
+    List.filter_map
+      (fun (stimulus : Keeper_event_queue.stimulus) ->
+         match stimulus.payload with
+         | Keeper_event_queue.Bg_completed
+             { bg_kind = Keeper_event_queue.Keeper_invocation
+             ; bg_invocation_join = Some join
+             ; _
+             } -> Some join
+         | _ -> None)
+      consumed_stimuli
+  in
   let pending_board_events =
     List.fold_left
       (fun acc (event : Keeper_world_observation.pending_board_event) ->
@@ -364,6 +383,7 @@ let heartbeat_event_intake
       (List.rev queued_observations)
   in
   { pending_board_events
+  ; keeper_invocation_joins
   ; consumed_stimulus_count
   ; consumed_stimuli
   ; claimed_lease

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.mli
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.mli
@@ -35,6 +35,7 @@ val record_event_queue_stimulus_turn_started
     after dedup and the number of stimuli consumed from the queue. *)
 type heartbeat_event_intake = {
   pending_board_events : Keeper_world_observation.pending_board_event list;
+  keeper_invocation_joins : Keeper_event_queue.keeper_invocation_join list;
   consumed_stimulus_count : int;
   consumed_stimuli : Keeper_event_queue.stimulus list;
   claimed_lease : Keeper_registry_event_queue.lease option;

--- a/lib/keeper/keeper_tool_emission_hook.ml
+++ b/lib/keeper/keeper_tool_emission_hook.ml
@@ -52,6 +52,41 @@ let snapshot acc : Yojson.Safe.t list =
   Stdlib.Mutex.unlock acc.mutex;
   items
 
+let unique_field name fields =
+  match List.filter_map (fun (key, value) -> if String.equal key name then Some value else None) fields with
+  | [] -> Ok None
+  | [ value ] -> Ok (Some value)
+  | _ -> Error (Printf.sprintf "tool result repeats reserved field %s" name)
+
+let artifact_ref_of_result = function
+  | `Assoc fields as result ->
+    let ( let* ) = Result.bind in
+    let* kind = unique_field Multimodal.Tool_emission.multimodal_kind_key fields in
+    (match kind with
+     | None -> Ok None
+     | Some (`String _) ->
+       (match Multimodal.Tool_emission.extract_kind_from_result result with
+        | None -> Error "tool result carries an unknown multimodal kind"
+        | Some _ ->
+          let* id = unique_field Multimodal.Tool_emission.multimodal_id_key fields in
+          (match id with
+           | Some json ->
+             Shared_types.Artifact_id.of_json json |> Result.map Option.some
+           | None -> Error "tagged tool result lacks a multimodal artifact id"))
+     | Some _ -> Error "tool result multimodal kind must be a string")
+  | _ -> Ok None
+
+let snapshot_artifact_refs acc =
+  snapshot acc
+  |> List.fold_left
+       (fun refs result ->
+          let ( let* ) = Result.bind in
+          let* refs = refs in
+          artifact_ref_of_result result
+          |> Result.map (function None -> refs | Some id -> id :: refs))
+       (Ok [])
+  |> Result.map (List.sort_uniq Shared_types.Artifact_id.compare)
+
 let accumulator_size acc =
   Stdlib.Mutex.lock acc.mutex;
   let n = List.length acc.items in

--- a/lib/keeper/keeper_tool_emission_hook.mli
+++ b/lib/keeper/keeper_tool_emission_hook.mli
@@ -61,6 +61,8 @@ val drain_into_working_context :
     The returned list preserves capture order. *)
 val snapshot : accumulator -> Yojson.Safe.t list
 
+val snapshot_artifact_refs : accumulator -> (Shared_types.Artifact_id.t list, string) result
+
 (** Number of items currently held in the accumulator. Useful for
     tests and metrics. *)
 val accumulator_size : accumulator -> int

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -141,24 +141,58 @@ type keeper_completion_projection =
   | Completion_already_present
   | Completion_storage_failed of string
 
-let terminal_completion_outcome = function
+let terminal_completion = function
   | Keeper_msg_async.Done { ok; body; data } ->
     let payload =
       match data with
       | None -> body
       | Some value -> Yojson.Safe.to_string value
     in
+    let result =
+      if ok
+      then Keeper_invocation_types.Invocation_succeeded { body; data }
+      else Keeper_invocation_types.Invocation_failed { body; data }
+    in
     Some
-      (if ok
-       then Keeper_event_queue.Bg_ok payload
-       else Keeper_event_queue.Bg_failed payload)
-  | Keeper_msg_async.Lost { reason }
-  | Keeper_msg_async.Cancelled { reason; _ }
-  | Keeper_msg_async.Persistence_failed { reason; _ } ->
-    Some (Keeper_event_queue.Bg_failed reason)
+      ( (if ok then Keeper_event_queue.Bg_ok payload else Keeper_event_queue.Bg_failed payload)
+      , result )
+  | Keeper_msg_async.Lost { reason } ->
+    Some
+      ( Keeper_event_queue.Bg_failed reason
+      , Keeper_invocation_types.Invocation_lost { reason } )
+  | Keeper_msg_async.Cancelled { reason; cancelled_by } ->
+    Some
+      ( Keeper_event_queue.Bg_failed reason
+      , Keeper_invocation_types.Invocation_cancelled { reason; cancelled_by } )
+  | Keeper_msg_async.Persistence_failed { attempted_status; reason } ->
+    Some
+      ( Keeper_event_queue.Bg_failed reason
+      , Keeper_invocation_types.Invocation_persistence_failed { attempted_status; reason } )
   | Keeper_msg_async.Queued
   | Keeper_msg_async.Running
   | Keeper_msg_async.Cancelling _ -> None
+
+let artifact_refs_of_terminal_result = function
+  | Keeper_invocation_types.Invocation_succeeded { data; _ }
+  | Keeper_invocation_types.Invocation_failed { data; _ } ->
+    (match data with
+     | Some (`Assoc fields) ->
+       (match List.assoc_opt Keeper_invocation_types.artifact_refs_key fields with
+        | None -> Ok []
+        | Some (`List values) ->
+          List.fold_left
+            (fun refs json ->
+               let* refs = refs in
+               Shared_types.Artifact_id.of_json json
+               |> Result.map (fun id -> id :: refs))
+            (Ok [])
+            values
+          |> Result.map (List.sort_uniq Shared_types.Artifact_id.compare)
+        | Some _ -> Error "Keeper completion artifact_refs must be a JSON list")
+     | Some _ | None -> Ok [])
+  | Keeper_invocation_types.Invocation_lost _
+  | Keeper_invocation_types.Invocation_cancelled _
+  | Keeper_invocation_types.Invocation_persistence_failed _ -> Ok []
 
 let signal_completion_caller ~base_path caller_keeper =
   match
@@ -184,13 +218,28 @@ let signal_completion_caller ~base_path caller_keeper =
       (Keeper_lifecycle_admission.autonomous_denial_to_wire denial)
 
 let completion_stimulus (entry : Keeper_msg_async.entry) =
-  match terminal_completion_outcome entry.status, entry.completed_at with
-  | Some bg_outcome, Some arrived_at ->
+  match terminal_completion entry.status, entry.completed_at with
+  | Some (bg_outcome, terminal_result), Some arrived_at ->
+    let* artifact_refs = artifact_refs_of_terminal_result terminal_result in
+    let run_ref : Keeper_invocation_types.run_ref =
+      { run_id = entry.request_id
+      ; target = Keeper_invocation_types.request_target entry.request
+      ; capability = Keeper_invocation_types.request_capability entry.request
+      }
+    in
+    let bg_invocation_join : Keeper_event_queue.keeper_invocation_join =
+      { run_ref
+      ; result_contract = Keeper_invocation_contract.result_contract entry
+      ; terminal_result
+      ; artifact_refs
+      }
+    in
     let completion : Keeper_event_queue.bg_job_completion =
       { bg_run_id = entry.request_id
       ; bg_kind = Keeper_event_queue.Keeper_invocation
       ; bg_outcome
       ; bg_board_post_id = ""
+      ; bg_invocation_join = Some bg_invocation_join
       }
     in
     Ok

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -860,13 +860,17 @@ let run_keeper_invocation_turn_admitted
               restart_keepalive_after_message_turn ctx meta;
               Progress.stop_tracking turn_task_id;
               tool_result_error user_message
-	            | Ok (result, final_max_runtime_context) ->
+            | Ok (result, final_max_runtime_context) ->
               (try
                  let _ = Trajectory.finalize trajectory_acc
                    Trajectory.Completed in
                  ()
                with Eio.Cancel.Cancelled _ as e -> raise e | exn -> log_keeper_exn
                  ~label:"trajectory finalize (agent_run ok)" exn);
+              let invocation_artifact_refs =
+                Keeper_tool_emission_hook.accumulator_for_keeper meta.name
+                |> Keeper_tool_emission_hook.snapshot_artifact_refs
+              in
               let resilience_handles =
                 Keeper_turn_runtime_budget.post_turn_resilience_handles
                   ~config:ctx.config ~meta
@@ -983,6 +987,11 @@ let run_keeper_invocation_turn_admitted
               restart_keepalive_after_message_turn ctx updated_meta;
               Progress.Tracker.complete turn_tracker
                 ~message:(Printf.sprintf "Turn completed: %d tool calls" (Keeper_agent_result.tool_call_count result)) ();
+              (match invocation_artifact_refs with
+               | Error detail ->
+                 tool_result_error
+                   ("Keeper tool artifact contract failed: " ^ detail)
+               | Ok artifact_refs ->
               let reply_json =
                 let surface_model_used = Keeper_agent_run.runtime_lane_label in
                 let u = result.usage in
@@ -1032,9 +1041,11 @@ let run_keeper_invocation_turn_admitted
                      chat row via append_turn ?turn_ref. *)
                   ( Keeper_turn_outcome.turn_ref_wire_key,
                     Ids.Turn_ref.to_yojson turn_ref );
+                  ( Keeper_invocation_types.artifact_refs_key,
+                    `List (List.map Shared_types.Artifact_id.to_json artifact_refs) );
                 ]
               in
-              tool_result_ok_data reply_json
+              tool_result_ok_data reply_json)
 
 )))))))))
 

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -848,7 +848,20 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
               Keeper_prompt_names.immediate_task_move
           ^ "\n")
       else None
-    (* 10. Board activity — reactive trigger. All authors and post kinds share
+    | Keeper_context_layers.Keeper_invocation_results ->
+      (match observation.keeper_invocation_joins with
+       | [] -> None
+       | joins ->
+         Some
+           (Printf.sprintf
+              "### Keeper Invocation Results (%d)\n%s\n\n"
+              (List.length joins)
+              (joins
+               |> List.map Keeper_event_queue.keeper_invocation_join_to_yojson
+               |> List.map Yojson.Safe.to_string
+               |> List.map (fun json -> "- " ^ json)
+               |> String.concat "\n")))
+    (* 11. Board activity — reactive trigger. All authors and post kinds share
        one neutral observation renderer. Exact mention remains routing context;
        it never promotes Board content to instruction authority. *)
     | Keeper_context_layers.Board_activity ->

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -75,6 +75,7 @@ let empty_scheduled_automation_observation =
 type world_observation =
   { pending_messages : Keeper_world_observation_message_scope.pending_message list
   ; pending_board_events : pending_board_event list
+  ; keeper_invocation_joins : Keeper_event_queue.keeper_invocation_join list
   ; idle_seconds : int
   ; active_goals : string list
   ; unclaimed_task_count : int
@@ -99,6 +100,7 @@ type event_queue_trigger =
   | Connector_attention_stimulus
   | Hitl_resolved_stimulus
   | Failure_judgment_stimulus
+  | Keeper_invocation_completed_stimulus
 
 type turn_reason = Keeper_world_observation_turn_types.turn_reason =
   | Mention_pending
@@ -108,6 +110,7 @@ type turn_reason = Keeper_world_observation_turn_types.turn_reason =
   | Connector_attention_pending
   | Hitl_resolved_pending
   | Failure_judgment_pending
+  | Keeper_invocation_completed_pending
   | Scheduled_autonomous_turn
   | Scheduled_automation_due
   | Task_backlog of
@@ -976,6 +979,7 @@ let collect_board_events_without_advancing_cursor
 
 let observe
       ~(pending_board_events : pending_board_event list option)
+      ?(keeper_invocation_joins = [])
       ~(config : Workspace.config)
       ~(meta : keeper_meta)
   : world_observation
@@ -1008,6 +1012,7 @@ let observe
   in
   { pending_messages
   ; pending_board_events
+  ; keeper_invocation_joins
   ; idle_seconds
   ; active_goals = meta.active_goal_ids
   ; unclaimed_task_count
@@ -1041,6 +1046,7 @@ let observe_direct_keeper_msg ~(config : Workspace.config) ~(meta : keeper_meta)
   in
   { pending_messages = []
   ; pending_board_events = []
+  ; keeper_invocation_joins = []
   ; idle_seconds = compute_idle_seconds ~meta
   ; active_goals = meta.active_goal_ids
   ; unclaimed_task_count
@@ -1066,6 +1072,7 @@ let verification_drives_wake pending_verification_count =
 let actionable_signal_present (observation : world_observation) =
   observation.pending_messages <> []
   || observation.pending_board_events <> []
+  || observation.keeper_invocation_joins <> []
   || claimable_drives_wake observation.claimable_task_count
   || failed_drives_wake observation.failed_task_count
   || verification_drives_wake observation.pending_verification_count
@@ -1100,7 +1107,8 @@ let keeper_cycle_decision
         | Bootstrap_stimulus
         | Scheduled_automation_stimulus
         | Connector_attention_stimulus
-        | Hitl_resolved_stimulus ->
+        | Hitl_resolved_stimulus
+        | Keeper_invocation_completed_stimulus ->
           false)
       event_queue_triggers
   in

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -81,6 +81,8 @@ type world_observation = {
   pending_board_events : pending_board_event list;
   (** Structured board events needing triage. *)
 
+  keeper_invocation_joins : Keeper_event_queue.keeper_invocation_join list;
+
   idle_seconds : int;
   (** Seconds since last keeper activity (turn or scheduled autonomous cycle). *)
 
@@ -129,6 +131,7 @@ type event_queue_trigger =
   | Connector_attention_stimulus
   | Hitl_resolved_stimulus
   | Failure_judgment_stimulus
+  | Keeper_invocation_completed_stimulus
 
 (** Typed reason for running a keeper cycle. Each variant corresponds to
     exactly one code path in {!keeper_cycle_decision}. *)
@@ -140,6 +143,7 @@ type turn_reason =
   | Connector_attention_pending
   | Hitl_resolved_pending
   | Failure_judgment_pending
+  | Keeper_invocation_completed_pending
   | Scheduled_autonomous_turn
   | Scheduled_automation_due
   | Task_backlog of { unclaimed : int; failed : int }
@@ -300,6 +304,7 @@ val read_scheduled_automation_observation :
     @param meta Current keeper metadata *)
 val observe :
   pending_board_events:pending_board_event list option ->
+  ?keeper_invocation_joins:Keeper_event_queue.keeper_invocation_join list ->
   config:Workspace.config ->
   meta:Keeper_meta_contract.keeper_meta ->
   world_observation

--- a/lib/keeper_contract/keeper_world_observation_turn_types.ml
+++ b/lib/keeper_contract/keeper_world_observation_turn_types.ml
@@ -44,6 +44,7 @@ type event_queue_trigger =
       (** Durable recovery control for a deterministic failed turn. This opens
           the independent judge even when the failed Keeper is unhealthy or
           its ordinary reactive lane is disabled. *)
+  | Keeper_invocation_completed_stimulus
 
 type turn_reason =
   | Mention_pending
@@ -53,6 +54,7 @@ type turn_reason =
   | Connector_attention_pending
   | Hitl_resolved_pending
   | Failure_judgment_pending
+  | Keeper_invocation_completed_pending
   | Scheduled_autonomous_turn
   | Scheduled_automation_due
   | Task_backlog of
@@ -81,6 +83,7 @@ let turn_reason_to_string = function
   | Connector_attention_pending -> "connector_attention_pending"
   | Hitl_resolved_pending -> "hitl_resolved_pending"
   | Failure_judgment_pending -> "failure_judgment_pending"
+  | Keeper_invocation_completed_pending -> "keeper_invocation_completed_pending"
   | Scheduled_autonomous_turn -> "scheduled_autonomous_turn"
   | Scheduled_automation_due -> "scheduled_automation_due"
   | Task_backlog _ -> "task_backlog"
@@ -93,6 +96,7 @@ let turn_reason_of_event_queue_trigger = function
   | Connector_attention_stimulus -> Connector_attention_pending
   | Hitl_resolved_stimulus -> Hitl_resolved_pending
   | Failure_judgment_stimulus -> Failure_judgment_pending
+  | Keeper_invocation_completed_stimulus -> Keeper_invocation_completed_pending
 ;;
 
 let skip_reason_to_string = function

--- a/lib/keeper_contract/keeper_world_observation_turn_types.mli
+++ b/lib/keeper_contract/keeper_world_observation_turn_types.mli
@@ -18,6 +18,7 @@ type event_queue_trigger =
           conversation. *)
   | Failure_judgment_stimulus
       (** Durable recovery control for a deterministic failed turn. *)
+  | Keeper_invocation_completed_stimulus
 
 type turn_reason =
   | Mention_pending
@@ -27,6 +28,7 @@ type turn_reason =
   | Connector_attention_pending
   | Hitl_resolved_pending
   | Failure_judgment_pending
+  | Keeper_invocation_completed_pending
   | Scheduled_autonomous_turn
   | Scheduled_automation_due
   | Task_backlog of

--- a/lib/keeper_invocation_types/keeper_invocation_types.ml
+++ b/lib/keeper_invocation_types/keeper_invocation_types.ml
@@ -26,6 +26,16 @@ type result_contract =
   | Completed
   | Failed
 
+type terminal_result =
+  | Invocation_succeeded of { body : string; data : Yojson.Safe.t option }
+  | Invocation_failed of { body : string; data : Yojson.Safe.t option }
+  | Invocation_lost of { reason : string }
+  | Invocation_cancelled of { reason : string; cancelled_by : string }
+  | Invocation_persistence_failed of { attempted_status : string; reason : string }
+[@@deriving yojson]
+
+let artifact_refs_key = "artifact_refs"
+
 let target_name = function Keeper name -> Keeper_id.Keeper_name.to_string name
 
 let target_to_json target =

--- a/lib/keeper_invocation_types/keeper_invocation_types.mli
+++ b/lib/keeper_invocation_types/keeper_invocation_types.mli
@@ -22,6 +22,16 @@ type result_contract =
   | Completed
   | Failed
 
+type terminal_result =
+  | Invocation_succeeded of { body : string; data : Yojson.Safe.t option }
+  | Invocation_failed of { body : string; data : Yojson.Safe.t option }
+  | Invocation_lost of { reason : string }
+  | Invocation_cancelled of { reason : string; cancelled_by : string }
+  | Invocation_persistence_failed of { attempted_status : string; reason : string }
+[@@deriving yojson]
+
+val artifact_refs_key : string
+
 val target_name : target -> string
 val target_to_json : target -> Yojson.Safe.t
 val keeper_turn : keeper_name:string -> prompt:string -> (request, string) result

--- a/lib/keeper_runtime/dune
+++ b/lib/keeper_runtime/dune
@@ -38,6 +38,7 @@
   masc.bounded_event_dedupe
   masc.json_field
   masc.masc_core
+  masc.shared_types
   masc.types_boundary
   masc_cancel_safe
   masc_core

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -109,6 +109,7 @@ and bg_job_completion = {
   bg_kind : bg_job_kind;
   bg_outcome : bg_job_outcome;
   bg_board_post_id : string;
+  bg_invocation_join : keeper_invocation_join option;
   (* correlates to an optional board evidence post; "" if none was created. *)
 }
 
@@ -135,6 +136,13 @@ and hitl_resolution = {
 and bg_job_outcome =
   | Bg_ok of string  (* result payload *)
   | Bg_failed of string  (* failure label *)
+
+and keeper_invocation_join = {
+  run_ref : Keeper_invocation_types.run_ref;
+  result_contract : Keeper_invocation_types.result_contract;
+  terminal_result : Keeper_invocation_types.terminal_result;
+  artifact_refs : Shared_types.Artifact_id.t list;
+}
 
 and connector_attention = {
   event_id : string;
@@ -493,6 +501,92 @@ let float_field ~context name fields =
   let* json = required_field ~context name fields in
   float_of_json ~context:(context ^ "." ^ name) json
 
+let keeper_invocation_join_to_yojson join =
+  `Assoc
+    [ "run_ref", Keeper_invocation_types.run_ref_to_json join.run_ref
+    ; ( "result_contract"
+      , `String
+          (Keeper_invocation_types.result_contract_to_string join.result_contract) )
+    ; ( "terminal_result"
+      , Keeper_invocation_types.terminal_result_to_yojson join.terminal_result )
+    ; "artifact_refs", `List (List.map Shared_types.Artifact_id.to_json join.artifact_refs)
+    ]
+;;
+
+let terminal_result_matches_contract result contract =
+  match result, contract with
+  | Keeper_invocation_types.Invocation_succeeded _
+    , (Keeper_invocation_types.Completed | Keeper_invocation_types.Yielded)
+  | Keeper_invocation_types.Invocation_failed _, Keeper_invocation_types.Failed
+  | Keeper_invocation_types.Invocation_lost _, Keeper_invocation_types.Failed
+  | Keeper_invocation_types.Invocation_cancelled _, Keeper_invocation_types.Cancelled
+  | ( Keeper_invocation_types.Invocation_persistence_failed _
+    , Keeper_invocation_types.Failed ) -> true
+  | _ -> false
+;;
+
+let invocation_run_ref_of_yojson json =
+  let context = "keeper_invocation_join.run_ref" in
+  let* fields = assoc_fields ~context json in
+  let* run_id = string_field ~context "run_id" fields in
+  let* target_json = required_field ~context "target" fields in
+  let* target = assoc_fields ~context:(context ^ ".target") target_json in
+  let* target_kind = string_field ~context:(context ^ ".target") "kind" target in
+  let* keeper_name = string_field ~context:(context ^ ".target") "name" target in
+  let* capability = string_field ~context "capability" fields in
+  if String.equal run_id ""
+  then Error "keeper_invocation_join.run_ref.run_id must not be empty"
+  else if not (String.equal target_kind "keeper")
+  then Error "keeper_invocation_join.run_ref.target.kind must be keeper"
+  else if not (String.equal capability "invoke_turn")
+  then Error "keeper_invocation_join.run_ref.capability must be invoke_turn"
+  else
+    Keeper_invocation_types.keeper_turn ~keeper_name ~prompt:"run_ref"
+    |> Result.map (fun request ->
+      { Keeper_invocation_types.run_id
+      ; target = Keeper_invocation_types.request_target request
+      ; capability = Keeper_invocation_types.request_capability request
+      })
+;;
+
+let keeper_invocation_join_of_yojson json =
+  let context = "keeper_invocation_join" in
+  let* fields = assoc_fields ~context json in
+  let* run_ref_json = required_field ~context "run_ref" fields in
+  let* run_ref = invocation_run_ref_of_yojson run_ref_json in
+  let* contract_label = string_field ~context "result_contract" fields in
+  let* result_contract =
+    match Keeper_invocation_types.result_contract_of_string contract_label with
+    | Some value -> Ok value
+    | None -> Error (Printf.sprintf "unknown invocation result_contract: %s" contract_label)
+  in
+  let* terminal_json = required_field ~context "terminal_result" fields in
+  let* terminal_result =
+    Keeper_invocation_types.terminal_result_of_yojson terminal_json
+  in
+  let* artifacts_json = required_field ~context "artifact_refs" fields in
+  let* artifact_refs =
+    match artifacts_json with
+    | `List values ->
+      List.fold_left
+        (fun acc json ->
+           let* refs = acc in
+           Shared_types.Artifact_id.of_json json |> Result.map (fun id -> id :: refs))
+        (Ok [])
+        values
+      |> Result.map List.rev
+    | _ -> Error "keeper_invocation_join.artifact_refs must be a JSON list"
+  in
+  let canonical_refs =
+    List.sort_uniq Shared_types.Artifact_id.compare artifact_refs
+  in
+  if not (terminal_result_matches_contract terminal_result result_contract)
+  then Error "keeper_invocation_join terminal result contradicts result_contract"
+  else if canonical_refs <> artifact_refs
+  then Error "keeper_invocation_join.artifact_refs must be sorted and unique"
+  else Ok { run_ref; result_contract; terminal_result; artifact_refs }
+;;
+
 let payload_to_yojson = function
   | Board_signal board ->
     `Assoc
@@ -524,6 +618,7 @@ let payload_to_yojson = function
       ; "ok", `Bool ok
       ; "payload", `String payload
       ; "board_post_id", `String c.bg_board_post_id
+      ; "keeper_invocation_join", option_json keeper_invocation_join_to_yojson c.bg_invocation_join
       ]
   | Schedule_due sw ->
     `Assoc
@@ -634,10 +729,35 @@ let payload_of_yojson json =
     let* ok = bool_field ~context "ok" fields in
     let* payload = string_field ~context "payload" fields in
     let* board_post_id = string_field ~context "board_post_id" fields in
+    let* bg_invocation_join =
+      match optional_field "keeper_invocation_join" fields with
+      | None -> Ok None
+      | Some json -> keeper_invocation_join_of_yojson json |> Result.map Option.some
+    in
     let bg_outcome = if ok then Bg_ok payload else Bg_failed payload in
-    Ok
-      (Bg_completed
-         { bg_run_id = run_id; bg_kind; bg_outcome; bg_board_post_id = board_post_id })
+    (match bg_kind, bg_invocation_join with
+     | Subprocess, None ->
+       Ok
+         (Bg_completed
+            { bg_run_id = run_id
+            ; bg_kind
+            ; bg_outcome
+            ; bg_board_post_id = board_post_id
+            ; bg_invocation_join = None
+            })
+     | Keeper_invocation, Some join
+       when String.equal run_id (Keeper_invocation_types.run_id join.run_ref) ->
+       Ok
+         (Bg_completed
+            { bg_run_id = run_id
+            ; bg_kind
+            ; bg_outcome
+            ; bg_board_post_id = board_post_id
+            ; bg_invocation_join = Some join
+            })
+     | Subprocess, Some _ -> Error "subprocess completion cannot carry an invocation join"
+     | Keeper_invocation, None -> Error "keeper invocation completion requires a typed join"
+     | Keeper_invocation, Some _ -> Error "keeper invocation run_id does not match run_ref")
   | "schedule_due" ->
     let* schedule_id = string_field ~context "schedule_id" fields in
     let* due_at = float_field ~context "due_at_unix" fields in

--- a/lib/keeper_runtime/keeper_event_queue.mli
+++ b/lib/keeper_runtime/keeper_event_queue.mli
@@ -122,6 +122,7 @@ and bg_job_completion = {
   bg_kind : bg_job_kind;
   bg_outcome : bg_job_outcome;
   bg_board_post_id : string;
+  bg_invocation_join : keeper_invocation_join option;
 }
 (** RFC-0290 payload for [Bg_completed]: mirrors [fusion_completion]. [bg_kind]
     is a closed sum so a new job kind forces exhaustive handling; [bg_outcome]
@@ -138,6 +139,13 @@ and bg_job_kind =
 and bg_job_outcome =
   | Bg_ok of string  (** result payload *)
   | Bg_failed of string  (** failure label *)
+
+and keeper_invocation_join = {
+  run_ref : Keeper_invocation_types.run_ref;
+  result_contract : Keeper_invocation_types.result_contract;
+  terminal_result : Keeper_invocation_types.terminal_result;
+  artifact_refs : Shared_types.Artifact_id.t list;
+}
 
 and hitl_resolution_decision =
   | Hitl_approved
@@ -193,6 +201,8 @@ and goal_assignment = {
   ga_assigned_by : string;
 }
 (** Payload for [Goal_assigned]. *)
+
+val keeper_invocation_join_to_yojson : keeper_invocation_join -> Yojson.Safe.t
 
 
 val fusion_completion_post_id : fusion_completion -> post_id

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -151,7 +151,14 @@ let validate_keeper_invocation_completion ~request_id stimulus =
     match stimulus.Keeper_event_queue.payload with
     | Keeper_event_queue.Bg_completed completion
       when completion.bg_kind = Keeper_event_queue.Keeper_invocation
-           && String.equal completion.bg_run_id request_id -> Ok ()
+           && String.equal completion.bg_run_id request_id ->
+      (match completion.bg_invocation_join with
+       | Some join
+         when String.equal
+                request_id
+                (Keeper_invocation_types.run_id join.run_ref) -> Ok ()
+       | Some _ -> Error "Keeper invocation receipt run_ref does not match request id"
+       | None -> Error "Keeper invocation receipt lacks its typed terminal join")
     | Keeper_event_queue.Bg_completed _ ->
       Error "Keeper invocation receipt does not match its typed completion"
     | _ -> Error "Keeper invocation receipt requires a Bg_completed payload"

--- a/test/test_fusion_wake.ml
+++ b/test/test_fusion_wake.ml
@@ -222,7 +222,7 @@ let bg_payload
       ()
   : Keeper_event_queue.bg_job_completion
   =
-  { bg_run_id; bg_kind; bg_outcome; bg_board_post_id }
+  { bg_run_id; bg_kind; bg_outcome; bg_board_post_id; bg_invocation_join = None }
 ;;
 
 let bg_stimulus ?bg_run_id ?bg_kind ?bg_outcome ?bg_board_post_id ()

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -252,6 +252,7 @@ let eio_test name fn =
 let base_observation : WO.world_observation =
   { pending_messages = []
   ; pending_board_events = []
+  ; keeper_invocation_joins = []
   ; idle_seconds = 0
   ; active_goals = []
   ; unclaimed_task_count = 0

--- a/test/test_keeper_connector_attention_wake.ml
+++ b/test/test_keeper_connector_attention_wake.ml
@@ -121,6 +121,7 @@ let external_attention_item ?(urgency = A.Ambient) ?(preview = "ambient TOKEN-12
 let quiet_obs : WO.world_observation =
   { pending_messages = []
   ; pending_board_events = []
+  ; keeper_invocation_joins = []
   ; idle_seconds = 0
   ; active_goals = []
   ; unclaimed_task_count = 0

--- a/test/test_keeper_context_layers.ml
+++ b/test/test_keeper_context_layers.ml
@@ -20,6 +20,7 @@ let all_layers =
     L.Pending_mentions;
     L.Scope_messages;
     L.Claimable_work;
+    L.Keeper_invocation_results;
     L.Board_activity;
   ]
 
@@ -49,7 +50,7 @@ let test_order_index_is_injective () =
     (List.length all_layers) (List.length sorted)
 
 let test_assemble_concatenates_present_in_order () =
-  (* Render a label for three layers spread across the order (positions 0, 4, 9)
+  (* Render a label for three layers spread across the order (positions 0, 4, 10)
      and nothing for the rest; assemble must yield them in ordered order. *)
   let content_of = function
     | L.Active_goals -> Some "A"
@@ -64,9 +65,9 @@ let test_assemble_empty_when_all_absent () =
   check string "no layers -> empty body" "" (L.assemble ~content_of:(fun _ -> None))
 
 let test_assemble_all_present_follows_ordered () =
-  (* Each layer renders its own order index; the result must read 0..9. *)
+  (* Each layer renders its own order index; the result must read 0..10. *)
   let content_of id = Some (string_of_int (L.order_index id)) in
-  check string "every layer present -> indices in order" "0123456789"
+  check string "every layer present -> indices in order" "012345678910"
     (L.assemble ~content_of)
 
 let () =

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -345,6 +345,7 @@ let () =
       ; bg_kind = Subprocess
       ; bg_outcome = Bg_ok "done"
       ; bg_board_post_id = "post-2"
+      ; bg_invocation_join = None
       }
   in
   assert (not (is_board_signal (bg_payload ())));
@@ -356,6 +357,7 @@ let () =
          ; bg_kind = Subprocess
          ; bg_outcome = Bg_ok "done"
          ; bg_board_post_id = "post-2"
+         ; bg_invocation_join = None
          })
       "post-2");
   assert (
@@ -365,6 +367,7 @@ let () =
          ; bg_kind = Subprocess
          ; bg_outcome = Bg_failed "exit 1"
          ; bg_board_post_id = ""
+         ; bg_invocation_join = None
          })
       "bg-run:bg-2");
 
@@ -416,6 +419,7 @@ let () =
                 ; bg_kind = Subprocess
                 ; bg_outcome = Bg_failed "boom"
                 ; bg_board_post_id = ""
+                ; bg_invocation_join = None
                 }
           })
    with

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -17,11 +17,30 @@ let stimulus ?(payload = Queue.Bootstrap) post_id arrived_at : Queue.stimulus =
 ;;
 
 let keeper_invocation_completion ?(outcome = Queue.Bg_ok "completed") request_id =
+  let request =
+    Keeper_invocation_types.keeper_turn ~keeper_name:"callee" ~prompt:"work"
+    |> Result.get_ok
+  in
+  let run_ref : Keeper_invocation_types.run_ref =
+    { run_id = request_id
+    ; target = Keeper_invocation_types.request_target request
+    ; capability = Keeper_invocation_types.request_capability request
+    }
+  in
   let completion : Queue.bg_job_completion =
     { bg_run_id = request_id
     ; bg_kind = Queue.Keeper_invocation
     ; bg_outcome = outcome
     ; bg_board_post_id = ""
+    ; bg_invocation_join =
+        Some
+          { run_ref
+          ; result_contract = Keeper_invocation_types.Completed
+          ; terminal_result =
+              Keeper_invocation_types.Invocation_succeeded
+                { body = "completed"; data = None }
+          ; artifact_refs = []
+          }
     }
   in
   stimulus

--- a/test/test_keeper_lifecycle_global_gate.ml
+++ b/test/test_keeper_lifecycle_global_gate.ml
@@ -98,6 +98,7 @@ let ready_meta () =
 let base_obs : WO.world_observation =
   { pending_messages = []
   ; pending_board_events = []
+  ; keeper_invocation_joins = []
   ; idle_seconds = 0
   ; active_goals = []
   ; unclaimed_task_count = 0

--- a/test/test_keeper_prompt_external.ml
+++ b/test/test_keeper_prompt_external.ml
@@ -138,6 +138,7 @@ let task_create_observation : WO.world_observation =
   {
     pending_messages = [];
     pending_board_events = [];
+    keeper_invocation_joins = [];
     idle_seconds = 1;
     active_goals = [ "goal-test-task-create" ];
     unclaimed_task_count = 0;

--- a/test/test_keeper_raw_task_signal_wake.ml
+++ b/test/test_keeper_raw_task_signal_wake.ml
@@ -6,6 +6,7 @@ module WO = Keeper_world_observation
 let base_observation : WO.world_observation =
   { pending_messages = []
   ; pending_board_events = []
+  ; keeper_invocation_joins = []
   ; idle_seconds = 0
   ; active_goals = []
   ; unclaimed_task_count = 0

--- a/test/test_keeper_surface_presence_prompt.ml
+++ b/test/test_keeper_surface_presence_prompt.ml
@@ -52,6 +52,7 @@ let base_observation : WO.world_observation =
   {
     pending_messages = [];
     pending_board_events = [];
+    keeper_invocation_joins = [];
     idle_seconds = 0;
     active_goals = [];
     unclaimed_task_count = 0;

--- a/test/test_keeper_tool_emission_hook.ml
+++ b/test/test_keeper_tool_emission_hook.ml
@@ -61,8 +61,9 @@ let test_drain_empties_accumulator () =
 
 let test_snapshot_does_not_drain () =
   let acc = H.create_accumulator () in
-  H.capture_typed_result acc (tagged ~kind:"doc" ~id:"doc-1" []);
+  H.capture_typed_result acc (tagged ~kind:"doc" ~id:"01900000-0000-7000-8000-000000000001" []);
   Alcotest.(check int) "snapshot" 1 (List.length (H.snapshot acc));
+  Alcotest.(check int) "artifact refs" 1 (Result.get_ok (H.snapshot_artifact_refs acc) |> List.length);
   assert_size "snapshot preserves" 1 acc
 ;;
 

--- a/test/test_keeper_unified_persona_block.ml
+++ b/test/test_keeper_unified_persona_block.ml
@@ -35,6 +35,7 @@ let base_observation : WO.world_observation =
   {
     pending_messages = [];
     pending_board_events = [];
+    keeper_invocation_joins = [];
     idle_seconds = 0;
     active_goals = [];
     unclaimed_task_count = 0;

--- a/test/test_keeper_unified_verification_surface.ml
+++ b/test/test_keeper_unified_verification_surface.ml
@@ -7,6 +7,7 @@ let base_observation : WO.world_observation =
   {
     pending_messages = [];
     pending_board_events = [];
+    keeper_invocation_joins = [];
     idle_seconds = 0;
     active_goals = [];
     unclaimed_task_count = 0;

--- a/test/test_keeper_wake_turn_context.ml
+++ b/test/test_keeper_wake_turn_context.ml
@@ -59,6 +59,7 @@ let base_observation : WO.world_observation =
   {
     pending_messages = [];
     pending_board_events = [];
+    keeper_invocation_joins = [];
     idle_seconds = 0;
     active_goals = [];
     unclaimed_task_count = 0;


### PR DESCRIPTION
## Outcome

- Persists one exact Keeper invocation join: run_ref, terminal result contract, full typed success/failure payload, and sorted UUIDv7 artifact refs.
- Removes the fake Board projection for Keeper invocation completions. Subprocess completion keeps its existing Board observation path.
- Reinjects the durable join only into the recorded caller Keeper lane, opens an explicit reactive turn reason, and renders the full typed join in its own context layer.
- Preserves Done failure data, Lost reason, Cancelled actor/reason, and persistence-failure attempted status across restart replay.
- Treats malformed explicit artifact tags as errors instead of silently discarding them.

## Boundary check

The new string comparisons are exact wire codecs only: keeper/invoke_turn decode the existing closed run_ref schema, and multimodal kind/id come from producer-authored reserved typed fields. No tool-name, model-name, URL, body-text, or product-specific semantic classification was added.

## Verification

- Exact diff: 374 additions + 25 deletions = 399 total changed lines.
- git diff --check: pass.
- ocamlformat --check on every changed ML/MLI file: pass.
- OCaml parser pass on every changed ML/MLI file: pass.
- Existing durable restart handshake and event-queue state tests now construct and persist the typed join; artifact snapshot test pins UUID extraction.
- Focused repo wrapper stopped before compilation on external OAS pin drift: installed 7e7b1e703a5fa2e8a8e504b5eb8a96d0290ad164, expected b02bc16f57b18542abae17023e1a2b886cda7347. No pin mutation and no MASC_SKIP_PIN_CHECK bypass were used; CI remains the build authority.

Stacked on #24728.