### PR TITLE
refactor(gate): hard-delete product dispatch variants

### DIFF
--- a/docs/rfc/RFC-0317-slack-builtin-gateway.md
+++ b/docs/rfc/RFC-0317-slack-builtin-gateway.md
@@ -20,16 +20,16 @@ One tool out, push in. The mirror of [[RFC-0203]] for Slack.
 > connector registration + `Keeper_chat_queue.Slack` deferred delivery. PR-3
 > (this batch) wires `Server_slack_in_process_gateway` + bootstrap + env
 > (`SLACK_APP_TOKEN`, `MASC_SLACK_TRIGGER_POLICY`) + `slack_observability`,
-> and adds the `connector_kind:Slack` arm together with that gateway (per the
-> "add it together with the gateway, not before" note in `gate_keeper_backend`).
+> and supplies a Slack-owned immutable delivery projection to the generic
+> Keeper acceptance boundary.
 > PR-4 (pending) deletes the sidecar. Ambient recording + idle-keeper wake on
 > non-triggering messages and reaction-as-trigger are follow-up scope, not PR-3.
 
 ## Why
 
-- `sidecars/slack-bot/` is a Python slack-bolt process with its own
-  lifecycle, its own HTTP push path (`/api/v1/gate/message` with
-  `connector_kind = Generic`), and its own failure modes. The server
+- `sidecars/slack-bot/` was a Python slack-bolt process with its own
+  lifecycle, its own HTTP push path (`/api/v1/gate/message`), and its own
+  failure modes. The server
   already in-processes Discord (`lib/gate/discord_*`); Slack is the last
   connector that lives in a separate process. Removing it collapses two
   failure surfaces into one.
@@ -172,13 +172,11 @@ failure (DNS/TLS/handshake) is fed as `Wss_closed` — there is no separate
    it yet.
 2. **PR-2 (landed)**: `slack_rest_client` + `keeper_chat_slack` +
    `channel_gate_slack_state` rewrite (in-process) + connector registration +
-   `Keeper_chat_queue.Slack` deferred-delivery source. (`connector_kind` Slack
-   moved to PR-3: `gate_keeper_backend` withholds the arm until the gateway that
-   emits `dispatch ~connector_kind:Slack` exists, to avoid a dead branch.)
+   `Keeper_chat_queue.Slack` deferred-delivery source.
 3. **PR-3 (this batch)**: `server_slack_in_process_gateway` + bootstrap + env
    (`SLACK_APP_TOKEN`, `MASC_SLACK_TRIGGER_POLICY`) + `slack_observability`
-   + `slack_rest_client.auth_test` (bot identity) + the `connector_kind:Slack`
-   arm (with `route_busy_connector` + the surface/conversation-id arms). Bridges
+   + `slack_rest_client.auth_test` (bot identity) + the leaf-owned typed
+   delivery projection. Bridges
    triggered `Message_create`/`App_mention` to
    `Channel_gate.handle_inbound_streaming` with a threaded streaming reply.
    Ambient recording, idle-keeper wake, and reaction-as-trigger are deferred.

--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -1,40 +1,6 @@
 (** Gate_keeper_backend -- adapter between the Channel Gate and the keeper subsystem.
     See [gate_keeper_backend.mli] for the full contract. *)
 
