### PR TITLE
feat(keeper): expose durable compaction parking

### DIFF
--- a/lib/keeper/keeper_current_operations.ml
+++ b/lib/keeper/keeper_current_operations.ml
@@ -11,6 +11,10 @@ type source =
       { revision : int64
       ; entry : Keeper_event_queue_state.outbox_entry
       }
+  | Event_queue_parked of
+      { revision : int64
+      ; entry : Keeper_event_queue_state.parked_entry
+      }
   | Async_request of Keeper_msg_async.entry
 
 type t =
@@ -79,7 +83,18 @@ let project_event_queue_state ~keeper_name state =
       ; source = Event_queue_outbox { revision; entry }
       })
   in
-  leases @ pending @ outbox
+  let parked =
+    Keeper_event_queue_state.parked_entries state
+    |> List.filter_map (fun (entry : Keeper_event_queue_state.parked_entry) ->
+      match entry.phase with
+      | Parked ->
+        Some
+          { keeper_name
+          ; source = Event_queue_parked { revision; entry }
+          }
+      | Resumed -> None)
+  in
+  leases @ parked @ pending @ outbox
 ;;
 
 let project_async_entries ~keeper_name entries =
@@ -182,6 +197,10 @@ let source_to_yojson = function
     `Assoc [ "kind", `String "event_queue_outbox"
            ; "revision", `String (Int64.to_string revision)
            ; "value", outbox_to_yojson entry ]
+  | Event_queue_parked { revision; entry } ->
+    `Assoc [ "kind", `String "event_queue_parked"
+           ; "revision", `String (Int64.to_string revision)
+           ; "value", Keeper_event_queue_state.parked_entry_to_yojson entry ]
   | Async_request entry ->
     `Assoc [ "kind", `String "async_request"; "value", async_entry_to_yojson entry ]
 ;;

--- a/lib/keeper/keeper_current_operations.mli
+++ b/lib/keeper/keeper_current_operations.mli
@@ -13,6 +13,10 @@ type source = private
       { revision : int64
       ; entry : Keeper_event_queue_state.outbox_entry
       }
+  | Event_queue_parked of
+      { revision : int64
+      ; entry : Keeper_event_queue_state.parked_entry
+      }
   | Async_request of Keeper_msg_async.entry
 
 type t =

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -2,7 +2,7 @@
 
     Extracted from keeper_registry.ml (lines 1854-1900) as part of the
     godfile decomp campaign. Each [registry_entry] carries its own
-    [event_queue : Keeper_event_queue.t Atomic.t].  The durable v2 envelope is
+    [event_queue : Keeper_event_queue.t Atomic.t].  The durable v3 envelope is
     the mutation authority; these wrappers publish its pending projection to
     that per-entry Atomic only after commit.  No coupling to the central
     registry Atomic state primitive. *)
@@ -40,10 +40,15 @@ type settlement = Keeper_event_queue_persistence.settlement =
 
 type transition_receipt = Keeper_event_queue_persistence.transition_receipt
 type outbox_entry = Keeper_event_queue_persistence.outbox_entry
+type parked_entry = Keeper_event_queue_persistence.parked_entry
 
 type settle_result = Keeper_event_queue_persistence.settle_result =
   | Settled of transition_receipt
   | Already_settled of transition_receipt
+
+type resume_result = Keeper_event_queue_persistence.resume_result =
+  | Resumed of Keeper_event_queue.stimulus list
+  | Already_resumed
 
 let lease_stimuli = Keeper_event_queue_persistence.lease_stimuli
 let lease_kind = Keeper_event_queue_persistence.lease_kind
@@ -59,6 +64,12 @@ let active_lease_result ~base_path name =
 
 let transition_outbox_result ~base_path name =
   Keeper_event_queue_persistence.transition_outbox_result
+    ~base_path
+    ~keeper_name:name
+;;
+
+let parked_entries_result ~base_path name =
+  Keeper_event_queue_persistence.parked_entries_result
     ~base_path
     ~keeper_name:name
 ;;
@@ -343,6 +354,32 @@ let settle_result ~base_path name ~settled_at ~lease ~settlement =
     ~settled_at
     ~lease
     ~settlement
