### PR TITLE
refactor(runtime): replace breaker state with observations

### DIFF
--- a/lib/core/circuit_breaker.ml
+++ b/lib/core/circuit_breaker.ml
@@ -174,15 +174,6 @@ let get_status t ~agent_id =
         }
   )
 
-let status_to_json (s : breaker_status) : Yojson.Safe.t =
-  `Assoc [
-    ("agent_id", `String s.agent_id);
-    ("state", `String s.state_name);
-    ("recent_failures", `Int s.recent_failures);
-    ("open_until", Json_util.float_opt_to_json s.open_until);
-    ("open_reason", Json_util.string_opt_to_json s.open_reason);
-  ]
-
 let list_all_breakers t =
   with_lock t (fun () ->
     StringMap.fold (fun agent_id breaker acc ->
@@ -204,24 +195,6 @@ let list_all_breakers t =
     ) t.breakers []
   )
 
-
-(** {1 Cleanup} *)
-
-let cleanup t ~older_than_seconds =
-  with_lock t (fun () ->
-    let now = Time_compat.now () in
-    let threshold = now -. float_of_int older_than_seconds in
-    let removed, kept =
-      StringMap.fold (fun agent_id breaker (n, m) ->
-        match breaker.state with
-        | Closed when breaker.last_check < threshold -> (n + 1, m)
-        | Closed | Open _ | HalfOpen ->
-            (n, StringMap.add agent_id breaker m)
-      ) t.breakers (0, StringMap.empty)
-    in
-    t.breakers <- kept;
-    removed
-  )
 
 (** {1 Global Instance}
 

--- a/lib/core/circuit_breaker.ml
+++ b/lib/core/circuit_breaker.ml
@@ -1,15 +1,9 @@
-(** Failure observation for MASC agents
+(** Failure observation for MASC agents.
 
-    Legacy status projection:
-    - 3 failures in 1 minute → 5 minute cooldown
-    - No execution gate, wrapper, or suspension API
-
-    Research basis:
-    - Trust-Vulnerability Paradox (TVP) - arxiv:2510.18563v1
-    - "3+ failures/min" threshold from operational experience
+    Recorded outcomes never classify, delay, or suppress execution.
 
     Implementation: all breaker records are immutable and stored in a
-    persistent [StringMap].  The single mutable field [breakers] in [t]
+    persistent [StringMap].  The single mutable field [observations] in [t]
     is protected by [Eio.Mutex].
 
     @since 0.6.0 - MASC Social v4 Tier 1
@@ -19,55 +13,27 @@ module StringMap = Set_util.StringMap
 
 (** {1 Types} *)
 
-type state =
-  | Closed        (** Normal operation *)
-  | Open of {
-      until: float;     (** Unix timestamp when to retry *)
-      reason: string;   (** Why the breaker opened *)
-      failure_count: int; (** Number of failures that triggered open *)
-    }
-  | HalfOpen      (** Testing if service recovered *)
-
 type failure_record = {
   timestamp: float;
   reason: string;
 }
 
-type breaker = {
+type observation = {
   agent_id: string;
-  state: state;
-  failures: failure_record list;
-  last_check: float;
+  failure_count: int;
+  last_failure: failure_record option;
+  last_success_at: float option;
 }
 
 type t = {
-  mutable breakers: breaker StringMap.t;
+  mutable observations: observation StringMap.t;
   mutex: Eio.Mutex.t;
-  failure_threshold: int;     (** Failures before opening (default: 3) *)
-  failure_window_sec: float;  (** Window to count failures (default: 60s) *)
-  cooldown_sec: float;        (** How long to stay open (default: 300s) *)
 }
-
-(** {1 Configuration} *)
-
-let default_failure_threshold = 3
-let default_failure_window = 60.0    (* 1 minute *)
-let default_cooldown = 300.0         (* 5 minutes *)
 
 (** {1 Creation} *)
 
-let create
-    ?(failure_threshold = default_failure_threshold)
-    ?(failure_window = default_failure_window)
-    ?(cooldown = default_cooldown)
-    () =
-  {
-    breakers = StringMap.empty;
-    mutex = Eio.Mutex.create ();
-    failure_threshold;
-    failure_window_sec = failure_window;
-    cooldown_sec = cooldown;
-  }
+let create () =
+  { observations = StringMap.empty; mutex = Eio.Mutex.create () }
 
 let create_default () = create ()
 
@@ -76,125 +42,60 @@ let create_default () = create ()
 let with_lock t f =
   Eio_guard.with_mutex t.mutex f
 
-(** Write a breaker back to the map. *)
-let put_breaker t breaker =
-  t.breakers <- StringMap.add breaker.agent_id breaker t.breakers
+let put_observation t observation =
+  t.observations <-
+    StringMap.add observation.agent_id observation t.observations
 
-let get_or_create_breaker t ~agent_id =
-  match StringMap.find_opt agent_id t.breakers with
-  | Some b -> b
+let get_or_create_observation t ~agent_id =
+  match StringMap.find_opt agent_id t.observations with
+  | Some observation -> observation
   | None ->
-      let b = {
-        agent_id;
-        state = Closed;
-        failures = [];
-        last_check = Time_compat.now ();
-      } in
-      t.breakers <- StringMap.add agent_id b t.breakers;
-      b
-
-(** Return a new breaker with expired failures removed. *)
-let prune_old_failures t breaker =
-  let threshold = Time_compat.now () -. t.failure_window_sec in
-  { breaker with failures = List.filter (fun f -> f.timestamp > threshold) breaker.failures }
+      let observation =
+        { agent_id; failure_count = 0; last_failure = None; last_success_at = None }
+      in
+      put_observation t observation;
+      observation
 
 (** {1 Core Operations} *)
 
 (** Record a failure for an agent *)
 let record_failure t ~agent_id ~reason =
   with_lock t (fun () ->
-    let breaker = get_or_create_breaker t ~agent_id in
+    let observation = get_or_create_observation t ~agent_id in
     let now = Time_compat.now () in
-    let breaker = { breaker with
-      failures = { timestamp = now; reason } :: breaker.failures } in
-    let breaker = prune_old_failures t breaker in
-    let failure_count = List.length breaker.failures in
-    let breaker =
-      if failure_count >= t.failure_threshold then begin
-        Log.Session.warn "[CircuitBreaker] OPENED for %s: %d failures" agent_id failure_count;
-        { breaker with state = Open {
-          until = now +. t.cooldown_sec;
-          reason = Printf.sprintf "%d failures in %.0fs: %s"
-                     failure_count t.failure_window_sec reason;
-          failure_count;
-        } }
-      end else breaker
+    let observation =
+      { observation with
+        failure_count = observation.failure_count + 1
+      ; last_failure = Some { timestamp = now; reason }
+      }
     in
-    put_breaker t breaker
+    put_observation t observation
   )
 
-(** Record a success - helps transition from HalfOpen to Closed *)
 let record_success t ~agent_id =
   with_lock t (fun () ->
-    let breaker = get_or_create_breaker t ~agent_id in
-    match breaker.state with
-    | HalfOpen ->
-        Log.Session.info "[CircuitBreaker] CLOSED for %s after recovery" agent_id;
-        put_breaker t { breaker with state = Closed; failures = [] }
-    | Closed ->
-        put_breaker t (prune_old_failures t breaker)
-    | Open _ ->
-        ()
+    let observation = get_or_create_observation t ~agent_id in
+    let now = Time_compat.now () in
+    put_observation t { observation with last_success_at = Some now }
   )
 
 (** {1 Status & Statistics} *)
 
-type breaker_status = {
-  agent_id: string;
-  state_name: string;
-  recent_failures: int;
-  open_until: float option;
-  open_reason: string option;
-}
-
-let get_status t ~agent_id =
+let get_observation t ~agent_id =
   with_lock t (fun () ->
-    match StringMap.find_opt agent_id t.breakers with
-    | None -> {
-        agent_id;
-        state_name = "closed";
-        recent_failures = 0;
-        open_until = None;
-        open_reason = None;
-      }
-    | Some breaker ->
-        let breaker = prune_old_failures t breaker in
-        put_breaker t breaker;
-        let state_name, open_until, open_reason = match breaker.state with
-          | Closed -> ("closed", None, None)
-          | HalfOpen -> ("half_open", None, None)
-          | Open { until; reason; _ } -> ("open", Some until, Some reason)
-        in
-        {
-          agent_id;
-          state_name;
-          recent_failures = List.length breaker.failures;
-          open_until;
-          open_reason;
-        }
+    match StringMap.find_opt agent_id t.observations with
+    | None ->
+      { agent_id; failure_count = 0; last_failure = None; last_success_at = None }
+    | Some observation -> observation
   )
 
-let list_all_breakers t =
+let list_all t =
   with_lock t (fun () ->
-    StringMap.fold (fun agent_id breaker acc ->
-      let breaker = prune_old_failures t breaker in
-      put_breaker t breaker;
-      let state_name, open_until, open_reason = match breaker.state with
-        | Closed -> ("closed", None, None)
-        | HalfOpen -> ("half_open", None, None)
-        | Open { until; reason; _ } -> ("open", Some until, Some reason)
-      in
-      let status = {
-        agent_id;
-        state_name;
-        recent_failures = List.length breaker.failures;
-        open_until;
-        open_reason;
-      } in
-      status :: acc
-    ) t.breakers []
+    StringMap.fold
+      (fun _ observation acc -> observation :: acc)
+      t.observations
+      []
   )
-
 
 (** {1 Global Instance}
 
@@ -219,4 +120,4 @@ let global () =
 
 let record_failure_global ~agent_id ~reason = record_failure (global ()) ~agent_id ~reason
 let record_success_global ~agent_id = record_success (global ()) ~agent_id
-let get_status_global ~agent_id = get_status (global ()) ~agent_id
+let get_observation_global ~agent_id = get_observation (global ()) ~agent_id

--- a/lib/core/circuit_breaker.mli
+++ b/lib/core/circuit_breaker.mli
@@ -18,37 +18,11 @@
     [get_or_create_breaker], [prune_old_failures] stay private —
     callers do not need Map / mutex / pruning primitives. *)
 
-(** {1 State machine} *)
-
-(** Breaker state — closed (normal), open (cooldown), half-open
-    (recovery probe). *)
-type state =
-  | Closed
-      (** Normal operation — calls flow through. *)
-  | Open of {
-      until : float;
-          (** Unix timestamp at which to retry. *)
-      reason : string;
-          (** Last failure reason that triggered open. *)
-      failure_count : int;
-          (** Number of failures inside the window when opening. *)
-    }
-      (** Legacy cooldown observation. It does not suppress execution. *)
-  | HalfOpen
-      (** Legacy recovery observation. It does not grant execution. *)
-
-(** {1 Records (concrete — for introspection)} *)
+(** {1 Records} *)
 
 type failure_record = {
   timestamp : float;
   reason : string;
-}
-
-type breaker = {
-  agent_id : string;
-  state : state;
-  failures : failure_record list;
-  last_check : float;
 }
 
 (** {1 Instance (abstract)} *)
@@ -71,11 +45,6 @@ val create :
 (** [create ?failure_threshold ?failure_window ?cooldown ()] returns
     a fresh instance with an empty breaker map.  Defaults match
     the [default_*] constants above. *)
-
-val create_default : unit -> t
-(** [create_default ()] creates an instance with all defaults.
-    Pinned at the contract seam — future config-driven overrides
-    reuse this entry without breaking callers. *)
 
 (** {1 Lifecycle} *)
 
@@ -108,37 +77,13 @@ val get_status : t -> agent_id:string -> breaker_status
     no breaker exists for [agent_id], returns a synthetic "closed"
     status (no side effects). *)
 
-val status_to_json : breaker_status -> Yojson.Safe.t
-(** Hand-written serialiser.  Output schema:
-
-    {[
-      \{
-        "agent_id": <string>,
-        "state": <"closed"|"open"|"half_open">,
-        "recent_failures": <int>,
-        "open_until": <float|null>,
-        "open_reason": <string|null>
-      \}
-    ]} *)
 val list_all_breakers : t -> breaker_status list
-
-
-(** {1 Maintenance} *)
-
-val cleanup : t -> older_than_seconds:int -> int
-(** [cleanup t ~older_than_seconds] removes [Closed] breakers
-    whose [last_check] is older than [older_than_seconds].
-    Returns the number removed.  Open / half-open breakers are
-    preserved regardless of age. *)
 
 (** {1 Global instance}
 
     Memoized singleton.  Uses Atomic+Stdlib.Mutex rather than {!Eio.Lazy}
     because tests and startup paths can touch the helpers before an Eio
     scheduler exists. *)
-
-val global : unit -> t
-(** Global circuit-breaker instance.  Prefer the [*_global] helpers below. *)
 
 val record_failure_global : agent_id:string -> reason:string -> unit
 val record_success_global : agent_id:string -> unit

--- a/lib/core/circuit_breaker.mli
+++ b/lib/core/circuit_breaker.mli
@@ -1,22 +1,16 @@
 (** Circuit_breaker — failure observation for MASC agents.
 
-    This intermediate status projection still groups failures by the legacy
-    window, but exposes no execution gate, wrapper, or administrative
-    suspension API. Recorded status never controls Keeper participation.
+    Recorded failures are immutable diagnostic facts. They do not classify,
+    gate, delay, or suspend Keeper participation.
 
     {b Concurrency}: all breaker records are immutable; the single
-    mutable field [breakers] in the instance is protected by a
+    mutable field [observations] in the instance is protected by a
     private {!Eio.Mutex}.  Safe to call from any fiber.
-
-    {b Research basis}: Trust-Vulnerability Paradox (TVP)
-    [arxiv:2510.18563v1]; the "3+ failures/min" threshold is from
-    operational experience.
 
     @since 0.6.0 — MASC Social v4 Tier 1.
 
-    Internal: [StringMap], [with_lock], [put_breaker],
-    [get_or_create_breaker], [prune_old_failures] stay private —
-    callers do not need Map / mutex / pruning primitives. *)
+    Internal: [StringMap], [with_lock], [put_observation], and
+    [get_or_create_observation] stay private. *)
 
 (** {1 Records} *)
 
@@ -25,59 +19,42 @@ type failure_record = {
   reason : string;
 }
 
+type observation = {
+  agent_id : string;
+  failure_count : int;
+  last_failure : failure_record option;
+  last_success_at : float option;
+}
+
 (** {1 Instance (abstract)} *)
 
 type t
 (** Opaque per-instance handle.  Construct via {!create} or use the
-    pre-built {!global}.  Fields ([breakers], [mutex],
-    [failure_threshold], [failure_window_sec], [cooldown_sec]) are
-    private — callers should not need them. *)
+    pre-built {!global}. *)
 
 
 (** {1 Construction} *)
 
-val create :
-  ?failure_threshold:int ->
-  ?failure_window:float ->
-  ?cooldown:float ->
-  unit ->
-  t
-(** [create ?failure_threshold ?failure_window ?cooldown ()] returns
-    a fresh instance with an empty breaker map.  Defaults match
-    the [default_*] constants above. *)
+val create : unit -> t
+(** [create ()] returns a fresh instance with no observations. *)
 
 (** {1 Lifecycle} *)
 
 val record_failure : t -> agent_id:string -> reason:string -> unit
 (** [record_failure t ~agent_id ~reason] appends a {!failure_record}
-    to the agent's failure list.  When the count inside
-    [t.failure_window_sec] reaches [t.failure_threshold], opens
-    the breaker for [t.cooldown_sec] seconds. *)
+    to the agent's failure history. *)
 
 val record_success : t -> agent_id:string -> unit
-(** [record_success t ~agent_id] clears the agent's failure list.
-    If the breaker was [HalfOpen], transitions to [Closed]. *)
+(** [record_success t ~agent_id] records the successful observation time.
+    It does not erase prior failure facts. *)
 
 (** {1 Introspection} *)
 
-type breaker_status = {
-  agent_id : string;
-  state_name : string;
-      (** ["closed"] / ["open"] / ["half_open"]. *)
-  recent_failures : int;
-      (** Failures inside [t.failure_window_sec], post-prune. *)
-  open_until : float option;
-      (** [Some _] iff [state_name = "open"]. *)
-  open_reason : string option;
-      (** [Some _] iff [state_name = "open"]. *)
-}
+val get_observation : t -> agent_id:string -> observation
+(** Returns the current immutable snapshot. Missing agents have a zero count
+    and no recorded outcome. This read has no side effects. *)
 
-val get_status : t -> agent_id:string -> breaker_status
-(** [get_status t ~agent_id] returns the current snapshot.  When
-    no breaker exists for [agent_id], returns a synthetic "closed"
-    status (no side effects). *)
-
-val list_all_breakers : t -> breaker_status list
+val list_all : t -> observation list
 
 (** {1 Global instance}
 
@@ -87,4 +64,4 @@ val list_all_breakers : t -> breaker_status list
 
 val record_failure_global : agent_id:string -> reason:string -> unit
 val record_success_global : agent_id:string -> unit
-val get_status_global : agent_id:string -> breaker_status
+val get_observation_global : agent_id:string -> observation

--- a/lib/health.ml
+++ b/lib/health.ml
@@ -26,86 +26,46 @@ module Random = Stdlib.Random
 
     @since 2.75.0 *)
 
-(** {1 Types} *)
-
-type health_status =
-  | Healthy
-  | Unhealthy of string  (** reason *)
-  | Recovering           (** half-open, testing *)
-  | Unknown of string    (** Issue #8607: unrecognised circuit-breaker
-                             state_name (carries the raw value for
-                             diagnostics). Previously [_ -> Healthy]
-                             silently masked future state additions
-                             (e.g. a 4th [Throttled]) and any wire-format
-                             drift as a green health signal. *)
-
 type agent_health_summary = {
   agent_name : string;
-  status : health_status;
-  recent_failures : int;
-  cooldown_remaining_sec : int;
+  failure_count : int;
+  last_failure : Circuit_breaker.failure_record option;
+  last_success_at : float option;
 }
 
-(** Record a successful action — clears half-open state. *)
 let record_success ~agent_name =
   Circuit_breaker.record_success_global ~agent_id:agent_name
 
-(** Record a failed action — may open the breaker. *)
 let record_failure ~agent_name ~reason =
   Circuit_breaker.record_failure_global ~agent_id:agent_name ~reason
 
 (** {1 Statistics} *)
 
-(* Issue #8607: shared mapping helper — both get_summary and
-   get_all_summaries used to inline the same 4-arm match with [_ ->
-   Healthy] as the catch-all, so an unknown state_name lied as
-   Healthy. Unifying ensures one place to update; routing the
-   catch-all through [Unknown name] makes drift operator-visible. *)
-let health_status_of_breaker
-    ~(state_name : string)
-    ~(open_reason : string option)
-    : health_status =
-  match state_name with
-  | "closed" -> Healthy
-  | "half_open" -> Recovering
-  | "open" -> Unhealthy (Option.value ~default:"unknown" open_reason)
-  | other -> Unknown other
-
-let cooldown_remaining_of (open_until : float option) : int =
-  match open_until with
-  | Some until ->
-      let remaining = until -. Time_compat.now () in
-      if Stdlib.Float.compare remaining 0.0 > 0 then Int.of_float remaining else 0
-  | None -> 0
-
 (** Get health summary for a single agent. *)
 let get_summary ~agent_name : agent_health_summary =
-  let status = Circuit_breaker.get_status_global ~agent_id:agent_name in
+  let observation =
+    Circuit_breaker.get_observation_global ~agent_id:agent_name
+  in
   {
     agent_name;
-    status =
-      health_status_of_breaker
-        ~state_name:status.state_name
-        ~open_reason:status.open_reason;
-    recent_failures = status.recent_failures;
-    cooldown_remaining_sec = cooldown_remaining_of status.open_until;
+    failure_count = observation.failure_count;
+    last_failure = observation.last_failure;
+    last_success_at = observation.last_success_at;
   }
 
 (** {1 JSON Serialization} *)
 
-let health_status_to_string = function
-  | Healthy -> "healthy"
-  | Unhealthy _ -> "unhealthy"
-  | Recovering -> "recovering"
-  (* Issue #8607: distinct wire string so dashboards/operators can
-     filter for unrecognised breaker states instead of mixing them
-     with green ones. *)
-  | Unknown _ -> "unknown"
+let failure_to_json (failure : Circuit_breaker.failure_record) =
+  `Assoc
+    [ "timestamp", `Float failure.timestamp
+    ; "reason", `String failure.reason
+    ]
 
 let summary_to_json (s : agent_health_summary) : Yojson.Safe.t =
   `Assoc [
     ("agent_name", `String s.agent_name);
-    ("status", `String (health_status_to_string s.status));
-    ("recent_failures", `Int s.recent_failures);
-    ("cooldown_remaining_sec", `Int s.cooldown_remaining_sec);
+    ("failure_count", `Int s.failure_count);
+    ( "last_failure"
+    , Option.fold ~none:`Null ~some:failure_to_json s.last_failure );
+    ("last_success_at", Json_util.float_opt_to_json s.last_success_at);
   ]

--- a/lib/health.mli
+++ b/lib/health.mli
@@ -29,29 +29,17 @@ module Random = Stdlib.Random
 
     @since 2.75.0 *)
 
