### PR TITLE
fix(keeper): pin sqlite values across finalize/close blocking windows

### DIFF
--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -1272,7 +1272,7 @@ let sqlite_finalize db stmt =
      and 2026-07-17 01:31 crash reports. Keeping [stmt] reachable past
      the call closes the window; the true fix (null the pointer before
      releasing the runtime) belongs upstream in the binding. *)
-  ignore (Sys.opaque_identity stmt);
+  ignore (Sys.opaque_identity stmt) (* See GC-liveness pin note above. *);
   result
 
 let combine_cleanup_error primary cleanup =
@@ -1501,7 +1501,7 @@ let close_database handle =
      wrap's pointer only afterwards. [handle] happens to stay reachable
      through [identity_result] below today; pin it explicitly so the
      safety does not depend on that incidental use. *)
-  ignore (Sys.opaque_identity handle.db);
+  ignore (Sys.opaque_identity handle.db) (* See GC-liveness pin note above. *);
   let identity_result =
     let* () = validate_owned_parent ~ownership_root:handle.ownership_root handle.path in
     match inspect_regular_or_absent handle.path with

--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -1250,13 +1250,30 @@ let sqlite_expect_done db stmt ~operation =
    propagation. [Sqlite3.finalize] is a non-suspending C call, so the
    catch-all cannot swallow Cancelled itself. *)
 let sqlite_finalize db stmt =
-  match Sqlite3.finalize stmt with
-  | rc ->
-    if Sqlite3.Rc.is_success rc
-    then Ok ()
-    else Error (sqlite_error ~operation:"statement finalize" db rc)
-  | exception exn ->
-    Error ("SQLite statement finalize raised: " ^ Printexc.to_string exn)
+  let result =
+    match Sqlite3.finalize stmt with
+    | rc ->
+      if Sqlite3.Rc.is_success rc
+      then Ok ()
+      else Error (sqlite_error ~operation:"statement finalize" db rc)
+    | exception exn ->
+      Error ("SQLite statement finalize raised: " ^ Printexc.to_string exn)
+  in
+  (* GC-liveness pin. The sqlite3 binding's [caml_sqlite3_stmt_finalize]
+     releases the OCaml runtime lock around [sqlite3_finalize] and only
+     nulls the wrap's statement pointer after re-acquiring it
+     (sqlite3_stubs.c, sqlite3.5.4.1). The call above is otherwise the
+     last use of [stmt], so the compiler drops it from the frame's GC
+     map; a GC from another domain during that blocking window can then
+     collect the wrap and run [stmt_wrap_finalize_gc], which calls
+     [sqlite3_finalize] on the same (already freed) pointer —
+     use-after-free, observed as SIGSEGV `checkMutexEnter <-
+     sqlite3_finalize <- stmt_wrap_finalize_gc` in the 2026-07-15 23:32
+     and 2026-07-17 01:31 crash reports. Keeping [stmt] reachable past
+     the call closes the window; the true fix (null the pointer before
+     releasing the runtime) belongs upstream in the binding. *)
+  ignore (Sys.opaque_identity stmt);
+  result
 
 let combine_cleanup_error primary cleanup =
   match primary, cleanup with
@@ -1479,6 +1496,12 @@ let close_database handle =
       else Error "SQLite database close reported a busy handle"
     with exn -> Error ("SQLite database close failed: " ^ Printexc.to_string exn)
   in
+  (* Same GC-liveness pin as [sqlite_finalize]: [caml_sqlite3_close]
+     also releases the runtime around [sqlite3_close] and nulls the
+     wrap's pointer only afterwards. [handle] happens to stay reachable
+     through [identity_result] below today; pin it explicitly so the
+     safety does not depend on that incidental use. *)
+  ignore (Sys.opaque_identity handle.db);
   let identity_result =
     let* () = validate_owned_parent ~ownership_root:handle.ownership_root handle.path in
     match inspect_regular_or_absent handle.path with

