### PR TITLE
docs(keeper): document explicit compaction boundary

### DIFF
--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -14,9 +14,9 @@ the categorization roadmap. Newly-added typed getters in
 `lib/config/env_config_*.ml` must carry nearby `@category` and
 `@ops_class` tags; existing knobs remain in the backfill lane.
 
-**Total**: 264 unique knobs across 8 modules.
+**Total**: 260 unique knobs across 8 modules.
 
-**Typed getter classification**: 39/148 tagged (`operator`: 39, `algorithm`: 0, `unclassified`: 109).
+**Typed getter classification**: 39/147 tagged (`operator`: 39, `algorithm`: 0, `unclassified`: 108).
 
 ## Env_config_core (25 knobs; typed classification 2/6)
 
@@ -48,16 +48,15 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_TEST_ALLOW_HOME_BASE_PATH` | string_literal | n/a | n/a | 430 | #9903: production base-path safeguard for test executables. Without this, a test whose [MASC_BASE_PATH] override fail... |
 | `MASC_URL` | string_literal | n/a | n/a | 289 | SSOT for the MASC_HTTP_BASE_URL env-var name (issue 8352). Defined here (above [masc_http_base_url]) so the constant ... |
 
-## Env_config_keeper (52 knobs; typed classification 26/46)
+## Env_config_keeper (51 knobs; typed classification 26/45)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_CONTEXT_RATIO_HARD_CAP` | typed:float | unclassified | unclassified | 649 | {1 Context Ratio Hard Cap} Absolute ceiling for compaction ratio_gate and handoff threshold after multiplier adjustme... |
-| `MASC_DASHBOARD_HEALTH_CTX_CRITICAL` | typed:float | unclassified | unclassified | 658 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_HEALTH_CTX_WARN` | typed:float | unclassified | unclassified | 659 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_HEALTH_PENALTY_CRITICAL` | typed:float | unclassified | unclassified | 660 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_HEALTH_PENALTY_WARN` | typed:float | unclassified | unclassified | 661 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 664 |  |
+| `MASC_DASHBOARD_HEALTH_CTX_CRITICAL` | typed:float | unclassified | unclassified | 648 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_HEALTH_CTX_WARN` | typed:float | unclassified | unclassified | 649 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_HEALTH_PENALTY_CRITICAL` | typed:float | unclassified | unclassified | 650 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_HEALTH_PENALTY_WARN` | typed:float | unclassified | unclassified | 651 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 654 |  |
 | `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 589 | Total HTTP body-consumption deadline for non-streaming OAS completion calls. In agent_sdk this wraps [Complete.comple... |
 | `MASC_KEEPER_BOOTSTRAP_ENABLED` | feature_flag | n/a | n/a | 20 | Enable startup keeper bootstrap scan |
 | `MASC_KEEPER_BOOTSTRAP_LAZY_STARTUP_POLL_INTERVAL_SEC` | typed:float | unclassified | unclassified | 41 | Polling interval (seconds) for the lazy-startup wait loop in [server_bootstrap_loops.ml]. The autoboot fiber wakes up... |
@@ -251,70 +250,67 @@ the categorization roadmap. Newly-added typed getters in
 |---|---|---|---|---|---|
 | `MASC_SLACK_TRIGGER_POLICY` | string_literal | n/a | n/a | 20 |  |
 
-## Env_config_snapshot (66 knobs; typed classification 0/0)
+## Env_config_snapshot (63 knobs; typed classification 0/0)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
 | `MASC_ALLOW_ANONYMOUS_MUTATIONS` | string_literal | n/a | n/a | 29 |  |
-| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 557 |  |
-| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 561 |  |
-| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 563 |  |
-| `MASC_BENCHMARK_RESULTS_DIR` | string_literal | n/a | n/a | 184 |  |
-| `MASC_CHANNEL_GATE_DEDUP_TTL_SEC` | string_literal | n/a | n/a | 270 |  |
-| `MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH` | string_literal | n/a | n/a | 272 |  |
-| `MASC_DASHBOARD_CACHE_MAX_ENTRIES` | string_literal | n/a | n/a | 186 |  |
-| `MASC_DASHBOARD_EXECUTION_REFRESH_TIMEOUT_S` | string_literal | n/a | n/a | 194 |  |
-| `MASC_DASHBOARD_TRANSPORT_HEALTH_TIMEOUT_S` | string_literal | n/a | n/a | 234 |  |
-| `MASC_DECISION_AUDIT_RING_CAPACITY` | string_literal | n/a | n/a | 288 |  |
-| `MASC_DEFAULT_MODEL` | string_literal | n/a | n/a | 513 |  |
-| `MASC_DEFAULT_PROVIDER` | string_literal | n/a | n/a | 515 |  |
-| `MASC_DISCORD_STATUS_STALE_SEC` | string_literal | n/a | n/a | 274 |  |
-| `MASC_DRIFT_COSINE_WEIGHT` | string_literal | n/a | n/a | 175 |  |
-| `MASC_DRIFT_JACCARD_WEIGHT` | string_literal | n/a | n/a | 174 |  |
-| `MASC_DRIFT_THRESHOLD` | string_literal | n/a | n/a | 173 |  |
-| `MASC_ECONOMY_ENABLED` | string_literal | n/a | n/a | 329 |  |
-| `MASC_ECONOMY_FRUGAL_THRESHOLD` | string_literal | n/a | n/a | 331 |  |
-| `MASC_ECONOMY_HUSTLE_THRESHOLD` | string_literal | n/a | n/a | 333 |  |
-| `MASC_ECONOMY_INITIAL_BALANCE` | string_literal | n/a | n/a | 335 |  |
-| `MASC_ECONOMY_REWARD_BOARD_POST` | string_literal | n/a | n/a | 337 |  |
-| `MASC_ECONOMY_REWARD_MENTION_RESPONSE` | string_literal | n/a | n/a | 339 |  |
-| `MASC_ECONOMY_REWARD_TASK_DONE` | string_literal | n/a | n/a | 341 |  |
-| `MASC_ECONOMY_REWARD_UPVOTE` | string_literal | n/a | n/a | 343 |  |
-| `MASC_EVENT_BUFFER_SIZE` | string_literal | n/a | n/a | 635 |  |
-| `MASC_GOAL_DISPATCH_RUNTIME` | string_literal | n/a | n/a | 517 |  |
+| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 545 |  |
+| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 549 |  |
+| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 551 |  |
+| `MASC_BENCHMARK_RESULTS_DIR` | string_literal | n/a | n/a | 178 |  |
+| `MASC_CHANNEL_GATE_DEDUP_TTL_SEC` | string_literal | n/a | n/a | 264 |  |
+| `MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH` | string_literal | n/a | n/a | 266 |  |
+| `MASC_DASHBOARD_CACHE_MAX_ENTRIES` | string_literal | n/a | n/a | 180 |  |
+| `MASC_DASHBOARD_EXECUTION_REFRESH_TIMEOUT_S` | string_literal | n/a | n/a | 188 |  |
+| `MASC_DASHBOARD_TRANSPORT_HEALTH_TIMEOUT_S` | string_literal | n/a | n/a | 228 |  |
+| `MASC_DECISION_AUDIT_RING_CAPACITY` | string_literal | n/a | n/a | 276 |  |
+| `MASC_DEFAULT_MODEL` | string_literal | n/a | n/a | 501 |  |
+| `MASC_DEFAULT_PROVIDER` | string_literal | n/a | n/a | 503 |  |
+| `MASC_DISCORD_STATUS_STALE_SEC` | string_literal | n/a | n/a | 268 |  |
+| `MASC_DRIFT_COSINE_WEIGHT` | string_literal | n/a | n/a | 169 |  |
+| `MASC_DRIFT_JACCARD_WEIGHT` | string_literal | n/a | n/a | 168 |  |
+| `MASC_DRIFT_THRESHOLD` | string_literal | n/a | n/a | 167 |  |
+| `MASC_ECONOMY_ENABLED` | string_literal | n/a | n/a | 317 |  |
+| `MASC_ECONOMY_FRUGAL_THRESHOLD` | string_literal | n/a | n/a | 319 |  |
+| `MASC_ECONOMY_HUSTLE_THRESHOLD` | string_literal | n/a | n/a | 321 |  |
+| `MASC_ECONOMY_INITIAL_BALANCE` | string_literal | n/a | n/a | 323 |  |
+| `MASC_ECONOMY_REWARD_BOARD_POST` | string_literal | n/a | n/a | 325 |  |
+| `MASC_ECONOMY_REWARD_MENTION_RESPONSE` | string_literal | n/a | n/a | 327 |  |
+| `MASC_ECONOMY_REWARD_TASK_DONE` | string_literal | n/a | n/a | 329 |  |
+| `MASC_ECONOMY_REWARD_UPVOTE` | string_literal | n/a | n/a | 331 |  |
+| `MASC_EVENT_BUFFER_SIZE` | string_literal | n/a | n/a | 623 |  |
+| `MASC_GOAL_DISPATCH_RUNTIME` | string_literal | n/a | n/a | 505 |  |
 | `MASC_GRPC_STREAM_MAX_BUFFER` | string_literal | n/a | n/a | 78 |  |
-| `MASC_HEBBIAN_DECAY` | string_literal | n/a | n/a | 177 |  |
-| `MASC_HEBBIAN_RATE` | string_literal | n/a | n/a | 176 |  |
+| `MASC_HEBBIAN_DECAY` | string_literal | n/a | n/a | 171 |  |
+| `MASC_HEBBIAN_RATE` | string_literal | n/a | n/a | 170 |  |
 | `MASC_HTTP_HOST` | string_literal | n/a | n/a | 21 |  |
 | `MASC_HTTP_MAX_CONNECTIONS` | string_literal | n/a | n/a | 22 |  |
-| `MASC_IMESSAGE_STATUS_STALE_SEC` | string_literal | n/a | n/a | 276 |  |
-| `MASC_KEEPER_AUTONOMOUS_MAX_TOKENS` | string_literal | n/a | n/a | 153 |  |
-| `MASC_KEEPER_COMPACT_MAX_MESSAGES` | string_literal | n/a | n/a | 146 |  |
-| `MASC_KEEPER_COMPACT_MAX_TOKENS` | string_literal | n/a | n/a | 148 |  |
-| `MASC_KEEPER_COMPACT_RATIO` | string_literal | n/a | n/a | 144 |  |
-| `MASC_KEEPER_LLM_RERANK_RUNTIME` | string_literal | n/a | n/a | 428 |  |
-| `MASC_KEEPER_UNIFIED_MAX_TOKENS` | string_literal | n/a | n/a | 151 |  |
-| `MASC_KEEPER_UNIFIED_TEMP` | string_literal | n/a | n/a | 150 |  |
-| `MASC_LOCK_WARN_MS` | string_literal | n/a | n/a | 178 |  |
-| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 611 |  |
-| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 645 |  |
-| `MASC_ROUTING_RUNTIME` | string_literal | n/a | n/a | 519 |  |
-| `MASC_RUNTIME_ATTEMPT_LIVENESS` | string_literal | n/a | n/a | 373 |  |
-| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 653 |  |
-| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 585 |  |
-| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 587 |  |
-| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 589 |  |
-| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 591 |  |
-| `MASC_SSE_KEEPALIVE_SEC` | string_literal | n/a | n/a | 637 |  |
-| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 597 |  |
+| `MASC_IMESSAGE_STATUS_STALE_SEC` | string_literal | n/a | n/a | 270 |  |
+| `MASC_KEEPER_AUTONOMOUS_MAX_TOKENS` | string_literal | n/a | n/a | 147 |  |
+| `MASC_KEEPER_LLM_RERANK_RUNTIME` | string_literal | n/a | n/a | 416 |  |
+| `MASC_KEEPER_UNIFIED_MAX_TOKENS` | string_literal | n/a | n/a | 145 |  |
+| `MASC_KEEPER_UNIFIED_TEMP` | string_literal | n/a | n/a | 144 |  |
+| `MASC_LOCK_WARN_MS` | string_literal | n/a | n/a | 172 |  |
+| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 599 |  |
+| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 633 |  |
+| `MASC_ROUTING_RUNTIME` | string_literal | n/a | n/a | 507 |  |
+| `MASC_RUNTIME_ATTEMPT_LIVENESS` | string_literal | n/a | n/a | 361 |  |
+| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 641 |  |
+| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 573 |  |
+| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 575 |  |
+| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 577 |  |
+| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 579 |  |
+| `MASC_SSE_KEEPALIVE_SEC` | string_literal | n/a | n/a | 625 |  |
+| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 585 |  |
 | `MASC_TELEMETRY_MAX_BYTES` | string_literal | n/a | n/a | 48 |  |
 | `MASC_TELEMETRY_RETENTION_DAYS` | string_literal | n/a | n/a | 45 |  |
-| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 627 |  |
-| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 629 |  |
+| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 615 |  |
+| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 617 |  |
 | `MASC_TLA_TRACE` | string_literal | n/a | n/a | 138 |  |
-| `MASC_WORKER_RUNTIME_BACKEND` | string_literal | n/a | n/a | 679 |  |
-| `MASC_WORKER_RUNTIME_DOCKER_IMAGE` | string_literal | n/a | n/a | 681 |  |
-| `MASC_WORKER_RUNTIME_HOST_MCP_BASE_URL` | string_literal | n/a | n/a | 683 |  |
+| `MASC_WORKER_RUNTIME_BACKEND` | string_literal | n/a | n/a | 667 |  |
+| `MASC_WORKER_RUNTIME_DOCKER_IMAGE` | string_literal | n/a | n/a | 669 |  |
+| `MASC_WORKER_RUNTIME_HOST_MCP_BASE_URL` | string_literal | n/a | n/a | 671 |  |
 | `MASC_WS_ACK_STALE_THRESHOLD_SEC` | string_literal | n/a | n/a | 88 |  |
 | `MASC_WS_CLIENT_BUFFER_LIMIT_BYTES` | string_literal | n/a | n/a | 85 |  |
 | `MASC_WS_MAX_INBOUND_DISPATCHES_PER_SESSION` | string_literal | n/a | n/a | 112 |  |

--- a/docs/spec/05-keeper-agent.md
+++ b/docs/spec/05-keeper-agent.md
@@ -179,8 +179,8 @@ stateDiagram-v2
   AgentRun --> UpdateMetrics : Agent.run 완료
   UpdateMetrics --> PostTurnLifecycle : 메트릭 갱신
   PostTurnLifecycle --> Checkpoint : continuity / checkpoint 정리
-  Checkpoint --> CompactCheck : compaction gate
-  CompactCheck --> HandoffCheck : handoff gate
+  Checkpoint --> CompactionRequest : explicit request 확인
+  CompactionRequest --> HandoffCheck : owner-lane operation 또는 요청 없음
   HandoffCheck --> MemoryWrite : memory bank notes
   MemoryWrite --> [*]
 ```
