### PR TITLE
fix(dashboard): make 2s snapshot loop incremental over append-only stores

### DIFF
--- a/lib/activity_graph/activity_graph.ml
+++ b/lib/activity_graph/activity_graph.ml
@@ -311,8 +311,21 @@ let parse_current_day_events_cached config path : event list =
      | _ ->
        let full_reparse_and_cache () =
          let events = parse_events_from_file config path in
-         Stdlib.Mutex.protect current_day_cache_mu (fun () ->
-           Hashtbl.replace current_day_cache path { cd_boundary = size; cd_events = events });
+         (* Other masc processes (stdio clients, workers) append to the
+            same file. If it grew between the stat above and this parse,
+            the parse may already include lines past [size]; caching
+            [size] as the boundary would make the next delta fold append
+            those lines a second time, and the duplicates would then live
+            in the cache until the next truncation. Only cache when the
+            post-parse size still matches — otherwise skip; the next call
+            re-parses and retries. *)
+         (match Unix.stat path with
+          | exception (Unix.Unix_error _ | Sys_error _) -> ()
+          | st_after when st_after.Unix.st_size = size ->
+            Stdlib.Mutex.protect current_day_cache_mu (fun () ->
+              Hashtbl.replace current_day_cache path
+                { cd_boundary = size; cd_events = events })
+          | _ -> ());
          events
        in
        (match cached with

--- a/lib/activity_graph/activity_graph.ml
+++ b/lib/activity_graph/activity_graph.ml
@@ -6,6 +6,7 @@ include Activity_graph_registry
 include Activity_graph_reducer
 
 module StringMap = Set_util.StringMap
+module StringSet = Set_util.StringSet
 
 (* ================================================================ *)
 (* File storage paths                                               *)
@@ -247,15 +248,148 @@ let rec past_day_cache_insert path mtime parsed =
 let file_mtime path =
   try Some (Unix.stat path).Unix.st_mtime with _ -> None
 
+let reset_past_day_cache_for_testing () = Atomic.set past_day_cache Past_day_path_map.empty
+
+(* P0-4 (masc perf root-cause report, 2026-07-15, item (1)): the 2s
+   [Dashboard_snapshot.refresh_loop] calls [read_all_events] up to 3x per
+   tick — [json_response], [graph_json], and [agent_spans_json] each call
+   [list_events_with_meta] / [list_events_with_total] independently — and
+   every call full-reparsed the current-day JSONL via
+   [parse_events_from_file] (measured 1.2 MB typical, 23 MB peak; Yojson
+   lexing dominated idle CPU). Past-day files already get incremental
+   treatment via [past_day_cache] above; this extends the same
+   boundary-keyed design used by
+   [Telemetry_unified.trajectory_summary_cache] (telemetry_unified.ml
+   ~L791-847) and [Dated_jsonl.file_count_cache] (dated_jsonl.ml
+   ~L537-598) to the current-day file. Unlike those two (which cache an
+   aggregate), this caches the *parsed event list* itself, since all
+   three payload builders need the raw events, not just a count — so
+   caching here transparently de-duplicates all 3 per-tick calls (and any
+   non-default HTTP query) without threading a shared value through
+   [Dashboard_snapshot.compute]. *)
+type current_day_entry = {
+  cd_boundary : int;
+  cd_events : event list;  (* unsorted — callers always re-sort by [seq] *)
+}
+
+let current_day_cache : (string, current_day_entry) Hashtbl.t = Hashtbl.create 4
+let current_day_cache_mu = Stdlib.Mutex.create ()
+
+(* For_testing observability only: counts non-blank lines folded through
+   the incremental *delta* path (NOT the initial cold-miss full parse, nor
+   the invalid-UTF-8 / shrink fallback rescans below), so a test can prove
+   that growth behind a warm cache re-parses only the appended lines. *)
+let current_day_parse_counter = Atomic.make 0
+
+let reset_current_day_cache_for_testing () =
+  Stdlib.Mutex.protect current_day_cache_mu (fun () -> Hashtbl.reset current_day_cache);
+  Atomic.set current_day_parse_counter 0
+
+(* Incrementally parses the current-day file. New writes are sanitized
+   before append ([emit] -> [sanitize_event_traced]), so the appended
+   delta is expected to be valid UTF-8; if a delta line is nonetheless
+   invalid (at-rest corruption from before that sanitize call existed, or
+   an external writer), fall back to the full repair-aware
+   [parse_events_from_file] — the same path this file already takes today
+   — and reset the cache boundary so the next call stays correct. A
+   cached boundary past the current file size (rotation/truncation) gets
+   the same full-rescan treatment as the two precedents above. *)
+let parse_current_day_events_cached config path : event list =
+  match Unix.stat path with
+  | exception (Unix.Unix_error _ | Sys_error _) ->
+    (* Should not happen: [path] came from [collect_event_files], which
+       only lists files that exist. Defensive fallback for a delete race. *)
+    parse_events_from_file config path
+  | st ->
+    let size = st.Unix.st_size in
+    let cached =
+      Stdlib.Mutex.protect current_day_cache_mu (fun () ->
+        Hashtbl.find_opt current_day_cache path)
+    in
+    (match cached with
+     | Some e when e.cd_boundary = size -> e.cd_events
+     | _ ->
+       let full_reparse_and_cache () =
+         let events = parse_events_from_file config path in
+         Stdlib.Mutex.protect current_day_cache_mu (fun () ->
+           Hashtbl.replace current_day_cache path { cd_boundary = size; cd_events = events });
+         events
+       in
+       (match cached with
+        | Some e when e.cd_boundary > size ->
+          (* boundary past the file size: shrink/rotation/truncation *)
+          full_reparse_and_cache ()
+        | Some e ->
+          let invalid_utf8 = ref false in
+          let rev_new_events, boundary =
+            Fs_compat.fold_appended_lines ~path ~from:e.cd_boundary ~init:[]
+              ~f:(fun acc line ->
+                if not (String.is_valid_utf_8 line) then begin
+                  invalid_utf8 := true;
+                  acc
+                end
+                else begin
+                  Atomic.incr current_day_parse_counter;
+                  match parse_event_line line with
+                  | Some ev -> ev :: acc
+                  | None -> acc
+                end)
+          in
+          if !invalid_utf8 then
+            full_reparse_and_cache ()
+          else begin
+            let events = List.rev_append rev_new_events e.cd_events in
+            Stdlib.Mutex.protect current_day_cache_mu (fun () ->
+              Hashtbl.replace current_day_cache path
+                { cd_boundary = boundary; cd_events = events });
+            events
+          end
+        | None -> full_reparse_and_cache ()))
+
+(* P0-4 item (2): [past_day_cache] never removed an entry once inserted, so
+   a file pruned from disk by the existing 24h [MASC_JSONL_RETENTION_DAYS]
+   maintenance sweep (server_bootstrap_maintenance.ml, same
+   activity-events directory, default 30 days) stayed cached forever —
+   unbounded growth over the process lifetime (report item (6)).
+   Reconcile both caches against the live file set on every
+   [read_all_events] call: entries whose path is no longer present are
+   dropped. This never evicts a file [collect_event_files] would still
+   touch, so it cannot regress the hit rate for anything still on disk —
+   it only reclaims memory for files that are gone and would never be
+   looked up again. Deliberately NOT a second, independent "keep last N
+   days" cap: that would require either (a) bounding [read_all_events]'s
+   scan itself, which would change [total_matching_events] /
+   [events_store_total] output for stores with low daily event volume (a
+   real behavior change, out of scope here), or (b) a second retention
+   constant parallel to [MASC_JSONL_RETENTION_DAYS] that could drift from
+   it — the "Scattered Hardcoded Defaults" anti-pattern
+   software-development.md warns against. Mirroring the existing knob
+   instead of introducing a new one keeps a single retention SSOT. *)
+let evict_stale_cache_entries ~live_paths =
+  let live_set = StringSet.of_list live_paths in
+  let rec evict_past_day () =
+    let prev = Atomic.get past_day_cache in
+    let next = Past_day_path_map.filter (fun path _ -> StringSet.mem path live_set) prev in
+    if Past_day_path_map.cardinal next <> Past_day_path_map.cardinal prev
+    && not (Atomic.compare_and_set past_day_cache prev next)
+    then evict_past_day ()
+  in
+  evict_past_day ();
+  Stdlib.Mutex.protect current_day_cache_mu (fun () ->
+    Hashtbl.filter_map_inplace
+      (fun path entry -> if StringSet.mem path live_set then Some entry else None)
+      current_day_cache)
+
 let read_all_events config =
   let current_day = day_path config in
-  collect_event_files config
+  let files = collect_event_files config in
+  evict_stale_cache_entries ~live_paths:files;
+  files
   |> List.fold_left
        (fun acc path ->
          let rows =
            if String.equal path current_day then
-             (* Current-day file mtime changes on every append. *)
-             parse_events_from_file config path
+             parse_current_day_events_cached config path
            else
              match file_mtime path with
              | None -> parse_events_from_file config path
@@ -756,3 +890,14 @@ let agent_spans_json config ?(limit = 500) ?since_ms () =
        ~extra:[("spans_count", `Int (List.length all_spans))]
        ());
   ]
+
+module For_testing = struct
+  let reset_current_day_cache_for_testing = reset_current_day_cache_for_testing
+  let reset_past_day_cache_for_testing = reset_past_day_cache_for_testing
+  let current_day_parsed_line_count () = Atomic.get current_day_parse_counter
+  let current_day_cache_entry_count () =
+    Stdlib.Mutex.protect current_day_cache_mu (fun () -> Hashtbl.length current_day_cache)
+  let past_day_cache_entry_count () =
+    Past_day_path_map.cardinal (Atomic.get past_day_cache)
+  let current_day_path = day_path
+end

--- a/lib/activity_graph/activity_graph.mli
+++ b/lib/activity_graph/activity_graph.mli
@@ -142,3 +142,28 @@ val agent_spans_json :
     window) are reported with [Span_open] and [end_ms] set
     to "now".  Returns [`Assoc [agents; spans; time_range;
     window]]. *)
+
+module For_testing : sig
+  val reset_current_day_cache_for_testing : unit -> unit
+  (** Clears the boundary-keyed current-day parse cache and its
+      delta-line counter so a test observes cold-start behavior. *)
+
+  val reset_past_day_cache_for_testing : unit -> unit
+  (** Clears the [(path, mtime) -> event list] past-day cache. *)
+
+  val current_day_parsed_line_count : unit -> int
+  (** Number of non-blank lines folded through the *incremental delta*
+      path since the last reset (excludes the initial cold-miss full
+      parse and the invalid-UTF-8 / shrink fallback rescans). Lets a
+      test prove that appending [n] lines behind a warm cache parses
+      exactly [n] lines, not the whole file. *)
+
+  val current_day_cache_entry_count : unit -> int
+  val past_day_cache_entry_count : unit -> int
+
+  val current_day_path : Workspace_utils.config -> string
+  (** Path of the file [read_all_events] treats as "current day" for
+      [config]. Exposed so tests can write directly to it to simulate
+      append growth, truncation, or invalid UTF-8 without going through
+      {!emit}. *)
+end

--- a/test/test_activity_graph.ml
+++ b/test/test_activity_graph.ml
@@ -631,6 +631,108 @@ let test_task_approved_completes_graph_and_span () =
             (s |> member "agent" |> to_string)
       | None -> Alcotest.fail "task span missing")
 
+(* ── P0-4 current-day incremental parse cache (masc perf root-cause
+   report 2026-07-15, item (1)) ──────────────────────────────────── *)
+
+let emit_n config n =
+  for i = 1 to n do
+    ignore
+      (Activity_graph.emit config ~kind:"message.broadcast"
+         ~actor:(Activity_graph.entity ~kind:"agent" "claude")
+         ~payload:(`Assoc [ ("seq_hint", `Int i) ])
+         ())
+  done
+
+(* Strips the wall-clock [generated_at_iso] field so two [json_response]
+   calls made moments apart can be compared for structural equality. *)
+let strip_generated_at_iso json =
+  match json with
+  | `Assoc fields ->
+    `Assoc
+      (List.map
+         (fun (k, v) -> if String.equal k "generated_at_iso" then (k, `Null) else (k, v))
+         fields)
+  | other -> other
+
+let test_current_day_cache_reparses_only_appended_delta () =
+  with_config (fun config ->
+      Activity_graph.For_testing.reset_current_day_cache_for_testing ();
+      emit_n config 10;
+      let first = Activity_graph.list_events config ~after_seq:0 ~limit:100 () in
+      check int "first read sees 10 events" 10 (List.length first);
+      check int "cold-miss full parse does not touch the delta counter" 0
+        (Activity_graph.For_testing.current_day_parsed_line_count ());
+      emit_n config 5;
+      let second = Activity_graph.list_events config ~after_seq:0 ~limit:100 () in
+      check int "second read sees all 15 events" 15 (List.length second);
+      check int "warm cache re-parses only the 5 appended lines" 5
+        (Activity_graph.For_testing.current_day_parsed_line_count ()))
+
+let test_current_day_cache_matches_uncached_golden () =
+  with_config (fun config ->
+      Activity_graph.For_testing.reset_current_day_cache_for_testing ();
+      emit_n config 4;
+      ignore (Activity_graph.json_response config ~after_seq:0 ~limit:100 ());
+      (* Grow behind the now-warm cache so the next read exercises the
+         incremental delta-fold path, not a cold full parse. *)
+      emit_n config 3;
+      let incremental =
+        Activity_graph.json_response config ~after_seq:0 ~limit:100 ()
+        |> strip_generated_at_iso
+      in
+      (* Force the reference path: an empty cache means the very next
+         read is a full, repair-aware [parse_events_from_file] call. *)
+      Activity_graph.For_testing.reset_current_day_cache_for_testing ();
+      let uncached =
+        Activity_graph.json_response config ~after_seq:0 ~limit:100 ()
+        |> strip_generated_at_iso
+      in
+      check string "incremental path output matches full-reparse reference"
+        (Yojson.Safe.to_string uncached) (Yojson.Safe.to_string incremental))
+
+let test_current_day_cache_rescans_from_zero_on_truncation () =
+  with_config (fun config ->
+      Activity_graph.For_testing.reset_current_day_cache_for_testing ();
+      emit_n config 6;
+      let baseline = Activity_graph.list_events config ~after_seq:0 ~limit:100 () in
+      check int "baseline has 6 events" 6 (List.length baseline);
+      (* Simulate rotation/truncation: rewrite the current-day file
+         smaller than the cached boundary. *)
+      let path = Activity_graph.For_testing.current_day_path config in
+      let raw_line seq =
+        Printf.sprintf
+          "{\"seq\":%d,\"ts_ms\":%d,\"ts_iso\":\"2026-01-01T00:00:00Z\",\
+           \"workspace_id\":\"default\",\"kind\":\"message.broadcast\",\
+           \"payload\":{},\"tags\":[]}\n"
+          seq seq
+      in
+      Fs_compat.save_file path (raw_line 1 ^ raw_line 2);
+      let after_truncate = Activity_graph.list_events config ~after_seq:0 ~limit:100 () in
+      check int "truncated file rescanned from zero, not merged with stale cache"
+        2 (List.length after_truncate))
+
+let test_past_day_cache_evicts_entries_for_deleted_files () =
+  with_config (fun config ->
+      Activity_graph.For_testing.reset_past_day_cache_for_testing ();
+      let baseline_count = Activity_graph.For_testing.past_day_cache_entry_count () in
+      let root = Filename.concat (Workspace_utils.masc_dir config) "activity-events" in
+      let month_dir = Filename.concat root "2000-01" in
+      Unix.mkdir root 0o755;
+      Unix.mkdir month_dir 0o755;
+      let day_path = Filename.concat month_dir "01.jsonl" in
+      Fs_compat.save_file day_path
+        "{\"seq\":1,\"ts_ms\":1,\"ts_iso\":\"2000-01-01T00:00:00Z\",\
+         \"workspace_id\":\"default\",\"kind\":\"message.broadcast\",\
+         \"payload\":{},\"tags\":[]}\n";
+      ignore (Activity_graph.list_events config ~after_seq:0 ~limit:100 ());
+      check bool "past-day file is now cached" true
+        (Activity_graph.For_testing.past_day_cache_entry_count () > baseline_count);
+      Sys.remove day_path;
+      Unix.rmdir month_dir;
+      ignore (Activity_graph.list_events config ~after_seq:0 ~limit:100 ());
+      check int "cache entry evicted once the backing file is gone"
+        baseline_count (Activity_graph.For_testing.past_day_cache_entry_count ()))
+
 let test_parse_since_ms_supports_minutes () =
   check (option int) "5m parses" (Some (5 * 60 * 1000))
     (Server_activity_http.parse_since_ms "5m");
@@ -688,5 +790,16 @@ let () =
             test_parse_since_ms_supports_minutes;
           test_case "span_status_opt None for unknown" `Quick
             test_span_status_of_string_opt_returns_none_for_unknown;
+        ] );
+      ( "current_day_cache",
+        [
+          test_case "warm cache re-parses only the appended delta" `Quick
+            test_current_day_cache_reparses_only_appended_delta;
+          test_case "incremental path output matches full-reparse reference"
+            `Quick test_current_day_cache_matches_uncached_golden;
+          test_case "truncated file rescans from zero" `Quick
+            test_current_day_cache_rescans_from_zero_on_truncation;
+          test_case "past-day cache evicts entries for deleted files" `Quick
+            test_past_day_cache_evicts_entries_for_deleted_files;
         ] );
     ]


