### PR TITLE
fix(config): keep public runtime seed unassigned

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -987,12 +987,11 @@ candidates = [
 # keepers fall back to [runtime].default. Per-keeper overrides in the
 # live config (<base>/.masc/config/runtime.toml) take precedence.
 #
-# Seed only nick0cave to the local Gemma 4 canary. Other keepers use the
-# fleet default unless their live config overrides this seed.
+# The public seed must not assign named keepers. Put personal or deployment
+# routing in the live config under <base>/.masc/config/runtime.toml.
 # Do not assign general keeper lanes to Pro here. Pro is reserved for explicit
 # judge/evaluator lanes ([runtime].cross_verifier and [fusion].judge).
 [runtime.assignments]
-nick0cave = "ollama.gemma4-26b-a4b-qat"
 # example: route a test keeper through the failover lane
 # canary = "default"
 


### PR DESCRIPTION
## Summary

- remove the personal `nick0cave` keeper assignment from the public runtime seed
- keep personal and deployment routing in the live `<base>/.masc/config/runtime.toml`
- restore the existing public-seed contract enforced by `test_runtime_config_validity`

## Evidence

- #24571 CI run 29476594146 failed only because the public seed contained one keeper assignment while the contract requires zero
- `python3 tomllib` confirms `runtime.assignments` is empty
- `git diff --check`
- no local Dune build; PR CI is the build authority
