### PR TITLE
feat(keeper): durably admit manual compaction requests

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -104,6 +104,7 @@
   masc.keeper_usage_trust
   masc.keeper_event_bus
   masc.keeper_compaction_evidence
+  masc.keeper_compaction_operation
   ;; Runtime_provider_labels extracted to lib/runtime_provider_labels/.
   ;; Leaf boundary over agent_sdk.llm_provider canonical provider labels.
   masc.runtime_provider_labels

--- a/lib/keeper/keeper_compaction_manual_request.ml
+++ b/lib/keeper/keeper_compaction_manual_request.ml
@@ -1,0 +1,197 @@
+module Operation = Keeper_compaction_operation
+module Store = Keeper_compaction_operation_store
+module Object_store = Keeper_compaction_object_store
+type request_status =
+  | Created
+  | Existing
+
+type confirmation =
+  { operation_id : Operation.Operation_id.t
+  ; status : request_status
+  ; source_checkpoint : Keeper_checkpoint_ref.t
+  }
+type error =
+  | Keeper_meta_unavailable of string
+  | Keeper_meta_identity_mismatch of
+      { requested : Keeper_id.Keeper_name.t
+      ; persisted : string
+      }
+  | Source_checkpoint_unavailable of
+      Keeper_checkpoint_store.checkpoint_ref_load_error
+  | Source_object_persist_failed of Object_store.put_error
+  | Durable_source_unavailable of
+      { operation_id : Operation.Operation_id.t
+      ; error : Object_store.load_error
+      }
+  | Journal_read_failed of Store.read_error
+  | Journal_append_failed of
+      { attempted_operation_id : Operation.Operation_id.t
+      ; error : Store.append_error
+      }
+  | Existing_operation_missing of
+      { attempted_operation_id : Operation.Operation_id.t
+      ; existing_operation_id : Operation.Operation_id.t
+      }
+  | Transaction_outcome_unresolved of
+      { attempted_operation_id : Operation.Operation_id.t
+      ; error : Store.transaction_error
+      ; replay_error : Store.read_error option
+      }
+let ( let* ) = Result.bind
+let find_operation operation_id (replay : Store.replay) =
+  List.find_opt
+    (fun (entry : Store.operation_entry) ->
+       Operation.Operation_id.equal entry.snapshot.operation_id operation_id)
+    replay.operations
+;;
+let find_producer producer (replay : Store.replay) =
+  List.find_opt
+    (fun (entry : Store.operation_entry) ->
+       Option.exists
+         (Operation.producer_ref_equal producer)
+         entry.snapshot.producer)
+    replay.operations
+;;
+let confirm_entry ~base_path ~keeper_name ~status
+    (entry : Store.operation_entry) =
+  let operation_id = entry.snapshot.operation_id in
+  let source_checkpoint = entry.snapshot.source_checkpoint in
+  match Object_store.load ~base_path ~keeper_name ~reference:source_checkpoint with
+  | Ok _ -> Ok { operation_id; status; source_checkpoint }
+  | Error error ->
+    Error (Durable_source_unavailable { operation_id; error })
+;;
+
+let replay ~base_path ~keeper_name =
+  Store.replay ~base_path ~keeper_name
+  |> Result.map_error (fun error -> Journal_read_failed error)
+;;
+
+let existing_for_producer ~base_path ~keeper_name = function
+  | None -> Ok None
+  | Some producer ->
+    replay ~base_path ~keeper_name
+    |> Result.map (fun history -> find_producer producer history)
+;;
+
+let existing_confirmation ~base_path ~keeper_name ~attempted_operation_id
+    existing_operation_id =
+  let* history = replay ~base_path ~keeper_name in
+  match find_operation existing_operation_id history with
+  | Some entry -> confirm_entry ~base_path ~keeper_name ~status:Existing entry
+  | None ->
+    Error
+      (Existing_operation_missing
+         { attempted_operation_id; existing_operation_id })
+;;
+
+let reconcile_unknown ~base_path ~keeper_name ~producer
+    ~attempted_operation_id transaction_error =
+  match Store.replay ~base_path ~keeper_name with
+  | Error replay_error ->
+    Error
+      (Transaction_outcome_unresolved
+         { attempted_operation_id
+         ; error = transaction_error
+         ; replay_error = Some replay_error
+         })
+  | Ok history ->
+    (match find_operation attempted_operation_id history with
+     | Some entry -> confirm_entry ~base_path ~keeper_name ~status:Created entry
+     | None ->
+       (match
+          Option.bind producer (fun producer ->
+            find_producer producer history)
+        with
+        | Some entry ->
+          confirm_entry ~base_path ~keeper_name ~status:Existing entry
+        | None ->
+          Error
+            (Transaction_outcome_unresolved
+               { attempted_operation_id
+               ; error = transaction_error
+               ; replay_error = None
+               })))
+;;
+
+let load_meta config keeper_name =
+  let requested = Keeper_id.Keeper_name.to_string keeper_name in
+  match Keeper_meta_store.read_meta config requested with
+  | Error detail -> Error (Keeper_meta_unavailable detail)
+  | Ok None ->
+    Error
+      (Keeper_meta_unavailable
+         (Printf.sprintf "keeper not found: %s" requested))
+  | Ok (Some meta) when String.equal meta.name requested -> Ok meta
+  | Ok (Some meta) ->
+    Error
+      (Keeper_meta_identity_mismatch
+         { requested = keeper_name; persisted = meta.name })
+;;
+
+let load_source config meta =
+  let session_id = Keeper_id.Trace_id.to_string meta.Keeper_meta_contract.runtime.trace_id in
+  let session =
+    Keeper_context_runtime.create_session
+      ~session_id
+      ~base_dir:(Keeper_types_profile.session_base_dir config)
+  in
+  Keeper_checkpoint_store.load_oas_exact_snapshot
+    ~session_dir:session.session_dir
+    ~session_id
+  |> Result.map_error (fun error -> Source_checkpoint_unavailable error)
+;;
+
+let request ~config ~keeper_name ~cause ~producer =
+  let base_path = config.Workspace.base_path in
+  let* existing =
+    existing_for_producer ~base_path ~keeper_name producer
+  in
+  match existing with
+  | Some entry -> confirm_entry ~base_path ~keeper_name ~status:Existing entry
+  | None ->
+    let* meta = load_meta config keeper_name in
+    let* source = load_source config meta in
+    let* _ =
+      Object_store.put ~base_path ~keeper_name source
+      |> Result.map_error (fun error -> Source_object_persist_failed error)
+    in
+    let source_checkpoint =
+      Keeper_checkpoint_store.exact_snapshot_reference source
+    in
+    let operation_id = Operation.Operation_id.generate () in
+    let event =
+      Operation.requested
+        ~operation_id
+        ~keeper_name
+        ~source_checkpoint
+        ~trigger:Compaction_trigger.Manual
+        ~cause
+        ~producer
+    in
+    match
+      Store.append
+        ~base_path
+        ~keeper_name
+        ~recorded_at:(Time_compat.now ())
+        event
+    with
+    | Ok _ -> Ok { operation_id; status = Created; source_checkpoint }
+    | Error
+        (Store.Event_rejected
+           (Store.Producer_already_bound { existing_operation_id; _ })) ->
+      existing_confirmation
+        ~base_path
+        ~keeper_name
+        ~attempted_operation_id:operation_id
+        existing_operation_id
+    | Error (Store.Transaction_error (Store.Outcome_unknown _ as error)) ->
+      reconcile_unknown
+        ~base_path
+        ~keeper_name
+        ~producer
+        ~attempted_operation_id:operation_id
+        error
+    | Error error ->
+      Error (Journal_append_failed { attempted_operation_id = operation_id; error })
+;;

