### PR TITLE
fix(gate): recover Auto Judge backlog safely

### DIFF
--- a/dashboard/src/api/dashboard-gate.ts
+++ b/dashboard/src/api/dashboard-gate.ts
@@ -171,6 +171,9 @@ export interface SetGateModeResponse {
   previous_mode: GateMode | null
   actor: string
   changed_at: string
+  reopened?: number
+  started?: number
+  queued?: number
 }
 
 export function setGateMode(mode: GateMode): Promise<SetGateModeResponse> {

--- a/dashboard/src/components/approvals/approvals-surface.ts
+++ b/dashboard/src/components/approvals/approvals-surface.ts
@@ -466,8 +466,8 @@ function ApAside({
           <div class="wka-auto-note">
             Human은 사람이 판단하고, Auto Judge는 LLM이 판단하며, Always Allow는 workspace의 명시적 선택입니다.
           </div>
-          ${gateMode?.state === 'invalid' || gateMode?.read_error
-            ? html`<div class="ap-env-warn mono">Gate mode invalid: ${gateMode.read_error ?? '상태 파싱 실패'}</div>`
+          ${gateMode?.state === 'invalid' || gateMode?.state === 'unavailable' || gateMode?.read_error
+            ? html`<div class="ap-env-warn mono">Gate mode ${gateMode.state ?? 'invalid'}: ${gateMode.read_error ?? '상태 확인 실패'}</div>`
             : null}
         </div>
       </section>

--- a/dashboard/src/components/gate-actions.ts
+++ b/dashboard/src/components/gate-actions.ts
@@ -74,12 +74,15 @@ export const GATE_MODE_ACTING_KEY = 'gate-mode'
 export async function setKeeperGateMode(mode: GateMode) {
   gateApprovalActing.value = GATE_MODE_ACTING_KEY
   try {
-    await setGateMode(mode)
+    const result = await setGateMode(mode)
     const label = mode === 'manual' ? 'Human' : mode === 'auto_judge' ? 'Auto Judge' : 'Always Allow'
-    showToast(`Gate 모드를 ${label}(으)로 전환했습니다`, 'success')
+    const recovery = mode === 'auto_judge' && (result.reopened ?? 0) > 0
+      ? ` · 실패 ${(result.reopened ?? 0).toLocaleString()}건 재평가 시작`
+      : ''
+    showToast(`Gate 모드를 ${label}(으)로 저장했습니다${recovery}`, 'success')
     await refreshGate({ force: true })
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Gate 모드를 변경하지 못했습니다'
+    const message = err instanceof Error ? err.message : 'Gate 모드를 저장하지 못했습니다'
     gateError.value = message
     showToast(message, 'error')
   } finally {

--- a/lib/keeper/hitl_summary_worker.ml
+++ b/lib/keeper/hitl_summary_worker.ml
@@ -9,6 +9,8 @@ let system_prompt () =
   Prompt_registry.render_prompt_template Keeper_prompt_names.gate_judgment []
 ;;
 
+let readiness () = Result.map (fun (_ : string) -> ()) (system_prompt ())
+
 type summary_provider =
   { runtime_id : string
   ; provider_config : Llm_provider.Provider_config.t
@@ -37,6 +39,25 @@ let provider_config_for_summary ~keeper_name =
       summary_runtime_id
       fallback_runtime_id;
     resolve fallback_runtime_id
+;;
+
+let effective_max_concurrency ~configured ~runtime_limit =
+  match runtime_limit with
+  | Some limit -> Int.min configured limit
+  | None -> configured
+;;
+
+let max_concurrency () =
+  let configured = Keeper_config.hitl_summary_max_concurrency () in
+  let runtime_limit =
+    match Runtime.hitl_summary_runtime_id () with
+    | Some runtime_id ->
+      (match Runtime.get_runtime_by_id runtime_id with
+       | Some runtime -> runtime.Runtime.binding.max_concurrent
+       | None -> None)
+    | None -> None
+  in
+  effective_max_concurrency ~configured ~runtime_limit
 ;;
 
 (* ── Metrics ────────────────────────────────────── *)
@@ -225,7 +246,7 @@ let build_context_bundle ~(entry : pending_approval) : Yojson.Safe.t =
     ; "input", entry.input
     ; ( "request_context"
       , match entry.request_context with
-        | Some context -> context
+        | Some context -> Keeper_gate_request_context.project context
         | None -> `Null )
     ; "task", task_json
     ; "goals", goals_json
@@ -271,6 +292,16 @@ let summary_llm_error_outcomes ~mode error =
     | _ -> "provider_error"
   in
   plain_mode_degradation_outcomes mode @ [ terminal ]
+;;
+
+let summary_llm_error_retryable error =
+  error
+  |> Agent_sdk.Error_domain.of_sdk_error
+  |> Agent_sdk.Error_domain.is_retryable
+;;
+
+let sdk_error_of_http_error error =
+  Agent_sdk.Provider_failure_attribution.sdk_error_of_http_error error
 ;;
 
 (** Appended on the [Plain_json_text] path so a model without native structured
@@ -334,8 +365,7 @@ let call_summary_llm ~sw ~net ~runtime_id ~provider_config ~context_bundle () =
   | Ok messages ->
     (match
        Keeper_provider_subcall.complete ~sw ~net ~config ~messages ()
-       |> Result.map_error (fun http_err ->
-            Agent_sdk.Error.Internal (Provider_http_error.to_message http_err))
+       |> Result.map_error sdk_error_of_http_error
      with
      | Ok response -> Ok (response, mode)
      | Error error -> Error (Llm_call_error { mode; error }))
@@ -455,7 +485,9 @@ let spawn
                List.iter
                  record_outcome
                  (summary_llm_error_outcomes ~mode error);
-               on_failure ~reason:(Agent_sdk.Error.to_string error) ~retryable:true)
+               on_failure
+                 ~reason:(Agent_sdk.Error.to_string error)
+                 ~retryable:(summary_llm_error_retryable error)))
       with
       | Eio.Cancel.Cancelled _ as e -> raise e
       | exn ->
@@ -478,6 +510,9 @@ module For_testing = struct
   let provider_config_for_summary = prepare_provider_config
   let extract_json_object = extract_json_object
   let summary_llm_error_outcomes = summary_llm_error_outcomes
+  let summary_llm_error_retryable = summary_llm_error_retryable
+  let sdk_error_of_http_error = sdk_error_of_http_error
+  let effective_max_concurrency = effective_max_concurrency
   let system_prompt = system_prompt
   let summary_version = summary_version
 end

--- a/lib/keeper/hitl_summary_worker.ml
+++ b/lib/keeper/hitl_summary_worker.ml
@@ -487,7 +487,7 @@ let spawn
                  (summary_llm_error_outcomes ~mode error);
                on_failure
                  ~reason:(Agent_sdk.Error.to_string error)
-                 ~retryable:(summary_llm_error_retryable error)))
+                 ~retryable:(summary_llm_error_retryable error))
       with
       | Eio.Cancel.Cancelled _ as e -> raise e
       | exn ->

--- a/lib/keeper/hitl_summary_worker.mli
+++ b/lib/keeper/hitl_summary_worker.mli
@@ -6,6 +6,14 @@ type summary_provider = private
 
 val provider_config_for_summary : keeper_name:string -> summary_provider option
 
+(** Effective Auto Judge worker cap. The subsystem cap is further bounded by
+    the selected runtime binding's [max_concurrent] declaration. *)
+val max_concurrency : unit -> int
+
+(** Verify that the registry-owned Gate judgment prompt is renderable. This is
+    the readiness floor for selecting the workspace Auto Judge mode. *)
+val readiness : unit -> (unit, string) result
+
 (** Spawn an asynchronous HITL context-summary worker for [runtime_id].
     The worker is fire-and-forget: it calls [on_summary] only for a validated
     LLM judgment and [on_failure] for every unavailable, timeout, transport, or
@@ -69,6 +77,14 @@ module For_testing : sig
     :  mode:summary_mode
     -> Agent_sdk.Error.sdk_error
     -> string list
+
+  val summary_llm_error_retryable : Agent_sdk.Error.sdk_error -> bool
+
+  val sdk_error_of_http_error
+    : Llm_provider.Http_client.http_error -> Agent_sdk.Error.sdk_error
+
+  val effective_max_concurrency
+    : configured:int -> runtime_limit:int option -> int
 
   val summary_version : int
 end

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -1106,7 +1106,7 @@ let create_entry
   ; input
   ; requested_at = Unix.gettimeofday ()
   ; turn_id
-  ; request_context
+  ; request_context = Option.map Keeper_gate_request_context.project request_context
   ; task_id
   ; goal_id
   ; goal_ids
@@ -1355,6 +1355,57 @@ let restart_failed_summary ~id =
         Ok false)
   in
   publish_summary_transition ~id updated
+;;
+
+let restart_failed_summaries ~base_path =
+  let updated =
+    with_pending_store_lock (fun () ->
+      let map = Atomic.get pending in
+      let reopened_ids, reopened, context_compacted =
+        SMap.fold
+          (fun id (entry : pending_approval) (ids, acc, compacted) ->
+             if String.equal entry.audit_base_path base_path
+             then (
+               let request_context =
+                 Option.map Keeper_gate_request_context.project entry.request_context
+               in
+               let context_changed =
+                 match entry.request_context, request_context with
+                 | Some before, Some after -> not (Yojson.Safe.equal before after)
+                 | None, None -> false
+                 | Some _, None | None, Some _ -> true
+               in
+               let entry = { entry with request_context } in
+               match entry.summary_status with
+               | Summary_failed _ ->
+                 ( id :: ids
+                 , SMap.add id { entry with summary_status = Summary_not_requested } acc
+                 , compacted || context_changed )
+               | Summary_not_requested | Summary_pending | Summary_available _ ->
+                 ids, SMap.add id entry acc, compacted || context_changed)
+             else ids, acc, compacted)
+          map
+          ([], map, false)
+      in
+      match reopened_ids, context_compacted with
+      | [], false -> Ok []
+      | _ ->
+        (match
+           persist_snapshot_unlocked
+             ~base_path
+             ~pending_map:reopened
+             ~delivery_map:(Atomic.get deliveries)
+         with
+         | Error _ as error -> error
+         | Ok () ->
+           Atomic.set pending reopened;
+           Ok (List.rev reopened_ids)))
+  in
+  match updated with
+  | Error _ as error -> error
+  | Ok ids ->
+    List.iter (fun id -> publish_summary_update ~id) ids;
+    Ok ids
 ;;
 
 let record_resolution_delivery_failure ~keeper_name ~approval_id reason =

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -240,6 +240,12 @@ val mark_summary_failed :
     classification never controls work. There is no timer or retry count. *)
 val restart_failed_summary : id:string -> (bool, storage_error) result
 
+(** Explicit operator recovery: transition every failed summary for this
+    workspace back to [Summary_not_requested] in one durable transaction.
+    This includes failures previously classified terminal; only an operator
+    action may reopen those entries. Returns the reopened approval ids. *)
+val restart_failed_summaries : base_path:string -> (string list, storage_error) result
+
 val pending_count : unit -> int
 val pending_count_for_keeper : keeper_name:string -> int
 val has_pending_for_keeper : keeper_name:string -> bool

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -307,7 +307,6 @@ let keeper_unified_max_tokens () : int =
   Runtime_params.get keeper_unified_max_tokens_rp
 
 (* ── HITL context-summary worker policy ─────────────────────── *)
-
 (** Temperature for the HITL summary LLM call. Deterministic by default. *)
 let hitl_summary_temperature_rp =
   _rp_float ~key:"keeper.hitl_summary.temperature"
@@ -318,11 +317,29 @@ let hitl_summary_temperature_rp =
 let hitl_summary_temperature () : float =
   Runtime_params.get hitl_summary_temperature_rp
 
+(** Maximum number of request-local Auto Judge calls that may be in flight.
+    A bounded queue prevents an operator recovery of a large durable backlog
+    from turning into an unbounded provider burst. *)
+let hitl_summary_max_concurrency_rp =
+  _rp_int ~key:"keeper.hitl_summary.max_concurrency"
+    ~default:(fun () ->
+      int_of_env_default
+        "MASC_KEEPER_HITL_SUMMARY_MAX_CONCURRENCY"
+        ~default:4
+        ~min_v:1
+        ~max_v:32)
+    ~min_v:1
+    ~max_v:32
+    ~description:"Maximum concurrent HITL Auto Judge calls" ()
+let hitl_summary_max_concurrency () : int =
+  Runtime_params.get hitl_summary_max_concurrency_rp
+
 (** Force module initialization to guarantee all runtime params are registered
     before [Runtime_params.restore]. Call from server bootstrap. *)
 let ensure_runtime_params_init () =
   let (_ : float) = Runtime_params.get keeper_unified_temperature_rp in
   let (_ : float) = Runtime_params.get hitl_summary_temperature_rp in
+  let (_ : int) = Runtime_params.get hitl_summary_max_concurrency_rp in
   ()
 
 let keeper_enable_thinking_rp =

--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -184,6 +184,7 @@ val keeper_unified_max_tokens : unit -> int
 (** {2 HITL Context-Summary Worker Policy} *)
 
 val hitl_summary_temperature : unit -> float
+val hitl_summary_max_concurrency : unit -> int
 
 val keeper_status_fast_default : unit -> bool
 

--- a/lib/keeper/keeper_gate.ml
+++ b/lib/keeper/keeper_gate.ml
@@ -282,6 +282,8 @@ let active_auto_judges : Auto_judge_ids.t Atomic.t =
 let rec claim_auto_judge id =
   let active = Atomic.get active_auto_judges in
   if Auto_judge_ids.mem id active
+     || Auto_judge_ids.cardinal active
+        >= Hitl_summary_worker.max_concurrency ()
   then false
   else
     let claimed = Auto_judge_ids.add id active in
@@ -297,7 +299,7 @@ let rec release_auto_judge id =
   then release_auto_judge id
 ;;
 
-let spawn_claimed_auto_judge_entry
+let rec spawn_claimed_auto_judge_entry
       (entry : Keeper_approval_queue.pending_approval)
   =
   let approval_id = entry.id in
@@ -373,7 +375,9 @@ let spawn_claimed_auto_judge_entry
          ~provider_config:selected.provider_config
          ~on_summary
          ~on_failure
-         ~on_finish:(fun () -> release_auto_judge approval_id)
+         ~on_finish:(fun () ->
+           release_auto_judge approval_id;
+           ignore (drain_auto_judges ~base_path:entry.audit_base_path))
          ();
        Ok Started
      with
@@ -394,15 +398,13 @@ let spawn_claimed_auto_judge_entry
       ~reason:"Auto Judge unavailable: no runtime provider is configured"
       ~retryable:true
   | Some _, Error reason -> fail_before_worker ~reason ~retryable:true
-;;
 
-let spawn_auto_judge_entry (entry : Keeper_approval_queue.pending_approval) =
+and spawn_auto_judge_entry (entry : Keeper_approval_queue.pending_approval) =
   if claim_auto_judge entry.id
   then spawn_claimed_auto_judge_entry entry
   else Ok Skipped
-;;
 
-let retry_auto_judge_entry (entry : Keeper_approval_queue.pending_approval) =
+and retry_auto_judge_entry (entry : Keeper_approval_queue.pending_approval) =
   if not (claim_auto_judge entry.id)
   then Ok Skipped
   else
@@ -414,9 +416,8 @@ let retry_auto_judge_entry (entry : Keeper_approval_queue.pending_approval) =
       release_auto_judge entry.id;
       Ok Skipped
     | Ok true -> spawn_claimed_auto_judge_entry entry
-;;
 
-let start_auto_judge approval_id =
+and start_auto_judge approval_id =
   match Keeper_approval_queue.get_pending_entry ~id:approval_id with
   | None -> Ok Skipped
   | Some entry ->
@@ -431,6 +432,51 @@ let start_auto_judge approval_id =
          release_auto_judge approval_id;
          Ok Skipped
        | Ok true -> spawn_claimed_auto_judge_entry entry)
+
+and drain_auto_judges ~base_path =
+  match Keeper_gate_mode.read ~base_path with
+  | Error _
+  | Ok (Keeper_gate_mode.Manual | Keeper_gate_mode.Always_allow) -> []
+  | Ok Keeper_gate_mode.Auto_judge ->
+    let capacity =
+      Hitl_summary_worker.max_concurrency ()
+      - Auto_judge_ids.cardinal (Atomic.get active_auto_judges)
+    in
+    if capacity <= 0
+    then []
+    else
+      Keeper_approval_queue.list_pending_entries ()
+      |> List.filter (fun (entry : Keeper_approval_queue.pending_approval) ->
+        String.equal entry.audit_base_path base_path
+        &&
+        match entry.summary_status with
+        | Keeper_approval_queue.Summary_not_requested
+        | Keeper_approval_queue.Summary_pending -> true
+        | Keeper_approval_queue.Summary_available _
+        | Keeper_approval_queue.Summary_failed _ -> false)
+      |> List.sort
+           (fun (left : Keeper_approval_queue.pending_approval)
+                (right : Keeper_approval_queue.pending_approval) ->
+              Float.compare left.requested_at right.requested_at)
+      |> List.filteri (fun index _ -> index < capacity)
+      |> List.filter_map (fun (entry : Keeper_approval_queue.pending_approval) ->
+        let started =
+          match entry.summary_status with
+          | Keeper_approval_queue.Summary_not_requested -> start_auto_judge entry.id
+          | Keeper_approval_queue.Summary_pending -> spawn_auto_judge_entry entry
+          | Keeper_approval_queue.Summary_available _
+          | Keeper_approval_queue.Summary_failed _ -> Ok Skipped
+        in
+        match started with
+        | Ok Started -> Some entry.id
+        | Ok Skipped -> None
+        | Error reason ->
+          Log.Keeper.error
+            ~keeper_name:entry.keeper_name
+            "Auto Judge bounded drain failed approval=%s: %s"
+            entry.id
+            reason;
+          None)
 ;;
 
 type recovered_work =
@@ -559,6 +605,43 @@ let resume_persisted_auto_judges ~base_path =
   ; skipped_ids = List.rev skipped_ids
   ; failures = List.rev failures
   }
+;;
+
+type operator_recovery_report =
+  { reopened_ids : string list
+  ; started_ids : string list
+  ; queued : int
+  }
+
+let request_operator_auto_judge_recovery ~base_path =
+  match Keeper_gate_mode.read ~base_path with
+  | Error detail -> Error detail
+  | Ok (Keeper_gate_mode.Manual | Keeper_gate_mode.Always_allow) ->
+    Error "operator Auto Judge recovery requires auto_judge mode"
+  | Ok Keeper_gate_mode.Auto_judge ->
+    (match Hitl_summary_worker.readiness () with
+     | Error detail -> Error detail
+     | Ok () ->
+    (match Keeper_approval_queue.restart_failed_summaries ~base_path with
+     | Error error -> Error (Keeper_approval_queue.storage_error_to_string error)
+     | Ok reopened_ids ->
+       let started_ids = drain_auto_judges ~base_path in
+       let queued =
+         Keeper_approval_queue.list_pending_entries ()
+         |> List.fold_left
+              (fun count (entry : Keeper_approval_queue.pending_approval) ->
+                 if String.equal entry.audit_base_path base_path
+                    &&
+                    match entry.summary_status with
+                    | Keeper_approval_queue.Summary_not_requested
+                    | Keeper_approval_queue.Summary_pending -> true
+                    | Keeper_approval_queue.Summary_available _
+                    | Keeper_approval_queue.Summary_failed _ -> false
+                 then count + 1
+                 else count)
+              0
+       in
+       Ok { reopened_ids; started_ids; queued }))
 ;;
 
 let defer request reason =

--- a/lib/keeper/keeper_gate.ml
+++ b/lib/keeper/keeper_gate.ml
@@ -377,6 +377,7 @@ let rec spawn_claimed_auto_judge_entry
          ~on_failure
          ~on_finish:(fun () ->
            release_auto_judge approval_id;
+           (* fire-and-forget: the queue owns subsequent worker completion. *)
            ignore (drain_auto_judges ~base_path:entry.audit_base_path))
          ();
        Ok Started

--- a/lib/keeper/keeper_gate.mli
+++ b/lib/keeper/keeper_gate.mli
@@ -97,6 +97,18 @@ val retry_failed_auto_judge : requested_by:string -> string -> (unit, string) re
     classification is diagnostic only; operator authority controls this state
     transition. No cadence, restart hook, or retry budget calls it. *)
 
+type operator_recovery_report =
+  { reopened_ids : string list
+  ; started_ids : string list
+  ; queued : int
+  }
+
+(** Reopen failed request-local judgments after an explicit operator selection
+    of Auto Judge, then start a concurrency-bounded drain of every unresolved
+    judgment for the workspace. *)
+val request_operator_auto_judge_recovery :
+  base_path:string -> (operator_recovery_report, string) result
+
 val authorization_source_to_string : authorization_source -> string
 val deferred_reason_to_string : deferred_reason -> string
 val unavailable_reason_to_string : unavailable_reason -> string

--- a/lib/keeper/keeper_gate_mode.ml
+++ b/lib/keeper/keeper_gate_mode.ml
@@ -65,6 +65,21 @@ let read ~base_path =
 
 let status_json ~base_path =
   match read ~base_path with
+  | Ok Auto_judge ->
+    (match Hitl_summary_worker.readiness () with
+     | Ok () ->
+       `Assoc
+         [ "mode", `String (to_string Auto_judge)
+         ; "configured", `Bool (Sys.file_exists (path ~base_path))
+         ; "state", `String "ready"
+         ]
+     | Error detail ->
+       `Assoc
+         [ "mode", `String (to_string Auto_judge)
+         ; "configured", `Bool (Sys.file_exists (path ~base_path))
+         ; "state", `String "unavailable"
+         ; "read_error", `String detail
+         ])
   | Ok mode ->
     `Assoc
       [ "mode", `String (to_string mode)

--- a/lib/keeper/keeper_gate_request_context.ml
+++ b/lib/keeper/keeper_gate_request_context.ml
@@ -1,0 +1,86 @@
+let history_evidence history_messages =
+  let count =
+    match history_messages with
+    | `List messages -> List.length messages
+    | _ -> 0
+  in
+  let sha256 =
+    history_messages
+    |> Yojson.Safe.to_string
+    |> Digestif.SHA256.digest_string
+    |> Digestif.SHA256.to_hex
+  in
+  `Assoc
+    [ "schema", `String "masc.keeper_gate.history_evidence.v1"
+    ; "included", `Bool false
+    ; "count", `Int count
+    ; "sha256", `String sha256
+    ]
+;;
+
+let text_evidence ~schema text =
+  `Assoc
+    [ "schema", `String schema
+    ; "included", `Bool false
+    ; "bytes", `Int (String.length text)
+    ; ( "sha256"
+      , `String Digestif.SHA256.(digest_string text |> to_hex) )
+    ]
+;;
+
+let project_text_field ~field ~evidence_field ~schema fields =
+  match List.assoc_opt field fields with
+  | Some (`String text) ->
+    fields
+    |> List.remove_assoc field
+    |> List.remove_assoc evidence_field
+    |> List.cons (evidence_field, text_evidence ~schema text)
+  | Some _ | None -> fields
+;;
+
+let project = function
+  | `Assoc fields as context ->
+    (match List.assoc_opt "initial" fields with
+     | Some (`Assoc initial_fields) ->
+       (match List.assoc_opt "history_messages" initial_fields with
+        | Some history_messages ->
+          let projected_initial =
+            initial_fields
+            |> List.remove_assoc "history_messages"
+            |> List.remove_assoc "history_messages_evidence"
+            |> List.cons
+                 ( "history_messages_evidence"
+                 , history_evidence history_messages )
+            |> project_text_field
+                 ~field:"base_system_prompt"
+                 ~evidence_field:"base_system_prompt_evidence"
+                 ~schema:"masc.keeper_gate.system_prompt_evidence.v1"
+            |> project_text_field
+                 ~field:"turn_system_prompt"
+                 ~evidence_field:"turn_system_prompt_evidence"
+                 ~schema:"masc.keeper_gate.system_prompt_evidence.v1"
+          in
+          `Assoc
+            (("initial", `Assoc projected_initial)
+             :: List.remove_assoc "initial" fields)
+        | None ->
+          let projected_initial =
+            initial_fields
+            |> project_text_field
+                 ~field:"base_system_prompt"
+                 ~evidence_field:"base_system_prompt_evidence"
+                 ~schema:"masc.keeper_gate.system_prompt_evidence.v1"
+            |> project_text_field
+                 ~field:"turn_system_prompt"
+                 ~evidence_field:"turn_system_prompt_evidence"
+                 ~schema:"masc.keeper_gate.system_prompt_evidence.v1"
+          in
+          if Yojson.Safe.equal (`Assoc initial_fields) (`Assoc projected_initial)
+          then context
+          else
+            `Assoc
+              (("initial", `Assoc projected_initial)
+               :: List.remove_assoc "initial" fields))
+     | Some _ | None -> context)
+  | context -> context
+;;

--- a/lib/keeper/keeper_gate_request_context.mli
+++ b/lib/keeper/keeper_gate_request_context.mli
@@ -1,0 +1,9 @@
+(** Durable projection for request-local Gate evidence.
+
+    The exact current user/dynamic context, operation input, and completed tool
+    calls remain inline. Historical Keeper messages are already durable in the
+    Keeper checkpoint, and executing-agent system prompts are code-owned policy
+    rather than request evidence. Both are represented by metadata plus SHA-256
+    so the Gate queue does not duplicate them in every pending request. *)
+
+val project : Yojson.Safe.t -> Yojson.Safe.t

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -405,6 +405,19 @@ let handle_gate_mode_body state operator_name request reqd body_str =
            (operator_error_json message)
        | Ok mode ->
          let config = Mcp_server.workspace_config state in
+         let readiness =
+           match mode with
+           | Keeper_gate_mode.Auto_judge -> Hitl_summary_worker.readiness ()
+           | Keeper_gate_mode.Manual | Keeper_gate_mode.Always_allow -> Ok ()
+         in
+         (match readiness with
+          | Error detail ->
+            respond_json_value_with_cors
+              ~status:`Service_unavailable
+              request
+              reqd
+              (operator_error_json ("Auto Judge unavailable: " ^ detail))
+          | Ok () ->
          (match Keeper_gate_mode.set config ~actor:operator_name mode with
           | Error message ->
             respond_json_value_with_cors
@@ -426,10 +439,38 @@ let handle_gate_mode_body state operator_name request reqd body_str =
                  ; "actor", `String operator_name
                  ; "changed_at", `String change.changed_at
                  ]);
+            let recovery =
+              match mode with
+              | Keeper_gate_mode.Auto_judge ->
+                Keeper_gate.request_operator_auto_judge_recovery
+                  ~base_path:config.base_path
+              | Keeper_gate_mode.Manual | Keeper_gate_mode.Always_allow ->
+                Ok
+                  { Keeper_gate.reopened_ids = []
+                  ; started_ids = []
+                  ; queued = 0
+                  }
+            in
+            (match recovery with
+             | Error detail ->
+               respond_json_value_with_cors
+                 ~status:`Service_unavailable
+                 request
+                 reqd
+                 (operator_error_json
+                    ("Gate mode saved, but Auto Judge recovery failed: " ^ detail))
+             | Ok recovery ->
             respond_json_value_with_cors
               request
               reqd
-              (Keeper_gate_mode.change_json change)))
+              (match Keeper_gate_mode.change_json change with
+               | `Assoc fields ->
+                 `Assoc
+                   (("reopened", `Int (List.length recovery.reopened_ids))
+                    :: ("started", `Int (List.length recovery.started_ids))
+                    :: ("queued", `Int recovery.queued)
+                    :: fields)
+               | other -> other)))))
   with
   | Eio.Cancel.Cancelled _ as error -> raise error
   | Yojson.Json_error message ->

--- a/test/test_hitl_summary_worker.ml
+++ b/test/test_hitl_summary_worker.ml
@@ -210,7 +210,7 @@ let test_http_error_mapping_preserves_typed_domain () =
 
 let test_gate_judgment_prompt_comes_from_registry () =
   Prompt_registry.set_markdown_dir
-    (Filename.concat (Sys.getcwd ()) "config/prompts");
+    (Masc_test_deps.source_path "config/prompts");
   match Worker.For_testing.system_prompt () with
   | Error detail -> fail ("Gate judgment prompt unavailable: " ^ detail)
   | Ok prompt ->
@@ -218,7 +218,7 @@ let test_gate_judgment_prompt_comes_from_registry () =
 ;;
 
 let test_readiness_fails_when_gate_prompt_is_missing () =
-  let original_dir = Filename.concat (Sys.getcwd ()) "config/prompts" in
+  let original_dir = Masc_test_deps.source_path "config/prompts" in
   let empty_dir =
     Filename.concat
       (Filename.get_temp_dir_name ())

--- a/test/test_hitl_summary_worker.ml
+++ b/test/test_hitl_summary_worker.ml
@@ -22,7 +22,17 @@ let sample_entry : Q.pending_approval =
   ; request_context =
       Some
         (`Assoc
-           [ "user_message", `String "inspect the exact requested operation" ])
+           [ ( "initial"
+             , `Assoc
+                 [ "history_messages", `List [ `String "older turn" ]
+                 ; "base_system_prompt", `String "base policy"
+                 ; "turn_system_prompt", `String "turn policy"
+                 ; "user_message", `String "inspect the exact requested operation"
+                 ; "dynamic_context", `String "current context"
+                 ; "runtime_id", `String "runtime"
+                 ] )
+           ; "completed_tool_calls", `List []
+           ])
   ; task_id = None
   ; goal_id = None
   ; goal_ids = []
@@ -106,12 +116,51 @@ let test_context_bundle_contains_exact_input_without_derived_classification () =
   let bundle = Worker.For_testing.build_context_bundle ~entry:sample_entry in
   let open Yojson.Safe.Util in
   check yojson "exact input" sample_entry.input (bundle |> member "input");
-  check yojson
-    "exact outer-turn context"
-    (Option.get sample_entry.request_context)
-    (bundle |> member "request_context");
+  let initial = bundle |> member "request_context" |> member "initial" in
+  check string "exact current user message"
+    "inspect the exact requested operation"
+    (initial |> member "user_message" |> to_string);
+  check yojson "executing-agent turn policy omitted" `Null
+    (initial |> member "turn_system_prompt");
+  let turn_policy_evidence = initial |> member "turn_system_prompt_evidence" in
+  check int "turn policy byte count" 11
+    (turn_policy_evidence |> member "bytes" |> to_int);
+  check int "turn policy digest is sha256" 64
+    (turn_policy_evidence |> member "sha256" |> to_string |> String.length);
+  check yojson "historical messages omitted" `Null
+    (initial |> member "history_messages");
+  let evidence = initial |> member "history_messages_evidence" in
+  check bool "historical omission is explicit" false
+    (evidence |> member "included" |> to_bool);
+  check string "historical evidence schema"
+    "masc.keeper_gate.history_evidence.v1"
+    (evidence |> member "schema" |> to_string);
+  check int "historical message count" 1
+    (evidence |> member "count" |> to_int);
+  check int "historical digest is sha256" 64
+    (evidence |> member "sha256" |> to_string |> String.length);
   check yojson "no derived classification" `Null (bundle |> member "classification");
   check yojson "no derived level" `Null (bundle |> member "level")
+;;
+
+let test_request_context_projection_is_idempotent () =
+  let projected =
+    Option.get sample_entry.request_context
+    |> Masc.Keeper_gate_request_context.project
+  in
+  check yojson "projection is idempotent" projected
+    (Masc.Keeper_gate_request_context.project projected)
+;;
+
+let test_concurrency_respects_runtime_binding () =
+  check int "runtime binding narrows subsystem cap" 1
+    (Worker.For_testing.effective_max_concurrency
+       ~configured:4
+       ~runtime_limit:(Some 1));
+  check int "subsystem cap remains when runtime omits a limit" 4
+    (Worker.For_testing.effective_max_concurrency
+       ~configured:4
+       ~runtime_limit:None)
 ;;
 
 let test_plain_json_requires_exact_object () =
@@ -126,6 +175,39 @@ let test_plain_json_requires_exact_object () =
             ("```json\n" ^ Yojson.Safe.to_string expected ^ "\n```")))
 ;;
 
+let test_typed_llm_retryability () =
+  check bool "context overflow is terminal for the exact request" false
+    (Worker.For_testing.summary_llm_error_retryable
+       (Agent_sdk.Error.Api
+          (ContextOverflow { message = "too large"; limit = Some 131072 })));
+  check bool "network failure remains retryable" true
+    (Worker.For_testing.summary_llm_error_retryable
+       (Agent_sdk.Error.Api
+          (NetworkError
+             { message = "refused"
+             ; kind = Llm_provider.Http_client.Connection_refused
+             })))
+;;
+
+let test_http_error_mapping_preserves_typed_domain () =
+  check bool "transport timeout stays typed" true
+    (match
+       Worker.For_testing.sdk_error_of_http_error
+         (Llm_provider.Http_client.TimeoutError
+            { message = "deadline"; phase = Non_streaming_body })
+     with
+     | Agent_sdk.Error.Provider (Llm_provider.Error.Timeout _) -> true
+     | _ -> false);
+  check bool "network failure stays typed" true
+    (match
+       Worker.For_testing.sdk_error_of_http_error
+         (Llm_provider.Http_client.NetworkError
+            { message = "refused"; kind = Connection_refused })
+     with
+     | Agent_sdk.Error.Api (NetworkError _) -> true
+     | _ -> false)
+;;
+
 let test_gate_judgment_prompt_comes_from_registry () =
   Prompt_registry.set_markdown_dir
     (Filename.concat (Sys.getcwd ()) "config/prompts");
@@ -133,6 +215,33 @@ let test_gate_judgment_prompt_comes_from_registry () =
   | Error detail -> fail ("Gate judgment prompt unavailable: " ^ detail)
   | Ok prompt ->
     check bool "prompt is non-empty" true (String.trim prompt <> "")
+;;
+
+let test_readiness_fails_when_gate_prompt_is_missing () =
+  let original_dir = Filename.concat (Sys.getcwd ()) "config/prompts" in
+  let empty_dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      ("masc-hitl-prompt-readiness-" ^ string_of_int (Random.bits ()))
+  in
+  Unix.mkdir empty_dir 0o700;
+  Fun.protect
+    ~finally:(fun () ->
+      Prompt_registry.set_markdown_dir original_dir;
+      Unix.rmdir empty_dir)
+    (fun () ->
+       Prompt_registry.set_markdown_dir empty_dir;
+       match Worker.readiness () with
+       | Ok () -> fail "missing Gate prompt reported ready"
+       | Error detail ->
+         check bool "missing prompt is explicit" true
+           (Astring.String.is_infix ~affix:"keeper.gate_judgment" detail);
+          let open Yojson.Safe.Util in
+          let status = Masc.Keeper_gate_mode.status_json ~base_path:empty_dir in
+          check string "dashboard status is unavailable" "unavailable"
+            (status |> member "state" |> to_string);
+          check bool "dashboard status carries readiness error" true
+            (status |> member "read_error" |> to_string |> String.trim <> ""))
 ;;
 
 let () =
@@ -154,13 +263,33 @@ let () =
             `Quick
             test_context_bundle_contains_exact_input_without_derived_classification
         ; test_case
+            "runtime binding caps judge concurrency"
+            `Quick
+            test_concurrency_respects_runtime_binding
+        ; test_case
+            "request context projection is idempotent"
+            `Quick
+            test_request_context_projection_is_idempotent
+        ; test_case
             "plain JSON requires exact object"
             `Quick
             test_plain_json_requires_exact_object
         ; test_case
+            "LLM retryability uses typed SDK domain"
+            `Quick
+            test_typed_llm_retryability
+        ; test_case
+            "HTTP errors preserve typed SDK domains"
+            `Quick
+            test_http_error_mapping_preserves_typed_domain
+        ; test_case
             "Gate judgment prompt is registry-owned"
             `Quick
             test_gate_judgment_prompt_comes_from_registry
+        ; test_case
+            "Gate judgment readiness fails when missing"
+            `Quick
+            test_readiness_fails_when_gate_prompt_is_missing
         ] )
     ]
 ;;

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -711,6 +711,50 @@ let test_all_summary_failures_accept_explicit_restart () =
        reject_and_cleanup terminal_id)
 ;;
 
