### PR TITLE
refactor(fusion): delete first-judge deadline schema

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -1110,7 +1110,6 @@ through an EVIDENCE lens: weigh each claim by how well it is supported, flag \
 unsupported assertions, and prefer conclusions grounded in verifiable reasoning. \
 Respond with ONLY the requested JSON object, no prose and no code fences.
 """
-timeout_s = 300.0
 
 [[fusion.presets.quorum.judges]]
 model = "ollama_cloud.ollama-cloud-devstral-small-2-24b"
@@ -1121,7 +1120,6 @@ through a COVERAGE lens: map what each answer addresses and omits, surface blind
 spots and unique insights, and prefer the most complete resolution. \
 Respond with ONLY the requested JSON object, no prose and no code fences.
 """
-timeout_s = 300.0
 
 # ── Staged-JoJ-capable preset (RFC-0283 staged_judge_of_judges) ──────────────
 # staged_judge_of_judges는 judge 수가 [fusion].staged_judge_group_size(=3)의
@@ -1136,9 +1134,7 @@ timeout_s = 300.0
 # 심판 런타임은 전부 supports-structured-output=true 선언 모델만 쓴다.
 # 비용/지연: LLM 호출 12회(panel 3 + 1차 심판 6 + stage meta 2 + 최종 meta 1).
 # 실행은 4단 순차 파이프라인(panel → 1차 심판 병렬 → stage meta 병렬 → 최종
-# meta, fusion_orchestrator run_staged_judge_of_judges)이라 각 단의
-# timeout(300s)이 누적된다 — 동시성 캡이 각 단을 한 웨이브로 소화할 때 최악
-# ~20분. 빠른 종합이 필요하면 단이 짧은 quorum/judge_of_judges 계열을 쓴다.
+# meta, fusion_orchestrator run_staged_judge_of_judges)이며 각 단의 경과 시간은 관측된다.
 # 키퍼 사용: masc_fusion preset="council" topology="staged_judge_of_judges"
 # (judge_of_judges topology도 동일 preset으로 사용 가능 — 6 lens 병렬 후 meta).
 [fusion.presets.council]
@@ -1174,7 +1170,6 @@ through an EVIDENCE lens: weigh each claim by how well it is supported, flag \
 unsupported assertions, and prefer conclusions grounded in verifiable reasoning. \
 Respond with ONLY the requested JSON object, no prose and no code fences.
 """
-timeout_s = 300.0
 
 [[fusion.presets.council.judges]]
 model = "ollama_cloud.ollama-cloud-devstral-small-2-24b"
@@ -1185,7 +1180,6 @@ through a COVERAGE lens: map what each answer addresses and omits, surface blind
 spots and unique insights, and prefer the most complete resolution. \
 Respond with ONLY the requested JSON object, no prose and no code fences.
 """
-timeout_s = 300.0
 
 [[fusion.presets.council.judges]]
 model = "ollama_cloud.ollama-cloud-ministral-3-14b"
@@ -1196,7 +1190,6 @@ through a RISK lens: identify failure modes, hidden assumptions, and worst-case 
 consequences each answer implies, and prefer the resolution that degrades most \
 gracefully. Respond with ONLY the requested JSON object, no prose and no code fences.
 """
-timeout_s = 300.0
 
 [[fusion.presets.council.judges]]
 model = "ollama_cloud.ollama-cloud-devstral-2-123b"
@@ -1207,7 +1200,6 @@ through a FEASIBILITY lens: judge how implementable each proposal is with the \
 stated constraints and resources, and prefer the most actionable resolution. \
 Respond with ONLY the requested JSON object, no prose and no code fences.
 """
-timeout_s = 300.0
 
 [[fusion.presets.council.judges]]
 model = "ollama_cloud.ollama-cloud-devstral-small-2-24b"
@@ -1218,7 +1210,6 @@ through a SIMPLICITY lens: prefer the resolution with the fewest moving parts \
 that still answers the question fully, and flag accidental complexity. \
 Respond with ONLY the requested JSON object, no prose and no code fences.
 """
-timeout_s = 300.0
 
 [[fusion.presets.council.judges]]
 model = "ollama_cloud.ollama-cloud-ministral-3-14b"
@@ -1229,4 +1220,3 @@ through an ADVERSARIAL lens: actively try to refute each answer's key claims, \
 keep only what survives refutation, and prefer the most defensible resolution. \
 Respond with ONLY the requested JSON object, no prose and no code fences.
 """
-timeout_s = 300.0

