### PR TITLE
refactor(keeper): hard-cut producerless compaction state

### DIFF
--- a/docs/COMMON-PITFALLS.md
+++ b/docs/COMMON-PITFALLS.md
@@ -95,25 +95,24 @@ List.filter_map (function Ok t -> Some t | Error _ -> None)
 
 **PR 체크:** `rg '\| Error _ -> \(\)' lib/` 로 새 `| Error _ -> ()` 확인.
 
-### 5.1. Naked Callback Invocation (PR #11134, 2026-04-27)
+### 5.1. Naked Callback Invocation
 
-`~on_compaction_started` / `~on_handoff_started` 같은 lifecycle callback closure를 `try/with` 없이 호출하면 callback 내부(예: SSE/metric dispatch) 실패가 caller(KCL/Rollover) 본체를 abort.
+`~on_appended` 같은 callback closure를 `try/with` 없이 호출하면 callback 내부 실패가 caller의 본체까지 전파된다. Callback을 받는 함수가 실패 경계를 소유하고 있다면 cancellation은 다시 올리고 나머지 실패는 그 함수의 typed error로 보존한다.
 
 **❌ DON'T:**
 ```ocaml
-let () = on_compaction_started () in
-proceed_with_compaction ()
+on_appended ();
+Ok ()
 ```
 
 **✅ DO:**
 ```ocaml
-(try on_compaction_started ()
+(try
+   on_appended ();
+   Ok ()
  with
  | Eio.Cancel.Cancelled _ as e -> raise e
- | exn ->
-     Keeper_callback_failure.record ~base_dir ~meta
-       ~callback:"on_compaction_started" exn);
-proceed_with_compaction ()
+ | exn -> Error (Printexc.to_string exn))
 ```
 
 **PR 체크:** `rg -nP '^\s+(let \(\) = )?on_[a-z_]+ \(\)' lib/keeper/` — match 발견 시 try/with wrap 검토.

--- a/lib/cancel_safe/cancel_safe.ml
+++ b/lib/cancel_safe/cancel_safe.ml
@@ -2,25 +2,9 @@
 
     [observe] runs [f ()] and catches all exceptions except
     [Eio.Cancel.Cancelled] (which must propagate to honor cooperative
-    cancellation).  All other exceptions are routed to [on_exn] instead
-    of propagating to the caller.
-
-    **FSM-critical callback policy**: when wrapping a lifecycle callback
-    that dispatches FSM state transitions (e.g. [on_compaction_started],
-    [on_handoff_started]), the [on_exn] handler MUST:
-
-    1. Increment a Otel_metric_store counter (e.g.
-       [masc_keeper_lifecycle_callback_failures_total{callback=...}])
-       so the failure is observable in Grafana.
-    2. Record the failure via [Keeper_callback_failure.record] for
-       durable audit.
-    3. Track callback success in the lifecycle record (e.g.
-       [started_dispatched : bool] on [compaction_event]) so downstream
-       dispatch sites know the FSM state and can recover the correct
-       transition path.
-
-    See [keeper_post_turn.ml] (compaction) and [keeper_rollover.ml]
-    (handoff) for reference implementations of this policy. *)
+    cancellation). All other exceptions are routed to [on_exn] instead
+    of propagating to the caller. The caller owns any logging, metrics,
+    or durable failure record required by its boundary. *)
 
 let protect ~on_exn f =
   try f ()

--- a/lib/dashboard/dashboard_harness_health.ml
+++ b/lib/dashboard/dashboard_harness_health.ml
@@ -37,10 +37,7 @@ type pre_compact_event =
 
     [message_count] and [role_counts] include the synthesized user turn
     that OAS will append from [~goal], matching the wire-level message
-    list the LLM will receive.
-
-    [has_compact_happened] marks whether MASC applied a pre-dispatch context
-    compaction before handing the resumed checkpoint to OAS. *)
+    list the LLM will receive. *)
 type wake_payload_event =
   { timestamp : float
   ; keeper_name : string
@@ -53,7 +50,6 @@ type wake_payload_event =
   ; message_count : int
   ; role_counts : (string * int) list
   ; tool_count : int
-  ; has_compact_happened : bool
   }
 
 type handoff_event =
@@ -388,7 +384,6 @@ let wake_payload_record_json (event : wake_payload_event) =
     ; "message_count", `Int event.message_count
     ; "role_counts", role_counts_to_json event.role_counts
     ; "tool_count", `Int event.tool_count
-    ; "has_compact_happened", `Bool event.has_compact_happened
     ]
 ;;
 
@@ -405,7 +400,6 @@ let wake_payload_event_json (event : wake_payload_event) =
     ; "message_count", `Int event.message_count
     ; "role_counts", role_counts_to_json event.role_counts
     ; "tool_count", `Int event.tool_count
-    ; "has_compact_happened", `Bool event.has_compact_happened
     ]
 ;;
 
@@ -444,7 +438,6 @@ let wake_payload_event_of_json json =
                message_count)
       in
       let* tool_count = required_nonnegative_int fields "tool_count" in
-      let* has_compact_happened = required_bool fields "has_compact_happened" in
       Ok
         { timestamp
         ; keeper_name
@@ -457,7 +450,6 @@ let wake_payload_event_of_json json =
         ; message_count
         ; role_counts
         ; tool_count
-        ; has_compact_happened
         }
   | _ -> Error "wake-payload record must be a JSON object"
 ;;
@@ -802,7 +794,6 @@ let record_wake_payload_at
       ~message_count
       ~role_counts
       ~tool_count
-      ~has_compact_happened
   =
   (* Project World Building: Broadcast live Yjs telemetry *)
   Dashboard_yjs.broadcast_keeper_telemetry ~keeper_name ~trace_id ~turn_index;
@@ -818,7 +809,6 @@ let record_wake_payload_at
     ; message_count
     ; role_counts
     ; tool_count
-    ; has_compact_happened
     }
   in
   append_store_json_fail_open
@@ -840,7 +830,6 @@ let record_wake_payload
       ~message_count
       ~role_counts
       ~tool_count
-      ~has_compact_happened
   =
   record_wake_payload_at
     ~timestamp:(Time_compat.now ())
@@ -854,7 +843,6 @@ let record_wake_payload
     ~message_count
     ~role_counts
     ~tool_count
-    ~has_compact_happened
 ;;
 
 let recent_verdicts_json ?since ?until () =
@@ -972,11 +960,11 @@ let json ~(config : Workspace.config) ?since ?until () =
 ;;
 
 let () =
-  Keeper_keepalive_signal.register_record_wake_payload (fun ~keeper_name ~trace_id ~turn_index ~context_window ~system_prompt_bytes ~tool_schema_json_bytes ~message_content_bytes ~message_count ~role_counts ~tool_count ~has_compact_happened ->
+  Keeper_keepalive_signal.register_record_wake_payload (fun ~keeper_name ~trace_id ~turn_index ~context_window ~system_prompt_bytes ~tool_schema_json_bytes ~message_content_bytes ~message_count ~role_counts ~tool_count ->
     let (_recorded : wake_payload_event) =
       record_wake_payload ~keeper_name ~trace_id ~turn_index ~context_window
         ~system_prompt_bytes ~tool_schema_json_bytes ~message_content_bytes
-        ~message_count ~role_counts ~tool_count ~has_compact_happened
+        ~message_count ~role_counts ~tool_count
     in
     ()
   );

--- a/lib/dashboard/dashboard_harness_health.mli
+++ b/lib/dashboard/dashboard_harness_health.mli
@@ -79,7 +79,6 @@ type wake_payload_event =
   ; message_count : int
   ; role_counts : (string * int) list
   ; tool_count : int
-  ; has_compact_happened : bool
   }
 
 (** {1 Recorders} *)
@@ -124,7 +123,6 @@ val record_wake_payload
   -> message_count:int
   -> role_counts:(string * int) list
   -> tool_count:int
-  -> has_compact_happened:bool
   -> wake_payload_event
 
 (** {1 Verdict readers} *)

--- a/lib/keeper/keeper_agent_result.ml
+++ b/lib/keeper/keeper_agent_result.ml
@@ -87,10 +87,6 @@ type run_result =
   ; stop_reason : Runtime_agent.stop_reason
   ; inference_telemetry : Agent_sdk.Types.inference_telemetry option
   ; tool_surface : tool_surface_metrics
-  ; pre_dispatch_compacted : bool
-  ; pre_dispatch_compaction_trigger : string option
-  ; pre_dispatch_compaction_before_tokens : int option
-  ; pre_dispatch_compaction_after_tokens : int option
   }
 
 let tool_names (result : run_result) = tool_names_of_calls result.tool_calls

--- a/lib/keeper/keeper_agent_result.mli
+++ b/lib/keeper/keeper_agent_result.mli
@@ -42,10 +42,6 @@ type run_result =
   ; stop_reason : Runtime_agent.stop_reason
   ; inference_telemetry : Agent_sdk.Types.inference_telemetry option
   ; tool_surface : Keeper_agent_tool_surface.tool_surface_metrics
-  ; pre_dispatch_compacted : bool
-  ; pre_dispatch_compaction_trigger : string option
-  ; pre_dispatch_compaction_before_tokens : int option
-  ; pre_dispatch_compaction_after_tokens : int option
   }
 
 val tool_call_detail_to_json : tool_call_detail -> Yojson.Safe.t

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -323,8 +323,6 @@ let run_turn
   let session = ctx.session in
   let base_system_prompt = ctx.base_system_prompt in
   let resume_oas_checkpoint = ctx.resume_oas_checkpoint in
-  let pre_dispatch_compacted = ctx.pre_dispatch_compacted in
-  let pre_dispatch_checkpoint_error = ctx.pre_dispatch_checkpoint_error in
   let start_turn_count = ctx.start_turn_count in
   let receipt_started_at = ctx.receipt_started_at in
   let config_root = ctx.config_root in
@@ -366,32 +364,8 @@ let run_turn
     ~decision:
       (Keeper_runtime_manifest.with_payload_role ~payload_role:Checkpoint
         (`Assoc
-          [
-            ("loaded_checkpoint_present", `Bool ctx.loaded_checkpoint_present);
-            ("pre_dispatch_compacted", `Bool pre_dispatch_compacted);
-            ( "pre_dispatch_checkpoint_error",
-              match pre_dispatch_checkpoint_error with
-              | None -> `Null
-              | Some err -> `String (Agent_sdk.Error.to_string err) );
-          ]))
+          [ "loaded_checkpoint_present", `Bool ctx.loaded_checkpoint_present ]))
     Keeper_runtime_manifest.Checkpoint_loaded;
