### PR TITLE
feat(keeper): add compaction journal record codec

### DIFF
--- a/lib/keeper_compaction_operation_record/dune
+++ b/lib/keeper_compaction_operation_record/dune
@@ -1,0 +1,11 @@
+(include_subdirs no)
+
+(library
+ (name masc_keeper_compaction_operation_record)
+ (public_name masc.keeper_compaction_operation_record)
+ (wrapped false)
+ (modules keeper_compaction_operation_record)
+ (libraries
+  masc.keeper_compaction_operation
+  masc.keeper_compaction_operation_codec
+  yojson))

--- a/lib/keeper_compaction_operation_record/keeper_compaction_operation_record.ml
+++ b/lib/keeper_compaction_operation_record/keeper_compaction_operation_record.ml
@@ -1,0 +1,116 @@
+module Codec = Keeper_compaction_operation_codec
+
+module Cursor = struct
+  type t = int
+  type error = Negative of int
+  let zero = 0
+  let of_int value = if value < 0 then Error (Negative value) else Ok value
+  let to_int value = value
+end
+
+type row =
+  { recorded_at : float
+  ; start_cursor : Cursor.t
+  ; end_cursor : Cursor.t
+  ; event : Keeper_compaction_operation.event
+  }
+
+type envelope_error =
+  | Expected_object
+  | Unknown_field of string
+  | Duplicate_field of string
+  | Missing_field of string
+  | Invalid_recorded_at
+  | Invalid_event of Codec.decode_error
+
+type issue =
+  | Incomplete_tail
+  | Malformed_json of string
+  | Invalid_envelope of envelope_error
+
+type decode_error =
+  { row_number : int option
+  ; start_cursor : Cursor.t
+  ; end_cursor : Cursor.t
+  ; issue : issue
+  }
+
+let ( let* ) = Result.bind
+
+let required_field name fields =
+  match List.filter (fun (field, _) -> String.equal field name) fields with
+  | [] -> Error (Missing_field name)
+  | [ _, value ] -> Ok value
+  | _ -> Error (Duplicate_field name)
+;;
+
+let decode_envelope = function
+  | `Assoc fields ->
+    let* () =
+      match
+        List.find_opt
+          (fun (name, _) ->
+             not (String.equal name "recorded_at" || String.equal name "event"))
+          fields
+      with
+      | None -> Ok ()
+      | Some (name, _) -> Error (Unknown_field name)
+    in
+    let* recorded_json = required_field "recorded_at" fields in
+    let* recorded_at =
+      match recorded_json with
+      | `Float value when Float.is_finite value -> Ok value
+      | _ -> Error Invalid_recorded_at
+    in
+    let* event_json = required_field "event" fields in
+    Codec.of_json event_json
+    |> Result.map_error (fun error -> Invalid_event error)
+    |> Result.map (fun event -> recorded_at, event)
+  | _ -> Error Expected_object
+;;
+
+let encode ~recorded_at event =
+  if not (Float.is_finite recorded_at)
+  then Error Invalid_recorded_at
+  else
+    Ok
+      (`Assoc
+         [ "recorded_at", `Float recorded_at; "event", Codec.to_json event ]
+       |> Yojson.Safe.to_string
+       |> fun value -> value ^ "\n")
+;;
+
+let decode_rows ~from ~row_number bytes =
+  let base = Cursor.to_int from in
+  let length = String.length bytes in
+  let locate number start_cursor end_cursor issue =
+    Error { row_number = number; start_cursor; end_cursor; issue }
+  in
+  let rec loop position number rows =
+    if position = length
+    then Ok (List.rev rows)
+    else
+      match String.index_from_opt bytes position '\n' with
+      | None ->
+        locate number (base + position) (base + length) Incomplete_tail
+      | Some newline ->
+        let start_cursor = base + position in
+        let end_cursor = base + newline + 1 in
+        let payload = String.sub bytes position (newline - position) in
+        (match
+           try Ok (Yojson.Safe.from_string payload) with
+           | Yojson.Json_error detail -> Error (Malformed_json detail)
+         with
+         | Error issue -> locate number start_cursor end_cursor issue
+         | Ok json ->
+           (match decode_envelope json with
+            | Error error ->
+              locate number start_cursor end_cursor (Invalid_envelope error)
+            | Ok (recorded_at, event) ->
+              loop
+                (newline + 1)
+                (Option.map succ number)
+                ({ recorded_at; start_cursor; end_cursor; event } :: rows)))
+  in
+  loop 0 row_number []
+;;

