### PR TITLE
refactor(compaction)!: purge heuristic trigger kinds

### DIFF
--- a/lib/compaction_trigger/compaction_trigger.ml
+++ b/lib/compaction_trigger/compaction_trigger.ml
@@ -1,33 +1,13 @@
 type t =
-  | Ratio_threshold of
-      { ratio : float
-      ; threshold : float
-      }
-  | Message_count of
-      { count : int
-      ; threshold : int
-      }
-  | Token_count of
-      { count : int
-      ; threshold : int
-      }
   | Provider_overflow of { limit_tokens : int option }
   | Manual
 
 let to_label = function
-  | Ratio_threshold _ -> "ratio"
-  | Message_count _ -> "messages"
-  | Token_count _ -> "tokens"
   | Provider_overflow _ -> "provider_overflow"
   | Manual -> "manual"
 ;;
 
 let to_human = function
-  | Ratio_threshold { ratio; threshold } ->
-    Printf.sprintf "ratio(%.4f>=%.4f)" ratio threshold
-  | Message_count { count; threshold } ->
-    Printf.sprintf "messages(%d>=%d)" count threshold
-  | Token_count { count; threshold } -> Printf.sprintf "tokens(%d>=%d)" count threshold
   | Provider_overflow { limit_tokens } ->
     Printf.sprintf
       "provider_overflow(limit=%s)"
@@ -38,14 +18,6 @@ let to_human = function
 ;;
 
 let to_detail_json : t -> Yojson.Safe.t = function
-  | Ratio_threshold { ratio; threshold } ->
-    `Assoc
-      [ "kind", `String "ratio"; "ratio", `Float ratio; "threshold", `Float threshold ]
-  | Message_count { count; threshold } ->
-    `Assoc
-      [ "kind", `String "messages"; "count", `Int count; "threshold", `Int threshold ]
-  | Token_count { count; threshold } ->
-    `Assoc [ "kind", `String "tokens"; "count", `Int count; "threshold", `Int threshold ]
   | Provider_overflow { limit_tokens } ->
     `Assoc
       [ "kind", `String "provider_overflow"
@@ -57,49 +29,59 @@ let to_detail_json : t -> Yojson.Safe.t = function
   | Manual -> `Assoc [ "kind", `String "manual" ]
 ;;
 
-let of_detail_json (json : Yojson.Safe.t) : t option =
+type decode_error =
+  | Expected_object
+  | Unknown_field of string
+  | Duplicate_field of string
+  | Missing_kind
+  | Invalid_kind
+  | Unknown_kind of string
+  | Missing_provider_limit
+  | Invalid_provider_limit
+
+let decode_error_to_string = function
+  | Expected_object -> "compaction trigger detail must be an object"
+  | Unknown_field name ->
+    Printf.sprintf "compaction trigger detail has unknown field %S" name
+  | Duplicate_field name ->
+    Printf.sprintf "compaction trigger detail has duplicate field %S" name
+  | Missing_kind -> "compaction trigger detail is missing kind"
+  | Invalid_kind -> "compaction trigger kind must be a string"
+  | Unknown_kind kind -> Printf.sprintf "unknown compaction trigger kind %S" kind
+  | Missing_provider_limit -> "provider overflow trigger is missing limit_tokens"
+  | Invalid_provider_limit ->
+    "provider overflow limit_tokens must be null or a positive integer"
+;;
+
+let of_detail_json (json : Yojson.Safe.t) : (t, decode_error) result =
   match json with
   | `Assoc fields ->
-    let str key =
-      match List.assoc_opt key fields with
-      | Some (`String s) -> Some s
-      | _ -> None
+    let rec reject_duplicate_fields seen = function
+      | [] -> Ok ()
+      | (name, _) :: _ when List.mem name seen -> Error (Duplicate_field name)
+      | (name, _) :: rest -> reject_duplicate_fields (name :: seen) rest
     in
-    let num_float key =
-      match List.assoc_opt key fields with
-      | Some (`Float f) -> Some f
-      | Some (`Int i) -> Some (float_of_int i)
-      | _ -> None
+    let reject_unknown_fields allowed =
+      match List.find_opt (fun (name, _) -> not (List.mem name allowed)) fields with
+      | Some (name, _) -> Error (Unknown_field name)
+      | None -> Ok ()
     in
