### PR TITLE
fix(memory): detach GC from fleet maintenance tick

### DIFF
--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -151,7 +151,7 @@ type t =
   | MemoryLaneInFlight
   | MemoryLaneProviderSlotBusy
   | MemoryBankCompactionFailures
-  | MemoryOsMaintenanceKeeperTimeout
+  | MemoryOsGcDispatches
   | MemoryOsConsolidationDispatches
   | WriteMetaCycleFailures
   | AlertPersistFailures
@@ -375,7 +375,7 @@ let to_string = function
   | MemoryLaneInFlight -> "masc_keeper_memory_lane_in_flight"
   | MemoryLaneProviderSlotBusy -> "masc_keeper_memory_lane_provider_slot_busy_total"
   | MemoryBankCompactionFailures -> "masc_keeper_memory_bank_compaction_failures_total"
-  | MemoryOsMaintenanceKeeperTimeout -> "masc_keeper_memory_os_maintenance_keeper_timeout_total"
+  | MemoryOsGcDispatches -> "masc_keeper_memory_os_gc_dispatch_total"
   | MemoryOsConsolidationDispatches -> "masc_keeper_memory_os_consolidation_dispatch_total"
   | WriteMetaCycleFailures -> "masc_keeper_write_meta_cycle_failures_total"
   | AlertPersistFailures -> "masc_keeper_alert_persist_failures_total"

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -142,7 +142,7 @@ type t =
   | MemoryLaneInFlight
   | MemoryLaneProviderSlotBusy
   | MemoryBankCompactionFailures
-  | MemoryOsMaintenanceKeeperTimeout
+  | MemoryOsGcDispatches
   | MemoryOsConsolidationDispatches
   | WriteMetaCycleFailures
   | AlertPersistFailures

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -101,44 +101,87 @@ let runtime_for_memory_os_consolidation () =
        default_runtime ())
 ;;
 
-(* P0-3: per-keeper maintenance timeout. One slow/corrupt keeper must not starve
-   the rest of the fleet. Each keeper fiber gets a bounded time budget; on
-   timeout we log the keeper and increment a metric so operators can see which
-   stores are stalling maintenance. *)
-let run_with_keeper_timeout ~clock ~timeout_sec ~keeper_id ~on_timeout f =
-  match clock with
-  | None -> f ()
-  | Some clock ->
-    (try Eio.Time.with_timeout_exn clock timeout_sec f with
-     | Eio.Time.Timeout ->
-       Otel_metric_store.inc_counter
-         Keeper_metrics.(to_string MemoryOsMaintenanceKeeperTimeout)
-         ~labels:[ "keeper", keeper_id ]
-         ();
-       on_timeout ())
-;;
-
-type memory_os_consolidation_dispatch =
+type memory_os_lane_dispatch =
   | Dispatch_started
   | Dispatch_already_active
   | Dispatch_executor_unavailable
   | Dispatch_fork_failed
 
-let memory_os_consolidation_dispatch_label = function
+let memory_os_lane_dispatch_label = function
   | Dispatch_started -> "started"
   | Dispatch_already_active -> "already_active"
   | Dispatch_executor_unavailable -> "executor_unavailable"
   | Dispatch_fork_failed -> "fork_failed"
 ;;
 
-let record_memory_os_consolidation_dispatch ~keeper_id outcome =
+let memory_os_lane_dispatch_of_submission = function
+  | Keeper_memory_lane.Idle_submitted -> Dispatch_started
+  | Idle_already_active -> Dispatch_already_active
+  | Idle_executor_unavailable -> Dispatch_executor_unavailable
+  | Idle_fork_failed -> Dispatch_fork_failed
+;;
+
+let observe_memory_os_lane_dispatch ~metric ~operation ~keeper_id submission =
+  let outcome = memory_os_lane_dispatch_of_submission submission in
+  let outcome_label = memory_os_lane_dispatch_label outcome in
   Otel_metric_store.inc_counter
