### PR TITLE
refactor(fusion): remove provider panel cap

### DIFF
--- a/lib/fusion_core/fusion_config.ml
+++ b/lib/fusion_core/fusion_config.ml
@@ -3,7 +3,7 @@
 
 type config_error =
   | Empty_presets
-  | Invalid_panel_size of string * int
+  | No_panel_models of string
   | Empty_panels of string
   | Conflicting_panel_grammar of string
   | Duplicate_panelist of string * string
@@ -110,7 +110,7 @@ let finish_preset name tbl (panels : Fusion_policy.panel_group list)
     | Error invalid ->
       Error
         (match invalid with
-         | Fusion_policy.Validated_preset.Bad_size n -> Invalid_panel_size (name, n)
+         | Fusion_policy.Validated_preset.No_panel_models -> No_panel_models name
          | Fusion_policy.Validated_preset.Missing_prompt -> Missing_prompt name
          | Fusion_policy.Validated_preset.Missing_judge_model -> Missing_judge_model name
          | Fusion_policy.Validated_preset.Duplicate_panelist id ->
@@ -131,8 +131,8 @@ let finish_preset name tbl (panels : Fusion_policy.panel_group list)
      단일 그룹이면 오늘과 byte-identical).
    둘 다 있으면 Conflicting_panel_grammar, panels=[](그룹 0개)면 Empty_panels로 명시적
    거부 (silent 한쪽 선택 금지). 빈 panel=[](모델 0개)은 legacy 길이-1 그룹으로 desugar
-   되어 size 검증에서 Invalid_panel_size(_, 0)으로 잡힌다 — "그룹 0개"(Empty_panels)와
-   "모델 0개"(Invalid_panel_size)는 다른 조건이므로 다른 variant로 구분한다.
+   되어 model-presence 검증에서 No_panel_models로 잡힌다 — "그룹 0개"(Empty_panels)와
+   "모델 0개"(No_panel_models)는 다른 조건이므로 다른 variant로 구분한다.
    panels가 스칼라 등 malformed면 get_array가 Type_error를 내고, find_opt/find_or는
    Key_error만 삼키고 Type_error는 전파하므로(otoml_base.ml:332-337) of_toml의
    Type_error 핸들러가 Toml_type_error로 fail-fast한다. 여기서 find_opt는 panels/panel

--- a/lib/fusion_core/fusion_config.mli
+++ b/lib/fusion_core/fusion_config.mli
@@ -9,10 +9,10 @@
 (** config 파싱/검증 에러 — 닫힌 합. *)
 type config_error =
   | Empty_presets  (** enabled=true인데 preset 0개 *)
-  | Invalid_panel_size of string * int
-      (** (preset 이름, 모델 총합) — 그룹 모델 총합 1..8 위반 (빈 panel=[] 포함). *)
+  | No_panel_models of string
+      (** preset의 모든 panel group에 모델이 없음 (빈 panel=[] 포함). *)
   | Empty_panels of string
-      (** preset의 [panels]가 빈 배열 (그룹 0개). "모델 0개"(Invalid_panel_size)와 구분. *)
+      (** preset의 [panels]가 빈 배열 (그룹 0개). "모델 0개"(No_panel_models)와 구분. *)
   | Conflicting_panel_grammar of string
       (** 같은 preset에 [[...panels]]와 flat [panel] 둘 다 존재 (silent 선택 금지). *)
   | Duplicate_panelist of string * string
@@ -50,7 +50,7 @@ val disabled : Fusion_policy.t
 
     - [fusion] 부재 → [Ok disabled].
     - enabled=true인데 preset 부재 → [Error [Empty_presets]].
-    - 패널 모델 총합 1..8 위반 → [Error [Invalid_panel_size _]].
+    - 모든 패널 그룹의 모델 목록이 비어 있음 → [Error [No_panel_models _]].
     - [panels] 빈 배열(그룹 0개) → [Error [Empty_panels _]].
     - [[...panels]]와 flat [panel] 동시 → [Error [Conflicting_panel_grammar _]].
     - 패널 정체성(panelist_id) 중복 → [Error [Duplicate_panelist _]]. 라벨이 다르면

--- a/lib/fusion_core/fusion_policy.ml
+++ b/lib/fusion_core/fusion_policy.ml
@@ -46,11 +46,9 @@ type preset =
   }
 [@@deriving show, eq]
 
-let min_panel = 1
-let max_panel = 8
 let min_answered_floor = 1
 let default_min_answered = min_answered_floor
