### PR TITLE
feat(keeper): persist terminal no-compaction

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -375,23 +375,6 @@ let run_turn
               | Some err -> `String (Agent_sdk.Error.to_string err) );
           ]))
     Keeper_runtime_manifest.Checkpoint_loaded;
-  append_manifest ~site:"context_compacted"
-    ~keeper_turn_id:manifest_keeper_turn_id
-    ?compaction_source:
-      (if pre_dispatch_compacted then Some "pre_dispatch_hygiene" else None)
-    ~status:(if pre_dispatch_compacted then "compacted" else "skipped")
-    ~decision:
-      (Keeper_runtime_manifest.with_payload_role ~payload_role:Model_input
-        (`Assoc
-          [
-            ("pre_dispatch_compacted", `Bool pre_dispatch_compacted);
-            ( "pre_dispatch_checkpoint_error",
-              match pre_dispatch_checkpoint_error with
-              | None -> `Null
-              | Some err -> `String (Agent_sdk.Error.to_string err) );
-            ("checkpoint_path", `String checkpoint_path);
-          ]))
-    Keeper_runtime_manifest.Context_compacted;
   (* Steps 5-6: turn prompt, memory/temporal context, prompt metrics,
      and user message append — Keeper_run_prompt. *)
   let prompt_ctx =

--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -69,20 +69,19 @@ type compaction_rejection =
   | Runtime_identity_unavailable
   | Summarizer_unavailable
   | Plan_unavailable_or_invalid
-  | Structurally_unchanged
   | Checkpoint_not_reduced
 
 let compaction_rejection_to_string = function
   | Runtime_identity_unavailable -> "runtime_identity_unavailable"
   | Summarizer_unavailable -> "summarizer_unavailable"
   | Plan_unavailable_or_invalid -> "plan_unavailable_or_invalid"
-  | Structurally_unchanged -> "structurally_unchanged"
   | Checkpoint_not_reduced -> "checkpoint_not_reduced"
 ;;
 
 type compaction_decision =
   | Applied of Compaction_trigger.t
   | Prepared of Compaction_trigger.t
+  | No_compaction of Compaction_trigger.t
   | Rejected of Compaction_trigger.t * compaction_rejection
   | Not_requested
   | Skipped_no_checkpoint
@@ -125,6 +124,7 @@ type compaction_preparation =
 let compaction_decision_to_string = function
   | Applied trigger -> "applied:" ^ Compaction_trigger.to_human trigger
   | Prepared trigger -> "prepared:" ^ Compaction_trigger.to_human trigger
+  | No_compaction trigger -> "no_compaction:" ^ Compaction_trigger.to_human trigger
   | Rejected (trigger, reason) ->
     Printf.sprintf
       "rejected:%s:%s"
@@ -136,12 +136,14 @@ let compaction_decision_to_string = function
 
 let compaction_decision_prepared = function
   | Prepared _ -> true
-  | Applied _ | Rejected _ | Not_requested | Skipped_no_checkpoint -> false
+  | Applied _ | No_compaction _ | Rejected _ | Not_requested
+  | Skipped_no_checkpoint -> false
 ;;
 
 let compaction_decision_applied = function
   | Applied _ -> true
-  | Prepared _ | Rejected _ | Not_requested | Skipped_no_checkpoint -> false
+  | Prepared _ | No_compaction _ | Rejected _ | Not_requested
+  | Skipped_no_checkpoint -> false
 ;;
 
 let compaction_policy_of_keeper (meta : keeper_meta) : float * int * int =
@@ -201,11 +203,13 @@ let record_pre_compact
 ;;
 
 type requested_compaction =
-  { messages : Agent_sdk.Types.message list
-  ; selected_runtime_id : string option
-  ; summarized_message_count : int
-  ; dropped_message_count : int
-  }
+  | Requested_plan of
+      { messages : Agent_sdk.Types.message list
+      ; selected_runtime_id : string option
+      ; summarized_message_count : int
+      ; dropped_message_count : int
+      }
+  | Requested_no_compaction of { selected_runtime_id : string option }
 
 let requested_messages (meta : keeper_meta) messages =
   let runtime_id =
@@ -232,14 +236,18 @@ let requested_messages (meta : keeper_meta) messages =
         | None -> Error Plan_unavailable_or_invalid
         | Some plan ->
           if plan.summarized = [] && plan.dropped = []
-          then Error Structurally_unchanged
+          then
+            Ok
+              (Requested_no_compaction
+                 { selected_runtime_id = plan.selected_runtime_id })
           else
             Ok
-              { messages = Keeper_compaction_llm_summarizer.apply plan ~messages
-              ; selected_runtime_id = plan.selected_runtime_id
-              ; summarized_message_count = List.length plan.summarized
-              ; dropped_message_count = List.length plan.dropped
-              }))
+              (Requested_plan
+                 { messages = Keeper_compaction_llm_summarizer.apply plan ~messages
+                 ; selected_runtime_id = plan.selected_runtime_id
+                 ; summarized_message_count = List.length plan.summarized
+                 ; dropped_message_count = List.length plan.dropped
+                 })))
 ;;
 
 let tool_block_counts messages =
@@ -311,7 +319,28 @@ let compact_for_request_typed
       ~checkpoint_bytes:before_bytes
       ~message_count:before_messages;
     { context = ctx; decision = Rejected (trigger, reason); evidence = None }
-  | Ok requested ->
+  | Ok (Requested_no_compaction { selected_runtime_id }) ->
+    let before_tool_use_count, before_tool_result_count =
+      tool_block_counts (messages_of_context ctx)
+    in
+    { context = ctx
+    ; decision = No_compaction trigger
+    ; evidence =
+        Some
+          { selected_runtime_id
+          ; before_checkpoint_bytes = before_bytes
+          ; after_checkpoint_bytes = before_bytes
+          ; before_message_count = before_messages
+          ; after_message_count = before_messages
+          ; summarized_message_count = 0
+          ; dropped_message_count = 0
+          ; before_tool_use_count
+          ; after_tool_use_count = before_tool_use_count
+          ; before_tool_result_count
+          ; after_tool_result_count = before_tool_result_count
+          }
+    }
+  | Ok (Requested_plan requested) ->
     let messages, pair_repair_stats =
       Keeper_context_core.repair_broken_tool_call_pairs_with_stats requested.messages
     in
@@ -329,9 +358,7 @@ let compact_for_request_typed
         ~message_count:before_messages;
       { context = ctx; decision = Rejected (trigger, reason); evidence = None }
     in
