### PR TITLE
refactor(keeper): hard-delete librarian provider slot

### DIFF
--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -14,9 +14,9 @@ the categorization roadmap. Newly-added typed getters in
 `lib/config/env_config_*.ml` must carry nearby `@category` and
 `@ops_class` tags; existing knobs remain in the backfill lane.
 
-**Total**: 273 unique knobs across 9 modules.
+**Total**: 272 unique knobs across 9 modules.
 
-**Typed getter classification**: 38/156 tagged (`operator`: 38, `algorithm`: 0, `unclassified`: 118).
+**Typed getter classification**: 37/155 tagged (`operator`: 37, `algorithm`: 0, `unclassified`: 118).
 
 ## Env_config_core (25 knobs; typed classification 2/6)
 
@@ -48,63 +48,62 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_TEST_ALLOW_HOME_BASE_PATH` | string_literal | n/a | n/a | 431 | #9903: production base-path safeguard for test executables. Without this, a test whose [MASC_BASE_PATH] override fail... |
 | `MASC_URL` | string_literal | n/a | n/a | 290 | SSOT for the MASC_HTTP_BASE_URL env-var name (issue 8352). Defined here (above [masc_http_base_url]) so the constant ... |
 
-## Env_config_keeper (53 knobs; typed classification 26/47)
+## Env_config_keeper (52 knobs; typed classification 25/46)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_CONTEXT_RATIO_HARD_CAP` | typed:float | unclassified | unclassified | 656 | {1 Context Ratio Hard Cap} Absolute ceiling for compaction ratio_gate and handoff threshold after multiplier adjustme... |
-| `MASC_DASHBOARD_HEALTH_CTX_CRITICAL` | typed:float | unclassified | unclassified | 665 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_HEALTH_CTX_WARN` | typed:float | unclassified | unclassified | 666 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_HEALTH_PENALTY_CRITICAL` | typed:float | unclassified | unclassified | 667 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_HEALTH_PENALTY_WARN` | typed:float | unclassified | unclassified | 668 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 671 |  |
-| `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 596 | Total HTTP body-consumption deadline for non-streaming OAS completion calls. In agent_sdk this wraps [Complete.comple... |
+| `MASC_CONTEXT_RATIO_HARD_CAP` | typed:float | unclassified | unclassified | 642 | {1 Context Ratio Hard Cap} Absolute ceiling for compaction ratio_gate and handoff threshold after multiplier adjustme... |
+| `MASC_DASHBOARD_HEALTH_CTX_CRITICAL` | typed:float | unclassified | unclassified | 651 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_HEALTH_CTX_WARN` | typed:float | unclassified | unclassified | 652 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_HEALTH_PENALTY_CRITICAL` | typed:float | unclassified | unclassified | 653 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_HEALTH_PENALTY_WARN` | typed:float | unclassified | unclassified | 654 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 657 |  |
+| `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 582 | Total HTTP body-consumption deadline for non-streaming OAS completion calls. In agent_sdk this wraps [Complete.comple... |
 | `MASC_KEEPER_BOOTSTRAP_ENABLED` | feature_flag | n/a | n/a | 20 | Enable startup keeper bootstrap scan |
 | `MASC_KEEPER_BOOTSTRAP_LAZY_STARTUP_POLL_INTERVAL_SEC` | typed:float | unclassified | unclassified | 41 | Polling interval (seconds) for the lazy-startup wait loop in [server_bootstrap_loops.ml]. The autoboot fiber wakes up... |
 | `MASC_KEEPER_BOOTSTRAP_LISTENER_RETRY_INTERVAL_SEC` | typed:float | unclassified | unclassified | 53 | Polling interval (seconds) for the keeper-lifecycle listener retry loop in [server_bootstrap_loops.ml]. After a liste... |
 | `MASC_KEEPER_BOOTSTRAP_MAX_SCAN` | typed:int | unclassified | unclassified | 28 | Max keeper meta files to scan during bootstrap |
 | `MASC_KEEPER_BOOTSTRAP_POST_STARTUP_SETTLE_SEC` | typed:float | unclassified | unclassified | 65 | Settle delay (seconds) between lazy-startup completion and the keeper bootstrap fan-out. The autoboot fiber sleeps fo... |
 | `MASC_KEEPER_BOOTSTRAP_STALE_TURN_SEC` | typed:float | unclassified | unclassified | 24 | Keeper considered stale when last turn exceeds this threshold (seconds) |
-| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 616 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI providers need an OAS upstream chan... |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_DEFAULT_LIMIT` | typed:int | Runtime | operator | 350 | Default item limit for [GET /keepers/:name/compaction-snapshots]. Default: 25. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_LIMIT_MULTIPLIER` | typed:int | Runtime | operator | 376 | Multiplier from requested item limit to manifest files scanned. Default: 4. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_MIN_FILES` | typed:int | Runtime | operator | 366 | Minimum manifest files scanned before applying [limit * multiplier]. Default: 8. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_TAIL_MAX_LINES` | typed:int | Runtime | operator | 386 | Tail line count read from each selected manifest file. Default: 200. @category Runtime @ops_class operator |
-| `MASC_KEEPER_COMPACTION_SNAPSHOT_MAX_LIMIT` | typed:int | Runtime | operator | 356 | Maximum accepted item limit for the compaction snapshot endpoint. Default: 100. @category Runtime @ops_class operator |
+| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 602 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI providers need an OAS upstream chan... |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_DEFAULT_LIMIT` | typed:int | Runtime | operator | 336 | Default item limit for [GET /keepers/:name/compaction-snapshots]. Default: 25. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_LIMIT_MULTIPLIER` | typed:int | Runtime | operator | 362 | Multiplier from requested item limit to manifest files scanned. Default: 4. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_MIN_FILES` | typed:int | Runtime | operator | 352 | Minimum manifest files scanned before applying [limit * multiplier]. Default: 8. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_TAIL_MAX_LINES` | typed:int | Runtime | operator | 372 | Tail line count read from each selected manifest file. Default: 200. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MAX_LIMIT` | typed:int | Runtime | operator | 342 | Maximum accepted item limit for the compaction snapshot endpoint. Default: 100. @category Runtime @ops_class operator |
 | `MASC_KEEPER_CRASH_PERSIST_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 143 | Crash persistence drain fiber wake interval in seconds. Drain fiber batches in-memory crash events and persists them ... |
 | `MASC_KEEPER_DEBUG` | feature_flag | n/a | n/a | 151 | Enable keeper debug logging. Default: false. |
-| `MASC_KEEPER_DURABLE_QUEUE_STALE_SEC` | typed:float | Telemetry | operator | 524 | Durable event-queue backlog age threshold for fleet health degradation. The durable queue remains fully reported rega... |
-| `MASC_KEEPER_GENERATED_MEDIA_DIR_MAX_BYTES` | typed:int | Policies | operator | 473 | Maximum total bytes retained in [<masc_dir>/media] after opportunistic cleanup. Default is 500 MiB. Range: [1, 5 GiB]... |
-| `MASC_KEEPER_GENERATED_MEDIA_MAX_BYTES` | typed:int | Policies | operator | 462 | Maximum raw generated-media bytes accepted by the durable store and serve route. Default is 10 MiB. Range: [1, 50 MiB... |
-| `MASC_KEEPER_GENERATED_MEDIA_RETENTION_SEC` | typed:float | Policies | operator | 484 | Maximum generated-media file age retained by opportunistic cleanup. Default is 24 hours. Range: [1 second, 30 days]. ... |
-| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 629 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
-| `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | unclassified | unclassified | 491 | Shared: keepalive interval, read early so WorkAsHeartbeat can reference it. |
-| `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | unclassified | unclassified | 506 | Maximum seconds since last successful workspace heartbeat before presence sync is required again. Floor = keepalive i... |
-| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION` | typed:bool | Policies | operator | 324 | Per-keeper Memory OS consolidation maintenance fiber kill switch. Default: false; invalid values fail closed to false... |
-| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION_RUNTIME_ID` | typed:string | Runtime | operator | 334 | Optional runtime id override for Memory OS consolidation. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_GC` | typed:bool | Storage | operator | 313 | Per-keeper Memory OS GC maintenance fiber kill switch. Default: true; invalid values fail closed to false. Env var ac... |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN` | typed:bool | Policies | operator | 233 | Memory OS librarian post-turn extraction kill switch. Default: true; invalid values fail closed to false so malformed... |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS` | typed:int | Runtime | operator | 245 | Turns between librarian extraction attempts per keeper. Default: 3, floored to 1. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT` | typed:int | Concurrency | operator | 301 | Fleet-wide concurrency gate for librarian provider calls. Default: 1; 0 disables the gate. @category Concurrency @ops... |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES` | typed:int | Runtime | operator | 257 | Base recent-message window for librarian extraction. Default: 24, floored to 1. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_TOKENS` | typed:int | Runtime | operator | 279 | Output token cap for librarian extraction, applied as min with the provider max_tokens. Default: 4096, floored to 1. ... |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID` | typed:string | Runtime | operator | 289 | Optional runtime id override for librarian extraction. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_TIMEOUT_SEC` | typed:float | Timeouts | operator | 267 | Provider timeout for librarian extraction. Default: 600 seconds; invalid, non-positive, NaN, or infinite values fall ... |
-| `MASC_KEEPER_MEMORY_OS_RECALL` | typed:bool | Policies | operator | 221 | Memory OS recall prompt injection kill switch. Default: true; invalid values fail closed to false so malformed operat... |
+| `MASC_KEEPER_DURABLE_QUEUE_STALE_SEC` | typed:float | Telemetry | operator | 510 | Durable event-queue backlog age threshold for fleet health degradation. The durable queue remains fully reported rega... |
+| `MASC_KEEPER_GENERATED_MEDIA_DIR_MAX_BYTES` | typed:int | Policies | operator | 459 | Maximum total bytes retained in [<masc_dir>/media] after opportunistic cleanup. Default is 500 MiB. Range: [1, 5 GiB]... |
+| `MASC_KEEPER_GENERATED_MEDIA_MAX_BYTES` | typed:int | Policies | operator | 448 | Maximum raw generated-media bytes accepted by the durable store and serve route. Default is 10 MiB. Range: [1, 50 MiB... |
+| `MASC_KEEPER_GENERATED_MEDIA_RETENTION_SEC` | typed:float | Policies | operator | 470 | Maximum generated-media file age retained by opportunistic cleanup. Default is 24 hours. Range: [1 second, 30 days]. ... |
+| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 615 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
+| `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | unclassified | unclassified | 477 | Shared: keepalive interval, read early so WorkAsHeartbeat can reference it. |
+| `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | unclassified | unclassified | 492 | Maximum seconds since last successful workspace heartbeat before presence sync is required again. Floor = keepalive i... |
+| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION` | typed:bool | Policies | operator | 310 | Per-keeper Memory OS consolidation maintenance fiber kill switch. Default: false; invalid values fail closed to false... |
+| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION_RUNTIME_ID` | typed:string | Runtime | operator | 320 | Optional runtime id override for Memory OS consolidation. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_GC` | typed:bool | Storage | operator | 299 | Per-keeper Memory OS GC maintenance fiber kill switch. Default: true; invalid values fail closed to false. Env var ac... |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN` | typed:bool | Policies | operator | 231 | Memory OS librarian post-turn extraction kill switch. Default: true; invalid values fail closed to false so malformed... |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS` | typed:int | Runtime | operator | 243 | Turns between librarian extraction attempts per keeper. Default: 3, floored to 1. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES` | typed:int | Runtime | operator | 255 | Base recent-message window for librarian extraction. Default: 24, floored to 1. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_TOKENS` | typed:int | Runtime | operator | 277 | Output token cap for librarian extraction, applied as min with the provider max_tokens. Default: 4096, floored to 1. ... |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID` | typed:string | Runtime | operator | 287 | Optional runtime id override for librarian extraction. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_TIMEOUT_SEC` | typed:float | Timeouts | operator | 265 | Provider timeout for librarian extraction. Default: 600 seconds; invalid, non-positive, NaN, or infinite values fall ... |
+| `MASC_KEEPER_MEMORY_OS_RECALL` | typed:bool | Policies | operator | 219 | Memory OS recall prompt injection kill switch. Default: true; invalid values fail closed to false so malformed operat... |
 | `MASC_KEEPER_METRICS_MAX_BYTES` | typed:int | unclassified | unclassified | 73 | Maximum metrics file size in bytes before rotation (default: 10MB) |
 | `MASC_KEEPER_METRICS_MAX_ROTATED` | typed:int | unclassified | unclassified | 76 | Number of rotated files to keep (default: 1, i.e. .1 only) |
-| `MASC_KEEPER_PROACTIVE_MAX_ATTEMPTS` | typed:int | unclassified | unclassified | 639 | Maximum proactive generation attempts before falling back. Default: 3. Range: [1, 10]. |
-| `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | unclassified | unclassified | 545 | Interruptible sleep chunk size in seconds. Smaller = faster wakeup response but more CPU polling. Default: 2.0. Range... |
+| `MASC_KEEPER_PROACTIVE_MAX_ATTEMPTS` | typed:int | unclassified | unclassified | 625 | Maximum proactive generation attempts before falling back. Default: 3. Range: [1, 10]. |
+| `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | unclassified | unclassified | 531 | Interruptible sleep chunk size in seconds. Smaller = faster wakeup response but more CPU polling. Default: 2.0. Range... |
 | `MASC_KEEPER_SNAPSHOT_SEC` | typed:int | unclassified | unclassified | 154 | Keeper keepalive snapshot interval, clamped to [15, 3600]. Default: 300. |
-| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 645 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
-| `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | string_literal | n/a | n/a | 556 |  |
-| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_BASE_SEC` | typed:float | Timeouts | operator | 423 | Base delay before trying the next vision runtime after a failed provider attempt. A small default avoids tight failov... |
-| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_MAX_SEC` | typed:float | Timeouts | operator | 433 | Upper bound for the per-candidate vision failover delay. Range: [base, 30] seconds, so a typo cannot exceed the tool'... |
-| `MASC_KEEPER_VISION_MAX_IMAGE_BYTES` | typed:int | Policies | operator | 413 | Maximum raw image bytes accepted by the one-shot vision tool before provider-message construction. Default is 5 MiB t... |
+| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 631 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
+| `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | string_literal | n/a | n/a | 542 |  |
+| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_BASE_SEC` | typed:float | Timeouts | operator | 409 | Base delay before trying the next vision runtime after a failed provider attempt. A small default avoids tight failov... |
+| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_MAX_SEC` | typed:float | Timeouts | operator | 419 | Upper bound for the per-candidate vision failover delay. Range: [base, 30] seconds, so a typo cannot exceed the tool'... |
+| `MASC_KEEPER_VISION_MAX_IMAGE_BYTES` | typed:int | Policies | operator | 399 | Maximum raw image bytes accepted by the one-shot vision tool before provider-message construction. Default is 5 MiB t... |
 | `MASC_KEEPER_WIRE_CAPTURE` | feature_flag | Policies | operator | 88 | Master switch for diagnostic MASC->OAS wire capture. Default off. @category Policies @ops_class operator |
 | `MASC_KEEPER_WIRE_CAPTURE_MAX_BYTES` | typed:int | Policies | operator | 114 | Maximum bytes for the active [<masc_root>/wire-capture/YYYY-MM/DD.jsonl] file and maximum total bytes retained below ... |
 | `MASC_KEEPER_WIRE_CAPTURE_RETENTION_DAYS` | typed:int | Policies | operator | 103 | Maximum age for [<masc_root>/wire-capture] day files retained by the diagnostic MASC->OAS wire-capture harness. Defau... |
-| `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 500 | Master switch. When true, successful Workspace.heartbeat after a unified turn counts as presence proof, allowing the ... |
+| `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 486 | Master switch. When true, successful Workspace.heartbeat after a unified turn counts as presence proof, allowing the ... |
 
 ## Env_config_keeper_supervisor (3 knobs; typed classification 2/2)
 
@@ -270,9 +269,9 @@ the categorization roadmap. Newly-added typed getters in
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
 | `MASC_ALLOW_ANONYMOUS_MUTATIONS` | string_literal | n/a | n/a | 29 |  |
-| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 566 |  |
-| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 570 |  |
-| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 572 |  |
+| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 562 |  |
+| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 566 |  |
+| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 568 |  |
 | `MASC_BENCHMARK_RESULTS_DIR` | string_literal | n/a | n/a | 184 |  |
 | `MASC_CHANNEL_GATE_DEDUP_TTL_SEC` | string_literal | n/a | n/a | 270 |  |
 | `MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH` | string_literal | n/a | n/a | 272 |  |
@@ -280,8 +279,8 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_DASHBOARD_EXECUTION_REFRESH_TIMEOUT_S` | string_literal | n/a | n/a | 194 |  |
 | `MASC_DASHBOARD_TRANSPORT_HEALTH_TIMEOUT_S` | string_literal | n/a | n/a | 234 |  |
 | `MASC_DECISION_AUDIT_RING_CAPACITY` | string_literal | n/a | n/a | 288 |  |
-| `MASC_DEFAULT_MODEL` | string_literal | n/a | n/a | 520 |  |
-| `MASC_DEFAULT_PROVIDER` | string_literal | n/a | n/a | 522 |  |
+| `MASC_DEFAULT_MODEL` | string_literal | n/a | n/a | 516 |  |
+| `MASC_DEFAULT_PROVIDER` | string_literal | n/a | n/a | 518 |  |
 | `MASC_DISCORD_STATUS_STALE_SEC` | string_literal | n/a | n/a | 274 |  |
 | `MASC_DRIFT_COSINE_WEIGHT` | string_literal | n/a | n/a | 175 |  |
 | `MASC_DRIFT_JACCARD_WEIGHT` | string_literal | n/a | n/a | 174 |  |
@@ -294,8 +293,8 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_ECONOMY_REWARD_MENTION_RESPONSE` | string_literal | n/a | n/a | 339 |  |
 | `MASC_ECONOMY_REWARD_TASK_DONE` | string_literal | n/a | n/a | 341 |  |
 | `MASC_ECONOMY_REWARD_UPVOTE` | string_literal | n/a | n/a | 343 |  |
-| `MASC_EVENT_BUFFER_SIZE` | string_literal | n/a | n/a | 650 |  |
-| `MASC_GOAL_DISPATCH_RUNTIME` | string_literal | n/a | n/a | 524 |  |
+| `MASC_EVENT_BUFFER_SIZE` | string_literal | n/a | n/a | 646 |  |
+| `MASC_GOAL_DISPATCH_RUNTIME` | string_literal | n/a | n/a | 520 |  |
 | `MASC_GRPC_STREAM_MAX_BUFFER` | string_literal | n/a | n/a | 76 |  |
 | `MASC_HEBBIAN_DECAY` | string_literal | n/a | n/a | 177 |  |
 | `MASC_HEBBIAN_RATE` | string_literal | n/a | n/a | 176 |  |
@@ -310,25 +309,25 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_UNIFIED_MAX_TOKENS` | string_literal | n/a | n/a | 151 |  |
 | `MASC_KEEPER_UNIFIED_TEMP` | string_literal | n/a | n/a | 150 |  |
 | `MASC_LOCK_WARN_MS` | string_literal | n/a | n/a | 178 |  |
-| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 626 |  |
-| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 660 |  |
-| `MASC_ROUTING_RUNTIME` | string_literal | n/a | n/a | 526 |  |
+| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 622 |  |
+| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 656 |  |
+| `MASC_ROUTING_RUNTIME` | string_literal | n/a | n/a | 522 |  |
 | `MASC_RUNTIME_ATTEMPT_LIVENESS` | string_literal | n/a | n/a | 375 |  |
-| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 668 |  |
-| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 594 |  |
-| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 596 |  |
-| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 598 |  |
-| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 600 |  |
-| `MASC_SSE_KEEPALIVE_SEC` | string_literal | n/a | n/a | 652 |  |
-| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 606 |  |
+| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 664 |  |
+| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 590 |  |
+| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 592 |  |
+| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 594 |  |
+| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 596 |  |
+| `MASC_SSE_KEEPALIVE_SEC` | string_literal | n/a | n/a | 648 |  |
+| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 602 |  |
 | `MASC_TELEMETRY_MAX_BYTES` | string_literal | n/a | n/a | 48 |  |
 | `MASC_TELEMETRY_RETENTION_DAYS` | string_literal | n/a | n/a | 45 |  |
-| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 642 |  |
-| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 644 |  |
+| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 638 |  |
+| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 640 |  |
 | `MASC_TLA_TRACE` | string_literal | n/a | n/a | 138 |  |
-| `MASC_WORKER_RUNTIME_BACKEND` | string_literal | n/a | n/a | 694 |  |
-| `MASC_WORKER_RUNTIME_DOCKER_IMAGE` | string_literal | n/a | n/a | 696 |  |
-| `MASC_WORKER_RUNTIME_HOST_MCP_BASE_URL` | string_literal | n/a | n/a | 698 |  |
+| `MASC_WORKER_RUNTIME_BACKEND` | string_literal | n/a | n/a | 690 |  |
+| `MASC_WORKER_RUNTIME_DOCKER_IMAGE` | string_literal | n/a | n/a | 692 |  |
+| `MASC_WORKER_RUNTIME_HOST_MCP_BASE_URL` | string_literal | n/a | n/a | 694 |  |
 | `MASC_WS_ACK_STALE_THRESHOLD_SEC` | string_literal | n/a | n/a | 86 |  |
 | `MASC_WS_CLIENT_BUFFER_LIMIT_BYTES` | string_literal | n/a | n/a | 83 |  |
 | `MASC_WS_MAX_INBOUND_DISPATCHES_PER_SESSION` | string_literal | n/a | n/a | 110 |  |

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -172,7 +172,6 @@ module KeeperMemoryOs = struct
   let librarian_timeout_sec_default = 600.0
   let librarian_max_tokens_default = 4096
   let librarian_runtime_id_default = None
-  let librarian_global_slot_default = 1
   let gc_enabled_default = true
   let consolidation_enabled_default = false
   let consolidation_runtime_id_default = None
@@ -188,7 +187,6 @@ module KeeperMemoryOs = struct
   let librarian_timeout_sec_env_key = "MASC_KEEPER_MEMORY_OS_LIBRARIAN_TIMEOUT_SEC"
   let librarian_max_tokens_env_key = "MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_TOKENS"
   let librarian_runtime_id_env_key = "MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID"
-  let librarian_global_slot_env_key = "MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT"
   let gc_env_key = "MASC_KEEPER_MEMORY_OS_GC"
   let consolidation_env_key = "MASC_KEEPER_MEMORY_OS_CONSOLIDATION"
   let consolidation_runtime_id_env_key = "MASC_KEEPER_MEMORY_OS_CONSOLIDATION_RUNTIME_ID"
@@ -288,18 +286,6 @@ module KeeperMemoryOs = struct
       ~default:(optional_string_default librarian_runtime_id_default)
       librarian_runtime_id_env_key
     |> nonempty_string
-  ;;
-
-  (** Fleet-wide concurrency gate for librarian provider calls. Default: 1; 0
-      disables the gate.
-      @category Concurrency
-      @ops_class operator *)
-  let librarian_global_slot () =
-    max
-      0
-      (get_int_logged
-         librarian_global_slot_env_key
-         ~default:librarian_global_slot_default)
   ;;
 
   (** Per-keeper Memory OS GC maintenance fiber kill switch. Default: true;

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -69,7 +69,6 @@ module KeeperMemoryOs : sig
   val librarian_timeout_sec_env_key : string
   val librarian_max_tokens_env_key : string
   val librarian_runtime_id_env_key : string
-  val librarian_global_slot_env_key : string
   val gc_env_key : string
   val consolidation_env_key : string
   val consolidation_runtime_id_env_key : string
@@ -81,7 +80,6 @@ module KeeperMemoryOs : sig
   val librarian_timeout_sec_default : float
   val librarian_max_tokens_default : int
   val librarian_runtime_id_default : string option
-  val librarian_global_slot_default : int
   val gc_enabled_default : bool
   val consolidation_enabled_default : bool
   val consolidation_runtime_id_default : string option
@@ -101,7 +99,6 @@ module KeeperMemoryOs : sig
       provider max_tokens. Default: 4096, floored to 1. *)
 
   val librarian_runtime_id : unit -> string option
-  val librarian_global_slot : unit -> int
   val gc_enabled : unit -> bool
   val consolidation_enabled : unit -> bool
   val consolidation_runtime_id : unit -> string option

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -488,10 +488,6 @@ let memory_entries =
       Memory_os_defaults.librarian_runtime_id_env_key
       "Optional runtime id override for librarian extraction; (none) displays the empty default";
     entry
-      ~default:(string_of_int Memory_os_defaults.librarian_global_slot_default)
-      Memory_os_defaults.librarian_global_slot_env_key
-      "Fleet-wide concurrency gate for librarian provider calls; 0 disables";
-    entry
       ~default:(string_of_bool Memory_os_defaults.gc_enabled_default)
       Memory_os_defaults.gc_env_key
       "Per-keeper Memory OS GC maintenance fiber kill switch; invalid values fail closed";

--- a/lib/keeper/keeper_agent_run_post_turn_memory.ml
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.ml
@@ -2,9 +2,97 @@
 
     Extracted from [Keeper_agent_run.run_turn] Step 8 body (RFC-0147 PR-4). *)
 
+let record_librarian_failure ~keeper_name error =
+  Otel_metric_store.inc_counter
+    Keeper_metrics.(to_string EpisodeCreateFailures)
+    ~labels:[ "keeper", keeper_name; "site", "memory_os_librarian" ]
+    ();
+  Keeper_librarian_runtime.operation_error_to_string error
+;;
+
+let execute_request ~base_path request =
+  let keeper_name = Keeper_memory_work_request.keeper_name request in
+  try
+    let config = Workspace.default_config base_path in
+    let meta = Keeper_memory_work_request.meta request in
+    let turn = Keeper_memory_work_request.turn request in
+    let notes_written =
+      Memory.append_from_tool_results
+        config
+        meta
+        ~turn
+        ~results:(Keeper_memory_work_request.tool_results request)
+    in
+    if notes_written > 0
+    then
+      Keeper_turn_telemetry.log_keeper_memory_write
+        ~keeper_name
+        ~notes_written
+        ~kinds_written:[ "long_term" ];
+    let input : Keeper_librarian.input =
+      { trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id
+      ; generation = Keeper_memory_work_request.generation request
+      ; messages = Keeper_memory_work_request.librarian_messages request
+      }
+    in
+    let operation : Keeper_librarian_runtime.operation_request =
+      { runtime_id = Keeper_memory_work_request.runtime_id request
+      ; keeper_id = keeper_name
+      ; input
+      }
+    in
+    (match Keeper_librarian_runtime.execute_operation operation with
+     | Error error -> Error (record_librarian_failure ~keeper_name error)
+     | Ok episode ->
+       Log.Keeper.info ~keeper_name
+         "memory os librarian wrote episode trace_id=%s generation=%d claims=%d"
+         episode.Keeper_memory_os_types.trace_id
+         episode.generation
+         (List.length episode.claims);
+       Ok ())
+  with
+  | Eio.Cancel.Cancelled _ as error -> raise error
+  | exn ->
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string MemoryWriteFailures)
+      ~labels:[ "keeper", keeper_name ]
+      ();
+    Error (Printexc.to_string exn)
+;;
+
+let drain_keeper ~base_path ~keeper_name =
+  match
+    Keeper_memory_work_drain.drain
+      ~base_path
+      ~keeper_name
+      ~execute:(execute_request ~base_path)
+  with
+  | Ok report ->
+    Log.Keeper.info ~keeper_name
+      "memory owner drain recovered=%d claimed=%d completed=%d failed=%d"
+      report.recovered
+      report.claimed
+      report.completed
+      report.failed
+  | Error error ->
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string DispatchEventFailures)
+      ~labels:[ "keeper", keeper_name; "site", "memory_owner_drain" ]
+      ();
+    Log.Keeper.error ~keeper_name
+      "memory owner drain failed: %s"
+      (Keeper_memory_work_drain.error_to_string error)
+;;
+
+let schedule_drain ~base_path ~keeper_name =
+  Keeper_memory_lane.submit
+    ~base_path
+    ~keeper_name
+    (fun () -> drain_keeper ~base_path ~keeper_name)
+;;
 
 let run
-  ~config
+  ~(config : Workspace.config)
   ~meta
   ~generation
   ~turn
@@ -27,80 +115,54 @@ let run
       (Keeper_tool_emission_hook.accumulator_for_keeper
          meta.Keeper_meta_contract.name)
   in
-  (* (1) deterministic write and (2) LLM librarian extraction run on this
-     keeper's memory lane (RFC-0257), detached from the turn lane. Both may
-     touch the keeper's memory stores; the per-keeper FIFO worker serializes
-     them. meta/config are immutable snapshots, so
-     using them after the turn returns does not race a later turn.
-     See RFC #3646 Section 3: Det/NonDet boundary. *)
-  let memory_series () =
-  (try
-     let notes_written =
-       Memory.append_from_tool_results
-         config
-         meta
-         ~turn
-         ~results:tool_results_snapshot
-     in
-     let kinds_written =
-       if notes_written > 0 then [ "long_term" ] else []
-     in
-     if notes_written > 0
-     then
-       Keeper_turn_telemetry.log_keeper_memory_write
-         ~keeper_name:meta.name
-         ~notes_written
-         ~kinds_written
+  let deliberation_execution_json =
+    Option.map Keeper_deliberation.execution_result_to_json deliberation_execution
+  in
+  (match
+     Keeper_memory_work_request.make
+       ~keeper_name:meta.name
+       ~generation
+       ~turn
+       ~runtime_id
+       ~meta
+       ~tool_results:tool_results_snapshot
+       ~librarian_messages
+       ~deliberation_execution:deliberation_execution_json
    with
-   | exn ->
-     Log.Keeper.error ~keeper_name:meta.name
-       "memory_write failed: %s"
-       (Printexc.to_string exn);
+   | Error detail ->
      Otel_metric_store.inc_counter
-       Keeper_metrics.(to_string MemoryWriteFailures)
-       ~labels:[ "keeper", meta.name ]
-       ());
-
-  (* Memory OS librarian extraction: opt-in, provider-backed, best-effort. *)
-  let librarian_input : Keeper_librarian.input =
-    { trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id
-    ; generation
-    ; messages = librarian_messages
-    }
-  in
-  let librarian_request : Keeper_librarian_runtime.operation_request =
-    { runtime_id; keeper_id = meta.name; input = librarian_input }
-  in
-  (match Keeper_librarian_runtime.execute_operation librarian_request with
-   | Ok episode ->
-     Log.Keeper.info ~keeper_name:meta.name
-       "memory os librarian wrote episode trace_id=%s generation=%d claims=%d"
-       episode.Keeper_memory_os_types.trace_id
-       episode.generation
-       (List.length episode.claims)
-   | Error error ->
-     (match error with
-      | Keeper_librarian_runtime.Provider_slot_busy _ ->
-        Otel_metric_store.inc_counter
-          Keeper_metrics.(to_string MemoryLaneProviderSlotBusy)
-          ~labels:
-            [ "keeper", meta.name
-            ; "site", Keeper_librarian_runtime.memory_os_librarian_provider_slot_site
-            ]
-          ()
-      | _ -> ());
-     Otel_metric_store.inc_counter
-       Keeper_metrics.(to_string EpisodeCreateFailures)
-       ~labels:[ "keeper", meta.name; "site", "memory_os_librarian" ]
+       Keeper_metrics.(to_string DispatchEventFailures)
+       ~labels:[ "keeper", meta.name; "site", "memory_work_request" ]
        ();
      Log.Keeper.error ~keeper_name:meta.name
-       "memory os librarian operation failed runtime=%s: %s"
-       runtime_id
-       (Keeper_librarian_runtime.operation_error_to_string error));
+       "memory work request rejected: %s"
+       detail
+   | Ok request ->
+     (match Keeper_memory_work_store.enqueue ~base_path:config.base_path request with
+      | Error error ->
+        Otel_metric_store.inc_counter
+          Keeper_metrics.(to_string DispatchEventFailures)
+          ~labels:[ "keeper", meta.name; "site", "memory_work_enqueue" ]
+          ();
+        Log.Keeper.error ~keeper_name:meta.name
+          "memory work durable enqueue failed: %s"
+          (Keeper_memory_work_store.error_to_string error)
+      | Ok
+          ( Keeper_memory_work_store.Enqueued
+          | Keeper_memory_work_store.Already_present ) ->
+        (match schedule_drain ~base_path:config.base_path ~keeper_name:meta.name with
+         | Ok () -> ()
+         | Error error ->
+           Otel_metric_store.inc_counter
+             Keeper_metrics.(to_string DispatchEventFailures)
+             ~labels:[ "keeper", meta.name; "site", "memory_owner_drain_admission" ]
+             ();
+           Log.Keeper.error ~keeper_name:meta.name
+             "memory work is durable but owner drain admission failed: %s"
+             (Keeper_memory_lane.admission_error_to_string error))));
 
-  (* Advisory delegation request drafts: keep review artifact persistence on the
-     same bounded post-turn memory lane as draft-skill projection, not on the
-     decision-record append path. *)
+  (* Delegation projection remains an explicit artifact boundary; it is not a
+     Memory work settlement. *)
   (try
      match deliberation_execution with
      | None -> ()
@@ -137,29 +199,6 @@ let run
        "delegation_requests failed: %s"
        (Printexc.to_string exn));
 
-  in
-  (* RFC-0257: detach (1)-(2) onto the per-keeper memory lane. Admission failure
-     is explicit and observable; provider-backed work never falls back into the
-     submitting turn fiber. *)
-  (match
-     Keeper_memory_lane.submit
-       ~base_path:config.base_path
-       ~keeper_name:meta.name
-       memory_series
-   with
-   | Ok () -> ()
-   | Error error ->
-     Otel_metric_store.inc_counter
-       Keeper_metrics.(to_string DispatchEventFailures)
-       ~labels:
-         [ "keeper", meta.name
-         ; "site", "memory_lane_admission"
-         ; "reason", Keeper_memory_lane.admission_error_code error
-         ]
-       ();
-     Log.Keeper.error ~keeper_name:meta.name
-       "post-turn memory lane admission failed: %s"
-       (Keeper_memory_lane.admission_error_to_string error));
   (* Post-turn memory recall evidence is logged to decisions.jsonl. *)
   (try
      let used_search =

--- a/lib/keeper/keeper_agent_run_post_turn_memory.mli
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.mli
@@ -5,8 +5,13 @@
     memory-bank rows: semantic consolidation requires an explicit typed LLM
     Memory operation, never a storage-pressure survival rule.
 
-    Each sub-stage is best-effort: non-cancel exceptions are logged and
-    counted, never propagated.  [Eio.Cancel.Cancelled] is re-raised. *)
+    Memory work is durably admitted before the owner lane is signalled. *)
+
+val schedule_drain
+  :  base_path:string
+  -> keeper_name:string
+  -> (unit, Keeper_memory_lane.admission_error) result
+(** Signal the per-Keeper owner lane to drain already-durable Memory work. *)
 
 val run :
   config:Workspace.config ->
@@ -32,6 +37,5 @@ val run :
     [inference_telemetry] is [result.response.telemetry] from the OAS
     result; it is optional because some providers do not emit telemetry.
 
-    [deliberation_execution], when available, is persisted as advisory
-    delegation request artifacts on this post-turn memory lane rather than on
-    the decision-record append path. *)
+    [deliberation_execution], when available, is persisted at the separate
+    delegation artifact boundary. *)

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -31,74 +31,6 @@ let default_complete ~sw ~net ?clock ~config ~messages () =
   Llm_provider.Complete.complete ~sw ~net ?clock ~config ~messages ()
 ;;
 
