### PR TITLE
refactor(connector): hard-delete transport breaker

### DIFF
--- a/docs/CONNECTOR-CONFIG-SCHEMA.md
+++ b/docs/CONNECTOR-CONFIG-SCHEMA.md
@@ -24,8 +24,6 @@ env  >  runtime TOML  >  field defaults
 | `gate_base_url` | `GATE_BASE_URL` (Discord/Slack/Telegram), `MASC_GATE_URL` (iMessage) | `http://localhost:8935` | MASC server. Loopback host relaxes auth. |
 | `gate_api_token` | `GATE_API_TOKEN`, `MASC_GATE_API_TOKEN` (iMessage) | `""` | Required unless `gate_base_url` is loopback. |
 | `gate_timeout_sec` | `GATE_TIMEOUT_SEC` | 120 (30 for iMessage) | int/float seconds, must be positive. |
-| `gate_breaker_failure_threshold` | `GATE_BREAKER_FAILURE_THRESHOLD` | 3 (5 for iMessage) | consecutive 5xx/timeout before circuit opens. |
-| `gate_breaker_reset_sec` | `GATE_BREAKER_RESET_SEC` | 30 (60 for iMessage) | half-open wait. |
 | `status_cache_ttl_sec` | `STATUS_CACHE_TTL_SEC` | 15 (10 for iMessage) | gate status cache. |
 | `keeper_cache_ttl_sec` | `KEEPER_CACHE_TTL_SEC` | 30 | keeper discovery cache. |
 | `binding_store_path` | `<NAME>_BINDING_STORE_PATH` | `.gate/runtime/<name>/bindings.json` | runtime-bind file. |

--- a/sidecars/imessage-bot/src/config.py
+++ b/sidecars/imessage-bot/src/config.py
@@ -28,6 +28,7 @@ DEFAULT_STATUS_PATH: Final[str] = ".gate/runtime/imessage/status.json"
 DEFAULT_CURSOR_PATH: Final[str] = ".gate/runtime/imessage/cursor.json"
 CHAT_DB_PATH: Final[str] = os.path.expanduser("~/Library/Messages/chat.db")
 
+
 def _runtime_toml_path() -> Path:
     raw = os.getenv("MASC_BASE_PATH", "").strip()
     root = Path(raw).expanduser() if raw else Path.cwd()
@@ -68,7 +69,13 @@ class BotConfig(BaseSettings):
         toml_source = TomlConfigSettingsSource(
             settings_cls, toml_file=_runtime_toml_path()
         )
-        return (init_settings, env_settings, dotenv_settings, toml_source, file_secret_settings)
+        return (
+            init_settings,
+            env_settings,
+            dotenv_settings,
+            toml_source,
+            file_secret_settings,
+        )
 
     # Gate connection
     gate_base_url: str = Field(
@@ -99,8 +106,6 @@ class BotConfig(BaseSettings):
 
     # Gate HTTP
     gate_timeout_sec: float = Field(default=30.0)
-    gate_breaker_failure_threshold: int = Field(default=5)
-    gate_breaker_reset_sec: int = Field(default=60)
 
     # Cache
     status_cache_ttl_sec: int = Field(default=10)

--- a/sidecars/imessage-bot/src/gate_client.py
+++ b/sidecars/imessage-bot/src/gate_client.py
@@ -36,8 +36,6 @@ class GateClient(GateClientBase):
             gate_api_token=cfg.gate_api_token,
             gate_origin=cfg.gate_origin(),
             timeout_sec=cfg.gate_timeout_sec,
-            breaker_failure_threshold=cfg.gate_breaker_failure_threshold,
-            breaker_reset_sec=cfg.gate_breaker_reset_sec,
             status_cache_ttl_sec=cfg.status_cache_ttl_sec,
             keeper_cache_ttl_sec=cfg.keeper_cache_ttl_sec,
         )

--- a/sidecars/shared/gate_shared/__init__.py
+++ b/sidecars/shared/gate_shared/__init__.py
@@ -14,13 +14,16 @@ from .diagnostics import (
     render_json,
     render_pretty,
 )
-from .gate_client_base import BreakerSnapshot, GateClientBase
+from .gate_client_base import GateClientBase
 from .gate_response import GateResponse
