### PR TITLE
refactor(keeper): retain durable settlement history

### DIFF
--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -59,28 +59,44 @@ type outbox_entry =
   ; stimuli : Keeper_event_queue.stimulus list
   }
 
+module Lease_sequence = struct
+  type t = int64
+
+  let compare = Int64.compare
+end
+
+module Sequence_map = Map.Make (Lease_sequence)
+
+type projection_state =
+  | Projection_pending
+  | Projection_complete
+
+type settled_transition =
+  { lease : lease
+  ; receipt : transition_receipt
+  ; projection : projection_state
+  }
+
 type t =
   { revision : int64
   ; next_lease_sequence : int64
   ; pending : Keeper_event_queue.t
   ; leases : lease list
-  ; last_settlement : transition_receipt option
-  ; transition_outbox : outbox_entry list
+  ; settled_transitions : settled_transition Sequence_map.t
   }
 
 type settle_result =
   | Settled of transition_receipt
   | Already_settled of transition_receipt
 
-let schema = "keeper.event_queue.state.v2"
+let schema = "keeper.event_queue.state.v3"
 
 let empty =
   { revision = 0L
   ; next_lease_sequence = 1L
   ; pending = Keeper_event_queue.empty
   ; leases = []
-  ; last_settlement = None
-  ; transition_outbox = []
+  ; settled_transitions = Sequence_map.empty
   }
 ;;
 
@@ -88,8 +104,15 @@ let revision state = state.revision
 let next_lease_sequence state = state.next_lease_sequence
 let pending state = state.pending
 let leases state = state.leases
-let last_settlement state = state.last_settlement
-let transition_outbox state = state.transition_outbox
+let transition_outbox state =
+  Sequence_map.bindings state.settled_transitions
+  |> List.filter_map (fun (_, transition) ->
+    match transition.projection with
+    | Projection_pending ->
+      Some { receipt = transition.receipt; stimuli = transition.lease.stimuli }
+    | Projection_complete -> None)
+;;
+
 let lease_kind (lease : lease) = lease.kind
 let active_lease state =
   match state.leases with
@@ -98,21 +121,33 @@ let active_lease state =
 ;;
 
 let mark_transition_projected ~transition_id state =
-  match state.transition_outbox with
-  | [ entry ] when String.equal entry.receipt.transition_id transition_id ->
-    Ok
-      { state with
-        last_settlement = Some entry.receipt
-      ; transition_outbox = []
-      }
-  | [] ->
-    (match state.last_settlement with
-     | Some receipt when String.equal receipt.transition_id transition_id -> Ok state
-     | Some _ | None ->
-       Error (Printf.sprintf "event queue transition not found: %s" transition_id))
-  | [ _ ] ->
+  let matching_sequence =
+    Sequence_map.fold
+      (fun sequence transition found ->
+         match found with
+         | Some _ -> found
+         | None ->
+           if String.equal transition.receipt.transition_id transition_id
+           then Some (sequence, transition)
+           else None)
+      state.settled_transitions
+      None
+  in
+  match matching_sequence with
+  | Some (sequence, transition) ->
+    (match transition.projection with
+     | Projection_complete -> Ok state
+     | Projection_pending ->
+       Ok
+         { state with
+           settled_transitions =
+             Sequence_map.add
+               sequence
+               { transition with projection = Projection_complete }
+               state.settled_transitions
+         })
+  | None ->
     Error (Printf.sprintf "event queue transition not found: %s" transition_id)
-  | _ :: _ :: _ -> Error "event queue state has multiple unprojected transitions"
 ;;
 let with_pending pending state = { state with pending }
 let with_revision revision state = { state with revision }
@@ -178,7 +213,7 @@ let make_lease ~kind ~claimed_at stimuli state =
 ;;
 
 let lease_admission_blocked state =
-  state.leases <> [] || state.transition_outbox <> []
+  state.leases <> [] || transition_outbox state <> []
 ;;
 
 let rec dequeue_first_ready ~ready skipped pending =
