### PR TITLE
test(keeper): cover manual compaction waiting producer

### DIFF
--- a/test/test_keeper_waiting_inventory.ml
+++ b/test/test_keeper_waiting_inventory.ml
@@ -238,6 +238,39 @@ let test_event_queue_pending_and_inflight_are_visible () =
      | rows -> failf "expected two queue rows, got %d" (List.length rows))
 ;;
 
+let test_manual_compaction_waiting_row_has_typed_producer () =
+  with_workspace
+  @@ fun config ->
+  let keeper_name = "manual-compaction-waiting-keeper" in
+  ensure_keeper config keeper_name;
+  let pending =
+    stimulus
+      ~post_id:Keeper_event_queue.manual_compaction_post_id
+      ~arrived_at:120.0
+      Keeper_event_queue.Manual_compaction_requested
+  in
+  Keeper_event_queue_persistence.persist
+    ~base_path:config.Workspace_utils_backend_setup.base_path
+    ~keeper_name
+    (queue_of_list [ pending ]);
+  let json = Server_keeper_waiting_inventory.dashboard_json config in
+  match find_keeper json keeper_name with
+  | None -> fail "manual compaction keeper row missing"
+  | Some keeper ->
+    (match U.(keeper |> member "waiting_on" |> to_list) with
+     | [ row ] ->
+       check string
+         "manual compaction waiting kind"
+         "manual_compaction_requested"
+         (json_string_member "waiting_on" row);
+       check string
+         "manual compaction wake producer"
+         "keeper_compaction_request"
+         (json_string_member "wake_producer" row)
+     | rows ->
+       failf "expected one manual compaction waiting row, got %d" (List.length rows))
+;;
+
 let test_chat_queue_pending_rows_are_visible () =
   with_workspace
   @@ fun config ->
@@ -941,6 +974,8 @@ let () =
     [ ( "dashboard_json"
       , [ test_case "event queue pending and inflight are visible" `Quick
             test_event_queue_pending_and_inflight_are_visible
+        ; test_case "manual compaction producer is typed" `Quick
+            test_manual_compaction_waiting_row_has_typed_producer
         ; test_case "chat queue pending rows are visible" `Quick
             test_chat_queue_pending_rows_are_visible
         ; test_case "chat queue recovery-required row is visible" `Quick


### PR DESCRIPTION
## What changed

- add a waiting-inventory regression test for `Manual_compaction_requested`
- persist the real typed event-queue stimulus
- assert the dashboard projection keeps both:
  - `waiting_on = "manual_compaction_requested"`
  - `wake_producer = "keeper_compaction_request"`

## Why

#24598 added the manual-compaction stimulus but omitted it from the exhaustive waiting-inventory projection, breaking main compilation. #24839 restored the production match, but did not add a direct regression test for the dashboard row.

This PR is intentionally test-only so it does not duplicate or rename the production fix already merged by #24839.

## Impact

Future event-queue stimulus additions or projection refactors will fail this focused suite if manual compaction stops being observable with its typed producer.

## Validation

- `ocamlformat --check test/test_keeper_waiting_inventory.ml`
- `ocamlc -stop-after parsing -c test/test_keeper_waiting_inventory.ml`
- `git diff --check origin/main...HEAD`
- the focused target and its 16 tests passed before the concurrent #24839 main update; latest-main focused rerun is delegated to PR CI because another worktree currently owns the repo-local Dune lock
