### PR TITLE
refactor(keeper): require process-owned compaction wake registry

### DIFF
--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -709,7 +709,8 @@ let persist_connector_assistant_reply ~base_dir ~keeper_name ~source ?surface
    to [None] ([dispatch]). Without the unit the optional leaks into [dispatch]'s
    inferred type and breaks the .mli signature. Do not drop the [()]. *)
 let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~submission_owner
-    ~sw ~clock ~proc_mgr ~net ~publication_recovery_provider ~config
+    ~sw ~clock ~proc_mgr ~net ~publication_recovery_provider
+    ~compaction_wake_registry ~config
     ~channel ~channel_user_id ~channel_user_name ~channel_workspace_id
     ~keeper_name ~idempotency_key ~metadata ~content () =
   let keeper_name = String.trim keeper_name in
@@ -814,6 +815,7 @@ let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~submission_owne
     proc_mgr;
     net;
     publication_recovery_provider;
+    compaction_wake_registry;
   } in
   let start_mtime = Mtime_clock.now () in
   let on_text_delta =
@@ -1015,7 +1017,7 @@ let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~submission_owne
    its kind also makes a missing wiring a compile error rather than a silent
    [Generic] default. *)
 let dispatch ~connector_kind ~submission_owner ~sw ~clock ~proc_mgr ~net
-    ~publication_recovery_provider ~config
+    ~publication_recovery_provider ~compaction_wake_registry ~config
     ~channel
     ~channel_user_id ~channel_user_name ~channel_workspace_id ~keeper_name
     ~idempotency_key ~metadata ~content =
@@ -1030,14 +1032,16 @@ let dispatch ~connector_kind ~submission_owner ~sw ~clock ~proc_mgr ~net
       ~idempotency_key ~metadata ~content
   | Generic ->
     dispatch_core ~connector_kind ~submission_owner ~sw ~clock ~proc_mgr ~net
-      ~publication_recovery_provider ~config ~channel ~channel_user_id
+      ~publication_recovery_provider ~compaction_wake_registry ~config
+      ~channel ~channel_user_id
       ~channel_user_name ~channel_workspace_id ~keeper_name ~idempotency_key
       ~metadata ~content ()
 
 let dispatch_with_text_snapshot ~connector_kind ~submission_owner
     ~on_text_snapshot ~sw ~clock ~proc_mgr ~net ~publication_recovery_provider
-    ~config ~channel ~channel_user_id ~channel_user_name ~channel_workspace_id
-    ~keeper_name ~idempotency_key ~metadata ~content =
+    ~compaction_wake_registry ~config ~channel ~channel_user_id
+    ~channel_user_name ~channel_workspace_id ~keeper_name ~idempotency_key
+    ~metadata ~content =
   match connector_kind with
   | Discord ->
     accept_connector ~connector:Discord_connector ~clock ~config ~channel
@@ -1049,6 +1053,7 @@ let dispatch_with_text_snapshot ~connector_kind ~submission_owner
       ~idempotency_key ~metadata ~content
   | Generic ->
     dispatch_core ~connector_kind ~submission_owner ~on_text_snapshot ~sw
-      ~clock ~proc_mgr ~net ~publication_recovery_provider ~config ~channel
-      ~channel_user_id ~channel_user_name ~channel_workspace_id ~keeper_name
-      ~idempotency_key ~metadata ~content ()
+      ~clock ~proc_mgr ~net ~publication_recovery_provider
+      ~compaction_wake_registry ~config ~channel ~channel_user_id
+      ~channel_user_name ~channel_workspace_id ~keeper_name ~idempotency_key
+      ~metadata ~content ()

--- a/lib/gate_keeper_backend.mli
+++ b/lib/gate_keeper_backend.mli
@@ -76,6 +76,7 @@ val dispatch :
   net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option ->
   publication_recovery_provider:
     Keeper_publication_recovery_availability.provider ->
+  compaction_wake_registry:Keeper_compaction_wake_registry.t ->
   config:Workspace.config ->
   channel:string ->
   channel_user_id:string ->
@@ -115,6 +116,7 @@ val dispatch_with_text_snapshot :
   net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option ->
   publication_recovery_provider:
     Keeper_publication_recovery_availability.provider ->
+  compaction_wake_registry:Keeper_compaction_wake_registry.t ->
   config:Workspace.config ->
   channel:string ->
   channel_user_id:string ->

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -177,6 +177,7 @@ let run_turn
       ~(meta : Keeper_meta_contract.keeper_meta)
       ~(publication_recovery :
           Keeper_publication_recovery_availability.turn_context)
+      ~(compaction_wake_registry : Keeper_compaction_wake_registry.t)
       ~(profile_defaults : Keeper_types_profile.keeper_profile_defaults)
       ~(turn_ctx_cell : Keeper_tool_call_log.turn_ctx_cell)
       ~(base_dir : string)
@@ -450,6 +451,7 @@ let run_turn
       ~config
       ~meta
       ~publication_recovery
+      ~compaction_wake_registry
       ?continuation_channel
       ?hitl_resolution
       ~turn_ctx_cell

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -113,6 +113,7 @@ val run_turn
   -> meta:Keeper_meta_contract.keeper_meta
   -> publication_recovery:
        Keeper_publication_recovery_availability.turn_context
+  -> compaction_wake_registry:Keeper_compaction_wake_registry.t
   -> profile_defaults:Keeper_types_profile.keeper_profile_defaults
   -> turn_ctx_cell:Keeper_tool_call_log.turn_ctx_cell
   -> base_dir:string

--- a/lib/keeper/keeper_heartbeat_loop_cycle.ml
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.ml
@@ -248,6 +248,7 @@ let run_keeper_cycle_admitted
               ~config:ctx.config
               ~meta:meta_after_triage
               ~publication_recovery_provider:ctx.publication_recovery_provider
+              ~compaction_wake_registry:ctx.compaction_wake_registry
               ~observation
               ~generation:meta_after_triage.runtime.generation
               ~wake

--- a/lib/keeper/keeper_run_tools.mli
+++ b/lib/keeper/keeper_run_tools.mli
@@ -70,6 +70,7 @@ val prepare_agent_setup
   -> meta:Keeper_meta_contract.keeper_meta
   -> publication_recovery:
        Keeper_publication_recovery_availability.turn_context
+  -> compaction_wake_registry:Keeper_compaction_wake_registry.t
   -> turn_ctx_cell:Keeper_tool_call_log.turn_ctx_cell
   -> ctx_work:working_context
   -> session:Keeper_types.session_context

--- a/lib/keeper/keeper_run_tools_setup.ml
+++ b/lib/keeper/keeper_run_tools_setup.ml
@@ -13,6 +13,7 @@ let prepare_agent_setup
       ~(meta : Keeper_meta_contract.keeper_meta)
       ~(publication_recovery :
           Keeper_publication_recovery_availability.turn_context)
+      ~(compaction_wake_registry : Keeper_compaction_wake_registry.t)
       ~(turn_ctx_cell : Keeper_tool_call_log.turn_ctx_cell)
       ~(ctx_work : working_context)
       ~(session : Keeper_types.session_context)
@@ -91,6 +92,7 @@ let prepare_agent_setup
       ~config
       ~meta
       ~publication_recovery
+      ~compaction_wake_registry
       ~ctx_snapshot
       ~search_fn:(fun () -> !local_search_fn_ref ())
       ?continuation_channel

--- a/lib/keeper/keeper_tool_boundary.ml
+++ b/lib/keeper/keeper_tool_boundary.ml
@@ -9,6 +9,7 @@ type 'a context = {
   net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option;
   publication_recovery_provider :
     Keeper_publication_recovery_availability.provider;
+  compaction_wake_registry : Keeper_compaction_wake_registry.t;
 }
 
 let create
@@ -19,6 +20,7 @@ let create
       ~proc_mgr
       ~net
       ~publication_recovery_provider
+      ~compaction_wake_registry
   =
   { config
   ; agent_name
@@ -27,6 +29,7 @@ let create
   ; proc_mgr
   ; net
   ; publication_recovery_provider
+  ; compaction_wake_registry
   }
 
 let to_tool_keeper_context (ctx : _ context) : _ Keeper_tool_surface.context =
@@ -38,6 +41,7 @@ let to_tool_keeper_context (ctx : _ context) : _ Keeper_tool_surface.context =
     proc_mgr = ctx.proc_mgr;
     net = ctx.net;
     publication_recovery_provider = ctx.publication_recovery_provider;
+    compaction_wake_registry = ctx.compaction_wake_registry;
   }
 
 let dispatch ctx ~name ~args =
@@ -52,6 +56,7 @@ let delegated_dispatch
       ~proc_mgr
       ~net
       ~publication_recovery_provider
+      ~compaction_wake_registry
   =
   let ctx =
     create
@@ -62,6 +67,7 @@ let delegated_dispatch
       ~proc_mgr
       ~net
       ~publication_recovery_provider
+      ~compaction_wake_registry
   in
   fun ~name ~args -> dispatch ctx ~name ~args
 ;;

--- a/lib/keeper/keeper_tool_boundary.mli
+++ b/lib/keeper/keeper_tool_boundary.mli
@@ -12,6 +12,7 @@ type 'a context = {
   net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option;
   publication_recovery_provider :
     Keeper_publication_recovery_availability.provider;
