### PR TITLE
refactor(connector): move trigger policy to leaf descriptor

### DIFF
--- a/dashboard/src/api/schemas/gate-connectors.test.ts
+++ b/dashboard/src/api/schemas/gate-connectors.test.ts
@@ -24,6 +24,7 @@ describe('parseGateConnectorsData', () => {
     expect(result.connectors).toHaveLength(1)
     expect(result.connectors[0].connector_id).toBe('c1')
     expect(result.connectors[0].capabilities).toEqual([])
+    expect(result.connectors[0].trigger_policy).toBeNull()
     expect(result.connectors[0].available).toBe(false)
     expect(result.connectors[0].guild_count).toBe(0)
     expect(result.connectors[0].source_health).toEqual({
@@ -36,6 +37,29 @@ describe('parseGateConnectorsData', () => {
     expect(result.total).toBe(1)
     expect(result.active_count).toBe(1)
     expect(result.generated_at).toBe('2024-01-01T00:00:00Z')
+  })
+
+  it('projects leaf trigger policy without retaining the legacy aggregate field', () => {
+    const result = parseGateConnectorsData({
+      ...minimalOuter,
+      connectors: [{ ...minimalConnector, trigger_policy: 'all' }],
+      discord_trigger_policy: 'mention_only',
+    })
+    expect(result.connectors[0].trigger_policy).toBe('all')
+    expect('discord_trigger_policy' in result).toBe(false)
+  })
+
+  it('does not reinterpret an invalid leaf trigger policy as null', () => {
+    const result = parseGateConnectorsData({
+      ...minimalOuter,
+      connectors: [
+        { ...minimalConnector, trigger_policy: 7 },
+        { ...minimalConnector, connector_id: 'c2', trigger_policy: null },
+      ],
+    })
+    expect(result.connectors).toHaveLength(1)
+    expect(result.connectors[0].connector_id).toBe('c2')
+    expect(result.connectors[0].trigger_policy).toBeNull()
   })
 
   it('throws GateConnectorsSchemaDriftError when generated_at is empty', () => {

--- a/dashboard/src/api/schemas/gate-connectors.ts
+++ b/dashboard/src/api/schemas/gate-connectors.ts
@@ -207,6 +207,7 @@ const GateConnectorInfoRawSchema = object({
   display_name: string(),
   channel: string(),
   capabilities: fallback(array(string()), []),
+  trigger_policy: optional(nullable(string()), null),
   status: fallback(string(), ''),
   available: fallback(boolean(), false),
   connected: fallback(boolean(), false),
@@ -252,6 +253,7 @@ export interface GateConnectorInfo {
   display_name: string
   channel: string
   capabilities: string[]
+  trigger_policy: string | null
   status: string
   available: boolean
   connected: boolean
@@ -361,6 +363,7 @@ function parseGateConnectorInfo(raw: unknown): GateConnectorInfo | null {
     display_name: outer.output.display_name,
     channel: outer.output.channel,
     capabilities: outer.output.capabilities,
+    trigger_policy: outer.output.trigger_policy,
     status: outer.output.status,
     available: outer.output.available,
     connected: outer.output.connected,
@@ -417,7 +420,6 @@ const GateConnectorsOuterSchema = object({
   connectors: optional(unknown()),
   total: fallback(number(), 0),
   active_count: fallback(number(), 0),
-  discord_trigger_policy: fallback(string(), 'unknown'),
   // Empty string is treated as drift — matches prior decoder's
   // `if (!generatedAt) return null` guard. A connectors payload
   // without a timestamp is not a useful one; the null-returning
@@ -429,7 +431,6 @@ export interface GateConnectorsData {
   connectors: GateConnectorInfo[]
   total: number
   active_count: number
-  discord_trigger_policy: string
   generated_at: string
 }
 
@@ -455,7 +456,6 @@ export function parseGateConnectorsData(data: unknown): GateConnectorsData {
     connectors,
     total: outer.total,
     active_count: outer.active_count,
-    discord_trigger_policy: outer.discord_trigger_policy,
     generated_at: outer.generated_at,
   }
 }

--- a/dashboard/src/components/connector-overview-strip.test.ts
+++ b/dashboard/src/components/connector-overview-strip.test.ts
@@ -73,6 +73,17 @@ describe('ConnectorOverviewStrip', () => {
     expect(imessageTile.textContent).toContain('Config와 Start')
   })
 
+  it('shows the Discord leaf trigger policy in the overview header', () => {
+    render(
+      html`<${ConnectorOverviewStrip}
+        connectors=${[mkConnector({ trigger_policy: 'mention_or_thread' })]}
+        keeperCount=${0}
+      />`,
+      container,
+    )
+    expect(container.textContent).toContain('trigger: mention_or_thread')
+  })
+
   it('Start All button counts only sidecars currently down', () => {
     _testResetBulkInflight()
     render(

--- a/dashboard/src/components/connector-overview-strip.ts
+++ b/dashboard/src/components/connector-overview-strip.ts
@@ -155,7 +155,6 @@ async function runBulk(
 interface OverviewProps {
   connectors: GateConnectorInfo[]
   keeperCount: number
-  discordTriggerPolicy?: string
   selectedConnectorId?: KnownConnectorId | null
   onSelectConnector?: (connectorId: KnownConnectorId) => void
   onOpenConfig?: (connectorId: KnownConnectorId) => void
@@ -758,7 +757,6 @@ function IncidentBanner({ droppedIds }: { droppedIds: string[] }) {
 export function ConnectorOverviewStrip({
   connectors,
   keeperCount,
-  discordTriggerPolicy,
   selectedConnectorId = null,
   onSelectConnector,
   onOpenConfig,
@@ -787,13 +785,14 @@ export function ConnectorOverviewStrip({
 
   const droppedIds = detectRecentDrops(stripMemory.value, connectors, Date.now())
   const summary = summarizeConnectorStrip(connectors, keeperCount)
+  const discordTriggerPolicy = findConnector(connectors, 'discord')?.trigger_policy
   return html`
     <${SurfaceCard} class="mb-4 !p-3 v2-connector-overview-strip" data-overview-strip-root>
       <${IncidentBanner} droppedIds=${droppedIds} />
       <div class="mb-3 flex flex-wrap items-center justify-between gap-2">
         <div class="flex flex-wrap items-center gap-2">
           <${StatusSummaryLine} summary=${summary} connectors=${connectors} />
-          ${discordTriggerPolicy && discordTriggerPolicy !== 'unknown'
+          ${discordTriggerPolicy
             ? html`<span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-0.5 text-3xs font-medium text-[var(--color-fg-secondary)]">trigger: ${discordTriggerPolicy}</span>`
             : null
           }

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -386,6 +386,7 @@ function placeholderConnector(connectorId: KnownConnectorId): GateConnectorInfo 
     display_name: CONNECTOR_DISPLAY_NAMES[connectorId],
     channel: connectorId,
     capabilities: ['bindings'],
+    trigger_policy: null,
     status: 'offline',
     available: false,
     connected: false,
@@ -2267,7 +2268,6 @@ export function ConnectorStatusPanel() {
                 <${ConnectorOverviewStrip}
                   connectors=${allConnectors}
                   keeperCount=${snapshot.keepers.length}
-                  discordTriggerPolicy=${snapshot.connectors?.discord_trigger_policy}
                   selectedConnectorId=${focusedConnectorId}
                   onSelectConnector=${(connectorId: KnownConnectorId) => { selectedConnectorId.value = connectorId }}
                   onOpenConfig=${(connectorId: KnownConnectorId) => {

--- a/lib/gate/channel_gate_connector.ml
+++ b/lib/gate/channel_gate_connector.ml
@@ -63,17 +63,11 @@ let connectors_json ?gate_status_json ?(audit_limit = 10) () =
         else acc)
       0 connector_jsons
   in
-  let policy_str =
-    match Channel_gate_discord_state.get_trigger_policy () with
-    | None -> "unknown"
-    | Some p -> Discord_gateway_state.trigger_policy_to_string p
-  in
   `Assoc
     [
       ("connectors", `List connector_jsons);
       ("total", `Int (List.length connectors));
       ("active_count", `Int active_count);
-      ("discord_trigger_policy", `String policy_str);
       ("generated_at",
        `String (Gate_time_util.iso8601_of_unix (Unix.gettimeofday ())));
     ]

--- a/lib/gate/channel_gate_discord_state.ml
+++ b/lib/gate/channel_gate_discord_state.ml
@@ -96,8 +96,8 @@ let unregister_thread ~thread_id =
 
 (* ── Trigger policy registry ──────────────────────────────────────
    Set once at gateway startup by [set_trigger_policy]. Read by
-   [connectors_json] for dashboard display. Same mutable-ref pattern
-   as [record_ready]. *)
+   this connector's status projection for dashboard display. Same
+   mutable-ref pattern as [record_ready]. *)
 
 let trigger_policy_ref : Discord_gateway_state.trigger_policy option ref =
   ref None
@@ -106,6 +106,12 @@ let set_trigger_policy (policy : Discord_gateway_state.trigger_policy) =
   trigger_policy_ref := Some policy
 
 let get_trigger_policy () = !trigger_policy_ref
+
+let trigger_policy_json () =
+  match get_trigger_policy () with
+  | None -> `Null
+  | Some policy ->
+    `String (Discord_gateway_state.trigger_policy_to_string policy)
 
 let string_member json key =
   Json_util.get_string_with_default json ~key ~default:""
@@ -207,6 +213,7 @@ let status_json ?(audit_limit = 10) () =
       ("error", `String error);
       ("status_source", `String "in_process_gateway");
       ("gateway_state", `String (gateway_state_label gateway_state));
+      ("trigger_policy", trigger_policy_json ());
       ("status_path", `String status_path);
       ("binding_store_path", `String binding_store_path);
       ("audit_path", `String audit_path);
@@ -331,6 +338,7 @@ let connector_json ?gate_status_json ?(audit_limit = 10) () =
       ("display_name", `String display_name);
       ("channel", `String channel);
       ("capabilities", Channel_gate_connector_capability.all_json);
+      ("trigger_policy", status |> U.member "trigger_policy");
       ("status", `String (string_member status "status"));
       ("available", `Bool (bool_member status "available"));
       ("connected", `Bool (bool_member status "connected"));

--- a/test/test_channel_gate_discord_state.ml
+++ b/test/test_channel_gate_discord_state.ml
@@ -187,6 +187,7 @@ let test_unbind_removes_existing_binding () =
 let test_connectors_json_advertises_gate_connector_descriptor () =
   with_temp_dir @@ fun dir ->
   with_discord_paths dir (fun () ->
+    Discord_state.set_trigger_policy Discord_gateway_state.All;
     ignore
       (Discord_state.bind ~channel_id:"1234567890" ~keeper_name:"luna"
          ~actor_name:"dashboard");
@@ -231,6 +232,13 @@ let test_connectors_json_advertises_gate_connector_descriptor () =
       (connector |> U.member "connector_id" |> U.to_string);
     check string "display name" "Discord"
       (connector |> U.member "display_name" |> U.to_string);
+    check string "leaf trigger policy" "all"
+      (connector |> U.member "trigger_policy" |> U.to_string);
+    (match json with
+     | `Assoc fields ->
+       check bool "aggregate has no Discord-specific field" false
+         (List.mem_assoc "discord_trigger_policy" fields)
+     | _ -> fail "expected connector aggregate object");
     check bool "bindings capability exposed" true
       (connector |> U.member "capabilities" |> U.to_list
        |> List.exists (function


### PR DESCRIPTION
## Why

The Gate connector aggregate exposed a Discord-only `discord_trigger_policy` field as if it were global connector authority. The policy belongs to the concrete connector descriptor.

This is a clean recut of #24625 on top of #25020.

## What

- expose Discord trigger policy on the Discord connector status/descriptor
- delete the aggregate `discord_trigger_policy` field
- make dashboard consumers read the selected connector leaf
- distinguish missing/null policy from wrong-typed policy; invalid values are no longer reinterpreted as normal `null`

## Boundary

- MASC-only connector projection
- no OAS changes
- no alias, aggregate fallback, or duplicate policy authority

## Focused proof

- `vitest ... gate-connectors.test.ts connector-overview-strip.test.ts`: 88 passed
- `tsc --noEmit`: passed
- `git diff --check`: passed
- OCaml focused build was started but cancelled after the shared Dune lock/build produced no additional output; it is not claimed as proof

Stack: #25020
Head reviewed: `115ff62247`