### PR TITLE
refactor(fusion): make clock observation-only

### DIFF
--- a/lib/fusion/fusion_orchestrator.ml
+++ b/lib/fusion/fusion_orchestrator.ml
@@ -81,12 +81,7 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                     }
                 ] )
           in
-          let clock =
-            Fusion_orchestrator_judge_wave.make_runtime_clock
-              ~missing_clock_failure:
-                (Fusion_types.Internal_error
-                   "fusion adaptive timeout requires a wall clock; initialise Masc_eio_env with ~clock")
-          in
+          let clock = Fusion_orchestrator_judge_wave.make_runtime_clock () in
           let elapsed_since_t0 () =
             Fusion_orchestrator_judge_wave.elapsed_since_t0 clock
           in
@@ -117,9 +112,6 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
           in
           let with_timeout_budget_fallback =
             Fusion_orchestrator_judge_wave.with_timeout_budget_fallback
-          in
-          let meta_budget_check () =
-            Fusion_orchestrator_judge_wave.meta_budget_check ~preset clock
           in
           let run_fallback_judge () =
             Fusion_orchestrator_judge_wave.run_fallback_judge
@@ -158,53 +150,39 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                  (Error err, first_nodes)
                | (_, first_s, _) :: _ ->
                  let firsts_usage = firsts_usage firsts_with_fallback in
-                 (match meta_budget_check () with
-                  | Error (failure, _) ->
+                 let priors = List.map (fun (id, s, _) -> (id, s)) ok_priors in
+                 (match
+                    Fusion_judge.run_meta ~sw ~net
+                      ?max_tokens:preset.Fusion_policy.judge_max_output_tokens
+                      ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
+                      ~judge_model:preset.Fusion_policy.judge
+                      ~question:req.Fusion_types.prompt ~panel ~priors
+                      ~web_tools:judge_web_tools ()
+                  with
+                  | Ok (meta_s, meta_u) ->
+                    ( Ok (meta_s, Fusion_types.add_usage firsts_usage meta_u)
+                    , first_nodes
+                      @ [ Fusion_types.Synthesized
+                            { Fusion_types.role = Meta
+                            ; synthesis = meta_s
+                            ; usage = meta_u
+                            }
+                        ] )
+                  | Error (failure, meta_u) ->
+                    Log.Keeper.warn ~keeper_name:req.Fusion_types.keeper
+                      "fusion run %s meta judge failed, keeping first judge synthesis: %s"
+                      req.Fusion_types.run_id
+                      (Fusion_types.judge_failure_text failure);
                     let elapsed_s = elapsed_since_t0 () in
-                    ( Ok (first_s, firsts_usage)
+                    ( Ok (first_s, Fusion_types.add_usage firsts_usage meta_u)
                     , first_nodes
                       @ [ Fusion_types.Judge_failed
                             { Fusion_types.failed_role = Meta
                             ; failure
-                            ; usage = Fusion_types.zero_usage
+                            ; usage = meta_u
                             ; elapsed_s
                             }
-                        ] )
-                  | Ok _meta_timeout_s ->
-                    let priors = List.map (fun (id, s, _) -> (id, s)) ok_priors in
-                     (match
-                       Fusion_judge.run_meta ~sw ~net
-                         ?max_tokens:preset.Fusion_policy.judge_max_output_tokens
-                         ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
-                         ~judge_model:preset.Fusion_policy.judge
-                         ~question:req.Fusion_types.prompt ~panel ~priors
-                         ~web_tools:judge_web_tools ()
-                     with
-                     | Ok (meta_s, meta_u) ->
-                       ( Ok (meta_s, Fusion_types.add_usage firsts_usage meta_u)
-                       , first_nodes
-                         @ [ Fusion_types.Synthesized
-                               { Fusion_types.role = Meta
-                               ; synthesis = meta_s
-                               ; usage = meta_u
-                               }
-                           ] )
-                     | Error (failure, meta_u) ->
-                       Log.Keeper.warn ~keeper_name:req.Fusion_types.keeper
-                         "fusion run %s meta judge failed, keeping first judge \
-                          synthesis: %s"
-                         req.Fusion_types.run_id
-                         (Fusion_types.judge_failure_text failure);
-                       let elapsed_s = elapsed_since_t0 () in
-                       ( Ok (first_s, Fusion_types.add_usage firsts_usage meta_u)
-                       , first_nodes
-                         @ [ Fusion_types.Judge_failed
-                               { Fusion_types.failed_role = Meta
-                               ; failure
-                               ; usage = meta_u
-                               ; elapsed_s
-                               }
-                           ] ))))
+                        ] )))
           in
           let run_staged_judge_of_judges () =
             let group_size = policy.Fusion_policy.staged_judge_group_size in
