### PR TITLE
feat(keeper): persist exact compaction producer identity

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -308,6 +308,7 @@
   masc.prompt_registry
   ;; MCP transport/session leaf primitives (extracted sub-libraries)
   masc.mcp_transport_protocol
+  masc.tool_invocation_ref
   masc.mcp_session
   ;; Response envelope leaf primitive (extracted sub-library)
   masc.response

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -134,7 +134,7 @@ let connector_attention_event_ids_of_stimuli stimuli =
       | Keeper_event_queue.Bootstrap
       | Keeper_event_queue.Hitl_resolved _
       | Keeper_event_queue.Failure_judgment _
-      | Keeper_event_queue.Manual_compaction_requested
+      | Keeper_event_queue.Manual_compaction_requested _
       | Keeper_event_queue.Goal_assigned _ ->
         None)
     stimuli
@@ -154,7 +154,7 @@ let record_schedule_due_turn_started_reactions ~ctx ~keeper_name stimuli =
        | Keeper_event_queue.Connector_attention _
        | Keeper_event_queue.Hitl_resolved _
        | Keeper_event_queue.Failure_judgment _
-       | Keeper_event_queue.Manual_compaction_requested
+       | Keeper_event_queue.Manual_compaction_requested _
        | Keeper_event_queue.Goal_assigned _ -> ())
     stimuli
 ;;
@@ -224,7 +224,7 @@ let failure_judgment_of_stimuli = function
            | Keeper_event_queue.Bootstrap
            | Keeper_event_queue.Connector_attention _
            | Keeper_event_queue.Hitl_resolved _
-           | Keeper_event_queue.Manual_compaction_requested
+           | Keeper_event_queue.Manual_compaction_requested _
            | Keeper_event_queue.Goal_assigned _ ->
              false)
         stimuli
@@ -233,7 +233,7 @@ let failure_judgment_of_stimuli = function
 ;;
 
 let manual_compaction_requested_of_stimuli = function
-  | [ { Keeper_event_queue.payload = Manual_compaction_requested; _ } ] -> true
+  | [ { Keeper_event_queue.payload = Manual_compaction_requested _; _ } ] -> true
   | [] | [ _ ] | _ :: _ :: _ -> false
 ;;
 

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -96,7 +96,7 @@ let event_queue_trigger_of_stimulus (stim : Keeper_event_queue.stimulus) =
     Some Keeper_world_observation.Hitl_resolved_stimulus
   | Keeper_event_queue.Failure_judgment _ ->
     Some Keeper_world_observation.Failure_judgment_stimulus
-  | Keeper_event_queue.Manual_compaction_requested ->
+  | Keeper_event_queue.Manual_compaction_requested _ ->
     Some Keeper_world_observation.Manual_compaction_stimulus
   | Keeper_event_queue.Board_signal _
   | Keeper_event_queue.Board_attention _
@@ -181,7 +181,7 @@ let consume_single_heartbeat_stimulus
       (Keeper_runtime_failure_route.judgment_provenance_label fj.fj_provenance)
       meta_after_triage.name;
     pending_board_event_of_stimulus ~meta_after_triage stim |> Option.to_list
-  | Keeper_event_queue.Manual_compaction_requested ->
+  | Keeper_event_queue.Manual_compaction_requested _ ->
     Log.Keeper.info
       "turn entry: manual compaction request delivered (keeper=%s)"
       meta_after_triage.name;
@@ -284,7 +284,7 @@ let stimulus_ready_for_intake (stimulus : Keeper_event_queue.stimulus) =
   | Keeper_event_queue.Schedule_due _
   | Keeper_event_queue.Connector_attention _
   | Keeper_event_queue.Failure_judgment _
-  | Keeper_event_queue.Manual_compaction_requested
+  | Keeper_event_queue.Manual_compaction_requested _
   | Keeper_event_queue.Goal_assigned _ ->
     true
 ;;

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -116,7 +116,7 @@ let stimulus_kind_of_event_queue (stimulus : Keeper_event_queue.stimulus) =
   | Keeper_event_queue.Connector_attention _ -> Connector_attention
   | Keeper_event_queue.Hitl_resolved _ -> Hitl_resolved
   | Keeper_event_queue.Failure_judgment _ -> Failure_judgment
-  | Keeper_event_queue.Manual_compaction_requested -> Manual_compaction
+  | Keeper_event_queue.Manual_compaction_requested _ -> Manual_compaction
   | Keeper_event_queue.Goal_assigned _ -> Goal_assigned
 ;;
 
@@ -221,7 +221,7 @@ let stimulus_payload_preview (payload : Keeper_event_queue.stimulus_payload) =
       fj.fj_runtime_id
       (Keeper_runtime_failure_route.judgment_class_label fj.fj_judgment)
       (Keeper_runtime_failure_route.judgment_provenance_label fj.fj_provenance)
-  | Keeper_event_queue.Manual_compaction_requested -> "manual_compaction_requested"
+  | Keeper_event_queue.Manual_compaction_requested _ -> "manual_compaction_requested"
   | Keeper_event_queue.Goal_assigned ga ->
     Printf.sprintf
       "goal_assigned goal_id=%s assigned_by=%s"
@@ -244,7 +244,7 @@ let stimulus_json ~keeper_name (stimulus : Keeper_event_queue.stimulus) =
     | Keeper_event_queue.Connector_attention _
     | Keeper_event_queue.Hitl_resolved _
     | Keeper_event_queue.Failure_judgment _
-    | Keeper_event_queue.Manual_compaction_requested
+    | Keeper_event_queue.Manual_compaction_requested _
     | Keeper_event_queue.Goal_assigned _ -> None
   in
   `Assoc

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -178,7 +178,7 @@ let board_attention_event_id (stimulus : Keeper_event_queue.stimulus) =
   | Keeper_event_queue.Connector_attention _
   | Keeper_event_queue.Hitl_resolved _
   | Keeper_event_queue.Failure_judgment _
-  | Keeper_event_queue.Manual_compaction_requested
+  | Keeper_event_queue.Manual_compaction_requested _
   | Keeper_event_queue.Goal_assigned _ ->
     None
 ;;

--- a/lib/keeper/keeper_tool_boundary.ml
+++ b/lib/keeper/keeper_tool_boundary.ml
@@ -7,11 +7,13 @@ type 'a context = {
   clock : 'a Eio.Time.clock;
   proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option;
   net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option;
+  invocation_ref : Tool_invocation_ref.t option;
   publication_recovery_provider :
     Keeper_publication_recovery_availability.provider;
 }
 
 let create
+      ?invocation_ref
       ~config
       ~agent_name
       ~sw
@@ -19,6 +21,7 @@ let create
       ~proc_mgr
       ~net
       ~publication_recovery_provider
+      ()
   =
   { config
   ; agent_name
@@ -26,6 +29,7 @@ let create
   ; clock
   ; proc_mgr
   ; net
+  ; invocation_ref
   ; publication_recovery_provider
   }
 
@@ -41,10 +45,15 @@ let to_tool_keeper_context (ctx : _ context) : _ Keeper_tool_surface.context =
   }
 
 let dispatch ctx ~name ~args =
-  Keeper_tool_surface.dispatch (to_tool_keeper_context ctx) ~name ~args
+  Keeper_tool_surface.dispatch
+    ?invocation_ref:ctx.invocation_ref
+    (to_tool_keeper_context ctx)
+    ~name
+    ~args
 
 (* TEL-OK: this only closes over Keeper-owned context; dispatch remains observed downstream. *)
 let delegated_dispatch
+      ?invocation_ref
       ~config
       ~agent_name
       ~sw
@@ -52,9 +61,11 @@ let delegated_dispatch
       ~proc_mgr
       ~net
       ~publication_recovery_provider
+      ()
   =
   let ctx =
     create
+      ?invocation_ref
       ~config
       ~agent_name
       ~sw
@@ -62,6 +73,7 @@ let delegated_dispatch
       ~proc_mgr
       ~net
       ~publication_recovery_provider
+      ()
   in
   fun ~name ~args -> dispatch ctx ~name ~args
 ;;

--- a/lib/keeper/keeper_tool_boundary.mli
+++ b/lib/keeper/keeper_tool_boundary.mli
@@ -10,11 +10,13 @@ type 'a context = {
   clock : 'a Eio.Time.clock;
   proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option;
   net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option;
+  invocation_ref : Tool_invocation_ref.t option;
   publication_recovery_provider :
     Keeper_publication_recovery_availability.provider;
 }
 
 val create :
+  ?invocation_ref:Tool_invocation_ref.t ->
   config:Workspace.config ->
   agent_name:string ->
   sw:Eio.Switch.t ->
@@ -23,12 +25,14 @@ val create :
   net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option ->
   publication_recovery_provider:
     Keeper_publication_recovery_availability.provider ->
+  unit ->
   'a context
 
 val dispatch :
   _ context -> name:string -> args:Yojson.Safe.t -> Keeper_types_profile.tool_result option
 
 val delegated_dispatch :
+  ?invocation_ref:Tool_invocation_ref.t ->
   config:Workspace.config ->
   agent_name:string ->
   sw:Eio.Switch.t ->
@@ -37,6 +41,7 @@ val delegated_dispatch :
   net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option ->
   publication_recovery_provider:
     Keeper_publication_recovery_availability.provider ->
+  unit ->
   name:string ->
   args:Yojson.Safe.t ->
   Keeper_types_profile.tool_result option

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -507,6 +507,11 @@ let keeper_compact_body
       args
   : tool_result
   =
+  match invocation_ref with
+  | None ->
+    tool_result_error
+      "masc_keeper_compact requires an exact tool invocation identity"
+  | Some producer_invocation ->
   match resolve_keeper_name_config ~config args with
   | Error err -> tool_result_error err
   | Ok name ->
@@ -527,10 +532,11 @@ let keeper_compact_body
     end
     else
       let stimulus : Keeper_event_queue.stimulus =
-        { post_id = Keeper_event_queue.manual_compaction_post_id
+        { post_id =
+            Keeper_event_queue.manual_compaction_post_id producer_invocation
         ; urgency = Immediate
         ; arrived_at = Time_compat.now ()
-        ; payload = Manual_compaction_requested
+        ; payload = Manual_compaction_requested producer_invocation
         }
       in
       let queued queue_outcome =
@@ -540,11 +546,7 @@ let keeper_compact_body
             ; "queued", `Bool true
             ; "queue_outcome", `String queue_outcome
             ; "stimulus", `String (Keeper_event_queue.payload_kind_label stimulus.payload)
