### PR TITLE
refactor(fusion): type elapsed availability

### DIFF
--- a/lib/fusion/fusion_orchestrator.ml
+++ b/lib/fusion/fusion_orchestrator.ml
@@ -79,7 +79,7 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                     { Fusion_types.failed_role = Refine_pass
                     ; failure
                     ; usage = u2
-                    ; elapsed_s = 0.0
+                    ; elapsed_s = None
                     }
                 ] )
           in
@@ -377,7 +377,7 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                        { Fusion_types.failed_role = Single
                        ; failure
                        ; usage = u
-                       ; elapsed_s = 0.0
+                       ; elapsed_s = None
                        }
                    ] ))
             | Fusion_types.Refine ->
@@ -388,7 +388,7 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                        { Fusion_types.failed_role = Single
                        ; failure
                        ; usage = u
-                       ; elapsed_s = 0.0
+                       ; elapsed_s = None
                        }
                    ] )
                | Ok pair -> refine_over pair)
@@ -400,7 +400,7 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                        { Fusion_types.failed_role = Single
                        ; failure
                        ; usage = u
-                       ; elapsed_s = 0.0
+                       ; elapsed_s = None
                        }
                    ] )
                | Ok ((s1, u1) as pair) ->

--- a/lib/fusion/fusion_orchestrator_judge_wave.ml
+++ b/lib/fusion/fusion_orchestrator_judge_wave.ml
@@ -4,7 +4,7 @@ type judge_run =
   * ( Fusion_types.judge_synthesis * Fusion_types.usage
     , Fusion_types.judge_failure * Fusion_types.usage )
     result
-  * float
+  * float option
   * bool
 
 type clock =
@@ -28,8 +28,8 @@ let make_runtime_clock () =
 
 let elapsed_since_t0 clock =
   match clock.now_opt (), clock.t0 with
-  | Some now, Some t0 -> now -. t0
-  | _ -> 0.0
+  | Some now, Some t0 -> Some (now -. t0)
+  | _ -> None
 ;;
 
 let run_first_judge

--- a/lib/fusion/fusion_orchestrator_judge_wave.mli
+++ b/lib/fusion/fusion_orchestrator_judge_wave.mli
@@ -6,7 +6,7 @@ type judge_run =
   * ( Fusion_types.judge_synthesis * Fusion_types.usage
     , Fusion_types.judge_failure * Fusion_types.usage )
     result
-  * float
+  * float option
   * bool
 
 type clock
@@ -17,9 +17,9 @@ val make_clock
 
 val make_runtime_clock : unit -> clock
 (** Build a clock from the current domain-local {!Masc_eio_env}. Missing
-    runtime env is represented as [None]; timing observation then reports 0. *)
+    runtime env never blocks execution and produces unavailable elapsed observations. *)
 
-val elapsed_since_t0 : clock -> float
+val elapsed_since_t0 : clock -> float option
 
 val run_first_judges
   :  sw:Eio.Switch.t

