### PR TITLE
feat(keeper): persist no-compaction decision

### DIFF
--- a/lib/keeper_compaction_evidence/keeper_compaction_evidence.ml
+++ b/lib/keeper_compaction_evidence/keeper_compaction_evidence.ml
@@ -12,6 +12,14 @@ type t =
   ; after_tool_result_count : int
   }
 
+type preserved =
+  { selected_runtime_id : string
+  ; checkpoint_bytes : int
+  ; message_count : int
+  ; tool_use_count : int
+  ; tool_result_count : int
+  }
+
 type field =
   | Before_checkpoint_bytes
   | After_checkpoint_bytes
@@ -43,6 +51,18 @@ type decode_error =
   | Empty_selected_runtime_id
   | Invalid_transition of measure * int * int
   | No_messages_compacted
+
+type preserved_field =
+  | Preserved_checkpoint_bytes
+  | Preserved_message_count
+  | Preserved_tool_use_count
+  | Preserved_tool_result_count
+
+type preserved_error =
+  | Preserved_expected_object
+  | Preserved_unknown_field of string
+  | Preserved_invalid_field of preserved_field * field_error
+  | Preserved_empty_selected_runtime_id
 
 let schema =
   [ Before_checkpoint_bytes, "before_checkpoint_bytes"
@@ -76,6 +96,12 @@ let decode_nonnegative_integer fields field =
   | _ -> Error (Invalid_field (field, Duplicate))
 ;;
 
+let validate_runtime_id = function
+  | Some runtime_id when String.trim runtime_id = "" ->
+    Error Empty_selected_runtime_id
+  | Some _ | None -> Ok ()
+;;
+
 let of_json ~selected_runtime_id = function
   | `Assoc fields ->
     let* () =
@@ -87,12 +113,7 @@ let of_json ~selected_runtime_id = function
       | None -> Ok ()
       | Some (name, _) -> Error (Unknown_field name)
     in
-    let* () =
-      match selected_runtime_id with
-      | Some runtime_id when String.trim runtime_id = "" ->
-        Error Empty_selected_runtime_id
-      | Some _ | None -> Ok ()
-    in
+    let* () = validate_runtime_id selected_runtime_id in
     let integer = decode_nonnegative_integer fields in
     let* before_checkpoint_bytes = integer Before_checkpoint_bytes in
     let* after_checkpoint_bytes = integer After_checkpoint_bytes in
@@ -147,4 +168,99 @@ let to_json evidence =
     ; "before_tool_result_count", `Int evidence.before_tool_result_count
     ; "after_tool_result_count", `Int evidence.after_tool_result_count
     ]
+;;
+
+let preserved_field_name = function
+  | Preserved_checkpoint_bytes -> "checkpoint_bytes"
+  | Preserved_message_count -> "message_count"
+  | Preserved_tool_use_count -> "tool_use_count"
+  | Preserved_tool_result_count -> "tool_result_count"
+;;
+
+let preserved
+      ~selected_runtime_id
+      ~checkpoint_bytes
+      ~message_count
+      ~tool_use_count
+      ~tool_result_count
+  =
+  let values =
+    [ Preserved_checkpoint_bytes, checkpoint_bytes
+    ; Preserved_message_count, message_count
+    ; Preserved_tool_use_count, tool_use_count
+    ; Preserved_tool_result_count, tool_result_count
+    ]
+  in
+  let* () =
+    if String.trim selected_runtime_id = ""
+    then Error Preserved_empty_selected_runtime_id
+    else Ok ()
+  in
+  match List.find_opt (fun (_, value) -> value < 0) values with
+  | Some (field, _) ->
+    Error (Preserved_invalid_field (field, Negative_integer))
+  | None ->
+    Ok
+      { selected_runtime_id
+      ; checkpoint_bytes
+      ; message_count
+      ; tool_use_count
+      ; tool_result_count
+      }
+;;
+
+let preserved_to_json evidence =
+  `Assoc
+    [ "checkpoint_bytes", `Int evidence.checkpoint_bytes
+    ; "message_count", `Int evidence.message_count
+    ; "tool_use_count", `Int evidence.tool_use_count
+    ; "tool_result_count", `Int evidence.tool_result_count
+    ]
+;;
+
+let preserved_of_json ~selected_runtime_id = function
+  | `Assoc fields ->
+    let* () =
+      match
+        List.find_opt
+          (fun (name, _) ->
+             not
+               (List.exists
+                  (fun field ->
+                     String.equal name (preserved_field_name field))
+                  [ Preserved_checkpoint_bytes
+                  ; Preserved_message_count
+                  ; Preserved_tool_use_count
+                  ; Preserved_tool_result_count
+                  ]))
+          fields
+      with
+      | None -> Ok ()
+      | Some (name, _) -> Error (Preserved_unknown_field name)
+    in
+    let integer field =
+      match
+        List.filter
+          (fun (name, _) ->
+             String.equal name (preserved_field_name field))
+          fields
+      with
+      | [] -> Error (Preserved_invalid_field (field, Missing))
+      | [ _, `Int value ] when value >= 0 -> Ok value
+      | [ _, `Int _ ] ->
+        Error (Preserved_invalid_field (field, Negative_integer))
+      | [ _ ] -> Error (Preserved_invalid_field (field, Expected_integer))
+      | _ -> Error (Preserved_invalid_field (field, Duplicate))
+    in
+    let* checkpoint_bytes = integer Preserved_checkpoint_bytes in
+    let* message_count = integer Preserved_message_count in
+    let* tool_use_count = integer Preserved_tool_use_count in
+    let* tool_result_count = integer Preserved_tool_result_count in
+    preserved
+      ~selected_runtime_id
+      ~checkpoint_bytes
+      ~message_count
+      ~tool_use_count
+      ~tool_result_count
+  | _ -> Error Preserved_expected_object
 ;;

--- a/lib/keeper_compaction_evidence/keeper_compaction_evidence.mli
+++ b/lib/keeper_compaction_evidence/keeper_compaction_evidence.mli
@@ -13,6 +13,14 @@ type t =
   ; after_tool_result_count : int
   }
 
+type preserved = private
+  { selected_runtime_id : string
+  ; checkpoint_bytes : int
+  ; message_count : int
+  ; tool_use_count : int
+  ; tool_result_count : int
+  }
+
 type field =
   | Before_checkpoint_bytes
   | After_checkpoint_bytes
@@ -45,6 +53,18 @@ type decode_error =
   | Invalid_transition of measure * int * int
   | No_messages_compacted
 
+type preserved_field =
+  | Preserved_checkpoint_bytes
+  | Preserved_message_count
+  | Preserved_tool_use_count
+  | Preserved_tool_result_count
+
+type preserved_error =
+  | Preserved_expected_object
+  | Preserved_unknown_field of string
+  | Preserved_invalid_field of preserved_field * field_error
+  | Preserved_empty_selected_runtime_id
+
 val to_json : t -> Yojson.Safe.t
 (** Structural observation projection of the exact measured counts.
     [selected_runtime_id] remains the enclosing runtime projection. *)
@@ -58,3 +78,20 @@ val of_json
     object. Unknown, duplicate, missing, malformed, or objectively impossible
     evidence is rejected explicitly. [Checkpoint_bytes] must strictly reduce;
     the other measures may stay equal but cannot increase. *)
+
+val preserved
+  :  selected_runtime_id:string
+  -> checkpoint_bytes:int
+  -> message_count:int
+  -> tool_use_count:int
+  -> tool_result_count:int
+  -> (preserved, preserved_error) result
+(** Construct evidence for a terminal LLM decision that leaves the exact
+    source checkpoint unchanged. One observed value per measure makes a false
+    before/after delta unrepresentable. *)
+
+val preserved_to_json : preserved -> Yojson.Safe.t
+val preserved_of_json
+  :  selected_runtime_id:string
+  -> Yojson.Safe.t
+  -> (preserved, preserved_error) result

--- a/lib/keeper_compaction_operation/keeper_compaction_operation.ml
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation.ml
@@ -28,6 +28,12 @@ type candidate =
   ; evidence : Keeper_compaction_evidence.t
   }
 
+type no_compaction =
+  { attempt_id : Attempt_id.t
+  ; source_checkpoint : Keeper_checkpoint_ref.t
+  ; evidence : Keeper_compaction_evidence.preserved
+  }
+
 type supersession =
   { attempt_id : Attempt_id.t
   ; observed_checkpoint : Keeper_checkpoint_ref.t option
@@ -41,6 +47,7 @@ type event_view =
   | Commit_reconciliation_required of candidate * reconciliation_reason
   | Source_superseded of supersession
   | Compacted of candidate
+  | No_compaction of no_compaction
   | Reinjected of Keeper_checkpoint_ref.t * Ids.Turn_ref.t
 
 type event =
@@ -106,6 +113,12 @@ let compacted ~operation_id ~attempt_id ~source_checkpoint
            ~source_checkpoint
            ~candidate_checkpoint:committed_checkpoint
            ~evidence)
+  }
+;;
+
+let no_compaction ~operation_id ~attempt_id ~source_checkpoint ~evidence =
+  { operation_id
+  ; view = No_compaction { attempt_id; source_checkpoint; evidence }
   }
 ;;
 

--- a/lib/keeper_compaction_operation/keeper_compaction_operation.mli
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation.mli
@@ -30,6 +30,12 @@ type candidate =
   ; evidence : Keeper_compaction_evidence.t
   }
 
+type no_compaction =
+  { attempt_id : Attempt_id.t
+  ; source_checkpoint : Keeper_checkpoint_ref.t
+  ; evidence : Keeper_compaction_evidence.preserved
+  }
+
 type supersession =
   { attempt_id : Attempt_id.t
   ; observed_checkpoint : Keeper_checkpoint_ref.t option
@@ -43,6 +49,7 @@ type event_view =
   | Commit_reconciliation_required of candidate * reconciliation_reason
   | Source_superseded of supersession
   | Compacted of candidate
+  | No_compaction of no_compaction
   | Reinjected of Keeper_checkpoint_ref.t * Ids.Turn_ref.t
 
 type event
@@ -89,6 +96,12 @@ val compacted :
   source_checkpoint:Keeper_checkpoint_ref.t ->
   committed_checkpoint:Keeper_checkpoint_ref.t ->
   evidence:Keeper_compaction_evidence.t ->
+  event
+val no_compaction :
+  operation_id:Operation_id.t ->
+  attempt_id:Attempt_id.t ->
+  source_checkpoint:Keeper_checkpoint_ref.t ->
+  evidence:Keeper_compaction_evidence.preserved ->
   event
 val reinjected :
   operation_id:Operation_id.t ->

--- a/lib/keeper_compaction_operation/keeper_compaction_operation_action_selector.ml
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation_action_selector.ml
@@ -118,7 +118,11 @@ let select ~mode (replay : Store.replay) =
       let snapshot = entry.Store.snapshot in
       let operation = operation_context entry in
       (match snapshot.phase with
-       | Reducer.Adopted | Reducer.Failed | Reducer.Superseded -> first rest
+       | Reducer.No_compaction_decided
+       | Reducer.Adopted
+       | Reducer.Failed
+       | Reducer.Superseded ->
+         first rest
        | Reducer.Request_pending -> Ok (Selected (Start_attempt operation))
        | Reducer.Attempt_in_progress ->
          let* attempt_id = require snapshot Attempt_id snapshot.attempt_id in

--- a/lib/keeper_compaction_operation/keeper_compaction_operation_codec.ml
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation_codec.ml
@@ -163,6 +163,25 @@ let decode_source_superseded ~operation_id payload =
        ~observed_checkpoint)
 ;;
 
+let decode_no_compaction ~operation_id payload =
+  let path = "payload" in
+  let fields = [ "attempt_id"; "source_checkpoint"; "evidence" ] in
+  let* values = Support.exact_object ~path ~allowed:fields ~required:fields payload in
+  let* attempt_id = field ~path "attempt_id" Support.attempt_id values in
+  let* source_checkpoint =
+    nested ~path "source_checkpoint" Support.checkpoint values
+  in
+  let* evidence =
+    nested ~path "evidence" Support.preserved_evidence values
+  in
+  Ok
+    (Operation.no_compaction
+       ~operation_id
+       ~attempt_id
+       ~source_checkpoint
+       ~evidence)
+;;
+
 let of_json json =
   let path = "$" in
   let fields = [ "kind"; "operation_id"; "payload" ] in
@@ -201,6 +220,7 @@ let of_json json =
           ~committed_checkpoint:value.candidate_checkpoint
           ~evidence:value.evidence)
       payload
+  | "no_compaction" -> decode_no_compaction ~operation_id payload
   | "reinjected" -> decode_reinjected ~operation_id payload
   | unknown -> Error (Support.Unknown_event_kind unknown)
 ;;

--- a/lib/keeper_compaction_operation/keeper_compaction_operation_codec.mli
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation_codec.mli
@@ -34,6 +34,7 @@ type decode_error = Keeper_compaction_operation_codec_support.decode_error =
   | Invalid_trigger of Compaction_trigger.decode_error
   | Invalid_producer of Tool_invocation_ref.decode_error
   | Invalid_evidence of Keeper_compaction_evidence.decode_error
+  | Invalid_preserved_evidence of Keeper_compaction_evidence.preserved_error
   | Invalid_turn_ref of string
 
 val to_json : Keeper_compaction_operation.event -> Yojson.Safe.t

--- a/lib/keeper_compaction_operation/keeper_compaction_operation_codec_support.ml
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation_codec_support.ml
@@ -34,6 +34,7 @@ type decode_error =
   | Invalid_trigger of Compaction_trigger.decode_error
   | Invalid_producer of Tool_invocation_ref.decode_error
   | Invalid_evidence of Keeper_compaction_evidence.decode_error
+  | Invalid_preserved_evidence of Keeper_compaction_evidence.preserved_error
   | Invalid_turn_ref of string
 
 let ( let* ) = Result.bind
@@ -136,6 +137,20 @@ let evidence ~path json =
   let* counts = required_field ~path "counts" values in
   Keeper_compaction_evidence.of_json ~selected_runtime_id counts
   |> Result.map_error (fun error -> Invalid_evidence error)
+;;
+
+let preserved_evidence ~path json =
+  let fields = [ "selected_runtime_id"; "counts" ] in
+  let* values = exact_object ~path ~allowed:fields ~required:fields json in
+  let* runtime_json = required_field ~path "selected_runtime_id" values in
+  let* selected_runtime_id =
+    string_field ~path "selected_runtime_id" runtime_json
+  in
+  let* counts = required_field ~path "counts" values in
+  Keeper_compaction_evidence.preserved_of_json
+    ~selected_runtime_id
+    counts
+  |> Result.map_error (fun error -> Invalid_preserved_evidence error)
 ;;
 
 let trigger ~path json =

--- a/lib/keeper_compaction_operation/keeper_compaction_operation_codec_support.mli
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation_codec_support.mli
@@ -32,6 +32,7 @@ type decode_error =
   | Invalid_trigger of Compaction_trigger.decode_error
   | Invalid_producer of Tool_invocation_ref.decode_error
   | Invalid_evidence of Keeper_compaction_evidence.decode_error
+  | Invalid_preserved_evidence of Keeper_compaction_evidence.preserved_error
   | Invalid_turn_ref of string
 
 val exact_object
@@ -86,6 +87,11 @@ val evidence
   :  path:string
   -> Yojson.Safe.t
   -> (Keeper_compaction_evidence.t, decode_error) result
+
+val preserved_evidence
+  :  path:string
+  -> Yojson.Safe.t
+  -> (Keeper_compaction_evidence.preserved, decode_error) result
 
 val trigger
   :  path:string

--- a/lib/keeper_compaction_operation/keeper_compaction_operation_json.ml
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation_json.ml
@@ -10,13 +10,23 @@ let checkpoint (checkpoint : Keeper_checkpoint_ref.t) =
     ]
 ;;
 
-let evidence evidence =
+let evidence (evidence : Keeper_compaction_evidence.t) =
   `Assoc
     [ ( "selected_runtime_id"
       , match evidence.Keeper_compaction_evidence.selected_runtime_id with
         | Some value -> `String value
         | None -> `Null )
     ; "counts", Keeper_compaction_evidence.to_json evidence
+    ]
+;;
+
+let preserved_evidence
+      (evidence : Keeper_compaction_evidence.preserved)
+  =
+  `Assoc
+    [ ( "selected_runtime_id"
+      , `String evidence.Keeper_compaction_evidence.selected_runtime_id )
+    ; "counts", Keeper_compaction_evidence.preserved_to_json evidence
     ]
 ;;
 
