### PR TITLE
feat(keeper): rebase compacted checkpoint over live delta

### DIFF
--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -589,6 +589,16 @@ type checkpoint_ref_load_error =
       }
   | Ref_lock_failed of string
 
+type exact_checkpoint_snapshot =
+  { checkpoint : Agent_sdk.Checkpoint.t
+  ; reference : Keeper_checkpoint_ref.t
+  ; canonical_bytes : string
+  }
+
+let exact_snapshot_checkpoint snapshot = snapshot.checkpoint
+let exact_snapshot_reference snapshot = snapshot.reference
+let exact_snapshot_canonical_bytes snapshot = snapshot.canonical_bytes
+
 type checkpoint_cas_error =
   | Source_unavailable of checkpoint_ref_load_error
   | Source_changed of Keeper_checkpoint_ref.t
@@ -643,6 +653,29 @@ let checkpoint_ref_of_canonical_bytes canonical_bytes
          ~canonical_checkpoint_bytes:canonical_bytes
        |> Result.map_error (fun error -> Ref_create_failed error))
 
+let exact_snapshot_of_checkpoint ~expected_session_id ~canonical_bytes checkpoint =
+  match checkpoint_ref_of_canonical_bytes canonical_bytes checkpoint with
+  | Error error -> Error (Ref_identity_invalid error)
+  | Ok reference
+    when not
+           (Keeper_id.Trace_id.equal
+              expected_session_id reference.trace_id) ->
+    Error
+      (Ref_session_mismatch
+         { expected = expected_session_id; actual = reference.trace_id })
+  | Ok reference -> Ok { checkpoint; reference; canonical_bytes }
+;;
+
+let exact_snapshot_of_canonical_bytes ~expected_session_id canonical_bytes =
+  match Agent_sdk.Checkpoint.of_string canonical_bytes with
+  | Error error -> Error (Ref_read_failed (classify_sdk_error error))
+  | Ok checkpoint ->
+    exact_snapshot_of_checkpoint
+      ~expected_session_id
+      ~canonical_bytes
+      checkpoint
+;;
+
 let load_ref_locked ~session_dir ~expected_session_id =
   let canonical_path =
     oas_checkpoint_path
@@ -653,18 +686,12 @@ let load_ref_locked ~session_dir ~expected_session_id =
   | Error error -> Error (Ref_read_failed error)
   | Ok None -> Error Ref_not_found
   | Ok (Some (canonical_bytes, checkpoint)) ->
-    (match checkpoint_ref_of_canonical_bytes canonical_bytes checkpoint with
-     | Error error -> Error (Ref_identity_invalid error)
-     | Ok reference
-       when not
-              (Keeper_id.Trace_id.equal
-                 expected_session_id reference.trace_id) ->
-       Error
-         (Ref_session_mismatch
-            { expected = expected_session_id; actual = reference.trace_id })
-     | Ok reference -> Ok (checkpoint, reference))
+    exact_snapshot_of_checkpoint
+      ~expected_session_id
+      ~canonical_bytes
+      checkpoint
 
-let load_oas_with_ref ~session_dir ~session_id =
+let load_oas_exact_snapshot ~session_dir ~session_id =
   match Keeper_id.Trace_id.of_string session_id with
   | Error reason -> Error (Ref_identity_invalid (Session_id_invalid reason))
   | Ok expected_session_id ->
@@ -674,6 +701,12 @@ let load_oas_with_ref ~session_dir ~session_id =
      with
      | Ok result -> result
      | Error detail -> Error (Ref_lock_failed detail))
+
+let load_oas_with_ref ~session_dir ~session_id =
+  load_oas_exact_snapshot ~session_dir ~session_id
+  |> Result.map (fun snapshot ->
+    exact_snapshot_checkpoint snapshot, exact_snapshot_reference snapshot)
+;;
 
 let with_checkpoint_cas_lock ~session_dir ~candidate_ref f =
   match canonical_session_location session_dir with
