### PR TITLE
refactor(keeper): pass compaction Eio resources explicitly

### DIFF
--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -66,14 +66,12 @@ let register_record_pre_compact
 ;;
 
 type compaction_rejection =
-  | Runtime_identity_unavailable
   | Summarizer_unavailable
   | Plan_unavailable_or_invalid
   | Structurally_unchanged
   | Checkpoint_not_reduced
 
 let compaction_rejection_to_string = function
-  | Runtime_identity_unavailable -> "runtime_identity_unavailable"
   | Summarizer_unavailable -> "summarizer_unavailable"
   | Plan_unavailable_or_invalid -> "plan_unavailable_or_invalid"
   | Structurally_unchanged -> "structurally_unchanged"
@@ -207,39 +205,25 @@ type requested_compaction =
   ; dropped_message_count : int
   }
 
-let requested_messages (meta : keeper_meta) messages =
-  let runtime_id =
-    try
-      let runtime_id = Keeper_meta_contract.runtime_id_of_meta meta in
-      if String.trim runtime_id = ""
-      then Error Runtime_identity_unavailable
-      else Ok runtime_id
-    with
-    | Failure _ -> Error Runtime_identity_unavailable
-  in
-  match runtime_id with
-  | Error _ as error -> error
-  | Ok runtime_id ->
-    (match
-       Keeper_compaction_llm_summarizer.make
-         ~runtime_id
-         ~keeper_name:meta.name
-         ()
-     with
-     | None -> Error Summarizer_unavailable
-     | Some summarize ->
-       (match summarize ~messages with
-        | None -> Error Plan_unavailable_or_invalid
-        | Some Keeper_compaction_llm_summarizer.No_compaction ->
-          Error Structurally_unchanged
-        | Some (Keeper_compaction_llm_summarizer.Planned plan) ->
-          let observed = Keeper_compaction_llm_summarizer.observation plan in
-          Ok
-            { messages = Keeper_compaction_llm_summarizer.apply plan
-            ; selected_runtime_id = observed.selected_runtime_id
-            ; summarized_message_count = observed.summarized_message_count
-            ; dropped_message_count = observed.dropped_message_count
-            }))
+let requested_messages
+      ~(summarizer : Keeper_compaction_llm_summarizer.summarizer option)
+      messages
+  =
+  match summarizer with
+  | None -> Error Summarizer_unavailable
+  | Some summarize ->
+    (match summarize ~messages with
+     | None -> Error Plan_unavailable_or_invalid
+     | Some Keeper_compaction_llm_summarizer.No_compaction ->
+       Error Structurally_unchanged
+     | Some (Keeper_compaction_llm_summarizer.Planned plan) ->
+       let observed = Keeper_compaction_llm_summarizer.observation plan in
+       Ok
+         { messages = Keeper_compaction_llm_summarizer.apply plan
+         ; selected_runtime_id = observed.selected_runtime_id
+         ; summarized_message_count = observed.summarized_message_count
+         ; dropped_message_count = observed.dropped_message_count
+         })
 ;;
 
 let tool_block_counts messages =
@@ -289,6 +273,7 @@ let log_rejection ~meta ~trigger ~reason ~checkpoint_bytes ~message_count =
 ;;
 
 let compact_for_request_typed
+      ~(summarizer : Keeper_compaction_llm_summarizer.summarizer option)
       ~(meta : keeper_meta)
       ~(trigger : Compaction_trigger.t)
       (ctx : working_context)
@@ -302,7 +287,7 @@ let compact_for_request_typed
     ~message_count:before_messages
     ~strategies:strategy_names
     ~trigger;
-  match requested_messages meta (messages_of_context ctx) with
+  match requested_messages ~summarizer (messages_of_context ctx) with
   | Error reason ->
     log_rejection
       ~meta

--- a/lib/keeper/keeper_compact_policy.mli
+++ b/lib/keeper/keeper_compact_policy.mli
@@ -4,7 +4,6 @@
     compaction on their own. *)
 
 type compaction_rejection =
-  | Runtime_identity_unavailable
   | Summarizer_unavailable
   | Plan_unavailable_or_invalid
   | Structurally_unchanged
@@ -54,12 +53,15 @@ type compaction_preparation =
     {!compact_for_request_typed}. *)
 val compaction_policy_of_keeper : Keeper_meta_contract.keeper_meta -> float * int * int
 
