### PR TITLE
feat(keeper): bind compaction producer identity

### DIFF
--- a/lib/keeper_compaction_operation/dune
+++ b/lib/keeper_compaction_operation/dune
@@ -25,6 +25,7 @@
   masc.masc_core
   masc.masc_types
   masc.tool_invocation_ref
+  digestif
   threads
   uuidm
   yojson))

--- a/lib/keeper_compaction_operation/keeper_compaction_operation.ml
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation.ml
@@ -13,12 +13,26 @@ type reconciliation_reason =
   | Commit_durability_unknown
   | Transaction_outcome_unknown
 
+type producer_ref =
+  | Tool_invocation of Tool_invocation_ref.t
+  | Provider_overflow of
+      { source_checkpoint : Keeper_checkpoint_ref.t
+      ; source_delivery_sha256 : string
+      }
+
+type producer_ref_error =
+  | Invalid_source_delivery_sha256_length of int
+  | Invalid_source_delivery_sha256_character of
+      { index : int
+      ; found : char
+      }
+
 type request =
   { keeper_name : Keeper_id.Keeper_name.t
   ; source_checkpoint : Keeper_checkpoint_ref.t
   ; trigger : Compaction_trigger.t
   ; cause : Cause.t
-  ; producer_invocation : Tool_invocation_ref.t option
+  ; producer : producer_ref option
   }
 
 type candidate =
@@ -51,16 +65,66 @@ type event =
 let operation_id event = event.operation_id
 let view event = event.view
 
+let tool_invocation_producer_ref invocation = Tool_invocation invocation
+
+let validate_source_delivery_sha256 value =
+  let length = String.length value in
+  if length <> 64
+  then Error (Invalid_source_delivery_sha256_length length)
+  else
+    let rec loop index =
+      if index = length
+      then Ok ()
+      else
+        match value.[index] with
+        | '0' .. '9' | 'a' .. 'f' -> loop (index + 1)
+        | found ->
+          Error
+            (Invalid_source_delivery_sha256_character { index; found })
+    in
+    loop 0
+;;
+
+let provider_overflow_producer_ref_of_persisted
+      ~source_checkpoint
+      ~source_delivery_sha256
+  =
+  validate_source_delivery_sha256 source_delivery_sha256
+  |> Result.map (fun () ->
+    Provider_overflow { source_checkpoint; source_delivery_sha256 })
+;;
+
+let provider_overflow_producer_ref ~source_checkpoint ~source_delivery_identity =
+  let source_delivery_sha256 =
+    Digestif.SHA256.(digest_string source_delivery_identity |> to_hex)
+  in
+  Provider_overflow { source_checkpoint; source_delivery_sha256 }
+;;
+
+let producer_ref_equal left right =
+  match left, right with
+  | Tool_invocation left, Tool_invocation right ->
+    Tool_invocation_ref.equal left right
+  | ( Provider_overflow left
+    , Provider_overflow right ) ->
+    Keeper_checkpoint_ref.equal left.source_checkpoint right.source_checkpoint
+    && String.equal
+         left.source_delivery_sha256
+         right.source_delivery_sha256
+  | Tool_invocation _, Provider_overflow _
+  | Provider_overflow _, Tool_invocation _ -> false
+;;
+
 let candidate ~attempt_id ~source_checkpoint ~candidate_checkpoint ~evidence =
   { attempt_id; source_checkpoint; candidate_checkpoint; evidence }
 ;;
 
 let requested ~operation_id ~keeper_name ~source_checkpoint ~trigger ~cause
-    ~producer_invocation =
+    ~producer =
   { operation_id
   ; view =
       Requested
-        { keeper_name; source_checkpoint; trigger; cause; producer_invocation }
+        { keeper_name; source_checkpoint; trigger; cause; producer }
   }
 ;;
 

--- a/lib/keeper_compaction_operation/keeper_compaction_operation.mli
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation.mli
@@ -15,12 +15,38 @@ type reconciliation_reason =
   | Commit_durability_unknown
   | Transaction_outcome_unknown
 
