### PR TITLE
refactor(keeper)!: require running wake targets

### DIFF
--- a/lib/keeper/keeper_goal_assignment_wake.ml
+++ b/lib/keeper/keeper_goal_assignment_wake.ml
@@ -40,7 +40,7 @@ let enqueue_goal_assigned_wakes
         keeper_name
         stimulus;
       match
-        Keeper_registry.wakeup
+        Keeper_registry.wakeup_running
           ~intent:Keeper_registry.Goal_signal
           ~base_path:config.base_path
           keeper_name

--- a/lib/keeper/keeper_goal_assignment_wake.ml
+++ b/lib/keeper/keeper_goal_assignment_wake.ml
@@ -39,26 +39,31 @@ let enqueue_goal_assigned_wakes
         ~base_path:config.base_path
         keeper_name
         stimulus;
-      match Keeper_registry.get ~base_path:config.base_path keeper_name with
-      | Some entry when entry.phase = Keeper_state_machine.Running ->
-        let (_ : Keeper_registry.wakeup_outcome) =
-          Keeper_registry.wakeup
-            ~intent:Keeper_registry.Goal_signal
-            ~base_path:config.base_path
-            keeper_name
-        in
-        ()
-      | Some entry ->
-        Log.Keeper.info
-          "goal assignment wake queued without fiber wake keeper=%s phase=%s \
-           goal_id=%s"
+      match
+        Keeper_registry.wakeup
+          ~intent:Keeper_registry.Goal_signal
+          ~base_path:config.base_path
           keeper_name
-          (Keeper_state_machine.phase_to_string entry.phase)
-          goal_id
-      | None ->
+      with
+      | Keeper_registry.Signaled -> ()
+      | Keeper_registry.Deferred_unregistered ->
         Log.Keeper.info
           "goal assignment wake persisted for unregistered keeper=%s goal_id=%s"
           keeper_name
+          goal_id
+      | Keeper_registry.Deferred_not_running phase ->
+        Log.Keeper.info
+          "goal assignment wake deferred by registry phase contract keeper=%s \
+           phase=%s goal_id=%s"
+          keeper_name
+          (Keeper_state_machine.phase_to_string phase)
+          goal_id
+      | Keeper_registry.Deferred_lifecycle denial ->
+        Log.Keeper.info
+          "goal assignment wake deferred by lifecycle keeper=%s reason=%s \
+           goal_id=%s"
+          keeper_name
+          (Keeper_lifecycle_admission.autonomous_denial_to_wire denial)
           goal_id)
     added;
   added

--- a/lib/keeper/keeper_goal_assignment_wake.mli
+++ b/lib/keeper/keeper_goal_assignment_wake.mli
@@ -1,8 +1,7 @@
 (** Keeper_goal_assignment_wake — RFC-0315 P3 W0 producer.
 
     Enqueues a [Keeper_event_queue.Goal_assigned] stimulus for each goal that
-    newly entered a keeper's [active_goal_ids], then signals every registered
-    lifecycle-admitted keeper.
+    newly entered a keeper's [active_goal_ids], then signals its Running lane.
 
     Edge semantics: callers pass the pre-change and post-change id lists;
     only ids present in [new_ids] and absent from [old_ids] enqueue.
@@ -23,6 +22,6 @@ val enqueue_goal_assigned_wakes :
 (** Enqueue one [Goal_assigned] stimulus per added goal (title resolved from
     Goal_store at enqueue time; a goal deleted between validation and
     enqueue falls back to its id as the label). The durable queue append
-    precedes the lifecycle-admitted wake hint; paused and dead-tombstone lanes
-    retain the queued entry without receiving the hint. Returns the added goal
-    ids. *)
+    precedes the Running-lane wake hint; inactive, paused, and dead-tombstone
+    lanes retain the queued entry without receiving the hint. Returns the added
+    goal ids. *)

