### PR TITLE
perf(log): throttle file-sink identity recheck off the emit path

### DIFF
--- a/lib/masc_log/log.ml
+++ b/lib/masc_log/log.ml
@@ -245,6 +245,20 @@ module Ring = struct
   let file_current_date : string ref = ref ""
   let file_base_dir : string ref = ref ""
 
+  (* Sink-identity recheck throttle. The dev/ino check in [sink_matches_path]
+     exists to catch external unlink/rename of the live log file — a rare
+     event — but it sits on the emit path, so unthrottled it cost three
+     stat-family syscalls per record (measured as 27% of main-thread samples;
+     issue #25003). Records emitted inside the window after an external
+     unlink land on the unlinked inode and are lost with it; the loss window
+     is bounded by the interval. Date-roll rotation is not throttled. *)
+  let default_sink_identity_recheck_interval_s = 5.0
+
+  let sink_identity_recheck_interval_s : float ref =
+    ref default_sink_identity_recheck_interval_s
+
+  let last_sink_identity_check_at : float ref = ref neg_infinity
+
   let date_string () = format_utc_date_of (Time_compat.now ())
 
   let log_file_path dir date =
@@ -335,8 +349,23 @@ module Ring = struct
       let needs_reopen =
         match !file_channel with
         | Some oc ->
-            today <> !file_current_date
-            || not (sink_matches_path (log_file_path !file_base_dir today) oc)
+            if today <> !file_current_date then true
+            else begin
+              (* [last_sink_identity_check_at] races benignly across threads —
+                 this function already runs outside [sink_mutex]; the worst
+                 case is a duplicate identity check. A backward wall-clock
+                 jump delays the next check by at most the jump size, which
+                 only widens the unlink-detection window. *)
+              let now = Time_compat.now () in
+              if
+                now -. !last_sink_identity_check_at
+                < !sink_identity_recheck_interval_s
+              then false
+              else begin
+                last_sink_identity_check_at := now;
+                not (sink_matches_path (log_file_path !file_base_dir today) oc)
+              end
+            end
         | None -> true
       in
       if needs_reopen then begin
@@ -563,7 +592,11 @@ module Ring = struct
         buf.(idx) <- { e with seq })
       buf_ring
 
-  let init_file_sink dir =
+  let init_file_sink
+      ?(identity_recheck_interval_s = default_sink_identity_recheck_interval_s)
+      dir =
+    sink_identity_recheck_interval_s := identity_recheck_interval_s;
+    last_sink_identity_check_at := neg_infinity;
     close_sink ();
     load_from_file dir;
     let loaded = Atomic.get total in

--- a/lib/masc_log/log.mli
+++ b/lib/masc_log/log.mli
@@ -163,10 +163,17 @@ module Ring : sig
       latest metadata, and file-sink state without raw log message text or
       [details] payloads. *)
 
-  val init_file_sink : string -> unit
+  val init_file_sink : ?identity_recheck_interval_s:float -> string -> unit
   (** Initialize file-based log persistence. Loads previous entries from disk
       into the ring buffer, then opens the file for appending new entries.
-      [dir] is the directory for dated JSONL log files. *)
+      [dir] is the directory for dated JSONL log files.
+
+      [identity_recheck_interval_s] (default 5.0) throttles the per-emit
+      sink-identity stat pair that detects external unlink/rename of the
+      live log file. Records emitted inside the window after an external
+      unlink are lost with the unlinked inode; the loss window is bounded
+      by the interval. Date-roll rotation is checked on every emit and is
+      not affected by the throttle. *)
 
   val cleanup_old_files : ?keep_days:int -> string -> unit
   (** Remove log files older than [keep_days] (default 7). *)

--- a/test/test_log_file_sink_self_heal.ml
+++ b/test/test_log_file_sink_self_heal.ml
@@ -7,15 +7,16 @@
    [write_to_sink]. The process stayed alive, [stderr] kept receiving
    records, but the structured JSON log just ended.
 