-(* ── Connector deferred-reply routing (RFC-connector-deferred-reply-via-chat-queue) ─────────────── *)
-
-(* [connector_kind] is the typed identity of the connector a [dispatch] serves.
-   It is a property of the connector, not of each message, so it is baked in at
-   dispatch-construction time (the Discord gateway passes [~connector_kind:Discord]
-   when it builds its dispatch). The per-message channel_id / user_id arrive as the
-   ordinary [channel_workspace_id] / [channel_user_id] dispatch fields.
-
-   This lives in [masc] (not the [masc_gate] [dispatch_fn] type) on purpose:
-   [message_source] is a [masc] type, and putting it on a [masc_gate] signature
-   would be a [masc_gate -> masc] dependency cycle. Threading the typed kind as an
-   injected dispatch argument keeps [masc_gate] connector-neutral (RFC-0226) while
-   letting the busy branch route without string-matching the [channel] lane. *)
-type connector_kind =
-  | Discord
-  | Slack
-      (** RFC-0317: the in-process Slack Socket Mode gateway
-          ([Server_slack_in_process_gateway]) builds its dispatch with
-          [~connector_kind:Slack]. Like [Discord] it has an outbound adapter
-          ([Keeper_chat_slack.adapter_loop], drained by the serial chat
-          consumer), so a message arriving mid-turn projects onto the chat queue
-          for deferred delivery rather than the outbound-less async poll store.
-          Added together with that gateway, not before. *)
-  | Generic
-      (** Every connector that is not a wired in-process inbound gateway with its
-          own outbound adapter. Today this is the HTTP gate-route lane
-          (imessage-bot, cli-connector) which POSTs and awaits synchronously, so
-          a busy message keeps the async [masc_keeper_msg] poll path; see
-          RFC-connector-deferred-reply-via-chat-queue §3.3 option (a). *)
-
-type submission_owner =
-  | Authenticated_caller of string
-  | Channel_actor
-
 type connector_delivery =
   { source : Keeper_chat_queue.message_source
   ; surface : Surface_ref.t
@@ -347,9 +313,6 @@ let metadata_value key metadata =
       if value = "" then None else Some value
   | None -> None
 
-let metadata_value_any keys metadata =
-  List.find_map (fun key -> metadata_value key metadata) keys
-
 let assoc_string_if_present key value =
   match non_empty_opt value with
   | None -> []
@@ -366,97 +329,31 @@ let gate_address ~channel ~channel_workspace_id ?conversation_id
   @ opt_assoc_string_if_present "conversation_id" conversation_id
   @ opt_assoc_string_if_present "external_message_id" external_message_id
 
-let discord_channel_id ~channel_workspace_id ~metadata =
-  match metadata_value_any [ "discord.channel_id"; "discord_channel_id" ] metadata with
-  | Some channel_id -> channel_id
-  | None -> String.trim channel_workspace_id
+let surface_for_channel_context ~channel ~channel_workspace_id ?conversation_id
+    ?external_message_id () =
+  let label =
+    match non_empty_opt channel with
+    | Some lane -> lane
+    | None -> "gate"
+  in
+  Surface_ref.Gate
+    { label
+    ; address =
+        gate_address ~channel ~channel_workspace_id ?conversation_id
+          ?external_message_id ()
+    }
 
-let discord_guild_id metadata =
-  metadata_value_any [ "discord.guild_id"; "discord_guild_id" ] metadata
-
-(* Slack surface derivation (RFC-0317). The in-process gateway sets
-   [channel_workspace_id = channel_id] and mirrors it as [slack.channel_id]
-   metadata; prefer the metadata key, fall back to the workspace id. *)
-let slack_channel_id ~channel_workspace_id ~metadata =
-  match metadata_value_any [ "slack.channel_id"; "slack_channel_id" ] metadata with
-  | Some channel_id -> channel_id
-  | None -> String.trim channel_workspace_id
-
-let slack_team_id metadata =
-  metadata_value_any [ "slack.team_id"; "slack_team_id" ] metadata
-
-let slack_thread_ts metadata =
-  metadata_value_any [ "slack.thread_ts"; "slack_thread_ts" ] metadata
-
-let surface_for_channel_context ~connector_kind ~channel ~channel_workspace_id
-    ~metadata ?conversation_id ?external_message_id () =
-  match connector_kind with
-  | Discord ->
-      Surface_ref.Discord
-        {
-          guild_id = discord_guild_id metadata;
-          channel_id = discord_channel_id ~channel_workspace_id ~metadata;
-          parent_channel_id =
-            metadata_value_any
-              [ "discord.parent_channel_id"; "discord_parent_channel_id" ]
-              metadata;
-          thread_id =
-            metadata_value_any [ "discord.thread_id"; "discord_thread_id" ] metadata;
-        }
-  | Slack ->
-      Surface_ref.Slack
-        {
-          team_id = slack_team_id metadata;
-          channel_id = slack_channel_id ~channel_workspace_id ~metadata;
-          thread_ts = slack_thread_ts metadata;
-        }
-  | Generic ->
-      let label =
-        match non_empty_opt channel with
-        | Some lane -> lane
-        | None -> "gate"
-      in
-      Surface_ref.Gate
-        {
-          label;
-          address =
-            gate_address ~channel ~channel_workspace_id ?conversation_id
-              ?external_message_id ();
-        }
-
-let conversation_id_for_channel_context ~connector_kind ~channel
-    ~channel_workspace_id ~metadata =
+let conversation_id_for_channel_context ~channel ~channel_workspace_id ~metadata =
   match metadata_value "conversation_id" metadata with
   | Some value -> Some value
-  | None -> (
-      match connector_kind with
-      | Discord ->
-          let channel_id = discord_channel_id ~channel_workspace_id ~metadata in
-          (match non_empty_opt channel_id with
-           | None -> None
-           | Some channel_id ->
-               let guild_label =
-                 match discord_guild_id metadata with
-                 | Some guild_id -> guild_id
-                 | None -> "dm"
-               in
-               Some (Printf.sprintf "discord:%s:channel:%s" guild_label channel_id))
-      | Slack ->
-          (* Same shape as the in-process gateway's [slack_conversation_id] so
-             the inbound-recorded conversation and the busy-deferred delivery
-             reference one id (Slack threads share the parent channel id). *)
-          let channel_id = slack_channel_id ~channel_workspace_id ~metadata in
-          (match non_empty_opt channel_id with
-           | None -> None
-           | Some channel_id -> Some (Printf.sprintf "slack:channel:%s" channel_id))
-      | Generic ->
-          (match non_empty_opt channel, non_empty_opt channel_workspace_id with
-           | Some lane, Some workspace_id ->
-               Some (Printf.sprintf "gate:%s:workspace:%s" lane workspace_id)
-           | _ -> None))
+  | None ->
+    (match non_empty_opt channel, non_empty_opt channel_workspace_id with
+     | Some lane, Some workspace_id ->
+       Some (Printf.sprintf "gate:%s:workspace:%s" lane workspace_id)
+     | _ -> None)
 
 let external_message_id_for_channel_context ~idempotency_key ~metadata =
-  match metadata_value_any [ "external_message_id"; "discord.message_id" ] metadata with
+  match metadata_value "external_message_id" metadata with
   | Some value -> Some value
   | None -> non_empty_opt idempotency_key
 
@@ -663,8 +560,8 @@ let persist_connector_assistant_reply ~base_dir ~keeper_name ~source ?surface
    below either pass it ([dispatch_with_text_snapshot]) or omit it so it defaults
    to [None] ([dispatch]). Without the unit the optional leaks into [dispatch]'s
    inferred type and breaks the .mli signature. Do not drop the [()]. *)
