### PR TITLE
fix(discord): close binding integrity boundary

### DIFF
--- a/lib/gate/channel_gate_binding_store.ml
+++ b/lib/gate/channel_gate_binding_store.ml
@@ -25,6 +25,7 @@ type t = {
   binding_audit_path : unit -> string;
   binding_audit_read_path : unit -> string;
   guild_id_field : guild_id_field;
+  mutation_lock : Cross_context_mutex.t;
 }
 
 let create ~binding_store_path ~binding_store_read_path ~binding_audit_path
@@ -35,7 +36,84 @@ let create ~binding_store_path ~binding_store_read_path ~binding_audit_path
     binding_audit_path;
     binding_audit_read_path;
     guild_id_field;
+    mutation_lock = Cross_context_mutex.create ();
   }
+
+type binding_decode_error =
+  | Expected_object
+  | Blank_channel_id
+  | Non_canonical_channel_id of string
+  | Keeper_name_not_string of string
+  | Blank_keeper_name of string
+  | Non_canonical_keeper_name of {
+      channel_id : string;
+      keeper_name : string;
+    }
+  | Duplicate_channel_id of string
+
+type binding_store_error =
+  | Binding_store_io_failed of string
+  | Binding_store_decode_failed of {
+      path : string;
+      error : binding_decode_error;
+    }
+
+type audit_append_error =
+  | Audit_append_failed of Fs_compat.private_jsonl_append_error
+  | Audit_io_failed of string
+
+type mutation_error =
+  | Mutation_rejected of string
+  | Mutation_read_failed of binding_store_error
+  | Mutation_write_failed of string
+  | Mutation_audit_failed of {
+      audit_error : audit_append_error;
+      binding_rollback_error : string option;
+    }
+
+let binding_decode_error_to_string = function
+  | Expected_object -> "expected a JSON object mapping channel ids to keeper names"
+  | Blank_channel_id -> "channel id must not be blank"
+  | Non_canonical_channel_id value ->
+    Printf.sprintf "channel id must not contain surrounding whitespace: %S" value
+  | Keeper_name_not_string channel_id ->
+    Printf.sprintf "keeper name for channel %S must be a string" channel_id
+  | Blank_keeper_name channel_id ->
+    Printf.sprintf "keeper name for channel %S must not be blank" channel_id
+  | Non_canonical_keeper_name { channel_id; keeper_name } ->
+    Printf.sprintf
+      "keeper name for channel %S must not contain surrounding whitespace: %S"
+      channel_id
+      keeper_name
+  | Duplicate_channel_id channel_id ->
+    Printf.sprintf "channel id %S must occur at most once" channel_id
+
+let binding_store_error_to_string = function
+  | Binding_store_io_failed detail -> detail
+  | Binding_store_decode_failed { path; error } ->
+    Printf.sprintf "%s: %s" path (binding_decode_error_to_string error)
+
+let audit_append_error_to_string = function
+  | Audit_append_failed error -> Fs_compat.private_jsonl_append_error_to_string error
+  | Audit_io_failed detail -> detail
+
+let mutation_error_to_string = function
+  | Mutation_rejected detail -> detail
+  | Mutation_read_failed error ->
+    Printf.sprintf "binding store read failed: %s"
+      (binding_store_error_to_string error)
+  | Mutation_write_failed detail ->
+    Printf.sprintf "binding store write failed: %s" detail
+  | Mutation_audit_failed { audit_error; binding_rollback_error = None } ->
+    Printf.sprintf
+      "binding audit append failed; binding rollback succeeded: %s"
+      (audit_append_error_to_string audit_error)
+  | Mutation_audit_failed
+      { audit_error; binding_rollback_error = Some rollback_error } ->
+    Printf.sprintf
+      "binding audit append failed: %s; binding rollback failed: %s"
+      (audit_append_error_to_string audit_error)
+      rollback_error
 
 let unix_error_message path fn arg code =
   let callsite =
@@ -69,33 +147,55 @@ let read_json_file_opt path =
   | Ok json -> json
   | Error _ -> None
 
-let normalize_bindings_json (json : Yojson.Safe.t) : binding list =
+module String_set = Set.Make (String)
+
+let normalize_bindings_json (json : Yojson.Safe.t) :
+    (binding list, binding_decode_error) result =
   match json with
   | `Assoc items ->
-      items
-      |> List.filter_map (fun (raw_channel_id, raw_keeper_name) ->
-             let channel_id = String.trim raw_channel_id in
-             let keeper_name =
-               match raw_keeper_name with
-               | `String value -> String.trim value
-               | _ -> ""
-             in
-             if channel_id = "" || keeper_name = "" then None
-             else Some ({ channel_id; keeper_name } : binding))
-      |> List.sort (fun (a : binding) (b : binding) ->
-             String.compare a.channel_id b.channel_id)
-  | _ -> []
+    let rec decode seen acc = function
+      | [] ->
+        Ok
+          (List.sort
+             (fun (a : binding) (b : binding) ->
+               String.compare a.channel_id b.channel_id)
+             acc)
+      | (raw_channel_id, raw_keeper_name) :: rest ->
+        let channel_id = String.trim raw_channel_id in
+        if String.equal channel_id "" then Error Blank_channel_id
+        else if not (String.equal channel_id raw_channel_id) then
+          Error (Non_canonical_channel_id raw_channel_id)
+        else if String_set.mem channel_id seen then
+          Error (Duplicate_channel_id channel_id)
+        else
+          (match raw_keeper_name with
+           | `String raw_keeper_name ->
+             let keeper_name = String.trim raw_keeper_name in
+             if String.equal keeper_name "" then
+               Error (Blank_keeper_name channel_id)
+             else if not (String.equal keeper_name raw_keeper_name) then
+               Error
+                 (Non_canonical_keeper_name
+                    { channel_id; keeper_name = raw_keeper_name })
+             else
+               decode
+                 (String_set.add channel_id seen)
+                 (({ channel_id; keeper_name } : binding) :: acc)
+                 rest
+           | _ -> Error (Keeper_name_not_string channel_id))
+    in
+    decode String_set.empty [] items
+  | _ -> Error Expected_object
 
-let read_bindings_result store : (binding list, string) result =
+let read_bindings_result store : (binding list, binding_store_error) result =
   let path = store.binding_store_read_path () in
   match read_json_file_result path with
-  | Error msg -> Error msg
+  | Error msg -> Error (Binding_store_io_failed msg)
   | Ok None -> Ok []
-  | Ok (Some (`Assoc _ as json)) -> Ok (normalize_bindings_json json)
-  | Ok (Some _) ->
-    Error
-      (Printf.sprintf
-         "%s: expected JSON object mapping channel ids to keeper names" path)
+  | Ok (Some json) ->
+    normalize_bindings_json json
+    |> Result.map_error (fun error ->
+         Binding_store_decode_failed { path; error })
 
 let read_bindings store : binding list =
   match read_bindings_result store with
@@ -111,14 +211,10 @@ let binding_json (binding : binding) =
 
 (* Durable atomic write delegated to the Fs_compat durability SSOT:
    tmp -> fsync(tmp) -> rename -> best-effort fsync(parent dir), the same
-   primitive board/event-queue/Memory-OS persistence use. A local hand-rolled
-   tmp+rename here (as before) skips both fsyncs, so a crash between rename
-   and the kernel's dirty-page flush can leave the binding file truncated
-   even though [append_audit_event] already fsynced an audit entry claiming
-   the change landed. Mapping [Error] to [Sys_error] preserves this
-   function's existing raise-on-failure contract, which [bind]/[unbind] in
-   the 3 caller modules already catch via [try ... with Sys_error _ -> ...]. *)
-let save_bindings store (bindings : binding list) =
+   primitive board/event-queue/Memory-OS persistence use. The result-returning
+   form is the authority for transactional callers; [save_bindings] preserves
+   the older connector interface until those callers move to [mutate_bindings]. *)
+let save_bindings_result store (bindings : binding list) =
   let path = store.binding_store_path () in
   let normalized =
     bindings
@@ -132,9 +228,17 @@ let save_bindings store (bindings : binding list) =
     |> fun items -> `Assoc items
   in
   let dir = Filename.dirname path in
-  Fs_compat.mkdir_p dir;
   let content = Yojson.Safe.pretty_to_string normalized ^ "\n" in
-  match Fs_compat.save_file_atomic path content with
+  try
+    Fs_compat.mkdir_p dir;
+    Fs_compat.save_file_atomic path content
+  with
+  | Sys_error detail -> Error detail
+  | Unix.Unix_error (code, fn, arg) ->
+    Error (unix_error_message path fn arg code)
+
+let save_bindings store bindings =
+  match save_bindings_result store bindings with
   | Ok () -> ()
   | Error msg -> raise (Sys_error msg)
 
@@ -165,20 +269,44 @@ let audit_event_json store event =
         ("previous_keeper", `String event.previous_keeper);
       ])
 
-let append_audit_event store event =
+let append_audit_event_result store event =
   let path = store.binding_audit_path () in
-  let dir = Filename.dirname path in
-  Fs_compat.mkdir_p dir;
-  let oc =
-    open_out_gen [ Open_creat; Open_wronly; Open_append; Open_binary ] 0o644 path
-  in
-  Fun.protect
-    ~finally:(fun () -> close_out_noerr oc)
-    (fun () ->
-      output_string oc (Yojson.Safe.to_string (audit_event_json store event));
-      output_char oc '\n';
-      flush oc;
-      Unix.fsync (Unix.descr_of_out_channel oc))
+  let suffix = Yojson.Safe.to_string (audit_event_json store event) ^ "\n" in
+  try
+    Fs_compat.append_private_jsonl_durable_locked_result path suffix
+    |> Result.map_error (fun error -> Audit_append_failed error)
+  with
+  | Sys_error detail -> Error (Audit_io_failed detail)
+  | Unix.Unix_error (code, fn, arg) ->
+    Error (Audit_io_failed (unix_error_message path fn arg code))
+
+let append_audit_event store event =
+  match append_audit_event_result store event with
+  | Ok () -> ()
+  | Error error -> raise (Sys_error (audit_append_error_to_string error))
+
+let mutate_bindings store ~decide =
+  Cross_context_mutex.with_durable_lock store.mutation_lock (fun () ->
+    match read_bindings_result store with
+    | Error error -> Error (Mutation_read_failed error)
+    | Ok original_bindings ->
+      (match decide original_bindings with
+       | Error detail -> Error (Mutation_rejected detail)
+       | Ok (updated_bindings, audit_event, committed_value) ->
+         (match save_bindings_result store updated_bindings with
+          | Error detail -> Error (Mutation_write_failed detail)
+          | Ok () ->
+            (match append_audit_event_result store audit_event with
+             | Ok () -> Ok committed_value
+             | Error audit_error ->
+               let binding_rollback_error =
+                 match save_bindings_result store original_bindings with
+                 | Ok () -> None
+                 | Error detail -> Some detail
+               in
+               Error
+                 (Mutation_audit_failed
+                    { audit_error; binding_rollback_error })))))
 
 let rec drop_left n xs =
   if n <= 0 then xs