--- a/lib/keeper/keeper_goal_assignment_wake.mli
+++ b/lib/keeper/keeper_goal_assignment_wake.mli
@@ -1,8 +1,8 @@
 (** Keeper_goal_assignment_wake — RFC-0315 P3 W0 producer.
 
     Enqueues a [Keeper_event_queue.Goal_assigned] stimulus for each goal that
-    newly entered a keeper's [active_goal_ids], and wakes the keeper fiber
-    when it is running.
+    newly entered a keeper's [active_goal_ids], then signals every registered
+    lifecycle-admitted keeper.
 
     Edge semantics: callers pass the pre-change and post-change id lists;
     only ids present in [new_ids] and absent from [old_ids] enqueue.
@@ -22,6 +22,7 @@ val enqueue_goal_assigned_wakes :
   string list
 (** Enqueue one [Goal_assigned] stimulus per added goal (title resolved from
     Goal_store at enqueue time; a goal deleted between validation and
-    enqueue falls back to its id as the label). Wakes the keeper fiber only
-    when its registry phase is [Running]; otherwise the durable queue entry
-    delivers on the next cycle. Returns the added goal ids. *)
+    enqueue falls back to its id as the label). The durable queue append
+    precedes the lifecycle-admitted wake hint; paused and dead-tombstone lanes
+    retain the queued entry without receiving the hint. Returns the added goal
+    ids. *)

--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -258,7 +258,7 @@ let interruptible_sleep ~clock ~stop ~wakeup duration : sleep_outcome =
     Event Layer queue ([Keeper_registry_event_queue.enqueue]) before the wakeup
     flag flips. This is RFC-0020 Rule 1 (enqueue is independent of policy)
     + the data-channel half of the layer split — [fiber_wakeup] remains the
-    lifecycle-admitted hint signal, the queue is the authoritative payload. *)
+    Running-lane hint signal, the queue is the authoritative payload. *)
 let wakeup_keeper ?base_path ?stimulus name =
   let entries =
     Keeper_registry.all ?base_path ()
@@ -267,8 +267,8 @@ let wakeup_keeper ?base_path ?stimulus name =
   in
   (* Payload admission is independent of current lifecycle phase. A completion
      that arrives while the keeper is paused/restarting must remain durable for
-     the lane's next admitted turn; the wake hint delegates only to the typed
-     lifecycle admission contract. *)
+     the lane's next admitted turn; the wake hint delegates to the typed
+     Running-lane and lifecycle admission contract. *)
   (match entries, stimulus, base_path with
    | [], Some value, Some resolved_base_path ->
      Keeper_registry_event_queue.enqueue
@@ -294,7 +294,7 @@ let wakeup_keeper ?base_path ?stimulus name =
               value)
          stimulus;
        match
-         Keeper_registry.wakeup
+         Keeper_registry.wakeup_running
            ~intent:Keeper_registry.Reactive_signal
            ~base_path:entry.base_path
            name
@@ -535,7 +535,7 @@ let wakeup_relevant_keeper_for_board_signal
                     signal.post_id
                 else (
                   let outcome =
-                    Keeper_registry.wakeup
+                    Keeper_registry.wakeup_running
                       ~intent:Keeper_registry.Reactive_signal
                       ~base_path:config.base_path
                       meta.name

--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -258,7 +258,7 @@ let interruptible_sleep ~clock ~stop ~wakeup duration : sleep_outcome =
     Event Layer queue ([Keeper_registry_event_queue.enqueue]) before the wakeup
     flag flips. This is RFC-0020 Rule 1 (enqueue is independent of policy)
     + the data-channel half of the layer split — [fiber_wakeup] remains the
-    hint signal, the queue is the authoritative payload. *)
+    lifecycle-admitted hint signal, the queue is the authoritative payload. *)
 let wakeup_keeper ?base_path ?stimulus name =
   let entries =
     Keeper_registry.all ?base_path ()
@@ -267,7 +267,8 @@ let wakeup_keeper ?base_path ?stimulus name =
   in
   (* Payload admission is independent of current lifecycle phase. A completion
      that arrives while the keeper is paused/restarting must remain durable for
-     the lane's next admitted turn; only the wake hint is phase-gated. *)
+     the lane's next admitted turn; the wake hint delegates only to the typed
+     lifecycle admission contract. *)
   (match entries, stimulus, base_path with
    | [], Some value, Some resolved_base_path ->
      Keeper_registry_event_queue.enqueue
@@ -292,34 +293,24 @@ let wakeup_keeper ?base_path ?stimulus name =
               name
               value)
          stimulus;
