### PR TITLE
feat(keeper): add exact checkpoint source CAS

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -90,6 +90,7 @@
   ;; RFC-0056 Phase 1N — Keeper_state_* deterministic FSM cluster extracted to
   ;; lib/keeper_state/. Parent still references bare Keeper_state_* modules.
   masc.keeper_registry
+  masc.keeper_checkpoint_ref
   ;; Keeper-owned pure/type leaves extracted from lib/keeper/.
   masc.keeper_contract
   masc.keeper_hooks_oas_types

--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -39,10 +39,12 @@ let max_oas_history_retained = 12
 let oas_history_path ~(session_dir : string) ~(snapshot_id : string) =
   Filename.concat session_dir snapshot_id
 
+let keeper_generation_context_key = "keeper_generation"
+
 let keeper_generation_of_context (context : Agent_sdk.Context.t) : int =
   match
     Agent_sdk.Context.get_scoped context Agent_sdk.Context.Session
-      "keeper_generation"
+      keeper_generation_context_key
   with
   | Some (`Int n) -> n
   | Some (`Intlit raw) -> Option.value ~default:0 (int_of_string_opt raw)
@@ -347,7 +349,7 @@ let archive_oas_history_best_effort ~session_dir ckpt =
         ]
       ()
 
-let load_canonical_strict path =
+let load_canonical_bytes_strict path =
   let unix_error error operation argument =
     Io_error
       (Printf.sprintf "%s(%s): %s"
@@ -382,14 +384,23 @@ let load_canonical_strict path =
          Error (unix_error error operation argument))
   in
   match Eio_guard.run_in_systhread read with
-  | Ok None -> Ok None
+  | Ok content -> Ok content
   | Error _ as error -> error
-  | Ok (Some content) ->
-    (match Agent_sdk.Checkpoint.of_string content with
-     | Ok checkpoint -> Ok (Some checkpoint)
-     | Error error -> Error (classify_sdk_error error))
   | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
   | exception exn -> Error (Io_error (Printexc.to_string exn))
+
+let load_canonical_bytes_and_checkpoint_strict path =
+  match load_canonical_bytes_strict path with
+  | Error _ as error -> error
+  | Ok None -> Ok None
+  | Ok (Some content) ->
+    (match Agent_sdk.Checkpoint.of_string content with
+     | Ok checkpoint -> Ok (Some (content, checkpoint))
+     | Error error -> Error (classify_sdk_error error))
+
+let load_canonical_strict path =
+  load_canonical_bytes_and_checkpoint_strict path
+  |> Result.map (Option.map snd)
 
 (* masc P0 perf fix (checkpoint save-path read-modify-write): a prior
    revision of this fix cached the watermark in a process-local Hashtbl.
@@ -561,6 +572,197 @@ let known_watermark ~canonical_path
        full_parse_fallback ~canonical_path ~sidecar_path ~reason:Fingerprint_mismatch
      | None ->
        full_parse_fallback ~canonical_path ~sidecar_path ~reason:Sidecar_unusable)
+
+type checkpoint_identity_error =
+  | Session_id_invalid of string
+  | Generation_missing
+  | Generation_not_integer
+  | Ref_create_failed of Keeper_checkpoint_ref.create_error
+
+type checkpoint_ref_load_error =
+  | Ref_not_found
+  | Ref_read_failed of checkpoint_load_error
+  | Ref_identity_invalid of checkpoint_identity_error
+  | Ref_session_mismatch of
+      { expected : Keeper_id.Trace_id.t
+      ; actual : Keeper_id.Trace_id.t
+      }
+  | Ref_lock_failed of string
+
+type checkpoint_cas_error =
+  | Source_unavailable of checkpoint_ref_load_error
+  | Source_changed of Keeper_checkpoint_ref.t
+  | Candidate_identity_invalid of checkpoint_identity_error
+  | Candidate_session_mismatch of
+      { expected : Keeper_id.Trace_id.t
+      ; candidate : Keeper_id.Trace_id.t
+      }
+  | Candidate_generation_mismatch of
+      { expected : int
+      ; candidate : int
+      }
+  | Candidate_turn_regressed of
+      { source_turn : int
+      ; candidate_turn : int
+      }
+  | Commit_not_installed of Keeper_fs.durable_write_error
+  | Commit_durability_unknown of
+      { installed_ref : Keeper_checkpoint_ref.t
+      ; error : Keeper_fs.durable_write_error
+      }
+  | Transaction_outcome_unknown of
+      { possible_installed_ref : Keeper_checkpoint_ref.t
+      ; error : File_lock_eio.durable_lock_error
+      }
+
+let checkpoint_generation_strict (checkpoint : Agent_sdk.Checkpoint.t) =
+  match
+    Agent_sdk.Context.get_scoped checkpoint.Agent_sdk.Checkpoint.context
+      Agent_sdk.Context.Session keeper_generation_context_key
+  with
+  | None -> Error Generation_missing
+  | Some (`Int generation) -> Ok generation
+  | Some (`Intlit raw) ->
+    (match int_of_string_opt raw with
+     | Some generation -> Ok generation
+     | None -> Error Generation_not_integer)
+  | Some _ -> Error Generation_not_integer
+
+let checkpoint_ref_of_canonical_bytes canonical_bytes
+    (checkpoint : Agent_sdk.Checkpoint.t) =
+  match Keeper_id.Trace_id.of_string checkpoint.Agent_sdk.Checkpoint.session_id with
+  | Error reason -> Error (Session_id_invalid reason)
+  | Ok trace_id ->
+    (match checkpoint_generation_strict checkpoint with
+     | Error _ as error -> error
+     | Ok generation ->
+       Keeper_checkpoint_ref.create
+         ~trace_id
+         ~generation
+         ~turn_count:checkpoint.turn_count
+         ~canonical_checkpoint_bytes:canonical_bytes
+       |> Result.map_error (fun error -> Ref_create_failed error))
+
+let load_ref_locked ~session_dir ~expected_session_id =
+  let canonical_path =
+    oas_checkpoint_path
+      ~session_dir
+      ~session_id:(Keeper_id.Trace_id.to_string expected_session_id)
+  in
+  match load_canonical_bytes_and_checkpoint_strict canonical_path with
+  | Error error -> Error (Ref_read_failed error)
+  | Ok None -> Error Ref_not_found
+  | Ok (Some (canonical_bytes, checkpoint)) ->
+    (match checkpoint_ref_of_canonical_bytes canonical_bytes checkpoint with
+     | Error error -> Error (Ref_identity_invalid error)
+     | Ok reference
+       when not
+              (Keeper_id.Trace_id.equal
+                 expected_session_id reference.trace_id) ->
+       Error
+         (Ref_session_mismatch
+            { expected = expected_session_id; actual = reference.trace_id })
+     | Ok reference -> Ok (checkpoint, reference))
+
+let load_oas_with_ref ~session_dir ~session_id =
+  match Keeper_id.Trace_id.of_string session_id with
+  | Error reason -> Error (Ref_identity_invalid (Session_id_invalid reason))
+  | Ok expected_session_id ->
+    (match
+       with_session_lock ~session_dir (fun session_dir ->
+         load_ref_locked ~session_dir ~expected_session_id)
+     with
+     | Ok result -> result
+     | Error detail -> Error (Ref_lock_failed detail))
+
+let with_checkpoint_cas_lock ~session_dir ~candidate_ref f =
+  match canonical_session_location session_dir with
+  | Error error ->
+    Error
+      (Source_unavailable
+         (Ref_lock_failed (save_oas_error_to_string error)))
+  | Ok session_dir ->
+    let lock_path = session_dir ^ ".checkpoint.lock" in
+    (match File_lock_eio.with_durable_lock ~lock_path (fun () -> f session_dir) with
+     | Ok result -> result
+     | Error error ->
+       (match error.File_lock_eio.phase with
+        | File_lock_eio.Release_process_lock ->
+          Error
+            (Transaction_outcome_unknown
+               { possible_installed_ref = candidate_ref; error })
+        | File_lock_eio.Open_lock_file
+        | File_lock_eio.Acquire_process_lock ->
+          Error
+            (Source_unavailable
+               (Ref_lock_failed
+                  (File_lock_eio.durable_lock_error_to_string error)))))
+
+let save_oas_if_source
+    ~session_dir
+    ~(expected_source_ref : Keeper_checkpoint_ref.t)
+    (candidate : Agent_sdk.Checkpoint.t) =
+  let candidate_json = Agent_sdk.Checkpoint.to_json candidate in
+  let candidate_bytes = Yojson.Safe.to_string candidate_json in
+  match checkpoint_ref_of_canonical_bytes candidate_bytes candidate with
+  | Error error -> Error (Candidate_identity_invalid error)
+  | Ok candidate_ref
+    when not
+           (Keeper_id.Trace_id.equal
+              expected_source_ref.trace_id candidate_ref.trace_id) ->
+    Error
+      (Candidate_session_mismatch
+         { expected = expected_source_ref.trace_id
+         ; candidate = candidate_ref.trace_id
+         })
+  | Ok candidate_ref
+    when not (Int.equal expected_source_ref.generation candidate_ref.generation) ->
+    Error
+      (Candidate_generation_mismatch
+         { expected = expected_source_ref.generation
+         ; candidate = candidate_ref.generation
+         })
+  | Ok candidate_ref
+    when candidate_ref.turn_count < expected_source_ref.turn_count ->
+    Error
+      (Candidate_turn_regressed
+         { source_turn = expected_source_ref.turn_count
+         ; candidate_turn = candidate_ref.turn_count
+         })
+  | Ok candidate_ref ->
+    let expected_session_id = expected_source_ref.trace_id in
+    with_checkpoint_cas_lock ~session_dir ~candidate_ref (fun session_dir ->
+      match load_ref_locked ~session_dir ~expected_session_id with
+         | Error error -> Error (Source_unavailable error)
+         | Ok (_, actual_source)
+           when not (Keeper_checkpoint_ref.equal expected_source_ref actual_source) ->
+           Error (Source_changed actual_source)
+         | Ok _ ->
+           let canonical_path =
+             oas_checkpoint_path
+               ~session_dir
+               ~session_id:(Keeper_id.Trace_id.to_string expected_session_id)
+           in
+           let ownership_root = Filename.dirname session_dir in
+           (match
+              Keeper_fs.save_json_durable_atomic
+                ~ownership_root
+                ~pretty:false
+                canonical_path
+                candidate_json
+            with
+            | Error error when error.Keeper_fs.renamed ->
+              Error
+                (Commit_durability_unknown
+                   { installed_ref = candidate_ref; error })
+            | Error error -> Error (Commit_not_installed error)
+            | Ok () ->
+              (* [candidate_bytes] and [save_json_durable_atomic ~pretty:false]
+                 use the same [Yojson.Safe.to_string candidate_json] contract.
+                 Once the writer returns [Ok], rename and both durability
+                 fsyncs have completed; a post-commit read cannot downgrade
+                 that committed outcome to a retryable failure. *)
+              Ok candidate_ref))
 
 let save_oas_classified_typed
     ~(session_dir : string)

