### PR TITLE
refactor(keeper): purge provider-slot observability contract

### DIFF
--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -151,7 +151,6 @@ type t =
   | MemoryLaneCancelledUnits
   | MemoryLanePending
   | MemoryLaneInFlight
-  | MemoryLaneProviderSlotBusy
   | MemoryBankCompactionFailures
   | MemoryOsMaintenanceKeeperTimeout
   | WriteMetaCycleFailures
@@ -378,7 +377,6 @@ let to_string = function
   | MemoryLaneCancelledUnits -> "masc_keeper_memory_lane_cancelled_units_total"
   | MemoryLanePending -> "masc_keeper_memory_lane_pending"
   | MemoryLaneInFlight -> "masc_keeper_memory_lane_in_flight"
-  | MemoryLaneProviderSlotBusy -> "masc_keeper_memory_lane_provider_slot_busy_total"
   | MemoryBankCompactionFailures -> "masc_keeper_memory_bank_compaction_failures_total"
   | MemoryOsMaintenanceKeeperTimeout -> "masc_keeper_memory_os_maintenance_keeper_timeout_total"
   | WriteMetaCycleFailures -> "masc_keeper_write_meta_cycle_failures_total"

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -142,7 +142,6 @@ type t =
   | MemoryLaneCancelledUnits
   | MemoryLanePending
   | MemoryLaneInFlight
-  | MemoryLaneProviderSlotBusy
   | MemoryBankCompactionFailures
   | MemoryOsMaintenanceKeeperTimeout
   | WriteMetaCycleFailures

--- a/lib/server/server_dashboard_http_keeper_memory_health.ml
+++ b/lib/server/server_dashboard_http_keeper_memory_health.ml
@@ -11,8 +11,6 @@
     - [Keeper_memory_os_io.events_path] + file stat for events bytes.
     - [Keeper_memory_os_gc.run_gc ~dry_run:true] for explicitly expired rows
       without mutating the store.
-    - [Otel_metric_store] provider-slot-busy counters for skipped librarian
-      extraction attempts, grouped by keeper.
     - [Keeper_librarian_runtime.cadence_counter_entries] for the cadence table
       size (one fleet-wide value). *)
 
@@ -25,20 +23,17 @@ type keeper_health =
   ; events_to_facts_ratio : float
   ; ttl_expired_on_disk : int
   ; near_duplicate : int
-  ; provider_slot_busy : int
   }
 
 type alert_code =
   | Ttl_expired_on_disk
   | Near_duplicate
-  | Provider_slot_busy
 
 type alert_severity = Warn
 
 type alert_target =
   | Ttl_expired_on_disk_target
   | Near_duplicate_target