--- a/lib/keeper_compaction_operation_record/keeper_compaction_operation_record.mli
+++ b/lib/keeper_compaction_operation_record/keeper_compaction_operation_record.mli
@@ -1,0 +1,49 @@
+(** Closed JSONL record codec around one typed compaction operation event. *)
+
+module Cursor : sig
+  type t
+  type error = Negative of int
+  val zero : t
+  val of_int : int -> (t, error) result
+  val to_int : t -> int
+end
+
+type row =
+  { recorded_at : float
+  ; start_cursor : Cursor.t
+  ; end_cursor : Cursor.t
+  ; event : Keeper_compaction_operation.event
+  }
+
+type envelope_error =
+  | Expected_object
+  | Unknown_field of string
+  | Duplicate_field of string
+  | Missing_field of string
+  | Invalid_recorded_at
+  | Invalid_event of Keeper_compaction_operation_codec.decode_error
+
+type issue =
+  | Incomplete_tail
+  | Malformed_json of string
+  | Invalid_envelope of envelope_error
+
+type decode_error =
+  { row_number : int option
+  ; start_cursor : Cursor.t
+  ; end_cursor : Cursor.t
+  ; issue : issue
+  }
+
+val encode :
+  recorded_at:float ->
+  Keeper_compaction_operation.event ->
+  (string, envelope_error) result
+(** Returns exactly one newline-terminated JSONL row. *)
+
+val decode_rows :
+  from:Cursor.t ->
+  row_number:int option ->
+  string ->
+  (row list, decode_error) result
+(** [row_number] is [Some] only when the caller owns the complete prefix. *)

--- a/test/keeper_compaction_operation_record/dune
+++ b/test/keeper_compaction_operation_record/dune
@@ -1,0 +1,11 @@
+(test
+ (name test_keeper_compaction_operation_record)
+ (libraries
+ alcotest
+  masc.compaction_trigger
+  masc.keeper_checkpoint_ref
+  masc.keeper_compaction_operation
+  masc.keeper_compaction_operation_codec
+  masc.keeper_compaction_operation_record
+  masc.keeper_registry
+  yojson))