--- a/dashboard/src/lib/fusion-meta.test.ts
+++ b/dashboard/src/lib/fusion-meta.test.ts
@@ -332,8 +332,8 @@ describe('normalizeFusionJudgeNodes', () => {
         role: 'meta',
         identity: 'o1',
         status: 'failed',
-        error: 'judge budget exceeded',
-        failure_code: 'budget_exceeded',
+        error: 'timeout',
+        failure_code: 'timeout',
         elapsed_s: 12.5,
         timed_out: true,
         input_tokens: 800,
@@ -343,8 +343,8 @@ describe('normalizeFusionJudgeNodes', () => {
     expect(node).toMatchObject({
       role: 'meta',
       failed: true,
-      error: 'judge budget exceeded',
-      failureCode: 'budget_exceeded',
+      error: 'timeout',
+      failureCode: 'timeout',
       elapsedS: 12.5,
       timedOut: true,
     })

--- a/docs/rfc/RFC-0306-fusion-settings-typed-editor.md
+++ b/docs/rfc/RFC-0306-fusion-settings-typed-editor.md
@@ -189,7 +189,7 @@ no longer enforces.
 - Creating/deleting whole presets from the UI (edit existing presets only); preset
   CRUD is a possible follow-up, see §7.2.
 - Per-call `timeout_s` range validation beyond what `of_preset` already checks
-  (`Bad_meta_timeout`, `Bad_judge_wave_budget`, `Bad_adaptive_factor`).
+  (`Bad_meta_timeout`, `Bad_adaptive_factor`).
 
 ## 5. Implementation plan
 

--- a/lib/fusion_core/fusion_config.ml
+++ b/lib/fusion_core/fusion_config.ml
@@ -20,9 +20,6 @@ type config_error =
       (** (preset 이름, min_answered): policy 허용 범위 밖 *)
   | Invalid_meta_timeout of string * float
       (** (preset 이름, meta_timeout_s): 양수 유한수가 아님. *)
-  | Invalid_judge_wave_budget of string * float
-      (** (preset 이름, judge_wave_budget_s): 0 미만이거나 최장 1차 심판 타임아웃/
-          meta_timeout_s보다 작음. *)
   | Invalid_adaptive_timeout_factor of string * float
       (** (preset 이름, adaptive_timeout_factor): 1.0 미만. *)
   | Toml_type_error of string
@@ -54,7 +51,7 @@ let parse_group (tbl : Otoml.t) : Fusion_policy.panel_group =
   }
 
 (* JOJ 1차 심판 한 명 파싱 (RFC-0283). [[fusion.presets.NAME.judges]] sub-table의
-   키 model/label/system_prompt/web_tools/timeout_s를 읽는다. sub-table
+   키 model/label/system_prompt/web_tools를 읽는다. sub-table
    이름(judges)이 scope를 주므로 키는 비-접두. parse_group과 동형. 누락 system_prompt는
    ""로 읽혀 Validated_preset 검증에서 Judge_panel_prompt_missing으로 fail-fast된다. *)
 let parse_judge_spec (tbl : Otoml.t) : Fusion_policy.judge_spec =
@@ -64,11 +61,6 @@ let parse_judge_spec (tbl : Otoml.t) : Fusion_policy.judge_spec =
       Otoml.find_or ~default:"" tbl Otoml.get_string [ "system_prompt" ]
   ; jweb_tools = Otoml.find_or ~default:false tbl Otoml.get_boolean [ "web_tools" ]
   ; jmax_output_tokens = Otoml.find_opt tbl Otoml.get_integer [ "max_output_tokens" ]
-  ; jtimeout_s =
-      Otoml.find_or ~default:Fusion_policy.default_timeout_s tbl Otoml.get_float
-        [ "timeout_s" ]
-  ; jmax_timeout_s =
-      Otoml.find_opt tbl Otoml.get_float [ "max_timeout_s" ]
   }
 
 let parse_min_answered _name tbl =
@@ -104,11 +96,6 @@ let finish_preset name tbl (panels : Fusion_policy.panel_group list)
     | Some entries -> List.map parse_judge_spec entries
     | None -> []
   in
-  (* 1차 심판 wave 전체 wall-clock 예산. 누락 시 무제한(legacy byte-identical). *)
-  let judge_wave_budget_s =
-    Otoml.find_or ~default:Float.max_float tbl Otoml.get_float
-      [ "judge_wave_budget_s" ]
-  in
   let adaptive_timeout_factor =
     Otoml.find_or ~default:1.0 tbl Otoml.get_float [ "adaptive_timeout_factor" ]
   in
@@ -128,7 +115,6 @@ let finish_preset name tbl (panels : Fusion_policy.panel_group list)
       ; judges
       ; meta_timeout_s
       ; min_answered
-      ; judge_wave_budget_s
       ; adaptive_timeout_factor
       ; fallback_judge_model
       }
@@ -158,8 +144,6 @@ let finish_preset name tbl (panels : Fusion_policy.panel_group list)
            Invalid_min_answered (name, v)
          | Fusion_policy.Validated_preset.Bad_meta_timeout v ->
            Invalid_meta_timeout (name, v)
-         | Fusion_policy.Validated_preset.Bad_judge_wave_budget v ->
-           Invalid_judge_wave_budget (name, v)
          | Fusion_policy.Validated_preset.Bad_adaptive_factor v ->
            Invalid_adaptive_timeout_factor (name, v)))
 

