### PR TITLE
refactor(connector)!: hard-cut continuation route schema

### DIFF
--- a/lib/fusion/fusion_sink.ml
+++ b/lib/fusion/fusion_sink.ml
@@ -300,12 +300,14 @@ let broadcast_run_status ~registry ~run_id =
 let wake_keeper_on_fusion_completion
       ~base_dir ~keeper ~run_id ~ok ~resolved_answer ~board_post_id :
     (unit, string) result =
+  let ( let* ) = Result.bind in
   (* A run started outside a connector conversation has no route; the wake then
      says so explicitly instead of inventing a destination. *)
-  let channel =
+  let* channel =
     match Fusion_wake_route.peek ~run_id with
-    | Some channel -> channel
-    | None -> Keeper_continuation_channel.unrouted "no originating connector"
+    | Some channel -> Ok channel
+    | None ->
+      Ok (Keeper_continuation_channel.unrouted "no originating connector")
   in
   let fusion_completion =
     Keeper_event_queue.{ run_id; ok; resolved_answer; board_post_id; channel }

--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -524,18 +524,25 @@ let registry : (string, queue_entry) Hashtbl.t = Hashtbl.create 16
 
 let continuation_channel_of_message_source = function
   | Dashboard { thread_id } ->
-    Keeper_continuation_channel.Dashboard { thread_id }
+    (match Keeper_continuation_channel.dashboard ~thread_id with
+     | Ok channel -> channel
+     | Error message -> invalid_arg message)
   | Discord { channel_id; user_id } ->
-    Keeper_continuation_channel.Discord
-      { guild_id = None
-      ; channel_id
-      ; parent_channel_id = None
-      ; thread_id = None
-      ; user_id
-      }
+    (match
+       Keeper_continuation_channel.discord
+         ~guild_id:None
+         ~channel_id
+         ~parent_channel_id:None
+         ~thread_id:None
+         ~user_id
+     with
+     | Ok channel -> channel
+     | Error message -> invalid_arg message)
   | Slack { channel_id; user_id; team_id; thread_ts; _ } ->
-    Keeper_continuation_channel.Slack
-      { team_id; channel_id; thread_ts; user_id }
+    (match Keeper_continuation_channel.slack ~team_id ~channel_id ~thread_ts ~user_id with
+     | Ok channel -> channel
+     | Error message -> invalid_arg message)
+;;
 
 let set_transition_observer observer = Atomic.set transition_observer observer
 

--- a/lib/keeper_runtime/keeper_continuation_channel.ml
+++ b/lib/keeper_runtime/keeper_continuation_channel.ml
@@ -143,9 +143,10 @@ let string_field name fields =
 
 let optional_string_field name fields =
   match List.assoc_opt name fields with