-(** Apply a caller-owned request. Only a valid configured-LLM plan that
+(** Apply a caller-owned request with the caller-resolved semantic
+    [summarizer]. [None] is an explicit unavailable dependency, never a signal
+    to consult ambient process state. Only a valid configured-LLM plan that
     strictly reduces the exact serialized checkpoint byte length is prepared.
     Every refusal preserves the original context and returns a typed reason.
     The caller owns the durable save and promotion from [Prepared] to [Applied]. *)
 val compact_for_request_typed
-  :  meta:Keeper_meta_contract.keeper_meta
+  :  summarizer:Keeper_compaction_llm_summarizer.summarizer option
+  -> meta:Keeper_meta_contract.keeper_meta
   -> trigger:Compaction_trigger.t
   -> Keeper_context_core.working_context
   -> compaction_preparation

--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -1,7 +1,7 @@
 (** LLM-backed keeper context compaction (RFC-0313-adjacent W2).
-    See keeper_compaction_llm_summarizer.mli. Structure mirrors
-    Keeper_memory_llm_summary: opt-in gate + fiber-local Eio capture +
-    schema-capable provider filter + fail-closed [None]. *)
+    See keeper_compaction_llm_summarizer.mli. The caller supplies the exact
+    Eio resources owned by its Keeper lane; this module performs no ambient
+    process-context lookup. *)
 
 module Schema = Keeper_structured_output_schema
 module Unit = Keeper_compaction_unit
