### PR TITLE
feat(keeper): preserve exact checkpoint snapshots

### DIFF
--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -589,6 +589,16 @@ type checkpoint_ref_load_error =
       }
   | Ref_lock_failed of string
 
+type exact_checkpoint_snapshot =
+  { checkpoint : Agent_sdk.Checkpoint.t
+  ; reference : Keeper_checkpoint_ref.t
+  ; canonical_bytes : string
+  }
+
+let exact_snapshot_checkpoint snapshot = snapshot.checkpoint
+let exact_snapshot_reference snapshot = snapshot.reference
+let exact_snapshot_canonical_bytes snapshot = snapshot.canonical_bytes
+
 type checkpoint_cas_error =
   | Source_unavailable of checkpoint_ref_load_error
   | Source_changed of Keeper_checkpoint_ref.t
@@ -643,6 +653,29 @@ let checkpoint_ref_of_canonical_bytes canonical_bytes
          ~canonical_checkpoint_bytes:canonical_bytes
        |> Result.map_error (fun error -> Ref_create_failed error))
 
+let exact_snapshot_of_checkpoint ~expected_session_id ~canonical_bytes checkpoint =
+  match checkpoint_ref_of_canonical_bytes canonical_bytes checkpoint with
+  | Error error -> Error (Ref_identity_invalid error)
+  | Ok reference
+    when not
+           (Keeper_id.Trace_id.equal
+              expected_session_id reference.trace_id) ->
+    Error
+      (Ref_session_mismatch
+         { expected = expected_session_id; actual = reference.trace_id })
+  | Ok reference -> Ok { checkpoint; reference; canonical_bytes }
+;;
+
+let exact_snapshot_of_canonical_bytes ~expected_session_id canonical_bytes =
+  match Agent_sdk.Checkpoint.of_string canonical_bytes with
+  | Error error -> Error (Ref_read_failed (classify_sdk_error error))
+  | Ok checkpoint ->
+    exact_snapshot_of_checkpoint
+      ~expected_session_id
+      ~canonical_bytes
+      checkpoint
+;;
+
 let load_ref_locked ~session_dir ~expected_session_id =
   let canonical_path =
     oas_checkpoint_path
@@ -653,18 +686,12 @@ let load_ref_locked ~session_dir ~expected_session_id =
   | Error error -> Error (Ref_read_failed error)
   | Ok None -> Error Ref_not_found
   | Ok (Some (canonical_bytes, checkpoint)) ->
-    (match checkpoint_ref_of_canonical_bytes canonical_bytes checkpoint with
-     | Error error -> Error (Ref_identity_invalid error)
-     | Ok reference
-       when not
-              (Keeper_id.Trace_id.equal
-                 expected_session_id reference.trace_id) ->
-       Error
-         (Ref_session_mismatch
-            { expected = expected_session_id; actual = reference.trace_id })
-     | Ok reference -> Ok (checkpoint, reference))
+    exact_snapshot_of_checkpoint
+      ~expected_session_id
+      ~canonical_bytes
+      checkpoint
 
-let load_oas_with_ref ~session_dir ~session_id =
+let load_oas_exact_snapshot ~session_dir ~session_id =
   match Keeper_id.Trace_id.of_string session_id with
   | Error reason -> Error (Ref_identity_invalid (Session_id_invalid reason))
   | Ok expected_session_id ->
@@ -674,6 +701,12 @@ let load_oas_with_ref ~session_dir ~session_id =
      with
      | Ok result -> result
      | Error detail -> Error (Ref_lock_failed detail))
+
+let load_oas_with_ref ~session_dir ~session_id =
+  load_oas_exact_snapshot ~session_dir ~session_id
+  |> Result.map (fun snapshot ->
+    exact_snapshot_checkpoint snapshot, exact_snapshot_reference snapshot)
+;;
 
 let with_checkpoint_cas_lock ~session_dir ~candidate_ref f =
   match canonical_session_location session_dir with
@@ -733,11 +766,14 @@ let save_oas_if_source
     let expected_session_id = expected_source_ref.trace_id in
     with_checkpoint_cas_lock ~session_dir ~candidate_ref (fun session_dir ->
       match load_ref_locked ~session_dir ~expected_session_id with
-         | Error error -> Error (Source_unavailable error)
-         | Ok (_, actual_source)
-           when not (Keeper_checkpoint_ref.equal expected_source_ref actual_source) ->
-           Error (Source_changed actual_source)
-         | Ok _ ->
+      | Error error -> Error (Source_unavailable error)
+      | Ok snapshot
+        when not
+               (Keeper_checkpoint_ref.equal
+                  expected_source_ref
+                  (exact_snapshot_reference snapshot)) ->
+        Error (Source_changed (exact_snapshot_reference snapshot))
+      | Ok _ ->
            let canonical_path =
              oas_checkpoint_path
                ~session_dir

--- a/lib/keeper/keeper_checkpoint_store.mli
+++ b/lib/keeper/keeper_checkpoint_store.mli
@@ -143,6 +143,31 @@ type checkpoint_ref_load_error =
       }
   | Ref_lock_failed of string
 