-  | Some (`String s) when String.trim s <> "" -> Some s
-  | Some (`String _) | Some `Null | None -> None
-  | Some _ -> None
+  | Some (`String s) when String.trim s <> "" -> Ok (Some s)
+  | Some (`String _) | Some `Null | None -> Ok None
+  | Some _ ->
+    Error (Printf.sprintf "continuation_channel: field %s must be a string or null" name)
 
 let of_yojson json =
   let* fields = assoc_fields json in
@@ -157,26 +158,27 @@ let of_yojson json =
   | "discord" ->
     let* channel_id = string_field "channel_id" fields in
     let* user_id = string_field "user_id" fields in
+    let* guild_id = optional_string_field "guild_id" fields in
+    let* parent_channel_id = optional_string_field "parent_channel_id" fields in
+    let* thread_id = optional_string_field "thread_id" fields in
     Ok
       (Discord
-         { guild_id = optional_string_field "guild_id" fields
+         { guild_id
          ; channel_id
-         ; parent_channel_id = optional_string_field "parent_channel_id" fields
-         ; thread_id = optional_string_field "thread_id" fields
+         ; parent_channel_id
+         ; thread_id
          ; user_id
          })
   | "slack" ->
-    let* channel_id =
-      match string_field "channel_id" fields with
-      | Ok value -> Ok value
-      | Error _ -> string_field "channel" fields
-    in
+    let* channel_id = string_field "channel_id" fields in
     let* user_id = string_field "user_id" fields in
+    let* team_id = optional_string_field "team_id" fields in
+    let* thread_ts = optional_string_field "thread_ts" fields in
     Ok
       (Slack
-         { team_id = optional_string_field "team_id" fields
+         { team_id
          ; channel_id
-         ; thread_ts = optional_string_field "thread_ts" fields
+         ; thread_ts
          ; user_id
          })
   | "unrouted" ->

--- a/lib/keeper_runtime/keeper_continuation_channel.ml
+++ b/lib/keeper_runtime/keeper_continuation_channel.ml
@@ -15,7 +15,50 @@ type t =
     }
   | Unrouted of { reason : string }
 
-let unrouted reason = Unrouted { reason }
+let ( let* ) = Result.bind
+
+let validate_nonblank field value =
+  if String.equal (String.trim value) ""
+  then Error (Printf.sprintf "continuation_channel: field %s must not be blank" field)
+  else Ok value
+;;
+
+let validate_optional_nonblank field = function
+  | None -> Ok None
+  | Some value ->
+    let* value = validate_nonblank field value in
+    Ok (Some value)
+;;
+
+let dashboard ~thread_id =
+  let* thread_id = validate_nonblank "thread_id" thread_id in
+  Ok (Dashboard { thread_id })
+;;
+
+let discord ~guild_id ~channel_id ~parent_channel_id ~thread_id ~user_id =
+  let* guild_id = validate_optional_nonblank "guild_id" guild_id in
+  let* channel_id = validate_nonblank "channel_id" channel_id in
+  let* parent_channel_id =
+    validate_optional_nonblank "parent_channel_id" parent_channel_id
+  in
+  let* thread_id = validate_optional_nonblank "thread_id" thread_id in
+  let* user_id = validate_nonblank "user_id" user_id in
+  Ok (Discord { guild_id; channel_id; parent_channel_id; thread_id; user_id })
+;;
+
+let slack ~team_id ~channel_id ~thread_ts ~user_id =
+  let* team_id = validate_optional_nonblank "team_id" team_id in
+  let* channel_id = validate_nonblank "channel_id" channel_id in
+  let* thread_ts = validate_optional_nonblank "thread_ts" thread_ts in
+  let* user_id = validate_nonblank "user_id" user_id in
+  Ok (Slack { team_id; channel_id; thread_ts; user_id })
+;;
+
+let unrouted reason =
+  match validate_nonblank "reason" reason with
+  | Ok reason -> Unrouted { reason }
+  | Error message -> invalid_arg message
+;;
 
 let is_routable = function
   | Unrouted _ -> false
@@ -129,11 +172,31 @@ let to_yojson = function
   | Unrouted { reason } ->
     `Assoc [ ("kind", `String "unrouted"); ("reason", `String reason) ]
 
-let ( let* ) = Result.bind
-
 let assoc_fields = function
   | `Assoc fields -> Ok fields
   | _ -> Error "continuation_channel must be a JSON object"
+
+let validate_unique_fields fields =
+  let rec loop seen = function
+    | [] -> Ok ()
+    | (name, _) :: rest ->
+      if List.mem name seen
+      then Error (Printf.sprintf "continuation_channel: duplicate field %s" name)
+      else loop (name :: seen) rest
+  in
+  loop [] fields
+;;
+
+let validate_allowed_fields ~kind allowed fields =
+  match List.find_opt (fun (name, _) -> not (List.mem name allowed)) fields with
+  | None -> Ok ()
+  | Some (name, _) ->
+    Error
+      (Printf.sprintf
+         "continuation_channel: field %s is not allowed for kind %s"
+         name
+         kind)
+;;
 
 let string_field name fields =
   match List.assoc_opt name fields with
@@ -154,38 +217,46 @@ let optional_string_field name fields =
 
 let of_yojson json =
   let* fields = assoc_fields json in
+  let* () = validate_unique_fields fields in
   let* kind = string_field "kind" fields in
   match kind with
   | "dashboard" ->
+    let* () = validate_allowed_fields ~kind [ "kind"; "thread_id" ] fields in
     let* thread_id = string_field "thread_id" fields in
-    Ok (Dashboard { thread_id })
+    dashboard ~thread_id
   | "discord" ->
+    let* () =
+      validate_allowed_fields
+        ~kind
+        [ "kind"
+        ; "guild_id"
+        ; "channel_id"
+        ; "parent_channel_id"
+        ; "thread_id"
+        ; "user_id"
+        ]
+        fields
+    in
     let* channel_id = string_field "channel_id" fields in
     let* user_id = string_field "user_id" fields in
     let* guild_id = optional_string_field "guild_id" fields in
     let* parent_channel_id = optional_string_field "parent_channel_id" fields in
     let* thread_id = optional_string_field "thread_id" fields in
-    Ok
-      (Discord
-         { guild_id
-         ; channel_id
-         ; parent_channel_id
-         ; thread_id
-         ; user_id
-         })
+    discord ~guild_id ~channel_id ~parent_channel_id ~thread_id ~user_id
   | "slack" ->
+    let* () =
+      validate_allowed_fields
+        ~kind
+        [ "kind"; "team_id"; "channel_id"; "thread_ts"; "user_id" ]
+        fields
+    in
     let* channel_id = string_field "channel_id" fields in
     let* user_id = string_field "user_id" fields in
     let* team_id = optional_string_field "team_id" fields in
     let* thread_ts = optional_string_field "thread_ts" fields in
-    Ok
-      (Slack
-         { team_id
-         ; channel_id
-         ; thread_ts
-         ; user_id
-         })
+    slack ~team_id ~channel_id ~thread_ts ~user_id
   | "unrouted" ->
+    let* () = validate_allowed_fields ~kind [ "kind"; "reason" ] fields in
     let* reason = string_field "reason" fields in
-    Ok (Unrouted { reason })
+    Ok (unrouted reason)
   | other -> Error (Printf.sprintf "continuation_channel: unknown kind: %s" other)

--- a/lib/keeper_runtime/keeper_continuation_channel.ml
+++ b/lib/keeper_runtime/keeper_continuation_channel.ml
@@ -137,14 +137,18 @@ let assoc_fields = function
 
 let string_field name fields =
   match List.assoc_opt name fields with
-  | Some (`String s) -> Ok s
+  | Some (`String s) when not (String.equal (String.trim s) "") -> Ok s
+  | Some (`String _) ->
+    Error (Printf.sprintf "continuation_channel: field %s must not be blank" name)
   | Some _ -> Error (Printf.sprintf "continuation_channel: field %s must be a string" name)
   | None -> Error (Printf.sprintf "continuation_channel: missing field %s" name)
 
 let optional_string_field name fields =
   match List.assoc_opt name fields with
-  | Some (`String s) when String.trim s <> "" -> Ok (Some s)
-  | Some (`String _) | Some `Null | None -> Ok None
+  | Some (`String s) when not (String.equal (String.trim s) "") -> Ok (Some s)
+  | Some (`String _) ->
+    Error (Printf.sprintf "continuation_channel: field %s must not be blank" name)
+  | Some `Null | None -> Ok None
   | Some _ ->
     Error (Printf.sprintf "continuation_channel: field %s must be a string or null" name)
 

--- a/lib/keeper_runtime/keeper_continuation_channel.mli
+++ b/lib/keeper_runtime/keeper_continuation_channel.mli
@@ -56,6 +56,8 @@ val same_route : t -> t -> bool
 val to_yojson : t -> Yojson.Safe.t
 
 (** [of_yojson json] parses a tagged object produced by {!to_yojson}. A
-    missing or unknown ["kind"], or a missing field, is an [Error]; there is
-    no permissive default (RFC-0320 §2 fail-closed). *)
+    missing or unknown ["kind"], a missing required field, or a non-string
+    connector coordinate is an [Error]. Only absent, null, or empty optional
+    coordinates become [None]; there are no field aliases or permissive
+    defaults (RFC-0320 §2 fail-closed). *)
 val of_yojson : Yojson.Safe.t -> (t, string) result

--- a/lib/keeper_runtime/keeper_continuation_channel.mli
+++ b/lib/keeper_runtime/keeper_continuation_channel.mli
@@ -14,7 +14,7 @@
     connector constructors carry the lossless coordinate fields used by
     [Surface_ref] without depending on that higher-level module. *)
 
-type t =
+type t = private
   | Dashboard of { thread_id : string }
   | Discord of {
       guild_id : string option;
@@ -31,8 +31,27 @@ type t =
     }
   | Unrouted of { reason : string }
 
+val dashboard : thread_id:string -> (t, string) result
+
+val discord :
+  guild_id:string option ->
+  channel_id:string ->
+  parent_channel_id:string option ->
+  thread_id:string option ->
+  user_id:string ->
+  (t, string) result
+
+val slack :
+  team_id:string option ->
+  channel_id:string ->
+  thread_ts:string option ->
+  user_id:string ->
+  (t, string) result
+
 (** [unrouted reason] is the fail-closed channel carrying a diagnostic
-    [reason] explaining why no connector could be determined. *)
+    [reason] explaining why no connector could be determined. It raises
+    [Invalid_argument] for a blank diagnostic. Every constructor therefore
+    admits only values replayable by {!of_yojson}. *)
 val unrouted : string -> t
 
 (** [is_routable t] is [false] only for [Unrouted]; a routable channel has a

--- a/lib/keeper_runtime/keeper_continuation_channel.mli
+++ b/lib/keeper_runtime/keeper_continuation_channel.mli
@@ -56,8 +56,8 @@ val same_route : t -> t -> bool
 val to_yojson : t -> Yojson.Safe.t
 
 (** [of_yojson json] parses a tagged object produced by {!to_yojson}. A
-    missing or unknown ["kind"], a missing required field, or a non-string
-    connector coordinate is an [Error]. Only absent, null, or empty optional
-    coordinates become [None]; there are no field aliases or permissive
-    defaults (RFC-0320 §2 fail-closed). *)
+    missing or unknown ["kind"], a missing or blank required field, or a
+    blank/non-string connector coordinate is an [Error]. Only absent or null
+    optional coordinates become [None]; there are no field aliases or
+    permissive defaults (RFC-0320 §2 fail-closed). *)
 val of_yojson : Yojson.Safe.t -> (t, string) result

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -576,12 +576,8 @@ let payload_to_yojson = function
       ]
 
 let continuation_channel_field fields =
-  match List.assoc_opt "channel" fields with
-  | None ->
-    (* Backward compat: pre-RFC-0320 persisted stimuli carry no channel; a
-       replayed legacy wake is [Unrouted] rather than a parse failure. *)
-    Ok (Keeper_continuation_channel.unrouted "legacy: channel not captured")
-  | Some json -> Keeper_continuation_channel.of_yojson json
+  let* json = required_field ~context:"stimulus.payload" "channel" fields in
+  Keeper_continuation_channel.of_yojson json
 
 let payload_of_yojson json =
   let context = "stimulus.payload" in
@@ -625,11 +621,6 @@ let payload_of_yojson json =
     let* ok = bool_field ~context "ok" fields in
     let* resolved_answer = string_field ~context "resolved_answer" fields in
     let* board_post_id = string_field ~context "board_post_id" fields in
-    (* [Fusion_completed] predates the reply-channel field and was persisted
-       without it, so a legacy snapshot row must replay as [Unrouted] rather
-       than failing the whole snapshot parse (which recovers to an empty queue,
-       dropping every co-resident stimulus). Same lenient contract as the
-       sibling [Connector_attention]/[Hitl_resolved] rows. *)
     let* channel = continuation_channel_field fields in
     Ok (Fusion_completed { run_id; ok; resolved_answer; board_post_id; channel })
   | "bg_completed" ->

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -719,7 +719,7 @@ let stimulus_of_yojson json =
   let* payload = payload_of_yojson payload_json in
   Ok { post_id; urgency; arrived_at; payload }
 
-let schema = "keeper.event_queue.v1"
+let schema = "keeper.event_queue.v2"
 
 let queue_to_yojson queue =
   `Assoc

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -46,7 +46,7 @@ let lease_stimuli (lease : lease) = lease.stimuli
 let lease_kind = State.lease_kind
 
 let snapshot_filename = "event-queue.json"
-let legacy_inflight_filename = "event-queue-inflight.json"
+let unsupported_inflight_filename = "event-queue-inflight.json"
 
 let owner_error_to_string = Owner_lock.resolve_error_to_string
 
@@ -70,8 +70,8 @@ let snapshot_path_of_owner owner =
   Filename.concat (keeper_runtime_dir_of_owner owner) snapshot_filename
 ;;
 
-let legacy_inflight_path_of_owner owner =
-  Filename.concat (keeper_runtime_dir_of_owner owner) legacy_inflight_filename
+let unsupported_inflight_path_of_owner owner =
+  Filename.concat (keeper_runtime_dir_of_owner owner) unsupported_inflight_filename
 ;;
 
 let save_json_atomic path json =
@@ -145,8 +145,7 @@ let schema_field = function
 
 type primary_snapshot =
   | Primary_missing
-  | Primary_v1 of Keeper_event_queue.t
-  | Primary_v2 of State.t
+  | Primary_current of State.t
 
 let read_primary_unlocked owner =
   let path = snapshot_path_of_owner owner in
@@ -158,108 +157,36 @@ let read_primary_unlocked owner =
      | Error message -> Error (Printf.sprintf "%s: %s" path message)
      | Ok schema when String.equal schema State.schema ->
        (match State.of_yojson json with
-        | Ok state -> Ok (Primary_v2 state)
-        | Error message -> Error (Printf.sprintf "%s: %s" path message))
-     | Ok schema when String.equal schema "keeper.event_queue.v1" ->
-       (match Keeper_event_queue.queue_of_yojson json with
-        | Ok queue -> Ok (Primary_v1 queue)
+        | Ok state -> Ok (Primary_current state)
         | Error message -> Error (Printf.sprintf "%s: %s" path message))
      | Ok schema ->
        Error (Printf.sprintf "%s: unsupported snapshot schema %s" path schema))
 ;;
 
-let read_legacy_inflight_unlocked owner =
-  let path = legacy_inflight_path_of_owner owner in
-  match read_json_if_present path with
-  | Error _ as error -> error
-  | Ok None -> Ok None
-  | Ok (Some json) ->
-    (match Keeper_event_queue.queue_of_yojson json with
-     | Ok queue -> Ok (Some queue)
-     | Error message -> Error (Printf.sprintf "%s: %s" path message))
-;;
-
-let remove_legacy_inflight_unlocked owner =
-  let path = legacy_inflight_path_of_owner owner in
+let reject_unsupported_inflight owner =
+  let path = unsupported_inflight_path_of_owner owner in
   try
-    if Sys.file_exists path then Sys.remove path;
-    Ok ()
+    if Sys.file_exists path
+    then
+      Error
+        (Printf.sprintf
+           "unsupported event queue sidecar remains at %s; remove it before starting the keeper"
+           path)
+    else Ok ()
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn ->
-    Error
-      (Printf.sprintf
-         "v2 state committed but failed to remove legacy inflight input %s: %s"
-         path
-         (Printexc.to_string exn))
-;;
-
-let migrate_unlocked owner pending legacy_inflight =
-  let state = State.with_pending pending State.empty in
-  let migration =
-    match legacy_inflight with
-    | None -> Ok (state, None)
-    | Some queue -> State.add_legacy_inflight (Keeper_event_queue.to_list queue) state
-  in
-  match migration with
-  | Error _ as error -> error
-  | Ok (state, _lease) ->
-    let state =
-      match State.recover_leases ~settled_at:(Time_compat.now ()) state with
-      | Ok state -> Ok state
-      | Error _ as error -> error
-    in
-    (match state with
-     | Error _ as error -> error
-     | Ok state ->
-    (match save_state_unlocked owner state with
-     | Error _ as error -> error
-     | Ok () ->
-       remove_legacy_inflight_unlocked owner |> Result.map (fun () -> state)))
-;;
-
-let state_accounts_for_stimulus state stimulus =
-  let same candidate =
-    Keeper_event_queue.stimulus_identity_equal candidate stimulus
-  in
-  List.exists same (Keeper_event_queue.to_list (State.pending state))
-  || List.exists
-       (fun (lease : lease) -> List.exists same lease.stimuli)
-       (State.leases state)
-  || List.exists
-       (fun (entry : outbox_entry) -> List.exists same entry.stimuli)
-       (State.transition_outbox state)
-;;
-
-let reconcile_v2_legacy_residue_unlocked owner state legacy =
-  let legacy_stimuli = Keeper_event_queue.to_list legacy in
-  if List.for_all (state_accounts_for_stimulus state) legacy_stimuli
-  then remove_legacy_inflight_unlocked owner |> Result.map (fun () -> state)
-  else
-    Error
-      (Printf.sprintf
-         "v2 event queue conflicts with legacy inflight residue: %s"
-         (legacy_inflight_path_of_owner owner))
+    Error (Printf.sprintf "failed to inspect unsupported sidecar %s: %s" path (Printexc.to_string exn))
 ;;
 
 let load_state_unlocked owner =
-  match read_primary_unlocked owner with
+  match reject_unsupported_inflight owner with
   | Error _ as error -> error
-  | Ok (Primary_v2 state) ->
-    (match read_legacy_inflight_unlocked owner with
+  | Ok () ->
+    (match read_primary_unlocked owner with
      | Error _ as error -> error
-     | Ok None -> Ok state
-     | Ok (Some legacy) -> reconcile_v2_legacy_residue_unlocked owner state legacy)
-  | Ok Primary_missing ->
-    (match read_legacy_inflight_unlocked owner with
-     | Error _ as error -> error
-     | Ok None -> Ok State.empty
-     | Ok (Some legacy) ->
-       migrate_unlocked owner Keeper_event_queue.empty (Some legacy))
-  | Ok (Primary_v1 pending) ->
-    (match read_legacy_inflight_unlocked owner with
-     | Error _ as error -> error
-     | Ok legacy -> migrate_unlocked owner pending legacy)
+     | Ok (Primary_current state) -> Ok state
+     | Ok Primary_missing -> Ok State.empty)
 ;;
 
 let load_state_result ~base_path ~keeper_name =
@@ -358,7 +285,7 @@ let diagnose_snapshot_read_error ~base_path ~keeper_name message =
   | Error invalid -> [ { kind = Invalid_path; path = None; message = invalid } ]
   | Ok owner ->
     let primary = snapshot_path_of_owner owner in
-    let legacy = legacy_inflight_path_of_owner owner in
+    let unsupported = unsupported_inflight_path_of_owner owner in
     let inspect path =
       try
         if not (Sys.file_exists path)
@@ -377,20 +304,12 @@ let diagnose_snapshot_read_error ~base_path ~keeper_name message =
           ; message = Printexc.to_string exn
           }
     in
-    (match inspect primary with
-     | Some ({ kind = Read_failed; _ } as error) -> [ error ]
-     | Some ({ kind = Parse_failed; _ } as primary_error) ->
-       (match inspect legacy with
-        | Some ({ kind = Read_failed; _ } as error) -> [ error ]
-        | Some ({ kind = Parse_failed; _ } as error) -> [ error ]
-        | Some { kind = Invalid_path; _ } -> [ primary_error ]
-        | None -> [ primary_error ])
-     | Some { kind = Invalid_path; _ } ->
-       [ { kind = Invalid_path; path = None; message } ]
-     | None ->
-       (match inspect legacy with
-        | Some error -> [ error ]
-        | None -> [ { kind = Parse_failed; path = None; message } ]))
+    match inspect unsupported with
+    | Some _ -> [ { kind = Parse_failed; path = Some unsupported; message } ]
+    | None ->
+      (match inspect primary with
+       | Some error -> [ error ]
+       | None -> [ { kind = Parse_failed; path = None; message } ])
 ;;
 
 let load_snapshot_pair_with_errors ~base_path ~keeper_name =
@@ -435,10 +354,9 @@ let discover_keeper_names_with_snapshots ~base_path =
                 (fun (names, errors) name ->
                    let keeper_dir = Filename.concat keepers_dir name in
                    let primary = Filename.concat keeper_dir snapshot_filename in
-                   let legacy = Filename.concat keeper_dir legacy_inflight_filename in
                    if
                      not (Sys.file_exists keeper_dir && Sys.is_directory keeper_dir)
-                     || not (Sys.file_exists primary || Sys.file_exists legacy)
+                     || not (Sys.file_exists primary)
                    then names, errors
                    else
                      match Keeper_id.Keeper_name.of_string name with
@@ -527,6 +445,19 @@ let update_checked_result ?(after_commit = fun () -> ()) ~base_path ~keeper_name
 type enqueue_stimulus_result =
   | Enqueued
   | Already_present
+
+let state_accounts_for_stimulus state stimulus =
+  let same candidate =
+    Keeper_event_queue.stimulus_identity_equal candidate stimulus
+  in
+  List.exists same (Keeper_event_queue.to_list (State.pending state))
+  || List.exists
+       (fun (lease : lease) -> List.exists same lease.stimuli)
+       (State.leases state)
+  || List.exists
+       (fun (entry : outbox_entry) -> List.exists same entry.stimuli)
+       (State.transition_outbox state)
+;;
 
 let enqueue_stimulus_if_absent_result
       ?(after_commit = fun _ -> ())

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -1,9 +1,9 @@
 (** Durable per-Keeper Event Layer state.
 
-    [event-queue.json] uses one v2 envelope containing pending stimuli, active
+    [event-queue.json] uses one v3 envelope containing pending stimuli, active
     typed leases, the monotonic lease sequence and the transition outbox.
-    [event-queue-inflight.json] is accepted only as a one-time v1 migration
-    input; it is never a second runtime authority. *)
+    Older schemas are unsupported. [event-queue-inflight.json] is rejected
+    explicitly rather than migrated or treated as a second authority. *)
 
 type lease_kind = Keeper_event_queue_state.lease_kind =
   | Single
@@ -110,8 +110,8 @@ val load_snapshot_pair_with_errors :
 
 val load_state_result :
   base_path:string -> keeper_name:string -> (Keeper_event_queue_state.t, string) result
-(** Strict state read used by tests and operator projection.  A malformed v2
-    envelope or v2-plus-legacy residue is an [Error], never an empty queue. *)
+(** Strict state read used by tests and operator projection. A malformed v3
+    envelope or v3-plus-legacy residue is an [Error], never an empty queue. *)
 
 val claim_when_result :
   ?after_commit:(Keeper_event_queue.t -> unit) ->
@@ -197,7 +197,7 @@ val persist_snapshot :
 val record_inflight :
   base_path:string -> keeper_name:string -> Keeper_event_queue.stimulus list -> unit
 (** Legacy source/test adapter.  Writes a typed [Legacy_inflight] lease into the
-    v2 envelope; it never creates [event-queue-inflight.json]. *)
+    v3 envelope; it never creates [event-queue-inflight.json]. *)
 
 val ack_inflight :
   base_path:string -> keeper_name:string -> Keeper_event_queue.stimulus list -> unit

