### PR TITLE
refactor(keeper): type safe compaction eligibility

### DIFF
--- a/lib/keeper/keeper_compaction_eligible_history.ml
+++ b/lib/keeper/keeper_compaction_eligible_history.ml
@@ -1,0 +1,178 @@
+module T = Agent_sdk.Types
+module Unit = Keeper_compaction_unit
+module Int_map = Map.Make (Int)
+
+module Summary = struct
+  type t = string
+  type error = Empty
+
+  let create value = if String.equal value "" then Error Empty else Ok value
+  let to_string value = value
+end
+
+type eligible_role =
+  | User
+  | Assistant
+
+type eligible_unit =
+  { index : int
+  ; role : eligible_role
+  ; message : T.message
+  ; text_blocks : string list
+  }
+
+type classified_unit =
+  | Eligible of eligible_unit
+  | Protected of Unit.closed_unit
+
+type t =
+  { units : classified_unit list
+  ; protected_suffix : T.message list
+  }
+
+type action =
+  | Keep
+  | Drop
+  | Summarize of Summary.t
+
+type decision =
+  { unit : eligible_unit
+  ; action : action
+  }
+
+type apply_error =
+  | Unknown_unit of int
+  | Unit_source_mismatch of int
+  | Duplicate_decision of int
+  | Missing_decisions of int list
+
+type outcome =
+  | No_compaction of T.message list
+  | Compacted of T.message list
+
+let eligible_role = function
+  | T.User -> Some User
+  | T.Assistant -> Some Assistant
+  | T.System | T.Tool -> None
+;;
+
+let pure_text_blocks = function
+  | [] -> None
+  | blocks ->
+    let rec collect texts = function
+      | [] -> Some (List.rev texts)
+      | T.Text text :: rest -> collect (text :: texts) rest
+      | ( T.Thinking _
+        | T.ReasoningDetails _
+        | T.RedactedThinking _
+        | T.Image _
+        | T.Document _
+        | T.Audio _
+        | T.ToolUse _
+        | T.ToolResult _ )
+        :: _ ->
+        None
+    in
+    collect [] blocks
+;;
+
+let classify index = function
+  | Unit.Closed_tool_cycle _ as unit -> Protected unit
+  | Unit.Ordinary_message message as unit ->
+    (match
+       ( eligible_role message.role
+       , message.tool_call_id
+       , message.metadata
+       , pure_text_blocks message.content )
+     with
+     | Some role, None, [], Some text_blocks ->
+       Eligible { index; role; message; text_blocks }
+     | _ -> Protected unit)
+;;
+
+let of_messages messages =
+  Unit.partition messages
+  |> Result.map (fun (partition : Unit.partition) ->
+    { units = List.mapi classify partition.closed_prefix
+    ; protected_suffix = partition.protected_suffix
+    })
+;;
+
+let eligible_units source =
+  List.filter_map
+    (function
+      | Eligible unit -> Some unit
+      | Protected _ -> None)
+    source.units
+;;
+
+let unit_index unit = unit.index
+let unit_role unit = unit.role
+let unit_message unit = unit.message
+let unit_text_blocks unit = unit.text_blocks
+let keep unit = { unit; action = Keep }
+let drop unit = { unit; action = Drop }
+let summarize unit summary = { unit; action = Summarize summary }
+
+let expected_units source =
+  List.fold_left
+    (fun units unit -> Int_map.add unit.index unit units)
+    Int_map.empty
+    (eligible_units source)
+;;
+
+let bind_decisions source decisions =
+  let expected = expected_units source in
+  let rec bind bound = function
+    | [] ->
+      let missing =
+        Int_map.fold
+          (fun index _ missing ->
+             if Int_map.mem index bound then missing else index :: missing)
+          expected
+          []
+        |> List.rev
+      in
+      if missing = [] then Ok bound else Error (Missing_decisions missing)
+    | decision :: rest ->
+      let index = decision.unit.index in
+      (match Int_map.find_opt index expected with
+       | None -> Error (Unknown_unit index)
+       | Some expected_unit when expected_unit <> decision.unit ->
+         Error (Unit_source_mismatch index)
+       | Some _ when Int_map.mem index bound -> Error (Duplicate_decision index)
+       | Some _ -> bind (Int_map.add index decision.action bound) rest)
+  in
+  bind Int_map.empty decisions
+;;
+
+let messages_of_closed_unit = function
+  | Unit.Ordinary_message message -> [ message ]
+  | Unit.Closed_tool_cycle messages -> messages
+;;
+
+let apply source decisions =
+  bind_decisions source decisions
+  |> Result.map (fun actions ->
+    let changed, chunks_rev =
+      List.fold_left
+        (fun (changed, chunks) -> function
+           | Protected unit ->
+             changed, messages_of_closed_unit unit :: chunks
+           | Eligible unit ->
+             (match Int_map.find unit.index actions with
+              | Keep -> changed, [ unit.message ] :: chunks
+              | Drop -> true, [] :: chunks
+              | Summarize summary ->
+                let summarized =
+                  { unit.message with
+                    content = [ T.Text (Summary.to_string summary) ]
+                  }
+                in
+                changed || summarized <> unit.message, [ summarized ] :: chunks))
+        (false, [])
+        source.units
+    in
+    let messages = List.concat (List.rev chunks_rev) @ source.protected_suffix in
+    if changed then Compacted messages else No_compaction messages)
+;;