@@ -192,8 +192,8 @@ stateDiagram-v2
 3. **AgentRun**: `keeper_agent_run.run_turn`이 OAS `Agent.run`에 위임. tools + hooks + context_reducer를 전달하며 memory object는 전달하지 않는다
 4. **ToolExecution**: Agent가 tool을 호출하면 `keeper_tools_oas`가 `agent_tool_dispatch_runtime.execute_keeper_tool_call`로 디스패치
 5. **UpdateMetrics**: `keeper_unified_turn.update_metrics_from_result`가 turn count, token 사용량, cost 등을 keeper_meta에 반영하고 `observation.idle_seconds`를 `masc_keeper_idle_seconds{keeper_name}` OTel metric-store gauge로 노출
-6. **PostTurnLifecycle**: `keeper_post_turn.apply_post_turn_lifecycle_with_resilience_handles`가 compaction, handoff rollover, typed checkpoint metadata를 single-writer로 처리
-7. **Checkpoint / Compact / Handoff**: checkpoint 저장 후 gate에 따라 compaction 또는 handoff rollover를 실행
+6. **PostTurnLifecycle**: `keeper_post_turn.apply_post_turn_lifecycle_with_resilience_handles`가 explicit compaction request, handoff rollover, typed checkpoint metadata를 single-writer로 처리
+7. **Checkpoint / Compact / Handoff**: checkpoint 저장 후 Manual 또는 typed provider-overflow 요청만 compaction 경계로 전달하고, handoff rollover를 별도 처리
 8. **MemoryWrite**: `keeper_agent_run` tail에서 MASC-owned memory bank note append를 수행한다
 
 ### 4.1.1 Post-turn Persistence Matrix
