### PR TITLE
feat(keeper): add compaction operation identities

### DIFF
--- a/lib/keeper_compaction_operation_identity/dune
+++ b/lib/keeper_compaction_operation_identity/dune
@@ -1,0 +1,8 @@
+(include_subdirs no)
+
+(library
+ (name masc_keeper_compaction_operation_identity)
+ (public_name masc.keeper_compaction_operation_identity)
+ (wrapped false)
+ (modules keeper_compaction_operation_identity)
+ (libraries threads uuidm))

--- a/lib/keeper_compaction_operation_identity/keeper_compaction_operation_identity.ml
+++ b/lib/keeper_compaction_operation_identity/keeper_compaction_operation_identity.ml
@@ -1,0 +1,43 @@
+type id_error = Invalid_canonical_uuid
+
+module Make_id () = struct
+  type t = Uuidm.t
+
+  (* NDT-OK: entropy creates identity only; no lifecycle decision uses it. *)
+  let rng = Random.State.make_self_init ()
+  let rng_mutex = Stdlib.Mutex.create ()
+  let generate () =
+    Stdlib.Mutex.protect rng_mutex (fun () -> Uuidm.v4_gen rng ())
+  ;;
+
+  let of_string value =
+    match Uuidm.of_string value with
+    | Some id when String.equal value (Uuidm.to_string id) -> Ok id
+    | Some _ | None -> Error Invalid_canonical_uuid
+  ;;
+
+  let to_string id = Uuidm.to_string id
+  let equal = Uuidm.equal
+  let compare = Uuidm.compare
+end
+
+module Operation_id = Make_id ()
+module Attempt_id = Make_id ()
+
+module Cause = struct
+  type t = string
+  type error =
+    | Empty
+    | Noncanonical
+
+  let of_string value =
+    if value = ""
+    then Error Empty
+    else if String.equal value (String.trim value)
+    then Ok value
+    else Error Noncanonical
+  ;;
+
+  let to_string value = value
+  let equal = String.equal
+end

--- a/lib/keeper_compaction_operation_identity/keeper_compaction_operation_identity.mli
+++ b/lib/keeper_compaction_operation_identity/keeper_compaction_operation_identity.mli
@@ -1,0 +1,31 @@
+(** Canonical identities carried by Keeper compaction operation events. *)
+
+type id_error = Invalid_canonical_uuid
+
+module Operation_id : sig
+  type t
+  val generate : unit -> t
+  val of_string : string -> (t, id_error) result
+  val to_string : t -> string
+  val equal : t -> t -> bool
+  val compare : t -> t -> int
+end
+
+module Attempt_id : sig
+  type t
+  val generate : unit -> t
+  val of_string : string -> (t, id_error) result
+  val to_string : t -> string
+  val equal : t -> t -> bool
+  val compare : t -> t -> int
+end
+
+module Cause : sig
+  type t
+  type error =
+    | Empty
+    | Noncanonical
+  val of_string : string -> (t, error) result
+  val to_string : t -> string
+  val equal : t -> t -> bool
+end

--- a/test/keeper_compaction_operation_identity/dune
+++ b/test/keeper_compaction_operation_identity/dune
@@ -1,0 +1,3 @@
+(test
+ (name test_keeper_compaction_operation_identity)
+ (libraries alcotest masc.keeper_compaction_operation_identity))

--- a/test/keeper_compaction_operation_identity/test_keeper_compaction_operation_identity.ml
+++ b/test/keeper_compaction_operation_identity/test_keeper_compaction_operation_identity.ml
@@ -1,0 +1,66 @@
+module Identity = Keeper_compaction_operation_identity
+
+let canonical_uuid = "123e4567-e89b-12d3-a456-426614174000"
+
+let test_typed_ids () =
+  let parse parse value =
+    match parse value with
+    | Ok id -> id
+    | Error Identity.Invalid_canonical_uuid -> Alcotest.fail "canonical UUID rejected"
+  in
+  let operation = parse Identity.Operation_id.of_string canonical_uuid in
+  let attempt = parse Identity.Attempt_id.of_string canonical_uuid in
+  Alcotest.(check string)
+    "operation projection"
+    canonical_uuid
+    (Identity.Operation_id.to_string operation);
+  Alcotest.(check string)
+    "attempt projection"
+    canonical_uuid
+    (Identity.Attempt_id.to_string attempt);
+  let generated_operation = Identity.Operation_id.generate () in
+  let next_operation = Identity.Operation_id.generate () in
+  Alcotest.(check bool)
+    "fresh operation ids differ"
+    false
+    (Identity.Operation_id.equal generated_operation next_operation);
+  (match
+     Identity.Operation_id.of_string
+       (Identity.Operation_id.to_string generated_operation)
+   with
+   | Ok restored ->
+     Alcotest.(check bool)
+       "generated operation is canonical"
+       true
+       (Identity.Operation_id.equal generated_operation restored)
+   | Error _ -> Alcotest.fail "generated operation id did not parse");
+  List.iter
+    (fun value ->
+       match Identity.Operation_id.of_string value with
+       | Error Identity.Invalid_canonical_uuid -> ()
+       | Ok _ -> Alcotest.failf "noncanonical UUID accepted: %S" value)
+    [ String.uppercase_ascii canonical_uuid; "not-a-uuid"; " " ^ canonical_uuid ]
+;;
+
+let test_cause () =
+  let open Identity.Cause in
+  (match of_string "provider context overflow" with
+   | Ok cause ->
+     Alcotest.(check string) "exact projection" "provider context overflow" (to_string cause)
+   | Error _ -> Alcotest.fail "canonical cause rejected");
+  List.iter
+    (fun (value, expected) ->
+       match of_string value with
+       | Error actual -> Alcotest.(check bool) value true (actual = expected)
+       | Ok _ -> Alcotest.failf "invalid cause accepted: %S" value)
+    [ "", Empty; " padded", Noncanonical; "padded ", Noncanonical ]
+;;
+
+let () =
+  Alcotest.run
+    "keeper compaction operation identity"
+    [ ( "identity"
+      , [ Alcotest.test_case "canonical typed UUIDs" `Quick test_typed_ids
+        ; Alcotest.test_case "canonical cause" `Quick test_cause
+        ] )
+    ]


### PR DESCRIPTION
## What changed

- adds distinct typed Operation_id and Attempt_id modules
- owns thread-safe canonical UUID generation and parsing in one leaf
- adds an opaque canonical Cause type for exact observed details

## Why

The compaction Operation Journal needs stable correlation identities before event, reducer, codec, and storage wiring can be added. Identity entropy does not authorize or classify any operation.

## Validation

- scripts/dune-local.sh build test/keeper_compaction_operation_identity/test_keeper_compaction_operation_identity.exe
- scripts/dune-local.sh exec test/keeper_compaction_operation_identity/test_keeper_compaction_operation_identity.exe
- ocamlformat --check on all changed OCaml files
- 151 inserted lines