### PR TITLE
refactor(keeper): index settlement evidence sources

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -391,7 +391,7 @@ let reaction_kind_of_settlement = function
 ;;
 
 let project_transition_outbox ~base_path ~keeper_name =
-  let rec project_stimuli ~reaction_kind ~receipt = function
+  let rec project_stimuli ~reaction_kind ~receipt ~source_index = function
     | [] -> Ok ()
     | stimulus :: rest ->
       (match
@@ -399,11 +399,17 @@ let project_transition_outbox ~base_path ~keeper_name =
            ~base_path
            ~keeper_name
            ~reaction_kind
+           ~source_index
            ~receipt
            stimulus
        with
        | Error _ as error -> error
-       | Ok () -> project_stimuli ~reaction_kind ~receipt rest)
+       | Ok () ->
+         project_stimuli
+           ~reaction_kind
+           ~receipt
+           ~source_index:(source_index + 1)
+           rest)
   in
   match Keeper_registry_event_queue.transition_outbox_result ~base_path keeper_name with
   | Error _ as error -> error
@@ -411,7 +417,7 @@ let project_transition_outbox ~base_path ~keeper_name =
   | Ok [ (entry : Keeper_registry_event_queue.outbox_entry) ] ->
     let receipt = entry.receipt in
     let reaction_kind = reaction_kind_of_settlement receipt.settlement in