-  append_manifest ~site:"context_compacted"
-    ~keeper_turn_id:manifest_keeper_turn_id
-    ?compaction_source:
-      (if pre_dispatch_compacted then Some "pre_dispatch_hygiene" else None)
-    ~status:(if pre_dispatch_compacted then "compacted" else "skipped")
-    ~decision:
-      (Keeper_runtime_manifest.with_payload_role ~payload_role:Model_input
-        (`Assoc
-          [
-            ("pre_dispatch_compacted", `Bool pre_dispatch_compacted);
-            ( "pre_dispatch_checkpoint_error",
-              match pre_dispatch_checkpoint_error with
-              | None -> `Null
-              | Some err -> `String (Agent_sdk.Error.to_string err) );
-            ("checkpoint_path", `String checkpoint_path);
-          ]))
-    Keeper_runtime_manifest.Context_compacted;
   (* Steps 5-6: turn prompt, memory/temporal context, prompt metrics,
      and user message append — Keeper_run_prompt. *)
   let prompt_ctx =
@@ -539,15 +513,10 @@ let run_turn
          ~user_message
          ~start_turn_count
          ~max_context
-         ~pre_dispatch_compacted
          ();
        (* Section 3: Dispatch — call Keeper_turn_driver.run_named / Agent.run. *)
-       let pre_dispatch_error = pre_dispatch_checkpoint_error in
        let turn_result =
-         match pre_dispatch_error with
-         | Some err -> Error err
-         | None ->
-              let cooperative_yield_probe =
+         let cooperative_yield_probe =
                 match autonomous_yield_requested with
                 | None -> None
                 | Some requested ->
@@ -571,11 +540,11 @@ let run_turn
                               (Printf.sprintf
                                  "keeper cooperative-yield probe failed: %s"
                                  (Printexc.to_string exn))))
-              in
-              let checkpoint_sidecar =
+         in
+         let checkpoint_sidecar =
                 ctx_work.checkpoint.Agent_sdk.Checkpoint.working_context
-              in
-              let checkpoint_sink (snapshot : Agent_sdk.Agent.checkpoint_snapshot) =
+         in
+         let checkpoint_sink (snapshot : Agent_sdk.Agent.checkpoint_snapshot) =
                 Option.iter (fun observe -> observe snapshot.stage) on_checkpoint_stage;
                 (* OAS's per-turn pipeline builds checkpoints with an empty
                    session_id (the OAS agent carries no session field), so the
@@ -600,8 +569,8 @@ let run_turn
                 with
                 | Ok _ -> Ok ()
                 | Error _ as error -> error
-              in
-              let call_run_named ?raw_trace ~initial_messages () =
+         in
+         let call_run_named ?raw_trace ~initial_messages () =
                 (* Keeper does not impose a cumulative turn, time, token, or cost
                    budget. Explicit cancellation and provider/tool progress
                    boundaries settle the lane, while usage remains observational. *)
@@ -650,11 +619,11 @@ let run_turn
                       (fun observation ->
                          receipt_runtime_observation_ref := Some observation)
                     ()
-              in
-              (* Trace-store failure isolation: [raw_trace_for_dispatch]
+         in
+         (* Trace-store failure isolation: [raw_trace_for_dispatch]
                  degrades to [None] (turn runs untraced, typed record
                  emitted) — sink trouble never fails the turn pre-dispatch. *)
-              (match
+         (match
                  call_run_named
                    ?raw_trace:(raw_trace_for_dispatch ~config ~meta)
                    ~initial_messages:history_messages
@@ -745,10 +714,6 @@ let run_turn
                             ctx_work.checkpoint.Agent_sdk.Checkpoint.working_context
                           ~prompt_metrics ~ctx_composition ~usage
                           ~receipt_response_text_present_ref ~history_assistant_source
-                          ~pre_dispatch_compacted:ctx.pre_dispatch_compacted
-                          ~pre_dispatch_compaction_trigger:ctx.pre_dispatch_compaction_trigger
-                          ~pre_dispatch_compaction_before_tokens:ctx.pre_dispatch_compaction_before_tokens
-                          ~pre_dispatch_compaction_after_tokens:ctx.pre_dispatch_compaction_after_tokens
                           ~raw_response_text:response_text
                           ?continuation_delivery_channel
                           ~capture_replay_response:
@@ -781,10 +746,6 @@ let run_turn
            ~receipt_started_at
            ~runtime_manifest_context
            ~acc
-           ~pre_dispatch_compacted
-           ~pre_dispatch_compaction_trigger:ctx.pre_dispatch_compaction_trigger
-           ~pre_dispatch_compaction_before_tokens:ctx.pre_dispatch_compaction_before_tokens
-           ~pre_dispatch_compaction_after_tokens:ctx.pre_dispatch_compaction_after_tokens
            ~degraded_retry_applied
            ~degraded_retry_runtime
            ~fallback_reason

--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -211,10 +211,6 @@ let finalize
     ~usage
     ~receipt_response_text_present_ref
     ~history_assistant_source
-    ~pre_dispatch_compacted
-    ~pre_dispatch_compaction_trigger
-    ~pre_dispatch_compaction_before_tokens
-    ~pre_dispatch_compaction_after_tokens
     ~raw_response_text
     ~capture_replay_response
     ?continuation_delivery_channel:_
@@ -395,9 +391,5 @@ let finalize
       ; stop_reason = result.stop_reason
       ; inference_telemetry = result.response.telemetry
       ; tool_surface = acc.tool_surface
-      ; pre_dispatch_compacted
-      ; pre_dispatch_compaction_trigger
-      ; pre_dispatch_compaction_before_tokens
-      ; pre_dispatch_compaction_after_tokens
       }
 ;;

--- a/lib/keeper/keeper_agent_run_phase0_telemetry.ml
+++ b/lib/keeper/keeper_agent_run_phase0_telemetry.ml
@@ -9,7 +9,6 @@ let record
     ~user_message
     ~start_turn_count
     ~max_context
-    ~pre_dispatch_compacted
     ()
   =
   try
@@ -34,7 +33,6 @@ let record
           ~message_count:sizes.message_count
           ~role_counts:sizes.role_counts
           ~tool_count:sizes.tool_count
-          ~has_compact_happened:pre_dispatch_compacted
       in
       ()
   with

--- a/lib/keeper/keeper_agent_run_phase0_telemetry.mli
+++ b/lib/keeper/keeper_agent_run_phase0_telemetry.mli
@@ -9,7 +9,6 @@ val record :
   user_message:string ->
   start_turn_count:int ->
   max_context:int ->
-  pre_dispatch_compacted:bool ->
   unit ->
   unit
 (** Record exact wake-time component bytes on every turn.

--- a/lib/keeper/keeper_agent_run_receipt.ml
+++ b/lib/keeper/keeper_agent_run_receipt.ml
@@ -52,10 +52,6 @@ let finalize
     ~receipt_started_at
     ~runtime_manifest_context
     ~(acc : Keeper_run_tools.hook_accumulator)
-    ~pre_dispatch_compacted
-    ~pre_dispatch_compaction_trigger
-    ~pre_dispatch_compaction_before_tokens
-    ~pre_dispatch_compaction_after_tokens
     ~degraded_retry_applied
     ~degraded_retry_runtime
     ~fallback_reason
@@ -186,10 +182,6 @@ let finalize
     ; extra_system_context_digest
     ; extra_system_context_computed_size
     ; extra_system_context_injected_size
-    ; pre_dispatch_compacted
-    ; pre_dispatch_compaction_trigger
-    ; pre_dispatch_compaction_before_tokens
-    ; pre_dispatch_compaction_after_tokens
     }
   in
   let disposition, reason = Keeper_execution_receipt.operator_disposition receipt in

--- a/lib/keeper/keeper_context_runtime.ml
+++ b/lib/keeper/keeper_context_runtime.ml
@@ -84,30 +84,20 @@ let compaction_decision_prepared =
 (* Re-export from Keeper_post_turn                                   *)
 (* ================================================================ *)
 
-type compaction_event = Keeper_post_turn.compaction_event = {
-  attempted : bool;
-  applied : bool;
-  started_dispatched : bool;
-  failure_reason : string option;
-  trigger : Compaction_trigger.t option;
-  decision : Keeper_compact_policy.compaction_decision;
-}
-
 type post_turn_lifecycle = Keeper_post_turn.post_turn_lifecycle = {
   updated_meta : keeper_meta;
   checkpoint : Agent_sdk.Checkpoint.t option;
   handoff_json : Yojson.Safe.t option;
   handoff_attempted : bool;
   handoff_failure_reason : string option;
-  compaction : compaction_event;
   turn_generation : int;
   checkpoint_bytes : int;
   message_count : int;
 }
 
-type overflow_retry_recovery = Keeper_post_turn.overflow_retry_recovery = {
+type compaction_recovery = Keeper_post_turn.compaction_recovery = {
   checkpoint : Agent_sdk.Checkpoint.t;
-  compaction : compaction_event;
+  trigger : Compaction_trigger.t;
   evidence : Keeper_compaction_evidence.t;
   turn_generation : int;
 }
@@ -162,8 +152,8 @@ let context_budget_json_of_resolution
 
 let apply_post_turn_lifecycle_with_resilience_handles =
   Keeper_post_turn.apply_post_turn_lifecycle_with_resilience_handles
-let recover_latest_checkpoint_for_overflow_retry =
-  Keeper_post_turn.recover_latest_checkpoint_for_overflow_retry
+let recover_latest_checkpoint_for_compaction =
+  Keeper_post_turn.recover_latest_checkpoint_for_compaction
 
 let record_lifecycle_dispatch_rejection ~keeper_name ~origin event ~error =
   Otel_metric_store.inc_counter
@@ -240,49 +230,6 @@ let dispatch_post_turn_lifecycle_events
     ~(config : Workspace.config)
     ~keeper_name
     (lifecycle : post_turn_lifecycle) =
-  if lifecycle.compaction.attempted then
-    if lifecycle.compaction.applied then begin
-      (* FSM boundary: compaction_stage must be Compaction_compacting
-         before we dispatch Compaction_completed.  If the
-         on_compaction_started callback succeeded (started_dispatched =
-         true), the FSM is already in compacting.  If it failed or was
-         never called (recovery path), the FSM is still at accumulating
-         and we must dispatch Compaction_started first.  The Started
-         dispatch is idempotent from compacting, so this is safe in
-         both cases. *)
-      if not lifecycle.compaction.started_dispatched then begin
-        Otel_metric_store.inc_counter Keeper_metrics.(to_string CompactionCallbackRecoveries)
-          ~labels:[ ("keeper", keeper_name) ] ();
-        Log.Keeper.warn
-          "%s: on_compaction_started callback did not fire — \
-           dispatching Compaction_started before Completed to recover \
-           FSM path.  If this repeats, investigate registry contention \
-           or keeper registration timing."
-          keeper_name;
-        dispatch_keeper_phase_event ~config
-          ~origin:Keeper_registry.Post_turn_lifecycle
-          ~keeper_name
-          Keeper_state_machine.Compaction_started
-      end;
-      dispatch_compaction_completed
-        ~config
-        ~origin:Keeper_registry.Post_turn_lifecycle
-        ~keeper_name
-      |> ignore
-    end
-    else
-      dispatch_keeper_phase_event
-        ~config
-        ~origin:Keeper_registry.Post_turn_lifecycle
-        ~keeper_name
-        (Keeper_state_machine.Compaction_failed
-           {
-             reason =
-               Option.value lifecycle.compaction.failure_reason
-                 ~default:
-                   (compaction_decision_to_string
-                      lifecycle.compaction.decision);
-           });
   match lifecycle.handoff_attempted, lifecycle.handoff_json with
   | true, Some _json ->
       dispatch_keeper_phase_event

--- a/lib/keeper/keeper_context_runtime.mli
+++ b/lib/keeper/keeper_context_runtime.mli
@@ -74,22 +74,12 @@ val save_oas_checkpoint
   -> generation:int
   -> (Agent_sdk.Checkpoint.t, string) result
 
-type compaction_event =
-  { attempted : bool
-  ; applied : bool
-  ; started_dispatched : bool
-  ; failure_reason : string option
-  ; trigger : Compaction_trigger.t option
-  ; decision : Keeper_compact_policy.compaction_decision
-  }
-
 type post_turn_lifecycle =
   { updated_meta : keeper_meta
   ; checkpoint : Agent_sdk.Checkpoint.t option
   ; handoff_json : Yojson.Safe.t option
   ; handoff_attempted : bool
   ; handoff_failure_reason : string option
-  ; compaction : compaction_event
   ; turn_generation : int
   ; checkpoint_bytes : int
   ; message_count : int
@@ -108,9 +98,9 @@ type context_budget_source =
   | Requested_override
   | Requested_override_clamped_to_provider
 
-type overflow_retry_recovery =
+type compaction_recovery =
   { checkpoint : Agent_sdk.Checkpoint.t
-  ; compaction : compaction_event
+  ; trigger : Compaction_trigger.t
   ; evidence : Keeper_compaction_evidence.t
   ; turn_generation : int
   }
@@ -141,13 +131,8 @@ val compaction_decision_prepared : compaction_decision -> bool
 val apply_post_turn_lifecycle_with_resilience_handles
   :  resilience_audit_store:Shared_audit.Store.t option
   -> resilience_strategy_executor:Resilience.Recovery.strategy_executor option
-  -> on_compaction_started:(unit -> unit)
-  -> on_handoff_started:(unit -> unit)
-  -> base_dir:string
   -> meta:keeper_meta
-  -> model:string
   -> primary_model_max_tokens:int
-  -> current_turn_blocker_info:blocker_info option
   -> checkpoint:Agent_sdk.Checkpoint.t option
   -> post_turn_lifecycle
 
@@ -186,12 +171,12 @@ val dispatch_post_turn_lifecycle_events
   -> post_turn_lifecycle
   -> unit
 
-val recover_latest_checkpoint_for_overflow_retry
+val recover_latest_checkpoint_for_compaction
   :  base_dir:string
   -> meta:keeper_meta
   -> trigger:Compaction_trigger.t
   -> primary_model_max_tokens:int
-  -> (overflow_retry_recovery, Keeper_post_turn.compaction_recovery_error) result
+  -> (compaction_recovery, Keeper_post_turn.compaction_recovery_error) result
 
 (** {1 Trace and Board Utilities} *)
 

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -395,13 +395,6 @@ let to_json_with_operator_disposition
       , Json_util.int_opt_to_json receipt.extra_system_context_injected_size )
     ; ( "extra_system_context_computed_size"
       , Json_util.int_opt_to_json receipt.extra_system_context_computed_size )
-    ; ( "pre_dispatch_compacted", `Bool receipt.pre_dispatch_compacted )
-    ; ( "pre_dispatch_compaction_trigger"
-      , string_opt_json receipt.pre_dispatch_compaction_trigger )
-    ; ( "pre_dispatch_compaction_before_tokens"
-      , Json_util.int_opt_to_json receipt.pre_dispatch_compaction_before_tokens )
-    ; ( "pre_dispatch_compaction_after_tokens"
-      , Json_util.int_opt_to_json receipt.pre_dispatch_compaction_after_tokens )
     ]
 ;;
 

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -167,10 +167,6 @@ type t =
   ; extra_system_context_digest : string option
   ; extra_system_context_injected_size : int option
   ; extra_system_context_computed_size : int option