-from .structured_content import SUPPORTED_BLOCK_TYPES, response_text, structured_plain_text
+from .structured_content import (
+    SUPPORTED_BLOCK_TYPES,
+    response_text,
+    structured_plain_text,
+)
 
 __all__ = [
     "AutoFix",
-    "BreakerSnapshot",
     "Check",
     "CheckFn",
     "Diagnostics",

--- a/sidecars/shared/gate_shared/gate_client_base.py
+++ b/sidecars/shared/gate_shared/gate_client_base.py
@@ -1,4 +1,4 @@
-"""Base Channel Gate client with circuit breaker and HTTP transport.
+"""Base Channel Gate client with HTTP transport.
 
 Connector-specific clients subclass this and provide their
 ``_channel_context()`` method.
@@ -10,7 +10,6 @@ import json as json_mod
 import logging
 import time
 from collections.abc import AsyncIterator
-from dataclasses import dataclass
 from typing import Any, cast
 
 import httpx
@@ -25,18 +24,8 @@ from .gate_response import GateResponse
 logger = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True, slots=True)
-class BreakerSnapshot:
-    """Current transport breaker state."""
-
-    open: bool
-    remaining_sec: int
-    consecutive_failures: int
-    last_failure: str
-
-
 class GateClientBase:
-    """HTTP client for the Channel Gate API with circuit breaker.
+    """HTTP client for the Channel Gate API.
 
     Subclass and implement ``_channel_context()`` for each connector.
     """
@@ -49,8 +38,6 @@ class GateClientBase:
         gate_api_token: str,
         gate_origin: str,
         timeout_sec: float = 30.0,
-        breaker_failure_threshold: int = 3,
-        breaker_reset_sec: int = 30,
         status_cache_ttl_sec: int = 15,
         keeper_cache_ttl_sec: int = 30,
     ) -> None:
@@ -63,16 +50,11 @@ class GateClientBase:
         self._keeper_status_url = f"{base}/api/v1/gate/keeper-status"
         self._stream_url = f"{base}/api/v1/keepers/chat/stream"
         self._timeout = timeout_sec
-        self._breaker_failure_threshold = breaker_failure_threshold
-        self._breaker_reset_sec = breaker_reset_sec
         self._status_cache_ttl = status_cache_ttl_sec
         self._keeper_cache_ttl = keeper_cache_ttl_sec
 
         self._headers = self._build_headers(gate_api_token, gate_origin)
         self._client: httpx.AsyncClient | None = None
-        self._consecutive_failures = 0
-        self._breaker_open_until = 0.0
-        self._last_failure = ""
         self._status_cache: tuple[float, dict[str, Any]] | None = None
         self._keeper_names_cache: tuple[float, list[str]] | None = None
         self._keeper_status_cache: dict[str, tuple[float, dict[str, Any]]] = {}
@@ -88,51 +70,13 @@ class GateClientBase:
             headers["Origin"] = origin
         return headers
 
-    # ── Time / Circuit Breaker ─────────────────────────────
+    # ── Time ───────────────────────────────────────────────
 
     def _now(self) -> float:
         return time.monotonic()
 
-    def _breaker_is_open(self) -> bool:
-        return self._breaker_open_until > self._now()
-
-    def _breaker_enabled(self) -> bool:
-        return self._breaker_failure_threshold > 0 and self._breaker_reset_sec > 0
-
-    def _breaker_error(self) -> str:
-        remaining = max(1, int(round(self._breaker_open_until - self._now())))
-        if self._last_failure:
-            return (
-                f"connector circuit open for {remaining}s after transport failures: "
-                f"{self._last_failure}"
-            )
-        return f"connector circuit open for {remaining}s after transport failures"
-
-    def _note_success(self) -> None:
-        self._consecutive_failures = 0
-        self._breaker_open_until = 0.0
-        self._last_failure = ""
-
-    def _note_transport_failure(self, reason: str) -> None:
-        self._consecutive_failures += 1
-        self._last_failure = reason
-        if self._breaker_enabled() and self._consecutive_failures >= self._breaker_failure_threshold:
-            self._breaker_open_until = self._now() + self._breaker_reset_sec
-        logger.warning(
-            "Gate transport failure %d/%d: %s",
-            self._consecutive_failures,
-            self._breaker_failure_threshold,
-            reason,
-        )
-
-    def breaker_snapshot(self) -> BreakerSnapshot:
-        remaining = max(0, int(round(self._breaker_open_until - self._now())))
-        return BreakerSnapshot(
-            open=self._breaker_is_open(),
-            remaining_sec=remaining,
-            consecutive_failures=self._consecutive_failures,
-            last_failure=self._last_failure,
-        )
+    def _observe_transport_failure(self, reason: str) -> None:
+        logger.warning("Gate transport failure: %s", reason)
 
     # ── HTTP Client ────────────────────────────────────────
 
@@ -161,41 +105,31 @@ class GateClientBase:
         *,
         json_body: dict[str, Any] | None = None,
         params: dict[str, str] | None = None,
-        allow_breaker_cache: tuple[float, dict[str, Any]] | None = None,
     ) -> dict[str, Any] | None:
-        if self._breaker_is_open():
-            if allow_breaker_cache is not None and self._cache_fresh(
-                allow_breaker_cache, self._status_cache_ttl
-            ):
-                return allow_breaker_cache[1]
-            logger.warning("Gate request short-circuited: %s", self._breaker_error())
-            return None
-
         client = self._get_client()
         try:
             response = await client.request(method, url, json=json_body, params=params)
             if response.status_code >= 500:
-                self._note_transport_failure(f"gate returned {response.status_code}")
+                self._observe_transport_failure(f"gate returned {response.status_code}")
                 return None
             if response.status_code >= 400:
-                logger.info("Gate returned %d for %s %s", response.status_code, method, url)
-                self._note_success()
+                logger.info(
+                    "Gate returned %d for %s %s", response.status_code, method, url
+                )
                 return None
             raw_data = response.json()
             if not isinstance(raw_data, dict):
                 logger.warning("Gate returned non-object JSON from %s %s", method, url)
-                self._note_success()
                 return None
-            self._note_success()
             return cast(dict[str, Any], raw_data)
         except httpx.TimeoutException:
-            self._note_transport_failure(f"gate timeout after {self._timeout}s")
+            self._observe_transport_failure(f"gate timeout after {self._timeout}s")
             return None
         except httpx.HTTPError as e:
-            self._note_transport_failure(f"gate http error: {e}")
+            self._observe_transport_failure(f"gate http error: {e}")
             return None
         except Exception as e:
-            self._note_transport_failure(f"gate error: {e}")
+            self._observe_transport_failure(f"gate error: {e}")
             return None
 
     # ── Gate API Methods ───────────────────────────────────
@@ -216,9 +150,6 @@ class GateClientBase:
             context: Channel-specific context (channel, channel_user_id, etc.)
             idempotency_key: Unique key to prevent duplicate processing.
         """
