### PR TITLE
test(quick-suite): align stale contract pins with landed refactors

### DIFF
--- a/test/test_dashboard_keeper_worker_degrade_source.ml
+++ b/test/test_dashboard_keeper_worker_degrade_source.ml
@@ -93,13 +93,15 @@ let test_context_max_fallback_uses_pure_runtime_budget () =
     src
     "Keeper_context_runtime.resolve_max_context_resolution_of_meta m";
   check_contains
-    "metrics zero context max falls back to runtime budget"
+    "context max is the typed runtime resolution budget"
     src
-    "if raw_context_max > 0 then raw_context_max else primary_max_context";
-  check_contains
-    "missing metrics ratio is recomputed from tokens and runtime budget"
-    src
-    "float_of_int context_tokens /. float_of_int context_max";
+    "let primary_max_context = max_context_resolution.effective_budget";
+  (* #24468 removed the raw-metrics fallback and ratio recompute outright:
+     the no-heuristic boundary means metrics never supply a context max. *)
+  check bool "raw metrics context max heuristic stays deleted" false
+    (contains ~needle:"raw_context_max" src);
+  check bool "metrics ratio recompute heuristic stays deleted" false
+    (contains ~needle:"float_of_int context_tokens /. float_of_int context_max" src);
   check bool "summary fallback does not hardcode zero context max" false
     (contains ~needle:"let primary_max_context = 0 in" src)
   ; check bool "dashboard read path avoids turn resolver side effects" false

--- a/test/test_keeper_compact_recovery_tool_surface.ml
+++ b/test/test_keeper_compact_recovery_tool_surface.ml
@@ -25,7 +25,7 @@ let persisted_meta_exn config name =
   | Ok None -> fail "persisted keeper meta is missing"
   | Error detail -> failf "persisted keeper meta read failed: %s" detail
 
-let test_missing_checkpoint_is_typed_tool_failure () =
+let test_missing_checkpoint_still_queues_owner_lane_stimulus () =
   Eio_main.run @@ fun env ->
   Masc_test_deps.ensure_rng_initialized ();
   Masc_test_deps.init_eio_clock env;
@@ -72,21 +72,29 @@ let test_missing_checkpoint_is_typed_tool_failure () =
           ~args:(`Assoc [ "name", `String keeper_name ])
       with
       | None -> fail "masc_keeper_compact is not registered"
-      | Some (Tool_result.Completed _) -> fail "missing checkpoint must not report success"
-      | Some (Tool_result.Deferred _) -> fail "missing checkpoint must not defer"
+      | Some (Tool_result.Deferred _) -> fail "compaction admission must not defer"
       | Some (Tool_result.Failed failure) ->