--- a/lib/keeper/keeper_compaction_eligible_history.mli
+++ b/lib/keeper/keeper_compaction_eligible_history.mli
@@ -1,0 +1,54 @@
+(** Typed LLM-rewrite boundary over structurally partitioned Keeper history.
+
+    Only ordinary User/Assistant text messages without provider metadata or a
+    Tool call identity become {!eligible_unit}s. System messages, Tool
+    messages, non-text content, closed Tool cycles, and the open-cycle suffix
+    remain exact. This boundary does not decide semantic value; it only makes
+    protected history impossible to target with a compaction decision. *)
+
+module Summary : sig
+  type t
+  type error = Empty
+
+  val create : string -> (t, error) result
+  val to_string : t -> string
+end
+
+type t
+type eligible_unit
+
+type eligible_role =
+  | User
+  | Assistant
+
+type decision
+
+type apply_error =
+  | Unknown_unit of int
+  | Unit_source_mismatch of int
+  | Duplicate_decision of int
+  | Missing_decisions of int list
+
+type outcome =
+  | No_compaction of Agent_sdk.Types.message list
+  | Compacted of Agent_sdk.Types.message list
+
+val of_messages :
+  Agent_sdk.Types.message list ->
+  (t, Keeper_compaction_unit.structural_error) result
+
+val eligible_units : t -> eligible_unit list
+val unit_index : eligible_unit -> int
+val unit_role : eligible_unit -> eligible_role
+val unit_message : eligible_unit -> Agent_sdk.Types.message
+val unit_text_blocks : eligible_unit -> string list
+
+val keep : eligible_unit -> decision
+val drop : eligible_unit -> decision
+val summarize : eligible_unit -> Summary.t -> decision
+
+(** Every eligible unit must have exactly one decision. Protected history is
+    reinserted value- and constructor-exact. A summary replaces only the source
+    message's content and preserves its role, name, Tool-call identity, and
+    metadata. *)
+val apply : t -> decision list -> (outcome, apply_error) result

--- a/test/test_keeper_compaction_unit.ml
+++ b/test/test_keeper_compaction_unit.ml
@@ -1,4 +1,5 @@
 module U = Masc.Keeper_compaction_unit
+module E = Masc.Keeper_compaction_eligible_history
 module T = Agent_sdk.Types
 
 let message role content : T.message =
@@ -24,6 +25,11 @@ let check_exact label expected actual =
 let require_ok = function
   | Ok value -> value
   | Error _ -> Alcotest.fail "expected structural partition"
+
+let require_summary value =
+  match E.Summary.create value with
+  | Ok summary -> summary
+  | Error E.Summary.Empty -> Alcotest.fail "expected non-empty summary"
 
 let test_signed_parallel_cycle_is_atomic () =
   let assistant =
@@ -146,6 +152,129 @@ let test_mixed_request_result_error () =
       ()
   | _ -> Alcotest.fail "expected typed mixed request/result"
 
