### PR TITLE
refactor(supervisor): remove finite restart authority

### DIFF
--- a/scripts/start-masc-supervised.sh
+++ b/scripts/start-masc-supervised.sh
@@ -2,10 +2,10 @@
 # scripts/start-masc-supervised.sh
 # Process-level supervisor for masc.
 #
-# Wraps start-masc.sh with auto-restart and a crash-loop circuit
-# breaker.  Satisfies the operator durability requirement described in
-# issue #10828 while respecting the <launchd> policy from ~/me/CLAUDE.md
-# (script-based, no system-level daemon registration).
+# Wraps start-masc.sh with continuous auto-restart.  Satisfies the
+# operator durability requirement described in issue #10828 while
+# respecting the <launchd> policy from ~/me/CLAUDE.md (script-based,
+# no system-level daemon registration).
 #
 # Usage:
 #   scripts/start-masc-supervised.sh [args forwarded to start-masc.sh]
@@ -13,19 +13,14 @@
 # Environment knobs:
 #   MASC_SUPERVISOR_LOG             — log file path
 #                                     (default: <repo-root>/logs/masc-supervisor.log)
-#   MASC_RESTART_WINDOW_SEC         — sliding window width for crash-loop
-#                                     detection in seconds (default: 300)
-#   MASC_MAX_RESTARTS_IN_WINDOW     — max exits allowed inside the window
-#                                     before the supervisor aborts (default: 5)
 #   MASC_RESTART_COOLDOWN_SEC       — sleep between restart attempts
 #                                     (default: 5)
 #
-# Crash-loop detection:
-#   When the server exits at least MASC_MAX_RESTARTS_IN_WINDOW times
-#   within a rolling MASC_RESTART_WINDOW_SEC window the supervisor stops
-#   restarting and exits with status 1 so that an outer watchdog (or the
-#   operator) can investigate the root cause.  This prevents a tight
-#   restart loop from masking an unrecovered crash (e.g. fd-leak, OOM).
+# Restart contract:
+#   Every child exit is logged with its real exit status and uptime.
+#   Child failures never revoke the supervisor's restart responsibility.
+#   TERM, INT, and HUP remain explicit external stop signals: they are
+#   forwarded to the active child and terminate the supervisor.
 #
 # Relationship to lib/supervisor.ml:
 #   lib/supervisor.ml manages *Eio fibers* inside a single OS process.
@@ -41,16 +36,86 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 LOG_FILE="${MASC_SUPERVISOR_LOG:-$REPO_ROOT/logs/masc-supervisor.log}"
 mkdir -p "$(dirname "$LOG_FILE")"
 
-WINDOW_SEC="${MASC_RESTART_WINDOW_SEC:-300}"
-MAX_RESTARTS="${MASC_MAX_RESTARTS_IN_WINDOW:-5}"
 COOLDOWN_SEC="${MASC_RESTART_COOLDOWN_SEC:-5}"
+active_pid=""
+active_kind=""
+stop_signal=""
+stop_exit_code=0
+stop_forwarded_pid=""
 
 log() {
   printf '[%s][supervisor] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" \
     | tee -a "$LOG_FILE" >&2
 }
 
