### PR TITLE
refactor(keeper): hard-cut global compaction planning

### DIFF
--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -233,15 +233,13 @@ let requested_messages (meta : keeper_meta) messages =
         | Some Keeper_compaction_llm_summarizer.No_compaction ->
           Error Structurally_unchanged
         | Some (Keeper_compaction_llm_summarizer.Planned plan) ->
-          if plan.summarized = [] && plan.dropped = []
-          then Error Structurally_unchanged
-          else
-            Ok
-              { messages = Keeper_compaction_llm_summarizer.apply plan ~messages
-              ; selected_runtime_id = plan.selected_runtime_id
-              ; summarized_message_count = List.length plan.summarized
-              ; dropped_message_count = List.length plan.dropped
-              }))
+          let observed = Keeper_compaction_llm_summarizer.observation plan in
+          Ok
+            { messages = Keeper_compaction_llm_summarizer.apply plan
+            ; selected_runtime_id = observed.selected_runtime_id
+            ; summarized_message_count = observed.summarized_message_count
+            ; dropped_message_count = observed.dropped_message_count
+            }))
 ;;
 
 let tool_block_counts messages =
@@ -314,9 +312,7 @@ let compact_for_request_typed
       ~message_count:before_messages;
     { context = ctx; decision = Rejected (trigger, reason); evidence = None }
   | Ok requested ->
-    let messages, pair_repair_stats =
-      Keeper_context_core.repair_broken_tool_call_pairs_with_stats requested.messages
-    in
+    let messages = requested.messages in
     let compacted_ctx =
       sync_oas_context
         { ctx with checkpoint = { (checkpoint_of_context ctx) with messages } }
@@ -343,20 +339,6 @@ let compact_for_request_typed
       let after_tool_use_count, after_tool_result_count =
         tool_block_counts (messages_of_context compacted_ctx)
       in
-      let tool_use_sample_json =
-        List.map
-          (fun (tool_use_id, tool_name) ->
-             `Assoc
-               [ "tool_use_id", `String tool_use_id
-               ; "tool_name", `String tool_name
-               ])
-          pair_repair_stats.dropped_tool_use_samples
-      in
-      let tool_result_id_json =
-        List.map
-          (fun tool_use_id -> `String tool_use_id)
-          pair_repair_stats.dropped_tool_result_ids
-      in
       Log.Harness.emit
         Log.Info
         ~details:
@@ -369,15 +351,6 @@ let compact_for_request_typed
               ; "saved_checkpoint_bytes", `Int (before_bytes - after_bytes)
               ; "before_messages", `Int before_messages
               ; "after_messages", `Int after_messages
-              ; ( "tool_pair_repair"
-                , `Assoc
-                    [ ( "dropped_tool_uses"
-                      , `Int pair_repair_stats.dropped_tool_uses )
-                    ; ( "dropped_tool_results"
-                      , `Int pair_repair_stats.dropped_tool_results )
-                    ; "dropped_tool_use_samples", `List tool_use_sample_json
-                    ; "dropped_tool_result_ids", `List tool_result_id_json
-                    ] )
               ])
         (Printf.sprintf
            "context compaction prepared keeper=%s saved_checkpoint_bytes=%d"

--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -4,19 +4,23 @@
     schema-capable provider filter + fail-closed [None]. *)
 
 module Schema = Keeper_structured_output_schema
-module Int_set = Set.Make (Int)
+module Unit = Keeper_compaction_unit
+module Unit_plan = Keeper_compaction_unit_plan
 
 type compaction_plan =
-  { summary : string
-  ; kept : int list
-  ; summarized : int list
-  ; dropped : int list
+  { plan : Unit_plan.t
   ; selected_runtime_id : string option
   }
 
 type planning_outcome =
   | Planned of compaction_plan
   | No_compaction
+
+type observation =
+  { selected_runtime_id : string option
+  ; summarized_message_count : int
+  ; dropped_message_count : int
+  }
 
 type summarizer = messages:Agent_sdk.Types.message list -> planning_outcome option
 
@@ -36,163 +40,63 @@ let provider_for_plan (provider_cfg : Llm_provider.Provider_config.t) =
      this call must read [Keeper_structured_output_schema.apply_to_provider_config]
      in source — same pattern as the other registry entries. *)
   |> Keeper_structured_output_schema.apply_to_provider_config
-       Schema.compaction_plan_output_schema
+       Schema.compaction_unit_plan_output_schema
 
 let plan_schema_supported provider_cfg =
