### PR TITLE
refactor(voice): remove playback execution deadlines

### DIFF
--- a/lib/voice_bridge_core/voice_bridge_core.ml
+++ b/lib/voice_bridge_core/voice_bridge_core.ml
@@ -167,14 +167,6 @@ let local_playback_argvs ?path_value ~audio_file () =
     | Some path -> Some (path :: args @ [ audio_file ])
     | None -> None)
 
-(* Playback subprocess timeout. The Exec_gate default (60s) used to kill any
-   player mid-play on audio longer than a minute; Process_eio reports the
-   kill as WEXITED 124 and the candidate loop then replayed the SAME file
-   from 0:00 through the fallback player — the audible-repeat amplifier in
-   the 2026-06-10 voice incident. Derive the budget from the probed audio
-   duration instead. *)
-let playback_timeout_margin_sec = 30.0
-let unknown_duration_playback_timeout_sec = 300.0
 let duration_probe_timeout_sec = 10.0
 
 let parse_afinfo_duration output =
@@ -202,11 +194,6 @@ let parse_afinfo_duration output =
     else None)
 
 let parse_ffprobe_duration output = float_of_string_opt (String.trim output)
-
-let playback_timeout_sec_for ~duration_sec =
-  match duration_sec with
-  | Some duration -> duration +. playback_timeout_margin_sec
-  | None -> unknown_duration_playback_timeout_sec
 
 let audio_duration_seconds ~audio_file =
   let probe argv parse =
@@ -277,12 +264,6 @@ let run_local_playback ~sw:_ ~agent_id ?message ~audio_file () =
           (Printf.sprintf "local voice playback unavailable: %s" reason);
         `Failed reason
       | candidates ->
-        (* Probe BEFORE taking the playback mutex so a slow probe never
-           extends the global playback serialization window. *)
-        let playback_timeout_sec =
-          playback_timeout_sec_for
-            ~duration_sec:(audio_duration_seconds ~audio_file)
-        in
         File_lock_eio.with_lock (playback_lock_path ()) (fun () ->
           let dedup_hit =
             match message with
@@ -323,7 +304,6 @@ let run_local_playback ~sw:_ ~agent_id ?message ~audio_file () =
                       ~actor:(Masc_exec.Agent_id.of_string "voice/bridge_core")
                       ~raw_source
                       ~summary:"voice local playback"
-                      ~timeout_sec:playback_timeout_sec
                       argv
                   with
                   | Unix.WEXITED 0, _ ->
@@ -343,25 +323,6 @@ let run_local_playback ~sw:_ ~agent_id ?message ~audio_file () =
                            agent_id audio_file executable dur);
                       `Played dur
                     end
-                  | Unix.WEXITED 124, _ ->
-                    (* WEXITED 124 is Process_eio's synthesized status for a
-                       timeout kill: the player ran past the probed duration
-                       + margin, so partial audio has almost certainly been
-                       heard. Terminal on purpose — falling through to the
-                       next candidate would replay the SAME file from 0:00. *)
-                    let reason =
-                      Printf.sprintf
-                        "%s killed by playback timeout after %.0fs; partial \
-                         audio may have played, not retrying with fallback \
-                         player"
-                        executable playback_timeout_sec
-                    in
-                    log_error
-                      (Printf.sprintf
-                         "local voice playback timed out (terminal): agent=%s \
-                          file=%s via=%s timeout=%.0fs"
-                         agent_id audio_file executable playback_timeout_sec);
-                    `Failed reason
                   | Unix.WEXITED code, output ->
                     let failure =
                       Printf.sprintf "%s exited %d%s" executable code

--- a/lib/voice_bridge_core/voice_bridge_core.mli
+++ b/lib/voice_bridge_core/voice_bridge_core.mli
@@ -75,16 +75,7 @@ val voice_mcp_port : unit -> int
    per-process piaf pool.  See voice_bridge_core.ml for the in-place
    note explaining the migration. *)
 
-(** {1 Playback timeout} *)
-
-val playback_timeout_margin_sec : float
-(** Extra seconds granted on top of the probed audio duration before the
-    player subprocess is killed. *)
-
-val unknown_duration_playback_timeout_sec : float
-(** Player subprocess timeout when the audio duration cannot be probed.
-    Generous on purpose: killing a player mid-play used to cascade into the
-    fallback chain replaying the same file from 0:00. *)
+(** {1 Playback observation} *)
 
 val parse_afinfo_duration : string -> float option
 (** Parse the ["estimated duration: 12.345 sec"] line from [afinfo] output. *)
@@ -92,10 +83,6 @@ val parse_afinfo_duration : string -> float option
 val parse_ffprobe_duration : string -> float option
 (** Parse the bare-seconds stdout of
     [ffprobe -show_entries format=duration -of default=noprint_wrappers=1:nokey=1]. *)
-
-val playback_timeout_sec_for : duration_sec:float option -> float
-(** [duration +. playback_timeout_margin_sec] when the duration is known,
-    {!unknown_duration_playback_timeout_sec} otherwise. *)
 
 val audio_duration_seconds : audio_file:string -> float option
 (** Probe the audio duration via [afinfo] (macOS) or [ffprobe]. [None] when
@@ -132,11 +119,8 @@ val run_local_playback :
       check-then-act race);
     - [`Skipped reason] — playback was intentionally skipped, for example
       because local playback is disabled for the agent;
