### PR TITLE
fix(keeper): dispatch Board attention per Keeper lane

### DIFF
--- a/lib/keeper/keeper_board_attention_candidate.ml
+++ b/lib/keeper/keeper_board_attention_candidate.ml
@@ -880,29 +880,30 @@ type scheduled_work =
   ; candidate : candidate
   }
 
-let max_scheduled_workspace_queue = 1
-let scheduled_work = Eio.Stream.create max_scheduled_workspace_queue
+let max_scheduled_keeper_queue = 1
+let scheduled_work = Eio.Stream.create max_scheduled_keeper_queue
 let worker_running = Atomic.make false
-let active_workspaces = Atomic.make Active_set.empty
+let active_keepers = Atomic.make Active_set.empty
 
-let active_key ~base_path = base_path
+let active_key ~base_path ~keeper_name =
+  Keeper_registry_types.registry_key ~base_path keeper_name
 ;;
 
 let rec claim_active key =
-  let current = Atomic.get active_workspaces in
+  let current = Atomic.get active_keepers in
   if Active_set.mem key current
   then false
-  else if Atomic.compare_and_set active_workspaces current (Active_set.add key current)
+  else if Atomic.compare_and_set active_keepers current (Active_set.add key current)
   then true
   else claim_active key
 ;;
 
 let rec release_active key =
-  let current = Atomic.get active_workspaces in
+  let current = Atomic.get active_keepers in
   if not (Active_set.mem key current)
   then ()
   else if
-    Atomic.compare_and_set active_workspaces current (Active_set.remove key current)
+    Atomic.compare_and_set active_keepers current (Active_set.remove key current)
   then ()
   else release_active key
 ;;
@@ -928,25 +929,36 @@ let observe_worker_failure ~base_path candidate kind detail =
       storage_detail
 ;;
 
+let run_in_keeper_lane ~base_path ~keeper_name f =
+  match Keeper_turn_admission.run_if_free ~base_path ~keeper_name f with
+  | `Ran value -> `Ran value
+  | `Busy _ -> `Busy
+;;
+
 let process_scheduled_work ~sw ~net { base_path; candidate } =
