### PR TITLE
feat(keeper): project exact current operations

### DIFF
--- a/lib/keeper/keeper_current_operations.ml
+++ b/lib/keeper/keeper_current_operations.ml
@@ -25,6 +25,19 @@ type source_name =
 type read_error =
   | Durable_read_failed of string
   | Access_rejected of Keeper_msg_async.access_rejection
+  | Async_keeper_mismatch of
+      { request_id : string
+      ; expected_keeper : string
+      ; actual_keeper : string
+      }
+  | Async_terminal_entry of
+      { request_id : string
+      ; status : Keeper_msg_async.request_status
+      }
+  | Async_active_entry_has_completion_time of
+      { request_id : string
+      ; completed_at : float
+      }
 
 type unavailable =
   { source : source_name

--- a/lib/keeper/keeper_current_operations.ml
+++ b/lib/keeper/keeper_current_operations.ml
@@ -111,7 +111,7 @@ let status_to_yojson = function
   | Done { ok; body; data } ->
     `Assoc [ "kind", `String "done"; "terminal", `Bool true; "ok", `Bool ok
            ; "body", `String body
-           ; "data", Option.value ~default:`Null data ]
+           ; "data", (match data with None -> `Null | Some value -> value) ]
 ;;
 
 let async_entry_to_yojson (entry : Keeper_msg_async.entry) =

--- a/lib/keeper/keeper_current_operations.ml
+++ b/lib/keeper/keeper_current_operations.ml
@@ -1,0 +1,194 @@
+type source =
+  | Event_queue_pending of
+      { revision : int64
+      ; stimulus : Keeper_event_queue.stimulus
+      }
+  | Event_queue_lease of
+      { revision : int64
+      ; lease : Keeper_event_queue_state.lease
+      }
+  | Event_queue_outbox of
+      { revision : int64
+      ; entry : Keeper_event_queue_state.outbox_entry
+      }
+  | Async_request of Keeper_msg_async.entry
+
+type t =
+  { keeper_name : string
+  ; source : source
+  }
+
+type source_name =
+  | Event_queue_source
+  | Async_request_source
+
+type read_error =
+  | Durable_read_failed of string
+  | Access_rejected of Keeper_msg_async.access_rejection
+
+type unavailable =
+  { source : source_name
+  ; keeper_name : string
+  ; error : read_error
+  }
+
+type 'a availability =
+  | Available of 'a
+  | Unavailable of unavailable
+
+type snapshot =
+  { keeper_name : string
+  ; event_queue : t list availability
+  ; async_requests : t list availability
+  }
+
+let project_event_queue_state ~keeper_name state =
+  let revision = Keeper_event_queue_state.revision state in
+  let pending =
+    Keeper_event_queue_state.pending state
+    |> Keeper_event_queue.to_list
+    |> List.map (fun stimulus ->
+      { keeper_name
+      ; source = Event_queue_pending { revision; stimulus }
+      })
+  in
+  let leases =
+    Keeper_event_queue_state.leases state
+    |> List.map (fun (lease : Keeper_event_queue_state.lease) ->
+      { keeper_name
+      ; source = Event_queue_lease { revision; lease }
+      })
+  in
+  let outbox =
+    Keeper_event_queue_state.transition_outbox state
+    |> List.map (fun (entry : Keeper_event_queue_state.outbox_entry) ->
+      { keeper_name
+      ; source = Event_queue_outbox { revision; entry }
+      })
+  in
+  leases @ pending @ outbox
+;;
+
+let project_async_entries entries =
+  List.map
+    (fun (entry : Keeper_msg_async.entry) ->
+       { keeper_name = entry.keeper_name
+       ; source = Async_request entry
+       })
+    entries
+;;
+
+let availability ~source ~keeper_name project = function
+  | Ok value -> Available (project value)
+  | Error error -> Unavailable { source; keeper_name; error }
+;;
+
+let project_snapshot ~keeper_name ~event_queue ~async_requests =
+  { keeper_name
+  ; event_queue =
+      availability ~source:Event_queue_source ~keeper_name
+        (project_event_queue_state ~keeper_name) event_queue
+  ; async_requests =
+      availability ~source:Async_request_source ~keeper_name
+        project_async_entries async_requests
+  }
+;;
+
+let status_to_yojson = function
+  | Keeper_msg_async.Queued -> `Assoc [ "kind", `String "queued"; "terminal", `Bool false ]
+  | Running -> `Assoc [ "kind", `String "running"; "terminal", `Bool false ]
+  | Cancelling { reason; cancelled_by } ->
+    `Assoc [ "kind", `String "cancelling"; "terminal", `Bool false
+           ; "reason", `String reason; "cancelled_by", `String cancelled_by ]
+  | Lost { reason } ->
+    `Assoc [ "kind", `String "lost"; "terminal", `Bool true; "reason", `String reason ]
+  | Cancelled { reason; cancelled_by } ->
+    `Assoc [ "kind", `String "cancelled"; "terminal", `Bool true
+           ; "reason", `String reason; "cancelled_by", `String cancelled_by ]
+  | Persistence_failed { attempted_status; reason } ->
+    `Assoc [ "kind", `String "persistence_failed"; "terminal", `Bool true
+           ; "attempted_status", `String attempted_status; "reason", `String reason ]
+  | Done { ok; body; data } ->
+    `Assoc [ "kind", `String "done"; "terminal", `Bool true; "ok", `Bool ok
+           ; "body", `String body
+           ; "data", Option.value ~default:`Null data ]
+;;
+
+let async_entry_to_yojson (entry : Keeper_msg_async.entry) =
+  `Assoc
+    [ "request_id", `String entry.request_id
+    ; "keeper_name", `String entry.keeper_name
+    ; "base_path", `String entry.base_path
+    ; "submitted_by", `String entry.submitted_by
+    ; "submitted_at", `Float entry.submitted_at
+    ; "completed_at", Option.fold ~none:`Null ~some:(fun value -> `Float value) entry.completed_at
+    ; "status", status_to_yojson entry.status
+    ]
+;;
+
+let outbox_to_yojson (entry : Keeper_event_queue_state.outbox_entry) =
+  `Assoc
+    [ "receipt", Keeper_event_queue_state.transition_receipt_to_yojson entry.receipt
+    ; "stimuli", `List (List.map Keeper_event_queue.stimulus_to_yojson entry.stimuli)
+    ]
+;;
+
+let source_to_yojson = function
+  | Event_queue_pending { revision; stimulus } ->
+    `Assoc [ "kind", `String "event_queue_pending"
+           ; "revision", `String (Int64.to_string revision)
+           ; "value", Keeper_event_queue.stimulus_to_yojson stimulus ]
+  | Event_queue_lease { revision; lease } ->
+    `Assoc [ "kind", `String "event_queue_lease"
+           ; "revision", `String (Int64.to_string revision)
+           ; "value", Keeper_event_queue_state.lease_to_yojson lease ]
+  | Event_queue_outbox { revision; entry } ->
+    `Assoc [ "kind", `String "event_queue_outbox"
+           ; "revision", `String (Int64.to_string revision)
+           ; "value", outbox_to_yojson entry ]
+  | Async_request entry ->
+    `Assoc [ "kind", `String "async_request"; "value", async_entry_to_yojson entry ]
+;;
+
+let to_yojson (operation : t) =
+  `Assoc
+    [ "keeper_name", `String operation.keeper_name
+    ; "source", source_to_yojson operation.source
+    ]
+;;
+
+let unavailable_to_yojson unavailable =
+  let source =
+    match unavailable.source with
+    | Event_queue_source -> "event_queue"
+    | Async_request_source -> "async_requests"
+  in
+  let error =
+    match unavailable.error with
+    | Durable_read_failed detail ->
+      `Assoc [ "kind", `String "durable_read_failed"; "detail", `String detail ]
+    | Access_rejected rejection ->
+      `Assoc [ "kind", `String "access_rejected"
+             ; "detail", Keeper_msg_async.access_rejection_to_json rejection ]
+  in
+  `Assoc [ "source", `String source; "keeper_name", `String unavailable.keeper_name
+         ; "error", error ]
+;;
+
+let availability_to_yojson = function
+  | Available operations ->
+    `Assoc [ "available", `Bool true; "operations", `List (List.map to_yojson operations) ]
+  | Unavailable error ->
+    `Assoc [ "available", `Bool false; "unavailable", unavailable_to_yojson error ]
+;;
+
+let snapshot_to_yojson snapshot =
+  `Assoc
+    [ "schema", `String "keeper.current_operations.v1"
+    ; "keeper_name", `String snapshot.keeper_name
+    ; "event_queue", availability_to_yojson snapshot.event_queue
+    ; "async_requests", availability_to_yojson snapshot.async_requests
+    ]
+;;
+
+let render operation = to_yojson operation |> Yojson.Safe.to_string

--- a/lib/keeper/keeper_current_operations.ml
+++ b/lib/keeper/keeper_current_operations.ml
@@ -69,17 +69,40 @@ let project_event_queue_state ~keeper_name state =
   leases @ pending @ outbox
 ;;
 
-let project_async_entries entries =
-  List.map
-    (fun (entry : Keeper_msg_async.entry) ->
-       { keeper_name = entry.keeper_name
-       ; source = Async_request entry
-       })
-    entries
+let project_async_entries ~keeper_name entries =
+  let rec loop projected_rev = function
+    | [] -> Ok (List.rev projected_rev)
+    | (entry : Keeper_msg_async.entry) :: rest ->
+      if not (String.equal entry.keeper_name keeper_name)
+      then
+        Error
+          (Async_keeper_mismatch
+             { request_id = entry.request_id
+             ; expected_keeper = keeper_name
+             ; actual_keeper = entry.keeper_name
+             })
+      else
+        (match entry.status with
+         | Lost _ | Cancelled _ | Persistence_failed _ | Done _ ->
+           Error
+             (Async_terminal_entry
+                { request_id = entry.request_id; status = entry.status })
+         | Queued | Running | Cancelling _ ->
+           (match entry.completed_at with
+            | Some completed_at ->
+              Error
+                (Async_active_entry_has_completion_time
+                   { request_id = entry.request_id; completed_at })
+            | None ->
+              loop
+                ({ keeper_name; source = Async_request entry } :: projected_rev)
+                rest))
+  in
+  loop [] entries
 ;;
 
-let availability ~source ~keeper_name project = function
-  | Ok value -> Available (project value)
+let availability ~source ~keeper_name = function
+  | Ok value -> Available value
   | Error error -> Unavailable { source; keeper_name; error }
 ;;
 
@@ -87,10 +110,10 @@ let project_snapshot ~keeper_name ~event_queue ~async_requests =
   { keeper_name
   ; event_queue =
       availability ~source:Event_queue_source ~keeper_name
-        (project_event_queue_state ~keeper_name) event_queue
+        (Result.map (project_event_queue_state ~keeper_name) event_queue)
   ; async_requests =
       availability ~source:Async_request_source ~keeper_name
-        project_async_entries async_requests
+        (Result.bind async_requests (project_async_entries ~keeper_name))
   }
 ;;
 
@@ -170,6 +193,25 @@ let unavailable_to_yojson unavailable =
     | Access_rejected rejection ->
       `Assoc [ "kind", `String "access_rejected"
              ; "detail", Keeper_msg_async.access_rejection_to_json rejection ]
+    | Async_keeper_mismatch { request_id; expected_keeper; actual_keeper } ->
+      `Assoc
+        [ "kind", `String "async_keeper_mismatch"
+        ; "request_id", `String request_id
+        ; "expected_keeper", `String expected_keeper
+        ; "actual_keeper", `String actual_keeper
+        ]
+    | Async_terminal_entry { request_id; status } ->
+      `Assoc
+        [ "kind", `String "async_terminal_entry"
+        ; "request_id", `String request_id
+        ; "status", status_to_yojson status
+        ]
+    | Async_active_entry_has_completion_time { request_id; completed_at } ->
+      `Assoc
+        [ "kind", `String "async_active_entry_has_completion_time"
+        ; "request_id", `String request_id
+        ; "completed_at", `Float completed_at
+        ]
   in
   `Assoc [ "source", `String source; "keeper_name", `String unavailable.keeper_name
          ; "error", error ]

--- a/lib/keeper/keeper_current_operations.mli
+++ b/lib/keeper/keeper_current_operations.mli
@@ -1,6 +1,6 @@
 (** Immutable Keeper work projection with no inferred progress, ETA, or store. *)
 
-type source =
+type source = private
   | Event_queue_pending of
       { revision : int64
       ; stimulus : Keeper_event_queue.stimulus
@@ -27,6 +27,19 @@ type source_name =
 type read_error =
   | Durable_read_failed of string
   | Access_rejected of Keeper_msg_async.access_rejection
+  | Async_keeper_mismatch of
+      { request_id : string
+      ; expected_keeper : string
+      ; actual_keeper : string
+      }
+  | Async_terminal_entry of
+      { request_id : string
+      ; status : Keeper_msg_async.request_status
+      }
+  | Async_active_entry_has_completion_time of
+      { request_id : string
+      ; completed_at : float
+      }
 
 type unavailable =
   { source : source_name
@@ -47,7 +60,8 @@ type snapshot =
 val project_event_queue_state :
   keeper_name:string -> Keeper_event_queue_state.t -> t list
 
-val project_async_entries : Keeper_msg_async.entry list -> t list
+val project_async_entries :
+  keeper_name:string -> Keeper_msg_async.entry list -> (t list, read_error) result
 
 val project_snapshot :
   keeper_name:string ->

--- a/lib/keeper/keeper_current_operations.mli
+++ b/lib/keeper/keeper_current_operations.mli
@@ -1,0 +1,62 @@
+(** Immutable Keeper work projection with no inferred progress, ETA, or store. *)
+
+type source =
+  | Event_queue_pending of
+      { revision : int64
+      ; stimulus : Keeper_event_queue.stimulus
+      }
+  | Event_queue_lease of
+      { revision : int64
+      ; lease : Keeper_event_queue_state.lease
+      }
+  | Event_queue_outbox of
+      { revision : int64
+      ; entry : Keeper_event_queue_state.outbox_entry
+      }
+  | Async_request of Keeper_msg_async.entry
+
+type t =
+  { keeper_name : string
+  ; source : source
+  }
+
+type source_name =
+  | Event_queue_source
+  | Async_request_source
+
+type read_error =
+  | Durable_read_failed of string
+  | Access_rejected of Keeper_msg_async.access_rejection
+
+type unavailable =
+  { source : source_name
+  ; keeper_name : string
+  ; error : read_error
+  }
+
+type 'a availability =
+  | Available of 'a
+  | Unavailable of unavailable
+
+type snapshot =
+  { keeper_name : string
+  ; event_queue : t list availability
+  ; async_requests : t list availability
+  }
+
+val project_event_queue_state :
+  keeper_name:string -> Keeper_event_queue_state.t -> t list
+
+val project_async_entries : Keeper_msg_async.entry list -> t list
+
+val project_snapshot :
+  keeper_name:string ->
+  event_queue:(Keeper_event_queue_state.t, read_error) result ->
+  async_requests:(Keeper_msg_async.entry list, read_error) result ->
+  snapshot
+(** Pure adapter seam. Callers must supply reads from canonical durable
+    sources; a process-local cache is not a substitute. *)
+
+val to_yojson : t -> Yojson.Safe.t
+val snapshot_to_yojson : snapshot -> Yojson.Safe.t
+val render : t -> string

--- a/test/dune
+++ b/test/dune
@@ -676,6 +676,11 @@
  (libraries alcotest masc_test_deps))
 
 (test
+ (name test_keeper_current_operations)
+ (modules test_keeper_current_operations)
+ (libraries alcotest masc_test_deps))
+
+(test
  (name test_keeper_failure_judgment_contract)
  (modules test_keeper_failure_judgment_contract)
  (libraries alcotest masc_test_deps))

--- a/test/test_keeper_current_operations.ml
+++ b/test/test_keeper_current_operations.ml
@@ -6,6 +6,7 @@ module A = Masc.Keeper_msg_async
 module J = Yojson.Safe.Util
 
 let ok = function Ok value -> value | Error error -> fail error
+let ok_projection = function Ok value -> value | Error _ -> fail "projection failed"
 let stimulus id at = { Q.post_id = id; urgency = Normal; arrived_at = at; payload = Bootstrap }
 let queue xs = List.fold_left Q.enqueue Q.empty xs
 
@@ -31,20 +32,24 @@ let test_event_queue_exact_state () =
   | operations -> failf "unexpected outbox operation count=%d" (List.length operations)
 ;;
 
-let test_async_terminal_and_unavailable () =
+let test_async_active_and_unavailable () =
   let entry : A.entry =
     { request_id = "request-1"; keeper_name = "keeper-a"; base_path = "/workspace"
     ; submitted_by = "caller-a"
-    ; status = Done { ok = false; body = "failed"; data = Some (`Assoc [ "artifact_ref", `String "artifact-1" ]) }
-    ; submitted_at = 5.0; completed_at = Some 6.0 }
+    ; status = Running
+    ; submitted_at = 5.0; completed_at = None }
   in
-  let operation = List.hd (O.project_async_entries [ entry ]) in
+  let operation =
+    O.project_async_entries ~keeper_name:"keeper-a" [ entry ]
+    |> ok_projection
+    |> List.hd
+  in
   let json = O.to_yojson operation in
   check string "request id" "request-1"
     J.(json |> member "source" |> member "value" |> member "request_id" |> to_string);
-  check bool "terminal" true J.(json |> member "source" |> member "value" |> member "status" |> member "terminal" |> to_bool);
-  check string "artifact payload" "artifact-1"
-    J.(json |> member "source" |> member "value" |> member "status" |> member "data" |> member "artifact_ref" |> to_string);
+  check bool "terminal" false
+    J.(json |> member "source" |> member "value" |> member "status"
+       |> member "terminal" |> to_bool);
   let snapshot =
     O.project_snapshot ~keeper_name:"keeper-a"
       ~event_queue:(Error (O.Durable_read_failed "corrupt state"))
@@ -56,13 +61,49 @@ let test_async_terminal_and_unavailable () =
    | _ -> fail "source failures were not preserved as typed Unavailable");
   let snapshot_json = O.snapshot_to_yojson snapshot in
   check bool "event unavailable" false J.(snapshot_json |> member "event_queue" |> member "available" |> to_bool);