@@ -256,53 +234,40 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                 | (_, first_s, _) :: _ ->
                   let firsts_usage = firsts_usage stage_firsts in
                   let priors = List.map (fun (id, s, _) -> (id, s)) ok_priors in
-                  (match meta_budget_check () with
-                   | Error (failure, _) ->
+                  (match
+                     Fusion_judge.run_meta ~sw ~net
+                       ?max_tokens:preset.Fusion_policy.judge_max_output_tokens
+                       ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
+                       ~judge_model:preset.Fusion_policy.judge
+                       ~question:req.Fusion_types.prompt ~panel ~priors
+                       ~web_tools:judge_web_tools ()
+                   with
+                   | Ok (stage_s, stage_u) ->
+                     ( ( stage_id
+                       , Ok (stage_s, Fusion_types.add_usage firsts_usage stage_u) )
+                     , first_nodes
+                       @ [ Fusion_types.Synthesized
+                             { Fusion_types.role = Stage_meta stage_num
+                             ; synthesis = stage_s
+                             ; usage = stage_u
+                             }
+                         ] )
+                   | Error (failure, stage_u) ->
+                     Log.Keeper.warn ~keeper_name:req.Fusion_types.keeper
+                       "fusion run %s staged JOJ %s meta judge failed, keeping first judge synthesis: %s"
+                       req.Fusion_types.run_id stage_id
+                       (Fusion_types.judge_failure_text failure);
                      let elapsed_s = elapsed_since_t0 () in
-                     ( (stage_id, Ok (first_s, firsts_usage))
+                     ( ( stage_id
+                       , Ok (first_s, Fusion_types.add_usage firsts_usage stage_u) )
                      , first_nodes
                        @ [ Fusion_types.Judge_failed
                              { Fusion_types.failed_role = Stage_meta stage_num
                              ; failure
-                             ; usage = Fusion_types.zero_usage
+                             ; usage = stage_u
                              ; elapsed_s
                              }
-                         ] )
-                   | Ok _meta_timeout_s ->
-                     (match
-                        Fusion_judge.run_meta ~sw ~net
-                          ?max_tokens:preset.Fusion_policy.judge_max_output_tokens
-                          ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
-                          ~judge_model:preset.Fusion_policy.judge
-                          ~question:req.Fusion_types.prompt ~panel ~priors
-                          ~web_tools:judge_web_tools ()
-                      with
-                      | Ok (stage_s, stage_u) ->
-                        ( ( stage_id
-                          , Ok (stage_s, Fusion_types.add_usage firsts_usage stage_u) )
-                        , first_nodes
-                          @ [ Fusion_types.Synthesized
-                                { Fusion_types.role = Stage_meta stage_num
-                                ; synthesis = stage_s
-                                ; usage = stage_u
-                                }
-                            ] )
-                      | Error (failure, stage_u) ->
-                        Log.Keeper.warn ~keeper_name:req.Fusion_types.keeper
-                          "fusion run %s staged JOJ %s meta judge failed, keeping first judge synthesis: %s"
-                          req.Fusion_types.run_id stage_id
-                          (Fusion_types.judge_failure_text failure);
-                        let elapsed_s = elapsed_since_t0 () in
-                        ( ( stage_id
-                          , Ok (first_s, Fusion_types.add_usage firsts_usage stage_u) )
-                        , first_nodes
-                          @ [ Fusion_types.Judge_failed
-                                { Fusion_types.failed_role = Stage_meta stage_num
-                                ; failure
-                                ; usage = stage_u
-                                ; elapsed_s
-                                }
-                            ] )))
+                         ] ))
               in
               let indexed_groups = List.mapi (fun i group -> (i + 1, group)) first_groups in
               let stage_runs =
@@ -325,51 +290,38 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                | (_, first_stage_s, _) :: _ ->
                  let stage_usage = Fusion_types.sum_all_usage stage_results in
                  let priors = List.map (fun (id, s, _) -> (id, s)) ok_stages in
