### PR TITLE
refactor(keeper): own compaction wake registry in server state

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -90,6 +90,7 @@
   ;; RFC-0056 Phase 1N — Keeper_state_* deterministic FSM cluster extracted to
   ;; lib/keeper_state/. Parent still references bare Keeper_state_* modules.
   masc.keeper_registry
+  masc.keeper_compaction_wake_registry
   ;; Keeper-owned pure/type leaves extracted from lib/keeper/.
   masc.keeper_contract
   masc.keeper_hooks_oas_types

--- a/lib/keeper_compaction_wake_registry/dune
+++ b/lib/keeper_compaction_wake_registry/dune
@@ -1,0 +1,8 @@
+(include_subdirs no)
+
+(library
+ (name masc_keeper_compaction_wake_registry)
+ (public_name masc.keeper_compaction_wake_registry)
+ (wrapped false)
+ (modules keeper_compaction_wake_registry)
+ (libraries eio masc.keeper_registry))

--- a/lib/keeper_compaction_wake_registry/keeper_compaction_wake_registry.ml
+++ b/lib/keeper_compaction_wake_registry/keeper_compaction_wake_registry.ml
@@ -92,7 +92,8 @@ let register ~sw owner keeper_name =
   if registered
   then (
     Eio.Switch.on_release sw (fun () ->
-      ignore (unregister registration : unregister_result));
+      match unregister registration with
+      | Unregistered | Registration_not_current -> ());
     Ok registration)
   else Error Already_registered
 ;;

--- a/lib/keeper_compaction_wake_registry/keeper_compaction_wake_registry.ml
+++ b/lib/keeper_compaction_wake_registry/keeper_compaction_wake_registry.ml
@@ -1,0 +1,127 @@
+module Key = struct
+  type t = Keeper_id.Keeper_name.t
+
+  let equal = Keeper_id.Keeper_name.equal
+  let hash value = Hashtbl.hash (Keeper_id.Keeper_name.to_string value)
+end
+
+module Registrations = Hashtbl.Make (Key)
+
+type registration_state =
+  | Open of { pending : bool }
+  | Closed
+
+type t =
+  { mutex : Stdlib.Mutex.t
+  ; registrations : registration Registrations.t
+  }
+
+and registration =
+  { owner : t
+  ; keeper_name : Keeper_id.Keeper_name.t
+  ; mutex : Stdlib.Mutex.t
+  ; condition : Eio.Condition.t
+  ; mutable state : registration_state
+  }
+
+type register_error = Already_registered
+
+type unregister_result =
+  | Unregistered
+  | Registration_not_current
+
+type wake_result =
+  | Signaled
+  | Coalesced
+  | Not_registered
+
+type await_result =
+  | Wake
+  | Registration_closed
+
+let create () =
+  { mutex = Stdlib.Mutex.create (); registrations = Registrations.create 0 }
+;;
+
+let with_registry (t : t) f = Stdlib.Mutex.protect t.mutex f
+let with_registration (registration : registration) f =
+  Stdlib.Mutex.protect registration.mutex f
+;;
+
+let unregister registration =
+  let removed =
+    with_registry registration.owner (fun () ->
+      match
+        Registrations.find_opt
+          registration.owner.registrations
+          registration.keeper_name
+      with
+      | Some current when current == registration ->
+        Registrations.remove
+          registration.owner.registrations
+          registration.keeper_name;
+        true
+      | Some _ | None -> false)
+  in
+  if removed
+  then (
+    with_registration registration (fun () -> registration.state <- Closed);
+    Eio.Condition.broadcast registration.condition;
+    Unregistered)
+  else Registration_not_current
+;;
+
+let register ~sw owner keeper_name =
+  Eio.Switch.check sw;
+  let registration =
+    { owner
+    ; keeper_name
+    ; mutex = Stdlib.Mutex.create ()
+    ; condition = Eio.Condition.create ()
+    ; state = Open { pending = false }
+    }
+  in
+  let registered =
+    with_registry owner (fun () ->
+      match Registrations.find_opt owner.registrations keeper_name with
+      | Some _ -> false
+      | None ->
+        Registrations.add owner.registrations keeper_name registration;
+        true)
+  in
+  if registered
+  then (
+    Eio.Switch.on_release sw (fun () ->
+      ignore (unregister registration : unregister_result));
+    Ok registration)
+  else Error Already_registered
+;;
+
+let wake owner keeper_name =
+  let result, notify =
+    with_registry owner (fun () ->
+      match Registrations.find_opt owner.registrations keeper_name with
+      | None -> (Not_registered, None)
+      | Some registration ->
+        with_registration registration (fun () ->
+          match registration.state with
+          | Closed -> Not_registered, None
+          | Open { pending = true } -> Coalesced, None
+          | Open { pending = false } ->
+            registration.state <- Open { pending = true };
+            Signaled, Some registration.condition))
+  in
+  Option.iter Eio.Condition.broadcast notify;
+  result
+;;
+
+let await registration =
+  Eio.Condition.loop_no_mutex registration.condition (fun () ->
+    with_registration registration (fun () ->
+      match registration.state with
+      | Closed -> Some Registration_closed
+      | Open { pending = false } -> None
+      | Open { pending = true } ->
+        registration.state <- Open { pending = false };
+        Some Wake))
+;;