--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -605,6 +605,7 @@ type checkpoint_cas_error =
       { source_turn : int
       ; candidate_turn : int
       }
+  | Watermark_invalidation_failed of Keeper_fs.durable_remove_error
   | Commit_not_installed of Keeper_fs.durable_write_error
   | Commit_durability_unknown of
       { installed_ref : Keeper_checkpoint_ref.t
@@ -744,25 +745,45 @@ let save_oas_if_source
                ~session_id:(Keeper_id.Trace_id.to_string expected_session_id)
            in
            let ownership_root = Filename.dirname session_dir in
+           let sidecar_path = watermark_sidecar_path canonical_path in
            (match
-              Keeper_fs.save_json_durable_atomic
-                ~ownership_root
-                ~pretty:false
-                canonical_path
-                candidate_json
+              Keeper_fs.remove_file_durable ~ownership_root sidecar_path
             with
-            | Error error when error.Keeper_fs.renamed ->
-              Error
-                (Commit_durability_unknown
-                   { installed_ref = candidate_ref; error })
-            | Error error -> Error (Commit_not_installed error)
+            | Error error -> Error (Watermark_invalidation_failed error)
             | Ok () ->
-              (* [candidate_bytes] and [save_json_durable_atomic ~pretty:false]
-                 use the same [Yojson.Safe.to_string candidate_json] contract.
-                 Once the writer returns [Ok], rename and both durability
-                 fsyncs have completed; a post-commit read cannot downgrade
-                 that committed outcome to a retryable failure. *)
-              Ok candidate_ref))
+              (match
+                 Keeper_fs.save_json_durable_atomic
+                   ~ownership_root
+                   ~pretty:false
+                   canonical_path
+                   candidate_json
+               with
+               | Error error when error.Keeper_fs.renamed ->
+                 Error
+                   (Commit_durability_unknown
+                      { installed_ref = candidate_ref; error })
+               | Error error -> Error (Commit_not_installed error)
+               | Ok () ->
+                 (match canonical_fingerprint canonical_path with
+                  | Some (size, mtime) ->
+                    save_sidecar_watermark_best_effort sidecar_path
+                      { session_id =
+                          Keeper_id.Trace_id.to_string expected_session_id
+                      ; turn_count = candidate.turn_count
+                      ; canonical_size = size
+                      ; canonical_mtime = mtime
+                      }
+                  | None -> ());
+                 (* [candidate_bytes] and
+                    [save_json_durable_atomic ~pretty:false] use the same
+                    [Yojson.Safe.to_string candidate_json] contract. Once
+                    the writer returns [Ok], rename and both durability
+                    fsyncs have completed; a post-commit read cannot
+                    downgrade that committed outcome to a retryable
+                    failure. The old watermark was durably removed before
+                    the commit, so a failed best-effort refresh leaves a
+                    miss, never stale matching metadata. *)
+                 Ok candidate_ref)))
 
 let save_oas_classified_typed
     ~(session_dir : string)

--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -402,176 +402,14 @@ let load_canonical_strict path =
   load_canonical_bytes_and_checkpoint_strict path
   |> Result.map (Option.map snd)
 
