### PR TITLE
feat(keeper): coalesce compaction wake hints

### DIFF
--- a/lib/keeper_compaction_wake_registry/dune
+++ b/lib/keeper_compaction_wake_registry/dune
@@ -1,0 +1,8 @@
+(include_subdirs no)
+
+(library
+ (name masc_keeper_compaction_wake_registry)
+ (public_name masc.keeper_compaction_wake_registry)
+ (wrapped false)
+ (modules keeper_compaction_wake_registry)
+ (libraries eio masc.keeper_registry))

--- a/lib/keeper_compaction_wake_registry/keeper_compaction_wake_registry.ml
+++ b/lib/keeper_compaction_wake_registry/keeper_compaction_wake_registry.ml
@@ -92,7 +92,8 @@ let register ~sw owner keeper_name =
   if registered
   then (
     Eio.Switch.on_release sw (fun () ->
-      ignore (unregister registration : unregister_result));
+      match unregister registration with
+      | Unregistered | Registration_not_current -> ());
     Ok registration)
   else Error Already_registered
 ;;

--- a/lib/keeper_compaction_wake_registry/keeper_compaction_wake_registry.ml
+++ b/lib/keeper_compaction_wake_registry/keeper_compaction_wake_registry.ml
@@ -1,0 +1,127 @@
+module Key = struct
+  type t = Keeper_id.Keeper_name.t
+
+  let equal = Keeper_id.Keeper_name.equal
+  let hash value = Hashtbl.hash (Keeper_id.Keeper_name.to_string value)
+end
+
+module Registrations = Hashtbl.Make (Key)
+
+type registration_state =
+  | Open of { pending : bool }
+  | Closed
+
+type t =
+  { mutex : Stdlib.Mutex.t
+  ; registrations : registration Registrations.t
+  }
+
+and registration =
+  { owner : t
+  ; keeper_name : Keeper_id.Keeper_name.t
+  ; mutex : Stdlib.Mutex.t
+  ; condition : Eio.Condition.t
+  ; mutable state : registration_state
+  }
+
+type register_error = Already_registered
+
+type unregister_result =
+  | Unregistered
+  | Registration_not_current
+
+type wake_result =
+  | Signaled
+  | Coalesced
+  | Not_registered
+
+type await_result =
+  | Wake
+  | Registration_closed
+
+let create () =
+  { mutex = Stdlib.Mutex.create (); registrations = Registrations.create 0 }
+;;
+
+let with_registry (t : t) f = Stdlib.Mutex.protect t.mutex f
+let with_registration (registration : registration) f =
+  Stdlib.Mutex.protect registration.mutex f
+;;
+
+let unregister registration =
+  let removed =
+    with_registry registration.owner (fun () ->
+      match
+        Registrations.find_opt
+          registration.owner.registrations
+          registration.keeper_name
+      with
+      | Some current when current == registration ->
+        Registrations.remove
+          registration.owner.registrations
+          registration.keeper_name;
+        true
+      | Some _ | None -> false)
+  in
+  if removed
+  then (
+    with_registration registration (fun () -> registration.state <- Closed);
+    Eio.Condition.broadcast registration.condition;
+    Unregistered)
+  else Registration_not_current
+;;
+
+let register ~sw owner keeper_name =
+  Eio.Switch.check sw;
+  let registration =
+    { owner
+    ; keeper_name
+    ; mutex = Stdlib.Mutex.create ()
+    ; condition = Eio.Condition.create ()
+    ; state = Open { pending = false }
+    }
+  in
+  let registered =
+    with_registry owner (fun () ->
+      match Registrations.find_opt owner.registrations keeper_name with
+      | Some _ -> false
+      | None ->
+        Registrations.add owner.registrations keeper_name registration;
+        true)
+  in
+  if registered
+  then (
+    Eio.Switch.on_release sw (fun () ->
+      ignore (unregister registration : unregister_result));
+    Ok registration)
+  else Error Already_registered
+;;
+
+let wake owner keeper_name =
+  let result, notify =
+    with_registry owner (fun () ->
+      match Registrations.find_opt owner.registrations keeper_name with
+      | None -> (Not_registered, None)
+      | Some registration ->
+        with_registration registration (fun () ->
+          match registration.state with
+          | Closed -> Not_registered, None
+          | Open { pending = true } -> Coalesced, None
+          | Open { pending = false } ->
+            registration.state <- Open { pending = true };
+            Signaled, Some registration.condition))
+  in
+  Option.iter Eio.Condition.broadcast notify;
+  result
+;;
+
+let await registration =
+  Eio.Condition.loop_no_mutex registration.condition (fun () ->
+    with_registration registration (fun () ->
+      match registration.state with
+      | Closed -> Some Registration_closed
+      | Open { pending = false } -> None
+      | Open { pending = true } ->
+        registration.state <- Open { pending = false };
+        Some Wake))
+;;

