### PR TITLE
refactor(mcp): carry exact tool invocation identity

### DIFF
--- a/docs/KEEPER-CAPABILITY-MATRIX.md
+++ b/docs/KEEPER-CAPABILITY-MATRIX.md
@@ -69,9 +69,9 @@ Important families:
 - scheduled automation: `masc_schedule_create`, `masc_schedule_list`,
   `masc_schedule_get`, `masc_schedule_cancel`, `masc_schedule_approve`,
   `masc_schedule_reject`
-- keeper management/messaging: `masc_keeper_list`, `masc_keeper_status`,
-  `masc_keeper_msg`, `masc_keeper_msg_result`, `masc_keeper_msg_queue`,
-  `masc_keeper_msg_cancel`
+- keeper management/delegation: `masc_keeper_list`, `masc_keeper_status`,
+  `masc_keeper_delegate`, `masc_keeper_delegate_status`,
+  `masc_keeper_delegate_list`, `masc_keeper_delegate_cancel`
 - operator/maintenance keeper controls: broader descriptors such as
   `masc_keeper_compact`, `masc_keeper_clear`, `masc_keeper_sandbox_start`,
   `masc_keeper_sandbox_stop`, `masc_keeper_reset`,
@@ -100,7 +100,7 @@ Excluded from keeper exposure:
 | Past decisions or shared references | memory and library tools | Writing scratch notes to durable memory |
 | Workspace planning, goal lifecycle, run logs, notes, deliverables | `masc_goal_*`, `masc_plan_*`, `masc_run_*`, `masc_note_add`, `masc_deliver` | Mutating goals/plans for ordinary status narration |
 | Durable future automation | `masc_schedule_*` | Assuming side-effecting schedules run without human approval |
-| Targeted async help from another keeper | `masc_keeper_list`, `masc_keeper_status`, `masc_keeper_msg`, result/queue/cancel tools | Broadcasting a private question, or messaging an unknown keeper without status/list evidence |
+| Targeted async help from another keeper | `masc_keeper_list`, `masc_keeper_status`, `masc_keeper_delegate`, status/list/cancel tools | Broadcasting a private question, or delegating to an unknown keeper without status/list evidence |
 | High-impact ambiguous decision needing independent perspectives | `masc_fusion` with self-contained context | Replacing cheap code inspection, exact status evidence, or blocker reporting |
 | Stored image artifact analysis | `analyze_image` | Treating visible chat attachments as hidden sandbox files |
 
@@ -110,7 +110,7 @@ Keeper continuity is a bounded advanced capability, not a general memory promise
 
 If productized, the continuity promise is:
 
-- `masc_keeper_msg` can continue a same-trace conversation when checkpoint restore is healthy
+- `masc_keeper_delegate` can continue a same-trace conversation when checkpoint restore is healthy
 - `masc_keeper_status` and `masc_keeper_list(detailed=true)` expose enough continuity state to diagnose restore and handoff behavior
 - validation should rely on OAS checkpoint truth plus live runtime evidence
 
@@ -151,7 +151,7 @@ BoardActivity, IdleTimeout, MetricsAnomaly, StrategicReview.
 | 목표 / 계획 lifecycle | `masc_goal_list`, `masc_goal_upsert`, `masc_goal_transition` |
 | 계획/런/산출물 기록 | `masc_plan_get`, `masc_plan_init`, `masc_plan_update`, `masc_plan_set_task`, `masc_plan_get_task`, `masc_plan_clear_task`, `masc_run_init`, `masc_run_list`, `masc_run_get`, `masc_run_plan`, `masc_note_add`, `masc_deliver` |
 | 예약 자동화 | `masc_schedule_create`, `masc_schedule_list`, `masc_schedule_get`, `masc_schedule_cancel`, `masc_schedule_approve`, `masc_schedule_reject` |
-| 다른 keeper 상태/메시지 | `masc_keeper_list`, `masc_keeper_status`, `masc_keeper_msg`, `masc_keeper_msg_result`, `masc_keeper_msg_queue`, `masc_keeper_msg_cancel` |
+| 다른 keeper 상태/위임 | `masc_keeper_list`, `masc_keeper_status`, `masc_keeper_delegate`, `masc_keeper_delegate_status`, `masc_keeper_delegate_list`, `masc_keeper_delegate_cancel` |
 | 패널 심의 / 비동기 판단 보강 | `masc_fusion`, `masc_fusion_status` |
 | 저장 이미지 artifact 분석 | `analyze_image` |
 | 코드 작성 / 수정 | `Read` / `Grep` -> `Edit` / `Write`, then `Execute` with typed `git` argv |

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -210,7 +210,7 @@ masc_claim_next()
 
 - repo workspace collaboration: `masc_start`, `masc_status`, `masc_transition`, `masc_plan_set_task`, `masc_heartbeat`
 - keeper runtime front door: `masc_keeper_list`, `masc_keeper_status`, `masc_keeper_up`, `masc_keeper_down`
