### PR TITLE
feat(keeper): persist exact bytes atomically

### DIFF
--- a/lib/keeper/keeper_fs.ml
+++ b/lib/keeper/keeper_fs.ml
@@ -195,7 +195,7 @@ let note_pressure_observer ~observer ~site note exn =
 ;;
 
 let note_durable_write_pressure exn =
-  let site = "filesystem_runtime.save_json_durable_atomic" in
+  let site = "filesystem_runtime.save_durable_atomic" in
   note_pressure_observer
     ~observer:"fd"
     ~site
@@ -273,6 +273,175 @@ let ensure_dir_durable
          })
 ;;
 
+let protect_durable_write f =
+  try f () with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | Durable_write_failed error -> Error error
+  | exn ->
+    note_durable_write_pressure exn;
+    Error
+      { renamed = false
+      ; stage = Directory_prepare
+      ; failure = Operation_failed (Printexc.to_string exn)
+      }
+;;
+
+let save_bytes_durable_atomic_core
+      ~before_stage
+      ?before_directory_fsync
+      ?ownership_root
+      ?temp_dir
+      path
+      bytes
+  =
+  let dir = Filename.dirname path in
+  (* DET-OK: an omitted staging directory means the destination directory;
+     both paths are derived from the same explicit destination [path]. *)
+  let temp_dir = Option.value temp_dir ~default:dir in
+  let directory_lease =
+    ensure_dir_durable
+      ~renamed:false
+      ~before_stage
+      ?before_directory_fsync
+      ?ownership_root
+      dir
+  in
+  let temp_directory_lease =
+    if String.equal temp_dir dir
+    then directory_lease
+    else
+      ensure_dir_durable
+        ~renamed:false
+        ~before_stage
+        ?before_directory_fsync
+        ?ownership_root
+        temp_dir
+  in
+  let result =
+    run_in_systhread_cancel_checked (fun () ->
+    let temp_path = ref None in
+    let channel = ref None in
+    let renamed = ref false in
+    Fun.protect
+      ~finally:(fun () ->
+        Option.iter close_out_noerr !channel;
+        match !temp_path with
+        | Some temp when not !renamed && Sys.file_exists temp ->
+          (try Sys.remove temp with
+           | exn ->
+             Log.Keeper.error
+               "filesystem_runtime: strict atomic temp cleanup failed path=%s error=%s"
+               temp
+               (Printexc.to_string exn))
+        | Some _ | None -> ())
+      (fun () ->
+         let temp, oc =
+           run_durable_write_stage
+             ~renamed:false
+             ~before_stage
+             Temp_file_create
+             (fun () -> Fs_compat.open_atomic_temp_file ~temp_dir ())
+         in
+         temp_path := Some temp;
+         channel := Some oc;
+         run_durable_write_stage
+           ~renamed:false
+           ~before_stage
+           Payload_write
+           (fun () -> output_string oc bytes; flush oc);
+         run_durable_write_stage
+           ~renamed:false
+           ~before_stage
+           Payload_fsync
+           (fun () -> Unix.fsync (Unix.descr_of_out_channel oc));
+         run_durable_write_stage
+           ~renamed:false
+           ~before_stage
+           Temp_file_close
+           (fun () -> close_out oc; channel := None);
+         run_durable_write_stage
+           ~renamed:false
+           ~before_stage
+           Atomic_rename
+           (fun () -> Unix.rename temp path; renamed := true);
+         run_durable_write_stage
+           ~renamed:true
+           ~before_stage
+           Parent_directory_fsync_after_rename
+           (fun () -> Keeper_fs_durable_directory.fsync_directory dir);
+         if not (String.equal temp_dir dir)
+         then
+           run_durable_write_stage
+             ~renamed:true
+             ~before_stage
+             Temp_directory_fsync_after_rename
+             (fun () -> Keeper_fs_durable_directory.fsync_directory temp_dir);
+         Ok ()))
+  in
+  let rec confirm_directory_lease lease =
+    if Keeper_fs_durable_directory.lease_is_current lease
+    then result
+    else (
+      let lease =
+        ensure_dir_durable
+          ~renamed:true
+          ~before_stage
+          ?before_directory_fsync
+          ?ownership_root
+          dir
+      in
+      run_in_systhread_cancel_checked (fun () ->
+        run_durable_write_stage
+          ~renamed:true
+          ~before_stage
+          Parent_directory_fsync_after_rename
+          (fun () ->
+             let (_ : Unix.stats) = Unix.lstat path in
+             Keeper_fs_durable_directory.fsync_directory dir));
+      confirm_directory_lease lease)
+  in
+  let result = confirm_directory_lease directory_lease in
+  let rec confirm_temp_directory_lease lease =
+    if String.equal temp_dir dir || Keeper_fs_durable_directory.lease_is_current lease
+    then result
+    else (
+      let lease =
+        ensure_dir_durable
+          ~renamed:true
+          ~before_stage
+          ?before_directory_fsync
+          ?ownership_root
+          temp_dir
+      in
+      run_in_systhread_cancel_checked (fun () ->
+        run_durable_write_stage
+          ~renamed:true
+          ~before_stage
+          Temp_directory_fsync_after_rename
+          (fun () -> Keeper_fs_durable_directory.fsync_directory temp_dir));
+      confirm_temp_directory_lease lease)
+  in
+  confirm_temp_directory_lease temp_directory_lease
+;;
+
+let save_bytes_durable_atomic_with
+      ~before_stage
+      ?before_directory_fsync
+      ?ownership_root
+      ?temp_dir
+      path
+      bytes
+  =
+  protect_durable_write (fun () ->
+    save_bytes_durable_atomic_core
+      ~before_stage
+      ?before_directory_fsync
+      ?ownership_root
+      ?temp_dir
+      path
+      bytes)
+;;
+
 let save_json_durable_atomic_from_with
       ~before_stage
       ?before_directory_fsync