--- a/lib/fusion_core/fusion_config.mli
+++ b/lib/fusion_core/fusion_config.mli
@@ -42,9 +42,6 @@ type config_error =
           모델 총합) 밖. full-panel quorum([총합])도 명시적으로 설정할 수 있다. *)
   | Invalid_meta_timeout of string * float
       (** (preset 이름, meta_timeout_s) — 양수 유한수가 아님. *)
-  | Invalid_judge_wave_budget of string * float
-      (** (preset 이름, judge_wave_budget_s) — 0 미만이거나 최장 1차 심판 타임아웃/
-          [meta_timeout_s]보다 작음. *)
   | Invalid_adaptive_timeout_factor of string * float
       (** (preset 이름, adaptive_timeout_factor) — 1.0 미만. *)
   | Toml_type_error of string  (** 필드 타입 불일치 (Otoml.Type_error) *)

--- a/lib/fusion_core/fusion_config_json.ml
+++ b/lib/fusion_core/fusion_config_json.ml
@@ -11,10 +11,6 @@ let opt_int : int option -> Yojson.Safe.t = function
   | None -> `Null
   | Some n -> `Int n
 
-let opt_float : float option -> Yojson.Safe.t = function
-  | None -> `Null
-  | Some f -> `Float f
-
 let opt_string : string option -> Yojson.Safe.t = function
   | None -> `Null
   | Some s -> `String s
@@ -38,8 +34,6 @@ let judge_spec_to_yojson (j : Fusion_policy.judge_spec) : Yojson.Safe.t =
     ; ("system_prompt", `String j.Fusion_policy.jsystem_prompt)
     ; ("web_tools", `Bool j.Fusion_policy.jweb_tools)
     ; ("max_output_tokens", opt_int j.Fusion_policy.jmax_output_tokens)
-    ; ("timeout_s", `Float j.Fusion_policy.jtimeout_s)
-    ; ("max_timeout_s", opt_float j.Fusion_policy.jmax_timeout_s)
     ]
 
 let preset_to_yojson (p : Fusion_policy.preset) : Yojson.Safe.t =
@@ -53,7 +47,6 @@ let preset_to_yojson (p : Fusion_policy.preset) : Yojson.Safe.t =
     ; ("meta_timeout_s", `Float p.Fusion_policy.meta_timeout_s)
     ; ("judges", `List (List.map judge_spec_to_yojson p.Fusion_policy.judges))
     ; ("min_answered", `Int p.Fusion_policy.min_answered)
-    ; ("judge_wave_budget_s", `Float p.Fusion_policy.judge_wave_budget_s)
     ; ( "adaptive_timeout_factor"
       , `Float p.Fusion_policy.adaptive_timeout_factor )
     ; ("fallback_judge_model", opt_string p.Fusion_policy.fallback_judge_model)

--- a/lib/fusion_core/fusion_policy.ml
+++ b/lib/fusion_core/fusion_policy.ml
@@ -26,9 +26,6 @@ type judge_spec =
   ; jsystem_prompt : string  (** 이 1차 심판의 lens (config 필수) *)
   ; jweb_tools : bool  (** web_search/web_fetch 주입 여부 *)
   ; jmax_output_tokens : int option  (** 출력 토큰 예산 override *)
-  ; jtimeout_s : float  (** 호출 구조적 타임아웃 (초) *)
-  ; jmax_timeout_s : float option
-      (** Legacy observed value. No runtime path extends a Provider timeout. *)
   }
 [@@deriving show, eq]
 
@@ -47,8 +44,6 @@ type preset =
           JOJ 위상은 런타임에 >= 2 를 요구한다. *)
   ; min_answered : int
       (** 심판 실행에 필요한 응답 패널 최소 수 (런타임 quorum). 기본 1. *)
-  ; judge_wave_budget_s : float
-      (** Legacy observed value. It never gates or skips Provider work. *)
   ; adaptive_timeout_factor : float
       (** Legacy observed value. It never extends Provider work. *)
   ; fallback_judge_model : string option
@@ -247,9 +242,6 @@ module Validated_preset = struct
         (** [min_answered]가 패널 모델 총합을 초과. *)
     | Bad_meta_timeout of float
         (** [meta_timeout_s]가 양수 유한수가 아님. *)
-    | Bad_judge_wave_budget of float
-        (** [judge_wave_budget_s]가 0 미만이거나, 양수인데 최장 1차 심판 타임아웃 또는
-            [meta_timeout_s]보다 작음. *)
     | Bad_adaptive_factor of float
         (** [adaptive_timeout_factor]가 1.0 미만. *)
 
@@ -298,19 +290,6 @@ module Validated_preset = struct
                   then Error (Bad_meta_timeout p.meta_timeout_s)
                   else if p.adaptive_timeout_factor < 1.0
                   then Error (Bad_adaptive_factor p.adaptive_timeout_factor)