-- keeper async turn injection: `masc_keeper_msg` (advanced/callable, hidden from default `tools/list`)
+- keeper async invocation: `masc_keeper_delegate` (advanced/callable, hidden from default `tools/list`)
 
 retired orchestration surfaces are historical only. 새 사용자는 repo workspace collaboration과 keeper runtime에서 시작하고, read visibility가 필요할 때만 dashboard/operator surface로 내려간다.
 

--- a/docs/spec/01-system-overview.md
+++ b/docs/spec/01-system-overview.md
@@ -148,7 +148,7 @@ MASC의 현재 canonical front door는 3가지다.
 장기 실행과 연속성을 위한 경로.
 
 - **대상**: keeper lifecycle, long-running execution, OAS-backed autonomy
-- **핵심 도구**: `masc_keeper_up`, `masc_keeper_msg`, `masc_keeper_status`, `masc_keeper_down`
+- **핵심 도구**: `masc_keeper_up`, `masc_keeper_delegate`, `masc_keeper_status`, `masc_keeper_down`
 - **설명**: keeper는 OAS `Agent.run` 기반으로 실행되며, retired orchestration surfaces와 독립적으로 동작한다. 자세한 turn lifecycle은 [`04-turn-lifecycle.md`](./04-turn-lifecycle.md)를 참조.
 
 ### 7.3 Dashboard and Operator Read Visibility

--- a/lib/dune
+++ b/lib/dune
@@ -309,6 +309,7 @@
   masc.prompt_registry
   ;; MCP transport/session leaf primitives (extracted sub-libraries)
   masc.mcp_transport_protocol
+  masc.tool_invocation_ref
   masc.mcp_session
   ;; Response envelope leaf primitive (extracted sub-library)
   masc.response

--- a/lib/keeper/keeper_tool_boundary.ml
+++ b/lib/keeper/keeper_tool_boundary.ml
@@ -7,11 +7,13 @@ type 'a context = {
   clock : 'a Eio.Time.clock;
   proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option;
   net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option;
+  invocation_ref : Tool_invocation_ref.t option;
   publication_recovery_provider :
     Keeper_publication_recovery_availability.provider;
 }
 
 let create
+      ?invocation_ref
       ~config
       ~agent_name
       ~sw
@@ -19,6 +21,7 @@ let create
       ~proc_mgr
       ~net
       ~publication_recovery_provider
+      ()
   =
   { config
   ; agent_name
@@ -26,6 +29,7 @@ let create
   ; clock
   ; proc_mgr
   ; net
+  ; invocation_ref
   ; publication_recovery_provider
   }
 
@@ -41,10 +45,15 @@ let to_tool_keeper_context (ctx : _ context) : _ Keeper_tool_surface.context =
   }
 
 let dispatch ctx ~name ~args =
-  Keeper_tool_surface.dispatch (to_tool_keeper_context ctx) ~name ~args
+  Keeper_tool_surface.dispatch
+    ?invocation_ref:ctx.invocation_ref
+    (to_tool_keeper_context ctx)
+    ~name
+    ~args
 
 (* TEL-OK: this only closes over Keeper-owned context; dispatch remains observed downstream. *)
 let delegated_dispatch
+      ?invocation_ref
       ~config
       ~agent_name
       ~sw
@@ -52,9 +61,11 @@ let delegated_dispatch
       ~proc_mgr
       ~net
       ~publication_recovery_provider
+      ()
   =
   let ctx =
     create
+      ?invocation_ref
       ~config
       ~agent_name
       ~sw
@@ -62,6 +73,7 @@ let delegated_dispatch
       ~proc_mgr
       ~net
       ~publication_recovery_provider
+      ()
   in
   fun ~name ~args -> dispatch ctx ~name ~args
 ;;

--- a/lib/keeper/keeper_tool_boundary.mli
+++ b/lib/keeper/keeper_tool_boundary.mli
@@ -10,11 +10,13 @@ type 'a context = {
   clock : 'a Eio.Time.clock;
   proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option;
   net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option;
+  invocation_ref : Tool_invocation_ref.t option;
   publication_recovery_provider :
     Keeper_publication_recovery_availability.provider;
 }
 
 val create :
+  ?invocation_ref:Tool_invocation_ref.t ->
   config:Workspace.config ->
   agent_name:string ->
   sw:Eio.Switch.t ->
@@ -23,12 +25,14 @@ val create :
   net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option ->
   publication_recovery_provider:
     Keeper_publication_recovery_availability.provider ->
+  unit ->
   'a context
 
 val dispatch :
   _ context -> name:string -> args:Yojson.Safe.t -> Keeper_types_profile.tool_result option
 
 val delegated_dispatch :
+  ?invocation_ref:Tool_invocation_ref.t ->
   config:Workspace.config ->
   agent_name:string ->
   sw:Eio.Switch.t ->
@@ -37,6 +41,7 @@ val delegated_dispatch :
   net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option ->
   publication_recovery_provider:
     Keeper_publication_recovery_availability.provider ->