-            ; ( "producer_invocation"
-              , Option.fold
-                  ~none:`Null
-                  ~some:Tool_invocation_ref.to_yojson
-                  invocation_ref )
+            ; "producer_invocation", Tool_invocation_ref.to_yojson producer_invocation
             ; ( "wake"
               , manual_compaction_wakeup_observation
                   ~base_path:config.base_path

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -501,7 +501,12 @@ let manual_compaction_wakeup_observation ~base_path keeper_name =
 
 (** Queue an operator compaction for the target Keeper's owning lane. *)
 (* RFC-0182 §3.1 — ctx-free body for keeper_dispatch_ref path. *)
-let keeper_compact_body ~(config : Workspace.config) args : tool_result =
+let keeper_compact_body
+      ?invocation_ref
+      ~(config : Workspace.config)
+      args
+  : tool_result
+  =
   match resolve_keeper_name_config ~config args with
   | Error err -> tool_result_error err
   | Ok name ->
@@ -535,6 +540,11 @@ let keeper_compact_body ~(config : Workspace.config) args : tool_result =
             ; "queued", `Bool true
             ; "queue_outcome", `String queue_outcome
             ; "stimulus", `String (Keeper_event_queue.payload_kind_label stimulus.payload)
+            ; ( "producer_invocation"
+              , Option.fold
+                  ~none:`Null
+                  ~some:Tool_invocation_ref.to_yojson
+                  invocation_ref )
             ; ( "wake"
               , manual_compaction_wakeup_observation
                   ~base_path:config.base_path
@@ -557,8 +567,8 @@ let keeper_compact_body ~(config : Workspace.config) args : tool_result =
        | Stimulus_enqueued -> queued "enqueued"
        | Stimulus_already_present -> queued "already_present")
 
-let handle_keeper_compact ctx args : tool_result =
-  keeper_compact_body ~config:ctx.config args
+let handle_keeper_compact ?invocation_ref ctx args : tool_result =
+  keeper_compact_body ?invocation_ref ~config:ctx.config args
 
 (** Last-resort context clear.
 
@@ -697,7 +707,7 @@ let keeper_clear_body ~(config : Workspace.config) args : tool_result =
 let handle_keeper_clear ctx args : tool_result =
   keeper_clear_body ~config:ctx.config args
 
-let dispatch ctx ~name ~args : tool_result option =
+let dispatch ?invocation_ref ctx ~name ~args : tool_result option =
   maybe_bootstrap_existing_keepalives ctx ~name ~args;
   let ctx = resolve_ctx ctx ~name args in
   match name with
@@ -740,7 +750,11 @@ let dispatch ctx ~name ~args : tool_result option =
            ~tool_name:name
            (handle_keeper_sandbox_status ctx args))
   | "masc_keeper_reset" -> Some (tool_result_with_tool_name ~tool_name:name (handle_keeper_reset ctx args))
-  | "masc_keeper_compact" -> Some (tool_result_with_tool_name ~tool_name:name (handle_keeper_compact ctx args))
+  | "masc_keeper_compact" ->
+    Some
+      (tool_result_with_tool_name
+         ~tool_name:name
+         (handle_keeper_compact ?invocation_ref ctx args))
   | "masc_keeper_clear" -> Some (tool_result_with_tool_name ~tool_name:name (handle_keeper_clear ctx args))
   | _ -> None
 

--- a/lib/keeper/keeper_tool_surface.mli
+++ b/lib/keeper/keeper_tool_surface.mli
@@ -17,7 +17,11 @@ type tool_result = Keeper_types_profile.tool_result
 val schemas : Masc_domain.tool_schema list
 
 val dispatch :
-  _ context -> name:string -> args:Yojson.Safe.t -> tool_result option
+  ?invocation_ref:Tool_invocation_ref.t ->
+  _ context ->
+  name:string ->
+  args:Yojson.Safe.t ->
+  tool_result option
 
 (** Internal async-message entry point for adapters whose authenticated
     submission principal differs from the target turn's [ctx.agent_name].

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -711,7 +711,7 @@ let pending_board_event_of_stimulus
   | Keeper_event_queue.Bootstrap
   | Keeper_event_queue.Connector_attention _
   | Keeper_event_queue.Hitl_resolved _
-  | Keeper_event_queue.Manual_compaction_requested ->
+  | Keeper_event_queue.Manual_compaction_requested _ ->
     (* RFC-connector-ambient-attention-wake P1: not a board event. The wake
        fires via the trigger itself; [Hitl_resolved] carries no observation to
        inject — the keeper resumes on its own state once the approval is gone

--- a/lib/keeper_runtime/dune
+++ b/lib/keeper_runtime/dune
@@ -38,6 +38,7 @@
   masc.bounded_event_dedupe
   masc.json_field
   masc.masc_core
+  masc.tool_invocation_ref
   masc.types_boundary
   masc_cancel_safe
   masc_core

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -76,7 +76,7 @@ type stimulus_payload =
          dedicated turn_reason, so scheduling cooldowns are unchanged and
          the stable per-(runtime, class) post_id lets queue identity dedup
          collapse repeats. *)
-  | Manual_compaction_requested
+  | Manual_compaction_requested of Tool_invocation_ref.t
   | Goal_assigned of goal_assignment
       (* RFC-0315 P3 W0: a goal entered this keeper's [active_goal_ids]
          (keeper_up tool args or TOML reconcile). Wakes the keeper ONCE at
@@ -194,7 +194,10 @@ let failure_judgment_post_id (fj : failure_judgment) =
   ^ ":"
   ^ Keeper_runtime_failure_route.judgment_provenance_label fj.fj_provenance
 
-let manual_compaction_post_id = "manual-compaction-request"
+let manual_compaction_post_id producer_invocation =
+  "manual-compaction-request:"
+  ^ Yojson.Safe.to_string (Tool_invocation_ref.to_yojson producer_invocation)
+;;
 
 let goal_assignment_post_id (ga : goal_assignment) =
   (* Stable per goal: re-assigning the same goal before the keeper consumes
@@ -247,7 +250,7 @@ let identity_payload = function
     Goal_assigned { ga with ga_goal_title = ""; ga_assigned_by = "" }
   | ( Board_signal _ | Board_attention _ | Bootstrap | Fusion_completed _
     | Bg_completed _ | Schedule_due _ | Connector_attention _ | Hitl_resolved _
-    | Manual_compaction_requested
+    | Manual_compaction_requested _
     ) as payload ->
     payload
 
@@ -265,6 +268,8 @@ let stimulus_identity_equal a b =
   match a.payload, b.payload with
   | Failure_judgment left, Failure_judgment right ->
     failure_judgment_identity_equal left right
+  | Manual_compaction_requested left, Manual_compaction_requested right ->
+    Tool_invocation_ref.equal left right
   | _ -> identity_payload a.payload = identity_payload b.payload
 
 let to_list (queue : t) : stimulus list =
@@ -350,14 +355,14 @@ let payload_kind_label = function
   | Connector_attention _ -> "connector_attention"
   | Hitl_resolved _ -> "hitl_resolved"
   | Failure_judgment _ -> "failure_judgment"
-  | Manual_compaction_requested -> "manual_compaction_requested"
+  | Manual_compaction_requested _ -> "manual_compaction_requested"
   | Goal_assigned _ -> "goal_assigned"
 
 let is_board_signal = function
   | Board_signal _ | Board_attention _ -> true
   | Bootstrap | Fusion_completed _ | Bg_completed _
   | Schedule_due _ | Connector_attention _ | Hitl_resolved _
-  | Failure_judgment _ | Manual_compaction_requested | Goal_assigned _ ->
+  | Failure_judgment _ | Manual_compaction_requested _ | Goal_assigned _ ->
     false
 
 let drain_board_all (queue : t) : stimulus list * t =
@@ -565,8 +570,11 @@ let payload_to_yojson = function
         , Keeper_runtime_failure_route.judgment_provenance_to_yojson fj.fj_provenance )
       ; "detail", `String fj.fj_detail
       ]
-  | Manual_compaction_requested ->
-    `Assoc [ "kind", `String "manual_compaction_requested" ]
+  | Manual_compaction_requested producer_invocation ->
+    `Assoc
+      [ "kind", `String "manual_compaction_requested"
+      ; "producer_invocation", Tool_invocation_ref.to_yojson producer_invocation
+      ]
   | Goal_assigned ga ->
     `Assoc
       [ "kind", `String "goal_assigned"