-                  else if p.judge_wave_budget_s < 0.0
-                  then Error (Bad_judge_wave_budget p.judge_wave_budget_s)
-                  else if
-                    p.judge_wave_budget_s > 0.0
-                    && Float.is_finite p.judge_wave_budget_s
-                    && (let longest_judge =
-                          List.fold_left
-                            (fun acc (j : judge_spec) -> Float.max acc j.jtimeout_s)
-                            0.0 p.judges
-                        in
-                        p.judge_wave_budget_s < longest_judge
-                        || p.judge_wave_budget_s < p.meta_timeout_s)
-                  then Error (Bad_judge_wave_budget p.judge_wave_budget_s)
                   else Ok p)))
 
   let preset (t : t) : preset = t

--- a/lib/fusion_core/fusion_policy.mli
+++ b/lib/fusion_core/fusion_policy.mli
@@ -32,9 +32,6 @@ type judge_spec =
   ; jweb_tools : bool  (** web_search/web_fetch 주입 여부. *)
   ; jmax_output_tokens : int option
       (** 출력 토큰 예산 override. [None]이면 Runtime_agent 기본값. *)
-  ; jtimeout_s : float  (** 호출 구조적 타임아웃 (초). *)
-  ; jmax_timeout_s : float option
-      (** Legacy observed value; no runtime path extends a Provider timeout. *)
   }
 [@@deriving show, eq]
 
@@ -63,8 +60,6 @@ type preset =
           [judge = Error]로 완료한다 (빈 패널 종합 날조 방지).
           허용 범위는 [1]부터 패널 모델 총합까지; full-panel quorum([총합])도
           명시적으로 설정할 수 있다. *)
-  ; judge_wave_budget_s : float
-      (** Legacy observed value; it never gates or skips Provider work. *)
   ; adaptive_timeout_factor : float
       (** Legacy observed value; it never extends Provider work. *)
   ; fallback_judge_model : string option
@@ -196,9 +191,6 @@ module Validated_preset : sig
         (** [min_answered]가 패널 모델 총합을 초과. *)
     | Bad_meta_timeout of float
         (** [meta_timeout_s]가 양수 유한수가 아님. *)
-    | Bad_judge_wave_budget of float
-        (** [judge_wave_budget_s]가 0 미만이거나, 양수 유한인데 최장 1차 심판
-            타임아웃 또는 [meta_timeout_s]보다 작음. *)
     | Bad_adaptive_factor of float
         (** [adaptive_timeout_factor]가 1.0 미만. *)
 