-(* RFC-0257 / P0-4 adversarial hardening: per-keeper librarian provider slot.
-   The previous process-global slot allowed one slow keeper to starve the fleet.
-   Capacity is still read from [MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT]
-   (default 1), but the semaphore is now keyed by [keeper_id] so each keeper
-   gets its own concurrency budget. A capacity of 0 disables the gate entirely. *)
-let per_keeper_slot_capacity () =
-  Env_config.KeeperMemoryOs.librarian_global_slot ()
-;;
-
-let memory_os_librarian_provider_slot_site = "memory_os_librarian_provider_slot"
-
-let provider_slot_wait_sec = 0.25
-
-type provider_slot =
-  { capacity : int
-  ; sem : Eio.Semaphore.t option
-  }
-
-let provider_slots_mu = Eio.Mutex.create ()
-let provider_slots : (string, provider_slot) Hashtbl.t = Hashtbl.create 64
-
-let provider_slot_for_keeper ~keeper_id capacity =
-  Eio_guard.with_mutex provider_slots_mu (fun () ->
-    match Hashtbl.find_opt provider_slots keeper_id with
-    | Some slot when slot.capacity = capacity -> slot
-    | _ ->
-      let slot =
-        { capacity
-        ; sem =
-            (match capacity with
-             | 0 -> None
-             | n -> Some (Eio.Semaphore.make n))
-        }
-      in
-      Hashtbl.replace provider_slots keeper_id slot;
-      slot)
-;;
-
-let with_provider_slot ~keeper_id ~clock f =
-  let capacity = per_keeper_slot_capacity () in
-  let slot = provider_slot_for_keeper ~keeper_id capacity in
-  match slot.sem with
-  | None -> Some (f ())
-  | Some sem ->
-    let acquired = ref false in
-    (try
-       (try
-          Eio.Time.with_timeout_exn clock provider_slot_wait_sec (fun () ->
-            Eio.Semaphore.acquire sem);
-         acquired := true
-        with
-        | Eio.Time.Timeout -> ())
-     with
-     | Eio.Cancel.Cancelled _ as e -> raise e
-     | exn ->
-       Log.Keeper.warn
-         "librarian provider slot acquisition failed keeper=%s: %s"
-         keeper_id
-         (Printexc.to_string exn));
-    if !acquired
-    then
-      Some
-        (Eio.Switch.run (fun cleanup_sw ->
-           Eio.Switch.on_release cleanup_sw (fun () -> Eio.Semaphore.release sem);
-           f ()))
-    else None
-;;
-
 let enabled () =
   (* Default on: a keeper without conversation ingestion is the pathology
      the Memory OS exists to fix (2026-06-12 diagnosis, issue #20909).
@@ -749,7 +681,6 @@ type operation_error =
   | Eio_context_unavailable
   | Runtime_resolution_failed of string
   | Direct_completion_unsupported
-  | Provider_slot_busy of { capacity : int }
   | Extraction_failed of extraction_error
   | Unexpected_failure of string
 
@@ -758,8 +689,6 @@ let operation_error_to_string = function
   | Runtime_resolution_failed detail -> "memory os librarian runtime resolution failed: " ^ detail
   | Direct_completion_unsupported ->
     "memory os librarian provider does not support direct completion"
-  | Provider_slot_busy { capacity } ->
-    Printf.sprintf "memory os librarian provider slot busy (capacity=%d)" capacity
   | Extraction_failed error -> extraction_error_to_string error
   | Unexpected_failure detail -> "memory os librarian unexpected failure: " ^ detail
 ;;
@@ -781,21 +710,19 @@ let execute_operation ?complete ?timeout_sec (request : operation_request) =
          else (
            let timeout_sec = Option.value timeout_sec ~default:(default_timeout_sec ()) in
            match
-             with_provider_slot ~keeper_id:request.keeper_id ~clock (fun () ->
-               extract_and_append_with_provider_classified
-                 ?complete
-                 ~clock
-                 ~timeout_sec
-                 ~sw
-                 ~net
-                 ~keeper_id:request.keeper_id
-                 ~runtime_id
-                 ~provider_cfg
-                 request.input)
+             extract_and_append_with_provider_classified
+               ?complete
+               ~clock
+               ~timeout_sec
+               ~sw
+               ~net
+               ~keeper_id:request.keeper_id
+               ~runtime_id
+               ~provider_cfg
+               request.input
            with
-           | None -> Error (Provider_slot_busy { capacity = per_keeper_slot_capacity () })
-           | Some (Error error) -> Error (Extraction_failed error)
-           | Some (Ok episode) -> Ok episode))
+           | Error error -> Error (Extraction_failed error)
+           | Ok episode -> Ok episode))
     | _ -> Error Eio_context_unavailable
   with
   | Eio.Cancel.Cancelled _ as error -> raise error

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -84,11 +84,6 @@ val cadence_counter_entries : unit -> int
     Uses [Eio_guard.with_mutex_ro] so runtime fibers take a cooperative mutex
     while focused pre-Eio tests keep a direct single-threaded path. *)
 
