### PR TITLE
feat(keeper): terminalize superseded compactions

### DIFF
--- a/lib/keeper_compaction_operation/keeper_compaction_operation.ml
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation.ml
@@ -28,12 +28,18 @@ type candidate =
   ; evidence : Keeper_compaction_evidence.t
   }
 
+type supersession =
+  { attempt_id : Attempt_id.t
+  ; observed_checkpoint : Keeper_checkpoint_ref.t option
+  }
+
 type event_view =
   | Requested of request
   | Attempt_started of Attempt_id.t
   | Candidate_prepared of candidate
   | Attempt_failed of Attempt_id.t * attempt_failure
   | Commit_reconciliation_required of candidate * reconciliation_reason
+  | Source_superseded of supersession
   | Compacted of candidate
   | Reinjected of Keeper_checkpoint_ref.t * Ids.Turn_ref.t
 
@@ -81,6 +87,12 @@ let commit_reconciliation_required ~operation_id ~attempt_id ~source_checkpoint
   ; view =
       Commit_reconciliation_required
         (candidate ~attempt_id ~source_checkpoint ~candidate_checkpoint ~evidence, reason)
+  }
+;;
+
+let source_superseded ~operation_id ~attempt_id ~observed_checkpoint =
+  { operation_id
+  ; view = Source_superseded { attempt_id; observed_checkpoint }
   }
 ;;
 

--- a/lib/keeper_compaction_operation/keeper_compaction_operation.mli
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation.mli
@@ -30,12 +30,18 @@ type candidate =
   ; evidence : Keeper_compaction_evidence.t
   }
 
+type supersession =
+  { attempt_id : Attempt_id.t
+  ; observed_checkpoint : Keeper_checkpoint_ref.t option
+  }
+
 type event_view =
   | Requested of request
   | Attempt_started of Attempt_id.t
   | Candidate_prepared of candidate
   | Attempt_failed of Attempt_id.t * attempt_failure
   | Commit_reconciliation_required of candidate * reconciliation_reason
+  | Source_superseded of supersession
   | Compacted of candidate
   | Reinjected of Keeper_checkpoint_ref.t * Ids.Turn_ref.t
 
@@ -71,6 +77,11 @@ val commit_reconciliation_required :
   candidate_checkpoint:Keeper_checkpoint_ref.t ->
   evidence:Keeper_compaction_evidence.t ->
   reason:reconciliation_reason ->
+  event
+val source_superseded :
+  operation_id:Operation_id.t ->
+  attempt_id:Attempt_id.t ->
+  observed_checkpoint:Keeper_checkpoint_ref.t option ->
   event
 val compacted :
   operation_id:Operation_id.t ->

--- a/lib/keeper_compaction_operation_codec/keeper_compaction_operation_codec.ml
+++ b/lib/keeper_compaction_operation_codec/keeper_compaction_operation_codec.ml
@@ -143,6 +143,26 @@ let decode_reinjected ~operation_id payload =
   Ok (Operation.reinjected ~operation_id ~adopted_checkpoint ~adopting_turn)
 ;;
 
+let decode_source_superseded ~operation_id payload =
+  let path = "payload" in
+  let fields = [ "attempt_id"; "observed_checkpoint" ] in
+  let* values = Support.exact_object ~path ~allowed:fields ~required:fields payload in
+  let* attempt_id = field ~path "attempt_id" Support.attempt_id values in
+  let* observed_json = Support.required_field ~path "observed_checkpoint" values in
+  let* observed_checkpoint =
+    match observed_json with
+    | `Null -> Ok None
+    | json ->
+      Support.checkpoint ~path:"payload.observed_checkpoint" json
+      |> Result.map Option.some
+  in
+  Ok
+    (Operation.source_superseded
+       ~operation_id
+       ~attempt_id
+       ~observed_checkpoint)
+;;
+
 let of_json json =
   let path = "$" in
   let fields = [ "kind"; "operation_id"; "payload" ] in
@@ -168,6 +188,7 @@ let of_json json =
   | "attempt_failed" -> decode_attempt_failed ~operation_id payload
   | "commit_reconciliation_required" ->
     decode_reconciliation ~operation_id payload
+  | "source_superseded" -> decode_source_superseded ~operation_id payload
   | "compacted" ->
     decode_candidate
       ~operation_id

--- a/lib/keeper_compaction_operation_json/keeper_compaction_operation_json.ml
+++ b/lib/keeper_compaction_operation_json/keeper_compaction_operation_json.ml
@@ -87,6 +87,17 @@ let to_json event =
       "commit_reconciliation_required"
       (candidate ~checkpoint_field:"candidate_checkpoint" value
        @ [ "reason", `String reason ])
