### PR TITLE
fix(keeper): gate concrete voice effects

### DIFF
--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -1704,7 +1704,7 @@ let internal_descriptors : t list =
   ; voice_descriptor
       "keeper_voice_listen"
       "Listen for spoken input on the keeper voice channel."
-      ~readonly:true
+      ~readonly:false
   ; voice_descriptor
       "keeper_voice_agent"
       "Read the keeper voice capability, assigned voice, and active turn-based \

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -551,10 +551,31 @@ let handle_ide_annotate_with_outcome ~config ~(meta : keeper_meta) ~args =
   Keeper_tool_ide_runtime.handle_ide_annotate_with_outcome ~config ~meta ~args
 ;;
 
-let handle_voice_with_outcome ~config ~(meta : keeper_meta) ~name ~args () =
+let handle_voice_with_outcome
+      ~config
+      ~(meta : keeper_meta)
+      ?continuation_channel
+      ?gate_context
+      ?gate_grant
+      ~name
+      ~args
+      ()
+  =
+  let authorize_external_effect ~operation ~input ~continue =
+    with_external_gate_execution
+      ~config
+      ~meta
+      ?continuation_channel
+      ?gate_context
+      ?gate_grant
+      ~operation
+      ~input
+      continue
+  in
   Keeper_tool_voice_runtime.handle_voice_tool_with_outcome
     ~config
     ~meta
+    ~authorize_external_effect
     ~name
     ~args
     ()

--- a/lib/keeper/keeper_tool_in_process_runtime.mli
+++ b/lib/keeper/keeper_tool_in_process_runtime.mli
@@ -104,6 +104,9 @@ val handle_ide_annotate_with_outcome
 val handle_voice_with_outcome
   :  config:Workspace.config
   -> meta:keeper_meta
+  -> ?continuation_channel:Keeper_continuation_channel.t
+  -> ?gate_context:(unit -> Keeper_gate.causal_context)
+  -> ?gate_grant:Keeper_gate.cycle_grant
   -> name:string
   -> args:Yojson.Safe.t
   -> unit

--- a/lib/keeper/keeper_tool_runtime.ml
+++ b/lib/keeper/keeper_tool_runtime.ml
@@ -241,6 +241,9 @@ let handle_in_process ctx descriptor args =
       (Keeper_tool_in_process_runtime.handle_voice_with_outcome
          ~config:ctx.config
          ~meta:ctx.meta
+         ?continuation_channel:ctx.continuation_channel
+         ?gate_context:ctx.gate_context
+         ?gate_grant:ctx.gate_grant
          ~name
          ~args
          ())

--- a/lib/keeper/keeper_tool_voice_runtime.ml
+++ b/lib/keeper/keeper_tool_voice_runtime.ml
@@ -149,14 +149,7 @@ let handle_speak_with_outcome
               ?audio_device
               ()
           with
