### PR TITLE
feat(fusion): persist worker claim handshake

### DIFF
--- a/lib/fusion/fusion_tool.ml
+++ b/lib/fusion/fusion_tool.ml
@@ -90,6 +90,25 @@ type orchestrator_runner =
   -> unit
   -> Fusion_orchestrator.outcome
 
+type execution_start_error =
+  | Claim_failed of Fusion_run_registry.claim_error
+  | Start_failed of Fusion_run_registry.start_error
+
+let execution_start_error_to_string = function
+  | Claim_failed error -> Fusion_run_registry.claim_error_to_string error
+  | Start_failed error -> Fusion_run_registry.start_error_to_string error
+;;
+
+let claim_and_start registry operation_id =
+  let ( let* ) = Result.bind in
+  let* claim =
+    Fusion_run_registry.claim_operation registry ~operation_id
+    |> Result.map_error (fun error -> Claim_failed error)
+  in
+  Fusion_run_registry.start_claimed registry claim
+  |> Result.map_error (fun error -> Start_failed error)
+;;
+
 let handle_with_runner_result ~run_orchestrator ~sw ~net ~base_dir ~keeper ~now_unix ~run_id
       ~policy ?continuation_channel ~args () : Tool_result.result =
   let tool_name = "masc_fusion" in
@@ -181,6 +200,19 @@ let handle_with_runner_result ~run_orchestrator ~sw ~net ~base_dir ~keeper ~now_
            ; ("error", `String reason)
            ]
        | Ok _ ->
+      (match claim_and_start (Fusion_run_registry.global ()) run_id with
+       | Error error ->
+         let reason = execution_start_error_to_string error in
+         record_completion ~keeper ~run_id ~failure:reason
+           ~failure_code:"worker_start_persistence_failed" ~ok:false ();
+         status_result ~tool_name ~class_:Tool_result.Runtime_failure ~ok:false
+           [ ("status", `String "persistence_failed")
+           ; ("run_id", `String run_id)
+           ; ("error", `String reason)
+           ]
+       | Ok operation ->
+      let allowed = operation.Fusion_types.request in
+      let topology = operation.topology in
       (* RFC-0266 §7 Phase 4: push the new [Running] card to the dashboard panel
          (no polling). wake-free, broadcast-failure-safe; see
          Fusion_sink.broadcast_run_status. *)
@@ -202,31 +234,8 @@ let handle_with_runner_result ~run_orchestrator ~sw ~net ~base_dir ~keeper ~now_
           append_chat_failure ~base_dir ~keeper ~run_id ~failure_code:"sink_failed"
             (Printf.sprintf "**Fusion run `%s`** _(sink failed: %s)_" run_id msg)
         | exception (Eio.Cancel.Cancelled _ as exn) ->
-          (* RFC-0266 §7: 취소도 종료 상태다. register_running(위 line 73)으로 [Running]
-             으로 등록된 run을 [Completed{ok=false}]로 갱신하지 않으면, in-memory registry
-             ([global], 서버 수명)에 영구 "running"으로 남아 dashboard fusion-runs 패널과
-             masc_fusion_status가 거짓 "심의중"을 보인다(prune는 [Running]을 evict하지 않음 —
-             fusion_run_registry.ml). 다른 종료 분기(Denied/Sink_failed/exception)는
-             append_chat_failure 경유로 이미 mark_completed 하는데 이 분기만 빠져 있었다.
-             completion receipt 실패도 registry에 typed state로 남는다. broadcast는
-             [Sse.broadcast]가 mailbox에서 suspend/block할 수 있어
-             취소/셧다운 캐스케이드를 deadlock시킬 위험이 있으므로 이 경로에선 생략한다 —
-             registry가 정확해 다음 HTTP fetch / tab-refresh가 패널을 self-heal한다.
-             그 뒤 구조적 취소는 흡수하지 않고 재전파한다 (Eio 규약). *)
-          let cancellation =
-            "cancelled: structural cancellation (shutdown or sibling switch failure)"
-          in
-          record_completion ~keeper ~run_id ~failure:cancellation
-            ~failure_code:"cancelled" ~ok:false ();
-          (match
-             Fusion_wake_route.queue_completion ~operation_id:run_id ~ok:false
-               ~content:cancellation ~evidence_ref:None
-           with
-           | Ok _ -> ()
-           | Error error ->
-             Log.Keeper.error ~keeper_name:keeper
-               "fusion cancellation completion queue failed run_id=%s: %s" run_id
-               (Fusion_wake_route.error_to_string error));
+          (* Root-switch cancellation is not a terminal Fusion outcome. The
+             durable Started claim remains replayable by the next process. *)
           raise exn
         | exception exn ->
           append_chat_failure ~base_dir ~keeper ~run_id ~failure_code:"aborted"