+  compaction_wake_registry : Keeper_compaction_wake_registry.t;
 }
 
 val create :
@@ -23,6 +24,7 @@ val create :
   net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option ->
   publication_recovery_provider:
     Keeper_publication_recovery_availability.provider ->
+  compaction_wake_registry:Keeper_compaction_wake_registry.t ->
   'a context
 
 val dispatch :
@@ -37,6 +39,7 @@ val delegated_dispatch :
   net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option ->
   publication_recovery_provider:
     Keeper_publication_recovery_availability.provider ->
+  compaction_wake_registry:Keeper_compaction_wake_registry.t ->
   name:string ->
   args:Yojson.Safe.t ->
   Keeper_types_profile.tool_result option

--- a/lib/keeper/keeper_tool_dispatch_runtime.ml
+++ b/lib/keeper/keeper_tool_dispatch_runtime.ml
@@ -114,6 +114,7 @@ let execute_keeper_tool_call_with_outcome
       ~(meta : keeper_meta)
       ~(publication_recovery :
           Keeper_publication_recovery_availability.turn_context)
+      ~(compaction_wake_registry : Keeper_compaction_wake_registry.t)
       ~(ctx_work : working_context)
       ?turn_sandbox_factory
       ~(exec_cache : Masc_exec.Exec_cache.t option)
@@ -144,6 +145,7 @@ let execute_keeper_tool_call_with_outcome
                        { config
                        ; meta
                        ; publication_recovery
+                       ; compaction_wake_registry
                        ; ctx_work
                        ; turn_sandbox_factory
                        ; exec_cache
@@ -217,6 +219,7 @@ let execute_keeper_tool_call
       ~(meta : keeper_meta)
       ~(publication_recovery :
           Keeper_publication_recovery_availability.turn_context)
+      ~(compaction_wake_registry : Keeper_compaction_wake_registry.t)
       ~(ctx_work : working_context)
       ?turn_sandbox_factory
       ~(exec_cache : Masc_exec.Exec_cache.t option)
@@ -231,6 +234,7 @@ let execute_keeper_tool_call
       ~config
       ~meta
       ~publication_recovery
+      ~compaction_wake_registry
       ~ctx_work
                   ?turn_sandbox_factory
                   ~exec_cache

--- a/lib/keeper/keeper_tool_dispatch_runtime.mli
+++ b/lib/keeper/keeper_tool_dispatch_runtime.mli
@@ -62,6 +62,7 @@ val execute_keeper_tool_call_with_outcome
   -> meta:keeper_meta
   -> publication_recovery:
        Keeper_publication_recovery_availability.turn_context
+  -> compaction_wake_registry:Keeper_compaction_wake_registry.t
   -> ctx_work:working_context
   -> ?turn_sandbox_factory:Keeper_sandbox_factory.t
   -> exec_cache:Masc_exec.Exec_cache.t option
@@ -89,6 +90,7 @@ val execute_keeper_tool_call
   -> meta:keeper_meta
   -> publication_recovery:
        Keeper_publication_recovery_availability.turn_context
+  -> compaction_wake_registry:Keeper_compaction_wake_registry.t
   -> ctx_work:working_context
   -> ?turn_sandbox_factory:Keeper_sandbox_factory.t
   -> exec_cache:Masc_exec.Exec_cache.t option

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -903,6 +903,7 @@ let handle_masc_local_runtime
 let handle_masc_keeper_with_outcome
       ~(publication_recovery_provider :
           Keeper_publication_recovery_availability.provider)
+      ~(compaction_wake_registry : Keeper_compaction_wake_registry.t)
       ?sw
       ?clock
       ?proc_mgr
@@ -932,6 +933,7 @@ let handle_masc_keeper_with_outcome
       ~config
       ~agent_name:meta.agent_name
       ~publication_recovery_provider
+      ~compaction_wake_registry
       ?sw
       ?clock
       ?proc_mgr
@@ -947,6 +949,7 @@ let handle_masc_keeper_with_outcome
 let handle_masc_keeper
       ~(publication_recovery_provider :
           Keeper_publication_recovery_availability.provider)
+      ~(compaction_wake_registry : Keeper_compaction_wake_registry.t)
       ?sw
       ?clock
       ?proc_mgr
@@ -963,6 +966,7 @@ let handle_masc_keeper
   =
   (handle_masc_keeper_with_outcome
      ~publication_recovery_provider
+     ~compaction_wake_registry
      ?sw
      ?clock
      ?proc_mgr

--- a/lib/keeper/keeper_tool_in_process_runtime.mli
+++ b/lib/keeper/keeper_tool_in_process_runtime.mli
@@ -271,6 +271,7 @@ val handle_analyze_image_with_outcome
 val handle_masc_keeper
   :  publication_recovery_provider:
        Keeper_publication_recovery_availability.provider
+  -> compaction_wake_registry:Keeper_compaction_wake_registry.t
   -> ?sw:Eio.Switch.t
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
   -> ?proc_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t
@@ -289,6 +290,7 @@ val handle_masc_keeper
 val handle_masc_keeper_with_outcome
   :  publication_recovery_provider:
        Keeper_publication_recovery_availability.provider
+  -> compaction_wake_registry:Keeper_compaction_wake_registry.t
   -> ?sw:Eio.Switch.t
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
   -> ?proc_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t

--- a/lib/keeper/keeper_tool_runtime.ml
+++ b/lib/keeper/keeper_tool_runtime.ml
@@ -15,6 +15,7 @@ type context =
   ; meta : Keeper_meta_contract.keeper_meta
   ; publication_recovery :
       Keeper_publication_recovery_availability.turn_context
+  ; compaction_wake_registry : Keeper_compaction_wake_registry.t
   ; ctx_work : Keeper_types.working_context
   ; turn_sandbox_factory : Keeper_sandbox_factory.t option
   ; exec_cache : Masc_exec.Exec_cache.t option
@@ -349,6 +350,7 @@ let handle_in_process ctx descriptor args =
     Some
       (Keeper_tool_in_process_runtime.handle_masc_keeper_with_outcome
          ~publication_recovery_provider:ctx.publication_recovery.provider
+         ~compaction_wake_registry:ctx.compaction_wake_registry
          ?sw:ctx.sw
          ?clock:ctx.clock
          ?proc_mgr:ctx.proc_mgr

--- a/lib/keeper/keeper_tool_runtime.mli
+++ b/lib/keeper/keeper_tool_runtime.mli
@@ -14,6 +14,7 @@ type context =
   ; meta : Keeper_meta_contract.keeper_meta
   ; publication_recovery :
       Keeper_publication_recovery_availability.turn_context
+  ; compaction_wake_registry : Keeper_compaction_wake_registry.t
   ; ctx_work : Keeper_types.working_context
   ; turn_sandbox_factory : Keeper_sandbox_factory.t option
   ; exec_cache : Masc_exec.Exec_cache.t option

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -865,7 +865,9 @@ let eio_context_missing tool_name =
 
 let () =
   Keeper_dispatch_ref.dispatch
-  := fun ~config ~agent_name ~publication_recovery_provider ?sw ?clock ?proc_mgr ?net ?mcp_session_id:_ ?authorize_external_effect ~name ~args () ->
+  := fun ~config ~agent_name ~publication_recovery_provider
+       ~compaction_wake_registry ?sw ?clock ?proc_mgr ?net ?mcp_session_id:_
+       ?authorize_external_effect ~name ~args () ->
     let run_external_effect continue =
       match authorize_external_effect with
       | None -> continue ()
@@ -926,6 +928,7 @@ let () =
            ; proc_mgr
            ; net
            ; publication_recovery_provider
+           ; compaction_wake_registry
            }
          in
          Some
@@ -956,6 +959,7 @@ let () =
            ; proc_mgr
            ; net
            ; publication_recovery_provider
+           ; compaction_wake_registry
            }
          in
          run_external_effect (fun () ->
@@ -974,7 +978,15 @@ let () =
       (match sw, clock with
        | Some sw, Some clock ->
          let ctx : _ Keeper_types_profile.context =
-           { config; agent_name; sw; clock; proc_mgr; net; publication_recovery_provider }
+           { config
+           ; agent_name
+           ; sw
+           ; clock
+           ; proc_mgr
+           ; net
+           ; publication_recovery_provider
+           ; compaction_wake_registry
+           }
          in
          Some (Keeper_tool_surface_ops.handle_keeper_delegate ~submitted_by:agent_name ctx args)
        | _ -> eio_context_missing "masc_keeper_delegate")
@@ -988,6 +1000,7 @@ let () =
               ~sw
               ~clock
               ~publication_recovery_provider
+              ~compaction_wake_registry
               ?proc_mgr
               ?net
               args)

--- a/lib/keeper/keeper_tool_surface.mli
+++ b/lib/keeper/keeper_tool_surface.mli
@@ -10,6 +10,7 @@ type 'a context = 'a Keeper_types_profile.context = {
   net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option;
   publication_recovery_provider :
     Keeper_publication_recovery_availability.provider;
+  compaction_wake_registry : Keeper_compaction_wake_registry.t;
 }
 
 type tool_result = Keeper_types_profile.tool_result

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -26,6 +26,7 @@ type 'a context = 'a Keeper_types_profile.context = {
   net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option;
   publication_recovery_provider :
     Keeper_publication_recovery_availability.provider;
+  compaction_wake_registry : Keeper_compaction_wake_registry.t;
 }
 type tool_result = Keeper_types_profile.tool_result
 let schemas = Keeper_types_profile.schemas
@@ -478,6 +479,7 @@ let keeper_up_body
       ~(clock : float Eio.Time.clock_ty Eio.Resource.t)
       ~(publication_recovery_provider :
           Keeper_publication_recovery_availability.provider)
+      ~(compaction_wake_registry : Keeper_compaction_wake_registry.t)
       ?proc_mgr
       ?net
       args : tool_result =
@@ -489,6 +491,7 @@ let keeper_up_body
     ; proc_mgr
     ; net
     ; publication_recovery_provider
+    ; compaction_wake_registry
     }
   in
   with_keeper_startup_gate (fun () -> execute_keeper_up keeper_ctx args)

