### PR TITLE
feat(keeper): reduce compaction operation facts

### DIFF
--- a/lib/keeper_compaction_operation_reducer/dune
+++ b/lib/keeper_compaction_operation_reducer/dune
@@ -1,13 +1,15 @@
-(test
- (name test_keeper_compaction_operation)
+(include_subdirs no)
+
+(library
+ (name masc_keeper_compaction_operation_reducer)
+ (public_name masc.keeper_compaction_operation_reducer)
+ (wrapped false)
+ (modules keeper_compaction_operation_reducer)
  (libraries
-  alcotest
   masc.compaction_trigger
   masc.keeper_checkpoint_ref
   masc.keeper_compaction_evidence
   masc.keeper_compaction_operation
-  masc.keeper_compaction_operation_reducer
   masc.keeper_registry
   masc.masc_types
-  masc.mcp_transport_protocol
   masc.tool_invocation_ref))

--- a/lib/keeper_compaction_operation_reducer/keeper_compaction_operation_reducer.ml
+++ b/lib/keeper_compaction_operation_reducer/keeper_compaction_operation_reducer.ml
@@ -1,0 +1,213 @@
+module Operation = Keeper_compaction_operation
+
+type phase =
+  | Request_pending
+  | Attempt_in_progress
+  | Candidate_pending_commit
+  | Reconciliation_pending
+  | Commit_complete
+  | Adopted
+
+type progress =
+  | Pending
+  | Running of Operation.Attempt_id.t
+  | Prepared of Operation.candidate
+  | Reconciling of Operation.candidate * Operation.reconciliation_reason
+  | Committed of Operation.candidate
+  | Adopted_state of
+      Operation.candidate * Keeper_checkpoint_ref.t * Ids.Turn_ref.t
+
+type state =
+  { operation_id : Operation.Operation_id.t
+  ; request : Operation.request
+  ; progress : progress
+  ; closed_attempts : Operation.Attempt_id.t list
+  }
+
+type snapshot =
+  { operation_id : Operation.Operation_id.t
+  ; keeper_name : Keeper_id.Keeper_name.t
+  ; source_checkpoint : Keeper_checkpoint_ref.t
+  ; trigger : Compaction_trigger.t
+  ; cause : Operation.Cause.t
+  ; producer_invocation : Tool_invocation_ref.t option
+  ; phase : phase
+  ; attempt_id : Operation.Attempt_id.t option
+  ; candidate_checkpoint : Keeper_checkpoint_ref.t option
+  ; evidence : Keeper_compaction_evidence.t option
+  ; reconciliation_reason : Operation.reconciliation_reason option
+  ; committed_checkpoint : Keeper_checkpoint_ref.t option
+  ; adopted_checkpoint : Keeper_checkpoint_ref.t option
+  ; adopting_turn : Ids.Turn_ref.t option
+  }
+
+type transition_error =
+  | Invalid_transition of phase option
+  | Operation_mismatch
+  | Attempt_mismatch
+  | Attempt_reused
+  | Source_mismatch
+  | Candidate_mismatch
+  | Reinjection_identity_mismatch
+
+let phase state =
+  match state.progress with
+  | Pending -> Request_pending
+  | Running _ -> Attempt_in_progress
+  | Prepared _ -> Candidate_pending_commit
+  | Reconciling _ -> Reconciliation_pending
+  | Committed _ -> Commit_complete
+  | Adopted_state _ -> Adopted
+;;
+
+let projection = function
+  | Pending -> None, None, None, None, None, None, None
+  | Running attempt -> Some attempt, None, None, None, None, None, None
+  | Prepared value ->
+    Some value.attempt_id, Some value.candidate_checkpoint, Some value.evidence,
+    None, None, None, None
+  | Reconciling (value, reason) ->
+    Some value.attempt_id, Some value.candidate_checkpoint, Some value.evidence,
+    Some reason, None, None, None
+  | Committed value ->
+    Some value.attempt_id, Some value.candidate_checkpoint, Some value.evidence,
+    None, Some value.candidate_checkpoint, None, None
+  | Adopted_state (value, checkpoint, turn) ->
+    Some value.attempt_id, Some value.candidate_checkpoint, Some value.evidence,
+    None, Some value.candidate_checkpoint, Some checkpoint, Some turn
+;;
+
+let snapshot state =
+  let attempt_id, candidate_checkpoint, evidence, reconciliation_reason,
+      committed_checkpoint, adopted_checkpoint, adopting_turn =
+    projection state.progress
+  in
+  { operation_id = state.operation_id
+  ; keeper_name = state.request.keeper_name
+  ; source_checkpoint = state.request.source_checkpoint
+  ; trigger = state.request.trigger
+  ; cause = state.request.cause
+  ; producer_invocation = state.request.producer_invocation
+  ; phase = phase state
+  ; attempt_id
+  ; candidate_checkpoint
+  ; evidence
+  ; reconciliation_reason
+  ; committed_checkpoint
+  ; adopted_checkpoint
+  ; adopting_turn
+  }
+;;
+
+let same_candidate
+      (expected : Operation.candidate)
+      (actual : Operation.candidate)
+  =
+  if not (Operation.Attempt_id.equal expected.attempt_id actual.attempt_id)
+  then Error Attempt_mismatch
+  else if
+    not
+      (Keeper_checkpoint_ref.equal
+         expected.source_checkpoint
+         actual.source_checkpoint)
+  then Error Source_mismatch
+  else if
+    not
+      (Keeper_checkpoint_ref.equal
+         expected.candidate_checkpoint
+         actual.candidate_checkpoint
+       && expected.evidence = actual.evidence)
+  then Error Candidate_mismatch
+  else Ok ()
+;;
+
+let close_attempt state attempt_id =
+  { state with progress = Pending; closed_attempts = attempt_id :: state.closed_attempts }
+;;
+
+let apply current event =
+  let invalid state = Error (Invalid_transition (Option.map phase state)) in
+  match current, Operation.view event with
+  | None, Operation.Requested request ->
+    Ok
+      { operation_id = Operation.operation_id event
+      ; request
+      ; progress = Pending
+      ; closed_attempts = []
+      }
+  | None, _ | Some _, Operation.Requested _ -> invalid current
+  | Some state, view ->
+    if not (Operation.Operation_id.equal state.operation_id (Operation.operation_id event))
+    then Error Operation_mismatch
+    else
+      match state.progress, view with
+      | Pending, Operation.Attempt_started attempt_id ->
+        if List.exists (Operation.Attempt_id.equal attempt_id) state.closed_attempts
+        then Error Attempt_reused
+        else Ok { state with progress = Running attempt_id }
+      | Running expected, Operation.Candidate_prepared value ->
+        if not (Operation.Attempt_id.equal expected value.attempt_id)
+        then Error Attempt_mismatch
+        else if
+          not
+            (Keeper_checkpoint_ref.equal
+               state.request.source_checkpoint
+               value.source_checkpoint)
+        then Error Source_mismatch
+        else if
+          Keeper_checkpoint_ref.equal
+            value.source_checkpoint
+            value.candidate_checkpoint
+        then Error Candidate_mismatch
+        else Ok { state with progress = Prepared value }
+      | Running expected,
+        Operation.Attempt_failed (actual, Operation.Pre_commit_failure _) ->
+        if Operation.Attempt_id.equal expected actual
+        then Ok (close_attempt state actual)
+        else Error Attempt_mismatch
+      | (Prepared expected | Reconciling (expected, _)),
+        Operation.Attempt_failed
+          ( actual
+          , Operation.Candidate_not_installed { observed_checkpoint; _ } ) ->
+        if not (Operation.Attempt_id.equal expected.attempt_id actual)
+        then Error Attempt_mismatch
+        else if
+          not
+            (Keeper_checkpoint_ref.equal
+               state.request.source_checkpoint
+               observed_checkpoint)
+        then Error Source_mismatch
+        else Ok (close_attempt state actual)
+      | Prepared expected,
+        Operation.Commit_reconciliation_required (actual, reason) ->
+        same_candidate expected actual
+        |> Result.map (fun () ->
+          { state with progress = Reconciling (expected, reason) })
+      | (Prepared expected | Reconciling (expected, _)), Operation.Compacted actual ->
+        same_candidate expected actual
+        |> Result.map (fun () -> { state with progress = Committed expected })
+      | Committed value, Operation.Reinjected (checkpoint, turn) ->
+        let trace =
+          Keeper_id.Trace_id.to_string value.candidate_checkpoint.trace_id
+        in
+        if
+          Keeper_checkpoint_ref.equal value.candidate_checkpoint checkpoint
+          && String.equal trace (Ids.Turn_ref.trace_id turn)
+        then Ok { state with progress = Adopted_state (value, checkpoint, turn) }
+        else Error Reinjection_identity_mismatch
+      | _ -> invalid current
+;;
+
+let fold events =
+  let rec loop state = function
+    | [] ->
+      (match state with
+       | Some value -> Ok value
+       | None -> Error (Invalid_transition None))
+    | event :: rest ->
+      (match apply state event with
+       | Error _ as error -> error
+       | Ok next -> loop (Some next) rest)
+  in
+  loop None events
+;;

--- a/lib/keeper_compaction_operation_reducer/keeper_compaction_operation_reducer.mli
+++ b/lib/keeper_compaction_operation_reducer/keeper_compaction_operation_reducer.mli
@@ -1,0 +1,43 @@
+(** Pure replay reducer for one compaction operation. *)
+
+module Operation = Keeper_compaction_operation
+
+type phase =
+  | Request_pending
+  | Attempt_in_progress
+  | Candidate_pending_commit
+  | Reconciliation_pending
+  | Commit_complete
+  | Adopted
+
+type state
+type snapshot =
+  { operation_id : Operation.Operation_id.t
+  ; keeper_name : Keeper_id.Keeper_name.t
+  ; source_checkpoint : Keeper_checkpoint_ref.t
+  ; trigger : Compaction_trigger.t
+  ; cause : Operation.Cause.t
+  ; producer_invocation : Tool_invocation_ref.t option
+  ; phase : phase
+  ; attempt_id : Operation.Attempt_id.t option
+  ; candidate_checkpoint : Keeper_checkpoint_ref.t option
+  ; evidence : Keeper_compaction_evidence.t option
+  ; reconciliation_reason : Operation.reconciliation_reason option
+  ; committed_checkpoint : Keeper_checkpoint_ref.t option
+  ; adopted_checkpoint : Keeper_checkpoint_ref.t option
+  ; adopting_turn : Ids.Turn_ref.t option
+  }
+
+type transition_error =
+  | Invalid_transition of phase option
+  | Operation_mismatch
+  | Attempt_mismatch
+  | Attempt_reused
+  | Source_mismatch
+  | Candidate_mismatch
+  | Reinjection_identity_mismatch
+
+val phase : state -> phase
+val snapshot : state -> snapshot
+val apply : state option -> Operation.event -> (state, transition_error) result
+val fold : Operation.event list -> (state, transition_error) result

--- a/test/keeper_compaction_operation/test_keeper_compaction_operation.ml
+++ b/test/keeper_compaction_operation/test_keeper_compaction_operation.ml
@@ -1,4 +1,5 @@
 module Operation = Keeper_compaction_operation
+module Reducer = Keeper_compaction_operation_reducer
 
 let ok = function Ok value -> value | Error _ -> Alcotest.fail "fixture rejected"
 let operation_id = ok (Operation.Operation_id.of_string "123e4567-e89b-12d3-a456-426614174000")
@@ -33,6 +34,27 @@ let cause = ok (Operation.Cause.of_string "operator request")
 let producer =
   let request_id = ok (Mcp_transport_protocol.request_id_of_yojson (`String "req-1")) in
   ok (Tool_invocation_ref.external_mcp ~request_id ~session_id:"session-1")
+;;
+
+let request_event () =
+  Operation.requested
+    ~operation_id
+    ~keeper_name
+    ~source_checkpoint:source
+    ~trigger:Compaction_trigger.Manual
+    ~cause
+    ~producer_invocation:(Some producer)
+;;
+
+let attempt_event () = Operation.attempt_started ~operation_id ~attempt_id
+
+let candidate_event () =
+  Operation.candidate_prepared
+    ~operation_id
+    ~attempt_id
+    ~source_checkpoint:source
+    ~candidate_checkpoint:candidate
+    ~evidence
 ;;
 
 let test_requested_view () =
@@ -134,6 +156,92 @@ let test_failure_and_reinjection_views () =
   | _ -> Alcotest.fail "reinjected event changed shape"
 ;;
 
+let test_reducer_happy_path () =
+  let turn = Ids.Turn_ref.make ~trace_id:"trace-a" ~absolute_turn:8 in
+  let state =
+    ok
+      (Reducer.fold
+         [ request_event ()
+         ; attempt_event ()
+         ; candidate_event ()
+         ; Operation.compacted
+             ~operation_id
+             ~attempt_id
+             ~source_checkpoint:source
+             ~committed_checkpoint:candidate
+             ~evidence
+         ; Operation.reinjected
+             ~operation_id
+             ~adopted_checkpoint:candidate
+             ~adopting_turn:turn
+         ])
+  in
+  let snapshot = Reducer.snapshot state in
+  Alcotest.(check bool) "adopted phase" true (snapshot.phase = Reducer.Adopted);
+  Alcotest.(check bool)
+    "adopted exact checkpoint"
+    true
+    (Option.exists
+       (Keeper_checkpoint_ref.equal candidate)
+       snapshot.adopted_checkpoint)
+;;
+
+let test_reducer_confirmed_failure () =
+  let state = ok (Reducer.fold [ request_event (); attempt_event (); candidate_event () ]) in
+  let wrong =
+    Operation.attempt_failed
+      ~operation_id
+      ~attempt_id
+      ~failure:
+        (Operation.Candidate_not_installed
+           { cause; observed_checkpoint = candidate })
+  in
+  (match Reducer.apply (Some state) wrong with
+   | Error Reducer.Source_mismatch -> ()
+   | Ok _ | Error _ -> Alcotest.fail "third checkpoint was treated as not-installed");
+  let confirmed =
+    Operation.attempt_failed
+      ~operation_id
+      ~attempt_id
+      ~failure:
+        (Operation.Candidate_not_installed
+           { cause; observed_checkpoint = source })
+  in
+  let state = ok (Reducer.apply (Some state) confirmed) in
+  Alcotest.(check bool)
+    "confirmed non-install returns pending"
+    true
+    (Reducer.phase state = Reducer.Request_pending);
+  match Reducer.apply (Some state) (attempt_event ()) with
+  | Error Reducer.Attempt_reused -> ()
+  | Ok _ | Error _ -> Alcotest.fail "closed attempt id was reused"
+;;
+
+let test_reducer_reconciliation () =
+  let state = ok (Reducer.fold [ request_event (); attempt_event (); candidate_event () ]) in
+  let event =
+    Operation.commit_reconciliation_required
+      ~operation_id
+      ~attempt_id
+      ~source_checkpoint:source
+      ~candidate_checkpoint:candidate
+      ~evidence
+      ~reason:Operation.Commit_durability_unknown
+  in
+  let state = ok (Reducer.apply (Some state) event) in
+  let snapshot = Reducer.snapshot state in
+  Alcotest.(check bool)
+    "unknown outcome remains reconciliation"
+    true
+    (snapshot.reconciliation_reason = Some Operation.Commit_durability_unknown)
+;;
+
+let test_reducer_invalid_transition () =
+  match Reducer.fold [ request_event (); candidate_event () ] with
+  | Error (Reducer.Invalid_transition (Some Reducer.Request_pending)) -> ()
+  | Ok _ | Error _ -> Alcotest.fail "candidate without attempt was accepted"
+;;
+
 let () =
   Alcotest.run
     "keeper compaction operation events"
@@ -144,5 +252,18 @@ let () =
             "failure and reinjection typed views"
             `Quick
             test_failure_and_reinjection_views
+        ; Alcotest.test_case "reducer happy path" `Quick test_reducer_happy_path
+        ; Alcotest.test_case
+            "reducer confirmed failure"
+            `Quick
+            test_reducer_confirmed_failure
+        ; Alcotest.test_case
+            "reducer reconciliation"
+            `Quick
+            test_reducer_reconciliation
+        ; Alcotest.test_case
+            "reducer invalid transition"
+            `Quick
+            test_reducer_invalid_transition
         ] )
     ]


### PR DESCRIPTION
## What changed

- adds a pure immutable reducer for one compaction operation
- rejects impossible, duplicate, cross-operation, reused-attempt, source, candidate, and reinjection transitions
- permits Candidate_not_installed only after the canonical source checkpoint is observed
- keeps durability or transaction uncertainty in a distinct reconciliation phase
- exposes a typed snapshot containing the complete request, current attempt and candidate evidence, reconciliation reason, committed checkpoint, and adoption facts

## Why

Recovery and workers need one deterministic replay contract before any durable writer is activated. Attempt failure must never be used as a fallback label for an unknown checkpoint commit outcome.

Keeper absolute turn ids and OAS checkpoint turn_count are different counter domains, so reinjection proves exact committed checkpoint equality and trace identity without comparing those numbers.

## Validation

- scripts/dune-local.sh build test/keeper_compaction_operation/test_keeper_compaction_operation.exe
- scripts/dune-local.sh exec test/keeper_compaction_operation/test_keeper_compaction_operation.exe
- ocamlformat --check on all changed OCaml files
- 393 inserted lines
- 7 focused tests green