### PR TITLE
refactor(runtime): remove circuit-breaker execution gate

### DIFF
--- a/lib/core/circuit_breaker.ml
+++ b/lib/core/circuit_breaker.ml
@@ -1,8 +1,8 @@
-(** Circuit Breaker for MASC agents
+(** Failure observation for MASC agents
 
-    Simple failure-based protection:
+    Legacy status projection:
     - 3 failures in 1 minute → 5 minute cooldown
-    - Prevents cascading failures in multi-agent systems
+    - No execution gate, wrapper, or suspension API
 
     Research basis:
     - Trust-Vulnerability Paradox (TVP) - arxiv:2510.18563v1
@@ -137,57 +137,6 @@ let record_success t ~agent_id =
         ()
   )
 
-(** Check if an agent is allowed to proceed *)
-let check t ~agent_id : (unit, string) result =
-  with_lock t (fun () ->
-    let breaker = get_or_create_breaker t ~agent_id in
-    let now = Time_compat.now () in
-    let breaker = { breaker with last_check = now } in
-
-    match breaker.state with
-    | Closed ->
-        put_breaker t breaker;
-        Ok ()
-
-    | Open { until; reason = _; _ } when now >= until ->
-        Log.Session.info "[CircuitBreaker] HALF-OPEN for %s, testing..." agent_id;
-        put_breaker t { breaker with state = HalfOpen };
-        Ok ()
-
-    | Open { until; reason; failure_count } ->
-        put_breaker t breaker;
-        let remaining = int_of_float (until -. now) in
-        Error (Printf.sprintf
-          "Circuit breaker OPEN for %s (%d failures). Retry in %ds. Reason: %s"
-          agent_id failure_count remaining reason)
-
-    | HalfOpen ->
-        put_breaker t breaker;
-        Ok ()
-  )
-
-(** Force-open a breaker (for manual suspension) *)
-let force_open t ~agent_id ~reason ~duration_sec =
-  with_lock t (fun () ->
-    let breaker = get_or_create_breaker t ~agent_id in
-    let now = Time_compat.now () in
-    put_breaker t { breaker with state = Open {
-      until = now +. duration_sec;
-      reason = "MANUAL: " ^ reason;
-      failure_count = 0;
-    } };
-    Log.Session.warn "[CircuitBreaker] FORCE-OPENED for %s: %s (%.0fs)"
-      agent_id reason duration_sec
-  )
-
-(** Force-close a breaker (for manual recovery) *)
-let force_close t ~agent_id =
-  with_lock t (fun () ->
-    let breaker = get_or_create_breaker t ~agent_id in
-    put_breaker t { breaker with state = Closed; failures = [] };
-    Log.Session.info "[CircuitBreaker] FORCE-CLOSED for %s" agent_id
-  )
-
 (** {1 Status & Statistics} *)
 
 type breaker_status = {
@@ -274,40 +223,6 @@ let cleanup t ~older_than_seconds =
     removed
   )
 
-(** {1 Wrap — Combined check + execute + record} *)
-
-(** Execute [f] with circuit breaker protection.
-    Returns [Error msg] if breaker is open.
-    Records success/failure automatically. *)
-let wrap t ~agent_id (f : unit -> ('a, string) result) : ('a, string) result =
-  match check t ~agent_id with
-  | Error msg -> Error msg
-  | Ok () ->
-      match f () with
-      | Ok _ as ok ->
-          record_success t ~agent_id;
-          ok
-      | Error msg as err ->
-          record_failure t ~agent_id ~reason:msg;
-          err
-
-(** Exception-catching variant of [wrap].
-    Re-raises [Eio.Cancel.Cancelled] to preserve cooperative cancellation. *)
-let wrap_result t ~agent_id (f : unit -> 'a) : ('a, string) result =
-  match check t ~agent_id with
-  | Error msg -> Error msg
-  | Ok () ->
-      (try
-         let result = f () in
-         record_success t ~agent_id;
-         Ok result
-       with
-       | Eio.Cancel.Cancelled _ as exn -> raise exn
-       | exn ->
-         let msg = Printexc.to_string exn in
-         record_failure t ~agent_id ~reason:msg;
-         Error msg)
-
 (** {1 Global Instance}
 
     The singleton is read from tests and startup paths that can run before an
@@ -329,10 +244,6 @@ let global () =
             Atomic.set global_cache (Some candidate);
             candidate)
 
-let check_global ~agent_id = check (global ()) ~agent_id
 let record_failure_global ~agent_id ~reason = record_failure (global ()) ~agent_id ~reason
 let record_success_global ~agent_id = record_success (global ()) ~agent_id
-let force_open_global ~agent_id ~reason ~duration_sec =
-  force_open (global ()) ~agent_id ~reason ~duration_sec
-let force_close_global ~agent_id = force_close (global ()) ~agent_id
 let get_status_global ~agent_id = get_status (global ()) ~agent_id

--- a/lib/core/circuit_breaker.ml
+++ b/lib/core/circuit_breaker.ml
@@ -174,15 +174,6 @@ let get_status t ~agent_id =
         }
   )
 