--- a/lib/fusion_core/fusion_types.ml
+++ b/lib/fusion_core/fusion_types.ml
@@ -197,7 +197,7 @@ type judge_node =
 [@@deriving yojson, show, eq]
 
 (* 심판(judge) 실패의 닫힌 합. {!panel_failure}와 동형이되 심판 도메인 전용 사유
-   ([Empty_result]/[Build_error]/[Parse_error]/[Budget_exceeded])를 추가한다.
+   ([Empty_result]/[Build_error]/[Parse_error])를 추가한다.
    [Fusion_judge] 계열이 {!Agent_sdk.Error}의 [Timeout] variant를 match에서 잡아 typed로
    반환하므로, 호출자는 string substring 분류 없이 exhaustive match로 분류한다
    (CLAUDE.md §string-classifier 안티패턴 회피). [panel_failure]를 공유하지 않는 이유는
@@ -209,16 +209,11 @@ type judge_failure =
   | Empty_result
   | Build_error of string
   | Parse_error of string
-  | Budget_exceeded of string
   | Panels_unavailable of skip_reason
   | Internal_error of string
 [@@deriving yojson, show, eq]
 
 let judge_failure_is_timeout = function Timeout -> true | _ -> false
-
-let judge_failure_is_timeout_or_budget = function
-  | Timeout | Budget_exceeded _ -> true
-  | _ -> false
 
 let judge_failure_text = function
   | Timeout -> "timeout"
@@ -227,7 +222,6 @@ let judge_failure_text = function
   | Empty_result -> "judge: empty result"
   | Build_error detail -> detail
   | Parse_error detail -> detail
-  | Budget_exceeded detail -> detail
   | Panels_unavailable reason -> render_skip_reason reason
   | Internal_error detail -> detail
 
@@ -238,7 +232,6 @@ let judge_failure_tag = function
   | Empty_result -> "empty_result"
   | Build_error _ -> "build_error"
   | Parse_error _ -> "parse_error"
-  | Budget_exceeded _ -> "budget_exceeded"
   | Panels_unavailable _ -> "panels_unavailable"
   | Internal_error _ -> "internal_error"
 

--- a/lib/fusion_core/fusion_types.mli
+++ b/lib/fusion_core/fusion_types.mli
@@ -205,11 +205,9 @@ type judge_role =
 [@@deriving yojson, show, eq]
 
 (** 심판(judge) 한 명이 실패하는 방식. {!panel_failure}와 동형인 닫힌 합이되, 심판
-    도메인에만 존재하는 사유([Empty_result]/[Build_error]/[Parse_error]/[Budget_exceeded])
+    도메인에만 존재하는 사유([Empty_result]/[Build_error]/[Parse_error])
     를 추가로 담는다. [panel_failure]를 literal하게 공유하지 않는 이유: 판(panel) 전용인
-    [Invalid_max_output_tokens]가 심판에서 dead variant가 되고, wave-budget SKIP을
-    [Provider_error "...skipped..."] 문자열에 숨기면 orchestrator의 fallback 분류가
-    substring match로 잔존하기 때문이다(CLAUDE.md §string-classifier 안티패턴).
+    [Invalid_max_output_tokens]가 심판에서 dead variant가 되기 때문이다.
 
     근원에서 typed로 propagate한다: [Fusion_judge.run] 계열이 {!Agent_sdk.Error}의
     [Timeout] variant를 match에서 잡아 [Timeout]으로, provider/transport 에러를
@@ -222,7 +220,6 @@ type judge_failure =
   | Empty_result  (** Async_agent.all 이 빈 결과를 반환 *)
   | Build_error of string  (** Fusion_oas.build_agent 실패 *)
   | Parse_error of string  (** Fusion_judge_parse.of_string 파싱 실패 *)
-  | Budget_exceeded of string  (** wave budget 초과로 심판 실행 전 SKIP *)
   | Panels_unavailable of skip_reason
       (** 패널 정족수 미달로 심판이 실행조차 되지 않음. 2026-07-01 사고에서 이
           사유가 [Internal_error] 문자열로 압축돼 모든 keeper-가시 표면이 패널
@@ -235,11 +232,6 @@ type judge_failure =
 (** [Timeout] 변형인가. {!judge_error_node}의 [timed_out] 파생처럼, 분류는 variant 자체로
     충분하므로 별도 bool 필드를 두지 않는다. *)
 val judge_failure_is_timeout : judge_failure -> bool
-
-(** [Timeout] 또는 [Budget_exceeded] 인가. orchestrator의 fallback-judge 트리거 조건:
-    1차 심판 전원이 타임아웃/예산-skip이면 fallback을 시도한다. exhaustive match로
-    string classifier([is_timeout_or_budget_error])를 대체한다. *)
-val judge_failure_is_timeout_or_budget : judge_failure -> bool
 
 (** sink/로그용 사람-가독 문자열. {!Fusion_oas.panel_failure_text}와 대칭. *)
 val judge_failure_text : judge_failure -> string

--- a/test/fusion_core/test_fusion.ml
+++ b/test/fusion_core/test_fusion.ml
@@ -48,7 +48,6 @@ let base_policy : Fusion_policy.t =
           ; meta_timeout_s = 300.0
           ; judges = []
           ; min_answered = Fusion_policy.default_min_answered
-          ; judge_wave_budget_s = Float.max_float
           ; adaptive_timeout_factor = 1.0
           ; fallback_judge_model = None
           }
@@ -754,8 +753,6 @@ let test_config_two_judges_not_staged_eligible () =
     ; jsystem_prompt = label ^ " lens"
     ; jweb_tools = false
     ; jmax_output_tokens = None
-    ; jtimeout_s = 300.0
-    ; jmax_timeout_s = None
     }
   in
   let judges =
@@ -861,7 +858,7 @@ let test_config_disabled_with_preset () =
    그 변형이 발화하는지 확인한다. private 타입이라 외부는 of_preset로만 t를 만든다. *)
 let mk_preset ?(panels = [ base_group ]) ?(judge = "j") ?(judge_prompt = "synthesize")
     ?(judges = []) ?(min_answered = Fusion_policy.default_min_answered)
-    ?(meta_timeout_s = 300.0) ?(judge_wave_budget_s = Float.max_float)
+    ?(meta_timeout_s = 300.0)
     ?(adaptive_timeout_factor = 1.0) ?(fallback_judge_model = None)
     (name : string) : Fusion_policy.preset =
   { Fusion_policy.name
@@ -873,7 +870,6 @@ let mk_preset ?(panels = [ base_group ]) ?(judge = "j") ?(judge_prompt = "synthe
   ; meta_timeout_s
   ; judges
   ; min_answered
-  ; judge_wave_budget_s
   ; adaptive_timeout_factor
   ; fallback_judge_model
   }
@@ -926,8 +922,6 @@ let base_judge : Fusion_policy.judge_spec =
   ; jsystem_prompt = "lens"
   ; jweb_tools = false
   ; jmax_output_tokens = None
-  ; jtimeout_s = 300.0
-  ; jmax_timeout_s = None
   }
 
 (* judges=[]면 (simple/refine/conditional preset) 기존과 동일하게 유효 = byte-identity. *)
@@ -1004,7 +998,7 @@ let test_staged_judge_groups_bad_size () =
 (* --- JOJ 1차 심판 TOML 파싱 (RFC-0283). parse_judge_spec + finish_preset의
        [[...judges]] array-of-tables 리더를 end-to-end로 검증한다. 위 of_preset
        검증 테스트는 OCaml record를 직접 구성해 config 레이어를 우회하므로, TOML 키
-       이름(model/label/system_prompt/web_tools/timeout_s)과 getter
+       이름(model/label/system_prompt/web_tools/max_output_tokens)과 getter
        매핑은 이 테스트만 커버한다 — 잘못된 키/getter는 여기서만 잡힌다. panel
        sub-table에는 동형 golden(test_config_panels_golden 등)이 있으나 judge에는
        없었다. --- *)