-(** {1 Types} *)
-
-type health_status =
-  | Healthy
-  | Unhealthy of string  (** reason *)
-  | Recovering           (** half-open, testing *)
-  | Unknown of string
-      (** Issue #8607: unrecognised circuit-breaker state_name (carries
-          the raw value for diagnostics). Previously [_ -> Healthy]
-          silently masked future state additions and wire-format drift
-          as a green health signal. *)
-
 type agent_health_summary = {
   agent_name : string;
-  status : health_status;
-  recent_failures : int;
-  cooldown_remaining_sec : int;
+  failure_count : int;
+  last_failure : Circuit_breaker.failure_record option;
+  last_success_at : float option;
 }
 
-(** Record a successful action — clears half-open state. *)
+(** Record a successful action as an observation. *)
 val record_success : agent_name:string -> unit
 
-(** Record a failed action — may open the breaker. *)
+(** Append a failed action observation. *)
 val record_failure : agent_name:string -> reason:string -> unit
 
 (** {1 Statistics} *)
@@ -60,11 +48,5 @@ val get_summary : agent_name:string -> agent_health_summary
 
 (** {1 JSON Serialization} *)
 
-(** Wire strings: ["healthy"] / ["unhealthy"] / ["recovering"] /
-    ["unknown"]. Issue #8607 introduced the dedicated ["unknown"] bucket
-    so dashboards can filter unrecognised states instead of mixing
-    them with green ones. *)
-val health_status_to_string : health_status -> string
-
-(** Shape: [{agent_name, status, recent_failures, cooldown_remaining_sec}]. *)
+(** Shape: [{agent_name, failure_count, last_failure, last_success_at}]. *)
 val summary_to_json : agent_health_summary -> Yojson.Safe.t