@@ -187,10 +187,14 @@ let candidates_for_assignment ~keeper_name assignment_id =
   | `Lane lane ->
     resolve_lane [] (Runtime_lane.ordered_candidates lane)
 
-type make_fn = runtime_id:string -> keeper_name:string -> unit -> summarizer option
-let make_override : make_fn option Atomic.t = Atomic.make None
-
-let make_resolved ?complete ~(runtime_id : string) ~(keeper_name : string) ()
+let make
+    ?complete
+    ~sw
+    ~net
+    ?clock
+    ~(runtime_id : string)
+    ~(keeper_name : string)
+    ()
   : summarizer option
   =
   match candidates_for_assignment ~keeper_name runtime_id with
@@ -201,59 +205,38 @@ let make_resolved ?complete ~(runtime_id : string) ~(keeper_name : string) ()
       runtime_id;
     None
   | Some candidates ->
-    (match Eio_context.get_switch_opt (), Eio_context.get_net_opt () with
-     | Some sw, Some net ->
-       let clock = Eio_context.get_clock_opt () in
-       Some
-         (fun ~messages ->
-           match Unit.partition messages with
-           | Error error ->
-             Log.Keeper.warn ~keeper_name
-               "compaction LLM source rejected assignment=%s: %s"
-               runtime_id (Unit.show_structural_error error);
-             None
-           | Ok source ->
-             let rec attempt = function
-               | [] ->
-                 Log.Keeper.warn ~keeper_name
-                   "compaction LLM candidate chain exhausted assignment=%s"
-                   runtime_id;
-                 None
-               | candidate :: rest ->
-                 (match
-                    run_plan ?complete ?clock ~keeper_name
-                      ~runtime_id:candidate.runtime_id ~sw ~net
-                      ~provider_cfg:candidate.provider_cfg ~source ()
-                  with
-                  | Some (Planned plan) ->
-                    Log.Keeper.info ~keeper_name
-                      "compaction LLM candidate succeeded assignment=%s runtime=%s"
-                      runtime_id candidate.runtime_id;
-                    Some (Planned plan)
-                  | Some No_compaction -> Some No_compaction
-                  | None -> attempt rest)
-             in
-             attempt candidates)
-     | _ ->
-       List.iter
-         (fun candidate ->
-           Log.Keeper.warn ~keeper_name
-             "compaction LLM candidate skipped runtime=%s assignment=%s: Eio \
-              context unavailable"
-             candidate.runtime_id runtime_id)
-       candidates;
-       None)
-
-let make ?complete ~runtime_id ~keeper_name () =
-  match Atomic.get make_override with
-  | Some override -> override ~runtime_id ~keeper_name ()
-  | None -> make_resolved ?complete ~runtime_id ~keeper_name ()
+    Some
+      (fun ~messages ->
+        match Unit.partition messages with
+        | Error error ->
+          Log.Keeper.warn ~keeper_name
+            "compaction LLM source rejected assignment=%s: %s"
+            runtime_id (Unit.show_structural_error error);
+          None
+        | Ok source ->
+          let rec attempt = function
+            | [] ->
+              Log.Keeper.warn ~keeper_name
+                "compaction LLM candidate chain exhausted assignment=%s"
+                runtime_id;
+              None
+            | candidate :: rest ->
+              (match
+                 run_plan ?complete ?clock ~keeper_name
+                   ~runtime_id:candidate.runtime_id ~sw ~net
+                   ~provider_cfg:candidate.provider_cfg ~source ()
+               with
+               | Some (Planned plan) ->
+                 Log.Keeper.info ~keeper_name
+                   "compaction LLM candidate succeeded assignment=%s runtime=%s"
+                   runtime_id candidate.runtime_id;
+                 Some (Planned plan)
+               | Some No_compaction -> Some No_compaction
+               | None -> attempt rest)
+          in
+          attempt candidates)
 
 module For_testing = struct
-  let with_make_override override f =
-    let previous = Atomic.exchange make_override (Some override) in
-    Fun.protect ~finally:(fun () -> Atomic.set make_override previous) f
-
   let provider_for_plan = provider_for_plan
 
   let candidate_runtime_ids_for_assignment ~keeper_name ~runtime_id =

--- a/lib/keeper/keeper_compaction_llm_summarizer.mli
+++ b/lib/keeper/keeper_compaction_llm_summarizer.mli
@@ -22,17 +22,22 @@ type summarizer = messages:Agent_sdk.Types.message list -> planning_outcome opti
     {!Llm_provider.Complete.complete}; overridable in tests. *)
 type complete_fn = Keeper_provider_subcall.complete_fn
 
-(** [make ~runtime_id ~keeper_name ()] resolves [runtime_id] as a Runtime or
-    Runtime Lane. A Runtime contributes its exact provider config; a Lane tries
-    its configured Runtime candidates in declared order until one returns a
-    valid plan. Missing, ineligible, and failed candidates are logged with
-    their Runtime id. No default Runtime is substituted. [complete] overrides
-    the Provider boundary in tests.
+(** [make ~sw ~net ?clock ~runtime_id ~keeper_name ()] resolves [runtime_id]
+    as a Runtime or Runtime Lane. The caller owns every Eio resource used by
+    the resulting summarizer; no ambient process context is consulted. A
+    Runtime contributes its exact provider config; a Lane tries its configured
+    Runtime candidates in declared order until one returns a valid plan.
+    Missing, ineligible, and failed candidates are logged with their Runtime
+    id. No default Runtime is substituted. [complete] overrides the Provider
+    boundary in tests.
 
     The compaction owner imposes no wall-clock deadline. Cancellation belongs
     to the owning Keeper lane or to the Provider transport boundary. *)
 val make
   :  ?complete:complete_fn
+  -> sw:Eio.Switch.t
+  -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+  -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
   -> runtime_id:string
   -> keeper_name:string
   -> unit
@@ -49,11 +54,6 @@ val apply : compaction_plan -> Agent_sdk.Types.message list
 val observation : compaction_plan -> observation
 
 module For_testing : sig
-  val with_make_override
-    :  (runtime_id:string -> keeper_name:string -> unit -> summarizer option)
-    -> (unit -> 'a)
-    -> 'a
-
   (** Apply the compaction request policy while preserving the input provider
       config's exact temperature, including omission. *)
   val provider_for_plan

--- a/lib/keeper/keeper_context_runtime.mli
+++ b/lib/keeper/keeper_context_runtime.mli
@@ -187,7 +187,8 @@ val dispatch_post_turn_lifecycle_events
   -> unit
 
 val recover_latest_checkpoint_for_overflow_retry
-  :  base_dir:string
+  :  summarizer:Keeper_compaction_llm_summarizer.summarizer option
+  -> base_dir:string
   -> meta:keeper_meta
   -> trigger:Compaction_trigger.t
   -> primary_model_max_tokens:int

--- a/lib/keeper/keeper_heartbeat_loop_cycle.ml
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.ml
@@ -210,15 +210,42 @@ let run_keeper_cycle_admitted
       ~shared_context
       ~(wake : Keeper_registry.wake_reason)
       ?failure_judgment
+      ?compaction_summarizer
       ?(manual_compaction_requested = false)
       ()
   =
+  let resolve_compaction_summarizer () =
+    match compaction_summarizer, ctx.net with
+    | Some summarizer, _ -> Some summarizer
+    | None, None -> None
+    | None, Some net ->
+      (try
+         Keeper_compaction_llm_summarizer.make
+           ~sw:ctx.sw
+           ~net
+           ~clock:(ctx.clock :> float Eio.Time.clock_ty Eio.Resource.t)
+           ~runtime_id:(Keeper_meta_contract.runtime_id_of_meta meta_after_triage)
+           ~keeper_name:meta_after_triage.name
+           ()
+       with
+       | Failure detail ->
+         Log.Keeper.warn
+           ~keeper_name:meta_after_triage.name
+           "compaction summarizer resolution failed: %s"
+           detail;
+         None)
+  in
   let admitted_execution =
     In_turn_pulse.with_in_turn_liveness_pulse ~ctx ~meta:meta_after_triage ~stop (fun () ->
       let prepared =
         if manual_compaction_requested
         then
-          (match Keeper_manual_compaction.run ~config:ctx.config ~meta:meta_after_triage with
+          (match
+             Keeper_manual_compaction.run
+               ~summarizer:(resolve_compaction_summarizer ())
+               ~config:ctx.config
+               ~meta:meta_after_triage
+           with
            | Error failure -> `Compaction_failed failure
            | Ok success ->
              Keeper_manual_compaction.observe_manifest