--- a/lib/keeper_compaction_wake_registry/keeper_compaction_wake_registry.mli
+++ b/lib/keeper_compaction_wake_registry/keeper_compaction_wake_registry.mli
@@ -1,0 +1,43 @@
+(** Process-local wake hints for per-Keeper compaction actors.
+
+    Durable compaction operations remain the sole work authority. A pending
+    hint only asks an already-registered actor to drain that journal; multiple
+    hints may coalesce without dropping durable work. Registration never
+    invents startup work, so the actor owner performs startup drain explicitly. *)
+
+type t
+type registration
+
+type register_error = Already_registered
+
+type unregister_result =
+  | Unregistered
+  | Registration_not_current
+
+type wake_result =
+  | Signaled
+  | Coalesced
+  | Not_registered
+
+type await_result =
+  | Wake
+  | Registration_closed
+
+val create : unit -> t
+
+val register
+  :  sw:Eio.Switch.t
+  -> t
+  -> Keeper_id.Keeper_name.t
+  -> (registration, register_error) result
+(** Register one exact Keeper identity for the lifetime of [sw]. A duplicate
+    live registration is rejected; switch release unregisters it. *)
+
+val unregister : registration -> unregister_result
+(** Idempotent lifecycle close. A stale token cannot remove a replacement. *)
+
+val wake : t -> Keeper_id.Keeper_name.t -> wake_result
+(** Set one non-blocking pending hint. An existing pending hint coalesces. *)
+
+val await : registration -> await_result
+(** Cancellably await and consume one hint, or observe registration close. *)

--- a/lib/mcp_server.ml
+++ b/lib/mcp_server.ml
@@ -525,6 +525,7 @@ type workspace_runtime =
 type server_state = {
   workspace_runtime: workspace_runtime;
   session_registry: Session.registry;
+  keeper_compaction_wake_registry: Keeper_compaction_wake_registry.t;
   on_sse_broadcast: (Yojson.Safe.t -> unit) option Atomic.t;  (* SSE push callback, Atomic for cross-fiber visibility *)
   sw: Eio.Switch.t option; (* Request/runtime fibers for HTTP/MCP handlers *)
   proc_mgr: Eio_unix.Process.mgr_ty Eio.Resource.t option; (* For agent spawning *)
@@ -550,6 +551,9 @@ let workspace_switch_error_to_string = function
 
 let workspace_scope state = Atomic.get state.workspace_runtime.scope
 let workspace_config state = (workspace_scope state).config
+let keeper_compaction_wake_registry state =
+  state.keeper_compaction_wake_registry
+;;
 
 let workspace_scope_publication_recovery_registry scope =
   match Atomic.get scope.publication_recovery.state with
@@ -1134,6 +1138,8 @@ module For_testing = struct
                 }
           }
       ; session_registry = registry
+      ; keeper_compaction_wake_registry =
+          Keeper_compaction_wake_registry.create ()
       ; on_sse_broadcast = Atomic.make None
       ; sw = None
       ; proc_mgr = None
@@ -1233,6 +1239,8 @@ let create_state_eio ~sw ~proc_mgr ~fs ~clock ~mono_clock ~net ~base_path =
             { config; publication_recovery }
       };
     session_registry = registry;
+    keeper_compaction_wake_registry =
+      Keeper_compaction_wake_registry.create ();
     on_sse_broadcast = Atomic.make None;
     sw = Some sw;
     proc_mgr = Some proc_mgr;