-val memory_os_librarian_provider_slot_site : string
-(** OTel [site] label used when the fleet-wide librarian provider slot is busy.
-    The producer and dashboard health reader share this value so label drift
-    cannot silently hide provider-slot-busy alerts. *)
-
 val max_messages : unit -> int
 (** Base per-turn cap on checkpoint messages sent to the librarian prompt. The
     effective prompt window is this value scaled by [cadence_turns] so skipped
@@ -184,24 +179,6 @@ val run_with_parse_retries
     retry. Pure given a pure [attempt] — the provider side effect lives in the
     [attempt] supplied by {!extract_with_provider}. *)
 
-val per_keeper_slot_capacity : unit -> int
-(** Per-keeper librarian provider slot capacity from
-    [MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT] (default 1, 0 disables the
-    gate). The capacity is applied per keeper, not fleet-wide. *)
-
-val with_provider_slot
-  :  keeper_id:string
-  -> clock:float Eio.Time.clock_ty Eio.Resource.t
-  -> (unit -> 'a)
-  -> 'a option
-(** Run [f] under the per-keeper librarian provider slot — the #21230/P0-4
-    storm guard. At capacity N per keeper, the (N+1)-th concurrent entrant for
-    the same keeper returns [None] after [provider_slot_wait_sec] (drop, not
-    block); capacity 0 disables the gate so [f] always runs ([Some]). The
-    provider slot registry is guarded through [Eio_guard.with_mutex], avoiding
-    blocking stdlib locks on keeper runtime fibers. Exposed for storm-guard
-    regression coverage (#21376). *)
-
 val librarian_provider_clock_unavailable_error : string
 (** Stable error returned before provider I/O when provider-backed librarian
     extraction is called without a clock. Exposed so callers/tests do not
@@ -274,7 +251,6 @@ type operation_error =
   | Eio_context_unavailable
   | Runtime_resolution_failed of string
   | Direct_completion_unsupported
-  | Provider_slot_busy of { capacity : int }
   | Extraction_failed of extraction_error
   | Unexpected_failure of string
 
@@ -289,5 +265,6 @@ val execute_operation
 
     This boundary does not consult the retired enable/cadence policy and never
     converts failure into [unit]. Cancellation propagates; every other outcome
-    is returned to its caller. Durable owner-lane settlement is a separate
-    orchestration boundary and must not infer success from this call returning. *)
+    is returned to its caller. Production execution is claimed by the durable
+    per-Keeper owner drain before entering this function; no provider-slot drop
+    or replacement concurrency heuristic exists here. *)

--- a/lib/keeper/keeper_memory_work_drain.ml
+++ b/lib/keeper/keeper_memory_work_drain.ml
@@ -1,0 +1,79 @@
+type report =
+  { recovered : int
+  ; claimed : int
+  ; completed : int
+  ; failed : int
+  }
+
+type error =
+  | Store_error of Keeper_memory_work_store.error
+  | Concurrent_claim of string
+
+let empty = { recovered = 0; claimed = 0; completed = 0; failed = 0 }
+let ( let* ) = Result.bind
+
+let error_to_string = function
+  | Store_error error -> Keeper_memory_work_store.error_to_string error
+  | Concurrent_claim request_id ->
+    Printf.sprintf "Memory work already claimed by another owner: %s" request_id
+;;
+
+let store result = Result.map_error (fun error -> Store_error error) result
+
+let next ~base_path ~keeper_name =
+  let* recovered =
+    Keeper_memory_work_store.recover_in_flight ~base_path ~keeper_name |> store
+  in
+  match recovered with
+  | Some request -> Ok (Some (`Recovered, request))
+  | None ->
+    let* claimed =
+      Keeper_memory_work_store.claim_next ~base_path ~keeper_name |> store
+    in
+    (match claimed with
+     | Keeper_memory_work_store.Queue_empty -> Ok None
+     | Keeper_memory_work_store.Claim_busy request_id ->
+       Error (Concurrent_claim request_id)
+     | Keeper_memory_work_store.Claimed request ->
+       Ok (Some (`Claimed, request)))
+;;
+
+let execute_result execute request =
+  try execute request with
+  | Eio.Cancel.Cancelled _ as error -> raise error
+  | exn -> Error (Printexc.to_string exn)
+;;
+
+let rec loop ~base_path ~keeper_name ~execute report =
+  let* next = next ~base_path ~keeper_name in
+  match next with
+  | None -> Ok report
+  | Some (source, request) ->
+    let request_id = Keeper_memory_work_request.request_id request in
+    let execution = execute_result execute request in
+    let outcome =
+      match execution with
+      | Ok () -> Keeper_memory_work_store.Completed
+      | Error detail -> Keeper_memory_work_store.Failed detail
+    in
+    let* (_ : Keeper_memory_work_store.settle_result) =
+      Keeper_memory_work_store.settle
+        ~base_path
+        ~keeper_name
+        ~request_id
+        outcome
+      |> store
+    in
+    let report =
+      { recovered = report.recovered + (match source with `Recovered -> 1 | `Claimed -> 0)
+      ; claimed = report.claimed + (match source with `Recovered -> 0 | `Claimed -> 1)
+      ; completed = report.completed + (match execution with Ok () -> 1 | Error _ -> 0)
+      ; failed = report.failed + (match execution with Ok () -> 0 | Error _ -> 1)
+      }
+    in
+    loop ~base_path ~keeper_name ~execute report
+;;
+
+let drain ~base_path ~keeper_name ~execute =
+  loop ~base_path ~keeper_name ~execute empty
+;;

--- a/lib/keeper/keeper_memory_work_drain.mli
+++ b/lib/keeper/keeper_memory_work_drain.mli
@@ -1,0 +1,24 @@
+(** Exact owner-lane drain over {!Keeper_memory_work_store}. *)
+
+type report =
+  { recovered : int
+  ; claimed : int
+  ; completed : int
+  ; failed : int
+  }
+
+type error =
+  | Store_error of Keeper_memory_work_store.error
+  | Concurrent_claim of string
+
+val error_to_string : error -> string
+
+val drain
+  :  base_path:string
+  -> keeper_name:string
+  -> execute:(Keeper_memory_work_request.t -> (unit, string) result)
+  -> (report, error) result
+(** Recover the exact in-flight request first, then claim and settle the durable
+    FIFO until empty. [Completed] is written only for [Ok ()]; [Error detail]
+    is durably settled as [Failed detail]. A store or settlement error stops the
+    drain with the current request still recoverable. *)

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -151,7 +151,6 @@ type t =
   | MemoryLaneCancelledUnits
   | MemoryLanePending
   | MemoryLaneInFlight
-  | MemoryLaneProviderSlotBusy
   | MemoryBankCompactionFailures
   | MemoryOsMaintenanceKeeperTimeout
   | WriteMetaCycleFailures
@@ -378,7 +377,6 @@ let to_string = function
   | MemoryLaneCancelledUnits -> "masc_keeper_memory_lane_cancelled_units_total"
   | MemoryLanePending -> "masc_keeper_memory_lane_pending"
   | MemoryLaneInFlight -> "masc_keeper_memory_lane_in_flight"
-  | MemoryLaneProviderSlotBusy -> "masc_keeper_memory_lane_provider_slot_busy_total"
   | MemoryBankCompactionFailures -> "masc_keeper_memory_bank_compaction_failures_total"
   | MemoryOsMaintenanceKeeperTimeout -> "masc_keeper_memory_os_maintenance_keeper_timeout_total"
   | WriteMetaCycleFailures -> "masc_keeper_write_meta_cycle_failures_total"

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -142,7 +142,6 @@ type t =
   | MemoryLaneCancelledUnits
   | MemoryLanePending
   | MemoryLaneInFlight
-  | MemoryLaneProviderSlotBusy
   | MemoryBankCompactionFailures
   | MemoryOsMaintenanceKeeperTimeout
   | WriteMetaCycleFailures

--- a/lib/server/server_dashboard_http_keeper_memory_health.ml
+++ b/lib/server/server_dashboard_http_keeper_memory_health.ml
@@ -11,8 +11,6 @@
     - [Keeper_memory_os_io.events_path] + file stat for events bytes.
     - [Keeper_memory_os_gc.run_gc ~dry_run:true] for explicitly expired rows
       without mutating the store.
-    - [Otel_metric_store] provider-slot-busy counters for skipped librarian
-      extraction attempts, grouped by keeper.
     - [Keeper_librarian_runtime.cadence_counter_entries] for the cadence table
       size (one fleet-wide value). *)
 
