### PR TITLE
refactor(fusion): remove zombie concurrency settings

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -1014,18 +1014,11 @@ trigger_policy = "mention_or_thread"
 # Deny로 즉시 반환되고 모델을 호출하지 않는다.
 #
 # 패널/심판 모델 문자열은 위의 <provider>.<model> 런타임 id를 그대로 쓴다.
-# 패널은 1..8개. 심판은 패널 답변을 종합한다.
+# 패널은 하나 이상의 런타임으로 구성하고, 심판은 패널 답변을 종합한다.
 [fusion]
 enabled = true
 default_preset = "trio"
-# 동시성 knob은 의도적으로 분리한다.
-# - max_concurrent_panels: 패널 답변 fan-out 상한.
-# - max_concurrent_judges: judge_of_judges 계열 judge wave fan-out 상한.
-# - staged_judge_group_size: staged_judge_of_judges의 고정 reducer group 크기.
-# 패널 cap은 답변 모델/provider backpressure 보호용이고, 심판 cap은 느린 심판
-# 하나가 나머지 독립 심판 lens를 직렬화하지 않게 하는 용도다.
-max_concurrent_panels = 2
-max_concurrent_judges = 3
+# staged_judge_of_judges의 고정 reducer group 크기.
 staged_judge_group_size = 3
 
 # 패널 프리셋. 패널 답변은 free text다. 2026-07-01 사고(ollama.com cloud가 json_schema를

--- a/dashboard/src/components/fusion-settings-panel.test.ts
+++ b/dashboard/src/components/fusion-settings-panel.test.ts
@@ -5,7 +5,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const SAMPLE = `[fusion]
 enabled = true
 default_preset = "trio"
-max_concurrent_panels = 2
 
 [fusion.gate]
 per_hour_budget = 20
@@ -173,7 +172,7 @@ describe('FusionSettingsPanel', () => {
   })
 
   it('surfaces malformed live TOML instead of rendering fallback values', async () => {
-    fetchMock.mockResolvedValue(cfg({ source_text: '[fusion]\nenabled = maybe\nmax_concurrent_panels = 1.5\n' }))
+    fetchMock.mockResolvedValue(cfg({ source_text: '[fusion]\nenabled = maybe\n' }))
     const { FusionSettingsPanel } = await import('./fusion-settings-panel')
     render(h(FusionSettingsPanel, {}), container)
 
@@ -192,24 +191,6 @@ describe('FusionSettingsPanel', () => {
     expect(q('[data-testid="fusion-settings-error"]')?.textContent).toContain('network down')
   })
 
-  it('does not POST empty or fractional number inputs', async () => {
-    fetchMock.mockResolvedValue(cfg({ source_text: SAMPLE }))
-    await mount()
-    const maxInput = q('[data-testid="fusion-max-concurrent-panels"]') as HTMLInputElement
-    maxInput.value = ''
-    await fireEvent.input(maxInput)
-
-    ;(q('[data-testid="fusion-settings-save"]') as HTMLButtonElement).click()
-    await vi.waitFor(() => expect(q('[data-testid="fusion-settings-error"]')).not.toBeNull())
-    expect(saveMock).not.toHaveBeenCalled()
-
-    maxInput.value = '1.5'
-    await fireEvent.input(maxInput)
-    ;(q('[data-testid="fusion-settings-save"]') as HTMLButtonElement).click()
-    await vi.waitFor(() => expect(q('[data-testid="fusion-settings-error"]')?.textContent).toContain('정수'))
-    expect(saveMock).not.toHaveBeenCalled()
-  })
-
   it('renders the read-only preset composition parsed from the loaded config', async () => {
     fetchMock.mockResolvedValue(cfg({ source_text: SAMPLE }))
     await mount()
@@ -226,7 +207,6 @@ describe('FusionSettingsPanel', () => {
     const noSection = `[fusion]
 enabled = false
 default_preset = "ghost"