-       if entry.phase = Keeper_state_machine.Running
-       then (
-         match
-           Keeper_registry.wakeup
-             ~intent:Keeper_registry.Reactive_signal
-             ~base_path:entry.base_path
-             name
-         with
-         | Keeper_registry.Signaled -> ()
-         | Keeper_registry.Deferred_unregistered ->
-           Log.Keeper.info ~keeper_name:name
-             "wakeup_keeper: wake deferred after registry removal"
-         | Keeper_registry.Deferred_not_running phase ->
-           Log.Keeper.info ~keeper_name:name
-             "wakeup_keeper: wake deferred after phase change phase=%s"
-             (Keeper_state_machine.phase_to_string phase)
-         | Keeper_registry.Deferred_lifecycle denial ->
-           Log.Keeper.info ~keeper_name:name
-             "wakeup_keeper: wake deferred by lifecycle reason=%s"
-             (Keeper_lifecycle_admission.autonomous_denial_to_wire denial))
-       else
+       match
+         Keeper_registry.wakeup
+           ~intent:Keeper_registry.Reactive_signal
+           ~base_path:entry.base_path
+           name
+       with
+       | Keeper_registry.Signaled -> ()
+       | Keeper_registry.Deferred_unregistered ->
          Log.Keeper.info ~keeper_name:name
-           "wakeup_keeper: stimulus queued; wake hint withheld phase=%s stimulus=%s"
-           (Keeper_state_machine.phase_to_string entry.phase)
-           (match stimulus with
-            | None -> "none"
-            | Some value ->
-              Keeper_event_queue.payload_kind_label value.Keeper_event_queue.payload))
+           "wakeup_keeper: wake deferred after registry removal"
+       | Keeper_registry.Deferred_not_running phase ->
+         Log.Keeper.info ~keeper_name:name
+           "wakeup_keeper: wake deferred by registry phase contract phase=%s"
+           (Keeper_state_machine.phase_to_string phase)
+       | Keeper_registry.Deferred_lifecycle denial ->
+         Log.Keeper.info ~keeper_name:name
+           "wakeup_keeper: wake deferred by lifecycle reason=%s"
+           (Keeper_lifecycle_admission.autonomous_denial_to_wire denial))
     entries
 ;;
 

--- a/lib/keeper/keeper_keepalive_signal.mli
+++ b/lib/keeper/keeper_keepalive_signal.mli
@@ -115,11 +115,11 @@ val interruptible_sleep :
 
     When [?stimulus] is given, the stimulus is durably appended to the keeper's
     Event Layer queue ([Keeper_registry_event_queue.enqueue]) independently of
-    lifecycle phase. The wake hint is sent to every lifecycle-admitted
-    registered Keeper; paused and dead-tombstone lanes remain denied by
-    [Keeper_registry.wakeup]. If no live registry entry exists, callers must
-    supply [base_path] so the payload can be persisted for replay. Callers that
-    only need to break the keeper out of [interruptible_sleep] may omit the
+    lifecycle phase. The wake hint is sent only to a lifecycle-admitted Running
+    Keeper; inactive, paused, and dead-tombstone lanes retain the durable event
+    without a false delivery claim. If no live registry entry exists, callers
+    must supply [base_path] so the payload can be persisted for replay. Callers
+    that only need to break the keeper out of [interruptible_sleep] may omit the
     stimulus. See RFC-0020 §3 (data channel vs hint signal). *)
 val wakeup_keeper :
   ?base_path:string ->

--- a/lib/keeper/keeper_keepalive_signal.mli
+++ b/lib/keeper/keeper_keepalive_signal.mli
@@ -115,11 +115,12 @@ val interruptible_sleep :
 
     When [?stimulus] is given, the stimulus is durably appended to the keeper's
     Event Layer queue ([Keeper_registry_event_queue.enqueue]) independently of