-(* masc P0 perf fix (checkpoint save-path read-modify-write): a prior
-   revision of this fix cached the watermark in a process-local Hashtbl.
-   That is exactly the structure #24561 (commit 20536cacbf, "make canonical
-   disk the watermark SSOT") deliberately removed: RFC-0225 §3.2 requires
-   the canonical file to be the *only* admission watermark, with no
-   process-local truth retained, because a process-local cache can drift
-   from disk across execution contexts (raw Domain vs Eio fiber; see the
-   companion #24548 fix distinguishing them) in ways a single process
-   cannot observe. This revision keeps that invariant: there is no
-   in-memory watermark state anywhere in this module.
-
-   Instead, a tiny fingerprinted sidecar file sits beside the canonical
-   checkpoint ([watermark_sidecar_path]) and is written inside the *same*
-   [with_session_lock_typed] transaction as the canonical write, so it is
-   never observed half-updated relative to canonical. It stores
-   [session_id], [turn_count], and the canonical file's own [size]/[mtime]
-   fingerprint at write time.
-
-   On the next save, [known_watermark] `stat`s the canonical file and
-   compares that fresh fingerprint against the sidecar's recorded one:
-   - Match: the sidecar's (session_id, turn_count) is trusted without
-     re-parsing the (0.7-1.37MB pretty-printed) canonical JSON.
-   - Mismatch, sidecar missing, or sidecar unparseable: falls back to the
-     original [load_canonical_strict] full parse unconditionally (the exact
-     path this module used before this fix), then re-derives the
-     fingerprint from the just-read canonical file and rewrites the
-     sidecar to heal it for the next save.
-
-   The canonical file is still the *only* source of truth: every decision
-   is re-verified against a fresh `stat` on every single call, so nothing
-   is ever trusted across process boundaries or execution contexts without
-   re-checking disk. A crash between the canonical write and the sidecar
-   write leaves a stale/absent sidecar, which the next save's fingerprint
-   check (or missing-sidecar check) detects and heals via the full-parse
-   fallback -- no special-cased recovery logic is required. *)
-
-let watermark_sidecar_path canonical_path = canonical_path ^ ".watermark.json"
-
-type sidecar_watermark =
-  { session_id : string
-  ; turn_count : int
-  ; canonical_size : int
-  ; canonical_mtime : float
-  }
-
-let sidecar_watermark_to_json (w : sidecar_watermark) : Yojson.Safe.t =
-  `Assoc
-    [ ("session_id", `String w.session_id)
-    ; ("turn_count", `Int w.turn_count)
-    ; ("canonical_size", `Int w.canonical_size)
-    ; ("canonical_mtime", `Float w.canonical_mtime)
-    ]
-
-let sidecar_watermark_of_json (json : Yojson.Safe.t) : sidecar_watermark option =
-  match
-    ( Json_util.get_string json "session_id"
-    , Json_util.get_int json "turn_count"
-    , Json_util.get_int json "canonical_size"
-    , Json_util.get_float json "canonical_mtime" )
-  with
-  | Some session_id, Some turn_count, Some canonical_size, Some canonical_mtime ->
-    Some { session_id; turn_count; canonical_size; canonical_mtime }
-  | _ -> None
-
-(* [Fs_compat.file_size]/[file_mtime] already dispatch Eio-native vs. Unix
-   fallback correctly for both Eio fibers and raw Domains ([with_fs_or_fallback]
-   catches [Stdlib.Effect.Unhandled] and retries on the blocking path), so no
-   separate execution-context check is needed here. Both return [None]
-   uniformly for "does not exist" and "stat failed for any other reason";
-   either way the caller has nothing trustworthy to fast-path against and
-   defers entirely to [load_canonical_strict], which already classifies
-   ENOENT vs. real I/O errors correctly. *)
-let canonical_fingerprint canonical_path : (int * float) option =
-  match Fs_compat.file_size canonical_path, Fs_compat.file_mtime canonical_path with
-  | Some size, Some mtime -> Some (size, mtime)
-  | _ -> None
-
-let load_sidecar_watermark sidecar_path : sidecar_watermark option =
-  match Fs_compat.load_file_opt sidecar_path with
-  | exception _ -> None
-  | None -> None
-  | Some raw ->
-    (match Yojson.Safe.from_string raw with
-     | json -> sidecar_watermark_of_json json
-     | exception _ -> None)
-
-let save_sidecar_watermark_best_effort sidecar_path (w : sidecar_watermark) : unit =
-  try Fs_compat.save_file sidecar_path (Yojson.Safe.to_string (sidecar_watermark_to_json w)) with
-  | Eio.Cancel.Cancelled _ as exn -> raise exn
-  | exn ->
-    Log.Keeper.warn
-      "checkpoint watermark sidecar write failed for %s: %s"
-      sidecar_path (Printexc.to_string exn);
-    Otel_metric_store.inc_counter
-      Keeper_metrics.(to_string CheckpointFailures)
-      ~labels:
-        [ ( "site"
-          , Keeper_checkpoint_store_failure_site.(to_label Oas_watermark_sidecar) )
-        ]
-      ()
-
 type watermark = { session_id : string; turn_count : int }
-
-type watermark_fast_path_miss_reason =
-  | No_canonical_file
-  | Sidecar_unusable
-  | Fingerprint_mismatch
-
-let watermark_fast_path_miss_reason_to_string = function
-  | No_canonical_file -> "no_canonical_file"
-  | Sidecar_unusable -> "sidecar_unusable"
-  | Fingerprint_mismatch -> "fingerprint_mismatch"
-
-(* Test-only instrumentation: proves the fast path actually skips
-   [load_canonical_strict] rather than merely returning the right answer by
-   coincidence (RFC-0342-style falsifiable claim, not a production metric). *)
-module For_testing = struct
-  let full_parse_count = Atomic.make 0
-  let reset_full_parse_count () = Atomic.set full_parse_count 0
-  let get_full_parse_count () = Atomic.get full_parse_count
-end
-
-let full_parse_fallback ~canonical_path ~sidecar_path ~reason
-  : (watermark option, checkpoint_load_error) result =
-  Atomic.incr For_testing.full_parse_count;
-  Log.Keeper.info
-    "checkpoint watermark sidecar fast-path miss for %s: %s -- falling back to full parse"
-    canonical_path (watermark_fast_path_miss_reason_to_string reason);
-  Otel_metric_store.inc_counter
-    "masc_keeper_checkpoint_watermark_fastpath_miss_total"
-    ~labels:[("reason", watermark_fast_path_miss_reason_to_string reason)]
-    ();
-  match load_canonical_strict canonical_path with
-  | Error _ as error -> error
-  | Ok None -> Ok None
-  | Ok (Some existing) ->
-    let watermark =
-      { session_id = existing.session_id; turn_count = existing.turn_count }
-    in
-    (match canonical_fingerprint canonical_path with
-     | Some (size, mtime) ->
-       save_sidecar_watermark_best_effort sidecar_path
-         { session_id = watermark.session_id
-         ; turn_count = watermark.turn_count
-         ; canonical_size = size
-         ; canonical_mtime = mtime
-         }
-     | None ->
-       (* The file we just successfully read is now unstatable (deleted out
-          from under us despite the session lock, or a transient stat
-          failure). Not fatal: the sidecar is left as-is and the next save's
-          fingerprint check will simply miss again and re-heal it. *)
-       ());
-    Ok (Some watermark)
 
 let known_watermark ~canonical_path
   : (watermark option, checkpoint_load_error) result =
-  let sidecar_path = watermark_sidecar_path canonical_path in
-  match canonical_fingerprint canonical_path with
-  | None -> full_parse_fallback ~canonical_path ~sidecar_path ~reason:No_canonical_file
-  | Some (size, mtime) ->
-    (match load_sidecar_watermark sidecar_path with
-     | Some sidecar
-       when Int.equal sidecar.canonical_size size
-         && Float.equal sidecar.canonical_mtime mtime ->
-       Ok (Some { session_id = sidecar.session_id; turn_count = sidecar.turn_count })
-     | Some _ ->
-       full_parse_fallback ~canonical_path ~sidecar_path ~reason:Fingerprint_mismatch
-     | None ->
-       full_parse_fallback ~canonical_path ~sidecar_path ~reason:Sidecar_unusable)
+  load_canonical_strict canonical_path
+  |> Result.map
+       (Option.map (fun (existing : Agent_sdk.Checkpoint.t) ->
+          { session_id = existing.session_id; turn_count = existing.turn_count }))
 
 type checkpoint_identity_error =
   | Session_id_invalid of string
@@ -605,7 +443,6 @@ type checkpoint_cas_error =
       { source_turn : int
       ; candidate_turn : int
       }
-  | Watermark_invalidation_failed of Keeper_fs.durable_remove_error
   | Commit_not_installed of Keeper_fs.durable_write_error
   | Commit_durability_unknown of
       { installed_ref : Keeper_checkpoint_ref.t
@@ -745,45 +582,26 @@ let save_oas_if_source
                ~session_id:(Keeper_id.Trace_id.to_string expected_session_id)
            in
            let ownership_root = Filename.dirname session_dir in
-           let sidecar_path = watermark_sidecar_path canonical_path in
            (match
-              Keeper_fs.remove_file_durable ~ownership_root sidecar_path
+              Keeper_fs.save_json_durable_atomic
+                ~ownership_root
+                ~pretty:false
+                canonical_path
+                candidate_json
             with
-            | Error error -> Error (Watermark_invalidation_failed error)
+            | Error error when error.Keeper_fs.renamed ->
+              Error
+                (Commit_durability_unknown
+                   { installed_ref = candidate_ref; error })
+            | Error error -> Error (Commit_not_installed error)
             | Ok () ->
-              (match
-                 Keeper_fs.save_json_durable_atomic
-                   ~ownership_root
-                   ~pretty:false
-                   canonical_path
-                   candidate_json
-               with
-               | Error error when error.Keeper_fs.renamed ->
-                 Error
-                   (Commit_durability_unknown
-                      { installed_ref = candidate_ref; error })
-               | Error error -> Error (Commit_not_installed error)
-               | Ok () ->
-                 (match canonical_fingerprint canonical_path with
-                  | Some (size, mtime) ->
-                    save_sidecar_watermark_best_effort sidecar_path
-                      { session_id =
-                          Keeper_id.Trace_id.to_string expected_session_id
-                      ; turn_count = candidate.turn_count
-                      ; canonical_size = size
-                      ; canonical_mtime = mtime
-                      }
-                  | None -> ());
-                 (* [candidate_bytes] and
-                    [save_json_durable_atomic ~pretty:false] use the same
-                    [Yojson.Safe.to_string candidate_json] contract. Once
-                    the writer returns [Ok], rename and both durability
-                    fsyncs have completed; a post-commit read cannot
-                    downgrade that committed outcome to a retryable
-                    failure. The old watermark was durably removed before
-                    the commit, so a failed best-effort refresh leaves a
-                    miss, never stale matching metadata. *)
-                 Ok candidate_ref)))
+              (* [candidate_bytes] and
+                 [save_json_durable_atomic ~pretty:false] use the same
+                 [Yojson.Safe.to_string candidate_json] contract. Once the
+                 writer returns [Ok], rename and both durability fsyncs have
+                 completed; a post-commit read cannot downgrade that committed
+                 outcome to a retryable failure. *)
+              Ok candidate_ref))
 
 let save_oas_classified_typed
     ~(session_dir : string)
@@ -829,20 +647,6 @@ let save_oas_classified_typed
          with
          | Error error -> Error (Canonical_write_failed error)
          | Ok () ->
-           (match canonical_fingerprint canonical_path with
-            | Some (size, mtime) ->
-              save_sidecar_watermark_best_effort
-                (watermark_sidecar_path canonical_path)
-                { session_id
-                ; turn_count = ckpt.turn_count
-                ; canonical_size = size
-                ; canonical_mtime = mtime
-                }
-            | None ->
-              (* The file we just durably wrote is now unstatable. Not fatal
-                 to this save -- the next save's fingerprint check will miss
-                 (no sidecar to trust) and fall back to a full parse. *)
-              ());
            archive_oas_history_best_effort ~session_dir ckpt;
            Ok
              (Saved

--- a/lib/keeper/keeper_checkpoint_store.mli
+++ b/lib/keeper/keeper_checkpoint_store.mli
@@ -169,6 +169,7 @@ type checkpoint_cas_error =
       { source_turn : int
       ; candidate_turn : int
       }
+  | Watermark_invalidation_failed of Keeper_fs.durable_remove_error
   | Commit_not_installed of Keeper_fs.durable_write_error
   | Commit_durability_unknown of
       { installed_ref : Keeper_checkpoint_ref.t
@@ -184,7 +185,11 @@ type checkpoint_cas_error =
     current bytes are re-read and hashed, and an equal-turn checkpoint with
     different content is rejected as [Source_changed]. On success the returned
     ref is derived from the exact compact bytes passed to the durable atomic
-    JSON writer. A writer error after atomic rename is
+    JSON writer. The previous watermark sidecar is durably invalidated before
+    the canonical commit and refreshed from the installed candidate, so a
+    same-size, same-mtime replacement cannot reuse stale admission metadata.
+    A sidecar invalidation failure refuses the canonical write. A writer error
+    after atomic rename is
     [Commit_durability_unknown], never a retryable not-installed failure. This
     same rule applies when releasing the stable lock fails after the body:
     [Transaction_outcome_unknown] requires reconciliation rather than retry. The

--- a/lib/keeper/keeper_checkpoint_store.mli
+++ b/lib/keeper/keeper_checkpoint_store.mli
@@ -127,6 +127,75 @@ val load_oas :
   session_id:string ->
   (Agent_sdk.Checkpoint.t, checkpoint_load_error) result
 
+type checkpoint_identity_error =
+  | Session_id_invalid of string
+  | Generation_missing
+  | Generation_not_integer
+  | Ref_create_failed of Keeper_checkpoint_ref.create_error
+
+type checkpoint_ref_load_error =
+  | Ref_not_found
+  | Ref_read_failed of checkpoint_load_error
+  | Ref_identity_invalid of checkpoint_identity_error
+  | Ref_session_mismatch of
+      { expected : Keeper_id.Trace_id.t
+      ; actual : Keeper_id.Trace_id.t
+      }
+  | Ref_lock_failed of string
+
+(** Load one canonical checkpoint and its exact source identity from the same
+    locked byte snapshot. No size, mtime, timestamp, or process cache
+    participates in the identity. *)
+val load_oas_with_ref :
+  session_dir:string ->
+  session_id:string ->
+  ( Agent_sdk.Checkpoint.t * Keeper_checkpoint_ref.t
+  , checkpoint_ref_load_error )
+  result
+
+type checkpoint_cas_error =
+  | Source_unavailable of checkpoint_ref_load_error
+  | Source_changed of Keeper_checkpoint_ref.t
+  | Candidate_identity_invalid of checkpoint_identity_error
+  | Candidate_session_mismatch of
+      { expected : Keeper_id.Trace_id.t
+      ; candidate : Keeper_id.Trace_id.t
+      }
+  | Candidate_generation_mismatch of
+      { expected : int
+      ; candidate : int
+      }
+  | Candidate_turn_regressed of
+      { source_turn : int
+      ; candidate_turn : int
+      }
+  | Commit_not_installed of Keeper_fs.durable_write_error
+  | Commit_durability_unknown of
+      { installed_ref : Keeper_checkpoint_ref.t
+      ; error : Keeper_fs.durable_write_error
+      }
+  | Transaction_outcome_unknown of
+      { possible_installed_ref : Keeper_checkpoint_ref.t
+      ; error : File_lock_eio.durable_lock_error
+      }
+
+(** Conditionally publish [candidate] only when the canonical bytes still
+    have exactly [expected_source_ref]. The stable session lock is reacquired,
+    current bytes are re-read and hashed, and an equal-turn checkpoint with
+    different content is rejected as [Source_changed]. On success the returned
+    ref is derived from the exact compact bytes passed to the durable atomic
+    JSON writer. A writer error after atomic rename is
+    [Commit_durability_unknown], never a retryable not-installed failure. This
+    same rule applies when releasing the stable lock fails after the body:
+    [Transaction_outcome_unknown] requires reconciliation rather than retry. The
+    payload-store commit is not an operation terminal fact; the Keeper operation
+    journal owns that authority. *)
+val save_oas_if_source :
+  session_dir:string ->
+  expected_source_ref:Keeper_checkpoint_ref.t ->
+  Agent_sdk.Checkpoint.t ->
+  (Keeper_checkpoint_ref.t, checkpoint_cas_error) result
+
 module For_testing : sig
   (** Number of times the checkpoint watermark resolution has fallen back to
       a full canonical-file parse (sidecar absent, corrupt, or fingerprint

--- a/lib/keeper/keeper_checkpoint_store.mli
+++ b/lib/keeper/keeper_checkpoint_store.mli
@@ -6,16 +6,6 @@
 val oas_checkpoint_path :
   session_dir:string -> session_id:string -> string
 
-(** Path of the fingerprinted watermark sidecar beside a canonical
-    checkpoint file ([<canonical_path>.watermark.json]). RFC-0225 §3.2:
-    the sidecar records [session_id], [turn_count], and the canonical
-    file's own [size]/[mtime] fingerprint at write time, so a later save
-    can skip re-parsing the full canonical JSON when the fingerprint still
-    matches. It is never treated as a source of truth on its own -- every
-    read re-verifies it against a fresh [stat] of the canonical file, and
-    any mismatch, absence, or corruption falls back to a full parse. *)
-val watermark_sidecar_path : string -> string
-
 (** [oas-snapshot-] prefix on OAS history archive entries. *)
 val oas_history_prefix : string
 
@@ -169,7 +159,6 @@ type checkpoint_cas_error =
       { source_turn : int
       ; candidate_turn : int
       }
-  | Watermark_invalidation_failed of Keeper_fs.durable_remove_error
   | Commit_not_installed of Keeper_fs.durable_write_error
   | Commit_durability_unknown of
       { installed_ref : Keeper_checkpoint_ref.t
@@ -185,11 +174,7 @@ type checkpoint_cas_error =
     current bytes are re-read and hashed, and an equal-turn checkpoint with
     different content is rejected as [Source_changed]. On success the returned
     ref is derived from the exact compact bytes passed to the durable atomic
-    JSON writer. The previous watermark sidecar is durably invalidated before
-    the canonical commit and refreshed from the installed candidate, so a
-    same-size, same-mtime replacement cannot reuse stale admission metadata.
-    A sidecar invalidation failure refuses the canonical write. A writer error
-    after atomic rename is
+    JSON writer. A writer error after atomic rename is
     [Commit_durability_unknown], never a retryable not-installed failure. This
     same rule applies when releasing the stable lock fails after the body:
     [Transaction_outcome_unknown] requires reconciliation rather than retry. The
@@ -200,16 +185,3 @@ val save_oas_if_source :
   expected_source_ref:Keeper_checkpoint_ref.t ->
   Agent_sdk.Checkpoint.t ->
   (Keeper_checkpoint_ref.t, checkpoint_cas_error) result
-
-module For_testing : sig
-  (** Number of times the checkpoint watermark resolution has fallen back to
-      a full canonical-file parse (sidecar absent, corrupt, or fingerprint
-      mismatch) since the last {!reset_full_parse_count}. Exists so a test
-      can prove the sidecar fast path actually skips
-      [load_canonical_strict] rather than merely returning the right answer
-      by coincidence. *)
-  val get_full_parse_count : unit -> int
-
-  (** Reset {!get_full_parse_count} to zero. *)
-  val reset_full_parse_count : unit -> unit
-end

--- a/lib/keeper_failure_taxonomy/keeper_checkpoint_store_failure_site.ml
+++ b/lib/keeper_failure_taxonomy/keeper_checkpoint_store_failure_site.ml
@@ -3,12 +3,10 @@ type t =
   | Oas_save
   | Oas_delete
   | Oas_archive
-  | Oas_watermark_sidecar
 
 let to_label = function
   | Oas_cleanup -> "oas_cleanup"
   | Oas_save -> "oas_save"
   | Oas_delete -> "oas_delete"
   | Oas_archive -> "oas_archive"
-  | Oas_watermark_sidecar -> "oas_watermark_sidecar"
 ;;

--- a/lib/keeper_failure_taxonomy/keeper_checkpoint_store_failure_site.mli
+++ b/lib/keeper_failure_taxonomy/keeper_checkpoint_store_failure_site.mli
@@ -7,6 +7,5 @@ type t =
   | Oas_save (** OAS checkpoint primary save failed. *)
   | Oas_delete (** OAS checkpoint delete failed. *)
   | Oas_archive (** OAS checkpoint history archive failed. *)
-  | Oas_watermark_sidecar (** OAS checkpoint watermark sidecar write failed (best-effort; canonical write already succeeded). *)
 
 val to_label : t -> string

--- a/test/stanzas/test_keeper_checkpoint_stale_guard.inc
+++ b/test/stanzas/test_keeper_checkpoint_stale_guard.inc
@@ -5,4 +5,4 @@
 (test
  (name test_keeper_checkpoint_stale_guard)
  (modules test_keeper_checkpoint_stale_guard)
- (libraries masc_test_deps))
+ (libraries masc_test_deps masc.keeper_checkpoint_ref))

--- a/test/test_keeper_checkpoint_stale_guard.ml
+++ b/test/test_keeper_checkpoint_stale_guard.ml
@@ -81,6 +81,12 @@ let make_checkpoint ~session_id ~turn_count ~marker =
     working_context = None;
   }
 
+let with_generation generation (checkpoint : Agent_sdk.Checkpoint.t) =
+  let context = Agent_sdk.Context.copy ~eio:false checkpoint.context in
+  Agent_sdk.Context.set_scoped context Agent_sdk.Context.Session
+    "keeper_generation" (`Int generation);
+  { checkpoint with context }
+
 let save_ok ~session_dir ckpt label =
   match Keeper_checkpoint_store.save_oas_classified ~session_dir ckpt with
   | Ok _ -> ()
