### PR TITLE
refactor(config): purge dead compaction authority

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -639,16 +639,6 @@ module KeeperProactive = struct
   ;;
 end
 
-(** {1 Context Ratio Hard Cap}
-
-    Absolute ceiling for compaction ratio_gate and handoff threshold after
-    multiplier adjustment.  Prevents runaway values from disabling
-    compaction/handoff.  Default: 0.95. Range: [0.80, 0.99]. *)
-
-let context_ratio_hard_cap =
-  Float.max 0.80 (Float.min 0.99 (get_float ~default:0.95 "MASC_CONTEXT_RATIO_HARD_CAP"))
-;;
-
 (** {1 Dashboard Health Thresholds}
 
     Thresholds used by the dashboard keeper health scorer and harness health

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -191,14 +191,6 @@ module KeeperProactive : sig
   val stage_timing_ring_size : int
 end
 
-(** {1 Context ratio hard cap} *)
-
-(** Absolute ceiling for compaction ratio_gate / handoff threshold
-    after multiplier adjustment.  Range: [\[0.80, 0.99\]].  Reached
-    qualified ([Env_config_keeper.context_ratio_hard_cap]) by
-    {!Keeper_memory_recall} guard sites. *)
-val context_ratio_hard_cap : float
-
 (** {1 Dashboard health thresholds} *)
 
 module DashboardHealth : sig

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -141,12 +141,6 @@ let keeper_entries =
 
 let keeper_execution_entries =
   [
-    entry ~default:"0.85" "MASC_KEEPER_COMPACT_RATIO"
-      "Context compaction trigger ratio";
-    entry ~default:"12" "MASC_KEEPER_COMPACT_MAX_MESSAGES"
-      "Max messages before compaction";
-    entry ~default:"4000" "MASC_KEEPER_COMPACT_MAX_TOKENS"
-      "Max tokens before compaction (0=disabled)";
     entry ~default:"0.4" "MASC_KEEPER_UNIFIED_TEMP" "Unified turn temperature";
     entry ~default:"131072" "MASC_KEEPER_UNIFIED_MAX_TOKENS"
       "Unified turn max output tokens";
@@ -275,12 +269,6 @@ let channel_gate_entries =
       "Discord status stale threshold (seconds)";
     entry ~default:"30" "MASC_IMESSAGE_STATUS_STALE_SEC"
       "iMessage status stale threshold (seconds)";
-  ]
-
-let compaction_entries =
-  [
-    entry ~default:"0.95" "MASC_CONTEXT_RATIO_HARD_CAP"
-      "Absolute ceiling for compaction ratio_gate (clamped 0.80-0.99)";
   ]
 
 let decision_entries =
@@ -708,7 +696,7 @@ let all_categories () =
        @ docker_playground_entries
        @ keeper_sandbox_entries);
     category "keeper_execution"
