### PR TITLE
refactor(keeper): delete compaction config surfaces

### DIFF
--- a/bin/masc_tui_render.ml
+++ b/bin/masc_tui_render.ml
@@ -927,7 +927,6 @@ let render_keeper_detail (state : state) =
     add_row "Total Cost:" (Printf.sprintf "$%.4f" k.k_total_cost_usd);
     add_row "Last Turn:" (short_ts k.k_last_turn_ts);
     add_row "Compactions:" (string_of_int k.k_compaction_count);
-    add_row "Compaction Gate:" (Printf.sprintf "%.0f%%" (k.k_compaction_ratio_gate *. 100.0));
     add_row "Context Budget:" (string_of_int k.k_context_budget);
     add_empty ();
 

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -712,9 +712,6 @@ let keepers_dashboard_json ?(compact = false) (config : Workspace.config) : Yojs
 	            | _ -> `Null
 	          in
 	          let summary =
-	            let compact_ratio_gate = m.compaction.ratio_gate in
-	            let compact_message_gate = m.compaction.message_gate in
-	            let compact_token_gate = m.compaction.token_gate in
               let trust_json =
                 keeper_trust_json ~include_receipt:(not compact) config m
               in
@@ -923,10 +920,6 @@ let keepers_dashboard_json ?(compact = false) (config : Workspace.config) : Yojs
               ("last_latency_ms", last_latency_ms_json m.runtime.usage.last_latency_ms);
               ("compaction_count", `Int m.runtime.compaction_rt.count);
               ("last_compaction_saved_tokens", `Int last_compaction_saved_tokens);
-              ("compaction_profile", `String m.compaction.profile);
-              ("compaction_ratio_gate", `Float compact_ratio_gate);
-              ("compaction_message_gate", `Int compact_message_gate);
-              ("compaction_token_gate", `Int compact_token_gate);
               ("autoboot_enabled", `Bool m.autoboot_enabled);
               ("proactive_enabled", `Bool m.proactive.enabled);
               ("proactive_count_total", `Int m.runtime.proactive_rt.count_total);

