### PR TITLE
feat(keeper): persist compaction operation journal

### DIFF
--- a/lib/keeper_compaction_operation_store/dune
+++ b/lib/keeper_compaction_operation_store/dune
@@ -1,0 +1,15 @@
+(include_subdirs no)
+(library
+ (name masc_keeper_compaction_operation_store)
+ (public_name masc.keeper_compaction_operation_store)
+ (wrapped false)
+ (modules keeper_compaction_operation_store)
+ (libraries
+  eio
+  masc.fs_compat
+  masc.keeper_compaction_operation
+  masc.keeper_compaction_operation_record
+  masc.keeper_compaction_operation_reducer
+  masc.keeper_registry
+  masc.masc_core
+  masc.tool_invocation_ref))

--- a/lib/keeper_compaction_operation_store/keeper_compaction_operation_store.ml
+++ b/lib/keeper_compaction_operation_store/keeper_compaction_operation_store.ml
@@ -1,0 +1,202 @@
+module Operation = Keeper_compaction_operation
+module Reducer = Keeper_compaction_operation_reducer
+module Record = Keeper_compaction_operation_record
+module Cursor = Record.Cursor
+type row = Record.row
+type operation_entry =
+  { snapshot : Reducer.snapshot
+  ; requested_at : float
+  ; request_cursor : Cursor.t
+  }
+type replay = { operations : operation_entry list; end_cursor : Cursor.t }
+type slice = { rows : row list; end_cursor : Cursor.t }
+type event_rejection =
+  | Transition_rejected of Reducer.transition_error
+  | Keeper_mismatch of
+      { expected : Keeper_id.Keeper_name.t
+      ; actual : Keeper_id.Keeper_name.t
+      }
+  | Producer_already_bound of
+      { producer : Tool_invocation_ref.t
+      ; existing_operation_id : Operation.Operation_id.t
+      }
+type history_error =
+  | Invalid_record of Record.decode_error
+  | Rejected_row of
+      { row_number : int
+      ; start_cursor : Cursor.t
+      ; end_cursor : Cursor.t
+      ; rejection : event_rejection
+      }
+type read_error =
+  | Read_failed of Fs_compat.Private_jsonl_slice.error
+  | Invalid_history of history_error
+type transaction_error =
+  | Not_committed of Fs_compat.durable_append_error
+  | Outcome_unknown of Fs_compat.durable_append_error
+  | Access_failed of exn
+type append_error =
+  | Encode_failed of Record.envelope_error
+  | Existing_history_invalid of history_error
+  | Event_rejected of event_rejection
+  | Transaction_error of transaction_error
+module Operation_map = Map.Make (struct
+    type t = Operation.Operation_id.t
+    let compare = Operation.Operation_id.compare
+  end)
+type operation_state =
+  { reducer : Reducer.state
+  ; requested_at : float
+  ; request_cursor : Cursor.t
+  }
+type fold_state =
+  { operations : operation_state Operation_map.t
+  ; producers : (Tool_invocation_ref.t * Operation.Operation_id.t) list
+  }
+let empty_state = { operations = Operation_map.empty; producers = [] }
+let ( let* ) = Result.bind
+let cursor value =
+  match Cursor.of_int value with
+  | Ok cursor -> cursor
+  | Error _ -> invalid_arg "negative durable journal offset"
+;;
+let journal_path ~base_path ~keeper_name =
+  Filename.concat
+    (Filename.concat
+       (Common.keepers_runtime_dir_of_base ~base_path)
+       (Keeper_id.Keeper_name.to_string keeper_name))
+    "operation-journal.jsonl"
+;;
+let producer_of_event event =
+  match Operation.view event with
+  | Operation.Requested { producer_invocation; _ } -> producer_invocation
+  | _ -> None
+;;
+let find_producer producer =
+  List.find_map (fun (candidate, operation_id) ->
+    if Tool_invocation_ref.equal producer candidate then Some operation_id else None)
+;;
+let apply_row ~keeper_name state row =
+  let event = row.Record.event in
+  let operation_id = Operation.operation_id event in
+  let current = Operation_map.find_opt operation_id state.operations in
+  let* next =
+    Reducer.apply (Option.map (fun value -> value.reducer) current) event
+    |> Result.map_error (fun error -> Transition_rejected error)
+  in
+  let actual = (Reducer.snapshot next).keeper_name in
+  if not (Keeper_id.Keeper_name.equal keeper_name actual)
+  then Error (Keeper_mismatch { expected = keeper_name; actual })
+  else
+    let operation =
+      match current with
+      | Some value -> { value with reducer = next }
+      | None ->
+        { reducer = next
+        ; requested_at = row.recorded_at
+        ; request_cursor = row.end_cursor
+        }
+    in
+    match producer_of_event event with
+    | Some producer ->
+      (match find_producer producer state.producers with
+       | Some existing_operation_id
+         when not (Operation.Operation_id.equal existing_operation_id operation_id) ->
+         Error (Producer_already_bound { producer; existing_operation_id })
+       | Some _ ->
+         Ok { state with operations = Operation_map.add operation_id operation state.operations }
+       | None ->
+         Ok
+           { operations = Operation_map.add operation_id operation state.operations
+           ; producers = (producer, operation_id) :: state.producers
+           })
+    | None ->
+      Ok { state with operations = Operation_map.add operation_id operation state.operations }
+;;
+let fold_rows ~keeper_name rows =
+  let rec loop row_number state = function
+    | [] -> Ok state
+    | row :: rest ->
+      (match apply_row ~keeper_name state row with
+       | Ok state -> loop (row_number + 1) state rest
+       | Error rejection ->
+         Error
+           (Rejected_row
+              { row_number
+              ; start_cursor = row.start_cursor
+              ; end_cursor = row.end_cursor
+              ; rejection
+              }))
+  in
+  loop 1 empty_state rows
+;;
+let decode_history ~keeper_name bytes =
+  match Record.decode_rows ~from:Cursor.zero ~row_number:(Some 1) bytes with
+  | Error error -> Error (Invalid_record error)
+  | Ok rows ->
+    fold_rows ~keeper_name rows |> Result.map (fun state -> rows, state)
+;;
+let replay ~base_path ~keeper_name =
+  let path = journal_path ~base_path ~keeper_name in
+  match Fs_compat.read_private_jsonl_slice_locked_result path ~from:0 with
+  | Error error -> Error (Read_failed error)
+  | Ok source ->
+    (match decode_history ~keeper_name source.bytes with
+     | Error error -> Error (Invalid_history error)
+     | Ok (_, state) ->
+       Ok
+         { operations =
+             Operation_map.bindings state.operations
+             |> List.map (fun (_, value) ->
+               { snapshot = Reducer.snapshot value.reducer
+               ; requested_at = value.requested_at
+               ; request_cursor = value.request_cursor
+               })
+             |> List.sort (fun (left : operation_entry) right ->
+               Int.compare
+                 (Cursor.to_int left.request_cursor)
+                 (Cursor.to_int right.request_cursor))
+         ; end_cursor = cursor source.end_offset
+         })
+;;
+let read_slice ~base_path ~keeper_name ~from =
+  let path = journal_path ~base_path ~keeper_name in
+  match
+    Fs_compat.read_private_jsonl_slice_locked_result
+      path
+      ~from:(Cursor.to_int from)
+  with
+  | Error error -> Error (Read_failed error)
+  | Ok source ->
+    (match Record.decode_rows ~from ~row_number:None source.bytes with
+     | Error error -> Error (Invalid_history (Invalid_record error))
+     | Ok rows -> Ok { rows; end_cursor = cursor source.end_offset })
+;;
+let append ~base_path ~keeper_name ~recorded_at event =
+  match Record.encode ~recorded_at event with
+  | Error error -> Error (Encode_failed error)
+  | Ok suffix ->
+    let path = journal_path ~base_path ~keeper_name in
+    (try
+       match
+       Fs_compat.update_private_file_durable_locked_result path (fun existing ->
+         match decode_history ~keeper_name existing with
+         | Error error -> None, Error (Existing_history_invalid error)
+         | Ok (_, state) ->
+           let start_cursor = cursor (String.length existing) in
+           let end_cursor =
+             cursor (Cursor.to_int start_cursor + String.length suffix)
+           in
+           let row = { Record.recorded_at; start_cursor; end_cursor; event } in
+           (match apply_row ~keeper_name state row with
+            | Error error -> None, Error (Event_rejected error)
+            | Ok _ -> Some suffix, Ok row))
+     with
+     | Ok result -> result
+     | Error ({ rollback_failures = []; _ } as error) ->
+       Error (Transaction_error (Not_committed error))
+     | Error error -> Error (Transaction_error (Outcome_unknown error))
+     with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn -> Error (Transaction_error (Access_failed exn)))
+;;

