### PR TITLE
docs(oas): name execution environment API exactly

### DIFF
--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,7 +3,7 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_VERSION="v0.215.0"
 # Pinned to the v0.215.0 release (tracks main). On top of 0.214.1:
-# - BREAKING (oas#2631): Tool.handler_kind gains WithInvocation so handlers
+# - BREAKING (oas#2631): Tool.handler_kind gains WithExecutionEnv so handlers
 #   can receive the exact turn/index occurrence for each tool call. MASC uses
 #   Tool.create and does not exhaustively match handler_kind, so its existing
 #   tool bridge remains source-compatible.


### PR DESCRIPTION
## What

- correct the OAS `v0.215.0` pin SSOT from the superseded constructor name `WithInvocation` to the tagged public API name `WithExecutionEnv`
- keep the exact release version, SHA, dependency manifests, and API-surface fingerprint unchanged

## Why

OAS #2631 initially used an exclusive `WithInvocation` shape, then replaced it with `WithExecutionEnv` so one handler can receive both context and exact invocation resources. The tagged `v0.215.0` public interface exposes `Tool.handler_kind.WithExecutionEnv`.

MASC #25004 was merged while its `Build and Test` and aggregate `CI Gate` checks were cancelled by closed-PR cleanup. This follow-up corrects only the live pin documentation and does not claim those cancelled checks were green.

## Impact

Documentation-only. There is no runtime behavior, dependency, lockfile, generated metadata, or API fingerprint change.

## Checks

- `bash -n scripts/oas-agent-sdk-pin.sh`
- `bash scripts/sync-oas-pin-manifests.sh --check --surface`
- `bash scripts/oas-drift-check.sh`
- `bash scripts/check-oas-pin.sh`
- `git diff --check`
- repository-wide `WithInvocation` residue search

[근거] OAS `v0.215.0` tagged `lib/base/tool.mli` and https://github.com/jeong-sik/oas/pull/2631 | verified 2026-07-17 KST | High
