### PR TITLE
refactor(keeper): delete time-window queue dedup

### DIFF
--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -317,22 +317,6 @@ let remove_by_post_id_pair post_id left right =
   let right_removed, right' = remove_by_post_id post_id right in
   uniq_stimuli (left_removed @ right_removed), left', right'
 
-let dedup_by_post_id ?(window_seconds = 60.0) (queue : t) : t =
-  let within_window a b =
-    Float.abs (a.arrived_at -. b.arrived_at) <= window_seconds
-  in
-  let rec aux acc = function
-    | [] -> List.rev acc
-    | s :: rest ->
-        let later =
-          List.filter
-            (fun s' -> not (s'.post_id = s.post_id && within_window s s'))
-            rest
-        in
-        aux (s :: acc) later
-  in
-  of_list (aux [] (to_list queue))
-
 let sort_by_urgency (queue : t) : t =
   queue
   |> to_list

--- a/lib/keeper_runtime/keeper_event_queue.mli
+++ b/lib/keeper_runtime/keeper_event_queue.mli
@@ -22,7 +22,8 @@ type urgency =
   | Low        (** background polling, telemetry-driven nudges *)
 
 type post_id = string
-(** Identifier used by [dedup_by_post_id] to collapse repeat events.
+(** Producer-supplied identity component used by
+    {!stimulus_identity_equal}.
 
     The runtime uses the originating board post id, the mention
     target id, or the operator directive token. The queue does
@@ -274,11 +275,6 @@ val dedup_by_identity : t -> t
 val remove_by_post_id_pair : post_id -> t -> t -> stimulus list * t * t
 (** Remove matching stimuli from two queues and return the de-duplicated
     removed stimuli plus both remaining queues. *)
-
-val dedup_by_post_id : ?window_seconds:float -> t -> t
-(** Drops later duplicates of the same [post_id] when their
-    [arrived_at] differs by less than [window_seconds] (default
-    [60.0]). FIFO order of survivors is preserved. *)
 
 val sort_by_urgency : t -> t
 (** Stable sort: [Immediate] < [Normal] < [Low]. Two stimuli of the

--- a/test/keeper_event_queue/test_keeper_event_queue.ml
+++ b/test/keeper_event_queue/test_keeper_event_queue.ml
@@ -11,9 +11,8 @@
 
 open Keeper_event_queue
 
-(* Stimuli are distinguished by [post_id] / [arrived_at]; the typed
-   [payload] defaults to [Bootstrap] since the queue ordering/dedup
-   logic is payload-agnostic. *)
+(* The typed [payload] defaults to [Bootstrap] since these ordering tests do
+   not need a domain payload. *)
 let make_stim ?(urgency = Normal) ?(arrived_at = 0.0) ?(payload = Bootstrap) post_id =
   { post_id; urgency; arrived_at; payload }
 
@@ -39,24 +38,6 @@ let test_enqueue_dequeue_fifo () =
            assert (is_empty rest2)
        | None -> assert false)
   | None -> assert false
-
-let test_dedup_within_window () =
-  let s1 = make_stim ~arrived_at:0.0 "p1" in
-  let s2 = make_stim ~arrived_at:30.0 "p1" in (* within 60s *)
-  let s3 = make_stim ~arrived_at:200.0 "p1" in (* outside 60s *)
-  let q = enqueue (enqueue (enqueue empty s1) s2) s3 in
-  let dedup = dedup_by_post_id q in
-  assert (length dedup = 2);
-  match dequeue dedup with
-  | Some (head, _) -> assert (head.arrived_at = 0.0) (* first survivor kept *)
-  | None -> assert false
-
-let test_dedup_custom_window () =
-  let s1 = make_stim ~arrived_at:0.0 "p1" in
-  let s2 = make_stim ~arrived_at:5.0 "p1" in
-  let q = enqueue (enqueue empty s1) s2 in
-  assert (length (dedup_by_post_id ~window_seconds:1.0 q) = 2);
-  assert (length (dedup_by_post_id ~window_seconds:10.0 q) = 1)
 
 let test_sort_by_urgency () =
   let s_low = make_stim ~urgency:Low "p1" in
@@ -136,8 +117,6 @@ let test_typed_payload_surface () =
 let () =
   test_empty ();
   test_enqueue_dequeue_fifo ();
-  test_dedup_within_window ();
-  test_dedup_custom_window ();
   test_sort_by_urgency ();
   test_sort_stable_within_bucket ();
   test_conservation ();


### PR DESCRIPTION
## What

- delete the unused `Keeper_event_queue.dedup_by_post_id` API
- delete its arbitrary 60-second/custom-window implementation
- delete tests whose only purpose was to preserve that withdrawn heuristic
- keep exact typed `stimulus_identity_equal` / `dedup_by_identity` as the queue identity boundary

## Why

Elapsed time does not establish event identity. The function has no production call sites, so retaining the public API and tests only preserves a heuristic contract that conflicts with the current typed occurrence direction.

## Validation

- `ocamlformat --check` on all three changed files: pass
- `git diff --check`: pass
- `rg dedup_by_post_id lib test`: zero
- focused Dune build: not claimed; the local switch is still `agent_sdk 0.213.0` while current main requires `0.214.1`, and the repo wrapper correctly rejected that pin drift. PR CI is the build authority.

Diff: 3 files, +4/-45.
