### PR TITLE
refactor(keeper): extract chat delivery identity leaf

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -103,6 +103,7 @@
   masc.keeper_usage_trust
   masc.keeper_event_bus
   masc.keeper_compaction_evidence
+  masc.keeper_chat_delivery_identity
   ;; Runtime_provider_labels extracted to lib/runtime_provider_labels/.
   ;; Leaf boundary over agent_sdk.llm_provider canonical provider labels.
   masc.runtime_provider_labels

--- a/lib/keeper_chat_delivery_identity/dune
+++ b/lib/keeper_chat_delivery_identity/dune
@@ -1,0 +1,8 @@
+(include_subdirs no)
+
+(library
+ (name masc_keeper_chat_delivery_identity)
+ (public_name masc.keeper_chat_delivery_identity)
+ (wrapped false)
+ (modules keeper_chat_delivery_identity)
+ (libraries digestif masc.masc_types masc_random_id threads uuidm yojson))

--- a/lib/keeper_chat_delivery_identity/keeper_chat_delivery_identity.ml
+++ b/lib/keeper_chat_delivery_identity/keeper_chat_delivery_identity.ml
@@ -1,3 +1,4 @@
+(** Exact identities shared by Keeper delivery producers and consumers. *)
 module Request_id = struct
   type t = string
 

--- a/lib/keeper_chat_delivery_identity/keeper_chat_delivery_identity.mli
+++ b/lib/keeper_chat_delivery_identity/keeper_chat_delivery_identity.mli
@@ -1,4 +1,4 @@
-(** Typed identity shared by direct Keeper chat requests, queued receipts,
+(** Typed immutable identity shared by direct Keeper chat requests, queued receipts,
     durable delivery journals, and transcript idempotency slots. *)
 
 module Request_id : sig

--- a/lib/server/dune
+++ b/lib/server/dune
@@ -82,6 +82,7 @@
   masc.keeper_metrics
   masc.keeper_types
   masc.keeper_runtime
+  masc.keeper_chat_delivery_identity
   masc.keeper_failure_taxonomy
   masc.keeper_toml
   masc.runtime_provider_labels

--- a/test/dune
+++ b/test/dune
@@ -661,7 +661,9 @@
   test_keeper_wire_capture
   test_board_rest_routes
   test_board_context_inference_resolution)
- (libraries masc_test_deps masc_schedule multimodal bigstringaf))
+ (libraries
+  masc_test_deps masc.keeper_chat_delivery_identity masc_schedule multimodal
+  bigstringaf))
 
 ; Request-authority admission uses Eio fiber-local bindings and therefore owns
 ; an explicit executable stanza instead of borrowing the pure synchronous test

--- a/test/test_keeper_chat_delivery_identity.ml
+++ b/test/test_keeper_chat_delivery_identity.ml
@@ -1,6 +1,6 @@
 open Alcotest
 
-module Identity = Masc.Keeper_chat_delivery_identity
+module Identity = Keeper_chat_delivery_identity
 
 let expect_ok = function
   | Ok value -> value


### PR DESCRIPTION
## Outcome

- move the existing Keeper chat delivery identity SSOT into a wrapped-false leaf
  library
- keep direct-request, queue-receipt, transcript-slot, codec, and digest
  semantics unchanged
- make the same typed delivery identity reusable by lower operation libraries
  without duplicating request or receipt types

## Production path

Connector/direct request, durable queue receipt, chat store, and transcript
continue to consume the same type. This is a structural leaf extraction, not a
new identity authority.

## Boundary

This PR adds no producer kind, gate, heuristic, timeout, or runtime behavior. It
is an independent `main` root; it is not stacked on the closed, unmerged #24943.

## Focused verification

- `scripts/dune-local.sh build lib/masc.cma test/test_keeper_chat_delivery_identity.exe`
- `test_keeper_chat_delivery_identity.exe`: 4 focused tests passed at the
  reviewed implementation
- `ocamlformat --check`
- `git diff --check`

Reviewed implementation: `e53bf6ee4656d3540da6d98edc1be0f9050fc434`.
