### PR TITLE
refactor(keeper): define per-unit compaction plan schema

### DIFF
--- a/lib/keeper/keeper_structured_output_schema.ml
+++ b/lib/keeper/keeper_structured_output_schema.ml
@@ -187,6 +187,35 @@ let compaction_plan_output_schema =
   object_schema ~required:(List.map fst fields) fields
 ;;
 
+(* Replacement compaction plan. Summaries are attached to their atomic source
+   unit so disjoint reductions preserve chronological placement. *)
+let compaction_unit_plan_field_kept_indices = "kept_indices"
+let compaction_unit_plan_field_dropped_indices = "dropped_indices"
+let compaction_unit_plan_field_summarized_units = "summarized_units"
+let compaction_unit_plan_field_unit_index = "unit_index"
+let compaction_unit_plan_field_unit_summary = "summary"
+
+let compaction_unit_plan_output_schema =
+  let int_array = `Assoc [ "type", `String "array"; "items", integer_schema ] in
+  let summarized_unit_fields =
+    [ compaction_unit_plan_field_unit_index, integer_schema
+    ; compaction_unit_plan_field_unit_summary, string_schema
+    ]
+  in
+  let summarized_unit =
+    object_schema
+      ~required:(List.map fst summarized_unit_fields)
+      summarized_unit_fields
+  in
+  let fields =
+    [ compaction_unit_plan_field_kept_indices, int_array
+    ; compaction_unit_plan_field_dropped_indices, int_array
+    ; compaction_unit_plan_field_summarized_units, array_schema summarized_unit
+    ]
+  in
+  object_schema ~required:(List.map fst fields) fields
+;;
+
 let vision_analyze_output_schema =
   let fields = [ "text", string_schema ] in
   object_schema ~required:(List.map fst fields) fields

--- a/lib/keeper/keeper_structured_output_schema.mli
+++ b/lib/keeper/keeper_structured_output_schema.mli
@@ -26,6 +26,17 @@ val compaction_plan_output_schema : Yojson.Safe.t
 (** JSON object the LLM compaction summarizer must return: a [summary] prose
     block plus kept / summarized / dropped 0-based message indices. *)
 
+val compaction_unit_plan_field_kept_indices : string
+val compaction_unit_plan_field_dropped_indices : string
+val compaction_unit_plan_field_summarized_units : string
+val compaction_unit_plan_field_unit_index : string
+val compaction_unit_plan_field_unit_summary : string
+
+val compaction_unit_plan_output_schema : Yojson.Safe.t
+(** Replacement compaction schema. Every atomic source unit is kept, dropped,
+    or replaced by its own non-empty summary so disjoint reductions retain
+    chronological placement. *)
+
 val vision_analyze_output_schema : Yojson.Safe.t
 (** JSON object the one-shot vision analyzer provider must return. *)
 

--- a/test/test_keeper_structured_output_schema.ml
+++ b/test/test_keeper_structured_output_schema.ml
@@ -53,6 +53,9 @@ let all_provider_native_schema_cases =
   [ "librarian_episode", Keeper_structured_output_schema.librarian_episode_output_schema
   ; "consolidation_plan", Keeper_structured_output_schema.consolidation_plan_output_schema
   ; "memory_bank_summary", Keeper_structured_output_schema.memory_bank_summary_output_schema
+  ; "compaction_plan", Keeper_structured_output_schema.compaction_plan_output_schema
+  ; ( "compaction_unit_plan"
+    , Keeper_structured_output_schema.compaction_unit_plan_output_schema )
   ; "vision_analyze", Keeper_structured_output_schema.vision_analyze_output_schema
   ; "operator_judge", Keeper_structured_output_schema.operator_judge_output_schema
   ; "fusion_judge", Keeper_structured_output_schema.fusion_judge_output_schema


### PR DESCRIPTION
## Summary

- add a provider-native compaction schema with one decision per atomic unit
- replace the ambiguous global summary shape with summarized_units entries carrying unit_index and summary
- keep schema field names as one typed SSOT for the parser/application follow-up

This is the first replacement slice for #24875. It does not activate the schema yet, so the existing planner remains unchanged on this base PR. The stacked implementation will hard-cut the old global-summary schema and will allow every closed-prefix unit, including a closed ToolUse/ToolResult cycle, to be kept, summarized, or dropped as one atomic unit. The open/in-flight protected suffix remains outside LLM rewrite.

#24875 remains open for comparison; this stack supersedes its must_keep closed-cycle rule and contiguous summarized-index constraint.

## Scope

- 3 files
- 43 additions

## Verification

- git diff --check
- ocamlformat --check on touched OCaml files
- scripts/dune-local.sh build test/test_keeper_structured_output_schema.exe
- test_keeper_structured_output_schema: 11/11 passed