@@ -446,6 +452,69 @@ let test_ready_runtime_raw_domain_save () =
   | Error _ -> fail "raw-domain checkpoint did not round-trip"
   | Ok checkpoint -> check int "raw-domain turn persisted" 11 checkpoint.turn_count
 
+let test_exact_source_cas_allows_one_equal_turn_writer () =
+  let session_dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir session_dir) (fun () ->
+    let session_id = "sess-exact-cas" in
+    save_ok ~session_dir
+      (make_checkpoint ~session_id ~turn_count:8 ~marker:"source"
+       |> with_generation 3)
+      "CAS seed save";
+    let source_ref =
+      match
+        Keeper_checkpoint_store.load_oas_with_ref ~session_dir ~session_id
+      with
+      | Ok (_, reference) -> reference
+      | Error _ -> fail "CAS source load failed"
+    in
+    let writer marker =
+      Keeper_checkpoint_store.save_oas_if_source
+        ~session_dir
+        ~expected_source_ref:source_ref
+        (make_checkpoint ~session_id ~turn_count:8 ~marker
+         |> with_generation 3)
+    in
+    let left = Domain.spawn (fun () -> "left", writer "left") in
+    let right = Domain.spawn (fun () -> "right", writer "right") in
+    let committed, changed =
+      [ Domain.join left; Domain.join right ]
+      |> List.fold_left
+           (fun (committed, changed) (marker, outcome) ->
+             match outcome with
+             | Ok reference -> (marker, reference) :: committed, changed
+             | Error (Keeper_checkpoint_store.Source_changed _) ->
+               committed, changed + 1
+             | Error _ -> fail "CAS writer returned an unexpected error")
+           ([], 0)
+    in
+    check int "exactly one writer commits" 1 (List.length committed);
+    check int "the competing source is rejected" 1 changed;
+    match committed,
+      Keeper_checkpoint_store.load_oas_with_ref ~session_dir ~session_id
+    with
+    | [ (winner, committed_ref) ], Ok (checkpoint, disk_ref) ->
+      check bool "committed ref identifies installed canonical bytes" true
+        (Keeper_checkpoint_ref.equal committed_ref disk_ref);
+      check bool "installed payload belongs to the winning writer" true
+        (List.exists
+           (fun (message : Agent_sdk.Types.message) ->
+             String.equal (Agent_sdk.Types.text_of_message message) winner)
+           checkpoint.messages)
+    | _ -> fail "CAS winner did not round-trip")
+
+let test_checkpoint_ref_requires_generation () =
+  let session_dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir session_dir) (fun () ->
+    let session_id = "sess-ref-generation" in
+    save_ok ~session_dir
+      (make_checkpoint ~session_id ~turn_count:1 ~marker:"legacy")
+      "generation-less seed";
+    match Keeper_checkpoint_store.load_oas_with_ref ~session_dir ~session_id with
+    | Error
+        (Keeper_checkpoint_store.Ref_identity_invalid
+           Keeper_checkpoint_store.Generation_missing) -> ()
+    | _ -> fail "generation-less checkpoint acquired an exact ref")
+
 let () =
   run "Keeper_checkpoint_store checkpoint watermark (RFC-0225 §3.2)"
     [
@@ -471,5 +540,9 @@ let () =
             test_fingerprint_mismatch_recovers_externally_written_canonical;
           test_case "canonical checkpoint is written compact and round-trips" `Quick
             test_canonical_checkpoint_is_written_compact;
+          test_case "exact source CAS permits one equal-turn writer" `Quick
+            test_exact_source_cas_allows_one_equal_turn_writer;
+          test_case "checkpoint refs require keeper generation" `Quick
+            test_checkpoint_ref_requires_generation;
         ] );
     ]

--- a/test/test_keeper_checkpoint_stale_guard.ml
+++ b/test/test_keeper_checkpoint_stale_guard.ml
@@ -502,6 +502,53 @@ let test_exact_source_cas_allows_one_equal_turn_writer () =
            checkpoint.messages)
     | _ -> fail "CAS winner did not round-trip")
 
+let test_exact_source_cas_invalidates_stale_watermark () =
+  let session_dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir session_dir) (fun () ->
+    let session_id = "sess-cas-watermark" in
+    save_ok ~session_dir
+      (make_checkpoint ~session_id ~turn_count:8 ~marker:"source"
+       |> with_generation 3)
+      "CAS watermark seed save";
+    let canonical_path =
+      Keeper_checkpoint_store.oas_checkpoint_path ~session_dir ~session_id
+    in
+    let seed_mtime = (Unix.stat canonical_path).st_mtime in
+    let source_ref =
+      match
+        Keeper_checkpoint_store.load_oas_with_ref ~session_dir ~session_id
+      with
+      | Ok (_, reference) -> reference
+      | Error _ -> fail "CAS watermark source load failed"
+    in
+    (match
+       Keeper_checkpoint_store.save_oas_if_source
+         ~session_dir
+         ~expected_source_ref:source_ref
+         (make_checkpoint ~session_id ~turn_count:9 ~marker:"target"
+          |> with_generation 3)
+     with
+     | Ok _ -> ()
+     | Error _ -> fail "CAS watermark candidate did not commit");
+    (* The source and candidate encodings have equal byte length. Restoring
+       the source mtime deterministically recreates the exact fingerprint
+       collision under which an untouched source sidecar would still look
+       valid for the candidate canonical file. *)
+    Unix.utimes canonical_path seed_mtime seed_mtime;
+    match
+      Keeper_checkpoint_store.save_oas_classified ~session_dir
+        (make_checkpoint ~session_id ~turn_count:8 ~marker:"stale!")
+    with
+    | Ok
+        (Keeper_checkpoint_store.Stale_noop
+           { incoming_turn_count; known_turn_count }) ->
+      check int "colliding stale input turn" 8 incoming_turn_count;
+      check int "CAS candidate remains the admission watermark" 9
+        known_turn_count
+    | Ok (Keeper_checkpoint_store.Saved _) ->
+      fail "stale save passed through a source sidecar after CAS"
+    | Error error -> fail ("post-CAS stale classification failed: " ^ error))
+
 let test_checkpoint_ref_requires_generation () =
   let session_dir = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir session_dir) (fun () ->
@@ -542,6 +589,8 @@ let () =
             test_canonical_checkpoint_is_written_compact;
           test_case "exact source CAS permits one equal-turn writer" `Quick
             test_exact_source_cas_allows_one_equal_turn_writer;
+          test_case "exact source CAS invalidates stale watermark metadata" `Quick
+            test_exact_source_cas_invalidates_stale_watermark;
           test_case "checkpoint refs require keeper generation" `Quick
             test_checkpoint_ref_requires_generation;
         ] );