--- a/lib/keeper/keeper_tools_oas_bundle.ml
+++ b/lib/keeper/keeper_tools_oas_bundle.ml
@@ -32,6 +32,7 @@ let make_tool_bundle
       ~(meta : Keeper_meta_contract.keeper_meta)
       ~(publication_recovery :
           Keeper_publication_recovery_availability.turn_context)
+      ~(compaction_wake_registry : Keeper_compaction_wake_registry.t)
       ~(ctx_snapshot : Keeper_types.working_context)
       ?search_fn
       ?clock
@@ -90,6 +91,7 @@ let make_tool_bundle
                  ~config
                  ~meta
                  ~publication_recovery
+                 ~compaction_wake_registry
                  ~ctx_snapshot
                    ?turn_sandbox_factory
                  ~exec_cache
@@ -142,6 +144,7 @@ let make_tools
       ~(meta : Keeper_meta_contract.keeper_meta)
       ~(publication_recovery :
           Keeper_publication_recovery_availability.turn_context)
+      ~(compaction_wake_registry : Keeper_compaction_wake_registry.t)
       ~(ctx_snapshot : Keeper_types.working_context)
       ?search_fn
       ?clock
@@ -152,6 +155,7 @@ let make_tools
      ~config
      ~meta
      ~publication_recovery
+     ~compaction_wake_registry
      ~ctx_snapshot
      ?search_fn
      ?clock

--- a/lib/keeper/keeper_tools_oas_bundle.mli
+++ b/lib/keeper/keeper_tools_oas_bundle.mli
@@ -9,6 +9,7 @@ val make_tool_bundle
   -> meta:Keeper_meta_contract.keeper_meta
   -> publication_recovery:
        Keeper_publication_recovery_availability.turn_context
+  -> compaction_wake_registry:Keeper_compaction_wake_registry.t
   -> ctx_snapshot:Keeper_types.working_context
   -> ?search_fn:(unit -> Keeper_tool_execution.t)
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
@@ -24,6 +25,7 @@ val make_tools
   -> meta:Keeper_meta_contract.keeper_meta
   -> publication_recovery:
        Keeper_publication_recovery_availability.turn_context
+  -> compaction_wake_registry:Keeper_compaction_wake_registry.t
   -> ctx_snapshot:Keeper_types.working_context
   -> ?search_fn:(unit -> Keeper_tool_execution.t)
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t

--- a/lib/keeper/keeper_tools_oas_handler.ml
+++ b/lib/keeper/keeper_tools_oas_handler.ml
@@ -15,6 +15,7 @@ let make_keeper_tool_handler
       ~(meta : Keeper_meta_contract.keeper_meta)
       ~(publication_recovery :
           Keeper_publication_recovery_availability.turn_context)
+      ~(compaction_wake_registry : Keeper_compaction_wake_registry.t)
       ~(ctx_snapshot : Keeper_types.working_context)
       ?turn_sandbox_factory
       ~(exec_cache : Masc_exec.Exec_cache.t option)
@@ -120,6 +121,7 @@ let make_keeper_tool_handler
               ~config
               ~meta
               ~publication_recovery
+              ~compaction_wake_registry
               ~ctx_snapshot
               ?turn_sandbox_factory
               ~exec_cache

--- a/lib/keeper/keeper_tools_oas_handler.mli
+++ b/lib/keeper/keeper_tools_oas_handler.mli
@@ -24,6 +24,7 @@ val make_keeper_tool_handler
   -> meta:Keeper_meta_contract.keeper_meta
   -> publication_recovery:
        Keeper_publication_recovery_availability.turn_context
+  -> compaction_wake_registry:Keeper_compaction_wake_registry.t
   -> ctx_snapshot:Keeper_types.working_context
   -> ?turn_sandbox_factory:Keeper_sandbox_factory.t
   -> exec_cache:Masc_exec.Exec_cache.t option

--- a/lib/keeper/keeper_tools_oas_handler_exec.ml
+++ b/lib/keeper/keeper_tools_oas_handler_exec.ml
@@ -14,6 +14,7 @@ let execute_with_observers
       ~(meta : Keeper_meta_contract.keeper_meta)
       ~(publication_recovery :
           Keeper_publication_recovery_availability.turn_context)
+      ~(compaction_wake_registry : Keeper_compaction_wake_registry.t)
       ~(ctx_snapshot : Keeper_types.working_context)
       ?turn_sandbox_factory
       ~(exec_cache : Masc_exec.Exec_cache.t option)
@@ -38,6 +39,7 @@ let execute_with_observers
           ~config
           ~meta
           ~publication_recovery
+          ~compaction_wake_registry
           ~ctx_work:ctx_snapshot
             ?turn_sandbox_factory
             ~exec_cache

--- a/lib/keeper/keeper_tools_oas_handler_exec.mli
+++ b/lib/keeper/keeper_tools_oas_handler_exec.mli
@@ -12,6 +12,7 @@ val execute_with_observers
   -> meta:Keeper_meta_contract.keeper_meta
   -> publication_recovery:
        Keeper_publication_recovery_availability.turn_context
+  -> compaction_wake_registry:Keeper_compaction_wake_registry.t
   -> ctx_snapshot:Keeper_types.working_context
   -> ?turn_sandbox_factory:Keeper_sandbox_factory.t
   -> exec_cache:Masc_exec.Exec_cache.t option

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -826,6 +826,8 @@ let run_keeper_invocation_turn_admitted
 			                                ~config:ctx.config
 			                                ~meta
 			                                ~publication_recovery
+			                                ~compaction_wake_registry:
+			                                  ctx.compaction_wake_registry
 			                                ~profile_defaults
 			                                ~turn_ctx_cell
 		                                ~base_dir

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -21,6 +21,7 @@ type 'a context = {
   net: [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option;
   publication_recovery_provider:
     Keeper_publication_recovery_availability.provider;
+  compaction_wake_registry: Keeper_compaction_wake_registry.t;
 }
 
 type tool_result = Tool_result.result

--- a/lib/keeper/keeper_types_profile.mli
+++ b/lib/keeper/keeper_types_profile.mli
@@ -17,6 +17,7 @@ type 'a context =
   ; net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option
   ; publication_recovery_provider :
       Keeper_publication_recovery_availability.provider
+  ; compaction_wake_registry : Keeper_compaction_wake_registry.t
   }
 
 type tool_result = Tool_result.result

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -333,6 +333,7 @@ let run_keeper_cycle
       ~(meta : keeper_meta)
       ~(publication_recovery_provider :
           Keeper_publication_recovery_availability.provider)
+      ~(compaction_wake_registry : Keeper_compaction_wake_registry.t)
       ~(observation : Keeper_world_observation.world_observation)
       ~(generation : int)
       ~(wake : Keeper_registry.wake_reason)
@@ -802,6 +803,7 @@ let run_keeper_cycle
                            ; observation
                            ; profile_defaults
                            ; publication_recovery
+                           ; compaction_wake_registry
                            ; shared_context
                            ; trajectory_acc
                            ; turn_id = keeper_turn_id

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -170,6 +170,7 @@ val run_keeper_cycle
   -> meta:Keeper_meta_contract.keeper_meta
   -> publication_recovery_provider:
        Keeper_publication_recovery_availability.provider
+  -> compaction_wake_registry:Keeper_compaction_wake_registry.t
   -> observation:Keeper_world_observation.world_observation
   -> generation:int
   -> wake:Keeper_registry.wake_reason

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -79,6 +79,7 @@ type ctx =
   ; profile_defaults : Keeper_types_profile.keeper_profile_defaults
   ; publication_recovery :
       Keeper_publication_recovery_availability.turn_context
+  ; compaction_wake_registry : Keeper_compaction_wake_registry.t
   ; shared_context : Agent_sdk.Context.t option
   ; trajectory_acc : Trajectory.accumulator
   ; turn_id : int
@@ -111,6 +112,7 @@ let run (ctx : ctx)
       ; trajectory_acc
       ; profile_defaults
       ; publication_recovery
+      ; compaction_wake_registry
       ; cleanup
       ; drain_turn_event_bus
       ; event_bus
