### PR TITLE
refactor(vision): hard-delete eager ingestion

### DIFF
--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -611,16 +611,14 @@ let save_oas_checkpoint_classified
   (* RFC vision-delegation §2.3 site 2 (checkpoint write boundary). For a
      Delegate keeper, evict any inline image to a handle-only placeholder BEFORE
      it is persisted, so a reloaded checkpoint can never re-materialise an
-     [Image] and re-trigger the RFC-0265 reroute. Store-only here — checkpoint
-     writes must not block the turn fiber on a vision provider call (eager
-     extraction is site 1's job). Also the migration path for images persisted
+     [Image] and re-trigger the RFC-0265 reroute. Ingestion is provider-free at
+     both write boundaries. This is also the migration path for images persisted
      by pre-existing checkpoints. No-op for Inherit/Reroute (safe-by-default).
      [multimodal_policy]/[keeper_name] are required so every checkpoint write
      path is compiler-forced to declare its policy (N-of-M closure). *)
   let checkpoint_messages =
     List.map
       (Keeper_vision_ingest.evict_message
-         ~mode:Keeper_vision_ingest.Store_only
          ~policy:multimodal_policy
          ~keeper_name)
       checkpoint_messages

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -485,14 +485,13 @@ let run_keeper_invocation_turn_admitted
        | Error err -> tool_result_error (Agent_sdk.Error.to_string err)
        | Ok profile_defaults ->
       (* RFC vision-delegation §2.3 site 1 (fresh input). For a Delegate keeper,
-         evict each image to the artifact store + an eager analyze_image reading
-         BEFORE it enters the turn, so the main history stays text-only and
-         RFC-0265 never recomputes required=['image'] from it. No-op for
-         Inherit/Reroute keepers (safe-by-default). *)
+         evict each image to the artifact store before it enters the turn, so
+         the main history stays text-only and RFC-0265 never recomputes
+         required=['image'] from it. The placeholder exposes [analyze_image] to
+         the Keeper; ingestion never starts a provider sub-call. *)
       let user_blocks =
         Option.map
           (Keeper_vision_ingest.evict_blocks
-             ~mode:Keeper_vision_ingest.Eager
              ~policy:meta.multimodal_policy
              ~keeper_name:meta.name)
           user_blocks

--- a/lib/keeper/keeper_vision_ingest.ml
+++ b/lib/keeper/keeper_vision_ingest.ml
@@ -3,21 +3,6 @@
 
 module Store = Multimodal.Vision_artifact_store
 
-type mode =
-  | Eager
-  | Store_only
-
-(* SSOT placeholder formats. The handle always lets the keeper re-read the
-   pixels via the analyze_image tool; the eager [read] text carries the meaning
-   so most follow-up turns answer without any further vision call. *)
-let image_read_placeholder ~handle ~media_type ~read_text =
-  Printf.sprintf
-    "[image read: %s | artifact:%s media_type:%s]"
-    read_text
-    (Store.to_string handle)
-    media_type
-;;
-
 let image_unread_placeholder ~handle ~media_type ~reason =
   Printf.sprintf
     "[image artifact:%s media_type:%s - %s; call analyze_image to read it]"
@@ -33,47 +18,11 @@ let image_store_failed_placeholder ~reason =
   Printf.sprintf "[image — could not store for delegation: %s]" reason
 ;;
 
-let eager_timeout_sec = 30.0
-let max_eager_reads_per_turn = 1
-let max_read_text_chars = 4000
-
-let string_of_mode = function
-  | Eager -> "eager"
-  | Store_only -> "store_only"
-;;
-
-let record_eviction ~mode ~result ~reason =
+let record_eviction ~result ~reason =
   Otel_metric_store.inc_counter
     Keeper_metrics.(to_string VisionIngestEvictions)
-    ~labels:[ "mode", string_of_mode mode; "result", result; "reason", reason ]
+    ~labels:[ "result", result; "reason", reason ]
     ()