-let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~submission_owner
-    ~sw ~clock ~proc_mgr ~net ~publication_recovery_provider ~config
+let dispatch_core ?on_text_snapshot ~submitted_by ~sw ~clock ~proc_mgr ~net
+    ~publication_recovery_provider ~config
     ~channel ~channel_user_id ~channel_user_name ~channel_workspace_id
     ~keeper_name ~idempotency_key ~metadata ~content () =
   let keeper_name = String.trim keeper_name in
@@ -677,11 +574,6 @@ let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~submission_owne
   let redact_json = Keeper_secret_redaction.redact_json redaction in
   let agent_name =
     agent_name_for_channel_actor ~channel ~channel_workspace_id ~channel_user_id
-  in
-  let submitted_by =
-    match submission_owner with
-    | Authenticated_caller caller -> caller
-    | Channel_actor -> agent_name
   in
   (* Use filesystem-safe sanitizer: this key is later used as a directory
      component in session_dir. An unsanitized channel_workspace_id with '..' or '/'
@@ -704,8 +596,7 @@ let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~submission_owne
   let lane = String.trim channel in
   let opt value = match String.trim value with "" -> None | v -> Some v in
   let conversation_id =
-    conversation_id_for_channel_context ~connector_kind ~channel
-      ~channel_workspace_id ~metadata
+    conversation_id_for_channel_context ~channel ~channel_workspace_id ~metadata
   in
   let external_message_id =
     external_message_id_for_channel_context ~idempotency_key ~metadata
@@ -716,8 +607,8 @@ let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~submission_owne
     |> ensure_metadata "external_message_id" external_message_id
   in
   let surface =
-    surface_for_channel_context ~connector_kind ~channel ~channel_workspace_id
-      ~metadata ?conversation_id ?external_message_id ()
+    surface_for_channel_context ~channel ~channel_workspace_id
+      ?conversation_id ?external_message_id ()
   in
   (* RFC-0232 §3.3: the connector decoded a structured mention of this
      channel's bound keeper (e.g. Discord <@snowflake>, invisible to
@@ -889,89 +780,20 @@ let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~submission_owne
   | `Async_ack (_, None) | `Streaming None ->
       Gate_protocol.Unavailable_result
 
-(* [connector_kind] is a required labelled argument (not optional): these
-   wrappers are partially applied to produce a [Channel_gate.dispatch_fn] /
-   [streaming_dispatch_fn], so a leading erasable optional would either fail to
-   erase (warning 16) or linger into the resulting function type and not match
-   the connector-neutral [dispatch_fn] shape. Requiring the connector to name
-   its kind also makes a missing wiring a compile error rather than a silent
-   [Generic] default. *)
-let dispatch ~connector_kind ~submission_owner ~sw ~clock ~proc_mgr ~net
-    ~publication_recovery_provider ~config
-    ~channel
+let dispatch ~submitted_by ~sw ~clock ~proc_mgr ~net
+    ~publication_recovery_provider ~config ~channel
     ~channel_user_id ~channel_user_name ~channel_workspace_id ~keeper_name
     ~idempotency_key ~metadata ~content =
-  match connector_kind with
-  | Discord ->
-    let delivery =
-      { source =
-          Keeper_chat_queue.Discord
-            { channel_id = channel_workspace_id; user_id = channel_user_id }
-      ; surface =
-          surface_for_channel_context ~connector_kind ~channel
-            ~channel_workspace_id ~metadata ()
-      ; conversation_id =
-          conversation_id_for_channel_context ~connector_kind ~channel
-            ~channel_workspace_id ~metadata
-      ; external_message_id =
-          external_message_id_for_channel_context ~idempotency_key ~metadata
-      }
-    in
-    accept_connector ~delivery ~clock ~config ~channel
-      ~channel_user_id ~channel_user_name ~channel_workspace_id ~keeper_name
-      ~idempotency_key ~metadata ~content
-  | Slack ->
-    let thread_ts =
-      match slack_thread_ts metadata with
-      | Some thread_ts -> Some thread_ts
-      | None ->
-        metadata_value_any [ "slack.message_ts"; "slack_message_ts" ] metadata
-    in
-    let delivery =
-      { source =
-          Keeper_chat_queue.Slack
-            { channel_id = channel_workspace_id
-            ; user_id = channel_user_id
-            ; user_name = channel_user_name
-            ; team_id = slack_team_id metadata
-            ; thread_ts
-            }
-      ; surface =
-          surface_for_channel_context ~connector_kind ~channel
-            ~channel_workspace_id ~metadata ()
-      ; conversation_id =
-          conversation_id_for_channel_context ~connector_kind ~channel
-            ~channel_workspace_id ~metadata
-      ; external_message_id =
-          external_message_id_for_channel_context ~idempotency_key ~metadata
-      }
-    in
-    accept_connector ~delivery ~clock ~config ~channel
-      ~channel_user_id ~channel_user_name ~channel_workspace_id ~keeper_name
-      ~idempotency_key ~metadata ~content
-  | Generic ->
-    dispatch_core ~connector_kind ~submission_owner ~sw ~clock ~proc_mgr ~net
-      ~publication_recovery_provider ~config ~channel ~channel_user_id
-      ~channel_user_name ~channel_workspace_id ~keeper_name ~idempotency_key
-      ~metadata ~content ()
+  dispatch_core ~submitted_by ~sw ~clock ~proc_mgr ~net
+    ~publication_recovery_provider ~config ~channel ~channel_user_id
+    ~channel_user_name ~channel_workspace_id ~keeper_name ~idempotency_key
+    ~metadata ~content ()
 
-let dispatch_with_text_snapshot ~connector_kind ~submission_owner
-    ~on_text_snapshot ~sw ~clock ~proc_mgr ~net ~publication_recovery_provider
-    ~config ~channel ~channel_user_id ~channel_user_name ~channel_workspace_id
-    ~keeper_name ~idempotency_key ~metadata ~content =
-  match connector_kind with
-  | Discord ->
-    dispatch ~connector_kind ~submission_owner ~sw ~clock ~proc_mgr ~net
-      ~publication_recovery_provider ~config ~channel ~channel_user_id
-      ~channel_user_name ~channel_workspace_id ~keeper_name ~idempotency_key
-      ~metadata ~content
-  | Slack ->
-    dispatch ~connector_kind ~submission_owner ~sw ~clock ~proc_mgr ~net
-      ~publication_recovery_provider ~config ~channel ~channel_user_id
-      ~channel_user_name ~channel_workspace_id ~keeper_name ~idempotency_key
-      ~metadata ~content
-  | Generic ->
-    dispatch_core ~connector_kind ~submission_owner ~on_text_snapshot ~sw
-      ~clock ~proc_mgr ~net ~publication_recovery_provider ~config ~channel
-      ~channel_user_id ~channel_user_name ~channel_workspace_id ~keeper_name
-      ~idempotency_key ~metadata ~content ()
+let dispatch_with_text_snapshot ~submitted_by ~on_text_snapshot ~sw ~clock
+    ~proc_mgr ~net ~publication_recovery_provider ~config ~channel
+    ~channel_user_id ~channel_user_name ~channel_workspace_id ~keeper_name
+    ~idempotency_key ~metadata ~content =
+  dispatch_core ~submitted_by ~on_text_snapshot ~sw ~clock ~proc_mgr ~net
+    ~publication_recovery_provider ~config ~channel ~channel_user_id
+    ~channel_user_name ~channel_workspace_id ~keeper_name ~idempotency_key
+    ~metadata ~content ()

--- a/lib/gate_keeper_backend.mli
+++ b/lib/gate_keeper_backend.mli
@@ -10,25 +10,7 @@
 
     @since 2.222.0 *)
 
-(** {1 Connector deferred-reply routing (RFC-connector-deferred-reply-via-chat-queue)} *)
-
-type connector_kind =
-  | Discord
-  | Slack
-  | Generic
-(** The typed identity of the connector a {!dispatch} serves, injected at
-    dispatch-construction time. [Discord] and [Slack] each have an in-process
-    inbound gateway and an outbound adapter, so a busy message projects onto the
-    chat queue; [Generic] (the HTTP gate-route lane: imessage-bot, cli-connector)
-    keeps the async [masc_keeper_msg] poll path. See
-    RFC-connector-deferred-reply-via-chat-queue §3.2–3.3 and RFC-0317. *)
-
-type submission_owner =
-  | Authenticated_caller of string
-  | Channel_actor
-(** Owner of an async request produced by this dispatch. [Channel_actor] uses
-    the external actor's deterministic gate identity. [Authenticated_caller]
-    keeps poll/cancel authority with the already-authenticated HTTP principal. *)
+(** {1 Connector delivery} *)
 
 type connector_delivery =
   { source : Keeper_chat_queue.message_source
@@ -61,8 +43,7 @@ val accept_connector :
     derived hash namespace. *)
 
 val dispatch :
-  connector_kind:connector_kind ->
-  submission_owner:submission_owner ->
+  submitted_by:string ->
   sw:Eio.Switch.t ->
   clock:_ Eio.Time.clock ->
   proc_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t option ->
@@ -79,28 +60,17 @@ val dispatch :
   metadata:(string * string) list ->
   content:string ->
   Gate_protocol.dispatch_result
-(** [Discord]/[Slack] delegates to {!accept_connector}: every message enters
-    [Keeper_chat_queue] before this call returns, regardless of current Keeper
-    admission. [Generic] builds a keeper context and retains the HTTP/poll
-    contract. The durable connector enqueue is acknowledged
-    only after its durable snapshot commits; the reply's [message_request]
-    carries the queue receipt id and revision. When admission is fenced by a
-    typed Keeper shutdown operation, the same envelope carries
-    [shutdown_operation_id] and the ACK says the receipt waits for the next
-    active lane rather than promising completion of a current turn.
-    Persistence failure returns an explicit [Keeper_error_result], never a
-    queued ACK. [Generic]
-    returns an accepted async request envelope ([Keeper_msg_async]) instead of
-    blocking the connector request behind that turn. The [channel] and
-    [channel_user_id] are used to construct the agent name
+(** Build the generic HTTP Gate Keeper context. A busy Keeper returns an
+    accepted async request envelope ([Keeper_msg_async]) instead of blocking the
+    HTTP request. Durable connector leaves use {!accept_connector} and do not
+    enter this path. The [channel] and [channel_user_id] construct the agent name
     ([gate:<channel>:<workspace_id>:<user_id>]) for conversation identity;
-    [submission_owner] independently binds poll/cancel authority. The other connector fields are
-    injected into the keeper-visible message body so external user identity
-    survives memory and handoff boundaries. *)
+    [submitted_by] independently binds poll/cancel authority. The other generic
+    Gate fields are injected into the keeper-visible message body so external
+    user identity survives memory and handoff boundaries. *)
 
 val dispatch_with_text_snapshot :
-  connector_kind:connector_kind ->
-  submission_owner:submission_owner ->
+  submitted_by:string ->
   on_text_snapshot:(string -> unit) ->
   sw:Eio.Switch.t ->
   clock:_ Eio.Time.clock ->

--- a/lib/server/server_routes_http_routes_channel_gate.ml
+++ b/lib/server/server_routes_http_routes_channel_gate.ml
@@ -140,15 +140,11 @@ let handle_gate_message ~sw ~clock ~submitted_by state request reqd =
     let request_started = Unix.gettimeofday () in
     let workspace_scope = Mcp_server.workspace_scope state in
     let dispatch =
-      (* RFC-connector-deferred-reply-via-chat-queue: the HTTP gate route is the convergence point for sidecar
-         connectors (imessage-bot, cli-connector) that POST and await the reply
-         synchronously. They have no in-process outbound adapter, so [Generic]
-         keeps their existing async [masc_keeper_msg] poll behaviour when the
-         keeper is busy. *)
+      (* The HTTP gate route posts and awaits synchronously. A busy Keeper keeps
+         the async [masc_keeper_msg] poll contract; durable connector leaves use
+         [accept_connector] before entering their Keeper lane. *)
       Gate_keeper_backend.dispatch
-        ~connector_kind:Gate_keeper_backend.Generic
-        ~submission_owner:(Gate_keeper_backend.Authenticated_caller submitted_by)
-        ~sw ~clock
+        ~submitted_by ~sw ~clock
         ~proc_mgr:state.Mcp_server.proc_mgr
         ~net:state.Mcp_server.net
         ~publication_recovery_provider:


### PR DESCRIPTION
## Summary
- hard-delete `connector_kind`, Discord/Slack dispatch arms, and product metadata parsers from the generic Gate backend
- keep durable connectors exclusively on leaf-built immutable delivery projections
- collapse the HTTP Gate owner argument to the authenticated `submitted_by` identity
- refresh the Slack architecture RFC without carrying approval/governance changes

## Boundary proof
- `Gate_keeper_backend` contains no Discord/Slack name, product route variant, or product metadata alias parser
- generic `dispatch` always projects `Surface_ref.Gate`
- connector leaves exclusively call `accept_connector`
- no compatibility shim or legacy migration remains

## Scope
- code-only recut of the useful part of merged #24636
- excludes every standing-approval, governance, Dashboard approval, and security-doc change that contaminated the old stacked head

## Verification
- focused Connector/Gate stack build at the final stacked head
- `ocamlformat --check`
- `ocamlc -stop-after parsing -c`
- repository-wide residue search
- `git diff --check`

Stacked on #24633.
