### PR TITLE
refactor(oas): remove bridge timeout policy

### DIFF
--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -251,11 +251,7 @@ let compute_judgments
     Runtime.runtime_id_for_structured_judge ()
   in
   match
-    (* #9629: caller uses run_with_caller so this judge inherits
-       Operator_judge's per-caller default and surfaces in the
-       Otel_metric_store counter. *)
-    Masc_oas_bridge.run_with_caller
-      ~caller:Env_config_oas_bridge.Operator_judge (fun () ->
+    Masc_oas_bridge.run_safe ~caller:Masc_oas_bridge.Operator_judge (fun () ->
       Keeper_turn_driver_wrappers.run_named_with_masc_tools ~runtime_id
         ~base_path ~goal:prompt ~masc_tools ~dispatch
         ~accept:Keeper_tool_response.response_has_text_or_tool_progress

--- a/lib/masc_oas_bridge.ml
+++ b/lib/masc_oas_bridge.ml
@@ -1,107 +1,60 @@
 (* lib/masc_oas_bridge.ml *)
 (** Centralized boundary between MASC subsystems and the OAS Agent SDK.
-    Enforces cancellation safety and type isolation. Wall-clock budgets are
-    advisory only and do not force-kill execution (fail-open directive). *)
+    Enforces cancellation safety and type isolation. MASC does not own a
+    wall-clock budget at this boundary. *)
 
-(** Safe execution of a generic OAS operation.
-    Requires a domain-local Eio clock and runs the operation to natural
-    completion; [timeout_s] is advisory and is not used to force-kill it.
-    A genuine inner transport [Eio.Time.Timeout] is converted into an error
-    result.
-    [Eio.Cancel.Cancelled] is always re-raised to preserve structured concurrency.
+type caller =
+  | Anti_rationalization
+  | Operator_judge
 
-    [caller] (#10094) is a free-form identifier
-    ("anti_rationalization", "operator_judge", ...) that flows into
-    the timeout label so operators can distinguish which trusted OAS
-    caller timed out at which configured budget.  Callers must pass
-    [~caller] explicitly or use {!run_with_caller}, which accepts a
-    typed caller and pulls the configured budget from
-    [Env_config_oas_bridge]. *)
-let timeout_overshoot_warn_ratio = 2.0
+let caller_key = function
+  | Anti_rationalization -> "anti_rationalization"
+  | Operator_judge -> "operator_judge"
+;;
 
-let run_safe ~caller ~timeout_s fn =
-  if
-    Float.classify_float timeout_s = FP_nan
-    || Float.classify_float timeout_s = FP_infinite
-    || Float.compare timeout_s 0.0 <= 0
-  then
-    invalid_arg
-      (Printf.sprintf
-         "Masc_oas_bridge.run_safe: timeout_s must be positive and finite \
-          (got %.6g)"
-         timeout_s);
-  match Masc_eio_env.get_opt () with
-  | None ->
-    let message =
-      Printf.sprintf
-        "Masc_oas_bridge.run_safe: Eio environment not initialized; refusing \
-         to run without timeout enforcement (caller=%s, budget=%.1fs)"
-        caller timeout_s
-    in
-    Log.Misc.error "%s" message;
-    Error
-      (Keeper_internal_error.sdk_error_of_masc_internal_error
-         (Keeper_internal_error.Internal_bridge_exception
-            { caller; exn_repr = message }))
-  | Some { Masc_eio_env.clock; _ } ->
-    let t0 = Eio.Time.now clock in
-    let elapsed () = Eio.Time.now clock -. t0 in
-    (* No wall-clock budget kill (fail-open; RFC-0156 withdrew the MASC turn-budget
-       timeout policy — total attempt time is observable, not a kill decision).
-       [timeout_s] is advisory only and is NOT used to force-kill the OAS
-       execution: a wall budget that fired while a provider was legitimately still
-       streaming turned slow-but-healthy calls into kill -> Error -> retry churn.
-       The call runs to natural completion. A genuine inner transport timeout (the
-       provider's own connect/idle deadline raising [Eio.Time.Timeout]) is still
-       surfaced below, and structured cancellation is still re-raised. *)
-    try
-      fn ()
-    with
+let run_safe ~caller fn =
+  let caller = caller_key caller in
+  let timing =
+    match Masc_eio_env.get_opt () with
+    | None -> None
+    | Some { Masc_eio_env.clock; _ } -> Some (clock, Eio.Time.now clock)
+  in
+  let elapsed () =
+    Option.map (fun (clock, started_at) -> Eio.Time.now clock -. started_at) timing
+  in
+  try fn () with
   | Eio.Time.Timeout ->
-    (* #10094: per-caller timeout counter so the operator can see
-       WHICH caller is timing out at WHICH configured budget instead
-       of collapsing all OAS timeouts into the same "after N.Ns"
-       string. *)
     let wall = elapsed () in
     Otel_metric_store.inc_counter
       Otel_metric_store.metric_oas_bridge_timeout
-      ~labels:[
-        ("caller", caller);
-        ("timeout_s", Printf.sprintf "%.1f" timeout_s);
-      ] ();
-    (* #18476: wall-clock overshoot detection. Eio cancel propagation
-       through the runtime runner's nested Switch layers can take
-       significant time after the budget fires.  Log the overshoot
-       ratio so operators can distinguish "timeout fired at 45s" from
-       "timeout fired but cleanup took 121s". *)
-    let overshoot_ratio = wall /. timeout_s in
-    if overshoot_ratio > timeout_overshoot_warn_ratio then
-      Log.Misc.warn
-        "masc_oas_bridge: timeout overshoot — budget=%.1fs wall=%.1fs \
-         (ratio=%.1fx, caller=%s). Cancel propagation through runtime \
-         runner Switch hierarchy is delayed."
-        timeout_s wall overshoot_ratio caller
-    else
-      Log.Misc.warn
-        "masc_oas_bridge: OAS execution timed out after %.1fs (caller=%s, wall=%.1fs)"
-        timeout_s caller wall;
+      ~labels:[ "caller", caller ]
+      ();
+    (match wall with
+     | Some wall ->
+       Log.Misc.warn
+         "masc_oas_bridge: inner OAS timeout observed caller=%s wall=%.1fs"
+         caller wall
+     | None ->
+       Log.Misc.warn
+         "masc_oas_bridge: inner OAS timeout observed caller=%s wall_unavailable"
+         caller);
+    let message =
+      match wall with
+      | Some wall -> Printf.sprintf "Inner OAS timeout observed after %.1fs" wall
+      | None -> "Inner OAS timeout observed"
+    in
     Error
       (Agent_sdk.Error.Api
          (Timeout
-            { message = Printf.sprintf "Execution timed out after %.1fs" timeout_s
-            ; phase = None
-            }))
+            { message; phase = None }))
   | Eio.Cancel.Cancelled inner_exn as exn ->
-    (* Mirror of #10942 (keeper_llm_bridge) for masc_oas_bridge: same opaque
-       cancel message ate both wall-duration class and the inner cancel reason.
-       Bucket boundaries come from the shared Cancel_wall_bucket SSOT so metric
-       queries can union the two sources into one bimodal view. [inner=...]
-       surfaces the parent fiber's exception payload so [Eio.Cancel.Cancel_hook]
-       vs supervisor-pause vs runtime-rotation can be told apart at the WARN
-       line. *)
     let bt = Printexc.get_raw_backtrace () in
     let wall = elapsed () in
-    let bucket = Cancel_wall_bucket.of_wall wall in
+    let bucket =
+      match wall with
+      | Some wall -> Cancel_wall_bucket.of_wall wall
+      | None -> "wall_unavailable"
+    in
     let inner_str =
       match inner_exn with
       | Failure msg -> "Failure(" ^ msg ^ ")"
@@ -113,13 +66,15 @@ let run_safe ~caller ~timeout_s fn =
         ("caller", caller);
         ("bucket", bucket);
       ] ();