+type producer_ref = private
+  | Tool_invocation of Tool_invocation_ref.t
+  | Provider_overflow of
+      { source_checkpoint : Keeper_checkpoint_ref.t
+      ; source_delivery_sha256 : string
+      }
+
+type producer_ref_error =
+  | Invalid_source_delivery_sha256_length of int
+  | Invalid_source_delivery_sha256_character of
+      { index : int
+      ; found : char
+      }
+
+val tool_invocation_producer_ref : Tool_invocation_ref.t -> producer_ref
+val provider_overflow_producer_ref :
+  source_checkpoint:Keeper_checkpoint_ref.t ->
+  source_delivery_identity:string ->
+  producer_ref
+val provider_overflow_producer_ref_of_persisted :
+  source_checkpoint:Keeper_checkpoint_ref.t ->
+  source_delivery_sha256:string ->
+  (producer_ref, producer_ref_error) result
+
+val producer_ref_equal : producer_ref -> producer_ref -> bool
+
 type request =
   { keeper_name : Keeper_id.Keeper_name.t
   ; source_checkpoint : Keeper_checkpoint_ref.t
   ; trigger : Compaction_trigger.t
   ; cause : Cause.t
-  ; producer_invocation : Tool_invocation_ref.t option
+  ; producer : producer_ref option
   }
 
 type candidate =
@@ -55,7 +81,7 @@ val requested :
   source_checkpoint:Keeper_checkpoint_ref.t ->
   trigger:Compaction_trigger.t ->
   cause:Cause.t ->
-  producer_invocation:Tool_invocation_ref.t option ->
+  producer:producer_ref option ->
   event
 val attempt_started : operation_id:Operation_id.t -> attempt_id:Attempt_id.t -> event
 val candidate_prepared :

--- a/lib/keeper_compaction_operation/keeper_compaction_operation_action_selector.ml
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation_action_selector.ml
@@ -64,7 +64,7 @@ let operation_context (entry : Store.operation_entry) =
       ; source_checkpoint = snapshot.source_checkpoint
       ; trigger = snapshot.trigger
       ; cause = snapshot.cause
-      ; producer_invocation = snapshot.producer_invocation
+      ; producer = snapshot.producer
       }
   }
 

--- a/lib/keeper_compaction_operation/keeper_compaction_operation_codec.ml
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation_codec.ml
@@ -53,7 +53,7 @@ let decode_requested ~operation_id payload =
     ; "source_checkpoint"
     ; "trigger"
     ; "cause"
-    ; "producer_invocation"
+    ; "producer"
     ]
   in
   let* values = Support.exact_object ~path ~allowed:fields ~required:fields payload in
@@ -63,8 +63,8 @@ let decode_requested ~operation_id payload =
   in
   let* trigger = nested ~path "trigger" Support.trigger values in
   let* cause = field ~path "cause" Support.cause values in
-  let* producer_json = Support.required_field ~path "producer_invocation" values in
-  let* producer_invocation = Support.producer_invocation producer_json in
+  let* producer_json = Support.required_field ~path "producer" values in
+  let* producer = Support.producer ~source_checkpoint producer_json in
   Ok
     (Operation.requested
        ~operation_id
@@ -72,7 +72,7 @@ let decode_requested ~operation_id payload =
        ~source_checkpoint
        ~trigger
        ~cause
-       ~producer_invocation)
+       ~producer)
 ;;
 
 let decode_attempt_started ~operation_id payload =

--- a/lib/keeper_compaction_operation/keeper_compaction_operation_codec.mli
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation_codec.mli
@@ -32,7 +32,9 @@ type decode_error = Keeper_compaction_operation_codec_support.decode_error =
   | Invalid_cause of Keeper_compaction_operation_identity.Cause.error
   | Invalid_checkpoint of Keeper_checkpoint_ref.create_error
   | Invalid_trigger of Compaction_trigger.decode_error
-  | Invalid_producer of Tool_invocation_ref.decode_error
+  | Unknown_producer_kind of string
+  | Invalid_tool_producer of Tool_invocation_ref.decode_error
+  | Invalid_provider_producer of Keeper_compaction_operation.producer_ref_error
   | Invalid_evidence of Keeper_compaction_evidence.decode_error
   | Invalid_turn_ref of string
 

