### PR TITLE
refactor(keeper): bind compaction plans to eligible units

### DIFF
--- a/lib/keeper/keeper_compaction_eligible_plan.ml
+++ b/lib/keeper/keeper_compaction_eligible_plan.ml
@@ -1,0 +1,214 @@
+module History = Keeper_compaction_eligible_history
+
+type t = History.decision list
+
+type decision_issue =
+  | Expected_object
+  | Unknown_field of string
+  | Duplicate_field of string
+  | Missing_field of string
+  | Invalid_unit_index
+  | Invalid_action
+  | Invalid_summary
+  | Missing_summary
+  | Unexpected_summary
+  | Empty_summary
+  | Unknown_unit of int
+
+type decode_error =
+  | Expected_plan_object
+  | Unknown_plan_field of string
+  | Duplicate_plan_field of string
+  | Missing_plan_field of string
+  | Decisions_not_array
+  | Invalid_decision of
+      { position : int
+      ; issue : decision_issue
+      }
+  | Invalid_binding of History.apply_error
+
+type action =
+  | Keep
+  | Drop
+  | Summarize
+
+let field_decisions = "decisions"
+let field_unit_index = "unit_index"
+let field_action = "action"
+let field_summary = "summary"
+let action_keep = "keep"
+let action_drop = "drop"
+let action_summarize = "summarize"
+let ( let* ) = Result.bind
+
+let object_schema ~required properties =
+  `Assoc
+    [ "type", `String "object"
+    ; "additionalProperties", `Bool false
+    ; "properties", `Assoc properties
+    ; "required", `List (List.map (fun field -> `String field) required)
+    ]
+;;
+
+let output_schema =
+  let decision =
+    object_schema
+      ~required:[ field_unit_index; field_action; field_summary ]
+      [ field_unit_index, `Assoc [ "type", `String "integer" ]
+      ; ( field_action
+        , `Assoc
+            [ "type", `String "string"
+            ; ( "enum"
+              , `List
+                  [ `String action_keep
+                  ; `String action_drop
+                  ; `String action_summarize
+                  ] )
+            ] )
+      ; ( field_summary
+        , `Assoc
+            [ "type", `List [ `String "string"; `String "null" ] ] )
+      ]
+  in
+  object_schema
+    ~required:[ field_decisions ]
+    [ field_decisions
+    , `Assoc [ "type", `String "array"; "items", decision ]
+    ]
+;;
+
+let input_json source =
+  let role = function
+    | History.User -> "user"
+    | History.Assistant -> "assistant"
+  in
+  History.eligible_units source
+  |> List.map (fun unit ->
+    `Assoc
+      [ field_unit_index, `Int (History.unit_index unit)
+      ; "role", `String (role (History.unit_role unit))
+      ; ( "text_blocks"
+        , `List
+            (List.map
+               (fun text -> `String text)
+               (History.unit_text_blocks unit)) )
+      ])
+  |> fun units -> `List units
+;;
+
+let find_unique ~missing ~duplicate field fields =
+  match List.filter (fun (name, _) -> String.equal name field) fields with
+  | [] -> Error missing
+  | [ _, value ] -> Ok value
+  | _ -> Error duplicate
+;;
+
+let unknown_field allowed fields =
+  List.find_map
+    (fun (name, _) ->
+       if List.exists (String.equal name) allowed then None else Some name)
+    fields
+;;
+
+let eligible_unit source index =
+  History.eligible_units source
+  |> List.find_opt (fun unit -> Int.equal index (History.unit_index unit))
+;;
+
+let decode_decision ~source ~position = function
+  | `Assoc fields ->
+    (match
+       unknown_field [ field_unit_index; field_action; field_summary ] fields
+     with
+     | Some field -> Error (Invalid_decision { position; issue = Unknown_field field })
+     | None ->
+       let invalid issue = Error (Invalid_decision { position; issue }) in
+       let* index_json =
+         find_unique
+           ~missing:(Invalid_decision { position; issue = Missing_field field_unit_index })
+           ~duplicate:
+             (Invalid_decision { position; issue = Duplicate_field field_unit_index })
+           field_unit_index
+           fields
+       in
+       let* index =
+         match index_json with
+         | `Int value -> Ok value
+         | _ -> invalid Invalid_unit_index
+       in
+       let* unit =
+         match eligible_unit source index with
+         | Some unit -> Ok unit
+         | None -> invalid (Unknown_unit index)
+       in
+       let* action_json =
+         find_unique
+           ~missing:(Invalid_decision { position; issue = Missing_field field_action })
+           ~duplicate:(Invalid_decision { position; issue = Duplicate_field field_action })
+           field_action
+           fields
+       in
+       let* action =
+         match action_json with
+         | `String value when String.equal value action_keep -> Ok Keep
+         | `String value when String.equal value action_drop -> Ok Drop
+         | `String value when String.equal value action_summarize -> Ok Summarize
+         | _ -> invalid Invalid_action
+       in
+       let* summary_json =
+         find_unique
+           ~missing:(Invalid_decision { position; issue = Missing_field field_summary })
+           ~duplicate:
+             (Invalid_decision { position; issue = Duplicate_field field_summary })
+           field_summary
+           fields
+       in
+       let* summary =
+         match summary_json with
+         | `Null -> Ok None
+         | `String value -> Ok (Some value)
+         | _ -> invalid Invalid_summary
+       in
+       (match action, summary with
+        | Keep, None -> Ok (History.keep unit)
+        | Drop, None -> Ok (History.drop unit)
+        | Summarize, None -> invalid Missing_summary
+        | (Keep | Drop), Some _ -> invalid Unexpected_summary
+        | Summarize, Some value ->
+          (match History.Summary.create value with
+           | Ok summary -> Ok (History.summarize unit summary)
+           | Error History.Summary.Empty -> invalid Empty_summary)))
+  | _ -> Error (Invalid_decision { position; issue = Expected_object })
+;;
+
+let decode ~source = function
+  | `Assoc fields ->
+    (match unknown_field [ field_decisions ] fields with
+     | Some field -> Error (Unknown_plan_field field)
+     | None ->
+       let* decisions_json =
+         find_unique
+           ~missing:(Missing_plan_field field_decisions)
+           ~duplicate:(Duplicate_plan_field field_decisions)
+           field_decisions
+           fields
+       in
+       let* items =
+         match decisions_json with
+         | `List items -> Ok items
+         | _ -> Error Decisions_not_array
+       in
+       let rec collect position decisions = function
+         | [] -> Ok (List.rev decisions)
+         | item :: rest ->
+           let* decision = decode_decision ~source ~position item in
+           collect (position + 1) (decision :: decisions) rest
+       in
+       let* decisions = collect 0 [] items in
+       (match History.apply source decisions with
+        | Ok _ -> Ok decisions
+        | Error error -> Error (Invalid_binding error)))
+  | _ -> Error Expected_plan_object
+;;
+
+let apply ~source plan = History.apply source plan

--- a/lib/keeper/keeper_compaction_eligible_plan.mli
+++ b/lib/keeper/keeper_compaction_eligible_plan.mli
@@ -1,0 +1,47 @@
+(** Closed structured-output boundary for LLM decisions over eligible Keeper
+    history. Wire field names and action tokens remain private to this codec. *)
+
+module History = Keeper_compaction_eligible_history
+
+type t
+
+type decision_issue =
+  | Expected_object
+  | Unknown_field of string
+  | Duplicate_field of string
+  | Missing_field of string
+  | Invalid_unit_index
+  | Invalid_action
+  | Invalid_summary
+  | Missing_summary
+  | Unexpected_summary
+  | Empty_summary
+  | Unknown_unit of int
+
+type decode_error =
+  | Expected_plan_object
+  | Unknown_plan_field of string
+  | Duplicate_plan_field of string
+  | Missing_plan_field of string
+  | Decisions_not_array
+  | Invalid_decision of
+      { position : int
+      ; issue : decision_issue
+      }
+  | Invalid_binding of History.apply_error
+
+val input_json : History.t -> Yojson.Safe.t
+(** Exact eligible units presented to the LLM. Protected history is absent. *)
+
+val output_schema : Yojson.Safe.t
+(** Closed per-unit [keep]/[drop]/[summarize] response schema. *)
+
+val decode :
+  source:History.t -> Yojson.Safe.t -> (t, decode_error) result
+(** Decode and bind exactly one decision to every eligible unit. Keep-all and
+    drop-all remain valid semantic choices; this boundary adds no policy. *)
+
+val apply :
+  source:History.t ->
+  t ->
+  (History.outcome, History.apply_error) result

--- a/test/test_keeper_compaction_unit.ml
+++ b/test/test_keeper_compaction_unit.ml
@@ -1,5 +1,6 @@
 module U = Masc.Keeper_compaction_unit
 module E = Masc.Keeper_compaction_eligible_history
+module P = Masc.Keeper_compaction_eligible_plan
 module T = Agent_sdk.Types
 
 let message role content : T.message =
@@ -275,6 +276,104 @@ let test_identical_summary_is_no_compaction () =
   | Ok (E.No_compaction messages) -> check_exact "identical summary" [ original ] messages
   | _ -> Alcotest.fail "identical summary reported a false compaction"
 
+let plan_decision index action summary =
+  `Assoc
+    [ "unit_index", `Int index
+    ; "action", `String action
+    ; "summary", summary
+    ]
+
+let plan decisions = `Assoc [ "decisions", `List decisions ]
+
+let test_eligible_plan_excludes_protected_history () =
+  let source =
+    E.of_messages
+      [ text T.System "system"
+      ; message T.User [ T.Text "first"; T.Text "second" ]
+      ; { (text T.Assistant "provider") with metadata = [ "id", `String "x" ] }
+      ]
+    |> require_ok
+  in
+  let expected =
+    `List
+      [ `Assoc
+          [ "unit_index", `Int 1
+          ; "role", `String "user"
+          ; "text_blocks", `List [ `String "first"; `String "second" ]
+          ]
+      ]
+  in
+  Alcotest.(check string)
+    "only exact eligible input"
+    (Yojson.Safe.to_string expected)
+    (Yojson.Safe.to_string (P.input_json source))
+
+let test_eligible_plan_decodes_per_unit_actions () =
+  let user = text T.User "user" in
+  let assistant = text T.Assistant "assistant" in
+  let source = E.of_messages [ user; assistant ] |> require_ok in
+  let json =
+    plan
+      [ plan_decision 0 "summarize" (`String "user summary")
+      ; plan_decision 1 "drop" `Null
+      ]
+  in
+  match P.decode ~source json with
+  | Error _ -> Alcotest.fail "valid eligible plan was rejected"
+  | Ok decoded ->
+    (match P.apply ~source decoded with
+     | Ok (E.Compacted messages) ->
+       check_exact
+         "per-unit role-preserving result"
+         [ { user with content = [ T.Text "user summary" ] } ]
+         messages
+     | _ -> Alcotest.fail "valid eligible plan did not compact")
+
+let test_eligible_plan_keeps_semantic_choices_open () =
+  let source = E.of_messages [ text T.User "one" ] |> require_ok in
+  List.iter
+    (fun json ->
+       match P.decode ~source json with
+       | Ok _ -> ()
+       | Error _ -> Alcotest.fail "codec imposed a semantic admission policy")
+    [ plan [ plan_decision 0 "keep" `Null ]
+    ; plan [ plan_decision 0 "drop" `Null ]
+    ]
+
+let test_eligible_plan_rejects_structural_ambiguity () =
+  let source =
+    E.of_messages [ text T.User "one"; text T.Assistant "two" ] |> require_ok
+  in
+  (match P.decode ~source (plan [ plan_decision 0 "keep" `Null ]) with
+   | Error (P.Invalid_binding (E.Missing_decisions [ 1 ])) -> ()
+   | _ -> Alcotest.fail "missing unit decision was not explicit");
+  (match
+     P.decode
+       ~source
+       (plan
+          [ plan_decision 0 "keep" `Null
+          ; plan_decision 0 "drop" `Null
+          ; plan_decision 1 "keep" `Null
+          ])
+   with
+   | Error (P.Invalid_binding (E.Duplicate_decision 0)) -> ()
+   | _ -> Alcotest.fail "duplicate unit decision was not explicit");
+  match P.decode ~source (plan [ plan_decision 9 "keep" `Null ]) with
+  | Error (P.Invalid_decision { position = 0; issue = P.Unknown_unit 9 }) -> ()
+  | _ -> Alcotest.fail "unknown eligible unit was not explicit"
+
+let test_eligible_plan_summary_contract_is_exact () =
+  let source = E.of_messages [ text T.User "one" ] |> require_ok in
+  (match P.decode ~source (plan [ plan_decision 0 "summarize" `Null ]) with
+   | Error (P.Invalid_decision { issue = P.Missing_summary; _ }) -> ()
+   | _ -> Alcotest.fail "missing summary was accepted");
+  (match P.decode ~source (plan [ plan_decision 0 "keep" (`String "unused") ]) with
+   | Error (P.Invalid_decision { issue = P.Unexpected_summary; _ }) -> ()
+   | _ -> Alcotest.fail "ambiguous keep summary was accepted");
+  match P.decode ~source (plan [ plan_decision 0 "summarize" (`String "") ]) with
+  | Error (P.Invalid_decision { issue = P.Empty_summary; _ }) -> ()
+  | _ -> Alcotest.fail "empty summary was accepted"
+
 let () =
   Alcotest.run "keeper_compaction_unit"
     [ ( "partition"
@@ -311,5 +410,17 @@ let () =
             test_eligible_history_preserves_text_block_boundaries
         ; Alcotest.test_case "identical summary is no-compaction" `Quick
             test_identical_summary_is_no_compaction
+        ] )
+    ; ( "eligible_plan"
+      , [ Alcotest.test_case "protected history excluded" `Quick
+            test_eligible_plan_excludes_protected_history
+        ; Alcotest.test_case "per-unit actions" `Quick
+            test_eligible_plan_decodes_per_unit_actions
+        ; Alcotest.test_case "semantic choices remain open" `Quick
+            test_eligible_plan_keeps_semantic_choices_open
+        ; Alcotest.test_case "structural ambiguity rejected" `Quick
+            test_eligible_plan_rejects_structural_ambiguity
+        ; Alcotest.test_case "summary contract exact" `Quick
+            test_eligible_plan_summary_contract_is_exact
         ] )
     ]


### PR DESCRIPTION
## 목적

Draft #24980이 만든 opaque eligible-history 경계 위에, LLM structured output을 per-unit typed decision으로 결합합니다. 기존 global message index partition이나 단일 Assistant summary를 재사용하지 않습니다.

Stacked on #24980. Partial foundation for #24965; provider call과 live async Lane wiring은 후속입니다.

## 계약

- LLM 입력에는 eligible unit의 exact index, typed role projection, exact text block list만 포함
- 출력은 각 eligible unit별 `keep | drop | summarize`와 nullable summary
- wire field/action 문자열은 codec 내부 단일 SSOT이며 public constant로 노출하지 않음
- unknown/duplicate/missing field, invalid action/summary, unknown unit, duplicate/missing decision은 typed error
- keep-all과 drop-all은 codec이 거부하지 않음: 의미 판단은 LLM 소유
- summary exact-empty만 구조적으로 거부; whitespace 점수/trim heuristic 없음
- protected history는 plan JSON에 들어오지 않으며 apply 시 source-bound opaque unit으로 재결합
- mutable registry/state 없음

## 검증

- `ocamlc -stop-after parsing` for new `.ml/.mli` and focused test: pass
- `ocamlformat --check`: pass
- `git diff --check`: pass
- diff: 3 files, 372 additions
- focused Dune wrapper는 코드 컴파일 전에 shared switch의 `agent_sdk 0.213.0`, repo required `>=0.214.1` pin guard에서 중단. guard 우회/공용 switch 변경 없이 CI를 type/build 권위로 사용합니다.