@@ -103,6 +113,14 @@ let to_json event =
       event
       "compacted"
       (candidate ~checkpoint_field:"committed_checkpoint" value)
+  | No_compaction value ->
+    envelope
+      event
+      "no_compaction"
+      [ "attempt_id", `String (Operation.Attempt_id.to_string value.attempt_id)
+      ; "source_checkpoint", checkpoint value.source_checkpoint
+      ; "evidence", preserved_evidence value.evidence
+      ]
   | Reinjected (adopted_checkpoint, adopting_turn) ->
     envelope
       event

--- a/lib/keeper_compaction_operation/keeper_compaction_operation_reducer.ml
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation_reducer.ml
@@ -6,6 +6,7 @@ type phase =
   | Candidate_pending_commit
   | Reconciliation_pending
   | Commit_complete
+  | No_compaction_decided
   | Adopted
   | Failed
   | Superseded
@@ -16,6 +17,7 @@ type progress =
   | Prepared of Operation.candidate
   | Reconciling of Operation.candidate * Operation.reconciliation_reason
   | Committed of Operation.candidate
+  | Preserved of Operation.no_compaction
   | Adopted_state of
       Operation.candidate * Keeper_checkpoint_ref.t * Ids.Turn_ref.t
   | Failed_state of Operation.Attempt_id.t * Operation.attempt_failure
@@ -45,6 +47,7 @@ type snapshot =
   ; attempt_id : Operation.Attempt_id.t option
   ; candidate_checkpoint : Keeper_checkpoint_ref.t option
   ; evidence : Keeper_compaction_evidence.t option
+  ; preserved_evidence : Keeper_compaction_evidence.preserved option
   ; reconciliation_reason : Operation.reconciliation_reason option
   ; committed_checkpoint : Keeper_checkpoint_ref.t option
   ; adopted_checkpoint : Keeper_checkpoint_ref.t option
@@ -71,30 +74,35 @@ let phase state =
   | Prepared _ -> Candidate_pending_commit
   | Reconciling _ -> Reconciliation_pending
   | Committed _ -> Commit_complete
+  | Preserved _ -> No_compaction_decided
   | Adopted_state _ -> Adopted
   | Failed_state _ -> Failed
   | Superseded_state _ -> Superseded
 ;;
 
 let projection = function
-  | Pending -> None, None, None, None, None, None, None, None, None
+  | Pending -> None, None, None, None, None, None, None, None, None, None
   | Running attempt ->
-    Some attempt, None, None, None, None, None, None, None, None
+    Some attempt, None, None, None, None, None, None, None, None, None
   | Prepared value ->
     Some value.attempt_id, Some value.candidate_checkpoint, Some value.evidence,
-    None, None, None, None, None, None
+    None, None, None, None, None, None, None
   | Reconciling (value, reason) ->
     Some value.attempt_id, Some value.candidate_checkpoint, Some value.evidence,
-    Some reason, None, None, None, None, None
+    Some reason, None, None, None, None, None, None
   | Committed value ->
     Some value.attempt_id, Some value.candidate_checkpoint, Some value.evidence,
-    None, Some value.candidate_checkpoint, None, None, None, None
+    None, Some value.candidate_checkpoint, None, None, None, None, None
+  | Preserved value ->
+    Some value.attempt_id, None, None, None, None, None, None, None, None,
+    Some value.evidence
   | Adopted_state (value, checkpoint, turn) ->
     Some value.attempt_id, Some value.candidate_checkpoint, Some value.evidence,
     None, Some value.candidate_checkpoint, Some checkpoint, Some turn, None,
-    None
+    None, None
   | Failed_state (attempt_id, failure) ->
-    Some attempt_id, None, None, None, None, None, None, Some failure, None
+    Some attempt_id, None, None, None, None, None, None, Some failure, None,
+    None
   | Superseded_state superseded ->
     let candidate_checkpoint, evidence =
       match superseded.candidate with
@@ -105,13 +113,14 @@ let projection = function
       if superseded.committed then candidate_checkpoint else None
     in
     Some superseded.attempt_id, candidate_checkpoint, evidence, None,
-    committed_checkpoint, None, None, None, superseded.observed_checkpoint
+    committed_checkpoint, None, None, None, superseded.observed_checkpoint,
+    None
 ;;
 
 let snapshot state =
   let attempt_id, candidate_checkpoint, evidence, reconciliation_reason,
       committed_checkpoint, adopted_checkpoint, adopting_turn, failure,
-      superseded_by_checkpoint =
+      superseded_by_checkpoint, preserved_evidence =
     projection state.progress
   in
   { operation_id = state.operation_id
@@ -124,6 +133,7 @@ let snapshot state =
   ; attempt_id
   ; candidate_checkpoint
   ; evidence
+  ; preserved_evidence
   ; reconciliation_reason
   ; committed_checkpoint
   ; adopted_checkpoint
@@ -204,6 +214,16 @@ let apply current event =
       match state.progress, view with
       | Pending, Operation.Attempt_started attempt_id ->
         Ok { state with progress = Running attempt_id }
+      | Running expected, Operation.No_compaction value ->
+        if not (Operation.Attempt_id.equal expected value.attempt_id)
+        then Error Attempt_mismatch
+        else if
+          not
+            (Keeper_checkpoint_ref.equal
+               state.request.source_checkpoint
+               value.source_checkpoint)
+        then Error Source_mismatch
+        else Ok { state with progress = Preserved value }
       | Running expected, Operation.Candidate_prepared value ->
         if not (Operation.Attempt_id.equal expected value.attempt_id)
         then Error Attempt_mismatch

--- a/lib/keeper_compaction_operation/keeper_compaction_operation_reducer.mli
+++ b/lib/keeper_compaction_operation/keeper_compaction_operation_reducer.mli
@@ -8,6 +8,7 @@ type phase =
   | Candidate_pending_commit
   | Reconciliation_pending
   | Commit_complete
+  | No_compaction_decided  (** Terminal decision; Lane release is queue-owned. *)
   | Adopted
   | Failed  (** Terminal; another objective requires a new operation. *)
   | Superseded
@@ -24,6 +25,7 @@ type snapshot =
   ; attempt_id : Operation.Attempt_id.t option
   ; candidate_checkpoint : Keeper_checkpoint_ref.t option
   ; evidence : Keeper_compaction_evidence.t option
+  ; preserved_evidence : Keeper_compaction_evidence.preserved option
   ; reconciliation_reason : Operation.reconciliation_reason option
   ; committed_checkpoint : Keeper_checkpoint_ref.t option
   ; adopted_checkpoint : Keeper_checkpoint_ref.t option

--- a/test/keeper_compaction_operation/test_keeper_compaction_operation.ml
+++ b/test/keeper_compaction_operation/test_keeper_compaction_operation.ml
@@ -6,6 +6,7 @@ module Reducer = Keeper_compaction_operation_reducer
 let ok = function Ok value -> value | Error _ -> Alcotest.fail "fixture rejected"
 let operation_id = ok (Operation.Operation_id.of_string "123e4567-e89b-12d3-a456-426614174000")
 let attempt_id = ok (Operation.Attempt_id.of_string "123e4567-e89b-12d3-a456-426614174001")
+let other_attempt_id = ok (Operation.Attempt_id.of_string "123e4567-e89b-12d3-a456-426614174002")
 let keeper_name = ok (Keeper_id.Keeper_name.of_string "keeper-a")
 let trace_id = ok (Keeper_id.Trace_id.of_string "trace-a")
 let checkpoint bytes turn_count =
@@ -33,6 +34,15 @@ let evidence : Keeper_compaction_evidence.t =
   ; after_tool_result_count = 1
   }
 ;;
+let preserved_evidence =
+  ok
+    (Keeper_compaction_evidence.preserved
+       ~selected_runtime_id:"compact-runtime"
+       ~checkpoint_bytes:100
+       ~message_count:10
+       ~tool_use_count:2
+       ~tool_result_count:2)
+;;
 let cause = ok (Operation.Cause.of_string "operator request")
 let producer =
   let request_id = ok (Mcp_transport_protocol.request_id_of_yojson (`String "req-1")) in