--- a/lib/keeper_compaction_operation/keeper_compaction_operation_codec_support.ml
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation_codec_support.ml
@@ -32,7 +32,9 @@ type decode_error =
   | Invalid_cause of Keeper_compaction_operation_identity.Cause.error
   | Invalid_checkpoint of Keeper_checkpoint_ref.create_error
   | Invalid_trigger of Compaction_trigger.decode_error
-  | Invalid_producer of Tool_invocation_ref.decode_error
+  | Unknown_producer_kind of string
+  | Invalid_tool_producer of Tool_invocation_ref.decode_error
+  | Invalid_provider_producer of Operation.producer_ref_error
   | Invalid_evidence of Keeper_compaction_evidence.decode_error
   | Invalid_turn_ref of string
 
@@ -153,12 +155,46 @@ let trigger ~path json =
   Ok trigger
 ;;
 
-let producer_invocation = function
+let producer ~source_checkpoint = function
   | `Null -> Ok None
   | json ->
-    Tool_invocation_ref.of_yojson json
-    |> Result.map_error (fun error -> Invalid_producer error)
-    |> Result.map Option.some
+    let path = "payload.producer" in
+    let allowed = [ "kind"; "invocation"; "source_delivery_sha256" ] in
+    let* values = exact_object ~path ~allowed ~required:[ "kind" ] json in
+    let* kind_json = required_field ~path "kind" values in
+    let* kind = string_field ~path "kind" kind_json in
+    (match kind with
+     | "tool_invocation" ->
+       let* values =
+         exact_object
+           ~path
+           ~allowed:[ "kind"; "invocation" ]
+           ~required:[ "kind"; "invocation" ]
+           json
+       in
+       let* invocation = required_field ~path "invocation" values in
+       Tool_invocation_ref.of_yojson invocation
+       |> Result.map_error (fun error -> Invalid_tool_producer error)
+       |> Result.map (fun value ->
+         Some (Operation.tool_invocation_producer_ref value))
+     | "provider_overflow" ->
+       let* values =
+         exact_object
+           ~path
+           ~allowed:[ "kind"; "source_delivery_sha256" ]
+           ~required:[ "kind"; "source_delivery_sha256" ]
+           json
+       in
+       let* digest_json = required_field ~path "source_delivery_sha256" values in
+       let* source_delivery_sha256 =
+         string_field ~path "source_delivery_sha256" digest_json
+       in
+       Operation.provider_overflow_producer_ref_of_persisted
+         ~source_checkpoint
+         ~source_delivery_sha256
+       |> Result.map_error (fun error -> Invalid_provider_producer error)
+       |> Result.map Option.some
+     | unknown -> Error (Unknown_producer_kind unknown))
 ;;
 
 let turn_ref json =

--- a/lib/keeper_compaction_operation/keeper_compaction_operation_codec_support.mli
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation_codec_support.mli
@@ -30,7 +30,9 @@ type decode_error =
   | Invalid_cause of Keeper_compaction_operation_identity.Cause.error
   | Invalid_checkpoint of Keeper_checkpoint_ref.create_error
   | Invalid_trigger of Compaction_trigger.decode_error
-  | Invalid_producer of Tool_invocation_ref.decode_error
+  | Unknown_producer_kind of string
+  | Invalid_tool_producer of Tool_invocation_ref.decode_error
+  | Invalid_provider_producer of Keeper_compaction_operation.producer_ref_error
   | Invalid_evidence of Keeper_compaction_evidence.decode_error
   | Invalid_turn_ref of string
 
@@ -92,8 +94,9 @@ val trigger
   -> Yojson.Safe.t
   -> (Compaction_trigger.t, decode_error) result
 
-val producer_invocation
-  :  Yojson.Safe.t
-  -> (Tool_invocation_ref.t option, decode_error) result
+val producer
+  :  source_checkpoint:Keeper_checkpoint_ref.t
+  -> Yojson.Safe.t
+  -> (Keeper_compaction_operation.producer_ref option, decode_error) result
 
 val turn_ref : Yojson.Safe.t -> (Ids.Turn_ref.t, decode_error) result

--- a/lib/keeper_compaction_operation/keeper_compaction_operation_json.ml
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation_json.ml
@@ -28,6 +28,19 @@ let candidate ~checkpoint_field (candidate : Operation.candidate) =
   ]
 ;;
 
+let producer = function
+  | Operation.Tool_invocation invocation ->
+    `Assoc
+      [ "kind", `String "tool_invocation"
+      ; "invocation", Tool_invocation_ref.to_yojson invocation
+      ]
+  | Operation.Provider_overflow { source_delivery_sha256; _ } ->
+    `Assoc
+      [ "kind", `String "provider_overflow"
+      ; "source_delivery_sha256", `String source_delivery_sha256
+      ]
+;;
+
 let envelope event kind payload =
   `Assoc
     [ "kind", `String kind
@@ -46,9 +59,9 @@ let to_json event =
       ; "source_checkpoint", checkpoint request.source_checkpoint
       ; "trigger", Compaction_trigger.to_detail_json request.trigger
       ; "cause", `String (Operation.Cause.to_string request.cause)
-      ; ( "producer_invocation"
-        , match request.producer_invocation with
-          | Some producer -> Tool_invocation_ref.to_yojson producer
+      ; ( "producer"
+        , match request.producer with
+          | Some value -> producer value
           | None -> `Null )
       ]
   | Attempt_started attempt_id ->