### PR DESCRIPTION
## 배경

masc 서버 idle CPU 폭주 근본 원인 조사 (masc#24697, 진단 전문: `~/me/reports/masc-perf-rootcause-20260716.md` §①③⑥, 적대검증 완료) 중 P0-4 항목.

`lib/server/server_bootstrap_maintenance.ml:725`의 2.0s snapshot 리프레시 루프가 매 tick마다 `lib/dashboard/dashboard_snapshot.ml:210-238`에서 `Activity_graph.json_response` / `graph_json` / `agent_spans_json`를 각각 독립적으로 호출한다. 세 함수 모두 내부적으로 `read_all_events`를 호출하고, `read_all_events`는 당일(current-day) activity-events JSONL을 매번 `parse_events_from_file`로 **전량 재파싱**했다 (실측 1.2MB 평시, 07-06 23MB 피크). 즉 하루치 파일을 **매 tick 3회 전량 재파싱** — Yojson lexing이 idle CPU를 지배하는 1차 엔진.

과거일(past-day) 파일은 이미 `past_day_cache`(mtime 키)로 캐싱되어 있었지만, 당일 파일만은 캐싱 대상에서 빠져 있었다.

## 변경 사항

### 1. 당일 파일 boundary-key 증분 파싱 캐시 (`lib/activity_graph/activity_graph.ml`)

기존 `telemetry_unified.ml`의 `trajectory_summary_cache`(L791-847), `dated_jsonl.ml`의 `file_count_cache`(L537-598)와 동일한 boundary-key(파일 byte size) 증분 캐시 패턴을 그대로 적용했다. 차이점: 저 두 캐시는 집계값(count, latest_ts)만 캐싱하지만, activity의 3개 payload 빌더는 원본 이벤트 리스트가 필요하므로 **파싱된 event list 자체**를 캐싱한다.

- 캐시 hit(파일 크기 불변): 즉시 반환, I/O 없음.
- 캐시 확장(파일 성장): `Fs_compat.fold_appended_lines`로 appended bytes만 파싱해 누적.
- 캐시 미스/shrink/rotation(boundary > size): 기존 repair-aware `parse_events_from_file`로 전량 재파싱(희귀 경로).
- delta에 invalid UTF-8이 섞이면(신규 write는 `emit`이 이미 sanitize하므로 이론상 발생하지 않지만 방어적으로) 동일하게 전량 재파싱 fallback + 캐시 boundary 리셋.

이 캐시는 `read_all_events` 레벨에 있으므로 `dashboard_snapshot.ml`을 건드리지 않고도 3개 payload 빌더 호출 + 향후 non-default HTTP 쿼리(`server_activity_http.ml`)까지 자동으로 공유된다.

### 2. `past_day_cache` 무한 보존 버그 수리

`past_day_cache`(과거일 파싱 결과 캐시)는 엔트리를 제거하는 코드가 아예 없어서, 기존 24h `MASC_JSONL_RETENTION_DAYS`(기본 30일, `server_bootstrap_maintenance.ml:584,610`, 동일한 `activity-events` 디렉토리에 이미 적용 중) sweep이 오래된 day-file을 디스크에서 지워도 캐시 엔트리는 프로세스 수명 내내 살아남았다 — 진단 보고서 item ⑥의 실제 근거.

`read_all_events` 호출마다 `collect_event_files`로 얻은 현재 live 파일 목록과 두 캐시(과거일 + 당일)를 대조해, 더 이상 존재하지 않는 파일의 엔트리만 제거한다.

**의도적으로 별도의 "최근 N일만 유지" 캡을 넣지 않았다**: 그러려면 (a) `read_all_events`의 스캔 자체를 N일로 제한해야 하는데, 이는 일일 이벤트량이 적은 스토어에서 `total_matching_events`/`events_store_total` 출력값을 바꾸는 실제 동작 변경이거나, (b) `MASC_JSONL_RETENTION_DAYS`와 별개의 두 번째 보존 상수를 도입하는 것 — CLAUDE.md가 경고하는 "하드코딩 산포" 안티패턴이다. 기존 디스크 레벨 SSOT를 그대로 참조(= 지워진 파일만 정리)하는 쪽이 정합성 리스크 없이 목적을 달성한다.

## 출력 불변 증명

- `json_response`/`graph_json`/`agent_spans_json`의 JSON 필드·형태 변경 없음.
- 2s 케이던스(interval_sec) 변경 없음.
- 테스트 `test/test_activity_graph.ml` (`current_day_cache` 그룹, 4건 신규):
  - **golden 비교**: 캐시 warm 상태(증분 경로)로 얻은 `json_response` 출력과, 캐시를 리셋해 강제로 전량 재파싱(reference 경로)한 출력이 `generated_at_iso`를 제외하고 문자열 동일함을 확인.
  - **증분 동작 증명**: `For_testing.current_day_parsed_line_count()` 카운터로, 10줄 캐싱 후 5줄 추가 append 시 정확히 5줄만 파싱됨을 증명 (15줄 전체가 아님).
  - **rotation/truncation 폴백**: 캐시된 boundary보다 파일이 작아지면(재기록) byte 0부터 재스캔되어 새 내용만 정확히 반영됨을 확인.
  - **eviction 경계**: 과거일 파일을 만들어 캐싱시킨 뒤 디스크에서 삭제하면, 다음 read에서 해당 캐시 엔트리가 제거됨을 확인.
- 기존 `test_activity_graph.ml` 16개 테스트 전부 무파손 확인 (총 20/20 pass).
- `test/test_activity_graph.exe` 로컬 실행 결과: `Test Successful in 0.187s. 20 tests run.`

## 미검증 (CI 대기)

- CI의 `Build and Test` 전체 스위트는 아직 미확인. 알려진 base 이슈: #24723 착지 전까지 quick suite 2100s hang을 상속할 수 있음 — fail 시 "timed out after 2100s" 시그니처인지 판별해서 코멘트로 남길 예정.
- 라이브 프로파일(perf/cpu profile) 재측정은 이 PR 스코프 밖 — 별도 검증 필요.

## 후속 (스코프 밖, 별도 이슈로 남김)

- telemetry summary의 41개 store × day-file stat 1,460회/tick (진단 보고서 item ①의 telemetry 부분) — 이 PR은 activity 3종 payload만 다룬다.
- goal_events.jsonl 매 tick 전체 로드 — 별도.
- 완전한 이벤트 드리븐 관측 파이프라인(RFC-A, 진단 보고서 §3 "별도 RFC 후보") — 이 PR은 2s 폴링 케이던스를 유지한 채 캐싱만 도입한다.

## 참고

- 진단: `~/me/reports/masc-perf-rootcause-20260716.md` §①③⑥
- masc#24697
- 선례: `lib/telemetry_unified/telemetry_unified.ml:791-847` (`trajectory_summary_cache`), `lib/dated_jsonl/dated_jsonl.ml:537-598` (`file_count_cache`)
- RFC-0201 (activity events wait-free snapshot) §4.2 Phase B — 이 PR이 다루는 것과 같은 최적화를 이미 제안했었음 (당일 파일 증분화까지는 다루지 않았던 부분을 이번에 마저 닫음)

`scripts/pr-rfc-check.sh` 결과: 매치되는 RFC subsystem·workaround 시그니처 없음 (exit 0, 별도 출력 없음) — `lib/activity_graph/`, `test/`만 건드리며 credential/identity/repo_manager/operator/hooks/workflow subsystem을 건드리지 않는다.
