### PR TITLE
refactor(keeper): hard-cut librarian turn cadence

### DIFF
--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -38,127 +38,8 @@ let enabled () =
   Env_config.KeeperMemoryOs.librarian_enabled ()
 ;;
 
-(* Librarian extraction cadence (per keeper).
-
-   Memory extraction runs once per keeper turn by default, which means every
-   keeper issues a provider-backed LLM extraction every turn against a shared
-   inference pool. That per-turn LLM load — not the lack of a concurrency gate —
-   is the dominant source of the librarian empty-response saturation observed
-   2026-06-16 (HTTP 200 empty body under pool contention). The fleet-wide
-   [provider_slot] only masked it by dropping (skip) most attempts.
-
-   Extract once every [cadence_turns ()] turns per keeper instead. The extraction
-   window ([max_messages ()], default 24) already spans several recent turns, so
-   batching over a small cadence is a deferral, not a loss: a skipped turn's
-   messages are still in the window at the next due turn. Cadence must stay small
-   relative to [max_messages ()] or early turns can scroll out of the window.
-
-   Tradeoff: recall in turns between extractions sees slightly staler memory
-   (a turn's freshly-produced fact is not extracted until the next due turn).
-   Memory extraction is best-effort, so this eventual-consistency is acceptable.
-
-   Set MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS=1 to restore per-turn
-   extraction (the previous behavior). *)
-let cadence_turns () =
-  Env_config.KeeperMemoryOs.librarian_cadence_turns ()
-;;
-
-(* Per-keeper "turns since last successful extraction" counter, paired with the
-   trace it belongs to. Keyed by [keeper_id] (the long-lived owner), NOT by
-   (keeper_id, trace_id): trace_id rotates on every keeper run, so a pair-keyed
-   table mints a fresh row per rotation and never reclaims the previous one,
-   growing without bound over the process lifetime. Keying by keeper_id bounds
-   the table to one row per live keeper; a rotated trace is detected as a stored
-   mismatch and resets the schedule in place.
-
-   [Eio_guard.with_mutex]: the cadence table is reachable from concurrent keeper
-   fibers, and a blocking stdlib mutex can stall unrelated Eio work if a fiber
-   holds that lock while waiting on another Eio resource. [Eio_guard] gives
-   runtime fibers cooperative locking while preserving a direct path for focused
-   tests that call the pure cadence helpers before the Eio runtime is enabled. *)
-let cadence_mu = Eio.Mutex.create ()
-let cadence_counters : (string, string * int) Hashtbl.t = Hashtbl.create 16
-
-(* A counter value below 0 means the keeper has never had a successful
-   extraction on the current trace: the next turn is due immediately. *)
-let fresh_counter = -1
-
-(* Pure cadence decision. Given the keeper's current [counter] (turns since its
-   last successful extraction) and the [cadence], return the updated counter and
-   whether extraction is due now.
-
-   - counter < 0 (fresh) is due immediately.
-   - cadence <= 1 is always due with the counter pinned at 0.
-   - When due, the counter is set to [cadence] and stays there until
-     [cadence_record_success] or [cadence_record_attempt] resets it to 0. This
-     keeps the keeper due across skipped work, while completed non-success
-     provider attempts can defer the next attempt to the cadence window instead
-     of retrying on every keeper turn. *)
-let cadence_step ~cadence ~counter =
-  if cadence <= 1
-  then 0, true
-  else if counter < 0
-  then cadence, true
-  else (
-    let next = counter + 1 in
-    if next >= cadence then cadence, true else next, false)
-;;
-
-(* Pure keyed cadence decision. Given a keeper's [prior] stored (trace, counter)
-   and the [current_trace], a stored entry from a different (rotated) trace is
-   treated as fresh — due immediately, not inheriting the old trace's schedule —
-   exactly like an unseen keeper ([prior = None]). Returns the value to store and
-   whether extraction is due now. Exposed for testing the rollover decision
-   without the global table. *)
-let cadence_step_keyed ~cadence ~current_trace ~prior =
-  let counter =
-    (* sound-partial: allow — an unseen keeper or a rotated trace is fresh
-       (due immediately via [fresh_counter]); fresh-state init, not a default
-       hiding a parse error. *)
-    match prior with
-    | Some (t, c) when String.equal t current_trace -> c
-    | _ -> fresh_counter
-  in
-  let updated, due = cadence_step ~cadence ~counter in
-  (current_trace, updated), due
-;;
-
-let cadence_due ~keeper_id ~trace_id =
-  Eio_guard.with_mutex cadence_mu (fun () ->
-    let prior = Hashtbl.find_opt cadence_counters keeper_id in
-    let value, due =
-      cadence_step_keyed ~cadence:(cadence_turns ()) ~current_trace:trace_id ~prior
-    in
-    Hashtbl.replace cadence_counters keeper_id value;
-    due)
-;;
-
-let cadence_record_success ~keeper_id ~trace_id =
-  Eio_guard.with_mutex cadence_mu (fun () ->
-    Hashtbl.replace cadence_counters keeper_id (trace_id, 0))
-;;
-
-let cadence_record_attempt ~keeper_id ~trace_id =
-  Eio_guard.with_mutex cadence_mu (fun () ->
-    Hashtbl.replace cadence_counters keeper_id (trace_id, 0))
-;;
-
-(* Live per-keeper cadence rows. Bounded by the number of keepers that have run
-   (one row each), so it doubles as a leak-regression signal: it must not grow
-   with trace rotations. Read-only; consumed by the cadence test and the
-   dashboard memory-health panel. *)
-let cadence_counter_entries () =
-  Eio_guard.with_mutex_ro cadence_mu (fun () -> Hashtbl.length cadence_counters)
-;;
-
 let max_messages () =
   Env_config.KeeperMemoryOs.librarian_max_messages ()
