### PR TITLE
fix(gate): wake one durable judge globally

### DIFF
--- a/lib/keeper/hitl_summary_worker.ml
+++ b/lib/keeper/hitl_summary_worker.ml
@@ -70,7 +70,9 @@ let () =
        Labels: [outcome] (ok_summary | parse_error | provider_error | timeout | \
        no_provider_config | no_net | prompt_error | crashed | \
        degraded_plain_json | restart_worker_recovered | \
-       restart_judgment_recovered | operator_retry_started). \
+       restart_judgment_recovered | operator_retry_started | \
+       terminal_wake_idle | terminal_wake_started | terminal_wake_failed | \
+       terminal_wake_crashed | terminal_wake_mode_unavailable). \
        [degraded_plain_json] is emitted alongside the terminal outcome when \
        the judge endpoint could not serve native structured output and the \
        strict plain-JSON capability path was used. The restart outcomes record which exact persisted work \

--- a/lib/keeper/keeper_gate.ml
+++ b/lib/keeper/keeper_gate.ml
@@ -285,11 +285,19 @@ type auto_judge_ready =
   ; source : auto_judge_ready_source
   }
 
+type auto_judge_attempt =
+  | Candidate_started
+  | Candidate_skipped
+  | Candidate_failed of string
+
+type auto_judge_wake_failure =
+  { candidate : auto_judge_ready
+  ; reason : string
+  }
+
 type auto_judge_wake_outcome =
-  | Wake_idle
-  | Wake_started of auto_judge_ready
-  | Wake_failed of auto_judge_ready * string
-  | Wake_crashed of string
+  | Wake_idle of auto_judge_wake_failure list
+  | Wake_started of auto_judge_ready * auto_judge_wake_failure list
 
 let active_auto_judges : Auto_judge_ids.t Atomic.t =
   Atomic.make Auto_judge_ids.empty
@@ -353,13 +361,52 @@ let ready_auto_judges ~finished_id =
   |> List.sort compare_ready_auto_judges
 ;;
 
+let attempt_ready_auto_judges ~attempt ready =
+  let rec loop failures = function
+    | [] -> Wake_idle (List.rev failures)
+    | candidate :: rest ->
+      (match attempt candidate with
+       | Candidate_started -> Wake_started (candidate, List.rev failures)
+       | Candidate_skipped -> loop failures rest
+       | Candidate_failed reason ->
+         loop ({ candidate; reason } :: failures) rest)
+  in
+  loop [] ready
+;;
+
+let observe_auto_judge_wake_failure ~finished_entry failure =
+  Log.Keeper.error
+    ~keeper_name:failure.candidate.entry.keeper_name
+    "Auto Judge terminal wake failed approval=%s after=%s: %s"
+    failure.candidate.entry.id
+    finished_entry.id
+    failure.reason;
+  Otel_metric_store.inc_counter
+    Keeper_metrics.(to_string HitlSummaryOutcomes)
+    ~labels:[ "outcome", "terminal_wake_failed" ]
+    ();
+  Keeper_approval_queue.audit_approval_event
+    ~base_path:failure.candidate.entry.audit_base_path
+    ~event_type:"auto_judge_terminal_wake_failed"
+    ~id:failure.candidate.entry.id
+    ~keeper_name:failure.candidate.entry.keeper_name
+    ~tool_name:failure.candidate.entry.tool_name
+    ?turn_id:failure.candidate.entry.turn_id
+    ?task_id:failure.candidate.entry.task_id
+    ?goal_id:failure.candidate.entry.goal_id
+    ~goal_ids:failure.candidate.entry.goal_ids
+    ()
+;;
+
 let observe_auto_judge_wake ~finished_entry = function
-  | Wake_idle ->
+  | Wake_idle failures ->
+    List.iter (observe_auto_judge_wake_failure ~finished_entry) failures;
     Otel_metric_store.inc_counter
       Keeper_metrics.(to_string HitlSummaryOutcomes)
       ~labels:[ "outcome", "terminal_wake_idle" ]
       ()
-  | Wake_started candidate ->
+  | Wake_started (candidate, failures) ->
+    List.iter (observe_auto_judge_wake_failure ~finished_entry) failures;
     Log.Keeper.info
       ~keeper_name:candidate.entry.keeper_name
       "Auto Judge terminal wake started approval=%s after=%s"
