### PR TITLE
fix(keeper): preserve active lease on registration

### DIFF
--- a/lib/keeper/keeper_registry_setup.ml
+++ b/lib/keeper/keeper_registry_setup.ml
@@ -456,11 +456,9 @@ let register_with_state_result
   let done_p, done_r = Eio.Promise.create () in
   let key = registry_key ~base_path name in
   match
-    Keeper_event_queue_persistence.prepare_registration_result
+    Keeper_event_queue_persistence.load_pending_result
       ~base_path
       ~keeper_name:name
-      ~settled_at:(Time_compat.now ())
-      ()
   with
   | Error detail -> Error (Registration_event_queue_unavailable { keeper_name = name; detail })
   | Ok initial_event_queue ->
@@ -663,11 +661,9 @@ let register_restarting ~base_path name meta
      queue snapshot instead of being reset across restart. *)
   let done_p, done_r = Eio.Promise.create () in
   match
-    Keeper_event_queue_persistence.prepare_registration_result
+    Keeper_event_queue_persistence.load_pending_result
       ~base_path
       ~keeper_name:name
-      ~settled_at:(Time_compat.now ())
-      ()
   with
   | Error detail -> Error (Restart_event_queue_unavailable { keeper_name = name; detail })
   | Ok initial_event_queue ->

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -648,19 +648,6 @@ let resume_parked_result
     |> Result.map_error State.parking_error_to_string)
 ;;
 
-let prepare_registration_result
-      ?(after_commit = fun _ -> ())
-      ~base_path
-      ~keeper_name
-      ~settled_at
-      ()
-  =
-  commit_transform ~base_path ~keeper_name ~after_commit (fun state ->
-    match State.recover_leases ~settled_at state with
-    | Error _ as error -> error
-    | Ok state -> Ok (state, State.pending state))
-;;
-
 let mark_transition_projected_result ~base_path ~keeper_name ~transition_id =
   commit_transform
     ~base_path

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -73,9 +73,10 @@ val parked_entries_result :
 
 val load : base_path:string -> keeper_name:string -> Keeper_event_queue.t
 (** Compatibility replay projection: pending followed by active lease stimuli.
-    New live registry code should use {!load_pending} after explicitly
-    recovering abandoned leases at registration. Raises [Failure] when the
-    durable state is unavailable; it never substitutes an empty queue. *)
+    New live registry code should use {!load_pending_result}; an active lease is
+    resumed through {!active_lease_result} without changing its identity.
+    Raises [Failure] when the durable state is unavailable; it never substitutes
+    an empty queue. *)
 
 val load_result :
   base_path:string -> keeper_name:string -> (Keeper_event_queue.t, string) result
@@ -171,18 +172,6 @@ val resume_parked_result :
   operation_id:Keeper_compaction_operation_identity.Operation_id.t ->
   unit ->
   (resume_result, string) result
-
-val prepare_registration_result :
-  ?after_commit:(Keeper_event_queue.t -> unit) ->
-  base_path:string ->
-  keeper_name:string ->
-  settled_at:float ->
-  unit ->
-  (Keeper_event_queue.t, string) result
-(** Registration boundary for a newly-owned lane. Requeues an abandoned lease,
-    records its stable [Registration_recovery] transition, and returns the
-    resulting pending projection from the same durable transaction. A malformed
-    state is an [Error]; registration must not substitute an empty queue. *)
 
 val mark_transition_projected_result :
   base_path:string ->

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -1051,14 +1051,14 @@ let test_transition_outbox_projects_with_stable_identity () =
     |> require_ok "empty outbox projection is idempotent")
 ;;
 
-let test_registration_preparation_is_atomic_and_fail_closed () =
+let test_registration_preserves_active_lease_and_fails_closed () =
   with_temp_dir "keeper-event-queue-v2-registration" (fun base_path ->
     let keeper_name = "registration_keeper" in
-    let source = stimulus "abandoned" 1.0 in
+    let source = stimulus "active" 1.0 in
     Persistence.update_result ~base_path ~keeper_name (fun pending ->
       Queue.enqueue pending source)
     |> require_ok "seed registration source";
-    ignore
+    let claimed =
       (Persistence.claim_when_result
          ~base_path
          ~keeper_name
@@ -1066,48 +1066,62 @@ let test_registration_preparation_is_atomic_and_fail_closed () =
          ~ready:(fun _ -> true)
          ()
        |> require_ok "claim registration source"
-       |> require_some "registration lease");
+       |> require_some "registration lease")
+    in
+    let before =
+      Persistence.load_state_result ~base_path ~keeper_name
+      |> require_ok "load state before registration"
+    in
     let pending =
