### PR TITLE
feat(keeper): decode compaction wire values

### DIFF
--- a/lib/keeper_compaction_operation_codec/dune
+++ b/lib/keeper_compaction_operation_codec/dune
@@ -1,0 +1,17 @@
+(include_subdirs no)
+
+(library
+ (name masc_keeper_compaction_operation_codec)
+ (public_name masc.keeper_compaction_operation_codec)
+ (wrapped false)
+ (modules keeper_compaction_operation_codec_support)
+ (libraries
+  masc.compaction_trigger
+  masc.keeper_checkpoint_ref
+  masc.keeper_compaction_evidence
+  masc.keeper_compaction_operation
+  masc.keeper_compaction_operation_identity
+  masc.keeper_registry
+  masc.masc_types
+  masc.tool_invocation_ref
+  yojson))

--- a/lib/keeper_compaction_operation_codec/keeper_compaction_operation_codec_support.ml
+++ b/lib/keeper_compaction_operation_codec/keeper_compaction_operation_codec_support.ml
@@ -1,0 +1,167 @@
+module Operation = Keeper_compaction_operation
+
+type field_error =
+  | Unknown_field of
+      { path : string
+      ; field : string
+      }
+  | Duplicate_field of
+      { path : string
+      ; field : string
+      }
+  | Missing_field of
+      { path : string
+      ; field : string
+      }
+  | Wrong_type of
+      { path : string
+      ; field : string
+      ; expected : string
+      }
+
+type decode_error =
+  | Expected_object of string
+  | Invalid_field of field_error
+  | Unknown_event_kind of string
+  | Unknown_failure_kind of string
+  | Unknown_reconciliation_reason of string
+  | Invalid_operation_id of Keeper_compaction_operation_identity.id_error
+  | Invalid_attempt_id of Keeper_compaction_operation_identity.id_error
+  | Invalid_keeper_name of string
+  | Invalid_trace_id of string
+  | Invalid_cause of Keeper_compaction_operation_identity.Cause.error
+  | Invalid_checkpoint of Keeper_checkpoint_ref.create_error
+  | Invalid_trigger of Compaction_trigger.decode_error
+  | Invalid_producer of Tool_invocation_ref.decode_error
+  | Invalid_evidence of Keeper_compaction_evidence.decode_error
+  | Invalid_turn_ref of string
+
+let ( let* ) = Result.bind
+let field_error error = Error (Invalid_field error)
+
+let exact_object ~path ~allowed ~required = function
+  | `Assoc fields ->
+    let rec validate seen = function
+      | [] -> Ok ()
+      | (field, _) :: _ when List.mem field seen ->
+        field_error (Duplicate_field { path; field })
+      | (field, _) :: _ when not (List.mem field allowed) ->
+        field_error (Unknown_field { path; field })
+      | (field, _) :: rest -> validate (field :: seen) rest
+    in
+    let rec require = function
+      | [] -> Ok fields
+      | field :: rest ->
+        if List.mem_assoc field fields
+        then require rest
+        else field_error (Missing_field { path; field })
+    in
+    let* () = validate [] fields in
+    require required
+  | _ -> Error (Expected_object path)
+;;
+
+let required_field ~path field fields =
+  match List.assoc_opt field fields with
+  | Some value -> Ok value
+  | None -> field_error (Missing_field { path; field })
+;;
+
+let string_field ~path field = function
+  | `String value -> Ok value
+  | _ -> field_error (Wrong_type { path; field; expected = "string" })
+;;
+
+let int_field ~path field = function
+  | `Int value -> Ok value
+  | _ -> field_error (Wrong_type { path; field; expected = "integer" })
+;;
+
+let operation_id ~path field json =
+  let* value = string_field ~path field json in
+  Operation.Operation_id.of_string value
+  |> Result.map_error (fun error -> Invalid_operation_id error)
+;;
+
+let attempt_id ~path field json =
+  let* value = string_field ~path field json in
+  Operation.Attempt_id.of_string value
+  |> Result.map_error (fun error -> Invalid_attempt_id error)
+;;
+
+let keeper_name ~path field json =
+  let* value = string_field ~path field json in
+  Keeper_id.Keeper_name.of_string value
+  |> Result.map_error (fun error -> Invalid_keeper_name error)
+;;
+
+let cause ~path field json =
+  let* value = string_field ~path field json in
+  Operation.Cause.of_string value
+  |> Result.map_error (fun error -> Invalid_cause error)
+;;
+
+let checkpoint ~path json =
+  let fields = [ "trace_id"; "generation"; "turn_count"; "sha256" ] in
+  let* values = exact_object ~path ~allowed:fields ~required:fields json in
+  let* trace_json = required_field ~path "trace_id" values in
+  let* trace_value = string_field ~path "trace_id" trace_json in
+  let* trace_id =
+    Keeper_id.Trace_id.of_string trace_value
+    |> Result.map_error (fun error -> Invalid_trace_id error)
+  in
+  let* generation_json = required_field ~path "generation" values in
+  let* generation = int_field ~path "generation" generation_json in
+  let* turn_count_json = required_field ~path "turn_count" values in
+  let* turn_count = int_field ~path "turn_count" turn_count_json in
+  let* sha_json = required_field ~path "sha256" values in
+  let* sha256 = string_field ~path "sha256" sha_json in
+  Keeper_checkpoint_ref.of_persisted ~trace_id ~generation ~turn_count ~sha256
+  |> Result.map_error (fun error -> Invalid_checkpoint error)
+;;
+
+let evidence ~path json =
+  let fields = [ "selected_runtime_id"; "counts" ] in
+  let* values = exact_object ~path ~allowed:fields ~required:fields json in
+  let* runtime_json = required_field ~path "selected_runtime_id" values in
+  let* selected_runtime_id =
+    match runtime_json with
+    | `Null -> Ok None
+    | `String value -> Ok (Some value)
+    | _ ->
+      field_error
+        (Wrong_type
+           { path; field = "selected_runtime_id"; expected = "string or null" })
+  in
+  let* counts = required_field ~path "counts" values in
+  Keeper_compaction_evidence.of_json ~selected_runtime_id counts
+  |> Result.map_error (fun error -> Invalid_evidence error)
+;;
+
+let trigger ~path json =
+  let* trigger =
+    Compaction_trigger.of_detail_json json
+    |> Result.map_error (fun error -> Invalid_trigger error)
+  in
+  let allowed, required =
+    match trigger with
+    | Compaction_trigger.Manual -> [ "kind" ], [ "kind" ]
+    | Provider_overflow _ ->
+      [ "kind"; "limit_tokens" ], [ "kind"; "limit_tokens" ]
+  in
+  let* _ = exact_object ~path ~allowed ~required json in
+  Ok trigger
+;;
+
+let producer_invocation = function
+  | `Null -> Ok None
+  | json ->
+    Tool_invocation_ref.of_yojson json
+    |> Result.map_error (fun error -> Invalid_producer error)
+    |> Result.map Option.some
+;;
+
+let turn_ref json =
+  Ids.Turn_ref.of_yojson json
+  |> Result.map_error (fun error -> Invalid_turn_ref error)
+;;