+  unit ->
   name:string ->
   args:Yojson.Safe.t ->
   Keeper_types_profile.tool_result option

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -501,7 +501,12 @@ let manual_compaction_wakeup_observation ~base_path keeper_name =
 
 (** Queue an operator compaction for the target Keeper's owning lane. *)
 (* RFC-0182 §3.1 — ctx-free body for keeper_dispatch_ref path. *)
-let keeper_compact_body ~(config : Workspace.config) args : tool_result =
+let keeper_compact_body
+      ?invocation_ref
+      ~(config : Workspace.config)
+      args
+  : tool_result
+  =
   match resolve_keeper_name_config ~config args with
   | Error err -> tool_result_error err
   | Ok name ->
@@ -535,6 +540,11 @@ let keeper_compact_body ~(config : Workspace.config) args : tool_result =
             ; "queued", `Bool true
             ; "queue_outcome", `String queue_outcome
             ; "stimulus", `String (Keeper_event_queue.payload_kind_label stimulus.payload)
+            ; ( "producer_invocation"
+              , Option.fold
+                  ~none:`Null
+                  ~some:Tool_invocation_ref.to_yojson
+                  invocation_ref )
             ; ( "wake"
               , manual_compaction_wakeup_observation
                   ~base_path:config.base_path
@@ -557,8 +567,8 @@ let keeper_compact_body ~(config : Workspace.config) args : tool_result =
        | Stimulus_enqueued -> queued "enqueued"
        | Stimulus_already_present -> queued "already_present")
 
-let handle_keeper_compact ctx args : tool_result =
-  keeper_compact_body ~config:ctx.config args
+let handle_keeper_compact ?invocation_ref ctx args : tool_result =
+  keeper_compact_body ?invocation_ref ~config:ctx.config args
 
 (** Last-resort context clear.
 
@@ -697,7 +707,7 @@ let keeper_clear_body ~(config : Workspace.config) args : tool_result =
 let handle_keeper_clear ctx args : tool_result =
   keeper_clear_body ~config:ctx.config args
 
-let dispatch ctx ~name ~args : tool_result option =
+let dispatch ?invocation_ref ctx ~name ~args : tool_result option =
   maybe_bootstrap_existing_keepalives ctx ~name ~args;
   let ctx = resolve_ctx ctx ~name args in
   match name with
@@ -740,7 +750,11 @@ let dispatch ctx ~name ~args : tool_result option =
            ~tool_name:name
            (handle_keeper_sandbox_status ctx args))
   | "masc_keeper_reset" -> Some (tool_result_with_tool_name ~tool_name:name (handle_keeper_reset ctx args))
-  | "masc_keeper_compact" -> Some (tool_result_with_tool_name ~tool_name:name (handle_keeper_compact ctx args))
+  | "masc_keeper_compact" ->
+    Some
+      (tool_result_with_tool_name
+         ~tool_name:name
+         (handle_keeper_compact ?invocation_ref ctx args))
   | "masc_keeper_clear" -> Some (tool_result_with_tool_name ~tool_name:name (handle_keeper_clear ctx args))
   | _ -> None
 

--- a/lib/keeper/keeper_tool_surface.mli
+++ b/lib/keeper/keeper_tool_surface.mli
@@ -17,7 +17,11 @@ type tool_result = Keeper_types_profile.tool_result
 val schemas : Masc_domain.tool_schema list
 
 val dispatch :
