### PR TITLE
refactor(keeper): extract transition projector

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -382,43 +382,13 @@ let settlement_of_cycle_outcome ~base_path ~settled_at ~stop_requested ~lease ou
     )
 ;;
 
-let reaction_kind_of_settlement = function
-  | Keeper_registry_event_queue.Ack -> Keeper_reaction_ledger.Event_queue_ack
-  | Keeper_registry_event_queue.Requeue _ ->
-    Keeper_reaction_ledger.Event_queue_requeued
-  | Keeper_registry_event_queue.Escalate _ ->
-    Keeper_reaction_ledger.Event_queue_escalated
-;;
-
 let project_transition_outbox ~base_path ~keeper_name =
-  let rec project_stimuli ~reaction_kind ~receipt = function
-    | [] -> Ok ()
-    | stimulus :: rest ->
-      (match
-         Keeper_reaction_ledger.record_event_queue_transition_reaction_result
-           ~base_path
-           ~keeper_name
-           ~reaction_kind
-           ~receipt
-           stimulus
-       with
-       | Error _ as error -> error
-       | Ok () -> project_stimuli ~reaction_kind ~receipt rest)
-  in
-  match Keeper_registry_event_queue.transition_outbox_result ~base_path keeper_name with
-  | Error _ as error -> error
-  | Ok [] -> Ok ()
-  | Ok [ (entry : Keeper_registry_event_queue.outbox_entry) ] ->
-    let receipt = entry.receipt in
-    let reaction_kind = reaction_kind_of_settlement receipt.settlement in
-    (match project_stimuli ~reaction_kind ~receipt entry.stimuli with
-     | Error _ as error -> error
-     | Ok () ->
-       Keeper_registry_event_queue.mark_transition_projected_result
-         ~base_path
-         keeper_name
-         ~transition_id:receipt.transition_id)
-  | Ok (_ :: _ :: _) -> Error "event queue state has multiple unprojected transitions"
+  match
+    Keeper_transition_projector.project_transition_outbox ~base_path ~keeper_name
+  with
+  | Ok _ -> Ok ()
+  | Error failure ->
+    Error (Keeper_transition_projector.projection_failure_to_string failure)
 ;;
 
 let settle_claimed_lease

--- a/lib/keeper/keeper_transition_projector.ml
+++ b/lib/keeper/keeper_transition_projector.ml
@@ -1,0 +1,92 @@
+type projection_failure =
+  | Queue_read_failed of { detail : string }
+  | Reaction_append_failed of
+      { transition_id : string
+      ; stimulus_post_id : string
+      ; detail : string
+      }
+  | Projection_mark_failed of
+      { transition_id : string
+      ; detail : string
+      }
+  | Multiple_unprojected_transitions of { count : int }
+
+type projection_report =
+  { projected_transition_count : int
+  ; projected_stimulus_count : int
+  }
+
+let projection_failure_to_string = function
+  | Queue_read_failed { detail }
+  | Reaction_append_failed { detail; _ }
+  | Projection_mark_failed { detail; _ } ->
+    detail
+  | Multiple_unprojected_transitions _ ->
+    "event queue state has multiple unprojected transitions"
+;;
+
+let reaction_kind_of_settlement = function
+  | Keeper_registry_event_queue.Ack -> Keeper_reaction_ledger.Event_queue_ack
+  | Keeper_registry_event_queue.Requeue _ ->
+    Keeper_reaction_ledger.Event_queue_requeued
+  | Keeper_registry_event_queue.Escalate _ ->
+    Keeper_reaction_ledger.Event_queue_escalated
+;;
+
+let project_transition_outbox ~base_path ~keeper_name =
+  let rec project_stimuli ~reaction_kind ~receipt ~projected_count = function
+    | [] -> Ok projected_count
+    | stimulus :: rest ->
+      (match
+         Keeper_reaction_ledger.record_event_queue_transition_reaction_result
+           ~base_path
+           ~keeper_name
+           ~reaction_kind
+           ~receipt
+           stimulus
+       with
+       | Error detail ->
+         Error
+           (Reaction_append_failed
+              { transition_id = receipt.transition_id
+              ; stimulus_post_id = stimulus.Keeper_event_queue.post_id
+              ; detail
+              })
+       | Ok () ->
+         project_stimuli
+           ~reaction_kind
+           ~receipt
+           ~projected_count:(projected_count + 1)
+           rest)
+  in
+  match Keeper_registry_event_queue.transition_outbox_result ~base_path keeper_name with
+  | Error detail -> Error (Queue_read_failed { detail })
+  | Ok [] ->
+    Ok { projected_transition_count = 0; projected_stimulus_count = 0 }
+  | Ok [ (entry : Keeper_registry_event_queue.outbox_entry) ] ->
+    let receipt = entry.receipt in
+    let reaction_kind = reaction_kind_of_settlement receipt.settlement in
+    (match
+       project_stimuli
+         ~reaction_kind
+         ~receipt
+         ~projected_count:0
+         entry.stimuli
+     with
+     | Error _ as error -> error
+     | Ok projected_stimulus_count ->
+       (match
+          Keeper_registry_event_queue.mark_transition_projected_result
+            ~base_path
+            keeper_name
+            ~transition_id:receipt.transition_id
+        with
+        | Error detail ->
+          Error
+            (Projection_mark_failed
+               { transition_id = receipt.transition_id; detail })
+        | Ok () ->
+          Ok { projected_transition_count = 1; projected_stimulus_count }))
+  | Ok entries ->
+    Error (Multiple_unprojected_transitions { count = List.length entries })
+;;