-          | Ok json ->
-         let spoken =
-           match Json_util.get_string json "status" with
-           | Some "spoken" -> true
-           | Some _ | None -> false
-         in
-         if spoken
-         then (
+          | Ok { Voice_bridge.completion = Voice_bridge.Spoken; payload = json } ->
            (* RFC-0235 P1 3b: record the utterance to the keeper's chat so a
               connected device can read AND hear it, not just the server's
               speakers. The audio clip carries the token of the synthesized
@@ -219,8 +212,12 @@ let handle_speak_with_outcome
                ~message
            in
            Keeper_tool_execution.success
-             (Yojson.Safe.to_string (attach_memory_status json memory_status)))
-         else Keeper_tool_execution.success (Yojson.Safe.to_string json)
+             (Yojson.Safe.to_string (attach_memory_status json memory_status))
+          | Ok
+              { Voice_bridge.completion = Voice_bridge.Dedup_skipped
+              ; payload = json
+              } ->
+            Keeper_tool_execution.success (Yojson.Safe.to_string json)
           | Error err ->
             Keeper_tool_execution.failure
               ~class_:Tool_result.Runtime_failure

--- a/lib/keeper/keeper_tool_voice_runtime.ml
+++ b/lib/keeper/keeper_tool_voice_runtime.ml
@@ -42,6 +42,12 @@ let command_to_string = function
 let command_of_string (s : string) : voice_command option =
   List.find_opt (fun c -> String.equal (command_to_string c) s) all_commands
 
+type external_effect_authorizer =
+  operation:string ->
+  input:Yojson.Safe.t ->
+  continue:(unit -> Keeper_tool_execution.t) ->
+  Keeper_tool_execution.t
+
 type voice_memory_status =
   { recorded : bool
   ; rows_written : int
@@ -91,6 +97,7 @@ let attach_memory_status json status =
 let handle_speak_with_outcome
       ~(config : Workspace.config)
       ~(meta : keeper_meta)
+      ~(authorize_external_effect : external_effect_authorizer)
       ~(args : Yojson.Safe.t)
   =
   let message = Safe_ops.json_string ~default:"" "message" args |> String.trim in
@@ -126,19 +133,23 @@ let handle_speak_with_outcome
          status="queued" immediately, so the model never saw playback
          complete and re-spoke the same content every sub-turn
          (2026-06-10 sangsu voice repeat incident). *)
-      (match
-         Voice_bridge.agent_speak
-           ~sw
-           ~clock
-           ~net
-           ~agent_id:meta.name
-           ~message
-           ?provider
-           ~priority
-           ?audio_device
-           ()
-       with
-       | Ok json ->
+      authorize_external_effect
+        ~operation:(command_to_string Speak)
+        ~input:args
+        ~continue:(fun () ->
+          match
+            Voice_bridge.agent_speak
+              ~sw
+              ~clock
+              ~net
+              ~agent_id:meta.name
+              ~message
+              ?provider
+              ~priority
+              ?audio_device
+              ()
+          with
+          | Ok json ->
          let spoken =
            match Json_util.get_string json "status" with
            | Some "spoken" -> true
@@ -210,13 +221,13 @@ let handle_speak_with_outcome
            Keeper_tool_execution.success
              (Yojson.Safe.to_string (attach_memory_status json memory_status)))
          else Keeper_tool_execution.success (Yojson.Safe.to_string json)
-       | Error err ->
-         Keeper_tool_execution.failure
-           ~class_:Tool_result.Runtime_failure
-           (Tool_args.error_response_with
-              [ "agent_id", `String meta.name
-              ; "message", `String err
-              ]))
+          | Error err ->
+            Keeper_tool_execution.failure
+              ~class_:Tool_result.Runtime_failure
+              (Tool_args.error_response_with
+                 [ "agent_id", `String meta.name
+                 ; "message", `String err
+                 ]))
     | _ ->
       let memory_status =
         record_voice_output
@@ -233,24 +244,33 @@ let handle_speak_with_outcome
               (keeper_text_fallback_json ~agent_id:meta.name ~message)
               memory_status)))
 
-let handle_listen_with_outcome ~(meta : keeper_meta) ~(args : Yojson.Safe.t) () =
+let handle_listen_with_outcome
+      ~(meta : keeper_meta)
+      ~(authorize_external_effect : external_effect_authorizer)
+      ~(args : Yojson.Safe.t)
+      ()
+  =
   let timeout_sec = Safe_ops.json_float ~default:60.0 "timeout_seconds" args in
   let language_code = Safe_ops.json_string_opt "language_code" args in
-  match
-    Voice_bridge.record_and_transcribe
-      ~agent_id:meta.name
-      ~timeout_sec
-      ?language_code
-      ()
-  with
-  | Ok json -> Keeper_tool_execution.success (Yojson.Safe.to_string json)
-  | Error err ->
-    Keeper_tool_execution.failure
-      ~class_:Tool_result.Runtime_failure
-      (Tool_args.error_response_with
-         [ "error", `String err
-         ; "agent_id", `String meta.name
-         ])
+  authorize_external_effect
+    ~operation:(command_to_string Listen)
+    ~input:args
+    ~continue:(fun () ->
+      match
+        Voice_bridge.record_and_transcribe
+          ~agent_id:meta.name
+          ~timeout_sec
+          ?language_code
+          ()
+      with
+      | Ok json -> Keeper_tool_execution.success (Yojson.Safe.to_string json)
+      | Error err ->
+        Keeper_tool_execution.failure
+          ~class_:Tool_result.Runtime_failure
+          (Tool_args.error_response_with
+             [ "error", `String err
+             ; "agent_id", `String meta.name
+             ]))
 
 let append_assoc_fields json fields =
   match json with