@@ -247,6 +274,7 @@ let run_keeper_cycle_admitted
           ( Keeper_unified_turn.run_keeper_cycle
               ~config:ctx.config
               ~meta:meta_after_triage
+              ~resolve_compaction_summarizer
               ~publication_recovery_provider:ctx.publication_recovery_provider
               ~observation
               ~generation:meta_after_triage.runtime.generation
@@ -345,6 +373,7 @@ let run_keeper_cycle
       ~shared_context
       ~(wake : Keeper_registry.wake_reason)
       ?failure_judgment
+      ?compaction_summarizer
       ?manual_compaction_requested
       ()
   =
@@ -361,6 +390,7 @@ let run_keeper_cycle
          ~shared_context
          ~wake
          ?failure_judgment
+         ?compaction_summarizer
          ?manual_compaction_requested
          ?event_bus
          ?hitl_resolution

--- a/lib/keeper/keeper_heartbeat_loop_cycle.mli
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.mli
@@ -54,6 +54,7 @@ val run_keeper_cycle
   -> shared_context:Agent_sdk.Context.t
   -> wake:Keeper_registry.wake_reason
   -> ?failure_judgment:Keeper_event_queue.failure_judgment
+  -> ?compaction_summarizer:Keeper_compaction_llm_summarizer.summarizer
   -> ?manual_compaction_requested:bool
   -> unit
   -> cycle_outcome

--- a/lib/keeper/keeper_manual_compaction.ml
+++ b/lib/keeper/keeper_manual_compaction.ml
@@ -58,7 +58,11 @@ let append_manifest ~config ~base_dir ~(meta : keeper_meta) recovery =
       ()
     |> Keeper_runtime_manifest.append config
 ;;
-let run ~(config : Workspace.config) ~(meta : keeper_meta) =
+let run
+      ~(summarizer : Keeper_compaction_llm_summarizer.summarizer option)
+      ~(config : Workspace.config)
+      ~(meta : keeper_meta)
+  =
   let dispatch stage event =
     Keeper_context_runtime.dispatch_keeper_phase_event_result
       ~config
@@ -86,6 +90,7 @@ let run ~(config : Workspace.config) ~(meta : keeper_meta) =
        let base_dir = Keeper_types_profile.session_base_dir config in
        (match
           Keeper_context_runtime.recover_latest_checkpoint_for_overflow_retry
+            ~summarizer
             ~base_dir
             ~meta
             ~trigger:Compaction_trigger.Manual

--- a/lib/keeper/keeper_manual_compaction.mli
+++ b/lib/keeper/keeper_manual_compaction.mli
@@ -8,7 +8,8 @@ type failure =
       Keeper_post_turn.compaction_recovery_error
       * (unit, Keeper_context_runtime.lifecycle_dispatch_error) result
 val run
-  :  config:Workspace.config
+  :  summarizer:Keeper_compaction_llm_summarizer.summarizer option
+  -> config:Workspace.config
   -> meta:Keeper_meta_contract.keeper_meta
   -> (success, failure) result
 val failure_to_string : failure -> string

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -502,6 +502,7 @@ let checkpoint_of_save_outcome = function
 ;;
 
 let recover_latest_checkpoint_for_overflow_retry
+    ~(summarizer : Keeper_compaction_llm_summarizer.summarizer option)
     ~(base_dir : string)
     ~(meta : keeper_meta)
     ~(trigger : Compaction_trigger.t)
@@ -545,6 +546,7 @@ let recover_latest_checkpoint_for_overflow_retry
     in
     let preparation =
       Keeper_compact_policy.compact_for_request_typed
+        ~summarizer
         ~meta:retry_meta
         ~trigger
         ctx

--- a/lib/keeper/keeper_post_turn.mli
+++ b/lib/keeper/keeper_post_turn.mli
@@ -113,6 +113,7 @@ val apply_post_turn_lifecycle_with_resilience_handles :
     structurally changed [Prepared] candidate; every other outcome is a typed
     [Error]. *)
 val recover_latest_checkpoint_for_overflow_retry :
+  summarizer:Keeper_compaction_llm_summarizer.summarizer option ->
   base_dir:string ->
   meta:Keeper_meta_contract.keeper_meta ->
   trigger:Compaction_trigger.t ->

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -96,7 +96,6 @@ let compaction_recovery_error_data ?dispatch_error error =
     match error with
     | Keeper_post_turn.Checkpoint_load_failed
         Keeper_checkpoint_store.Not_found -> Not_found
-    | Compaction_rejected Runtime_identity_unavailable
     | Compaction_rejected Structurally_unchanged
     | Compaction_rejected Checkpoint_not_reduced ->
       Precondition_failed

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -139,6 +139,7 @@ let recover_provider_context_overflow_in_lane
       ~(config : Workspace.config)
       ~base_dir
       ~(meta : keeper_meta)
+      ~(summarizer : Keeper_compaction_llm_summarizer.summarizer option)
       ~primary_model_max_tokens
       error
   =
@@ -196,6 +197,7 @@ let recover_provider_context_overflow_in_lane
           (try
              match
                recover_latest_checkpoint_for_overflow_retry
+                 ~summarizer
                  ~base_dir
                  ~meta
                  ~trigger
@@ -331,6 +333,8 @@ let append_provider_overflow_manifest
 let run_keeper_cycle
       ~(config : Workspace.config)
       ~(meta : keeper_meta)
+      ~(resolve_compaction_summarizer :
+          unit -> Keeper_compaction_llm_summarizer.summarizer option)
       ~(publication_recovery_provider :
           Keeper_publication_recovery_availability.provider)
       ~(observation : Keeper_world_observation.world_observation)
@@ -1075,6 +1079,7 @@ dominant source of the observed CAS race exhaustion after
                       ~config
                       ~base_dir
                       ~meta
+                      ~summarizer:(resolve_compaction_summarizer ())
                       ~primary_model_max_tokens:final_execution.max_context
                       err
                   in

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -168,6 +168,8 @@ type turn_success =
 val run_keeper_cycle
   :  config:Workspace.config
   -> meta:Keeper_meta_contract.keeper_meta
+  -> resolve_compaction_summarizer:
+       (unit -> Keeper_compaction_llm_summarizer.summarizer option)
   -> publication_recovery_provider:
        Keeper_publication_recovery_availability.provider
   -> observation:Keeper_world_observation.world_observation

--- a/test/test_compaction_llm_summarizer.ml
+++ b/test/test_compaction_llm_summarizer.ml
@@ -91,6 +91,70 @@ let test_lane_candidates_keep_declared_order () =
     (Some [ "local.kimi_like"; "fallback.kimi_like" ])
     actual
 
+let test_make_uses_caller_owned_eio_resources () =
+  with_temperature_runtime @@ fun _ ->
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let net = Eio.Stdenv.net env in
+  let clock = Eio.Stdenv.clock env in
+  let called_with_exact_resources = ref false in
+  let complete
+        ~sw:received_sw
+        ~net:received_net
+        ?clock:received_clock
+        ~config:_
+        ~messages:_
+        ()
+    =
+    called_with_exact_resources :=
+      received_sw == sw
+      && received_net == net
+      && Option.fold
+           ~none:false
+           ~some:(fun received_clock -> received_clock == clock)
+           received_clock;
+    Ok
+      { Agent_sdk.Types.id = "compaction-explicit-resources"
+      ; model = "test-model"
+      ; stop_reason = Agent_sdk.Types.EndTurn
+      ; content =
+          [ Agent_sdk.Types.Text
+              {|{"kept_indices":[0],"dropped_indices":[],"summarized_units":[]}|}
+          ]
+      ; usage = None
+      ; telemetry = None
+      }
+  in
+  let summarizer =
+    match
+      C.make
+        ~complete
+        ~sw
+        ~net
+        ~clock
+        ~runtime_id:temperature_runtime_id
+        ~keeper_name:"keeper-test"
+        ()
+    with
+    | Some summarizer -> summarizer
+    | None -> Alcotest.fail "explicit-resource summarizer should resolve"
+  in
+  let outcome =
+    summarizer
+      ~messages:
+        [ Agent_sdk.Types.text_message Agent_sdk.Types.User "keep this exact unit" ]
+  in
+  Alcotest.(check bool)
+    "provider received the caller-owned switch, net, and clock"
+    true
+    !called_with_exact_resources;
+  Alcotest.(check bool)
+    "valid terminal no-compaction judgment is preserved"
+    true
+    (match outcome with
+     | Some C.No_compaction -> true
+     | Some (C.Planned _) | None -> false)
+
 let () =
   Alcotest.run "compaction_llm_summarizer"
     [ ( "provider"
@@ -100,5 +164,7 @@ let () =
             test_provider_for_plan_preserves_temperature_omission
         ; Alcotest.test_case "lane candidates keep declared order" `Quick
             test_lane_candidates_keep_declared_order
+        ; Alcotest.test_case "make uses caller-owned Eio resources" `Quick
+            test_make_uses_caller_owned_eio_resources
         ] )
     ]

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -255,7 +255,7 @@ let test_manual_compaction_serializes_owner_lane () =
         ; since_last_scheduled_autonomous = None
         }
       in
