### PR TITLE
feat(keeper): add compaction operation events

### DIFF
--- a/lib/keeper_compaction_operation/dune
+++ b/lib/keeper_compaction_operation/dune
@@ -1,0 +1,15 @@
+(include_subdirs no)
+
+(library
+ (name masc_keeper_compaction_operation)
+ (public_name masc.keeper_compaction_operation)
+ (wrapped false)
+ (modules keeper_compaction_operation)
+ (libraries
+  masc.compaction_trigger
+  masc.keeper_checkpoint_ref
+  masc.keeper_compaction_evidence
+  masc.keeper_compaction_operation_identity
+  masc.keeper_registry
+  masc.masc_types
+  masc.tool_invocation_ref))

--- a/lib/keeper_compaction_operation/keeper_compaction_operation.ml
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation.ml
@@ -1,0 +1,102 @@
+module Operation_id = Keeper_compaction_operation_identity.Operation_id
+module Attempt_id = Keeper_compaction_operation_identity.Attempt_id
+module Cause = Keeper_compaction_operation_identity.Cause
+
+type attempt_failure =
+  | Pre_commit_failure of Cause.t
+  | Candidate_not_installed of
+      { cause : Cause.t
+      ; observed_checkpoint : Keeper_checkpoint_ref.t
+      }
+
+type reconciliation_reason =
+  | Commit_durability_unknown
+  | Transaction_outcome_unknown
+
+type request =
+  { keeper_name : Keeper_id.Keeper_name.t
+  ; source_checkpoint : Keeper_checkpoint_ref.t
+  ; trigger : Compaction_trigger.t
+  ; cause : Cause.t
+  ; producer_invocation : Tool_invocation_ref.t option
+  }
+
+type candidate =
+  { attempt_id : Attempt_id.t
+  ; source_checkpoint : Keeper_checkpoint_ref.t
+  ; candidate_checkpoint : Keeper_checkpoint_ref.t
+  ; evidence : Keeper_compaction_evidence.t
+  }
+
+type event_view =
+  | Requested of request
+  | Attempt_started of Attempt_id.t
+  | Candidate_prepared of candidate
+  | Attempt_failed of Attempt_id.t * attempt_failure
+  | Commit_reconciliation_required of candidate * reconciliation_reason
+  | Compacted of candidate
+  | Reinjected of Keeper_checkpoint_ref.t * Ids.Turn_ref.t
+
+type event =
+  { operation_id : Operation_id.t
+  ; view : event_view
+  }
+
+let operation_id event = event.operation_id
+let view event = event.view
+
+let candidate ~attempt_id ~source_checkpoint ~candidate_checkpoint ~evidence =
+  { attempt_id; source_checkpoint; candidate_checkpoint; evidence }
+;;
+
+let requested ~operation_id ~keeper_name ~source_checkpoint ~trigger ~cause
+    ~producer_invocation =
+  { operation_id
+  ; view =
+      Requested
+        { keeper_name; source_checkpoint; trigger; cause; producer_invocation }
+  }
+;;
+
+let attempt_started ~operation_id ~attempt_id =
+  { operation_id; view = Attempt_started attempt_id }
+;;
+
+let candidate_prepared ~operation_id ~attempt_id ~source_checkpoint
+    ~candidate_checkpoint ~evidence =
+  { operation_id
+  ; view =
+      Candidate_prepared
+        (candidate ~attempt_id ~source_checkpoint ~candidate_checkpoint ~evidence)
+  }
+;;
+
+let attempt_failed ~operation_id ~attempt_id ~failure =
+  { operation_id; view = Attempt_failed (attempt_id, failure) }
+;;
+
+let commit_reconciliation_required ~operation_id ~attempt_id ~source_checkpoint
+    ~candidate_checkpoint ~evidence ~reason =
+  { operation_id
+  ; view =
+      Commit_reconciliation_required
+        (candidate ~attempt_id ~source_checkpoint ~candidate_checkpoint ~evidence, reason)
+  }
+;;
+
+let compacted ~operation_id ~attempt_id ~source_checkpoint
+    ~committed_checkpoint ~evidence =
+  { operation_id
+  ; view =
+      Compacted
+        (candidate
+           ~attempt_id
+           ~source_checkpoint
+           ~candidate_checkpoint:committed_checkpoint
+           ~evidence)
+  }
+;;
+
+let reinjected ~operation_id ~adopted_checkpoint ~adopting_turn =
+  { operation_id; view = Reinjected (adopted_checkpoint, adopting_turn) }
+;;

