### PR TITLE
feat(keeper): plan eligible compaction through runtime lanes

### DIFF
--- a/lib/keeper/keeper_compaction_eligible_llm_planner.ml
+++ b/lib/keeper/keeper_compaction_eligible_llm_planner.ml
@@ -1,0 +1,177 @@
+module History = Keeper_compaction_eligible_history
+module Plan = Keeper_compaction_eligible_plan
+
+type complete_fn = Keeper_provider_subcall.complete_fn
+
+type structured_response_error =
+  | Missing_text
+  | Invalid_json of string
+
+type candidate_failure_reason =
+  | Runtime_missing
+  | Schema_rejected of string
+  | Transport_failed of Llm_provider.Http_client.http_error
+  | Structured_response_rejected of structured_response_error
+  | Plan_rejected of Plan.decode_error
+
+type candidate_failure =
+  { runtime_id : string
+  ; reason : candidate_failure_reason
+  }
+
+type success =
+  { plan : Plan.t
+  ; selected_runtime_id : string
+  ; failed_candidates : candidate_failure list
+  }
+
+type error =
+  | Assignment_missing of string
+  | Candidates_exhausted of
+      { assignment_id : string
+      ; failures : candidate_failure list
+      }
+
+type candidate =
+  { runtime_id : string
+  ; runtime : Runtime.t option
+  }
+
+let provider_for_plan (provider : Llm_provider.Provider_config.t) =
+  { provider with
+    tool_choice = None
+  ; disable_parallel_tool_use = true
+  ; response_format = Agent_sdk.Types.JsonSchema Plan.output_schema
+  ; output_schema = Some Plan.output_schema
+  }
+;;
+
+let messages_for_plan source =
+  let message role text = Agent_sdk.Types.text_message role text in
+  [ message
+      Agent_sdk.Types.System
+      "Judge every supplied eligible unit exactly once. Preserve facts or \
+       replace/remove content only according to your semantic judgment. Return \
+       only JSON conforming to the supplied response schema."
+  ; message
+      Agent_sdk.Types.User
+      (Yojson.Safe.to_string (Plan.input_json source))
+  ]
+;;
+
+let structured_json (response : Agent_sdk.Types.api_response) =
+  let text = Agent_sdk.Types.visible_text_of_response response in
+  if String.equal text ""
+  then Error Missing_text
+  else
+    try Ok (Yojson.Safe.from_string text) with
+    | Yojson.Json_error detail -> Error (Invalid_json detail)
+;;
+
+let complete_provider ?override ~sw ~net ?clock ~config ~messages () =
+  match override with
+  | Some complete -> complete ~sw ~net ?clock ~config ~messages ()
+  | None ->
+    Llm_provider.Complete.complete
+      ~sw
+      ~net
+      ?clock
+      ~config
+      ~messages
+      ~tools:[]
+      ()
+;;
+
+let candidates assignment_id =
+  match Runtime.resolve_assignment assignment_id with
+  | `Missing -> Error (Assignment_missing assignment_id)
+  | `Single_runtime runtime ->
+    Ok [ { runtime_id = runtime.Runtime.id; runtime = Some runtime } ]
+  | `Lane lane ->
+    Ok
+      (Runtime_lane.ordered_candidates lane
+       |> List.map (fun runtime_id ->
+         { runtime_id; runtime = Runtime.get_runtime_by_id runtime_id }))
+;;
+
+let attempt
+    ?complete
+    ~sw
+    ~net
+    ?clock
+    ~source
+    ({ runtime_id = _; runtime } : candidate)
+  =
+  match runtime with
+  | None -> Error Runtime_missing
+  | Some runtime ->
+    let provider = provider_for_plan runtime.Runtime.provider_config in
+    (match Llm_provider.Provider_config.validate_output_schema_request provider with
+     | Error detail -> Error (Schema_rejected detail)
+     | Ok () ->
+       (match
+          complete_provider
+            ?override:complete
+            ~sw
+            ~net
+            ?clock
+            ~config:provider
+            ~messages:(messages_for_plan source)
+            ()
+        with
+        | Error error -> Error (Transport_failed error)
+        | Ok response ->
+          (match structured_json response with
+           | Error error -> Error (Structured_response_rejected error)
+           | Ok json ->
+             (match Plan.decode ~source json with
+              | Error error -> Error (Plan_rejected error)
+              | Ok plan -> Ok plan))))
+;;
+
+let failure_label = function
+  | Runtime_missing -> "runtime_missing"
+  | Schema_rejected _ -> "schema_rejected"
+  | Transport_failed _ -> "transport_failed"
+  | Structured_response_rejected _ -> "structured_response_rejected"
+  | Plan_rejected _ -> "plan_rejected"
+;;
+
+let run
+    ?complete
+    ~sw
+    ~net
+    ?clock
+    ~keeper_name
+    ~assignment_id
+    ~source
+    ()
+  =
+  match candidates assignment_id with
+  | Error error -> Error error
+  | Ok candidates ->
+    let rec loop failures = function
+      | [] ->
+        Error
+          (Candidates_exhausted
+             { assignment_id; failures = List.rev failures })
+      | ({ runtime_id; _ } as candidate) :: rest ->
+        (match attempt ?complete ~sw ~net ?clock ~source candidate with
+         | Ok plan ->
+           Ok
+             { plan
+             ; selected_runtime_id = runtime_id
+             ; failed_candidates = List.rev failures
+             }
+         | Error reason ->
+           Log.Keeper.warn
+             ~keeper_name
+             "eligible compaction plan candidate rejected assignment=%s \
+              runtime=%s reason=%s"
+             assignment_id
+             runtime_id
+             (failure_label reason);
+           loop ({ runtime_id; reason } :: failures) rest)
+    in
+    loop [] candidates
+;;

--- a/lib/keeper/keeper_compaction_eligible_llm_planner.mli
+++ b/lib/keeper/keeper_compaction_eligible_llm_planner.mli
@@ -1,0 +1,59 @@
+(** One-shot LLM planning over structurally eligible Keeper history.
+
+    The caller owns the Eio resources and Runtime assignment. Every rejected
+    candidate remains typed and ordered; this boundary never substitutes a
+    default Runtime or hides failure as [None]. *)
+
+module History = Keeper_compaction_eligible_history
+module Plan = Keeper_compaction_eligible_plan
+
+type complete_fn = Keeper_provider_subcall.complete_fn
+
+type structured_response_error =
+  | Missing_text
+  | Invalid_json of string
+
+type candidate_failure_reason =
+  | Runtime_missing
+  | Schema_rejected of string
+  | Transport_failed of Llm_provider.Http_client.http_error
+  | Structured_response_rejected of structured_response_error
+  | Plan_rejected of Plan.decode_error
+
+type candidate_failure =
+  { runtime_id : string
+  ; reason : candidate_failure_reason
+  }
+
+type success =
+  { plan : Plan.t
+  ; selected_runtime_id : string
+  ; failed_candidates : candidate_failure list
+    (** Earlier candidates rejected in exact declaration order. *)
+  }
+
+type error =
+  | Assignment_missing of string
+  | Candidates_exhausted of
+      { assignment_id : string
+      ; failures : candidate_failure list
+      }
+
+(** Resolve [assignment_id] as a Runtime or ordered Lane and ask each
+    candidate for a plan over [source]. The request contains only
+    {!Plan.input_json}; protected history is never sent. Provider model,
+    temperature, and sampling configuration remain those of the selected
+    Runtime, while tools are disabled and {!Plan.output_schema} is required.
+
+    No timeout, turn limit, budget, retry cap, ambient Eio context, or live
+    Keeper heartbeat wiring exists here. *)
+val run
+  :  ?complete:complete_fn
+  -> sw:Eio.Switch.t
+  -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+  -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> keeper_name:string
+  -> assignment_id:string
+  -> source:History.t
+  -> unit
+  -> (success, error) result

--- a/test/test_compaction_llm_summarizer.ml
+++ b/test/test_compaction_llm_summarizer.ml
@@ -7,6 +7,9 @@
 
 open Masc
 module C = Keeper_compaction_llm_summarizer
+module E = Keeper_compaction_eligible_history
+module EP = Keeper_compaction_eligible_llm_planner
+module P = Keeper_compaction_eligible_plan
 
 let plan_json ~summary ~kept ~summarized ~dropped : Yojson.Safe.t =
   let ints xs = `List (List.map (fun i -> `Int i) xs) in
@@ -106,6 +109,114 @@ let test_lane_candidates_keep_declared_order () =
   Alcotest.(check (option (list string))) "declared candidate order"
     (Some [ "local.kimi_like"; "fallback.kimi_like" ])
     actual
+
+let eligible_source () =
+  match
+    E.of_messages
+      [ Agent_sdk.Types.text_message Agent_sdk.Types.System "protected secret"
+      ; Agent_sdk.Types.text_message Agent_sdk.Types.User "eligible detail"
+      ]
+  with
+  | Ok source -> source
+  | Error _ -> Alcotest.fail "eligible source should partition"
+
+let response text : Agent_sdk.Types.api_response =
+  { id = "eligible-plan"
+  ; model = "kimi-like"
+  ; stop_reason = Agent_sdk.Types.EndTurn
+  ; content = [ Agent_sdk.Types.Text text ]
+  ; usage = None
+  ; telemetry = None
+  }
+
+let test_eligible_planner_uses_resources_schema_and_ordered_failover () =
+  with_temperature_runtime @@ fun _ ->
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let net = Eio.Stdenv.net env in
+  let clock = Eio.Stdenv.clock env in
+  let source = eligible_source () in
+  let calls = ref [] in
+  let complete ~sw:sw' ~net:net' ?clock:clock' ~config ~messages () =
+    calls := config.base_url :: !calls;
+    Alcotest.(check bool) "exact switch" true (sw == sw');
+    Alcotest.(check bool) "exact net" true (net == net');
+    Alcotest.(check bool)
+      "exact clock"
+      true
+      (Option.fold ~none:false ~some:(fun value -> value == clock) clock');
+    Alcotest.(check bool) "tools disabled" true (config.tool_choice = None);
+    Alcotest.(check bool) "parallel tools disabled" true config.disable_parallel_tool_use;
+    Alcotest.(check (option (float 0.0001))) "temperature exact" (Some 1.0) config.temperature;
+    Alcotest.(check string) "model exact" "kimi-like" config.model_id;
+    Alcotest.(check bool)
+      "output schema exact"
+      true
+      (config.output_schema = Some P.output_schema);
+    Alcotest.(check bool)
+      "response schema exact"
+      true
+      (match config.response_format with
+       | Agent_sdk.Types.JsonSchema schema -> schema = P.output_schema
+       | Agent_sdk.Types.JsonMode | Agent_sdk.Types.Off -> false);
+    let user_json = Yojson.Safe.to_string (P.input_json source) in
+    (match messages with
+     | [ _; user ] ->
+       Alcotest.(check string)
+         "prompt contains only eligible input"
+         user_json
+         (Agent_sdk.Types.text_of_message user)
+     | _ -> Alcotest.fail "expected one system and one eligible-input message");
+    Alcotest.(check bool)
+      "protected history absent"
+      false
+      (List.exists
+         (fun message -> String.equal (Agent_sdk.Types.text_of_message message) "protected secret")
+         messages);
+    if String.equal config.base_url "http://localhost:11434"
+    then Ok (response "not-json")
+    else
+      Ok
+        (response
+           {|{"decisions":[{"unit_index":1,"action":"keep","summary":null}]}|})
+  in
+  match
+    EP.run ~complete ~sw ~net ~clock ~keeper_name:"keeper-test"
+      ~assignment_id:"compaction" ~source ()
+  with
+  | Error _ -> Alcotest.fail "second declared candidate should succeed"
+  | Ok success ->
+    Alcotest.(check string)
+      "selected runtime"
+      "fallback.kimi_like"
+      success.selected_runtime_id;
+    Alcotest.(check (list string))
+      "declared provider order"
+      [ "http://localhost:11434"; "http://localhost:11435" ]
+      (List.rev !calls);
+    (match success.failed_candidates with
+     | [ { runtime_id = "local.kimi_like"; reason = EP.Structured_response_rejected _ } ] -> ()
+     | _ -> Alcotest.fail "first typed candidate failure should be returned")
+
+let test_eligible_planner_returns_ordered_aggregate_failure () =
+  with_temperature_runtime @@ fun _ ->
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let complete ~sw:_ ~net:_ ?clock:_ ~config:_ ~messages:_ () =
+    Ok (response "not-json")
+  in
+  match
+    EP.run ~complete ~sw ~net:(Eio.Stdenv.net env)
+      ~keeper_name:"keeper-test" ~assignment_id:"compaction"
+      ~source:(eligible_source ()) ()
+  with
+  | Ok _ -> Alcotest.fail "invalid responses should exhaust the lane"
+  | Error (EP.Assignment_missing _) -> Alcotest.fail "lane should resolve"
+  | Error (EP.Candidates_exhausted { failures; _ }) ->
+    Alcotest.(check (list string))
+      "all failures retain declared runtime ids"
+      [ "local.kimi_like"; "fallback.kimi_like" ]
+      (List.map (fun failure -> failure.EP.runtime_id) failures)
 
 (* -- plan_of_json: valid partition accepted -- *)
 
@@ -237,6 +348,10 @@ let () =
             test_provider_for_plan_preserves_temperature_omission
         ; Alcotest.test_case "lane candidates keep declared order" `Quick
             test_lane_candidates_keep_declared_order
+        ; Alcotest.test_case "eligible planner explicit resources and failover" `Quick
+            test_eligible_planner_uses_resources_schema_and_ordered_failover
+        ; Alcotest.test_case "eligible planner aggregate failure" `Quick
+            test_eligible_planner_returns_ordered_aggregate_failure
         ] )
     ; ( "plan_of_json"
       , [ Alcotest.test_case "valid partition accepted" `Quick test_valid_partition_accepted


### PR DESCRIPTION
## 목적

Draft #24984의 source-bound eligible plan codec 위에, 명시적 Eio resource와 Runtime assignment만 사용하는 one-shot LLM planner를 쌓습니다. 기존 global message-index summarizer나 live heartbeat wiring은 건드리지 않습니다.

Stacked on #24984. Partial implementation for #24965.

## 계약

- `run ~sw ~net ?clock ~keeper_name ~assignment_id ~source` 단일 호출; ambient `Eio_context`, timeout, max-turn, budget, retry cap 없음
- assignment는 exact Runtime 또는 Lane으로 해석하고 Lane candidate를 선언 순서로 시도
- missing Runtime, schema rejection, transport, structured response, typed plan rejection을 candidate Runtime id와 함께 반환
- 후속 candidate가 성공해도 앞선 실패는 `success.failed_candidates`에 선언 순서로 보존; 전부 실패하면 typed aggregate error
- provider/model/temperature/sampling config는 Runtime 값을 유지하고, tool choice/parallel tool use를 끈 뒤 `Keeper_compaction_eligible_plan.output_schema`를 native schema로 결합
- production call은 OAS `Complete.complete`에 `tools=[]`를 명시하고 `body_timeout_s`를 전달하지 않음
- LLM history payload는 `Plan.input_json source`뿐이며 protected history/global message index는 전달하지 않음
- plan action wire token 해석은 `Keeper_compaction_eligible_plan` codec에만 존재
- no `String.trim`, semantic admission heuristic, mutable production state, silent `None`

## 검증

- `ocamlformat --check` (3 files): pass
- `ocamlc -stop-after parsing` (`.ml`, `.mli`, focused test): pass
- `git diff --check`: pass
- focused wrapper: expected pre-build stop because shared switch has `agent_sdk 0.213.0` while this stack requires `>=0.214.1`; guard was not bypassed and shared switch was not mutated
- Build/Test type authority: PR CI

## 테스트 범위

- exact caller-owned switch/net/clock forwarding
- Runtime model/temperature preservation and exact output schema/tool disabling
- protected history excluded; user payload equals `Plan.input_json`
- first candidate structured-response failure → second declared candidate success, with prior typed failure retained
- all candidates fail → ordered typed aggregate with exact Runtime ids

## 크기

- 3 files, 351 additions

## 후속 경계

Provider-native token count (OAS v0.214.1 Anthropic 포함)을 이용한 structural overflow subdivision은 별도 leaf입니다. 이 PR은 fixed chunk size나 token-count heuristic을 만들지 않습니다.