-max_concurrent_panels = 2
 `
     fetchMock.mockResolvedValue(cfg({ source_text: noSection }))
     await mount()
@@ -241,7 +221,6 @@ max_concurrent_panels = 2
     const noPanel = `[fusion]
 enabled = true
 default_preset = "trio"
-max_concurrent_panels = 2
 
 [fusion.presets.trio]
 min_answered = 2
@@ -259,7 +238,6 @@ min_answered = 2
     const noPanel = `[fusion]
 enabled = true
 default_preset = "trio"
-max_concurrent_panels = 2
 
 [fusion.presets.trio]
 min_answered = 2
@@ -280,7 +258,6 @@ min_answered = 2
     const grouped = `[fusion]
 enabled = true
 default_preset = "mixed"
-max_concurrent_panels = 2
 
 [fusion.presets.mixed]
 judge = "j"
@@ -306,7 +283,6 @@ panel = ["careful1"]
     const quorumLike = `[fusion]
 enabled = true
 default_preset = "quorum"
-max_concurrent_panels = 2
 
 [fusion.presets.quorum]
 panel = ["p1", "p2"]

--- a/dashboard/src/components/fusion-settings-panel.ts
+++ b/dashboard/src/components/fusion-settings-panel.ts
@@ -29,7 +29,6 @@ type EditorState = 'loading' | 'idle' | 'saving' | 'saved' | 'error'
 type FusionSettingsDraft = {
   readonly enabled: boolean
   readonly defaultPreset: string
-  readonly maxConcurrentPanels: string
   readonly minAnswered: string
   readonly panel: readonly string[]
   readonly judge: string
@@ -41,7 +40,6 @@ function draftFromSettings(sourceText: string, s: FusionSettings): FusionSetting
   return {
     enabled: s.enabled,
     defaultPreset: s.defaultPreset,
-    maxConcurrentPanels: String(s.maxConcurrentPanels),
     minAnswered: String(s.minAnswered),
     panel: flatPreset?.panel ?? [],
     judge: flatPreset?.judge ?? '',
@@ -58,14 +56,11 @@ function parseDraftPositiveInt(label: string, raw: string): number | string {
 function settingsFromDraft(draft: FusionSettingsDraft): FusionSettings | string {
   const defaultPreset = draft.defaultPreset
   if (defaultPreset !== '' && defaultPreset.trim() === '') return 'default_preset은 공백만 입력할 수 없습니다.'
-  const maxConcurrentPanels = parseDraftPositiveInt('max_concurrent_panels', draft.maxConcurrentPanels)
-  if (typeof maxConcurrentPanels === 'string') return maxConcurrentPanels
   const minAnswered = parseDraftPositiveInt('min_answered', draft.minAnswered)
   if (typeof minAnswered === 'string') return minAnswered
   return {
     enabled: draft.enabled,
     defaultPreset,
-    maxConcurrentPanels,
     minAnswered,
   }
 }
@@ -348,11 +343,6 @@ export function FusionSettingsPanel() {
       <label class="set-line">
         <span>기본 프리셋 (default_preset)</span>
         <input type="text" value=${draft.defaultPreset} onInput=${(e: Event) => patchDefaultPreset(str(e))} />
-      </label>
-      <label class="set-line">
-        <span>동시 패널 수 (max_concurrent_panels)</span>
-        <input type="number" step="1" data-testid="fusion-max-concurrent-panels" value=${draft.maxConcurrentPanels}
-          onInput=${(e: Event) => patch({ maxConcurrentPanels: str(e) })} />
       </label>
       <label class="set-line">
         <span>최소 응답 패널 (${draft.defaultPreset || '프리셋'} min_answered)</span>

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -1559,7 +1559,7 @@ describe('SettingsSurface', () => {
       ok: true,
       path: MOCK_RUNTIME_PATH,
       file_name: 'runtime.toml',
-      source_text: '[fusion]\nenabled = true\ndefault_preset = "trio"\nmax_concurrent_panels = 2\n\n[fusion.presets.trio]\nmin_answered = 2\n',
+      source_text: '[fusion]\nenabled = true\ndefault_preset = "trio"\n\n[fusion.presets.trio]\nmin_answered = 2\n',
       reloaded: false,
     })
     render(html`<${SettingsSurface} />`, container)

--- a/dashboard/src/lib/fusion-settings.test.ts
+++ b/dashboard/src/lib/fusion-settings.test.ts
@@ -15,7 +15,6 @@ const SAMPLE = `# live runtime config
 [fusion]
 enabled = true
 default_preset = "trio"