@@ -177,6 +179,7 @@ let run (ctx : ctx)
                  ~config
                  ~meta:run_meta
                  ~publication_recovery
+                 ~compaction_wake_registry
                  ~profile_defaults
                  ?continuation_delivery_channel
                  ?hitl_resolution

--- a/lib/keeper_dispatch_ref.ml
+++ b/lib/keeper_dispatch_ref.ml
@@ -15,6 +15,7 @@ let dispatch
      -> agent_name:string
      -> publication_recovery_provider:
           Keeper_publication_recovery_availability.provider
+     -> compaction_wake_registry:Keeper_compaction_wake_registry.t
      -> ?sw:Eio.Switch.t
      -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
      -> ?proc_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t
@@ -27,7 +28,9 @@ let dispatch
      -> Tool_result.result option)
       ref
   =
-  ref (fun ~config:_ ~agent_name:_ ~publication_recovery_provider:_ ?sw:_ ?clock:_ ?proc_mgr:_ ?net:_ ?mcp_session_id:_ ?authorize_external_effect:_ ~name ~args:_ () ->
+  ref (fun ~config:_ ~agent_name:_ ~publication_recovery_provider:_
+           ~compaction_wake_registry:_ ?sw:_ ?clock:_ ?proc_mgr:_ ?net:_
+           ?mcp_session_id:_ ?authorize_external_effect:_ ~name ~args:_ () ->
     failwith
       (Printf.sprintf
          "keeper_dispatch_ref: dispatch called for tool %S before boot registration — \

--- a/lib/keeper_dispatch_ref.mli
+++ b/lib/keeper_dispatch_ref.mli
@@ -40,6 +40,7 @@ val dispatch
      -> agent_name:string
      -> publication_recovery_provider:
           Keeper_publication_recovery_availability.provider
+     -> compaction_wake_registry:Keeper_compaction_wake_registry.t
      -> ?sw:Eio.Switch.t
      -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
      -> ?proc_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -242,6 +242,8 @@ let execute_tool_eio
                 ~net:state.Mcp_server.net
                 ~publication_recovery_provider:
                   (Mcp_server.publication_recovery_availability_provider state)
+                ~compaction_wake_registry:
+                  (Mcp_server.keeper_compaction_wake_registry state)
             in
             (* Dispatch a single module by tag — creates only that module's context.
      Pre-hooks may coerce arguments (e.g. OAS type coercion: "42" -> 42).
@@ -272,7 +274,9 @@ let execute_tool_eio
                               ~net:state.Mcp_server.net
                               ~publication_recovery_provider:
                                 (Mcp_server.publication_recovery_availability_provider
-                                   state))
+                                   state)
+                              ~compaction_wake_registry:
+                                (Mcp_server.keeper_compaction_wake_registry state))
                      ; mcp_session_id
                      }
                    in

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -1460,6 +1460,8 @@ let start_keeper_loops_owned
         ; net = state.net
         ; publication_recovery_provider =
             Mcp_server.publication_recovery_availability_provider state
+        ; compaction_wake_registry =
+            Mcp_server.keeper_compaction_wake_registry state
         }
       in
       Log.Keeper.info "autoboot: %d keeper(s) to boot" (List.length names);
@@ -1519,6 +1521,8 @@ let start_keeper_loops_owned
                 ; net = state.net
                 ; publication_recovery_provider =
                     Mcp_server.publication_recovery_availability_provider state
+                ; compaction_wake_registry =
+                    Mcp_server.keeper_compaction_wake_registry state
                 }
               in
               let launch_outcome =

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -751,7 +751,9 @@ let operator_control_context ~state ~sw ~clock ~config ~agent_name
            ~proc_mgr:state.Mcp_server.proc_mgr
            ~net:state.Mcp_server.net
            ~publication_recovery_provider:
-             (Mcp_server.publication_recovery_availability_provider state))
+             (Mcp_server.publication_recovery_availability_provider state)
+           ~compaction_wake_registry:
+             (Mcp_server.keeper_compaction_wake_registry state))
   ; mcp_session_id = None
   }
 ;;

--- a/lib/server/server_dashboard_http_keeper_api_lifecycle_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_lifecycle_post.ml
@@ -235,6 +235,8 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
         net = state.Mcp_server.net;
         publication_recovery_provider =
           Mcp_server.publication_recovery_availability_provider state;
+        compaction_wake_registry =
+          Mcp_server.keeper_compaction_wake_registry state;
       }
     in
     let args_result =

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -701,6 +701,8 @@ let handle_keeper_config_post ~sw ~clock state agent_name req reqd body_str =
                           net = state.Mcp_server.net;
                           publication_recovery_provider =
                             Mcp_server.publication_recovery_availability_provider state;
+                          compaction_wake_registry =
+                            Mcp_server.keeper_compaction_wake_registry state;
                         }
                       in
                       (match
@@ -893,6 +895,8 @@ let keeper_ctx_of_dashboard_state ~sw ~clock state agent_name :
     net = state.Mcp_server.net;
     publication_recovery_provider =
       Mcp_server.publication_recovery_availability_provider state;
+    compaction_wake_registry =
+      Mcp_server.keeper_compaction_wake_registry state;
   }
 
 let meta_with_directive_paused_state

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -813,6 +813,8 @@ let start ~sw ~env ~clock ~state =
         ~net:state.Mcp_server.net
         ~publication_recovery_provider:
           (Mcp_server.publication_recovery_availability_provider state)
+        ~compaction_wake_registry:
+          (Mcp_server.keeper_compaction_wake_registry state)
         ~config
     in
     let policy_label = Discord_gateway_state.trigger_policy_to_string policy in

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -572,6 +572,8 @@ let execute_keeper_stream_tool
           net = state.Mcp_server.net;
           publication_recovery_provider =
             Mcp_server.publication_recovery_availability_provider state;
+          compaction_wake_registry =
+            Mcp_server.keeper_compaction_wake_registry state;
         }
       in
       match
@@ -859,6 +861,8 @@ let execute_keeper_stream_tool_streaming
           net = state.Mcp_server.net;
           publication_recovery_provider =
             Mcp_server.publication_recovery_availability_provider state;
+          compaction_wake_registry =
+            Mcp_server.keeper_compaction_wake_registry state;
         }
       in
       match
@@ -969,6 +973,8 @@ let execute_keeper_stream_tool_streaming_if_free
           net = state.Mcp_server.net;
           publication_recovery_provider =
             Mcp_server.publication_recovery_availability_provider state;
+          compaction_wake_registry =
+            Mcp_server.keeper_compaction_wake_registry state;
         }
       in
       match

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -364,6 +364,8 @@ let dispatch_board_context_inference ~state ~sw ~clock ~request ~target_keeper
       net = state.Mcp_server.net;
       publication_recovery_provider =
         Mcp_server.publication_recovery_availability_provider state;
+      compaction_wake_registry =
+        Mcp_server.keeper_compaction_wake_registry state;
     }
   in
   let post_id = Board.Post_id.to_string post.id in

--- a/lib/server/server_routes_http_routes_channel_gate.ml
+++ b/lib/server/server_routes_http_routes_channel_gate.ml
@@ -153,6 +153,8 @@ let handle_gate_message ~sw ~clock ~submitted_by state request reqd =
         ~net:state.Mcp_server.net
         ~publication_recovery_provider:
           (Mcp_server.publication_recovery_availability_provider state)
+        ~compaction_wake_registry:
+          (Mcp_server.keeper_compaction_wake_registry state)
         ~config:workspace_scope.config
     in
     let result =
@@ -296,6 +298,8 @@ let gate_keeper_ctx ~sw ~clock state =
     net = state.Mcp_server.net;
     publication_recovery_provider =
       Mcp_server.publication_recovery_availability_provider state;
+    compaction_wake_registry =
+      Mcp_server.keeper_compaction_wake_registry state;
   }
 
 let keeper_exists ~sw ~clock state keeper_name =

--- a/test/deps/dune
+++ b/test/deps/dune
@@ -84,6 +84,7 @@
   (re_export masc.tool_call_quality_benchmark)
   (re_export masc.keeper_runtime)
   (re_export masc.keeper_contract)
+  (re_export masc.keeper_compaction_wake_registry)
   ;; RFC-0056 Phase 1K — Compaction_trigger leaf sub-library.
   (re_export masc.compaction_trigger)
   ;; RFC-0056 Phase 1L — Attribution leaf sub-library.

--- a/test/test_completion_trust_harness.ml
+++ b/test/test_completion_trust_harness.ml
@@ -156,6 +156,7 @@ let attempt_done
       ()
   =
   KET.execute_keeper_tool_call_with_outcome
+    ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
     ~config
     ~meta
     ~publication_recovery
@@ -190,6 +191,7 @@ let claim_via_dispatch
       ~task_id
   =
   KET.execute_keeper_tool_call_with_outcome
+    ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
     ~config
     ~meta
     ~publication_recovery

--- a/test/test_dashboard_namespace_truth.ml
+++ b/test/test_dashboard_namespace_truth.ml
@@ -133,6 +133,7 @@ let create_keeper env sw state name =
       sw;
       clock = Eio.Stdenv.clock env;
       proc_mgr = Some (Eio.Stdenv.process_mgr env); net = None;
