### PR TITLE
refactor(gate)!: remove Auto Judge global cap

### DIFF
--- a/lib/keeper/hitl_summary_worker.ml
+++ b/lib/keeper/hitl_summary_worker.ml
@@ -41,25 +41,6 @@ let provider_config_for_summary ~keeper_name =
     resolve fallback_runtime_id
 ;;
 
-let effective_max_concurrency ~configured ~runtime_limit =
-  match runtime_limit with
-  | Some limit -> Int.min configured limit
-  | None -> configured
-;;
-
-let max_concurrency () =
-  let configured = Keeper_config.hitl_summary_max_concurrency () in
-  let runtime_limit =
-    match Runtime.hitl_summary_runtime_id () with
-    | Some runtime_id ->
-      (match Runtime.get_runtime_by_id runtime_id with
-       | Some runtime -> runtime.Runtime.binding.max_concurrent
-       | None -> None)
-    | None -> None
-  in
-  effective_max_concurrency ~configured ~runtime_limit
-;;
-
 (* ── Metrics ────────────────────────────────────── *)
 
 let () =
@@ -512,7 +493,6 @@ module For_testing = struct
   let summary_llm_error_outcomes = summary_llm_error_outcomes
   let summary_llm_error_retryable = summary_llm_error_retryable
   let sdk_error_of_http_error = sdk_error_of_http_error
-  let effective_max_concurrency = effective_max_concurrency
   let system_prompt = system_prompt
   let summary_version = summary_version
 end

--- a/lib/keeper/hitl_summary_worker.mli
+++ b/lib/keeper/hitl_summary_worker.mli
@@ -6,10 +6,6 @@ type summary_provider = private
 
 val provider_config_for_summary : keeper_name:string -> summary_provider option
 
-(** Effective Auto Judge worker cap. The subsystem cap is further bounded by
-    the selected runtime binding's [max_concurrent] declaration. *)
-val max_concurrency : unit -> int
-
 (** Verify that the registry-owned Gate judgment prompt is renderable. This is
     the readiness floor for selecting the workspace Auto Judge mode. *)
 val readiness : unit -> (unit, string) result
@@ -82,9 +78,6 @@ module For_testing : sig
 
   val sdk_error_of_http_error
     : Llm_provider.Http_client.http_error -> Agent_sdk.Error.sdk_error
-
-  val effective_max_concurrency
-    : configured:int -> runtime_limit:int option -> int
 
   val summary_version : int
 end

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -317,29 +317,11 @@ let hitl_summary_temperature_rp =
 let hitl_summary_temperature () : float =
   Runtime_params.get hitl_summary_temperature_rp
 
-(** Maximum number of request-local Auto Judge calls that may be in flight.
-    A bounded queue prevents an operator recovery of a large durable backlog
-    from turning into an unbounded provider burst. *)
-let hitl_summary_max_concurrency_rp =
-  _rp_int ~key:"keeper.hitl_summary.max_concurrency"
-    ~default:(fun () ->
-      int_of_env_default
-        "MASC_KEEPER_HITL_SUMMARY_MAX_CONCURRENCY"
-        ~default:4
-        ~min_v:1
-        ~max_v:32)
-    ~min_v:1
-    ~max_v:32
-    ~description:"Maximum concurrent HITL Auto Judge calls" ()
-let hitl_summary_max_concurrency () : int =
-  Runtime_params.get hitl_summary_max_concurrency_rp
-
 (** Force module initialization to guarantee all runtime params are registered
     before [Runtime_params.restore]. Call from server bootstrap. *)
 let ensure_runtime_params_init () =
   let (_ : float) = Runtime_params.get keeper_unified_temperature_rp in
   let (_ : float) = Runtime_params.get hitl_summary_temperature_rp in
-  let (_ : int) = Runtime_params.get hitl_summary_max_concurrency_rp in
   ()
 
 let keeper_enable_thinking_rp =

--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -184,7 +184,6 @@ val keeper_unified_max_tokens : unit -> int
 (** {2 HITL Context-Summary Worker Policy} *)
 
 val hitl_summary_temperature : unit -> float
-val hitl_summary_max_concurrency : unit -> int
 
 val keeper_status_fast_default : unit -> bool
 

--- a/lib/keeper/keeper_gate.ml
+++ b/lib/keeper/keeper_gate.ml
@@ -275,31 +275,29 @@ type auto_judge_start_outcome =
 
 module Auto_judge_ids = Set_util.StringSet
 
-let active_auto_judges : Auto_judge_ids.t Atomic.t =
+let claimed_auto_judges : Auto_judge_ids.t Atomic.t =
   Atomic.make Auto_judge_ids.empty
 ;;
 
 let rec claim_auto_judge id =
-  let active = Atomic.get active_auto_judges in
-  if Auto_judge_ids.mem id active
-     || Auto_judge_ids.cardinal active
-        >= Hitl_summary_worker.max_concurrency ()
+  let claimed = Atomic.get claimed_auto_judges in
+  if Auto_judge_ids.mem id claimed
   then false
   else
-    let claimed = Auto_judge_ids.add id active in
-    if Atomic.compare_and_set active_auto_judges active claimed
+    let next = Auto_judge_ids.add id claimed in
+    if Atomic.compare_and_set claimed_auto_judges claimed next
     then true
     else claim_auto_judge id
 ;;
 
 let rec release_auto_judge id =
-  let active = Atomic.get active_auto_judges in
-  let released = Auto_judge_ids.remove id active in
-  if not (Atomic.compare_and_set active_auto_judges active released)
+  let claimed = Atomic.get claimed_auto_judges in
+  let released = Auto_judge_ids.remove id claimed in
+  if not (Atomic.compare_and_set claimed_auto_judges claimed released)
   then release_auto_judge id
 ;;
 
-let rec spawn_claimed_auto_judge_entry
+let spawn_claimed_auto_judge_entry
       (entry : Keeper_approval_queue.pending_approval)
   =
   let approval_id = entry.id in
@@ -376,9 +374,7 @@ let rec spawn_claimed_auto_judge_entry
          ~on_summary
          ~on_failure
          ~on_finish:(fun () ->
-           release_auto_judge approval_id;
-           (* fire-and-forget: the queue owns subsequent worker completion. *)
-           ignore (drain_auto_judges ~base_path:entry.audit_base_path))
+           release_auto_judge approval_id)
          ();
        Ok Started
      with
