### PR TITLE
refactor(task): remove title dedup admission

### DIFF
--- a/lib/tool_surface/tool_shard_types_schemas_taskboard.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_taskboard.ml
@@ -171,7 +171,7 @@ let taskboard_tools : Masc_domain.tool_schema list =
   ; { name = "keeper_task_create"
     ; description =
         "Create a new task on the MASC backlog. The task appears for any keeper to \
-         claim. Duplicate titles are rejected automatically (dedup by normalized title)."
+         claim."
     ; input_schema =
         `Assoc
           [ "type", `String "object"

--- a/lib/workspace/workspace_task_create.ml
+++ b/lib/workspace/workspace_task_create.ml
@@ -1,4 +1,4 @@
-(** Workspace_task_create — Dedup logic, add_task, batch_add_tasks.
+(** Workspace_task_create — add_task, batch_add_tasks.
 
     Extracted from Workspace_task to separate task creation from classification,
     claiming, and transitions.  All bindings are re-exported by [Workspace_task]
@@ -13,38 +13,6 @@ include Workspace_broadcast
 open Workspace_backlog
 open Workspace_task_id
 
-(** Normalize title for deduplication: lowercase, keep only alphanumeric+space.
-    Deterministic string transform — no LLM involved. *)
-let normalize_title_for_dedup (title : string) : string =
-  let buf = Buffer.create (String.length title) in
-  String.iter
-    (fun c ->
-       let lc = Char.lowercase_ascii c in
-       if (lc >= 'a' && lc <= 'z') || (lc >= '0' && lc <= '9') || lc = ' '
-       then Buffer.add_char buf lc)
-    title;
-  Buffer.contents buf |> String.trim
-;;
-
-(** Check if a task with a similar title already exists in the backlog.
-    Returns [Some existing_task_id] if a duplicate is found, [None] otherwise.
-    Uses normalized title comparison — deterministic, no fuzzy matching. *)
-let find_duplicate_task (backlog : backlog) ~(title : string)
-  : string option
-  =
-  let norm = normalize_title_for_dedup title in
-  if norm = ""
-  then None
-  else
-    List.find_opt
-      (fun (t : task) ->
-         let t_norm = normalize_title_for_dedup t.title in
-         t_norm = norm
-         && not (Masc_domain.task_status_is_terminal t.task_status))
-      backlog.tasks
-    |> Option.map (fun (t : task) -> t.id)
-;;
-
 type add_task_success =
   { task_id : string
   ; summary : string
@@ -56,7 +24,6 @@ type add_task_success =
 
 type add_task_error =
   | Backlog_read_failed of string
-  | Duplicate of { title : string; existing_id : string }
   | Goal_link_write_failed of string
   | Backlog_write_failed of string
   | Unexpected_error of string
@@ -77,11 +44,6 @@ type batch_add_tasks_error =
 
 let add_task_error_to_string = function
   | Backlog_read_failed msg -> Printf.sprintf "Error: %s" msg
-  | Duplicate { title; existing_id } ->
-    Printf.sprintf
-      "Duplicate rejected: '%s' matches existing %s. Use that task instead."
-      title
-      existing_id
   | Goal_link_write_failed msg ->
     Printf.sprintf "Error linking task to goal: %s" msg
   | Backlog_write_failed msg -> Printf.sprintf "Error writing backlog: %s" msg
@@ -135,9 +97,7 @@ let rollback_goal_links config task_goal_ids =
     task_goal_ids
 ;;
 
-(** Add task — file-locked to prevent task ID collision under concurrency.
-    Rejects tasks with duplicate titles (exact match after normalization)
-    to prevent the same work from being created multiple times. *)
+(** Add task — file-locked to prevent task ID collision under concurrency. *)
 let add_task_with_result
       ?contract
       ?goal_id
@@ -181,12 +141,9 @@ let add_task_with_result
          with
          | Error e -> Error e
          | Ok () ->
-        (* Dedup guard: reject if an active task with the same normalized title exists *)
-        (match find_duplicate_task backlog ~title with
-         | Some existing_id ->
-           Error (Duplicate { title; existing_id })
-         | None ->
-           let task_id = Printf.sprintf "task-%03d" (next_task_number config backlog) in
+           let task_id =
+             Printf.sprintf "task-%03d" (next_task_number config backlog)
+           in
            let contract =
              Some
                (Workspace_task_classify.ensure_task_contract_for_verification
@@ -273,7 +230,7 @@ let add_task_with_result
                       ~content:(Printf.sprintf "New quest: %s" title)
                   in
                   let summary = Printf.sprintf "Added %s: %s" task_id title in
-                  Ok { task_id; summary; title; priority; description; goal_id })))))
+                  Ok { task_id; summary; title; priority; description; goal_id }))))
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | e -> Error (Unexpected_error (Printexc.to_string e))

--- a/lib/workspace/workspace_task_create.ml
+++ b/lib/workspace/workspace_task_create.ml
@@ -97,7 +97,10 @@ let rollback_goal_links config task_goal_ids =
     task_goal_ids
 ;;
 
