### PR TITLE
refactor(keeper): isolate generic operation records

### DIFF
--- a/lib/keeper_operation_record/dune
+++ b/lib/keeper_operation_record/dune
@@ -1,0 +1,8 @@
+(include_subdirs no)
+
+(library
+ (name masc_keeper_operation_record)
+ (public_name masc.keeper_operation_record)
+ (wrapped false)
+ (modules keeper_operation_record)
+ (libraries yojson))

--- a/lib/keeper_operation_record/keeper_operation_record.ml
+++ b/lib/keeper_operation_record/keeper_operation_record.ml
@@ -1,0 +1,121 @@
+module Cursor = struct
+  type t = int
+  type error = Negative of int
+
+  let zero = 0
+  let of_int value = if value < 0 then Error (Negative value) else Ok value
+  let to_int value = value
+end
+
+type 'event row =
+  { recorded_at : float
+  ; start_cursor : Cursor.t
+  ; end_cursor : Cursor.t
+  ; event : 'event
+  }
+
+type 'event_error envelope_error =
+  | Expected_object
+  | Unknown_field of string
+  | Duplicate_field of string
+  | Missing_field of string
+  | Invalid_recorded_at
+  | Invalid_event of 'event_error
+
+type encode_error = Non_finite_recorded_at
+
+type 'event_error issue =
+  | Incomplete_tail
+  | Malformed_json of string
+  | Invalid_envelope of 'event_error envelope_error
+
+type 'event_error decode_error =
+  { row_number : int option
+  ; start_cursor : Cursor.t
+  ; end_cursor : Cursor.t
+  ; issue : 'event_error issue
+  }
+
+let ( let* ) = Result.bind
+
+let required_field name fields =
+  match List.filter (fun (field, _) -> String.equal field name) fields with
+  | [] -> Error (Missing_field name)
+  | [ _, value ] -> Ok value
+  | _ -> Error (Duplicate_field name)
+;;
+
+let decode_envelope ~decode_event = function
+  | `Assoc fields ->
+    let* () =
+      match
+        List.find_opt
+          (fun (name, _) ->
+             not
+               (String.equal name "recorded_at"
+                || String.equal name "event"))
+          fields
+      with
+      | None -> Ok ()
+      | Some (name, _) -> Error (Unknown_field name)
+    in
+    let* recorded_json = required_field "recorded_at" fields in
+    let* recorded_at =
+      match recorded_json with
+      | `Float value when Float.is_finite value -> Ok value
+      | _ -> Error Invalid_recorded_at
+    in
+    let* event_json = required_field "event" fields in
+    decode_event event_json
+    |> Result.map_error (fun error -> Invalid_event error)
+    |> Result.map (fun event -> recorded_at, event)
+  | _ -> Error Expected_object
+;;
+
+let encode ~encode_event ~recorded_at event =
+  if not (Float.is_finite recorded_at)
+  then Error Non_finite_recorded_at
+  else
+    Ok
+      (`Assoc
+         [ "recorded_at", `Float recorded_at
+         ; "event", encode_event event
+         ]
+       |> Yojson.Safe.to_string
+       |> fun value -> value ^ "\n")
+;;
+
+let decode_rows ~decode_event ~from ~row_number bytes =
+  let base = Cursor.to_int from in
+  let length = String.length bytes in
+  let locate number start_cursor end_cursor issue =
+    Error { row_number = number; start_cursor; end_cursor; issue }
+  in
+  let rec loop position number rows =
+    if position = length
+    then Ok (List.rev rows)
+    else
+      match String.index_from_opt bytes position '\n' with
+      | None ->
+        locate number (base + position) (base + length) Incomplete_tail
+      | Some newline ->
+        let start_cursor = base + position in
+        let end_cursor = base + newline + 1 in
+        let payload = String.sub bytes position (newline - position) in
+        (match
+           try Ok (Yojson.Safe.from_string payload) with
+           | Yojson.Json_error detail -> Error (Malformed_json detail)
+         with
+         | Error issue -> locate number start_cursor end_cursor issue
+         | Ok json ->
+           (match decode_envelope ~decode_event json with
+            | Error error ->
+              locate number start_cursor end_cursor (Invalid_envelope error)
+            | Ok (recorded_at, event) ->
+              loop
+                (newline + 1)
+                (Option.map succ number)
+                ({ recorded_at; start_cursor; end_cursor; event } :: rows)))
+  in
+  loop 0 row_number []
+;;