@@ -25,20 +23,17 @@ type keeper_health =
   ; events_to_facts_ratio : float
   ; ttl_expired_on_disk : int
   ; near_duplicate : int
-  ; provider_slot_busy : int
   }
 
 type alert_code =
   | Ttl_expired_on_disk
   | Near_duplicate
-  | Provider_slot_busy
 
 type alert_severity = Warn
 
 type alert_target =
   | Ttl_expired_on_disk_target
   | Near_duplicate_target
-  | Provider_slot_busy_target
 
 type keeper_alert =
   { code : alert_code
@@ -53,15 +48,9 @@ type keeper_alert =
 let ttl_expired_on_disk_threshold = 0.0
 let near_duplicate_threshold = 0.0
 
-let provider_slot_busy_threshold = 0.0
-
-let provider_slot_busy_metric = Keeper_metrics.(to_string MemoryLaneProviderSlotBusy)
-let provider_slot_busy_site = Keeper_librarian_runtime.memory_os_librarian_provider_slot_site
-
 let alert_code_to_string = function
   | Ttl_expired_on_disk -> "ttl_expired_on_disk"
   | Near_duplicate -> "near_duplicate"
-  | Provider_slot_busy -> "provider_slot_busy"
 ;;
 
 let alert_severity_to_string = function
@@ -71,7 +60,6 @@ let alert_severity_to_string = function
 let alert_target_to_string = function
   | Ttl_expired_on_disk_target -> "ttl_expired_on_disk"
   | Near_duplicate_target -> "near_duplicate"
-  | Provider_slot_busy_target -> "provider_slot_busy"
 ;;
 
 (* Alert labels are endpoint-owned wire copy for this backend-defined diagnostic
@@ -80,7 +68,6 @@ let alert_target_to_string = function
 let alert_label = function
   | Ttl_expired_on_disk -> "TTL"
   | Near_duplicate -> "중복"
-  | Provider_slot_busy -> "슬롯"
 ;;
 
 let alert ~code ~target ~message ~value ~threshold =
@@ -109,18 +96,6 @@ let keeper_alerts h =
         ~message:"Near-duplicate Memory OS fact rows remain on disk; GC dry-run would deduplicate them."
         ~value:(float_of_int h.near_duplicate)
         ~threshold:near_duplicate_threshold
-      :: alerts
-    else alerts)
-  |> (fun alerts ->
-    if h.provider_slot_busy > 0
-    then
-      alert
-        ~code:Provider_slot_busy
-        ~target:Provider_slot_busy_target
-        ~message:
-          "Memory OS librarian provider slot was busy; extraction was skipped and remains due."
-        ~value:(float_of_int h.provider_slot_busy)
-        ~threshold:provider_slot_busy_threshold
       :: alerts
     else alerts)
   |> List.rev
@@ -163,17 +138,6 @@ let count_lines_in_file path =
 let file_size_bytes path =
   (* NDT-OK: file size is a diagnostic metric. *)
   if not (Sys.file_exists path) then 0 else (Unix.stat path).Unix.st_size
-;;
-
-let provider_slot_busy_for_keeper keeper_id =
-  (* MemoryLaneProviderSlotBusy is emitted through [inc_counter], so values are
-     integral counts even though the metric store carries floats. Keep the JSON
-     field as an int to match the rest of this count-oriented health snapshot. *)
-  Otel_metric_store.metric_value_or_zero
-    provider_slot_busy_metric
-    ~labels:[ "keeper", keeper_id; "site", provider_slot_busy_site ]
-    ()
-  |> int_of_float
 ;;
 
 let duplicate_claim_identity_rows facts =
@@ -221,7 +185,6 @@ let keeper_health ~keepers_dir ~now keeper_id =
       float_of_int events_bytes /. float_of_int (max 1 facts_bytes)
   ; ttl_expired_on_disk = gc_report.ttl_expired
   ; near_duplicate = duplicate_claim_identity_rows facts
-  ; provider_slot_busy = provider_slot_busy_for_keeper keeper_id
   }
 ;;
 