@@ -50,6 +60,13 @@ let request_event () =
 ;;
 
 let attempt_event () = Operation.attempt_started ~operation_id ~attempt_id
+let no_compaction_event ?(attempt_id = attempt_id) ?(source = source) () =
+  Operation.no_compaction
+    ~operation_id
+    ~attempt_id
+    ~source_checkpoint:source
+    ~evidence:preserved_evidence
+;;
 
 let candidate_event () =
   Operation.candidate_prepared
@@ -187,6 +204,30 @@ let test_reducer_happy_path () =
     (Option.exists
        (Keeper_checkpoint_ref.equal candidate)
        snapshot.adopted_checkpoint)
+;;
+
+let test_reducer_no_compaction_terminal () =
+  let running = ok (Reducer.fold [ request_event (); attempt_event () ]) in
+  let terminal = ok (Reducer.apply (Some running) (no_compaction_event ())) in
+  let snapshot = Reducer.snapshot terminal in
+  Alcotest.(check bool)
+    "distinct terminal"
+    true
+    (snapshot.phase = Reducer.No_compaction_decided
+     && snapshot.preserved_evidence = Some preserved_evidence);
+  (match Reducer.apply (Some running) (no_compaction_event ~source:advanced ()) with
+   | Error Reducer.Source_mismatch -> ()
+   | Ok _ | Error _ -> Alcotest.fail "different exact source was accepted");
+  (match
+     Reducer.apply
+       (Some running)
+       (no_compaction_event ~attempt_id:other_attempt_id ())
+   with
+   | Error Reducer.Attempt_mismatch -> ()
+   | Ok _ | Error _ -> Alcotest.fail "different attempt was accepted");
+  match Reducer.apply (Some terminal) (candidate_event ()) with
+  | Error (Reducer.Invalid_transition (Some Reducer.No_compaction_decided)) -> ()
+  | Ok _ | Error _ -> Alcotest.fail "terminal no-op restarted"
 ;;
 
 let test_reducer_confirmed_failure () =