--- a/lib/keeper_compaction_operation/keeper_compaction_operation.mli
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation.mli
@@ -1,0 +1,86 @@
+(** Typed immutable facts for one Keeper compaction operation. *)
+
+module Operation_id = Keeper_compaction_operation_identity.Operation_id
+module Attempt_id = Keeper_compaction_operation_identity.Attempt_id
+module Cause = Keeper_compaction_operation_identity.Cause
+
+type attempt_failure =
+  | Pre_commit_failure of Cause.t
+  | Candidate_not_installed of
+      { cause : Cause.t
+      ; observed_checkpoint : Keeper_checkpoint_ref.t
+      }
+
+type reconciliation_reason =
+  | Commit_durability_unknown
+  | Transaction_outcome_unknown
+
+type request =
+  { keeper_name : Keeper_id.Keeper_name.t
+  ; source_checkpoint : Keeper_checkpoint_ref.t
+  ; trigger : Compaction_trigger.t
+  ; cause : Cause.t
+  ; producer_invocation : Tool_invocation_ref.t option
+  }
+
+type candidate =
+  { attempt_id : Attempt_id.t
+  ; source_checkpoint : Keeper_checkpoint_ref.t
+  ; candidate_checkpoint : Keeper_checkpoint_ref.t
+  ; evidence : Keeper_compaction_evidence.t
+  }
+
+type event_view =
+  | Requested of request
+  | Attempt_started of Attempt_id.t
+  | Candidate_prepared of candidate
+  | Attempt_failed of Attempt_id.t * attempt_failure
+  | Commit_reconciliation_required of candidate * reconciliation_reason
+  | Compacted of candidate
+  | Reinjected of Keeper_checkpoint_ref.t * Ids.Turn_ref.t
+
+type event
+val operation_id : event -> Operation_id.t
+val view : event -> event_view
+
+val requested :
+  operation_id:Operation_id.t ->
+  keeper_name:Keeper_id.Keeper_name.t ->
+  source_checkpoint:Keeper_checkpoint_ref.t ->
+  trigger:Compaction_trigger.t ->
+  cause:Cause.t ->
+  producer_invocation:Tool_invocation_ref.t option ->
+  event
+val attempt_started : operation_id:Operation_id.t -> attempt_id:Attempt_id.t -> event
+val candidate_prepared :
+  operation_id:Operation_id.t ->
+  attempt_id:Attempt_id.t ->
+  source_checkpoint:Keeper_checkpoint_ref.t ->
+  candidate_checkpoint:Keeper_checkpoint_ref.t ->
+  evidence:Keeper_compaction_evidence.t ->
+  event
+val attempt_failed :
+  operation_id:Operation_id.t ->
+  attempt_id:Attempt_id.t ->
+  failure:attempt_failure ->
+  event
+val commit_reconciliation_required :
+  operation_id:Operation_id.t ->
+  attempt_id:Attempt_id.t ->
+  source_checkpoint:Keeper_checkpoint_ref.t ->
+  candidate_checkpoint:Keeper_checkpoint_ref.t ->
+  evidence:Keeper_compaction_evidence.t ->
+  reason:reconciliation_reason ->
+  event
+val compacted :
+  operation_id:Operation_id.t ->
+  attempt_id:Attempt_id.t ->
+  source_checkpoint:Keeper_checkpoint_ref.t ->
+  committed_checkpoint:Keeper_checkpoint_ref.t ->
+  evidence:Keeper_compaction_evidence.t ->
+  event
+val reinjected :
+  operation_id:Operation_id.t ->
+  adopted_checkpoint:Keeper_checkpoint_ref.t ->
+  adopting_turn:Ids.Turn_ref.t ->
+  event

--- a/test/keeper_compaction_operation/dune
+++ b/test/keeper_compaction_operation/dune
@@ -1,0 +1,12 @@
+(test
+ (name test_keeper_compaction_operation)
+ (libraries
+  alcotest
+  masc.compaction_trigger
+  masc.keeper_checkpoint_ref
+  masc.keeper_compaction_evidence
+  masc.keeper_compaction_operation
+  masc.keeper_registry
+  masc.masc_types
+  masc.mcp_transport_protocol
+  masc.tool_invocation_ref))

