### PR TITLE
fix(keeper): compact board attention candidate ledger on write

### DIFF
--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -1868,6 +1868,26 @@ let update_private_file_durable_locked_result path decide =
               |> Result.map (fun () -> result))))
 ;;
 
+let rewrite_private_file_durable_locked_result path decide =
+  test_exec_home_guard ~op:"rewrite_private_file_durable_locked" path;
+  let dir = Filename.dirname path in
+  mkdir_p_memoized dir;
+  let path_mu = get_append_path_mutex path in
+  run_blocking_private_file_transaction
+    ~label:"fs-compat-durable-rewrite"
+    ~path
+    (fun () ->
+    Stdlib.Mutex.protect path_mu (fun () ->
+      let existing = Option.value (load_file_opt path) ~default:"" in
+      let content, result = decide existing in
+      match content with
+      | None -> Ok result
+      | Some content ->
+        (match save_file_atomic path content with
+         | Ok () -> Ok result
+         | Error message -> Error message)))
+;;
+
 type private_jsonl_append_error =
   | Incomplete_jsonl_tail
   | Invalid_jsonl_suffix

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -785,6 +785,22 @@ val durable_append_error_to_string : durable_append_error -> string
 val update_private_file_durable_locked_result :
   string -> (string -> string option * 'a) -> ('a, durable_append_error) result
 
+(** [rewrite_private_file_durable_locked_result path decide] is the whole-file
+    replacement sibling of {!update_private_file_durable_locked_result}. It takes
+    the same shared per-path append mutex, reads the exact existing bytes (empty
+    string when the file is absent), and calls [decide]. [Some content] replaces
+    the file's entire contents with [content] via a temp-file + atomic rename
+    (see {!save_file_atomic}); [None] performs no write. Because it shares the
+    append mutex, in-process appends and rewrites of the same path are
+    serialized. The atomic rename leaves the original file untouched until it
+    succeeds, so a failed rewrite never leaves a partially written ledger. This
+    coordinates in-process writers only; unlike the append primitive it does not
+    hold a whole-file lock across the read/rewrite, so a second OS process must
+    not write the same path concurrently. Returns the rename failure message on
+    [Error]; [decide] exceptions still propagate. *)
+val rewrite_private_file_durable_locked_result :
+  string -> (string -> string option * 'a) -> ('a, string) result
+
 type private_jsonl_append_error =
   | Incomplete_jsonl_tail
   | Invalid_jsonl_suffix

--- a/lib/keeper/keeper_board_attention_candidate.ml
+++ b/lib/keeper/keeper_board_attention_candidate.ml
@@ -621,19 +621,32 @@ let load_candidates ~base_path ~keeper_name =
 
 let append_row candidate = Yojson.Safe.to_string (candidate_to_json candidate) ^ "\n"
 
+let serialize_candidates candidates =
+  String.concat "" (List.map append_row candidates)
+;;
+
 let update_ledger ~base_path ~keeper_name decide =
   let path = candidate_path ~base_path ~keeper_name in
+  (* Compact on write: a committed change rewrites the ledger as the deduped
+     latest-per-id set (via [latest_candidates]) instead of appending one row.
+     The reader already discards all but the latest row per candidate_id, so the
+     older rows are dead weight; appending them grew the file without bound and
+     made every update O(n^2) because the durable transaction re-parses the whole
+     ledger before writing. Rewriting keeps the file bounded to the number of
+     distinct candidates. *)
   match
-    Fs_compat.update_private_file_durable_locked_result path (fun content ->
+    Fs_compat.rewrite_private_file_durable_locked_result path (fun content ->
       match load_candidates_from_content content with
       | Error detail -> None, Error detail
       | Ok candidates ->
         (match decide candidates with
          | Error _ as error -> None, error
          | Ok (None, result) -> None, Ok result
-         | Ok (Some candidate, result) -> Some (append_row candidate), Ok result))
+         | Ok (Some candidate, result) ->
+           let compacted = latest_candidates (candidates @ [ candidate ]) in
+           Some (serialize_candidates compacted), Ok result))
   with
-  | Error error -> Error (durable_error_to_string error)
+  | Error error -> Error error
   | Ok result -> result
 ;;
 

--- a/test/test_keeper_board_attention_candidate.ml
+++ b/test/test_keeper_board_attention_candidate.ml
@@ -342,6 +342,72 @@ let test_strict_judgment_contract_rejects_extra_fields () =
   | Ok _ -> Alcotest.fail "structured judgment accepted an undeclared score"
 ;;
 