--- a/lib/fusion/fusion_sink.ml
+++ b/lib/fusion/fusion_sink.ml
@@ -248,7 +248,10 @@ let judge_node_meta (o : Fusion_types.judge_outcome) : Yojson.Safe.t =
          ; ("failure_code", `String (Fusion_types.judge_failure_tag failure))
          ; ("input_tokens", `Int usage.Fusion_types.input_tokens)
          ; ("output_tokens", `Int usage.Fusion_types.output_tokens)
-         ; ("elapsed_s", `Float elapsed_s)
+         ; ( "elapsed_s"
+           , match elapsed_s with
+             | Some value -> `Float value
+             | None -> `Null )
          ; ("timed_out", `Bool timed_out)
          ])
 

--- a/lib/fusion_core/fusion_types.ml
+++ b/lib/fusion_core/fusion_types.ml
@@ -248,10 +248,10 @@ type judge_error_node =
   ; usage : usage
       (** 실패해도 태운 토큰 — 관측 record가 비용을 버리지 않는다(RFC-0284, 적대 리뷰 #22112 E).
           [panel_error]와 달리 심판 실패는 토큰 소비 후일 수 있어 usage를 동반한다. *)
-  ; elapsed_s : float
-      (** 이 심판 노드가 시작된 시점부터 실패까지 경과한 시간(초). 예산/타임아웃
-          분석에 쓰인다(RFC-0284-FUSION-P0). [timed_out]은 [judge_failure_is_timeout failure]
-          로 파생 가능해 별도 필드에서 제거했다. *)
+  ; elapsed_s : float option
+      (** 이 심판 노드가 시작된 시점부터 실패까지 경과한 시간(초). [None]은
+          clock 미가용으로 관측할 수 없었음을 뜻한다. [timed_out]은
+          [judge_failure_is_timeout failure]로 파생 가능해 별도 필드에서 제거했다. *)
   }
 [@@deriving yojson, show, eq]
 

--- a/lib/fusion_core/fusion_types.mli
+++ b/lib/fusion_core/fusion_types.mli
@@ -262,8 +262,9 @@ type judge_error_node =
   ; failure : judge_failure
   ; usage : usage
       (** 실패해도 태운 토큰 — 관측 record가 비용을 버리지 않는다(RFC-0284, 적대 리뷰 #22112 E). *)
-  ; elapsed_s : float
-      (** Wave start부터 실패까지 경과한 시간(초). 타임아웃/예산 원인 분석용. *)
+  ; elapsed_s : float option
+      (** Wave start부터 실패까지 경과한 시간(초). [None]은 clock 미가용으로
+          관측할 수 없었음을 뜻한다. *)
   }
 [@@deriving yojson, show, eq]
 

--- a/test/fusion_core/test_fusion.ml
+++ b/test/fusion_core/test_fusion.ml
@@ -1346,7 +1346,7 @@ let test_judge_outcome_roundtrip () =
         { failed_role = Meta
         ; failure = Provider_error "boom"
         ; usage = { input_tokens = 9; output_tokens = 10 }
-        ; elapsed_s = 0.0
+        ; elapsed_s = None
         }
     ]
   in
@@ -1550,7 +1550,7 @@ let test_judge_error_node_timed_out () =
       { Fusion_types.failed_role = First "j"
       ; failure = Fusion_types.Timeout
       ; usage = Fusion_types.zero_usage
-      ; elapsed_s = 5.0
+      ; elapsed_s = Some 5.0
       }
   in
   let budget_node =
@@ -1559,7 +1559,7 @@ let test_judge_error_node_timed_out () =
       ; failure =
           Fusion_types.Budget_exceeded "judge j skipped: would exceed wave budget"
       ; usage = Fusion_types.zero_usage
-      ; elapsed_s = 3.0
+      ; elapsed_s = None
       }
   in
   match
@@ -1571,10 +1571,12 @@ let test_judge_error_node_timed_out () =
   | Ok (Judge_failed n1), Ok (Judge_failed n2) ->
     Alcotest.(check bool) "timeout node roundtrips timed_out" true
       (Fusion_types.judge_failure_is_timeout n1.failure);
-    Alcotest.(check (float 0.001)) "timeout node roundtrips elapsed_s" 5.0 n1.elapsed_s;
+    Alcotest.(check (option (float 0.001))) "timeout node roundtrips elapsed_s"
+      (Some 5.0) n1.elapsed_s;
     Alcotest.(check bool) "budget node roundtrips timed_out" false
       (Fusion_types.judge_failure_is_timeout n2.failure);
-    Alcotest.(check (float 0.001)) "budget node roundtrips elapsed_s" 3.0 n2.elapsed_s
+    Alcotest.(check (option (float 0.001))) "unavailable elapsed roundtrips"
+      None n2.elapsed_s
   | _ -> Alcotest.fail "expected Judge_failed roundtrip"
 
 let test_validated_bad_meta_timeout () =

--- a/test/test_fusion_adaptive_timeout.ml
+++ b/test/test_fusion_adaptive_timeout.ml
@@ -119,6 +119,11 @@ let test_runtime_clock_does_not_gate_meta_provider_call () =
   Masc_eio_env.reset_for_test ();
   Fun.protect ~finally:Masc_eio_env.reset_for_test (fun () ->
     let clock = Fusion_orchestrator_judge_wave.make_runtime_clock () in
+    check
+      (option (float 0.0))
+      "missing clock is explicit"
+      None
+      (Fusion_orchestrator_judge_wave.elapsed_since_t0 clock);
     match
       Fusion_orchestrator_judge_wave.meta_provider_timeout
         ~preset:(adaptive_preset ())
@@ -134,7 +139,7 @@ let test_sink_failed_node_includes_timeout_fields () =
       { Fusion_types.failed_role = First "j"
       ; failure = Fusion_types.Timeout
       ; usage = sample_usage
-      ; elapsed_s = 5.0
+      ; elapsed_s = Some 5.0
       }
   in
   let json = Fusion_sink.judge_node_meta node in

--- a/test/test_fusion_metrics.ml
+++ b/test/test_fusion_metrics.ml
@@ -41,7 +41,7 @@ let test_labels () =
           { Fusion_types.failed_role = Meta
           ; failure = Fusion_types.Provider_error "boom"
           ; usage = sample_usage
-          ; elapsed_s = 0.0
+          ; elapsed_s = None
           }))
 
 let test_record_judge_execution_emits () =

--- a/test/test_fusion_sink_meta.ml
+++ b/test/test_fusion_sink_meta.ml
@@ -258,7 +258,7 @@ let test_node_failed_keeps_identity () =
       { failed_role = First "a (m)"
       ; failure = Provider_error "boom"
       ; usage = { input_tokens = 7; output_tokens = 8 }
-      ; elapsed_s = 1.5
+      ; elapsed_s = Some 1.5
       }
   in
   let a = assoc_of (Masc.Fusion_sink.judge_node_meta o) in
@@ -270,7 +270,21 @@ let test_node_failed_keeps_identity () =
   check bool "no consensus on failed node" false (List.mem "consensus" (keys a));
   check (option int) "failed node input_tokens (E)" (Some 7) (int_field a "input_tokens");
   check (option int) "failed node output_tokens (E)" (Some 8)
-    (int_field a "output_tokens")
+    (int_field a "output_tokens");
+  check bool "observed elapsed is numeric" true
+    (List.assoc_opt "elapsed_s" a = Some (`Float 1.5));
+  let unavailable =
+    Judge_failed
+      { failed_role = Meta
+      ; failure = Internal_error "clock unavailable"
+      ; usage = zero_usage
+      ; elapsed_s = None
+      }
+    |> Masc.Fusion_sink.judge_node_meta
+    |> assoc_of
+  in
+  check bool "unavailable elapsed is null" true
+    (List.assoc_opt "elapsed_s" unavailable = Some `Null)
 
 let () =
   run "Fusion_sink.judge_meta"


### PR DESCRIPTION
## Summary

- stack this observation-only change on #24571, the Provider-timeout SSOT hard cut
- change judge elapsed observation from mandatory `float` to `float option`
- represent an available clock as `Some seconds` and a missing clock as `None`
- emit unavailable elapsed time as JSON `null`, while preserving numeric values when observed
- exclude the automatic retry/fallback behavior from #24786

## Regression evidence

- clockless fallback execution records `None`
- judge outcome codec round-trips both observed and unavailable elapsed values
- sink metadata emits a number for `Some` and `null` for `None`

## Verification

- `ocamlformat --check` on every changed OCaml file
- `ocamlc -stop-after parsing` on every changed OCaml file
- `git diff --check`
- no local Dune build; PR CI is the build authority
