### PR TITLE
fix(keeper): converge restart candidates per lane

### DIFF
--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -271,20 +271,45 @@ type keeper_persistence_report =
   ; requests : Keeper_msg_async.recovery_report
   }
 
+module Recovery_target = struct
+  type t = Keeper_invocation_types.target
+
+  let compare left right =
+    match left, right with
+    | Keeper left_name, Keeper right_name ->
+      String.compare
+        (Keeper_id.Keeper_name.to_string left_name)
+        (Keeper_id.Keeper_name.to_string right_name)
+  ;;
+end
+
+module Recovery_target_map = Map.Make (Recovery_target)
+
 let recovery_candidate_lanes candidates =
-  candidates
-  |> List.fold_left
-       (fun lanes (candidate : Keeper_msg_async.recovery_candidate) ->
-          let keeper_name =
-            Keeper_invocation_types.request_target_name candidate.entry.request
-          in
-          match lanes with
-          | (current, rev_candidates) :: rest when String.equal current keeper_name ->
-            (current, candidate :: rev_candidates) :: rest
-          | _ -> (keeper_name, [ candidate ]) :: lanes)
-       []
-  |> List.rev_map (fun (keeper_name, rev_candidates) ->
-    keeper_name, List.rev rev_candidates)
+  let lane_order_rev, candidates_by_target =
+    List.fold_left
+      (fun (lane_order_rev, candidates_by_target)
+        (candidate : Keeper_msg_async.recovery_candidate) ->
+         let target = Keeper_invocation_types.request_target candidate.entry.request in
+         match Recovery_target_map.find_opt target candidates_by_target with
+         | None ->
+           ( target :: lane_order_rev
+           , Recovery_target_map.add target [ candidate ] candidates_by_target )
+         | Some candidates_rev ->
+           ( lane_order_rev
+           , Recovery_target_map.add
+               target
+               (candidate :: candidates_rev)
+               candidates_by_target ))
+      ([], Recovery_target_map.empty)
+      candidates
+  in
+  List.rev_map
+    (fun target ->
+       match Recovery_target_map.find_opt target candidates_by_target with
+       | Some candidates_rev -> target, List.rev candidates_rev
+       | None -> invalid_arg "recovery lane target missing from immutable index")
+    lane_order_rev
 ;;
 
 type keeper_persistence_failure_phase =
@@ -1223,6 +1248,19 @@ let start_keeper_loops_owned
     loop ());
   (* Inject Event_bus into keeper keepalive runtime for telemetry publishing *)
   Keeper_keepalive.set_bus event_bus;
+  let observe_recovery_projection ~request_id = function
+    | Keeper_tool_surface_ops.Completion_not_durable ->
+      Log.Keeper.error
+        "keeper invocation restart completion was not durable request_id=%s"
+        request_id
+    | Keeper_tool_surface_ops.Completion_storage_failed _ ->
+      (* [project_keeper_completion] emits the exact failed operation and
+         storage detail before returning this typed result. *)
+      ()
+    | Keeper_tool_surface_ops.Completion_not_routed
+    | Keeper_tool_surface_ops.Completion_enqueued
+    | Keeper_tool_surface_ops.Completion_already_present -> ()
+  in
   let project_recovery_terminal (entry : Keeper_msg_async.entry) =
     match
       Keeper_msg_async.load_canonical_durable_terminal
@@ -1231,10 +1269,9 @@ let start_keeper_loops_owned
         entry.request_id
     with
     | Ok proof ->
-      ignore
-        (Keeper_tool_surface_ops.project_durable_keeper_completion
-           ~base_path:config.base_path proof
-          : Keeper_tool_surface_ops.keeper_completion_projection)
+      Keeper_tool_surface_ops.project_durable_keeper_completion
+        ~base_path:config.base_path proof
+      |> observe_recovery_projection ~request_id:entry.request_id
     | Error error ->
       Log.Keeper.error
         "keeper invocation restart terminal reload failed request_id=%s error=%s"
@@ -1255,13 +1292,12 @@ let start_keeper_loops_owned
         ~finally:(fun () ->
           ignore (Eio.Promise.try_resolve resolve_settled () : bool))
         (fun () ->
-           ignore
-             (Keeper_tool_surface_ops.project_keeper_completion
-                ~base_path:config.base_path
-                ~submitted_by:entry.submitted_by
-                ~request_id
-                settlement
-               : Keeper_tool_surface_ops.keeper_completion_projection))
+           Keeper_tool_surface_ops.project_keeper_completion
+             ~base_path:config.base_path
+             ~submitted_by:entry.submitted_by
+             ~request_id
+             settlement
+           |> observe_recovery_projection ~request_id)
     in
     let f request_sw =
       match candidate.provenance with