@@ -380,27 +427,18 @@ let observe_auto_judge_wake ~finished_entry = function
       ?goal_id:candidate.entry.goal_id
       ~goal_ids:candidate.entry.goal_ids
       ()
-  | Wake_failed (candidate, reason) ->
-    Log.Keeper.error
-      ~keeper_name:candidate.entry.keeper_name
-      "Auto Judge terminal wake failed approval=%s after=%s: %s"
-      candidate.entry.id
-      finished_entry.id
-      reason;
-    Otel_metric_store.inc_counter
-      Keeper_metrics.(to_string HitlSummaryOutcomes)
-      ~labels:[ "outcome", "terminal_wake_failed" ]
-      ()
-  | Wake_crashed reason ->
-    Log.Keeper.error
-      ~keeper_name:finished_entry.keeper_name
-      "Auto Judge terminal wake crashed after=%s: %s"
-      finished_entry.id
-      reason;
-    Otel_metric_store.inc_counter
-      Keeper_metrics.(to_string HitlSummaryOutcomes)
-      ~labels:[ "outcome", "terminal_wake_crashed" ]
-      ()
+;;
+
+let observe_auto_judge_wake_crash ~finished_entry exn =
+  Log.Keeper.error
+    ~keeper_name:finished_entry.keeper_name
+    "Auto Judge terminal wake crashed after=%s: %s"
+    finished_entry.id
+    (Printexc.to_string exn);
+  Otel_metric_store.inc_counter
+    Keeper_metrics.(to_string HitlSummaryOutcomes)
+    ~labels:[ "outcome", "terminal_wake_crashed" ]
+    ()
 ;;
 
 let rec claim_auto_judge id =
@@ -501,12 +539,12 @@ let rec spawn_claimed_auto_judge_entry
          ~on_failure
          ~on_finish:(fun () ->
            release_auto_judge approval_id;
-           let outcome =
-             try wake_one_auto_judge ~finished_id:approval_id with
-             | Eio.Cancel.Cancelled _ as exn -> raise exn
-             | exn -> Wake_crashed (Printexc.to_string exn)
-           in
-           observe_auto_judge_wake ~finished_entry:entry outcome)
+           try
+             wake_one_auto_judge ~finished_id:approval_id
+             |> observe_auto_judge_wake ~finished_entry:entry
+           with
+           | Eio.Cancel.Cancelled _ as exn -> raise exn
+           | exn -> observe_auto_judge_wake_crash ~finished_entry:entry exn)
          ();
        Ok Started
      with
@@ -608,20 +646,18 @@ and drain_auto_judges ~base_path =
           None)
 
 and wake_one_auto_judge ~finished_id =
-  let rec start_first = function
-    | [] -> Wake_idle
-    | candidate :: rest ->
-      let result =
-        match candidate.source with
-        | Awaiting_start -> start_auto_judge candidate.entry.id
-        | Restart_replay -> spawn_auto_judge_entry candidate.entry
-      in
-      (match result with
-       | Ok Started -> Wake_started candidate
-       | Ok Skipped -> start_first rest
-       | Error reason -> Wake_failed (candidate, reason))
+  let attempt candidate =
+    let result =
+      match candidate.source with
+      | Awaiting_start -> start_auto_judge candidate.entry.id
+      | Restart_replay -> spawn_auto_judge_entry candidate.entry
+    in
+    match result with
+    | Ok Started -> Candidate_started
+    | Ok Skipped -> Candidate_skipped
+    | Error reason -> Candidate_failed reason
   in
-  start_first (ready_auto_judges ~finished_id)
+  attempt_ready_auto_judges ~attempt (ready_auto_judges ~finished_id)
 ;;
 
 type recovered_work =
@@ -932,10 +968,42 @@ module For_testing = struct
     | Awaiting_start
     | Restart_replay
 