--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -72,7 +72,7 @@ type settle_result =
   | Settled of transition_receipt
   | Already_settled of transition_receipt
 
-let schema = "keeper.event_queue.state.v2"
+let schema = "keeper.event_queue.state.v3"
 
 let empty =
   { revision = 0L

--- a/lib/keeper_runtime/keeper_event_queue_state.mli
+++ b/lib/keeper_runtime/keeper_event_queue_state.mli
@@ -145,4 +145,4 @@ val to_yojson : t -> Yojson.Safe.t
 val of_yojson : Yojson.Safe.t -> (t, string) result
 
 val schema : string
-(** ["keeper.event_queue.state.v2"]. *)
+(** ["keeper.event_queue.state.v3"]. *)

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -648,13 +648,16 @@ let handle_ambient ?resolved_keeper_name ~base_dir
                Keeper_event_queue.Connector_attention
                  { event_id
                  ; channel =
-                     Keeper_continuation_channel.Discord
-                       { guild_id
-                       ; channel_id
-                       ; parent_channel_id
-                       ; thread_id
-                       ; user_id = author_id
-                       }
+                     (match
+                        Keeper_continuation_channel.discord
+                          ~guild_id
+                          ~channel_id
+                          ~parent_channel_id
+                          ~thread_id
+                          ~user_id:author_id
+                      with
+                      | Ok channel -> channel
+                      | Error message -> invalid_arg message)
                  }
            }
          in

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -2742,7 +2742,9 @@ let handle_keeper_chat_stream ~sw ~clock ~submitted_by state request reqd payloa
   let now_id () = int_of_float (Time_compat.now () *. 1000.0) in
   let thread_id = "keeper:" ^ payload.name in
   let continuation_channel =
