### PR TITLE
feat(fusion): resume durable recovery on boot

### DIFF
--- a/lib/fusion/fusion_tool.ml
+++ b/lib/fusion/fusion_tool.ml
@@ -90,6 +90,30 @@ type orchestrator_runner =
   -> unit
   -> Fusion_orchestrator.outcome
 
+let fork_operation ~run_orchestrator ~sw ~net ~base_dir ~policy operation =
+  let request = operation.Fusion_types.request in
+  let keeper = request.keeper in
+  let run_id = request.run_id in
+  Eio.Fiber.fork ~sw (fun () ->
+    match
+      run_orchestrator ~sw ~net ~base_dir ~policy ~topology:operation.topology
+        ~request ()
+    with
+    | Fusion_orchestrator.Completed _ -> ()
+    | Fusion_orchestrator.Denied reason ->
+      append_chat_failure ~base_dir ~keeper ~run_id ~failure_code:"denied"
+        (Printf.sprintf "**Fusion run `%s`** _(denied after start: %s)_" run_id
+           (Fusion_types.deny_reason_label reason))
+    | Fusion_orchestrator.Sink_failed detail ->
+      append_chat_failure ~base_dir ~keeper ~run_id ~failure_code:"sink_failed"
+        (Printf.sprintf "**Fusion run `%s`** _(sink failed: %s)_" run_id detail)
+    | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
+    | exception exn ->
+      append_chat_failure ~base_dir ~keeper ~run_id ~failure_code:"aborted"
+        (Printf.sprintf "**Fusion run `%s`** _(aborted: %s)_" run_id
+           (Printexc.to_string exn)))
+;;
+
 type execution_start_error =
   | Claim_failed of Fusion_run_registry.claim_error
   | Start_failed of Fusion_run_registry.start_error
@@ -107,6 +131,61 @@ let claim_and_start registry operation_id =
   in
   Fusion_run_registry.start_claimed registry claim
   |> Result.map_error (fun error -> Start_failed error)
+;;
+
+type recovery_failure =
+  | Completion_address_unavailable of Fusion_wake_route.error
+  | Recovery_claim_failed of Fusion_run_registry.claim_error
+  | Recovery_start_failed of Fusion_run_registry.start_error
+
+type recovery_report =
+  { started : int
+  ; failures : (string * recovery_failure) list
+  }
+
+let recovery_failure_to_string = function
+  | Completion_address_unavailable error -> Fusion_wake_route.error_to_string error
+  | Recovery_claim_failed error -> Fusion_run_registry.claim_error_to_string error
+  | Recovery_start_failed error -> Fusion_run_registry.start_error_to_string error
+;;
+
+let recovery_failure_of_start = function
+  | Claim_failed error -> Recovery_claim_failed error
+  | Start_failed error -> Recovery_start_failed error
+;;
+
+let recover_required_with_runner ~run_orchestrator ~sw ~net ~base_dir ~policy =
+  let registry = Fusion_run_registry.global () in
+  Fusion_run_registry.list_runs registry
+  |> List.fold_left
+       (fun report (run : Fusion_run_registry.run) ->
+         match run.status with
+         | Running | Completed _ -> report
+         | Recovery_required _ ->
+           let operation_id = Fusion_run_registry.operation_id run in
+           let prepared =
+             let ( let* ) = Result.bind in
+             let* () =
+               Fusion_wake_route.validate_registered_address operation_id
+               |> Result.map_error (fun error -> Completion_address_unavailable error)
+             in
+             claim_and_start registry operation_id
+             |> Result.map_error recovery_failure_of_start
+           in
+           (match prepared with
+            | Error error ->
+              Log.Misc.error "fusion recovery unavailable %s: %s" operation_id
+                (recovery_failure_to_string error);
+              { report with failures = (operation_id, error) :: report.failures }
+            | Ok operation ->
+              fork_operation ~run_orchestrator ~sw ~net ~base_dir ~policy operation;
+              { report with started = report.started + 1 }))
+       { started = 0; failures = [] }
+  |> fun report -> { report with failures = List.rev report.failures }
+;;
+
+let recover_required =
+  recover_required_with_runner ~run_orchestrator:Fusion_orchestrator.run
 ;;
 
 let handle_with_runner_result ~run_orchestrator ~sw ~net ~base_dir ~keeper ~now_unix ~run_id