-  ; pre_dispatch_compacted : bool
-  ; pre_dispatch_compaction_trigger : string option
-  ; pre_dispatch_compaction_before_tokens : int option
-  ; pre_dispatch_compaction_after_tokens : int option
   }
 
 val stop_reason_to_string : Runtime_agent.stop_reason -> string

--- a/lib/keeper/keeper_execution_receipt_types.ml
+++ b/lib/keeper/keeper_execution_receipt_types.ml
@@ -191,10 +191,6 @@ type t =
   ; extra_system_context_digest : string option
   ; extra_system_context_injected_size : int option
   ; extra_system_context_computed_size : int option
-  ; pre_dispatch_compacted : bool
-  ; pre_dispatch_compaction_trigger : string option
-  ; pre_dispatch_compaction_before_tokens : int option
-  ; pre_dispatch_compaction_after_tokens : int option
   }
 
 let stop_reason_to_string = function

--- a/lib/keeper/keeper_execution_receipt_types.mli
+++ b/lib/keeper/keeper_execution_receipt_types.mli
@@ -91,10 +91,6 @@ type t = {
   extra_system_context_digest : string option;
   extra_system_context_injected_size : int option;
   extra_system_context_computed_size : int option;
-  pre_dispatch_compacted : bool;
-  pre_dispatch_compaction_trigger : string option;
-  pre_dispatch_compaction_before_tokens : int option;
-  pre_dispatch_compaction_after_tokens : int option;
 }
 val stop_reason_to_string : Runtime_agent.stop_reason -> string
 

--- a/lib/keeper/keeper_keepalive_signal.ml
+++ b/lib/keeper/keeper_keepalive_signal.ml
@@ -38,7 +38,6 @@ let record_wake_payload_callback
        message_count:int ->
        role_counts:(string * int) list ->
        tool_count:int ->
-       has_compact_happened:bool ->
        unit)
       Atomic.t
   =
@@ -52,8 +51,7 @@ let record_wake_payload_callback
       ~message_content_bytes:_
       ~message_count:_
       ~role_counts:_
-      ~tool_count:_
-      ~has_compact_happened:_ ->
+      ~tool_count:_ ->
       Log.Keeper.warn "wake-payload observer unavailable: keeper=%s" keeper_name)
 
 let record_wake_payload
@@ -67,7 +65,6 @@ let record_wake_payload
     ~message_count
     ~role_counts
     ~tool_count
-    ~has_compact_happened
   =
   (Atomic.get record_wake_payload_callback)
     ~keeper_name
@@ -80,7 +77,6 @@ let record_wake_payload
     ~message_count
     ~role_counts
     ~tool_count
-    ~has_compact_happened
 ;;
 
 let register_record_wake_payload f = Atomic.set record_wake_payload_callback f

--- a/lib/keeper/keeper_keepalive_signal.mli
+++ b/lib/keeper/keeper_keepalive_signal.mli
@@ -21,7 +21,6 @@ val record_wake_payload :
   message_count:int ->
   role_counts:(string * int) list ->
   tool_count:int ->
-  has_compact_happened:bool ->
   unit
 
 val register_record_wake_payload :
@@ -35,7 +34,6 @@ val register_record_wake_payload :
    message_count:int ->
    role_counts:(string * int) list ->
    tool_count:int ->
-   has_compact_happened:bool ->
    unit) ->
   unit
 

--- a/lib/keeper/keeper_manual_compaction.ml
+++ b/lib/keeper/keeper_manual_compaction.ml
@@ -1,10 +1,27 @@
 open Keeper_meta_contract
 type success =
-  { recovery : Keeper_context_runtime.overflow_retry_recovery
+  { recovery : Keeper_context_runtime.compaction_recovery
   ; manifest : (unit, string) result
   }
+
+type lifecycle_stage =
+  | Operator_request
+  | Compaction_started
+  | Compaction_completed
+
 type failure =
-  | Lifecycle of string * bool * Keeper_context_runtime.lifecycle_dispatch_error
+  | Lifecycle of
+      { stage : lifecycle_stage
+      ; checkpoint_applied : bool
+      ; error : Keeper_context_runtime.lifecycle_dispatch_error
+      }
+  | Lifecycle_with_failure_dispatch of
+      { stage : lifecycle_stage
+      ; checkpoint_applied : bool
+      ; error : Keeper_context_runtime.lifecycle_dispatch_error
+      ; failure_dispatch :
+          (unit, Keeper_context_runtime.lifecycle_dispatch_error) result
+      }
   | Recovery of
       Keeper_post_turn.compaction_recovery_error
       * (unit, Keeper_context_runtime.lifecycle_dispatch_error) result
@@ -13,9 +30,7 @@ let primary_max_context meta =
   resolution.effective_budget
 ;;
 let append_manifest ~config ~base_dir ~(meta : keeper_meta) recovery =
-  match recovery.Keeper_context_runtime.compaction.trigger with
-  | None -> Error "manual compaction completed without its typed trigger"
-  | Some trigger ->
+  let trigger = recovery.Keeper_context_runtime.trigger in
     let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
     let context : Keeper_runtime_manifest.turn_context =
       { manifest_keeper_name = meta.name
@@ -58,14 +73,12 @@ let append_manifest ~config ~base_dir ~(meta : keeper_meta) recovery =
     |> Keeper_runtime_manifest.append config
 ;;
 let run ~(config : Workspace.config) ~(meta : keeper_meta) =
-  let dispatch stage event =
+  let dispatch event =
     Keeper_context_runtime.dispatch_keeper_phase_event_result
       ~config
       ~origin:Keeper_registry.Operator_compact
       ~keeper_name:meta.name
       event
-    |> Result.map_error (fun error ->
-      Lifecycle (stage, false, error))
   in
   let dispatch_failed reason =
     Keeper_context_runtime.dispatch_keeper_phase_event_result
@@ -74,17 +87,24 @@ let run ~(config : Workspace.config) ~(meta : keeper_meta) =
       ~keeper_name:meta.name
       (Keeper_state_machine.Compaction_failed { reason })
   in
-  match dispatch "operator_request" Keeper_state_machine.Operator_compact_requested with
-  | Error _ as error -> error
+  match dispatch Keeper_state_machine.Operator_compact_requested with
+  | Error error ->
+    Error (Lifecycle { stage = Operator_request; checkpoint_applied = false; error })
   | Ok () ->
-    (match dispatch "compaction_started" Keeper_state_machine.Compaction_started with
-     | Error _ as error ->
-       dispatch_failed "compaction_start_rejected" |> ignore;
-       error
+    (match dispatch Keeper_state_machine.Compaction_started with
+     | Error error ->
+       let failure_dispatch = dispatch_failed "compaction_start_rejected" in
+       Error
+         (Lifecycle_with_failure_dispatch
+            { stage = Compaction_started
+            ; checkpoint_applied = false
+            ; error
+            ; failure_dispatch
+            })
      | Ok () ->
        let base_dir = Keeper_types_profile.session_base_dir config in
        (match
-          Keeper_context_runtime.recover_latest_checkpoint_for_overflow_retry
+          Keeper_context_runtime.recover_latest_checkpoint_for_compaction
             ~base_dir
             ~meta
             ~trigger:Compaction_trigger.Manual
@@ -104,18 +124,51 @@ let run ~(config : Workspace.config) ~(meta : keeper_meta) =
                ~origin:Keeper_registry.Operator_compact
            with
            | Error error ->
-             Error (Lifecycle ("compaction_completed", true, error))
-           | Ok () -> Ok { recovery; manifest })))
+             Error
+               (Lifecycle
+                  { stage = Compaction_completed
+                  ; checkpoint_applied = true
+                  ; error
+                  })
+           | Ok () ->
+             Keeper_unified_metrics.broadcast_compaction
+               ~name:meta.name
+               recovery;
+             Ok { recovery; manifest })))
+;;
+
+let lifecycle_stage_to_string = function
+  | Operator_request -> "operator_request"
+  | Compaction_started -> "compaction_started"
+  | Compaction_completed -> "compaction_completed"
+;;
+
+let failure_dispatch_to_string = function
+  | Ok () -> "applied"
+  | Error error ->
+    "rejected:" ^ Keeper_context_runtime.lifecycle_dispatch_error_to_string error
 ;;
 
 let failure_to_string = function
-  | Lifecycle (stage, checkpoint_applied, error) ->
+  | Lifecycle { stage; checkpoint_applied; error } ->
     Printf.sprintf
       "stage=%s checkpoint_applied=%b error=%s"
-      stage
+      (lifecycle_stage_to_string stage)
       checkpoint_applied
       (Keeper_context_runtime.lifecycle_dispatch_error_to_string error)
-  | Recovery (error, _) -> Keeper_post_turn.compaction_recovery_error_to_string error
+  | Lifecycle_with_failure_dispatch
+      { stage; checkpoint_applied; error; failure_dispatch } ->
+    Printf.sprintf
+      "stage=%s checkpoint_applied=%b error=%s failure_dispatch=%s"
+      (lifecycle_stage_to_string stage)
+      checkpoint_applied
+      (Keeper_context_runtime.lifecycle_dispatch_error_to_string error)
+      (failure_dispatch_to_string failure_dispatch)
+  | Recovery (error, failure_dispatch) ->
+    Printf.sprintf
+      "recovery_error=%s failure_dispatch=%s"
+      (Keeper_post_turn.compaction_recovery_error_to_string error)
+      (failure_dispatch_to_string failure_dispatch)
 ;;
 
 let observe_manifest ~keeper_name = function

--- a/lib/keeper/keeper_manual_compaction.mli
+++ b/lib/keeper/keeper_manual_compaction.mli
@@ -1,9 +1,26 @@
 type success =
