### PR TITLE
refactor(keeper)!: make status observations fresh and inputs closed

### DIFF
--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -28,15 +28,8 @@ let nonnegative_number_schema description =
     ]
 ;;
 
-(** Issue #8486: hand-mirrored from
-    [Keeper_status_detail.valid_tail_order_strings].  Same cycle
-    constraint — Keeper_schema is upstream of Keeper_status_detail.
-    The test [test_types.ml :: tail_order_ssot] asserts this mirror
-    stays in sync with the SSOT so adding a 3rd ordering constructor
-    fails compilation in [tail_order_to_string] AND fails the test
-    here, instead of silently dropping from the JSON Schema. *)
 let tail_order_enum_strings =
-  [ "oldest_first"; "newest_first" ]
+  Keeper_status_options_defaults.valid_tail_order_strings
 
 let string_array_schema =
   `Assoc [
@@ -279,59 +272,62 @@ let keeper_schemas : tool_schema list = [
   {
     name = "masc_keeper_status";
     description = "Get keeper status (keepalive/live/reconcile state plus current context and monitoring tails).";
-    input_schema = `Assoc [
-      ("type", `String "object");
-      ("properties", `Assoc [
-        ("name", `Assoc [
+    input_schema = closed_object_schema ~required:[] [
+        (Keeper_status_options_defaults.Argument.name, `Assoc [
           ("type", `String "string");
-          ("description", `String "Keeper handle. Optional; defaults to the caller when omitted.");
+          ("minLength", `Int 1);
+          ("pattern", `String "\\S");
+          ("description", `String "Non-blank Keeper handle. Optional; defaults to the caller only when omitted.");
         ]);
-        ("tail_turns", `Assoc [
+        (Keeper_status_options_defaults.Argument.tail_turns, `Assoc [
           ("type", `String "integer");
+          ("minimum", `Int Keeper_status_options_defaults.min_tail_turns);
           ("description", `String (Printf.sprintf "How many recent turns to include from keeper metrics (default: %d)." Keeper_status_options_defaults.tail_turns));
         ]);
-        ("tail_messages", `Assoc [
+        (Keeper_status_options_defaults.Argument.tail_messages, `Assoc [
           ("type", `String "integer");
+          ("minimum", `Int Keeper_status_options_defaults.min_tail_messages);
           ("description", `String (Printf.sprintf "How many recent history messages to include (default: %d)." Keeper_status_options_defaults.tail_messages));
         ]);
-        ("tail_compactions", `Assoc [
+        (Keeper_status_options_defaults.Argument.tail_compactions, `Assoc [
           ("type", `String "integer");
+          ("minimum", `Int Keeper_status_options_defaults.min_tail_compactions);
           ("description", `String (Printf.sprintf "How many recent compaction events to include (default: %d)." Keeper_status_options_defaults.tail_compactions));
         ]);
-        ("tail_bytes", `Assoc [
+        (Keeper_status_options_defaults.Argument.tail_bytes, `Assoc [
           ("type", `String "integer");
+          ("minimum", `Int Keeper_status_options_defaults.min_tail_bytes);
           ("description", `String (Printf.sprintf "How many bytes from the end of files to scan for tails (default: %d; minimum: %d)." Keeper_status_options_defaults.tail_bytes Keeper_status_options_defaults.min_tail_bytes));
         ]);
-        ("tail_order", `Assoc [
+        (Keeper_status_options_defaults.Argument.tail_order, `Assoc [
           ("type", `String "string");
           ("enum", `List (List.map (fun s -> `String s) tail_order_enum_strings));
           ("description", `String "Ordering for metrics/history/compaction tails and recent memory notes. Default: oldest_first (compat).");
         ]);
-        ("fast", `Assoc [
+        (Keeper_status_options_defaults.Argument.fast, `Assoc [
           ("type", `String "boolean");
           ("description", `String "Enable fast mode (skip heavy sections unless explicitly enabled).");
         ]);
-        ("include_context", `Assoc [
+        (Keeper_status_options_defaults.Argument.include_context, `Assoc [
           ("type", `String "boolean");
           ("description", `String "Include checkpoint-derived context stats (default: !fast).");
         ]);
-        ("include_metrics_overview", `Assoc [
+        (Keeper_status_options_defaults.Argument.include_metrics_overview, `Assoc [
           ("type", `String "boolean");
           ("description", `String "Include metrics overview + skill route scan (default: !fast).");
         ]);
-        ("include_memory_bank", `Assoc [
+        (Keeper_status_options_defaults.Argument.include_memory_bank, `Assoc [
           ("type", `String "boolean");
           ("description", `String "Include memory bank summary (default: !fast).");
         ]);
-        ("include_history_tail", `Assoc [
+        (Keeper_status_options_defaults.Argument.include_history_tail, `Assoc [
           ("type", `String "boolean");
           ("description", `String "Include recent history tail + fragment counters (default: !fast).");
         ]);
-        ("include_compaction_history", `Assoc [
+        (Keeper_status_options_defaults.Argument.include_compaction_history, `Assoc [
           ("type", `String "boolean");
           ("description", `String "Include recent compaction history tail (default: !fast).");
         ]);
-      ]);
     ];
   };
 

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -288,19 +288,19 @@ let keeper_schemas : tool_schema list = [
         ]);
         ("tail_turns", `Assoc [
           ("type", `String "integer");
-          ("description", `String "How many recent turns to include from keeper metrics (default: 3).");
+          ("description", `String (Printf.sprintf "How many recent turns to include from keeper metrics (default: %d)." Keeper_status_options_defaults.tail_turns));
         ]);
         ("tail_messages", `Assoc [
           ("type", `String "integer");
-          ("description", `String "How many recent history messages to include (default: 5).");
+          ("description", `String (Printf.sprintf "How many recent history messages to include (default: %d)." Keeper_status_options_defaults.tail_messages));
         ]);
         ("tail_compactions", `Assoc [
           ("type", `String "integer");
-          ("description", `String "How many recent compaction events to include (default: 10).");
+          ("description", `String (Printf.sprintf "How many recent compaction events to include (default: %d)." Keeper_status_options_defaults.tail_compactions));
         ]);
         ("tail_bytes", `Assoc [
           ("type", `String "integer");
-          ("description", `String "How many bytes from the end of files to scan for tails (default: 60000).");
+          ("description", `String (Printf.sprintf "How many bytes from the end of files to scan for tails (default: %d; minimum: %d)." Keeper_status_options_defaults.tail_bytes Keeper_status_options_defaults.min_tail_bytes));
         ]);
         ("tail_order", `Assoc [
           ("type", `String "string");

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -282,22 +282,26 @@ let keeper_schemas : tool_schema list = [
         (Keeper_status_options_defaults.Argument.tail_turns, `Assoc [
           ("type", `String "integer");
           ("minimum", `Int Keeper_status_options_defaults.min_tail_turns);
-          ("description", `String (Printf.sprintf "How many recent turns to include from keeper metrics (default: %d)." Keeper_status_options_defaults.tail_turns));
+          ("maximum", `Int Keeper_status_options_defaults.max_tail_turns);
+          ("description", `String (Printf.sprintf "How many recent turns to include from keeper metrics (default: %d; maximum: %d)." Keeper_status_options_defaults.tail_turns Keeper_status_options_defaults.max_tail_turns));
         ]);
         (Keeper_status_options_defaults.Argument.tail_messages, `Assoc [
           ("type", `String "integer");
           ("minimum", `Int Keeper_status_options_defaults.min_tail_messages);
-          ("description", `String (Printf.sprintf "How many recent history messages to include (default: %d)." Keeper_status_options_defaults.tail_messages));
+          ("maximum", `Int Keeper_status_options_defaults.max_tail_messages);
+          ("description", `String (Printf.sprintf "How many recent history messages to include (default: %d; maximum: %d)." Keeper_status_options_defaults.tail_messages Keeper_status_options_defaults.max_tail_messages));
         ]);
         (Keeper_status_options_defaults.Argument.tail_compactions, `Assoc [
           ("type", `String "integer");
           ("minimum", `Int Keeper_status_options_defaults.min_tail_compactions);
-          ("description", `String (Printf.sprintf "How many recent compaction events to include (default: %d)." Keeper_status_options_defaults.tail_compactions));
+          ("maximum", `Int Keeper_status_options_defaults.max_tail_compactions);
+          ("description", `String (Printf.sprintf "How many recent compaction events to include (default: %d; maximum: %d)." Keeper_status_options_defaults.tail_compactions Keeper_status_options_defaults.max_tail_compactions));
         ]);
         (Keeper_status_options_defaults.Argument.tail_bytes, `Assoc [
           ("type", `String "integer");
           ("minimum", `Int Keeper_status_options_defaults.min_tail_bytes);
-          ("description", `String (Printf.sprintf "How many bytes from the end of files to scan for tails (default: %d; minimum: %d)." Keeper_status_options_defaults.tail_bytes Keeper_status_options_defaults.min_tail_bytes));
+          ("maximum", `Int Keeper_status_options_defaults.max_tail_bytes);
+          ("description", `String (Printf.sprintf "How many bytes from the end of files to scan for tails (default: %d; range: %d..%d)." Keeper_status_options_defaults.tail_bytes Keeper_status_options_defaults.min_tail_bytes Keeper_status_options_defaults.max_tail_bytes));
         ]);
         (Keeper_status_options_defaults.Argument.tail_order, `Assoc [
           ("type", `String "string");

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -99,32 +99,37 @@ let optional_bool_argument fields key ~default =
       Error
         (Printf.sprintf "keeper_status argument %S must be a boolean" key)
 
-let optional_int_argument fields key ~default ~minimum =
-  match status_argument fields key with
-  | None -> Ok default
-  | Some (`Int value) when value >= minimum -> Ok value
-  | Some (`Intlit literal) ->
-      (match int_of_string_opt literal with
-       | Some value when value >= minimum -> Ok value
-       | Some value ->
-           Error
-             (Printf.sprintf
-                "keeper_status argument %S must be at least %d (received %d)"
-                key
-                minimum
-                value)
-       | None ->
-           Error
-             (Printf.sprintf
-                "keeper_status argument %S is outside the supported integer range"
-                key))
-  | Some (`Int value) ->
+let optional_int_argument fields key ~default ~minimum ~maximum =
+  let validate value =
+    if value < minimum
+    then
       Error
         (Printf.sprintf
            "keeper_status argument %S must be at least %d (received %d)"
            key
            minimum
            value)
+    else if value > maximum
+    then
+      Error
+        (Printf.sprintf
+           "keeper_status argument %S must be at most %d (received %d)"
+           key
+           maximum
+           value)
+    else Ok value
+  in
+  match status_argument fields key with
+  | None -> Ok default
+  | Some (`Int value) -> validate value
+  | Some (`Intlit literal) ->
+      (match int_of_string_opt literal with
+       | Some value -> validate value
+       | None ->
+           Error
+             (Printf.sprintf
+                "keeper_status argument %S is outside the supported integer range"
+                key))
   | Some _ ->
       Error
         (Printf.sprintf "keeper_status argument %S must be an integer" key)
@@ -149,14 +154,16 @@ let tail_order_of_fields fields =
   with
   | None -> Ok Oldest_first
   | Some (`String raw_value) ->
-      (match String.trim raw_value with
-       | "oldest_first" -> Ok Oldest_first
-       | "newest_first" -> Ok Newest_first
-       | value ->
+      (match Keeper_status_options_defaults.tail_order_of_string raw_value with
+       | Some order -> Ok order
+       | None ->
            Error
              (Printf.sprintf
-                "invalid tail_order %S (allowed: oldest_first, newest_first)"
-                value))
+                "invalid tail_order %S (allowed: %s)"
+                raw_value
+                (String.concat
+                   ", "
+                   Keeper_status_options_defaults.valid_tail_order_strings)))
   | Some _ ->
       Error "keeper_status argument \"tail_order\" must be a string"
 
@@ -184,6 +191,7 @@ let status_options_of_fields fields =
       Keeper_status_options_defaults.Argument.tail_turns
       ~default:Keeper_status_options_defaults.tail_turns
       ~minimum:Keeper_status_options_defaults.min_tail_turns
+      ~maximum:Keeper_status_options_defaults.max_tail_turns
   in
   let* tail_messages =
     optional_int_argument
@@ -191,6 +199,7 @@ let status_options_of_fields fields =
       Keeper_status_options_defaults.Argument.tail_messages
       ~default:Keeper_status_options_defaults.tail_messages
       ~minimum:Keeper_status_options_defaults.min_tail_messages
+      ~maximum:Keeper_status_options_defaults.max_tail_messages
   in
   let* tail_compactions =
     optional_int_argument
@@ -198,6 +207,7 @@ let status_options_of_fields fields =
       Keeper_status_options_defaults.Argument.tail_compactions
       ~default:Keeper_status_options_defaults.tail_compactions
       ~minimum:Keeper_status_options_defaults.min_tail_compactions
+      ~maximum:Keeper_status_options_defaults.max_tail_compactions
   in
   let* tail_bytes =
     optional_int_argument
@@ -205,6 +215,7 @@ let status_options_of_fields fields =
       Keeper_status_options_defaults.Argument.tail_bytes
       ~default:Keeper_status_options_defaults.tail_bytes
       ~minimum:Keeper_status_options_defaults.min_tail_bytes
+      ~maximum:Keeper_status_options_defaults.max_tail_bytes
   in
   let* include_context =
     optional_bool_argument
@@ -497,7 +508,11 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
                  config
                  ~name:m.name
                  ~max_bytes:tail_bytes
-                 ~max_lines:(max (tail_turns * 10) 400)
+                 ~max_lines:
+                   (max
+                      (tail_turns
+                       * Keeper_status_options_defaults.metrics_lines_per_turn)
+                      Keeper_status_options_defaults.min_metrics_scan_lines)
                  ~recent_limit:8
              with
              | Ok summary ->
@@ -605,7 +620,12 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
            if not include_compaction_history then
              (`List [], 0)
            else
-             let n = max 200 (tail_compactions * 20) in
+             let n =
+               max
+                 Keeper_status_options_defaults.min_compaction_scan_lines
+                 (tail_compactions
+                  * Keeper_status_options_defaults.compaction_lines_per_event)
+             in
              let lines = Dated_jsonl.read_recent_lines metrics_store n in
              let events_rev =
                List.fold_left

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -158,11 +158,14 @@ let effective_status_name (ctx : _ context) args =
   effective_status_name_config ~agent_name:ctx.agent_name args
 
 let tail_order_of_args args =
-  match String.lowercase_ascii (String.trim (get_string args "tail_order" "")) with
-  | "newest_first" | "newest" | "latest_first" | "desc" ->
-      Newest_first
-  | _ ->
-      Oldest_first
+  match String.trim (get_string args "tail_order" "") with
+  | "" | "oldest_first" -> Ok Oldest_first
+  | "newest_first" -> Ok Newest_first
+  | value ->
+      Error
+        (Printf.sprintf
+           "invalid tail_order %S (allowed: oldest_first, newest_first)"
+           value)
 
 let tail_order_to_string = function
   | Oldest_first -> "oldest_first"
@@ -179,20 +182,48 @@ let valid_tail_order_strings =
 
 let status_options_of_args args =
   let fast = get_bool args "fast" (keeper_status_fast_default ()) in
-  { tail_turns = max 0 (get_int args "tail_turns" 3)
-  ; tail_messages = max 0 (get_int args "tail_messages" 5)
-  ; tail_compactions = max 0 (get_int args "tail_compactions" 10)
-  ; tail_bytes = max 1_000 (get_int args "tail_bytes" 60_000)
-  ; tail_order = tail_order_of_args args
-  ; fast
-  ; include_context = get_bool args "include_context" (not fast)
-  ; include_metrics_overview =
-      get_bool args "include_metrics_overview" (not fast)
-  ; include_memory_bank = get_bool args "include_memory_bank" (not fast)
-  ; include_history_tail = get_bool args "include_history_tail" (not fast)
-  ; include_compaction_history =
-      get_bool args "include_compaction_history" (not fast)
-  }
+  match tail_order_of_args args with
+  | Error _ as error -> error
+  | Ok tail_order ->
+      Ok
+        { tail_turns =
+            max
+              0
+              (get_int
+                 args
+                 "tail_turns"
+                 Keeper_status_options_defaults.tail_turns)
+        ; tail_messages =
+            max
+              0
+              (get_int
+                 args
+                 "tail_messages"
+                 Keeper_status_options_defaults.tail_messages)
+        ; tail_compactions =
+            max
+              0
+              (get_int
+                 args
+                 "tail_compactions"
+                 Keeper_status_options_defaults.tail_compactions)
+        ; tail_bytes =
+            max
+              Keeper_status_options_defaults.min_tail_bytes
+              (get_int
+                 args
+                 "tail_bytes"
+                 Keeper_status_options_defaults.tail_bytes)
+        ; tail_order
+        ; fast
+        ; include_context = get_bool args "include_context" (not fast)
+        ; include_metrics_overview =
+            get_bool args "include_metrics_overview" (not fast)
+        ; include_memory_bank = get_bool args "include_memory_bank" (not fast)
+        ; include_history_tail = get_bool args "include_history_tail" (not fast)
+        ; include_compaction_history =
+            get_bool args "include_compaction_history" (not fast)
+        }
 
 let apply_tail_order order items =
   match order with
@@ -250,6 +281,8 @@ let effective_meta_overlay_hash (meta : keeper_meta) =
   let opt_int = Option.fold ~none:"" ~some:string_of_int in
   let fields =
     [
+      ( "persisted_meta"
+      , Keeper_meta_json.meta_to_json meta |> Yojson.Safe.to_string );
       ("persona", opt_string meta.persona);
       ("instructions", meta.instructions);
       ("sandbox_profile", sandbox_profile_to_string meta.sandbox_profile);
@@ -259,6 +292,12 @@ let effective_meta_overlay_hash (meta : keeper_meta) =
       ("mention_targets", cache_fingerprint_list meta.mention_targets);
       ( "multimodal_policy",
         multimodal_policy_to_string meta.multimodal_policy );
+      ("compaction_profile", meta.compaction.profile);
+      ("compaction_ratio_gate", string_of_float meta.compaction.ratio_gate);
+      ("compaction_message_gate", string_of_int meta.compaction.message_gate);
+      ("compaction_token_gate", string_of_int meta.compaction.token_gate);
+      ("compaction_cooldown_sec", string_of_int meta.compaction.cooldown_sec);
+      ("max_context_override", opt_int meta.max_context_override);
       ("active_goal_ids", cache_fingerprint_list meta.active_goal_ids);
       ("proactive_enabled", string_of_bool meta.proactive.enabled);
       ("autoboot_enabled", string_of_bool meta.autoboot_enabled);
@@ -364,9 +403,11 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
   match resolve_status_target_config ~config ~agent_name args with
   | Error err -> tool_result_error err
   | Ok (name, m) ->
+      (match status_options_of_args args with
+       | Error err -> tool_result_error err
+       | Ok options ->
       let cache_key = status_cache_key ~base_path:config.base_path ~name in
       let chat_queue_observation = observe_chat_queue ~keeper_name:m.name in
-      let options = status_options_of_args args in
       let cache_input =
         { options
         ; effective_meta_overlay_hash = effective_meta_overlay_hash m
@@ -1019,6 +1060,6 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
          Eio_guard.with_mutex cache_mu (fun () ->
            Hashtbl.replace _cache cache_key
              { updated_at = m.updated_at; cache_input; response = json });
-         tool_result_ok_data json)
+         tool_result_ok_data json))
 (* TEL-OK: 1-line delegate to ctx-free body. *)
 let handle_keeper_status (ctx : _ context) args = handle_keeper_status_config ~config:ctx.config ~agent_name:ctx.agent_name args

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -1,7 +1,7 @@
 (** Keeper_status_detail — single-keeper detailed status handler.
     Split from keeper_status.ml.
 
-    Server-side response cache: keyed on (base_path, name, updated_at, args_hash).
+    Server-side response cache: keyed on (base_path, name, updated_at, cache input).
     Avoids expensive JSONL parsing and checkpoint loading when keeper
     state has not changed between consecutive status polls. *)
 
@@ -29,9 +29,33 @@ let read_tail_lines_or_empty ~site path ~max_bytes ~max_lines =
 
 (* ── Response cache ──────────────────────────────────── *)
 
+type tail_order =
+  | Oldest_first
+  | Newest_first
+
+type status_options =
+  { tail_turns : int
+  ; tail_messages : int
+  ; tail_compactions : int
+  ; tail_bytes : int
+  ; tail_order : tail_order
+  ; fast : bool
+  ; include_context : bool
+  ; include_metrics_overview : bool
+  ; include_memory_bank : bool
+  ; include_history_tail : bool
+  ; include_compaction_history : bool
+  }
+
+type status_cache_input =
+  { options : status_options
+  ; effective_meta_overlay_hash : string
+  ; chat_queue_fingerprint : string
+  }
+
 type cache_entry = {
   updated_at : string;
-  args_hash : string;
+  cache_input : status_cache_input;
   response : Yojson.Safe.t;
 }
 
@@ -133,10 +157,6 @@ let effective_status_name_config ~(agent_name : string) args =
 let effective_status_name (ctx : _ context) args =
   effective_status_name_config ~agent_name:ctx.agent_name args
 
-type tail_order =
-  | Oldest_first
-  | Newest_first
-
 let tail_order_of_args args =
   match String.lowercase_ascii (String.trim (get_string args "tail_order" "")) with
   | "newest_first" | "newest" | "latest_first" | "desc" ->
@@ -156,6 +176,23 @@ let tail_order_to_string = function
 let all_tail_orders = [ Oldest_first; Newest_first ]
 let valid_tail_order_strings =
   List.map tail_order_to_string all_tail_orders
+
+let status_options_of_args args =
+  let fast = get_bool args "fast" (keeper_status_fast_default ()) in
+  { tail_turns = max 0 (get_int args "tail_turns" 3)
+  ; tail_messages = max 0 (get_int args "tail_messages" 5)
+  ; tail_compactions = max 0 (get_int args "tail_compactions" 10)
+  ; tail_bytes = max 1_000 (get_int args "tail_bytes" 60_000)
+  ; tail_order = tail_order_of_args args
+  ; fast
+  ; include_context = get_bool args "include_context" (not fast)
+  ; include_metrics_overview =
+      get_bool args "include_metrics_overview" (not fast)
+  ; include_memory_bank = get_bool args "include_memory_bank" (not fast)
+  ; include_history_tail = get_bool args "include_history_tail" (not fast)
+  ; include_compaction_history =
+      get_bool args "include_compaction_history" (not fast)
+  }
 
 let apply_tail_order order items =
   match order with
@@ -315,25 +352,6 @@ let chat_queue_status_to_json observation =
       ; "durable_replay_enabled", `Bool durable_replay_enabled
       ]
 
-let hash_status_args _config resolved_name (meta : keeper_meta)
-    ~chat_queue_fingerprint args =
-  let parts = [
-    resolved_name;
-    effective_meta_overlay_hash meta;
-    chat_queue_fingerprint;
-    (* Keeper_manual_reconcile.cache_key removed with reconcile system. *)
-    string_of_bool (get_bool args "fast" false);
-    string_of_bool (get_bool args "include_context" false);
-    string_of_bool (get_bool args "include_metrics_overview" false);
-    string_of_bool (get_bool args "include_memory_bank" false);
-    string_of_bool (get_bool args "include_history_tail" false);
-    string_of_bool (get_bool args "include_compaction_history" false);
-    string_of_int (get_int args "tail_turns" 3);
-    string_of_int (get_int args "tail_messages" 5);
-    tail_order_to_string (tail_order_of_args args);
-  ] in
-  Digest.string (String.concat "|" parts) |> Digest.to_hex
-
 let nonempty_trimmed = Keeper_status_detail_observability.nonempty_trimmed
 let json_string_opt_member = Json_util.get_string_nonempty
 let latest_metrics_json = Keeper_status_detail_observability.latest_metrics_json
@@ -348,13 +366,15 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
   | Ok (name, m) ->
       let cache_key = status_cache_key ~base_path:config.base_path ~name in
       let chat_queue_observation = observe_chat_queue ~keeper_name:m.name in
-      let args_hash =
-        hash_status_args config name m
-          ~chat_queue_fingerprint:
-            (chat_queue_observation_fingerprint chat_queue_observation)
-          args
+      let options = status_options_of_args args in
+      let cache_input =
+        { options
+        ; effective_meta_overlay_hash = effective_meta_overlay_hash m
+        ; chat_queue_fingerprint =
+            chat_queue_observation_fingerprint chat_queue_observation
+        }
       in
-      (* Cache hit: same updated_at + same args/effective-meta hash → return cached response.
+      (* Cache hit: same updated_at + same typed args/effective-meta input → return cached response.
          The read is taken under [cache_mu] so it cannot interleave with
          an eviction from [invalidate_status_cache_{for,all}]. *)
       (match
@@ -363,23 +383,23 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
        with
        | Some entry
          when entry.updated_at = m.updated_at
-           && entry.args_hash = args_hash ->
+           && entry.cache_input = cache_input ->
          tool_result_ok_data entry.response
        | _ ->
-      let tail_turns = max 0 (get_int args "tail_turns" 3) in
-      let tail_messages = max 0 (get_int args "tail_messages" 5) in
-      let tail_compactions = max 0 (get_int args "tail_compactions" 10) in
-      let tail_bytes = max 1_000 (get_int args "tail_bytes" 60_000) in
-      let fast = get_bool args "fast" (keeper_status_fast_default ()) in
-      let tail_order = tail_order_of_args args in
-      let include_context = get_bool args "include_context" (not fast) in
-      let include_metrics_overview =
-        get_bool args "include_metrics_overview" (not fast)
-      in
-      let include_memory_bank = get_bool args "include_memory_bank" (not fast) in
-      let include_history_tail = get_bool args "include_history_tail" (not fast) in
-      let include_compaction_history =
-        get_bool args "include_compaction_history" (not fast)
+      let
+        { tail_turns
+        ; tail_messages
+        ; tail_compactions
+        ; tail_bytes
+        ; tail_order
+        ; fast
+        ; include_context
+        ; include_metrics_overview
+        ; include_memory_bank
+        ; include_history_tail
+        ; include_compaction_history
+        }
+        = options
       in
       let max_context_resolution =
         Keeper_context_runtime.resolve_max_context_resolution_of_meta m
@@ -899,6 +919,10 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
              ("token_gate_enabled", `Bool (compact_token_gate > 0));
            ]);
            ("status_options", `Assoc [
+             ("tail_turns", `Int tail_turns);
+             ("tail_messages", `Int tail_messages);
+             ("tail_compactions", `Int tail_compactions);
+             ("tail_bytes", `Int tail_bytes);
              ("fast", `Bool fast);
              ("include_context", `Bool include_context);
              ("include_metrics_overview", `Bool include_metrics_overview);
@@ -994,7 +1018,7 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
          ]) in
          Eio_guard.with_mutex cache_mu (fun () ->
            Hashtbl.replace _cache cache_key
-             { updated_at = m.updated_at; args_hash; response = json });
+             { updated_at = m.updated_at; cache_input; response = json });
          tool_result_ok_data json)
 (* TEL-OK: 1-line delegate to ctx-free body. *)
 let handle_keeper_status (ctx : _ context) args = handle_keeper_status_config ~config:ctx.config ~agent_name:ctx.agent_name args

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -1,11 +1,6 @@
 (** Keeper_status_detail — single-keeper detailed status handler.
-    Split from keeper_status.ml.
+    Split from keeper_status.ml. *)
 
-    Server-side response cache: keyed on (base_path, name, updated_at, cache input).
-    Avoids expensive JSONL parsing and checkpoint loading when keeper
-    state has not changed between consecutive status polls. *)
-
-open Tool_args
 open Keeper_types
 open Keeper_meta_contract
 open Keeper_meta_store
@@ -27,9 +22,9 @@ let read_tail_lines_or_empty ~site path ~max_bytes ~max_lines =
       record_memory_recall_read_error ~site path exn_class;
       []
 
-(* ── Response cache ──────────────────────────────────── *)
+(* Status request contract. *)
 
-type tail_order =
+type tail_order = Keeper_status_options_defaults.tail_order =
   | Oldest_first
   | Newest_first
 
@@ -47,65 +42,6 @@ type status_options =
   ; include_compaction_history : bool
   }
 
-type status_cache_input =
-  { options : status_options
-  ; effective_meta_overlay_hash : string
-  ; chat_queue_fingerprint : string
-  }
-
-type cache_entry = {
-  updated_at : string;
-  cache_input : status_cache_input;
-  response : Yojson.Safe.t;
-}
-
-let _cache : (string, cache_entry) Hashtbl.t = Hashtbl.create 8
-
-type docker_preflight_status_cache_entry = {
-  key : string;
-  observed_at : float;
-  value : Yojson.Safe.t option;
-}
-
-let docker_preflight_status_cache :
-    docker_preflight_status_cache_entry option ref =
-  ref None
-
-let docker_preflight_status_cache_mu = Eio.Mutex.create ()
-let docker_preflight_status_cache_ttl_sec = 60.0
-
-(** Mutex protecting [_cache].  [handle_keeper_status] runs from an MCP
-    tool-dispatch fiber, one per concurrent [masc_keeper_status]
-    request, and [invalidate_status_cache_{for,all}] is called from
-    keeper state-change paths on different fibers — so every access
-    path competes for the same module-level [Hashtbl.t] with no
-    serialisation.  The dangerous pair is [Hashtbl.filter_map_inplace]
-    (eviction) interleaving with [Hashtbl.find_opt] / [Hashtbl.replace]
-    from another fiber, which can segfault or return torn values: OCaml
-    [Hashtbl] is explicitly unsafe for concurrent mutate-during-read. *)
-let cache_mu = Eio.Mutex.create ()
-
-let invalidate_status_cache_for name =
-  Eio_guard.with_mutex cache_mu (fun () ->
-    Hashtbl.filter_map_inplace
-      (fun key entry ->
-        match String.rindex_opt key ':' with
-        | Some idx ->
-            let cached_name =
-              String.sub key (idx + 1) (String.length key - idx - 1)
-            in
-            if String.equal cached_name name then None else Some entry
-        | None -> Some entry)
-      _cache)
-
-let invalidate_status_cache_all () =
-  Eio_guard.with_mutex cache_mu (fun () ->
-    Hashtbl.clear _cache);
-  Eio_guard.with_mutex docker_preflight_status_cache_mu (fun () ->
-    docker_preflight_status_cache := None)
-
-let status_cache_key ~base_path ~name = base_path ^ ":" ^ name
-
 let normalize_status_name = String.trim
 
 let status_name_lookup_candidates raw_name =
@@ -120,110 +56,199 @@ let status_name_lookup_candidates raw_name =
     in
     trimmed :: aliases
 
-let docker_preflight_status_cache_key ~timeout_sec =
-  String.concat "|"
-    [
-      string_of_bool (Env_config_sandbox.Preflight.enabled ());
-      Env_config_sandbox.Runtime.docker_image ();
-      Env_config_sandbox.Hardening.seccomp_profile ();
-      string_of_bool (Env_config_sandbox.Hardening.require_rootless ());
-      string_of_bool (Env_config_sandbox.Hardening.require_userns ());
-      Printf.sprintf "%.3f" timeout_sec;
-    ]
+let status_argument_fields = function
+  | `Assoc fields ->
+      let rec collect seen = function
+        | [] -> Ok (List.rev seen)
+        | (key, value) :: rest ->
+            if
+              not
+                (List.exists
+                   (String.equal key)
+                   Keeper_status_options_defaults.Argument.all)
+            then
+              Error
+                (Printf.sprintf
+                   "unknown keeper_status argument %S"
+                   key)
+            else if
+              List.exists
+                (fun (seen_key, _) -> String.equal key seen_key)
+                seen
+            then
+              Error
+                (Printf.sprintf
+                   "keeper_status argument %S must occur at most once"
+                   key)
+            else collect ((key, value) :: seen) rest
+      in
+      collect [] fields
+  | _ -> Error "keeper_status arguments must be a JSON object"
 
-let cached_docker_preflight_status_json ~timeout_sec =
-  if not (Env_config_sandbox.Preflight.enabled ()) then
-    None
-  else
-    let key = docker_preflight_status_cache_key ~timeout_sec in
-    Eio_guard.with_mutex docker_preflight_status_cache_mu (fun () ->
-      let now = Time_compat.now () in
-      match !docker_preflight_status_cache with
-      | Some entry
-        when String.equal entry.key key
-             && now -. entry.observed_at < docker_preflight_status_cache_ttl_sec ->
-          entry.value
-      | _ ->
-          let value = Keeper_sandbox_control.preflight_status_json ~timeout_sec in
-          docker_preflight_status_cache := Some { key; observed_at = now; value };
-          value)
+let status_argument fields key =
+  List.find_map
+    (fun (candidate, value) ->
+      if String.equal key candidate then Some value else None)
+    fields
 
-(* RFC-0182 §3.1 — ctx-free body for keeper_dispatch_ref path. *)
-let effective_status_name_config ~(agent_name : string) args =
-  match normalize_status_name (get_string args "name" "") with
-  | "" -> normalize_status_name agent_name
-  | value -> value
+let optional_bool_argument fields key ~default =
+  match status_argument fields key with
+  | None -> Ok default
+  | Some (`Bool value) -> Ok value
+  | Some _ ->
+      Error
+        (Printf.sprintf "keeper_status argument %S must be a boolean" key)
 
-let effective_status_name (ctx : _ context) args =
-  effective_status_name_config ~agent_name:ctx.agent_name args
-
-let tail_order_of_args args =
-  match String.trim (get_string args "tail_order" "") with
-  | "" | "oldest_first" -> Ok Oldest_first
-  | "newest_first" -> Ok Newest_first
-  | value ->
+let optional_int_argument fields key ~default ~minimum =
+  match status_argument fields key with
+  | None -> Ok default
+  | Some (`Int value) when value >= minimum -> Ok value
+  | Some (`Intlit literal) ->
+      (match int_of_string_opt literal with
+       | Some value when value >= minimum -> Ok value
+       | Some value ->
+           Error
+             (Printf.sprintf
+                "keeper_status argument %S must be at least %d (received %d)"
+                key
+                minimum
+                value)
+       | None ->
+           Error
+             (Printf.sprintf
+                "keeper_status argument %S is outside the supported integer range"
+                key))
+  | Some (`Int value) ->
       Error
         (Printf.sprintf
-           "invalid tail_order %S (allowed: oldest_first, newest_first)"
+           "keeper_status argument %S must be at least %d (received %d)"
+           key
+           minimum
            value)
+  | Some _ ->
+      Error
+        (Printf.sprintf "keeper_status argument %S must be an integer" key)
 
-let tail_order_to_string = function
-  | Oldest_first -> "oldest_first"
-  | Newest_first -> "newest_first"
+(* RFC-0182 §3.1 — ctx-free body for keeper_dispatch_ref path. *)
+let effective_status_name_config ~(agent_name : string) fields =
+  match
+    status_argument fields Keeper_status_options_defaults.Argument.name
+  with
+  | None -> Ok (normalize_status_name agent_name)
+  | Some (`String raw_name) ->
+      (match normalize_status_name raw_name with
+       | "" ->
+           Error "keeper_status argument \"name\" must not be blank"
+       | value -> Ok value)
+  | Some _ ->
+      Error "keeper_status argument \"name\" must be a string"
 
-(* Issue #8486: Variant SSOT for [tail_order]. Adding a constructor
-   forces [tail_order_to_string] exhaustiveness AND extends
-   [valid_tail_order_strings]; the schema in [Keeper_schema] mirrors
-   this list (cycle-avoidance: Keeper_schema -> Keeper_types ->
-   Keeper_types_profile -> Keeper_schema, same shape as #8467). *)
-let all_tail_orders = [ Oldest_first; Newest_first ]
-let valid_tail_order_strings =
-  List.map tail_order_to_string all_tail_orders
+let tail_order_of_fields fields =
+  match
+    status_argument fields Keeper_status_options_defaults.Argument.tail_order
+  with
+  | None -> Ok Oldest_first
+  | Some (`String raw_value) ->
+      (match String.trim raw_value with
+       | "oldest_first" -> Ok Oldest_first
+       | "newest_first" -> Ok Newest_first
+       | value ->
+           Error
+             (Printf.sprintf
+                "invalid tail_order %S (allowed: oldest_first, newest_first)"
+                value))
+  | Some _ ->
+      Error "keeper_status argument \"tail_order\" must be a string"
 
-let status_options_of_args args =
-  let fast = get_bool args "fast" (keeper_status_fast_default ()) in
-  match tail_order_of_args args with
+let tail_order_of_args args =
+  match status_argument_fields args with
   | Error _ as error -> error
-  | Ok tail_order ->
-      Ok
-        { tail_turns =
-            max
-              0
-              (get_int
-                 args
-                 "tail_turns"
-                 Keeper_status_options_defaults.tail_turns)
-        ; tail_messages =
-            max
-              0
-              (get_int
-                 args
-                 "tail_messages"
-                 Keeper_status_options_defaults.tail_messages)
-        ; tail_compactions =
-            max
-              0
-              (get_int
-                 args
-                 "tail_compactions"
-                 Keeper_status_options_defaults.tail_compactions)
-        ; tail_bytes =
-            max
-              Keeper_status_options_defaults.min_tail_bytes
-              (get_int
-                 args
-                 "tail_bytes"
-                 Keeper_status_options_defaults.tail_bytes)
-        ; tail_order
-        ; fast
-        ; include_context = get_bool args "include_context" (not fast)
-        ; include_metrics_overview =
-            get_bool args "include_metrics_overview" (not fast)
-        ; include_memory_bank = get_bool args "include_memory_bank" (not fast)
-        ; include_history_tail = get_bool args "include_history_tail" (not fast)
-        ; include_compaction_history =
-            get_bool args "include_compaction_history" (not fast)
-        }
+  | Ok fields -> tail_order_of_fields fields
+
+let tail_order_to_string = Keeper_status_options_defaults.tail_order_to_string
+let all_tail_orders = Keeper_status_options_defaults.all_tail_orders
+let valid_tail_order_strings = Keeper_status_options_defaults.valid_tail_order_strings
+
+let status_options_of_fields fields =
+  let ( let* ) = Result.bind in
+  let* fast =
+    optional_bool_argument
+      fields
+      Keeper_status_options_defaults.Argument.fast
+      ~default:(keeper_status_fast_default ())
+  in
+  let* tail_order = tail_order_of_fields fields in
+  let* tail_turns =
+    optional_int_argument
+      fields
+      Keeper_status_options_defaults.Argument.tail_turns
+      ~default:Keeper_status_options_defaults.tail_turns
+      ~minimum:Keeper_status_options_defaults.min_tail_turns
+  in
+  let* tail_messages =
+    optional_int_argument
+      fields
+      Keeper_status_options_defaults.Argument.tail_messages
+      ~default:Keeper_status_options_defaults.tail_messages
+      ~minimum:Keeper_status_options_defaults.min_tail_messages
+  in
+  let* tail_compactions =
+    optional_int_argument
+      fields
+      Keeper_status_options_defaults.Argument.tail_compactions
+      ~default:Keeper_status_options_defaults.tail_compactions
+      ~minimum:Keeper_status_options_defaults.min_tail_compactions
+  in
+  let* tail_bytes =
+    optional_int_argument
+      fields
+      Keeper_status_options_defaults.Argument.tail_bytes
+      ~default:Keeper_status_options_defaults.tail_bytes
+      ~minimum:Keeper_status_options_defaults.min_tail_bytes
+  in
+  let* include_context =
+    optional_bool_argument
+      fields
+      Keeper_status_options_defaults.Argument.include_context
+      ~default:(not fast)
+  in
+  let* include_metrics_overview =
+    optional_bool_argument
+      fields
+      Keeper_status_options_defaults.Argument.include_metrics_overview
+      ~default:(not fast)
+  in
+  let* include_memory_bank =
+    optional_bool_argument
+      fields
+      Keeper_status_options_defaults.Argument.include_memory_bank
+      ~default:(not fast)
+  in
+  let* include_history_tail =
+    optional_bool_argument
+      fields
+      Keeper_status_options_defaults.Argument.include_history_tail
+      ~default:(not fast)
+  in
+  let* include_compaction_history =
+    optional_bool_argument
+      fields
+      Keeper_status_options_defaults.Argument.include_compaction_history
+      ~default:(not fast)
+  in
+  Ok
+    { tail_turns
+    ; tail_messages
+    ; tail_compactions
+    ; tail_bytes
+    ; tail_order
+    ; fast
+    ; include_context
+    ; include_metrics_overview
+    ; include_memory_bank
+    ; include_history_tail
+    ; include_compaction_history
+    }
 
 let apply_tail_order order items =
   match order with
@@ -231,88 +256,24 @@ let apply_tail_order order items =
   | Newest_first -> List.rev items
 
 (* RFC-0182 §3.1 — ctx-free body for keeper_dispatch_ref path. *)
-let resolve_status_target_config ~(config : Workspace.config) ~(agent_name : string) args =
-  let requested_name = effective_status_name_config ~agent_name args in
+let resolve_status_target_config ~(config : Workspace.config) ~(agent_name : string) fields =
+  let ( let* ) = Result.bind in
+  let* requested_name = effective_status_name_config ~agent_name fields in
   let candidates =
-    status_name_lookup_candidates requested_name
-    |> List.filter validate_name
+    status_name_lookup_candidates requested_name |> List.filter validate_name
   in
-  if candidates = [] then
-    Error (invalid_name_error requested_name)
+  if candidates = []
+  then Error (invalid_name_error requested_name)
   else
     let rec loop = function
       | [] -> Error (Printf.sprintf "keeper not found: %s" requested_name)
-      | candidate :: rest -> (
-          match read_effective_meta_resolved config candidate with
-          | Error e -> Error e
-          | Ok (Some (resolved_name, meta)) -> Ok (resolved_name, meta)
-          | Ok None -> loop rest)
+      | candidate :: rest ->
+          (match read_effective_meta_resolved config candidate with
+           | Error e -> Error e
+           | Ok (Some (resolved_name, meta)) -> Ok (resolved_name, meta)
+           | Ok None -> loop rest)
     in
     loop candidates
-
-let resolve_status_target (ctx : _ context) args =
-  resolve_status_target_config ~config:ctx.config ~agent_name:ctx.agent_name args
-
-(** Hash the status-affecting args and the profile-overlay fields so different
-    parameter combos (e.g. fast=true vs fast=false) and TOML/persona overlays
-    get separate cache entries. Persisted JSON writes update [updated_at], but
-    external [keepers/<name>.toml] edits do not. *)
-let cache_fingerprint_field (key, value) =
-  Printf.sprintf "%s=%d:%s" key (String.length value) value
-
-let cache_fingerprint_list values = String.concat "\x1f" values
-
-let cache_fingerprint_pairs pairs =
-  pairs
-  |> List.map (fun (key, value) ->
-       key ^ "\x1e" ^ string_of_int (String.length value) ^ "\x1e" ^ value)
-  |> String.concat "\x1f"
-
-let effective_meta_overlay_hash (meta : keeper_meta) =
-  let opt_string = function
-    | Some value -> value
-    | None -> ""
-  in
-  let opt_bool = function
-    | Some true -> "true"
-    | Some false -> "false"
-    | None -> ""
-  in
-  let opt_int = Option.fold ~none:"" ~some:string_of_int in
-  let fields =
-    [
-      ( "persisted_meta"
-      , Keeper_meta_json.meta_to_json meta |> Yojson.Safe.to_string );
-      ("persona", opt_string meta.persona);
-      ("instructions", meta.instructions);
-      ("sandbox_profile", sandbox_profile_to_string meta.sandbox_profile);
-      ("sandbox_image", opt_string meta.sandbox_image);
-      ("network_mode", network_mode_to_string meta.network_mode);
-      ("allowed_paths", cache_fingerprint_list meta.allowed_paths);
-      ("mention_targets", cache_fingerprint_list meta.mention_targets);
-      ( "multimodal_policy",
-        multimodal_policy_to_string meta.multimodal_policy );
-      ("compaction_profile", meta.compaction.profile);
-      ("compaction_ratio_gate", string_of_float meta.compaction.ratio_gate);
-      ("compaction_message_gate", string_of_int meta.compaction.message_gate);
-      ("compaction_token_gate", string_of_int meta.compaction.token_gate);
-      ("compaction_cooldown_sec", string_of_int meta.compaction.cooldown_sec);
-      ("max_context_override", opt_int meta.max_context_override);
-      ("active_goal_ids", cache_fingerprint_list meta.active_goal_ids);
-      ("proactive_enabled", string_of_bool meta.proactive.enabled);
-      ("autoboot_enabled", string_of_bool meta.autoboot_enabled);
-      ("telemetry_feedback_enabled", opt_bool meta.telemetry_feedback_enabled);
-      ( "telemetry_feedback_window_hours",
-        opt_int meta.telemetry_feedback_window_hours );
-      ("always_allow", opt_bool meta.always_allow);
-      ("oas_env", cache_fingerprint_pairs meta.oas_env);
-    ]
-  in
-  fields
-  |> List.map cache_fingerprint_field
-  |> String.concat "\n"
-  |> Digest.string
-  |> Digest.to_hex
 
 type chat_queue_status_observation =
   | Chat_queue_snapshot of Keeper_chat_queue.diagnostic_snapshot
@@ -322,37 +283,6 @@ let observe_chat_queue ~keeper_name =
   if Eio_guard.is_ready ()
   then Chat_queue_snapshot (Keeper_chat_queue.snapshot ~keeper_name)
   else Chat_queue_unavailable "eio_guard_not_ready"
-
-let chat_queue_load_error_fingerprint
-    (error : Keeper_chat_queue.snapshot_load_error) =
-  let path =
-    match error.path with
-    | Some path -> path
-    | None -> "<no-path>"
-  in
-  String.concat ":"
-    [ Keeper_chat_queue.snapshot_load_error_kind_to_string error.kind
-    ; path
-    ; error.message
-    ]
-
-let chat_queue_observation_fingerprint observation =
-  let persistence =
-    string_of_bool (Keeper_chat_queue.persistence_configured ())
-  in
-  match observation with
-  | Chat_queue_unavailable reason ->
-    String.concat ":" [ persistence; "unavailable"; reason ]
-  | Chat_queue_snapshot snapshot ->
-    String.concat ":"
-      [ persistence
-      ; Int64.to_string snapshot.revision
-      ; string_of_int (List.length snapshot.pending)
-      ; string_of_int (List.length snapshot.inflight)
-      ; snapshot.load_errors
-        |> List.map chat_queue_load_error_fingerprint
-        |> String.concat ","
-      ]
 
 let chat_queue_load_error_to_json
     (error : Keeper_chat_queue.snapshot_load_error) =
@@ -396,37 +326,20 @@ let json_string_opt_member = Json_util.get_string_nonempty
 let latest_metrics_json = Keeper_status_detail_observability.latest_metrics_json
 let model_observability_json = Keeper_status_detail_observability.model_observability_json
 
-(* TEL-OK: status handler — telemetry surfaces via the cache layer
-   ([_cache] mutex-protected reads/writes) and Otel_metric_store counters in
-   the downstream [Keeper_status_runtime]/[Keeper_status_bridge] calls. *)
+(* TEL-OK: status handler — telemetry surfaces through Otel_metric_store
+   counters in the downstream runtime and bridge calls. *)
 let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : string) args : tool_result =
-  match resolve_status_target_config ~config ~agent_name args with
+  match status_argument_fields args with
   | Error err -> tool_result_error err
-  | Ok (name, m) ->
-      (match status_options_of_args args with
+  | Ok fields ->
+      (match status_options_of_fields fields with
        | Error err -> tool_result_error err
        | Ok options ->
-      let cache_key = status_cache_key ~base_path:config.base_path ~name in
+      (match resolve_status_target_config ~config ~agent_name fields with
+       | Error err -> tool_result_error err
+       | Ok (name, m) ->
       let chat_queue_observation = observe_chat_queue ~keeper_name:m.name in
-      let cache_input =
-        { options
-        ; effective_meta_overlay_hash = effective_meta_overlay_hash m
-        ; chat_queue_fingerprint =
-            chat_queue_observation_fingerprint chat_queue_observation
-        }
-      in
-      (* Cache hit: same updated_at + same typed args/effective-meta input → return cached response.
-         The read is taken under [cache_mu] so it cannot interleave with
-         an eviction from [invalidate_status_cache_{for,all}]. *)
-      (match
-         Eio_guard.with_mutex_ro cache_mu (fun () ->
-           Hashtbl.find_opt _cache cache_key)
-       with
-       | Some entry
-         when entry.updated_at = m.updated_at
-           && entry.cache_input = cache_input ->
-         tool_result_ok_data entry.response
-       | _ ->
+      let chat_queue_status = chat_queue_status_to_json chat_queue_observation in
       let
         { tail_turns
         ; tail_messages
@@ -851,7 +764,7 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
            | other -> other
          in
          let chat_queue =
-           chat_queue_status_to_json chat_queue_observation
+           chat_queue_status
          in
 
          let json = `Assoc ([
@@ -1057,9 +970,6 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
                with Sys_error _ -> `List []);
            ]);
          ]) in
-         Eio_guard.with_mutex cache_mu (fun () ->
-           Hashtbl.replace _cache cache_key
-             { updated_at = m.updated_at; cache_input; response = json });
          tool_result_ok_data json))
 (* TEL-OK: 1-line delegate to ctx-free body. *)
 let handle_keeper_status (ctx : _ context) args = handle_keeper_status_config ~config:ctx.config ~agent_name:ctx.agent_name args

--- a/lib/keeper/keeper_status_detail.mli
+++ b/lib/keeper/keeper_status_detail.mli
@@ -1,18 +1,17 @@
 (** Single-keeper status detail handler.
 
-    Owns the [keeper_status] tool dispatch plus the response cache
-    that keeps the dashboard latency manageable. The list /
-    trajectory / eval handlers are in [Keeper_status]; this module
-    only handles the per-keeper detail view.
+    Owns the [keeper_status] tool dispatch. The list / trajectory / eval
+    handlers are in [Keeper_status]; this module only handles the per-keeper
+    detail view.
 
-    Selective .mli — internal helpers (cache hashtable + mutex,
-    [latest_metrics_json], [model_observability_json], the
+    Selective .mli — internal helpers ([latest_metrics_json],
+    [model_observability_json], the
     [resolve_status_target] dispatch helpers, etc.) stay private. *)
 
 type tool_result = Keeper_types_profile.tool_result
 
 (** Sort order for tail-window projections (metrics / trajectory). *)
-type tail_order =
+type tail_order = Keeper_status_options_defaults.tail_order =
   | Oldest_first
   | Newest_first
 
@@ -34,17 +33,9 @@ val valid_tail_order_strings : string list
     [Oldest_first], [List.rev] for [Newest_first]. *)
 val apply_tail_order : tail_order -> 'a list -> 'a list
 
-(** Drop the cache entry for a single keeper; called from any
-    state-change path that invalidates the cached snapshot. *)
-val invalidate_status_cache_for : string -> unit
-
-(** Drop the entire status cache; called on global state changes
-    (boot, mass reload). *)
-val invalidate_status_cache_all : unit -> unit
-
-(** [keeper_status] tool handler. Reads from the response cache
-    when the keeper's [updated_at] + args hash is unchanged;
-    otherwise rebuilds the snapshot and refreshes the cache. *)
+(** [keeper_status] tool handler. Builds a fresh observation so time-derived,
+    file-backed, registry, queue, and sandbox fields cannot be frozen behind
+    an incomplete cache identity. *)
 val handle_keeper_status :
   _ Keeper_types_profile.context -> Yojson.Safe.t -> tool_result
 

--- a/lib/keeper/keeper_status_detail.mli
+++ b/lib/keeper/keeper_status_detail.mli
@@ -17,8 +17,9 @@ type tail_order =
   | Newest_first
 
 (** Parse the [tail_order] argument from a tool-call JSON.
-    Defaults to [Oldest_first] for unknown / missing values. *)
-val tail_order_of_args : Yojson.Safe.t -> tail_order
+    Defaults to [Oldest_first] when missing and rejects values outside the
+    public schema enum. *)
+val tail_order_of_args : Yojson.Safe.t -> (tail_order, string) result
 
 val tail_order_to_string : tail_order -> string
 

--- a/lib/keeper/keeper_status_options_defaults.ml
+++ b/lib/keeper/keeper_status_options_defaults.ml
@@ -11,6 +11,19 @@ let min_tail_messages = 0
 let min_tail_compactions = 0
 let min_tail_bytes = 1_000
 
+(* A status request must not read more source bytes for one tail than the
+   process will publish for one tool result.  Count ceilings are derived from
+   that byte ceiling and the exact overscan factors used by the readers, so
+   the decoder cannot admit values that overflow the downstream products. *)
+let max_tail_bytes = Common.max_tool_output_bytes
+let metrics_lines_per_turn = 10
+let compaction_lines_per_event = 20
+let min_metrics_scan_lines = 400
+let min_compaction_scan_lines = 200
+let max_tail_turns = max_tail_bytes / metrics_lines_per_turn
+let max_tail_messages = max_tail_bytes
+let max_tail_compactions = max_tail_bytes / compaction_lines_per_event
+
 type tail_order =
   | Oldest_first
   | Newest_first
@@ -21,6 +34,11 @@ let tail_order_to_string = function
 
 let all_tail_orders = [ Oldest_first; Newest_first ]
 let valid_tail_order_strings = List.map tail_order_to_string all_tail_orders
+
+let tail_order_of_string value =
+  List.find_opt
+    (fun order -> String.equal value (tail_order_to_string order))
+    all_tail_orders
 
 module Argument = struct
   let name = "name"

--- a/lib/keeper/keeper_status_options_defaults.ml
+++ b/lib/keeper/keeper_status_options_defaults.ml
@@ -1,0 +1,9 @@
+(** Canonical defaults and limits for [masc_keeper_status] tail options.
+    Shared by runtime parsing and the public tool schema so the advertised
+    contract cannot drift from execution. *)
+
+let tail_turns = 3
+let tail_messages = 5
+let tail_compactions = 10
+let tail_bytes = 60_000
+let min_tail_bytes = 1_000

--- a/lib/keeper/keeper_status_options_defaults.ml
+++ b/lib/keeper/keeper_status_options_defaults.ml
@@ -1,4 +1,4 @@
-(** Canonical defaults and limits for [masc_keeper_status] tail options.
+(** Canonical defaults, limits, and field names for [masc_keeper_status].
     Shared by runtime parsing and the public tool schema so the advertised
     contract cannot drift from execution. *)
 
@@ -6,4 +6,48 @@ let tail_turns = 3
 let tail_messages = 5
 let tail_compactions = 10
 let tail_bytes = 60_000
+let min_tail_turns = 0
+let min_tail_messages = 0
+let min_tail_compactions = 0
 let min_tail_bytes = 1_000
+
+type tail_order =
+  | Oldest_first
+  | Newest_first
+
+let tail_order_to_string = function
+  | Oldest_first -> "oldest_first"
+  | Newest_first -> "newest_first"
+
+let all_tail_orders = [ Oldest_first; Newest_first ]
+let valid_tail_order_strings = List.map tail_order_to_string all_tail_orders
+
+module Argument = struct
+  let name = "name"
+  let tail_turns = "tail_turns"
+  let tail_messages = "tail_messages"
+  let tail_compactions = "tail_compactions"
+  let tail_bytes = "tail_bytes"
+  let tail_order = "tail_order"
+  let fast = "fast"
+  let include_context = "include_context"
+  let include_metrics_overview = "include_metrics_overview"
+  let include_memory_bank = "include_memory_bank"
+  let include_history_tail = "include_history_tail"
+  let include_compaction_history = "include_compaction_history"
+
+  let all =
+    [ name
+    ; tail_turns
+    ; tail_messages
+    ; tail_compactions
+    ; tail_bytes
+    ; tail_order
+    ; fast
+    ; include_context
+    ; include_metrics_overview
+    ; include_memory_bank
+    ; include_history_tail
+    ; include_compaction_history
+    ]
+end

--- a/lib/keeper/keeper_status_options_defaults.mli
+++ b/lib/keeper/keeper_status_options_defaults.mli
@@ -1,0 +1,7 @@
+(** Canonical defaults and limits for [masc_keeper_status] tail options. *)
+
+val tail_turns : int
+val tail_messages : int
+val tail_compactions : int
+val tail_bytes : int
+val min_tail_bytes : int

--- a/lib/keeper/keeper_status_options_defaults.mli
+++ b/lib/keeper/keeper_status_options_defaults.mli
@@ -1,7 +1,34 @@
-(** Canonical defaults and limits for [masc_keeper_status] tail options. *)
+(** Canonical defaults, limits, and field names for [masc_keeper_status]. *)
 
 val tail_turns : int
 val tail_messages : int
 val tail_compactions : int
 val tail_bytes : int
+val min_tail_turns : int
+val min_tail_messages : int
+val min_tail_compactions : int
 val min_tail_bytes : int
+
+type tail_order =
+  | Oldest_first
+  | Newest_first
+
+val tail_order_to_string : tail_order -> string
+val all_tail_orders : tail_order list
+val valid_tail_order_strings : string list
+
+module Argument : sig
+  val name : string
+  val tail_turns : string
+  val tail_messages : string
+  val tail_compactions : string
+  val tail_bytes : string
+  val tail_order : string
+  val fast : string
+  val include_context : string
+  val include_metrics_overview : string
+  val include_memory_bank : string
+  val include_history_tail : string
+  val include_compaction_history : string
+  val all : string list
+end

--- a/lib/keeper/keeper_status_options_defaults.mli
+++ b/lib/keeper/keeper_status_options_defaults.mli
@@ -8,6 +8,14 @@ val min_tail_turns : int
 val min_tail_messages : int
 val min_tail_compactions : int
 val min_tail_bytes : int
+val max_tail_turns : int
+val max_tail_messages : int
+val max_tail_compactions : int
+val max_tail_bytes : int
+val metrics_lines_per_turn : int
+val compaction_lines_per_event : int
+val min_metrics_scan_lines : int
+val min_compaction_scan_lines : int
 
 type tail_order =
   | Oldest_first
@@ -16,6 +24,7 @@ type tail_order =
 val tail_order_to_string : tail_order -> string
 val all_tail_orders : tail_order list
 val valid_tail_order_strings : string list
+val tail_order_of_string : string -> tail_order option
 
 module Argument : sig
   val name : string

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -326,7 +326,6 @@ let keeper_sandbox_start_body ~(config : Workspace.config) args : tool_result =
            with
            | Error err -> tool_result_error err
            | Ok result ->
-               invalidate_status_cache meta.name;
                tool_result_ok_data
                  (`Assoc
                     [
@@ -368,9 +367,6 @@ let keeper_sandbox_stop_body ~(config : Workspace.config) args : tool_result =
         else
           None
       in
-      (match keeper_name with
-       | Some name -> invalidate_status_cache name
-       | None -> Keeper_status_detail.invalidate_status_cache_all ());
       let stop_json =
         `Assoc
           [
@@ -682,7 +678,6 @@ let keeper_clear_body ~(config : Workspace.config) args : tool_result =
       (* Clear registry failure state *)
       Keeper_registry.set_failure_reason ~base_path:config.base_path name None;
       Keeper_registry.reset_turn_failures ~base_path:config.base_path name;
-      invalidate_status_cache name;
       Log.Keeper.warn
         "%s: context cleared by operator (reason=%s, preserve_system=%b, cleared=%d msgs)"
         name reason preserve_system cleared_count;
@@ -975,8 +970,6 @@ let () =
          in
          run_external_effect (fun () ->
            Keeper_tool_surface_ops.invalidate_keeper_list_cache ();
-           Keeper_tool_surface_ops.invalidate_status_cache
-             (Tool_args.get_string args "name" "");
            Some
              (tool_result_with_tool_name
                 ~tool_name:name

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -616,7 +616,6 @@ let submit_keeper_invocation
       ctx
       ~request
   =
-  let name = Keeper_invocation_contract.target_name request in
   match
     let* background_sw =
       Keeper_msg_async.server_background_switch ()

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -188,7 +188,6 @@ let maybe_reseed_keeper_identity_config ~(config : Workspace.config) (meta : kee
             "failed to persist reseeded keeper identity for %s: %s"
             meta.name err)
     in
-    Keeper_status_detail.invalidate_status_cache_for updated_meta.name;
     Ok
       ( updated_meta,
         Some
@@ -255,8 +254,6 @@ let execute_keeper_up ctx args : tool_result =
         | None -> json
       in
       invalidate_keeper_list_cache ();
-      Keeper_status_detail.invalidate_status_cache_for
-        (get_string prepared_args "name" "");
       Ok (tool_result_ok_data (annotate_keeper_json ~runtime_class:"keeper" json))
   with
   | Ok result -> result
@@ -354,8 +351,6 @@ let keeper_list_row_json ~runtime_class config name =
             ("runtime_id", `String (Keeper_meta_contract.runtime_id_of_meta meta));
             ("created_at", `String meta.created_at); ("updated_at", `String meta.updated_at);
           ]))
-let invalidate_status_cache name =
-  Keeper_status_detail.invalidate_status_cache_for name
 let with_keeper_name args name =
   match args with
   | `Assoc fields ->
@@ -459,7 +454,6 @@ let handle_keeper_create_from_persona ctx args : tool_result =
               ]
           in
           invalidate_keeper_list_cache ();
-          invalidate_status_cache (get_string resolved_args "name" "");
           Ok (tool_result_ok_data json)
     with
     | Ok result -> result
@@ -639,10 +633,7 @@ let submit_keeper_invocation
           let worker_ctx = { ctx with sw = request_sw } in
           let result = run_turn ?event_bus request worker_ctx in
           if tool_result_success result
-          then begin
-            invalidate_keeper_list_cache ();
-            invalidate_status_cache name
-          end;
+          then invalidate_keeper_list_cache ();
           result)
         ()
       |> Result.map_error (fun error ->
@@ -839,11 +830,10 @@ let keeper_delegate_list_body ~(config : Workspace.config) ~caller args =
     tool_result_error_data (Keeper_msg_async.access_rejection_to_json rejection)
 ;;
 
-let complete_keeper_msg_stream_result ~name result =
+let complete_keeper_msg_stream_result result =
   if not (tool_result_success result) then result
   else begin
     invalidate_keeper_list_cache ();
-    invalidate_status_cache name;
     tool_result_ok_data
       (annotate_keeper_json ~runtime_class:"keeper" (Tool_result.data result))
   end
@@ -875,7 +865,7 @@ let handle_keeper_msg_stream
         ctx
         resolved_args
     in
-    complete_keeper_msg_stream_result ~name result
+    complete_keeper_msg_stream_result result
   in
   match resolve_keeper_name ctx args with
   | Ok name -> run name
@@ -928,7 +918,7 @@ let handle_keeper_msg_stream_if_free
      with
      | `Busy rejection -> `Busy rejection
      | `Ran result ->
-       `Ran (complete_keeper_msg_stream_result ~name result))
+       `Ran (complete_keeper_msg_stream_result result))
 (* RFC-0182 §3.1 — ctx-free body for keeper_dispatch_ref path. *)
 let resolve_keeper_meta_config ~(config : Workspace.config) args =
   let name = String.trim (get_string args "name" "") in
@@ -945,5 +935,4 @@ let resolve_keeper_meta ctx args =
 
 let handle_keeper_down ctx args : tool_result =
   invalidate_keeper_list_cache ();
-  invalidate_status_cache (get_string args "name" "");
   Turn.handle_keeper_down ctx args

--- a/lib/keeper/keeper_turn_helpers.ml
+++ b/lib/keeper/keeper_turn_helpers.ml
@@ -324,8 +324,6 @@ let record_pre_dispatch_terminal_observation
       false
   in
   if receipt_append_ok then
-    Keeper_status_detail.invalidate_status_cache_for meta.name;
-  if receipt_append_ok then
     append_manifest
       ~site:"pre_dispatch_receipt_appended"
       Keeper_runtime_manifest.Receipt_appended;

--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -50,43 +50,6 @@ let required_names schema =
   | _ -> []
 ;;
 
-let has_enum schema =
-  match Json_util.assoc_member_opt "enum" schema with
-  | Some (`List (_ :: _)) -> true
-  | _ -> false
-;;
-
-let optional_enum_fields schema =
-  let required = required_names schema in
-  match Json_util.assoc_member_opt "properties" schema with
-  | Some (`Assoc props) ->
-    List.filter_map
-      (fun (name, prop_schema) ->
-         if (not (List.mem name required)) && has_enum prop_schema
-         then Some name
-         else None)
-      props
-  | _ -> []
-;;
-
-let normalize_blank_optional_enum_args ?schema args =
-  match schema, args with
-  | Some schema, `Assoc fields ->
-    let optional_enums = optional_enum_fields schema in
-    if optional_enums = []
-    then args
-    else
-      `Assoc
-        (List.filter
-           (fun (key, value) ->
-              match value with
-              | `String raw when List.mem key optional_enums && String.trim raw = "" ->
-                false
-              | _ -> true)
-           fields)
-  | _ -> args
-;;
-
 let schema_property_names schema =
   match Json_util.assoc_member_opt "properties" schema with
   | Some (`Assoc props) -> List.map fst props
@@ -221,10 +184,7 @@ let schema_shape_json schema =
 
 let schema_has_property_name schema name = List.mem name (schema_property_names schema)
 
-let prepare_args ?schema ~name:_ args =
-  let args = strip_internal_marker_args args in
-  normalize_blank_optional_enum_args ?schema args
-;;
+let prepare_args ?schema:_ ~name:_ args = strip_internal_marker_args args
 
 let schema_has_properties = function
   | `Assoc fields ->

--- a/test/test_keeper_effective_meta_overlay.ml
+++ b/test/test_keeper_effective_meta_overlay.ml
@@ -193,6 +193,17 @@ let status_json_with ?(agent_name = "test-agent") ?name config =
     Alcotest.failf "status failed: %s" (Profile.tool_result_body result);
   Yojson.Safe.from_string (Profile.tool_result_body result)
 
+let status_json_with_args config args =
+  let result =
+    Status_detail.handle_keeper_status_config
+      ~config
+      ~agent_name:"test-agent"
+      args
+  in
+  if not (Profile.tool_result_success result) then
+    Alcotest.failf "status failed: %s" (Profile.tool_result_body result);
+  Yojson.Safe.from_string (Profile.tool_result_body result)
+
 let resolved_keeper_name config name =
   match
     Keeper_tool_surface_ops.resolve_keeper_name_config
@@ -590,6 +601,75 @@ let test_status_cache_tracks_toml_overlay_changes () =
     "second cache instructions after toml edit"
     (status_instructions config name)
 
+let test_status_cache_distinguishes_normalized_options () =
+  with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir ->
+  let name = "status-options-cache" in
+  write_keeper_toml ~keepers_dir ~name ~sandbox_profile:"local"
+    ~instructions:"normalized status options";
+  let config = Workspace.default_config base in
+  ignore (seed_runtime_meta config name : Masc.Keeper_meta_contract.keeper_meta);
+  Status_detail.invalidate_status_cache_all ();
+  let common_fields =
+    [ "name", `String name
+    ; "fast", `Bool false
+    ; "include_metrics_overview", `Bool false
+    ; "include_memory_bank", `Bool false
+    ; "include_history_tail", `Bool false
+    ; "include_compaction_history", `Bool false
+    ]
+  in
+  let context_enabled = status_json_with_args config (`Assoc common_fields) in
+  Alcotest.(check (option bool))
+    "derived include_context default is true"
+    (Some true)
+    (json_assoc_field "status_options" context_enabled
+     |> json_bool_field "include_context");
+  let context_disabled =
+    status_json_with_args config
+      (`Assoc (("include_context", `Bool false) :: common_fields))
+  in
+  Alcotest.(check (option bool))
+    "explicit include_context false is not served from the prior cache entry"
+    (Some false)
+    (json_assoc_field "status_options" context_disabled
+     |> json_bool_field "include_context");
+  Alcotest.(check (option bool))
+    "disabled context is observable"
+    (Some true)
+    (json_assoc_field "context" context_disabled |> json_bool_field "skipped");
+  let first_window =
+    status_json_with_args config
+      (`Assoc
+        [ "name", `String name
+        ; "fast", `Bool true
+        ; "tail_compactions", `Int 1
+        ; "tail_bytes", `Int 1
+        ])
+  in
+  let first_options = json_assoc_field "status_options" first_window in
+  Alcotest.(check (option int))
+    "tail bytes clamp is observable"
+    (Some 1_000)
+    (json_int_field "tail_bytes" first_options);
+  let second_window =
+    status_json_with_args config
+      (`Assoc
+        [ "name", `String name
+        ; "fast", `Bool true
+        ; "tail_compactions", `Int 7
+        ; "tail_bytes", `Int 8_000
+        ])
+  in
+  let second_options = json_assoc_field "status_options" second_window in
+  Alcotest.(check (option int))
+    "tail compaction window participates in cache identity"
+    (Some 7)
+    (json_int_field "tail_compactions" second_options);
+  Alcotest.(check (option int))
+    "tail byte window participates in cache identity"
+    (Some 8_000)
+    (json_int_field "tail_bytes" second_options)
+
 let test_status_surfaces_chat_queue_runtime () =
   with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir ->
   let name = "chatqueue-status" in
@@ -807,6 +887,8 @@ let () =
             `Quick test_missing_profile_source_fails_loud;
           Alcotest.test_case "status cache tracks TOML overlay edits" `Quick
             test_status_cache_tracks_toml_overlay_changes;
+          Alcotest.test_case "status cache distinguishes normalized options"
+            `Quick test_status_cache_distinguishes_normalized_options;
           Alcotest.test_case "status surfaces chat queue runtime" `Quick
             test_status_surfaces_chat_queue_runtime;
           Alcotest.test_case "keeper list surfaces effective meta errors"

--- a/test/test_keeper_effective_meta_overlay.ml
+++ b/test/test_keeper_effective_meta_overlay.ml
@@ -755,6 +755,22 @@ let test_status_rejects_malformed_options () =
     (`Assoc [ "name", `String name; "tail_turns", `Int (-1) ])
     "tail_turns\" must be at least";
   check_rejected
+    "tail turns above schema maximum"
+    (`Assoc
+      [ "name", `String name
+      ; ( "tail_turns"
+        , `Int (Masc.Keeper_status_options_defaults.max_tail_turns + 1) )
+      ])
+    "tail_turns\" must be at most";
+  check_rejected
+    "tail bytes above schema maximum"
+    (`Assoc
+      [ "name", `String name
+      ; ( "tail_bytes"
+        , `Int (Masc.Keeper_status_options_defaults.max_tail_bytes + 1) )
+      ])
+    "tail_bytes\" must be at most";
+  check_rejected
     "string tail messages"
     (`Assoc [ "name", `String name; "tail_messages", `String "10" ])
     "tail_messages\" must be an integer";
@@ -795,6 +811,13 @@ let test_status_rejects_malformed_options () =
     (`Assoc
       [ "name", `String name
       ; "tail_order", `String " "
+      ])
+    "invalid tail_order";
+  check_rejected
+    "padded tail order"
+    (`Assoc
+      [ "name", `String name
+      ; "tail_order", `String " oldest_first "
       ])
     "invalid tail_order"
 
@@ -841,7 +864,28 @@ let test_status_schema_tracks_argument_contract () =
   Alcotest.(check (list string))
     "tail order schema follows the typed variants"
     Status_detail.valid_tail_order_strings
-    tail_order_values
+    tail_order_values;
+  let properties =
+    match json_field "properties" schema.input_schema with
+    | Some (`Assoc fields) -> fields
+    | _ -> []
+  in
+  let schema_maximum argument =
+    match List.assoc_opt argument properties with
+    | Some (`Assoc fields) ->
+        (match List.assoc_opt "maximum" fields with
+         | Some (`Int value) -> Some value
+         | _ -> None)
+    | _ -> None
+  in
+  Alcotest.(check (option int))
+    "tail turns schema maximum follows runtime SSOT"
+    (Some Status_options_defaults.max_tail_turns)
+    (schema_maximum Status_options_defaults.Argument.tail_turns);
+  Alcotest.(check (option int))
+    "tail bytes schema maximum follows runtime SSOT"
+    (Some Status_options_defaults.max_tail_bytes)
+    (schema_maximum Status_options_defaults.Argument.tail_bytes)
 
 let test_status_tracks_persisted_meta_without_updated_at () =
   with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir ->

--- a/test/test_keeper_effective_meta_overlay.ml
+++ b/test/test_keeper_effective_meta_overlay.ml
@@ -1,7 +1,9 @@
 module Workspace = Masc.Workspace
 module Store = Masc.Keeper_meta_store
 module Profile = Masc.Keeper_types_profile
+module Keeper_schema = Masc.Keeper_schema
 module Status_detail = Masc.Keeper_status_detail
+module Status_options_defaults = Masc.Keeper_status_options_defaults
 module Turn_setup = Masc.Keeper_turn_setup
 module Turn = Masc.Keeper_turn
 module Keeper_tool_surface = Masc.Keeper_tool_surface
@@ -589,7 +591,7 @@ let test_missing_profile_source_fails_loud () =
         true
         (contains_substring ~needle:"sandbox_profile is required" err)
 
-let test_status_cache_tracks_toml_overlay_changes () =
+let test_status_tracks_toml_overlay_changes () =
   with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir ->
   let name = "statuscache" in
   write_keeper_toml ~keepers_dir ~name ~sandbox_profile:"local"
@@ -607,14 +609,13 @@ let test_status_cache_tracks_toml_overlay_changes () =
     "second cache instructions after toml edit"
     (status_instructions config name)
 
-let test_status_cache_distinguishes_normalized_options () =
+let test_status_reports_normalized_options () =
   with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir ->
   let name = "status-options-cache" in
   write_keeper_toml ~keepers_dir ~name ~sandbox_profile:"local"
     ~instructions:"normalized status options";
   let config = Workspace.default_config base in
   ignore (seed_runtime_meta config name : Masc.Keeper_meta_contract.keeper_meta);
-  Status_detail.invalidate_status_cache_all ();
   let common_fields =
     [ "name", `String name
     ; "fast", `Bool false
@@ -652,7 +653,7 @@ let test_status_cache_distinguishes_normalized_options () =
       (`Assoc (("include_context", `Bool false) :: common_fields))
   in
   Alcotest.(check (option bool))
-    "explicit include_context false is not served from the prior cache entry"
+    "explicit include_context false is reported"
     (Some false)
     (json_assoc_field "status_options" context_disabled
      |> json_bool_field "include_context");
@@ -666,13 +667,14 @@ let test_status_cache_distinguishes_normalized_options () =
         [ "name", `String name
         ; "fast", `Bool true
         ; "tail_compactions", `Int 1
-        ; "tail_bytes", `Int 1
+        ; ( "tail_bytes"
+          , `Int Masc.Keeper_status_options_defaults.min_tail_bytes )
         ])
   in
   let first_options = json_assoc_field "status_options" first_window in
   Alcotest.(check (option int))
-    "tail bytes clamp is observable"
-    (Some 1_000)
+    "minimum tail bytes is preserved"
+    (Some Masc.Keeper_status_options_defaults.min_tail_bytes)
     (json_int_field "tail_bytes" first_options);
   let second_window =
     status_json_with_args config
@@ -685,11 +687,11 @@ let test_status_cache_distinguishes_normalized_options () =
   in
   let second_options = json_assoc_field "status_options" second_window in
   Alcotest.(check (option int))
-    "tail compaction window participates in cache identity"
+    "tail compaction window is reported"
     (Some 7)
     (json_int_field "tail_compactions" second_options);
   Alcotest.(check (option int))
-    "tail byte window participates in cache identity"
+    "tail byte window is reported"
     (Some 8_000)
     (json_int_field "tail_bytes" second_options)
 
@@ -719,14 +721,135 @@ let test_status_rejects_tail_order_outside_schema () =
        ~needle:"allowed: oldest_first, newest_first"
        (Profile.tool_result_body result))
 
-let test_status_cache_tracks_persisted_meta_without_updated_at () =
+let test_status_rejects_malformed_options () =
+  with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir ->
+  let name = "status-malformed-options" in
+  write_keeper_toml
+    ~keepers_dir
+    ~name
+    ~sandbox_profile:"local"
+    ~instructions:"strict status options";
+  let config = Workspace.default_config base in
+  ignore (seed_runtime_meta config name : Masc.Keeper_meta_contract.keeper_meta);
+  let check_rejected label args needle =
+    let result = status_result_with_args config args in
+    Alcotest.(check bool)
+      (label ^ " fails")
+      false
+      (Profile.tool_result_success result);
+    Alcotest.(check bool)
+      (label ^ " explains the rejected field")
+      true
+      (contains_substring ~needle (Profile.tool_result_body result))
+  in
+  check_rejected
+    "tail bytes below schema minimum"
+    (`Assoc
+      [ "name", `String name
+      ; ( "tail_bytes"
+        , `Int (Masc.Keeper_status_options_defaults.min_tail_bytes - 1) )
+      ])
+    "tail_bytes\" must be at least";
+  check_rejected
+    "negative tail turns"
+    (`Assoc [ "name", `String name; "tail_turns", `Int (-1) ])
+    "tail_turns\" must be at least";
+  check_rejected
+    "string tail messages"
+    (`Assoc [ "name", `String name; "tail_messages", `String "10" ])
+    "tail_messages\" must be an integer";
+  check_rejected
+    "integer fast flag"
+    (`Assoc [ "name", `String name; "fast", `Int 1 ])
+    "fast\" must be a boolean";
+  check_rejected
+    "non-string tail order"
+    (`Assoc [ "name", `String name; "tail_order", `Bool true ])
+    "tail_order\" must be a string";
+  check_rejected
+    "non-string keeper name"
+    (`Assoc [ "name", `Int 7 ])
+    "name\" must be a string";
+  check_rejected
+    "non-object arguments"
+    (`List [])
+    "must be a JSON object";
+  check_rejected
+    "unknown argument"
+    (`Assoc [ "name", `String name; "mystery", `Bool true ])
+    "unknown keeper_status argument \"mystery\"";
+  check_rejected
+    "duplicate known argument"
+    (`Assoc
+      [ "name", `String name
+      ; "fast", `Bool true
+      ; "fast", `Bool false
+      ])
+    "argument \"fast\" must occur at most once";
+  check_rejected
+    "blank keeper name"
+    (`Assoc [ "name", `String " " ])
+    "argument \"name\" must not be blank";
+  check_rejected
+    "blank tail order"
+    (`Assoc
+      [ "name", `String name
+      ; "tail_order", `String " "
+      ])
+    "invalid tail_order"
+
+let test_status_schema_tracks_argument_contract () =
+  let schema =
+    List.find_opt
+      (fun (schema : Masc_domain.tool_schema) ->
+        String.equal schema.name "masc_keeper_status")
+      Keeper_schema.keeper_schemas
+    |> Option.get
+  in
+  let properties =
+    match json_field "properties" schema.input_schema with
+    | Some (`Assoc fields) -> List.map fst fields
+    | _ -> Alcotest.fail "keeper_status schema has no object properties"
+  in
+  Alcotest.(check (list string))
+    "schema properties use the runtime argument SSOT"
+    (List.sort String.compare Status_options_defaults.Argument.all)
+    (List.sort String.compare properties);
+  Alcotest.(check (option bool))
+    "schema rejects unknown properties"
+    (Some false)
+    (json_bool_field "additionalProperties" schema.input_schema);
+  let tail_order_values =
+    match
+      List.assoc_opt
+        Status_options_defaults.Argument.tail_order
+        (match json_field "properties" schema.input_schema with
+         | Some (`Assoc fields) -> fields
+         | _ -> [])
+    with
+    | Some (`Assoc fields) ->
+        (match List.assoc_opt "enum" fields with
+         | Some (`List values) ->
+             List.filter_map
+               (function
+                 | `String value -> Some value
+                 | _ -> None)
+               values
+         | _ -> [])
+    | _ -> []
+  in
+  Alcotest.(check (list string))
+    "tail order schema follows the typed variants"
+    Status_detail.valid_tail_order_strings
+    tail_order_values
+
+let test_status_tracks_persisted_meta_without_updated_at () =
   with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir ->
   let name = "status-persisted-meta-cache" in
   write_keeper_toml ~keepers_dir ~name ~sandbox_profile:"local"
     ~instructions:"persisted meta cache";
   let config = Workspace.default_config base in
   let meta = seed_runtime_meta config name in
-  Status_detail.invalidate_status_cache_all ();
   let initial = status_json_with ~name config in
   Alcotest.(check (option bool))
     "initial status is active"
@@ -738,9 +861,49 @@ let test_status_cache_tracks_persisted_meta_without_updated_at () =
     (Masc.Keeper_meta_json.meta_to_json paused |> Yojson.Safe.to_string);
   let refreshed = status_json_with ~name config in
   Alcotest.(check (option bool))
-    "persisted paused change invalidates cache without updated_at change"
+    "persisted paused change is observed without updated_at change"
     (Some true)
     (json_assoc_field "meta" refreshed |> json_bool_field "paused")
+
+let test_status_reads_live_registry_each_call () =
+  with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir ->
+  let name = "status-live-registry" in
+  write_keeper_toml
+    ~keepers_dir
+    ~name
+    ~sandbox_profile:"local"
+    ~instructions:"live registry observation";
+  let config = Workspace.default_config base in
+  let meta = seed_runtime_meta config name in
+  Masc.Keeper_registry.clear ();
+  Fun.protect
+    ~finally:Masc.Keeper_registry.clear
+    (fun () ->
+      ignore
+        (Masc.Keeper_registry.register
+           ~base_path:config.base_path
+           name
+           meta);
+      let status () =
+        status_json_with_args config
+          (`Assoc [ "name", `String name; "fast", `Bool true ])
+      in
+      Masc.Keeper_registry.set_last_error_entry
+        ~base_path:config.base_path
+        ~name
+        "first live error";
+      Alcotest.(check (option string))
+        "first registry observation"
+        (Some "first live error")
+        (json_string_field "sandbox_last_error" (status ()));
+      Masc.Keeper_registry.set_last_error_entry
+        ~base_path:config.base_path
+        ~name
+        "second live error";
+      Alcotest.(check (option string))
+        "second registry observation is not frozen by a response cache"
+        (Some "second live error")
+        (json_string_field "sandbox_last_error" (status ())))
 
 let test_status_surfaces_chat_queue_runtime () =
   with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir ->
@@ -957,15 +1120,20 @@ let () =
           Alcotest.test_case
             "missing profile source fails loudly"
             `Quick test_missing_profile_source_fails_loud;
-          Alcotest.test_case "status cache tracks TOML overlay edits" `Quick
-            test_status_cache_tracks_toml_overlay_changes;
-          Alcotest.test_case "status cache distinguishes normalized options"
-            `Quick test_status_cache_distinguishes_normalized_options;
+          Alcotest.test_case "status tracks TOML overlay edits" `Quick
+            test_status_tracks_toml_overlay_changes;
+          Alcotest.test_case "status reports normalized options"
+            `Quick test_status_reports_normalized_options;
           Alcotest.test_case "status rejects tail order outside schema" `Quick
             test_status_rejects_tail_order_outside_schema;
-          Alcotest.test_case
-            "status cache tracks persisted meta without updated_at" `Quick
-            test_status_cache_tracks_persisted_meta_without_updated_at;
+          Alcotest.test_case "status rejects malformed options" `Quick
+            test_status_rejects_malformed_options;
+          Alcotest.test_case "status schema tracks argument contract" `Quick
+            test_status_schema_tracks_argument_contract;
+          Alcotest.test_case "status tracks persisted meta without updated_at"
+            `Quick test_status_tracks_persisted_meta_without_updated_at;
+          Alcotest.test_case "status reads live registry each call" `Quick
+            test_status_reads_live_registry_each_call;
           Alcotest.test_case "status surfaces chat queue runtime" `Quick
             test_status_surfaces_chat_queue_runtime;
           Alcotest.test_case "keeper list surfaces effective meta errors"

--- a/test/test_keeper_effective_meta_overlay.ml
+++ b/test/test_keeper_effective_meta_overlay.ml
@@ -204,6 +204,12 @@ let status_json_with_args config args =
     Alcotest.failf "status failed: %s" (Profile.tool_result_body result);
   Yojson.Safe.from_string (Profile.tool_result_body result)
 
+let status_result_with_args config args =
+  Status_detail.handle_keeper_status_config
+    ~config
+    ~agent_name:"test-agent"
+    args
+
 let resolved_keeper_name config name =
   match
     Keeper_tool_surface_ops.resolve_keeper_name_config
@@ -619,6 +625,23 @@ let test_status_cache_distinguishes_normalized_options () =
     ]
   in
   let context_enabled = status_json_with_args config (`Assoc common_fields) in
+  let default_options = json_assoc_field "status_options" context_enabled in
+  Alcotest.(check (option int))
+    "tail turns runtime default"
+    (Some Masc.Keeper_status_options_defaults.tail_turns)
+    (json_int_field "tail_turns" default_options);
+  Alcotest.(check (option int))
+    "tail messages runtime default"
+    (Some Masc.Keeper_status_options_defaults.tail_messages)
+    (json_int_field "tail_messages" default_options);
+  Alcotest.(check (option int))
+    "tail compactions runtime default"
+    (Some Masc.Keeper_status_options_defaults.tail_compactions)
+    (json_int_field "tail_compactions" default_options);
+  Alcotest.(check (option int))
+    "tail bytes runtime default"
+    (Some Masc.Keeper_status_options_defaults.tail_bytes)
+    (json_int_field "tail_bytes" default_options);
   Alcotest.(check (option bool))
     "derived include_context default is true"
     (Some true)
@@ -669,6 +692,55 @@ let test_status_cache_distinguishes_normalized_options () =
     "tail byte window participates in cache identity"
     (Some 8_000)
     (json_int_field "tail_bytes" second_options)
+
+let test_status_rejects_tail_order_outside_schema () =
+  with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir ->
+  let name = "status-tail-order" in
+  write_keeper_toml ~keepers_dir ~name ~sandbox_profile:"local"
+    ~instructions:"strict tail order";
+  let config = Workspace.default_config base in
+  ignore (seed_runtime_meta config name : Masc.Keeper_meta_contract.keeper_meta);
+  let result =
+    status_result_with_args config
+      (`Assoc
+        [ "name", `String name
+        ; "fast", `Bool true
+        ; "tail_order", `String "desc"
+        ])
+  in
+  Alcotest.(check bool)
+    "unadvertised alias is rejected"
+    false
+    (Profile.tool_result_success result);
+  Alcotest.(check bool)
+    "error names exact allowed values"
+    true
+    (contains_substring
+       ~needle:"allowed: oldest_first, newest_first"
+       (Profile.tool_result_body result))
+
+let test_status_cache_tracks_persisted_meta_without_updated_at () =
+  with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir ->
+  let name = "status-persisted-meta-cache" in
+  write_keeper_toml ~keepers_dir ~name ~sandbox_profile:"local"
+    ~instructions:"persisted meta cache";
+  let config = Workspace.default_config base in
+  let meta = seed_runtime_meta config name in
+  Status_detail.invalidate_status_cache_all ();
+  let initial = status_json_with ~name config in
+  Alcotest.(check (option bool))
+    "initial status is active"
+    (Some false)
+    (json_assoc_field "meta" initial |> json_bool_field "paused");
+  let paused = { meta with paused = true } in
+  write_file
+    (Profile.keeper_meta_path config name)
+    (Masc.Keeper_meta_json.meta_to_json paused |> Yojson.Safe.to_string);
+  let refreshed = status_json_with ~name config in
+  Alcotest.(check (option bool))
+    "persisted paused change invalidates cache without updated_at change"
+    (Some true)
+    (json_assoc_field "meta" refreshed |> json_bool_field "paused")
 
 let test_status_surfaces_chat_queue_runtime () =
   with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir ->
@@ -889,6 +961,11 @@ let () =
             test_status_cache_tracks_toml_overlay_changes;
           Alcotest.test_case "status cache distinguishes normalized options"
             `Quick test_status_cache_distinguishes_normalized_options;
+          Alcotest.test_case "status rejects tail order outside schema" `Quick
+            test_status_rejects_tail_order_outside_schema;
+          Alcotest.test_case
+            "status cache tracks persisted meta without updated_at" `Quick
+            test_status_cache_tracks_persisted_meta_without_updated_at;
           Alcotest.test_case "status surfaces chat queue runtime" `Quick
             test_status_surfaces_chat_queue_runtime;
           Alcotest.test_case "keeper list surfaces effective meta errors"

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -1445,7 +1445,7 @@ let test_registered_hook_transition_strips_internal_agent_marker () =
   Alcotest.(check string) "agent_name preserved" "codex-local-admin"
     (assoc_string "agent_name" forwarded)
 
-let test_registered_hook_goal_list_strips_blank_optional_enums () =
+let test_registered_hook_goal_list_preserves_blank_optional_enums () =
   let args =
     `Assoc
       [
@@ -1460,8 +1460,10 @@ let test_registered_hook_goal_list_strips_blank_optional_enums () =
       ()
   in
   Alcotest.(check bool) "not blocked" true (Option.is_none blocked);
-  Alcotest.(check bool) "phase removed" true
-    (Yojson.Safe.Util.member "phase" forwarded = `Null)
+  Alcotest.(check string)
+    "blank phase reaches the owning handler for explicit rejection"
+    " "
+    (assoc_string "phase" forwarded)
 
 let test_registered_hook_goal_list_rejects_status_filter () =
   let args = `Assoc [ ("status", `String "active") ] in
@@ -2064,8 +2066,8 @@ let () =
         test_registered_hook_transition_preserves_canonical_action;
       Alcotest.test_case "masc_transition strips internal markers" `Quick
         test_registered_hook_transition_strips_internal_agent_marker;
-      Alcotest.test_case "masc_goal_list strips blank optional enum filters"
-        `Quick test_registered_hook_goal_list_strips_blank_optional_enums;
+      Alcotest.test_case "masc_goal_list preserves blank optional enum filters"
+        `Quick test_registered_hook_goal_list_preserves_blank_optional_enums;
       Alcotest.test_case "masc_goal_list rejects status filter" `Quick
         test_registered_hook_goal_list_rejects_status_filter;
       Alcotest.test_case "masc_goal_list preserves invalid enum filters" `Quick


### PR DESCRIPTION
## Outcome

Deletes the stale whole-response cache from `masc_keeper_status` and makes every call a fresh observation of registry, persisted metadata, files, metrics, queue, time-derived fields, and sandbox state.

The cache had no exact revision identity for all response dependencies. Keeping it would require arbitrary TTLs or incomplete fingerprints, both of which can return false runtime truth. This PR removes that legacy path instead of adding another heuristic invalidation layer.

It also closes the status input contract:

- one typed SSOT for defaults, minima, argument names, and tail-order values
- strict object decoding with explicit errors for unknown, duplicate, malformed, blank, and out-of-range values
- schema/runtime parity with `additionalProperties=false`
- no global silent deletion of blank optional enum values
- no status-cache invalidation fanout in unrelated keeper mutation paths

## Focused proof

- status observes TOML and persisted metadata changes on the next call
- status observes live registry `last_error` changes with identical arguments
- malformed inputs fail closed
- schema properties and enum values follow the runtime SSOT
- blank optional enums reach the owning handler instead of being silently normalized away
- changed OCaml files pass parse and format checks; diff check is clean

Focused Dune targets are queued behind the repository-wide Dune lock. Full build/test remains CI authority.