-;;
-
-let eager_read_eviction_reason_of_outcome = function
-  | Keeper_vision_tool.Vo_ok _ -> None
-  | Keeper_vision_tool.Vo_empty -> Some "eager_empty"
-  | Keeper_vision_tool.Vo_truncated -> Some "eager_truncated"
-  | Keeper_vision_tool.Vo_timeout -> Some "eager_timeout"
-  | Keeper_vision_tool.Vo_no_runtime _ -> Some "eager_no_runtime"
-  | Keeper_vision_tool.Vo_invalid_request _ -> Some "eager_invalid_request"
-  | Keeper_vision_tool.Vo_invalid_structured_response _ ->
-    Some "eager_invalid_structured_response"
-  | Keeper_vision_tool.Vo_provider _ -> Some "eager_provider_error"
-;;
-
-let truncate_read_text text =
-  let length = String.length text in
-  if length <= max_read_text_chars
-  then text
-  else String.sub text 0 max_read_text_chars ^ "\n[truncated]"
-;;
-
-(* Operator decision (2026-06-25, RFC §2.3-eager): exhaustive description, so a
-   later text-only turn rarely needs to re-read the pixels. *)
-let extraction_query =
-  "Describe everything in this image: transcribe all text verbatim, and list \
-   every UI element, the layout, colors, state, errors, and numbers. Be \
-   exhaustive — the reader cannot see the image, only your description."
 ;;
 
 let store_dir ~keeper_name = Keeper_vision_tool.vision_store_dir ~keeper_name
