### PR TITLE
refactor(gate)!: require dedicated Auto Judge runtime

### DIFF
--- a/lib/keeper/hitl_summary_worker.ml
+++ b/lib/keeper/hitl_summary_worker.ml
@@ -9,36 +9,34 @@ let system_prompt () =
   Prompt_registry.render_prompt_template Keeper_prompt_names.gate_judgment []
 ;;
 
-let readiness () = Result.map (fun (_ : string) -> ()) (system_prompt ())
-
 type summary_provider =
   { runtime_id : string
   ; provider_config : Llm_provider.Provider_config.t
   }
 
-let provider_config_for_summary ~keeper_name =
-  let resolve runtime_id =
-    Option.map
-      (fun runtime ->
-         { runtime_id; provider_config = runtime.Runtime.provider_config })
-      (Runtime.get_runtime_by_id runtime_id)
-  in
-  let keeper_runtime_id () =
-    match Runtime.runtime_id_for_keeper keeper_name with
-    | Some id when String.trim id <> "" -> id
-    | Some _ | None -> Keeper_config.default_runtime_id ()
-  in
-  let summary_runtime_id = Runtime.runtime_id_for_hitl_summary () in
-  match resolve summary_runtime_id with
-  | Some _ as config -> config
+let provider_config_for_summary () =
+  match Runtime.hitl_summary_runtime_id () with
+  | None -> None
+  | Some runtime_id ->
+    Runtime.get_runtime_by_id runtime_id
+    |> Option.map (fun runtime ->
+      { runtime_id; provider_config = runtime.Runtime.provider_config })
+;;
+
+let readiness () =
+  let ( let* ) = Result.bind in
+  let* (_ : string) = system_prompt () in
+  match Runtime.hitl_summary_runtime_id () with
   | None ->
-    let fallback_runtime_id = keeper_runtime_id () in
-    Log.Keeper.warn
-      ~keeper_name
-      "HITL judgment runtime=%s is unavailable; falling back to keeper runtime=%s"
-      summary_runtime_id
-      fallback_runtime_id;
-    resolve fallback_runtime_id
+    Error "Auto Judge requires an explicit [runtime].hitl_summary runtime"
+  | Some runtime_id ->
+    (match Runtime.get_runtime_by_id runtime_id with
+     | Some _ -> Ok ()
+     | None ->
+       Error
+         (Printf.sprintf
+            "Auto Judge [runtime].hitl_summary=%s is not loaded"
+            runtime_id))
 ;;
 
 let effective_max_concurrency ~configured ~runtime_limit =

--- a/lib/keeper/hitl_summary_worker.mli
+++ b/lib/keeper/hitl_summary_worker.mli
@@ -4,14 +4,14 @@ type summary_provider = private
   ; provider_config : Llm_provider.Provider_config.t
   }
 