--- a/lib/keeper_compaction_operation_codec/keeper_compaction_operation_codec_support.mli
+++ b/lib/keeper_compaction_operation_codec/keeper_compaction_operation_codec_support.mli
@@ -1,0 +1,99 @@
+type field_error =
+  | Unknown_field of
+      { path : string
+      ; field : string
+      }
+  | Duplicate_field of
+      { path : string
+      ; field : string
+      }
+  | Missing_field of
+      { path : string
+      ; field : string
+      }
+  | Wrong_type of
+      { path : string
+      ; field : string
+      ; expected : string
+      }
+
+type decode_error =
+  | Expected_object of string
+  | Invalid_field of field_error
+  | Unknown_event_kind of string
+  | Unknown_failure_kind of string
+  | Unknown_reconciliation_reason of string
+  | Invalid_operation_id of Keeper_compaction_operation_identity.id_error
+  | Invalid_attempt_id of Keeper_compaction_operation_identity.id_error
+  | Invalid_keeper_name of string
+  | Invalid_trace_id of string
+  | Invalid_cause of Keeper_compaction_operation_identity.Cause.error
+  | Invalid_checkpoint of Keeper_checkpoint_ref.create_error
+  | Invalid_trigger of Compaction_trigger.decode_error
+  | Invalid_producer of Tool_invocation_ref.decode_error
+  | Invalid_evidence of Keeper_compaction_evidence.decode_error
+  | Invalid_turn_ref of string
+
+val exact_object
+  :  path:string
+  -> allowed:string list
+  -> required:string list
+  -> Yojson.Safe.t
+  -> ((string * Yojson.Safe.t) list, decode_error) result
+
+val required_field
+  :  path:string
+  -> string
+  -> (string * Yojson.Safe.t) list
+  -> (Yojson.Safe.t, decode_error) result
+
+val string_field
+  :  path:string
+  -> string
+  -> Yojson.Safe.t
+  -> (string, decode_error) result
+
+val operation_id
+  :  path:string
+  -> string
+  -> Yojson.Safe.t
+  -> (Keeper_compaction_operation.Operation_id.t, decode_error) result
+
+val attempt_id
+  :  path:string
+  -> string
+  -> Yojson.Safe.t
+  -> (Keeper_compaction_operation.Attempt_id.t, decode_error) result
+
+val keeper_name
+  :  path:string
+  -> string
+  -> Yojson.Safe.t
+  -> (Keeper_id.Keeper_name.t, decode_error) result
+
+val cause
+  :  path:string
+  -> string
+  -> Yojson.Safe.t
+  -> (Keeper_compaction_operation.Cause.t, decode_error) result
+
+val checkpoint
+  :  path:string
+  -> Yojson.Safe.t
+  -> (Keeper_checkpoint_ref.t, decode_error) result
+
+val evidence
+  :  path:string
+  -> Yojson.Safe.t
+  -> (Keeper_compaction_evidence.t, decode_error) result
+
+val trigger
+  :  path:string
+  -> Yojson.Safe.t
+  -> (Compaction_trigger.t, decode_error) result
+
+val producer_invocation
+  :  Yojson.Safe.t
+  -> (Tool_invocation_ref.t option, decode_error) result
+
+val turn_ref : Yojson.Safe.t -> (Ids.Turn_ref.t, decode_error) result