+let test_operator_recovery_reopens_all_failed_summaries () =
+  let base_path = temp_dir () in
+  let keeper_name = "queue-summary-operator-recovery" in
+  Fun.protect
+    ~finally:(fun () ->
+      AQ.For_testing.reset_runtime_state ();
+      cleanup_dir base_path)
+    (fun () ->
+       let retryable_id =
+         submit ~base_path ~keeper_name ~input:(`String "retryable")
+       in
+       let terminal_id =
+         submit ~base_path ~keeper_name ~input:(`String "terminal")
+       in
+       List.iter
+         (fun id -> check_update "mark pending" true (AQ.mark_summary_pending ~id))
+         [ retryable_id; terminal_id ];
+       check_update
+         "retryable failure"
+         true
+         (AQ.mark_summary_failed ~id:retryable_id ~reason:"transport" ~retryable:true);
+       check_update
+         "terminal failure"
+         true
+         (AQ.mark_summary_failed ~id:terminal_id ~reason:"prompt" ~retryable:false);
+       let reopened =
+         match AQ.restart_failed_summaries ~base_path with
+         | Ok ids -> List.sort String.compare ids
+         | Error error -> Alcotest.fail (AQ.storage_error_to_string error)
+       in
+       Alcotest.(check (list string))
+         "explicit operator action reopens both classes"
+         (List.sort String.compare [ retryable_id; terminal_id ])
+         reopened;
+       List.iter
+         (fun id ->
+            match AQ.get_pending_entry ~id with
+            | Some { summary_status = AQ.Summary_not_requested; _ } -> ()
+            | Some _ | None -> Alcotest.fail "failed summary was not reopened")
+         reopened;
+       reject_and_cleanup retryable_id;
+       reject_and_cleanup terminal_id)
+;;
+
 let test_lane_activity_does_not_retry_failed_auto_judge () =
   let base_path = temp_dir () in
   let keeper_a = "queue-retry-lane-a" in
