### PR TITLE
refactor(keeper): extract immutable operation projection

### DIFF
--- a/lib/keeper_compaction_operation/dune
+++ b/lib/keeper_compaction_operation/dune
@@ -11,6 +11,7 @@
   keeper_compaction_operation_codec_support
   keeper_compaction_operation_identity
   keeper_compaction_operation_json
+  keeper_compaction_operation_projection
   keeper_compaction_operation_reducer
   keeper_compaction_operation_store
   keeper_operation_record)

--- a/lib/keeper_compaction_operation/keeper_compaction_operation_projection.ml
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation_projection.ml
@@ -1,0 +1,145 @@
+module Operation = Keeper_compaction_operation
+module Reducer = Keeper_compaction_operation_reducer
+module Record = Keeper_operation_record
+module Cursor = Record.Cursor
+
+type operation_entry =
+  { snapshot : Reducer.snapshot
+  ; requested_at : float
+  ; request_cursor : Cursor.t
+  }
+
+type rejection =
+  | Cursor_mismatch of
+      { expected : Cursor.t
+      ; actual : Cursor.t
+      }
+  | Transition_rejected of Reducer.transition_error
+  | Keeper_mismatch of
+      { expected : Keeper_id.Keeper_name.t
+      ; actual : Keeper_id.Keeper_name.t
+      }
+  | Producer_already_bound of
+      { producer : Tool_invocation_ref.t
+      ; existing_operation_id : Operation.Operation_id.t
+      }
+
+type replay_error =
+  | Rejected_row of
+      { row_number : int
+      ; start_cursor : Cursor.t
+      ; end_cursor : Cursor.t
+      ; rejection : rejection
+      }
+
+module Operation_map = Map.Make (struct
+    type t = Operation.Operation_id.t
+    let compare = Operation.Operation_id.compare
+  end)
+
+type operation_state =
+  { reducer : Reducer.state
+  ; requested_at : float
+  ; request_cursor : Cursor.t
+  }
+
+type t =
+  { keeper_name : Keeper_id.Keeper_name.t
+  ; operations : operation_state Operation_map.t
+  ; producers : (Tool_invocation_ref.t * Operation.Operation_id.t) list
+  ; end_cursor : Cursor.t
+  }
+
+let empty ~keeper_name =
+  { keeper_name
+  ; operations = Operation_map.empty
+  ; producers = []
+  ; end_cursor = Cursor.zero
+  }
+;;
+
+let ( let* ) = Result.bind
+
+let producer_of_event event =
+  match Operation.view event with
+  | Operation.Requested { producer_invocation; _ } -> producer_invocation
+  | _ -> None
+;;
+
+let find_producer producer =
+  List.find_map (fun (candidate, operation_id) ->
+    if Tool_invocation_ref.equal producer candidate then Some operation_id else None)
+;;
+
+let apply state (row : Operation.event Record.row) =
+  if not (Cursor.equal row.start_cursor state.end_cursor)
+  then Error (Cursor_mismatch { expected = state.end_cursor; actual = row.start_cursor })
+  else
+    let event = row.event in
+    let operation_id = Operation.operation_id event in
+    let current = Operation_map.find_opt operation_id state.operations in
+    let* next =
+      Reducer.apply (Option.map (fun value -> value.reducer) current) event
+      |> Result.map_error (fun error -> Transition_rejected error)
+    in
+    let actual = (Reducer.snapshot next).keeper_name in
+    if not (Keeper_id.Keeper_name.equal state.keeper_name actual)
+    then Error (Keeper_mismatch { expected = state.keeper_name; actual })
+    else
+      let operation =
+        match current with
+        | Some value -> { value with reducer = next }
+        | None ->
+          { reducer = next
+          ; requested_at = row.recorded_at
+          ; request_cursor = row.end_cursor
+          }
+      in
+      let operations = Operation_map.add operation_id operation state.operations in
+      match producer_of_event event with
+      | Some producer ->
+        (match find_producer producer state.producers with
+         | Some existing_operation_id
+           when not (Operation.Operation_id.equal existing_operation_id operation_id) ->
+           Error (Producer_already_bound { producer; existing_operation_id })
+         | Some _ -> Ok { state with operations; end_cursor = row.end_cursor }
+         | None ->
+           Ok
+             { state with
+               operations
+             ; producers = (producer, operation_id) :: state.producers
+             ; end_cursor = row.end_cursor
+             })
+      | None -> Ok { state with operations; end_cursor = row.end_cursor }
+;;
+
+let replay ~keeper_name rows =
+  let rec loop row_number state = function
+    | [] -> Ok state
+    | (row : Operation.event Record.row) :: rest ->
+      (match apply state row with
+       | Ok state -> loop (row_number + 1) state rest
+       | Error rejection ->
+         Error
+           (Rejected_row
+              { row_number
+              ; start_cursor = row.start_cursor
+              ; end_cursor = row.end_cursor
+              ; rejection
+              }))
+  in
+  loop 1 (empty ~keeper_name) rows
+;;
+
+let end_cursor state = state.end_cursor
+
+let operations state =
+  Operation_map.bindings state.operations
+  |> List.map (fun (_, value) ->
+    { snapshot = Reducer.snapshot value.reducer
+    ; requested_at = value.requested_at
+    ; request_cursor = value.request_cursor
+    })
+  |> List.sort (fun (left : operation_entry) right ->
+    Cursor.compare left.request_cursor right.request_cursor)
+;;