--- a/test/keeper_compaction_operation_record/test_keeper_compaction_operation_record.ml
+++ b/test/keeper_compaction_operation_record/test_keeper_compaction_operation_record.ml
@@ -1,0 +1,142 @@
+module Operation = Keeper_compaction_operation
+module Record = Keeper_compaction_operation_record
+
+let ok = function
+  | Ok value -> value
+  | Error _ -> Alcotest.fail "fixture construction failed"
+;;
+
+let checkpoint_option_equal left right =
+  match left, right with
+  | None, None -> true
+  | Some left, Some right -> Keeper_checkpoint_ref.equal left right
+  | None, Some _ | Some _, None -> false
+;;
+
+let keeper_name = ok (Keeper_id.Keeper_name.of_string "record-keeper")
+let trace_id = ok (Keeper_id.Trace_id.of_string "record-trace")
+
+let source =
+  ok
+    (Keeper_checkpoint_ref.create
+       ~trace_id
+       ~generation:1
+       ~turn_count:3
+       ~canonical_checkpoint_bytes:"source")
+;;
+
+let event =
+  let operation_id =
+    ok
+      (Operation.Operation_id.of_string
+         "00000000-0000-4000-8000-000000000001")
+  in
+  Operation.requested
+    ~operation_id
+    ~keeper_name
+    ~source_checkpoint:source
+    ~trigger:Compaction_trigger.Manual
+    ~cause:(ok (Operation.Cause.of_string "manual compaction"))
+    ~producer_invocation:None
+;;
+
+let test_roundtrip_and_cursor () =
+  let encoded = ok (Record.encode ~recorded_at:(-1.25) event) in
+  let from = ok (Record.Cursor.of_int 17) in
+  match Record.decode_rows ~from ~row_number:None encoded with
+  | Ok [ row ] ->
+    Alcotest.(check (float 0.0)) "timestamp" (-1.25) row.recorded_at;
+    Alcotest.(check int) "start" 17 (Record.Cursor.to_int row.start_cursor);
+    Alcotest.(check int)
+      "newline end"
+      (17 + String.length encoded)
+      (Record.Cursor.to_int row.end_cursor);
+    Alcotest.(check bool)
+      "event identity"
+      true
+      (Operation.Operation_id.equal
+         (Operation.operation_id row.event)
+         (Operation.operation_id event))
+  | _ -> Alcotest.fail "canonical row did not decode"
+;;
+
+let test_closed_envelope_and_finite_time () =
+  (match Record.encode ~recorded_at:Float.nan event with
+   | Error Record.Invalid_recorded_at -> ()
+   | _ -> Alcotest.fail "non-finite timestamp encoded");
+  let malformed =
+    `Assoc
+      [ "recorded_at", `Float 1.0
+      ; "event", Keeper_compaction_operation_codec.to_json event
+      ; "extra", `Null
+      ]
+    |> Yojson.Safe.to_string
+    |> fun value -> value ^ "\n"
+  in
+  match Record.decode_rows ~from:Record.Cursor.zero ~row_number:(Some 1) malformed with
+  | Error
+      { row_number = Some 1
+      ; issue = Record.Invalid_envelope (Record.Unknown_field "extra")
+      ; _
+      } ->
+    ()
+  | _ -> Alcotest.fail "unknown envelope field was accepted"
+;;
+
+let test_incomplete_tail_is_located () =
+  match
+    Record.decode_rows
+      ~from:(ok (Record.Cursor.of_int 8))
+      ~row_number:None
+      "{}"
+  with
+  | Error
+      { row_number = None
+      ; start_cursor
+      ; end_cursor
+      ; issue = Record.Incomplete_tail
+      } ->
+    Alcotest.(check int) "start" 8 (Record.Cursor.to_int start_cursor);
+    Alcotest.(check int) "end" 10 (Record.Cursor.to_int end_cursor)
+  | _ -> Alcotest.fail "incomplete tail was accepted"
+;;
+
+let test_superseded_roundtrip () =
+  let attempt_id =
+    ok
+      (Operation.Attempt_id.of_string
+         "00000000-0000-4000-8000-000000000011")
+  in
+  List.iter
+    (fun observed_checkpoint ->
+       let superseded =
+         Operation.source_superseded
+           ~operation_id:(Operation.operation_id event)
+           ~attempt_id
+           ~observed_checkpoint
+       in
+       let encoded = ok (Record.encode ~recorded_at:1.0 superseded) in
+       match Record.decode_rows ~from:Record.Cursor.zero ~row_number:(Some 1) encoded with
+       | Ok [ row ] ->
+         (match Operation.view row.event with
+          | Operation.Source_superseded actual ->
+            Alcotest.(check bool)
+              "exact optional checkpoint"
+              true
+              (checkpoint_option_equal actual.observed_checkpoint observed_checkpoint)
+          | _ -> Alcotest.fail "supersession kind changed")
+       | _ -> Alcotest.fail "supersession did not roundtrip")
+    [ None; Some source ]
+;;
+
+let () =
+  Alcotest.run
+    "keeper compaction operation record"
+    [ ( "record"
+      , [ Alcotest.test_case "roundtrip and cursor" `Quick test_roundtrip_and_cursor
+        ; Alcotest.test_case "closed envelope" `Quick test_closed_envelope_and_finite_time
+        ; Alcotest.test_case "incomplete tail" `Quick test_incomplete_tail_is_located
+        ; Alcotest.test_case "superseded roundtrip" `Quick test_superseded_roundtrip
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary
- add an abstract nonnegative byte cursor for operation journal rows
- wrap typed compaction events in a closed {recorded_at,event} JSONL envelope
- decode complete rows with exact absolute cursors and optional full-history row numbers
- reject unknown, duplicate, missing, malformed, non-finite, and incomplete records explicitly
- preserve Source_superseded with both absent and exact observed checkpoint variants

## Boundary
- event semantics remain owned by Keeper_compaction_operation_codec
- no journal mutation, worker, Event_bus, Reaction Ledger, FSM, manifest, budget, timeout, or environment wiring

## Verification
- focused wrapper build passed on #24926 head 1ad53e6693
- 4/4 record codec tests passed
- ocamlformat and diff checks passed
- 329 changed lines