### PR TITLE
feat(memory): add exact idle Keeper lane submission

### DIFF
--- a/lib/keeper/keeper_memory_lane.ml
+++ b/lib/keeper/keeper_memory_lane.ml
@@ -15,6 +15,17 @@ type outcome =
   | Ran_inline
   | Dropped
 
+type idle_submission =
+  | Idle_submitted
+  | Idle_already_active
+  | Idle_executor_unavailable
+  | Idle_fork_failed
+
+type start_result =
+  | Start_submitted
+  | Start_executor_unavailable
+  | Start_fork_failed
+
 type reservation =
   { release_mu : Stdlib.Mutex.t
   ; mutable released : bool
@@ -112,6 +123,16 @@ let try_reserve ~keeper_name entry =
       Some bound))
 ;;
 
+let try_reserve_if_idle ~keeper_name entry =
+  Stdlib.Mutex.protect entry.state_mu (fun () ->
+    if entry.pending <> 0
+    then false
+    else (
+      entry.pending <- 1;
+      inc_pending ~keeper_name ();
+      true))
+;;
+
 let release_reservation ~keeper_name entry =
   Stdlib.Mutex.protect entry.state_mu (fun () ->
     entry.pending <- entry.pending - 1;
@@ -190,7 +211,7 @@ let arm_switch_release ~keeper_name entry reservation sw =
    exit, including cancellation at shutdown. No exception escapes: a best-effort
    unit must never propagate into the executor switch — that would cancel the
    fleet. *)
-let run_unit ~keeper_name entry reservation sw f =
+let run_unit ~keeper_name entry reservation f =
   let acquired = ref false in
   let in_flight = ref false in
   Eio.Switch.run (fun cleanup_sw ->
@@ -204,7 +225,7 @@ let run_unit ~keeper_name entry reservation sw f =
         acquired := true;
         inc_in_flight ~keeper_name ();
         in_flight := true;
-        Eio_context.with_turn_switch sw f
+        Eio_context.with_turn_switch cleanup_sw (fun () -> f cleanup_sw)
       with
       | Eio.Cancel.Cancelled _ -> () (* shutdown: silent, cleanup runs above *)
       | exn ->
@@ -212,6 +233,35 @@ let run_unit ~keeper_name entry reservation sw f =
         Log.Keeper.warn ~keeper_name
           "memory lane unit failed: %s"
           (Printexc.to_string exn))
+;;
+
+let start_reserved ~keeper_name entry sw f =
+  let reservation = make_reservation () in
+  arm_switch_release ~keeper_name entry reservation sw;
+  if reservation_released reservation
+  then (
+    record_counter ~keeper_name MemoryLaneDropped;
+    Log.Keeper.warn ~keeper_name
+      "memory lane executor switch unavailable: dropping memory unit";
+    Start_executor_unavailable)
+  else
+    try
+      record_counter ~keeper_name MemoryLaneSubmitted;
+      Eio.Fiber.fork ~sw (fun () -> run_unit ~keeper_name entry reservation f);
+      Start_submitted
+    with
+    | Eio.Cancel.Cancelled _ as e ->
+      protect_cleanup ~keeper_name "fork_cancel_release" (fun () ->
+        release_reservation_once ~keeper_name entry reservation);
+      raise e
+    | exn ->
+      protect_cleanup ~keeper_name "fork_failure_release" (fun () ->
+        release_reservation_once ~keeper_name entry reservation);
+      record_counter ~keeper_name MemoryLaneUnitFailures;
+      Log.Keeper.warn ~keeper_name
+        "memory lane fork failed: %s"
+        (Printexc.to_string exn);
+      Start_fork_failed
 ;;
 
 let submit ~base_path ~keeper_name f =
@@ -243,32 +293,23 @@ let submit ~base_path ~keeper_name f =
          (max_pending ());
        Dropped
      | Some _bound ->