--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -1270,8 +1270,11 @@ let sqlite_finalize db stmt =
      use-after-free, observed as SIGSEGV `checkMutexEnter <-
      sqlite3_finalize <- stmt_wrap_finalize_gc` in the 2026-07-15 23:32
      and 2026-07-17 01:31 crash reports. Keeping [stmt] reachable past
-     the call closes the window; the true fix (null the pointer before
-     releasing the runtime) belongs upstream in the binding. *)
+     the call closes the window — [Sys.opaque_identity] is documented to
+     "prevent the argument from being garbage collected until the
+     location where the call would have occurred" (sys.mli). The true
+     fix (null the pointer before releasing the runtime) belongs
+     upstream in the binding. *)
   ignore (Sys.opaque_identity stmt) (* See GC-liveness pin note above. *);
   result
 

--- a/test/test_keeper_chat_coalescing.ml
+++ b/test/test_keeper_chat_coalescing.ml
@@ -877,6 +877,32 @@ let test_finalize_statement_total () =
        (Printexc.to_string exn));
   ignore (Sqlite3.db_close db : bool)
 
+let test_finalize_statement_gc_pressure () =
+  Printf.printf
+    "Test: finalize keeps the statement wrap pinned across its blocking window\n%!";
+  (* Regression smoke for the stmt_wrap_finalize_gc use-after-free
+     (SIGSEGV `checkMutexEnter <- sqlite3_finalize <- stmt_wrap_finalize_gc`,
+     2026-07-15 / 2026-07-17 crash reports): finalize each statement as its
+     last use while forcing allocation churn and minor collections, so the
+     finalize blocking window overlaps GC activity. Without the
+     Sys.opaque_identity pin in [sqlite_finalize] the wrap can be collected
+     mid-window and double-finalized by the GC finalizer; a regression
+     surfaces as a crash of this executable rather than a check failure
+     (GC timing races admit no deterministic assertion). *)
+  let db = Sqlite3.db_open ":memory:" in
+  let churn = ref [] in
+  for i = 1 to 2_000 do
+    let stmt = Sqlite3.prepare db "SELECT 1" in
+    (match Keeper_chat_queue.For_testing.finalize_statement db stmt with
+     | Ok () -> ()
+     | Error detail -> fail "gc-pressure finalize returns Ok" detail);
+    churn := String.make 256 'x' :: (if i mod 16 = 0 then [] else !churn);
+    if i mod 64 = 0 then Gc.minor ()
+  done;
+  ignore (Sys.opaque_identity !churn);
+  check "2000 finalize cycles under GC pressure complete" true;
+  ignore (Sqlite3.db_close db : bool)
+
 let () =
   Eio_main.run @@ fun _environment ->
   test_first_enqueue_with_runtime_eio_guard ();
@@ -897,6 +923,7 @@ let () =
   test_foreign_database_and_symlink_are_quarantined ();
   test_reconcile_absent_lane_and_stage_order ();
   test_finalize_statement_total ();