--- a/lib/keeper_operation_record/keeper_operation_record.mli
+++ b/lib/keeper_operation_record/keeper_operation_record.mli
@@ -1,0 +1,54 @@
+(** Closed JSONL envelope around one caller-owned typed operation codec. *)
+
+module Cursor : sig
+  type t
+  type error = Negative of int
+
+  val zero : t
+  val of_int : int -> (t, error) result
+  val to_int : t -> int
+end
+
+type 'event row =
+  { recorded_at : float
+  ; start_cursor : Cursor.t
+  ; end_cursor : Cursor.t
+  ; event : 'event
+  }
+
+type 'event_error envelope_error =
+  | Expected_object
+  | Unknown_field of string
+  | Duplicate_field of string
+  | Missing_field of string
+  | Invalid_recorded_at
+  | Invalid_event of 'event_error
+
+type encode_error = Non_finite_recorded_at
+
+type 'event_error issue =
+  | Incomplete_tail
+  | Malformed_json of string
+  | Invalid_envelope of 'event_error envelope_error
+
+type 'event_error decode_error =
+  { row_number : int option
+  ; start_cursor : Cursor.t
+  ; end_cursor : Cursor.t
+  ; issue : 'event_error issue
+  }
+
+val encode
+  :  encode_event:('event -> Yojson.Safe.t)
+  -> recorded_at:float
+  -> 'event
+  -> (string, encode_error) result
+(** Returns exactly one newline-terminated JSONL row. *)
+
+val decode_rows
+  :  decode_event:(Yojson.Safe.t -> ('event, 'event_error) result)
+  -> from:Cursor.t
+  -> row_number:int option
+  -> string
+  -> ('event row list, 'event_error decode_error) result
+(** [row_number] is [Some] only when the caller owns the complete prefix. *)

--- a/test/keeper_operation_record/dune
+++ b/test/keeper_operation_record/dune
@@ -1,0 +1,3 @@
+(test
+ (name test_keeper_operation_record)
+ (libraries alcotest masc.keeper_operation_record yojson))

--- a/test/keeper_operation_record/test_keeper_operation_record.ml
+++ b/test/keeper_operation_record/test_keeper_operation_record.ml
@@ -1,0 +1,187 @@
+module Record = Keeper_operation_record
+
+type event = { sequence : int }
+
+type event_error =
+  | Expected_event_object
+  | Unknown_event_field of string
+  | Duplicate_sequence
+  | Missing_sequence
+  | Invalid_sequence
+
+let encode_event event = `Assoc [ "sequence", `Int event.sequence ]
+
+let decode_event = function
+  | `Assoc fields ->
+    (match
+       List.find_opt
+         (fun (name, _) -> not (String.equal name "sequence"))
+         fields
+     with
+     | Some (name, _) -> Error (Unknown_event_field name)
+     | None ->
+       (match List.filter (fun (name, _) -> String.equal name "sequence") fields with
+        | [] -> Error Missing_sequence
+        | [ _, `Int sequence ] -> Ok { sequence }
+        | [ _ ] -> Error Invalid_sequence
+        | _ -> Error Duplicate_sequence))
+  | _ -> Error Expected_event_object
+;;
+
+let ok = function
+  | Ok value -> value
+  | Error _ -> Alcotest.fail "fixture construction failed"
+;;
+
+let encode ~recorded_at event =
+  Record.encode ~encode_event ~recorded_at event
+;;
+
+let decode_rows ~from ~row_number bytes =
+  Record.decode_rows ~decode_event ~from ~row_number bytes
+;;
+
+let jsonl json = Yojson.Safe.to_string json ^ "\n"
+
+let expect_envelope_issue expected bytes =
+  match decode_rows ~from:Record.Cursor.zero ~row_number:(Some 4) bytes with
+  | Error { row_number = Some 4; issue = Record.Invalid_envelope actual; _ }
+    when expected actual ->
+    ()
+  | _ -> Alcotest.fail "unexpected envelope result"
+;;
+
+let test_roundtrip_and_cursor () =
+  let first = ok (encode ~recorded_at:(-1.25) { sequence = 7 }) in
+  let second = ok (encode ~recorded_at:2.5 { sequence = 8 }) in
+  let from = ok (Record.Cursor.of_int 17) in
+  match decode_rows ~from ~row_number:(Some 4) (first ^ second) with
+  | Ok [ left; right ] ->
+    Alcotest.(check int) "first event" 7 left.event.sequence;
+    Alcotest.(check int) "second event" 8 right.event.sequence;
+    Alcotest.(check (float 0.0)) "first timestamp" (-1.25) left.recorded_at;
+    Alcotest.(check int) "first start" 17 (Record.Cursor.to_int left.start_cursor);
+    Alcotest.(check int)
+      "first end"
+      (17 + String.length first)
+      (Record.Cursor.to_int left.end_cursor);
+    Alcotest.(check int)
+      "second end"
+      (17 + String.length first + String.length second)
+      (Record.Cursor.to_int right.end_cursor)
+  | _ -> Alcotest.fail "canonical rows did not decode"
+;;
+
+let test_cursor_rejects_negative () =
+  match Record.Cursor.of_int (-1) with
+  | Error (Record.Cursor.Negative (-1)) -> ()
+  | _ -> Alcotest.fail "negative cursor accepted"
+;;
+
+let test_closed_envelope () =
+  let event = encode_event { sequence = 1 } in
+  expect_envelope_issue
+    (function
+      | Record.Unknown_field "extra" -> true
+      | _ -> false)
+    (jsonl
+       (`Assoc
+          [ "recorded_at", `Float 1.0
+          ; "event", event
+          ; "extra", `Null
+          ]));
+  expect_envelope_issue
+    (function
+      | Record.Duplicate_field "event" -> true
+      | _ -> false)
+    (jsonl
+       (`Assoc
+          [ "recorded_at", `Float 1.0
+          ; "event", event
+          ; "event", event
+          ]));
+  expect_envelope_issue
+    (function
+      | Record.Missing_field "event" -> true
+      | _ -> false)
+    (jsonl (`Assoc [ "recorded_at", `Float 1.0 ]))
+;;
+
+let test_invalid_event_is_preserved () =
+  let bytes =
+    jsonl
+      (`Assoc
+         [ "recorded_at", `Float 1.0
+         ; "event", `Assoc [ "future", `Int 1 ]
+         ])
+  in
+  expect_envelope_issue
+    (function
+      | Record.Invalid_event (Unknown_event_field "future") -> true
+      | _ -> false)
+    bytes
+;;
+
+let test_incomplete_tail () =
+  match
+    decode_rows
+      ~from:(ok (Record.Cursor.of_int 8))
+      ~row_number:None
+      "{}"
+  with
+  | Error
+      { row_number = None
+      ; start_cursor
+      ; end_cursor
+      ; issue = Record.Incomplete_tail
+      } ->
+    Alcotest.(check int) "start" 8 (Record.Cursor.to_int start_cursor);
+    Alcotest.(check int) "end" 10 (Record.Cursor.to_int end_cursor)
+  | _ -> Alcotest.fail "incomplete tail was accepted"
+;;
+
+let test_malformed_json () =
+  match decode_rows ~from:Record.Cursor.zero ~row_number:(Some 9) "{]\n" with
+  | Error
+      { row_number = Some 9
+      ; start_cursor
+      ; end_cursor
+      ; issue = Record.Malformed_json _
+      } ->
+    Alcotest.(check int) "start" 0 (Record.Cursor.to_int start_cursor);
+    Alcotest.(check int) "end" 3 (Record.Cursor.to_int end_cursor)
+  | _ -> Alcotest.fail "malformed JSON was accepted"
+;;
+
+let test_non_finite_time () =
+  List.iter
+    (fun recorded_at ->
+       match encode ~recorded_at { sequence = 1 } with
+       | Error Record.Non_finite_recorded_at -> ()
+       | _ -> Alcotest.fail "non-finite timestamp encoded")
+    [ Float.nan; Float.infinity; Float.neg_infinity ];
+  expect_envelope_issue
+    (function
+      | Record.Invalid_recorded_at -> true
+      | _ -> false)
+    (jsonl
+       (`Assoc
+          [ "recorded_at", `String "not-a-number"
+          ; "event", encode_event { sequence = 1 }
+          ]))
+;;
+
+let () =
+  Alcotest.run
+    "keeper operation record"
+    [ ( "record"
+      , [ Alcotest.test_case "roundtrip and cursor" `Quick test_roundtrip_and_cursor
+        ; Alcotest.test_case "negative cursor" `Quick test_cursor_rejects_negative
+        ; Alcotest.test_case "closed envelope" `Quick test_closed_envelope
+        ; Alcotest.test_case "invalid event" `Quick test_invalid_event_is_preserved
+        ; Alcotest.test_case "incomplete tail" `Quick test_incomplete_tail
+        ; Alcotest.test_case "malformed JSON" `Quick test_malformed_json
+        ; Alcotest.test_case "finite time" `Quick test_non_finite_time
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary
- introduce one codec-parametric JSONL operation-record boundary
- keep the library independent from compaction, providers, tools, plugins, and product-domain types
- preserve typed cursor and exact decode failures without fallback

## Scope
- 5 files, 373 changed lines
- direct stack on current `main`
- no consumer wiring in this PR

## Verification
- `MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build @test/keeper_operation_record/runtest` (7/7 pass)
- `ocamlformat --check` on all changed OCaml/Dune files
- `git diff --check`

The pin bypass is local-environment-only: this repository declares OAS/agent_sdk `0.214.1`, while the shared opam switch currently points at a different session pin. PR CI remains the authoritative `0.214.1` verification.