--- a/test/test_eio_mutex_concurrency.ml
+++ b/test/test_eio_mutex_concurrency.ml
@@ -52,18 +52,18 @@ let test_rate_limit_independent_keys () =
 (** {1 Circuit Breaker Concurrency} *)
 
 let test_failure_observation_concurrent () =
-  let cb = CB.create ~failure_threshold:50 ~cooldown:1.0 () in
+  let cb = CB.create () in
   (* Concurrent failure recording + observation reads. *)
   Eio.Fiber.all [
     (fun () -> for _ = 1 to 30 do
       CB.record_failure cb ~agent_id:"test-agent" ~reason:"concurrent-test"
     done);
     (fun () -> for _ = 1 to 30 do
-      let _s = CB.get_status cb ~agent_id:"test-agent" in ()
+      let _s = CB.get_observation cb ~agent_id:"test-agent" in ()
     done);
   ];
-  let status = CB.get_status cb ~agent_id:"test-agent" in
-  check int "all failures observed" 30 status.recent_failures
+  let observation = CB.get_observation cb ~agent_id:"test-agent" in
+  check int "all failures observed" 30 observation.failure_count
 
 let test_circuit_breaker_multi_agent () =
   let cb = CB.create () in
@@ -74,7 +74,7 @@ let test_circuit_breaker_multi_agent () =
       CB.record_failure cb ~agent_id ~reason:"test";
     done
   ));
