### PR TITLE
refactor(fusion): stop injecting execution timeouts

### DIFF
--- a/bin/fusion_run.ml
+++ b/bin/fusion_run.ml
@@ -115,7 +115,6 @@ let synthesize ~sw ~net ~(preset : Fusion_policy.preset) ~(prompt : string)
   Masc.Fusion_judge.run
     ~sw
     ~net
-    ~timeout_s:preset.Fusion_policy.judge_timeout_s
     ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
     ~judge_model:preset.Fusion_policy.judge
     ~question:prompt
@@ -381,20 +380,16 @@ let () =
   Eio_main.run @@ fun env ->
   Crypto_rng.ensure_default ();
   Time_compat.set_clock (Eio.Stdenv.clock env);
-  (* Register the ambient Eio clock the agent runtime resolves via
-     [Process_eio.get_clock]. Without this, any runtime config that sets
-     [stream_idle_timeout_s] fails closed at agent build time ("no clock
-     resolvable ... refusing to run with a silently disarmed stream idle
-     timeout") and every panel/judge call aborts before the first request. *)
+  (* Register the ambient Eio clock for resolved runtime transport behavior.
+     A runtime/provider may own an idle timeout; Fusion does not add one. *)
   Process_eio.init
     ~cwd_default:(Eio.Stdenv.fs env)
     ~proc_mgr:(Eio.Stdenv.process_mgr env)
     ~clock:(Eio.Stdenv.clock env);
   Eio.Switch.run @@ fun sw ->
   let net = Eio.Stdenv.net env in
-  (* Capture the Eio handles the OAS/fusion call path reads via
-     [Masc_eio_env.get_opt]. Without this, [Masc_oas_bridge.run_safe] fails
-     closed before starting panel/judge calls. *)
+  (* Capture the Eio handles used by Fusion runtime dependencies and elapsed
+     telemetry. This does not install a Fusion-owned execution deadline. *)
   Masc.Masc_eio_env.init ~sw ~net ~clock:(Eio.Stdenv.clock env) ();
   let config_path = Masc.Fusion_config_loader.runtime_toml_path ~base_path in
   (match Runtime.init_default_strict ~config_path with

--- a/docs/rfc/RFC-0252-fusion-panel-judge-deliberation.md
+++ b/docs/rfc/RFC-0252-fusion-panel-judge-deliberation.md
@@ -189,7 +189,7 @@ val all : sw:Eio.Switch.t -> ?clock:_ -> ?max_fibers:int
        -> (string * (Types.api_response, Error.sdk_error) Result.t) list
 ```
 - per-agent 에러 격리(한 패널 실패가 나머지 안 죽임), 부모 switch 취소 전파.
-- `Fusion_panel.run`: preset의 모델 목록 → 각 모델별 `Agent.t` 생성(provider config + web 도구 주입 + per-panel tool budget) → `Async_agent.all ~max_fibers:policy.max_concurrent_panels` → 결과를 `panel_outcome list`로 매핑. 각 호출은 `Masc_oas_bridge.run_safe ~caller:"fusion_panel" ~timeout_s`로 감싼다.
+- `Fusion_panel.run`: preset의 모델 목록 → 각 모델별 `Agent.t` 생성(provider config + web 도구 주입 + per-panel tool budget) → `Async_agent.all ~max_fibers:policy.max_concurrent_panels` → 결과를 `panel_outcome list`로 매핑. Fusion은 별도 deadline을 합성하지 않으며 provider/runtime의 typed timeout은 개별 `panel_outcome` 관측으로 보존한다.
 
 ### 7.2 심판 — `Structured.extract`
 

--- a/lib/fusion/fusion_judge.ml
+++ b/lib/fusion/fusion_judge.ml
@@ -177,7 +177,7 @@ let apply_fusion_judge_output_contract provider_cfg =
    에러도 usage를 동반한다: 토큰을 태운 뒤 실패(빈 응답/파싱 실패)는 소비분을, 토큰
    소비 전 실패(빌드/실행/빈 결과/provider 에러)는 [zero_usage]를 싣는다. 호출자는
    실패 경로에서도 비용을 회계할 수 있다. *)
-let run_composed ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_model
+let run_composed ~sw ~net ?max_tokens ~judge_system_prompt ~judge_model
     ~web_tools ~prompt () :
     ( Fusion_types.judge_synthesis * Fusion_types.usage
     , Fusion_types.judge_failure * Fusion_types.usage )
@@ -185,7 +185,7 @@ let run_composed ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_mod
   let tools = if web_tools then Fusion_oas.web_tool_bundle () else [] in
   match
     Fusion_oas.build_agent ~sw ~net ~system_prompt:judge_system_prompt ~tools
-      ~timeout_s ?max_tokens
+      ?max_tokens
       ~provider_config_transform:apply_fusion_judge_output_contract
       judge_model
   with
@@ -222,28 +222,28 @@ let run_composed ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_mod
              ~prefix:"judge provider error: " e
          , Fusion_types.zero_usage ))
 
-let run ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_model ~question
+let run ~sw ~net ?max_tokens ~judge_system_prompt ~judge_model ~question
     ~panel ~web_tools () :
     ( Fusion_types.judge_synthesis * Fusion_types.usage
     , Fusion_types.judge_failure * Fusion_types.usage )
     result =
-  run_composed ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_model ~web_tools
+  run_composed ~sw ~net ?max_tokens ~judge_system_prompt ~judge_model ~web_tools
     ~prompt:(compose_prompt ~question ~panel) ()
 
-let run_refine ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_model ~question
+let run_refine ~sw ~net ?max_tokens ~judge_system_prompt ~judge_model ~question
     ~panel ~prior ~web_tools () :
     ( Fusion_types.judge_synthesis * Fusion_types.usage
     , Fusion_types.judge_failure * Fusion_types.usage )
     result =
-  run_composed ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_model ~web_tools
+  run_composed ~sw ~net ?max_tokens ~judge_system_prompt ~judge_model ~web_tools
     ~prompt:(compose_refine_prompt ~question ~panel ~prior) ()
 
-let run_meta ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_model ~question
+let run_meta ~sw ~net ?max_tokens ~judge_system_prompt ~judge_model ~question
     ~panel ~priors ~web_tools () :
     ( Fusion_types.judge_synthesis * Fusion_types.usage
     , Fusion_types.judge_failure * Fusion_types.usage )
     result =
-  run_composed ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_model ~web_tools
+  run_composed ~sw ~net ?max_tokens ~judge_system_prompt ~judge_model ~web_tools
     ~prompt:(compose_meta_prompt ~question ~panel ~priors) ()
 
 module For_testing = struct

--- a/lib/fusion/fusion_judge.mli
+++ b/lib/fusion/fusion_judge.mli
@@ -30,7 +30,6 @@ val compose_prompt : question:string -> panel:Fusion_types.panel_outcome list ->
 val run
   :  sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
-  -> timeout_s:float
   -> ?max_tokens:int
   -> judge_system_prompt:string
   -> judge_model:string
@@ -60,7 +59,6 @@ val compose_refine_prompt
 val run_refine
   :  sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
-  -> timeout_s:float
   -> ?max_tokens:int
   -> judge_system_prompt:string
   -> judge_model:string
@@ -100,7 +98,6 @@ val compose_meta_prompt
 val run_meta
   :  sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
-  -> timeout_s:float
   -> ?max_tokens:int
   -> judge_system_prompt:string
   -> judge_model:string

--- a/lib/fusion/fusion_oas.ml
+++ b/lib/fusion/fusion_oas.ml
@@ -104,20 +104,6 @@ let panel_failure_text (failure : Fusion_types.panel_failure) : string =
   | Fusion_types.Invalid_max_output_tokens n ->
     Printf.sprintf "invalid max_output_tokens %d" n
 
-let provider_timeout_opt timeout_s =
-  if Float.is_finite timeout_s && timeout_s > 0.0 then Some timeout_s else None
-
-let apply_provider_timeout ?timeout_s (base_config : Runtime_agent.config) =
-  match Option.bind timeout_s provider_timeout_opt with
-  | None -> base_config
-  | Some timeout_s ->
-    (* OAS selects the single applicable Provider boundary: inter-event idle
-       for streaming, response body for non-streaming. *)
-    { base_config with
-      Runtime_agent.stream_idle_timeout_s = Some timeout_s
-    ; body_timeout_s = Some timeout_s
-    }
-
 (** [Keeper_tool_descriptor]에서 날것의 web tool descriptor를 찾아
     [Agent_sdk.Tool.t]로 변환한다. 패널/심판이 web_search/web_fetch를
     호출할 수 있게 하는 목적으로만 쓰인다. *)
@@ -154,7 +140,6 @@ let build_agent
     ~net
     ~system_prompt
     ?(tools = [])
-    ?timeout_s
     ?max_tokens
     ?name
     ?provider_config_transform
@@ -196,7 +181,6 @@ let build_agent
            ~system_prompt
            ~tools
        in
-       let base_config = apply_provider_timeout ?timeout_s base_config in
        let config =
          match max_tokens with
          | None -> Ok base_config
@@ -218,6 +202,5 @@ let build_agent
                  : Fusion_types.panel_failure))))
 
 module For_testing = struct
-  let apply_provider_timeout = apply_provider_timeout
   let empty_response_detail = empty_response_detail
 end

--- a/lib/fusion/fusion_oas.mli
+++ b/lib/fusion/fusion_oas.mli
@@ -11,9 +11,8 @@
     [tools]를 주면 패널/심판이 tool call을 할 수 있다.
     [max_tokens]는 지정된 패널/심판 호출의 출력 토큰 예산이다. 생략하면
     Runtime_agent 기본값을 보존한다.
-    [timeout_s]는 OAS Provider transport의 단일 적용 경계에만 매핑한다:
-    streaming inter-event idle 또는 non-streaming response body. Fusion/bridge는
-    별도 wall-clock deadline을 추가하지 않는다.
+    Fusion은 transport/body/wall-clock timeout을 합성하지 않고 resolved runtime의
+    liveness 계약을 그대로 보존한다.
     [name]은 에이전트 카드명 — [Async_agent.all]이 결과 키로 반환하는 패널 정체성이다
     (RFC-0278: 같은 model을 다른 라벨로 구분). 미지정이면 카드명=[model]. provider
     라우팅은 카드명과 무관하게 [model]로 한다.
@@ -26,7 +25,6 @@ val build_agent
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> system_prompt:string
   -> ?tools:Agent_sdk.Tool.t list
-  -> ?timeout_s:float
   -> ?max_tokens:int
   -> ?name:string
   -> ?provider_config_transform:
@@ -35,15 +33,8 @@ val build_agent
   -> string
   -> (Agent_sdk.Agent.t, Fusion_types.panel_failure) result
 
-(** Test seam for Fusion-local OAS runtime config mapping. Production callers
-    should use [build_agent], which also resolves runtime providers and builds
-    the OAS agent. *)
+(** Test seam for Fusion-local response diagnostics. *)
 module For_testing : sig
-  val apply_provider_timeout
-    :  ?timeout_s:float
-    -> Runtime_agent.config
-    -> Runtime_agent.config
-
   val empty_response_detail : Agent_sdk.Types.api_response -> string
 end
 

--- a/lib/fusion/fusion_orchestrator.ml
+++ b/lib/fusion/fusion_orchestrator.ml
@@ -42,7 +42,6 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
           in
           let run_single_judge () =
             Fusion_judge.run ~sw ~net
-              ~timeout_s:preset.Fusion_policy.judge_timeout_s
               ?max_tokens:preset.Fusion_policy.judge_max_output_tokens
               ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
               ~judge_model:preset.Fusion_policy.judge
@@ -55,7 +54,6 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
             in
             match
               Fusion_judge.run_refine ~sw ~net
-                ~timeout_s:preset.Fusion_policy.judge_timeout_s
                 ?max_tokens:preset.Fusion_policy.judge_max_output_tokens
                 ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
                 ~judge_model:preset.Fusion_policy.judge
@@ -152,11 +150,10 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                             ; elapsed_s
                             }
                         ] )
-                  | Ok meta_timeout_s ->
+                  | Ok _meta_timeout_s ->
                     let priors = List.map (fun (id, s, _) -> (id, s)) ok_priors in
                      (match
-                       Fusion_judge.run_meta ~sw ~net
-                         ~timeout_s:meta_timeout_s
+                      Fusion_judge.run_meta ~sw ~net
                          ?max_tokens:preset.Fusion_policy.judge_max_output_tokens
                          ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
                          ~judge_model:preset.Fusion_policy.judge
@@ -248,10 +245,9 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                              ; elapsed_s
                              }
                          ] )
-                   | Ok meta_timeout_s ->
+                   | Ok _meta_timeout_s ->
                      (match
                         Fusion_judge.run_meta ~sw ~net
-                          ~timeout_s:meta_timeout_s
                           ?max_tokens:preset.Fusion_policy.judge_max_output_tokens
                           ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
                           ~judge_model:preset.Fusion_policy.judge
@@ -318,10 +314,9 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                             ; elapsed_s
                             }
                         ] )
-                  | Ok meta_timeout_s ->
+                  | Ok _meta_timeout_s ->
                     (match
                        Fusion_judge.run_meta ~sw ~net
-                         ~timeout_s:meta_timeout_s
                          ?max_tokens:preset.Fusion_policy.judge_max_output_tokens
                          ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
                          ~judge_model:preset.Fusion_policy.judge

--- a/lib/fusion/fusion_orchestrator.mli
+++ b/lib/fusion/fusion_orchestrator.mli
@@ -20,7 +20,7 @@ type outcome =
 
     + [Fusion_policy.decide]로 정책 판정 → [Deny]면 [Denied] 반환(부작용 없음).
     + [Allow]면 preset의 패널 모델로 [Fusion_panel.run], judge 모델로 [Fusion_judge.run].
-      패널/심판 system prompt와 타임아웃은 preset(=config)에서 온다 — 코드 default 없음.
+      패널/심판 system prompt는 preset(=config)에서 온다 — 코드 default 없음.
     + [topology]에 따라 reduce 위상을 고른다: [Simple]은 panel→judge→sink(현행),
       [Refine]은 panel→judge→judge'(1차 종합 재검토)→sink, [Conditional]은 1차 판정이
       [Insufficient]일 때만 refine하고 그 외엔 [Simple]처럼 1차 종합 그대로

--- a/lib/fusion/fusion_orchestrator_judge_wave.ml
+++ b/lib/fusion/fusion_orchestrator_judge_wave.ml
@@ -50,7 +50,6 @@ let run_first_judge
     Fusion_judge.run
       ~sw
       ~net
-      ~timeout_s:j.jtimeout_s
       ~judge_system_prompt:j.jsystem_prompt
       ~judge_model:j.jmodel
       ~question

--- a/lib/fusion/fusion_panel.ml
+++ b/lib/fusion/fusion_panel.ml
@@ -83,7 +83,6 @@ let run ~sw ~net ~max_fibers ~groups ~prompt ()
             let panelist = Fusion_policy.panelist_id ~label:g.label ~model in
             match
               Fusion_oas.build_agent ~sw ~net ~system_prompt:g.system_prompt ~tools
-                ~timeout_s:g.timeout_s
                 ?max_tokens:g.max_output_tokens
                 ~name:panelist model
             with

--- a/lib/fusion/fusion_panel.mli
+++ b/lib/fusion/fusion_panel.mli
@@ -12,7 +12,7 @@
 
 (** 이종 패널 그룹들을 하나의 fan-out으로 병렬 실행해 결과를 [panel_outcome]으로 반환.
 
-    - [groups]: 각 그룹은 자기 [system_prompt]/[web_tools]/[timeout_s]로
+    - [groups]: 각 그룹은 자기 [system_prompt]/[web_tools]로
       모델들을 에이전트로 빌드한다 (그룹마다 다를 수 있음 = 이종). 모든 그룹의
       에이전트를 하나의 [Async_agent.all]에 union으로 던진다.
     - [web_tools]가 true인 그룹은 web_search/web_fetch 도구를 주입한다.
@@ -20,8 +20,8 @@
       빈 텍스트만 [Failed Empty_response]. JSON envelope를 요구하지 않는다 —
       단일 문자열에 envelope는 정보 이득 0에 provider가 schema를 무시하면 패널이
       전멸하는 실패 클래스만 추가했다 (2026-07-01 사고, 구현부 주석 참조).
-    - 그룹 [timeout_s]는 OAS Provider transport의 idle/body 경계에만 적용된다.
-      fan-out 전체를 취소하는 별도 wall-clock timeout은 없다.
+    - Fusion은 fan-out timeout을 합성하지 않는다. provider/runtime timeout은
+      typed [Failed Timeout] 관측으로 보존한다.
     - 빌드 실패·실행 실패·빈 응답은 [Failed]로 격리되어 다른 패널을 죽이지 않는다.
     - 반환 순서: 빌드 실패분 먼저, 그 다음 실행 결과(그룹순 × 그룹내 모델순). *)
 val run

--- a/test/test_fusion_oas_error_detail.ml
+++ b/test/test_fusion_oas_error_detail.ml
@@ -1,21 +1,5 @@
 open Masc
 
-let provider_cfg () =
-  Llm_provider.Provider_config.make
-    ~kind:Llm_provider.Provider_config.Anthropic
-    ~model_id:"fusion-test"
-    ~base_url:"http://localhost"
-    ()
-;;
-
-let runtime_config () =
-  Runtime_agent.default_config
-    ~name:"fusion-test"
-    ~provider_cfg:(provider_cfg ())
-    ~system_prompt:""
-    ~tools:[]
-;;
-
 let test_rewrites_unknown_provider () =
   let detail =
     Fusion_oas.provider_error_detail ~runtime_id:"ollama_cloud.kimi-k2-6"
@@ -211,22 +195,6 @@ let test_panel_failure_yojson_round_trips_current_shapes () =
           (Fusion_types.Empty_response "empty response (stop_reason=max_tokens)")))
 ;;
 
-let test_timeout_budget_sets_transport_timeouts () =
-  let config =
-    Fusion_oas.For_testing.apply_provider_timeout
-      ~timeout_s:300.0
-      (runtime_config ())
-  in
-  Alcotest.(check (option (float 0.001)))
-    "stream idle timeout"
-    (Some 300.0)
-    config.stream_idle_timeout_s;
-  Alcotest.(check (option (float 0.001)))
-    "body timeout"
-    (Some 300.0)
-    config.body_timeout_s
-;;
-
 let () =
   Alcotest.run
     "Fusion_oas_error_detail"
@@ -271,10 +239,6 @@ let () =
             "panel failure yojson round-trips current shapes"
             `Quick
             test_panel_failure_yojson_round_trips_current_shapes
-        ; Alcotest.test_case
-            "timeout budget sets transport timeouts"
-            `Quick
-            test_timeout_budget_sets_transport_timeouts
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary

- delete Fusion projection of preset timeout values into OAS stream-idle and body timeout settings
- remove timeout_s from Fusion judge APIs and every panel/judge/meta call site
- retain Masc_oas_bridge as an exception/cancellation observation boundary; it adds no deadline
- preserve provider/runtime timeout failures as typed observations

This is the execution hard-cut. Timeout policy/schema fields remain temporarily inert and are deleted by the following focused stacks.

## Verification

- repository search finds no timeout_s or apply_provider_timeout in Fusion execution/build paths; only inert policy metadata remains
- ocamlformat check passed on every changed OCaml file
- git diff check passed
- 12 files, 125 changed lines
- focused Dune validation was not started because another session is running a bare dune build; CI remains the build authority

## Boundary

Fusion no longer converts product policy numbers into Provider transport authority. Resolved runtime/provider behavior remains outside this feature layer, while failures and elapsed time remain observable.