@@ -247,7 +256,7 @@ let handle_with_runner_result ~run_orchestrator ~sw ~net ~base_dir ~keeper ~now_
               "async: you will be woken with the result when deliberation \
                completes; the conclusion (or failure reason) also lands on \
                your chat lane. No need to poll masc_fusion_status." )
-        ]))
+        ])))
 
 let handle_result ~sw ~net ~base_dir ~keeper ~now_unix ~run_id ~policy
       ?continuation_channel ~args () =

--- a/lib/fusion_core/dune
+++ b/lib/fusion_core/dune
@@ -10,6 +10,6 @@
  (name masc_fusion_core)
  (public_name masc.fusion_core)
  (wrapped false)
- (libraries fs_compat masc_log yojson otoml threads)
+ (libraries fs_compat masc_log yojson otoml threads uuidm)
  (preprocess
   (pps ppx_deriving_yojson ppx_deriving.show ppx_deriving.eq)))

--- a/lib/fusion_core/fusion_run_registry.ml
+++ b/lib/fusion_core/fusion_run_registry.ml
@@ -17,11 +17,14 @@
 
 type recovery_reason = Worker_process_restarted
 
+module Claim_id = Fusion_run_registry_event.Claim_id
+
 type persistence_error =
   | Append_failed of
       { path : string
       ; detail : string
       }
+  | Operation_already_registered of string
 
 type completion_receipt =
   | Durable
@@ -44,15 +47,22 @@ type run_status =
       receipt : completion_receipt;
     }
 