-    Keeper_continuation_channel.Dashboard { thread_id }
+    match Keeper_continuation_channel.dashboard ~thread_id with
+    | Ok channel -> channel
+    | Error message -> invalid_arg message
   in
 
   let sse_adapter_loop ~events ~writer ~mutex ~closed ~on_closed ~on_finished =

--- a/test/keeper_continuation_channel/test_keeper_continuation_channel.ml
+++ b/test/keeper_continuation_channel/test_keeper_continuation_channel.ml
@@ -2,7 +2,7 @@
 
    Covers the closed-variant contract:
      - codec round-trips for every constructor,
-     - fail-closed parsing (unknown kind / missing field / non-object -> Error),
+     - fail-closed parsing (unknown kind / missing or malformed field / legacy alias -> Error),
      - the routing helpers (is_routable, kind_label, same_route). *)
 
 open Keeper_continuation_channel
@@ -46,6 +46,63 @@ let test_missing_field_is_error () =
   (* discord requires user_id *)
   expect_error "missing discord user_id"
     (`Assoc [ ("kind", `String "discord"); ("channel_id", `String "C") ])
+
+let test_optional_route_coordinates_are_strict () =
+  List.iter
+    (fun (label, json) -> expect_error label json)
+    [ ( "discord guild_id wrong type"
+      , `Assoc
+          [ "kind", `String "discord"
+          ; "channel_id", `String "C"
+          ; "user_id", `String "U"
+          ; "guild_id", `Int 1
+          ] )
+    ; ( "discord parent_channel_id wrong type"
+      , `Assoc
+          [ "kind", `String "discord"
+          ; "channel_id", `String "C"
+          ; "user_id", `String "U"
+          ; "parent_channel_id", `Bool true
+          ] )
+    ; ( "discord thread_id wrong type"
+      , `Assoc
+          [ "kind", `String "discord"
+          ; "channel_id", `String "C"
+          ; "user_id", `String "U"
+          ; "thread_id", `List []
+          ] )
+    ; ( "slack team_id wrong type"
+      , `Assoc
+          [ "kind", `String "slack"
+          ; "channel_id", `String "C"
+          ; "user_id", `String "U"
+          ; "team_id", `Assoc []
+          ] )
+    ; ( "slack thread_ts wrong type"
+      , `Assoc
+          [ "kind", `String "slack"
+          ; "channel_id", `String "C"
+          ; "user_id", `String "U"
+          ; "thread_ts", `Float 1.0
+          ] )
+    ]
+
+let test_slack_legacy_channel_alias_is_rejected () =
+  expect_error
+    "legacy channel alias"
+    (`Assoc
+       [ "kind", `String "slack"
+       ; "channel", `String "C"
+       ; "user_id", `String "U"
+       ]);
+  expect_error
+    "invalid channel_id is not masked by alias"
+    (`Assoc
+       [ "kind", `String "slack"
+       ; "channel_id", `Int 1
+       ; "channel", `String "C"
+       ; "user_id", `String "U"
+       ])
 
 let test_missing_kind_is_error () =
   expect_error "missing kind" (`Assoc [ ("thread_id", `String "t") ])
@@ -146,6 +203,8 @@ let () =
   test_codec_roundtrip ();
   test_unknown_kind_is_error ();
   test_missing_field_is_error ();
+  test_optional_route_coordinates_are_strict ();
+  test_slack_legacy_channel_alias_is_rejected ();
   test_missing_kind_is_error ();
   test_non_object_is_error ();
   test_is_routable ();

--- a/test/keeper_continuation_channel/test_keeper_continuation_channel.ml
+++ b/test/keeper_continuation_channel/test_keeper_continuation_channel.ml
@@ -7,28 +7,37 @@
 
 open Keeper_continuation_channel
 
+let dashboard_channel thread_id = dashboard ~thread_id |> Result.get_ok
+
+let discord_channel ~guild_id ~channel_id ~parent_channel_id ~thread_id ~user_id =
+  discord ~guild_id ~channel_id ~parent_channel_id ~thread_id ~user_id
+  |> Result.get_ok
+;;
+
+let slack_channel ~team_id ~channel_id ~thread_ts ~user_id =
+  slack ~team_id ~channel_id ~thread_ts ~user_id |> Result.get_ok
+;;
+
 let roundtrip ch =
   match of_yojson (to_yojson ch) with
   | Ok ch' -> assert (ch' = ch)
   | Error e -> failwith ("continuation_channel roundtrip failed: " ^ e)
 
 let test_codec_roundtrip () =
-  roundtrip (Dashboard { thread_id = "thread-42" });
+  roundtrip (dashboard_channel "thread-42");
   roundtrip
-    (Discord
-       { guild_id = Some "G1"
-       ; channel_id = "C123"
-       ; parent_channel_id = Some "P1"
-       ; thread_id = Some "T1"
-       ; user_id = "U9"
-       });
+    (discord_channel
+       ~guild_id:(Some "G1")
+       ~channel_id:"C123"
+       ~parent_channel_id:(Some "P1")
+       ~thread_id:(Some "T1")
+       ~user_id:"U9");
   roundtrip
-    (Slack
-       { team_id = Some "TEAM1"
-       ; channel_id = "general"
-       ; thread_ts = Some "1710000000.000001"
-       ; user_id = "U1"
-       });
+    (slack_channel
+       ~team_id:(Some "TEAM1")
+       ~channel_id:"general"
+       ~thread_ts:(Some "1710000000.000001")
+       ~user_id:"U1");
   roundtrip (unrouted "connector not captured at submission")
 
 let expect_error label json =
@@ -49,6 +58,40 @@ let test_missing_field_is_error () =
   (* discord requires user_id *)
   expect_error "missing discord user_id"
     (`Assoc [ ("kind", `String "discord"); ("channel_id", `String "C") ])
+
+let test_smart_constructors_reject_blank_coordinates () =
+  assert (Result.is_error (dashboard ~thread_id:" "));
+  assert (
+    Result.is_error
+      (discord
+         ~guild_id:None
+         ~channel_id:"C"
+         ~parent_channel_id:None
+         ~thread_id:None
+         ~user_id:""));
+  assert (
+    Result.is_error
+      (slack
+         ~team_id:(Some " ")
+         ~channel_id:"C"
+         ~thread_ts:None
+         ~user_id:"U"))
+
+let test_duplicate_and_unknown_fields_are_errors () =
+  expect_error
+    "duplicate kind"
+    (`Assoc
+       [ "kind", `String "dashboard"
+       ; "kind", `String "dashboard"
+       ; "thread_id", `String "T"
+       ]);
+  expect_error
+    "unknown dashboard field"
+    (`Assoc
+       [ "kind", `String "dashboard"
+       ; "thread_id", `String "T"
+       ; "channel_id", `String "C"
+       ])
 
 let test_optional_route_coordinates_are_strict () =
   List.iter
