### PR TITLE
feat(mcp): decode exact tool invocation identity

### DIFF
--- a/lib/tool_invocation_ref/tool_invocation_ref.ml
+++ b/lib/tool_invocation_ref/tool_invocation_ref.ml
@@ -6,6 +6,16 @@ type t =
 
 type error = Empty_mcp_session_id
 
+type decode_error =
+  | Expected_object
+  | Unknown_field of string
+  | Duplicate_field of string
+  | Missing_field of string
+  | Expected_string of string
+  | Invalid_source of string
+  | Invalid_request_id of Mcp_transport_protocol.request_id_error
+  | Invalid_identity of error
+
 let external_mcp ~request_id ~session_id =
   if String.equal (String.trim session_id) ""
   then Error Empty_mcp_session_id
@@ -21,6 +31,45 @@ let to_yojson = function
       ]
 ;;
 
+let of_yojson = function
+  | `Assoc fields ->
+    let allowed = [ "source"; "session_id"; "request_id" ] in
+    let rec validate seen = function
+      | [] -> Ok ()
+      | (name, _) :: rest when not (List.mem name allowed) -> Error (Unknown_field name)
+      | (name, _) :: _ when List.mem name seen -> Error (Duplicate_field name)
+      | (name, _) :: rest -> validate (name :: seen) rest
+    in
+    let required name =
+      match List.assoc_opt name fields with
+      | Some value -> Ok value
+      | None -> Error (Missing_field name)
+    in
+    let ( let* ) = Result.bind in
+    let* () = validate [] fields in
+    let* source = required "source" in
+    let* session_id = required "session_id" in
+    let* request_id = required "request_id" in
+    let* () =
+      match source with
+      | `String "external_mcp" -> Ok ()
+      | `String value -> Error (Invalid_source value)
+      | _ -> Error (Expected_string "source")
+    in
+    let* session_id =
+      match session_id with
+      | `String value -> Ok value
+      | _ -> Error (Expected_string "session_id")
+    in
+    let* request_id =
+      Mcp_transport_protocol.request_id_of_yojson request_id
+      |> Result.map_error (fun error -> Invalid_request_id error)
+    in
+    external_mcp ~request_id ~session_id
+    |> Result.map_error (fun error -> Invalid_identity error)
+  | _ -> Error Expected_object
+;;
+
 let equal left right =
   match left, right with
   | ( External_mcp { request_id = left_id; session_id = left_session }
@@ -32,4 +81,21 @@ let equal left right =
 let error_to_string = function
   | Empty_mcp_session_id ->
     "external MCP tool invocation requires a non-empty stable session id"
+;;
+
+let decode_error_to_string = function
+  | Expected_object -> "tool invocation identity must be a JSON object"
+  | Unknown_field name ->
+    Printf.sprintf "tool invocation identity has unknown field %S" name
+  | Duplicate_field name ->
+    Printf.sprintf "tool invocation identity has duplicate field %S" name
+  | Missing_field name ->
+    Printf.sprintf "tool invocation identity is missing field %S" name
+  | Expected_string name ->
+    Printf.sprintf "tool invocation identity field %S must be a string" name
+  | Invalid_source source ->
+    Printf.sprintf "tool invocation identity has invalid source %S" source
+  | Invalid_request_id error ->
+    Mcp_transport_protocol.request_id_error_to_string error
+  | Invalid_identity error -> error_to_string error
 ;;

--- a/lib/tool_invocation_ref/tool_invocation_ref.mli
+++ b/lib/tool_invocation_ref/tool_invocation_ref.mli
@@ -7,6 +7,16 @@ type t
 
 type error = Empty_mcp_session_id
 
+type decode_error =
+  | Expected_object
+  | Unknown_field of string
+  | Duplicate_field of string
+  | Missing_field of string
+  | Expected_string of string
+  | Invalid_source of string
+  | Invalid_request_id of Mcp_transport_protocol.request_id_error
+  | Invalid_identity of error
+
 val external_mcp :
   request_id:Mcp_transport_protocol.request_id ->
   session_id:string ->
@@ -17,6 +27,11 @@ val external_mcp :
 val to_yojson : t -> Yojson.Safe.t
 (** Typed, inspectable projection. *)
 
+val of_yojson : Yojson.Safe.t -> (t, decode_error) result
+(** Restores the exact producer identity from its closed projection. Unknown,
+    duplicate, or malformed fields are rejected rather than ignored. *)
+
 val equal : t -> t -> bool
 
 val error_to_string : error -> string
+val decode_error_to_string : decode_error -> string

--- a/test/tool_invocation_ref/dune
+++ b/test/tool_invocation_ref/dune
@@ -1,0 +1,3 @@
+(test
+ (name test_tool_invocation_ref)
+ (libraries alcotest yojson masc.tool_invocation_ref masc.mcp_transport_protocol))

--- a/test/tool_invocation_ref/test_tool_invocation_ref.ml
+++ b/test/tool_invocation_ref/test_tool_invocation_ref.ml
@@ -1,0 +1,86 @@
+let request_id json =
+  match Mcp_transport_protocol.request_id_of_yojson json with
+  | Ok value -> value
+  | Error error ->
+    Alcotest.fail (Mcp_transport_protocol.request_id_error_to_string error)
+;;
+
+let identity () =
+  match
+    Tool_invocation_ref.external_mcp
+      ~request_id:(request_id (`Intlit "9007199254740993"))
+      ~session_id:"session-1"
+  with
+  | Ok value -> value
+  | Error error -> Alcotest.fail (Tool_invocation_ref.error_to_string error)
+;;
+
+let test_roundtrip () =
+  let expected = identity () in
+  match Tool_invocation_ref.of_yojson (Tool_invocation_ref.to_yojson expected) with
+  | Ok actual ->
+    Alcotest.(check bool)
+      "exact identity"
+      true
+      (Tool_invocation_ref.equal expected actual)
+  | Error error ->
+    Alcotest.fail (Tool_invocation_ref.decode_error_to_string error)
+;;
+
+let test_closed_decoder () =
+  let canonical = Tool_invocation_ref.to_yojson (identity ()) in
+  let fields =
+    match canonical with
+    | `Assoc fields -> fields
+    | _ -> Alcotest.fail "canonical identity must be an object"
+  in
+  let check label expected json =
+    match Tool_invocation_ref.of_yojson json with
+    | Error actual -> Alcotest.(check bool) label true (actual = expected)
+    | Ok _ -> Alcotest.failf "%s: malformed identity decoded" label
+  in
+  check
+    "unknown"
+    (Tool_invocation_ref.Unknown_field "extra")
+    (`Assoc (("extra", `Null) :: fields));
+  check
+    "duplicate"
+    (Tool_invocation_ref.Duplicate_field "source")
+    (`Assoc (("source", `String "external_mcp") :: fields));
+  check
+    "missing"
+    (Tool_invocation_ref.Missing_field "request_id")
+    (`Assoc (List.remove_assoc "request_id" fields));
+  check
+    "source"
+    (Tool_invocation_ref.Invalid_source "invented")
+    (`Assoc
+      (("source", `String "invented") :: List.remove_assoc "source" fields));
+  check
+    "source type"
+    (Tool_invocation_ref.Expected_string "source")
+    (`Assoc (("source", `Null) :: List.remove_assoc "source" fields));
+  check
+    "request id"
+    (Tool_invocation_ref.Invalid_request_id
+       Mcp_transport_protocol.Null_request_id)
+    (`Assoc (("request_id", `Null) :: List.remove_assoc "request_id" fields));
+  check
+    "session"
+    (Tool_invocation_ref.Invalid_identity
+       Tool_invocation_ref.Empty_mcp_session_id)
+    (`Assoc (("session_id", `String " ") :: List.remove_assoc "session_id" fields));
+  check
+    "session type"
+    (Tool_invocation_ref.Expected_string "session_id")
+    (`Assoc (("session_id", `Null) :: List.remove_assoc "session_id" fields))
+;;
+
+let () =
+  Alcotest.run
+    "tool invocation ref"
+    [ ( "codec"
+      , [ Alcotest.test_case "roundtrip" `Quick test_roundtrip
+        ; Alcotest.test_case "closed decoder" `Quick test_closed_decoder
+        ] )
+    ]


### PR DESCRIPTION
## Summary
- add the single closed decoder for `Tool_invocation_ref`
- reject unknown, duplicate, missing, mistyped, and invalid request-id fields explicitly
- preserve lossless integer-vs-string JSON-RPC request identity

This type remains correlation-only. It grants no authority and performs no tool-name or argument inference.

## Verification
- `scripts/dune-local.sh build @test/tool_invocation_ref/runtest` (2/2)
- `opam exec -- ocamlformat --check` on changed OCaml files
- `git diff --check`

## Stack
Base: #24957