### PR TITLE
refactor(runtime): hide breaker policy internals

### DIFF
--- a/lib/core/circuit_breaker.ml
+++ b/lib/core/circuit_breaker.ml
@@ -174,15 +174,6 @@ let get_status t ~agent_id =
         }
   )
 
-let status_to_json (s : breaker_status) : Yojson.Safe.t =
-  `Assoc [
-    ("agent_id", `String s.agent_id);
-    ("state", `String s.state_name);
-    ("recent_failures", `Int s.recent_failures);
-    ("open_until", Json_util.float_opt_to_json s.open_until);
-    ("open_reason", Json_util.string_opt_to_json s.open_reason);
-  ]
-
 let list_all_breakers t =
   with_lock t (fun () ->
     StringMap.fold (fun agent_id breaker acc ->
@@ -204,24 +195,6 @@ let list_all_breakers t =
     ) t.breakers []
   )
 
-
-(** {1 Cleanup} *)
-
-let cleanup t ~older_than_seconds =
-  with_lock t (fun () ->
-    let now = Time_compat.now () in
-    let threshold = now -. float_of_int older_than_seconds in
-    let removed, kept =
-      StringMap.fold (fun agent_id breaker (n, m) ->
-        match breaker.state with
-        | Closed when breaker.last_check < threshold -> (n + 1, m)
-        | Closed | Open _ | HalfOpen ->
-            (n, StringMap.add agent_id breaker m)
-      ) t.breakers (0, StringMap.empty)
-    in
-    t.breakers <- kept;
-    removed
-  )
 
 (** {1 Global Instance}
 

--- a/lib/core/circuit_breaker.mli
+++ b/lib/core/circuit_breaker.mli
@@ -18,37 +18,11 @@
     [get_or_create_breaker], [prune_old_failures] stay private —
     callers do not need Map / mutex / pruning primitives. *)
 
-(** {1 State machine} *)
-
-(** Breaker state — closed (normal), open (cooldown), half-open
-    (recovery probe). *)
-type state =
-  | Closed
-      (** Normal operation — calls flow through. *)
-  | Open of {
-      until : float;
-          (** Unix timestamp at which to retry. *)
-      reason : string;
-          (** Last failure reason that triggered open. *)
-      failure_count : int;
-          (** Number of failures inside the window when opening. *)
-    }
-      (** Legacy cooldown observation. It does not suppress execution. *)
-  | HalfOpen
-      (** Legacy recovery observation. It does not grant execution. *)
-
-(** {1 Records (concrete — for introspection)} *)
+(** {1 Records} *)
 
 type failure_record = {
   timestamp : float;
   reason : string;
-}
-
-type breaker = {
-  agent_id : string;
-  state : state;
-  failures : failure_record list;
-  last_check : float;
 }
 
 (** {1 Instance (abstract)} *)
@@ -71,11 +45,6 @@ val create :
 (** [create ?failure_threshold ?failure_window ?cooldown ()] returns
     a fresh instance with an empty breaker map.  Defaults match
     the [default_*] constants above. *)
-
-val create_default : unit -> t
-(** [create_default ()] creates an instance with all defaults.
-    Pinned at the contract seam — future config-driven overrides
-    reuse this entry without breaking callers. *)
 
 (** {1 Lifecycle} *)
 
@@ -108,37 +77,13 @@ val get_status : t -> agent_id:string -> breaker_status
     no breaker exists for [agent_id], returns a synthetic "closed"
     status (no side effects). *)
 
-val status_to_json : breaker_status -> Yojson.Safe.t
-(** Hand-written serialiser.  Output schema:
-
-    {[
-      \{
-        "agent_id": <string>,
-        "state": <"closed"|"open"|"half_open">,
-        "recent_failures": <int>,
-        "open_until": <float|null>,
-        "open_reason": <string|null>
-      \}
-    ]} *)
 val list_all_breakers : t -> breaker_status list
-
-
-(** {1 Maintenance} *)
-
-val cleanup : t -> older_than_seconds:int -> int
-(** [cleanup t ~older_than_seconds] removes [Closed] breakers
-    whose [last_check] is older than [older_than_seconds].
-    Returns the number removed.  Open / half-open breakers are
-    preserved regardless of age. *)
 
 (** {1 Global instance}
 
     Memoized singleton.  Uses Atomic+Stdlib.Mutex rather than {!Eio.Lazy}
     because tests and startup paths can touch the helpers before an Eio
     scheduler exists. *)
-
-val global : unit -> t
-(** Global circuit-breaker instance.  Prefer the [*_global] helpers below. *)
 
 val record_failure_global : agent_id:string -> reason:string -> unit
 val record_success_global : agent_id:string -> unit


### PR DESCRIPTION
## What changed

- stop exporting the Closed/Open/HalfOpen state machine and concrete breaker record
- remove unused status JSON serialization
- remove unused age cleanup API and implementation
- stop exporting singleton construction helpers that have no external caller

## Why

After the execution gate removal, these public surfaces are policy internals with zero production callsites. Hiding/deleting them narrows the next type migration to the facts MASC actually consumes: recorded failures and successful outcomes.

## Validation

- `git diff --check`
- repository-wide callsite audit confirms every removed public function has zero callers
- focused wrapper reached its own isolated Dune invocation after waiting for the valid machine lock; I cancelled only this newly started local build to avoid competing with the ongoing repository work, and did not interrupt another session
- CI remains the build authority

Stacked on #24800. The following stack deletes the private Open/HalfOpen and 3/60/300 implementation and changes the remaining Health projection to typed observations.