-      Persistence.prepare_registration_result
+      Persistence.load_pending_result
         ~base_path
         ~keeper_name
-        ~settled_at:3.0
-        ()
-      |> require_ok "prepare registration"
+      |> require_ok "load registration pending projection"
     in
     Alcotest.(check (list string))
-      "abandoned lease returned to pending"
-      [ "abandoned" ]
+      "active lease is not duplicated into pending"
+      []
       (post_ids pending);
     let prepared =
       Persistence.load_state_result ~base_path ~keeper_name
-      |> require_ok "load prepared registration state"
+      |> require_ok "load registration state"
     in
-    Alcotest.(check int) "registration leaves no active lease" 0 (List.length (State.leases prepared));
+    (match State.leases prepared with
+     | [ active ] ->
+       Alcotest.(check (testable Yojson.Safe.pp Yojson.Safe.equal))
+         "registration preserves the exact lease"
+         (State.lease_to_yojson claimed)
+         (State.lease_to_yojson active)
+     | _ -> Alcotest.fail "registration changed the active lease cardinality");
     Alcotest.(check int)
-      "registration records one recovery transition"
-      1
+      "registration synthesizes no recovery transition"
+      0
       (List.length (State.transition_outbox prepared));
-    let prepared_revision = State.revision prepared in
+    Alcotest.(check int64)
+      "registration is read-only"
+      (State.revision before)
+      (State.revision prepared);
+    Alcotest.(check (testable Yojson.Safe.pp Yojson.Safe.equal))
+      "registration leaves durable state unchanged"
+      (State.to_yojson before)
+      (State.to_yojson prepared);
     ignore
-      (Persistence.prepare_registration_result
+      (Persistence.load_pending_result
          ~base_path
          ~keeper_name
-         ~settled_at:4.0
-         ()
-       |> require_ok "repeat prepared registration");
+       |> require_ok "repeat registration projection");
     let repeated =
       Persistence.load_state_result ~base_path ~keeper_name
       |> require_ok "load repeated registration state"
     in
     Alcotest.(check int64)
-      "repeat registration does not synthesize a transition"
-      prepared_revision
+      "repeat registration remains read-only"
+      (State.revision before)
       (State.revision repeated);
     Alcotest.(check int)
-      "repeat registration retains one recovery transition"
+      "repeat registration preserves active lease"
       1
-      (List.length (State.transition_outbox repeated));
+      (List.length (State.leases repeated));
 
     let malformed_keeper = "malformed_registration_keeper" in
     let malformed_path =
@@ -1119,11 +1133,9 @@ let test_registration_preparation_is_atomic_and_fail_closed () =
     Fs_compat.save_file_atomic malformed_path "{}"
     |> require_ok "write malformed registration state";
     (match
-       Persistence.prepare_registration_result
+       Persistence.load_pending_result
          ~base_path
          ~keeper_name:malformed_keeper
-         ~settled_at:5.0
-         ()
      with
      | Error _ -> ()
      | Ok _ -> Alcotest.fail "malformed registration state became an empty queue"))
@@ -1208,9 +1220,9 @@ let () =
             `Quick
             test_transition_outbox_projects_with_stable_identity
         ; Alcotest.test_case
-            "registration preparation"
+            "registration preserves active lease"
             `Quick
-            test_registration_preparation_is_atomic_and_fail_closed
+            test_registration_preserves_active_lease_and_fails_closed
         ; Alcotest.test_case
             "lane write fault isolation"
             `Quick


### PR DESCRIPTION
## Outcome

Keeper registration and restart no longer mutate every durable active lease into a synthetic `Registration_recovery` requeue.

- registration reads only the pending projection
- the exact active lease sequence, kind, payload, and claim time remain durable
- heartbeat intake resumes that same lease before claiming new work
- no recovery transition or duplicate pending stimulus is synthesized
- malformed durable state still fails the Keeper-local registration explicitly

This closes the crash window where a committed compaction `Requested` fact could lose its exact source lease before the lane actor parks it. Unrelated Keeper lanes remain independent.

## Boundary

No policy, timeout, budget, risk level, semantic matching, or cross-Keeper coordinator is added. The change deletes a registration-time mutation and reuses the existing strict pending read plus exact active-lease resume path.

## Verification

- focused build: `lib/masc.cma` and `test_keeper_event_queue_state_v2.exe`
- event queue state/persistence: 15/15
- registration test compares the complete durable state and exact lease JSON before/after
- ocamlformat check: green
- diff check: green
- 46 additions / 62 deletions