-log "process supervisor starting (window=${WINDOW_SEC}s max_restarts=${MAX_RESTARTS} cooldown=${COOLDOWN_SEC}s)"
+forward_stop_to_active() {
+  if [ -n "$stop_signal" ] \
+    && [ -n "$active_pid" ] \
+    && [ "$stop_forwarded_pid" != "$active_pid" ] \
+    && kill -0 "$active_pid" 2>/dev/null
+  then
+    log "forwarding SIG${stop_signal} to ${active_kind} pid=${active_pid}"
+    kill "-${stop_signal}" "$active_pid" 2>/dev/null || true
+    stop_forwarded_pid="$active_pid"
+  fi
+}
+
+request_stop() {
+  local signal_name="$1"
+  local signal_number
+
+  if [ -n "$stop_signal" ]; then
+    return
+  fi
+
+  signal_number=$(kill -l "$signal_name")
+  stop_signal="$signal_name"
+  stop_exit_code=$((128 + signal_number))
+  log "supervisor received SIG${signal_name}; stop requested"
+
+  forward_stop_to_active
+}
+
+run_active() {
+  local kind="$1"
+  local status
+  local reaped_status
+  shift
+
+  active_kind="$kind"
+  "$@" &
+  active_pid=$!
+  stop_forwarded_pid=""
+  forward_stop_to_active
+  wait "$active_pid"
+  status=$?
+
+  if [ -n "$stop_signal" ]; then
+    wait "$active_pid" 2>/dev/null
+    reaped_status=$?
+    if [ "$reaped_status" -ne 127 ]; then
+      status="$reaped_status"
+    fi
+  fi
+
+  active_pid=""
+  active_kind=""
+  stop_forwarded_pid=""
+  return "$status"
+}
+
+stop_if_requested() {
+  if [ -n "$stop_signal" ]; then
+    log "process supervisor stopping after SIG${stop_signal}"
+    exit "$stop_exit_code"
+  fi
+}
+
+trap 'request_stop TERM' TERM
+trap 'request_stop INT' INT
+trap 'request_stop HUP' HUP
+
+log "process supervisor starting (cooldown=${COOLDOWN_SEC}s)"
 log "wrapping: $REPO_ROOT/start-masc.sh${*:+ $*}"
 
 if [ ! -x "$REPO_ROOT/start-masc.sh" ]; then
@@ -58,18 +123,15 @@ if [ ! -x "$REPO_ROOT/start-masc.sh" ]; then
   exit 1
 fi
 
-# restart_timestamps holds the Unix epoch seconds of each recent exit,
-# trimmed to the current sliding window on every iteration.
-restart_timestamps=()
-
 while true; do
+  stop_if_requested
   log "starting masc"
   start_epoch=$(date +%s)
 
   # No `set -e` is active, so a failing start-masc.sh does not abort this
   # loop; `|| true` here would make `$?` observe `true` and record every
   # exit — including SIGSEGV (139) and SIGTERM (143) — as code=0.
-  "$REPO_ROOT/start-masc.sh" "$@"
+  run_active "masc" "$REPO_ROOT/start-masc.sh" "$@"
   exit_code=$?
   end_epoch=$(date +%s)
   uptime_s=$((end_epoch - start_epoch))
@@ -83,27 +145,9 @@ while true; do
   fi
 
   log "masc exited code=${exit_code}${exit_detail} uptime=${uptime_s}s"
+  stop_if_requested
 
-  # Trim restart_timestamps to the sliding window.
-  cutoff=$((end_epoch - WINDOW_SEC))
-  fresh=()
-  for ts in "${restart_timestamps[@]+"${restart_timestamps[@]}"}"; do
-    if [[ "$ts" -gt "$cutoff" ]]; then
-      fresh+=("$ts")
-    fi
-  done
-  restart_timestamps=("${fresh[@]+"${fresh[@]}"}")
-
-  # Record this exit in the window.
-  restart_timestamps+=("$end_epoch")
-  window_count=${#restart_timestamps[@]}
-
-  if [[ "$window_count" -ge "$MAX_RESTARTS" ]]; then
-    log "ABORT: $window_count exits in ${WINDOW_SEC}s window (limit $MAX_RESTARTS) — not restarting"
-    log "Investigate root cause then restart manually with: $REPO_ROOT/start-masc.sh $*"
-    exit 1
-  fi
-
-  log "restart in ${COOLDOWN_SEC}s (exit #${window_count} in ${WINDOW_SEC}s window)"
-  sleep "$COOLDOWN_SEC"
+  log "restart in ${COOLDOWN_SEC}s"
+  run_active "restart cooldown" sleep "$COOLDOWN_SEC"
+  stop_if_requested
 done

--- a/test/test_start_masc_script.ml
+++ b/test/test_start_masc_script.ml
@@ -1202,7 +1202,7 @@ let test_loopback_disables_keeper_autoboot_by_default_and_requires_opt_in ()
       check bool "loopback honors explicit keeper autoboot opt-in" true
         (contains_substring captured_override "MASC_KEEPER_BOOTSTRAP_ENABLED=true"))
 