+  | Source_superseded supersession ->
+    envelope
+      event
+      "source_superseded"
+      [ ( "attempt_id"
+        , `String (Operation.Attempt_id.to_string supersession.attempt_id) )
+      ; ( "observed_checkpoint"
+        , match supersession.observed_checkpoint with
+          | Some value -> checkpoint value
+          | None -> `Null )
+      ]
   | Compacted value ->
     envelope
       event

--- a/lib/keeper_compaction_operation_reducer/keeper_compaction_operation_reducer.ml
+++ b/lib/keeper_compaction_operation_reducer/keeper_compaction_operation_reducer.ml
@@ -7,6 +7,7 @@ type phase =
   | Reconciliation_pending
   | Commit_complete
   | Adopted
+  | Superseded
 
 type progress =
   | Pending
@@ -16,6 +17,15 @@ type progress =
   | Committed of Operation.candidate
   | Adopted_state of
       Operation.candidate * Keeper_checkpoint_ref.t * Ids.Turn_ref.t
+
+  | Superseded_state of superseded_state
+
+and superseded_state =
+  { attempt_id : Operation.Attempt_id.t
+  ; candidate : Operation.candidate option
+  ; committed : bool
+  ; observed_checkpoint : Keeper_checkpoint_ref.t option
+  }
 
 type state =
   { operation_id : Operation.Operation_id.t
@@ -39,6 +49,7 @@ type snapshot =
   ; committed_checkpoint : Keeper_checkpoint_ref.t option
   ; adopted_checkpoint : Keeper_checkpoint_ref.t option
   ; adopting_turn : Ids.Turn_ref.t option
+  ; superseded_by_checkpoint : Keeper_checkpoint_ref.t option
   }
 
 type transition_error =
@@ -49,6 +60,9 @@ type transition_error =
   | Source_mismatch
   | Candidate_mismatch
   | Reinjection_identity_mismatch
+  | Supersession_not_observed
+  | Supersession_candidate_installed
+  | Supersession_trace_mismatch
 
 let phase state =
   match state.progress with
@@ -58,28 +72,42 @@ let phase state =
   | Reconciling _ -> Reconciliation_pending
   | Committed _ -> Commit_complete
   | Adopted_state _ -> Adopted
+  | Superseded_state _ -> Superseded
 ;;
 
 let projection = function
-  | Pending -> None, None, None, None, None, None, None
-  | Running attempt -> Some attempt, None, None, None, None, None, None
+  | Pending -> None, None, None, None, None, None, None, None
+  | Running attempt ->
+    Some attempt, None, None, None, None, None, None, None
   | Prepared value ->
     Some value.attempt_id, Some value.candidate_checkpoint, Some value.evidence,
-    None, None, None, None
+    None, None, None, None, None
   | Reconciling (value, reason) ->
     Some value.attempt_id, Some value.candidate_checkpoint, Some value.evidence,
-    Some reason, None, None, None
+    Some reason, None, None, None, None
   | Committed value ->
     Some value.attempt_id, Some value.candidate_checkpoint, Some value.evidence,
-    None, Some value.candidate_checkpoint, None, None
+    None, Some value.candidate_checkpoint, None, None, None
   | Adopted_state (value, checkpoint, turn) ->
     Some value.attempt_id, Some value.candidate_checkpoint, Some value.evidence,
-    None, Some value.candidate_checkpoint, Some checkpoint, Some turn
+    None, Some value.candidate_checkpoint, Some checkpoint, Some turn, None
+  | Superseded_state superseded ->
+    let candidate_checkpoint, evidence =
+      match superseded.candidate with
+      | Some value -> Some value.candidate_checkpoint, Some value.evidence
+      | None -> None, None
+    in
+    let committed_checkpoint =
+      if superseded.committed then candidate_checkpoint else None
+    in
+    Some superseded.attempt_id, candidate_checkpoint, evidence, None,
+    committed_checkpoint, None, None, superseded.observed_checkpoint
 ;;
 
 let snapshot state =
   let attempt_id, candidate_checkpoint, evidence, reconciliation_reason,
