### PR TITLE
fix(gate): report mode-save recovery separately

### DIFF
--- a/dashboard/src/api/dashboard-gate.ts
+++ b/dashboard/src/api/dashboard-gate.ts
@@ -1,7 +1,7 @@
 // MASC Dashboard — Gate / HITL transport and normalization boundary.
 // Public symbols are re-exported from dashboard.ts.
 
-import { get, post, withRetries } from './core'
+import { ApiRequestError, get, post, withRetries } from './core'
 import { isRecord, asBoolean, asInt, asNullableString, asString } from '../components/common/normalize'
 import { asNullableIsoTimestamp, normalizeKeeperApprovalQueueItem } from './board'
 import { normalizeKeeperResolvedApprovalDecision } from '../lib/keeper-approval-decision'
@@ -171,11 +171,119 @@ export interface SetGateModeResponse {
   previous_mode: GateMode | null
   actor: string
   changed_at: string
-  reopened?: number
-  started?: number
-  queued?: number
+  recovery_status: 'completed' | 'failed' | 'not_requested'
+  recovery_error: string | null
+  reopened: number
+  started: number
+  queued: number
+  replaced_read_error?: string
 }
 
-export function setGateMode(mode: GateMode): Promise<SetGateModeResponse> {
-  return post('/api/v1/dashboard/gate/mode', { mode })
+const SET_GATE_MODE_RESPONSE_FIELDS = new Set([
+  'ok',
+  'mode',
+  'previous_mode',
+  'actor',
+  'changed_at',
+  'recovery_status',
+  'recovery_error',
+  'reopened',
+  'started',
+  'queued',
+  'replaced_read_error',
+])
+
+function gateModeProtocolDrift(detail: string): never {
+  throw new ApiRequestError({
+    method: 'POST',
+    path: '/api/v1/dashboard/gate/mode',
+    detail: `invalid Gate mode response: ${detail}`,
+    errorCode: 'protocol_drift',
+  })
+}
+
+function nonNegativeSafeInteger(raw: unknown, field: string): number {
+  if (typeof raw !== 'number' || !Number.isSafeInteger(raw) || raw < 0) {
+    return gateModeProtocolDrift(`${field} must be a non-negative safe integer`)
+  }
+  return raw
+}
+
+function decodeSetGateModeResponse(raw: unknown, requestedMode: GateMode): SetGateModeResponse {
+  if (!isRecord(raw)) return gateModeProtocolDrift('expected an object')
+  const unknownField = Object.keys(raw).find(field => !SET_GATE_MODE_RESPONSE_FIELDS.has(field))
+  if (unknownField) return gateModeProtocolDrift(`unknown field ${unknownField}`)
+  if (raw.ok !== true) return gateModeProtocolDrift('ok must be true')
+
+  const mode = normalizeGateModeValue(raw.mode)
+  if (!mode) return gateModeProtocolDrift('mode is invalid')
+  if (mode !== requestedMode) {
+    return gateModeProtocolDrift(`mode does not match requested mode ${requestedMode}`)
+  }
+
+  const previousMode = raw.previous_mode === null
+    ? null
+    : normalizeGateModeValue(raw.previous_mode)
+  if (previousMode === null && raw.previous_mode !== null) {
+    return gateModeProtocolDrift('previous_mode must be null or a Gate mode')
+  }
+
+  const actor = typeof raw.actor === 'string' ? raw.actor.trim() : ''
+  if (!actor) return gateModeProtocolDrift('actor must be a non-empty string')
+  const changedAt = typeof raw.changed_at === 'string' ? raw.changed_at.trim() : ''
+  if (!changedAt) return gateModeProtocolDrift('changed_at must be a non-empty string')
+
+  const status = raw.recovery_status
+  if (status !== 'completed' && status !== 'failed' && status !== 'not_requested') {
+    return gateModeProtocolDrift('recovery_status is invalid')
+  }
+  const recoveryError = raw.recovery_error === null
+    ? null
+    : typeof raw.recovery_error === 'string' && raw.recovery_error.trim() !== ''
+      ? raw.recovery_error
+      : gateModeProtocolDrift('recovery_error must be null or a non-empty string')
+  const reopened = nonNegativeSafeInteger(raw.reopened, 'reopened')
+  const started = nonNegativeSafeInteger(raw.started, 'started')
+  const queued = nonNegativeSafeInteger(raw.queued, 'queued')
+
+  if (status === 'completed' && (mode !== 'auto_judge' || recoveryError !== null)) {
+    return gateModeProtocolDrift('completed recovery requires auto_judge mode and no error')
+  }
+  if (status === 'failed'
+      && (mode !== 'auto_judge' || recoveryError === null
+        || reopened !== 0 || started !== 0 || queued !== 0)) {
+    return gateModeProtocolDrift('failed recovery requires auto_judge mode, an error, and zero counts')
+  }
+  if (status === 'not_requested'
+      && (mode === 'auto_judge' || recoveryError !== null
+        || reopened !== 0 || started !== 0 || queued !== 0)) {
+    return gateModeProtocolDrift('not_requested recovery requires a non-auto mode and zero outcome')
+  }
+
+  const replacedReadError = raw.replaced_read_error
+  if (replacedReadError !== undefined
+      && (typeof replacedReadError !== 'string' || replacedReadError.trim() === '')) {
+    return gateModeProtocolDrift('replaced_read_error must be a non-empty string when present')
+  }
+
+  return {
+    ok: true,
+    mode,
+    previous_mode: previousMode,
+    actor,
+    changed_at: changedAt,
+    recovery_status: status,
+    recovery_error: recoveryError,
+    reopened,
+    started,
+    queued,
+    ...(typeof replacedReadError === 'string'
+      ? { replaced_read_error: replacedReadError }
+      : {}),
+  }
+}
+
+export async function setGateMode(mode: GateMode): Promise<SetGateModeResponse> {
+  const raw = await post<unknown>('/api/v1/dashboard/gate/mode', { mode })
+  return decodeSetGateModeResponse(raw, mode)
 }

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -1420,27 +1420,112 @@ describe('fetchDashboardGate', () => {
 })
 
 describe('setGateMode', () => {
+  const completedResponse = {
+    ok: true,
+    mode: 'auto_judge',
+    previous_mode: 'manual',
+    actor: 'operator',
+    changed_at: '2026-07-12T00:00:00Z',
+    recovery_status: 'completed',
+    recovery_error: null,
+    reopened: 2,
+    started: 1,
+    queued: 1,
+  } as const
+
   it('posts the exact non-hierarchical Gate mode contract', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({
-        ok: true,
-        mode: 'auto_judge',
-        previous_mode: 'manual',
-        actor: 'operator',
-        changed_at: '2026-07-12T00:00:00Z',
-      }), {
+      new Response(JSON.stringify(completedResponse), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       }),
     )
     vi.stubGlobal('fetch', fetchMock)
 
-    await setGateMode('auto_judge')
+    const result = await setGateMode('auto_judge')
 
     expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/dashboard/gate/mode')
     const init = fetchMock.mock.calls[0]?.[1] as RequestInit
     expect(init.method).toBe('POST')
     expect(JSON.parse(String(init.body))).toEqual({ mode: 'auto_judge' })
+    expect(result).toMatchObject({
+      recovery_status: 'completed',
+      recovery_error: null,
+      reopened: 2,
+      started: 1,
+      queued: 1,
+    })
+  })
+
+  it.each([
+    {
+      label: 'failed recovery',
+      requestedMode: 'auto_judge' as const,
+      response: {
+        ...completedResponse,
+        recovery_status: 'failed',
+        recovery_error: 'judge worker unavailable',
+        reopened: 0,
+        started: 0,
+        queued: 0,
+      },
+    },
+    {
+      label: 'non-auto mode without recovery',
+      requestedMode: 'manual' as const,
+      response: {
+        ...completedResponse,
+        mode: 'manual',
+        recovery_status: 'not_requested',
+        recovery_error: null,
+        reopened: 0,
+        started: 0,
+        queued: 0,
+        replaced_read_error: 'replaced invalid persisted mode',
+      },
+    },
+  ])('decodes $label', async ({ requestedMode, response }) => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(response), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ))
+
+    await expect(setGateMode(requestedMode)).resolves.toMatchObject(response)
+  })
+
+  it.each([
+    ['non-object', null],
+    ['unsuccessful envelope', { ...completedResponse, ok: false }],
+    ['requested mode mismatch', { ...completedResponse, mode: 'manual' }],
+    ['unknown recovery status', { ...completedResponse, recovery_status: 'pending' }],
+    ['completed recovery with error', { ...completedResponse, recovery_error: 'unexpected' }],
+    ['failed recovery without error', {
+      ...completedResponse,
+      recovery_status: 'failed',
+      reopened: 0,
+      started: 0,
+      queued: 0,
+    }],
+    ['negative count', { ...completedResponse, reopened: -1 }],
+    ['non-zero not-requested outcome', {
+      ...completedResponse,
+      recovery_status: 'not_requested',
+    }],
+    ['unknown field', { ...completedResponse, legacy_status: 'ok' }],
+  ])('rejects protocol drift: %s', async (_label, response) => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(response), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ))
+
+    await expect(setGateMode('auto_judge')).rejects.toMatchObject({
+      name: 'ApiRequestError',
+      errorCode: 'protocol_drift',
+    })
   })
 })
 