-        if self._breaker_is_open():
-            return GateResponse.from_error(self._breaker_error())
-
         payload = {
             **context,
             "keeper_name": keeper_name,
@@ -230,27 +161,24 @@ class GateClientBase:
         try:
             resp = await client.post(self._message_url, json=payload)
             if resp.status_code == 409:
-                self._note_success()
                 return GateResponse.from_error("duplicate message")
             if resp.status_code >= 500:
-                self._note_transport_failure(f"gate returned {resp.status_code}")
+                self._observe_transport_failure(f"gate returned {resp.status_code}")
                 return GateResponse.from_error(f"gate returned {resp.status_code}")
 
             raw_data = resp.json()
             if not isinstance(raw_data, dict):
-                self._note_success()
                 return GateResponse.from_error("gate returned invalid json")
 
-            self._note_success()
             return GateResponse.from_json(cast(dict[str, Any], raw_data))
         except httpx.TimeoutException:
-            self._note_transport_failure(f"gate timeout after {self._timeout}s")
+            self._observe_transport_failure(f"gate timeout after {self._timeout}s")
             return GateResponse.from_error(f"gate timeout after {self._timeout}s")
         except httpx.HTTPError as e:
-            self._note_transport_failure(f"gate http error: {e}")
+            self._observe_transport_failure(f"gate http error: {e}")
             return GateResponse.from_error(f"gate http error: {e}")
         except Exception as e:
-            self._note_transport_failure(f"gate error: {e}")
+            self._observe_transport_failure(f"gate error: {e}")
             return GateResponse.from_error(f"gate error: {e}")
 
     async def health_check(self) -> bool:
@@ -259,8 +187,6 @@ class GateClientBase:
             self._status_cache, self._status_cache_ttl
         ):
             return True
-        if self._breaker_is_open():
-            return False
         data = await self._request_json("GET", self._health_url)
         return data is not None
 
