### PR TITLE
fix(memory): remove consolidation execution deadline

### DIFF
--- a/lib/keeper/keeper_memory_lane.ml
+++ b/lib/keeper/keeper_memory_lane.ml
@@ -15,6 +15,17 @@ type outcome =
   | Ran_inline
   | Dropped
 
+type idle_submission =
+  | Idle_submitted
+  | Idle_already_active
+  | Idle_executor_unavailable
+  | Idle_fork_failed
+
+type start_result =
+  | Start_submitted
+  | Start_executor_unavailable
+  | Start_fork_failed
+
 type reservation =
   { release_mu : Stdlib.Mutex.t
   ; mutable released : bool
@@ -112,6 +123,16 @@ let try_reserve ~keeper_name entry =
       Some bound))
 ;;
 
+let try_reserve_if_idle ~keeper_name entry =
+  Stdlib.Mutex.protect entry.state_mu (fun () ->
+    if entry.pending <> 0
+    then false
+    else (
+      entry.pending <- 1;
+      inc_pending ~keeper_name ();
+      true))
+;;
+
 let release_reservation ~keeper_name entry =
   Stdlib.Mutex.protect entry.state_mu (fun () ->
     entry.pending <- entry.pending - 1;
@@ -190,7 +211,7 @@ let arm_switch_release ~keeper_name entry reservation sw =
    exit, including cancellation at shutdown. No exception escapes: a best-effort
    unit must never propagate into the executor switch — that would cancel the
    fleet. *)
-let run_unit ~keeper_name entry reservation sw f =
+let run_unit ~keeper_name entry reservation f =
   let acquired = ref false in
   let in_flight = ref false in
   Eio.Switch.run (fun cleanup_sw ->
@@ -204,7 +225,7 @@ let run_unit ~keeper_name entry reservation sw f =
         acquired := true;
         inc_in_flight ~keeper_name ();
         in_flight := true;
-        Eio_context.with_turn_switch sw f
+        Eio_context.with_turn_switch cleanup_sw (fun () -> f cleanup_sw)
       with
       | Eio.Cancel.Cancelled _ -> () (* shutdown: silent, cleanup runs above *)
       | exn ->
@@ -212,6 +233,35 @@ let run_unit ~keeper_name entry reservation sw f =
         Log.Keeper.warn ~keeper_name
           "memory lane unit failed: %s"
           (Printexc.to_string exn))
+;;
+
+let start_reserved ~keeper_name entry sw f =
+  let reservation = make_reservation () in
+  arm_switch_release ~keeper_name entry reservation sw;
+  if reservation_released reservation
+  then (
+    record_counter ~keeper_name MemoryLaneDropped;
+    Log.Keeper.warn ~keeper_name
+      "memory lane executor switch unavailable: dropping memory unit";
+    Start_executor_unavailable)
+  else
+    try
+      record_counter ~keeper_name MemoryLaneSubmitted;
+      Eio.Fiber.fork ~sw (fun () -> run_unit ~keeper_name entry reservation f);
+      Start_submitted
+    with
+    | Eio.Cancel.Cancelled _ as e ->
+      protect_cleanup ~keeper_name "fork_cancel_release" (fun () ->
+        release_reservation_once ~keeper_name entry reservation);
+      raise e
+    | exn ->
+      protect_cleanup ~keeper_name "fork_failure_release" (fun () ->
+        release_reservation_once ~keeper_name entry reservation);
+      record_counter ~keeper_name MemoryLaneUnitFailures;
+      Log.Keeper.warn ~keeper_name
+        "memory lane fork failed: %s"
+        (Printexc.to_string exn);
+      Start_fork_failed
 ;;
 
 let submit ~base_path ~keeper_name f =
@@ -243,32 +293,23 @@ let submit ~base_path ~keeper_name f =
          (max_pending ());
        Dropped
      | Some _bound ->
-       let reservation = make_reservation () in
-       arm_switch_release ~keeper_name entry reservation sw;
-       if reservation_released reservation
-       then (
-         record_counter ~keeper_name MemoryLaneDropped;
-         Log.Keeper.warn ~keeper_name
-           "memory lane executor switch unavailable: dropping post-turn memory unit";
-         Dropped)
-       else (
-         try
-           record_counter ~keeper_name MemoryLaneSubmitted;
-           Eio.Fiber.fork ~sw (fun () -> run_unit ~keeper_name entry reservation sw f);
-           Submitted
-         with
-         | Eio.Cancel.Cancelled _ as e ->
-           protect_cleanup ~keeper_name "fork_cancel_release" (fun () ->
-             release_reservation_once ~keeper_name entry reservation);
-           raise e
-         | exn ->
-           protect_cleanup ~keeper_name "fork_failure_release" (fun () ->
-             release_reservation_once ~keeper_name entry reservation);
-           record_counter ~keeper_name MemoryLaneUnitFailures;
-           Log.Keeper.warn ~keeper_name
-             "memory lane fork failed: %s"
-             (Printexc.to_string exn);
-           Dropped))
+       (match start_reserved ~keeper_name entry sw (fun _ -> f ()) with
+        | Start_submitted -> Submitted
+        | Start_executor_unavailable | Start_fork_failed -> Dropped))
+;;
+
+let submit_if_idle ~base_path ~keeper_name f =
+  match current_sw () with
+  | None -> Idle_executor_unavailable
+  | Some sw ->
+    let entry = entry_for ~base_path ~keeper_name in
+    if not (try_reserve_if_idle ~keeper_name entry)
+    then Idle_already_active
+    else
+      match start_reserved ~keeper_name entry sw f with
+      | Start_submitted -> Idle_submitted
+      | Start_executor_unavailable -> Idle_executor_unavailable
+      | Start_fork_failed -> Idle_fork_failed
 ;;
 
 module For_testing = struct

