### PR TITLE
fix(keeper): isolate reaction ledger projection

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -392,44 +392,6 @@ let settlement_of_cycle_outcome ~base_path ~settled_at ~stop_requested ~lease ou
     )
 ;;
 
-let reaction_kind_of_settlement = function
-  | Keeper_registry_event_queue.Ack -> Keeper_reaction_ledger.Event_queue_ack
-  | Keeper_registry_event_queue.Requeue _ ->
-    Keeper_reaction_ledger.Event_queue_requeued
-  | Keeper_registry_event_queue.Escalate _ ->
-    Keeper_reaction_ledger.Event_queue_escalated
-;;
-
-let project_transition_outbox ~base_path ~keeper_name =
-  let rec project_entries = function
-    | [] -> Ok ()
-    | (entry : Keeper_registry_event_queue.outbox_entry) :: rest ->
-      let receipt = entry.receipt in
-      let reaction_kind = reaction_kind_of_settlement receipt.settlement in
-      (match
-         Keeper_reaction_ledger.record_event_queue_transition_reaction_result
-           ~base_path
-           ~keeper_name
-           ~reaction_kind
-           ~receipt
-           entry.stimulus
-       with
-       | Error _ as error -> error
-       | Ok () ->
-         (match
-            Keeper_registry_event_queue.mark_transition_projected_result
-              ~base_path
-              keeper_name
-              ~transition_id:receipt.transition_id
-          with
-          | Error _ as error -> error
-          | Ok () -> project_entries rest))
-  in
-  match Keeper_registry_event_queue.transition_outbox_result ~base_path keeper_name with
-  | Error _ as error -> error
-  | Ok entries -> project_entries entries
-;;
-
 let settle_claimed_lease
       ~base_path
       ~keeper_name
@@ -513,6 +475,7 @@ let run_keepalive_unified_turn
       ~(proactive_warmup_elapsed : bool)
       ~(turn_origin : turn_origin)
       ~(shared_context : Agent_sdk.Context.t)
+      ~notify_transition_projection
   : keepalive_turn_outcome
   =
   if not proactive_warmup_elapsed
@@ -573,17 +536,6 @@ let run_keepalive_unified_turn
              message)
     in
     try
-      (match
-         project_transition_outbox
-           ~base_path:ctx.config.base_path
-           ~keeper_name:meta_after_triage.name
-       with
-       | Ok () -> ()
-       | Error message ->
-         Log.Keeper.error
-           "registry: deferred transition projection keeper=%s: %s"
-           meta_after_triage.name
-           message);
       let event_intake =
         heartbeat_event_intake
           ~ctx
@@ -894,17 +846,7 @@ let run_keepalive_unified_turn
             lease_settled := true;
             ready_queue_followup :=
               ready_queue_followup_of_settlement ~lease settlement;
-            (match
-               project_transition_outbox
-                 ~base_path:ctx.config.base_path
-                 ~keeper_name:meta_after_triage.name
-             with
-             | Error message ->
-               Log.Keeper.error
-                 "registry: deferred transition projection keeper=%s: %s"
-                 meta_after_triage.name
-                 message
-             | Ok () -> ());
+            notify_transition_projection ();
             if settlement_is_ack settlement
             then
               mark_connector_attention_ignored_after_turn
@@ -1027,6 +969,16 @@ let run_heartbeat_loop
      and tool-call counters are recreated inside run_turn and therefore
      do not accumulate for the full keeper lifecycle. *)
   let shared_context = Agent_sdk.Context.create () in
