### PR TITLE
fix(keeper): fall back to the structured-judge lane for compaction plans

### DIFF
--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -246,7 +246,7 @@ let eligible_candidate ~keeper_name (runtime : Runtime.t) =
     None)
   else Some { runtime_id; provider_cfg }
 
-let candidates_for_assignment ~keeper_name assignment_id =
+let resolve_assignment_candidates ~keeper_name assignment_id =
   let rec resolve_lane acc = function
     | [] -> Some (List.rev acc)
     | runtime_id :: rest ->
@@ -274,6 +274,31 @@ let candidates_for_assignment ~keeper_name assignment_id =
     Some (Option.to_list (eligible_candidate ~keeper_name runtime))
   | `Lane lane ->
     resolve_lane [] (Runtime_lane.ordered_candidates lane)
+
+let candidates_for_assignment ~keeper_name assignment_id =
+  match resolve_assignment_candidates ~keeper_name assignment_id with
+  | Some (_ :: _) as eligible -> eligible
+  | (Some [] | None) as primary ->
+    (* The compaction plan is a structured-output subcall. A keeper whose chat
+       assignment offers no schema-capable candidate must not lose compaction
+       entirely (an over-budget keeper then wedges: every turn replays the
+       oversized prompt and fails, and the keeper can never shrink it — #24838).
+       Route the plan through the designated structured-judge lane instead,
+       the same chat/schema lane separation the completion verifier applies. *)
+    (match
+       try Some (Runtime.runtime_id_for_structured_judge ()) with
+       | Failure _ -> None
+     with
+     | Some judge_id when not (String.equal judge_id assignment_id) ->
+       (match resolve_assignment_candidates ~keeper_name judge_id with
+        | Some (_ :: _ as candidates) ->
+          Log.Keeper.info ~keeper_name
+            "compaction LLM summarizer falling back to structured-judge lane \
+             runtime=%s (assignment %s has no schema-capable candidate)"
+            judge_id assignment_id;
+          Some candidates
+        | Some [] | None -> primary)
+     | Some _ | None -> primary)
 
 type make_fn = runtime_id:string -> keeper_name:string -> unit -> summarizer option
 let make_override : make_fn option Atomic.t = Atomic.make None

--- a/test/test_compaction_llm_summarizer.ml
+++ b/test/test_compaction_llm_summarizer.ml
@@ -107,6 +107,73 @@ let test_lane_candidates_keep_declared_order () =
     (Some [ "local.kimi_like"; "fallback.kimi_like" ])
     actual
 
+(* -- structured-judge fallback (#24838): a chat assignment with no
+      schema-capable candidate must not lose compaction entirely -- *)
+
+let judge_fallback_runtime_toml =
+  "[providers.local]\n\
+   display-name = \"Local\"\n\
+   protocol = \"ollama-http\"\n\
+   endpoint = \"http://localhost:11434\"\n\
+   \n\
+   [models.chat_like]\n\
+   api-name = \"chat-like\"\n\
+   max-context = 1024\n\
+   \n\
+   [models.judge_like]\n\
+   api-name = \"judge-like\"\n\
+   max-context = 1024\n\
+   \n\
+   [models.judge_like.capabilities]\n\
+   supports-structured-output = true\n\
+   \n\
+   [local.chat_like]\n\
+   \n\
+   [local.judge_like]\n\
+   \n\
+   [runtime]\n\
+   default = \"local.chat_like\"\n\
+   structured_judge = \"local.judge_like\"\n"
+
+let with_judge_fallback_runtime f =
+  let path = Filename.temp_file "compaction_judge_fallback_runtime" ".toml" in
+  let runtime_snapshot = Runtime.For_testing.snapshot () in
+  Fun.protect
+    ~finally:(fun () ->
+      Runtime.For_testing.restore runtime_snapshot;
+      try Sys.remove path with
+      | Sys_error _ -> ())
+    (fun () ->
+      match
+        Runtime.save_config_text ~runtime_config_path:path judge_fallback_runtime_toml
+      with
+      | Error detail -> Alcotest.failf "runtime config should load: %s" detail
+      | Ok () -> f ())
+
+let test_schemaless_assignment_falls_back_to_structured_judge () =
+  with_judge_fallback_runtime @@ fun () ->
+  let actual =
+    C.For_testing.candidate_runtime_ids_for_assignment
+      ~keeper_name:"keeper-test"
+      ~runtime_id:"local.chat_like"
+  in
+  Alcotest.(check (option (list string)))
+    "schema-capable structured-judge lane replaces the empty chat candidates"
+    (Some [ "local.judge_like" ])
+    actual
+
+let test_schema_capable_assignment_keeps_own_lane () =
+  with_judge_fallback_runtime @@ fun () ->
+  let actual =
+    C.For_testing.candidate_runtime_ids_for_assignment
+      ~keeper_name:"keeper-test"
+      ~runtime_id:"local.judge_like"
+  in
+  Alcotest.(check (option (list string)))
+    "an already schema-capable assignment does not detour"
+    (Some [ "local.judge_like" ])
+    actual
+
 (* -- plan_of_json: valid partition accepted -- *)
 
 let test_valid_partition_accepted () =
@@ -237,6 +304,10 @@ let () =
             test_provider_for_plan_preserves_temperature_omission
         ; Alcotest.test_case "lane candidates keep declared order" `Quick
             test_lane_candidates_keep_declared_order
