### PR TITLE
fix(connector): remove Keeper SSE read deadline

### DIFF
--- a/sidecars/shared/gate_shared/gate_client_base.py
+++ b/sidecars/shared/gate_shared/gate_client_base.py
@@ -16,11 +16,9 @@ from typing import Any, cast
 import httpx
 
 try:
-    import httpx_sse
-
-    _HAS_SSE = True
+    import httpx_sse as _httpx_sse
 except ImportError:
-    _HAS_SSE = False
+    _httpx_sse = None
 
 from .gate_response import GateResponse
 
@@ -358,8 +356,9 @@ class GateClientBase:
         Uses POST /api/v1/keepers/chat/stream which returns AG-UI SSE events.
         Only TEXT_MESSAGE_CONTENT deltas are yielded as strings.
         Requires httpx-sse; yields nothing if the library is not installed.
+        Transport failures are recorded and raised to the caller.
         """
-        if not _HAS_SSE:
+        if _httpx_sse is None:
             logger.warning("httpx-sse not installed; streaming unavailable")
             return
         if self._breaker_is_open():
@@ -373,12 +372,17 @@ class GateClientBase:
         client = self._get_client()
 
         try:
-            async with httpx_sse.aconnect_sse(
+            async with _httpx_sse.aconnect_sse(
                 client,
                 "POST",
                 self._stream_url,
                 json=payload,
-                timeout=httpx.Timeout(timeout=300.0, connect=10.0),
+                timeout=httpx.Timeout(
+                    connect=self._timeout,
+                    read=None,
+                    write=self._timeout,
+                    pool=self._timeout,
+                ),
             ) as event_source:
                 if event_source.response.status_code >= 400:
                     self._note_transport_failure(
@@ -411,12 +415,15 @@ class GateClientBase:
                         err = str(custom.get("message", ""))
                         logger.warning("Keeper stream error: %s", err)
                         return
-        except httpx.TimeoutException:
-            self._note_transport_failure("stream timeout after 300s")
+        except httpx.TimeoutException as e:
+            self._note_transport_failure(f"stream transport timeout: {e}")
+            raise
         except httpx.HTTPError as e:
             self._note_transport_failure(f"stream http error: {e}")
+            raise
         except Exception as e:  # pragma: no cover
             self._note_transport_failure(f"stream error: {e}")
+            raise
 
     # ── Activity Polling ─────────────────────────────────
 

--- a/sidecars/shared/tests/test_gate_client_base.py
+++ b/sidecars/shared/tests/test_gate_client_base.py
@@ -2,12 +2,53 @@
 
 from __future__ import annotations
 
+import asyncio
 import time
-from unittest.mock import AsyncMock, patch
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import cast
 
+import httpx
 import pytest
 
-from gate_shared import BreakerSnapshot, GateClientBase, GateResponse
+from gate_shared import GateClientBase
+
+
+@asynccontextmanager
+async def _idle_sse_server() -> AsyncIterator[
+    tuple[str, asyncio.Queue[None], asyncio.Event]
+]:
+    accepted: asyncio.Queue[None] = asyncio.Queue()
+    release = asyncio.Event()
+
+    async def handle(
+        reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        try:
+            await reader.readuntil(b"\r\n\r\n")
+            writer.write(
+                b"HTTP/1.1 200 OK\r\n"
+                b"Content-Type: text/event-stream\r\n"
+                b"Connection: close\r\n\r\n"
+            )
+            await writer.drain()
+            accepted.put_nowait(None)
+            await release.wait()
+            writer.write(b'data: {"type":"TEXT_MESSAGE_CONTENT","delta":"ready"}\n\n')
+            await writer.drain()
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+    server = await asyncio.start_server(handle, "127.0.0.1", 0)
+    socket = server.sockets[0]
+    host, port = socket.getsockname()[:2]
+    try:
+        yield f"http://{host}:{port}/stream", accepted, release
+    finally:
+        release.set()
+        server.close()
+        await server.wait_closed()
 
 
 def _make_client(**kwargs: object) -> GateClientBase:
@@ -125,3 +166,86 @@ class TestSendMessage:
         )
         assert not resp.ok
         assert "circuit open" in resp.error
+
+
+class TestKeeperStream:
+    @pytest.mark.asyncio
+    async def test_accepted_idle_stream_has_no_read_deadline(self) -> None:
+        c = _make_client(timeout_sec=0.1)
+        observed_timeouts: list[dict[str, float | None]] = []
+
+        async def observe_timeout(request: httpx.Request) -> None:
+            observed_timeouts.append(
+                cast(dict[str, float | None], request.extensions["timeout"])
+            )
+
+        async with _idle_sse_server() as (url, accepted, release):
+            c._stream_url = url
+            c._client = httpx.AsyncClient(
+                headers=c._headers,
+                event_hooks={"request": [observe_timeout]},
+            )
+
+            async def release_after_idle() -> None:
+                await accepted.get()
+                await asyncio.sleep(0.2)
+                release.set()
+
+            release_task = asyncio.create_task(release_after_idle())
+            try:
+                deltas = [
+                    delta
+                    async for delta in c.stream_keeper(
+                        keeper_name="keeper-a",
+                        message="continue",
+                        context={"channel": "test"},
+                    )
+                ]
+                await release_task
+            finally:
+                await c.aclose()
+
+        assert deltas == ["ready"]
+        assert len(observed_timeouts) == 1
+        assert observed_timeouts[0] == {
+            "connect": 0.1,
+            "read": None,
+            "write": 0.1,
+            "pool": 0.1,
+        }
+
+    @pytest.mark.asyncio
+    async def test_transport_timeout_is_raised_to_caller(self) -> None:
+        c = _make_client(timeout_sec=0.1)
+        async with _idle_sse_server() as (url, accepted, release):
+            c._stream_url = url
+            c._client = httpx.AsyncClient(
+                headers=c._headers,
+                limits=httpx.Limits(max_connections=1),
+            )
+            first_stream = c.stream_keeper(
+                keeper_name="keeper-a",
+                message="first",
+                context={"channel": "test"},
+            )
+
+            async def consume_first_stream() -> list[str]:
+                return [delta async for delta in first_stream]
+
+            first_result = asyncio.create_task(consume_first_stream())
+            await accepted.get()
+
+            second_stream = c.stream_keeper(
+                keeper_name="keeper-b",
+                message="second",
+                context={"channel": "test"},
+            )
+            try:
+                with pytest.raises(httpx.PoolTimeout):
+                    await anext(second_stream)
+                assert c.breaker_snapshot().consecutive_failures == 1
+                release.set()
+                assert await first_result == ["ready"]
+            finally:
+                release.set()
+                await c.aclose()


### PR DESCRIPTION
## Why

An accepted Keeper SSE request continues server-side after the connector disconnects. The hard-coded 300-second read cutoff therefore turned a still-running request into a normal generator end and could invite a duplicate retry.

## Change

- configure the stream with `read=None` while keeping connect, write, and pool liveness on the existing connector timeout
- record and re-raise HTTP transport failures instead of presenting timeout/HTTP exceptions as successful stream completion
- make the optional `httpx_sse` binding explicit for type checking

## Regression proof

- a real loopback SSE server accepts one request, remains delta-free longer than the configured transport timeout, and later delivers the original stream delta
- the observed HTTPX request contract is `read=None` with finite connect/write/pool values
- a real single-connection pool exhaustion raises `httpx.PoolTimeout` to the caller and records one breaker failure

## Validation

- `PYTHONPATH=/tmp/masc-connector-sse-test-deps:sidecars/shared pytest -q sidecars/shared/tests` (56 passed)
- `pyright --outputjson` on both changed Python files (0 errors)
- `ruff check` on both changed Python files
- `ruff format --check` on the changed test and changed source ranges

## Deliberate non-goal

Multi-connector/global breaker ownership is a separate architecture issue; this PR does not redesign breaker scope.