@@ -733,11 +766,14 @@ let save_oas_if_source
     let expected_session_id = expected_source_ref.trace_id in
     with_checkpoint_cas_lock ~session_dir ~candidate_ref (fun session_dir ->
       match load_ref_locked ~session_dir ~expected_session_id with
-         | Error error -> Error (Source_unavailable error)
-         | Ok (_, actual_source)
-           when not (Keeper_checkpoint_ref.equal expected_source_ref actual_source) ->
-           Error (Source_changed actual_source)
-         | Ok _ ->
+      | Error error -> Error (Source_unavailable error)
+      | Ok snapshot
+        when not
+               (Keeper_checkpoint_ref.equal
+                  expected_source_ref
+                  (exact_snapshot_reference snapshot)) ->
+        Error (Source_changed (exact_snapshot_reference snapshot))
+      | Ok _ ->
            let canonical_path =
              oas_checkpoint_path
                ~session_dir

--- a/lib/keeper/keeper_checkpoint_store.mli
+++ b/lib/keeper/keeper_checkpoint_store.mli
@@ -143,6 +143,31 @@ type checkpoint_ref_load_error =
       }
   | Ref_lock_failed of string
 
+(** Canonical checkpoint value, exact persisted bytes, and their reference
+    derived from one immutable byte snapshot. *)
+type exact_checkpoint_snapshot
+
+val exact_snapshot_checkpoint :
+  exact_checkpoint_snapshot -> Agent_sdk.Checkpoint.t
+
+val exact_snapshot_reference :
+  exact_checkpoint_snapshot -> Keeper_checkpoint_ref.t
+
+val exact_snapshot_canonical_bytes : exact_checkpoint_snapshot -> string
+
+(** Strictly decode exact canonical bytes and derive their reference without
+    re-encoding. *)
+val exact_snapshot_of_canonical_bytes :
+  expected_session_id:Keeper_id.Trace_id.t ->
+  string ->
+  (exact_checkpoint_snapshot, checkpoint_ref_load_error) result
+
+(** Load an exact canonical checkpoint snapshot under the session lock. *)
+val load_oas_exact_snapshot :
+  session_dir:string ->
+  session_id:string ->
+  (exact_checkpoint_snapshot, checkpoint_ref_load_error) result
+
 (** Load one canonical checkpoint and its exact source identity from the same
     locked byte snapshot. No size, mtime, timestamp, or process cache
     participates in the identity. *)

--- a/lib/keeper/keeper_compaction_live_delta.ml
+++ b/lib/keeper/keeper_compaction_live_delta.ml
@@ -1,0 +1,49 @@
+type error =
+  | Source_superseded of
+      { source_trace_id : Keeper_id.Trace_id.t
+      ; source_generation : int
+      ; current_trace_id : Keeper_id.Trace_id.t
+      ; current_generation : int
+      }
+  | Current_messages_prefix_mismatch of Keeper_replay_prefix.prefix_mismatch
+
+let same_lineage (source_ref : Keeper_checkpoint_ref.t)
+    (current_ref : Keeper_checkpoint_ref.t) =
+  Keeper_id.Trace_id.equal source_ref.trace_id current_ref.trace_id
+  && Int.equal source_ref.generation current_ref.generation
+;;
+
+let rebase ~source ~compacted_messages ~current =
+  let source_checkpoint =
+    Keeper_checkpoint_store.exact_snapshot_checkpoint source
+  in
+  let current_checkpoint =
+    Keeper_checkpoint_store.exact_snapshot_checkpoint current
+  in
+  let source_ref = Keeper_checkpoint_store.exact_snapshot_reference source in
+  let current_ref = Keeper_checkpoint_store.exact_snapshot_reference current in
+  let candidate = { source_checkpoint with messages = compacted_messages } in
+  if Keeper_checkpoint_ref.equal source_ref current_ref
+  then Ok candidate
+  else if not (same_lineage source_ref current_ref)
+  then
+    Error
+      (Source_superseded
+         { source_trace_id = source_ref.trace_id
+         ; source_generation = source_ref.generation
+         ; current_trace_id = current_ref.trace_id
+         ; current_generation = current_ref.generation
+         })
+  else
+    match
+      Keeper_replay_prefix.split
+        ~prefix:source_checkpoint.messages
+        current_checkpoint.messages
+    with
+    | Error mismatch -> Error (Current_messages_prefix_mismatch mismatch)
+    | Ok exact_suffix ->
+      Ok
+        { current_checkpoint with
+          messages = compacted_messages @ exact_suffix
+        }
+;;