@@ -1025,7 +1019,6 @@ label = "strict"
 system_prompt = "lens A"
 web_tools = true
 max_output_tokens = 1536
-timeout_s = 222.0
 [[fusion.presets.joj.judges]]
 model = "judge-b"
 label = "lenient"
@@ -1039,22 +1032,19 @@ let test_config_judges_parse () =
      | [ vp ] ->
        (match (raw vp).Fusion_policy.judges with
         | [ ja; jb ] ->
-          (* judge-a: 6개 키를 모두 distinct 값으로 채워 키↔getter 매핑을 핀한다. *)
+          (* judge-a: 5개 키를 모두 distinct 값으로 채워 키↔getter 매핑을 핀한다. *)
           Alcotest.(check string) "ja model" "judge-a" ja.Fusion_policy.jmodel;
           Alcotest.(check string) "ja label" "strict" ja.Fusion_policy.jlabel;
           Alcotest.(check string) "ja prompt" "lens A" ja.Fusion_policy.jsystem_prompt;
           Alcotest.(check bool) "ja web" true ja.Fusion_policy.jweb_tools;
           Alcotest.(check (option int)) "ja max output" (Some 1536)
             ja.Fusion_policy.jmax_output_tokens;
-          Alcotest.(check (float 0.001)) "ja timeout" 222.0 ja.Fusion_policy.jtimeout_s;
-          (* judge-b: 누락 키는 find_or default 경로 (web=false / timeout=default). *)
+          (* judge-b: 누락 키는 find_or default 경로 (web=false). *)
           Alcotest.(check string) "jb model" "judge-b" jb.Fusion_policy.jmodel;
           Alcotest.(check string) "jb prompt" "lens B" jb.Fusion_policy.jsystem_prompt;
           Alcotest.(check bool) "jb web default" false jb.Fusion_policy.jweb_tools;
           Alcotest.(check (option int)) "jb max output default" None
-            jb.Fusion_policy.jmax_output_tokens;
-          Alcotest.(check (float 0.001)) "jb timeout default"
-            Fusion_policy.default_timeout_s jb.Fusion_policy.jtimeout_s
+            jb.Fusion_policy.jmax_output_tokens
         | _ -> Alcotest.fail "expected exactly two parsed judges")
      | _ -> Alcotest.fail "expected exactly one preset")
   | Error es ->
@@ -1365,9 +1355,7 @@ let test_panels_unavailable_failure () =
   Alcotest.(check string) "failure text = rendered skip reason"
     "fusion aborted: none of 3 panels returned an answer"
     (judge_failure_text failure);
-  Alcotest.(check bool) "not a timeout" false (judge_failure_is_timeout failure);
-  Alcotest.(check bool) "not timeout-or-budget (no fallback judge trigger)" false
-    (judge_failure_is_timeout_or_budget failure)
+  Alcotest.(check bool) "not a timeout" false (judge_failure_is_timeout failure)
 
 (* min_answered must be in the policy range 1..total panels (inclusive).
    base_group has 3 models, so 0 and 4 are rejected; full-panel quorum (3) is allowed. *)
@@ -1407,7 +1395,6 @@ judge = "meta"
 judge_system_prompt = "reconcile"
 judge_timeout_s = 120.0
 meta_timeout_s = 90.0
-judge_wave_budget_s = 500.0
 adaptive_timeout_factor = 2.0
 fallback_judge_model = "fallback-model"
 [[fusion.presets.adaptive.panels]]
@@ -1416,12 +1403,9 @@ panel_system_prompt = "answer"
 [[fusion.presets.adaptive.judges]]
 model = "judge-a"
 system_prompt = "lens A"
-timeout_s = 100.0
-max_timeout_s = 180.0
 [[fusion.presets.adaptive.judges]]
 model = "judge-b"
 system_prompt = "lens B"
-timeout_s = 110.0
 |}
 
 let test_config_adaptive_timeout_parse () =
@@ -1432,20 +1416,12 @@ let test_config_adaptive_timeout_parse () =
        let preset = raw vp in
        Alcotest.(check (float 0.001)) "meta_timeout_s" 90.0
          preset.Fusion_policy.meta_timeout_s;
-       Alcotest.(check (float 0.001)) "judge_wave_budget_s" 500.0
-         preset.Fusion_policy.judge_wave_budget_s;
        Alcotest.(check (float 0.001)) "adaptive_timeout_factor" 2.0
          preset.Fusion_policy.adaptive_timeout_factor;
        Alcotest.(check (option string)) "fallback_judge_model"
          (Some "fallback-model")
          preset.Fusion_policy.fallback_judge_model;
