### PR TITLE
refactor(runtime): rename breaker journal to observations

### DIFF
--- a/lib/core/dune
+++ b/lib/core/dune
@@ -16,7 +16,7 @@
   safe_ops
   common
   validation
-  circuit_breaker
+  failure_observation
   cross_context_mutex
   eio_guard
   executor_pool_ref

--- a/lib/core/failure_observation.ml
+++ b/lib/core/failure_observation.ml
@@ -1,4 +1,4 @@
-(** Failure observation for MASC agents.
+(** Failure_observation records MASC agent outcomes.
 
     Recorded outcomes never classify, delay, or suppress execution.
 

--- a/lib/core/failure_observation.mli
+++ b/lib/core/failure_observation.mli
@@ -1,4 +1,4 @@
-(** Circuit_breaker — failure observation for MASC agents.
+(** Failure_observation records MASC agent outcomes.
 
     Recorded failures are immutable diagnostic facts. They do not classify,
     gate, delay, or suspend Keeper participation.

--- a/lib/health.ml
+++ b/lib/health.ml
@@ -16,9 +16,9 @@ module Int = Stdlib.Int
 module Float = Stdlib.Float
 module Random = Stdlib.Random
 
-(** Agent Health — Keeper failure observation over Circuit Breaker.
+(** Agent Health — Keeper outcome observation.
 
-    Wraps Circuit_breaker with agent-name semantics for Keeper Heartbeat.
+    Wraps Failure_observation with agent-name semantics for Keeper Heartbeat.
     Failure history is diagnostic data and never controls participation.
 
     Integration points:
@@ -29,22 +29,22 @@ module Random = Stdlib.Random
 type agent_health_summary = {
   agent_name : string;
   failure_count : int;
-  last_failure : Circuit_breaker.failure_record option;
+  last_failure : Failure_observation.failure_record option;
   last_success_at : float option;
 }
 
 let record_success ~agent_name =
-  Circuit_breaker.record_success_global ~agent_id:agent_name
+  Failure_observation.record_success_global ~agent_id:agent_name
 
 let record_failure ~agent_name ~reason =
-  Circuit_breaker.record_failure_global ~agent_id:agent_name ~reason
+  Failure_observation.record_failure_global ~agent_id:agent_name ~reason
 
 (** {1 Statistics} *)
 
 (** Get health summary for a single agent. *)
 let get_summary ~agent_name : agent_health_summary =
   let observation =
-    Circuit_breaker.get_observation_global ~agent_id:agent_name
+    Failure_observation.get_observation_global ~agent_id:agent_name
   in
   {
     agent_name;
@@ -55,7 +55,7 @@ let get_summary ~agent_name : agent_health_summary =
 
 (** {1 JSON Serialization} *)
 
-let failure_to_json (failure : Circuit_breaker.failure_record) =
+let failure_to_json (failure : Failure_observation.failure_record) =
   `Assoc
     [ "timestamp", `Float failure.timestamp
     ; "reason", `String failure.reason

--- a/lib/health.mli
+++ b/lib/health.mli
@@ -16,9 +16,9 @@ module Int = Stdlib.Int
 module Float = Stdlib.Float
 module Random = Stdlib.Random
 
-(** Agent Health — Keeper failure observation over Circuit Breaker.
+(** Agent Health — Keeper outcome observation.
 
-    Wraps {!Circuit_breaker} with agent-name semantics for Keeper
+    Wraps {!Failure_observation} with agent-name semantics for Keeper
     Heartbeat. Failure history is diagnostic data and never controls
     Keeper participation.
 
@@ -32,7 +32,7 @@ module Random = Stdlib.Random
 type agent_health_summary = {
   agent_name : string;
   failure_count : int;
-  last_failure : Circuit_breaker.failure_record option;
+  last_failure : Failure_observation.failure_record option;
   last_success_at : float option;
 }
 

--- a/test/test_eio_mutex_concurrency.ml
+++ b/test/test_eio_mutex_concurrency.ml
@@ -5,7 +5,7 @@
 
     Modules tested:
     - Rate_limit (token bucket under contention)
-    - Circuit_breaker (state transitions under contention)
+    - Failure_observation (outcome recording under contention)
     - Otel_metric_store (metric increments under contention)
     - Streamable_http.Session (session CRUD under contention)
     - Client_registry_eio (identity resolution under contention)
@@ -14,7 +14,7 @@
 open Alcotest
 
 module RL = Masc.Rate_limit
-module CB = Circuit_breaker
+module Observation = Failure_observation
 module Metrics = Masc.Otel_metric_store
 module SH = Masc.Streamable_http
 
@@ -49,32 +49,32 @@ let test_rate_limit_independent_keys () =
     check bool (Printf.sprintf "%s remaining >= 0" key) true (rem >= 0)
   ) (List.init 10 Fun.id)
 
-(** {1 Circuit Breaker Concurrency} *)
+(** {1 Failure Observation Concurrency} *)
 
 let test_failure_observation_concurrent () =
-  let cb = CB.create () in
+  let observations = Observation.create () in
   (* Concurrent failure recording + observation reads. *)
   Eio.Fiber.all [
     (fun () -> for _ = 1 to 30 do
-      CB.record_failure cb ~agent_id:"test-agent" ~reason:"concurrent-test"
+      Observation.record_failure observations ~agent_id:"test-agent" ~reason:"concurrent-test"
     done);
     (fun () -> for _ = 1 to 30 do
-      let _s = CB.get_observation cb ~agent_id:"test-agent" in ()
+      let _s = Observation.get_observation observations ~agent_id:"test-agent" in ()
     done);
   ];
-  let observation = CB.get_observation cb ~agent_id:"test-agent" in
+  let observation = Observation.get_observation observations ~agent_id:"test-agent" in
   check int "all failures observed" 30 observation.failure_count
 
-let test_circuit_breaker_multi_agent () =
-  let cb = CB.create () in
+let test_failure_observation_multi_agent () =
+  let observations = Observation.create () in
   (* Different agents recording failures concurrently *)
   Eio.Fiber.all (List.init 5 (fun i -> fun () ->
     let agent_id = Printf.sprintf "agent-%d" i in
     for _ = 1 to 20 do
-      CB.record_failure cb ~agent_id ~reason:"test";
+      Observation.record_failure observations ~agent_id ~reason:"test";
     done
   ));
-  let all = CB.list_all cb in
+  let all = Observation.list_all observations in
   check int "5 breakers exist" 5 (List.length all)
 
 (** {1 Otel_metric_store Concurrency} *)
@@ -127,10 +127,11 @@ let () =
       test_case "concurrent same key" `Quick test_rate_limit_concurrent;
       test_case "concurrent independent keys" `Quick test_rate_limit_independent_keys;
     ];
-    "Circuit Breaker", [
+    "Failure observation", [
       test_case "concurrent failure observation" `Quick
         test_failure_observation_concurrent;
-      test_case "concurrent multi-agent" `Quick test_circuit_breaker_multi_agent;
+      test_case "concurrent multi-agent" `Quick
+        test_failure_observation_multi_agent;
     ];
     "Otel_metric_store", [
       test_case "concurrent counter" `Quick test_otel_metric_store_concurrent;

--- a/test/test_health.ml
+++ b/test/test_health.ml
@@ -1,7 +1,7 @@
-(** Tests for Health module — Keeper failure observation over Circuit Breaker.
+(** Tests for Health module — Keeper outcome observation.
 
-    All tests that touch Circuit_breaker must run inside Eio_main.run
-    because Circuit_breaker uses Eio.Mutex internally. *)
+    All tests that touch Failure_observation run inside Eio_main.run because
+    the shared observation store uses Eio.Mutex. *)
 
 module Health = Masc.Health
 
@@ -29,7 +29,7 @@ let test_get_summary_with_failures () =
   check int "all failures counted" 2 s.failure_count;
   let last_reason =
     Option.map
-      (fun (failure : Circuit_breaker.failure_record) -> failure.reason)
+      (fun (failure : Failure_observation.failure_record) -> failure.reason)
       s.last_failure
   in
   check (option string) "latest failure observed" (Some "oops2") last_reason


### PR DESCRIPTION
## What changed

- rename `Circuit_breaker` files and Dune module to `Failure_observation`
- update Health and focused tests to use the observation name
- remove breaker/state-transition language from test groups and boundary docs

## Why

After #24805, the module no longer contains a circuit, breaker, threshold, cooldown, state transition, or execution gate. Keeping the old name would preserve the wrong abstraction and encourage governance logic to be wired back into this neutral telemetry boundary.

## Validation

- focused build: `scripts/dune-local.sh build test/test_health.exe test/test_eio_mutex_concurrency.exe test/test_heartbeat_integration.exe`
- `test_health.exe`: 3/3
- `test_eio_mutex_concurrency.exe`: 7/7
- `test_heartbeat_integration.exe`: 45/45
- `ocamlformat --check` on every changed OCaml file
- zero `Circuit_breaker` references remain in the renamed core/Health/test boundary
- `git diff --check`

Stacked on #24805. Total: 61 changed lines.