### PR TITLE
test(routing): give catalog fixtures real provider identity

### DIFF
--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -307,6 +307,16 @@ supports_tools = true
 supports_response_format_json = true
 supports_structured_output = true
 supports_native_streaming = true
+
+[[providers]]
+id = "kimi"
+kind = "kimi"
+identity_kinds = ["kimi", "openai_compat"]
+base_url = "https://api.kimi.com/coding"
+request_path = "/v1/messages"
+api_key_env = "KIMI_API_KEY"
+capabilities_base = "kimi"
+identity_hosts = ["api.kimi.com"]
 |}
 ;;
 
@@ -1067,7 +1077,8 @@ max-concurrent = 1
 let runtime_thinking_model_catalog =
   {|
 [[models]]
-id_prefix = "openai_compat/qwen36-35b-a3b-mtp"
+id_prefix = "qwen36-35b-a3b-mtp"
+provider_name = "ollama_cloud"
 base = "openai_chat"
 max_context_tokens = 131072
 max_output_tokens = 65536
@@ -1104,7 +1115,8 @@ supports_computer_use = true
 supports_code_execution = true
 
 [[models]]
-id_prefix = "openai_compat/reasoning-small-out"
+id_prefix = "reasoning-small-out"
+provider_name = "ollama_cloud"
 base = "openai_chat"
 max_context_tokens = 131072
 max_output_tokens = 4096
@@ -1114,7 +1126,8 @@ supports_extended_thinking = true
 supports_native_streaming = true
 
 [[models]]
-id_prefix = "openai_compat/reasoning-big-out"
+id_prefix = "reasoning-big-out"
+provider_name = "ollama_cloud"
 base = "openai_chat"
 max_context_tokens = 1000000
 max_output_tokens = 200000


### PR DESCRIPTION
## 요약

quick-suite 잔여 실패 6케이스(`runtime-assignment routing 15`, `per-model thinking gate 4/5`, `runtime token capacity projection 0/1/2`)의 수리. 전부 `test_runtime_per_keeper_routing`의 카탈로그 fixture가 OAS 0.212의 provider-qualified capability lookup 계약(명시 `provider_name` 필드 + 정확 `id_prefix`, bare fallback 없음)을 모르던 문제입니다.

- models-only 카탈로그에 kimi `[[providers]]` 엔트리 부재 → messages-http registry gate가 init_default를 거부 (case 15)
- 모델 행의 `"openai_compat/..."` prefix 철자가 ollama_cloud 런타임과 절대 매치 불가 → capability 미스가 runtime.toml projection의 기본값(no_toggle/기본 캡)으로 강등 (thinking 4/5, token capacity 0/1/2)

OAS 카탈로그의 kimi provider 엔트리를 미러하고, 3개 모델 행에 `provider_name = "ollama_cloud"`를 선언.

## 검증

- main(c22e50c6e9) 위에서 39/39 로컬 통과 (수리 전 동일 지점 6 FAIL 재현 확인)
- DET/NDT gate PASS

## 맥락

#24735 green train 착지 후 순수 main 실측에서 유일하게 남은 quick-suite 결정론 실패. 이 PR 착지 시 잔여 known-red는 #24794(patch-mode 보안 결정 대기)와 #24774(coordination flake, RFC급)뿐.

RFC-WAIVED: 테스트 fixture 전용 변경.