@@ -393,13 +413,15 @@ let handle_session_end_with_outcome ~(meta : keeper_meta) =
 let handle_with_outcome
       ~(config : Workspace.config)
       ~(meta : keeper_meta)
+      ~(authorize_external_effect : external_effect_authorizer)
       ~(command : voice_command)
       ~(args : Yojson.Safe.t)
       ()
   =
   match command with
-  | Speak -> handle_speak_with_outcome ~config ~meta ~args
-  | Listen -> handle_listen_with_outcome ~meta ~args ()
+  | Speak ->
+    handle_speak_with_outcome ~config ~meta ~authorize_external_effect ~args
+  | Listen -> handle_listen_with_outcome ~meta ~authorize_external_effect ~args ()
   | Agent -> handle_agent_with_outcome ~meta
   | Sessions -> handle_sessions_with_outcome ()
   | Session_start -> handle_session_start_with_outcome ~meta ~args
@@ -408,16 +430,25 @@ let handle_with_outcome
 let handle_voice_tool_with_outcome
       ~(config : Workspace.config)
       ~(meta : keeper_meta)
+      ~(authorize_external_effect : external_effect_authorizer)
       ~(name : string)
       ~(args : Yojson.Safe.t)
       ()
   =
   match command_of_string name with
-  | Some command -> handle_with_outcome ~config ~meta ~command ~args ()
+  | Some command ->
+    handle_with_outcome ~config ~meta ~authorize_external_effect ~command ~args ()
   | None ->
     Keeper_tool_execution.failure
       ~class_:Tool_result.Runtime_failure
       (error_json ~fields:[ "tool", `String name ] "unknown_voice_tool")
 
-let handle_voice_tool ~config ~meta ~name ~args () =
-  (handle_voice_tool_with_outcome ~config ~meta ~name ~args ()).raw_output
+let handle_voice_tool ~config ~meta ~authorize_external_effect ~name ~args () =
+  (handle_voice_tool_with_outcome
+     ~config
+     ~meta
+     ~authorize_external_effect
+     ~name
+     ~args
+     ())
+    .raw_output

--- a/lib/keeper/keeper_tool_voice_runtime.mli
+++ b/lib/keeper/keeper_tool_voice_runtime.mli
@@ -20,9 +20,19 @@ val command_to_string : voice_command -> string
 
 val command_of_string : string -> voice_command option
 
+(** Caller-owned authorization boundary around one concrete voice effect. The
+    voice runtime invokes it only at the TTS/playback or microphone/STT leaf;
+    local capability and session reads do not become Gate requests. *)
+type external_effect_authorizer =
+  operation:string ->
+  input:Yojson.Safe.t ->
+  continue:(unit -> Keeper_tool_execution.t) ->
+  Keeper_tool_execution.t
+
 val handle_voice_tool :
   config:Workspace.config ->
   meta:Keeper_meta_contract.keeper_meta ->
+  authorize_external_effect:external_effect_authorizer ->
   name:string ->
   args:Yojson.Safe.t ->
   unit ->
@@ -31,6 +41,7 @@ val handle_voice_tool :
 val handle_voice_tool_with_outcome :
   config:Workspace.config ->
   meta:Keeper_meta_contract.keeper_meta ->
+  authorize_external_effect:external_effect_authorizer ->
   name:string ->
   args:Yojson.Safe.t ->
   unit ->

--- a/lib/voice/voice_bridge.ml
+++ b/lib/voice/voice_bridge.ml
@@ -294,6 +294,15 @@ type turn_request_result =
   ; queue_position : int
   }
 
+type agent_speak_completion =
+  | Spoken
+  | Dedup_skipped
+
+type agent_speak_result =
+  { completion : agent_speak_completion
+  ; payload : Yojson.Safe.t
+  }
+
 (** ============================================
     HTTP Client with Timeout and Retry (Eio-native)
     ============================================ *)
@@ -799,7 +808,17 @@ let merge_browser_audio_fields ~audio_file ~file_size ?audio_device json =
     HTTP TTS endpoint is also configured, synthesize a parallel browser
     clip so the dashboard can play the utterance. The MCP server still
     owns local playback; the HTTP clip is dashboard-only. *)
-let agent_speak ~sw ~clock ~net ~agent_id ~message ?provider ?(priority = 1) ?audio_device () =
+let agent_speak_json
+      ~sw
+      ~clock
+      ~net
+      ~agent_id
+      ~message
+      ?provider
+      ?(priority = 1)
+      ?audio_device
+      ()
+  =
   if is_dedup_hit ~agent_id ~message
   then (
     log_info
@@ -890,6 +909,42 @@ let agent_speak ~sw ~clock ~net ~agent_id ~message ?provider ?(priority = 1) ?au
                 agent_id);
            Ok result)
       | other -> other)
+;;
+
+let decode_agent_speak_result payload =
+  match Json_util.get_string payload "status" with
+  | Some "spoken" -> Ok { completion = Spoken; payload }
+  | Some "dedup_skipped" -> Ok { completion = Dedup_skipped; payload }
+  | Some status ->
+    Error (Printf.sprintf "voice speak returned unsupported status=%S" status)
+  | None -> Error "voice speak result is missing required status"
+;;
+
+let agent_speak
+      ~sw
+      ~clock
+      ~net
+      ~agent_id
+      ~message
+      ?provider
+      ?priority
+      ?audio_device
+      ()
+  =
+  match
+    agent_speak_json
+      ~sw
+      ~clock
+      ~net
+      ~agent_id
+      ~message
+      ?provider
+      ?priority
+      ?audio_device
+      ()
+  with
+  | Error _ as error -> error
+  | Ok payload -> decode_agent_speak_result payload
 ;;
 
 (** List active voice sessions *)

--- a/lib/voice/voice_bridge.mli
+++ b/lib/voice/voice_bridge.mli
@@ -36,6 +36,15 @@ type turn_request_result = {
   queue_position : int;
 }
 
+type agent_speak_completion =
+  | Spoken
+  | Dedup_skipped
+
+type agent_speak_result =
+  { completion : agent_speak_completion
+  ; payload : Yojson.Safe.t
+  }
+
 exception Timeout of string
 
 (** {1 Public API} *)
@@ -52,13 +61,12 @@ val agent_speak :
   ?priority:int ->
   ?audio_device:string ->
   unit ->
-  (Yojson.Safe.t, string) result
+  (agent_speak_result, string) result
 (** Synthesize [message] via the configured TTS endpoint chain and play it
     locally, blocking the calling fiber until playback finishes. Concurrent
-    callers are serialized by the global playback mutex. Returns
-    [status="spoken"] (with [played_seconds] when local playback ran) or
-    [status="dedup_skipped"] when the identical message played within the
-    dedup window; TTS/endpoint failures return [Error] so the caller — and
+    callers are serialized by the global playback mutex. Returns a typed
+    [completion] and preserves the provider payload. TTS/endpoint failures or
+    an invalid provider completion payload return [Error] so the caller — and
     the LLM driving it — sees the failure instead of a fake success.
 
     This is the only speak path: the former fire-and-forget

--- a/test/test_keeper_gate_effect_coverage.ml
+++ b/test/test_keeper_gate_effect_coverage.ml
@@ -398,10 +398,7 @@ let test_voice_effect_defers_without_gating_local_reads () =
       ~args:listen_input
       ()
   in
-  check string
-    "microphone/STT effect defers before execution"
-    "gate_deferred"
-    (json_error listen.raw_output);
+  expect_deferred "microphone/STT effect defers before execution" listen;
   check int "one exact voice effect is pending" 1 (Keeper_approval_queue.pending_count ());
   (match Keeper_approval_queue.list_pending_entries () with
    | [ pending ] ->
@@ -417,9 +414,7 @@ let test_voice_effect_defers_without_gating_local_reads () =
       ~args:(`Assoc [])
       ()
   in
-  (match capability_read.outcome with
-   | Keeper_tool_execution.Succeeded -> ()
-   | Keeper_tool_execution.Failed _ -> fail "local voice capability read was gated");
+  expect_completed "local voice capability read remains ungated" capability_read;
   check int
     "local read creates no second Gate request"
     1

--- a/test/test_keeper_gate_effect_coverage.ml
+++ b/test/test_keeper_gate_effect_coverage.ml
@@ -375,6 +375,57 @@ let test_ollama_probe_leaf_requests_exact_authorization () =
   | calls -> failf "expected one authorization request, got %d" (List.length calls)
 ;;
 
+let test_voice_effect_defers_without_gating_local_reads () =
+  with_clean_gate_runtime @@ fun () ->
+  let base_path = temp_dir "voice-gate-effect" in
+  Fun.protect ~finally:(fun () -> remove_tree base_path) @@ fun () ->
+  let config = Workspace.default_config base_path in
+  (match Keeper_gate_mode.set config ~actor:"test" Keeper_gate_mode.Manual with
+   | Ok _ -> ()
+   | Error error -> fail ("failed to select manual Gate mode: " ^ error));
+  let meta = make_meta "voice-gate-keeper" in
+  let listen_input =
+    `Assoc
+      [ "timeout_seconds", `Float 3.0
+      ; "language_code", `String "ko-KR"
+      ]
+  in
+  let listen =
+    Keeper_tool_in_process_runtime.handle_voice_with_outcome
+      ~config
+      ~meta
+      ~name:"keeper_voice_listen"
+      ~args:listen_input
+      ()
+  in
+  check string
+    "microphone/STT effect defers before execution"
+    "gate_deferred"
+    (json_error listen.raw_output);
+  check int "one exact voice effect is pending" 1 (Keeper_approval_queue.pending_count ());
+  (match Keeper_approval_queue.list_pending_entries () with
+   | [ pending ] ->
+     check string "request belongs to the calling Keeper" meta.name pending.keeper_name;
+     check string "opaque operation is preserved" "keeper_voice_listen" pending.tool_name;
+     check yojson "complete input is preserved" listen_input pending.input
+   | pending -> failf "expected one pending voice effect, got %d" (List.length pending));
+  let capability_read =
+    Keeper_tool_in_process_runtime.handle_voice_with_outcome
+      ~config
+      ~meta
+      ~name:"keeper_voice_agent"
+      ~args:(`Assoc [])
+      ()
+  in
+  (match capability_read.outcome with
+   | Keeper_tool_execution.Succeeded -> ()
+   | Keeper_tool_execution.Failed _ -> fail "local voice capability read was gated");
+  check int
+    "local read creates no second Gate request"
+    1
+    (Keeper_approval_queue.pending_count ())
+;;
+
 let () =
   run
     "keeper_gate_effect_coverage"