-    let num_int key =
-      match List.assoc_opt key fields with
-      | Some (`Int i) -> Some i
-      | Some (`Intlit s) -> int_of_string_opt s
-      | _ -> None
-    in
-    (match str "kind" with
-     | Some "ratio" ->
-       (match num_float "ratio", num_float "threshold" with
-        | Some ratio, Some threshold -> Some (Ratio_threshold { ratio; threshold })
-        | _ -> None)
-     | Some "messages" ->
-       (match num_int "count", num_int "threshold" with
-        | Some count, Some threshold -> Some (Message_count { count; threshold })
-        | _ -> None)
-     | Some "tokens" ->
-       (match num_int "count", num_int "threshold" with
-        | Some count, Some threshold -> Some (Token_count { count; threshold })
-        | _ -> None)
-     | Some "provider_overflow" ->
+    let ( let* ) = Result.bind in
+    let* () = reject_duplicate_fields [] fields in
+    (match List.assoc_opt "kind" fields with
+     | Some (`String "provider_overflow") ->
+       let* () = reject_unknown_fields [ "kind"; "limit_tokens" ] in
        (match List.assoc_opt "limit_tokens" fields with
-        | Some `Null | None -> Some (Provider_overflow { limit_tokens = None })
-        | Some (`Int limit_tokens) ->
-          Some (Provider_overflow { limit_tokens = Some limit_tokens })
-        | Some _ -> None)
-     (* "tool_heavy" rows persist in historical JSONL; the trigger was removed
-        (gate measured stored-history bulk that the OAS call-time pruner already
-        bounds per call) so they parse to None like any unknown kind. *)
-     | Some "manual" -> Some Manual
-     | _ -> None)
-  | _ -> None
+        | Some `Null -> Ok (Provider_overflow { limit_tokens = None })
+        | Some (`Int limit_tokens) when limit_tokens > 0 ->
+          Ok (Provider_overflow { limit_tokens = Some limit_tokens })
+        | None -> Error Missing_provider_limit
+        | Some _ -> Error Invalid_provider_limit)
+     | Some (`String "manual") ->
+       let* () = reject_unknown_fields [ "kind" ] in
+       Ok Manual
+     | Some (`String kind) -> Error (Unknown_kind kind)
+     | Some _ -> Error Invalid_kind
+     | None -> Error Missing_kind)
+  | _ -> Error Expected_object
 ;;

--- a/lib/compaction_trigger/compaction_trigger.mli
+++ b/lib/compaction_trigger/compaction_trigger.mli
@@ -1,44 +1,33 @@
-(** Compaction_trigger — closed sum type for context compaction reason.
-
-    Replaces the prior [string] / [string option] representation in
-    [compaction_event.trigger] and [pre_compact_event.trigger] so the
-    Otel_metric_store [trigger] label has bounded cardinality (5 values) while
-    structured numerical detail (ratio, counts, thresholds) is preserved
-    in the JSON receipt via [to_detail_json]. *)
+(** Compaction_trigger — explicit context compaction request origin. *)
 
 type t =
-  | Ratio_threshold of
-      { ratio : float
-      ; threshold : float
-      }
-  | Message_count of
-      { count : int
-      ; threshold : int
-      }
-  | Token_count of
-      { count : int
-      ; threshold : int
-      }
   | Provider_overflow of { limit_tokens : int option }
       (** Typed provider context-window overflow. [limit_tokens] is the
           provider-declared limit when present, never an estimated count. *)
   | Manual
 
-(** Closed label set (5 values) for Otel_metric_store / SSE [trigger] label.
+(** Closed label set for Otel_metric_store / SSE [trigger] label.
     Use this anywhere cardinality matters. *)
 val to_label : t -> string
 
-(** Human-readable rendering with embedded numerical detail.  Use for
-    [Log.*] string interpolation only — NOT for Otel_metric_store labels. *)
+(** Human-readable rendering. Use for [Log.*] string interpolation only. *)
 val to_human : t -> string
 
-(** Structured JSON detail with all numerical fields preserved.  Use
-    inside SSE broadcasts and JSON receipts so dashboards can plot
-    actual ratios/counts rather than parse strings. *)
+(** Structured JSON detail for durable observation. *)
 val to_detail_json : t -> Yojson.Safe.t
 
-(** Inverse of {!to_detail_json}.  Returns [None] if the JSON cannot be
-    parsed as a known trigger kind.  Used by persistence-recovery code
-    paths (e.g. dashboard log replay) where the typed variant must be
-    reconstructed from a stored JSON record. *)
-val of_detail_json : Yojson.Safe.t -> t option
+type decode_error =
+  | Expected_object
+  | Unknown_field of string
+  | Duplicate_field of string
+  | Missing_kind
+  | Invalid_kind
+  | Unknown_kind of string
+  | Missing_provider_limit
+  | Invalid_provider_limit
+
+val decode_error_to_string : decode_error -> string
+
+val of_detail_json : Yojson.Safe.t -> (t, decode_error) result
+(** Exact inverse of {!to_detail_json}. Retired heuristic trigger kinds and
+    malformed rows are rejected explicitly. *)

--- a/lib/compaction_trigger/dune
+++ b/lib/compaction_trigger/dune
@@ -1,11 +1,8 @@
 ; RFC-0056 Phase 1K — extract Compaction_trigger leaf module from
 ; lib/keeper/. Third lib/keeper/ leaf after Phase 1I/1J.
 ;
-; 94+45 LoC. Pure dependency-leaf: stdlib + Yojson + masc_log
-; (Log.X sub-module). Encodes compaction trigger heuristic + JSON
-; serializer used by dashboard_harness_health and several keeper modules.
-;
-; Fan-in: 17 (mix of lib + test) + 2 wrapped-pattern test callers.
+; Pure dependency-leaf: stdlib + Yojson. Encodes explicit
+; Manual/provider-overflow compaction origins and their typed JSON codec.
 ;
 ; (include_subdirs no) opts out of parent's (include_subdirs unqualified).
 ; (wrapped false) keeps the bare identifier `Compaction_trigger`.
@@ -19,4 +16,4 @@
  (wrapped false)
  (flags
   (:standard -w +4))
- (libraries yojson masc_log))
+ (libraries yojson))

--- a/lib/dashboard/dashboard_harness_health.ml
+++ b/lib/dashboard/dashboard_harness_health.ml
@@ -244,30 +244,37 @@ let pre_compact_event_json (event : pre_compact_event) =
 ;;
 
 let pre_compact_event_of_json json =
-  let record_type = string_field json "record_type" in
-  if record_type <> "" && not (String.equal record_type "pre_compact")
-  then None
-  else
-    Some
-      { timestamp = Safe_ops.json_float ~default:0.0 "timestamp" json
-      ; keeper_name = string_field json "keeper_name"
-      ; checkpoint_bytes = Safe_ops.json_int ~default:0 "checkpoint_bytes" json
-      ; message_count = Safe_ops.json_int ~default:0 "message_count" json
-      ; strategies = Safe_ops.json_string_list "strategies" json
-      ; trigger =
-          (match
-             List.assoc_opt
-               "trigger_detail"
-               (match json with
-                | `Assoc kv -> kv
-                | _ -> [])
-           with
-           | Some detail ->
-             (match Compaction_trigger.of_detail_json detail with
-              | Some t -> t
-              | None -> Compaction_trigger.Manual)
-           | None -> Compaction_trigger.Manual)
-      }
+  let reject reason =
+    Log.Harness.warn "[pre_compact] rejected persisted row: %s" reason;
+    None
+  in
+  match json with
+  | `Assoc fields ->
+    (match List.assoc_opt "record_type" fields with
+     | None -> reject "missing record_type"
+     | Some (`String "pre_compact") ->
+       (match List.assoc_opt "trigger_detail" fields with
+        | None -> reject "missing trigger_detail"
+        | Some detail ->
+          (match Compaction_trigger.of_detail_json detail with
+           | Ok trigger ->
+             Some
+               { timestamp = Safe_ops.json_float ~default:0.0 "timestamp" json
+               ; keeper_name = string_field json "keeper_name"
+               ; checkpoint_bytes = Safe_ops.json_int ~default:0 "checkpoint_bytes" json
+               ; message_count = Safe_ops.json_int ~default:0 "message_count" json
+               ; strategies = Safe_ops.json_string_list "strategies" json
+               ; trigger
+               }
+           | Error error ->
+             reject
+               (Printf.sprintf
+                  "invalid trigger_detail: %s"
+                  (Compaction_trigger.decode_error_to_string error))))
+     | Some (`String record_type) ->
+       reject (Printf.sprintf "unexpected record_type %S" record_type)
+     | Some _ -> reject "record_type must be a string")
+  | _ -> reject "expected an object"
 ;;
 
 let role_counts_to_json (counts : (string * int) list) : Yojson.Safe.t =

--- a/test/test_keeper_overflow_recovery.ml
+++ b/test/test_keeper_overflow_recovery.ml
@@ -26,9 +26,87 @@ let overflow_event ?(limit = Some 200_000) () =
 let test_provider_overflow_trigger_roundtrip () =
   let trigger = Compaction_trigger.Provider_overflow { limit_tokens = Some 200_000 } in
   check string "typed trigger label" "provider_overflow" (Compaction_trigger.to_label trigger);
-  match Compaction_trigger.of_detail_json (Compaction_trigger.to_detail_json trigger) with
-  | Some (Compaction_trigger.Provider_overflow { limit_tokens = Some 200_000 }) -> ()
-  | _ -> fail "typed provider overflow trigger did not round-trip"
+  List.iter
+    (fun expected ->
+       match
+         Compaction_trigger.of_detail_json (Compaction_trigger.to_detail_json expected)
+       with
+       | Ok actual when actual = expected -> ()
+       | Ok _ | Error _ -> fail "typed compaction trigger did not round-trip")
+    [ trigger
+    ; Compaction_trigger.Provider_overflow { limit_tokens = None }
+    ; Compaction_trigger.Manual
+    ]
+;;
+
+let test_retired_trigger_kinds_are_rejected () =
+  let decode kind =
+    Compaction_trigger.of_detail_json (`Assoc [ "kind", `String kind ])
+  in
+  List.iter
+    (fun kind ->
+       match decode kind with
+       | Error (Compaction_trigger.Unknown_kind actual)
+         when String.equal actual kind -> ()
+       | Ok _ | Error _ -> failf "retired trigger %s was not explicitly rejected" kind)
+    [ "ratio"; "messages"; "tokens" ];
+  match
+    Compaction_trigger.of_detail_json
+      (`Assoc [ "kind", `String "provider_overflow" ])
+  with
+  | Error Compaction_trigger.Missing_provider_limit -> ()
+  | Ok _ | Error _ -> fail "provider overflow without limit_tokens was admitted"
+;;
+
+let test_malformed_trigger_details_are_typed_errors () =
+  let check_error message expected json =
+    match Compaction_trigger.of_detail_json json with
+    | Error actual when actual = expected -> ()
+    | Ok _ | Error _ -> fail message
+  in
+  check_error
+    "non-object trigger detail was admitted"
+    Compaction_trigger.Expected_object
+    (`String "manual");
+  check_error
+    "missing trigger kind was admitted"
+    Compaction_trigger.Missing_kind
+    (`Assoc []);
+  check_error
+    "unknown manual field was admitted"
+    (Compaction_trigger.Unknown_field "limit_tokens")
+    (`Assoc [ "kind", `String "manual"; "limit_tokens", `Null ]);
+  check_error
+    "unknown provider field was admitted"
+    (Compaction_trigger.Unknown_field "extra")
+    (`Assoc
+      [ "kind", `String "provider_overflow"
+      ; "limit_tokens", `Int 200_000
+      ; "extra", `Null
+      ]);
+  check_error
+    "duplicate trigger kind was admitted"
+    (Compaction_trigger.Duplicate_field "kind")
+    (`Assoc [ "kind", `String "manual"; "kind", `String "manual" ]);
+  check_error
+    "duplicate provider limit was admitted"
+    (Compaction_trigger.Duplicate_field "limit_tokens")
+    (`Assoc
+      [ "kind", `String "provider_overflow"
+      ; "limit_tokens", `Int 200_000
+      ; "limit_tokens", `Int 200_000
+      ]);
+  check_error
+    "non-string trigger kind was admitted"
+    Compaction_trigger.Invalid_kind
+    (`Assoc [ "kind", `Int 1 ]);
+  List.iter
+    (fun limit ->
+       check_error
+         "invalid provider limit was admitted"
+         Compaction_trigger.Invalid_provider_limit
+         (`Assoc [ "kind", `String "provider_overflow"; "limit_tokens", limit ]))
+    [ `Int 0; `Int (-1); `String "200000" ]
 ;;
 
 let apply_ok phase conds ev =
@@ -170,6 +248,10 @@ let () =
     "overflow-lifecycle",
     [ test_case "provider overflow trigger codec" `Quick
         test_provider_overflow_trigger_roundtrip;
+      test_case "retired trigger kinds rejected" `Quick
+        test_retired_trigger_kinds_are_rejected;
+      test_case "malformed trigger details are typed errors" `Quick
+        test_malformed_trigger_details_are_typed_errors;
       test_case "happy path" `Quick test_happy_path;
       test_case "compact failure releases Lane" `Quick
         test_compact_failure_releases_lane;


### PR DESCRIPTION
## Outcome

- hard-delete `Ratio_threshold`, `Message_count`, and `Token_count` from `Compaction_trigger`
- retain only explicit `Manual` and provider-native `Provider_overflow { limit_tokens }` origins
- replace optional decoding with typed failures for malformed, missing, duplicate, unknown, or retired trigger details
- reject and log invalid persisted pre-compaction rows instead of silently relabeling them as `Manual`
- remove the leaf module's unused logging dependency and stale fan-in claim

## Hard-cut proof

- production constructor call sites for the three deleted variants outside their codec on current `main`: **0**
- compatibility decoding for `ratio`, `messages`, `tokens`, and historical `tool_heavy`: **removed**
- persisted provider limits accept only explicit `null` or a positive integer; absent or malformed values return typed errors
- no dual representation or fallback migration path was added

## Verification

- `ocamlc -stop-after parsing` on touched implementation and test files
- `ocamlformat --check` on all touched OCaml files
- `git diff --check`
- current-main full build/test remains PR CI authority