-  _ context -> name:string -> args:Yojson.Safe.t -> tool_result option
+  ?invocation_ref:Tool_invocation_ref.t ->
+  _ context ->
+  name:string ->
+  args:Yojson.Safe.t ->
+  tool_result option
 
 (** Internal async-message entry point for adapters whose authenticated
     submission principal differs from the target turn's [ctx.agent_name].

--- a/lib/mcp_server_eio.mli
+++ b/lib/mcp_server_eio.mli
@@ -128,6 +128,7 @@ val execute_tool_eio :
   workspace_scope:Mcp_server.workspace_scope ->
   ?profile:tool_profile ->
   ?mcp_session_id:string ->
+  ?invocation_ref:Tool_invocation_ref.t ->
   ?auth_token:string ->
   ?internal_keeper_runtime:bool ->
   server_state ->

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -489,6 +489,25 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
   in
   let config = workspace_scope.config in
   let make_response = Mcp_transport_protocol.make_response in
+  let request_id =
+    match Mcp_transport_protocol.request_id_of_yojson id with
+    | Ok request_id -> request_id
+    | Error error ->
+      invalid_arg
+        ("handle_call_tool_eio admitted an invalid MCP request id: "
+         ^ Mcp_transport_protocol.request_id_error_to_string error)
+  in
+  let invocation_ref =
+    match mcp_session_id with
+    | None -> None
+    | Some session_id ->
+      (match Tool_invocation_ref.external_mcp ~request_id ~session_id with
+       | Ok invocation_ref -> Some invocation_ref
+       | Error error ->
+         invalid_arg
+           ("handle_call_tool_eio admitted an invalid MCP invocation scope: "
+            ^ Tool_invocation_ref.error_to_string error))
+  in
   let (name, arguments) =
     match profile with
     | Managed_agent -> (
@@ -512,6 +531,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
         ~workspace_scope
         ?profile:(Some profile)
         ?mcp_session_id
+        ?invocation_ref
         ?auth_token
         ?internal_keeper_runtime:(Some internal_keeper_runtime)
         state
@@ -550,14 +570,10 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
   in
   let end_time = Eio.Time.now clock in
   let duration_ms = int_of_float ((end_time -. start_time) *. 1000.0) in
-  let jsonrpc_id_str =
-    match id with
-    | `String s -> s
-    | `Int i -> string_of_int i
-    | `Intlit s -> s
-    | `Float f -> Printf.sprintf "%0.0f" f
-    | _ -> "unknown"
+  let request_id_json =
+    Mcp_transport_protocol.request_id_to_yojson request_id
   in
+  let request_id_trace_fallback = Yojson.Safe.to_string request_id_json in
   let mcp_session_detail = Json_util.string_opt_to_json mcp_session_id in
 
   (* Resolve caller identity for telemetry.  HTTP auth injects [_agent_name];
@@ -609,7 +625,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
               `String (Tool_result.tool_failure_class_to_string failure_class) );
             ("tool_name", `String name);
             ("phase", `String "failure");
-            ("request_id", `String jsonrpc_id_str);
+            ("request_id", request_id_json);
             ("session_id", mcp_session_detail);
             ("outcome", `String "error");
             ("agent_name", `String agent_name);
@@ -755,7 +771,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
   let trace_id =
     match otel_trace_id with
     | Some tid -> tid
-    | None -> jsonrpc_id_str
+    | None -> request_id_trace_fallback
   in
   (match keeper_entry with
    | Some entry ->
@@ -835,7 +851,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
           ("event_family", `String "tool_call");
           ("tool_name", `String name);
           ("phase", `String "result");
-          ("request_id", `String jsonrpc_id_str);
+          ("request_id", request_id_json);
           ("session_id", mcp_session_detail);
           ("agent_name", `String agent_name);
           ("outcome", `String (Tool_result.string_of_tool_call_outcome outcome));

--- a/lib/mcp_server_eio_call_tool.mli
+++ b/lib/mcp_server_eio_call_tool.mli
@@ -115,6 +115,7 @@ val handle_call_tool_eio :
      workspace_scope:Mcp_server.workspace_scope ->
      ?profile:Mcp_server_eio_types.tool_profile ->
      ?mcp_session_id:string ->
+     ?invocation_ref:Tool_invocation_ref.t ->
      ?auth_token:'auth ->
      ?internal_keeper_runtime:bool ->
      Mcp_server.server_state ->

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -25,6 +25,7 @@ let execute_tool_eio
       ~(workspace_scope : Mcp_server.workspace_scope)
       ?(profile = Mcp_server_eio_tool_profile.Full)
       ?mcp_session_id
+      ?invocation_ref
       ?auth_token
       ?(internal_keeper_runtime = false)
       state
@@ -234,6 +235,7 @@ let execute_tool_eio
             (* Helper: create keeper tool boundary context (shared by goals) *)
             let make_keeper_tool_ctx () =
               Keeper_tool_boundary.create
+                ?invocation_ref
                 ~config
                 ~agent_name
                 ~sw
@@ -242,6 +244,7 @@ let execute_tool_eio
                 ~net:state.Mcp_server.net
                 ~publication_recovery_provider:
                   (Mcp_server.publication_recovery_availability_provider state)
+                ()
             in
             (* Dispatch a single module by tag — creates only that module's context.
      Pre-hooks may coerce arguments (e.g. OAS type coercion: "42" -> 42).
@@ -254,6 +257,20 @@ let execute_tool_eio
                 (match tag with
                  | Mod_plan -> Tool_plan.dispatch { config } ~name ~args:coerced_args
                  | Mod_operator ->
+                   let delegated_dispatch =
+                     Keeper_tool_boundary.delegated_dispatch
+                       ?invocation_ref
+                       ~config
+                       ~agent_name
+                       ~sw
+                       ~clock
+                       ~proc_mgr:state.Mcp_server.proc_mgr
+                       ~net:state.Mcp_server.net
+                       ~publication_recovery_provider:
+                         (Mcp_server.publication_recovery_availability_provider
+                            state)
+                       ()
+                   in
                    let ctx =
                      { Tool_operator.config
                      ; agent_name
@@ -261,18 +278,7 @@ let execute_tool_eio
                      ; clock
                      ; proc_mgr = state.Mcp_server.proc_mgr
                      ; net = state.Mcp_server.net
-                     ; delegated_dispatch =
-                         Some
-                           (Keeper_tool_boundary.delegated_dispatch
-                              ~config
-                              ~agent_name
-                              ~sw
-                              ~clock
-                              ~proc_mgr:state.Mcp_server.proc_mgr
-                              ~net:state.Mcp_server.net
-                              ~publication_recovery_provider:
-                                (Mcp_server.publication_recovery_availability_provider
-                                   state))
+                     ; delegated_dispatch = Some delegated_dispatch
                      ; mcp_session_id
                      }
                    in

--- a/lib/mcp_server_eio_execute.mli
+++ b/lib/mcp_server_eio_execute.mli
@@ -46,6 +46,7 @@ val execute_tool_eio :
   workspace_scope:Mcp_server.workspace_scope ->
   ?profile:Mcp_server_eio_types.tool_profile ->
   ?mcp_session_id:string ->
+  ?invocation_ref:Tool_invocation_ref.t ->
   ?auth_token:string ->
   ?internal_keeper_runtime:bool ->
   Mcp_server.server_state ->

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -753,13 +753,7 @@ let handle_request
         | Ok req ->
           let id = get_id req in
           let base_path = (Mcp_server.workspace_config state).Workspace.base_path in
-          if not (is_valid_request_id id)
-          then
-            make_error_typed
-              ~id:`Null
-              Mcp_error_code.Invalid_request
-              "Invalid Request: id must be string, number, or null"
-          else if Mcp_transport_protocol.is_notification req
+          if Mcp_transport_protocol.is_notification req
           then (
             match req.method_ with
             | "dashboard/ack" ->
@@ -771,6 +765,12 @@ let handle_request
                 (fun _auth_token ->
                    handle_dashboard_ack_notification ?mcp_session_id req.params)
             | _ -> `Null)
+          else if not (is_valid_request_id id)
+          then
+            make_error_typed
+              ~id:`Null
+              Mcp_error_code.Invalid_request
+              "Invalid Request: MCP id must be a string or integer"
           else (
             try
               match req.method_ with

--- a/lib/mcp_transport_protocol/mcp_transport_protocol.ml
+++ b/lib/mcp_transport_protocol/mcp_transport_protocol.ml
@@ -17,6 +17,71 @@ type jsonrpc_request = {
   params : Yojson.Safe.t option; [@default None]
 } [@@deriving yojson { strict = false }]
 
+type request_id =
+  | String_id of string
+  | Integer_id of string
+
+type request_id_error =
+  | Null_request_id
+  | Non_lossless_number
+  | Invalid_integer_lexeme of string
+  | Invalid_request_id_kind
+
+let is_digit c = c >= '0' && c <= '9'
+
+let is_json_integer_lexeme value =
+  let length = String.length value in
+  let first_digit =
+    if length > 0 && value.[0] = '-' then 1 else 0
+  in
+  if first_digit >= length
+  then false
+  else
+    let first = value.[first_digit] in
+    if first = '0'
+    then first_digit + 1 = length
+    else
+      first >= '1'
+      && first <= '9'
+      &&
+      let rec all_digits index =
+        index = length
+        || (is_digit value.[index] && all_digits (index + 1))
+      in
+      all_digits (first_digit + 1)
+;;
+
+let request_id_of_yojson = function
+  | `String value -> Ok (String_id value)
+  | `Int value -> Ok (Integer_id (string_of_int value))
+  | `Intlit value when is_json_integer_lexeme value -> Ok (Integer_id value)
+  | `Intlit value -> Error (Invalid_integer_lexeme value)
+  | `Float _ -> Error Non_lossless_number
+  | `Null -> Error Null_request_id
+  | `Assoc _ | `List _ | `Bool _ -> Error Invalid_request_id_kind
+;;
+
+let request_id_to_yojson = function
+  | String_id value -> `String value
+  | Integer_id value -> `Intlit value
+;;
+
+let request_id_equal left right =
+  match left, right with
+  | String_id left, String_id right
+  | Integer_id left, Integer_id right -> String.equal left right
+  | String_id _, Integer_id _ | Integer_id _, String_id _ -> false
+;;
+
+let request_id_error_to_string = function
+  | Null_request_id -> "MCP request id must not be null"
+  | Non_lossless_number ->
+    "MCP request id must be an integer; floating JSON numbers are not lossless"
+  | Invalid_integer_lexeme value ->
+    Printf.sprintf "invalid MCP integer request id lexeme: %S" value
+  | Invalid_request_id_kind -> "MCP request id must be a string or integer"
+;;
+
 let has_field key = function
   | `Assoc fields -> List.exists (fun (k, _) -> k = key) fields
   | _ -> false
@@ -44,9 +109,7 @@ let is_notification req = req.id = None
 
 let get_id req = match req.id with Some id -> id | None -> `Null
 
-let is_valid_request_id = function
-  | `Null | `String _ | `Int _ | `Intlit _ | `Float _ -> true
-  | _ -> false
+let is_valid_request_id value = Result.is_ok (request_id_of_yojson value)
 
 let validate_initialize_params params =
   let ( let* ) = Result.bind in

--- a/lib/mcp_transport_protocol/mcp_transport_protocol.mli
+++ b/lib/mcp_transport_protocol/mcp_transport_protocol.mli
@@ -18,6 +18,29 @@ type jsonrpc_request = {
 (** JSON-RPC 2.0 request. [id = None] denotes a notification. The
     [method_] OCaml field maps to the JSON ["method"] key. *)
 
+type request_id
+(** Exact MCP request identity. Integer ids retain their canonical JSON
+    lexeme so callers never round-trip through a binary float. *)
+
+type request_id_error =
+  | Null_request_id
+  | Non_lossless_number
+  | Invalid_integer_lexeme of string
+  | Invalid_request_id_kind
+
+val request_id_of_yojson :
+  Yojson.Safe.t -> (request_id, request_id_error) result
+(** Parses the MCP request-id contract: string or integer only. [`Float _]
+    is rejected even when mathematically integral because Yojson has already
+    discarded the producer's exact decimal lexeme. *)
+
+val request_id_to_yojson : request_id -> Yojson.Safe.t
+(** Lossless wire projection of a typed request id. *)
+
+val request_id_equal : request_id -> request_id -> bool
+
+val request_id_error_to_string : request_id_error -> string
+
 val has_field : string -> Yojson.Safe.t -> bool
 (** [has_field key json] is [true] when [json] is an [`Assoc] containing [key]. *)
 
@@ -39,8 +62,8 @@ val get_id : jsonrpc_request -> Yojson.Safe.t
 (** Returns the request id, defaulting to [`Null] for notifications. *)
 
 val is_valid_request_id : Yojson.Safe.t -> bool
-(** Per the JSON-RPC 2.0 spec, valid ids are [`Null], [`String _],
-    [`Int _], [`Intlit _], or [`Float _]. *)
+(** MCP requests admit string or integer ids. Null and floating-point ids are
+    rejected, as required by the MCP request contract. *)
 
 val validate_initialize_params : Yojson.Safe.t option -> (unit, string) result
 (** Checks that [params] for the MCP [initialize] method contain

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -751,7 +751,8 @@ let operator_control_context ~state ~sw ~clock ~config ~agent_name
            ~proc_mgr:state.Mcp_server.proc_mgr
            ~net:state.Mcp_server.net
            ~publication_recovery_provider:
-             (Mcp_server.publication_recovery_availability_provider state))
+             (Mcp_server.publication_recovery_availability_provider state)
+           ())
   ; mcp_session_id = None
   }
 ;;

--- a/lib/tool_invocation_ref/dune
+++ b/lib/tool_invocation_ref/dune
@@ -1,0 +1,10 @@
+(include_subdirs no)
+
+(library
+ (name masc_tool_invocation_ref)
+ (public_name masc.tool_invocation_ref)
+ (wrapped false)
+ (modules tool_invocation_ref)
+ (flags
+  (:standard -w +4))
+ (libraries masc.mcp_transport_protocol yojson))

--- a/lib/tool_invocation_ref/tool_invocation_ref.ml
+++ b/lib/tool_invocation_ref/tool_invocation_ref.ml
@@ -1,0 +1,35 @@
+type t =
+  | External_mcp of
+      { request_id : Mcp_transport_protocol.request_id
+      ; session_id : string
+      }
+
+type error = Empty_mcp_session_id
+
+let external_mcp ~request_id ~session_id =
+  if String.equal (String.trim session_id) ""
+  then Error Empty_mcp_session_id
+  else Ok (External_mcp { request_id; session_id })
+;;
+
+let to_yojson = function
+  | External_mcp { request_id; session_id } ->
+    `Assoc
+      [ "source", `String "external_mcp"
+      ; "session_id", `String session_id
+      ; "request_id", Mcp_transport_protocol.request_id_to_yojson request_id
+      ]
+;;
+
+let equal left right =
+  match left, right with
+  | ( External_mcp { request_id = left_id; session_id = left_session }
+    , External_mcp { request_id = right_id; session_id = right_session } ) ->
+    String.equal left_session right_session
+    && Mcp_transport_protocol.request_id_equal left_id right_id
+;;
+
+let error_to_string = function
+  | Empty_mcp_session_id ->
+    "external MCP tool invocation requires a non-empty stable session id"
+;;

--- a/lib/tool_invocation_ref/tool_invocation_ref.mli
+++ b/lib/tool_invocation_ref/tool_invocation_ref.mli
@@ -1,0 +1,22 @@
+(** Exact producer identity for a tool invocation crossing into MASC.
+
+    This type owns correlation only. It does not authorize an effect and does
+    not infer identity from tool names, arguments, timestamps, or hashes. *)
+
+type t
+
+type error = Empty_mcp_session_id
+
+val external_mcp :
+  request_id:Mcp_transport_protocol.request_id ->
+  session_id:string ->
+  (t, error) result
+(** Builds an external MCP identity from the exact typed JSON-RPC request id
+    and the stable transport session id. *)
+
+val to_yojson : t -> Yojson.Safe.t
+(** Typed, inspectable projection. *)
+
+val equal : t -> t -> bool
+
+val error_to_string : error -> string

--- a/test/deps/dune
+++ b/test/deps/dune
@@ -112,6 +112,7 @@
   (re_export masc.masc_compression)
   (re_export masc.mcp_session)
   (re_export masc.mcp_transport_protocol)
+  (re_export masc.tool_invocation_ref)
   (re_export masc.multimodal)
   (re_export masc.prompt_registry)
   (re_export masc.pulse)

--- a/test/test_keeper_adversarial_review.ml
+++ b/test/test_keeper_adversarial_review.ml
@@ -69,7 +69,8 @@ let operator_ctx env sw config agent_name : _ Operator_control.context =
            ~clock:(Eio.Stdenv.clock env)
            ~proc_mgr:(Some (Eio.Stdenv.process_mgr env))
            ~net:(Some (Eio.Stdenv.net env))
-           ~publication_recovery_provider);
+           ~publication_recovery_provider
+           ());
     mcp_session_id = None;
   }
 

--- a/test/test_mcp_server_eio_call_tool.ml
+++ b/test/test_mcp_server_eio_call_tool.ml
@@ -104,7 +104,7 @@ let with_call_tool_state f =
       f env sw state)
 ;;
 
-let call_with_result ~env ~sw state result =
+let call_with_result ?mcp_session_id ?observe_invocation ~env ~sw state result =
   Masc.Mcp_server_eio_call_tool.handle_call_tool_eio
     ~execute_tool_eio:
       (fun
@@ -113,15 +113,19 @@ let call_with_result ~env ~sw state result =
         ~workspace_scope:_
         ?profile:_
         ?mcp_session_id:_
+        ?invocation_ref
         ?auth_token:_
         ?internal_keeper_runtime:_
         _state
         ~name:_
-        ~arguments:_ -> result)
+        ~arguments:_ ->
+        Option.iter (fun observe -> observe invocation_ref) observe_invocation;
+        result)
     ~maybe_emit_resource_notifications:(fun ~success:_ ~tool_name:_ -> ())
     ~broadcast_tools_list_changed:(fun () -> ())
     ~sw
     ~clock:(Eio.Stdenv.clock env)