--- a/lib/keeper_compaction_wake_registry/keeper_compaction_wake_registry.mli
+++ b/lib/keeper_compaction_wake_registry/keeper_compaction_wake_registry.mli
@@ -1,0 +1,43 @@
+(** Process-local wake hints for per-Keeper compaction actors.
+
+    Durable compaction operations remain the sole work authority. A pending
+    hint only asks an already-registered actor to drain that journal; multiple
+    hints may coalesce without dropping durable work. Registration never
+    invents startup work, so the actor owner performs startup drain explicitly. *)
+
+type t
+type registration
+
+type register_error = Already_registered
+
+type unregister_result =
+  | Unregistered
+  | Registration_not_current
+
+type wake_result =
+  | Signaled
+  | Coalesced
+  | Not_registered
+
+type await_result =
+  | Wake
+  | Registration_closed
+
+val create : unit -> t
+
+val register
+  :  sw:Eio.Switch.t
+  -> t
+  -> Keeper_id.Keeper_name.t
+  -> (registration, register_error) result
+(** Register one exact Keeper identity for the lifetime of [sw]. A duplicate
+    live registration is rejected; switch release unregisters it. *)
+
+val unregister : registration -> unregister_result
+(** Idempotent lifecycle close. A stale token cannot remove a replacement. *)
+
+val wake : t -> Keeper_id.Keeper_name.t -> wake_result
+(** Set one non-blocking pending hint. An existing pending hint coalesces. *)
+
+val await : registration -> await_result
+(** Cancellably await and consume one hint, or observe registration close. *)

--- a/test/keeper_compaction_wake_registry/dune
+++ b/test/keeper_compaction_wake_registry/dune
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_compaction_wake_registry)
+ (libraries alcotest eio eio_main masc.keeper_compaction_wake_registry
+  masc.keeper_registry))

