### PR TITLE
fix(release): bind smoke runtime to catalog provider

### DIFF
--- a/scripts/release-evidence.sh
+++ b/scripts/release-evidence.sh
@@ -235,9 +235,9 @@ copy_install_smoke() {
 # serves /health. The [models.deepseek-v4-flash] block mirrors
 # config/runtime.toml's shape so the runtime resolves; its model id is what the
 # gate matches against the catalog.
-default = "release_evidence.deepseek-v4-flash"
+default = "ollama_cloud.deepseek-v4-flash"
 
-[providers.release_evidence]
+[providers.ollama_cloud]
 display-name = "Release Evidence Smoke"
 protocol = "openai-compatible-http"
 endpoint = "http://127.0.0.1:9/v1"
@@ -248,7 +248,7 @@ max-context = 32768
 tools-support = true
 streaming = true
 
-[release_evidence.deepseek-v4-flash]
+[ollama_cloud.deepseek-v4-flash]
 is-default = true
 max-concurrent = 1
 EOF


### PR DESCRIPTION
## Summary

- bind the release-evidence smoke runtime to the catalog-known `ollama_cloud` provider namespace
- keep the provider endpoint on the isolated loopback dead port, so the evidence run makes no real provider call
- remove the stale synthetic `release_evidence` provider identity that fail-closed catalog validation correctly rejected

## Regression evidence

Release run 29478669697 built and smoke-tested the binary, then failed startup in `release-evidence.sh` with:

`all configured runtime models are absent from the OAS capability catalog`

## Verification

- `bash -n scripts/release-evidence.sh`
- `git diff --check`
- full `scripts/release-evidence.sh` run against the existing macOS binary passed
- no local Dune build; CI remains the build authority