@@ -440,6 +481,7 @@ let test_canonical_json_projection () =
         ~source_checkpoint:source
         ~committed_checkpoint:candidate
         ~evidence
+    ; no_compaction_event ()
     ; Operation.reinjected
         ~operation_id
         ~adopted_checkpoint:candidate
@@ -464,6 +506,7 @@ let test_canonical_json_projection () =
     ; "commit_reconciliation_required"
     ; "source_superseded"
     ; "compacted"
+    ; "no_compaction"
     ; "reinjected"
     ]
     kinds;
@@ -519,6 +562,7 @@ let test_codec_roundtrip_all_events () =
         ~source_checkpoint:source
         ~committed_checkpoint:candidate
         ~evidence
+    ; no_compaction_event ()
     ; Operation.reinjected
         ~operation_id
         ~adopted_checkpoint:candidate
@@ -612,6 +656,10 @@ let () =
             `Quick
             test_failure_and_reinjection_views
         ; Alcotest.test_case "reducer happy path" `Quick test_reducer_happy_path
+        ; Alcotest.test_case
+            "reducer no-compaction terminal"
+            `Quick
+            test_reducer_no_compaction_terminal
         ; Alcotest.test_case
             "reducer confirmed failure"
             `Quick

--- a/test/keeper_compaction_operation_store/dune
+++ b/test/keeper_compaction_operation_store/dune
@@ -5,6 +5,7 @@
   masc.compaction_trigger
   masc.fs_compat
   masc.keeper_checkpoint_ref