--- a/lib/dashboard/dashboard_http_keeper_snapshot.ml
+++ b/lib/dashboard/dashboard_http_keeper_snapshot.ml
@@ -210,15 +210,6 @@ let keeper_config_json (config : Workspace.config) (name : string)
           ("verify", `Bool false);
         ]
       in
-      let compaction =
-        `Assoc [
-          ("profile", `String m.compaction.profile);
-          ("ratio_gate", `Float m.compaction.ratio_gate);
-          ("message_gate", `Int m.compaction.message_gate);
-          ("token_gate", `Int m.compaction.token_gate);
-          ("cooldown_sec", `Int m.compaction.cooldown_sec);
-        ]
-      in
       let proactive =
         `Assoc [
           ("enabled", `Bool m.proactive.enabled);
@@ -305,8 +296,7 @@ let keeper_config_json (config : Workspace.config) (name : string)
              profile_config_error );
          ("prompt", prompt);
          ("execution", execution);
-         ("compaction", compaction);
-         ("proactive", proactive);
+        ("proactive", proactive);
          ("drift", drift);
          ("auto_execution_session", auto_execution_session_surface_json ());
          ("hooks", Keeper_hooks_oas.hook_introspection_json ());

--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -144,10 +144,6 @@ let compaction_decision_applied = function
   | Prepared _ | Rejected _ | Not_requested | Skipped_no_checkpoint -> false
 ;;
 
-let compaction_policy_of_keeper (meta : keeper_meta) : float * int * int =
-  meta.compaction.ratio_gate, meta.compaction.message_gate, meta.compaction.token_gate
-;;
-
 let strategy_names = [ "ConfiguredLlm" ]
 
 let record_pre_compact

--- a/lib/keeper/keeper_compact_policy.mli
+++ b/lib/keeper/keeper_compact_policy.mli
@@ -49,11 +49,6 @@ type compaction_preparation =
   ; evidence : compaction_evidence option
   }
 
-(** Legacy configuration projection retained until the unused ratio/message/
-    token gates are removed from [keeper_meta]. It is not consulted by
-    {!compact_for_request_typed}. *)
-val compaction_policy_of_keeper : Keeper_meta_contract.keeper_meta -> float * int * int
-
 (** Apply a caller-owned request. Only a valid configured-LLM plan that
     strictly reduces the exact serialized checkpoint byte length is prepared.
     Every refusal preserves the original context and returns a typed reason.

--- a/lib/keeper/keeper_config_text.ml
+++ b/lib/keeper/keeper_config_text.ml
@@ -80,6 +80,11 @@ let removed_keeper_input_key_names =
     "policy_shell_mode";
     "persona_ref";
     "runtime_ref";
+    "compaction_profile";
+    "compaction_ratio_gate";
+    "compaction_message_gate";
+    "compaction_token_gate";
+    "compaction_cooldown_sec";
     "tool_access";
     "tool_denylist";
     "shards";

--- a/lib/keeper/keeper_context_runtime.ml
+++ b/lib/keeper/keeper_context_runtime.ml
@@ -61,8 +61,6 @@ let load_context_from_checkpoint = Keeper_context_core.load_context_from_checkpo
 (* Re-export from Keeper_compact_policy                              *)
 (* ================================================================ *)
 
-let compaction_policy_of_keeper = Keeper_compact_policy.compaction_policy_of_keeper
-
 type compaction_decision = Keeper_compact_policy.compaction_decision =
   | Applied of Compaction_trigger.t
   | Prepared of Compaction_trigger.t

--- a/lib/keeper/keeper_context_runtime.mli
+++ b/lib/keeper/keeper_context_runtime.mli
@@ -125,8 +125,6 @@ val load_context_from_checkpoint
 
 (** {1 Compaction} *)
 
-val compaction_policy_of_keeper : keeper_meta -> float * int * int
-
 type compaction_decision = Keeper_compact_policy.compaction_decision =
   | Applied of Compaction_trigger.t
   | Prepared of Compaction_trigger.t

--- a/lib/keeper/keeper_execution.ml
+++ b/lib/keeper/keeper_execution.ml
@@ -13,7 +13,6 @@ include Keeper_prompt
 
 let log_keeper_exn = Keeper_context_runtime.log_keeper_exn
 let load_context_from_checkpoint = Keeper_context_runtime.load_context_from_checkpoint
-let compaction_policy_of_keeper = Keeper_context_runtime.compaction_policy_of_keeper
 let generate_trace_id = Keeper_context_runtime.generate_trace_id
 let effective_model_labels_for_turn = Keeper_context_runtime.effective_model_labels_for_turn
 let memory_check_default_json = Keeper_context_runtime.memory_check_default_json

--- a/lib/keeper/keeper_execution.mli
+++ b/lib/keeper/keeper_execution.mli
@@ -32,11 +32,6 @@ val memory_check_default_json : unit -> Yojson.Safe.t
 (* Proactive emission and explicit workspace replies are now handled
    by Keeper_unified_turn via the unified keeper loop. *)
 
-(** {1 Compaction} *)
-
-(** Extract compaction policy tuple from keeper metadata. *)
-val compaction_policy_of_keeper : keeper_meta -> float * int * int
-
 (** {1 Trace and Model} *)
 
 (** Generate unique trace ID for a keeper turn. *)

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -250,26 +250,6 @@ let keeper_schemas : tool_schema list = [
           ("type", `String "boolean");
           ("description", `String "If true, scheduled keeper cycles may produce proactive responses.");
         ]);
-        ("compaction_profile", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Compaction profile. One of: aggressive, balanced, conservative, custom.");
-        ]);
-        ("compaction_ratio_gate", `Assoc [
-          ("type", `String "number");
-          ("description", `String "Context ratio gate for compaction (0.1-0.98). Overrides compaction profile when set.");
-        ]);
-        ("compaction_message_gate", `Assoc [
-          ("type", `String "integer");
-          ("description", `String "Message count gate for compaction (0 disables this gate). Overrides compaction profile when set.");
-        ]);
-        ("compaction_token_gate", `Assoc [
-          ("type", `String "integer");
-          ("description", `String "Token count gate for compaction (0 disables this gate). Overrides compaction profile when set.");
-        ]);
-        ("compaction_cooldown_sec", `Assoc [
-          ("type", `String "integer");
-          ("description", `String "Minimum seconds between completed compactions. 0 disables the cooldown.");
-        ]);
         ("allowed_paths", `Assoc [
           ("type", `String "array");
           ("items", `Assoc [("type", `String "string")]);

--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -58,9 +58,6 @@ let handle_keeper_list ctx args : tool_result =
           let last_compaction_saved_tokens =
             max 0 (m.runtime.compaction_rt.last_before_tokens - m.runtime.compaction_rt.last_after_tokens)
           in
-          let (compact_ratio_gate, compact_message_gate, compact_token_gate) =
-            compaction_policy_of_keeper m
-          in
           let metrics_store = Keeper_types_support.keeper_metrics_store ctx.config m.name in
           let metrics_window_lines = Dated_jsonl.read_recent_lines metrics_store 120 in
           let last_metrics =
@@ -109,16 +106,6 @@ let handle_keeper_list ctx args : tool_result =
                      (Keeper_memory_recall_exn_class.to_label exn_class))
               in
               empty, note
-          in
-            let compaction_cooldown_remaining_s =
-              let cooldown = Float.of_int m.compaction.cooldown_sec in
-              if cooldown <= 0.0 then
-                0.0
-              else if m.runtime.compaction_rt.last_ts <= 0.0 then
-                0.0
-              else
-                let elapsed = now_ts -. m.runtime.compaction_rt.last_ts in
-                max 0.0 (cooldown -. elapsed)
           in
           let context_json =
             match last_metrics with
@@ -173,10 +160,6 @@ let handle_keeper_list ctx args : tool_result =
               ("handoff_count_total", `Int trace_history_count);
               ("compaction_count", `Int m.runtime.compaction_rt.count);
               ("last_compaction_saved_tokens", `Int last_compaction_saved_tokens);
-              ("compaction_profile", `String m.compaction.profile);
-              ("compaction_ratio_gate", `Float compact_ratio_gate);
-              ("compaction_message_gate", `Int compact_message_gate);
-              ("compaction_token_gate", `Int compact_token_gate);
               ("autoboot_enabled", `Bool m.autoboot_enabled);
               ("proactive_enabled", `Bool m.proactive.enabled);
               ("proactive_count_total", `Int m.runtime.proactive_rt.count_total);
@@ -206,8 +189,6 @@ let handle_keeper_list ctx args : tool_result =
             ]
             @ runtime_blocker_fields
             @ attention_fields @ [
-              ("compaction_cooldown_sec", `Int m.compaction.cooldown_sec);
-              ("compaction_cooldown_remaining_s", `Float compaction_cooldown_remaining_s);
               ("autonomous_turn_count", `Int m.runtime.autonomous_turn_count);
               ("autonomous_text_turn_count", `Int m.runtime.autonomous_text_turn_count);
               ("autonomous_tool_turn_count", `Int m.runtime.autonomous_tool_turn_count);

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -443,10 +443,6 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
          let last_compaction_saved_tokens =
            max 0 (m.runtime.compaction_rt.last_before_tokens - m.runtime.compaction_rt.last_after_tokens)
          in
-         let (compact_ratio_gate, compact_message_gate, compact_token_gate) =
-           compaction_policy_of_keeper m
-         in
-
          let metrics_store = Keeper_types_support.keeper_metrics_store config m.name in
          let memory_bank_path =
            Keeper_types_support.keeper_memory_bank_path config m.name
@@ -891,13 +887,6 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
              ("tool_action_count", `Int m.runtime.autonomous_action_count);
            ]);
         ] @ runtime_blocker_fields @ attention_fields @ [
-           ("compaction_policy", `Assoc [
-             ("profile", `String m.compaction.profile);
-             ("ratio_gate", `Float compact_ratio_gate);
-             ("message_gate", `Int compact_message_gate);
-             ("token_gate", `Int compact_token_gate);
-             ("token_gate_enabled", `Bool (compact_token_gate > 0));
-           ]);
            ("status_options", `Assoc [
              ("fast", `Bool fast);
              ("include_context", `Bool include_context);

--- a/lib/keeper_metrics/keeper_measurement.ml
+++ b/lib/keeper_metrics/keeper_measurement.ml
@@ -2,14 +2,6 @@
     Phase 1: types and serialization.
     Phase 4: pure [capture] function. *)
 
-type threshold_params = {
-  compaction_ratio_gate : float;
-  compaction_message_gate : int;
-  compaction_token_gate : int;
-  compaction_cooldown_sec : int;
-  model_ratio_multiplier : float;
-}
-
 type context_measurement = {
   context_ratio : float;
   message_count : int;
@@ -34,27 +26,16 @@ type measurement_snapshot = {
   keeper_name : string;
   generation : int;
   timestamp : float;
-  thresholds : threshold_params;
   context : context_measurement;
   timing : timing_measurement;
   failures : failure_measurement;
 }
-
-let threshold_params_to_json (t : threshold_params) : Yojson.Safe.t =
-  `Assoc [
-    "compaction_ratio_gate", `Float t.compaction_ratio_gate;
-    "compaction_message_gate", `Int t.compaction_message_gate;
-    "compaction_token_gate", `Int t.compaction_token_gate;
-    "compaction_cooldown_sec", `Int t.compaction_cooldown_sec;
-    "model_ratio_multiplier", `Float t.model_ratio_multiplier;
-  ]
 
 let capture
       ~snapshot_id
       ~keeper_name
       ~generation
       ~timestamp
-      ~thresholds
       ~context_ratio
       ~message_count
       ~token_count
@@ -72,7 +53,6 @@ let capture
   ; keeper_name
   ; generation
   ; timestamp
-  ; thresholds
   ; context =
       { context_ratio
       ; message_count
@@ -97,7 +77,6 @@ let measurement_snapshot_to_json (s : measurement_snapshot) : Yojson.Safe.t =
     "keeper_name", `String s.keeper_name;
     "generation", `Int s.generation;
     "timestamp", `Float s.timestamp;
-    "thresholds", threshold_params_to_json s.thresholds;
     "context", `Assoc [
       "context_ratio", `Float s.context.context_ratio;
       "message_count", `Int s.context.message_count;

--- a/lib/keeper_metrics/keeper_measurement.mli
+++ b/lib/keeper_metrics/keeper_measurement.mli
@@ -8,19 +8,6 @@
     Phase 4: pure [capture] function — accepts pre-computed values,
     returns [measurement_snapshot]. All I/O happens upstream in the caller. *)
 
-(** {1 Threshold Parameters} *)
-
-(** Frozen snapshot of all runtime-configurable thresholds.
-    Captured once per decision cycle to eliminate TOCTOU windows
-    where [Runtime_params.get] could return different values. *)
-type threshold_params = {
-  compaction_ratio_gate : float;
-  compaction_message_gate : int;
-  compaction_token_gate : int;
-  compaction_cooldown_sec : int;
-  model_ratio_multiplier : float;
-}
-
 (** {1 Sub-measurements} *)
 
 type context_measurement = {
@@ -53,7 +40,6 @@ type measurement_snapshot = {
   keeper_name : string;
   generation : int;
   timestamp : float;
-  thresholds : threshold_params;
   context : context_measurement;
   timing : timing_measurement;
   failures : failure_measurement;
@@ -69,7 +55,6 @@ val capture :
   keeper_name:string ->
   generation:int ->
   timestamp:float ->
-  thresholds:threshold_params ->
   context_ratio:float ->
   message_count:int ->
   token_count:int ->

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -1980,7 +1980,7 @@ let handle_keeper_get_subroutes state req request reqd =
           let b = Buffer.create 256 in
           Buffer.add_string b "stateDiagram-v2\n";
           Buffer.add_string b "    [*] --> Accumulating\n";
-          Buffer.add_string b "    Accumulating --> Compacting: ratio_gate\n";
+          Buffer.add_string b "    Accumulating --> Compacting: Compaction_requested\n";
           Buffer.add_string b "    Compacting --> Done: Compaction_completed\n";
           Buffer.add_string b "    Compacting --> Accumulating: Compaction_failed\n";
           Buffer.add_string b "    Done --> [*]\n";

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -388,7 +388,6 @@ let dashboard_config_string_fields =
   [
     "runtime_id";
     "instructions";
-    "compaction_profile";
     "sandbox_profile";
     "network_mode";
   ]
@@ -397,18 +396,6 @@ let dashboard_config_bool_fields =
   [
     "autoboot_enabled";
     "proactive_enabled";
-  ]
-
-let dashboard_config_int_fields =
-  [
-    "compaction_message_gate";
-    "compaction_token_gate";
-    "compaction_cooldown_sec";
-  ]
-
-let dashboard_config_float_fields =
-  [
-    "compaction_ratio_gate";
   ]
 
 let dashboard_config_string_list_fields =
@@ -423,8 +410,6 @@ let dashboard_config_patch_allowed_fields =
   @
   dashboard_config_string_fields
   @ dashboard_config_bool_fields
-  @ dashboard_config_int_fields
-  @ dashboard_config_float_fields
   @ dashboard_config_string_list_fields
 
 let dedupe_keep_order_strings values =
@@ -540,20 +525,6 @@ let validate_dashboard_string_list_field key = function
       loop 0 items
   | other -> dashboard_field_type_error key "an array of strings" other
 
-let validate_dashboard_normalized_int key normalize value =
-  let normalized = normalize value in
-  if normalized = value then Ok ()
-  else
-    Error
-      (Printf.sprintf "%s is out of range for dashboard config: %d" key value)
-
-let validate_dashboard_normalized_float key normalize value =
-  let normalized = normalize value in
-  if normalized = value then Ok ()
-  else
-    Error
-      (Printf.sprintf "%s is out of range for dashboard config: %g" key value)
-
 let validate_dashboard_nonnegative_int key value =
   if value >= 0 then Ok ()
   else
@@ -588,31 +559,6 @@ let validate_dashboard_config_field key value =
     match value with
     | `Bool _ -> Ok ()
     | other -> dashboard_field_type_error key "a boolean" other
-  else if List.mem key dashboard_config_int_fields then
-    match value with
-    | `Int value ->
-        (match key with
-         | "compaction_message_gate" ->
-             validate_dashboard_normalized_int key
-               Keeper_config.normalize_compaction_message_gate value
-         | "compaction_token_gate" ->
-             validate_dashboard_normalized_int key
-               Keeper_config.normalize_compaction_token_gate value
-         | "compaction_cooldown_sec" ->
-             validate_dashboard_normalized_int key
-               Keeper_config.normalize_compaction_cooldown_sec value
-         | _ -> Ok ())
-    | other -> dashboard_field_type_error key "an integer" other
-  else if List.mem key dashboard_config_float_fields then
-    match value with
-    | `Int value ->
-        let f = float_of_int value in
-        validate_dashboard_normalized_float key
-          Keeper_config.normalize_compaction_ratio_gate f
-    | `Float value ->
-        validate_dashboard_normalized_float key
-          Keeper_config.normalize_compaction_ratio_gate value
-    | other -> dashboard_field_type_error key "a number" other
   else if List.mem key dashboard_config_string_list_fields then
     validate_dashboard_string_list_field key value
   else Ok ()

--- a/lib/tui_decode.ml
+++ b/lib/tui_decode.ml
@@ -30,7 +30,6 @@ type keeper = {
   k_total_cost_usd : float;
   k_last_turn_ts : string;
   k_compaction_count : int;
-  k_compaction_ratio_gate : float;
   k_trigger_mode : string;
   k_context_budget : int;
   k_drift_enabled : bool;
@@ -221,7 +220,6 @@ let decode_keeper ~filename json =
              (Json_util.kind_name other))
   in
   let* k_compaction_count = require_int_field json "compaction_count" in
-  let* k_compaction_ratio_gate = require_float_field json "compaction_ratio_gate" in
   let* k_trigger_mode = require_string_field json "trigger_mode" in
   let* k_context_budget = require_int_field json "context_budget" in
   let* k_drift_enabled = require_bool_field json "drift_enabled" in
@@ -249,7 +247,6 @@ let decode_keeper ~filename json =
       k_total_cost_usd;
       k_last_turn_ts;
       k_compaction_count;
-      k_compaction_ratio_gate;
       k_trigger_mode;
       k_context_budget;
       k_drift_enabled;

--- a/lib/tui_decode.mli
+++ b/lib/tui_decode.mli
@@ -28,7 +28,6 @@ type keeper = {
   k_total_cost_usd : float;
   k_last_turn_ts : string;
   k_compaction_count : int;
-  k_compaction_ratio_gate : float;
   k_trigger_mode : string;
   k_context_budget : int;
   k_drift_enabled : bool;

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -597,8 +597,50 @@ let test_masc_keeper_up_schema () =
           Alcotest.(check bool) "omits allowed_models" false
             (List.mem_assoc "allowed_models" props);
           Alcotest.(check bool) "omits active_model" false
-            (List.mem_assoc "active_model" props)
+            (List.mem_assoc "active_model" props);
+          List.iter
+            (fun key ->
+              Alcotest.(check bool)
+                ("omits removed " ^ key)
+                false
+                (List.mem_assoc key props))
+            [ "compaction_profile"
+            ; "compaction_ratio_gate"
+            ; "compaction_message_gate"
+            ; "compaction_token_gate"
+            ; "compaction_cooldown_sec"
+            ]
       | None -> Alcotest.fail "masc_keeper_up missing properties"
+
+let test_keeper_compaction_config_args_rejected () =
+  let args =
+    `Assoc
+      [ "compaction_profile", `String "balanced"
+      ; "compaction_ratio_gate", `Float 0.85
+      ; "compaction_message_gate", `Int 120
+      ; "compaction_token_gate", `Int 120000
+      ; "compaction_cooldown_sec", `Int 30
+      ]
+  in
+  match
+    Masc.Keeper_config.reject_removed_keeper_input_keys
+      ~tool_name:"masc_keeper_up"
+      args
+  with
+  | Ok () -> Alcotest.fail "removed compaction config args should be rejected"
+  | Error msg ->
+    List.iter
+      (fun key ->
+        Alcotest.(check bool)
+          (key ^ " mentioned")
+          true
+          (contains_substring ~needle:key msg))
+      [ "compaction_profile"
+      ; "compaction_ratio_gate"
+      ; "compaction_message_gate"
+      ; "compaction_token_gate"
+      ; "compaction_cooldown_sec"
+      ]
 
 let test_keeper_sandbox_args_rejected () =
   let args =
@@ -854,6 +896,8 @@ let () =
         test_keeper_goal_arg_rejected;
       Alcotest.test_case "keeper-up" `Quick
         test_masc_keeper_up_schema;
+      Alcotest.test_case "keeper-compaction-config-args-rejected" `Quick
+        test_keeper_compaction_config_args_rejected;
       Alcotest.test_case "keeper-sandbox-args-rejected" `Quick
         test_keeper_sandbox_args_rejected;
       Alcotest.test_case "keeper-sandbox-args-dashboard-allowed" `Quick

--- a/test/test_tui_decode.ml
+++ b/test/test_tui_decode.ml
@@ -58,7 +58,6 @@ let keeper_json ?(models = `List [ `String "glm-5.1" ]) ?(last_turn_ts = `String
        ("total_cost_usd", `Float 0.42);
        ("last_turn_ts", last_turn_ts);
        ("compaction_count", `Int 1);
-       ("compaction_ratio_gate", `Float 0.8);
        ("trigger_mode", `String "mention");
        ("context_budget", `Int 32000);
        ("drift_enabled", `Bool true);


### PR DESCRIPTION
## Summary

- hard-delete keeper compaction config from public schemas, dashboard write validation, status/TUI projections, and dead threshold measurement shape
- reject removed keeper-up keys explicitly
- preserve manual and typed provider-overflow compaction paths

## Stack

- first 237 changed lines of the #24919 recut
- rebased onto current `main` after #24905 merged
- next: #24948

## Verification

- `scripts/dune-local.sh build lib/masc.cma lib/keeper_metrics/keeper_metrics.cma test/test_tui_decode.exe test/test_tools_coverage.exe`
- `test_tools_coverage.exe` — 48/48
- `test_tui_decode.exe` — 23/23
- own diff: 237 changed lines

Full build and suite remain delegated to PR CI.