@@ -226,34 +226,28 @@ stateDiagram-v2
 - 재시작에는 fleet-wide 정지나 exponential backoff admission을 두지 않는다.
 - 최근 5건의 crash log 유지
 
-### 4.3 Compaction Policy
+### 4.3 Compaction Request Boundary
 
 ```mermaid
 stateDiagram-v2
-  [*] --> Check
-  Check --> Blocked : ratio < ratio_gate AND messages < message_gate AND tokens < token_gate
-  Check --> CooldownHold : continuity_reflection 쿨다운 미충족
-  Check --> LlmPlan : threshold 초과 + 쿨다운 충족
-  LlmPlan --> Apply : configured LLM의 유효한 plan
-  LlmPlan --> Preserve : runtime/plan 오류 또는 deterministic mode
-  Apply --> [*] : LLM plan이 만든 context
-  Preserve --> [*] : 원문 checkpoint 유지
-  Blocked --> [*]
-  CooldownHold --> [*]
+  [*] --> Requested : Manual 또는 typed provider overflow
+  Requested --> OwnerLane : durable request claim
+  OwnerLane --> LlmPlan : configured Runtime 호출
+  LlmPlan --> Validate : typed structural plan
+  Validate --> Apply : source checkpoint CAS 성공
+  Validate --> Preserve : invalid 또는 stale plan
+  LlmPlan --> Preserve : Runtime 실패
+  Apply --> [*] : before/after 및 reinjection evidence
+  Preserve --> [*] : 원문 checkpoint 유지 + typed failure
 ```
 