@@ -129,90 +172,79 @@ let test_non_object_is_error () =
   expect_error "non-object list" (`List [ `String "a" ])
 
 let test_is_routable () =
-  assert (is_routable (Dashboard { thread_id = "t" }));
+  assert (is_routable (dashboard_channel "t"));
   assert (
     is_routable
-      (Discord
-         { guild_id = None
-         ; channel_id = "c"
-         ; parent_channel_id = None
-         ; thread_id = None
-         ; user_id = "u"
-         }));
+      (discord_channel
+         ~guild_id:None
+         ~channel_id:"c"
+         ~parent_channel_id:None
+         ~thread_id:None
+         ~user_id:"u"));
   assert (
     is_routable
-      (Slack { team_id = None; channel_id = "c"; thread_ts = None; user_id = "u" }));
+      (slack_channel ~team_id:None ~channel_id:"c" ~thread_ts:None ~user_id:"u"));
   assert (not (is_routable (unrouted "x")))
 
 let test_kind_label () =
-  assert (String.equal (kind_label (Dashboard { thread_id = "t" })) "dashboard");
+  assert (String.equal (kind_label (dashboard_channel "t")) "dashboard");
   assert (
     String.equal
       (kind_label
-         (Discord
-            { guild_id = None
-            ; channel_id = "c"
-            ; parent_channel_id = None
-            ; thread_id = None
-            ; user_id = "u"
-            }))
+         (discord_channel
+            ~guild_id:None
+            ~channel_id:"c"
+            ~parent_channel_id:None
+            ~thread_id:None
+            ~user_id:"u"))
       "discord");
   assert (
     String.equal
       (kind_label
-         (Slack { team_id = None; channel_id = "c"; thread_ts = None; user_id = "u" }))
+         (slack_channel ~team_id:None ~channel_id:"c" ~thread_ts:None ~user_id:"u"))
       "slack");
   assert (String.equal (kind_label (unrouted "x")) "unrouted")
 
 let test_same_route () =
   (* same destination *)