--- a/lib/keeper/keeper_compaction_live_delta.mli
+++ b/lib/keeper/keeper_compaction_live_delta.mli
@@ -1,0 +1,34 @@
+(** Deterministic rebase of a compacted checkpoint over live append-only
+    Keeper progress.
+
+    The caller supplies only the replacement messages.  The candidate
+    checkpoint is constructed from [source] inside this boundary, so
+    compaction cannot alter checkpoint identity, metadata, context, usage, or
+    turn coordinates. *)
+
+type error =
+  | Source_superseded of
+      { source_trace_id : Keeper_id.Trace_id.t
+      ; source_generation : int
+      ; current_trace_id : Keeper_id.Trace_id.t
+      ; current_generation : int
+      }
+  | Current_messages_prefix_mismatch of Keeper_replay_prefix.prefix_mismatch
+
+val rebase
+  :  source:Keeper_checkpoint_store.exact_checkpoint_snapshot
+  -> compacted_messages:Agent_sdk.Types.message list
+  -> current:Keeper_checkpoint_store.exact_checkpoint_snapshot
+  -> (Agent_sdk.Checkpoint.t, error) result
+(** Returns the source checkpoint with [compacted_messages] when the source
+    and current snapshot references are identical.
+
+    For a later checkpoint in the same trace and generation, [source.messages]
+    must be an exact structural prefix of [current.messages].  The exact live
+    suffix is appended to [compacted_messages], while every other field comes
+    from [current].
+
+    Checkpoints and their references arrive as one exact snapshot type, so a
+    mismatched pair is not representable.  Diverged lineage and prefix
+    mismatches fail explicitly.  No serialization, semantic matching, size
+    threshold, or time heuristic is used. *)

--- a/test/keeper_compaction_live_delta/dune
+++ b/test/keeper_compaction_live_delta/dune
@@ -1,0 +1,8 @@
+(test
+ (name test_keeper_compaction_live_delta)
+ (libraries
+  agent_sdk
+  alcotest
+  masc
+  masc.keeper_checkpoint_ref
+  masc.keeper_registry))