+type worker_state =
+  | Registered
+  | Claimed of Claim_id.t
+  | Started of Claim_id.t
+
 type run = {
   operation : Fusion_types.fusion_operation;
   started_at : float;  (* unix seconds from the keeper clock at fork start *)
+  worker_state : worker_state;
   status : run_status;
 }
 
 type t = {
   runs : run list Atomic.t;
   path : string option;
+  lock : Mutex.t;
 }
 
 (* Recent-history retention for [Completed] runs. Active and recovery-required
@@ -60,7 +70,7 @@ type t = {
    execution or invocation rate. *)
 let max_completed_retained = 64
 
-let create ?path () : t = { runs = Atomic.make []; path }
+let create ?path () : t = { runs = Atomic.make []; path; lock = Mutex.create () }
 
 let is_unresolved (r : run) =
   match r.status with
@@ -90,6 +100,8 @@ let rec update (t : t) (f : run list -> run list) =
 let persistence_error_to_string = function
   | Append_failed { path; detail } ->
     Printf.sprintf "fusion registry append failed for %s: %s" path detail
+  | Operation_already_registered operation_id ->
+    Printf.sprintf "fusion operation %s is already registered" operation_id
 ;;
 
 let completion_error_to_string = function
@@ -119,25 +131,19 @@ let append_event t event =
 
 let register_running t ~operation ~started_at =
   let id = Fusion_types.fusion_operation_id operation in
-  match
-    append_event
-      t
-      (Fusion_run_registry_event.Register { operation; started_at })
-  with
-  | Error _ as error -> error
-  | Ok () ->
-    update t (fun runs ->
-      let run = { operation; started_at; status = Running } in
-      (* defensive: a re-registered operation id replaces its prior entry *)
-      let without_dup =
-        List.filter
-          (fun run ->
-             not
-               (String.equal (run_operation_id run) id))
-          runs
-      in
-      prune (run :: without_dup));
-    Ok ()
+  Mutex.protect t.lock (fun () ->
+    if List.exists (fun run -> String.equal (run_operation_id run) id) (Atomic.get t.runs)
+    then Error (Operation_already_registered id)
+    else
+      (match
+         append_event t
+           (Fusion_run_registry_event.Register { operation; started_at })
+       with
+       | Error _ as error -> error
+       | Ok () ->
+         update t (fun runs ->
+           prune ({ operation; started_at; worker_state = Registered; status = Running } :: runs));
+         Ok ()))
 ;;
 
 let list_runs (t : t) : run list =
@@ -150,8 +156,92 @@ let get (t : t) ~operation_id:expected : run option =
     (Atomic.get t.runs)
 ;;
 
+type claim =
+  { operation_id : string
+  ; claim_id : Claim_id.t
+  }
+
+type claim_error =
+  | Claim_unknown_operation of string
+  | Claim_terminal_operation of string
+  | Claim_already_owned of Claim_id.t
+  | Claim_persistence_failed of persistence_error
+
+type start_error =
+  | Start_unknown_operation of string
+  | Start_terminal_operation of string
+  | Start_not_claimed of string
+  | Start_claim_mismatch of string
+  | Start_already_started of Claim_id.t
+  | Start_persistence_failed of persistence_error
+
+let claim_error_to_string = function
+  | Claim_unknown_operation id -> Printf.sprintf "unknown fusion operation %s" id
+  | Claim_terminal_operation id -> Printf.sprintf "fusion operation %s is terminal" id
+  | Claim_already_owned id ->
+    Printf.sprintf "fusion operation is already claimed by %s" (Claim_id.to_string id)
+  | Claim_persistence_failed error -> persistence_error_to_string error
+;;
+
+let start_error_to_string = function
+  | Start_unknown_operation id -> Printf.sprintf "unknown fusion operation %s" id
+  | Start_terminal_operation id -> Printf.sprintf "fusion operation %s is terminal" id
+  | Start_not_claimed id -> Printf.sprintf "fusion operation %s is not claimed" id
+  | Start_claim_mismatch id -> Printf.sprintf "fusion operation %s claim is stale" id
+  | Start_already_started claim_id ->
+    Printf.sprintf "fusion claim %s already started" (Claim_id.to_string claim_id)
+  | Start_persistence_failed error -> persistence_error_to_string error
+;;
+
+let claim_operation t ~operation_id =
+  Mutex.protect t.lock (fun () ->
+    match get t ~operation_id with
+    | None -> Error (Claim_unknown_operation operation_id)
+    | Some { status = Completed _; _ } -> Error (Claim_terminal_operation operation_id)
+    | Some { status = Running; worker_state = (Claimed id | Started id); _ } ->
+      Error (Claim_already_owned id)
+    | Some ({ status = Running; worker_state = Registered; _ } | { status = Recovery_required _; _ }) ->
+      let claim_id = Claim_id.create () in
+      (match
+         append_event t (Fusion_run_registry_event.Claim { operation_id; claim_id })
+       with
+       | Error error -> Error (Claim_persistence_failed error)
+       | Ok () ->
+         update t (List.map (fun run ->
+           if String.equal (run_operation_id run) operation_id
+           then { run with worker_state = Claimed claim_id; status = Running }
+           else run));
+         Ok { operation_id; claim_id }))
+;;
+
+let start_claimed t claim =
+  Mutex.protect t.lock (fun () ->
+    match get t ~operation_id:claim.operation_id with
+    | None -> Error (Start_unknown_operation claim.operation_id)
+    | Some { status = Completed _; _ } -> Error (Start_terminal_operation claim.operation_id)
+    | Some { worker_state = Registered; _ } -> Error (Start_not_claimed claim.operation_id)
+    | Some { worker_state = Started current; _ } when Claim_id.equal current claim.claim_id ->
+      Error (Start_already_started current)
+    | Some { worker_state = (Claimed current | Started current); _ }
+      when not (Claim_id.equal current claim.claim_id) ->
+      Error (Start_claim_mismatch claim.operation_id)
+    | Some run ->
+      (match
+         append_event t
+           (Fusion_run_registry_event.Start
+              { operation_id = claim.operation_id; claim_id = claim.claim_id })
+       with
+       | Error error -> Error (Start_persistence_failed error)
+       | Ok () ->
+         update t (List.map (fun current ->
+           if String.equal (run_operation_id current) claim.operation_id
+           then { current with worker_state = Started claim.claim_id; status = Running }
+           else current));
+         Ok run.operation))
+;;
+
 let mark_completed (t : t) ~operation_id ?failure ?failure_code ~ok () =
-  match get t ~operation_id with
+  Mutex.protect t.lock (fun () -> match get t ~operation_id with
   | None -> Error (Unknown_run operation_id)
   | Some _ ->
     let persisted =
@@ -172,7 +262,7 @@ let mark_completed (t : t) ~operation_id ?failure ?failure_code ~ok () =
       |> prune);
     (match persisted with
      | Ok () -> Ok ()
-     | Error error -> Error (Completion_persistence_failed error))
+     | Error error -> Error (Completion_persistence_failed error)))
 ;;
 
 (* Stable status vocabulary shared by every fusion-run surface (Phase 3 keeper
@@ -201,6 +291,14 @@ let run_to_yojson (r : run) : Yojson.Safe.t =
     ; ("status", `String (status_label r.status))
     ]
   in
+  let worker_fields =
+    match r.worker_state with
+    | Registered -> [ "worker_state", `String "registered" ]
+    | Claimed claim_id ->
+      [ ("worker_state", `String "claimed"); ("claim_id", `String (Claim_id.to_string claim_id)) ]
+    | Started claim_id ->
+      [ ("worker_state", `String "started"); ("claim_id", `String (Claim_id.to_string claim_id)) ]
+  in
   (* 실패 사유는 additive 필드로만 싣는다 — 기존 소비자(tool/HTTP/SSE/프론트)의
      필드 집합은 그대로 유지된다. *)
   let failure_fields =
@@ -224,20 +322,30 @@ let run_to_yojson (r : run) : Yojson.Safe.t =
       ; ("receipt_error", `String (persistence_error_to_string error))
       ]
   in
-  `Assoc (base @ failure_fields @ receipt_fields)
+  `Assoc (base @ worker_fields @ failure_fields @ receipt_fields)
 ;;
 
 (* Replay helpers — used to hydrate the in-memory table from disk at boot. *)
 let apply_event runs = function
   | Fusion_run_registry_event.Register { operation; started_at } ->
     let id = Fusion_types.fusion_operation_id operation in
-    let run = { operation; started_at; status = Running } in
+    let run = { operation; started_at; worker_state = Registered; status = Running } in
     let without_dup =
       List.filter
         (fun run -> not (String.equal (run_operation_id run) id))
         runs
     in
     run :: without_dup
+  | Fusion_run_registry_event.Claim { operation_id; claim_id } ->
+    List.map (fun run ->
+      if String.equal (run_operation_id run) operation_id
+      then { run with worker_state = Claimed claim_id }
+      else run) runs
+  | Fusion_run_registry_event.Start { operation_id; claim_id } ->
+    List.map (fun run ->
+      if String.equal (run_operation_id run) operation_id
+      then { run with worker_state = Started claim_id }
+      else run) runs
   | Fusion_run_registry_event.Complete { operation_id = completed_id; ok; failure; failure_code } ->
     List.map
       (fun r ->
@@ -301,12 +409,26 @@ let events_of_run (run : run) =
       ; started_at = run.started_at
       }
   in
+  let worker_events =
+    match run.worker_state with
+    | Registered -> []
+    | Claimed claim_id ->
+      [ Fusion_run_registry_event.Claim
+          { operation_id = run_operation_id run; claim_id }
+      ]
+    | Started claim_id ->
+      [ Fusion_run_registry_event.Claim
+          { operation_id = run_operation_id run; claim_id }
+      ; Fusion_run_registry_event.Start
+          { operation_id = run_operation_id run; claim_id }
+      ]
+  in
   match run.status with
-  | Running | Recovery_required _ -> [ register ]
-  | Completed { receipt = Persistence_failed _; _ } -> [ register ]
+  | Running | Recovery_required _ -> register :: worker_events
+  | Completed { receipt = Persistence_failed _; _ } -> register :: worker_events
   | Completed { ok; failure; failure_code; receipt = Durable } ->
-    [ register
-    ; Fusion_run_registry_event.Complete
+    register :: worker_events
+    @ [ Fusion_run_registry_event.Complete
         { operation_id = run_operation_id run; ok; failure; failure_code }
     ]
 ;;
@@ -324,7 +446,7 @@ let compact_replay_log path runs =
   in
   try
     match Fs_compat.save_file_atomic path content with
-    | Ok () -> ()
+    | Ok () -> Fs_compat.invalidate_cached_writer path
     | Error msg ->
       Log.Misc.warn "fusion_run_registry: replay compaction failed for %s: %s" path msg
   with
@@ -391,7 +513,7 @@ let replay path : t =
     |> prune
   in
   if should_compact then compact_replay_log path runs;
-  { runs = Atomic.make runs; path = Some path }
+  { runs = Atomic.make runs; path = Some path; lock = Mutex.create () }
 ;;
 
 (* Process-wide registry the fusion tool/sink write to (server-lifetime). Tests

--- a/lib/fusion_core/fusion_run_registry.mli
+++ b/lib/fusion_core/fusion_run_registry.mli
@@ -11,11 +11,14 @@
 
 type recovery_reason = Worker_process_restarted
 
+module Claim_id = Fusion_run_registry_event.Claim_id
+
 type persistence_error =
   | Append_failed of
       { path : string
       ; detail : string
       }
+  | Operation_already_registered of string
 
 val persistence_error_to_string : persistence_error -> string
 
@@ -45,9 +48,15 @@ type run_status =
       receipt : completion_receipt;
     }
 
+type worker_state =
+  | Registered
+  | Claimed of Claim_id.t
+  | Started of Claim_id.t
+
 type run = {
   operation : Fusion_types.fusion_operation;
   started_at : float;  (** unix seconds from the keeper clock at fork start *)
+  worker_state : worker_state;
   status : run_status;
 }
 
@@ -79,6 +88,31 @@ val register_running :
     When the registry was created with a path, the durable [Register] event is
     committed before publishing in-memory state. An append failure returns
     [Error] and the run is not registered. *)
+
+type claim
+
+type claim_error =
+  | Claim_unknown_operation of string
+  | Claim_terminal_operation of string
+  | Claim_already_owned of Claim_id.t
+  | Claim_persistence_failed of persistence_error
+
+type start_error =
+  | Start_unknown_operation of string
+  | Start_terminal_operation of string
+  | Start_not_claimed of string
+  | Start_claim_mismatch of string
+  | Start_already_started of Claim_id.t
+  | Start_persistence_failed of persistence_error
+
+val claim_error_to_string : claim_error -> string
+val start_error_to_string : start_error -> string
+val claim_operation : t -> operation_id:string -> (claim, claim_error) result
+val start_claimed : t -> claim -> (Fusion_types.fusion_operation, start_error) result
+(** The durable execution handshake. [claim_operation] appends exact ownership
+    before exposing an opaque affine claim; [start_claimed] appends start before
+    returning the canonical operation. A live claim cannot be superseded.
+    Replayed unfinished work is explicitly reclaimable without a timeout. *)
 
 val mark_completed
   :  t

--- a/lib/fusion_core/fusion_run_registry_event.ml
+++ b/lib/fusion_core/fusion_run_registry_event.ml
@@ -1,12 +1,32 @@
 (* JSONL event type for fusion run registry persistence (RFC-0266 §7 Phase D).
-   Each [register_running] / [mark_completed] appends one line so run history
+   Each lifecycle transition appends one line so run history
    survives server restart. [Register] contains the complete canonical operation;
    replay never reconstructs an execution request from metadata or defaults. *)
+
+module Claim_id = struct
+  type t = Claim_id of string [@@deriving yojson, show, eq]
+
+  let create () =
+    (* NDT-OK: entropy is identity only; decisions never inspect its contents. *)
+    Claim_id
+      (Uuidm.v4_gen (Random.State.make_self_init ()) () |> Uuidm.to_string)
+  ;;
+
+  let to_string (Claim_id value) = value
+end
 
 type t =
   | Register of
       { operation : Fusion_types.fusion_operation
       ; started_at : float
+      }
+  | Claim of
+      { operation_id : string
+      ; claim_id : Claim_id.t
+      }
+  | Start of
+      { operation_id : string
+      ; claim_id : Claim_id.t
       }
   | Complete of
       { operation_id : string
@@ -21,6 +41,18 @@ let to_yojson = function
       [ ("event", `String "register")
       ; ("operation", Fusion_types.fusion_operation_to_yojson operation)
       ; ("started_at", `Float started_at)
+      ]
+  | Claim { operation_id; claim_id } ->
+    `Assoc
+      [ ("event", `String "claim")
+      ; ("operation_id", `String operation_id)
+      ; ("claim_id", Claim_id.to_yojson claim_id)
+      ]
+  | Start { operation_id; claim_id } ->
+    `Assoc
+      [ ("event", `String "start")
+      ; ("operation_id", `String operation_id)
+      ; ("claim_id", Claim_id.to_yojson claim_id)
       ]
   | Complete { operation_id; ok; failure; failure_code } ->
     `Assoc
@@ -86,6 +118,12 @@ let operation_field fields =
   Fusion_types.fusion_operation_of_yojson json
 ;;
 
+let claim_id_field fields =
+  let ( let* ) = Result.bind in
+  let* json = field "claim_id" fields in
+  Claim_id.of_yojson json
+;;
+
 let of_yojson json =
   let ( let* ) = Result.bind in
   let* fields = object_fields json in
@@ -95,6 +133,14 @@ let of_yojson json =
     let* operation = operation_field fields in
     let* started_at = float_field "started_at" fields in
     Ok (Register { operation; started_at })
+  | "claim" ->
+    let* operation_id = string_field "operation_id" fields in
+    let* claim_id = claim_id_field fields in
+    Ok (Claim { operation_id; claim_id })
+  | "start" ->
+    let* operation_id = string_field "operation_id" fields in
+    let* claim_id = claim_id_field fields in
+    Ok (Start { operation_id; claim_id })
   | "complete" ->
     let* operation_id = string_field "operation_id" fields in
     let* ok = bool_field "ok" fields in

--- a/lib/fusion_core/fusion_run_registry_event.mli
+++ b/lib/fusion_core/fusion_run_registry_event.mli
@@ -4,10 +4,25 @@
     event line to disk. On server boot the log is replayed to restore recent
     run history. *)
 
+module Claim_id : sig
+  type t [@@deriving yojson, show, eq]
+
+  val create : unit -> t
+  val to_string : t -> string
+end
+
 type t =
   | Register of
       { operation : Fusion_types.fusion_operation
       ; started_at : float
+      }
+  | Claim of
+      { operation_id : string
+      ; claim_id : Claim_id.t
+      }
+  | Start of
+      { operation_id : string
+      ; claim_id : Claim_id.t
       }
   | Complete of
       { operation_id : string

--- a/test/fusion_core/test_fusion_run_registry.ml
+++ b/test/fusion_core/test_fusion_run_registry.ml
@@ -93,7 +93,56 @@ let test_register_persistence_failure_is_not_published () =
        | Error (R.Append_failed { path = failed_path; _ }) ->
          check string "failed path" path failed_path;
          check bool "failed durable register is not published" true
-           (Option.is_none (R.get t ~run_id:"r-no-receipt")))
+           (Option.is_none (R.get t ~run_id:"r-no-receipt"))
+       | Error (R.Operation_already_registered id) -> fail ("unexpected duplicate " ^ id))
+;;
+
+let test_claim_start_replay_is_affine () =
+  let path = Filename.temp_file "fusion-claim-start" ".jsonl" in
+  Fun.protect
+    ~finally:(fun () -> try Sys.remove path with Sys_error _ -> ())
+    (fun () ->
+       let t = R.create ~path () in
+       let operation = R.operation ~run_id:"r-claim" ~keeper:"k" ~preset:"deep" in
+       (match Registry.register_running t ~operation ~started_at:1.0 with
+        | Ok () -> ()
+        | Error error -> fail (R.persistence_error_to_string error));
+       let claim =
+         match R.claim_operation t ~operation_id:"r-claim" with
+         | Ok claim -> claim
+         | Error error -> fail (R.claim_error_to_string error)
+       in
+       (match R.start_claimed t claim with
+        | Ok started ->
+          check bool "start returns exact canonical operation" true
+            (Fusion_types.equal_fusion_operation operation started)
+        | Error error -> fail (R.start_error_to_string error));
+       (match R.claim_operation t ~operation_id:"r-claim" with
+        | Error (R.Claim_already_owned _) -> ()
+        | Error error -> fail (R.claim_error_to_string error)
+        | Ok _ -> fail "a live claim cannot be superseded");
+       (match R.start_claimed t claim with
+        | Error (R.Start_already_started _) -> ()
+        | Error error -> fail (R.start_error_to_string error)
+        | Ok _ -> fail "one durable claim cannot start twice");
+       let recovered = R.replay path in
+       (match R.get recovered ~run_id:"r-claim" with
+        | Some { status = R.Recovery_required _; worker_state = R.Started _; _ } -> ()
+        | Some _ -> fail "started work must replay as owned recovery"
+        | None -> fail "recovery must retain the canonical operation");
+       let recovery_claim =
+         match R.claim_operation recovered ~operation_id:"r-claim" with
+         | Ok claim -> claim
+         | Error error -> fail (R.claim_error_to_string error)
+       in
+       (match R.start_claimed recovered recovery_claim with
+        | Ok _ -> ()
+        | Error error -> fail (R.start_error_to_string error));
+       R.mark_completed recovered ~run_id:"r-claim" ~ok:true ();
+       match R.get (R.replay path) ~run_id:"r-claim" with
+       | Some { status = R.Completed { ok = true; _ }; _ } -> ()
+       | Some _ -> fail "terminal completion must replay without recovery"
+       | None -> fail "terminal operation must remain observable")
 ;;
 
 let test_mark_completed () =
@@ -210,6 +259,7 @@ let test_status_label () =
           { ok = false
           ; failure = Some "judge failed"
           ; failure_code = Some "parse_error"
+          ; receipt = R.Durable
           }))
 ;;
 