+    ?mcp_session_id
     state
     (`Int 1)
     (`Assoc
@@ -129,6 +133,36 @@ let call_with_result ~env ~sw state result =
       ; "arguments", `Assoc [ "_agent_name", `String "projection-test" ]
       ])
 ;;
+
+let test_threads_exact_mcp_invocation_identity () =
+  with_call_tool_state (fun env sw state ->
+    let observed = ref None in
+    let result =
+      Tool_result.make_ok
+        ~tool_name:"masc_status"
+        ~start_time:0.0
+        ~data:(`String "ok")
+        ()
+    in
+    ignore
+      (call_with_result
+         ~mcp_session_id:"typed-session"
+         ~observe_invocation:(fun invocation -> observed := invocation)
+         ~env ~sw state result);
+    let request_id =
+      Mcp_transport_protocol.request_id_of_yojson (`Int 1) |> Result.get_ok
+    in
+    let expected =
+      Tool_invocation_ref.external_mcp
+        ~request_id
+        ~session_id:"typed-session"
+      |> Result.get_ok
+    in
+    match !observed with
+    | Some actual ->
+      check bool "exact invocation identity" true
+        (Tool_invocation_ref.equal expected actual)
+    | None -> fail "execute callback did not receive invocation identity")
 
 let result_fields response = response |> U.member "result"
 let result_envelope response = result_fields response |> U.member "resultEnvelope"