-    if after_bytes = before_bytes
-    then reject Structurally_unchanged
-    else if after_bytes > before_bytes
+    if after_bytes >= before_bytes
     then reject Checkpoint_not_reduced
     else (
       let after_messages = message_count compacted_ctx in

--- a/lib/keeper/keeper_compact_policy.mli
+++ b/lib/keeper/keeper_compact_policy.mli
@@ -7,13 +7,15 @@ type compaction_rejection =
   | Runtime_identity_unavailable
   | Summarizer_unavailable
   | Plan_unavailable_or_invalid
-  | Structurally_unchanged
   | Checkpoint_not_reduced
 
-(** [Prepared] is structural only; [Applied] requires a durable save. *)
+(** [Prepared] is structural only; [Applied] requires a durable save.
+    [No_compaction] is the LLM's terminal decision to preserve the exact
+    checkpoint, so it requires no replacement checkpoint. *)
 type compaction_decision =
   | Applied of Compaction_trigger.t
   | Prepared of Compaction_trigger.t
+  | No_compaction of Compaction_trigger.t
   | Rejected of Compaction_trigger.t * compaction_rejection
   | Not_requested
   | Skipped_no_checkpoint

--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -152,11 +152,6 @@ let plan_of_json ~message_count json =
   in
   let* () = validate_partition ~message_count ~kept ~summarized ~dropped in
   let* () = validate_non_empty_output ~message_count ~kept ~summarized in
-  let* () =
-    if summarized = [] && dropped = []
-    then Error "plan keeps every message without summarizing or dropping any"
-    else Ok ()
-  in
   Ok { summary; kept; summarized; dropped; selected_runtime_id = None }
 
 (* Marker prefix so the folded summary is recognizable in the transcript and

--- a/lib/keeper/keeper_compaction_llm_summarizer.mli
+++ b/lib/keeper/keeper_compaction_llm_summarizer.mli
@@ -6,8 +6,8 @@
     index in [kept]/[summarized]/[dropped] is in [\[0, n)], the three sets are
     pairwise disjoint, and together they cover every index exactly once. For
     non-empty inputs, at least one [kept] or [summarized] index is required so
-    applying the plan cannot erase the entire working set. At least one
-    [summarized] or [dropped] index is required, so all-kept no-ops are invalid. *)
+    applying the plan cannot erase the entire working set. An all-kept plan is
+    a valid terminal no-compaction judgment. *)
 type compaction_plan = private
   { summary : string
   ; kept : int list

--- a/lib/keeper/keeper_context_runtime.ml
+++ b/lib/keeper/keeper_context_runtime.ml
@@ -84,11 +84,16 @@ let compaction_decision_prepared =
 (* Re-export from Keeper_post_turn                                   *)
 (* ================================================================ *)
 
+type compaction_outcome = Keeper_post_turn.compaction_outcome =
+  | Not_attempted
+  | Applied_checkpoint
+  | Failed_compaction of string option
+
+let compaction_outcome_to_string = Keeper_post_turn.compaction_outcome_to_string
+
 type compaction_event = Keeper_post_turn.compaction_event = {
-  attempted : bool;
-  applied : bool;
+  outcome : compaction_outcome;
   started_dispatched : bool;
-  failure_reason : string option;
   trigger : Compaction_trigger.t option;
   decision : Keeper_compact_policy.compaction_decision;
 }
@@ -240,8 +245,8 @@ let dispatch_post_turn_lifecycle_events
     ~(config : Workspace.config)
     ~keeper_name
     (lifecycle : post_turn_lifecycle) =
-  if lifecycle.compaction.attempted then
-    if lifecycle.compaction.applied then begin
+  (match lifecycle.compaction.outcome with
+   | Applied_checkpoint ->
       (* FSM boundary: compaction_stage must be Compaction_compacting
          before we dispatch Compaction_completed.  If the
          on_compaction_started callback succeeded (started_dispatched =
@@ -269,20 +274,17 @@ let dispatch_post_turn_lifecycle_events
         ~origin:Keeper_registry.Post_turn_lifecycle
         ~keeper_name
       |> ignore
-    end
-    else
-      dispatch_keeper_phase_event
-        ~config
-        ~origin:Keeper_registry.Post_turn_lifecycle
-        ~keeper_name
-        (Keeper_state_machine.Compaction_failed
-           {
-             reason =
-               Option.value lifecycle.compaction.failure_reason
-                 ~default:
-                   (compaction_decision_to_string
-                      lifecycle.compaction.decision);
-           });
+   | Failed_compaction failure_reason ->
+     dispatch_keeper_phase_event
+       ~config
+       ~origin:Keeper_registry.Post_turn_lifecycle
+       ~keeper_name
+       (Keeper_state_machine.Compaction_failed
+          { reason =
+              Option.value failure_reason
+                ~default:(compaction_decision_to_string lifecycle.compaction.decision)
+          })
+   | Not_attempted -> ());
   match lifecycle.handoff_attempted, lifecycle.handoff_json with
   | true, Some _json ->
       dispatch_keeper_phase_event

--- a/lib/keeper/keeper_context_runtime.ml
+++ b/lib/keeper/keeper_context_runtime.ml
@@ -66,6 +66,7 @@ let compaction_policy_of_keeper = Keeper_compact_policy.compaction_policy_of_kee
 type compaction_decision = Keeper_compact_policy.compaction_decision =
   | Applied of Compaction_trigger.t
   | Prepared of Compaction_trigger.t
+  | No_compaction of Compaction_trigger.t
   | Rejected of Compaction_trigger.t * Keeper_compact_policy.compaction_rejection
   | Not_requested
   | Skipped_no_checkpoint
@@ -87,6 +88,7 @@ let compaction_decision_prepared =
 type compaction_outcome = Keeper_post_turn.compaction_outcome =
   | Not_attempted
   | Applied_checkpoint
+  | No_checkpoint_change
   | Failed_compaction of string option
 
 let compaction_outcome_to_string = Keeper_post_turn.compaction_outcome_to_string
@@ -246,7 +248,7 @@ let dispatch_post_turn_lifecycle_events
     ~keeper_name
     (lifecycle : post_turn_lifecycle) =
   (match lifecycle.compaction.outcome with
-   | Applied_checkpoint ->
+   | Applied_checkpoint | No_checkpoint_change ->
       (* FSM boundary: compaction_stage must be Compaction_compacting
          before we dispatch Compaction_completed.  If the
          on_compaction_started callback succeeded (started_dispatched =

--- a/lib/keeper/keeper_context_runtime.mli
+++ b/lib/keeper/keeper_context_runtime.mli
@@ -74,11 +74,16 @@ val save_oas_checkpoint
   -> generation:int
   -> (Agent_sdk.Checkpoint.t, string) result
 
+type compaction_outcome = Keeper_post_turn.compaction_outcome =
+  | Not_attempted
+  | Applied_checkpoint
+  | Failed_compaction of string option
+
+val compaction_outcome_to_string : compaction_outcome -> string
+
 type compaction_event =
-  { attempted : bool
-  ; applied : bool
+  { outcome : compaction_outcome
   ; started_dispatched : bool
-  ; failure_reason : string option
   ; trigger : Compaction_trigger.t option
   ; decision : Keeper_compact_policy.compaction_decision
   }

--- a/lib/keeper/keeper_context_runtime.mli
+++ b/lib/keeper/keeper_context_runtime.mli
@@ -77,6 +77,7 @@ val save_oas_checkpoint
 type compaction_outcome = Keeper_post_turn.compaction_outcome =
   | Not_attempted
   | Applied_checkpoint
+  | No_checkpoint_change
   | Failed_compaction of string option
 
 val compaction_outcome_to_string : compaction_outcome -> string
@@ -135,6 +136,7 @@ val compaction_policy_of_keeper : keeper_meta -> float * int * int
 type compaction_decision = Keeper_compact_policy.compaction_decision =
   | Applied of Compaction_trigger.t
   | Prepared of Compaction_trigger.t
+  | No_compaction of Compaction_trigger.t
   | Rejected of Compaction_trigger.t * Keeper_compact_policy.compaction_rejection
   | Not_requested
   | Skipped_no_checkpoint

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -322,7 +322,7 @@ let settlement_of_cycle_outcome ~base_path ~settled_at ~stop_requested ~lease ou
          Keeper_registry_event_queue.Approval_grant_state_unavailable)
   | None ->
     (match outcome with
-  | Some (Cycle.Manual_compaction_applied _ as applied) ->
+  | Some (Cycle.Manual_compaction_completed _ as applied) ->
     (match Cycle.manual_compaction_followup_failure applied with
      | Some
          ({ Keeper_unified_turn.source_lease_disposition =
@@ -485,7 +485,7 @@ let run_keepalive_unified_turn
           | Cycle.Busy _
           | Cycle.Judgment_settled _
           | Cycle.Manual_compaction_failed _
-          | Cycle.Manual_compaction_applied _ )
+          | Cycle.Manual_compaction_completed _ )
       | None ->
         record_crashed_cycle_failure
           ~base_path:ctx.config.base_path
@@ -800,7 +800,7 @@ let run_keepalive_unified_turn
           | Some (Cycle.Manual_compaction_failed _) ->
             record_settlement_failure
               "manual compaction failed without an owning event queue lease"
-          | Some (Cycle.Manual_compaction_applied _) ->
+          | Some (Cycle.Manual_compaction_completed _) ->
             record_settlement_failure
               "manual compaction completed without an owning event queue lease"
           | Some

--- a/lib/keeper/keeper_heartbeat_loop_cycle.ml
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.ml
@@ -55,7 +55,7 @@ type cycle_outcome =
       { meta : keeper_meta
       ; failure : Keeper_manual_compaction.failure
       }
-  | Manual_compaction_applied of cycle_outcome
+  | Manual_compaction_completed of cycle_outcome
 
 and failure_judgment_terminal =
   | Judgment_boundary_failed of { detail : string }
@@ -73,24 +73,24 @@ let rec meta = function
   | Judgment_settled { meta; _ }
   | Manual_compaction_failed { meta; _ } ->
     meta
-  | Manual_compaction_applied outcome -> meta outcome
+  | Manual_compaction_completed outcome -> meta outcome
 ;;
 
 let rec turn_failure = function
   | Failed { failure; _ } -> Some failure
-  | Manual_compaction_applied outcome -> turn_failure outcome
+  | Manual_compaction_completed outcome -> turn_failure outcome
   | Completed _ | Cancelled _ | Skipped _ | Busy _
   | Judgment_settled _ | Manual_compaction_failed _ -> None
 ;;
 
 let manual_compaction_followup_failure = function
-  | Manual_compaction_applied outcome -> turn_failure outcome
+  | Manual_compaction_completed outcome -> turn_failure outcome
   | Completed _ | Cancelled _ | Skipped _ | Failed _ | Busy _
   | Judgment_settled _ | Manual_compaction_failed _ -> None
 ;;
 
-let with_manual_compaction applied outcome =
-  if applied then Manual_compaction_applied outcome else outcome
+let with_manual_compaction completed outcome =
+  if completed then Manual_compaction_completed outcome else outcome
 ;;
 
 let record_failure_judgment_outcome
@@ -242,7 +242,7 @@ let run_keeper_cycle_admitted
       match prepared with
       | `Compaction_failed failure -> `Compaction_failed failure
       | `Settle outcome -> `Judgment outcome
-      | `Run (observation, manual_compaction_applied) ->
+      | `Run (observation, manual_compaction_completed) ->
         `Turn
           ( Keeper_unified_turn.run_keeper_cycle
               ~config:ctx.config
@@ -260,7 +260,7 @@ let run_keeper_cycle_admitted
               ~shared_context
               ?event_bus
               ()
-          , manual_compaction_applied ))
+          , manual_compaction_completed ))
   in
   match admitted_execution with
   | `Compaction_failed failure ->
@@ -270,7 +270,7 @@ let run_keeper_cycle_admitted
       (Keeper_manual_compaction.failure_to_string failure);
     Manual_compaction_failed { meta = meta_after_triage; failure }
   | `Judgment outcome -> Judgment_settled { meta = meta_after_triage; outcome }
-  | `Turn (Error failure, manual_compaction_applied) ->
+  | `Turn (Error failure, manual_compaction_completed) ->
     let err = failure.Keeper_unified_turn.error in
     let e_str = Agent_sdk.Error.to_string err in
     Log.Keeper.debug "%s: keeper cycle failed: %s" meta_after_triage.name e_str;
@@ -324,13 +324,13 @@ let run_keeper_cycle_admitted
           ();
         meta_after_triage
     in
-    with_manual_compaction manual_compaction_applied (Failed { meta; failure })
-  | `Turn (Ok (Keeper_unified_turn.Turn_completed updated), applied) ->
-    with_manual_compaction applied (Completed updated)
-  | `Turn (Ok (Keeper_unified_turn.Turn_cancelled meta), applied) ->
-    with_manual_compaction applied (Cancelled meta)
-  | `Turn (Ok (Keeper_unified_turn.Turn_skipped meta), applied) ->
-    with_manual_compaction applied (Skipped meta)
+    with_manual_compaction manual_compaction_completed (Failed { meta; failure })
+  | `Turn (Ok (Keeper_unified_turn.Turn_completed updated), completed) ->
+    with_manual_compaction completed (Completed updated)
+  | `Turn (Ok (Keeper_unified_turn.Turn_cancelled meta), completed) ->
+    with_manual_compaction completed (Cancelled meta)
+  | `Turn (Ok (Keeper_unified_turn.Turn_skipped meta), completed) ->
+    with_manual_compaction completed (Skipped meta)
 ;;
 
 let run_keeper_cycle

--- a/lib/keeper/keeper_heartbeat_loop_cycle.mli
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.mli
@@ -20,7 +20,7 @@ type cycle_outcome =
       { meta : Keeper_meta_contract.keeper_meta
       ; failure : Keeper_manual_compaction.failure
       }
-  | Manual_compaction_applied of cycle_outcome
+  | Manual_compaction_completed of cycle_outcome
 
 and failure_judgment_terminal =
   | Judgment_boundary_failed of { detail : string }
@@ -38,9 +38,9 @@ val meta : cycle_outcome -> Keeper_meta_contract.keeper_meta
 val manual_compaction_followup_failure
   :  cycle_outcome
   -> Keeper_unified_turn.turn_failure option
-(** The following-turn failure only when manual compaction already committed.
-    Queue settlement uses this projection to preserve an LLM judgment
-    successor without replaying the completed compaction transaction. *)
+(** The following-turn failure only after the manual compaction request reached
+    a terminal decision. Queue settlement uses this projection without
+    replaying the completed compaction request. *)
 
 val run_keeper_cycle
   :  ?event_bus:Agent_sdk.Event_bus.t

--- a/lib/keeper/keeper_manual_compaction.ml
+++ b/lib/keeper/keeper_manual_compaction.ml
@@ -13,10 +13,25 @@ let primary_max_context meta =
   let resolution = Keeper_context_runtime.resolve_max_context_resolution_of_meta meta in
   max min_context resolution.effective_budget
 ;;
+
+let manifest_event = function
+  | Keeper_compact_policy.Applied _ ->
+    Ok (Keeper_runtime_manifest.Context_compacted, "compacted")
+  | Keeper_compact_policy.No_compaction _ ->
+    Ok (Keeper_runtime_manifest.Context_compaction_noop, "no_compaction")
+  | decision ->
+    Error
+      ("manual compaction recovered unexpected decision: "
+       ^ Keeper_compact_policy.compaction_decision_to_string decision)
+;;
+
 let append_manifest ~config ~base_dir ~(meta : keeper_meta) recovery =
   match recovery.Keeper_context_runtime.compaction.trigger with
   | None -> Error "manual compaction completed without its typed trigger"
   | Some trigger ->
+    (match manifest_event recovery.compaction.decision with
+     | Error _ as error -> error
+     | Ok (event, status) ->
     let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
     let context : Keeper_runtime_manifest.turn_context =
       { manifest_keeper_name = meta.name
@@ -34,15 +49,15 @@ let append_manifest ~config ~base_dir ~(meta : keeper_meta) recovery =
     let clock_refs =
       Keeper_runtime_manifest.clock_refs_for_context
         context
-        ~event:Keeper_runtime_manifest.Context_compacted
+        ~event
         ~compaction_source:"operator_manual"
         ()
     in
     Keeper_runtime_manifest.make_for_context
       context
-      ~event:Keeper_runtime_manifest.Context_compacted
+      ~event
       ?runtime_id:recovery.evidence.selected_runtime_id
-      ~status:"compacted"
+      ~status
       ~decision:
         (Keeper_runtime_manifest.with_clock_refs
            ~clock_refs
@@ -57,6 +72,7 @@ let append_manifest ~config ~base_dir ~(meta : keeper_meta) recovery =
       ~checkpoint_path
       ()
     |> Keeper_runtime_manifest.append config
+    )
 ;;
 let run ~(config : Workspace.config) ~(meta : keeper_meta) =
   let dispatch stage event =

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -40,9 +40,18 @@ open Keeper_meta_contract
 open Keeper_types_profile
 open Keeper_context_core
 
+type compaction_outcome =
+  | Not_attempted
+  | Applied_checkpoint
+  | Failed_compaction of string option
+
+let compaction_outcome_to_string = function
+  | Not_attempted -> "not_attempted"
+  | Applied_checkpoint -> "applied_checkpoint"
+  | Failed_compaction _ -> "failed"
+
 type compaction_event = {
-  attempted : bool;
-  applied : bool;
+  outcome : compaction_outcome;
   (** [started_dispatched] is [true] when the [on_compaction_started] callback
       successfully dispatched [Compaction_started] to the registry, placing the
       FSM in [Compaction_compacting].  When [false] (callback failed, skipped,
@@ -51,7 +60,6 @@ type compaction_event = {
       before [Compaction_completed] to avoid the forbidden
       accumulating -> done transition. *)
   started_dispatched : bool;
-  failure_reason : string option;
   trigger : Compaction_trigger.t option;
   decision : Keeper_compact_policy.compaction_decision;
 }
@@ -188,9 +196,10 @@ let apply_resilience_wirein
           let maybe_error =
             (* First non-None error signal from this turn's
                compaction or handoff steps. *)
-            match lifecycle.compaction.failure_reason with
-            | Some _ as r -> r
-            | None -> lifecycle.handoff_failure_reason
+            match lifecycle.compaction.outcome with
+            | Failed_compaction (Some _ as reason) -> reason
+            | Not_attempted | Applied_checkpoint | Failed_compaction None ->
+              lifecycle.handoff_failure_reason
           in
           let witness = Resilience.Keeper_bridge.running_witness in
           let outcome =
@@ -405,10 +414,8 @@ let apply_post_turn_lifecycle_with_resilience_handles
         handoff_failure_reason = None;
         compaction =
           {
-            attempted = false;
-            applied = false;
+            outcome = Not_attempted;
             started_dispatched = false;
-            failure_reason = None;
             trigger = None;
             decision = no_checkpoint_decision;
         };
@@ -458,10 +465,8 @@ let apply_post_turn_lifecycle_with_resilience_handles
         handoff_failure_reason = None;
         compaction =
           {
-            attempted = false;
-            applied = false;
+            outcome = Not_attempted;
             started_dispatched = false;
-            failure_reason = None;
             trigger = None;
             decision;
         };
@@ -575,10 +580,8 @@ let recover_latest_checkpoint_for_overflow_retry
             Ok
               { checkpoint = saved_checkpoint
               ; compaction =
-                  { attempted = true
-                  ; applied = true
+                  { outcome = Applied_checkpoint
                   ; started_dispatched = false
-                  ; failure_reason = None
                   ; trigger = Some prepared_trigger
                   ; decision
                   }

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -43,11 +43,13 @@ open Keeper_context_core
 type compaction_outcome =
   | Not_attempted
   | Applied_checkpoint
+  | No_checkpoint_change
   | Failed_compaction of string option
 
 let compaction_outcome_to_string = function
   | Not_attempted -> "not_attempted"
   | Applied_checkpoint -> "applied_checkpoint"
+  | No_checkpoint_change -> "no_checkpoint_change"
   | Failed_compaction _ -> "failed"
 
 type compaction_event = {
@@ -198,7 +200,10 @@ let apply_resilience_wirein
                compaction or handoff steps. *)
             match lifecycle.compaction.outcome with
             | Failed_compaction (Some _ as reason) -> reason
-            | Not_attempted | Applied_checkpoint | Failed_compaction None ->
+            | Not_attempted
+            | Applied_checkpoint
+            | No_checkpoint_change
+            | Failed_compaction None ->
               lifecycle.handoff_failure_reason
           in
           let witness = Resilience.Keeper_bridge.running_witness in
@@ -557,6 +562,20 @@ let recover_latest_checkpoint_for_overflow_retry
     (match preparation.decision, preparation.evidence with
      | Keeper_compact_policy.Prepared _, None ->
        Error Compaction_evidence_missing
+     | Keeper_compact_policy.No_compaction _, None ->
+       Error Compaction_evidence_missing
+     | Keeper_compact_policy.No_compaction no_compaction_trigger, Some evidence ->
+       Ok
+         { checkpoint
+         ; compaction =
+             { outcome = No_checkpoint_change
+             ; started_dispatched = false
+             ; trigger = Some no_compaction_trigger
+             ; decision = Keeper_compact_policy.No_compaction no_compaction_trigger
+             }
+         ; evidence
+         ; turn_generation
+         }
      | Keeper_compact_policy.Prepared prepared_trigger, Some evidence ->
        (try
           match

--- a/lib/keeper/keeper_post_turn.mli
+++ b/lib/keeper/keeper_post_turn.mli
@@ -12,17 +12,22 @@
 
     Extracted from Keeper_context_runtime as part of #4955 god-file split. *)
 
-(** Outcome of the compaction step. [applied] iff an explicit compaction
-    request ran. *)
+type compaction_outcome =
+  | Not_attempted
+  | Applied_checkpoint
+  | Failed_compaction of string option
+
+val compaction_outcome_to_string : compaction_outcome -> string
+
+(** Typed outcome of the compaction step; invalid bool combinations are not
+    representable. *)
 type compaction_event =
-  { attempted : bool
-  ; applied : bool
+  { outcome : compaction_outcome
   ; started_dispatched : bool
         (** [true] when [on_compaction_started] completed without raising,
             meaning the FSM is at [Compaction_compacting].  [false] when
             the callback failed or was never called (recovery path), so
             the FSM is still at [Compaction_accumulating]. *)
-  ; failure_reason : string option
   ; trigger : Compaction_trigger.t option
   ; decision : Keeper_compact_policy.compaction_decision
   }

--- a/lib/keeper/keeper_post_turn.mli
+++ b/lib/keeper/keeper_post_turn.mli
@@ -15,6 +15,7 @@
 type compaction_outcome =
   | Not_attempted
   | Applied_checkpoint
+  | No_checkpoint_change
   | Failed_compaction of string option
 
 val compaction_outcome_to_string : compaction_outcome -> string
@@ -113,10 +114,10 @@ val apply_post_turn_lifecycle_with_resilience_handles :
     verification.  Callers own serialization; the typical pattern
     is one store per keeper, owned by the keeper bridge. *)
 
-(** Reload the canonical OAS checkpoint and apply an explicit typed
-    compaction request. Returns a durably saved [Applied] checkpoint only for a
-    structurally changed [Prepared] candidate; every other outcome is a typed
-    [Error]. *)
+(** Reload the canonical OAS checkpoint and apply an explicit typed compaction
+    request. A changed [Prepared] candidate is saved before returning [Applied].
+    An LLM [No_compaction] decision returns the unchanged durable checkpoint as
+    the successful terminal [No_checkpoint_change] outcome. *)
 val recover_latest_checkpoint_for_overflow_retry :
   base_dir:string ->
   meta:Keeper_meta_contract.keeper_meta ->

--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -51,7 +51,8 @@ let source_clock_of_event = function
   | Provider_attempt_finished ->
     Provider
   | Context_injected
-  | Context_compacted ->
+  | Context_compacted
+  | Context_compaction_noop ->
     Logical
   | _ -> Wall
 
@@ -224,6 +225,7 @@ let clock_lane_of_event = function
     "oas_agent"
   | Context_injected
   | Context_compacted
+  | Context_compaction_noop
   | Event_bus_correlated ->
     "memory_context"
 
@@ -270,7 +272,8 @@ let clock_refs_for_context ctx ~event ?oas_turn_count ?elapsed_ms
   in
   let compaction_id =
     match event with
-    | Context_compacted ->
+    | Context_compacted
+    | Context_compaction_noop ->
       Some (context_compaction_id ctx ~source:(Option.value ~default:"pre_dispatch" compaction_source))
     | Event_bus_correlated ->
       Some (context_compaction_id ctx ~source:(Option.value ~default:"event_bus" compaction_source))

--- a/lib/keeper/keeper_runtime_manifest_housekeeping.ml
+++ b/lib/keeper/keeper_runtime_manifest_housekeeping.ml
@@ -86,7 +86,8 @@ let mandatory_clock_refs_for_event = function
     [ "edge_id"; "lane"; "provider_attempt_id"; "elapsed_ms" ]
   | Provider_lane_resolved ->
     [ "edge_id"; "lane"; "tool_batch_id" ]
-  | Context_compacted ->
+  | Context_compacted
+  | Context_compaction_noop ->
     [ "edge_id"; "lane"; "compaction_id"; "compaction_source" ]
   | Checkpoint_saved ->
     [ "edge_id"; "lane"; "checkpoint_id" ]

--- a/lib/keeper/keeper_runtime_manifest_housekeeping.mli
+++ b/lib/keeper/keeper_runtime_manifest_housekeeping.mli
@@ -12,6 +12,7 @@ type event_kind =
   | Provider_attempt_finished
   | Context_injected
   | Context_compacted
+  | Context_compaction_noop
   | Event_bus_correlated
   | Checkpoint_loaded
   | Checkpoint_saved

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -97,7 +97,6 @@ let compaction_recovery_error_data ?dispatch_error error =
     | Keeper_post_turn.Checkpoint_load_failed
         Keeper_checkpoint_store.Not_found -> Not_found
     | Compaction_rejected Runtime_identity_unavailable
-    | Compaction_rejected Structurally_unchanged
     | Compaction_rejected Checkpoint_not_reduced ->
       Precondition_failed
     | Compaction_rejected Summarizer_unavailable

--- a/lib/keeper/keeper_unified_metrics_broadcast.ml
+++ b/lib/keeper/keeper_unified_metrics_broadcast.ml
@@ -14,7 +14,11 @@ let broadcast_lifecycle_events ~(name : string)
     ~(compaction : Keeper_context_runtime.compaction_event)
     ~(handoff_json : Yojson.Safe.t option) : unit =
   let now_ts = Time_compat.now () in
-  (if compaction.applied then
+  (if
+     match compaction.outcome with
+     | Applied_checkpoint -> true
+     | Not_attempted | Failed_compaction _ -> false
+   then
      try
        Sse.broadcast
          (`Assoc
@@ -22,6 +26,10 @@ let broadcast_lifecycle_events ~(name : string)
              ("type", `String "keeper_compaction");
              ("name", `String name);
              ("generation", `Int turn_generation);
+             ( "outcome",
+               `String
+                 (Keeper_context_runtime.compaction_outcome_to_string
+                    compaction.outcome) );
              ( "trigger",
                match compaction.trigger with
                | Some trigger -> `String (Compaction_trigger.to_label trigger)

--- a/lib/keeper/keeper_unified_metrics_broadcast.ml
+++ b/lib/keeper/keeper_unified_metrics_broadcast.ml
@@ -16,7 +16,7 @@ let broadcast_lifecycle_events ~(name : string)
   let now_ts = Time_compat.now () in
   (if
      match compaction.outcome with
-     | Applied_checkpoint -> true
+     | Applied_checkpoint | No_checkpoint_change -> true
      | Not_attempted | Failed_compaction _ -> false
    then
      try

--- a/lib/keeper/keeper_unified_metrics_snapshot.ml
+++ b/lib/keeper/keeper_unified_metrics_snapshot.ml
@@ -118,7 +118,7 @@ let append_metrics_snapshot ~(config : Workspace.config) ~(meta : keeper_meta)
           `Bool
             (match compaction.outcome with
              | Applied_checkpoint -> true
-             | Not_attempted | Failed_compaction _ -> false) );
+             | Not_attempted | No_checkpoint_change | Failed_compaction _ -> false) );
         ( "compaction_outcome",
           `String
             (Keeper_context_runtime.compaction_outcome_to_string

--- a/lib/keeper/keeper_unified_metrics_snapshot.ml
+++ b/lib/keeper/keeper_unified_metrics_snapshot.ml
@@ -114,7 +114,15 @@ let append_metrics_snapshot ~(config : Workspace.config) ~(meta : keeper_meta)
         ("checkpoint_bytes", `Int checkpoint_bytes);
         ("message_count", `Int message_count);
         ("continuity_state", `Null);
-        ("compacted", `Bool compaction.applied);
+        ( "compacted",
+          `Bool
+            (match compaction.outcome with
+             | Applied_checkpoint -> true
+             | Not_attempted | Failed_compaction _ -> false) );
+        ( "compaction_outcome",
+          `String
+            (Keeper_context_runtime.compaction_outcome_to_string
+               compaction.outcome) );
         ("compaction_trigger",
           match compaction.trigger with
           | Some trigger -> `String (Compaction_trigger.to_label trigger)

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -24,6 +24,18 @@ type source_lease_disposition =
   | Requeue_after_context_compaction
   | Acknowledge_after_in_turn_handling
 
+let provider_overflow_manifest_projection = function
+  | Keeper_context_runtime.Applied_checkpoint ->
+    Keeper_runtime_manifest.Context_compacted,
+    true,
+    Requeue_after_context_compaction
+  | Keeper_context_runtime.No_checkpoint_change ->
+    Keeper_runtime_manifest.Context_compaction_noop, false, Follow_failure_route
+  | Keeper_context_runtime.Not_attempted
+  | Keeper_context_runtime.Failed_compaction _ ->
+    Keeper_runtime_manifest.Runtime_failed, false, Follow_failure_route
+;;
+
 type turn_failure =
   { error : Agent_sdk.Error.sdk_error
   ; runtime_id : string
@@ -129,6 +141,10 @@ type provider_overflow_recovery =
       { trigger : Compaction_trigger.t
       ; recovery : Keeper_context_runtime.overflow_retry_recovery
       }
+  | Provider_overflow_no_compaction of
+      { trigger : Compaction_trigger.t
+      ; recovery : Keeper_context_runtime.overflow_retry_recovery
+      }
   | Provider_overflow_retry of
       { trigger : Compaction_trigger.t
       ; reason : string
@@ -218,6 +234,11 @@ let recover_provider_context_overflow_in_lane
                        ~keeper_name:meta.name
                        "provider overflow compaction committed; source stimulus will be requeued";
                      Provider_overflow_applied { trigger; recovery }
+                   | Keeper_context_runtime.No_checkpoint_change ->
+                     Log.Keeper.info
+                       ~keeper_name:meta.name
+                       "provider overflow compaction completed without a context change";
+                     Provider_overflow_no_compaction { trigger; recovery }
                    | Keeper_context_runtime.Not_attempted
                    | Keeper_context_runtime.Failed_compaction _ ->
                      retry_after_started
@@ -255,8 +276,17 @@ let append_provider_overflow_manifest
       ~base_dir
       outcome
   =
-  let append_recovery ~status ~error ~trigger ~recovery turn_state =
+  let append_recovery
+        ~status
+        ~error
+        ~trigger
+        ~recovery
+        turn_state
+    =
     let evidence = recovery.evidence in
+    let event, source_requeued, disposition =
+      provider_overflow_manifest_projection recovery.compaction.outcome
+    in
     let session_id = recovery.checkpoint.session_id in
     let checkpoint_path =
       Keeper_checkpoint_store.oas_checkpoint_path
@@ -280,19 +310,19 @@ let append_provider_overflow_manifest
              (`Assoc
                [ "trigger", `String (Compaction_trigger.to_label trigger)
                ; "trigger_detail", Compaction_trigger.to_detail_json trigger
-               ; "source_requeued", `Bool true
+               ; "source_requeued", `Bool source_requeued
                ; "error", error
                ; ( "exact_evidence"
                  , Keeper_compact_policy.compaction_evidence_to_json evidence )
                ]))
-        Keeper_runtime_manifest.Context_compacted
+        event
     in
-    turn_state
+    disposition, turn_state
   in
   match outcome with
   | Not_provider_overflow -> Follow_failure_route, turn_state
   | Provider_overflow_applied { trigger; recovery } ->
-    let turn_state =
+    let disposition, turn_state =
       append_recovery
         ~status:"compacted"
         ~error:`Null
@@ -300,9 +330,19 @@ let append_provider_overflow_manifest
         ~recovery
         turn_state
     in
-    Requeue_after_context_compaction, turn_state
+    disposition, turn_state
+  | Provider_overflow_no_compaction { trigger; recovery } ->
+    let disposition, turn_state =
+      append_recovery
+        ~status:"no_compaction"
+        ~error:`Null
+        ~trigger
+        ~recovery
+        turn_state
+    in
+    disposition, turn_state
   | Provider_overflow_retry { trigger; reason; recovery = Some recovery } ->
-    let turn_state =
+    let disposition, turn_state =
       append_recovery
         ~status:"retryable_failure"
         ~error:(`String reason)
@@ -310,7 +350,7 @@ let append_provider_overflow_manifest
         ~recovery
         turn_state
     in
-    Requeue_after_context_compaction, turn_state
+    disposition, turn_state
   | Provider_overflow_retry { trigger; reason; recovery = None } ->
     let turn_state =
       Keeper_unified_turn_manifest.append_manifest
@@ -327,12 +367,12 @@ let append_provider_overflow_manifest
              (`Assoc
                [ "trigger", `String (Compaction_trigger.to_label trigger)
                ; "trigger_detail", Compaction_trigger.to_detail_json trigger
-               ; "source_requeued", `Bool true
+               ; "source_requeued", `Bool false
                ; "error", `String reason
                ]))
-        Keeper_runtime_manifest.Context_compacted
+        Keeper_runtime_manifest.Runtime_failed
     in
-    Requeue_after_context_compaction, turn_state
+    Follow_failure_route, turn_state
 ;;
 
 let run_keeper_cycle

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -212,10 +212,17 @@ let recover_provider_context_overflow_in_lane
                     ~keeper_name:meta.name
                 with
                 | Ok () ->
-                    Log.Keeper.info
-                      ~keeper_name:meta.name
-                      "provider overflow compaction committed; source stimulus will be requeued";
-                    Provider_overflow_applied { trigger; recovery }
+                  (match recovery.compaction.outcome with
+                   | Keeper_context_runtime.Applied_checkpoint ->
+                     Log.Keeper.info
+                       ~keeper_name:meta.name
+                       "provider overflow compaction committed; source stimulus will be requeued";
+                     Provider_overflow_applied { trigger; recovery }
+                   | Keeper_context_runtime.Not_attempted
+                   | Keeper_context_runtime.Failed_compaction _ ->
+                     retry_after_started
+                       ~recovery
+                       "provider overflow recovery returned a non-terminal compaction outcome")
                 | Error error ->
                   retry_after_started
                     ~recovery

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -146,6 +146,11 @@ type source_lease_disposition =
     the configured in-turn policy already handled the terminal failure; the
     cycle remains failed for receipts, counters, and heartbeat freshness. *)
 
+val provider_overflow_manifest_projection
+  :  Keeper_context_runtime.compaction_outcome
+  -> Keeper_runtime_manifest.event_kind * bool * source_lease_disposition
+(** Durable outcome projection; never requeues unchanged context. *)
+
 type turn_failure =
   { error : Agent_sdk.Error.sdk_error
   ; runtime_id : string

--- a/lib/keeper_registry/keeper_runtime_manifest_types.ml
+++ b/lib/keeper_registry/keeper_runtime_manifest_types.ml
@@ -18,6 +18,7 @@ type event_kind =
   | Provider_attempt_finished
   | Context_injected
   | Context_compacted
+  | Context_compaction_noop
   | Event_bus_correlated
   | Checkpoint_loaded
   | Checkpoint_saved
@@ -38,6 +39,7 @@ let all_event_kinds =
     Provider_attempt_finished;
     Context_injected;
     Context_compacted;
+    Context_compaction_noop;
     Event_bus_correlated;
     Checkpoint_loaded;
     Checkpoint_saved;
@@ -58,6 +60,7 @@ let event_kind_to_string = function
   | Provider_attempt_finished -> "provider_attempt_finished"
   | Context_injected -> "context_injected"
   | Context_compacted -> "context_compacted"
+  | Context_compaction_noop -> "context_compaction_noop"
   | Event_bus_correlated -> "event_bus_correlated"
   | Checkpoint_loaded -> "checkpoint_loaded"
   | Checkpoint_saved -> "checkpoint_saved"
@@ -77,6 +80,7 @@ let event_kind_of_string = function
   | "provider_attempt_finished" -> Some Provider_attempt_finished
   | "context_injected" -> Some Context_injected
   | "context_compacted" -> Some Context_compacted
+  | "context_compaction_noop" -> Some Context_compaction_noop
   | "event_bus_correlated" -> Some Event_bus_correlated
   | "checkpoint_loaded" -> Some Checkpoint_loaded
   | "checkpoint_saved" -> Some Checkpoint_saved
@@ -150,6 +154,7 @@ let known_unrelated_untyped_compaction_snapshot_events =
 let classify_compaction_snapshot_typed_event = function
   | Event_bus_correlated
   | Context_compacted
+  | Context_compaction_noop
   | Context_injected
   | Checkpoint_loaded ->
     Compaction_snapshot_relevant

--- a/lib/keeper_registry/keeper_runtime_manifest_types.mli
+++ b/lib/keeper_registry/keeper_runtime_manifest_types.mli
@@ -11,6 +11,7 @@ type event_kind =
   | Provider_attempt_finished
   | Context_injected
   | Context_compacted
+  | Context_compaction_noop
   | Event_bus_correlated
   | Checkpoint_loaded
   | Checkpoint_saved

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -867,7 +867,8 @@ let compaction_snapshot_of_manifest_row
   match row.event with
   | Keeper_runtime_manifest.Event_bus_correlated ->
     compaction_event_bus_snapshot_json ~keeper_id row
-  | Keeper_runtime_manifest.Context_compacted ->
+  | Keeper_runtime_manifest.Context_compacted
+  | Keeper_runtime_manifest.Context_compaction_noop ->
     compaction_context_snapshot_json ~keeper_id ~manifest_rows ~row_index row
   | _ -> None
 ;;

--- a/lib/server/server_dashboard_http_keeper_api_runtime_lens.ml
+++ b/lib/server/server_dashboard_http_keeper_api_runtime_lens.ml
@@ -137,6 +137,10 @@ let runtime_lens_json ~config ~keeper_name ~trace_id ?turn_id scan =
                   ("context_injected_count", `Int scan.context_injected_count);
                   ( "context_compacted_event_count",
                     `Int scan.context_compacted_event_count );
+                  ( "context_compaction_noop_event_count",
+                    `Int
+                      (runtime_lens_event_count scan
+                         Keeper_runtime_manifest.Context_compaction_noop) );
                   ( "event_bus_correlated_count",
                     `Int scan.event_bus_count );
                   ( "context_compact_started_count",
@@ -234,6 +238,7 @@ let runtime_lens_json ~config ~keeper_name ~trace_id ?turn_id scan =
                   [
                     Keeper_runtime_manifest.Context_injected;
                     Keeper_runtime_manifest.Context_compacted;
+                    Keeper_runtime_manifest.Context_compaction_noop;
                     Keeper_runtime_manifest.Event_bus_correlated;
                     Keeper_runtime_manifest.Checkpoint_loaded;
                     Keeper_runtime_manifest.Checkpoint_saved;

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_clock_edges.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_clock_edges.ml
@@ -90,6 +90,7 @@ let event_started_at (row : manifest_row) =
   | Keeper_runtime_manifest.Provider_attempt_started
   | Keeper_runtime_manifest.Context_injected
   | Keeper_runtime_manifest.Context_compacted
+  | Keeper_runtime_manifest.Context_compaction_noop
   | Keeper_runtime_manifest.Event_bus_correlated
   | Keeper_runtime_manifest.Checkpoint_loaded ->
     Some row.Keeper_runtime_manifest.ts
@@ -120,6 +121,7 @@ let event_finished_at (row : manifest_row) =
   | Keeper_runtime_manifest.Provider_attempt_started
   | Keeper_runtime_manifest.Context_injected
   | Keeper_runtime_manifest.Context_compacted
+  | Keeper_runtime_manifest.Context_compaction_noop
   | Keeper_runtime_manifest.Event_bus_correlated
   | Keeper_runtime_manifest.Checkpoint_loaded ->
     None
@@ -160,6 +162,7 @@ let clock_edge_json ~idx ~provider_attempt_index (row : manifest_row) =
   let compaction_id =
     match event with
     | Keeper_runtime_manifest.Context_compacted
+    | Keeper_runtime_manifest.Context_compaction_noop
     | Keeper_runtime_manifest.Event_bus_correlated ->
       first_string_opt [ clock_string row "compaction_id"; Some (fallback_compaction_id row idx) ]
     | _ -> clock_string row "compaction_id"

--- a/lib/server/server_dashboard_http_keeper_runtime_lens_swimlane.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_lens_swimlane.ml
@@ -156,6 +156,7 @@ let event_lane = function
     "oas_agent"
   | Keeper_runtime_manifest.Context_injected
   | Keeper_runtime_manifest.Context_compacted
+  | Keeper_runtime_manifest.Context_compaction_noop
   | Keeper_runtime_manifest.Event_bus_correlated ->
     "memory_context"
 

--- a/lib/server/server_dashboard_http_keeper_runtime_manifest_scan.ml
+++ b/lib/server/server_dashboard_http_keeper_runtime_manifest_scan.ml
@@ -298,6 +298,7 @@ let update_runtime_manifest_scan scan (row : Keeper_runtime_manifest.t) =
    | Keeper_runtime_manifest.Context_compacted ->
      scan.context_compacted_event_count <- scan.context_compacted_event_count + 1;
      scan.latest_context_compacted_row <- Some row
+   | Keeper_runtime_manifest.Context_compaction_noop -> ()
    | Keeper_runtime_manifest.Event_bus_correlated ->
      let decision = row.Keeper_runtime_manifest.decision in
      scan.event_bus_count <- scan.event_bus_count + 1;

--- a/test/test_compaction_llm_summarizer.ml
+++ b/test/test_compaction_llm_summarizer.ml
@@ -116,12 +116,12 @@ let test_valid_partition_accepted () =
     true
     (is_ok (C.plan_of_json ~message_count:5 json))
 
-let test_all_kept_rejected () =
+let test_all_kept_accepted () =
   let json = plan_json ~summary:"n/a" ~kept:[ 0; 1; 2 ] ~summarized:[] ~dropped:[] in
   Alcotest.(check bool)
-    "keeping everything is not semantic compaction"
+    "keeping everything is a terminal no-compaction judgment"
     true
-    (is_error (C.plan_of_json ~message_count:3 json))
+    (is_ok (C.plan_of_json ~message_count:3 json))
 
 let test_drop_only_with_kept_accepted () =
   let json = plan_json ~summary:"unused" ~kept:[ 1 ] ~summarized:[] ~dropped:[ 0 ] in
@@ -240,7 +240,7 @@ let () =
         ] )
     ; ( "plan_of_json"
       , [ Alcotest.test_case "valid partition accepted" `Quick test_valid_partition_accepted
-        ; Alcotest.test_case "all kept rejected" `Quick test_all_kept_rejected
+        ; Alcotest.test_case "all kept accepted" `Quick test_all_kept_accepted
         ; Alcotest.test_case "drop-only with kept accepted" `Quick
             test_drop_only_with_kept_accepted
         ; Alcotest.test_case "out of range rejected" `Quick test_out_of_range_rejected

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -503,7 +503,7 @@ let test_applied_compaction_settles_followup_atomically () =
       ~stop_requested:false
       ~lease
       (Some
-         (Masc.Keeper_heartbeat_loop_cycle.Manual_compaction_applied
+         (Masc.Keeper_heartbeat_loop_cycle.Manual_compaction_completed
             (Masc.Keeper_heartbeat_loop_cycle.Failed { meta; failure })))
   in
   let judgment_failure =

--- a/test/test_keeper_lifecycle_registry_dispatch.ml
+++ b/test/test_keeper_lifecycle_registry_dispatch.ml
@@ -163,10 +163,8 @@ let base_lifecycle ~(meta : Keeper_meta_contract.keeper_meta) : KEC.post_turn_li
     handoff_failure_reason = None;
     compaction =
       {
-        attempted = false;
-        applied = false;
+        outcome = KEC.Not_attempted;
         started_dispatched = false;
-        failure_reason = None;
         trigger = None;
         decision = KEC.Not_requested;
     };
@@ -292,10 +290,8 @@ let test_dispatch_post_turn_lifecycle_events_uses_workspace_base_path () =
           (base_lifecycle ~meta) with
           compaction =
             {
-              attempted = true;
-              applied = true;
+              outcome = KEC.Applied_checkpoint;
               started_dispatched = true;
-              failure_reason = None;
               trigger = Some Compaction_trigger.Manual;
               decision = KEC.Applied Compaction_trigger.Manual;
             };
@@ -348,10 +344,8 @@ let test_post_turn_compaction_runs_from_failing_health_lane () =
           (base_lifecycle ~meta) with
           compaction =
             {
-              attempted = true;
-              applied = true;
+              outcome = KEC.Applied_checkpoint;
               started_dispatched = true;
-              failure_reason = None;
               trigger = Some Compaction_trigger.Manual;
               decision = KEC.Applied Compaction_trigger.Manual;
             };
@@ -394,10 +388,8 @@ let test_compaction_completion_without_started_is_nonfatal () =
           (base_lifecycle ~meta) with
           compaction =
             {
-              attempted = true;
-              applied = true;
+              outcome = KEC.Applied_checkpoint;
               started_dispatched = true;
-              failure_reason = None;
               trigger = Some Compaction_trigger.Manual;
               decision = KEC.Applied Compaction_trigger.Manual;
             };
@@ -438,10 +430,8 @@ let test_post_turn_compaction_restarts_after_done_stage () =
           (base_lifecycle ~meta) with
           compaction =
             {
-              attempted = true;
-              applied = true;
+              outcome = KEC.Applied_checkpoint;
               started_dispatched = true;
-              failure_reason = None;
               trigger = Some Compaction_trigger.Manual;
               decision = KEC.Applied Compaction_trigger.Manual;
             };

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -4069,6 +4069,7 @@ let check_compaction_snapshot_event_class label expected actual =
 let expected_compaction_snapshot_event_class = function
   | Runtime_manifest.Event_bus_correlated
   | Runtime_manifest.Context_compacted
+  | Runtime_manifest.Context_compaction_noop
   | Runtime_manifest.Context_injected
   | Runtime_manifest.Checkpoint_loaded ->
     Runtime_manifest.Compaction_snapshot_relevant

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -112,7 +112,7 @@ let test_regular_post_turn_does_not_auto_compact () =
     check bool "checkpoint messages retained exactly" true
       (retained.messages = checkpoint.messages)
 
-let only_compaction_manifest config (meta : Masc.Keeper_meta_contract.keeper_meta) =
+let compaction_manifests config (meta : Masc.Keeper_meta_contract.keeper_meta) =
   let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
   Masc.Keeper_runtime_manifest.path_for_trace
     config
@@ -125,12 +125,11 @@ let only_compaction_manifest config (meta : Masc.Keeper_meta_contract.keeper_met
     then None
     else
       match Masc.Keeper_runtime_manifest.of_json (Yojson.Safe.from_string line) with
-      | Ok ({ event = Context_compacted; _ } as row) -> Some row
+      | Ok
+          ({ event = (Context_compacted | Context_compaction_noop); _ } as row) ->
+        Some row
       | Ok _ -> None
       | Error detail -> failf "runtime manifest decode failed: %s" detail)
-  |> function
-  | [ row ] -> row
-  | rows -> failf "expected one manual compaction manifest, got %d" (List.length rows)
 ;;
 
 let test_manual_compaction_serializes_owner_lane () =
@@ -303,8 +302,8 @@ let test_manual_compaction_serializes_owner_lane () =
           run_cycle
       in
       (match outcome with
-       | Cycle.Manual_compaction_applied _ -> ()
-       | _ -> fail "owner-lane cycle did not apply manual compaction");
+       | Cycle.Manual_compaction_completed _ -> ()
+       | _ -> fail "owner-lane cycle did not complete manual compaction");
       let compacted =
         Result.get_ok
           (Masc.Keeper_checkpoint_store.load_oas
@@ -324,10 +323,54 @@ let test_manual_compaction_serializes_owner_lane () =
          |> Option.map Masc.Keeper_context_runtime.messages_of_context
          |> Option.value ~default:[]
          |> List.length);
-      let manifest = only_compaction_manifest config meta in
+      let manifest =
+        match compaction_manifests config meta with
+        | [ row ] -> row
+        | rows ->
+          failf "expected one applied compaction manifest, got %d" (List.length rows)
+      in
       check int "manifest records post-turn source size" 4
         Yojson.Safe.Util.(manifest.decision |> member "exact_evidence"
                           |> member "before_message_count" |> to_int);
+      let no_compaction_plan =
+        Masc.Keeper_compaction_llm_summarizer.plan_of_json
+          ~message_count:2
+          (`Assoc
+            [ "summary", `String ""
+            ; "kept_indices", `List [ `Int 0; `Int 1 ]
+            ; "summarized_indices", `List []
+            ; "dropped_indices", `List []
+            ])
+        |> Result.get_ok
+      in
+      let no_compaction =
+        Masc.Keeper_compaction_llm_summarizer.For_testing.with_make_override
+          (fun ~runtime_id:_ ~keeper_name:_ () ->
+             Some (fun ~messages:_ -> Some no_compaction_plan))
+          (fun () -> Masc.Keeper_manual_compaction.run ~config ~meta)
+      in
+      (match no_compaction with
+       | Ok success ->
+         Masc.Keeper_manual_compaction.observe_manifest
+           ~keeper_name:meta.name
+           success.manifest;
+         (match success.recovery.compaction.outcome with
+          | Masc.Keeper_context_runtime.No_checkpoint_change -> ()
+          | _ -> fail "all-kept plan did not complete as no-compaction")
+       | Error failure ->
+         failf
+           "all-kept manual compaction failed: %s"
+           (Masc.Keeper_manual_compaction.failure_to_string failure));
+      (match List.rev (compaction_manifests config meta) with
+       | { event = Context_compaction_noop; status = "no_compaction"; decision; _ }
+         :: _ ->
+         let open Yojson.Safe.Util in
+         check int "no-op before bytes persisted"
+           (decision |> member "exact_evidence" |> member "before_checkpoint_bytes"
+            |> to_int)
+           (decision |> member "exact_evidence" |> member "after_checkpoint_bytes"
+            |> to_int)
+       | _ -> fail "typed no-compaction manifest was not persisted");
       Registry_queue.settle_result
         ~base_path
         meta.name

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -99,8 +99,9 @@ let test_regular_post_turn_does_not_auto_compact () =
       ~current_turn_blocker_info:None
       ~checkpoint:(Some checkpoint)
   in
-  check bool "compaction not attempted" false result.compaction.attempted;
-  check bool "compaction not applied" false result.compaction.applied;
+  (match result.compaction.outcome with
+   | Post_turn.Not_attempted -> ()
+   | _ -> fail "regular post-turn reported a compaction terminal outcome");
   (match result.compaction.decision with
    | Compact_policy.Not_requested -> ()
    | _ -> fail "regular post-turn returned a compaction decision");

--- a/test/test_keeper_unified_context_overflow.ml
+++ b/test/test_keeper_unified_context_overflow.ml
@@ -1,6 +1,9 @@
 open Alcotest
 
 module EC = Masc.Keeper_error_classify
+module M = Masc.Keeper_runtime_manifest
+module U = Masc.Keeper_unified_turn
+
 let test_is_context_overflow_only_for_overflow_errors () =
   check
     bool
@@ -42,6 +45,24 @@ let test_context_overflow_is_auto_recoverable () =
        (Agent_sdk.Error.Api (ContextOverflow { message = "exceeded"; limit = Some 32768 })))
 ;;
 
+let test_overflow_projection_never_requeues_unchanged_context () =
+  let project = U.provider_overflow_manifest_projection in
+  check bool "applied context requeues source" true
+    (match project Masc.Keeper_context_runtime.Applied_checkpoint with
+     | M.Context_compacted, true, U.Requeue_after_context_compaction -> true
+     | _ -> false);
+  List.iter
+    (fun outcome ->
+       check bool "unchanged context follows failure route" true
+         (match project outcome with
+          | (M.Context_compaction_noop | M.Runtime_failed), false,
+            U.Follow_failure_route -> true
+          | _ -> false))
+    [ Masc.Keeper_context_runtime.No_checkpoint_change
+    ; Masc.Keeper_context_runtime.Failed_compaction (Some "failed")
+    ]
+;;
+
 let () =
   run
     "keeper_unified_context_overflow"
@@ -54,6 +75,10 @@ let () =
             "context overflow is auto-recoverable"
             `Quick
             test_context_overflow_is_auto_recoverable
+        ; test_case
+            "overflow projection never requeues unchanged context"
+            `Quick
+            test_overflow_projection_never_requeues_unchanged_context
         ] )
     ]
 ;;


### PR DESCRIPTION
## Outcome

The existing live compaction planner can now return an all-kept decision as a typed terminal `No_compaction`, without writing a replacement checkpoint or emitting a false `Context_compacted` row. Manual and provider-overflow consumers use the same live authority; no second planner, codec, or writer is introduced.

This is stacked on #24994 and is the second live-authority slice of #24990. The issue remains open until eligible-unit protection and the per-unit closed decision wire replace the remaining global-index plan.

## Semantics

- `No_compaction` is a successful terminal LLM decision with exact before=after evidence.
- manual requests persist `Context_compaction_noop`, complete the owner-lane lifecycle, and settle without replay.
- provider overflow projects only from the durable compaction outcome: only `Applied_checkpoint` requeues the exact source; no-op and failed/no recovery follow the typed failure route.
- a missing recovery emits `Runtime_failed`, never false `Context_compacted` evidence.
- dashboard projections expose no-op separately and do not count it as a context delta.
- the always-false pre-dispatch `Context_compacted` producer is deleted.

## Verification

- 398 changed lines (under the 400-line stack limit)
- pure overflow projection regression covers applied requeue versus unchanged/failed no-requeue
- owner-lane integration covers durable no-op manifest and exact before=after evidence
- `ocamlformat --check` on all changed OCaml files: pass
- `ocamlc -stop-after parsing` on all changed OCaml files: pass
- `git diff --check`: pass
- focused Dune targets were invoked through `scripts/dune-local.sh`; local compilation stops in unchanged `server_dashboard_http_runtime_info.ml` because the shared switch still has agent_sdk 0.213.0 while this repo pins 0.214.1. Full build/test truth is delegated to PR CI as required.

## Stack

1. #24994 typed terminal outcome prerequisite
2. this PR: terminal no-compaction + durable projection
3. follow-up: eligible/protected source hard cut in the same live planner
4. follow-up: per-unit closed decision wire hard cut in the same live planner