+  let transition_projector =
+    Keeper_transition_projector.create
+      ~base_path:ctx.config.base_path
+      ~keeper_name:m.name
+  in
+  (* Read-model projection is lane-owned but not lane-authoritative.  A blocked
+     projector therefore cannot keep the heartbeat body alive during teardown. *)
+  Eio.Fiber.fork_daemon ~sw:ctx.sw (fun () ->
+    Keeper_transition_projector.run transition_projector;
+    `Stop_daemon);
   (* Mtime-based change detection for keeper meta disk reads.
      Avoids re-parsing the JSON file on every heartbeat cycle when
      no operator has modified it.  Initialized to 0.0 so the first
@@ -1212,6 +1164,8 @@ let run_heartbeat_loop
                 ~proactive_warmup_elapsed
                 ~turn_origin:!last_turn_origin
                 ~shared_context
+                ~notify_transition_projection:(fun () ->
+                  Keeper_transition_projector.notify transition_projector)
             in
             Keeper_keepalive_signal.pre_turn_complete_heartbeat ~turn_running;
             turn_running := false;
@@ -1314,5 +1268,7 @@ let run_heartbeat_loop
            last_turn_origin := origin);
       if Atomic.get stop then () else loop ())
   in
-  loop ()
+  Eio_guard.protect
+    ~finally:(fun () -> Keeper_transition_projector.stop transition_projector)
+    loop
 ;;

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -171,12 +171,6 @@ val settlement_of_cycle_outcome :
 (** Pure lease settlement boundary. Completed work acknowledges; typed
     cancellation and non-executable-phase skips requeue. *)
 
-val project_transition_outbox :
-  base_path:string -> keeper_name:string -> (unit, string) result
-(** Idempotently materialize the lane's single durable transition into the
-    reaction ledger, then retire the outbox entry. New claims remain blocked
-    while this projection is incomplete. *)
-
 (** Pure: post-turn status event derived from the registry
     turn-failure counter. [turn_fail_count > 0] maps to [Turn_failed];
     [0] maps to [Turn_succeeded]. *)
@@ -196,6 +190,7 @@ val run_keepalive_unified_turn :
   proactive_warmup_elapsed:bool ->
   turn_origin:turn_origin ->
   shared_context:Agent_sdk.Context.t ->
+  notify_transition_projection:(unit -> unit) ->
   keepalive_turn_outcome
 
 val refresh_work_as_heartbeat :

--- a/lib/keeper/keeper_transition_projector.ml
+++ b/lib/keeper/keeper_transition_projector.ml
@@ -1,0 +1,148 @@
+type t =
+  { base_path : string
+  ; keeper_name : string
+  ; project : unit -> (int, string) result
+  ; dispatch :
+      (unit -> (int, string) result) ->
+      (int, string) result
+  ; wake_pending : bool Atomic.t
+  ; stop_requested : bool Atomic.t
+  ; wake_condition : Eio.Condition.t
+  }
+
+let reaction_kind_of_settlement = function
+  | Keeper_registry_event_queue.Ack -> Keeper_reaction_ledger.Event_queue_ack
+  | Keeper_registry_event_queue.Requeue _ ->
+    Keeper_reaction_ledger.Event_queue_requeued
+  | Keeper_registry_event_queue.Escalate _ ->
+    Keeper_reaction_ledger.Event_queue_escalated
+;;
+
+let project_pending ~base_path ~keeper_name =
+  let rec project_entries count = function
+    | [] -> Ok count
+    | (entry : Keeper_registry_event_queue.outbox_entry) :: rest ->
+      let receipt = entry.receipt in
+      let reaction_kind = reaction_kind_of_settlement receipt.settlement in
+      (match
+         Keeper_reaction_ledger.record_event_queue_transition_reaction_result
+           ~base_path
+           ~keeper_name
+           ~reaction_kind
+           ~receipt
+           entry.stimulus
+       with
+       | Error _ as error -> error
+       | Ok () ->
+         (match
+            Keeper_registry_event_queue.mark_transition_projected_result
+              ~base_path
+              keeper_name
+              ~transition_id:receipt.transition_id
+          with
+          | Error _ as error -> error
+          | Ok () -> project_entries (count + 1) rest))
+  in
+  match Keeper_registry_event_queue.transition_outbox_result ~base_path keeper_name with
+  | Error _ as error -> error
+  | Ok entries -> project_entries 0 entries
+;;
+
+let create_with_dispatch ~base_path ~keeper_name ~project ~dispatch =
+  { base_path
+  ; keeper_name
+  ; project
+  ; dispatch
+  ; wake_pending = Atomic.make true
+  ; stop_requested = Atomic.make false
+  ; wake_condition = Eio.Condition.create ()
+  }
+;;
+
+let create_with_project ~base_path ~keeper_name ~project =
+  create_with_dispatch
+    ~base_path
+    ~keeper_name
+    ~project
+    ~dispatch:(fun project -> project ())
+;;
+
+let create ~base_path ~keeper_name =
+  create_with_dispatch
+    ~base_path
+    ~keeper_name
+    ~project:(fun () -> project_pending ~base_path ~keeper_name)
+    ~dispatch:(fun project ->
+      match Executor_pool_ref.get () with
+      | None -> Error "server executor pool is unavailable"
+      | Some pool ->
+        Eio.Executor_pool.submit_exn pool ~weight:1.0 (fun () ->
+          Eio.Switch.run (fun _sw -> project ())))
+;;
+
+let notify t =
+  Atomic.set t.wake_pending true;
+  Eio.Condition.broadcast t.wake_condition
+;;
+
+let stop t =
+  Atomic.set t.stop_requested true;
+  Eio.Condition.broadcast t.wake_condition
+;;
+
+type command =
+  | Project
+  | Stop
+
+let await_command t =
+  Eio.Condition.loop_no_mutex t.wake_condition (fun () ->
+    if Atomic.get t.stop_requested
+    then Some Stop
+    else if Atomic.exchange t.wake_pending false
+    then Some Project
+    else None)
+;;
+
+let project_once t =
+  let result =
+    try
+      t.dispatch (fun () ->
+        try t.project () with
+        | Eio.Cancel.Cancelled _ as exn -> raise exn
+        | exn ->
+          Error
+            (Printf.sprintf
+               "unexpected projector exception: %s"
+               (Printexc.to_string exn)))
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn ->
+      Error
+        (Printf.sprintf
+           "projector dispatch failed: %s"
+           (Printexc.to_string exn))
+  in
+  match result with
+  | Ok _ -> ()
+  | Error detail ->
+    Log.Keeper.error
+      "reaction ledger projector failed keeper=%s base_path=%s: %s"
+      t.keeper_name
+      t.base_path
+      detail
+;;
+
+let run t =
+  let rec loop () =
+    match await_command t with
+    | Stop -> ()
+    | Project ->
+      project_once t;
+      loop ()
+  in
+  loop ()
+;;
+
+module For_testing = struct
+  let create_with_project = create_with_project
+end

--- a/lib/keeper/keeper_transition_projector.mli
+++ b/lib/keeper/keeper_transition_projector.mli
@@ -1,0 +1,38 @@
+(** Per-Keeper event-transition outbox projector.
+
+    The durable event queue remains the lifecycle authority.  This actor only
+    materializes its ordered outbox into the Reaction Ledger read model and
+    retires an entry after the ledger append succeeds. *)
+
+type t
+
+val create : base_path:string -> keeper_name:string -> t
+(** Create one lane-owned projector.  The initial wake is pending so durable
+    backlog left by an earlier process is retried without a timer. *)
+
+val notify : t -> unit
+(** Coalescing, nonblocking wake.  Safe to call on the Keeper control path
+    after durable settlement. *)
+
+val stop : t -> unit
+(** Ask the actor to stop without discarding durable outbox entries. *)
+
+val run : t -> unit
+(** Run until {!stop} or structured cancellation.  Projection failures are
+    logged and retained for the next explicit wake.  Production projection
+    fails explicitly when the server executor is unavailable; it never falls
+    back to blocking file I/O on the Keeper Eio domain. *)
+
+val project_pending :
+  base_path:string -> keeper_name:string -> (int, string) result
+(** Synchronously project every currently ordered outbox entry.  Returns the
+    number retired.  This is exposed for recovery commands and focused tests;
+    Keeper heartbeat code must use {!notify}. *)
+
+module For_testing : sig
+  val create_with_project :
+    base_path:string ->
+    keeper_name:string ->
+    project:(unit -> (int, string) result) ->
+    t
+end

--- a/lib/keeper_runtime/keeper_event_queue_state.mli
+++ b/lib/keeper_runtime/keeper_event_queue_state.mli
@@ -113,8 +113,9 @@ val active_lease : t -> lease option
 val mark_transition_projected : transition_id:string -> t -> (t, string) result
 (** Atomically retire the oldest durable outbox entry after an external projector has
     materialized its stable [event_id]. Other ordered entries remain durable;
-    the retired receipt is retained for an immediate idempotent retry. Unknown
-    transition ids fail closed. *)
+    the retired receipt is retained for an immediate idempotent retry. Claims
+    are independent of this read-model cursor. Unknown transition ids fail
+    closed. *)
 
 val remove_by_post_id :
   Keeper_event_queue.post_id -> t -> Keeper_event_queue.stimulus list * t

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -4,6 +4,7 @@ module Persistence = Keeper_event_queue_persistence
 module Heartbeat = Masc.Keeper_heartbeat_loop
 module Intake = Masc.Keeper_heartbeat_stimulus_intake
 module Registry = Masc.Keeper_registry
+module Projector = Masc.Keeper_transition_projector
 
 let require_ok label = function
   | Ok value -> value
@@ -981,7 +982,8 @@ let test_transition_outbox_projects_with_stable_identity () =
       |> require_ok "load ordered transition outbox"
     in
     Alcotest.(check int) "two settlements await projection" 2 (List.length queued_outbox);
-    Masc.Keeper_heartbeat_loop.project_transition_outbox ~base_path ~keeper_name
+    Projector.project_pending ~base_path ~keeper_name
+    |> Result.map ignore
     |> require_ok "project transition outbox";
     let state =
       Persistence.load_state_result ~base_path ~keeper_name
@@ -1009,8 +1011,114 @@ let test_transition_outbox_projects_with_stable_identity () =
       "stable event id deduplicates crash replay"
       2
       (summary |> member "event_queue_ack_count" |> to_int);
-    Masc.Keeper_heartbeat_loop.project_transition_outbox ~base_path ~keeper_name
+    Projector.project_pending ~base_path ~keeper_name
+    |> Result.map ignore
     |> require_ok "empty outbox projection is idempotent")
+;;
+
+let test_slow_failed_projection_preserves_lane_claim_and_provenance () =
+  with_temp_dir "keeper-transition-projector-isolation" (fun base_path ->
+    let keeper_name = "projection_isolation_keeper" in
+    let source = stimulus "projection-source" 1.0 in
+    let unrelated = stimulus "projection-unrelated" 2.0 in
+    Persistence.update_result ~base_path ~keeper_name (fun pending ->
+      Queue.enqueue (Queue.enqueue pending source) unrelated)
+    |> require_ok "seed projection isolation queue";
+    let source_lease =
+      Persistence.claim_when_result
+        ~base_path
+        ~keeper_name
+        ~claimed_at:3.0
+        ~ready:(fun _ -> true)
+        ()
+      |> require_ok "claim projection source"
+      |> require_some "projection source lease"
+    in
+    ignore
+      (Persistence.settle_result
+         ~base_path
+         ~keeper_name
+         ~settled_at:4.0
+         ~lease:source_lease
+         ~settlement:State.Ack
+         ()
+       |> require_ok "settle projection source");
+    let started, resolve_started = Eio.Promise.create () in
+    let release, resolve_release = Eio.Promise.create () in
+    let finished, resolve_finished = Eio.Promise.create () in
+    let projector =
+      Projector.For_testing.create_with_project
+        ~base_path
+        ~keeper_name
+        ~project:(fun () ->
+          Eio.Promise.resolve resolve_started ();
+          Eio.Promise.await release;
+          let result = Projector.project_pending ~base_path ~keeper_name in
+          Eio.Promise.resolve resolve_finished result;
+          result)
+    in
+    Dated_jsonl.set_append_guard (fun _ -> raise Exit);
+    let projection_result =
+      Fun.protect
+        ~finally:Dated_jsonl.For_testing.reset_append_guard
+        (fun () ->
+           Eio_main.run
+           @@ fun _env ->
+           Eio.Switch.run
+           @@ fun sw ->
+           Eio.Fiber.fork ~sw (fun () -> Projector.run projector);
+           Eio.Promise.await started;
+           Projector.notify projector;
+           let state =
+             Persistence.load_state_result ~base_path ~keeper_name
+             |> require_ok "load queue during slow projection"
+           in
+           let origin =
+             Heartbeat.next_turn_origin
+               ~ready_queue_followup_count:
+                 (Intake.ready_stimulus_count
+                    ~excluding:None
+                    (State.pending state))
+               ~sleep:(fun () -> Alcotest.fail "internal drain entered wakeup CAS")
+             |> require_some "internal lane drain origin"
+           in
+           (match Heartbeat.wake_reason_of_turn_origin origin [ unrelated ] with
+            | Registry.Ready_queue_followup [ Queue.Bootstrap ] -> ()
+            | Registry.Ready_queue_followup _
+            | Registry.Proactive_tick
+            | Registry.Woken _ ->
+              Alcotest.fail "slow projection fabricated external wake provenance");
+           let unrelated_lease =
+             Persistence.claim_when_result
+               ~base_path
+               ~keeper_name
+               ~claimed_at:5.0
+               ~ready:(fun _ -> true)
+               ()
+             |> require_ok "claim during slow projection"
+             |> require_some "unrelated lease during slow projection"
+           in
+           Alcotest.(check string)
+             "slow projection does not prevent unrelated actual lease"
+             unrelated.post_id
+             (Persistence.lease_stimulus unrelated_lease).post_id;
+           Projector.stop projector;
+           Eio.Promise.resolve resolve_release ();
+           Eio.Promise.await finished)
+    in
+    (match projection_result with
+     | Error _ -> ()
+     | Ok _ -> Alcotest.fail "injected projection failure was not explicit");
+    let retained =
+      Persistence.transition_outbox_result ~base_path ~keeper_name
+      |> require_ok "load retained projection outbox"
+    in
+    Alcotest.(check int) "failure retains exact outbox entry" 1 (List.length retained);
+    Alcotest.(check int)
+      "later retry retires retained entry"
+      1
+      (Projector.project_pending ~base_path ~keeper_name
+       |> require_ok "retry retained projection"))
 ;;
 
 let test_registration_preparation_is_atomic_and_fail_closed () =
@@ -1175,6 +1283,10 @@ let () =
             "transition outbox projection"
             `Quick
             test_transition_outbox_projects_with_stable_identity
+        ; Alcotest.test_case
+            "slow failed projection preserves lane claim and provenance"
+            `Quick
+            test_slow_failed_projection_preserves_lane_claim_and_provenance
         ; Alcotest.test_case
             "registration preparation"
             `Quick

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -485,7 +485,10 @@ let test_acked_occurrence_recovery_does_not_enqueue_or_wake_again () =
        | Ok (Keeper_registry_event_queue.Settled _)
        | Ok (Keeper_registry_event_queue.Already_settled _) -> ()
        | Error detail -> fail detail);