-   This test exercises the smaller of the two paths the patch closes —
-   the [output_string] failure path — by deleting the underlying file
-   after the sink is open, then emitting and checking that the channel
-   was dropped and reopened. The atomic-rotate path ([try_open_channel]
-   returning [None] from the rotate code) is harder to drive without
-   monkey-patching [open_out_gen], so we keep the contract pinned by
-   construction: [rotate_if_needed] now reads through [try_open_channel]
-   which protects against the raise — the absence of a [None]-on-success
-   transition is enforced by the source structure.
+   2026-07-17 (#25003): the sink-identity check that detects external
+   unlink/rename (a dev/ino stat pair inside [sink_matches_path]) used to
+   run on every emit — three stat-family syscalls per record, measured as
+   27% of main-thread samples. It is now throttled by
+   [identity_recheck_interval_s] (default 5s). The contract changed from
+   "external unlink detected on the next emit" to "external unlink detected
+   within the interval": records emitted inside the window go to the
+   unlinked inode and are lost with it. These tests pin both halves of that
+   contract — within the window the check is skipped (no recreate), past
+   the window the sink self-heals.
 
    These tests run in process and mutate global [Log.Ring] state, so they
    share state with anything else that runs in the same alcotest binary.
@@ -36,17 +37,16 @@ let date_string_utc () =
 
 let log_path dir = Filename.concat dir (Printf.sprintf "system_log_%s.jsonl" (date_string_utc ()))
 
-let rm_rf path =
+(* Removes [path] itself, not just its contents — [fresh_dir] follows with
+   [Sys.mkdir], which raises [File exists] on leftovers from a prior run of
+   this binary (the tmp root is shared across runs and worktrees). *)
+let rec rm_rf path =
   if Sys.file_exists path then
-    if Sys.is_directory path then
-      Array.iter (fun n ->
-        let p = Filename.concat path n in
-        if Sys.is_directory p then
-          ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote p)))
-        else Sys.remove p)
-        (Sys.readdir path)
-    else
-      Sys.remove path
+    if Sys.is_directory path then begin
+      Array.iter (fun n -> rm_rf (Filename.concat path n)) (Sys.readdir path);
+      Sys.rmdir path
+    end
+    else Sys.remove path
 
 let fresh_dir name =
   let dir = Filename.concat tmp_root name in
@@ -86,35 +86,51 @@ let normal_emit_lands_on_disk () =
   check bool "message recorded" true
     (contains body "test_log_file_sink_self_heal:normal:hello world")
 
-(* Self-heal: open sink, emit once, delete the underlying file, emit
-   again. With the fix, the second emit must re-create the file and
-   include its own message. Without the fix, [output_string] would
-   raise into the [match !file_channel with Some oc -> ...] arm; the
-   [output_string] arm is wrapped in [try ... with exn -> close_sink ()],
-   so the channel drops to [None] and the next emit reopens. *)
-let emit_after_file_unlink_reopens () =
+(* Throttle half of the contract: with a long recheck interval, emits that
+   land inside the window after an external unlink must NOT recreate the
+   file — the identity stat pair is skipped, and the records go to the
+   still-open unlinked inode. The absence of the file is the observable
+   proof that no stat check ran. *)
+let unlink_within_window_is_throttled () =
+  let dir = fresh_dir "throttled" in
+  R.init_file_sink ~identity_recheck_interval_s:60.0 dir;
+  (* First emit consumes the initial identity check (armed at init). *)
+  L.info "test_log_file_sink_self_heal:throttled:before";
+  let path = log_path dir in
+  check bool "file exists before unlink" true (Sys.file_exists path);
+  Sys.remove path;
+  check bool "file removed" false (Sys.file_exists path);
+  L.info "test_log_file_sink_self_heal:throttled:inside_window_1";
+  L.info "test_log_file_sink_self_heal:throttled:inside_window_2";
+  check bool "file NOT recreated inside the throttle window" false
+    (Sys.file_exists path)
+
+(* Self-heal half of the contract: past the recheck interval, the next emit
+   must detect the unlink through the identity check, reopen the sink at the
+   correct path, and record its own message. *)
+let unlink_after_window_recreates () =
   let dir = fresh_dir "unlinked" in