-       (match preset.Fusion_policy.judges with
-        | [ ja; _ ] ->
-          Alcotest.(check (float 0.001)) "ja timeout" 100.0 ja.Fusion_policy.jtimeout_s;
-          Alcotest.(check (option (float 0.001))) "ja max_timeout_s"
-            (Some 180.0)
-            ja.Fusion_policy.jmax_timeout_s
-        | _ -> Alcotest.fail "expected two judges")
+       Alcotest.(check int) "two judges" 2 (List.length preset.Fusion_policy.judges)
      | _ -> Alcotest.fail "expected exactly one preset")
   | Error es ->
     Alcotest.failf "expected Ok, got errors: %s"
@@ -1460,9 +1436,6 @@ let test_config_adaptive_timeout_defaults () =
        Alcotest.(check (float 0.001)) "meta_timeout_s defaults to judge_timeout_s"
          preset.Fusion_policy.judge_timeout_s
          preset.Fusion_policy.meta_timeout_s;
-       Alcotest.(check bool) "judge_wave_budget_s defaults to max_float"
-         true
-         (preset.Fusion_policy.judge_wave_budget_s = Float.max_float);
        Alcotest.(check (float 0.001)) "adaptive_timeout_factor defaults to 1.0"
          1.0
          preset.Fusion_policy.adaptive_timeout_factor;
@@ -1516,32 +1489,6 @@ adaptive_timeout_factor = 0.5
          es)
   | Ok _ -> Alcotest.fail "expected Error Invalid_adaptive_timeout_factor"
 
-let test_config_invalid_judge_wave_budget () =
-  let s =
-    {|
-[fusion]
-enabled = true
-default_preset = "p"
-[fusion.presets.p]
-panel = ["a"]
-judge = "j"
-panel_system_prompt = "x"
-judge_system_prompt = "y"
-judge_wave_budget_s = 50.0
-[[fusion.presets.p.judges]]
-model = "judge-a"
-system_prompt = "lens"
-timeout_s = 100.0
-|}
-  in
-  match Fusion_config.of_toml (parse s) with
-  | Error es ->
-    Alcotest.(check bool) "Invalid_judge_wave_budget present" true
-      (List.exists
-         (function Fusion_config.Invalid_judge_wave_budget _ -> true | _ -> false)
-         es)
-  | Ok _ -> Alcotest.fail "expected Error Invalid_judge_wave_budget"
-
 let test_judge_error_node_timed_out () =
   let timeout_node =
     Fusion_types.Judge_failed
@@ -1551,11 +1498,10 @@ let test_judge_error_node_timed_out () =
       ; elapsed_s = Some 5.0
       }
   in
-  let budget_node =
+  let unavailable_node =
     Fusion_types.Judge_failed
       { Fusion_types.failed_role = First "j"
-      ; failure =
-          Fusion_types.Budget_exceeded "judge j skipped: would exceed wave budget"
+      ; failure = Fusion_types.Provider_error "provider unavailable"
       ; usage = Fusion_types.zero_usage
       ; elapsed_s = None
       }
@@ -1564,14 +1510,14 @@ let test_judge_error_node_timed_out () =
     ( Fusion_types.judge_outcome_of_yojson
         (Fusion_types.judge_outcome_to_yojson timeout_node)
     , Fusion_types.judge_outcome_of_yojson
-        (Fusion_types.judge_outcome_to_yojson budget_node) )
+        (Fusion_types.judge_outcome_to_yojson unavailable_node) )
   with
   | Ok (Judge_failed n1), Ok (Judge_failed n2) ->
     Alcotest.(check bool) "timeout node roundtrips timed_out" true
       (Fusion_types.judge_failure_is_timeout n1.failure);
     Alcotest.(check (option (float 0.001))) "timeout node roundtrips elapsed_s"
       (Some 5.0) n1.elapsed_s;
-    Alcotest.(check bool) "budget node roundtrips timed_out" false
+    Alcotest.(check bool) "provider node roundtrips timed_out" false
       (Fusion_types.judge_failure_is_timeout n2.failure);
     Alcotest.(check (option (float 0.001))) "unavailable elapsed roundtrips"
       None n2.elapsed_s
@@ -1591,14 +1537,6 @@ let test_validated_bad_adaptive_factor () =
   with
   | Error (Fusion_policy.Validated_preset.Bad_adaptive_factor 0.5) -> ()
   | _ -> Alcotest.fail "expected Bad_adaptive_factor 0.5"
-
-let test_validated_bad_judge_wave_budget () =
-  match
-    Fusion_policy.Validated_preset.of_preset
-      (mk_preset ~judge_wave_budget_s:50.0 ~judges:[ base_judge ] "bad-budget")
-  with
-  | Error (Fusion_policy.Validated_preset.Bad_judge_wave_budget 50.0) -> ()
-  | _ -> Alcotest.fail "expected Bad_judge_wave_budget 50.0"
 
 let () =
   Alcotest.run "fusion_core"
@@ -1659,8 +1597,6 @@ let () =
         ; Alcotest.test_case "invalid_meta_timeout" `Quick test_config_invalid_meta_timeout
         ; Alcotest.test_case "invalid_adaptive_factor" `Quick
             test_config_invalid_adaptive_factor
