### PR TITLE
refactor(gate): remove Auto Judge admission cap

### DIFF
--- a/lib/keeper/hitl_summary_worker.ml
+++ b/lib/keeper/hitl_summary_worker.ml
@@ -41,25 +41,6 @@ let provider_config_for_summary ~keeper_name =
     resolve fallback_runtime_id
 ;;
 
-let effective_max_concurrency ~configured ~runtime_limit =
-  match runtime_limit with
-  | Some limit -> Int.min configured limit
-  | None -> configured
-;;
-
-let max_concurrency () =
-  let configured = Keeper_config.hitl_summary_max_concurrency () in
-  let runtime_limit =
-    match Runtime.hitl_summary_runtime_id () with
-    | Some runtime_id ->
-      (match Runtime.get_runtime_by_id runtime_id with
-       | Some runtime -> runtime.Runtime.binding.max_concurrent
-       | None -> None)
-    | None -> None
-  in
-  effective_max_concurrency ~configured ~runtime_limit
-;;
-
 (* ── Metrics ────────────────────────────────────── *)
 
 let () =
@@ -525,7 +506,6 @@ module For_testing = struct
   let summary_llm_error_outcomes = summary_llm_error_outcomes
   let summary_llm_error_retryable = summary_llm_error_retryable
   let sdk_error_of_http_error = sdk_error_of_http_error
-  let effective_max_concurrency = effective_max_concurrency
   let body_timeout_clock = body_timeout_clock
   let system_prompt = system_prompt
   let summary_version = summary_version

--- a/lib/keeper/hitl_summary_worker.mli
+++ b/lib/keeper/hitl_summary_worker.mli
@@ -6,10 +6,6 @@ type summary_provider = private
 
 val provider_config_for_summary : keeper_name:string -> summary_provider option
 
-(** Effective Auto Judge worker cap. The subsystem cap is further bounded by
-    the selected runtime binding's [max_concurrent] declaration. *)
-val max_concurrency : unit -> int
-
 (** Verify that the registry-owned Gate judgment prompt is renderable. This is
     the readiness floor for selecting the workspace Auto Judge mode. *)
 val readiness : unit -> (unit, string) result
@@ -82,9 +78,6 @@ module For_testing : sig
 
   val sdk_error_of_http_error
     : Llm_provider.Http_client.http_error -> Agent_sdk.Error.sdk_error
-
-  val effective_max_concurrency
-    : configured:int -> runtime_limit:int option -> int
 
   val body_timeout_clock
     : unit -> float Eio.Time.clock_ty Eio.Resource.t option

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -239,29 +239,11 @@ let hitl_summary_temperature_rp =
 let hitl_summary_temperature () : float =
   Runtime_params.get hitl_summary_temperature_rp
 
-(** Maximum number of request-local Auto Judge calls that may be in flight.
-    A bounded queue prevents an operator recovery of a large durable backlog
-    from turning into an unbounded provider burst. *)
-let hitl_summary_max_concurrency_rp =
-  _rp_int ~key:"keeper.hitl_summary.max_concurrency"
-    ~default:(fun () ->
-      int_of_env_default
-        "MASC_KEEPER_HITL_SUMMARY_MAX_CONCURRENCY"
-        ~default:4
-        ~min_v:1
-        ~max_v:32)
-    ~min_v:1
-    ~max_v:32
-    ~description:"Maximum concurrent HITL Auto Judge calls" ()
-let hitl_summary_max_concurrency () : int =
-  Runtime_params.get hitl_summary_max_concurrency_rp
-
 (** Force module initialization to guarantee all runtime params are registered
     before [Runtime_params.restore]. Call from server bootstrap. *)
 let ensure_runtime_params_init () =
   let (_ : float) = Runtime_params.get keeper_unified_temperature_rp in
   let (_ : float) = Runtime_params.get hitl_summary_temperature_rp in
-  let (_ : int) = Runtime_params.get hitl_summary_max_concurrency_rp in
   ()
 
 let keeper_enable_thinking_rp =

--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -153,7 +153,6 @@ val keeper_unified_max_tokens : unit -> int
 (** {2 HITL Context-Summary Worker Policy} *)
 
 val hitl_summary_temperature : unit -> float
-val hitl_summary_max_concurrency : unit -> int
 
 val keeper_status_fast_default : unit -> bool
 

--- a/lib/keeper/keeper_gate.ml
+++ b/lib/keeper/keeper_gate.ml
@@ -282,8 +282,6 @@ let active_auto_judges : Auto_judge_ids.t Atomic.t =
 let rec claim_auto_judge id =
   let active = Atomic.get active_auto_judges in
   if Auto_judge_ids.mem id active
-     || Auto_judge_ids.cardinal active
-        >= Hitl_summary_worker.max_concurrency ()
   then false
   else
     let claimed = Auto_judge_ids.add id active in
@@ -299,7 +297,7 @@ let rec release_auto_judge id =
   then release_auto_judge id
 ;;
 
-let rec spawn_claimed_auto_judge_entry
+let spawn_claimed_auto_judge_entry
       (entry : Keeper_approval_queue.pending_approval)
   =
   let approval_id = entry.id in
@@ -375,10 +373,7 @@ let rec spawn_claimed_auto_judge_entry
          ~provider_config:selected.provider_config
          ~on_summary
          ~on_failure
-         ~on_finish:(fun () ->
-           release_auto_judge approval_id;
-           (* fire-and-forget: the queue owns subsequent worker completion. *)
-           ignore (drain_auto_judges ~base_path:entry.audit_base_path))
+         ~on_finish:(fun () -> release_auto_judge approval_id)
          ();
        Ok Started
      with
@@ -400,12 +395,12 @@ let rec spawn_claimed_auto_judge_entry
       ~retryable:true
   | Some _, Error reason -> fail_before_worker ~reason ~retryable:true
 
-and spawn_auto_judge_entry (entry : Keeper_approval_queue.pending_approval) =
+let spawn_auto_judge_entry (entry : Keeper_approval_queue.pending_approval) =
   if claim_auto_judge entry.id
   then spawn_claimed_auto_judge_entry entry
   else Ok Skipped
 
-and retry_auto_judge_entry (entry : Keeper_approval_queue.pending_approval) =
+let retry_auto_judge_entry (entry : Keeper_approval_queue.pending_approval) =
   if not (claim_auto_judge entry.id)
   then Ok Skipped
   else
@@ -418,7 +413,7 @@ and retry_auto_judge_entry (entry : Keeper_approval_queue.pending_approval) =
       Ok Skipped
     | Ok true -> spawn_claimed_auto_judge_entry entry
 
-and start_auto_judge approval_id =
+let start_auto_judge approval_id =
   match Keeper_approval_queue.get_pending_entry ~id:approval_id with
   | None -> Ok Skipped
   | Some entry ->
@@ -434,50 +429,42 @@ and start_auto_judge approval_id =
          Ok Skipped
        | Ok true -> spawn_claimed_auto_judge_entry entry)
 
