### PR TITLE
refactor(keeper): type compaction planning outcome

### DIFF
--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -230,7 +230,9 @@ let requested_messages (meta : keeper_meta) messages =
      | Some summarize ->
        (match summarize ~messages with
         | None -> Error Plan_unavailable_or_invalid
-        | Some plan ->
+        | Some Keeper_compaction_llm_summarizer.No_compaction ->
+          Error Structurally_unchanged
+        | Some (Keeper_compaction_llm_summarizer.Planned plan) ->
           if plan.summarized = [] && plan.dropped = []
           then Error Structurally_unchanged
           else

--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -14,7 +14,11 @@ type compaction_plan =
   ; selected_runtime_id : string option
   }
 
-type summarizer = messages:Agent_sdk.Types.message list -> compaction_plan option
+type planning_outcome =
+  | Planned of compaction_plan
+  | No_compaction
+
+type summarizer = messages:Agent_sdk.Types.message list -> planning_outcome option
 
 type complete_fn = Keeper_provider_subcall.complete_fn
 
@@ -200,7 +204,7 @@ let run_plan
     ~net
     ~(provider_cfg : Llm_provider.Provider_config.t)
     ~(messages : Agent_sdk.Types.message list)
-    () : compaction_plan option =
+    () : planning_outcome option =
   let message_count = List.length messages in
   let provider_cfg = provider_for_plan provider_cfg in
   let request = messages_for_plan ~messages in
@@ -215,7 +219,8 @@ let run_plan
     None
   | Ok response ->
     (match plan_of_response ~message_count response with
-     | Ok plan -> Some { plan with selected_runtime_id = Some runtime_id }
+     | Ok plan ->
+       Some (Planned { plan with selected_runtime_id = Some runtime_id })
      | Error detail ->
        Log.Keeper.warn ~keeper_name
          "compaction LLM plan rejected runtime=%s: %s"
@@ -306,11 +311,12 @@ let make_resolved ?complete ~(runtime_id : string) ~(keeper_name : string) ()
                     ~runtime_id:candidate.runtime_id ~sw ~net
                     ~provider_cfg:candidate.provider_cfg ~messages ()
                 with
-                | Some _ as plan ->
+                | Some (Planned _) as outcome ->
                   Log.Keeper.info ~keeper_name
                     "compaction LLM candidate succeeded assignment=%s runtime=%s"
                     runtime_id candidate.runtime_id;
-                  plan
+                  outcome
+                | Some No_compaction -> Some No_compaction
                 | None -> attempt rest)
            in
            attempt candidates)

--- a/lib/keeper/keeper_compaction_llm_summarizer.mli
+++ b/lib/keeper/keeper_compaction_llm_summarizer.mli
@@ -18,11 +18,13 @@ type compaction_plan = private
         plan parsed directly through {!plan_of_json} before provider binding. *)
   }
 
-(** [summarizer ~messages] returns [Some plan] when the LLM produced a valid
-    plan over [messages], or [None] on any failure (provider error, empty
-    or invalid structured response). Total and synchronous; the effect is
-    hidden in the closure captured by {!make}. *)
-type summarizer = messages:Agent_sdk.Types.message list -> compaction_plan option
+type planning_outcome =
+  | Planned of compaction_plan
+  | No_compaction
+
+(** [None] means unavailable/invalid. [No_compaction] is reserved as a valid
+    terminal LLM judgment and must not fall through to another Runtime. *)
+type summarizer = messages:Agent_sdk.Types.message list -> planning_outcome option
 
 (** The low-level provider completion the summarizer drives. Defaulted to
     {!Llm_provider.Complete.complete}; overridable in tests. *)

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -298,7 +298,9 @@ let test_manual_compaction_serializes_owner_lane () =
       let outcome =
         Masc.Keeper_compaction_llm_summarizer.For_testing.with_make_override
           (fun ~runtime_id:_ ~keeper_name:_ () ->
-             Some (fun ~messages:_ -> Some plan))
+             Some
+               (fun ~messages:_ ->
+                  Some (Masc.Keeper_compaction_llm_summarizer.Planned plan)))
           run_cycle
       in
       (match outcome with


### PR DESCRIPTION
## Summary

- distinguish a planned compaction from a valid terminal No_compaction judgment in the summarizer contract
- reserve None exclusively for unavailable or invalid planning
- map No_compaction to the existing typed Structurally_unchanged policy outcome
- ensure a terminal No_compaction never falls through to another Runtime candidate

This independent typed prerequisite does not activate a planner. A future eligible-history planner may map its typed No_compaction result into this outcome while deleting the legacy parser/schema.

## Scope

- 4 files
- 36 changed lines (24 additions, 12 deletions)

## Verification

- git diff --check
- ocamlformat --check on touched OCaml files
- scripts/dune-local.sh build test/test_compaction_llm_summarizer.exe test/test_keeper_post_turn_wirein_order.exe
- test_compaction_llm_summarizer: 3/3 passed
- test_keeper_post_turn_wirein_order: 3/3 passed

