### PR TITLE
feat(fs): append private JSONL at exact cursor

### DIFF
--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -1891,6 +1891,11 @@ let rewrite_private_file_durable_locked_result path decide =
 type private_jsonl_append_error =
   | Incomplete_jsonl_tail
   | Invalid_jsonl_suffix
+  | Negative_expected_end_offset of int
+  | End_offset_mismatch of
+      { expected : int
+      ; actual : int
+      }
   | Durable_jsonl_append_failed of durable_append_error
 
 let private_jsonl_append_error_to_string = function
@@ -1898,22 +1903,36 @@ let private_jsonl_append_error_to_string = function
     "existing JSONL file ends with an incomplete row"
   | Invalid_jsonl_suffix ->
     "JSONL append suffix must be non-empty and newline-terminated"
+  | Negative_expected_end_offset offset ->
+    Printf.sprintf "expected JSONL end offset must be non-negative: %d" offset
+  | End_offset_mismatch { expected; actual } ->
+    Printf.sprintf
+      "JSONL end offset mismatch: expected %d, observed %d"
+      expected
+      actual
   | Durable_jsonl_append_failed error -> durable_append_error_to_string error
 ;;
 
-let append_private_jsonl_durable_locked_with_end_offset_result path suffix =
+let append_private_jsonl_durable_locked_with_expected_end_offset_result
+      path
+      ~expected_end_offset
+      suffix
+  =
   if String.equal suffix ""
      || not (Char.equal suffix.[String.length suffix - 1] '\n')
   then Error Invalid_jsonl_suffix
-  else (
-    test_exec_home_guard ~op:"append_private_jsonl_durable_locked" path;
-    let dir = Filename.dirname path in
-    mkdir_p_memoized dir;
-    let path_mu = get_append_path_mutex path in
-    run_blocking_private_file_transaction
-      ~label:"fs-compat-durable-append"
-      ~path
-      (fun () ->
+  else
+    match expected_end_offset with
+    | Some offset when offset < 0 -> Error (Negative_expected_end_offset offset)
+    | _ ->
+      test_exec_home_guard ~op:"append_private_jsonl_durable_locked" path;
+      let dir = Filename.dirname path in
+      mkdir_p_memoized dir;
+      let path_mu = get_append_path_mutex path in
+      run_blocking_private_file_transaction
+        ~label:"fs-compat-durable-append"
+        ~path
+        (fun () ->
       Stdlib.Mutex.protect path_mu (fun () ->
         let fd =
           Unix.openfile path
@@ -1929,34 +1948,58 @@ let append_private_jsonl_durable_locked_with_end_offset_result path suffix =
              ignore (Unix.lseek fd 0 Unix.SEEK_SET : int);
              lock_whole_file fd;
              let original_length = Unix.lseek fd 0 Unix.SEEK_END in
-             let tail_is_complete =
-               if original_length = 0
-               then true
+             match expected_end_offset with
+             | Some expected when expected <> original_length ->
+               Error
+                 (End_offset_mismatch
+                    { expected; actual = original_length })
+             | _ ->
+               let tail_is_complete =
+                 if original_length = 0
+                 then true
+                 else (
+                   (* See Unix.lseek: only the file-position side effect is required. *)
+                   ignore (Unix.lseek fd (original_length - 1) Unix.SEEK_SET : int);
+                   let byte = Bytes.create 1 in
+                   let rec read_tail () =
+                     match Unix.read fd byte 0 1 with
+                     | 1 -> Char.equal (Bytes.get byte 0) '\n'
+                     | 0 -> false
+                     | _ -> false
+                     | exception Unix.Unix_error (Unix.EINTR, _, _) -> read_tail ()
+                   in
+                   read_tail ())
+               in
+               if not tail_is_complete
+               then Error Incomplete_jsonl_tail
                else (
                  (* See Unix.lseek: only the file-position side effect is required. *)
-                 ignore (Unix.lseek fd (original_length - 1) Unix.SEEK_SET : int);
-                 let byte = Bytes.create 1 in
-                 let rec read_tail () =
-                   match Unix.read fd byte 0 1 with
-                   | 1 -> Char.equal (Bytes.get byte 0) '\n'
-                   | 0 -> false
-                   | _ -> false
-                   | exception Unix.Unix_error (Unix.EINTR, _, _) -> read_tail ()
-                 in
-                 read_tail ())
-             in
-             if not tail_is_complete
-             then Error Incomplete_jsonl_tail
-             else (
-               (* See Unix.lseek: only the file-position side effect is required. *)
-               ignore (Unix.lseek fd 0 Unix.SEEK_END : int);
-               append_fd_durable
-                 ~io:durable_append_unix_io
-                 ~fd
-                 ~original_length
-                 suffix
-               |> Result.map_error (fun error -> Durable_jsonl_append_failed error)
-               |> Result.map (fun () -> original_length + String.length suffix))))))
+                 ignore (Unix.lseek fd 0 Unix.SEEK_END : int);
+                 append_fd_durable
+                   ~io:durable_append_unix_io
+                   ~fd
+                   ~original_length
+                   suffix
+                 |> Result.map_error (fun error -> Durable_jsonl_append_failed error)
+                 |> Result.map (fun () -> original_length + String.length suffix)))))
+;;
+
+let append_private_jsonl_durable_locked_with_end_offset_result path suffix =
+  append_private_jsonl_durable_locked_with_expected_end_offset_result
+    path
+    ~expected_end_offset:None
+    suffix
+;;
+
+let append_private_jsonl_durable_locked_at_end_offset_result
+      path
+      ~expected_end_offset
+      suffix
+  =
+  append_private_jsonl_durable_locked_with_expected_end_offset_result
+    path
+    ~expected_end_offset:(Some expected_end_offset)
+    suffix
 ;;
 
 let append_private_jsonl_durable_locked_result path suffix =

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -804,6 +804,11 @@ val rewrite_private_file_durable_locked_result :
 type private_jsonl_append_error =
   | Incomplete_jsonl_tail
   | Invalid_jsonl_suffix