-    Keeper_metrics.(to_string MemoryOsConsolidationDispatches)
-    ~labels:
-      [ "keeper", keeper_id
-      ; "outcome", memory_os_consolidation_dispatch_label outcome
-      ]
-    ()
+    Keeper_metrics.(to_string metric)
+    ~labels:[ "keeper", keeper_id; "outcome", outcome_label ]
+    ();
+  match outcome with
+  | Dispatch_started | Dispatch_already_active ->
+    Log.Server.info
+      "%s: keeper=%s dispatch=%s"
+      operation
+      keeper_id
+      outcome_label
+  | Dispatch_executor_unavailable | Dispatch_fork_failed ->
+    Log.Server.warn
+      "%s: keeper=%s dispatch=%s"
+      operation
+      keeper_id
+      outcome_label
+;;
+
+(* Dispatch exact-expiry cleanup independently for every Keeper fact store.
+   The tick owns no child work: each accepted unit is owned by that Keeper's
+   memory lane, so a blocked file lock or I/O operation cannot hold the fleet
+   tick or prevent peer Keepers from starting. *)
+let run_memory_os_gc_tick
+      ?(run_gc =
+        fun ~keeper_id ~now () -> Keeper_memory_os_gc.run_gc ~keeper_id ~now ())
+      ~base_path
+      ~now
+      ()
+  =
+  let gc_one keeper_id () =
+    try
+      let report = run_gc ~keeper_id ~now () in
+      if report.Keeper_memory_os_gc.ttl_expired > 0
+      then
+        Log.Server.info
+          "memory_os_gc: keeper=%s ttl_expired=%d written=%d"
+          keeper_id
+          report.ttl_expired
+          report.written
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+      Log.Server.warn
+        "memory_os_gc: keeper=%s tick crashed: %s"
+        keeper_id
+        (Printexc.to_string exn)
+  in
+  Keeper_memory_os_io.list_fact_store_keeper_ids ()
+  |> List.iter (fun keeper_id ->
+    Keeper_memory_lane.submit_if_idle
+      ~base_path
+      ~keeper_name:keeper_id
+      (fun _worker_sw -> gc_one keeper_id ())
+    |> observe_memory_os_lane_dispatch
+         ~metric:Keeper_metrics.MemoryOsGcDispatches
+         ~operation:"memory_os_gc"
+         ~keeper_id)
 ;;
 
 (* Run one consolidation pass over every keeper that currently has a fact store.
@@ -226,28 +269,11 @@ let run_memory_os_consolidation_tick
            ~keeper_name:keeper_id
            (fun worker_sw -> consolidate_one worker_sw keeper_id ())
        in
-       let dispatch, level, detail =
-         match outcome with
-         | Keeper_memory_lane.Idle_submitted ->
-           Dispatch_started, `Info, "started"
-         | Idle_already_active ->
-           Dispatch_already_active, `Info, "already_active"
-         | Idle_executor_unavailable ->
-           Dispatch_executor_unavailable, `Warn, "executor_unavailable"
-         | Idle_fork_failed -> Dispatch_fork_failed, `Warn, "fork_failed"
-       in
-       record_memory_os_consolidation_dispatch ~keeper_id dispatch;
-       match level with
-       | `Info ->
-         Log.Server.info
-           "memory_os_keeper_consolidation: keeper=%s dispatch=%s"
-           keeper_id
-           detail
-       | `Warn ->
-         Log.Server.warn
-           "memory_os_keeper_consolidation: keeper=%s dispatch=%s"
-           keeper_id
-           detail)
+       observe_memory_os_lane_dispatch
+         ~metric:Keeper_metrics.MemoryOsConsolidationDispatches
+         ~operation:"memory_os_keeper_consolidation"
+         ~keeper_id
+         outcome)
     keeper_ids
 ;;
 