@@ -285,6 +335,8 @@ let () =
         ; test_case "mark completed (ok true/false)" `Quick test_mark_completed
         ; test_case "durable register failure is not published" `Quick
             test_register_persistence_failure_is_not_published
+        ; test_case "claim/start is affine across recovery and terminal replay" `Quick
+            test_claim_start_replay_is_affine
         ; test_case
             "finalize before suspend keeps Completed (buggy order leaks Running)"
             `Quick


### PR DESCRIPTION
## Outcome

- Adds a durable Register -> Claim -> Start -> Complete lifecycle for canonical Fusion operations.
- Persists typed claim ownership before exposing an affine claim and persists Start before returning the exact canonical operation to the worker launcher.
- Rejects duplicate registration, live-claim supersession, stale claim start, and repeated start with typed errors.
- Allows a new claim only after replay has explicitly classified unfinished work as Recovery_required. There is no lease duration, timeout, retry count, or numeric ownership heuristic.
- Keeps structural root-switch cancellation nonterminal so the persisted Started claim remains recoverable after process restart.
- Wires new Fusion tool invocations to fork only the operation returned by the durable claim/start handshake.
- Invalidates the append writer after replay compaction, preventing later terminal events from being written to the atomically replaced old inode.

## Exact replay proof

- The focused test uses the real append-only JSONL path.
- A live claim cannot be superseded.
- One claim cannot start twice.
- A Started operation replays as Recovery_required with its ownership evidence.
- Reclaim after process replay returns the original immutable operation.
- A durable terminal completion replays as Completed and is not recovery work.

## Boundary and next stack

- No Keeper, connector, Gate, scheduler, lease, budget, or timeout policy was added to Fusion core.
- C19a supplies the durable SSOT and new-invocation handshake. C19b will wire boot recovery to reclaim and launch Recovery_required operations through this API.

## Verification

- Diff: 7 files, 337 insertions, 59 deletions, 396 total changed lines.
- Actual Fusion types, event, registry interface and implementation compilation passed.
- Standalone focused executable: 12/12 tests passed, including affine claim/start, restart recovery, and terminal replay.
- ocamlformat, parse checks, and git diff --check passed.
- Focused official Dune wrapper was attempted but another worktree held the shared Dune lock. No lock bypass and no fake green.

Stack base: #24736