@@ -272,7 +198,6 @@ class GateClientBase:
         data = await self._request_json(
             "GET",
             self._status_url,
-            allow_breaker_cache=self._status_cache,
         )
         if data is None:
             if self._cache_fresh(self._status_cache, self._status_cache_ttl):
@@ -284,7 +209,9 @@ class GateClientBase:
 
     async def list_keepers(self, *, force: bool = False) -> list[str]:
         """Return keeper names for autocomplete and binding validation."""
-        if not force and self._cache_fresh(self._keeper_names_cache, self._keeper_cache_ttl):
+        if not force and self._cache_fresh(
+            self._keeper_names_cache, self._keeper_cache_ttl
+        ):
             assert self._keeper_names_cache is not None
             return self._keeper_names_cache[1]
 
@@ -361,9 +288,6 @@ class GateClientBase:
         if _httpx_sse is None:
             logger.warning("httpx-sse not installed; streaming unavailable")
             return
-        if self._breaker_is_open():
-            return
-
         payload = {
             "name": keeper_name,
             "message": message,
@@ -385,11 +309,10 @@ class GateClientBase:
                 ),
             ) as event_source:
                 if event_source.response.status_code >= 400:
-                    self._note_transport_failure(
+                    self._observe_transport_failure(
                         f"stream returned {event_source.response.status_code}"
                     )
                     return
-                self._note_success()
                 async for sse in event_source.aiter_sse():
                     if not sse.data:
                         continue
@@ -416,13 +339,13 @@ class GateClientBase:
                         logger.warning("Keeper stream error: %s", err)
                         return
         except httpx.TimeoutException as e:
-            self._note_transport_failure(f"stream transport timeout: {e}")
+            self._observe_transport_failure(f"stream transport timeout: {e}")
             raise
         except httpx.HTTPError as e:
-            self._note_transport_failure(f"stream http error: {e}")
+            self._observe_transport_failure(f"stream http error: {e}")
             raise
         except Exception as e:  # pragma: no cover
-            self._note_transport_failure(f"stream error: {e}")
+            self._observe_transport_failure(f"stream error: {e}")
             raise
 
     # ── Activity Polling ─────────────────────────────────
@@ -462,7 +385,9 @@ class GateClientBase:
             if isinstance(data, dict):
                 events = data.get("events", [])
                 if isinstance(events, list):
-                    return [cast(dict[str, Any], e) for e in events if isinstance(e, dict)]
+                    return [
+                        cast(dict[str, Any], e) for e in events if isinstance(e, dict)
+                    ]
         except Exception as e:  # pragma: no cover
             logger.warning("Activity poll error: %s", e)
         return []

--- a/sidecars/shared/tests/test_gate_client_base.py
+++ b/sidecars/shared/tests/test_gate_client_base.py
@@ -1,4 +1,4 @@
-"""Tests for GateClientBase circuit breaker and HTTP transport."""
+"""Tests for GateClientBase HTTP transport."""
 
 from __future__ import annotations
 
@@ -58,8 +58,6 @@ def _make_client(**kwargs: object) -> GateClientBase:
         "gate_api_token": "",
         "gate_origin": "http://localhost:8935",
         "timeout_sec": 5.0,
-        "breaker_failure_threshold": 3,
-        "breaker_reset_sec": 10,
     }
     defaults.update(kwargs)
     return GateClientBase(**defaults)  # type: ignore[arg-type]
@@ -93,50 +91,6 @@ class TestHeaders:
         assert c._headers["X-Gate-Agent"] == "my-bot"
 
 