--- a/lib/keeper_compaction_operation/keeper_compaction_operation_reducer.ml
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation_reducer.ml
@@ -40,7 +40,7 @@ type snapshot =
   ; source_checkpoint : Keeper_checkpoint_ref.t
   ; trigger : Compaction_trigger.t
   ; cause : Operation.Cause.t
-  ; producer_invocation : Tool_invocation_ref.t option
+  ; producer : Operation.producer_ref option
   ; phase : phase
   ; attempt_id : Operation.Attempt_id.t option
   ; candidate_checkpoint : Keeper_checkpoint_ref.t option
@@ -55,6 +55,9 @@ type snapshot =
 
 type transition_error =
   | Invalid_transition of phase option
+  | Provider_overflow_producer_required
+  | Producer_trigger_mismatch
+  | Producer_source_mismatch
   | Operation_mismatch
   | Attempt_mismatch
   | Source_mismatch
@@ -119,7 +122,7 @@ let snapshot state =
   ; source_checkpoint = state.request.source_checkpoint
   ; trigger = state.request.trigger
   ; cause = state.request.cause
-  ; producer_invocation = state.request.producer_invocation
+  ; producer = state.request.producer
   ; phase = phase state
   ; attempt_id
   ; candidate_checkpoint
@@ -190,6 +193,29 @@ let validate_supersession
 let apply current event =
   let invalid state = Error (Invalid_transition (Option.map phase state)) in
   match current, Operation.view event with
+  | None,
+    Operation.Requested
+      { trigger = Compaction_trigger.Provider_overflow _
+      ; producer = (None | Some (Operation.Tool_invocation _))
+      ; _
+      } ->
+    Error Provider_overflow_producer_required
+  | None,
+    Operation.Requested
+      { trigger = Compaction_trigger.Manual
+      ; producer = Some (Operation.Provider_overflow _)
+      ; _
+      } ->
+    Error Producer_trigger_mismatch
+  | None,
+    Operation.Requested
+      { source_checkpoint
+      ; producer =
+          Some (Operation.Provider_overflow { source_checkpoint = bound; _ })
+      ; _
+      }
+    when not (Keeper_checkpoint_ref.equal source_checkpoint bound) ->
+    Error Producer_source_mismatch
   | None, Operation.Requested request ->
     Ok
       { operation_id = Operation.operation_id event

--- a/lib/keeper_compaction_operation/keeper_compaction_operation_reducer.mli
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation_reducer.mli
@@ -19,7 +19,7 @@ type snapshot =
   ; source_checkpoint : Keeper_checkpoint_ref.t
   ; trigger : Compaction_trigger.t
   ; cause : Operation.Cause.t
-  ; producer_invocation : Tool_invocation_ref.t option
+  ; producer : Operation.producer_ref option
   ; phase : phase
   ; attempt_id : Operation.Attempt_id.t option
   ; candidate_checkpoint : Keeper_checkpoint_ref.t option
@@ -34,6 +34,9 @@ type snapshot =
 
 type transition_error =
   | Invalid_transition of phase option
+  | Provider_overflow_producer_required
+  | Producer_trigger_mismatch
+  | Producer_source_mismatch
   | Operation_mismatch
   | Attempt_mismatch
   | Source_mismatch

--- a/lib/keeper_compaction_operation/keeper_compaction_operation_store.ml
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation_store.ml
@@ -17,7 +17,7 @@ type event_rejection =
       ; actual : Keeper_id.Keeper_name.t
       }
   | Producer_already_bound of
