### PR TITLE
perf(gate): cache discord TLS client config across reconnects

### DIFF
--- a/lib/gate/discord_wss_connection.ml
+++ b/lib/gate/discord_wss_connection.ml
@@ -73,13 +73,27 @@ let close_code_no_status = 1005
    buffering inbound frames without limit. The gateway reader drains promptly. *)
 let inbound_capacity = 64
 
+(* Process-wide cache. [Ca_certs.authenticator] loads the system trust
+   store on every call (macOS: one `security find-certificate` subprocess
+   per keychain plus a full PEM parse of the anchor set), and this runs on
+   every gateway (re)connect. The first successful config is reused for
+   the process lifetime; certificate validity is still evaluated per
+   handshake via the authenticator's clock closure. Failures are not
+   cached — the next reconnect retries the load. *)
+let cached_client_tls_config : Tls.Config.client option Atomic.t = Atomic.make None
+
 let client_tls_config () =
-  match Ca_certs.authenticator () with
-  | Error (`Msg m) -> failwith ("discord_wss_connection: ca-certs: " ^ m)
-  | Ok authenticator ->
-    (match Tls.Config.client ~authenticator () with
-     | Error (`Msg m) -> failwith ("discord_wss_connection: Tls.Config.client: " ^ m)
-     | Ok cfg -> cfg)
+  match Atomic.get cached_client_tls_config with
+  | Some cfg -> cfg
+  | None ->
+    (match Ca_certs.authenticator () with
+     | Error (`Msg m) -> failwith ("discord_wss_connection: ca-certs: " ^ m)
+     | Ok authenticator ->
+       (match Tls.Config.client ~authenticator () with
+        | Error (`Msg m) -> failwith ("discord_wss_connection: Tls.Config.client: " ^ m)
+        | Ok cfg ->
+          Atomic.set cached_client_tls_config (Some cfg);
+          cfg))
 ;;
 
 let host_domain host =

--- a/lib/gate/discord_wss_connection.ml
+++ b/lib/gate/discord_wss_connection.ml
@@ -270,6 +270,7 @@ module For_testing = struct
   let message_to_event = message_to_event
   let close_to_event = close_to_event
   let close_code_no_status = close_code_no_status
+  let client_tls_config = client_tls_config
 
   (* A connection with a real session switch + spawn/close but no socket: the
      wsd is a bare, never-driven endpoint and the event stream stays empty. For

--- a/lib/gate/discord_wss_connection.mli
+++ b/lib/gate/discord_wss_connection.mli
@@ -90,6 +90,13 @@ module For_testing : sig
 
   val close_code_no_status : int
 
+  val client_tls_config : unit -> Tls.Config.client
+  (** The process-wide cached TLS client configuration used by [connect].
+      Read-only (no authenticator override; the "by design" note above
+      stands). Exposed so the reconnect-path cache has a regression test:
+      repeat calls must return the physically same config instead of
+      reloading the system trust store per (re)connect. *)
+
   val make_test_conn : sw:Eio.Switch.t -> conn
   (** A connection with a real session switch + [spawn] / [close] but no socket
       (the wsd is a bare, never-driven endpoint; the event stream stays empty).

--- a/test/dune
+++ b/test/dune
@@ -1678,6 +1678,8 @@
 
 (include stanzas/test_discord_gateway_client.inc)
 
+(include stanzas/test_discord_tls_config_cache.inc)
+
 (include stanzas/test_discord_presence_bridge.inc)
 
 (include stanzas/test_discord_observability.inc)

--- a/test/stanzas/test_discord_tls_config_cache.inc
+++ b/test/stanzas/test_discord_tls_config_cache.inc
@@ -1,0 +1,6 @@
+; Regression guard: Discord gateway TLS config is cached process-wide
+; (trust store loaded once, not per reconnect).
+(test
+ (name test_discord_tls_config_cache)
+ (modules test_discord_tls_config_cache)
+ (libraries alcotest masc.gate))

--- a/test/test_discord_tls_config_cache.ml
+++ b/test/test_discord_tls_config_cache.ml
@@ -1,0 +1,35 @@
+(** Regression guard for the process-wide Discord TLS config cache.
+
+    [client_tls_config] runs on every gateway (re)connect; it must load
+    the system trust store once (macOS: one `security find-certificate`
+    subprocess per keychain plus a full PEM parse) and reuse the config
+    on later calls instead of reloading per reconnect (2026-07-17 masc
+    CPU-full diagnosis; the LLM connection-path twin of this cache is
+    tested in oas test_tls_config_cache).
+
+    Hosts without a readable trust store make the loader raise [Failure];
+    there is nothing to cache in that environment, so the case prints a
+    skip note and passes vacuously (failures are deliberately not
+    cached — the next reconnect retries the load). *)
+
+module Conn = Discord_wss_connection
+
+let test_physical_identity () =
+  match Conn.For_testing.client_tls_config () with
+  | exception Failure msg ->
+    Printf.printf "skip: system trust store unavailable: %s\n" msg
+  | first ->
+    let second = Conn.For_testing.client_tls_config () in
+    Alcotest.(check bool)
+      "same physical Tls.Config.client on repeat calls"
+      true
+      (first == second)
+;;
+
+let () =
+  Alcotest.run
+    "discord_tls_config_cache"
+    [ ( "cache"
+      , [ Alcotest.test_case "physical identity" `Quick test_physical_identity ] )
+    ]
+;;


### PR DESCRIPTION
## 문제

`discord_wss_connection.client_tls_config`가 게이트웨이 (재)접속마다 `Ca_certs.authenticator()`를 재실행합니다. macOS에서 1회 = keychain당 `security find-certificate` 서브프로세스 + 수백 KB PEM 파싱이며, 서버 main 도메인에서 실행됩니다. 2026-07-17 masc CPU 폭주 라이브 진단(10s `sample` ×2)에서 확인된 ca-certs 재로딩 계열의 masc 측 잔여 사이트입니다 (주 발원지인 OAS 연결 경로는 oas#2626에서 수리).

## 수리

기존 `Eio_context._https_connector_cache`와 같은 계열의 Atomic 캐시로 (단, eio_context는 CAS로 racer를 단일 승자에 수렴시키고 본 PR은 plain `Atomic.set` — cold-start에 Discord/Slack 게이트웨이가 동시에 진입하면 최대 1회 중복 로드가 가능하나 각자 유효한 config를 사용하므로 정확성 무영향) 첫 성공 `Tls.Config.client`를 프로세스 수명 동안 재사용:
- 인증서 유효기간 검증은 핸드셰이크마다 clock closure로 평가 — 캐시가 시간 검증을 동결하지 않음
- 실패는 캐시하지 않음 — 다음 재접속에서 재시도

`Ca_certs.authenticator` 전수 스윕 결과: eio_context(이미 캐시됨) / otel_spans(emitter당 1회 — 비대상) / discord(본 PR) — 잔여 per-call 사이트 0.

## 검증

- `test_discord_gateway_client` 7 tests PASS
- `For_testing.client_tls_config` read-only accessor 노출 + `test_discord_tls_config_cache`(물리적 동등성) 추가 — coverage gate 대응. authenticator override는 여전히 비노출(mli "by design" 유지).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PgGNxsWM8yCaJiHnTzrVa