+    ~after_commit:(publish_pending ~base_path name)
+    ()
+;;
+
+let park_for_compaction_result
+    ~base_path
+    name
+    ~settled_at
+    ~lease
+    ~operation_id
+  =
+  Keeper_event_queue_persistence.park_for_compaction_result
+    ~base_path
+    ~keeper_name:name
+    ~settled_at
+    ~lease
+    ~operation_id
+    ~after_commit:(publish_pending ~base_path name)
+    ()
+;;
+
+let resume_parked_result ~base_path name ~operation_id =
+  Keeper_event_queue_persistence.resume_parked_result
+    ~base_path
+    ~keeper_name:name
+    ~operation_id
     ~after_commit:(publish_pending ~base_path name)
     ()
 ;;

--- a/lib/keeper/keeper_registry_event_queue.mli
+++ b/lib/keeper/keeper_registry_event_queue.mli
@@ -1,7 +1,7 @@
 (** Per-keeper event-queue access.
 
     SSOT for enqueueing / draining the per-keeper stimulus queue.
-    The MASC-owned v2 envelope is authoritative.  Mutations commit that one
+    The MASC-owned v3 envelope is authoritative.  Mutations commit that one
     durable state first, then publish its pending projection into the
     entry-owned [event_queue : Keeper_event_queue.t Atomic.t].  No central
     registry Atomic is touched. *)
@@ -39,10 +39,15 @@ type settlement = Keeper_event_queue_persistence.settlement =
 
 type transition_receipt = Keeper_event_queue_persistence.transition_receipt
 type outbox_entry = Keeper_event_queue_persistence.outbox_entry
+type parked_entry = Keeper_event_queue_persistence.parked_entry
 
 type settle_result = Keeper_event_queue_persistence.settle_result =
   | Settled of transition_receipt
   | Already_settled of transition_receipt
+
+type resume_result = Keeper_event_queue_persistence.resume_result =
+  | Resumed of Keeper_event_queue.stimulus list
+  | Already_resumed
 
 val lease_stimuli : lease -> Keeper_event_queue.stimulus list
 val lease_kind : lease -> Keeper_event_queue_persistence.lease_kind
@@ -52,6 +57,9 @@ val active_lease_result :
 
 val transition_outbox_result :
   base_path:string -> string -> (outbox_entry list, string) result
+
+val parked_entries_result :
+  base_path:string -> string -> (parked_entry list, string) result
 
 val mark_transition_projected_result :
   base_path:string -> string -> transition_id:string -> (unit, string) result
@@ -73,6 +81,20 @@ val settle_result :
   lease:lease ->
   settlement:settlement ->
   (settle_result, string) result
