### PR TITLE
fix(gate): scope retry to authenticated workspace

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -2006,6 +2006,7 @@ module For_testing = struct
 end
 
 let resolve_with_policy
+      ~base_path
       ~id
       ~(decision : decision)
       ?(source = Human_operator)
@@ -2014,13 +2015,25 @@ let resolve_with_policy
       ()
   : (resolution_result, resolve_error) result
   =
-  if not (claim_resolution id)
+  let belongs_to_workspace () =
+    match SMap.find_opt id (Atomic.get pending) with
+    | Some entry -> String.equal entry.audit_base_path base_path
+    | None ->
+      (match SMap.find_opt id (Atomic.get deliveries) with
+       | Some delivery -> String.equal delivery.entry.audit_base_path base_path
+       | None -> false)
+  in
+  if not (belongs_to_workspace ())
+  then Error (Not_found id)
+  else if not (claim_resolution id)
   then Error (Already_resolved id)
   else
     Fun.protect
       ~finally:(fun () -> release_resolution_claim id)
       (fun () ->
-         match SMap.find_opt id (Atomic.get pending) with
+         if not (belongs_to_workspace ())
+         then Error (Not_found id)
+         else match SMap.find_opt id (Atomic.get pending) with
          | Some _ ->
            let remember_rule =
              match decision with
@@ -2061,14 +2074,13 @@ let resolve_with_policy
     Called from the dashboard approval HTTP handler
     ([server_dashboard_http.ml]) and MCP runtime.
 
-    [base_path] is sourced from the entry's captured [audit_base_path]
-    rather than threaded from the caller: the convenience wrapper takes
-    only an [id], so the entry is the authoritative workspace source
-    (RFC-0274 Wave A). *)
-let resolve ~id ~(decision : decision)
+    [base_path] is the authenticated caller workspace. The pending or
+    in-progress delivery entry must belong to it exactly before any resolution
+    claim or journal mutation is attempted. *)
+let resolve ~base_path ~id ~(decision : decision)
   : (unit, resolve_error) result
   =
-  match resolve_with_policy ~id ~decision () with
+  match resolve_with_policy ~base_path ~id ~decision () with
   | Ok _ -> Ok ()
   | Error _ as error -> error
 ;;

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -203,6 +203,7 @@ val resolve_error_to_string : resolve_error -> string
 (** Commit a resolution, optionally persist an exact Always Allowed rule for
     [Decision.Approve], then wake only the Keeper captured by the pending entry. *)
 val resolve_with_policy :
+  base_path:string ->
   id:string ->
   decision:decision ->
   ?source:decision_source ->
@@ -212,6 +213,7 @@ val resolve_with_policy :
   (resolution_result, resolve_error) result
 
 val resolve :
+  base_path:string ->
   id:string ->
   decision:decision ->
   (unit, resolve_error) result