-  | Provider_slot_busy_target
 
 type keeper_alert =
   { code : alert_code
@@ -53,15 +48,9 @@ type keeper_alert =
 let ttl_expired_on_disk_threshold = 0.0
 let near_duplicate_threshold = 0.0
 
-let provider_slot_busy_threshold = 0.0
-
-let provider_slot_busy_metric = Keeper_metrics.(to_string MemoryLaneProviderSlotBusy)
-let provider_slot_busy_site = Keeper_librarian_runtime.memory_os_librarian_provider_slot_site
-
 let alert_code_to_string = function
   | Ttl_expired_on_disk -> "ttl_expired_on_disk"
   | Near_duplicate -> "near_duplicate"
-  | Provider_slot_busy -> "provider_slot_busy"
 ;;
 
 let alert_severity_to_string = function
@@ -71,7 +60,6 @@ let alert_severity_to_string = function
 let alert_target_to_string = function
   | Ttl_expired_on_disk_target -> "ttl_expired_on_disk"
   | Near_duplicate_target -> "near_duplicate"
-  | Provider_slot_busy_target -> "provider_slot_busy"
 ;;
 
 (* Alert labels are endpoint-owned wire copy for this backend-defined diagnostic
@@ -80,7 +68,6 @@ let alert_target_to_string = function
 let alert_label = function
   | Ttl_expired_on_disk -> "TTL"
   | Near_duplicate -> "중복"
-  | Provider_slot_busy -> "슬롯"
 ;;
 
 let alert ~code ~target ~message ~value ~threshold =
@@ -109,18 +96,6 @@ let keeper_alerts h =
         ~message:"Near-duplicate Memory OS fact rows remain on disk; GC dry-run would deduplicate them."
         ~value:(float_of_int h.near_duplicate)
         ~threshold:near_duplicate_threshold
-      :: alerts
-    else alerts)
-  |> (fun alerts ->
-    if h.provider_slot_busy > 0
-    then
-      alert
-        ~code:Provider_slot_busy
-        ~target:Provider_slot_busy_target
-        ~message:
-          "Memory OS librarian provider slot was busy; extraction was skipped and remains due."
-        ~value:(float_of_int h.provider_slot_busy)
-        ~threshold:provider_slot_busy_threshold
       :: alerts
     else alerts)
   |> List.rev
@@ -163,17 +138,6 @@ let count_lines_in_file path =
 let file_size_bytes path =
   (* NDT-OK: file size is a diagnostic metric. *)
   if not (Sys.file_exists path) then 0 else (Unix.stat path).Unix.st_size
-;;
-
-let provider_slot_busy_for_keeper keeper_id =
-  (* MemoryLaneProviderSlotBusy is emitted through [inc_counter], so values are
-     integral counts even though the metric store carries floats. Keep the JSON
-     field as an int to match the rest of this count-oriented health snapshot. *)
-  Otel_metric_store.metric_value_or_zero
-    provider_slot_busy_metric
-    ~labels:[ "keeper", keeper_id; "site", provider_slot_busy_site ]
-    ()
-  |> int_of_float
 ;;
 
 let duplicate_claim_identity_rows facts =
@@ -221,7 +185,6 @@ let keeper_health ~keepers_dir ~now keeper_id =
       float_of_int events_bytes /. float_of_int (max 1 facts_bytes)
   ; ttl_expired_on_disk = gc_report.ttl_expired
   ; near_duplicate = duplicate_claim_identity_rows facts
-  ; provider_slot_busy = provider_slot_busy_for_keeper keeper_id
   }
 ;;
 
@@ -235,7 +198,6 @@ let keeper_health_entry_to_json (h, alerts) : Yojson.Safe.t =
     ; "events_to_facts_ratio", `Float h.events_to_facts_ratio
     ; "ttl_expired_on_disk", `Int h.ttl_expired_on_disk
     ; "near_duplicate", `Int h.near_duplicate
-    ; "provider_slot_busy", `Int h.provider_slot_busy
     ; "alerts", `List (List.map keeper_alert_to_json alerts)
     ]
 ;;
@@ -282,7 +244,6 @@ let keeper_memory_health_http_json ~base_path : Yojson.Safe.t =
           ; "events_bytes", `Int (sum (fun h -> h.events_bytes))
           ; "ttl_expired_on_disk", `Int (sum (fun h -> h.ttl_expired_on_disk))
           ; "near_duplicate", `Int (sum (fun h -> h.near_duplicate))
-          ; "provider_slot_busy", `Int (sum (fun h -> h.provider_slot_busy))
           ] )
     ; ( "alert_summary"
       , `Assoc
@@ -299,12 +260,10 @@ let keeper_memory_health_http_json ~base_path : Yojson.Safe.t =
                    entries) )
           ; "ttl_expired_keepers", `Int (alert_count_by_code Ttl_expired_on_disk)
           ; "near_duplicate_keepers", `Int (alert_count_by_code Near_duplicate)