+  type nonrec auto_judge_attempt = auto_judge_attempt =
+    | Candidate_started
+    | Candidate_skipped
+    | Candidate_failed of string
+
+  type auto_judge_wake_plan =
+    { started_id : string option
+    ; failures : (string * string) list
+    }
+
   let next_auto_judge_wake_candidate ~finished_id =
     match ready_auto_judges ~finished_id with
     | [] -> None
     | candidate :: _ -> Some (candidate.entry.id, candidate.source)
+  ;;
+
+  let drive_auto_judge_wake ~finished_id ~attempt =
+    let attempt candidate = attempt candidate.entry.id in
+    let plan =
+      attempt_ready_auto_judges ~attempt (ready_auto_judges ~finished_id)
+    in
+    match plan with
+    | Wake_idle failures ->
+      { started_id = None
+      ; failures =
+          List.map
+            (fun failure -> failure.candidate.entry.id, failure.reason)
+            failures
+      }
+    | Wake_started (candidate, failures) ->
+      { started_id = Some candidate.entry.id
+      ; failures =
+          List.map
+            (fun failure -> failure.candidate.entry.id, failure.reason)
+            failures
+      }
   ;;
 end
 ;;

--- a/lib/keeper/keeper_gate.ml
+++ b/lib/keeper/keeper_gate.ml
@@ -274,9 +274,133 @@ type auto_judge_start_outcome =
   | Skipped
 
 module Auto_judge_ids = Set_util.StringSet
+module Auto_judge_paths = Set_util.StringSet
+
+type auto_judge_ready_source =
+  | Awaiting_start
+  | Restart_replay
+
+type auto_judge_ready =
+  { entry : Keeper_approval_queue.pending_approval
+  ; source : auto_judge_ready_source
+  }
+
+type auto_judge_wake_outcome =
+  | Wake_idle
+  | Wake_started of auto_judge_ready
+  | Wake_failed of auto_judge_ready * string
+  | Wake_crashed of string
 
 let active_auto_judges : Auto_judge_ids.t Atomic.t =
   Atomic.make Auto_judge_ids.empty
+;;
+
+let ready_auto_judge (entry : Keeper_approval_queue.pending_approval) =
+  match entry.summary_status with
+  | Keeper_approval_queue.Summary_not_requested ->
+    Some { entry; source = Awaiting_start }
+  | Keeper_approval_queue.Summary_pending ->
+    Some { entry; source = Restart_replay }
+  | Keeper_approval_queue.Summary_available _
+  | Keeper_approval_queue.Summary_failed _ -> None
+;;
+
+let compare_ready_auto_judges left right =
+  let by_time = Float.compare left.entry.requested_at right.entry.requested_at in
+  if by_time <> 0 then by_time else String.compare left.entry.id right.entry.id
+;;
+
+let auto_judge_paths ready =
+  let candidate_paths =
+    List.fold_left
+      (fun paths candidate ->
+         Auto_judge_paths.add candidate.entry.audit_base_path paths)
+      Auto_judge_paths.empty
+      ready
+  in
+  Auto_judge_paths.fold
+    (fun base_path paths ->
+       match Keeper_gate_mode.read ~base_path with
+       | Ok Keeper_gate_mode.Auto_judge -> Auto_judge_paths.add base_path paths
+       | Ok (Keeper_gate_mode.Manual | Keeper_gate_mode.Always_allow) -> paths
+       | Error detail ->
+         Log.Keeper.error
+           "Auto Judge terminal wake skipped workspace=%s: %s"
+           base_path
+           detail;
+         Otel_metric_store.inc_counter
+           Keeper_metrics.(to_string HitlSummaryOutcomes)
+           ~labels:[ "outcome", "terminal_wake_mode_unavailable" ]
+           ();
+         paths)
+    candidate_paths
+    Auto_judge_paths.empty
+;;
+
+let ready_auto_judges ~finished_id =
+  let active = Atomic.get active_auto_judges in
+  let ready =
+    Keeper_approval_queue.list_pending_entries ()
+    |> List.filter (fun (entry : Keeper_approval_queue.pending_approval) ->
+      not (String.equal entry.id finished_id)
+      && not (Auto_judge_ids.mem entry.id active))
+    |> List.filter_map ready_auto_judge
+  in
+  let eligible_paths = auto_judge_paths ready in
+  ready
+  |> List.filter (fun candidate ->
+    Auto_judge_paths.mem candidate.entry.audit_base_path eligible_paths)
+  |> List.sort compare_ready_auto_judges
+;;
+
+let observe_auto_judge_wake ~finished_entry = function
+  | Wake_idle ->
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string HitlSummaryOutcomes)
+      ~labels:[ "outcome", "terminal_wake_idle" ]
+      ()
+  | Wake_started candidate ->
+    Log.Keeper.info
+      ~keeper_name:candidate.entry.keeper_name
+      "Auto Judge terminal wake started approval=%s after=%s"
+      candidate.entry.id
+      finished_entry.id;
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string HitlSummaryOutcomes)
+      ~labels:[ "outcome", "terminal_wake_started" ]
+      ();
+    Keeper_approval_queue.audit_approval_event
+      ~base_path:candidate.entry.audit_base_path
+      ~event_type:"auto_judge_terminal_wake_started"
+      ~id:candidate.entry.id
+      ~keeper_name:candidate.entry.keeper_name
+      ~tool_name:candidate.entry.tool_name
+      ?turn_id:candidate.entry.turn_id
+      ?task_id:candidate.entry.task_id
+      ?goal_id:candidate.entry.goal_id
+      ~goal_ids:candidate.entry.goal_ids
+      ()
+  | Wake_failed (candidate, reason) ->
+    Log.Keeper.error
+      ~keeper_name:candidate.entry.keeper_name
+      "Auto Judge terminal wake failed approval=%s after=%s: %s"
+      candidate.entry.id
+      finished_entry.id
+      reason;
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string HitlSummaryOutcomes)
+      ~labels:[ "outcome", "terminal_wake_failed" ]
+      ()
+  | Wake_crashed reason ->
+    Log.Keeper.error
+      ~keeper_name:finished_entry.keeper_name
+      "Auto Judge terminal wake crashed after=%s: %s"
+      finished_entry.id
+      reason;
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string HitlSummaryOutcomes)
+      ~labels:[ "outcome", "terminal_wake_crashed" ]
+      ()
 ;;
 
 let rec claim_auto_judge id =
