### PR TITLE
feat(keeper): consolidate compaction operation library

### DIFF
--- a/docs/KEEPER-CAPABILITY-MATRIX.md
+++ b/docs/KEEPER-CAPABILITY-MATRIX.md
@@ -69,9 +69,9 @@ Important families:
 - scheduled automation: `masc_schedule_create`, `masc_schedule_list`,
   `masc_schedule_get`, `masc_schedule_cancel`, `masc_schedule_approve`,
   `masc_schedule_reject`
-- keeper management/messaging: `masc_keeper_list`, `masc_keeper_status`,
-  `masc_keeper_msg`, `masc_keeper_msg_result`, `masc_keeper_msg_queue`,
-  `masc_keeper_msg_cancel`
+- keeper management/delegation: `masc_keeper_list`, `masc_keeper_status`,
+  `masc_keeper_delegate`, `masc_keeper_delegate_status`,
+  `masc_keeper_delegate_list`, `masc_keeper_delegate_cancel`
 - operator/maintenance keeper controls: broader descriptors such as
   `masc_keeper_compact`, `masc_keeper_clear`, `masc_keeper_sandbox_start`,
   `masc_keeper_sandbox_stop`, `masc_keeper_reset`,
@@ -100,7 +100,7 @@ Excluded from keeper exposure:
 | Past decisions or shared references | memory and library tools | Writing scratch notes to durable memory |
 | Workspace planning, goal lifecycle, run logs, notes, deliverables | `masc_goal_*`, `masc_plan_*`, `masc_run_*`, `masc_note_add`, `masc_deliver` | Mutating goals/plans for ordinary status narration |
 | Durable future automation | `masc_schedule_*` | Assuming side-effecting schedules run without human approval |
-| Targeted async help from another keeper | `masc_keeper_list`, `masc_keeper_status`, `masc_keeper_msg`, result/queue/cancel tools | Broadcasting a private question, or messaging an unknown keeper without status/list evidence |
+| Targeted async help from another keeper | `masc_keeper_list`, `masc_keeper_status`, `masc_keeper_delegate`, status/list/cancel tools | Broadcasting a private question, or delegating to an unknown keeper without status/list evidence |
 | High-impact ambiguous decision needing independent perspectives | `masc_fusion` with self-contained context | Replacing cheap code inspection, exact status evidence, or blocker reporting |
 | Stored image artifact analysis | `analyze_image` | Treating visible chat attachments as hidden sandbox files |
 
@@ -110,7 +110,7 @@ Keeper continuity is a bounded advanced capability, not a general memory promise
 
 If productized, the continuity promise is:
 
-- `masc_keeper_msg` can continue a same-trace conversation when checkpoint restore is healthy
+- `masc_keeper_delegate` can continue a same-trace conversation when checkpoint restore is healthy
 - `masc_keeper_status` and `masc_keeper_list(detailed=true)` expose enough continuity state to diagnose restore and handoff behavior
 - validation should rely on OAS checkpoint truth plus live runtime evidence
 
@@ -151,7 +151,7 @@ BoardActivity, IdleTimeout, MetricsAnomaly, StrategicReview.
 | 목표 / 계획 lifecycle | `masc_goal_list`, `masc_goal_upsert`, `masc_goal_transition` |
 | 계획/런/산출물 기록 | `masc_plan_get`, `masc_plan_init`, `masc_plan_update`, `masc_plan_set_task`, `masc_plan_get_task`, `masc_plan_clear_task`, `masc_run_init`, `masc_run_list`, `masc_run_get`, `masc_run_plan`, `masc_note_add`, `masc_deliver` |
 | 예약 자동화 | `masc_schedule_create`, `masc_schedule_list`, `masc_schedule_get`, `masc_schedule_cancel`, `masc_schedule_approve`, `masc_schedule_reject` |
-| 다른 keeper 상태/메시지 | `masc_keeper_list`, `masc_keeper_status`, `masc_keeper_msg`, `masc_keeper_msg_result`, `masc_keeper_msg_queue`, `masc_keeper_msg_cancel` |
+| 다른 keeper 상태/위임 | `masc_keeper_list`, `masc_keeper_status`, `masc_keeper_delegate`, `masc_keeper_delegate_status`, `masc_keeper_delegate_list`, `masc_keeper_delegate_cancel` |
 | 패널 심의 / 비동기 판단 보강 | `masc_fusion`, `masc_fusion_status` |
 | 저장 이미지 artifact 분석 | `analyze_image` |
 | 코드 작성 / 수정 | `Read` / `Grep` -> `Edit` / `Write`, then `Execute` with typed `git` argv |

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -210,7 +210,7 @@ masc_claim_next()
 
 - repo workspace collaboration: `masc_start`, `masc_status`, `masc_transition`, `masc_plan_set_task`, `masc_heartbeat`
 - keeper runtime front door: `masc_keeper_list`, `masc_keeper_status`, `masc_keeper_up`, `masc_keeper_down`
-- keeper async turn injection: `masc_keeper_msg` (advanced/callable, hidden from default `tools/list`)
+- keeper async invocation: `masc_keeper_delegate` (advanced/callable, hidden from default `tools/list`)
 
 retired orchestration surfaces are historical only. 새 사용자는 repo workspace collaboration과 keeper runtime에서 시작하고, read visibility가 필요할 때만 dashboard/operator surface로 내려간다.
 

--- a/docs/spec/01-system-overview.md
+++ b/docs/spec/01-system-overview.md
@@ -148,7 +148,7 @@ MASC의 현재 canonical front door는 3가지다.
 장기 실행과 연속성을 위한 경로.
 
 - **대상**: keeper lifecycle, long-running execution, OAS-backed autonomy
-- **핵심 도구**: `masc_keeper_up`, `masc_keeper_msg`, `masc_keeper_status`, `masc_keeper_down`
+- **핵심 도구**: `masc_keeper_up`, `masc_keeper_delegate`, `masc_keeper_status`, `masc_keeper_down`
 - **설명**: keeper는 OAS `Agent.run` 기반으로 실행되며, retired orchestration surfaces와 독립적으로 동작한다. 자세한 turn lifecycle은 [`04-turn-lifecycle.md`](./04-turn-lifecycle.md)를 참조.
 
 ### 7.3 Dashboard and Operator Read Visibility

--- a/lib/compaction_trigger/compaction_trigger.ml
+++ b/lib/compaction_trigger/compaction_trigger.ml
@@ -1,33 +1,13 @@
 type t =
-  | Ratio_threshold of
-      { ratio : float
-      ; threshold : float
-      }
-  | Message_count of
-      { count : int
-      ; threshold : int
-      }
-  | Token_count of
-      { count : int
-      ; threshold : int
-      }
   | Provider_overflow of { limit_tokens : int option }
   | Manual
 
 let to_label = function
-  | Ratio_threshold _ -> "ratio"
-  | Message_count _ -> "messages"
-  | Token_count _ -> "tokens"
   | Provider_overflow _ -> "provider_overflow"
   | Manual -> "manual"
 ;;
 
 let to_human = function
-  | Ratio_threshold { ratio; threshold } ->
-    Printf.sprintf "ratio(%.4f>=%.4f)" ratio threshold
-  | Message_count { count; threshold } ->
-    Printf.sprintf "messages(%d>=%d)" count threshold
-  | Token_count { count; threshold } -> Printf.sprintf "tokens(%d>=%d)" count threshold
   | Provider_overflow { limit_tokens } ->
     Printf.sprintf
       "provider_overflow(limit=%s)"
@@ -38,14 +18,6 @@ let to_human = function
 ;;
 
 let to_detail_json : t -> Yojson.Safe.t = function
-  | Ratio_threshold { ratio; threshold } ->
-    `Assoc
-      [ "kind", `String "ratio"; "ratio", `Float ratio; "threshold", `Float threshold ]
-  | Message_count { count; threshold } ->
-    `Assoc
-      [ "kind", `String "messages"; "count", `Int count; "threshold", `Int threshold ]
-  | Token_count { count; threshold } ->
-    `Assoc [ "kind", `String "tokens"; "count", `Int count; "threshold", `Int threshold ]
   | Provider_overflow { limit_tokens } ->
     `Assoc
       [ "kind", `String "provider_overflow"
@@ -57,49 +29,38 @@ let to_detail_json : t -> Yojson.Safe.t = function
   | Manual -> `Assoc [ "kind", `String "manual" ]
 ;;
 