-      { producer : Tool_invocation_ref.t
+      { producer : Operation.producer_ref
       ; existing_operation_id : Operation.Operation_id.t
       }
 type history_error =
@@ -51,7 +51,7 @@ type operation_state =
   }
 type fold_state =
   { operations : operation_state Operation_map.t
-  ; producers : (Tool_invocation_ref.t * Operation.Operation_id.t) list
+  ; producers : (Operation.producer_ref * Operation.Operation_id.t) list
   }
 let empty_state = { operations = Operation_map.empty; producers = [] }
 let ( let* ) = Result.bind
@@ -69,12 +69,14 @@ let journal_path ~base_path ~keeper_name =
 ;;
 let producer_of_event event =
   match Operation.view event with
-  | Operation.Requested { producer_invocation; _ } -> producer_invocation
+  | Operation.Requested { producer; _ } -> producer
   | _ -> None
 ;;
 let find_producer producer =
   List.find_map (fun (candidate, operation_id) ->
-    if Tool_invocation_ref.equal producer candidate then Some operation_id else None)
+    if Operation.producer_ref_equal producer candidate
+    then Some operation_id
+    else None)
 ;;
 let apply_row ~keeper_name state row =
   let event = row.Record.event in

--- a/lib/keeper_compaction_operation/keeper_compaction_operation_store.mli
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation_store.mli
@@ -16,7 +16,7 @@ type event_rejection =
       ; actual : Keeper_id.Keeper_name.t
       }
   | Producer_already_bound of
-      { producer : Tool_invocation_ref.t
+      { producer : Keeper_compaction_operation.producer_ref
       ; existing_operation_id : Keeper_compaction_operation.Operation_id.t
       }
 type history_error =

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -1143,6 +1143,7 @@ let run_stdio ~handle_request ~sw ~env state =
   let stdin = Eio.Stdenv.stdin env in
   let stdout = Eio.Stdenv.stdout env in
   let clock = Eio.Stdenv.clock env in
+  let transport_session_id = Mcp_session.generate () in
   Log.Mcp.info "MASC MCP Server (Eio stdio mode)";
   Log.Mcp.info "Default workspace: %s" (Mcp_server.workspace_config state).Workspace.base_path;
   let buf = Eio.Buf_read.of_flow stdin ~max_size:(16 * 1024 * 1024) in
@@ -1212,7 +1213,12 @@ let run_stdio ~handle_request ~sw ~env state =
         | Some "" -> loop (Some mode)
         | Some request_str ->
           let response =
-            handle_request ~clock ~sw ~mcp_session_id:"stdio" state request_str
+            handle_request
+              ~clock
+              ~sw
+              ~mcp_session_id:transport_session_id
+              state
+              request_str
           in
           respond ~mode response;
           loop (Some mode))