@@ -377,8 +501,12 @@ let rec spawn_claimed_auto_judge_entry
          ~on_failure
          ~on_finish:(fun () ->
            release_auto_judge approval_id;
-           (* fire-and-forget: the queue owns subsequent worker completion. *)
-           ignore (drain_auto_judges ~base_path:entry.audit_base_path))
+           let outcome =
+             try wake_one_auto_judge ~finished_id:approval_id with
+             | Eio.Cancel.Cancelled _ as exn -> raise exn
+             | exn -> Wake_crashed (Printexc.to_string exn)
+           in
+           observe_auto_judge_wake ~finished_entry:entry outcome)
          ();
        Ok Started
      with
@@ -478,6 +606,22 @@ and drain_auto_judges ~base_path =
             entry.id
             reason;
           None)
+
+and wake_one_auto_judge ~finished_id =
+  let rec start_first = function
+    | [] -> Wake_idle
+    | candidate :: rest ->
+      let result =
+        match candidate.source with
+        | Awaiting_start -> start_auto_judge candidate.entry.id
+        | Restart_replay -> spawn_auto_judge_entry candidate.entry
+      in
+      (match result with
+       | Ok Started -> Wake_started candidate
+       | Ok Skipped -> start_first rest
+       | Error reason -> Wake_failed (candidate, reason))
+  in
+  start_first (ready_auto_judges ~finished_id)
 ;;
 
 type recovered_work =
@@ -781,4 +925,17 @@ let decide ?cycle_grant ~keeper_always_allow request =
       ~labels:[ "keeper", request.keeper_name; "site", "cycle_grant_lookup" ]
       ();
     Unavailable reason
+;;
+
+module For_testing = struct
+  type nonrec auto_judge_ready_source = auto_judge_ready_source =
+    | Awaiting_start
+    | Restart_replay
+
+  let next_auto_judge_wake_candidate ~finished_id =
+    match ready_auto_judges ~finished_id with
+    | [] -> None
+    | candidate :: _ -> Some (candidate.entry.id, candidate.source)
+  ;;
+end
 ;;