-  let all = CB.list_all_breakers cb in
+  let all = CB.list_all cb in
   check int "5 breakers exist" 5 (List.length all)
 
 (** {1 Otel_metric_store Concurrency} *)

--- a/test/test_health.ml
+++ b/test/test_health.ml
@@ -14,8 +14,8 @@ let test_get_summary () =
   let name = "test-summary-" ^ string_of_int (Random.int 100000) in
   let s = Health.get_summary ~agent_name:name in
   check string "agent_name matches" name s.agent_name;
-  check int "no recent failures" 0 s.recent_failures;
-  check int "no cooldown" 0 s.cooldown_remaining_sec
+  check int "no failures" 0 s.failure_count;
+  check bool "no success observation" true (Option.is_none s.last_success_at)
 
 (* Test: get_summary shows failures after recording *)
 let test_get_summary_with_failures () =
@@ -26,15 +26,13 @@ let test_get_summary_with_failures () =
   Health.record_failure ~agent_name:name ~reason:"oops2";
   let s = Health.get_summary ~agent_name:name in
   check string "agent_name" name s.agent_name;
-  check bool "has failures" true (s.recent_failures >= 2)
-
-(* Test: health_status_to_string — pure function, no Eio needed *)
-let test_status_to_string () =
-  check string "healthy" "healthy" (Health.health_status_to_string Health.Healthy);
-  check string "recovering" "recovering" (Health.health_status_to_string Health.Recovering);
-  check string "unhealthy" "unhealthy" (Health.health_status_to_string (Health.Unhealthy "x"));
-  (* Issue #8607 *)
-  check string "unknown" "unknown" (Health.health_status_to_string (Health.Unknown "throttled"))
+  check int "all failures counted" 2 s.failure_count;
+  let last_reason =
+    Option.map
+      (fun (failure : Circuit_breaker.failure_record) -> failure.reason)
+      s.last_failure
+  in
+  check (option string) "latest failure observed" (Some "oops2") last_reason
 
 (* Test: summary_to_json produces valid JSON *)
 let test_summary_to_json () =
@@ -49,8 +47,8 @@ let test_summary_to_json () =
   check bool "has agent_name field" true
     (try ignore (Yojson.Safe.Util.member "agent_name" json); true
      with _ -> false);
-  check bool "has status field" true
-    (try ignore (Yojson.Safe.Util.member "status" json); true
+  check bool "has failure_count field" true
+    (try ignore (Yojson.Safe.Util.member "failure_count" json); true
      with _ -> false)
 
 let () =
@@ -59,8 +57,5 @@ let () =
       test_case "get_summary structure" `Quick test_get_summary;
       test_case "get_summary with failures" `Quick test_get_summary_with_failures;
     ];
-    "serialization", [
-      test_case "status_to_string" `Quick test_status_to_string;
-      test_case "summary_to_json" `Quick test_summary_to_json;
-    ];
+    "serialization", [test_case "summary_to_json" `Quick test_summary_to_json];
   ]

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -3206,7 +3206,7 @@ let test_crashed_cycle_records_health_failure () =
       (Failure (Printf.sprintf "boom-%d" i))
   done;
   let summary = Health.get_summary ~agent_name:keeper_name in
-  check int "crashed cycles are observed" 3 summary.recent_failures
+  check int "crashed cycles are observed" 3 summary.failure_count
 
 (* ── Test runner ──────────────────────────────────────────── *)
 


### PR DESCRIPTION
## What changed

- delete the private Closed/Open/HalfOpen state machine
- delete failure threshold, failure window, cooldown, and all 3/60/300 defaults
- stop pruning failures through an implicit time window
- replace string state/open-until/open-reason projection with a typed immutable observation: exact count, latest failure, latest success
- keep the shared map as the single mutex-protected mutable cell; stored records remain immutable
- update Keeper crash integration and dashboard-ready Health JSON to assert observations, not participation state

## Why

The remaining circuit-breaker implementation still converted three failures inside sixty seconds into a five-minute Open status even after the execution gate was removed. Those numbers are not objective truths. They also forced Health to recover semantics by matching free strings.

The new record is observation-only and bounded in memory: a monotonic count plus the latest typed failure and success timestamps. It has no threshold, cooldown, classification, state string, or skip path.

## Validation

- focused build: `scripts/dune-local.sh build test/test_health.exe test/test_eio_mutex_concurrency.exe test/test_heartbeat_integration.exe`
- `test_health.exe`: 3/3
- `test_eio_mutex_concurrency.exe`: 7/7
- `test_heartbeat_integration.exe`: 45/45
- repository-wide ratchet: zero old check/wrap/force/status/threshold/cooldown/string-state callsites in this boundary
- `git diff --check`

Stacked on #24803. This PR is exactly 399 changed lines.