-let of_detail_json (json : Yojson.Safe.t) : t option =
+type decode_error =
+  | Expected_object
+  | Missing_kind
+  | Invalid_kind
+  | Unknown_kind of string
+  | Missing_provider_limit
+  | Invalid_provider_limit
+
+let decode_error_to_string = function
+  | Expected_object -> "compaction trigger detail must be an object"
+  | Missing_kind -> "compaction trigger detail is missing kind"
+  | Invalid_kind -> "compaction trigger kind must be a string"
+  | Unknown_kind kind -> Printf.sprintf "unknown compaction trigger kind %S" kind
+  | Missing_provider_limit -> "provider overflow trigger is missing limit_tokens"
+  | Invalid_provider_limit ->
+    "provider overflow limit_tokens must be null or a positive integer"
+;;
+
+let of_detail_json (json : Yojson.Safe.t) : (t, decode_error) result =
   match json with
   | `Assoc fields ->
-    let str key =
-      match List.assoc_opt key fields with
-      | Some (`String s) -> Some s
-      | _ -> None
-    in
-    let num_float key =
-      match List.assoc_opt key fields with
-      | Some (`Float f) -> Some f
-      | Some (`Int i) -> Some (float_of_int i)
-      | _ -> None
-    in
-    let num_int key =
-      match List.assoc_opt key fields with
-      | Some (`Int i) -> Some i
-      | Some (`Intlit s) -> int_of_string_opt s
-      | _ -> None
-    in
-    (match str "kind" with
-     | Some "ratio" ->
-       (match num_float "ratio", num_float "threshold" with
-        | Some ratio, Some threshold -> Some (Ratio_threshold { ratio; threshold })
-        | _ -> None)
-     | Some "messages" ->
-       (match num_int "count", num_int "threshold" with
-        | Some count, Some threshold -> Some (Message_count { count; threshold })
-        | _ -> None)
-     | Some "tokens" ->
-       (match num_int "count", num_int "threshold" with
-        | Some count, Some threshold -> Some (Token_count { count; threshold })
-        | _ -> None)
-     | Some "provider_overflow" ->
+    (match List.assoc_opt "kind" fields with
+     | Some (`String "provider_overflow") ->
        (match List.assoc_opt "limit_tokens" fields with
-        | Some `Null | None -> Some (Provider_overflow { limit_tokens = None })
-        | Some (`Int limit_tokens) ->
-          Some (Provider_overflow { limit_tokens = Some limit_tokens })
-        | Some _ -> None)
-     (* "tool_heavy" rows persist in historical JSONL; the trigger was removed
-        (gate measured stored-history bulk that the OAS call-time pruner already
-        bounds per call) so they parse to None like any unknown kind. *)
-     | Some "manual" -> Some Manual
-     | _ -> None)
-  | _ -> None
+        | Some `Null -> Ok (Provider_overflow { limit_tokens = None })
+        | Some (`Int limit_tokens) when limit_tokens > 0 ->
+          Ok (Provider_overflow { limit_tokens = Some limit_tokens })
+        | None -> Error Missing_provider_limit
+        | Some _ -> Error Invalid_provider_limit)
+     | Some (`String "manual") -> Ok Manual
+     | Some (`String kind) -> Error (Unknown_kind kind)
+     | Some _ -> Error Invalid_kind
+     | None -> Error Missing_kind)
+  | _ -> Error Expected_object
 ;;

--- a/lib/compaction_trigger/compaction_trigger.mli
+++ b/lib/compaction_trigger/compaction_trigger.mli
@@ -1,44 +1,31 @@
-(** Compaction_trigger — closed sum type for context compaction reason.
-
-    Replaces the prior [string] / [string option] representation in
-    [compaction_event.trigger] and [pre_compact_event.trigger] so the
-    Otel_metric_store [trigger] label has bounded cardinality (5 values) while
-    structured numerical detail (ratio, counts, thresholds) is preserved
-    in the JSON receipt via [to_detail_json]. *)
+(** Compaction_trigger — explicit context compaction request origin. *)
 
 type t =
-  | Ratio_threshold of
-      { ratio : float
-      ; threshold : float
-      }
-  | Message_count of
-      { count : int
-      ; threshold : int
-      }
-  | Token_count of
-      { count : int
-      ; threshold : int
-      }
   | Provider_overflow of { limit_tokens : int option }
       (** Typed provider context-window overflow. [limit_tokens] is the
           provider-declared limit when present, never an estimated count. *)
   | Manual
 
-(** Closed label set (5 values) for Otel_metric_store / SSE [trigger] label.
+(** Closed label set for Otel_metric_store / SSE [trigger] label.
     Use this anywhere cardinality matters. *)
 val to_label : t -> string
 
-(** Human-readable rendering with embedded numerical detail.  Use for
-    [Log.*] string interpolation only — NOT for Otel_metric_store labels. *)
+(** Human-readable rendering. Use for [Log.*] string interpolation only. *)
 val to_human : t -> string
 
-(** Structured JSON detail with all numerical fields preserved.  Use
-    inside SSE broadcasts and JSON receipts so dashboards can plot
-    actual ratios/counts rather than parse strings. *)
+(** Structured JSON detail for durable observation. *)
 val to_detail_json : t -> Yojson.Safe.t
 
-(** Inverse of {!to_detail_json}.  Returns [None] if the JSON cannot be
-    parsed as a known trigger kind.  Used by persistence-recovery code
-    paths (e.g. dashboard log replay) where the typed variant must be
-    reconstructed from a stored JSON record. *)
-val of_detail_json : Yojson.Safe.t -> t option
+type decode_error =
+  | Expected_object
+  | Missing_kind
+  | Invalid_kind
+  | Unknown_kind of string
+  | Missing_provider_limit
+  | Invalid_provider_limit
+
+val decode_error_to_string : decode_error -> string
+
+val of_detail_json : Yojson.Safe.t -> (t, decode_error) result
+(** Exact inverse of {!to_detail_json}. Retired heuristic trigger kinds and
+    malformed rows are rejected explicitly. *)

--- a/lib/compaction_trigger/dune
+++ b/lib/compaction_trigger/dune
@@ -1,11 +1,8 @@
 ; RFC-0056 Phase 1K — extract Compaction_trigger leaf module from
 ; lib/keeper/. Third lib/keeper/ leaf after Phase 1I/1J.
 ;
-; 94+45 LoC. Pure dependency-leaf: stdlib + Yojson + masc_log
-; (Log.X sub-module). Encodes compaction trigger heuristic + JSON
-; serializer used by dashboard_harness_health and several keeper modules.
-;
-; Fan-in: 17 (mix of lib + test) + 2 wrapped-pattern test callers.
+; Pure dependency-leaf: stdlib + Yojson. Encodes explicit
+; Manual/provider-overflow compaction origins and their typed JSON codec.
 ;
 ; (include_subdirs no) opts out of parent's (include_subdirs unqualified).
 ; (wrapped false) keeps the bare identifier `Compaction_trigger`.
@@ -19,4 +16,4 @@
  (wrapped false)
  (flags
   (:standard -w +4))
- (libraries yojson masc_log))
+ (libraries yojson))

--- a/lib/dashboard/dashboard_harness_health.ml
+++ b/lib/dashboard/dashboard_harness_health.ml
@@ -244,30 +244,37 @@ let pre_compact_event_json (event : pre_compact_event) =
 ;;
 
 let pre_compact_event_of_json json =
-  let record_type = string_field json "record_type" in
-  if record_type <> "" && not (String.equal record_type "pre_compact")
-  then None
-  else
-    Some
-      { timestamp = Safe_ops.json_float ~default:0.0 "timestamp" json
-      ; keeper_name = string_field json "keeper_name"
-      ; checkpoint_bytes = Safe_ops.json_int ~default:0 "checkpoint_bytes" json
-      ; message_count = Safe_ops.json_int ~default:0 "message_count" json
-      ; strategies = Safe_ops.json_string_list "strategies" json
-      ; trigger =
-          (match
-             List.assoc_opt
-               "trigger_detail"
-               (match json with
-                | `Assoc kv -> kv
-                | _ -> [])
-           with
-           | Some detail ->
-             (match Compaction_trigger.of_detail_json detail with
-              | Some t -> t
-              | None -> Compaction_trigger.Manual)
-           | None -> Compaction_trigger.Manual)
-      }
+  let reject reason =
+    Log.Harness.warn "[pre_compact] rejected persisted row: %s" reason;
+    None
+  in
+  match json with
+  | `Assoc fields ->
+    (match List.assoc_opt "record_type" fields with
+     | None -> reject "missing record_type"
+     | Some (`String "pre_compact") ->
+       (match List.assoc_opt "trigger_detail" fields with
+        | None -> reject "missing trigger_detail"
+        | Some detail ->
+          (match Compaction_trigger.of_detail_json detail with
+           | Ok trigger ->
+             Some
+               { timestamp = Safe_ops.json_float ~default:0.0 "timestamp" json
+               ; keeper_name = string_field json "keeper_name"
+               ; checkpoint_bytes = Safe_ops.json_int ~default:0 "checkpoint_bytes" json
+               ; message_count = Safe_ops.json_int ~default:0 "message_count" json
+               ; strategies = Safe_ops.json_string_list "strategies" json
+               ; trigger
+               }
+           | Error error ->
+             reject
+               (Printf.sprintf
+                  "invalid trigger_detail: %s"
+                  (Compaction_trigger.decode_error_to_string error))))
+     | Some (`String record_type) ->
+       reject (Printf.sprintf "unexpected record_type %S" record_type)
+     | Some _ -> reject "record_type must be a string")
+  | _ -> reject "expected an object"
 ;;
 
 let role_counts_to_json (counts : (string * int) list) : Yojson.Safe.t =

--- a/lib/dune
+++ b/lib/dune
@@ -309,6 +309,7 @@
   masc.prompt_registry
   ;; MCP transport/session leaf primitives (extracted sub-libraries)
   masc.mcp_transport_protocol
+  masc.tool_invocation_ref
   masc.mcp_session
   ;; Response envelope leaf primitive (extracted sub-library)
   masc.response

--- a/lib/dune
+++ b/lib/dune
@@ -102,6 +102,7 @@
   masc.keeper_types_profile_sandbox
   masc.keeper_usage_trust
   masc.keeper_event_bus
+  masc.keeper_compaction_evidence
   ;; Runtime_provider_labels extracted to lib/runtime_provider_labels/.
   ;; Leaf boundary over agent_sdk.llm_provider canonical provider labels.
   masc.runtime_provider_labels

--- a/lib/dune
+++ b/lib/dune
@@ -90,6 +90,7 @@
   ;; RFC-0056 Phase 1N — Keeper_state_* deterministic FSM cluster extracted to
   ;; lib/keeper_state/. Parent still references bare Keeper_state_* modules.
   masc.keeper_registry
+  masc.keeper_checkpoint_ref
   ;; Keeper-owned pure/type leaves extracted from lib/keeper/.
   masc.keeper_contract
   masc.keeper_hooks_oas_types

--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -39,10 +39,12 @@ let max_oas_history_retained = 12
 let oas_history_path ~(session_dir : string) ~(snapshot_id : string) =
   Filename.concat session_dir snapshot_id
 
+let keeper_generation_context_key = "keeper_generation"
+
 let keeper_generation_of_context (context : Agent_sdk.Context.t) : int =
   match
     Agent_sdk.Context.get_scoped context Agent_sdk.Context.Session
-      "keeper_generation"
+      keeper_generation_context_key
   with
   | Some (`Int n) -> n
   | Some (`Intlit raw) -> Option.value ~default:0 (int_of_string_opt raw)
@@ -347,7 +349,7 @@ let archive_oas_history_best_effort ~session_dir ckpt =
         ]
       ()
 
-let load_canonical_strict path =
+let load_canonical_bytes_strict path =
   let unix_error error operation argument =
     Io_error
       (Printf.sprintf "%s(%s): %s"
@@ -382,14 +384,23 @@ let load_canonical_strict path =
          Error (unix_error error operation argument))
   in
   match Eio_guard.run_in_systhread read with
-  | Ok None -> Ok None
+  | Ok content -> Ok content
   | Error _ as error -> error
-  | Ok (Some content) ->
-    (match Agent_sdk.Checkpoint.of_string content with
-     | Ok checkpoint -> Ok (Some checkpoint)
-     | Error error -> Error (classify_sdk_error error))
   | exception (Eio.Cancel.Cancelled _ as exn) -> raise exn
   | exception exn -> Error (Io_error (Printexc.to_string exn))
+
+let load_canonical_bytes_and_checkpoint_strict path =
+  match load_canonical_bytes_strict path with
+  | Error _ as error -> error
+  | Ok None -> Ok None
+  | Ok (Some content) ->
+    (match Agent_sdk.Checkpoint.of_string content with
+     | Ok checkpoint -> Ok (Some (content, checkpoint))
+     | Error error -> Error (classify_sdk_error error))
+
+let load_canonical_strict path =
+  load_canonical_bytes_and_checkpoint_strict path
+  |> Result.map (Option.map snd)
 
 (* masc P0 perf fix (checkpoint save-path read-modify-write): a prior
    revision of this fix cached the watermark in a process-local Hashtbl.
@@ -561,6 +572,197 @@ let known_watermark ~canonical_path
        full_parse_fallback ~canonical_path ~sidecar_path ~reason:Fingerprint_mismatch
      | None ->
        full_parse_fallback ~canonical_path ~sidecar_path ~reason:Sidecar_unusable)
+
+type checkpoint_identity_error =
+  | Session_id_invalid of string
+  | Generation_missing
+  | Generation_not_integer
+  | Ref_create_failed of Keeper_checkpoint_ref.create_error
+
+type checkpoint_ref_load_error =
+  | Ref_not_found
+  | Ref_read_failed of checkpoint_load_error
+  | Ref_identity_invalid of checkpoint_identity_error
+  | Ref_session_mismatch of
+      { expected : Keeper_id.Trace_id.t
+      ; actual : Keeper_id.Trace_id.t
+      }
+  | Ref_lock_failed of string
+
+type checkpoint_cas_error =
+  | Source_unavailable of checkpoint_ref_load_error
+  | Source_changed of Keeper_checkpoint_ref.t
+  | Candidate_identity_invalid of checkpoint_identity_error
+  | Candidate_session_mismatch of
+      { expected : Keeper_id.Trace_id.t
+      ; candidate : Keeper_id.Trace_id.t
+      }
+  | Candidate_generation_mismatch of
+      { expected : int
+      ; candidate : int
+      }
+  | Candidate_turn_regressed of
+      { source_turn : int
+      ; candidate_turn : int
+      }
+  | Commit_not_installed of Keeper_fs.durable_write_error
+  | Commit_durability_unknown of
+      { installed_ref : Keeper_checkpoint_ref.t
+      ; error : Keeper_fs.durable_write_error
+      }
+  | Transaction_outcome_unknown of
+      { possible_installed_ref : Keeper_checkpoint_ref.t
+      ; error : File_lock_eio.durable_lock_error
+      }
+
+let checkpoint_generation_strict (checkpoint : Agent_sdk.Checkpoint.t) =
+  match
+    Agent_sdk.Context.get_scoped checkpoint.Agent_sdk.Checkpoint.context
+      Agent_sdk.Context.Session keeper_generation_context_key
+  with
+  | None -> Error Generation_missing
+  | Some (`Int generation) -> Ok generation
+  | Some (`Intlit raw) ->
+    (match int_of_string_opt raw with
+     | Some generation -> Ok generation
+     | None -> Error Generation_not_integer)
+  | Some _ -> Error Generation_not_integer
+
+let checkpoint_ref_of_canonical_bytes canonical_bytes
+    (checkpoint : Agent_sdk.Checkpoint.t) =
+  match Keeper_id.Trace_id.of_string checkpoint.Agent_sdk.Checkpoint.session_id with
+  | Error reason -> Error (Session_id_invalid reason)
+  | Ok trace_id ->
+    (match checkpoint_generation_strict checkpoint with
+     | Error _ as error -> error
+     | Ok generation ->
+       Keeper_checkpoint_ref.create
+         ~trace_id
+         ~generation
+         ~turn_count:checkpoint.turn_count
+         ~canonical_checkpoint_bytes:canonical_bytes
+       |> Result.map_error (fun error -> Ref_create_failed error))
+
+let load_ref_locked ~session_dir ~expected_session_id =
+  let canonical_path =
+    oas_checkpoint_path
+      ~session_dir
+      ~session_id:(Keeper_id.Trace_id.to_string expected_session_id)
+  in
+  match load_canonical_bytes_and_checkpoint_strict canonical_path with
+  | Error error -> Error (Ref_read_failed error)
+  | Ok None -> Error Ref_not_found
+  | Ok (Some (canonical_bytes, checkpoint)) ->
+    (match checkpoint_ref_of_canonical_bytes canonical_bytes checkpoint with
+     | Error error -> Error (Ref_identity_invalid error)
+     | Ok reference
+       when not
+              (Keeper_id.Trace_id.equal
+                 expected_session_id reference.trace_id) ->
+       Error
+         (Ref_session_mismatch
+            { expected = expected_session_id; actual = reference.trace_id })
+     | Ok reference -> Ok (checkpoint, reference))
+
+let load_oas_with_ref ~session_dir ~session_id =
+  match Keeper_id.Trace_id.of_string session_id with
+  | Error reason -> Error (Ref_identity_invalid (Session_id_invalid reason))
+  | Ok expected_session_id ->
+    (match
+       with_session_lock ~session_dir (fun session_dir ->
+         load_ref_locked ~session_dir ~expected_session_id)
+     with
+     | Ok result -> result
+     | Error detail -> Error (Ref_lock_failed detail))
+
+let with_checkpoint_cas_lock ~session_dir ~candidate_ref f =
+  match canonical_session_location session_dir with
+  | Error error ->
+    Error
+      (Source_unavailable
+         (Ref_lock_failed (save_oas_error_to_string error)))
+  | Ok session_dir ->
+    let lock_path = session_dir ^ ".checkpoint.lock" in
+    (match File_lock_eio.with_durable_lock ~lock_path (fun () -> f session_dir) with
+     | Ok result -> result
+     | Error error ->
+       (match error.File_lock_eio.phase with
+        | File_lock_eio.Release_process_lock ->
+          Error
+            (Transaction_outcome_unknown
+               { possible_installed_ref = candidate_ref; error })
+        | File_lock_eio.Open_lock_file
+        | File_lock_eio.Acquire_process_lock ->
+          Error
+            (Source_unavailable
+               (Ref_lock_failed
+                  (File_lock_eio.durable_lock_error_to_string error)))))
+
+let save_oas_if_source
+    ~session_dir
+    ~(expected_source_ref : Keeper_checkpoint_ref.t)
+    (candidate : Agent_sdk.Checkpoint.t) =
+  let candidate_json = Agent_sdk.Checkpoint.to_json candidate in
+  let candidate_bytes = Yojson.Safe.to_string candidate_json in
+  match checkpoint_ref_of_canonical_bytes candidate_bytes candidate with
+  | Error error -> Error (Candidate_identity_invalid error)
+  | Ok candidate_ref
+    when not
+           (Keeper_id.Trace_id.equal
+              expected_source_ref.trace_id candidate_ref.trace_id) ->
+    Error
+      (Candidate_session_mismatch
+         { expected = expected_source_ref.trace_id
+         ; candidate = candidate_ref.trace_id
+         })
+  | Ok candidate_ref
+    when not (Int.equal expected_source_ref.generation candidate_ref.generation) ->
+    Error
+      (Candidate_generation_mismatch
+         { expected = expected_source_ref.generation
+         ; candidate = candidate_ref.generation
+         })
+  | Ok candidate_ref
+    when candidate_ref.turn_count < expected_source_ref.turn_count ->
+    Error
+      (Candidate_turn_regressed
+         { source_turn = expected_source_ref.turn_count
+         ; candidate_turn = candidate_ref.turn_count
+         })
+  | Ok candidate_ref ->
+    let expected_session_id = expected_source_ref.trace_id in
+    with_checkpoint_cas_lock ~session_dir ~candidate_ref (fun session_dir ->
+      match load_ref_locked ~session_dir ~expected_session_id with
+         | Error error -> Error (Source_unavailable error)
+         | Ok (_, actual_source)
+           when not (Keeper_checkpoint_ref.equal expected_source_ref actual_source) ->
+           Error (Source_changed actual_source)
+         | Ok _ ->
+           let canonical_path =
+             oas_checkpoint_path
+               ~session_dir
+               ~session_id:(Keeper_id.Trace_id.to_string expected_session_id)
+           in
+           let ownership_root = Filename.dirname session_dir in
+           (match
+              Keeper_fs.save_json_durable_atomic
+                ~ownership_root
+                ~pretty:false
+                canonical_path
+                candidate_json
+            with
+            | Error error when error.Keeper_fs.renamed ->
+              Error
+                (Commit_durability_unknown
+                   { installed_ref = candidate_ref; error })
+            | Error error -> Error (Commit_not_installed error)
+            | Ok () ->
+              (* [candidate_bytes] and [save_json_durable_atomic ~pretty:false]
+                 use the same [Yojson.Safe.to_string candidate_json] contract.
+                 Once the writer returns [Ok], rename and both durability
+                 fsyncs have completed; a post-commit read cannot downgrade
+                 that committed outcome to a retryable failure. *)
+              Ok candidate_ref))
 
 let save_oas_classified_typed
     ~(session_dir : string)

--- a/lib/keeper/keeper_checkpoint_store.mli
+++ b/lib/keeper/keeper_checkpoint_store.mli
@@ -127,6 +127,75 @@ val load_oas :
   session_id:string ->
   (Agent_sdk.Checkpoint.t, checkpoint_load_error) result
 
+type checkpoint_identity_error =
+  | Session_id_invalid of string
+  | Generation_missing
+  | Generation_not_integer
+  | Ref_create_failed of Keeper_checkpoint_ref.create_error
+
+type checkpoint_ref_load_error =
+  | Ref_not_found
+  | Ref_read_failed of checkpoint_load_error
+  | Ref_identity_invalid of checkpoint_identity_error
+  | Ref_session_mismatch of
+      { expected : Keeper_id.Trace_id.t
+      ; actual : Keeper_id.Trace_id.t
+      }
+  | Ref_lock_failed of string
+
+(** Load one canonical checkpoint and its exact source identity from the same
+    locked byte snapshot. No size, mtime, timestamp, or process cache
+    participates in the identity. *)
+val load_oas_with_ref :
+  session_dir:string ->
+  session_id:string ->
+  ( Agent_sdk.Checkpoint.t * Keeper_checkpoint_ref.t
+  , checkpoint_ref_load_error )
+  result
+
+type checkpoint_cas_error =
+  | Source_unavailable of checkpoint_ref_load_error
+  | Source_changed of Keeper_checkpoint_ref.t
+  | Candidate_identity_invalid of checkpoint_identity_error
+  | Candidate_session_mismatch of
+      { expected : Keeper_id.Trace_id.t
+      ; candidate : Keeper_id.Trace_id.t
+      }
+  | Candidate_generation_mismatch of
+      { expected : int
+      ; candidate : int
+      }
+  | Candidate_turn_regressed of
+      { source_turn : int
+      ; candidate_turn : int
+      }
+  | Commit_not_installed of Keeper_fs.durable_write_error
+  | Commit_durability_unknown of
+      { installed_ref : Keeper_checkpoint_ref.t
+      ; error : Keeper_fs.durable_write_error
+      }
+  | Transaction_outcome_unknown of
+      { possible_installed_ref : Keeper_checkpoint_ref.t
+      ; error : File_lock_eio.durable_lock_error
+      }
+
+(** Conditionally publish [candidate] only when the canonical bytes still
+    have exactly [expected_source_ref]. The stable session lock is reacquired,
+    current bytes are re-read and hashed, and an equal-turn checkpoint with
+    different content is rejected as [Source_changed]. On success the returned
+    ref is derived from the exact compact bytes passed to the durable atomic
+    JSON writer. A writer error after atomic rename is
+    [Commit_durability_unknown], never a retryable not-installed failure. This
+    same rule applies when releasing the stable lock fails after the body:
+    [Transaction_outcome_unknown] requires reconciliation rather than retry. The
+    payload-store commit is not an operation terminal fact; the Keeper operation
+    journal owns that authority. *)
+val save_oas_if_source :
+  session_dir:string ->
+  expected_source_ref:Keeper_checkpoint_ref.t ->
+  Agent_sdk.Checkpoint.t ->
+  (Keeper_checkpoint_ref.t, checkpoint_cas_error) result
+
 module For_testing : sig
   (** Number of times the checkpoint watermark resolution has fallen back to
       a full canonical-file parse (sidecar absent, corrupt, or fingerprint

--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -87,39 +87,10 @@ type compaction_decision =
   | Not_requested
   | Skipped_no_checkpoint
 
-type compaction_evidence =
-  { selected_runtime_id : string option
-  ; before_checkpoint_bytes : int
-  ; after_checkpoint_bytes : int
-  ; before_message_count : int
-  ; after_message_count : int
-  ; summarized_message_count : int
-  ; dropped_message_count : int
-  ; before_tool_use_count : int
-  ; after_tool_use_count : int
-  ; before_tool_result_count : int
-  ; after_tool_result_count : int
-  }
-
-let compaction_evidence_to_json evidence =
-  `Assoc
-    [ "before_checkpoint_bytes", `Int evidence.before_checkpoint_bytes
-    ; "after_checkpoint_bytes", `Int evidence.after_checkpoint_bytes
-    ; "before_message_count", `Int evidence.before_message_count
-    ; "after_message_count", `Int evidence.after_message_count
-    ; "summarized_message_count", `Int evidence.summarized_message_count
-    ; "dropped_message_count", `Int evidence.dropped_message_count
-    ; "before_tool_use_count", `Int evidence.before_tool_use_count
-    ; "after_tool_use_count", `Int evidence.after_tool_use_count
-    ; "before_tool_result_count", `Int evidence.before_tool_result_count
-    ; "after_tool_result_count", `Int evidence.after_tool_result_count
-    ]
-;;
-
 type compaction_preparation =
   { context : working_context
   ; decision : compaction_decision
-  ; evidence : compaction_evidence option
+  ; evidence : Keeper_compaction_evidence.t option
   }
 
 let compaction_decision_to_string = function

--- a/lib/keeper/keeper_compact_policy.mli
+++ b/lib/keeper/keeper_compact_policy.mli
@@ -23,30 +23,10 @@ val compaction_decision_to_string : compaction_decision -> string
 val compaction_decision_prepared : compaction_decision -> bool
 val compaction_decision_applied : compaction_decision -> bool
 
-type compaction_evidence =
-  { selected_runtime_id : string option
-  ; before_checkpoint_bytes : int
-  ; after_checkpoint_bytes : int
-  ; before_message_count : int
-  ; after_message_count : int
-  ; summarized_message_count : int
-  ; dropped_message_count : int
-  ; before_tool_use_count : int
-  ; after_tool_use_count : int
-  ; before_tool_result_count : int
-  ; after_tool_result_count : int
-  }
-(** Exact structural evidence from the LLM-selected plan. Byte, message, and
-    tool-block counts are measured from the actual checkpoint on both sides;
-    no token estimate is synthesized. *)
-
-val compaction_evidence_to_json : compaction_evidence -> Yojson.Safe.t
-(** Lossless wire projection shared by every MASC compaction producer. *)
-
 type compaction_preparation =
   { context : Keeper_context_core.working_context
   ; decision : compaction_decision
-  ; evidence : compaction_evidence option
+  ; evidence : Keeper_compaction_evidence.t option
   }
 
 (** Legacy configuration projection retained until the unused ratio/message/

--- a/lib/keeper/keeper_context_runtime.ml
+++ b/lib/keeper/keeper_context_runtime.ml
@@ -108,7 +108,7 @@ type post_turn_lifecycle = Keeper_post_turn.post_turn_lifecycle = {
 type overflow_retry_recovery = Keeper_post_turn.overflow_retry_recovery = {
   checkpoint : Agent_sdk.Checkpoint.t;
   compaction : compaction_event;
-  evidence : Keeper_compact_policy.compaction_evidence;
+  evidence : Keeper_compaction_evidence.t;
   turn_generation : int;
 }
 

--- a/lib/keeper/keeper_context_runtime.mli
+++ b/lib/keeper/keeper_context_runtime.mli
@@ -111,7 +111,7 @@ type context_budget_source =
 type overflow_retry_recovery =
   { checkpoint : Agent_sdk.Checkpoint.t
   ; compaction : compaction_event
-  ; evidence : Keeper_compact_policy.compaction_evidence
+  ; evidence : Keeper_compaction_evidence.t
   ; turn_generation : int
   }
 

--- a/lib/keeper/keeper_manual_compaction.ml
+++ b/lib/keeper/keeper_manual_compaction.ml
@@ -52,7 +52,7 @@ let append_manifest ~config ~base_dir ~(meta : keeper_meta) recovery =
                 [ "trigger", `String (Compaction_trigger.to_label trigger)
                 ; "trigger_detail", Compaction_trigger.to_detail_json trigger
                 ; ( "exact_evidence"
-                  , Keeper_compact_policy.compaction_evidence_to_json recovery.evidence )
+                  , Keeper_compaction_evidence.to_json recovery.evidence )
                 ])))
       ~checkpoint_path
       ()

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -71,7 +71,7 @@ type post_turn_lifecycle = {
 type overflow_retry_recovery = {
   checkpoint : Agent_sdk.Checkpoint.t;
   compaction : compaction_event;
-  evidence : Keeper_compact_policy.compaction_evidence;
+  evidence : Keeper_compaction_evidence.t;
   turn_generation : int;
 } [@@warning "-69"]
 

--- a/lib/keeper/keeper_post_turn.mli
+++ b/lib/keeper/keeper_post_turn.mli
@@ -50,7 +50,7 @@ type post_turn_lifecycle =
 type overflow_retry_recovery =
   { checkpoint : Agent_sdk.Checkpoint.t
   ; compaction : compaction_event
-  ; evidence : Keeper_compact_policy.compaction_evidence
+  ; evidence : Keeper_compaction_evidence.t
   ; turn_generation : int
   } [@@warning "-69"]
 

--- a/lib/keeper/keeper_tool_boundary.ml
+++ b/lib/keeper/keeper_tool_boundary.ml
@@ -7,11 +7,13 @@ type 'a context = {
   clock : 'a Eio.Time.clock;
   proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option;
   net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option;
+  invocation_ref : Tool_invocation_ref.t option;
   publication_recovery_provider :
     Keeper_publication_recovery_availability.provider;
 }
 
 let create
+      ?invocation_ref
       ~config
       ~agent_name
       ~sw
@@ -19,6 +21,7 @@ let create
       ~proc_mgr
       ~net
       ~publication_recovery_provider
+      ()
   =
   { config
   ; agent_name
@@ -26,6 +29,7 @@ let create
   ; clock
   ; proc_mgr
   ; net
+  ; invocation_ref
   ; publication_recovery_provider
   }
 
@@ -41,10 +45,15 @@ let to_tool_keeper_context (ctx : _ context) : _ Keeper_tool_surface.context =
   }
 
 let dispatch ctx ~name ~args =
-  Keeper_tool_surface.dispatch (to_tool_keeper_context ctx) ~name ~args
+  Keeper_tool_surface.dispatch
+    ?invocation_ref:ctx.invocation_ref
+    (to_tool_keeper_context ctx)
+    ~name
+    ~args
 
 (* TEL-OK: this only closes over Keeper-owned context; dispatch remains observed downstream. *)
 let delegated_dispatch
+      ?invocation_ref
       ~config
       ~agent_name
       ~sw
@@ -52,9 +61,11 @@ let delegated_dispatch
       ~proc_mgr
       ~net
       ~publication_recovery_provider
+      ()
   =
   let ctx =
     create
+      ?invocation_ref
       ~config
       ~agent_name
       ~sw
@@ -62,6 +73,7 @@ let delegated_dispatch
       ~proc_mgr
       ~net
       ~publication_recovery_provider
+      ()
   in
   fun ~name ~args -> dispatch ctx ~name ~args
 ;;

--- a/lib/keeper/keeper_tool_boundary.mli
+++ b/lib/keeper/keeper_tool_boundary.mli
@@ -10,11 +10,13 @@ type 'a context = {
   clock : 'a Eio.Time.clock;
   proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option;
   net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option;
+  invocation_ref : Tool_invocation_ref.t option;
   publication_recovery_provider :
     Keeper_publication_recovery_availability.provider;
 }
 
 val create :
+  ?invocation_ref:Tool_invocation_ref.t ->
   config:Workspace.config ->
   agent_name:string ->
   sw:Eio.Switch.t ->
@@ -23,12 +25,14 @@ val create :
   net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option ->
   publication_recovery_provider:
     Keeper_publication_recovery_availability.provider ->
+  unit ->
   'a context
 
 val dispatch :
   _ context -> name:string -> args:Yojson.Safe.t -> Keeper_types_profile.tool_result option
 
 val delegated_dispatch :
+  ?invocation_ref:Tool_invocation_ref.t ->
   config:Workspace.config ->
   agent_name:string ->
   sw:Eio.Switch.t ->
@@ -37,6 +41,7 @@ val delegated_dispatch :
   net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option ->
   publication_recovery_provider:
     Keeper_publication_recovery_availability.provider ->
+  unit ->
   name:string ->
   args:Yojson.Safe.t ->
   Keeper_types_profile.tool_result option

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -501,7 +501,12 @@ let manual_compaction_wakeup_observation ~base_path keeper_name =
 
 (** Queue an operator compaction for the target Keeper's owning lane. *)
 (* RFC-0182 §3.1 — ctx-free body for keeper_dispatch_ref path. *)
-let keeper_compact_body ~(config : Workspace.config) args : tool_result =
+let keeper_compact_body
+      ?invocation_ref
+      ~(config : Workspace.config)
+      args
+  : tool_result
+  =
   match resolve_keeper_name_config ~config args with
   | Error err -> tool_result_error err
   | Ok name ->
@@ -535,6 +540,11 @@ let keeper_compact_body ~(config : Workspace.config) args : tool_result =
             ; "queued", `Bool true
             ; "queue_outcome", `String queue_outcome
             ; "stimulus", `String (Keeper_event_queue.payload_kind_label stimulus.payload)
+            ; ( "producer_invocation"
+              , Option.fold
+                  ~none:`Null
+                  ~some:Tool_invocation_ref.to_yojson
+                  invocation_ref )
             ; ( "wake"
               , manual_compaction_wakeup_observation
                   ~base_path:config.base_path
@@ -557,8 +567,8 @@ let keeper_compact_body ~(config : Workspace.config) args : tool_result =
        | Stimulus_enqueued -> queued "enqueued"
        | Stimulus_already_present -> queued "already_present")
 
-let handle_keeper_compact ctx args : tool_result =
-  keeper_compact_body ~config:ctx.config args
+let handle_keeper_compact ?invocation_ref ctx args : tool_result =
+  keeper_compact_body ?invocation_ref ~config:ctx.config args
 
 (** Last-resort context clear.
 
@@ -697,7 +707,7 @@ let keeper_clear_body ~(config : Workspace.config) args : tool_result =
 let handle_keeper_clear ctx args : tool_result =
   keeper_clear_body ~config:ctx.config args
 
-let dispatch ctx ~name ~args : tool_result option =
+let dispatch ?invocation_ref ctx ~name ~args : tool_result option =
   maybe_bootstrap_existing_keepalives ctx ~name ~args;
   let ctx = resolve_ctx ctx ~name args in
   match name with
@@ -740,7 +750,11 @@ let dispatch ctx ~name ~args : tool_result option =
            ~tool_name:name
            (handle_keeper_sandbox_status ctx args))
   | "masc_keeper_reset" -> Some (tool_result_with_tool_name ~tool_name:name (handle_keeper_reset ctx args))
-  | "masc_keeper_compact" -> Some (tool_result_with_tool_name ~tool_name:name (handle_keeper_compact ctx args))
+  | "masc_keeper_compact" ->
+    Some
+      (tool_result_with_tool_name
+         ~tool_name:name
+         (handle_keeper_compact ?invocation_ref ctx args))
   | "masc_keeper_clear" -> Some (tool_result_with_tool_name ~tool_name:name (handle_keeper_clear ctx args))
   | _ -> None
 

--- a/lib/keeper/keeper_tool_surface.mli
+++ b/lib/keeper/keeper_tool_surface.mli
@@ -17,7 +17,11 @@ type tool_result = Keeper_types_profile.tool_result
 val schemas : Masc_domain.tool_schema list
 
 val dispatch :
-  _ context -> name:string -> args:Yojson.Safe.t -> tool_result option
+  ?invocation_ref:Tool_invocation_ref.t ->
+  _ context ->
+  name:string ->
+  args:Yojson.Safe.t ->
+  tool_result option
 
 (** Internal async-message entry point for adapters whose authenticated
     submission principal differs from the target turn's [ctx.agent_name].

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -276,7 +276,7 @@ let append_provider_overflow_manifest
                ; "source_requeued", `Bool true
                ; "error", error
                ; ( "exact_evidence"
-                 , Keeper_compact_policy.compaction_evidence_to_json evidence )
+                 , Keeper_compaction_evidence.to_json evidence )
                ]))
         Keeper_runtime_manifest.Context_compacted
     in

--- a/lib/keeper_checkpoint_ref/dune
+++ b/lib/keeper_checkpoint_ref/dune
@@ -1,0 +1,8 @@
+(include_subdirs no)
+
+(library
+ (name masc_keeper_checkpoint_ref)
+ (public_name masc.keeper_checkpoint_ref)
+ (wrapped false)
+ (modules keeper_checkpoint_ref)
+ (libraries digestif masc.keeper_registry))

--- a/lib/keeper_checkpoint_ref/keeper_checkpoint_ref.ml
+++ b/lib/keeper_checkpoint_ref/keeper_checkpoint_ref.ml
@@ -1,0 +1,48 @@
+type t =
+  { trace_id : Keeper_id.Trace_id.t
+  ; generation : int
+  ; turn_count : int
+  ; sha256 : string
+  }
+
+type create_error =
+  | Negative_generation of int
+  | Negative_turn_count of int
+  | Invalid_sha256 of string
+
+let validate_coordinates ~generation ~turn_count =
+  if generation < 0
+  then Error (Negative_generation generation)
+  else if turn_count < 0
+  then Error (Negative_turn_count turn_count)
+  else Ok ()
+;;
+
+let create ~trace_id ~generation ~turn_count ~canonical_checkpoint_bytes =
+  match validate_coordinates ~generation ~turn_count with
+  | Error _ as error -> error
+  | Ok () ->
+    Ok
+      { trace_id
+      ; generation
+      ; turn_count
+      ; sha256 = Digestif.SHA256.(digest_string canonical_checkpoint_bytes |> to_hex)
+      }
+;;
+
+let of_persisted ~trace_id ~generation ~turn_count ~sha256 =
+  match validate_coordinates ~generation ~turn_count with
+  | Error _ as error -> error
+  | Ok () ->
+    (match Digestif.SHA256.consistent_of_hex_opt sha256 with
+     | Some digest when String.equal sha256 (Digestif.SHA256.to_hex digest) ->
+       Ok { trace_id; generation; turn_count; sha256 }
+     | Some _ | None -> Error (Invalid_sha256 sha256))
+;;
+
+let equal left right =
+  Keeper_id.Trace_id.equal left.trace_id right.trace_id
+  && Int.equal left.generation right.generation
+  && Int.equal left.turn_count right.turn_count
+  && String.equal left.sha256 right.sha256
+;;

--- a/lib/keeper_checkpoint_ref/keeper_checkpoint_ref.mli
+++ b/lib/keeper_checkpoint_ref/keeper_checkpoint_ref.mli
@@ -1,0 +1,32 @@
+(** Exact identity of one canonical Keeper checkpoint payload. *)
+type t = private
+  { trace_id : Keeper_id.Trace_id.t
+  ; generation : int
+  ; turn_count : int
+  ; sha256 : string
+  }
+
+type create_error =
+  | Negative_generation of int
+  | Negative_turn_count of int
+  | Invalid_sha256 of string
+
+val create
+  :  trace_id:Keeper_id.Trace_id.t
+  -> generation:int
+  -> turn_count:int
+  -> canonical_checkpoint_bytes:string
+  -> (t, create_error) result
+(** Hashes the supplied canonical bytes exactly; no JSON decode or re-encoding
+    occurs at this identity boundary. *)
+
+val of_persisted
+  :  trace_id:Keeper_id.Trace_id.t
+  -> generation:int
+  -> turn_count:int
+  -> sha256:string
+  -> (t, create_error) result
+(** Restores an identity from its canonical lowercase SHA-256 projection.
+    Non-canonical or malformed digests are rejected. *)
+
+val equal : t -> t -> bool

--- a/lib/keeper_compaction_evidence/dune
+++ b/lib/keeper_compaction_evidence/dune
@@ -1,0 +1,8 @@
+(include_subdirs no)
+
+(library
+ (name masc_keeper_compaction_evidence)
+ (public_name masc.keeper_compaction_evidence)
+ (wrapped false)
+ (modules keeper_compaction_evidence)
+ (libraries yojson))

--- a/lib/keeper_compaction_evidence/keeper_compaction_evidence.ml
+++ b/lib/keeper_compaction_evidence/keeper_compaction_evidence.ml
@@ -1,0 +1,150 @@
+type t =
+  { selected_runtime_id : string option
+  ; before_checkpoint_bytes : int
+  ; after_checkpoint_bytes : int
+  ; before_message_count : int
+  ; after_message_count : int
+  ; summarized_message_count : int
+  ; dropped_message_count : int
+  ; before_tool_use_count : int
+  ; after_tool_use_count : int
+  ; before_tool_result_count : int
+  ; after_tool_result_count : int
+  }
+
+type field =
+  | Before_checkpoint_bytes
+  | After_checkpoint_bytes
+  | Before_message_count
+  | After_message_count
+  | Summarized_message_count
+  | Dropped_message_count
+  | Before_tool_use_count
+  | After_tool_use_count
+  | Before_tool_result_count
+  | After_tool_result_count
+
+type field_error =
+  | Missing
+  | Duplicate
+  | Expected_integer
+  | Negative_integer
+
+type measure =
+  | Checkpoint_bytes
+  | Messages
+  | Tool_uses
+  | Tool_results
+
+type decode_error =
+  | Expected_object
+  | Unknown_field of string
+  | Invalid_field of field * field_error
+  | Empty_selected_runtime_id
+  | Invalid_transition of measure * int * int
+  | No_messages_compacted
+
+let schema =
+  [ Before_checkpoint_bytes, "before_checkpoint_bytes"
+  ; After_checkpoint_bytes, "after_checkpoint_bytes"
+  ; Before_message_count, "before_message_count"
+  ; After_message_count, "after_message_count"
+  ; Summarized_message_count, "summarized_message_count"
+  ; Dropped_message_count, "dropped_message_count"
+  ; Before_tool_use_count, "before_tool_use_count"
+  ; After_tool_use_count, "after_tool_use_count"
+  ; Before_tool_result_count, "before_tool_result_count"
+  ; After_tool_result_count, "after_tool_result_count"
+  ]
+;;
+
+let field_name field = List.assoc field schema
+let known_field name = List.exists (fun (_, key) -> String.equal name key) schema
+
+let ( let* ) = Result.bind
+
+let decode_nonnegative_integer fields field =
+  match
+    List.filter
+      (fun (name, _) -> String.equal name (field_name field))
+      fields
+  with
+  | [] -> Error (Invalid_field (field, Missing))
+  | [ _, `Int value ] when value >= 0 -> Ok value
+  | [ _, `Int _ ] -> Error (Invalid_field (field, Negative_integer))
+  | [ _ ] -> Error (Invalid_field (field, Expected_integer))
+  | _ -> Error (Invalid_field (field, Duplicate))
+;;
+
+let of_json ~selected_runtime_id = function
+  | `Assoc fields ->
+    let* () =
+      match
+        List.find_opt
+          (fun (name, _) -> not (known_field name))
+          fields
+      with
+      | None -> Ok ()
+      | Some (name, _) -> Error (Unknown_field name)
+    in
+    let* () =
+      match selected_runtime_id with
+      | Some runtime_id when String.trim runtime_id = "" ->
+        Error Empty_selected_runtime_id
+      | Some _ | None -> Ok ()
+    in
+    let integer = decode_nonnegative_integer fields in
+    let* before_checkpoint_bytes = integer Before_checkpoint_bytes in
+    let* after_checkpoint_bytes = integer After_checkpoint_bytes in
+    let* before_message_count = integer Before_message_count in
+    let* after_message_count = integer After_message_count in
+    let* summarized_message_count = integer Summarized_message_count in
+    let* dropped_message_count = integer Dropped_message_count in
+    let* before_tool_use_count = integer Before_tool_use_count in
+    let* after_tool_use_count = integer After_tool_use_count in
+    let* before_tool_result_count = integer Before_tool_result_count in
+    let* after_tool_result_count = integer After_tool_result_count in
+    if after_checkpoint_bytes >= before_checkpoint_bytes
+    then Error (Invalid_transition (Checkpoint_bytes, before_checkpoint_bytes, after_checkpoint_bytes))
+    else if after_message_count > before_message_count
+    then Error (Invalid_transition (Messages, before_message_count, after_message_count))
+    else if after_tool_use_count > before_tool_use_count
+    then Error (Invalid_transition (Tool_uses, before_tool_use_count, after_tool_use_count))
+    else if after_tool_result_count > before_tool_result_count
+    then
+      Error
+        (Invalid_transition
+           (Tool_results, before_tool_result_count, after_tool_result_count))
+    else if summarized_message_count = 0 && dropped_message_count = 0
+    then Error No_messages_compacted
+    else
+      Ok
+        { selected_runtime_id
+        ; before_checkpoint_bytes
+        ; after_checkpoint_bytes
+        ; before_message_count
+        ; after_message_count
+        ; summarized_message_count
+        ; dropped_message_count
+        ; before_tool_use_count
+        ; after_tool_use_count
+        ; before_tool_result_count
+        ; after_tool_result_count
+        }
+  | _ -> Error Expected_object
+;;
+
+let to_json evidence =
+  `Assoc
+    [ "before_checkpoint_bytes", `Int evidence.before_checkpoint_bytes
+    ; "after_checkpoint_bytes", `Int evidence.after_checkpoint_bytes
+    ; "before_message_count", `Int evidence.before_message_count
+    ; "after_message_count", `Int evidence.after_message_count
+    ; "summarized_message_count", `Int evidence.summarized_message_count
+    ; "dropped_message_count", `Int evidence.dropped_message_count
+    ; "before_tool_use_count", `Int evidence.before_tool_use_count
+    ; "after_tool_use_count", `Int evidence.after_tool_use_count
+    ; "before_tool_result_count", `Int evidence.before_tool_result_count
+    ; "after_tool_result_count", `Int evidence.after_tool_result_count
+    ]
+;;

--- a/lib/keeper_compaction_evidence/keeper_compaction_evidence.mli
+++ b/lib/keeper_compaction_evidence/keeper_compaction_evidence.mli
@@ -1,0 +1,60 @@
+(** Exact structural evidence for one LLM compaction result. *)
+type t =
+  { selected_runtime_id : string option
+  ; before_checkpoint_bytes : int
+  ; after_checkpoint_bytes : int
+  ; before_message_count : int
+  ; after_message_count : int
+  ; summarized_message_count : int
+  ; dropped_message_count : int
+  ; before_tool_use_count : int
+  ; after_tool_use_count : int
+  ; before_tool_result_count : int
+  ; after_tool_result_count : int
+  }
+
+type field =
+  | Before_checkpoint_bytes
+  | After_checkpoint_bytes
+  | Before_message_count
+  | After_message_count
+  | Summarized_message_count
+  | Dropped_message_count
+  | Before_tool_use_count
+  | After_tool_use_count
+  | Before_tool_result_count
+  | After_tool_result_count
+
+type field_error =
+  | Missing
+  | Duplicate
+  | Expected_integer
+  | Negative_integer
+
+type measure =
+  | Checkpoint_bytes
+  | Messages
+  | Tool_uses
+  | Tool_results
+
+type decode_error =
+  | Expected_object
+  | Unknown_field of string
+  | Invalid_field of field * field_error
+  | Empty_selected_runtime_id
+  | Invalid_transition of measure * int * int
+  | No_messages_compacted
+
+val to_json : t -> Yojson.Safe.t
+(** Structural observation projection of the exact measured counts.
+    [selected_runtime_id] remains the enclosing runtime projection. *)
+
+val of_json
+  :  selected_runtime_id:string option
+  -> Yojson.Safe.t
+  -> (t, decode_error) result
+(** Restore persisted structural evidence. The Runtime identity is supplied
+    from its enclosing typed projection rather than duplicated in the counts
+    object. Unknown, duplicate, missing, malformed, or objectively impossible
+    evidence is rejected explicitly. [Checkpoint_bytes] must strictly reduce;
+    the other measures may stay equal but cannot increase. *)

--- a/lib/keeper_compaction_operation/dune
+++ b/lib/keeper_compaction_operation/dune
@@ -1,0 +1,30 @@
+(include_subdirs no)
+
+(library
+ (name masc_keeper_compaction_operation)
+ (public_name masc.keeper_compaction_operation)
+ (wrapped false)
+ (modules
+  keeper_compaction_operation
+  keeper_compaction_operation_action_selector
+  keeper_compaction_operation_codec
+  keeper_compaction_operation_codec_support
+  keeper_compaction_operation_identity
+  keeper_compaction_operation_json
+  keeper_compaction_operation_record
+  keeper_compaction_operation_reducer
+  keeper_compaction_operation_store)
+ (private_modules keeper_compaction_operation_codec_support)
+ (libraries
+  eio
+  masc.compaction_trigger
+  masc.fs_compat
+  masc.keeper_checkpoint_ref
+  masc.keeper_compaction_evidence
+  masc.keeper_registry
+  masc.masc_core
+  masc.masc_types
+  masc.tool_invocation_ref
+  threads
+  uuidm
+  yojson))

--- a/lib/keeper_compaction_operation/keeper_compaction_operation.ml
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation.ml
@@ -1,0 +1,114 @@
+module Operation_id = Keeper_compaction_operation_identity.Operation_id
+module Attempt_id = Keeper_compaction_operation_identity.Attempt_id
+module Cause = Keeper_compaction_operation_identity.Cause
+
+type attempt_failure =
+  | Pre_commit_failure of Cause.t
+  | Candidate_not_installed of
+      { cause : Cause.t
+      ; observed_checkpoint : Keeper_checkpoint_ref.t
+      }
+
+type reconciliation_reason =
+  | Commit_durability_unknown
+  | Transaction_outcome_unknown
+
+type request =
+  { keeper_name : Keeper_id.Keeper_name.t
+  ; source_checkpoint : Keeper_checkpoint_ref.t
+  ; trigger : Compaction_trigger.t
+  ; cause : Cause.t
+  ; producer_invocation : Tool_invocation_ref.t option
+  }
+
+type candidate =
+  { attempt_id : Attempt_id.t
+  ; source_checkpoint : Keeper_checkpoint_ref.t
+  ; candidate_checkpoint : Keeper_checkpoint_ref.t
+  ; evidence : Keeper_compaction_evidence.t
+  }
+
+type supersession =
+  { attempt_id : Attempt_id.t
+  ; observed_checkpoint : Keeper_checkpoint_ref.t option
+  }
+
+type event_view =
+  | Requested of request
+  | Attempt_started of Attempt_id.t
+  | Candidate_prepared of candidate
+  | Attempt_failed of Attempt_id.t * attempt_failure
+  | Commit_reconciliation_required of candidate * reconciliation_reason
+  | Source_superseded of supersession
+  | Compacted of candidate
+  | Reinjected of Keeper_checkpoint_ref.t * Ids.Turn_ref.t
+
+type event =
+  { operation_id : Operation_id.t
+  ; view : event_view
+  }
+
+let operation_id event = event.operation_id
+let view event = event.view
+
+let candidate ~attempt_id ~source_checkpoint ~candidate_checkpoint ~evidence =
+  { attempt_id; source_checkpoint; candidate_checkpoint; evidence }
+;;
+
+let requested ~operation_id ~keeper_name ~source_checkpoint ~trigger ~cause
+    ~producer_invocation =
+  { operation_id
+  ; view =
+      Requested
+        { keeper_name; source_checkpoint; trigger; cause; producer_invocation }
+  }
+;;
+
+let attempt_started ~operation_id ~attempt_id =
+  { operation_id; view = Attempt_started attempt_id }
+;;
+
+let candidate_prepared ~operation_id ~attempt_id ~source_checkpoint
+    ~candidate_checkpoint ~evidence =
+  { operation_id
+  ; view =
+      Candidate_prepared
+        (candidate ~attempt_id ~source_checkpoint ~candidate_checkpoint ~evidence)
+  }
+;;
+
+let attempt_failed ~operation_id ~attempt_id ~failure =
+  { operation_id; view = Attempt_failed (attempt_id, failure) }
+;;
+
+let commit_reconciliation_required ~operation_id ~attempt_id ~source_checkpoint
+    ~candidate_checkpoint ~evidence ~reason =
+  { operation_id
+  ; view =
+      Commit_reconciliation_required
+        (candidate ~attempt_id ~source_checkpoint ~candidate_checkpoint ~evidence, reason)
+  }
+;;
+
+let source_superseded ~operation_id ~attempt_id ~observed_checkpoint =
+  { operation_id
+  ; view = Source_superseded { attempt_id; observed_checkpoint }
+  }
+;;
+
+let compacted ~operation_id ~attempt_id ~source_checkpoint
+    ~committed_checkpoint ~evidence =
+  { operation_id
+  ; view =
+      Compacted
+        (candidate
+           ~attempt_id
+           ~source_checkpoint
+           ~candidate_checkpoint:committed_checkpoint
+           ~evidence)
+  }
+;;
+
+let reinjected ~operation_id ~adopted_checkpoint ~adopting_turn =
+  { operation_id; view = Reinjected (adopted_checkpoint, adopting_turn) }
+;;

--- a/lib/keeper_compaction_operation/keeper_compaction_operation.mli
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation.mli
@@ -1,0 +1,97 @@
+(** Typed immutable facts for one Keeper compaction operation. *)
+
+module Operation_id = Keeper_compaction_operation_identity.Operation_id
+module Attempt_id = Keeper_compaction_operation_identity.Attempt_id
+module Cause = Keeper_compaction_operation_identity.Cause
+
+type attempt_failure =
+  | Pre_commit_failure of Cause.t
+  | Candidate_not_installed of
+      { cause : Cause.t
+      ; observed_checkpoint : Keeper_checkpoint_ref.t
+      }
+
+type reconciliation_reason =
+  | Commit_durability_unknown
+  | Transaction_outcome_unknown
+
+type request =
+  { keeper_name : Keeper_id.Keeper_name.t
+  ; source_checkpoint : Keeper_checkpoint_ref.t
+  ; trigger : Compaction_trigger.t
+  ; cause : Cause.t
+  ; producer_invocation : Tool_invocation_ref.t option
+  }
+
+type candidate =
+  { attempt_id : Attempt_id.t
+  ; source_checkpoint : Keeper_checkpoint_ref.t
+  ; candidate_checkpoint : Keeper_checkpoint_ref.t
+  ; evidence : Keeper_compaction_evidence.t
+  }
+
+type supersession =
+  { attempt_id : Attempt_id.t
+  ; observed_checkpoint : Keeper_checkpoint_ref.t option
+  }
+
+type event_view =
+  | Requested of request
+  | Attempt_started of Attempt_id.t
+  | Candidate_prepared of candidate
+  | Attempt_failed of Attempt_id.t * attempt_failure
+  | Commit_reconciliation_required of candidate * reconciliation_reason
+  | Source_superseded of supersession
+  | Compacted of candidate
+  | Reinjected of Keeper_checkpoint_ref.t * Ids.Turn_ref.t
+
+type event
+val operation_id : event -> Operation_id.t
+val view : event -> event_view
+
+val requested :
+  operation_id:Operation_id.t ->
+  keeper_name:Keeper_id.Keeper_name.t ->
+  source_checkpoint:Keeper_checkpoint_ref.t ->
+  trigger:Compaction_trigger.t ->
+  cause:Cause.t ->
+  producer_invocation:Tool_invocation_ref.t option ->
+  event
+val attempt_started : operation_id:Operation_id.t -> attempt_id:Attempt_id.t -> event
+val candidate_prepared :
+  operation_id:Operation_id.t ->
+  attempt_id:Attempt_id.t ->
+  source_checkpoint:Keeper_checkpoint_ref.t ->
+  candidate_checkpoint:Keeper_checkpoint_ref.t ->
+  evidence:Keeper_compaction_evidence.t ->
+  event
+val attempt_failed :
+  operation_id:Operation_id.t ->
+  attempt_id:Attempt_id.t ->
+  failure:attempt_failure ->
+  event
+val commit_reconciliation_required :
+  operation_id:Operation_id.t ->
+  attempt_id:Attempt_id.t ->
+  source_checkpoint:Keeper_checkpoint_ref.t ->
+  candidate_checkpoint:Keeper_checkpoint_ref.t ->
+  evidence:Keeper_compaction_evidence.t ->
+  reason:reconciliation_reason ->
+  event
+val source_superseded :
+  operation_id:Operation_id.t ->
+  attempt_id:Attempt_id.t ->
+  observed_checkpoint:Keeper_checkpoint_ref.t option ->
+  event
+val compacted :
+  operation_id:Operation_id.t ->
+  attempt_id:Attempt_id.t ->
+  source_checkpoint:Keeper_checkpoint_ref.t ->
+  committed_checkpoint:Keeper_checkpoint_ref.t ->
+  evidence:Keeper_compaction_evidence.t ->
+  event
+val reinjected :
+  operation_id:Operation_id.t ->
+  adopted_checkpoint:Keeper_checkpoint_ref.t ->
+  adopting_turn:Ids.Turn_ref.t ->
+  event

--- a/lib/keeper_compaction_operation/keeper_compaction_operation_action_selector.ml
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation_action_selector.ml
@@ -1,0 +1,147 @@
+module Operation = Keeper_compaction_operation
+module Reducer = Keeper_compaction_operation_reducer
+module Store = Keeper_compaction_operation_store
+
+type mode =
+  | Startup_recovery
+  | Steady_state
+
+type operation_context =
+  { operation_id : Operation.Operation_id.t
+  ; request_cursor : Store.Cursor.t
+  ; request : Operation.request
+  }
+
+type candidate_context =
+  { operation : operation_context
+  ; candidate : Operation.candidate
+  }
+
+type attempt_context =
+  { operation : operation_context
+  ; attempt_id : Operation.Attempt_id.t
+  }
+
+type action =
+  | Start_attempt of operation_context
+  | Terminalize_interrupted_attempt of attempt_context
+  | Resume_candidate_commit of candidate_context
+  | Reconcile_commit of candidate_context * Operation.reconciliation_reason
+  | Wake_for_reinjection of candidate_context
+
+type selection =
+  | Selected of action
+  | In_flight of attempt_context
+  | Idle
+
+type required_fact =
+  | Attempt_id
+  | Candidate_checkpoint
+  | Evidence
+  | Reconciliation_reason
+  | Committed_checkpoint
+
+type invariant_error =
+  | Missing_fact of
+      { operation_id : Operation.Operation_id.t
+      ; phase : Reducer.phase
+      ; fact : required_fact
+      }
+  | Committed_checkpoint_mismatch of
+      { operation_id : Operation.Operation_id.t
+      ; candidate_checkpoint : Keeper_checkpoint_ref.t
+      ; committed_checkpoint : Keeper_checkpoint_ref.t
+      }
+
+let ( let* ) = Result.bind
+
+let operation_context (entry : Store.operation_entry) =
+  let snapshot = entry.snapshot in
+  { operation_id = snapshot.operation_id
+  ; request_cursor = entry.request_cursor
+  ; request =
+      { keeper_name = snapshot.keeper_name
+      ; source_checkpoint = snapshot.source_checkpoint
+      ; trigger = snapshot.trigger
+      ; cause = snapshot.cause
+      ; producer_invocation = snapshot.producer_invocation
+      }
+  }
+
+let require (snapshot : Reducer.snapshot) fact = function
+  | Some value -> Ok value
+  | None ->
+    Error
+      (Missing_fact
+         { operation_id = snapshot.operation_id; phase = snapshot.phase; fact })
+
+let candidate_context entry =
+  let snapshot = entry.Store.snapshot in
+  let* attempt_id = require snapshot Attempt_id snapshot.attempt_id in
+  let* candidate_checkpoint =
+    require snapshot Candidate_checkpoint snapshot.candidate_checkpoint
+  in
+  let* evidence = require snapshot Evidence snapshot.evidence in
+  Ok
+    { operation = operation_context entry
+    ; candidate =
+        { attempt_id
+        ; source_checkpoint = snapshot.source_checkpoint
+        ; candidate_checkpoint
+        ; evidence
+        }
+    }
+
+let committed_candidate_context entry =
+  let snapshot = entry.Store.snapshot in
+  let* candidate = candidate_context entry in
+  let* committed_checkpoint =
+    require snapshot Committed_checkpoint snapshot.committed_checkpoint
+  in
+  if
+    Keeper_checkpoint_ref.equal
+      candidate.candidate.candidate_checkpoint
+      committed_checkpoint
+  then Ok candidate
+  else
+    Error
+      (Committed_checkpoint_mismatch
+         { operation_id = snapshot.operation_id
+         ; candidate_checkpoint = candidate.candidate.candidate_checkpoint
+         ; committed_checkpoint
+         })
+
+let select ~mode (replay : Store.replay) =
+  let rec first = function
+    | [] -> Ok Idle
+    | entry :: rest ->
+      let snapshot = entry.Store.snapshot in
+      let operation = operation_context entry in
+      (match snapshot.phase with
+       | Reducer.Adopted | Reducer.Failed | Reducer.Superseded -> first rest
+       | Reducer.Request_pending -> Ok (Selected (Start_attempt operation))
+       | Reducer.Attempt_in_progress ->
+         let* attempt_id = require snapshot Attempt_id snapshot.attempt_id in
+         (match mode with
+         | Startup_recovery ->
+            Ok
+              (Selected
+                 (Terminalize_interrupted_attempt { operation; attempt_id }))
+          | Steady_state -> Ok (In_flight { operation; attempt_id }))
+       | Reducer.Candidate_pending_commit ->
+         let* candidate = candidate_context entry in
+         Ok (Selected (Resume_candidate_commit candidate))
+       | Reducer.Reconciliation_pending ->
+         let* candidate = candidate_context entry in
+         let* reason =
+           require
+             snapshot
+             Reconciliation_reason
+             snapshot.reconciliation_reason
+        in
+        Ok (Selected (Reconcile_commit (candidate, reason)))
+       | Reducer.Commit_complete ->
+         let* candidate = committed_candidate_context entry in
+         Ok (Selected (Wake_for_reinjection candidate)))
+  in
+  first replay.operations

--- a/lib/keeper_compaction_operation/keeper_compaction_operation_action_selector.mli
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation_action_selector.mli
@@ -1,0 +1,59 @@
+module Operation = Keeper_compaction_operation
+module Reducer = Keeper_compaction_operation_reducer
+module Store = Keeper_compaction_operation_store
+
+type mode =
+  | Startup_recovery
+  | Steady_state
+
+type operation_context =
+  { operation_id : Operation.Operation_id.t
+  ; request_cursor : Store.Cursor.t
+  ; request : Operation.request
+  }
+
+type candidate_context =
+  { operation : operation_context
+  ; candidate : Operation.candidate
+  }
+
+type attempt_context =
+  { operation : operation_context
+  ; attempt_id : Operation.Attempt_id.t
+  }
+
+type action =
+  | Start_attempt of operation_context
+  | Terminalize_interrupted_attempt of attempt_context
+  | Resume_candidate_commit of candidate_context
+  | Reconcile_commit of candidate_context * Operation.reconciliation_reason
+  | Wake_for_reinjection of candidate_context
+
+type selection =
+  | Selected of action
+  | In_flight of attempt_context
+  | Idle
+
+type required_fact =
+  | Attempt_id
+  | Candidate_checkpoint
+  | Evidence
+  | Reconciliation_reason
+  | Committed_checkpoint
+
+type invariant_error =
+  | Missing_fact of
+      { operation_id : Operation.Operation_id.t
+      ; phase : Reducer.phase
+      ; fact : required_fact
+      }
+  | Committed_checkpoint_mismatch of
+      { operation_id : Operation.Operation_id.t
+      ; candidate_checkpoint : Keeper_checkpoint_ref.t
+      ; committed_checkpoint : Keeper_checkpoint_ref.t
+      }
+
+val select
+  :  mode:mode
+  -> Store.replay
+  -> (selection, invariant_error) result

--- a/lib/keeper_compaction_operation/keeper_compaction_operation_codec.ml
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation_codec.ml
@@ -1,0 +1,206 @@
+module Operation = Keeper_compaction_operation
+module Support = Keeper_compaction_operation_codec_support
+include Support
+
+let ( let* ) = Result.bind
+let to_json = Keeper_compaction_operation_json.to_json
+
+let field ~path name decode fields =
+  let* json = Support.required_field ~path name fields in
+  decode ~path name json
+;;
+
+let nested ~path name decode fields =
+  let* json = Support.required_field ~path name fields in
+  decode ~path:(path ^ "." ^ name) json
+;;
+
+type candidate =
+  { attempt_id : Operation.Attempt_id.t
+  ; source_checkpoint : Keeper_checkpoint_ref.t
+  ; candidate_checkpoint : Keeper_checkpoint_ref.t
+  ; evidence : Keeper_compaction_evidence.t
+  }
+
+let candidate ~path ~checkpoint_field fields =
+  let* attempt_id = field ~path "attempt_id" Support.attempt_id fields in
+  let* source_checkpoint =
+    nested ~path "source_checkpoint" Support.checkpoint fields
+  in
+  let* candidate_checkpoint =
+    nested ~path checkpoint_field Support.checkpoint fields
+  in
+  let* evidence = nested ~path "evidence" Support.evidence fields in
+  Ok { attempt_id; source_checkpoint; candidate_checkpoint; evidence }
+;;
+
+let candidate_fields checkpoint_field =
+  [ "attempt_id"; "source_checkpoint"; checkpoint_field; "evidence" ]
+;;
+
+let decode_candidate ~operation_id ~checkpoint_field ~make payload =
+  let path = "payload" in
+  let fields = candidate_fields checkpoint_field in
+  let* values = Support.exact_object ~path ~allowed:fields ~required:fields payload in
+  let* value = candidate ~path ~checkpoint_field values in
+  Ok (make value ~operation_id)
+;;
+
+let decode_requested ~operation_id payload =
+  let path = "payload" in
+  let fields =
+    [ "keeper_name"
+    ; "source_checkpoint"
+    ; "trigger"
+    ; "cause"
+    ; "producer_invocation"
+    ]
+  in
+  let* values = Support.exact_object ~path ~allowed:fields ~required:fields payload in
+  let* keeper_name = field ~path "keeper_name" Support.keeper_name values in
+  let* source_checkpoint =
+    nested ~path "source_checkpoint" Support.checkpoint values
+  in
+  let* trigger = nested ~path "trigger" Support.trigger values in
+  let* cause = field ~path "cause" Support.cause values in
+  let* producer_json = Support.required_field ~path "producer_invocation" values in
+  let* producer_invocation = Support.producer_invocation producer_json in
+  Ok
+    (Operation.requested
+       ~operation_id
+       ~keeper_name
+       ~source_checkpoint
+       ~trigger
+       ~cause
+       ~producer_invocation)
+;;
+
+let decode_attempt_started ~operation_id payload =
+  let path = "payload" in
+  let fields = [ "attempt_id" ] in
+  let* values = Support.exact_object ~path ~allowed:fields ~required:fields payload in
+  let* attempt_id = field ~path "attempt_id" Support.attempt_id values in
+  Ok (Operation.attempt_started ~operation_id ~attempt_id)
+;;
+
+let decode_attempt_failed ~operation_id payload =
+  let path = "payload" in
+  let fields = [ "attempt_id"; "failure_kind"; "cause"; "observed_checkpoint" ] in
+  let* values = Support.exact_object ~path ~allowed:fields ~required:fields payload in
+  let* attempt_id = field ~path "attempt_id" Support.attempt_id values in
+  let* failure_kind = field ~path "failure_kind" Support.string_field values in
+  let* cause = field ~path "cause" Support.cause values in
+  let* observed = Support.required_field ~path "observed_checkpoint" values in
+  let* failure =
+    match failure_kind, observed with
+    | "pre_commit", `Null -> Ok (Operation.Pre_commit_failure cause)
+    | "pre_commit", _ ->
+      Error
+        (Support.Invalid_field
+           (Support.Wrong_type
+              { path; field = "observed_checkpoint"; expected = "null" }))
+    | "candidate_not_installed", json ->
+      let* observed_checkpoint =
+        Support.checkpoint ~path:"payload.observed_checkpoint" json
+      in
+      Ok (Operation.Candidate_not_installed { cause; observed_checkpoint })
+    | unknown, _ -> Error (Support.Unknown_failure_kind unknown)
+  in
+  Ok (Operation.attempt_failed ~operation_id ~attempt_id ~failure)
+;;
+
+let decode_reconciliation ~operation_id payload =
+  let path = "payload" in
+  let fields = candidate_fields "candidate_checkpoint" @ [ "reason" ] in
+  let* values = Support.exact_object ~path ~allowed:fields ~required:fields payload in
+  let* value = candidate ~path ~checkpoint_field:"candidate_checkpoint" values in
+  let* reason = field ~path "reason" Support.string_field values in
+  let* reason =
+    match reason with
+    | "commit_durability_unknown" -> Ok Operation.Commit_durability_unknown
+    | "transaction_outcome_unknown" -> Ok Operation.Transaction_outcome_unknown
+    | unknown -> Error (Support.Unknown_reconciliation_reason unknown)
+  in
+  Ok
+    (Operation.commit_reconciliation_required
+       ~operation_id
+       ~attempt_id:value.attempt_id
+       ~source_checkpoint:value.source_checkpoint
+       ~candidate_checkpoint:value.candidate_checkpoint
+       ~evidence:value.evidence
+       ~reason)
+;;
+
+let decode_reinjected ~operation_id payload =
+  let path = "payload" in
+  let fields = [ "adopted_checkpoint"; "adopting_turn" ] in
+  let* values = Support.exact_object ~path ~allowed:fields ~required:fields payload in
+  let* adopted_checkpoint =
+    nested ~path "adopted_checkpoint" Support.checkpoint values
+  in
+  let* turn_json = Support.required_field ~path "adopting_turn" values in
+  let* adopting_turn = Support.turn_ref turn_json in
+  Ok (Operation.reinjected ~operation_id ~adopted_checkpoint ~adopting_turn)
+;;
+
+let decode_source_superseded ~operation_id payload =
+  let path = "payload" in
+  let fields = [ "attempt_id"; "observed_checkpoint" ] in
+  let* values = Support.exact_object ~path ~allowed:fields ~required:fields payload in
+  let* attempt_id = field ~path "attempt_id" Support.attempt_id values in
+  let* observed_json = Support.required_field ~path "observed_checkpoint" values in
+  let* observed_checkpoint =
+    match observed_json with
+    | `Null -> Ok None
+    | json ->
+      Support.checkpoint ~path:"payload.observed_checkpoint" json
+      |> Result.map Option.some
+  in
+  Ok
+    (Operation.source_superseded
+       ~operation_id
+       ~attempt_id
+       ~observed_checkpoint)
+;;
+
+let of_json json =
+  let path = "$" in
+  let fields = [ "kind"; "operation_id"; "payload" ] in
+  let* values = Support.exact_object ~path ~allowed:fields ~required:fields json in
+  let* kind = field ~path "kind" Support.string_field values in
+  let* operation_id = field ~path "operation_id" Support.operation_id values in
+  let* payload = Support.required_field ~path "payload" values in
+  match kind with
+  | "requested" -> decode_requested ~operation_id payload
+  | "attempt_started" -> decode_attempt_started ~operation_id payload
+  | "candidate_prepared" ->
+    decode_candidate
+      ~operation_id
+      ~checkpoint_field:"candidate_checkpoint"
+      ~make:(fun value ~operation_id ->
+        Operation.candidate_prepared
+          ~operation_id
+          ~attempt_id:value.attempt_id
+          ~source_checkpoint:value.source_checkpoint
+          ~candidate_checkpoint:value.candidate_checkpoint
+          ~evidence:value.evidence)
+      payload
+  | "attempt_failed" -> decode_attempt_failed ~operation_id payload
+  | "commit_reconciliation_required" ->
+    decode_reconciliation ~operation_id payload
+  | "source_superseded" -> decode_source_superseded ~operation_id payload
+  | "compacted" ->
+    decode_candidate
+      ~operation_id
+      ~checkpoint_field:"committed_checkpoint"
+      ~make:(fun value ~operation_id ->
+        Operation.compacted
+          ~operation_id
+          ~attempt_id:value.attempt_id
+          ~source_checkpoint:value.source_checkpoint
+          ~committed_checkpoint:value.candidate_checkpoint
+          ~evidence:value.evidence)
+      payload
+  | "reinjected" -> decode_reinjected ~operation_id payload
+  | unknown -> Error (Support.Unknown_event_kind unknown)
+;;

--- a/lib/keeper_compaction_operation/keeper_compaction_operation_codec.mli
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation_codec.mli
@@ -1,0 +1,40 @@
+(** Closed durable codec for typed compaction operation facts. *)
+
+type field_error = Keeper_compaction_operation_codec_support.field_error =
+  | Unknown_field of
+      { path : string
+      ; field : string
+      }
+  | Duplicate_field of
+      { path : string
+      ; field : string
+      }
+  | Missing_field of
+      { path : string
+      ; field : string
+      }
+  | Wrong_type of
+      { path : string
+      ; field : string
+      ; expected : string
+      }
+
+type decode_error = Keeper_compaction_operation_codec_support.decode_error =
+  | Expected_object of string
+  | Invalid_field of field_error
+  | Unknown_event_kind of string
+  | Unknown_failure_kind of string
+  | Unknown_reconciliation_reason of string
+  | Invalid_operation_id of Keeper_compaction_operation_identity.id_error
+  | Invalid_attempt_id of Keeper_compaction_operation_identity.id_error
+  | Invalid_keeper_name of string
+  | Invalid_trace_id of string
+  | Invalid_cause of Keeper_compaction_operation_identity.Cause.error
+  | Invalid_checkpoint of Keeper_checkpoint_ref.create_error
+  | Invalid_trigger of Compaction_trigger.decode_error
+  | Invalid_producer of Tool_invocation_ref.decode_error
+  | Invalid_evidence of Keeper_compaction_evidence.decode_error
+  | Invalid_turn_ref of string
+
+val to_json : Keeper_compaction_operation.event -> Yojson.Safe.t
+val of_json : Yojson.Safe.t -> (Keeper_compaction_operation.event, decode_error) result

--- a/lib/keeper_compaction_operation/keeper_compaction_operation_codec_support.ml
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation_codec_support.ml
@@ -1,0 +1,167 @@
+module Operation = Keeper_compaction_operation
+
+type field_error =
+  | Unknown_field of
+      { path : string
+      ; field : string
+      }
+  | Duplicate_field of
+      { path : string
+      ; field : string
+      }
+  | Missing_field of
+      { path : string
+      ; field : string
+      }
+  | Wrong_type of
+      { path : string
+      ; field : string
+      ; expected : string
+      }
+
+type decode_error =
+  | Expected_object of string
+  | Invalid_field of field_error
+  | Unknown_event_kind of string
+  | Unknown_failure_kind of string
+  | Unknown_reconciliation_reason of string
+  | Invalid_operation_id of Keeper_compaction_operation_identity.id_error
+  | Invalid_attempt_id of Keeper_compaction_operation_identity.id_error
+  | Invalid_keeper_name of string
+  | Invalid_trace_id of string
+  | Invalid_cause of Keeper_compaction_operation_identity.Cause.error
+  | Invalid_checkpoint of Keeper_checkpoint_ref.create_error
+  | Invalid_trigger of Compaction_trigger.decode_error
+  | Invalid_producer of Tool_invocation_ref.decode_error
+  | Invalid_evidence of Keeper_compaction_evidence.decode_error
+  | Invalid_turn_ref of string
+
+let ( let* ) = Result.bind
+let field_error error = Error (Invalid_field error)
+
+let exact_object ~path ~allowed ~required = function
+  | `Assoc fields ->
+    let rec validate seen = function
+      | [] -> Ok ()
+      | (field, _) :: _ when List.mem field seen ->
+        field_error (Duplicate_field { path; field })
+      | (field, _) :: _ when not (List.mem field allowed) ->
+        field_error (Unknown_field { path; field })
+      | (field, _) :: rest -> validate (field :: seen) rest
+    in
+    let rec require = function
+      | [] -> Ok fields
+      | field :: rest ->
+        if List.mem_assoc field fields
+        then require rest
+        else field_error (Missing_field { path; field })
+    in
+    let* () = validate [] fields in
+    require required
+  | _ -> Error (Expected_object path)
+;;
+
+let required_field ~path field fields =
+  match List.assoc_opt field fields with
+  | Some value -> Ok value
+  | None -> field_error (Missing_field { path; field })
+;;
+
+let string_field ~path field = function
+  | `String value -> Ok value
+  | _ -> field_error (Wrong_type { path; field; expected = "string" })
+;;
+
+let int_field ~path field = function
+  | `Int value -> Ok value
+  | _ -> field_error (Wrong_type { path; field; expected = "integer" })
+;;
+
+let operation_id ~path field json =
+  let* value = string_field ~path field json in
+  Operation.Operation_id.of_string value
+  |> Result.map_error (fun error -> Invalid_operation_id error)
+;;
+
+let attempt_id ~path field json =
+  let* value = string_field ~path field json in
+  Operation.Attempt_id.of_string value
+  |> Result.map_error (fun error -> Invalid_attempt_id error)
+;;
+
+let keeper_name ~path field json =
+  let* value = string_field ~path field json in
+  Keeper_id.Keeper_name.of_string value
+  |> Result.map_error (fun error -> Invalid_keeper_name error)
+;;
+
+let cause ~path field json =
+  let* value = string_field ~path field json in
+  Operation.Cause.of_string value
+  |> Result.map_error (fun error -> Invalid_cause error)
+;;
+
+let checkpoint ~path json =
+  let fields = [ "trace_id"; "generation"; "turn_count"; "sha256" ] in
+  let* values = exact_object ~path ~allowed:fields ~required:fields json in
+  let* trace_json = required_field ~path "trace_id" values in
+  let* trace_value = string_field ~path "trace_id" trace_json in
+  let* trace_id =
+    Keeper_id.Trace_id.of_string trace_value
+    |> Result.map_error (fun error -> Invalid_trace_id error)
+  in
+  let* generation_json = required_field ~path "generation" values in
+  let* generation = int_field ~path "generation" generation_json in
+  let* turn_count_json = required_field ~path "turn_count" values in
+  let* turn_count = int_field ~path "turn_count" turn_count_json in
+  let* sha_json = required_field ~path "sha256" values in
+  let* sha256 = string_field ~path "sha256" sha_json in
+  Keeper_checkpoint_ref.of_persisted ~trace_id ~generation ~turn_count ~sha256
+  |> Result.map_error (fun error -> Invalid_checkpoint error)
+;;
+
+let evidence ~path json =
+  let fields = [ "selected_runtime_id"; "counts" ] in
+  let* values = exact_object ~path ~allowed:fields ~required:fields json in
+  let* runtime_json = required_field ~path "selected_runtime_id" values in
+  let* selected_runtime_id =
+    match runtime_json with
+    | `Null -> Ok None
+    | `String value -> Ok (Some value)
+    | _ ->
+      field_error
+        (Wrong_type
+           { path; field = "selected_runtime_id"; expected = "string or null" })
+  in
+  let* counts = required_field ~path "counts" values in
+  Keeper_compaction_evidence.of_json ~selected_runtime_id counts
+  |> Result.map_error (fun error -> Invalid_evidence error)
+;;
+
+let trigger ~path json =
+  let* trigger =
+    Compaction_trigger.of_detail_json json
+    |> Result.map_error (fun error -> Invalid_trigger error)
+  in
+  let allowed, required =
+    match trigger with
+    | Compaction_trigger.Manual -> [ "kind" ], [ "kind" ]
+    | Provider_overflow _ ->
+      [ "kind"; "limit_tokens" ], [ "kind"; "limit_tokens" ]
+  in
+  let* _ = exact_object ~path ~allowed ~required json in
+  Ok trigger
+;;
+
+let producer_invocation = function
+  | `Null -> Ok None
+  | json ->
+    Tool_invocation_ref.of_yojson json
+    |> Result.map_error (fun error -> Invalid_producer error)
+    |> Result.map Option.some
+;;
+
+let turn_ref json =
+  Ids.Turn_ref.of_yojson json
+  |> Result.map_error (fun error -> Invalid_turn_ref error)
+;;

--- a/lib/keeper_compaction_operation/keeper_compaction_operation_codec_support.mli
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation_codec_support.mli
@@ -1,0 +1,99 @@
+type field_error =
+  | Unknown_field of
+      { path : string
+      ; field : string
+      }
+  | Duplicate_field of
+      { path : string
+      ; field : string
+      }
+  | Missing_field of
+      { path : string
+      ; field : string
+      }
+  | Wrong_type of
+      { path : string
+      ; field : string
+      ; expected : string
+      }
+
+type decode_error =
+  | Expected_object of string
+  | Invalid_field of field_error
+  | Unknown_event_kind of string
+  | Unknown_failure_kind of string
+  | Unknown_reconciliation_reason of string
+  | Invalid_operation_id of Keeper_compaction_operation_identity.id_error
+  | Invalid_attempt_id of Keeper_compaction_operation_identity.id_error
+  | Invalid_keeper_name of string
+  | Invalid_trace_id of string
+  | Invalid_cause of Keeper_compaction_operation_identity.Cause.error
+  | Invalid_checkpoint of Keeper_checkpoint_ref.create_error
+  | Invalid_trigger of Compaction_trigger.decode_error
+  | Invalid_producer of Tool_invocation_ref.decode_error
+  | Invalid_evidence of Keeper_compaction_evidence.decode_error
+  | Invalid_turn_ref of string
+
+val exact_object
+  :  path:string
+  -> allowed:string list
+  -> required:string list
+  -> Yojson.Safe.t
+  -> ((string * Yojson.Safe.t) list, decode_error) result
+
+val required_field
+  :  path:string
+  -> string
+  -> (string * Yojson.Safe.t) list
+  -> (Yojson.Safe.t, decode_error) result
+
+val string_field
+  :  path:string
+  -> string
+  -> Yojson.Safe.t
+  -> (string, decode_error) result
+
+val operation_id
+  :  path:string
+  -> string
+  -> Yojson.Safe.t
+  -> (Keeper_compaction_operation.Operation_id.t, decode_error) result
+
+val attempt_id
+  :  path:string
+  -> string
+  -> Yojson.Safe.t
+  -> (Keeper_compaction_operation.Attempt_id.t, decode_error) result
+
+val keeper_name
+  :  path:string
+  -> string
+  -> Yojson.Safe.t
+  -> (Keeper_id.Keeper_name.t, decode_error) result
+
+val cause
+  :  path:string
+  -> string
+  -> Yojson.Safe.t
+  -> (Keeper_compaction_operation.Cause.t, decode_error) result
+
+val checkpoint
+  :  path:string
+  -> Yojson.Safe.t
+  -> (Keeper_checkpoint_ref.t, decode_error) result
+
+val evidence
+  :  path:string
+  -> Yojson.Safe.t
+  -> (Keeper_compaction_evidence.t, decode_error) result
+
+val trigger
+  :  path:string
+  -> Yojson.Safe.t
+  -> (Compaction_trigger.t, decode_error) result
+
+val producer_invocation
+  :  Yojson.Safe.t
+  -> (Tool_invocation_ref.t option, decode_error) result
+
+val turn_ref : Yojson.Safe.t -> (Ids.Turn_ref.t, decode_error) result

--- a/lib/keeper_compaction_operation/keeper_compaction_operation_identity.ml
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation_identity.ml
@@ -1,0 +1,43 @@
+type id_error = Invalid_canonical_uuid
+
+module Make_id () = struct
+  type t = Uuidm.t
+
+  (* NDT-OK: entropy creates identity only; no lifecycle decision uses it. *)
+  let rng = Random.State.make_self_init ()
+  let rng_mutex = Stdlib.Mutex.create ()
+  let generate () =
+    Stdlib.Mutex.protect rng_mutex (fun () -> Uuidm.v4_gen rng ())
+  ;;
+
+  let of_string value =
+    match Uuidm.of_string value with
+    | Some id when String.equal value (Uuidm.to_string id) -> Ok id
+    | Some _ | None -> Error Invalid_canonical_uuid
+  ;;
+
+  let to_string id = Uuidm.to_string id
+  let equal = Uuidm.equal
+  let compare = Uuidm.compare
+end
+
+module Operation_id = Make_id ()
+module Attempt_id = Make_id ()
+
+module Cause = struct
+  type t = string
+  type error =
+    | Empty
+    | Noncanonical
+
+  let of_string value =
+    if value = ""
+    then Error Empty
+    else if String.equal value (String.trim value)
+    then Ok value
+    else Error Noncanonical
+  ;;
+
+  let to_string value = value
+  let equal = String.equal
+end

--- a/lib/keeper_compaction_operation/keeper_compaction_operation_identity.mli
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation_identity.mli
@@ -1,0 +1,31 @@
+(** Canonical identities carried by Keeper compaction operation events. *)
+
+type id_error = Invalid_canonical_uuid
+
+module Operation_id : sig
+  type t
+  val generate : unit -> t
+  val of_string : string -> (t, id_error) result
+  val to_string : t -> string
+  val equal : t -> t -> bool
+  val compare : t -> t -> int
+end
+
+module Attempt_id : sig
+  type t
+  val generate : unit -> t
+  val of_string : string -> (t, id_error) result
+  val to_string : t -> string
+  val equal : t -> t -> bool
+  val compare : t -> t -> int
+end
+
+module Cause : sig
+  type t
+  type error =
+    | Empty
+    | Noncanonical
+  val of_string : string -> (t, error) result
+  val to_string : t -> string
+  val equal : t -> t -> bool
+end

--- a/lib/keeper_compaction_operation/keeper_compaction_operation_json.ml
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation_json.ml
@@ -1,0 +1,113 @@
+module Operation = Keeper_compaction_operation
+open Operation
+
+let checkpoint (checkpoint : Keeper_checkpoint_ref.t) =
+  `Assoc
+    [ "trace_id", `String (Keeper_id.Trace_id.to_string checkpoint.trace_id)
+    ; "generation", `Int checkpoint.generation
+    ; "turn_count", `Int checkpoint.turn_count
+    ; "sha256", `String checkpoint.sha256
+    ]
+;;
+
+let evidence evidence =
+  `Assoc
+    [ ( "selected_runtime_id"
+      , match evidence.Keeper_compaction_evidence.selected_runtime_id with
+        | Some value -> `String value
+        | None -> `Null )
+    ; "counts", Keeper_compaction_evidence.to_json evidence
+    ]
+;;
+
+let candidate ~checkpoint_field (candidate : Operation.candidate) =
+  [ "attempt_id", `String (Operation.Attempt_id.to_string candidate.attempt_id)
+  ; "source_checkpoint", checkpoint candidate.source_checkpoint
+  ; checkpoint_field, checkpoint candidate.candidate_checkpoint
+  ; "evidence", evidence candidate.evidence
+  ]
+;;
+
+let envelope event kind payload =
+  `Assoc
+    [ "kind", `String kind
+    ; "operation_id", `String (Operation.Operation_id.to_string (Operation.operation_id event))
+    ; "payload", `Assoc payload
+    ]
+;;
+
+let to_json event =
+  match Operation.view event with
+  | Requested request ->
+    envelope
+      event
+      "requested"
+      [ "keeper_name", `String (Keeper_id.Keeper_name.to_string request.keeper_name)
+      ; "source_checkpoint", checkpoint request.source_checkpoint
+      ; "trigger", Compaction_trigger.to_detail_json request.trigger
+      ; "cause", `String (Operation.Cause.to_string request.cause)
+      ; ( "producer_invocation"
+        , match request.producer_invocation with
+          | Some producer -> Tool_invocation_ref.to_yojson producer
+          | None -> `Null )
+      ]
+  | Attempt_started attempt_id ->
+    envelope
+      event
+      "attempt_started"
+      [ "attempt_id", `String (Operation.Attempt_id.to_string attempt_id) ]
+  | Candidate_prepared value ->
+    envelope
+      event
+      "candidate_prepared"
+      (candidate ~checkpoint_field:"candidate_checkpoint" value)
+  | Attempt_failed (attempt_id, failure) ->
+    let failure_kind, cause, observed_checkpoint =
+      match failure with
+      | Pre_commit_failure cause -> "pre_commit", cause, `Null
+      | Candidate_not_installed { cause; observed_checkpoint } ->
+        "candidate_not_installed", cause, checkpoint observed_checkpoint
+    in
+    envelope
+      event
+      "attempt_failed"
+      [ "attempt_id", `String (Operation.Attempt_id.to_string attempt_id)
+      ; "failure_kind", `String failure_kind
+      ; "cause", `String (Operation.Cause.to_string cause)
+      ; "observed_checkpoint", observed_checkpoint
+      ]
+  | Commit_reconciliation_required (value, reason) ->
+    let reason =
+      match reason with
+      | Commit_durability_unknown -> "commit_durability_unknown"
+      | Transaction_outcome_unknown -> "transaction_outcome_unknown"
+    in
+    envelope
+      event
+      "commit_reconciliation_required"
+      (candidate ~checkpoint_field:"candidate_checkpoint" value
+       @ [ "reason", `String reason ])
+  | Source_superseded supersession ->
+    envelope
+      event
+      "source_superseded"
+      [ ( "attempt_id"
+        , `String (Operation.Attempt_id.to_string supersession.attempt_id) )
+      ; ( "observed_checkpoint"
+        , match supersession.observed_checkpoint with
+          | Some value -> checkpoint value
+          | None -> `Null )
+      ]
+  | Compacted value ->
+    envelope
+      event
+      "compacted"
+      (candidate ~checkpoint_field:"committed_checkpoint" value)
+  | Reinjected (adopted_checkpoint, adopting_turn) ->
+    envelope
+      event
+      "reinjected"
+      [ "adopted_checkpoint", checkpoint adopted_checkpoint
+      ; "adopting_turn", Ids.Turn_ref.to_yojson adopting_turn
+      ]
+;;

--- a/lib/keeper_compaction_operation/keeper_compaction_operation_json.mli
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation_json.mli
@@ -1,0 +1,3 @@
+(** Canonical JSON projection of typed compaction operation facts. *)
+
+val to_json : Keeper_compaction_operation.event -> Yojson.Safe.t

--- a/lib/keeper_compaction_operation/keeper_compaction_operation_record.ml
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation_record.ml
@@ -1,0 +1,116 @@
+module Codec = Keeper_compaction_operation_codec
+
+module Cursor = struct
+  type t = int
+  type error = Negative of int
+  let zero = 0
+  let of_int value = if value < 0 then Error (Negative value) else Ok value
+  let to_int value = value
+end
+
+type row =
+  { recorded_at : float
+  ; start_cursor : Cursor.t
+  ; end_cursor : Cursor.t
+  ; event : Keeper_compaction_operation.event
+  }
+
+type envelope_error =
+  | Expected_object
+  | Unknown_field of string
+  | Duplicate_field of string
+  | Missing_field of string
+  | Invalid_recorded_at
+  | Invalid_event of Codec.decode_error
+
+type issue =
+  | Incomplete_tail
+  | Malformed_json of string
+  | Invalid_envelope of envelope_error
+
+type decode_error =
+  { row_number : int option
+  ; start_cursor : Cursor.t
+  ; end_cursor : Cursor.t
+  ; issue : issue
+  }
+
+let ( let* ) = Result.bind
+
+let required_field name fields =
+  match List.filter (fun (field, _) -> String.equal field name) fields with
+  | [] -> Error (Missing_field name)
+  | [ _, value ] -> Ok value
+  | _ -> Error (Duplicate_field name)
+;;
+
+let decode_envelope = function
+  | `Assoc fields ->
+    let* () =
+      match
+        List.find_opt
+          (fun (name, _) ->
+             not (String.equal name "recorded_at" || String.equal name "event"))
+          fields
+      with
+      | None -> Ok ()
+      | Some (name, _) -> Error (Unknown_field name)
+    in
+    let* recorded_json = required_field "recorded_at" fields in
+    let* recorded_at =
+      match recorded_json with
+      | `Float value when Float.is_finite value -> Ok value
+      | _ -> Error Invalid_recorded_at
+    in
+    let* event_json = required_field "event" fields in
+    Codec.of_json event_json
+    |> Result.map_error (fun error -> Invalid_event error)
+    |> Result.map (fun event -> recorded_at, event)
+  | _ -> Error Expected_object
+;;
+
+let encode ~recorded_at event =
+  if not (Float.is_finite recorded_at)
+  then Error Invalid_recorded_at
+  else
+    Ok
+      (`Assoc
+         [ "recorded_at", `Float recorded_at; "event", Codec.to_json event ]
+       |> Yojson.Safe.to_string
+       |> fun value -> value ^ "\n")
+;;
+
+let decode_rows ~from ~row_number bytes =
+  let base = Cursor.to_int from in
+  let length = String.length bytes in
+  let locate number start_cursor end_cursor issue =
+    Error { row_number = number; start_cursor; end_cursor; issue }
+  in
+  let rec loop position number rows =
+    if position = length
+    then Ok (List.rev rows)
+    else
+      match String.index_from_opt bytes position '\n' with
+      | None ->
+        locate number (base + position) (base + length) Incomplete_tail
+      | Some newline ->
+        let start_cursor = base + position in
+        let end_cursor = base + newline + 1 in
+        let payload = String.sub bytes position (newline - position) in
+        (match
+           try Ok (Yojson.Safe.from_string payload) with
+           | Yojson.Json_error detail -> Error (Malformed_json detail)
+         with
+         | Error issue -> locate number start_cursor end_cursor issue
+         | Ok json ->
+           (match decode_envelope json with
+            | Error error ->
+              locate number start_cursor end_cursor (Invalid_envelope error)
+            | Ok (recorded_at, event) ->
+              loop
+                (newline + 1)
+                (Option.map succ number)
+                ({ recorded_at; start_cursor; end_cursor; event } :: rows)))
+  in
+  loop 0 row_number []
+;;

--- a/lib/keeper_compaction_operation/keeper_compaction_operation_record.mli
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation_record.mli
@@ -1,0 +1,49 @@
+(** Closed JSONL record codec around one typed compaction operation event. *)
+
+module Cursor : sig
+  type t
+  type error = Negative of int
+  val zero : t
+  val of_int : int -> (t, error) result
+  val to_int : t -> int
+end
+
+type row =
+  { recorded_at : float
+  ; start_cursor : Cursor.t
+  ; end_cursor : Cursor.t
+  ; event : Keeper_compaction_operation.event
+  }
+
+type envelope_error =
+  | Expected_object
+  | Unknown_field of string
+  | Duplicate_field of string
+  | Missing_field of string
+  | Invalid_recorded_at
+  | Invalid_event of Keeper_compaction_operation_codec.decode_error
+
+type issue =
+  | Incomplete_tail
+  | Malformed_json of string
+  | Invalid_envelope of envelope_error
+
+type decode_error =
+  { row_number : int option
+  ; start_cursor : Cursor.t
+  ; end_cursor : Cursor.t
+  ; issue : issue
+  }
+
+val encode :
+  recorded_at:float ->
+  Keeper_compaction_operation.event ->
+  (string, envelope_error) result
+(** Returns exactly one newline-terminated JSONL row. *)
+
+val decode_rows :
+  from:Cursor.t ->
+  row_number:int option ->
+  string ->
+  (row list, decode_error) result
+(** [row_number] is [Some] only when the caller owns the complete prefix. *)

--- a/lib/keeper_compaction_operation/keeper_compaction_operation_reducer.ml
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation_reducer.ml
@@ -1,0 +1,343 @@
+module Operation = Keeper_compaction_operation
+
+type phase =
+  | Request_pending
+  | Attempt_in_progress
+  | Candidate_pending_commit
+  | Reconciliation_pending
+  | Commit_complete
+  | Adopted
+  | Failed
+  | Superseded
+
+type progress =
+  | Pending
+  | Running of Operation.Attempt_id.t
+  | Prepared of Operation.candidate
+  | Reconciling of Operation.candidate * Operation.reconciliation_reason
+  | Committed of Operation.candidate
+  | Adopted_state of
+      Operation.candidate * Keeper_checkpoint_ref.t * Ids.Turn_ref.t
+  | Failed_state of Operation.Attempt_id.t * Operation.attempt_failure
+  | Superseded_state of superseded_state
+
+and superseded_state =
+  { attempt_id : Operation.Attempt_id.t
+  ; candidate : Operation.candidate option
+  ; committed : bool
+  ; observed_checkpoint : Keeper_checkpoint_ref.t option
+  }
+
+type state =
+  { operation_id : Operation.Operation_id.t
+  ; request : Operation.request
+  ; progress : progress
+  }
+
+type snapshot =
+  { operation_id : Operation.Operation_id.t
+  ; keeper_name : Keeper_id.Keeper_name.t
+  ; source_checkpoint : Keeper_checkpoint_ref.t
+  ; trigger : Compaction_trigger.t
+  ; cause : Operation.Cause.t
+  ; producer_invocation : Tool_invocation_ref.t option
+  ; phase : phase
+  ; attempt_id : Operation.Attempt_id.t option
+  ; candidate_checkpoint : Keeper_checkpoint_ref.t option
+  ; evidence : Keeper_compaction_evidence.t option
+  ; reconciliation_reason : Operation.reconciliation_reason option
+  ; committed_checkpoint : Keeper_checkpoint_ref.t option
+  ; adopted_checkpoint : Keeper_checkpoint_ref.t option
+  ; adopting_turn : Ids.Turn_ref.t option
+  ; failure : Operation.attempt_failure option
+  ; superseded_by_checkpoint : Keeper_checkpoint_ref.t option
+  }
+
+type transition_error =
+  | Invalid_transition of phase option
+  | Operation_mismatch
+  | Attempt_mismatch
+  | Source_mismatch
+  | Candidate_mismatch
+  | Reinjection_identity_mismatch
+  | Supersession_not_observed
+  | Supersession_candidate_installed
+  | Supersession_trace_mismatch
+
+let phase state =
+  match state.progress with
+  | Pending -> Request_pending
+  | Running _ -> Attempt_in_progress
+  | Prepared _ -> Candidate_pending_commit
+  | Reconciling _ -> Reconciliation_pending
+  | Committed _ -> Commit_complete
+  | Adopted_state _ -> Adopted
+  | Failed_state _ -> Failed
+  | Superseded_state _ -> Superseded
+;;
+
+let projection = function
+  | Pending -> None, None, None, None, None, None, None, None, None
+  | Running attempt ->
+    Some attempt, None, None, None, None, None, None, None, None
+  | Prepared value ->
+    Some value.attempt_id, Some value.candidate_checkpoint, Some value.evidence,
+    None, None, None, None, None, None
+  | Reconciling (value, reason) ->
+    Some value.attempt_id, Some value.candidate_checkpoint, Some value.evidence,
+    Some reason, None, None, None, None, None
+  | Committed value ->
+    Some value.attempt_id, Some value.candidate_checkpoint, Some value.evidence,
+    None, Some value.candidate_checkpoint, None, None, None, None
+  | Adopted_state (value, checkpoint, turn) ->
+    Some value.attempt_id, Some value.candidate_checkpoint, Some value.evidence,
+    None, Some value.candidate_checkpoint, Some checkpoint, Some turn, None,
+    None
+  | Failed_state (attempt_id, failure) ->
+    Some attempt_id, None, None, None, None, None, None, Some failure, None
+  | Superseded_state superseded ->
+    let candidate_checkpoint, evidence =
+      match superseded.candidate with
+      | Some value -> Some value.candidate_checkpoint, Some value.evidence
+      | None -> None, None
+    in
+    let committed_checkpoint =
+      if superseded.committed then candidate_checkpoint else None
+    in
+    Some superseded.attempt_id, candidate_checkpoint, evidence, None,
+    committed_checkpoint, None, None, None, superseded.observed_checkpoint
+;;
+
+let snapshot state =
+  let attempt_id, candidate_checkpoint, evidence, reconciliation_reason,
+      committed_checkpoint, adopted_checkpoint, adopting_turn, failure,
+      superseded_by_checkpoint =
+    projection state.progress
+  in
+  { operation_id = state.operation_id
+  ; keeper_name = state.request.keeper_name
+  ; source_checkpoint = state.request.source_checkpoint
+  ; trigger = state.request.trigger
+  ; cause = state.request.cause
+  ; producer_invocation = state.request.producer_invocation
+  ; phase = phase state
+  ; attempt_id
+  ; candidate_checkpoint
+  ; evidence
+  ; reconciliation_reason
+  ; committed_checkpoint
+  ; adopted_checkpoint
+  ; adopting_turn
+  ; failure
+  ; superseded_by_checkpoint
+  }
+;;
+
+let same_candidate
+      (expected : Operation.candidate)
+      (actual : Operation.candidate)
+  =
+  if not (Operation.Attempt_id.equal expected.attempt_id actual.attempt_id)
+  then Error Attempt_mismatch
+  else if
+    not
+      (Keeper_checkpoint_ref.equal
+         expected.source_checkpoint
+         actual.source_checkpoint)
+  then Error Source_mismatch
+  else if
+    not
+      (Keeper_checkpoint_ref.equal
+         expected.candidate_checkpoint
+         actual.candidate_checkpoint
+       && expected.evidence = actual.evidence)
+  then Error Candidate_mismatch
+  else Ok ()
+;;
+
+let validate_supersession
+      (state : state)
+      (candidate : Operation.candidate option)
+      ~source_may_match
+      (observed_checkpoint : Keeper_checkpoint_ref.t option)
+  =
+  match observed_checkpoint with
+  | None -> Ok ()
+  | Some observed_checkpoint ->
+    if
+      not
+        (Keeper_id.Trace_id.equal
+           state.request.source_checkpoint.trace_id
+           observed_checkpoint.trace_id)
+    then Error Supersession_trace_mismatch
+    else if
+      not source_may_match
+      &&
+      Keeper_checkpoint_ref.equal
+        state.request.source_checkpoint
+        observed_checkpoint
+    then Error Supersession_not_observed
+    else
+      (match candidate with
+       | Some value
+         when Keeper_checkpoint_ref.equal
+                value.candidate_checkpoint
+                observed_checkpoint ->
+         Error Supersession_candidate_installed
+       | Some _ | None -> Ok ())
+;;
+
+let apply current event =
+  let invalid state = Error (Invalid_transition (Option.map phase state)) in
+  match current, Operation.view event with
+  | None, Operation.Requested request ->
+    Ok
+      { operation_id = Operation.operation_id event
+      ; request
+      ; progress = Pending
+      }
+  | None, _ | Some _, Operation.Requested _ -> invalid current
+  | Some state, view ->
+    if not (Operation.Operation_id.equal state.operation_id (Operation.operation_id event))
+    then Error Operation_mismatch
+    else
+      match state.progress, view with
+      | Pending, Operation.Attempt_started attempt_id ->
+        Ok { state with progress = Running attempt_id }
+      | Running expected, Operation.Candidate_prepared value ->
+        if not (Operation.Attempt_id.equal expected value.attempt_id)
+        then Error Attempt_mismatch
+        else if
+          not
+            (Keeper_checkpoint_ref.equal
+               state.request.source_checkpoint
+               value.source_checkpoint)
+        then Error Source_mismatch
+        else if
+          Keeper_checkpoint_ref.equal
+            value.source_checkpoint
+            value.candidate_checkpoint
+        then Error Candidate_mismatch
+        else Ok { state with progress = Prepared value }
+      | Running expected,
+        Operation.Attempt_failed
+          (actual, (Operation.Pre_commit_failure _ as failure)) ->
+        if Operation.Attempt_id.equal expected actual
+        then Ok { state with progress = Failed_state (actual, failure) }
+        else Error Attempt_mismatch
+      | (Prepared expected | Reconciling (expected, _)),
+        Operation.Attempt_failed
+          ( actual
+          , (Operation.Candidate_not_installed { observed_checkpoint; _ } as failure) ) ->
+        if not (Operation.Attempt_id.equal expected.attempt_id actual)
+        then Error Attempt_mismatch
+        else if
+          not
+            (Keeper_checkpoint_ref.equal
+               state.request.source_checkpoint
+               observed_checkpoint)
+        then Error Source_mismatch
+        else
+          Ok
+            { state with
+              progress = Failed_state (actual, failure)
+            }
+      | Prepared expected,
+        Operation.Commit_reconciliation_required (actual, reason) ->
+        same_candidate expected actual
+        |> Result.map (fun () ->
+          { state with progress = Reconciling (expected, reason) })
+      | Running expected, Operation.Source_superseded supersession ->
+        if not (Operation.Attempt_id.equal expected supersession.attempt_id)
+        then Error Attempt_mismatch
+        else
+          validate_supersession
+            state
+            None
+            ~source_may_match:false
+            supersession.observed_checkpoint
+          |> Result.map (fun () ->
+            { state with
+              progress =
+                Superseded_state
+                  { attempt_id = expected
+                  ; candidate = None
+                  ; committed = false
+                  ; observed_checkpoint = supersession.observed_checkpoint
+                  }
+            })
+      | (Prepared expected | Reconciling (expected, _)),
+        Operation.Source_superseded supersession ->
+        if
+          not
+            (Operation.Attempt_id.equal
+               expected.attempt_id
+               supersession.attempt_id)
+        then Error Attempt_mismatch
+        else
+          validate_supersession
+            state
+            (Some expected)
+            ~source_may_match:false
+            supersession.observed_checkpoint
+          |> Result.map (fun () ->
+            { state with
+              progress =
+                Superseded_state
+                  { attempt_id = expected.attempt_id
+                  ; candidate = Some expected
+                  ; committed = false
+                  ; observed_checkpoint = supersession.observed_checkpoint
+                  }
+            })
+      | (Prepared expected | Reconciling (expected, _)), Operation.Compacted actual ->
+        same_candidate expected actual
+        |> Result.map (fun () -> { state with progress = Committed expected })
+      | Committed expected, Operation.Source_superseded supersession ->
+        if
+          not
+            (Operation.Attempt_id.equal
+               expected.attempt_id
+               supersession.attempt_id)
+        then Error Attempt_mismatch
+        else
+          validate_supersession
+            state
+            (Some expected)
+            ~source_may_match:true
+            supersession.observed_checkpoint
+          |> Result.map (fun () ->
+            { state with
+              progress =
+                Superseded_state
+                  { attempt_id = expected.attempt_id
+                  ; candidate = Some expected
+                  ; committed = true
+                  ; observed_checkpoint = supersession.observed_checkpoint
+                  }
+            })
+      | Committed value, Operation.Reinjected (checkpoint, turn) ->
+        let trace =
+          Keeper_id.Trace_id.to_string value.candidate_checkpoint.trace_id
+        in
+        if
+          Keeper_checkpoint_ref.equal value.candidate_checkpoint checkpoint
+          && String.equal trace (Ids.Turn_ref.trace_id turn)
+        then Ok { state with progress = Adopted_state (value, checkpoint, turn) }
+        else Error Reinjection_identity_mismatch
+      | _ -> invalid current
+;;
+
+let fold events =
+  let rec loop state = function
+    | [] ->
+      (match state with
+       | Some value -> Ok value
+       | None -> Error (Invalid_transition None))
+    | event :: rest ->
+      (match apply state event with
+       | Error _ as error -> error
+       | Ok next -> loop (Some next) rest)
+  in
+  loop None events
+;;

--- a/lib/keeper_compaction_operation/keeper_compaction_operation_reducer.mli
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation_reducer.mli
@@ -1,0 +1,49 @@
+(** Pure replay reducer for one compaction operation. *)
+
+module Operation = Keeper_compaction_operation
+
+type phase =
+  | Request_pending
+  | Attempt_in_progress
+  | Candidate_pending_commit
+  | Reconciliation_pending
+  | Commit_complete
+  | Adopted
+  | Failed  (** Terminal; another objective requires a new operation. *)
+  | Superseded
+
+type state
+type snapshot =
+  { operation_id : Operation.Operation_id.t
+  ; keeper_name : Keeper_id.Keeper_name.t
+  ; source_checkpoint : Keeper_checkpoint_ref.t
+  ; trigger : Compaction_trigger.t
+  ; cause : Operation.Cause.t
+  ; producer_invocation : Tool_invocation_ref.t option
+  ; phase : phase
+  ; attempt_id : Operation.Attempt_id.t option
+  ; candidate_checkpoint : Keeper_checkpoint_ref.t option
+  ; evidence : Keeper_compaction_evidence.t option
+  ; reconciliation_reason : Operation.reconciliation_reason option
+  ; committed_checkpoint : Keeper_checkpoint_ref.t option
+  ; adopted_checkpoint : Keeper_checkpoint_ref.t option
+  ; adopting_turn : Ids.Turn_ref.t option
+  ; failure : Operation.attempt_failure option
+  ; superseded_by_checkpoint : Keeper_checkpoint_ref.t option
+  }
+
+type transition_error =
+  | Invalid_transition of phase option
+  | Operation_mismatch
+  | Attempt_mismatch
+  | Source_mismatch
+  | Candidate_mismatch
+  | Reinjection_identity_mismatch
+  | Supersession_not_observed
+  | Supersession_candidate_installed
+  | Supersession_trace_mismatch
+
+val phase : state -> phase
+val snapshot : state -> snapshot
+val apply : state option -> Operation.event -> (state, transition_error) result
+val fold : Operation.event list -> (state, transition_error) result

--- a/lib/keeper_compaction_operation/keeper_compaction_operation_store.ml
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation_store.ml
@@ -1,0 +1,202 @@
+module Operation = Keeper_compaction_operation
+module Reducer = Keeper_compaction_operation_reducer
+module Record = Keeper_compaction_operation_record
+module Cursor = Record.Cursor
+type row = Record.row
+type operation_entry =
+  { snapshot : Reducer.snapshot
+  ; requested_at : float
+  ; request_cursor : Cursor.t
+  }
+type replay = { operations : operation_entry list; end_cursor : Cursor.t }
+type slice = { rows : row list; end_cursor : Cursor.t }
+type event_rejection =
+  | Transition_rejected of Reducer.transition_error
+  | Keeper_mismatch of
+      { expected : Keeper_id.Keeper_name.t
+      ; actual : Keeper_id.Keeper_name.t
+      }
+  | Producer_already_bound of
+      { producer : Tool_invocation_ref.t
+      ; existing_operation_id : Operation.Operation_id.t
+      }
+type history_error =
+  | Invalid_record of Record.decode_error
+  | Rejected_row of
+      { row_number : int
+      ; start_cursor : Cursor.t
+      ; end_cursor : Cursor.t
+      ; rejection : event_rejection
+      }
+type read_error =
+  | Read_failed of Fs_compat.Private_jsonl_slice.error
+  | Invalid_history of history_error
+type transaction_error =
+  | Not_committed of Fs_compat.durable_append_error
+  | Outcome_unknown of Fs_compat.durable_append_error
+  | Access_failed of exn
+type append_error =
+  | Encode_failed of Record.envelope_error
+  | Existing_history_invalid of history_error
+  | Event_rejected of event_rejection
+  | Transaction_error of transaction_error
+module Operation_map = Map.Make (struct
+    type t = Operation.Operation_id.t
+    let compare = Operation.Operation_id.compare
+  end)
+type operation_state =
+  { reducer : Reducer.state
+  ; requested_at : float
+  ; request_cursor : Cursor.t
+  }
+type fold_state =
+  { operations : operation_state Operation_map.t
+  ; producers : (Tool_invocation_ref.t * Operation.Operation_id.t) list
+  }
+let empty_state = { operations = Operation_map.empty; producers = [] }
+let ( let* ) = Result.bind
+let cursor value =
+  match Cursor.of_int value with
+  | Ok cursor -> cursor
+  | Error _ -> invalid_arg "negative durable journal offset"
+;;
+let journal_path ~base_path ~keeper_name =
+  Filename.concat
+    (Filename.concat
+       (Common.keepers_runtime_dir_of_base ~base_path)
+       (Keeper_id.Keeper_name.to_string keeper_name))
+    "operation-journal.jsonl"
+;;
+let producer_of_event event =
+  match Operation.view event with
+  | Operation.Requested { producer_invocation; _ } -> producer_invocation
+  | _ -> None
+;;
+let find_producer producer =
+  List.find_map (fun (candidate, operation_id) ->
+    if Tool_invocation_ref.equal producer candidate then Some operation_id else None)
+;;
+let apply_row ~keeper_name state row =
+  let event = row.Record.event in
+  let operation_id = Operation.operation_id event in
+  let current = Operation_map.find_opt operation_id state.operations in
+  let* next =
+    Reducer.apply (Option.map (fun value -> value.reducer) current) event
+    |> Result.map_error (fun error -> Transition_rejected error)
+  in
+  let actual = (Reducer.snapshot next).keeper_name in
+  if not (Keeper_id.Keeper_name.equal keeper_name actual)
+  then Error (Keeper_mismatch { expected = keeper_name; actual })
+  else
+    let operation =
+      match current with
+      | Some value -> { value with reducer = next }
+      | None ->
+        { reducer = next
+        ; requested_at = row.recorded_at
+        ; request_cursor = row.end_cursor
+        }
+    in
+    match producer_of_event event with
+    | Some producer ->
+      (match find_producer producer state.producers with
+       | Some existing_operation_id
+         when not (Operation.Operation_id.equal existing_operation_id operation_id) ->
+         Error (Producer_already_bound { producer; existing_operation_id })
+       | Some _ ->
+         Ok { state with operations = Operation_map.add operation_id operation state.operations }
+       | None ->
+         Ok
+           { operations = Operation_map.add operation_id operation state.operations
+           ; producers = (producer, operation_id) :: state.producers
+           })
+    | None ->
+      Ok { state with operations = Operation_map.add operation_id operation state.operations }
+;;
+let fold_rows ~keeper_name rows =
+  let rec loop row_number state = function
+    | [] -> Ok state
+    | row :: rest ->
+      (match apply_row ~keeper_name state row with
+       | Ok state -> loop (row_number + 1) state rest
+       | Error rejection ->
+         Error
+           (Rejected_row
+              { row_number
+              ; start_cursor = row.start_cursor
+              ; end_cursor = row.end_cursor
+              ; rejection
+              }))
+  in
+  loop 1 empty_state rows
+;;
+let decode_history ~keeper_name bytes =
+  match Record.decode_rows ~from:Cursor.zero ~row_number:(Some 1) bytes with
+  | Error error -> Error (Invalid_record error)
+  | Ok rows ->
+    fold_rows ~keeper_name rows |> Result.map (fun state -> rows, state)
+;;
+let replay ~base_path ~keeper_name =
+  let path = journal_path ~base_path ~keeper_name in
+  match Fs_compat.read_private_jsonl_slice_locked_result path ~from:0 with
+  | Error error -> Error (Read_failed error)
+  | Ok source ->
+    (match decode_history ~keeper_name source.bytes with
+     | Error error -> Error (Invalid_history error)
+     | Ok (_, state) ->
+       Ok
+         { operations =
+             Operation_map.bindings state.operations
+             |> List.map (fun (_, value) ->
+               { snapshot = Reducer.snapshot value.reducer
+               ; requested_at = value.requested_at
+               ; request_cursor = value.request_cursor
+               })
+             |> List.sort (fun (left : operation_entry) right ->
+               Int.compare
+                 (Cursor.to_int left.request_cursor)
+                 (Cursor.to_int right.request_cursor))
+         ; end_cursor = cursor source.end_offset
+         })
+;;
+let read_slice ~base_path ~keeper_name ~from =
+  let path = journal_path ~base_path ~keeper_name in
+  match
+    Fs_compat.read_private_jsonl_slice_locked_result
+      path
+      ~from:(Cursor.to_int from)
+  with
+  | Error error -> Error (Read_failed error)
+  | Ok source ->
+    (match Record.decode_rows ~from ~row_number:None source.bytes with
+     | Error error -> Error (Invalid_history (Invalid_record error))
+     | Ok rows -> Ok { rows; end_cursor = cursor source.end_offset })
+;;
+let append ~base_path ~keeper_name ~recorded_at event =
+  match Record.encode ~recorded_at event with
+  | Error error -> Error (Encode_failed error)
+  | Ok suffix ->
+    let path = journal_path ~base_path ~keeper_name in
+    (try
+       match
+       Fs_compat.update_private_file_durable_locked_result path (fun existing ->
+         match decode_history ~keeper_name existing with
+         | Error error -> None, Error (Existing_history_invalid error)
+         | Ok (_, state) ->
+           let start_cursor = cursor (String.length existing) in
+           let end_cursor =
+             cursor (Cursor.to_int start_cursor + String.length suffix)
+           in
+           let row = { Record.recorded_at; start_cursor; end_cursor; event } in
+           (match apply_row ~keeper_name state row with
+            | Error error -> None, Error (Event_rejected error)
+            | Ok _ -> Some suffix, Ok row))
+     with
+     | Ok result -> result
+     | Error ({ rollback_failures = []; _ } as error) ->
+       Error (Transaction_error (Not_committed error))
+     | Error error -> Error (Transaction_error (Outcome_unknown error))
+     with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn -> Error (Transaction_error (Access_failed exn)))
+;;

--- a/lib/keeper_compaction_operation/keeper_compaction_operation_store.mli
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation_store.mli
@@ -1,0 +1,59 @@
+(** Sole durable mutation facade for one Keeper's compaction operations. *)
+module Record = Keeper_compaction_operation_record
+module Cursor = Record.Cursor
+type row = Record.row
+type operation_entry =
+  { snapshot : Keeper_compaction_operation_reducer.snapshot
+  ; requested_at : float
+  ; request_cursor : Cursor.t
+  }
+type replay = { operations : operation_entry list; end_cursor : Cursor.t }
+type slice = { rows : row list; end_cursor : Cursor.t }
+type event_rejection =
+  | Transition_rejected of Keeper_compaction_operation_reducer.transition_error
+  | Keeper_mismatch of
+      { expected : Keeper_id.Keeper_name.t
+      ; actual : Keeper_id.Keeper_name.t
+      }
+  | Producer_already_bound of
+      { producer : Tool_invocation_ref.t
+      ; existing_operation_id : Keeper_compaction_operation.Operation_id.t
+      }
+type history_error =
+  | Invalid_record of Record.decode_error
+  | Rejected_row of
+      { row_number : int
+      ; start_cursor : Cursor.t
+      ; end_cursor : Cursor.t
+      ; rejection : event_rejection
+      }
+type read_error =
+  | Read_failed of Fs_compat.Private_jsonl_slice.error
+  | Invalid_history of history_error
+type transaction_error =
+  | Not_committed of Fs_compat.durable_append_error
+  | Outcome_unknown of Fs_compat.durable_append_error
+  | Access_failed of exn
+type append_error =
+  | Encode_failed of Record.envelope_error
+  | Existing_history_invalid of history_error
+  | Event_rejected of event_rejection
+  | Transaction_error of transaction_error
+val journal_path :
+  base_path:string -> keeper_name:Keeper_id.Keeper_name.t -> string
+val replay :
+  base_path:string ->
+  keeper_name:Keeper_id.Keeper_name.t ->
+  (replay, read_error) result
+val read_slice :
+  base_path:string ->
+  keeper_name:Keeper_id.Keeper_name.t ->
+  from:Cursor.t ->
+  (slice, read_error) result
+(** Structural decode only; it never invents prior reducer state. *)
+val append :
+  base_path:string ->
+  keeper_name:Keeper_id.Keeper_name.t ->
+  recorded_at:float ->
+  Keeper_compaction_operation.event ->
+  (row, append_error) result

--- a/lib/mcp_server_eio.mli
+++ b/lib/mcp_server_eio.mli
@@ -128,6 +128,7 @@ val execute_tool_eio :
   workspace_scope:Mcp_server.workspace_scope ->
   ?profile:tool_profile ->
   ?mcp_session_id:string ->
+  ?invocation_ref:Tool_invocation_ref.t ->
   ?auth_token:string ->
   ?internal_keeper_runtime:bool ->
   server_state ->

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -489,6 +489,25 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
   in
   let config = workspace_scope.config in
   let make_response = Mcp_transport_protocol.make_response in
+  let request_id =
+    match Mcp_transport_protocol.request_id_of_yojson id with
+    | Ok request_id -> request_id
+    | Error error ->
+      invalid_arg
+        ("handle_call_tool_eio admitted an invalid MCP request id: "
+         ^ Mcp_transport_protocol.request_id_error_to_string error)
+  in
+  let invocation_ref =
+    match mcp_session_id with
+    | None -> None
+    | Some session_id ->
+      (match Tool_invocation_ref.external_mcp ~request_id ~session_id with
+       | Ok invocation_ref -> Some invocation_ref
+       | Error error ->
+         invalid_arg
+           ("handle_call_tool_eio admitted an invalid MCP invocation scope: "
+            ^ Tool_invocation_ref.error_to_string error))
+  in
   let (name, arguments) =
     match profile with
     | Managed_agent -> (
@@ -512,6 +531,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
         ~workspace_scope
         ?profile:(Some profile)
         ?mcp_session_id
+        ?invocation_ref
         ?auth_token
         ?internal_keeper_runtime:(Some internal_keeper_runtime)
         state
@@ -550,14 +570,10 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
   in
   let end_time = Eio.Time.now clock in
   let duration_ms = int_of_float ((end_time -. start_time) *. 1000.0) in
-  let jsonrpc_id_str =
-    match id with
-    | `String s -> s
-    | `Int i -> string_of_int i
-    | `Intlit s -> s
-    | `Float f -> Printf.sprintf "%0.0f" f
-    | _ -> "unknown"
+  let request_id_json =
+    Mcp_transport_protocol.request_id_to_yojson request_id
   in
+  let request_id_trace_fallback = Yojson.Safe.to_string request_id_json in
   let mcp_session_detail = Json_util.string_opt_to_json mcp_session_id in
 
   (* Resolve caller identity for telemetry.  HTTP auth injects [_agent_name];
@@ -609,7 +625,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
               `String (Tool_result.tool_failure_class_to_string failure_class) );
             ("tool_name", `String name);
             ("phase", `String "failure");
-            ("request_id", `String jsonrpc_id_str);
+            ("request_id", request_id_json);
             ("session_id", mcp_session_detail);
             ("outcome", `String "error");
             ("agent_name", `String agent_name);
@@ -755,7 +771,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
   let trace_id =
     match otel_trace_id with
     | Some tid -> tid
-    | None -> jsonrpc_id_str
+    | None -> request_id_trace_fallback
   in
   (match keeper_entry with
    | Some entry ->
@@ -835,7 +851,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
           ("event_family", `String "tool_call");
           ("tool_name", `String name);
           ("phase", `String "result");
-          ("request_id", `String jsonrpc_id_str);
+          ("request_id", request_id_json);
           ("session_id", mcp_session_detail);
           ("agent_name", `String agent_name);
           ("outcome", `String (Tool_result.string_of_tool_call_outcome outcome));

--- a/lib/mcp_server_eio_call_tool.mli
+++ b/lib/mcp_server_eio_call_tool.mli
@@ -115,6 +115,7 @@ val handle_call_tool_eio :
      workspace_scope:Mcp_server.workspace_scope ->
      ?profile:Mcp_server_eio_types.tool_profile ->
      ?mcp_session_id:string ->
+     ?invocation_ref:Tool_invocation_ref.t ->
      ?auth_token:'auth ->
      ?internal_keeper_runtime:bool ->
      Mcp_server.server_state ->

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -25,6 +25,7 @@ let execute_tool_eio
       ~(workspace_scope : Mcp_server.workspace_scope)
       ?(profile = Mcp_server_eio_tool_profile.Full)
       ?mcp_session_id
+      ?invocation_ref
       ?auth_token
       ?(internal_keeper_runtime = false)
       state
@@ -234,6 +235,7 @@ let execute_tool_eio
             (* Helper: create keeper tool boundary context (shared by goals) *)
             let make_keeper_tool_ctx () =
               Keeper_tool_boundary.create
+                ?invocation_ref
                 ~config
                 ~agent_name
                 ~sw
@@ -242,6 +244,7 @@ let execute_tool_eio
                 ~net:state.Mcp_server.net
                 ~publication_recovery_provider:
                   (Mcp_server.publication_recovery_availability_provider state)
+                ()
             in
             (* Dispatch a single module by tag — creates only that module's context.
      Pre-hooks may coerce arguments (e.g. OAS type coercion: "42" -> 42).
@@ -254,6 +257,20 @@ let execute_tool_eio
                 (match tag with
                  | Mod_plan -> Tool_plan.dispatch { config } ~name ~args:coerced_args
                  | Mod_operator ->
+                   let delegated_dispatch =
+                     Keeper_tool_boundary.delegated_dispatch
+                       ?invocation_ref
+                       ~config
+                       ~agent_name
+                       ~sw
+                       ~clock
+                       ~proc_mgr:state.Mcp_server.proc_mgr
+                       ~net:state.Mcp_server.net
+                       ~publication_recovery_provider:
+                         (Mcp_server.publication_recovery_availability_provider
+                            state)
+                       ()
+                   in
                    let ctx =
                      { Tool_operator.config
                      ; agent_name
@@ -261,18 +278,7 @@ let execute_tool_eio
                      ; clock
                      ; proc_mgr = state.Mcp_server.proc_mgr
                      ; net = state.Mcp_server.net
-                     ; delegated_dispatch =
-                         Some
-                           (Keeper_tool_boundary.delegated_dispatch
-                              ~config
-                              ~agent_name
-                              ~sw
-                              ~clock
-                              ~proc_mgr:state.Mcp_server.proc_mgr
-                              ~net:state.Mcp_server.net
-                              ~publication_recovery_provider:
-                                (Mcp_server.publication_recovery_availability_provider
-                                   state))
+                     ; delegated_dispatch = Some delegated_dispatch
                      ; mcp_session_id
                      }
                    in

--- a/lib/mcp_server_eio_execute.mli
+++ b/lib/mcp_server_eio_execute.mli
@@ -46,6 +46,7 @@ val execute_tool_eio :
   workspace_scope:Mcp_server.workspace_scope ->
   ?profile:Mcp_server_eio_types.tool_profile ->
   ?mcp_session_id:string ->
+  ?invocation_ref:Tool_invocation_ref.t ->
   ?auth_token:string ->
   ?internal_keeper_runtime:bool ->
   Mcp_server.server_state ->

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -753,13 +753,7 @@ let handle_request
         | Ok req ->
           let id = get_id req in
           let base_path = (Mcp_server.workspace_config state).Workspace.base_path in
-          if not (is_valid_request_id id)
-          then
-            make_error_typed
-              ~id:`Null
-              Mcp_error_code.Invalid_request
-              "Invalid Request: id must be string, number, or null"
-          else if Mcp_transport_protocol.is_notification req
+          if Mcp_transport_protocol.is_notification req
           then (
             match req.method_ with
             | "dashboard/ack" ->
@@ -771,6 +765,12 @@ let handle_request
                 (fun _auth_token ->
                    handle_dashboard_ack_notification ?mcp_session_id req.params)
             | _ -> `Null)
+          else if not (is_valid_request_id id)
+          then
+            make_error_typed
+              ~id:`Null
+              Mcp_error_code.Invalid_request
+              "Invalid Request: MCP id must be a string or integer"
           else (
             try
               match req.method_ with

--- a/lib/mcp_transport_protocol/mcp_transport_protocol.ml
+++ b/lib/mcp_transport_protocol/mcp_transport_protocol.ml
@@ -17,6 +17,71 @@ type jsonrpc_request = {
   params : Yojson.Safe.t option; [@default None]
 } [@@deriving yojson { strict = false }]
 
+type request_id =
+  | String_id of string
+  | Integer_id of string
+
+type request_id_error =
+  | Null_request_id
+  | Non_lossless_number
+  | Invalid_integer_lexeme of string
+  | Invalid_request_id_kind
+
+let is_digit c = c >= '0' && c <= '9'
+
+let is_json_integer_lexeme value =
+  let length = String.length value in
+  let first_digit =
+    if length > 0 && value.[0] = '-' then 1 else 0
+  in
+  if first_digit >= length
+  then false
+  else
+    let first = value.[first_digit] in
+    if first = '0'
+    then first_digit + 1 = length
+    else
+      first >= '1'
+      && first <= '9'
+      &&
+      let rec all_digits index =
+        index = length
+        || (is_digit value.[index] && all_digits (index + 1))
+      in
+      all_digits (first_digit + 1)
+;;
+
+let request_id_of_yojson = function
+  | `String value -> Ok (String_id value)
+  | `Int value -> Ok (Integer_id (string_of_int value))
+  | `Intlit value when is_json_integer_lexeme value -> Ok (Integer_id value)
+  | `Intlit value -> Error (Invalid_integer_lexeme value)
+  | `Float _ -> Error Non_lossless_number
+  | `Null -> Error Null_request_id
+  | `Assoc _ | `List _ | `Bool _ -> Error Invalid_request_id_kind
+;;
+
+let request_id_to_yojson = function
+  | String_id value -> `String value
+  | Integer_id value -> `Intlit value
+;;
+
+let request_id_equal left right =
+  match left, right with
+  | String_id left, String_id right
+  | Integer_id left, Integer_id right -> String.equal left right
+  | String_id _, Integer_id _ | Integer_id _, String_id _ -> false
+;;
+
+let request_id_error_to_string = function
+  | Null_request_id -> "MCP request id must not be null"
+  | Non_lossless_number ->
+    "MCP request id must be an integer; floating JSON numbers are not lossless"
+  | Invalid_integer_lexeme value ->
+    Printf.sprintf "invalid MCP integer request id lexeme: %S" value
+  | Invalid_request_id_kind -> "MCP request id must be a string or integer"
+;;
+
 let has_field key = function
   | `Assoc fields -> List.exists (fun (k, _) -> k = key) fields
   | _ -> false
@@ -44,9 +109,7 @@ let is_notification req = req.id = None
 
 let get_id req = match req.id with Some id -> id | None -> `Null
 
-let is_valid_request_id = function
-  | `Null | `String _ | `Int _ | `Intlit _ | `Float _ -> true
-  | _ -> false
+let is_valid_request_id value = Result.is_ok (request_id_of_yojson value)
 
 let validate_initialize_params params =
   let ( let* ) = Result.bind in

--- a/lib/mcp_transport_protocol/mcp_transport_protocol.mli
+++ b/lib/mcp_transport_protocol/mcp_transport_protocol.mli
@@ -18,6 +18,29 @@ type jsonrpc_request = {
 (** JSON-RPC 2.0 request. [id = None] denotes a notification. The
     [method_] OCaml field maps to the JSON ["method"] key. *)
 
+type request_id
+(** Exact MCP request identity. Integer ids retain their canonical JSON
+    lexeme so callers never round-trip through a binary float. *)
+
+type request_id_error =
+  | Null_request_id
+  | Non_lossless_number
+  | Invalid_integer_lexeme of string
+  | Invalid_request_id_kind
+
+val request_id_of_yojson :
+  Yojson.Safe.t -> (request_id, request_id_error) result
+(** Parses the MCP request-id contract: string or integer only. [`Float _]
+    is rejected even when mathematically integral because Yojson has already
+    discarded the producer's exact decimal lexeme. *)
+
+val request_id_to_yojson : request_id -> Yojson.Safe.t
+(** Lossless wire projection of a typed request id. *)
+
+val request_id_equal : request_id -> request_id -> bool
+
+val request_id_error_to_string : request_id_error -> string
+
 val has_field : string -> Yojson.Safe.t -> bool
 (** [has_field key json] is [true] when [json] is an [`Assoc] containing [key]. *)
 
@@ -39,8 +62,8 @@ val get_id : jsonrpc_request -> Yojson.Safe.t
 (** Returns the request id, defaulting to [`Null] for notifications. *)
 
 val is_valid_request_id : Yojson.Safe.t -> bool
-(** Per the JSON-RPC 2.0 spec, valid ids are [`Null], [`String _],
-    [`Int _], [`Intlit _], or [`Float _]. *)
+(** MCP requests admit string or integer ids. Null and floating-point ids are
+    rejected, as required by the MCP request contract. *)
 
 val validate_initialize_params : Yojson.Safe.t option -> (unit, string) result
 (** Checks that [params] for the MCP [initialize] method contain

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -751,7 +751,8 @@ let operator_control_context ~state ~sw ~clock ~config ~agent_name
            ~proc_mgr:state.Mcp_server.proc_mgr
            ~net:state.Mcp_server.net
            ~publication_recovery_provider:
-             (Mcp_server.publication_recovery_availability_provider state))
+             (Mcp_server.publication_recovery_availability_provider state)
+           ())
   ; mcp_session_id = None
   }
 ;;

--- a/lib/tool_invocation_ref/dune
+++ b/lib/tool_invocation_ref/dune
@@ -1,0 +1,10 @@
+(include_subdirs no)
+
+(library
+ (name masc_tool_invocation_ref)
+ (public_name masc.tool_invocation_ref)
+ (wrapped false)
+ (modules tool_invocation_ref)
+ (flags
+  (:standard -w +4))
+ (libraries masc.mcp_transport_protocol yojson))

--- a/lib/tool_invocation_ref/tool_invocation_ref.ml
+++ b/lib/tool_invocation_ref/tool_invocation_ref.ml
@@ -1,0 +1,35 @@
+type t =
+  | External_mcp of
+      { request_id : Mcp_transport_protocol.request_id
+      ; session_id : string
+      }
+
+type error = Empty_mcp_session_id
+
+let external_mcp ~request_id ~session_id =
+  if String.equal (String.trim session_id) ""
+  then Error Empty_mcp_session_id
+  else Ok (External_mcp { request_id; session_id })
+;;
+
+let to_yojson = function
+  | External_mcp { request_id; session_id } ->
+    `Assoc
+      [ "source", `String "external_mcp"
+      ; "session_id", `String session_id
+      ; "request_id", Mcp_transport_protocol.request_id_to_yojson request_id
+      ]
+;;
+
+let equal left right =
+  match left, right with
+  | ( External_mcp { request_id = left_id; session_id = left_session }
+    , External_mcp { request_id = right_id; session_id = right_session } ) ->
+    String.equal left_session right_session
+    && Mcp_transport_protocol.request_id_equal left_id right_id
+;;
+
+let error_to_string = function
+  | Empty_mcp_session_id ->
+    "external MCP tool invocation requires a non-empty stable session id"
+;;

--- a/lib/tool_invocation_ref/tool_invocation_ref.ml
+++ b/lib/tool_invocation_ref/tool_invocation_ref.ml
@@ -6,6 +6,16 @@ type t =
 
 type error = Empty_mcp_session_id
 
+type decode_error =
+  | Expected_object
+  | Unknown_field of string
+  | Duplicate_field of string
+  | Missing_field of string
+  | Expected_string of string
+  | Invalid_source of string
+  | Invalid_request_id of Mcp_transport_protocol.request_id_error
+  | Invalid_identity of error
+
 let external_mcp ~request_id ~session_id =
   if String.equal (String.trim session_id) ""
   then Error Empty_mcp_session_id
@@ -21,6 +31,45 @@ let to_yojson = function
       ]
 ;;
 
+let of_yojson = function
+  | `Assoc fields ->
+    let allowed = [ "source"; "session_id"; "request_id" ] in
+    let rec validate seen = function
+      | [] -> Ok ()
+      | (name, _) :: rest when not (List.mem name allowed) -> Error (Unknown_field name)
+      | (name, _) :: _ when List.mem name seen -> Error (Duplicate_field name)
+      | (name, _) :: rest -> validate (name :: seen) rest
+    in
+    let required name =
+      match List.assoc_opt name fields with
+      | Some value -> Ok value
+      | None -> Error (Missing_field name)
+    in
+    let ( let* ) = Result.bind in
+    let* () = validate [] fields in
+    let* source = required "source" in
+    let* session_id = required "session_id" in
+    let* request_id = required "request_id" in
+    let* () =
+      match source with
+      | `String "external_mcp" -> Ok ()
+      | `String value -> Error (Invalid_source value)
+      | _ -> Error (Expected_string "source")
+    in
+    let* session_id =
+      match session_id with
+      | `String value -> Ok value
+      | _ -> Error (Expected_string "session_id")
+    in
+    let* request_id =
+      Mcp_transport_protocol.request_id_of_yojson request_id
+      |> Result.map_error (fun error -> Invalid_request_id error)
+    in
+    external_mcp ~request_id ~session_id
+    |> Result.map_error (fun error -> Invalid_identity error)
+  | _ -> Error Expected_object
+;;
+
 let equal left right =
   match left, right with
   | ( External_mcp { request_id = left_id; session_id = left_session }
@@ -32,4 +81,21 @@ let equal left right =
 let error_to_string = function
   | Empty_mcp_session_id ->
     "external MCP tool invocation requires a non-empty stable session id"
+;;
+
+let decode_error_to_string = function
+  | Expected_object -> "tool invocation identity must be a JSON object"
+  | Unknown_field name ->
+    Printf.sprintf "tool invocation identity has unknown field %S" name
+  | Duplicate_field name ->
+    Printf.sprintf "tool invocation identity has duplicate field %S" name
+  | Missing_field name ->
+    Printf.sprintf "tool invocation identity is missing field %S" name
+  | Expected_string name ->
+    Printf.sprintf "tool invocation identity field %S must be a string" name
+  | Invalid_source source ->
+    Printf.sprintf "tool invocation identity has invalid source %S" source
+  | Invalid_request_id error ->
+    Mcp_transport_protocol.request_id_error_to_string error
+  | Invalid_identity error -> error_to_string error
 ;;

--- a/lib/tool_invocation_ref/tool_invocation_ref.mli
+++ b/lib/tool_invocation_ref/tool_invocation_ref.mli
@@ -1,0 +1,22 @@
+(** Exact producer identity for a tool invocation crossing into MASC.
+
+    This type owns correlation only. It does not authorize an effect and does
+    not infer identity from tool names, arguments, timestamps, or hashes. *)
+
+type t
+
+type error = Empty_mcp_session_id
+
+val external_mcp :
+  request_id:Mcp_transport_protocol.request_id ->
+  session_id:string ->
+  (t, error) result
+(** Builds an external MCP identity from the exact typed JSON-RPC request id
+    and the stable transport session id. *)
+
+val to_yojson : t -> Yojson.Safe.t
+(** Typed, inspectable projection. *)
+
+val equal : t -> t -> bool
+
+val error_to_string : error -> string

--- a/lib/tool_invocation_ref/tool_invocation_ref.mli
+++ b/lib/tool_invocation_ref/tool_invocation_ref.mli
@@ -7,6 +7,16 @@ type t
 
 type error = Empty_mcp_session_id
 
+type decode_error =
+  | Expected_object
+  | Unknown_field of string
+  | Duplicate_field of string
+  | Missing_field of string
+  | Expected_string of string
+  | Invalid_source of string
+  | Invalid_request_id of Mcp_transport_protocol.request_id_error
+  | Invalid_identity of error
+
 val external_mcp :
   request_id:Mcp_transport_protocol.request_id ->
   session_id:string ->
@@ -17,6 +27,11 @@ val external_mcp :
 val to_yojson : t -> Yojson.Safe.t
 (** Typed, inspectable projection. *)
 
+val of_yojson : Yojson.Safe.t -> (t, decode_error) result
+(** Restores the exact producer identity from its closed projection. Unknown,
+    duplicate, or malformed fields are rejected rather than ignored. *)
+
 val equal : t -> t -> bool
 
 val error_to_string : error -> string
+val decode_error_to_string : decode_error -> string

--- a/test/deps/dune
+++ b/test/deps/dune
@@ -112,6 +112,7 @@
   (re_export masc.masc_compression)
   (re_export masc.mcp_session)
   (re_export masc.mcp_transport_protocol)
+  (re_export masc.tool_invocation_ref)
   (re_export masc.multimodal)
   (re_export masc.prompt_registry)
   (re_export masc.pulse)

--- a/test/keeper_checkpoint_ref/dune
+++ b/test/keeper_checkpoint_ref/dune
@@ -1,0 +1,3 @@
+(test
+ (name test_keeper_checkpoint_ref)
+ (libraries alcotest masc.keeper_checkpoint_ref masc.keeper_registry))

--- a/test/keeper_checkpoint_ref/test_keeper_checkpoint_ref.ml
+++ b/test/keeper_checkpoint_ref/test_keeper_checkpoint_ref.ml
@@ -1,0 +1,89 @@
+let result_ok = function
+  | Ok value -> value
+  | Error _ -> Alcotest.fail "checkpoint identity construction failed"
+;;
+
+let trace_id =
+  match Keeper_id.Trace_id.of_string "trace-1" with
+  | Ok value -> value
+  | Error detail -> Alcotest.fail detail
+;;
+
+let create bytes =
+  Keeper_checkpoint_ref.create
+    ~trace_id
+    ~generation:2
+    ~turn_count:7
+    ~canonical_checkpoint_bytes:bytes
+  |> result_ok
+;;
+
+let test_exact_bytes_identity () =
+  let first = create {|{"messages":["before"]}|} in
+  let same = create {|{"messages":["before"]}|} in
+  let changed = create {|{ "messages": ["before"] }|} in
+  Alcotest.(check bool) "same exact bytes" true (Keeper_checkpoint_ref.equal first same);
+  Alcotest.(check bool) "re-encoded bytes differ" false (Keeper_checkpoint_ref.equal first changed);
+  Alcotest.(check string) "typed trace" "trace-1" (Keeper_id.Trace_id.to_string first.trace_id);
+  Alcotest.(check int) "generation" 2 first.generation;
+  Alcotest.(check int) "turn count" 7 first.turn_count
+;;
+
+let test_typed_rejections () =
+  let make generation turn_count =
+    Keeper_checkpoint_ref.create
+      ~trace_id
+      ~generation
+      ~turn_count
+      ~canonical_checkpoint_bytes:"{}"
+  in
+  Alcotest.(check bool)
+    "negative generation"
+    true
+    (match make (-1) 0 with
+     | Error (Keeper_checkpoint_ref.Negative_generation (-1)) -> true
+     | Ok _ | Error _ -> false);
+  Alcotest.(check bool)
+    "negative turn"
+    true
+    (match make 0 (-2) with
+     | Error (Keeper_checkpoint_ref.Negative_turn_count (-2)) -> true
+     | Ok _ | Error _ -> false)
+;;
+
+let test_persisted_roundtrip_is_canonical () =
+  let expected = create {|{"messages":["before"]}|} in
+  let restore sha256 =
+    Keeper_checkpoint_ref.of_persisted
+      ~trace_id
+      ~generation:expected.generation
+      ~turn_count:expected.turn_count
+      ~sha256
+  in
+  (match restore expected.sha256 with
+   | Ok restored ->
+     Alcotest.(check bool)
+       "restored identity"
+       true
+       (Keeper_checkpoint_ref.equal expected restored)
+   | Error _ -> Alcotest.fail "canonical persisted identity was rejected");
+  List.iter
+    (fun sha256 ->
+       match restore sha256 with
+       | Error (Keeper_checkpoint_ref.Invalid_sha256 _) -> ()
+       | Ok _ | Error _ -> Alcotest.fail "non-canonical digest was accepted")
+    [ String.uppercase_ascii expected.sha256; String.sub expected.sha256 0 62; " " ^ expected.sha256 ]
+;;
+
+let () =
+  Alcotest.run
+    "keeper checkpoint ref"
+    [ ( "identity"
+      , [ Alcotest.test_case "exact bytes" `Quick test_exact_bytes_identity
+        ; Alcotest.test_case "typed rejections" `Quick test_typed_rejections
+        ; Alcotest.test_case
+            "persisted canonical roundtrip"
+            `Quick
+            test_persisted_roundtrip_is_canonical
+        ] )
+    ]

--- a/test/keeper_compaction_evidence/dune
+++ b/test/keeper_compaction_evidence/dune
@@ -1,0 +1,3 @@
+(test
+ (name test_keeper_compaction_evidence)
+ (libraries alcotest yojson masc.keeper_compaction_evidence))

--- a/test/keeper_compaction_evidence/test_keeper_compaction_evidence.ml
+++ b/test/keeper_compaction_evidence/test_keeper_compaction_evidence.ml
@@ -1,0 +1,105 @@
+let evidence : Keeper_compaction_evidence.t =
+  { selected_runtime_id = Some "compact-runtime"
+  ; before_checkpoint_bytes = 4096
+  ; after_checkpoint_bytes = 1024
+  ; before_message_count = 12
+  ; after_message_count = 5
+  ; summarized_message_count = 6
+  ; dropped_message_count = 1
+  ; before_tool_use_count = 3
+  ; after_tool_use_count = 1
+  ; before_tool_result_count = 3
+  ; after_tool_result_count = 1
+  }
+;;
+
+let canonical = Keeper_compaction_evidence.to_json evidence
+
+let fields = function
+  | `Assoc fields -> fields
+  | _ -> Alcotest.fail "canonical evidence must be an object"
+;;
+
+let replace name value json =
+  `Assoc
+    (List.map
+       (fun (key, current) ->
+          if String.equal key name then key, value else key, current)
+       (fields json))
+;;
+
+let test_projection_and_roundtrip () =
+  let expected =
+    `Assoc
+      [ "before_checkpoint_bytes", `Int 4096
+      ; "after_checkpoint_bytes", `Int 1024
+      ; "before_message_count", `Int 12
+      ; "after_message_count", `Int 5
+      ; "summarized_message_count", `Int 6
+      ; "dropped_message_count", `Int 1
+      ; "before_tool_use_count", `Int 3
+      ; "after_tool_use_count", `Int 1
+      ; "before_tool_result_count", `Int 3
+      ; "after_tool_result_count", `Int 1
+      ]
+  in
+  Alcotest.check
+    (Alcotest.testable Yojson.Safe.pp Yojson.Safe.equal)
+    "exact projection"
+    expected
+    canonical;
+  match
+    Keeper_compaction_evidence.of_json
+      ~selected_runtime_id:evidence.selected_runtime_id
+      canonical
+  with
+  | Ok restored -> Alcotest.(check bool) "exact restore" true (restored = evidence)
+  | Error _ -> Alcotest.fail "canonical evidence must decode"
+;;
+
+let test_rejections () =
+  let open Keeper_compaction_evidence in
+  let check label runtime_id expected json =
+    match of_json ~selected_runtime_id:runtime_id json with
+    | Error actual -> Alcotest.(check bool) label true (actual = expected)
+    | Ok _ -> Alcotest.failf "%s: invalid evidence decoded" label
+  in
+  let no_messages =
+    canonical
+    |> replace "summarized_message_count" (`Int 0)
+    |> replace "dropped_message_count" (`Int 0)
+  in
+  let duplicate =
+    `Assoc (("after_message_count", `Int 5) :: fields canonical)
+  in
+  List.iter
+    (fun (label, runtime_id, expected, json) ->
+       check label runtime_id expected json)
+    [ ( "negative"
+      , evidence.selected_runtime_id
+      , Invalid_field (Before_message_count, Negative_integer)
+      , replace "before_message_count" (`Int (-1)) canonical )
+    ; ( "not reduced"
+      , evidence.selected_runtime_id
+      , Invalid_transition (Checkpoint_bytes, 4096, 4096)
+      , replace "after_checkpoint_bytes" (`Int 4096) canonical )
+    ; "no messages", evidence.selected_runtime_id, No_messages_compacted, no_messages
+    ; "blank runtime", Some "   ", Empty_selected_runtime_id, canonical
+    ; ( "duplicate"
+      , evidence.selected_runtime_id
+      , Invalid_field (After_message_count, Duplicate)
+      , duplicate )
+    ]
+;;
+
+let () =
+  Alcotest.run
+    "keeper compaction evidence"
+    [ ( "projection"
+      , [ Alcotest.test_case
+            "projection and roundtrip"
+            `Quick
+            test_projection_and_roundtrip
+        ; Alcotest.test_case "closed rejections" `Quick test_rejections
+        ] )
+    ]

--- a/test/keeper_compaction_operation/dune
+++ b/test/keeper_compaction_operation/dune
@@ -1,0 +1,13 @@
+(test
+ (name test_keeper_compaction_operation)
+ (libraries
+  alcotest
+  masc.compaction_trigger
+  masc.keeper_checkpoint_ref
+  masc.keeper_compaction_evidence
+  masc.keeper_compaction_operation
+  masc.keeper_registry
+  masc.masc_types
+  masc.mcp_transport_protocol
+  masc.tool_invocation_ref
+  yojson))

--- a/test/keeper_compaction_operation/test_keeper_compaction_operation.ml
+++ b/test/keeper_compaction_operation/test_keeper_compaction_operation.ml
@@ -1,0 +1,648 @@
+module Operation = Keeper_compaction_operation
+module Codec = Keeper_compaction_operation_codec
+module Operation_json = Keeper_compaction_operation_json
+module Reducer = Keeper_compaction_operation_reducer
+
+let ok = function Ok value -> value | Error _ -> Alcotest.fail "fixture rejected"
+let operation_id = ok (Operation.Operation_id.of_string "123e4567-e89b-12d3-a456-426614174000")
+let attempt_id = ok (Operation.Attempt_id.of_string "123e4567-e89b-12d3-a456-426614174001")
+let keeper_name = ok (Keeper_id.Keeper_name.of_string "keeper-a")
+let trace_id = ok (Keeper_id.Trace_id.of_string "trace-a")
+let checkpoint bytes turn_count =
+  ok
+    (Keeper_checkpoint_ref.create
+       ~trace_id
+       ~generation:2
+       ~turn_count
+       ~canonical_checkpoint_bytes:bytes)
+;;
+let source = checkpoint "before" 7
+let candidate = checkpoint "after" 7
+let advanced = checkpoint "advanced" 8
+let evidence : Keeper_compaction_evidence.t =
+  { selected_runtime_id = Some "compact-runtime"
+  ; before_checkpoint_bytes = 100
+  ; after_checkpoint_bytes = 50
+  ; before_message_count = 10
+  ; after_message_count = 4
+  ; summarized_message_count = 6
+  ; dropped_message_count = 0
+  ; before_tool_use_count = 2
+  ; after_tool_use_count = 1
+  ; before_tool_result_count = 2
+  ; after_tool_result_count = 1
+  }
+;;
+let cause = ok (Operation.Cause.of_string "operator request")
+let producer =
+  let request_id = ok (Mcp_transport_protocol.request_id_of_yojson (`String "req-1")) in
+  ok (Tool_invocation_ref.external_mcp ~request_id ~session_id:"session-1")
+;;
+
+let request_event () =
+  Operation.requested
+    ~operation_id
+    ~keeper_name
+    ~source_checkpoint:source
+    ~trigger:Compaction_trigger.Manual
+    ~cause
+    ~producer_invocation:(Some producer)
+;;
+
+let attempt_event () = Operation.attempt_started ~operation_id ~attempt_id
+
+let candidate_event () =
+  Operation.candidate_prepared
+    ~operation_id
+    ~attempt_id
+    ~source_checkpoint:source
+    ~candidate_checkpoint:candidate
+    ~evidence
+;;
+
+let test_requested_view () =
+  let event =
+    Operation.requested
+      ~operation_id
+      ~keeper_name
+      ~source_checkpoint:source
+      ~trigger:Compaction_trigger.Manual
+      ~cause
+      ~producer_invocation:(Some producer)
+  in
+  Alcotest.(check bool)
+    "operation identity"
+    true
+    (Operation.Operation_id.equal operation_id (Operation.operation_id event));
+  match Operation.view event with
+  | Operation.Requested request ->
+    Alcotest.(check bool)
+      "keeper identity"
+      true
+      (Keeper_id.Keeper_name.equal keeper_name request.keeper_name);
+    Alcotest.(check bool)
+      "source identity"
+      true
+      (Keeper_checkpoint_ref.equal source request.source_checkpoint);
+    Alcotest.(check bool)
+      "producer identity"
+      true
+      (Option.exists (Tool_invocation_ref.equal producer) request.producer_invocation)
+  | _ -> Alcotest.fail "requested event changed shape"
+;;
+
+let test_candidate_views () =
+  let prepared =
+    Operation.candidate_prepared
+      ~operation_id
+      ~attempt_id
+      ~source_checkpoint:source
+      ~candidate_checkpoint:candidate
+      ~evidence
+  in
+  let reconciled =
+    Operation.commit_reconciliation_required
+      ~operation_id
+      ~attempt_id
+      ~source_checkpoint:source
+      ~candidate_checkpoint:candidate
+      ~evidence
+      ~reason:Operation.Transaction_outcome_unknown
+  in
+  let check_candidate = function
+    | Operation.Candidate_prepared value
+    | Operation.Commit_reconciliation_required (value, _) ->
+      Alcotest.(check bool)
+        "candidate identity"
+        true
+        (Keeper_checkpoint_ref.equal candidate value.candidate_checkpoint)
+    | _ -> Alcotest.fail "candidate event changed shape"
+  in
+  check_candidate (Operation.view prepared);
+  check_candidate (Operation.view reconciled)
+;;
+
+let test_failure_and_reinjection_views () =
+  let failure =
+    Operation.attempt_failed
+      ~operation_id
+      ~attempt_id
+      ~failure:
+        (Operation.Candidate_not_installed
+           { cause; observed_checkpoint = source })
+  in
+  let turn = Ids.Turn_ref.make ~trace_id:"trace-a" ~absolute_turn:8 in
+  let reinjected =
+    Operation.reinjected
+      ~operation_id
+      ~adopted_checkpoint:candidate
+      ~adopting_turn:turn
+  in
+  (match Operation.view failure with
+   | Operation.Attempt_failed
+       (_, Operation.Candidate_not_installed { observed_checkpoint; _ }) ->
+     Alcotest.(check bool)
+       "observed canonical source"
+       true
+       (Keeper_checkpoint_ref.equal source observed_checkpoint)
+   | _ -> Alcotest.fail "failure event changed shape");
+  match Operation.view reinjected with
+  | Operation.Reinjected (checkpoint, adopting_turn) ->
+    Alcotest.(check bool)
+      "adopted checkpoint"
+      true
+      (Keeper_checkpoint_ref.equal candidate checkpoint);
+    Alcotest.(check string)
+      "adopting turn"
+      "trace-a#8"
+      (Ids.Turn_ref.to_string adopting_turn)
+  | _ -> Alcotest.fail "reinjected event changed shape"
+;;
+
+let test_reducer_happy_path () =
+  let turn = Ids.Turn_ref.make ~trace_id:"trace-a" ~absolute_turn:8 in
+  let state =
+    ok
+      (Reducer.fold
+         [ request_event ()
+         ; attempt_event ()
+         ; candidate_event ()
+         ; Operation.compacted
+             ~operation_id
+             ~attempt_id
+             ~source_checkpoint:source
+             ~committed_checkpoint:candidate
+             ~evidence
+         ; Operation.reinjected
+             ~operation_id
+             ~adopted_checkpoint:candidate
+             ~adopting_turn:turn
+         ])
+  in
+  let snapshot = Reducer.snapshot state in
+  Alcotest.(check bool) "adopted phase" true (snapshot.phase = Reducer.Adopted);
+  Alcotest.(check bool)
+    "adopted exact checkpoint"
+    true
+    (Option.exists
+       (Keeper_checkpoint_ref.equal candidate)
+       snapshot.adopted_checkpoint)
+;;
+
+let test_reducer_confirmed_failure () =
+  let pre_commit_state =
+    ok (Reducer.fold [ request_event (); attempt_event () ])
+  in
+  let pre_commit_failure =
+    Operation.attempt_failed
+      ~operation_id
+      ~attempt_id
+      ~failure:(Operation.Pre_commit_failure cause)
+  in
+  let pre_commit_state =
+    ok (Reducer.apply (Some pre_commit_state) pre_commit_failure)
+  in
+  let pre_commit_snapshot = Reducer.snapshot pre_commit_state in
+  Alcotest.(check bool)
+    "pre-commit failure is terminal"
+    true
+    (pre_commit_snapshot.phase = Reducer.Failed);
+  (match pre_commit_snapshot.failure with
+   | Some (Operation.Pre_commit_failure actual_cause) ->
+     Alcotest.(check bool)
+       "pre-commit cause retained"
+       true
+       (Operation.Cause.equal cause actual_cause)
+   | Some (Operation.Candidate_not_installed _) | None ->
+     Alcotest.fail "pre-commit failure evidence was lost");
+  let state = ok (Reducer.fold [ request_event (); attempt_event (); candidate_event () ]) in
+  let wrong =
+    Operation.attempt_failed
+      ~operation_id
+      ~attempt_id
+      ~failure:
+        (Operation.Candidate_not_installed
+           { cause; observed_checkpoint = candidate })
+  in
+  (match Reducer.apply (Some state) wrong with
+   | Error Reducer.Source_mismatch -> ()
+   | Ok _ | Error _ -> Alcotest.fail "third checkpoint was treated as not-installed");
+  let confirmed =
+    Operation.attempt_failed
+      ~operation_id
+      ~attempt_id
+      ~failure:
+        (Operation.Candidate_not_installed
+           { cause; observed_checkpoint = source })
+  in
+  let state = ok (Reducer.apply (Some state) confirmed) in
+  let snapshot = Reducer.snapshot state in
+  Alcotest.(check bool)
+    "confirmed non-install is terminal"
+    true
+    (Reducer.phase state = Reducer.Failed);
+  (match snapshot.failure with
+   | Some
+       (Operation.Candidate_not_installed
+          { cause = actual_cause; observed_checkpoint }) ->
+     Alcotest.(check bool)
+       "failure cause retained"
+       true
+       (Operation.Cause.equal cause actual_cause);
+     Alcotest.(check bool)
+       "observed source retained"
+       true
+       (Keeper_checkpoint_ref.equal source observed_checkpoint)
+   | Some (Operation.Pre_commit_failure _) | None ->
+     Alcotest.fail "terminal failure evidence was lost");
+  match Reducer.apply (Some state) (attempt_event ()) with
+  | Error (Reducer.Invalid_transition (Some Reducer.Failed)) -> ()
+  | Ok _ | Error _ -> Alcotest.fail "terminal failure accepted another attempt"
+;;
+
+let test_reducer_reconciliation () =
+  let state = ok (Reducer.fold [ request_event (); attempt_event (); candidate_event () ]) in
+  let event =
+    Operation.commit_reconciliation_required
+      ~operation_id
+      ~attempt_id
+      ~source_checkpoint:source
+      ~candidate_checkpoint:candidate
+      ~evidence
+      ~reason:Operation.Commit_durability_unknown
+  in
+  let state = ok (Reducer.apply (Some state) event) in
+  let snapshot = Reducer.snapshot state in
+  Alcotest.(check bool)
+    "unknown outcome remains reconciliation"
+    true
+    (snapshot.reconciliation_reason = Some Operation.Commit_durability_unknown)
+;;
+
+let test_reducer_source_superseded () =
+  let superseded =
+    Operation.source_superseded
+      ~operation_id
+      ~attempt_id
+      ~observed_checkpoint:(Some advanced)
+  in
+  let before_candidate =
+    ok (Reducer.fold [ request_event (); attempt_event (); superseded ])
+  in
+  let before_snapshot = Reducer.snapshot before_candidate in
+  Alcotest.(check bool)
+    "preparation-free supersession is terminal"
+    true
+    (before_snapshot.phase = Reducer.Superseded);
+  Alcotest.(check bool)
+    "observed checkpoint retained"
+    true
+    (Option.exists
+       (Keeper_checkpoint_ref.equal advanced)
+       before_snapshot.superseded_by_checkpoint);
+  let source_removed =
+    Operation.source_superseded
+      ~operation_id
+      ~attempt_id
+      ~observed_checkpoint:None
+  in
+  let removed =
+    ok (Reducer.fold [ request_event (); attempt_event (); source_removed ])
+  in
+  let removed_snapshot = Reducer.snapshot removed in
+  Alcotest.(check bool)
+    "missing exact source is terminal"
+    true
+    (removed_snapshot.phase = Reducer.Superseded
+     && Option.is_none removed_snapshot.superseded_by_checkpoint);
+  let after_candidate =
+    ok
+      (Reducer.fold
+         [ request_event (); attempt_event (); candidate_event (); superseded ])
+  in
+  let after_snapshot = Reducer.snapshot after_candidate in
+  Alcotest.(check bool)
+    "prepared candidate remains observable"
+    true
+    (Option.exists
+       (Keeper_checkpoint_ref.equal candidate)
+       after_snapshot.candidate_checkpoint);
+  let compacted =
+    Operation.compacted
+      ~operation_id
+      ~attempt_id
+      ~source_checkpoint:source
+      ~committed_checkpoint:candidate
+      ~evidence
+  in
+  let after_commit =
+    ok
+      (Reducer.fold
+         [ request_event ()
+         ; attempt_event ()
+         ; candidate_event ()
+         ; compacted
+         ; superseded
+         ])
+  in
+  let committed_snapshot = Reducer.snapshot after_commit in
+  Alcotest.(check bool)
+    "superseded operation retains prior commit"
+    true
+    (Option.exists
+       (Keeper_checkpoint_ref.equal candidate)
+       committed_snapshot.committed_checkpoint);
+  match Reducer.apply (Some after_candidate) (attempt_event ()) with
+  | Error (Reducer.Invalid_transition (Some Reducer.Superseded)) -> ()
+  | Ok _ | Error _ -> Alcotest.fail "superseded operation restarted"
+;;
+
+let test_reducer_rejects_false_supersession () =
+  let running = ok (Reducer.fold [ request_event (); attempt_event () ]) in
+  let event observed_checkpoint =
+    Operation.source_superseded
+      ~operation_id
+      ~attempt_id
+      ~observed_checkpoint:(Some observed_checkpoint)
+  in
+  (match Reducer.apply (Some running) (event source) with
+   | Error Reducer.Supersession_not_observed -> ()
+   | Ok _ | Error _ -> Alcotest.fail "source equality was called superseded");
+  let prepared = ok (Reducer.apply (Some running) (candidate_event ())) in
+  (match Reducer.apply (Some prepared) (event candidate) with
+   | Error Reducer.Supersession_candidate_installed -> ()
+   | Ok _ | Error _ -> Alcotest.fail "installed candidate was called superseded");
+  let committed =
+    ok
+      (Reducer.apply
+         (Some prepared)
+         (Operation.compacted
+            ~operation_id
+            ~attempt_id
+            ~source_checkpoint:source
+            ~committed_checkpoint:candidate
+            ~evidence))
+  in
+  (match Reducer.apply (Some committed) (event source) with
+   | Ok state when Reducer.phase state = Reducer.Superseded -> ()
+   | Ok _ | Error _ ->
+     Alcotest.fail "post-commit source restoration was not superseded");
+  let other_trace = ok (Keeper_id.Trace_id.of_string "trace-b") in
+  let other =
+    ok
+      (Keeper_checkpoint_ref.create
+         ~trace_id:other_trace
+         ~generation:2
+         ~turn_count:8
+         ~canonical_checkpoint_bytes:"other")
+  in
+  match Reducer.apply (Some running) (event other) with
+  | Error Reducer.Supersession_trace_mismatch -> ()
+  | Ok _ | Error _ -> Alcotest.fail "cross-trace supersession was accepted"
+;;
+
+let test_reducer_invalid_transition () =
+  match Reducer.fold [ request_event (); candidate_event () ] with
+  | Error (Reducer.Invalid_transition (Some Reducer.Request_pending)) -> ()
+  | Ok _ | Error _ -> Alcotest.fail "candidate without attempt was accepted"
+;;
+
+let test_canonical_json_projection () =
+  let turn = Ids.Turn_ref.make ~trace_id:"trace-a" ~absolute_turn:8 in
+  let events =
+    [ request_event ()
+    ; attempt_event ()
+    ; candidate_event ()
+    ; Operation.attempt_failed
+        ~operation_id
+        ~attempt_id
+        ~failure:(Operation.Pre_commit_failure cause)
+    ; Operation.attempt_failed
+        ~operation_id
+        ~attempt_id
+        ~failure:
+          (Operation.Candidate_not_installed
+             { cause; observed_checkpoint = source })
+    ; Operation.commit_reconciliation_required
+        ~operation_id
+        ~attempt_id
+        ~source_checkpoint:source
+        ~candidate_checkpoint:candidate
+        ~evidence
+        ~reason:Operation.Commit_durability_unknown
+    ; Operation.source_superseded
+        ~operation_id
+        ~attempt_id
+        ~observed_checkpoint:(Some advanced)
+    ; Operation.compacted
+        ~operation_id
+        ~attempt_id
+        ~source_checkpoint:source
+        ~committed_checkpoint:candidate
+        ~evidence
+    ; Operation.reinjected
+        ~operation_id
+        ~adopted_checkpoint:candidate
+        ~adopting_turn:turn
+    ]
+  in
+  let kinds =
+    List.map
+      (fun event ->
+         Operation_json.to_json event
+         |> Yojson.Safe.Util.member "kind"
+         |> Yojson.Safe.Util.to_string)
+      events
+  in
+  Alcotest.(check (list string))
+    "closed event labels"
+    [ "requested"
+    ; "attempt_started"
+    ; "candidate_prepared"
+    ; "attempt_failed"
+    ; "attempt_failed"
+    ; "commit_reconciliation_required"
+    ; "source_superseded"
+    ; "compacted"
+    ; "reinjected"
+    ]
+    kinds;
+  let requested = Operation_json.to_json (List.hd events) in
+  Alcotest.(check string)
+    "exact producer request id"
+    "req-1"
+    (requested
+     |> Yojson.Safe.Util.member "payload"
+     |> Yojson.Safe.Util.member "producer_invocation"
+     |> Yojson.Safe.Util.member "request_id"
+     |> Yojson.Safe.Util.to_string)
+;;
+
+let test_codec_roundtrip_all_events () =
+  let turn = Ids.Turn_ref.make ~trace_id:"trace-a" ~absolute_turn:8 in
+  let failed failure =
+    Operation.attempt_failed ~operation_id ~attempt_id ~failure
+  in
+  let reconcile reason =
+    Operation.commit_reconciliation_required
+      ~operation_id
+      ~attempt_id
+      ~source_checkpoint:source
+      ~candidate_checkpoint:candidate
+      ~evidence
+      ~reason
+  in
+  let events =
+    [ request_event ()
+    ; Operation.requested
+        ~operation_id
+        ~keeper_name
+        ~source_checkpoint:source
+        ~trigger:(Compaction_trigger.Provider_overflow { limit_tokens = None })
+        ~cause
+        ~producer_invocation:None
+    ; attempt_event ()
+    ; candidate_event ()
+    ; failed (Operation.Pre_commit_failure cause)
+    ; failed
+        (Operation.Candidate_not_installed
+           { cause; observed_checkpoint = source })
+    ; reconcile Operation.Commit_durability_unknown
+    ; reconcile Operation.Transaction_outcome_unknown
+    ; Operation.source_superseded
+        ~operation_id
+        ~attempt_id
+        ~observed_checkpoint:(Some advanced)
+    ; Operation.compacted
+        ~operation_id
+        ~attempt_id
+        ~source_checkpoint:source
+        ~committed_checkpoint:candidate
+        ~evidence
+    ; Operation.reinjected
+        ~operation_id
+        ~adopted_checkpoint:candidate
+        ~adopting_turn:turn
+    ]
+  in
+  List.iter
+    (fun event ->
+       let json = Codec.to_json event in
+       match Codec.of_json json with
+       | Ok decoded ->
+         Alcotest.(check (testable Yojson.Safe.pp Yojson.Safe.equal))
+           "canonical roundtrip"
+           json
+           (Codec.to_json decoded)
+       | Error _ -> Alcotest.fail "canonical event was rejected")
+    events
+;;
+
+let replace_field name value = function
+  | `Assoc fields ->
+    `Assoc
+      (List.map
+         (fun (field, current) ->
+            if String.equal field name then field, value else field, current)
+         fields)
+  | json -> json
+;;
+
+let expect_field_error message expected json =
+  match Codec.of_json json with
+  | Error (Codec.Invalid_field actual) when actual = expected -> ()
+  | Ok _ | Error _ -> Alcotest.fail message
+;;
+
+let test_codec_rejects_nested_unknown_field () =
+  let json = Codec.to_json (request_event ()) in
+  let payload = Yojson.Safe.Util.member "payload" json in
+  let prepend name value = function
+    | `Assoc fields -> `Assoc ((name, value) :: fields)
+    | current -> current
+  in
+  let remove name = function
+    | `Assoc fields -> `Assoc (List.remove_assoc name fields)
+    | current -> current
+  in
+  let with_unknown name =
+    prepend name `Null
+  in
+  expect_field_error
+    "event accepted an unknown top field"
+    (Codec.Unknown_field { path = "$"; field = "unexpected_top" })
+    (with_unknown "unexpected_top" json);
+  expect_field_error
+    "event accepted a duplicate top field"
+    (Codec.Duplicate_field { path = "$"; field = "kind" })
+    (prepend "kind" (`String "requested") json);
+  expect_field_error
+    "event accepted a missing top field"
+    (Codec.Missing_field { path = "$"; field = "payload" })
+    (remove "payload" json);
+  expect_field_error
+    "event accepted a wrong-type top field"
+    (Codec.Wrong_type { path = "$"; field = "operation_id"; expected = "string" })
+    (replace_field "operation_id" (`Int 1) json);
+  let payload_unknown =
+    replace_field "payload" (with_unknown "unexpected_payload" payload) json
+  in
+  expect_field_error
+    "event accepted an unknown payload field"
+    (Codec.Unknown_field { path = "payload"; field = "unexpected_payload" })
+    payload_unknown;
+  let trigger =
+    `Assoc [ "kind", `String "manual"; "unexpected", `Null ]
+  in
+  let malformed = replace_field "payload" (replace_field "trigger" trigger payload) json in
+  expect_field_error
+    "event accepted an unknown trigger field"
+    (Codec.Unknown_field { path = "payload.trigger"; field = "unexpected" })
+    malformed
+;;
+
+let () =
+  Alcotest.run
+    "keeper compaction operation events"
+    [ ( "events"
+      , [ Alcotest.test_case "requested typed view" `Quick test_requested_view
+        ; Alcotest.test_case "candidate typed views" `Quick test_candidate_views
+        ; Alcotest.test_case
+            "failure and reinjection typed views"
+            `Quick
+            test_failure_and_reinjection_views
+        ; Alcotest.test_case "reducer happy path" `Quick test_reducer_happy_path
+        ; Alcotest.test_case
+            "reducer confirmed failure"
+            `Quick
+            test_reducer_confirmed_failure
+        ; Alcotest.test_case
+            "reducer reconciliation"
+            `Quick
+            test_reducer_reconciliation
+        ; Alcotest.test_case
+            "reducer source superseded"
+            `Quick
+            test_reducer_source_superseded
+        ; Alcotest.test_case
+            "reducer rejects false supersession"
+            `Quick
+            test_reducer_rejects_false_supersession
+        ; Alcotest.test_case
+            "reducer invalid transition"
+            `Quick
+            test_reducer_invalid_transition
+        ; Alcotest.test_case
+            "canonical JSON projection"
+            `Quick
+            test_canonical_json_projection
+        ; Alcotest.test_case
+            "codec roundtrip all events"
+            `Quick
+            test_codec_roundtrip_all_events
+        ; Alcotest.test_case
+            "codec rejects nested unknown field"
+            `Quick
+            test_codec_rejects_nested_unknown_field
+        ] )
+    ]

--- a/test/keeper_compaction_operation_action_selector/dune
+++ b/test/keeper_compaction_operation_action_selector/dune
@@ -1,0 +1,5 @@
+(test
+ (name test_keeper_compaction_operation_action_selector)
+ (libraries alcotest masc.compaction_trigger masc.keeper_checkpoint_ref
+  masc.keeper_compaction_evidence masc.keeper_compaction_operation
+  masc.keeper_registry))

--- a/test/keeper_compaction_operation_action_selector/test_keeper_compaction_operation_action_selector.ml
+++ b/test/keeper_compaction_operation_action_selector/test_keeper_compaction_operation_action_selector.ml
@@ -1,0 +1,178 @@
+module Operation = Keeper_compaction_operation
+module Reducer = Keeper_compaction_operation_reducer
+module Selector = Keeper_compaction_operation_action_selector
+module Store = Keeper_compaction_operation_store
+
+open Selector
+let ok = function Ok value -> value | Error _ -> Alcotest.fail "fixture failed"
+let operation value = ok (Operation.Operation_id.of_string value)
+let op1 = operation "00000000-0000-4000-8000-000000000001"
+let op2 = operation "00000000-0000-4000-8000-000000000002"
+let op3 = operation "00000000-0000-4000-8000-000000000003"
+let attempt =
+  ok
+    (Operation.Attempt_id.of_string
+       "00000000-0000-4000-8000-000000000011")
+
+let keeper = ok (Keeper_id.Keeper_name.of_string "selector-keeper")
+let trace = ok (Keeper_id.Trace_id.of_string "selector-trace")
+let checkpoint bytes =
+  ok
+    (Keeper_checkpoint_ref.create
+       ~trace_id:trace
+       ~generation:1
+       ~turn_count:4
+       ~canonical_checkpoint_bytes:bytes)
+
+let source = checkpoint "source"
+let target = checkpoint "candidate"
+let cause = ok (Operation.Cause.of_string "explicit request")
+let evidence : Keeper_compaction_evidence.t =
+  { selected_runtime_id = Some "runtime-a"
+  ; before_checkpoint_bytes = 120
+  ; after_checkpoint_bytes = 60
+  ; before_message_count = 12
+  ; after_message_count = 5
+  ; summarized_message_count = 7
+  ; dropped_message_count = 0
+  ; before_tool_use_count = 2
+  ; after_tool_use_count = 1
+  ; before_tool_result_count = 2
+  ; after_tool_result_count = 1
+  }
+
+let requested operation_id =
+  Operation.requested
+    ~operation_id
+    ~keeper_name:keeper
+    ~source_checkpoint:source
+    ~trigger:Compaction_trigger.Manual
+    ~cause
+    ~producer_invocation:None
+
+let prepared operation_id =
+  [ Operation.attempt_started ~operation_id ~attempt_id:attempt
+  ; Operation.candidate_prepared
+      ~operation_id
+      ~attempt_id:attempt
+      ~source_checkpoint:source
+      ~candidate_checkpoint:target
+      ~evidence
+  ]
+
+let snapshot operation_id events =
+  ok (Reducer.fold (requested operation_id :: events)) |> Reducer.snapshot
+
+let entry cursor snapshot : Store.operation_entry =
+  { snapshot
+  ; requested_at = float_of_int cursor
+  ; request_cursor = ok (Store.Cursor.of_int cursor)
+  }
+
+let replay operations : Store.replay =
+  { operations; end_cursor = ok (Store.Cursor.of_int 1000) }
+
+let select mode operations = Selector.select ~mode (replay operations)
+let same_operation expected actual =
+  Operation.Operation_id.equal expected actual.operation_id
+
+let same_candidate expected (actual : candidate_context) =
+  same_operation expected actual.operation
+  && Operation.Attempt_id.equal attempt actual.candidate.attempt_id
+  && Keeper_checkpoint_ref.equal source actual.candidate.source_checkpoint
+  && Keeper_checkpoint_ref.equal target actual.candidate.candidate_checkpoint
+  && actual.candidate.evidence = evidence
+
+let test_fifo_and_terminal_skip () =
+  let pending = snapshot op3 [] in
+  let operations =
+    [ entry 1 { pending with phase = Reducer.Adopted }
+    ; entry 2 { pending with phase = Reducer.Failed }
+    ; entry 3 { pending with phase = Reducer.Superseded }
+    ; entry 4 pending
+    ; entry 5 (snapshot op2 [])
+    ]
+  in
+  match select Steady_state operations with
+  | Ok (Selected (Start_attempt selected)) ->
+    Alcotest.(check bool) "first nonterminal" true
+      (same_operation op3 selected);
+    Alcotest.(check int) "exact cursor" 4
+      (Store.Cursor.to_int selected.request_cursor)
+  | Ok _ | Error _ -> Alcotest.fail "FIFO request was not selected"
+
+let test_attempt_modes () =
+  let running =
+    entry 1
+      (snapshot op1
+         [ Operation.attempt_started ~operation_id:op1 ~attempt_id:attempt ])
+  in
+  let operations = [ running; entry 2 (snapshot op2 []) ] in
+  (match select Startup_recovery operations with
+   | Ok (Selected (Terminalize_interrupted_attempt selected)) ->
+     Alcotest.(check bool) "startup operation" true
+       (same_operation op1 selected.operation);
+     Alcotest.(check bool) "attempt retained" true
+       (Operation.Attempt_id.equal attempt selected.attempt_id)
+   | Ok _ | Error _ -> Alcotest.fail "startup interruption not terminalized");
+  match select Steady_state operations with
+  | Ok (In_flight selected) ->
+    Alcotest.(check bool) "steady operation" true
+      (same_operation op1 selected.operation);
+    Alcotest.(check bool) "request retained" true
+      (Operation.Cause.equal cause selected.operation.request.cause)
+  | Ok _ | Error _ -> Alcotest.fail "in-flight operation was bypassed"
+
+let test_candidate_actions () =
+  let prepared_snapshot = snapshot op1 (prepared op1) in
+  let reconciliation =
+    snapshot op2
+      (prepared op2
+       @ [ Operation.commit_reconciliation_required
+             ~operation_id:op2
+             ~attempt_id:attempt
+             ~source_checkpoint:source
+             ~candidate_checkpoint:target
+             ~evidence
+             ~reason:Operation.Transaction_outcome_unknown
+         ])
+  in
+  let committed =
+    snapshot op3
+      (prepared op3
+       @ [ Operation.compacted
+             ~operation_id:op3
+             ~attempt_id:attempt
+             ~source_checkpoint:source
+             ~committed_checkpoint:target
+             ~evidence
+         ])
+  in
+  (match select Steady_state [ entry 1 prepared_snapshot ] with
+   | Ok (Selected (Resume_candidate_commit selected)) ->
+     Alcotest.(check bool) "prepared exact" true
+       (same_candidate op1 selected)
+   | Ok _ | Error _ -> Alcotest.fail "prepared action missing");
+  (match select Steady_state [ entry 1 reconciliation ] with
+   | Ok
+       (Selected
+          (Reconcile_commit (selected, Operation.Transaction_outcome_unknown)))
+     ->
+     Alcotest.(check bool) "reconcile exact" true
+       (same_candidate op2 selected)
+   | Ok _ | Error _ -> Alcotest.fail "reconcile action missing");
+  match select Steady_state [ entry 1 committed ] with
+  | Ok (Selected (Wake_for_reinjection selected)) ->
+    Alcotest.(check bool) "committed exact" true
+      (same_candidate op3 selected)
+  | Ok _ | Error _ -> Alcotest.fail "reinjection action missing"
+
+let () =
+  Alcotest.run "keeper compaction operation action selector"
+    [ ( "selection"
+      , [ Alcotest.test_case "FIFO and terminal skip" `Quick
+            test_fifo_and_terminal_skip
+        ; Alcotest.test_case "attempt modes" `Quick test_attempt_modes
+        ; Alcotest.test_case "candidate actions" `Quick test_candidate_actions
+        ] )
+    ]

--- a/test/keeper_compaction_operation_identity/dune
+++ b/test/keeper_compaction_operation_identity/dune
@@ -1,0 +1,3 @@
+(test
+ (name test_keeper_compaction_operation_identity)
+ (libraries alcotest masc.keeper_compaction_operation))

--- a/test/keeper_compaction_operation_identity/test_keeper_compaction_operation_identity.ml
+++ b/test/keeper_compaction_operation_identity/test_keeper_compaction_operation_identity.ml
@@ -1,0 +1,66 @@
+module Identity = Keeper_compaction_operation_identity
+
+let canonical_uuid = "123e4567-e89b-12d3-a456-426614174000"
+
+let test_typed_ids () =
+  let parse parse value =
+    match parse value with
+    | Ok id -> id
+    | Error Identity.Invalid_canonical_uuid -> Alcotest.fail "canonical UUID rejected"
+  in
+  let operation = parse Identity.Operation_id.of_string canonical_uuid in
+  let attempt = parse Identity.Attempt_id.of_string canonical_uuid in
+  Alcotest.(check string)
+    "operation projection"
+    canonical_uuid
+    (Identity.Operation_id.to_string operation);
+  Alcotest.(check string)
+    "attempt projection"
+    canonical_uuid
+    (Identity.Attempt_id.to_string attempt);
+  let generated_operation = Identity.Operation_id.generate () in
+  let next_operation = Identity.Operation_id.generate () in
+  Alcotest.(check bool)
+    "fresh operation ids differ"
+    false
+    (Identity.Operation_id.equal generated_operation next_operation);
+  (match
+     Identity.Operation_id.of_string
+       (Identity.Operation_id.to_string generated_operation)
+   with
+   | Ok restored ->
+     Alcotest.(check bool)
+       "generated operation is canonical"
+       true
+       (Identity.Operation_id.equal generated_operation restored)
+   | Error _ -> Alcotest.fail "generated operation id did not parse");
+  List.iter
+    (fun value ->
+       match Identity.Operation_id.of_string value with
+       | Error Identity.Invalid_canonical_uuid -> ()
+       | Ok _ -> Alcotest.failf "noncanonical UUID accepted: %S" value)
+    [ String.uppercase_ascii canonical_uuid; "not-a-uuid"; " " ^ canonical_uuid ]
+;;
+
+let test_cause () =
+  let open Identity.Cause in
+  (match of_string "provider context overflow" with
+   | Ok cause ->
+     Alcotest.(check string) "exact projection" "provider context overflow" (to_string cause)
+   | Error _ -> Alcotest.fail "canonical cause rejected");
+  List.iter
+    (fun (value, expected) ->
+       match of_string value with
+       | Error actual -> Alcotest.(check bool) value true (actual = expected)
+       | Ok _ -> Alcotest.failf "invalid cause accepted: %S" value)
+    [ "", Empty; " padded", Noncanonical; "padded ", Noncanonical ]
+;;
+
+let () =
+  Alcotest.run
+    "keeper compaction operation identity"
+    [ ( "identity"
+      , [ Alcotest.test_case "canonical typed UUIDs" `Quick test_typed_ids
+        ; Alcotest.test_case "canonical cause" `Quick test_cause
+        ] )
+    ]

--- a/test/keeper_compaction_operation_record/dune
+++ b/test/keeper_compaction_operation_record/dune
@@ -1,0 +1,9 @@
+(test
+ (name test_keeper_compaction_operation_record)
+ (libraries
+ alcotest
+  masc.compaction_trigger
+  masc.keeper_checkpoint_ref
+  masc.keeper_compaction_operation
+  masc.keeper_registry
+  yojson))

--- a/test/keeper_compaction_operation_record/test_keeper_compaction_operation_record.ml
+++ b/test/keeper_compaction_operation_record/test_keeper_compaction_operation_record.ml
@@ -1,0 +1,142 @@
+module Operation = Keeper_compaction_operation
+module Record = Keeper_compaction_operation_record
+
+let ok = function
+  | Ok value -> value
+  | Error _ -> Alcotest.fail "fixture construction failed"
+;;
+
+let checkpoint_option_equal left right =
+  match left, right with
+  | None, None -> true
+  | Some left, Some right -> Keeper_checkpoint_ref.equal left right
+  | None, Some _ | Some _, None -> false
+;;
+
+let keeper_name = ok (Keeper_id.Keeper_name.of_string "record-keeper")
+let trace_id = ok (Keeper_id.Trace_id.of_string "record-trace")
+
+let source =
+  ok
+    (Keeper_checkpoint_ref.create
+       ~trace_id
+       ~generation:1
+       ~turn_count:3
+       ~canonical_checkpoint_bytes:"source")
+;;
+
+let event =
+  let operation_id =
+    ok
+      (Operation.Operation_id.of_string
+         "00000000-0000-4000-8000-000000000001")
+  in
+  Operation.requested
+    ~operation_id
+    ~keeper_name
+    ~source_checkpoint:source
+    ~trigger:Compaction_trigger.Manual
+    ~cause:(ok (Operation.Cause.of_string "manual compaction"))
+    ~producer_invocation:None
+;;
+
+let test_roundtrip_and_cursor () =
+  let encoded = ok (Record.encode ~recorded_at:(-1.25) event) in
+  let from = ok (Record.Cursor.of_int 17) in
+  match Record.decode_rows ~from ~row_number:None encoded with
+  | Ok [ row ] ->
+    Alcotest.(check (float 0.0)) "timestamp" (-1.25) row.recorded_at;
+    Alcotest.(check int) "start" 17 (Record.Cursor.to_int row.start_cursor);
+    Alcotest.(check int)
+      "newline end"
+      (17 + String.length encoded)
+      (Record.Cursor.to_int row.end_cursor);
+    Alcotest.(check bool)
+      "event identity"
+      true
+      (Operation.Operation_id.equal
+         (Operation.operation_id row.event)
+         (Operation.operation_id event))
+  | _ -> Alcotest.fail "canonical row did not decode"
+;;
+
+let test_closed_envelope_and_finite_time () =
+  (match Record.encode ~recorded_at:Float.nan event with
+   | Error Record.Invalid_recorded_at -> ()
+   | _ -> Alcotest.fail "non-finite timestamp encoded");
+  let malformed =
+    `Assoc
+      [ "recorded_at", `Float 1.0
+      ; "event", Keeper_compaction_operation_codec.to_json event
+      ; "extra", `Null
+      ]
+    |> Yojson.Safe.to_string
+    |> fun value -> value ^ "\n"
+  in
+  match Record.decode_rows ~from:Record.Cursor.zero ~row_number:(Some 1) malformed with
+  | Error
+      { row_number = Some 1
+      ; issue = Record.Invalid_envelope (Record.Unknown_field "extra")
+      ; _
+      } ->
+    ()
+  | _ -> Alcotest.fail "unknown envelope field was accepted"
+;;
+
+let test_incomplete_tail_is_located () =
+  match
+    Record.decode_rows
+      ~from:(ok (Record.Cursor.of_int 8))
+      ~row_number:None
+      "{}"
+  with
+  | Error
+      { row_number = None
+      ; start_cursor
+      ; end_cursor
+      ; issue = Record.Incomplete_tail
+      } ->
+    Alcotest.(check int) "start" 8 (Record.Cursor.to_int start_cursor);
+    Alcotest.(check int) "end" 10 (Record.Cursor.to_int end_cursor)
+  | _ -> Alcotest.fail "incomplete tail was accepted"
+;;
+
+let test_superseded_roundtrip () =
+  let attempt_id =
+    ok
+      (Operation.Attempt_id.of_string
+         "00000000-0000-4000-8000-000000000011")
+  in
+  List.iter
+    (fun observed_checkpoint ->
+       let superseded =
+         Operation.source_superseded
+           ~operation_id:(Operation.operation_id event)
+           ~attempt_id
+           ~observed_checkpoint
+       in
+       let encoded = ok (Record.encode ~recorded_at:1.0 superseded) in
+       match Record.decode_rows ~from:Record.Cursor.zero ~row_number:(Some 1) encoded with
+       | Ok [ row ] ->
+         (match Operation.view row.event with
+          | Operation.Source_superseded actual ->
+            Alcotest.(check bool)
+              "exact optional checkpoint"
+              true
+              (checkpoint_option_equal actual.observed_checkpoint observed_checkpoint)
+          | _ -> Alcotest.fail "supersession kind changed")
+       | _ -> Alcotest.fail "supersession did not roundtrip")
+    [ None; Some source ]
+;;
+
+let () =
+  Alcotest.run
+    "keeper compaction operation record"
+    [ ( "record"
+      , [ Alcotest.test_case "roundtrip and cursor" `Quick test_roundtrip_and_cursor
+        ; Alcotest.test_case "closed envelope" `Quick test_closed_envelope_and_finite_time
+        ; Alcotest.test_case "incomplete tail" `Quick test_incomplete_tail_is_located
+        ; Alcotest.test_case "superseded roundtrip" `Quick test_superseded_roundtrip
+        ] )
+    ]
+;;

--- a/test/keeper_compaction_operation_store/dune
+++ b/test/keeper_compaction_operation_store/dune
@@ -1,0 +1,12 @@
+(test
+ (name test_keeper_compaction_operation_store)
+ (libraries
+  alcotest
+  masc.compaction_trigger
+  masc.fs_compat
+  masc.keeper_checkpoint_ref
+  masc.keeper_compaction_operation
+  masc.keeper_registry
+  masc.mcp_transport_protocol
+  masc.tool_invocation_ref
+  unix))

--- a/test/keeper_compaction_operation_store/test_keeper_compaction_operation_store.ml
+++ b/test/keeper_compaction_operation_store/test_keeper_compaction_operation_store.ml
@@ -1,0 +1,105 @@
+module Operation = Keeper_compaction_operation
+module Store = Keeper_compaction_operation_store
+let ok = function Ok value -> value | Error _ -> Alcotest.fail "fixture failed"
+let keeper_name = ok (Keeper_id.Keeper_name.of_string "store-keeper")
+let trace_id = ok (Keeper_id.Trace_id.of_string "store-trace")
+let cause = ok (Operation.Cause.of_string "manual compaction")
+let source =
+  ok
+    (Keeper_checkpoint_ref.create
+       ~trace_id
+       ~generation:1
+       ~turn_count:3
+       ~canonical_checkpoint_bytes:"source")
+;;
+let id value = ok (Operation.Operation_id.of_string value)
+let op1 = id "00000000-0000-4000-8000-000000000001"
+let op2 = id "00000000-0000-4000-8000-000000000002"
+let attempt = ok (Operation.Attempt_id.of_string "00000000-0000-4000-8000-000000000011")
+let request ?producer operation_id =
+  Operation.requested ~operation_id ~keeper_name ~source_checkpoint:source
+    ~trigger:Compaction_trigger.Manual ~cause ~producer_invocation:producer
+;;
+let rec remove path =
+  if Sys.file_exists path then if Sys.is_directory path
+    then (Sys.readdir path |> Array.iter (fun name -> remove (Filename.concat path name));
+          Unix.rmdir path)
+    else Unix.unlink path
+;;
+let with_base f =
+  let base = Filename.temp_dir "operation_store_" "" in
+  Fun.protect ~finally:(fun () -> remove base) (fun () -> f base)
+;;
+let append base time event =
+  match Store.append ~base_path:base ~keeper_name ~recorded_at:time event with
+  | Ok row -> row
+  | Error _ -> Alcotest.fail "valid append failed"
+;;
+let test_append_replay_and_slice () =
+  with_base @@ fun base ->
+  let first = append base 1.0 (request op2) in
+  let second = append base 2.0 (request op1) in
+  let last = append base 3.0 (Operation.attempt_started ~operation_id:op2 ~attempt_id:attempt) in
+  (match Store.replay ~base_path:base ~keeper_name with
+   | Ok { operations = [ a; b ]; _ } ->
+     Alcotest.(check bool) "request-cursor FIFO" true
+       (Operation.Operation_id.equal a.snapshot.operation_id op2
+        && Operation.Operation_id.equal b.snapshot.operation_id op1
+        && a.snapshot.phase = Keeper_compaction_operation_reducer.Attempt_in_progress
+        && Store.Cursor.to_int a.request_cursor = Store.Cursor.to_int first.end_cursor)
+   | _ -> Alcotest.fail "valid history did not replay");
+  match Store.read_slice ~base_path:base ~keeper_name ~from:second.end_cursor with
+  | Ok { rows = [ row ]; end_cursor } ->
+    Alcotest.(check int) "exact suffix end"
+      (Store.Cursor.to_int last.end_cursor) (Store.Cursor.to_int end_cursor);
+    Alcotest.(check (float 0.0)) "last timestamp" 3.0 row.recorded_at
+  | _ -> Alcotest.fail "cursor slice was not exact"
+;;
+let producer () =
+  let request_id = ok (Mcp_transport_protocol.request_id_of_yojson (`Int 7)) in
+  ok (Tool_invocation_ref.external_mcp ~request_id ~session_id:"store-session")
+;;
+let test_rejections_do_not_write () =
+  with_base @@ fun base ->
+  let producer = producer () in
+  ignore (append base 1.0 (request ~producer op1));
+  let path = Store.journal_path ~base_path:base ~keeper_name in
+  let before = Fs_compat.load_file path in
+  (match Store.append ~base_path:base ~keeper_name ~recorded_at:2.0 (request ~producer op2) with
+   | Error (Store.Event_rejected (Store.Producer_already_bound { existing_operation_id; _ }))
+     when Operation.Operation_id.equal existing_operation_id op1 -> ()
+   | _ -> Alcotest.fail "producer retry was not bound to its original operation");
+  (match Store.append ~base_path:base ~keeper_name ~recorded_at:3.0 (request ~producer op1) with
+   | Error (Store.Event_rejected (Store.Transition_rejected _)) -> ()
+   | _ -> Alcotest.fail "invalid transition was not rejected");
+  let other = ok (Keeper_id.Keeper_name.of_string "other-keeper") in
+  let wrong =
+    Operation.requested ~operation_id:op2 ~keeper_name:other ~source_checkpoint:source
+      ~trigger:Compaction_trigger.Manual ~cause ~producer_invocation:None
+  in
+  (match Store.append ~base_path:base ~keeper_name ~recorded_at:4.0 wrong with
+   | Error (Store.Event_rejected (Store.Keeper_mismatch _)) -> ()
+   | _ -> Alcotest.fail "cross-Keeper request was not rejected");
+  Alcotest.(check string) "rejections wrote no bytes" before (Fs_compat.load_file path)
+;;
+let test_malformed_history_fails_loud () =
+  with_base @@ fun base ->
+  let path = Store.journal_path ~base_path:base ~keeper_name in
+  Fs_compat.mkdir_p (Filename.dirname path);
+  Out_channel.with_open_bin path (fun output -> output_string output "not-json\n");
+  (match Store.replay ~base_path:base ~keeper_name with
+   | Error (Store.Invalid_history (Store.Invalid_record _)) -> ()
+   | _ -> Alcotest.fail "malformed history did not fail replay");
+  match Store.append ~base_path:base ~keeper_name ~recorded_at:1.0 (request op1) with
+  | Error (Store.Existing_history_invalid _) ->
+    Alcotest.(check string) "malformed bytes unchanged" "not-json\n" (Fs_compat.load_file path)
+  | _ -> Alcotest.fail "append accepted malformed history"
+;;
+let () =
+  Alcotest.run "keeper compaction operation store"
+    [ "journal",
+      [ Alcotest.test_case "append replay slice" `Quick test_append_replay_and_slice
+      ; Alcotest.test_case "rejections no write" `Quick test_rejections_do_not_write
+      ; Alcotest.test_case "malformed history" `Quick test_malformed_history_fails_loud
+      ] ]
+;;

--- a/test/stanzas/test_keeper_checkpoint_stale_guard.inc
+++ b/test/stanzas/test_keeper_checkpoint_stale_guard.inc
@@ -5,4 +5,4 @@
 (test
  (name test_keeper_checkpoint_stale_guard)
  (modules test_keeper_checkpoint_stale_guard)
- (libraries masc_test_deps))
+ (libraries masc_test_deps masc.keeper_checkpoint_ref))

--- a/test/test_keeper_adversarial_review.ml
+++ b/test/test_keeper_adversarial_review.ml
@@ -69,7 +69,8 @@ let operator_ctx env sw config agent_name : _ Operator_control.context =
            ~clock:(Eio.Stdenv.clock env)
            ~proc_mgr:(Some (Eio.Stdenv.process_mgr env))
            ~net:(Some (Eio.Stdenv.net env))
-           ~publication_recovery_provider);
+           ~publication_recovery_provider
+           ());
     mcp_session_id = None;
   }
 

--- a/test/test_keeper_checkpoint_stale_guard.ml
+++ b/test/test_keeper_checkpoint_stale_guard.ml
@@ -81,6 +81,12 @@ let make_checkpoint ~session_id ~turn_count ~marker =
     working_context = None;
   }
 
+let with_generation generation (checkpoint : Agent_sdk.Checkpoint.t) =
+  let context = Agent_sdk.Context.copy ~eio:false checkpoint.context in
+  Agent_sdk.Context.set_scoped context Agent_sdk.Context.Session
+    "keeper_generation" (`Int generation);
+  { checkpoint with context }
+
 let save_ok ~session_dir ckpt label =
   match Keeper_checkpoint_store.save_oas_classified ~session_dir ckpt with
   | Ok _ -> ()
@@ -446,6 +452,69 @@ let test_ready_runtime_raw_domain_save () =
   | Error _ -> fail "raw-domain checkpoint did not round-trip"
   | Ok checkpoint -> check int "raw-domain turn persisted" 11 checkpoint.turn_count
 
+let test_exact_source_cas_allows_one_equal_turn_writer () =
+  let session_dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir session_dir) (fun () ->
+    let session_id = "sess-exact-cas" in
+    save_ok ~session_dir
+      (make_checkpoint ~session_id ~turn_count:8 ~marker:"source"
+       |> with_generation 3)
+      "CAS seed save";
+    let source_ref =
+      match
+        Keeper_checkpoint_store.load_oas_with_ref ~session_dir ~session_id
+      with
+      | Ok (_, reference) -> reference
+      | Error _ -> fail "CAS source load failed"
+    in
+    let writer marker =
+      Keeper_checkpoint_store.save_oas_if_source
+        ~session_dir
+        ~expected_source_ref:source_ref
+        (make_checkpoint ~session_id ~turn_count:8 ~marker
+         |> with_generation 3)
+    in
+    let left = Domain.spawn (fun () -> "left", writer "left") in
+    let right = Domain.spawn (fun () -> "right", writer "right") in
+    let committed, changed =
+      [ Domain.join left; Domain.join right ]
+      |> List.fold_left
+           (fun (committed, changed) (marker, outcome) ->
+             match outcome with
+             | Ok reference -> (marker, reference) :: committed, changed
+             | Error (Keeper_checkpoint_store.Source_changed _) ->
+               committed, changed + 1
+             | Error _ -> fail "CAS writer returned an unexpected error")
+           ([], 0)
+    in
+    check int "exactly one writer commits" 1 (List.length committed);
+    check int "the competing source is rejected" 1 changed;
+    match committed,
+      Keeper_checkpoint_store.load_oas_with_ref ~session_dir ~session_id
+    with
+    | [ (winner, committed_ref) ], Ok (checkpoint, disk_ref) ->
+      check bool "committed ref identifies installed canonical bytes" true
+        (Keeper_checkpoint_ref.equal committed_ref disk_ref);
+      check bool "installed payload belongs to the winning writer" true
+        (List.exists
+           (fun (message : Agent_sdk.Types.message) ->
+             String.equal (Agent_sdk.Types.text_of_message message) winner)
+           checkpoint.messages)
+    | _ -> fail "CAS winner did not round-trip")
+
+let test_checkpoint_ref_requires_generation () =
+  let session_dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir session_dir) (fun () ->
+    let session_id = "sess-ref-generation" in
+    save_ok ~session_dir
+      (make_checkpoint ~session_id ~turn_count:1 ~marker:"legacy")
+      "generation-less seed";
+    match Keeper_checkpoint_store.load_oas_with_ref ~session_dir ~session_id with
+    | Error
+        (Keeper_checkpoint_store.Ref_identity_invalid
+           Keeper_checkpoint_store.Generation_missing) -> ()
+    | _ -> fail "generation-less checkpoint acquired an exact ref")
+
 let () =
   run "Keeper_checkpoint_store checkpoint watermark (RFC-0225 §3.2)"
     [
@@ -471,5 +540,9 @@ let () =
             test_fingerprint_mismatch_recovers_externally_written_canonical;
           test_case "canonical checkpoint is written compact and round-trips" `Quick
             test_canonical_checkpoint_is_written_compact;
+          test_case "exact source CAS permits one equal-turn writer" `Quick
+            test_exact_source_cas_allows_one_equal_turn_writer;
+          test_case "checkpoint refs require keeper generation" `Quick
+            test_checkpoint_ref_requires_generation;
         ] );
     ]

--- a/test/test_keeper_overflow_recovery.ml
+++ b/test/test_keeper_overflow_recovery.ml
@@ -26,9 +26,63 @@ let overflow_event ?(limit = Some 200_000) () =
 let test_provider_overflow_trigger_roundtrip () =
   let trigger = Compaction_trigger.Provider_overflow { limit_tokens = Some 200_000 } in
   check string "typed trigger label" "provider_overflow" (Compaction_trigger.to_label trigger);
-  match Compaction_trigger.of_detail_json (Compaction_trigger.to_detail_json trigger) with
-  | Some (Compaction_trigger.Provider_overflow { limit_tokens = Some 200_000 }) -> ()
-  | _ -> fail "typed provider overflow trigger did not round-trip"
+  List.iter
+    (fun expected ->
+       match
+         Compaction_trigger.of_detail_json (Compaction_trigger.to_detail_json expected)
+       with
+       | Ok actual when actual = expected -> ()
+       | Ok _ | Error _ -> fail "typed compaction trigger did not round-trip")
+    [ trigger
+    ; Compaction_trigger.Provider_overflow { limit_tokens = None }
+    ; Compaction_trigger.Manual
+    ]
+;;
+
+let test_retired_trigger_kinds_are_rejected () =
+  let decode kind =
+    Compaction_trigger.of_detail_json (`Assoc [ "kind", `String kind ])
+  in
+  List.iter
+    (fun kind ->
+       match decode kind with
+       | Error (Compaction_trigger.Unknown_kind actual)
+         when String.equal actual kind -> ()
+       | Ok _ | Error _ -> failf "retired trigger %s was not explicitly rejected" kind)
+    [ "ratio"; "messages"; "tokens" ];
+  match
+    Compaction_trigger.of_detail_json
+      (`Assoc [ "kind", `String "provider_overflow" ])
+  with
+  | Error Compaction_trigger.Missing_provider_limit -> ()
+  | Ok _ | Error _ -> fail "provider overflow without limit_tokens was admitted"
+;;
+
+let test_malformed_trigger_details_are_typed_errors () =
+  let check_error message expected json =
+    match Compaction_trigger.of_detail_json json with
+    | Error actual when actual = expected -> ()
+    | Ok _ | Error _ -> fail message
+  in
+  check_error
+    "non-object trigger detail was admitted"
+    Compaction_trigger.Expected_object
+    (`String "manual");
+  check_error
+    "missing trigger kind was admitted"
+    Compaction_trigger.Missing_kind
+    (`Assoc []);
+  check_error
+    "non-string trigger kind was admitted"
+    Compaction_trigger.Invalid_kind
+    (`Assoc [ "kind", `Int 1 ]);
+  List.iter
+    (fun limit ->
+       check_error
+         "invalid provider limit was admitted"
+         Compaction_trigger.Invalid_provider_limit
+         (`Assoc [ "kind", `String "provider_overflow"; "limit_tokens", limit ]))
+    [ `Int 0; `Int (-1); `String "200000" ]
 ;;
 
 let apply_ok phase conds ev =
@@ -170,6 +224,10 @@ let () =
     "overflow-lifecycle",
     [ test_case "provider overflow trigger codec" `Quick
         test_provider_overflow_trigger_roundtrip;
+      test_case "retired trigger kinds rejected" `Quick
+        test_retired_trigger_kinds_are_rejected;
+      test_case "malformed trigger details are typed errors" `Quick
+        test_malformed_trigger_details_are_typed_errors;
       test_case "happy path" `Quick test_happy_path;
       test_case "compact failure releases Lane" `Quick
         test_compact_failure_releases_lane;

--- a/test/test_mcp_server_eio_call_tool.ml
+++ b/test/test_mcp_server_eio_call_tool.ml
@@ -104,7 +104,7 @@ let with_call_tool_state f =
       f env sw state)
 ;;
 
-let call_with_result ~env ~sw state result =
+let call_with_result ?mcp_session_id ?observe_invocation ~env ~sw state result =
   Masc.Mcp_server_eio_call_tool.handle_call_tool_eio
     ~execute_tool_eio:
       (fun
@@ -113,15 +113,19 @@ let call_with_result ~env ~sw state result =
         ~workspace_scope:_
         ?profile:_
         ?mcp_session_id:_
+        ?invocation_ref
         ?auth_token:_
         ?internal_keeper_runtime:_
         _state
         ~name:_
-        ~arguments:_ -> result)
+        ~arguments:_ ->
+        Option.iter (fun observe -> observe invocation_ref) observe_invocation;
+        result)
     ~maybe_emit_resource_notifications:(fun ~success:_ ~tool_name:_ -> ())
     ~broadcast_tools_list_changed:(fun () -> ())
     ~sw
     ~clock:(Eio.Stdenv.clock env)
+    ?mcp_session_id
     state
     (`Int 1)
     (`Assoc
@@ -129,6 +133,36 @@ let call_with_result ~env ~sw state result =
       ; "arguments", `Assoc [ "_agent_name", `String "projection-test" ]
       ])
 ;;
+
+let test_threads_exact_mcp_invocation_identity () =
+  with_call_tool_state (fun env sw state ->
+    let observed = ref None in
+    let result =
+      Tool_result.make_ok
+        ~tool_name:"masc_status"
+        ~start_time:0.0
+        ~data:(`String "ok")
+        ()
+    in
+    ignore
+      (call_with_result
+         ~mcp_session_id:"typed-session"
+         ~observe_invocation:(fun invocation -> observed := invocation)
+         ~env ~sw state result);
+    let request_id =
+      Mcp_transport_protocol.request_id_of_yojson (`Int 1) |> Result.get_ok
+    in
+    let expected =
+      Tool_invocation_ref.external_mcp
+        ~request_id
+        ~session_id:"typed-session"
+      |> Result.get_ok
+    in
+    match !observed with
+    | Some actual ->
+      check bool "exact invocation identity" true
+        (Tool_invocation_ref.equal expected actual)
+    | None -> fail "execute callback did not receive invocation identity")
 
 let result_fields response = response |> U.member "result"
 let result_envelope response = result_fields response |> U.member "resultEnvelope"
@@ -261,6 +295,7 @@ let test_handle_call_executes_transient_failure_once () =
               ~workspace_scope:_
               ?profile:_
               ?mcp_session_id:_
+              ?invocation_ref:_
               ?auth_token:_
               ?internal_keeper_runtime:_
               _state
@@ -328,6 +363,7 @@ let test_call_captures_admission_scope_across_workspace_switch () =
               ~workspace_scope
               ?profile:_
               ?mcp_session_id:_
+              ?invocation_ref:_
               ?auth_token:_
               ?internal_keeper_runtime:_
               callback_state
@@ -732,6 +768,8 @@ let () =
             test_handle_call_executes_transient_failure_once;
           test_case "captures admission scope across workspace switch" `Quick
             test_call_captures_admission_scope_across_workspace_switch;
+          test_case "threads exact MCP invocation identity" `Quick
+            test_threads_exact_mcp_invocation_identity;
           test_case "activity payload sanitizes invalid UTF-8" `Quick
             test_activity_payload_sanitizes_invalid_utf8;
           test_case "records MCP server operation duration metric" `Quick

--- a/test/test_mcp_server_eio_coverage.ml
+++ b/test/test_mcp_server_eio_coverage.ml
@@ -8,6 +8,7 @@ open Alcotest
 module Mcp_server_eio = Masc.Mcp_server_eio
 module Mcp_server = Masc.Mcp_server
 module Mcp_server_eio_protocol = Masc.Mcp_server_eio_protocol
+module Request_id = Mcp_transport_protocol
 (* ============================================================
    is_jsonrpc_v2 Tests
    ============================================================ *)
@@ -214,7 +215,7 @@ let test_get_id_none () =
    ============================================================ *)
 
 let test_is_valid_request_id_null () =
-  check bool "null valid" true (Mcp_server.is_valid_request_id `Null)
+  check bool "null invalid" false (Mcp_server.is_valid_request_id `Null)
 
 let test_is_valid_request_id_string () =
   check bool "string valid" true (Mcp_server.is_valid_request_id (`String "id-1"))
@@ -223,7 +224,38 @@ let test_is_valid_request_id_int () =
   check bool "int valid" true (Mcp_server.is_valid_request_id (`Int 123))
 
 let test_is_valid_request_id_float () =
-  check bool "float valid" true (Mcp_server.is_valid_request_id (`Float 1.5))
+  check bool "float invalid" false (Mcp_server.is_valid_request_id (`Float 1.5))
+
+let test_request_id_preserves_large_integer_lexeme () =
+  let lexeme = "92233720368547758081234567890" in
+  match Request_id.request_id_of_yojson (`Intlit lexeme) with
+  | Error _ -> fail "expected exact large integer request id"
+  | Ok request_id ->
+    check string "exact lexeme" lexeme
+      (Yojson.Safe.to_string (Request_id.request_id_to_yojson request_id))
+
+let invocation_ref_exn request_id =
+  match
+    Tool_invocation_ref.external_mcp
+      ~request_id
+      ~session_id:"mcp-session-1"
+  with
+  | Ok invocation -> invocation
+  | Error error -> fail (Tool_invocation_ref.error_to_string error)
+
+let test_tool_invocation_identity_distinguishes_string_and_integer () =
+  let string_id =
+    Request_id.request_id_of_yojson (`String "1")
+    |> Result.get_ok
+    |> invocation_ref_exn
+  in
+  let integer_id =
+    Request_id.request_id_of_yojson (`Int 1)
+    |> Result.get_ok
+    |> invocation_ref_exn
+  in
+  check bool "typed ids remain distinct" true
+    (not (Tool_invocation_ref.equal string_id integer_id))
 
 let test_is_valid_request_id_array () =
   check bool "array invalid" false (Mcp_server.is_valid_request_id (`List []))
@@ -484,6 +516,12 @@ let () =
       test_case "float" `Quick test_is_valid_request_id_float;
       test_case "array" `Quick test_is_valid_request_id_array;
       test_case "object" `Quick test_is_valid_request_id_object;
+    ];
+    "typed_request_identity", [
+      test_case "large integer lexeme" `Quick
+        test_request_id_preserves_large_integer_lexeme;
+      test_case "string and integer distinct" `Quick
+        test_tool_invocation_identity_distinguishes_string_and_integer;
     ];
     "validate_initialize_params", [
       test_case "valid" `Quick test_validate_initialize_params_valid;

--- a/test/test_operator_control_support.ml
+++ b/test/test_operator_control_support.ml
@@ -77,7 +77,8 @@ let operator_ctx ?mcp_session_id env sw config agent_name :
            ~clock:(Eio.Stdenv.clock env)
            ~proc_mgr:(Some (Eio.Stdenv.process_mgr env))
            ~net:(Some (Eio.Stdenv.net env))
-           ~publication_recovery_provider);
+           ~publication_recovery_provider
+           ());
     mcp_session_id;
   }
 

--- a/test/tool_invocation_ref/dune
+++ b/test/tool_invocation_ref/dune
@@ -1,0 +1,3 @@
+(test
+ (name test_tool_invocation_ref)
+ (libraries alcotest yojson masc.tool_invocation_ref masc.mcp_transport_protocol))

--- a/test/tool_invocation_ref/test_tool_invocation_ref.ml
+++ b/test/tool_invocation_ref/test_tool_invocation_ref.ml
@@ -1,0 +1,86 @@
+let request_id json =
+  match Mcp_transport_protocol.request_id_of_yojson json with
+  | Ok value -> value
+  | Error error ->
+    Alcotest.fail (Mcp_transport_protocol.request_id_error_to_string error)
+;;
+
+let identity () =
+  match
+    Tool_invocation_ref.external_mcp
+      ~request_id:(request_id (`Intlit "9007199254740993"))
+      ~session_id:"session-1"
+  with
+  | Ok value -> value
+  | Error error -> Alcotest.fail (Tool_invocation_ref.error_to_string error)
+;;
+
+let test_roundtrip () =
+  let expected = identity () in
+  match Tool_invocation_ref.of_yojson (Tool_invocation_ref.to_yojson expected) with
+  | Ok actual ->
+    Alcotest.(check bool)
+      "exact identity"
+      true
+      (Tool_invocation_ref.equal expected actual)
+  | Error error ->
+    Alcotest.fail (Tool_invocation_ref.decode_error_to_string error)
+;;
+
+let test_closed_decoder () =
+  let canonical = Tool_invocation_ref.to_yojson (identity ()) in
+  let fields =
+    match canonical with
+    | `Assoc fields -> fields
+    | _ -> Alcotest.fail "canonical identity must be an object"
+  in
+  let check label expected json =
+    match Tool_invocation_ref.of_yojson json with
+    | Error actual -> Alcotest.(check bool) label true (actual = expected)
+    | Ok _ -> Alcotest.failf "%s: malformed identity decoded" label
+  in
+  check
+    "unknown"
+    (Tool_invocation_ref.Unknown_field "extra")
+    (`Assoc (("extra", `Null) :: fields));
+  check
+    "duplicate"
+    (Tool_invocation_ref.Duplicate_field "source")
+    (`Assoc (("source", `String "external_mcp") :: fields));
+  check
+    "missing"
+    (Tool_invocation_ref.Missing_field "request_id")
+    (`Assoc (List.remove_assoc "request_id" fields));
+  check
+    "source"
+    (Tool_invocation_ref.Invalid_source "invented")
+    (`Assoc
+      (("source", `String "invented") :: List.remove_assoc "source" fields));
+  check
+    "source type"
+    (Tool_invocation_ref.Expected_string "source")
+    (`Assoc (("source", `Null) :: List.remove_assoc "source" fields));
+  check
+    "request id"
+    (Tool_invocation_ref.Invalid_request_id
+       Mcp_transport_protocol.Null_request_id)
+    (`Assoc (("request_id", `Null) :: List.remove_assoc "request_id" fields));
+  check
+    "session"
+    (Tool_invocation_ref.Invalid_identity
+       Tool_invocation_ref.Empty_mcp_session_id)
+    (`Assoc (("session_id", `String " ") :: List.remove_assoc "session_id" fields));
+  check
+    "session type"
+    (Tool_invocation_ref.Expected_string "session_id")
+    (`Assoc (("session_id", `Null) :: List.remove_assoc "session_id" fields))
+;;
+
+let () =
+  Alcotest.run
+    "tool invocation ref"
+    [ ( "codec"
+      , [ Alcotest.test_case "roundtrip" `Quick test_roundtrip
+        ; Alcotest.test_case "closed decoder" `Quick test_closed_decoder
+        ] )
+    ]


### PR DESCRIPTION
## Outcome

Replaces the eleven-PR compaction operation stack with one compileable library
and one review surface.

- keeps the exact typed operation identity, facts, reducer, JSON projection,
  closed codec, journal record, store, terminal failure, supersession, and
  replay action selection
- exposes one public library: `masc.keeper_compaction_operation`
- keeps reducer/codec/record/store/action-selector layers as internal modules
  of that library
- removes seven extra public libraries and their cross-library link edges
- preserves the accumulated implementation from #24914 through #24938

## Why

The previous stack represented one concept as eight separately published Dune
libraries. That multiplied the public API and executable link graph without
creating an actual ownership boundary.

This replacement keeps the module boundaries but makes the physical library
boundary match the single compaction-operation concept.

## Stack

- Base: #24906
- Supersedes: #24914, #24915, #24916, #24918, #24922, #24923, #24926,
  #24927, #24928, #24932, #24938

## Verification

- focused Dune build of all five compaction-operation test executables
- operation events/reducer/codec: 12/12
- identity: 2/2
- journal record: 4/4
- journal store: 3/3
- replay action selector: 3/3
- total: 24/24
- `ocamlformat --check` on all implementation/interfaces/tests
- `git diff --check`
- repository scan: one `public_name masc.keeper_compaction_operation`, zero
  `masc.keeper_compaction_operation_*` public-library dependencies

Full build remains CI authority.