@@ -235,7 +198,6 @@ let keeper_health_entry_to_json (h, alerts) : Yojson.Safe.t =
     ; "events_to_facts_ratio", `Float h.events_to_facts_ratio
     ; "ttl_expired_on_disk", `Int h.ttl_expired_on_disk
     ; "near_duplicate", `Int h.near_duplicate
-    ; "provider_slot_busy", `Int h.provider_slot_busy
     ; "alerts", `List (List.map keeper_alert_to_json alerts)
     ]
 ;;
@@ -282,7 +244,6 @@ let keeper_memory_health_http_json ~base_path : Yojson.Safe.t =
           ; "events_bytes", `Int (sum (fun h -> h.events_bytes))
           ; "ttl_expired_on_disk", `Int (sum (fun h -> h.ttl_expired_on_disk))
           ; "near_duplicate", `Int (sum (fun h -> h.near_duplicate))
-          ; "provider_slot_busy", `Int (sum (fun h -> h.provider_slot_busy))
           ] )
     ; ( "alert_summary"
       , `Assoc
@@ -299,12 +260,10 @@ let keeper_memory_health_http_json ~base_path : Yojson.Safe.t =
                    entries) )
           ; "ttl_expired_keepers", `Int (alert_count_by_code Ttl_expired_on_disk)
           ; "near_duplicate_keepers", `Int (alert_count_by_code Near_duplicate)