@@ -382,56 +408,21 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
   (* RFC-0247 §2.3: memory-os expiry sweep. Off the keeper hot path — every
      [interval]s it runs the deterministic per-keeper GC: facts whose explicit
      [valid_until] has passed are removed and every other row is preserved.
-     Default ON; env var [MASC_KEEPER_MEMORY_OS_GC] is the kill switch. Per-keeper
-     fibers run in parallel with a bounded timeout so one slow/corrupt store
-     cannot starve the fleet. *)
+     Default ON; env var [MASC_KEEPER_MEMORY_OS_GC] is the kill switch. Each
+     accepted unit belongs to its Keeper memory lane; the loop never joins or
+     cancels peer work. *)
   if Env_config.KeeperMemoryOs.gc_enabled () then
     fork_logged_fiber
       ~sw
       ~on_error:(log_server_fiber_crash "memory_os_gc")
       (fun () ->
-      (* Coarser than consolidation (300s): GC rewrites stores, so a 10-minute
-         cadence is ample off the hot path. *)
+      (* GC keeps the existing 10-minute maintenance cadence. *)
       let interval = 600.0 in
-      let gc_one keeper_id () =
-        try
-          let report =
-            Keeper_memory_os_gc.run_gc ~keeper_id ~now:(Time_compat.now ()) ()
-          in
-          if report.Keeper_memory_os_gc.ttl_expired > 0
-          then
-            Log.Server.info
-              "memory_os_gc: keeper=%s ttl_expired=%d written=%d"
-              keeper_id
-              report.ttl_expired
-              report.written
-        with
-        | Eio.Cancel.Cancelled _ as e -> raise e
-        | exn ->
-          Log.Server.warn
-            "memory_os_gc: keeper=%s tick crashed: %s"
-            keeper_id
-            (Printexc.to_string exn)
-      in
       let rec loop () =
-        let keeper_ids =
-          List.filter
-            (fun id -> not (String.equal id Keeper_memory_os_types.shared_store_id))
-            (Keeper_memory_os_io.list_fact_store_keeper_ids ())
-        in
-        Eio.Fiber.all
-          (List.map
-             (fun keeper_id () ->
-                run_with_keeper_timeout
-                  ~clock:(Some clock)
-                  ~timeout_sec:120.0
-                  ~keeper_id
-                  ~on_timeout:(fun () ->
-                    Log.Server.warn
-                      "memory_os_gc: keeper=%s timeout after 120s"
-                      keeper_id)
-                  (gc_one keeper_id))
-             keeper_ids);
+        run_memory_os_gc_tick
+          ~base_path:(Mcp_server.workspace_config state).base_path
+          ~now:(Time_compat.now ())
+          ();
         Eio.Time.sleep clock interval;
         loop ()
       in

--- a/lib/server/server_bootstrap_maintenance.mli
+++ b/lib/server/server_bootstrap_maintenance.mli
@@ -6,6 +6,20 @@ val runtime_for_memory_os_consolidation : unit -> Runtime.t option
 (** Resolve the selected consolidation runtime without discarding its identity;
     an unknown explicit selection is logged before falling back to the default. *)
 
+val run_memory_os_gc_tick :
+  ?run_gc:
+    (keeper_id:string ->
+     now:float ->
+     unit ->
+     Keeper_memory_os_gc.gc_report) ->
+  base_path:string ->
+  now:float ->
+  unit ->
+  unit
+(** Dispatch one exact-expiry GC unit per persisted Keeper onto that Keeper's
+    memory lane. The tick never waits for a dispatched unit. An already active
+    Keeper is observed and skipped while peer Keepers continue independently. *)
+
 val run_memory_os_consolidation_tick :
   ?complete:Keeper_memory_os_consolidation_runtime.complete_fn ->
   base_path:string ->

--- a/test/test_server_bootstrap_maintenance_memory_os.ml
+++ b/test/test_server_bootstrap_maintenance_memory_os.ml
@@ -8,6 +8,7 @@
 
 module Types = Masc.Keeper_memory_os_types
 module Io = Masc.Keeper_memory_os_io
+module GC = Masc.Keeper_memory_os_gc
 module Recall = Masc.Keeper_memory_os_recall
 module Lane = Masc.Keeper_memory_lane
 module Atypes = Agent_sdk.Types
@@ -49,6 +50,17 @@ let provider_cfg () =
     ~model_id:"fake"
     ~base_url:"http://localhost"
     ()
+;;
+
+let empty_gc_report =
+  { GC.total_input = 0
+  ; ttl_expired = 0
+  ; ttl_expired_ephemeral = 0
+  ; ttl_expired_non_ephemeral = 0
+  ; ttl_expired_by_category = []
+  ; written = 0
+  ; dry_run = false
+  }
 ;;
 
 let with_temp_keepers ~sw f =
@@ -235,6 +247,58 @@ let test_parallel_natural_completion_per_keeper () =
           Alcotest.(check int) "slow keeper unchanged" slow_count_before slow_count_after))))
 ;;
 
