### PR TITLE
refactor(runtime)!: remove local probe timeout clamp

### DIFF
--- a/lib/tool_local_runtime.ml
+++ b/lib/tool_local_runtime.ml
@@ -164,7 +164,7 @@ let handle_runtime_bench _ctx args : Core.tool_result =
         ~class_:Tool_result.Runtime_failure
         err
 
-let run_runtime_ollama_probe args : Core.tool_result =
+let run_runtime_ollama_probe ?timeout_sec args : Core.tool_result =
   let tool_name = "masc_runtime_ollama_probe" in
   let start_time = Time_compat.now () in
   let server_url = Json_util.get_string args "server_url" in
@@ -188,15 +188,6 @@ let run_runtime_ollama_probe args : Core.tool_result =
         | Some parsed -> parsed
         | None -> 16)
     | _ -> 16
-  in
-  let timeout_sec =
-    match Json_util.assoc_member_opt "timeout_sec" args with
-    | Some (`Int value) -> value
-    | Some (`Intlit value) ->
-        (match Core.parse_int_opt value with
-         | Some parsed -> parsed
-         | None -> 6)
-    | _ -> 6
   in
   let think_mode =
     match Json_util.assoc_member_opt "think_mode" args with
@@ -236,19 +227,41 @@ let run_runtime_ollama_probe args : Core.tool_result =
         [
           ( "result",
             runtime_ollama_probe_json ?server_url ?model ?prompt ?keep_alive
-              ~probe_runs ~max_tokens ~think_mode ~timeout_sec
+              ~probe_runs ~max_tokens ~think_mode ?timeout_sec
               ~generate_when_unloaded ~run_generate () );
         ]
 
+let runtime_ollama_probe_timeout_sec args =
+  match Json_field.int args "timeout_sec" with
+  | Json_field.Field_absent -> Ok None
+  | Json_field.Found value ->
+      Result.map
+        (fun timeout_sec -> Some timeout_sec)
+        (Tool_local_runtime_probe.validate_timeout_sec value)
+  | Json_field.Wrong_shape { expected; got } ->
+      Error
+        (Printf.sprintf
+           "timeout_sec must be a positive %s, got %s"
+           expected
+           got)
+
 let handle_runtime_ollama_probe (ctx : Core.context) args : Core.tool_result =
-  let continue () = run_runtime_ollama_probe args in
-  match ctx.authorize_external_effect with
-  | None -> continue ()
-  | Some authorize ->
-    authorize
-      ~operation:"masc_runtime_ollama_probe"
-      ~input:args
-      ~continue
+  match runtime_ollama_probe_timeout_sec args with
+  | Error message ->
+      err_response
+        ~tool_name:"masc_runtime_ollama_probe"
+        ~start_time:(Time_compat.now ())
+        ~class_:Tool_result.Workflow_rejection
+        message
+  | Ok timeout_sec ->
+      let continue () = run_runtime_ollama_probe ?timeout_sec args in
+      (match ctx.authorize_external_effect with
+       | None -> continue ()
+       | Some authorize ->
+         authorize
+           ~operation:"masc_runtime_ollama_probe"
+           ~input:args
+           ~continue)
 ;;
 
 let dispatch ctx ~name ~args : Core.tool_result option =

--- a/lib/tool_local_runtime.mli
+++ b/lib/tool_local_runtime.mli
@@ -59,7 +59,8 @@ val runtime_ollama_probe_json :
 (** Re-export of {!Tool_local_runtime_probe.runtime_ollama_probe_json}.
     All parameters are optional with defaults: [probe_runs = 2],
     [max_tokens = 16], [think_mode = Think_auto],
-    [timeout_sec = 6], [ps_timeout_sec = 2],
+    [timeout_sec = 6] (positive explicit values are preserved),
+    [ps_timeout_sec = 2],
     [generate_when_unloaded = true], [run_generate = true].  Per
     PR #20479 spirit: the tool itself (ollama [OLLAMA_LOAD_TIMEOUT])
     owns hang protection; callers do not observe these timeouts. *)

--- a/lib/tool_local_runtime_probe.ml
+++ b/lib/tool_local_runtime_probe.ml
@@ -66,6 +66,12 @@ type generate_probe_decision =
 
 let clamp ~min_value ~max_value value = max min_value (min max_value value)
 