-    (match project_stimuli ~reaction_kind ~receipt entry.stimuli with
+    (match project_stimuli ~reaction_kind ~receipt ~source_index:0 entry.stimuli with
      | Error _ as error -> error
      | Ok () ->
        Keeper_registry_event_queue.mark_transition_projected_result

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -307,28 +307,38 @@ let record_event_queue_reaction ~base_path ~keeper_name ~reaction_kind stimulus 
     (event_queue_reaction_json ~keeper_name ~reaction_kind stimulus)
 ;;
 
+let event_queue_transition_event_id
+      (receipt : Keeper_event_queue_state.transition_receipt)
+      source_index
+  =
+  Printf.sprintf "%s:source:%d" receipt.event_id source_index
+;;
+
 let event_queue_transition_reaction_json
       ~keeper_name
       ~reaction_kind
+      ~source_index
       (receipt : Keeper_event_queue_state.transition_receipt)
       stimulus
   =
   let stimulus_id = stimulus_id_of_event_queue stimulus in
+  let event_id = event_queue_transition_event_id receipt source_index in
   `Assoc
     (base_fields
        ~record_kind:"reaction"
-       ~event_id:(digest_id "krl" (receipt.event_id ^ "|" ^ stimulus_id))
+       ~event_id
        ~keeper_name
        ~recorded_at:receipt.settled_at
      @ [ "stimulus_id", `String stimulus_id
        ; ( "reaction"
          , `Assoc
              [ "kind", `String (reaction_kind_to_string reaction_kind)
-             ; "source", `String "keeper_event_queue_transition_outbox"
+             ; "source", `String "keeper_event_queue_settlement"
              ; "post_id", `String stimulus.post_id
              ; ( "stimulus_kind"
                , `String
                    (stimulus_kind_to_string (stimulus_kind_of_event_queue stimulus)) )
+             ; "source_index", `Int source_index
              ; "transition_id", `String receipt.transition_id
              ; ( "transition_receipt"
                , Keeper_event_queue_state.transition_receipt_to_yojson receipt )
@@ -340,15 +350,18 @@ let record_event_queue_transition_reaction_result
       ~base_path
       ~keeper_name
       ~reaction_kind
+      ~source_index
       ~receipt
       stimulus
   =
+  let event_id = event_queue_transition_event_id receipt source_index in
   try
     Dated_jsonl.append
       (store_for_base_path ~base_path ~keeper_name)
       (event_queue_transition_reaction_json
          ~keeper_name
          ~reaction_kind
+         ~source_index
          receipt
          stimulus);
     Ok ()
@@ -357,9 +370,9 @@ let record_event_queue_transition_reaction_result
   | exn ->
     Error
       (Printf.sprintf
-         "event queue transition ledger append failed keeper=%s transition=%s: %s"
+         "event queue settlement ledger append failed keeper=%s event_id=%s: %s"
          keeper_name
-         receipt.Keeper_event_queue_state.transition_id
+         event_id
          (Printexc.to_string exn))
 ;;
 

--- a/lib/keeper/keeper_reaction_ledger.mli
+++ b/lib/keeper/keeper_reaction_ledger.mli
@@ -73,12 +73,13 @@ val record_event_queue_transition_reaction_result :
   base_path:string ->
   keeper_name:string ->
   reaction_kind:reaction_kind ->
+  source_index:int ->
   receipt:Keeper_event_queue_state.transition_receipt ->
   Keeper_event_queue.stimulus ->
   (unit, string) result
-(** Append the outbox-owned terminal transition with a stable event id.  A
-    retry may append the same id after a crash, so readers treat [event_id] as
-    the idempotency identity.  Persistence failures remain explicit [Error]. *)
+(** Append one settlement source at its exact ordered index. Persistence
+    failures remain explicit [Error]. Readers use the deterministic event id
+    as the logical idempotency identity. *)
 
 type event_queue_reaction_evidence =
   { keeper_name : string

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -387,6 +387,15 @@ let settlement_equal left right =
     false
 ;;
 
+let transition_receipt_equal left right =
+  String.equal left.transition_id right.transition_id
+  && String.equal left.event_id right.event_id
+  && String.equal left.lease_id right.lease_id
+  && Int64.equal left.lease_sequence right.lease_sequence
+  && Float.equal left.settled_at right.settled_at
+  && left.settlement = right.settlement
+;;
+
 let validate_settlement = function
   | Ack | Requeue _ -> Ok ()
   | Escalate
@@ -476,6 +485,11 @@ let lease_equal (left : lease) (right : lease) =
 ;;
 
 let settle ~settled_at ~lease ~settlement state =
+  let* () =
+    if Float.is_finite settled_at
+    then Ok ()
+    else Error "event queue settlement time must be finite"
+  in
   let* () = validate_settlement settlement in
   match committed_lease lease state with
   | None ->
@@ -523,6 +537,39 @@ let settle ~settled_at ~lease ~settlement state =
         ; transition_outbox = [ outbox_entry ]
         }
       , Settled receipt )
+;;
+
+let replay_transition_receipt receipt state =
+  match
+    List.find_opt
+      (fun (lease : lease) -> Int64.equal lease.sequence receipt.lease_sequence)
+      state.leases
+  with
+  | Some lease ->
+    let* state, result =
+      settle
+        ~settled_at:receipt.settled_at
+        ~lease
+        ~settlement:receipt.settlement
+        state
+    in
+    let actual =
+      match result with
+      | Settled actual | Already_settled actual -> actual
+    in
+    if transition_receipt_equal receipt actual
+    then Ok state
+    else Error (Printf.sprintf "event queue receipt replay conflict: %s" receipt.lease_id)
+  | None ->
+    (match find_prior_receipt receipt.lease_id state with
+     | Some prior when transition_receipt_equal prior receipt -> Ok state
+     | Some _ ->
+       Error (Printf.sprintf "event queue receipt replay conflict: %s" receipt.lease_id)
+     | None ->
+       Error
+         (Printf.sprintf
+            "event queue receipt has no matching active lease: %s"
+            receipt.lease_id))
 ;;
 
 let recover_leases ~settled_at state =
@@ -594,6 +641,19 @@ let required_field ~context name fields =
   match List.assoc_opt name fields with
   | Some value -> Ok value
   | None -> Error (Printf.sprintf "%s missing required field %s" context name)
+;;
+
+let exact_fields ~context ~expected fields =
+  let rec loop seen = function
+    | [] -> Ok ()
+    | (name, _) :: rest ->
+      if not (List.exists (String.equal name) expected)
+      then Error (Printf.sprintf "%s contains unknown field %s" context name)
+      else if List.exists (String.equal name) seen
+      then Error (Printf.sprintf "%s contains duplicate field %s" context name)
+      else loop (name :: seen) rest
+  in
+  loop [] fields
 ;;
 
 let string_field ~context name fields =
@@ -711,25 +771,31 @@ let settlement_of_yojson json =
   let* fields = assoc_fields ~context json in
   let* kind = string_field ~context "kind" fields in
   match kind with
-  | "ack" -> Ok Ack
+  | "ack" ->
+    let* () = exact_fields ~context ~expected:[ "kind" ] fields in
+    Ok Ack
   | "requeue" ->
+    let* () = exact_fields ~context ~expected:[ "kind"; "reason" ] fields in
     let* reason = string_field ~context "reason" fields in
     let* reason = requeue_reason_of_label reason in
     Ok (Requeue reason)
   | "escalate" ->
-    let* reason_label = string_field ~context "reason" fields in
-    let reason_detail =
-      match List.assoc_opt "reason_detail" fields with
-      | Some json -> json
-      | None -> `Null
+    let* () =
+      exact_fields
+        ~context
+        ~expected:[ "kind"; "reason"; "reason_detail"; "successor" ]
+        fields
     in
+    let* reason_label = string_field ~context "reason" fields in
+    let* reason_detail = required_field ~context "reason_detail" fields in
     let* reason = escalation_reason_of_wire ~label:reason_label ~detail_json:reason_detail in
     let* successor =
       match List.assoc_opt "successor" fields with
-      | None | Some `Null -> Ok None
+      | Some `Null -> Ok None
       | Some json ->
         let* successor = Keeper_event_queue.stimulus_of_yojson json in
         Ok (Some successor)
+      | None -> Error "event queue settlement missing required field successor"
     in
     let settlement = Escalate { reason; successor } in
     let* () = validate_settlement settlement in
@@ -751,6 +817,19 @@ let transition_receipt_to_yojson receipt =
 let transition_receipt_of_yojson json =
   let context = "event queue transition receipt" in
   let* fields = assoc_fields ~context json in
+  let* () =
+    exact_fields
+      ~context
+      ~expected:
+        [ "transition_id"
+        ; "event_id"
+        ; "lease_id"
+        ; "lease_sequence"
+        ; "settled_at_unix"
+        ; "settlement"
+        ]
+      fields
+  in
   let* transition_id = string_field ~context "transition_id" fields in
   let* event_id = string_field ~context "event_id" fields in
   let* lease_id = string_field ~context "lease_id" fields in
@@ -763,7 +842,11 @@ let transition_receipt_of_yojson json =
     Printf.sprintf "%s:%s" expected_lease_id (settlement_kind_label settlement)
   in
   let expected_event_id = event_id_of_transition expected_transition_id in
-  if not (String.equal lease_id expected_lease_id)
+  if Int64.compare lease_sequence 1L < 0
+  then Error "event queue receipt lease sequence must be positive"
+  else if not (Float.is_finite settled_at)
+  then Error "event queue receipt settlement time must be finite"
+  else if not (String.equal lease_id expected_lease_id)
   then Error (Printf.sprintf "event queue receipt lease id mismatch: %s" lease_id)
   else if not (String.equal transition_id expected_transition_id)
   then Error (Printf.sprintf "event queue receipt transition id mismatch: %s" transition_id)

--- a/lib/keeper_runtime/keeper_event_queue_state.mli
+++ b/lib/keeper_runtime/keeper_event_queue_state.mli
@@ -113,7 +113,13 @@ val settle :
 
     [Retry_after_observed] and [Context_compaction_retry] retain the exact
     leased stimuli at the pending FIFO tail so unrelated work in the same lane
-    can proceed before another provider attempt. *)
+    can proceed before another provider attempt. Non-finite settlement times
+    are rejected. *)
+
+val replay_transition_receipt : transition_receipt -> t -> (t, string) result
+(** Apply one canonical durable receipt to its exact active lease. Replaying
+    the same retained receipt is idempotent; a different receipt or a missing
+    lease is an explicit conflict. *)
 
 val recover_leases : settled_at:float -> t -> (t, string) result
 (** Requeue every active lease with [Registration_recovery], preserving claim
@@ -139,6 +145,7 @@ val release_legacy_inflight :
 
 val lease_to_yojson : lease -> Yojson.Safe.t
 val lease_of_yojson : Yojson.Safe.t -> (lease, string) result
+val transition_receipt_equal : transition_receipt -> transition_receipt -> bool
 val transition_receipt_to_yojson : transition_receipt -> Yojson.Safe.t
 val transition_receipt_of_yojson : Yojson.Safe.t -> (transition_receipt, string) result
 val to_yojson : t -> Yojson.Safe.t

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -97,6 +97,108 @@ let test_claim_codec_ack_idempotency () =
    | Ok _ -> Alcotest.fail "conflicting second settlement was accepted")
 ;;
 
+let test_canonical_receipt_replay () =
+  let state =
+    State.with_pending (queue [ stimulus "replay" 1.0 ]) State.empty
+  in
+  let claimed, lease = claim_head state in
+  let lease = require_some "replay lease" lease in
+  let settled, result =
+    State.settle ~settled_at:11.0 ~lease ~settlement:State.Ack claimed
+    |> require_ok "settle replay fixture"
+  in
+  let receipt =
+    match result with
+    | State.Settled receipt -> receipt
+    | State.Already_settled _ -> Alcotest.fail "replay fixture was already settled"
+  in
+  let decoded =
+    State.transition_receipt_to_yojson receipt
+    |> State.transition_receipt_of_yojson
+    |> require_ok "canonical receipt roundtrip"
+  in
+  Alcotest.(check bool)
+    "receipt equality survives codec"
+    true
+    (State.transition_receipt_equal receipt decoded);
+  let replayed =
+    State.replay_transition_receipt decoded claimed
+    |> require_ok "replay canonical receipt"
+  in
+  Alcotest.(check string)
+    "replay reconstructs exact state"
+    (State.to_yojson settled |> Yojson.Safe.to_string)
+    (State.to_yojson replayed |> Yojson.Safe.to_string);
+  let repeated =
+    State.replay_transition_receipt decoded replayed
+    |> require_ok "replay canonical receipt idempotently"
+  in
+  Alcotest.(check string)
+    "idempotent replay preserves state"
+    (State.to_yojson replayed |> Yojson.Safe.to_string)
+    (State.to_yojson repeated |> Yojson.Safe.to_string);
+  let conflicting = { decoded with event_id = "wrong-event-id" } in
+  match State.replay_transition_receipt conflicting claimed with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "conflicting receipt replay was accepted"
+;;
+
+let test_receipt_codec_is_closed_and_finite () =
+  let state =
+    State.with_pending (queue [ stimulus "codec" 1.0 ]) State.empty
+  in
+  let claimed, lease = claim_head state in
+  let lease = require_some "codec lease" lease in
+  (match State.settle ~settled_at:Float.nan ~lease ~settlement:State.Ack claimed with
+   | Error _ -> ()
+   | Ok _ -> Alcotest.fail "non-finite settlement time was accepted");
+  let _, result =
+    State.settle ~settled_at:12.0 ~lease ~settlement:State.Ack claimed
+    |> require_ok "settle codec fixture"
+  in
+  let receipt =
+    match result with
+    | State.Settled receipt -> receipt
+    | State.Already_settled _ -> Alcotest.fail "codec fixture was already settled"
+  in
+  let fields =
+    match State.transition_receipt_to_yojson receipt with
+    | `Assoc fields -> fields
+    | _ -> Alcotest.fail "receipt encoder did not return an object"
+  in
+  let rejects label json =
+    match State.transition_receipt_of_yojson json with
+    | Error _ -> ()
+    | Ok _ -> Alcotest.failf "%s was accepted" label
+  in
+  rejects "unknown receipt field" (`Assoc (("extra", `Null) :: fields));
+  rejects
+    "duplicate receipt field"
+    (`Assoc (("transition_id", `String receipt.transition_id) :: fields));
+  rejects
+    "non-finite receipt time"
+    (`Assoc
+       (List.map
+          (fun (name, value) ->
+             if String.equal name "settled_at_unix"
+             then name, `Float Float.infinity
+             else name, value)
+          fields));
+  rejects
+    "unknown settlement field"
+    (`Assoc
+       (List.map
+          (fun (name, value) ->
+             if String.equal name "settlement"
+             then (
+               match value with
+               | `Assoc settlement_fields ->
+                 name, `Assoc (("extra", `Null) :: settlement_fields)
+               | _ -> Alcotest.fail "settlement encoder did not return an object")
+             else name, value)
+          fields))
+;;
+
 let test_claim_leases_earliest_ready_without_reordering_skipped_work () =
   let blocked =
     { (stimulus "blocked" 1.0) with urgency = Queue.Immediate }
