### PR TITLE
refactor(keeper): extract compaction evidence leaf

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -102,6 +102,7 @@
   masc.keeper_types_profile_sandbox
   masc.keeper_usage_trust
   masc.keeper_event_bus
+  masc.keeper_compaction_evidence
   ;; Runtime_provider_labels extracted to lib/runtime_provider_labels/.
   ;; Leaf boundary over agent_sdk.llm_provider canonical provider labels.
   masc.runtime_provider_labels

--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -87,39 +87,10 @@ type compaction_decision =
   | Not_requested
   | Skipped_no_checkpoint
 
-type compaction_evidence =
-  { selected_runtime_id : string option
-  ; before_checkpoint_bytes : int
-  ; after_checkpoint_bytes : int
-  ; before_message_count : int
-  ; after_message_count : int
-  ; summarized_message_count : int
-  ; dropped_message_count : int
-  ; before_tool_use_count : int
-  ; after_tool_use_count : int
-  ; before_tool_result_count : int
-  ; after_tool_result_count : int
-  }
-
-let compaction_evidence_to_json evidence =
-  `Assoc
-    [ "before_checkpoint_bytes", `Int evidence.before_checkpoint_bytes
-    ; "after_checkpoint_bytes", `Int evidence.after_checkpoint_bytes
-    ; "before_message_count", `Int evidence.before_message_count
-    ; "after_message_count", `Int evidence.after_message_count
-    ; "summarized_message_count", `Int evidence.summarized_message_count
-    ; "dropped_message_count", `Int evidence.dropped_message_count
-    ; "before_tool_use_count", `Int evidence.before_tool_use_count
-    ; "after_tool_use_count", `Int evidence.after_tool_use_count
-    ; "before_tool_result_count", `Int evidence.before_tool_result_count
-    ; "after_tool_result_count", `Int evidence.after_tool_result_count
-    ]
-;;
-
 type compaction_preparation =
   { context : working_context
   ; decision : compaction_decision
-  ; evidence : compaction_evidence option
+  ; evidence : Keeper_compaction_evidence.t option
   }
 
 let compaction_decision_to_string = function

--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -71,6 +71,7 @@ type compaction_rejection =
   | Plan_unavailable_or_invalid
   | Structurally_unchanged
   | Checkpoint_not_reduced
+  | Invalid_structural_evidence
 
 let compaction_rejection_to_string = function
   | Runtime_identity_unavailable -> "runtime_identity_unavailable"
@@ -78,6 +79,7 @@ let compaction_rejection_to_string = function
   | Plan_unavailable_or_invalid -> "plan_unavailable_or_invalid"
   | Structurally_unchanged -> "structurally_unchanged"
   | Checkpoint_not_reduced -> "checkpoint_not_reduced"
+  | Invalid_structural_evidence -> "invalid_structural_evidence"
 ;;
 
 type compaction_decision =
@@ -312,61 +314,64 @@ let compact_for_request_typed
       let after_tool_use_count, after_tool_result_count =
         tool_block_counts (messages_of_context compacted_ctx)
       in
-      let tool_use_sample_json =
-        List.map
-          (fun (tool_use_id, tool_name) ->
-             `Assoc
-               [ "tool_use_id", `String tool_use_id
-               ; "tool_name", `String tool_name
-               ])
-          pair_repair_stats.dropped_tool_use_samples
-      in
-      let tool_result_id_json =
-        List.map
-          (fun tool_use_id -> `String tool_use_id)
-          pair_repair_stats.dropped_tool_result_ids
-      in
-      Log.Harness.emit
-        Log.Info
-        ~details:
-          (`Assoc
-              [ "keeper_name", `String meta.name
-              ; "trigger", `String (Compaction_trigger.to_label trigger)
-              ; "trigger_detail", Compaction_trigger.to_detail_json trigger
-              ; "before_checkpoint_bytes", `Int before_bytes
-              ; "after_checkpoint_bytes", `Int after_bytes
-              ; "saved_checkpoint_bytes", `Int (before_bytes - after_bytes)
-              ; "before_messages", `Int before_messages
-              ; "after_messages", `Int after_messages
-              ; ( "tool_pair_repair"
-                , `Assoc
-                    [ ( "dropped_tool_uses"
-                      , `Int pair_repair_stats.dropped_tool_uses )
-                    ; ( "dropped_tool_results"
-                      , `Int pair_repair_stats.dropped_tool_results )
-                    ; "dropped_tool_use_samples", `List tool_use_sample_json
-                    ; "dropped_tool_result_ids", `List tool_result_id_json
-                    ] )
-              ])
-        (Printf.sprintf
-           "context compaction prepared keeper=%s saved_checkpoint_bytes=%d"
-           meta.name
-           (before_bytes - after_bytes));
-      { context = compacted_ctx
-      ; decision = Prepared trigger
-      ; evidence =
-          Some
-            { selected_runtime_id = requested.selected_runtime_id
-            ; before_checkpoint_bytes = before_bytes
-            ; after_checkpoint_bytes = after_bytes
-            ; before_message_count = before_messages
-            ; after_message_count = after_messages
-            ; summarized_message_count = requested.summarized_message_count
-            ; dropped_message_count = requested.dropped_message_count
-            ; before_tool_use_count
-            ; after_tool_use_count
-            ; before_tool_result_count
-            ; after_tool_result_count
-            }
-      })
+      match
+        Keeper_compaction_evidence.create
+          ~selected_runtime_id:requested.selected_runtime_id
+          ~before_checkpoint_bytes:before_bytes
+          ~after_checkpoint_bytes:after_bytes
+          ~before_message_count:before_messages
+          ~after_message_count:after_messages
+          ~summarized_message_count:requested.summarized_message_count
+          ~dropped_message_count:requested.dropped_message_count
+          ~before_tool_use_count
+          ~after_tool_use_count
+          ~before_tool_result_count
+          ~after_tool_result_count
+      with
+      | Error _ -> reject Invalid_structural_evidence
+      | Ok evidence ->
+        let tool_use_sample_json =
+          List.map
+            (fun (tool_use_id, tool_name) ->
+               `Assoc
+                 [ "tool_use_id", `String tool_use_id
+                 ; "tool_name", `String tool_name
+                 ])
+            pair_repair_stats.dropped_tool_use_samples
+        in
+        let tool_result_id_json =
+          List.map
+            (fun tool_use_id -> `String tool_use_id)
+            pair_repair_stats.dropped_tool_result_ids
+        in
+        Log.Harness.emit
+          Log.Info
+          ~details:
+            (`Assoc
+                [ "keeper_name", `String meta.name
+                ; "trigger", `String (Compaction_trigger.to_label trigger)
+                ; "trigger_detail", Compaction_trigger.to_detail_json trigger
+                ; "before_checkpoint_bytes", `Int before_bytes
+                ; "after_checkpoint_bytes", `Int after_bytes
+                ; "saved_checkpoint_bytes", `Int (before_bytes - after_bytes)
+                ; "before_messages", `Int before_messages
+                ; "after_messages", `Int after_messages
+                ; ( "tool_pair_repair"
+                  , `Assoc
+                      [ ( "dropped_tool_uses"
+                        , `Int pair_repair_stats.dropped_tool_uses )
+                      ; ( "dropped_tool_results"
+                        , `Int pair_repair_stats.dropped_tool_results )
+                      ; "dropped_tool_use_samples", `List tool_use_sample_json
+                      ; "dropped_tool_result_ids", `List tool_result_id_json
+                      ] )
+                ])
+          (Printf.sprintf
+             "context compaction prepared keeper=%s saved_checkpoint_bytes=%d"
+             meta.name
+             (before_bytes - after_bytes));
+        { context = compacted_ctx
+        ; decision = Prepared trigger
+        ; evidence = Some evidence
+        })
 ;;

--- a/lib/keeper/keeper_compact_policy.mli
+++ b/lib/keeper/keeper_compact_policy.mli
@@ -9,6 +9,7 @@ type compaction_rejection =
   | Plan_unavailable_or_invalid
   | Structurally_unchanged
   | Checkpoint_not_reduced
+  | Invalid_structural_evidence
 
 (** [Prepared] is structural only; [Applied] requires a durable save. *)
 type compaction_decision =

--- a/lib/keeper/keeper_compact_policy.mli
+++ b/lib/keeper/keeper_compact_policy.mli
@@ -23,30 +23,10 @@ val compaction_decision_to_string : compaction_decision -> string
 val compaction_decision_prepared : compaction_decision -> bool
 val compaction_decision_applied : compaction_decision -> bool
 
-type compaction_evidence =
-  { selected_runtime_id : string option
-  ; before_checkpoint_bytes : int
-  ; after_checkpoint_bytes : int
-  ; before_message_count : int
-  ; after_message_count : int
-  ; summarized_message_count : int
-  ; dropped_message_count : int
-  ; before_tool_use_count : int
-  ; after_tool_use_count : int
-  ; before_tool_result_count : int
-  ; after_tool_result_count : int
-  }
-(** Exact structural evidence from the LLM-selected plan. Byte, message, and
-    tool-block counts are measured from the actual checkpoint on both sides;
-    no token estimate is synthesized. *)
-
-val compaction_evidence_to_json : compaction_evidence -> Yojson.Safe.t
-(** Lossless wire projection shared by every MASC compaction producer. *)
-
 type compaction_preparation =
   { context : Keeper_context_core.working_context
   ; decision : compaction_decision
-  ; evidence : compaction_evidence option
+  ; evidence : Keeper_compaction_evidence.t option
   }
 
 (** Legacy configuration projection retained until the unused ratio/message/

--- a/lib/keeper/keeper_context_runtime.ml
+++ b/lib/keeper/keeper_context_runtime.ml
@@ -108,7 +108,7 @@ type post_turn_lifecycle = Keeper_post_turn.post_turn_lifecycle = {
 type overflow_retry_recovery = Keeper_post_turn.overflow_retry_recovery = {
   checkpoint : Agent_sdk.Checkpoint.t;
   compaction : compaction_event;
-  evidence : Keeper_compact_policy.compaction_evidence;
+  evidence : Keeper_compaction_evidence.t;
   turn_generation : int;
 }
 

--- a/lib/keeper/keeper_context_runtime.mli
+++ b/lib/keeper/keeper_context_runtime.mli
@@ -111,7 +111,7 @@ type context_budget_source =
 type overflow_retry_recovery =
   { checkpoint : Agent_sdk.Checkpoint.t
   ; compaction : compaction_event
-  ; evidence : Keeper_compact_policy.compaction_evidence
+  ; evidence : Keeper_compaction_evidence.t
   ; turn_generation : int
   }
 

--- a/lib/keeper/keeper_manual_compaction.ml
+++ b/lib/keeper/keeper_manual_compaction.ml
@@ -52,7 +52,7 @@ let append_manifest ~config ~base_dir ~(meta : keeper_meta) recovery =
                 [ "trigger", `String (Compaction_trigger.to_label trigger)
                 ; "trigger_detail", Compaction_trigger.to_detail_json trigger
                 ; ( "exact_evidence"
-                  , Keeper_compact_policy.compaction_evidence_to_json recovery.evidence )
+                  , Keeper_compaction_evidence.to_json recovery.evidence )
                 ])))
       ~checkpoint_path
       ()

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -71,7 +71,7 @@ type post_turn_lifecycle = {
 type overflow_retry_recovery = {
   checkpoint : Agent_sdk.Checkpoint.t;
   compaction : compaction_event;
-  evidence : Keeper_compact_policy.compaction_evidence;
+  evidence : Keeper_compaction_evidence.t;
   turn_generation : int;
 } [@@warning "-69"]
 

--- a/lib/keeper/keeper_post_turn.mli
+++ b/lib/keeper/keeper_post_turn.mli
@@ -50,7 +50,7 @@ type post_turn_lifecycle =
 type overflow_retry_recovery =
   { checkpoint : Agent_sdk.Checkpoint.t
   ; compaction : compaction_event
-  ; evidence : Keeper_compact_policy.compaction_evidence
+  ; evidence : Keeper_compaction_evidence.t
   ; turn_generation : int
   } [@@warning "-69"]
 

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -102,6 +102,7 @@ let compaction_recovery_error_data ?dispatch_error error =
       Precondition_failed
     | Compaction_rejected Summarizer_unavailable
     | Compaction_rejected Plan_unavailable_or_invalid
+    | Compaction_rejected Invalid_structural_evidence
     | Compaction_evidence_missing
     | Unexpected_compaction_decision _ -> Internal_error
     | Checkpoint_superseded _ -> Conflict

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -276,7 +276,7 @@ let append_provider_overflow_manifest
                ; "source_requeued", `Bool true
                ; "error", error
                ; ( "exact_evidence"
-                 , Keeper_compact_policy.compaction_evidence_to_json evidence )
+                 , Keeper_compaction_evidence.to_json evidence )
                ]))
         Keeper_runtime_manifest.Context_compacted
     in

--- a/lib/keeper_compaction_evidence/dune
+++ b/lib/keeper_compaction_evidence/dune
@@ -1,0 +1,8 @@
+(include_subdirs no)
+
+(library
+ (name masc_keeper_compaction_evidence)
+ (public_name masc.keeper_compaction_evidence)
+ (wrapped false)
+ (modules keeper_compaction_evidence)
+ (libraries yojson))

--- a/lib/keeper_compaction_evidence/keeper_compaction_evidence.ml
+++ b/lib/keeper_compaction_evidence/keeper_compaction_evidence.ml
@@ -101,6 +101,92 @@ let decode_nonnegative_integer fields field =
   | _ -> Error (Invalid_field (field, Duplicate))
 ;;
 
+let create
+      ~selected_runtime_id
+      ~before_checkpoint_bytes
+      ~after_checkpoint_bytes
+      ~before_message_count
+      ~after_message_count
+      ~summarized_message_count
+      ~dropped_message_count
+      ~before_tool_use_count
+      ~after_tool_use_count
+      ~before_tool_result_count
+      ~after_tool_result_count
+  =
+  let values =
+    [ Before_checkpoint_bytes, before_checkpoint_bytes
+    ; After_checkpoint_bytes, after_checkpoint_bytes
+    ; Before_message_count, before_message_count
+    ; After_message_count, after_message_count
+    ; Summarized_message_count, summarized_message_count
+    ; Dropped_message_count, dropped_message_count
+    ; Before_tool_use_count, before_tool_use_count
+    ; After_tool_use_count, after_tool_use_count
+    ; Before_tool_result_count, before_tool_result_count
+    ; After_tool_result_count, after_tool_result_count
+    ]
+  in
+  match List.find_opt (fun (_, value) -> value < 0) values with
+  | Some (field, _) -> Error (Invalid_field (field, Negative_integer))
+  | None ->
+    (match selected_runtime_id with
+     | Some runtime_id when String.trim runtime_id = "" ->
+       Error Empty_selected_runtime_id
+     | Some _ | None ->
+       if after_checkpoint_bytes >= before_checkpoint_bytes
+       then
+         Error
+           (Invalid_transition
+              (Checkpoint_bytes, before_checkpoint_bytes, after_checkpoint_bytes))
+       else if after_message_count > before_message_count
+       then
+         Error
+           (Invalid_transition
+              (Messages, before_message_count, after_message_count))
+       else if after_tool_use_count > before_tool_use_count
+       then
+         Error
+           (Invalid_transition
+              (Tool_uses, before_tool_use_count, after_tool_use_count))
+       else if after_tool_result_count > before_tool_result_count
+       then
+         Error
+           (Invalid_transition
+              (Tool_results, before_tool_result_count, after_tool_result_count))
+       else if summarized_message_count = 0 && dropped_message_count = 0
+       then Error No_messages_compacted
+       else if
+         not
+           (message_accounting_is_possible
+              ~before_message_count
+              ~after_message_count
+              ~summarized_message_count
+              ~dropped_message_count)
+       then
+         Error
+           (Invalid_message_accounting
+              { before_message_count
+              ; after_message_count
+              ; summarized_message_count
+              ; dropped_message_count
+              })
+       else
+         Ok
+           { selected_runtime_id
+           ; before_checkpoint_bytes
+           ; after_checkpoint_bytes
+           ; before_message_count
+           ; after_message_count
+           ; summarized_message_count
+           ; dropped_message_count
+           ; before_tool_use_count
+           ; after_tool_use_count
+           ; before_tool_result_count
+           ; after_tool_result_count
+           })
+;;
+
 let of_json ~selected_runtime_id = function
   | `Assoc fields ->
     let* () =
@@ -111,12 +197,6 @@ let of_json ~selected_runtime_id = function
       with
       | None -> Ok ()
       | Some (name, _) -> Error (Unknown_field name)
-    in
-    let* () =
-      match selected_runtime_id with
-      | Some runtime_id when String.trim runtime_id = "" ->
-        Error Empty_selected_runtime_id
-      | Some _ | None -> Ok ()
     in
     let integer = decode_nonnegative_integer fields in
     let* before_checkpoint_bytes = integer Before_checkpoint_bytes in
@@ -129,48 +209,18 @@ let of_json ~selected_runtime_id = function
     let* after_tool_use_count = integer After_tool_use_count in
     let* before_tool_result_count = integer Before_tool_result_count in
     let* after_tool_result_count = integer After_tool_result_count in
-    if after_checkpoint_bytes >= before_checkpoint_bytes
-    then Error (Invalid_transition (Checkpoint_bytes, before_checkpoint_bytes, after_checkpoint_bytes))
-    else if after_message_count > before_message_count
-    then Error (Invalid_transition (Messages, before_message_count, after_message_count))
-    else if after_tool_use_count > before_tool_use_count
-    then Error (Invalid_transition (Tool_uses, before_tool_use_count, after_tool_use_count))
-    else if after_tool_result_count > before_tool_result_count
-    then
-      Error
-        (Invalid_transition
-           (Tool_results, before_tool_result_count, after_tool_result_count))
-    else if summarized_message_count = 0 && dropped_message_count = 0
-    then Error No_messages_compacted
-    else if
-      not
-        (message_accounting_is_possible
-           ~before_message_count
-           ~after_message_count
-           ~summarized_message_count
-           ~dropped_message_count)
-    then
-      Error
-        (Invalid_message_accounting
-           { before_message_count
-           ; after_message_count
-           ; summarized_message_count
-           ; dropped_message_count
-           })
-    else
-      Ok
-        { selected_runtime_id
-        ; before_checkpoint_bytes
-        ; after_checkpoint_bytes
-        ; before_message_count
-        ; after_message_count
-        ; summarized_message_count
-        ; dropped_message_count
-        ; before_tool_use_count
-        ; after_tool_use_count
-        ; before_tool_result_count
-        ; after_tool_result_count
-        }
+    create
+      ~selected_runtime_id
+      ~before_checkpoint_bytes
+      ~after_checkpoint_bytes
+      ~before_message_count
+      ~after_message_count
+      ~summarized_message_count
+      ~dropped_message_count
+      ~before_tool_use_count
+      ~after_tool_use_count
+      ~before_tool_result_count
+      ~after_tool_result_count
   | _ -> Error Expected_object
 ;;
 

--- a/lib/keeper_compaction_evidence/keeper_compaction_evidence.ml
+++ b/lib/keeper_compaction_evidence/keeper_compaction_evidence.ml
@@ -1,0 +1,190 @@
+type t =
+  { selected_runtime_id : string option
+  ; before_checkpoint_bytes : int
+  ; after_checkpoint_bytes : int
+  ; before_message_count : int
+  ; after_message_count : int
+  ; summarized_message_count : int
+  ; dropped_message_count : int
+  ; before_tool_use_count : int
+  ; after_tool_use_count : int
+  ; before_tool_result_count : int
+  ; after_tool_result_count : int
+  }
+
+type field =
+  | Before_checkpoint_bytes
+  | After_checkpoint_bytes
+  | Before_message_count
+  | After_message_count
+  | Summarized_message_count
+  | Dropped_message_count
+  | Before_tool_use_count
+  | After_tool_use_count
+  | Before_tool_result_count
+  | After_tool_result_count
+
+type field_error =
+  | Missing
+  | Duplicate
+  | Expected_integer
+  | Negative_integer
+
+type measure =
+  | Checkpoint_bytes
+  | Messages
+  | Tool_uses
+  | Tool_results
+
+type decode_error =
+  | Expected_object
+  | Unknown_field of string
+  | Invalid_field of field * field_error
+  | Empty_selected_runtime_id
+  | Invalid_transition of measure * int * int
+  | Invalid_message_accounting of
+      { before_message_count : int
+      ; after_message_count : int
+      ; summarized_message_count : int
+      ; dropped_message_count : int
+      }
+  | No_messages_compacted
+
+let schema =
+  [ Before_checkpoint_bytes, "before_checkpoint_bytes"
+  ; After_checkpoint_bytes, "after_checkpoint_bytes"
+  ; Before_message_count, "before_message_count"
+  ; After_message_count, "after_message_count"
+  ; Summarized_message_count, "summarized_message_count"
+  ; Dropped_message_count, "dropped_message_count"
+  ; Before_tool_use_count, "before_tool_use_count"
+  ; After_tool_use_count, "after_tool_use_count"
+  ; Before_tool_result_count, "before_tool_result_count"
+  ; After_tool_result_count, "after_tool_result_count"
+  ]
+;;
+
+let field_name field = List.assoc field schema
+let known_field name = List.exists (fun (_, key) -> String.equal name key) schema
+
+let ( let* ) = Result.bind
+
+let message_accounting_is_possible
+      ~before_message_count
+      ~after_message_count
+      ~summarized_message_count
+      ~dropped_message_count
+  =
+  summarized_message_count <= before_message_count
+  && dropped_message_count <= before_message_count - summarized_message_count
+  &&
+  if summarized_message_count = 0
+  then
+    after_message_count = before_message_count - dropped_message_count
+  else (
+    let maximum_after = before_message_count - dropped_message_count in
+    let minimum_after = maximum_after - summarized_message_count + 1 in
+    after_message_count >= minimum_after
+    && after_message_count <= maximum_after)
+;;
+
+let decode_nonnegative_integer fields field =
+  match
+    List.filter
+      (fun (name, _) -> String.equal name (field_name field))
+      fields
+  with
+  | [] -> Error (Invalid_field (field, Missing))
+  | [ _, `Int value ] when value >= 0 -> Ok value
+  | [ _, `Int _ ] -> Error (Invalid_field (field, Negative_integer))
+  | [ _ ] -> Error (Invalid_field (field, Expected_integer))
+  | _ -> Error (Invalid_field (field, Duplicate))
+;;
+
+let of_json ~selected_runtime_id = function
+  | `Assoc fields ->
+    let* () =
+      match
+        List.find_opt
+          (fun (name, _) -> not (known_field name))
+          fields
+      with
+      | None -> Ok ()
+      | Some (name, _) -> Error (Unknown_field name)
+    in
+    let* () =
+      match selected_runtime_id with
+      | Some runtime_id when String.trim runtime_id = "" ->
+        Error Empty_selected_runtime_id
+      | Some _ | None -> Ok ()
+    in
+    let integer = decode_nonnegative_integer fields in
+    let* before_checkpoint_bytes = integer Before_checkpoint_bytes in
+    let* after_checkpoint_bytes = integer After_checkpoint_bytes in
+    let* before_message_count = integer Before_message_count in
+    let* after_message_count = integer After_message_count in
+    let* summarized_message_count = integer Summarized_message_count in
+    let* dropped_message_count = integer Dropped_message_count in
+    let* before_tool_use_count = integer Before_tool_use_count in
+    let* after_tool_use_count = integer After_tool_use_count in
+    let* before_tool_result_count = integer Before_tool_result_count in
+    let* after_tool_result_count = integer After_tool_result_count in
+    if after_checkpoint_bytes >= before_checkpoint_bytes
+    then Error (Invalid_transition (Checkpoint_bytes, before_checkpoint_bytes, after_checkpoint_bytes))
+    else if after_message_count > before_message_count
+    then Error (Invalid_transition (Messages, before_message_count, after_message_count))
+    else if after_tool_use_count > before_tool_use_count
+    then Error (Invalid_transition (Tool_uses, before_tool_use_count, after_tool_use_count))
+    else if after_tool_result_count > before_tool_result_count
+    then
+      Error
+        (Invalid_transition
+           (Tool_results, before_tool_result_count, after_tool_result_count))
+    else if summarized_message_count = 0 && dropped_message_count = 0
+    then Error No_messages_compacted
+    else if
+      not
+        (message_accounting_is_possible
+           ~before_message_count
+           ~after_message_count
+           ~summarized_message_count
+           ~dropped_message_count)
+    then
+      Error
+        (Invalid_message_accounting
+           { before_message_count
+           ; after_message_count
+           ; summarized_message_count
+           ; dropped_message_count
+           })
+    else
+      Ok
+        { selected_runtime_id
+        ; before_checkpoint_bytes
+        ; after_checkpoint_bytes
+        ; before_message_count
+        ; after_message_count
+        ; summarized_message_count
+        ; dropped_message_count
+        ; before_tool_use_count
+        ; after_tool_use_count
+        ; before_tool_result_count
+        ; after_tool_result_count
+        }
+  | _ -> Error Expected_object
+;;
+
+let to_json evidence =
+  `Assoc
+    [ "before_checkpoint_bytes", `Int evidence.before_checkpoint_bytes
+    ; "after_checkpoint_bytes", `Int evidence.after_checkpoint_bytes
+    ; "before_message_count", `Int evidence.before_message_count
+    ; "after_message_count", `Int evidence.after_message_count
+    ; "summarized_message_count", `Int evidence.summarized_message_count
+    ; "dropped_message_count", `Int evidence.dropped_message_count
+    ; "before_tool_use_count", `Int evidence.before_tool_use_count
+    ; "after_tool_use_count", `Int evidence.after_tool_use_count
+    ; "before_tool_result_count", `Int evidence.before_tool_result_count
+    ; "after_tool_result_count", `Int evidence.after_tool_result_count
+    ]
+;;

--- a/lib/keeper_compaction_evidence/keeper_compaction_evidence.mli
+++ b/lib/keeper_compaction_evidence/keeper_compaction_evidence.mli
@@ -1,0 +1,66 @@
+(** Exact structural evidence for one LLM compaction result. *)
+type t =
+  { selected_runtime_id : string option
+  ; before_checkpoint_bytes : int
+  ; after_checkpoint_bytes : int
+  ; before_message_count : int
+  ; after_message_count : int
+  ; summarized_message_count : int
+  ; dropped_message_count : int
+  ; before_tool_use_count : int
+  ; after_tool_use_count : int
+  ; before_tool_result_count : int
+  ; after_tool_result_count : int
+  }
+
+type field =
+  | Before_checkpoint_bytes
+  | After_checkpoint_bytes
+  | Before_message_count
+  | After_message_count
+  | Summarized_message_count
+  | Dropped_message_count
+  | Before_tool_use_count
+  | After_tool_use_count
+  | Before_tool_result_count
+  | After_tool_result_count
+
+type field_error =
+  | Missing
+  | Duplicate
+  | Expected_integer
+  | Negative_integer
+
+type measure =
+  | Checkpoint_bytes
+  | Messages
+  | Tool_uses
+  | Tool_results
+
+type decode_error =
+  | Expected_object
+  | Unknown_field of string
+  | Invalid_field of field * field_error
+  | Empty_selected_runtime_id
+  | Invalid_transition of measure * int * int
+  | Invalid_message_accounting of
+      { before_message_count : int
+      ; after_message_count : int
+      ; summarized_message_count : int
+      ; dropped_message_count : int
+      }
+  | No_messages_compacted
+
+val to_json : t -> Yojson.Safe.t
+(** Structural observation projection of the exact measured counts.
+    [selected_runtime_id] remains the enclosing runtime projection. *)
+
+val of_json
+  :  selected_runtime_id:string option
+  -> Yojson.Safe.t
+  -> (t, decode_error) result
+(** Restore persisted structural evidence. The Runtime identity is supplied
+    from its enclosing typed projection rather than duplicated in the counts
+    object. Unknown, duplicate, missing, malformed, or objectively impossible
+    evidence is rejected explicitly. [Checkpoint_bytes] must strictly reduce;
+    the other measures may stay equal but cannot increase. *)

--- a/lib/keeper_compaction_evidence/keeper_compaction_evidence.mli
+++ b/lib/keeper_compaction_evidence/keeper_compaction_evidence.mli
@@ -1,5 +1,6 @@
 (** Exact structural evidence for one LLM compaction result. *)
 type t =
+  private
   { selected_runtime_id : string option
   ; before_checkpoint_bytes : int
   ; after_checkpoint_bytes : int
@@ -50,6 +51,22 @@ type decode_error =
       ; dropped_message_count : int
       }
   | No_messages_compacted
+
+val create
+  :  selected_runtime_id:string option
+  -> before_checkpoint_bytes:int
+  -> after_checkpoint_bytes:int
+  -> before_message_count:int
+  -> after_message_count:int
+  -> summarized_message_count:int
+  -> dropped_message_count:int
+  -> before_tool_use_count:int
+  -> after_tool_use_count:int
+  -> before_tool_result_count:int
+  -> after_tool_result_count:int
+  -> (t, decode_error) result
+(** Construct evidence through the same closed validation boundary used by
+    persisted JSON restoration. *)
 
 val to_json : t -> Yojson.Safe.t
 (** Structural observation projection of the exact measured counts.

--- a/test/keeper_compaction_evidence/dune
+++ b/test/keeper_compaction_evidence/dune
@@ -1,0 +1,3 @@
+(test
+ (name test_keeper_compaction_evidence)
+ (libraries alcotest yojson masc.keeper_compaction_evidence))

--- a/test/keeper_compaction_evidence/test_keeper_compaction_evidence.ml
+++ b/test/keeper_compaction_evidence/test_keeper_compaction_evidence.ml
@@ -1,0 +1,117 @@
+let evidence : Keeper_compaction_evidence.t =
+  { selected_runtime_id = Some "compact-runtime"
+  ; before_checkpoint_bytes = 4096
+  ; after_checkpoint_bytes = 1024
+  ; before_message_count = 12
+  ; after_message_count = 6
+  ; summarized_message_count = 6
+  ; dropped_message_count = 1
+  ; before_tool_use_count = 3
+  ; after_tool_use_count = 1
+  ; before_tool_result_count = 3
+  ; after_tool_result_count = 1
+  }
+;;
+
+let canonical = Keeper_compaction_evidence.to_json evidence
+
+let fields = function
+  | `Assoc fields -> fields
+  | _ -> Alcotest.fail "canonical evidence must be an object"
+;;
+
+let replace name value json =
+  `Assoc
+    (List.map
+       (fun (key, current) ->
+          if String.equal key name then key, value else key, current)
+       (fields json))
+;;
+
+let test_projection_and_roundtrip () =
+  let expected =
+    `Assoc
+      [ "before_checkpoint_bytes", `Int 4096
+      ; "after_checkpoint_bytes", `Int 1024
+      ; "before_message_count", `Int 12
+      ; "after_message_count", `Int 6
+      ; "summarized_message_count", `Int 6
+      ; "dropped_message_count", `Int 1
+      ; "before_tool_use_count", `Int 3
+      ; "after_tool_use_count", `Int 1
+      ; "before_tool_result_count", `Int 3
+      ; "after_tool_result_count", `Int 1
+      ]
+  in
+  Alcotest.check
+    (Alcotest.testable Yojson.Safe.pp Yojson.Safe.equal)
+    "exact projection"
+    expected
+    canonical;
+  match
+    Keeper_compaction_evidence.of_json
+      ~selected_runtime_id:evidence.selected_runtime_id
+      canonical
+  with
+  | Ok restored -> Alcotest.(check bool) "exact restore" true (restored = evidence)
+  | Error _ -> Alcotest.fail "canonical evidence must decode"
+;;
+
+let test_rejections () =
+  let open Keeper_compaction_evidence in
+  let check label runtime_id expected json =
+    match of_json ~selected_runtime_id:runtime_id json with
+    | Error actual -> Alcotest.(check bool) label true (actual = expected)
+    | Ok _ -> Alcotest.failf "%s: invalid evidence decoded" label
+  in
+  let no_messages =
+    canonical
+    |> replace "summarized_message_count" (`Int 0)
+    |> replace "dropped_message_count" (`Int 0)
+  in
+  let duplicate =
+    `Assoc (("after_message_count", `Int 6) :: fields canonical)
+  in
+  let impossible_accounting =
+    replace "summarized_message_count" (`Int 999) canonical
+  in
+  List.iter
+    (fun (label, runtime_id, expected, json) ->
+       check label runtime_id expected json)
+    [ ( "negative"
+      , evidence.selected_runtime_id
+      , Invalid_field (Before_message_count, Negative_integer)
+      , replace "before_message_count" (`Int (-1)) canonical )
+    ; ( "not reduced"
+      , evidence.selected_runtime_id
+      , Invalid_transition (Checkpoint_bytes, 4096, 4096)
+      , replace "after_checkpoint_bytes" (`Int 4096) canonical )
+    ; "no messages", evidence.selected_runtime_id, No_messages_compacted, no_messages
+    ; "blank runtime", Some "   ", Empty_selected_runtime_id, canonical
+    ; ( "duplicate"
+      , evidence.selected_runtime_id
+      , Invalid_field (After_message_count, Duplicate)
+      , duplicate )
+    ; ( "impossible message accounting"
+      , evidence.selected_runtime_id
+      , Invalid_message_accounting
+          { before_message_count = 12
+          ; after_message_count = 6
+          ; summarized_message_count = 999
+          ; dropped_message_count = 1
+          }
+      , impossible_accounting )
+    ]
+;;
+
+let () =
+  Alcotest.run
+    "keeper compaction evidence"
+    [ ( "projection"
+      , [ Alcotest.test_case
+            "projection and roundtrip"
+            `Quick
+            test_projection_and_roundtrip
+        ; Alcotest.test_case "closed rejections" `Quick test_rejections
+        ] )
+    ]

--- a/test/keeper_compaction_evidence/test_keeper_compaction_evidence.ml
+++ b/test/keeper_compaction_evidence/test_keeper_compaction_evidence.ml
@@ -1,16 +1,17 @@
 let evidence : Keeper_compaction_evidence.t =
-  { selected_runtime_id = Some "compact-runtime"
-  ; before_checkpoint_bytes = 4096
-  ; after_checkpoint_bytes = 1024
-  ; before_message_count = 12
-  ; after_message_count = 6
-  ; summarized_message_count = 6
-  ; dropped_message_count = 1
-  ; before_tool_use_count = 3
-  ; after_tool_use_count = 1
-  ; before_tool_result_count = 3
-  ; after_tool_result_count = 1
-  }
+  Keeper_compaction_evidence.create
+    ~selected_runtime_id:(Some "compact-runtime")
+    ~before_checkpoint_bytes:4096
+    ~after_checkpoint_bytes:1024
+    ~before_message_count:12
+    ~after_message_count:6
+    ~summarized_message_count:6
+    ~dropped_message_count:1
+    ~before_tool_use_count:3
+    ~after_tool_use_count:1
+    ~before_tool_result_count:3
+    ~after_tool_result_count:1
+  |> Result.get_ok
 ;;
 
 let canonical = Keeper_compaction_evidence.to_json evidence


### PR DESCRIPTION
## Outcome

Extracts Keeper compaction evidence from `Keeper_compact_policy` into the shared
immutable `masc.keeper_compaction_evidence` leaf.

- preserves the existing `exact_evidence` JSON shape at manual and
  provider-overflow consumers
- adds one typed persisted decoder for future Operation Journal replay
- supplies `selected_runtime_id` from the enclosing typed runtime projection
- rejects malformed persisted fields with closed error variants

## Boundary

This PR changes no compaction trigger, writer, journal, queue, lane, wake-up,
manifest routing, or runtime selection behavior. It is an independent `main`
root, not a stack on #24900.

## Adversarial blocker

The current decoder is not yet exact. For a compaction that summarizes `N`
messages, `Keeper_compaction_llm_summarizer.apply` replaces them with exactly one
message before pair repair. The persisted evidence therefore needs exact
stage-by-stage counts, including the number removed by pair repair. The current
range check can accept an impossible post-count and reject a legitimate
post-pair-repair count.

`Keeper_compact_policy` must also preserve the typed decode reason instead of
collapsing every decoder error into `Invalid_structural_evidence`.

Until those two items are repaired, this PR is not merge-ready.

Reviewed implementation: `8da6c6001900de78fb875a56140e6db35e2a6879`.