-class TestCircuitBreaker:
-    def test_starts_closed(self) -> None:
-        c = _make_client()
-        assert not c._breaker_is_open()
-
-    def test_opens_after_threshold_failures(self) -> None:
-        c = _make_client(breaker_failure_threshold=2)
-        c._note_transport_failure("fail 1")
-        assert not c._breaker_is_open()
-        c._note_transport_failure("fail 2")
-        assert c._breaker_is_open()
-
-    def test_resets_on_success(self) -> None:
-        c = _make_client(breaker_failure_threshold=2)
-        c._note_transport_failure("fail 1")
-        c._note_transport_failure("fail 2")
-        assert c._breaker_is_open()
-        c._note_success()
-        assert not c._breaker_is_open()
-        assert c._consecutive_failures == 0
-
-    def test_snapshot(self) -> None:
-        c = _make_client(breaker_failure_threshold=2)
-        snap = c.breaker_snapshot()
-        assert snap.open is False
-        assert snap.consecutive_failures == 0
-        assert snap.last_failure == ""
-
-        c._note_transport_failure("timeout")
-        c._note_transport_failure("timeout again")
-        snap = c.breaker_snapshot()
-        assert snap.open is True
-        assert snap.consecutive_failures == 2
-        assert snap.last_failure == "timeout again"
-
-    def test_disabled_breaker(self) -> None:
-        c = _make_client(breaker_failure_threshold=0)
-        assert not c._breaker_enabled()
-        c._note_transport_failure("fail")
-        c._note_transport_failure("fail")
-        c._note_transport_failure("fail")
-        assert not c._breaker_is_open()
-
-
 class TestCacheFreshness:
     def test_fresh_cache(self) -> None:
         c = _make_client()
@@ -155,17 +109,45 @@ class TestCacheFreshness:
 
 class TestSendMessage:
     @pytest.mark.asyncio
-    async def test_returns_error_when_breaker_open(self) -> None:
-        c = _make_client(breaker_failure_threshold=1)
-        c._note_transport_failure("forced open")
-        resp = await c.send_message(
-            keeper_name="test",
-            content="hello",
-            context={"channel": "test"},
-            idempotency_key="key-1",
+    async def test_transport_failure_does_not_refuse_next_request(self) -> None:
+        responses = iter(
+            [
+                httpx.Response(503),
+                httpx.Response(200, json={"ok": True, "reply": "ready"}),
+            ]
         )
-        assert not resp.ok
-        assert "circuit open" in resp.error
+        request_count = 0
+
+        def respond(request: httpx.Request) -> httpx.Response:
+            nonlocal request_count
+            request_count += 1
+            return next(responses)
+
+        c = _make_client()
+        c._client = httpx.AsyncClient(
+            transport=httpx.MockTransport(respond),
+            headers=c._headers,
+        )
+        try:
+            first = await c.send_message(
+                keeper_name="keeper-a",
+                content="first",
+                context={"channel": "test"},
+                idempotency_key="key-1",
+            )
+            second = await c.send_message(
+                keeper_name="keeper-b",
+                content="second",
+                context={"channel": "test"},
+                idempotency_key="key-2",
+            )
+        finally:
+            await c.aclose()
+
+        assert not first.ok
+        assert second.ok
+        assert second.reply == "ready"
+        assert request_count == 2
 
 
 class TestKeeperStream:
@@ -243,7 +225,6 @@ class TestKeeperStream:
             try:
                 with pytest.raises(httpx.PoolTimeout):
                     await anext(second_stream)
-                assert c.breaker_snapshot().consecutive_failures == 1
                 release.set()
                 assert await first_result == ["ready"]
             finally:

--- a/sidecars/slack-bot/src/config.py
+++ b/sidecars/slack-bot/src/config.py
@@ -117,18 +117,6 @@ class BotConfig(BaseSettings):
         default=120.0,
         validation_alias=AliasChoices("GATE_TIMEOUT_SEC", "gate_timeout_sec"),
     )
-    gate_breaker_failure_threshold: int = Field(
-        default=3,
-        validation_alias=AliasChoices(
-            "GATE_BREAKER_FAILURE_THRESHOLD", "gate_breaker_failure_threshold"
-        ),
-    )
-    gate_breaker_reset_sec: int = Field(
-        default=30,
-        validation_alias=AliasChoices(
-            "GATE_BREAKER_RESET_SEC", "gate_breaker_reset_sec"
-        ),
-    )
     status_cache_ttl_sec: int = Field(
         default=15,
         validation_alias=AliasChoices("STATUS_CACHE_TTL_SEC", "status_cache_ttl_sec"),

--- a/sidecars/slack-bot/src/gate_client.py
+++ b/sidecars/slack-bot/src/gate_client.py
@@ -35,8 +35,6 @@ class GateClient(GateClientBase):
             gate_api_token=cfg.gate_api_token,
             gate_origin=cfg.gate_origin(),
             timeout_sec=cfg.gate_timeout_sec,
-            breaker_failure_threshold=cfg.gate_breaker_failure_threshold,
-            breaker_reset_sec=cfg.gate_breaker_reset_sec,
             status_cache_ttl_sec=cfg.status_cache_ttl_sec,
             keeper_cache_ttl_sec=cfg.keeper_cache_ttl_sec,
         )