-          ; "provider_slot_busy_keepers", `Int (alert_count_by_code Provider_slot_busy)
           ; ( "thresholds"
             , `Assoc
                 [ "ttl_expired_on_disk", `Float ttl_expired_on_disk_threshold
                 ; "near_duplicate", `Float near_duplicate_threshold
-                ; "provider_slot_busy", `Float provider_slot_busy_threshold
                 ] )
           ] )
     ]

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -3445,115 +3445,6 @@ let test_no_category_infers_validity () =
     (Types.Unknown "novel" :: Types.all_categories)
 ;;
 
-let with_env name value f =
-  let old = Sys.getenv_opt name in
-  Unix.putenv name value;
-  Fun.protect ~finally:(fun () -> restore_env name old) f
-;;
-
-let test_librarian_provider_slot_gate_caps_at_capacity () =
-  with_env Env_config.KeeperMemoryOs.librarian_global_slot_env_key "1" (fun () ->
-    with_eio (fun ~sw ~net:_ ~clock ->
-      (* Capacity 1: while one entrant holds the slot, a concurrent entrant drops
-         ([None]) after [provider_slot_wait_sec] instead of blocking — the #21230
-         storm-guard the per-keeper lane keeps as an optional fleet-wide gate. *)
-      let entered, resolve_entered = Eio.Promise.create () in
-      let release, resolve_release = Eio.Promise.create () in
-      let first = ref None in
-      Eio.Fiber.fork ~sw (fun () ->
-        first
-        := Some
-             (Librarian_runtime.with_provider_slot
-                ~keeper_id:"keeper-a"
-                ~clock
-                (fun () ->
-                   Eio.Promise.resolve resolve_entered ();
-                   Eio.Promise.await release;
-                   "ran")));
-      Eio.Promise.await entered;
-      let second =
-        Librarian_runtime.with_provider_slot ~keeper_id:"keeper-a" ~clock (fun () -> "ran")
-      in
-      Eio.Promise.resolve resolve_release ();
-      wait_for_ref ~clock "first slot holder" first;
-      Alcotest.(check (option string))
-        "concurrent entrant drops at capacity 1"
-        None
-        second;
-      Alcotest.(check (option (option string)))
-        "slot holder ran"
-        (Some (Some "ran"))
-        !first))
-;;
-
-let test_librarian_provider_slot_gate_disabled_at_zero () =
-  with_env Env_config.KeeperMemoryOs.librarian_global_slot_env_key "0" (fun () ->
-    with_eio (fun ~sw ~net:_ ~clock ->
-      (* Capacity 0 disables the gate: a held slot does not cap a concurrent
-         entrant — both run ([Some]). *)
-      let entered, resolve_entered = Eio.Promise.create () in
-      let release, resolve_release = Eio.Promise.create () in
-      let first = ref None in
-      Eio.Fiber.fork ~sw (fun () ->
-        first
-        := Some
-             (Librarian_runtime.with_provider_slot
-                ~keeper_id:"keeper-a"
-                ~clock
-                (fun () ->
-                   Eio.Promise.resolve resolve_entered ();
-                   Eio.Promise.await release;
-                   "ran")));
-      Eio.Promise.await entered;
-      let second =
-        Librarian_runtime.with_provider_slot ~keeper_id:"keeper-a" ~clock (fun () -> "ran")
-      in
-      Eio.Promise.resolve resolve_release ();
-      wait_for_ref ~clock "first slot holder" first;
-      Alcotest.(check (option string))
-        "gate disabled: concurrent entrant also ran"
-        (Some "ran")
-        second;
-      Alcotest.(check (option (option string)))
-        "slot holder ran"
-        (Some (Some "ran"))
-        !first))
-;;
-
-let test_librarian_provider_slot_gate_is_per_keeper () =
-  with_env Env_config.KeeperMemoryOs.librarian_global_slot_env_key "1" (fun () ->
-    with_eio (fun ~sw ~net:_ ~clock ->
-      (* Capacity 1 is per keeper: a slot held by keeper-a must not block
-         keeper-b. This is the P0-4 isolation contract. *)
-      let entered, resolve_entered = Eio.Promise.create () in
-      let release, resolve_release = Eio.Promise.create () in
-      let first = ref None in
-      Eio.Fiber.fork ~sw (fun () ->
-        first
-        := Some
-             (Librarian_runtime.with_provider_slot
-                ~keeper_id:"keeper-a"
-                ~clock
-                (fun () ->
-                   Eio.Promise.resolve resolve_entered ();
-                   Eio.Promise.await release;
-                   "ran")));
-      Eio.Promise.await entered;
-      let other_keeper =
-        Librarian_runtime.with_provider_slot ~keeper_id:"keeper-b" ~clock (fun () -> "ran")
-      in
-      Eio.Promise.resolve resolve_release ();
-      wait_for_ref ~clock "first slot holder" first;
-      Alcotest.(check (option string))
-        "different keeper runs despite capacity 1 held"
-        (Some "ran")
-        other_keeper;
-      Alcotest.(check (option (option string)))
-        "slot holder ran"
-        (Some (Some "ran"))
-        !first))
-;;
-
 (* ---------- Explicit validity only ---------- *)
 
 let test_fact_validity_uses_only_stored_value () =
@@ -4919,18 +4810,6 @@ let () =
             "unstructured fallback does not write facts"
             `Quick
             test_librarian_invalid_output_does_not_write_facts
-        ; Alcotest.test_case
-            "provider slot gate caps concurrency at capacity (#21376/#21230)"
-            `Quick
-            test_librarian_provider_slot_gate_caps_at_capacity
-        ; Alcotest.test_case
-            "provider slot gate disabled at capacity 0"
-            `Quick
-            test_librarian_provider_slot_gate_disabled_at_zero
-        ; Alcotest.test_case
-            "provider slot gate isolates keepers (P0-4)"
-            `Quick
-            test_librarian_provider_slot_gate_is_per_keeper
         ] )
     ; ( "rfc-0259 volatile"
       , [ Alcotest.test_case

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -1020,8 +1020,6 @@ let memory_os_knob_readers : (string * (unit -> unit)) list =
   ; ( Env_config.KeeperMemoryOs.librarian_runtime_id_env_key
     , fun () ->
         ignore (Env_config.KeeperMemoryOs.librarian_runtime_id () : string option) )
-  ; ( Env_config.KeeperMemoryOs.librarian_global_slot_env_key
-    , fun () -> ignore (Env_config.KeeperMemoryOs.librarian_global_slot () : int) )
   ; ( Env_config.KeeperMemoryOs.gc_env_key
     , fun () -> ignore (Env_config.KeeperMemoryOs.gc_enabled () : bool) )
   ; ( Env_config.KeeperMemoryOs.consolidation_env_key

--- a/test/test_keeper_memory_write.ml
+++ b/test/test_keeper_memory_write.ml
@@ -4,6 +4,7 @@ module Runtime = Masc.Keeper_tool_memory_runtime
 module Bank = Masc.Keeper_memory_bank
 module Work_request = Masc.Keeper_memory_work_request
 module Work_store = Masc.Keeper_memory_work_store
+module Work_drain = Masc.Keeper_memory_work_drain
 
 let make_args ~kind ~title ~content =
   `Assoc
@@ -416,6 +417,56 @@ let test_memory_work_store_claim_settle_recovery () =
       Alcotest.fail "third request did not progress after failure")
 ;;
 