@@ -1318,7 +1354,8 @@ let start_keeper_loops_owned
   in
   claimed_persistence.claimed_report.requests.candidates
   |> recovery_candidate_lanes
-  |> List.iter (fun (keeper_name, candidates) ->
+  |> List.iter (fun (target, candidates) ->
+    let keeper_name = Keeper_invocation_types.target_name target in
     fork_logged_fiber
       ~sw
       ~on_error:(fun exn ->

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -271,6 +271,22 @@ type keeper_persistence_report =
   ; requests : Keeper_msg_async.recovery_report
   }
 
+let recovery_candidate_lanes candidates =
+  candidates
+  |> List.fold_left
+       (fun lanes (candidate : Keeper_msg_async.recovery_candidate) ->
+          let keeper_name =
+            Keeper_invocation_types.request_target_name candidate.entry.request
+          in
+          match lanes with
+          | (current, rev_candidates) :: rest when String.equal current keeper_name ->
+            (current, candidate :: rev_candidates) :: rest
+          | _ -> (keeper_name, [ candidate ]) :: lanes)
+       []
+  |> List.rev_map (fun (keeper_name, rev_candidates) ->
+    keeper_name, List.rev rev_candidates)
+;;
+
 type keeper_persistence_failure_phase =
   | Resolving_base_path
   | Restoring_shutdown
@@ -1207,6 +1223,110 @@ let start_keeper_loops_owned
     loop ());
   (* Inject Event_bus into keeper keepalive runtime for telemetry publishing *)
   Keeper_keepalive.set_bus event_bus;
+  let project_recovery_terminal (entry : Keeper_msg_async.entry) =
+    match
+      Keeper_msg_async.load_canonical_durable_terminal
+        ~base_path:config.base_path
+        ~caller:entry.submitted_by
+        entry.request_id
+    with
+    | Ok proof ->
+      ignore
+        (Keeper_tool_surface_ops.project_durable_keeper_completion
+           ~base_path:config.base_path proof
+          : Keeper_tool_surface_ops.keeper_completion_projection)
+    | Error error ->
+      Log.Keeper.error
+        "keeper invocation restart terminal reload failed request_id=%s error=%s"
+        entry.request_id
+        (Keeper_msg_async.canonical_terminal_error_to_string error)
+  in
+  let explicit_recovery_failure request_id reason =
+    Tool_result.error
+      ~tool_name:"keeper_invocation_recovery"
+      ~start_time:(Time_compat.now ())
+      (Printf.sprintf "restart recovery failed request_id=%s: %s" request_id reason)
+  in
+  let run_recovery_candidate (candidate : Keeper_msg_async.recovery_candidate) =
+    let entry = candidate.entry in
+    let settled, resolve_settled = Eio.Promise.create () in
+    let on_worker_settled ~request_id settlement =
+      Fun.protect
+        ~finally:(fun () ->
+          ignore (Eio.Promise.try_resolve resolve_settled () : bool))
+        (fun () ->
+           ignore
+             (Keeper_tool_surface_ops.project_keeper_completion
+                ~base_path:config.base_path
+                ~submitted_by:entry.submitted_by
+                ~request_id
+                settlement
+               : Keeper_tool_surface_ops.keeper_completion_projection))
+    in
+    let f request_sw =
+      match candidate.provenance with
+      | Keeper_msg_async.Running_before_restart ->
+        explicit_recovery_failure
+          entry.request_id
+          "execution had already started before process restart; effect replay was refused"
+      | Keeper_msg_async.Cancelling_before_restart _ ->
+        explicit_recovery_failure
+          entry.request_id
+          "persisted cancellation did not reach the worker admission boundary"
+      | Keeper_msg_async.Queued_before_restart ->
+        (match Keeper_invocation_types.request_direct_delivery entry.request with
+         | Some _ ->
+           explicit_recovery_failure
+             entry.request_id
+             "direct delivery requires its transcript checkpoint executor; delegated replay was refused"
+         | None ->
+           let recovery_ctx : _ Keeper_types_profile.context =
+             { config
+             ; agent_name = entry.submitted_by
+             ; sw = request_sw
+             ; clock
+             ; proc_mgr = Some proc_mgr
+             ; net = state.net
+             ; publication_recovery_provider =
+                 Mcp_server.publication_recovery_availability_provider state
+             }
+           in
+           Keeper_turn.handle_keeper_delegate
+             ~event_bus
+             recovery_ctx
+             entry.request)
+    in
+    match
+      Keeper_msg_async.resume_recovery_candidate
+        ~on_worker_settled
+        ~background_sw:sw
+        ~f
+        candidate
+    with
+    | Ok _ -> Eio.Promise.await settled
+    | Error error ->
+      Otel_metric_store.inc_counter
+        Keeper_metrics.(to_string LifecycleCallbackFailures)
+        ~labels:[ "callback", "keeper_invocation_restart" ]
+        ();
+      Log.Keeper.error
+        "keeper_msg_async: restart convergence failed request_id=%s keeper=%s error=%s"
+        entry.request_id
+        (Keeper_invocation_types.request_target_name entry.request)
+        (Keeper_msg_async.recovery_resume_error_to_string error);
+      project_recovery_terminal entry
+  in
+  claimed_persistence.claimed_report.requests.candidates
+  |> recovery_candidate_lanes
+  |> List.iter (fun (keeper_name, candidates) ->
+    fork_logged_fiber
+      ~sw
+      ~on_error:(fun exn ->
+        Log.Keeper.error
+          "keeper invocation restart lane crashed keeper=%s error=%s"
+          keeper_name
+          (Printexc.to_string exn))
+      (fun () -> List.iter run_recovery_candidate candidates));
   Board_dispatch.set_board_signal_hook (fun signal ->
     Keeper_keepalive.wakeup_relevant_keeper_for_board_signal
       ~config:(Mcp_server.workspace_config state)
@@ -1985,6 +2105,8 @@ module For_testing = struct
   let prepared_base_paths prepared =
     prepared.base_path.requested, prepared.base_path.canonical
   ;;
+
+  let recovery_candidate_lanes = recovery_candidate_lanes
 
   let begin_keeper_loops_start = acquire_keeper_loops_start
   let finish_keeper_loops_start = finish_keeper_loops_start

--- a/lib/server/server_bootstrap_loops.mli
+++ b/lib/server/server_bootstrap_loops.mli
@@ -162,7 +162,7 @@ module For_testing : sig
 
   val recovery_candidate_lanes :
     Keeper_msg_async.recovery_candidate list ->
-    (string * Keeper_msg_async.recovery_candidate list) list
+    (Keeper_invocation_types.target * Keeper_msg_async.recovery_candidate list) list
 
   val begin_keeper_loops_start :
     config:Workspace.config ->

--- a/lib/server/server_bootstrap_loops.mli
+++ b/lib/server/server_bootstrap_loops.mli
@@ -160,6 +160,10 @@ module For_testing : sig
 
   val prepared_base_paths : prepared_keeper_persistence -> string * string
 
+  val recovery_candidate_lanes :
+    Keeper_msg_async.recovery_candidate list ->
+    (string * Keeper_msg_async.recovery_candidate list) list
+
   val begin_keeper_loops_start :
     config:Workspace.config ->
     claimed_keeper_persistence ->

--- a/test/test_keeper_mutex_coverage.ml
+++ b/test/test_keeper_mutex_coverage.ml
@@ -1429,6 +1429,45 @@ let test_keeper_msg_async_resumes_exact_queued_candidate_once () =
        | Ok _ -> fail "terminal candidate was restarted")
 ;;
 
+let test_restart_candidates_preserve_fifo_per_keeper_lane () =
+  with_eio_env
+  @@ fun _env ->
+  let base_path = temp_dir "keeper-msg-restart-lanes-" in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base_path)
+    (fun () ->
+       [ "kmsg_alpha_2", "alpha", 2.0
+       ; "kmsg_beta_1", "beta", 1.0
+       ; "kmsg_alpha_1", "alpha", 1.0
+       ]
+       |> List.iter (fun (request_id, keeper_name, submitted_at) ->
+         write_request_record
+           ~keeper_name
+           ~submitted_at
+           ~base_path
+           ~request_id
+           ~status:"queued"
+           ~status_fields:[]
+           ());
+       let lanes =
+         (Keeper_msg_async.For_testing.recover_request_records ~base_path ())
+           .candidates
+         |> Server_bootstrap_loops.For_testing.recovery_candidate_lanes
+       in
+       let ids candidates =
+         List.map
+           (fun (candidate : Keeper_msg_async.recovery_candidate) ->
+              candidate.entry.request_id)
+           candidates
+       in
+       match lanes with
+       | [ "alpha", alpha; "beta", beta ] ->
+         check (list string) "alpha FIFO" [ "kmsg_alpha_1"; "kmsg_alpha_2" ]
+           (ids alpha);
+         check (list string) "beta lane" [ "kmsg_beta_1" ] (ids beta)
+       | _ -> failf "expected two independent restart lanes, got %d" (List.length lanes))
+;;
+
 let require_record_path ~location ~base_path ~request_id =
   match disk_record_path ~location ~base_path ~request_id with
   | Some path -> path
