### PR TITLE
fix(ci): seed ocamlformat opam cache on main scope, drop same-version canary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -947,42 +947,6 @@ jobs:
             echo "::notice::main_eio.exe not found, skipping config-diagnostic"
           fi
 
-  ocaml-55-canary:
-    name: OCaml 5.5 Build Canary
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    continue-on-error: true
-    needs: [pr-live-gate, changes]
-    if: ${{ always() && !cancelled() && needs.pr-live-gate.outputs.run_heavy == 'true' && needs.changes.result == 'success' && (needs.changes.outputs.build == 'true' || needs.pr-live-gate.outputs.live_state == 'NON_PR') }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Setup OCaml 5.5 toolchain
-        uses: ./.github/actions/setup-ocaml-toolchain
-        with:
-          ocaml-compiler: '5.5.0'
-          cache-prefix: ocaml55-canary
-          dune-cache-save: "true"
-
-      - name: Pin external OCaml dependencies
-        uses: ./.github/actions/pin-ocaml-deps
-        with:
-          pin-flags: --with-bisect
-
-      - name: Install system and OCaml dependencies
-        uses: ./.github/actions/install-ocaml-deps
-        with:
-          install-flags: --with-test
-          install-timeout-minutes: "30"
-          os-packages: jq ripgrep
-
-      - name: Build install target
-        env:
-          DUNE_JOBS: 1
-        run: opam exec -- dune build --root . @install
-
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/ocamlformat.yml
+++ b/.github/workflows/ocamlformat.yml
@@ -7,6 +7,21 @@ on:
       - '**/*.mli'
       - '.ocamlformat'
       - '.github/workflows/ocamlformat.yml'
+  # Default-branch runs exist to SEED the formatter opam caches into the
+  # main-branch cache scope. Actions caches are ref-scoped: a PR run can only
+  # restore caches created on its own ref or on the default branch. Without a
+  # main-scoped entry every PR cold-misses, rebuilds the opam switch, and saves
+  # a duplicate into its own PR scope — on 2026-07-16 that was 42 duplicate
+  # v3-setup-ocaml entries (5.48 GB of the repo's 10 GB quota) whose LRU
+  # pressure evicted the Build and Test dune cache (dune-linux-oas-otel-02
+  # had zero live entries), forcing every build cold.
+  push:
+    branches: [main]
+    paths:
+      - '**/*.ml'
+      - '**/*.mli'
+      - '.ocamlformat'
+      - '.github/workflows/ocamlformat.yml'
 
 permissions:
   contents: read
@@ -14,7 +29,10 @@ permissions:
 
 concurrency:
   group: ocamlformat-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # Never cancel a main seeding run: rapid merge trains would keep aborting it
+  # before the post-job cache save, and the whole point of the push trigger is
+  # to complete one save into the default-branch scope.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   ocamlformat-check:
@@ -32,6 +50,17 @@ jobs:
         id: changed
         run: |
           set -euo pipefail
+          if [ "${GITHUB_EVENT_NAME}" != "pull_request" ]; then
+            # Default-branch cache-seeding run (see the push trigger comment):
+            # push events carry no PR base/head SHAs to diff, and checking
+            # every file would turn formatter drift into a red main. Run the
+            # toolchain setup with an empty file list so the opam caches get
+            # saved into the default-branch scope, and check nothing.
+            : > /tmp/changed-ocaml-files.txt
+            echo "no_files=false" >> "$GITHUB_OUTPUT"
+            echo "Default-branch run: seeding formatter toolchain caches; no per-file checks."
+            exit 0
+          fi
           base="${{ github.event.pull_request.base.sha }}"
           head="${{ github.event.pull_request.head.sha }}"
           if ! git cat-file -e "$base" 2>/dev/null; then


### PR DESCRIPTION
## Problem

The repo's Actions cache quota is at the 10 GB eviction ceiling (9.98 GB, 89 entries, measured 2026-07-16 01:40 UTC via `gh api /repos/jeong-sik/masc/actions/cache/usage`), and the Build and Test dune cache is the casualty: `gh api /repos/jeong-sik/masc/actions/caches?key=dune-linux-oas-otel-02` returns **0 entries**. Every Build and Test run therefore compiles cold at `DUNE_JOBS=1` — 1140-1300 s on current PRs and main (runs 29428286583, 29441134963, 29449189094), and 2460-2937 s during the 07-08/07-11 merge trains. `prune-pr-caches.yml` already documents the cost ("a missed main cache costs a ~40 min cold `dune build`") but only reclaims closed-PR refs.

Quota breakdown of the polluters:

| Entry family | Count | Size | Producer |
|---|---|---|---|
| `v3-setup-ocaml-opam-*` (identical key, per-PR scope) | 42 | 5.48 GB | `ocamlformat.yml` → `ocaml/setup-ocaml@v3` |
| `dune-linux-ocaml55-canary-*` | 1 | 1.29 GB | `ocaml-55-canary` job |
| `opam-linux-ocaml55-canary-*` | 1 | 0.89 GB | `ocaml-55-canary` job |

## Change

**1. `ocamlformat.yml`: add a `push: main` cache-seeding trigger.** Actions caches are ref-scoped; PR runs can only restore caches created on their own ref or the default branch. `ocamlformat.yml` had a `pull_request`-only trigger, so its opam caches were never written to the default-branch scope → every PR cold-missed, rebuilt the opam switch, and saved a ~130 MB duplicate into its own PR scope. The seeding run diffs nothing (push events have no PR base/head SHAs; checking all files would turn formatter drift into red main) — it exists solely to complete one cache save into the main scope. Seeding runs are excluded from `cancel-in-progress` so merge trains cannot abort the save.

**2. Remove the `ocaml-55-canary` job.** It builds `@install` with OCaml `5.5.0` — byte-identical to the main toolchain default (`setup-ocaml-toolchain/action.yml` `ocaml-compiler` default: `"5.5.0"`), so it produces zero forward-compatibility signal while paying a full opam setup + dune build per heavy run and holding 2.18 GB of the shared quota. It is advisory only: `continue-on-error: true` and absent from the `ci-gate` `needs` list, so no required check disappears. Re-add when a genuinely newer compiler (5.6.x/trunk) is worth canarying.

## Expected effect

~7.6 GB of quota stops being consumed/recreated, giving the main-push dune cache (`dune-linux-oas-otel-02-*`, written by the authoritative Build and Test writer on every main push) room to survive between merges. PR builds then restore a warm content-addressed store instead of compiling the full graph cold. This does not remove the `DUNE_JOBS=1` link-serialization cost on changed test executables — that is the separate test-runner consolidation track (masc_test_deps re_exports 137 libraries into 869 test executables; RFC to follow).

## Verification

- `actionlint` on both workflows: no findings in changed regions (pre-existing SC2129 style notes at ci.yml:77/177 untouched).
- `rg -n "canary"` confirms the removed job was self-contained (no `needs:` references, not in `ci-gate`).
- Post-merge check: next `.ml`-touching main push should produce a `v3-setup-ocaml-opam-*` and `opam-ocamlformat-*` entry with `ref: refs/heads/main` in `gh api /repos/jeong-sik/masc/actions/caches`, and subsequent PR ocamlformat runs should log a cache hit instead of an opam switch bootstrap.

## Not in scope

Quick-suite / test-runner steps (`ci.yml` 578-948) are deliberately untouched — that region is owned by #24718 (observational runner) and #24735 (ingress-lane hang fix). A follow-up quick-suite dedup (e2e extraction out of the quick suite, dead `MASC_INCLUDE_OPERATOR_CONTROL` knob, duplicated operator/sse executions) is deferred until those land.

MASC: task-2297.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JY83aHNyNR8UKqUYRL6p6v