--- a/test/test_keeper_checkpoint_stale_guard.ml
+++ b/test/test_keeper_checkpoint_stale_guard.ml
@@ -7,14 +7,10 @@
     than the canonical checkpoint observed inside the save transaction, without
     turning that watermark hit into keeper lifecycle failure.
 
-    Also covers the checkpoint save-path read-modify-write perf fix: a
-    fingerprinted sidecar file (size + mtime of the canonical file) lets a
-    save skip re-parsing the canonical JSON when nothing has touched it
-    since the sidecar was written, while every decision is still re-verified
-    against a fresh disk `stat` (no process-local watermark state -- see
-    #24561 / commit 20536cacbf, which removed exactly that structure for
-    this reason). The canonical file itself is now written compact rather
-    than pretty-printed. *)
+    The canonical file is parsed under the stable session lock for every
+    admission decision. No process-local cache, fingerprint, or sidecar may
+    substitute for the checkpoint bytes. The canonical file is written in
+    compact JSON. *)
 
 open Alcotest
 open Masc
@@ -121,14 +117,8 @@ let test_forward_equal_and_stale () =
         on_disk.Agent_sdk.Checkpoint.turn_count
     | Error _ -> fail "load after rejection failed")
 
-(* The canonical checkpoint file is still the only durable admission
-   watermark (RFC-0225 §3.2). This save's stale-check happens to be served
-   by the fingerprint-matched sidecar fast path (nothing touched the
-   canonical file between the seed save and the stale check, so the sidecar
-   [size]/[mtime] fingerprint still matches) -- [test_fingerprint_match_skips_full_parse]
-   below proves that explicitly via the parse-count hook; this test only
-   asserts the observable outcome is unchanged from the pre-sidecar
-   disk-only behavior. *)
+(* The canonical checkpoint file is the only durable admission watermark
+   (RFC-0225 §3.2). *)
 let test_disk_is_the_watermark_ssot () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
