### PR TITLE
fix(keeper): harden post-merge runtime boundaries

### DIFF
--- a/docs/spec/15-testing.md
+++ b/docs/spec/15-testing.md
@@ -224,7 +224,7 @@ CI 테스트 실행기. 다음 기능을 제공한다:
 | Heartbeat logging | `CI_TEST_HEARTBEAT_SEC` (기본 30초) 간격으로 진행 상태 출력. "silent hang" 방지. |
 | Diagnostics dump | 실패 시 프로세스 스냅샷, 로그 파일 경로, 빌드 디렉토리 정보 출력. |
 | Disk observation | 사용 가능 공간이 임계값 아래로 내려가면 상태와 진단을 기록하되 실행을 중단하지 않는다. |
-| Single attempt | 명령을 정확히 한 번 실행하고 원래 종료 코드를 보존한다. 실행 경계는 CI job이 소유한다. |
+| Single attempt | 명령을 정확히 한 번 실행하고 원래 종료 코드를 보존한다. 실행 경계는 호출 수명주기(CI에서는 job, 로컬에서는 foreground parent)가 소유한다. |
 
 ### 6.2 실행 흐름
 

--- a/lib/keeper/keeper_msg_async.ml
+++ b/lib/keeper/keeper_msg_async.ml
@@ -119,6 +119,10 @@ and recovery_record_error_kind =
 
 type submit_error =
   | Submit_rejected of access_rejection
+  | Request_store_inspection_failed of
+      { path : string
+      ; reason : string
+      }
   | Submit_invalid_keeper_name of { reason : string }
   | Initial_persistence_failed of { reason : string }
   | Acceptance_persistence_failed of
@@ -276,6 +280,7 @@ type request_ops =
       -> string
       -> (unit, Keeper_fs.durable_remove_error) result
   ; generate_request_id : unit -> string
+  ; before_request_store_inspection : unit -> unit
   ; before_integrity_projection : unit -> unit
   ; signal_cancel : Eio.Switch.t -> exn -> unit
   }
@@ -293,6 +298,7 @@ let production_request_ops =
          Keeper_fs.remove_file_durable ~ownership_root path)
   ; generate_request_id =
       (fun () -> Random_id.prefixed ~prefix:"kmsg-" ~bytes:16)
+  ; before_request_store_inspection = (fun () -> ())
   ; before_integrity_projection = (fun () -> ())
   ; signal_cancel = Eio.Switch.fail
   }
@@ -658,6 +664,12 @@ let durable_terminal_entry proof = proof.terminal_entry
 
 let submit_error_to_json = function
   | Submit_rejected rejection -> access_rejection_to_json rejection
+  | Request_store_inspection_failed { path; reason } ->
+    `Assoc
+      [ "error", `String "request_store_inspection_failed"
+      ; "path", `String path
+      ; "message", `String reason
+      ]
   | Submit_invalid_keeper_name { reason } ->
     `Assoc
       [ "error", `String "invalid_keeper_name"
@@ -1723,17 +1735,32 @@ let recover_lost_disk_records ~base_path () =
 
 let with_lock f = Eio.Mutex.use_rw ~protect:true mu (fun () -> f ())
 
-let validate_request_store_root ~base_path =
-  match
-    Fs_compat.inspect_owned_directory_chain
-      ~ownership_root:base_path
-      (request_dir ~base_path)
+let validate_request_store_root ~ops ~base_path =
+  let path = request_dir ~base_path in
+  try
+    ops.before_request_store_inspection ();
+    match
+      Fs_compat.inspect_owned_directory_chain
+        ~ownership_root:base_path
+        path
+    with
+    | Ok (Fs_compat.Owned_directory_missing | Fs_compat.Owned_directory _) ->
+      Ok ()
+    | Error rejection ->
+      Error
+        (Submit_rejected
+           (Invalid_base_path
+              { reason =
+                  Fs_compat.owned_directory_chain_rejection_to_string rejection
+              }))
   with
-  | Ok (Fs_compat.Owned_directory_missing | Fs_compat.Owned_directory _) -> Ok ()
-  | Error rejection ->
+  | Eio.Cancel.Cancelled _ as exn ->
+    let bt = Printexc.get_raw_backtrace () in
+    Printexc.raise_with_backtrace exn bt
+  | exn ->
     Error
-      (Invalid_base_path
-         { reason = Fs_compat.owned_directory_chain_rejection_to_string rejection })
+      (Request_store_inspection_failed
+         { path; reason = Printexc.to_string exn })
 ;;
 
 let reserve_new_request ~ops ~base_path ~submitted_by ~keeper_name =
@@ -1774,16 +1801,16 @@ let reserve_new_request ~ops ~base_path ~submitted_by ~keeper_name =
                 `Reserved (request_id, entry, key, transition_lock))
           | Located _ -> `Collision
           | Located_unreadable _ ->
-            (match validate_request_store_root ~base_path with
+            (match validate_request_store_root ~ops ~base_path with
              | Ok () -> `Collision
-             | Error rejection -> `Rejected rejection)
-          | Located_rejected rejection -> `Rejected rejection)
+             | Error error -> `Rejected error)
+          | Located_rejected rejection -> `Rejected (Submit_rejected rejection))
       with
       | `Reserved reserved -> Ok reserved
       | `Collision -> reserve ()
       | `Rejected rejection -> Error rejection
   in
-  match validate_request_store_root ~base_path with
+  match validate_request_store_root ~ops ~base_path with
   | Ok () -> reserve ()
   | Error _ as error -> error
 ;;