@@ -400,12 +396,12 @@ let rec spawn_claimed_auto_judge_entry
       ~retryable:true
   | Some _, Error reason -> fail_before_worker ~reason ~retryable:true
 
-and spawn_auto_judge_entry (entry : Keeper_approval_queue.pending_approval) =
+let spawn_auto_judge_entry (entry : Keeper_approval_queue.pending_approval) =
   if claim_auto_judge entry.id
   then spawn_claimed_auto_judge_entry entry
   else Ok Skipped
 
-and retry_auto_judge_entry (entry : Keeper_approval_queue.pending_approval) =
+let retry_auto_judge_entry (entry : Keeper_approval_queue.pending_approval) =
   if not (claim_auto_judge entry.id)
   then Ok Skipped
   else
@@ -418,7 +414,7 @@ and retry_auto_judge_entry (entry : Keeper_approval_queue.pending_approval) =
       Ok Skipped
     | Ok true -> spawn_claimed_auto_judge_entry entry
 
-and start_auto_judge approval_id =
+let start_auto_judge approval_id =
   match Keeper_approval_queue.get_pending_entry ~id:approval_id with
   | None -> Ok Skipped
   | Some entry ->
@@ -434,50 +430,42 @@ and start_auto_judge approval_id =
          Ok Skipped
        | Ok true -> spawn_claimed_auto_judge_entry entry)
 
-and drain_auto_judges ~base_path =
+let drain_auto_judges ~base_path =
   match Keeper_gate_mode.read ~base_path with
   | Error _
   | Ok (Keeper_gate_mode.Manual | Keeper_gate_mode.Always_allow) -> []
   | Ok Keeper_gate_mode.Auto_judge ->
-    let capacity =
-      Hitl_summary_worker.max_concurrency ()
-      - Auto_judge_ids.cardinal (Atomic.get active_auto_judges)
-    in
-    if capacity <= 0
-    then []
-    else
-      Keeper_approval_queue.list_pending_entries ()
-      |> List.filter (fun (entry : Keeper_approval_queue.pending_approval) ->
-        String.equal entry.audit_base_path base_path
-        &&
+    Keeper_approval_queue.list_pending_entries ()
+    |> List.filter (fun (entry : Keeper_approval_queue.pending_approval) ->
+      String.equal entry.audit_base_path base_path
+      &&
+      match entry.summary_status with
+      | Keeper_approval_queue.Summary_not_requested
+      | Keeper_approval_queue.Summary_pending -> true
+      | Keeper_approval_queue.Summary_available _
+      | Keeper_approval_queue.Summary_failed _ -> false)
+    |> List.sort
+         (fun (left : Keeper_approval_queue.pending_approval)
+              (right : Keeper_approval_queue.pending_approval) ->
+            Float.compare left.requested_at right.requested_at)
+    |> List.filter_map (fun (entry : Keeper_approval_queue.pending_approval) ->
+      let started =
         match entry.summary_status with
-        | Keeper_approval_queue.Summary_not_requested
-        | Keeper_approval_queue.Summary_pending -> true
+        | Keeper_approval_queue.Summary_not_requested -> start_auto_judge entry.id
+        | Keeper_approval_queue.Summary_pending -> spawn_auto_judge_entry entry
         | Keeper_approval_queue.Summary_available _
-        | Keeper_approval_queue.Summary_failed _ -> false)
-      |> List.sort
-           (fun (left : Keeper_approval_queue.pending_approval)
-                (right : Keeper_approval_queue.pending_approval) ->
-              Float.compare left.requested_at right.requested_at)
-      |> List.filteri (fun index _ -> index < capacity)
-      |> List.filter_map (fun (entry : Keeper_approval_queue.pending_approval) ->
-        let started =
-          match entry.summary_status with
-          | Keeper_approval_queue.Summary_not_requested -> start_auto_judge entry.id
-          | Keeper_approval_queue.Summary_pending -> spawn_auto_judge_entry entry
-          | Keeper_approval_queue.Summary_available _
-          | Keeper_approval_queue.Summary_failed _ -> Ok Skipped
-        in
-        match started with
-        | Ok Started -> Some entry.id
-        | Ok Skipped -> None
-        | Error reason ->
-          Log.Keeper.error
-            ~keeper_name:entry.keeper_name
-            "Auto Judge bounded drain failed approval=%s: %s"
-            entry.id
-            reason;
-          None)
+        | Keeper_approval_queue.Summary_failed _ -> Ok Skipped
+      in
+      match started with
+      | Ok Started -> Some entry.id
+      | Ok Skipped -> None
+      | Error reason ->
+        Log.Keeper.error
+          ~keeper_name:entry.keeper_name
+          "Auto Judge drain failed approval=%s: %s"
+          entry.id
+          reason;
+        None)
 ;;
 
 type recovered_work =

