### PR TITLE
fix(keeper): admit manual compaction past chat backlog

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop_cycle.ml
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.ml
@@ -89,10 +89,6 @@ let manual_compaction_followup_failure = function
   | Judgment_settled _ | Manual_compaction_failed _ -> None
 ;;
 
-let with_manual_compaction applied outcome =
-  if applied then Manual_compaction_applied outcome else outcome
-;;
-
 let record_failure_judgment_outcome
       ~keeper_name
       (request : Keeper_event_queue.failure_judgment)
@@ -210,67 +206,48 @@ let run_keeper_cycle_admitted
       ~shared_context
       ~(wake : Keeper_registry.wake_reason)
       ?failure_judgment
-      ?(manual_compaction_requested = false)
       ()
   =
   let admitted_execution =
     In_turn_pulse.with_in_turn_liveness_pulse ~ctx ~meta:meta_after_triage ~stop (fun () ->
       let prepared =
-        if manual_compaction_requested
-        then
-          (match Keeper_manual_compaction.run ~config:ctx.config ~meta:meta_after_triage with
-           | Error failure -> `Compaction_failed failure
-           | Ok success ->
-             Keeper_manual_compaction.observe_manifest
+        match failure_judgment with
+        | None -> `Run obs
+        | Some request ->
+          (match
+             prepare_failure_judgment_turn
+               ~base_path:ctx.config.base_path
                ~keeper_name:meta_after_triage.name
-               success.manifest;
-             `Run (obs, true))
-        else
-          match failure_judgment with
-          | None -> `Run (obs, false)
-          | Some request ->
-            (match
-               prepare_failure_judgment_turn
-                 ~base_path:ctx.config.base_path
-                 ~keeper_name:meta_after_triage.name
-                 ~request
-                 obs
-             with
-             | `Run observation -> `Run (observation, false)
-             | `Settle outcome -> `Settle outcome)
+               ~request
+               obs
+           with
+           | `Run observation -> `Run observation
+           | `Settle outcome -> `Settle outcome)
       in
       match prepared with
-      | `Compaction_failed failure -> `Compaction_failed failure
       | `Settle outcome -> `Judgment outcome
-      | `Run (observation, manual_compaction_applied) ->
+      | `Run observation ->
         `Turn
-          ( Keeper_unified_turn.run_keeper_cycle
-              ~config:ctx.config
-              ~meta:meta_after_triage
-              ~publication_recovery_provider:ctx.publication_recovery_provider
-              ~observation
-              ~generation:meta_after_triage.runtime.generation
-              ~wake
-              ~channel:turn_decision.channel
-              ?hitl_resolution
-              ?continuation_delivery_channel
-              (* RFC-0315: pass the whole decision, not just its channel — the
-                 prompt renders the verdict reasons so the turn knows why it woke. *)
-              ~turn_decision
-              ~shared_context
-              ?event_bus
-              ()
-          , manual_compaction_applied ))
+          (Keeper_unified_turn.run_keeper_cycle
+             ~config:ctx.config
+             ~meta:meta_after_triage
+             ~publication_recovery_provider:ctx.publication_recovery_provider
+             ~observation
+             ~generation:meta_after_triage.runtime.generation
+             ~wake
+             ~channel:turn_decision.channel
+             ?hitl_resolution
+             ?continuation_delivery_channel
+             (* RFC-0315: pass the whole decision, not just its channel — the
+                prompt renders the verdict reasons so the turn knows why it woke. *)
+             ~turn_decision
+             ~shared_context
+             ?event_bus
+             ()))
   in
   match admitted_execution with
-  | `Compaction_failed failure ->
-    Log.Keeper.error
-      ~keeper_name:meta_after_triage.name
-      "manual compaction failed in owner lane: %s"
-      (Keeper_manual_compaction.failure_to_string failure);
-    Manual_compaction_failed { meta = meta_after_triage; failure }
   | `Judgment outcome -> Judgment_settled { meta = meta_after_triage; outcome }
-  | `Turn (Error failure, manual_compaction_applied) ->
+  | `Turn (Error failure) ->
     let err = failure.Keeper_unified_turn.error in
     let e_str = Agent_sdk.Error.to_string err in
     Log.Keeper.debug "%s: keeper cycle failed: %s" meta_after_triage.name e_str;
@@ -324,13 +301,10 @@ let run_keeper_cycle_admitted
           ();
         meta_after_triage
     in
-    with_manual_compaction manual_compaction_applied (Failed { meta; failure })
-  | `Turn (Ok (Keeper_unified_turn.Turn_completed updated), applied) ->
-    with_manual_compaction applied (Completed updated)
-  | `Turn (Ok (Keeper_unified_turn.Turn_cancelled meta), applied) ->
-    with_manual_compaction applied (Cancelled meta)
-  | `Turn (Ok (Keeper_unified_turn.Turn_skipped meta), applied) ->
-    with_manual_compaction applied (Skipped meta)
+    Failed { meta; failure }
+  | `Turn (Ok (Keeper_unified_turn.Turn_completed updated)) -> Completed updated
+  | `Turn (Ok (Keeper_unified_turn.Turn_cancelled meta)) -> Cancelled meta
+  | `Turn (Ok (Keeper_unified_turn.Turn_skipped meta)) -> Skipped meta
 ;;
 
 let run_keeper_cycle
@@ -348,69 +322,83 @@ let run_keeper_cycle
       ?manual_compaction_requested
       ()
   =
-  let admit =
-    (* #24865: a manual-compaction cycle is the remedy for the overflow that
-       wedges chat delivery. Admitting it through the standard lane parks it
-       behind the durable chat backlog it exists to unblock, so it takes the
-       compaction admission variant, which skips only that backlog yield.
-       [None] means the caller did not thread the flag, which
-       [run_keeper_cycle_admitted] also treats as [false]; both take the
-       standard lane. *)
-    match manual_compaction_requested with
-    | Some true -> Keeper_turn_admission.run_compaction_if_free
-    | Some false | None -> Keeper_turn_admission.run_if_free
+  let busy_outcome block =
+    (match block with
+     | Keeper_turn_admission.Chat_backlog { pending_count; inflight_count } ->
+       Log.Keeper.info
+         "%s: yielding autonomous cycle to chat backlog (pending=%d inflight=%d); \
+          skipping until next heartbeat"
+         meta_after_triage.name
+         pending_count
+         inflight_count
+     | Keeper_turn_admission.Shutdown_requested operation_id ->
+       Log.Keeper.info
+         "%s: autonomous turn admission closed by shutdown operation %s"
+         meta_after_triage.name
+         (Keeper_shutdown_types.Operation_id.to_string operation_id)
+     | Keeper_turn_admission.Turn_busy in_flight ->
+       (* Another lane holds this keeper's turn slot (RFC-0225 §3.1): skip the
+          cycle and return the pre-cycle meta unchanged. The next heartbeat
+          retries naturally — same shape as the pre-existing skip decisions. *)
+       let holder =
+         match in_flight with
+         | Some { Keeper_turn_admission.lane; started_at } ->
+           Printf.sprintf
+             "%s turn running for %.0fs"
+             (Keeper_turn_admission.lane_to_string lane)
+             (* NDT-OK: gettimeofday renders the in-flight turn age for the log line only *)
+             (Unix.gettimeofday () -. started_at)
+         | None -> "holder info not yet published"
+       in
+       Log.Keeper.info
+         "%s: turn slot busy (%s); skipping autonomous cycle until next heartbeat"
+         meta_after_triage.name
+         holder);
+    Busy { meta = meta_after_triage; block }
   in
-  match
-    admit
-      ~base_path:ctx.config.base_path
-      ~keeper_name:meta_after_triage.name
-      (run_keeper_cycle_admitted
-         ~ctx
-         ~meta_after_triage
-         ~stop
-         ~obs
-         ~turn_decision
-         ~shared_context
-         ~wake
-         ?failure_judgment
-         ?manual_compaction_requested
-         ?event_bus
-         ?hitl_resolution
-         ?continuation_delivery_channel)
-  with
-  | `Ran outcome -> outcome
-  | `Busy ((Keeper_turn_admission.Chat_backlog { pending_count; inflight_count }) as
-          block) ->
-    Log.Keeper.info
-      "%s: yielding autonomous cycle to chat backlog (pending=%d inflight=%d); \
-       skipping until next heartbeat"
-      meta_after_triage.name
-      pending_count
-      inflight_count;
-    Busy { meta = meta_after_triage; block }
-  | `Busy ((Keeper_turn_admission.Shutdown_requested operation_id) as block) ->
-    Log.Keeper.info
-      "%s: autonomous turn admission closed by shutdown operation %s"
-      meta_after_triage.name
-      (Keeper_shutdown_types.Operation_id.to_string operation_id);
-    Busy { meta = meta_after_triage; block }
-  | `Busy ((Keeper_turn_admission.Turn_busy in_flight) as block) ->
-    (* Another lane holds this keeper's turn slot (RFC-0225 §3.1): skip the
-       cycle and return the pre-cycle meta unchanged. The next heartbeat
-       retries naturally — same shape as the pre-existing skip decisions. *)
-    let holder =
-      match in_flight with
-      | Some { Keeper_turn_admission.lane; started_at } ->
-        (* NDT-OK: gettimeofday renders the in-flight turn age for the log line only *)
-        Printf.sprintf
-          "%s turn running for %.0fs"
-          (Keeper_turn_admission.lane_to_string lane)
-          (Unix.gettimeofday () -. started_at)
-      | None -> "holder info not yet published"
-    in
-    Log.Keeper.info
-      "%s: turn slot busy (%s); skipping autonomous cycle until next heartbeat"
-      meta_after_triage.name
-      holder;
-    Busy { meta = meta_after_triage; block }
+  let run_standard_cycle () =
+    match
+      Keeper_turn_admission.run_if_free
+        ~base_path:ctx.config.base_path
+        ~keeper_name:meta_after_triage.name
+        (run_keeper_cycle_admitted
+           ~ctx
+           ~meta_after_triage
+           ~stop
+           ~obs
+           ~turn_decision
+           ~shared_context
+           ~wake
+           ?failure_judgment
+           ?event_bus
+           ?hitl_resolution
+           ?continuation_delivery_channel)
+    with
+    | `Ran outcome -> outcome
+    | `Busy block -> busy_outcome block
+  in
+  match manual_compaction_requested with
+  | Some false | None -> run_standard_cycle ()
+  | Some true ->
+    (* #24865: a manual-compaction cycle is the remedy for the overflow that
+       wedges chat delivery, so its compaction-only critical section admits
+       past the durable chat backlog ([run_compaction_if_free] inside
+       [run_admitted]) and releases the slot the moment the checkpoint
+       commits. The follow-up turn then re-enters the standard lane below,
+       where a chat backlog wins — the remedy may cut the line, an arbitrary
+       LLM turn may not. [Manual_compaction_applied (Busy _)] settles the
+       stimulus as Ack, so a yielded follow-up does not replay compaction. *)
+    (match
+       Keeper_manual_compaction.run_admitted
+         ~config:ctx.config
+         ~meta:meta_after_triage
+     with
+     | `Busy block -> busy_outcome block
+     | `Compaction_failed failure ->
+       Log.Keeper.error
+         ~keeper_name:meta_after_triage.name
+         "manual compaction failed in owner lane: %s"
+         (Keeper_manual_compaction.failure_to_string failure);
+       Manual_compaction_failed { meta = meta_after_triage; failure }
+     | `Applied _success -> Manual_compaction_applied (run_standard_cycle ()))
 ;;

--- a/lib/keeper/keeper_heartbeat_loop_cycle.ml
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.ml
@@ -348,8 +348,20 @@ let run_keeper_cycle
       ?manual_compaction_requested
       ()
   =
+  let admit =
+    (* #24865: a manual-compaction cycle is the remedy for the overflow that
+       wedges chat delivery. Admitting it through the standard lane parks it
+       behind the durable chat backlog it exists to unblock, so it takes the
+       compaction admission variant, which skips only that backlog yield.
+       [None] means the caller did not thread the flag, which
+       [run_keeper_cycle_admitted] also treats as [false]; both take the
+       standard lane. *)
+    match manual_compaction_requested with
+    | Some true -> Keeper_turn_admission.run_compaction_if_free
+    | Some false | None -> Keeper_turn_admission.run_if_free
+  in
   match
-    Keeper_turn_admission.run_if_free
+    admit
       ~base_path:ctx.config.base_path
       ~keeper_name:meta_after_triage.name
       (run_keeper_cycle_admitted
@@ -367,6 +379,15 @@ let run_keeper_cycle
          ?continuation_delivery_channel)
   with
   | `Ran outcome -> outcome
+  | `Busy ((Keeper_turn_admission.Chat_backlog { pending_count; inflight_count }) as
+          block) ->
+    Log.Keeper.info
+      "%s: yielding autonomous cycle to chat backlog (pending=%d inflight=%d); \
+       skipping until next heartbeat"
+      meta_after_triage.name
+      pending_count
+      inflight_count;
+    Busy { meta = meta_after_triage; block }
   | `Busy ((Keeper_turn_admission.Shutdown_requested operation_id) as block) ->
     Log.Keeper.info
       "%s: autonomous turn admission closed by shutdown operation %s"

--- a/lib/keeper/keeper_manual_compaction.ml
+++ b/lib/keeper/keeper_manual_compaction.ml
@@ -131,3 +131,22 @@ let observe_manifest ~keeper_name = function
       ~labels:[ "keeper", keeper_name; "phase", "manual_compaction_manifest" ]
       ()
 ;;
+
+(* Single sanctioned caller of [Keeper_turn_admission.run_compaction_if_free]:
+   the admitted section is exactly [run] (checkpoint recovery + manifest
+   observation), never a provider turn, and the slot releases as soon as it
+   returns. A follow-up turn re-enters the standard admission lane where a
+   chat backlog wins (#24865 review). *)
+let run_admitted ~(config : Workspace.config) ~(meta : keeper_meta) =
+  match
+    Keeper_turn_admission.run_compaction_if_free
+      ~base_path:config.base_path
+      ~keeper_name:meta.name
+      (fun () -> run ~config ~meta)
+  with
+  | `Busy block -> `Busy block
+  | `Ran (Error failure) -> `Compaction_failed failure
+  | `Ran (Ok success) ->
+    observe_manifest ~keeper_name:meta.name success.manifest;
+    `Applied success
+;;

--- a/lib/keeper/keeper_manual_compaction.mli
+++ b/lib/keeper/keeper_manual_compaction.mli
@@ -11,5 +11,24 @@ val run
   :  config:Workspace.config
   -> meta:Keeper_meta_contract.keeper_meta
   -> (success, failure) result
+
+val run_admitted
+  :  config:Workspace.config
+  -> meta:Keeper_meta_contract.keeper_meta
+  -> [ `Applied of success
+     | `Compaction_failed of failure
+     | `Busy of Keeper_turn_admission.autonomous_block
+     ]
+(** [run] inside the keeper's turn slot via
+    [Keeper_turn_admission.run_compaction_if_free], releasing the slot the
+    moment the compaction commits (manifest observation included).
+
+    This is the single sanctioned caller of that admission variant, and the
+    critical section is exactly the checkpoint recovery — a deterministic
+    file/FSM operation, never a provider turn — so bypassing the
+    chat-backlog yield cannot park queued chat behind long work. Any
+    follow-up turn must re-enter through the standard [run_if_free] lane,
+    where a chat backlog wins (#24865 review). *)
+
 val failure_to_string : failure -> string
 val observe_manifest : keeper_name:string -> (unit, string) result -> unit

--- a/lib/keeper/keeper_turn_admission.ml
+++ b/lib/keeper/keeper_turn_admission.ml
@@ -21,6 +21,10 @@ type in_flight_info =
 
 type autonomous_block =
   | Turn_busy of in_flight_info option
+  | Chat_backlog of
+      { pending_count : int
+      ; inflight_count : int
+      }
   | Shutdown_requested of Keeper_shutdown_types.Operation_id.t
 
 type rejection =
@@ -215,7 +219,7 @@ let shutdown_rejection_snapshot slot operation_id =
     })
 ;;
 