+      compaction_wake_registry = Keeper_compaction_wake_registry.create ();
       publication_recovery_provider =
         Lib.Mcp_server.publication_recovery_availability_provider state;
     }

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -612,6 +612,7 @@ let test_fresh_presence_preserves_turn_failures () =
           clock = Eio.Stdenv.clock env;
           proc_mgr = None;
           net = None;
+          compaction_wake_registry = Keeper_compaction_wake_registry.create ();
           publication_recovery_provider =
             Masc_test_deps.non_runtime_publication_recovery_provider;
         }
@@ -715,6 +716,7 @@ let test_direct_start_keepalive_resolves_done_on_stop () =
           clock = Eio.Stdenv.clock env;
           proc_mgr = Some (Eio.Stdenv.process_mgr env);
           net = None;
+          compaction_wake_registry = Keeper_compaction_wake_registry.create ();
           publication_recovery_provider =
             Masc_test_deps.publication_recovery_provider
               (publication_recovery_registry env sw config);
@@ -1553,6 +1555,7 @@ let test_operator_update_supersedes_exact_blocked_shutdown () =
         ; clock = Eio.Stdenv.clock env
         ; proc_mgr = None
         ; net = None
+        ; compaction_wake_registry = Keeper_compaction_wake_registry.create ()
         ; publication_recovery_provider =
             Masc_test_deps.non_runtime_publication_recovery_provider
         }
@@ -3132,6 +3135,7 @@ let test_start_keepalive_denies_dead_tombstone_before_registration () =
         ; clock = Eio.Stdenv.clock env
         ; proc_mgr = Some (Eio.Stdenv.process_mgr env)
         ; net = None
+        ; compaction_wake_registry = Keeper_compaction_wake_registry.create ()
         ; publication_recovery_provider =
             Masc_test_deps.non_runtime_publication_recovery_provider
         }
@@ -3175,6 +3179,7 @@ let test_start_keepalive_preserves_unresolved_failing_entry () =
           clock = Eio.Stdenv.clock env;
           proc_mgr = Some (Eio.Stdenv.process_mgr env);
           net = None;
+          compaction_wake_registry = Keeper_compaction_wake_registry.create ();
           publication_recovery_provider =
             Masc_test_deps.publication_recovery_provider
               (publication_recovery_registry env sw config);
@@ -3224,6 +3229,7 @@ let test_start_keepalive_reclaims_finished_failing_entry () =
           clock = Eio.Stdenv.clock env;
           proc_mgr = Some (Eio.Stdenv.process_mgr env);
           net = None;
+          compaction_wake_registry = Keeper_compaction_wake_registry.create ();
           publication_recovery_provider =
             Masc_test_deps.publication_recovery_provider
               (publication_recovery_registry env sw config);

--- a/test/test_keeper_adversarial_review.ml
+++ b/test/test_keeper_adversarial_review.ml
@@ -63,6 +63,7 @@ let operator_ctx env sw config agent_name : _ Operator_control.context =
     delegated_dispatch =
       Some
         (Masc.Keeper_tool_boundary.delegated_dispatch
+           ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
            ~config
            ~agent_name
            ~sw

--- a/test/test_keeper_busy_connector_deferred.ml
+++ b/test/test_keeper_busy_connector_deferred.ml
@@ -98,6 +98,7 @@ let test_busy_discord_enqueues () =
         let reply =
           with_busy_slot ~base ~sw (fun () ->
             Gate_keeper_backend.dispatch
+              ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
               ~connector_kind:Gate_keeper_backend.Discord
               ~submission_owner:Gate_keeper_backend.Channel_actor
               ~sw ~clock ~proc_mgr:None ~net:None
@@ -216,6 +217,7 @@ let test_unpublished_busy_slot_queues_without_resolved_meta () =
             check "raw lock has no published in-flight metadata"
               (Keeper_turn_admission.in_flight ~base_path:base ~keeper_name = None);
             Gate_keeper_backend.dispatch
+              ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
               ~connector_kind:Gate_keeper_backend.Discord
               ~submission_owner:Gate_keeper_backend.Channel_actor
               ~sw ~clock ~proc_mgr:None ~net:None
@@ -266,6 +268,7 @@ let test_busy_discord_persist_failure_is_explicit () =
             Keeper_chat_queue.For_testing.fail_transaction_at_stages
               [ Mutation_applied ];
             Gate_keeper_backend.dispatch
+              ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
               ~connector_kind:Gate_keeper_backend.Discord
               ~submission_owner:Gate_keeper_backend.Channel_actor
               ~sw ~clock ~proc_mgr:None ~net:None
@@ -322,6 +325,7 @@ let test_pending_receipt_prevents_direct_overtake () =
       Eio.Switch.run @@ fun sw ->
       let reply =
         Gate_keeper_backend.dispatch
+          ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
           ~connector_kind:Gate_keeper_backend.Discord
           ~submission_owner:Gate_keeper_backend.Channel_actor
           ~sw ~clock ~proc_mgr:None ~net:None
@@ -365,6 +369,7 @@ let test_busy_slack_preserves_thread_context () =
       let reply =
         with_busy_slot ~base ~sw (fun () ->
           Gate_keeper_backend.dispatch
+            ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
             ~connector_kind:Gate_keeper_backend.Slack
             ~submission_owner:Gate_keeper_backend.Channel_actor
             ~sw ~clock ~proc_mgr:None ~net:None
@@ -506,6 +511,7 @@ let test_shutdown_fenced_connector_ack
         Eio.Switch.on_release sw Keeper_chat_queue.For_testing.reset;
         let reply =
           Gate_keeper_backend.dispatch
+            ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
             ~connector_kind
             ~submission_owner:Gate_keeper_backend.Channel_actor
             ~sw ~clock ~proc_mgr:None ~net:None

--- a/test/test_keeper_busy_dashboard_deferred.ml
+++ b/test/test_keeper_busy_dashboard_deferred.ml
@@ -367,6 +367,7 @@ let test_stream_surface_preserves_typed_shutdown_rejection () =
     ; clock
     ; proc_mgr = None
     ; net = None
+    ; compaction_wake_registry = Keeper_compaction_wake_registry.create ()
     ; publication_recovery_provider =
         Masc_test_deps.non_runtime_publication_recovery_provider
     }
@@ -416,6 +417,7 @@ let test_delegate_surface_uses_serialized_shutdown_fence () =
     ; clock
     ; proc_mgr = None
     ; net = None
+    ; compaction_wake_registry = Keeper_compaction_wake_registry.create ()
     ; publication_recovery_provider =
         Masc_test_deps.non_runtime_publication_recovery_provider
     }
@@ -454,6 +456,7 @@ let test_delegate_resource_error_uses_typed_tool_name () =
     ; clock
     ; proc_mgr = None
     ; net = None
+    ; compaction_wake_registry = Keeper_compaction_wake_registry.create ()
     ; publication_recovery_provider =
         Masc_test_deps.non_runtime_publication_recovery_provider
     }

--- a/test/test_keeper_compact_recovery_tool_surface.ml
+++ b/test/test_keeper_compact_recovery_tool_surface.ml
@@ -61,6 +61,7 @@ let test_missing_checkpoint_still_queues_owner_lane_stimulus () =
         ; clock = Eio.Stdenv.clock env
         ; proc_mgr = None
         ; net = None
+        ; compaction_wake_registry = Keeper_compaction_wake_registry.create ()
         ; publication_recovery_provider =
             Masc_test_deps.non_runtime_publication_recovery_provider
         }

--- a/test/test_keeper_effective_meta_overlay.ml
+++ b/test/test_keeper_effective_meta_overlay.ml
@@ -436,6 +436,7 @@ sandbox_profile = "docker"
       clock = Eio.Stdenv.clock env;
       proc_mgr = None;
       net = None;
+      compaction_wake_registry = Keeper_compaction_wake_registry.create ();
       publication_recovery_provider =
         Masc_test_deps.non_runtime_publication_recovery_provider;
     }
@@ -516,6 +517,7 @@ instructions = "missing sandbox profile"
       clock = Eio.Stdenv.clock env;
       proc_mgr = None;
       net = None;
+      compaction_wake_registry = Keeper_compaction_wake_registry.create ();
       publication_recovery_provider =
         Masc_test_deps.non_runtime_publication_recovery_provider;
     }
@@ -545,6 +547,7 @@ let test_keeper_up_rejects_missing_profile_source () =
       clock = Eio.Stdenv.clock env;
       proc_mgr = None;
       net = None;
+      compaction_wake_registry = Keeper_compaction_wake_registry.create ();
       publication_recovery_provider =
         Masc_test_deps.non_runtime_publication_recovery_provider;
     }
@@ -732,6 +735,7 @@ instructions = "missing sandbox profile"
           clock = Eio.Stdenv.clock env;
           proc_mgr = None;
           net = None;
+          compaction_wake_registry = Keeper_compaction_wake_registry.create ();
           publication_recovery_provider =
             Masc_test_deps.publication_recovery_provider
               publication_recovery_registry;

