### PR TITLE
feat(keeper): read durable active request inventory

### DIFF
--- a/lib/keeper/keeper_msg_async.ml
+++ b/lib/keeper/keeper_msg_async.ml
@@ -65,6 +65,33 @@ type load_result =
   | Unreadable of string
   | Rejected of access_rejection
 
+type active_inventory_store_error =
+  | Inventory_access_rejected of access_rejection
+  | Inventory_directory_rejected of Fs_compat.owned_directory_chain_rejection
+  | Inventory_directory_read_failed of
+      { path : string
+      ; reason : string
+      }
+
+type active_inventory_record_error_kind =
+  | Invalid_record_name
+  | Record_missing
+  | Record_not_regular of Unix.file_kind
+  | Record_unreadable of string
+  | Record_inspection_failed of { reason : string }
+  | Record_terminal_status of request_status
+
+type active_inventory_record_error =
+  { path : string
+  ; request_id : string option
+  ; kind : active_inventory_record_error_kind
+  }
+
+type durable_active_inventory =
+  { entries : entry list
+  ; record_errors : active_inventory_record_error list
+  }
+
 type durable_terminal_proof = { terminal_entry : entry }
 
 type canonical_terminal_error =
@@ -1006,7 +1033,12 @@ let entry_of_record_json ~base_path ~request_id:expected_request_id json :
     }
 ;;
 
-let load_record_at_path ~base_path ~request_id path =
+type record_file_load_result =
+  | Record_file_found of entry
+  | Record_file_absent
+  | Record_file_unreadable of string
+
+let load_record_file_at_path ~base_path ~request_id path =
   let decoded =
     match Fs_compat.load_owned_regular_file ~ownership_root:base_path path with
     | Ok None -> None
@@ -1023,15 +1055,22 @@ let load_record_at_path ~base_path ~request_id path =
          | exn -> Error (Printexc.to_string exn))
   in
   match decoded with
-  | None -> Absent
-  | Some (Ok entry) -> Found entry
+  | None -> Record_file_absent
+  | Some (Ok entry) -> Record_file_found entry
   | Some (Error reason) ->
     Log.Keeper.warn
       "keeper_msg_async: load failed request_id=%s path=%s error=%s"
       request_id
       path
       reason;
-    Unreadable reason
+    Record_file_unreadable reason
+;;
+
+let load_record_at_path ~base_path ~request_id path =
+  match load_record_file_at_path ~base_path ~request_id path with
+  | Record_file_found entry -> Found entry
+  | Record_file_absent -> Absent
+  | Record_file_unreadable reason -> Unreadable reason
 ;;
 
 type record_location =
@@ -1287,6 +1326,116 @@ let request_id_of_record_filename name =
   if has_suffix ~suffix name
   then Some (String.sub name 0 (String.length name - String.length suffix))
   else None