+  | Negative_expected_end_offset of int
+  | End_offset_mismatch of
+      { expected : int
+      ; actual : int
+      }
   | Durable_jsonl_append_failed of durable_append_error
 
 (** Append one or more complete JSONL rows without reading the existing file.
@@ -816,6 +821,16 @@ type private_jsonl_append_error =
     in a system thread so one contended file cannot stop unrelated fibers. *)
 val append_private_jsonl_durable_locked_with_end_offset_result :
   string -> string -> (int, private_jsonl_append_error) result
+
+(** Append only when the file's locked byte length is exactly
+    [expected_end_offset]. A stale writer receives [End_offset_mismatch] and
+    writes no bytes. The successful result is the committed newline-end byte
+    offset. *)
+val append_private_jsonl_durable_locked_at_end_offset_result :
+  string ->
+  expected_end_offset:int ->
+  string ->
+  (int, private_jsonl_append_error) result
 
 (** As {!append_private_jsonl_durable_locked_with_end_offset_result}, discarding
     the committed newline-end byte offset. *)

--- a/test/test_fs_compat_durable_append.ml
+++ b/test/test_fs_compat_durable_append.ml
@@ -256,6 +256,43 @@ let test_private_jsonl_append_returns_committed_end_offset () =
    | Error error -> fail (Fs_compat.private_jsonl_append_error_to_string error))
 ;;
 
+let test_private_jsonl_append_at_exact_end_offset () =
+  let original = "{\"row\":1}\n" in
+  let suffix = "{\"row\":2}\n" in
+  with_temp_jsonl original @@ fun path ->
+  (match
+     Fs_compat.append_private_jsonl_durable_locked_at_end_offset_result
+       path
+       ~expected_end_offset:(String.length original)
+       suffix
+   with
+   | Ok end_offset ->
+     check int
+       "committed newline-end byte offset"
+       (String.length original + String.length suffix)
+       end_offset
+   | Error error -> fail (Fs_compat.private_jsonl_append_error_to_string error));
+  check string "exact append bytes" (original ^ suffix) (Fs_compat.load_file path)
+;;
+
+let test_private_jsonl_append_rejects_stale_end_offset () =
+  let original = "{\"row\":1}\n" in
+  with_temp_jsonl original @@ fun path ->
+  (match
+     Fs_compat.append_private_jsonl_durable_locked_at_end_offset_result
+       path
+       ~expected_end_offset:0
+       "{\"row\":2}\n"
+   with
+   | Error
+       (Fs_compat.End_offset_mismatch
+          { expected = 0; actual }) ->
+     check int "locked actual byte offset" (String.length original) actual
+   | Error error -> fail (Fs_compat.private_jsonl_append_error_to_string error)
+   | Ok _ -> fail "stale cursor unexpectedly appended");
+  check string "stale append writes no bytes" original (Fs_compat.load_file path)
+;;
+
 let test_private_jsonl_slice_reads_exact_cursor_suffix () =
   let row1 = "{\"row\":1}\n" in
   let row2 = "{\"row\":2}\n" in
@@ -361,6 +398,14 @@ let () =
             "private JSONL append returns committed end offset"
             `Quick
             test_private_jsonl_append_returns_committed_end_offset
+        ; test_case
+            "private JSONL append accepts exact end offset"
+            `Quick
+            test_private_jsonl_append_at_exact_end_offset
+        ; test_case
+            "private JSONL append rejects stale end offset"
+            `Quick
+            test_private_jsonl_append_rejects_stale_end_offset
         ; test_case
             "private JSONL cursor read returns exact suffix"
             `Quick


### PR DESCRIPTION
## What changed

- add `append_private_jsonl_durable_locked_at_end_offset_result`
- compare the caller's expected byte cursor while holding the existing in-process mutex and cross-process file lock
- reject stale writers with typed `End_offset_mismatch { expected; actual }` before writing any bytes
- keep the existing rollback + fsync durability contract and return the committed end cursor
- reject negative expected cursors explicitly

## Why

The Keeper Operation Journal must replay once, then append incrementally without rereading its complete JSONL history on every event. An immutable writer state can carry its last committed cursor, but a copied/stale state must not append behind another writer. This exact-cursor CAS is the minimal storage primitive for that contract:

```text
immutable replay state + expected cursor
  -> locked cursor compare
  -> durable append
  -> new immutable state/cursor
```

It adds no timer, retry count, capacity limit, semantic classifier, or hidden fallback.

## Validation

- `scripts/dune-local.sh build test/test_fs_compat_durable_append.exe`
- `_build/default/test/test_fs_compat_durable_append.exe` — 16/16 pass
- `ocamlformat` on the three changed files
- `git diff --check`
- 3 files, 175 changed lines (<400)

Full repository CI remains authoritative. This storage leaf is independent of the published OAS v0.215.0 release and current MASC pin; it adds no OAS contract or dependency.

## Stack role

This is the first replacement slice for #24966 §3. The next PR builds one Keeper-owned generic MASC Operation Journal with immutable replay state over this primitive; the compaction-only O(n²) writer is then deleted rather than retained as a compatibility path.