-  assert (same_route (Dashboard { thread_id = "t1" }) (Dashboard { thread_id = "t1" }));
+  assert (same_route (dashboard_channel "t1") (dashboard_channel "t1"));
   assert (
     same_route
-      (Discord
-         { guild_id = Some "g"
-         ; channel_id = "c"
-         ; parent_channel_id = Some "p"
-         ; thread_id = Some "t"
-         ; user_id = "u"
-         })
-      (Discord
-         { guild_id = Some "g"
-         ; channel_id = "c"
-         ; parent_channel_id = Some "p"
-         ; thread_id = Some "t"
-         ; user_id = "u"
-         }));
+      (discord_channel
+         ~guild_id:(Some "g")
+         ~channel_id:"c"
+         ~parent_channel_id:(Some "p")
+         ~thread_id:(Some "t")
+         ~user_id:"u")
+      (discord_channel
+         ~guild_id:(Some "g")
+         ~channel_id:"c"
+         ~parent_channel_id:(Some "p")
+         ~thread_id:(Some "t")
+         ~user_id:"u"));
   (* differing coordinate -> different route *)
-  assert (not (same_route (Dashboard { thread_id = "t1" }) (Dashboard { thread_id = "t2" })));
+  assert (not (same_route (dashboard_channel "t1") (dashboard_channel "t2")));
   assert (
     not
       (same_route
-         (Discord
-            { guild_id = Some "g"
-            ; channel_id = "c"
-            ; parent_channel_id = Some "p"
-            ; thread_id = Some "t"
-            ; user_id = "u"
-            })
-         (Discord
-            { guild_id = Some "g"
-            ; channel_id = "c"
-            ; parent_channel_id = Some "p"
-            ; thread_id = Some "t2"
-            ; user_id = "u"
-            })));
+         (discord_channel
+            ~guild_id:(Some "g")
+            ~channel_id:"c"
+            ~parent_channel_id:(Some "p")
+            ~thread_id:(Some "t")
+            ~user_id:"u")
+         (discord_channel
+            ~guild_id:(Some "g")
+            ~channel_id:"c"
+            ~parent_channel_id:(Some "p")
+            ~thread_id:(Some "t2")
+            ~user_id:"u")));
   (* different constructor -> different route *)
   assert (
     not
       (same_route
-         (Dashboard { thread_id = "t" })
-         (Slack
-            { team_id = None
-            ; channel_id = "c"
-            ; thread_ts = None
-            ; user_id = "u"
-            })));
+         (dashboard_channel "t")
+         (slack_channel ~team_id:None ~channel_id:"c" ~thread_ts:None ~user_id:"u")));
   (* two Unrouted values never share a route (no destination to share) *)
   assert (not (same_route (unrouted "a") (unrouted "a")))
 
@@ -220,6 +252,8 @@ let () =
   test_codec_roundtrip ();
   test_unknown_kind_is_error ();
   test_missing_field_is_error ();
+  test_smart_constructors_reject_blank_coordinates ();
+  test_duplicate_and_unknown_fields_are_errors ();
   test_optional_route_coordinates_are_strict ();
   test_slack_legacy_channel_alias_is_rejected ();
   test_missing_kind_is_error ();

--- a/test/keeper_continuation_channel/test_keeper_continuation_channel.ml
+++ b/test/keeper_continuation_channel/test_keeper_continuation_channel.ml
@@ -43,6 +43,9 @@ let test_unknown_kind_is_error () =
 let test_missing_field_is_error () =
   (* dashboard requires thread_id *)
   expect_error "missing thread_id" (`Assoc [ ("kind", `String "dashboard") ]);
+  expect_error
+    "blank thread_id"
+    (`Assoc [ "kind", `String "dashboard"; "thread_id", `String "  " ]);
   (* discord requires user_id *)
   expect_error "missing discord user_id"
     (`Assoc [ ("kind", `String "discord"); ("channel_id", `String "C") ])