--- a/lib/keeper/keeper_compaction_manual_request.mli
+++ b/lib/keeper/keeper_compaction_manual_request.mli
@@ -1,0 +1,43 @@
+module Operation = Keeper_compaction_operation
+module Store = Keeper_compaction_operation_store
+type request_status =
+  | Created
+  | Existing
+type confirmation =
+  { operation_id : Operation.Operation_id.t
+  ; status : request_status
+  ; source_checkpoint : Keeper_checkpoint_ref.t
+  }
+type error =
+  | Keeper_meta_unavailable of string
+  | Keeper_meta_identity_mismatch of
+      { requested : Keeper_id.Keeper_name.t
+      ; persisted : string
+      }
+  | Source_checkpoint_unavailable of
+      Keeper_checkpoint_store.checkpoint_ref_load_error
+  | Source_object_persist_failed of Keeper_compaction_object_store.put_error
+  | Durable_source_unavailable of
+      { operation_id : Operation.Operation_id.t
+      ; error : Keeper_compaction_object_store.load_error
+      }
+  | Journal_read_failed of Store.read_error
+  | Journal_append_failed of
+      { attempted_operation_id : Operation.Operation_id.t
+      ; error : Store.append_error
+      }
+  | Existing_operation_missing of
+      { attempted_operation_id : Operation.Operation_id.t
+      ; existing_operation_id : Operation.Operation_id.t
+      }
+  | Transaction_outcome_unresolved of
+      { attempted_operation_id : Operation.Operation_id.t
+      ; error : Store.transaction_error
+      ; replay_error : Store.read_error option
+      }
+val request :
+  config:Workspace.config ->
+  keeper_name:Keeper_id.Keeper_name.t ->
+  cause:Operation.Cause.t ->
+  producer:Operation.producer_ref option ->
+  (confirmation, error) result