-let run_if_free ~base_path ~keeper_name f =
+let admit_autonomous ~yield_to_chat_backlog ~base_path ~keeper_name f =
   let slot = slot_for ~base_path ~keeper_name in
   (* Yield to deferred work before touching the lock. [waiting > 0] implies
      the slot is held (a waiter only parks because a turn is in flight), so
@@ -223,32 +227,57 @@ let run_if_free ~base_path ~keeper_name f =
      autonomous lane from competing for a slot a parked chat is already
      queued on. A non-empty [Keeper_chat_queue] means a busy connector
      (Slack/Discord) or dashboard message is deferred for this keeper but
-     has not parked on the slot; the autonomous lane must yield for it too,
-     otherwise a long or back-to-back autonomous turn starves that queue
-     indefinitely (the busy-ACK loop). Reading the queue length is a
+     has not parked on the slot; the standard autonomous lane must yield for
+     it too, otherwise a long or back-to-back autonomous turn starves that
+     queue indefinitely (the busy-ACK loop). Reading the queue length is a
      lock-only, non-suspending peek and is the SSOT signal that closes the
      gap: the autonomous lane cooperates on the same backlog the consumer
      drains, so the consumer's [in_flight = None] window opens
      deterministically instead of racing the next autonomous cycle. A leased
      receipt remains active until its terminal decision commits, so the
      autonomous lane must also yield during the short lease-to-admission and
-     admission-to-finalization windows. *)
+     admission-to-finalization windows.
+
+     [yield_to_chat_backlog:false] (the manual-compaction lane) skips only
+     that queue peek: the backlog yield presumes the chat consumer can make
+     progress, and a context-overflowed keeper violates that premise — its
+     chat turns fail until compaction rewrites the checkpoint, so queueing
+     the compaction cycle behind the backlog inverts the priority and
+     starves both lanes (#24865). *)
   match peek_shutdown slot with
   | Some operation_id -> `Busy (Shutdown_requested operation_id)
   | None when waiting_count slot > 0 -> `Busy (Turn_busy (peek_info slot))
   | None ->
-    let snapshot = Keeper_chat_queue.snapshot ~keeper_name in
-    (* Queue persistence/read failures remain typed Chat-boundary failures.
-       They are not evidence of queued work and therefore cannot close an
-       otherwise independent autonomous lane. *)
-    if snapshot.pending <> [] || snapshot.inflight <> []
-    then `Busy (Turn_busy (peek_info slot))
-    else if Eio.Mutex.try_lock slot.turn_mu
-    then
-      match run_locked slot ~lane:Autonomous f with
-      | `Ran value -> `Ran value
-      | `Shutdown_requested operation_id -> `Busy (Shutdown_requested operation_id)
-    else `Busy (Turn_busy (peek_info slot))
+    let chat_backlog =
+      if yield_to_chat_backlog
+      then (
+        let snapshot = Keeper_chat_queue.snapshot ~keeper_name in
+        (* Queue persistence/read failures remain typed Chat-boundary
+           failures. They are not evidence of queued work and therefore
+           cannot close an otherwise independent autonomous lane. *)
+        match List.length snapshot.pending, List.length snapshot.inflight with
+        | 0, 0 -> None
+        | pending_count, inflight_count ->
+          Some (Chat_backlog { pending_count; inflight_count }))
+      else None
+    in
+    (match chat_backlog with
+     | Some block -> `Busy block
+     | None ->
+       if Eio.Mutex.try_lock slot.turn_mu
+       then (
+         match run_locked slot ~lane:Autonomous f with
+         | `Ran value -> `Ran value
+         | `Shutdown_requested operation_id -> `Busy (Shutdown_requested operation_id))
+       else `Busy (Turn_busy (peek_info slot)))
+;;
+
+let run_if_free ~base_path ~keeper_name f =
+  admit_autonomous ~yield_to_chat_backlog:true ~base_path ~keeper_name f
+;;
+
+let run_compaction_if_free ~base_path ~keeper_name f =
+  admit_autonomous ~yield_to_chat_backlog:false ~base_path ~keeper_name f
 ;;
 
 let run_serialized ~base_path ~keeper_name f =

--- a/lib/keeper/keeper_turn_admission.mli
+++ b/lib/keeper/keeper_turn_admission.mli
@@ -142,10 +142,17 @@ val run_compaction_if_free
   -> keeper_name:string
   -> (unit -> 'a)
   -> [ `Ran of 'a | `Busy of autonomous_block ]
-(** [run_if_free] for a cycle that carries a manual-compaction request
-    ([Keeper_manual_compaction]), differing in exactly one fence: it does
-    not yield to the [Keeper_chat_queue] backlog and therefore never
-    returns [`Busy (Chat_backlog _)].
+(** [run_if_free] for the manual-compaction critical section, differing in
+    exactly one fence: it does not yield to the [Keeper_chat_queue] backlog
+    and therefore never returns [`Busy (Chat_backlog _)].
+
+    Sole sanctioned caller: [Keeper_manual_compaction.run_admitted]. The
+    admitted section must be the compaction commit only — a deterministic
+    checkpoint/FSM operation — never a provider turn; any follow-up turn
+    re-enters [run_if_free] and yields to the backlog. This module cannot
+    name [Keeper_manual_compaction] types without inverting the layering,
+    so the closure stays generic here and the compaction-only shape is
+    enforced at that single wrapper.
 
     The standard lane's backlog yield assumes the chat consumer can drain
     the queue. When the keeper's context has overflowed its provider

--- a/lib/keeper/keeper_turn_admission.mli
+++ b/lib/keeper/keeper_turn_admission.mli
@@ -40,6 +40,17 @@ type in_flight_info =
 
 type autonomous_block =
   | Turn_busy of in_flight_info option
+  | Chat_backlog of
+      { pending_count : int
+      ; inflight_count : int
+      }
+    (** The slot mutex itself is free, but active [Keeper_chat_queue]
+        receipts exist for this keeper; the standard autonomous lane yields
+        so the chat consumer can drain them. Distinct from [Turn_busy None]
+        (a held slot whose holder has not yet published its info): before
+        this variant existed both cases logged as "holder info not yet
+        published", which mis-directed the #24865 diagnosis toward a stale
+        slot when the durable chat backlog was the actual fence. *)
   | Shutdown_requested of Keeper_shutdown_types.Operation_id.t
 
 type rejection =
@@ -110,9 +121,10 @@ val run_if_free
     re-raise.
 
     Also returns [`Busy] without attempting the lock when a chat request is
-    already parked on this slot ([chat_waiting] is true), or when a busy
-    connector/dashboard receipt is active in [Keeper_chat_queue] for this
-    keeper (pending or inflight). Eio.Mutex hands a released slot
+    already parked on this slot ([chat_waiting] is true, reported as
+    [Turn_busy]), or when a busy connector/dashboard receipt is active in
+    [Keeper_chat_queue] for this keeper (pending or inflight, reported as
+    [Chat_backlog] with the exact counts). Eio.Mutex hands a released slot
     directly to the next parked waiter, so a new autonomous cycle would not
     overtake a queued chat regardless; these pre-checks make the yield
     explicit and keep a heartbeat-scheduled cycle from competing for a slot
@@ -124,6 +136,30 @@ val run_if_free
     deterministically. Queue persistence/read errors remain explicit typed
     failures at the Chat mutation/consumer boundary; because they are not
     queued work, they do not close this independent autonomous lane. *)
+
+val run_compaction_if_free
+  :  base_path:string
+  -> keeper_name:string
+  -> (unit -> 'a)
+  -> [ `Ran of 'a | `Busy of autonomous_block ]
+(** [run_if_free] for a cycle that carries a manual-compaction request
+    ([Keeper_manual_compaction]), differing in exactly one fence: it does
+    not yield to the [Keeper_chat_queue] backlog and therefore never
+    returns [`Busy (Chat_backlog _)].
+
+    The standard lane's backlog yield assumes the chat consumer can drain
+    the queue. When the keeper's context has overflowed its provider
+    window, chat delivery itself fails until compaction rewrites the
+    checkpoint — so yielding parks the remedy behind the very backlog it
+    is meant to unblock, a priority inversion that starved manual
+    compaction indefinitely (#24865: durable pending receipts fenced every
+    cycle across restarts while the slot mutex stayed free).
+
+    Everything else is unchanged from [run_if_free]: a durable shutdown
+    reservation still fences admission, a parked chat waiter still wins,
+    and a genuinely held slot still returns [`Busy (Turn_busy _)] — this
+    lane never interleaves with an in-flight turn, it only stops queueing
+    behind work that cannot progress. *)
 
 val chat_waiting : base_path:string -> keeper_name:string -> bool
 (** [true] when at least one chat request is parked on this keeper's slot

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -1748,6 +1748,7 @@ let test_keeper_shutdown_store_isolates_corrupt_owner () =
               corrupt_operation.operation_id
               operation_id)
        | `Busy (Masc.Keeper_turn_admission.Turn_busy _)
+       | `Busy (Masc.Keeper_turn_admission.Chat_backlog _)
        | `Ran () -> fail "corrupt owner admission was reopened");
       match Shutdown_runtime.recover_operation ~config recoverable_operation with
       | Ok recovered ->
@@ -2202,6 +2203,7 @@ let test_keeper_shutdown_prepare_joins_idle_lane () =
            true
            (Shutdown_types.Operation_id.equal operation.operation_id operation_id)
       | `Busy (Masc.Keeper_turn_admission.Turn_busy _)
+      | `Busy (Masc.Keeper_turn_admission.Chat_backlog _)
       | `Ran () ->
          fail "shutdown admission fence reopened before finalization"))
 
@@ -2315,7 +2317,11 @@ let test_keeper_shutdown_prepare_failure_rolls_back_fence () =
       | `Busy (Masc.Keeper_turn_admission.Turn_busy _) ->
         fail
           "failed shutdown prepare left the keeper admission fence closed: \
-           Turn_busy owns the slot")
+           Turn_busy owns the slot"
+      | `Busy (Masc.Keeper_turn_admission.Chat_backlog _) ->
+        fail
+          "failed shutdown prepare left the keeper admission fence closed: \
+           chat backlog fences the slot")
 
 let test_keeper_shutdown_finalizes_idle_operation () =
   Eio_main.run @@ fun env ->
@@ -2552,6 +2558,7 @@ let test_keeper_shutdown_delivers_dead_tombstone_completion_after_receipt () =
          check bool "pending receipt retains exact admission owner" true
            (Shutdown_types.Operation_id.equal operation_id reserved)
        | `Busy (Masc.Keeper_turn_admission.Turn_busy _)
+       | `Busy (Masc.Keeper_turn_admission.Chat_backlog _)
        | `Ran () -> fail "pending completion reopened admission");
       Masc.Keeper_turn_admission.For_testing.reset ();
       let boot_inventory =
@@ -2581,6 +2588,7 @@ let test_keeper_shutdown_delivers_dead_tombstone_completion_after_receipt () =
          check bool "boot-restored fence keeps exact completion owner" true
            (Shutdown_types.Operation_id.equal operation_id reserved)
        | `Busy (Masc.Keeper_turn_admission.Turn_busy _)
+       | `Busy (Masc.Keeper_turn_admission.Chat_backlog _)
        | `Ran () -> fail "boot recovery reopened pending completion admission");
       Shutdown_finalize.register_completion_handler
         Tombstone_cleanup.handle_completion;