+  test_finalize_statement_gc_pressure ();
   if !failures > 0
   then (
     Printf.printf "FAILED: %d check(s)\n%!" !failures;

--- a/test/test_keeper_chat_coalescing.ml
+++ b/test/test_keeper_chat_coalescing.ml
@@ -880,15 +880,19 @@ let test_finalize_statement_total () =
 let test_finalize_statement_gc_pressure () =
   Printf.printf
     "Test: finalize keeps the statement wrap pinned across its blocking window\n%!";
-  (* Regression smoke for the stmt_wrap_finalize_gc use-after-free
-     (SIGSEGV `checkMutexEnter <- sqlite3_finalize <- stmt_wrap_finalize_gc`,
-     2026-07-15 / 2026-07-17 crash reports): finalize each statement as its
-     last use while forcing allocation churn and minor collections, so the
-     finalize blocking window overlaps GC activity. Without the
-     Sys.opaque_identity pin in [sqlite_finalize] the wrap can be collected
-     mid-window and double-finalized by the GC finalizer; a regression
-     surfaces as a crash of this executable rather than a check failure
-     (GC timing races admit no deterministic assertion). *)
+  (* Exercises the pinned [sqlite_finalize] path under allocation churn:
+     2,000 prepare/finalize cycles stay functionally correct while the
+     minor heap turns over. Honest scope note: this loop is single-threaded
+     and [Gc.minor] runs only after each finalize returns, so it does NOT
+     construct the cross-thread race the pin closes (the
+     stmt_wrap_finalize_gc use-after-free needs another thread to drive a
+     collection during the finalize blocking window — SIGSEGV
+     `checkMutexEnter <- sqlite3_finalize <- stmt_wrap_finalize_gc`,
+     2026-07-15 / 2026-07-17 crash reports). The pin's guarantee rests on
+     the documented [Sys.opaque_identity] semantics ("prevent the argument
+     from being garbage collected until the location where the call would
+     have occurred", sys.mli), which no in-process test can deterministically
+     falsify; this test guards the code path's functional behavior only. *)
   let db = Sqlite3.db_open ":memory:" in
   let churn = ref [] in
   for i = 1 to 2_000 do


### PR DESCRIPTION
## 문제 — 유일 확정 crash 클래스 (crash report 2건)

- 2026-07-15 23:32, 2026-07-17 01:31 두 .ips 모두 동일 스택:
  `checkMutexEnter ← sqlite3_finalize ← stmt_wrap_finalize_gc ← caml_stw_empty_minor_heap_no_major_slice` (SIGSEGV, KERN_INVALID_ADDRESS @0x1)

## 근본 원인 (바인딩 소스로 확정, sqlite3.5.4.1)

`caml_sqlite3_stmt_finalize`(sqlite3_stubs.c:900-906):
1. runtime lock 해제 후 `sqlite3_finalize(stmtw->stmt)` — C 객체 해제
2. lock 재획득 **후에** `stmtw->stmt = NULL`

`sqlite_finalize`에서 이 호출이 stmt 값의 **마지막 사용**이라 프레임 GC map에서 탈락 → blocking window 동안 타 도메인 GC가 wrap을 수거 → `stmt_wrap_finalize_gc`가 아직 NULL이 아닌 포인터로 `sqlite3_finalize`를 재호출 → use-after-free. `caml_sqlite3_close`(:552-561)도 동일한 release-then-null 형태.

Yojson 파싱 부하로 minor GC가 잦은 현 상태에서 발현 빈도가 올라감 (crash 시점 모두 systhread Yojson lex 활성).

## 수리

- `sqlite_finalize`: `Sys.opaque_identity stmt` pin — finalize가 포인터를 NULL로 마킹할 때까지 wrap이 수거되지 않도록 liveness 보장 (FFI GC-rooting, CAMLparam과 동류)
- `close_database`: `handle.db` 동일 pin — 현재는 이후 field read 덕에 우연히 live지만, 안전성이 원거리 코드에 의존하지 않도록 명시화

어제(07-16) 리포트의 "busy-close가 살아있는 stmt를 죽은 db 위에 남김" 가설은 **정정**: 바인딩은 `_Atomic ref_count`로 out-of-order GC를 처리하므로 busy-close는 leak-only. 크래셔는 위 liveness 레이스.

## 업스트림

진짜 SSOT 수정은 바인딩에서 "runtime 해제 **전에** 포인터를 읽고 NULL 마킹" (2줄 reorder). 별도 이슈로 추적 — pinned fork 또는 upstream PR.

## 검증

- `test_keeper_chat_coalescing`(finalize 엣지 케이스 포함) / `test_keeper_waiting_inventory`(16) — PASS
- GC 타이밍 레이스 특성상 결정론적 단위 테스트로 부재 증명 불가 — 근거는 crash 스택 2건 + 바인딩 소스 분석. `Sys.opaque_identity`는 시맨틱 무변경 최적화 배리어.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PgGNxsWM8yCaJiHnTzrVa