-  check bool "async unavailable" false J.(snapshot_json |> member "async_requests" |> member "available" |> to_bool)
+  check bool "async unavailable" false J.(snapshot_json |> member "async_requests" |> member "available" |> to_bool);
+  let wrong_keeper = { entry with keeper_name = "keeper-b" } in
+  let mixed_snapshot =
+    O.project_snapshot ~keeper_name:"keeper-a"
+      ~event_queue:(Ok S.empty)
+      ~async_requests:(Ok [ wrong_keeper ])
+  in
+  match mixed_snapshot.async_requests with
+  | Unavailable
+      { error =
+          Async_keeper_mismatch
+            { request_id = "request-1"
+            ; expected_keeper = "keeper-a"
+            ; actual_keeper = "keeper-b"
+            }
+      ; _
+      } ->
+    ()
+  | _ -> fail "cross-keeper async entry was not rejected"
+;;
+
+let test_terminal_async_entry_is_not_current () =
+  let terminal : A.entry =
+    { request_id = "request-terminal"
+    ; keeper_name = "keeper-a"
+    ; base_path = "/workspace"
+    ; submitted_by = "caller-a"
+    ; status = Done { ok = true; body = "done"; data = None }
+    ; submitted_at = 5.0
+    ; completed_at = Some 6.0
+    }
+  in
+  match O.project_async_entries ~keeper_name:"keeper-a" [ terminal ] with
+  | Error (O.Async_terminal_entry { request_id = "request-terminal"; _ }) -> ()
+  | _ -> fail "terminal async entry was projected as a current operation"
 ;;
 
 let () =
   run "keeper_current_operations"
     [ "projection",
       [ test_case "event queue exact state" `Quick test_event_queue_exact_state
-      ; test_case "async terminal and unavailable" `Quick test_async_terminal_and_unavailable
+      ; test_case "async active and unavailable" `Quick test_async_active_and_unavailable
+      ; test_case "terminal async is not current" `Quick
+          test_terminal_async_entry_is_not_current
       ] ]
 ;;