@@ -151,132 +141,31 @@ let test_disk_is_the_watermark_ssot () =
     save_ok ~session_dir (make_checkpoint ~session_id:sid ~turn_count:9 ~marker:"v9")
       "forward save from disk SSOT")
 
-(* RFC-0225 §3.2 fast path: once a session's sidecar fingerprint matches the
-   canonical file's current (size, mtime), [load_canonical_strict] must not
-   run again. A correct answer alone would not distinguish "read the
-   sidecar" from "re-parsed canonical and happened to get the same result",
-   so this asserts the parse-count hook directly. *)
-let test_fingerprint_match_skips_full_parse () =
+let test_externally_replaced_canonical_is_the_watermark () =
   let session_dir = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir session_dir) (fun () ->
-    let sid = "sess-fastpath" in
-    Keeper_checkpoint_store.For_testing.reset_full_parse_count ();
-    save_ok ~session_dir (make_checkpoint ~session_id:sid ~turn_count:5 ~marker:"v5")
-      "seed save (cold: no canonical file yet, so this necessarily falls back once)";
-    check int "cold seed save runs exactly one full-parse fallback" 1
-      (Keeper_checkpoint_store.For_testing.get_full_parse_count ());
-    Keeper_checkpoint_store.For_testing.reset_full_parse_count ();
-    save_ok ~session_dir (make_checkpoint ~session_id:sid ~turn_count:6 ~marker:"v6")
-      "forward save served by the sidecar fast path";
-    check int "fingerprint-matched forward save skips the full parse" 0
-      (Keeper_checkpoint_store.For_testing.get_full_parse_count ());
-    (match
-       Keeper_checkpoint_store.save_oas_classified ~session_dir
-         (make_checkpoint ~session_id:sid ~turn_count:4 ~marker:"v4-stale")
-     with
-     | Ok (Keeper_checkpoint_store.Stale_noop
-             { incoming_turn_count; known_turn_count }) ->
-       check int "fast-path stale incoming turn_count" 4 incoming_turn_count;
-       check int "fast-path known turn_count" 6 known_turn_count
-     | Ok (Keeper_checkpoint_store.Saved _) -> fail "stale save advanced via the fast path"
-     | Error e -> fail ("fast-path stale save returned lifecycle failure: " ^ e));
-    check int "fingerprint-matched stale check also skips the full parse" 0
-      (Keeper_checkpoint_store.For_testing.get_full_parse_count ()))
-
-(* Sidecar absent or corrupt: the fast path must never blindly trust a
-   missing/unparseable sidecar. Both sub-cases fall back to the ORIGINAL
-   full-parse path unconditionally (the exact path this module used before
-   this fix) and heal the sidecar afterward so the next save can use the
-   fast path again. *)
-let test_sidecar_unusable_falls_back_to_full_parse () =
-  let session_dir = temp_dir () in
-  Fun.protect ~finally:(fun () -> cleanup_dir session_dir) (fun () ->
-    let sid = "sess-sidecar-unusable" in
-    let sidecar_path =
-      Keeper_checkpoint_store.watermark_sidecar_path
-        (Keeper_checkpoint_store.oas_checkpoint_path ~session_dir ~session_id:sid)
-    in
-    save_ok ~session_dir (make_checkpoint ~session_id:sid ~turn_count:8 ~marker:"v8")
-      "seed save (writes canonical + sidecar)";
-    check bool "seed save writes a sidecar" true (Fs_compat.file_exists sidecar_path);
-    (* Sub-case 1: sidecar deleted outright. *)
-    Sys.remove sidecar_path;
-    Keeper_checkpoint_store.For_testing.reset_full_parse_count ();
-    (match
-       Keeper_checkpoint_store.save_oas_classified ~session_dir
-         (make_checkpoint ~session_id:sid ~turn_count:3 ~marker:"v3-stale")
-     with
-     | Ok (Keeper_checkpoint_store.Stale_noop
-             { incoming_turn_count; known_turn_count }) ->
-       check int "sidecar-absent stale incoming turn_count" 3 incoming_turn_count;
-       check int "sidecar-absent known turn_count recovered from canonical" 8 known_turn_count
-     | Ok (Keeper_checkpoint_store.Saved _) -> fail "stale save advanced with an absent sidecar"
-     | Error e -> fail ("sidecar-absent stale save returned lifecycle failure: " ^ e));
-    check bool "sidecar-absent path ran the full-parse fallback" true
-      (Keeper_checkpoint_store.For_testing.get_full_parse_count () > 0);
-    check bool "the fallback healed the sidecar" true (Fs_compat.file_exists sidecar_path);
-    (* Sub-case 2: sidecar present but corrupt (unparseable JSON). *)
-    Fs_compat.save_file sidecar_path "{not-json";
-    Keeper_checkpoint_store.For_testing.reset_full_parse_count ();
-    (match
-       Keeper_checkpoint_store.save_oas_classified ~session_dir
-         (make_checkpoint ~session_id:sid ~turn_count:2 ~marker:"v2-stale")
-     with
-     | Ok (Keeper_checkpoint_store.Stale_noop
-             { incoming_turn_count; known_turn_count }) ->
-       check int "corrupt-sidecar stale incoming turn_count" 2 incoming_turn_count;
-       check int "corrupt-sidecar known turn_count recovered from canonical" 8 known_turn_count
-     | Ok (Keeper_checkpoint_store.Saved _) -> fail "stale save advanced with a corrupt sidecar"
-     | Error e -> fail ("corrupt-sidecar stale save returned lifecycle failure: " ^ e));
-    check bool "corrupt-sidecar path ran the full-parse fallback" true
-      (Keeper_checkpoint_store.For_testing.get_full_parse_count () > 0))
-
-(* Fingerprint mismatch: a canonical write that bypasses [save_oas_classified]
-   (a different writer, or a crash between a writer's own canonical write and
-   its sidecar update) leaves the sidecar stale relative to disk. The next
-   save must detect the (size, mtime) mismatch and recover the REAL watermark
-   from a full parse of canonical, not the stale sidecar's belief -- this is
-   exactly the drift the removed in-memory cache (#24561 / commit 20536cacbf)
-   could not detect, because it had no way to notice a canonical write it did
-   not itself perform. *)
-let test_fingerprint_mismatch_recovers_externally_written_canonical () =
-  let session_dir = temp_dir () in
-  Fun.protect ~finally:(fun () -> cleanup_dir session_dir) (fun () ->
-    let sid = "sess-external-write" in
+    let session_id = "sess-external-write" in
     let canonical_path =
-      Keeper_checkpoint_store.oas_checkpoint_path ~session_dir ~session_id:sid
+      Keeper_checkpoint_store.oas_checkpoint_path ~session_dir ~session_id
     in
-    save_ok ~session_dir (make_checkpoint ~session_id:sid ~turn_count:5 ~marker:"v5")
-      "seed save (sidecar now records turn_count=5)";
-    (* Simulate a different writer updating canonical directly without
-       updating the sidecar. A much longer marker guarantees the byte size
-       differs, so the fingerprint mismatch is detected regardless of
-       filesystem mtime resolution. *)
+    save_ok ~session_dir
+      (make_checkpoint ~session_id ~turn_count:5 ~marker:"v5")
+      "seed save";
     Fs_compat.save_file canonical_path
-      (make_checkpoint ~session_id:sid ~turn_count:9
-         ~marker:"externally-written-turn-nine-with-a-much-longer-marker-to-force-a-size-change"
+      (make_checkpoint ~session_id ~turn_count:9 ~marker:"external-v9"
        |> Agent_sdk.Checkpoint.to_string);
-    Keeper_checkpoint_store.For_testing.reset_full_parse_count ();
-    (match
-       Keeper_checkpoint_store.save_oas_classified ~session_dir
-         (make_checkpoint ~session_id:sid ~turn_count:7
-            ~marker:"v7-would-wrongly-look-forward-against-a-stale-sidecar")
-     with
-     | Ok (Keeper_checkpoint_store.Stale_noop
-             { incoming_turn_count; known_turn_count }) ->
-       check int "incoming turn_count" 7 incoming_turn_count;
-       check int "known turn_count is the real canonical value, not the stale sidecar's" 9
-         known_turn_count
-     | Ok (Keeper_checkpoint_store.Saved _) ->
-       fail "turn_count=7 was wrongly accepted as forward against a stale sidecar's turn_count=5"
-     | Error e -> fail ("fingerprint-mismatch save returned lifecycle failure: " ^ e));
-    check bool "fingerprint mismatch ran the full-parse fallback" true
-      (Keeper_checkpoint_store.For_testing.get_full_parse_count () > 0);
-    match Keeper_checkpoint_store.load_oas ~session_dir ~session_id:sid with
-    | Ok on_disk ->
-      check int "externally-written turn_count=9 remains on disk, untouched by the stale save" 9
-        on_disk.Agent_sdk.Checkpoint.turn_count
-    | Error _ -> fail "load after fingerprint-mismatch stale rejection failed")
+    match
+      Keeper_checkpoint_store.save_oas_classified ~session_dir
+        (make_checkpoint ~session_id ~turn_count:7 ~marker:"stale-v7")
+    with
+    | Ok
+        (Keeper_checkpoint_store.Stale_noop
+           { incoming_turn_count; known_turn_count }) ->
+      check int "external replacement makes turn 7 stale" 7 incoming_turn_count;
+      check int "canonical replacement is the known watermark" 9 known_turn_count
+    | Ok (Keeper_checkpoint_store.Saved _) ->
+      fail "stale save ignored an externally replaced canonical checkpoint"
+    | Error error -> fail ("external replacement classification failed: " ^ error))
 
 (* The OAS per-turn pipeline builds checkpoints with an empty session_id (the
    OAS agent carries no session field). The keeper sink stamps a validated,
@@ -502,7 +391,7 @@ let test_exact_source_cas_allows_one_equal_turn_writer () =
            checkpoint.messages)
     | _ -> fail "CAS winner did not round-trip")
 