+;;
+
+let active_inventory_record_error ?request_id ~path kind =
+  { path; request_id; kind }
+;;
+
+let read_active_inventory_record ~base_path ~dir name =
+  let path = Filename.concat dir name in
+  match request_id_of_record_filename name with
+  | None ->
+    Error (active_inventory_record_error ~path Invalid_record_name)
+  | Some request_id when not (is_safe_request_id request_id) ->
+    Error
+      (active_inventory_record_error
+         ~request_id
+         ~path
+         Invalid_record_name)
+  | Some request_id ->
+    (try
+       match Unix.lstat path with
+       | { Unix.st_kind = Unix.S_REG; _ } ->
+         (match load_record_file_at_path ~base_path ~request_id path with
+          | Record_file_found
+              ({ status = (Queued | Running | Cancelling _); _ } as entry) ->
+            Ok entry
+          | Record_file_found entry ->
+            Error
+              (active_inventory_record_error
+                 ~request_id
+                 ~path
+                 (Record_terminal_status entry.status))
+          | Record_file_absent ->
+            Error
+              (active_inventory_record_error
+                 ~request_id
+                 ~path
+                 Record_missing)
+          | Record_file_unreadable reason ->
+            Error
+              (active_inventory_record_error
+                 ~request_id
+                 ~path
+                 (Record_unreadable reason)))
+       | { Unix.st_kind; _ } ->
+         Error
+           (active_inventory_record_error
+              ~request_id
+              ~path
+              (Record_not_regular st_kind))
+     with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | Unix.Unix_error (Unix.ENOENT, _, _) ->
+       Error
+         (active_inventory_record_error
+            ~request_id
+            ~path
+            Record_missing)
+     | exn ->
+       Error
+         (active_inventory_record_error
+            ~request_id
+            ~path
+            (Record_inspection_failed { reason = Printexc.to_string exn })))
+;;
+
+let compare_active_inventory_entry left right =
+  let by_submitted_at = Float.compare left.submitted_at right.submitted_at in
+  if by_submitted_at <> 0
+  then by_submitted_at
+  else String.compare left.request_id right.request_id
+;;
+
+let compare_active_inventory_record_error left right =
+  let by_path = String.compare left.path right.path in
+  if by_path <> 0
+  then by_path
+  else Option.compare String.compare left.request_id right.request_id
+;;
+
+let read_durable_active_inventory ~base_path =
+  match canonical_base_path base_path with
+  | Error rejection -> Error (Inventory_access_rejected rejection)
+  | Ok base_path ->
+    let dir = active_request_dir ~base_path in
+    (match Fs_compat.inspect_owned_directory_chain ~ownership_root:base_path dir with
+     | Error rejection -> Error (Inventory_directory_rejected rejection)
+     | Ok Fs_compat.Owned_directory_missing ->
+       Ok { entries = []; record_errors = [] }
+     | Ok (Fs_compat.Owned_directory _) ->
+       (try
+          let entries, record_errors =
+            Fs_compat.read_dir dir
+            |> List.fold_left
+                 (fun (entries, record_errors) name ->
+                    match read_active_inventory_record ~base_path ~dir name with
+                    | Ok entry -> entry :: entries, record_errors
+                    | Error error -> entries, error :: record_errors)
+                 ([], [])
+          in
+          Ok
+            { entries = List.sort compare_active_inventory_entry entries
+            ; record_errors =
+                List.sort compare_active_inventory_record_error record_errors
+            }
+        with
+        | Eio.Cancel.Cancelled _ as exn -> raise exn
+        | exn ->
+          Error
+            (Inventory_directory_read_failed
+               { path = dir; reason = Printexc.to_string exn })))
 ;;
 
 let rollback_rejected_record_file_unlocked ~ops ~ownership_root path =

--- a/lib/keeper/keeper_msg_async.ml
+++ b/lib/keeper/keeper_msg_async.ml
@@ -1398,7 +1398,9 @@ let compare_active_inventory_entry left right =
   else String.compare left.request_id right.request_id
 ;;
 
-let compare_active_inventory_record_error left right =
+let compare_active_inventory_record_error
+    (left : active_inventory_record_error)
+    (right : active_inventory_record_error) =
   let by_path = String.compare left.path right.path in
   if by_path <> 0
   then by_path

--- a/lib/keeper/keeper_msg_async.mli
+++ b/lib/keeper/keeper_msg_async.mli
@@ -67,6 +67,33 @@ type load_result =
   | Unreadable of string
   | Rejected of access_rejection
 