@@ -261,6 +295,7 @@ let test_handle_call_executes_transient_failure_once () =
               ~workspace_scope:_
               ?profile:_
               ?mcp_session_id:_
+              ?invocation_ref:_
               ?auth_token:_
               ?internal_keeper_runtime:_
               _state
@@ -328,6 +363,7 @@ let test_call_captures_admission_scope_across_workspace_switch () =
               ~workspace_scope
               ?profile:_
               ?mcp_session_id:_
+              ?invocation_ref:_
               ?auth_token:_
               ?internal_keeper_runtime:_
               callback_state
@@ -732,6 +768,8 @@ let () =
             test_handle_call_executes_transient_failure_once;
           test_case "captures admission scope across workspace switch" `Quick
             test_call_captures_admission_scope_across_workspace_switch;
+          test_case "threads exact MCP invocation identity" `Quick
+            test_threads_exact_mcp_invocation_identity;
           test_case "activity payload sanitizes invalid UTF-8" `Quick
             test_activity_payload_sanitizes_invalid_utf8;
           test_case "records MCP server operation duration metric" `Quick

--- a/test/test_mcp_server_eio_coverage.ml
+++ b/test/test_mcp_server_eio_coverage.ml
@@ -8,6 +8,7 @@ open Alcotest
 module Mcp_server_eio = Masc.Mcp_server_eio
 module Mcp_server = Masc.Mcp_server
 module Mcp_server_eio_protocol = Masc.Mcp_server_eio_protocol