--- a/lib/keeper_compaction_operation/keeper_compaction_operation_projection.mli
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation_projection.mli
@@ -1,0 +1,47 @@
+(** Pure immutable read model for compaction rows in the Keeper operation
+    journal. This module has no path, codec, or append authority. *)
+
+module Operation = Keeper_compaction_operation
+module Reducer = Keeper_compaction_operation_reducer
+module Record = Keeper_operation_record
+module Cursor = Record.Cursor
+
+type operation_entry =
+  { snapshot : Reducer.snapshot
+  ; requested_at : float
+  ; request_cursor : Cursor.t
+  }
+
+type rejection =
+  | Cursor_mismatch of
+      { expected : Cursor.t
+      ; actual : Cursor.t
+      }
+  | Transition_rejected of Reducer.transition_error
+  | Keeper_mismatch of
+      { expected : Keeper_id.Keeper_name.t
+      ; actual : Keeper_id.Keeper_name.t
+      }
+  | Producer_already_bound of
+      { producer : Tool_invocation_ref.t
+      ; existing_operation_id : Operation.Operation_id.t
+      }
+
+type replay_error =
+  | Rejected_row of
+      { row_number : int
+      ; start_cursor : Cursor.t
+      ; end_cursor : Cursor.t
+      ; rejection : rejection
+      }
+
+type t
+
+val empty : keeper_name:Keeper_id.Keeper_name.t -> t
+val apply : t -> Operation.event Record.row -> (t, rejection) result
+val replay :
+  keeper_name:Keeper_id.Keeper_name.t ->
+  Operation.event Record.row list ->
+  (t, replay_error) result
+val end_cursor : t -> Cursor.t
+val operations : t -> operation_entry list

--- a/lib/keeper_compaction_operation/keeper_compaction_operation_store.ml
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation_store.ml
@@ -3,15 +3,20 @@ module Reducer = Keeper_compaction_operation_reducer
 module Codec = Keeper_compaction_operation_codec
 module Record = Keeper_operation_record
 module Cursor = Record.Cursor
+module Projection = Keeper_compaction_operation_projection
 type row = Operation.event Record.row
-type operation_entry =
+type operation_entry = Projection.operation_entry =
   { snapshot : Reducer.snapshot
   ; requested_at : float
   ; request_cursor : Cursor.t
   }
 type replay = { operations : operation_entry list; end_cursor : Cursor.t }
 type slice = { rows : row list; end_cursor : Cursor.t }