@@ -282,15 +451,11 @@ let save_json_durable_atomic_from_with
       path
       json_source
   =
-  let dir = Filename.dirname path in
-  (* DET-OK: an omitted staging directory means the destination directory;
-     both paths are derived from the same explicit destination [path]. *)
-  let temp_dir = Option.value temp_dir ~default:dir in
   let encode json =
     if pretty then Yojson.Safe.pretty_to_string json else Yojson.Safe.to_string json
   in
-  try
-    let content =
+  protect_durable_write (fun () ->
+    let bytes =
       run_durable_write_stage
         ~renamed:false
         ~before_stage
@@ -298,140 +463,13 @@ let save_json_durable_atomic_from_with
         (fun () ->
            Executor_pool_ref.submit_or_inline (fun () -> encode (json_source ())))
     in
-    let directory_lease =
-      ensure_dir_durable
-        ~renamed:false
-        ~before_stage
-        ?before_directory_fsync
-        ?ownership_root
-        dir
-    in
-    let temp_directory_lease =
-      if String.equal temp_dir dir
-      then directory_lease
-      else
-        ensure_dir_durable
-          ~renamed:false
-          ~before_stage
-          ?before_directory_fsync
-          ?ownership_root
-          temp_dir
-    in
-    let result =
-      run_in_systhread_cancel_checked (fun () ->
-      let temp_path = ref None in
-      let channel = ref None in
-      let renamed = ref false in
-      Fun.protect
-        ~finally:(fun () ->
-          Option.iter close_out_noerr !channel;
-          match !temp_path with
-          | Some temp when not !renamed && Sys.file_exists temp ->
-            (try Sys.remove temp with
-             | exn ->
-               Log.Keeper.error
-                 "filesystem_runtime: strict atomic temp cleanup failed path=%s error=%s"
-                 temp
-                 (Printexc.to_string exn))
-          | Some _ | None -> ())
-        (fun () ->
-           let temp, oc =
-             run_durable_write_stage
-               ~renamed:false
-               ~before_stage
-               Temp_file_create
-               (fun () -> Fs_compat.open_atomic_temp_file ~temp_dir ())
-           in
-           temp_path := Some temp;
-           channel := Some oc;
-           run_durable_write_stage
-             ~renamed:false
-             ~before_stage
-             Payload_write
-             (fun () -> output_string oc content; flush oc);
-           run_durable_write_stage
-             ~renamed:false
-             ~before_stage
-             Payload_fsync
-             (fun () -> Unix.fsync (Unix.descr_of_out_channel oc));
-           run_durable_write_stage
-             ~renamed:false
-             ~before_stage
-             Temp_file_close
-             (fun () -> close_out oc; channel := None);
-           run_durable_write_stage
-             ~renamed:false
-             ~before_stage
-             Atomic_rename
-             (fun () -> Unix.rename temp path; renamed := true);
-           run_durable_write_stage
-             ~renamed:true
-             ~before_stage
-             Parent_directory_fsync_after_rename
-             (fun () -> Keeper_fs_durable_directory.fsync_directory dir);
-           if not (String.equal temp_dir dir)
-           then
-             run_durable_write_stage
-               ~renamed:true
-               ~before_stage
-               Temp_directory_fsync_after_rename
-               (fun () -> Keeper_fs_durable_directory.fsync_directory temp_dir);
-           Ok ()))
-    in
-    let rec confirm_directory_lease lease =
-      if Keeper_fs_durable_directory.lease_is_current lease
-      then result
-      else (
-        let lease =
-          ensure_dir_durable
-            ~renamed:true
-            ~before_stage
-            ?before_directory_fsync
-            ?ownership_root
-            dir
-        in
-        run_in_systhread_cancel_checked (fun () ->
-          run_durable_write_stage
-            ~renamed:true
-            ~before_stage
-            Parent_directory_fsync_after_rename
-            (fun () ->
-               let (_ : Unix.stats) = Unix.lstat path in
-               Keeper_fs_durable_directory.fsync_directory dir));
-        confirm_directory_lease lease)
-    in
-    let result = confirm_directory_lease directory_lease in
-    let rec confirm_temp_directory_lease lease =
-      if String.equal temp_dir dir || Keeper_fs_durable_directory.lease_is_current lease
-      then result
-      else (
-        let lease =
-          ensure_dir_durable
-            ~renamed:true
-            ~before_stage
-            ?before_directory_fsync
-            ?ownership_root
-            temp_dir
-        in
-        run_in_systhread_cancel_checked (fun () ->
-          run_durable_write_stage
-            ~renamed:true
-            ~before_stage
-            Temp_directory_fsync_after_rename
-            (fun () -> Keeper_fs_durable_directory.fsync_directory temp_dir));
-        confirm_temp_directory_lease lease)
-    in
-    confirm_temp_directory_lease temp_directory_lease
-  with
-  | Eio.Cancel.Cancelled _ as exn -> raise exn
-  | Durable_write_failed error -> Error error
-  | exn ->
-    note_durable_write_pressure exn;
-    Error
-      { renamed = false
-      ; stage = Directory_prepare
-      ; failure = Operation_failed (Printexc.to_string exn)
-    }
+    save_bytes_durable_atomic_core
+      ~before_stage
+      ?before_directory_fsync
+      ?ownership_root
+      ?temp_dir
+      path
+      bytes)
 ;;
 
 let save_json_durable_atomic_with