-max_concurrent_panels = 2
 
 [fusion.gate]
 per_hour_budget = 20
@@ -34,7 +33,6 @@ describe('readFusionSettings', () => {
     expect(readFusionSettings(SAMPLE)).toEqual({
       enabled: true,
       defaultPreset: 'trio',
-      maxConcurrentPanels: 2,
       minAnswered: 2,
     })
   })
@@ -44,14 +42,11 @@ describe('readFusionSettings', () => {
   })
 
   it('surfaces malformed scalars instead of coercing them into plausible values', () => {
-    const src = '[fusion]\nenabled = maybe\nmax_concurrent_panels = 1.5\n'
+    const src = '[fusion]\nenabled = maybe\n'
     const result = readFusionSettingsResult(src)
     expect(result.ok).toBe(false)
     if (!result.ok) {
-      expect(result.issues.map(issue => issue.key)).toEqual([
-        'fusion.enabled',
-        'fusion.max_concurrent_panels',
-      ])
+      expect(result.issues.map(issue => issue.key)).toEqual(['fusion.enabled'])
     }
     expect(() => readFusionSettings(src)).toThrow(/Invalid fusion settings/)
   })
@@ -64,7 +59,6 @@ describe('readFusionSettings', () => {
     expect(readFusionSettings(`[fusion]
 enabled = false
 default_preset = "rocket\\U0001F680"
-max_concurrent_panels = 1
 `).defaultPreset).toBe(`rocket${rocket}`)
 
     const invalid = readFusionSettingsResult(SAMPLE.replace('default_preset = "trio"', 'default_preset = "tri\\/o"'))
@@ -73,17 +67,6 @@ max_concurrent_panels = 1
       expect(invalid.issues[0]).toMatchObject({
         key: 'fusion.default_preset',
         message: 'unsupported TOML string escape',
-      })
-    }
-  })
-
-  it('rejects negative integer tokens with the same positive-integer contract used by the editor draft', () => {
-    const result = readFusionSettingsResult('[fusion]\nmax_concurrent_panels = -1\n')
-    expect(result.ok).toBe(false)
-    if (!result.ok) {
-      expect(result.issues[0]).toMatchObject({
-        key: 'fusion.max_concurrent_panels',
-        message: 'expected an integer >= 1',
       })
     }
   })
@@ -103,12 +86,10 @@ max_concurrent_panels = 1
     const disabledUnknownPreset = `[fusion]
 enabled = false
 default_preset = "old"
-max_concurrent_panels = 1
 `
     expect(readFusionSettings(disabledUnknownPreset)).toEqual({
       enabled: false,
       defaultPreset: 'old',
-      maxConcurrentPanels: 1,
       minAnswered: 1,
     })
   })
@@ -131,13 +112,11 @@ describe('applyFusionSettings', () => {
     const next = applyFusionSettings(SAMPLE, {
       enabled: false,
       defaultPreset: 'trio',
-      maxConcurrentPanels: 4,
       minAnswered: 3,
     })
     expect(readFusionSettings(next)).toEqual({
       enabled: false,
       defaultPreset: 'trio',
-      maxConcurrentPanels: 4,
       minAnswered: 3,
     })
   })