-and drain_auto_judges ~base_path =
+let drain_auto_judges ~base_path =
   match Keeper_gate_mode.read ~base_path with
   | Error _
   | Ok (Keeper_gate_mode.Manual | Keeper_gate_mode.Always_allow) -> []
   | Ok Keeper_gate_mode.Auto_judge ->
-    let capacity =
-      Hitl_summary_worker.max_concurrency ()
-      - Auto_judge_ids.cardinal (Atomic.get active_auto_judges)
-    in
-    if capacity <= 0
-    then []
-    else
-      Keeper_approval_queue.list_pending_entries ()
-      |> List.filter (fun (entry : Keeper_approval_queue.pending_approval) ->
-        String.equal entry.audit_base_path base_path
-        &&
+    Keeper_approval_queue.list_pending_entries ()
+    |> List.filter (fun (entry : Keeper_approval_queue.pending_approval) ->
+      String.equal entry.audit_base_path base_path
+      &&
+      match entry.summary_status with
+      | Keeper_approval_queue.Summary_not_requested
+      | Keeper_approval_queue.Summary_pending -> true
+      | Keeper_approval_queue.Summary_available _
+      | Keeper_approval_queue.Summary_failed _ -> false)
+    |> List.sort
+         (fun (left : Keeper_approval_queue.pending_approval)
+              (right : Keeper_approval_queue.pending_approval) ->
+            Float.compare left.requested_at right.requested_at)
+    |> List.filter_map (fun (entry : Keeper_approval_queue.pending_approval) ->
+      let started =
         match entry.summary_status with
-        | Keeper_approval_queue.Summary_not_requested
-        | Keeper_approval_queue.Summary_pending -> true
+        | Keeper_approval_queue.Summary_not_requested -> start_auto_judge entry.id
+        | Keeper_approval_queue.Summary_pending -> spawn_auto_judge_entry entry
         | Keeper_approval_queue.Summary_available _
-        | Keeper_approval_queue.Summary_failed _ -> false)
-      |> List.sort
-           (fun (left : Keeper_approval_queue.pending_approval)
-                (right : Keeper_approval_queue.pending_approval) ->
-              Float.compare left.requested_at right.requested_at)
-      |> List.filteri (fun index _ -> index < capacity)
-      |> List.filter_map (fun (entry : Keeper_approval_queue.pending_approval) ->
-        let started =
-          match entry.summary_status with
-          | Keeper_approval_queue.Summary_not_requested -> start_auto_judge entry.id
-          | Keeper_approval_queue.Summary_pending -> spawn_auto_judge_entry entry
-          | Keeper_approval_queue.Summary_available _
-          | Keeper_approval_queue.Summary_failed _ -> Ok Skipped
-        in
-        match started with
-        | Ok Started -> Some entry.id
-        | Ok Skipped -> None
-        | Error reason ->
-          Log.Keeper.error
-            ~keeper_name:entry.keeper_name
-            "Auto Judge bounded drain failed approval=%s: %s"
-            entry.id
-            reason;
-          None)
+        | Keeper_approval_queue.Summary_failed _ -> Ok Skipped
+      in
+      match started with
+      | Ok Started -> Some entry.id
+      | Ok Skipped -> None
+      | Error reason ->
+        Log.Keeper.error
+          ~keeper_name:entry.keeper_name
+          "Auto Judge drain failed approval=%s: %s"
+          entry.id
+          reason;
+        None)
 ;;
 
 type recovered_work =
