### PR TITLE
refactor(auth)!: delete root outcome shadow

### DIFF
--- a/lib/silent_dashboard_actor_outcome.ml
+++ b/lib/silent_dashboard_actor_outcome.ml
@@ -1,8 +1,0 @@
-type t =
-  | None_resolved
-  | Error_classified
-
-let to_label = function
-  | None_resolved -> "none"
-  | Error_classified -> "error"
-;;

--- a/test/test_auth_error_kind_dashboard_fallback.ml
+++ b/test/test_auth_error_kind_dashboard_fallback.ml
@@ -2,7 +2,7 @@
 
 open Alcotest
 module Aek = Auth_error_kind
-module Sda = Masc.Silent_dashboard_actor_outcome
+module Sda = Silent_dashboard_actor_outcome
 
 let with_eio_runtime f =
   Eio_main.run @@ fun _env -> f ()


### PR DESCRIPTION
## What changed

- delete the root silent_dashboard_actor_outcome implementation copy
- make the focused fallback test consume the existing masc.auth leaf module directly
- add no facade, alias, migration, fallback, or second implementation

## Why

The root copy had no production consumer and existed only to preserve Masc.Silent_dashboard_actor_outcome in one test. Keeping a compatibility facade would retain an unnecessary public shadow and violate the single-writer hard-cut contract in #24884.

The leaf masc.auth module remains the sole implementation and Auth_error_kind already consumes it directly.

## Verification

- opam exec -- ocamlformat --check test/test_auth_error_kind_dashboard_fallback.ml
- scripts/dune-local.sh build test/test_auth_error_kind_dashboard_fallback.exe
- focused executable: 5/5 passed
- git diff --check

Supersedes #24866 with the minimal hard cut.