--- a/lib/keeper/keeper_gate.mli
+++ b/lib/keeper/keeper_gate.mli
@@ -113,3 +113,12 @@ val authorization_source_to_string : authorization_source -> string
 val deferred_reason_to_string : deferred_reason -> string
 val unavailable_reason_to_string : unavailable_reason -> string
 val decision_to_yojson : decision -> Yojson.Safe.t
+
+module For_testing : sig
+  type auto_judge_ready_source =
+    | Awaiting_start
+    | Restart_replay
+
+  val next_auto_judge_wake_candidate :
+    finished_id:string -> (string * auto_judge_ready_source) option
+end

--- a/lib/keeper/keeper_gate.mli
+++ b/lib/keeper/keeper_gate.mli
@@ -119,6 +119,21 @@ module For_testing : sig
     | Awaiting_start
     | Restart_replay
 
+  type auto_judge_attempt =
+    | Candidate_started
+    | Candidate_skipped
+    | Candidate_failed of string
+
+  type auto_judge_wake_plan =
+    { started_id : string option
+    ; failures : (string * string) list
+    }
+
   val next_auto_judge_wake_candidate :
     finished_id:string -> (string * auto_judge_ready_source) option
+
+  val drive_auto_judge_wake :
+    finished_id:string ->
+    attempt:(string -> auto_judge_attempt) ->
+    auto_judge_wake_plan
 end

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -927,6 +927,48 @@ let test_inflight_auto_judge_preserves_durable_restart_marker () =
         | None -> Alcotest.fail "cleanup resolution was not durable"))
 ;;
 
+let test_terminal_wake_selects_replay_across_workspaces () =
+  let finished_base_path = temp_dir () in
+  let replay_base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      AQ.For_testing.reset_runtime_state ();
+      cleanup_dir finished_base_path;
+      cleanup_dir replay_base_path)
+    (fun () ->
+       AQ.For_testing.reset_runtime_state ();
+       let finished_id =
+         submit
+           ~base_path:finished_base_path
+           ~keeper_name:"queue-terminal-finished"
+           ~input:(`String "finished")
+       in
+       let replay_id =
+         submit
+           ~base_path:replay_base_path
+           ~keeper_name:"queue-terminal-replay"
+           ~input:(`String "replay")
+       in
+       check_update
+         "replay candidate is durable"
+         true
+         (AQ.mark_summary_pending ~id:replay_id);
+       (match
+          Gate.For_testing.next_auto_judge_wake_candidate ~finished_id
+        with
+        | Some (actual_id, Gate.For_testing.Restart_replay) ->
+          Alcotest.(check string)
+            "another workspace replay is selected"
+            replay_id
+            actual_id
+        | Some (_, Gate.For_testing.Awaiting_start) ->
+          Alcotest.fail "durable replay was classified as a fresh start"
+        | None ->
+          Alcotest.fail "another workspace's durable replay was not selected");
+       reject_and_cleanup finished_id;
+       reject_and_cleanup replay_id)
+;;
+
 let test_malformed_snapshot_fails_install_and_is_observed () =
   let base_path = temp_dir () in
   Fun.protect