-    (* Treat every [Eio.Cancel.Cancelled] as a routine cancellation and log it
-       at INFO level. We intentionally avoid matching on Eio internal exception
-       names (e.g. Fiber's Not_first race exception) because those strings are
-       not a stable API and will break if Eio renames the underlying exception. *)
-    Log.Misc.info
-      "masc_oas_bridge: OAS execution cancelled caller=%s wall=%.1fs bucket=%s inner=%s (re-raising)"
-      caller wall bucket inner_str;
+    (match wall with
+     | Some wall ->
+       Log.Misc.info
+         "masc_oas_bridge: OAS execution cancelled caller=%s wall=%.1fs bucket=%s inner=%s (re-raising)"
+         caller wall bucket inner_str
+     | None ->
+       Log.Misc.info
+         "masc_oas_bridge: OAS execution cancelled caller=%s wall_unavailable inner=%s (re-raising)"
+         caller inner_str);
     Printexc.raise_with_backtrace exn bt
   | exn ->
     let bt = Printexc.get_backtrace () in
@@ -132,13 +87,3 @@ let run_safe ~caller ~timeout_s fn =
       (Keeper_internal_error.sdk_error_of_masc_internal_error
          (Keeper_internal_error.Internal_bridge_exception
             { caller; exn_repr = Printexc.to_string exn }))
-
-(** [run_with_caller ~caller fn] — single entry point that resolves
-    the per-caller timeout from [Env_config_oas_bridge] and labels
-    the resulting Otel_metric_store counter.  The remaining trusted OAS
-    callers are evaluator/advisory flows with caller-specific defaults
-    owned by [Env_config_oas_bridge]; removed runtime-invocation
-    surfaces must not reappear as hidden timeout configuration. *)
-let run_with_caller ~caller fn =
-  let timeout_s = Env_config_oas_bridge.timeout_sec ~caller () in
-  run_safe ~caller:(Env_config_oas_bridge.caller_key caller) ~timeout_s fn

--- a/lib/masc_oas_bridge.mli
+++ b/lib/masc_oas_bridge.mli
@@ -1,36 +1,22 @@
 (* lib/masc_oas_bridge.mli *)
 
 (** Centralized boundary between MASC subsystems and the OAS Agent SDK.
-    Enforces strict structural timeouts, cancellation safety, and type isolation.
+    Enforces cancellation safety and typed exception isolation without owning
+    an execution budget. *)
 
-    Migration and entrypoint requirements are documented in
-    [docs/oas-bridge-clock-timeout-contract.md]. This is intentionally
-    fail-closed: adding a default-off compatibility flag would restore the
-    clockless path that silently ignored configured wall-clock budgets. *)
+type caller =
+  | Anti_rationalization
+  | Operator_judge
 