+(** Canonical checkpoint value, exact persisted bytes, and their reference
+    derived from one immutable byte snapshot. *)
+type exact_checkpoint_snapshot
+
+val exact_snapshot_checkpoint :
+  exact_checkpoint_snapshot -> Agent_sdk.Checkpoint.t
+
+val exact_snapshot_reference :
+  exact_checkpoint_snapshot -> Keeper_checkpoint_ref.t
+
+val exact_snapshot_canonical_bytes : exact_checkpoint_snapshot -> string
+
+(** Strictly decode exact canonical bytes and derive their reference without
+    re-encoding. *)
+val exact_snapshot_of_canonical_bytes :
+  expected_session_id:Keeper_id.Trace_id.t ->
+  string ->
+  (exact_checkpoint_snapshot, checkpoint_ref_load_error) result
+
+(** Load an exact canonical checkpoint snapshot under the session lock. *)
+val load_oas_exact_snapshot :
+  session_dir:string ->
+  session_id:string ->
+  (exact_checkpoint_snapshot, checkpoint_ref_load_error) result
+
 (** Load one canonical checkpoint and its exact source identity from the same
     locked byte snapshot. No size, mtime, timestamp, or process cache
     participates in the identity. *)

--- a/test/test_keeper_checkpoint_stale_guard.ml
+++ b/test/test_keeper_checkpoint_stale_guard.ml
@@ -515,6 +515,47 @@ let test_checkpoint_ref_requires_generation () =
            Keeper_checkpoint_store.Generation_missing) -> ()
     | _ -> fail "generation-less checkpoint acquired an exact ref")
 
+let test_exact_snapshot_preserves_locked_canonical_bytes () =
+  let session_dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir session_dir) (fun () ->
+    let session_id = "sess-exact-snapshot" in
+    save_ok ~session_dir
+      (make_checkpoint ~session_id ~turn_count:4 ~marker:"exact"
+       |> with_generation 2)
+      "exact snapshot seed";
+    let canonical_path = Filename.concat session_dir (session_id ^ ".json") in
+    let expected_bytes =
+      Fs_compat.load_file canonical_path
+      |> Yojson.Safe.from_string
+      |> Yojson.Safe.pretty_to_string
+    in
+    Fs_compat.save_file canonical_path expected_bytes;
+    match
+      Keeper_checkpoint_store.load_oas_exact_snapshot
+        ~session_dir
+        ~session_id
+    with
+    | Error _ -> fail "exact snapshot load failed"
+    | Ok snapshot ->
+      check string "canonical bytes are not re-encoded" expected_bytes
+        (Keeper_checkpoint_store.exact_snapshot_canonical_bytes snapshot);
+      let reference =
+        Keeper_checkpoint_store.exact_snapshot_reference snapshot
+      in
+      let expected_session_id =
+        Result.get_ok (Keeper_id.Trace_id.of_string session_id)
+      in
+      match
+        Keeper_checkpoint_store.exact_snapshot_of_canonical_bytes
+          ~expected_session_id
+          expected_bytes
+      with
+      | Ok decoded ->
+        check bool "pure decode derives the same exact ref" true
+          (Keeper_checkpoint_ref.equal reference
+             (Keeper_checkpoint_store.exact_snapshot_reference decoded))
+      | Error _ -> fail "exact snapshot bytes did not decode")
+
 let () =
   run "Keeper_checkpoint_store checkpoint watermark (RFC-0225 §3.2)"
     [
@@ -544,5 +585,7 @@ let () =
             test_exact_source_cas_allows_one_equal_turn_writer;
           test_case "checkpoint refs require keeper generation" `Quick
             test_checkpoint_ref_requires_generation;
+          test_case "exact snapshot preserves canonical bytes" `Quick
+            test_exact_snapshot_preserves_locked_canonical_bytes;
         ] );
     ]


### PR DESCRIPTION
## Summary
- expose an opaque exact checkpoint snapshot derived under the canonical session lock
- preserve the original canonical bytes alongside the decoded checkpoint and exact ref
- route the existing `load_oas_with_ref` compatibility projection through the same snapshot SSOT

## Invariants
- no checkpoint re-encoding participates in identity
- strict decode and ref derivation share one implementation
- size, mtime, timestamps, and process caches do not participate

## Verification
- `scripts/dune-local.sh build test/test_keeper_checkpoint_stale_guard.exe`
- `_build/default/test/test_keeper_checkpoint_stale_guard.exe` (13/13)