+        ; Alcotest.test_case "schemaless assignment falls back to structured judge" `Quick
+            test_schemaless_assignment_falls_back_to_structured_judge
+        ; Alcotest.test_case "schema-capable assignment keeps its own lane" `Quick
+            test_schema_capable_assignment_keeps_own_lane
         ] )
     ; ( "plan_of_json"
       , [ Alcotest.test_case "valid partition accepted" `Quick test_valid_partition_accepted


### PR DESCRIPTION
## 문제 (#24838의 masc측 핵심 — "LLM 레인 왜 못 붙음"의 답)

compaction LLM summarizer가 후보를 **keeper 자신의 chat assignment에서만** 뽑습니다. schema를 못 받는 레인(OpenAI-compat `/v1`은 plan schema 미강제)에 배정된 keeper는 항상 `Summarizer_unavailable`:

```
[WARN] compaction LLM candidate skipped runtime=ollama_cloud.deepseek-v4-flash: provider does not support the compaction plan schema
[WARN] compaction LLM summarizer has no eligible candidate assignment=ollama_cloud.deepseek-v4-flash
[ERROR] manual compaction failed in owner lane: compaction rejected: summarizer_unavailable
```

라이브 실측 (2026-07-16 17:27~17:32): taskmaster/ramarama/verifier의 manual compaction 전부 위 사유로 거부. 이 keeper들은 히스토리가 provider budget을 넘어 **모든 턴이 초과 프롬프트를 재전송하며 실패**하는 wedge 상태 — 유일한 출구인 compaction이 자기 라우팅으로는 도달 불가능한 구조였습니다.

repo 시드 주석이 이미 원칙을 명시합니다: "Provider-native structured-output judges must not inherit the fleet chat default when that default lacks schema support" — completion verifier에는 적용됐지만 compaction summarizer에는 빠져 있었습니다.

## 수정

`candidates_for_assignment`: assignment 해석 결과 schema-capable 후보가 0이면, **지정 structured-judge 레인**(`Runtime.runtime_id_for_structured_judge` — failure_judge/board_attention과 동일 접근자)을 같은 eligibility 검사로 재해석해 사용. 

- schema-capable assignment → 자기 레인 유지 (우회 없음)
- judge id == assignment id 또는 judge 미구성/미해석 → 기존 결과 유지 (동작 불변)
- fallback 발동 시 INFO 로그 (operator 가시성)

## 검증

- 신규 2케이스: schemaless assignment → judge 레인으로 대체 / schema-capable assignment → 자기 레인 유지 (Runtime `save_config_text` fixture, 기존 테스트 관례)
- `compaction_llm_summarizer` 스위트 **17/17**
- ocamlformat clean

## 배포 맥락

배포 config에는 native structured 레인(`ollama_cloud_native.minimax-m3-native-structured`)이 이미 추가·재기동됨(#24838 코멘트 참조). 이 PR 착지+배포 시 wedge keeper들의 manual compaction이 그 레인으로 실제 요약을 수행할 수 있게 됩니다.

Refs: #24838, oas#2621 (typed overflow 신호 — 두 절반이 합쳐져 self-heal 루프 완성)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