-;;
-
-(* Scale the prompt window by the cadence so skipped turns stay visible until
-   the next due extraction. Without this, a tool-heavy skipped turn can scroll
-   out of the per-turn cap before its first successful extraction. *)
-let prompt_max_messages () = max_messages () * cadence_turns ()
 ;;
 
 let default_timeout_sec () =
@@ -360,19 +241,6 @@ type parse_retry_error =
   | Retry_exhausted_unparseable of unparseable_response
   | Retry_transport_failed of extraction_error
 
-let should_record_cadence_backoff_after_error = function
-  | Provider_timeout
-  | Provider_transport_failed _
-  | Provider_empty_response
-  | Provider_unparseable_response _ ->
-    true
-  | Provider_clock_unavailable
-  | Provider_config_rejected _
-  | Prompt_render_failed _
-  | Memory_fact_upsert_failed _ ->
-    false
-;;
-
 let prefer_unparseable_response prior current =
   match current.raw_evidence with
   | Some raw when not (String.equal (String.trim raw) "") -> current
@@ -413,7 +281,7 @@ let render_prompt key variables =
 
 let messages_for_librarian (inp : Keeper_librarian.input) =
   let input =
-    { inp with messages = select_recent_messages ~max_messages:(prompt_max_messages ()) inp.messages }
+    { inp with messages = select_recent_messages ~max_messages:(max_messages ()) inp.messages }
   in
   match render_prompt Keeper_prompt_names.librarian_system [] with
   | Error _ as e -> e

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -16,78 +16,8 @@ type complete_fn =
 val enabled : unit -> bool
 (** Opt-in gate controlled by [MASC_KEEPER_MEMORY_OS_LIBRARIAN]. *)
 