--- a/lib/keeper/keeper_memory_lane.ml
+++ b/lib/keeper/keeper_memory_lane.ml
@@ -214,25 +214,25 @@ let arm_switch_release ~keeper_name entry reservation sw =
 let run_unit ~keeper_name entry reservation f =
   let acquired = ref false in
   let in_flight = ref false in
-  Eio.Switch.run (fun cleanup_sw ->
-    Eio.Switch.on_release cleanup_sw (fun () ->
-      release_after_run ~keeper_name entry reservation ~acquired ~in_flight);
+  try
+    Eio.Switch.run (fun cleanup_sw ->
+      Eio.Switch.on_release cleanup_sw (fun () ->
+        release_after_run ~keeper_name entry reservation ~acquired ~in_flight);
       disarm_switch_hook reservation;
-      try
-        Eio.Mutex.lock entry.mem_mu;
-        (* No suspension point between [lock] returning and this assignment, so
-           cancellation cannot strand a held mutex with [acquired = false]. *)
-        acquired := true;
-        inc_in_flight ~keeper_name ();
-        in_flight := true;
-        Eio_context.with_turn_switch cleanup_sw (fun () -> f cleanup_sw)
-      with
-      | Eio.Cancel.Cancelled _ -> () (* shutdown: silent, cleanup runs above *)
-      | exn ->
-        record_counter ~keeper_name MemoryLaneUnitFailures;
-        Log.Keeper.warn ~keeper_name
-          "memory lane unit failed: %s"
-          (Printexc.to_string exn))
+      Eio.Mutex.lock entry.mem_mu;
+      (* No suspension point between [lock] returning and this assignment, so
+         cancellation cannot strand a held mutex with [acquired = false]. *)
+      acquired := true;
+      inc_in_flight ~keeper_name ();
+      in_flight := true;
+      Eio_context.with_turn_switch cleanup_sw (fun () -> f cleanup_sw))
+  with
+  | Eio.Cancel.Cancelled _ -> () (* shutdown: cleanup ran with child switch *)
+  | exn ->
+    record_counter ~keeper_name MemoryLaneUnitFailures;
+    Log.Keeper.warn ~keeper_name
+      "memory lane unit failed: %s"
+      (Printexc.to_string exn)
 ;;
 
 let start_reserved ~keeper_name entry sw f =

--- a/lib/keeper/keeper_memory_lane.mli
+++ b/lib/keeper/keeper_memory_lane.mli
@@ -34,6 +34,12 @@ type outcome =
           discarded. Memory extraction is best-effort, so saturation drops
           rather than blocking the turn. The drop is counted, never silent. *)
 
+type idle_submission =
+  | Idle_submitted
+  | Idle_already_active
+  | Idle_executor_unavailable
+  | Idle_fork_failed
+
 val init : sw:Eio.Switch.t -> unit
 (** Record the long-lived switch that owns detached memory fibers. Call once at
     server startup, after [Eio_context.set_switch]. *)
@@ -49,6 +55,18 @@ val submit
     executor is not initialized, [f] runs inline and any exception is contained
     and counted rather than escaping. The bound, outcomes, and per-keeper
     pending/in-flight state are exported as metrics. *)
+
+val submit_if_idle
+  :  base_path:string
+  -> keeper_name:string
+  -> (Eio.Switch.t -> unit)
+  -> idle_submission
+(** Submit [f] only when the exact Keeper memory lane has no running or queued
+    unit. This is the nonblocking maintenance boundary: an active lane yields
+    [Idle_already_active] instead of waiting, queueing duplicate work, or
+    dropping it under a numeric capacity policy. A missing executor and a fork
+    failure remain distinct typed outcomes. [f] receives the unit-local child
+    switch that owns provider and I/O resources. *)
 
 module For_testing : sig
   val reset : unit -> unit

--- a/lib/keeper/keeper_memory_os_consolidation_runtime.ml
+++ b/lib/keeper/keeper_memory_os_consolidation_runtime.ml
@@ -23,38 +23,13 @@ let default_complete ~sw ~net ?clock ~config ~messages () =
 let user_message text : Agent_sdk.Types.message = Agent_sdk.Types.user_msg text
 ;;
 
