### PR TITLE
test(gate): purge retired standing rule arms

### DIFF
--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -545,7 +545,6 @@ let test_cycle_grant_uses_exact_effect_and_is_consumed_once () =
         with
         | Gate.Keeper_always_allow -> ()
         | Gate.One_shot_resolution _
-        | Gate.Exact_always_rule _
         | Gate.Workspace_always_allow ->
           Alcotest.fail "different exact input consumed the grant");
        (match
@@ -560,7 +559,6 @@ let test_cycle_grant_uses_exact_effect_and_is_consumed_once () =
         with
         | Gate.One_shot_resolution actual_id ->
           Alcotest.(check string) "exact approval id" approval_id actual_id
-        | Gate.Exact_always_rule _
         | Gate.Keeper_always_allow
         | Gate.Workspace_always_allow ->
           Alcotest.fail "exact effect did not consume its one-shot grant");
@@ -573,7 +571,6 @@ let test_cycle_grant_uses_exact_effect_and_is_consumed_once () =
         with
         | Gate.Keeper_always_allow -> ()
         | Gate.One_shot_resolution _
-        | Gate.Exact_always_rule _
         | Gate.Workspace_always_allow ->
           Alcotest.fail "one-shot grant was consumed more than once");
        (match


### PR DESCRIPTION
## What changed

- Deleted the three stale `Gate.Exact_always_rule` pattern arms from the one-shot grant test.
- Preserved the live one-shot authorization assertions and the #24636 Auto Judge lane recovery implementation unchanged.

## Why

#24636 removes the standing approval constructor from the production Gate contract. The remaining test patterns referenced a constructor that no longer exists, so the stacked branch could not type-check.

This is a hard deletion of retired test residue. It does not add a compatibility shim, absence test, or replacement standing-rule behavior.

## Validation

- `ocamlformat --check test/test_keeper_approval_queue.ml`
- `git diff --check`
- residue scan for `Exact_always_rule`, `remember_rule`, and `approval_rule` across the touched test and Gate interface
- verified no diff from #24636 in `keeper_gate.ml/.mli` or `keeper_approval_queue.ml/.mli`
- focused Dune target was attempted through `scripts/dune-local.sh`; the wrapper correctly refused concurrent execution because another session has a long-running bare Dune process. Full build remains CI authority.

## Stack

- Base: #24636 (`codex/gate-product-dispatch-hardcut-20260715`)
- Diff: 1 file, 3 deletions