--- a/test/keeper_compaction_operation/test_keeper_compaction_operation.ml
+++ b/test/keeper_compaction_operation/test_keeper_compaction_operation.ml
@@ -37,6 +37,12 @@ let cause = ok (Operation.Cause.of_string "operator request")
 let producer =
   let request_id = ok (Mcp_transport_protocol.request_id_of_yojson (`String "req-1")) in
   ok (Tool_invocation_ref.external_mcp ~request_id ~session_id:"session-1")
+  |> Operation.tool_invocation_producer_ref
+;;
+let overflow_producer =
+  Operation.provider_overflow_producer_ref
+    ~source_checkpoint:source
+    ~source_delivery_identity:"canonical-provider-delivery"
 ;;
 
 let request_event () =
@@ -46,7 +52,7 @@ let request_event () =
     ~source_checkpoint:source
     ~trigger:Compaction_trigger.Manual
     ~cause
-    ~producer_invocation:(Some producer)
+    ~producer:(Some producer)
 ;;
 
 let attempt_event () = Operation.attempt_started ~operation_id ~attempt_id
@@ -68,7 +74,7 @@ let test_requested_view () =
       ~source_checkpoint:source
       ~trigger:Compaction_trigger.Manual
       ~cause
-      ~producer_invocation:(Some producer)
+      ~producer:(Some producer)
   in
   Alcotest.(check bool)
     "operation identity"
@@ -87,7 +93,7 @@ let test_requested_view () =
     Alcotest.(check bool)
       "producer identity"
       true
-      (Option.exists (Tool_invocation_ref.equal producer) request.producer_invocation)
+      (Option.exists (Operation.producer_ref_equal producer) request.producer)
   | _ -> Alcotest.fail "requested event changed shape"
 ;;
 
@@ -407,6 +413,52 @@ let test_reducer_invalid_transition () =
   | Ok _ | Error _ -> Alcotest.fail "candidate without attempt was accepted"
 ;;
 
+let test_reducer_rejects_provider_source_mismatch () =
+  let mismatched =
+    Operation.requested
+      ~operation_id
+      ~keeper_name
+      ~source_checkpoint:advanced
+      ~trigger:(Compaction_trigger.Provider_overflow { limit_tokens = None })
+      ~cause
+      ~producer:(Some overflow_producer)
+  in
+  match Reducer.apply None mismatched with
+  | Error Reducer.Producer_source_mismatch -> ()
+  | Ok _ | Error _ ->
+    Alcotest.fail "provider producer was detached from its exact source"
+;;
+
+let test_reducer_requires_typed_provider_producer () =
+  let request ~trigger ~producer =
+    Operation.requested
+      ~operation_id
+      ~keeper_name
+      ~source_checkpoint:source
+      ~trigger
+      ~cause
+      ~producer
+  in
+  (match
+     Reducer.apply
+       None
+       (request
+          ~trigger:(Compaction_trigger.Provider_overflow { limit_tokens = None })
+          ~producer:None)
+   with
+   | Error Reducer.Provider_overflow_producer_required -> ()
+   | Ok _ | Error _ ->
+     Alcotest.fail "provider overflow without exact producer was accepted");
+  match
+    Reducer.apply
+      None
+      (request ~trigger:Compaction_trigger.Manual ~producer:(Some overflow_producer))
+  with
+  | Error Reducer.Producer_trigger_mismatch -> ()
+  | Ok _ | Error _ ->
+    Alcotest.fail "provider producer was attached to a manual trigger"
+;;
+
 let test_canonical_json_projection () =
   let turn = Ids.Turn_ref.make ~trace_id:"trace-a" ~absolute_turn:8 in
   let events =
@@ -473,7 +525,8 @@ let test_canonical_json_projection () =
     "req-1"
     (requested
      |> Yojson.Safe.Util.member "payload"
-     |> Yojson.Safe.Util.member "producer_invocation"
+     |> Yojson.Safe.Util.member "producer"
+     |> Yojson.Safe.Util.member "invocation"
      |> Yojson.Safe.Util.member "request_id"
      |> Yojson.Safe.Util.to_string)
 ;;
@@ -500,7 +553,7 @@ let test_codec_roundtrip_all_events () =
         ~source_checkpoint:source
         ~trigger:(Compaction_trigger.Provider_overflow { limit_tokens = None })
         ~cause
-        ~producer_invocation:None
+        ~producer:(Some overflow_producer)
     ; attempt_event ()
     ; candidate_event ()
     ; failed (Operation.Pre_commit_failure cause)
@@ -601,6 +654,35 @@ let test_codec_rejects_nested_unknown_field () =
     malformed
 ;;
 
+let test_codec_rejects_invalid_provider_digest () =
+  let event =
+    Operation.requested
+      ~operation_id
+      ~keeper_name
+      ~source_checkpoint:source
+      ~trigger:(Compaction_trigger.Provider_overflow { limit_tokens = None })
+      ~cause
+      ~producer:(Some overflow_producer)
+  in
+  let json = Codec.to_json event in
+  let payload = Yojson.Safe.Util.member "payload" json in
+  let producer = Yojson.Safe.Util.member "producer" payload in
+  let malformed_producer =
+    replace_field "source_delivery_sha256" (`String "bad") producer
+  in
+  let malformed =
+    replace_field
+      "payload"
+      (replace_field "producer" malformed_producer payload)
+      json
+  in
+  match Codec.of_json malformed with
+  | Error
+      (Codec.Invalid_provider_producer
+         (Operation.Invalid_source_delivery_sha256_length 3)) -> ()
+  | Ok _ | Error _ -> Alcotest.fail "invalid provider digest was accepted"
+;;
+
 let () =
   Alcotest.run
     "keeper compaction operation events"
@@ -633,6 +715,14 @@ let () =
             `Quick
             test_reducer_invalid_transition
         ; Alcotest.test_case
+            "provider producer source invariant"
+            `Quick
+            test_reducer_rejects_provider_source_mismatch
+        ; Alcotest.test_case
+            "provider trigger requires typed producer"
+            `Quick
+            test_reducer_requires_typed_provider_producer
+        ; Alcotest.test_case
             "canonical JSON projection"
             `Quick
             test_canonical_json_projection
@@ -644,5 +734,9 @@ let () =
             "codec rejects nested unknown field"
             `Quick
             test_codec_rejects_nested_unknown_field
+        ; Alcotest.test_case
+            "codec rejects invalid provider digest"
+            `Quick
+            test_codec_rejects_invalid_provider_digest
         ] )
     ]