--- a/test/keeper_compaction_operation/test_keeper_compaction_operation.ml
+++ b/test/keeper_compaction_operation/test_keeper_compaction_operation.ml
@@ -1,0 +1,148 @@
+module Operation = Keeper_compaction_operation
+
+let ok = function Ok value -> value | Error _ -> Alcotest.fail "fixture rejected"
+let operation_id = ok (Operation.Operation_id.of_string "123e4567-e89b-12d3-a456-426614174000")
+let attempt_id = ok (Operation.Attempt_id.of_string "123e4567-e89b-12d3-a456-426614174001")
+let keeper_name = ok (Keeper_id.Keeper_name.of_string "keeper-a")
+let trace_id = ok (Keeper_id.Trace_id.of_string "trace-a")
+let checkpoint bytes turn_count =
+  ok
+    (Keeper_checkpoint_ref.create
+       ~trace_id
+       ~generation:2
+       ~turn_count
+       ~canonical_checkpoint_bytes:bytes)
+;;
+let source = checkpoint "before" 7
+let candidate = checkpoint "after" 7
+let evidence : Keeper_compaction_evidence.t =
+  { selected_runtime_id = Some "compact-runtime"
+  ; before_checkpoint_bytes = 100
+  ; after_checkpoint_bytes = 50
+  ; before_message_count = 10
+  ; after_message_count = 4
+  ; summarized_message_count = 6
+  ; dropped_message_count = 0
+  ; before_tool_use_count = 2
+  ; after_tool_use_count = 1
+  ; before_tool_result_count = 2
+  ; after_tool_result_count = 1
+  }
+;;
+let cause = ok (Operation.Cause.of_string "operator request")
+let producer =
+  let request_id = ok (Mcp_transport_protocol.request_id_of_yojson (`String "req-1")) in
+  ok (Tool_invocation_ref.external_mcp ~request_id ~session_id:"session-1")
+;;
+
+let test_requested_view () =
+  let event =
+    Operation.requested
+      ~operation_id
+      ~keeper_name
+      ~source_checkpoint:source
+      ~trigger:Compaction_trigger.Manual
+      ~cause
+      ~producer_invocation:(Some producer)
+  in
+  Alcotest.(check bool)
+    "operation identity"
+    true
+    (Operation.Operation_id.equal operation_id (Operation.operation_id event));
+  match Operation.view event with
+  | Operation.Requested request ->
+    Alcotest.(check bool)
+      "keeper identity"
+      true
+      (Keeper_id.Keeper_name.equal keeper_name request.keeper_name);
+    Alcotest.(check bool)
+      "source identity"
+      true
+      (Keeper_checkpoint_ref.equal source request.source_checkpoint);
+    Alcotest.(check bool)
+      "producer identity"
+      true
+      (Option.exists (Tool_invocation_ref.equal producer) request.producer_invocation)
+  | _ -> Alcotest.fail "requested event changed shape"
+;;
+
+let test_candidate_views () =
+  let prepared =
+    Operation.candidate_prepared
+      ~operation_id
+      ~attempt_id
+      ~source_checkpoint:source
+      ~candidate_checkpoint:candidate
+      ~evidence
+  in
+  let reconciled =
+    Operation.commit_reconciliation_required
+      ~operation_id
+      ~attempt_id
+      ~source_checkpoint:source
+      ~candidate_checkpoint:candidate
+      ~evidence
+      ~reason:Operation.Transaction_outcome_unknown
+  in
+  let check_candidate = function
+    | Operation.Candidate_prepared value
+    | Operation.Commit_reconciliation_required (value, _) ->
+      Alcotest.(check bool)
+        "candidate identity"
+        true
+        (Keeper_checkpoint_ref.equal candidate value.candidate_checkpoint)
+    | _ -> Alcotest.fail "candidate event changed shape"
+  in
+  check_candidate (Operation.view prepared);
+  check_candidate (Operation.view reconciled)
+;;
+
+let test_failure_and_reinjection_views () =
+  let failure =
+    Operation.attempt_failed
+      ~operation_id
+      ~attempt_id
+      ~failure:
+        (Operation.Candidate_not_installed
+           { cause; observed_checkpoint = source })
+  in
+  let turn = Ids.Turn_ref.make ~trace_id:"trace-a" ~absolute_turn:8 in
+  let reinjected =
+    Operation.reinjected
+      ~operation_id
+      ~adopted_checkpoint:candidate
+      ~adopting_turn:turn
+  in
+  (match Operation.view failure with
+   | Operation.Attempt_failed
+       (_, Operation.Candidate_not_installed { observed_checkpoint; _ }) ->
+     Alcotest.(check bool)
+       "observed canonical source"
+       true
+       (Keeper_checkpoint_ref.equal source observed_checkpoint)
+   | _ -> Alcotest.fail "failure event changed shape");
+  match Operation.view reinjected with
+  | Operation.Reinjected (checkpoint, adopting_turn) ->
+    Alcotest.(check bool)
+      "adopted checkpoint"
+      true
+      (Keeper_checkpoint_ref.equal candidate checkpoint);
+    Alcotest.(check string)
+      "adopting turn"
+      "trace-a#8"
+      (Ids.Turn_ref.to_string adopting_turn)
+  | _ -> Alcotest.fail "reinjected event changed shape"
+;;
+
+let () =
+  Alcotest.run
+    "keeper compaction operation events"
+    [ ( "events"
+      , [ Alcotest.test_case "requested typed view" `Quick test_requested_view
+        ; Alcotest.test_case "candidate typed views" `Quick test_candidate_views
+        ; Alcotest.test_case
+            "failure and reinjection typed views"
+            `Quick
+            test_failure_and_reinjection_views
+        ] )
+    ]


### PR DESCRIPTION
## What changed

- adds immutable typed Requested, Attempt_started, Candidate_prepared, Attempt_failed, Commit_reconciliation_required, Compacted, and Reinjected facts
- exposes event operation identity and one typed event_view inspection SSOT
- keeps producer identity correlation-only and preserves exact source, candidate, evidence, adopted checkpoint, and adopting turn facts
- distinguishes confirmed pre-commit or not-installed failure from unknown commit reconciliation

## Why

Operation Journal storage and recovery must inspect facts without decoding JSON or inferring semantics from strings. This PR defines facts only: no persistence, clocks, lifecycle authority, budgets, or execution wiring.

## Validation

- scripts/dune-local.sh build test/keeper_compaction_operation/test_keeper_compaction_operation.exe
- scripts/dune-local.sh exec test/keeper_compaction_operation/test_keeper_compaction_operation.exe
- ocamlformat --check on all changed OCaml files
- 363 inserted lines