-let test_exact_source_cas_invalidates_stale_watermark () =
+let test_exact_source_cas_updates_canonical_watermark () =
   let session_dir = temp_dir () in
   Fun.protect ~finally:(fun () -> cleanup_dir session_dir) (fun () ->
     let session_id = "sess-cas-watermark" in
@@ -510,10 +399,6 @@ let test_exact_source_cas_invalidates_stale_watermark () =
       (make_checkpoint ~session_id ~turn_count:8 ~marker:"source"
        |> with_generation 3)
       "CAS watermark seed save";
-    let canonical_path =
-      Keeper_checkpoint_store.oas_checkpoint_path ~session_dir ~session_id
-    in
-    let seed_mtime = (Unix.stat canonical_path).st_mtime in
     let source_ref =
       match
         Keeper_checkpoint_store.load_oas_with_ref ~session_dir ~session_id
@@ -530,11 +415,6 @@ let test_exact_source_cas_invalidates_stale_watermark () =
      with
      | Ok _ -> ()
      | Error _ -> fail "CAS watermark candidate did not commit");
-    (* The source and candidate encodings have equal byte length. Restoring
-       the source mtime deterministically recreates the exact fingerprint
-       collision under which an untouched source sidecar would still look
-       valid for the candidate canonical file. *)
-    Unix.utimes canonical_path seed_mtime seed_mtime;
     match
       Keeper_checkpoint_store.save_oas_classified ~session_dir
         (make_checkpoint ~session_id ~turn_count:8 ~marker:"stale!")
