### PR TITLE
refactor(repo): schedule sync by repository cadence

### DIFF
--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -14,9 +14,9 @@ the categorization roadmap. Newly-added typed getters in
 `lib/config/env_config_*.ml` must carry nearby `@category` and
 `@ops_class` tags; existing knobs remain in the backfill lane.
 
-**Total**: 271 unique knobs across 8 modules.
+**Total**: 270 unique knobs across 8 modules.
 
-**Typed getter classification**: 37/155 tagged (`operator`: 37, `algorithm`: 0, `unclassified`: 118).
+**Typed getter classification**: 37/154 tagged (`operator`: 37, `algorithm`: 0, `unclassified`: 117).
 
 ## Env_config_core (25 knobs; typed classification 2/6)
 
@@ -113,7 +113,7 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_DOMAIN_POOL_ENABLED` | feature_flag | n/a | n/a | 12 | Historical keeper Domain_pool pilot flag. The supervisor still reads this for observability, but keepalive fibers rem... |
 | `MASC_KEEPER_SUPERVISOR_SWEEP_SEC` | typed:float | Timeouts | operator | 17 | Interval between supervisor sweep runs (seconds). @category Timeouts @ops_class operator |
 
-## Env_config_runtime (82 knobs; typed classification 4/66)
+## Env_config_runtime (81 knobs; typed classification 4/65)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
@@ -171,14 +171,13 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_PUBLIC_TOOLS_EXTRA` | string_literal | n/a | n/a | 365 | Extra public tools (comma-separated names). |
 | `MASC_RATE_BURST` | typed:int | unclassified | unclassified | 393 | Burst capacity. Default: 150. |
 | `MASC_RATE_LIMIT` | typed:float | unclassified | unclassified | 390 | Requests per second. Default: 100. |
-| `MASC_RATE_LIMIT_BUCKET_TTL_SEC` | typed:int | unclassified | unclassified | 638 | Rate-limit bucket staleness TTL (seconds). Buckets with no traffic for this long are reaped by the janitor loop. Defa... |
-| `MASC_REPO_SYNC_INTERVAL_SEC` | typed:float | unclassified | unclassified | 630 | Repository auto-sync interval (seconds). The repo_sync fiber in [server_bootstrap_loops] wakes at this cadence to fet... |
+| `MASC_RATE_LIMIT_BUCKET_TTL_SEC` | typed:int | unclassified | unclassified | 631 | Rate-limit bucket staleness TTL (seconds). Buckets with no traffic for this long are reaped by the janitor loop. Defa... |
 | `MASC_SESSION_MAX_AGE_SEC` | typed:float | unclassified | unclassified | 36 | Maximum session age before cleanup (seconds) |
 | `MASC_SESSION_RATE_LIMIT_WINDOW_SEC` | typed:float | unclassified | unclassified | 40 | Rate limit window (seconds) |
 | `MASC_SESSION_SSE_GRACE_PERIOD_SEC` | typed:float | unclassified | unclassified | 45 | Grace period after SSE disconnect before reaping transport session (seconds). Prevents "Unknown Mcp-Session-Id" error... |