+let test_eligible_history_preserves_protected_units_and_roles () =
+  let system = text T.System "system exact" in
+  let user = { (text T.User "user detail") with name = Some "alice" } in
+  let assistant = text T.Assistant "assistant detail" in
+  let provider_bound =
+    { (text T.Assistant "provider bound") with
+      metadata = [ "provider_message_id", `String "opaque-id" ]
+    }
+  in
+  let tool_request = message T.Assistant [ use "call" ] in
+  let progress = text T.Assistant "tool progress" in
+  let tool_result = message T.User [ result "call" ] in
+  let reasoning =
+    message
+      T.Assistant
+      [ T.ReasoningDetails
+          { reasoning_content = Some "opaque"; details = [] }
+      ]
+  in
+  let open_request = message T.Assistant [ use "open" ] in
+  let open_progress = text T.User "still running" in
+  let source_messages =
+    [ system
+    ; user
+    ; assistant
+    ; provider_bound
+    ; tool_request
+    ; progress
+    ; tool_result
+    ; reasoning
+    ; open_request
+    ; open_progress
+    ]
+  in
+  let source = E.of_messages source_messages |> require_ok in
+  let eligible = E.eligible_units source in
+  Alcotest.(check (list int))
+    "only pure User/Assistant units"
+    [ 1; 2 ]
+    (List.map E.unit_index eligible);
+  match eligible with
+  | [ user_unit; assistant_unit ] ->
+    let decisions =
+      [ E.summarize user_unit (require_summary "user summary")
+      ; E.drop assistant_unit
+      ]
+    in
+    (match E.apply source decisions with
+     | Error _ -> Alcotest.fail "eligible plan was rejected"
+     | Ok (E.No_compaction _) -> Alcotest.fail "changed plan reported no compaction"
+     | Ok (E.Compacted messages) ->
+       let summarized_user = { user with content = [ T.Text "user summary" ] } in
+       check_exact
+         "protected units and open suffix remain exact"
+         [ system
+         ; summarized_user
+         ; provider_bound
+         ; tool_request
+         ; progress
+         ; tool_result
+         ; reasoning
+         ; open_request
+         ; open_progress
+         ]
+         messages)
+  | _ -> Alcotest.fail "unexpected eligible unit set"
+
+let test_eligible_history_rejects_incomplete_or_foreign_decisions () =
+  let source =
+    E.of_messages [ text T.User "one"; text T.Assistant "two" ] |> require_ok
+  in
+  let first, second =
+    match E.eligible_units source with
+    | [ first; second ] -> first, second
+    | _ -> Alcotest.fail "expected two eligible units"
+  in
+  (match E.apply source [ E.keep first ] with
+   | Error (E.Missing_decisions [ index ]) ->
+     Alcotest.(check int) "missing exact unit" (E.unit_index second) index
+   | _ -> Alcotest.fail "missing decision was not explicit");
+  (match E.apply source [ E.keep first; E.keep first; E.keep second ] with
+   | Error (E.Duplicate_decision index) ->
+     Alcotest.(check int) "duplicate exact unit" (E.unit_index first) index
+   | _ -> Alcotest.fail "duplicate decision was not explicit");
+  let foreign_source = E.of_messages [ text T.User "foreign" ] |> require_ok in
+  let foreign = List.hd (E.eligible_units foreign_source) in
+  match E.apply source [ E.keep foreign; E.keep second ] with
+  | Error (E.Unit_source_mismatch 0) -> ()
+  | _ -> Alcotest.fail "foreign decision was not explicit"
+
+let test_eligible_history_keep_is_exact_no_compaction () =
+  let original = { (text T.User "exact") with name = Some "speaker" } in
+  let source = E.of_messages [ original ] |> require_ok in
+  let unit = List.hd (E.eligible_units source) in
+  match E.apply source [ E.keep unit ] with
+  | Ok (E.No_compaction messages) -> check_exact "exact keep" [ original ] messages
+  | _ -> Alcotest.fail "keep-only plan did not report no compaction"
+
+let test_eligible_history_preserves_text_block_boundaries () =
+  let original = message T.User [ T.Text "first"; T.Text "second" ] in
+  let source = E.of_messages [ original ] |> require_ok in
+  let unit = List.hd (E.eligible_units source) in
+  Alcotest.(check (list string))
+    "exact text blocks"
+    [ "first"; "second" ]
+    (E.unit_text_blocks unit);
+  let unchanged = E.summarize unit (require_summary "first") in
+  match E.apply source [ unchanged ] with
+  | Ok (E.Compacted [ summarized ]) ->
+    check_exact
+      "summary replaces content structurally"
+      [ { original with content = [ T.Text "first" ] } ]
+      [ summarized ]
+  | _ -> Alcotest.fail "structural summary was not applied"
+
+let test_identical_summary_is_no_compaction () =
+  let original = text T.Assistant "same" in
+  let source = E.of_messages [ original ] |> require_ok in
+  let unit = List.hd (E.eligible_units source) in
+  match E.apply source [ E.summarize unit (require_summary "same") ] with
+  | Ok (E.No_compaction messages) -> check_exact "identical summary" [ original ] messages
+  | _ -> Alcotest.fail "identical summary reported a false compaction"
+
 let () =
   Alcotest.run "keeper_compaction_unit"
     [ ( "partition"
@@ -170,5 +299,17 @@ let () =
         ; Alcotest.test_case "duplicate use" `Quick test_duplicate_tool_use_error
         ; Alcotest.test_case "mixed request/result" `Quick
             test_mixed_request_result_error
+        ] )
+    ; ( "eligible_history"
+      , [ Alcotest.test_case "protected exact and role preserving" `Quick
+            test_eligible_history_preserves_protected_units_and_roles
+        ; Alcotest.test_case "decision coverage and source binding" `Quick
+            test_eligible_history_rejects_incomplete_or_foreign_decisions
+        ; Alcotest.test_case "keep-only is exact no-compaction" `Quick
+            test_eligible_history_keep_is_exact_no_compaction
+        ; Alcotest.test_case "text block boundaries remain exact" `Quick
+            test_eligible_history_preserves_text_block_boundaries
+        ; Alcotest.test_case "identical summary is no-compaction" `Quick
+            test_identical_summary_is_no_compaction
         ] )
     ]