--- a/sidecars/telegram-bot/src/config.py
+++ b/sidecars/telegram-bot/src/config.py
@@ -24,6 +24,7 @@ DEFAULT_STATE_DIR: Final[str] = ".gate/runtime/telegram"
 DEFAULT_BINDING_STORE_PATH: Final[str] = ".gate/runtime/telegram/bindings.json"
 DEFAULT_STATUS_PATH: Final[str] = ".gate/runtime/telegram/status.json"
 
+
 def _runtime_toml_path() -> Path:
     raw = os.getenv("MASC_BASE_PATH", "").strip()
     root = Path(raw).expanduser() if raw else Path.cwd()
@@ -64,7 +65,13 @@ class BotConfig(BaseSettings):
         toml_source = TomlConfigSettingsSource(
             settings_cls, toml_file=_runtime_toml_path()
         )
-        return (init_settings, env_settings, dotenv_settings, toml_source, file_secret_settings)
+        return (
+            init_settings,
+            env_settings,
+            dotenv_settings,
+            toml_source,
+            file_secret_settings,
+        )
 
     # Required: Telegram Bot API token from @BotFather
     telegram_bot_token: str = Field(
@@ -99,16 +106,6 @@ class BotConfig(BaseSettings):
         default=120.0,
         validation_alias=AliasChoices("GATE_TIMEOUT_SEC", "gate_timeout_sec"),
     )
-    gate_breaker_failure_threshold: int = Field(
-        default=3,
-        validation_alias=AliasChoices(
-            "GATE_BREAKER_FAILURE_THRESHOLD", "gate_breaker_failure_threshold"
-        ),
-    )
-    gate_breaker_reset_sec: int = Field(
-        default=30,
-        validation_alias=AliasChoices("GATE_BREAKER_RESET_SEC", "gate_breaker_reset_sec"),
-    )
     status_cache_ttl_sec: int = Field(
         default=15,
         validation_alias=AliasChoices("STATUS_CACHE_TTL_SEC", "status_cache_ttl_sec"),
@@ -137,6 +134,7 @@ class BotConfig(BaseSettings):
             "status_path",
         ),
     )
+
     @field_validator("telegram_bot_token")
     @classmethod
     def token_not_empty(cls, v: str) -> str:

--- a/sidecars/telegram-bot/src/gate_client.py
+++ b/sidecars/telegram-bot/src/gate_client.py
@@ -38,8 +38,6 @@ class GateClient(GateClientBase):
             gate_api_token=cfg.gate_api_token,
             gate_origin=cfg.gate_origin(),
             timeout_sec=cfg.gate_timeout_sec,
-            breaker_failure_threshold=cfg.gate_breaker_failure_threshold,
-            breaker_reset_sec=cfg.gate_breaker_reset_sec,
             status_cache_ttl_sec=cfg.status_cache_ttl_sec,
             keeper_cache_ttl_sec=cfg.keeper_cache_ttl_sec,
         )


### PR DESCRIPTION
## What changed

- hard-delete the process-wide transport circuit breaker from the shared connector client
- remove retired breaker thresholds/reset settings from Telegram, Slack, and iMessage adapters and config SSOT
- keep each HTTP attempt observable without letting prior failures refuse unrelated Keeper or connector requests
- replace breaker-behavior tests with a regression proving a request after a transport failure is still sent

## Why

The breaker accumulated failures across the whole sidecar instance. A short failure series for one operation therefore denied every Keeper and connector operation until a heuristic clock window elapsed. Transport observations must not become global execution authority.

This slice preserves per-request transport timeouts, status/discovery cache TTLs, explicit `GateResponse` errors, SSE cancellation, and failure logs.

## Validation

- `ruff check` on all changed Python files
- `ruff format --check` on all changed Python files
- `pyright --pythonpath /tmp/masc-connector-gate-venv/bin/python --outputjson ...` (9 files, 0 errors)
- shared Gate client focused tests: 11 passed
- Telegram/Slack config-path + schema tests: 2 passed each
- iMessage config-path + schema + config tests: 8 passed

## Stack

C1 of 2. C2 will make SSE failure outcomes typed and remove Telegram's ambiguous automatic batch fallback after stream acceptance.