@@ -696,7 +704,11 @@ let payload_of_yojson json =
          ; fj_provenance = provenance
          ; fj_detail = detail
          })
-  | "manual_compaction_requested" -> Ok Manual_compaction_requested
+  | "manual_compaction_requested" ->
+    let* producer_json = required_field ~context "producer_invocation" fields in
+    Tool_invocation_ref.of_yojson producer_json
+    |> Result.map (fun producer -> Manual_compaction_requested producer)
+    |> Result.map_error Tool_invocation_ref.decode_error_to_string
   | "goal_assigned" ->
     let* goal_id = string_field ~context "goal_id" fields in
     let* goal_title = string_field ~context "goal_title" fields in

--- a/lib/keeper_runtime/keeper_event_queue.mli
+++ b/lib/keeper_runtime/keeper_event_queue.mli
@@ -90,9 +90,12 @@ type stimulus_payload =
   | Failure_judgment of failure_judgment
       (** RFC-0313 deterministic failure class was rejected/blocked and should
           produce an LLM-boundary verdict prompt on the keeper lane. *)
-  | Manual_compaction_requested
-      (** Operator-requested MASC compaction. The tool only enqueues this
-          stimulus; the owning Keeper consumes it under its turn slot. *)
+  | Manual_compaction_requested of Tool_invocation_ref.t
+      (** Operator-requested MASC compaction, bound to the exact tool
+          invocation that admitted it. The owning Keeper consumes the durable
+          stimulus under its turn slot; downstream operation admission uses
+          this producer identity without reconstructing it from tool names,
+          arguments, timestamps, or payload hashes. *)
   | Goal_assigned of goal_assignment
       (** A goal was newly added to this keeper's [active_goal_ids]. *)
 (** Closed set of stimulus kinds. Replaces the prior [payload : string] +
@@ -212,7 +215,8 @@ val hitl_resolution_post_id : hitl_resolution -> post_id
 
 val failure_judgment_post_id : failure_judgment -> post_id
 
-val manual_compaction_post_id : post_id
+val manual_compaction_post_id : Tool_invocation_ref.t -> post_id
+(** Stable queue identity derived from the exact typed producer projection. *)
 
 val goal_assignment_post_id : goal_assignment -> post_id
 

--- a/lib/mcp_server_eio.mli
+++ b/lib/mcp_server_eio.mli
@@ -128,6 +128,7 @@ val execute_tool_eio :
   workspace_scope:Mcp_server.workspace_scope ->
   ?profile:tool_profile ->
   ?mcp_session_id:string ->
+  ?invocation_ref:Tool_invocation_ref.t ->
   ?auth_token:string ->
   ?internal_keeper_runtime:bool ->
   server_state ->

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -489,6 +489,25 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
   in
   let config = workspace_scope.config in
   let make_response = Mcp_transport_protocol.make_response in
+  let request_id =
+    match Mcp_transport_protocol.request_id_of_yojson id with
+    | Ok request_id -> request_id
+    | Error error ->
+      invalid_arg
+        ("handle_call_tool_eio admitted an invalid MCP request id: "
+         ^ Mcp_transport_protocol.request_id_error_to_string error)
+  in
+  let invocation_ref =
+    match mcp_session_id with
+    | None -> None
+    | Some session_id ->
+      (match Tool_invocation_ref.external_mcp ~request_id ~session_id with
+       | Ok invocation_ref -> Some invocation_ref
+       | Error error ->
+         invalid_arg
+           ("handle_call_tool_eio admitted an invalid MCP invocation scope: "
+            ^ Tool_invocation_ref.error_to_string error))
+  in
   let (name, arguments) =
     match profile with
     | Managed_agent -> (
@@ -512,6 +531,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
         ~workspace_scope
         ?profile:(Some profile)
         ?mcp_session_id
+        ?invocation_ref
         ?auth_token
         ?internal_keeper_runtime:(Some internal_keeper_runtime)
         state
@@ -550,14 +570,10 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
   in
   let end_time = Eio.Time.now clock in
   let duration_ms = int_of_float ((end_time -. start_time) *. 1000.0) in
-  let jsonrpc_id_str =
-    match id with
-    | `String s -> s
-    | `Int i -> string_of_int i
-    | `Intlit s -> s
-    | `Float f -> Printf.sprintf "%0.0f" f
-    | _ -> "unknown"
+  let request_id_json =
+    Mcp_transport_protocol.request_id_to_yojson request_id
   in
+  let request_id_trace_fallback = Yojson.Safe.to_string request_id_json in
   let mcp_session_detail = Json_util.string_opt_to_json mcp_session_id in
 
   (* Resolve caller identity for telemetry.  HTTP auth injects [_agent_name];
@@ -609,7 +625,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
               `String (Tool_result.tool_failure_class_to_string failure_class) );
             ("tool_name", `String name);
             ("phase", `String "failure");
-            ("request_id", `String jsonrpc_id_str);
+            ("request_id", request_id_json);
             ("session_id", mcp_session_detail);
             ("outcome", `String "error");
             ("agent_name", `String agent_name);
@@ -755,7 +771,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
   let trace_id =
     match otel_trace_id with
     | Some tid -> tid
-    | None -> jsonrpc_id_str
+    | None -> request_id_trace_fallback
   in
   (match keeper_entry with
    | Some entry ->
@@ -835,7 +851,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
           ("event_family", `String "tool_call");
           ("tool_name", `String name);
           ("phase", `String "result");
-          ("request_id", `String jsonrpc_id_str);
+          ("request_id", request_id_json);
           ("session_id", mcp_session_detail);
           ("agent_name", `String agent_name);
           ("outcome", `String (Tool_result.string_of_tool_call_outcome outcome));

--- a/lib/mcp_server_eio_call_tool.mli
+++ b/lib/mcp_server_eio_call_tool.mli
@@ -115,6 +115,7 @@ val handle_call_tool_eio :
      workspace_scope:Mcp_server.workspace_scope ->
      ?profile:Mcp_server_eio_types.tool_profile ->
      ?mcp_session_id:string ->
+     ?invocation_ref:Tool_invocation_ref.t ->
      ?auth_token:'auth ->
      ?internal_keeper_runtime:bool ->
      Mcp_server.server_state ->

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -25,6 +25,7 @@ let execute_tool_eio
       ~(workspace_scope : Mcp_server.workspace_scope)
       ?(profile = Mcp_server_eio_tool_profile.Full)
       ?mcp_session_id
+      ?invocation_ref
       ?auth_token
       ?(internal_keeper_runtime = false)
       state
@@ -234,6 +235,7 @@ let execute_tool_eio
             (* Helper: create keeper tool boundary context (shared by goals) *)
             let make_keeper_tool_ctx () =
               Keeper_tool_boundary.create
+                ?invocation_ref
                 ~config
                 ~agent_name
                 ~sw
@@ -242,6 +244,7 @@ let execute_tool_eio
                 ~net:state.Mcp_server.net
                 ~publication_recovery_provider:
                   (Mcp_server.publication_recovery_availability_provider state)
+                ()
             in
             (* Dispatch a single module by tag — creates only that module's context.
      Pre-hooks may coerce arguments (e.g. OAS type coercion: "42" -> 42).
@@ -254,6 +257,20 @@ let execute_tool_eio
                 (match tag with
                  | Mod_plan -> Tool_plan.dispatch { config } ~name ~args:coerced_args
                  | Mod_operator ->
+                   let delegated_dispatch =
+                     Keeper_tool_boundary.delegated_dispatch
+                       ?invocation_ref
+                       ~config
+                       ~agent_name
+                       ~sw
+                       ~clock
+                       ~proc_mgr:state.Mcp_server.proc_mgr
+                       ~net:state.Mcp_server.net
+                       ~publication_recovery_provider:
+                         (Mcp_server.publication_recovery_availability_provider
+                            state)
+                       ()
+                   in
                    let ctx =
                      { Tool_operator.config
                      ; agent_name
@@ -261,18 +278,7 @@ let execute_tool_eio
                      ; clock
                      ; proc_mgr = state.Mcp_server.proc_mgr
                      ; net = state.Mcp_server.net
-                     ; delegated_dispatch =
-                         Some
-                           (Keeper_tool_boundary.delegated_dispatch
-                              ~config
-                              ~agent_name
-                              ~sw
-                              ~clock
-                              ~proc_mgr:state.Mcp_server.proc_mgr
-                              ~net:state.Mcp_server.net
-                              ~publication_recovery_provider:
-                                (Mcp_server.publication_recovery_availability_provider
-                                   state))
+                     ; delegated_dispatch = Some delegated_dispatch
                      ; mcp_session_id
                      }
                    in

--- a/lib/mcp_server_eio_execute.mli
+++ b/lib/mcp_server_eio_execute.mli
@@ -46,6 +46,7 @@ val execute_tool_eio :
   workspace_scope:Mcp_server.workspace_scope ->
   ?profile:Mcp_server_eio_types.tool_profile ->
   ?mcp_session_id:string ->
+  ?invocation_ref:Tool_invocation_ref.t ->
   ?auth_token:string ->
   ?internal_keeper_runtime:bool ->
   Mcp_server.server_state ->

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -753,13 +753,7 @@ let handle_request
         | Ok req ->
           let id = get_id req in
           let base_path = (Mcp_server.workspace_config state).Workspace.base_path in
-          if not (is_valid_request_id id)
-          then
-            make_error_typed
-              ~id:`Null
-              Mcp_error_code.Invalid_request
-              "Invalid Request: id must be string, number, or null"
-          else if Mcp_transport_protocol.is_notification req
+          if Mcp_transport_protocol.is_notification req
           then (
             match req.method_ with
             | "dashboard/ack" ->
@@ -771,6 +765,12 @@ let handle_request
                 (fun _auth_token ->
                    handle_dashboard_ack_notification ?mcp_session_id req.params)
             | _ -> `Null)
+          else if not (is_valid_request_id id)
+          then
+            make_error_typed
+              ~id:`Null
+              Mcp_error_code.Invalid_request
+              "Invalid Request: MCP id must be a string or integer"
           else (
             try
               match req.method_ with

--- a/lib/mcp_transport_protocol/mcp_transport_protocol.ml
+++ b/lib/mcp_transport_protocol/mcp_transport_protocol.ml
@@ -17,6 +17,71 @@ type jsonrpc_request = {
   params : Yojson.Safe.t option; [@default None]
 } [@@deriving yojson { strict = false }]
 
+type request_id =
+  | String_id of string
+  | Integer_id of string
+
+type request_id_error =
+  | Null_request_id
+  | Non_lossless_number
+  | Invalid_integer_lexeme of string
+  | Invalid_request_id_kind
+
+let is_digit c = c >= '0' && c <= '9'
+
+let is_json_integer_lexeme value =
+  let length = String.length value in
+  let first_digit =
+    if length > 0 && value.[0] = '-' then 1 else 0
+  in
+  if first_digit >= length
+  then false
+  else
+    let first = value.[first_digit] in
+    if first = '0'
+    then first_digit + 1 = length
+    else
+      first >= '1'
+      && first <= '9'
+      &&
+      let rec all_digits index =
+        index = length
+        || (is_digit value.[index] && all_digits (index + 1))
+      in
+      all_digits (first_digit + 1)
+;;
+
+let request_id_of_yojson = function
+  | `String value -> Ok (String_id value)
+  | `Int value -> Ok (Integer_id (string_of_int value))
+  | `Intlit value when is_json_integer_lexeme value -> Ok (Integer_id value)
+  | `Intlit value -> Error (Invalid_integer_lexeme value)
+  | `Float _ -> Error Non_lossless_number
+  | `Null -> Error Null_request_id
+  | `Assoc _ | `List _ | `Bool _ -> Error Invalid_request_id_kind
+;;
+
+let request_id_to_yojson = function
+  | String_id value -> `String value
+  | Integer_id value -> `Intlit value
+;;
+
+let request_id_equal left right =
+  match left, right with
+  | String_id left, String_id right
+  | Integer_id left, Integer_id right -> String.equal left right
+  | String_id _, Integer_id _ | Integer_id _, String_id _ -> false
+;;
+
+let request_id_error_to_string = function
+  | Null_request_id -> "MCP request id must not be null"
+  | Non_lossless_number ->
+    "MCP request id must be an integer; floating JSON numbers are not lossless"
+  | Invalid_integer_lexeme value ->
+    Printf.sprintf "invalid MCP integer request id lexeme: %S" value
+  | Invalid_request_id_kind -> "MCP request id must be a string or integer"
+;;
+
 let has_field key = function
   | `Assoc fields -> List.exists (fun (k, _) -> k = key) fields
   | _ -> false
@@ -44,9 +109,7 @@ let is_notification req = req.id = None
 
 let get_id req = match req.id with Some id -> id | None -> `Null
 
-let is_valid_request_id = function
-  | `Null | `String _ | `Int _ | `Intlit _ | `Float _ -> true
-  | _ -> false
+let is_valid_request_id value = Result.is_ok (request_id_of_yojson value)
 
 let validate_initialize_params params =
   let ( let* ) = Result.bind in

--- a/lib/mcp_transport_protocol/mcp_transport_protocol.mli
+++ b/lib/mcp_transport_protocol/mcp_transport_protocol.mli
@@ -18,6 +18,29 @@ type jsonrpc_request = {
 (** JSON-RPC 2.0 request. [id = None] denotes a notification. The
     [method_] OCaml field maps to the JSON ["method"] key. *)
 
+type request_id
+(** Exact MCP request identity. Integer ids retain their canonical JSON
+    lexeme so callers never round-trip through a binary float. *)
+
+type request_id_error =
+  | Null_request_id
+  | Non_lossless_number
+  | Invalid_integer_lexeme of string
+  | Invalid_request_id_kind
+
+val request_id_of_yojson :
+  Yojson.Safe.t -> (request_id, request_id_error) result
+(** Parses the MCP request-id contract: string or integer only. [`Float _]
+    is rejected even when mathematically integral because Yojson has already
+    discarded the producer's exact decimal lexeme. *)
+
+val request_id_to_yojson : request_id -> Yojson.Safe.t
+(** Lossless wire projection of a typed request id. *)
+
+val request_id_equal : request_id -> request_id -> bool
+
+val request_id_error_to_string : request_id_error -> string
+
 val has_field : string -> Yojson.Safe.t -> bool
 (** [has_field key json] is [true] when [json] is an [`Assoc] containing [key]. *)
 
@@ -39,8 +62,8 @@ val get_id : jsonrpc_request -> Yojson.Safe.t
 (** Returns the request id, defaulting to [`Null] for notifications. *)
 
 val is_valid_request_id : Yojson.Safe.t -> bool
-(** Per the JSON-RPC 2.0 spec, valid ids are [`Null], [`String _],
-    [`Int _], [`Intlit _], or [`Float _]. *)
+(** MCP requests admit string or integer ids. Null and floating-point ids are
+    rejected, as required by the MCP request contract. *)
 
 val validate_initialize_params : Yojson.Safe.t option -> (unit, string) result
 (** Checks that [params] for the MCP [initialize] method contain

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -751,7 +751,8 @@ let operator_control_context ~state ~sw ~clock ~config ~agent_name
            ~proc_mgr:state.Mcp_server.proc_mgr
            ~net:state.Mcp_server.net
            ~publication_recovery_provider:
-             (Mcp_server.publication_recovery_availability_provider state))
+             (Mcp_server.publication_recovery_availability_provider state)
+           ())
   ; mcp_session_id = None
   }
 ;;

--- a/lib/server_keeper_waiting_inventory.ml
+++ b/lib/server_keeper_waiting_inventory.ml
@@ -130,7 +130,7 @@ let wake_producer_of_payload : Keeper_event_queue.stimulus_payload -> wake_produ
   | Connector_attention _ -> Connector_attention_hook
   | Hitl_resolved _ -> Hitl_resolution_hook
   | Failure_judgment _ -> Keeper_turn_failure_route
-  | Manual_compaction_requested -> Keeper_compaction_request
+  | Manual_compaction_requested _ -> Keeper_compaction_request
   | Goal_assigned _ -> Keeper_goal_assignment
 ;;
 

--- a/lib/tool_invocation_ref/dune
+++ b/lib/tool_invocation_ref/dune
@@ -1,0 +1,10 @@
+(include_subdirs no)
+
+(library
+ (name masc_tool_invocation_ref)
+ (public_name masc.tool_invocation_ref)
+ (wrapped false)
+ (modules tool_invocation_ref)
+ (flags
+  (:standard -w +4))
+ (libraries masc.mcp_transport_protocol yojson))

--- a/lib/tool_invocation_ref/tool_invocation_ref.ml
+++ b/lib/tool_invocation_ref/tool_invocation_ref.ml
@@ -1,0 +1,35 @@
+type t =
+  | External_mcp of
+      { request_id : Mcp_transport_protocol.request_id
+      ; session_id : string
+      }
+
+type error = Empty_mcp_session_id
+
+let external_mcp ~request_id ~session_id =
+  if String.equal (String.trim session_id) ""
+  then Error Empty_mcp_session_id
+  else Ok (External_mcp { request_id; session_id })
+;;
+
+let to_yojson = function
+  | External_mcp { request_id; session_id } ->
+    `Assoc
+      [ "source", `String "external_mcp"
+      ; "session_id", `String session_id
+      ; "request_id", Mcp_transport_protocol.request_id_to_yojson request_id
+      ]
+;;
+
+let equal left right =
+  match left, right with
+  | ( External_mcp { request_id = left_id; session_id = left_session }
+    , External_mcp { request_id = right_id; session_id = right_session } ) ->
+    String.equal left_session right_session
+    && Mcp_transport_protocol.request_id_equal left_id right_id
+;;
+
+let error_to_string = function
+  | Empty_mcp_session_id ->
+    "external MCP tool invocation requires a non-empty stable session id"
+;;

--- a/lib/tool_invocation_ref/tool_invocation_ref.ml
+++ b/lib/tool_invocation_ref/tool_invocation_ref.ml
@@ -6,6 +6,16 @@ type t =
 
 type error = Empty_mcp_session_id
 
+type decode_error =
+  | Expected_object
+  | Unknown_field of string
+  | Duplicate_field of string
+  | Missing_field of string
+  | Expected_string of string
+  | Invalid_source of string
+  | Invalid_request_id of Mcp_transport_protocol.request_id_error
+  | Invalid_identity of error
+
 let external_mcp ~request_id ~session_id =
   if String.equal (String.trim session_id) ""
   then Error Empty_mcp_session_id
@@ -21,6 +31,45 @@ let to_yojson = function
       ]
 ;;
 
+let of_yojson = function
+  | `Assoc fields ->
+    let allowed = [ "source"; "session_id"; "request_id" ] in
+    let rec validate seen = function
+      | [] -> Ok ()
+      | (name, _) :: rest when not (List.mem name allowed) -> Error (Unknown_field name)
+      | (name, _) :: _ when List.mem name seen -> Error (Duplicate_field name)
+      | (name, _) :: rest -> validate (name :: seen) rest
+    in
+    let required name =
+      match List.assoc_opt name fields with
+      | Some value -> Ok value
+      | None -> Error (Missing_field name)
+    in
+    let ( let* ) = Result.bind in
+    let* () = validate [] fields in
+    let* source = required "source" in
+    let* session_id = required "session_id" in
+    let* request_id = required "request_id" in
+    let* () =
+      match source with
+      | `String "external_mcp" -> Ok ()
+      | `String value -> Error (Invalid_source value)
+      | _ -> Error (Expected_string "source")
+    in
+    let* session_id =
+      match session_id with
+      | `String value -> Ok value
+      | _ -> Error (Expected_string "session_id")
+    in
+    let* request_id =
+      Mcp_transport_protocol.request_id_of_yojson request_id
+      |> Result.map_error (fun error -> Invalid_request_id error)
+    in
+    external_mcp ~request_id ~session_id
+    |> Result.map_error (fun error -> Invalid_identity error)
+  | _ -> Error Expected_object
+;;
+
 let equal left right =
   match left, right with
   | ( External_mcp { request_id = left_id; session_id = left_session }
@@ -32,4 +81,21 @@ let equal left right =
 let error_to_string = function
   | Empty_mcp_session_id ->
     "external MCP tool invocation requires a non-empty stable session id"
+;;
+
+let decode_error_to_string = function
+  | Expected_object -> "tool invocation identity must be a JSON object"
+  | Unknown_field name ->
+    Printf.sprintf "tool invocation identity has unknown field %S" name
+  | Duplicate_field name ->
+    Printf.sprintf "tool invocation identity has duplicate field %S" name
+  | Missing_field name ->
+    Printf.sprintf "tool invocation identity is missing field %S" name
+  | Expected_string name ->
+    Printf.sprintf "tool invocation identity field %S must be a string" name
+  | Invalid_source source ->
+    Printf.sprintf "tool invocation identity has invalid source %S" source
+  | Invalid_request_id error ->
+    Mcp_transport_protocol.request_id_error_to_string error
+  | Invalid_identity error -> error_to_string error
 ;;

--- a/lib/tool_invocation_ref/tool_invocation_ref.mli
+++ b/lib/tool_invocation_ref/tool_invocation_ref.mli
@@ -1,0 +1,22 @@
+(** Exact producer identity for a tool invocation crossing into MASC.
+
+    This type owns correlation only. It does not authorize an effect and does
+    not infer identity from tool names, arguments, timestamps, or hashes. *)
+
+type t
+
+type error = Empty_mcp_session_id
+
+val external_mcp :
+  request_id:Mcp_transport_protocol.request_id ->
+  session_id:string ->
+  (t, error) result
+(** Builds an external MCP identity from the exact typed JSON-RPC request id
+    and the stable transport session id. *)
+
+val to_yojson : t -> Yojson.Safe.t
+(** Typed, inspectable projection. *)
+
+val equal : t -> t -> bool
+
+val error_to_string : error -> string

--- a/lib/tool_invocation_ref/tool_invocation_ref.mli
+++ b/lib/tool_invocation_ref/tool_invocation_ref.mli
@@ -7,6 +7,16 @@ type t
 
 type error = Empty_mcp_session_id
 
+type decode_error =
+  | Expected_object
+  | Unknown_field of string
+  | Duplicate_field of string
+  | Missing_field of string
+  | Expected_string of string
+  | Invalid_source of string
+  | Invalid_request_id of Mcp_transport_protocol.request_id_error
+  | Invalid_identity of error
+
 val external_mcp :
   request_id:Mcp_transport_protocol.request_id ->
   session_id:string ->
@@ -17,6 +27,11 @@ val external_mcp :
 val to_yojson : t -> Yojson.Safe.t
 (** Typed, inspectable projection. *)
 
+val of_yojson : Yojson.Safe.t -> (t, decode_error) result
+(** Restores the exact producer identity from its closed projection. Unknown,
+    duplicate, or malformed fields are rejected rather than ignored. *)
+
 val equal : t -> t -> bool
 
 val error_to_string : error -> string
+val decode_error_to_string : decode_error -> string

--- a/test/deps/dune
+++ b/test/deps/dune
@@ -112,6 +112,7 @@
   (re_export masc.masc_compression)
   (re_export masc.mcp_session)
   (re_export masc.mcp_transport_protocol)
+  (re_export masc.tool_invocation_ref)
   (re_export masc.multimodal)
   (re_export masc.prompt_registry)
   (re_export masc.pulse)

--- a/test/test_keeper_adversarial_review.ml
+++ b/test/test_keeper_adversarial_review.ml
@@ -69,7 +69,8 @@ let operator_ctx env sw config agent_name : _ Operator_control.context =
            ~clock:(Eio.Stdenv.clock env)
            ~proc_mgr:(Some (Eio.Stdenv.process_mgr env))
            ~net:(Some (Eio.Stdenv.net env))
-           ~publication_recovery_provider);
+           ~publication_recovery_provider
+           ());
     mcp_session_id = None;
   }
 

--- a/test/test_keeper_compact_recovery_tool_surface.ml
+++ b/test/test_keeper_compact_recovery_tool_surface.ml
@@ -25,6 +25,14 @@ let persisted_meta_exn config name =
   | Ok None -> fail "persisted keeper meta is missing"
   | Error detail -> failf "persisted keeper meta read failed: %s" detail
 
+let producer_invocation () =
+  let request_id =
+    Mcp_transport_protocol.request_id_of_yojson (`String "compact-request")
+    |> Result.get_ok
+  in
+  Tool_invocation_ref.external_mcp ~request_id ~session_id:"compact-test-session"
+  |> Result.get_ok
+
 let test_missing_checkpoint_still_queues_owner_lane_stimulus () =
   Eio_main.run @@ fun env ->
   Masc_test_deps.ensure_rng_initialized ();
@@ -65,8 +73,22 @@ let test_missing_checkpoint_still_queues_owner_lane_stimulus () =
             Masc_test_deps.non_runtime_publication_recovery_provider
         }
       in
+      (match
+         Keeper_tool_surface.dispatch
+           ctx
+           ~name:"masc_keeper_compact"
+           ~args:(`Assoc [ "name", `String keeper_name ])
+       with
+       | Some (Tool_result.Failed failure) ->
+         check string
+           "missing producer identity fails explicitly"
+           "masc_keeper_compact requires an exact tool invocation identity"
+           failure.message
+       | _ -> fail "compaction admission without a producer identity must fail");
+      let producer_invocation = producer_invocation () in
       match
         Keeper_tool_surface.dispatch
+          ~invocation_ref:producer_invocation
           ctx
           ~name:"masc_keeper_compact"
           ~args:(`Assoc [ "name", `String keeper_name ])
@@ -87,7 +109,23 @@ let test_missing_checkpoint_still_queues_owner_lane_stimulus () =
           Yojson.Safe.Util.(output.data |> member "stimulus" |> to_string);
         check bool "queue outcome is reported" true
           Yojson.Safe.Util.(
-            output.data |> member "queue_outcome" |> to_string <> ""))
+            output.data |> member "queue_outcome" |> to_string <> "");
+        (match
+           Keeper_registry_event_queue.snapshot
+             ~base_path:config.base_path
+             keeper_name
+           |> Keeper_event_queue.to_list
+         with
+         | [ { payload = Manual_compaction_requested persisted; post_id; _ } ] ->
+           check bool
+             "durable request preserves exact producer"
+             true
+             (Tool_invocation_ref.equal producer_invocation persisted);
+           check string
+             "queue identity is producer-bound"
+             (Keeper_event_queue.manual_compaction_post_id producer_invocation)
+             post_id
+         | _ -> fail "manual compaction producer was not durably queued"))
 
 let () =
   run "keeper_compact_recovery_tool_surface"

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -22,6 +22,15 @@ let post_ids queue =
   Queue.to_list queue |> List.map (fun (stimulus : Queue.stimulus) -> stimulus.post_id)
 ;;
 
+let manual_compaction_invocation () =
+  let request_id =
+    Mcp_transport_protocol.request_id_of_yojson (`String "queue-outcome")
+    |> Result.get_ok
+  in
+  Tool_invocation_ref.external_mcp ~request_id ~session_id:"event-queue-test"
+  |> Result.get_ok
+;;
+
 let claim_head state =
   State.claim_when ~claimed_at:10.0 ~ready:(fun _ -> true) state
   |> require_ok "claim head"
@@ -488,11 +497,12 @@ let cycle_meta () =
 ;;
 
 let test_applied_compaction_settles_followup_atomically () =
+  let producer_invocation = manual_compaction_invocation () in
   let lease =
     lease_for
       (stimulus
-         ~payload:Queue.Manual_compaction_requested
-         Queue.manual_compaction_post_id
+         ~payload:(Queue.Manual_compaction_requested producer_invocation)
+         (Queue.manual_compaction_post_id producer_invocation)
          1.0)
   in
   let meta = cycle_meta () in

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -10,6 +10,14 @@ module Queue = Keeper_event_queue
 module Registry_queue = Masc.Keeper_registry_event_queue
 module WO = Masc.Keeper_world_observation
 
+let manual_compaction_invocation () =
+  let request_id =
+    Mcp_transport_protocol.request_id_of_yojson (`String "post-turn-wirein")
+    |> Result.get_ok
+  in
+  Tool_invocation_ref.external_mcp ~request_id ~session_id:"post-turn-test"
+  |> Result.get_ok
+
 let test_prepared_becomes_applied_only_after_save () =
   let trigger = Compaction_trigger.Manual in
   check bool "Prepared is not Applied" false
@@ -212,8 +220,10 @@ let test_manual_compaction_serializes_owner_lane () =
         in
         Eio.Promise.resolve finished_u result);
       Eio.Promise.await held;
+      let producer_invocation = manual_compaction_invocation () in
       let tool_result =
         Masc.Keeper_tool_surface.dispatch
+          ~invocation_ref:producer_invocation
           ctx
           ~name:"masc_keeper_compact"
           ~args:(`Assoc [ "name", `String meta.name ])
@@ -239,7 +249,9 @@ let test_manual_compaction_serializes_owner_lane () =
       in
       let lease =
         match intake.claimed_lease, intake.consumed_stimuli with
-        | Some lease, [ { Queue.payload = Manual_compaction_requested; _ } ] -> lease
+        | Some lease, [ { Queue.payload = Manual_compaction_requested persisted; _ } ]
+          when Tool_invocation_ref.equal producer_invocation persisted ->
+          lease
         | _ -> fail "manual compaction request was not the sole durable lease"
       in
       let obs =
@@ -263,7 +275,9 @@ let test_manual_compaction_serializes_owner_lane () =
           ~obs
           ~turn_decision:decision
           ~shared_context:(Agent_sdk.Context.create_sync ())
-          ~wake:(Masc.Keeper_registry.Woken [ Manual_compaction_requested ])
+          ~wake:
+            (Masc.Keeper_registry.Woken
+               [ Manual_compaction_requested producer_invocation ])
           ~manual_compaction_requested:true
           ()
       in

--- a/test/test_keeper_waiting_inventory.ml
+++ b/test/test_keeper_waiting_inventory.ml
@@ -13,6 +13,14 @@ module Server_keeper_waiting_inventory = Masc.Server_keeper_waiting_inventory
 
 let () = ignore Operator_tool.force_link
 
+let manual_compaction_invocation () =
+  let request_id =
+    Mcp_transport_protocol.request_id_of_yojson (`String "waiting-inventory")
+    |> Result.get_ok
+  in
+  Tool_invocation_ref.external_mcp ~request_id ~session_id:"waiting-inventory-test"
+  |> Result.get_ok
+
 let temp_dir () =
   let path = Filename.temp_file "keeper_waiting_inventory_test" "" in
   Sys.remove path;
@@ -243,11 +251,12 @@ let test_manual_compaction_waiting_row_has_typed_producer () =
   @@ fun config ->
   let keeper_name = "manual-compaction-waiting-keeper" in
   ensure_keeper config keeper_name;
+  let producer_invocation = manual_compaction_invocation () in
   let pending =
     stimulus
-      ~post_id:Keeper_event_queue.manual_compaction_post_id
+      ~post_id:(Keeper_event_queue.manual_compaction_post_id producer_invocation)
       ~arrived_at:120.0
-      Keeper_event_queue.Manual_compaction_requested
+      (Keeper_event_queue.Manual_compaction_requested producer_invocation)
   in
   Keeper_event_queue_persistence.persist
     ~base_path:config.Workspace_utils_backend_setup.base_path

--- a/test/test_mcp_server_eio_call_tool.ml
+++ b/test/test_mcp_server_eio_call_tool.ml
@@ -104,7 +104,7 @@ let with_call_tool_state f =
       f env sw state)
 ;;
 
-let call_with_result ~env ~sw state result =
+let call_with_result ?mcp_session_id ?observe_invocation ~env ~sw state result =
   Masc.Mcp_server_eio_call_tool.handle_call_tool_eio
     ~execute_tool_eio:
       (fun
@@ -113,15 +113,19 @@ let call_with_result ~env ~sw state result =
         ~workspace_scope:_
         ?profile:_
         ?mcp_session_id:_
+        ?invocation_ref
         ?auth_token:_
         ?internal_keeper_runtime:_
         _state
         ~name:_
-        ~arguments:_ -> result)
+        ~arguments:_ ->
+        Option.iter (fun observe -> observe invocation_ref) observe_invocation;
+        result)
     ~maybe_emit_resource_notifications:(fun ~success:_ ~tool_name:_ -> ())
     ~broadcast_tools_list_changed:(fun () -> ())
     ~sw
     ~clock:(Eio.Stdenv.clock env)
+    ?mcp_session_id
     state
     (`Int 1)
     (`Assoc
@@ -129,6 +133,36 @@ let call_with_result ~env ~sw state result =
       ; "arguments", `Assoc [ "_agent_name", `String "projection-test" ]
       ])
 ;;
+
+let test_threads_exact_mcp_invocation_identity () =
+  with_call_tool_state (fun env sw state ->
+    let observed = ref None in
+    let result =
+      Tool_result.make_ok
+        ~tool_name:"masc_status"
+        ~start_time:0.0
+        ~data:(`String "ok")
+        ()
+    in
+    ignore
+      (call_with_result
+         ~mcp_session_id:"typed-session"
+         ~observe_invocation:(fun invocation -> observed := invocation)
+         ~env ~sw state result);
+    let request_id =
+      Mcp_transport_protocol.request_id_of_yojson (`Int 1) |> Result.get_ok
+    in
+    let expected =
+      Tool_invocation_ref.external_mcp
+        ~request_id
+        ~session_id:"typed-session"
+      |> Result.get_ok
+    in
+    match !observed with
+    | Some actual ->
+      check bool "exact invocation identity" true
+        (Tool_invocation_ref.equal expected actual)
+    | None -> fail "execute callback did not receive invocation identity")
 
 let result_fields response = response |> U.member "result"
 let result_envelope response = result_fields response |> U.member "resultEnvelope"
@@ -261,6 +295,7 @@ let test_handle_call_executes_transient_failure_once () =
               ~workspace_scope:_
               ?profile:_
               ?mcp_session_id:_
+              ?invocation_ref:_
               ?auth_token:_
               ?internal_keeper_runtime:_
               _state
@@ -328,6 +363,7 @@ let test_call_captures_admission_scope_across_workspace_switch () =
               ~workspace_scope
               ?profile:_
               ?mcp_session_id:_
+              ?invocation_ref:_
               ?auth_token:_
               ?internal_keeper_runtime:_
               callback_state
@@ -732,6 +768,8 @@ let () =
             test_handle_call_executes_transient_failure_once;
           test_case "captures admission scope across workspace switch" `Quick
             test_call_captures_admission_scope_across_workspace_switch;
+          test_case "threads exact MCP invocation identity" `Quick
+            test_threads_exact_mcp_invocation_identity;
           test_case "activity payload sanitizes invalid UTF-8" `Quick
             test_activity_payload_sanitizes_invalid_utf8;
           test_case "records MCP server operation duration metric" `Quick

--- a/test/test_mcp_server_eio_coverage.ml
+++ b/test/test_mcp_server_eio_coverage.ml
@@ -8,6 +8,7 @@ open Alcotest
 module Mcp_server_eio = Masc.Mcp_server_eio
 module Mcp_server = Masc.Mcp_server
 module Mcp_server_eio_protocol = Masc.Mcp_server_eio_protocol
+module Request_id = Mcp_transport_protocol
 (* ============================================================
    is_jsonrpc_v2 Tests
    ============================================================ *)
@@ -214,7 +215,7 @@ let test_get_id_none () =
    ============================================================ *)
 
 let test_is_valid_request_id_null () =
-  check bool "null valid" true (Mcp_server.is_valid_request_id `Null)
+  check bool "null invalid" false (Mcp_server.is_valid_request_id `Null)
 
 let test_is_valid_request_id_string () =
   check bool "string valid" true (Mcp_server.is_valid_request_id (`String "id-1"))
@@ -223,7 +224,38 @@ let test_is_valid_request_id_int () =
   check bool "int valid" true (Mcp_server.is_valid_request_id (`Int 123))
 
 let test_is_valid_request_id_float () =
-  check bool "float valid" true (Mcp_server.is_valid_request_id (`Float 1.5))
+  check bool "float invalid" false (Mcp_server.is_valid_request_id (`Float 1.5))
+
+let test_request_id_preserves_large_integer_lexeme () =
+  let lexeme = "92233720368547758081234567890" in
+  match Request_id.request_id_of_yojson (`Intlit lexeme) with
+  | Error _ -> fail "expected exact large integer request id"
+  | Ok request_id ->
+    check string "exact lexeme" lexeme
+      (Yojson.Safe.to_string (Request_id.request_id_to_yojson request_id))
+
+let invocation_ref_exn request_id =
+  match
+    Tool_invocation_ref.external_mcp
+      ~request_id
+      ~session_id:"mcp-session-1"
+  with
+  | Ok invocation -> invocation
+  | Error error -> fail (Tool_invocation_ref.error_to_string error)
+
+let test_tool_invocation_identity_distinguishes_string_and_integer () =
+  let string_id =
+    Request_id.request_id_of_yojson (`String "1")
+    |> Result.get_ok
+    |> invocation_ref_exn
+  in
+  let integer_id =
+    Request_id.request_id_of_yojson (`Int 1)
+    |> Result.get_ok
+    |> invocation_ref_exn
+  in
+  check bool "typed ids remain distinct" true
+    (not (Tool_invocation_ref.equal string_id integer_id))
 
 let test_is_valid_request_id_array () =
   check bool "array invalid" false (Mcp_server.is_valid_request_id (`List []))
