### PR TITLE
refactor(fusion): fallback after all judge errors

### DIFF
--- a/lib/fusion/fusion_orchestrator.ml
+++ b/lib/fusion/fusion_orchestrator.ml
@@ -110,8 +110,8 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
           let all_fail_error_of_runs =
             Fusion_orchestrator_judge_wave.all_fail_error_of_runs
           in
-          let with_timeout_budget_fallback =
-            Fusion_orchestrator_judge_wave.with_timeout_budget_fallback
+          let with_all_error_fallback =
+            Fusion_orchestrator_judge_wave.with_all_error_fallback
           in
           let run_fallback_judge () =
             Fusion_orchestrator_judge_wave.run_fallback_judge
@@ -135,7 +135,7 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
             | judges ->
               let firsts = run_first_judges judges in
               let firsts_with_fallback =
-                with_timeout_budget_fallback ~run_fallback_judge firsts
+                with_all_error_fallback ~run_fallback_judge firsts
               in
               let first_nodes = first_judge_nodes firsts_with_fallback in
               let ok_priors = successful_syntheses firsts_with_fallback in
@@ -197,7 +197,7 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
             | Ok _groups ->
               let firsts =
                 run_first_judges preset.Fusion_policy.judges
-                |> with_timeout_budget_fallback ~run_fallback_judge
+                |> with_all_error_fallback ~run_fallback_judge
               in
               let rec take n acc rest =
                 if n = 0

--- a/lib/fusion/fusion_orchestrator_judge_wave.ml
+++ b/lib/fusion/fusion_orchestrator_judge_wave.ml
@@ -1,11 +1,9 @@
 type judge_run =
-  Fusion_policy.judge_spec
-  * string
+  string
   * ( Fusion_types.judge_synthesis * Fusion_types.usage
     , Fusion_types.judge_failure * Fusion_types.usage )
     result
   * float