-| `MASC_SIDECAR_CONTROL_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 664 | Subprocess timeout (seconds) for sidecar control commands — [stop], [tail], and similar quick housekeeping operatio... |
-| `MASC_SIDECAR_RECONCILE_BACKOFF_SEC` | typed:float | unclassified | unclassified | 652 | Backoff window (seconds) between repeated same-generation [running + unavailable] start dispatches. Default: 30 (matc... |
-| `MASC_SIDECAR_SCHEMA_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 680 | Subprocess timeout (seconds) for sidecar Python schema generation. Wraps [Process_eio.run_argv_with_status] at [serve... |
+| `MASC_SIDECAR_CONTROL_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 657 | Subprocess timeout (seconds) for sidecar control commands — [stop], [tail], and similar quick housekeeping operatio... |
+| `MASC_SIDECAR_RECONCILE_BACKOFF_SEC` | typed:float | unclassified | unclassified | 645 | Backoff window (seconds) between repeated same-generation [running + unavailable] start dispatches. Default: 30 (matc... |
+| `MASC_SIDECAR_SCHEMA_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 673 | Subprocess timeout (seconds) for sidecar Python schema generation. Wraps [Process_eio.run_argv_with_status] at [serve... |
 | `MASC_SSE_BUFFER_TTL_SEC` | typed:float | unclassified | unclassified | 612 | SSE buffer TTL (seconds). Default: 300 (5 min). |
 | `MASC_STALLED_SESSION_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 616 | Operator digest stalled session threshold (seconds). Default: 300 (5 min). |
 | `MASC_STARTUP_WATCHDOG_SEC` | typed:float | unclassified | unclassified | 295 | Startup watchdog timeout, clamped to [30, 600]. Default: 240. Re-readable within the process, but operationally a boo... |
@@ -193,8 +192,8 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_WEB_SEARCH_PROVIDER` | string_literal | n/a | n/a | 368 |  |
 | `MASC_WEB_SEARCH_PROVIDER_ORDER` | string_literal | n/a | n/a | 371 |  |
 | `MASC_WEB_SEARCH_TIMEOUT_SEC` | typed:int | unclassified | unclassified | 377 |  |
-| `MASC_WORKSPACE_FILE_MAX_READ_BYTES` | typed:int | Policies | operator | 725 | Maximum bytes served by the IDE workspace file endpoint in one response. The route rejects larger files instead of ma... |
-| `MASC_WORKSPACE_GIT_LOCAL_OP_TIMEOUT_SEC` | typed:float | Timeouts | operator | 715 | Budget (seconds) for local-only git operations under [Masc_exec.Exec_gate.run_argv*] in {!Workspace_git}: [rev-parse]... |
+| `MASC_WORKSPACE_FILE_MAX_READ_BYTES` | typed:int | Policies | operator | 718 | Maximum bytes served by the IDE workspace file endpoint in one response. The route rejects larger files instead of ma... |
+| `MASC_WORKSPACE_GIT_LOCAL_OP_TIMEOUT_SEC` | typed:float | Timeouts | operator | 708 | Budget (seconds) for local-only git operations under [Masc_exec.Exec_gate.run_argv*] in {!Workspace_git}: [rev-parse]... |
 | `MASC_WS_ENABLED` | feature_flag | n/a | n/a | 265 | Whether WebSocket transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at... |
 | `MASC_WS_PORT` | string_literal | n/a | n/a | 261 | WebSocket server port. Default: 8937. |
 | `MASC_ZOMBIE_CLEANUP_INTERVAL_SEC` | typed:float | unclassified | unclassified | 14 | Cleanup loop interval (seconds) |

--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -623,13 +623,6 @@ module InternalTimers = struct
   let janitor_interval_sec =
     get_float ~default:60.0 "MASC_JANITOR_INTERVAL_SEC"
 
-  (** Repository auto-sync interval (seconds). The repo_sync fiber in
-      [server_bootstrap_loops] wakes at this cadence to fetch repositories
-      with [auto_sync = true]. Default: 300 (5 min). *)
-  let repo_sync_interval_sec =
-    let value = get_float ~default:300.0 "MASC_REPO_SYNC_INTERVAL_SEC" in
-    if value > 0.0 then value else 300.0
-
   (** Rate-limit bucket staleness TTL (seconds). Buckets with no traffic for
       this long are reaped by the janitor loop. Default: 300 (5 min). Raise
       for longer client quiet periods; lower to free memory faster under

--- a/lib/config/env_config_runtime.mli
+++ b/lib/config/env_config_runtime.mli
@@ -238,7 +238,6 @@ module InternalTimers : sig
   val sse_buffer_ttl_sec : float
   val stalled_session_threshold_sec : float
   val janitor_interval_sec : float
-  val repo_sync_interval_sec : float
   val rate_limit_bucket_ttl_sec : int
 end
 

--- a/lib/mcp_server.ml
+++ b/lib/mcp_server.ml
@@ -521,11 +521,27 @@ type workspace_runtime =
   ; scope : workspace_scope Atomic.t
   }
 
+type repo_sync_revision = unit ref
+
+type repo_sync_change_signal =
+  { mutex : Eio.Mutex.t
+  ; changed : Eio.Condition.t
+  ; mutable revision : repo_sync_revision
+  }
+
+let create_repo_sync_change_signal () =
+  { mutex = Eio.Mutex.create ()
+  ; changed = Eio.Condition.create ()
+  ; revision = ref ()
+  }
+;;
+
 (** MCP Server state *)
 type server_state = {
   workspace_runtime: workspace_runtime;
   session_registry: Session.registry;
   on_sse_broadcast: (Yojson.Safe.t -> unit) option Atomic.t;  (* SSE push callback, Atomic for cross-fiber visibility *)
+  repo_sync_change: repo_sync_change_signal;
   sw: Eio.Switch.t option; (* Request/runtime fibers for HTTP/MCP handlers *)
   proc_mgr: Eio_unix.Process.mgr_ty Eio.Resource.t option; (* For agent spawning *)
   fs: Eio.Fs.dir_ty Eio.Path.t option; (* For filesystem access *)
@@ -550,6 +566,26 @@ let workspace_switch_error_to_string = function
 
 let workspace_scope state = Atomic.get state.workspace_runtime.scope
 let workspace_config state = (workspace_scope state).config
+
+let repo_sync_revision state =
+  Eio.Mutex.use_ro state.repo_sync_change.mutex (fun () ->
+    state.repo_sync_change.revision)
+;;
+
+let notify_repo_sync_change state =
+  Eio.Mutex.use_rw ~protect:false state.repo_sync_change.mutex (fun () ->
+    state.repo_sync_change.revision <- ref ());
+  Eio.Condition.broadcast state.repo_sync_change.changed
+;;
+
+let await_repo_sync_change state ~after =
+  Eio.Mutex.use_ro state.repo_sync_change.mutex (fun () ->
+    while state.repo_sync_change.revision == after do
+      Eio.Condition.await
+        state.repo_sync_change.changed
+        state.repo_sync_change.mutex
+    done)
+;;
 
 let workspace_scope_publication_recovery_registry scope =
   match Atomic.get scope.publication_recovery.state with
@@ -1016,6 +1052,7 @@ let set_workspace_config state config =
       then replace_config ()
     in
     replace_config ();
+    notify_repo_sync_change state;
     Ok ()
 ;;
 
@@ -1135,6 +1172,7 @@ module For_testing = struct
           }
       ; session_registry = registry
       ; on_sse_broadcast = Atomic.make None
+      ; repo_sync_change = create_repo_sync_change_signal ()
       ; sw = None
       ; proc_mgr = None
       ; fs = None
@@ -1234,6 +1272,7 @@ let create_state_eio ~sw ~proc_mgr ~fs ~clock ~mono_clock ~net ~base_path =
       };
     session_registry = registry;
     on_sse_broadcast = Atomic.make None;
+    repo_sync_change = create_repo_sync_change_signal ();
     sw = Some sw;
     proc_mgr = Some proc_mgr;
     fs = Some fs;

--- a/lib/mcp_server.mli
+++ b/lib/mcp_server.mli
@@ -189,11 +189,15 @@ type workspace_scope = private
 
 type workspace_runtime
 
+type repo_sync_revision
+type repo_sync_change_signal
+
 type server_state = private {
   workspace_runtime : workspace_runtime;
   session_registry : Session.registry;
   on_sse_broadcast :
     (Yojson.Safe.t -> unit) option Atomic.t;
+  repo_sync_change : repo_sync_change_signal;
   sw : Eio.Switch.t option;
   proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option;
   fs : Eio.Fs.dir_ty Eio.Path.t option;
@@ -213,6 +217,18 @@ val workspace_scope : server_state -> workspace_scope
 
 val workspace_config : server_state -> Workspace.config
 (** Current workspace configuration. *)
+
+val repo_sync_revision : server_state -> repo_sync_revision
+(** Snapshot the repository configuration revision before loading its schedule. *)
+
+val notify_repo_sync_change : server_state -> unit
+(** Wake the repository scheduler after a repository or workspace
+    configuration mutation has committed. *)
+
+val await_repo_sync_change :
+  server_state -> after:repo_sync_revision -> unit
+(** Wait until the repository configuration revision differs from [after].
+    Cancellation is propagated to the caller. *)
 
 val publication_recovery_availability_provider :
   server_state -> Keeper_publication_recovery_availability.provider

--- a/lib/repo_manager/repo_sync.ml
+++ b/lib/repo_manager/repo_sync.ml
@@ -10,6 +10,11 @@ type advance_outcome =
   | Fast_forward_refused of { behind : int; reason : string }
   | Advance_inspect_failed of { reason : string }
 
+type sync_attempt = {
+  repository : repository;
+  result : (advance_outcome, string) result;
+}
+
 let advance_outcome_label = function
   | Advanced _ -> "advanced"
   | Already_current -> "already_current"
@@ -85,15 +90,27 @@ let should_sync repo ~now =
     let elapsed = Int64.sub now repo.updated_at in
     Int64.to_int elapsed >= repo.sync_interval
 
+let next_due_at repos =
+  List.fold_left
+    (fun earliest (repo : repository) ->
+      if not repo.auto_sync then earliest
+      else
+        let due_at =
+          Int64.add repo.updated_at (Int64.of_int repo.sync_interval)
+        in
+        match earliest with
+        | None -> Some due_at
+        | Some current -> Some (Int64.min current due_at))
+    None repos
+
 let sync_all ~base_path ~now :
-    ((repository * advance_outcome) list, string) result =
+    (sync_attempt list, string) result =
   let* repos = Repo_store.load_all ~base_path in
   let due = List.filter (fun r -> should_sync r ~now) repos in
-  let rec loop synced = function
-    | [] -> Ok (List.rev synced)
-    | repo :: rest -> (
-        match sync_repository ~base_path repo with
-        | Error _ -> loop synced rest
-        | Ok outcome -> loop ((repo, outcome) :: synced) rest)
+  let rec loop attempts = function
+    | [] -> Ok (List.rev attempts)
+    | repository :: rest ->
+        let result = sync_repository ~base_path repository in
+        loop ({ repository; result } :: attempts) rest
   in
   loop [] due

--- a/lib/repo_manager/repo_sync.mli
+++ b/lib/repo_manager/repo_sync.mli
@@ -19,6 +19,14 @@ type advance_outcome =
       (** A read-only git inspection (rev-list / rev-parse / status) failed;
           the tree is unchanged. *)
 
+type sync_attempt = {
+  repository : repository;
+  result : (advance_outcome, string) result;
+}
+(** The explicit result of attempting one due repository. Failures remain in
+    the returned list so callers can observe them without stopping later
+    repositories. *)
+
 val advance_outcome_label : advance_outcome -> string
 (** Stable wire/log label for each [advance_outcome] constructor. *)
 
@@ -35,10 +43,15 @@ val should_sync : repository -> now:int64 -> bool
 (** [should_sync repo ~now] returns [true] if [repo.auto_sync] is enabled and
     [now - repo.updated_at] exceeds [repo.sync_interval] seconds. *)
 
+val next_due_at : repository list -> int64 option
+(** [next_due_at repos] returns the earliest declared auto-sync due time.
+    Repositories with [auto_sync = false] do not participate. *)
+
 val sync_all :
   base_path:string ->
   now:int64 ->
-  ((repository * advance_outcome) list, string) result
+  (sync_attempt list, string) result
 (** [sync_all ~base_path ~now] loads all repositories, filters those that
-    should_sync, syncs each one, and returns the successfully synced
-    repositories paired with their working-tree advance outcome. *)
+    should sync, and attempts each one. A repository failure is returned as a
+    [sync_attempt] and does not stop later due repositories. Only loading the
+    repository store can fail the whole operation. *)

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -641,53 +641,75 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
     ~sw
     ~on_error:(log_server_fiber_crash "repo_sync")
     (fun () ->
-    let repo_sync_interval_sec =
-      Env_config_runtime.InternalTimers.repo_sync_interval_sec
-    in
-    let sync_once () =
-      try
-        let now = Int64.of_float (Eio.Time.now clock) in
-        match Repo_sync.sync_all ~base_path:(Mcp_server.workspace_config state).base_path ~now with
-        | Ok synced ->
-          List.iter
-            (fun ((repo : Repo_manager_types.repository), outcome) ->
-              match outcome with
-              | Repo_sync.Already_current -> ()
-              | Repo_sync.Advanced { behind } ->
-                Log.Server.info
-                  "repo_sync: %s advanced %d commit(s) to origin/%s"
-                  repo.id behind repo.default_branch
-              | Repo_sync.Skipped_dirty { staged; unstaged; conflicted } ->
-                Log.Server.warn
-                  "repo_sync: %s not advanced (dirty tree: staged=%d unstaged=%d conflicted=%d)"
-                  repo.id staged unstaged conflicted
-              | Repo_sync.Skipped_not_on_default_branch { current } ->
-                Log.Server.warn
-                  "repo_sync: %s not advanced (checked out %s, default %s)"
-                  repo.id current repo.default_branch
-              | Repo_sync.Fast_forward_refused { behind; reason } ->
-                Log.Server.warn
-                  "repo_sync: %s is %d commit(s) behind but fast-forward was refused: %s"
-                  repo.id behind reason
-              | Repo_sync.Advance_inspect_failed { reason } ->
-                Log.Server.warn
-                  "repo_sync: %s advance inspection failed: %s" repo.id reason)
-            synced;
-          if synced <> []
-          then Log.Server.info "repo_sync: synced %d repositories" (List.length synced)
-        | Error msg -> Log.Server.warn "repo_sync: sync_all failed: %s" msg
-      with
-      | Eio.Cancel.Cancelled _ as e -> raise e
-      | exn -> Log.Server.error "repo_sync: iteration failed: %s" (Printexc.to_string exn)
+    let log_attempt (attempt : Repo_sync.sync_attempt) =
+      let repo = attempt.repository in
+      match attempt.result with
+      | Error reason ->
+        Log.Server.warn "repo_sync: %s failed: %s" repo.id reason
+      | Ok Repo_sync.Already_current -> ()
+      | Ok (Repo_sync.Advanced { behind }) ->
+        Log.Server.info
+          "repo_sync: %s advanced %d commit(s) to origin/%s"
+          repo.id behind repo.default_branch
+      | Ok (Repo_sync.Skipped_dirty { staged; unstaged; conflicted }) ->
+        Log.Server.warn
+          "repo_sync: %s not advanced (dirty tree: staged=%d unstaged=%d conflicted=%d)"
+          repo.id staged unstaged conflicted
+      | Ok (Repo_sync.Skipped_not_on_default_branch { current }) ->
+        Log.Server.warn
+          "repo_sync: %s not advanced (checked out %s, default %s)"
+          repo.id current repo.default_branch
+      | Ok (Repo_sync.Fast_forward_refused { behind; reason }) ->
+        Log.Server.warn
+          "repo_sync: %s is %d commit(s) behind but fast-forward was refused: %s"
+          repo.id behind reason
+      | Ok (Repo_sync.Advance_inspect_failed { reason }) ->
+        Log.Server.warn
+          "repo_sync: %s advance inspection failed: %s" repo.id reason
     in
     let rec sync_loop () =
-      (try Eio.Time.sleep clock repo_sync_interval_sec with
-       | Eio.Cancel.Cancelled _ as e -> raise e
-       | exn -> Log.Server.error "repo_sync: sleep failed: %s" (Printexc.to_string exn));
-      sync_once ();
+      let revision = Mcp_server.repo_sync_revision state in
+      let base_path = (Mcp_server.workspace_config state).base_path in
+      let now = Int64.of_float (Eio.Time.now clock) in
+      let next_due_at =
+        match Repo_sync.sync_all ~base_path ~now with
+        | Error reason ->
+          Log.Server.warn "repo_sync: repository store load failed: %s" reason;
+          None
+        | Ok attempts ->
+          List.iter log_attempt attempts;
+          if attempts <> []
+          then (
+            let succeeded =
+              List.fold_left
+                (fun count (attempt : Repo_sync.sync_attempt) ->
+                  match attempt.result with
+                  | Ok _ -> count + 1
+                  | Error _ -> count)
+                0 attempts
+            in
+            Log.Server.info
+              "repo_sync: attempted=%d succeeded=%d failed=%d"
+              (List.length attempts)
+              succeeded
+              (List.length attempts - succeeded));
+          (match Repo_store.load_all ~base_path with
+           | Ok repositories -> Repo_sync.next_due_at repositories
+           | Error reason ->
+             Log.Server.warn
+               "repo_sync: next due schedule unavailable: %s"
+               reason;
+             None)
+      in
+      (match next_due_at with
+       | None -> Mcp_server.await_repo_sync_change state ~after:revision
+       | Some due_at ->
+         Eio.Fiber.first
+           (fun () -> Eio.Time.sleep_until clock (Int64.to_float due_at))
+           (fun () ->
+             Mcp_server.await_repo_sync_change state ~after:revision));
       sync_loop ()
     in
-    sync_once ();
     sync_loop ());
   (* RFC-0138 Phase 3 Step 1: lock-free dashboard snapshot refresher.
      Publishes shell/tools/telemetry_summary every [interval_sec] so

--- a/lib/server/server_routes_http_routes_repositories.ml
+++ b/lib/server/server_routes_http_routes_repositories.ml
@@ -324,6 +324,7 @@ let handle_add_repository state _agent_name req reqd =
           | Error msg ->
               json_response ~status:`Bad_request req reqd (json_error msg)
           | Ok added_repo ->
+              Mcp_server.notify_repo_sync_change state;
               let json = repository_json ~base_path added_repo in
               Http.Response.json_value ~request:req json reqd))
 
@@ -341,6 +342,7 @@ let handle_remove_repository state _agent_name req reqd =
       | Error msg ->
           json_response ~status:`Not_found req reqd (json_error msg)
       | Ok () ->
+          Mcp_server.notify_repo_sync_change state;
           let json = `Assoc [("id", `String id); ("removed", `Bool true)] in
           Http.Response.json_value ~request:req json reqd)
       | _ ->
@@ -374,6 +376,7 @@ let handle_update_repository state _agent_name req reqd =
                           json_response ~status:`Internal_server_error req reqd
                             (json_error msg)
                       | Ok persisted ->
+                          Mcp_server.notify_repo_sync_change state;
                           Http.Response.json_value ~request:req
                             (repository_json ~base_path persisted) reqd))))
       | _ ->