-                 (match meta_budget_check () with
-                  | Error (failure, _) ->
+                 (match
+                    Fusion_judge.run_meta ~sw ~net
+                      ?max_tokens:preset.Fusion_policy.judge_max_output_tokens
+                      ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
+                      ~judge_model:preset.Fusion_policy.judge
+                      ~question:req.Fusion_types.prompt ~panel ~priors
+                      ~web_tools:judge_web_tools ()
+                  with
+                  | Ok (final_s, final_u) ->
+                    ( Ok (final_s, Fusion_types.add_usage stage_usage final_u)
+                    , stage_nodes
+                      @ [ Fusion_types.Synthesized
+                            { Fusion_types.role = Final_meta
+                            ; synthesis = final_s
+                            ; usage = final_u
+                            }
+                        ] )
+                  | Error (failure, final_u) ->
+                    Log.Keeper.warn ~keeper_name:req.Fusion_types.keeper
+                      "fusion run %s staged JOJ final meta judge failed, keeping first stage synthesis: %s"
+                      req.Fusion_types.run_id
+                      (Fusion_types.judge_failure_text failure);
                     let elapsed_s = elapsed_since_t0 () in
-                    ( Ok (first_stage_s, stage_usage)
+                    ( Ok (first_stage_s, Fusion_types.add_usage stage_usage final_u)
                     , stage_nodes
                       @ [ Fusion_types.Judge_failed
                             { Fusion_types.failed_role = Final_meta
                             ; failure
-                            ; usage = Fusion_types.zero_usage
+                            ; usage = final_u
                             ; elapsed_s
                             }
-                        ] )
-                  | Ok _meta_timeout_s ->
-                    (match
-                       Fusion_judge.run_meta ~sw ~net
-                         ?max_tokens:preset.Fusion_policy.judge_max_output_tokens
-                         ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
-                         ~judge_model:preset.Fusion_policy.judge
-                         ~question:req.Fusion_types.prompt ~panel ~priors
-                         ~web_tools:judge_web_tools ()
-                     with
-                     | Ok (final_s, final_u) ->
-                       ( Ok (final_s, Fusion_types.add_usage stage_usage final_u)
-                       , stage_nodes
-                         @ [ Fusion_types.Synthesized
-                               { Fusion_types.role = Final_meta
-                               ; synthesis = final_s
-                               ; usage = final_u
-                               }
-                           ] )
-                     | Error (failure, final_u) ->
-                       Log.Keeper.warn ~keeper_name:req.Fusion_types.keeper
-                         "fusion run %s staged JOJ final meta judge failed, keeping first stage synthesis: %s"
-                         req.Fusion_types.run_id
-                         (Fusion_types.judge_failure_text failure);
-                       let elapsed_s = elapsed_since_t0 () in
-                       ( Ok (first_stage_s, Fusion_types.add_usage stage_usage final_u)
-                       , stage_nodes
-                         @ [ Fusion_types.Judge_failed
-                               { Fusion_types.failed_role = Final_meta
-                               ; failure
-                               ; usage = final_u
-                               ; elapsed_s
-                               }
-                           ] ))))
+                        ] )))
           in
           let judge_full, judge_nodes =
             match Fusion_types.answered_of panel with

--- a/lib/fusion/fusion_orchestrator_judge_wave.ml
+++ b/lib/fusion/fusion_orchestrator_judge_wave.ml
@@ -10,21 +10,20 @@ type judge_run =
 type clock =
   { now_opt : unit -> float option
   ; t0 : float option
-  ; missing_clock_failure : Fusion_types.judge_failure
   }
 
-let make_clock ~now_opt ~missing_clock_failure =
+let make_clock ~now_opt =
   let t0 = now_opt () in
-  { now_opt; t0; missing_clock_failure }
+  { now_opt; t0 }
 ;;
 
-let make_runtime_clock ~missing_clock_failure =
+let make_runtime_clock () =
   let now_opt () =
     match Masc_eio_env.get_opt () with
     | Some { Masc_eio_env.clock; _ } -> Some (Eio.Time.now clock)
     | None -> None
   in
-  make_clock ~now_opt ~missing_clock_failure
+  make_clock ~now_opt
 ;;
 
 let elapsed_since_t0 clock =
@@ -32,12 +31,6 @@ let elapsed_since_t0 clock =
   | Some now, Some t0 -> now -. t0
   | _ -> 0.0
 ;;