--- a/lib/keeper_compaction_operation_store/keeper_compaction_operation_store.mli
+++ b/lib/keeper_compaction_operation_store/keeper_compaction_operation_store.mli
@@ -1,0 +1,59 @@
+(** Sole durable mutation facade for one Keeper's compaction operations. *)
+module Record = Keeper_compaction_operation_record
+module Cursor = Record.Cursor
+type row = Record.row
+type operation_entry =
+  { snapshot : Keeper_compaction_operation_reducer.snapshot
+  ; requested_at : float
+  ; request_cursor : Cursor.t
+  }
+type replay = { operations : operation_entry list; end_cursor : Cursor.t }
+type slice = { rows : row list; end_cursor : Cursor.t }
+type event_rejection =
+  | Transition_rejected of Keeper_compaction_operation_reducer.transition_error
+  | Keeper_mismatch of
+      { expected : Keeper_id.Keeper_name.t
+      ; actual : Keeper_id.Keeper_name.t
+      }
+  | Producer_already_bound of
+      { producer : Tool_invocation_ref.t
+      ; existing_operation_id : Keeper_compaction_operation.Operation_id.t
+      }
+type history_error =
+  | Invalid_record of Record.decode_error
+  | Rejected_row of
+      { row_number : int
+      ; start_cursor : Cursor.t
+      ; end_cursor : Cursor.t
+      ; rejection : event_rejection
+      }
+type read_error =
+  | Read_failed of Fs_compat.Private_jsonl_slice.error
+  | Invalid_history of history_error
+type transaction_error =
+  | Not_committed of Fs_compat.durable_append_error
+  | Outcome_unknown of Fs_compat.durable_append_error
+  | Access_failed of exn
+type append_error =
+  | Encode_failed of Record.envelope_error
+  | Existing_history_invalid of history_error
+  | Event_rejected of event_rejection
+  | Transaction_error of transaction_error
+val journal_path :
+  base_path:string -> keeper_name:Keeper_id.Keeper_name.t -> string
+val replay :
+  base_path:string ->
+  keeper_name:Keeper_id.Keeper_name.t ->
+  (replay, read_error) result
+val read_slice :
+  base_path:string ->
+  keeper_name:Keeper_id.Keeper_name.t ->
+  from:Cursor.t ->
+  (slice, read_error) result
+(** Structural decode only; it never invents prior reducer state. *)
+val append :
+  base_path:string ->
+  keeper_name:Keeper_id.Keeper_name.t ->
+  recorded_at:float ->
+  Keeper_compaction_operation.event ->
+  (row, append_error) result

--- a/test/keeper_compaction_operation_store/dune
+++ b/test/keeper_compaction_operation_store/dune
@@ -1,0 +1,15 @@
+(test
+ (name test_keeper_compaction_operation_store)
+ (libraries
+  alcotest
+  masc.compaction_trigger
+  masc.fs_compat
+  masc.keeper_checkpoint_ref
+  masc.keeper_compaction_operation
+  masc.keeper_compaction_operation_record
+  masc.keeper_compaction_operation_reducer
+  masc.keeper_compaction_operation_store
+  masc.keeper_registry
+  masc.mcp_transport_protocol
+  masc.tool_invocation_ref
+  unix))

--- a/test/keeper_compaction_operation_store/test_keeper_compaction_operation_store.ml
+++ b/test/keeper_compaction_operation_store/test_keeper_compaction_operation_store.ml
@@ -1,0 +1,105 @@
+module Operation = Keeper_compaction_operation
+module Store = Keeper_compaction_operation_store
+let ok = function Ok value -> value | Error _ -> Alcotest.fail "fixture failed"
+let keeper_name = ok (Keeper_id.Keeper_name.of_string "store-keeper")
+let trace_id = ok (Keeper_id.Trace_id.of_string "store-trace")
+let cause = ok (Operation.Cause.of_string "manual compaction")
+let source =
+  ok
+    (Keeper_checkpoint_ref.create
+       ~trace_id
+       ~generation:1
+       ~turn_count:3
+       ~canonical_checkpoint_bytes:"source")
+;;
+let id value = ok (Operation.Operation_id.of_string value)
+let op1 = id "00000000-0000-4000-8000-000000000001"
+let op2 = id "00000000-0000-4000-8000-000000000002"
+let attempt = ok (Operation.Attempt_id.of_string "00000000-0000-4000-8000-000000000011")
+let request ?producer operation_id =
+  Operation.requested ~operation_id ~keeper_name ~source_checkpoint:source
+    ~trigger:Compaction_trigger.Manual ~cause ~producer_invocation:producer
+;;
+let rec remove path =
+  if Sys.file_exists path then if Sys.is_directory path
+    then (Sys.readdir path |> Array.iter (fun name -> remove (Filename.concat path name));
+          Unix.rmdir path)
+    else Unix.unlink path
+;;
+let with_base f =
+  let base = Filename.temp_dir "operation_store_" "" in
+  Fun.protect ~finally:(fun () -> remove base) (fun () -> f base)
+;;
+let append base time event =
+  match Store.append ~base_path:base ~keeper_name ~recorded_at:time event with
+  | Ok row -> row
+  | Error _ -> Alcotest.fail "valid append failed"
+;;
+let test_append_replay_and_slice () =
+  with_base @@ fun base ->
+  let first = append base 1.0 (request op2) in
+  let second = append base 2.0 (request op1) in
+  let last = append base 3.0 (Operation.attempt_started ~operation_id:op2 ~attempt_id:attempt) in
+  (match Store.replay ~base_path:base ~keeper_name with
+   | Ok { operations = [ a; b ]; _ } ->
+     Alcotest.(check bool) "request-cursor FIFO" true
+       (Operation.Operation_id.equal a.snapshot.operation_id op2
+        && Operation.Operation_id.equal b.snapshot.operation_id op1
+        && a.snapshot.phase = Keeper_compaction_operation_reducer.Attempt_in_progress
+        && Store.Cursor.to_int a.request_cursor = Store.Cursor.to_int first.end_cursor)
+   | _ -> Alcotest.fail "valid history did not replay");
+  match Store.read_slice ~base_path:base ~keeper_name ~from:second.end_cursor with
+  | Ok { rows = [ row ]; end_cursor } ->
+    Alcotest.(check int) "exact suffix end"
+      (Store.Cursor.to_int last.end_cursor) (Store.Cursor.to_int end_cursor);
+    Alcotest.(check (float 0.0)) "last timestamp" 3.0 row.recorded_at
+  | _ -> Alcotest.fail "cursor slice was not exact"
+;;
+let producer () =
+  let request_id = ok (Mcp_transport_protocol.request_id_of_yojson (`Int 7)) in
+  ok (Tool_invocation_ref.external_mcp ~request_id ~session_id:"store-session")
+;;
+let test_rejections_do_not_write () =
+  with_base @@ fun base ->
+  let producer = producer () in
+  ignore (append base 1.0 (request ~producer op1));
+  let path = Store.journal_path ~base_path:base ~keeper_name in
+  let before = Fs_compat.load_file path in
+  (match Store.append ~base_path:base ~keeper_name ~recorded_at:2.0 (request ~producer op2) with
+   | Error (Store.Event_rejected (Store.Producer_already_bound { existing_operation_id; _ }))
+     when Operation.Operation_id.equal existing_operation_id op1 -> ()
+   | _ -> Alcotest.fail "producer retry was not bound to its original operation");
+  (match Store.append ~base_path:base ~keeper_name ~recorded_at:3.0 (request ~producer op1) with
+   | Error (Store.Event_rejected (Store.Transition_rejected _)) -> ()
+   | _ -> Alcotest.fail "invalid transition was not rejected");
+  let other = ok (Keeper_id.Keeper_name.of_string "other-keeper") in
+  let wrong =
+    Operation.requested ~operation_id:op2 ~keeper_name:other ~source_checkpoint:source
+      ~trigger:Compaction_trigger.Manual ~cause ~producer_invocation:None
+  in
+  (match Store.append ~base_path:base ~keeper_name ~recorded_at:4.0 wrong with
+   | Error (Store.Event_rejected (Store.Keeper_mismatch _)) -> ()
+   | _ -> Alcotest.fail "cross-Keeper request was not rejected");
+  Alcotest.(check string) "rejections wrote no bytes" before (Fs_compat.load_file path)
+;;
+let test_malformed_history_fails_loud () =
+  with_base @@ fun base ->
+  let path = Store.journal_path ~base_path:base ~keeper_name in
+  Fs_compat.mkdir_p (Filename.dirname path);
+  Out_channel.with_open_bin path (fun output -> output_string output "not-json\n");
+  (match Store.replay ~base_path:base ~keeper_name with
+   | Error (Store.Invalid_history (Store.Invalid_record _)) -> ()
+   | _ -> Alcotest.fail "malformed history did not fail replay");
+  match Store.append ~base_path:base ~keeper_name ~recorded_at:1.0 (request op1) with
+  | Error (Store.Existing_history_invalid _) ->
+    Alcotest.(check string) "malformed bytes unchanged" "not-json\n" (Fs_compat.load_file path)
+  | _ -> Alcotest.fail "append accepted malformed history"
+;;
+let () =
+  Alcotest.run "keeper compaction operation store"
+    [ "journal",
+      [ Alcotest.test_case "append replay slice" `Quick test_append_replay_and_slice
+      ; Alcotest.test_case "rejections no write" `Quick test_rejections_do_not_write
+      ; Alcotest.test_case "malformed history" `Quick test_malformed_history_fails_loud
+      ] ]
+;;


### PR DESCRIPTION
## Summary
- add the sole durable per-Keeper operation-journal.jsonl mutation facade
- validate full history and the candidate transition under one durable per-path lock before append
- keep immutable Operation_id Map lookup while replay returns typed entries in first Requested cursor FIFO
- preserve requested_at and newline-end request_cursor for future drain scheduling
- bind exact producer invocation identity to one operation so MCP retries cannot duplicate compactions
- expose structural nonzero cursor slices without inventing prior reducer state

## Failure semantics
- rollback completed: Not_committed
- rollback had failures: Outcome_unknown
- setup/access exception: Access_failed; Eio cancellation is re-raised
- malformed history, Keeper mismatch, producer reuse, and invalid transitions fail loudly without suffix writes

## Boundary
- no worker, wake, Event_bus, Reaction Ledger, FSM, manifest, budget, timeout, environment, or heuristic wiring

## Verification
- focused wrapper build passed
- 3/3 store tests and 4/4 stacked record tests passed
- proves request-cursor FIFO, structural Attempt_started slice, exact producer binding, Keeper mismatch/no-write, transition/no-write, and malformed-history fail-loud
- ocamlformat and diff checks passed
- 396 changed lines