-(** Add task — file-locked to prevent task ID collision under concurrency. *)
+(** Add task — file-locked to prevent task ID collision under concurrency.
+    A title is display content, not task identity or admission authority, so
+    equal titles receive distinct task IDs. A workflow that needs semantic
+    duplicate judgment performs that explicit LLM decision before submission. *)
 let add_task_with_result
       ?contract
       ?goal_id

--- a/lib/workspace/workspace_task_create.mli
+++ b/lib/workspace/workspace_task_create.mli
@@ -1,4 +1,4 @@
-(** Workspace_task_create — Dedup logic, add_task, batch_add_tasks.
+(** Workspace_task_create — add_task, batch_add_tasks.
 
     This module is [include]d by {!Workspace_task}; all bindings are part of
     the public Workspace interface.  Re-exports {!Workspace_utils} and
@@ -6,16 +6,6 @@
 
 include module type of Workspace_utils
 include module type of Workspace_state
-
-(** {1 Task deduplication} *)
-
-val normalize_title_for_dedup : string -> string
-(** Normalize title for deduplication: lowercase, keep only alphanumeric+space. *)
-
-val find_duplicate_task :
-  Masc_domain.backlog -> title:string -> string option
-(** Check if a task with a similar title already exists in the backlog.
-    Returns [Some existing_task_id] if a duplicate is found, [None] otherwise. *)
 
 (** {1 Task creation} *)
 
@@ -30,7 +20,6 @@ type add_task_success =
 
 type add_task_error =
   | Backlog_read_failed of string
-  | Duplicate of { title : string; existing_id : string }
   | Goal_link_write_failed of string
   | Backlog_write_failed of string
   | Unexpected_error of string

--- a/lib/workspace/workspace_task_create.mli
+++ b/lib/workspace/workspace_task_create.mli
@@ -45,6 +45,10 @@ val add_task_error_to_string : add_task_error -> string
 
 val batch_add_tasks_error_to_string : batch_add_tasks_error -> string
 
+(** Creates one new task identity per successful call. Titles are opaque display
+    content; equal titles are valid and receive distinct IDs. Semantic duplicate
+    judgment belongs to an explicit LLM workflow before submission, not this
+    storage boundary. *)
 val add_task_with_result :
   ?contract:Masc_domain.task_contract ->
   ?goal_id:string ->

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -348,21 +348,25 @@ let () = test "handle_add_task_returns_structured_task_id" (fun () ->
   | Some summary -> assert (str_contains summary "Added task-001")
   | None -> failwith "missing summary")
 
-let () = test "handle_add_task_duplicate_returns_workflow_rejection" (fun () ->
+let () = test "handle_add_task_preserves_identical_titles_as_distinct_tasks" (fun () ->
   let ctx = make_test_ctx () in
   let first =
     Task.Tool.handle_add_task ~tool_name:"masc_add_task" ~start_time:0.0 ctx
       (`Assoc [ ("title", `String "Duplicate contract task") ])
   in
   if not (Tool_result.is_success first) then failwith (Tool_result.message first);
-  let duplicate =
+  let second =
     Task.Tool.handle_add_task ~tool_name:"masc_add_task" ~start_time:0.0 ctx
       (`Assoc [ ("title", `String "Duplicate contract task") ])
   in
-  assert (not (Tool_result.is_success duplicate));
-  assert ((Tool_result.failure_class duplicate) = Some Tool_result.Workflow_rejection);
-  assert (str_contains (Tool_result.message duplicate) "Duplicate rejected");
-  assert (str_contains (Tool_result.message duplicate) "task-001"))
+  if not (Tool_result.is_success second) then failwith (Tool_result.message second);
+  assert (Json_util.get_string (Tool_result.data first) "task_id" = Some "task-001");
+  assert (Json_util.get_string (Tool_result.data second) "task_id" = Some "task-002");
+  let backlog = Workspace.read_backlog ctx.config in
+  assert (List.map (fun (task : Masc_domain.task) -> task.id) backlog.tasks
+          = [ "task-001"; "task-002" ]);
+  assert (List.map (fun (task : Masc_domain.task) -> task.title) backlog.tasks
+          = [ "Duplicate contract task"; "Duplicate contract task" ]))
 
 let () = test "workspace_add_task_with_result_returns_typed_task_id" (fun () ->
   let ctx = make_test_ctx () in


### PR DESCRIPTION
## Outcome

- deletes normalized-title string matching from Task creation
- removes the `Duplicate` workflow rejection and stale public/tool contracts
- preserves only structural task ID allocation and the separate explicit capacity hook
- proves two byte-identical titles create `task-001` and `task-002` and both remain in backlog

Task semantic equivalence is no longer guessed by an ASCII normalization heuristic. If duplicate intent matters, it belongs at an LLM judgment boundary rather than deterministic Task admission.

## Verification

- `scripts/dune-local.sh build test/test_tool_task_coverage.exe`
- targeted Tool Task coverage case passed
- `ocamlformat --check`
- `git show --check`
- residue search for removed title-dedup symbols

18 additions / 68 deletions, 86 changed lines.