@@ -392,7 +395,9 @@ let handle_sync_repository state _agent_name req reqd =
       | Error msg ->
           json_response ~status:`Not_found req reqd (json_error msg)
       | Ok repo -> (
-          match Repo_sync.sync_repository ~base_path repo with
+          let sync_result = Repo_sync.sync_repository ~base_path repo in
+          Mcp_server.notify_repo_sync_change state;
+          match sync_result with
           | Error msg ->
               json_response ~status:`Internal_server_error req reqd
                 (json_error msg)
@@ -445,6 +450,7 @@ let handle_discover_repositories state _agent_name req reqd =
   | Error msg ->
       json_response ~status:`Internal_server_error req reqd (json_error msg)
   | Ok repos ->
+      if repos <> [] then Mcp_server.notify_repo_sync_change state;
       let json =
         `Assoc
           [

--- a/test/test_repo_sync.ml
+++ b/test/test_repo_sync.ml
@@ -2,6 +2,8 @@
 
 open Repo_manager_types
 
+module Mcp_server = Masc.Mcp_server
+
 let sample_repo ?(auto_sync = true) ?(sync_interval = 300) ?(updated_at = Int64.of_int 1700000000) id =
   {
     id;
@@ -52,6 +54,42 @@ let test_should_sync_negative_elapsed () =
   let repo = sample_repo ~auto_sync:true ~sync_interval:300 ~updated_at:(Int64.of_int 1700000100) "r1" in
   let now = Int64.of_int 1700000000 in
   Alcotest.(check bool) "now < updated_at means elapsed < 0" false (Repo_sync.should_sync repo ~now)
+
+let test_next_due_at_uses_each_repository_cadence () =
+  let short =
+    sample_repo ~sync_interval:60 ~updated_at:(Int64.of_int 100) "short"
+  in
+  let long =
+    sample_repo ~sync_interval:300 ~updated_at:(Int64.of_int 100) "long"
+  in
+  let disabled =
+    sample_repo
+      ~auto_sync:false
+      ~sync_interval:1
+      ~updated_at:Int64.zero
+      "disabled"
+  in
+  Alcotest.(check (option int64))
+    "earliest declared cadence"
+    (Some (Int64.of_int 160))
+    (Repo_sync.next_due_at [ long; disabled; short ])
+
+let test_repo_sync_change_notification_wakes_waiter () =
+  Eio_main.run (fun _env ->
+    let state = Mcp_server.For_testing.create_state ~base_path:"." in
+    let revision = Mcp_server.repo_sync_revision state in
+    let awakened = Atomic.make false in
+    Eio.Fiber.both
+      (fun () ->
+        Mcp_server.await_repo_sync_change state ~after:revision;
+        Atomic.set awakened true)
+      (fun () ->
+        Eio.Fiber.yield ();
+        Mcp_server.notify_repo_sync_change state);
+    Alcotest.(check bool)
+      "committed change wakes scheduler"
+      true
+      (Atomic.get awakened))
 
 let with_temp_base_path f =
   let dir = Filename.temp_file "repo_sync_test" "" in
@@ -180,6 +218,58 @@ let with_advance_fixture base_path f =
    | Error e -> Alcotest.fail ("save_all failed: " ^ e));
   f ~origin ~clone repo
 
+let test_sync_all_preserves_failure_and_continues () =
+  with_temp_base_path (fun base_path ->
+    let bad_path = Filename.concat base_path "not-a-repository" in
+    Unix.mkdir bad_path 0o755;
+    let origin = Filename.concat base_path "origin-for-sync-all" in
+    let clone = Filename.concat base_path "clone-for-sync-all" in
+    init_origin origin;
+    git ~cwd:base_path [ "clone"; origin; clone ];
+    let bad =
+      { (sample_repo ~sync_interval:0 "bad") with
+        url = bad_path
+      ; local_path = bad_path
+      }
+    in
+    let good =
+      { (sample_repo ~sync_interval:0 "good") with
+        url = origin
+      ; local_path = clone
+      }
+    in
+    (match Repo_store.save_all ~base_path [ bad; good ] with
+     | Ok () -> ()
+     | Error reason -> Alcotest.fail ("save_all failed: " ^ reason));
+    match Repo_sync.sync_all ~base_path ~now:(Int64.of_int 1700004000) with
+    | Error reason -> Alcotest.fail ("sync_all failed: " ^ reason)
+    | Ok attempts ->
+      Alcotest.(check int) "both due repositories attempted" 2 (List.length attempts);
+      let find id =
+        List.find_opt
+          (fun (attempt : Repo_sync.sync_attempt) ->
+            String.equal attempt.repository.id id)
+          attempts
+      in
+      (match find "bad" with
+       | Some { result = Error reason; _ } ->
+         Alcotest.(check bool)
+           "failure reason remains observable"
+           true
+           (String.trim reason <> "")
+       | Some { result = Ok _; _ } ->
+         Alcotest.fail "non-repository unexpectedly synced"
+       | None -> Alcotest.fail "failed repository attempt was dropped");
+      (match find "good" with
+       | Some { result = Ok Repo_sync.Already_current; _ } -> ()
+       | Some { result = Ok outcome; _ } ->
+         Alcotest.failf
+           "good repository returned %s"
+           (Repo_sync.advance_outcome_label outcome)
+       | Some { result = Error reason; _ } ->
+         Alcotest.fail ("later repository was stopped: " ^ reason)
+       | None -> Alcotest.fail "later repository was not attempted"))
+
 let check_outcome expected actual =
   Alcotest.(check string)
     "advance outcome"
@@ -283,11 +373,15 @@ let () =
           Alcotest.test_case "zero interval" `Quick test_should_sync_zero_interval;
           Alcotest.test_case "large elapsed" `Quick test_should_sync_large_elapsed;
           Alcotest.test_case "negative elapsed" `Quick test_should_sync_negative_elapsed;
+          Alcotest.test_case "earliest repository cadence" `Quick
+            test_next_due_at_uses_each_repository_cadence;
         ] );
       ( "sync_all",
         [
           Alcotest.test_case "empty repos" `Quick test_sync_all_empty_repos;
           Alcotest.test_case "no due repos" `Quick test_sync_all_no_due_repos;
+          Alcotest.test_case "failure is observable and isolated" `Quick
+            test_sync_all_preserves_failure_and_continues;
         ] );
       ( "advance_working_tree",
         [
@@ -298,5 +392,10 @@ let () =
           Alcotest.test_case "preserves dirty tree" `Quick test_sync_preserves_dirty_tree;
           Alcotest.test_case "refuses diverged clone" `Quick test_sync_refuses_diverged_clone;
           Alcotest.test_case "skips non-default branch" `Quick test_sync_skips_non_default_branch;
+        ] );
+      ( "change_notification",
+        [
+          Alcotest.test_case "configuration change wakes scheduler" `Quick
+            test_repo_sync_change_notification_wakes_waiter;
         ] );
     ]


### PR DESCRIPTION
## What changed

- removed the global `MASC_REPO_SYNC_INTERVAL_SEC` execution cadence and its implicit 300-second fallback
- derive the next wake time from the earliest `updated_at + sync_interval` among repositories with `auto_sync = true`
- wake the scheduler immediately after committed repository or workspace configuration changes
- return and log every due repository attempt, including failures, while continuing with later repositories
- regenerated the runtime-tunable catalog

## Why

The previous bootstrap fiber slept on one global interval before consulting repository state. A repository declaring a shorter cadence could therefore never run on that cadence, and `Repo_sync.sync_all` silently removed individual failures from its result.

The repository record is now the scheduling SSOT. The background fiber waits only for the next declared repository due time or an explicit configuration revision change; it does not replace the removed 300-second gate with another polling heuristic.

## Impact

- repositories keep independent declared cadences
- a failed repository remains explicitly observable and does not prevent later due repositories from being attempted
- no repository schedule means the fiber waits for a real configuration change instead of polling
- Keeper and sibling server fibers remain independent under the existing isolated maintenance fiber

## Validation

- `scripts/dune-local.sh build test/test_repo_sync.exe`
- `./_build/default/test/test_repo_sync.exe` — 18/18 passed
- `ocamlformat --check` on all changed OCaml files
- `git diff --check`
- generated `docs/runtime-tunables.md` from the catalog executable
- final diff: 10 files, +275/-72 (347 changed lines)

Full build and suite remain CI authority.

## Follow-up

- #24855 removes the remaining legacy per-repository implicit 300-second cadence so `auto_sync = true` requires an explicit typed cadence.