@@ -2016,7 +2043,7 @@ let submit_with_ops ops ?on_accepted ?on_worker_aborted ?on_worker_settled ~back
     let keeper_name = Keeper_id.Keeper_name.to_string keeper_name_id in
     with_keeper_submission_lock ~base_path ~keeper_name:keeper_name_id (fun () ->
     match reserve_new_request ~ops ~base_path ~submitted_by ~keeper_name with
-    | Error rejection -> Error (Submit_rejected rejection)
+    | Error error -> Error error
     | Ok (request_id, entry, key, transition_lock) ->
     let reconciliation_outcome reason =
       Ok
@@ -2620,6 +2647,8 @@ module For_testing = struct
 
   let make_request_ops ?before_durable_write ?before_durable_remove
       ?(generate_request_id = production_request_ops.generate_request_id)
+      ?(before_request_store_inspection =
+        production_request_ops.before_request_store_inspection)
       ?(before_integrity_projection =
         production_request_ops.before_integrity_projection)
       ?(signal_cancel = production_request_ops.signal_cancel) () =
@@ -2648,6 +2677,7 @@ module For_testing = struct
     { save_json_durable
     ; remove_file_durable
     ; generate_request_id
+    ; before_request_store_inspection
     ; before_integrity_projection
     ; signal_cancel
     }

--- a/lib/keeper/keeper_msg_async.mli
+++ b/lib/keeper/keeper_msg_async.mli
@@ -139,6 +139,10 @@ and recovery_record_error_kind =
 
 type submit_error =
   | Submit_rejected of access_rejection
+  | Request_store_inspection_failed of
+      { path : string
+      ; reason : string
+      }
   | Submit_invalid_keeper_name of { reason : string }
   | Initial_persistence_failed of { reason : string }
   | Acceptance_persistence_failed of
@@ -349,6 +353,7 @@ module For_testing : sig
     :  ?before_durable_write:(Keeper_fs.durable_write_stage -> unit)
     -> ?before_durable_remove:(Keeper_fs.durable_remove_stage -> unit)
     -> ?generate_request_id:(unit -> string)
+    -> ?before_request_store_inspection:(unit -> unit)
     -> ?before_integrity_projection:(unit -> unit)
     -> ?signal_cancel:(Eio.Switch.t -> exn -> unit)
     -> unit

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -1,7 +1,7 @@
 (** Keeper_status_detail — single-keeper detailed status handler.
     Split from keeper_status.ml.
 
-    Server-side response cache: keyed on (base_path, name, updated_at, args_hash).
+    Server-side response cache: keyed on (base_path, name, updated_at, cache input).
     Avoids expensive JSONL parsing and checkpoint loading when keeper
     state has not changed between consecutive status polls. *)
 
@@ -29,9 +29,33 @@ let read_tail_lines_or_empty ~site path ~max_bytes ~max_lines =
 
 (* ── Response cache ──────────────────────────────────── *)
 
+type tail_order =
+  | Oldest_first
+  | Newest_first
+
+type status_options =
+  { tail_turns : int
+  ; tail_messages : int
+  ; tail_compactions : int
+  ; tail_bytes : int
+  ; tail_order : tail_order
+  ; fast : bool
+  ; include_context : bool
+  ; include_metrics_overview : bool
+  ; include_memory_bank : bool
+  ; include_history_tail : bool
+  ; include_compaction_history : bool
+  }
+
+type status_cache_input =
+  { options : status_options
+  ; effective_meta_overlay_hash : string
+  ; chat_queue_fingerprint : string
+  }
+
 type cache_entry = {
   updated_at : string;
-  args_hash : string;
+  cache_input : status_cache_input;
   response : Yojson.Safe.t;
 }
 
@@ -133,10 +157,6 @@ let effective_status_name_config ~(agent_name : string) args =
 let effective_status_name (ctx : _ context) args =
   effective_status_name_config ~agent_name:ctx.agent_name args
 
-type tail_order =
-  | Oldest_first
-  | Newest_first
-
 let tail_order_of_args args =
   match String.lowercase_ascii (String.trim (get_string args "tail_order" "")) with
   | "newest_first" | "newest" | "latest_first" | "desc" ->
@@ -156,6 +176,23 @@ let tail_order_to_string = function
 let all_tail_orders = [ Oldest_first; Newest_first ]
 let valid_tail_order_strings =
   List.map tail_order_to_string all_tail_orders
+
+let status_options_of_args args =
+  let fast = get_bool args "fast" (keeper_status_fast_default ()) in
+  { tail_turns = max 0 (get_int args "tail_turns" 3)
+  ; tail_messages = max 0 (get_int args "tail_messages" 5)
+  ; tail_compactions = max 0 (get_int args "tail_compactions" 10)
+  ; tail_bytes = max 1_000 (get_int args "tail_bytes" 60_000)
+  ; tail_order = tail_order_of_args args
+  ; fast
+  ; include_context = get_bool args "include_context" (not fast)
+  ; include_metrics_overview =
+      get_bool args "include_metrics_overview" (not fast)
+  ; include_memory_bank = get_bool args "include_memory_bank" (not fast)
+  ; include_history_tail = get_bool args "include_history_tail" (not fast)
+  ; include_compaction_history =
+      get_bool args "include_compaction_history" (not fast)
+  }
 
 let apply_tail_order order items =
   match order with
@@ -315,25 +352,6 @@ let chat_queue_status_to_json observation =
       ; "durable_replay_enabled", `Bool durable_replay_enabled
       ]
 
-let hash_status_args _config resolved_name (meta : keeper_meta)
-    ~chat_queue_fingerprint args =
-  let parts = [
-    resolved_name;
-    effective_meta_overlay_hash meta;
-    chat_queue_fingerprint;
-    (* Keeper_manual_reconcile.cache_key removed with reconcile system. *)
-    string_of_bool (get_bool args "fast" false);
-    string_of_bool (get_bool args "include_context" false);
-    string_of_bool (get_bool args "include_metrics_overview" false);
-    string_of_bool (get_bool args "include_memory_bank" false);
-    string_of_bool (get_bool args "include_history_tail" false);
-    string_of_bool (get_bool args "include_compaction_history" false);
-    string_of_int (get_int args "tail_turns" 3);
-    string_of_int (get_int args "tail_messages" 5);
-    tail_order_to_string (tail_order_of_args args);
-  ] in
-  Digest.string (String.concat "|" parts) |> Digest.to_hex
-
 let nonempty_trimmed = Keeper_status_detail_observability.nonempty_trimmed
 let json_string_opt_member = Json_util.get_string_nonempty
 let latest_metrics_json = Keeper_status_detail_observability.latest_metrics_json
@@ -348,13 +366,15 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
   | Ok (name, m) ->
       let cache_key = status_cache_key ~base_path:config.base_path ~name in
       let chat_queue_observation = observe_chat_queue ~keeper_name:m.name in
-      let args_hash =
-        hash_status_args config name m
-          ~chat_queue_fingerprint:
-            (chat_queue_observation_fingerprint chat_queue_observation)
-          args
+      let options = status_options_of_args args in
+      let cache_input =
+        { options
+        ; effective_meta_overlay_hash = effective_meta_overlay_hash m
+        ; chat_queue_fingerprint =
+            chat_queue_observation_fingerprint chat_queue_observation
+        }
       in
-      (* Cache hit: same updated_at + same args/effective-meta hash → return cached response.
+      (* Cache hit: same updated_at + same typed args/effective-meta input → return cached response.
          The read is taken under [cache_mu] so it cannot interleave with
          an eviction from [invalidate_status_cache_{for,all}]. *)
       (match
@@ -363,23 +383,23 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
        with
        | Some entry
          when entry.updated_at = m.updated_at
-           && entry.args_hash = args_hash ->
+           && entry.cache_input = cache_input ->
          tool_result_ok_data entry.response
        | _ ->
-      let tail_turns = max 0 (get_int args "tail_turns" 3) in
-      let tail_messages = max 0 (get_int args "tail_messages" 5) in
-      let tail_compactions = max 0 (get_int args "tail_compactions" 10) in
-      let tail_bytes = max 1_000 (get_int args "tail_bytes" 60_000) in
-      let fast = get_bool args "fast" (keeper_status_fast_default ()) in
-      let tail_order = tail_order_of_args args in
-      let include_context = get_bool args "include_context" (not fast) in
-      let include_metrics_overview =
-        get_bool args "include_metrics_overview" (not fast)
-      in
-      let include_memory_bank = get_bool args "include_memory_bank" (not fast) in
-      let include_history_tail = get_bool args "include_history_tail" (not fast) in
-      let include_compaction_history =
-        get_bool args "include_compaction_history" (not fast)
+      let
+        { tail_turns
+        ; tail_messages
+        ; tail_compactions
+        ; tail_bytes
+        ; tail_order
+        ; fast
+        ; include_context
+        ; include_metrics_overview
+        ; include_memory_bank
+        ; include_history_tail
+        ; include_compaction_history
+        }
+        = options
       in
       let max_context_resolution =
         Keeper_context_runtime.resolve_max_context_resolution_of_meta m
@@ -915,6 +935,10 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
              ("token_gate_enabled", `Bool (compact_token_gate > 0));
            ]);
            ("status_options", `Assoc [
+             ("tail_turns", `Int tail_turns);
+             ("tail_messages", `Int tail_messages);
+             ("tail_compactions", `Int tail_compactions);
+             ("tail_bytes", `Int tail_bytes);
              ("fast", `Bool fast);
              ("include_context", `Bool include_context);
              ("include_metrics_overview", `Bool include_metrics_overview);