-type event_rejection =
+type event_rejection = Projection.rejection =
+  | Cursor_mismatch of
+      { expected : Cursor.t
+      ; actual : Cursor.t
+      }
   | Transition_rejected of Reducer.transition_error
   | Keeper_mismatch of
       { expected : Keeper_id.Keeper_name.t
@@ -41,21 +46,6 @@ type append_error =
   | Existing_history_invalid of history_error
   | Event_rejected of event_rejection
   | Transaction_error of transaction_error
-module Operation_map = Map.Make (struct
-    type t = Operation.Operation_id.t
-    let compare = Operation.Operation_id.compare
-  end)
-type operation_state =
-  { reducer : Reducer.state
-  ; requested_at : float
-  ; request_cursor : Cursor.t
-  }
-type fold_state =
-  { operations : operation_state Operation_map.t
-  ; producers : (Tool_invocation_ref.t * Operation.Operation_id.t) list
-  }
-let empty_state = { operations = Operation_map.empty; producers = [] }
-let ( let* ) = Result.bind
 let cursor value =
   match Cursor.of_int value with
   | Ok cursor -> cursor
@@ -68,69 +58,6 @@ let journal_path ~base_path ~keeper_name =
        (Keeper_id.Keeper_name.to_string keeper_name))
     "operation-journal.jsonl"
 ;;
-let producer_of_event event =
-  match Operation.view event with
-  | Operation.Requested { producer_invocation; _ } -> producer_invocation
-  | _ -> None
-;;
-let find_producer producer =
-  List.find_map (fun (candidate, operation_id) ->
-    if Tool_invocation_ref.equal producer candidate then Some operation_id else None)
-;;
-let apply_row ~keeper_name state row =
-  let event = row.Record.event in
-  let operation_id = Operation.operation_id event in
-  let current = Operation_map.find_opt operation_id state.operations in
-  let* next =
-    Reducer.apply (Option.map (fun value -> value.reducer) current) event
-    |> Result.map_error (fun error -> Transition_rejected error)
-  in
-  let actual = (Reducer.snapshot next).keeper_name in
-  if not (Keeper_id.Keeper_name.equal keeper_name actual)
-  then Error (Keeper_mismatch { expected = keeper_name; actual })
-  else
-    let operation =
-      match current with
-      | Some value -> { value with reducer = next }
-      | None ->
-        { reducer = next
-        ; requested_at = row.recorded_at
-        ; request_cursor = row.end_cursor
-        }
-    in
-    match producer_of_event event with
-    | Some producer ->
-      (match find_producer producer state.producers with
-       | Some existing_operation_id
-         when not (Operation.Operation_id.equal existing_operation_id operation_id) ->
-         Error (Producer_already_bound { producer; existing_operation_id })
-       | Some _ ->
-         Ok { state with operations = Operation_map.add operation_id operation state.operations }
-       | None ->
-         Ok
-           { operations = Operation_map.add operation_id operation state.operations
-           ; producers = (producer, operation_id) :: state.producers
-           })
-    | None ->
-      Ok { state with operations = Operation_map.add operation_id operation state.operations }
-;;
-let fold_rows ~keeper_name rows =
-  let rec loop row_number state = function
-    | [] -> Ok state
-    | row :: rest ->
-      (match apply_row ~keeper_name state row with
-       | Ok state -> loop (row_number + 1) state rest
-       | Error rejection ->
-         Error
-           (Rejected_row
-              { row_number
-              ; start_cursor = row.start_cursor
-              ; end_cursor = row.end_cursor
-              ; rejection
-              }))
-  in
-  loop 1 empty_state rows
-;;
 let decode_history ~keeper_name bytes =
   match
     Record.decode_rows
@@ -141,7 +68,11 @@ let decode_history ~keeper_name bytes =
   with
   | Error error -> Error (Invalid_record error)
   | Ok rows ->
-    fold_rows ~keeper_name rows |> Result.map (fun state -> rows, state)
+    Projection.replay ~keeper_name rows
+    |> Result.map_error (function
+      | Projection.Rejected_row
+          { row_number; start_cursor; end_cursor; rejection } ->
+        Rejected_row { row_number; start_cursor; end_cursor; rejection })
 ;;
 let replay ~base_path ~keeper_name =
   let path = journal_path ~base_path ~keeper_name in