-      committed_checkpoint, adopted_checkpoint, adopting_turn =
+      committed_checkpoint, adopted_checkpoint, adopting_turn,
+      superseded_by_checkpoint =
     projection state.progress
   in
   { operation_id = state.operation_id
@@ -96,6 +124,7 @@ let snapshot state =
   ; committed_checkpoint
   ; adopted_checkpoint
   ; adopting_turn
+  ; superseded_by_checkpoint
   }
 ;;
 
@@ -123,6 +152,38 @@ let same_candidate
 
 let close_attempt state attempt_id =
   { state with progress = Pending; closed_attempts = attempt_id :: state.closed_attempts }
+;;
+
+let validate_supersession
+      (state : state)
+      (candidate : Operation.candidate option)
+      ~source_may_match
+      (observed_checkpoint : Keeper_checkpoint_ref.t option)
+  =
+  match observed_checkpoint with
+  | None -> Ok ()
+  | Some observed_checkpoint ->
+    if
+      not
+        (Keeper_id.Trace_id.equal
+           state.request.source_checkpoint.trace_id
+           observed_checkpoint.trace_id)
+    then Error Supersession_trace_mismatch
+    else if
+      not source_may_match
+      &&
+      Keeper_checkpoint_ref.equal
+        state.request.source_checkpoint
+        observed_checkpoint
+    then Error Supersession_not_observed
+    else
+      (match candidate with
+       | Some value
+         when Keeper_checkpoint_ref.equal
+                value.candidate_checkpoint
+                observed_checkpoint ->
+         Error Supersession_candidate_installed
+       | Some _ | None -> Ok ())
 ;;
 
 let apply current event =
@@ -183,9 +244,75 @@ let apply current event =
         same_candidate expected actual
         |> Result.map (fun () ->
           { state with progress = Reconciling (expected, reason) })
+      | Running expected, Operation.Source_superseded supersession ->
+        if not (Operation.Attempt_id.equal expected supersession.attempt_id)
+        then Error Attempt_mismatch
+        else
+          validate_supersession
+            state
+            None
+            ~source_may_match:false
+            supersession.observed_checkpoint
+          |> Result.map (fun () ->
+            { state with
+              progress =
+                Superseded_state
+                  { attempt_id = expected
+                  ; candidate = None
+                  ; committed = false
+                  ; observed_checkpoint = supersession.observed_checkpoint
+                  }
+            })
+      | (Prepared expected | Reconciling (expected, _)),
+        Operation.Source_superseded supersession ->
+        if
+          not
+            (Operation.Attempt_id.equal
+               expected.attempt_id
+               supersession.attempt_id)
+        then Error Attempt_mismatch
+        else
+          validate_supersession
+            state
+            (Some expected)
+            ~source_may_match:false
+            supersession.observed_checkpoint
+          |> Result.map (fun () ->
+            { state with
+              progress =
+                Superseded_state
+                  { attempt_id = expected.attempt_id
+                  ; candidate = Some expected
+                  ; committed = false
+                  ; observed_checkpoint = supersession.observed_checkpoint
+                  }
+            })
       | (Prepared expected | Reconciling (expected, _)), Operation.Compacted actual ->
         same_candidate expected actual
         |> Result.map (fun () -> { state with progress = Committed expected })
+      | Committed expected, Operation.Source_superseded supersession ->
+        if
+          not
+            (Operation.Attempt_id.equal
+               expected.attempt_id
+               supersession.attempt_id)
+        then Error Attempt_mismatch
+        else
+          validate_supersession
+            state
+            (Some expected)
+            ~source_may_match:true
+            supersession.observed_checkpoint
+          |> Result.map (fun () ->
+            { state with
+              progress =
+                Superseded_state
+                  { attempt_id = expected.attempt_id
+                  ; candidate = Some expected
+                  ; committed = true
+                  ; observed_checkpoint = supersession.observed_checkpoint
+                  }
+            })
       | Committed value, Operation.Reinjected (checkpoint, turn) ->
         let trace =
           Keeper_id.Trace_id.to_string value.candidate_checkpoint.trace_id

--- a/lib/keeper_compaction_operation_reducer/keeper_compaction_operation_reducer.mli
+++ b/lib/keeper_compaction_operation_reducer/keeper_compaction_operation_reducer.mli
@@ -9,6 +9,7 @@ type phase =
   | Reconciliation_pending
   | Commit_complete
   | Adopted
+  | Superseded
 
 type state
 type snapshot =