+module Request_id = Mcp_transport_protocol
 (* ============================================================
    is_jsonrpc_v2 Tests
    ============================================================ *)
@@ -214,7 +215,7 @@ let test_get_id_none () =
    ============================================================ *)
 
 let test_is_valid_request_id_null () =
-  check bool "null valid" true (Mcp_server.is_valid_request_id `Null)
+  check bool "null invalid" false (Mcp_server.is_valid_request_id `Null)
 
 let test_is_valid_request_id_string () =
   check bool "string valid" true (Mcp_server.is_valid_request_id (`String "id-1"))
@@ -223,7 +224,38 @@ let test_is_valid_request_id_int () =
   check bool "int valid" true (Mcp_server.is_valid_request_id (`Int 123))
 
 let test_is_valid_request_id_float () =
-  check bool "float valid" true (Mcp_server.is_valid_request_id (`Float 1.5))
+  check bool "float invalid" false (Mcp_server.is_valid_request_id (`Float 1.5))
+
+let test_request_id_preserves_large_integer_lexeme () =
+  let lexeme = "92233720368547758081234567890" in
+  match Request_id.request_id_of_yojson (`Intlit lexeme) with
+  | Error _ -> fail "expected exact large integer request id"
+  | Ok request_id ->
+    check string "exact lexeme" lexeme
+      (Yojson.Safe.to_string (Request_id.request_id_to_yojson request_id))
+
+let invocation_ref_exn request_id =
+  match
+    Tool_invocation_ref.external_mcp
+      ~request_id
+      ~session_id:"mcp-session-1"
+  with
+  | Ok invocation -> invocation
+  | Error error -> fail (Tool_invocation_ref.error_to_string error)
+
+let test_tool_invocation_identity_distinguishes_string_and_integer () =
+  let string_id =
+    Request_id.request_id_of_yojson (`String "1")
+    |> Result.get_ok
+    |> invocation_ref_exn
+  in
+  let integer_id =
+    Request_id.request_id_of_yojson (`Int 1)
+    |> Result.get_ok
+    |> invocation_ref_exn
+  in
+  check bool "typed ids remain distinct" true
+    (not (Tool_invocation_ref.equal string_id integer_id))
 
 let test_is_valid_request_id_array () =
   check bool "array invalid" false (Mcp_server.is_valid_request_id (`List []))
