### PR TITLE
fix(gate): pass root clock for HITL body timeout

### DIFF
--- a/lib/keeper/hitl_summary_worker.ml
+++ b/lib/keeper/hitl_summary_worker.ml
@@ -304,6 +304,18 @@ let sdk_error_of_http_error error =
   Agent_sdk.Provider_failure_attribution.sdk_error_of_http_error error
 ;;
 
+let root_clock_for_body_timeout ~body_timeout_s ~root_clock =
+  match body_timeout_s with
+  | None -> None
+  | Some _ -> root_clock
+;;
+
+let body_timeout_clock () =
+  root_clock_for_body_timeout
+    ~body_timeout_s:(Keeper_runtime_resolved.body_timeout_override_sec ())
+    ~root_clock:(Eio_context.get_clock_opt ())
+;;
+
 (** Appended on the [Plain_json_text] path so a model without native structured
     output still returns a parseable object. The schema is the SSOT for both
     paths (native applies it as [response_format]; here it is inlined). *)
@@ -363,8 +375,9 @@ let call_summary_llm ~sw ~net ~runtime_id ~provider_config ~context_bundle () =
   match messages with
   | Error detail -> Error (Prompt_unavailable detail)
   | Ok messages ->
+    let clock = body_timeout_clock () in
     (match
-       Keeper_provider_subcall.complete ~sw ~net ~config ~messages ()
+       Keeper_provider_subcall.complete ~sw ~net ?clock ~config ~messages ()
        |> Result.map_error sdk_error_of_http_error
      with
      | Ok response -> Ok (response, mode)
@@ -513,6 +526,7 @@ module For_testing = struct
   let summary_llm_error_retryable = summary_llm_error_retryable
   let sdk_error_of_http_error = sdk_error_of_http_error
   let effective_max_concurrency = effective_max_concurrency
+  let body_timeout_clock = body_timeout_clock
   let system_prompt = system_prompt
   let summary_version = summary_version
 end

--- a/lib/keeper/hitl_summary_worker.mli
+++ b/lib/keeper/hitl_summary_worker.mli
@@ -86,5 +86,10 @@ module For_testing : sig
   val effective_max_concurrency
     : configured:int -> runtime_limit:int option -> int
 
+  val body_timeout_clock
+    : unit -> float Eio.Time.clock_ty Eio.Resource.t option
+  (** Resolve the server root clock only when the non-streaming body timeout is
+      explicitly configured. [None] leaves the body-read deadline disabled. *)
+
   val summary_version : int
 end

--- a/test/test_hitl_summary_worker.ml
+++ b/test/test_hitl_summary_worker.ml
@@ -3,6 +3,7 @@ open Alcotest
 module Q = Masc.Keeper_approval_queue
 module Worker = Masc.Hitl_summary_worker
 module Schema = Masc.Keeper_structured_output_schema
+module Runtime_resolved = Masc.Keeper_runtime_resolved
 
 let yojson = testable Yojson.Safe.pretty_print Yojson.Safe.equal
 
@@ -244,6 +245,48 @@ let test_readiness_fails_when_gate_prompt_is_missing () =
             (status |> member "read_error" |> to_string |> String.trim <> ""))
 ;;
 
+let with_body_timeout_env value f =
+  let name = "MASC_KEEPER_BODY_TIMEOUT_SEC" in
+  let previous = Sys.getenv_opt name in
+  Unix.putenv name value;
+  Runtime_resolved.reset_for_tests ();
+  Fun.protect
+    ~finally:(fun () ->
+      (match previous with
+       | Some previous -> Unix.putenv name previous
+       | None -> Unix.unsetenv name);
+      Runtime_resolved.reset_for_tests ())
+    f
+;;
+
+let with_root_eio_context f =
+  Eio_main.run @@ fun env ->
+  let net = Eio.Stdenv.net env in
+  let clock = Eio.Stdenv.clock env in
+  let mono_clock = Eio.Stdenv.mono_clock env in
+  Eio.Switch.run @@ fun sw ->
+  Eio_context.with_test_env ~net ~clock ~mono_clock ~sw (fun () -> f clock)
+;;
+
+let test_unset_body_timeout_does_not_forward_root_clock () =
+  with_root_eio_context @@ fun _root_clock ->
+  with_body_timeout_env "" @@ fun () ->
+  check
+    bool
+    "unset body timeout keeps provider clock absent"
+    true
+    (Option.is_none (Worker.For_testing.body_timeout_clock ()))
+;;
+
+let test_explicit_body_timeout_forwards_root_clock () =
+  with_root_eio_context @@ fun root_clock ->
+  with_body_timeout_env "30" @@ fun () ->
+  match Worker.For_testing.body_timeout_clock () with
+  | Some actual ->
+    check bool "explicit body timeout uses the exact root clock" true (actual == root_clock)
+  | None -> fail "explicit body timeout dropped the root clock"
+;;
+
 let () =
   run
     "Hitl_summary_worker"
@@ -290,6 +333,14 @@ let () =
             "Gate judgment readiness fails when missing"
             `Quick
             test_readiness_fails_when_gate_prompt_is_missing
+        ; test_case
+            "unset body timeout does not forward root clock"
+            `Quick
+            test_unset_body_timeout_does_not_forward_root_clock
+        ; test_case
+            "explicit body timeout forwards root clock"
+            `Quick
+            test_explicit_body_timeout_forwards_root_clock
         ] )
     ]
 ;;


### PR DESCRIPTION
## What changed

- select the bootstrap/root Eio clock for HITL provider calls only when `MASC_KEEPER_BODY_TIMEOUT_SEC` resolves to an explicit value
- pass that clock through the existing Keeper provider boundary so OAS can enforce the configured body-read deadline
- keep the unset path clock-free, preserving the existing unbounded asynchronous worker behavior
- add set/unset regressions using the real resolved environment and `Eio_context` root clock

## Contract

- no finite default
- no HITL-local timeout wrapper
- no new wait on the Keeper lane; the worker remains fire-and-forget under `Eio.Fiber.fork`
- the provider remains the only timeout enforcement boundary

## Validation

- `scripts/dune-local.sh build test/test_hitl_summary_worker.exe`
- `./_build/default/test/test_hitl_summary_worker.exe test --color=never --show-errors` (9 tests)

The focused build and all 9 HITL worker tests pass. The full CI compile and all
guards also pass.

The quick suite is currently blocked by the same pre-existing failures on
current `main`
([main CI](https://github.com/jeong-sik/masc/actions/runs/29481594359));
the PR run introduces no additional failing test label
([PR CI](https://github.com/jeong-sik/masc/actions/runs/29481071622)).