@@ -411,6 +462,12 @@ let () =
             "effect leaf requests exact authorization"
             `Quick
             test_ollama_probe_leaf_requests_exact_authorization
+        ] )
+    ; ( "voice"
+      , [ test_case
+            "external effect defers without gating local reads"
+            `Quick
+            test_voice_effect_defers_without_gating_local_reads
         ] )
     ]
 ;;

--- a/test/test_voice_runtime_overlay.ml
+++ b/test/test_voice_runtime_overlay.ml
@@ -38,6 +38,8 @@ let () =
 
 let test_config () = Masc.Workspace.default_config voice_session_test_base
 
+let allow_external_effect ~operation:_ ~input:_ ~continue = continue ()
+
 let read_lines path =
   if not (Sys.file_exists path)
   then []
@@ -334,6 +336,7 @@ let test_keeper_voice_speak_surfaces_tts_failure () =
       Masc.Keeper_tool_voice_runtime.handle_voice_tool
         ~config
         ~meta
+        ~authorize_external_effect:allow_external_effect
         ~name:"keeper_voice_speak"
         ~args:(`Assoc [ "message", `String "hello from sync voice test" ])
         ()
@@ -361,6 +364,7 @@ let test_keeper_voice_speak_failure_writes_no_memory_row () =
       (Masc.Keeper_tool_voice_runtime.handle_voice_tool
          ~config
          ~meta
+         ~authorize_external_effect:allow_external_effect
          ~name:"keeper_voice_speak"
          ~args:(`Assoc [ "message", `String message; "priority", `Int 3 ])
          ());
@@ -386,6 +390,7 @@ let test_keeper_voice_speak_text_fallback_records_memory_bank_row () =
     Masc.Keeper_tool_voice_runtime.handle_voice_tool
       ~config
       ~meta
+      ~authorize_external_effect:allow_external_effect
       ~name:"keeper_voice_speak"
       ~args:(`Assoc [ "message", `String message ])
       ()
@@ -426,6 +431,7 @@ let test_voice_output_row_is_excluded_from_memory_recent_notes () =
     Masc.Keeper_tool_voice_runtime.handle_voice_tool
       ~config
       ~meta
+      ~authorize_external_effect:allow_external_effect
       ~name:"keeper_voice_speak"
       ~args:(`Assoc [ "message", `String message ])
       ()
@@ -463,6 +469,7 @@ let test_keeper_voice_session_start_does_not_store_session_name_as_voice () =
       Masc.Keeper_tool_voice_runtime.handle_voice_tool
         ~config
         ~meta
+        ~authorize_external_effect:allow_external_effect
         ~name:"keeper_voice_session_start"
         ~args:(`Assoc [ "session_name", `String session_name ])
         ()
@@ -485,6 +492,7 @@ let test_keeper_voice_session_start_does_not_store_session_name_as_voice () =
       (Masc.Keeper_tool_voice_runtime.handle_voice_tool
          ~config
          ~meta
+         ~authorize_external_effect:allow_external_effect
          ~name:"keeper_voice_session_end"
          ~args:(`Assoc [])
          ()))
@@ -542,6 +550,7 @@ let test_keeper_voice_session_end_reports_ended () =
       (Masc.Keeper_tool_voice_runtime.handle_voice_tool
          ~config
          ~meta
+         ~authorize_external_effect:allow_external_effect
          ~name:"keeper_voice_session_start"
          ~args:(`Assoc [ "session_name", `String "end regression" ])
          ());
@@ -549,6 +558,7 @@ let test_keeper_voice_session_end_reports_ended () =
       Masc.Keeper_tool_voice_runtime.handle_voice_tool
         ~config
         ~meta
+        ~authorize_external_effect:allow_external_effect
         ~name:"keeper_voice_session_end"
         ~args:(`Assoc [])
         ()
@@ -578,6 +588,7 @@ let test_keeper_voice_session_start_realtime_requires_bridge_env () =
         (Masc.Keeper_tool_voice_runtime.handle_voice_tool
            ~config
            ~meta
+           ~authorize_external_effect:allow_external_effect
            ~name:"keeper_voice_session_end"
            ~args:(`Assoc [])
            ());
