### PR TITLE
feat(keeper): add exact live-delta rebase core

### DIFF
--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -427,6 +427,16 @@ type checkpoint_ref_load_error =
       }
   | Ref_lock_failed of string
 
+type exact_checkpoint_snapshot =
+  { checkpoint : Agent_sdk.Checkpoint.t
+  ; reference : Keeper_checkpoint_ref.t
+  ; canonical_bytes : string
+  }
+
+let exact_snapshot_checkpoint snapshot = snapshot.checkpoint
+let exact_snapshot_reference snapshot = snapshot.reference
+let exact_snapshot_canonical_bytes snapshot = snapshot.canonical_bytes
+
 type checkpoint_cas_error =
   | Source_unavailable of checkpoint_ref_load_error
   | Source_changed of Keeper_checkpoint_ref.t
@@ -481,6 +491,29 @@ let checkpoint_ref_of_canonical_bytes canonical_bytes
          ~canonical_checkpoint_bytes:canonical_bytes
        |> Result.map_error (fun error -> Ref_create_failed error))
 
+let exact_snapshot_of_checkpoint ~expected_session_id ~canonical_bytes checkpoint =
+  match checkpoint_ref_of_canonical_bytes canonical_bytes checkpoint with
+  | Error error -> Error (Ref_identity_invalid error)
+  | Ok reference
+    when not
+           (Keeper_id.Trace_id.equal
+              expected_session_id reference.trace_id) ->
+    Error
+      (Ref_session_mismatch
+         { expected = expected_session_id; actual = reference.trace_id })
+  | Ok reference -> Ok { checkpoint; reference; canonical_bytes }
+;;
+
+let exact_snapshot_of_canonical_bytes ~expected_session_id canonical_bytes =
+  match Agent_sdk.Checkpoint.of_string canonical_bytes with
+  | Error error -> Error (Ref_read_failed (classify_sdk_error error))
+  | Ok checkpoint ->
+    exact_snapshot_of_checkpoint
+      ~expected_session_id
+      ~canonical_bytes
+      checkpoint
+;;
+
 let load_ref_locked ~session_dir ~expected_session_id =
   let canonical_path =
     oas_checkpoint_path
@@ -491,18 +524,12 @@ let load_ref_locked ~session_dir ~expected_session_id =
   | Error error -> Error (Ref_read_failed error)
   | Ok None -> Error Ref_not_found
   | Ok (Some (canonical_bytes, checkpoint)) ->
-    (match checkpoint_ref_of_canonical_bytes canonical_bytes checkpoint with
-     | Error error -> Error (Ref_identity_invalid error)
-     | Ok reference
-       when not
-              (Keeper_id.Trace_id.equal
-                 expected_session_id reference.trace_id) ->
-       Error
-         (Ref_session_mismatch
-            { expected = expected_session_id; actual = reference.trace_id })
-     | Ok reference -> Ok (checkpoint, reference))
+    exact_snapshot_of_checkpoint
+      ~expected_session_id
+      ~canonical_bytes
+      checkpoint
 
-let load_oas_with_ref ~session_dir ~session_id =
+let load_oas_exact_snapshot ~session_dir ~session_id =
   match Keeper_id.Trace_id.of_string session_id with
   | Error reason -> Error (Ref_identity_invalid (Session_id_invalid reason))
   | Ok expected_session_id ->
@@ -512,6 +539,12 @@ let load_oas_with_ref ~session_dir ~session_id =
      with
      | Ok result -> result
      | Error detail -> Error (Ref_lock_failed detail))
+
+let load_oas_with_ref ~session_dir ~session_id =
+  load_oas_exact_snapshot ~session_dir ~session_id
+  |> Result.map (fun snapshot ->
+    exact_snapshot_checkpoint snapshot, exact_snapshot_reference snapshot)
+;;
 
 let with_checkpoint_cas_lock ~session_dir ~candidate_ref f =
   match canonical_session_location session_dir with