-type 'a timeout_result =
-  | Completed of 'a
-  | Timed_out
-  | Clock_unavailable
-
-(* Fail-open per RFC-0156 (MASC turn-budget timeout policy withdrawn) / repo-owner
-   directive (mirrors [Keeper_llm_bridge]
-   @151ac9a27f): a wall-clock budget must NOT force-kill a legitimate LLM/agent
-   execution. The old [Eio.Time.with_timeout_exn] kill only produced
-   kill -> error -> retry churn on slow-but-legitimate provider calls, so [f] now
-   runs to natural completion. A genuine INNER transport timeout still raises
-   [Eio.Time.Timeout] (from the provider's own transport/idle deadlines) and is
-   surfaced as [Timed_out]. [Eio.Cancel.Cancelled] is deliberately not caught here
-   so it propagates (re-raises) to the enclosing switch. [timeout_sec] is no longer
-   consulted for a wall deadline (kept in the signature as advisory only).
-   The [None -> Clock_unavailable] fail-closed guard is retained unchanged: without
-   a clock the provider's inner transport cannot enforce its own idle/connect
-   deadlines, so the call is still refused upstream. *)
-let with_timeout ?clock ~timeout_sec:_ f =
-  match clock with
-  | None -> Clock_unavailable
-  | Some _clock ->
-    (try Completed (f ()) with
-     | Eio.Time.Timeout -> Timed_out)
-;;
-
 (* The plan can list many groups over a large store, so allow more than the
    512-token summary budget. *)
 let consolidation_max_tokens = 2048
 
 type outcome =
   | Skipped_too_few of int
+  | Transport_timed_out
   | Transport_failed of string
   | Unparseable of string
   | Empty_response
@@ -155,7 +130,6 @@ let invalid_structured_response_detail detail =
 let consolidate_keeper
       ?(complete = default_complete)
       ?clock
-      ?(timeout_sec = Env_config_runtime_services.Inference.timeout_seconds)
       ?(dry_run = false)
       ~sw
       ~net
@@ -179,19 +153,15 @@ let consolidate_keeper
         (match validate_provider_for_consolidation config with
          | Error msg -> Transport_failed ("consolidation provider config rejected: " ^ msg)
          | Ok () ->
-        (match
-           with_timeout ?clock ~timeout_sec (fun () ->
-             complete ~sw ~net ?clock ~config ~messages ())
-         with
-         | Timed_out -> Transport_failed "consolidation provider timed out"
-         | Clock_unavailable ->
-           Transport_failed
-             (Printf.sprintf
-                "consolidation provider clock unavailable; refusing provider call \
-                 without enforcing timeout_sec=%.1f"
-                timeout_sec)
-         | Completed (Error _) -> Transport_failed "consolidation provider transport error"
-         | Completed (Ok response) ->
+        let completion =
+          try `Completed (complete ~sw ~net ?clock ~config ~messages ()) with
+          | Eio.Time.Timeout -> `Timed_out
+        in
+        (match completion with
+         | `Timed_out -> Transport_timed_out
+         | `Completed (Error _) ->
+           Transport_failed "consolidation provider transport error"
+         | `Completed (Ok response) ->
            if String.trim (Agent_sdk_response.text_of_response response) = ""
            then Empty_response
            else

--- a/lib/keeper/keeper_memory_os_consolidation_runtime.mli
+++ b/lib/keeper/keeper_memory_os_consolidation_runtime.mli
@@ -12,6 +12,7 @@ val default_complete : complete_fn
 
 type outcome =
   | Skipped_too_few of int
+  | Transport_timed_out
   | Transport_failed of string
   | Unparseable of string
   | Empty_response
@@ -36,19 +37,15 @@ end
     still matches the model's input. Only an empty store skips the LLM call; a
     numeric fact-count threshold never suppresses model judgment. Returns the
     outcome without raising for the expected failure modes so a
-    caller fiber stays alive. If [timeout_sec] is configured but no [clock] is
-    available, the provider call is refused as [Transport_failed _] (without a
-    clock the provider's inner transport cannot enforce its idle/connect
-    deadlines). When a clock is present the call runs to natural completion:
-    [timeout_sec] is advisory and never force-kills a legitimate provider call
-    (fail-open per RFC-0156); only a genuine inner transport [Eio.Time.Timeout]
-    surfaces as [Transport_failed _]. [runtime_id] remains paired with
+    caller fiber stays alive. The call runs to natural completion without a
+    MASC wall-clock budget. A genuine inner transport [Eio.Time.Timeout]
+    surfaces as [Transport_timed_out], while parent cancellation propagates.
+    [runtime_id] remains paired with
     [provider_cfg] so model-level temperature declarations survive request
     tuning. *)
 val consolidate_keeper
   :  ?complete:complete_fn
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
-  -> ?timeout_sec:float
   -> ?dry_run:bool
   -> sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -152,6 +152,7 @@ type t =
   | MemoryLaneProviderSlotBusy
   | MemoryBankCompactionFailures
   | MemoryOsMaintenanceKeeperTimeout
+  | MemoryOsConsolidationDispatches
   | WriteMetaCycleFailures
   | AlertPersistFailures
   | MetricsSseFailures
@@ -375,6 +376,7 @@ let to_string = function
   | MemoryLaneProviderSlotBusy -> "masc_keeper_memory_lane_provider_slot_busy_total"
   | MemoryBankCompactionFailures -> "masc_keeper_memory_bank_compaction_failures_total"
   | MemoryOsMaintenanceKeeperTimeout -> "masc_keeper_memory_os_maintenance_keeper_timeout_total"
+  | MemoryOsConsolidationDispatches -> "masc_keeper_memory_os_consolidation_dispatch_total"
   | WriteMetaCycleFailures -> "masc_keeper_write_meta_cycle_failures_total"
   | AlertPersistFailures -> "masc_keeper_alert_persist_failures_total"
   | MetricsSseFailures -> "masc_keeper_metrics_sse_failures_total"

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -143,6 +143,7 @@ type t =
   | MemoryLaneProviderSlotBusy
   | MemoryBankCompactionFailures
   | MemoryOsMaintenanceKeeperTimeout
+  | MemoryOsConsolidationDispatches
   | WriteMetaCycleFailures
   | AlertPersistFailures
   | MetricsSseFailures

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -118,14 +118,36 @@ let run_with_keeper_timeout ~clock ~timeout_sec ~keeper_id ~on_timeout f =
        on_timeout ())
 ;;
 
+type memory_os_consolidation_dispatch =
+  | Dispatch_started
+  | Dispatch_already_active
+  | Dispatch_executor_unavailable
+  | Dispatch_fork_failed
+
+let memory_os_consolidation_dispatch_label = function
+  | Dispatch_started -> "started"
+  | Dispatch_already_active -> "already_active"
+  | Dispatch_executor_unavailable -> "executor_unavailable"
+  | Dispatch_fork_failed -> "fork_failed"
+;;
+
+let record_memory_os_consolidation_dispatch ~keeper_id outcome =
+  Otel_metric_store.inc_counter
+    Keeper_metrics.(to_string MemoryOsConsolidationDispatches)
+    ~labels:
+      [ "keeper", keeper_id
+      ; "outcome", memory_os_consolidation_dispatch_label outcome
+      ]
+    ()
+;;
+
 (* Run one consolidation pass over every keeper that currently has a fact store.
    The optional [complete] injection lets tests drive the loop with a fake model.
-   The optional [timeout_sec] lets tests exercise the per-keeper timeout without
-   waiting for the production default (300s). *)
+   Each keeper owns an independent fiber. No MASC wall deadline cancels a valid
+   provider call or its subsequent snapshot-checked writeback. *)
 let run_memory_os_consolidation_tick
       ?(complete = Keeper_memory_os_consolidation_runtime.default_complete)
-      ?(timeout_sec = 300.0)
-      ~sw
+      ~base_path
       ~net
       ?clock
       ~runtime_id
@@ -134,12 +156,12 @@ let run_memory_os_consolidation_tick
       ()
   =
   let keeper_ids = Keeper_memory_os_io.list_fact_store_keeper_ids () in
-  let consolidate_one keeper_id () =
+  let consolidate_one worker_sw keeper_id () =
     try
       match
         Keeper_memory_os_consolidation_runtime.consolidate_keeper
           ~complete
-          ~sw
+          ~sw:worker_sw
           ~net
           ?clock
           ~runtime_id
@@ -159,6 +181,10 @@ let run_memory_os_consolidation_tick
           "memory_os_keeper_consolidation: keeper=%s skipped_too_few=%d"
           keeper_id
           n
+      | Transport_timed_out ->
+        Log.Server.warn
+          "memory_os_keeper_consolidation: keeper=%s transport_timed_out"
+          keeper_id
       | Transport_failed msg ->
         Log.Server.warn
           "memory_os_keeper_consolidation: keeper=%s transport_failed: %s"
@@ -192,20 +218,37 @@ let run_memory_os_consolidation_tick
         keeper_id
         (Printexc.to_string exn)
   in
-  Eio.Fiber.all
-    (List.map
-       (fun keeper_id () ->
-          run_with_keeper_timeout
-            ~clock
-            ~timeout_sec
-            ~keeper_id
-            ~on_timeout:(fun () ->
-              Log.Server.warn
-                "memory_os_keeper_consolidation: keeper=%s timeout after %.0fs"
-                keeper_id
-                timeout_sec)
-            (consolidate_one keeper_id))
-       keeper_ids)
+  List.iter
+    (fun keeper_id ->
+       let outcome =
+         Keeper_memory_lane.submit_if_idle
+           ~base_path
+           ~keeper_name:keeper_id
+           (fun worker_sw -> consolidate_one worker_sw keeper_id ())
+       in
+       let dispatch, level, detail =
+         match outcome with
+         | Keeper_memory_lane.Idle_submitted ->
+           Dispatch_started, `Info, "started"
+         | Idle_already_active ->
+           Dispatch_already_active, `Info, "already_active"
+         | Idle_executor_unavailable ->
+           Dispatch_executor_unavailable, `Warn, "executor_unavailable"
+         | Idle_fork_failed -> Dispatch_fork_failed, `Warn, "fork_failed"
+       in
+       record_memory_os_consolidation_dispatch ~keeper_id dispatch;
+       match level with
+       | `Info ->
+         Log.Server.info
+           "memory_os_keeper_consolidation: keeper=%s dispatch=%s"
+           keeper_id
+           detail
+       | `Warn ->
+         Log.Server.warn
+           "memory_os_keeper_consolidation: keeper=%s dispatch=%s"
+           keeper_id
+           detail)
+    keeper_ids
 ;;
 
 let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_state) =
@@ -414,7 +457,7 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
                "memory_os_keeper_consolidation: no runtime configured; skipping tick"
            | Some runtime ->
              run_memory_os_consolidation_tick
-               ~sw
+               ~base_path:(Mcp_server.workspace_config state).base_path
                ~net:env#net
                ~clock
                ~runtime_id:runtime.Runtime.id

--- a/lib/server/server_bootstrap_maintenance.mli
+++ b/lib/server/server_bootstrap_maintenance.mli
@@ -8,8 +8,7 @@ val runtime_for_memory_os_consolidation : unit -> Runtime.t option
 
 val run_memory_os_consolidation_tick :
   ?complete:Keeper_memory_os_consolidation_runtime.complete_fn ->
-  ?timeout_sec:float ->
-  sw:Eio.Switch.t ->
+  base_path:string ->
   net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
   ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
   runtime_id:string ->

--- a/test/test_keeper_memory_lane.ml
+++ b/test/test_keeper_memory_lane.ml
@@ -211,6 +211,47 @@ let test_finished_switch_drops_without_leak () =
   | None -> Alcotest.fail "keeper entry missing after finished switch submit"
 ;;
 
+(* Maintenance submission neither queues behind an active Keeper nor blocks a
+   different Keeper's lane. The closure owns a unit-local child switch. *)
+let test_submit_if_idle_is_keeper_local () =
+  Lane.For_testing.reset ();
+  (match
+     Lane.submit_if_idle ~base_path ~keeper_name:"k1" (fun _sw -> ())
+   with
+   | Lane.Idle_executor_unavailable -> ()
+   | _ -> Alcotest.fail "uninitialized idle submission was not rejected");
+  Eio_main.run (fun _env ->
+    Eio.Switch.run (fun sw ->
+      Lane.init ~sw;
+      let active, set_active = Eio.Promise.create () in
+      let release, set_release = Eio.Promise.create () in
+      let peer_done, set_peer_done = Eio.Promise.create () in
+      let first =
+        Lane.submit_if_idle ~base_path ~keeper_name:"k1" (fun _unit_sw ->
+          Eio.Promise.resolve set_active ();
+          Eio.Promise.await release)
+      in
+      (match first with
+       | Lane.Idle_submitted -> ()
+       | _ -> Alcotest.fail "first idle unit was not submitted");
+      Eio.Promise.await active;
+      let duplicate =
+        Lane.submit_if_idle ~base_path ~keeper_name:"k1" (fun _sw -> ())
+      in
+      (match duplicate with
+       | Lane.Idle_already_active -> ()
+       | _ -> Alcotest.fail "active Keeper accepted duplicate maintenance");
+      let peer =
+        Lane.submit_if_idle ~base_path ~keeper_name:"k2" (fun _sw ->
+          Eio.Promise.resolve set_peer_done ())
+      in
+      (match peer with
+       | Lane.Idle_submitted -> ()
+       | _ -> Alcotest.fail "peer Keeper did not get its independent lane");
+      Eio.Promise.await peer_done;
+      Eio.Promise.resolve set_release ()))
+;;
+
 let () =
   Alcotest.run
     "keeper_memory_lane"
@@ -238,6 +279,10 @@ let () =
             "finished switch drops without leak"
             `Quick
             test_finished_switch_drops_without_leak
+        ; Alcotest.test_case
+            "idle maintenance is Keeper-local"
+            `Quick
+            test_submit_if_idle_is_keeper_local
         ] )
     ]
 ;;

--- a/test/test_keeper_memory_lane.ml
+++ b/test/test_keeper_memory_lane.ml
@@ -252,6 +252,51 @@ let test_submit_if_idle_is_keeper_local () =
       Eio.Promise.resolve set_release ()))
 ;;
 
+let rec await_pending keeper_name expected =
+  match Lane.For_testing.pending ~base_path ~keeper_name with
+  | Some actual when actual = expected -> ()
+  | None | Some _ ->
+    Eio.Fiber.yield ();
+    await_pending keeper_name expected
+;;
+
+(* A child fiber attached to a maintenance unit can fail the unit-local switch,
+   but must not fail the executor switch. Cleanup releases the original lane,
+   after which both that Keeper and a peer can run again. *)
+let test_child_failure_is_lane_local () =
+  Lane.For_testing.reset ();
+  Eio_main.run (fun _env ->
+    Eio.Switch.run (fun sw ->
+      Lane.init ~sw;
+      let child_started, set_child_started = Eio.Promise.create () in
+      let failed_unit =
+        Lane.submit_if_idle ~base_path ~keeper_name:"k1" (fun unit_sw ->
+          Eio.Fiber.fork ~sw:unit_sw (fun () ->
+            Eio.Promise.resolve set_child_started ();
+            raise Test_boom))
+      in
+      (match failed_unit with
+       | Lane.Idle_submitted -> ()
+       | _ -> Alcotest.fail "child-failure unit was not submitted");
+      Eio.Promise.await child_started;
+      await_pending "k1" 0;
+      let same_done, set_same_done = Eio.Promise.create () in
+      let peer_done, set_peer_done = Eio.Promise.create () in
+      let same =
+        Lane.submit_if_idle ~base_path ~keeper_name:"k1" (fun _sw ->
+          Eio.Promise.resolve set_same_done ())
+      in
+      let peer =
+        Lane.submit_if_idle ~base_path ~keeper_name:"k2" (fun _sw ->
+          Eio.Promise.resolve set_peer_done ())
+      in
+      (match same, peer with
+       | Lane.Idle_submitted, Lane.Idle_submitted -> ()
+       | _ -> Alcotest.fail "child failure stopped a Keeper lane or its peer");
+      Eio.Promise.await same_done;
+      Eio.Promise.await peer_done))
+;;
+
 let () =
   Alcotest.run
     "keeper_memory_lane"
@@ -283,6 +328,10 @@ let () =
             "idle maintenance is Keeper-local"
             `Quick
             test_submit_if_idle_is_keeper_local
+        ; Alcotest.test_case
+            "child failure is Keeper-local"
+            `Quick
+            test_child_failure_is_lane_local
         ] )
     ]
 ;;

--- a/test/test_keeper_memory_os_consolidation_runtime.ml
+++ b/test/test_keeper_memory_os_consolidation_runtime.ml
@@ -363,7 +363,7 @@ let test_consolidate_classifies_invalid_structured_response () =
             "expected Invalid_structured_response for malformed provider output"))))
 ;;
 
-let test_consolidate_requires_clock_before_provider_call () =
+let test_consolidate_runs_without_clock () =
   Eio_main.run (fun env ->
     Eio.Switch.run (fun sw ->
       with_prompts (fun () ->
@@ -372,16 +372,15 @@ let test_consolidate_requires_clock_before_provider_call () =
         List.iter
           (Io.append_fact ~keeper_id)
           [ fact "a"; fact "b"; fact "c"; fact "d" ];
-        let called = ref false in
+        let called = Atomic.make false in
         let complete : Runtime.complete_fn =
           fun ~sw:_ ~net:_ ?clock:_ ~config:_ ~messages:_ () ->
-          called := true;
+          Atomic.set called true;
           Ok (fake_response {|{"groups":[],"drop_indices":[]}|})
         in
         let outcome =
           Runtime.consolidate_keeper
             ~complete
-            ~timeout_sec:1.0
             ~sw
             ~net:(Eio.Stdenv.net env)
             ~runtime_id:unconfigured_runtime_id
@@ -390,18 +389,58 @@ let test_consolidate_requires_clock_before_provider_call () =
             ~keeper_id
             ()
         in
-        Alcotest.(check bool) "provider was not called" false !called;
+        Alcotest.(check bool) "provider was called" true (Atomic.get called);
         match outcome with
-        | Runtime.Transport_failed msg ->
-          Alcotest.(check bool)
-            "message names unavailable clock"
-            true
-            (contains "clock unavailable" msg);
-          Alcotest.(check bool)
-            "message names timeout"
-            true
-            (contains "timeout_sec=1.0" msg)
-        | _ -> Alcotest.fail "expected Transport_failed for missing clock"))))
+        | Runtime.Consolidated { before = 4; after = 4 } -> ()
+        | _ -> Alcotest.fail "expected clockless provider completion to be applied"))))
+;;
+
+let test_consolidate_preserves_transport_timeout_and_parent_cancellation () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      with_prompts (fun () ->
+      with_temp_keepers (fun () ->
+        let keeper_id = "keeper-1" in
+        List.iter (Io.append_fact ~keeper_id) [ fact "a"; fact "b" ];
+        let timeout_complete : Runtime.complete_fn =
+          fun ~sw:_ ~net:_ ?clock:_ ~config:_ ~messages:_ () ->
+          raise Eio.Time.Timeout
+        in
+        let timeout_outcome =
+          Runtime.consolidate_keeper
+            ~complete:timeout_complete
+            ~sw
+            ~net:(Eio.Stdenv.net env)
+            ~runtime_id:unconfigured_runtime_id
+            ~provider_cfg:(provider_cfg ())
+            ~now
+            ~keeper_id
+            ()
+        in
+        (match timeout_outcome with
+         | Runtime.Transport_timed_out -> ()
+         | _ -> Alcotest.fail "expected typed transport timeout outcome");
+        let cancel_complete : Runtime.complete_fn =
+          fun ~sw:_ ~net:_ ?clock:_ ~config:_ ~messages:_ () ->
+          raise (Eio.Cancel.Cancelled (Failure "synthetic parent cancellation"))
+        in
+        let cancel_propagated =
+          try
+            ignore
+              (Runtime.consolidate_keeper
+                 ~complete:cancel_complete
+                 ~sw
+                 ~net:(Eio.Stdenv.net env)
+                 ~runtime_id:unconfigured_runtime_id
+                 ~provider_cfg:(provider_cfg ())
+                 ~now
+                 ~keeper_id
+                 ());
+            false
+          with
+          | Eio.Cancel.Cancelled _ -> true
+        in
+        Alcotest.(check bool) "parent cancellation propagated" true cancel_propagated))))
 ;;
 
 let test_consolidate_respects_provider_config_and_prompt_template () =
@@ -499,9 +538,13 @@ let () =
             `Quick
             test_consolidate_classifies_invalid_structured_response
         ; Alcotest.test_case
-            "requires clock before provider call"
+            "runs without a clock"
             `Quick
-            test_consolidate_requires_clock_before_provider_call
+            test_consolidate_runs_without_clock
+        ; Alcotest.test_case
+            "preserves transport timeout and parent cancellation"
+            `Quick
+            test_consolidate_preserves_transport_timeout_and_parent_cancellation
         ; Alcotest.test_case
             "respects provider config and prompt template"
             `Quick

--- a/test/test_server_bootstrap_maintenance_memory_os.ml
+++ b/test/test_server_bootstrap_maintenance_memory_os.ml
@@ -9,14 +9,8 @@
 module Types = Masc.Keeper_memory_os_types
 module Io = Masc.Keeper_memory_os_io
 module Recall = Masc.Keeper_memory_os_recall
+module Lane = Masc.Keeper_memory_lane
 module Atypes = Agent_sdk.Types
-
-let message_text (m : Atypes.message) =
-  m.content
-  |> List.filter_map (function
-    | Atypes.Text s -> Some s
-    | _ -> None)
-  |> String.concat "\n"
 
 let now = 1_000_000.0
 let unconfigured_runtime_id = "test.unconfigured"
@@ -57,10 +51,14 @@ let provider_cfg () =
     ()
 ;;
 
-let with_temp_keepers f =
+let with_temp_keepers ~sw f =
   let marker = Filename.temp_file "consolidation-tick-" ".tmp" in
   Sys.remove marker;
-  Io.For_testing.with_keepers_dir marker f
+  Lane.For_testing.reset ();
+  Lane.init ~sw;
+  Fun.protect
+    ~finally:Lane.For_testing.reset
+    (fun () -> Io.For_testing.with_keepers_dir marker (fun () -> f marker))
 ;;
 
 let with_prompts f =
@@ -78,11 +76,30 @@ let with_prompts f =
        f ())
 ;;
 
+let pending_count ~base_path keeper_ids =
+  List.fold_left
+    (fun total keeper_name ->
+       total
+       + Option.value
+           ~default:0
+           (Lane.For_testing.pending ~base_path ~keeper_name))
+    0
+    keeper_ids
+;;
+
+let rec await_pending ~base_path ~keeper_ids expected =
+  if pending_count ~base_path keeper_ids = expected
+  then ()
+  else (
+    Eio.Fiber.yield ();
+    await_pending ~base_path ~keeper_ids expected)
+;;
+
 let test_accumulate_consolidate_recall () =
   Eio_main.run (fun env ->
     Eio.Switch.run (fun sw ->
       with_prompts (fun () ->
-        with_temp_keepers (fun () ->
+        with_temp_keepers ~sw (fun base_path ->
           let keeper_id = "keeper-1" in
           (* 1. Accumulate: append five redundant facts. *)
           List.iter
@@ -101,13 +118,14 @@ let test_accumulate_consolidate_recall () =
           in
           Server_bootstrap_maintenance.run_memory_os_consolidation_tick
             ~complete:(fake_complete plan)
-            ~sw
+            ~base_path
             ~net:(Eio.Stdenv.net env)
             ~clock:(Eio.Stdenv.clock env)
             ~runtime_id:unconfigured_runtime_id
             ~provider_cfg:(provider_cfg ())
             ~now
             ();
+          await_pending ~base_path ~keeper_ids:[ keeper_id ] 0;
           let after_facts = Io.read_facts_all ~keeper_id in
           let after_count = List.length after_facts in
           Alcotest.(check int) "consolidated store size" 4 after_count;
@@ -138,7 +156,7 @@ let test_skips_when_too_few () =
   Eio_main.run (fun env ->
     Eio.Switch.run (fun sw ->
       with_prompts (fun () ->
-        with_temp_keepers (fun () ->
+        with_temp_keepers ~sw (fun base_path ->
           let keeper_id = "keeper-1" in
           (* A single fact is below the consolidation threshold. *)
           Io.append_fact ~keeper_id (fact "only one fact");
@@ -146,21 +164,22 @@ let test_skips_when_too_few () =
           Alcotest.(check int) "single fact accumulated" 1 before_count;
           Server_bootstrap_maintenance.run_memory_os_consolidation_tick
             ~complete:(fake_complete "{\"groups\":[],\"drop_indices\":[]}")
-            ~sw
+            ~base_path
             ~net:(Eio.Stdenv.net env)
             ~runtime_id:unconfigured_runtime_id
             ~provider_cfg:(provider_cfg ())
             ~now
             ();
+          await_pending ~base_path ~keeper_ids:[ keeper_id ] 0;
           let after_count = List.length (Io.read_facts_all ~keeper_id) in
           Alcotest.(check int) "store unchanged when too few facts" 1 after_count))))
 ;;
 
-let test_parallel_timeout_per_keeper () =
+let test_parallel_natural_completion_per_keeper () =
   Eio_main.run (fun env ->
     Eio.Switch.run (fun sw ->
       with_prompts (fun () ->
-        with_temp_keepers (fun () ->
+        with_temp_keepers ~sw (fun base_path ->
           (* Two keepers each have enough facts to be considered for consolidation. *)
           List.iter (Io.append_fact ~keeper_id:"keeper-slow") [ fact "slow 1"; fact "slow 2" ];
           List.iter (Io.append_fact ~keeper_id:"keeper-fast") [ fact "fast 1"; fact "fast 2" ];
@@ -168,42 +187,52 @@ let test_parallel_timeout_per_keeper () =
           let fast_count_before = List.length (Io.read_facts_all ~keeper_id:"keeper-fast") in
           Alcotest.(check int) "slow keeper accumulated" 2 slow_count_before;
           Alcotest.(check int) "fast keeper accumulated" 2 fast_count_before;
-          let slow_complete ~sw:_ ~net:_ ?clock ~config:_ ~messages:_ () =
-            (match clock with
-             | Some clock -> Eio.Time.sleep clock 2.0
-             | None -> ());
+          let calls = Atomic.make 0 in
+          let release_first, set_release_first = Eio.Promise.create () in
+          let first_started, set_first_started = Eio.Promise.create () in
+          let complete ~sw:_ ~net:_ ?clock:_ ~config:_ ~messages:_ () =
+            let call_index = Atomic.fetch_and_add calls 1 in
+            if call_index = 0
+            then (
+              Eio.Promise.resolve set_first_started ();
+              Eio.Promise.await release_first);
             Ok (fake_response "{\"groups\":[],\"drop_indices\":[]}")
           in
-          let fast_complete = fake_complete "{\"groups\":[],\"drop_indices\":[]}" in
-          let complete ~sw ~net ?clock ~config ~messages () =
-            if List.exists
-                 (fun (m : Agent_sdk.Types.message) ->
-                    String.contains (message_text m) 'f')
-                 messages
-            then fast_complete ~sw ~net ?clock ~config ~messages ()
-            else slow_complete ~sw ~net ?clock ~config ~messages ()
-          in
-          let start = Unix.gettimeofday () in
           Server_bootstrap_maintenance.run_memory_os_consolidation_tick
             ~complete
-            ~timeout_sec:0.1
-            ~sw
+            ~base_path
             ~net:(Eio.Stdenv.net env)
             ~clock:(Eio.Stdenv.clock env)
             ~runtime_id:unconfigured_runtime_id
             ~provider_cfg:(provider_cfg ())
             ~now
             ();
-          let elapsed = Unix.gettimeofday () -. start in
-          (* The slow keeper should hit the 0.1s timeout and the fast keeper should
-             complete; the total elapsed time must be far below the slow keeper's
-             2.0s sleep, proving per-keeper timeout and parallel scheduling. *)
-          Alcotest.(check bool) "tick returns before slow keeper sleep" true (elapsed < 1.0);
-          (* The fast keeper store should be unchanged (no groups). The slow keeper
-             may or may not have been rewritten depending on timing; we only assert
-             that the fast path completed. *)
+          Eio.Promise.await first_started;
+          let keeper_ids = [ "keeper-fast"; "keeper-slow" ] in
+          await_pending ~base_path ~keeper_ids 1;
+          Alcotest.(check int) "first tick dispatched both keepers" 2 (Atomic.get calls);
+          Server_bootstrap_maintenance.run_memory_os_consolidation_tick
+            ~complete
+            ~base_path
+            ~net:(Eio.Stdenv.net env)
+            ~clock:(Eio.Stdenv.clock env)
+            ~runtime_id:unconfigured_runtime_id
+            ~provider_cfg:(provider_cfg ())
+            ~now
+            ();
+          while Atomic.get calls < 3 do
+            Eio.Fiber.yield ()
+          done;
+          Alcotest.(check int)
+            "active keeper skipped while peer ran again"
+            3
+            (Atomic.get calls);
+          Eio.Promise.resolve set_release_first ();
+          await_pending ~base_path ~keeper_ids 0;
           let fast_count_after = List.length (Io.read_facts_all ~keeper_id:"keeper-fast") in
-          Alcotest.(check int) "fast keeper unchanged" fast_count_before fast_count_after))))
+          let slow_count_after = List.length (Io.read_facts_all ~keeper_id:"keeper-slow") in
+          Alcotest.(check int) "fast keeper unchanged" fast_count_before fast_count_after;
+          Alcotest.(check int) "slow keeper unchanged" slow_count_before slow_count_after))))
 ;;
 
 let () =
@@ -219,9 +248,9 @@ let () =
             `Quick
             test_skips_when_too_few
         ; Alcotest.test_case
-            "parallel per-keeper timeout"
+            "parallel per-keeper natural completion"
             `Quick
-            test_parallel_timeout_per_keeper
+            test_parallel_natural_completion_per_keeper
         ] )
     ]
 ;;


### PR DESCRIPTION
## Outcome

- Deletes the MASC-owned 300-second consolidation execution deadline instead of renaming it.
- Runs consolidation even when no clock capability is available.
- Preserves provider transport timeout as a typed result and does not swallow parent cancellation in the consolidation runtime.
- Dispatches each Keeper through its existing Memory Lane without a fleet-wide Fiber.all join barrier.
- A stuck Keeper remains active only on its own lane; later ticks skip that Keeper and continue dispatching peers.
- Records every dispatch outcome, including already active, executor unavailable, and fork failed.

## Deliberate non-claims

- This does not yet introduce a durable maintenance operation with restart replay, terminal settlement, and Keeper wake.
- The separate Memory OS GC 120-second helper and its fleet-wide join remain follow-up cleanup.
- The existing consolidation enablement and cadence policy are not changed in this slice.

## Focused verification

- scripts/dune-local.sh build test/test_keeper_memory_lane.exe test/test_keeper_memory_os_consolidation_runtime.exe test/test_server_bootstrap_maintenance_memory_os.exe
- test_keeper_memory_lane.exe: 9/9 passed
- test_keeper_memory_os_consolidation_runtime.exe: 10/10 passed
- test_server_bootstrap_maintenance_memory_os.exe: 3/3 passed
- Full build and suite remain CI authority.

Stacked on #24807. This PR itself is 214 additions and 130 deletions.