### PR TITLE
fix(config): drop deployment-local keeper assignment from public seed

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -987,12 +987,13 @@ candidates = [
 # keepers fall back to [runtime].default. Per-keeper overrides in the
 # live config (<base>/.masc/config/runtime.toml) take precedence.
 #
-# Seed only nick0cave to the local Gemma 4 canary. Other keepers use the
-# fleet default unless their live config overrides this seed.
+# The public seed ships no keeper assignments: keeper names are
+# deployment-local identities, so per-keeper routing belongs in the live
+# config, not here (enforced by test_runtime_config_validity "public seed
+# has no keeper assignments").
 # Do not assign general keeper lanes to Pro here. Pro is reserved for explicit
 # judge/evaluator lanes ([runtime].cross_verifier and [fusion].judge).
 [runtime.assignments]
-nick0cave = "ollama.gemma4-26b-a4b-qat"
 # example: route a test keeper through the failover lane
 # canary = "default"
 


### PR DESCRIPTION
## 문제

green train #24735 착지 후 첫 main run(29474225831)의 `Runtime TOML validity gate`가 6초 만에 fail:

```
FAIL public seed has no keeper assignments
   Expected: `0'
```

train이 gate 테스트에 "public seed는 keeper assignment를 싣지 않는다" 불변식(test_runtime_config_validity.ml:724)을 추가했는데, 시드 `config/runtime.toml:995`에는 `nick0cave = "ollama.gemma4-26b-a4b-qat"`가 남아 있었습니다.

## 판단

테스트의 불변식이 옳습니다: keeper 이름은 deployment-local identity라 public repo 시드에 개별 라우팅을 박는 것은 배포 누수입니다. 시드 주석 자체가 "live config(<base>/.masc/config/runtime.toml)가 우선"이라고 명시하고 있고, nick0cave의 실제 라우팅은 live config 소관입니다.

## 수정

- 시드에서 `nick0cave` 할당 1줄 제거, 주석을 불변식 서술로 교체 (`[runtime.assignments]` 섹션과 예시 주석은 유지)
- 코드/테스트 무변경

## 검증

- `test_runtime_config_validity.exe` 로컬 **38/38** (실패하던 gate #7 포함)

Refs: #24735 (불변식 도입), run 29474225831 (첫 재현)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