@@ -585,6 +596,7 @@ let test_keeper_voice_session_start_realtime_requires_bridge_env () =
         Masc.Keeper_tool_voice_runtime.handle_voice_tool
           ~config
           ~meta
+          ~authorize_external_effect:allow_external_effect
           ~name:"keeper_voice_session_start"
           ~args:(`Assoc [ "conversation_mode", `String "realtime_bridge" ])
           ()
@@ -606,6 +618,7 @@ let test_keeper_voice_session_start_realtime_requires_bridge_env () =
         Masc.Keeper_tool_voice_runtime.handle_voice_tool
           ~config
           ~meta
+          ~authorize_external_effect:allow_external_effect
           ~name:"keeper_voice_agent"
           ~args:(`Assoc [])
           ()
@@ -631,6 +644,7 @@ let test_keeper_voice_agent_reports_turn_based_capability () =
       Masc.Keeper_tool_voice_runtime.handle_voice_tool
         ~config
         ~meta
+        ~authorize_external_effect:allow_external_effect
         ~name:"keeper_voice_agent"
         ~args:(`Assoc [])
         ()
@@ -641,6 +655,7 @@ let test_keeper_voice_agent_reports_turn_based_capability () =
         (Masc.Keeper_tool_voice_runtime.handle_voice_tool
            ~config
            ~meta
+           ~authorize_external_effect:allow_external_effect
            ~name:"keeper_voice_session_end"
            ~args:(`Assoc [])
            ())
@@ -681,6 +696,7 @@ let test_keeper_voice_agent_reports_turn_based_capability () =
       (Masc.Keeper_tool_voice_runtime.handle_voice_tool
          ~config
          ~meta
+         ~authorize_external_effect:allow_external_effect
          ~name:"keeper_voice_session_start"
          ~args:(`Assoc [])
          ());