-val cadence_turns : unit -> int
-(** Turns between librarian extractions per keeper. Default 3, floored at 1,
-    overridable with [MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS]. 1 restores
-    per-turn extraction. *)
-
-val cadence_step : cadence:int -> counter:int -> int * bool
-(** Pure cadence decision. [(updated_counter, due)] for a keeper whose counter
-    (turns since last successful extraction) is [counter] under [cadence].
-    [counter < 0] is treated as fresh and is due immediately.
-    cadence<=1 is always due with the counter pinned at 0. When due, the updated
-    counter is set to [cadence] and stays there until [cadence_record_success] or
-    [cadence_record_attempt] resets it. Skipped work leaves the counter due;
-    completed non-success attempts may be recorded to wait for the next cadence
-    window. Exposed for testing the cadence logic without the per-keeper counter
-    table. *)
-
-val cadence_step_keyed
-  :  cadence:int
-  -> current_trace:string
-  -> prior:(string * int) option
-  -> (string * int) * bool
-(** Pure keyed cadence decision. Given a keeper's [prior] stored
-    [(trace, counter)] and the [current_trace], returns the [(trace, counter)]
-    value to store and whether extraction is due now. A [prior] from a different
-    (rotated) trace, or [None], is treated as fresh — due immediately, not
-    inheriting the old trace's schedule. Exposed for testing the rollover
-    decision without the global table. *)
-
-val cadence_due : keeper_id:string -> trace_id:string -> bool
-(** Advance the persistent cadence counter for [keeper_id] by one turn and
-    report whether extraction is due now. The counter is keyed by [keeper_id]
-    and stores the active [trace_id] alongside it, so a handoff rollover (a new
-    [trace_id]) resets the cadence cycle in place — bounding the table to one
-    row per keeper. First call for an unseen keeper, or the first call after a
-    rollover, is due immediately. Explicit operations do not consult this
-    legacy scheduler state.
-
-    Uses [Eio_guard.with_mutex] so runtime fibers take a cooperative mutex while
-    focused pre-Eio tests keep a direct single-threaded path. *)
-
-val cadence_record_success : keeper_id:string -> trace_id:string -> unit
-(** Record a successful structured extraction for [keeper_id] on [trace_id] so
-    the cadence counter resets and the next cycle can begin. Must only be called
-    after a due turn actually produced a structured episode; skipped, failed, or
-    unparseable provider attempts must not call this.
-
-    Uses [Eio_guard.with_mutex] so runtime fibers take a cooperative mutex while
-    focused pre-Eio tests keep a direct single-threaded path. *)
-
-val cadence_record_attempt : keeper_id:string -> trace_id:string -> unit
-(** Record a completed non-success extraction attempt for [keeper_id] on
-    [trace_id] so transient provider failures and unparseable structured-output
-    failures do not immediately retry every keeper turn. This intentionally does
-    not mark the extraction as semantically successful. Skipped work such as a
-    busy provider slot must not call this, because no provider attempt happened.
-
-    Uses [Eio_guard.with_mutex] so runtime fibers take a cooperative mutex while
-    focused pre-Eio tests keep a direct single-threaded path. *)
-
-val cadence_counter_entries : unit -> int
-(** Number of live per-keeper cadence rows. Bounded by the number of keepers
-    that have run (one row each), independent of trace rotations — so it is the
-    leak-regression signal for the keeper-keyed cadence table and a memory-health
-    metric for the dashboard. Read-only.
-
-    Uses [Eio_guard.with_mutex_ro] so runtime fibers take a cooperative mutex
-    while focused pre-Eio tests keep a direct single-threaded path. *)
-
 val max_messages : unit -> int