+  masc.keeper_compaction_evidence
   masc.keeper_compaction_operation
   masc.keeper_registry
   masc.mcp_transport_protocol

--- a/test/keeper_compaction_operation_store/test_keeper_compaction_operation_store.ml
+++ b/test/keeper_compaction_operation_store/test_keeper_compaction_operation_store.ml
@@ -1,6 +1,7 @@
 module Operation = Keeper_compaction_operation
 module Projection = Keeper_compaction_operation_projection
 module Record = Keeper_operation_record
+module Selector = Keeper_compaction_operation_action_selector
 module Store = Keeper_compaction_operation_store
 let ok = function Ok value -> value | Error _ -> Alcotest.fail "fixture failed"
 let keeper_name = ok (Keeper_id.Keeper_name.of_string "store-keeper")
@@ -18,6 +19,15 @@ let id value = ok (Operation.Operation_id.of_string value)
 let op1 = id "00000000-0000-4000-8000-000000000001"
 let op2 = id "00000000-0000-4000-8000-000000000002"
 let attempt = ok (Operation.Attempt_id.of_string "00000000-0000-4000-8000-000000000011")
+let preserved =
+  ok
+    (Keeper_compaction_evidence.preserved
+       ~selected_runtime_id:"compact-runtime"
+       ~checkpoint_bytes:6
+       ~message_count:1
+       ~tool_use_count:0
+       ~tool_result_count:0)
+;;
 let request ?producer operation_id =
   Operation.requested ~operation_id ~keeper_name ~source_checkpoint:source
     ~trigger:Compaction_trigger.Manual ~cause ~producer_invocation:producer