@@ -445,16 +480,6 @@ let receipt_for_lease ~settled_at ~settlement (lease : lease) =
   }
 ;;
 
-let find_prior_receipt lease_id state =
-  match state.transition_outbox with
-  | [ entry ] when String.equal entry.receipt.lease_id lease_id -> Some entry.receipt
-  | [] | [ _ ] ->
-    (match state.last_settlement with
-     | Some receipt when String.equal receipt.lease_id lease_id -> Some receipt
-     | Some _ | None -> None)
-  | _ :: _ :: _ -> None
-;;
-
 let remove_lease lease_id leases =
   List.filter
     (fun (lease : lease) -> not (String.equal lease.lease_id lease_id))
@@ -479,15 +504,18 @@ let settle ~settled_at ~lease ~settlement state =
   let* () = validate_settlement settlement in
   match committed_lease lease state with
   | None ->
-    (match find_prior_receipt lease.lease_id state with
-     | Some receipt when settlement_equal receipt.settlement settlement ->
-       Ok (state, Already_settled receipt)
-     | Some receipt ->
+    (match Sequence_map.find_opt lease.sequence state.settled_transitions with
+     | Some transition when not (lease_equal transition.lease lease) ->
+       Error (Printf.sprintf "event queue settled lease payload conflict: %s" lease.lease_id)
+     | Some transition
+       when settlement_equal transition.receipt.settlement settlement ->
+       Ok (state, Already_settled transition.receipt)
+     | Some transition ->
        Error
          (Printf.sprintf
             "event queue lease %s already settled as %s; refusing %s"
             lease.lease_id
-            (settlement_kind_label receipt.settlement)
+            (settlement_kind_label transition.receipt.settlement)
             (settlement_kind_label settlement))
      | None -> Error (Printf.sprintf "event queue lease not found: %s" lease.lease_id))
   | Some committed when not (lease_equal committed lease) ->
@@ -511,16 +539,15 @@ let settle ~settled_at ~lease ~settlement state =
         enqueue_if_missing state.pending successor
     in
     let receipt = receipt_for_lease ~settled_at ~settlement committed in
-    let outbox_entry =
-      { receipt
-      ; stimuli = committed.stimuli
-      }
-    in
     Ok
       ( { state with
           pending
         ; leases = remove_lease committed.lease_id state.leases
-        ; transition_outbox = [ outbox_entry ]
+        ; settled_transitions =
+            Sequence_map.add
+              committed.sequence
+              { lease = committed; receipt; projection = Projection_pending }
+              state.settled_transitions
         }
       , Settled receipt )
 ;;
@@ -763,7 +790,9 @@ let transition_receipt_of_yojson json =
     Printf.sprintf "%s:%s" expected_lease_id (settlement_kind_label settlement)
   in
   let expected_event_id = event_id_of_transition expected_transition_id in
-  if not (String.equal lease_id expected_lease_id)
+  if Int64.compare lease_sequence 1L < 0
+  then Error "event queue receipt lease sequence must be positive"
+  else if not (String.equal lease_id expected_lease_id)
   then Error (Printf.sprintf "event queue receipt lease id mismatch: %s" lease_id)
   else if not (String.equal transition_id expected_transition_id)
   then Error (Printf.sprintf "event queue receipt transition id mismatch: %s" transition_id)
@@ -780,22 +809,40 @@ let transition_receipt_of_yojson json =
       }
 ;;
 