-    - [`Failed reason] — local playback was requested but no candidate player
-      succeeded, or the player was killed by the playback timeout. A timeout
-      kill is terminal: the fallback chain is NOT tried, because partial audio
-      has likely played and a fallback player would replay the same file from
-      0:00 (the audible-repeat amplifier in the 2026-06-10 voice incident);
+    - [`Failed reason] — local playback was requested but every candidate
+      player exited unsuccessfully, was stopped/signalled, or raised;
     - [`Opened duration_seconds] — the file was handed to macOS [open(1)] after
       all blocking players failed. This is a GUI handoff fallback; playback
       completion is not observable from the runtime;

--- a/test/test_voice_runtime_overlay.ml
+++ b/test/test_voice_runtime_overlay.ml
@@ -801,7 +801,7 @@ let test_keeper_voice_agent_reports_realtime_bridge_capability () =
         end_session ()))
 ;;
 
-let test_playback_timeout_parsers_and_budget () =
+let test_playback_duration_parsers () =
   check (option (float 0.001)) "afinfo duration line parses"
     (Some 236.6)
     (Voice_bridge_core.parse_afinfo_duration
@@ -812,13 +812,7 @@ let test_playback_timeout_parsers_and_budget () =
     (Some 61.25)
     (Voice_bridge_core.parse_ffprobe_duration "61.25\n");
   check (option (float 0.001)) "ffprobe N/A is None" None
-    (Voice_bridge_core.parse_ffprobe_duration "N/A");
-  check (float 0.001) "known duration gets margin"
-    (100.0 +. Voice_bridge_core.playback_timeout_margin_sec)
-    (Voice_bridge_core.playback_timeout_sec_for ~duration_sec:(Some 100.0));
-  check (float 0.001) "unknown duration uses generous default"
-    Voice_bridge_core.unknown_duration_playback_timeout_sec
-    (Voice_bridge_core.playback_timeout_sec_for ~duration_sec:None)
+    (Voice_bridge_core.parse_ffprobe_duration "N/A")
 ;;
 
 let write_local_playback_config () =
@@ -979,11 +973,11 @@ let () =
             `Quick
             test_keeper_voice_agent_reports_realtime_bridge_capability
         ] )
-    ; ( "playback_timeout"
+    ; ( "playback"
       , [ test_case
-            "duration parsers and timeout budget"
+            "duration parsers"
             `Quick
-            test_playback_timeout_parsers_and_budget
+            test_playback_duration_parsers
         ; test_case
             "open fallback reports handoff"
             `Quick


### PR DESCRIPTION
## What changed

- remove the duration-derived playback deadline (`duration + 30s`)
- remove the 300-second fallback deadline for audio whose duration cannot be probed
- delete the retired timeout API and its contract test
- keep duration probing for dashboard audio metadata

## Why

Playback duration is observation, not authority to stop a Keeper-visible effect. The old path converted a best-effort duration probe into execution policy and synthesized `WEXITED 124` after a fixed deadline. Unknown-duration audio was therefore killed after 300 seconds, while known-duration audio was killed after an inferred duration plus a fixed margin.

Local playback now delegates without an outer wall-clock deadline. Real player exit/stopped/signalled statuses remain typed, and `Eio.Cancel.Cancelled` still propagates from the parent scope. The host-wide file lock remains in place because a physical default speaker cannot play multiple utterances coherently at once.

## Scope boundary

This does **not** claim durable asynchronous Voice completion. `keeper_voice_speak` still waits for synthesis/playback and may wait for the physical speaker lock. Moving that work off the Keeper lane requires a product-neutral background-operation/job owner with wake-up semantics; reusing the message-specific `Keeper_msg_async` stack would create the wrong coupling. The durable multimodal operation/lane contract is tracked by #24756.

## Validation

- `git diff --check origin/main...HEAD`
- `ocamlformat --check lib/voice_bridge_core/voice_bridge_core.ml lib/voice_bridge_core/voice_bridge_core.mli test/test_voice_runtime_overlay.ml`
- `ocamlc -stop-after parsing` for both implementation files and the interface
- zero-result source scan for the retired playback timeout symbols and timeout-kill contract
- `scripts/dune-local.sh build test/test_voice_runtime_overlay.exe`
- `_build/default/test/test_voice_runtime_overlay.exe` (22 tests)

CI remains the full build authority.