--- a/lib/keeper/keeper_gate.mli
+++ b/lib/keeper/keeper_gate.mli
@@ -104,8 +104,9 @@ type operator_recovery_report =
   }
 
 (** Reopen failed request-local judgments after an explicit operator selection
-    of Auto Judge, then start a concurrency-bounded drain of every unresolved
-    judgment for the workspace. *)
+    of Auto Judge, then submit every unresolved judgment for the workspace.
+    The Gate owns exact-id duplicate suppression only; it does not impose a
+    numeric execution budget or a fleet-wide admission policy. *)
 val request_operator_auto_judge_recovery :
   base_path:string -> (operator_recovery_report, string) result
 

--- a/test/test_hitl_summary_worker.ml
+++ b/test/test_hitl_summary_worker.ml
@@ -152,17 +152,6 @@ let test_request_context_projection_is_idempotent () =
     (Masc.Keeper_gate_request_context.project projected)
 ;;
 
-let test_concurrency_respects_runtime_binding () =
-  check int "runtime binding narrows subsystem cap" 1
-    (Worker.For_testing.effective_max_concurrency
-       ~configured:4
-       ~runtime_limit:(Some 1));
-  check int "subsystem cap remains when runtime omits a limit" 4
-    (Worker.For_testing.effective_max_concurrency
-       ~configured:4
-       ~runtime_limit:None)
-;;
-
 let test_plain_json_requires_exact_object () =
   let expected = judgment_json "require_human" in
   match Worker.For_testing.extract_json_object (Yojson.Safe.to_string expected) with
@@ -262,10 +251,6 @@ let () =
             "context carries exact input"
             `Quick
             test_context_bundle_contains_exact_input_without_derived_classification
-        ; test_case
-            "runtime binding caps judge concurrency"
-            `Quick
-            test_concurrency_respects_runtime_binding
         ; test_case
             "request context projection is idempotent"
             `Quick


### PR DESCRIPTION
## Summary

- remove `keeper.hitl_summary.max_concurrency` and `MASC_KEEPER_HITL_SUMMARY_MAX_CONCURRENCY`
- remove MASC-owned `min(configured, runtime.max_concurrent)` admission
- submit every durable unresolved judgment during explicit Auto Judge recovery
- retain only exact approval-id duplicate suppression
- remove worker-completion coupling that retriggered only the completed entry workspace

## Boundary

The Gate owns authorization state and exact-id idempotence. It no longer owns a numeric fleet-wide execution budget. Provider/Runtime transport remains the resource boundary; one judgment no longer withholds another Keeper or workspace judgment through a shared capacity counter.

No risk class, tool-name semantics, retry budget, timer, or replacement numeric cap was added.

## Validation

- `git diff --check`
- `ocamlformat --check` on all changed OCaml files
- `ocamlc -stop-after parsing` on changed implementations/tests
- residue scan: removed runtime param, env variable, effective-cap helper, capacity filter, and bounded-drain wording are absent
- diff: 164 changed lines

Focused Dune execution was not claimed: the shared repo `_build/.lock` is currently held by external Dune processes, including long-lived PID 75289. PR CI is the build/test authority.

## Origin

Hard-cut follow-up to #24810. That PR fixed prompt bootstrap and typed provider failures but reintroduced a MASC-global numeric Auto Judge gate.