### PR TITLE
fix(test): complete Auth_error_kind unification renames omitted from #24869

### DIFF
--- a/test/test_auth_error_kind.ml
+++ b/test/test_auth_error_kind.ml
@@ -8,7 +8,7 @@ module Types = Masc_domain
     label. *)
 
 open Alcotest
-module Aek = Masc.Auth_error_kind
+module Aek = Auth_error_kind
 
 let test_to_of_string_round_trip () =
   List.iter

--- a/test/test_auth_error_kind_dashboard_fallback.ml
+++ b/test/test_auth_error_kind_dashboard_fallback.ml
@@ -14,7 +14,7 @@
     [auth_error_kind.mli §Dashboard actor fallback typed surface]. *)
 
 open Alcotest
-module Aek = Masc.Auth_error_kind
+module Aek = Auth_error_kind
 module Sda = Masc.Silent_dashboard_actor_outcome
 
 let with_eio_runtime f =

--- a/test/test_server_auth_dashboard_actor_resolution.ml
+++ b/test/test_server_auth_dashboard_actor_resolution.ml
@@ -61,8 +61,8 @@ let test_rejected_credential_cannot_supply_actor_hint () =
   let request = request ~token:"stale-token" ~actor:"forged-actor" () in
   (match resolve ~base_path request with
    | Server_auth.Rejected_credential
-       (Masc.Auth_error_kind.Outcome_error
-          { err_kind = Masc.Auth_error_kind.Token_mismatch
+       (Auth_error_kind.Outcome_error
+          { err_kind = Auth_error_kind.Token_mismatch
           ; actor_hint = Some actor_hint
           ; _
           }) ->
@@ -100,8 +100,8 @@ let test_malformed_credential_cannot_become_anonymous () =
   in
   (match resolve ~base_path request with
    | Server_auth.Rejected_credential
-       (Masc.Auth_error_kind.Outcome_error
-          { err_kind = Masc.Auth_error_kind.Unauthorized
+       (Auth_error_kind.Outcome_error
+          { err_kind = Auth_error_kind.Unauthorized
           ; actor_hint = Some actor_hint
           ; _
           }) ->

--- a/test/test_server_auth_warn_log_bound.ml
+++ b/test/test_server_auth_warn_log_bound.ml
@@ -10,7 +10,7 @@ let test_warn_log_table_bounded () =
   let inserted = cap + 500 in
   for i = 1 to inserted do
     Server_auth.record_dashboard_actor_fallback
-      { Masc.Auth_error_kind.outcome = Masc.Auth_error_kind.Outcome_none
+      { Auth_error_kind.outcome = Auth_error_kind.Outcome_none
       ; token_hash_prefix = Printf.sprintf "prefix-%d" i
       }
   done;


### PR DESCRIPTION
## 요약

#24869 후속 — 커밋 누락분 수리 (main 테스트 컴파일 파손 복구).

## 무엇이 잘못됐나

#24869는 `lib/auth_error_kind.ml` 삭제 + `test/dune`만 커밋에 실었고, 로컬에서 검증까지 마친 테스트 4파일의 `Masc.Auth_error_kind` → `Auth_error_kind` rename이 **unstaged로 누락**됐습니다. 결과: main에서 해당 테스트 4개가 `Unbound module Masc.Auth_error_kind` 컴파일 실패. 원인은 파일 단위 부분 스테이징(`git add test/dune`) 후 검증된 working tree 전체가 커밋됐다고 오인한 것.

## 검증

- 이 브랜치(= main + 4파일)에서 `dune build --root . @check` clean
- 4개 스위트 green: auth_error_kind 11 / dashboard_fallback 11 / actor_resolution 5 / warn_log_bound 1

RFC-WAIVED: #24869 body의 waiver와 동일 — 인가 의미론 무변경, 테스트 참조 rename만.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JY83aHNyNR8UKqUYRL6p6v
