### PR TITLE
refactor(keeper): bind compaction decisions to atomic units

### DIFF
--- a/lib/keeper/keeper_compaction_unit.ml
+++ b/lib/keeper/keeper_compaction_unit.ml
@@ -38,6 +38,7 @@ type structural_error =
       { message_index : int
       ; tool_use_id : string
       }
+[@@deriving show]
 
 type partition =
   { closed_prefix : closed_unit list

--- a/lib/keeper/keeper_compaction_unit.mli
+++ b/lib/keeper/keeper_compaction_unit.mli
@@ -42,6 +42,7 @@ type structural_error =
       { message_index : int
       ; tool_use_id : string
       }
+[@@deriving show]
 
 type partition =
   { closed_prefix : closed_unit list

--- a/lib/keeper/keeper_compaction_unit_plan.ml
+++ b/lib/keeper/keeper_compaction_unit_plan.ml
@@ -1,0 +1,245 @@
+module T = Agent_sdk.Types
+module Unit = Keeper_compaction_unit
+module Schema = Keeper_structured_output_schema
+module Int_map = Map.Make (Int)
+module String_set = Set.Make (String)
+
+type decision =
+  | Keep
+  | Drop
+  | Summarize of string
+
+type planned_unit =
+  | Kept of Unit.closed_unit
+  | Dropped
+  | Summarized of string
+
+type observation =
+  { summarized_units : int
+  ; summarized_source_messages : int
+  ; emitted_summary_messages : int
+  ; dropped_units : int
+  ; dropped_source_messages : int
+  }
+
+type t =
+  { source : Unit.partition
+  ; units : planned_unit list
+  ; observation : observation
+  }
+
+type decode_error =
+  | Expected_object
+  | Missing_field of string
+  | Duplicate_field of string
+  | Expected_array of string
+  | Expected_integer of string
+  | Expected_string of string
+  | Unknown_field of string
+  | Blank_summary of int
+  | Index_out_of_range of
+      { index : int
+      ; unit_count : int
+      }
+  | Duplicate_decision of int
+  | Missing_decision of int
+  | No_compaction
+[@@deriving show]
+
+let ( let* ) = Result.bind
+
+let exact_object ~allowed = function
+  | `Assoc fields as json ->
+    let allowed = String_set.of_list allowed in
+    let rec check seen = function
+      | [] -> Ok json
+      | (key, _) :: rest ->
+        if not (String_set.mem key allowed)
+        then Error (Unknown_field key)
+        else if String_set.mem key seen
+        then Error (Duplicate_field key)
+        else check (String_set.add key seen) rest
+    in
+    check String_set.empty fields
+  | _ -> Error Expected_object
+;;
+
+let field key = function
+  | `Assoc fields ->
+    (match
+       List.filter_map
+         (fun (candidate, value) ->
+            if String.equal key candidate then Some value else None)
+         fields
+     with
+     | [ value ] -> Ok value
+     | [] -> Error (Missing_field key)
+     | _ -> Error (Duplicate_field key))
+  | _ -> Error Expected_object
+;;
+
+let rec map_result f = function
+  | [] -> Ok []
+  | value :: rest ->
+    let* value = f value in
+    let* rest = map_result f rest in
+    Ok (value :: rest)
+;;
+
+let list_field key parse json =
+  let* value = field key json in
+  match value with
+  | `List values -> map_result parse values
+  | _ -> Error (Expected_array key)
+;;
+
+let int_list_field key =
+  list_field key (function
+    | `Int value -> Ok value
+    | _ -> Error (Expected_integer key))
+;;
+
+let summarized_entry json =
+  let index_key = Schema.compaction_unit_plan_field_unit_index in
+  let summary_key = Schema.compaction_unit_plan_field_unit_summary in
+  let* json = exact_object ~allowed:[ index_key; summary_key ] json in
+  let* index_json = field index_key json in
+  let* summary_json = field summary_key json in
+  let* index =
+    match index_json with
+    | `Int value -> Ok value
+    | _ -> Error (Expected_integer index_key)
+  in
+  match summary_json with
+  | `String value when String.trim value <> "" -> Ok (index, value)
+  | `String _ -> Error (Blank_summary index)
+  | _ -> Error (Expected_string summary_key)
+;;
+
+let unit_to_json index = function
+  | Unit.Ordinary_message message ->
+    `Assoc
+      [ "unit_index", `Int index
+      ; "unit_type", `String "ordinary_message"
+      ; "messages", `List [ Keeper_context_core.message_to_json message ]
+      ]
+  | Unit.Closed_tool_cycle messages ->
+    `Assoc
+      [ "unit_index", `Int index
+      ; "unit_type", `String "closed_tool_cycle"
+      ; "messages", `List (List.map Keeper_context_core.message_to_json messages)
+      ]
+;;
+
+let input_json source =
+  `Assoc
+    [ "unit_count", `Int (List.length source.Unit.closed_prefix)
+    ; "units", `List (List.mapi unit_to_json source.closed_prefix)
+    ]
+;;
+
+let add_decision ~unit_count decisions index decision =
+  if index < 0 || index >= unit_count
+  then Error (Index_out_of_range { index; unit_count })
+  else if Int_map.mem index decisions
+  then Error (Duplicate_decision index)
+  else Ok (Int_map.add index decision decisions)
+;;
+
+let rec add_indices ~unit_count decision decisions = function
+  | [] -> Ok decisions
+  | index :: rest ->
+    let* decisions = add_decision ~unit_count decisions index decision in
+    add_indices ~unit_count decision decisions rest
+;;
+
+let rec add_summaries ~unit_count decisions = function
+  | [] -> Ok decisions
+  | (index, summary) :: rest ->
+    let* decisions =
+      add_decision ~unit_count decisions index (Summarize summary)
+    in
+    add_summaries ~unit_count decisions rest
+;;
+
+let decode ~source json =
+  let unit_count = List.length source.Unit.closed_prefix in
+  let* json =
+    exact_object
+      ~allowed:
+        [ Schema.compaction_unit_plan_field_kept_indices
+        ; Schema.compaction_unit_plan_field_dropped_indices
+        ; Schema.compaction_unit_plan_field_summarized_units
+        ]
+      json
+  in
+  let* kept =
+    int_list_field Schema.compaction_unit_plan_field_kept_indices json
+  in
+  let* dropped =
+    int_list_field Schema.compaction_unit_plan_field_dropped_indices json
+  in
+  let* summarized =
+    list_field
+      Schema.compaction_unit_plan_field_summarized_units
+      summarized_entry
+      json
+  in
+  let* decisions = add_indices ~unit_count Keep Int_map.empty kept in
+  let* decisions = add_indices ~unit_count Drop decisions dropped in
+  let* decisions = add_summaries ~unit_count decisions summarized in
+  let unit_message_count = function
+    | Unit.Ordinary_message _ -> 1
+    | Unit.Closed_tool_cycle messages -> List.length messages
+  in
+  let rec bind index units_rev observation = function
+    | [] ->
+      if observation.summarized_units = 0 && observation.dropped_units = 0
+      then Error No_compaction
+      else Ok { source; units = List.rev units_rev; observation }
+    | unit :: rest ->
+      (match Int_map.find_opt index decisions with
+       | None -> Error (Missing_decision index)
+       | Some Keep ->
+         bind (index + 1) (Kept unit :: units_rev) observation rest
+       | Some Drop ->
+         let observation =
+           { observation with
+             dropped_units = observation.dropped_units + 1
+           ; dropped_source_messages =
+               observation.dropped_source_messages + unit_message_count unit
+           }
+         in
+         bind (index + 1) (Dropped :: units_rev) observation rest
+       | Some (Summarize summary) ->
+         let observation =
+           { observation with
+             summarized_units = observation.summarized_units + 1
+           ; summarized_source_messages =
+               observation.summarized_source_messages + unit_message_count unit
+           ; emitted_summary_messages = observation.emitted_summary_messages + 1
+           }
+         in
+         bind (index + 1) (Summarized summary :: units_rev) observation rest)
+  in
+  bind 0 []
+    { summarized_units = 0
+    ; summarized_source_messages = 0
+    ; emitted_summary_messages = 0
+    ; dropped_units = 0
+    ; dropped_source_messages = 0
+    }
+    source.closed_prefix
+;;
+
+let apply plan =
+  let messages = function
+    | Kept (Unit.Ordinary_message message) -> [ message ]
+    | Kept (Unit.Closed_tool_cycle messages) -> messages
+    | Dropped -> []
+    | Summarized summary -> [ T.text_message T.Assistant summary ]
+  in
+  List.concat_map messages plan.units @ plan.source.protected_suffix
+;;
+
+let observation plan = plan.observation

--- a/lib/keeper/keeper_compaction_unit_plan.mli
+++ b/lib/keeper/keeper_compaction_unit_plan.mli
@@ -1,0 +1,46 @@
+(** Immutable LLM decisions over {!Keeper_compaction_unit.partition}. *)
+
+type t
+
+type decode_error =
+  | Expected_object
+  | Missing_field of string
+  | Duplicate_field of string
+  | Expected_array of string
+  | Expected_integer of string
+  | Expected_string of string
+  | Unknown_field of string
+  | Blank_summary of int
+  | Index_out_of_range of
+      { index : int
+      ; unit_count : int
+      }
+  | Duplicate_decision of int
+  | Missing_decision of int
+  | No_compaction
+[@@deriving show]
+
+val input_json
+  :  Keeper_compaction_unit.partition
+  -> Yojson.Safe.t
+(** Canonical closed-prefix units supplied to the LLM. The protected suffix is
+    deliberately absent. *)
+
+val decode
+  :  source:Keeper_compaction_unit.partition
+  -> Yojson.Safe.t
+  -> (t, decode_error) result
+(** Bind exactly one keep, summarize, or drop decision to every source unit. *)
+
+val apply : t -> Agent_sdk.Types.message list
+(** Rebuild units chronologically and append the protected suffix exact. *)
+
+type observation =
+  { summarized_units : int
+  ; summarized_source_messages : int
+  ; emitted_summary_messages : int
+  ; dropped_units : int
+  ; dropped_source_messages : int
+  }
+
+val observation : t -> observation

--- a/test/test_keeper_compaction_unit.ml
+++ b/test/test_keeper_compaction_unit.ml
@@ -1,4 +1,5 @@
 module U = Masc.Keeper_compaction_unit
+module P = Masc.Keeper_compaction_unit_plan
 module T = Agent_sdk.Types
 
 let message role content : T.message =
@@ -146,6 +147,104 @@ let test_mixed_request_result_error () =
       ()
   | _ -> Alcotest.fail "expected typed mixed request/result"
 
+let plan_json ~kept ~dropped ~summarized =
+  let ints values = `List (List.map (fun value -> `Int value) values) in
+  let summary (unit_index, value) =
+    `Assoc [ "unit_index", `Int unit_index; "summary", `String value ]
+  in
+  `Assoc
+    [ "kept_indices", ints kept
+    ; "dropped_indices", ints dropped
+    ; "summarized_units", `List (List.map summary summarized)
+    ]
+
+let test_unit_plan_contract () =
+  let ordinary = text T.User "ordinary" in
+  let request = message T.Assistant [ use "closed" ] in
+  let result = message T.Tool [ result "closed" ] in
+  let open_request = message T.Assistant [ use "open" ] in
+  let progress = text T.Assistant "in-flight" in
+  let source = U.partition [ ordinary; request; result; open_request; progress ] |> require_ok in
+  let input = P.input_json source in
+  let units = Yojson.Safe.Util.(member "units" input |> to_list) in
+  Alcotest.(check int) "protected suffix excluded" 2 (List.length units);
+  check_exact "no must_keep heuristic" `Null
+    Yojson.Safe.Util.(member "must_keep" (List.nth units 1));
+  let decode ~kept ~dropped ~summarized =
+    P.decode ~source (plan_json ~kept ~dropped ~summarized)
+  in
+  let summarized_cycle =
+    decode ~kept:[ 0 ] ~dropped:[] ~summarized:[ 1, "cycle summary" ]
+    |> Result.get_ok
+  in
+  check_exact "closed pair summarized atomically"
+    [ ordinary; text T.Assistant "cycle summary"; open_request; progress ]
+    (P.apply summarized_cycle);
+  let observed = P.observation summarized_cycle in
+  Alcotest.(check int) "two source messages summarized" 2
+    observed.summarized_source_messages;
+  Alcotest.(check int) "one summary emitted" 1 observed.emitted_summary_messages;
+  let dropped_cycle =
+    decode ~kept:[ 0 ] ~dropped:[ 1 ] ~summarized:[] |> Result.get_ok
+  in
+  check_exact "closed pair dropped atomically"
+    [ ordinary; open_request; progress ]
+    (P.apply dropped_cycle);
+  let kept_cycle =
+    decode ~kept:[ 1 ] ~dropped:[] ~summarized:[ 0, "  exact summary  " ]
+    |> Result.get_ok
+  in
+  check_exact "summary bytes and kept cycle stay exact"
+    [ text T.Assistant "  exact summary  "; request; result; open_request; progress ]
+    (P.apply kept_cycle);
+  let disjoint_messages =
+    [ text T.User "zero"; request; result; text T.User "two" ]
+  in
+  let disjoint_source = U.partition disjoint_messages |> require_ok in
+  let disjoint =
+    P.decode ~source:disjoint_source
+      (plan_json ~kept:[ 1 ] ~dropped:[]
+         ~summarized:[ 0, "summary zero"; 2, "summary two" ])
+    |> Result.get_ok
+  in
+  check_exact "disjoint summaries retain chronology"
+    [ text T.Assistant "summary zero"; request; result; text T.Assistant "summary two" ]
+    (P.apply disjoint);
+  let is_error expected json =
+    match P.decode ~source json with
+    | Error actual -> expected actual
+    | Ok _ -> false
+  in
+  Alcotest.(check bool) "blank summary rejected" true
+    (is_error
+       (function P.Blank_summary 1 -> true | _ -> false)
+       (plan_json ~kept:[ 0 ] ~dropped:[] ~summarized:[ 1, " " ]));
+  Alcotest.(check bool) "duplicate decision rejected" true
+    (is_error
+       (function P.Duplicate_decision 0 -> true | _ -> false)
+       (plan_json ~kept:[ 0 ] ~dropped:[ 0 ] ~summarized:[ 1, "x" ]));
+  Alcotest.(check bool) "missing decision rejected" true
+    (is_error
+       (function P.Missing_decision 1 -> true | _ -> false)
+       (plan_json ~kept:[ 0 ] ~dropped:[] ~summarized:[]));
+  Alcotest.(check bool) "out-of-range rejected" true
+    (is_error
+       (function P.Index_out_of_range { index = 2; unit_count = 2 } -> true | _ -> false)
+       (plan_json ~kept:[ 0; 2 ] ~dropped:[ 1 ] ~summarized:[]));
+  Alcotest.(check bool) "all-kept no-op rejected" true
+    (is_error
+       (function P.No_compaction -> true | _ -> false)
+       (plan_json ~kept:[ 0; 1 ] ~dropped:[] ~summarized:[]));
+  Alcotest.(check bool) "unknown field rejected" true
+    (is_error
+       (function P.Unknown_field "repair" -> true | _ -> false)
+       (`Assoc
+          [ "kept_indices", `List [ `Int 0 ]
+          ; "dropped_indices", `List [ `Int 1 ]
+          ; "summarized_units", `List []
+          ; "repair", `Bool true
+          ]))
+
 let () =
   Alcotest.run "keeper_compaction_unit"
     [ ( "partition"
@@ -170,5 +269,6 @@ let () =
         ; Alcotest.test_case "duplicate use" `Quick test_duplicate_tool_use_error
         ; Alcotest.test_case "mixed request/result" `Quick
             test_mixed_request_result_error
+        ; Alcotest.test_case "typed unit plan" `Quick test_unit_plan_contract
         ] )
     ]


### PR DESCRIPTION
## Summary

- bind LLM keep, summarize, or drop decisions to the exact immutable Keeper_compaction_unit partition
- preserve the open/in-flight protected suffix inside the opaque source-bound plan and never expose it to LLM rewrite
- allow a closed ToolUse/ToolResult cycle to be kept exact, summarized to one ordinary Assistant message, or dropped as one atomic unit
- preserve chronology with one summary per source unit; disjoint summaries no longer require a fabricated contiguous run
- reject unknown/duplicate/missing fields, blank summaries, duplicate/out-of-range/missing decisions, and no-op plans with typed errors and no repair fallback
- observe unit counts and source-message counts separately so a multi-message closed cycle is not reported as one summarized message

This is replacement slice 2 for #24875 and stacks on #24921. It is an inert typed foundation; the next Draft hard-cuts the old global-summary parser/schema and activates this contract in the LLM summarizer and compact policy. #24875 remains open for comparison.

The opaque plan retains the exact immutable partition by structural sharing. apply accepts only the plan, so a caller cannot combine a decision set with a stale or mismatched protected suffix.

Oversized-input hierarchical batching is intentionally not implemented here and remains the next worker prerequisite after activation.

## Scope

- 5 files
- 393 additions

## Verification

- git diff --check
- ocamlformat --check on all touched OCaml files
- scripts/dune-local.sh build test/test_keeper_compaction_unit.exe
- test_keeper_compaction_unit: 13/13 passed
- risk-pattern scan: no Obj.magic, ref/mutable, stub, assert false, raise, blocking Unix, or timeout path added