@@ -451,6 +489,15 @@ let save_json_durable_atomic_with
     ?pretty
     path
     (fun () -> json)
+;;
+
+let save_bytes_durable_atomic ?ownership_root ?temp_dir path bytes =
+  save_bytes_durable_atomic_with
+    ~before_stage:(fun _ -> ())
+    ?ownership_root
+    ?temp_dir
+    path
+    bytes
 ;;
 
 let save_json_durable_atomic ?ownership_root ?temp_dir ?pretty path json =
@@ -550,6 +597,23 @@ let remove_file_durable ?ownership_root path =
 ;;
 
 module For_testing = struct
+  let save_bytes_durable_atomic
+        ~before_stage
+        ?before_directory_fsync
+        ?ownership_root
+        ?temp_dir
+        path
+        bytes
+    =
+    save_bytes_durable_atomic_with
+      ~before_stage
+      ?before_directory_fsync
+      ?ownership_root
+      ?temp_dir
+      path
+      bytes
+  ;;
+
   let save_json_durable_atomic
         ~before_stage
         ?before_directory_fsync

--- a/lib/keeper/keeper_fs.mli
+++ b/lib/keeper/keeper_fs.mli
@@ -58,6 +58,15 @@ type durable_write_error =
   ; failure : durable_write_failure
   }
 
+(** Strict durable atomic write of the supplied immutable byte string.
+    The payload is written exactly, without parsing or re-encoding. *)
+val save_bytes_durable_atomic
+  :  ?ownership_root:string
+  -> ?temp_dir:string
+  -> string
+  -> string
+  -> (unit, durable_write_error) result
+
 (** Strict durable atomic JSON write. Unlike the compatibility
     [save_json_atomic] boundary, parent-directory fsync failure is returned as
     an error and never downgraded to success. When [temp_dir] differs from the
@@ -117,6 +126,15 @@ module For_testing : sig
       named filesystem operation. [before_directory_fsync] runs immediately
       before anchoring one directory component in the durability systhread.
       Either may raise to verify the typed contract and retry behavior. *)
+  val save_bytes_durable_atomic
+    :  before_stage:(durable_write_stage -> unit)
+    -> ?before_directory_fsync:(string -> unit)
+    -> ?ownership_root:string
+    -> ?temp_dir:string
+    -> string
+    -> string
+    -> (unit, durable_write_error) result
+
   val save_json_durable_atomic
     :  before_stage:(durable_write_stage -> unit)
     -> ?before_directory_fsync:(string -> unit)

