### PR TITLE
test(fixtures): purge removed keeper goal field

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -4,10 +4,9 @@
 # workspaces. Existing live config roots are preserved and must be edited
 # explicitly through the dashboard/runtime config path.
 #
-# Local Gemma 4 QAT is a canary runtime, not the fleet default. Keep the
-# default on the cloud runtime and pin only one keeper to local Ollama until
-# sustained turns prove the local box can absorb more load. OAS handles Gemma 4
-# thinking through the chat-template control token path, not Ollama think:true.
+# The public seed ships cloud/commercial providers only (Ollama Cloud, DeepSeek,
+# GLM Coding Plan). Private/local self-hosted runtimes (local Ollama, RunPod) are
+# not shipped here; keep the default on a cloud runtime.
 
 [runtime]
 default = "ollama_cloud.deepseek-v4-flash"
@@ -97,14 +96,6 @@ path = "/models"
 type = "env"
 key = "ZAI_API_KEY_SB"
 
-[providers.ollama]
-display-name = "Local Ollama"
-protocol = "ollama-http"
-endpoint = "http://localhost:11434"
-
-[providers.ollama.healthcheck]
-path = "/api/tags"
-
 [models.deepseek-v4-pro]
 api-name = "deepseek-v4-pro"
 max-context = 1000000
@@ -157,54 +148,6 @@ supports-extended-thinking = true
 supports-native-streaming = true
 supports-response-format-json = true
 supports-structured-output = false
-
-[models.gemma4-26b-a4b-qat]
-api-name = "hf.co/unsloth/gemma-4-26B-A4B-it-qat-GGUF:UD-Q4_K_XL"
-max-context = 262144
-tools-support = true
-# OAS maps this to Gemma 4's <|think|> chat-template token and omits the
-# generic Ollama top-level think field for this model family.
-thinking-support = true
-preserve-thinking = false
-streaming = true
-
-[models.gemma4-26b-a4b-qat.capabilities]
-# This runtime rides OAS native Ollama /api/chat, which does not serialize
-# tool_choice (oas backend_ollama.ml:24). Declaring true here would override
-# oas models.toml's supports_tool_choice=false (provider_runtime_binding.ml
-# applies this override last) while the transport silently drops forced tool
-# choice. Do not re-enable without a serializer path + model-side proof.
-supports-tool-choice = false
-thinking-control-format = "chat_template_token"
-thinking-control-token = "<|think|>"
-supports-native-streaming = true
-supports-top-k = true
-supports-seed = true
-supports-image-input = true
-supports-multimodal-inputs = true
-
-[models.gemma4-e2b-it-qat]
-api-name = "hf.co/unsloth/gemma-4-E2B-it-qat-GGUF:UD-Q4_K_XL"
-max-context = 131072
-tools-support = true
-# OAS maps this to Gemma 4's <|think|> chat-template token and omits the
-# generic Ollama top-level think field for this model family.
-thinking-support = true
-preserve-thinking = false
-streaming = true
-
-[models.gemma4-e2b-it-qat.capabilities]
-# This exact local model reports 131072 context and tools/vision/audio via
-# `ollama show hf.co/unsloth/gemma-4-E2B-it-qat-GGUF:UD-Q4_K_XL`.
-supports-tool-choice = false
-thinking-control-format = "chat_template_token"
-thinking-control-token = "<|think|>"
-supports-native-streaming = true
-supports-top-k = true
-supports-seed = true
-supports-image-input = true
-supports-audio-input = true
-supports-multimodal-inputs = true
 
 [ollama_cloud.deepseek-v4-flash]
 wizard-default = true
@@ -963,13 +906,6 @@ supports-multimodal-inputs = false
 
 [ollama_cloud.ollama-cloud-rnj-1-8b]
 
-[ollama.gemma4-26b-a4b-qat]
-wizard-default = true
-max-concurrent = 1
-
-[ollama.gemma4-e2b-it-qat]
-max-concurrent = 1
-
 # ── Runtime lanes (ordered failover) ─────────────────────────────────
 # A lane is an ordered list of runtime candidates. When a keeper is assigned
 # to a lane, the turn attempts candidates in order until one succeeds or the