--- a/test/keeper_compaction_operation_action_selector/test_keeper_compaction_operation_action_selector.ml
+++ b/test/keeper_compaction_operation_action_selector/test_keeper_compaction_operation_action_selector.ml
@@ -48,7 +48,7 @@ let requested operation_id =
     ~source_checkpoint:source
     ~trigger:Compaction_trigger.Manual
     ~cause
-    ~producer_invocation:None
+    ~producer:None
 
 let prepared operation_id =
   [ Operation.attempt_started ~operation_id ~attempt_id:attempt

--- a/test/keeper_compaction_operation_record/test_keeper_compaction_operation_record.ml
+++ b/test/keeper_compaction_operation_record/test_keeper_compaction_operation_record.ml
@@ -37,7 +37,7 @@ let event =
     ~source_checkpoint:source
     ~trigger:Compaction_trigger.Manual
     ~cause:(ok (Operation.Cause.of_string "manual compaction"))
-    ~producer_invocation:None
+    ~producer:None
 ;;
 
 let test_roundtrip_and_cursor () =

--- a/test/keeper_compaction_operation_store/test_keeper_compaction_operation_store.ml
+++ b/test/keeper_compaction_operation_store/test_keeper_compaction_operation_store.ml
@@ -12,13 +12,21 @@ let source =
        ~turn_count:3
        ~canonical_checkpoint_bytes:"source")
 ;;
+let next_source =
+  ok
+    (Keeper_checkpoint_ref.create
+       ~trace_id
+       ~generation:1
+       ~turn_count:4
+       ~canonical_checkpoint_bytes:"next-source")
+;;
 let id value = ok (Operation.Operation_id.of_string value)
 let op1 = id "00000000-0000-4000-8000-000000000001"
 let op2 = id "00000000-0000-4000-8000-000000000002"
 let attempt = ok (Operation.Attempt_id.of_string "00000000-0000-4000-8000-000000000011")
 let request ?producer operation_id =
   Operation.requested ~operation_id ~keeper_name ~source_checkpoint:source
-    ~trigger:Compaction_trigger.Manual ~cause ~producer_invocation:producer
+    ~trigger:Compaction_trigger.Manual ~cause ~producer
 ;;
 let rec remove path =
   if Sys.file_exists path then if Sys.is_directory path