@@ -546,7 +426,7 @@ let test_exact_source_cas_invalidates_stale_watermark () =
       check int "CAS candidate remains the admission watermark" 9
         known_turn_count
     | Ok (Keeper_checkpoint_store.Saved _) ->
-      fail "stale save passed through a source sidecar after CAS"
+      fail "stale save ignored the canonical checkpoint installed by CAS"
     | Error error -> fail ("post-CAS stale classification failed: " ^ error))
 
 let test_checkpoint_ref_requires_generation () =
@@ -571,6 +451,8 @@ let () =
             test_forward_equal_and_stale;
           test_case "canonical disk is the watermark SSOT" `Quick
             test_disk_is_the_watermark_ssot;
+          test_case "external canonical replacement is the watermark" `Quick
+            test_externally_replaced_canonical_is_the_watermark;
           test_case "empty session_id is refused, not silently dropped" `Quick
             test_empty_session_id_rejected;
           test_case "invalid canonical checkpoint fails closed" `Quick
@@ -579,18 +461,12 @@ let () =
             test_multi_domain_writers_leave_max_turn_on_disk;
           test_case "ready runtime raw Domain saves through Unix context" `Quick
             test_ready_runtime_raw_domain_save;
-          test_case "fingerprint-matched sidecar skips the full parse" `Quick
-            test_fingerprint_match_skips_full_parse;
-          test_case "absent or corrupt sidecar falls back to full parse" `Quick
-            test_sidecar_unusable_falls_back_to_full_parse;
-          test_case "fingerprint mismatch recovers an externally-written canonical" `Quick
-            test_fingerprint_mismatch_recovers_externally_written_canonical;
           test_case "canonical checkpoint is written compact and round-trips" `Quick
             test_canonical_checkpoint_is_written_compact;
           test_case "exact source CAS permits one equal-turn writer" `Quick
             test_exact_source_cas_allows_one_equal_turn_writer;
-          test_case "exact source CAS invalidates stale watermark metadata" `Quick
-            test_exact_source_cas_invalidates_stale_watermark;
+          test_case "exact source CAS updates the canonical watermark" `Quick
+            test_exact_source_cas_updates_canonical_watermark;
           test_case "checkpoint refs require keeper generation" `Quick
             test_checkpoint_ref_requires_generation;
         ] );


### PR DESCRIPTION
## Summary

- stack on #24900 and use `Keeper_checkpoint_ref` as the single checkpoint identity SSOT
- load checkpoint bytes and typed ref from one stable-lock snapshot
- conditionally save only when the current canonical SHA-256/session/generation/turn identity still exactly matches
- purge the checkpoint watermark sidecar, its size/mtime fingerprint heuristic, public API, metric/error taxonomy, and sidecar-only tests
- keep this as a subordinate payload store; no compaction or operation-terminal wiring is activated here

## Why

The turn-count guard permits an equal-turn writer with different content to overwrite the canonical checkpoint. Exact source CAS prevents silent clobber between load and save. The fingerprinted watermark sidecar was a second admission authority and made CAS correctness depend on invalidation/recreation ordering, so this cumulative head deletes it instead of preserving compatibility.

## Invariants

- no size, mtime, timestamp, random id, process cache, sidecar, or heuristic participates in checkpoint admission or CAS identity
- canonical source SHA is computed from the actual locked file bytes
- ordinary stale admission parses canonical checkpoint state under the same stable session lock
- committed ref uses the exact compact bytes supplied to the durable writer contract
- renamed=true and lock-release failure are reconciliation-required, never blind-retry failures
- operation journal remains the sole terminal operation authority

## Verification

- `ocamlc -stop-after parsing` passed for all five touched OCaml source/interface/test files
- `ocamlformat --check` passed
- `git diff --check` passed
- focused wrapper build was attempted, but correctly stopped with exit 75 because another live bare `dune build --root .` bypassed the machine-wide lock; no bypass was used
- full PR CI is authoritative

## Follow-up found

- #25056 tracks preserving the completed CAS body outcome when lock release itself fails; this is an orthogonal `File_lock_eio` contract issue and is not guessed around here.