-  Schema.provider_config_accepts_schema Schema.compaction_plan_output_schema provider_cfg
+  Schema.provider_config_accepts_schema
+    Schema.compaction_unit_plan_output_schema
+    provider_cfg
 
 let message role text : Agent_sdk.Types.message = Agent_sdk.Types.text_message role text
 
-(* One indexed line per message: "[i] role: <text>". The model must classify
-   every [i] into exactly one of kept/summarized/dropped. *)
-let indexed_messages_text (messages : Agent_sdk.Types.message list) =
-  messages
-  |> List.mapi (fun idx (m : Agent_sdk.Types.message) ->
-    let role =
-      match m.role with
-      | Agent_sdk.Types.System -> "system"
-      | Agent_sdk.Types.User -> "user"
-      | Agent_sdk.Types.Assistant -> "assistant"
-      | Agent_sdk.Types.Tool -> "tool"
-    in
-    let text = Agent_sdk.Types.text_of_message m |> String.trim in
-    Printf.sprintf "[%d] %s: %s" idx role text)
-  |> String.concat "\n"
-
-let messages_for_plan ~(messages : Agent_sdk.Types.message list) =
-  let count = List.length messages in
+let messages_for_plan ~(source : Unit.partition) =
+  let count = List.length source.closed_prefix in
   let system =
-    "You compact a keeper's working context. Classify EVERY message, by its \
-     0-based index, into exactly one of: kept (verbatim, still load-bearing), \
-     summarized (folded into the summary), or dropped (low value, discard). \
-     Every index in range must appear in exactly one list; do not invent \
-     indices. Prefer keeping recent messages and any with concrete code paths, \
-     commands, decisions, or unresolved blockers. Write one durable [summary] \
-     prose block that stands in for the summarized messages. Do not invent \
-     facts. Do not include markdown fences."
+    "Decide every supplied atomic compaction unit exactly once: keep it \
+     verbatim, summarize it with a unit-specific summary, or drop it. A \
+     closed_tool_cycle contains a complete ToolUse/ToolResult cycle and must be \
+     decided as one unit, but all three decisions are allowed. The omitted \
+     open/in-flight suffix is preserved exactly outside your rewrite. Return \
+     no invented indices or facts and no markdown fences."
   in
   let user =
     Printf.sprintf
-      "message_count: %d\nmessages:\n%s\n\nReturn a JSON object with fields \
-       summary, kept_indices, summarized_indices, dropped_indices covering \
-       every index in [0, %d) exactly once."
+      "Return kept_indices, dropped_indices, and summarized_units entries \
+       containing unit_index and summary. Cover every unit index in [0,%d) \
+       exactly once.\n%s"
       count
-      (indexed_messages_text messages)
-      count
+      (Yojson.Safe.to_string (Unit_plan.input_json source))
   in
   [ message Agent_sdk.Types.System system; message Agent_sdk.Types.User user ]
 