@@ -26,6 +27,7 @@ type snapshot =
   ; committed_checkpoint : Keeper_checkpoint_ref.t option
   ; adopted_checkpoint : Keeper_checkpoint_ref.t option
   ; adopting_turn : Ids.Turn_ref.t option
+  ; superseded_by_checkpoint : Keeper_checkpoint_ref.t option
   }
 
 type transition_error =
@@ -36,6 +38,9 @@ type transition_error =
   | Source_mismatch
   | Candidate_mismatch
   | Reinjection_identity_mismatch
+  | Supersession_not_observed
+  | Supersession_candidate_installed
+  | Supersession_trace_mismatch
 
 val phase : state -> phase
 val snapshot : state -> snapshot

--- a/test/keeper_compaction_operation/test_keeper_compaction_operation.ml
+++ b/test/keeper_compaction_operation/test_keeper_compaction_operation.ml
@@ -18,6 +18,7 @@ let checkpoint bytes turn_count =
 ;;
 let source = checkpoint "before" 7
 let candidate = checkpoint "after" 7
+let advanced = checkpoint "advanced" 8
 let evidence : Keeper_compaction_evidence.t =
   { selected_runtime_id = Some "compact-runtime"
   ; before_checkpoint_bytes = 100
@@ -238,6 +239,128 @@ let test_reducer_reconciliation () =
     (snapshot.reconciliation_reason = Some Operation.Commit_durability_unknown)
 ;;
 
+let test_reducer_source_superseded () =
+  let superseded =
+    Operation.source_superseded
+      ~operation_id
+      ~attempt_id
+      ~observed_checkpoint:(Some advanced)
+  in
+  let before_candidate =
+    ok (Reducer.fold [ request_event (); attempt_event (); superseded ])
+  in
+  let before_snapshot = Reducer.snapshot before_candidate in
+  Alcotest.(check bool)
+    "preparation-free supersession is terminal"
+    true
+    (before_snapshot.phase = Reducer.Superseded);
+  Alcotest.(check bool)
+    "observed checkpoint retained"
+    true
+    (Option.exists
+       (Keeper_checkpoint_ref.equal advanced)
+       before_snapshot.superseded_by_checkpoint);
+  let source_removed =
+    Operation.source_superseded
+      ~operation_id
+      ~attempt_id
+      ~observed_checkpoint:None
+  in
+  let removed =
+    ok (Reducer.fold [ request_event (); attempt_event (); source_removed ])
+  in
+  let removed_snapshot = Reducer.snapshot removed in
+  Alcotest.(check bool)
+    "missing exact source is terminal"
+    true
+    (removed_snapshot.phase = Reducer.Superseded
+     && Option.is_none removed_snapshot.superseded_by_checkpoint);
+  let after_candidate =
+    ok
+      (Reducer.fold
+         [ request_event (); attempt_event (); candidate_event (); superseded ])
+  in
+  let after_snapshot = Reducer.snapshot after_candidate in
+  Alcotest.(check bool)
+    "prepared candidate remains observable"
+    true
+    (Option.exists
+       (Keeper_checkpoint_ref.equal candidate)
+       after_snapshot.candidate_checkpoint);
+  let compacted =
+    Operation.compacted
+      ~operation_id
+      ~attempt_id
+      ~source_checkpoint:source
+      ~committed_checkpoint:candidate
+      ~evidence
+  in
+  let after_commit =
+    ok
+      (Reducer.fold
+         [ request_event ()
+         ; attempt_event ()
+         ; candidate_event ()
+         ; compacted
+         ; superseded
+         ])
+  in
+  let committed_snapshot = Reducer.snapshot after_commit in
+  Alcotest.(check bool)
+    "superseded operation retains prior commit"
+    true
+    (Option.exists
+       (Keeper_checkpoint_ref.equal candidate)
+       committed_snapshot.committed_checkpoint);
+  match Reducer.apply (Some after_candidate) (attempt_event ()) with
+  | Error (Reducer.Invalid_transition (Some Reducer.Superseded)) -> ()
+  | Ok _ | Error _ -> Alcotest.fail "superseded operation restarted"
+;;
+
+let test_reducer_rejects_false_supersession () =
+  let running = ok (Reducer.fold [ request_event (); attempt_event () ]) in
+  let event observed_checkpoint =
+    Operation.source_superseded
+      ~operation_id
+      ~attempt_id
+      ~observed_checkpoint:(Some observed_checkpoint)
+  in
+  (match Reducer.apply (Some running) (event source) with
+   | Error Reducer.Supersession_not_observed -> ()
+   | Ok _ | Error _ -> Alcotest.fail "source equality was called superseded");
+  let prepared = ok (Reducer.apply (Some running) (candidate_event ())) in
+  (match Reducer.apply (Some prepared) (event candidate) with
+   | Error Reducer.Supersession_candidate_installed -> ()
+   | Ok _ | Error _ -> Alcotest.fail "installed candidate was called superseded");
+  let committed =
+    ok
+      (Reducer.apply
+         (Some prepared)
+         (Operation.compacted
+            ~operation_id
+            ~attempt_id
+            ~source_checkpoint:source
+            ~committed_checkpoint:candidate
+            ~evidence))
+  in
+  (match Reducer.apply (Some committed) (event source) with
+   | Ok state when Reducer.phase state = Reducer.Superseded -> ()
+   | Ok _ | Error _ ->
+     Alcotest.fail "post-commit source restoration was not superseded");
+  let other_trace = ok (Keeper_id.Trace_id.of_string "trace-b") in
+  let other =
+    ok
+      (Keeper_checkpoint_ref.create
+         ~trace_id:other_trace
+         ~generation:2
+         ~turn_count:8
+         ~canonical_checkpoint_bytes:"other")
+  in
+  match Reducer.apply (Some running) (event other) with
+  | Error Reducer.Supersession_trace_mismatch -> ()
+  | Ok _ | Error _ -> Alcotest.fail "cross-trace supersession was accepted"
+;;
+
 let test_reducer_invalid_transition () =
   match Reducer.fold [ request_event (); candidate_event () ] with
   | Error (Reducer.Invalid_transition (Some Reducer.Request_pending)) -> ()
@@ -267,6 +390,10 @@ let test_canonical_json_projection () =
         ~candidate_checkpoint:candidate
         ~evidence
         ~reason:Operation.Commit_durability_unknown
+    ; Operation.source_superseded
+        ~operation_id
+        ~attempt_id
+        ~observed_checkpoint:(Some advanced)
     ; Operation.compacted
         ~operation_id
         ~attempt_id
@@ -295,6 +422,7 @@ let test_canonical_json_projection () =
     ; "attempt_failed"
     ; "attempt_failed"
     ; "commit_reconciliation_required"
+    ; "source_superseded"
     ; "compacted"
     ; "reinjected"
     ]