--- a/test/test_keeper_gate_effect_coverage.ml
+++ b/test/test_keeper_gate_effect_coverage.ml
@@ -95,6 +95,7 @@ let with_keeper_dispatch_probe f =
         ~config:_
         ~agent_name:_
         ~publication_recovery_provider:_
+        ~compaction_wake_registry:_
         ?sw:_
         ?clock:_
         ?proc_mgr:_
@@ -190,6 +191,7 @@ let test_keeper_effects_defer_without_dispatch () =
        let args = `Assoc [ "opaque", `String name ] in
          let result =
            Keeper_tool_in_process_runtime.handle_masc_keeper_with_outcome
+           ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
            ~publication_recovery_provider:publication_recovery.provider
            ~config
            ~meta
@@ -217,6 +219,7 @@ let test_keeper_effects_unavailable_without_dispatch () =
     (fun name ->
          let result =
            Keeper_tool_in_process_runtime.handle_masc_keeper_with_outcome
+           ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
            ~publication_recovery_provider:publication_recovery.provider
            ~config
            ~meta
@@ -248,6 +251,7 @@ let test_keeper_effects_allow_exact_dispatch () =
        let args = `Assoc [ "opaque", `String name ] in
          let result =
            Keeper_tool_in_process_runtime.handle_masc_keeper_with_outcome
+           ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
            ~publication_recovery_provider:publication_recovery.provider
            ~config
            ~meta

--- a/test/test_keeper_lifecycle_registry_dispatch.ml
+++ b/test/test_keeper_lifecycle_registry_dispatch.ml
@@ -565,6 +565,7 @@ let test_keepalive_dispatch_event_rejection_increments_metric () =
           clock = Eio.Stdenv.clock env;
           proc_mgr = Some (Eio.Stdenv.process_mgr env);
           net = None;
+          compaction_wake_registry = Keeper_compaction_wake_registry.create ();
           publication_recovery_provider =
             Publication_availability.constant
               Publication_availability.Non_runtime;

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -184,6 +184,7 @@ let test_manual_compaction_serializes_owner_lane () =
         ; clock = Eio.Stdenv.clock env
         ; proc_mgr = None
         ; net = None
+        ; compaction_wake_registry = Keeper_compaction_wake_registry.create ()
         ; publication_recovery_provider =
             Masc_test_deps.non_runtime_publication_recovery_provider
         }

--- a/test/test_keeper_registry_hardening.ml
+++ b/test/test_keeper_registry_hardening.ml
@@ -369,6 +369,7 @@ let test_tool_dispatch_preserves_exact_meta_after_replacement () =
              | None -> fail "replacement entry not found");
             let result =
               KET.execute_keeper_tool_call_with_outcome
+                ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
                 ~config
                 ~meta:exact_resources.entry.meta
                 ~publication_recovery:exact_resources.publication_recovery

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -528,6 +528,7 @@ let keeper_runtime_context env sw config : _ Keeper_types_profile.context =
   ; clock = Eio.Stdenv.clock env
   ; proc_mgr = Some (Eio.Stdenv.process_mgr env)
   ; net = Some (Eio.Stdenv.net env)
+  ; compaction_wake_registry = Keeper_compaction_wake_registry.create ()
   ; publication_recovery_provider =
       Masc_test_deps.publication_recovery_provider
         (publication_recovery_registry env sw config)
@@ -989,6 +990,7 @@ let test_sweep_does_not_synthesize_gate_from_runtime_blocker () =
           clock = Eio.Stdenv.clock env;
           proc_mgr = Some (Eio.Stdenv.process_mgr env);
           net = Some (Eio.Stdenv.net env);
+          compaction_wake_registry = Keeper_compaction_wake_registry.create ();
           publication_recovery_provider =
             Masc_test_deps.publication_recovery_provider
               (publication_recovery_registry env sw config);
@@ -1122,6 +1124,7 @@ let test_restart_path_emits_attempt_and_started_outcome_metrics () =
           clock = Eio.Stdenv.clock env;
           proc_mgr = Some (Eio.Stdenv.process_mgr env);
           net = Some (Eio.Stdenv.net env);
+          compaction_wake_registry = Keeper_compaction_wake_registry.create ();
           publication_recovery_provider =
             Masc_test_deps.publication_recovery_provider
               (publication_recovery_registry env sw config);
@@ -1184,6 +1187,7 @@ let test_restart_path_emits_meta_unavailable_outcome_metric () =
           clock = Eio.Stdenv.clock env;
           proc_mgr = Some (Eio.Stdenv.process_mgr env);
           net = Some (Eio.Stdenv.net env);
+          compaction_wake_registry = Keeper_compaction_wake_registry.create ();
           publication_recovery_provider =
             Masc_test_deps.publication_recovery_provider
               (publication_recovery_registry env sw config);
@@ -1260,6 +1264,7 @@ let test_restart_denies_persisted_dead_tombstone () =
         ; clock = Eio.Stdenv.clock env
         ; proc_mgr = Some (Eio.Stdenv.process_mgr env)
         ; net = Some (Eio.Stdenv.net env)
+        ; compaction_wake_registry = Keeper_compaction_wake_registry.create ()
         ; publication_recovery_provider =
             Masc_test_deps.publication_recovery_provider
               (publication_recovery_registry env sw config)
@@ -1330,6 +1335,7 @@ let with_reap_ready_dead_keeper name f =
           ; clock = Eio.Stdenv.clock env
           ; proc_mgr = Some (Eio.Stdenv.process_mgr env)
           ; net = Some (Eio.Stdenv.net env)
+          ; compaction_wake_registry = Keeper_compaction_wake_registry.create ()
           ; publication_recovery_provider =
               Masc_test_deps.publication_recovery_provider
                 (publication_recovery_registry env sw config)
@@ -1429,6 +1435,7 @@ let test_launch_rejected_terminal_state_does_not_announce_running () =
           clock = Eio.Stdenv.clock env;
           proc_mgr = Some (Eio.Stdenv.process_mgr env);
           net = Some (Eio.Stdenv.net env);
+          compaction_wake_registry = Keeper_compaction_wake_registry.create ();
           publication_recovery_provider =
             Masc_test_deps.publication_recovery_provider
               (publication_recovery_registry env sw config);
@@ -1496,6 +1503,7 @@ let test_launch_fork_rejection_does_not_announce_running () =
           clock = Eio.Stdenv.clock env;
           proc_mgr = Some (Eio.Stdenv.process_mgr env);
           net = Some (Eio.Stdenv.net env);
+          compaction_wake_registry = Keeper_compaction_wake_registry.create ();
           publication_recovery_provider =
             Masc_test_deps.publication_recovery_provider
               (publication_recovery_registry env sw config);
@@ -1547,6 +1555,7 @@ let test_fork_rejection_preserves_replacement_lane () =
         ; clock = Eio.Stdenv.clock env
         ; proc_mgr = Some (Eio.Stdenv.process_mgr env)
         ; net = Some (Eio.Stdenv.net env)
+        ; compaction_wake_registry = Keeper_compaction_wake_registry.create ()
         ; publication_recovery_provider =
             Masc_test_deps.publication_recovery_provider
               (publication_recovery_registry env sw config)
@@ -1600,6 +1609,7 @@ let test_fork_rejection_unregisters_non_terminalizable_owner () =
         ; clock = Eio.Stdenv.clock env
         ; proc_mgr = Some (Eio.Stdenv.process_mgr env)
         ; net = Some (Eio.Stdenv.net env)
+        ; compaction_wake_registry = Keeper_compaction_wake_registry.create ()
         ; publication_recovery_provider =
             Masc_test_deps.publication_recovery_provider
               (publication_recovery_registry env sw config)
@@ -1642,6 +1652,7 @@ let test_sweep_waits_for_lane_join_before_unregister () =
         ; clock = Eio.Stdenv.clock env
         ; proc_mgr = Some (Eio.Stdenv.process_mgr env)
         ; net = Some (Eio.Stdenv.net env)
+        ; compaction_wake_registry = Keeper_compaction_wake_registry.create ()
         ; publication_recovery_provider =
             Masc_test_deps.publication_recovery_provider
               (publication_recovery_registry env sw config)
@@ -1719,6 +1730,7 @@ let test_idle_duration_never_stops_keeper () =
           clock = Eio.Stdenv.clock env;
           proc_mgr = Some (Eio.Stdenv.process_mgr env);
           net = Some (Eio.Stdenv.net env);
+          compaction_wake_registry = Keeper_compaction_wake_registry.create ();
           publication_recovery_provider =
             Masc_test_deps.publication_recovery_provider
               (publication_recovery_registry env sw config);
@@ -1779,6 +1791,7 @@ let test_non_storm_crashed_restarts_normally () =
           clock = Eio.Stdenv.clock env;
           proc_mgr = Some (Eio.Stdenv.process_mgr env);
           net = Some (Eio.Stdenv.net env);
+          compaction_wake_registry = Keeper_compaction_wake_registry.create ();
           publication_recovery_provider =
             Masc_test_deps.publication_recovery_provider
               (publication_recovery_registry env sw config);
@@ -1845,6 +1858,7 @@ let test_persisted_blocker_survives_unregister () =
         ; clock = Eio.Stdenv.clock env
         ; proc_mgr = Some (Eio.Stdenv.process_mgr env)
         ; net = Some (Eio.Stdenv.net env)