-          ; "provider_slot_busy_keepers", `Int (alert_count_by_code Provider_slot_busy)
           ; ( "thresholds"
             , `Assoc
                 [ "ttl_expired_on_disk", `Float ttl_expired_on_disk_threshold
                 ; "near_duplicate", `Float near_duplicate_threshold
-                ; "provider_slot_busy", `Float provider_slot_busy_threshold
                 ] )
           ] )
     ]

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -3445,115 +3445,6 @@ let test_no_category_infers_validity () =
     (Types.Unknown "novel" :: Types.all_categories)
 ;;
 
-let with_env name value f =
-  let old = Sys.getenv_opt name in
-  Unix.putenv name value;
-  Fun.protect ~finally:(fun () -> restore_env name old) f
-;;
-
-let test_librarian_provider_slot_gate_caps_at_capacity () =
-  with_env Env_config.KeeperMemoryOs.librarian_global_slot_env_key "1" (fun () ->
-    with_eio (fun ~sw ~net:_ ~clock ->
-      (* Capacity 1: while one entrant holds the slot, a concurrent entrant drops
-         ([None]) after [provider_slot_wait_sec] instead of blocking — the #21230
-         storm-guard the per-keeper lane keeps as an optional fleet-wide gate. *)
-      let entered, resolve_entered = Eio.Promise.create () in
-      let release, resolve_release = Eio.Promise.create () in
-      let first = ref None in
-      Eio.Fiber.fork ~sw (fun () ->
-        first
-        := Some
-             (Librarian_runtime.with_provider_slot
-                ~keeper_id:"keeper-a"
-                ~clock
-                (fun () ->
-                   Eio.Promise.resolve resolve_entered ();
-                   Eio.Promise.await release;
-                   "ran")));
-      Eio.Promise.await entered;
-      let second =
-        Librarian_runtime.with_provider_slot ~keeper_id:"keeper-a" ~clock (fun () -> "ran")
-      in
-      Eio.Promise.resolve resolve_release ();
-      wait_for_ref ~clock "first slot holder" first;
-      Alcotest.(check (option string))
-        "concurrent entrant drops at capacity 1"
-        None
-        second;
-      Alcotest.(check (option (option string)))
-        "slot holder ran"
-        (Some (Some "ran"))
-        !first))
-;;
-
-let test_librarian_provider_slot_gate_disabled_at_zero () =
-  with_env Env_config.KeeperMemoryOs.librarian_global_slot_env_key "0" (fun () ->
-    with_eio (fun ~sw ~net:_ ~clock ->
-      (* Capacity 0 disables the gate: a held slot does not cap a concurrent
-         entrant — both run ([Some]). *)
-      let entered, resolve_entered = Eio.Promise.create () in
-      let release, resolve_release = Eio.Promise.create () in
-      let first = ref None in
-      Eio.Fiber.fork ~sw (fun () ->
-        first
-        := Some
-             (Librarian_runtime.with_provider_slot
-                ~keeper_id:"keeper-a"
-                ~clock
-                (fun () ->
-                   Eio.Promise.resolve resolve_entered ();
-                   Eio.Promise.await release;
-                   "ran")));
-      Eio.Promise.await entered;
-      let second =
-        Librarian_runtime.with_provider_slot ~keeper_id:"keeper-a" ~clock (fun () -> "ran")
-      in
-      Eio.Promise.resolve resolve_release ();
-      wait_for_ref ~clock "first slot holder" first;
-      Alcotest.(check (option string))
-        "gate disabled: concurrent entrant also ran"
-        (Some "ran")
-        second;
-      Alcotest.(check (option (option string)))
-        "slot holder ran"
-        (Some (Some "ran"))
-        !first))
-;;
-
-let test_librarian_provider_slot_gate_is_per_keeper () =
-  with_env Env_config.KeeperMemoryOs.librarian_global_slot_env_key "1" (fun () ->
-    with_eio (fun ~sw ~net:_ ~clock ->
-      (* Capacity 1 is per keeper: a slot held by keeper-a must not block
-         keeper-b. This is the P0-4 isolation contract. *)
-      let entered, resolve_entered = Eio.Promise.create () in
-      let release, resolve_release = Eio.Promise.create () in
-      let first = ref None in
-      Eio.Fiber.fork ~sw (fun () ->
-        first
-        := Some
-             (Librarian_runtime.with_provider_slot
-                ~keeper_id:"keeper-a"
-                ~clock
-                (fun () ->
-                   Eio.Promise.resolve resolve_entered ();
-                   Eio.Promise.await release;
-                   "ran")));
-      Eio.Promise.await entered;
-      let other_keeper =
-        Librarian_runtime.with_provider_slot ~keeper_id:"keeper-b" ~clock (fun () -> "ran")
-      in
-      Eio.Promise.resolve resolve_release ();
-      wait_for_ref ~clock "first slot holder" first;
-      Alcotest.(check (option string))
-        "different keeper runs despite capacity 1 held"
-        (Some "ran")
-        other_keeper;
-      Alcotest.(check (option (option string)))
-        "slot holder ran"
-        (Some (Some "ran"))
-        !first))
-;;
-
 (* ---------- Explicit validity only ---------- *)
 
 let test_fact_validity_uses_only_stored_value () =
@@ -4919,18 +4810,6 @@ let () =
             "unstructured fallback does not write facts"
             `Quick
             test_librarian_invalid_output_does_not_write_facts
-        ; Alcotest.test_case
-            "provider slot gate caps concurrency at capacity (#21376/#21230)"
-            `Quick
-            test_librarian_provider_slot_gate_caps_at_capacity
-        ; Alcotest.test_case
-            "provider slot gate disabled at capacity 0"
-            `Quick
-            test_librarian_provider_slot_gate_disabled_at_zero
-        ; Alcotest.test_case
-            "provider slot gate isolates keepers (P0-4)"
-            `Quick
-            test_librarian_provider_slot_gate_is_per_keeper
         ] )
     ; ( "rfc-0259 volatile"
       , [ Alcotest.test_case

--- a/test/test_server_dashboard_http_keeper_memory_health.ml
+++ b/test/test_server_dashboard_http_keeper_memory_health.ml
@@ -2,9 +2,6 @@
 
 module Types = Masc.Keeper_memory_os_types
 module Io = Masc.Keeper_memory_os_io
-module Metrics = Masc.Otel_metric_store
-module KeeperMetrics = Keeper_metrics
-module LibrarianRuntime = Masc.Keeper_librarian_runtime
 module Health = Server_dashboard_http_keeper_memory_health
 
 let test_now = 1_700_000_000.0
@@ -175,7 +172,6 @@ let test_reports_per_keeper_metric_values () =
     (float_field "events_to_facts_ratio" k);
   Alcotest.(check int) "nothing expired" 0 (int_field "ttl_expired_on_disk" k);
   Alcotest.(check int) "no duplicates" 0 (int_field "near_duplicate" k);
-  Alcotest.(check int) "no provider slot busy skips" 0 (int_field "provider_slot_busy" k);
   Alcotest.(check int) "no keeper alerts" 0 (List.length (list_field "alerts" k));
   Alcotest.(check int) "totals.facts" 2 (int_field "facts" (totals json));
   Alcotest.(check bool)
@@ -234,52 +230,6 @@ let test_health_reports_expiry_and_exact_duplicate_identity () =
   (* dry_run must NOT rewrite the store: a fresh read still sees all 4 rows. *)
   let reread = Io.read_facts_all_for_keepers_dir ~keepers_dir ~keeper_id:"gc" in
   Alcotest.(check int) "store untouched by dry-run gc" 4 (List.length reread)
-;;
-
-let test_reports_provider_slot_busy_metric_as_alert () =
-  Eio_main.run
-  @@ fun _env ->
-  let now = test_now in
-  let base = fresh_dir "masc-memory-health-provider-slot" in
-  (* Otel_metric_store is process-global. Use a temp-derived keeper label so
-     repeated test runs in one process cannot inherit this counter cell. *)
-  let keeper_id = "slotbusy-health-" ^ Filename.basename base in
-  let keepers_dir = Config_dir_resolver.keepers_dir_for_base_path ~base_path:base in
-  Io.rewrite_facts_atomically_for_keepers_dir
-    ~keepers_dir
-    ~keeper_id
-    [ fact ~now "slot busy metric keeper fact" ];
-  Metrics.inc_counter
-    KeeperMetrics.(to_string MemoryLaneProviderSlotBusy)
-    ~labels:
-      [ "keeper", keeper_id
-      ; "site", LibrarianRuntime.memory_os_librarian_provider_slot_site
-      ]
-    ~delta:3.0
-    ();
-  let json = Health.keeper_memory_health_http_json ~base_path:base in
-  let k = keeper_obj keeper_id json in
-  Alcotest.(check int) "provider slot busy projected" 3 (int_field "provider_slot_busy" k);
-  Alcotest.(check int)
-    "totals provider slot busy"
-    3
-    (int_field "provider_slot_busy" (totals json));
-  let alerts = list_field "alerts" k in
-  Alcotest.(check (list string))
-    "provider slot alert code"
-    [ "provider_slot_busy" ]
-    (List.map (string_field "code") alerts);
-  Alcotest.(check (list string))
-    "provider slot alert target"
-    [ "provider_slot_busy" ]
-    (List.map (string_field "target") alerts);
-  Alcotest.(check (list string))
-    "provider slot alert label"
-    [ "슬롯" ]
-    (List.map (string_field "label") alerts);
-  let summary = alert_summary json in
-  Alcotest.(check int) "summary provider slot keepers" 1 (int_field "provider_slot_busy_keepers" summary);
-  Alcotest.(check int) "summary total alerts" 1 (int_field "total_alerts" summary)
 ;;
 
 let test_sorts_keepers_by_facts_bytes_desc () =
@@ -353,10 +303,6 @@ let () =
             "dry-run gc reports expired and duplicate rows"
             `Quick
             test_health_reports_expiry_and_exact_duplicate_identity
-        ; Alcotest.test_case
-            "reports provider slot busy metric as alert"
-            `Quick
-            test_reports_provider_slot_busy_metric_as_alert
         ; Alcotest.test_case
             "sorts keepers by facts_bytes descending"
             `Quick


### PR DESCRIPTION
## Stack

- Base: #24737 (`codex/memory-durable-owner-drain-c3a-20260716`)
- This PR: C3b1 remove the orphan provider-slot observability/test contract
- Next: C3b2 deletes the semaphore, 0.25 s drop path, `Provider_slot_busy`, and its env/catalog surface

## Why this is a separate hard cut

At the base commit `a3572caa7b`, `git grep MemoryLaneProviderSlotBusy -- lib` finds only the metric enum and the dashboard reader. There is no producer after #24737 moved Memory execution to the typed durable owner drain. The dashboard therefore reports a permanently zero retired control path.

## What changed

- Remove the orphan provider-slot metric and dashboard fields/alert taxonomy.
- Remove the three tests whose sole purpose was proving slot saturation drops or bypasses work.
- Remove the dashboard test that synthesised a counter no production path emits.
- No runtime behavior, replacement heuristic, or new gate is introduced here.

## Size

- 219 deletions, 0 additions.

## Proof

- OCaml parse and `ocamlformat --check` passed.
- Coverage checker passed without waiver.
- Focused target build passed:
  - `test/test_keeper_memory_os.exe`
  - `test/test_server_dashboard_http_keeper_memory_health.exe`
- Dashboard suite: 6/6 passed.
- Memory OS suite: 102/103 passed. The remaining failure is the pre-existing, out-of-scope `memory provider configs use runtime.toml temperature` assertion (`Some 1.0` expected, `None` received); isolated rerun fails identically and this PR does not touch the provider-summary/runtime-temperature path.