@@ -150,20 +81,10 @@ let replay ~base_path ~keeper_name =
   | Ok source ->
     (match decode_history ~keeper_name source.bytes with
      | Error error -> Error (Invalid_history error)
-     | Ok (_, state) ->
+     | Ok state ->
        Ok
-         { operations =
-             Operation_map.bindings state.operations
-             |> List.map (fun (_, value) ->
-               { snapshot = Reducer.snapshot value.reducer
-               ; requested_at = value.requested_at
-               ; request_cursor = value.request_cursor
-               })
-             |> List.sort (fun (left : operation_entry) right ->
-               Int.compare
-                 (Cursor.to_int left.request_cursor)
-                 (Cursor.to_int right.request_cursor))
-         ; end_cursor = cursor source.end_offset
+         { operations = Projection.operations state
+         ; end_cursor = Projection.end_cursor state
          })
 ;;
 let read_slice ~base_path ~keeper_name ~from =
@@ -195,7 +116,7 @@ let append ~base_path ~keeper_name ~recorded_at event =
        Fs_compat.update_private_file_durable_locked_result path (fun existing ->
          match decode_history ~keeper_name existing with
          | Error error -> None, Error (Existing_history_invalid error)
-         | Ok (_, state) ->
+         | Ok state ->
            let start_cursor = cursor (String.length existing) in
            let end_cursor =
              cursor (Cursor.to_int start_cursor + String.length suffix)
@@ -207,7 +128,7 @@ let append ~base_path ~keeper_name ~recorded_at event =
              ; event
              }
            in
-           (match apply_row ~keeper_name state row with
+           (match Projection.apply state row with
             | Error error -> None, Error (Event_rejected error)
             | Ok _ -> Some suffix, Ok row))
      with

--- a/lib/keeper_compaction_operation/keeper_compaction_operation_store.mli
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation_store.mli
@@ -2,15 +2,20 @@
     records. The single-writer implementation migrates separately. *)
 module Record = Keeper_operation_record
 module Cursor = Record.Cursor
+module Projection = Keeper_compaction_operation_projection
 type row = Keeper_compaction_operation.event Record.row
-type operation_entry =
+type operation_entry = Projection.operation_entry =
   { snapshot : Keeper_compaction_operation_reducer.snapshot
   ; requested_at : float
   ; request_cursor : Cursor.t
   }
 type replay = { operations : operation_entry list; end_cursor : Cursor.t }
 type slice = { rows : row list; end_cursor : Cursor.t }
