### PR TITLE
feat(keeper): project compaction operation JSON

### DIFF
--- a/lib/keeper_compaction_operation_json/dune
+++ b/lib/keeper_compaction_operation_json/dune
@@ -1,15 +1,16 @@
-(test
- (name test_keeper_compaction_operation)
+(include_subdirs no)
+
+(library
+ (name masc_keeper_compaction_operation_json)
+ (public_name masc.keeper_compaction_operation_json)
+ (wrapped false)
+ (modules keeper_compaction_operation_json)
  (libraries
-  alcotest
   masc.compaction_trigger
   masc.keeper_checkpoint_ref
   masc.keeper_compaction_evidence
   masc.keeper_compaction_operation
-  masc.keeper_compaction_operation_json
-  masc.keeper_compaction_operation_reducer
   masc.keeper_registry
   masc.masc_types
-  masc.mcp_transport_protocol
   masc.tool_invocation_ref
   yojson))

--- a/lib/keeper_compaction_operation_json/keeper_compaction_operation_json.ml
+++ b/lib/keeper_compaction_operation_json/keeper_compaction_operation_json.ml
@@ -1,0 +1,102 @@
+module Operation = Keeper_compaction_operation
+open Operation
+
+let checkpoint (checkpoint : Keeper_checkpoint_ref.t) =
+  `Assoc
+    [ "trace_id", `String (Keeper_id.Trace_id.to_string checkpoint.trace_id)
+    ; "generation", `Int checkpoint.generation
+    ; "turn_count", `Int checkpoint.turn_count
+    ; "sha256", `String checkpoint.sha256
+    ]
+;;
+
+let evidence evidence =
+  `Assoc
+    [ ( "selected_runtime_id"
+      , match evidence.Keeper_compaction_evidence.selected_runtime_id with
+        | Some value -> `String value
+        | None -> `Null )
+    ; "counts", Keeper_compaction_evidence.to_json evidence
+    ]
+;;
+
+let candidate ~checkpoint_field (candidate : Operation.candidate) =
+  [ "attempt_id", `String (Operation.Attempt_id.to_string candidate.attempt_id)
+  ; "source_checkpoint", checkpoint candidate.source_checkpoint
+  ; checkpoint_field, checkpoint candidate.candidate_checkpoint
+  ; "evidence", evidence candidate.evidence
+  ]
+;;
+
+let envelope event kind payload =
+  `Assoc
+    [ "kind", `String kind
+    ; "operation_id", `String (Operation.Operation_id.to_string (Operation.operation_id event))
+    ; "payload", `Assoc payload
+    ]
+;;
+
+let to_json event =
+  match Operation.view event with
+  | Requested request ->
+    envelope
+      event
+      "requested"
+      [ "keeper_name", `String (Keeper_id.Keeper_name.to_string request.keeper_name)
+      ; "source_checkpoint", checkpoint request.source_checkpoint
+      ; "trigger", Compaction_trigger.to_detail_json request.trigger
+      ; "cause", `String (Operation.Cause.to_string request.cause)
+      ; ( "producer_invocation"
+        , match request.producer_invocation with
+          | Some producer -> Tool_invocation_ref.to_yojson producer
+          | None -> `Null )
+      ]
+  | Attempt_started attempt_id ->
+    envelope
+      event
+      "attempt_started"
+      [ "attempt_id", `String (Operation.Attempt_id.to_string attempt_id) ]
+  | Candidate_prepared value ->
+    envelope
+      event
+      "candidate_prepared"
+      (candidate ~checkpoint_field:"candidate_checkpoint" value)
+  | Attempt_failed (attempt_id, failure) ->
+    let failure_kind, cause, observed_checkpoint =
+      match failure with
+      | Pre_commit_failure cause -> "pre_commit", cause, `Null
+      | Candidate_not_installed { cause; observed_checkpoint } ->
+        "candidate_not_installed", cause, checkpoint observed_checkpoint
+    in
+    envelope
+      event
+      "attempt_failed"
+      [ "attempt_id", `String (Operation.Attempt_id.to_string attempt_id)
+      ; "failure_kind", `String failure_kind
+      ; "cause", `String (Operation.Cause.to_string cause)
+      ; "observed_checkpoint", observed_checkpoint
+      ]
+  | Commit_reconciliation_required (value, reason) ->
+    let reason =
+      match reason with
+      | Commit_durability_unknown -> "commit_durability_unknown"
+      | Transaction_outcome_unknown -> "transaction_outcome_unknown"
+    in
+    envelope
+      event
+      "commit_reconciliation_required"
+      (candidate ~checkpoint_field:"candidate_checkpoint" value
+       @ [ "reason", `String reason ])
+  | Compacted value ->
+    envelope
+      event
+      "compacted"
+      (candidate ~checkpoint_field:"committed_checkpoint" value)
+  | Reinjected (adopted_checkpoint, adopting_turn) ->
+    envelope
+      event
+      "reinjected"
+      [ "adopted_checkpoint", checkpoint adopted_checkpoint
+      ; "adopting_turn", Ids.Turn_ref.to_yojson adopting_turn
+      ]
+;;

--- a/lib/keeper_compaction_operation_json/keeper_compaction_operation_json.mli
+++ b/lib/keeper_compaction_operation_json/keeper_compaction_operation_json.mli
@@ -1,0 +1,3 @@
+(** Canonical JSON projection of typed compaction operation facts. *)
+
+val to_json : Keeper_compaction_operation.event -> Yojson.Safe.t

--- a/test/keeper_compaction_operation/test_keeper_compaction_operation.ml
+++ b/test/keeper_compaction_operation/test_keeper_compaction_operation.ml
@@ -1,4 +1,5 @@
 module Operation = Keeper_compaction_operation
+module Operation_json = Keeper_compaction_operation_json
 module Reducer = Keeper_compaction_operation_reducer
 
 let ok = function Ok value -> value | Error _ -> Alcotest.fail "fixture rejected"
@@ -242,6 +243,72 @@ let test_reducer_invalid_transition () =
   | Ok _ | Error _ -> Alcotest.fail "candidate without attempt was accepted"
 ;;
 
+let test_canonical_json_projection () =
+  let turn = Ids.Turn_ref.make ~trace_id:"trace-a" ~absolute_turn:8 in
+  let events =
+    [ request_event ()
+    ; attempt_event ()
+    ; candidate_event ()
+    ; Operation.attempt_failed
+        ~operation_id
+        ~attempt_id
+        ~failure:(Operation.Pre_commit_failure cause)
+    ; Operation.attempt_failed
+        ~operation_id
+        ~attempt_id
+        ~failure:
+          (Operation.Candidate_not_installed
+             { cause; observed_checkpoint = source })
+    ; Operation.commit_reconciliation_required
+        ~operation_id
+        ~attempt_id
+        ~source_checkpoint:source
+        ~candidate_checkpoint:candidate
+        ~evidence
+        ~reason:Operation.Commit_durability_unknown
+    ; Operation.compacted
+        ~operation_id
+        ~attempt_id
+        ~source_checkpoint:source
+        ~committed_checkpoint:candidate
+        ~evidence
+    ; Operation.reinjected
+        ~operation_id
+        ~adopted_checkpoint:candidate
+        ~adopting_turn:turn
+    ]
+  in
+  let kinds =
+    List.map
+      (fun event ->
+         Operation_json.to_json event
+         |> Yojson.Safe.Util.member "kind"
+         |> Yojson.Safe.Util.to_string)
+      events
+  in
+  Alcotest.(check (list string))
+    "closed event labels"
+    [ "requested"
+    ; "attempt_started"
+    ; "candidate_prepared"
+    ; "attempt_failed"
+    ; "attempt_failed"
+    ; "commit_reconciliation_required"
+    ; "compacted"
+    ; "reinjected"
+    ]
+    kinds;
+  let requested = Operation_json.to_json (List.hd events) in
+  Alcotest.(check string)
+    "exact producer request id"
+    "req-1"
+    (requested
+     |> Yojson.Safe.Util.member "payload"
+     |> Yojson.Safe.Util.member "producer_invocation"
+     |> Yojson.Safe.Util.member "request_id"
+     |> Yojson.Safe.Util.to_string)
+;;
+
 let () =
   Alcotest.run
     "keeper compaction operation events"
@@ -265,5 +332,9 @@ let () =
             "reducer invalid transition"
             `Quick
             test_reducer_invalid_transition
+        ; Alcotest.test_case
+            "canonical JSON projection"
+            `Quick
+            test_canonical_json_projection
         ] )
     ]


### PR DESCRIPTION
## Summary
- add one canonical JSON projection for typed compaction operation facts
- preserve exact checkpoint, evidence, producer, failure, reconciliation, and reinjection fields
- keep parsing, persistence, lifecycle authority, and policy out of this leaf

## Verification
- `MASC_DUNE_THROTTLE=0 MASC_SKIP_OPAM_LOCK=1 scripts/dune-local.sh build test/keeper_compaction_operation/test_keeper_compaction_operation.exe`
- `MASC_DUNE_THROTTLE=0 MASC_SKIP_OPAM_LOCK=1 scripts/dune-local.sh exec test/keeper_compaction_operation/test_keeper_compaction_operation.exe` (8/8)
- `ocamlformat --check ...`
- `git diff --check`

## Stack
- base: #24916
- changed lines: +195/-1