--- a/test/test_keeper_turn_admission.ml
+++ b/test/test_keeper_turn_admission.ml
@@ -764,6 +764,15 @@ let test_compaction_lane_bypasses_chat_backlog () =
    with
    | `Ran 8 -> check "compaction lane admits despite an inflight receipt" true
    | `Ran _ | `Busy _ -> check "compaction lane admits despite an inflight receipt" false);
+  (* Production order (#24865 review): the compaction admission released the
+     slot on return, and a follow-up turn re-entering the standard lane still
+     yields to the remaining backlog — the bypass covers the compaction
+     commit only, never the turn that follows it. *)
+  (match Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () -> ()) with
+   | `Busy (Keeper_turn_admission.Chat_backlog _) ->
+     check "standard lane still yields to the backlog after compaction admission" true
+   | `Busy _ | `Ran () ->
+     check "standard lane still yields to the backlog after compaction admission" false);
   (* A genuinely held slot still refuses the compaction lane: it must never
      interleave with an in-flight turn. *)
   Keeper_turn_admission.For_testing.with_unpublished_turn_lock

--- a/test/test_keeper_turn_admission.ml
+++ b/test/test_keeper_turn_admission.ml
@@ -49,6 +49,10 @@ let reset () =
   Keeper_turn_admission.For_testing.reset ();
   Keeper_chat_queue.For_testing.reset ();
   remove_tree base_path;