+let count_ledger_lines base_path =
+  let dir =
+    Filename.concat
+      (Filename.concat base_path ".masc")
+      "board_attention_candidates"
+  in
+  Sys.readdir dir
+  |> Array.to_list
+  |> List.filter (fun name -> Filename.check_suffix name ".jsonl")
+  |> List.fold_left
+       (fun total name ->
+         let channel = open_in (Filename.concat dir name) in
+         Fun.protect
+           ~finally:(fun () -> close_in channel)
+           (fun () ->
+             let rec loop count =
+               match input_line channel with
+               | (_ : string) -> loop (count + 1)
+               | exception End_of_file -> count
+             in
+             total + loop 0))
+       0
+;;
+
+let test_update_ledger_compacts_to_distinct () =
+  with_temp_base "keeper-board-attention-compaction" @@ fun base_path ->
+  let pending = record_or_fail ~base_path (candidate ()) in
+  let keeper_name = pending.keeper_name in
+  (* Record several retryable failures against the same candidate id. Each is a
+     committed update; before compaction the ledger grew by one row per update
+     (and each update re-parsed the whole ledger, so writes were O(n^2)). *)
+  let transitions = 6 in
+  ignore
+    (List.fold_left
+       (fun current index ->
+         let failure : A.retryable_failure =
+           { kind = A.Provider_unavailable
+           ; detail = Printf.sprintf "provider unavailable %d" index
+           ; failed_at = 102.0 +. float_of_int index
+           }
+         in
+         match A.record_retryable_failure ~base_path current failure with
+         | Ok candidate -> candidate
+         | Error detail -> Alcotest.failf "failure %d not recorded: %s" index detail)
+       pending
+       (List.init transitions Fun.id)
+     : A.candidate);
+  Alcotest.(check int)
+    "ledger holds one row per distinct candidate_id"
+    1
+    (count_ledger_lines base_path);
+  match A.load_candidates ~base_path ~keeper_name with
+  | Ok [ latest ] ->
+    (match latest.status with
+     | A.Pending { last_failure = Some observed } ->
+       Alcotest.(check string)
+         "latest failure wins after compaction"
+         "provider unavailable 5"
+         observed.detail
+     | A.Pending { last_failure = None } | A.Judged _ | A.Consumed _ ->
+       Alcotest.fail "compaction dropped the latest pending failure")
+  | Ok candidates ->
+    Alcotest.failf "expected one compacted candidate, got %d" (List.length candidates)
+  | Error detail -> Alcotest.failf "load after compaction failed: %s" detail
+;;
+
 let () =
   Alcotest.run
     "keeper_board_attention_candidate"
@@ -378,6 +444,10 @@ let () =
             "strict judgment rejects undeclared score"
             `Quick
             test_strict_judgment_contract_rejects_extra_fields
+        ; Alcotest.test_case
+            "update ledger compacts to distinct candidate count"
+            `Quick
+            test_update_ledger_compacts_to_distinct
         ] )
     ]
 ;;


### PR DESCRIPTION
## 문제

`Keeper_board_attention_candidate`의 candidate 원장(`.masc/board_attention_candidates/<keeper>.jsonl`)이 **compaction 없는 append-only ledger**입니다. `update_ledger`가 상태 갱신마다 한 줄을 append하는데, reader(`latest_candidates`)는 candidate_id별 최신 행만 남기고 나머지를 버립니다. 결과:

- 파일이 무한 증가 — 실측 `.masc/board_attention_candidates/` = **150MB**, 최대 파일 `rondo.jsonl` 3556줄 / distinct candidate_id 505 (**7:1** 죽은 행).
- `update_ledger`의 durable 트랜잭션이 append 전에 원장 전체를 재파싱 → 갱신이 **O(n²)**.
- 부팅 시 `resume_pending → load_candidates`가 이 거대 원장을 동기 파싱 → HTTP fiber 기아 → health 무응답. 실측: startup RSS 10.2GB, health 10분+ 무응답.

## 수정 (근본, compact-on-write)

원장의 의미가 이미 "candidate_id별 최신"이므로, 저장도 최신 집합만 유지한다.

1. `fs_compat.rewrite_private_file_durable_locked_result` 추가 — `update_private_file_durable_locked_result`(append 전용)의 **원자 전체교체 형제**. 같은 per-path append mutex를 잡고, `Some content`면 `save_file_atomic`(temp + rename)으로 파일 전체를 교체, `None`이면 무기록. mutex 공유로 in-process append와 rewrite가 직렬화된다. rename 원자성으로 실패 시 원본이 손상되지 않는다.
2. `Keeper_board_attention_candidate.update_ledger`가 커밋 시 append 대신 `latest_candidates (candidates @ [candidate])`를 직렬화해 **전체 재기록**. 파일이 distinct candidate 수로 bound되고, 갱신이 O(distinct)로 떨어진다.
3. malformed 원장은 그대로 보존(`load_candidates_from_content` 실패 시 `None` 반환 = 무기록) — 기존 계약 유지.

## 검증

- 신규 테스트 `test_update_ledger_compacts_to_distinct`: 같은 candidate_id에 retryable failure 6회 → 원장 raw 줄수 **1** (append 시절이면 7) + 최신 실패값 보존.
- 기존 `keeper_board_attention_candidate` 테스트 전부 유지(dedup / retryable / malformed-preserve 포함).

## 데이터 remediation (본 PR과 별개, 이미 수행)

기존 150MB 원장은 동일 latest-per-id 의미로 offline compact(150MB → 36MB) 후 서버 재기동 완료. 재기동 startup RSS 10.2GB → **1.2GB**, health 정상. 본 PR은 재발 방지(코드).

## 경계/범위

- 이 rewrite 프리미티브는 in-process 쓰기만 직렬화한다(append 프리미티브와 달리 read/rewrite 구간에 whole-file lock을 잡지 않음). masc 서버는 이 원장의 유일한 프로세스 writer이므로 충분하나, 이 가정을 .mli 주석에 명시했다.

## 근본 수정 판정 (workaround 아님)

storage를 read 모델(latest-per-id)에 일치시키는 근본 수정이다. counter/telemetry-as-fix도, symptom 억제도 아니며, 죽은 행 누적과 O(n²)의 원인 자체를 제거한다.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