@@ -58,6 +66,7 @@ let test_append_replay_and_slice () =
 let producer () =
   let request_id = ok (Mcp_transport_protocol.request_id_of_yojson (`Int 7)) in
   ok (Tool_invocation_ref.external_mcp ~request_id ~session_id:"store-session")
+  |> Operation.tool_invocation_producer_ref
 ;;
 let test_rejections_do_not_write () =
   with_base @@ fun base ->
@@ -75,12 +84,46 @@ let test_rejections_do_not_write () =
   let other = ok (Keeper_id.Keeper_name.of_string "other-keeper") in
   let wrong =
     Operation.requested ~operation_id:op2 ~keeper_name:other ~source_checkpoint:source
-      ~trigger:Compaction_trigger.Manual ~cause ~producer_invocation:None
+      ~trigger:Compaction_trigger.Manual ~cause ~producer:None
   in
   (match Store.append ~base_path:base ~keeper_name ~recorded_at:4.0 wrong with
    | Error (Store.Event_rejected (Store.Keeper_mismatch _)) -> ()
    | _ -> Alcotest.fail "cross-Keeper request was not rejected");
   Alcotest.(check string) "rejections wrote no bytes" before (Fs_compat.load_file path)
+;;
+let provider_request operation_id source_checkpoint =
+  let producer =
+    Operation.provider_overflow_producer_ref
+      ~source_checkpoint
+      ~source_delivery_identity:"same-delivery"
+  in
+  Operation.requested
+    ~operation_id
+    ~keeper_name
+    ~source_checkpoint
+    ~trigger:(Compaction_trigger.Provider_overflow { limit_tokens = None })
+    ~cause
+    ~producer:(Some producer)
+;;
+let test_provider_binding_includes_exact_source () =
+  with_base @@ fun base ->
+  ignore (append base 1.0 (provider_request op1 source));
+  (match
+     Store.append
+       ~base_path:base
+       ~keeper_name
+       ~recorded_at:2.0
+       (provider_request op2 source)
+   with
+   | Error
+       (Store.Event_rejected
+          (Store.Producer_already_bound { existing_operation_id; _ }))
+     when Operation.Operation_id.equal existing_operation_id op1 -> ()
+   | _ -> Alcotest.fail "same source delivery created a second operation");
+  ignore (append base 3.0 (provider_request op2 next_source));
+  match Store.replay ~base_path:base ~keeper_name with
+  | Ok { operations = [ _; _ ]; _ } -> ()
+  | _ -> Alcotest.fail "advanced source did not create a distinct operation"
 ;;
 let test_malformed_history_fails_loud () =
   with_base @@ fun base ->
@@ -100,6 +143,10 @@ let () =
     [ "journal",
       [ Alcotest.test_case "append replay slice" `Quick test_append_replay_and_slice
       ; Alcotest.test_case "rejections no write" `Quick test_rejections_do_not_write
+      ; Alcotest.test_case
+          "provider binding includes exact source"
+          `Quick
+          test_provider_binding_includes_exact_source
       ; Alcotest.test_case "malformed history" `Quick test_malformed_history_fails_loud
       ] ]
 ;;


### PR DESCRIPTION
## Outcome

Compaction requests now carry a closed typed producer identity instead of a tool-only invocation reference.

- keeps exact tool invocation identity
- binds provider overflow to the exact source checkpoint and SHA-256 of canonical delivery identity bytes
- rejects provider overflow without a typed provider producer
- rejects trigger/producer and source/producer mismatches
- generalizes durable producer uniqueness without tool or vendor semantics
- hard-cuts the old `producer_invocation` journal field

## Boundary

This is MASC-owned operation identity. OAS remains unaware of Keeper, compaction, providers, and product-specific tools.

## Verification

- `scripts/dune-local.sh build test/keeper_compaction_operation/test_keeper_compaction_operation.exe test/keeper_compaction_operation_store/test_keeper_compaction_operation_store.exe test/keeper_compaction_operation_action_selector/test_keeper_compaction_operation_action_selector.exe test/keeper_compaction_operation_record/test_keeper_compaction_operation_record.exe`
- operation events: 15/15
- operation store: 4/4
- action selector: 3/3
- operation record: 4/4
- `ocamlformat --check` on all changed OCaml files
- exact diff: +358/-41 = 399 changed lines
