### PR TITLE
docs(keeper): replace removed message tool names

### DIFF
--- a/docs/KEEPER-CAPABILITY-MATRIX.md
+++ b/docs/KEEPER-CAPABILITY-MATRIX.md
@@ -69,9 +69,9 @@ Important families:
 - scheduled automation: `masc_schedule_create`, `masc_schedule_list`,
   `masc_schedule_get`, `masc_schedule_cancel`, `masc_schedule_approve`,
   `masc_schedule_reject`
-- keeper management/messaging: `masc_keeper_list`, `masc_keeper_status`,
-  `masc_keeper_msg`, `masc_keeper_msg_result`, `masc_keeper_msg_queue`,
-  `masc_keeper_msg_cancel`
+- keeper management/delegation: `masc_keeper_list`, `masc_keeper_status`,
+  `masc_keeper_delegate`, `masc_keeper_delegate_status`,
+  `masc_keeper_delegate_list`, `masc_keeper_delegate_cancel`
 - operator/maintenance keeper controls: broader descriptors such as
   `masc_keeper_compact`, `masc_keeper_clear`, `masc_keeper_sandbox_start`,
   `masc_keeper_sandbox_stop`, `masc_keeper_reset`,
@@ -100,7 +100,7 @@ Excluded from keeper exposure:
 | Past decisions or shared references | memory and library tools | Writing scratch notes to durable memory |
 | Workspace planning, goal lifecycle, run logs, notes, deliverables | `masc_goal_*`, `masc_plan_*`, `masc_run_*`, `masc_note_add`, `masc_deliver` | Mutating goals/plans for ordinary status narration |
 | Durable future automation | `masc_schedule_*` | Assuming side-effecting schedules run without human approval |
-| Targeted async help from another keeper | `masc_keeper_list`, `masc_keeper_status`, `masc_keeper_msg`, result/queue/cancel tools | Broadcasting a private question, or messaging an unknown keeper without status/list evidence |
+| Targeted async help from another keeper | `masc_keeper_list`, `masc_keeper_status`, `masc_keeper_delegate`, status/list/cancel tools | Broadcasting a private question, or delegating to an unknown keeper without status/list evidence |
 | High-impact ambiguous decision needing independent perspectives | `masc_fusion` with self-contained context | Replacing cheap code inspection, exact status evidence, or blocker reporting |
 | Stored image artifact analysis | `analyze_image` | Treating visible chat attachments as hidden sandbox files |
 
@@ -110,7 +110,7 @@ Keeper continuity is a bounded advanced capability, not a general memory promise
 
 If productized, the continuity promise is:
 
-- `masc_keeper_msg` can continue a same-trace conversation when checkpoint restore is healthy
+- `masc_keeper_delegate` can continue a same-trace conversation when checkpoint restore is healthy
 - `masc_keeper_status` and `masc_keeper_list(detailed=true)` expose enough continuity state to diagnose restore and handoff behavior
 - validation should rely on OAS checkpoint truth plus live runtime evidence
 
@@ -151,7 +151,7 @@ BoardActivity, IdleTimeout, MetricsAnomaly, StrategicReview.
 | 목표 / 계획 lifecycle | `masc_goal_list`, `masc_goal_upsert`, `masc_goal_transition` |
 | 계획/런/산출물 기록 | `masc_plan_get`, `masc_plan_init`, `masc_plan_update`, `masc_plan_set_task`, `masc_plan_get_task`, `masc_plan_clear_task`, `masc_run_init`, `masc_run_list`, `masc_run_get`, `masc_run_plan`, `masc_note_add`, `masc_deliver` |
 | 예약 자동화 | `masc_schedule_create`, `masc_schedule_list`, `masc_schedule_get`, `masc_schedule_cancel`, `masc_schedule_approve`, `masc_schedule_reject` |
-| 다른 keeper 상태/메시지 | `masc_keeper_list`, `masc_keeper_status`, `masc_keeper_msg`, `masc_keeper_msg_result`, `masc_keeper_msg_queue`, `masc_keeper_msg_cancel` |
+| 다른 keeper 상태/위임 | `masc_keeper_list`, `masc_keeper_status`, `masc_keeper_delegate`, `masc_keeper_delegate_status`, `masc_keeper_delegate_list`, `masc_keeper_delegate_cancel` |
 | 패널 심의 / 비동기 판단 보강 | `masc_fusion`, `masc_fusion_status` |
 | 저장 이미지 artifact 분석 | `analyze_image` |
 | 코드 작성 / 수정 | `Read` / `Grep` -> `Edit` / `Write`, then `Execute` with typed `git` argv |

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -210,7 +210,7 @@ masc_claim_next()
 
 - repo workspace collaboration: `masc_start`, `masc_status`, `masc_transition`, `masc_plan_set_task`, `masc_heartbeat`
 - keeper runtime front door: `masc_keeper_list`, `masc_keeper_status`, `masc_keeper_up`, `masc_keeper_down`
-- keeper async turn injection: `masc_keeper_msg` (advanced/callable, hidden from default `tools/list`)
+- keeper async invocation: `masc_keeper_delegate` (advanced/callable, hidden from default `tools/list`)
 
 retired orchestration surfaces are historical only. 새 사용자는 repo workspace collaboration과 keeper runtime에서 시작하고, read visibility가 필요할 때만 dashboard/operator surface로 내려간다.
 

--- a/docs/spec/01-system-overview.md
+++ b/docs/spec/01-system-overview.md
@@ -148,7 +148,7 @@ MASC의 현재 canonical front door는 3가지다.
 장기 실행과 연속성을 위한 경로.
 
 - **대상**: keeper lifecycle, long-running execution, OAS-backed autonomy
-- **핵심 도구**: `masc_keeper_up`, `masc_keeper_msg`, `masc_keeper_status`, `masc_keeper_down`
+- **핵심 도구**: `masc_keeper_up`, `masc_keeper_delegate`, `masc_keeper_status`, `masc_keeper_down`
 - **설명**: keeper는 OAS `Agent.run` 기반으로 실행되며, retired orchestration surfaces와 독립적으로 동작한다. 자세한 turn lifecycle은 [`04-turn-lifecycle.md`](./04-turn-lifecycle.md)를 참조.
 
 ### 7.3 Dashboard and Operator Read Visibility


### PR DESCRIPTION
## Summary

- update keeper capability and quick-start documentation to the current board/surface tool names
- keep the documentation correction separate from the exact MCP invocation identity implementation

## Stack

- base: #24957 (`agent/tool-invocation-identity-core-split-20260717`)
- this leaf: 8 additions + 8 deletions = 16 changed lines across 3 documentation files
- combined tree is exactly identical to preserved Draft PR #24903 head

## Verification

- core base #24957 completed the focused OCaml wrapper build and 77 focused test cases
- this leaf changes documentation only
- `git diff --exit-code a5d577d835fe767a4bd7d2760263c5169f1e0b89 HEAD`
- final tree hash equals #24903 head: `ab3f3da7fb31f28caf742cacfb5be342a198f43b`