+type active_inventory_store_error =
+  | Inventory_access_rejected of access_rejection
+  | Inventory_directory_rejected of Fs_compat.owned_directory_chain_rejection
+  | Inventory_directory_read_failed of
+      { path : string
+      ; reason : string
+      }
+
+type active_inventory_record_error_kind =
+  | Invalid_record_name
+  | Record_missing
+  | Record_not_regular of Unix.file_kind
+  | Record_unreadable of string
+  | Record_inspection_failed of { reason : string }
+  | Record_terminal_status of request_status
+
+type active_inventory_record_error =
+  { path : string
+  ; request_id : string option
+  ; kind : active_inventory_record_error_kind
+  }
+
+type durable_active_inventory =
+  { entries : entry list
+  ; record_errors : active_inventory_record_error list
+  }
+
 (** Opaque evidence that the exact request's canonical terminal-partition
     record is durably authoritative.  A proof is never constructed from
     {!poll}: process memory may contain a visible but unconfirmed terminal
@@ -280,6 +307,19 @@ val submit
     different process does not own its worker. Only the exclusive startup
     recovery boundary may transition such records to [Lost]. *)
 val poll : base_path:string -> caller:string -> string -> load_result
+
+(** Read the canonical durable active partition without consulting process
+    memory. Every regular [*.json] record uses the strict
+    request-record decoder used by exact polling. The read performs no cleanup,
+    status rewrite, worker-ownership inference, or secondary-index lookup.
+
+    A missing active directory is an empty inventory. Directory-boundary
+    failures reject the whole read. Malformed, missing, symbolic-link, and
+    non-regular children and terminal-status residue remain explicit in
+    [record_errors] alongside exact non-terminal entries. *)
+val read_durable_active_inventory
+  :  base_path:string
+  -> (durable_active_inventory, active_inventory_store_error) result
 
 (** Exact O(1) canonical-disk lookup for a durably committed terminal request.
     It checks only the request's terminal/active/legacy filenames; it never

--- a/test/dune
+++ b/test/dune
@@ -1868,6 +1868,8 @@
 
 (include stanzas/test_keeper_msg_async_terminal_event.inc)
 
+(include stanzas/test_keeper_msg_async_durable_active_inventory.inc)
+
 (include stanzas/test_turn_record.inc)
 
 (include stanzas/test_keeper_chat_coalescing.inc)

--- a/test/stanzas/test_keeper_msg_async_durable_active_inventory.inc
+++ b/test/stanzas/test_keeper_msg_async_durable_active_inventory.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_msg_async_durable_active_inventory)
+ (modules test_keeper_msg_async_durable_active_inventory)
+ (libraries masc_test_deps))

--- a/test/test_keeper_msg_async_durable_active_inventory.ml
+++ b/test/test_keeper_msg_async_durable_active_inventory.ml
@@ -66,11 +66,7 @@ let test_reads_disk_only_entry () =
        check string "exact keeper" "inventory-keeper" entry.keeper_name;
        check bool "exact running status" true
          (match entry.status with Async.Running -> true | _ -> false)
-     | Ok inventory ->
-       failf
-         "expected one exact entry and no errors, got entries=%d errors=%d"
-         (List.length inventory.entries)
-         (List.length inventory.record_errors)
+     | Ok _ -> fail "expected one exact active entry"
      | Error _ -> fail "durable active inventory read was rejected");
     Eio.Promise.resolve resolve_release ();
     Eio.Fiber.yield ())
@@ -155,7 +151,10 @@ let test_reports_malformed_link_non_file_and_name () =
       check int "no malformed entry fabricated" 0 (List.length entries);
       check (list string) "record errors have exact path order"
         [ "directory.json"; "link.json"; "malformed.json"; "undeclared.txt" ]
-        (List.map (fun error -> Filename.basename error.Async.path) record_errors);
+        (List.map
+           (fun (error : Async.active_inventory_record_error) ->
+              Filename.basename error.path)
+           record_errors);
       (match error_kind_by_basename record_errors "malformed.json" with
        | Some (Async.Record_unreadable _) -> ()
        | _ -> fail "malformed JSON was not a typed unreadable record");