+
+val park_for_compaction_result :
+  base_path:string ->
+  string ->
+  settled_at:float ->
+  lease:lease ->
+  operation_id:Keeper_compaction_operation_identity.Operation_id.t ->
+  (settle_result, string) result
+
+val resume_parked_result :
+  base_path:string ->
+  string ->
+  operation_id:Keeper_compaction_operation_identity.Operation_id.t ->
+  (resume_result, string) result
 
 (** Enqueue a stimulus on the keeper's event queue. When the keeper is not
     registered yet, persist the stimulus to the durable snapshot so later

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -39,9 +39,19 @@ type lease = State.lease
 type transition_receipt = State.transition_receipt
 type outbox_entry = State.outbox_entry
 
+type parked_phase = State.parked_phase =
+  | Parked
+  | Resumed
+
+type parked_entry = State.parked_entry
+
 type settle_result = State.settle_result =
   | Settled of transition_receipt
   | Already_settled of transition_receipt
+
+type resume_result = State.resume_result =
+  | Resumed of Keeper_event_queue.stimulus list
+  | Already_resumed
 
 let lease_stimuli (lease : lease) = lease.stimuli
 let lease_kind = State.lease_kind
@@ -147,7 +157,7 @@ let schema_field = function
 type primary_snapshot =
   | Primary_missing
   | Primary_v1 of Keeper_event_queue.t
-  | Primary_v2 of State.t
+  | Primary_current of State.t
 
 let read_primary_unlocked owner =
   let path = snapshot_path_of_owner owner in
@@ -159,7 +169,7 @@ let read_primary_unlocked owner =
      | Error message -> Error (Printf.sprintf "%s: %s" path message)
      | Ok schema when String.equal schema State.schema ->
        (match State.of_yojson json with
-        | Ok state -> Ok (Primary_v2 state)
+        | Ok state -> Ok (Primary_current state)
         | Error message -> Error (Printf.sprintf "%s: %s" path message))
      | Ok schema when String.equal schema "keeper.event_queue.v1" ->
        (match Keeper_event_queue.queue_of_yojson json with
@@ -190,7 +200,7 @@ let remove_legacy_inflight_unlocked owner =
   | exn ->
     Error
       (Printf.sprintf
-         "v2 state committed but failed to remove legacy inflight input %s: %s"
+         "current state committed but failed to remove legacy inflight input %s: %s"
          path
          (Printexc.to_string exn))
 ;;
@@ -230,27 +240,33 @@ let state_accounts_for_stimulus state stimulus =
   || List.exists
        (fun (entry : outbox_entry) -> List.exists same entry.stimuli)
        (State.transition_outbox state)
+  || List.exists
+       (fun (entry : parked_entry) ->
+          match entry.phase with
+          | Parked -> List.exists same entry.source_lease.stimuli
+          | Resumed -> false)
+       (State.parked_entries state)
 ;;
 
-let reconcile_v2_legacy_residue_unlocked owner state legacy =
+let reconcile_current_legacy_residue_unlocked owner state legacy =
   let legacy_stimuli = Keeper_event_queue.to_list legacy in
   if List.for_all (state_accounts_for_stimulus state) legacy_stimuli
   then remove_legacy_inflight_unlocked owner |> Result.map (fun () -> state)
   else
     Error
       (Printf.sprintf
-         "v2 event queue conflicts with legacy inflight residue: %s"
+         "current event queue conflicts with legacy inflight residue: %s"
          (legacy_inflight_path_of_owner owner))
 ;;
 
 let load_state_unlocked owner =
   match read_primary_unlocked owner with
   | Error _ as error -> error
-  | Ok (Primary_v2 state) ->
+  | Ok (Primary_current state) ->
     (match read_legacy_inflight_unlocked owner with
      | Error _ as error -> error
      | Ok None -> Ok state
-     | Ok (Some legacy) -> reconcile_v2_legacy_residue_unlocked owner state legacy)
+     | Ok (Some legacy) -> reconcile_current_legacy_residue_unlocked owner state legacy)
   | Ok Primary_missing ->
     (match read_legacy_inflight_unlocked owner with
      | Error _ as error -> error
@@ -284,6 +300,10 @@ let active_lease_result ~base_path ~keeper_name =
 
 let transition_outbox_result ~base_path ~keeper_name =
   load_state_result ~base_path ~keeper_name |> Result.map State.transition_outbox
+;;
+
+let parked_entries_result ~base_path ~keeper_name =
+  load_state_result ~base_path ~keeper_name |> Result.map State.parked_entries
 ;;
 
 let queue_of_stimuli stimuli =
@@ -600,6 +620,32 @@ let settle_result
   =
   commit_transform ~base_path ~keeper_name ~after_commit (fun state ->
     State.settle ~settled_at ~lease ~settlement state)
+;;
+
+let park_for_compaction_result
+      ?(after_commit = fun _ -> ())
+      ~base_path
+      ~keeper_name
+      ~settled_at
+      ~lease
+      ~operation_id
+      ()
+  =
+  commit_transform ~base_path ~keeper_name ~after_commit (fun state ->
+    State.park_for_compaction ~settled_at ~lease ~operation_id state
+    |> Result.map_error State.parking_error_to_string)
+;;
+
+let resume_parked_result
+      ?(after_commit = fun _ -> ())
+      ~base_path
+      ~keeper_name
+      ~operation_id
+      ()
+  =
+  commit_transform ~base_path ~keeper_name ~after_commit (fun state ->
+    State.resume_parked ~operation_id state
+    |> Result.map_error State.parking_error_to_string)
 ;;
 
 let prepare_registration_result

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -1,6 +1,6 @@
 (** Durable per-Keeper Event Layer state.
 
-    [event-queue.json] uses one v2 envelope containing pending stimuli, active
+    [event-queue.json] uses one v3 envelope containing pending stimuli, active
     typed leases, the monotonic lease sequence and the transition outbox.
     [event-queue-inflight.json] is accepted only as a one-time v1 migration
     input; it is never a second runtime authority. *)
@@ -43,9 +43,19 @@ type lease = Keeper_event_queue_state.lease
 type transition_receipt = Keeper_event_queue_state.transition_receipt
 type outbox_entry = Keeper_event_queue_state.outbox_entry
 
+type parked_phase = Keeper_event_queue_state.parked_phase =
+  | Parked
+  | Resumed
+
+type parked_entry = Keeper_event_queue_state.parked_entry
+
 type settle_result = Keeper_event_queue_state.settle_result =
   | Settled of transition_receipt
   | Already_settled of transition_receipt
+
+type resume_result = Keeper_event_queue_state.resume_result =
+  | Resumed of Keeper_event_queue.stimulus list
+  | Already_resumed
 
 val lease_stimuli : lease -> Keeper_event_queue.stimulus list
 val lease_kind : lease -> lease_kind
@@ -57,6 +67,9 @@ val transition_outbox_result :
   base_path:string -> keeper_name:string -> (outbox_entry list, string) result
 (** Read the single pending projection entry for this Keeper lane.  The state
     machine blocks new claims until this list is drained. *)
+
+val parked_entries_result :
+  base_path:string -> keeper_name:string -> (parked_entry list, string) result
 
 val load : base_path:string -> keeper_name:string -> Keeper_event_queue.t
 (** Compatibility replay projection: pending followed by active lease stimuli.
@@ -111,8 +124,8 @@ val load_snapshot_pair_with_errors :
 
 val load_state_result :
   base_path:string -> keeper_name:string -> (Keeper_event_queue_state.t, string) result
-(** Strict state read used by tests and operator projection.  A malformed v2
-    envelope or v2-plus-legacy residue is an [Error], never an empty queue. *)
+(** Strict state read used by tests and operator projection.  A malformed v3
+    envelope or v3-plus-legacy residue is an [Error], never an empty queue. *)
 
 val claim_when_result :
   ?after_commit:(Keeper_event_queue.t -> unit) ->
@@ -140,6 +153,24 @@ val settle_result :
   settlement:settlement ->
   unit ->
   (settle_result, string) result
+
+val park_for_compaction_result :
+  ?after_commit:(Keeper_event_queue.t -> unit) ->
+  base_path:string ->
+  keeper_name:string ->
+  settled_at:float ->
+  lease:lease ->
+  operation_id:Keeper_compaction_operation_identity.Operation_id.t ->
+  unit ->
+  (settle_result, string) result
+
+val resume_parked_result :
+  ?after_commit:(Keeper_event_queue.t -> unit) ->
+  base_path:string ->
+  keeper_name:string ->
+  operation_id:Keeper_compaction_operation_identity.Operation_id.t ->
+  unit ->
+  (resume_result, string) result
 
 val prepare_registration_result :
   ?after_commit:(Keeper_event_queue.t -> unit) ->
@@ -198,7 +229,7 @@ val persist_snapshot :
 val record_inflight :
   base_path:string -> keeper_name:string -> Keeper_event_queue.stimulus list -> unit
 (** Legacy source/test adapter.  Writes a typed [Legacy_inflight] lease into the
-    v2 envelope; it never creates [event-queue-inflight.json]. *)
+    v3 envelope; it never creates [event-queue-inflight.json]. *)
 
 val ack_inflight :
   base_path:string -> keeper_name:string -> Keeper_event_queue.stimulus list -> unit

--- a/lib/keeper_runtime/keeper_event_queue_state.mli
+++ b/lib/keeper_runtime/keeper_event_queue_state.mli
@@ -66,6 +66,17 @@ type outbox_entry =
   ; stimuli : Keeper_event_queue.stimulus list
   }
 
+type parked_phase =
+  | Parked
+  | Resumed
+
+type parked_entry =
+  { operation_id : Keeper_compaction_operation_identity.Operation_id.t
+  ; source_lease : lease
+  ; settled_at : float
+  ; phase : parked_phase
+  }
+
 type t
 
 type settle_result =
@@ -93,6 +104,7 @@ val pending : t -> Keeper_event_queue.t
 val leases : t -> lease list
 val last_settlement : t -> transition_receipt option
 val transition_outbox : t -> outbox_entry list
+val parked_entries : t -> parked_entry list
 val lease_kind : lease -> lease_kind
 
 val with_pending : Keeper_event_queue.t -> t -> t
@@ -168,6 +180,7 @@ val lease_to_yojson : lease -> Yojson.Safe.t
 val lease_of_yojson : Yojson.Safe.t -> (lease, string) result
 val transition_receipt_to_yojson : transition_receipt -> Yojson.Safe.t
 val transition_receipt_of_yojson : Yojson.Safe.t -> (transition_receipt, string) result
+val parked_entry_to_yojson : parked_entry -> Yojson.Safe.t
 val to_yojson : t -> Yojson.Safe.t
 val of_yojson : Yojson.Safe.t -> (t, string) result
 

--- a/test/dune
+++ b/test/dune
@@ -676,7 +676,7 @@
 (test
  (name test_keeper_current_operations)
  (modules test_keeper_current_operations)
- (libraries alcotest masc_test_deps))
+ (libraries alcotest masc_test_deps masc.keeper_compaction_operation_identity))
 
 (test
  (name test_keeper_failure_judgment_contract)

--- a/test/test_keeper_current_operations.ml
+++ b/test/test_keeper_current_operations.ml
@@ -32,6 +32,47 @@ let test_event_queue_exact_state () =
   | operations -> failf "unexpected outbox operation count=%d" (List.length operations)
 ;;
 
+let test_event_queue_parked_is_exact_and_nonterminal_only () =
+  let source = stimulus "overflow-source" 1.0 in
+  let state = S.empty |> S.with_pending (queue [ source ]) |> S.with_revision 23L in
+  let state, lease = S.claim_when ~claimed_at:2.0 ~ready:(fun _ -> true) state |> ok in
+  let lease = Option.get lease in
+  let operation_id = Keeper_compaction_operation_identity.Operation_id.generate () in
+  let state, settlement =
+    S.park_for_compaction ~settled_at:3.0 ~lease ~operation_id state
+    |> Result.map_error S.parking_error_to_string
+    |> ok
+  in
+  let receipt =
+    match settlement with
+    | S.Settled receipt -> receipt
+    | S.Already_settled _ -> fail "first park was already settled"
+  in
+  let state =
+    S.mark_transition_projected ~transition_id:receipt.transition_id state |> ok
+  in
+  (match O.project_event_queue_state ~keeper_name:"keeper-a" state with
+   | [ ({ source = Event_queue_parked { revision; entry }; _ } as operation) ] ->
+     check int64 "revision" 23L revision;
+     check bool "operation id" true
+       (Keeper_compaction_operation_identity.Operation_id.equal
+          operation_id
+          entry.operation_id);
+     check string "source lease" lease.lease_id entry.source_lease.lease_id;
+     check string "projection kind" "event_queue_parked"
+       J.(O.to_yojson operation |> member "source" |> member "kind" |> to_string)
+   | operations -> failf "unexpected parked operation count=%d" (List.length operations));
+  let resumed, _ =
+    S.resume_parked ~operation_id state
+    |> Result.map_error S.parking_error_to_string
+    |> ok
+  in
+  match O.project_event_queue_state ~keeper_name:"keeper-a" resumed with
+  | [ { source = Event_queue_pending _; _ } ] -> ()
+  | operations ->
+    failf "resumed audit row remained current count=%d" (List.length operations)
+;;
+
 let test_async_active_and_unavailable () =
   let entry : A.entry =
     { request_id = "request-1"; keeper_name = "keeper-a"; base_path = "/workspace"
@@ -102,6 +143,10 @@ let () =
   run "keeper_current_operations"
     [ "projection",
       [ test_case "event queue exact state" `Quick test_event_queue_exact_state
+      ; test_case
+          "event queue parked exact state"
+          `Quick
+          test_event_queue_parked_is_exact_and_nonterminal_only
       ; test_case "async active and unavailable" `Quick test_async_active_and_unavailable
       ; test_case "terminal async is not current" `Quick
           test_terminal_async_entry_is_not_current

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -668,6 +668,112 @@ let with_temp_dir prefix f =
   Fun.protect ~finally:(fun () -> remove_tree path) (fun () -> f path)
 ;;
 
+let test_compaction_parking_persistence_facade () =
+  with_temp_dir "keeper-event-queue-v3-parking-facade" (fun base_path ->
+    let keeper_name = "parking_facade_keeper" in
+    let source = stimulus "overflow-source" 1.0 in
+    let unrelated = stimulus "unrelated" 2.0 in
+    Persistence.update_result ~base_path ~keeper_name (fun pending ->
+      List.fold_left Queue.enqueue pending [ source; unrelated ])
+    |> require_ok "seed parking facade";
+    let lease =
+      Persistence.claim_when_result
+        ~base_path
+        ~keeper_name
+        ~claimed_at:3.0
+        ~ready:(fun _ -> true)
+        ()
+      |> require_ok "claim overflow source"
+      |> require_some "overflow source lease"
+    in
+    let operation_id =
+      Keeper_compaction_operation_identity.Operation_id.generate ()
+    in
+    let published = ref [] in
+    let receipt =
+      match
+        Persistence.park_for_compaction_result
+          ~base_path
+          ~keeper_name
+          ~settled_at:4.0
+          ~lease
+          ~operation_id
+          ~after_commit:(fun pending -> published := post_ids pending :: !published)
+          ()
+        |> require_ok "park through persistence"
+      with
+      | Persistence.Settled receipt -> receipt
+      | Persistence.Already_settled _ ->
+        Alcotest.fail "first durable park was already settled"
+    in
+    (match
+       Persistence.parked_entries_result ~base_path ~keeper_name
+       |> require_ok "load parked entries"
+     with
+     | [ entry ] ->
+       Alcotest.(check bool)
+         "exact operation id"
+         true
+         (Keeper_compaction_operation_identity.Operation_id.equal
+            operation_id
+            entry.operation_id);
+       Alcotest.(check string)
+         "exact source lease"
+         lease.lease_id
+         entry.source_lease.lease_id;
+       Alcotest.(check bool) "parked phase" true (entry.phase = State.Parked)
+     | entries ->
+       Alcotest.failf "expected one parked entry, got %d" (List.length entries));
+    Persistence.mark_transition_projected_result
+      ~base_path
+      ~keeper_name
+      ~transition_id:receipt.transition_id
+    |> require_ok "project park transition";
+    (match
+       Persistence.enqueue_stimulus_if_absent_result
+         ~base_path
+         ~keeper_name
+         source
+       |> require_ok "deduplicate parked source"
+     with
+     | Persistence.Already_present -> ()
+     | Persistence.Enqueued ->
+       Alcotest.fail "parked source escaped durable identity accounting");
+    (match
+       Persistence.resume_parked_result
+         ~base_path
+         ~keeper_name
+         ~operation_id
+         ~after_commit:(fun pending -> published := post_ids pending :: !published)
+         ()
+       |> require_ok "resume through persistence"
+     with
+     | Persistence.Resumed [ resumed ] ->
+       Alcotest.(check string) "resumed exact source" source.post_id resumed.post_id
+     | Persistence.Resumed _ | Persistence.Already_resumed ->
+       Alcotest.fail "first durable resume changed the source");
+    (match
+       Persistence.resume_parked_result
+         ~base_path
+         ~keeper_name
+         ~operation_id
+         ()
+       |> require_ok "repeat resume through persistence"
+     with
+     | Persistence.Already_resumed -> ()
+     | Persistence.Resumed _ -> Alcotest.fail "durable resume was not idempotent");
+    Alcotest.(check (list string))
+      "resumed FIFO"
+      [ unrelated.post_id; source.post_id ]
+      (Persistence.load_pending_result ~base_path ~keeper_name
+       |> require_ok "load resumed pending"
+       |> post_ids);
+    Alcotest.(check int)
+      "only state-changing commits publish"
+      2
+      (List.length !published))
+;;
+
 let keeper_dir ~base_path ~keeper_name =
   Filename.concat (Common.keepers_runtime_dir_of_base ~base_path) keeper_name
 ;;
@@ -1086,6 +1192,10 @@ let () =
             `Quick
             test_unconsumed_approval_requeues_behind_other_work
         ; Alcotest.test_case "compaction parking" `Quick test_compaction_parking_is_exact_and_idempotent
+        ; Alcotest.test_case
+            "compaction parking persistence facade"
+            `Quick
+            test_compaction_parking_persistence_facade
         ] )
     ; ( "persistence"
       , [ Alcotest.test_case


### PR DESCRIPTION
## Summary
- expose exact durable `park_for_compaction_result` and `resume_parked_result` through the persistence and registered-Keeper queue facades
- expose persisted parked entries and project only nonterminal `Event_queue_parked` rows into current operations
- keep a parked source inside durable stimulus identity accounting after its transition outbox is projected
- correct the current event-queue envelope terminology to v3

## Invariants
- one atomic `event-queue.json` transaction remains the mutation authority
- park removes only the exact leased source; unrelated FIFO work remains claimable
- resume appends the exact source once and is idempotent
- `Resumed` audit rows do not masquerade as current work
- no timeout, polling cadence, execution cap, process-global state, or semantic string classification

## Verification
- `scripts/dune-local.sh build lib/masc.cma test/test_keeper_event_queue_state_v2.exe test/test_keeper_current_operations.exe`
- `scripts/dune-local.sh exec test/test_keeper_event_queue_state_v2.exe` (15 tests)
- `scripts/dune-local.sh exec test/test_keeper_current_operations.exe` (4 tests)
- `ocamlformat --check` on all changed OCaml files
- `git diff --check`

357 changed lines. Stacked on #24944.