--- a/lib/keeper/keeper_transition_projector.mli
+++ b/lib/keeper/keeper_transition_projector.mli
@@ -1,0 +1,33 @@
+(** Synchronous projection of one Keeper lane's durable queue transition.
+
+    The projector appends every stimulus reaction in source order and retires
+    the transition only after every append succeeds. *)
+
+type projection_failure =
+  | Queue_read_failed of { detail : string }
+  | Reaction_append_failed of
+      { transition_id : string
+      ; stimulus_post_id : string
+      ; detail : string
+      }
+  | Projection_mark_failed of
+      { transition_id : string
+      ; detail : string
+      }
+  | Multiple_unprojected_transitions of { count : int }
+
+type projection_report =
+  { projected_transition_count : int
+  ; projected_stimulus_count : int
+  }
+
+val project_transition_outbox :
+  base_path:string ->
+  keeper_name:string ->
+  (projection_report, projection_failure) result
+(** Project the lane's current transition outbox synchronously. An empty
+    outbox succeeds with zero counts. More than one entry is an explicit state
+    invariant failure. *)
+
+val projection_failure_to_string : projection_failure -> string
+(** Preserve the existing heartbeat boundary's textual failure contract. *)

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -931,8 +931,26 @@ let test_transition_outbox_projects_with_stable_identity () =
      with
      | Persistence.Already_present -> ()
      | Persistence.Enqueued -> Alcotest.fail "outbox stimulus was duplicated");
-    Masc.Keeper_heartbeat_loop.project_transition_outbox ~base_path ~keeper_name
-    |> require_ok "project transition outbox";
+    let report =
+      match
+        Masc.Keeper_transition_projector.project_transition_outbox
+          ~base_path
+          ~keeper_name
+      with
+      | Ok report -> report
+      | Error failure ->
+        Alcotest.failf
+          "project transition outbox: %s"
+          (Masc.Keeper_transition_projector.projection_failure_to_string failure)
+    in
+    Alcotest.(check int)
+      "one transition projected"
+      1
+      report.projected_transition_count;
+    Alcotest.(check int)
+      "one stimulus projected"
+      1
+      report.projected_stimulus_count;
     let state =
       Persistence.load_state_result ~base_path ~keeper_name
       |> require_ok "load projected state"


### PR DESCRIPTION
## What

- extract the synchronous queue-transition projection body from Keeper heartbeat into a dedicated typed module
- classify queue reads, reaction appends, projection retirement, and outbox-cardinality failures with a closed variant
- return explicit projected transition/stimulus counts while preserving the existing heartbeat string-result wrapper

## Semantics preserved

- projection still runs synchronously at the same two heartbeat call sites
- stimulus reactions are appended serially in source order
- the outbox entry is retired only after every append succeeds
- the first failure still aborts projection with the same external error text
- no admission, daemon, timeout, cap, scheduling, or settlement behavior changes

## Verification

- MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_keeper_event_queue_state_v2.exe
- _build/default/test/test_keeper_event_queue_state_v2.exe (13 tests passed)
- ocamlformat --check on all touched OCaml files
- git diff --check

Stacked on #24999 exact head 122fd27147d1c797659a84fa5a48de1fe5ddac49.