@@ -2783,6 +2822,10 @@ let () =
             "queued restart candidate is claimed exactly once"
             `Quick
             test_keeper_msg_async_resumes_exact_queued_candidate_once
+        ; test_case
+            "restart candidates preserve FIFO per Keeper lane"
+            `Quick
+            test_restart_candidates_preserve_fifo_per_keeper_lane
         ; test_case
             "terminal precedence cleans stale active"
             `Quick

--- a/test/test_keeper_mutex_coverage.ml
+++ b/test/test_keeper_mutex_coverage.ml
@@ -1449,9 +1449,25 @@ let test_restart_candidates_preserve_fifo_per_keeper_lane () =
            ~status:"queued"
            ~status_fields:[]
            ());
-       let lanes =
+       let candidates =
          (Keeper_msg_async.For_testing.recover_request_records ~base_path ())
            .candidates
+       in
+       let candidate request_id =
+         match
+           List.find_opt
+             (fun (candidate : Keeper_msg_async.recovery_candidate) ->
+                String.equal candidate.entry.request_id request_id)
+             candidates
+         with
+         | Some candidate -> candidate
+         | None -> failf "missing restart candidate %s" request_id
+       in
+       let lanes =
+         [ candidate "kmsg_alpha_1"
+         ; candidate "kmsg_beta_1"
+         ; candidate "kmsg_alpha_2"
+         ]
          |> Server_bootstrap_loops.For_testing.recovery_candidate_lanes
        in
        let ids candidates =
@@ -1461,7 +1477,11 @@ let test_restart_candidates_preserve_fifo_per_keeper_lane () =
            candidates
        in
        match lanes with
-       | [ "alpha", alpha; "beta", beta ] ->
+       | [ (Keeper alpha_name, alpha); (Keeper beta_name, beta) ] ->
+         check string "first lane target" "alpha"
+           (Keeper_id.Keeper_name.to_string alpha_name);
+         check string "peer lane target" "beta"
+           (Keeper_id.Keeper_name.to_string beta_name);
          check (list string) "alpha FIFO" [ "kmsg_alpha_1"; "kmsg_alpha_2" ]
            (ids alpha);
          check (list string) "beta lane" [ "kmsg_beta_1" ] (ids beta)


### PR DESCRIPTION
## Root cause

Even with an exact recovery claim, startup must actually converge every durable nonterminal request. It must also preserve Lane Per Keeper: one Keeper's recovery may wait, but it cannot block a peer Keeper.

## Change

- coalesce all interleaved candidates by typed Keeper target
- preserve first-seen lane order and FIFO within each Keeper lane
- run exactly one isolated recovery fiber per Keeper
- resume queued delegated turns through the existing Keeper executor
- refuse replay of an execution that was already running and settle it explicitly failed
- let persisted cancellation converge through worker admission
- project terminal results through the existing durable caller queue/wake SSOT
- log non-durable projection explicitly; storage failures retain the projector's exact operation/detail log
- test `alpha, beta, alpha` input as one alpha lane plus an independent beta lane

Queued direct delivery is deliberately terminalized as an explicit failure here: the durable request does not encode exact transcript-checkpoint ownership, so guessing the executor from strings/surface would be a heuristic. A follow-up typed checkpoint association is required before safe replay.

Stacked on #24771.

## Validation

- `ocamlformat --check` — pass
- `ocamlc -stop-after parsing` — pass
- `git diff --check` — pass
- focused Dune wrapper was attempted but correctly refused while another session owned a bare Dune process (PID 73655); CI remains build authority

Base-relative diff: 226 lines.