### PR TITLE
feat(keeper): decode compaction operation events

### DIFF
--- a/lib/keeper_compaction_operation_codec/dune
+++ b/lib/keeper_compaction_operation_codec/dune
@@ -4,13 +4,17 @@
  (name masc_keeper_compaction_operation_codec)
  (public_name masc.keeper_compaction_operation_codec)
  (wrapped false)
- (modules keeper_compaction_operation_codec_support)
+ (modules
+  keeper_compaction_operation_codec
+  keeper_compaction_operation_codec_support)
+ (private_modules keeper_compaction_operation_codec_support)
  (libraries
   masc.compaction_trigger
   masc.keeper_checkpoint_ref
   masc.keeper_compaction_evidence
   masc.keeper_compaction_operation
   masc.keeper_compaction_operation_identity
+  masc.keeper_compaction_operation_json
   masc.keeper_registry
   masc.masc_types
   masc.tool_invocation_ref

--- a/lib/keeper_compaction_operation_codec/keeper_compaction_operation_codec.ml
+++ b/lib/keeper_compaction_operation_codec/keeper_compaction_operation_codec.ml
@@ -1,0 +1,185 @@
+module Operation = Keeper_compaction_operation
+module Support = Keeper_compaction_operation_codec_support
+include Support
+
+let ( let* ) = Result.bind
+let to_json = Keeper_compaction_operation_json.to_json
+
+let field ~path name decode fields =
+  let* json = Support.required_field ~path name fields in
+  decode ~path name json
+;;
+
+let nested ~path name decode fields =
+  let* json = Support.required_field ~path name fields in
+  decode ~path:(path ^ "." ^ name) json
+;;
+
+type candidate =
+  { attempt_id : Operation.Attempt_id.t
+  ; source_checkpoint : Keeper_checkpoint_ref.t
+  ; candidate_checkpoint : Keeper_checkpoint_ref.t
+  ; evidence : Keeper_compaction_evidence.t
+  }
+
+let candidate ~path ~checkpoint_field fields =
+  let* attempt_id = field ~path "attempt_id" Support.attempt_id fields in
+  let* source_checkpoint =
+    nested ~path "source_checkpoint" Support.checkpoint fields
+  in
+  let* candidate_checkpoint =
+    nested ~path checkpoint_field Support.checkpoint fields
+  in
+  let* evidence = nested ~path "evidence" Support.evidence fields in
+  Ok { attempt_id; source_checkpoint; candidate_checkpoint; evidence }
+;;
+
+let candidate_fields checkpoint_field =
+  [ "attempt_id"; "source_checkpoint"; checkpoint_field; "evidence" ]
+;;
+
+let decode_candidate ~operation_id ~checkpoint_field ~make payload =
+  let path = "payload" in
+  let fields = candidate_fields checkpoint_field in
+  let* values = Support.exact_object ~path ~allowed:fields ~required:fields payload in
+  let* value = candidate ~path ~checkpoint_field values in
+  Ok (make value ~operation_id)
+;;
+
+let decode_requested ~operation_id payload =
+  let path = "payload" in
+  let fields =
+    [ "keeper_name"
+    ; "source_checkpoint"
+    ; "trigger"
+    ; "cause"
+    ; "producer_invocation"
+    ]
+  in
+  let* values = Support.exact_object ~path ~allowed:fields ~required:fields payload in
+  let* keeper_name = field ~path "keeper_name" Support.keeper_name values in
+  let* source_checkpoint =
+    nested ~path "source_checkpoint" Support.checkpoint values
+  in
+  let* trigger = nested ~path "trigger" Support.trigger values in
+  let* cause = field ~path "cause" Support.cause values in
+  let* producer_json = Support.required_field ~path "producer_invocation" values in
+  let* producer_invocation = Support.producer_invocation producer_json in
+  Ok
+    (Operation.requested
+       ~operation_id
+       ~keeper_name
+       ~source_checkpoint
+       ~trigger
+       ~cause
+       ~producer_invocation)
+;;
+
+let decode_attempt_started ~operation_id payload =
+  let path = "payload" in
+  let fields = [ "attempt_id" ] in
+  let* values = Support.exact_object ~path ~allowed:fields ~required:fields payload in
+  let* attempt_id = field ~path "attempt_id" Support.attempt_id values in
+  Ok (Operation.attempt_started ~operation_id ~attempt_id)
+;;
+
+let decode_attempt_failed ~operation_id payload =
+  let path = "payload" in
+  let fields = [ "attempt_id"; "failure_kind"; "cause"; "observed_checkpoint" ] in
+  let* values = Support.exact_object ~path ~allowed:fields ~required:fields payload in
+  let* attempt_id = field ~path "attempt_id" Support.attempt_id values in
+  let* failure_kind = field ~path "failure_kind" Support.string_field values in
+  let* cause = field ~path "cause" Support.cause values in
+  let* observed = Support.required_field ~path "observed_checkpoint" values in
+  let* failure =
+    match failure_kind, observed with
+    | "pre_commit", `Null -> Ok (Operation.Pre_commit_failure cause)
+    | "pre_commit", _ ->
+      Error
+        (Support.Invalid_field
+           (Support.Wrong_type
+              { path; field = "observed_checkpoint"; expected = "null" }))
+    | "candidate_not_installed", json ->
+      let* observed_checkpoint =
+        Support.checkpoint ~path:"payload.observed_checkpoint" json
+      in
+      Ok (Operation.Candidate_not_installed { cause; observed_checkpoint })
+    | unknown, _ -> Error (Support.Unknown_failure_kind unknown)
+  in
+  Ok (Operation.attempt_failed ~operation_id ~attempt_id ~failure)
+;;
+
+let decode_reconciliation ~operation_id payload =
+  let path = "payload" in
+  let fields = candidate_fields "candidate_checkpoint" @ [ "reason" ] in
+  let* values = Support.exact_object ~path ~allowed:fields ~required:fields payload in
+  let* value = candidate ~path ~checkpoint_field:"candidate_checkpoint" values in
+  let* reason = field ~path "reason" Support.string_field values in
+  let* reason =
+    match reason with
+    | "commit_durability_unknown" -> Ok Operation.Commit_durability_unknown
+    | "transaction_outcome_unknown" -> Ok Operation.Transaction_outcome_unknown
+    | unknown -> Error (Support.Unknown_reconciliation_reason unknown)
+  in
+  Ok
+    (Operation.commit_reconciliation_required
+       ~operation_id
+       ~attempt_id:value.attempt_id
+       ~source_checkpoint:value.source_checkpoint
+       ~candidate_checkpoint:value.candidate_checkpoint
+       ~evidence:value.evidence
+       ~reason)
+;;
+
+let decode_reinjected ~operation_id payload =
+  let path = "payload" in
+  let fields = [ "adopted_checkpoint"; "adopting_turn" ] in
+  let* values = Support.exact_object ~path ~allowed:fields ~required:fields payload in
+  let* adopted_checkpoint =
+    nested ~path "adopted_checkpoint" Support.checkpoint values
+  in
+  let* turn_json = Support.required_field ~path "adopting_turn" values in
+  let* adopting_turn = Support.turn_ref turn_json in
+  Ok (Operation.reinjected ~operation_id ~adopted_checkpoint ~adopting_turn)
+;;
+
+let of_json json =
+  let path = "$" in
+  let fields = [ "kind"; "operation_id"; "payload" ] in
+  let* values = Support.exact_object ~path ~allowed:fields ~required:fields json in
+  let* kind = field ~path "kind" Support.string_field values in
+  let* operation_id = field ~path "operation_id" Support.operation_id values in
+  let* payload = Support.required_field ~path "payload" values in
+  match kind with
+  | "requested" -> decode_requested ~operation_id payload
+  | "attempt_started" -> decode_attempt_started ~operation_id payload
+  | "candidate_prepared" ->
+    decode_candidate
+      ~operation_id
+      ~checkpoint_field:"candidate_checkpoint"
+      ~make:(fun value ~operation_id ->
+        Operation.candidate_prepared
+          ~operation_id
+          ~attempt_id:value.attempt_id
+          ~source_checkpoint:value.source_checkpoint
+          ~candidate_checkpoint:value.candidate_checkpoint
+          ~evidence:value.evidence)
+      payload
+  | "attempt_failed" -> decode_attempt_failed ~operation_id payload
+  | "commit_reconciliation_required" ->
+    decode_reconciliation ~operation_id payload
+  | "compacted" ->
+    decode_candidate
+      ~operation_id
+      ~checkpoint_field:"committed_checkpoint"
+      ~make:(fun value ~operation_id ->
+        Operation.compacted
+          ~operation_id
+          ~attempt_id:value.attempt_id
+          ~source_checkpoint:value.source_checkpoint
+          ~committed_checkpoint:value.candidate_checkpoint
+          ~evidence:value.evidence)
+      payload
+  | "reinjected" -> decode_reinjected ~operation_id payload
+  | unknown -> Error (Support.Unknown_event_kind unknown)
+;;

--- a/lib/keeper_compaction_operation_codec/keeper_compaction_operation_codec.mli
+++ b/lib/keeper_compaction_operation_codec/keeper_compaction_operation_codec.mli
@@ -1,0 +1,40 @@
+(** Closed durable codec for typed compaction operation facts. *)
+
+type field_error = Keeper_compaction_operation_codec_support.field_error =
+  | Unknown_field of
+      { path : string
+      ; field : string
+      }
+  | Duplicate_field of
+      { path : string
+      ; field : string
+      }
+  | Missing_field of
+      { path : string
+      ; field : string
+      }
+  | Wrong_type of
+      { path : string
+      ; field : string
+      ; expected : string
+      }
+
+type decode_error = Keeper_compaction_operation_codec_support.decode_error =
+  | Expected_object of string
+  | Invalid_field of field_error
+  | Unknown_event_kind of string
+  | Unknown_failure_kind of string
+  | Unknown_reconciliation_reason of string
+  | Invalid_operation_id of Keeper_compaction_operation_identity.id_error
+  | Invalid_attempt_id of Keeper_compaction_operation_identity.id_error
+  | Invalid_keeper_name of string
+  | Invalid_trace_id of string
+  | Invalid_cause of Keeper_compaction_operation_identity.Cause.error
+  | Invalid_checkpoint of Keeper_checkpoint_ref.create_error
+  | Invalid_trigger of Compaction_trigger.decode_error
+  | Invalid_producer of Tool_invocation_ref.decode_error
+  | Invalid_evidence of Keeper_compaction_evidence.decode_error
+  | Invalid_turn_ref of string
+
+val to_json : Keeper_compaction_operation.event -> Yojson.Safe.t
+val of_json : Yojson.Safe.t -> (Keeper_compaction_operation.event, decode_error) result

--- a/test/keeper_compaction_operation/test_keeper_compaction_operation.ml
+++ b/test/keeper_compaction_operation/test_keeper_compaction_operation.ml
@@ -1,5 +1,5 @@
 module Operation = Keeper_compaction_operation
-module Decode_support = Keeper_compaction_operation_codec_support
+module Codec = Keeper_compaction_operation_codec
 module Operation_json = Keeper_compaction_operation_json
 module Reducer = Keeper_compaction_operation_reducer
 
@@ -310,41 +310,123 @@ let test_canonical_json_projection () =
      |> Yojson.Safe.Util.to_string)
 ;;
 
-let test_nested_decode_support () =
-  let projected = Operation_json.to_json (candidate_event ()) in
-  let payload = Yojson.Safe.Util.member "payload" projected in
-  let checkpoint_json = Yojson.Safe.Util.member "source_checkpoint" payload in
-  let evidence_json = Yojson.Safe.Util.member "evidence" payload in
-  let decoded_checkpoint =
-    Decode_support.checkpoint ~path:"payload.source_checkpoint" checkpoint_json
-    |> Result.get_ok
+let test_codec_roundtrip_all_events () =
+  let turn = Ids.Turn_ref.make ~trace_id:"trace-a" ~absolute_turn:8 in
+  let failed failure =
+    Operation.attempt_failed ~operation_id ~attempt_id ~failure
   in
-  let decoded_evidence =
-    Decode_support.evidence ~path:"payload.evidence" evidence_json
-    |> Result.get_ok
+  let reconcile reason =
+    Operation.commit_reconciliation_required
+      ~operation_id
+      ~attempt_id
+      ~source_checkpoint:source
+      ~candidate_checkpoint:candidate
+      ~evidence
+      ~reason
   in
-  Alcotest.(check bool)
-    "checkpoint identity"
-    true
-    (Keeper_checkpoint_ref.equal source decoded_checkpoint);
-  Alcotest.(check string)
-    "runtime identity"
-    "compact-runtime"
-    (Option.get decoded_evidence.selected_runtime_id)
+  let events =
+    [ request_event ()
+    ; Operation.requested
+        ~operation_id
+        ~keeper_name
+        ~source_checkpoint:source
+        ~trigger:(Compaction_trigger.Provider_overflow { limit_tokens = None })
+        ~cause
+        ~producer_invocation:None
+    ; attempt_event ()
+    ; candidate_event ()
+    ; failed (Operation.Pre_commit_failure cause)
+    ; failed
+        (Operation.Candidate_not_installed
+           { cause; observed_checkpoint = source })
+    ; reconcile Operation.Commit_durability_unknown
+    ; reconcile Operation.Transaction_outcome_unknown
+    ; Operation.compacted
+        ~operation_id
+        ~attempt_id
+        ~source_checkpoint:source
+        ~committed_checkpoint:candidate
+        ~evidence
+    ; Operation.reinjected
+        ~operation_id
+        ~adopted_checkpoint:candidate
+        ~adopting_turn:turn
+    ]
+  in
+  List.iter
+    (fun event ->
+       let json = Codec.to_json event in
+       match Codec.of_json json with
+       | Ok decoded ->
+         Alcotest.(check (testable Yojson.Safe.pp Yojson.Safe.equal))
+           "canonical roundtrip"
+           json
+           (Codec.to_json decoded)
+       | Error _ -> Alcotest.fail "canonical event was rejected")
+    events
 ;;
 
-let test_nested_decode_support_rejects_unknown_field () =
-  match
-    Decode_support.trigger
-      ~path:"payload.trigger"
-      (`Assoc [ "kind", `String "manual"; "unexpected", `Null ])
-  with
-  | Error
-      (Decode_support.Invalid_field
-         (Decode_support.Unknown_field
-            { path = "payload.trigger"; field = "unexpected" })) ->
-    ()
-  | Ok _ | Error _ -> Alcotest.fail "manual trigger accepted an unknown field"
+let replace_field name value = function
+  | `Assoc fields ->
+    `Assoc
+      (List.map
+         (fun (field, current) ->
+            if String.equal field name then field, value else field, current)
+         fields)
+  | json -> json
+;;
+
+let expect_field_error message expected json =
+  match Codec.of_json json with
+  | Error (Codec.Invalid_field actual) when actual = expected -> ()
+  | Ok _ | Error _ -> Alcotest.fail message
+;;
+
+let test_codec_rejects_nested_unknown_field () =
+  let json = Codec.to_json (request_event ()) in
+  let payload = Yojson.Safe.Util.member "payload" json in
+  let prepend name value = function
+    | `Assoc fields -> `Assoc ((name, value) :: fields)
+    | current -> current
+  in
+  let remove name = function
+    | `Assoc fields -> `Assoc (List.remove_assoc name fields)
+    | current -> current
+  in
+  let with_unknown name =
+    prepend name `Null
+  in
+  expect_field_error
+    "event accepted an unknown top field"
+    (Codec.Unknown_field { path = "$"; field = "unexpected_top" })
+    (with_unknown "unexpected_top" json);
+  expect_field_error
+    "event accepted a duplicate top field"
+    (Codec.Duplicate_field { path = "$"; field = "kind" })
+    (prepend "kind" (`String "requested") json);
+  expect_field_error
+    "event accepted a missing top field"
+    (Codec.Missing_field { path = "$"; field = "payload" })
+    (remove "payload" json);
+  expect_field_error
+    "event accepted a wrong-type top field"
+    (Codec.Wrong_type { path = "$"; field = "operation_id"; expected = "string" })
+    (replace_field "operation_id" (`Int 1) json);
+  let payload_unknown =
+    replace_field "payload" (with_unknown "unexpected_payload" payload) json
+  in
+  expect_field_error
+    "event accepted an unknown payload field"
+    (Codec.Unknown_field { path = "payload"; field = "unexpected_payload" })
+    payload_unknown;
+  let trigger =
+    `Assoc [ "kind", `String "manual"; "unexpected", `Null ]
+  in
+  let malformed = replace_field "payload" (replace_field "trigger" trigger payload) json in
+  expect_field_error
+    "event accepted an unknown trigger field"
+    (Codec.Unknown_field { path = "payload.trigger"; field = "unexpected" })
+    malformed
 ;;
 
 let () =
@@ -375,12 +457,12 @@ let () =
             `Quick
             test_canonical_json_projection
         ; Alcotest.test_case
-            "nested decode support"
+            "codec roundtrip all events"
             `Quick
-            test_nested_decode_support
+            test_codec_roundtrip_all_events
         ; Alcotest.test_case
-            "nested decode support rejects unknown field"
+            "codec rejects nested unknown field"
             `Quick
-            test_nested_decode_support_rejects_unknown_field
+            test_codec_rejects_nested_unknown_field
         ] )
     ]


### PR DESCRIPTION
## Summary
- expose one closed `Keeper_compaction_operation_codec` with canonical `to_json` and strict `of_json`
- keep decode support private after wiring the public codec
- enforce exact top envelope, event payload, and nested wire shapes
- roundtrip every event and sub-shape, including both failures, both reconciliation reasons, provider limit null, producer null, and reinjection Turn_ref

## Verification
- focused build: `test/keeper_compaction_operation/test_keeper_compaction_operation.exe`
- focused test: 10/10 green
- malformed proof: top unknown/duplicate/missing/wrong-type, payload unknown, nested trigger unknown
- `ocamlformat --check ...`
- `git diff --check`

## Stack
- base: #24922
- changed lines: +348/-37 (385 total)