-(** Safe execution of a generic OAS operation with a mandatory Eio clock.
-    Catches [Eio.Time.Timeout] and [Eio.Cancel.Cancelled] to perform functional rollback.
-    [caller] (#10094) labels the Otel_metric_store timeout counter so the
-    operator can attribute timeouts to specific call sites.
-    Raises [Invalid_argument] when [timeout_s] is [NaN], infinite, or not
-    positive. A missing Eio environment fails closed without running [fn]. *)
+(** Stable observation label for the closed caller vocabulary. *)
+val caller_key : caller -> string
+
+(** Run a generic OAS operation without imposing a MASC wall-clock budget.
+    A genuine inner [Eio.Time.Timeout] becomes a typed SDK timeout;
+    [Eio.Cancel.Cancelled] is always re-raised with its backtrace. When the
+    current domain has a captured Eio clock, elapsed wall time is observed;
+    clock absence never refuses execution. *)
 val run_safe
-  :  caller:string
-  -> timeout_s:float
-  -> (unit -> ('a, Agent_sdk.Error.sdk_error) result)
-  -> ('a, Agent_sdk.Error.sdk_error) result
-
-(** Single entry point that resolves the per-caller timeout from
-    [Env_config_oas_bridge] and labels the resulting Otel_metric_store
-    counter.  Preferred over [run_safe] for new callers — the
-    timeout is no longer a hardcoded literal but an
-    env-overridable per-caller budget.  See [Env_config_oas_bridge]
-    for the per-caller default table, env-var layout, and invalid-env fallback.
-
-    Inherits the [Invalid_argument] contract from [run_safe]. The env parser
-    accepts only positive finite values; invalid values such as ["0"], ["-1"],
-    ["nan"], or ["infinity"] fall back before this boundary. *)
-val run_with_caller
-  :  caller:Env_config_oas_bridge.caller
+  :  caller:caller
   -> (unit -> ('a, Agent_sdk.Error.sdk_error) result)
   -> ('a, Agent_sdk.Error.sdk_error) result

--- a/lib/otel_metric_store/otel_builtin_metric_names.ml
+++ b/lib/otel_metric_store/otel_builtin_metric_names.ml
@@ -60,14 +60,7 @@ let metric_telemetry_observe_failures = Otel_metric_store_core.declare_counter "
    most 19 (3 + 8 + 8). *)
 let metric_workspace_telemetry_drop = Otel_metric_store_core.declare_counter "masc_workspace_telemetry_drop_total"
 
-(* #10094: per-caller counter for [Masc_oas_bridge.run_safe]
-   timeouts.  The [caller] string supplied at the run_safe entry
-   point lets the operator see WHICH caller is timing out at
-   WHICH configured budget without grepping warn-level log
-   lines.  Paired with per-caller env-overridable defaults in
-   [Env_config_oas_bridge] so remaining evaluator/advisory callers
-   expose their own budgets instead of hiding behind one generic OAS
-   timeout class. *)
+(* Per-caller observation of genuine inner OAS timeout exceptions. *)
 include Otel_oas_metric_names
 
 

--- a/lib/otel_metric_store/otel_oas_metric_names.mli
+++ b/lib/otel_metric_store/otel_oas_metric_names.mli
@@ -3,14 +3,12 @@
     Included by {!Otel_metric_store} so existing callers keep using
     [Otel_metric_store.metric_*] bindings unchanged. *)
 
-(** Labelled [caller, timeout_s] so operators can distinguish short budgets
-    from intentional 120/180s budgets when both fire timeouts in the same
-    session. *)
+(** Labelled [caller]. Counts genuine inner [Eio.Time.Timeout] observations;
+    MASC does not fabricate a bridge budget label. *)
 val metric_oas_bridge_timeout : string
 
-(** Labelled [caller, bucket] where bucket is a wall-clock class shared with
-    [masc_keeper_oas_cancel_total], allowing backend queries to union the two sources
-    for a fleet-wide bimodal view. *)
+(** Labelled [caller, bucket]. [bucket] is a shared wall-clock class when a
+    domain-local clock exists, or [wall_unavailable] otherwise. *)
 val metric_oas_bridge_cancel : string
 
 val metric_oas_sse_relay_retries : string

--- a/lib/workspace_metric_hooks.ml
+++ b/lib/workspace_metric_hooks.ml
@@ -457,19 +457,17 @@ let install () =
                 { field = "task.anti_rationalization.output_schema"; detail }))
     in
     match
-	      Masc_oas_bridge.run_with_caller
-	        ~caller:Env_config_oas_bridge.Anti_rationalization
-	        (fun () ->
-	           let base_path = Env_config_core.base_path () in
-	           Keeper_turn_driver_wrappers.run_named_with_masc_tools
-	             ~runtime_id:evaluator_runtime
-	             ~base_path
-	             ~goal:prompt
-             ~masc_tools:[ report_tool_schema ]
-             ~dispatch
-             ~provider_config_transform:apply_review_verdict_output_schema
-             ?sw
-             ())
+      Masc_oas_bridge.run_safe ~caller:Masc_oas_bridge.Anti_rationalization (fun () ->
+        let base_path = Env_config_core.base_path () in
+        Keeper_turn_driver_wrappers.run_named_with_masc_tools
+          ~runtime_id:evaluator_runtime
+          ~base_path
+          ~goal:prompt
+          ~masc_tools:[ report_tool_schema ]
+          ~dispatch
+          ~provider_config_transform:apply_review_verdict_output_schema
+          ?sw
+          ())
     with
     | Ok result ->
       (match !protocol_error_ref with

--- a/scripts/oas-boundary-ratchet.sh
+++ b/scripts/oas-boundary-ratchet.sh
@@ -87,7 +87,7 @@ count_bridge_adoption() {
 
 # Metric definitions: name|hint
 METRICS=(
-  "c4_direct_runtime_calls_layer_c|Direct Oas.Agent.run / Oas.Tool.dispatch in Layer C — route through Masc_oas_bridge.run_with_caller (or Keeper_tools_oas / Oas_worker)."
+  "c4_direct_runtime_calls_layer_c|Direct Oas.Agent.run / Oas.Tool.dispatch in Layer C — route through Masc_oas_bridge.run_safe (or Keeper_tools_oas / Oas_worker)."
 )
 
 DESCRIPTIVE_METRICS=(

--- a/test/dune
+++ b/test/dune
@@ -155,7 +155,6 @@
   test_sse_qw
   test_sse_stream
   test_health
-  test_masc_oas_bridge_timeout_guard
   test_keeper_llm_bridge
   test_keeper_hooks_oas_log_shape
   test_keeper_tool_duration_buckets
@@ -474,7 +473,6 @@
   test_sse_qw
   test_sse_stream
   test_health
-  test_masc_oas_bridge_timeout_guard
   test_keeper_llm_bridge
   test_keeper_hooks_oas_log_shape
   test_keeper_tool_duration_buckets
@@ -1981,10 +1979,6 @@
 
 (include stanzas/test_normalized_actor.inc)
 
-(include stanzas/test_oas_bridge_judge_callers_9629.inc)
-
-(include stanzas/test_oas_bridge_timeout_ssot_10094.inc)
-
 (include stanzas/test_keeper_runtime_observation_boundaries.inc)
 
 (include stanzas/test_oas_worker_exec_close_cancel_source.inc)
@@ -1995,7 +1989,7 @@
 
 (include stanzas/test_openapi_api_e2e.inc)
 
-(include stanzas/test_masc_oas_bridge_cancel_boundary.inc)
+(include stanzas/test_masc_oas_bridge_observation.inc)
 
 (include stanzas/test_operator_mcp_e2e.inc)
 

--- a/test/stanzas/test_masc_oas_bridge_observation.inc
+++ b/test/stanzas/test_masc_oas_bridge_observation.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_masc_oas_bridge_observation)
+ (modules test_masc_oas_bridge_observation)
+ (libraries masc_test_deps))

--- a/test/test_masc_oas_bridge_observation.ml
+++ b/test/test_masc_oas_bridge_observation.ml
@@ -1,0 +1,75 @@
+open Masc
+
+let require_clockless () =
+  match Masc_eio_env.get_opt () with
+  | None -> ()
+  | Some _ -> Alcotest.fail "test requires an uninitialized Masc_eio_env"
+;;
+
+let test_clockless_execution () =
+  require_clockless ();
+  match
+    Masc_oas_bridge.run_safe ~caller:Masc_oas_bridge.Anti_rationalization (fun () ->
+      Ok "clockless")
+  with
+  | Ok value -> Alcotest.(check string) "body result" "clockless" value
+  | Error error -> Alcotest.fail (Agent_sdk.Error.to_string error)
+;;
+
+let test_inner_timeout_observation () =
+  require_clockless ();
+  match
+    Masc_oas_bridge.run_safe ~caller:Masc_oas_bridge.Operator_judge (fun () ->
+      raise Eio.Time.Timeout)
+  with
+  | Error (Agent_sdk.Error.Api (Agent_sdk.Retry.Timeout _)) -> ()
+  | Error error -> Alcotest.fail (Agent_sdk.Error.to_string error)
+  | Ok _ -> Alcotest.fail "inner timeout returned success"
+;;
+
+let test_structured_cancellation_reraise () =
+  require_clockless ();
+  match
+    try
+      Masc_oas_bridge.run_safe ~caller:Masc_oas_bridge.Operator_judge (fun () ->
+        raise (Eio.Cancel.Cancelled (Failure "bridge-cancel")))
+      |> ignore;
+      None
+    with
+    | Eio.Cancel.Cancelled inner -> Some inner
+  with
+  | Some (Failure message) -> Alcotest.(check string) "inner cause" "bridge-cancel" message
+  | Some exn -> Alcotest.fail (Printexc.to_string exn)
+  | None -> Alcotest.fail "structured cancellation was swallowed"
+;;
+
+let test_exception_isolation () =
+  require_clockless ();
+  match
+    Masc_oas_bridge.run_safe ~caller:Masc_oas_bridge.Operator_judge (fun () ->
+      raise Exit)
+  with
+  | Error error ->
+    (match Keeper_internal_error.classify_masc_internal_error error with
+     | Some (Keeper_internal_error.Internal_bridge_exception { caller; _ }) ->
+       Alcotest.(check string) "typed caller" "operator_judge" caller
+     | Some other ->
+       Alcotest.fail (Keeper_internal_error.kind_of_masc_internal_error other)
+     | None -> Alcotest.fail (Agent_sdk.Error.to_string error))
+  | Ok _ -> Alcotest.fail "unexpected exception escaped as success"
+;;
+
+let () =
+  Alcotest.run
+    "masc_oas_bridge_observation"
+    [ ( "boundary"
+      , [ Alcotest.test_case "clockless execution" `Quick test_clockless_execution
+        ; Alcotest.test_case "inner timeout" `Quick test_inner_timeout_observation
+        ; Alcotest.test_case
+            "structured cancellation"
+            `Quick
+            test_structured_cancellation_reraise
+        ; Alcotest.test_case "typed exception isolation" `Quick test_exception_isolation
+        ] )
+    ]
+;;

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -480,35 +480,6 @@ let () = test "task_history_events_json_returns_empty_for_missing_task" (fun () 
   | `List _ -> failwith "missing task should have no history events"
   | _ -> failwith "task history payload must be a JSON list"
 )
-let () = test "masc_oas_bridge_fails_closed_without_eio_env" (fun () ->
-  match Masc_eio_env.get_opt () with
-  | Some _ ->
-    failwith
-      "masc_oas_bridge_fails_closed_without_eio_env requires Masc_eio_env.get_opt () = None before calling run_safe"
-  | None ->
-    let called = ref false in
-    match
-      Masc_oas_bridge.run_safe ~caller:"test_tool_task_coverage" ~timeout_s:0.1 (fun () ->
-        called := true;
-        Ok "ok")
-    with
-    | Error error ->
-        if !called then failwith "run_safe called fn without an Eio env";
-        (match Keeper_internal_error.classify_masc_internal_error error with
-         | Some (Keeper_internal_error.Internal_bridge_exception { caller; _ }) ->
-             if caller <> "test_tool_task_coverage" then
-               failwith ("unexpected bridge caller: " ^ caller)
-         | Some other ->
-             failwith
-               ( "unexpected internal error: "
-               ^ Keeper_internal_error.kind_of_masc_internal_error other )
-         | None ->
-             failwith
-               ("expected typed internal bridge error, got: "
-               ^ Agent_sdk.Error.to_string error))
-    | Ok other -> failwith ("unexpected success: " ^ other)
-)
-
 (* Test dispatch transition claim *)
 let () = test "dispatch_transition_claim" (fun () ->
   let ctx = make_test_ctx () in


### PR DESCRIPTION
## Root cause

`Masc_oas_bridge` stopped enforcing its 180/300-second wall budgets, but retained the policy vocabulary: it validated an advisory `timeout_s`, refused to execute without `Masc_eio_env.clock`, emitted fabricated budget/overshoot labels, and routed two live LLM judges through `Env_config_oas_bridge`.

That left a fail-open implementation with a fail-closed admission gate. Dashboard Operator judge and anti-rationalization could be rejected before their model call solely because the bridge could not measure a timeout it no longer enforced.

## Change

- replace free-form timeout callers with the closed `Anti_rationalization | Operator_judge` observation type
- keep `run_safe` as cancellation/exception isolation only; remove `~timeout_s` and `run_with_caller`
- execute clockless calls instead of fabricating a bridge failure
- preserve genuine inner `Eio.Time.Timeout` as typed SDK timeout observation
- record only caller plus actual elapsed wall when a clock exists
- record clockless cancellation as `wall_unavailable`, then rethrow with the original backtrace
- keep both live judge call paths executing through the boundary
- retire four tests that proved the deleted timeout/refusal contract
- add behavioral clockless, inner-timeout, cancellation, and typed-exception regressions

No compatibility call path remains. `Env_config_oas_bridge` is temporarily unused in this stacked intermediate and is hard-deleted in C2.

Stacked on #24778, which removes the direct Fusion wrappers first.

## Validation

- `ocamlformat --check` — pass
- parser checks for every touched OCaml file — pass
- `git diff --check` — pass
- focused `scripts/dune-local.sh build test/test_masc_oas_bridge_observation.exe` was attempted; the wrapper correctly refused because an unrelated bare Dune process (PID 30942) was active. No bypass was used; CI is build authority.

Base-relative diff: 163 additions, 203 deletions, 366 changed lines.