-      (keeper_execution_entries @ compaction_entries @ decision_entries
+      (keeper_execution_entries @ decision_entries
        @ keeper_tool_entries @ keeper_runtime_entries
        @ keeper_proactive_entries @ keeper_grpc_entries);
     category "autonomy" (autonomy_entries @ keeper_supervisor_entries);

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -36,47 +36,6 @@ include Keeper_config_text
 let keeper_status_fast_default () : bool =
   bool_of_env_default "MASC_KEEPER_STATUS_FAST_DEFAULT" ~default:false
 
-(* MASC-owned explicit compaction threshold. This value is not forwarded to
-   OAS and does not imply an OAS event or retry policy. *)
-let keeper_compact_ratio_rp =
-  _rp_float ~key:"keeper.compaction.ratio"
-    ~default:(fun () -> float_of_env_default "MASC_KEEPER_COMPACT_RATIO"
-                          ~default:0.85 ~min_v:0.1 ~max_v:0.98)
-    ~min_v:0.1 ~max_v:0.98
-    ~description:"Compaction ratio gate" ()
-let keeper_compact_ratio () : float =
-  Runtime_params.get keeper_compact_ratio_rp
-
-let keeper_compact_max_messages_rp =
-  _rp_int ~key:"keeper.compaction.max_messages"
-    ~default:(fun () -> int_of_env_default "MASC_KEEPER_COMPACT_MAX_MESSAGES"
-                          ~default:0 ~min_v:0 ~max_v:5000)
-    ~min_v:0 ~max_v:5000
-    ~description:"Compaction message gate (0=disabled)" ()
-let keeper_compact_max_messages () : int =
-  Runtime_params.get keeper_compact_max_messages_rp
-
-let keeper_compact_max_tokens_rp =
-  _rp_int ~key:"keeper.compaction.max_tokens"
-    ~default:(fun () -> int_of_env_default "MASC_KEEPER_COMPACT_MAX_TOKENS"
-                          ~default:196608 ~min_v:0 ~max_v:5000000)
-    ~min_v:0 ~max_v:5000000
-    ~description:"Compaction token gate (75%% of 262k context)" ()
-let keeper_compact_max_tokens () : int =
-  Runtime_params.get keeper_compact_max_tokens_rp
-
-(** Cooldown between compaction attempts.  Previous default (90s) exceeded
-    the proactive heartbeat interval (30s), permanently blocking compaction
-    for proactive keepers.  15s allows compaction to fire every other cycle. *)
-let keeper_compaction_cooldown_sec_rp =
-  _rp_int ~key:"keeper.compaction.cooldown_sec"
-    ~default:(fun () -> int_of_env_default "MASC_KEEPER_COMPACTION_COOLDOWN_SEC"
-                          ~default:15 ~min_v:0 ~max_v:two_days_seconds_int)
-    ~min_v:0 ~max_v:two_days_seconds_int
-    ~description:"Compaction cooldown (seconds)" ()
-let keeper_compaction_cooldown_sec () : int =
-  Runtime_params.get keeper_compaction_cooldown_sec_rp
-
 let keeper_bootstrap_proactive_warmup_sec_rp =
   _rp_int ~key:"keeper.proactive.warmup_sec"
     ~default:(fun () -> int_of_env_default "MASC_KEEPER_BOOTSTRAP_PROACTIVE_WARMUP_SEC"
@@ -103,91 +62,6 @@ let keeper_bootstrap_retry_interval_sec_rp =
     ~description:"Delay between autoboot retry rounds (seconds)" ()
 let keeper_bootstrap_retry_interval_sec () : int =
   Runtime_params.get keeper_bootstrap_retry_interval_sec_rp
-
-let keeper_compaction_policy_from_env () : (float * int * int) =
-  ( keeper_compact_ratio (),
-    keeper_compact_max_messages (),
-    keeper_compact_max_tokens () )
-
-let normalize_compaction_ratio_gate (v : float) : float =
-  max 0.1 (min 0.98 v)
-
-let normalize_compaction_message_gate (v : int) : int =
-  clamp_int v ~min_v:0 ~max_v:5000
-
-let normalize_compaction_token_gate (v : int) : int =
-  clamp_int v ~min_v:0 ~max_v:5000000
-
-let normalize_compaction_cooldown_sec (v : int) : int =
-  clamp_int v ~min_v:0 ~max_v:two_days_seconds_int
-
-let default_compaction_profile = "custom"
-
-let canonical_compaction_profile raw =
-  match String.lowercase_ascii (String.trim raw) with
-  | "aggressive" | "tight" -> Some "aggressive"
-  | "balanced" | "default" -> Some "balanced"
-  | "conservative" | "loose" -> Some "conservative"
-  | "custom" | "manual" | "env" -> Some "custom"
-  | _ -> None
-
-let parse_compaction_profile_opt args key : (string option, string) result =
-  match get_string_opt args key with
-  | None -> Ok None
-  | Some raw ->
-      (match canonical_compaction_profile raw with
-       | Some p -> Ok (Some p)
-       | None ->
-           Error
-             (Printf.sprintf
-                "invalid compaction_profile '%s' (allowed: aggressive, balanced, conservative, custom)"
-                raw))
-
-let compaction_policy_of_profile (profile : string) : (float * int * int) =
-  match canonical_compaction_profile profile |> Option.value ~default:default_compaction_profile with
-  | "aggressive" -> (0.35, 120, 60_000)
-  | "balanced" -> (0.50, 240, 120_000)
-  | "conservative" -> (0.70, 480, 250_000)
-  | _ -> keeper_compaction_policy_from_env ()
-
-let resolve_compaction_policy
-    ~(profile_opt : string option)
-    ~(ratio_opt : float option)
-    ~(message_opt : int option)
-    ~(token_opt : int option)
-    ~(fallback_profile : string)
-    ~(fallback_ratio : float)
-    ~(fallback_message : int)
-    ~(fallback_token : int) : string * float * int * int =
-  let has_explicit_gate =
-    Option.is_some ratio_opt || Option.is_some message_opt || Option.is_some token_opt
-  in
-  let base_profile =
-    match profile_opt with
-    | Some p -> p
-    | None ->
-        if has_explicit_gate then "custom" else fallback_profile
-  in
-  let (base_ratio, base_message, base_token) =
-    match profile_opt with
-    | Some p -> compaction_policy_of_profile p
-    | None ->
-        if has_explicit_gate then (fallback_ratio, fallback_message, fallback_token)
-        else (fallback_ratio, fallback_message, fallback_token)
-  in
-  let ratio =
-    Option.value ~default:base_ratio ratio_opt
-    |> normalize_compaction_ratio_gate
-  in
-  let message_gate =
-    Option.value ~default:base_message message_opt
-    |> normalize_compaction_message_gate
-  in
-  let token_gate =
-    Option.value ~default:base_token token_opt
-    |> normalize_compaction_token_gate
-  in
-  (base_profile, ratio, message_gate, token_gate)
 
 let keeper_batch_limit_rp =
   _rp_int ~key:"keeper.turn.batch_limit"

--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -102,44 +102,11 @@ val utf8_repair_string : string -> string
     boundary. Caller MUST pass [max_bytes] explicitly so the unit is visible. *)
 val normalize_prompt_text : max_bytes:int -> string -> string
 
-(** {1 Compaction Configuration} *)
-
-val default_compaction_profile : string
-val canonical_compaction_profile : string -> string option
-val parse_compaction_profile_opt :
-  Yojson.Safe.t -> string -> (string option, string) result
-
-(** Return (ratio, message_gate, token_gate) for a named profile. *)
-val compaction_policy_of_profile : string -> float * int * int
-
-(** Resolve compaction policy from explicit overrides with profile-based fallbacks. *)
-val resolve_compaction_policy :
-  profile_opt:string option ->
-  ratio_opt:float option ->
-  message_opt:int option ->
-  token_opt:int option ->
-  fallback_profile:string ->
-  fallback_ratio:float ->
-  fallback_message:int ->
-  fallback_token:int ->
-  string * float * int * int
-
-val normalize_compaction_ratio_gate : float -> float
-val normalize_compaction_message_gate : int -> int
-val normalize_compaction_token_gate : int -> int
-val normalize_compaction_cooldown_sec : int -> int
-
 (** {1 Runtime Parameters}
 
     These functions return the current runtime-tunable value.
     Each parameter is registered with [Runtime_params] and can be
     adjusted via the dashboard at runtime. *)
-
-val keeper_compact_ratio : unit -> float
-val keeper_compact_max_messages : unit -> int
-val keeper_compact_max_tokens : unit -> int
-val keeper_compaction_cooldown_sec : unit -> int
-val keeper_compaction_policy_from_env : unit -> float * int * int
 
 val keeper_bootstrap_proactive_warmup_sec : unit -> int
 val keeper_bootstrap_stagger_step_sec : unit -> int

--- a/lib/keeper/keeper_types_profile_toml.mli
+++ b/lib/keeper/keeper_types_profile_toml.mli
@@ -25,28 +25,6 @@ val reject_removed_keeper_msg_input_keys :
   tool_name:string -> Yojson.Safe.t -> (unit, string) result
 val utf8_repair_string : string -> string
 val normalize_prompt_text : max_bytes:int -> string -> string
-val default_compaction_profile : string
-val canonical_compaction_profile : string -> string option
-val parse_compaction_profile_opt :
-  Yojson.Safe.t -> string -> (string option, string) result
-val compaction_policy_of_profile : string -> float * int * int
-val resolve_compaction_policy :
-  profile_opt:string option ->
-  ratio_opt:float option ->
-  message_opt:int option ->
-  token_opt:int option ->
-  fallback_profile:string ->
-  fallback_ratio:float ->
-  fallback_message:int -> fallback_token:int -> string * float * int * int
-val normalize_compaction_ratio_gate : float -> float
-val normalize_compaction_message_gate : int -> int
-val normalize_compaction_token_gate : int -> int
-val normalize_compaction_cooldown_sec : int -> int
-val keeper_compact_ratio : unit -> float
-val keeper_compact_max_messages : unit -> int
-val keeper_compact_max_tokens : unit -> int
-val keeper_compaction_cooldown_sec : unit -> int
-val keeper_compaction_policy_from_env : unit -> float * int * int
 val keeper_bootstrap_proactive_warmup_sec : unit -> int
 val keeper_bootstrap_stagger_step_sec : unit -> int
 val keeper_bootstrap_retry_interval_sec : unit -> int

--- a/lib/keeper/keeper_types_profile_toml_io.mli
+++ b/lib/keeper/keeper_types_profile_toml_io.mli
@@ -25,28 +25,6 @@ val reject_removed_keeper_msg_input_keys :
   tool_name:string -> Yojson.Safe.t -> (unit, string) result
 val utf8_repair_string : string -> string
 val normalize_prompt_text : max_bytes:int -> string -> string
-val default_compaction_profile : string
-val canonical_compaction_profile : string -> string option
-val parse_compaction_profile_opt :
-  Yojson.Safe.t -> string -> (string option, string) result
-val compaction_policy_of_profile : string -> float * int * int
-val resolve_compaction_policy :
-  profile_opt:string option ->
-  ratio_opt:float option ->
-  message_opt:int option ->
-  token_opt:int option ->
-  fallback_profile:string ->
-  fallback_ratio:float ->
-  fallback_message:int -> fallback_token:int -> string * float * int * int
-val normalize_compaction_ratio_gate : float -> float
-val normalize_compaction_message_gate : int -> int
-val normalize_compaction_token_gate : int -> int
-val normalize_compaction_cooldown_sec : int -> int
-val keeper_compact_ratio : unit -> float
-val keeper_compact_max_messages : unit -> int
-val keeper_compact_max_tokens : unit -> int
-val keeper_compaction_cooldown_sec : unit -> int
-val keeper_compaction_policy_from_env : unit -> float * int * int
 val keeper_bootstrap_proactive_warmup_sec : unit -> int
 val keeper_bootstrap_stagger_step_sec : unit -> int
 val keeper_bootstrap_retry_interval_sec : unit -> int

--- a/lib/keeper/keeper_types_profile_toml_normalizers.mli
+++ b/lib/keeper/keeper_types_profile_toml_normalizers.mli
@@ -25,28 +25,6 @@ val reject_removed_keeper_msg_input_keys :
   tool_name:string -> Yojson.Safe.t -> (unit, string) result
 val utf8_repair_string : string -> string
 val normalize_prompt_text : max_bytes:int -> string -> string
-val default_compaction_profile : string
-val canonical_compaction_profile : string -> string option
-val parse_compaction_profile_opt :
-  Yojson.Safe.t -> string -> (string option, string) result
-val compaction_policy_of_profile : string -> float * int * int
-val resolve_compaction_policy :
-  profile_opt:string option ->
-  ratio_opt:float option ->
-  message_opt:int option ->
-  token_opt:int option ->
-  fallback_profile:string ->
-  fallback_ratio:float ->
-  fallback_message:int -> fallback_token:int -> string * float * int * int
-val normalize_compaction_ratio_gate : float -> float
-val normalize_compaction_message_gate : int -> int
-val normalize_compaction_token_gate : int -> int
-val normalize_compaction_cooldown_sec : int -> int
-val keeper_compact_ratio : unit -> float
-val keeper_compact_max_messages : unit -> int
-val keeper_compact_max_tokens : unit -> int
-val keeper_compaction_cooldown_sec : unit -> int
-val keeper_compaction_policy_from_env : unit -> float * int * int
 val keeper_bootstrap_proactive_warmup_sec : unit -> int
 val keeper_bootstrap_stagger_step_sec : unit -> int
 val keeper_bootstrap_retry_interval_sec : unit -> int

--- a/lib/keeper/keeper_types_profile_toml_parser.mli
+++ b/lib/keeper/keeper_types_profile_toml_parser.mli
@@ -25,28 +25,6 @@ val reject_removed_keeper_msg_input_keys :
   tool_name:string -> Yojson.Safe.t -> (unit, string) result
 val utf8_repair_string : string -> string
 val normalize_prompt_text : max_bytes:int -> string -> string
-val default_compaction_profile : string
-val canonical_compaction_profile : string -> string option
-val parse_compaction_profile_opt :
-  Yojson.Safe.t -> string -> (string option, string) result
-val compaction_policy_of_profile : string -> float * int * int
-val resolve_compaction_policy :
-  profile_opt:string option ->
-  ratio_opt:float option ->
-  message_opt:int option ->
-  token_opt:int option ->
-  fallback_profile:string ->
-  fallback_ratio:float ->
-  fallback_message:int -> fallback_token:int -> string * float * int * int
-val normalize_compaction_ratio_gate : float -> float
-val normalize_compaction_message_gate : int -> int
-val normalize_compaction_token_gate : int -> int
-val normalize_compaction_cooldown_sec : int -> int
-val keeper_compact_ratio : unit -> float
-val keeper_compact_max_messages : unit -> int
-val keeper_compact_max_tokens : unit -> int
-val keeper_compaction_cooldown_sec : unit -> int
-val keeper_compaction_policy_from_env : unit -> float * int * int
 val keeper_bootstrap_proactive_warmup_sec : unit -> int
 val keeper_bootstrap_stagger_step_sec : unit -> int
 val keeper_bootstrap_retry_interval_sec : unit -> int

--- a/lib/keeper_registry/keeper_state_machine.mli
+++ b/lib/keeper_registry/keeper_state_machine.mli
@@ -64,7 +64,7 @@ type conditions = {
   turn_healthy : bool;
   (** Result of the latest completed turn observation. *)
   context_within_budget : bool;
-  (** [context_ratio < compaction.ratio_gate] *)
+  (** No compaction request is pending. *)
   context_handoff_needed : bool;
   compaction_active : bool;
   (** Set true on compaction entry, false on exit *)

--- a/lib/runtime_settings.ml
+++ b/lib/runtime_settings.ml
@@ -427,16 +427,6 @@ let surfaces =
       ];
     };
     {
-      id = "keeper_compaction";
-      description = "Keeper context compaction thresholds and cooldown";
-      param_keys = [
-        "keeper.compaction.ratio";
-        "keeper.compaction.max_messages";
-        "keeper.compaction.max_tokens";
-        "keeper.compaction.cooldown_sec";
-      ];
-    };
-    {
       id = "keeper_proactive";
       description = "Keeper proactive turn scheduling and bootstrap timing";
       param_keys = [

--- a/test/test_keeper_identity_parse.ml
+++ b/test/test_keeper_identity_parse.ml
@@ -155,6 +155,23 @@ let test_legacy_goal_meta_rejected () =
       (Astring.String.is_infix ~affix:"removed keeper meta field" msg
        && Astring.String.is_infix ~affix:"goal" msg)
 
+let test_removed_compaction_config_meta_rejected () =
+  match
+    strict_meta_of_fields
+      [ ("name", `String "alice")
+      ; ("agent_name", `String "keeper-alice-agent")
+      ; ("trace_id", `String "alice-001")
+      ; ("compaction_ratio_gate", `Float 0.85)
+      ]
+  with
+  | Ok _ -> fail "removed compaction config meta must be rejected"
+  | Error msg ->
+    check bool
+      "error names removed compaction config"
+      true
+      (Astring.String.is_infix ~affix:"removed keeper meta field" msg
+       && Astring.String.is_infix ~affix:"compaction_ratio_gate" msg)
+
 let () =
   run "keeper_identity_parse"
     [ ( "parse_keeper_identity"
@@ -172,5 +189,7 @@ let () =
             test_removed_voice_policy_meta_rejected
         ; test_case "removed legacy goal meta" `Quick
             test_legacy_goal_meta_rejected
+        ; test_case "removed compaction config meta" `Quick
+            test_removed_compaction_config_meta_rejected
         ] )
     ]


### PR DESCRIPTION
## Summary

- delete now-unreferenced compaction profiles, thresholds, normalization, runtime params, env entries, and duplicated interface exports
- remove the obsolete runtime-settings surface and ratio hard-cap configuration
- verify removed persisted compaction metadata is rejected explicitly
- leave compaction triggering with explicit MASC requests and typed provider overflow only

## Stack

- stacked after metadata authority removal
- recuts 310 changed lines of #24919
- next: #24951

## Verification

- `scripts/dune-local.sh build lib/masc.cma test/test_keeper_identity_parse.exe`
- `test_keeper_identity_parse.exe` — 10/10
- own diff: 310 changed lines

Full build and suite remain delegated to PR CI.