-MASC에는 message importance scorer나 deterministic reducer fallback이 없다.
-실제 provider context-window compaction과 overflow retry는 OAS가 소유하며,
-MASC의 post-turn 경로는 configured LLM plan만 선택적으로 적용한다.
+MASC에는 ratio/message/token/cooldown gate, importance scorer, deterministic
+reducer fallback이 없다. `context_ratio`와 message/token count는 관측값이며
+semantic mutation 권한이 아니다.
 
-Compaction profile별 gate 기본값:
-
-| Profile | ratio_gate | message_gate | token_gate |
-|---------|-----------|--------------|------------|
-| `aggressive` | 0.35 | 120 | 60,000 |
-| `balanced` | 0.50 | 240 | 120,000 |
-| `conservative` | 0.70 | 480 | 250,000 |
-| `custom` | env 기반 | env 기반 | env 기반 |
+OAS는 provider/model 호출과 typed capacity failure만 제공한다. Compaction
+정책, 요청 수명, owner-lane 실행, source checkpoint CAS와 reinjection
+evidence는 MASC가 소유한다.
 
 ### 4.4 Deliberation Pipeline
 
@@ -417,8 +411,6 @@ dependency가 unavailable이면 해당 handler가 명시적 typed failure를 반
 
 모든 환경변수는 `MASC_KEEPER_` 접두사를 사용한다. 전체 목록은 `lib/keeper/keeper_config.ml` 참조.
 