+  (* [Keeper_fs] never creates a filesystem root, only descendants
+     (durable-directory ownership guard), so enqueue after this wipe fails
+     with [Missing_root] unless the fixture recreates its own root. *)
+  ensure_dir base_path;
   ignore
     (Keeper_chat_queue.configure_persistence ~base_path
       : Keeper_chat_queue.configure_report)
@@ -638,6 +642,7 @@ let test_shutdown_reservation_fences_and_rolls_back () =
        "autonomous lane sees typed shutdown fence"
        (Keeper_shutdown_types.Operation_id.equal reserved operation_id)
    | `Busy (Keeper_turn_admission.Turn_busy _)
+   | `Busy (Keeper_turn_admission.Chat_backlog _)
    | `Ran () ->
      check "autonomous lane cannot cross shutdown fence" false);
   (match Keeper_turn_admission.run_serialized ~base_path ~keeper_name (fun () -> ()) with
@@ -723,6 +728,67 @@ let test_shutdown_reservation_restores_durable_owner () =
     check "registration cannot cross restored fence" false
 ;;
 
+let test_compaction_lane_bypasses_chat_backlog () =
+  reset ();
+  Printf.printf
+    "Test 10b: manual-compaction lane admits despite a durable chat backlog (#24865)\n%!";
+  (match Keeper_chat_queue.enqueue ~keeper_name queued_message with
+   | Ok _ -> ()
+   | Error error ->
+     check
+       ("enqueue succeeds: " ^ Keeper_chat_queue.mutation_error_to_string error)
+       false);
+  (* The standard lane reports the backlog as a typed [Chat_backlog] with the
+     exact counts, not as [Turn_busy None]. Before this variant existed the
+     queue fence logged "holder info not yet published", which mis-directed
+     the #24865 diagnosis toward a stale slot. *)
+  (match Keeper_turn_admission.run_if_free ~base_path ~keeper_name (fun () -> ()) with
+   | `Busy (Keeper_turn_admission.Chat_backlog { pending_count = 1; inflight_count = 0 })
+     -> check "standard lane reports the backlog as typed Chat_backlog" true
+   | `Busy _ | `Ran () ->
+     check "standard lane reports the backlog as typed Chat_backlog" false);
+  (match
+     Keeper_turn_admission.run_compaction_if_free ~base_path ~keeper_name (fun () -> 7)
+   with
+   | `Ran 7 -> check "compaction lane admits despite a pending receipt" true
+   | `Ran _ | `Busy _ -> check "compaction lane admits despite a pending receipt" false);
+  (* Leasing moves the receipt to inflight; the compaction lane still admits
+     (an inflight receipt whose delivery cannot progress is exactly the
+     #24865 wedge), while the standard lane keeps yielding. *)
+  (match Keeper_chat_queue.lease_next ~keeper_name with
+   | `Leased _ -> ()
+   | `Empty | `Already_leased _ | `Recovery_required _ | `Error _ ->
+     check "lease_next leases the queued message" false);
+  (match
+     Keeper_turn_admission.run_compaction_if_free ~base_path ~keeper_name (fun () -> 8)
+   with
+   | `Ran 8 -> check "compaction lane admits despite an inflight receipt" true
+   | `Ran _ | `Busy _ -> check "compaction lane admits despite an inflight receipt" false);
+  (* A genuinely held slot still refuses the compaction lane: it must never
+     interleave with an in-flight turn. *)
+  Keeper_turn_admission.For_testing.with_unpublished_turn_lock
+    ~base_path
+    ~keeper_name
+    (fun () ->
+       match
+         Keeper_turn_admission.run_compaction_if_free ~base_path ~keeper_name (fun () -> ())
+       with
+       | `Busy (Keeper_turn_admission.Turn_busy _) ->
+         check "compaction lane still refuses a held slot" true
+       | `Busy _ | `Ran () -> check "compaction lane still refuses a held slot" false);
+  (* A durable shutdown reservation still fences the compaction lane. *)
+  let operation_id = Keeper_shutdown_types.Operation_id.generate () in
+  ignore
+    (Keeper_turn_admission.begin_shutdown ~base_path ~keeper_name ~operation_id
+      : Keeper_turn_admission.begin_shutdown_result);
+  match
+    Keeper_turn_admission.run_compaction_if_free ~base_path ~keeper_name (fun () -> ())
+  with
+  | `Busy (Keeper_turn_admission.Shutdown_requested _) ->
+    check "compaction lane still honors the shutdown fence" true
+  | `Busy _ | `Ran () -> check "compaction lane still honors the shutdown fence" false
+;;
+
 let () =
   Eio_main.run @@ fun _env ->
   test_autonomous_admits_when_chat_persistence_is_not_configured ();
@@ -740,6 +806,7 @@ let () =
   test_autonomous_yields_to_parked_chat ();
   test_idle_loop_yields_to_parked_chat ();
   test_autonomous_yields_to_queued_connector_message ();
+  test_compaction_lane_bypasses_chat_backlog ();
   test_shutdown_reservation_fences_and_rolls_back ();
   test_shutdown_reservation_restores_durable_owner ();
   if !failures > 0


### PR DESCRIPTION
## Summary

Manual compaction (dashboard "지금 컴팩트" → `masc_keeper_compact`) enqueued its stimulus successfully, but the applying cycle never ran: `run_if_free` yields to any durable `Keeper_chat_queue` backlog before touching the slot mutex, and reports that yield as `Turn_busy None` — logged as "holder info not yet published". A context-overflowed keeper cannot drain its chat backlog (delivery turns fail until compaction rewrites the checkpoint), so the compaction cycle queued behind the very backlog it exists to unblock — a priority inversion that survives restarts because the queue is durable (sqlite).

Live evidence (#24865, keeper=rondo, 2026-07-17): `manual-compaction-request` consumed and re-consumed every few minutes, each followed by `turn slot busy (holder info not yet published); skipping autonomous cycle`; admission health showed the slot mutex free (`in_flight=null`, `chat_waiting_count=0`) while `keepers/rondo/chat-queue.sqlite3` held 8 `pending` + 1 `recovery_required` receipts.

## What changed

- `Keeper_turn_admission.run_compaction_if_free`: identical admission to `run_if_free` except it does not yield to the chat backlog. The shutdown fence, parked chat waiters, and a genuinely held slot still refuse.
- **Compaction-only critical section** (adversarial-review P1): `Keeper_manual_compaction.run_admitted` — the single sanctioned caller of that admission variant — runs exactly the checkpoint recovery (+ manifest observation) inside the slot and releases it the moment the compaction commits. The follow-up turn re-enters through the standard `run_if_free` lane, where a chat backlog wins: the remedy may cut the line, an arbitrary LLM turn may not. `Manual_compaction_applied (Busy _)` settles the stimulus as `Ack` (existing settlement mapping in `keeper_heartbeat_loop.ml`), so a yielded follow-up does not replay compaction.
- `run_keeper_cycle_admitted` loses its compaction branch and the `manual_compaction_applied` threading; `run_keeper_cycle` sequences Phase A (compaction admission) and Phase B (standard cycle) explicitly.
- The backlog yield is now reported as typed `Chat_backlog { pending_count; inflight_count }` instead of `Turn_busy None`, and the skip log names the actual fence. The old shared message mis-directed the #24865 diagnosis toward a stale slot.
- Test fixture: `reset ()` recreates the wiped base_path root. `Keeper_fs` never creates filesystem roots (durable-directory ownership guard), so every enqueue-dependent case in this suite (pre-existing Test 1c/10) failed locally with `Missing_root` after the fixture wiped its own root.

## Out of scope (tracked separately)

- The stuck `recovery_required` head receipt (startup-orphaned lease) still requires explicit resolution via the chat recovery command; this PR unblocks compaction, not chat delivery.
- A live turn wedged in a provider-4xx retry loop still holds the slot against compaction (#24838 request-size direction; compaction stack #24966).
- Board-attention judge fan-out and cross-domain Switch failures: #24886 (start_async guard landed in #25033).

## Verification

- `MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build lib test/test_keeper_turn_admission.exe test/test_keeper_waiting_inventory.exe test/test_keeper_post_turn_wirein_order.exe test/test_heartbeat_integration.exe`
- `test_keeper_turn_admission.exe`: all checks pass. Test 10b covers: typed `Chat_backlog` report with exact counts; compaction lane admits past pending and inflight receipts; **production order — after a compaction admission returns, the slot is free and the standard lane still yields to the remaining backlog**; compaction lane still refuses a held slot and a shutdown reservation.
- `test_keeper_waiting_inventory.exe` 16/16, `test_keeper_post_turn_wirein_order.exe` 3/3, `test_heartbeat_integration.exe` 46/46.
- Counterfactual: with the fix stashed, the suite reproduces the baseline failure shape (no compaction admission path; fixture cases fail on `Missing_root`).
- `ocamlformat --check` on all changed OCaml files; `git diff --check` clean; `scripts/ci/check-determinism-contract.sh` PASS locally.
- Pin note: the shared local opam switch may lag this repository's declared agent_sdk pin; PR CI remains the authoritative verification (same caveat as #25005).

Closes #24865

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