-
-let missing_clock_result clock =
-  Error (clock.missing_clock_failure, Fusion_types.zero_usage)
-;;
-
-let clock_available clock = Option.is_some (clock.now_opt ())
 
 let run_first_judge
       ~sw
@@ -156,26 +149,6 @@ let with_timeout_budget_fallback ~run_fallback_judge runs =
   else runs
 ;;
 
-let remaining_wave_budget ~preset clock =
-  preset.Fusion_policy.judge_wave_budget_s -. elapsed_since_t0 clock
-;;
-
-let meta_budget_check ~preset clock =
-  if not (clock_available clock)
-  then missing_clock_result clock
-  else if
-    not
-      (Fusion_policy.judge_wave_budget_enabled
-         ~wave_budget_s:preset.Fusion_policy.judge_wave_budget_s)
-  then Ok preset.Fusion_policy.meta_timeout_s
-  else if remaining_wave_budget ~preset clock < preset.Fusion_policy.meta_timeout_s
-  then
-    Error
-      ( Fusion_types.Budget_exceeded "insufficient remaining budget for meta"
-      , Fusion_types.zero_usage )
-  else Ok preset.Fusion_policy.meta_timeout_s
-;;
-
 let run_fallback_judge
       ~sw
       ~net
@@ -201,18 +174,15 @@ let run_fallback_judge
       }
     in
     let id = Fusion_policy.panelist_id ~label:j.jlabel ~model:j.jmodel in
-    if not (clock_available clock)
-    then Some (j, id, missing_clock_result clock, elapsed_s, false)
-    else (
-      match
-        Fusion_policy.adjust_judge_timeout
-          ~base_s:j.jtimeout_s
-          ~max_s:None
-          ~factor:1.0
-          ~wave_budget_s:preset.Fusion_policy.judge_wave_budget_s
-          ~elapsed_s
-          ~already_timed_out:false
-      with
+    (match
+       Fusion_policy.adjust_judge_timeout
+         ~base_s:j.jtimeout_s
+         ~max_s:None
+         ~factor:1.0
+         ~wave_budget_s:preset.Fusion_policy.judge_wave_budget_s
+         ~elapsed_s
+         ~already_timed_out:false
+     with
       | None ->
         Some
           ( j
@@ -242,5 +212,5 @@ let run_fallback_judge
           | Error (f, _) -> Fusion_types.judge_failure_is_timeout f
           | Ok _ -> false
         in
-        Some (j, id, result, elapsed_s, timed_out))
+       Some (j, id, result, elapsed_s, timed_out))
 ;;

--- a/lib/fusion/fusion_orchestrator_judge_wave.mli
+++ b/lib/fusion/fusion_orchestrator_judge_wave.mli
@@ -13,15 +13,12 @@ type clock
 
 val make_clock
   :  now_opt:(unit -> float option)
-  -> missing_clock_failure:Fusion_types.judge_failure
   -> clock
 
-val make_runtime_clock
-  :  missing_clock_failure:Fusion_types.judge_failure
-  -> clock
-(** Build a clock from the current domain-local {!Masc_eio_env}. Missing
-    runtime env is represented as [None] so callers can return the configured
-    [missing_clock_failure] instead of raising from {!Masc_eio_env.get}. *)
+val make_runtime_clock : unit -> clock
+(** Build an optional observation clock from the current domain-local
+    {!Masc_eio_env}. Missing runtime env never blocks execution; elapsed
+    observations remain [0.0]. *)
 
 val elapsed_since_t0 : clock -> float
 
@@ -61,11 +58,6 @@ val with_timeout_budget_fallback
 (** Append the configured fallback judge when the whole first-judge wave failed
     only with timeout/budget failures. Shared by JOJ and staged JOJ so both
     topologies honor [fallback_judge_model] consistently. *)
-
-val meta_budget_check
-  :  preset:Fusion_policy.preset
-  -> clock
-  -> (float, Fusion_types.judge_failure * Fusion_types.usage) result
 
 val run_fallback_judge
   :  sw:Eio.Switch.t

--- a/test/test_fusion_adaptive_timeout.ml
+++ b/test/test_fusion_adaptive_timeout.ml
@@ -166,29 +166,37 @@ let test_adjust_judge_timeout_extend () =
     (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:(Some 30.0)
        ~factor:2.0 ~wave_budget_s:5.0 ~elapsed_s:5.0 ~already_timed_out:true)
 
-let test_runtime_clock_missing_env_returns_typed_failure () =
+let test_runtime_clock_missing_env_still_attempts_fallback () =
   Masc_eio_env.reset_for_test ();
   Fun.protect ~finally:Masc_eio_env.reset_for_test (fun () ->
-    let missing_clock_failure =
-      Fusion_types.Internal_error "missing runtime clock"
-    in
-    let clock =
-      Fusion_orchestrator_judge_wave.make_runtime_clock ~missing_clock_failure
+    Eio_main.run @@ fun env ->
+    Eio.Switch.run @@ fun sw ->
+    let clock = Fusion_orchestrator_judge_wave.make_runtime_clock () in
+    let preset =
+      { (adaptive_preset ()) with
+        Fusion_policy.fallback_judge_model =
+          Some "fusion-clockless-regression-missing-runtime"
+      }
     in
     match
-      Fusion_orchestrator_judge_wave.meta_budget_check
-        ~preset:(adaptive_preset ())
-        clock
+      Fusion_orchestrator_judge_wave.run_fallback_judge
+        ~sw
+        ~net:(Eio.Stdenv.net env)
+        ~preset
+        ~panel:[]
+        ~question:"clockless"
+        ~clock
+        ~judge_web_tools:false
+        ()
     with
-    | Error (Fusion_types.Internal_error msg, usage) ->
-      check string "typed failure message" "missing runtime clock" msg;
-      check int "input usage" 0 usage.Fusion_types.input_tokens;
-      check int "output usage" 0 usage.Fusion_types.output_tokens
-    | Error (failure, _) ->
-      failf
-        "expected Internal_error, got %s"
-        (Fusion_types.judge_failure_text failure)
-    | Ok _ -> fail "expected missing clock failure")
+    | Some (_, id, Error (Fusion_types.Build_error _, _), elapsed_s, false) ->
+      check string "fallback attempted"
+        "fallback (fusion-clockless-regression-missing-runtime)" id;
+      check (float 0.0) "missing clock is observation-only" 0.0 elapsed_s
+    | Some (_, _, Error (failure, _), _, _) ->
+      failf "unexpected fallback failure: %s" (Fusion_types.judge_failure_text failure)
+    | Some _ -> fail "expected missing runtime build failure"
+    | None -> fail "configured fallback must be attempted")
 
 let test_timeout_budget_first_wave_appends_fallback () =
   let fallback_calls = ref 0 in