### PR DESCRIPTION
## 목적

기존 global index plan은 System, Tool protocol, provider-bound content까지 동일한 Keep/Drop/Summarize 표면으로 노출하고 summary를 Assistant 문자열로 재작성할 수 있었습니다. 이 PR은 의미 판단을 하드코딩하지 않고, LLM 판단에 넘길 수 있는 구조적 입력 경계만 타입으로 고정합니다.

Closes no issue. Partial foundation for #24965; live async Lane wiring and journal hard cut remain separate.

## 변경

- `Keeper_compaction_unit.partition` 이후 ordinary User/Assistant pure-text message만 opaque `eligible_unit`으로 노출
- System, Tool, non-text, provider metadata, tool-call identity, closed Tool cycle, open/progress suffix는 exact protected
- text block 경계를 list로 유지하여 임의 newline normalization 제거
- decision은 source의 opaque eligible unit에 직접 결합하며 unknown/source mismatch/duplicate/missing을 typed error로 반환
- summary는 원래 role/name/tool-call identity/metadata를 보존하고 content만 치환
- 실제 출력이 동일하면 `No_compaction`; false compaction 관측 금지
- mutable state, semantic string matching, numeric heuristic 없음

## 의도적 다음 단계

완료된 Tool cycle은 영구적으로 compact 불가하다는 뜻이 아닙니다. durable exact operation/receipt/artifact join이 생긴 뒤 ID, outcome, error, artifact refs를 보존하는 typed terminal Tool summary로 별도 축약합니다. 이 기반 PR은 그 증거가 없는 상태에서 provenance를 잃지 않게 합니다.

또한 이 PR 자체는 live heartbeat의 동기 compaction을 바꾸지 않습니다. eligible-only LLM plan codec과 per-Keeper async Lane wiring이 뒤따라야 #24965가 완료됩니다.

## 검증

- focused build: `scripts/dune-local.sh build test/test_keeper_compaction_unit.exe`
- focused tests: 17/17 pass
- `ocamlformat --check` pass
- `git diff --check` pass
- diff: 3 files, 373 additions