@@ -1370,6 +1412,10 @@ let () =
             "interrupted judge keeps restart marker"
             `Quick
             test_inflight_auto_judge_preserves_durable_restart_marker
+        ; Alcotest.test_case
+            "terminal wake crosses workspace boundary"
+            `Quick
+            test_terminal_wake_selects_replay_across_workspaces
         ; Alcotest.test_case
             "malformed snapshot is explicit"
             `Quick

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -969,6 +969,64 @@ let test_terminal_wake_selects_replay_across_workspaces () =
        reject_and_cleanup replay_id)
 ;;
 
+let test_terminal_wake_continues_after_candidate_failure () =
+  let finished_base_path = temp_dir () in
+  let first_base_path = temp_dir () in
+  let second_base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      AQ.For_testing.reset_runtime_state ();
+      List.iter
+        cleanup_dir
+        [ finished_base_path; first_base_path; second_base_path ])
+    (fun () ->
+       AQ.For_testing.reset_runtime_state ();
+       let finished_id =
+         submit
+           ~base_path:finished_base_path
+           ~keeper_name:"queue-terminal-failure-origin"
+           ~input:(`String "finished")
+       in
+       let candidate_ids =
+         [ submit
+             ~base_path:first_base_path
+             ~keeper_name:"queue-terminal-first-candidate"
+             ~input:(`String "first")
+         ; submit
+             ~base_path:second_base_path
+             ~keeper_name:"queue-terminal-second-candidate"
+             ~input:(`String "second")
+         ]
+       in
+       let first_id =
+         match Gate.For_testing.next_auto_judge_wake_candidate ~finished_id with
+         | Some (id, _) -> id
+         | None -> Alcotest.fail "terminal wake had no first candidate"
+       in
+       let second_id =
+         match List.filter (fun id -> not (String.equal id first_id)) candidate_ids with
+         | [ id ] -> id
+         | _ -> Alcotest.fail "candidate identities were not exact"
+       in
+       let plan =
+         Gate.For_testing.drive_auto_judge_wake
+           ~finished_id
+           ~attempt:(fun id ->
+             if String.equal id first_id
+             then Gate.For_testing.Candidate_failed "first candidate failed"
+             else Gate.For_testing.Candidate_started)
+       in
+       Alcotest.(check (option string))
+         "second candidate starts"
+         (Some second_id)
+         plan.started_id;
+       Alcotest.(check (list (pair string string)))
+         "first failure remains observable"
+         [ first_id, "first candidate failed" ]
+         plan.failures;
+       List.iter reject_and_cleanup (finished_id :: candidate_ids))
+;;
+
 let test_malformed_snapshot_fails_install_and_is_observed () =
   let base_path = temp_dir () in
   Fun.protect
@@ -1416,6 +1474,10 @@ let () =
             "terminal wake crosses workspace boundary"
             `Quick
             test_terminal_wake_selects_replay_across_workspaces
+        ; Alcotest.test_case
+            "terminal wake continues after one failure"
+            `Quick
+            test_terminal_wake_continues_after_candidate_failure
         ; Alcotest.test_case
             "malformed snapshot is explicit"
             `Quick


### PR DESCRIPTION
## What changed

- replace Auto Judge terminal completion's same-workspace backlog drain with a process-global durable ready selection
- classify candidates as typed `Awaiting_start` or `Restart_replay` from the durable summary state
- start at most one eligible request after one terminal transition; duplicate/raced candidates are skipped without bursting the backlog
- order candidates by durable request time with exact approval identity as the deterministic tie-breaker
- observe started, idle, failed, crashed, and invalid-mode wake outcomes; persist an audit event for a successful wake
- add a cross-workspace regression proving a durable replay in workspace B is selected after workspace A finishes

## Why

The active Auto Judge set is process-global, but completion previously called `drain_auto_judges` only for the completed entry's `audit_base_path`. Under the current temporary execution bound, a pending request in another loaded workspace could therefore remain stranded even though a worker slot had been released.

One terminal transition now wakes exactly one globally eligible durable request. This preserves request identity and replay state without restoring the unsafe full-backlog fiber burst from #24939.

## Scope boundary

This is an exact terminal-wake slice of #24967, not the complete generic execution scheduler. It deliberately does **not**:

- remove or bless the existing `keeper.hitl_summary.max_concurrency` mechanism
- add a provider/model/tool-specific queue
- invent a numeric cap, environment knob, or resource heuristic
- claim that `Eio.Switch` is a resource bound

A generic process-owned execution resource contract is still required before the old Auto Judge cap can be deleted safely. Durable approval admission remains owned by `Keeper_approval_queue`; this PR changes only post-terminal execution scheduling.

## Validation

- `ocamlc -stop-after parsing` on all changed OCaml sources/interfaces
- `ocamlformat --check` on all changed OCaml files
- `git diff --check`
- focused `scripts/dune-local.sh build test/test_keeper_approval_queue.exe` was requested but stopped before compilation because the shared switch has `agent_sdk 0.213.0` while current main requires `>= 0.214.1`; no pin bypass or shared-switch mutation was used

Related: #24967

[근거] `gh issue view 24967`, current `origin/main@d2b5e8e566`, and source call-graph review on 2026-07-17 KST; confidence High.