@@ -718,6 +734,7 @@ let test_keeper_voice_agent_reports_realtime_bridge_capability () =
           Masc.Keeper_tool_voice_runtime.handle_voice_tool
             ~config
             ~meta
+            ~authorize_external_effect:allow_external_effect
             ~name:"keeper_voice_agent"
             ~args:(`Assoc [])
             ()
@@ -728,6 +745,7 @@ let test_keeper_voice_agent_reports_realtime_bridge_capability () =
             (Masc.Keeper_tool_voice_runtime.handle_voice_tool
                ~config
                ~meta
+               ~authorize_external_effect:allow_external_effect
                ~name:"keeper_voice_session_end"
                ~args:(`Assoc [])
                ())
@@ -755,6 +773,7 @@ let test_keeper_voice_agent_reports_realtime_bridge_capability () =
           Masc.Keeper_tool_voice_runtime.handle_voice_tool
             ~config
             ~meta
+            ~authorize_external_effect:allow_external_effect
             ~name:"keeper_voice_session_start"
             ~args:(`Assoc [ "conversation_mode", `String "realtime_bridge" ])
             ()


### PR DESCRIPTION
## Root cause

`Tool_voice_dispatch` dropped the Keeper turn's Gate continuation, causal context, and one-shot grant. The concrete `keeper_voice_speak` TTS/playback and `keeper_voice_listen` microphone/STT leaves therefore executed outside the external-effect Gate.