--- a/test/test_keeper_fs.ml
+++ b/test/test_keeper_fs.ml
@@ -145,11 +145,14 @@ let test_durable_raw_bytes_contract () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir base)
     (fun () ->
+       let save path bytes =
+         match KF.save_bytes_durable_atomic path bytes with
+         | Ok () -> ()
+         | Error error -> fail (KF.durable_write_error_to_string error)
+       in
        let path = Filename.concat base "raw.bin" in
        let bytes = "\000raw\r\n\255" in
-       (match KF.save_bytes_durable_atomic path bytes with
-        | Ok () -> ()
-        | Error error -> fail (KF.durable_write_error_to_string error));
+       save path bytes;
        check string "exact bytes" bytes (read_file path);
        check int "private mode" 0o600 ((Unix.stat path).st_perm land 0o777);
        let fail_at expected path bytes =
@@ -166,6 +169,8 @@ let test_durable_raw_bytes_contract () =
         | Ok () -> fail "pre-rename fault succeeded");
        check bool "failed first create stays absent" false
          (Sys.file_exists absent);
+       save absent "retry\000bytes";
+       check string "same path retry" "retry\000bytes" (read_file absent);
        let published = "\255new\000bytes" in
        (match fail_at KF.Parent_directory_fsync_after_rename path published with
         | Error

--- a/test/test_keeper_fs.ml
+++ b/test/test_keeper_fs.ml
@@ -138,6 +138,45 @@ let test_save_json_atomic () =
   check int "gen field" 1 (loaded |> member "gen" |> to_int);
   cleanup_dir base
 
+let test_durable_raw_bytes_contract () =
+  Eio_main.run
+  @@ fun _env ->
+  let base = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base)
+    (fun () ->
+       let path = Filename.concat base "raw.bin" in
+       let bytes = "\000raw\r\n\255" in
+       (match KF.save_bytes_durable_atomic path bytes with
+        | Ok () -> ()
+        | Error error -> fail (KF.durable_write_error_to_string error));
+       check string "exact bytes" bytes (read_file path);
+       check int "private mode" 0o600 ((Unix.stat path).st_perm land 0o777);
+       let fail_at expected path bytes =
+         KF.For_testing.save_bytes_durable_atomic
+           ~before_stage:(fun stage ->
+             if stage = expected then failwith "injected")
+           path
+           bytes
+       in
+       let absent = Filename.concat base "absent.bin" in
+       (match fail_at KF.Payload_fsync absent "not-published" with
+        | Error { renamed = false; stage = KF.Payload_fsync; _ } -> ()
+        | Error error -> fail (KF.durable_write_error_to_string error)
+        | Ok () -> fail "pre-rename fault succeeded");
+       check bool "failed first create stays absent" false
+         (Sys.file_exists absent);
+       let published = "\255new\000bytes" in
+       (match fail_at KF.Parent_directory_fsync_after_rename path published with
+        | Error
+            { renamed = true
+            ; stage = KF.Parent_directory_fsync_after_rename
+            ; _
+            } -> ()
+        | Error error -> fail (KF.durable_write_error_to_string error)
+        | Ok () -> fail "post-rename fault succeeded");
+       check string "renamed bytes visible" published (read_file path))
+
 let test_durable_write_pre_publish_failure_preserves_target () =
   Eio_main.run
   @@ fun _env ->
@@ -545,6 +584,7 @@ let () =
           test_case "overwrites" `Quick test_save_atomic_overwrites;
           test_case "creates parent dir" `Quick test_save_atomic_creates_parent_dir;
           test_case "json atomic" `Quick test_save_json_atomic;
+          test_case "durable raw bytes" `Quick test_durable_raw_bytes_contract;
         ] );
       ( "durability",
         [ test_case


### PR DESCRIPTION
## What changed

- add `Keeper_fs.save_bytes_durable_atomic` and its deterministic `For_testing` boundary
- extract the existing strict JSON publication path into one raw-byte atomic core
- keep JSON encoding as a producer step, then publish through that same core
- retain ownership-root inspection, no-symlink directory preparation, temp cleanup, payload fsync, atomic rename, and target/staging directory fsync
- use a neutral durable-write observability site for both JSON and raw payloads

## Why

Immutable canonical checkpoint objects must persist their exact byte identity. The prior append-based object writer can leave an empty first-created target after rollback; a strict replace path must instead leave the target absent before rename and report whether rename became visible.

The raw API accepts an immutable OCaml string and passes it directly to `output_string`; it does not parse, normalize, or re-encode the payload.

## Validation

- `scripts/dune-local.sh build test/test_keeper_fs.exe test/test_keeper_fs_directory_durability.exe`
- `test_keeper_fs.exe`: 21/21 pass
- `test_keeper_fs_directory_durability.exe`: 16/16 pass
- raw contract checks exact bytes and mode `0600`
- injected pre-rename payload fsync failure leaves a first-create target absent
- injected parent-directory fsync failure returns `renamed=true`, the exact post-rename stage, and leaves exact target bytes observable
- 394 changed lines

## Base\n\n- independent `main`-root storage leaf\n- #24936 must wait until both this PR and the corrected #24952 checkpoint/live-delta leaf are present on `main`