--- a/dashboard/src/components/approvals/approvals-surface.test.ts
+++ b/dashboard/src/components/approvals/approvals-surface.test.ts
@@ -59,7 +59,18 @@ async function loadSurface(
     .mockResolvedValue({ ok: true, id: 'appr-1' })
   const setGateMode = vi
     .fn()
-    .mockResolvedValue({ ok: true, mode: 'auto_judge', previous_mode: 'manual', actor: 'op', changed_at: '2026-06-19T00:00:00Z' })
+    .mockResolvedValue({
+      ok: true,
+      mode: 'auto_judge',
+      previous_mode: 'manual',
+      actor: 'op',
+      changed_at: '2026-06-19T00:00:00Z',
+      recovery_status: 'completed',
+      recovery_error: null,
+      reopened: 0,
+      started: 0,
+      queued: 0,
+    })
   const response = hitl
     ? responseWithQueue(approval_queue, recent_resolved, approval_rules, hitl)
     : responseWithQueue(approval_queue, recent_resolved, approval_rules)

--- a/dashboard/src/components/gate-actions.test.ts
+++ b/dashboard/src/components/gate-actions.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  refreshGate: vi.fn(),
+  setGateMode: vi.fn(),
+  showToast: vi.fn(),
+}))
+
+vi.mock('./common/toast', () => ({
+  showToast: mocks.showToast,
+}))
+
+vi.mock('../api/dashboard-gate', () => ({
+  deleteGateApprovalRule: vi.fn(),
+  resolveGateApproval: vi.fn(),
+  retryGateAutoJudge: vi.fn(),
+  setGateMode: mocks.setGateMode,
+}))
+
+vi.mock('./gate-refresh', () => ({
+  refreshGate: mocks.refreshGate,
+}))
+
+import { setKeeperGateMode } from './gate-actions'
+import { gateApprovalActing, gateError } from './gate-signals'
+
+const baseResponse = {
+  ok: true,
+  mode: 'auto_judge',
+  previous_mode: 'manual',
+  actor: 'operator',
+  changed_at: '2026-07-16T00:00:00Z',
+  recovery_error: null,
+  reopened: 0,
+  started: 0,
+  queued: 0,
+} as const
+
+beforeEach(() => {
+  mocks.refreshGate.mockReset().mockResolvedValue(undefined)
+  mocks.setGateMode.mockReset()
+  mocks.showToast.mockReset()
+  gateApprovalActing.value = null
+  gateError.value = ''
+})
+
+describe('setKeeperGateMode recovery result', () => {
+  it('keeps the saved mode successful, warns on failed recovery, and refreshes', async () => {
+    mocks.setGateMode.mockResolvedValue({
+      ...baseResponse,
+      recovery_status: 'failed',
+      recovery_error: 'judge worker unavailable',
+    })
+
+    await setKeeperGateMode('auto_judge')
+
+    expect(mocks.showToast).toHaveBeenCalledWith(
+      'Gate 모드를 Auto Judge(으)로 저장했습니다 · Auto Judge backlog recovery 실패: judge worker unavailable',
+      'warning',
+    )
+    expect(mocks.refreshGate).toHaveBeenCalledWith({ force: true })
+    expect(gateError.value).toBe('')
+    expect(gateApprovalActing.value).toBeNull()
+  })
+
+  it('reports completed recovery with every observed count and refreshes', async () => {
+    mocks.setGateMode.mockResolvedValue({
+      ...baseResponse,
+      recovery_status: 'completed',
+      reopened: 2,
+      started: 1,
+      queued: 1,
+    })
+
+    await setKeeperGateMode('auto_judge')
+
+    expect(mocks.showToast).toHaveBeenCalledWith(
+      'Gate 모드를 Auto Judge(으)로 저장했습니다 · Auto Judge backlog recovery 요청 처리 완료'
+      + ' (reopened 2, started 1, queued 1)',
+      'success',
+    )
+    expect(mocks.refreshGate).toHaveBeenCalledWith({ force: true })
+  })
+
+  it('reports that recovery was not requested and refreshes', async () => {
+    mocks.setGateMode.mockResolvedValue({
+      ...baseResponse,
+      mode: 'manual',
+      recovery_status: 'not_requested',
+    })
+
+    await setKeeperGateMode('manual')
+
+    expect(mocks.showToast).toHaveBeenCalledWith(
+      'Gate 모드를 Human(으)로 저장했습니다 · backlog recovery 비적용',
+      'success',
+    )
+    expect(mocks.refreshGate).toHaveBeenCalledWith({ force: true })
+  })
+})