--- a/test/keeper_compaction_operation_store/dune
+++ b/test/keeper_compaction_operation_store/dune
@@ -2,6 +2,7 @@
  (name test_keeper_compaction_operation_store)
  (libraries
   alcotest
+  masc_test_deps
   masc.compaction_trigger
   masc.fs_compat
   masc.keeper_checkpoint_ref

--- a/test/keeper_compaction_operation_store/test_keeper_compaction_operation_store.ml
+++ b/test/keeper_compaction_operation_store/test_keeper_compaction_operation_store.ml
@@ -138,6 +138,159 @@ let test_malformed_history_fails_loud () =
     Alcotest.(check string) "malformed bytes unchanged" "not-json\n" (Fs_compat.load_file path)
   | _ -> Alcotest.fail "append accepted malformed history"
 ;;
+let write_meta config name =
+  let meta =
+    ok
+      (Masc_test_deps.meta_of_json_fixture
+         (`Assoc
+           [ "name", `String name
+           ; "agent_name", `String (name ^ "-agent")
+           ; "trace_id", `String (name ^ "-trace")
+           ; "allowed_paths", `List [ `String "*" ]
+           ]))
+  in
+  ok (Masc.Keeper_meta_store.write_meta config meta);
+  meta
+;;
+let save_checkpoint config meta =
+  let session_id =
+    Keeper_id.Trace_id.to_string
+      meta.Masc.Keeper_meta_contract.runtime.trace_id
+  in
+  let session =
+    Masc.Keeper_context_runtime.create_session
+      ~session_id
+      ~base_dir:(Masc.Keeper_types_profile.session_base_dir config)
+  in
+  let working =
+    Masc.Keeper_context_core.create
+      ~eio:false
+      ~system_prompt:"test"
+      ~max_tokens:1
+  in
+  let context = Masc.Keeper_context_core.oas_context_of_context working in
+  Agent_sdk.Context.set_scoped context Agent_sdk.Context.Session
+    "keeper_generation" (`Int meta.runtime.generation);
+  let checkpoint =
+    Masc.Keeper_context_core.checkpoint_of_context working
+    |> fun checkpoint ->
+    { checkpoint with
+      session_id
+    ; agent_name = meta.agent_name
+    ; model = "test"
+    ; turn_count = 1
+    }
+  in
+  ignore
+    (ok
+       (Masc.Keeper_checkpoint_store.save_oas_classified
+          ~session_dir:session.session_dir
+          checkpoint));
+  let snapshot =
+    ok
+      (Masc.Keeper_checkpoint_store.load_oas_exact_snapshot
+         ~session_dir:session.session_dir
+         ~session_id)
+  in
+  session.session_dir, session_id, snapshot
+;;
+let test_manual_request_persists_source_before_journal () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  with_base @@ fun base ->
+  let config = Masc.Workspace.default_config base in
+  ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+  let meta = write_meta config "manual-request" in
+  let keeper = ok (Keeper_id.Keeper_name.of_string meta.name) in
+  let session_dir, session_id, source = save_checkpoint config meta in
+  let source_ref =
+    Masc.Keeper_checkpoint_store.exact_snapshot_reference source
+  in
+  let producer = producer () in
+  let created =
+    ok
+      (Masc.Keeper_compaction_manual_request.request
+         ~config
+         ~keeper_name:keeper
+         ~cause
+         ~producer:(Some producer))
+  in
+  Alcotest.(check bool) "created" true
+    (created.status = Masc.Keeper_compaction_manual_request.Created);
+  Alcotest.(check bool) "exact source" true
+    (Keeper_checkpoint_ref.equal source_ref created.source_checkpoint);
+  let journal =
+    Store.journal_path ~base_path:config.base_path ~keeper_name:keeper
+  in
+  let before_retry = Fs_compat.load_file journal in
+  Unix.unlink
+    (Masc.Keeper_checkpoint_store.oas_checkpoint_path
+       ~session_dir
+       ~session_id);
+  let existing =
+    ok
+      (Masc.Keeper_compaction_manual_request.request
+         ~config
+         ~keeper_name:keeper
+         ~cause
+         ~producer:(Some producer))
+  in
+  Alcotest.(check bool) "existing" true
+    (existing.status = Masc.Keeper_compaction_manual_request.Existing);
+  Alcotest.(check bool) "same operation" true
+    (Operation.Operation_id.equal created.operation_id existing.operation_id);
+  Alcotest.(check string) "retry wrote no bytes" before_retry
+    (Fs_compat.load_file journal)
+;;
+let test_source_failures () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  with_base @@ fun base ->
+  let config = Masc.Workspace.default_config base in
+  ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+  let missing = write_meta config "manual-missing" in
+  let missing_keeper = ok (Keeper_id.Keeper_name.of_string missing.name) in
+  (match
+     Masc.Keeper_compaction_manual_request.request
+       ~config
+       ~keeper_name:missing_keeper
+       ~cause
+       ~producer:None
+   with
+   | Error (Masc.Keeper_compaction_manual_request.Source_checkpoint_unavailable _) -> ()
+   | _ -> Alcotest.fail "missing checkpoint did not fail explicitly");
+  Alcotest.(check bool) "missing checkpoint wrote no journal" false
+    (Sys.file_exists
+       (Store.journal_path
+          ~base_path:config.base_path
+          ~keeper_name:missing_keeper));
+  let meta = write_meta config "manual-object-failure" in
+  let keeper = ok (Keeper_id.Keeper_name.of_string meta.name) in
+  let _, _, source = save_checkpoint config meta in
+  let reference =
+    Masc.Keeper_checkpoint_store.exact_snapshot_reference source
+  in
+  let object_path =
+    Masc.Keeper_compaction_object_store.object_path
+      ~base_path:config.base_path
+      ~keeper_name:keeper
+      ~reference
+  in
+  Fs_compat.mkdir_p (Filename.dirname object_path);
+  Fs_compat.save_file object_path "corrupt\n";
+  (match
+     Masc.Keeper_compaction_manual_request.request
+       ~config
+       ~keeper_name:keeper
+       ~cause
+       ~producer:None
+   with
+   | Error (Masc.Keeper_compaction_manual_request.Source_object_persist_failed _) -> ()
+   | _ -> Alcotest.fail "invalid source object did not fail explicitly");
+  Alcotest.(check bool) "object failure wrote no journal" false
+    (Sys.file_exists
+       (Store.journal_path ~base_path:config.base_path ~keeper_name:keeper))
+;;
 let () =
   Alcotest.run "keeper compaction operation store"
     [ "journal",
@@ -148,5 +301,8 @@ let () =
           `Quick
           test_provider_binding_includes_exact_source
       ; Alcotest.test_case "malformed history" `Quick test_malformed_history_fails_loud
+      ; Alcotest.test_case "manual source durability" `Quick
+          test_manual_request_persists_source_before_journal
+      ; Alcotest.test_case "source failures" `Quick test_source_failures
       ] ]
 ;;


### PR DESCRIPTION
## What changed

- add a pure typed admission API for manual Keeper compaction operations
- resolve an existing closed producer reference before touching current Keeper state
- load one exact canonical checkpoint snapshot under the checkpoint lock
- durably materialize the source object before appending `Requested`
- reconcile producer races and uncertain journal outcomes by exact replay
- validate the durable source object before returning `Created` or `Existing`
- read canonical persisted Keeper meta without pulling sandbox/runtime admission policy into compaction admission

## Boundary

This layer knows only Keeper identity, typed cause, optional `Operation.producer_ref`, exact checkpoint source, immutable object storage, and the operation journal.

It does not know tool invocation types, tool names, registry phase, wake-up mechanics, legacy event queue, risk levels, budgets, timeouts, or product-specific dispatch.

## Validation

- `scripts/dune-local.sh build test/keeper_compaction_operation_store/test_keeper_compaction_operation_store.exe`
- `_build/default/test/keeper_compaction_operation_store/test_keeper_compaction_operation_store.exe` (6/6 passing)
- same producer retry returns the original operation after the canonical checkpoint is removed and writes no journal bytes
- missing canonical checkpoint writes no journal
- corrupt pre-existing source object writes no journal
- `git diff --check`
- adversarial forbidden-pattern scan on the core module