### PR TITLE
refactor(fusion): delete panel timeout contract

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -1054,8 +1054,6 @@ question. Synthesize them: identify points of consensus, contradictions, \
 partial coverage, unique insights, and blind spots, then give one resolved \
 answer. Respond with ONLY the requested JSON object, no prose and no code fences.
 """
-# 구조적 타임아웃(초). 미지정 시 Fusion_policy.default_timeout_s.
-panel_timeout_s = 300.0
 judge_timeout_s = 300.0
 # 패널/심판에 MASC web_search/web_fetch 도구를 주입할지 여부.
 web_tools = false
@@ -1092,7 +1090,6 @@ Reconcile them: where the judges agree, state the consensus; where they diverge,
 adjudicate with reasons; surface any blind spot that a single lens missed. Produce \
 one resolved answer. Respond with ONLY the requested JSON object, no prose and no code fences.
 """
-panel_timeout_s = 300.0
 judge_timeout_s = 300.0
 # meta/stage-meta reducer 구조적 타임아웃. 미지정 시 judge_timeout_s와 동일.
 meta_timeout_s = 300.0
@@ -1164,7 +1161,6 @@ adjudicate with reasons; surface any blind spot that a single stage missed. \
 Produce one resolved answer. Respond with ONLY the requested JSON object, no \
 prose and no code fences.
 """
-panel_timeout_s = 300.0
 judge_timeout_s = 300.0
 meta_timeout_s = 300.0
 web_tools = false

--- a/dashboard/src/components/fusion-settings-panel.test.ts
+++ b/dashboard/src/components/fusion-settings-panel.test.ts
@@ -218,9 +218,8 @@ describe('FusionSettingsPanel', () => {
     const models = Array.from(container.querySelectorAll('[data-testid="fusion-preset-panel-model"]')).map(m => m.textContent)
     expect(models).toEqual(['a', 'b', 'c'])
     expect(q('[data-testid="fusion-preset-judge"]')?.textContent).toBe('j')
-    // SAMPLE's trio declares no timeouts → shown as '—', never fabricated.
+    // SAMPLE's trio declares no judge timeout → shown as '—', never fabricated.
     const timing = q('[data-testid="fusion-preset-timing"]')?.textContent ?? ''
-    expect(timing).toContain('panel_timeout —')
     expect(timing).toContain('judge_timeout —')
   })
 

--- a/dashboard/src/components/fusion-settings-panel.ts
+++ b/dashboard/src/components/fusion-settings-panel.ts
@@ -418,7 +418,7 @@ export function FusionSettingsPanel() {
               </div>
             </div>
             <div class="set-mcp-detail mono" data-testid="fusion-preset-timing" style=${{ marginTop: 10 }}>
-              panel_timeout ${timeoutLabel(presetView.panelTimeoutS)} · judge_timeout ${timeoutLabel(presetView.judgeTimeoutS)}
+              judge_timeout ${timeoutLabel(presetView.judgeTimeoutS)}
             </div>
           `
         : null}

--- a/dashboard/src/lib/fusion-preset-view.test.ts
+++ b/dashboard/src/lib/fusion-preset-view.test.ts
@@ -19,7 +19,6 @@ judge = "ollama_cloud.devstral-2-123b"
 panel_system_prompt = """
 You are an expert panelist. Answer directly.
 """
-panel_timeout_s = 300.0
 judge_timeout_s = 250.0
 
 [fusion.presets.quorum]
@@ -37,7 +36,7 @@ describe('readFusionPresetView', () => {
     expect(readFusionPresetView(MULTILINE, 'nonexistent')).toBeNull()
   })
 
-  it('parses a multi-line panel array plus scalar judge/timeouts', () => {
+  it('parses a multi-line panel array plus scalar judge timeout', () => {
     const view = readFusionPresetView(MULTILINE, 'trio')
     expect(view).not.toBeNull()
     expect(view!.preset).toBe('trio')
@@ -48,7 +47,6 @@ describe('readFusionPresetView', () => {
     ])
     expect(view!.judge).toBe('ollama_cloud.devstral-2-123b')
     // Scalars are found even though a multi-line prompt string precedes them.
-    expect(view!.panelTimeoutS).toBe(300)
     expect(view!.judgeTimeoutS).toBe(250)
   })
 
@@ -56,8 +54,7 @@ describe('readFusionPresetView', () => {
     const view = readFusionPresetView(MULTILINE, 'quorum')
     expect(view!.panel).toEqual(['lens_a', 'lens_b'])
     expect(view!.judge).toBe('meta')
-    // quorum declares no timeouts → null, not the trio values.
-    expect(view!.panelTimeoutS).toBeNull()
+    // quorum declares no judge timeout → null, not the trio value.
     expect(view!.judgeTimeoutS).toBeNull()
   })
 
@@ -74,7 +71,6 @@ describe('readFusionPresetView', () => {
     expect(view).not.toBeNull()
     expect(view!.panel).toEqual([])
     expect(view!.judge).toBeNull()
-    expect(view!.panelTimeoutS).toBeNull()
   })
 
   it('flags a flat preset as not grouped', () => {
@@ -102,7 +98,6 @@ web_tools = false
 panel = ["careful1"]
 panel_system_prompt = "deliberate"
 web_tools = true
-panel_timeout_s = 180.0
 `
 
 describe('readFusionPresetView — grouped panels', () => {
@@ -115,7 +110,6 @@ describe('readFusionPresetView — grouped panels', () => {
     // panel — the silent-partial regression this guards against.
     expect(view!.panel).toEqual([])
     expect(view!.judge).toBeNull()
-    expect(view!.panelTimeoutS).toBeNull()
   })
 
   it('treats a conflicting grouped+flat preset as grouped (never trusts the flat panel)', () => {

--- a/dashboard/src/lib/fusion-preset-view.ts
+++ b/dashboard/src/lib/fusion-preset-view.ts
@@ -1,11 +1,11 @@
 // Read-only view of a [fusion.presets.<preset>] table for the Settings fusion
-// section (keeper-v2 settings.jsx: trio preset lanes + timeouts).
+// section (keeper-v2 settings.jsx: trio preset lanes + judge timeout).
 //
 // This is a display-only reader — it never writes back, so it deliberately does
 // NOT live in fusion-settings.ts (whose line-surgical write path forbids
 // multi-line values). The preset `panel` value is a possibly multi-line TOML
 // array, which the scalar getRuntimeTomlKey helper cannot read; scalar keys
-// (judge / timeouts) reuse getRuntimeTomlKey so the
+// (judge / judge timeout) reuse getRuntimeTomlKey so the
 // section-scoping stays consistent with the rest of the runtime.toml tooling.
 //
 // The source text is the live runtime.toml already fetched by
@@ -27,12 +27,10 @@ export interface FusionPresetView {
   readonly judgeGroupCount: number
   readonly panel: readonly string[]
   readonly judge: string | null
-  readonly panelTimeoutS: number | null
   readonly judgeTimeoutS: number | null
 }
 
 const KEY_JUDGE = 'judge'
-const KEY_PANEL_TIMEOUT_S = 'panel_timeout_s'
 const KEY_JUDGE_TIMEOUT_S = 'judge_timeout_s'
 
 function presetSection(preset: string): string {
@@ -171,7 +169,6 @@ export function readFusionPresetView(sourceText: string, preset: string): Fusion
       judgeGroupCount,
       panel: [],
       judge: null,
-      panelTimeoutS: null,
       judgeTimeoutS: null,
     }
   }
@@ -185,7 +182,6 @@ export function readFusionPresetView(sourceText: string, preset: string): Fusion
     judgeGroupCount,
     panel: parseStringArray(body, 'panel'),
     judge: parseScalarString(sourceText, section, KEY_JUDGE),
-    panelTimeoutS: parseScalarNumber(sourceText, section, KEY_PANEL_TIMEOUT_S),
     judgeTimeoutS: parseScalarNumber(sourceText, section, KEY_JUDGE_TIMEOUT_S),
   }
 }

--- a/docs/rfc/RFC-0252-fusion-panel-judge-deliberation.md
+++ b/docs/rfc/RFC-0252-fusion-panel-judge-deliberation.md
@@ -255,7 +255,6 @@ panel = ["deepseek.v4-flash", "glm.5-turbo", "ollama.gemma4-26b"]
 judge = "deepseek.v4-flash"
 panel_system_prompt = "..."           # 행동 정의 — 코드 default 없음, 비면 Missing_prompt
 judge_system_prompt = "..."
-panel_timeout_s = 120.0               # 생략 시 default_timeout_s
 judge_timeout_s = 120.0
 max_output_tokens_per_panel = 4096    # 생략 시 Runtime_agent 기본 출력 예산
 judge_max_output_tokens = 4096        # 생략 시 Runtime_agent 기본 출력 예산

--- a/docs/rfc/RFC-0277-fusion-heterogeneous-panels.md
+++ b/docs/rfc/RFC-0277-fusion-heterogeneous-panels.md
@@ -22,17 +22,16 @@ type preset =
   ; panel_system_prompt : string  (* 패널 전체 공유 *)
   ; web_tools : bool              (* 패널 전체 공유 *)
   ; max_tool_calls_per_panel : int
-  ; panel_timeout_s : float
   ; ... }
 ```
 
-`panel_system_prompt`/`web_tools`/`max_tool_calls_per_panel`/`panel_timeout_s`가 패널 전체에 **하나씩** 적용되므로, 한 preset 안에서 "tool 없는 빠른 그룹 + web tool 켠 신중한 그룹"처럼 **이질적(heterogeneous)** 구성을 표현할 수 없다. 근거: Self-MoA 비판은 *동질·중복* 패널이 다양성 이득을 깎는다는 것이므로, 이질 패널이 그 비판을 피하는 방향이다.
+`panel_system_prompt`/`web_tools`/`max_tool_calls_per_panel`가 패널 전체에 **하나씩** 적용되므로, 한 preset 안에서 "tool 없는 빠른 그룹 + web tool 켠 신중한 그룹"처럼 **이질적(heterogeneous)** 구성을 표현할 수 없다. 근거: Self-MoA 비판은 *동질·중복* 패널이 다양성 이득을 깎는다는 것이므로, 이질 패널이 그 비판을 피하는 방향이다.
 
 둘째, RFC-0252 §6의 발동 예산(`per_hour_budget`)은 시간당 fusion **activation** 횟수 cap이다 — gate 통과 후 `Fusion_budget.try_incr_if_under`로 소비했다 (`lib/fusion/fusion_orchestrator.ml:17`, `lib/fusion_core/fusion_policy.ml:44`). 이 cap은 운영상 의미가 없다(아래 §3): fusion은 키퍼가 명시적으로 호출하는 out-of-band 심의이고, activation 빈도는 cap이 아니라 키퍼 판단·턴 구조가 이미 bound한다.
 
 ### 1.2 이 RFC가 하는 것
 
-1. **이종 패널 그룹**: `preset.panel : string list` → `preset.panels : panel_group list`. 각 그룹이 자기 `system_prompt`/`web_tools`/`max_tool_calls`/`timeout_s`를 갖는다. 모든 그룹의 에이전트를 **하나의 `Async_agent.all`**에 union으로 던진다 (동시성/격리 경계 무변경). judge/sink는 평면 `panel_outcome list`만 보므로 **무변경**.
+1. **이종 패널 그룹**: `preset.panel : string list` → `preset.panels : panel_group list`. 각 그룹이 자기 `system_prompt`/`web_tools`/`max_tool_calls`를 갖는다. 모든 그룹의 에이전트를 **하나의 `Async_agent.all`**에 union으로 던진다 (동시성/격리 경계 무변경). judge/sink는 평면 `panel_outcome list`만 보므로 **무변경**.
 2. **legacy 무변경**: 기존 flat `panel=[...]` 문법을 **정확히 길이-1 그룹으로 desugar** (`lib/fusion_core/fusion_config.ml:55`). 운영자 TOML 0줄 변경, 단일 그룹이면 오늘과 **byte-identical** 동작.
 3. **발동 예산 제거**: `per_hour_budget`/`Fusion_budget`/`Over_hourly_budget`/gate 소비를 전부 제거. cost-control cap을 두지 않는다 (§3).
 
@@ -52,7 +51,6 @@ type panel_group =
   ; system_prompt : string
   ; web_tools : bool
   ; max_tool_calls : int   (* 0 = 무제한 *)
-  ; timeout_s : float
   }
 [@@deriving show, eq]
 
@@ -80,7 +78,6 @@ panel = ["careful1"]
 web_tools = true
 max_tool_calls_per_panel = 4
 max_output_tokens_per_panel = 4096
-panel_timeout_s = 180.0
 ```
 
 legacy flat `panel=[...]`는 같은 `parse_group` 함수를 preset 테이블 자체에 적용해 길이-1 그룹으로 desugar한다(코드 재사용). 두 문법이 같은 키 이름을 쓰기 때문이다.
@@ -108,9 +105,8 @@ RFC-0252 §6은 비용을 예측 가능하게 통제하려고 `per_hour_budget`(
 
 ## 4. byte-identity 복구 (실행축)
 
-`preset.web_tools`/`max_tool_calls_per_panel`/`panel_timeout_s`는 오늘 패널뿐 아니라 **심판 호출과 외곽 run_safe 타임아웃**에도 쓰인다 (`lib/fusion/fusion_orchestrator.ml:29-48`). 이 값들을 per-group으로 옮기면 심판/외곽-timeout이 대표값을 잃는다. 단일 그룹에서 오늘과 byte-identical을 보장하기 위해 순수 derive 함수를 둔다:
+`preset.web_tools`/`max_tool_calls_per_panel`는 심판 호출에도 쓰인다. 이 값들을 per-group으로 옮기면 심판이 대표값을 잃는다. 단일 그룹에서 오늘과 byte-identical을 보장하기 위해 순수 derive 함수를 둔다:
 
-- `panel_outer_timeout_of groups` = 그룹 timeout 중 max (단일이면 그 그룹 timeout = `panel_timeout_s`).
 - `judge_web_tools_of ~req_web_tools groups` = `req || (어느 그룹이든 web_tools)` (단일이면 `req || group.web_tools` = 오늘).
 - `judge_tool_budget_of groups` = 0(무제한)이 흡수자, 그 외 그룹 max (단일이면 그 그룹 값 = 오늘).
 - `max_output_tokens_per_panel`은 group-local이다. 심판 출력 예산은 `judge_max_output_tokens`와 `[[...judges]].max_output_tokens`가 소유하므로, 그룹별 패널 예산이 심판 호출에 암묵 전파되지 않는다.

--- a/docs/rfc/RFC-0306-fusion-settings-typed-editor.md
+++ b/docs/rfc/RFC-0306-fusion-settings-typed-editor.md
@@ -35,7 +35,7 @@ Read-only display only (`dashboard/src/lib/fusion-preset-view.ts`, header commen
 "display-only reader — it never writes back"):
 
 - `panel = [...]` roster, `judge` (meta), `[[fusion.presets.<name>.judges]]` (JoJ
-  first-round judges), `panel_timeout_s`, `judge_timeout_s`,
+  first-round judges), `judge_timeout_s`,
   `max_tool_calls_per_panel`, `max_concurrent_judges`, `staged_judge_group_size`.
 
 Backend schema (`lib/fusion_core/fusion_config.ml`, `lib/fusion_core/fusion_policy.ml`)

--- a/lib/fusion_core/fusion_config.ml
+++ b/lib/fusion_core/fusion_config.ml
@@ -39,7 +39,7 @@ let disabled : Fusion_policy.t =
 
 (* 패널 그룹 한 개 파싱. 그룹 sub-table(새 [[...panels]] 문법)에도, preset table
    자체(legacy flat 문법의 desugar)에도 동일하게 적용된다 — 두 문법이 같은 키
-   이름(panel/label/panel_system_prompt/web_tools/panel_timeout_s)을
+   이름(panel/label/panel_system_prompt/web_tools)을
    쓰므로 코드 재사용. 누락 필드는 명시적 default. label 기본 ""(정체성=model 그대로)
    → legacy flat은 label 키가 없으므로 byte-identical (RFC-0278). *)
 let parse_group (tbl : Otoml.t) : Fusion_policy.panel_group =
@@ -51,9 +51,6 @@ let parse_group (tbl : Otoml.t) : Fusion_policy.panel_group =
   ; web_tools = Otoml.find_or ~default:false tbl Otoml.get_boolean [ "web_tools" ]
   ; max_output_tokens =
       Otoml.find_opt tbl Otoml.get_integer [ "max_output_tokens_per_panel" ]
-  ; timeout_s =
-      Otoml.find_or ~default:Fusion_policy.default_timeout_s tbl Otoml.get_float
-        [ "panel_timeout_s" ]
   }
 
 (* JOJ 1차 심판 한 명 파싱 (RFC-0283). [[fusion.presets.NAME.judges]] sub-table의

--- a/lib/fusion_core/fusion_config_json.ml
+++ b/lib/fusion_core/fusion_config_json.ml
@@ -27,7 +27,6 @@ let panel_group_to_yojson (g : Fusion_policy.panel_group) : Yojson.Safe.t =
     ; ("system_prompt", `String g.Fusion_policy.system_prompt)
     ; ("web_tools", `Bool g.Fusion_policy.web_tools)
     ; ("max_output_tokens", opt_int g.Fusion_policy.max_output_tokens)
-    ; ("timeout_s", `Float g.Fusion_policy.timeout_s)
     ]
 
 (* Judge fields are prefixed [j*] in the record; the JSON drops the prefix so the

--- a/lib/fusion_core/fusion_policy.ml
+++ b/lib/fusion_core/fusion_policy.ml
@@ -14,7 +14,6 @@ type panel_group =
   ; system_prompt : string  (** 그룹 패널 모델 system prompt (config 필수) *)
   ; web_tools : bool  (** 그룹에 web_search/web_fetch 주입 여부 *)
   ; max_output_tokens : int option  (** 그룹 모델당 출력 토큰 예산 override *)
-  ; timeout_s : float  (** 그룹 패널 호출 구조적 타임아웃 (초) *)
   }
 [@@deriving show, eq]
 

--- a/lib/fusion_core/fusion_policy.mli
+++ b/lib/fusion_core/fusion_policy.mli
@@ -19,7 +19,6 @@ type panel_group =
   ; web_tools : bool  (** 그룹에 web_search/web_fetch 주입 여부. *)
   ; max_output_tokens : int option
       (** 그룹 모델당 출력 토큰 예산 override. [None]이면 Runtime_agent 기본값. *)
-  ; timeout_s : float  (** 그룹 패널 호출 구조적 타임아웃 (초). *)
   }
 [@@deriving show, eq]
 

--- a/test/fusion_core/test_fusion.ml
+++ b/test/fusion_core/test_fusion.ml
@@ -19,7 +19,6 @@ let base_group : Fusion_policy.panel_group =
   ; system_prompt = "panel"
   ; web_tools = false
   ; max_output_tokens = None
-  ; timeout_s = 300.0
   }
 
 (* RFC-0280: presets는 [Validated_preset.t]라 private — of_preset로만 생성. 테스트
@@ -206,7 +205,6 @@ default_preset = "p"
 [fusion.presets.p]
 web_tools = true
 max_output_tokens_per_panel = 2048
-panel_timeout_s = 123.0
 panel = ["a", "b", "c"]
 judge = "j"
 panel_system_prompt = "answer independently"
@@ -230,7 +228,6 @@ panel = ["a", "b", "c"]
 panel_system_prompt = "answer independently"
 web_tools = true
 max_output_tokens_per_panel = 2048
-panel_timeout_s = 123.0
 |}
 
 let test_config_panels_golden () =
@@ -267,7 +264,6 @@ web_tools = false
 panel = ["careful1"]
 panel_system_prompt = "deliberate"
 web_tools = true
-panel_timeout_s = 180.0
 |}
 
 let test_config_heterogeneous () =
@@ -285,9 +281,8 @@ let test_config_heterogeneous () =
           Alcotest.(check bool) "g2 web" true g2.Fusion_policy.web_tools;
           Alcotest.(check (option int)) "g1 default max output" None
             g1.Fusion_policy.max_output_tokens;
-          Alcotest.(check (float 0.001)) "g2 timeout" 180.0 g2.Fusion_policy.timeout_s;
-          Alcotest.(check (float 0.001)) "g1 default timeout"
-            Fusion_policy.default_timeout_s g1.Fusion_policy.timeout_s
+          Alcotest.(check (option int)) "g2 default max output" None
+            g2.Fusion_policy.max_output_tokens
         | _ -> Alcotest.fail "expected two groups")
      | _ -> Alcotest.fail "expected exactly one preset")
   | Error es ->
@@ -838,7 +833,6 @@ panel = [
 judge = "deepseek.deepseek-v4-pro"
 panel_system_prompt = "answer independently"
 judge_system_prompt = "synthesize the panel"
-panel_timeout_s = 300.0
 judge_timeout_s = 300.0
 |}
 
@@ -1078,7 +1072,7 @@ let test_config_no_judges () =
      | _ -> Alcotest.fail "expected one preset")
   | Error _ -> Alcotest.fail "golden must parse Ok"
 
-(* --- execution-axis judge argument derivations. --- *)
+(* --- execution-axis judge web-tool derivation. --- *)
 
 let g_web4 : Fusion_policy.panel_group =
   { Fusion_policy.models = [ "a" ]
@@ -1086,7 +1080,6 @@ let g_web4 : Fusion_policy.panel_group =
   ; system_prompt = "p"
   ; web_tools = true
   ; max_output_tokens = None
-  ; timeout_s = 123.0
   }
 
 let test_judge_args_single_group_identity () =
@@ -1099,6 +1092,11 @@ let test_judge_args_single_group_identity () =
   Alcotest.(check bool) "judge web = req||group, req=true overrides" true
     (Fusion_policy.judge_web_tools_of ~req_web_tools:true
        [ { g_web4 with Fusion_policy.web_tools = false } ])
+
+let test_judge_args_multi_group () =
+  let g_no_web = { g_web4 with Fusion_policy.web_tools = false } in
+  Alcotest.(check bool) "any group may request judge web tools" true
+    (Fusion_policy.judge_web_tools_of ~req_web_tools:false [ g_no_web; g_web4 ])
 
 (* --- judge LLM-facing JSON parse (RFC-0252 §7.2) --- *)
 
@@ -1693,6 +1691,7 @@ let () =
     ; ( "judge_args"
       , [ Alcotest.test_case "single_group_identity" `Quick
             test_judge_args_single_group_identity
+        ; Alcotest.test_case "multi_group" `Quick test_judge_args_multi_group
         ] )
     ; ( "judge_parse"
       , [ Alcotest.test_case "valid" `Quick test_judge_valid

--- a/test/test_fusion_wake.ml
+++ b/test/test_fusion_wake.ml
@@ -186,7 +186,6 @@ let fusion_tool_policy () : Fusion_policy.t =
     ; system_prompt = "panel system prompt"
     ; web_tools = false
     ; max_output_tokens = None
-    ; timeout_s = Fusion_policy.default_timeout_s
     }
   in
   let preset : Fusion_policy.preset =


### PR DESCRIPTION
## Summary

- delete `panel_timeout_s` from Fusion preset and panel-group contracts
- remove panel timeout serialization and dashboard editor/view projections
- remove shipped runtime values and RFC wording
- delete timeout-specific tests instead of preserving a retired compatibility contract

## Boundary

Panel configuration now describes model, prompt, tools, and output shape only. It no longer carries execution-liveness authority.

## Verification

- exact C2 patch-id preserved while rebasing onto the refreshed C1 head
- repository search across production config, Fusion core, dashboard, tests, and selected RFCs finds no `panel_timeout_s`, `panel_outer_timeout_of`, or panel-group `.timeout_s` residue
- `ocamlformat --check`: pass
- `git diff --check`: pass
- per-PR delta: 14 files, 68 changed lines
- cumulative C6 stack focused Dune build: pass
- cumulative focused tests: Fusion core 74, config JSON 1, Fusion wake 14, TOML editor 4, Orchestrator 25, dashboard 66

Stacked on #24778 (`ae2c846569`).