-  * bool
 
 type clock =
   { now_opt : unit -> float option
@@ -40,12 +38,11 @@ let run_first_judge
       ~question
       ~clock
       ~judge_web_tools
-      ~already_timed_out
       (j : Fusion_policy.judge_spec)
   : judge_run
   =
   let id = Fusion_policy.panelist_id ~label:j.jlabel ~model:j.jmodel in
-  let _ = preset, judge_web_tools, already_timed_out in
+  let _ = preset, judge_web_tools in
   let result =
     Fusion_judge.run
       ~sw
@@ -58,12 +55,7 @@ let run_first_judge
       ()
   in
   let elapsed_s = elapsed_since_t0 clock in
-  let timed_out =
-    match result with
-    | Error (f, _) -> Fusion_types.judge_failure_is_timeout f
-    | Ok _ -> false
-  in
-  j, id, result, elapsed_s, timed_out
+  id, result, elapsed_s
 ;;
 
 let run_first_judges
@@ -90,13 +82,13 @@ let run_first_judges
   let _ = max_concurrent_judges in
   Eio.Fiber.List.map
     ~max_fibers:(max 1 (List.length judges))
-    (run_first_judge ~already_timed_out:false)
+    run_first_judge
     judges
 ;;
 
 let first_judge_nodes runs =
   List.map
-    (fun (_, id, result, elapsed_s, _timed_out) ->
+    (fun (id, result, elapsed_s) ->
        match result with
        | Ok (s, u) ->
          Fusion_types.Synthesized { Fusion_types.role = First id; synthesis = s; usage = u }
@@ -108,7 +100,7 @@ let first_judge_nodes runs =
 
 let successful_syntheses runs =
   List.filter_map
-    (fun (_, id, result, _, _) ->
+    (fun (id, result, _) ->
        match result with
        | Ok (s, u) -> Some (id, s, u)
        | Error _ -> None)
@@ -125,23 +117,23 @@ let successful_pair_syntheses pairs =
 ;;
 
 let firsts_usage runs =
-  Fusion_types.sum_all_usage (List.map (fun (_, id, result, _, _) -> id, result) runs)
+  Fusion_types.sum_all_usage (List.map (fun (id, result, _) -> id, result) runs)
 ;;
 
 let all_fail_error_of_runs ~fallback runs =
   Fusion_types.all_fail_error
     ~fallback
-    (List.map (fun (_, id, result, _, _) -> id, result) runs)
+    (List.map (fun (id, result, _) -> id, result) runs)
 ;;
 
-let failed_timeout_or_budget (_, _, result, _, _) =
+let failed (_, result, _) =
   match result with
-  | Error (failure, _) -> Fusion_types.judge_failure_is_timeout_or_budget failure
+  | Error _ -> true
   | Ok _ -> false
 ;;
 
-let with_timeout_budget_fallback ~run_fallback_judge runs =
-  if runs <> [] && List.for_all failed_timeout_or_budget runs
+let with_all_error_fallback ~run_fallback_judge runs =
+  if runs <> [] && List.for_all failed runs
   then (
     match run_fallback_judge () with
     | Some fallback -> runs @ [ fallback ]
@@ -162,55 +154,18 @@ let run_fallback_judge
   match preset.Fusion_policy.fallback_judge_model with
   | None -> None
   | Some model ->
-    let elapsed_s = elapsed_since_t0 clock in
-    let j : Fusion_policy.judge_spec =
-      { jmodel = model
-      ; jlabel = "fallback"
-      ; jsystem_prompt = preset.Fusion_policy.judge_system_prompt
-      ; jweb_tools = judge_web_tools
-      ; jmax_output_tokens = preset.Fusion_policy.judge_max_output_tokens
-      ; jtimeout_s = preset.Fusion_policy.judge_timeout_s
-      ; jmax_timeout_s = None
-      }
+    let id = Fusion_policy.panelist_id ~label:"fallback" ~model in
+    let result =
+      Fusion_judge.run
+        ~sw
+        ~net
+        ?max_tokens:preset.Fusion_policy.judge_max_output_tokens
+        ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
+        ~judge_model:model
+        ~question
+        ~panel
+        ~web_tools:judge_web_tools
+        ()
     in
-    let id = Fusion_policy.panelist_id ~label:j.jlabel ~model:j.jmodel in
-    (match
-       Fusion_policy.adjust_judge_timeout
-         ~base_s:j.jtimeout_s
-         ~max_s:None
-         ~factor:1.0
-         ~wave_budget_s:preset.Fusion_policy.judge_wave_budget_s
-         ~elapsed_s
-         ~already_timed_out:false
-     with
-      | None ->
-        Some
-          ( j
-          , id
-          , Error
-              ( Fusion_types.Budget_exceeded
-                  "fallback judge skipped: insufficient remaining wave budget"
-              , Fusion_types.zero_usage )
-          , elapsed_s
-          , false )
-      | Some _timeout_s ->
-        let result =
-          Fusion_judge.run
-            ~sw
-            ~net
-            ?max_tokens:j.jmax_output_tokens
-            ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
-            ~judge_model:model
-            ~question
-            ~panel
-            ~web_tools:judge_web_tools
-            ()
-        in
-        let elapsed_s = elapsed_since_t0 clock in
-        let timed_out =
-          match result with
-          | Error (f, _) -> Fusion_types.judge_failure_is_timeout f
-          | Ok _ -> false
-        in
-       Some (j, id, result, elapsed_s, timed_out))
+    Some (id, result, elapsed_since_t0 clock)
 ;;

--- a/lib/fusion/fusion_orchestrator_judge_wave.mli
+++ b/lib/fusion/fusion_orchestrator_judge_wave.mli
@@ -1,13 +1,11 @@
 (** Judge wave helpers for {!Fusion_orchestrator}. *)
 
 type judge_run =
-  Fusion_policy.judge_spec
-  * string
+  string
   * ( Fusion_types.judge_synthesis * Fusion_types.usage
     , Fusion_types.judge_failure * Fusion_types.usage )
     result
   * float
-  * bool
 
 type clock
 
@@ -51,13 +49,13 @@ val all_fail_error_of_runs
   -> judge_run list
   -> Fusion_types.judge_failure * Fusion_types.usage
 
-val with_timeout_budget_fallback
+val with_all_error_fallback
   :  run_fallback_judge:(unit -> judge_run option)
   -> judge_run list
   -> judge_run list
 (** Append the configured fallback judge when the whole first-judge wave failed
-    only with timeout/budget failures. Shared by JOJ and staged JOJ so both
-    topologies honor [fallback_judge_model] consistently. *)
+    with typed errors and produced no synthesis. Shared by JOJ and staged JOJ
+    so both topologies honor [fallback_judge_model] consistently. *)
 
 val run_fallback_judge
   :  sw:Eio.Switch.t

--- a/lib/fusion_core/fusion_policy.ml
+++ b/lib/fusion_core/fusion_policy.ml
@@ -248,51 +248,18 @@ let panel_outer_timeout_of ~max_fibers (groups : panel_group list) =
 let judge_web_tools_of ~req_web_tools (groups : panel_group list) =
   req_web_tools || List.exists (fun (g : panel_group) -> g.web_tools) groups
 
-(* 적응형 타임아웃 임계값들. [adaptive_extension_threshold]는 adaptive 확장을 끄는
+(* 적응형 타임아웃 임계값. [adaptive_extension_threshold]는 adaptive 확장을 끄는
    factor 값(config default 1.0; 검증이 >= 1.0을 강제). 1.0은 IEEE754에서 정확히
    표현되지만, 의도를 명시하고 drift를 막기 named 상수로 둔다 — callers 도 float
    equality 비교 대신 [adaptive_timeout_enabled]를 쓴다 (CLAUDE.md §Magic Number +
-   P2#6 float-equality-as-toggle 회피). [min_effective_timeout_s]는 확장 후 effective
-   타임아웃이 이보다 작으면 즉시 실패(None)하는 하한이다. *)
+   P2#6 float-equality-as-toggle 회피). *)
 let adaptive_extension_threshold = 1.0
-
-let min_effective_timeout_s = 0.001
 
 (* [adaptive_timeout_enabled preset] — preset의 factor가 확장 임계값을 넘는가. float
    equality 대신 typed bool 토글로, callers(orchestrator)가 adaptive 재시도 분기를
    판정한다. *)
 let adaptive_timeout_enabled (p : preset) =
   p.adaptive_timeout_factor > adaptive_extension_threshold
-
-let judge_wave_budget_enabled ~wave_budget_s = wave_budget_s > 0.0
-
-(* 적응형 타임아웃: 1차 심판/재시도 호출에 사용할 effective timeout을 계산한다.
-   - factor <= [adaptive_extension_threshold] (또는 아직 타임아웃 안 됨): base_s를 wave
-     예산에 맞춰 반환.
-   - already_timed_out && factor > [adaptive_extension_threshold]: base_s *. factor를
-     max_s로 상한, 남은 예산으로 하한해 확장된 타임아웃을 반환.
-   예산/상한이 너무 작아 [min_effective_timeout_s] 미만이면 None (즉시 실패). *)
-let adjust_judge_timeout ~base_s ~max_s ~factor ~wave_budget_s ~elapsed_s
-    ~already_timed_out : float option =
-  let budget_enabled = judge_wave_budget_enabled ~wave_budget_s in
-  let budget_allows timeout_s =
-    (not budget_enabled) || elapsed_s +. timeout_s <= wave_budget_s
-  in
-  if factor <= adaptive_extension_threshold || not already_timed_out
-  then if budget_allows base_s then Some base_s else None
-  else
-    let extended = base_s *. factor in
-    let proposed =
-      match max_s with
-      | Some m -> Float.min extended m
-      | None -> extended
-    in
-    let effective =
-      if budget_enabled
-      then Float.min proposed (wave_budget_s -. elapsed_s)
-      else proposed
-    in
-    if effective < min_effective_timeout_s then None else Some effective
 
 (* RFC-0280: 검증된 preset을 타입으로 증명한다 (Parse, don't validate).
    [Validated_preset.t = private preset]이라 외부는 필드를 읽되([preset]/coercion)

--- a/lib/fusion_core/fusion_policy.mli
+++ b/lib/fusion_core/fusion_policy.mli
@@ -185,26 +185,6 @@ val judge_web_tools_of : req_web_tools:bool -> panel_group list -> bool
     adaptive 재시도 분기를 판정한다. *)
 val adaptive_timeout_enabled : preset -> bool
 
-(** [judge_wave_budget_enabled ~wave_budget_s] is false only for the validated
-    legacy disabled value [0.0]. Positive finite or effectively-unbounded
-    budgets still enforce the wave cap. *)
-val judge_wave_budget_enabled : wave_budget_s:float -> bool
-
-(** 적응형 타임아웃: 1차 심판/재시도 호출에 사용할 effective timeout을 계산한다.
-    [wave_budget_s = 0.0]이면 legacy disabled budget으로 간주해 wave cap을 적용하지
-    않는다. [factor <= adaptive_extension_threshold](= 1.0)이면 [base_s]를 반환하고,
-    [already_timed_out]이고 [factor > adaptive_extension_threshold]이면 [base_s *.
-    factor]를 [max_s]로 상한·남은 예산으로 하한해 확장한다. 결과가
-    [min_effective_timeout_s](0.001s) 미만이면 [None]. *)
-val adjust_judge_timeout
-  :  base_s:float
-  -> max_s:float option
-  -> factor:float
-  -> wave_budget_s:float
-  -> elapsed_s:float
-  -> already_timed_out:bool
-  -> float option
-
 (** RFC-0280: 검증을 통과한 preset (Parse, don't validate). [t = private preset]이라
     필드는 자유롭게 읽되([preset] 또는 coercion [(vp :> preset)]) 검증 없이 생성할 수
     없다 → invalid preset이 게이트·orchestrator로 흐를 수 없다. 검증 SSOT는

--- a/lib/fusion_core/fusion_types.ml
+++ b/lib/fusion_core/fusion_types.ml
@@ -216,10 +216,6 @@ type judge_failure =
 
 let judge_failure_is_timeout = function Timeout -> true | _ -> false
 
-let judge_failure_is_timeout_or_budget = function
-  | Timeout | Budget_exceeded _ -> true
-  | _ -> false
-
 let judge_failure_text = function
   | Timeout -> "timeout"
   | Provider_error detail -> detail

--- a/lib/fusion_core/fusion_types.mli
+++ b/lib/fusion_core/fusion_types.mli
@@ -236,11 +236,6 @@ type judge_failure =
     충분하므로 별도 bool 필드를 두지 않는다. *)
 val judge_failure_is_timeout : judge_failure -> bool
 
-(** [Timeout] 또는 [Budget_exceeded] 인가. orchestrator의 fallback-judge 트리거 조건:
-    1차 심판 전원이 타임아웃/예산-skip이면 fallback을 시도한다. exhaustive match로
-    string classifier([is_timeout_or_budget_error])를 대체한다. *)
-val judge_failure_is_timeout_or_budget : judge_failure -> bool
-
 (** sink/로그용 사람-가독 문자열. {!Fusion_oas.panel_failure_text}와 대칭. *)
 val judge_failure_text : judge_failure -> string
 

--- a/test/fusion_core/test_fusion.ml
+++ b/test/fusion_core/test_fusion.ml
@@ -1401,9 +1401,7 @@ let test_panels_unavailable_failure () =
   Alcotest.(check string) "failure text = rendered skip reason"
     "fusion aborted: none of 3 panels returned an answer"
     (judge_failure_text failure);
-  Alcotest.(check bool) "not a timeout" false (judge_failure_is_timeout failure);
-  Alcotest.(check bool) "not timeout-or-budget (no fallback judge trigger)" false
-    (judge_failure_is_timeout_or_budget failure)
+  Alcotest.(check bool) "not a timeout" false (judge_failure_is_timeout failure)
 
 (* min_answered must be in the policy range 1..total panels (inclusive).
    base_group has 3 models, so 0 and 4 are rejected; full-panel quorum (3) is allowed. *)
@@ -1578,42 +1576,6 @@ timeout_s = 100.0
          es)
   | Ok _ -> Alcotest.fail "expected Error Invalid_judge_wave_budget"
 
-let test_adjust_judge_timeout_disabled () =
-  Alcotest.(check (option (float 0.001))) "factor=1.0 within budget"
-    (Some 10.0)
-    (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:None ~factor:1.0
-       ~wave_budget_s:100.0 ~elapsed_s:5.0 ~already_timed_out:false);
-  Alcotest.(check (option (float 0.001))) "factor=1.0 over budget"
-    None
-    (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:None ~factor:1.0
-       ~wave_budget_s:14.0 ~elapsed_s:5.0 ~already_timed_out:false);
-  Alcotest.(check (option (float 0.001))) "wave budget 0 disables cap"
-    (Some 10.0)
-    (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:None ~factor:1.0
-       ~wave_budget_s:0.0 ~elapsed_s:500.0 ~already_timed_out:false)
-
-let test_adjust_judge_timeout_extend () =
-  (* already timed out + factor > 1.0 extends up to max_s and remaining budget. *)
-  Alcotest.(check (option (float 0.001))) "extend capped by max_s"
-    (Some 15.0)
-    (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:(Some 15.0)
-       ~factor:2.0 ~wave_budget_s:100.0 ~elapsed_s:5.0 ~already_timed_out:true);
-  Alcotest.(check (option (float 0.001))) "extend capped by remaining budget"
-    (Some 7.0)
-    (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:(Some 30.0)
-       ~factor:2.0 ~wave_budget_s:12.0 ~elapsed_s:5.0 ~already_timed_out:true);
-  Alcotest.(check (option (float 0.001))) "extend below 0.001 -> None"
-    None
-    (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:(Some 30.0)
-       ~factor:2.0 ~wave_budget_s:5.0 ~elapsed_s:5.0 ~already_timed_out:true)
-
-let test_adjust_judge_timeout_not_yet_timed_out () =
-  (* factor > 1.0 but not yet timed out: still use base_s, just budget-check. *)
-  Alcotest.(check (option (float 0.001))) "not timed out uses base_s"
-    (Some 10.0)
-    (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:(Some 5.0)
-       ~factor:2.0 ~wave_budget_s:100.0 ~elapsed_s:5.0 ~already_timed_out:false)
-
 let test_judge_error_node_timed_out () =
   let timeout_node =
     Fusion_types.Judge_failed
@@ -1764,12 +1726,6 @@ let () =
         ; Alcotest.test_case "multi_group" `Quick test_judge_args_multi_group
         ; Alcotest.test_case "outer_timeout_wave_math" `Quick
             test_panel_outer_timeout_wave_math
-        ] )
-    ; ( "adaptive_timeout"
-      , [ Alcotest.test_case "disabled" `Quick test_adjust_judge_timeout_disabled
-        ; Alcotest.test_case "extend" `Quick test_adjust_judge_timeout_extend
-        ; Alcotest.test_case "not_yet_timed_out" `Quick
-            test_adjust_judge_timeout_not_yet_timed_out
         ] )
     ; ( "judge_parse"
       , [ Alcotest.test_case "valid" `Quick test_judge_valid

--- a/test/test_fusion_adaptive_timeout.ml
+++ b/test/test_fusion_adaptive_timeout.ml
@@ -1,6 +1,6 @@
 (* FUSION adaptive timeout / P0 hardening tests.
-   Covers: config parse/validation, pure adjust_judge_timeout semantics,
-   OTel counter emission, and sink meta JSON for failed judge nodes. *)
+   Covers: config parse/validation, fallback semantics, OTel counter emission,
+   and sink meta JSON for failed judge nodes. *)
 
 open Alcotest
 open Masc
@@ -19,22 +19,12 @@ let sample_synthesis : Fusion_types.judge_synthesis =
   ; decision = Fusion_types.Answer "ok"
   }
 
-let sample_judge model : Fusion_policy.judge_spec =
-  { Fusion_policy.jmodel = model
-  ; jlabel = ""
-  ; jsystem_prompt = "judge"
-  ; jweb_tools = false
-  ; jmax_output_tokens = None
-  ; jtimeout_s = 1.0
-  ; jmax_timeout_s = None
-  }
-
 let failed_judge_run model failure :
     Fusion_orchestrator_judge_wave.judge_run =
-  sample_judge model, model, Error (failure, Fusion_types.zero_usage), 0.0, false
+  model, Error (failure, Fusion_types.zero_usage), 0.0
 
 let ok_judge_run model : Fusion_orchestrator_judge_wave.judge_run =
-  sample_judge model, model, Ok (sample_synthesis, sample_usage), 0.0, false
+  model, Ok (sample_synthesis, sample_usage), 0.0
 
 let parse s = Otoml.Parser.from_string s
 
@@ -144,28 +134,6 @@ adaptive_timeout_factor = 0.5
          es)
   | Ok _ -> fail "expected Error Invalid_adaptive_timeout_factor"
 
-let test_adjust_judge_timeout_disabled () =
-  check (option (float 0.001)) "factor=1.0 within budget" (Some 10.0)
-    (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:None ~factor:1.0
-       ~wave_budget_s:100.0 ~elapsed_s:5.0 ~already_timed_out:false);
-  check (option (float 0.001)) "factor=1.0 over budget" None
-    (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:None ~factor:1.0
-       ~wave_budget_s:14.0 ~elapsed_s:5.0 ~already_timed_out:false);
-  check (option (float 0.001)) "wave budget 0 disables cap" (Some 10.0)
-    (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:None ~factor:1.0
-       ~wave_budget_s:0.0 ~elapsed_s:500.0 ~already_timed_out:false)
-
-let test_adjust_judge_timeout_extend () =
-  check (option (float 0.001)) "extend capped by max_s" (Some 15.0)
-    (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:(Some 15.0)
-       ~factor:2.0 ~wave_budget_s:100.0 ~elapsed_s:5.0 ~already_timed_out:true);
-  check (option (float 0.001)) "extend capped by remaining budget" (Some 7.0)
-    (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:(Some 30.0)
-       ~factor:2.0 ~wave_budget_s:12.0 ~elapsed_s:5.0 ~already_timed_out:true);
-  check (option (float 0.001)) "extend below 0.001 -> None" None
-    (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:(Some 30.0)
-       ~factor:2.0 ~wave_budget_s:5.0 ~elapsed_s:5.0 ~already_timed_out:true)
-
 let test_runtime_clock_missing_env_still_attempts_fallback () =
   Masc_eio_env.reset_for_test ();
   Fun.protect ~finally:Masc_eio_env.reset_for_test (fun () ->
@@ -189,27 +157,25 @@ let test_runtime_clock_missing_env_still_attempts_fallback () =
         ~judge_web_tools:false
         ()
     with
-    | Some (_, id, Error (Fusion_types.Build_error _, _), elapsed_s, false) ->
+    | Some (id, Error (Fusion_types.Build_error _, _), elapsed_s) ->
       check string "fallback attempted"
         "fallback (fusion-clockless-regression-missing-runtime)" id;
       check (float 0.0) "missing clock is observation-only" 0.0 elapsed_s
-    | Some (_, _, Error (failure, _), _, _) ->
+    | Some (_, Error (failure, _), _) ->
       failf "unexpected fallback failure: %s" (Fusion_types.judge_failure_text failure)
     | Some _ -> fail "expected missing runtime build failure"
     | None -> fail "configured fallback must be attempted")
 
-let test_timeout_budget_first_wave_appends_fallback () =
+let test_all_error_first_wave_appends_fallback () =
   let fallback_calls = ref 0 in
   let fallback = ok_judge_run "fallback-model" in
   let runs =
     [ failed_judge_run "judge-a" Fusion_types.Timeout
-    ; failed_judge_run
-        "judge-b"
-        (Fusion_types.Budget_exceeded "wave budget exhausted")
+    ; failed_judge_run "judge-b" (Fusion_types.Provider_error "provider unavailable")
     ]
   in
   let with_fallback =
-    Fusion_orchestrator_judge_wave.with_timeout_budget_fallback
+    Fusion_orchestrator_judge_wave.with_all_error_fallback
       ~run_fallback_judge:(fun () ->
         incr fallback_calls;
         Some fallback)
@@ -218,18 +184,18 @@ let test_timeout_budget_first_wave_appends_fallback () =
   check int "fallback called once" 1 !fallback_calls;
   check int "fallback appended" 3 (List.length with_fallback);
   match List.rev with_fallback with
-  | (_, id, Ok _, _, _) :: _ -> check string "fallback id" "fallback-model" id
+  | (id, Ok _, _) :: _ -> check string "fallback id" "fallback-model" id
   | _ -> fail "expected appended successful fallback"
 
-let test_timeout_budget_first_wave_skips_fallback_on_provider_error () =
+let test_partial_success_skips_fallback () =
   let fallback_calls = ref 0 in
   let runs =
     [ failed_judge_run "judge-a" Fusion_types.Timeout
-    ; failed_judge_run "judge-b" (Fusion_types.Provider_error "hard failure")
+    ; ok_judge_run "judge-b"
     ]
   in
   let without_fallback =
-    Fusion_orchestrator_judge_wave.with_timeout_budget_fallback
+    Fusion_orchestrator_judge_wave.with_all_error_fallback
       ~run_fallback_judge:(fun () ->
         incr fallback_calls;
         Some (ok_judge_run "fallback-model"))
@@ -286,19 +252,15 @@ let () =
         ; test_case "invalid_adaptive_factor" `Quick
             test_config_invalid_adaptive_factor
         ] )
-    ; ( "adjust_judge_timeout"
-      , [ test_case "disabled" `Quick test_adjust_judge_timeout_disabled
-        ; test_case "extend" `Quick test_adjust_judge_timeout_extend
-        ] )
     ; ( "clock"
       , [ test_case "missing runtime env still attempts fallback" `Quick
             test_runtime_clock_missing_env_still_attempts_fallback
         ] )
     ; ( "fallback"
-      , [ test_case "timeout/budget wave appends fallback" `Quick
-            test_timeout_budget_first_wave_appends_fallback
-        ; test_case "provider failure skips fallback" `Quick
-            test_timeout_budget_first_wave_skips_fallback_on_provider_error
+      , [ test_case "all-error wave appends fallback" `Quick
+            test_all_error_first_wave_appends_fallback
+        ; test_case "partial success skips fallback" `Quick
+            test_partial_success_skips_fallback
         ] )
     ; ( "metrics"
       , [ test_case "record_adaptive_timeout emits counter" `Quick


### PR DESCRIPTION
## Summary

- reduce `judge_run` to identity, typed result, and elapsed observation; remove synthetic timeout state
- attempt `fallback_judge_model` exactly once when every first judge returned typed `Error`, regardless of error class
- skip fallback when any first judge produced a synthesis
- delete wave-budget timeout adjustment and its timeout/budget-only predicate instead of replacing limits with sentinel values

This is stacked on #24785. Timeout configuration/schema fields remain for the next hard-delete stack and do not control execution after this PR.

## Regression evidence

- mixed timeout/provider failures append one fallback
- a wave containing one successful synthesis never invokes fallback
- retired timeout-adjustment tests were removed with their implementation

## Verification

- `ocamlformat --check` on every changed OCaml file
- `ocamlc -stop-after parsing` on every changed OCaml file
- `git diff --check`
- focused Dune refused to run while an external bare Dune process bypassed the shared lock; PR CI is the build authority