@@ -1013,7 +1037,7 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
          ]) in
          Eio_guard.with_mutex cache_mu (fun () ->
            Hashtbl.replace _cache cache_key
-             { updated_at = m.updated_at; args_hash; response = json });
+             { updated_at = m.updated_at; cache_input; response = json });
          tool_result_ok_data json)
 (* TEL-OK: 1-line delegate to ctx-free body. *)
 let handle_keeper_status (ctx : _ context) args = handle_keeper_status_config ~config:ctx.config ~agent_name:ctx.agent_name args

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -933,6 +933,22 @@ let should_persist_directive_paused_state directive (meta : Keeper_meta_contract
   | Keeper_directive.Pause | Keeper_directive.Wakeup
   | Keeper_directive.Assign_task _ -> not (Bool.equal meta.paused paused)
 
+type resume_registration =
+  | Already_registered
+  | Booted_missing_registry
+
+type paused_state_persist_plan =
+  | Persist_paused_state of bool
+  | Skip_paused_state_persist
+
+let paused_state_persist_plan directive registration =
+  match directive, registration with
+  | Keeper_directive.Pause, _ -> Persist_paused_state true
+  | Keeper_directive.Resume, Already_registered -> Persist_paused_state false
+  | Keeper_directive.Resume, Booted_missing_registry -> Skip_paused_state_persist
+  | Keeper_directive.Wakeup, _
+  | Keeper_directive.Assign_task _, _ -> Skip_paused_state_persist
+
 let persist_directive_paused_state ~config ~name ~action_str directive meta paused =
   let updated_meta = meta_with_directive_paused_state meta paused in
     (* Pause/resume toggle via CAS merge: do not rewind a concurrent
@@ -963,14 +979,14 @@ let persist_directive_paused_state ~config ~name ~action_str directive meta paus
 let ensure_registered_for_resume ~sw ~clock state agent_name name =
   let config = Mcp_server.workspace_config state in
   match Keeper_registry.get ~base_path:config.base_path name with
-  | Some _ -> Ok `Already_registered
+  | Some _ -> Ok Already_registered
   | None ->
       let keeper_ctx = keeper_ctx_of_dashboard_state ~sw ~clock state agent_name in
       let args = `Assoc [ ("name", `String name) ] in
       (match Keeper_tool_surface.dispatch keeper_ctx ~name:"masc_keeper_up" ~args with
        | Some result when Tool_result.is_success result ->
            (match Keeper_registry.get ~base_path:config.base_path name with
-            | Some _ -> Ok `Booted_missing_registry
+            | Some _ -> Ok Booted_missing_registry
             | None ->
                 Error
                   (Printf.sprintf
@@ -1059,13 +1075,9 @@ let handle_keeper_directive_post ~sw ~clock state agent_name req reqd body_str =
                 reqd
           | Ok registration_state ->
               let persist_result =
-                match directive, registration_state with
-                | Keeper_directive.Pause, _ -> persist_paused_state true
-                | Keeper_directive.Resume, `Already_registered ->
-                  persist_paused_state false
-                | Keeper_directive.Resume, `Booted_missing_registry -> Ok ()
-                | Keeper_directive.Wakeup, _
-                | Keeper_directive.Assign_task _, _ -> Ok ()
+                match paused_state_persist_plan directive registration_state with
+                | Persist_paused_state paused -> persist_paused_state paused
+                | Skip_paused_state_persist -> Ok ()
               in
               (match persist_result with
               | Error err ->
@@ -1259,26 +1271,31 @@ let handle_keeper_bulk_directive_post ~sw ~clock state agent_name req reqd body_
                | Keeper_directive.Resume ->
                  ensure_registered_for_resume ~sw ~clock state agent_name name
                | Keeper_directive.Pause | Keeper_directive.Wakeup
-               | Keeper_directive.Assign_task _ -> Ok `Already_registered
+               | Keeper_directive.Assign_task _ -> Ok Already_registered
              with
              | Error err ->
                  `Assoc
                    [ ("name", `String name); ("ok", `Bool false); ("error", `String err) ]
              | Ok registration_state ->
                  let persist_result =
-                   match directive, registration_state, target_paused, meta_opt with
-                   | Keeper_directive.Resume, `Booted_missing_registry, _, _ -> Ok ()
-                   | _, _, Some target, Some meta
-                     when should_persist_directive_paused_state directive meta target
-                     ->
-                       persist_directive_paused_state
-                         ~config
-                         ~name
-                         ~action_str
-                         directive
-                         meta
-                         target
-                   | _ -> Ok ()
+                   match paused_state_persist_plan directive registration_state with
+                   | Persist_paused_state target ->
+                     (match target_paused, meta_opt with
+                      | Some target_paused, Some meta
+                        when Bool.equal target target_paused
+                             && should_persist_directive_paused_state
+                                  directive
+                                  meta
+                                  target ->
+                        persist_directive_paused_state
+                          ~config
+                          ~name
+                          ~action_str
+                          directive
+                          meta
+                          target
+                      | _ -> Ok ())
+                   | Skip_paused_state_persist -> Ok ()
                  in
                  (match persist_result with
                   | Error err ->

--- a/lib/server/server_dashboard_http_keeper_api_post.mli
+++ b/lib/server/server_dashboard_http_keeper_api_post.mli
@@ -69,6 +69,17 @@ val refresh_keeper_execution_surfaces :
 val invalidate_keeper_execution_surfaces :
   config:Workspace_utils.config -> unit -> unit
 
+type resume_registration =
+  | Already_registered
+  | Booted_missing_registry
+
+type paused_state_persist_plan =
+  | Persist_paused_state of bool
+  | Skip_paused_state_persist
+
+val paused_state_persist_plan :
+  Keeper_directive.t -> resume_registration -> paused_state_persist_plan
+
 val handle_keeper_config_post :
   sw:Eio.Switch.t ->
   clock:[> float Eio.Time.clock_ty ] Eio.Time.clock ->

--- a/mk/test.mk
+++ b/mk/test.mk
@@ -39,7 +39,7 @@ clean-tlc-artifacts:
 coverage:
 	rm -rf _coverage
 	mkdir -p _coverage
-	CI_TEST_TIMEOUT_SEC=1200 CI_TEST_HEARTBEAT_SEC=30 scripts/ci-run-tests.sh "BISECT_FILE=$(CURDIR)/_coverage/bisect scripts/dune-local.sh test --instrument-with bisect_ppx --force"
+	CI_TEST_HEARTBEAT_SEC=30 scripts/ci-run-tests.sh "BISECT_FILE=$(CURDIR)/_coverage/bisect scripts/dune-local.sh test --instrument-with bisect_ppx --force"
 
 # Print coverage summary to stdout
 coverage-summary: coverage

--- a/scripts/ci-run-tests.sh
+++ b/scripts/ci-run-tests.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# CI test observer. The workflow job owns the outer execution boundary.
+# Test observer. The invoking lifecycle owns the outer execution boundary
+# (the workflow job in CI, or the foreground parent for local invocations).
 # This script reports progress and diagnostics, but never terminates or retries
-# the command it observes.
+# the command it observes except when its own lifecycle is cancelled.
 
 mktemp_ci_log() {
   local tmp_dir="${TMPDIR:-/tmp}"
@@ -187,8 +188,7 @@ effective_test_cmd() {
   fi
 }
 
-kill_active_cmd_tree() {
-  local signal="${1:-TERM}"
+terminate_active_cmd_tree() {
   local tree_pids=()
   local pid=""
   while IFS= read -r pid; do
@@ -196,22 +196,46 @@ kill_active_cmd_tree() {
   done < <(active_cmd_tree_pids)
   local idx=0
   for (( idx=${#tree_pids[@]}-1; idx>=0; idx-- )); do
-    kill "-${signal}" "${tree_pids[idx]}" >/dev/null 2>&1 || true
+    kill -TERM "${tree_pids[idx]}" >/dev/null 2>&1 || true
   done
+  # Cancellation must converge even when a child ignores TERM. Reuse the
+  # captured tree so descendants that become reparented after TERM are still
+  # terminated; no wall-clock grace-period heuristic is introduced here.
+  for (( idx=${#tree_pids[@]}-1; idx>=0; idx-- )); do
+    kill -KILL "${tree_pids[idx]}" >/dev/null 2>&1 || true
+  done
+  if [[ -n "${ACTIVE_CMD_PID}" ]]; then
+    wait "${ACTIVE_CMD_PID}" >/dev/null 2>&1 || true
+  fi
+  ACTIVE_CMD_PID=""
+  ACTIVE_CMD_PGID=""
 }
 
 hb_pid=""
-cleanup() {
-  if [[ -n "${ACTIVE_CMD_PID}" ]] && kill -0 "${ACTIVE_CMD_PID}" >/dev/null 2>&1; then
-    kill_active_cmd_tree TERM
-    wait "${ACTIVE_CMD_PID}" >/dev/null 2>&1 || true
-  fi
+stop_observation_helpers() {
   [[ -z "${hb_pid}" ]] || kill "${hb_pid}" >/dev/null 2>&1 || true
   [[ -z "${ACTIVE_LOG_TAIL_PID}" ]] || kill "${ACTIVE_LOG_TAIL_PID}" >/dev/null 2>&1 || true
+  hb_pid=""
+  ACTIVE_LOG_TAIL_PID=""
+}
+
+cleanup() {
+  terminate_active_cmd_tree
+  stop_observation_helpers
+}
+
+handle_signal() {
+  local signal_name="$1"
+  local exit_code="$2"
+  diag_dump "signal_${signal_name}"
+  terminate_active_cmd_tree
+  stop_observation_helpers
+  trap - EXIT INT TERM
+  exit "${exit_code}"
 }
 trap cleanup EXIT
-trap 'cleanup; exit 130' INT
-trap 'cleanup; exit 143' TERM
+trap 'handle_signal INT 130' INT
+trap 'handle_signal TERM 143' TERM
 
 run_observed() {
   local cmd="$1"

--- a/test/dune
+++ b/test/dune
@@ -115,6 +115,7 @@
   test_server_keeper_background
   test_server_dashboard_http_legacy_keeper_inventory
   test_server_dashboard_http_keeper_api_trace
+  test_keeper_directive_persist_plan
   eval_memory_os_value
   test_keeper_reconcile_state
   test_attempt_state
@@ -435,6 +436,7 @@
   test_server_keeper_background
   test_server_dashboard_http_legacy_keeper_inventory
   test_server_dashboard_http_keeper_api_trace
+  test_keeper_directive_persist_plan
   eval_memory_os_value
   test_keeper_reconcile_state
   test_attempt_state

--- a/test/test_ci_run_tests_script.ml
+++ b/test/test_ci_run_tests_script.ml
@@ -95,6 +95,61 @@ let run_ci ?(env = []) ~cwd command =
   let script = script_path () in
   run_process ~cwd ~env script [| script; command |]
 
+let run_ci_then_signal ~cwd ~env ~ready_file command =
+  let script = script_path () in
+  let out = Filename.temp_file "ci-run-tests-signal-out" ".txt" in
+  let err = Filename.temp_file "ci-run-tests-signal-err" ".txt" in
+  let out_fd = Unix.openfile out [ Unix.O_WRONLY; Unix.O_TRUNC ] 0o600 in
+  let err_fd = Unix.openfile err [ Unix.O_WRONLY; Unix.O_TRUNC ] 0o600 in
+  let original_cwd = Sys.getcwd () in
+  let pid =
+    Fun.protect
+      ~finally:(fun () ->
+        Sys.chdir original_cwd;
+        Unix.close out_fd;
+        Unix.close err_fd)
+      (fun () ->
+        Sys.chdir cwd;
+        Unix.create_process_env script [| script; command |] (env_array env)
+          Unix.stdin out_fd err_fd)
+  in
+  let rec await_ready remaining =
+    if Sys.file_exists ready_file then ()
+    else if remaining = 0 then fail "observed command did not become ready"
+    else (
+      Unix.sleepf 0.01;
+      await_ready (remaining - 1))
+  in
+  let waitpid_nointr () =
+    let rec wait () =
+      try Unix.waitpid [] pid
+      with Unix.Unix_error (Unix.EINTR, _, _) -> wait ()
+    in
+    wait ()
+  in
+  let _, status =
+    Fun.protect
+      ~finally:(fun () ->
+        try
+          Unix.kill pid Sys.sigkill;
+          ignore (Unix.waitpid [] pid)
+        with Unix.Unix_error (Unix.ESRCH | Unix.ECHILD, _, _) -> ())
+      (fun () ->
+        await_ready 500;
+        Unix.kill pid Sys.sigterm;
+        waitpid_nointr ())
+  in
+  let code =
+    match status with
+    | Unix.WEXITED code -> code
+    | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> 255
+  in
+  let stdout = read_file out in
+  let stderr = read_file err in
+  Sys.remove out;
+  Sys.remove err;
+  code, stdout, stderr
+
 let base_env log_file =
   [
     ("CI_TEST_HEARTBEAT_SEC", "1");
@@ -184,6 +239,23 @@ let test_contract_harness_runs_once () =
       check bool "contract success reported" true
         (contains_substring observed "contract harness completed successfully"))
 
+let test_signal_dumps_diagnostics_and_converges () =
+  with_temp_dir "ci-run-tests-signal" (fun dir ->
+      let ci_log = Filename.concat dir "ci.log" in
+      let ready_file = Filename.concat dir "ready" in
+      let command =
+        Printf.sprintf
+          "printf ready > %s; trap '' TERM INT; while :; do sleep 1; done"
+          (Filename.quote ready_file)
+      in
+      let code, stdout, stderr =
+        run_ci_then_signal ~cwd:dir ~env:(base_env ci_log) ~ready_file command
+      in
+      check int "TERM exit code" 143 code;
+      let observed = String.concat "\n" [ read_file ci_log; stdout; stderr ] in
+      check bool "signal diagnostics emitted" true
+        (contains_substring observed "[ci-diag] reason=signal_TERM"))
+
 let test_control_layers_are_absent () =
   let script = read_file (script_path ()) in
   List.iter
@@ -211,6 +283,8 @@ let () =
             test_legacy_deadline_knob_does_not_terminate_command;
           test_case "contract harness runs once" `Quick
             test_contract_harness_runs_once;
+          test_case "signal diagnostics converge" `Quick
+            test_signal_dumps_diagnostics_and_converges;
           test_case "control layers are absent" `Quick
             test_control_layers_are_absent;
         ] );

--- a/test/test_cross_context_mutex.ml
+++ b/test/test_cross_context_mutex.ml
@@ -88,6 +88,70 @@ let test_exception_does_not_poison_lock () =
   Alcotest.(check int) "lock is reusable" 42 (Lock.with_lock lock (fun () -> 42))
 ;;
 
+let test_cancelled_holder_releases_lock () =
+  Eio_main.run @@ fun _env ->
+  let lock = Lock.create () in
+  let cancellation_propagated =
+    match
+      Eio.Cancel.sub (fun cancellation_context ->
+        Lock.with_lock lock (fun () ->
+          Eio.Cancel.cancel cancellation_context Exit;
+          Eio.Fiber.check ()))
+    with
+    | () -> false
+    | exception Eio.Cancel.Cancelled Exit -> true
+    | exception Eio.Cancel.Cancelled cause ->
+      Alcotest.failf "unexpected cancellation cause: %s" (Printexc.to_string cause)
+  in
+  Alcotest.(check bool) "holder cancellation propagates" true cancellation_propagated;
+  Alcotest.(check int)
+    "holder cancellation releases both gates"
+    42
+    (Lock.with_lock lock (fun () -> 42))
+;;
+
+let test_cancelled_waiter_releases_eio_gate () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun sw ->
+  let lock = Lock.create () in
+  let owner_entered, resolve_owner_entered = Eio.Promise.create () in
+  let release_owner, resolve_release_owner = Eio.Promise.create () in
+  Eio.Fiber.fork ~sw (fun () ->
+    Lock.with_lock lock (fun () ->
+      Eio.Promise.resolve resolve_owner_entered ();
+      Eio.Promise.await release_owner));
+  Eio.Promise.await owner_entered;
+  let waiter_context, resolve_waiter_context = Eio.Promise.create () in
+  let waiter_attempted = Atomic.make false in
+  let waiter_entered = Atomic.make false in
+  let waiter_cancelled, resolve_waiter_cancelled = Eio.Promise.create () in
+  Eio.Fiber.fork ~sw (fun () ->
+    match
+      Eio.Cancel.sub (fun cancellation_context ->
+        Eio.Promise.resolve resolve_waiter_context cancellation_context;
+        Atomic.set waiter_attempted true;
+        Lock.with_lock lock (fun () -> Atomic.set waiter_entered true))
+    with
+    | () -> Alcotest.fail "cancelled waiter unexpectedly acquired the lock"
+    | exception Eio.Cancel.Cancelled Exit ->
+      Eio.Promise.resolve resolve_waiter_cancelled ()
+    | exception Eio.Cancel.Cancelled cause ->
+      Alcotest.failf "unexpected cancellation cause: %s" (Printexc.to_string cause));
+  let cancellation_context = Eio.Promise.await waiter_context in
+  await_atomic waiter_attempted;
+  Eio.Cancel.cancel cancellation_context Exit;
+  Eio.Promise.await waiter_cancelled;
+  Alcotest.(check bool)
+    "cancelled waiter never enters the critical section"
+    false
+    (Atomic.get waiter_entered);
+  Eio.Promise.resolve resolve_release_owner ();
+  Alcotest.(check int)
+    "waiter cancellation releases the Eio gate"
+    42
+    (Lock.with_lock lock (fun () -> 42))
+;;
+
 let () =
   Alcotest.run
     "cross-context-mutex"
@@ -98,6 +162,10 @@ let () =
             test_domain_owner_and_eio_waiter_share_lock
         ; Alcotest.test_case "callback exception releases lock" `Quick
             test_exception_does_not_poison_lock
+        ; Alcotest.test_case "holder cancellation releases lock" `Quick
+            test_cancelled_holder_releases_lock
+        ; Alcotest.test_case "waiter cancellation releases Eio gate" `Quick
+            test_cancelled_waiter_releases_eio_gate
         ] )
     ]
 ;;

--- a/test/test_keeper_directive_persist_plan.ml
+++ b/test/test_keeper_directive_persist_plan.ml
@@ -1,0 +1,162 @@
+open Alcotest
+open Masc
+
+module Post = Server_dashboard_http_keeper_api_post
+
+let plan = Post.paused_state_persist_plan
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then (
+      Sys.readdir path
+      |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path)
+    else Sys.remove path
+;;
+
+let rec mkdir_p path =
+  if not (Sys.file_exists path) then (
+    let parent = Filename.dirname path in
+    if not (String.equal parent path) then mkdir_p parent;
+    Unix.mkdir path 0o700)
+;;
+
+let with_temp_dir f =
+  let path = Filename.temp_file "keeper-directive-plan-" "" in
+  Sys.remove path;
+  Unix.mkdir path 0o700;
+  Fun.protect ~finally:(fun () -> rm_rf path) (fun () -> f path)
+;;
+
+let response_status response =
+  match String.split_on_char ' ' response with
+  | _ :: status :: _ -> int_of_string status
+  | _ -> failf "invalid HTTP response: %S" response
+;;
+
+let directive_response ~base_path ~name ~body =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio.Switch.run
+  @@ fun sw ->
+  let state = Mcp_server_eio.For_testing.create_state ~base_path () in
+  let target = Printf.sprintf "/api/v1/keepers/%s/directive" name in
+  let response = Buffer.create 512 in
+  let connection =
+    Httpun.Server_connection.create (fun reqd ->
+      Post.handle_keeper_directive_post
+        ~sw
+        ~clock:(Eio.Stdenv.clock env)
+        state
+        "operator"
+        (Httpun.Reqd.request reqd)
+        reqd
+        body)
+  in
+  let request =
+    Printf.sprintf "POST %s HTTP/1.1\r\nhost: localhost\r\ncontent-length: 0\r\n\r\n" target
+  in
+  let bytes = Bigstringaf.of_string ~off:0 ~len:(String.length request) request in
+  let consumed =
+    Httpun.Server_connection.read_eof
+      connection
+      bytes
+      ~off:0
+      ~len:(Bigstringaf.length bytes)
+  in
+  check int "complete request consumed" (Bigstringaf.length bytes) consumed;
+  let rec flush () =
+    match Httpun.Server_connection.next_write_operation connection with
+    | `Write iovecs ->
+      let written =
+        List.fold_left
+          (fun total (iov : Bigstringaf.t Httpun.IOVec.t) ->
+             Buffer.add_string
+               response
+               (Bigstringaf.substring iov.buffer ~off:iov.off ~len:iov.len);
+             total + iov.len)
+          0
+          iovecs
+      in
+      Httpun.Server_connection.report_write_result connection (`Ok written);
+      flush ()
+    | `Yield | `Close _ -> ()
+  in
+  flush ();
+  Buffer.contents response
+;;
+
+let test_paused_state_persist_plan () =
+  check bool
+    "pause persists true for an existing registration"
+    true
+    (plan Keeper_directive.Pause Post.Already_registered
+     = Post.Persist_paused_state true);
+  check bool
+    "pause persists true after registration recovery"
+    true
+    (plan Keeper_directive.Pause Post.Booted_missing_registry
+     = Post.Persist_paused_state true);
+  check bool
+    "resume persists false for an existing registration"
+    true
+    (plan Keeper_directive.Resume Post.Already_registered
+     = Post.Persist_paused_state false);
+  check bool
+    "resume recovery does not overwrite freshly booted metadata"
+    true
+    (plan Keeper_directive.Resume Post.Booted_missing_registry
+     = Post.Skip_paused_state_persist);
+  check bool
+    "wakeup does not mutate paused state"
+    true
+    (plan Keeper_directive.Wakeup Post.Already_registered
+     = Post.Skip_paused_state_persist)
+;;
+
+let test_missing_meta_is_not_a_silent_pause_success () =
+  with_temp_dir
+  @@ fun base_path ->
+  let response =
+    directive_response
+      ~base_path
+      ~name:"missing-meta"
+      ~body:{|{"action":"pause"}|}
+  in
+  check int "missing meta is not found" 404 (response_status response)
+;;
+
+let test_malformed_meta_is_an_explicit_pause_failure () =
+  with_temp_dir
+  @@ fun base_path ->
+  let config = Workspace.default_config base_path in
+  let path = Keeper_types_profile.keeper_meta_path config "malformed-meta" in
+  mkdir_p (Filename.dirname path);
+  Out_channel.with_open_bin path (fun channel ->
+    output_string channel {|{"name":|});
+  let response =
+    directive_response
+      ~base_path
+      ~name:"malformed-meta"
+      ~body:{|{"action":"pause"}|}
+  in
+  check int "malformed meta is an internal error" 500 (response_status response)
+;;
+
+let () =
+  run
+    "keeper_directive_persist_plan"
+    [ ( "planner"
+      , [ test_case "typed paused-state plan" `Quick test_paused_state_persist_plan
+        ; test_case
+            "missing meta pause fails explicitly"
+            `Quick
+            test_missing_meta_is_not_a_silent_pause_success
+        ; test_case
+            "malformed meta pause fails explicitly"
+            `Quick
+            test_malformed_meta_is_an_explicit_pause_failure
+        ] )
+    ]
+;;

--- a/test/test_keeper_effective_meta_overlay.ml
+++ b/test/test_keeper_effective_meta_overlay.ml
@@ -193,6 +193,17 @@ let status_json_with ?(agent_name = "test-agent") ?name config =
     Alcotest.failf "status failed: %s" (Profile.tool_result_body result);
   Yojson.Safe.from_string (Profile.tool_result_body result)
 
+let status_json_with_args config args =
+  let result =
+    Status_detail.handle_keeper_status_config
+      ~config
+      ~agent_name:"test-agent"
+      args
+  in
+  if not (Profile.tool_result_success result) then
+    Alcotest.failf "status failed: %s" (Profile.tool_result_body result);
+  Yojson.Safe.from_string (Profile.tool_result_body result)
+
 let resolved_keeper_name config name =
   match
     Keeper_tool_surface_ops.resolve_keeper_name_config
@@ -590,6 +601,75 @@ let test_status_cache_tracks_toml_overlay_changes () =
     "second cache instructions after toml edit"
     (status_instructions config name)
 
+let test_status_cache_distinguishes_normalized_options () =
+  with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir ->
+  let name = "status-options-cache" in
+  write_keeper_toml ~keepers_dir ~name ~sandbox_profile:"local"
+    ~instructions:"normalized status options";
+  let config = Workspace.default_config base in
+  ignore (seed_runtime_meta config name : Masc.Keeper_meta_contract.keeper_meta);
+  Status_detail.invalidate_status_cache_all ();
+  let common_fields =
+    [ "name", `String name
+    ; "fast", `Bool false
+    ; "include_metrics_overview", `Bool false
+    ; "include_memory_bank", `Bool false
+    ; "include_history_tail", `Bool false
+    ; "include_compaction_history", `Bool false
+    ]
+  in
+  let context_enabled = status_json_with_args config (`Assoc common_fields) in
+  Alcotest.(check (option bool))
+    "derived include_context default is true"
+    (Some true)
+    (json_assoc_field "status_options" context_enabled
+     |> json_bool_field "include_context");
+  let context_disabled =
+    status_json_with_args config
+      (`Assoc (("include_context", `Bool false) :: common_fields))
+  in
+  Alcotest.(check (option bool))
+    "explicit include_context false is not served from the prior cache entry"
+    (Some false)
+    (json_assoc_field "status_options" context_disabled
+     |> json_bool_field "include_context");
+  Alcotest.(check (option bool))
+    "disabled context is observable"
+    (Some true)
+    (json_assoc_field "context" context_disabled |> json_bool_field "skipped");
+  let first_window =
+    status_json_with_args config
+      (`Assoc
+        [ "name", `String name
+        ; "fast", `Bool true
+        ; "tail_compactions", `Int 1
+        ; "tail_bytes", `Int 1
+        ])
+  in
+  let first_options = json_assoc_field "status_options" first_window in
+  Alcotest.(check (option int))
+    "tail bytes clamp is observable"
+    (Some 1_000)
+    (json_int_field "tail_bytes" first_options);
+  let second_window =
+    status_json_with_args config
+      (`Assoc
+        [ "name", `String name
+        ; "fast", `Bool true
+        ; "tail_compactions", `Int 7
+        ; "tail_bytes", `Int 8_000
+        ])
+  in
+  let second_options = json_assoc_field "status_options" second_window in
+  Alcotest.(check (option int))
+    "tail compaction window participates in cache identity"
+    (Some 7)
+    (json_int_field "tail_compactions" second_options);
+  Alcotest.(check (option int))
+    "tail byte window participates in cache identity"
+    (Some 8_000)
+    (json_int_field "tail_bytes" second_options)
+
 let test_status_surfaces_chat_queue_runtime () =
   with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir ->
   let name = "chatqueue-status" in
@@ -807,6 +887,8 @@ let () =
             `Quick test_missing_profile_source_fails_loud;
           Alcotest.test_case "status cache tracks TOML overlay edits" `Quick
             test_status_cache_tracks_toml_overlay_changes;
+          Alcotest.test_case "status cache distinguishes normalized options"
+            `Quick test_status_cache_distinguishes_normalized_options;
           Alcotest.test_case "status surfaces chat queue runtime" `Quick
             test_status_surfaces_chat_queue_runtime;
           Alcotest.test_case "keeper list surfaces effective meta errors"

--- a/test/test_keeper_mutex_coverage.ml
+++ b/test/test_keeper_mutex_coverage.ml
@@ -420,6 +420,64 @@ let test_keeper_msg_async_does_not_accept_failed_initial_persistence () =
            (Keeper_msg_async.submit_outcome_to_json outcome |> Yojson.Safe.to_string))
 ;;
 
+let test_keeper_msg_async_reports_request_store_inspection_failure () =
+  with_eio_env
+  @@ fun _env ->
+  Eio.Switch.run
+  @@ fun background_sw ->
+  let base_path = temp_dir "keeper-msg-inspection-failure-" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_msg_async.For_testing.clear ();
+      rm_rf base_path)
+    (fun () ->
+       let generated = Atomic.make 0 in
+       let worker_ran = Atomic.make false in
+       let request_ops =
+         Keeper_msg_async.For_testing.make_request_ops
+           ~before_request_store_inspection:(fun () ->
+             raise (Unix.Unix_error (Unix.EIO, "lstat", "request-store")))
+           ~generate_request_id:(fun () ->
+             Atomic.incr generated;
+             "kmsg-inspection-must-not-reserve")
+           ()
+       in
+       match
+         Keeper_msg_async.For_testing.submit
+           request_ops
+           ~background_sw
+           ~base_path
+           ~caller
+           ~keeper_name:"inspection-failure"
+           ~f:(fun _request_sw ->
+             Atomic.set worker_ran true;
+             tr_ok "{}")
+           ()
+       with
+       | Error
+           (Keeper_msg_async.Request_store_inspection_failed { path; reason = _ }) ->
+         Alcotest.(check string)
+           "error identifies the request store"
+           (Filename.concat
+              (Common.masc_dir_from_base_path ~base_path)
+              "keeper_msg_requests")
+           path;
+         Alcotest.(check int) "request id was not generated" 0
+           (Atomic.get generated);
+         Alcotest.(check bool) "worker was not started" false
+           (Atomic.get worker_ran);
+         Alcotest.(check int) "no request id was reserved" 0
+           (Keeper_msg_async.For_testing.reserved_request_id_count ())
+       | Error error ->
+         Alcotest.failf
+           "expected request store inspection failure, got %s"
+           (Keeper_msg_async.submit_error_to_json error |> Yojson.Safe.to_string)
+       | Ok outcome ->
+         Alcotest.failf
+           "request store inspection failure was accepted: %s"
+           (Keeper_msg_async.submit_outcome_to_json outcome |> Yojson.Safe.to_string))
+;;
+
 let fail_once_on_write_stage expected =
   let armed = Atomic.make true in
   fun actual ->
@@ -2563,6 +2621,10 @@ let () =
             "initial persistence failure is not accepted"
             `Quick
             test_keeper_msg_async_does_not_accept_failed_initial_persistence
+        ; test_case
+            "request store inspection failure is typed"
+            `Quick
+            test_keeper_msg_async_reports_request_store_inspection_failure
         ; test_case
             "request id collision uses reservation index"
             `Quick

--- a/test/test_keeper_runtime_trust_snapshot.ml
+++ b/test/test_keeper_runtime_trust_snapshot.ml
@@ -500,7 +500,7 @@ let test_runtime_blocker_supersedes_completion_observation () =
          |> Masc.Keeper_meta_contract.map_runtime (fun rt ->
            { rt with
              last_blocker = Some blocker
-           ; usage = { rt.usage with last_turn_ts = 1_800_000_000.0 }
+           ; usage = { rt.usage with last_turn_ts = Time_compat.now () }
            })
        in
        let receipt_store =


### PR DESCRIPTION
## Summary
- normalize keeper status options once and use the typed record as the cache identity
- return a typed request-store inspection failure while preserving Eio cancellation
- make CI observer cancellation diagnostic and convergent without adding a timeout heuristic
- centralize pause/resume persistence planning and replace deleted source-string checks with behavioral HTTP tests
- remove the future-dated runtime trust fixture

## Validation
- `opam exec -- ocamlformat --check` on all touched OCaml files
- `bash -n scripts/ci-run-tests.sh`
- signal smoke: TERM-ignoring observed child -> diagnostic `signal_TERM`, exit 143, no surviving child
- `git diff --check`
- focused/full Dune verification intentionally delegated to PR CI per repository policy