--- a/test/keeper_compaction_live_delta/test_keeper_compaction_live_delta.ml
+++ b/test/keeper_compaction_live_delta/test_keeper_compaction_live_delta.ml
@@ -1,0 +1,217 @@
+module Live_delta = Masc.Keeper_compaction_live_delta
+
+let message text =
+  Agent_sdk.Types.
+    { role = User
+    ; content = [ Text text ]
+    ; name = None
+    ; tool_call_id = None
+    ; metadata = []
+    }
+;;
+
+let checkpoint ?(session_id = "trace") ?(agent_name = "keeper")
+    ?(generation = 2) ?(turn_count = 7) ?(created_at = 1.0)
+    ?(usage = Agent_sdk.Types.empty_usage) ?(working_context = None) messages =
+  let context = Agent_sdk.Context.create_sync () in
+  Agent_sdk.Context.set_scoped
+    context
+    Agent_sdk.Context.Session
+    "keeper_generation"
+    (`Int generation);
+  Agent_sdk.Checkpoint.
+    { version = checkpoint_version
+    ; session_id
+    ; agent_name
+    ; model = "model"
+    ; system_prompt = Some "system"
+    ; messages
+    ; usage
+    ; turn_count
+    ; created_at
+    ; tools = []
+    ; tool_choice = None
+    ; disable_parallel_tool_use = false
+    ; temperature = None
+    ; top_p = None
+    ; top_k = None
+    ; min_p = None
+    ; enable_thinking = None
+    ; preserve_thinking = None
+    ; response_format = Agent_sdk.Types.Off
+    ; thinking_budget = None
+    ; reasoning_effort = None
+    ; cache_system_prompt = false
+    ; context
+    ; mcp_sessions = []
+    ; working_context
+    }
+;;
+
+let trace value =
+  match Keeper_id.Trace_id.of_string value with
+  | Ok trace_id -> trace_id
+  | Error detail -> Alcotest.fail detail
+;;
+
+let snapshot ?session_id ?agent_name ?generation ?turn_count ?created_at ?usage
+    ?working_context messages =
+  let checkpoint =
+    checkpoint
+      ?session_id
+      ?agent_name
+      ?generation
+      ?turn_count
+      ?created_at
+      ?usage
+      ?working_context
+      messages
+  in
+  match
+    Masc.Keeper_checkpoint_store.exact_snapshot_of_canonical_bytes
+      ~expected_session_id:(trace checkpoint.session_id)
+      (Agent_sdk.Checkpoint.to_string checkpoint)
+  with
+  | Ok snapshot -> snapshot
+  | Error _ -> Alcotest.fail "exact checkpoint snapshot construction failed"
+;;
+
+let expect_ok = function
+  | Ok value -> value
+  | Error _ -> Alcotest.fail "live delta rebase failed"
+;;
+
+let check_messages expected actual =
+  Alcotest.(check bool) "exact structural messages" true (expected = actual)
+;;
+
+let test_exact_source_returns_compacted_candidate () =
+  let source = snapshot [ message "old" ] in
+  let source_checkpoint =
+    Masc.Keeper_checkpoint_store.exact_snapshot_checkpoint source
+  in
+  let compacted_messages = [ message "summary" ] in
+  let result =
+    Live_delta.rebase
+      ~source
+      ~compacted_messages
+      ~current:source
+    |> expect_ok
+  in
+  check_messages compacted_messages result.messages;
+  Alcotest.(check string)
+    "source metadata"
+    source_checkpoint.session_id
+    result.session_id;
+  Alcotest.(check bool)
+    "source context"
+    true
+    (source_checkpoint.context == result.context)
+;;
+
+let test_append_only_delta_preserves_exact_suffix () =
+  let source_messages = [ message "a"; message "b" ] in
+  let exact_suffix = [ message "c"; message "d" ] in
+  let compacted_messages = [ message "summary"; message "b" ] in
+  let source = snapshot source_messages in
+  let current = snapshot ~turn_count:9 (source_messages @ exact_suffix) in
+  let result =
+    Live_delta.rebase ~source ~compacted_messages ~current
+    |> expect_ok
+  in
+  check_messages (compacted_messages @ exact_suffix) result.messages
+;;
+
+let test_non_prefix_fails () =
+  let source = snapshot [ message "a"; message "b" ] in
+  let current = snapshot ~turn_count:8 [ message "a"; message "changed" ] in
+  match
+    Live_delta.rebase
+      ~source
+      ~compacted_messages:[ message "summary" ]
+      ~current
+  with
+  | Error
+      (Live_delta.Current_messages_prefix_mismatch
+         Masc.Keeper_replay_prefix.Prefix_message_mismatch) -> ()
+  | Ok _ | Error _ -> Alcotest.fail "non-prefix current checkpoint was accepted"
+;;
+
+let expect_superseded source current =
+  match
+    Live_delta.rebase
+      ~source
+      ~compacted_messages:[ message "summary" ]
+      ~current
+  with
+  | Error (Live_delta.Source_superseded _) -> ()
+  | Ok _ | Error _ -> Alcotest.fail "superseded source was accepted"
+;;
+
+let test_trace_mismatch_fails () =
+  expect_superseded
+    (snapshot [ message "a" ])
+    (snapshot ~session_id:"other" ~turn_count:8 [ message "a"; message "b" ])
+;;
+
+let test_generation_mismatch_fails () =
+  expect_superseded
+    (snapshot [ message "a" ])
+    (snapshot ~generation:3 ~turn_count:8 [ message "a"; message "b" ])
+;;
+
+let test_current_metadata_is_preserved () =
+  let source = snapshot [ message "a" ] in
+  let usage =
+    Agent_sdk.Types.
+      { empty_usage with total_input_tokens = 42; api_calls = 3 }
+  in
+  let current =
+    snapshot
+      ~agent_name:"live-keeper"
+      ~turn_count:11
+      ~created_at:9.0
+      ~usage
+      ~working_context:(Some (`Assoc [ "live", `Bool true ]))
+      [ message "a"; message "live" ]
+  in
+  let result =
+    Live_delta.rebase
+      ~source
+      ~compacted_messages:[ message "summary" ]
+      ~current
+    |> expect_ok
+  in
+  let current_checkpoint =
+    Masc.Keeper_checkpoint_store.exact_snapshot_checkpoint current
+  in
+  Alcotest.(check string) "session" current_checkpoint.session_id result.session_id;
+  Alcotest.(check string) "agent" current_checkpoint.agent_name result.agent_name;
+  Alcotest.(check int) "turn count" current_checkpoint.turn_count result.turn_count;
+  Alcotest.(check (float 0.0))
+    "created at"
+    current_checkpoint.created_at
+    result.created_at;
+  Alcotest.(check bool) "usage" true (current_checkpoint.usage = result.usage);
+  Alcotest.(check bool)
+    "context"
+    true
+    (current_checkpoint.context == result.context);
+  Alcotest.(check bool)
+    "working context"
+    true
+    (current_checkpoint.working_context = result.working_context)
+;;
+
+let () =
+  Alcotest.run
+    "keeper compaction live delta"
+    [ ( "rebase"
+      , [ Alcotest.test_case "exact source" `Quick test_exact_source_returns_compacted_candidate
+        ; Alcotest.test_case "append-only delta" `Quick test_append_only_delta_preserves_exact_suffix
+        ; Alcotest.test_case "non-prefix" `Quick test_non_prefix_fails
+        ; Alcotest.test_case "trace mismatch" `Quick test_trace_mismatch_fails
+        ; Alcotest.test_case "generation mismatch" `Quick test_generation_mismatch_fails
+        ; Alcotest.test_case "metadata preservation" `Quick test_current_metadata_is_preserved
+        ] )
+    ]

--- a/test/test_keeper_checkpoint_stale_guard.ml
+++ b/test/test_keeper_checkpoint_stale_guard.ml
@@ -515,6 +515,47 @@ let test_checkpoint_ref_requires_generation () =
            Keeper_checkpoint_store.Generation_missing) -> ()
     | _ -> fail "generation-less checkpoint acquired an exact ref")
 
+let test_exact_snapshot_preserves_locked_canonical_bytes () =
+  let session_dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir session_dir) (fun () ->
+    let session_id = "sess-exact-snapshot" in
+    save_ok ~session_dir
+      (make_checkpoint ~session_id ~turn_count:4 ~marker:"exact"
+       |> with_generation 2)
+      "exact snapshot seed";
+    let canonical_path = Filename.concat session_dir (session_id ^ ".json") in
+    let expected_bytes =
+      Fs_compat.load_file canonical_path
+      |> Yojson.Safe.from_string
+      |> Yojson.Safe.pretty_to_string
+    in
+    Fs_compat.save_file canonical_path expected_bytes;
+    match
+      Keeper_checkpoint_store.load_oas_exact_snapshot
+        ~session_dir
+        ~session_id
+    with
+    | Error _ -> fail "exact snapshot load failed"
+    | Ok snapshot ->
+      check string "canonical bytes are not re-encoded" expected_bytes
+        (Keeper_checkpoint_store.exact_snapshot_canonical_bytes snapshot);
+      let reference =
+        Keeper_checkpoint_store.exact_snapshot_reference snapshot
+      in
+      let expected_session_id =
+        Result.get_ok (Keeper_id.Trace_id.of_string session_id)
+      in
+      match
+        Keeper_checkpoint_store.exact_snapshot_of_canonical_bytes
+          ~expected_session_id
+          expected_bytes
+      with
+      | Ok decoded ->
+        check bool "pure decode derives the same exact ref" true
+          (Keeper_checkpoint_ref.equal reference
+             (Keeper_checkpoint_store.exact_snapshot_reference decoded))
+      | Error _ -> fail "exact snapshot bytes did not decode")
+
 let () =
   run "Keeper_checkpoint_store checkpoint watermark (RFC-0225 §3.2)"
     [
@@ -544,5 +585,7 @@ let () =
             test_exact_source_cas_allows_one_equal_turn_writer;
           test_case "checkpoint refs require keeper generation" `Quick
             test_checkpoint_ref_requires_generation;
+          test_case "exact snapshot preserves canonical bytes" `Quick
+            test_exact_snapshot_preserves_locked_canonical_bytes;
         ] );
     ]


### PR DESCRIPTION
## Summary

- add a pure typed rebase boundary for a compacted checkpoint and concurrent append-only Keeper progress
- accept source and current only as Keeper_checkpoint_store.exact_checkpoint_snapshot, so checkpoint, exact canonical bytes, and reference cannot be mismatched by callers
- construct the compacted candidate internally from the exact source checkpoint plus compacted_messages, so compaction cannot alter source identity, metadata, context, usage, or turn coordinates
- return that candidate unchanged for an identical exact snapshot reference
- for the same trace and generation, require source.messages to be an exact structural prefix through Keeper_replay_prefix.split, then append the exact live suffix while preserving every non-message field from the exact current checkpoint
- fail explicitly with typed Source_superseded or prefix mismatch errors
- perform no checkpoint serialization/re-encoding in production and use no semantic, string, size, or time heuristic

## Verification

- scripts/dune-local.sh build test/keeper_compaction_live_delta/test_keeper_compaction_live_delta.exe
- focused Alcotest: 6/6 green (exact source, append-only delta, non-prefix, trace mismatch, generation mismatch, metadata/context/usage preservation)
- ocamlformat --check on all added OCaml files
- git diff --check

## Stack

- base: #24935 / codex/compaction-exact-snapshot-20260717 at 387b849e078949f645bd822795701f7b4c6e70e4
- leaf diff: 308 additions, 0 deletions