@@ -150,7 +129,7 @@ describe('applyFusionSettings', () => {
   })
 
   it('never touches the removed per_hour_budget key (RFC-0277)', () => {
-    const next = applyFusionSettings(SAMPLE, { ...readFusionSettings(SAMPLE), maxConcurrentPanels: 5 })
+    const next = applyFusionSettings(SAMPLE, { ...readFusionSettings(SAMPLE), enabled: false })
     // unchanged verbatim — the editor neither reads nor writes it
     expect(next).toContain('per_hour_budget = 20')
   })
@@ -165,7 +144,6 @@ min_answered = 1
     const switched = applyFusionSettings(withDuo, {
       enabled: true,
       defaultPreset: 'duo',
-      maxConcurrentPanels: 2,
       minAnswered: 1,
     })
     expect(switched.split('[fusion.presets.trio]')[1]?.split('[runtime]')[0]).not.toContain('min_answered')
@@ -174,23 +152,13 @@ min_answered = 1
     const cleared = applyFusionSettings(SAMPLE, {
       enabled: true,
       defaultPreset: '',
-      maxConcurrentPanels: 2,
       minAnswered: 1,
     })
     expect(cleared.split('[fusion.presets.trio]')[1]?.split('[runtime]')[0]).not.toContain('min_answered')
   })
 