--- a/lib/keeper/keeper_gate.ml
+++ b/lib/keeper/keeper_gate.ml
@@ -257,6 +257,7 @@ let resolve_judgment (entry : Keeper_approval_queue.pending_approval) ~approval_
   | Some decision ->
     (match
        Keeper_approval_queue.resolve_with_policy
+         ~base_path:entry.audit_base_path
          ~id:approval_id
          ~decision
          ~source:Keeper_approval_queue.Auto_judge
@@ -536,9 +537,11 @@ let observe_recovered_work kind (entry : Keeper_approval_queue.pending_approval)
     ()
 ;;
 
-let retry_failed_auto_judge ~requested_by approval_id =
+let retry_failed_auto_judge ~base_path ~requested_by approval_id =
   match Keeper_approval_queue.get_pending_entry ~id:approval_id with
   | None -> Error ("pending approval not found: " ^ approval_id)
+  | Some entry when not (String.equal entry.audit_base_path base_path) ->
+    Error ("pending approval not found: " ^ approval_id)
   | Some entry ->
     (match retry_auto_judge_entry entry with
      | Error _ as error -> error

--- a/lib/keeper/keeper_gate.mli
+++ b/lib/keeper/keeper_gate.mli
@@ -92,10 +92,12 @@ val decide :
 val resume_persisted_auto_judges :
   base_path:string -> auto_judge_resume_report
 
-val retry_failed_auto_judge : requested_by:string -> string -> (unit, string) result
+val retry_failed_auto_judge :
+  base_path:string -> requested_by:string -> string -> (unit, string) result
 (** Explicitly retry one failed Auto Judge summary. The stored [retryable]
     classification is diagnostic only; operator authority controls this state
-    transition. No cadence, restart hook, or retry budget calls it. *)
+    transition. The approval must belong to the authenticated workspace exactly.
+    No cadence, restart hook, or retry budget calls it. *)
 
 type operator_recovery_report =
   { reopened_ids : string list

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -363,7 +363,7 @@ let approval_resolve_http_error_to_string = function
   | Unavailable err -> Keeper_approval_queue.resolve_error_to_string err
 ;;
 
-let dashboard_gate_resolve_http_json ~created_by ~(args : Yojson.Safe.t)
+let dashboard_gate_resolve_http_json ~base_path ~created_by ~(args : Yojson.Safe.t)
   : (Yojson.Safe.t, approval_resolve_http_error) result
   =
   match Safe_ops.json_string_opt "id" args with
@@ -385,6 +385,7 @@ let dashboard_gate_resolve_http_json ~created_by ~(args : Yojson.Safe.t)
        let decision = approval_resolve_decision_to_queue_decision decision in
        (match
           Keeper_approval_queue.resolve_with_policy
+            ~base_path
             ~id
             ~decision
             ~remember_rule
@@ -412,11 +413,11 @@ let dashboard_gate_resolve_http_json ~created_by ~(args : Yojson.Safe.t)
           Error (Gone err)))
 ;;
 
-let dashboard_gate_retry_http_json ~requested_by ~(args : Yojson.Safe.t) =
+let dashboard_gate_retry_http_json ~base_path ~requested_by ~(args : Yojson.Safe.t) =
   match Safe_ops.json_string_opt "id" args with
   | None -> Error "id is required"
   | Some id ->
-    (match Keeper_gate.retry_failed_auto_judge ~requested_by id with
+    (match Keeper_gate.retry_failed_auto_judge ~base_path ~requested_by id with
      | Error _ as error -> error
      | Ok () -> Ok (`Assoc [ "ok", `Bool true; "id", `String id ]))
 ;;

--- a/lib/server/server_dashboard_http.mli
+++ b/lib/server/server_dashboard_http.mli
@@ -93,11 +93,13 @@ val dashboard_proof_http_json :
   config:Workspace.config -> Httpun.Request.t -> Yojson.Safe.t
 
 val dashboard_gate_resolve_http_json :
+  base_path:string ->
   created_by:string ->
   args:Yojson.Safe.t ->
   (Yojson.Safe.t, approval_resolve_http_error) result
 
 val dashboard_gate_retry_http_json :
+  base_path:string ->
   requested_by:string ->
   args:Yojson.Safe.t ->
   (Yojson.Safe.t, string) result

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -481,10 +481,11 @@ let handle_gate_mode_body state operator_name request reqd body_str =
       (operator_error_json (Printf.sprintf "invalid json: %s" message))
 ;;
 
-let handle_gate_resolve_body operator_name request reqd body_str =
+let handle_gate_resolve_body state operator_name request reqd body_str =
   try
     let args = Yojson.Safe.from_string body_str in
-    match dashboard_gate_resolve_http_json ~created_by:operator_name ~args with
+    let base_path = (Mcp_server.workspace_config state).Workspace.base_path in
+    match dashboard_gate_resolve_http_json ~base_path ~created_by:operator_name ~args with
     | Ok json -> respond_json_value_with_cors request reqd json
     | Error (Gone _ as error) ->
       respond_json_value_with_cors
@@ -513,10 +514,11 @@ let handle_gate_resolve_body operator_name request reqd body_str =
       (operator_error_json (Printf.sprintf "invalid json: %s" message))
 ;;
 
-let handle_gate_retry_body operator_name request reqd body_str =
+let handle_gate_retry_body state operator_name request reqd body_str =
   try
     let args = Yojson.Safe.from_string body_str in
-    match dashboard_gate_retry_http_json ~requested_by:operator_name ~args with
+    let base_path = (Mcp_server.workspace_config state).base_path in
+    match dashboard_gate_retry_http_json ~base_path ~requested_by:operator_name ~args with
     | Ok json -> respond_json_value_with_cors request reqd json
     | Error message ->
       respond_json_value_with_cors
@@ -1248,15 +1250,15 @@ let add_routes ~sw ~clock router =
        ) request reqd)
   |> Http.Router.post "/api/v1/dashboard/gate/resolve" (fun request reqd ->
        with_token_permission_auth ~permission:Masc_domain.CanAdmin
-         (fun _state operator_name _req reqd ->
+         (fun state operator_name _req reqd ->
            Http.Request.read_body_async reqd
-             (handle_gate_resolve_body operator_name request reqd))
+             (handle_gate_resolve_body state operator_name request reqd))
          request reqd)
   |> Http.Router.post "/api/v1/dashboard/gate/retry" (fun request reqd ->
        with_token_permission_auth ~permission:Masc_domain.CanAdmin
-         (fun _state operator_name _req reqd ->
+         (fun state operator_name _req reqd ->
            Http.Request.read_body_async reqd
-             (handle_gate_retry_body operator_name request reqd))
+             (handle_gate_retry_body state operator_name request reqd))
          request reqd)
   |> Http.Router.post "/api/v1/dashboard/schedule/prune" (fun request reqd ->
        with_token_permission_auth ~permission:Masc_domain.CanAdmin

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -105,8 +105,8 @@ let submit ~base_path ~keeper_name ~input =
   submit_with_context ~base_path ~keeper_name ~input ()
 ;;
 
-let reject_and_cleanup id =
-  match AQ.resolve ~id ~decision:(AQ.Decision.Reject "test cleanup") with
+let reject_and_cleanup ~base_path id =
+  match AQ.resolve ~base_path ~id ~decision:(AQ.Decision.Reject "test cleanup") with
   | Ok () -> ()
   | Error error -> Alcotest.fail (AQ.resolve_error_to_string error)
 ;;
@@ -208,7 +208,7 @@ let test_dedup_never_merges_distinct_origins () =
             Alcotest.(check bool) "distinct origin has its own request" true
               (not (String.equal first id)))
          [ another_turn; another_channel; another_goal_context ];
-       List.iter reject_and_cleanup
+       List.iter (reject_and_cleanup ~base_path)
          [ first; another_turn; another_channel; another_goal_context ])
 ;;
 
@@ -390,8 +390,8 @@ let test_submit_is_nonblocking_and_exactly_deduplicated () =
             (Some request_context)
             entry.request_context
         | None -> Alcotest.fail "pending request was not restored");
-       reject_and_cleanup first;
-       reject_and_cleanup changed)
+       reject_and_cleanup ~base_path first;
+       reject_and_cleanup ~base_path changed)
 ;;
 
 let test_resolution_is_durable_and_origin_scoped () =
@@ -405,6 +405,7 @@ let test_resolution_is_durable_and_origin_scoped () =
        let id = submit ~base_path ~keeper_name ~input in
        let result =
          AQ.resolve_with_policy
+           ~base_path
            ~id
            ~decision:AQ.Decision.Approve
            ~remember_rule:true
@@ -507,7 +508,7 @@ let test_cycle_grant_uses_exact_effect_and_is_consumed_once () =
            ~input
            ()
        in
-       (match AQ.resolve ~id:approval_id ~decision:AQ.Decision.Approve with
+       (match AQ.resolve ~base_path ~id:approval_id ~decision:AQ.Decision.Approve with
         | Ok () -> ()
         | Error error -> Alcotest.fail (AQ.resolve_error_to_string error));
        let resolution =
@@ -653,7 +654,7 @@ let test_summary_updates_never_resolve_pending_request () =
        Alcotest.(check bool) "model judgment remains pending" true
          (Option.is_some (AQ.get_pending_entry ~id));
        Alcotest.(check bool) "resolved entry cannot be updated" true
-         (match AQ.resolve ~id ~decision:(AQ.Decision.Reject "operator denied") with
+         (match AQ.resolve ~base_path ~id ~decision:(AQ.Decision.Reject "operator denied") with
           | Error error -> Alcotest.fail (AQ.resolve_error_to_string error)
           | Ok () ->
             (match AQ.attach_summary ~id summary with
@@ -707,8 +708,8 @@ let test_all_summary_failures_accept_explicit_restart () =
        (match AQ.get_pending_entry ~id:terminal_id with
         | Some { summary_status = AQ.Summary_pending; _ } -> ()
         | Some _ | None -> Alcotest.fail "operator restart was gated by diagnostic state");
-       reject_and_cleanup retryable_id;
-       reject_and_cleanup terminal_id)
+       reject_and_cleanup ~base_path retryable_id;
+       reject_and_cleanup ~base_path terminal_id)
 ;;
 
 let test_operator_recovery_reopens_all_failed_summaries () =
@@ -751,8 +752,114 @@ let test_operator_recovery_reopens_all_failed_summaries () =
             | Some { summary_status = AQ.Summary_not_requested; _ } -> ()
             | Some _ | None -> Alcotest.fail "failed summary was not reopened")
          reopened;
-       reject_and_cleanup retryable_id;
-       reject_and_cleanup terminal_id)
+       reject_and_cleanup ~base_path retryable_id;
+       reject_and_cleanup ~base_path terminal_id)
+;;
+
+let test_dashboard_retry_rejects_cross_workspace_approval () =
+  let base_a = temp_dir () in
+  let base_b = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      AQ.For_testing.reset_runtime_state ();
+      cleanup_dir base_a;
+      cleanup_dir base_b)
+    (fun () ->
+       AQ.For_testing.reset_runtime_state ();
+       let approval_id =
+         submit
+           ~base_path:base_a
+           ~keeper_name:"queue-retry-base-a"
+           ~input:(`Assoc [ "request", `String "base-a" ])
+       in
+       check_update "mark pending" true (AQ.mark_summary_pending ~id:approval_id);
+       check_update
+         "mark failed"
+         true
+         (AQ.mark_summary_failed
+            ~id:approval_id
+            ~reason:"base-a-original"
+            ~retryable:true);
+       let args = `Assoc [ "id", `String approval_id ] in
+       (match
+          Server_dashboard_http.dashboard_gate_retry_http_json
+            ~base_path:base_b
+            ~requested_by:"operator-b"
+            ~args
+        with
+        | Error message ->
+          Alcotest.(check string)
+            "cross-workspace id is not addressable"
+            ("pending approval not found: " ^ approval_id)
+            message
+        | Ok _ -> Alcotest.fail "workspace B retried workspace A approval");
+       (match AQ.get_pending_entry ~id:approval_id with
+        | Some
+            { summary_status =
+                AQ.Summary_failed { reason = "base-a-original"; retryable = true }
+            ; _
+            } ->
+          ()
+        | Some _ | None ->
+          Alcotest.fail "cross-workspace retry changed workspace A state");
+       reject_and_cleanup ~base_path:base_a approval_id)
+;;
+
+let test_dashboard_resolve_rejects_cross_workspace_approval () =
+  let base_a = temp_dir () in
+  let base_b = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      AQ.For_testing.reset_runtime_state ();
+      cleanup_dir base_a;
+      cleanup_dir base_b)
+    (fun () ->
+       AQ.For_testing.reset_runtime_state ();
+       let approval_id =
+         submit
+           ~base_path:base_a
+           ~keeper_name:"queue-resolve-base-a"
+           ~input:(`Assoc [ "request", `String "base-a" ])
+       in
+       let resolve ~decision ~remember_rule =
+         Server_dashboard_http.dashboard_gate_resolve_http_json
+           ~base_path:base_b
+           ~created_by:"operator-b"
+           ~args:
+             (`Assoc
+                 [ "id", `String approval_id
+                 ; "decision", `String decision
+                 ; "remember_rule", `Bool remember_rule
+                 ])
+       in
+       List.iter
+         (fun (decision, remember_rule) ->
+            match resolve ~decision ~remember_rule with
+            | Error
+                (Server_dashboard_http.Gone
+                   (AQ.Not_found missing_id)) ->
+              Alcotest.(check string)
+                "cross-workspace id is indistinguishable from missing"
+                approval_id
+                missing_id
+            | Error error ->
+              Alcotest.fail
+                (Server_dashboard_http.approval_resolve_http_error_to_string error)
+            | Ok _ -> Alcotest.fail "workspace B resolved workspace A approval")
+         [ "approve", true; "reject", false ];
+       Alcotest.(check bool)
+         "source approval remains pending"
+         true
+         (Option.is_some (AQ.get_pending_entry ~id:approval_id));
+       List.iter
+         (fun base_path ->
+            Alcotest.(check bool)
+              "cross-workspace resolve did not persist a rule"
+              false
+              (Sys.file_exists
+                 (AQ.For_testing.always_allowed_store_path ~base_path)))
+         [ base_a; base_b ];
+       reject_and_cleanup ~base_path:base_a approval_id)
 ;;
 
 let test_lane_activity_does_not_retry_failed_auto_judge () =
@@ -821,8 +928,8 @@ let test_lane_activity_does_not_retry_failed_auto_judge () =
           ()
         | Some _ | None ->
           Alcotest.fail "lane activity changed another Keeper's judge failure");
-       reject_and_cleanup id_a;
-       reject_and_cleanup id_b;
+       reject_and_cleanup ~base_path id_a;
+       reject_and_cleanup ~base_path id_b;
        List.iter
          (fun (keeper_name, approval_id) ->
             match durable_resolution_opt ~base_path ~keeper_name ~approval_id with
@@ -921,7 +1028,7 @@ let test_inflight_auto_judge_preserves_durable_restart_marker () =
          "restart marker remains persisted"
          true
          (Yojson.Safe.equal persisted_status (`String "pending"));
-       reject_and_cleanup id;
+       reject_and_cleanup ~base_path id;
        (match durable_resolution_opt ~base_path ~keeper_name ~approval_id:id with
         | Some resolution -> drop_resolution ~base_path ~keeper_name resolution
         | None -> Alcotest.fail "cleanup resolution was not durable"))
@@ -1188,7 +1295,7 @@ let test_default_auto_judge_defers_without_blocking () =
             ()
           | Some _ -> Alcotest.fail "Auto Judge failure was not durably retryable"
           | None -> Alcotest.fail "Auto Judge request was not durably queued");
-         reject_and_cleanup approval_id
+         reject_and_cleanup ~base_path approval_id
        | Gate.Deferred { reason = Gate.Judge_requested; _ } ->
          Alcotest.fail "test unexpectedly has a running server Auto Judge context"
        | Gate.Deferred { reason = (Gate.Human_requested | Gate.Mode_state_invalid _); _ } ->
@@ -1208,7 +1315,7 @@ let test_unavailable_cycle_grant_never_falls_through () =
       cleanup_dir base_path)
     (fun () ->
        let approval_id = submit ~base_path ~keeper_name ~input in
-       (match AQ.resolve ~id:approval_id ~decision:AQ.Decision.Approve with
+       (match AQ.resolve ~base_path ~id:approval_id ~decision:AQ.Decision.Approve with
         | Ok () -> ()
         | Error error -> Alcotest.fail (AQ.resolve_error_to_string error));
        let resolution =
@@ -1267,6 +1374,7 @@ let test_nonapproved_resolution_payload_is_delivered () =
        let rationale = "Use the project-scoped target." in
        (match
           AQ.resolve
+            ~base_path
             ~id:reject_id
             ~decision:(AQ.Decision.Reject rationale)
         with
@@ -1296,7 +1404,7 @@ let test_nonapproved_resolution_payload_is_delivered () =
        let edited_input =
          `Assoc [ "target", `String "after"; "confirmed", `Bool true ]
        in
-       (match AQ.resolve ~id:edit_id ~decision:(AQ.Decision.Edit edited_input) with
+       (match AQ.resolve ~base_path ~id:edit_id ~decision:(AQ.Decision.Edit edited_input) with
         | Ok () -> ()
         | Error error -> Alcotest.fail (AQ.resolve_error_to_string error));
        let edited =
@@ -1354,6 +1462,14 @@ let () =
             "all summary failures accept explicit operator restart"
             `Quick
             test_all_summary_failures_accept_explicit_restart
+        ; Alcotest.test_case
+            "dashboard retry rejects cross-workspace approval"
+            `Quick
+            test_dashboard_retry_rejects_cross_workspace_approval
+        ; Alcotest.test_case
+            "dashboard resolve rejects cross-workspace approval"
+            `Quick
+            test_dashboard_resolve_rejects_cross_workspace_approval
         ; Alcotest.test_case
             "lane activity never retries a failed Auto Judge"
             `Quick

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -334,6 +334,7 @@ let test_pending_hitl_approval_keeper_names_filters_persisted_pending () =
         (fun id ->
           ignore
             (AQ.resolve
+               ~base_path:base_dir
                ~id
                ~decision:(AQ.Decision.Reject "test cleanup")))
         !approval_ids;
@@ -1022,6 +1023,7 @@ let test_sweep_reports_pending_hitl_approval () =
         (fun id ->
            ignore
              (AQ.resolve
+                ~base_path:base_dir
                 ~id
                 ~decision:(AQ.Decision.Reject "test cleanup")))
         !approval_id;
@@ -1070,7 +1072,7 @@ let test_sweep_reports_pending_hitl_approval () =
       check bool "pending HITL approval visibility emitted" true visibility_seen;
       check bool "approval remains pending after visibility sweep" true
         (AQ.has_pending_for_keeper ~keeper_name:name);
-      (match AQ.resolve ~id ~decision:AQ.Decision.Approve with
+      (match AQ.resolve ~base_path:base_dir ~id ~decision:AQ.Decision.Approve with
        | Ok () -> approval_id := None
        | Error err -> fail ("resolve failed: " ^ AQ.resolve_error_to_string err));
       check bool "resolution removes pending request" false


### PR DESCRIPTION
## Outcome

- thread the authenticated workspace `base_path` from the dashboard route to Gate retry
- reject approval IDs whose persisted `audit_base_path` belongs to another workspace
- preserve the generic not-found response so cross-workspace IDs are not disclosed
- prove workspace B cannot mutate workspace A's failed summary

## Production path

`dashboard route -> authenticated state.base_path -> Gate retry/resolve -> approval queue`

Both pending and in-progress delivery verify that the persisted workspace matches
before a claim or mutation. A foreign-workspace ID is returned through the same
`Not_found` surface as an absent ID.

## Boundary

This is a workspace-authorization fix only. It adds no policy, heuristic, timeout,
fallback, or second workspace authority.

## Focused verification

- `scripts/dune-local.sh build test/test_keeper_approval_queue.exe`
- `test_keeper_approval_queue.exe`: 19 focused tests passed at the reviewed implementation

Reviewed implementation: `d5851dd6a3ef1ee4d415a5225d9519c85fda7500`.
