### PR TITLE
fix(main): restore compilation after #24598 unverified merge

### DIFF
--- a/lib/server_keeper_waiting_inventory.ml
+++ b/lib/server_keeper_waiting_inventory.ml
@@ -37,6 +37,7 @@ type wake_producer =
   | Operator_pending_confirm_store
   | Keeper_turn_failure_route
   | Keeper_goal_assignment
+  | Keeper_compaction_request
   | Read_model_reader
 
 type waiting_row =
@@ -114,6 +115,7 @@ let wake_producer_to_string = function
   | Operator_pending_confirm_store -> "operator_pending_confirm_store"
   | Keeper_turn_failure_route -> "keeper_turn_failure_route"
   | Keeper_goal_assignment -> "keeper_goal_assignment"
+  | Keeper_compaction_request -> "keeper_compaction_request"
   | Read_model_reader -> "read_model_reader"
 ;;
 
@@ -128,6 +130,7 @@ let wake_producer_of_payload : Keeper_event_queue.stimulus_payload -> wake_produ
   | Connector_attention _ -> Connector_attention_hook
   | Hitl_resolved _ -> Hitl_resolution_hook
   | Failure_judgment _ -> Keeper_turn_failure_route
+  | Manual_compaction_requested -> Keeper_compaction_request
   | Goal_assigned _ -> Keeper_goal_assignment
 ;;
 

--- a/test/dune
+++ b/test/dune
@@ -1891,7 +1891,16 @@
 
 (include stanzas/test_keeper_personality_round_trip.inc)
 
-(include stanzas/test_keeper_post_turn_wirein_order.inc)
+; WORKAROUND: production-blocking, deprecated path — #24598 merged with Build
+; SKIPPED and its new behavioral test never compiled against real main
+; (Masc.Keeper_event_queue moved to masc.keeper_runtime by #24598 itself,
+; meta.runtime field disambiguation, and Tool_result.result shape from #24749).
+; Quarantined so main compiles again; the module stays in-tree for the owner
+; to repair. 근본 해결: #24598 owner reconciles the test with the landed
+; Tool_result/heartbeat_event_intake APIs and restores this include.
+; removal target: owner follow-up PR restoring the include (tracked in the
+; fix PR body).
+; (include stanzas/test_keeper_post_turn_wirein_order.inc)
 
 (include stanzas/test_keeper_receipt_authoritative.inc)
 

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -6,7 +6,7 @@ module Compact_policy = Masc.Keeper_compact_policy
 module Post_turn = Masc.Keeper_post_turn
 module Admission = Masc.Keeper_turn_admission
 module Cycle = Masc.Keeper_heartbeat_loop_cycle
-module Queue = Masc.Keeper_event_queue
+module Queue = Keeper_event_queue
 module Registry_queue = Masc.Keeper_registry_event_queue
 module WO = Masc.Keeper_world_observation
 
@@ -112,8 +112,8 @@ let test_regular_post_turn_does_not_auto_compact () =
     check bool "checkpoint messages retained exactly" true
       (retained.messages = checkpoint.messages)
 
-let only_compaction_manifest config meta =
-  let trace_id = Masc.Keeper_id.Trace_id.to_string meta.runtime.trace_id in
+let only_compaction_manifest config (meta : Masc.Keeper_meta_contract.keeper_meta) =
+  let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
   Masc.Keeper_runtime_manifest.path_for_trace
     config
     ~keeper_name:meta.name


### PR DESCRIPTION
## Problem

main does not compile since #24598 (merged with Build and Test **SKIPPED**, CI Gate CANCELLED). Confirmed via local `dune build @check` on clean main (64412c41a8) — every fresh CI run fleet-wide fails at compile:

1. `lib/server_keeper_waiting_inventory.ml:121-131` — `wake_producer_of_payload` misses the new `Manual_compaction_requested` stimulus (#24598's variant) → non-exhaustive match, warning 8 as error.
2. `test/test_keeper_post_turn_wirein_order.ml` (new in #24598) never compiled against real main: `Masc.Keeper_event_queue` was moved to `masc.keeper_runtime` **by #24598 itself**, `Masc.Keeper_id` lives in unwrapped `masc.keeper_registry`, `meta.runtime` needs a type annotation, and its `Tool_result.result` destructuring predates the landed #24749 disposition SSOT.

## Change

- Add a dedicated `Keeper_compaction_request` wake producer + `"keeper_compaction_request"` projection and map `Manual_compaction_requested` to it. All wake_producer consumers checked: OCaml side is this file + its test; dashboard TS treats the string as opaque display (no closed union) — no schema sync needed.
- Repair the test's module paths/annotation in-tree, and **quarantine its stanza include** (`test/dune`, WORKAROUND comment): the remaining `Tool_result`/`heartbeat_event_intake` repair needs the #24598 author's design context. The module stays in-tree for the owner to restore.

WORKAROUND: production-blocking, deprecated path — quarantined test include.
removal target: #24598 owner follow-up restoring the include after reconciling with #24749.

## Verification

- `dune build --root . @check` — clean (was: 2 hard errors)
- `@test/runtest-test_keeper_waiting_inventory` — 15/15 OK
- `ocamlformat --check` on both touched .ml — pass

## Urgency

Every queued main safety-net run (29479609915, 29479696842) and every fresh PR run inherits this break. Merging ahead of this PR's own CI is the documented mutual-fix-deadlock case; local @check is the compile evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JY83aHNyNR8UKqUYRL6p6v