@@ -116,6 +126,37 @@ let test_rejections_do_not_write () =
    | _ -> Alcotest.fail "cross-Keeper request was not rejected");
   Alcotest.(check string) "rejections wrote no bytes" before (Fs_compat.load_file path)
 ;;
+let test_no_compaction_decision_is_durable () =
+  with_base @@ fun base ->
+  ignore (append base 1.0 (request op1));
+  ignore (append base 2.0 (Operation.attempt_started ~operation_id:op1 ~attempt_id:attempt));
+  let path = Store.journal_path ~base_path:base ~keeper_name in
+  let before = Fs_compat.load_file path in
+  let decision source_checkpoint =
+    Operation.no_compaction
+      ~operation_id:op1
+      ~attempt_id:attempt
+      ~source_checkpoint
+      ~evidence:preserved
+  in
+  (match Store.append ~base_path:base ~keeper_name ~recorded_at:3.0 (decision next_source) with
+   | Error
+       (Store.Event_rejected
+          (Store.Transition_rejected Keeper_compaction_operation_reducer.Source_mismatch))
+     -> ()
+   | _ -> Alcotest.fail "different source decision was accepted");
+  Alcotest.(check string) "rejected decision wrote no bytes" before (Fs_compat.load_file path);
+  ignore (append base 4.0 (decision source));
+  match Store.replay ~base_path:base ~keeper_name with
+  | Ok ({ operations = [ entry ]; _ } as replay)
+    when entry.snapshot.phase
+         = Keeper_compaction_operation_reducer.No_compaction_decided
+         && entry.snapshot.preserved_evidence = Some preserved ->
+    (match Selector.select ~mode:Selector.Startup_recovery replay with
+     | Ok Selector.Idle -> ()
+     | Ok _ | Error _ -> Alcotest.fail "durable decision restarted LLM work")
+  | Ok _ | Error _ -> Alcotest.fail "durable decision did not replay exactly"
+;;
 let test_malformed_history_fails_loud () =
   with_base @@ fun base ->
   let path = Store.journal_path ~base_path:base ~keeper_name in