--- a/test/keeper_compaction_wake_registry/test_keeper_compaction_wake_registry.ml
+++ b/test/keeper_compaction_wake_registry/test_keeper_compaction_wake_registry.ml
@@ -1,0 +1,97 @@
+module Registry = Keeper_compaction_wake_registry
+
+let keeper value =
+  match Keeper_id.Keeper_name.of_string value with
+  | Ok keeper -> keeper
+  | Error error -> Alcotest.fail error
+;;
+
+let alpha = keeper "compaction-alpha"
+let beta = keeper "compaction-beta"
+
+let registration = function
+  | Ok value -> value
+  | Error Registry.Already_registered ->
+    Alcotest.fail "unexpected duplicate registration"
+;;
+
+let check_equal label expected actual =
+  Alcotest.(check bool) label true (expected = actual)
+;;
+
+let test_coalesces_and_rearms () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun sw ->
+  let registry = Registry.create () in
+  let actor = registration (Registry.register ~sw registry alpha) in
+  (match Registry.register ~sw registry alpha with
+   | Error Registry.Already_registered -> ()
+   | Ok _ -> Alcotest.fail "duplicate registration accepted");
+  check_equal "first hint" Registry.Signaled (Registry.wake registry alpha);
+  check_equal "coalesced hint" Registry.Coalesced (Registry.wake registry alpha);
+  check_equal "consume hint" Registry.Wake (Registry.await actor);
+  check_equal "rearmed hint" Registry.Signaled (Registry.wake registry alpha);
+  check_equal "consume rearmed" Registry.Wake (Registry.await actor)
+;;
+
+let test_stale_token_cannot_remove_replacement () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun sw ->
+  let registry = Registry.create () in
+  let first = registration (Registry.register ~sw registry alpha) in
+  check_equal "first close" Registry.Unregistered (Registry.unregister first);
+  let replacement = registration (Registry.register ~sw registry alpha) in
+  check_equal
+    "stale token"
+    Registry.Registration_not_current
+    (Registry.unregister first);
+  check_equal "replacement signaled" Registry.Signaled
+    (Registry.wake registry alpha);
+  check_equal "replacement receives hint" Registry.Wake
+    (Registry.await replacement)
+;;
+
+let test_keeper_lifetimes_are_isolated () =
+  Eio_main.run @@ fun _env ->
+  let registry = Registry.create () in
+  Eio.Switch.run @@ fun beta_sw ->
+  let beta_actor = registration (Registry.register ~sw:beta_sw registry beta) in
+  Eio.Switch.run (fun alpha_sw ->
+    ignore (registration (Registry.register ~sw:alpha_sw registry alpha)));
+  check_equal "released keeper absent" Registry.Not_registered
+    (Registry.wake registry alpha);
+  check_equal "other keeper signaled" Registry.Signaled
+    (Registry.wake registry beta);
+  check_equal "other keeper receives" Registry.Wake
+    (Registry.await beta_actor)
+;;
+
+let test_await_propagates_cancellation () =
+  let propagated = ref false in
+  (try
+     Eio_main.run @@ fun _env ->
+     Eio.Switch.run @@ fun sw ->
+     let registry = Registry.create () in
+     let actor = registration (Registry.register ~sw registry alpha) in
+     Eio.Cancel.sub (fun context ->
+       Eio.Cancel.cancel context Exit;
+       ignore (Registry.await actor : Registry.await_result))
+   with
+   | Eio.Cancel.Cancelled _ -> propagated := true);
+  Alcotest.(check bool) "await cancellation propagated" true !propagated
+;;
+
+let () =
+  Alcotest.run
+    "keeper compaction wake registry"
+    [ ( "wake hints"
+      , [ Alcotest.test_case "coalesces and rearms" `Quick
+            test_coalesces_and_rearms
+        ; Alcotest.test_case "stale token replacement" `Quick
+            test_stale_token_cannot_remove_replacement
+        ; Alcotest.test_case "keeper isolation" `Quick
+            test_keeper_lifetimes_are_isolated
+        ; Alcotest.test_case "cancellation propagation" `Quick
+            test_await_propagates_cancellation
+        ] )
+    ]


### PR DESCRIPTION
## What changed

- add an independent process-local wake registry keyed by typed Keeper identity
- bind each registration to its actor `Eio.Switch` lifetime
- coalesce repeated wake hints into one pending bit without a queue or capacity
- make stale unregister tokens unable to remove a replacement actor
- expose typed register, unregister, wake, and cancellable await outcomes

## Boundary

The registry owns no compaction work. Durable operation journals remain the sole authority; a hint only asks a live actor to drain its journal. Coalescing therefore cannot drop durable work. Registration does not synthesize a startup wake—the actor caller performs startup drain explicitly.

There is no polling interval, timeout, global stop state, capacity limit, or fleet-wide failure path. Registry instances are passed explicitly, and each Keeper has an isolated condition and pending state.

## Validation

- `scripts/dune-local.sh build test/keeper_compaction_wake_registry/test_keeper_compaction_wake_registry.exe`
- focused tests: 4/4 pass
- verifies coalescing and re-arm
- verifies duplicate registration rejection and stale-token replacement safety
- verifies one Keeper switch release does not affect another Keeper
- verifies `await` propagates Eio cancellation
- 279 changed lines