-val provider_config_for_summary : keeper_name:string -> summary_provider option
+val provider_config_for_summary : unit -> summary_provider option
 
 (** Effective Auto Judge worker cap. The subsystem cap is further bounded by
     the selected runtime binding's [max_concurrent] declaration. *)
 val max_concurrency : unit -> int
 
-(** Verify that the registry-owned Gate judgment prompt is renderable. This is
-    the readiness floor for selecting the workspace Auto Judge mode. *)
+(** Verify that the registry-owned Gate judgment prompt is renderable and that
+    the exact [runtime].hitl_summary runtime is configured and loaded. *)
 val readiness : unit -> (unit, string) result
 
 (** Spawn an asynchronous HITL context-summary worker for [runtime_id].

--- a/lib/keeper/keeper_gate.ml
+++ b/lib/keeper/keeper_gate.ml
@@ -355,9 +355,7 @@ let rec spawn_claimed_auto_judge_entry
   in
   let provider_selection =
     try
-      Ok
-        (Hitl_summary_worker.provider_config_for_summary
-           ~keeper_name:entry.keeper_name)
+      Ok (Hitl_summary_worker.provider_config_for_summary ())
     with
     | Eio.Cancel.Cancelled _ as exn ->
       release_auto_judge approval_id;
@@ -397,7 +395,8 @@ let rec spawn_claimed_auto_judge_entry
       ~retryable:true
   | Some _, Ok None ->
     fail_before_worker
-      ~reason:"Auto Judge unavailable: no runtime provider is configured"
+      ~reason:
+        "Auto Judge unavailable: explicit [runtime].hitl_summary provider is not loaded"
       ~retryable:true
   | Some _, Error reason -> fail_before_worker ~reason ~retryable:true
 

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -1121,9 +1121,9 @@ let librarian_runtime_id () = (runtime_state ()).librarian_runtime_id
    provider-native schema requests. *)
 let structured_judge_runtime_id () = (runtime_state ()).structured_judge_runtime_id
 
-(* [runtime].hitl_summary is the dedicated HITL approval-summary lane,
-   consumed by [Keeper_approval_queue.provider_config_for_summary]. [None]
-   falls through to the structured-judge routing chain. *)
+(* [runtime].hitl_summary is the dedicated HITL approval-summary lane.
+   [None] means that Auto Judge is not configured; callers must not substitute
+   another subsystem's runtime. *)
 let hitl_summary_runtime_id () = (runtime_state ()).hitl_summary_runtime_id
 
 let runtime_id_for_structured_judge () =
@@ -1132,12 +1132,6 @@ let runtime_id_for_structured_judge () =
   | Some id, _ -> id
   | None, Some id -> id
   | None, None -> default_runtime_id_or_fail ()
-;;
-
-let runtime_id_for_hitl_summary () =
-  match (runtime_state ()).hitl_summary_runtime_id with
-  | Some id -> id
-  | None -> runtime_id_for_structured_judge ()
 ;;
 
 (* [runtime].cross_verifier routing for the anti-rationalization evaluator.

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -214,7 +214,7 @@ val structured_judge_runtime_id : unit -> string option
 val hitl_summary_runtime_id : unit -> string option
 (** [\[runtime\].hitl_summary] runtime id for HITL approval context summaries,
     or [None] when unset. Validated at load so a [Some] resolves to a configured
-    runtime. *)
+    runtime. Auto Judge does not inherit another subsystem's runtime. *)
 
 val runtime_id_for_structured_judge : unit -> string
 (** Resolved runtime id for configured structured-output judgment calls.
@@ -222,11 +222,6 @@ val runtime_id_for_structured_judge : unit -> string
     [\[runtime\].librarian] migration lane, then [\[runtime\].default]. The final
     default path still fails loudly at each caller's schema validation if the
     runtime cannot satisfy provider-native structured output. *)
-
-val runtime_id_for_hitl_summary : unit -> string
-(** Resolved runtime id for HITL approval context summaries. Uses
-    [\[runtime\].hitl_summary] first, then the existing structured-judge routing
-    chain. *)
 
 val media_failover : unit -> string list
 (** [\[runtime\].media_failover] (RFC-0265) — ordered runtime ids consulted when a

--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -251,8 +251,8 @@ type config =
     (** [\[runtime\].hitl_summary] — runtime id for HITL approval context
         summaries. When set, it must resolve to a configured runtime. The HITL
         worker decides native structured vs plain JSON mode at call time, so
-        load-time validation only rejects unknown ids. [None] keeps the legacy
-        structured-judge routing fallback. *)
+        load-time validation only rejects unknown ids. [None] leaves Auto Judge
+        unavailable; it never inherits another subsystem's runtime. *)
   ; cross_verifier_runtime_id : string option
     (** [\[runtime\].cross_verifier] — runtime id for the anti-rationalization
         evaluator. It requests JSON mode and must run on a model declaring

--- a/lib/runtime/runtime_schema.mli
+++ b/lib/runtime/runtime_schema.mli
@@ -185,8 +185,8 @@ type config =
     (** [\[runtime\].hitl_summary] — runtime id for HITL approval context
         summaries. When set, it must resolve to a configured runtime. The HITL
         worker decides native structured vs plain JSON mode at call time, so
-        load-time validation only rejects unknown ids. [None] keeps the legacy
-        structured-judge routing fallback. *)
+        load-time validation only rejects unknown ids. [None] leaves Auto Judge
+        unavailable; it never inherits another subsystem's runtime. *)
   ; cross_verifier_runtime_id : string option
     (** [\[runtime\].cross_verifier] — runtime id for the anti-rationalization
         evaluator (cross-model task verification). The evaluator requests JSON

--- a/test/test_hitl_summary_worker.ml
+++ b/test/test_hitl_summary_worker.ml
@@ -7,6 +7,43 @@ module Runtime_resolved = Masc.Keeper_runtime_resolved
 
 let yojson = testable Yojson.Safe.pretty_print Yojson.Safe.equal
 
+let exact_runtime_id = "local.auto_judge"
+
+let runtime_toml ~hitl_summary =
+  "[providers.local]\n\
+   display-name = \"Local\"\n\
+   protocol = \"ollama-http\"\n\
+   endpoint = \"http://localhost:11434\"\n\
+   \n\
+   [models.auto_judge]\n\
+   api-name = \"auto-judge\"\n\
+   max-context = 4096\n\
+   \n\
+   [models.auto_judge.capabilities]\n\
+   supports-structured-output = true\n\
+   \n\
+   [local.auto_judge]\n\
+   \n\
+   [runtime]\n\
+   default = \"local.auto_judge\"\n\
+   structured_judge = \"local.auto_judge\"\n"
+  ^ if hitl_summary then "hitl_summary = \"local.auto_judge\"\n" else ""
+;;
+
+let with_runtime_config content f =
+  let path = Filename.temp_file "hitl-summary-runtime" ".toml" in
+  let snapshot = Runtime.For_testing.snapshot () in
+  Fun.protect
+    ~finally:(fun () ->
+      Runtime.For_testing.restore snapshot;
+      try Sys.remove path with
+      | Sys_error _ -> ())
+    (fun () ->
+       match Runtime.save_config_text ~runtime_config_path:path content with
+       | Error detail -> failf "runtime config should load: %s" detail
+       | Ok () -> f ())
+;;
+
 let sample_entry : Q.pending_approval =
   { id = "approval-1"
   ; keeper_name = "keeper"
@@ -287,6 +324,36 @@ let test_explicit_body_timeout_forwards_root_clock () =
   | None -> fail "explicit body timeout dropped the root clock"
 ;;
 
+let test_readiness_requires_explicit_dedicated_runtime () =
+  Prompt_registry.set_markdown_dir
+    (Masc_test_deps.source_path "config/prompts");
+  with_runtime_config (runtime_toml ~hitl_summary:false) @@ fun () ->
+  check (option string) "dedicated runtime is absent" None
+    (Runtime.hitl_summary_runtime_id ());
+  check bool "structured judge is not reused" true
+    (Option.is_none (Worker.provider_config_for_summary ()));
+  match Worker.readiness () with
+  | Ok () -> fail "Auto Judge reported ready without [runtime].hitl_summary"
+  | Error detail ->
+    check string
+      "missing dedicated runtime is explicit"
+      "Auto Judge requires an explicit [runtime].hitl_summary runtime"
+      detail
+;;
+
+let test_readiness_selects_exact_dedicated_runtime () =
+  Prompt_registry.set_markdown_dir
+    (Masc_test_deps.source_path "config/prompts");
+  with_runtime_config (runtime_toml ~hitl_summary:true) @@ fun () ->
+  (match Worker.readiness () with
+   | Ok () -> ()
+   | Error detail -> fail detail);
+  match Worker.provider_config_for_summary () with
+  | None -> fail "configured Auto Judge runtime did not resolve"
+  | Some selected ->
+    check string "exact dedicated runtime selected" exact_runtime_id selected.runtime_id
+;;
+
 let () =
   run
     "Hitl_summary_worker"
@@ -341,6 +408,14 @@ let () =
             "explicit body timeout forwards root clock"
             `Quick
             test_explicit_body_timeout_forwards_root_clock
+        ; test_case
+            "readiness requires dedicated runtime"
+            `Quick
+            test_readiness_requires_explicit_dedicated_runtime
+        ; test_case
+            "readiness selects exact dedicated runtime"
+            `Quick
+            test_readiness_selects_exact_dedicated_runtime
         ] )
     ]
 ;;

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -2028,9 +2028,7 @@ let test_hitl_summary_runtime_routing () =
         (option string)
         "saved hitl_summary runtime id"
         (Some "local.summary")
-        (Runtime.hitl_summary_runtime_id ());
-      check string "resolved HITL summary runtime" "local.summary"
-        (Runtime.runtime_id_for_hitl_summary ()));
+        (Runtime.hitl_summary_runtime_id ()));
   with_temp_runtime_toml base (fun path ->
     match
       Runtime.set_runtime_hitl_summary


### PR DESCRIPTION
## What changed

- require Auto Judge to resolve the explicit `[runtime].hitl_summary` binding
- remove the hidden `structured_judge -> librarian -> default` cross-subsystem fallback
- make readiness verify both the Gate judgment prompt and the configured runtime
- delete `Runtime.runtime_id_for_hitl_summary`, leaving the typed optional binding as the routing SSOT
- fail explicitly when Auto Judge is selected without a loaded `hitl_summary` runtime

## Why

Auto Judge must not silently borrow another subsystem's model selection. `runtime.toml` already has a parser-, validator-, dashboard-, and production-backed `hitl_summary` binding, so that explicit binding is authoritative.

This is an independent current-`main` recut. It does not include the blocked global concurrency-cap removal from #24876 and does not depend on #24881.

## Impact

- selecting Auto Judge without `[runtime].hitl_summary` is an explicit readiness error
- clearing the optional binding remains valid configuration, but Auto Judge stays unavailable until it is configured
- no cross-runtime provider/model fallback is introduced
- existing body-timeout behavior and runtime concurrency behavior are outside this PR

## Validation

- `ocamlc -stop-after parsing` on all changed implementation and test files
- `ocamlformat --check` on all changed OCaml files
- `git diff --check`
- fresh full PR CI is the build authority
- residue scan for `runtime_id_for_hitl_summary` and legacy fallback wording