-       let reservation = make_reservation () in
-       arm_switch_release ~keeper_name entry reservation sw;
-       if reservation_released reservation
-       then (
-         record_counter ~keeper_name MemoryLaneDropped;
-         Log.Keeper.warn ~keeper_name
-           "memory lane executor switch unavailable: dropping post-turn memory unit";
-         Dropped)
-       else (
-         try
-           record_counter ~keeper_name MemoryLaneSubmitted;
-           Eio.Fiber.fork ~sw (fun () -> run_unit ~keeper_name entry reservation sw f);
-           Submitted
-         with
-         | Eio.Cancel.Cancelled _ as e ->
-           protect_cleanup ~keeper_name "fork_cancel_release" (fun () ->
-             release_reservation_once ~keeper_name entry reservation);
-           raise e
-         | exn ->
-           protect_cleanup ~keeper_name "fork_failure_release" (fun () ->
-             release_reservation_once ~keeper_name entry reservation);
-           record_counter ~keeper_name MemoryLaneUnitFailures;
-           Log.Keeper.warn ~keeper_name
-             "memory lane fork failed: %s"
-             (Printexc.to_string exn);
-           Dropped))
+       (match start_reserved ~keeper_name entry sw (fun _ -> f ()) with
+        | Start_submitted -> Submitted
+        | Start_executor_unavailable | Start_fork_failed -> Dropped))
+;;
+
+let submit_if_idle ~base_path ~keeper_name f =
+  match current_sw () with
+  | None -> Idle_executor_unavailable
+  | Some sw ->
+    let entry = entry_for ~base_path ~keeper_name in
+    if not (try_reserve_if_idle ~keeper_name entry)
+    then Idle_already_active
+    else
+      match start_reserved ~keeper_name entry sw f with
+      | Start_submitted -> Idle_submitted
+      | Start_executor_unavailable -> Idle_executor_unavailable
+      | Start_fork_failed -> Idle_fork_failed
 ;;
 
 module For_testing = struct

--- a/lib/keeper/keeper_memory_lane.ml
+++ b/lib/keeper/keeper_memory_lane.ml
@@ -214,25 +214,25 @@ let arm_switch_release ~keeper_name entry reservation sw =
 let run_unit ~keeper_name entry reservation f =
   let acquired = ref false in
   let in_flight = ref false in
-  Eio.Switch.run (fun cleanup_sw ->
-    Eio.Switch.on_release cleanup_sw (fun () ->
-      release_after_run ~keeper_name entry reservation ~acquired ~in_flight);
+  try
+    Eio.Switch.run (fun cleanup_sw ->
+      Eio.Switch.on_release cleanup_sw (fun () ->
+        release_after_run ~keeper_name entry reservation ~acquired ~in_flight);
       disarm_switch_hook reservation;
-      try
-        Eio.Mutex.lock entry.mem_mu;
-        (* No suspension point between [lock] returning and this assignment, so
-           cancellation cannot strand a held mutex with [acquired = false]. *)
-        acquired := true;
-        inc_in_flight ~keeper_name ();
-        in_flight := true;
-        Eio_context.with_turn_switch cleanup_sw (fun () -> f cleanup_sw)
-      with
-      | Eio.Cancel.Cancelled _ -> () (* shutdown: silent, cleanup runs above *)
-      | exn ->
-        record_counter ~keeper_name MemoryLaneUnitFailures;
-        Log.Keeper.warn ~keeper_name
-          "memory lane unit failed: %s"
-          (Printexc.to_string exn))
+      Eio.Mutex.lock entry.mem_mu;
+      (* No suspension point between [lock] returning and this assignment, so
+         cancellation cannot strand a held mutex with [acquired = false]. *)
+      acquired := true;
+      inc_in_flight ~keeper_name ();
+      in_flight := true;
+      Eio_context.with_turn_switch cleanup_sw (fun () -> f cleanup_sw))
+  with
+  | Eio.Cancel.Cancelled _ -> () (* shutdown: cleanup ran with child switch *)
+  | exn ->
+    record_counter ~keeper_name MemoryLaneUnitFailures;
+    Log.Keeper.warn ~keeper_name
+      "memory lane unit failed: %s"
+      (Printexc.to_string exn)
 ;;
 
 let start_reserved ~keeper_name entry sw f =