-let status_to_json (s : breaker_status) : Yojson.Safe.t =
-  `Assoc [
-    ("agent_id", `String s.agent_id);
-    ("state", `String s.state_name);
-    ("recent_failures", `Int s.recent_failures);
-    ("open_until", Json_util.float_opt_to_json s.open_until);
-    ("open_reason", Json_util.string_opt_to_json s.open_reason);
-  ]
-
 let list_all_breakers t =
   with_lock t (fun () ->
     StringMap.fold (fun agent_id breaker acc ->
@@ -204,24 +195,6 @@ let list_all_breakers t =
     ) t.breakers []
   )
 
-
-(** {1 Cleanup} *)
-
-let cleanup t ~older_than_seconds =
-  with_lock t (fun () ->
-    let now = Time_compat.now () in
-    let threshold = now -. float_of_int older_than_seconds in
-    let removed, kept =
-      StringMap.fold (fun agent_id breaker (n, m) ->
-        match breaker.state with
-        | Closed when breaker.last_check < threshold -> (n + 1, m)
-        | Closed | Open _ | HalfOpen ->
-            (n, StringMap.add agent_id breaker m)
-      ) t.breakers (0, StringMap.empty)
-    in
-    t.breakers <- kept;
-    removed
-  )
 
 (** {1 Global Instance}
 

--- a/lib/core/circuit_breaker.mli
+++ b/lib/core/circuit_breaker.mli
@@ -1,9 +1,8 @@
-(** Circuit_breaker — failure-based protection for MASC agents.
+(** Circuit_breaker — failure observation for MASC agents.
 
-    Threshold-driven state machine: 3 failures inside a 1-minute
-    window opens the breaker for 5 minutes (HalfOpen probe at the
-    end of the cooldown).  Defaults are tunable per-instance via
-    {!create}.
+    This intermediate status projection still groups failures by the legacy
+    window, but exposes no execution gate, wrapper, or administrative
+    suspension API. Recorded status never controls Keeper participation.
 
     {b Concurrency}: all breaker records are immutable; the single
     mutable field [breakers] in the instance is protected by a
@@ -34,11 +33,9 @@ type state =
       failure_count : int;
           (** Number of failures inside the window when opening. *)
     }
-      (** Cooldown — calls return [Error _] without invoking the
-          underlying function. *)
+      (** Legacy cooldown observation. It does not suppress execution. *)
   | HalfOpen
-      (** Probe state — single call permitted; success -> closed,
-          failure -> back to open with fresh cooldown. *)
+      (** Legacy recovery observation. It does not grant execution. *)
 
 (** {1 Records (concrete — for introspection)} *)
 
@@ -92,28 +89,6 @@ val record_success : t -> agent_id:string -> unit
 (** [record_success t ~agent_id] clears the agent's failure list.
     If the breaker was [HalfOpen], transitions to [Closed]. *)
 
-val check : t -> agent_id:string -> (unit, string) result
-(** [check t ~agent_id] is the gate query:
-
-    - [Closed] -> [Ok ()].
-    - [Open] past [until] -> transition to [HalfOpen], [Ok ()].
-    - [Open] before [until] ->
-      [Error "Circuit open until <iso> (<reason>)"].
-    - [HalfOpen] -> [Ok ()] (probe permitted). *)
-
-(** {1 Admin override} *)
-
-val force_open :
-  t -> agent_id:string -> reason:string -> duration_sec:float -> unit
-(** [force_open t ~agent_id ~reason ~duration_sec] manually opens
-    the breaker for [duration_sec] seconds with the supplied
-    [reason].  Used by operators to quarantine misbehaving agents. *)
-
-val force_close : t -> agent_id:string -> unit
-(** [force_close t ~agent_id] manually closes the breaker and
-    clears any pending failures.  Used by operators to override a
-    cooldown after manual intervention. *)
-
 (** {1 Introspection} *)
 
 type breaker_status = {
@@ -156,27 +131,6 @@ val cleanup : t -> older_than_seconds:int -> int
     Returns the number removed.  Open / half-open breakers are
     preserved regardless of age. *)
 
-(** {1 Wrappers (combined check + execute + record)} *)
-
-val wrap :
-  t ->
-  agent_id:string ->
-  (unit -> ('a, string) result) ->
-  ('a, string) result
-(** [wrap t ~agent_id f] composes [check] + [f] + record:
-
-    + [check] open -> [Error _] (f not called).
-    + [f ()] returns [Ok _] -> [record_success], pass through.
-    + [f ()] returns [Error msg] -> [record_failure ~reason:msg],
-      pass through. *)
-
-val wrap_result :
-  t -> agent_id:string -> (unit -> 'a) -> ('a, string) result
-(** [wrap_result t ~agent_id f] is the exception-catching variant.
-    Re-raises {!Eio.Cancel.Cancelled} (cooperative cancellation
-    must propagate); other exceptions are converted to
-    [Error (Printexc.to_string exn)] with [record_failure]. *)
-
 (** {1 Global instance}
 
     Memoized singleton.  Uses Atomic+Stdlib.Mutex rather than {!Eio.Lazy}
@@ -186,10 +140,6 @@ val wrap_result :
 val global : unit -> t
 (** Global circuit-breaker instance.  Prefer the [*_global] helpers below. *)
 
-val check_global : agent_id:string -> (unit, string) result
 val record_failure_global : agent_id:string -> reason:string -> unit
 val record_success_global : agent_id:string -> unit
-val force_open_global :
-  agent_id:string -> reason:string -> duration_sec:float -> unit
-val force_close_global : agent_id:string -> unit
 val get_status_global : agent_id:string -> breaker_status

--- a/lib/core/circuit_breaker.mli
+++ b/lib/core/circuit_breaker.mli
@@ -18,37 +18,11 @@
     [get_or_create_breaker], [prune_old_failures] stay private —
     callers do not need Map / mutex / pruning primitives. *)
 
-(** {1 State machine} *)
-
-(** Breaker state — closed (normal), open (cooldown), half-open
-    (recovery probe). *)
-type state =
-  | Closed
-      (** Normal operation — calls flow through. *)
-  | Open of {
-      until : float;
-          (** Unix timestamp at which to retry. *)
-      reason : string;
-          (** Last failure reason that triggered open. *)
-      failure_count : int;
-          (** Number of failures inside the window when opening. *)
-    }
-      (** Legacy cooldown observation. It does not suppress execution. *)
-  | HalfOpen
-      (** Legacy recovery observation. It does not grant execution. *)
-
-(** {1 Records (concrete — for introspection)} *)
+(** {1 Records} *)
 
 type failure_record = {
   timestamp : float;
   reason : string;
-}
-
-type breaker = {
-  agent_id : string;
-  state : state;
-  failures : failure_record list;
-  last_check : float;
 }
 
 (** {1 Instance (abstract)} *)
@@ -71,11 +45,6 @@ val create :
 (** [create ?failure_threshold ?failure_window ?cooldown ()] returns
     a fresh instance with an empty breaker map.  Defaults match
     the [default_*] constants above. *)
-
-val create_default : unit -> t
-(** [create_default ()] creates an instance with all defaults.
-    Pinned at the contract seam — future config-driven overrides
-    reuse this entry without breaking callers. *)
 
 (** {1 Lifecycle} *)
 
@@ -108,37 +77,13 @@ val get_status : t -> agent_id:string -> breaker_status
     no breaker exists for [agent_id], returns a synthetic "closed"
     status (no side effects). *)
 
-val status_to_json : breaker_status -> Yojson.Safe.t
-(** Hand-written serialiser.  Output schema:
-
-    {[
-      \{
-        "agent_id": <string>,
-        "state": <"closed"|"open"|"half_open">,
-        "recent_failures": <int>,
-        "open_until": <float|null>,
-        "open_reason": <string|null>
-      \}
-    ]} *)
 val list_all_breakers : t -> breaker_status list
-
-
-(** {1 Maintenance} *)
-
-val cleanup : t -> older_than_seconds:int -> int
-(** [cleanup t ~older_than_seconds] removes [Closed] breakers
-    whose [last_check] is older than [older_than_seconds].
-    Returns the number removed.  Open / half-open breakers are
-    preserved regardless of age. *)
 
 (** {1 Global instance}
 
     Memoized singleton.  Uses Atomic+Stdlib.Mutex rather than {!Eio.Lazy}
     because tests and startup paths can touch the helpers before an Eio
     scheduler exists. *)
-
-val global : unit -> t
-(** Global circuit-breaker instance.  Prefer the [*_global] helpers below. *)
 
 val record_failure_global : agent_id:string -> reason:string -> unit
 val record_success_global : agent_id:string -> unit

--- a/test/test_eio_mutex_concurrency.ml
+++ b/test/test_eio_mutex_concurrency.ml
@@ -51,24 +51,19 @@ let test_rate_limit_independent_keys () =
 
 (** {1 Circuit Breaker Concurrency} *)
 
-let test_circuit_breaker_concurrent () =
+let test_failure_observation_concurrent () =
   let cb = CB.create ~failure_threshold:50 ~cooldown:1.0 () in
-  (* Concurrent failure recording + status checking *)
+  (* Concurrent failure recording + observation reads. *)
   Eio.Fiber.all [
     (fun () -> for _ = 1 to 30 do
       CB.record_failure cb ~agent_id:"test-agent" ~reason:"concurrent-test"
     done);
     (fun () -> for _ = 1 to 30 do
-      ignore (CB.check cb ~agent_id:"test-agent")
-    done);
-    (fun () -> for _ = 1 to 30 do
       let _s = CB.get_status cb ~agent_id:"test-agent" in ()
     done);
   ];
-  (* State must be one of the valid states *)
   let status = CB.get_status cb ~agent_id:"test-agent" in
-  check bool "state is valid"
-    true (List.mem status.state_name ["closed"; "open"; "half_open"])
+  check int "all failures observed" 30 status.recent_failures
 
 let test_circuit_breaker_multi_agent () =
   let cb = CB.create () in
@@ -77,7 +72,6 @@ let test_circuit_breaker_multi_agent () =
     let agent_id = Printf.sprintf "agent-%d" i in
     for _ = 1 to 20 do
       CB.record_failure cb ~agent_id ~reason:"test";
-      ignore (CB.check cb ~agent_id)
     done
   ));
   let all = CB.list_all_breakers cb in
@@ -134,7 +128,8 @@ let () =
       test_case "concurrent independent keys" `Quick test_rate_limit_independent_keys;
     ];
     "Circuit Breaker", [
-      test_case "concurrent failure/check" `Quick test_circuit_breaker_concurrent;
+      test_case "concurrent failure observation" `Quick
+        test_failure_observation_concurrent;
       test_case "concurrent multi-agent" `Quick test_circuit_breaker_multi_agent;
     ];
     "Otel_metric_store", [

--- a/test/test_pulse.ml
+++ b/test/test_pulse.ml
@@ -413,43 +413,6 @@ let () = test "failing consumer remains active" (fun () ->
   assert (!ok_count >= 5)
 )
 
-(* ── Test: circuit_breaker wrap ────────────────────────────── *)
-
-let () = test "circuit_breaker wrap records success/failure" (fun () ->
-  Eio_main.run @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
-  let cb = Circuit_breaker.create
-    ~failure_threshold:2 ~failure_window:60.0 ~cooldown:1.0 () in
-  (* Success path *)
-  let r1 = Circuit_breaker.wrap cb ~agent_id:"test" (fun () -> Ok 42) in
-  assert (r1 = Ok 42);
-  let s = Circuit_breaker.get_status cb ~agent_id:"test" in
-  assert (s.state_name = "closed");
-  (* 2 failures should open the breaker *)
-  ignore (Circuit_breaker.wrap cb ~agent_id:"test" (fun () -> Error "fail1"));
-  ignore (Circuit_breaker.wrap cb ~agent_id:"test" (fun () -> Error "fail2"));
-  let s2 = Circuit_breaker.get_status cb ~agent_id:"test" in
-  assert (s2.state_name = "open");
-  (* Wrapped call should be rejected while open *)
-  let r2 = Circuit_breaker.wrap cb ~agent_id:"test" (fun () -> Ok 99) in
-  (match r2 with Error _ -> () | Ok _ -> failwith "expected Error while open")
-)
-
-(* ── Test: circuit_breaker wrap_result ────────────────────────── *)
-
-let () = test "circuit_breaker wrap_result catches exceptions" (fun () ->
-  Eio_main.run @@ fun env ->
-  Fs_compat.set_fs (Eio.Stdenv.fs env);
-  let cb = Circuit_breaker.create
-    ~failure_threshold:3 ~failure_window:60.0 ~cooldown:1.0 () in
-  let r = Circuit_breaker.wrap_result cb ~agent_id:"exc-test" (fun () ->
-    failwith "boom"
-  ) in
-  (match r with Error _ -> () | Ok _ -> failwith "expected Error from exception");
-  let s = Circuit_breaker.get_status cb ~agent_id:"exc-test" in
-  assert (s.recent_failures = 1)
-)
-
 (* ── Test: set_rhythm updates interval ────────────────────── *)
 
 let () = test "set_rhythm changes interval" (fun () ->


### PR DESCRIPTION
## What changed

- delete `Circuit_breaker.check` and its global gate
- delete `wrap`/`wrap_result`, which could skip the supplied operation
- delete force-open/force-close administrative suspension APIs
- remove retired wrapper rejection tests
- keep concurrent failure recording and introspection coverage

## Why

A live callsite audit found every removed API was unused by production code. Keeping an unused execution-denial surface would still preserve the wrong architecture and invite future Keeper wiring back to a threshold-driven gate.

This stack deliberately leaves failure recording and status introspection intact. No recorded failure can now prevent the wrapped operation from running because there is no wrapper or check API.

## Validation

- `git diff --check`
- repository-wide `rg` confirms zero remaining circuit-breaker check/wrap/force callsites and interface declarations
- focused Dune wrapper was attempted twice; it correctly refused because two other sessions have live bare Dune builds, so no valid build was killed and the lock was not bypassed
- CI is the build authority for this draft

Stacked on #24799. The next stack replaces the remaining Open/HalfOpen/3-failures/60s/300s status projection with typed failure observations.