--- a/dashboard/src/components/gate-actions.ts
+++ b/dashboard/src/components/gate-actions.ts
@@ -5,6 +5,7 @@ import {
   retryGateAutoJudge,
   setGateMode,
 } from '../api/dashboard-gate'
+import type { SetGateModeResponse } from '../api/dashboard-gate'
 import type { GateMode } from '../types'
 import { refreshGate } from './gate-refresh'
 import {
@@ -71,20 +72,61 @@ export async function deleteKeeperApprovalRule(id: string) {
 
 export const GATE_MODE_ACTING_KEY = 'gate-mode'
 
+function gateModeLabel(mode: GateMode): string {
+  return mode === 'manual' ? 'Human' : mode === 'auto_judge' ? 'Auto Judge' : 'Always Allow'
+}
+
+function showGateModeSaved(result: SetGateModeResponse): void {
+  const saved = `Gate 모드를 ${gateModeLabel(result.mode)}(으)로 저장했습니다`
+  switch (result.recovery_status) {
+    case 'completed':
+      showToast(
+        `${saved} · Auto Judge backlog recovery 요청 처리 완료`
+        + ` (reopened ${result.reopened.toLocaleString()},`
+        + ` started ${result.started.toLocaleString()},`
+        + ` queued ${result.queued.toLocaleString()})`,
+        'success',
+      )
+      return
+    case 'failed':
+      showToast(
+        `${saved} · Auto Judge backlog recovery 실패:`
+        + ` ${result.recovery_error ?? '상세 오류 없음'}`,
+        'warning',
+      )
+      return
+    case 'not_requested':
+      showToast(`${saved} · backlog recovery 비적용`, 'success')
+      return
+    default: {
+      const unreachable: never = result.recovery_status
+      throw new Error(`unsupported Gate recovery status: ${String(unreachable)}`)
+    }
+  }
+}
+
 export async function setKeeperGateMode(mode: GateMode) {
   gateApprovalActing.value = GATE_MODE_ACTING_KEY
   try {
-    const result = await setGateMode(mode)
-    const label = mode === 'manual' ? 'Human' : mode === 'auto_judge' ? 'Auto Judge' : 'Always Allow'
-    const recovery = mode === 'auto_judge' && (result.reopened ?? 0) > 0
-      ? ` · 실패 ${(result.reopened ?? 0).toLocaleString()}건 재평가 시작`
-      : ''
-    showToast(`Gate 모드를 ${label}(으)로 저장했습니다${recovery}`, 'success')
-    await refreshGate({ force: true })
-  } catch (err) {
-    const message = err instanceof Error ? err.message : 'Gate 모드를 저장하지 못했습니다'
-    gateError.value = message
-    showToast(message, 'error')
+    let result: SetGateModeResponse
+    try {
+      result = await setGateMode(mode)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Gate 모드를 저장하지 못했습니다'
+      gateError.value = message
+      showToast(message, 'error')
+      return
+    }
+
+    showGateModeSaved(result)
+    try {
+      await refreshGate({ force: true })
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : '상세 오류 없음'
+      const message = `Gate 모드는 저장됐지만 새로고침하지 못했습니다: ${detail}`
+      gateError.value = message
+      showToast(message, 'warning')
+    }
   } finally {
     gateApprovalActing.value = null
   }

--- a/lib/keeper/keeper_gate_mode.mli
+++ b/lib/keeper/keeper_gate_mode.mli
@@ -33,4 +33,6 @@ val status_json : base_path:string -> Yojson.Safe.t
 val set :
   Workspace.config -> actor:string -> t -> (change, string) result
 
-val change_json : change -> Yojson.Safe.t
+val change_json : change -> [ `Assoc of (string * Yojson.Safe.t) list ]
+(** Closed object projection; callers can extend its fields without an
+    impossible non-object branch. *)

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -379,6 +379,42 @@ let respond_runtime_config_reload state agent_name ~operation request reqd =
       ~status:(runtime_config_path_error_status msg)
       ~request reqd msg
 
+type gate_mode_recovery =
+  | Recovery_completed of Keeper_gate.operator_recovery_report
+  | Recovery_failed of string
+  | Recovery_not_requested
+
+let gate_mode_change_json change recovery =
+  let recovery_status, recovery_error, reopened, started, queued =
+    match recovery with
+    | Recovery_completed report ->
+      ( "completed"
+      , `Null
+      , List.length report.reopened_ids
+      , List.length report.started_ids
+      , report.queued )
+    | Recovery_failed detail -> "failed", `String detail, 0, 0, 0
+    | Recovery_not_requested -> "not_requested", `Null, 0, 0, 0
+  in
+  let `Assoc fields = Keeper_gate_mode.change_json change in
+  `Assoc
+    (("recovery_status", `String recovery_status)
+     :: ("recovery_error", recovery_error)
+     :: ("reopened", `Int reopened)
+     :: ("started", `Int started)
+     :: ("queued", `Int queued)
+     :: fields)
+;;
+
+module For_testing = struct
+  type nonrec gate_mode_recovery = gate_mode_recovery =
+    | Recovery_completed of Keeper_gate.operator_recovery_report
+    | Recovery_failed of string
+    | Recovery_not_requested
+
+  let gate_mode_change_json = gate_mode_change_json
+end
+
 let handle_gate_mode_body state operator_name request reqd body_str =
   try
     let args = Yojson.Safe.from_string body_str in
@@ -442,35 +478,32 @@ let handle_gate_mode_body state operator_name request reqd body_str =
             let recovery =
               match mode with
               | Keeper_gate_mode.Auto_judge ->
-                Keeper_gate.request_operator_auto_judge_recovery
-                  ~base_path:config.base_path
+                (match
+                   Keeper_gate.request_operator_auto_judge_recovery
+                     ~base_path:config.base_path
+                 with
+                 | Ok report -> Recovery_completed report
+                 | Error detail ->
+                   Log.Dashboard.emit
+                     Log.Warn
+                     ~details:
+                       (`Assoc
+                          [ "event", `String "gate_mode_recovery_failed"
+                          ; "base_path", `String config.base_path
+                          ; "actor", `String operator_name
+                          ; "mode", `String (Keeper_gate_mode.to_string mode)
+                          ; "changed_at", `String change.changed_at
+                          ; "error", `String detail
+                          ])
+                     "Gate mode was saved, but Auto Judge recovery failed";
+                   Recovery_failed detail)
               | Keeper_gate_mode.Manual | Keeper_gate_mode.Always_allow ->
-                Ok
-                  { Keeper_gate.reopened_ids = []
-                  ; started_ids = []
-                  ; queued = 0
-                  }
+                Recovery_not_requested
             in
-            (match recovery with
-             | Error detail ->
-               respond_json_value_with_cors
-                 ~status:`Service_unavailable
-                 request
-                 reqd
-                 (operator_error_json
-                    ("Gate mode saved, but Auto Judge recovery failed: " ^ detail))
-             | Ok recovery ->
             respond_json_value_with_cors
               request
               reqd
-              (match Keeper_gate_mode.change_json change with
-               | `Assoc fields ->
-                 `Assoc
-                   (("reopened", `Int (List.length recovery.reopened_ids))
-                    :: ("started", `Int (List.length recovery.started_ids))
-                    :: ("queued", `Int recovery.queued)
-                    :: fields)
-               | other -> other)))))
+              (gate_mode_change_json change recovery))))
   with
   | Eio.Cancel.Cancelled _ as error -> raise error
   | Yojson.Json_error message ->

--- a/lib/server/server_routes_http_routes_dashboard.mli
+++ b/lib/server/server_routes_http_routes_dashboard.mli
@@ -19,3 +19,13 @@ val ensure_dashboard_dev_token : string -> (string, string) result
     string, generating + persisting one to {!dashboard_dev_token_path}
     on first call. [Error msg] when the auth dir is unwritable. Exposed
     so the dashboard-keeper-routes test can drive the boot path directly. *)
+
+module For_testing : sig
+  type gate_mode_recovery =
+    | Recovery_completed of Keeper_gate.operator_recovery_report
+    | Recovery_failed of string
+    | Recovery_not_requested
+
+  val gate_mode_change_json :
+    Keeper_gate_mode.change -> gate_mode_recovery -> Yojson.Safe.t
+end

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -790,6 +790,62 @@ let test_dashboard_proof_route_registered_in_http_routers () =
   check bool "HTTP/2 dashboard proof route registered" true
     (contains_substring h2 "\"/api/v1/dashboard/proof\"")
 
+let test_gate_mode_change_json_separates_saved_mode_from_recovery () =
+  let open Yojson.Safe.Util in
+  let change : Masc.Keeper_gate_mode.change =
+    { previous = Some Masc.Keeper_gate_mode.Manual
+    ; current = Masc.Keeper_gate_mode.Auto_judge
+    ; actor = "operator"
+    ; changed_at = "2026-07-16T00:00:00Z"
+    ; replaced_read_error = None
+    }
+  in
+  let json recovery =
+    Server_routes_http_routes_dashboard.For_testing.gate_mode_change_json
+      change
+      recovery
+  in
+  let completed =
+    json
+      (Server_routes_http_routes_dashboard.For_testing.Recovery_completed
+         { Masc.Keeper_gate.reopened_ids = [ "approval-1"; "approval-2" ]
+         ; started_ids = [ "approval-1" ]
+         ; queued = 1
+         })
+  in
+  check string "completed status" "completed"
+    (completed |> member "recovery_status" |> to_string);
+  check bool "completed error is null" true
+    (completed |> member "recovery_error" = `Null);
+  check int "completed reopened" 2 (completed |> member "reopened" |> to_int);
+  check int "completed started" 1 (completed |> member "started" |> to_int);
+  check int "completed queued" 1 (completed |> member "queued" |> to_int);
+  let failed =
+    json
+      (Server_routes_http_routes_dashboard.For_testing.Recovery_failed
+         "judge worker unavailable")
+  in
+  check string "failed status" "failed"
+    (failed |> member "recovery_status" |> to_string);
+  check string "failed detail" "judge worker unavailable"
+    (failed |> member "recovery_error" |> to_string);
+  check int "failed reopened" 0 (failed |> member "reopened" |> to_int);
+  check int "failed started" 0 (failed |> member "started" |> to_int);
+  check int "failed queued" 0 (failed |> member "queued" |> to_int);
+  let not_requested =
+    json Server_routes_http_routes_dashboard.For_testing.Recovery_not_requested
+  in
+  check string "not requested status" "not_requested"
+    (not_requested |> member "recovery_status" |> to_string);
+  check bool "not requested error is null" true
+    (not_requested |> member "recovery_error" = `Null);
+  check int "not requested reopened" 0
+    (not_requested |> member "reopened" |> to_int);
+  check int "not requested started" 0
+    (not_requested |> member "started" |> to_int);
+  check int "not requested queued" 0
+    (not_requested |> member "queued" |> to_int)
+
 let test_dashboard_ide_snapshot_json_surfaces_legacy_partition_metadata () =
   with_test_env @@ fun ~env:_ ~sw:_ ~config ->
   Fun.protect
@@ -1918,6 +1974,8 @@ let () =
             test_dashboard_proof_http_json_surfaces_verification_index;
           test_case "proof route registered in HTTP routers" `Quick
             test_dashboard_proof_route_registered_in_http_routers;
+          test_case "Gate mode save reports recovery independently" `Quick
+            test_gate_mode_change_json_separates_saved_mode_from_recovery;
           test_case "IDE snapshot exposes legacy partition metadata" `Quick
             test_dashboard_ide_snapshot_json_surfaces_legacy_partition_metadata;
           test_case "bootstrap omits eager goal tree" `Quick


### PR DESCRIPTION
## What changed

- keep a durably persisted Gate mode change as HTTP 2xx even when subsequent Auto Judge backlog recovery fails
- return typed `recovery_status`, nullable `recovery_error`, and exact `reopened` / `started` / `queued` counts
- decode the 200 response from `unknown` through a closed frontend wire contract with status-specific invariants
- surface protocol drift as `ApiRequestError(errorCode=protocol_drift)` instead of accepting a TypeScript assertion
- remove the backend impossible non-object branch and emit structured recovery-failure observation
- keep the dashboard save action successful, show recovery warnings, and refresh Gate state

## Why

Mode persistence and asynchronous backlog recovery are separate effects. A recovery failure must not misreport the already durable mode write as failed or invite a blind retry, but malformed 2xx payloads must still fail loudly at the frontend transport boundary.

## Validation

- Dashboard `pnpm exec tsc --noEmit --pretty false`
- focused Vitest: `dashboard.test.ts` + `gate-actions.test.ts` — 84 tests passed
- `ocamlc -stop-after parsing` on touched OCaml implementations
- `ocamlformat --check` on changed OCaml files
- `git diff --check`
- full build/test remains PR CI authority

Independent current-main leaf; no dependency on #24881/#24882.