+let test_memory_work_drain_exact_settlement () =
+  with_temp_dir (fun base_path ->
+    let meta = make_meta "durable-memory-drain" in
+    let make_request turn =
+      Work_request.make
+        ~keeper_name:meta.name
+        ~generation:meta.runtime.generation
+        ~turn
+        ~runtime_id:(Printf.sprintf "runtime.drain.%d" turn)
+        ~meta
+        ~tool_results:[]
+        ~librarian_messages:[]
+        ~deliberation_execution:None
+      |> Result.get_ok
+    in
+    let first, second = make_request 1, make_request 2 in
+    List.iter
+      (fun request ->
+         Work_store.enqueue ~base_path request
+         |> Result.map_error Work_store.error_to_string
+         |> Result.get_ok
+         |> ignore)
+      [ first; second ];
+    let observed = ref [] in
+    let execute request =
+      observed := Work_request.request_id request :: !observed;
+      if Work_request.turn request = 2 then Error "provider unavailable" else Ok ()
+    in
+    let report =
+      Work_drain.drain ~base_path ~keeper_name:meta.name ~execute
+      |> Result.map_error Work_drain.error_to_string
+      |> Result.get_ok
+    in
+    Alcotest.(check (list string))
+      "exact execution order"
+      (List.map Work_request.request_id [ first; second ])
+      (List.rev !observed);
+    Alcotest.(check int) "completed" 1 report.completed;
+    Alcotest.(check int) "failed" 1 report.failed;
+    let terminal =
+      Work_store.terminal ~base_path ~keeper_name:meta.name
+      |> Result.map_error Work_store.error_to_string
+      |> Result.get_ok
+    in
+    (match List.map (fun item -> item.Work_store.outcome) terminal with
+     | [ Work_store.Completed; Work_store.Failed "provider unavailable" ] -> ()
+     | _ -> Alcotest.fail "terminal outcome or order mismatch");
+    Alcotest.(check int) "both outcomes durable" 2 (List.length terminal))
+;;
+
 let () =
   Alcotest.run
     "keeper_memory_write"