-type event_rejection =
+type event_rejection = Projection.rejection =
+  | Cursor_mismatch of
+      { expected : Cursor.t
+      ; actual : Cursor.t
+      }
   | Transition_rejected of Keeper_compaction_operation_reducer.transition_error
   | Keeper_mismatch of
       { expected : Keeper_id.Keeper_name.t

--- a/lib/keeper_compaction_operation/keeper_operation_record.ml
+++ b/lib/keeper_compaction_operation/keeper_operation_record.ml
@@ -3,6 +3,8 @@ module Cursor = struct
   type error = Negative of int
   let zero = 0
   let of_int value = if value < 0 then Error (Negative value) else Ok value
+  let equal = Int.equal
+  let compare = Int.compare
   let to_int value = value
 end
 

--- a/lib/keeper_compaction_operation/keeper_operation_record.mli
+++ b/lib/keeper_compaction_operation/keeper_operation_record.mli
@@ -5,6 +5,8 @@ module Cursor : sig
   type error = Negative of int
   val zero : t
   val of_int : int -> (t, error) result
+  val equal : t -> t -> bool
+  val compare : t -> t -> int
   val to_int : t -> int
 end
 

--- a/test/keeper_compaction_operation_store/test_keeper_compaction_operation_store.ml
+++ b/test/keeper_compaction_operation_store/test_keeper_compaction_operation_store.ml
@@ -1,4 +1,6 @@
 module Operation = Keeper_compaction_operation
+module Projection = Keeper_compaction_operation_projection
+module Record = Keeper_operation_record
 module Store = Keeper_compaction_operation_store
 let ok = function Ok value -> value | Error _ -> Alcotest.fail "fixture failed"
 let keeper_name = ok (Keeper_id.Keeper_name.of_string "store-keeper")
@@ -34,6 +36,38 @@ let append base time event =
   match Store.append ~base_path:base ~keeper_name ~recorded_at:time event with
   | Ok row -> row
   | Error _ -> Alcotest.fail "valid append failed"
+;;
+let cursor value = ok (Record.Cursor.of_int value)
+let row start_cursor end_cursor recorded_at event : Operation.event Record.row =
+  { recorded_at
+  ; start_cursor = cursor start_cursor
+  ; end_cursor = cursor end_cursor
+  ; event
+  }
+;;
+let test_incremental_projection_matches_replay () =
+  let rows =
+    [ row 0 10 1.0 (request op2)
+    ; row 10 20 2.0 (request op1)
+    ; row 20 30 3.0 (Operation.attempt_started ~operation_id:op2 ~attempt_id:attempt)
+    ]
+  in
+  let replayed = ok (Projection.replay ~keeper_name rows) in
+  let incremented =
+    List.fold_left
+      (fun state entry -> ok (Projection.apply state entry))
+      (Projection.empty ~keeper_name)
+      rows
+  in
+  Alcotest.(check bool) "same ordered entries" true
+    (Projection.operations replayed = Projection.operations incremented);
+  Alcotest.(check int) "same end cursor" 30
+    (Record.Cursor.to_int (Projection.end_cursor incremented));
+  match Projection.apply incremented (List.hd rows) with
+  | Error (Projection.Cursor_mismatch { expected; actual }) ->
+    Alcotest.(check int) "expected current end" 30 (Record.Cursor.to_int expected);
+    Alcotest.(check int) "stale row start" 0 (Record.Cursor.to_int actual)
+  | _ -> Alcotest.fail "stale row was not rejected explicitly"
 ;;
 let test_append_replay_and_slice () =
   with_base @@ fun base ->
@@ -98,7 +132,11 @@ let test_malformed_history_fails_loud () =
 let () =
   Alcotest.run "keeper compaction operation store"
     [ "journal",
-      [ Alcotest.test_case "append replay slice" `Quick test_append_replay_and_slice
+      [ Alcotest.test_case
+          "pure incremental replay"
+          `Quick
+          test_incremental_projection_matches_replay
+      ; Alcotest.test_case "append replay slice" `Quick test_append_replay_and_slice
       ; Alcotest.test_case "rejections no write" `Quick test_rejections_do_not_write
       ; Alcotest.test_case "malformed history" `Quick test_malformed_history_fails_loud
       ] ]


### PR DESCRIPTION
## Scope

- keep the pure immutable compaction projection inside the existing operation-store library rather than creating another public library
- validate exact cursor continuity, Keeper identity, reducer transitions, and producer uniqueness per row
- make the existing store delegate complete-history replay and append candidate validation to the projection
- expose ordered operation entries and the exact projected end cursor through abstract `Cursor.equal` / `Cursor.compare`

## Boundary

This PR adds no path, JSON codec, or writer. The existing store I/O append still rereads the full history and remains the open #24966 blocker. Exact cursor-CAS writer integration belongs after #24971.

The producer association-list scaling residue is recorded as #24997. It must become a typed immutable map whose structural ordering agrees with `producer_ref_equal`; this PR intentionally does not invent a string/JSON identity key.

## Proof

- focused wrapper build: `MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/keeper_compaction_operation_store/test_keeper_compaction_operation_store.exe test/keeper_operation_record/test_keeper_operation_record.exe`
- focused tests: operation store 5/5, operation record 5/5
- covers full replay vs row-by-row immutable projection, stale cursor rejection, reducer rejection, producer binding, and malformed-history fail-closed behavior
- `ocamlformat --check` and `git diff --check` pass
- diff against the stacked base: 262 additions + 104 deletions = 366 changed lines