-      (match Keeper_heartbeat_loop.project_transition_outbox ~base_path ~keeper_name with
+      (match
+         Keeper_transition_projector.project_pending ~base_path ~keeper_name
+         |> Result.map ignore
+       with
        | Ok () -> ()
        | Error detail -> fail detail);
       (match Schedule_store.get_schedule config ~schedule_id:request.schedule_id with


### PR DESCRIPTION
## Outcome

Reaction Ledger projection no longer runs on the Keeper heartbeat/control hot path.

- durable event-queue settlement/outbox remains the sole lifecycle authority
- each Keeper owns an independent projection daemon, wake bit, and condition
- heartbeat performs only a coalescing `notify` after durable settlement
- startup immediately retries durable backlog left by an earlier process
- projection I/O runs through the server executor resource; unavailable dispatch is an explicit failure and never becomes claim admission authority
- append/dispatch failure leaves the exact ordered backlog durable for an explicit wake or restart retry
- the former synchronous `Keeper_heartbeat_loop.project_transition_outbox` API is hard-deleted

## Stack

Stacked on replacement foundation #24976 (`097f978a2e`), which supersedes closed #24646. It inherits repaired FIFO/LaneDrain and external-wake provenance from #24630.

## Focused nonblocking proof

One integrated test now:

1. settles a source and starts its projector;
2. holds projection I/O in flight and injects an explicit ledger failure;
3. verifies the same Keeper selects `Ready_queue_followup`, never external `Woken`;
4. verifies an unrelated stimulus becomes the actual durable lease while projection is still blocked;
5. verifies failure retains the exact outbox entry and a later retry retires it.

## Verification

- `scripts/dune-local.sh build test/test_keeper_event_queue_state_v2.exe test/test_schedule_consumer_dispatch.exe`
- `test_keeper_event_queue_state_v2.exe`: 16/16 PASS
- `test_schedule_consumer_dispatch.exe`: 11/11 PASS
- `ocamlformat --check` on all touched OCaml files
- `git diff --check`
- synchronous `project_transition_outbox` references: 0
- heartbeat `project_pending` / `Dated_jsonl` calls: 0
- production inline fallback: 0

## Scope

397 changed lines. Reaction Ledger remains a read model. This PR adds no timer, timeout, environment knob, fleet cap, retry-count cap, polling heuristic, global projection lifecycle authority, or inline production I/O fallback. The shared executor is only an execution resource: saturation/unavailability may delay projection, but cannot block any Keeper claim lane and cannot discard its durable backlog.
