### PR TITLE
fix(build): unbreak main — Manual_compaction wake routing + exclude stale wirein test

### DIFF
--- a/lib/server_keeper_waiting_inventory.ml
+++ b/lib/server_keeper_waiting_inventory.ml
@@ -38,6 +38,7 @@ type wake_producer =
   | Keeper_turn_failure_route
   | Keeper_goal_assignment
   | Read_model_reader
+  | Keeper_manual_compaction
 
 type waiting_row =
   { keeper_name : string option
@@ -115,6 +116,7 @@ let wake_producer_to_string = function
   | Keeper_turn_failure_route -> "keeper_turn_failure_route"
   | Keeper_goal_assignment -> "keeper_goal_assignment"
   | Read_model_reader -> "read_model_reader"
+  | Keeper_manual_compaction -> "keeper_manual_compaction"
 ;;
 
 let wake_producer_of_payload : Keeper_event_queue.stimulus_payload -> wake_producer =
@@ -129,6 +131,7 @@ let wake_producer_of_payload : Keeper_event_queue.stimulus_payload -> wake_produ
   | Hitl_resolved _ -> Hitl_resolution_hook
   | Failure_judgment _ -> Keeper_turn_failure_route
   | Goal_assigned _ -> Keeper_goal_assignment
+  | Manual_compaction_requested -> Keeper_manual_compaction
 ;;
 
 let unix_iso_json = function

--- a/test/dune
+++ b/test/dune
@@ -1891,7 +1891,14 @@
 
 (include stanzas/test_keeper_personality_round_trip.inc)
 
-(include stanzas/test_keeper_post_turn_wirein_order.inc)
+; WORKAROUND(unbreak-main): test_keeper_post_turn_wirein_order is stale against
+; restructured Keeper APIs already on main — Keeper_event_queue/Keeper_id moved out
+; of the `masc` wrapper library, and Tool_result.result was replaced by disposition.
+; The test no longer compiles, breaking `dune build .`. Excluded here to restore a
+; buildable main. Root fix / removal target: #24607 (isolate manual compaction
+; transaction) owns the full rewrite of this test to the new shape; re-enable this
+; include when #24607 lands.
+; (include stanzas/test_keeper_post_turn_wirein_order.inc)
 
 (include stanzas/test_keeper_receipt_authoritative.inc)
 


### PR DESCRIPTION
## 문제
`dune build .` on main이 **2개 타겟에서 실패**합니다 (CI Gate가 bypass되는 동안 착지한 incomplete migration의 결과):

1. **`lib/server_keeper_waiting_inventory.ml`** (product library) — `Manual_compaction_requested` stimulus variant는 main에 있는데 `wake_producer_of_payload` 매치에 arm이 없어 **non-exhaustive match** (`warning 8 [partial-match]` as error).
2. **`test/test_keeper_post_turn_wirein_order.ml`** — main에 이미 착지한 Keeper API 재구조화에 stale: `Keeper_event_queue`/`Keeper_id`가 `masc` wrapper 밖(`masc_keeper_runtime`/`keeper_registry`)으로 이동, `Tool_result.result` → `Tool_result.disposition`. 컴파일 불가.

## 수정
1. `Keeper_manual_compaction` `wake_producer` variant + 문자열 매핑 + payload arm 추가. Blast radius contained — `wake_producer`는 이 파일에서만 match되고 다른 곳은 값 생성만 하므로 추가 exhaustiveness break 없음.
2. stale wirein test를 `test/dune` stanza에서 제외.

## WORKAROUND (test 제외)
- `WORKAROUND`: main이 빌드 안 됨 (production-blocking). 제외한 test는 **이미 비컴파일 = 유효 coverage 0**이라 제외로 잃는 것 없음.
- `removal target`: **#24607** (isolate manual compaction transaction)이 이 test의 full rewrite를 소유 → 랜딩 시 include 복원.

## 검증
`dune build @check` 통과 (전 모듈 타입체크). E1 컴파일 정상, E2 제외로 `dune build .` 복구.

## 남은 base-red
이 PR은 **컴파일 break만** 수정합니다. main의 CI Gate는 별개의 config-validity flaky 게이트(공개 seed↔배포 overlay 분리)로 여전히 red이며, 그건 fleet가 수렴 중입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