--- a/lib/gate/channel_gate_binding_store.mli
+++ b/lib/gate/channel_gate_binding_store.mli
@@ -24,6 +24,38 @@ type audit_event = {
 
 type t
 
+type binding_decode_error =
+  | Expected_object
+  | Blank_channel_id
+  | Non_canonical_channel_id of string
+  | Keeper_name_not_string of string
+  | Blank_keeper_name of string
+  | Non_canonical_keeper_name of {
+      channel_id : string;
+      keeper_name : string;
+    }
+  | Duplicate_channel_id of string
+
+type binding_store_error =
+  | Binding_store_io_failed of string
+  | Binding_store_decode_failed of {
+      path : string;
+      error : binding_decode_error;
+    }
+
+type audit_append_error =
+  | Audit_append_failed of Fs_compat.private_jsonl_append_error
+  | Audit_io_failed of string
+
+type mutation_error =
+  | Mutation_rejected of string
+  | Mutation_read_failed of binding_store_error
+  | Mutation_write_failed of string
+  | Mutation_audit_failed of {
+      audit_error : audit_append_error;
+      binding_rollback_error : string option;
+    }
+
 val create :
   binding_store_path:(unit -> string) ->
   binding_store_read_path:(unit -> string) ->
@@ -34,11 +66,20 @@ val create :
 
 val read_json_file_result : string -> (Yojson.Safe.t option, string) result
 val read_json_file_opt : string -> Yojson.Safe.t option
-val normalize_bindings_json : Yojson.Safe.t -> binding list
-val read_bindings_result : t -> (binding list, string) result
+val normalize_bindings_json :
+  Yojson.Safe.t -> (binding list, binding_decode_error) result
+val binding_decode_error_to_string : binding_decode_error -> string
+val binding_store_error_to_string : binding_store_error -> string
+val audit_append_error_to_string : audit_append_error -> string
+val mutation_error_to_string : mutation_error -> string
+val read_bindings_result : t -> (binding list, binding_store_error) result
 val read_bindings : t -> binding list
 val binding_json : binding -> Yojson.Safe.t
 val save_bindings : t -> binding list -> unit
 val audit_event_json : t -> audit_event -> Yojson.Safe.t
 val append_audit_event : t -> audit_event -> unit
+val mutate_bindings :
+  t ->
+  decide:(binding list -> (binding list * audit_event * 'a, string) result) ->
+  ('a, mutation_error) result
 val read_recent_audit : t -> limit:int -> Yojson.Safe.t list

--- a/lib/gate/channel_gate_discord_state.ml
+++ b/lib/gate/channel_gate_discord_state.ml
@@ -49,6 +49,7 @@ let binding_store =
     ~binding_audit_read_path ~guild_id_field:Store.Include_event_value
 
 let read_bindings () = Store.read_bindings binding_store
+let read_bindings_result () = Store.read_bindings_result binding_store
 let binding_json = Store.binding_json
 let save_bindings bindings = Store.save_bindings binding_store bindings
 let append_audit_event event = Store.append_audit_event binding_store event
@@ -56,7 +57,7 @@ let read_recent_audit ~limit = Store.read_recent_audit binding_store ~limit
 
 (* ── Thread registry ──────────────────────────────────────────────
    Thread→parent mapping populated from THREAD_CREATE gateway events.
-   Used by [resolve_keeper_for_channel] to resolve bindings for thread
+   Used by [resolve_keeper_for_channel_result] to resolve bindings for thread
    messages whose channel_id is the thread's snowflake, not the parent
    channel's. Module-level mutable state (same pattern as [last_ready]). *)
 
@@ -374,8 +375,17 @@ let connector_json ?gate_status_json ?(audit_limit = 10) () =
     ]
 
 let rollback_bindings original_bindings =
-  try save_bindings original_bindings with
-  | Sys_error _ -> ()
+  try
+    save_bindings original_bindings;
+    Ok ()
+  with
+  | Sys_error detail -> Error detail
+
+let mutation_error ~primary ~rollback =
+  match rollback with
+  | Ok () -> primary
+  | Error rollback_detail ->
+    Printf.sprintf "%s; rollback failed: %s" primary rollback_detail
 
 let bind ~channel_id ~keeper_name ~actor_name =
   let channel_id = String.trim channel_id in
@@ -385,7 +395,9 @@ let bind ~channel_id ~keeper_name ~actor_name =
   else if keeper_name = "" then
     Error "keeper_name is required"
   else
-    let original_bindings = read_bindings () in
+    match read_bindings_result () with
+    | Error detail -> Error ("binding store read failed: " ^ detail)
+    | Ok original_bindings ->
     let previous_keeper =
       original_bindings
       |> List.find_map (fun (binding : binding) ->
@@ -423,15 +435,19 @@ let bind ~channel_id ~keeper_name ~actor_name =
       Ok (status_json ())
     with
     | Sys_error msg ->
-        rollback_bindings original_bindings;
-        Error msg
+      Error
+        (mutation_error
+           ~primary:msg
+           ~rollback:(rollback_bindings original_bindings))
 
 let unbind ~channel_id ~actor_name =
   let channel_id = String.trim channel_id in
   if channel_id = "" then
     Error "channel_id is required"
   else
-    let original_bindings = read_bindings () in
+    match read_bindings_result () with
+    | Error detail -> Error ("binding store read failed: " ^ detail)
+    | Ok original_bindings ->
     match
       original_bindings
       |> List.find_opt (fun (binding : binding) ->
@@ -464,8 +480,10 @@ let unbind ~channel_id ~actor_name =
           Ok (status_json ())
         with
         | Sys_error msg ->
-            rollback_bindings original_bindings;
-            Error msg
+          Error
+            (mutation_error
+               ~primary:msg
+               ~rollback:(rollback_bindings original_bindings))
 
 (* ---------------------------------------------------------------- *)
 (* In-process gateway support — replaces sidecars/discord-bot/      *)
@@ -478,106 +496,83 @@ type keeper_binding_resolution = {
   via_parent : bool;
 }
 
+type binding_lookup_error =
+  | Binding_store_read_failed of string
+
+let pp_binding_lookup_error formatter = function
+  | Binding_store_read_failed detail ->
+    Format.fprintf formatter "Discord binding store read failed: %s" detail
+
 let binding_for_channel bindings ~channel_id =
   List.find_map
     (fun (b : binding) ->
       if String.equal b.channel_id channel_id then Some b else None)
     bindings
 
-let resolve_keeper_for_channel ~channel_id =
+let resolve_keeper_for_channel_result ~channel_id =
   let normalized = String.trim channel_id in
-  if String.equal normalized "" then None
+  if String.equal normalized "" then Ok None
   else
-    let candidates =
-      try read_bindings ()
-      with
-      | Eio.Cancel.Cancelled _ as e -> raise e
-      | _ -> []
-    in
-    match binding_for_channel candidates ~channel_id:normalized with
-    | Some b ->
-        Some
-          {
-            keeper_name = b.keeper_name;
-            incoming_channel_id = normalized;
-            bound_channel_id = b.channel_id;
-            via_parent = false;
-          }
-    | None -> (
-        (* Thread fallback: if this channel_id is a known Discord thread,
-           try resolving via its parent channel's binding. *)
-        match parent_channel_of_thread ~channel_id:normalized with
-        | Some parent_id when parent_id <> normalized ->
-            (match binding_for_channel candidates ~channel_id:parent_id with
-             | Some b ->
-                 Some
-                   {
-                     keeper_name = b.keeper_name;
-                     incoming_channel_id = normalized;
-                     bound_channel_id = b.channel_id;
-                     via_parent = true;
-                   }
-             | None -> (
-                 (* Final fallback: names file (legacy sidecar data). *)
-                 let names_parent =
-                   try Names.resolve_parent_channel_id_for_channel ~channel_id:normalized
-                   with
-                   | Eio.Cancel.Cancelled _ as e -> raise e
-                   | _ -> None
-                 in
-                 match names_parent with
-                 | None -> None
-                 | Some names_parent ->
-                     let names_parent = String.trim names_parent in
-                     match binding_for_channel candidates ~channel_id:names_parent with
-                     | None -> None
-                     | Some b ->
-                         Some
-                           {
-                             keeper_name = b.keeper_name;
-                             incoming_channel_id = normalized;
-                             bound_channel_id = b.channel_id;
-                             via_parent = true;
-                           } ))
-        | _ -> (
-            (* No thread match — try names file (legacy sidecar data). *)
-            let parent_channel_id =
-              try Names.resolve_parent_channel_id_for_channel ~channel_id:normalized
-              with
-              | Eio.Cancel.Cancelled _ as e -> raise e
-              | _ -> None
-            in
-            match parent_channel_id with
-            | None -> None
-            | Some parent_channel_id -> (
-                let parent_channel_id = String.trim parent_channel_id in
-                match binding_for_channel candidates ~channel_id:parent_channel_id with
-                | None -> None
-                | Some b ->
-                    Some
-                      {
-                        keeper_name = b.keeper_name;
-                        incoming_channel_id = normalized;
-                        bound_channel_id = b.channel_id;
-                        via_parent = true;
-                      } )) )
+    match read_bindings_result () with
+    | Error detail -> Error (Binding_store_read_failed detail)
+    | Ok candidates ->
+      let binding, via_parent =
+        match binding_for_channel candidates ~channel_id:normalized with
+        | Some binding -> Some binding, false
+        | None ->
+          let parent_binding =
+            Option.bind
+              (parent_channel_of_thread ~channel_id:normalized)
+              (fun parent_channel_id ->
+                 if String.equal parent_channel_id normalized
+                 then None
+                 else
+                   binding_for_channel candidates
+                     ~channel_id:parent_channel_id)
+          in
+          parent_binding, true
+      in
+      Ok
+        (Option.map
+           (fun (binding : binding) ->
+              { keeper_name = binding.keeper_name
+              ; incoming_channel_id = normalized
+              ; bound_channel_id = binding.channel_id
+              ; via_parent
+              })
+           binding)
+
+let keeper_for_channel_result ~channel_id =
+  resolve_keeper_for_channel_result ~channel_id
+  |> Result.map
+       (Option.map (fun resolution -> resolution.keeper_name))
 
 let keeper_for_channel ~channel_id =
-  match resolve_keeper_for_channel ~channel_id with
-  | None -> None
-  | Some resolution -> Some resolution.keeper_name
+  match keeper_for_channel_result ~channel_id with
+  | Ok keeper_name -> keeper_name
+  | Error error ->
+    failwith (Format.asprintf "%a" pp_binding_lookup_error error)
 
 (* RFC-0223 P2: presence surface. Both recomputed per call — no cached
    presence state. *)
 
-let bound_channels ~keeper_name =
+let bound_channels_result ~keeper_name =
   let normalized = String.trim keeper_name in
-  if String.equal normalized "" then []
+  if String.equal normalized "" then Ok []
   else
-    read_bindings ()
-    |> List.filter_map (fun (b : binding) ->
-           if String.equal b.keeper_name normalized then Some b.channel_id
-           else None)
+    read_bindings_result ()
+    |> Result.map (fun bindings ->
+         bindings
+         |> List.filter_map (fun (b : binding) ->
+              if String.equal b.keeper_name normalized
+              then Some b.channel_id
+              else None))
+
+let bound_channels ~keeper_name =
+  match bound_channels_result ~keeper_name with
+  | Ok channels -> channels
+  | Error detail ->
+    failwith ("Discord binding store read failed: " ^ detail)
 
 let connected () =
   (* The in-process gateway (RFC-0203) is the only Discord transport;

--- a/lib/gate/channel_gate_discord_state.ml
+++ b/lib/gate/channel_gate_discord_state.ml
@@ -50,16 +50,17 @@ let binding_store =
 
 let read_bindings_result () = Store.read_bindings_result binding_store
 let binding_json = Store.binding_json
-let save_bindings bindings = Store.save_bindings binding_store bindings
-let append_audit_event event = Store.append_audit_event binding_store event
 let read_recent_audit ~limit = Store.read_recent_audit binding_store ~limit
 
 type binding_lookup_error =
-  | Binding_store_read_failed of string
+  | Binding_store_read_failed of Store.binding_store_error
 
 let pp_binding_lookup_error formatter = function
   | Binding_store_read_failed detail ->
-    Format.fprintf formatter "Discord binding store read failed: %s" detail
+    Format.fprintf
+      formatter
+      "Discord binding store read failed: %s"
+      (Store.binding_store_error_to_string detail)
 
 let binding_lookup_error_to_string error =
   Format.asprintf "%a" pp_binding_lookup_error error
@@ -404,19 +405,6 @@ let connector_json ?gate_status_json ?(audit_limit = 10) () =
       ("observed_channel", observed_channel);
     ]
 
-let rollback_bindings original_bindings =
-  try
-    save_bindings original_bindings;
-    Ok ()
-  with
-  | Sys_error detail -> Error detail
-
-let mutation_error ~primary ~rollback =
-  match rollback with
-  | Ok () -> primary
-  | Error rollback_detail ->
-    Printf.sprintf "%s; rollback failed: %s" primary rollback_detail
-
 let bind ~channel_id ~keeper_name ~actor_name =
   let channel_id = String.trim channel_id in
   let keeper_name = String.trim keeper_name in
@@ -425,95 +413,86 @@ let bind ~channel_id ~keeper_name ~actor_name =
   else if keeper_name = "" then
     Error "keeper_name is required"
   else
-    match read_bindings_result () with
-    | Error detail -> Error ("binding store read failed: " ^ detail)
-    | Ok original_bindings ->
-    let previous_keeper =
-      original_bindings
-      |> List.find_map (fun (binding : binding) ->
+    Store.mutate_bindings binding_store ~decide:(fun original_bindings ->
+      let previous_keeper =
+        original_bindings
+        |> List.find_map (fun (binding : binding) ->
              if String.equal binding.channel_id channel_id then
                Some binding.keeper_name
-             else
-               None)
-      |> Option.value ~default:""
-    in
-    let updated_bindings =
-      (({ channel_id; keeper_name } : binding)
-       :: List.filter
-            (fun (binding : binding) ->
-              not (String.equal binding.channel_id channel_id))
-            original_bindings)
-      |> List.sort (fun (a : binding) (b : binding) ->
-             String.compare a.channel_id b.channel_id)
-    in
-    try
-      save_bindings updated_bindings;
-      let guild_id =
-        Option.value (Names.resolve_guild_id_for_channel ~channel_id) ~default:""
+             else None)
+        |> function
+        | Some keeper_name -> keeper_name
+        | None ->
+          (* DET-OK: the audit wire contract uses an empty string to represent
+             that this channel had no previous binding; it does not affect the
+             mutation decision. *)
+          ""
       in
-      append_audit_event
-        Store.{
-          timestamp = Gate_time_util.iso8601_of_unix (Unix.gettimeofday ());
-          action = "bind";
-          guild_id = Some guild_id;
-          channel_id;
-          keeper_name;
-          actor_id = actor_name;
-          actor_name;
-          previous_keeper;
-        };
-      Ok (status_json ())
-    with
-    | Sys_error msg ->
-      Error
-        (mutation_error
-           ~primary:msg
-           ~rollback:(rollback_bindings original_bindings))
+      let updated_bindings =
+        (({ channel_id; keeper_name } : binding)
+         :: List.filter
+              (fun (binding : binding) ->
+                not (String.equal binding.channel_id channel_id))
+              original_bindings)
+        |> List.sort (fun (a : binding) (b : binding) ->
+             String.compare a.channel_id b.channel_id)
+      in
+      let guild_id = Names.resolve_guild_id_for_channel ~channel_id in
+      Ok
+        ( updated_bindings
+        , Store.{
+            (* NDT-OK: wall-clock time is persisted as operator-facing audit
+               evidence only; mutation ordering comes from the durable lock. *)
+            timestamp = Gate_time_util.iso8601_of_unix (Unix.gettimeofday ());
+            action = "bind";
+            guild_id;
+            channel_id;
+            keeper_name;
+            actor_id = actor_name;
+            actor_name;
+            previous_keeper;
+          }
+        , () ))
+    |> Result.map_error Store.mutation_error_to_string
+    |> Result.map (fun () -> status_json ())
 
 let unbind ~channel_id ~actor_name =
   let channel_id = String.trim channel_id in
   if channel_id = "" then
     Error "channel_id is required"
   else
-    match read_bindings_result () with
-    | Error detail -> Error ("binding store read failed: " ^ detail)
-    | Ok original_bindings ->
-    match
-      original_bindings
-      |> List.find_opt (fun (binding : binding) ->
+    Store.mutate_bindings binding_store ~decide:(fun original_bindings ->
+      match
+        original_bindings
+        |> List.find_opt (fun (binding : binding) ->
              String.equal binding.channel_id channel_id)
-    with
-    | None -> Error "binding not found"
-    | Some (removed_binding : binding) ->
+      with
+      | None -> Error "binding not found"
+      | Some (removed_binding : binding) ->
         let updated_bindings =
           List.filter
             (fun (binding : binding) ->
               not (String.equal binding.channel_id channel_id))
             original_bindings
         in
-        try
-          save_bindings updated_bindings;
-          let guild_id =
-            Option.value (Names.resolve_guild_id_for_channel ~channel_id) ~default:""
-          in
-          append_audit_event
-            Store.{
+        let guild_id = Names.resolve_guild_id_for_channel ~channel_id in
+        Ok
+          ( updated_bindings
+          , Store.{
+              (* NDT-OK: wall-clock time is persisted as operator-facing audit
+                 evidence only; mutation ordering comes from the durable lock. *)
               timestamp = Gate_time_util.iso8601_of_unix (Unix.gettimeofday ());
               action = "unbind";
-              guild_id = Some guild_id;
+              guild_id;
               channel_id;
               keeper_name = removed_binding.keeper_name;
               actor_id = actor_name;
               actor_name;
               previous_keeper = removed_binding.keeper_name;
-            };
-          Ok (status_json ())
-        with
-        | Sys_error msg ->
-          Error
-            (mutation_error
-               ~primary:msg
-               ~rollback:(rollback_bindings original_bindings))
+            }
+          , () ))
+    |> Result.map_error Store.mutation_error_to_string
+    |> Result.map (fun () -> status_json ())
 
 (* ---------------------------------------------------------------- *)
 (* In-process gateway support — replaces sidecars/discord-bot/      *)

--- a/lib/gate/channel_gate_discord_state.ml
+++ b/lib/gate/channel_gate_discord_state.ml
@@ -547,12 +547,6 @@ let keeper_for_channel_result ~channel_id =
   |> Result.map
        (Option.map (fun resolution -> resolution.keeper_name))
 
-let keeper_for_channel ~channel_id =
-  match keeper_for_channel_result ~channel_id with
-  | Ok keeper_name -> keeper_name
-  | Error error ->
-    failwith (Format.asprintf "%a" pp_binding_lookup_error error)
-
 (* RFC-0223 P2: presence surface. Both recomputed per call — no cached
    presence state. *)
 
@@ -572,7 +566,11 @@ let bound_channels ~keeper_name =
   match bound_channels_result ~keeper_name with
   | Ok channels -> channels
   | Error detail ->
-    failwith ("Discord binding store read failed: " ^ detail)
+    Log.Discord.error
+      "Discord binding presence read failed (keeper=%s): %s"
+      keeper_name
+      detail;
+    []
 
 let connected () =
   (* The in-process gateway (RFC-0203) is the only Discord transport;

--- a/lib/gate/channel_gate_discord_state.ml
+++ b/lib/gate/channel_gate_discord_state.ml
@@ -503,6 +503,9 @@ let pp_binding_lookup_error formatter = function
   | Binding_store_read_failed detail ->
     Format.fprintf formatter "Discord binding store read failed: %s" detail
 
+let binding_lookup_error_to_string error =
+  Format.asprintf "%a" pp_binding_lookup_error error
+
 let binding_for_channel bindings ~channel_id =
   List.find_map
     (fun (b : binding) ->
@@ -516,31 +519,35 @@ let resolve_keeper_for_channel_result ~channel_id =
     match read_bindings_result () with
     | Error detail -> Error (Binding_store_read_failed detail)
     | Ok candidates ->
-      let binding, via_parent =
-        match binding_for_channel candidates ~channel_id:normalized with
-        | Some binding -> Some binding, false
-        | None ->
-          let parent_binding =
-            Option.bind
-              (parent_channel_of_thread ~channel_id:normalized)
-              (fun parent_channel_id ->
-                 if String.equal parent_channel_id normalized
-                 then None
-                 else
-                   binding_for_channel candidates
-                     ~channel_id:parent_channel_id)
-          in
-          parent_binding, true
-      in
-      Ok
-        (Option.map
-           (fun (binding : binding) ->
+      (match binding_for_channel candidates ~channel_id:normalized with
+       | Some binding ->
+         Ok
+           (Some
               { keeper_name = binding.keeper_name
               ; incoming_channel_id = normalized
               ; bound_channel_id = binding.channel_id
-              ; via_parent
+              ; via_parent = false
               })
-           binding)
+       | None ->
+         let parent_binding =
+           Option.bind
+             (parent_channel_of_thread ~channel_id:normalized)
+             (fun parent_channel_id ->
+                if String.equal parent_channel_id normalized
+                then None
+                else
+                  binding_for_channel candidates
+                    ~channel_id:parent_channel_id)
+         in
+         Ok
+           (Option.map
+              (fun (binding : binding) ->
+                 { keeper_name = binding.keeper_name
+                 ; incoming_channel_id = normalized
+                 ; bound_channel_id = binding.channel_id
+                 ; via_parent = true
+                 })
+              parent_binding))
 
 let keeper_for_channel_result ~channel_id =
   resolve_keeper_for_channel_result ~channel_id
@@ -555,6 +562,7 @@ let bound_channels_result ~keeper_name =
   if String.equal normalized "" then Ok []
   else
     read_bindings_result ()
+    |> Result.map_error (fun detail -> Binding_store_read_failed detail)
     |> Result.map (fun bindings ->
          bindings
          |> List.filter_map (fun (b : binding) ->
@@ -569,7 +577,7 @@ let bound_channels ~keeper_name =
     Log.Discord.error
       "Discord binding presence read failed (keeper=%s): %s"
       keeper_name
-      detail;
+      (binding_lookup_error_to_string detail);
     []
 
 let connected () =

--- a/lib/gate/channel_gate_discord_state.ml
+++ b/lib/gate/channel_gate_discord_state.ml
@@ -48,12 +48,25 @@ let binding_store =
   Store.create ~binding_store_path ~binding_store_read_path ~binding_audit_path
     ~binding_audit_read_path ~guild_id_field:Store.Include_event_value
 
-let read_bindings () = Store.read_bindings binding_store
 let read_bindings_result () = Store.read_bindings_result binding_store
 let binding_json = Store.binding_json
 let save_bindings bindings = Store.save_bindings binding_store bindings
 let append_audit_event event = Store.append_audit_event binding_store event
 let read_recent_audit ~limit = Store.read_recent_audit binding_store ~limit
+
+type binding_lookup_error =
+  | Binding_store_read_failed of string
+
+let pp_binding_lookup_error formatter = function
+  | Binding_store_read_failed detail ->
+    Format.fprintf formatter "Discord binding store read failed: %s" detail
+
+let binding_lookup_error_to_string error =
+  Format.asprintf "%a" pp_binding_lookup_error error
+
+let read_bindings_lookup_result () =
+  read_bindings_result ()
+  |> Result.map_error (fun detail -> Binding_store_read_failed detail)
 
 (* ── Thread registry ──────────────────────────────────────────────
    Thread→parent mapping populated from THREAD_CREATE gateway events.
@@ -174,17 +187,24 @@ let status_json ?(audit_limit = 10) () =
   let audit_path = binding_audit_read_path () in
   let names_path = Names.names_read_path () in
   let name_map = Names.read () in
-  let configured_bindings = read_bindings () in
+  let configured_bindings_result = read_bindings_lookup_result () in
+  let configured_bindings = Result.value ~default:[] configured_bindings_result in
+  let binding_store_error =
+    match configured_bindings_result with
+    | Ok _ -> None
+    | Error error -> Some (binding_lookup_error_to_string error)
+  in
   let recent_audit = read_recent_audit ~limit:audit_limit in
   let channel = "discord" in
   let gateway_state = Discord_gateway_client.connection_state () in
   let token_present = Option.is_some (bot_token_opt ()) in
-  let available =
+  let transport_available =
     match gateway_state with
     | Disconnected -> token_present
     | Awaiting_hello | Identifying | Resuming | Connected _
     | Reconnect_pending _ | Failed _ -> true
   in
+  let available = transport_available && Result.is_ok configured_bindings_result in
   let connected =
     match gateway_state with
     | Connected _ -> true
@@ -195,13 +215,20 @@ let status_json ?(audit_limit = 10) () =
   (* NDT-OK: status_json is a dashboard observation boundary; this timestamp
      only reports gateway freshness and is not used for control flow. *)
   let updated_at = Gate_time_util.iso8601_of_unix (Unix.gettimeofday ()) in
-  let error =
+  let gateway_error =
     match gateway_state with
     | Disconnected ->
       if token_present then "" else "DISCORD_BOT_TOKEN is unset or empty"
     | Failed msg -> msg
     | Awaiting_hello | Identifying | Resuming | Connected _
     | Reconnect_pending _ -> ""
+  in
+  let error =
+    [ (if String.equal gateway_error "" then None else Some gateway_error)
+    ; binding_store_error
+    ]
+    |> List.filter_map Fun.id
+    |> String.concat "; "
   in
   `Assoc
     [
@@ -243,6 +270,9 @@ let status_json ?(audit_limit = 10) () =
       ("gate_healthy", if connected then `Bool true else `Null);
       ("gate_health_checked_at", `String (if connected then updated_at else ""));
       ("binding_source", `String "persisted");
+      ("binding_store_read_ok", `Bool (Result.is_ok configured_bindings_result));
+      ( "binding_store_error",
+        `String (Option.value ~default:"" binding_store_error) );
       ("runtime_bindings_count", `Int (List.length configured_bindings));
       (* NDT-OK: pid is process identity telemetry for operators; availability
          and connection status come from the gateway state above. *)
@@ -496,16 +526,6 @@ type keeper_binding_resolution = {
   via_parent : bool;
 }
 
-type binding_lookup_error =
-  | Binding_store_read_failed of string
-
-let pp_binding_lookup_error formatter = function
-  | Binding_store_read_failed detail ->
-    Format.fprintf formatter "Discord binding store read failed: %s" detail
-
-let binding_lookup_error_to_string error =
-  Format.asprintf "%a" pp_binding_lookup_error error
-
 let binding_for_channel bindings ~channel_id =
   List.find_map
     (fun (b : binding) ->
@@ -516,8 +536,8 @@ let resolve_keeper_for_channel_result ~channel_id =
   let normalized = String.trim channel_id in
   if String.equal normalized "" then Ok None
   else
-    match read_bindings_result () with
-    | Error detail -> Error (Binding_store_read_failed detail)
+    match read_bindings_lookup_result () with
+    | Error _ as error -> error
     | Ok candidates ->
       (match binding_for_channel candidates ~channel_id:normalized with
        | Some binding ->
@@ -561,8 +581,7 @@ let bound_channels_result ~keeper_name =
   let normalized = String.trim keeper_name in
   if String.equal normalized "" then Ok []
   else
-    read_bindings_result ()
-    |> Result.map_error (fun detail -> Binding_store_read_failed detail)
+    read_bindings_lookup_result ()
     |> Result.map (fun bindings ->
          bindings
          |> List.filter_map (fun (b : binding) ->

--- a/lib/gate/channel_gate_discord_state.mli
+++ b/lib/gate/channel_gate_discord_state.mli
@@ -74,6 +74,7 @@ type binding_lookup_error =
   | Binding_store_read_failed of string
 
 val pp_binding_lookup_error : Format.formatter -> binding_lookup_error -> unit
+val binding_lookup_error_to_string : binding_lookup_error -> string
 
 val keeper_for_channel_result :
   channel_id:string -> (string option, binding_lookup_error) result
@@ -93,8 +94,10 @@ val bound_channels : keeper_name:string -> string list
     Callers that need control-flow authority must use
     {!bound_channels_result}. RFC-0223 P2 presence. *)
 
-val bound_channels_result : keeper_name:string -> (string list, string) result
-(** Typed bound-channel lookup. *)
+val bound_channels_result :
+  keeper_name:string -> (string list, binding_lookup_error) result
+(** Typed bound-channel lookup. Store failures use the same error contract as
+    single-channel lookup. *)
 
 val connected : unit -> bool
 (** Whether the in-process gateway's run loop currently reports

--- a/lib/gate/channel_gate_discord_state.mli
+++ b/lib/gate/channel_gate_discord_state.mli
@@ -63,11 +63,6 @@ val unbind :
     that replaces the deleted [sidecars/discord-bot/] Python
     connector. *)
 
-val keeper_for_channel : channel_id:string -> string option
-(** Look up the keeper bound to a Discord channel snowflake.
-    Returns [None] when no binding exists, when the channel id is
-    blank, or when the binding store is unreadable. *)
-
 type keeper_binding_resolution = {
   keeper_name : string;
   incoming_channel_id : string;
@@ -75,16 +70,33 @@ type keeper_binding_resolution = {
   via_parent : bool;
 }
 
-val resolve_keeper_for_channel :
-  channel_id:string -> keeper_binding_resolution option
-(** Resolve the keeper for [channel_id]. Exact bindings win. If no
-    exact binding exists and [channel_id] is a Discord thread known
-    in the names side-store, its parent channel binding is used. *)
+type binding_lookup_error =
+  | Binding_store_read_failed of string
+
+val pp_binding_lookup_error : Format.formatter -> binding_lookup_error -> unit
+
+val keeper_for_channel_result :
+  channel_id:string -> (string option, binding_lookup_error) result
+(** Typed keeper lookup. A binding-store read failure is distinct from an
+    unbound channel. *)
+
+val keeper_for_channel : channel_id:string -> string option
+(** Compatibility projection of {!keeper_for_channel_result}. Store failures
+    raise rather than silently becoming [None]. *)
+
+val resolve_keeper_for_channel_result :
+  channel_id:string ->
+  (keeper_binding_resolution option, binding_lookup_error) result
+(** Resolve the keeper for [channel_id]. Exact bindings win. The only
+    parent fallback is an in-process thread-registry observation. *)
 
 val bound_channels : keeper_name:string -> string list
 (** Channel snowflakes bound to [keeper_name], freshly read from the
-    binding store on each call. Empty on blank name or unreadable
-    store. RFC-0223 P2 presence. *)
+    binding store on each call. Store failures raise rather than silently
+    becoming an empty set. RFC-0223 P2 presence. *)
+
+val bound_channels_result : keeper_name:string -> (string list, string) result
+(** Typed bound-channel lookup. *)
 
 val connected : unit -> bool
 (** Whether the in-process gateway's run loop currently reports
@@ -100,7 +112,7 @@ val record_ready : bot_user_id:string -> unit
 (** {2 Thread registry}
 
     Thread→parent channel mapping populated from THREAD_CREATE gateway
-    events. Used by {!resolve_keeper_for_channel} to resolve bindings
+    events. Used by {!resolve_keeper_for_channel_result} to resolve bindings
     for messages in Discord threads (whose [channel_id] is the thread's
     snowflake, distinct from the parent channel). *)
 

--- a/lib/gate/channel_gate_discord_state.mli
+++ b/lib/gate/channel_gate_discord_state.mli
@@ -10,7 +10,7 @@
     [string_member] / [int_member] / [bool_member] /
     [bool_option_member] yojson lookups, [stale_of_updated_at],
     [connector_state_label], [list_assoc_field],
-    [find_assoc_by_string_field], and [rollback_bindings]) are
+    [find_assoc_by_string_field], and binding transaction helpers) are
     hidden — only the {!Channel_gate_connector.S} surface is
     public. *)
 
@@ -71,7 +71,7 @@ type keeper_binding_resolution = {
 }
 
 type binding_lookup_error =
-  | Binding_store_read_failed of string
+  | Binding_store_read_failed of Channel_gate_binding_store.binding_store_error
 
 val pp_binding_lookup_error : Format.formatter -> binding_lookup_error -> unit
 val binding_lookup_error_to_string : binding_lookup_error -> string

--- a/lib/gate/channel_gate_discord_state.mli
+++ b/lib/gate/channel_gate_discord_state.mli
@@ -80,10 +80,6 @@ val keeper_for_channel_result :
 (** Typed keeper lookup. A binding-store read failure is distinct from an
     unbound channel. *)
 
-val keeper_for_channel : channel_id:string -> string option
-(** Compatibility projection of {!keeper_for_channel_result}. Store failures
-    raise rather than silently becoming [None]. *)
-
 val resolve_keeper_for_channel_result :
   channel_id:string ->
   (keeper_binding_resolution option, binding_lookup_error) result
@@ -92,8 +88,10 @@ val resolve_keeper_for_channel_result :
 
 val bound_channels : keeper_name:string -> string list
 (** Channel snowflakes bound to [keeper_name], freshly read from the
-    binding store on each call. Store failures raise rather than silently
-    becoming an empty set. RFC-0223 P2 presence. *)
+    binding store on each call. The generic connector interface cannot carry
+    an error, so store failures are logged before returning an empty projection.
+    Callers that need control-flow authority must use
+    {!bound_channels_result}. RFC-0223 P2 presence. *)
 
 val bound_channels_result : keeper_name:string -> (string list, string) result
 (** Typed bound-channel lookup. *)

--- a/lib/gate/channel_gate_slack_state.ml
+++ b/lib/gate/channel_gate_slack_state.ml
@@ -223,7 +223,7 @@ let bind ~channel_id ~keeper_name ~actor_name =
   else if String.equal keeper_name "" then Error "keeper_name is required"
   else
     match read_bindings_result () with
-    | Error msg -> Error msg
+    | Error error -> Error (Store.binding_store_error_to_string error)
     | Ok original_bindings ->
       let previous_keeper =
         match
@@ -268,7 +268,7 @@ let unbind ~channel_id ~actor_name =
   if String.equal channel_id "" then Error "channel_id is required"
   else
     match read_bindings_result () with
-    | Error msg -> Error msg
+    | Error error -> Error (Store.binding_store_error_to_string error)
     | Ok original_bindings -> (
       match
         original_bindings
@@ -324,7 +324,7 @@ let resolve_keeper_for_channel_result ~channel_id =
   if String.equal normalized "" then Ok None
   else
     match read_bindings_result () with
-    | Error msg -> Error msg
+    | Error error -> Error (Store.binding_store_error_to_string error)
     | Ok candidates -> (
       match binding_for_channel candidates ~channel_id:normalized with
       | Some b ->

--- a/lib/gate/discord_observability.ml
+++ b/lib/gate/discord_observability.ml
@@ -30,6 +30,7 @@ type inbound_outcome =
 
 type ambient_outcome =
   | Ambient_recorded
+  | Ambient_binding_store_error
   | Ambient_dropped_unbound
   | Ambient_dropped_empty
   | Ambient_dropped_too_long
@@ -61,6 +62,7 @@ let inbound_outcome_label = function
 
 let ambient_outcome_label = function
   | Ambient_recorded -> "recorded"
+  | Ambient_binding_store_error -> "binding_store_error"
   | Ambient_dropped_unbound -> "dropped_unbound"
   | Ambient_dropped_empty -> "dropped_empty"
   | Ambient_dropped_too_long -> "dropped_too_long"

--- a/lib/gate/discord_observability.mli
+++ b/lib/gate/discord_observability.mli
@@ -34,6 +34,7 @@ type inbound_outcome =
 
 type ambient_outcome =
   | Ambient_recorded
+  | Ambient_binding_store_error
   | Ambient_dropped_unbound
   | Ambient_dropped_empty
   | Ambient_dropped_too_long

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -412,18 +412,24 @@ let handle_surface_post_with_outcome
     fail
       (Keeper_surface_post.error_json "content is required and must be non-empty.")
   else
-    let bound_discord_channels =
-      Channel_gate_discord_state.bound_channels ~keeper_name:meta.name
-    in
-    let bound_slack_channels =
-      Channel_gate_slack_state.bound_channels ~keeper_name:meta.name
-    in
     match
-      Keeper_surface_post.resolve_target ~surface ~channel_id
-        ~bound_slack_channels ~bound_discord_channels ()
+      Channel_gate_discord_state.bound_channels_result ~keeper_name:meta.name
     with
-    | Error message -> fail (Keeper_surface_post.error_json message)
-    | Ok Keeper_surface_post.To_dashboard ->
+    | Error detail ->
+      fail
+        ~class_:Tool_result.Runtime_failure
+        (Keeper_surface_post.error_json
+           ("Discord binding store read failed: " ^ detail))
+    | Ok bound_discord_channels ->
+      let bound_slack_channels =
+        Channel_gate_slack_state.bound_channels ~keeper_name:meta.name
+      in
+      (match
+         Keeper_surface_post.resolve_target ~surface ~channel_id
+           ~bound_slack_channels ~bound_discord_channels ()
+       with
+      | Error message -> fail (Keeper_surface_post.error_json message)
+      | Ok Keeper_surface_post.To_dashboard ->
         Keeper_chat_store.append_assistant_message
           ~base_dir:config.Workspace.base_path
           ~keeper_name:meta.name
@@ -540,7 +546,7 @@ let handle_surface_post_with_outcome
                 ~source:"slack"
                 ~content:safe_content
                 ();
-              succeed (Keeper_surface_post.ok_json ~surface ())))
+              succeed (Keeper_surface_post.ok_json ~surface ()))))
 ;;
 
 let handle_ide_annotate ~config ~(meta : keeper_meta) ~args =

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -419,7 +419,7 @@ let handle_surface_post_with_outcome
       fail
         ~class_:Tool_result.Runtime_failure
         (Keeper_surface_post.error_json
-           ("Discord binding store read failed: " ^ detail))
+           (Channel_gate_discord_state.binding_lookup_error_to_string detail))
     | Ok bound_discord_channels ->
       let bound_slack_channels =
         Channel_gate_slack_state.bound_channels ~keeper_name:meta.name

--- a/lib/server/discord_presence_bridge.ml
+++ b/lib/server/discord_presence_bridge.ml
@@ -55,6 +55,7 @@ let live_keeper_presence ~base_path =
             keeper_presence_of_registry_entry ~base_path entry
             |> Result.map (fun keeper -> keeper :: keepers))
        (Ok [])
+  |> Result.map List.rev
 ;;
 
 let update_presence ~workspace_config =
@@ -63,7 +64,7 @@ let update_presence ~workspace_config =
   | Error detail ->
     Log.Discord.error
       "discord_presence_bridge: binding read failed: %s"
-      detail
+      (Channel_gate_discord_state.binding_lookup_error_to_string detail)
   | Ok keepers ->
     (match
        presence_status_for_keepers

--- a/lib/server/discord_presence_bridge.ml
+++ b/lib/server/discord_presence_bridge.ml
@@ -37,27 +37,41 @@ let presence_status_for_keepers ~gateway_connected keepers =
 
 let keeper_presence_of_registry_entry ~base_path (entry : Keeper_registry.registry_entry)
   =
-  { keeper_name = entry.name
-  ; running = Keeper_registry.is_running ~base_path entry.name
-  ; bound_channels =
-      Channel_gate_discord_state.bound_channels ~keeper_name:entry.name
-  }
+  Channel_gate_discord_state.bound_channels_result ~keeper_name:entry.name
+  |> Result.map (fun bound_channels ->
+       { keeper_name = entry.name
+       ; running = Keeper_registry.is_running ~base_path entry.name
+       ; bound_channels
+       })
 ;;
 
 let live_keeper_presence ~base_path =
   Keeper_registry.all ~base_path ()
-  |> List.map (keeper_presence_of_registry_entry ~base_path)
+  |> List.fold_left
+       (fun result entry ->
+          match result with
+          | Error _ as error -> error
+          | Ok keepers ->
+            keeper_presence_of_registry_entry ~base_path entry
+            |> Result.map (fun keeper -> keeper :: keepers))
+       (Ok [])
 ;;
 
 let update_presence ~workspace_config =
   let base_path = workspace_config.Workspace.base_path in
-  match
-    presence_status_for_keepers
-      ~gateway_connected:(Channel_gate_discord_state.connected ())
-      (live_keeper_presence ~base_path)
-  with
-  | None -> ()
-  | Some status -> Discord_gateway_client.set_presence status
+  match live_keeper_presence ~base_path with
+  | Error detail ->
+    Log.Discord.error
+      "discord_presence_bridge: binding read failed: %s"
+      detail
+  | Ok keepers ->
+    (match
+       presence_status_for_keepers
+         ~gateway_connected:(Channel_gate_discord_state.connected ())
+         keepers
+     with
+     | None -> ()
+     | Some status -> Discord_gateway_client.set_presence status)
 ;;
 
 (* ── Fiber entry ────────────────────────────────────────────────── *)

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -422,7 +422,7 @@ let handle_ambient ?resolved_keeper_name ~base_dir
   | Error error ->
     log_binding_lookup_failure ~channel_id error;
     Discord_observability.record_ambient
-      Discord_observability.Ambient_dropped_unbound
+      Discord_observability.Ambient_binding_store_error
   | Ok None ->
     Discord_observability.record_ambient
       Discord_observability.Ambient_dropped_unbound
@@ -568,7 +568,7 @@ let submit_ingress ingress ~lane ~event_id run =
       (Connector_ingress_lane.submit_error_to_string error)
 ;;
 
-let submit_triggered_event ?deliver ingress ~dispatch_for_delivery ~base_dir
+  let submit_triggered_event ?deliver ingress ~dispatch_for_delivery ~base_dir
     (ev : Gw.gateway_event) =
   match ev with
   | Gw.Message_create { channel_id; message_id; _ } ->
@@ -613,7 +613,10 @@ let submit_ambient_event ingress ~base_dir (ev : Gw.gateway_event) =
   match ev with
   | Gw.Message_create { channel_id; message_id; _ } ->
     (match State.keeper_for_channel_result ~channel_id with
-     | Error error -> log_binding_lookup_failure ~channel_id error
+     | Error error ->
+       log_binding_lookup_failure ~channel_id error;
+       Discord_observability.record_ambient
+         Discord_observability.Ambient_binding_store_error
      | Ok None -> on_ambient ~base_dir ev
      | Ok (Some keeper_name) ->
        submit_ingress

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -177,28 +177,18 @@ let mark_attention_resolved ~base_dir ~keeper_name ~event_id ~reason =
         "discord external attention resolve failed (keeper=%s event=%s): %s"
         keeper_name event_id error
 
-let resolve_binding_for_message ~channel_id ~message_reference_channel_id =
-  match State.resolve_keeper_for_channel ~channel_id with
-  | Some resolution -> Some (resolution, [])
-  | None -> (
-      match message_reference_channel_id with
-      | None -> None
-      | Some reference_channel_id ->
-          let reference_channel_id = String.trim reference_channel_id in
-          if reference_channel_id = "" || String.equal reference_channel_id channel_id
-          then None
-          else
-            match State.resolve_keeper_for_channel ~channel_id:reference_channel_id with
-            | None -> None
-            | Some resolution ->
-                Some
-                  ( {
-                      State.keeper_name = resolution.State.keeper_name;
-                      incoming_channel_id = channel_id;
-                      bound_channel_id = resolution.bound_channel_id;
-                      via_parent = true;
-                    },
-                    [ ("discord.binding_reference_channel_id", reference_channel_id) ] ))
+let log_binding_lookup_failure ~channel_id error =
+  let detail =
+    Format.asprintf "%a" State.pp_binding_lookup_error error
+  in
+  Log.Server.error
+    "Discord binding lookup failed (channel=%s): %s"
+    channel_id
+    detail
+
+let resolve_binding_for_message ~channel_id =
+  State.resolve_keeper_for_channel_result ~channel_id
+  |> Result.map (Option.map (fun resolution -> resolution, []))
 
 let accept_message_create ~resolved_binding ~dispatch_for_delivery
       ~(channel_id : string) ~(message_id : string)
@@ -213,18 +203,22 @@ let accept_message_create ~resolved_binding ~dispatch_for_delivery
       ~(referenced_message_author_id : string option) () =
   let binding =
     match resolved_binding with
-    | Some binding -> Some binding
-    | None ->
-      resolve_binding_for_message ~channel_id ~message_reference_channel_id
+    | Some binding -> Ok (Some binding)
+    | None -> resolve_binding_for_message ~channel_id
   in
   match binding with
-  | None ->
+  | Error error ->
+    log_binding_lookup_failure ~channel_id error;
+    Discord_observability.record_inbound_dispatch
+      Discord_observability.Gate_error;
+    None
+  | Ok None ->
     (* No binding for this channel — drop quietly. The bot may be in
        channels it isn't bound to (e.g. server-wide guild messages). *)
     Discord_observability.record_inbound_dispatch
       Discord_observability.Dropped_unbound;
     None
-  | Some (resolution, resolution_metadata) ->
+  | Ok (Some (resolution, resolution_metadata)) ->
     let keeper_name = resolution.State.keeper_name in
     let metadata =
       discord_chat_metadata ~guild_id ~channel_id ~message_id
@@ -421,14 +415,18 @@ let handle_ambient ?resolved_keeper_name ~base_dir
       ~(author_id : string) ~(author_name : string option) ~(content : string) () =
   let keeper_name =
     match resolved_keeper_name with
-    | Some keeper_name -> Some keeper_name
-    | None -> State.keeper_for_channel ~channel_id
+    | Some keeper_name -> Ok (Some keeper_name)
+    | None -> State.keeper_for_channel_result ~channel_id
   in
   match keeper_name with
-  | None ->
+  | Error error ->
+    log_binding_lookup_failure ~channel_id error;
     Discord_observability.record_ambient
       Discord_observability.Ambient_dropped_unbound
-  | Some keeper_name ->
+  | Ok None ->
+    Discord_observability.record_ambient
+      Discord_observability.Ambient_dropped_unbound
+  | Ok (Some keeper_name) ->
     let trimmed = String.trim content in
     if String.equal trimmed "" then
       Discord_observability.record_ambient
@@ -573,15 +571,16 @@ let submit_ingress ingress ~lane ~event_id run =
 let submit_triggered_event ?deliver ingress ~dispatch_for_delivery ~base_dir
     (ev : Gw.gateway_event) =
   match ev with
-  | Gw.Message_create
-      { channel_id; message_id; message_reference_channel_id; _ } ->
-    (match
-       resolve_binding_for_message ~channel_id ~message_reference_channel_id
-     with
-     | None ->
-       ignore
-         (accept_event ~resolved_binding:None ~dispatch_for_delivery ~base_dir ev)
-     | Some ((resolution, _) as resolved_binding) ->
+  | Gw.Message_create { channel_id; message_id; _ } ->
+    (match resolve_binding_for_message ~channel_id with
+     | Error error ->
+       log_binding_lookup_failure ~channel_id error;
+       Discord_observability.record_inbound_dispatch
+         Discord_observability.Gate_error
+     | Ok None ->
+       Discord_observability.record_inbound_dispatch
+         Discord_observability.Dropped_unbound
+     | Ok (Some ((resolution, _) as resolved_binding)) ->
        (match
           accept_event
             ~resolved_binding:(Some resolved_binding)
@@ -613,9 +612,10 @@ end
 let submit_ambient_event ingress ~base_dir (ev : Gw.gateway_event) =
   match ev with
   | Gw.Message_create { channel_id; message_id; _ } ->
-    (match State.keeper_for_channel ~channel_id with
-     | None -> on_ambient ~base_dir ev
-     | Some keeper_name ->
+    (match State.keeper_for_channel_result ~channel_id with
+     | Error error -> log_binding_lookup_failure ~channel_id error
+     | Ok None -> on_ambient ~base_dir ev
+     | Ok (Some keeper_name) ->
        submit_ingress
          ingress
          ~lane:(Connector_ingress_lane.Keeper_lane keeper_name)

--- a/lib/server/server_discord_in_process_gateway.mli
+++ b/lib/server/server_discord_in_process_gateway.mli
@@ -8,7 +8,7 @@
        ({!Discord_gateway_client.run}).
     2. For each accepted [Message_create] event, looks up the
        channel→keeper binding
-       ({!Channel_gate_discord_state.keeper_for_channel}), runs the
+       ({!Channel_gate_discord_state.keeper_for_channel_result}), runs the
        keeper turn through {!Channel_gate.handle_inbound_streaming},
        projects redacted text snapshots by posting/editing one Discord
        reply, and falls back to

--- a/test/test_channel_gate_binding_store.ml
+++ b/test/test_channel_gate_binding_store.ml
@@ -54,16 +54,35 @@ let test_normalizes_bindings_json () =
     Store.normalize_bindings_json
       (`Assoc
         [
-          ("z-channel", `String " luna ");
-          ("", `String "ignored");
-          ("bad-channel", `Int 1);
-          ("a-channel", `String " arya ");
+          ("z-channel", `String "luna");
+          ("a-channel", `String "arya");
         ])
+    |> Result.get_ok
   in
-  check int "valid bindings only" 2 (List.length bindings);
+  check int "all canonical bindings" 2 (List.length bindings);
   let first = List.hd bindings in
   check string "sorted by channel id" "a-channel" first.channel_id;
-  check string "trims keeper name" "arya" first.keeper_name
+  check string "preserves keeper name" "arya" first.keeper_name
+
+let test_rejects_malformed_binding_rows () =
+  let expect_error label json =
+    match Store.normalize_bindings_json json with
+    | Ok _ -> fail label
+    | Error _ -> ()
+  in
+  expect_error "blank channel id was discarded"
+    (`Assoc [ "", `String "luna" ]);
+  expect_error "non-string keeper was discarded"
+    (`Assoc [ "channel-1", `Int 1 ]);
+  expect_error "blank keeper was discarded"
+    (`Assoc [ "channel-1", `String " " ]);
+  expect_error "non-canonical channel id was normalized"
+    (`Assoc [ " channel-1", `String "luna" ]);
+  expect_error "duplicate channel id was accepted"
+    (`Assoc
+      [ "channel-1", `String "luna"
+      ; "channel-1", `String "sangsu"
+      ])
 
 let test_save_and_read_bindings_round_trip () =
   with_temp_dir @@ fun dir ->
@@ -84,7 +103,7 @@ let test_read_bindings_result_missing_store_is_empty () =
   let store = store_for_dir dir ~guild_id_field:Store.Omit in
   match Store.read_bindings_result store with
   | Ok bindings -> check int "missing store means no bindings" 0 (List.length bindings)
-  | Error err -> fail err
+  | Error error -> fail (Store.binding_store_error_to_string error)
 
 let test_read_bindings_result_reports_invalid_json () =
   with_temp_dir @@ fun dir ->
@@ -96,9 +115,131 @@ let test_read_bindings_result_reports_invalid_json () =
     (fun () -> output_string oc "{not-json");
   match Store.read_bindings_result store with
   | Ok _ -> fail "expected invalid binding store to return Error"
-  | Error err ->
+  | Error error ->
+    let err = Store.binding_store_error_to_string error in
     check bool "reports invalid JSON" true
       (String.length err > 0 && String.contains err ':')
+
+let test_audit_failure_rolls_back_binding_mutation () =
+  with_temp_dir @@ fun dir ->
+  let binding_path = Filename.concat dir "bindings.json" in
+  let store =
+    Store.create
+      ~binding_store_path:(fun () -> binding_path)
+      ~binding_store_read_path:(fun () -> binding_path)
+      ~binding_audit_path:(fun () -> dir)
+      ~binding_audit_read_path:(fun () -> dir)
+      ~guild_id_field:Store.Omit
+  in
+  let original =
+    [ ({ channel_id = "channel-1"; keeper_name = "luna" } : Store.binding) ]
+  in
+  Store.save_bindings store original;
+  let result =
+    Store.mutate_bindings store ~decide:(fun _ ->
+      Ok
+        ( [ ({ channel_id = "channel-2"; keeper_name = "sangsu" }
+            : Store.binding) ]
+        , sample_event ~action:"bind" ()
+        , () ))
+  in
+  (match result with
+   | Ok () -> fail "audit directory unexpectedly accepted an append"
+   | Error _ -> ());
+  match Store.read_bindings_result store with
+  | Error error -> fail (Store.binding_store_error_to_string error)
+  | Ok bindings ->
+    check (list string) "original binding restored after audit failure"
+      [ "channel-1:luna" ]
+      (List.map
+         (fun (binding : Store.binding) ->
+           binding.channel_id ^ ":" ^ binding.keeper_name)
+         bindings)
+
+let test_failed_mutation_cannot_erase_concurrent_success () =
+  with_temp_dir @@ fun dir ->
+  let binding_path = Filename.concat dir "bindings.json" in
+  let audit_path = Filename.concat dir "binding_audit.jsonl" in
+  let coordination_mu = Stdlib.Mutex.create () in
+  let coordination = Stdlib.Condition.create () in
+  let audit_calls = ref 0 in
+  let first_audit_waiting = ref false in
+  let second_mutation_started = ref false in
+  let release_first_audit = ref false in
+  let binding_audit_path () =
+    Stdlib.Mutex.lock coordination_mu;
+    Fun.protect
+      ~finally:(fun () -> Stdlib.Mutex.unlock coordination_mu)
+      (fun () ->
+        incr audit_calls;
+        if !audit_calls = 1 then (
+          first_audit_waiting := true;
+          Stdlib.Condition.broadcast coordination;
+          while not !release_first_audit do
+            Stdlib.Condition.wait coordination coordination_mu
+          done;
+          dir
+        ) else audit_path)
+  in
+  let store =
+    Store.create
+      ~binding_store_path:(fun () -> binding_path)
+      ~binding_store_read_path:(fun () -> binding_path)
+      ~binding_audit_path
+      ~binding_audit_read_path:(fun () -> audit_path)
+      ~guild_id_field:Store.Omit
+  in
+  Store.save_bindings store
+    [ ({ channel_id = "original"; keeper_name = "luna" } : Store.binding) ];
+  let bind channel_id keeper_name =
+    Store.mutate_bindings store ~decide:(fun bindings ->
+      let updated =
+        ({ channel_id; keeper_name } : Store.binding)
+        :: List.filter
+             (fun (binding : Store.binding) ->
+               not (String.equal binding.channel_id channel_id))
+             bindings
+      in
+      Ok (updated, sample_event ~action:"bind" (), ()))
+  in
+  let failed = Domain.spawn (fun () -> bind "failed" "sangsu") in
+  Stdlib.Mutex.lock coordination_mu;
+  while not !first_audit_waiting do
+    Stdlib.Condition.wait coordination coordination_mu
+  done;
+  Stdlib.Mutex.unlock coordination_mu;
+  let succeeded =
+    Domain.spawn (fun () ->
+      Stdlib.Mutex.lock coordination_mu;
+      second_mutation_started := true;
+      Stdlib.Condition.broadcast coordination;
+      Stdlib.Mutex.unlock coordination_mu;
+      bind "committed" "arya")
+  in
+  Stdlib.Mutex.lock coordination_mu;
+  while not !second_mutation_started do
+    Stdlib.Condition.wait coordination coordination_mu
+  done;
+  release_first_audit := true;
+  Stdlib.Condition.broadcast coordination;
+  Stdlib.Mutex.unlock coordination_mu;
+  (match Domain.join failed with
+   | Ok () -> fail "first mutation unexpectedly committed"
+   | Error _ -> ());
+  (match Domain.join succeeded with
+   | Error error -> fail (Store.mutation_error_to_string error)
+   | Ok () -> ());
+  match Store.read_bindings_result store with
+  | Error error -> fail (Store.binding_store_error_to_string error)
+  | Ok bindings ->
+    check (list string)
+      "failed rollback preserves the later serialized commit"
+      [ "committed:arya"; "original:luna" ]
+      (bindings
+       |> List.sort (fun (a : Store.binding) (b : Store.binding) ->
+            String.compare a.channel_id b.channel_id)
+       |> List.map (fun (binding : Store.binding) ->
+            binding.channel_id ^ ":" ^ binding.keeper_name))
 
 let test_audit_guild_id_policy () =
   with_temp_dir @@ fun dir ->
@@ -133,12 +274,18 @@ let () =
       ( "bindings",
         [
           test_case "normalizes binding JSON" `Quick test_normalizes_bindings_json;
+          test_case "rejects malformed binding rows" `Quick
+            test_rejects_malformed_binding_rows;
           test_case "saves and reads bindings" `Quick
             test_save_and_read_bindings_round_trip;
           test_case "missing binding store is empty" `Quick
             test_read_bindings_result_missing_store_is_empty;
           test_case "invalid binding store is an error" `Quick
             test_read_bindings_result_reports_invalid_json;
+          test_case "audit failure rolls back mutation" `Quick
+            test_audit_failure_rolls_back_binding_mutation;
+          test_case "failed rollback preserves concurrent success" `Quick
+            test_failed_mutation_cannot_erase_concurrent_success;
         ] );
       ( "audit",
         [

--- a/test/test_channel_gate_discord_state.ml
+++ b/test/test_channel_gate_discord_state.ml
@@ -377,9 +377,14 @@ let test_resolve_keeper_for_thread_parent_binding () =
     ignore
       (Discord_state.bind ~channel_id:"parent-1" ~keeper_name:"luna"
          ~actor_name:"dashboard");
-    match Discord_state.resolve_keeper_for_channel ~channel_id:"thread-1" with
-    | None -> fail "expected parent binding to resolve"
-    | Some resolution ->
+    Discord_state.register_thread
+      ~thread_id:"thread-1"
+      ~parent_channel_id:"parent-1";
+    match
+      Discord_state.resolve_keeper_for_channel_result ~channel_id:"thread-1"
+    with
+    | Error _ | Ok None -> fail "expected registered parent binding to resolve"
+    | Ok (Some resolution) ->
         check string "keeper" "luna" resolution.keeper_name;
         check string "incoming" "thread-1" resolution.incoming_channel_id;
         check string "bound" "parent-1" resolution.bound_channel_id;
@@ -402,13 +407,39 @@ let test_resolve_keeper_exact_binding_wins_over_parent () =
     ignore
       (Discord_state.bind ~channel_id:"thread-1" ~keeper_name:"sangsu"
          ~actor_name:"dashboard");
-    match Discord_state.resolve_keeper_for_channel ~channel_id:"thread-1" with
-    | None -> fail "expected exact binding to resolve"
-    | Some resolution ->
+    match
+      Discord_state.resolve_keeper_for_channel_result ~channel_id:"thread-1"
+    with
+    | Error _ | Ok None -> fail "expected exact binding to resolve"
+    | Ok (Some resolution) ->
         check string "keeper" "sangsu" resolution.keeper_name;
         check string "incoming" "thread-1" resolution.incoming_channel_id;
         check string "bound" "thread-1" resolution.bound_channel_id;
         check bool "not via parent" false resolution.via_parent)
+
+let test_binding_store_failures_are_not_empty_state () =
+  with_temp_dir @@ fun dir ->
+  with_discord_paths dir (fun () ->
+    Fs_compat.save_file (Filename.concat dir "bindings.json") "{not-json";
+    (match
+       Discord_state.resolve_keeper_for_channel_result ~channel_id:"channel-1"
+     with
+     | Error (Discord_state.Binding_store_read_failed _) -> ()
+     | Ok _ -> fail "lookup reduced malformed store to an unbound channel");
+    (match
+       Discord_state.bind ~channel_id:"channel-1" ~keeper_name:"luna"
+         ~actor_name:"dashboard"
+     with
+     | Error _ -> ()
+     | Ok _ -> fail "bind overwrote a malformed binding store");
+    (match
+       Discord_state.unbind ~channel_id:"channel-1" ~actor_name:"dashboard"
+     with
+     | Error _ -> ()
+     | Ok _ -> fail "unbind overwrote a malformed binding store");
+    match Discord_state.bound_channels_result ~keeper_name:"luna" with
+    | Error _ -> ()
+    | Ok _ -> fail "presence reduced malformed bindings to an empty set")
 
 let test_thread_registry_round_trip () =
   let suffix = Printf.sprintf "%d-%06d" (Unix.getpid ()) !temp_dir_counter in
@@ -457,6 +488,8 @@ let () =
             test_bind_persists_binding_and_audit;
           test_case "unbind removes binding" `Quick
             test_unbind_removes_existing_binding;
+          test_case "binding-store failures remain explicit" `Quick
+            test_binding_store_failures_are_not_empty_state;
           test_case "connectors json advertises connector descriptor" `Quick
             test_connectors_json_advertises_gate_connector_descriptor;
           test_case "registry register replaces and all snapshots" `Quick

--- a/test/test_channel_gate_discord_state.ml
+++ b/test/test_channel_gate_discord_state.ml
@@ -3,7 +3,6 @@ open Alcotest
 module Discord_state = Channel_gate_discord_state
 module Discord_names = Channel_gate_discord_names
 module U = Yojson.Safe.Util
-
 module Registry_test_connector_a = struct
   let connector_id = "registry-test-connector"
   let display_name = "Registry Test A"
@@ -23,7 +22,6 @@ module Registry_test_connector_a = struct
   let bound_channels ~keeper_name:_ = []
   let connected () = false
 end
-
 module Registry_test_connector_b = struct
   include Registry_test_connector_a
 
@@ -38,7 +36,6 @@ module Registry_test_connector_b = struct
   let bind ~channel_id:_ ~keeper_name:_ ~actor_name:_ =
     Ok (`Assoc [ "variant", `String "b" ])
 end
-
 let with_env name value f =
   let previous = Sys.getenv_opt name in
   (match value with
@@ -50,9 +47,7 @@ let with_env name value f =
       | Some v -> Unix.putenv name v
       | None -> Unix.putenv name "")
     f
-
 let temp_dir_counter = ref 0
-
 let with_temp_dir f =
   incr temp_dir_counter;
   let base =
@@ -421,25 +416,19 @@ let test_binding_store_failures_are_not_empty_state () =
   with_temp_dir @@ fun dir ->
   with_discord_paths dir (fun () ->
     Fs_compat.save_file (Filename.concat dir "bindings.json") "{not-json";
-    (match
-       Discord_state.resolve_keeper_for_channel_result ~channel_id:"channel-1"
-     with
-     | Error (Discord_state.Binding_store_read_failed _) -> ()
-     | Ok _ -> fail "lookup reduced malformed store to an unbound channel");
-    (match
-       Discord_state.bind ~channel_id:"channel-1" ~keeper_name:"luna"
-         ~actor_name:"dashboard"
-     with
-     | Error _ -> ()
-     | Ok _ -> fail "bind overwrote a malformed binding store");
-    (match
-       Discord_state.unbind ~channel_id:"channel-1" ~actor_name:"dashboard"
-     with
-     | Error _ -> ()
-     | Ok _ -> fail "unbind overwrote a malformed binding store");
-    match Discord_state.bound_channels_result ~keeper_name:"luna" with
-    | Error _ -> ()
-    | Ok _ -> fail "presence reduced malformed bindings to an empty set")
+    let expect_error label = function
+      | Error _ -> ()
+      | Ok _ -> fail label
+    in
+    Discord_state.resolve_keeper_for_channel_result ~channel_id:"channel-1"
+    |> expect_error "lookup reduced malformed store to unbound";
+    Discord_state.bind ~channel_id:"channel-1" ~keeper_name:"luna"
+      ~actor_name:"dashboard"
+    |> expect_error "bind overwrote malformed store";
+    Discord_state.unbind ~channel_id:"channel-1" ~actor_name:"dashboard"
+    |> expect_error "unbind overwrote malformed store";
+    Discord_state.bound_channels_result ~keeper_name:"luna"
+    |> expect_error "presence reduced malformed store to empty")
 
 let test_thread_registry_round_trip () =
   let suffix = Printf.sprintf "%d-%06d" (Unix.getpid ()) !temp_dir_counter in

--- a/test/test_channel_gate_discord_state.ml
+++ b/test/test_channel_gate_discord_state.ml
@@ -125,6 +125,23 @@ let test_status_json_ignores_legacy_sidecar_status_file () =
     check int "runtime bindings from persisted bindings" 0
       (json |> U.member "runtime_bindings_count" |> U.to_int)))
 
+let test_status_json_surfaces_binding_store_failure () =
+  with_temp_dir @@ fun dir ->
+  with_discord_paths dir (fun () ->
+  with_env "DISCORD_BOT_TOKEN" (Some "token") (fun () ->
+    Fs_compat.save_file (Filename.concat dir "bindings.json") "{not-json";
+    let json = Discord_state.status_json () in
+    check bool "routing unavailable" false
+      (json |> U.member "available" |> U.to_bool);
+    check bool "binding store read failed" false
+      (json |> U.member "binding_store_read_ok" |> U.to_bool);
+    check bool "binding store error is explicit" true
+      (json |> U.member "binding_store_error" |> U.to_string |> String.length
+       |> fun length -> length > 0);
+    check bool "connector error includes binding failure" true
+      (json |> U.member "error" |> U.to_string |> String.length
+       |> fun length -> length > 0)))
+
 (* record_ready ordering: this test runs in the same process as the
    blank-identity assertions above, so it must come after them in the
    suite — last_ready is module-global and has no reset (production
@@ -471,6 +488,8 @@ let () =
             test_status_json_reports_in_process_gateway_status;
           test_case "ignores legacy sidecar status file" `Quick
             test_status_json_ignores_legacy_sidecar_status_file;
+          test_case "surfaces binding store failure" `Quick
+            test_status_json_surfaces_binding_store_failure;
           test_case "record_ready surfaces bot identity" `Quick
             test_record_ready_surfaces_bot_identity;
           test_case "bind persists binding and audit" `Quick

--- a/test/test_channel_gate_discord_state_in_process.ml
+++ b/test/test_channel_gate_discord_state_in_process.ml
@@ -20,18 +20,19 @@ let unsetenv k = Unix.putenv k ""
 (* ---------------------------------------------------------------- *)
 
 let test_lookup_blank_channel_id () =
-  check (option string) "empty => None" None
-    (State.keeper_for_channel ~channel_id:"")
+  check (result (option string) reject) "empty => None" (Ok None)
+    (State.keeper_for_channel_result ~channel_id:"")
 
 let test_lookup_whitespace_channel_id () =
-  check (option string) "whitespace => None" None
-    (State.keeper_for_channel ~channel_id:"   ")
+  check (result (option string) reject) "whitespace => None" (Ok None)
+    (State.keeper_for_channel_result ~channel_id:"   ")
 
 let test_lookup_unbound_channel_returns_none () =
   (* No bind() called for this channel id and the binding store may
      be empty or missing; lookup must not raise either way. *)
-  check (option string) "no binding => None" None
-    (State.keeper_for_channel ~channel_id:"channel-id-with-no-binding")
+  check (result (option string) reject) "no binding => None" (Ok None)
+    (State.keeper_for_channel_result
+       ~channel_id:"channel-id-with-no-binding")
 
 (* ---------------------------------------------------------------- *)
 (* send_error / pp_send_error                                       *)

--- a/test/test_discord_observability.ml
+++ b/test/test_discord_observability.ml
@@ -22,6 +22,8 @@ let test_label_contract () =
     (Obs.inbound_outcome_label Obs.Dispatch_unavailable);
   check string "ambient too_long" "dropped_too_long"
     (Obs.ambient_outcome_label Obs.Ambient_dropped_too_long);
+  check string "ambient binding store error" "binding_store_error"
+    (Obs.ambient_outcome_label Obs.Ambient_binding_store_error);
   check string "reply failed" "send_error"
     (Obs.reply_outcome_label Obs.Reply_send_failed)
 
@@ -49,9 +51,9 @@ let test_inbound_dispatch_counter () =
     Obs.record_inbound_dispatch Obs.Dispatch_unavailable)
 
 let test_ambient_counter () =
-  let labels = [ "outcome", "recorded" ] in
+  let labels = [ "outcome", "binding_store_error" ] in
   check_delta Names.metric_discord_ambient_record ~labels (fun () ->
-    Obs.record_ambient Obs.Ambient_recorded)
+    Obs.record_ambient Obs.Ambient_binding_store_error)
 
 let test_reply_counter () =
   let labels = [ "outcome", "sent" ] in

--- a/test/test_gate_surface.ml
+++ b/test/test_gate_surface.ml
@@ -135,10 +135,12 @@ let test_bound_channels_blank_keeper_is_empty () =
     [ ("98791450001", "surface-keeper") ]
     (fun () ->
       check (list string) "blank name" []
-        (Channel_gate_discord_state.bound_channels ~keeper_name:"  ");
+        (Channel_gate_discord_state.bound_channels_result ~keeper_name:"  "
+         |> Result.get_ok);
       check (list string) "bound name" [ "98791450001" ]
-        (Channel_gate_discord_state.bound_channels
-           ~keeper_name:"surface-keeper"))
+        (Channel_gate_discord_state.bound_channels_result
+           ~keeper_name:"surface-keeper"
+         |> Result.get_ok))
 
 let test_discord_not_connected_without_run_loop () =
   check bool "no gateway => not connected" false


### PR DESCRIPTION
## Outcome

Closes the Discord channel-to-Keeper binding integrity boundary without reviving the retired sidecar stack.

- binding-store read failure is distinct from an unbound channel through one typed `binding_lookup_error`
- exact channel bindings win; only the in-process thread registry can authorize parent fallback
- reply-reference channel IDs remain transcript metadata and never gain routing authority
- bind/unbind refuse malformed current state and surface rollback failure
- presence and keeper surface-post consumers keep binding failures explicit
- triggered and ambient lookup failures have explicit low-cardinality metrics
- Keeper registry order is preserved in the presence projection
- the obsolete resolver argument for reply-reference routing is removed

This is the current-main replacement for the binding-integrity slice of closed #24674. It intentionally excludes that PRs retired connector stack.

## Verification

- all changed OCaml files pass parser and `ocamlformat --check`
- `git diff --check` passes
- focused malformed-store coverage remains for lookup, bind, unbind, and bound-channel reads
- observability coverage pins the new `binding_store_error` label and counter
- focused Dune build was not bypassed while another worktree held the repository lock; full build/test remains CI authority

## Adversarial status

- P0: 0
- P1: 0
- P2 findings from the prior review are repaired
- mergeability: keep draft and DNM until fresh CI is green