-  R.init_file_sink dir;
+  R.init_file_sink ~identity_recheck_interval_s:0.05 dir;
   L.info "test_log_file_sink_self_heal:unlinked:before";
   let path = log_path dir in
   check bool "file exists before unlink" true (Sys.file_exists path);
   Sys.remove path;
   check bool "file removed" false (Sys.file_exists path);
-  (* First post-unlink emit may drop the channel (if output_string raises),
-     then the same call's self-heal logic, or the next call's, must
-     reopen. We emit twice to cover both single-call and split-call
-     cases. *)
-  L.info "test_log_file_sink_self_heal:unlinked:after_first";
-  L.info "test_log_file_sink_self_heal:unlinked:after_second";
-  check bool "file re-created after self-heal" true (Sys.file_exists path);
+  Unix.sleepf 0.12;
+  L.info "test_log_file_sink_self_heal:unlinked:after_window";
+  check bool "file re-created after the throttle window" true
+    (Sys.file_exists path);
   let body = file_contents path in
   check bool "post-heal message recorded" true
-    (contains body "test_log_file_sink_self_heal:unlinked:after_second")
+    (contains body "test_log_file_sink_self_heal:unlinked:after_window")
 
 let () =
   run "log_file_sink_self_heal"
     [ "normal", [ test_case "emit lands on disk" `Quick normal_emit_lands_on_disk ]
     ; "self-heal"
-    , [ test_case "post-unlink emit reopens" `Quick emit_after_file_unlink_reopens
+    , [ test_case "unlink inside window stays throttled" `Quick
+          unlink_within_window_is_throttled
+      ; test_case "unlink past window reopens" `Quick
+          unlink_after_window_recreates
       ]
     ]


### PR DESCRIPTION
## 문제 (#25003 발견 1)

`Log.Ring`의 파일 싱크가 **레코드당** `rotate_if_needed → sink_matches_path`로 `Sys.file_exists`+`Unix.stat`+`Unix.fstat` 3회를 수행. 각각이 domain masterlock의 blocking-section 왕복이라, 프로덕션 `sample` 실측으로 **main 스레드 tick의 27~28%**가 이 경로의 락 재획득 대기였음. systhread 폭발(722개 관측) 하에서는 왕복 하나가 초 단위로 늘어져 `/health` 8s+ 타임아웃에 직접 기여.

## 수리

- sink identity(dev/ino) 검사를 `identity_recheck_interval_s`(기본 5s, `init_file_sink` 파라미터)로 스로틀
- 날짜 롤 회전 검사는 emit마다 유지(문자열 비교, syscall 없음)
- 스로틀 상태는 기존 `rotate_if_needed`와 동일하게 mutex 밖 benign race (주석 명시)

## 계약 변경 (명시)

외부 unlink/rename 감지: "다음 emit에서 즉시" → "interval 내" (창 안의 레코드는 unlinked inode와 함께 유실, 유실 창은 interval로 유계). `.mli` 문서화 완료.

## 검증

- `test_log_file_sink_self_heal` 3/3 pass:
  - `unlink inside window stays throttled` — 창 안 재생성 없음 = stat 스킵의 행동적 증거
  - `unlink past window reopens` — self-heal 보존(유계 지연)
- **counterfactual**: main의 기존 테스트가 정반대 단언("unlink 후 즉시 재생성")으로 구 동작을 박제 — 본 브랜치에서 역전된 단언이 pass = 스로틀이 실동작
- 테스트 하네스 부수 수리: `fresh_dir`가 디렉토리 자신을 지우지 않아 재실행 시 `File exists`로 터지던 기존 결함(`rm_rf` 재귀화)
- ocamlformat 3파일 clean
- 미검증: 프로덕션 효과 재측정은 머지+재배포 후 `sample`로 (성공 기준: main 스레드 `caml_sys_file_exists` 분기 소멸)

## 관련

- #25003 (발견 1) / #24912 (masterlock convoy — 본 PR은 main 스레드 쪽 최다 왕복 제거)
- 발견 2(board attention ledger)는 병렬 작업 `fix-candidate-ledger-compaction`(50f5121633)이 write-side 압축으로 수리 중

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PgGNxsWM8yCaJiHnTzrVa