+let validate_timeout_sec value =
+  if value > 0 then
+    Ok value
+  else
+    Error
+      (Printf.sprintf "timeout_sec must be a positive integer (got %d)" value)
 
 let normalize_ollama_server_url raw =
   let trimmed = String.trim raw in
@@ -508,7 +514,11 @@ let runtime_ollama_probe_json ?server_url ?model ?prompt ?(probe_runs = 2)
   in
   let probe_runs = clamp ~min_value:1 ~max_value:4 probe_runs in
   let max_tokens = clamp ~min_value:1 ~max_value:128 max_tokens in
-  let timeout_sec = clamp ~min_value:3 ~max_value:300 timeout_sec in
+  let timeout_sec =
+    match validate_timeout_sec timeout_sec with
+    | Ok value -> value
+    | Error message -> invalid_arg message
+  in
   let ps_timeout_sec = clamp ~min_value:1 ~max_value:30 ps_timeout_sec in
   let think_enabled = effective_think_enabled think_mode in
   let before_status, loaded_before, before_error =

--- a/lib/tool_local_runtime_probe.mli
+++ b/lib/tool_local_runtime_probe.mli
@@ -221,6 +221,10 @@ val kv_cache_assessment_json :
 
 (** {1 Top-level probe} *)
 
+val validate_timeout_sec : int -> (int, string) result
+(** [validate_timeout_sec value] accepts every positive integer unchanged.
+    Non-positive values are rejected explicitly. *)
+
 val runtime_ollama_probe_json :
   ?server_url:string ->
   ?model:string ->