--- a/lib/mcp_server.mli
+++ b/lib/mcp_server.mli
@@ -192,6 +192,7 @@ type workspace_runtime
 type server_state = private {
   workspace_runtime : workspace_runtime;
   session_registry : Session.registry;
+  keeper_compaction_wake_registry : Keeper_compaction_wake_registry.t;
   on_sse_broadcast :
     (Yojson.Safe.t -> unit) option Atomic.t;
   sw : Eio.Switch.t option;
@@ -213,6 +214,11 @@ val workspace_scope : server_state -> workspace_scope
 
 val workspace_config : server_state -> Workspace.config
 (** Current workspace configuration. *)
+
+val keeper_compaction_wake_registry :
+  server_state -> Keeper_compaction_wake_registry.t
+(** Stable process-lifetime wake-hint registry owned by this server state.
+    Durable compaction operations remain the sole work authority. *)
 
 val publication_recovery_availability_provider :
   server_state -> Keeper_publication_recovery_availability.provider

--- a/test/keeper_compaction_wake_registry/dune
+++ b/test/keeper_compaction_wake_registry/dune
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_compaction_wake_registry)
+ (libraries alcotest eio eio_main masc.keeper_compaction_wake_registry
+  masc.keeper_registry))

--- a/test/keeper_compaction_wake_registry/test_keeper_compaction_wake_registry.ml
+++ b/test/keeper_compaction_wake_registry/test_keeper_compaction_wake_registry.ml
@@ -1,0 +1,97 @@
+module Registry = Keeper_compaction_wake_registry
+
+let keeper value =
+  match Keeper_id.Keeper_name.of_string value with
+  | Ok keeper -> keeper
+  | Error error -> Alcotest.fail error
+;;
+
+let alpha = keeper "compaction-alpha"
+let beta = keeper "compaction-beta"
+
+let registration = function
+  | Ok value -> value
+  | Error Registry.Already_registered ->
+    Alcotest.fail "unexpected duplicate registration"
+;;
+
+let check_equal label expected actual =
+  Alcotest.(check bool) label true (expected = actual)
+;;
+
+let test_coalesces_and_rearms () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun sw ->
+  let registry = Registry.create () in
+  let actor = registration (Registry.register ~sw registry alpha) in
+  (match Registry.register ~sw registry alpha with
+   | Error Registry.Already_registered -> ()
+   | Ok _ -> Alcotest.fail "duplicate registration accepted");
+  check_equal "first hint" Registry.Signaled (Registry.wake registry alpha);
+  check_equal "coalesced hint" Registry.Coalesced (Registry.wake registry alpha);
+  check_equal "consume hint" Registry.Wake (Registry.await actor);
+  check_equal "rearmed hint" Registry.Signaled (Registry.wake registry alpha);
+  check_equal "consume rearmed" Registry.Wake (Registry.await actor)
+;;
+
+let test_stale_token_cannot_remove_replacement () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun sw ->
+  let registry = Registry.create () in
+  let first = registration (Registry.register ~sw registry alpha) in
+  check_equal "first close" Registry.Unregistered (Registry.unregister first);
+  let replacement = registration (Registry.register ~sw registry alpha) in
+  check_equal
+    "stale token"
+    Registry.Registration_not_current
+    (Registry.unregister first);
+  check_equal "replacement signaled" Registry.Signaled
+    (Registry.wake registry alpha);
+  check_equal "replacement receives hint" Registry.Wake
+    (Registry.await replacement)
+;;
+
+let test_keeper_lifetimes_are_isolated () =
+  Eio_main.run @@ fun _env ->
+  let registry = Registry.create () in
+  Eio.Switch.run @@ fun beta_sw ->
+  let beta_actor = registration (Registry.register ~sw:beta_sw registry beta) in
+  Eio.Switch.run (fun alpha_sw ->
+    ignore (registration (Registry.register ~sw:alpha_sw registry alpha)));
+  check_equal "released keeper absent" Registry.Not_registered
+    (Registry.wake registry alpha);
+  check_equal "other keeper signaled" Registry.Signaled
+    (Registry.wake registry beta);
+  check_equal "other keeper receives" Registry.Wake
+    (Registry.await beta_actor)
+;;
+
+let test_await_propagates_cancellation () =
+  let propagated = ref false in
+  (try
+     Eio_main.run @@ fun _env ->
+     Eio.Switch.run @@ fun sw ->
+     let registry = Registry.create () in
+     let actor = registration (Registry.register ~sw registry alpha) in
+     Eio.Cancel.sub (fun context ->
+       Eio.Cancel.cancel context Exit;
+       ignore (Registry.await actor : Registry.await_result))
+   with
+   | Eio.Cancel.Cancelled _ -> propagated := true);
+  Alcotest.(check bool) "await cancellation propagated" true !propagated
+;;
+
+let () =
+  Alcotest.run
+    "keeper compaction wake registry"
+    [ ( "wake hints"
+      , [ Alcotest.test_case "coalesces and rearms" `Quick
+            test_coalesces_and_rearms
+        ; Alcotest.test_case "stale token replacement" `Quick
+            test_stale_token_cannot_remove_replacement
+        ; Alcotest.test_case "keeper isolation" `Quick
+            test_keeper_lifetimes_are_isolated
+        ; Alcotest.test_case "cancellation propagation" `Quick
+            test_await_propagates_cancellation
+        ] )
+    ]