@@ -138,6 +179,10 @@ let () =
           test_incremental_projection_matches_replay
       ; Alcotest.test_case "append replay slice" `Quick test_append_replay_and_slice
       ; Alcotest.test_case "rejections no write" `Quick test_rejections_do_not_write
+      ; Alcotest.test_case
+          "no-compaction decision is durable"
+          `Quick
+          test_no_compaction_decision_is_durable
       ; Alcotest.test_case "malformed history" `Quick test_malformed_history_fails_loud
       ] ]
 ;;


### PR DESCRIPTION
## Scope

- add an immutable `No_compaction` operation event bound to the exact attempt and source checkpoint
- persist a distinct `No_compaction_decided` terminal fact instead of manufacturing a compacted before/after delta
- require a nonblank selected LLM runtime id and nonnegative single-source observations
- close the JSON codec and operation-record error mapping for the new event
- make operation recovery skip the decided terminal so it never reruns LLM work

## Durable proof

The focused store test executes the real path:

1. append `Requested`
2. append `Attempt_started`
3. reject a `No_compaction` decision for a different exact source and prove journal bytes did not change
4. append the valid decision
5. replay private JSONL into the immutable projection/reducer
6. verify `No_compaction_decided` plus exact preserved evidence
7. verify startup selection is `Idle`, not `Start_attempt`

## Boundary

- Depends on #24988.
- This is the inactive operation-journal algebra/codec/reducer prerequisite. It does **not** claim that live Manual/provider-overflow compaction writes this fact yet.
- `No_compaction_decided` means the LLM decision is durable; it does not mean checkpoint mutation or Lane release completed.
- Lane release remains queue-owned. The activation stack will add typed `Continue (Compaction_decide { operation_id })` and `Continue (Compaction_release { operation_id })` saga steps before hard-cutting the direct Manual path.
- No risk taxonomy, budget limit, tool-name classification, timeout, heuristic, or silent fallback is added.

## Proof run

- focused wrapper build: operation, record, store, and action-selector targets
- operation 17/17, record 5/5, store 6/6, selector 3/3: **31/31 green**
- `ocamlformat --check` and `git diff --check` pass
- adversarial review: P0/P1 none
- diff against stacked base: **379 additions + 18 deletions = 397 changed lines**

Full build/test remains PR CI authority.