@@ -484,6 +516,12 @@ let () =
       test_case "float" `Quick test_is_valid_request_id_float;
       test_case "array" `Quick test_is_valid_request_id_array;
       test_case "object" `Quick test_is_valid_request_id_object;
+    ];
+    "typed_request_identity", [
+      test_case "large integer lexeme" `Quick
+        test_request_id_preserves_large_integer_lexeme;
+      test_case "string and integer distinct" `Quick
+        test_tool_invocation_identity_distinguishes_string_and_integer;
     ];
     "validate_initialize_params", [
       test_case "valid" `Quick test_validate_initialize_params_valid;

--- a/test/test_operator_control_support.ml
+++ b/test/test_operator_control_support.ml
@@ -77,7 +77,8 @@ let operator_ctx ?mcp_session_id env sw config agent_name :
            ~clock:(Eio.Stdenv.clock env)
            ~proc_mgr:(Some (Eio.Stdenv.process_mgr env))
            ~net:(Some (Eio.Stdenv.net env))
-           ~publication_recovery_provider);
+           ~publication_recovery_provider
+           ());
     mcp_session_id;
   }
 

--- a/test/tool_invocation_ref/dune
+++ b/test/tool_invocation_ref/dune
@@ -1,0 +1,3 @@
+(test
+ (name test_tool_invocation_ref)
+ (libraries alcotest yojson masc.tool_invocation_ref masc.mcp_transport_protocol))