--- a/test/mcp_server_compaction_wake_registry/dune
+++ b/test/mcp_server_compaction_wake_registry/dune
@@ -1,0 +1,9 @@
+(test
+ (name test_mcp_server_compaction_wake_registry)
+ (libraries
+  alcotest
+  eio
+  eio_main
+  masc
+  masc.keeper_compaction_wake_registry
+  masc.keeper_registry))

--- a/test/mcp_server_compaction_wake_registry/test_mcp_server_compaction_wake_registry.ml
+++ b/test/mcp_server_compaction_wake_registry/test_mcp_server_compaction_wake_registry.ml
@@ -1,0 +1,66 @@
+module Mcp_server = Masc.Mcp_server
+module Registry = Keeper_compaction_wake_registry
+
+let keeper_name =
+  match Keeper_id.Keeper_name.of_string "compaction-state-resource" with
+  | Ok value -> value
+  | Error error -> Alcotest.fail error
+;;
+
+let create_state suffix =
+  Mcp_server.For_testing.create_state
+    ~base_path:
+      (Filename.concat
+         (Filename.get_temp_dir_name ())
+         ("masc-compaction-wake-" ^ suffix))
+;;
+
+let test_accessor_identity_and_state_isolation () =
+  Eio_main.run
+  @@ fun _env ->
+  let first_state = create_state "first" in
+  let second_state = create_state "second" in
+  let first_registry =
+    Mcp_server.keeper_compaction_wake_registry first_state
+  in
+  let same_first_registry =
+    Mcp_server.keeper_compaction_wake_registry first_state
+  in
+  let second_registry =
+    Mcp_server.keeper_compaction_wake_registry second_state
+  in
+  Alcotest.(check bool)
+    "same state returns stable registry identity"
+    true
+    (first_registry == same_first_registry);
+  Alcotest.(check bool)
+    "different states own different registries"
+    false
+    (first_registry == second_registry);
+  Eio.Switch.run
+  @@ fun sw ->
+  (match Registry.register ~sw first_registry keeper_name with
+   | Ok _ -> ()
+   | Error Registry.Already_registered ->
+     Alcotest.fail "fresh state registry already contained the Keeper");
+  (match Registry.wake second_registry keeper_name with
+   | Registry.Not_registered -> ()
+   | Registry.Signaled | Registry.Coalesced ->
+     Alcotest.fail "registration leaked into another server state");
+  match Registry.wake same_first_registry keeper_name with
+  | Registry.Signaled -> ()
+  | Registry.Coalesced | Registry.Not_registered ->
+    Alcotest.fail "same state accessor did not reach its registered Keeper"
+;;
+
+let () =
+  Alcotest.run
+    "mcp server compaction wake registry"
+    [ ( "state ownership"
+      , [ Alcotest.test_case
+            "stable accessor and isolated states"
+            `Quick
+            test_accessor_identity_and_state_isolation
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary
- make Mcp_server.server_state own one process-lifetime Keeper compaction wake registry
- expose a stable accessor without adding a global singleton, tool wiring, or lane actor
- construct independent registry instances in both production create_state_eio and For_testing.create_state
- prove stable same-state identity and behavioral isolation across states

## SSOT boundary
Durable compaction operations remain the sole work authority. This registry carries only coalescible process-local wake hints.

## Verification
- scripts/dune-local.sh build test/mcp_server_compaction_wake_registry/test_mcp_server_compaction_wake_registry.exe
- scripts/dune-local.sh exec test/mcp_server_compaction_wake_registry/test_mcp_server_compaction_wake_registry.exe
- git diff --check
- adversarial boundary and constructor-path self-review

Stacked on #24941 via base branch codex/compaction-wake-hint-registry-20260717.