+        ; compaction_wake_registry = Keeper_compaction_wake_registry.create ()
         ; publication_recovery_provider =
             Masc_test_deps.publication_recovery_provider
               (publication_recovery_registry env sw config)

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -1334,6 +1334,8 @@ let test_keeper_dispatch_ref_reaches_every_keeper_descriptor () =
                ~config
                ~agent_name
                ~publication_recovery_provider:publication_recovery.provider
+               ~compaction_wake_registry:
+                 (Keeper_compaction_wake_registry.create ())
                ~name
                ~args:(`Assoc [])
                ()

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -211,6 +211,7 @@ let test_public_read_rejects_unsupported_range_fields () =
     (fun ~config ~meta ~publication_recovery ~ctx_work ->
       let result =
         KET.execute_keeper_tool_call_with_outcome
+          ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
           ~config
           ~meta
           ~publication_recovery
@@ -256,6 +257,7 @@ let test_public_read_rejects_offset_without_enrichment () =
     (fun ~config ~meta ~publication_recovery ~ctx_work ->
       let result =
         KET.execute_keeper_tool_call_with_outcome
+          ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
           ~config
           ~meta
           ~publication_recovery
@@ -552,6 +554,7 @@ let test_execute_with_outcome_missing_file_is_failure () =
       mkdir_p (Filename.concat repo_dir ".git");
       let result =
         KET.execute_keeper_tool_call_with_outcome
+          ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
           ~config ~meta ~publication_recovery ~ctx_work ~exec_cache:None
           ~name:"Read"
           ~input:(`Assoc [ ("file_path", `String "config/runtime.toml") ])
@@ -690,6 +693,7 @@ let test_initializing_recovery_isolates_only_publication_writes () =
        write_file existing_path untouched;
        let execute ~name ~input =
          KET.execute_keeper_tool_call_with_outcome
+           ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
            ~config
            ~meta
            ~publication_recovery
@@ -830,6 +834,7 @@ let test_manual_gate_defers_publication_writes_before_recovery () =
        write_file path original;
        let execute ~name ~input =
          KET.execute_keeper_tool_call_with_outcome
+           ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
            ~config
            ~meta
            ~publication_recovery
@@ -902,6 +907,7 @@ let test_manual_gate_deferral_stays_deferred_through_oas_bridge () =
        in
        let handler =
          Masc.Keeper_tools_oas_handler.make_keeper_tool_handler
+           ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
            ~name:"Write"
            ~input_schema
            ~config
@@ -967,6 +973,7 @@ let test_publication_initialization_crash_is_redacted () =
        let path = Filename.concat config.base_path "crash-must-not-write.txt" in
        let result =
          KET.execute_keeper_tool_call_with_outcome
+           ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
            ~config
            ~meta
            ~publication_recovery
@@ -1098,6 +1105,7 @@ let test_publication_reconciliation_evidence_is_redacted () =
        let target = Filename.concat config.base_path "must-not-write.txt" in
        let result =
          KET.execute_keeper_tool_call_with_outcome
+           ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
            ~config
            ~meta
            ~publication_recovery
@@ -1161,6 +1169,7 @@ let test_publication_registry_evidence_is_redacted () =
        let target = Filename.concat config.base_path "registry-must-not-write.txt" in
        let result =
          KET.execute_keeper_tool_call_with_outcome
+           ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
            ~config
            ~meta
            ~publication_recovery
@@ -1211,6 +1220,7 @@ let test_publication_write_rereads_live_provider_after_initialization () =
        let path = Filename.concat config.base_path "after-initialization.txt" in
        let execute () =
          KET.execute_keeper_tool_call_with_outcome
+           ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
            ~config
            ~meta
            ~publication_recovery
@@ -1238,6 +1248,7 @@ let test_publication_write_rereads_live_provider_after_initialization () =
          (Atomic.get provider_reads);
        let edit =
          KET.execute_keeper_tool_call_with_outcome
+           ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
            ~config
            ~meta
            ~publication_recovery
@@ -1418,6 +1429,7 @@ let test_real_publication_release_failure_preserves_effect_truth () =
        let target = Filename.concat config.base_path "release-effect.txt" in
        let execute_at target content =
          KET.execute_keeper_tool_call_with_outcome
+           ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
            ~config
            ~meta
            ~publication_recovery
@@ -1686,6 +1698,7 @@ let test_real_directory_release_failure_preserves_effect_truth () =
        in
        let execute target content =
          KET.execute_keeper_tool_call_with_outcome
+           ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
            ~config
            ~meta
            ~publication_recovery
@@ -1827,6 +1840,7 @@ let test_tool_search_without_session_searcher_is_unavailable () =
     (fun ~config ~meta ~publication_recovery ~ctx_work ->
       let result =
         KET.execute_keeper_tool_call_with_outcome
+          ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
           ~config ~meta ~publication_recovery ~ctx_work ~exec_cache:None
           ~name:"keeper_tool_search"
           ~input:(`Assoc [])
@@ -1856,6 +1870,7 @@ let test_tool_search_uses_exact_injected_searcher () =
       in
       let result =
         KET.execute_keeper_tool_call_with_outcome
+          ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
           ~config ~meta ~publication_recovery ~ctx_work ~exec_cache:None ~search_fn
           ~name:"keeper_tool_search"
           ~input:(`Assoc [])
@@ -1879,6 +1894,7 @@ let test_model_visible_local_tools_dispatch_to_runtime_handlers () =
       let file_path = Filename.concat playground visible_file_path in
       let run name input =
         KET.execute_keeper_tool_call_with_outcome
+          ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
           ~config
           ~meta
           ~publication_recovery
@@ -1958,6 +1974,7 @@ let test_keeper_task_claim_accepts_specific_task_id () =
            ~description:"must be claimed by explicit task_id");
       let result =
         KET.execute_keeper_tool_call_with_outcome
+          ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
           ~config
           ~meta
           ~publication_recovery
@@ -1996,6 +2013,7 @@ let test_unknown_tool_returns_exact_error () =
     (fun ~config ~meta ~publication_recovery ~ctx_work ->
       let result =
         KET.execute_keeper_tool_call_with_outcome
+          ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
           ~config
           ~meta
           ~publication_recovery
@@ -2034,6 +2052,7 @@ let test_model_visible_web_search_dispatches_to_misc_runtime () =
         (fun () ->
           let result =
             KET.execute_keeper_tool_call_with_outcome
+              ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
               ~config
               ~meta
               ~publication_recovery
@@ -2103,6 +2122,7 @@ let test_model_visible_web_fetch_dispatches_to_misc_runtime () =
         (fun () ->
           let result =
             KET.execute_keeper_tool_call_with_outcome
+              ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
               ~config
               ~meta
               ~publication_recovery
@@ -2157,6 +2177,7 @@ let test_public_masc_web_fetch_reaches_localhost_after_gate () =
         (fun () ->
           let result =
             KET.execute_keeper_tool_call_with_outcome
+              ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
               ~config
               ~meta
               ~publication_recovery
@@ -2195,6 +2216,7 @@ let test_manual_gate_defers_web_tools_before_network () =
             (fun () ->
               let search =
                 KET.execute_keeper_tool_call_with_outcome
+                  ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
                   ~config
                   ~meta
                   ~publication_recovery
@@ -2206,6 +2228,7 @@ let test_manual_gate_defers_web_tools_before_network () =
               in
               let fetch =
                 KET.execute_keeper_tool_call_with_outcome
+                  ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
                   ~config
                   ~meta
                   ~publication_recovery
@@ -2260,6 +2283,7 @@ let test_manual_gate_defers_tool_execute_before_process () =
       let marker = Filename.concat config.base_path "must-not-execute" in
       let result =
         KET.execute_keeper_tool_call_with_outcome
+          ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
           ~config
           ~meta
           ~publication_recovery
@@ -2296,6 +2320,7 @@ let test_tool_execute_raw_cmd_requires_typed_shell_ir () =
       in
       let run () =
         KET.execute_keeper_tool_call
+          ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
           ~config ~meta ~publication_recovery ~ctx_work ~exec_cache:None
           ~name:"tool_execute" ~input ()
       in
@@ -2358,6 +2383,10 @@ let test_oas_handler_threads_eio_context_to_keeper_dispatch () =
       let saw_turn_sw = Atomic.make false in
       let saw_clock = Atomic.make false in
       let saw_provider = Atomic.make false in
+      let compaction_wake_registry =
+        Keeper_compaction_wake_registry.create ()
+      in
+      let saw_compaction_wake_registry = Atomic.make false in
       let delegated_data =
         `Assoc [ "run_ref", `Assoc [ "run_id", `String "test-run" ] ]
       in
@@ -2369,6 +2398,7 @@ let test_oas_handler_threads_eio_context_to_keeper_dispatch () =
           Masc.Keeper_dispatch_ref.dispatch :=
             (fun ~config:_ ~agent_name:_
                  ~publication_recovery_provider:observed_provider
+                 ~compaction_wake_registry:observed_compaction_wake_registry
                  ?sw ?clock ?proc_mgr:_ ?net:_ ?mcp_session_id:_
                  ?authorize_external_effect:_
                  ~name ~args:_ () ->
@@ -2378,6 +2408,8 @@ let test_oas_handler_threads_eio_context_to_keeper_dispatch () =
               Atomic.set saw_clock (Option.is_some clock);
               Atomic.set saw_provider
                 (observed_provider == publication_recovery.provider);
+              Atomic.set saw_compaction_wake_registry
+                (observed_compaction_wake_registry == compaction_wake_registry);
               Some
                 (Tool_result.make_ok
                    ~tool_name:name
@@ -2386,6 +2418,7 @@ let test_oas_handler_threads_eio_context_to_keeper_dispatch () =
                    ()));
           let handler =
             Masc.Keeper_tools_oas_handler.make_keeper_tool_handler
+              ~compaction_wake_registry
               ~name:"masc_keeper_delegate"
               ~input_schema:(keeper_delegate_input_schema ())
               ~config
@@ -2416,7 +2449,9 @@ let test_oas_handler_threads_eio_context_to_keeper_dispatch () =
           check bool "turn switch reaches keeper dispatch" true (Atomic.get saw_turn_sw);
           check bool "clock reaches keeper dispatch" true (Atomic.get saw_clock);
           check bool "live provider reaches keeper dispatch" true
-            (Atomic.get saw_provider))))
+            (Atomic.get saw_provider);
+          check bool "compaction wake registry identity reaches keeper dispatch" true
+            (Atomic.get saw_compaction_wake_registry))))
 
 let registered_dispatch_probe_tool = "test_keeper_registered_dispatch_probe"
 