@@ -1314,6 +1358,10 @@ let () =
             "lane activity never retries a failed Auto Judge"
             `Quick
             test_lane_activity_does_not_retry_failed_auto_judge
+        ; Alcotest.test_case
+            "operator recovery reopens terminal failures"
+            `Quick
+            test_operator_recovery_reopens_all_failed_summaries
         ; Alcotest.test_case
             "decisive summary finalizes after restart"
             `Quick


### PR DESCRIPTION
## Summary

- bootstrap the prompt registry before persisted Auto Judge recovery starts
- fail closed when the judgment prompt is unavailable and expose readiness in the dashboard
- make an explicit Auto Judge save reopen retryable/terminal summary failures without a hot loop
- classify provider failures through typed OAS SDK domains and use the provider-owned body deadline
- compact durable approval context to exact current-turn evidence plus hashed historical evidence
- bound judge concurrency by both the HITL runtime parameter and the selected runtime binding

## Root cause

Persisted Auto Judge recovery started before prompt bootstrap, so recovered entries failed with `Prompt 'keeper.gate_judgment' is missing`. The mode endpoint reported ready without rendering the prompt. Retryable failures had no explicit operator recovery path, and historical Keeper context was duplicated into every durable request, inflating the queue and process memory.

## Verification

- `scripts/dune-local.sh build test/test_hitl_summary_worker.exe test/test_keeper_approval_queue.exe test/test_server_runtime_bootstrap.exe`
- `test_hitl_summary_worker.exe test`: 12/12
- `test_keeper_approval_queue.exe test`: 19/19
- `test_server_runtime_bootstrap.exe test bootstrap 23`: 1/1
- Dashboard TypeScript typecheck
- focused Dashboard Vitest: 99/99
- `git diff --check`
- touched OCaml files pass `ocamlformat --check`

## Live evidence

- patched binary commit `38ac9a6266` ran for about eight hours on `127.0.0.1:8935`
- prompt-missing failures stopped after startup ordering was fixed
- an explicit Auto Judge save returned HTTP 200 and reopened failed work
- durable queue shrank from about 172 MB to about 8.7 MB after projection/migration
- delivery journal recorded 85 `auto_judge` decisions and 10 `human_operator` decisions during the long run
- Auto Judge produced both approve and deny outcomes; `require_human` judgments remained open for a human
- the remaining long-run failures were typed 60-second provider timeouts, not prompt/readiness failures

The live daemon was later externally restarted from the root main checkout, so the currently running `8935` binary is not this branch. Runtime lane drift is reported separately from this source fix.

## Related follow-up issues

- #24744 fresh-runtime autoboot recursive mutex deadlock
- #24745 fresh embedded config retains retired masc_keeper_msg tokens