@@ -571,11 +604,14 @@ let save_oas_if_source
     let expected_session_id = expected_source_ref.trace_id in
     with_checkpoint_cas_lock ~session_dir ~candidate_ref (fun session_dir ->
       match load_ref_locked ~session_dir ~expected_session_id with
-         | Error error -> Error (Source_unavailable error)
-         | Ok (_, actual_source)
-           when not (Keeper_checkpoint_ref.equal expected_source_ref actual_source) ->
-           Error (Source_changed actual_source)
-         | Ok _ ->
+      | Error error -> Error (Source_unavailable error)
+      | Ok snapshot
+        when not
+               (Keeper_checkpoint_ref.equal
+                  expected_source_ref
+                  (exact_snapshot_reference snapshot)) ->
+        Error (Source_changed (exact_snapshot_reference snapshot))
+      | Ok _ ->
            let canonical_path =
              oas_checkpoint_path
                ~session_dir

--- a/lib/keeper/keeper_checkpoint_store.mli
+++ b/lib/keeper/keeper_checkpoint_store.mli
@@ -133,6 +133,31 @@ type checkpoint_ref_load_error =
       }
   | Ref_lock_failed of string
 
+(** Canonical checkpoint value, exact persisted bytes, and their reference
+    derived from one immutable byte snapshot. *)
+type exact_checkpoint_snapshot
+
+val exact_snapshot_checkpoint :
+  exact_checkpoint_snapshot -> Agent_sdk.Checkpoint.t
+
+val exact_snapshot_reference :
+  exact_checkpoint_snapshot -> Keeper_checkpoint_ref.t
+
+val exact_snapshot_canonical_bytes : exact_checkpoint_snapshot -> string
+
+(** Strictly decode exact canonical bytes and derive their reference without
+    re-encoding. *)
+val exact_snapshot_of_canonical_bytes :
+  expected_session_id:Keeper_id.Trace_id.t ->
+  string ->
+  (exact_checkpoint_snapshot, checkpoint_ref_load_error) result
+
+(** Load an exact canonical checkpoint snapshot under the session lock. *)
+val load_oas_exact_snapshot :
+  session_dir:string ->
+  session_id:string ->
+  (exact_checkpoint_snapshot, checkpoint_ref_load_error) result
+
 (** Load one canonical checkpoint and its exact source identity from the same
     locked byte snapshot. No size, mtime, timestamp, or process cache
     participates in the identity. *)

--- a/lib/keeper/keeper_compaction_live_delta.ml
+++ b/lib/keeper/keeper_compaction_live_delta.ml
@@ -5,6 +5,10 @@ type error =
       ; current_trace_id : Keeper_id.Trace_id.t
       ; current_generation : int
       }
+  | Current_turn_regressed of
+      { source_turn_count : int
+      ; current_turn_count : int
+      }
   | Current_messages_prefix_mismatch of Keeper_replay_prefix.prefix_mismatch
 
 let same_lineage (source_ref : Keeper_checkpoint_ref.t)
@@ -33,6 +37,13 @@ let rebase ~source ~compacted_messages ~current =
          ; source_generation = source_ref.generation
          ; current_trace_id = current_ref.trace_id
          ; current_generation = current_ref.generation
+         })
+  else if current_ref.turn_count < source_ref.turn_count
+  then
+    Error
+      (Current_turn_regressed
+         { source_turn_count = source_ref.turn_count
+         ; current_turn_count = current_ref.turn_count
          })
   else
     match