-let outbox_entry_to_yojson entry =
+let settled_transition_to_yojson transition =
   `Assoc
-    [ "receipt", transition_receipt_to_yojson entry.receipt
-    ; "stimuli", `List (List.map Keeper_event_queue.stimulus_to_yojson entry.stimuli)
+    [ "lease", lease_to_yojson transition.lease
+    ; "receipt", transition_receipt_to_yojson transition.receipt
+    ; ( "projection"
+      , `String
+          (match transition.projection with
+           | Projection_pending -> "pending"
+           | Projection_complete -> "complete") )
     ]
 ;;
 
-let outbox_entry_of_yojson json =
-  let context = "event queue outbox entry" in
+let settled_transition_of_yojson json =
+  let context = "event queue settled transition" in
   let* fields = assoc_fields ~context json in
+  let* () = exact_reason_fields ~context [ "lease"; "receipt"; "projection" ] fields in
+  let* lease_json = required_field ~context "lease" fields in
+  let* lease = lease_of_yojson lease_json in
   let* receipt_json = required_field ~context "receipt" fields in
   let* receipt = transition_receipt_of_yojson receipt_json in
-  let* stimuli =
-    list_field ~context "stimuli" Keeper_event_queue.stimulus_of_yojson fields
+  let* projection_label = string_field ~context "projection" fields in
+  let* projection =
+    match projection_label with
+    | "pending" -> Ok Projection_pending
+    | "complete" -> Ok Projection_complete
+    | label ->
+      Error (Printf.sprintf "unknown event queue projection state: %s" label)
   in
-  Ok { receipt; stimuli }
+  if
+    not
+      (Int64.equal lease.sequence receipt.lease_sequence
+       && String.equal lease.lease_id receipt.lease_id)
+  then Error "event queue settled transition lease/receipt mismatch"
+  else Ok { lease; receipt; projection }
 ;;
 
 let to_yojson state =
@@ -805,83 +852,98 @@ let to_yojson state =
     ; "next_lease_sequence", int64_json state.next_lease_sequence
     ; "pending", Keeper_event_queue.queue_to_yojson state.pending
     ; "leases", `List (List.map lease_to_yojson state.leases)
-    ; ( "last_settlement"
-      , match state.last_settlement with
-        | None -> `Null
-        | Some receipt -> transition_receipt_to_yojson receipt )
-    ; ( "transition_outbox"
-      , `List (List.map outbox_entry_to_yojson state.transition_outbox) )
+    ; ( "settled_transitions"
+      , `List
+          (Sequence_map.bindings state.settled_transitions
+           |> List.map (fun (_, transition) ->
+             settled_transition_to_yojson transition)) )
     ]
 ;;
 
-let duplicate_by key values =
-  let rec loop seen = function
-    | [] -> None
-    | value :: rest ->
-      let key = key value in
-      if List.exists (String.equal key) seen
-      then Some key
-      else loop (key :: seen) rest
-  in
-  loop [] values
-;;
-
 let validate_state state =
+  let projection_count = List.length (transition_outbox state) in
   if Int64.compare state.revision 0L < 0
   then Error "event queue revision must not be negative"
   else if Int64.compare state.next_lease_sequence 1L < 0
   then Error "event queue next lease sequence must be positive"
   else if List.length state.leases > 1
   then Error "event queue state must contain at most one active lease"
-  else if List.length state.transition_outbox > 1
+  else if projection_count > 1
   then Error "event queue state must contain at most one unprojected transition"
-  else if state.leases <> [] && state.transition_outbox <> []
+  else if state.leases <> [] && projection_count > 0
   then Error "event queue state cannot contain both an active lease and an outbox transition"
   else if
-    match state.last_settlement, state.transition_outbox with
-    | Some receipt, [ entry ] ->
-      String.equal receipt.transition_id entry.receipt.transition_id
-    | None, _ | Some _, ([] | _ :: _ :: _) -> false
-  then Error "event queue last settlement duplicates the unprojected transition"
-  else
-    match duplicate_by (fun (lease : lease) -> lease.lease_id) state.leases with
-    | Some lease_id -> Error (Printf.sprintf "duplicate event queue lease id: %s" lease_id)
-    | None ->
-      (match
-         duplicate_by
-           (fun entry -> entry.receipt.transition_id)
-           state.transition_outbox
-       with
-       | Some transition_id ->
-         Error (Printf.sprintf "duplicate event queue transition id: %s" transition_id)
-       | None ->
-         let max_sequence =
-           List.fold_left
-             (fun acc (lease : lease) -> Int64.max acc lease.sequence)
-             0L
-             state.leases
-         in
-         let max_sequence =
-           List.fold_left
-             (fun acc entry -> Int64.max acc entry.receipt.lease_sequence)
-             max_sequence
-             state.transition_outbox
-         in
-         let max_sequence =
-           match state.last_settlement with
-           | None -> max_sequence
-           | Some receipt -> Int64.max max_sequence receipt.lease_sequence
-         in
-         if Int64.compare state.next_lease_sequence max_sequence <= 0
-         then
-           Error
-             "event queue next lease sequence must exceed every lease and receipt sequence"
-         else Ok state)
+    List.exists
+      (fun (lease : lease) ->
+         Sequence_map.mem lease.sequence state.settled_transitions)
+      state.leases
+  then Error "event queue active lease duplicates a settled lease"
+  else if
+    not
+      (Sequence_map.for_all
+         (fun sequence transition ->
+            Int64.equal sequence transition.lease.sequence
+            && Int64.equal sequence transition.receipt.lease_sequence
+            && String.equal transition.lease.lease_id transition.receipt.lease_id)
+         state.settled_transitions)
+  then Error "event queue settled transition identity mismatch"
+  else (
+    let max_sequence =
+      List.fold_left
+        (fun acc (lease : lease) -> Int64.max acc lease.sequence)
+        0L
+        state.leases
+    in
+    let max_sequence =
+      match Sequence_map.max_binding_opt state.settled_transitions with
+      | None -> max_sequence
+      | Some (sequence, _) -> Int64.max max_sequence sequence
+    in
+    if Int64.compare state.next_lease_sequence max_sequence <= 0
+    then
+      Error
+        "event queue next lease sequence must exceed every lease and receipt sequence"
+    else Ok state)
+;;
+
+let settled_transitions_of_list transitions =
+  let rec loop previous settled_transitions = function
+    | [] -> Ok settled_transitions
+    | transition :: rest ->
+      let sequence = transition.lease.sequence in
+      if
+        match previous with
+        | Some previous -> Int64.compare sequence previous <= 0
+        | None -> false
+      then
+        Error
+          (Printf.sprintf
+             "event queue settled transition sequences must be strictly increasing: %Ld"
+             sequence)
+      else
+        loop
+          (Some sequence)
+          (Sequence_map.add sequence transition settled_transitions)
+          rest
+  in
+  loop None Sequence_map.empty transitions
 ;;
 
 let of_yojson json =
   let context = "keeper event queue state" in
   let* fields = assoc_fields ~context json in
+  let* () =
+    exact_reason_fields
+      ~context
+      [ "schema"
+      ; "revision"
+      ; "next_lease_sequence"
+      ; "pending"
+      ; "leases"
+      ; "settled_transitions"
+      ]
+      fields
+  in
   let* schema_value = string_field ~context "schema" fields in
   if not (String.equal schema_value schema)
   then Error (Printf.sprintf "unsupported keeper event queue state schema: %s" schema_value)
@@ -891,21 +953,17 @@ let of_yojson json =
     let* pending_json = required_field ~context "pending" fields in
     let* pending = Keeper_event_queue.queue_of_yojson pending_json in
     let* leases = list_field ~context "leases" lease_of_yojson fields in
-    let* last_settlement =
-      match List.assoc_opt "last_settlement" fields with
-      | Some `Null -> Ok None
-      | Some json -> transition_receipt_of_yojson json |> Result.map Option.some
-      | None -> Error "keeper event queue state missing required field last_settlement"
+    let* settled_transition_list =
+      list_field ~context "settled_transitions" settled_transition_of_yojson fields
     in
-    let* transition_outbox =
-      list_field ~context "transition_outbox" outbox_entry_of_yojson fields
+    let* settled_transitions =
+      settled_transitions_of_list settled_transition_list
     in
     validate_state
       { revision
       ; next_lease_sequence
       ; pending
       ; leases
-      ; last_settlement
-      ; transition_outbox
+      ; settled_transitions
       }
 ;;

--- a/lib/keeper_runtime/keeper_event_queue_state.mli
+++ b/lib/keeper_runtime/keeper_event_queue_state.mli
@@ -76,7 +76,6 @@ val revision : t -> int64
 val next_lease_sequence : t -> int64
 val pending : t -> Keeper_event_queue.t
 val leases : t -> lease list
-val last_settlement : t -> transition_receipt option
 val transition_outbox : t -> outbox_entry list
 val lease_kind : lease -> lease_kind
 
@@ -124,9 +123,9 @@ val active_lease : t -> lease option
     claiming new pending work. *)
 
 val mark_transition_projected : transition_id:string -> t -> (t, string) result
-(** Atomically retire a durable outbox entry after an external projector has
-    materialized its stable [event_id], retaining only the last receipt for an
-    immediate idempotent retry. Unknown transition ids fail closed. *)
+(** Mark the serial outbox entry projected after its stable [event_id] is
+    materialized. The immutable settled transition retains semantic lease
+    identity and the exact receipt. Unknown transition ids fail closed. *)
 
 val remove_by_post_id :
   Keeper_event_queue.post_id -> t -> Keeper_event_queue.stimulus list * t
@@ -145,4 +144,4 @@ val to_yojson : t -> Yojson.Safe.t
 val of_yojson : Yojson.Safe.t -> (t, string) result
 
 val schema : string
-(** ["keeper.event_queue.state.v2"]. *)
+(** ["keeper.event_queue.state.v3"]. *)

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -18,6 +18,11 @@ let stimulus ?(payload = Queue.Bootstrap) post_id arrived_at : Queue.stimulus =
 
 let queue stimuli = List.fold_left Queue.enqueue Queue.empty stimuli
 
+let list_head_opt = function
+  | [] -> None
+  | head :: _ -> Some head
+;;
+
 let post_ids queue =
   Queue.to_list queue |> List.map (fun (stimulus : Queue.stimulus) -> stimulus.post_id)
 ;;
@@ -78,14 +83,13 @@ let test_claim_codec_ack_idempotency () =
     "projected outbox is retired"
     0
     (List.length (State.transition_outbox state));
-  let projected = require_some "last projected settlement" (State.last_settlement state) in
-  Alcotest.(check string)
-    "projection acknowledgement retains the last receipt"
-    receipt.transition_id
-    projected.transition_id;
   ignore
     (State.mark_transition_projected ~transition_id:receipt.transition_id state
      |> require_ok "projection acknowledgement is idempotent");
+  let forged_lease = { lease with stimuli = [ stimulus "forged" 12.5 ] } in
+  (match State.settle ~settled_at:12.5 ~lease:forged_lease ~settlement:State.Ack state with
+   | Error _ -> ()
+   | Ok _ -> Alcotest.fail "settled lease accepted a different source identity");
   (match
      State.settle
        ~settled_at:13.0
@@ -94,7 +98,62 @@ let test_claim_codec_ack_idempotency () =
        state
    with
    | Error _ -> ()
-   | Ok _ -> Alcotest.fail "conflicting second settlement was accepted")
+   | Ok _ -> Alcotest.fail "conflicting second settlement was accepted");
+  let state = State.with_pending (queue [ stimulus "second" 14.0 ]) state in
+  let state, second_lease = claim_head state in
+  let second_lease = require_some "second history lease" second_lease in
+  let state, second_result =
+    State.settle ~settled_at:15.0 ~lease:second_lease ~settlement:State.Ack state
+    |> require_ok "second history settlement"
+  in
+  let second_receipt =
+    match second_result with
+    | State.Settled receipt -> receipt
+    | State.Already_settled _ ->
+      Alcotest.fail "fresh second history lease was already settled"
+  in
+  let state =
+    State.mark_transition_projected ~transition_id:second_receipt.transition_id state
+    |> require_ok "project second history settlement"
+  in
+  let state_json = State.to_yojson state in
+  let fields =
+    match state_json with
+    | `Assoc fields -> fields
+    | _ -> Alcotest.fail "event queue state codec did not emit an object"
+  in
+  (match State.of_yojson (`Assoc (("last_settlement", `Null) :: fields)) with
+   | Error _ -> ()
+   | Ok _ -> Alcotest.fail "v3 state accepted a legacy authority field");
+  let reversed_transitions =
+    match List.assoc "settled_transitions" fields with
+    | `List transitions -> `List (List.rev transitions)
+    | _ -> Alcotest.fail "settled transitions codec did not emit a list"
+  in
+  let reversed_json =
+    `Assoc
+      (("settled_transitions", reversed_transitions)
+       :: List.remove_assoc "settled_transitions" fields)
+  in
+  (match State.of_yojson reversed_json with
+   | Error _ -> ()
+   | Ok _ -> Alcotest.fail "v3 state accepted reordered receipt history");
+  let state =
+    State.of_yojson state_json
+    |> require_ok "multiple projected receipts roundtrip"
+  in
+  let _, older_retry =
+    State.settle ~settled_at:16.0 ~lease ~settlement:State.Ack state
+    |> require_ok "retry older projected settlement"
+  in
+  (match older_retry with
+   | State.Already_settled older_receipt ->
+     Alcotest.(check string)
+       "older exact receipt survives later projection"
+       receipt.transition_id
+       older_receipt.transition_id
+   | State.Settled _ ->
+     Alcotest.fail "older projected settlement was applied twice")
 ;;
 
 let test_claim_leases_earliest_ready_without_reordering_skipped_work () =
@@ -254,12 +313,12 @@ let test_requeue_and_escalation_are_total () =
     (List.length (State.transition_outbox state));
   let open Yojson.Safe.Util in
   let boundary_failure_settlement =
-    State.to_yojson state
-    |> member "transition_outbox"
-    |> to_list
+    State.transition_outbox state
     |> List.rev
-    |> List.hd
-    |> member "receipt"
+    |> list_head_opt
+    |> require_some "boundary failure transition"
+    |> fun (entry : State.outbox_entry) ->
+    State.transition_receipt_to_yojson entry.receipt
     |> member "settlement"
   in
   Alcotest.(check string)
@@ -357,11 +416,11 @@ let test_judgment_terminal_evidence_is_durable () =
    | _ -> Alcotest.fail "external-input judgment evidence changed during roundtrip");
   let open Yojson.Safe.Util in
   let settlement_json =
-    State.to_yojson state
-    |> member "transition_outbox"
-    |> to_list
-    |> List.hd
-    |> member "receipt"
+    State.transition_outbox state
+    |> list_head_opt
+    |> require_some "external-input transition"
+    |> fun (entry : State.outbox_entry) ->
+    State.transition_receipt_to_yojson entry.receipt
     |> member "settlement"
   in
   Alcotest.(check string)


### PR DESCRIPTION
## Stack

Base: #24998

## What

- replaces the lossy `last_settlement` slot with one immutable `Map.Make(Int64)` authority
- retains semantic source-lease identity, exact receipt, and projection state per settled sequence
- keeps canonical sequence ordering and exact retry/conflict behavior after later settlements
- hard-cuts the wire envelope to `keeper.event_queue.state.v3` and rejects legacy authority fields

## Deliberate boundary

This is the safe history prerequisite only. It deliberately retains the current serial outbox admission rule. It does **not** claim that Keeper execution is nonblocking yet; the next stacked cut must move projection I/O off the heartbeat lane while removing the admission/dedup authority atomically.

Do not merge until the deployment cutover is explicit: local runtime inspection found zero v2 snapshots under `/Users/dancer/me/.masc`, but that is not proof for every deployed base path. v2 cannot be losslessly reconstructed because its projected receipt omitted the original source lease.

## Verification

- `scripts/dune-local.sh build test/test_keeper_event_queue_state_v2.exe`
- `scripts/dune-local.sh exec test/test_keeper_event_queue_state_v2.exe` — 13/13 green
- focused `ocamlformat --check`
- `git diff --check`
- 398 changed lines