@@ -211,8 +290,6 @@ let handle_with_runner_result ~run_orchestrator ~sw ~net ~base_dir ~keeper ~now_
            ; ("error", `String reason)
            ]
        | Ok operation ->
-      let allowed = operation.Fusion_types.request in
-      let topology = operation.topology in
       (* RFC-0266 §7 Phase 4: push the new [Running] card to the dashboard panel
          (no polling). wake-free, broadcast-failure-safe; see
          Fusion_sink.broadcast_run_status. *)
@@ -221,26 +298,7 @@ let handle_with_runner_result ~run_orchestrator ~sw ~net ~base_dir ~keeper ~now_
          배경 fiber 실패/거부/싱크 실패는 동일한 chat lane에 기록해 started-but-failed
          상태가 남지 않도록 한다. 호출자는 이 fiber가 키퍼 턴보다 오래 살아도록 root
          switch를 sw로 넘긴다 (turn switch면 턴 종료 시 심의가 취소됨). *)
-      Eio.Fiber.fork ~sw (fun () ->
-        match
-          run_orchestrator ~sw ~net ~base_dir ~policy ~topology ~request:allowed ()
-        with
-        | Fusion_orchestrator.Completed _ -> ()
-        | Fusion_orchestrator.Denied reason ->
-          append_chat_failure ~base_dir ~keeper ~run_id ~failure_code:"denied"
-            (Printf.sprintf "**Fusion run `%s`** _(denied after start: %s)_" run_id
-               (Fusion_types.deny_reason_label reason))
-        | Fusion_orchestrator.Sink_failed msg ->
-          append_chat_failure ~base_dir ~keeper ~run_id ~failure_code:"sink_failed"
-            (Printf.sprintf "**Fusion run `%s`** _(sink failed: %s)_" run_id msg)
-        | exception (Eio.Cancel.Cancelled _ as exn) ->
-          (* Root-switch cancellation is not a terminal Fusion outcome. The
-             durable Started claim remains replayable by the next process. *)
-          raise exn
-        | exception exn ->
-          append_chat_failure ~base_dir ~keeper ~run_id ~failure_code:"aborted"
-            (Printf.sprintf "**Fusion run `%s`** _(aborted: %s)_" run_id
-               (Printexc.to_string exn)));
+      fork_operation ~run_orchestrator ~sw ~net ~base_dir ~policy operation;
       (* [delivery] 필드는 도구 결과의 async 계약을 명시한다: 완료 시 키퍼는
          [Fusion_completed] wake로 깨워지고 결론/실패 사유가 chat lane에 durable하게
          남는다. 2026-07-01 관측: 이 계약이 결과 JSON에 없어서 키퍼들이 3-5초 간격
@@ -280,6 +338,8 @@ let handle ~sw ~net ~base_dir ~keeper ~now_unix ~run_id ~policy ?continuation_ch
 
 module For_test = struct
   type nonrec orchestrator_runner = orchestrator_runner
+
+  let recover_required_with_runner = recover_required_with_runner
 
   let handle_with_runner ~run_orchestrator ~sw ~net ~base_dir ~keeper ~now_unix
         ~run_id ~policy ?continuation_channel ~args () =

--- a/lib/fusion/fusion_tool.mli
+++ b/lib/fusion/fusion_tool.mli
@@ -9,6 +9,21 @@
 
     설계 SSOT: docs/rfc/RFC-0252-fusion-panel-judge-deliberation.md §4/§6 *)
 
+type recovery_failure =
+  | Completion_address_unavailable of Fusion_wake_route.error
+  | Recovery_claim_failed of Fusion_run_registry.claim_error
+  | Recovery_start_failed of Fusion_run_registry.start_error
+
+type recovery_report =
+  { started : int
+  ; failures : (string * recovery_failure) list
+  }
+
+val recovery_failure_to_string : recovery_failure -> string
+val recover_required :
+  sw:Eio.Switch.t -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  base_dir:string -> policy:Fusion_policy.t -> recovery_report
+
 (** [masc_fusion] 호출 처리. status JSON 문자열을 반환한다.
 
     @param now_unix 현재 유닉스초 (키퍼 clock에서; run 시작 시각 기록).
@@ -59,6 +74,11 @@ module For_test : sig
     -> request:Fusion_types.fusion_request
     -> unit
     -> Fusion_orchestrator.outcome
+
+  val recover_required_with_runner :
+    run_orchestrator:orchestrator_runner -> sw:Eio.Switch.t ->
+    net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t -> base_dir:string ->
+    policy:Fusion_policy.t -> recovery_report
 
   (** [handle]과 같은 계약이되 background runner를 명시적으로 받는다.
 

--- a/lib/fusion/fusion_wake_route.ml
+++ b/lib/fusion/fusion_wake_route.ml
@@ -9,6 +9,15 @@ type route =
 type error =
   | Outbox_error of Outbox.error
   | Invalid_address of { operation_id : string; detail : string }
+  | Operation_unavailable of string
+  | Owner_mismatch of
+      { operation_id : string
+      ; expected_owner : string
+      ; registered_owner : string
+      }
+  | Completion_state_conflict of
+      { operation_id : string; registry_ok : bool; outbox_ok : bool }
+  | Registry_completion_failed of Fusion_run_registry.completion_error
   | Lane_commit_failed of { operation_id : string; owner : string; detail : string }
 
 type delivery_receipt = Delivered | Already_delivered
@@ -19,6 +28,16 @@ let error_to_string = function
   | Outbox_error error -> Outbox.error_to_string error
   | Invalid_address { operation_id; detail } ->
     Printf.sprintf "fusion address decode failed %s: %s" operation_id detail
+  | Operation_unavailable operation_id ->
+    Printf.sprintf "fusion canonical operation unavailable %s" operation_id
+  | Owner_mismatch { operation_id; expected_owner; registered_owner } ->
+    Printf.sprintf "fusion address owner mismatch %s: expected=%s registered=%s"
+      operation_id expected_owner registered_owner
+  | Completion_state_conflict { operation_id; registry_ok; outbox_ok } ->
+    Printf.sprintf "fusion completion conflict %s: registry=%b outbox=%b"
+      operation_id registry_ok outbox_ok
+  | Registry_completion_failed error ->
+    Fusion_run_registry.completion_error_to_string error
   | Lane_commit_failed { operation_id; owner; detail } ->
     Printf.sprintf "fusion lane commit failed %s/%s: %s" operation_id owner detail
 ;;
@@ -28,25 +47,74 @@ let address_of_route route =
     (Yojson.Safe.to_string (route_to_yojson route))
 ;;
 
-let route_of_item (item : Outbox.item) =
-  let raw = Outbox.Completion_address.to_opaque_string item.address in
+let route_of_address ~operation_id address =
+  let raw = Outbox.Completion_address.to_opaque_string address in
   try
     Yojson.Safe.from_string raw
     |> route_of_yojson
-    |> Result.map_error (fun detail -> Invalid_address { operation_id = item.operation_id; detail })
+    |> Result.map_error (fun detail -> Invalid_address { operation_id; detail })
   with
-  | exn -> Error (Invalid_address { operation_id = item.operation_id; detail = Printexc.to_string exn })
+  | exn -> Error (Invalid_address { operation_id; detail = Printexc.to_string exn })
+;;
+
+let registered_route operation_id =
+  match Outbox.registered_address (Outbox.global ()) ~operation_id with
+  | None -> Error (Outbox_error (Outbox.Unknown_address operation_id))
+  | Some address -> route_of_address ~operation_id address
+;;
+
+let validate_known_owner ~operation_id route =
+  match Fusion_run_registry.get (Fusion_run_registry.global ()) ~operation_id with
+  | None -> Error (Operation_unavailable operation_id)
+  | Some run ->
+    let owner = Fusion_run_registry.keeper run in
+    if String.equal owner route.owner
+    then Ok ()
+    else
+      Error
+        (Owner_mismatch
+           { operation_id; expected_owner = owner; registered_owner = route.owner })
+;;
+
+let validate_registered_address operation_id =
+  let ( let* ) = Result.bind in
+  let* route = registered_route operation_id in
+  validate_known_owner ~operation_id route
 ;;
 
 let register ~operation_id ~owner ~channel =
-  Outbox.register_address (Outbox.global ()) ~operation_id
-    (address_of_route { owner; channel })
-  |> Result.map_error (fun error -> Outbox_error error)
+  let route = { owner; channel } in
+  match validate_known_owner ~operation_id route with
+  | Error _ as error -> error
+  | Ok () ->
+    Outbox.register_address (Outbox.global ()) ~operation_id (address_of_route route)
+    |> Result.map_error (fun error -> Outbox_error error)
 ;;
 
 let completion ~ok ~content ~evidence_ref =
   let payload : Outbox.completion_payload = { content; evidence_ref } in
   if ok then Outbox.Succeeded payload else Outbox.Failed payload
+;;
+
+let ensure_registry_completion ~operation_id ~ok (payload : Outbox.completion_payload) =
+  let persist ?failure ?failure_code () =
+    Fusion_run_registry.mark_completed (Fusion_run_registry.global ())
+      ~operation_id ?failure ?failure_code ~ok ()
+    |> Result.map_error (fun error -> Registry_completion_failed error)
+  in
+  match Fusion_run_registry.get (Fusion_run_registry.global ()) ~operation_id with
+  | None -> Ok ()
+  | Some { status = (Running | Recovery_required _); _ } ->
+    persist ?failure:(if ok then None else Some payload.content) ()
+  | Some { status = Completed { ok = registry_ok; receipt = Durable; _ }; _ }
+    when Bool.equal registry_ok ok -> Ok ()
+  | Some
+      { status = Completed { ok = registry_ok; receipt = Persistence_failed _; failure; failure_code }
+      ; _
+      }
+    when Bool.equal registry_ok ok -> persist ?failure ?failure_code ()
+  | Some { status = Completed { ok = registry_ok; _ }; _ } ->
+    Error (Completion_state_conflict { operation_id; registry_ok; outbox_ok = ok })
 ;;
 
 let queue_completion ~operation_id ~ok ~content ~evidence_ref =
@@ -57,12 +125,21 @@ let queue_completion ~operation_id ~ok ~content ~evidence_ref =
 
 let deliver_item ~base_dir (item : Outbox.item) =
   let ( let* ) = Result.bind in
-  let* route = route_of_item item in
+  let* route = registered_route item.operation_id in
+  let* () =
+    match
+      Fusion_run_registry.get (Fusion_run_registry.global ())
+        ~operation_id:item.operation_id
+    with
+    | None -> Ok ()
+    | Some _ -> validate_known_owner ~operation_id:item.operation_id route
+  in
   let ok, payload =
     match item.completion with
     | Outbox.Succeeded payload -> true, payload
     | Outbox.Failed payload -> false, payload
   in
+  let* () = ensure_registry_completion ~operation_id:item.operation_id ~ok payload in
   let board_post_id = Option.value payload.evidence_ref ~default:"" in
   let fusion_completion =
     Keeper_event_queue.

--- a/lib/fusion/fusion_wake_route.mli
+++ b/lib/fusion/fusion_wake_route.mli
@@ -11,6 +11,7 @@ type delivery_receipt = Delivered | Already_delivered
 type drain_report = { delivered : int; failures : error list }
 
 val error_to_string : error -> string
+val validate_registered_address : string -> (unit, error) result
 val register :
   operation_id:string -> owner:string -> channel:Keeper_continuation_channel.t ->
   (Fusion_completion_outbox.register_receipt, error) result

--- a/lib/fusion_core/fusion_completion_outbox.ml
+++ b/lib/fusion_core/fusion_completion_outbox.ml
@@ -157,6 +157,7 @@ let acknowledge t ~operation_id =
 ;;
 
 let pending t = Atomic.get t.state |> fun state -> By_id.bindings state.pending |> List.map snd
+let registered_address t ~operation_id = By_id.find_opt operation_id (Atomic.get t.state).addresses
 
 let replay path =
   if not (Fs_compat.file_exists path)

--- a/lib/fusion_core/fusion_completion_outbox.mli
+++ b/lib/fusion_core/fusion_completion_outbox.mli
@@ -56,5 +56,6 @@ val acknowledge :
   t -> operation_id:string -> (acknowledgement_receipt, error) result
 
 val pending : t -> item list
+val registered_address : t -> operation_id:string -> Completion_address.t option
 val global : unit -> t
 val set_global : t -> unit

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -1078,6 +1078,19 @@ let activate_owner_state
     ~domain_mgr
     ~proc_mgr
     state;
+  let base_dir = (Mcp_server.workspace_config state).base_path in
+  (match Fusion_config_loader.load ~base_path:base_dir with
+   | Error detail ->
+     Log.Server.error "fusion recovery policy unavailable: %s" detail
+   | Ok policy ->
+     let report = Fusion_tool.recover_required ~sw ~net ~base_dir ~policy in
+     Log.Server.info "fusion recovery started=%d failed=%d" report.started
+       (List.length report.failures);
+     List.iter
+       (fun (operation_id, error) ->
+          Log.Server.error "fusion recovery operation=%s error=%s" operation_id
+            (Fusion_tool.recovery_failure_to_string error))
+       report.failures);
   { state
   ; path_diagnostics = initialized.path_diagnostics
   ; domain_pool = initialized.domain_pool

--- a/test/test_fusion_wake.ml
+++ b/test/test_fusion_wake.ml
@@ -574,10 +574,162 @@ let register_route_exn ~operation_id ~owner channel =
   | Error error -> fail (Fusion_wake_route.error_to_string error)
 ;;
 
+let install_recovery_required_exn ~base_dir operation =
+  let path = Filename.concat base_dir "fusion-runs.jsonl" in
+  let registry = Fusion_run_registry.create ~path () in
+  Fusion_run_registry.set_global registry;
+  (match
+     Fusion_run_registry.register_running registry ~operation ~started_at:1.0
+   with
+   | Ok () -> ()
+   | Error error -> fail (Fusion_run_registry.persistence_error_to_string error));
+  let claim =
+    match
+      Fusion_run_registry.claim_operation registry
+        ~operation_id:(Fusion_types.fusion_operation_id operation)
+    with
+    | Ok claim -> claim
+    | Error error -> fail (Fusion_run_registry.claim_error_to_string error)
+  in
+  (match Fusion_run_registry.start_claimed registry claim with
+   | Ok started ->
+     check bool "started canonical operation" true
+       (Fusion_types.equal_fusion_operation operation started)
+   | Error error -> fail (Fusion_run_registry.start_error_to_string error));
+  let recovered = Fusion_run_registry.replay path in
+  Fusion_run_registry.set_global recovered;
+  recovered
+;;
+
+let test_recovery_resumes_exact_operation_and_owner_lane () =
+  with_isolated_eio_base_path "fusion-boot-recovery" (fun env sw base_dir ->
+    let keeper = "fusion-recovery-owner" in
+    let run_id = "fus-boot-recovery" in
+    let operation =
+      { (fusion_operation ~run_id ~keeper ~preset:"unit") with
+        request =
+          { (fusion_operation ~run_id ~keeper ~preset:"unit").request with
+            prompt = "recover this exact persisted prompt"
+          ; web_tools = true
+          }
+      ; topology = Fusion_types.Judge_of_judges
+      }
+    in
+    let registry = install_recovery_required_exn ~base_dir operation in
+    register_route_exn ~operation_id:run_id ~owner:keeper discord_channel;
+    let completed, resolve_completed = Eio.Promise.create () in
+    let run_orchestrator ~sw:_ ~net:_ ~base_dir ~policy:_ ~topology ~request () =
+      let observed : Fusion_types.fusion_operation = { request; topology } in
+      check bool "recovery uses exact persisted operation" true
+        (Fusion_types.equal_fusion_operation operation observed);
+      let synthesis = judge_synthesis "RECOVERED-ANSWER" in
+      let outcome =
+        match
+          Fusion_sink.emit ~base_dir ~keeper:request.keeper ~run_id:request.run_id
+            ~question:request.prompt ~panel:[] ~judge:(Ok synthesis) ~judges:[]
+            ~judge_usage:Fusion_types.zero_usage
+        with
+        | Ok () -> Fusion_orchestrator.Completed { panel = []; judge = Ok synthesis }
+        | Error detail -> Fusion_orchestrator.Sink_failed detail
+      in
+      Eio.Promise.resolve resolve_completed outcome;
+      outcome
+    in
+    let report =
+      Fusion_tool.For_test.recover_required_with_runner ~run_orchestrator ~sw
+        ~net:(Eio.Stdenv.net env) ~base_dir ~policy:(fusion_tool_policy ())
+    in
+    check int "one recovery started" 1 report.started;
+    check int "no recovery preparation failure" 0 (List.length report.failures);
+    (match
+       Eio.Time.with_timeout_exn (Eio.Stdenv.clock env) 2.0 (fun () ->
+         Eio.Promise.await completed)
+     with
+     | Fusion_orchestrator.Completed _ -> ()
+     | Fusion_orchestrator.Denied _ -> fail "recovery runner denied"
+     | Fusion_orchestrator.Sink_failed detail -> fail detail);
+    (match get_run registry ~run_id with
+     | Some { Fusion_run_registry.status = Completed { ok = true; _ }; _ } -> ()
+     | Some _ -> fail "recovered operation must become terminal"
+     | None -> fail "recovered operation must remain observable");
+    (match
+       Keeper_event_queue_persistence.load ~base_path:base_dir ~keeper_name:keeper
+       |> Keeper_event_queue.dequeue
+     with
+     | Some ({ payload = Keeper_event_queue.Fusion_completed completion; _ }, _) ->
+       check string "owner lane receives recovered answer" "RECOVERED-ANSWER"
+         completion.resolved_answer;
+       (match completion.channel with
+        | Keeper_continuation_channel.Discord { channel_id = "chan-9"; _ } -> ()
+        | channel ->
+          failf "recovery lost the persisted channel: %s"
+            (Keeper_continuation_channel.describe channel))
+     | Some _ -> fail "owner lane received the wrong recovery stimulus"
+     | None -> fail "owner lane must receive recovered completion");
+    let second =
+      Fusion_tool.For_test.recover_required_with_runner ~run_orchestrator ~sw
+        ~net:(Eio.Stdenv.net env) ~base_dir ~policy:(fusion_tool_policy ())
+    in
+    check int "terminal operation is not replayed" 0 second.started)
+;;
+
+let test_recovery_requires_exact_registered_owner () =
+  with_isolated_eio_base_path "fusion-recovery-wrong-owner" (fun env sw base_dir ->
+    let operation =
+      fusion_operation ~run_id:"fus-wrong-recovery-owner" ~keeper:"expected-owner"
+        ~preset:"unit"
+    in
+    register_running_exn (Fusion_run_registry.global ())
+      ~run_id:"fus-wrong-recovery-owner" ~keeper:"wrong-owner" ~preset:"unit"
+      ~started_at:0.0;
+    register_route_exn ~operation_id:"fus-wrong-recovery-owner"
+      ~owner:"wrong-owner" discord_channel;
+    let registry = install_recovery_required_exn ~base_dir operation in
+    (match
+       Fusion_wake_route.queue_completion ~operation_id:"fus-wrong-recovery-owner"
+         ~ok:true ~content:"must not reach wrong owner" ~evidence_ref:None
+     with
+     | Ok Fusion_completion_outbox.Queued -> ()
+     | Ok _ -> fail "test completion should be newly queued"
+     | Error error -> fail (Fusion_wake_route.error_to_string error));
+    let drain = Fusion_wake_route.drain_all ~base_dir in
+    check int "wrong owner delivers no pending completion" 0 drain.delivered;
+    check int "wrong owner is an explicit drain failure" 1
+      (List.length drain.failures);
+    check int "failed drain preserves pending completion" 1
+      (List.length
+         (Fusion_completion_outbox.pending (Fusion_completion_outbox.global ())));
+    check int "wrong owner lane remains empty" 0
+      (Keeper_event_queue.length
+         (Keeper_event_queue_persistence.load ~base_path:base_dir
+            ~keeper_name:"wrong-owner"));
+    let called = ref false in
+    let run_orchestrator ~sw:_ ~net:_ ~base_dir:_ ~policy:_ ~topology:_ ~request:_ () =
+      called := true;
+      failwith "recovery must not start for a different owner"
+    in
+    let report =
+      Fusion_tool.For_test.recover_required_with_runner ~run_orchestrator ~sw
+        ~net:(Eio.Stdenv.net env) ~base_dir ~policy:(fusion_tool_policy ())
+    in
+    check int "wrong owner starts no worker" 0 report.started;
+    check bool "runner is not called" false !called;
+    (match report.failures with
+     | [ ( "fus-wrong-recovery-owner"
+         , Fusion_tool.Completion_address_unavailable _ ) ] -> ()
+     | _ -> fail "owner mismatch must be a typed recovery failure");
+    match get_run registry ~run_id:"fus-wrong-recovery-owner" with
+    | Some { Fusion_run_registry.status = Recovery_required _; _ } -> ()
+    | Some _ -> fail "unroutable recovery must remain recovery_required"
+    | None -> fail "unroutable recovery inventory must remain observable")
+;;
+
 let test_wake_durable_commit_carries_channel_and_acks_outbox () =
   with_isolated_base_path "fusion-wake-durable" (fun base_dir ->
     let keeper = Printf.sprintf "fusion-wake-%d" (Random.bits ()) in
     let run_id = Printf.sprintf "fus-wake-%d" (Random.bits ()) in
+    register_running_exn (Fusion_run_registry.global ()) ~run_id ~keeper
+      ~preset:"unit" ~started_at:1.0;
     register_route_exn ~operation_id:run_id ~owner:keeper discord_channel;
     let result =
       Fusion_sink.wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id ~ok:true
@@ -621,6 +773,8 @@ let test_wake_fail_closed_preserves_pending_completion () =
      with
      | Ok () -> ()
      | Error e -> fail (Printf.sprintf "seeding the conflicting durable row should commit: %s" e));
+    register_running_exn (Fusion_run_registry.global ()) ~run_id ~keeper
+      ~preset:"unit" ~started_at:1.0;
     register_route_exn ~operation_id:run_id ~owner:keeper discord_channel;
     let result =
       Fusion_sink.wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id ~ok:true
@@ -900,6 +1054,14 @@ let () =
             "tool handle returns Running then async success projects evidence"
             `Quick
             test_tool_handle_async_success_projects_running_then_completed
+        ; test_case
+            "boot recovery resumes exact operation into exact owner lane"
+            `Quick
+            test_recovery_resumes_exact_operation_and_owner_lane
+        ; test_case
+            "boot recovery requires its exact registered owner"
+            `Quick
+            test_recovery_requires_exact_registered_owner
         ; test_case
             "tool handle does not start without durable register"
             `Quick

--- a/test/test_fusion_wake.ml
+++ b/test/test_fusion_wake.ml
@@ -574,6 +574,15 @@ let register_route_exn ~operation_id ~owner channel =
   | Error error -> fail (Fusion_wake_route.error_to_string error)
 ;;
 
+let queue_completion_exn ~operation_id ~ok ~content =
+  match
+    Fusion_wake_route.queue_completion ~operation_id ~ok ~content ~evidence_ref:None
+  with
+  | Ok Fusion_completion_outbox.Queued -> ()
+  | Ok _ -> fail "test completion should be newly queued"
+  | Error error -> fail (Fusion_wake_route.error_to_string error)
+;;
+
 let install_recovery_required_exn ~base_dir operation =
   let path = Filename.concat base_dir "fusion-runs.jsonl" in
   let registry = Fusion_run_registry.create ~path () in
@@ -605,12 +614,11 @@ let test_recovery_resumes_exact_operation_and_owner_lane () =
   with_isolated_eio_base_path "fusion-boot-recovery" (fun env sw base_dir ->
     let keeper = "fusion-recovery-owner" in
     let run_id = "fus-boot-recovery" in
-    let operation =
-      { (fusion_operation ~run_id ~keeper ~preset:"unit") with
-        request =
-          { (fusion_operation ~run_id ~keeper ~preset:"unit").request with
-            prompt = "recover this exact persisted prompt"
-          ; web_tools = true
+    let base_operation = fusion_operation ~run_id ~keeper ~preset:"unit" in
+    let operation : Fusion_types.fusion_operation =
+      { request =
+          { base_operation.request with
+            prompt = "recover this exact persisted prompt"; web_tools = true
           }
       ; topology = Fusion_types.Judge_of_judges
       }
@@ -685,13 +693,8 @@ let test_recovery_requires_exact_registered_owner () =
     register_route_exn ~operation_id:"fus-wrong-recovery-owner"
       ~owner:"wrong-owner" discord_channel;
     let registry = install_recovery_required_exn ~base_dir operation in
-    (match
-       Fusion_wake_route.queue_completion ~operation_id:"fus-wrong-recovery-owner"
-         ~ok:true ~content:"must not reach wrong owner" ~evidence_ref:None
-     with
-     | Ok Fusion_completion_outbox.Queued -> ()
-     | Ok _ -> fail "test completion should be newly queued"
-     | Error error -> fail (Fusion_wake_route.error_to_string error));
+    queue_completion_exn ~operation_id:"fus-wrong-recovery-owner" ~ok:true
+      ~content:"must not reach wrong owner";
     let drain = Fusion_wake_route.drain_all ~base_dir in
     check int "wrong owner delivers no pending completion" 0 drain.delivered;
     check int "wrong owner is an explicit drain failure" 1
@@ -722,6 +725,110 @@ let test_recovery_requires_exact_registered_owner () =
     | Some { Fusion_run_registry.status = Recovery_required _; _ } -> ()
     | Some _ -> fail "unroutable recovery must remain recovery_required"
     | None -> fail "unroutable recovery inventory must remain observable")
+;;
+
+let test_pending_terminal_reconciles_before_recovery () =
+  with_isolated_eio_base_path "fusion-recovery-reconcile" (fun env sw base_dir ->
+    let keeper = "fusion-reconciled-owner" in
+    let run_id = "fus-reconciled-terminal" in
+    let operation = fusion_operation ~run_id ~keeper ~preset:"unit" in
+    let registry = install_recovery_required_exn ~base_dir operation in
+    register_route_exn ~operation_id:run_id ~owner:keeper discord_channel;
+    queue_completion_exn ~operation_id:run_id ~ok:true
+      ~content:"RECONCILED-ANSWER";
+    let drain = Fusion_wake_route.drain_all ~base_dir in
+    check int "pending terminal delivered once" 1 drain.delivered;
+    check int "reconcile has no drain failure" 0 (List.length drain.failures);
+    (match get_run registry ~run_id with
+     | Some { Fusion_run_registry.status = Completed { ok = true; _ }; _ } -> ()
+     | Some _ -> fail "outbox terminal must durably reconcile the registry"
+     | None -> fail "reconciled operation must remain observable");
+    let called = ref false in
+    let run_orchestrator ~sw:_ ~net:_ ~base_dir:_ ~policy:_ ~topology:_ ~request:_ () =
+      called := true;
+      failwith "a reconciled terminal must not restart a worker"
+    in
+    let report =
+      Fusion_tool.For_test.recover_required_with_runner ~run_orchestrator ~sw
+        ~net:(Eio.Stdenv.net env) ~base_dir ~policy:(fusion_tool_policy ())
+    in
+    check int "reconciled terminal starts no worker" 0 report.started;
+    check bool "reconciled terminal runner is not called" false !called;
+    match
+      Keeper_event_queue_persistence.load ~base_path:base_dir ~keeper_name:keeper
+      |> Keeper_event_queue.dequeue
+    with
+    | Some ({ payload = Keeper_event_queue.Fusion_completed completion; _ }, _) ->
+      check string "reconciled answer reaches exact owner" "RECONCILED-ANSWER"
+        completion.resolved_answer
+    | Some _ -> fail "reconciled owner lane received the wrong stimulus"
+    | None -> fail "reconciled completion must reach its owner lane")
+;;
+
+let test_conflicting_terminal_stays_pending_without_restart () =
+  with_isolated_eio_base_path "fusion-recovery-conflict" (fun env sw base_dir ->
+    let keeper = "fusion-conflict-owner" in
+    let run_id = "fus-conflicting-terminal" in
+    register_running_exn (Fusion_run_registry.global ()) ~run_id ~keeper
+      ~preset:"unit" ~started_at:1.0;
+    register_route_exn ~operation_id:run_id ~owner:keeper discord_channel;
+    (match
+       Fusion_run_registry.mark_completed (Fusion_run_registry.global ())
+         ~operation_id:run_id ~failure:"registry failed" ~ok:false ()
+     with
+     | Ok () -> ()
+     | Error error -> fail (Fusion_run_registry.completion_error_to_string error));
+    queue_completion_exn ~operation_id:run_id ~ok:true
+      ~content:"conflicting success";
+    let drain = Fusion_wake_route.drain_all ~base_dir in
+    check int "conflicting terminal is not delivered" 0 drain.delivered;
+    check int "conflict is explicit" 1 (List.length drain.failures);
+    check int "conflicting terminal remains pending" 1
+      (List.length
+         (Fusion_completion_outbox.pending (Fusion_completion_outbox.global ())));
+    let called = ref false in
+    let run_orchestrator ~sw:_ ~net:_ ~base_dir:_ ~policy:_ ~topology:_ ~request:_ () =
+      called := true;
+      failwith "a terminal conflict must not start a worker"
+    in
+    let report =
+      Fusion_tool.For_test.recover_required_with_runner ~run_orchestrator ~sw
+        ~net:(Eio.Stdenv.net env) ~base_dir ~policy:(fusion_tool_policy ())
+    in
+    check int "conflicting terminal starts no worker" 0 report.started;
+    check bool "conflicting terminal runner is not called" false !called;
+    check int "conflicting owner lane remains empty" 0
+      (Keeper_event_queue.length
+         (Keeper_event_queue_persistence.load ~base_path:base_dir
+            ~keeper_name:keeper)))
+;;
+
+let test_pruned_registry_uses_validated_durable_address () =
+  with_isolated_base_path "fusion-delivery-pruned-registry" (fun base_dir ->
+    let keeper = "fusion-pruned-owner" in
+    let run_id = "fus-pruned-registry" in
+    register_running_exn (Fusion_run_registry.global ()) ~run_id ~keeper
+      ~preset:"unit" ~started_at:1.0;
+    register_route_exn ~operation_id:run_id ~owner:keeper discord_channel;
+    queue_completion_exn ~operation_id:run_id ~ok:true
+      ~content:"PRUNED-REGISTRY-ANSWER";
+    Fusion_run_registry.set_global (Fusion_run_registry.create ());
+    let drain = Fusion_wake_route.drain_all ~base_dir in
+    check int "validated address survives registry pruning" 1 drain.delivered;
+    check int "pruned registry delivery has no failure" 0
+      (List.length drain.failures);
+    check int "pruned registry delivery is acknowledged" 0
+      (List.length
+         (Fusion_completion_outbox.pending (Fusion_completion_outbox.global ())));
+    match
+      Keeper_event_queue_persistence.load ~base_path:base_dir ~keeper_name:keeper
+      |> Keeper_event_queue.dequeue
+    with
+    | Some ({ payload = Keeper_event_queue.Fusion_completed completion; _ }, _) ->
+      check string "validated exact owner receives completion"
+        "PRUNED-REGISTRY-ANSWER" completion.resolved_answer
+    | Some _ -> fail "validated owner received the wrong stimulus"
+    | None -> fail "validated durable address must remain deliverable")
 ;;
 
 let test_wake_durable_commit_carries_channel_and_acks_outbox () =
@@ -1062,6 +1169,18 @@ let () =
             "boot recovery requires its exact registered owner"
             `Quick
             test_recovery_requires_exact_registered_owner
+        ; test_case
+            "pending terminal reconciles before recovery starts"
+            `Quick
+            test_pending_terminal_reconciles_before_recovery
+        ; test_case
+            "conflicting terminal stays pending without worker restart"
+            `Quick
+            test_conflicting_terminal_stays_pending_without_restart
+        ; test_case
+            "validated address survives registry pruning"
+            `Quick
+            test_pruned_registry_uses_validated_durable_address
         ; test_case
             "tool handle does not start without durable register"
             `Quick


### PR DESCRIPTION
## Summary
- resume persisted `Recovery_required` Fusion operations once from the server root switch using their exact canonical request/topology
- require the immutable completion address to match the canonical Keeper owner before claim/start or delivery
- reconcile a pending outbox terminal into the registry before owner-Lane delivery, preserving pending state on conflict or persistence failure
- report preparation failures explicitly; add no retry count, cadence, lease, timeout, or execution budget

## Stacked base
- #24741 (`feat(fusion): persist worker claim handshake`)

## Verification
- 395 total changed lines (365 additions, 30 deletions)
- `ocamlformat` + parser checks + `git diff --check` passed
- actual OCaml compilation passed for current C19a `Fusion_types`, registry event/registry, completion outbox, wake route, and Fusion tool contracts/implementations
- focused Dune target was requested repeatedly but remained behind the shared `/tmp/me-dune-local.lock`; PR CI is the full build authority
- focused recovery tests cover exact persisted operation/owner Lane and owner mismatch fail-closed behavior

## Follow-up proof slice
- add the replay-equivalent cross-store tests: pending terminal + `Recovery_required` drains once then starts no worker; conflicting terminal remains pending and starts no worker