@@ -87,61 +36,34 @@ let raw_bytes_of_image_data data =
   | Error (`Msg m) -> Error m
 ;;
 
-(* Eager extraction through the shared vision core, only when an Eio context is
-   present (prod turn). Absent (tests / pre-bootstrap) -> [None]; the caller then
-   emits an unread placeholder. Bounded by [run_vision]'s [with_timeout]. *)
-let eager_read ~media_type ~bytes : (string, string) result option =
-  match
-    Eio_context.get_net_opt (), Eio_context.get_switch_opt (), Eio_context.get_clock_opt ()
-  with
-  | Some net, Some sw, Some clock ->
-    (match
-       Keeper_vision_tool.run_vision
-         ~sw
-         ~clock
-         ~net
-         ~timeout_sec:eager_timeout_sec
-         ~query:extraction_query
-         ~media_type
-         ~bytes
-         ()
-     with
-     | Keeper_vision_tool.Vo_ok text -> Some (Ok (truncate_read_text text))
-     | outcome ->
-       (match eager_read_eviction_reason_of_outcome outcome with
-        | Some reason -> Some (Error reason)
-        | None -> Some (Error "eager_read_failed")))
-  | _ -> None
-;;
-
 (* Transform one block. An [Image] is evicted to a text placeholder; everything
    else — including an already-evicted [Text] placeholder — passes through
    unchanged, so re-running on a rehydrated message is a no-op (idempotent: no
    double-store, no double-extract). *)
-let evict_block ~mode ~keeper_name ~eager_budget (block : Agent_sdk.Types.content_block) =
+let evict_block ~keeper_name (block : Agent_sdk.Types.content_block) =
   match block with
   | Agent_sdk.Types.Image { media_type; data; source_type } ->
     (match source_type with
      | Agent_sdk.Types.Url | Agent_sdk.Types.File_id ->
-       record_eviction ~mode ~result:"error" ~reason:"invalid_source_type";
+       record_eviction ~result:"error" ~reason:"invalid_source_type";
        Agent_sdk.Types.Text
          (image_store_failed_placeholder ~reason:"unsupported image source")
      | Agent_sdk.Types.Base64 ->
        match raw_bytes_of_image_data data with
       | Error _ ->
-        record_eviction ~mode ~result:"error" ~reason:"bad_base64";
+        record_eviction ~result:"error" ~reason:"bad_base64";
         Agent_sdk.Types.Text
           (image_store_failed_placeholder ~reason:"invalid image payload")
       | Ok bytes ->
         (match Keeper_vision_tool.validate_image_size bytes with
          | Error _ ->
-           record_eviction ~mode ~result:"error" ~reason:"image_too_large";
+           record_eviction ~result:"error" ~reason:"image_too_large";
            Agent_sdk.Types.Text
              (image_store_failed_placeholder ~reason:"image too large")
          | Ok () ->
            (match Keeper_vision_tool.validate_media_type media_type with
             | Error _ ->
-              record_eviction ~mode ~result:"error" ~reason:"invalid_media_type";
+              record_eviction ~result:"error" ~reason:"invalid_media_type";
               Agent_sdk.Types.Text
                 (image_store_failed_placeholder ~reason:"unsupported image media type")
             | Ok media_type ->
@@ -149,43 +71,16 @@ let evict_block ~mode ~keeper_name ~eager_budget (block : Agent_sdk.Types.conten
                  Keeper_vision_tool.store_artifact ~dir:(store_dir ~keeper_name) bytes
                with
                | Error _ ->
-                 record_eviction ~mode ~result:"error" ~reason:"store_failed";
+                 record_eviction ~result:"error" ~reason:"store_failed";
                  Agent_sdk.Types.Text
                    (image_store_failed_placeholder ~reason:"artifact store failed")
                | Ok handle ->
-                 (match mode with
-                  | Store_only ->
-                    record_eviction ~mode ~result:"ok" ~reason:"stored";
-                    Agent_sdk.Types.Text
-                      (image_unread_placeholder ~handle ~media_type ~reason:"not read")
-                  | Eager when !eager_budget > 0 ->
-                    decr eager_budget;
-                    (match eager_read ~media_type ~bytes with
-                     | Some (Ok read_text) ->
-                       record_eviction ~mode ~result:"ok" ~reason:"eager_read";
-                       Agent_sdk.Types.Text
-                         (image_read_placeholder ~handle ~media_type ~read_text)
-                     | Some (Error reason) ->
-                       record_eviction ~mode ~result:"error" ~reason;
-                       Agent_sdk.Types.Text
-                         (image_unread_placeholder
-                            ~handle
-                            ~media_type
-                            ~reason:"vision read failed")
-                     | None ->
-                       record_eviction ~mode ~result:"ok" ~reason:"stored_unread";
-                       Agent_sdk.Types.Text
-                         (image_unread_placeholder
-                            ~handle
-                            ~media_type
-                            ~reason:"not yet read"))
-                  | Eager ->
-                    record_eviction ~mode ~result:"ok" ~reason:"eager_budget_exhausted";
-                    Agent_sdk.Types.Text
-                      (image_unread_placeholder
-                         ~handle
-                         ~media_type
-                         ~reason:"not read"))))))
+                 record_eviction ~result:"ok" ~reason:"stored";
+                 Agent_sdk.Types.Text
+                   (image_unread_placeholder
+                      ~handle
+                      ~media_type
+                      ~reason:"awaiting analyze_image tool call")))))
   | other -> other
 ;;
 
@@ -194,25 +89,18 @@ let delegating = function
   | Keeper_types_profile.Mm_reroute | Keeper_types_profile.Mm_inherit -> false
 ;;
 
-let evict_blocks ~mode ~policy ~keeper_name blocks =
+let evict_blocks ~policy ~keeper_name blocks =
   if delegating policy
-  then (
-    let eager_budget =
-      ref
-        (match mode with
-         | Eager -> max_eager_reads_per_turn
-         | Store_only -> 0)
-    in
-    List.map (evict_block ~mode ~keeper_name ~eager_budget) blocks)
+  then List.map (evict_block ~keeper_name) blocks
   else blocks
 ;;
 
-let evict_message ~mode ~policy ~keeper_name (message : Agent_sdk.Types.message) =
+let evict_message ~policy ~keeper_name (message : Agent_sdk.Types.message) =
   if delegating policy
   then
     { message with
       Agent_sdk.Types.content =
-        evict_blocks ~mode ~policy ~keeper_name message.Agent_sdk.Types.content
+        evict_blocks ~policy ~keeper_name message.Agent_sdk.Types.content
     }
   else message
 ;;

--- a/lib/keeper/keeper_vision_ingest.mli
+++ b/lib/keeper/keeper_vision_ingest.mli
@@ -6,50 +6,31 @@
     so the persisted checkpoint never holds inline base64 and rehydration
     cannot re-materialise an [Image]:
 
-    - Site 1 (fresh input, [Eager]): the turn caller validates and stores every
-      image, then runs at most one bounded [analyze_image] vision sub-call for
-      the first valid image and embeds the reading in the placeholder.
-    - Site 2 (checkpoint write, [Store_only]): the persistence boundary evicts
-      with a handle-only placeholder (no provider call on the turn fiber); also
-      migrates images already persisted in pre-existing checkpoints.
+    - Site 1 (fresh input): the turn caller validates and stores every image,
+      then emits a handle-only placeholder. The Keeper decides when to call
+      [analyze_image]; ingestion never starts a provider call.
+    - Site 2 (checkpoint write): the persistence boundary performs the same
+      store + handle transform and also migrates images already persisted in
+      pre-existing checkpoints.
 
     Gated by {!Keeper_types_profile.multimodal_policy}: only [Mm_delegate]
     evicts; [Mm_reroute]/[Mm_inherit] are a no-op (safe-by-default). Idempotent:
     a [Text] placeholder is not an [Image], so re-running is a no-op. *)
 
-type mode =
-  | Eager  (** site 1: run the vision sub-call now, embed the reading *)
-  | Store_only  (** site 2: store + handle-only placeholder, no provider call *)
-
-val extraction_query : string
-(** The fixed exhaustive extraction query used by [Eager] (RFC §2.3-eager). *)
-
-val eager_read_eviction_reason_of_outcome
-  :  Keeper_vision_tool.vision_outcome
-  -> string option
-(** Metric reason projection for failed [Eager] vision sub-calls. [Vo_ok] has
-    no error reason; every non-ok outcome maps to a finite eviction reason so
-    provider failures, timeouts, invalid requests, and invalid structured
-    responses do not collapse into one counter bucket. *)
-
 val evict_blocks
-  :  mode:mode
-  -> policy:Keeper_types_profile.multimodal_policy
+  :  policy:Keeper_types_profile.multimodal_policy
   -> keeper_name:string
   -> Agent_sdk.Types.content_block list
   -> Agent_sdk.Types.content_block list
 (** Site 1. Evict every [Image] in the list when [policy = Mm_delegate]; return
     the list unchanged otherwise. Images are fail-closed before store on
-    base64 payload, size, and media type. [Eager] consults the
-    fiber-local Eio context for one bounded sub-call; with none present (tests)
-    it falls back to an unread placeholder, so eviction still holds. *)
+    base64 payload, size, and media type. Successful stores always return a
+    placeholder that exposes the exact artifact handle to [analyze_image]. *)
 
 val evict_message
-  :  mode:mode
-  -> policy:Keeper_types_profile.multimodal_policy
+  :  policy:Keeper_types_profile.multimodal_policy
   -> keeper_name:string
   -> Agent_sdk.Types.message
   -> Agent_sdk.Types.message
-(** Site 2. Same transform applied to a message's content blocks at the
-    checkpoint write boundary. Use [Store_only] here — checkpoint writes must
-    not block the turn fiber on a provider call. *)
+(** Site 2. Same provider-free transform applied to a message's content blocks
+    at the checkpoint write boundary. *)

--- a/lib/keeper/keeper_vision_tool.mli
+++ b/lib/keeper/keeper_vision_tool.mli
@@ -98,9 +98,7 @@ val load_artifact
 (** Load image bytes from the content-addressed artifact store. Blocking
     filesystem work is offloaded when the Eio runtime is active. *)
 
-(** Typed outcome of {!run_vision}. SSOT shared by the tool handler (renders to
-    JSON) and eager ingestion eviction ({!Keeper_vision_ingest}, renders to a
-    placeholder). *)
+(** Typed outcome of {!run_vision}. SSOT rendered by the tool handler as JSON. *)
 type vision_outcome =
   | Vo_ok of string
   | Vo_invalid_request of string

--- a/test/test_keeper_vision_tool.ml
+++ b/test/test_keeper_vision_tool.ml
@@ -889,29 +889,11 @@ let test_accept_rejected_is_policy_rejection_without_failover () =
       assert (String.equal (assoc_string "error" json) "provider_error");
       assert (String.equal (assoc_string "failure_class" json) "policy_rejection")))
 
-let test_eager_eviction_reason_preserves_typed_outcome () =
-  let reason = Vi.eager_read_eviction_reason_of_outcome in
-  assert (reason (Vt.Vo_ok "text") = None);
-  assert (reason Vt.Vo_empty = Some "eager_empty");
-  assert (reason Vt.Vo_truncated = Some "eager_truncated");
-  assert (reason Vt.Vo_timeout = Some "eager_timeout");
-  assert (reason (Vt.Vo_no_runtime "missing") = Some "eager_no_runtime");
-  assert (reason (Vt.Vo_invalid_request "bad") = Some "eager_invalid_request");
-  assert
-    (reason (Vt.Vo_invalid_structured_response "bad json")
-     = Some "eager_invalid_structured_response");
-  assert
-    (reason
-       (Vt.Vo_provider { failure_class = Tool_result.Runtime_failure; detail = "boom" })
-     = Some "eager_provider_error")
-
-let test_delegate_eager_eviction_stores_image_and_removes_inline_block () =
+let test_delegate_eviction_stores_image_and_removes_inline_block () =
   with_temp_base (fun _ ->
     let keeper_name = "vision-ingest-delegate" in
     let bytes = "\x89PNG\r\n\x1a\ninline-image" in
-    let metric_labels =
-      [ "mode", "eager"; "result", "ok"; "reason", "stored_unread" ]
-    in
+    let metric_labels = [ "result", "ok"; "reason", "stored" ] in
     let before =
       metric_value Keeper_metrics.VisionIngestEvictions ~labels:metric_labels
     in
@@ -927,7 +909,6 @@ let test_delegate_eager_eviction_stores_image_and_removes_inline_block () =
     in
     match
       Vi.evict_blocks
-        ~mode:Vi.Eager
         ~policy:Masc.Keeper_types_profile.Mm_delegate
         ~keeper_name
         blocks
@@ -938,7 +919,7 @@ let test_delegate_eager_eviction_stores_image_and_removes_inline_block () =
       ] ->
       assert (contains_substring placeholder "[image artifact:");
       assert (contains_substring placeholder "media_type:image/png");
-      assert (contains_substring placeholder "not yet read");
+      assert (contains_substring placeholder "awaiting analyze_image tool call");
       let handle = artifact_handle_of_placeholder placeholder in
       (match
          Store.load
@@ -948,7 +929,7 @@ let test_delegate_eager_eviction_stores_image_and_removes_inline_block () =
        | Ok stored -> assert (String.equal stored bytes)
        | Error msg -> failwith msg);
       assert_metric_increment
-        "vision_ingest stored_unread"
+        "vision_ingest stored"
         before
         (metric_value Keeper_metrics.VisionIngestEvictions ~labels:metric_labels)
     | _ -> failwith "delegate eviction should replace the image with text")
@@ -957,15 +938,12 @@ let test_delegate_eviction_rejects_invalid_media_type_before_store () =
   with_temp_base (fun _ ->
     let keeper_name = "vision-ingest-invalid-media" in
     let bytes = "\x89PNG\r\n\x1a\ninline-image" in
-    let metric_labels =
-      [ "mode", "store_only"; "result", "error"; "reason", "invalid_media_type" ]
-    in
+    let metric_labels = [ "result", "error"; "reason", "invalid_media_type" ] in
     let before =
       metric_value Keeper_metrics.VisionIngestEvictions ~labels:metric_labels
     in
     match
       Vi.evict_blocks
-        ~mode:Vi.Store_only
         ~policy:Masc.Keeper_types_profile.Mm_delegate
         ~keeper_name
         [ Agent_sdk.Types.Image
@@ -990,7 +968,6 @@ let test_delegate_eviction_rejects_oversize_before_store () =
       let bytes = "\x89PNG\r\n\x1a\ninline-image" in
       match
         Vi.evict_blocks
-          ~mode:Vi.Store_only
           ~policy:Masc.Keeper_types_profile.Mm_delegate
           ~keeper_name
           [ Agent_sdk.Types.Image
@@ -1007,7 +984,6 @@ let test_delegate_eviction_rejects_oversize_before_store () =
 let test_delegate_eviction_bad_base64_surfaces_redacted_text_error () =
   match
     Vi.evict_blocks
-      ~mode:Vi.Store_only
       ~policy:Masc.Keeper_types_profile.Mm_delegate
       ~keeper_name:"vision-ingest-bad-base64"
       [ Agent_sdk.Types.Image
@@ -1027,15 +1003,12 @@ let test_delegate_eviction_rejects_non_base64_source_before_store () =
   List.iter
     (fun source_type ->
       let source_name = Agent_sdk.Types.media_source_kind_to_string source_type in
-      let metric_labels =
-        [ "mode", "store_only"; "result", "error"; "reason", "invalid_source_type" ]
-      in
+      let metric_labels = [ "result", "error"; "reason", "invalid_source_type" ] in
       let before =
         metric_value Keeper_metrics.VisionIngestEvictions ~labels:metric_labels
       in
       match
         Vi.evict_blocks
-          ~mode:Vi.Store_only
           ~policy:Masc.Keeper_types_profile.Mm_delegate
           ~keeper_name:("vision-ingest-source-" ^ source_name)
           [ Agent_sdk.Types.Image
@@ -1067,7 +1040,6 @@ let test_non_delegate_eviction_preserves_inline_image () =
   in
   match
     Vi.evict_blocks
-      ~mode:Vi.Eager
       ~policy:Masc.Keeper_types_profile.Mm_inherit
       ~keeper_name:"vision-ingest-inherit"
       blocks
@@ -1097,7 +1069,6 @@ let test_evicted_history_has_no_image_modality () =
     assert (List.mem "image" (modalities [ msg ]));
     let evicted =
       Vi.evict_message
-        ~mode:Vi.Store_only
         ~policy:Masc.Keeper_types_profile.Mm_delegate
         ~keeper_name
         msg
@@ -1105,7 +1076,6 @@ let test_evicted_history_has_no_image_modality () =
     assert (not (List.mem "image" (modalities [ evicted ])));
     let evicted2 =
       Vi.evict_message
-        ~mode:Vi.Store_only
         ~policy:Masc.Keeper_types_profile.Mm_delegate
         ~keeper_name
         evicted
@@ -1139,9 +1109,8 @@ let () =
     test_retryable_provider_error_tries_next_runtime ();
     test_deadline_exhaustion_preserves_provider_error ();
     test_non_retryable_provider_error_stops_without_trying_next_runtime ();
-    test_accept_rejected_is_policy_rejection_without_failover ();
-    test_eager_eviction_reason_preserves_typed_outcome ());
-  test_delegate_eager_eviction_stores_image_and_removes_inline_block ();
+    test_accept_rejected_is_policy_rejection_without_failover ());
+  test_delegate_eviction_stores_image_and_removes_inline_block ();
   test_delegate_eviction_rejects_invalid_media_type_before_store ();
   test_delegate_eviction_rejects_oversize_before_store ();
   test_delegate_eviction_bad_base64_surfaces_redacted_text_error ();


### PR DESCRIPTION
## Outcome

- Hard-deletes `Keeper_vision_ingest.Eager` and the synchronous vision provider sub-call from fresh Keeper input admission.
- Removes the arbitrary eager-only 30-second deadline, one-image read cap, and 4000-character response truncation.
- Makes fresh input and checkpoint persistence share one provider-free transform: validate, content-address store, and expose the exact artifact handle to `analyze_image`.
- Keeps image-reading capability in the existing typed `analyze_image` tool, so the Keeper LLM decides which stored image to inspect and with what query.

## Boundary

This is the independently mergeable prerequisite for #24756. It deliberately does **not** add a dormant artifact queue variant or depend on unreleased OAS image APIs.

The durable multimodal operation/terminal slice must follow these existing stacks instead of duplicating their SSOTs:

- #24724 through #24751: canonical durable operation, claim/start/recovery, completion outbox, commit-before-owner-lane wake.
- #24728 and #24738: exact Keeper caller join, typed terminal artifact refs, restart replay, and owner-lane reinjection.

After those merge, the next slice can specialize their generic operation/join boundary for provider-neutral Vision/Image/Audio work without adding a second outbox or event-queue completion hierarchy.

Closes no issue; advances #24756.

## Verification

- 45 additions + 212 deletions = 257 total changed lines.
- `ocamlformat --check` passed for every changed ML/MLI file.
- `ocamlc -stop-after parsing` passed for every changed ML/MLI file.
- `git diff --check` passed.
- Focused wrapper build was not forced: `scripts/dune-local.sh build test/test_keeper_vision_tool.exe` correctly refused while another session owned a bare `dune test --root .`. Full build/test remains PR CI authority.