@@ -781,4 +768,10 @@ let decide ?cycle_grant ~keeper_always_allow request =
       ~labels:[ "keeper", request.keeper_name; "site", "cycle_grant_lookup" ]
       ();
     Unavailable reason
+;;
+
+module For_testing = struct
+  let claim_auto_judge = claim_auto_judge
+  let release_auto_judge = release_auto_judge
+end
 ;;

--- a/lib/keeper/keeper_gate.mli
+++ b/lib/keeper/keeper_gate.mli
@@ -104,8 +104,9 @@ type operator_recovery_report =
   }
 
 (** Reopen failed request-local judgments after an explicit operator selection
-    of Auto Judge, then start a concurrency-bounded drain of every unresolved
-    judgment for the workspace. *)
+    of Auto Judge, then start every unresolved judgment for the workspace.
+    Exact approval identity prevents duplicate workers; MASC imposes no global
+    admission cap. *)
 val request_operator_auto_judge_recovery :
   base_path:string -> (operator_recovery_report, string) result
 
@@ -113,3 +114,8 @@ val authorization_source_to_string : authorization_source -> string
 val deferred_reason_to_string : deferred_reason -> string
 val unavailable_reason_to_string : unavailable_reason -> string
 val decision_to_yojson : decision -> Yojson.Safe.t
+
+module For_testing : sig
+  val claim_auto_judge : string -> bool
+  val release_auto_judge : string -> unit
+end

--- a/test/test_hitl_summary_worker.ml
+++ b/test/test_hitl_summary_worker.ml
@@ -2,6 +2,7 @@ open Alcotest
 
 module Q = Masc.Keeper_approval_queue
 module Worker = Masc.Hitl_summary_worker
+module Gate = Masc.Keeper_gate
 module Schema = Masc.Keeper_structured_output_schema
 module Runtime_resolved = Masc.Keeper_runtime_resolved
 
@@ -153,15 +154,22 @@ let test_request_context_projection_is_idempotent () =
     (Masc.Keeper_gate_request_context.project projected)
 ;;
 
-let test_concurrency_respects_runtime_binding () =
-  check int "runtime binding narrows subsystem cap" 1
-    (Worker.For_testing.effective_max_concurrency
-       ~configured:4
-       ~runtime_limit:(Some 1));
-  check int "subsystem cap remains when runtime omits a limit" 4
-    (Worker.For_testing.effective_max_concurrency
-       ~configured:4
-       ~runtime_limit:None)
+let test_auto_judge_admission_depends_only_on_exact_identity () =
+  let ids =
+    List.init 64 (fun index ->
+      Printf.sprintf "unbounded-auto-judge-test-%d" index)
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      List.iter Gate.For_testing.release_auto_judge ids)
+    (fun () ->
+      List.iter
+        (fun id ->
+           check bool ("claim " ^ id) true
+             (Gate.For_testing.claim_auto_judge id))
+        ids;
+      check bool "duplicate exact identity is rejected" false
+        (Gate.For_testing.claim_auto_judge (List.hd ids)))
 ;;
 
 let test_plain_json_requires_exact_object () =
@@ -306,13 +314,13 @@ let () =
             `Quick
             test_context_bundle_contains_exact_input_without_derived_classification
         ; test_case
-            "runtime binding caps judge concurrency"
-            `Quick
-            test_concurrency_respects_runtime_binding
-        ; test_case
             "request context projection is idempotent"
             `Quick
             test_request_context_projection_is_idempotent
+        ; test_case
+            "Auto Judge admission uses exact identity only"
+            `Quick
+            test_auto_judge_admission_depends_only_on_exact_identity
         ; test_case
             "plain JSON requires exact object"
             `Quick


### PR DESCRIPTION
## Outcome

Auto Judge admission now depends only on exact approval identity. Distinct durable judgments are all started; only a duplicate worker for the same approval id is rejected.

## Hard cuts

- remove keeper.hitl_summary.max_concurrency runtime parameter
- remove MASC_KEEPER_HITL_SUMMARY_MAX_CONCURRENCY
- remove runtime binding max_concurrent from Gate admission
- remove capacity slicing from durable backlog drain
- remove completion-time backlog rescans that only existed to fill bounded slots

Provider/runtime transport may still manage its own execution resources, but MASC no longer turns that into a global Gate authorization constraint.

## Proof

- focused build: test/test_hitl_summary_worker.exe, test/test_keeper_approval_queue.exe
- Hitl_summary_worker: 14/14 green
- Keeper_approval_queue: 19/19 green
- regression: 64 distinct approval identities all claim successfully; the exact duplicate is rejected
- repository search: removed config/env/API identifiers are 0 occurrences

Full build remains CI authority.