### PR TITLE
refactor(worker): purge max-turn contract tombstones

### DIFF
--- a/lib/local/worker_container.ml
+++ b/lib/local/worker_container.ml
@@ -89,25 +89,16 @@ let worker_meta_allowed_fields =
     "last_run_at";
   ]
 
-let worker_meta_removed_fields =
-  [ "max_turns_override"; "tool_profile"; "shell_profile"; "worker_class" ]
-
 let validate_worker_meta_fields fields =
   let field_names = List.map fst fields in
-  match List.find_opt (fun name -> List.mem name worker_meta_removed_fields) field_names with
+  match
+    List.find_opt
+      (fun name -> not (List.mem name worker_meta_allowed_fields))
+      field_names
+  with
   | Some field ->
-      Error
-        (Printf.sprintf
-           "worker meta field %S has been removed; worker runtime state is now backend-only"
-           field)
-  | None -> (
-      match List.find_opt
-              (fun name -> not (List.mem name worker_meta_allowed_fields))
-              field_names
-      with
-      | Some field ->
-          Error (Printf.sprintf "unknown worker meta field %S" field)
-      | None -> Ok ())
+      Error (Printf.sprintf "unknown worker meta field %S" field)
+  | None -> Ok ()
 
 let worker_meta_to_yojson (meta : worker_container_meta) =
   `Assoc

--- a/lib/local/worker_container.mli
+++ b/lib/local/worker_container.mli
@@ -32,7 +32,6 @@
     [stable_worker_session_id],
     [oas_worker_evidence_session_id],
     [worker_meta_allowed_fields],
-    [worker_meta_removed_fields],
     [validate_worker_meta_fields], [worker_meta_to_yojson],
     [worker_meta_of_yojson], [worker_container_state],
     [append_worker_turn_log], [start_worker_heartbeat]). *)
@@ -72,8 +71,8 @@ val load_worker_meta :
   worker_container_meta option
 (** Reads [meta.json] under {!worker_container_dir}.
     Returns [None] when the file is missing, the JSON
-    fails to parse, or validation rejects unknown /
-    removed fields.  Validation errors are logged via
+    fails to parse, or validation rejects unknown fields.
+    Validation errors are logged via
     [Log.LocalWorker.warn] for operator visibility. *)
 
 val save_worker_meta :

--- a/lib/worker_execution_spec/worker_execution_spec.ml
+++ b/lib/worker_execution_spec/worker_execution_spec.ml
@@ -47,23 +47,12 @@ let allowed_fields =
     "timeout_sec";
   ]
 
-let removed_fields =
-  [ "worker_class"; "max_turns"; "allowed_tools"; "allowed_shell_tools" ]
-
 let validate_fields fields =
   let field_names = List.map fst fields in
-  match List.find_opt (fun name -> List.mem name removed_fields) field_names with
+  match List.find_opt (fun name -> not (List.mem name allowed_fields)) field_names with
   | Some field ->
-      Error
-        (Printf.sprintf
-           "worker execution spec field %S has been removed; use runtime_backend + fixed worker surfaces"
-           field)
-  | None -> (
-      match List.find_opt (fun name -> not (List.mem name allowed_fields)) field_names with
-      | Some field ->
-          Error
-            (Printf.sprintf "unknown worker execution spec field %S" field)
-      | None -> Ok ())
+      Error (Printf.sprintf "unknown worker execution spec field %S" field)
+  | None -> Ok ()
 
 let to_yojson (spec : t) =
   `Assoc

--- a/lib/worker_execution_spec/worker_execution_spec.mli
+++ b/lib/worker_execution_spec/worker_execution_spec.mli
@@ -21,6 +21,6 @@ type t = {
 
 val to_yojson : t -> Yojson.Safe.t
 
-(** [of_yojson json] parses a previously serialized spec and rejects
-    removed worker contract fields. *)
+(** [of_yojson json] parses a serialized spec and rejects fields outside
+    the current worker invocation contract. *)
 val of_yojson : Yojson.Safe.t -> (t, string) result

--- a/test/test_worker_runtime.ml
+++ b/test/test_worker_runtime.ml
@@ -196,25 +196,6 @@ let test_run_worker_oas_rejects_invalid_explicit_model_label () =
           check bool "mentions rejected label" true
             (String.contains err 'n' && String.contains err '-'))
 
-let test_worker_execution_spec_rejects_removed_fields () =
-  let json =
-    Yojson.Safe.from_string
-      {|{
-  "base_path": "/tmp/base",
-  "worker_name": "worker",
-  "model_label": "custom:qwen@http://127.0.0.1:19001",
-  "runtime_backend": "docker",
-  "prompt": "hello",
-  "timeout_sec": 30,
-  "allowed_tools": ["masc_status"]
-}|}
-  in
-  match Worker_execution_spec.of_yojson json with
-  | Ok _ -> fail "expected removed worker spec field to be rejected"
-  | Error msg ->
-      check bool "mentions removed field" true
-        (Astring.String.is_infix ~affix:"allowed_tools" msg)
-
 let () =
   Alcotest.run "worker_runtime"
     [
@@ -234,7 +215,4 @@ let () =
         [ test_case "invalid explicit model label fails before local worker execution"
             `Quick
             test_run_worker_oas_rejects_invalid_explicit_model_label ] );
-      ( "spec_schema",
-        [ test_case "removed worker spec fields are rejected" `Quick
-            test_worker_execution_spec_rejects_removed_fields ] );
     ]


### PR DESCRIPTION
## What changed

- delete the legacy `Worker_execution_spec` special-case list containing `max_turns`
- delete the persisted worker-meta special-case list containing `max_turns_override`
- retain one current-schema allowlist at each JSON boundary, so unknown fields still fail explicitly
- remove the test whose only purpose was proving rejection of a retired worker contract

## Why

Production worker execution no longer carries or applies a turn budget: `Worker_execution_spec.t` has no turn-limit field, and `Worker_oas` does not pass one through OAS Builder or resume configuration. The remaining string tombstones were compatibility-era product knowledge, not execution authority.

This hard cut makes the current typed worker contract the SSOT. Historical payloads are not migrated or specially recognized; they fail as ordinary unknown fields.

## Scope classification

Intentionally unchanged:

- `Eval_harness.max_turns`: an explicit offline evaluation scenario bound
- readiness `max_turns_per_keeper`: a latest-N observation sample window
- provider maximum context: a real provider protocol constraint

None of those values gates production worker/sub-agent execution.

## Validation

- `ocamlformat --check` on all five touched OCaml files
- `git diff --check`
- focused residue scan: no `max_turns`, `max_turns_override`, or removed-field list remains in the worker execution/meta boundary
- focused Dune build requested via `scripts/dune-local.sh build lib/worker_execution_spec/worker_execution_spec.cma test/test_worker_runtime.exe`; wrapper stopped before compilation because the shared switch has `agent_sdk 0.213.0` while this checkout requires `>= 0.214.1`. No pin bypass or shared-switch mutation was used; CI remains the build authority.