-(* -- structured plan parsing + validation (Parse, don't validate) -- *)
+let plan_of_json ~messages json =
+  match Unit.partition messages with
+  | Error error -> Error (Unit.show_structural_error error)
+  | Ok source ->
+    (match Unit_plan.decode ~source json with
+     | Ok plan -> Ok { plan; selected_runtime_id = None }
+     | Error error -> Error (Unit_plan.show_decode_error error))
 
-let int_list_field key = function
-  | `Assoc fields ->
-    (match List.assoc_opt key fields with
-     | Some (`List items) ->
-       List.fold_right
-         (fun item acc ->
-           match acc, item with
-           | Ok xs, `Int n -> Ok (n :: xs)
-           | Ok _, _ -> Error (Printf.sprintf "%s must contain only integers" key)
-           | Error _, _ -> acc)
-         items
-         (Ok [])
-     | Some _ -> Error (Printf.sprintf "%s must be an array" key)
-     | None -> Error (Printf.sprintf "missing %s" key))
-  | _ -> Error "plan must be a JSON object"
+let apply plan = Unit_plan.apply plan.plan
 
-let string_field key = function
-  | `Assoc fields ->
-    (match List.assoc_opt key fields with
-     | Some (`String s) -> Ok s
-     | Some _ -> Error (Printf.sprintf "%s must be a string" key)
-     | None -> Error (Printf.sprintf "missing %s" key))
-  | _ -> Error "plan must be a JSON object"
+let observation plan =
+  let observed = Unit_plan.observation plan.plan in
+  { selected_runtime_id = plan.selected_runtime_id
+  ; summarized_message_count = observed.summarized_source_messages
+  ; dropped_message_count = observed.dropped_source_messages
+  }
 
-let ( let* ) = Result.bind
-
-(* The three index lists must together partition [0, message_count) exactly.
-   An invalid LLM plan is an explicit error, never a silent repair. *)
-let validate_partition ~message_count ~kept ~summarized ~dropped =
-  let all = kept @ summarized @ dropped in
-  let seen = Array.make message_count false in
-  let rec check = function
-    | [] -> Ok ()
-    | idx :: rest ->
-      if idx < 0 || idx >= message_count then
-        Error (Printf.sprintf "index %d out of range [0, %d)" idx message_count)
-      else if seen.(idx) then Error (Printf.sprintf "index %d appears more than once" idx)
-      else begin
-        seen.(idx) <- true;
-        check rest
-      end
-  in
-  let* () = check all in
-  let missing = ref [] in
-  Array.iteri (fun idx covered -> if not covered then missing := idx :: !missing) seen;
-  match !missing with
-  | [] -> Ok ()
-  | xs ->
-    Error
-      (Printf.sprintf
-         "indices not covered: %s"
-         (String.concat "," (List.rev_map string_of_int xs)))
-
-let validate_non_empty_output ~message_count ~kept ~summarized =
-  if message_count > 0 && kept = [] && summarized = [] then
-    Error "plan would produce empty compaction output"
-  else Ok ()
-
-let plan_of_json ~message_count json =
-  let* summary = string_field Schema.compaction_plan_field_summary json in
-  let summary = String.trim summary in
-  let* kept = int_list_field Schema.compaction_plan_field_kept_indices json in
-  let* summarized = int_list_field Schema.compaction_plan_field_summarized_indices json in
-  let* dropped = int_list_field Schema.compaction_plan_field_dropped_indices json in
-  (* The summary must be non-empty exactly when [apply] will use it. *)
-  let* () =
-    if summarized <> [] && summary = ""
-    then Error "summary must be non-empty when summarized indices are present"
-    else Ok ()
-  in
-  let* () = validate_partition ~message_count ~kept ~summarized ~dropped in
-  let* () = validate_non_empty_output ~message_count ~kept ~summarized in
-  let* () =
-    if summarized = [] && dropped = []
-    then Error "plan keeps every message without summarizing or dropping any"
-    else Ok ()
-  in
-  Ok { summary; kept; summarized; dropped; selected_runtime_id = None }
-
-(* Marker prefix so the folded summary is recognizable in the transcript and
-   by downstream tooling, matching the memory-bank [MEMORY_SUMMARY] convention. *)
-let summary_marker = "[COMPACTION_SUMMARY]"
-
-let apply (plan : compaction_plan) ~(messages : Agent_sdk.Types.message list) =
-  let summarized = List.fold_left (fun s i -> Int_set.add i s) Int_set.empty plan.summarized in
-  let dropped = List.fold_left (fun s i -> Int_set.add i s) Int_set.empty plan.dropped in
-  let first_summarized =
-    List.fold_left min max_int plan.summarized
-  in
-  let summary_msg =
-    message Agent_sdk.Types.Assistant (summary_marker ^ " " ^ plan.summary)
-  in
-  messages
-  |> List.mapi (fun idx m -> idx, m)
-  |> List.filter_map (fun (idx, m) ->
-    if Int_set.mem idx dropped then None
-    else if Int_set.mem idx summarized then
-      (* Emit the single summary message at the position of the first
-         summarized index; the rest of the summarized indices collapse away. *)
-      if idx = first_summarized then Some summary_msg else None
-    else Some m)
-
-let plan_of_response ~message_count response =
+let plan_of_response ~source response =
   match
     Agent_sdk_response.structured_json_of_response
-      ~schema_name:"keeper_compaction_plan"
+      ~schema_name:"keeper_compaction_unit_plan"
       response
   with
-  | Ok json -> plan_of_json ~message_count json
+  | Ok json ->
+    (match Unit_plan.decode ~source json with
+     | Ok plan -> Ok (Some { plan; selected_runtime_id = None })
+     | Error Unit_plan.No_compaction -> Ok None
+     | Error error -> Error (Unit_plan.show_decode_error error))
   | Error detail -> Error ("invalid structured response: " ^ detail)
 
 let run_plan
@@ -203,11 +107,10 @@ let run_plan
     ~sw
     ~net
     ~(provider_cfg : Llm_provider.Provider_config.t)
-    ~(messages : Agent_sdk.Types.message list)
+    ~(source : Unit.partition)
     () : planning_outcome option =
-  let message_count = List.length messages in
   let provider_cfg = provider_for_plan provider_cfg in
-  let request = messages_for_plan ~messages in
+  let request = messages_for_plan ~source in
   match
     Keeper_provider_subcall.complete ?override:complete ~sw ~net ?clock
       ~config:provider_cfg ~messages:request ()
@@ -218,9 +121,13 @@ let run_plan
       runtime_id (Provider_http_error.to_message err);
     None
   | Ok response ->
-    (match plan_of_response ~message_count response with
-     | Ok plan ->
+    (match plan_of_response ~source response with
+     | Ok (Some plan) ->
        Some (Planned { plan with selected_runtime_id = Some runtime_id })
+     | Ok None ->
+       Log.Keeper.info ~keeper_name
+         "compaction LLM accepted no compaction runtime=%s" runtime_id;
+       Some No_compaction
      | Error detail ->
        Log.Keeper.warn ~keeper_name
          "compaction LLM plan rejected runtime=%s: %s"
@@ -299,27 +206,34 @@ let make_resolved ?complete ~(runtime_id : string) ~(keeper_name : string) ()
        let clock = Eio_context.get_clock_opt () in
        Some
          (fun ~messages ->
-           let rec attempt = function
-             | [] ->
-               Log.Keeper.warn ~keeper_name
-                 "compaction LLM candidate chain exhausted assignment=%s"
-                 runtime_id;
-               None
-             | candidate :: rest ->
-               (match
-                  run_plan ?complete ?clock ~keeper_name
-                    ~runtime_id:candidate.runtime_id ~sw ~net
-                    ~provider_cfg:candidate.provider_cfg ~messages ()
-                with
-                | Some (Planned _) as outcome ->
-                  Log.Keeper.info ~keeper_name
-                    "compaction LLM candidate succeeded assignment=%s runtime=%s"
-                    runtime_id candidate.runtime_id;
-                  outcome
-                | Some No_compaction -> Some No_compaction
-                | None -> attempt rest)
-           in
-           attempt candidates)
+           match Unit.partition messages with
+           | Error error ->
+             Log.Keeper.warn ~keeper_name
+               "compaction LLM source rejected assignment=%s: %s"
+               runtime_id (Unit.show_structural_error error);
+             None
+           | Ok source ->
+             let rec attempt = function
+               | [] ->
+                 Log.Keeper.warn ~keeper_name
+                   "compaction LLM candidate chain exhausted assignment=%s"
+                   runtime_id;
+                 None
+               | candidate :: rest ->
+                 (match
+                    run_plan ?complete ?clock ~keeper_name
+                      ~runtime_id:candidate.runtime_id ~sw ~net
+                      ~provider_cfg:candidate.provider_cfg ~source ()
+                  with
+                  | Some (Planned plan) ->
+                    Log.Keeper.info ~keeper_name
+                      "compaction LLM candidate succeeded assignment=%s runtime=%s"
+                      runtime_id candidate.runtime_id;
+                    Some (Planned plan)
+                  | Some No_compaction -> Some No_compaction
+                  | None -> attempt rest)
+             in
+             attempt candidates)
      | _ ->
        List.iter
          (fun candidate ->

--- a/lib/keeper/keeper_compaction_llm_summarizer.mli
+++ b/lib/keeper/keeper_compaction_llm_summarizer.mli
@@ -2,20 +2,12 @@
     produces a structured {!compaction_plan}; unavailable providers and invalid
     plans fail explicitly as [None]. *)
 
-(** A validated compaction plan over a working set of [n] messages. Every
-    index in [kept]/[summarized]/[dropped] is in [\[0, n)], the three sets are
-    pairwise disjoint, and together they cover every index exactly once. For
-    non-empty inputs, at least one [kept] or [summarized] index is required so
-    applying the plan cannot erase the entire working set. At least one
-    [summarized] or [dropped] index is required, so all-kept no-ops are invalid. *)
-type compaction_plan = private
-  { summary : string
-  ; kept : int list
-  ; summarized : int list
-  ; dropped : int list
-  ; selected_runtime_id : string option
-    (** Exact Runtime candidate that produced this plan. [None] only for a
-        plan parsed directly through {!plan_of_json} before provider binding. *)
+type compaction_plan
+
+type observation =
+  { selected_runtime_id : string option
+  ; summarized_message_count : int
+  ; dropped_message_count : int
   }
 
 type planning_outcome =
@@ -46,27 +38,15 @@ val make
   -> unit
   -> summarizer option
 
-(** Parse+validate a raw structured response into a plan over [message_count]
-    messages. Exposed for tests. Returns [Error] with a reason on any
-    structural violation (out-of-range / negative / duplicate / non-covering
-    indices, empty output for a non-empty working set, or a missing/empty
-    summary). *)
 val plan_of_json
-  :  message_count:int
+  :  messages:Agent_sdk.Types.message list
   -> Yojson.Safe.t
   -> (compaction_plan, string) result
 
-(** [apply plan ~messages] rebuilds the working set from a validated [plan]:
-    [kept] indices survive verbatim, the [summarized] indices are replaced by a
-    single assistant memory-summary message ([plan.summary]), and [dropped]
-    indices are removed. Original message order is preserved; the summary is
-    inserted at the position of the first summarized index. [plan] is assumed
-    to have been validated against [List.length messages] (it partitions the
-    index space), so this is total. *)
-val apply
-  :  compaction_plan
-  -> messages:Agent_sdk.Types.message list
-  -> Agent_sdk.Types.message list
+val apply : compaction_plan -> Agent_sdk.Types.message list
+(** Rebuild the bound source chronologically and append its protected suffix. *)
+
+val observation : compaction_plan -> observation
 
 module For_testing : sig
   val with_make_override

--- a/lib/keeper/keeper_structured_output_schema.ml
+++ b/lib/keeper/keeper_structured_output_schema.ml
@@ -163,32 +163,8 @@ let memory_bank_summary_output_schema =
   object_schema ~required:(List.map fst fields) fields
 ;;
 
-(* Compaction plan (RFC-0313-adjacent W2). The LLM classifies each working-set
-   message by 0-based index into kept / summarized / dropped, and returns one
-   [summary] prose block that stands in for the summarized indices. Index-based
-   (not free-text rewrite) so the original messages are never fabricated — the
-   consumer reconstructs the context by index, matching the
-   [consolidation_plan] member_indices/drop_indices precedent. Field names are
-   exported as constants so the parser shares this SSOT. *)
-let compaction_plan_field_summary = "summary"
-let compaction_plan_field_kept_indices = "kept_indices"
-let compaction_plan_field_summarized_indices = "summarized_indices"
-let compaction_plan_field_dropped_indices = "dropped_indices"
-
-let compaction_plan_output_schema =
-  let int_array = `Assoc [ "type", `String "array"; "items", integer_schema ] in
-  let fields =
-    [ compaction_plan_field_summary, string_schema
-    ; compaction_plan_field_kept_indices, int_array
-    ; compaction_plan_field_summarized_indices, int_array
-    ; compaction_plan_field_dropped_indices, int_array
-    ]
-  in
-  object_schema ~required:(List.map fst fields) fields
-;;
-
-(* Replacement compaction plan. Summaries are attached to their atomic source
-   unit so disjoint reductions preserve chronological placement. *)
+(* Summaries are attached to their atomic source unit so disjoint reductions
+   preserve chronological placement. *)
 let compaction_unit_plan_field_kept_indices = "kept_indices"
 let compaction_unit_plan_field_dropped_indices = "dropped_indices"
 let compaction_unit_plan_field_summarized_units = "summarized_units"

--- a/lib/keeper/keeper_structured_output_schema.mli
+++ b/lib/keeper/keeper_structured_output_schema.mli
@@ -14,18 +14,6 @@ val consolidation_plan_output_schema : Yojson.Safe.t
 val memory_bank_summary_output_schema : Yojson.Safe.t
 (** JSON object the memory-bank summary provider must return. *)
 
-(** Wire field names for {!compaction_plan_output_schema}; shared with the
-    W2 compaction-plan parser as the single source of truth. *)
-val compaction_plan_field_summary : string
-
-val compaction_plan_field_kept_indices : string
-val compaction_plan_field_summarized_indices : string
-val compaction_plan_field_dropped_indices : string
-
-val compaction_plan_output_schema : Yojson.Safe.t
-(** JSON object the LLM compaction summarizer must return: a [summary] prose
-    block plus kept / summarized / dropped 0-based message indices. *)
-
 val compaction_unit_plan_field_kept_indices : string
 val compaction_unit_plan_field_dropped_indices : string
 val compaction_unit_plan_field_summarized_units : string

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -283,14 +283,19 @@ let test_manual_compaction_serializes_owner_lane () =
       (match Eio.Promise.await finished with
        | `Ran () -> ()
        | `Rejected _ -> fail "simulated owner turn was rejected");
-      let plan =
+      let plan messages =
         Masc.Keeper_compaction_llm_summarizer.plan_of_json
-          ~message_count:4
+          ~messages
           (`Assoc
-            [ "summary", `String "owner-lane compacted context"
-            ; "kept_indices", `List [ `Int 0 ]
-            ; "summarized_indices", `List [ `Int 1; `Int 2; `Int 3 ]
-            ; "dropped_indices", `List []
+            [ "kept_indices", `List [ `Int 0 ]
+            ; "dropped_indices", `List [ `Int 1; `Int 2 ]
+            ; ( "summarized_units"
+              , `List
+                  [ `Assoc
+                      [ "unit_index", `Int 3
+                      ; "summary", `String "owner-lane compacted context"
+                      ]
+                  ] )
             ])
         |> Result.get_ok
       in
@@ -299,8 +304,10 @@ let test_manual_compaction_serializes_owner_lane () =
         Masc.Keeper_compaction_llm_summarizer.For_testing.with_make_override
           (fun ~runtime_id:_ ~keeper_name:_ () ->
              Some
-               (fun ~messages:_ ->
-                  Some (Masc.Keeper_compaction_llm_summarizer.Planned plan)))
+               (fun ~messages ->
+                  Some
+                    (Masc.Keeper_compaction_llm_summarizer.Planned
+                       (plan messages))))
           run_cycle
       in
       (match outcome with

--- a/test/test_keeper_structured_output_schema.ml
+++ b/test/test_keeper_structured_output_schema.ml
@@ -53,7 +53,6 @@ let all_provider_native_schema_cases =
   [ "librarian_episode", Keeper_structured_output_schema.librarian_episode_output_schema
   ; "consolidation_plan", Keeper_structured_output_schema.consolidation_plan_output_schema
   ; "memory_bank_summary", Keeper_structured_output_schema.memory_bank_summary_output_schema
-  ; "compaction_plan", Keeper_structured_output_schema.compaction_plan_output_schema
   ; ( "compaction_unit_plan"
     , Keeper_structured_output_schema.compaction_unit_plan_output_schema )
   ; "vision_analyze", Keeper_structured_output_schema.vision_analyze_output_schema


### PR DESCRIPTION
## Summary

- delete the global summary plus message-index compaction schema, parser, marker, and application path
- partition the source exactly once before Runtime fallback and present only closed-prefix atomic units to the LLM
- bind plans to the exact immutable partition from #24924; the protected open/in-flight suffix remains outside LLM rewrite
- allow a closed ToolUse/ToolResult cycle to be kept, summarized, or dropped only as one whole unit
- preserve chronology through per-unit summaries; no contiguous-index rule remains
- map a valid Unit_plan.No_compaction judgment to the typed terminal No_compaction outcome without trying another Runtime
- keep structural source failure on the invalid path without retrying it across Runtime candidates
- remove downstream tool-pair repair; invalid plans fail explicitly and are never repaired
- report summarized/dropped source-message counts, while after_message_count remains measured from the actually rebuilt context

This Draft supersedes #24875. #24875 remains open for comparison and is not closed by this PR.

Oversized-input hierarchical batching is intentionally not implemented here. It is the next worker prerequisite: the planner currently sends the canonical closed-prefix input in one provider request.

## Scope

- 7 files
- 399 changed lines (118 additions, 281 deletions)

## Verification

- git diff --check
- ocamlformat --check on all touched OCaml files
- zero legacy references in lib/test for compaction_plan_output_schema, compaction_plan_field_*, summarized_indices, and [COMPACTION_SUMMARY]
- scripts/dune-local.sh build test/test_compaction_llm_summarizer.exe test/test_keeper_compaction_unit.exe test/test_keeper_post_turn_wirein_order.exe test/test_keeper_structured_output_schema.exe
- test_compaction_llm_summarizer: 3/3 passed
- test_keeper_compaction_unit: 13/13 passed
- test_keeper_post_turn_wirein_order: 3/3 passed
- test_keeper_structured_output_schema: 11/11 passed

The typed unit-plan test proves closed-cycle keep/summarize/drop atomicity, disjoint chronological summaries, exact protected suffix, raw summary preservation, source-message observation counts, and explicit blank/duplicate/range/missing/unknown/no-op rejection.