@@ -2474,6 +2509,7 @@ let execute_registered_probe ~fixture ~name ~make_result =
   with_exec_fixture fixture
     (fun ~config ~meta ~publication_recovery ~ctx_work ->
     KET.execute_keeper_tool_call_with_outcome
+      ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
       ~config
       ~meta
       ~publication_recovery
@@ -2678,6 +2714,7 @@ let test_model_visible_tools_do_not_infer_oas_descriptors () =
     (fun ~config ~meta ~publication_recovery ~ctx_work:_ ->
        let tools =
          Masc.Keeper_tools_oas_bundle.make_tools
+           ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
            ~config
            ~meta
            ~publication_recovery

--- a/test/test_keeper_tool_matrix.ml
+++ b/test/test_keeper_tool_matrix.ml
@@ -389,6 +389,7 @@ let test_keeper_oas_bundle_materializes_masc_fusion_tool () =
       in
       let tools =
         Masc.Keeper_tools_oas_bundle.make_tools
+          ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
           ~config ~meta ~publication_recovery ~ctx_snapshot ()
       in
       let names =

--- a/test/test_keeper_tool_matrix_cases.ml
+++ b/test/test_keeper_tool_matrix_cases.ml
@@ -185,6 +185,7 @@ let make_fixture
   ignore (Masc.Keeper_registry.register ~base_path "tool-matrix" meta);
   let tools =
     KTO.make_tools
+      ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
       ~config
       ~meta
       ~publication_recovery

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -215,6 +215,7 @@ let test_snapshot_prefers_metrics_context_truth_over_usage_counters () =
           clock = Eio.Stdenv.clock env;
           proc_mgr = Some (Eio.Stdenv.process_mgr env);
           net = None;
+          compaction_wake_registry = Keeper_compaction_wake_registry.create ();
           publication_recovery_provider =
             Masc_test_deps.publication_recovery_provider
               (publication_recovery_registry env sw config);
@@ -373,6 +374,7 @@ let test_keeper_up_clears_dead_tombstone_resume_state () =
       clock = Eio.Stdenv.clock env;
       proc_mgr = Some (Eio.Stdenv.process_mgr env);
       net = None;
+      compaction_wake_registry = Keeper_compaction_wake_registry.create ();
       publication_recovery_provider =
         Masc_test_deps.publication_recovery_provider
           (publication_recovery_registry env sw config);
@@ -772,6 +774,7 @@ let test_dead_revival_launch_failure_rolls_back_both_authorities () =
         ; clock = Eio.Stdenv.clock env
         ; proc_mgr = Some (Eio.Stdenv.process_mgr env)
         ; net = None
+        ; compaction_wake_registry = Keeper_compaction_wake_registry.create ()
         ; publication_recovery_provider =
             Masc_test_deps.publication_recovery_provider
               (publication_recovery_registry env sw config)
@@ -975,6 +978,7 @@ let test_digest_workspace_includes_keeper_runtime_attention () =
           clock = Eio.Stdenv.clock env;
           proc_mgr = Some (Eio.Stdenv.process_mgr env);
           net = None;
+          compaction_wake_registry = Keeper_compaction_wake_registry.create ();
           publication_recovery_provider =
             Masc_test_deps.publication_recovery_provider
               (publication_recovery_registry env sw config);
@@ -1084,6 +1088,7 @@ let test_lightweight_snapshot_preserves_receipt_latest_causal_event () =
           clock = Eio.Stdenv.clock env;
           proc_mgr = Some (Eio.Stdenv.process_mgr env);
           net = None;
+          compaction_wake_registry = Keeper_compaction_wake_registry.create ();
           publication_recovery_provider =
             Masc_test_deps.publication_recovery_provider
               (publication_recovery_registry env sw config);
@@ -1359,6 +1364,7 @@ let test_snapshot_lightweight_summary_keeps_tool_audit () =
           clock = Eio.Stdenv.clock env;
           proc_mgr = Some (Eio.Stdenv.process_mgr env);
           net = None;
+          compaction_wake_registry = Keeper_compaction_wake_registry.create ();
           publication_recovery_provider =
             Masc_test_deps.publication_recovery_provider
               (publication_recovery_registry env sw config);
@@ -1473,6 +1479,7 @@ let test_snapshot_lightweight_summary_keeps_recent_tools_distinct_from_latest ()
           clock = Eio.Stdenv.clock env;
           proc_mgr = Some (Eio.Stdenv.process_mgr env);
           net = None;
+          compaction_wake_registry = Keeper_compaction_wake_registry.create ();
           publication_recovery_provider =
             Masc_test_deps.publication_recovery_provider
               (publication_recovery_registry env sw config);

--- a/test/test_operator_control_support.ml
+++ b/test/test_operator_control_support.ml
@@ -71,6 +71,7 @@ let operator_ctx ?mcp_session_id env sw config agent_name :
     delegated_dispatch =
       Some
         (Masc.Keeper_tool_boundary.delegated_dispatch
+           ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
            ~config
            ~agent_name
            ~sw

--- a/test/test_warn_root_causes.ml
+++ b/test/test_warn_root_causes.ml
@@ -97,6 +97,7 @@ let test_web_alias_bundle_visible_without_injected_masc_schema () =
       in
       let bundle =
         Keeper_tools_oas_bundle.make_tool_bundle
+          ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
           ~config ~meta ~publication_recovery ~ctx_snapshot ()
       in
       Fun.protect
@@ -149,6 +150,7 @@ let test_fusion_default_descriptor_is_bundle_visible () =
       in
       let bundle =
         Keeper_tools_oas_bundle.make_tool_bundle
+          ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
           ~config ~meta ~publication_recovery ~ctx_snapshot ()
       in
       Fun.protect
@@ -186,6 +188,7 @@ let test_bundle_exactly_matches_model_visible_descriptors () =
       in
       let bundle =
         Keeper_tools_oas_bundle.make_tool_bundle
+          ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
           ~config ~meta ~publication_recovery ~ctx_snapshot ()
       in
       Fun.protect
@@ -245,6 +248,7 @@ let test_missing_current_task_reconciled_before_transition_hint () =
       in
       let bundle =
         Keeper_tools_oas_bundle.make_tool_bundle
+          ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
           ~config ~meta ~publication_recovery ~ctx_snapshot ()
       in
       Fun.protect
@@ -292,6 +296,7 @@ let test_tool_bundle_does_not_emit_full_universe_assignment () =
       in
       let bundle =
         Keeper_tools_oas_bundle.make_tool_bundle
+          ~compaction_wake_registry:(Keeper_compaction_wake_registry.create ())
           ~config ~meta ~publication_recovery ~ctx_snapshot ()
       in
       Fun.protect


### PR DESCRIPTION
## Stack

- Base: #24945
- This leaf makes that process-owned registry a required Keeper runtime resource.

## What changed

- add required `compaction_wake_registry` to Keeper runtime/tool contexts
- thread the exact `Mcp_server.keeper_compaction_wake_registry state` handle through heartbeat, direct turns, gates, delegated/self tools, and OAS tool handlers
- preserve the same handle through context projection and record updates
- keep test fixtures explicit and isolated with independent registries
- assert physical handle identity across the OAS handler -> `Keeper_dispatch_ref` boundary

## Invariants

- no optional/default/global registry fallback
- no compaction body, lane actor, wake call, or gate-decision behavior change
- production creates registries only at `Mcp_server.server_state` construction
- 239 changed lines total

## Verification

- `scripts/dune-local.sh build lib/masc.cmxa`
- focused build of 18 affected test executables
- `test_keeper_tool_dispatch_runtime`: OAS handler Eio/context identity case green
- `test_keeper_gate_effect_coverage`: 7/7 green
- `test_keeper_lifecycle_registry_dispatch`: 13/13 green
- `git diff --check`