--- a/test/test_keeper_current_operations.ml
+++ b/test/test_keeper_current_operations.ml
@@ -1,0 +1,68 @@
+open Alcotest
+module O = Masc.Keeper_current_operations
+module Q = Keeper_event_queue
+module S = Keeper_event_queue_state
+module A = Masc.Keeper_msg_async
+module J = Yojson.Safe.Util
+
+let ok = function Ok value -> value | Error error -> fail error
+let stimulus id at = { Q.post_id = id; urgency = Normal; arrived_at = at; payload = Bootstrap }
+let queue xs = List.fold_left Q.enqueue Q.empty xs
+
+let test_event_queue_exact_state () =
+  let first = stimulus "wake-1" 1.0 and second = stimulus "wake-2" 2.0 in
+  let state = S.empty |> S.with_pending (queue [ first; second ]) |> S.with_revision 17L in
+  let state, lease = S.claim_when ~claimed_at:3.0 ~ready:(fun _ -> true) state |> ok in
+  let lease = Option.get lease in
+  (match O.project_event_queue_state ~keeper_name:"keeper-a" state with
+   | [ { source = Event_queue_lease { revision; lease = projected }; _ }
+     ; { source = Event_queue_pending { stimulus = pending; _ }; _ } ] ->
+     check string "lease id" lease.lease_id projected.lease_id;
+     check int64 "revision" 17L revision;
+     check string "pending identity" second.post_id pending.post_id
+   | operations -> failf "unexpected operation count=%d" (List.length operations));
+  let state, _ = S.settle ~settled_at:4.0 ~lease ~settlement:S.Ack state |> ok in
+  match O.project_event_queue_state ~keeper_name:"keeper-a" state with
+  | [ { source = Event_queue_pending _; _ }
+    ; ({ source = Event_queue_outbox { entry; _ }; _ } as operation) ] ->
+    check string "transition" "lease:1:ack" entry.receipt.transition_id;
+    check string "render is exact JSON"
+      (O.to_yojson operation |> Yojson.Safe.to_string) (O.render operation)
+  | operations -> failf "unexpected outbox operation count=%d" (List.length operations)
+;;
+
+let test_async_terminal_and_unavailable () =
+  let entry : A.entry =
+    { request_id = "request-1"; keeper_name = "keeper-a"; base_path = "/workspace"
+    ; submitted_by = "caller-a"
+    ; status = Done { ok = false; body = "failed"; data = Some (`Assoc [ "artifact_ref", `String "artifact-1" ]) }
+    ; submitted_at = 5.0; completed_at = Some 6.0 }
+  in
+  let operation = List.hd (O.project_async_entries [ entry ]) in
+  let json = O.to_yojson operation in
+  check string "request id" "request-1"
+    J.(json |> member "source" |> member "value" |> member "request_id" |> to_string);
+  check bool "terminal" true J.(json |> member "source" |> member "value" |> member "status" |> member "terminal" |> to_bool);
+  check string "artifact payload" "artifact-1"
+    J.(json |> member "source" |> member "value" |> member "status" |> member "data" |> member "artifact_ref" |> to_string);
+  let snapshot =
+    O.project_snapshot ~keeper_name:"keeper-a"
+      ~event_queue:(Error (O.Durable_read_failed "corrupt state"))
+      ~async_requests:(Error (O.Access_rejected A.Caller_mismatch))
+  in
+  (match snapshot.event_queue, snapshot.async_requests with
+   | Unavailable { error = Durable_read_failed _; _ },
+     Unavailable { error = Access_rejected Caller_mismatch; _ } -> ()
+   | _ -> fail "source failures were not preserved as typed Unavailable");
+  let snapshot_json = O.snapshot_to_yojson snapshot in
+  check bool "event unavailable" false J.(snapshot_json |> member "event_queue" |> member "available" |> to_bool);
+  check bool "async unavailable" false J.(snapshot_json |> member "async_requests" |> member "available" |> to_bool)
+;;
+
+let () =
+  run "keeper_current_operations"
+    [ "projection",
+      [ test_case "event queue exact state" `Quick test_event_queue_exact_state
+      ; test_case "async terminal and unavailable" `Quick test_async_terminal_and_unavailable
+      ] ]
+;;