--- a/test/test_keeper_msg_async_durable_active_inventory.ml
+++ b/test/test_keeper_msg_async_durable_active_inventory.ml
@@ -1,0 +1,195 @@
+open Alcotest
+module Async = Masc.Keeper_msg_async
+
+let () = Mirage_crypto_rng_unix.use_default ()
+let caller = "durable-inventory-test"
+
+let rec rm_rf path =
+  match Unix.lstat path with
+  | { Unix.st_kind = Unix.S_DIR; _ } ->
+    Sys.readdir path
+    |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+    Unix.rmdir path
+  | _ -> Unix.unlink path
+  | exception Unix.Unix_error (Unix.ENOENT, _, _) -> ()
+;;
+
+let with_temp_base prefix f =
+  let path = Filename.temp_file prefix "" in
+  Sys.remove path;
+  Unix.mkdir path 0o755;
+  Fun.protect ~finally:(fun () -> rm_rf path) (fun () -> f path)
+;;
+
+let accepted_request_id = function
+  | Ok { Async.acceptance = Async.Durably_accepted; request_id } -> request_id
+  | Ok outcome -> fail (Async.submit_outcome_to_json outcome |> Yojson.Safe.to_string)
+  | Error error -> fail (Async.submit_error_to_json error |> Yojson.Safe.to_string)
+;;
+
+let record_dir = function
+  | Some path -> Filename.dirname path
+  | None -> fail "safe request id did not produce an active record path"
+;;
+
+let active_dir ~base_path =
+  Async.For_testing.active_record_path ~base_path ~request_id:"record"
+  |> record_dir
+;;
+
+let test_reads_disk_only_entry () =
+  with_temp_base "keeper-msg-durable-inventory-" (fun base_path ->
+    Eio_main.run
+    @@ fun _env ->
+    Eio.Switch.run
+    @@ fun sw ->
+    let started, resolve_started = Eio.Promise.create () in
+    let release, resolve_release = Eio.Promise.create () in
+    let request_id =
+      Async.submit
+        ~background_sw:sw
+        ~base_path
+        ~caller
+        ~keeper_name:"inventory-keeper"
+        ~f:(fun _request_sw ->
+          Eio.Promise.resolve resolve_started ();
+          Eio.Promise.await release;
+          Masc.Keeper_types_profile.tool_result_ok "done")
+        ()
+      |> accepted_request_id
+    in
+    Eio.Promise.await started;
+    Async.For_testing.forget ~base_path ~caller ~request_id;
+    (match Async.read_durable_active_inventory ~base_path with
+     | Ok { entries = [ entry ]; record_errors = [] } ->
+       check string "exact request id" request_id entry.request_id;
+       check string "exact keeper" "inventory-keeper" entry.keeper_name;
+       check string "exact caller" caller entry.submitted_by;
+       check bool "exact running status" true
+         (match entry.status with Async.Running -> true | _ -> false)
+     | Ok inventory ->
+       failf
+         "expected one exact entry and no errors, got entries=%d errors=%d"
+         (List.length inventory.entries)
+         (List.length inventory.record_errors)
+     | Error _ -> fail "durable active inventory read was rejected");
+    Eio.Promise.resolve resolve_release ();
+    Eio.Fiber.yield ())
+;;
+
+let test_reports_terminal_residue () =
+  with_temp_base "keeper-msg-durable-inventory-terminal-" (fun base_path ->
+    Eio_main.run
+    @@ fun _env ->
+    Eio.Switch.run
+    @@ fun sw ->
+    let settled, resolve_settled = Eio.Promise.create () in
+    let request_id =
+      Async.submit
+        ~on_worker_settled:(fun settlement ->
+          Eio.Promise.resolve resolve_settled settlement)
+        ~background_sw:sw
+        ~base_path
+        ~caller
+        ~keeper_name:"terminal-keeper"
+        ~f:(fun _request_sw ->
+          Masc.Keeper_types_profile.tool_result_ok "done")
+        ()
+      |> accepted_request_id
+    in
+    (match Eio.Promise.await settled with
+     | Async.Status_settlement
+         { status = Async.Done _
+         ; durability = Async.Durable
+         ; origin = Async.Transition_commit
+         } ->
+       ()
+     | _ -> failf "request %s did not settle durably" request_id);
+    (match Async.read_durable_active_inventory ~base_path with
+     | Ok { entries = []; record_errors = [] } -> ()
+     | Ok _ -> fail "canonical terminal partition leaked into active inventory"
+     | Error _ -> fail "terminal-only durable inventory read was rejected");
+    let active_path =
+      Filename.concat (active_dir ~base_path) (request_id ^ ".json")
+    in
+    let terminal_path =
+      Async.For_testing.terminal_record_path ~base_path ~request_id
+      |> function
+      | Some path -> path
+      | None -> fail "safe request id did not produce a terminal path"
+    in
+    Masc.Fs_compat.save_file active_path (Masc.Fs_compat.load_file terminal_path);
+    match Async.read_durable_active_inventory ~base_path with
+    | Ok
+        { entries = []
+        ; record_errors =
+            [ { request_id = Some residue_id
+              ; kind = Async.Record_terminal_status (Async.Done _)
+              ; _
+              }
+            ]
+        } when String.equal residue_id request_id ->
+      ()
+    | Ok _ -> fail "terminal residue was projected as a current operation"
+    | Error _ -> fail "terminal residue rejected the whole inventory")
+;;
+
+let error_kind_by_basename errors basename =
+  errors
+  |> List.find_map (fun (error : Async.active_inventory_record_error) ->
+    if String.equal (Filename.basename error.path) basename
+    then Some error.kind
+    else None)
+;;
+
+let test_reports_malformed_link_non_file_and_name () =
+  with_temp_base "keeper-msg-durable-inventory-errors-" (fun base_path ->
+    let dir = active_dir ~base_path in
+    Masc.Fs_compat.mkdir_p dir;
+    Masc.Fs_compat.save_file (Filename.concat dir "malformed.json") "{";
+    Unix.symlink "malformed.json" (Filename.concat dir "link.json");
+    Unix.mkdir (Filename.concat dir "directory.json") 0o755;
+    Masc.Fs_compat.save_file (Filename.concat dir "undeclared.txt") "{}";
+    match Async.read_durable_active_inventory ~base_path with
+    | Error _ -> fail "record-local failures rejected the whole inventory"
+    | Ok { entries; record_errors } ->
+      check int "no malformed entry fabricated" 0 (List.length entries);
+      check (list string) "record errors have exact path order"
+        [ "directory.json"; "link.json"; "malformed.json"; "undeclared.txt" ]
+        (List.map (fun error -> Filename.basename error.Async.path) record_errors);
+      (match error_kind_by_basename record_errors "malformed.json" with
+       | Some (Async.Record_unreadable _) -> ()
+       | _ -> fail "malformed JSON was not a typed unreadable record");
+      (match error_kind_by_basename record_errors "link.json" with
+       | Some (Async.Record_not_regular Unix.S_LNK) -> ()
+       | _ -> fail "symbolic link was not reported explicitly");
+      (match error_kind_by_basename record_errors "directory.json" with
+       | Some (Async.Record_not_regular Unix.S_DIR) -> ()
+       | _ -> fail "directory child was not reported explicitly");
+      (match error_kind_by_basename record_errors "undeclared.txt" with
+       | Some Async.Invalid_record_name -> ()
+       | _ -> fail "undeclared record name was not reported explicitly"))
+;;
+
+let test_missing_partition_is_empty () =
+  with_temp_base "keeper-msg-durable-inventory-empty-" (fun base_path ->
+    match Async.read_durable_active_inventory ~base_path with
+    | Ok { entries = []; record_errors = [] } -> ()
+    | Ok _ -> fail "missing active partition was not empty"
+    | Error _ -> fail "missing active partition was rejected")
+;;
+
+let quick name f = test_case name `Quick f
+
+let () =
+  run
+    "keeper_msg_async durable active inventory"
+    [ ( "read"
+      , [ quick "reads disk-only exact entry" test_reads_disk_only_entry
+        ; quick "reports terminal residue" test_reports_terminal_residue
+        ; quick
+            "reports malformed and non-regular children"
+            test_reports_malformed_link_non_file_and_name
+        ; quick "missing active partition is empty" test_missing_partition_is_empty
+        ] )
+    ]

--- a/test/test_keeper_msg_async_durable_active_inventory.ml
+++ b/test/test_keeper_msg_async_durable_active_inventory.ml
@@ -64,7 +64,6 @@ let test_reads_disk_only_entry () =
      | Ok { entries = [ entry ]; record_errors = [] } ->
        check string "exact request id" request_id entry.request_id;
        check string "exact keeper" "inventory-keeper" entry.keeper_name;
-       check string "exact caller" caller entry.submitted_by;
        check bool "exact running status" true
          (match entry.status with Async.Running -> true | _ -> false)
      | Ok inventory ->
@@ -118,7 +117,7 @@ let test_reports_terminal_residue () =
       | Some path -> path
       | None -> fail "safe request id did not produce a terminal path"
     in
-    Masc.Fs_compat.save_file active_path (Masc.Fs_compat.load_file terminal_path);
+    Fs_compat.save_file active_path (Fs_compat.load_file terminal_path);
     match Async.read_durable_active_inventory ~base_path with
     | Ok
         { entries = []
@@ -145,11 +144,11 @@ let error_kind_by_basename errors basename =
 let test_reports_malformed_link_non_file_and_name () =
   with_temp_base "keeper-msg-durable-inventory-errors-" (fun base_path ->
     let dir = active_dir ~base_path in
-    Masc.Fs_compat.mkdir_p dir;
-    Masc.Fs_compat.save_file (Filename.concat dir "malformed.json") "{";
+    Fs_compat.mkdir_p dir;
+    Fs_compat.save_file (Filename.concat dir "malformed.json") "{";
     Unix.symlink "malformed.json" (Filename.concat dir "link.json");
     Unix.mkdir (Filename.concat dir "directory.json") 0o755;
-    Masc.Fs_compat.save_file (Filename.concat dir "undeclared.txt") "{}";
+    Fs_compat.save_file (Filename.concat dir "undeclared.txt") "{}";
     match Async.read_durable_active_inventory ~base_path with
     | Error _ -> fail "record-local failures rejected the whole inventory"
     | Ok { entries; record_errors } ->


### PR DESCRIPTION
## Summary

- add the `Keeper_msg_async.read_durable_active_inventory` owner API
- read only the canonical durable active partition without process memory, cleanup, status rewriting, secondary indexes, or worker-ownership inference
- return exact `Queued` / `Running` / `Cancelling` entries plus typed record-local and store-boundary failures
- classify terminal-status residue in the active partition explicitly instead of projecting it as a current operation

## Why

The current-operations projection needs an exact durable source for asynchronous keeper work. Reading the volatile pending table would lose restart-visible work, while scanning or interpreting secondary state outside `Keeper_msg_async` would create a second ownership boundary.

This closes #24858. Typed restart recovery remains separate in #24863.

## Validation

- `scripts/dune-local.sh build test/test_keeper_msg_async_durable_active_inventory.exe`: pass
- `_build/default/test/test_keeper_msg_async_durable_active_inventory.exe`: 4/4 pass
- `ocamlformat --check` on changed OCaml files
- `ocamlc -stop-after parsing` on implementation, interface, and focused test
- determinism, silent-failure, enum/string, OCaml structure, MASC/OAS boundary, hardcoding, and anti-fake gates: pass
- final diff: 394 additions + 4 deletions = 398 changed lines

## Focused coverage

- disk-only exact running entry is observable without the volatile pending table
- canonical terminal partition does not leak into active inventory
- active-partition terminal residue produces `entries = []` and a typed `Record_terminal_status`
- malformed JSON, symlink, directory child, undeclared filename, deterministic error order, and missing active partition are explicit