-(** Base per-turn cap on checkpoint messages sent to the librarian prompt. The
-    effective prompt window is this value scaled by [cadence_turns] so skipped
-    turns are not evicted before the next due extraction. *)
+(** Exact cap on checkpoint messages sent to one librarian operation. *)
 
 val default_timeout_sec : unit -> float
 (** Provider timeout for post-turn extraction. Defaults to
@@ -159,11 +89,6 @@ type attempt_outcome =
 type parse_retry_error =
   | Retry_exhausted_unparseable of unparseable_response
   | Retry_transport_failed of extraction_error
-
-val should_record_cadence_backoff_after_error : extraction_error -> bool
-(** Whether an extraction error represents enough completed work to defer the
-    next attempt until the next cadence window. Only completed provider-attempt
-    failures should defer cadence; local deterministic failures stay due. *)
 
 val run_with_parse_retries
   :  max_retries:int
@@ -263,7 +188,7 @@ val execute_operation
   -> (Keeper_memory_os_types.episode, operation_error) result
 (** Execute one explicitly requested LLM Memory operation.
 
-    This boundary does not consult the retired enable/cadence policy and never
+    This boundary does not consult the legacy enable flag and never
     converts failure into [unit]. Cancellation propagates; every other outcome
     is returned to its caller. Production execution is claimed by the durable
     per-Keeper owner drain before entering this function; no provider-slot drop

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -860,6 +860,41 @@ let with_memory_os_env name value f =
   Fun.protect ~finally:(fun () -> restore_env name old) f
 ;;
 
+let test_librarian_runtime_uses_exact_message_cap () =
+  with_prompt_registry (fun () ->
+    with_memory_os_env
+      Env_config.KeeperMemoryOs.librarian_max_messages_env_key
+      "2"
+      (fun () ->
+         let input : Librarian.input =
+           { trace_id = "trace-exact-message-cap"
+           ; generation = 1
+           ; messages =
+               [ text_message "oldest-message-must-be-dropped"
+               ; text_message "recent-message-one"
+               ; text_message "recent-message-two"
+               ]
+           }
+         in
+         match Librarian_runtime.messages_for_librarian input with
+         | Error error -> Alcotest.fail error
+         | Ok [ _system; user ] ->
+           let prompt = message_text user in
+           Alcotest.(check bool)
+             "configured cap drops the oldest message"
+             false
+             (contains "oldest-message-must-be-dropped" prompt);
+           Alcotest.(check bool)
+             "configured cap keeps the first selected message"
+             true
+             (contains "recent-message-one" prompt);
+           Alcotest.(check bool)
+             "configured cap keeps the newest message"
+             true
+             (contains "recent-message-two" prompt)
+         | Ok _ -> Alcotest.fail "librarian prompt must contain system and user messages"))
+;;
+
 let with_captured_console_lines f =
   Console_sink.For_testing.reset ();
   let lines = ref [] in
@@ -4443,6 +4478,10 @@ let () =
             "librarian prompt omits private blocks"
             `Quick
             test_librarian_prompt_omits_private_blocks
+        ; Alcotest.test_case
+            "librarian runtime uses exact message cap"
+            `Quick
+            test_librarian_runtime_uses_exact_message_cap
         ; Alcotest.test_case
             "librarian rejects extra confidence field"
             `Quick


### PR DESCRIPTION
## Stack

Base: #24743 (`codex/memory-cadence-runtime-purge-c3c1-20260716`)

## What changed

- hard-delete the orphan cadence mutex, mutable counter table, due/reset helpers, and provider-error backoff classifier
- remove the implicit `max_messages * cadence_turns` prompt-window expansion
- make each explicitly claimed Memory operation use the configured `librarian_max_messages` value as its exact cap
- add a behavioral test proving cap=2 drops the oldest message and sends exactly the two most recent messages to the LLM prompt

No timer, turn counter, backoff window, replacement limit, or concurrency heuristic was introduced. Durable per-Keeper enqueue/claim/drain/settle remains the only production execution ownership path.

## Residue proof

After this change, `keeper_librarian_runtime.ml/.mli` contains zero cadence, cadence-counter, prompt-multiplier, or cadence-backoff symbols. The now-orphan configuration keys are intentionally removed in the next <=399-line stack so generated catalog churn stays reviewable.

## Verification

- focused build: Memory OS and librarian retry executables
- exact message-cap regression: 1/1
- relevant provider execution/failure cases: 3/3
- librarian operation/retry/parser: 21/21
- OCaml parse and format checks: pass
- test coverage checker and `git diff --check`: pass

Full repository build remains CI-owned.