### PR DESCRIPTION
## Summary

- add immutable `Keeper_current_operations` closed source variants for event-queue pending/lease/outbox and typed active async entries
- preserve the event queue revision plus complete typed lease, settlement/outbox, request owner/target/status payloads
- surface each source independently as `Available | Unavailable`; a broken source never becomes silent `[]` and never hides the other source
- reject cross-Keeper async entries, terminal entries, and active entries carrying a completion timestamp as typed source errors
- serialize/render exact JSON only; no inferred progress, percentage, ETA, timeout, governance, or new operation store

## Boundary

- this is a pure projection/adapter foundation; production prompt/dashboard wiring is intentionally deferred
- the module does not use `Keeper_msg_async.list_for_keeper` as durable truth
- the missing canonical durable async inventory boundary remains tracked in #24858
- no filesystem scan, filename inference, terminal-history folding, Fusion registry, or Bg_task registry projection is included

## Stack

- base: #24862
- this is the stack top used for combined focused verification

## Focused verification

- `scripts/dune-local.sh build test/test_pbt_context_overflow.exe test/test_keeper_context_core_dedup.exe test/test_keeper_compaction_unit.exe test/test_keeper_current_operations.exe`
- `test_pbt_context_overflow.exe`: 13/13 passed
- `test_keeper_context_core_dedup.exe`: 13/13 passed
- `test_keeper_compaction_unit.exe`: 12/12 passed
- `test_keeper_current_operations.exe`: 3/3 passed
- `ocamlformat --check` and `git diff --check`

The first local build attempt exposed a missing implementation-side variant declaration; it was fixed and the complete stack-top build and 41 focused tests then passed.