-let test_supervisor_preserves_child_exit_status_across_restart_policy () =
+let test_supervisor_restarts_without_exit_limit_and_preserves_status () =
   with_temp_dir "start-masc-supervised-script" (fun repo_root ->
       let scripts_dir = Filename.concat repo_root "scripts" in
       let supervisor_script =
@@ -1223,6 +1223,12 @@ if [ -f %s ]; then
 fi
 count=$((count + 1))
 printf '%%s\n' "$count" > %s
+if [ "$count" -ge 6 ]; then
+  kill -TERM "$PPID"
+  while true; do
+    sleep 1
+  done
+fi
 exit 23
 |}
            (quote invocation_count) (quote invocation_count)
@@ -1232,14 +1238,12 @@ exit 23
           ~env:
             [
               ("MASC_SUPERVISOR_LOG", log_file);
-              ("MASC_RESTART_WINDOW_SEC", "300");
-              ("MASC_MAX_RESTARTS_IN_WINDOW", "2");
               ("MASC_RESTART_COOLDOWN_SEC", "0");
             ]
           []
       in
-      check int "crash-loop breaker exit status" 1 code;
-      check string "child restarted until configured exit limit" "2\n"
+      check int "external stop signal remains explicit" 143 code;
+      check string "child keeps restarting after repeated failures" "6\n"
         (read_file invocation_count);
       let log = read_file log_file in
       check bool "real child exit status is recorded" true
@@ -1247,8 +1251,10 @@ exit 23
       check bool "child failure is not rewritten as success" false
         (contains_substring log "masc exited code=0");
       check string "supervisor writes no stdout" "" stdout;
-      check bool "abort remains explicit" true
-        (contains_substring stderr "ABORT: 2 exits in 300s window"))
+      check bool "external stop is logged" true
+        (contains_substring stderr "supervisor received SIGTERM");
+      check bool "finite crash-loop abort is absent" false
+        (contains_substring stderr "ABORT:"))
 
 let () =
   run "start_masc_script"
@@ -1321,8 +1327,8 @@ let () =
             `Quick
             test_loopback_disables_keeper_autoboot_by_default_and_requires_opt_in;
           test_case
-            "supervisor preserves child exit status across restart policy"
+            "supervisor restarts without exit limit and preserves status"
             `Quick
-            test_supervisor_preserves_child_exit_status_across_restart_policy;
+            test_supervisor_restarts_without_exit_limit_and_preserves_status;
         ] );
     ]


### PR DESCRIPTION
## What changed

- removed `MASC_RESTART_WINDOW_SEC` and `MASC_MAX_RESTARTS_IN_WINDOW`
- deleted the finite crash-window abort path
- kept every child exit explicit through exit-code, signal, and uptime logs
- made `TERM`, `INT`, and `HUP` explicit supervisor stops that are forwarded to the active child
- replaced the retired abort test with proof that six consecutive child starts continue until an external signal stops the supervisor

## Why

The process supervisor owned a hidden execution gate: five exits inside 300 seconds permanently revoked restart responsibility. A transient or lane-local failure could therefore stop the whole MASC process until manual intervention.

The supervisor now keeps restarting independently of failure count. Only explicit external signals or an invalid installation boundary stop it.

## Validation

- `bash -n scripts/start-masc-supervised.sh`
- `shellcheck scripts/start-masc-supervised.sh`
- `scripts/dune-local.sh build test/test_start_masc_script.exe`
- full `test_start_masc_script.exe`: 26/26 passed
- post-rebase focused supervisor case: 1/1 passed
- `git diff --check`

Diff scope: 2 files, 156 changed lines.
