### PR TITLE
refactor(keeper): centralize operation journal record

### DIFF
--- a/lib/keeper_compaction_operation/dune
+++ b/lib/keeper_compaction_operation/dune
@@ -11,9 +11,9 @@
   keeper_compaction_operation_codec_support
   keeper_compaction_operation_identity
   keeper_compaction_operation_json
-  keeper_compaction_operation_record
   keeper_compaction_operation_reducer
-  keeper_compaction_operation_store)
+  keeper_compaction_operation_store
+  keeper_operation_record)
  (private_modules keeper_compaction_operation_codec_support)
  (libraries
   eio

--- a/lib/keeper_compaction_operation/keeper_compaction_operation_store.ml
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation_store.ml
@@ -1,8 +1,9 @@
 module Operation = Keeper_compaction_operation
 module Reducer = Keeper_compaction_operation_reducer
-module Record = Keeper_compaction_operation_record
+module Codec = Keeper_compaction_operation_codec
+module Record = Keeper_operation_record
 module Cursor = Record.Cursor
-type row = Record.row
+type row = Operation.event Record.row
 type operation_entry =
   { snapshot : Reducer.snapshot
   ; requested_at : float
@@ -21,7 +22,7 @@ type event_rejection =
       ; existing_operation_id : Operation.Operation_id.t
       }
 type history_error =
-  | Invalid_record of Record.decode_error
+  | Invalid_record of Codec.decode_error Record.decode_error
   | Rejected_row of
       { row_number : int
       ; start_cursor : Cursor.t
@@ -36,7 +37,7 @@ type transaction_error =
   | Outcome_unknown of Fs_compat.durable_append_error
   | Access_failed of exn
 type append_error =
-  | Encode_failed of Record.envelope_error
+  | Encode_failed of Record.encode_error
   | Existing_history_invalid of history_error
   | Event_rejected of event_rejection
   | Transaction_error of transaction_error
@@ -131,7 +132,13 @@ let fold_rows ~keeper_name rows =
   loop 1 empty_state rows
 ;;
 let decode_history ~keeper_name bytes =
-  match Record.decode_rows ~from:Cursor.zero ~row_number:(Some 1) bytes with
+  match
+    Record.decode_rows
+      ~decode_event:Codec.of_json
+      ~from:Cursor.zero
+      ~row_number:(Some 1)
+      bytes
+  with
   | Error error -> Error (Invalid_record error)
   | Ok rows ->
     fold_rows ~keeper_name rows |> Result.map (fun state -> rows, state)
@@ -168,12 +175,18 @@ let read_slice ~base_path ~keeper_name ~from =
   with
   | Error error -> Error (Read_failed error)
   | Ok source ->
-    (match Record.decode_rows ~from ~row_number:None source.bytes with
+    (match
+       Record.decode_rows
+         ~decode_event:Codec.of_json
+         ~from
+         ~row_number:None
+         source.bytes
+     with
      | Error error -> Error (Invalid_history (Invalid_record error))
      | Ok rows -> Ok { rows; end_cursor = cursor source.end_offset })
 ;;
 let append ~base_path ~keeper_name ~recorded_at event =
-  match Record.encode ~recorded_at event with
+  match Record.encode ~encode_event:Codec.to_json ~recorded_at event with
   | Error error -> Error (Encode_failed error)
   | Ok suffix ->
     let path = journal_path ~base_path ~keeper_name in
@@ -187,7 +200,13 @@ let append ~base_path ~keeper_name ~recorded_at event =
            let end_cursor =
              cursor (Cursor.to_int start_cursor + String.length suffix)
            in
-           let row = { Record.recorded_at; start_cursor; end_cursor; event } in
+           let row =
+             { Record.recorded_at
+             ; start_cursor
+             ; end_cursor
+             ; event
+             }
+           in
            (match apply_row ~keeper_name state row with
             | Error error -> None, Error (Event_rejected error)
             | Ok _ -> Some suffix, Ok row))

--- a/lib/keeper_compaction_operation/keeper_compaction_operation_store.mli
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation_store.mli
@@ -1,7 +1,8 @@
-(** Sole durable mutation facade for one Keeper's compaction operations. *)
-module Record = Keeper_compaction_operation_record
+(** Current compaction reducer/append facade over generic Keeper operation
+    records. The single-writer implementation migrates separately. *)
+module Record = Keeper_operation_record
 module Cursor = Record.Cursor
-type row = Record.row
+type row = Keeper_compaction_operation.event Record.row
 type operation_entry =
   { snapshot : Keeper_compaction_operation_reducer.snapshot
   ; requested_at : float
@@ -20,7 +21,7 @@ type event_rejection =
       ; existing_operation_id : Keeper_compaction_operation.Operation_id.t
       }
 type history_error =
-  | Invalid_record of Record.decode_error
+  | Invalid_record of Keeper_compaction_operation_codec.decode_error Record.decode_error
   | Rejected_row of
       { row_number : int
       ; start_cursor : Cursor.t
@@ -35,7 +36,7 @@ type transaction_error =
   | Outcome_unknown of Fs_compat.durable_append_error
   | Access_failed of exn
 type append_error =
-  | Encode_failed of Record.envelope_error
+  | Encode_failed of Record.encode_error
   | Existing_history_invalid of history_error
   | Event_rejected of event_rejection
   | Transaction_error of transaction_error

--- a/lib/keeper_compaction_operation/keeper_operation_record.ml
+++ b/lib/keeper_compaction_operation/keeper_operation_record.ml
@@ -1,5 +1,3 @@
-module Codec = Keeper_compaction_operation_codec
-
 module Cursor = struct
   type t = int
   type error = Negative of int
@@ -8,31 +6,33 @@ module Cursor = struct
   let to_int value = value
 end
 
-type row =
+type 'event row =
   { recorded_at : float
   ; start_cursor : Cursor.t
   ; end_cursor : Cursor.t
-  ; event : Keeper_compaction_operation.event
+  ; event : 'event
   }
 
-type envelope_error =
+type 'event_error envelope_error =
   | Expected_object
   | Unknown_field of string
   | Duplicate_field of string
   | Missing_field of string
   | Invalid_recorded_at
-  | Invalid_event of Codec.decode_error
+  | Invalid_event of 'event_error
 
-type issue =
+type encode_error = Non_finite_recorded_at
+
+type 'event_error issue =
   | Incomplete_tail
   | Malformed_json of string
-  | Invalid_envelope of envelope_error
+  | Invalid_envelope of 'event_error envelope_error
 
-type decode_error =
+type 'event_error decode_error =
   { row_number : int option
   ; start_cursor : Cursor.t
   ; end_cursor : Cursor.t
-  ; issue : issue
+  ; issue : 'event_error issue
   }
 
 let ( let* ) = Result.bind
@@ -44,13 +44,15 @@ let required_field name fields =
   | _ -> Error (Duplicate_field name)
 ;;
 
-let decode_envelope = function
+let decode_envelope ~decode_event = function
   | `Assoc fields ->
     let* () =
       match
         List.find_opt
           (fun (name, _) ->
-             not (String.equal name "recorded_at" || String.equal name "event"))
+             not
+               (String.equal name "recorded_at"
+                || String.equal name "event"))
           fields
       with
       | None -> Ok ()
@@ -63,24 +65,26 @@ let decode_envelope = function
       | _ -> Error Invalid_recorded_at
     in
     let* event_json = required_field "event" fields in
-    Codec.of_json event_json
+    decode_event event_json
     |> Result.map_error (fun error -> Invalid_event error)
     |> Result.map (fun event -> recorded_at, event)
   | _ -> Error Expected_object
 ;;
 
-let encode ~recorded_at event =
+let encode ~encode_event ~recorded_at event =
   if not (Float.is_finite recorded_at)
-  then Error Invalid_recorded_at
+  then Error Non_finite_recorded_at
   else
     Ok
       (`Assoc
-         [ "recorded_at", `Float recorded_at; "event", Codec.to_json event ]
+         [ "recorded_at", `Float recorded_at
+         ; "event", encode_event event
+         ]
        |> Yojson.Safe.to_string
        |> fun value -> value ^ "\n")
 ;;
 
-let decode_rows ~from ~row_number bytes =
+let decode_rows ~decode_event ~from ~row_number bytes =
   let base = Cursor.to_int from in
   let length = String.length bytes in
   let locate number start_cursor end_cursor issue =
@@ -103,7 +107,7 @@ let decode_rows ~from ~row_number bytes =
          with
          | Error issue -> locate number start_cursor end_cursor issue
          | Ok json ->
-           (match decode_envelope json with
+           (match decode_envelope ~decode_event json with
             | Error error ->
               locate number start_cursor end_cursor (Invalid_envelope error)
             | Ok (recorded_at, event) ->

--- a/lib/keeper_compaction_operation/keeper_operation_record.mli
+++ b/lib/keeper_compaction_operation/keeper_operation_record.mli
@@ -1,4 +1,4 @@
-(** Closed JSONL record codec around one typed compaction operation event. *)
+(** Closed JSONL envelope around one caller-owned typed operation codec. *)
 
 module Cursor : sig
   type t
@@ -8,42 +8,46 @@ module Cursor : sig
   val to_int : t -> int
 end
 
-type row =
+type 'event row =
   { recorded_at : float
   ; start_cursor : Cursor.t
   ; end_cursor : Cursor.t
-  ; event : Keeper_compaction_operation.event
+  ; event : 'event
   }
 
-type envelope_error =
+type 'event_error envelope_error =
   | Expected_object
   | Unknown_field of string
   | Duplicate_field of string
   | Missing_field of string
   | Invalid_recorded_at
-  | Invalid_event of Keeper_compaction_operation_codec.decode_error
+  | Invalid_event of 'event_error
 
-type issue =
+type encode_error = Non_finite_recorded_at
+
+type 'event_error issue =
   | Incomplete_tail
   | Malformed_json of string
-  | Invalid_envelope of envelope_error
+  | Invalid_envelope of 'event_error envelope_error
 
-type decode_error =
+type 'event_error decode_error =
   { row_number : int option
   ; start_cursor : Cursor.t
   ; end_cursor : Cursor.t
-  ; issue : issue
+  ; issue : 'event_error issue
   }
 
 val encode :
+  encode_event:('event -> Yojson.Safe.t) ->
   recorded_at:float ->
-  Keeper_compaction_operation.event ->
-  (string, envelope_error) result
+  'event ->
+  (string, encode_error) result
 (** Returns exactly one newline-terminated JSONL row. *)
 
 val decode_rows :
+  decode_event:(Yojson.Safe.t -> ('event, 'event_error) result) ->
   from:Cursor.t ->
   row_number:int option ->
   string ->
-  (row list, decode_error) result
+  ('event row list, 'event_error decode_error) result
 (** [row_number] is [Some] only when the caller owns the complete prefix. *)

--- a/test/keeper_operation_record/dune
+++ b/test/keeper_operation_record/dune
@@ -1,7 +1,7 @@
 (test
- (name test_keeper_compaction_operation_record)
+ (name test_keeper_operation_record)
  (libraries
- alcotest
+  alcotest
   masc.compaction_trigger
   masc.keeper_checkpoint_ref
   masc.keeper_compaction_operation

--- a/test/keeper_operation_record/test_keeper_operation_record.ml
+++ b/test/keeper_operation_record/test_keeper_operation_record.ml
@@ -1,5 +1,6 @@
 module Operation = Keeper_compaction_operation
-module Record = Keeper_compaction_operation_record
+module Codec = Keeper_compaction_operation_codec
+module Record = Keeper_operation_record
 
 let ok = function
   | Ok value -> value
@@ -15,6 +16,7 @@ let checkpoint_option_equal left right =
 
 let keeper_name = ok (Keeper_id.Keeper_name.of_string "record-keeper")
 let trace_id = ok (Keeper_id.Trace_id.of_string "record-trace")
+let cause = ok (Operation.Cause.of_string "manual compaction")
 
 let source =
   ok
@@ -36,14 +38,22 @@ let event =
     ~keeper_name
     ~source_checkpoint:source
     ~trigger:Compaction_trigger.Manual
-    ~cause:(ok (Operation.Cause.of_string "manual compaction"))
+    ~cause
     ~producer_invocation:None
 ;;
 
+let encode ~recorded_at event =
+  Record.encode ~encode_event:Codec.to_json ~recorded_at event
+;;
+
+let decode_rows ~from ~row_number bytes =
+  Record.decode_rows ~decode_event:Codec.of_json ~from ~row_number bytes
+;;
+
 let test_roundtrip_and_cursor () =
-  let encoded = ok (Record.encode ~recorded_at:(-1.25) event) in
+  let encoded = ok (encode ~recorded_at:(-1.25) event) in
   let from = ok (Record.Cursor.of_int 17) in
-  match Record.decode_rows ~from ~row_number:None encoded with
+  match decode_rows ~from ~row_number:None encoded with
   | Ok [ row ] ->
     Alcotest.(check (float 0.0)) "timestamp" (-1.25) row.recorded_at;
     Alcotest.(check int) "start" 17 (Record.Cursor.to_int row.start_cursor);
@@ -51,29 +61,38 @@ let test_roundtrip_and_cursor () =
       "newline end"
       (17 + String.length encoded)
       (Record.Cursor.to_int row.end_cursor);
+    let actual = row.event in
     Alcotest.(check bool)
-      "event identity"
+      "operation identity"
       true
       (Operation.Operation_id.equal
-         (Operation.operation_id row.event)
-         (Operation.operation_id event))
+         (Operation.operation_id actual)
+         (Operation.operation_id event));
+    (match Operation.view actual with
+     | Operation.Requested request ->
+       Alcotest.(check bool) "keeper" true
+         (Keeper_id.Keeper_name.equal keeper_name request.keeper_name);
+       Alcotest.(check bool) "exact source" true
+         (Keeper_checkpoint_ref.equal source request.source_checkpoint);
+       Alcotest.(check bool) "cause" true
+         (Operation.Cause.equal cause request.cause);
+       (match request.trigger, request.producer_invocation with
+        | Compaction_trigger.Manual, None -> ()
+        | _ -> Alcotest.fail "typed request facts changed")
+     | _ -> Alcotest.fail "compaction event kind changed")
   | _ -> Alcotest.fail "canonical row did not decode"
 ;;
 
 let test_closed_envelope_and_finite_time () =
-  (match Record.encode ~recorded_at:Float.nan event with
-   | Error Record.Invalid_recorded_at -> ()
+  (match encode ~recorded_at:Float.nan event with
+   | Error Record.Non_finite_recorded_at -> ()
    | _ -> Alcotest.fail "non-finite timestamp encoded");
+  let canonical = ok (encode ~recorded_at:1.0 event) in
   let malformed =
-    `Assoc
-      [ "recorded_at", `Float 1.0
-      ; "event", Keeper_compaction_operation_codec.to_json event
-      ; "extra", `Null
-      ]
-    |> Yojson.Safe.to_string
-    |> fun value -> value ^ "\n"
+    String.sub canonical 0 (String.length canonical - 2)
+    ^ ",\"extra\":null}\n"
   in
-  match Record.decode_rows ~from:Record.Cursor.zero ~row_number:(Some 1) malformed with
+  match decode_rows ~from:Record.Cursor.zero ~row_number:(Some 1) malformed with
   | Error
       { row_number = Some 1
       ; issue = Record.Invalid_envelope (Record.Unknown_field "extra")
@@ -83,9 +102,33 @@ let test_closed_envelope_and_finite_time () =
   | _ -> Alcotest.fail "unknown envelope field was accepted"
 ;;
 
+let test_event_error_is_preserved () =
+  let unknown_event =
+    match Codec.to_json event with
+    | `Assoc fields ->
+      `Assoc (("kind", `String "future") :: List.remove_assoc "kind" fields)
+    | _ -> Alcotest.fail "canonical event was not an object"
+  in
+  let unknown =
+    `Assoc [ "recorded_at", `Float 1.0; "event", unknown_event ]
+    |> Yojson.Safe.to_string
+    |> fun value -> value ^ "\n"
+  in
+  match decode_rows ~from:Record.Cursor.zero ~row_number:(Some 1) unknown with
+  | Error
+      { row_number = Some 1
+      ; issue =
+          Record.Invalid_envelope
+            (Record.Invalid_event (Codec.Unknown_event_kind "future"))
+      ; _
+      } ->
+    ()
+  | _ -> Alcotest.fail "typed event error was collapsed or discarded"
+;;
+
 let test_incomplete_tail_is_located () =
   match
-    Record.decode_rows
+    decode_rows
       ~from:(ok (Record.Cursor.of_int 8))
       ~row_number:None
       "{}"
@@ -115,15 +158,17 @@ let test_superseded_roundtrip () =
            ~attempt_id
            ~observed_checkpoint
        in
-       let encoded = ok (Record.encode ~recorded_at:1.0 superseded) in
-       match Record.decode_rows ~from:Record.Cursor.zero ~row_number:(Some 1) encoded with
+       let encoded = ok (encode ~recorded_at:1.0 superseded) in
+       match decode_rows ~from:Record.Cursor.zero ~row_number:(Some 1) encoded with
        | Ok [ row ] ->
          (match Operation.view row.event with
           | Operation.Source_superseded actual ->
             Alcotest.(check bool)
               "exact optional checkpoint"
               true
-              (checkpoint_option_equal actual.observed_checkpoint observed_checkpoint)
+              (checkpoint_option_equal
+                 actual.observed_checkpoint
+                 observed_checkpoint)
           | _ -> Alcotest.fail "supersession kind changed")
        | _ -> Alcotest.fail "supersession did not roundtrip")
     [ None; Some source ]
@@ -131,10 +176,11 @@ let test_superseded_roundtrip () =
 
 let () =
   Alcotest.run
-    "keeper compaction operation record"
+    "keeper operation record"
     [ ( "record"
       , [ Alcotest.test_case "roundtrip and cursor" `Quick test_roundtrip_and_cursor
         ; Alcotest.test_case "closed envelope" `Quick test_closed_envelope_and_finite_time
+        ; Alcotest.test_case "exact event error" `Quick test_event_error_is_preserved
         ; Alcotest.test_case "incomplete tail" `Quick test_incomplete_tail_is_located
         ; Alcotest.test_case "superseded roundtrip" `Quick test_superseded_roundtrip
         ] )


### PR DESCRIPTION
## 목적

compaction 전용 public record/codec을 Keeper Operation Journal의 권위로 두지 않고, MASC의 generic closed event sum과 단일 public JSONL record codec으로 hard-cut합니다.

Stacked on #24963. Partial response to #24966; immutable cursor-CAS writer와 O(n²) append 제거는 후속입니다.

## 변경

- central `Keeper_operation_event.t = Compaction of ...` closed sum 추가
- generic `Keeper_operation_record`가 domain envelope, exact cursor, finite timestamp, closed decode error를 단독 소유
- old `Keeper_compaction_operation_record` 제거
- compaction raw codec/json/support를 `masc.keeper_operation` private modules로 이동
- public `provider_delivery_ref_to_yojson` escape hatch 제거
- public record error는 private raw codec type 대신 closed `compaction_event_error`로 투영
- unknown domain은 explicit `Unknown_domain`; unknown event를 silent skip하지 않음
- compaction reducer/store/action selector는 generic typed row/event만 소비
- central record roundtrip이 operation identity, checkpoint, cause, trigger, producer와 optional supersession ref를 검증

## 의도적 다음 단계

이 PR은 writer 성능/권위를 완료했다고 주장하지 않습니다. 현재 compaction store의 path-based append는 여전히 history replay를 수행합니다. #24971 exact end-cursor CAS 위에 immutable replay state + incremental reducer를 쌓고, 그 다음 PR에서 이 O(n²) writer를 제거해야 #24966의 journal SSOT 항목이 완료됩니다.

## 검증

- focused build 4 targets: pass
- focused tests: 28/28 pass (record 5, operation 16, store 4, selector 3)
- `ocamlformat --check`: pass
- `git diff --check`: pass
- reverse search: old record/public raw codec callers 0
- diff: +285/-109 = 394 changed lines