### PR TITLE
feat(keeper): add canonical checkpoint identity

### DIFF
--- a/lib/keeper_checkpoint_ref/dune
+++ b/lib/keeper_checkpoint_ref/dune
@@ -1,0 +1,8 @@
+(include_subdirs no)
+
+(library
+ (name masc_keeper_checkpoint_ref)
+ (public_name masc.keeper_checkpoint_ref)
+ (wrapped false)
+ (modules keeper_checkpoint_ref)
+ (libraries digestif masc.keeper_registry))

--- a/lib/keeper_checkpoint_ref/keeper_checkpoint_ref.ml
+++ b/lib/keeper_checkpoint_ref/keeper_checkpoint_ref.ml
@@ -1,0 +1,48 @@
+type t =
+  { trace_id : Keeper_id.Trace_id.t
+  ; generation : int
+  ; turn_count : int
+  ; sha256 : string
+  }
+
+type create_error =
+  | Negative_generation of int
+  | Negative_turn_count of int
+  | Invalid_sha256 of string
+
+let validate_coordinates ~generation ~turn_count =
+  if generation < 0
+  then Error (Negative_generation generation)
+  else if turn_count < 0
+  then Error (Negative_turn_count turn_count)
+  else Ok ()
+;;
+
+let create ~trace_id ~generation ~turn_count ~canonical_checkpoint_bytes =
+  match validate_coordinates ~generation ~turn_count with
+  | Error _ as error -> error
+  | Ok () ->
+    Ok
+      { trace_id
+      ; generation
+      ; turn_count
+      ; sha256 = Digestif.SHA256.(digest_string canonical_checkpoint_bytes |> to_hex)
+      }
+;;
+
+let of_persisted ~trace_id ~generation ~turn_count ~sha256 =
+  match validate_coordinates ~generation ~turn_count with
+  | Error _ as error -> error
+  | Ok () ->
+    (match Digestif.SHA256.consistent_of_hex_opt sha256 with
+     | Some digest when String.equal sha256 (Digestif.SHA256.to_hex digest) ->
+       Ok { trace_id; generation; turn_count; sha256 }
+     | Some _ | None -> Error (Invalid_sha256 sha256))
+;;
+
+let equal left right =
+  Keeper_id.Trace_id.equal left.trace_id right.trace_id
+  && Int.equal left.generation right.generation
+  && Int.equal left.turn_count right.turn_count
+  && String.equal left.sha256 right.sha256
+;;

--- a/lib/keeper_checkpoint_ref/keeper_checkpoint_ref.mli
+++ b/lib/keeper_checkpoint_ref/keeper_checkpoint_ref.mli
@@ -1,0 +1,32 @@
+(** Exact identity of one canonical Keeper checkpoint payload. *)
+type t = private
+  { trace_id : Keeper_id.Trace_id.t
+  ; generation : int
+  ; turn_count : int
+  ; sha256 : string
+  }
+
+type create_error =
+  | Negative_generation of int
+  | Negative_turn_count of int
+  | Invalid_sha256 of string
+
+val create
+  :  trace_id:Keeper_id.Trace_id.t
+  -> generation:int
+  -> turn_count:int
+  -> canonical_checkpoint_bytes:string
+  -> (t, create_error) result
+(** Hashes the supplied canonical bytes exactly; no JSON decode or re-encoding
+    occurs at this identity boundary. *)
+
+val of_persisted
+  :  trace_id:Keeper_id.Trace_id.t
+  -> generation:int
+  -> turn_count:int
+  -> sha256:string
+  -> (t, create_error) result
+(** Restores an identity from its canonical lowercase SHA-256 projection.
+    Non-canonical or malformed digests are rejected. *)
+
+val equal : t -> t -> bool

--- a/test/keeper_checkpoint_ref/dune
+++ b/test/keeper_checkpoint_ref/dune
@@ -1,0 +1,3 @@
+(test
+ (name test_keeper_checkpoint_ref)
+ (libraries alcotest masc.keeper_checkpoint_ref masc.keeper_registry))