-        check string "tool identity" "masc_keeper_compact" failure.tool_name;
-        check string "typed recovery error" "checkpoint_not_found"
-          Yojson.Safe.Util.(failure.data |> member "compaction_error" |> to_string);
-        check bool "checkpoint was not applied" false
-          Yojson.Safe.Util.(failure.data |> member "checkpoint_applied" |> to_bool))
+        failf "compaction admission must queue, got failure: %s" failure.message
+      | Some (Tool_result.Completed output) ->
+        (* #24598 (RFC-0182 §3.1): the tool surface only queues a
+           Manual_compaction_requested stimulus on the owner lane; the
+           checkpoint lookup and its typed recovery failure now surface
+           when the lane consumes the stimulus, not at dispatch. *)
+        check string "tool identity" "masc_keeper_compact" output.tool_name;
+        check bool "admission acknowledges queueing" true
+          Yojson.Safe.Util.(output.data |> member "queued" |> to_bool);
+        check string "owner-lane stimulus kind" "manual_compaction_requested"
+          Yojson.Safe.Util.(output.data |> member "stimulus" |> to_string);
+        check bool "queue outcome is reported" true
+          Yojson.Safe.Util.(
+            output.data |> member "queue_outcome" |> to_string <> ""))
 
 let () =
   run "keeper_compact_recovery_tool_surface"
     [ ( "recovery_failure"
       , [ test_case
-            "missing checkpoint is a typed tool failure"
+            "missing checkpoint still queues the owner-lane stimulus"
             `Quick
-            test_missing_checkpoint_is_typed_tool_failure
+            test_missing_checkpoint_still_queues_owner_lane_stimulus
         ] )
     ]

--- a/test/test_keeper_structured_output_coverage.ml
+++ b/test/test_keeper_structured_output_coverage.ml
@@ -23,6 +23,13 @@ let direct_completion_files_under rel =
   |> List.sort String.compare
 ;;
 
+let subcall_caller_files_under rel =
+  ml_files_under rel
+  |> List.filter (fun rel ->
+    Ast_grep.count_calls ~module_path:rel ~callee:"Keeper_provider_subcall.complete" > 0)
+  |> List.sort String.compare
+;;
+
 let direct_agent_run_files_under rel =
   ml_files_under rel
   |> List.filter (fun rel ->
@@ -38,7 +45,16 @@ let direct_agent_run_files () =
 
 let keeper_direct_completion_files () = direct_completion_files_under "lib/keeper"
 
-let expected_structured_completion_files =
+let expected_completion_boundary_files =
+  List.sort
+    String.compare
+    [ (* #24571 centralized every keeper LLM subcall behind this boundary;
+         the schema contract now lives in its callers, pinned below. *)
+      "lib/keeper/keeper_provider_subcall.ml"
+    ]
+;;
+
+let expected_subcall_caller_files =
   List.sort
     String.compare
     [ "lib/keeper/hitl_summary_worker.ml"
@@ -169,7 +185,7 @@ let masc_tool_agent_run_files () =
 let expected_all_direct_completion_files =
   List.sort
     String.compare
-    (expected_structured_completion_files @ expected_unstructured_completion_exemptions)
+    (expected_completion_boundary_files @ expected_unstructured_completion_exemptions)
 ;;
 
 let structured_output_contract_call_count rel =
@@ -212,12 +228,20 @@ let test_keeper_direct_completions_are_enumerated () =
   check
     (list string)
     "keeper direct completion files"
-    expected_structured_completion_files
+    expected_completion_boundary_files
     (keeper_direct_completion_files ())
 ;;
 
-let test_keeper_direct_completions_request_structured_output () =
-  List.iter check_structured_output_contract expected_structured_completion_files
+let test_keeper_subcall_callers_are_enumerated () =
+  check
+    (list string)
+    "keeper subcall caller files"
+    expected_subcall_caller_files
+    (subcall_caller_files_under "lib")
+;;
+
+let test_keeper_subcall_callers_request_structured_output () =
+  List.iter check_structured_output_contract expected_subcall_caller_files
 ;;
 
 let test_agent_run_json_judges_request_structured_output rels =
@@ -521,10 +545,16 @@ let () =
             "lib/keeper direct completion files are enumerated"
             `Quick
             test_keeper_direct_completions_are_enumerated
-        ; test_case
-            "lib/keeper direct completions request structured output"
+        ] )
+    ; ( "keeper subcall callers"
+      , [ test_case
+            "Keeper_provider_subcall callers are enumerated"
             `Quick
-            test_keeper_direct_completions_request_structured_output
+            test_keeper_subcall_callers_are_enumerated
+        ; test_case
+            "Keeper_provider_subcall callers request structured output"
+            `Quick
+            test_keeper_subcall_callers_request_structured_output
         ] )
     ; ( "dashboard json judges"
       , [ test_case

--- a/test/test_keeper_turn_fsm_wired_sites.ml
+++ b/test/test_keeper_turn_fsm_wired_sites.ml
@@ -97,14 +97,18 @@ let test_success_completion_transitions_owned_once () =
   Alcotest.(check int)
     "success completion transitions not emitted by caller" 0
     (count_substring unified "Keeper_turn_fsm.Completing");
+  (* #24332 deleted the completion-contract branch (Completing -> Failed)
+     along with the governance mechanism, so the success handler owns two
+     completion-state references (enter Completing, Completing -> Done)
+     and no Failed transition. *)
   Alcotest.(check int)
-    "success handler owns three completion-state references" 3
+    "success handler owns two completion-state references" 2
     (count_substring success "Keeper_turn_fsm.Completing");
   Alcotest.(check int)
     "success handler owns one done transition" 1
     (count_substring success "Keeper_turn_fsm.Done");
   Alcotest.(check int)
-    "success handler owns one typed failed transition" 1
+    "success handler owns no typed failed transition" 0
     (count_substring success "Keeper_turn_fsm.Failed")
 
 let () =

--- a/test/test_typed_tool_masc.ml
+++ b/test/test_typed_tool_masc.ml
@@ -31,19 +31,18 @@ let test_parse_missing_message () =
   | Error _ -> ()
 
 let test_parse_wrong_type () =
-  (* agent_sdk coerces scalar values into string fields, so use a container
-     value here to assert a non-coercible parse failure. *)
   let json = `Assoc [("message", `List [`String "a"])] in
   match parse json with
   | Ok _ -> Alcotest.fail "expected parse error"
   | Error _ -> ()
 
-let test_parse_coerces_int_message () =
+let test_parse_rejects_int_message () =
+  (* OAS 0.212 removed implicit input coercion (issue #24773): a scalar of
+     the wrong type is a typed reject, no int -> string widening. *)
   let json = `Assoc [("message", `Int 42)] in
   match parse json with
-  | Ok message ->
-    Alcotest.(check string) "message coerced" "42" message
-  | Error e -> Alcotest.fail ("expected coercion: " ^ e)
+  | Ok message -> Alcotest.fail ("expected strict reject, got: " ^ message)
+  | Error _ -> ()
 
 let test_handler_success () =
   match Tool_broadcast_typed.handle_broadcast "hello @claude" with
@@ -93,16 +92,15 @@ let test_e2e_parse_error () =
   | Ok _ -> Alcotest.fail "expected error"
   | Error e -> Alcotest.(check bool) "recoverable" true e.recoverable
 
-let test_e2e_coerced_input () =
+let test_e2e_int_input_rejected () =
   let oas_tool = Typed_tool_masc.to_oas Tool_broadcast_typed.tool in
   match Agent_sdk.Typed_tool.execute oas_tool (`Assoc [("message", `Int 99)]) with
   | Ok { content; _ } ->
-    let result = Yojson.Safe.from_string content in
-    let open Yojson.Safe.Util in
-    Alcotest.(check bool) "delivered" true (result |> member "delivered" |> to_bool);
-    Alcotest.(check string) "broadcast_message" "99"
-      (result |> member "broadcast_message" |> to_string)
-  | Error e -> Alcotest.fail ("expected coercion success: " ^ e.message)
+    Alcotest.fail ("expected strict reject, got success: " ^ content)
+  | Error e ->
+    (* Recoverable: the typed error tells the caller to fix parameters and
+       retry, matching the strict contract codified in issue #24773. *)
+    Alcotest.(check bool) "recoverable" true e.recoverable
 
 let test_e2e_handler_error () =
   let oas_tool = Typed_tool_masc.to_oas Tool_broadcast_typed.tool in
@@ -127,7 +125,7 @@ let () =
       Alcotest.test_case "extra fields ignored (#8595)" `Quick test_parse_extra_fields_ignored;
       Alcotest.test_case "missing message" `Quick test_parse_missing_message;
       Alcotest.test_case "wrong type" `Quick test_parse_wrong_type;
-      Alcotest.test_case "int coerces to string" `Quick test_parse_coerces_int_message;
+      Alcotest.test_case "int is strictly rejected" `Quick test_parse_rejects_int_message;
     ]);
     ("handler", [
       Alcotest.test_case "success" `Quick test_handler_success;
@@ -141,7 +139,7 @@ let () =
     ("e2e", [
       Alcotest.test_case "success" `Quick test_e2e_success;
       Alcotest.test_case "parse error" `Quick test_e2e_parse_error;
-      Alcotest.test_case "coerced input" `Quick test_e2e_coerced_input;
+      Alcotest.test_case "int input rejected" `Quick test_e2e_int_input_rejected;
       Alcotest.test_case "handler error" `Quick test_e2e_handler_error;
     ]);
     ("registration", [


### PR DESCRIPTION
## 요약

main quick suite 잔여 red 중 **고아 5클러스터**(수리 중인 open PR 없음 확인) 수리입니다. 전부 "머지된 refactor가 의도적으로 제거한 형태를 contract pin이 계속 단언"하는 stale-pin 클래스 — red-window 머지라 원 PR CI에서 드러나지 않았습니다.

| 실패 | 원인 커밋 | 수리 |
|---|---|---|
| `all/keeper direct completion 0` | #24571 (subcall 경계 중앙화) | pin을 경계 모듈로 재고정 + caller 6파일 스키마 계약 이식(신규 "keeper subcall callers" 그룹) |
| `recovery_failure 0` | #24598 (owner-lane compaction, RFC-0182 §3.1) | dispatch는 admission ack(queued/stimulus/queue_outcome) pin으로 전환 — typed 실패는 lane 소비 시점 계약 |
| `wiring 1` | #24332 (completion-contract 거버넌스 삭제) | Completing 3→2, Failed 1→0 (주석으로 귀속 명기) |
| `worker_failure 2` | #24468 (no-heuristic context boundary) | raw-metrics fallback/ratio 양성 pin → 부재(음성) pin으로 반전 + typed resolution 단독 사용 단언 |
| `parse 4` / `e2e 2` (coercion) | OAS 0.212 hard-cut (#24436 흡수, issue #24773) | green train이 성문화한 strict 계약의 누락 방향(int→string) 2건을 strict reject로 정렬 — **제품 결정 A/B 미선점** (이슈 코멘트 참조) |

## 비수리 (fleet in-flight, 미간섭)

- `loop 7`: #24808이 테스트 포함 수리 중
- `typed judgment 6`: #24810/#24842 in-flight
- `posts 12`: #24848 in-flight
- routing 클러스터: #24812 (내 PR, CI로 fixture 유효성 증명됨)

## 검증

- 6개 test exe 전부 로컬 green (main head에서 각각 FAIL 재현 후 수리)
- ocamlformat --check 통과

RFC-WAIVED: 테스트 pin 정렬 배치 — lib/아키텍처/credential 표면 무변경.

Co-Authored-By: Claude Fable 5