@@ -238,8 +242,9 @@ val runtime_ollama_probe_json :
 (** Top-level probe orchestrator.  Defaults: [probe_runs=2]
     (clamped to [\[1, 4]]), [max_tokens=16] (clamped to
     [\[1, 128]]), [think_mode=Think_auto], [timeout_sec=6]
-    (clamped to [\[3, 300]]), [ps_timeout_sec=2] (clamped to
-    [\[1, 30]]), [generate_when_unloaded=true], [run_generate=true].
+    (every positive explicit value is preserved; non-positive values raise
+    [Invalid_argument]), [ps_timeout_sec=2] (clamped to [\[1, 30]]),
+    [generate_when_unloaded=true], [run_generate=true].
     Returns a JSON snapshot with [/api/ps] state + per-run timing +
     KV-cache assessment.  Per PR #20479 spirit: the tool itself
     (ollama [OLLAMA_LOAD_TIMEOUT]) owns hang protection; callers do

--- a/lib/tool_schemas/tool_schemas_local_runtime.ml
+++ b/lib/tool_schemas/tool_schemas_local_runtime.ml
@@ -78,7 +78,15 @@ let definitions : definition list =
                           `String
                             "Adaptive thinking policy for Ollama reasoning models. auto defaults to response-oriented non-thinking probes; enabled measures thinking path explicitly." );
                       ] );
-                  ("timeout_sec", `Assoc [ ("type", `String "integer") ]);
+                  ( "timeout_sec",
+                    `Assoc
+                      [
+                        ("type", `String "integer");
+                        ("minimum", `Int 1);
+                        ( "description",
+                          `String
+                            "Explicit probe timeout in seconds. Every positive value is passed through unchanged." );
+                      ] );
                   ("generate_when_unloaded", `Assoc [ ("type", `String "boolean") ]);
                   ("run_generate", `Assoc [ ("type", `String "boolean") ]);
                 ] );

--- a/test/test_tool_local_runtime_probe.ml
+++ b/test/test_tool_local_runtime_probe.ml
@@ -145,6 +145,66 @@ let test_runtime_probe_status_only_skip_reports_reason () =
   check bool "status-only flag reported" false
     (json |> member "run_generate" |> to_bool)
 
+let test_runtime_probe_preserves_positive_timeout () =
+  let timeout_of requested =
+    Eio_main.run @@ fun _env ->
+    Masc.Tool_local_runtime_probe.runtime_ollama_probe_json
+      ~server_url:"http://127.0.0.1:1"
+      ~model:"dummy-probe-model"
+      ~run_generate:false
+      ~timeout_sec:requested
+      ~ps_timeout_sec:1
+      ()
+    |> Yojson.Safe.Util.member "timeout_sec"
+    |> Yojson.Safe.Util.to_int
+  in
+  check int "below old floor is unchanged" 1 (timeout_of 1);
+  check int "above old cap is unchanged" 301 (timeout_of 301)
+
+let test_runtime_probe_rejects_nonpositive_timeout () =
+  check_raises
+    "zero timeout is rejected before I/O"
+    (Invalid_argument "timeout_sec must be a positive integer (got 0)")
+    (fun () ->
+      ignore
+        (Masc.Tool_local_runtime_probe.runtime_ollama_probe_json
+           ~server_url:"http://127.0.0.1:1"
+           ~timeout_sec:0
+           ()))
+
+let test_dispatch_rejects_invalid_timeout_before_authorization () =
+  let authorization_calls = ref 0 in
+  let authorize_external_effect ~operation:_ ~input:_ ~continue:_ =
+    incr authorization_calls;
+    fail "invalid input must not reach authorization"
+  in
+  let context : Masc.Tool_local_runtime_core.context =
+    {
+      config = Masc.Workspace.default_config "/tmp";
+      agent_name = "probe-timeout-test";
+      authorize_external_effect = Some authorize_external_effect;
+    }
+  in
+  let expect_rejection label timeout_json =
+    match
+      Masc.Tool_local_runtime.dispatch context
+        ~name:"masc_runtime_ollama_probe"
+        ~args:(`Assoc [ ("timeout_sec", timeout_json) ])
+    with
+    | None -> fail "Ollama probe handler was not selected"
+    | Some result ->
+        check bool (label ^ " failed") true (Tool_result.is_failed result);
+        check
+          bool
+          (label ^ " is a typed workflow rejection")
+          true
+          (Tool_result.failure_class result
+           = Some Tool_result.Workflow_rejection)
+  in
+  expect_rejection "non-positive timeout" (`Int 0);
+  expect_rejection "wrong-shape timeout" (`String "301");
+  check int "authorization was not invoked" 0 !authorization_calls
+
 let test_normalize_server_url_strips_trailing_slashes () =
   check string "normalizes trailing slash" "http://127.0.0.1:11434"
     (Masc.Tool_local_runtime_probe.normalize_ollama_server_url
@@ -288,6 +348,12 @@ let () =
             test_runtime_probe_reports_effective_think_mode;
           test_case "status-only skip reports reason" `Quick
             test_runtime_probe_status_only_skip_reports_reason;
+          test_case "preserves every positive explicit timeout" `Quick
+            test_runtime_probe_preserves_positive_timeout;
+          test_case "rejects non-positive timeout before I/O" `Quick
+            test_runtime_probe_rejects_nonpositive_timeout;
+          test_case "rejects invalid timeout before authorization" `Quick
+            test_dispatch_rejects_invalid_timeout_before_authorization;
           test_case "computes tok per second from generate response" `Quick
             test_ollama_generate_parser_computes_tok_per_second;
         ] );


### PR DESCRIPTION
## What changed

- removed the `[3, 300]` silent clamp from the Ollama local-runtime probe timeout
- preserve every positive explicit `timeout_sec` unchanged through the probe boundary
- reject non-positive or wrong-shape timeout input as a typed `Workflow_rejection` before Gate authorization
- declare the objective positive-integer domain in the tool schema
- replace the old clamp contract with focused preservation and fail-loud tests

## Why

The previous clamp silently rewrote operator intent: `1` became `3`, while `301+` became `300`. Invalid JSON input could also fall back to the implicit default. A local diagnostic tool must either execute the explicit positive timeout or reject invalid input; it must not invent a different deadline.

## Validation

- `ocamlformat --check` on all changed OCaml files
- `ocamlc -stop-after parsing` on all changed implementations/interfaces
- `git diff --check`
- static residue search confirms the `[3, 300]` probe timeout clamp and documentation are gone
- focused `scripts/dune-local.sh build test/test_tool_local_runtime_probe.exe` was attempted, but correctly refused because another session is running bare `dune build .` outside the machine-wide lock; full build/test remains CI authority