-  let key = active_key ~base_path in
+  let key = active_key ~base_path ~keeper_name:candidate.keeper_name in
   Fun.protect
     ~finally:(fun () -> release_active key)
     (fun () ->
        try
-         match
+         match run_in_keeper_lane ~base_path ~keeper_name:candidate.keeper_name (fun () ->
            process_with_judge
              ~base_path
              ~judge:(run_judge ~sw ~net ~base_path)
-             candidate
+             candidate)
          with
-         | Ok _ -> ()
-         | Error detail ->
+         | `Ran (Ok _) -> ()
+         | `Ran (Error detail) ->
            observe_worker_failure
              ~base_path
              candidate
              Worker_unavailable
              detail
+         | `Busy ->
+           Log.Keeper.debug
+             "Board attention judgment deferred to busy Keeper lane keeper=%s candidate=%s"
+             candidate.keeper_name
+             candidate.candidate_id
        with
        | Eio.Cancel.Cancelled _ as exn -> raise exn
        | exn ->
@@ -961,12 +973,29 @@ let run_worker ~sw ~net () =
   if not (Atomic.compare_and_set worker_running false true)
   then Log.Keeper.warn "Board attention worker already running"
   else (
-    Log.Keeper.info "Board attention worker started (global concurrency=1)";
+    Log.Keeper.info "Board attention dispatcher started (lane per Keeper)";
     Fun.protect
       ~finally:(fun () -> Atomic.set worker_running false)
       (fun () ->
          while true do
-           Eio.Stream.take scheduled_work |> process_scheduled_work ~sw ~net
+           let work = Eio.Stream.take scheduled_work in
+           (try Eio.Fiber.fork ~sw (fun () -> process_scheduled_work ~sw ~net work) with
+            | Eio.Cancel.Cancelled _ as exn ->
+              release_active
+                (active_key
+                   ~base_path:work.base_path
+                   ~keeper_name:work.candidate.keeper_name);
+              raise exn
+            | exn ->
+              release_active
+                (active_key
+                   ~base_path:work.base_path
+                   ~keeper_name:work.candidate.keeper_name);
+              observe_worker_failure
+                ~base_path:work.base_path
+                work.candidate
+                Worker_unavailable
+                (Printexc.to_string exn))
          done))
 ;;
 
@@ -974,7 +1003,7 @@ let schedule ~base_path candidate =
   match candidate.status with
   | Consumed _ -> false
   | Pending _ | Judged _ ->
-    let key = active_key ~base_path in
+    let key = active_key ~base_path ~keeper_name:candidate.keeper_name in
     if not (Atomic.get worker_running)
     then (
       observe_worker_failure
@@ -1024,3 +1053,7 @@ let resume_pending ~base_path ~keeper_name =
   in
   Ok started
 ;;
+
+module For_testing = struct
+  let run_in_keeper_lane = run_in_keeper_lane
+end

--- a/lib/keeper/keeper_board_attention_candidate.ml
+++ b/lib/keeper/keeper_board_attention_candidate.ml
@@ -802,7 +802,7 @@ let reject_unregistered_tool ~name ~args:_ =
     "Board attention judgment is a tool-free boundary"
 ;;
 
-let run_judge ~base_path candidate =
+let run_judge ~sw ~net ~base_path candidate =
   let runtime_id_result =
     try Ok (Runtime.runtime_id_for_structured_judge ()) with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
@@ -826,6 +826,8 @@ let run_judge ~base_path candidate =
                ~keeper_name:candidate.keeper_name
                ~goal:prompt
                ~base_path
+               ~sw
+               ~net
                ~masc_tools:[]
                ~dispatch:reject_unregistered_tool
                ~provider_config_transform:apply_output_schema
@@ -873,31 +875,33 @@ let rec process_with_judge ~base_path ~judge candidate =
        process_with_judge ~base_path ~judge current)
 ;;
 
-let process ~base_path candidate =
-  process_with_judge ~base_path ~judge:(run_judge ~base_path) candidate
-;;
+type scheduled_work =
+  { base_path : string
+  ; candidate : candidate
+  }
 
-let active_candidates = Atomic.make Active_set.empty
+let scheduled_work = Eio.Stream.create max_int
+let worker_running = Atomic.make false
+let active_workspaces = Atomic.make Active_set.empty
 
-let active_key ~base_path candidate =
-  String.concat "\031" [ base_path; candidate.keeper_name; candidate.candidate_id ]
+let active_key ~base_path = base_path
 ;;
 
 let rec claim_active key =
-  let current = Atomic.get active_candidates in
+  let current = Atomic.get active_workspaces in
   if Active_set.mem key current
   then false
-  else if Atomic.compare_and_set active_candidates current (Active_set.add key current)
+  else if Atomic.compare_and_set active_workspaces current (Active_set.add key current)
   then true
   else claim_active key
 ;;
 
 let rec release_active key =
-  let current = Atomic.get active_candidates in
+  let current = Atomic.get active_workspaces in
   if not (Active_set.mem key current)
   then ()
   else if
-    Atomic.compare_and_set active_candidates current (Active_set.remove key current)
+    Atomic.compare_and_set active_workspaces current (Active_set.remove key current)
   then ()
   else release_active key
 ;;
@@ -923,59 +927,79 @@ let observe_worker_failure ~base_path candidate kind detail =
       storage_detail
 ;;
 
-let start_async ~base_path candidate =
+let process_scheduled_work ~sw ~net { base_path; candidate } =
+  let key = active_key ~base_path in
+  Fun.protect
+    ~finally:(fun () -> release_active key)
+    (fun () ->
+       try
+         match
+           process_with_judge
+             ~base_path
+             ~judge:(run_judge ~sw ~net ~base_path)
+             candidate
+         with
+         | Ok _ -> ()
+         | Error detail ->
+           observe_worker_failure
+             ~base_path
+             candidate
+             Worker_unavailable
+             detail
+       with
+       | Eio.Cancel.Cancelled _ as exn -> raise exn
+       | exn ->
+         observe_worker_failure
+           ~base_path
+           candidate
+           Worker_unavailable
+           (Printexc.to_string exn))
+;;
+
+let run_worker ~sw ~net () =
+  if not (Atomic.compare_and_set worker_running false true)
+  then Log.Keeper.warn "Board attention worker already running"
+  else (
+    Log.Keeper.info "Board attention worker started (global concurrency=1)";
+    Fun.protect
+      ~finally:(fun () -> Atomic.set worker_running false)
+      (fun () ->
+         while true do
+           Eio.Stream.take scheduled_work |> process_scheduled_work ~sw ~net
+         done))
+;;
+
+let schedule ~base_path candidate =
   match candidate.status with
   | Consumed _ -> false
   | Pending _ | Judged _ ->
-    let key = active_key ~base_path candidate in
-    if not (claim_active key)
+    let key = active_key ~base_path in
+    if not (Atomic.get worker_running)
+    then (
+      observe_worker_failure
+        ~base_path
+        candidate
+        Worker_unavailable
+        "Board attention worker is not running";
+      false)
+    else if not (claim_active key)
     then false
     else (
-      match Eio_context.get_root_switch_opt () with
-      | None ->
+      try
+        Eio.Stream.add scheduled_work { base_path; candidate };
+        true
+      with
+      | Eio.Cancel.Cancelled _ as exn ->
+        release_active key;
+        raise exn
+      | exn ->
         release_active key;
         observe_worker_failure
           ~base_path
           candidate
           Worker_unavailable
-          "server root switch is not installed";
-        false
-      | Some sw ->
-        (try
-           Eio.Fiber.fork ~sw (fun () ->
-             Fun.protect
-               ~finally:(fun () -> release_active key)
-               (fun () ->
-                  try
-                    match process ~base_path candidate with
-                    | Ok _ -> ()
-                    | Error detail ->
-                      observe_worker_failure
-                        ~base_path
-                        candidate
-                        Worker_unavailable
-                        detail
-                  with
-                  | Eio.Cancel.Cancelled _ as exn -> raise exn
-                  | exn ->
-                    observe_worker_failure
-                      ~base_path
-                      candidate
-                      Worker_unavailable
-                      (Printexc.to_string exn)));
-           true
-         with
-         | Eio.Cancel.Cancelled _ as exn ->
-           release_active key;
-           raise exn
-         | exn ->
-           release_active key;
-           observe_worker_failure
-             ~base_path
-             candidate
-             Worker_unavailable
-             (Printexc.to_string exn);
-           false))
+          (Printexc.to_string exn);
+        false)
 ;;
 
 let record_and_start ~base_path candidate =
@@ -983,8 +1007,8 @@ let record_and_start ~base_path candidate =
   | Record_error detail -> Error detail
   | Recorded persisted | Duplicate persisted ->
     (* The durable candidate is the authority. Worker startup is best-effort
-       scheduling only; [start_async] records every startup failure itself. *)
-    let (_worker_started : bool) = start_async ~base_path persisted in
+       scheduling only; [schedule] records every scheduling failure itself. *)
+    let (_worker_started : bool) = schedule ~base_path persisted in
     Ok persisted
 ;;
 
@@ -993,7 +1017,7 @@ let resume_pending ~base_path ~keeper_name =
   let started =
     List.fold_left
       (fun count candidate ->
-         if start_async ~base_path candidate then count + 1 else count)
+         if schedule ~base_path candidate then count + 1 else count)
       0
       candidates
   in

--- a/lib/keeper/keeper_board_attention_candidate.ml
+++ b/lib/keeper/keeper_board_attention_candidate.ml
@@ -880,7 +880,8 @@ type scheduled_work =
   ; candidate : candidate
   }
 
-let scheduled_work = Eio.Stream.create max_int
+let max_scheduled_workspace_queue = 1
+let scheduled_work = Eio.Stream.create max_scheduled_workspace_queue
 let worker_running = Atomic.make false
 let active_workspaces = Atomic.make Active_set.empty
 

--- a/lib/keeper/keeper_board_attention_candidate.mli
+++ b/lib/keeper/keeper_board_attention_candidate.mli
@@ -113,9 +113,10 @@ val process_with_judge :
     judge through {!record_and_start} and {!resume_pending}. *)
 
 val run_worker : sw:Eio.Switch.t -> net:Eio_context.eio_net -> unit -> unit
-(** Run the process-lifetime Board-attention judgment consumer. The caller must
-    pass the Eio capabilities owned by the server domain. Work submission is
-    cross-domain safe and globally serialized. *)
+(** Run the process-lifetime Board-attention dispatcher. The caller must pass
+    the Eio capabilities owned by the server domain. Cross-domain submissions
+    are transferred to server-owned fibers, while judgment execution remains
+    isolated by the candidate's Keeper turn lane. *)
 
 val record_and_start :
   base_path:string -> candidate -> (candidate, string) result
@@ -126,3 +127,11 @@ val resume_pending :
   base_path:string -> keeper_name:string -> (int, string) result
 (** Asynchronously retries every non-consumed candidate in this Keeper lane.
     The returned count is observability only and never limits retries. *)
+
+module For_testing : sig
+  val run_in_keeper_lane :
+    base_path:string ->
+    keeper_name:string ->
+    (unit -> 'a) ->
+    [ `Ran of 'a | `Busy ]
+end

--- a/lib/keeper/keeper_board_attention_candidate.mli
+++ b/lib/keeper/keeper_board_attention_candidate.mli
@@ -112,6 +112,11 @@ val process_with_judge :
 (** Testable state-machine boundary. Production uses the configured structured
     judge through {!record_and_start} and {!resume_pending}. *)
 
+val run_worker : sw:Eio.Switch.t -> net:Eio_context.eio_net -> unit -> unit
+(** Run the process-lifetime Board-attention judgment consumer. The caller must
+    pass the Eio capabilities owned by the server domain. Work submission is
+    cross-domain safe and globally serialized. *)
+
 val record_and_start :
   base_path:string -> candidate -> (candidate, string) result
 (** Returns after the Pending row is durably committed. Worker availability or

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -1416,6 +1416,9 @@ let start_keeper_loops_owned
       ());
   fork_subsystem "session_cleanup" (fun () ->
     Session.start_mcp_session_cleanup_loop ~sw ~clock ());
+  fork_subsystem
+    "keeper_board_attention_worker"
+    (fun () -> Keeper_board_attention_candidate.run_worker ~sw ~net ());
   (* No verification_timeout fork: RFC-0220 §11 PR-3 deleted the sweep —
      the wall-clock deadline rescue was removed in §5 and the fork had been
      spinning on a no-op since PR-1. *)

--- a/test/test_keeper_board_attention_candidate.ml
+++ b/test/test_keeper_board_attention_candidate.ml
@@ -176,6 +176,26 @@ let test_record_dedupes_exact_candidate_identity () =
   ignore (only_loaded ~base_path ~keeper_name:first.keeper_name : A.candidate)
 ;;
 
+let test_record_and_start_retains_pending_when_worker_is_unavailable () =
+  with_temp_base "keeper-board-attention-worker-unavailable" @@ fun base_path ->
+  let recorded =
+    match A.record_and_start ~base_path (candidate ()) with
+    | Ok candidate -> candidate
+    | Error detail -> Alcotest.failf "record_and_start failed: %s" detail
+  in
+  let current = only_loaded ~base_path ~keeper_name:recorded.keeper_name in
+  match current.status with
+  | A.Pending
+      { last_failure = Some { kind = A.Worker_unavailable; detail; _ } } ->
+    Alcotest.(check string)
+      "worker startup failure is explicit"
+      "Board attention worker is not running"
+      detail
+  | A.Pending { last_failure = None } | A.Pending { last_failure = Some _ }
+  | A.Judged _ | A.Consumed _ ->
+    Alcotest.fail "worker startup failure did not remain durably Pending"
+;;
+
 let test_retryable_judge_failure_remains_pending () =
   with_temp_base "keeper-board-attention-retry" @@ fun base_path ->
   let pending = record_or_fail ~base_path (candidate ()) in
@@ -354,6 +374,10 @@ let () =
             "record dedupes exact candidate identity"
             `Quick
             test_record_dedupes_exact_candidate_identity
+        ; Alcotest.test_case
+            "record_and_start retains Pending without worker"
+            `Quick
+            test_record_and_start_retains_pending_when_worker_is_unavailable
         ; Alcotest.test_case
             "retryable judge failure remains Pending"
             `Quick

--- a/test/test_keeper_board_attention_candidate.ml
+++ b/test/test_keeper_board_attention_candidate.ml
@@ -1,4 +1,5 @@
 module A = Masc.Keeper_board_attention_candidate
+module Admission = Masc.Keeper_turn_admission
 module J = Masc.Keeper_board_attention_judgment
 
 let rec remove_tree path =
@@ -196,6 +197,47 @@ let test_record_and_start_retains_pending_when_worker_is_unavailable () =
     Alcotest.fail "worker startup failure did not remain durably Pending"
 ;;
 
+let test_judgment_execution_is_isolated_per_keeper_lane () =
+  with_temp_base "keeper-board-attention-lanes" @@ fun base_path ->
+  Admission.For_testing.reset ();
+  Fun.protect
+    ~finally:(fun () -> Admission.For_testing.reset ())
+    (fun () ->
+       Eio_main.run @@ fun _env ->
+       Eio.Switch.run @@ fun sw ->
+       let entered, signal_entered = Eio.Promise.create () in
+       let release, signal_release = Eio.Promise.create () in
+       Eio.Fiber.fork ~sw (fun () ->
+         match
+           A.For_testing.run_in_keeper_lane
+             ~base_path
+             ~keeper_name:"sangsu"
+             (fun () ->
+                Eio.Promise.resolve signal_entered ();
+                Eio.Promise.await release)
+         with
+         | `Ran () -> ()
+         | `Busy -> Alcotest.fail "first Keeper lane was unexpectedly busy");
+       Eio.Promise.await entered;
+       (match
+          A.For_testing.run_in_keeper_lane
+            ~base_path
+            ~keeper_name:"sangsu"
+            (fun () -> ())
+        with
+        | `Busy -> ()
+        | `Ran () -> Alcotest.fail "same Keeper admitted concurrent judgment");
+       (match
+          A.For_testing.run_in_keeper_lane
+            ~base_path
+            ~keeper_name:"rondo"
+            (fun () -> ())
+        with
+        | `Ran () -> ()
+        | `Busy -> Alcotest.fail "independent Keeper lane was globally blocked");
+       Eio.Promise.resolve signal_release ())
+;;
+
 let test_retryable_judge_failure_remains_pending () =
   with_temp_base "keeper-board-attention-retry" @@ fun base_path ->
   let pending = record_or_fail ~base_path (candidate ()) in
@@ -378,6 +420,10 @@ let () =
             "record_and_start retains Pending without worker"
             `Quick
             test_record_and_start_retains_pending_when_worker_is_unavailable
+        ; Alcotest.test_case
+            "judgment execution is isolated per Keeper lane"
+            `Quick
+            test_judgment_execution_is_isolated_per_keeper_lane
         ; Alcotest.test_case
             "retryable judge failure remains Pending"
             `Quick


### PR DESCRIPTION
## What changed

- Move Board-attention work submission onto a server-owned, cross-domain-safe dispatcher.
- Pass the server-owned Eio switch and network capability explicitly into the structured judge.
- Dispatch provider work in independent fibers keyed by exact workspace + Keeper identity.
- Admit each judgment through that Keeper lane with `Keeper_turn_admission.run_if_free`.
- Keep the durable candidate ledger as the execution/retry authority; a busy Keeper lane leaves the candidate pending for the next normal `resume_pending` pass.
- Use a bounded capacity-1 transfer mailbox. The dispatcher only transfers work to Keeper-owned fibers; it does not run or globally serialize provider calls.
- Preserve explicit `Worker_unavailable` evidence when the dispatcher is not running.

## Why

After #24879 moved first Board observation to the exact origin, persisted history replay could schedule many structured judgments from domains that did not own the server root switch. Live symptoms included `Switch accessed from wrong domain`, provider request fanout, HTTP timeouts, and high CPU.

The first revision removed the cross-domain exception but incorrectly executed every provider call in one global worker. This revision keeps the capability fix while restoring Lane Per Keeper isolation: one Keeper cannot run overlapping judgments, and a blocked Keeper does not block another Keeper.

The future MASC Operation Journal hard cut documented by #24884 is not yet available on `main`; this patch does not invent a second writer. The existing durable candidate JSONL remains the restart/retry SSOT, and relevant judgments still commit exact candidate identity into the Keeper event queue before consumption.

## Validation

- `scripts/dune-local.sh build test/test_keeper_board_attention_candidate.exe bin/main_eio.exe`
- `./_build/default/test/test_keeper_board_attention_candidate.exe` — 10/10 pass
- new regression: same Keeper lane rejects concurrent judgment while a different Keeper lane remains runnable
- `bash scripts/ci/check-stream-create-bounded.sh` — 17 call sites verified
- `ocamlformat --check` on all changed OCaml files
- `git diff --check`

## Follow-ups

- #24893: bound/compact candidate JSONL replay cost separately
- #24894: repair MCP harness auth-header lifetime

Draft PR. Full CI remains authoritative.