--- a/test/keeper_compaction_operation/dune
+++ b/test/keeper_compaction_operation/dune
@@ -6,6 +6,7 @@
   masc.keeper_checkpoint_ref
   masc.keeper_compaction_evidence
   masc.keeper_compaction_operation
+  masc.keeper_compaction_operation_codec
   masc.keeper_compaction_operation_json
   masc.keeper_compaction_operation_reducer
   masc.keeper_registry

--- a/test/keeper_compaction_operation/test_keeper_compaction_operation.ml
+++ b/test/keeper_compaction_operation/test_keeper_compaction_operation.ml
@@ -1,4 +1,5 @@
 module Operation = Keeper_compaction_operation
+module Decode_support = Keeper_compaction_operation_codec_support
 module Operation_json = Keeper_compaction_operation_json
 module Reducer = Keeper_compaction_operation_reducer
 
@@ -309,6 +310,43 @@ let test_canonical_json_projection () =
      |> Yojson.Safe.Util.to_string)
 ;;
 
+let test_nested_decode_support () =
+  let projected = Operation_json.to_json (candidate_event ()) in
+  let payload = Yojson.Safe.Util.member "payload" projected in
+  let checkpoint_json = Yojson.Safe.Util.member "source_checkpoint" payload in
+  let evidence_json = Yojson.Safe.Util.member "evidence" payload in
+  let decoded_checkpoint =
+    Decode_support.checkpoint ~path:"payload.source_checkpoint" checkpoint_json
+    |> Result.get_ok
+  in
+  let decoded_evidence =
+    Decode_support.evidence ~path:"payload.evidence" evidence_json
+    |> Result.get_ok
+  in
+  Alcotest.(check bool)
+    "checkpoint identity"
+    true
+    (Keeper_checkpoint_ref.equal source decoded_checkpoint);
+  Alcotest.(check string)
+    "runtime identity"
+    "compact-runtime"
+    (Option.get decoded_evidence.selected_runtime_id)
+;;
+
+let test_nested_decode_support_rejects_unknown_field () =
+  match
+    Decode_support.trigger
+      ~path:"payload.trigger"
+      (`Assoc [ "kind", `String "manual"; "unexpected", `Null ])
+  with
+  | Error
+      (Decode_support.Invalid_field
+         (Decode_support.Unknown_field
+            { path = "payload.trigger"; field = "unexpected" })) ->
+    ()
+  | Ok _ | Error _ -> Alcotest.fail "manual trigger accepted an unknown field"
+;;
+
 let () =
   Alcotest.run
     "keeper compaction operation events"
@@ -336,5 +374,13 @@ let () =
             "canonical JSON projection"
             `Quick
             test_canonical_json_projection
+        ; Alcotest.test_case
+            "nested decode support"
+            `Quick
+            test_nested_decode_support
+        ; Alcotest.test_case
+            "nested decode support rejects unknown field"
+            `Quick
+            test_nested_decode_support_rejects_unknown_field
         ] )
     ]


### PR DESCRIPTION
## Summary
- add strict object and field decoding for compaction wire values
- delegate checkpoint, evidence, trigger, producer, and turn semantics to their typed SSOT decoders
- reject unknown, duplicate, missing, and wrong-type nested fields explicitly
- intentionally exclude public event decoding from this stack leaf

## Verification
- focused build: `test/keeper_compaction_operation/test_keeper_compaction_operation.exe`
- focused test: 10/10 green
- `ocamlformat --check ...`
- `git diff --check`

## Stack
- base: #24918
- changed lines: +330/-0