-**Compaction**: `COMPACT_RATIO`(0.5), `COMPACT_MAX_MESSAGES`(240), `COMPACT_MAX_TOKENS`(0), `CONTINUITY_COMPACTION_COOLDOWN_SEC`(90)
-
 **Proactive**: `PROACTIVE_TEMP_LOW/MID/HIGH`(0.55/0.75/0.9), `PROACTIVE_SIMILARITY`(0.72), `PROACTIVE_MAX_TOKENS`(1024)
 
 **Cost Gates**: `TOOL_COST_MAX_USD`(disabled by default; set a positive USD value to enable the live unified-turn accumulated cost ceiling, `0` keeps it disabled), `COST_GATE_USD`(0.10, legacy compatibility knob; not used by the unified turn cost guard)
@@ -514,11 +506,11 @@ Keeper turn에서 어떤 "skill" 경로를 사용할지 결정:
 
 `max_checkpoints_retained = 3`. `save` 후 `prune`이 호출되어 초과분을 삭제한다.
 
-### INV-KEEPER-004: compaction cooldown 강제
+### INV-KEEPER-004: compaction 요청 권한
 
-`compact_if_needed`는 실제 완료된 마지막 compaction 시각을 기준으로
-`compaction_cooldown_sec`를 적용한다. Assistant text나 proactive turn은 이
-clock을 갱신하지 않는다.
+Compaction은 명시적 Manual 요청 또는 typed provider overflow에서만
+시작한다. Context ratio, message count, token estimate, cooldown projection은
+compaction을 요청하거나 checkpoint를 변경할 수 없다.
 
 
 


### PR DESCRIPTION
## Summary

- replace threshold/cooldown gate documentation with the explicit Manual or typed provider-overflow request boundary
- document MASC ownership of request lifetime, owner-lane execution, checkpoint CAS, reinjection, and before/after evidence
- refresh generated runtime-tunable inventory after dead env/config removal

## Stack

- final documentation leaf of the #24919 recut
- own diff: 178 changed lines
- full stack is rebased onto current `main` and preserves the #24919 change set while retaining intervening main changes

## Verification

- final focused OCaml build: `lib/masc.cma`, keeper metrics, TUI, heartbeat, keeper identity, and tools coverage targets
- `test_tools_coverage.exe` — 48/48; `test_tui_decode.exe` — 23/23; `test_keeper_identity_parse.exe` — 10/10
- dashboard `tsc` green; focused Vitest 5 files, 250/250
- `git range-diff` maps all five original recut commits; leaves 2-5 are patch-identical and leaf 1 differs only by intervening main cleanup context
- full stack: 58 files, +200/-1019, matching #24919

Full suite remains delegated to PR CI.