### PR TITLE
fix(auth): serialize crypto RNG generation

### DIFF
--- a/lib/crypto_rng/crypto_rng.ml
+++ b/lib/crypto_rng/crypto_rng.ml
@@ -1,19 +1,17 @@
-let initialization_mutex = Mutex.create ()
+let mutex = Mutex.create ()
 
-let default () =
+let default_unlocked () =
   match Mirage_crypto_rng.default_generator () with
   | rng -> rng
   | exception Mirage_crypto_rng.No_default_generator ->
-    Mutex.protect initialization_mutex (fun () ->
-      match Mirage_crypto_rng.default_generator () with
-      | rng -> rng
-      | exception Mirage_crypto_rng.No_default_generator ->
-        Mirage_crypto_rng_unix.use_default ();
-        Mirage_crypto_rng.default_generator ())
+    Mirage_crypto_rng_unix.use_default ();
+    Mirage_crypto_rng.default_generator ()
 ;;
 
-let ensure_default () = ignore (default ())
-
-let generate bytes =
-  Mirage_crypto_rng.generate ~g:(default ()) bytes
+let with_generator fn =
+  Mutex.protect mutex (fun () -> fn (default_unlocked ()))
 ;;
+
+let ensure_default () = with_generator ignore
+
+let generate bytes = with_generator (fun rng -> Mirage_crypto_rng.generate ~g:rng bytes)

--- a/lib/crypto_rng/crypto_rng.mli
+++ b/lib/crypto_rng/crypto_rng.mli
@@ -1,8 +1,9 @@
-(** Process-wide Mirage Crypto RNG initialization boundary. *)
+(** Process-wide Mirage Crypto RNG initialization and generation boundary. *)
 
 val ensure_default : unit -> unit
 (** Ensure that Mirage Crypto has a process-wide default generator. *)
 
 val generate : int -> string
 (** [generate bytes] returns [bytes] cryptographically random bytes using the
-    generator obtained from the process-wide default boundary. *)
+    generator obtained from the process-wide default boundary. Calls are
+    serialized because the generator is not safe for concurrent use. *)

--- a/test/dune
+++ b/test/dune
@@ -667,6 +667,10 @@
   test_board_context_inference_resolution)
  (libraries masc_test_deps masc_schedule multimodal bigstringaf))
 
+(test
+ (name test_crypto_rng)
+ (libraries alcotest masc.crypto_rng))
+
 ; Request-authority admission uses Eio fiber-local bindings and therefore owns
 ; an explicit executable stanza instead of borrowing the pure synchronous test
 ; group above.

--- a/test/test_crypto_rng.ml
+++ b/test/test_crypto_rng.ml
@@ -1,0 +1,38 @@
+open Alcotest
+
+let test_parallel_generation_is_safe () =
+  Crypto_rng.ensure_default ();
+  let worker_count = 8 in
+  let values_per_worker = 1_024 in
+  let ready = Atomic.make 0 in
+  let start = Atomic.make false in
+  let workers =
+    List.init worker_count (fun _ ->
+      Domain.spawn (fun () ->
+        ignore (Atomic.fetch_and_add ready 1);
+        while not (Atomic.get start) do
+          Domain.cpu_relax ()
+        done;
+        Array.init values_per_worker (fun _ -> Crypto_rng.generate 32)))
+  in
+  while Atomic.get ready < worker_count do
+    Domain.cpu_relax ()
+  done;
+  Atomic.set start true;
+  let values =
+    List.concat_map (fun worker -> Array.to_list (Domain.join worker)) workers
+  in
+  check int "all values generated" (worker_count * values_per_worker) (List.length values);
+  List.iter (fun value -> check int "value length" 32 (String.length value)) values;
+  check
+    int
+    "values are unique across domains"
+    (List.length values)
+    (List.length (List.sort_uniq String.compare values))
+;;
+
+let () =
+  run
+    "crypto_rng"
+    [ "generation", [ test_case "parallel generation is safe" `Quick test_parallel_generation_is_safe ] ]
+;;


### PR DESCRIPTION
## 문제

통합 HEAD의 `Crypto_rng`는 default generator 초기화만 mutex로 보호하고 실제 `Mirage_crypto_rng.generate` 호출은 보호하지 않았습니다. 프로세스 단일 경계라는 이름과 달리 병렬 fiber/domain에서 동일 generator를 동시에 사용할 수 있습니다.

## 변경

- 초기화와 생성을 동일한 process-wide mutex 임계구역으로 통합
- 잠금 재진입을 피하기 위해 내부 `default_unlocked` helper 사용
- 공개 인터페이스 문서에 생성 직렬화 계약 명시

## 검증

- `ocamlformat --check` 통과
- `ocamlc -stop-after parsing` (`.ml`, `.mli`) 통과
- `git diff --check` 통과
- 로컬 Dune 미실행; 빌드/테스트는 CI 판정