+let test_gc_tick_isolates_active_keeper () =
+  Eio_main.run (fun _env ->
+    Eio.Switch.run (fun sw ->
+      with_temp_keepers ~sw (fun base_path ->
+        let keeper_ids = [ "keeper-gc-a"; "keeper-gc-b" ] in
+        List.iter
+          (fun keeper_id -> Io.append_fact ~keeper_id (fact (keeper_id ^ " fact")))
+          keeper_ids;
+        let calls = Atomic.make 0 in
+        let release_first, set_release_first = Eio.Promise.create () in
+        let first_started, set_first_started = Eio.Promise.create () in
+        let peer_finished, set_peer_finished = Eio.Promise.create () in
+        let peer_repeated, set_peer_repeated = Eio.Promise.create () in
+        let run_gc ~keeper_id ~now:_ () =
+          (match Atomic.fetch_and_add calls 1 with
+           | 0 ->
+             Eio.Promise.resolve set_first_started keeper_id;
+             Eio.Promise.await release_first
+           | 1 -> Eio.Promise.resolve set_peer_finished keeper_id
+           | 2 -> Eio.Promise.resolve set_peer_repeated keeper_id
+           | call_index ->
+             Alcotest.failf "unexpected GC call index: %d" call_index);
+          empty_gc_report
+        in
+        Server_bootstrap_maintenance.run_memory_os_gc_tick
+          ~run_gc
+          ~base_path
+          ~now
+          ();
+        let active_keeper = Eio.Promise.await first_started in
+        let peer_keeper = Eio.Promise.await peer_finished in
+        Alcotest.(check bool)
+          "first tick dispatched a distinct peer"
+          true
+          (not (String.equal active_keeper peer_keeper));
+        await_pending ~base_path ~keeper_ids 1;
+        Alcotest.(check int) "first tick dispatched both keepers" 2 (Atomic.get calls);
+        Server_bootstrap_maintenance.run_memory_os_gc_tick
+          ~run_gc
+          ~base_path
+          ~now
+          ();
+        let repeated_keeper = Eio.Promise.await peer_repeated in
+        Alcotest.(check string)
+          "second tick skipped only the active keeper"
+          peer_keeper
+          repeated_keeper;
+        Alcotest.(check int) "only the idle peer ran again" 3 (Atomic.get calls);
+        Eio.Promise.resolve set_release_first ();
+        await_pending ~base_path ~keeper_ids 0)))
+;;
+
 let () =
   Alcotest.run
     "server_bootstrap_maintenance_memory_os"
@@ -251,6 +315,10 @@ let () =
             "parallel per-keeper natural completion"
             `Quick
             test_parallel_natural_completion_per_keeper
+        ; Alcotest.test_case
+            "GC tick isolates one active Keeper"
+            `Quick
+            test_gc_tick_isolates_active_keeper
         ] )
     ]
 ;;


### PR DESCRIPTION
## Outcome

- Removes the Memory OS GC `run_with_keeper_timeout` 120-second execution cancellation and its retired timeout metric.
- Removes the fleet-wide `Eio.Fiber.all` join from the GC maintenance tick.
- Dispatches each persisted Keeper's exact-expiry GC through `Keeper_memory_lane.submit_if_idle`.
- Records typed `started`, `already_active`, `executor_unavailable`, and `fork_failed` outcomes under a GC-specific metric and explicit log.

## Root cause

The old loop waited for every Keeper GC fiber and cancelled each one after 120 seconds. One blocked Keeper therefore held the whole maintenance tick until the timeout, while a valid long-running rewrite was terminated by a MASC-owned wall-clock policy.

The replacement tick owns no child work. Each accepted unit is owned by its Keeper memory lane, so the tick returns after dispatch, an active Keeper alone is skipped on later ticks, and idle peers continue independently.

## Stack

- Base: #24808 — consolidation uses the same nonblocking per-Keeper lane boundary.
- This PR: Memory OS GC timeout/join hard cut.

## Deterministic proof

The new Promise fixture holds the first Keeper GC indefinitely without any elapsed-time assertion. It proves that:

1. the peer Keeper completes and the first tick returns;
2. exactly one Keeper remains active;
3. the next tick skips only that active Keeper and runs the peer again;
4. releasing the held Promise drains both lanes cleanly.

## Residual, intentionally not faked

Accepted GC work is still process-owned rather than durably replayed after restart. This PR does not add a second queue or an in-memory replay marker. #24817 records the exact follow-up: extend the existing durable Memory FIFO/owner drain rather than inventing another SSOT.

## Verification

- `scripts/dune-local.sh build test/test_server_bootstrap_maintenance_memory_os.exe`
- `_build/default/test/test_server_bootstrap_maintenance_memory_os.exe` — 4/4 passed
- `GITHUB_BASE_REF=codex/memory-consolidation-no-timeout-v2 python3 scripts/check_test_coverage.py`
- `ocamlc -stop-after parsing` for every changed OCaml file
- `ocamlformat --check` for every changed OCaml file
- `git diff --check`
- Stacked diff: 167 additions / 94 deletions = 261 changed lines

## Evidence

[근거] [Eio Fiber 1.3 official API](https://ocaml.org/p/eio/latest/doc/Eio/Fiber/index.html) — checked 2026-07-16, confidence High. `Fiber.fork ~sw` does not wait for the child, while `Fiber.all` waits for all supplied fibers; the implementation uses the former at the Keeper-owned lane boundary and removes the latter from the fleet tick.