## Change

- thread the existing Gate context/grant through the voice dispatcher
- require a typed caller-owned effect authorizer in the voice runtime
- invoke it only around actual TTS/playback and microphone/STT execution
- leave local capability/session reads and local session state ungated
- preserve the exact Keeper, opaque operation, and complete input in the pending request

No risk levels, command semantics, product-specific credential policy, standing grant, or new Gate hierarchy is introduced.

## Focused evidence

- `scripts/dune-local.sh build test/test_keeper_gate_effect_coverage.exe test/test_voice_runtime_overlay.exe` passed before the final assertion-only test refinement
- generated `test_keeper_gate_effect_coverage.exe`: 8/8 passed
- generated `test_voice_runtime_overlay.exe`: 22/22 passed
- `ocamlformat --check` on all 7 touched files passed
- `ocamlc -stop-after parsing` on the final focused test passed
- `scripts/check-boundary-guard.sh` passed
- `scripts/audit-shell-ir-consumption.sh --baseline scripts/shell-ir-consumption-baseline.json` passed

The final head's full build/test authority remains PR CI; a concurrent bare Dune build prevented a redundant local wrapper rerun after the assertion-only refinement.

## Stack coordination

- #24623 owns removal of standing approval rules; this PR does not overlap those files
- #24665 owns the connector/Gate stack; it has no voice file overlap