--- a/lib/keeper/keeper_compaction_live_delta.ml
+++ b/lib/keeper/keeper_compaction_live_delta.ml
@@ -1,0 +1,49 @@
+type error =
+  | Source_superseded of
+      { source_trace_id : Keeper_id.Trace_id.t
+      ; source_generation : int
+      ; current_trace_id : Keeper_id.Trace_id.t
+      ; current_generation : int
+      }
+  | Current_messages_prefix_mismatch of Keeper_replay_prefix.prefix_mismatch
+
+let same_lineage (source_ref : Keeper_checkpoint_ref.t)
+    (current_ref : Keeper_checkpoint_ref.t) =
+  Keeper_id.Trace_id.equal source_ref.trace_id current_ref.trace_id
+  && Int.equal source_ref.generation current_ref.generation
+;;
+
+let rebase ~source ~compacted_messages ~current =
+  let source_checkpoint =
+    Keeper_checkpoint_store.exact_snapshot_checkpoint source
+  in
+  let current_checkpoint =
+    Keeper_checkpoint_store.exact_snapshot_checkpoint current
+  in
+  let source_ref = Keeper_checkpoint_store.exact_snapshot_reference source in
+  let current_ref = Keeper_checkpoint_store.exact_snapshot_reference current in
+  let candidate = { source_checkpoint with messages = compacted_messages } in
+  if Keeper_checkpoint_ref.equal source_ref current_ref
+  then Ok candidate
+  else if not (same_lineage source_ref current_ref)
+  then
+    Error
+      (Source_superseded
+         { source_trace_id = source_ref.trace_id
+         ; source_generation = source_ref.generation
+         ; current_trace_id = current_ref.trace_id
+         ; current_generation = current_ref.generation
+         })
+  else
+    match
+      Keeper_replay_prefix.split
+        ~prefix:source_checkpoint.messages
+        current_checkpoint.messages
+    with
+    | Error mismatch -> Error (Current_messages_prefix_mismatch mismatch)
+    | Ok exact_suffix ->
+      Ok
+        { current_checkpoint with
+          messages = compacted_messages @ exact_suffix
+        }
+;;

--- a/lib/keeper/keeper_compaction_live_delta.mli
+++ b/lib/keeper/keeper_compaction_live_delta.mli
@@ -13,6 +13,10 @@ type error =
       ; current_trace_id : Keeper_id.Trace_id.t
       ; current_generation : int
       }
+  | Current_turn_regressed of
+      { source_turn_count : int
+      ; current_turn_count : int
+      }
   | Current_messages_prefix_mismatch of Keeper_replay_prefix.prefix_mismatch
 
 val rebase
@@ -30,5 +34,5 @@ val rebase
 
     Checkpoints and their references arrive as one exact snapshot type, so a
     mismatched pair is not representable.  Diverged lineage and prefix
-    mismatches fail explicitly.  No serialization, semantic matching, size
-    threshold, or time heuristic is used. *)
+    mismatches and a regressed current turn fail explicitly.  No serialization,
+    semantic matching, size threshold, or time heuristic is used. *)

--- a/lib/keeper/keeper_compaction_live_delta.mli
+++ b/lib/keeper/keeper_compaction_live_delta.mli
@@ -1,0 +1,34 @@
+(** Deterministic rebase of a compacted checkpoint over live append-only
+    Keeper progress.
+
+    The caller supplies only the replacement messages.  The candidate
+    checkpoint is constructed from [source] inside this boundary, so
+    compaction cannot alter checkpoint identity, metadata, context, usage, or
+    turn coordinates. *)
+
+type error =
+  | Source_superseded of
+      { source_trace_id : Keeper_id.Trace_id.t
+      ; source_generation : int
+      ; current_trace_id : Keeper_id.Trace_id.t
+      ; current_generation : int
+      }
+  | Current_messages_prefix_mismatch of Keeper_replay_prefix.prefix_mismatch
+
+val rebase
+  :  source:Keeper_checkpoint_store.exact_checkpoint_snapshot
+  -> compacted_messages:Agent_sdk.Types.message list
+  -> current:Keeper_checkpoint_store.exact_checkpoint_snapshot
+  -> (Agent_sdk.Checkpoint.t, error) result
+(** Returns the source checkpoint with [compacted_messages] when the source
+    and current snapshot references are identical.
+
+    For a later checkpoint in the same trace and generation, [source.messages]
+    must be an exact structural prefix of [current.messages].  The exact live
+    suffix is appended to [compacted_messages], while every other field comes
+    from [current].
+
+    Checkpoints and their references arrive as one exact snapshot type, so a
+    mismatched pair is not representable.  Diverged lineage and prefix
+    mismatches fail explicitly.  No serialization, semantic matching, size
+    threshold, or time heuristic is used. *)