-  { recovery : Keeper_context_runtime.overflow_retry_recovery
+  { recovery : Keeper_context_runtime.compaction_recovery
   ; manifest : (unit, string) result
   }
+
+type lifecycle_stage =
+  | Operator_request
+  | Compaction_started
+  | Compaction_completed
+
 type failure =
-  | Lifecycle of string * bool * Keeper_context_runtime.lifecycle_dispatch_error
+  | Lifecycle of
+      { stage : lifecycle_stage
+      ; checkpoint_applied : bool
+      ; error : Keeper_context_runtime.lifecycle_dispatch_error
+      }
+  | Lifecycle_with_failure_dispatch of
+      { stage : lifecycle_stage
+      ; checkpoint_applied : bool
+      ; error : Keeper_context_runtime.lifecycle_dispatch_error
+      ; failure_dispatch :
+          (unit, Keeper_context_runtime.lifecycle_dispatch_error) result
+      }
   | Recovery of
       Keeper_post_turn.compaction_recovery_error
       * (unit, Keeper_context_runtime.lifecycle_dispatch_error) result

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -1,6 +1,8 @@
-(** Keeper_post_turn — post-turn lifecycle: compaction and overflow retry recovery.
+(** Keeper_post_turn — post-turn checkpoint preservation and explicit
+    compaction recovery.
 
-    Orchestrates the end-of-turn checkpoint pipeline.
+    Orchestrates the end-of-turn checkpoint pipeline. Compaction is entered
+    only through an explicit typed request from its owner lane.
 
     This module owns only the checkpoint/lineage tail of a keeper turn.
     Memory bank append, episode flush, and Hebbian learning are recorded
@@ -40,40 +42,23 @@ open Keeper_meta_contract
 open Keeper_types_profile
 open Keeper_context_core
 
-type compaction_event = {
-  attempted : bool;
-  applied : bool;
-  (** [started_dispatched] is [true] when the [on_compaction_started] callback
-      successfully dispatched [Compaction_started] to the registry, placing the
-      FSM in [Compaction_compacting].  When [false] (callback failed, skipped,
-      or not attempted), the FSM is still at [Compaction_accumulating] and
-      [dispatch_post_turn_lifecycle_events] must dispatch [Compaction_started]
-      before [Compaction_completed] to avoid the forbidden
-      accumulating -> done transition. *)
-  started_dispatched : bool;
-  failure_reason : string option;
-  trigger : Compaction_trigger.t option;
-  decision : Keeper_compact_policy.compaction_decision;
-}
-
 type post_turn_lifecycle = {
   updated_meta : keeper_meta;
   checkpoint : Agent_sdk.Checkpoint.t option;
   handoff_json : Yojson.Safe.t option;
   handoff_attempted : bool;
   handoff_failure_reason : string option;
-  compaction : compaction_event;
   turn_generation : int;
   checkpoint_bytes : int;
   message_count : int;
 }
 
-type overflow_retry_recovery = {
+type compaction_recovery = {
   checkpoint : Agent_sdk.Checkpoint.t;
-  compaction : compaction_event;
+  trigger : Compaction_trigger.t;
   evidence : Keeper_compaction_evidence.t;
   turn_generation : int;
-} [@@warning "-69"]
+}
 
 type compaction_recovery_error =
   | Checkpoint_load_failed of Keeper_checkpoint_store.checkpoint_load_error
@@ -185,13 +170,7 @@ let apply_resilience_wirein
         lifecycle
     | Some cp -> (
         try
-          let maybe_error =
-            (* First non-None error signal from this turn's
-               compaction or handoff steps. *)
-            match lifecycle.compaction.failure_reason with
-            | Some _ as r -> r
-            | None -> lifecycle.handoff_failure_reason
-          in
+          let maybe_error = lifecycle.handoff_failure_reason in
           let witness = Resilience.Keeper_bridge.running_witness in
           let outcome =
             Resilience.Keeper_bridge.apply_post_turn_resilience
@@ -354,13 +333,8 @@ let apply_multimodal_wirein
 let apply_post_turn_lifecycle_with_resilience_handles
     ~(resilience_audit_store : Shared_audit.Store.t option)
     ~(resilience_strategy_executor : Resilience.Recovery.strategy_executor option)
-    ~on_compaction_started:_
-    ~on_handoff_started:_
-    ~base_dir:_
     ~(meta : keeper_meta)
-    ~model:_
     ~(primary_model_max_tokens : int)
-    ~current_turn_blocker_info:_
     ~(checkpoint : Agent_sdk.Checkpoint.t option) : post_turn_lifecycle =
   (* Reviewer #13214: an executor without an audit store would let
      retry/fallback/handoff/abort callbacks mutate live state
@@ -403,15 +377,6 @@ let apply_post_turn_lifecycle_with_resilience_handles
         handoff_json = None;
         handoff_attempted = false;
         handoff_failure_reason = None;
-        compaction =
-          {
-            attempted = false;
-            applied = false;
-            started_dispatched = false;
-            failure_reason = None;
-            trigger = None;
-            decision = no_checkpoint_decision;
-        };
         turn_generation = meta.runtime.generation;
         checkpoint_bytes = 0;
         message_count = 0;
@@ -433,7 +398,7 @@ let apply_post_turn_lifecycle_with_resilience_handles
             meta
       in
       let decision = Keeper_compact_policy.Not_requested in
-      let meta_after_compaction =
+      let meta_after_context_check =
         map_runtime
           (fun rt ->
             {
@@ -451,20 +416,11 @@ let apply_post_turn_lifecycle_with_resilience_handles
           base_meta
       in
       {
-        updated_meta = meta_after_compaction;
+        updated_meta = meta_after_context_check;
         checkpoint = Some cp;
         handoff_json = None;
         handoff_attempted = false;
         handoff_failure_reason = None;
-        compaction =
-          {
-            attempted = false;
-            applied = false;
-            started_dispatched = false;
-            failure_reason = None;
-            trigger = None;
-            decision;
-        };
         turn_generation = current_generation;
         checkpoint_bytes = serialized_bytes ctx;
         message_count = message_count ctx;
@@ -487,8 +443,7 @@ let apply_post_turn_lifecycle_with_resilience_handles
 let commit_prepared_after_save ~trigger ~save =
   match save () with
   | Error _ as error -> error
-  | Ok checkpoint ->
-    Ok (checkpoint, Keeper_compact_policy.Applied trigger)
+  | Ok checkpoint -> Ok (checkpoint, trigger)
 ;;
 
 let checkpoint_of_save_outcome = function
@@ -501,12 +456,12 @@ let checkpoint_of_save_outcome = function
   | Error detail -> Error (Checkpoint_save_failed detail)
 ;;
 
-let recover_latest_checkpoint_for_overflow_retry
+let recover_latest_checkpoint_for_compaction
     ~(base_dir : string)
     ~(meta : keeper_meta)
     ~(trigger : Compaction_trigger.t)
     ~(primary_model_max_tokens : int)
-  : (overflow_retry_recovery, compaction_recovery_error) result
+  : (compaction_recovery, compaction_recovery_error) result
   =
   let session = create_session ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id) ~base_dir in
   match
@@ -515,14 +470,14 @@ let recover_latest_checkpoint_for_overflow_retry
   with
   | Error Keeper_checkpoint_store.Not_found ->
     Log.Keeper.debug
-      "keeper:%s overflow-retry OAS checkpoint not found"
+      "keeper:%s compaction OAS checkpoint not found"
       (Keeper_id.Trace_id.to_string meta.runtime.trace_id);
     Error (Checkpoint_load_failed Keeper_checkpoint_store.Not_found)
   | Error
       ((Parse_error detail | Store_error detail | Io_error detail
        | Sdk_other_error detail) as error) ->
     Log.Keeper.error
-      "keeper:%s overflow retry OAS load error: %s"
+      "keeper:%s compaction OAS load error: %s"
       (Keeper_id.Trace_id.to_string meta.runtime.trace_id)
       detail;
     Otel_metric_store.inc_counter
@@ -530,7 +485,7 @@ let recover_latest_checkpoint_for_overflow_retry
       ~labels:
         [ "keeper", meta.name
         ; ( "phase"
-          , Keeper_oas_execution_error_phase.(to_label Overflow_retry_oas_load) )
+          , Keeper_oas_execution_error_phase.(to_label Compaction_checkpoint_load) )
         ]
       ();
     Error (Checkpoint_load_failed error)
@@ -567,21 +522,14 @@ let recover_latest_checkpoint_for_overflow_retry
                   ~generation:turn_generation
                 |> checkpoint_of_save_outcome)
           with
-          | Ok (saved_checkpoint, decision) ->
+          | Ok (saved_checkpoint, trigger) ->
             Otel_metric_store.inc_counter
               Keeper_metrics.(to_string Compactions)
               ~labels:[ "keeper", retry_meta.name ]
               ();
             Ok
               { checkpoint = saved_checkpoint
-              ; compaction =
-                  { attempted = true
-                  ; applied = true
-                  ; started_dispatched = false
-                  ; failure_reason = None
-                  ; trigger = Some prepared_trigger
-                  ; decision
-                  }
+              ; trigger
               ; evidence
               ; turn_generation
               }
@@ -589,19 +537,20 @@ let recover_latest_checkpoint_for_overflow_retry
               (Checkpoint_superseded
                  { incoming_turn_count; known_turn_count } as error) ->
             Log.Keeper.warn
-              "overflow retry checkpoint superseded: incoming_turn_count=%d known_turn_count=%d"
+              "compaction checkpoint superseded: incoming_turn_count=%d known_turn_count=%d"
               incoming_turn_count
               known_turn_count;
             Error error
           | Error (Checkpoint_save_failed detail as error) ->
             Log.Keeper.error
-              "overflow retry checkpoint save failed: %s"
+              "compaction checkpoint save failed: %s"
               detail;
             Otel_metric_store.inc_counter
               Keeper_metrics.(to_string CheckpointFailures)
               ~labels:
                 [ "keeper", retry_meta.agent_name
-                ; "operation", "overflow_save"
+                ; ( "operation"
+                  , Keeper_checkpoint_failure_operation.(to_label Compaction_save) )
                 ]
               ();
             Error error
@@ -611,7 +560,7 @@ let recover_latest_checkpoint_for_overflow_retry
         | exn ->
           let detail = Printexc.to_string exn in
           log_keeper_exn
-            ~label:"overflow retry checkpoint save exception"
+            ~label:"compaction checkpoint save exception"
             exn;
           Error (Checkpoint_save_failed detail))
      | Keeper_compact_policy.Rejected (_, reason), _ ->
@@ -620,7 +569,3 @@ let recover_latest_checkpoint_for_overflow_retry
        | Keeper_compact_policy.Not_requested
        | Keeper_compact_policy.Skipped_no_checkpoint) as decision, _ ->
        Error (Unexpected_compaction_decision decision))
-
-module For_testing = struct
-  let commit_prepared_after_save = commit_prepared_after_save
-end

--- a/lib/keeper/keeper_post_turn.mli
+++ b/lib/keeper/keeper_post_turn.mli
@@ -1,8 +1,9 @@
-(** Keeper_post_turn — post-turn lifecycle: compaction, handoff
-    rollover, and overflow retry recovery.
+(** Keeper_post_turn — post-turn checkpoint preservation, handoff rollover,
+    and explicit compaction recovery.
 
-    Orchestrates the end-of-turn pipeline that decides whether to
-    compact the context and roll over to a new generation.
+    Orchestrates end-of-turn checkpoint wire-ins. Compaction is never inferred
+    here; manual and provider-overflow callers enter the explicit recovery
+    function with a typed trigger.
 
     This module owns only the checkpoint/lineage tail of a keeper
     turn. Memory bank append, episode flush, and Hebbian learning
@@ -12,44 +13,24 @@
 
     Extracted from Keeper_context_runtime as part of #4955 god-file split. *)
 
-(** Outcome of the compaction step. [applied] iff an explicit compaction
-    request ran. *)
-type compaction_event =
-  { attempted : bool
-  ; applied : bool
-  ; started_dispatched : bool
-        (** [true] when [on_compaction_started] completed without raising,
-            meaning the FSM is at [Compaction_compacting].  [false] when
-            the callback failed or was never called (recovery path), so
-            the FSM is still at [Compaction_accumulating]. *)
-  ; failure_reason : string option
-  ; trigger : Compaction_trigger.t option
-  ; decision : Keeper_compact_policy.compaction_decision
-  }
-
-(** Combined post-turn outcome — compaction + rollover + per-turn context
-    metrics. *)
+(** Combined post-turn outcome for checkpoint preservation, rollover, and
+    per-turn context metrics. Explicit compaction has its own request path. *)
 type post_turn_lifecycle =
   { updated_meta : Keeper_meta_contract.keeper_meta
   ; checkpoint : Agent_sdk.Checkpoint.t option
   ; handoff_json : Yojson.Safe.t option
   ; handoff_attempted : bool
   ; handoff_failure_reason : string option
-  ; compaction : compaction_event
   ; turn_generation : int
   ; checkpoint_bytes : int
   ; message_count : int
   }
 
-(** Recovered checkpoint + applied compaction event used by the
-    overflow-retry flow to restart the turn from a smaller context.
-
-    [@@warning "-69"]: declared in the .ml because not every field
-    is read at the call site, but the record is exported so callers
-    can match exhaustively. *)
-type overflow_retry_recovery =
+(** Recovered checkpoint after a durably applied explicit compaction request.
+    Manual and provider-overflow callers consume the same result. *)
+type compaction_recovery =
   { checkpoint : Agent_sdk.Checkpoint.t
-  ; compaction : compaction_event
+  ; trigger : Compaction_trigger.t
   ; evidence : Keeper_compaction_evidence.t
   ; turn_generation : int
   } [@@warning "-69"]
@@ -74,13 +55,8 @@ val compaction_recovery_error_to_string : compaction_recovery_error -> string
 val apply_post_turn_lifecycle_with_resilience_handles :
   resilience_audit_store:Shared_audit.Store.t option ->
   resilience_strategy_executor:Resilience.Recovery.strategy_executor option ->
-  on_compaction_started:(unit -> unit) ->
-  on_handoff_started:(unit -> unit) ->
-  base_dir:string ->
   meta:Keeper_meta_contract.keeper_meta ->
-  model:string ->
   primary_model_max_tokens:int ->
-  current_turn_blocker_info:Keeper_meta_contract.blocker_info option ->
   checkpoint:Agent_sdk.Checkpoint.t option ->
   post_turn_lifecycle
 (** Apply the keeper post-turn lifecycle with explicit resilience handles.
@@ -109,24 +85,12 @@ val apply_post_turn_lifecycle_with_resilience_handles :
     is one store per keeper, owned by the keeper bridge. *)
 
 (** Reload the canonical OAS checkpoint and apply an explicit typed
-    compaction request. Returns a durably saved [Applied] checkpoint only for a
-    structurally changed [Prepared] candidate; every other outcome is a typed
-    [Error]. *)
-val recover_latest_checkpoint_for_overflow_retry :
+    compaction request. Returns success only after a structurally changed
+    [Prepared] candidate has been durably saved; every other outcome is a
+    typed [Error]. *)
+val recover_latest_checkpoint_for_compaction :
   base_dir:string ->
   meta:Keeper_meta_contract.keeper_meta ->
   trigger:Compaction_trigger.t ->
   primary_model_max_tokens:int ->
-  (overflow_retry_recovery, compaction_recovery_error) result
-
-module For_testing : sig
-  (** Promote a structurally [Prepared] trigger only after [save] reports an
-      actual durable write. Callers with a classified store result must not
-      map a stale no-op to [Ok]. *)
-  val commit_prepared_after_save :
-    trigger:Compaction_trigger.t ->
-    save:(unit -> ('checkpoint, 'error) result) ->
-    ( 'checkpoint * Keeper_compact_policy.compaction_decision
-    , 'error )
-    result
-end
+  (compaction_recovery, compaction_recovery_error) result

--- a/lib/keeper/keeper_run_context.ml
+++ b/lib/keeper/keeper_run_context.ml
@@ -19,11 +19,6 @@ type run_context =
   ; base_system_prompt : string
   ; ctx_work : working_context
   ; resume_oas_checkpoint : Agent_sdk.Checkpoint.t option
-  ; pre_dispatch_compacted : bool
-  ; pre_dispatch_compaction_trigger : string option
-  ; pre_dispatch_compaction_before_tokens : int option
-  ; pre_dispatch_compaction_after_tokens : int option
-  ; pre_dispatch_checkpoint_error : Agent_sdk.Error.sdk_error option
   ; start_turn_count : int
   ; receipt_started_at : string
   ; config_root : string
@@ -157,11 +152,6 @@ let prepare_run_context
     then Some (Keeper_context_runtime.checkpoint_of_context ctx_work)
     else None
   in
-  let pre_dispatch_compacted = false in
-  let pre_dispatch_compaction_trigger = None in
-  let pre_dispatch_compaction_before_tokens = None in
-  let pre_dispatch_compaction_after_tokens = None in
-  let pre_dispatch_checkpoint_error = None in
   let start_turn_count =
     match resume_oas_checkpoint with
     | Some cp -> cp.turn_count
@@ -177,11 +167,6 @@ let prepare_run_context
   ; base_system_prompt
   ; ctx_work
   ; resume_oas_checkpoint
-  ; pre_dispatch_compacted
-  ; pre_dispatch_compaction_trigger
-  ; pre_dispatch_compaction_before_tokens
-  ; pre_dispatch_compaction_after_tokens
-  ; pre_dispatch_checkpoint_error
   ; start_turn_count
   ; receipt_started_at
   ; config_root

--- a/lib/keeper/keeper_run_context.mli
+++ b/lib/keeper/keeper_run_context.mli
@@ -16,11 +16,6 @@ type run_context =
   ; base_system_prompt : string
   ; ctx_work : working_context
   ; resume_oas_checkpoint : Agent_sdk.Checkpoint.t option
-  ; pre_dispatch_compacted : bool
-  ; pre_dispatch_compaction_trigger : string option
-  ; pre_dispatch_compaction_before_tokens : int option
-  ; pre_dispatch_compaction_after_tokens : int option
-  ; pre_dispatch_checkpoint_error : Agent_sdk.Error.sdk_error option
   ; start_turn_count : int
   ; receipt_started_at : string
   ; config_root : string

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -877,23 +877,8 @@ let run_keeper_invocation_turn_admitted
                     resilience_handles.resilience_audit_store
                   ~resilience_strategy_executor:
                     resilience_handles.resilience_strategy_executor
-                  ~base_dir
-                  ~on_compaction_started:(fun () ->
-                    Keeper_context_runtime.dispatch_keeper_phase_event
-                      ~config:ctx.config
-                      ~origin:Keeper_registry.Post_turn_lifecycle
-                      ~keeper_name:meta.name
-                      Keeper_state_machine.Compaction_started)
-                  ~on_handoff_started:(fun () ->
-                    Keeper_context_runtime.dispatch_keeper_phase_event
-                      ~config:ctx.config
-                      ~origin:Keeper_registry.Post_turn_lifecycle
-                      ~keeper_name:meta.name
-                      Keeper_state_machine.Handoff_started)
 	                  ~meta
-	                  ~model:result.model_used
 	                  ~primary_model_max_tokens:final_max_runtime_context
-                  ~current_turn_blocker_info:None
                   ~checkpoint:result.checkpoint
                 |> resilience_handles.sync_lifecycle_meta
               in
@@ -950,7 +935,6 @@ let run_keeper_invocation_turn_admitted
                    ~snapshot_source:"keeper_turn_msg"
                    ~checkpoint_bytes:lifecycle.checkpoint_bytes
                    ~message_count:lifecycle.message_count
-                   ~compaction:lifecycle.compaction
                    ~handoff_json:lifecycle.handoff_json
                    ()
                with
@@ -978,7 +962,6 @@ let run_keeper_invocation_turn_admitted
               Keeper_unified_metrics.broadcast_lifecycle_events
                 ~name:updated_meta.name
                 ~turn_generation:lifecycle.turn_generation
-                ~compaction:lifecycle.compaction
                 ~handoff_json:lifecycle.handoff_json;
               restart_keepalive_after_message_turn ctx updated_meta;
               Progress.Tracker.complete turn_tracker

--- a/lib/keeper/keeper_turn_helpers.ml
+++ b/lib/keeper/keeper_turn_helpers.ml
@@ -261,10 +261,6 @@ let record_pre_dispatch_terminal_observation
     ; extra_system_context_digest = None
     ; extra_system_context_injected_size = None
     ; extra_system_context_computed_size = None
-    ; pre_dispatch_compacted = false
-    ; pre_dispatch_compaction_trigger = None
-    ; pre_dispatch_compaction_before_tokens = None
-    ; pre_dispatch_compaction_after_tokens = None
     ; oas_internal_runtime_allowed = false
     }
   in

--- a/lib/keeper/keeper_unified_metrics.ml
+++ b/lib/keeper/keeper_unified_metrics.ml
@@ -21,4 +21,6 @@ let update_metrics_from_result = Keeper_unified_metrics_result.update_metrics_fr
 let append_metrics_snapshot = Keeper_unified_metrics_snapshot.append_metrics_snapshot
 let broadcast_lifecycle_events =
   Keeper_unified_metrics_broadcast.broadcast_lifecycle_events
+
+let broadcast_compaction = Keeper_unified_metrics_broadcast.broadcast_compaction
 let update_metrics_from_failure = Keeper_unified_metrics_failure.update_metrics_from_failure

--- a/lib/keeper/keeper_unified_metrics.mli
+++ b/lib/keeper/keeper_unified_metrics.mli
@@ -162,7 +162,6 @@ val append_metrics_snapshot :
   snapshot_source:string ->
   checkpoint_bytes:int ->
   message_count:int ->
-  compaction:Keeper_context_runtime.compaction_event ->
   handoff_json:Yojson.Safe.t option ->
   ?count_completed_turn:bool ->
   ?deliberation_execution:Keeper_deliberation.execution_result ->
@@ -190,9 +189,11 @@ val append_decision_record :
 val broadcast_lifecycle_events :
   name:string ->
   turn_generation:int ->
-  compaction:Keeper_context_runtime.compaction_event ->
   handoff_json:Yojson.Safe.t option ->
   unit
+
+val broadcast_compaction :
+  name:string -> Keeper_context_runtime.compaction_recovery -> unit
 
 val has_substantive_tool_calls : string list -> bool
 

--- a/lib/keeper/keeper_unified_metrics_broadcast.ml
+++ b/lib/keeper/keeper_unified_metrics_broadcast.ml
@@ -9,38 +9,38 @@ open Keeper_meta_contract
 open Keeper_types_profile
 open Keeper_context_runtime
 
+let broadcast_compaction
+      ~(name : string)
+      (recovery : Keeper_context_runtime.compaction_recovery)
+  =
+  try
+    Sse.broadcast
+      (`Assoc
+        [ "type", `String "keeper_compaction"
+        ; "name", `String name
+        ; "generation", `Int recovery.turn_generation
+        ; "outcome", `String "applied_checkpoint"
+        ; "trigger", `String (Compaction_trigger.to_label recovery.trigger)
+        ; "trigger_detail", Compaction_trigger.to_detail_json recovery.trigger
+        ; "ts_unix", `Float (Time_compat.now ())
+        ])
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    Log.Keeper.error
+      "compaction SSE broadcast failed: %s"
+      (Printexc.to_string exn);
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string MetricsSseFailures)
+      ~labels:
+        [ "kind", Keeper_metrics_sse_failure_kind.(to_label Compaction) ]
+      ()
+;;
+
 let broadcast_lifecycle_events ~(name : string)
     ~(turn_generation : int)
-    ~(compaction : Keeper_context_runtime.compaction_event)
     ~(handoff_json : Yojson.Safe.t option) : unit =
   let now_ts = Time_compat.now () in
-  (if compaction.applied then
-     try
-       Sse.broadcast
-         (`Assoc
-           [
-             ("type", `String "keeper_compaction");
-             ("name", `String name);
-             ("generation", `Int turn_generation);
-             ( "trigger",
-               match compaction.trigger with
-               | Some trigger -> `String (Compaction_trigger.to_label trigger)
-               | None ->
-                   `String
-                     (Keeper_context_runtime.compaction_decision_to_string
-                        compaction.decision) );
-             ( "trigger_detail",
-               match compaction.trigger with
-               | Some trigger -> Compaction_trigger.to_detail_json trigger
-               | None -> `Null );
-             ("ts_unix", `Float now_ts);
-           ])
-     with
-     | Eio.Cancel.Cancelled _ as e -> raise e
-     | exn ->
-         Log.Keeper.error "compaction SSE broadcast failed: %s"
-           (Printexc.to_string exn);
-         Otel_metric_store.inc_counter Keeper_metrics.(to_string MetricsSseFailures) ~labels:[("kind", Keeper_metrics_sse_failure_kind.(to_label Compaction))] ());
   match handoff_json with
   | Some ((`Assoc _ as handoff)) ->
       let from_generation =

--- a/lib/keeper/keeper_unified_metrics_broadcast.mli
+++ b/lib/keeper/keeper_unified_metrics_broadcast.mli
@@ -1,8 +1,10 @@
 (** Keeper lifecycle SSE broadcast helpers. *)
 
+val broadcast_compaction :
+  name:string -> Keeper_context_runtime.compaction_recovery -> unit
+
 val broadcast_lifecycle_events :
   name:string ->
   turn_generation:int ->
-  compaction:Keeper_context_runtime.compaction_event ->
   handoff_json:Yojson.Safe.t option ->
   unit

--- a/lib/keeper/keeper_unified_metrics_snapshot.ml
+++ b/lib/keeper/keeper_unified_metrics_snapshot.ml
@@ -18,7 +18,6 @@ let append_metrics_snapshot ~(config : Workspace.config) ~(meta : keeper_meta)
     ~(snapshot_source : string)
     ~(checkpoint_bytes : int)
     ~(message_count : int)
-    ~(compaction : Keeper_context_runtime.compaction_event)
     ~(handoff_json : Yojson.Safe.t option)
     ?(count_completed_turn = true)
     ?deliberation_execution () : unit =
@@ -114,15 +113,9 @@ let append_metrics_snapshot ~(config : Workspace.config) ~(meta : keeper_meta)
         ("checkpoint_bytes", `Int checkpoint_bytes);
         ("message_count", `Int message_count);
         ("continuity_state", `Null);
-        ("compacted", `Bool compaction.applied);
-        ("compaction_trigger",
-          match compaction.trigger with
-          | Some trigger -> `String (Compaction_trigger.to_label trigger)
-          | None -> `Null);
-        ("compaction_trigger_detail",
-          match compaction.trigger with
-          | Some trigger -> Compaction_trigger.to_detail_json trigger
-          | None -> `Null);
+        ("compacted", `Bool false);
+        ("compaction_trigger", `Null);
+        ("compaction_trigger_detail", `Null);
         ("turn_mode", `String (turn_mode_to_string turn_mode));
         ( "scheduled_autonomous_outcome",
           match scheduled_autonomous_outcome with

--- a/lib/keeper/keeper_unified_metrics_snapshot.mli
+++ b/lib/keeper/keeper_unified_metrics_snapshot.mli
@@ -12,7 +12,6 @@ val append_metrics_snapshot :
   snapshot_source:string ->
   checkpoint_bytes:int ->
   message_count:int ->
-  compaction:Keeper_context_runtime.compaction_event ->
   handoff_json:Yojson.Safe.t option ->
   ?count_completed_turn:bool ->
   ?deliberation_execution:Keeper_deliberation.execution_result ->

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -125,14 +125,14 @@ let user_message_with_hitl_resolution ~base_path ~user_message = function
 
 type provider_overflow_recovery =
   | Not_provider_overflow
-  | Provider_overflow_applied of
-      { trigger : Compaction_trigger.t
-      ; recovery : Keeper_context_runtime.overflow_retry_recovery
-      }
-  | Provider_overflow_retry of
+  | Provider_overflow_applied of Keeper_context_runtime.compaction_recovery
+  | Provider_overflow_retry_without_checkpoint of
       { trigger : Compaction_trigger.t
       ; reason : string
-      ; recovery : Keeper_context_runtime.overflow_retry_recovery option
+      }
+  | Provider_overflow_retry_with_checkpoint of
+      { reason : string
+      ; recovery : Keeper_context_runtime.compaction_recovery
       }
 
 let recover_provider_context_overflow_in_lane
@@ -183,19 +183,21 @@ let recover_provider_context_overflow_in_lane
     let retry_after_started ?recovery reason =
       record_overflow_failure ~config ~meta ~reason;
       release_failed_lifecycle reason;
-      Provider_overflow_retry { trigger; reason; recovery }
+      match recovery with
+      | None -> Provider_overflow_retry_without_checkpoint { trigger; reason }
+      | Some recovery -> Provider_overflow_retry_with_checkpoint { reason; recovery }
     in
     (match dispatch "context_overflow_detected" overflow_event with
      | Error reason ->
        record_overflow_failure ~config ~meta ~reason;
-       Provider_overflow_retry { trigger; reason; recovery = None }
+       Provider_overflow_retry_without_checkpoint { trigger; reason }
      | Ok () ->
        (match dispatch "compaction_started" Keeper_state_machine.Compaction_started with
         | Error reason -> retry_after_started reason
         | Ok () ->
           (try
              match
-               recover_latest_checkpoint_for_overflow_retry
+               recover_latest_checkpoint_for_compaction
                  ~base_dir
                  ~meta
                  ~trigger
@@ -212,10 +214,13 @@ let recover_provider_context_overflow_in_lane
                     ~keeper_name:meta.name
                 with
                 | Ok () ->
-                    Log.Keeper.info
-                      ~keeper_name:meta.name
-                      "provider overflow compaction committed; source stimulus will be requeued";
-                    Provider_overflow_applied { trigger; recovery }
+                  Log.Keeper.info
+                    ~keeper_name:meta.name
+                    "provider overflow compaction committed; source stimulus will be requeued";
+                  Keeper_unified_metrics.broadcast_compaction
+                    ~name:meta.name
+                    recovery;
+                  Provider_overflow_applied recovery
                 | Error error ->
                   retry_after_started
                     ~recovery
@@ -248,8 +253,9 @@ let append_provider_overflow_manifest
       ~base_dir
       outcome
   =
-  let append_recovery ~status ~error ~trigger ~recovery turn_state =
+  let append_recovery ~status ~error ~recovery turn_state =
     let evidence = recovery.evidence in
+    let trigger = recovery.trigger in
     let session_id = recovery.checkpoint.session_id in
     let checkpoint_path =
       Keeper_checkpoint_store.oas_checkpoint_path
@@ -284,27 +290,25 @@ let append_provider_overflow_manifest
   in
   match outcome with
   | Not_provider_overflow -> Follow_failure_route, turn_state
-  | Provider_overflow_applied { trigger; recovery } ->
+  | Provider_overflow_applied recovery ->
     let turn_state =
       append_recovery
         ~status:"compacted"
         ~error:`Null
-        ~trigger
         ~recovery
         turn_state
     in
     Requeue_after_context_compaction, turn_state
-  | Provider_overflow_retry { trigger; reason; recovery = Some recovery } ->
+  | Provider_overflow_retry_with_checkpoint { reason; recovery } ->
     let turn_state =
       append_recovery
         ~status:"retryable_failure"
         ~error:(`String reason)
-        ~trigger
         ~recovery
         turn_state
     in
     Requeue_after_context_compaction, turn_state
-  | Provider_overflow_retry { trigger; reason; recovery = None } ->
+  | Provider_overflow_retry_without_checkpoint { trigger; reason } ->
     let turn_state =
       Keeper_unified_turn_manifest.append_manifest
         ~config
@@ -1137,7 +1141,6 @@ dominant source of the observed CAS race exhaustion after
                   let success =
                     Keeper_unified_turn_success.handle
                       ~config
-                      ~base_dir
                       ~meta
                       ~turn_ctx_cell
                       ~observation
@@ -1146,7 +1149,6 @@ dominant source of the observed CAS race exhaustion after
                       ~degraded_retry_applied
                       ~degraded_retry_runtime
                       ~fallback_reason
-                      ~current_turn_blocker_info:turn_state.current_turn_blocker_info
                       ~keeper_turn_id
                       result
                   in

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -13,29 +13,19 @@ let runtime_lane_label = Boundary_redaction.to_string Boundary_redaction.runtime
 let turn_cost result = KUM.estimate_usage_cost_usd result.Keeper_agent_run.usage
 ;;
 
-let apply_lifecycle ~config ~base_dir ~meta ~final_execution ~current_turn_blocker_info result =
+let apply_lifecycle
+      ~config
+      ~meta
+      ~final_execution
+      (result : Keeper_agent_run.run_result)
+  =
   let resilience_handles = KCB.post_turn_resilience_handles ~config ~meta in
   let lifecycle : KEC.post_turn_lifecycle =
     KEC.apply_post_turn_lifecycle_with_resilience_handles
-      ~base_dir
       ~resilience_audit_store:resilience_handles.resilience_audit_store
       ~resilience_strategy_executor:resilience_handles.resilience_strategy_executor
-      ~on_compaction_started:(fun () ->
-        KEC.dispatch_keeper_phase_event
-          ~config
-          ~origin:Keeper_registry.Post_turn_lifecycle
-          ~keeper_name:meta.name
-          Keeper_state_machine.Compaction_started)
-      ~on_handoff_started:(fun () ->
-        KEC.dispatch_keeper_phase_event
-          ~config
-          ~origin:Keeper_registry.Post_turn_lifecycle
-          ~keeper_name:meta.name
-          Keeper_state_machine.Handoff_started)
       ~meta
-      ~model:result.Keeper_agent_run.model_used
       ~primary_model_max_tokens:final_execution.KCB.max_context
-      ~current_turn_blocker_info
       ~checkpoint:result.checkpoint
     |> resilience_handles.sync_lifecycle_meta
   in
@@ -133,7 +123,6 @@ let append_metrics_snapshot
       ~snapshot_source:"keeper_unified_turn"
       ~checkpoint_bytes:lifecycle.checkpoint_bytes
       ~message_count:lifecycle.message_count
-      ~compaction:lifecycle.compaction
       ~handoff_json:lifecycle.handoff_json
       ~count_completed_turn:(terminal_outcome_is_completed_turn terminal_outcome)
       ()
@@ -527,7 +516,6 @@ let emit_terminal_fsm
 
 let handle
       ~config
-      ~base_dir
       ~meta
       ~turn_ctx_cell
       ~observation
@@ -536,7 +524,6 @@ let handle
       ~degraded_retry_applied
       ~degraded_retry_runtime
       ~fallback_reason
-      ~current_turn_blocker_info
       ~keeper_turn_id
       result
   =
@@ -544,10 +531,8 @@ let handle
   let lifecycle =
     apply_lifecycle
       ~config
-      ~base_dir
       ~meta
       ~final_execution
-      ~current_turn_blocker_info
       result
   in
   let updated_meta =
@@ -598,7 +583,6 @@ let handle
   KUM.broadcast_lifecycle_events
     ~name:updated_meta.name
     ~turn_generation:lifecycle.turn_generation
-    ~compaction:lifecycle.compaction
     ~handoff_json:lifecycle.handoff_json;
   KUM.append_decision_record
     ~config

--- a/lib/keeper/keeper_unified_turn_success.mli
+++ b/lib/keeper/keeper_unified_turn_success.mli
@@ -36,7 +36,6 @@ type handle_result =
 
 val handle
   :  config:Workspace.config
-  -> base_dir:string
   -> meta:Keeper_meta_contract.keeper_meta
   -> turn_ctx_cell:Keeper_tool_call_log.turn_ctx_cell
   -> observation:Keeper_world_observation.world_observation
@@ -45,7 +44,6 @@ val handle
   -> degraded_retry_applied:bool
   -> degraded_retry_runtime:string option
   -> fallback_reason:Keeper_error_classify.degraded_retry_reason option
-  -> current_turn_blocker_info:Keeper_meta_contract.blocker_info option
   -> keeper_turn_id:int
   -> Keeper_agent_run.run_result
   -> handle_result

--- a/lib/keeper_failure_taxonomy/keeper_checkpoint_failure_operation.ml
+++ b/lib/keeper_failure_taxonomy/keeper_checkpoint_failure_operation.ml
@@ -7,6 +7,7 @@ type t =
   | Oas_sdk
   | Oas_sanitize_save
   | Create_initial_save
+  | Compaction_save
 
 let to_label = function
   | Migrate_main_history -> "migrate_main_history"
@@ -17,4 +18,5 @@ let to_label = function
   | Oas_sdk -> "oas_sdk"
   | Oas_sanitize_save -> "oas_sanitize_save"
   | Create_initial_save -> "create_initial_save"
+  | Compaction_save -> "compaction_save"
 ;;

--- a/lib/keeper_failure_taxonomy/keeper_checkpoint_failure_operation.mli
+++ b/lib/keeper_failure_taxonomy/keeper_checkpoint_failure_operation.mli
@@ -1,8 +1,7 @@
 (** Keeper_checkpoint_failure_operation — closed sum for the [operation] label
     on [metric_keeper_checkpoint_failures].
 
-    Replaces 7 hardcoded literals scattered across 7 emit sites in
-    [keeper_context_core.ml].  Each value names a distinct
+    Each value names a distinct
     checkpoint-related failure mode in keeper context loading/saving. *)
 
 type t =
@@ -14,5 +13,6 @@ type t =
   | Oas_sdk (** OAS SDK-level checkpoint error. *)
   | Oas_sanitize_save (** Persisting a sanitized OAS checkpoint failed. *)
   | Create_initial_save (** Initial checkpoint save during keeper boot create flow. *)
+  | Compaction_save (** Saving a structurally compacted checkpoint failed. *)
 
 val to_label : t -> string

--- a/lib/keeper_failure_taxonomy/keeper_metrics_sse_failure_kind.mli
+++ b/lib/keeper_failure_taxonomy/keeper_metrics_sse_failure_kind.mli
@@ -1,12 +1,8 @@
-(** Keeper_metrics_sse_failure_kind — closed sum for the [kind] label on
-    [metric_keeper_metrics_sse_failures].
-
-    Replaces 2 hardcoded string literals in [keeper_unified_metrics.ml]
-    (`"compaction"` / `"handoff"`) — the two SSE broadcast paths
-    whose failures are counted on this metric. *)
+(** Closed sum for the [kind] label on
+    [metric_keeper_metrics_sse_failures]. *)
 
 type t =
-  | Compaction (** keeper_compaction lifecycle SSE broadcast failure. *)
-  | Handoff (** keeper handoff/rollover SSE broadcast failure. *)
+  | Compaction
+  | Handoff
 
 val to_label : t -> string

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -164,7 +164,6 @@ type t =
   | TurnPhaseDuration
   | LifecycleTransitions
   | LifecycleCallbackFailures
-  | CompactionCallbackRecoveries
   | EventBusDrain
   | SupervisorCleanupFailures
   | RegistryUpdateDropped
@@ -387,8 +386,6 @@ let to_string = function
   | TurnPhaseDuration -> "masc_keeper_turn_phase_duration_seconds"
   | LifecycleTransitions -> "masc_keeper_lifecycle_transitions_total"
   | LifecycleCallbackFailures -> "masc_keeper_lifecycle_callback_failures_total"
-  | CompactionCallbackRecoveries ->
-    "masc_keeper_compaction_callback_recoveries_total"
   | EventBusDrain -> "masc_keeper_event_bus_drain_total"
   | SupervisorCleanupFailures -> "masc_keeper_supervisor_cleanup_failures_total"
   | RegistryUpdateDropped -> "masc_keeper_registry_update_dropped_total"

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -155,7 +155,6 @@ type t =
   | TurnPhaseDuration
   | LifecycleTransitions
   | LifecycleCallbackFailures
-  | CompactionCallbackRecoveries
   | EventBusDrain
   | SupervisorCleanupFailures
   | RegistryUpdateDropped

--- a/lib/keeper_metrics/keeper_oas_execution_error_phase.ml
+++ b/lib/keeper_metrics/keeper_oas_execution_error_phase.ml
@@ -5,7 +5,7 @@ type t =
   | Cycle_failed
   | Persistent_escalation
   | Resilience_audit_store
-  | Overflow_retry_oas_load
+  | Compaction_checkpoint_load
   | Provider_context_overflow
 
 let to_label = function
@@ -15,6 +15,6 @@ let to_label = function
   | Cycle_failed -> "cycle_failed"
   | Persistent_escalation -> "persistent_escalation"
   | Resilience_audit_store -> "resilience_audit_store"
-  | Overflow_retry_oas_load -> "overflow_retry_oas_load"
+  | Compaction_checkpoint_load -> "compaction_checkpoint_load"
   | Provider_context_overflow -> "provider_context_overflow"
 ;;

--- a/lib/keeper_metrics/keeper_oas_execution_error_phase.mli
+++ b/lib/keeper_metrics/keeper_oas_execution_error_phase.mli
@@ -19,7 +19,7 @@ type t =
   | Cycle_failed
   | Persistent_escalation
   | Resilience_audit_store
-  | Overflow_retry_oas_load
+  | Compaction_checkpoint_load
   | Provider_context_overflow
 
 val to_label : t -> string

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -808,22 +808,11 @@ let compaction_context_snapshot_json
   =
   (* TEL-OK: read-only dashboard projection; compaction telemetry is emitted by
      the keeper runtime/event bridge that produced the manifest row. *)
-  let pre_dispatch_compacted =
-    Json_util.get_bool row.decision "pre_dispatch_compacted" = Some true
-  in
-  if (not pre_dispatch_compacted) && Keeper_runtime_manifest.status_is_skipped row
+  if Keeper_runtime_manifest.status_is_skipped row
   then None
   else
-    let before_tokens =
-      match Json_util.get_int row.decision "before_tokens" with
-      | Some tokens -> Some tokens
-      | None -> Json_util.get_int row.decision "pre_dispatch_compaction_before_tokens"
-    in
-    let after_tokens =
-      match Json_util.get_int row.decision "after_tokens" with
-      | Some tokens -> Some tokens
-      | None -> Json_util.get_int row.decision "pre_dispatch_compaction_after_tokens"
-    in
+    let before_tokens = Json_util.get_int row.decision "before_tokens" in
+    let after_tokens = Json_util.get_int row.decision "after_tokens" in
     let compaction_source =
       compaction_snapshot_clock_string row.decision "compaction_source"
     in
@@ -841,7 +830,7 @@ let compaction_context_snapshot_json
          ; source = "runtime_manifest"
          (* DET-OK: manifest projection fallback only; a missing source maps to
             a stable UI label and does not drive keeper policy. *)
-         ; trigger = Option.value ~default:"pre_dispatch_hygiene" compaction_source
+         ; trigger = Option.value ~default:"context_compacted" compaction_source
          ; runtime_id = row.runtime_id
          ; before_tokens
          ; after_tokens

--- a/scripts/test_wake_payload_stats.py
+++ b/scripts/test_wake_payload_stats.py
@@ -11,7 +11,7 @@ import wake_payload_stats as stats
 
 def valid_record():
     return json.loads(
-        '{"record_type":"wake_payload","timestamp":1.5,"keeper_name":"k","trace_id":"t","turn_index":1,"context_window":4096,"system_prompt_bytes":3,"tool_schema_json_bytes":4,"message_content_bytes":5,"message_count":2,"tool_count":1,"role_counts":{"user":1,"assistant":1},"has_compact_happened":false}'
+        '{"record_type":"wake_payload","timestamp":1.5,"keeper_name":"k","trace_id":"t","turn_index":1,"context_window":4096,"system_prompt_bytes":3,"tool_schema_json_bytes":4,"message_content_bytes":5,"message_count":2,"tool_count":1,"role_counts":{"user":1,"assistant":1}}'
     )
 
 

--- a/scripts/wake_payload_stats.py
+++ b/scripts/wake_payload_stats.py
@@ -66,10 +66,6 @@ def validate_wake_payload_record(record: dict, path: str, lineno: int) -> bool:
     if record["message_count"] <= 0:
         warn_skip(path, lineno, "message_count must be positive")
         return False
-    compacted = record.get("has_compact_happened")
-    if not isinstance(compacted, bool):
-        warn_skip(path, lineno, "has_compact_happened must be a boolean")
-        return False
     role_counts = record.get("role_counts")
     if not isinstance(role_counts, dict):
         warn_skip(path, lineno, "role_counts must be an object")

--- a/test/test_dashboard_harness_health.ml
+++ b/test/test_dashboard_harness_health.ml
@@ -43,7 +43,6 @@ let record_wake_payload ~trace_id =
     ~message_count:3
     ~role_counts:[ "user", 1; "assistant", 2 ]
     ~tool_count:4
-    ~has_compact_happened:false
 
 let test_wake_payload_store_round_trip () =
   reset_after @@ fun () ->
@@ -60,8 +59,7 @@ let test_wake_payload_store_round_trip () =
     check int "system prompt bytes" 10 event.system_prompt_bytes;
     check int "tool schema JSON bytes" 20 event.tool_schema_json_bytes;
     check int "message content bytes" 70 event.message_content_bytes;
-    check int "tool count" 4 event.tool_count;
-    check bool "compact flag" false event.has_compact_happened
+    check int "tool count" 4 event.tool_count
   | events ->
     failf "expected one wake payload event, got %d" (List.length events)
 
@@ -95,7 +93,6 @@ let test_wake_payload_reader_rejects_malformed_exact_records () =
     ; "message_count", `Int 3
     ; "role_counts", `Assoc [ "user", `Int 1; "assistant", `Int 2 ]
     ; "tool_count", `Int 4
-    ; "has_compact_happened", `Bool false
     ]
   in
   let replace key value fields =

--- a/test/test_keeper_callback_hardening.ml
+++ b/test/test_keeper_callback_hardening.ml
@@ -2,8 +2,8 @@
 
     Two new counters were added in PR-J:
     1. [masc_keeper_lifecycle_callback_failures_total{callback,...}] —
-       bumped when post-turn lifecycle callbacks or per-keeper OAS hook
-       side effects raise. Lifecycle wrappers emit [callback] only;
+       bumped when lifecycle or per-keeper OAS hook side effects raise.
+       Lifecycle wrappers emit [callback] only;
        per-keeper hook sites also include [keeper].
     2. [masc_keeper_event_bus_drain_total{site,outcome}] — bumped on
        every drain, with [outcome=drained] when at least one event
@@ -44,8 +44,8 @@ let read_keeper_hook_failure ~keeper ~callback =
     ~labels:[("keeper", keeper); ("callback", callback)] ()
 
 let test_lifecycle_callback_label_isolation () =
-  let cb_a = "on_compaction_started" in
-  let cb_b = "on_handoff_started" in
+  let cb_a = "guard_tool_call_log" in
+  let cb_b = "after_turn_sse_broadcast" in
   let a_before = read_lifecycle_failure ~callback:cb_a in
   let b_before = read_lifecycle_failure ~callback:cb_b in
   P.inc_counter Keeper_metrics.(to_string LifecycleCallbackFailures)
@@ -113,16 +113,14 @@ let test_drain_outcome_label_distinction () =
     empty_before empty_after
 
 (* ── Documented label vocabulary check ──────────────────────
-   The wrappers in keeper_post_turn.ml / keeper_rollover.ml and the
-   per-keeper hook sites in keeper_hooks_oas.ml must stay aligned with
+   The lifecycle wrappers and the per-keeper hook sites in
+   keeper_hooks_oas.ml must stay aligned with
    otel_metric_store.mli. This test pins the callback vocabulary so a future
    refactor that renames a label without updating the docs is caught. *)
 
 let test_documented_callback_label_vocabulary () =
   let documented_labels =
     [
-      "on_compaction_started";
-      "on_handoff_started";
       "guard_tool_call_log";
       "after_turn_sse_broadcast";
       "post_tool_log_write";

--- a/test/test_keeper_global_shared_refs_atomic.ml
+++ b/test/test_keeper_global_shared_refs_atomic.ml
@@ -109,7 +109,6 @@ let test_keepalive_signal_callbacks () =
       ~message_count:_
       ~role_counts:_
       ~tool_count:_
-      ~has_compact_happened:_
     -> wake_called := true);
   Keeper_keepalive_signal.record_wake_payload
     ~keeper_name:"k"
@@ -121,8 +120,7 @@ let test_keepalive_signal_callbacks () =
     ~message_content_bytes:0
     ~message_count:0
     ~role_counts:[]
-    ~tool_count:0
-    ~has_compact_happened:false;
+    ~tool_count:0;
   check bool "wake payload callback invoked" true !wake_called;
   Keeper_keepalive_signal.register_record_wake_payload
     (fun
@@ -136,7 +134,6 @@ let test_keepalive_signal_callbacks () =
       ~message_count:_
       ~role_counts:_
       ~tool_count:_
-      ~has_compact_happened:_
     -> ());
   let skipped = ref false in
   Keeper_keepalive_signal.register_record_tool_skipped

--- a/test/test_keeper_lifecycle_registry_dispatch.ml
+++ b/test/test_keeper_lifecycle_registry_dispatch.ml
@@ -1,6 +1,7 @@
 open Alcotest
 
 module KEC = Masc.Keeper_context_runtime
+module KMC = Masc.Keeper_manual_compaction
 module Keeper_meta_contract = Masc.Keeper_meta_contract
 module Keeper_meta_json = Masc.Keeper_meta_json
 module Keeper_meta_json_parse = Masc.Keeper_meta_json_parse
@@ -154,27 +155,6 @@ let make_keeper_meta ?(name = "keeper-lifecycle-test")
   | Ok meta -> meta
   | Error err -> fail ("meta_of_json failed: " ^ err)
 
-let base_lifecycle ~(meta : Keeper_meta_contract.keeper_meta) : KEC.post_turn_lifecycle =
-  {
-    updated_meta = meta;
-    checkpoint = None;
-    handoff_json = None;
-    handoff_attempted = false;
-    handoff_failure_reason = None;
-    compaction =
-      {
-        attempted = false;
-        applied = false;
-        started_dispatched = false;
-        failure_reason = None;
-        trigger = None;
-        decision = KEC.Not_requested;
-    };
-    turn_generation = meta.runtime.generation;
-    checkpoint_bytes = 0;
-    message_count = 0;
-  }
-
 let test_registry_rejects_meta_name_mismatch_update () =
   let base_dir = temp_dir "keeper_lifecycle_registry_meta_mismatch" in
   Fun.protect
@@ -271,7 +251,7 @@ let test_dispatch_keeper_phase_event_uses_workspace_base_path () =
             (KST.phase_to_string entry.phase)
       | None -> fail "expected registered keeper after compaction dispatch")
 
-let test_dispatch_post_turn_lifecycle_events_uses_workspace_base_path () =
+let test_dispatch_compaction_completed_uses_workspace_base_path () =
   let base_dir = temp_dir "keeper_lifecycle_registry_outcome" in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
@@ -287,31 +267,18 @@ let test_dispatch_post_turn_lifecycle_events_uses_workspace_base_path () =
         ~origin:KR.Post_turn_lifecycle
         ~keeper_name:meta.name
         KST.Compaction_started;
-      let lifecycle =
-        {
-          (base_lifecycle ~meta) with
-          compaction =
-            {
-              attempted = true;
-              applied = true;
-              started_dispatched = true;
-              failure_reason = None;
-              trigger = Some Compaction_trigger.Manual;
-              decision = KEC.Applied Compaction_trigger.Manual;
-            };
-        }
-      in
-      KEC.dispatch_post_turn_lifecycle_events
+      KEC.dispatch_compaction_completed
         ~config
+        ~origin:KR.Post_turn_lifecycle
         ~keeper_name:meta.name
-        lifecycle;
+      |> Result.get_ok;
       match KR.get ~base_path:config.base_path meta.name with
       | Some entry ->
           check string "compaction completion reaches registry" "running"
             (KST.phase_to_string entry.phase)
       | None -> fail "expected registered keeper after lifecycle dispatch")
 
-let test_post_turn_compaction_runs_from_failing_health_lane () =
+let test_compaction_runs_from_failing_health_lane () =
   let base_dir = temp_dir "keeper_lifecycle_registry_failing_compaction" in
   Fun.protect
     ~finally:(fun () ->
@@ -343,24 +310,11 @@ let test_post_turn_compaction_runs_from_failing_health_lane () =
            check string "post-turn compaction starts while failing" "compacting"
              (KST.phase_to_string entry.phase)
        | None -> fail "expected registered keeper after compaction start");
-      let lifecycle =
-        {
-          (base_lifecycle ~meta) with
-          compaction =
-            {
-              attempted = true;
-              applied = true;
-              started_dispatched = true;
-              failure_reason = None;
-              trigger = Some Compaction_trigger.Manual;
-              decision = KEC.Applied Compaction_trigger.Manual;
-            };
-        }
-      in
-      KEC.dispatch_post_turn_lifecycle_events
+      KEC.dispatch_compaction_completed
         ~config
+        ~origin:KR.Post_turn_lifecycle
         ~keeper_name:meta.name
-        lifecycle;
+      |> Result.get_ok;
       match KR.get ~base_path:config.base_path meta.name with
       | Some entry ->
           check string "compaction completion preserves failing health lane" "failing"
@@ -389,24 +343,11 @@ let test_compaction_completion_without_started_is_nonfatal () =
           ~labels ()
         |> Option.value ~default:0.0
       in
-      let lifecycle =
-        {
-          (base_lifecycle ~meta) with
-          compaction =
-            {
-              attempted = true;
-              applied = true;
-              started_dispatched = true;
-              failure_reason = None;
-              trigger = Some Compaction_trigger.Manual;
-              decision = KEC.Applied Compaction_trigger.Manual;
-            };
-        }
-      in
-      KEC.dispatch_post_turn_lifecycle_events
+      KEC.dispatch_compaction_completed
         ~config
+        ~origin:KR.Post_turn_lifecycle
         ~keeper_name:meta.name
-        lifecycle;
+      |> ignore;
       let after =
         Masc.Otel_metric_store.get_metric_value
           Keeper_metrics.(to_string LifecycleDispatchRejections)
@@ -420,7 +361,7 @@ let test_compaction_completion_without_started_is_nonfatal () =
             (KST.phase_to_string entry.phase)
       | None -> fail "expected registered keeper after rejected completion")
 
-let test_post_turn_compaction_restarts_after_done_stage () =
+let test_compaction_restarts_after_done_stage () =
   let base_dir = temp_dir "keeper_lifecycle_registry_repeat_compaction" in
   Fun.protect
     ~finally:(fun () ->
@@ -433,20 +374,6 @@ let test_post_turn_compaction_restarts_after_done_stage () =
       let config = Masc.Workspace.default_config base_dir in
       let meta = make_keeper_meta ~name:"keeper-repeat-compaction" () in
       ignore (KR.register ~base_path:config.base_path meta.name meta);
-      let lifecycle =
-        {
-          (base_lifecycle ~meta) with
-          compaction =
-            {
-              attempted = true;
-              applied = true;
-              started_dispatched = true;
-              failure_reason = None;
-              trigger = Some Compaction_trigger.Manual;
-              decision = KEC.Applied Compaction_trigger.Manual;
-            };
-        }
-      in
       let run_compaction label =
         KEC.dispatch_keeper_phase_event
           ~config
@@ -458,10 +385,11 @@ let test_post_turn_compaction_restarts_after_done_stage () =
              check string (label ^ " start reaches compacting") "compacting"
                (KST.phase_to_string entry.phase)
          | None -> fail "expected registered keeper after compaction start");
-        KEC.dispatch_post_turn_lifecycle_events
+        KEC.dispatch_compaction_completed
           ~config
+          ~origin:KR.Post_turn_lifecycle
           ~keeper_name:meta.name
-          lifecycle;
+        |> Result.get_ok;
         match KR.get ~base_path:config.base_path meta.name with
         | Some entry ->
             check string (label ^ " completion returns running") "running"
@@ -544,6 +472,39 @@ let test_dispatch_keeper_phase_event_rejection_increments_metric () =
         |> Option.value ~default:0.0
       in
       check bool "rejection metric increments" true (after > before))
+
+let test_manual_compaction_preserves_failed_failure_dispatch () =
+  let primary =
+    KEC.Transition_rejected
+      (KST.Precondition_violation
+         { event = "compaction_started"; reason = "primary rejection" })
+  in
+  let failure_dispatch =
+    KEC.Transition_rejected
+      (KST.Precondition_violation
+         { event = "compaction_failed"; reason = "failure dispatch rejection" })
+  in
+  let failure =
+    KMC.Lifecycle_with_failure_dispatch
+      { stage = KMC.Compaction_started
+      ; checkpoint_applied = false
+      ; error = primary
+      ; failure_dispatch = Error failure_dispatch
+      }
+  in
+  let detail = KMC.failure_to_string failure in
+  check bool "primary rejection is rendered" true
+    (Astring.String.is_infix ~affix:"primary rejection" detail);
+  check bool "failure dispatch rejection is rendered" true
+    (Astring.String.is_infix ~affix:"failure dispatch rejection" detail);
+  let recovery_detail =
+    KMC.failure_to_string
+      (KMC.Recovery
+         ( Masc.Keeper_post_turn.Compaction_evidence_missing
+         , Error failure_dispatch ))
+  in
+  check bool "recovery failure dispatch rejection is rendered" true
+    (Astring.String.is_infix ~affix:"failure dispatch rejection" recovery_detail)
 
 let test_keepalive_dispatch_event_rejection_increments_metric () =
   let base_dir = temp_dir "keeper_lifecycle_keepalive_rejection" in
@@ -701,18 +662,20 @@ let () =
         [
           test_case "phase event uses workspace base_path" `Quick
             test_dispatch_keeper_phase_event_uses_workspace_base_path;
-          test_case "post-turn lifecycle events use workspace base_path" `Quick
-            test_dispatch_post_turn_lifecycle_events_uses_workspace_base_path;
-          test_case "post-turn compaction runs from failing health lane" `Quick
-            test_post_turn_compaction_runs_from_failing_health_lane;
+          test_case "compaction completion uses workspace base_path" `Quick
+            test_dispatch_compaction_completed_uses_workspace_base_path;
+          test_case "compaction runs from failing health lane" `Quick
+            test_compaction_runs_from_failing_health_lane;
           test_case "compaction completion without started is nonfatal" `Quick
             test_compaction_completion_without_started_is_nonfatal;
-          test_case "post-turn compaction restarts after done stage" `Quick
-            test_post_turn_compaction_restarts_after_done_stage;
+          test_case "compaction restarts after done stage" `Quick
+            test_compaction_restarts_after_done_stage;
           test_case "unscoped lifecycle event is rejected" `Quick
             test_dispatch_keeper_phase_event_rejects_unscoped_lifecycle_event;
           test_case "phase event rejection increments metric" `Quick
             test_dispatch_keeper_phase_event_rejection_increments_metric;
+          test_case "manual compaction preserves failed failure dispatch" `Quick
+            test_manual_compaction_preserves_failed_failure_dispatch;
           test_case "keepalive event rejection increments metric" `Quick
             test_keepalive_dispatch_event_rejection_increments_metric;
           test_case "publication recovery turn resolution is filesystem idle" `Quick

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -10,28 +10,6 @@ module Queue = Keeper_event_queue
 module Registry_queue = Masc.Keeper_registry_event_queue
 module WO = Masc.Keeper_world_observation
 
-let test_prepared_becomes_applied_only_after_save () =
-  let trigger = Compaction_trigger.Manual in
-  check bool "Prepared is not Applied" false
-    (Compact_policy.compaction_decision_applied
-       (Compact_policy.Prepared trigger));
-  (match
-     Post_turn.For_testing.commit_prepared_after_save
-       ~trigger
-       ~save:(fun () -> Error "checkpoint unavailable")
-   with
-   | Error detail -> check string "save failure preserved" "checkpoint unavailable" detail
-   | Ok _ -> fail "failed checkpoint save promoted Prepared to Applied");
-  match
-    Post_turn.For_testing.commit_prepared_after_save
-      ~trigger
-      ~save:(fun () -> Ok "durable-checkpoint")
-  with
-  | Error detail -> failf "successful checkpoint save failed: %s" detail
-  | Ok (checkpoint, Compact_policy.Applied Compaction_trigger.Manual) ->
-    check string "saved checkpoint returned" "durable-checkpoint" checkpoint
-  | Ok _ -> fail "successful checkpoint save did not produce Applied Manual"
-
 let test_compaction_rejection_tag_is_stable () =
   let error =
     Post_turn.Compaction_rejected
@@ -100,25 +78,14 @@ let test_regular_post_turn_does_not_auto_compact () =
   Eio_main.run @@ fun _env ->
   let meta = make_meta () in
   let checkpoint = make_checkpoint () in
-  let unexpected_callback () = fail "regular post-turn invoked a compaction callback" in
   let result =
     Post_turn.apply_post_turn_lifecycle_with_resilience_handles
       ~resilience_audit_store:None
       ~resilience_strategy_executor:None
-      ~on_compaction_started:unexpected_callback
-      ~on_handoff_started:unexpected_callback
-      ~base_dir:"unused"
       ~meta
-      ~model:"test-model"
       ~primary_model_max_tokens:8192
-      ~current_turn_blocker_info:None
       ~checkpoint:(Some checkpoint)
   in
-  check bool "compaction not attempted" false result.compaction.attempted;
-  check bool "compaction not applied" false result.compaction.applied;
-  (match result.compaction.decision with
-   | Compact_policy.Not_requested -> ()
-   | _ -> fail "regular post-turn returned a compaction decision");
   match result.checkpoint with
   | None -> fail "regular post-turn discarded the checkpoint"
   | Some retained ->
@@ -358,8 +325,6 @@ let test_manual_compaction_serializes_owner_lane () =
 let () =
   run "post-turn durability" [
     "durable compaction", [
-      test_case "Prepared requires a successful checkpoint save"
-        `Quick test_prepared_becomes_applied_only_after_save;
       test_case "compaction rejection tag is stable"
         `Quick test_compaction_rejection_tag_is_stable;
       test_case "regular post-turn does not auto-compact"

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -247,10 +247,6 @@ let base_receipt : R.t =
   ; extra_system_context_digest = None
   ; extra_system_context_injected_size = None
   ; extra_system_context_computed_size = None
-  ; pre_dispatch_compacted = false
-  ; pre_dispatch_compaction_trigger = None
-  ; pre_dispatch_compaction_before_tokens = None
-  ; pre_dispatch_compaction_after_tokens = None
   }
 ;;
 
@@ -797,10 +793,6 @@ let () =
     ; stop_reason
     ; inference_telemetry = None
     ; tool_surface
-    ; pre_dispatch_compacted = false
-    ; pre_dispatch_compaction_trigger = None
-    ; pre_dispatch_compaction_before_tokens = None
-    ; pre_dispatch_compaction_after_tokens = None
     }
   in
   let stale_provider_failure =

--- a/test/test_keeper_wake_telemetry.ml
+++ b/test/test_keeper_wake_telemetry.ml
@@ -215,7 +215,7 @@ let test_phase0_record_always_emits_observation () =
     Masc.Keeper_keepalive_signal.register_record_wake_payload
       (fun ~keeper_name:_ ~trace_id:_ ~turn_index:_ ~context_window:_
         ~system_prompt_bytes:_ ~tool_schema_json_bytes:_ ~message_content_bytes:_
-        ~message_count:_ ~role_counts:_ ~tool_count:_ ~has_compact_happened:_ -> ())
+        ~message_count:_ ~role_counts:_ ~tool_count:_ -> ())
   in
   Fun.protect
     ~finally:restore
@@ -223,7 +223,7 @@ let test_phase0_record_always_emits_observation () =
        Masc.Keeper_keepalive_signal.register_record_wake_payload
          (fun ~keeper_name ~trace_id:_ ~turn_index:_ ~context_window:_
            ~system_prompt_bytes ~tool_schema_json_bytes:_ ~message_content_bytes:_
-           ~message_count ~role_counts:_ ~tool_count:_ ~has_compact_happened:_ ->
+           ~message_count ~role_counts:_ ~tool_count:_ ->
             observed := Some (keeper_name, system_prompt_bytes, message_count));
        Masc.Keeper_agent_run_phase0_telemetry.record
          ~meta
@@ -233,7 +233,6 @@ let test_phase0_record_always_emits_observation () =
          ~user_message:"next"
          ~start_turn_count:3
          ~max_context:4096
-         ~pre_dispatch_compacted:false
          ();
        check
          (option (triple string int int))


### PR DESCRIPTION
## Outcome

Hard-cuts the producerless pre-dispatch and post-turn compaction product instead of replacing booleans with another inert terminal type.

- regular post-turn preserves checkpoints and owns no compaction result, callback, trigger, or FSM completion
- explicit manual/provider-overflow compaction shares one compaction_recovery success type: durable checkpoint + typed trigger + exact evidence + generation
- lifecycle failures carry a closed lifecycle_stage instead of string labels
- a rejected compensating Compaction_failed dispatch is preserved beside the primary transition error; no secondary failure is ignored
- provider-overflow retry distinguishes checkpoint-producing and pre-checkpoint failures without option plus duplicated trigger state
- keeper_compaction SSE fires only from the two real success producers, after durable save and FSM completion

## Adversarial cuts

- removed the always-false pre-dispatch compaction fields from run context, wake telemetry, agent result, execution receipt JSON, dashboard projection, and the stats script
- removed dead post-turn callback arguments, fake compaction dispatcher state, callback-recovery metric, and callback label vocabulary
- replaced fabricated lifecycle-record tests with direct tests of the production dispatch_compaction_completed boundary
- removed the test-only Result wrapper proof around checkpoint save
- renamed the shared recovery API away from overflow-only terminology because manual compaction uses the same authority
- retained both primary recovery failure and compensating lifecycle-dispatch failure in the public diagnostic

Net diff: 53 files, 316 insertions, 697 deletions.

## Evidence

- head: f5cfc485a74729fc30299f984c3502a20175593b
- base: main 3be51c2160591798fe6123e1c4f0544b5b75592c
- ocamlformat and parser checks on changed OCaml files: pass
- scripts/dune-local.sh build test/test_keeper_lifecycle_registry_dispatch.exe: pass
- focused lifecycle executable: 14/14 pass, including primary plus compensation failure preservation
- git diff --check: pass
- current-head GitHub CI: pending

## Merge condition

Code review P0/P1: 0 at the exact head above. Keep Draft and status:do-not-merge until current-head required checks complete.