@@ -341,6 +469,10 @@ let test_codec_roundtrip_all_events () =
            { cause; observed_checkpoint = source })
     ; reconcile Operation.Commit_durability_unknown
     ; reconcile Operation.Transaction_outcome_unknown
+    ; Operation.source_superseded
+        ~operation_id
+        ~attempt_id
+        ~observed_checkpoint:(Some advanced)
     ; Operation.compacted
         ~operation_id
         ~attempt_id
@@ -448,6 +580,14 @@ let () =
             "reducer reconciliation"
             `Quick
             test_reducer_reconciliation
+        ; Alcotest.test_case
+            "reducer source superseded"
+            `Quick
+            test_reducer_source_superseded
+        ; Alcotest.test_case
+            "reducer rejects false supersession"
+            `Quick
+            test_reducer_rejects_false_supersession
         ; Alcotest.test_case
             "reducer invalid transition"
             `Quick


### PR DESCRIPTION
## Why

A non-blocking Keeper may advance, replace, or explicitly remove its canonical checkpoint while an asynchronous compaction works from an older exact source. Retrying that immutable operation would pin it to a source that can no longer become current. A candidate can also commit and then be replaced before any turn adopts it.

## Change

- add typed `Source_superseded` operation fact and terminal `Superseded` phase
- accept supersession before candidate preparation, after preparation/reconciliation, or after commit-before-reinjection
- represent an explicitly absent source as `observed_checkpoint = null`; I/O/parse faults do not use this terminal path
- retain the exact observed checkpoint, prepared candidate evidence, and prior committed checkpoint when applicable
- reject false supersession when the observed ref is the unchanged source before commit, the installed candidate, or another trace
- extend canonical JSON projection and strict codec atomically

## Proof

- `ocamlformat --check` on touched files
- `scripts/dune-local.sh build test/keeper_compaction_operation/test_keeper_compaction_operation.exe`
- focused executable: 12/12 passed
- 341 changed lines; stacked on #24923