--- a/test/test_keeper_checkpoint_stale_guard.ml
+++ b/test/test_keeper_checkpoint_stale_guard.ml
@@ -442,6 +442,47 @@ let test_checkpoint_ref_requires_generation () =
            Keeper_checkpoint_store.Generation_missing) -> ()
     | _ -> fail "generation-less checkpoint acquired an exact ref")
 
+let test_exact_snapshot_preserves_locked_canonical_bytes () =
+  let session_dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir session_dir) (fun () ->
+    let session_id = "sess-exact-snapshot" in
+    save_ok ~session_dir
+      (make_checkpoint ~session_id ~turn_count:4 ~marker:"exact"
+       |> with_generation 2)
+      "exact snapshot seed";
+    let canonical_path = Filename.concat session_dir (session_id ^ ".json") in
+    let expected_bytes =
+      Fs_compat.load_file canonical_path
+      |> Yojson.Safe.from_string
+      |> Yojson.Safe.pretty_to_string
+    in
+    Fs_compat.save_file canonical_path expected_bytes;
+    match
+      Keeper_checkpoint_store.load_oas_exact_snapshot
+        ~session_dir
+        ~session_id
+    with
+    | Error _ -> fail "exact snapshot load failed"
+    | Ok snapshot ->
+      check string "canonical bytes are not re-encoded" expected_bytes
+        (Keeper_checkpoint_store.exact_snapshot_canonical_bytes snapshot);
+      let reference =
+        Keeper_checkpoint_store.exact_snapshot_reference snapshot
+      in
+      let expected_session_id =
+        Result.get_ok (Keeper_id.Trace_id.of_string session_id)
+      in
+      match
+        Keeper_checkpoint_store.exact_snapshot_of_canonical_bytes
+          ~expected_session_id
+          expected_bytes
+      with
+      | Ok decoded ->
+        check bool "pure decode derives the same exact ref" true
+          (Keeper_checkpoint_ref.equal reference
+             (Keeper_checkpoint_store.exact_snapshot_reference decoded))
+      | Error _ -> fail "exact snapshot bytes did not decode")
+
 let () =
   run "Keeper_checkpoint_store checkpoint watermark (RFC-0225 §3.2)"
     [
@@ -469,5 +510,7 @@ let () =
             test_exact_source_cas_updates_canonical_watermark;
           test_case "checkpoint refs require keeper generation" `Quick
             test_checkpoint_ref_requires_generation;
+          test_case "exact snapshot preserves canonical bytes" `Quick
+            test_exact_snapshot_preserves_locked_canonical_bytes;
         ] );
     ]


### PR DESCRIPTION
## Summary

- stack directly on repaired #24902 checkpoint CAS
- expose an immutable exact checkpoint snapshot containing decoded value, exact persisted bytes, and its typed reference
- deterministically rebase compacted messages over an exact append-only live suffix
- fail closed on trace/generation divergence, current-turn regression, and structural prefix mismatch

## Invariants

- checkpoint identity derives from the locked canonical bytes without decode/re-encode
- no size, mtime, sidecar, process cache, timeout, or semantic matching participates
- identical refs replace only messages on the exact source checkpoint
- same trace/generation requires `current.turn_count >= source.turn_count` and an exact structural message prefix
- every non-message candidate field comes from the exact current checkpoint when a live suffix exists

## Stack

- base: #24902 exact checkpoint source CAS and watermark-sidecar purge
- child proof: #24953

## Verification

- final #24953 stack focused build passed for `test/keeper_compaction_live_delta/test_keeper_compaction_live_delta.exe`
- direct focused executable: 7/7 green
- `ocamlformat --check`, parse checks, and `git diff --check` passed
- no checkpoint watermark sidecar/fingerprint residue is reintroduced
- full CI remains authoritative after stack landing.