--- a/lib/keeper/keeper_memory_lane.mli
+++ b/lib/keeper/keeper_memory_lane.mli
@@ -34,6 +34,12 @@ type outcome =
           discarded. Memory extraction is best-effort, so saturation drops
           rather than blocking the turn. The drop is counted, never silent. *)
 
+type idle_submission =
+  | Idle_submitted
+  | Idle_already_active
+  | Idle_executor_unavailable
+  | Idle_fork_failed
+
 val init : sw:Eio.Switch.t -> unit
 (** Record the long-lived switch that owns detached memory fibers. Call once at
     server startup, after [Eio_context.set_switch]. *)
@@ -49,6 +55,18 @@ val submit
     executor is not initialized, [f] runs inline and any exception is contained
     and counted rather than escaping. The bound, outcomes, and per-keeper
     pending/in-flight state are exported as metrics. *)
+
+val submit_if_idle
+  :  base_path:string
+  -> keeper_name:string
+  -> (Eio.Switch.t -> unit)
+  -> idle_submission
+(** Submit [f] only when the exact Keeper memory lane has no running or queued
+    unit. This is the nonblocking maintenance boundary: an active lane yields
+    [Idle_already_active] instead of waiting, queueing duplicate work, or
+    dropping it under a numeric capacity policy. A missing executor and a fork
+    failure remain distinct typed outcomes. [f] receives the unit-local child
+    switch that owns provider and I/O resources. *)
 
 module For_testing : sig
   val reset : unit -> unit

--- a/test/test_keeper_memory_lane.ml
+++ b/test/test_keeper_memory_lane.ml
@@ -211,6 +211,47 @@ let test_finished_switch_drops_without_leak () =
   | None -> Alcotest.fail "keeper entry missing after finished switch submit"
 ;;
 
+(* Maintenance submission neither queues behind an active Keeper nor blocks a
+   different Keeper's lane. The closure owns a unit-local child switch. *)
+let test_submit_if_idle_is_keeper_local () =
+  Lane.For_testing.reset ();
+  (match
+     Lane.submit_if_idle ~base_path ~keeper_name:"k1" (fun _sw -> ())
+   with
+   | Lane.Idle_executor_unavailable -> ()
+   | _ -> Alcotest.fail "uninitialized idle submission was not rejected");
+  Eio_main.run (fun _env ->
+    Eio.Switch.run (fun sw ->
+      Lane.init ~sw;
+      let active, set_active = Eio.Promise.create () in
+      let release, set_release = Eio.Promise.create () in
+      let peer_done, set_peer_done = Eio.Promise.create () in
+      let first =
+        Lane.submit_if_idle ~base_path ~keeper_name:"k1" (fun _unit_sw ->
+          Eio.Promise.resolve set_active ();
+          Eio.Promise.await release)
+      in
+      (match first with
+       | Lane.Idle_submitted -> ()
+       | _ -> Alcotest.fail "first idle unit was not submitted");
+      Eio.Promise.await active;
+      let duplicate =
+        Lane.submit_if_idle ~base_path ~keeper_name:"k1" (fun _sw -> ())
+      in
+      (match duplicate with
+       | Lane.Idle_already_active -> ()
+       | _ -> Alcotest.fail "active Keeper accepted duplicate maintenance");
+      let peer =
+        Lane.submit_if_idle ~base_path ~keeper_name:"k2" (fun _sw ->
+          Eio.Promise.resolve set_peer_done ())
+      in
+      (match peer with
+       | Lane.Idle_submitted -> ()
+       | _ -> Alcotest.fail "peer Keeper did not get its independent lane");
+      Eio.Promise.await peer_done;
+      Eio.Promise.resolve set_release ()))
+;;
+
 let () =
   Alcotest.run
     "keeper_memory_lane"
@@ -238,6 +279,10 @@ let () =
             "finished switch drops without leak"
             `Quick
             test_finished_switch_drops_without_leak
+        ; Alcotest.test_case
+            "idle maintenance is Keeper-local"
+            `Quick
+            test_submit_if_idle_is_keeper_local
         ] )
     ]
 ;;