@@ -448,6 +499,10 @@ let () =
             "durable work store claim settle recovery"
             `Quick
             test_memory_work_store_claim_settle_recovery
+        ; Alcotest.test_case
+            "durable work drain exact settlement"
+            `Quick
+            test_memory_work_drain_exact_settlement
         ] )
     ]
 ;;

--- a/test/test_server_dashboard_http_keeper_memory_health.ml
+++ b/test/test_server_dashboard_http_keeper_memory_health.ml
@@ -2,9 +2,6 @@
 
 module Types = Masc.Keeper_memory_os_types
 module Io = Masc.Keeper_memory_os_io
-module Metrics = Masc.Otel_metric_store
-module KeeperMetrics = Keeper_metrics
-module LibrarianRuntime = Masc.Keeper_librarian_runtime
 module Health = Server_dashboard_http_keeper_memory_health
 
 let test_now = 1_700_000_000.0
@@ -175,7 +172,6 @@ let test_reports_per_keeper_metric_values () =
     (float_field "events_to_facts_ratio" k);
   Alcotest.(check int) "nothing expired" 0 (int_field "ttl_expired_on_disk" k);
   Alcotest.(check int) "no duplicates" 0 (int_field "near_duplicate" k);
-  Alcotest.(check int) "no provider slot busy skips" 0 (int_field "provider_slot_busy" k);
   Alcotest.(check int) "no keeper alerts" 0 (List.length (list_field "alerts" k));
   Alcotest.(check int) "totals.facts" 2 (int_field "facts" (totals json));
   Alcotest.(check bool)
@@ -234,52 +230,6 @@ let test_health_reports_expiry_and_exact_duplicate_identity () =
   (* dry_run must NOT rewrite the store: a fresh read still sees all 4 rows. *)
   let reread = Io.read_facts_all_for_keepers_dir ~keepers_dir ~keeper_id:"gc" in
   Alcotest.(check int) "store untouched by dry-run gc" 4 (List.length reread)
-;;
-
-let test_reports_provider_slot_busy_metric_as_alert () =
-  Eio_main.run
-  @@ fun _env ->
-  let now = test_now in
-  let base = fresh_dir "masc-memory-health-provider-slot" in
-  (* Otel_metric_store is process-global. Use a temp-derived keeper label so
-     repeated test runs in one process cannot inherit this counter cell. *)
-  let keeper_id = "slotbusy-health-" ^ Filename.basename base in
-  let keepers_dir = Config_dir_resolver.keepers_dir_for_base_path ~base_path:base in
-  Io.rewrite_facts_atomically_for_keepers_dir
-    ~keepers_dir
-    ~keeper_id
-    [ fact ~now "slot busy metric keeper fact" ];
-  Metrics.inc_counter
-    KeeperMetrics.(to_string MemoryLaneProviderSlotBusy)
-    ~labels:
-      [ "keeper", keeper_id
-      ; "site", LibrarianRuntime.memory_os_librarian_provider_slot_site
-      ]
-    ~delta:3.0
-    ();
-  let json = Health.keeper_memory_health_http_json ~base_path:base in
-  let k = keeper_obj keeper_id json in
-  Alcotest.(check int) "provider slot busy projected" 3 (int_field "provider_slot_busy" k);
-  Alcotest.(check int)
-    "totals provider slot busy"
-    3
-    (int_field "provider_slot_busy" (totals json));
-  let alerts = list_field "alerts" k in
-  Alcotest.(check (list string))
-    "provider slot alert code"
-    [ "provider_slot_busy" ]
-    (List.map (string_field "code") alerts);
-  Alcotest.(check (list string))
-    "provider slot alert target"
-    [ "provider_slot_busy" ]
-    (List.map (string_field "target") alerts);
-  Alcotest.(check (list string))
-    "provider slot alert label"
-    [ "슬롯" ]
-    (List.map (string_field "label") alerts);
-  let summary = alert_summary json in
-  Alcotest.(check int) "summary provider slot keepers" 1 (int_field "provider_slot_busy_keepers" summary);
-  Alcotest.(check int) "summary total alerts" 1 (int_field "total_alerts" summary)
 ;;
 
 let test_sorts_keepers_by_facts_bytes_desc () =
@@ -353,10 +303,6 @@ let () =
             "dry-run gc reports expired and duplicate rows"
             `Quick
             test_health_reports_expiry_and_exact_duplicate_identity
-        ; Alcotest.test_case
-            "reports provider slot busy metric as alert"
-            `Quick
-            test_reports_provider_slot_busy_metric_as_alert
         ; Alcotest.test_case
             "sorts keepers by facts_bytes descending"
             `Quick


### PR DESCRIPTION
## Stack

Base: #24739 (`codex/memory-provider-slot-contract-purge-c3b1-20260716`)

## What changed

- hard-delete the per-Keeper semaphore registry, the 0.25s acquisition timeout/drop path, `Provider_slot_busy`, and the associated environment knob/catalog entry
- call the typed librarian provider operation directly; no replacement timeout, slot, concurrency heuristic, or permissive fallback was introduced
- keep production ownership in the existing durable per-Keeper Memory lane

## Ownership proof

- the only production caller of `execute_operation` is `lib/keeper/keeper_agent_run_post_turn_memory.ml:44`
- the immutable request is durably enqueued at `keeper_agent_run_post_turn_memory.ml:141`; drain scheduling occurs only after enqueue succeeds at line 153
- `keeper_memory_work_drain.ml:25-38` recovers/claims the Keeper-owned request before execution, and lines 59-65 settle the exact terminal outcome
- `test_keeper_memory_lane` proves one FIFO worker per Keeper and independent progress across Keepers

Exact residue search over `lib test config docs/runtime-tunables.md` returns zero matches for the removed slot APIs, error, metric, site label, and environment key.

## Verification

- env knob catalog regeneration: success
- focused build: `test_keeper_memory_write.exe`, `test_keeper_memory_lane.exe`, `test_keeper_librarian_retry.exe`, `test_keeper_memory_os.exe`
- Memory durable work: 9/9
- Keeper lane: 10/10
- Librarian operation/retry/cadence/parser: 32/32
- relevant Memory OS config/runtime cases: 5/5
- `git diff --check`: clean

Full repository build remains CI-owned.