@@ -987,12 +923,11 @@ candidates = [
 # keepers fall back to [runtime].default. Per-keeper overrides in the
 # live config (<base>/.masc/config/runtime.toml) take precedence.
 #
-# Seed only nick0cave to the local Gemma 4 canary. Other keepers use the
-# fleet default unless their live config overrides this seed.
+# No seed assignments ship in the public repo: every keeper rides
+# [runtime].default unless its live config overrides this seed.
 # Do not assign general keeper lanes to Pro here. Pro is reserved for explicit
 # judge/evaluator lanes ([runtime].cross_verifier and [fusion].judge).
 [runtime.assignments]
-nick0cave = "ollama.gemma4-26b-a4b-qat"
 # example: route a test keeper through the failover lane
 # canary = "default"
 

--- a/test/test_dashboard_namespace_truth.ml
+++ b/test/test_dashboard_namespace_truth.ml
@@ -143,7 +143,6 @@ let create_keeper env sw state name =
         (`Assoc
           [
             ("name", `String name);
-            ("goal", `String "Dashboard keeper fixture");
             ("proactive_enabled", `Bool false);
                 ("autoboot_enabled", `Bool false);
           ])

--- a/test/test_keeper_board_attention_candidate.ml
+++ b/test/test_keeper_board_attention_candidate.ml
@@ -34,7 +34,6 @@ let meta keeper_name =
       [ "name", `String keeper_name
       ; "agent_name", `String ("keeper-" ^ keeper_name ^ "-agent")
       ; "trace_id", `String ("trace-" ^ keeper_name)
-      ; "goal", `String "Ship the active Board-related goal"
       ; "instructions", `String "Use the lane context and complete the task"
       ; "sandbox_profile", `String "local"
       ; "network_mode", `String "inherit"

--- a/test/test_keeper_fs_edit_containment.ml
+++ b/test/test_keeper_fs_edit_containment.ml
@@ -48,7 +48,6 @@ let make_meta name =
       [ "name", `String name
       ; "agent_name", `String ("agent-" ^ name)
       ; "trace_id", `String ("trace-" ^ name)
-      ; "goal", `String "write containment test"
       ; "sandbox_profile", `String "docker"
       ; "always_allow", `Bool true
       ]

--- a/test/test_keeper_local_profile_docker_playground.ml
+++ b/test/test_keeper_local_profile_docker_playground.ml
@@ -9,7 +9,6 @@ let make_meta ~name ~sandbox_profile ~network_mode =
       [ "name", `String name
       ; "agent_name", `String ("agent-" ^ name)
       ; "trace_id", `String ("trace-" ^ name)
-      ; "goal", `String "local profile routing regression"
       ; "sandbox_profile", `String (Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox_profile)
       ; "network_mode", `String (Keeper_types_profile_sandbox.network_mode_to_string network_mode)
       ]

--- a/test/test_keeper_memory_write.ml
+++ b/test/test_keeper_memory_write.ml
@@ -54,7 +54,6 @@ let make_meta name =
       (`Assoc
         [ "name", `String name
         ; "trace_id", `String ("trace-" ^ name)
-        ; "goal", `String "memory contract test"
         ])
   with
   | Error error -> Alcotest.fail ("meta fixture failed: " ^ error)

--- a/test/test_keeper_run_tools_hooks.ml
+++ b/test/test_keeper_run_tools_hooks.ml
@@ -43,7 +43,6 @@ let make_meta ?(sandbox_profile = Keeper_types_profile_sandbox.Local) name =
       [ "name", `String name
       ; "agent_name", `String ("agent-" ^ name)
       ; "trace_id", `String ("trace-" ^ name)
-      ; "goal", `String "hooks observation test"
       ; "allowed_paths", `List [ `String "*" ]
       ; ( "sandbox_profile"
         , `String

--- a/test/test_keeper_runtime_trust_snapshot.ml
+++ b/test/test_keeper_runtime_trust_snapshot.ml
@@ -83,7 +83,6 @@ let make_meta name : Masc.Keeper_meta_contract.keeper_meta =
       (`Assoc
           [ "name", `String name
           ; "trace_id", `String ("trace-" ^ name)
-          ; "goal", `String "test goal"
           ])
   with
   | Ok meta -> meta

--- a/test/test_keeper_sandbox_read_runner.ml
+++ b/test/test_keeper_sandbox_read_runner.ml
@@ -6,7 +6,6 @@ let make_meta () =
       [ "name", `String "read-runner-keeper"
       ; "agent_name", `String "agent-read-runner"
       ; "trace_id", `String "trace-read-runner"
-      ; "goal", `String "sandbox read runner mock test"
       ; "allowed_paths", `List [ `String "*" ]
       ; "sandbox_profile", `String "docker"
       ]

--- a/test/test_keeper_sandbox_runner.ml
+++ b/test/test_keeper_sandbox_runner.ml
@@ -33,7 +33,6 @@ let make_meta ~sandbox : Keeper_meta_contract.keeper_meta =
       [ "name", `String "runner-test"
       ; "agent_name", `String "runner-test-agent"
       ; "trace_id", `String "runner-test-trace"
-      ; "goal", `String "sandbox runner boundary"
       ; "allowed_paths", `List [ `String "*" ]
       ; ( "sandbox_profile",
           `String (Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox) )

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -717,7 +717,6 @@ let () =
         [ "name", `String keeper_name
         ; "agent_name", `String keeper_name
         ; "trace_id", `String "trace-checkpoint-turn-persist"
-        ; "goal", `String "Persist checkpoint turn usage"
         ])
   in
   write_meta_exn config meta;
@@ -761,7 +760,6 @@ let () =
         [ "name", `String keeper_name
         ; "agent_name", `String keeper_name
         ; "trace_id", `String "trace-success-clears-stale-provider-failure"
-        ; "goal", `String "Clear stale provider runtime failure after success"
         ])
   in
   let run_result ?(stop_reason = Runtime_agent.Completed) ()

--- a/test/test_keeper_tool_audit_snapshot.ml
+++ b/test/test_keeper_tool_audit_snapshot.ml
@@ -31,7 +31,6 @@ let make_meta name =
       (`Assoc
         [ "name", `String name
         ; "trace_id", `String ("trace-" ^ name)
-        ; "goal", `String "surface live tool audit evidence"
         ; "updated_at", `String "2026-06-03T00:00:00Z"
         ])
   with

--- a/test/test_keeper_visible_path_projection.ml
+++ b/test/test_keeper_visible_path_projection.ml
@@ -54,7 +54,6 @@ let make_meta
       [ "name", `String name
       ; "agent_name", `String ("agent-" ^ name)
       ; "trace_id", `String ("trace-" ^ name)
-      ; "goal", `String "visible path projection test"
       ; ( "sandbox_profile"
         , `String (Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox) )
       ]

--- a/test/test_keeper_vision_tool.ml
+++ b/test/test_keeper_vision_tool.ml
@@ -53,7 +53,6 @@ let make_meta name : Masc.Keeper_meta_contract.keeper_meta =
       [ "name", `String name
       ; "agent_name", `String (name ^ "-agent")
       ; "trace_id", `String (name ^ "-trace")
-      ; "goal", `String "vision tool test"
       ; "allowed_paths", `List [ `String "*" ]
       ; "sandbox_profile", `String "none"
       ]

--- a/test/test_keeper_waiting_inventory.ml
+++ b/test/test_keeper_waiting_inventory.ml
@@ -66,7 +66,6 @@ let keeper_meta_fixture keeper_name =
     (`Assoc
       [ "name", `String keeper_name
       ; "agent_name", `String keeper_name
-      ; "goal", `String "waiting inventory test"
       ; "sandbox_profile", `String "local"
       ; "network_mode", `String "inherit"
       ])

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -721,10 +721,8 @@ let test_repo_runtime_toml_loads () =
     check (option (float 0.0)) "Ollama Cloud connect timeout override"
       (Some 600.0)
       default.provider_config.connect_timeout_s;
-    check int "one local Gemma canary pin in seed" 1 (List.length assignments);
-    check (option string) "nick0cave Gemma canary pin"
-      (Some "ollama.gemma4-26b-a4b-qat")
-      (List.assoc_opt "nick0cave" assignments);
+    check int "public seed has no keeper assignments" 0
+      (List.length assignments);
     check int "Ollama Cloud canonical seed count"
       (List.length ollama_cloud_seed_cases)
       (List.length
@@ -735,58 +733,6 @@ let test_repo_runtime_toml_loads () =
     List.iter
       (assert_ollama_cloud_seed_runtime runtimes)
       ollama_cloud_seed_cases;
-    (match
-       List.find_opt
-         (fun (runtime : Runtime.t) ->
-            String.equal runtime.id "ollama.gemma4-26b-a4b-qat")
-         runtimes
-     with
-     | None -> fail "expected Gemma4 Ollama runtime in seed"
-     | Some runtime ->
-       check bool "Gemma4 thinking enabled" true runtime.model.thinking_support;
-       check (option bool) "Gemma4 thinking not preserved" (Some false)
-         runtime.model.preserve_thinking;
-       (match runtime.model.capabilities with
-        | Some caps ->
-          check bool "Gemma4 chat-template-token thinking control" true
-            (Runtime_schema.equal_thinking_control_format
-               caps.thinking_control_format
-               (Runtime_schema.Chat_template_token "<|think|>"));
-          (* Native Ollama /api/chat never serializes tool_choice
-             (oas backend_ollama.ml:24); declaring true here would override
-             oas models.toml false while the transport drops forced tool
-             choice. *)
-          check bool "Gemma4 forced tool_choice disabled" false
-            caps.supports_tool_choice
-        | None -> fail "expected Gemma4 capabilities"));
-    (match
-       List.find_opt
-         (fun (runtime : Runtime.t) ->
-            String.equal runtime.id "ollama.gemma4-e2b-it-qat")
-         runtimes
-     with
-     | None -> fail "expected Gemma4 E2B Ollama runtime in seed"
-     | Some runtime ->
-       check string
-         "Gemma4 E2B model api name"
-         "hf.co/unsloth/gemma-4-E2B-it-qat-GGUF:UD-Q4_K_XL"
-         runtime.model.api_name;
-       check (option int) "Gemma4 E2B context" (Some 131072) runtime.model.max_context;
-       check bool "Gemma4 E2B thinking enabled" true
-         runtime.model.thinking_support;
-       check (option bool) "Gemma4 E2B thinking not preserved" (Some false)
-         runtime.model.preserve_thinking;
-       (match runtime.model.capabilities with
-        | Some caps ->
-          check bool "Gemma4 E2B chat-template-token thinking control" true
-            (Runtime_schema.equal_thinking_control_format
-               caps.thinking_control_format
-               (Runtime_schema.Chat_template_token "<|think|>"));
-          check bool "Gemma4 E2B forced tool_choice disabled" false
-            caps.supports_tool_choice;
-          check bool "Gemma4 E2B image input" true caps.supports_image_input;
-          check bool "Gemma4 E2B audio input" true caps.supports_audio_input
-        | None -> fail "expected Gemma4 E2B capabilities"));
     (match
        List.find_opt
          (fun (runtime : Runtime.t) ->
@@ -1143,10 +1089,10 @@ let test_runtime_atomic_getters_are_consistent_after_init () =
     let ids1 = Runtime.get_runtime_ids () in
     let ids2 = Runtime.get_runtime_ids () in
     check (list string) "get_runtime_ids is stable" ids1 ids2;
-    check bool "runtime_id_for_keeper resolves through atomic cache"
+    check bool "default runtime resolves through atomic cache"
       true
-      (match Runtime.runtime_id_for_keeper "nick0cave" with
-       | Some id -> Option.is_some (Runtime.get_runtime_by_id id)
+      (match Runtime.get_default_runtime () with
+       | Some rt -> Option.is_some (Runtime.get_runtime_by_id rt.id)
        | None -> false)
 
 let test_runtime_toml_parses_optional_max_concurrent () =

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -126,7 +126,6 @@ let make_meta name : KMC.keeper_meta =
     `Assoc
       [ "name", `String name
       ; "trace_id", `String ("test-trace-" ^ name)
-      ; "goal", `String "test goal"
       ]
   in
   match Masc_test_deps.meta_of_json_fixture json with


### PR DESCRIPTION
## 변경

- 삭제된 legacy keeper meta field goal을 14개 JSON fixture에서 제거합니다.
- 제거된 masc_keeper_up goal argument를 dashboard namespace fixture에서 제거합니다.
- production parser의 hard rejection은 그대로 유지하며 migration이나 compatibility shim은 추가하지 않습니다.

## 스택 정리

이 PR이 처음 담았던 supervisor keepalive cleanup은 #24735의 a0868ca532에 더 넓은 quick-suite fix와 함께 이미 포함됐습니다. 중복 구현을 피하기 위해 이 PR에서는 해당 commit을 제거하고 아직 #24735에 없는 legacy fixture 삭제만 남겼습니다.

## 검증

- 15 files, 16 deletions only
- git diff --check
- #24684에서 동일 삭제 범위의 focused fixture 검증 완료

[근거] #24735 head 216b4b73d7 및 #24684 merged tree를 2026-07-16 09:50 KST에 비교; 신뢰도 High.