--- a/test/test_keeper_memory_lane.ml
+++ b/test/test_keeper_memory_lane.ml
@@ -252,6 +252,51 @@ let test_submit_if_idle_is_keeper_local () =
       Eio.Promise.resolve set_release ()))
 ;;
 
+let rec await_pending keeper_name expected =
+  match Lane.For_testing.pending ~base_path ~keeper_name with
+  | Some actual when actual = expected -> ()
+  | None | Some _ ->
+    Eio.Fiber.yield ();
+    await_pending keeper_name expected
+;;
+
+(* A child fiber attached to a maintenance unit can fail the unit-local switch,
+   but must not fail the executor switch. Cleanup releases the original lane,
+   after which both that Keeper and a peer can run again. *)
+let test_child_failure_is_lane_local () =
+  Lane.For_testing.reset ();
+  Eio_main.run (fun _env ->
+    Eio.Switch.run (fun sw ->
+      Lane.init ~sw;
+      let child_started, set_child_started = Eio.Promise.create () in
+      let failed_unit =
+        Lane.submit_if_idle ~base_path ~keeper_name:"k1" (fun unit_sw ->
+          Eio.Fiber.fork ~sw:unit_sw (fun () ->
+            Eio.Promise.resolve set_child_started ();
+            raise Test_boom))
+      in
+      (match failed_unit with
+       | Lane.Idle_submitted -> ()
+       | _ -> Alcotest.fail "child-failure unit was not submitted");
+      Eio.Promise.await child_started;
+      await_pending "k1" 0;
+      let same_done, set_same_done = Eio.Promise.create () in
+      let peer_done, set_peer_done = Eio.Promise.create () in
+      let same =
+        Lane.submit_if_idle ~base_path ~keeper_name:"k1" (fun _sw ->
+          Eio.Promise.resolve set_same_done ())
+      in
+      let peer =
+        Lane.submit_if_idle ~base_path ~keeper_name:"k2" (fun _sw ->
+          Eio.Promise.resolve set_peer_done ())
+      in
+      (match same, peer with
+       | Lane.Idle_submitted, Lane.Idle_submitted -> ()
+       | _ -> Alcotest.fail "child failure stopped a Keeper lane or its peer");
+      Eio.Promise.await same_done;
+      Eio.Promise.await peer_done))
+;;
+
 let () =
   Alcotest.run
     "keeper_memory_lane"
@@ -283,6 +328,10 @@ let () =
             "idle maintenance is Keeper-local"
             `Quick
             test_submit_if_idle_is_keeper_local
+        ; Alcotest.test_case
+            "child failure is Keeper-local"
+            `Quick
+            test_child_failure_is_lane_local
         ] )
     ]
 ;;


### PR DESCRIPTION
## Outcome

- Reuses the existing per-Keeper Memory Lane as the single execution SSOT.
- Adds typed idle-only submission: active Keeper, unavailable executor, and fork failure remain distinct outcomes.
- Gives each accepted maintenance unit a child switch for provider and I/O resource ownership.
- An active Keeper skips only its own duplicate unit; other Keeper lanes remain independent.

## Boundary

This PR adds the generic lane primitive only. It does not add product-specific policy, numeric admission thresholds, or a second in-flight registry. The consolidation deadline hard-cut is stacked separately.

## Focused verification

- scripts/dune-local.sh build test/test_keeper_memory_lane.exe test/test_keeper_memory_os_consolidation_runtime.exe test/test_server_bootstrap_maintenance_memory_os.exe
- test_keeper_memory_lane.exe: 9/9 passed
- Full build and suite remain CI authority.