--- a/test/tool_invocation_ref/test_tool_invocation_ref.ml
+++ b/test/tool_invocation_ref/test_tool_invocation_ref.ml
@@ -1,0 +1,86 @@
+let request_id json =
+  match Mcp_transport_protocol.request_id_of_yojson json with
+  | Ok value -> value
+  | Error error ->
+    Alcotest.fail (Mcp_transport_protocol.request_id_error_to_string error)
+;;
+
+let identity () =
+  match
+    Tool_invocation_ref.external_mcp
+      ~request_id:(request_id (`Intlit "9007199254740993"))
+      ~session_id:"session-1"
+  with
+  | Ok value -> value
+  | Error error -> Alcotest.fail (Tool_invocation_ref.error_to_string error)
+;;
+
+let test_roundtrip () =
+  let expected = identity () in
+  match Tool_invocation_ref.of_yojson (Tool_invocation_ref.to_yojson expected) with
+  | Ok actual ->
+    Alcotest.(check bool)
+      "exact identity"
+      true
+      (Tool_invocation_ref.equal expected actual)
+  | Error error ->
+    Alcotest.fail (Tool_invocation_ref.decode_error_to_string error)
+;;
+
+let test_closed_decoder () =
+  let canonical = Tool_invocation_ref.to_yojson (identity ()) in
+  let fields =
+    match canonical with
+    | `Assoc fields -> fields
+    | _ -> Alcotest.fail "canonical identity must be an object"
+  in
+  let check label expected json =
+    match Tool_invocation_ref.of_yojson json with
+    | Error actual -> Alcotest.(check bool) label true (actual = expected)
+    | Ok _ -> Alcotest.failf "%s: malformed identity decoded" label
+  in
+  check
+    "unknown"
+    (Tool_invocation_ref.Unknown_field "extra")
+    (`Assoc (("extra", `Null) :: fields));
+  check
+    "duplicate"
+    (Tool_invocation_ref.Duplicate_field "source")
+    (`Assoc (("source", `String "external_mcp") :: fields));
+  check
+    "missing"
+    (Tool_invocation_ref.Missing_field "request_id")
+    (`Assoc (List.remove_assoc "request_id" fields));
+  check
+    "source"
+    (Tool_invocation_ref.Invalid_source "invented")
+    (`Assoc
+      (("source", `String "invented") :: List.remove_assoc "source" fields));
+  check
+    "source type"
+    (Tool_invocation_ref.Expected_string "source")
+    (`Assoc (("source", `Null) :: List.remove_assoc "source" fields));
+  check
+    "request id"
+    (Tool_invocation_ref.Invalid_request_id
+       Mcp_transport_protocol.Null_request_id)
+    (`Assoc (("request_id", `Null) :: List.remove_assoc "request_id" fields));
+  check
+    "session"
+    (Tool_invocation_ref.Invalid_identity
+       Tool_invocation_ref.Empty_mcp_session_id)
+    (`Assoc (("session_id", `String " ") :: List.remove_assoc "session_id" fields));
+  check
+    "session type"
+    (Tool_invocation_ref.Expected_string "session_id")
+    (`Assoc (("session_id", `Null) :: List.remove_assoc "session_id" fields))
+;;
+
+let () =
+  Alcotest.run
+    "tool invocation ref"
+    [ ( "codec"
+      , [ Alcotest.test_case "roundtrip" `Quick test_roundtrip
+        ; Alcotest.test_case "closed decoder" `Quick test_closed_decoder
+        ] )
+    ]


### PR DESCRIPTION
## Outcome

Integrates the closed `Tool_invocation_ref` decoder leaf with its first live durable consumer. `masc_keeper_compact` now admits a manual-compaction stimulus only when the exact MCP invocation identity is present, persists that typed identity in the Keeper-owned queue, and restores it through the existing queue codec.

## Boundary

- `Manual_compaction_requested` carries `Tool_invocation_ref.t`.
- Queue identity is derived from the exact closed typed projection; no tool-name, argument, timestamp, risk, or content heuristic is used.
- Missing producer identity is an explicit tool failure rather than an unattributed operation.
- Existing queue persistence remains the single writer; no second request codec, operation journal, actor, or global registry is introduced.
- The old synchronous compaction execution path is intentionally unchanged. This PR is producer-to-durable-stimulus admission only; it is not the async operation/lane hard-cut required by #24990.

## Stack and SSOT

- Base: #24957 (`Tool_invocation_ref` transport carry), currently mergeable and focused-CI green.
- This cumulative head includes the decoder from closed duplicate #24909 because the decoder now has a live queue consumer in the same integration diff.
- #24963 already contains a duplicate decoder copy and must drop/restack that copy before it can proceed.
- Current diff from #24957: 338 changed lines (299 additions, 39 deletions).

## Verification

- `scripts/dune-local.sh build test/test_keeper_compact_recovery_tool_surface.exe test/test_keeper_post_turn_wirein_order.exe test/test_keeper_event_queue_state_v2.exe test/test_keeper_waiting_inventory.exe`
- `scripts/dune-local.sh build @test/tool_invocation_ref/runtest`
- Executed the four queue/consumer binaries plus the decoder suite: 35 focused tests passed.
- `ocamlc -stop-after parsing` on every touched OCaml source/interface.
- `ocamlformat` on every touched OCaml source/interface.
- `git diff --check`.

Closes no issue: #24990 still requires the integrated eligible-unit planner, durable `Planned | No_compaction` terminal outcomes, live runtime-lane consumer, and removal of the old plan authority.
