### PR TITLE
refactor(keeper): add structural compaction units

### DIFF
--- a/lib/keeper/keeper_compaction_unit.ml
+++ b/lib/keeper/keeper_compaction_unit.ml
@@ -1,7 +1,7 @@
 module T = Agent_sdk.Types
 module Id_set = Set.Make (String)
 
-type compactable_unit =
+type closed_unit =
   | Ordinary_message of T.message
   | Closed_tool_cycle of T.message list
 
@@ -40,7 +40,7 @@ type structural_error =
       }
 
 type partition =
-  { compactable_prefix : compactable_unit list
+  { closed_prefix : closed_unit list
   ; protected_suffix : T.message list
   }
 
@@ -97,7 +97,7 @@ let partition messages =
           | None -> []
           | Some cycle -> List.rev cycle.messages_rev
         in
-        Ok { compactable_prefix = List.rev units_rev; protected_suffix }
+        Ok { closed_prefix = List.rev units_rev; protected_suffix }
     | (message : T.message) :: rest ->
         let tool_ids, result_ids = top_level_anchors message.content in
         (match message.role, tool_ids with

--- a/lib/keeper/keeper_compaction_unit.ml
+++ b/lib/keeper/keeper_compaction_unit.ml
@@ -1,0 +1,164 @@
+module T = Agent_sdk.Types
+module Id_set = Set.Make (String)
+
+type compactable_unit =
+  | Ordinary_message of T.message
+  | Closed_tool_cycle of T.message list
+
+type structural_error =
+  | Orphan_tool_result of
+      { message_index : int
+      ; tool_use_id : string
+      }
+  | Duplicate_tool_result of
+      { message_index : int
+      ; tool_use_id : string
+      }
+  | Unknown_tool_result of
+      { message_index : int
+      ; tool_use_id : string
+      }
+  | Non_assistant_tool_use of
+      { message_index : int
+      ; tool_use_id : string
+      }
+  | Duplicate_tool_use_id of
+      { message_index : int
+      ; tool_use_id : string
+      }
+  | Overlapping_tool_cycle of
+      { message_index : int
+      ; tool_use_id : string
+      }
+  | Tool_request_contains_result of
+      { message_index : int
+      ; tool_use_id : string
+      }
+  | Non_result_tool_role of
+      { message_index : int
+      ; tool_use_id : string
+      }
+
+type partition =
+  { compactable_prefix : compactable_unit list
+  ; protected_suffix : T.message list
+  }
+
+type open_cycle =
+  { expected : Id_set.t
+  ; pending : Id_set.t
+  ; messages_rev : T.message list
+  }
+
+let top_level_anchors blocks =
+  List.fold_left
+    (fun (uses, results) -> function
+      | T.ToolUse { id; _ } -> id :: uses, results
+      | T.ToolResult { tool_use_id; _ } -> uses, tool_use_id :: results
+      | T.Text _
+      | T.Thinking _
+      | T.ReasoningDetails _
+      | T.RedactedThinking _
+      | T.Image _
+      | T.Document _
+      | T.Audio _ ->
+          uses, results)
+    ([], []) blocks
+  |> fun (uses, results) -> List.rev uses, List.rev results
+
+let rec add_tool_ids ~message_index seen = function
+  | [] -> Ok seen
+  | tool_use_id :: rest ->
+      if Id_set.mem tool_use_id seen then
+        Error (Duplicate_tool_use_id { message_index; tool_use_id })
+      else add_tool_ids ~message_index (Id_set.add tool_use_id seen) rest
+
+let rec consume_results ~message_index ~expected pending seen = function
+  | [] -> Ok (pending, seen)
+  | tool_use_id :: rest ->
+      if Id_set.mem tool_use_id seen then
+        Error (Duplicate_tool_result { message_index; tool_use_id })
+      else if not (Id_set.mem tool_use_id expected) then
+        Error (Unknown_tool_result { message_index; tool_use_id })
+      else
+        consume_results ~message_index ~expected
+          (Id_set.remove tool_use_id pending)
+          (Id_set.add tool_use_id seen) rest
+
+let is_result_role = function
+  | T.User | T.Tool -> true
+  | T.System | T.Assistant -> false
+
+let partition messages =
+  let rec loop index units_rev seen_tools seen_results open_cycle = function
+    | [] ->
+        let protected_suffix =
+          match open_cycle with
+          | None -> []
+          | Some cycle -> List.rev cycle.messages_rev
+        in
+        Ok { compactable_prefix = List.rev units_rev; protected_suffix }
+    | (message : T.message) :: rest ->
+        let tool_ids, result_ids = top_level_anchors message.content in
+        (match message.role, tool_ids with
+        | (T.System | T.User | T.Tool), tool_use_id :: _ ->
+            Error (Non_assistant_tool_use { message_index = index; tool_use_id })
+        | _ -> (
+            match open_cycle, tool_ids, result_ids with
+            | Some _, tool_use_id :: _, _ ->
+                Error (Overlapping_tool_cycle { message_index = index; tool_use_id })
+            | None, _, _ -> (
+                match add_tool_ids ~message_index:index seen_tools tool_ids with
+                | Error _ as error -> error
+                | Ok seen_tools -> (
+                    match tool_ids, result_ids with
+                    | [], tool_use_id :: _ ->
+                        if Id_set.mem tool_use_id seen_results then
+                          Error
+                            (Duplicate_tool_result
+                               { message_index = index; tool_use_id })
+                        else
+                          Error
+                            (Orphan_tool_result
+                               { message_index = index; tool_use_id })
+                    | [], [] ->
+                        loop (index + 1)
+                          (Ordinary_message message :: units_rev)
+                          seen_tools seen_results None rest
+                    | tool_use_id :: _, _ :: _ ->
+                        Error
+                          (Tool_request_contains_result
+                             { message_index = index; tool_use_id })
+                    | _ :: _, [] ->
+                        let expected = Id_set.of_list tool_ids in
+                        loop (index + 1) units_rev seen_tools seen_results
+                          (Some
+                             { expected
+                             ; pending = expected
+                             ; messages_rev = [ message ]
+                             })
+                          rest))
+            | Some cycle, [], [] ->
+                loop (index + 1) units_rev seen_tools seen_results
+                  (Some { cycle with messages_rev = message :: cycle.messages_rev })
+                  rest
+            | Some _, [], tool_use_id :: _ when not (is_result_role message.role) ->
+                Error (Non_result_tool_role { message_index = index; tool_use_id })
+            | Some cycle, [], _ :: _ -> (
+                match
+                  consume_results ~message_index:index ~expected:cycle.expected
+                    cycle.pending seen_results result_ids
+                with
+                | Error _ as error -> error
+                | Ok (pending, seen_results) ->
+                    let messages_rev = message :: cycle.messages_rev in
+                    if Id_set.is_empty pending then
+                      loop (index + 1)
+                        (Closed_tool_cycle (List.rev messages_rev) :: units_rev)
+                        seen_tools seen_results None rest
+                    else
+                      loop (index + 1) units_rev seen_tools seen_results
+                        (Some { cycle with pending; messages_rev })
+                        rest)))
+  in
+  loop 0 [] Id_set.empty Id_set.empty None messages

--- a/lib/keeper/keeper_compaction_unit.mli
+++ b/lib/keeper/keeper_compaction_unit.mli
@@ -1,0 +1,52 @@
+(** Pure structural partitioning for LLM compaction.
+
+    Tool protocol cycles remain byte- and constructor-exact units. This module
+    inspects only top-level content blocks; nested ToolResult payload blocks are
+    never interpreted as protocol anchors. *)
+
+type compactable_unit =
+  | Ordinary_message of Agent_sdk.Types.message
+  | Closed_tool_cycle of Agent_sdk.Types.message list
+
+type structural_error =
+  | Orphan_tool_result of
+      { message_index : int
+      ; tool_use_id : string
+      }
+  | Duplicate_tool_result of
+      { message_index : int
+      ; tool_use_id : string
+      }
+  | Unknown_tool_result of
+      { message_index : int
+      ; tool_use_id : string
+      }
+  | Non_assistant_tool_use of
+      { message_index : int
+      ; tool_use_id : string
+      }
+  | Duplicate_tool_use_id of
+      { message_index : int
+      ; tool_use_id : string
+      }
+  | Overlapping_tool_cycle of
+      { message_index : int
+      ; tool_use_id : string
+      }
+  | Tool_request_contains_result of
+      { message_index : int
+      ; tool_use_id : string
+      }
+  | Non_result_tool_role of
+      { message_index : int
+      ; tool_use_id : string
+      }
+
+type partition =
+  { compactable_prefix : compactable_unit list
+  ; protected_suffix : Agent_sdk.Types.message list
+  }
+
+val partition
+  :  Agent_sdk.Types.message list
+  -> (partition, structural_error) result

--- a/lib/keeper/keeper_compaction_unit.mli
+++ b/lib/keeper/keeper_compaction_unit.mli
@@ -2,9 +2,10 @@
 
     Tool protocol cycles remain byte- and constructor-exact units. This module
     inspects only top-level content blocks; nested ToolResult payload blocks are
-    never interpreted as protocol anchors. *)
+    never interpreted as protocol anchors. Presence in [closed_prefix] does not
+    by itself authorize a unit for LLM summarization. *)
 