@@ -56,6 +59,13 @@ let test_optional_route_coordinates_are_strict () =
           ; "channel_id", `String "C"
           ; "user_id", `String "U"
           ; "guild_id", `Int 1
+          ] )
+    ; ( "discord guild_id blank"
+      , `Assoc
+          [ "kind", `String "discord"
+          ; "channel_id", `String "C"
+          ; "user_id", `String "U"
+          ; "guild_id", `String ""
           ] )
     ; ( "discord parent_channel_id wrong type"
       , `Assoc
@@ -84,6 +94,13 @@ let test_optional_route_coordinates_are_strict () =
           ; "channel_id", `String "C"
           ; "user_id", `String "U"
           ; "thread_ts", `Float 1.0
+          ] )
+    ; ( "slack thread_ts blank"
+      , `Assoc
+          [ "kind", `String "slack"
+          ; "channel_id", `String "C"
+          ; "user_id", `String "U"
+          ; "thread_ts", `String " "
           ] )
     ]
 

--- a/test/test_fusion_wake.ml
+++ b/test/test_fusion_wake.ml
@@ -530,13 +530,13 @@ let test_emit_success_projects_board_chat_and_registry () =
    time is consumed exactly once by the completion wake. Pure map semantics
    plus the registration edge inside [handle_with_runner]. *)
 let discord_channel =
-  Keeper_continuation_channel.Discord
-    { guild_id = Some "g-1"
-    ; channel_id = "chan-9"
-    ; parent_channel_id = None
-    ; thread_id = None
-    ; user_id = "user-3"
-    }
+  Keeper_continuation_channel.discord
+    ~guild_id:(Some "g-1")
+    ~channel_id:"chan-9"
+    ~parent_channel_id:None
+    ~thread_id:None
+    ~user_id:"user-3"
+  |> Result.get_ok
 ;;
 
 let test_wake_route_register_take_discard () =

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -147,10 +147,12 @@ let test_dedup_never_merges_distinct_origins () =
     (fun () ->
        let input = `Assoc [ "target", `String "same-action" ] in
        let dashboard_a =
-         Keeper_continuation_channel.Dashboard { thread_id = "thread-a" }
+         Keeper_continuation_channel.dashboard ~thread_id:"thread-a"
+         |> Result.get_ok
        in
        let dashboard_b =
-         Keeper_continuation_channel.Dashboard { thread_id = "thread-b" }
+         Keeper_continuation_channel.dashboard ~thread_id:"thread-b"
+         |> Result.get_ok
        in
        let first =
          submit_with_context
@@ -491,7 +493,8 @@ let test_cycle_grant_uses_exact_effect_and_is_consumed_once () =
       ]
   in
   let continuation_channel =
-    Keeper_continuation_channel.Dashboard { thread_id = "origin-thread" }
+    Keeper_continuation_channel.dashboard ~thread_id:"origin-thread"
+    |> Result.get_ok
   in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_path)

--- a/test/test_keeper_connector_attention_wake.ml
+++ b/test/test_keeper_connector_attention_wake.ml
@@ -170,13 +170,13 @@ let test_connector_attention_codec_roundtrips () =
         Q.Connector_attention
           { event_id = "evt-77"
           ; channel =
-              Keeper_continuation_channel.Discord
-                { guild_id = Some "guild-77"
-                ; channel_id = "chan-77"
-                ; parent_channel_id = Some "parent-77"
-                ; thread_id = Some "thread-77"
-                ; user_id = "user-77"
-                }
+              (Keeper_continuation_channel.discord
+                 ~guild_id:(Some "guild-77")
+                 ~channel_id:"chan-77"
+                 ~parent_channel_id:(Some "parent-77")
+                 ~thread_id:(Some "thread-77")
+                 ~user_id:"user-77"
+               |> Result.get_ok)
           }
     }
   in
@@ -188,13 +188,13 @@ let test_connector_attention_codec_roundtrips () =
       check bool "connector coordinates survive the JSON round-trip" true
         (Keeper_continuation_channel.same_route
            channel
-           (Keeper_continuation_channel.Discord
-              { guild_id = Some "guild-77"
-              ; channel_id = "chan-77"
-              ; parent_channel_id = Some "parent-77"
-              ; thread_id = Some "thread-77"
-              ; user_id = "user-77"
-              }))
+           (Keeper_continuation_channel.discord
+              ~guild_id:(Some "guild-77")
+              ~channel_id:"chan-77"
+              ~parent_channel_id:(Some "parent-77")
+              ~thread_id:(Some "thread-77")
+              ~user_id:"user-77"
+            |> Result.get_ok))
     | _ -> check bool "round-trip payload stays Connector_attention" true false)
   | Error e -> check bool ("round-trip decode failed: " ^ e) true false
 
@@ -207,13 +207,13 @@ let connector_stimulus ~event_id ~arrived_at =
       Q.Connector_attention
         { event_id
         ; channel =
-            Keeper_continuation_channel.Discord
-              { guild_id = Some "guild-durable"
-              ; channel_id = "channel-durable"
-              ; parent_channel_id = None
-              ; thread_id = None
-              ; user_id = "user-durable"
-              }
+            (Keeper_continuation_channel.discord
+               ~guild_id:(Some "guild-durable")
+               ~channel_id:"channel-durable"
+               ~parent_channel_id:None
+               ~thread_id:None
+               ~user_id:"user-durable"
+             |> Result.get_ok)
         }
   }
 

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -255,11 +255,9 @@ let () =
          ; channel = Keeper_continuation_channel.unrouted "test fixture"
          })
       "post-1");
-  (* Reply-route parity: the fusion wake serializes its originating channel,
-     and — like the sibling Connector_attention/Hitl_resolved rows — a legacy
-     Fusion_completed row persisted before the channel field existed replays as
-     [Unrouted] rather than failing the snapshot parse (a parse failure recovers
-     to an empty queue, dropping every co-resident stimulus). *)
+  (* Reply-route parity: every continuation-bearing wake serializes its exact
+     originating channel. A missing route is malformed durable state, not an
+     implicit [Unrouted] destination. *)
   (let routed : Keeper_event_queue.fusion_completion =
      { run_id = "fus-routed"
      ; ok = true
@@ -292,8 +290,8 @@ let () =
         | _ -> false)
     | Ok _ -> assert false
     | Error e -> failwith e);
-   let missing_channel_json =
-     match stimulus_to_yojson stim with
+   let without_payload_channel stimulus =
+     match stimulus_to_yojson stimulus with
      | `Assoc fields ->
        `Assoc
          (List.map
@@ -312,20 +310,30 @@ let () =
             fields)
      | other -> other
    in
-   match stimulus_of_yojson missing_channel_json with
-   | Ok { payload = Fusion_completed fc; _ } ->
-     assert (
-       match fc.channel with
-       | Keeper_continuation_channel.Unrouted { reason } ->
-         String.equal reason "legacy: channel not captured"
-       | _ -> false)
-   | Ok _ -> failwith "legacy fusion row must decode as Fusion_completed"
-   | Error e ->
-     failwith
-       (Printf.sprintf
-          "legacy fusion row without a channel key must replay Unrouted, not \
-           fail closed: %s"
-          e));
+   List.iter
+     (fun (label, stimulus) ->
+        match stimulus_of_yojson (without_payload_channel stimulus) with
+        | Error _ -> ()
+        | Ok _ -> failwith (label ^ " without channel must fail explicitly"))
+     [ "fusion completion", stim
+     ; ( "connector attention"
+       , { stim with
+           post_id = "connector-route"
+         ; payload =
+             Connector_attention
+               { event_id = "connector-route"; channel = routed.channel }
+         } )
+     ; ( "HITL resolution"
+       , { stim with
+           post_id = "hitl:approval-route"
+         ; payload =
+             Hitl_resolved
+               { approval_id = "approval-route"
+               ; decision = Hitl_approved
+               ; channel = routed.channel
+               }
+         } )
+     ]);
   assert (
     String.equal
       (fusion_completion_post_id

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -264,13 +264,13 @@ let () =
      ; resolved_answer = "answer"
      ; board_post_id = "post-9"
      ; channel =
-         Keeper_continuation_channel.Discord
-           { guild_id = None
-           ; channel_id = "chan-42"
-           ; parent_channel_id = None
-           ; thread_id = Some "th-1"
-           ; user_id = "u-7"
-           }
+         (Keeper_continuation_channel.discord
+            ~guild_id:None
+            ~channel_id:"chan-42"
+            ~parent_channel_id:None
+            ~thread_id:(Some "th-1")
+            ~user_id:"u-7"
+          |> Result.get_ok)
      }
    in
    let stim : Keeper_event_queue.stimulus =

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -1640,45 +1640,4 @@ let () =
       in
       assert (String.equal second.post_id "bootstrap"));
 
-  (* RFC-0320 backward compat: pre-W2 persisted stimuli have no [channel] in
-     their payload and must replay as [Unrouted], not fail — a restart
-     replaying a legacy wake queue must not break. Simulate by serializing a W2
-     stimulus then stripping the [channel] field before parsing back. *)
-  (let strip_channel json =
-     match json with
-     | `Assoc top ->
-       `Assoc
-         (List.map
-            (fun (k, v) ->
-              if String.equal k "payload" then
-                ( k
-                , match v with
-                  | `Assoc p ->
-                    `Assoc
-                      (List.filter (fun (pk, _) -> not (String.equal pk "channel")) p)
-                  | other -> other )
-              else (k, v))
-            top)
-     | other -> other
-   in
-   let hitl_stim =
-     { post_id = "p-legacy"
-     ; urgency = Immediate
-     ; arrived_at = 1.0
-     ; payload =
-         Hitl_resolved
-           { approval_id = "a"
-           ; decision = Hitl_approved
-           ; channel = Keeper_continuation_channel.unrouted "seed"
-           }
-     }
-   in
-   match stimulus_of_yojson (strip_channel (stimulus_to_yojson hitl_stim)) with
-   | Ok s ->
-     (match s.payload with
-      | Hitl_resolved r ->
-        assert (not (Keeper_continuation_channel.is_routable r.channel))
-      | _ -> assert false)
-   | Error _ -> assert false);
-
   print_endline "test_keeper_event_queue: all passed"

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -639,14 +639,12 @@ let write_queue path queue =
   |> require_ok ("write fixture " ^ path)
 ;;
 
-let read_schema path =
-  match Safe_ops.read_json_file_safe path with
-  | Error message -> Alcotest.failf "read migrated state: %s" message
-  | Ok (`Assoc fields) ->
-    (match List.assoc_opt "schema" fields with
-     | Some (`String schema) -> schema
-     | _ -> Alcotest.fail "migrated state lacks schema")
-  | Ok _ -> Alcotest.fail "migrated state is not an object"
+let write_state path state =
+  Fs_compat.mkdir_p (Filename.dirname path);
+  State.to_yojson state
+  |> Yojson.Safe.pretty_to_string
+  |> Fs_compat.save_file_atomic path
+  |> require_ok ("write fixture " ^ path)
 ;;
 
 let test_context_compaction_retry_is_durable_and_lane_local () =
@@ -784,46 +782,32 @@ let test_context_compaction_retry_is_durable_and_lane_local () =
     | _ -> Alcotest.fail "retained retry was not left pending after peer work claimed")
 ;;
 
-let test_legacy_pair_migrates_once () =
-  with_temp_dir "keeper-event-queue-v2-migration" (fun base_path ->
-    let keeper_name = "migration_keeper" in
+let test_unsupported_snapshots_fail_closed () =
+  with_temp_dir "keeper-event-queue-v3-hardcut" (fun base_path ->
+    let keeper_name = "hardcut_keeper" in
     let dir = keeper_dir ~base_path ~keeper_name in
     let primary = Filename.concat dir "event-queue.json" in
-    let legacy = Filename.concat dir "event-queue-inflight.json" in
-    write_queue primary (queue [ stimulus "pending" 1.0 ]);
-    write_queue legacy (queue [ stimulus "leased" 2.0 ]);
-    let state =
-      Persistence.load_state_result ~base_path ~keeper_name
-      |> require_ok "migrate legacy pair"
-    in
-    Alcotest.(check string) "primary became v2" State.schema (read_schema primary);
-    Alcotest.(check bool) "legacy input removed" false (Sys.file_exists legacy);
-    Alcotest.(check (list string))
-      "legacy lease recovered before publication"
-      [ "leased"; "pending" ]
-      (post_ids (State.pending state));
-    Alcotest.(check int) "no abandoned lease survives migration" 0 (List.length (State.leases state));
-    Alcotest.(check int)
-      "migration recovery receipt retained"
-      1
-      (List.length (State.transition_outbox state));
-    write_queue legacy (queue [ stimulus "leased" 2.0 ]);
-    let resumed =
-      Persistence.load_state_result ~base_path ~keeper_name
-      |> require_ok "resume completed migration cleanup"
-    in
-    Alcotest.(check (list string))
-      "crash residue does not duplicate migrated stimulus"
-      [ "leased"; "pending" ]
-      (post_ids (State.pending resumed));
+    let unsupported = Filename.concat dir "event-queue-inflight.json" in
+    write_state
+      primary
+      (State.with_pending (queue [ stimulus "pending" 1.0 ]) State.empty);
+    write_queue unsupported (queue [ stimulus "obsolete" 2.0 ]);
+    (match Persistence.load_state_result ~base_path ~keeper_name with
+     | Error message ->
+       Alcotest.(check bool)
+         "unsupported sidecar is named"
+         true
+         (String.starts_with ~prefix:"unsupported event queue sidecar remains" message)
+     | Ok _ -> Alcotest.fail "current state silently accepted unsupported sidecar");
     Alcotest.(check bool)
-      "verified crash residue removed"
-      false
-      (Sys.file_exists legacy);
-    write_queue legacy (queue [ stimulus "forbidden-residue" 3.0 ]);
+      "hard cut does not delete unsupported input"
+      true
+      (Sys.file_exists unsupported);
+    Sys.remove unsupported;
+    write_queue primary (queue [ stimulus "old-schema" 3.0 ]);
     (match Persistence.load_state_result ~base_path ~keeper_name with
      | Error _ -> ()
-     | Ok _ -> Alcotest.fail "v2 state silently accepted legacy residue"))
+     | Ok _ -> Alcotest.fail "old primary schema was migrated"))
 ;;
 
 let test_transition_outbox_projects_with_stable_identity () =
@@ -1050,7 +1034,10 @@ let () =
             "context compaction retry is durable and lane-local"
             `Quick
             test_context_compaction_retry_is_durable_and_lane_local
-        ; Alcotest.test_case "legacy pair migration" `Quick test_legacy_pair_migrates_once
+        ; Alcotest.test_case
+            "unsupported snapshots fail closed"
+            `Quick
+            test_unsupported_snapshots_fail_closed
         ; Alcotest.test_case
             "transition outbox projection"
             `Quick


### PR DESCRIPTION
## Why

#24616 changed persisted continuation semantics without changing the enclosing durable schema, and its public raw constructors could create values that its decoder rejected. This recut preserves the useful strict-route behavior while making the hard cut explicit and atomic.

Replaces #24616. No migration or compatibility shim is provided.

## What

- make continuation route variants private and expose validated smart constructors
- reject blank coordinates, duplicate JSON fields, unknown fields, missing routes, and kind-specific extra fields
- route every production producer through the validated constructors
- bump `keeper.event_queue.v1` to `keeper.event_queue.v2` and state envelope v2 to v3
- delete v1/sidecar migration and reject obsolete `event-queue-inflight.json` explicitly
- retain fail-closed errors instead of synthesizing `Unrouted` for missing persisted routes

## Architecture

- MASC-owned durable routing only; no OAS dependency or authority change
- one authoritative persisted route per wake
- no aliases, inferred defaults, migration, heuristic repair, or silent empty fallback
- the codec and enclosing schema hard cut stay in one PR because splitting them would recreate a same-version semantic mutation

## Focused proof

- `scripts/dune-local.sh build test/keeper_continuation_channel/test_keeper_continuation_channel.exe`
- `_build/default/test/keeper_continuation_channel/test_keeper_continuation_channel.exe`
- `scripts/dune-local.sh build test/keeper_event_queue/test_keeper_event_queue.exe test/test_keeper_event_queue_state_v2.exe`
- `_build/default/test/keeper_event_queue/test_keeper_event_queue.exe`
- `_build/default/test/test_keeper_event_queue_state_v2.exe`
- `ocamlformat --check` on all 17 touched OCaml files
- `git diff --check`

Head reviewed: `147369157d`