### PR TITLE
fix(keeper): make sqlite statement finalize total

### DIFF
--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -1242,11 +1242,21 @@ let sqlite_expect_done db stmt ~operation =
   | Sqlite3.Rc.DONE -> Ok ()
   | rc -> Error (sqlite_error ~operation db rc)
 
+(* Total: [Sqlite3.finalize] may raise SqliteError (documented in the
+   binding's mli) in addition to returning an error rc. A raise here has
+   two bad escapes in [with_statement]: on the normal path it would erase
+   [body_result], and on the cancellation path it would replace
+   [Eio.Cancel.Cancelled] with SqliteError, breaking cancellation
+   propagation. [Sqlite3.finalize] is a non-suspending C call, so the
+   catch-all cannot swallow Cancelled itself. *)
 let sqlite_finalize db stmt =
-  let rc = Sqlite3.finalize stmt in
-  if Sqlite3.Rc.is_success rc
-  then Ok ()
-  else Error (sqlite_error ~operation:"statement finalize" db rc)
+  match Sqlite3.finalize stmt with
+  | rc ->
+    if Sqlite3.Rc.is_success rc
+    then Ok ()
+    else Error (sqlite_error ~operation:"statement finalize" db rc)
+  | exception exn ->
+    Error ("SQLite statement finalize raised: " ^ Printexc.to_string exn)
 
 let combine_cleanup_error primary cleanup =
   match primary, cleanup with

--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -3884,6 +3884,7 @@ module For_testing = struct
     Atomic.set inventory_classified_observer_for_testing observer
 
   let failure_kind_of_string = failure_kind_of_string
+  let finalize_statement = sqlite_finalize
   let snapshot_path = snapshot_path
 
   let receipt_json ~base_path ~keeper_name ~receipt_id =

--- a/lib/keeper/keeper_chat_queue.mli
+++ b/lib/keeper/keeper_chat_queue.mli
@@ -380,6 +380,12 @@ module For_testing : sig
   val set_before_entry_lock_observer : (string -> unit) option -> unit
   val set_inventory_classified_observer : (unit -> unit) option -> unit
   val failure_kind_of_string : string -> (failure_kind, string) result
+
+  val finalize_statement : Sqlite3.db -> Sqlite3.stmt -> (unit, string) result
+  (** Total statement finalize: folds both the rc channel and the
+      SqliteError raise channel of [Sqlite3.finalize] into [result], so
+      cleanup can never erase a body result or replace a pending
+      [Eio.Cancel.Cancelled]. Exposed for the totality regression test. *)
   val snapshot_path : base_path:string -> keeper_name:string -> (string, string) result
   val receipt_json :
     base_path:string ->

--- a/test/stanzas/test_keeper_chat_coalescing.inc
+++ b/test/stanzas/test_keeper_chat_coalescing.inc
@@ -1,4 +1,4 @@
 (test
  (name test_keeper_chat_coalescing)
  (modules test_keeper_chat_coalescing)
- (libraries masc_test_deps))
+ (libraries masc_test_deps sqlite3))

--- a/test/test_keeper_chat_coalescing.ml
+++ b/test/test_keeper_chat_coalescing.ml
@@ -854,6 +854,29 @@ let test_reconcile_absent_lane_and_stage_order () =
        ; Before_close
        ])
 
+let test_finalize_statement_total () =
+  Printf.printf "Test: statement finalize is total on both rc and raise channels\n%!";
+  let db = Sqlite3.db_open ":memory:" in
+  let stmt = Sqlite3.prepare db "SELECT 1" in
+  (match Keeper_chat_queue.For_testing.finalize_statement db stmt with
+   | Ok () -> check "healthy statement finalize returns Ok" true
+   | Error detail -> fail "healthy statement finalize returns Ok" detail);
+  (* Sqlite3.finalize raises SqliteError on an already-finalized statement;
+     the wrapper must fold that raise into Error instead of letting it
+     escape cleanup. *)
+  (match Keeper_chat_queue.For_testing.finalize_statement db stmt with
+   | Error detail ->
+     check "already-finalized statement folds to Error without raising"
+       (detail <> "");
+     check "the Error comes from the raise channel, not an error rc"
+       (String.starts_with ~prefix:"SQLite statement finalize raised:" detail)
+   | Ok () ->
+     check "already-finalized statement folds to Error without raising" false
+   | exception exn ->
+     fail "already-finalized statement folds to Error without raising"
+       (Printexc.to_string exn));
+  ignore (Sqlite3.db_close db : bool)
+
 let () =
   Eio_main.run @@ fun _environment ->
   test_first_enqueue_with_runtime_eio_guard ();
@@ -873,6 +896,7 @@ let () =
   test_runtime_root_child_replacement_during_inventory_is_rejected ();
   test_foreign_database_and_symlink_are_quarantined ();
   test_reconcile_absent_lane_and_stage_order ();
+  test_finalize_statement_total ();
   if !failures > 0
   then (
     Printf.printf "FAILED: %d check(s)\n%!" !failures;


### PR DESCRIPTION
## 요약

`Sqlite3.finalize`는 rc 반환 외에 SqliteError를 raise할 수 있는데(binding mli:480), `sqlite_finalize` 래퍼가 이를 처리하지 않아 `with_statement`에서 두 가지 탈출이 가능했습니다:
1. 정상 경로: cleanup의 raise가 `body_result`를 소실시킴
2. `Eio.Cancel.Cancelled` 경로: Cancelled가 SqliteError로 치환 — Eio 취소 전파 위반 (KeeperTurnFSM.tla의 CancelledNeverAbsorbed 클래스)

match-with-exception으로 total 전환. `Sqlite3.finalize`는 비서스펜딩 C 호출이라 catch-all이 Cancelled 자체를 삼킬 수 없음.

## 배경 (issue #24696)

07-15 23:32 stmt GC-finalizer SIGSEGV의 감사 결과물. sqlite3-ocaml 5.4.1 C stubs 정독으로 기존 "busy-tolerant close" 이론은 기각(`my_sqlite3_close = sqlite3_close_v2`, 좀비 체인은 메모리 안전), crash는 #24533/#24535 fiber-safety 수리 이전의 stale binary로 귀속이 유력. 상세: https://github.com/jeong-sik/masc/issues/24696#issuecomment-4986865818

## 검증

- 로컬 빌드 green (chat consumer/coalescing 테스트 exe 포함)
- 해당 테스트들의 로컬 실패는 이 변경과 무관 — 무수정 main에서 동일 실패 재현(RNG 미초기화 → Eio mutex Poisoned 연쇄), #24735 green train의 lib/auth RNG 수리가 해소 예정
- 이 브랜치는 main 기준이라 Build and Test는 #24735 착지 전까지 base hang 상속 — 착지 후 rebase/re-run 예정

RFC-WAIVED: FFI 경계 exception→Result totality 전환 1함수 — credential/identity 아키텍처 표면 무변경.