-    lifecycle phase. Only the wake hint is restricted to [Running]. If no live
-    registry entry exists, callers must supply [base_path] so the payload can
-    be persisted for replay. Callers that only need to break the keeper out of
-    [interruptible_sleep] may omit the stimulus. See RFC-0020 §3 (data channel
-    vs hint signal). *)
+    lifecycle phase. The wake hint is sent to every lifecycle-admitted
+    registered Keeper; paused and dead-tombstone lanes remain denied by
+    [Keeper_registry.wakeup]. If no live registry entry exists, callers must
+    supply [base_path] so the payload can be persisted for replay. Callers that
+    only need to break the keeper out of [interruptible_sleep] may omit the
+    stimulus. See RFC-0020 §3 (data channel vs hint signal). *)
 val wakeup_keeper :
   ?base_path:string ->
   ?stimulus:Keeper_event_queue.stimulus ->

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -415,7 +415,7 @@ let record_lifecycle_wakeup_denial ~intent (entry : registry_entry) denial =
     reason
 ;;
 
-let wakeup_entry ~intent ~require_running (entry : registry_entry) =
+let wakeup_running_entry ~intent (entry : registry_entry) =
   let lifecycle_state =
     Keeper_lifecycle_admission.state
       ~paused:entry.meta.paused
@@ -426,7 +426,7 @@ let wakeup_entry ~intent ~require_running (entry : registry_entry) =
     record_lifecycle_wakeup_denial ~intent entry denial;
     Deferred_lifecycle denial
   | Keeper_lifecycle_admission.Autonomous_admitted ->
-    if require_running && entry.phase <> Keeper_state_machine.Running
+    if entry.phase <> Keeper_state_machine.Running
     then Deferred_not_running entry.phase
     else (
       (* tla-lint: allow-mutation: lifecycle-admitted fiber hint signal *)
@@ -434,16 +434,10 @@ let wakeup_entry ~intent ~require_running (entry : registry_entry) =
       Signaled)
 ;;
 
-let wakeup ~intent ~base_path name =
-  match StringMap.find_opt (registry_key ~base_path name) (Atomic.get registry) with
-  | None -> Deferred_unregistered
-  | Some entry -> wakeup_entry ~intent ~require_running:false entry
-;;
-
 let wakeup_running ~intent ~base_path name =
   match StringMap.find_opt (registry_key ~base_path name) (Atomic.get registry) with
   | None -> Deferred_unregistered
-  | Some entry -> wakeup_entry ~intent ~require_running:true entry
+  | Some entry -> wakeup_running_entry ~intent entry
 ;;
 
 let wakeup_all ~intent ?base_path () =
@@ -456,7 +450,7 @@ let wakeup_all ~intent ?base_path () =
          if entry.phase = Running
          then
            let (_ : wakeup_outcome) =
-             wakeup_entry ~intent ~require_running:true entry
+             wakeup_running_entry ~intent entry
            in
            ())
     (Atomic.get registry)

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -458,13 +458,6 @@ type wakeup_outcome =
   | Deferred_not_running of Keeper_state_machine.phase
   | Deferred_lifecycle of Keeper_lifecycle_admission.autonomous_denial
 