-type compactable_unit =
+type closed_unit =
   | Ordinary_message of Agent_sdk.Types.message
   | Closed_tool_cycle of Agent_sdk.Types.message list
 
@@ -43,7 +44,7 @@ type structural_error =
       }
 
 type partition =
-  { compactable_prefix : compactable_unit list
+  { closed_prefix : closed_unit list
   ; protected_suffix : Agent_sdk.Types.message list
   }
 

--- a/lib/keeper/keeper_current_operations.ml
+++ b/lib/keeper/keeper_current_operations.ml
@@ -1,0 +1,249 @@
+type source =
+  | Event_queue_pending of
+      { revision : int64
+      ; stimulus : Keeper_event_queue.stimulus
+      }
+  | Event_queue_lease of
+      { revision : int64
+      ; lease : Keeper_event_queue_state.lease
+      }
+  | Event_queue_outbox of
+      { revision : int64
+      ; entry : Keeper_event_queue_state.outbox_entry
+      }
+  | Async_request of Keeper_msg_async.entry
+
+type t =
+  { keeper_name : string
+  ; source : source
+  }
+
+type source_name =
+  | Event_queue_source
+  | Async_request_source
+
+type read_error =
+  | Durable_read_failed of string
+  | Access_rejected of Keeper_msg_async.access_rejection
+  | Async_keeper_mismatch of
+      { request_id : string
+      ; expected_keeper : string
+      ; actual_keeper : string
+      }
+  | Async_terminal_entry of
+      { request_id : string
+      ; status : Keeper_msg_async.request_status
+      }
+  | Async_active_entry_has_completion_time of
+      { request_id : string
+      ; completed_at : float
+      }
+
+type unavailable =
+  { source : source_name
+  ; keeper_name : string
+  ; error : read_error
+  }
+
+type 'a availability =
+  | Available of 'a
+  | Unavailable of unavailable
+
+type snapshot =
+  { keeper_name : string
+  ; event_queue : t list availability
+  ; async_requests : t list availability
+  }
+
+let project_event_queue_state ~keeper_name state =
+  let revision = Keeper_event_queue_state.revision state in
+  let pending =
+    Keeper_event_queue_state.pending state
+    |> Keeper_event_queue.to_list
+    |> List.map (fun stimulus ->
+      { keeper_name
+      ; source = Event_queue_pending { revision; stimulus }
+      })
+  in
+  let leases =
+    Keeper_event_queue_state.leases state
+    |> List.map (fun (lease : Keeper_event_queue_state.lease) ->
+      { keeper_name
+      ; source = Event_queue_lease { revision; lease }
+      })
+  in
+  let outbox =
+    Keeper_event_queue_state.transition_outbox state
+    |> List.map (fun (entry : Keeper_event_queue_state.outbox_entry) ->
+      { keeper_name
+      ; source = Event_queue_outbox { revision; entry }
+      })
+  in
+  leases @ pending @ outbox
+;;
+
+let project_async_entries ~keeper_name entries =
+  let rec loop projected_rev = function
+    | [] -> Ok (List.rev projected_rev)
+    | (entry : Keeper_msg_async.entry) :: rest ->
+      if not (String.equal entry.keeper_name keeper_name)
+      then
+        Error
+          (Async_keeper_mismatch
+             { request_id = entry.request_id
+             ; expected_keeper = keeper_name
+             ; actual_keeper = entry.keeper_name
+             })
+      else
+        (match entry.status with
+         | Lost _ | Cancelled _ | Persistence_failed _ | Done _ ->
+           Error
+             (Async_terminal_entry
+                { request_id = entry.request_id; status = entry.status })
+         | Queued | Running | Cancelling _ ->
+           (match entry.completed_at with
+            | Some completed_at ->
+              Error
+                (Async_active_entry_has_completion_time
+                   { request_id = entry.request_id; completed_at })
+            | None ->
+              loop
+                ({ keeper_name; source = Async_request entry } :: projected_rev)
+                rest))
+  in
+  loop [] entries
+;;
+
+let availability ~source ~keeper_name = function
+  | Ok value -> Available value
+  | Error error -> Unavailable { source; keeper_name; error }
+;;
+
+let project_snapshot ~keeper_name ~event_queue ~async_requests =
+  { keeper_name
+  ; event_queue =
+      availability ~source:Event_queue_source ~keeper_name
+        (Result.map (project_event_queue_state ~keeper_name) event_queue)
+  ; async_requests =
+      availability ~source:Async_request_source ~keeper_name
+        (Result.bind async_requests (project_async_entries ~keeper_name))
+  }
+;;
+
+let status_to_yojson = function
+  | Keeper_msg_async.Queued -> `Assoc [ "kind", `String "queued"; "terminal", `Bool false ]
+  | Running -> `Assoc [ "kind", `String "running"; "terminal", `Bool false ]
+  | Cancelling { reason; cancelled_by } ->
+    `Assoc [ "kind", `String "cancelling"; "terminal", `Bool false
+           ; "reason", `String reason; "cancelled_by", `String cancelled_by ]
+  | Lost { reason } ->
+    `Assoc [ "kind", `String "lost"; "terminal", `Bool true; "reason", `String reason ]
+  | Cancelled { reason; cancelled_by } ->
+    `Assoc [ "kind", `String "cancelled"; "terminal", `Bool true
+           ; "reason", `String reason; "cancelled_by", `String cancelled_by ]
+  | Persistence_failed { attempted_status; reason } ->
+    `Assoc [ "kind", `String "persistence_failed"; "terminal", `Bool true
+           ; "attempted_status", `String attempted_status; "reason", `String reason ]
+  | Done { ok; body; data } ->
+    `Assoc [ "kind", `String "done"; "terminal", `Bool true; "ok", `Bool ok
+           ; "body", `String body
+           ; "data", (match data with None -> `Null | Some value -> value) ]
+;;
+
+let async_entry_to_yojson (entry : Keeper_msg_async.entry) =
+  `Assoc
+    [ "request_id", `String entry.request_id
+    ; "keeper_name", `String entry.keeper_name
+    ; "base_path", `String entry.base_path
+    ; "submitted_by", `String entry.submitted_by
+    ; "submitted_at", `Float entry.submitted_at
+    ; "completed_at", Option.fold ~none:`Null ~some:(fun value -> `Float value) entry.completed_at
+    ; "status", status_to_yojson entry.status
+    ]
+;;
+
+let outbox_to_yojson (entry : Keeper_event_queue_state.outbox_entry) =
+  `Assoc
+    [ "receipt", Keeper_event_queue_state.transition_receipt_to_yojson entry.receipt
+    ; "stimuli", `List (List.map Keeper_event_queue.stimulus_to_yojson entry.stimuli)
+    ]
+;;
+
+let source_to_yojson = function
+  | Event_queue_pending { revision; stimulus } ->
+    `Assoc [ "kind", `String "event_queue_pending"
+           ; "revision", `String (Int64.to_string revision)
+           ; "value", Keeper_event_queue.stimulus_to_yojson stimulus ]
+  | Event_queue_lease { revision; lease } ->
+    `Assoc [ "kind", `String "event_queue_lease"
+           ; "revision", `String (Int64.to_string revision)
+           ; "value", Keeper_event_queue_state.lease_to_yojson lease ]
+  | Event_queue_outbox { revision; entry } ->
+    `Assoc [ "kind", `String "event_queue_outbox"
+           ; "revision", `String (Int64.to_string revision)
+           ; "value", outbox_to_yojson entry ]
+  | Async_request entry ->
+    `Assoc [ "kind", `String "async_request"; "value", async_entry_to_yojson entry ]
+;;
+
+let to_yojson (operation : t) =
+  `Assoc
+    [ "keeper_name", `String operation.keeper_name
+    ; "source", source_to_yojson operation.source
+    ]
+;;
+
+let unavailable_to_yojson unavailable =
+  let source =
+    match unavailable.source with
+    | Event_queue_source -> "event_queue"
+    | Async_request_source -> "async_requests"
+  in
+  let error =
+    match unavailable.error with
+    | Durable_read_failed detail ->
+      `Assoc [ "kind", `String "durable_read_failed"; "detail", `String detail ]
+    | Access_rejected rejection ->
+      `Assoc [ "kind", `String "access_rejected"
+             ; "detail", Keeper_msg_async.access_rejection_to_json rejection ]
+    | Async_keeper_mismatch { request_id; expected_keeper; actual_keeper } ->
+      `Assoc
+        [ "kind", `String "async_keeper_mismatch"
+        ; "request_id", `String request_id
+        ; "expected_keeper", `String expected_keeper
+        ; "actual_keeper", `String actual_keeper
+        ]
+    | Async_terminal_entry { request_id; status } ->
+      `Assoc
+        [ "kind", `String "async_terminal_entry"
+        ; "request_id", `String request_id
+        ; "status", status_to_yojson status
+        ]
+    | Async_active_entry_has_completion_time { request_id; completed_at } ->
+      `Assoc
+        [ "kind", `String "async_active_entry_has_completion_time"
+        ; "request_id", `String request_id
+        ; "completed_at", `Float completed_at
+        ]
+  in
+  `Assoc [ "source", `String source; "keeper_name", `String unavailable.keeper_name
+         ; "error", error ]
+;;
+
+let availability_to_yojson = function
+  | Available operations ->
+    `Assoc [ "available", `Bool true; "operations", `List (List.map to_yojson operations) ]
+  | Unavailable error ->
+    `Assoc [ "available", `Bool false; "unavailable", unavailable_to_yojson error ]
+;;
+
+let snapshot_to_yojson snapshot =
+  `Assoc
+    [ "schema", `String "keeper.current_operations.v1"
+    ; "keeper_name", `String snapshot.keeper_name
+    ; "event_queue", availability_to_yojson snapshot.event_queue
+    ; "async_requests", availability_to_yojson snapshot.async_requests
+    ]
+;;
+
+let render operation = to_yojson operation |> Yojson.Safe.to_string

--- a/lib/keeper/keeper_current_operations.mli
+++ b/lib/keeper/keeper_current_operations.mli
@@ -1,0 +1,76 @@
+(** Immutable Keeper work projection with no inferred progress, ETA, or store. *)
+
+type source = private
+  | Event_queue_pending of
+      { revision : int64
+      ; stimulus : Keeper_event_queue.stimulus
+      }
+  | Event_queue_lease of
+      { revision : int64
+      ; lease : Keeper_event_queue_state.lease
+      }
+  | Event_queue_outbox of
+      { revision : int64
+      ; entry : Keeper_event_queue_state.outbox_entry
+      }
+  | Async_request of Keeper_msg_async.entry
+
+type t =
+  { keeper_name : string
+  ; source : source
+  }
+
+type source_name =
+  | Event_queue_source
+  | Async_request_source
+
+type read_error =
+  | Durable_read_failed of string
+  | Access_rejected of Keeper_msg_async.access_rejection
+  | Async_keeper_mismatch of
+      { request_id : string
+      ; expected_keeper : string
+      ; actual_keeper : string
+      }
+  | Async_terminal_entry of
+      { request_id : string
+      ; status : Keeper_msg_async.request_status
+      }
+  | Async_active_entry_has_completion_time of
+      { request_id : string
+      ; completed_at : float
+      }
+
+type unavailable =
+  { source : source_name
+  ; keeper_name : string
+  ; error : read_error
+  }
+
+type 'a availability =
+  | Available of 'a
+  | Unavailable of unavailable
+
+type snapshot =
+  { keeper_name : string
+  ; event_queue : t list availability
+  ; async_requests : t list availability
+  }
+
+val project_event_queue_state :
+  keeper_name:string -> Keeper_event_queue_state.t -> t list
+
+val project_async_entries :
+  keeper_name:string -> Keeper_msg_async.entry list -> (t list, read_error) result
+
+val project_snapshot :
+  keeper_name:string ->
+  event_queue:(Keeper_event_queue_state.t, read_error) result ->
+  async_requests:(Keeper_msg_async.entry list, read_error) result ->
+  snapshot
+(** Pure adapter seam. Callers must supply reads from canonical durable
+    sources; a process-local cache is not a substitute. *)
+
+val to_yojson : t -> Yojson.Safe.t
+val snapshot_to_yojson : snapshot -> Yojson.Safe.t
+val render : t -> string

--- a/test/dune
+++ b/test/dune
@@ -286,6 +286,7 @@
   test_keeper_artifact_hydrator
   test_artifacts_endpoint
   test_tool_output_washing_e2e
+  test_keeper_compaction_unit
   test_keeper_context_core_dedup
   test_tool_call_quality_benchmark
   test_keeper_prompt_metrics
@@ -607,6 +608,7 @@
   test_keeper_artifact_hydrator
   test_artifacts_endpoint
   test_tool_output_washing_e2e
+  test_keeper_compaction_unit
   test_keeper_context_core_dedup
   test_tool_call_quality_benchmark
   test_keeper_prompt_metrics

--- a/test/dune
+++ b/test/dune
@@ -676,6 +676,11 @@
  (libraries alcotest masc_test_deps))
 
 (test
+ (name test_keeper_current_operations)
+ (modules test_keeper_current_operations)
+ (libraries alcotest masc_test_deps))
+
+(test
  (name test_keeper_failure_judgment_contract)
  (modules test_keeper_failure_judgment_contract)
  (libraries alcotest masc_test_deps))

--- a/test/test_keeper_compaction_unit.ml
+++ b/test/test_keeper_compaction_unit.ml
@@ -1,0 +1,174 @@
+module U = Masc.Keeper_compaction_unit
+module T = Agent_sdk.Types
+
+let message role content : T.message =
+  { role; content; name = None; tool_call_id = None; metadata = [] }
+
+let text role value = message role [ T.Text value ]
+
+let use id =
+  T.ToolUse { id; name = "test_tool"; input = `Assoc [ "id", `String id ] }
+
+let result ?content_blocks id =
+  T.ToolResult
+    { tool_use_id = id
+    ; content = "result:" ^ id
+    ; outcome = T.Tool_succeeded
+    ; json = Some (`Assoc [ "id", `String id ])
+    ; content_blocks
+    }
+
+let check_exact label expected actual =
+  Alcotest.(check bool) label true (expected = actual)
+
+let require_ok = function
+  | Ok value -> value
+  | Error _ -> Alcotest.fail "expected structural partition"
+
+let test_signed_parallel_cycle_is_atomic () =
+  let assistant =
+    message T.Assistant
+      [ T.Thinking { content = "private bytes"; signature = Some "signed-bytes" }
+      ; use "call-a"
+      ; T.RedactedThinking "opaque"
+      ; use "call-b"
+      ]
+  in
+  let nested_payload =
+    [ T.ToolUse { id = "payload-only"; name = "not-an-anchor"; input = `Null }
+    ; result "payload-only"
+    ]
+  in
+  let result_b = message T.User [ result ~content_blocks:nested_payload "call-b" ] in
+  let result_a = message T.Tool [ result "call-a" ] in
+  let cycle = [ assistant; result_b; result_a ] in
+  let output = U.partition cycle |> require_ok in
+  Alcotest.(check int) "one atomic unit" 1 (List.length output.compactable_prefix);
+  check_exact "closed cycle exact"
+    [ U.Closed_tool_cycle cycle ]
+    output.compactable_prefix;
+  check_exact "no protected suffix" [] output.protected_suffix;
+  match assistant.content with
+  | T.Thinking { signature; content } :: _ ->
+      Alcotest.(check (option string)) "signature exact" (Some "signed-bytes")
+        signature;
+      Alcotest.(check string) "thinking exact" "private bytes" content
+  | _ -> Alcotest.fail "expected signed thinking"
+
+let test_open_after_assistant_is_protected () =
+  let prefix = text T.User "before" in
+  let assistant = message T.Assistant [ use "open" ] in
+  let output = U.partition [ prefix; assistant ] |> require_ok in
+  check_exact "ordinary prefix"
+    [ U.Ordinary_message prefix ]
+    output.compactable_prefix;
+  check_exact "assistant suffix exact" [ assistant ] output.protected_suffix
+
+let test_open_interstitial_suffix_is_exact () =
+  let assistant = message T.Assistant [ use "open" ] in
+  let middle_user = text T.User "still waiting" in
+  let middle_assistant = text T.Assistant "progress prose" in
+  let suffix = [ assistant; middle_user; middle_assistant ] in
+  let output = U.partition suffix |> require_ok in
+  check_exact "no compactable unit" [] output.compactable_prefix;
+  check_exact "interstitial suffix exact" suffix output.protected_suffix
+
+let test_closed_interstitial_cycle_is_atomic () =
+  let assistant = message T.Assistant [ use "call" ] in
+  let progress = text T.Assistant "tool progress" in
+  let completed = message T.User [ result "call" ] in
+  let cycle = [ assistant; progress; completed ] in
+  let output = U.partition cycle |> require_ok in
+  check_exact "closed interstitial cycle"
+    [ U.Closed_tool_cycle cycle ]
+    output.compactable_prefix;
+  check_exact "no protected suffix" [] output.protected_suffix
+
+let test_ordinary_prefix_order () =
+  let messages =
+    [ text T.System "system"; text T.User "one"; text T.Assistant "two" ]
+  in
+  let output = U.partition messages |> require_ok in
+  check_exact "ordinary order"
+    (List.map (fun msg -> U.Ordinary_message msg) messages)
+    output.compactable_prefix;
+  check_exact "empty suffix" [] output.protected_suffix
+
+let test_orphan_result_error () =
+  match U.partition [ message T.User [ result "orphan" ] ] with
+  | Error (U.Orphan_tool_result { message_index = 0; tool_use_id = "orphan" }) ->
+      ()
+  | _ -> Alcotest.fail "expected typed orphan ToolResult"
+
+let test_duplicate_result_error () =
+  let assistant = message T.Assistant [ use "a"; use "b" ] in
+  let first = message T.User [ result "a" ] in
+  let duplicate = message T.User [ result "a" ] in
+  match U.partition [ assistant; first; duplicate ] with
+  | Error (U.Duplicate_tool_result { message_index = 2; tool_use_id = "a" }) ->
+      ()
+  | _ -> Alcotest.fail "expected typed duplicate ToolResult"
+
+let test_unknown_result_error () =
+  let assistant = message T.Assistant [ use "known" ] in
+  let unknown = message T.User [ result "unknown" ] in
+  match U.partition [ assistant; unknown ] with
+  | Error (U.Unknown_tool_result { message_index = 1; tool_use_id = "unknown" }) ->
+      ()
+  | _ -> Alcotest.fail "expected typed unknown ToolResult"
+
+let test_open_result_role_error () =
+  let assistant = message T.Assistant [ use "call" ] in
+  let invalid = message T.Assistant [ result "call" ] in
+  match U.partition [ assistant; invalid ] with
+  | Error (U.Non_result_tool_role { message_index = 1; tool_use_id = "call" }) ->
+      ()
+  | _ -> Alcotest.fail "expected typed ToolResult role error"
+
+let test_non_assistant_tool_use_error () =
+  match U.partition [ message T.User [ use "invalid" ] ] with
+  | Error
+      (U.Non_assistant_tool_use { message_index = 0; tool_use_id = "invalid" }) ->
+      ()
+  | _ -> Alcotest.fail "expected typed non-assistant ToolUse"
+
+let test_duplicate_tool_use_error () =
+  match U.partition [ message T.Assistant [ use "same"; use "same" ] ] with
+  | Error (U.Duplicate_tool_use_id { message_index = 0; tool_use_id = "same" }) ->
+      ()
+  | _ -> Alcotest.fail "expected typed duplicate ToolUse"
+
+let test_mixed_request_result_error () =
+  match U.partition [ message T.Assistant [ use "same"; result "same" ] ] with
+  | Error
+      (U.Tool_request_contains_result
+        { message_index = 0; tool_use_id = "same" }) ->
+      ()
+  | _ -> Alcotest.fail "expected typed mixed request/result"
+
+let () =
+  Alcotest.run "keeper_compaction_unit"
+    [ ( "partition"
+      , [ Alcotest.test_case "signed parallel cycle exact" `Quick
+            test_signed_parallel_cycle_is_atomic
+        ; Alcotest.test_case "open after assistant" `Quick
+            test_open_after_assistant_is_protected
+        ; Alcotest.test_case "open interstitial suffix" `Quick
+            test_open_interstitial_suffix_is_exact
+        ; Alcotest.test_case "closed interstitial cycle" `Quick
+            test_closed_interstitial_cycle_is_atomic
+        ; Alcotest.test_case "ordinary prefix order" `Quick
+            test_ordinary_prefix_order
+        ; Alcotest.test_case "orphan result" `Quick test_orphan_result_error
+        ; Alcotest.test_case "duplicate result" `Quick
+            test_duplicate_result_error
+        ; Alcotest.test_case "unknown result" `Quick test_unknown_result_error
+        ; Alcotest.test_case "invalid result role" `Quick
+            test_open_result_role_error
+        ; Alcotest.test_case "non-assistant use" `Quick
+            test_non_assistant_tool_use_error
+        ; Alcotest.test_case "duplicate use" `Quick test_duplicate_tool_use_error
+        ; Alcotest.test_case "mixed request/result" `Quick
+            test_mixed_request_result_error
+        ] )
+    ]

--- a/test/test_keeper_compaction_unit.ml
+++ b/test/test_keeper_compaction_unit.ml
@@ -43,10 +43,10 @@ let test_signed_parallel_cycle_is_atomic () =
   let result_a = message T.Tool [ result "call-a" ] in
   let cycle = [ assistant; result_b; result_a ] in
   let output = U.partition cycle |> require_ok in
-  Alcotest.(check int) "one atomic unit" 1 (List.length output.compactable_prefix);
+  Alcotest.(check int) "one atomic unit" 1 (List.length output.closed_prefix);
   check_exact "closed cycle exact"
     [ U.Closed_tool_cycle cycle ]
-    output.compactable_prefix;
+    output.closed_prefix;
   check_exact "no protected suffix" [] output.protected_suffix;
   match assistant.content with
   | T.Thinking { signature; content } :: _ ->
@@ -61,7 +61,7 @@ let test_open_after_assistant_is_protected () =
   let output = U.partition [ prefix; assistant ] |> require_ok in
   check_exact "ordinary prefix"
     [ U.Ordinary_message prefix ]
-    output.compactable_prefix;
+    output.closed_prefix;
   check_exact "assistant suffix exact" [ assistant ] output.protected_suffix
 
 let test_open_interstitial_suffix_is_exact () =
@@ -70,7 +70,7 @@ let test_open_interstitial_suffix_is_exact () =
   let middle_assistant = text T.Assistant "progress prose" in
   let suffix = [ assistant; middle_user; middle_assistant ] in
   let output = U.partition suffix |> require_ok in
-  check_exact "no compactable unit" [] output.compactable_prefix;
+  check_exact "no closed unit" [] output.closed_prefix;
   check_exact "interstitial suffix exact" suffix output.protected_suffix
 
 let test_closed_interstitial_cycle_is_atomic () =
@@ -81,7 +81,7 @@ let test_closed_interstitial_cycle_is_atomic () =
   let output = U.partition cycle |> require_ok in
   check_exact "closed interstitial cycle"
     [ U.Closed_tool_cycle cycle ]
-    output.compactable_prefix;
+    output.closed_prefix;
   check_exact "no protected suffix" [] output.protected_suffix
 
 let test_ordinary_prefix_order () =
@@ -91,7 +91,7 @@ let test_ordinary_prefix_order () =
   let output = U.partition messages |> require_ok in
   check_exact "ordinary order"
     (List.map (fun msg -> U.Ordinary_message msg) messages)
-    output.compactable_prefix;
+    output.closed_prefix;
   check_exact "empty suffix" [] output.protected_suffix
 
 let test_orphan_result_error () =

--- a/test/test_keeper_current_operations.ml
+++ b/test/test_keeper_current_operations.ml
@@ -1,0 +1,109 @@
+open Alcotest
+module O = Masc.Keeper_current_operations
+module Q = Keeper_event_queue
+module S = Keeper_event_queue_state
+module A = Masc.Keeper_msg_async
+module J = Yojson.Safe.Util
+
+let ok = function Ok value -> value | Error error -> fail error
+let ok_projection = function Ok value -> value | Error _ -> fail "projection failed"
+let stimulus id at = { Q.post_id = id; urgency = Normal; arrived_at = at; payload = Bootstrap }
+let queue xs = List.fold_left Q.enqueue Q.empty xs
+
+let test_event_queue_exact_state () =
+  let first = stimulus "wake-1" 1.0 and second = stimulus "wake-2" 2.0 in
+  let state = S.empty |> S.with_pending (queue [ first; second ]) |> S.with_revision 17L in
+  let state, lease = S.claim_when ~claimed_at:3.0 ~ready:(fun _ -> true) state |> ok in
+  let lease = Option.get lease in
+  (match O.project_event_queue_state ~keeper_name:"keeper-a" state with
+   | [ { source = Event_queue_lease { revision; lease = projected }; _ }
+     ; { source = Event_queue_pending { stimulus = pending; _ }; _ } ] ->
+     check string "lease id" lease.lease_id projected.lease_id;
+     check int64 "revision" 17L revision;
+     check string "pending identity" second.post_id pending.post_id
+   | operations -> failf "unexpected operation count=%d" (List.length operations));
+  let state, _ = S.settle ~settled_at:4.0 ~lease ~settlement:S.Ack state |> ok in
+  match O.project_event_queue_state ~keeper_name:"keeper-a" state with
+  | [ { source = Event_queue_pending _; _ }
+    ; ({ source = Event_queue_outbox { entry; _ }; _ } as operation) ] ->
+    check string "transition" "lease:1:ack" entry.receipt.transition_id;
+    check string "render is exact JSON"
+      (O.to_yojson operation |> Yojson.Safe.to_string) (O.render operation)
+  | operations -> failf "unexpected outbox operation count=%d" (List.length operations)
+;;
+
+let test_async_active_and_unavailable () =
+  let entry : A.entry =
+    { request_id = "request-1"; keeper_name = "keeper-a"; base_path = "/workspace"
+    ; submitted_by = "caller-a"
+    ; status = Running
+    ; submitted_at = 5.0; completed_at = None }
+  in
+  let operation =
+    O.project_async_entries ~keeper_name:"keeper-a" [ entry ]
+    |> ok_projection
+    |> List.hd
+  in
+  let json = O.to_yojson operation in
+  check string "request id" "request-1"
+    J.(json |> member "source" |> member "value" |> member "request_id" |> to_string);
+  check bool "terminal" false
+    J.(json |> member "source" |> member "value" |> member "status"
+       |> member "terminal" |> to_bool);
+  let snapshot =
+    O.project_snapshot ~keeper_name:"keeper-a"
+      ~event_queue:(Error (O.Durable_read_failed "corrupt state"))
+      ~async_requests:(Error (O.Access_rejected A.Caller_mismatch))
+  in
+  (match snapshot.event_queue, snapshot.async_requests with
+   | Unavailable { error = Durable_read_failed _; _ },
+     Unavailable { error = Access_rejected Caller_mismatch; _ } -> ()
+   | _ -> fail "source failures were not preserved as typed Unavailable");
+  let snapshot_json = O.snapshot_to_yojson snapshot in
+  check bool "event unavailable" false J.(snapshot_json |> member "event_queue" |> member "available" |> to_bool);
+  check bool "async unavailable" false J.(snapshot_json |> member "async_requests" |> member "available" |> to_bool);
+  let wrong_keeper = { entry with keeper_name = "keeper-b" } in
+  let mixed_snapshot =
+    O.project_snapshot ~keeper_name:"keeper-a"
+      ~event_queue:(Ok S.empty)
+      ~async_requests:(Ok [ wrong_keeper ])
+  in
+  match mixed_snapshot.async_requests with
+  | Unavailable
+      { error =
+          Async_keeper_mismatch
+            { request_id = "request-1"
+            ; expected_keeper = "keeper-a"
+            ; actual_keeper = "keeper-b"
+            }
+      ; _
+      } ->
+    ()
+  | _ -> fail "cross-keeper async entry was not rejected"
+;;
+
+let test_terminal_async_entry_is_not_current () =
+  let terminal : A.entry =
+    { request_id = "request-terminal"
+    ; keeper_name = "keeper-a"
+    ; base_path = "/workspace"
+    ; submitted_by = "caller-a"
+    ; status = Done { ok = true; body = "done"; data = None }
+    ; submitted_at = 5.0
+    ; completed_at = Some 6.0
+    }
+  in
+  match O.project_async_entries ~keeper_name:"keeper-a" [ terminal ] with
+  | Error (O.Async_terminal_entry { request_id = "request-terminal"; _ }) -> ()
+  | _ -> fail "terminal async entry was projected as a current operation"
+;;
+
+let () =
+  run "keeper_current_operations"
+    [ "projection",
+      [ test_case "event queue exact state" `Quick test_event_queue_exact_state
+      ; test_case "async active and unavailable" `Quick test_async_active_and_unavailable
+      ; test_case "terminal async is not current" `Quick
+          test_terminal_async_entry_is_not_current
+      ] ]
+;;


### PR DESCRIPTION
## Summary

- add a pure typed partitioner for ordinary messages and exact closed ToolUse/ToolResult cycles
- preserve signed Thinking, parallel ToolUse ordering, nested ToolResult payloads, and open-cycle suffixes without flattening or repair
- reject orphan, duplicate, unknown, role-invalid, overlapping, and mixed protocol anchors with typed structural errors
- keep structural closure separate from LLM compaction eligibility: membership in `closed_prefix` grants no summarization authority

## Scope

This stacked PR creates structural history units only. It does not invoke an LLM, choose summarization candidates, summarize ToolResult content, or reconstruct live ToolProgress state. Active open cycles remain an exact protected suffix for later durable-state wiring.

## Stack

- base: #24860
- next: #24859

## Stack-top verification

The related checkpoint, structural partition, and operation-projection targets are verified together at the top of the stack rather than rerunning the same local build for every intermediate PR.
