### PR TITLE
refactor(fs): return durable JSONL commit cursor

### DIFF
--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -1770,7 +1770,7 @@ let private_jsonl_append_error_to_string = function
   | Durable_jsonl_append_failed error -> durable_append_error_to_string error
 ;;
 
-let append_private_jsonl_durable_locked_result path suffix =
+let append_private_jsonl_durable_locked_with_end_offset_result path suffix =
   if String.equal suffix ""
      || not (Char.equal suffix.[String.length suffix - 1] '\n')
   then Error Invalid_jsonl_suffix
@@ -1821,7 +1821,13 @@ let append_private_jsonl_durable_locked_result path suffix =
                  ~fd
                  ~original_length
                  suffix
-               |> Result.map_error (fun error -> Durable_jsonl_append_failed error))))))
+               |> Result.map_error (fun error -> Durable_jsonl_append_failed error)
+               |> Result.map (fun () -> original_length + String.length suffix))))))
+;;
+
+let append_private_jsonl_durable_locked_result path suffix =
+  append_private_jsonl_durable_locked_with_end_offset_result path suffix
+  |> Result.map ignore
 ;;
 
 let append_jsonl (path : string) (json : Yojson.Safe.t) : unit =

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -771,6 +771,11 @@ type private_jsonl_append_error =
     is proportional to [suffix], not to historical file size. When the Eio
     filesystem is active, the entire blocking lock/write/fsync transaction runs
     in a system thread so one contended file cannot stop unrelated fibers. *)
+val append_private_jsonl_durable_locked_with_end_offset_result :
+  string -> string -> (int, private_jsonl_append_error) result
+
+(** As {!append_private_jsonl_durable_locked_with_end_offset_result}, discarding
+    the committed newline-end byte offset. *)
 val append_private_jsonl_durable_locked_result :
   string -> string -> (unit, private_jsonl_append_error) result
 

--- a/test/test_fs_compat_durable_append.ml
+++ b/test/test_fs_compat_durable_append.ml
@@ -239,6 +239,23 @@ let test_private_jsonl_append_preserves_complete_history () =
     (Fs_compat.load_file path)
 ;;
 
+let test_private_jsonl_append_returns_committed_end_offset () =
+  let original = "{\"row\":1}\n" in
+  let suffix = "{\"row\":2}\n{\"row\":3}\n" in
+  with_temp_jsonl original @@ fun path ->
+  (match
+     Fs_compat.append_private_jsonl_durable_locked_with_end_offset_result
+       path
+       suffix
+   with
+   | Ok end_offset ->
+     check int
+       "committed newline-end byte offset"
+       (String.length original + String.length suffix)
+       end_offset
+   | Error error -> fail (Fs_compat.private_jsonl_append_error_to_string error))
+;;
+
 let test_private_jsonl_append_rejects_incomplete_tail () =
   with_temp_jsonl "{\"row\":1}" @@ fun path ->
   (match
@@ -287,6 +304,10 @@ let () =
             "private JSONL append preserves complete history"
             `Quick
             test_private_jsonl_append_preserves_complete_history
+        ; test_case
+            "private JSONL append returns committed end offset"
+            `Quick
+            test_private_jsonl_append_returns_committed_end_offset
         ; test_case
             "private JSONL append rejects incomplete tail"
             `Quick


### PR DESCRIPTION
## Summary
- return the exact committed newline-end byte offset from the existing durable private JSONL append transaction
- preserve the existing unit API as a delegating compatibility surface
- add focused proof across a multi-row append

No new storage engine, lock, actor, registry, cache, or production writer is introduced.

## Verification
- `scripts/dune-local.sh build test/test_fs_compat_durable_append.exe`
- `scripts/dune-local.sh exec ./test/test_fs_compat_durable_append.exe` (10/10)
- `ocamlformat --check ...`
- `git diff --check`