-let default_max_concurrent_judges = max_panel
+let default_max_concurrent_judges = 8
 let min_staged_judge_group_size = 2
 let default_staged_judge_group_size = 3
 
@@ -62,12 +60,10 @@ let valid_max_output_tokens = function
 let preset_models (p : preset) =
   List.concat_map (fun (g : panel_group) -> g.models) p.panels
 
-(* 패널 전체(그룹 합) 모델 수가 1..8 범위인가. 1..8은 OpenRouter Fusion의 총 모델
-   상한이므로 그룹별이 아니라 평탄화 총합에 건다. panels=[]는 명시적 실패
-   (Unknown→Permissive 회피 — 빈 그룹 리스트를 통과시키지 않는다). *)
-let preset_size_ok (p : preset) =
-  let total = List.length (preset_models p) in
-  p.panels <> [] && total >= min_panel && total <= max_panel
+(* 적어도 하나의 패널 모델이 있는가. Provider별 cardinality 한계는 MASC의
+   preset 타입을 제한하지 않는다. 실행 시 provider가 거부하면 그 typed failure를
+   관측하며, 다른 provider와 heterogeneous panel 구성은 계속 실행된다. *)
+let preset_has_models (p : preset) = preset_models p <> []
 
 (* 패널 정체성 (RFC-0278). label이 비면 model 그대로(legacy byte-identity), 있으면
    "label (model)". 이 문자열이 패널의 유일 식별자다: agent 카드명(Async_agent.all
@@ -219,7 +215,7 @@ module Validated_preset = struct
   (* 검증 실패 사유 — 닫힌 합. config 계층이 이를 자기 [config_error]로 매핑한다
      (의존 방향: config → policy). *)
   type invalid =
-    | Bad_size of int  (** 모델 총합(panels=[] 포함)이 min_panel..max_panel 밖 *)
+    | No_panel_models  (** 그룹 전체에 모델이 하나도 없음 *)
     | Missing_prompt  (** 패널 또는 심판 system prompt 비어있음 *)
     | Missing_judge_model  (** 심판 model id 비어있음 *)
     | Duplicate_panelist of string  (** 두 패널이 같은 정체성(panelist_id) *)
@@ -232,13 +228,13 @@ module Validated_preset = struct
     | Min_answered_above_max of int
         (** [min_answered]가 패널 모델 총합을 초과. *)
 
-  (* 검증 순서는 config 로드 시점과 동일(byte-identical config_error): size → 패널 prompt →
+  (* 검증 순서는 config 로드 시점과 동일: model presence → 패널 prompt →
      judge model → 패널 정체성 중복 → 패널 max_output_tokens 범위 → (RFC-0283)
      1차 심판 prompt → 1차 심판 정체성 중복 → 심판 max_output_tokens 범위 → min_answered.
      judges=[]면 1차 심판 관련 셋은 통과(simple/refine/conditional preset은 기존과 동일
      결과 = byte-identity). *)
   let of_preset (p : preset) : (t, invalid) result =
-    if not (preset_size_ok p) then Error (Bad_size (List.length (preset_models p)))
+    if not (preset_has_models p) then Error No_panel_models
     else if not (preset_prompts_present p) then Error Missing_prompt
     else if not (preset_judge_present p) then Error Missing_judge_model
     else

--- a/lib/fusion_core/fusion_policy.ml
+++ b/lib/fusion_core/fusion_policy.ml
@@ -48,6 +48,9 @@ type preset =
 
 let min_answered_floor = 1
 let default_min_answered = min_answered_floor
+(* Legacy config default copied from the retired OpenRouter panel bound. No
+   execution path reads it; the stacked schema hard-cut deletes the field and
+   this value together. *)
 let default_max_concurrent_judges = 8
 let min_staged_judge_group_size = 2
 let default_staged_judge_group_size = 3

--- a/lib/fusion_core/fusion_policy.mli
+++ b/lib/fusion_core/fusion_policy.mli
@@ -67,8 +67,9 @@ val min_answered_floor : int
 
 val default_min_answered : int
 
-(** Default JOJ first-judge execution concurrency. This batches execution only;
-    it never limits the number of configured judges or panel models. *)
+(** Legacy config default copied from the retired OpenRouter panel bound.
+    Execution does not read it. The stacked schema hard-cut deletes this value
+    with the dead config field. *)
 val default_max_concurrent_judges : int
 
 (** Default staged JOJ group size. A staged judge-of-judges run groups first

--- a/lib/fusion_core/fusion_policy.mli
+++ b/lib/fusion_core/fusion_policy.mli
@@ -42,7 +42,7 @@ type judge_spec =
     desugar한다 — 그 경우 오늘과 byte-identical 동작. *)
 type preset =
   { name : string
-  ; panels : panel_group list  (** 1개 이상 그룹; 모델 총합 {!min_panel}..{!max_panel} *)
+  ; panels : panel_group list  (** 그룹 전체에 모델이 하나 이상 있어야 함. *)
   ; judge : string
   ; judge_system_prompt : string
       (** 심판 모델 system prompt — config에서 필수(코드 default 없음). *)
@@ -62,18 +62,13 @@ type preset =
   }
 [@@deriving show, eq]
 
-(** 패널 크기(모델 총합) 하한/상한 (OpenRouter Fusion: 1..8 모델). *)
-val min_panel : int
-
-val max_panel : int
-
 (** [min_answered] 하한과 기본값. 기본 1 = "응답 패널이 1개도 없을 때만 judge skip". *)
 val min_answered_floor : int
 
 val default_min_answered : int
 
-(** Default JOJ first-judge concurrency. Derived from {!max_panel} so judge
-    fan-out has its own bounded capacity instead of borrowing panel throttling. *)
+(** Default JOJ first-judge execution concurrency. This batches execution only;
+    it never limits the number of configured judges or panel models. *)
 val default_max_concurrent_judges : int
 
 (** Default staged JOJ group size. A staged judge-of-judges run groups first
@@ -91,10 +86,10 @@ val valid_max_output_tokens : int option -> bool
 (** 모든 그룹의 모델을 평탄화 (그룹순 × 그룹내 모델순 보존). *)
 val preset_models : preset -> string list
 
-(** 패널 모델 총합이 [min_panel]..[max_panel] 범위이고 [panels]가 비어있지 않은가.
-    {!Validated_preset.of_preset}의 검증 술어 (RFC-0280: 게이트는 더 이상 재검증하지
-    않고 [Validated_preset.t]로 타입 증명한다). *)
-val preset_size_ok : preset -> bool
+(** 그룹 전체에 패널 모델이 하나 이상 있는가.
+    {!Validated_preset.of_preset}의 검증 술어. Provider별 cardinality 한계는 이
+    MASC-owned preset 타입을 제한하지 않는다. *)
+val preset_has_models : preset -> bool
 
 (** 패널 정체성 (RFC-0278). [label]이 비면 [model] 그대로(legacy byte-identical),
     있으면 ["label (model)"]. agent 카드명·심판 패널 태그·[panel_answer.model]에
@@ -169,7 +164,7 @@ module Validated_preset : sig
 
   (** 검증 실패 사유 — 닫힌 합. config 계층이 자기 [config_error]로 매핑한다. *)
   type invalid =
-    | Bad_size of int  (** 모델 총합(panels=[] 포함)이 [min_panel]..[max_panel] 밖 *)
+    | No_panel_models  (** 그룹 전체에 모델이 하나도 없음 *)
     | Missing_prompt  (** 패널 또는 심판 system prompt 비어있음 *)
     | Missing_judge_model  (** 심판 model id 비어있음 *)
     | Duplicate_panelist of string  (** 두 패널이 같은 정체성({!panelist_id}) *)
@@ -181,7 +176,7 @@ module Validated_preset : sig
         (** [min_answered]가 하한 [min_answered_floor] 미만. *)
     | Min_answered_above_max of int
         (** [min_answered]가 패널 모델 총합을 초과. *)
-  (** 검증 순서: size → prompt → judge → 정체성 중복 → max_output_tokens →
+  (** 검증 순서: model presence → prompt → judge → 정체성 중복 → max_output_tokens →
       1차 심판 prompt/정체성/max_output_tokens → min_answered.
       통과 시 [Ok vp], 첫 위반에서 [Error invalid].
       config 로드의 검증 순서와 동일. *)

--- a/test/fusion_core/test_fusion.ml
+++ b/test/fusion_core/test_fusion.ml
@@ -455,23 +455,52 @@ let test_config_empty_presets () =
       (List.mem Fusion_config.Empty_presets es)
   | Ok _ -> Alcotest.fail "expected Error Empty_presets"
 
-let test_config_invalid_size () =
+let test_config_large_panel_is_valid () =
   let s =
     {|
 [fusion]
 enabled = true
-[fusion.presets.toomany]
-panel = ["a", "b", "c", "d", "e", "f", "g", "h", "i"]
+default_preset = "large"
+[fusion.presets.large]
+panel = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l"]
+panel_system_prompt = "analyze"
 judge = "a"
+judge_system_prompt = "synthesize"
 |}
   in
   match Fusion_config.of_toml (parse s) with
-  | Error es ->
-    Alcotest.(check bool) "Invalid_panel_size present" true
-      (List.exists
-         (function Fusion_config.Invalid_panel_size _ -> true | _ -> false)
-         es)
-  | Ok _ -> Alcotest.fail "expected Error Invalid_panel_size"
+  | Ok policy ->
+    let preset =
+      Fusion_policy.find_preset policy "large"
+      |> Option.map Fusion_policy.Validated_preset.preset
+    in
+    Alcotest.(check int)
+      "all configured panel models survive validation"
+      12
+      (Option.fold ~none:0 ~some:(fun value ->
+         List.length (Fusion_policy.preset_models value)) preset)
+  | Error _ -> Alcotest.fail "provider-independent panel width was rejected"
+
+let test_config_no_panel_models () =
+  let s =
+    {|
+[fusion]
+enabled = true
+default_preset = "empty"
+[fusion.presets.empty]
+panel = []
+panel_system_prompt = "analyze"
+judge = "a"
+judge_system_prompt = "synthesize"
+|}
+  in
+  match Fusion_config.of_toml (parse s) with
+  | Error errors ->
+    Alcotest.(check bool)
+      "No_panel_models present"
+      true
+      (List.mem (Fusion_config.No_panel_models "empty") errors)
+  | Ok _ -> Alcotest.fail "model-free panel preset was accepted"
 
 let test_config_invalid_min_answered () =
   let check_invalid value =
@@ -869,13 +898,13 @@ let test_validated_ok () =
       (List.length (raw vp).Fusion_policy.panels)
   | Error _ -> Alcotest.fail "expected Ok for a valid preset"
 
-let test_validated_bad_size () =
+let test_validated_no_panel_models () =
   let empty_group = { base_group with Fusion_policy.models = [] } in
   match
     Fusion_policy.Validated_preset.of_preset (mk_preset ~panels:[ empty_group ] "empty")
   with
-  | Error (Fusion_policy.Validated_preset.Bad_size 0) -> ()
-  | _ -> Alcotest.fail "expected Bad_size 0 for zero models"
+  | Error Fusion_policy.Validated_preset.No_panel_models -> ()
+  | _ -> Alcotest.fail "expected No_panel_models for zero models"
 
 let test_validated_missing_prompt () =
   let no_prompt = { base_group with Fusion_policy.system_prompt = "" } in
@@ -1433,7 +1462,8 @@ let () =
         ; Alcotest.test_case "panelist_id_collision_fail_closed" `Quick
             test_config_panelist_id_collision_fail_closed
         ; Alcotest.test_case "empty_presets" `Quick test_config_empty_presets
-        ; Alcotest.test_case "invalid_size" `Quick test_config_invalid_size
+        ; Alcotest.test_case "large_panel_is_valid" `Quick test_config_large_panel_is_valid
+        ; Alcotest.test_case "no_panel_models" `Quick test_config_no_panel_models
         ; Alcotest.test_case "invalid_min_answered" `Quick
             test_config_invalid_min_answered
         ; Alcotest.test_case "missing_default" `Quick test_config_missing_default
@@ -1459,7 +1489,7 @@ let () =
         ] )
     ; ( "validated_preset"
       , [ Alcotest.test_case "ok" `Quick test_validated_ok
-        ; Alcotest.test_case "bad_size" `Quick test_validated_bad_size
+        ; Alcotest.test_case "no_panel_models" `Quick test_validated_no_panel_models
         ; Alcotest.test_case "missing_prompt" `Quick test_validated_missing_prompt
         ; Alcotest.test_case "missing_judge" `Quick test_validated_missing_judge
         ; Alcotest.test_case "duplicate_panelist" `Quick test_validated_duplicate_panelist


### PR DESCRIPTION
## Outcome

- deletes the OpenRouter-specific 8-model admission cap from generic MASC Fusion presets
- requires only a non-empty typed panel model set
- preserves duplicate identity, prompt, output-token, and quorum structural validation
- proves a 12-model heterogeneous panel survives config validation unchanged

`max_concurrent_judges` remains execution/config cleanup scope for the next isolated PR; it no longer determines preset cardinality here.

## Verification

- `scripts/dune-local.sh build test/fusion_core/test_fusion.exe`
- `./_build/default/test/fusion_core/test_fusion.exe` — 75/75 passed
- `ocamlformat --check` on changed OCaml files
- `git diff --check`