@@ -1007,6 +1109,14 @@ let () =
     "keeper event queue v2"
     [ ( "state"
       , [ Alcotest.test_case "claim codec ack idempotency" `Quick test_claim_codec_ack_idempotency
+        ; Alcotest.test_case
+            "canonical receipt replay"
+            `Quick
+            test_canonical_receipt_replay
+        ; Alcotest.test_case
+            "receipt codec is closed and finite"
+            `Quick
+            test_receipt_codec_is_closed_and_finite
         ; Alcotest.test_case
             "claim earliest ready without reordering"
             `Quick

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -870,6 +870,7 @@ let test_transition_outbox_projects_with_stable_identity () =
       ~base_path
       ~keeper_name
       ~reaction_kind:Masc.Keeper_reaction_ledger.Event_queue_ack
+      ~source_index:0
       ~receipt
       source
     |> require_ok "replay stable transition reaction";

--- a/test/test_keeper_reaction_ledger.ml
+++ b/test/test_keeper_reaction_ledger.ml
@@ -295,6 +295,7 @@ let test_failure_judgment_external_input_is_typed_history () =
     ~base_path
     ~keeper_name
     ~reaction_kind:Keeper_reaction_ledger.Event_queue_escalated
+    ~source_index:0
     ~receipt
     stimulus
   |> require_ok "record external-input judgment transition";
@@ -320,6 +321,48 @@ let test_failure_judgment_external_input_is_typed_history () =
     (fleet |> member "event_queue_external_input_count" |> to_int);
   check (list string) "fleet has no false current reason" []
     (fleet |> member "status_reasons" |> to_list |> List.map to_string)
+;;
+
+let test_transition_reactions_distinguish_ordered_sources () =
+  with_temp_base @@ fun base_path ->
+  let keeper_name = "batch-projection-keeper" in
+  let first = board_stimulus ~post_id:"shared-post" ~updated_at:1.0 () in
+  let second = board_stimulus ~post_id:"shared-post" ~updated_at:2.0 () in
+  let receipt =
+    transition_receipt ~settlement:Keeper_event_queue_state.Ack first
+  in
+  let record source_index stimulus =
+    Keeper_reaction_ledger.record_event_queue_transition_reaction_result
+      ~base_path
+      ~keeper_name
+      ~reaction_kind:Keeper_reaction_ledger.Event_queue_ack
+      ~source_index
+      ~receipt
+      stimulus
+    |> require_ok "record ordered settlement source"
+  in
+  record 0 first;
+  record 1 second;
+  let rows =
+    Keeper_reaction_ledger.read_recent_for_keeper
+      ~base_path
+      ~keeper_name
+      ~limit:10
+  in
+  check (list string)
+    "ordered source ids are collision-free"
+    [ receipt.event_id ^ ":source:0"; receipt.event_id ^ ":source:1" ]
+    (List.map (fun row -> row |> member "event_id" |> to_string) rows);
+  check (list int)
+    "source index remains observable"
+    [ 0; 1 ]
+    (List.map
+       (fun row -> row |> member "reaction" |> member "source_index" |> to_int)
+       rows);
+  check (list string)
+    "shared stimulus id does not collapse ordered sources"
+    [ "board:shared-post"; "board:shared-post" ]
+    (List.map (fun row -> row |> member "stimulus_id" |> to_string) rows)
 ;;
 
 let test_cursor_ack_is_replayable_state_entry () =
@@ -1120,6 +1163,10 @@ let () =
             "failure judgment external input is typed history"
             `Quick
             test_failure_judgment_external_input_is_typed_history
+        ; test_case
+            "transition reactions distinguish ordered sources"
+            `Quick
+            test_transition_reactions_distinguish_ordered_sources
         ; test_case
             "cursor ack is replayable state entry"
             `Quick


### PR DESCRIPTION
## Outcome

- gives every settlement stimulus the deterministic identity `(receipt.event_id, source_index)`
- records `source_index` and neutral `keeper_event_queue_settlement` provenance in the Reaction Ledger
- makes `State.transition_receipt` the canonical typed receipt with exact JSON/equality/replay
- rejects non-finite settlement time, non-positive sequence, source mismatch, and conflicting replay explicitly
- treats exact receipt replay as idempotent without a history cache or full-ledger scan

## Boundary

This 306-line parent stack contains source identity plus the canonical receipt contract. It adds no settlement-history cache, O(N) resume scan, generic WAL payload, retry loop, timeout, capacity, execution gate, risk hierarchy, or semantic classifier.

The commits were rebased onto current main with identical range-diff:

- `acc33cd728` → `381f0a16ae`
- `486b89497e` → `d9894ce2f3`

The append+fsync commit point is deliberately the stacked child #25063, not hidden here.

## Verification

- pre-rebase focused event-queue/ledger builds green
- canonical receipt direct cases: 15/15 green
- Reaction Ledger direct cases: 22/22 green
- changed-file `ocamlformat --check` and `git diff --check` green
- exact rebased head CI is running
- 7 files, +287/-19 = 306 changed lines

## Non-claim

This PR does not claim WAL durability or nonblocking Reaction Ledger I/O. #25063 supplies the cursor-bound settlement WAL; actor/projection activation remains a separate follow-up.