-  it('rejects invalid local editor values before writing', () => {
-    expect(() => applyFusionSettings(SAMPLE, {
-      enabled: true,
-      defaultPreset: 'trio',
-      maxConcurrentPanels: 0,
-      minAnswered: 1,
-    })).toThrow(/max_concurrent_panels/)
-  })
-
   it('preserves comments and untouched sections/keys', () => {
-    const next = applyFusionSettings(SAMPLE, { ...readFusionSettings(SAMPLE), maxConcurrentPanels: 5 })
+    const next = applyFusionSettings(SAMPLE, { ...readFusionSettings(SAMPLE), enabled: false })
     expect(next).toContain('# live runtime config')
     expect(next).toContain('[runtime]')
     expect(next).toContain('default = "x.y"')

--- a/dashboard/src/lib/fusion-settings.ts
+++ b/dashboard/src/lib/fusion-settings.ts
@@ -24,7 +24,6 @@ import { deleteRuntimeTomlKey, getRuntimeTomlKey, setRuntimeTomlKey, setRuntimeT
 const SECTION_FUSION = 'fusion'
 const KEY_ENABLED = 'enabled'
 const KEY_DEFAULT_PRESET = 'default_preset'
-const KEY_MAX_CONCURRENT_PANELS = 'max_concurrent_panels'
 const KEY_MIN_ANSWERED = 'min_answered'
 const KEY_PANEL = 'panel'
 const KEY_JUDGE = 'judge'
@@ -33,7 +32,6 @@ const presetSection = (preset: string): string => `${SECTION_FUSION}.presets.${p
 export interface FusionSettings {
   readonly enabled: boolean
   readonly defaultPreset: string
-  readonly maxConcurrentPanels: number
   // min_answered for the default preset (RFC-0252 answered-panel quorum).
   readonly minAnswered: number
 }
@@ -60,7 +58,6 @@ export type FusionSettingsReadResult =
 export const FUSION_SETTINGS_DEFAULTS: FusionSettings = {
   enabled: false,
   defaultPreset: '',
-  maxConcurrentPanels: 1,
   minAnswered: 1,
 }
 
@@ -199,19 +196,12 @@ export function readFusionSettingsResult(sourceText: string): FusionSettingsRead
     FUSION_SETTINGS_DEFAULTS.defaultPreset,
     `${SECTION_FUSION}.${KEY_DEFAULT_PRESET}`,
   )
-  const maxConcurrentPanelsParsed = parsePositiveInt(
-    getRuntimeTomlKey(sourceText, SECTION_FUSION, KEY_MAX_CONCURRENT_PANELS),
-    FUSION_SETTINGS_DEFAULTS.maxConcurrentPanels,
-    `${SECTION_FUSION}.${KEY_MAX_CONCURRENT_PANELS}`,
-  )
   if (isParseIssue(enabledParsed)) issues.push(enabledParsed)
   if (isParseIssue(defaultPresetParsed)) issues.push(defaultPresetParsed)
-  if (isParseIssue(maxConcurrentPanelsParsed)) issues.push(maxConcurrentPanelsParsed)
   if (issues.length > 0) return { ok: false, issues }
 
   const enabled = enabledParsed as boolean
   const defaultPreset = defaultPresetParsed as string
-  const maxConcurrentPanels = maxConcurrentPanelsParsed as number
   const preset = defaultPreset
   const presetExists = preset !== '' && sectionExists(sourceText, presetSection(preset))
   if (enabled && preset !== '' && !presetExists) {
@@ -234,7 +224,6 @@ export function readFusionSettingsResult(sourceText: string): FusionSettingsRead
     settings: {
       enabled,
       defaultPreset,
-      maxConcurrentPanels,
       minAnswered,
     },
   }
@@ -260,9 +249,6 @@ export function readFusionPresetMinAnswered(sourceText: string, preset: string):
 
 export function validateFusionSettings(s: FusionSettings): string[] {
   const errors: string[] = []
-  if (!Number.isSafeInteger(s.maxConcurrentPanels) || s.maxConcurrentPanels < 1) {
-    errors.push(`${KEY_MAX_CONCURRENT_PANELS} must be an integer >= 1`)
-  }
   if (s.defaultPreset !== '' && s.defaultPreset.trim() === '') {
     errors.push(`${KEY_DEFAULT_PRESET} must not be whitespace`)
   }
@@ -291,7 +277,6 @@ export function applyFusionSettings(sourceText: string, s: FusionSettings): stri
   let text = sourceText
   text = setRuntimeTomlKey(text, SECTION_FUSION, KEY_ENABLED, s.enabled)
   text = setRuntimeTomlKey(text, SECTION_FUSION, KEY_DEFAULT_PRESET, s.defaultPreset)
-  text = setRuntimeTomlKey(text, SECTION_FUSION, KEY_MAX_CONCURRENT_PANELS, s.maxConcurrentPanels)
   if (previousPreset !== '' && previousPreset !== s.defaultPreset) {
     text = deleteRuntimeTomlKey(text, presetSection(previousPreset), KEY_MIN_ANSWERED)
   }

--- a/lib/fusion_core/fusion_config_json.ml
+++ b/lib/fusion_core/fusion_config_json.ml
@@ -1,11 +1,12 @@
 (* Fusion config -> JSON projection for the dashboard read endpoint.
 
    RFC-0306 §3.1. The dashboard fusion settings editor needs the full active
-   [Fusion_policy.t] as structured JSON to populate its form (panel roster, meta
-   judge, JoJ first-round judges). No serializer existed: the config
-   types derive only [show]/[eq], and the only consumer flattens errors to a
-   string ([fusion_config_loader.ml]). This is a read-only projection; it does
-   not round-trip back to TOML (the write path is line-based, RFC-0306 §3.2). *)
+   product-relevant [Fusion_policy.t] fields as structured JSON to populate its
+   form (panel roster, meta judge, JoJ first-round judges). No serializer
+   existed: the config types derive only [show]/[eq], and the only consumer
+   flattens errors to a string ([fusion_config_loader.ml]). This is a read-only
+   projection; it does not round-trip back to TOML (the write path is
+   line-based, RFC-0306 §3.2). *)
 
 let opt_int : int option -> Yojson.Safe.t = function
   | None -> `Null
@@ -52,8 +53,6 @@ let to_yojson (c : Fusion_policy.t) : Yojson.Safe.t =
   `Assoc
     [ ("enabled", `Bool c.Fusion_policy.enabled)
     ; ("default_preset", `String c.Fusion_policy.default_preset)
-    ; ("max_concurrent_panels", `Int c.Fusion_policy.max_concurrent_panels)
-    ; ("max_concurrent_judges", `Int c.Fusion_policy.max_concurrent_judges)
     ; ("staged_judge_group_size", `Int c.Fusion_policy.staged_judge_group_size)
     ; ( "presets"
       , `List

--- a/lib/fusion_core/fusion_config_json.mli
+++ b/lib/fusion_core/fusion_config_json.mli
@@ -1,11 +1,11 @@
 (* Fusion config -> JSON projection for the dashboard read endpoint (RFC-0306 §3.1).
    Read-only; does not round-trip back to TOML. *)
 
-(** [to_yojson c] is the structured JSON projection of the active fusion config:
-    [enabled], [default_preset], the concurrency knobs, and every validated
-    preset (panel roster, meta judge, JoJ first-round judges, timeouts). Judge
-    record fields lose their [j] prefix in the output so panel and judge shapes
-    read symmetrically. *)
+(** [to_yojson c] is the structured JSON projection of the product-relevant
+    active fusion config: [enabled], [default_preset], staged reducer group size,
+    and every validated preset (panel roster, meta judge, JoJ first-round
+    judges). Judge record fields lose their [j] prefix in the output so panel
+    and judge shapes read symmetrically. *)
 val to_yojson : Fusion_policy.t -> Yojson.Safe.t
 
 (** [preset_to_yojson p] projects a single preset; exposed for tests. *)

--- a/test/toml_line_editor/test_toml_line_editor.ml
+++ b/test/toml_line_editor/test_toml_line_editor.ml
@@ -7,8 +7,6 @@ let fixture =
   {|# top-of-file note
 [fusion]
 enabled = true
-# concurrency knob doc, must survive edits
-max_concurrent_panels = 2
 
 # panel roster doc line 1
 # panel roster doc line 2
@@ -79,15 +77,15 @@ let test_multiline_array_edit_preserves_comments () =
   Alcotest.(check bool) "sibling scalar untouched" true
     (has_line out {|judge = "old-judge"|})
 
-(* The scalar editor must target the right table: [max_concurrent_panels] exists
-   in [fusion] and must not be touched when editing [fusion.presets.trio]. *)
+(* The scalar editor must target the right table: [enabled] exists in [fusion]
+   and must not be touched when editing [fusion.presets.trio]. *)
 let test_scalar_edit_is_table_scoped () =
   let out =
     Toml_line_editor.edit_table_scalar fixture ~path:"fusion.presets.trio"
       ~key:"judge" ~value:(Some "new-judge")
   in
   Alcotest.(check bool) "[fusion] scalar untouched" true
-    (has_line out "max_concurrent_panels = 2")
+    (has_line out "enabled = true")
 
 let () =
   Alcotest.run "toml_line_editor"


### PR DESCRIPTION
## Outcome

Removes Fusion concurrency controls from every user-visible/product projection because neither value controls execution:

- deletes `max_concurrent_panels` and `max_concurrent_judges` from the runtime example and its false fan-out claims
- deletes both values from Fusion config JSON and dashboard settings parsing/writing/UI
- deletes only tests that enforced the retired product contract
- preserves `staged_judge_group_size`, which changes reducer topology rather than execution concurrency

This is product-surface PR A stacked on #24961. Internal dead schema/parser/API fields remain for PR B so each review stays below 400 changed lines.

## Verification

- focused OCaml build passed
- `fusion_config_json`: 1/1
- `toml_line_editor`: 4/4
- `runtime_config_validity`: 38/38
- dashboard TypeScript typecheck passed
- related Vitest suites: 75/75
- `ocamlformat --check`
- `git diff --check`

Full `pnpm lint` still reports the unrelated pre-existing `src/keeper-actions.ts:1008` `no-nested-ternary` violation; this PR does not claim that check as green.

22 additions / 113 deletions, 135 changed lines.