@@ -283,8 +291,8 @@ let () =
         ; test_case "extend" `Quick test_adjust_judge_timeout_extend
         ] )
     ; ( "clock"
-      , [ test_case "missing runtime env returns typed failure" `Quick
-            test_runtime_clock_missing_env_returns_typed_failure
+      , [ test_case "missing runtime env still attempts fallback" `Quick
+            test_runtime_clock_missing_env_still_attempts_fallback
         ] )
     ; ( "fallback"
       , [ test_case "timeout/budget wave appends fallback" `Quick


### PR DESCRIPTION
## Summary

- make the Fusion clock optional instead of an execution prerequisite
- delete `meta_budget_check` and remaining-wave-budget skips so JOJ, staged meta, and final meta calls always run when synthesis inputs exist
- preserve elapsed observation when a clock exists without fabricating a deadline or clock value

This is stacked on #24778. #24786 removes adaptive judge-run state and changes fallback selection to all-typed-Error semantics; timeout configuration fields remain for the later schema hard cut.

## Regression evidence

The clockless test resets `Masc_eio_env`, configures a deliberately missing fallback runtime, and proves execution reaches runtime resolution as a typed `Build_error`. The old implementation returned a synthetic missing-clock `Internal_error` before attempting the judge.

## Stacked observability completion

This PR alone inherits a mandatory elapsed `float`, where clock-unavailable is ambiguous. Stacked PR #24787 completes the contract as `float option` and emits JSON `null` for unavailable observations, without NaN, a numeric sentinel, or string inference.

## Verification

- `ocamlformat --check` on every changed OCaml file
- `ocamlc -stop-after parsing` on every changed OCaml file
- `git diff --check`
- focused Dune target delegated to PR CI because another worktree held the repo-local Dune lock