--- a/test/keeper_checkpoint_ref/test_keeper_checkpoint_ref.ml
+++ b/test/keeper_checkpoint_ref/test_keeper_checkpoint_ref.ml
@@ -1,0 +1,89 @@
+let result_ok = function
+  | Ok value -> value
+  | Error _ -> Alcotest.fail "checkpoint identity construction failed"
+;;
+
+let trace_id =
+  match Keeper_id.Trace_id.of_string "trace-1" with
+  | Ok value -> value
+  | Error detail -> Alcotest.fail detail
+;;
+
+let create bytes =
+  Keeper_checkpoint_ref.create
+    ~trace_id
+    ~generation:2
+    ~turn_count:7
+    ~canonical_checkpoint_bytes:bytes
+  |> result_ok
+;;
+
+let test_exact_bytes_identity () =
+  let first = create {|{"messages":["before"]}|} in
+  let same = create {|{"messages":["before"]}|} in
+  let changed = create {|{ "messages": ["before"] }|} in
+  Alcotest.(check bool) "same exact bytes" true (Keeper_checkpoint_ref.equal first same);
+  Alcotest.(check bool) "re-encoded bytes differ" false (Keeper_checkpoint_ref.equal first changed);
+  Alcotest.(check string) "typed trace" "trace-1" (Keeper_id.Trace_id.to_string first.trace_id);
+  Alcotest.(check int) "generation" 2 first.generation;
+  Alcotest.(check int) "turn count" 7 first.turn_count
+;;
+
+let test_typed_rejections () =
+  let make generation turn_count =
+    Keeper_checkpoint_ref.create
+      ~trace_id
+      ~generation
+      ~turn_count
+      ~canonical_checkpoint_bytes:"{}"
+  in
+  Alcotest.(check bool)
+    "negative generation"
+    true
+    (match make (-1) 0 with
+     | Error (Keeper_checkpoint_ref.Negative_generation (-1)) -> true
+     | Ok _ | Error _ -> false);
+  Alcotest.(check bool)
+    "negative turn"
+    true
+    (match make 0 (-2) with
+     | Error (Keeper_checkpoint_ref.Negative_turn_count (-2)) -> true
+     | Ok _ | Error _ -> false)
+;;
+
+let test_persisted_roundtrip_is_canonical () =
+  let expected = create {|{"messages":["before"]}|} in
+  let restore sha256 =
+    Keeper_checkpoint_ref.of_persisted
+      ~trace_id
+      ~generation:expected.generation
+      ~turn_count:expected.turn_count
+      ~sha256
+  in
+  (match restore expected.sha256 with
+   | Ok restored ->
+     Alcotest.(check bool)
+       "restored identity"
+       true
+       (Keeper_checkpoint_ref.equal expected restored)
+   | Error _ -> Alcotest.fail "canonical persisted identity was rejected");
+  List.iter
+    (fun sha256 ->
+       match restore sha256 with
+       | Error (Keeper_checkpoint_ref.Invalid_sha256 _) -> ()
+       | Ok _ | Error _ -> Alcotest.fail "non-canonical digest was accepted")
+    [ String.uppercase_ascii expected.sha256; String.sub expected.sha256 0 62; " " ^ expected.sha256 ]
+;;
+
+let () =
+  Alcotest.run
+    "keeper checkpoint ref"
+    [ ( "identity"
+      , [ Alcotest.test_case "exact bytes" `Quick test_exact_bytes_identity
+        ; Alcotest.test_case "typed rejections" `Quick test_typed_rejections
+        ; Alcotest.test_case
+            "persisted canonical roundtrip"
+            `Quick
+            test_persisted_roundtrip_is_canonical
+        ] )
+    ]


### PR DESCRIPTION
## Outcome

Adds one shared, immutable `Keeper_checkpoint_ref` leaf for checkpoint CAS and the future Keeper operation journal.

- typed `Trace_id`, generation, turn count, and SHA-256
- SHA-256 is computed from the exact supplied canonical bytes; no JSON decode/re-encode
- persisted replay restores only a validated canonical lowercase SHA-256 digest
- closed construction errors for negative generation/turn count and malformed/non-canonical digests
- private read-only fields and equality
- 180 inserted lines; no runtime wiring, journal writer, projection, or compatibility path

This removes the risk of checkpoint CAS and the operation journal inventing parallel checkpoint identities or duplicate digest codecs.

## Verification

- focused library/test build passed after rebasing latest `origin/main`
- focused Alcotest: 3/3 passed
- `ocamlformat --check` and `git diff --check` passed

Full CI remains authoritative.