-(** Signal a registered keeper without requiring a Running phase. Lifecycle
-    admission is still mandatory: paused and dead-tombstone lanes are never
-    made runnable by a hint signal. The typed intent is observability data,
-    not a policy bypass. *)
-val wakeup :
-  intent:wakeup_intent -> base_path:string -> string -> wakeup_outcome
-
 val wakeup_running :
   intent:wakeup_intent -> base_path:string -> string -> wakeup_outcome
 (** Signal a registered Keeper only while its fiber phase is [Running]. The

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -471,7 +471,7 @@ let resolve_primary_max_context (meta : Keeper_meta_contract.keeper_meta option)
 
 let manual_compaction_wakeup_observation ~base_path keeper_name =
   match
-    Keeper_registry.wakeup
+    Keeper_registry.wakeup_running
       ~intent:Keeper_registry.Compaction_signal
       ~base_path
       keeper_name

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -683,7 +683,7 @@ let handle_ambient ?resolved_keeper_name ~base_dir
           | Keeper_registry_event_queue.Stimulus_enqueued
           | Keeper_registry_event_queue.Stimulus_already_present ->
             (match
-               Keeper_registry.wakeup
+               Keeper_registry.wakeup_running
                  ~intent:Keeper_registry.Reactive_signal
                  ~base_path:base_dir
                  keeper_name

--- a/lib/server/server_schedule_consumers.ml
+++ b/lib/server/server_schedule_consumers.ml
@@ -359,7 +359,7 @@ let dispatch_keeper_wake
    | Already_drained -> ()
    | Wake_required ->
      let wakeup_outcome =
-       Keeper_registry.wakeup
+       Keeper_registry.wakeup_running
          ~intent:Keeper_registry.Scheduled_signal
          ~base_path
          keeper_name

--- a/test/test_keeper_registry_hardening.ml
+++ b/test/test_keeper_registry_hardening.ml
@@ -251,33 +251,12 @@ let test_wakeup_running_reports_typed_outcome () =
      fail "offline keeper did not return Deferred_not_running")
 ;;
 
-let test_wakeup_signals_lifecycle_admitted_offline_keeper () =
-  KR.clear ();
-  let meta = make_meta "offline-wakeup" in
-  let entry = KR.register_offline ~base_path meta.name meta in
-  Atomic.set entry.fiber_wakeup false;
-  (match KR.wakeup ~intent:KR.Scheduled_signal ~base_path meta.name with
-   | KR.Signaled -> ()
-   | KR.Deferred_unregistered
-   | KR.Deferred_not_running _
-   | KR.Deferred_lifecycle _ ->
-     fail "lifecycle-admitted offline keeper was not signaled");
-  check bool "offline keeper wake flag is set" true (Atomic.get entry.fiber_wakeup);
-  Atomic.set entry.fiber_wakeup false;
-  (match KR.wakeup_running ~intent:KR.Scheduled_signal ~base_path meta.name with
-   | KR.Deferred_not_running phase ->
-     check string "running-only deferred phase" "offline" (KSM.phase_to_string phase)
-   | KR.Signaled | KR.Deferred_unregistered | KR.Deferred_lifecycle _ ->
-     fail "running-only wake did not defer the offline keeper");
-  check bool "running-only wake leaves flag false" false (Atomic.get entry.fiber_wakeup)
-;;
-
 let test_wakeup_denies_paused_and_dead_without_signaling () =
   KR.clear ();
   let paused_meta = { (make_meta "paused-wakeup") with paused = true } in
   let paused_entry = KR.register ~base_path paused_meta.name paused_meta in
   Atomic.set paused_entry.fiber_wakeup false;
-  (match KR.wakeup ~intent:KR.Scheduled_signal ~base_path paused_meta.name with
+  (match KR.wakeup_running ~intent:KR.Scheduled_signal ~base_path paused_meta.name with
    | KR.Deferred_lifecycle (Keeper_lifecycle_admission.Autonomous_paused _) -> ()
    | KR.Signaled
    | KR.Deferred_unregistered
@@ -293,7 +272,7 @@ let test_wakeup_denies_paused_and_dead_without_signaling () =
   in
   let entry = KR.register ~base_path meta.name meta in
   Atomic.set entry.fiber_wakeup false;
-  (match KR.wakeup ~intent:KR.Scheduled_signal ~base_path meta.name with
+  (match KR.wakeup_running ~intent:KR.Scheduled_signal ~base_path meta.name with
    | KR.Deferred_lifecycle
        Keeper_lifecycle_admission.Autonomous_dead_tombstone -> ()
    | KR.Signaled
@@ -322,10 +301,12 @@ let cleanup_dir path =
         Unix.rmdir target)
       else Unix.unlink target
   in
-  try rm path with _ -> ()
+  match rm path with
+  | () -> ()
+  | exception Unix.Unix_error (Unix.ENOENT, _, _) -> ()
 ;;
 
-let test_reactive_wakeup_signals_offline_lane_after_queue_commit () =
+let test_reactive_wakeup_defers_offline_lane_after_queue_commit () =
   let dir = temp_dir "registry_reactive_offline_wakeup" in
   Fun.protect
     ~finally:(fun () ->
@@ -349,7 +330,7 @@ let test_reactive_wakeup_signals_offline_lane_after_queue_commit () =
          ~base_path:dir
          ~stimulus
          meta.name;
-       check bool "offline reactive wake flag is set" true
+       check bool "offline reactive wake flag remains clear" false
          (Atomic.get entry.fiber_wakeup);
        match
          Masc.Keeper_registry_event_queue.snapshot ~base_path:dir meta.name
@@ -360,7 +341,7 @@ let test_reactive_wakeup_signals_offline_lane_after_queue_commit () =
        | _ -> fail "reactive stimulus was not retained in the offline lane")
 ;;
 
-let test_goal_assignment_signals_offline_lane_after_queue_commit () =
+let test_goal_assignment_defers_offline_lane_after_queue_commit () =
   let dir = temp_dir "registry_goal_offline_wakeup" in
   Fun.protect
     ~finally:(fun () ->
@@ -386,7 +367,7 @@ let test_goal_assignment_signals_offline_lane_after_queue_commit () =
            ()
        in
        check (list string) "new goal is reported" [ "goal-offline-1" ] added;
-       check bool "offline goal wake flag is set" true
+       check bool "offline goal wake flag remains clear" false
          (Atomic.get entry.fiber_wakeup);
        match
          Masc.Keeper_registry_event_queue.snapshot
@@ -560,23 +541,19 @@ let () =
             `Quick
             test_wakeup_running_reports_typed_outcome
         ; test_case
-            "signals lifecycle-admitted offline keeper"
-            `Quick
-            test_wakeup_signals_lifecycle_admitted_offline_keeper
-        ; test_case
             "paused and dead keepers never receive runnable signal"
             `Quick
             test_wakeup_denies_paused_and_dead_without_signaling
         ] )
     ; ( "wakeup_callers"
       , [ test_case
-            "reactive stimulus wakes lifecycle-admitted offline lane"
+            "reactive stimulus persists while offline wake is deferred"
             `Quick
-            test_reactive_wakeup_signals_offline_lane_after_queue_commit
+            test_reactive_wakeup_defers_offline_lane_after_queue_commit
         ; test_case
-            "goal assignment wakes lifecycle-admitted offline lane"
+            "goal assignment persists while offline wake is deferred"
             `Quick
-            test_goal_assignment_signals_offline_lane_after_queue_commit
+            test_goal_assignment_defers_offline_lane_after_queue_commit
         ] )
     ; ( "tool_dispatch_exact_resources"
       , [ test_case "preserves exact meta after healthy entry replacement" `Quick

--- a/test/test_keeper_registry_hardening.ml
+++ b/test/test_keeper_registry_hardening.ml
@@ -325,6 +325,81 @@ let cleanup_dir path =
   try rm path with _ -> ()
 ;;
 
+let test_reactive_wakeup_signals_offline_lane_after_queue_commit () =
+  let dir = temp_dir "registry_reactive_offline_wakeup" in
+  Fun.protect
+    ~finally:(fun () ->
+      KR.clear ();
+      cleanup_dir dir)
+    (fun () ->
+       Eio_main.run @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       KR.clear ();
+       let meta = make_meta "reactive-offline" in
+       let entry = KR.register_offline ~base_path:dir meta.name meta in
+       let stimulus : Keeper_event_queue.stimulus =
+         { post_id = "reactive-offline-stimulus"
+         ; urgency = Keeper_event_queue.Normal
+         ; arrived_at = 1.0
+         ; payload = Keeper_event_queue.Bootstrap
+         }
+       in
+       Atomic.set entry.fiber_wakeup false;
+       Masc.Keeper_keepalive_signal.wakeup_keeper
+         ~base_path:dir
+         ~stimulus
+         meta.name;
+       check bool "offline reactive wake flag is set" true
+         (Atomic.get entry.fiber_wakeup);
+       match
+         Masc.Keeper_registry_event_queue.snapshot ~base_path:dir meta.name
+         |> Keeper_event_queue.to_list
+       with
+       | [ { post_id; payload = Keeper_event_queue.Bootstrap; _ } ] ->
+         check string "reactive stimulus remains queued" stimulus.post_id post_id
+       | _ -> fail "reactive stimulus was not retained in the offline lane")
+;;
+
+let test_goal_assignment_signals_offline_lane_after_queue_commit () =
+  let dir = temp_dir "registry_goal_offline_wakeup" in
+  Fun.protect
+    ~finally:(fun () ->
+      KR.clear ();
+      cleanup_dir dir)
+    (fun () ->
+       Eio_main.run @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       KR.clear ();
+       let config = Masc.Workspace.default_config dir in
+       let meta = make_meta "goal-offline" in
+       let entry =
+         KR.register_offline ~base_path:config.base_path meta.name meta
+       in
+       Atomic.set entry.fiber_wakeup false;
+       let added =
+         Masc.Keeper_goal_assignment_wake.enqueue_goal_assigned_wakes
+           ~config
+           ~keeper_name:meta.name
+           ~assigned_by:"test"
+           ~old_ids:[]
+           ~new_ids:[ "goal-offline-1" ]
+           ()
+       in
+       check (list string) "new goal is reported" [ "goal-offline-1" ] added;
+       check bool "offline goal wake flag is set" true
+         (Atomic.get entry.fiber_wakeup);
+       match
+         Masc.Keeper_registry_event_queue.snapshot
+           ~base_path:config.base_path
+           meta.name
+         |> Keeper_event_queue.to_list
+       with
+       | [ { payload = Keeper_event_queue.Goal_assigned assignment; _ } ] ->
+         check string "queued goal id" "goal-offline-1" assignment.ga_goal_id;
+         check string "queued assignment actor" "test" assignment.ga_assigned_by
+       | _ -> fail "goal assignment was not retained in the offline lane")
+;;
+
 let contains_substring text needle =
   let text_len = String.length text in
   let needle_len = String.length needle in
@@ -492,6 +567,16 @@ let () =
             "paused and dead keepers never receive runnable signal"
             `Quick
             test_wakeup_denies_paused_and_dead_without_signaling
+        ] )
+    ; ( "wakeup_callers"
+      , [ test_case
+            "reactive stimulus wakes lifecycle-admitted offline lane"
+            `Quick
+            test_reactive_wakeup_signals_offline_lane_after_queue_commit
+        ; test_case
+            "goal assignment wakes lifecycle-admitted offline lane"
+            `Quick
+            test_goal_assignment_signals_offline_lane_after_queue_commit
         ] )
     ; ( "tool_dispatch_exact_resources"
       , [ test_case "preserves exact meta after healthy entry replacement" `Quick


### PR DESCRIPTION
## Summary

- restack only the unique caller change on current `main`; the already-squashed #24913 parent commit is gone
- delete the phase-independent `Keeper_registry.wakeup` API
- route reactive, goal, schedule, Discord, board, and manual-compaction durable producers through the single typed `wakeup_running` boundary
- preserve durable queue acceptance before every best-effort live-fiber hint
- remove the dormant `require_running` boolean policy switch from the registry helper

## Why

`prepare_fiber_launch` clears `fiber_wakeup` before starting a lane. Setting that flag for Offline/Starting/Stopped entries therefore cannot truthfully mean delivery and may be erased before any fiber observes it. A durable payload and a live-fiber wake hint are separate facts.

## Invariants

- `Signaled` means a lifecycle-admitted registry entry was exactly in `Running` and its live hint flag was set
- inactive/unregistered/lifecycle-denied targets return typed deferred outcomes; no false success
- payload persistence remains phase-independent and precedes the hint
- no timeout, retry heuristic, phase string match, or OAS dependency is added
- no compatibility alias remains for non-running wake hints

## Verification

- no `Keeper_registry.wakeup`, `KR.wakeup`, public `val wakeup`, or `require_running` residue remains
- `ocamlformat --check` passed for all 10 touched OCaml files
- `ocamlc -stop-after parsing` passed for all 10 touched OCaml files
- `git diff --check` passed
- focused wrapper build was attempted and correctly refused with exit 75 because two live bare Dune processes bypassed the machine-wide lock; no bypass was used
- full PR CI is authoritative

## Tests

The existing focused registry suite now asserts that reactive and goal stimuli remain durable while an Offline wake is explicitly deferred and the hint flag remains clear. The old test that required a false Offline `Signaled` outcome is removed.