-      let run_cycle () =
+      let run_cycle ?compaction_summarizer () =
         Cycle.run_keeper_cycle
           ~ctx
           ~meta_after_triage:meta
@@ -264,6 +264,7 @@ let test_manual_compaction_serializes_owner_lane () =
           ~turn_decision:decision
           ~shared_context:(Agent_sdk.Context.create_sync ())
           ~wake:(Masc.Keeper_registry.Woken [ Manual_compaction_requested ])
+          ?compaction_summarizer
           ~manual_compaction_requested:true
           ()
       in
@@ -301,14 +302,12 @@ let test_manual_compaction_serializes_owner_lane () =
       in
       Atomic.set owner_entry.fiber_stop true;
       let outcome =
-        Masc.Keeper_compaction_llm_summarizer.For_testing.with_make_override
-          (fun ~runtime_id:_ ~keeper_name:_ () ->
-             Some
-               (fun ~messages ->
-                  Some
-                    (Masc.Keeper_compaction_llm_summarizer.Planned
-                       (plan messages))))
-          run_cycle
+        run_cycle
+          ~compaction_summarizer:(fun ~messages ->
+            Some
+              (Masc.Keeper_compaction_llm_summarizer.Planned
+                 (plan messages)))
+          ()
       in
       (match outcome with
        | Cycle.Manual_compaction_applied _ -> ()


### PR DESCRIPTION
## Summary
- make the compaction LLM constructor require caller-owned switch and network resources, with an optional caller-owned clock
- remove ambient Eio_context lookup and the process-global Atomic constructor override
- inject the resolved summarizer explicitly through compact policy, manual compaction, and typed provider-overflow recovery
- make compact policy judge only summarizer availability and the typed LLM plan outcome; it no longer re-resolves meta Runtime identity
- preserve declared Runtime candidate order and terminal No_compaction behavior

## Boundary
- no timeout, budget, ratio, environment variable, or fallback heuristic was added
- the production Keeper bootstrap already supplies state.net, while resource-less paths remain an explicit Summarizer_unavailable rejection only when compaction is requested
- Runtime_identity_unavailable and its downstream tool-surface mapping were deleted as duplicate authority
- base: PR #24930 at 6d8704aef4

## Verification
- scripts/dune-local.sh build test/test_compaction_llm_summarizer.exe test/test_keeper_post_turn_wirein_order.exe test/test_keeper_compact_recovery_tool_surface.exe
- _build/default/test/test_compaction_llm_summarizer.exe (4/4)
- _build/default/test/test_keeper_post_turn_wirein_order.exe (3/3)
- _build/default/test/test_keeper_compact_recovery_tool_surface.exe (1/1)
- ocamlformat --check on all changed OCaml files
- git diff --check

## Size
- 16 files, 204 additions, 122 deletions, 326 changed lines