@@ -484,6 +516,12 @@ let () =
       test_case "float" `Quick test_is_valid_request_id_float;
       test_case "array" `Quick test_is_valid_request_id_array;
       test_case "object" `Quick test_is_valid_request_id_object;
+    ];
+    "typed_request_identity", [
+      test_case "large integer lexeme" `Quick
+        test_request_id_preserves_large_integer_lexeme;
+      test_case "string and integer distinct" `Quick
+        test_tool_invocation_identity_distinguishes_string_and_integer;
     ];
     "validate_initialize_params", [
       test_case "valid" `Quick test_validate_initialize_params_valid;

--- a/test/test_operator_control_support.ml
+++ b/test/test_operator_control_support.ml
@@ -77,7 +77,8 @@ let operator_ctx ?mcp_session_id env sw config agent_name :
            ~clock:(Eio.Stdenv.clock env)
            ~proc_mgr:(Some (Eio.Stdenv.process_mgr env))
            ~net:(Some (Eio.Stdenv.net env))
-           ~publication_recovery_provider);
+           ~publication_recovery_provider
+           ());
     mcp_session_id;
   }
 


### PR DESCRIPTION
## Summary

- Add an abstract, lossless MCP request-id type for string/integer IDs; reject null and floating JSON numbers.
- Carry `Tool_invocation_ref.t` from JSON-RPC admission through MCP execution and the Keeper tool boundary.
- Preserve the typed request ID in observability JSON, so string `"1"` and integer `1` remain distinct.
- Expose the typed producer reference on `masc_keeper_compact` results without minting a replacement ID.
- Place `Tool_invocation_ref` in the cycle-safe wrapped-false `masc.tool_invocation_ref` leaf, depending only on `masc.mcp_transport_protocol` and `yojson`.

## Boundary and SSOT

- `Tool_invocation_ref.t` is correlation data only. This PR adds no writer, journal, cache, global map, counter, timestamp/hash identity, authorization, or routing heuristic.
- It does not make `Durable_event`, `Raw_trace`, or `Event_bus` an operation writer. The Operation Journal follow-up can depend directly on the leaf and embed this typed value during the single-writer hard cut.
- The root `masc` library depends on the leaf; the leaf does not depend on root `masc`, Keeper, or the future Operation Journal.
- The current OAS `Agent_sdk.Tool` handler boundary drops the exact provider `tool_use_id` and exposes no non-`Raw_trace` execution/scope reference. The OAS-origin variant is intentionally not fabricated here.
- MCP requires request IDs to be unique within a session. Duplicate-ID admission enforcement is tracked separately in #24901; this PR preserves the exact transport pair but does not claim externally validated uniqueness before that fix.

Spec: https://modelcontextprotocol.io/specification/2025-11-25/basic/index

## Validation

- `scripts/dune-local.sh build test/test_mcp_server_eio_coverage.exe test/test_mcp_server_eio_call_tool.exe test/test_keeper_adversarial_review.exe`
- `test_mcp_server_eio_coverage.exe`: 53 passed
- `test_mcp_server_eio_call_tool.exe`: 10 passed
- `test_keeper_adversarial_review.exe`: 14 passed
- `git diff --check origin/main...HEAD`
- Diff size: 342 additions + 48 deletions = 390 changed lines