-        ; Alcotest.test_case "invalid_judge_wave_budget" `Quick
-            test_config_invalid_judge_wave_budget
         ] )
     ; ( "validated_preset"
       , [ Alcotest.test_case "ok" `Quick test_validated_ok
@@ -1679,8 +1615,6 @@ let () =
         ; Alcotest.test_case "bad_meta_timeout" `Quick test_validated_bad_meta_timeout
         ; Alcotest.test_case "bad_adaptive_factor" `Quick
             test_validated_bad_adaptive_factor
-        ; Alcotest.test_case "bad_judge_wave_budget" `Quick
-            test_validated_bad_judge_wave_budget
         ] )
     ; ( "staged_judge_groups"
       , [ Alcotest.test_case "exact_3x3" `Quick test_staged_judge_groups_exact_3x3

--- a/test/test_fusion_adaptive_timeout.ml
+++ b/test/test_fusion_adaptive_timeout.ml
@@ -19,7 +19,6 @@ judge = "meta"
 judge_system_prompt = "reconcile"
 judge_timeout_s = 120.0
 meta_timeout_s = 90.0
-judge_wave_budget_s = 500.0
 adaptive_timeout_factor = 2.0
 fallback_judge_model = "fallback-model"
 [[fusion.presets.adaptive.panels]]
@@ -28,12 +27,9 @@ panel_system_prompt = "answer"
 [[fusion.presets.adaptive.judges]]
 model = "judge-a"
 system_prompt = "lens A"
-timeout_s = 100.0
-max_timeout_s = 180.0
 [[fusion.presets.adaptive.judges]]
 model = "judge-b"
 system_prompt = "lens B"
-timeout_s = 110.0
 |}
 
 let adaptive_preset () =
@@ -53,18 +49,11 @@ let test_config_adaptive_timeout_parse () =
      | [ vp ] ->
        let preset = Fusion_policy.Validated_preset.preset vp in
        check (float 0.001) "meta_timeout_s" 90.0 preset.Fusion_policy.meta_timeout_s;
-       check (float 0.001) "judge_wave_budget_s" 500.0
-         preset.Fusion_policy.judge_wave_budget_s;
        check (float 0.001) "adaptive_timeout_factor" 2.0
          preset.Fusion_policy.adaptive_timeout_factor;
        check (option string) "fallback_judge_model" (Some "fallback-model")
          preset.Fusion_policy.fallback_judge_model;
-       (match preset.Fusion_policy.judges with
-        | [ ja; _ ] ->
-          check (float 0.001) "ja timeout" 100.0 ja.Fusion_policy.jtimeout_s;
-          check (option (float 0.001)) "ja max_timeout_s" (Some 180.0)
-            ja.Fusion_policy.jmax_timeout_s
-        | _ -> fail "expected two judges")
+       check int "two judges" 2 (List.length preset.Fusion_policy.judges)
      | _ -> fail "expected exactly one preset")
   | Error es ->
     failf "expected Ok, got errors: %s"

--- a/test/test_fusion_wake.ml
+++ b/test/test_fusion_wake.ml
@@ -198,7 +198,6 @@ let fusion_tool_policy () : Fusion_policy.t =
     ; meta_timeout_s = Fusion_policy.default_timeout_s
     ; judges = []
     ; min_answered = Fusion_policy.default_min_answered
-    ; judge_wave_budget_s = Float.max_float
     ; adaptive_timeout_factor = 1.0
     ; fallback_judge_model = None
     }


### PR DESCRIPTION
## What changed

- removed `judge_spec.jtimeout_s` / `jmax_timeout_s` from the Fusion policy, TOML parser, and dashboard JSON projection
- removed the inert `judge_wave_budget_s` preset field and its validation/error surface
- deleted the obsolete `Budget_exceeded` judge failure and timeout-or-budget classifier
- removed first-judge timeout keys from checked-in runtime config and deleted tests tied only to the retired schema
- kept the existing judge TOML parser test focused on the five product fields that remain; no compatibility decoder or retired-key test was added

## Why

The lower stack no longer injects or enforces MASC-owned Fusion execution deadlines. Keeping first-judge timeout and wave-budget fields after their execution authority disappeared made inert values look operational and preserved dead validation paths.

## Preserved behavior

- judge fan-out, judge identity/lenses, staged grouping, and output-token overrides remain intact
- `judge_timeout_s` / `meta_timeout_s` remain for the later judge-stage schema cut
- typed provider/runtime `Timeout` and elapsed-time observation remain intact
- `adaptive_timeout_factor` and `fallback_judge_model` are outside this cut

## Verification

- exact C3 patch-id preserved while cascading onto the refreshed C2 head
- `ocamlformat --check`: pass
- `git diff --check`: pass
- static residue search for the deleted fields, variants, and helper: pass
- cumulative C6 stack focused Dune build: pass
- cumulative dashboard typecheck and focused tests: 3 files, 66 tests passed
- per-PR delta: 13 files, 202 changed lines

Stacked on #24790 (`ac8b78d3dc`).
