### PR TITLE
feat(keeper): surface exact OAS tool occurrence

### DIFF
--- a/dashboard/src/api/dashboard-keeper-tool-calls.ts
+++ b/dashboard/src/api/dashboard-keeper-tool-calls.ts
@@ -39,6 +39,9 @@ export type ToolCallEntry = {
   // join this entry's output onto the transcript. Absent when the call carried
   // no provider id (synthesised tc-<position> rows) or on pre-PR-2 logs.
   tool_use_id?: string
+  // OAS model-tool occurrence slot. Together with turn it scopes provider ids
+  // that may be blank or repeated.
+  planned_index?: number
   // Goal id(s) this call was attributed to (conditional on the row carrying
   // them), for goal-scoped drill-down alongside task_id/turn.
   goal_ids?: string[]
@@ -93,7 +96,8 @@ function decodeToolCallEntry(raw: unknown): ToolCallEntry | null {
     task_id: asString(raw.task_id),
     lane: asString(raw.lane),
     execution_id: asString(raw.execution_id),
-    tool_use_id: asString(raw.tool_use_id),
+    tool_use_id: typeof raw.tool_use_id === 'string' ? raw.tool_use_id : undefined,
+    planned_index: asNumber(raw.planned_index),
     goal_ids: asStringArray(raw.goal_ids),
   }
 }

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -396,7 +396,7 @@ describe('keeper tool telemetry fetchers', () => {
     })
   })
 
-  it('decodes objective success and goal_ids on an entry', async () => {
+  it('decodes objective success, goals, and exact OAS occurrence', async () => {
     const fetchMock = vi.fn(() => Promise.resolve(
       new Response(JSON.stringify({
         keeper: 'keeper-alpha',
@@ -411,6 +411,9 @@ describe('keeper tool telemetry fetchers', () => {
             output: 'ok',
             success: true,
             duration_ms: 5,
+            tool_use_id: '',
+            turn: 6,
+            planned_index: 2,
             goal_ids: ['g-1', 'g-2'],
           },
         ],
@@ -422,6 +425,9 @@ describe('keeper tool telemetry fetchers', () => {
     const entry = result.entries[0]
     expect(entry?.success).toBe(true)
     expect(entry?.goal_ids).toEqual(['g-1', 'g-2'])
+    expect(entry?.tool_use_id).toBe('')
+    expect(entry?.turn).toBe(6)
+    expect(entry?.planned_index).toBe(2)
   })
 
   it('keeps missing or malformed tool-call duration unmeasured', async () => {

--- a/dashboard/src/components/keeper-tool-call-inspector-render.test.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector-render.test.ts
@@ -243,7 +243,9 @@ describe('KeeperToolCallInspector render', () => {
           success: false,
           duration_ms: 2_600,
           trace_id: 'trace-runtime',
+          tool_use_id: '',
           turn: 9,
+          planned_index: 4,
           lane: 'autonomous',
         },
       ],
@@ -268,6 +270,7 @@ describe('KeeperToolCallInspector render', () => {
     expect(text).toContain('Evidence links')
     expect(text).toContain('Code')
     expect(text).toContain('Task')
+    expect(text).toContain('turn 9 · plan 4 · tool_use_id (blank)')
   })
 
   it('does not render Code links for unsafe absolute tool-call file inputs', async () => {

--- a/dashboard/src/components/keeper-tool-call-inspector.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector.ts
@@ -205,6 +205,10 @@ function entryScopeLabel(entry: ToolCallEntry): string {
   const goalIds = entry.goal_ids ?? []
   const parts = [
     typeof entry.turn === 'number' ? `turn ${entry.turn}` : null,
+    typeof entry.planned_index === 'number' ? `plan ${entry.planned_index}` : null,
+    entry.tool_use_id !== undefined
+      ? `tool_use_id ${entry.tool_use_id === '' ? '(blank)' : entry.tool_use_id}`
+      : null,
     typeof entry.keeper_turn_id === 'number' ? `keeper ${entry.keeper_turn_id}` : null,
     entry.lane ? `lane ${entry.lane}` : null,
     entry.task_id ? `task ${entry.task_id}` : null,
@@ -504,6 +508,9 @@ function ToolCallRow({ entry }: { entry: ToolCallEntry }) {
           ${entry.model ? html`
             <div class="text-3xs text-[var(--color-fg-muted)]">model: <span class="text-[var(--color-fg-secondary)] font-mono">${entry.model}</span></div>
           ` : null}
+          <div class="text-3xs text-[var(--color-fg-muted)]">
+            occurrence: <span class="text-[var(--color-fg-secondary)] font-mono">${entryScopeLabel(entry)}</span>
+          </div>
           ${routeLinks.length > 0 ? html`
             <div class="flex items-center justify-between gap-2 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2.5 py-2 v2-monitoring-toolbar">
               <span class="min-w-0 truncate text-3xs font-mono text-[var(--color-fg-muted)]" title=${routeLinks.map(link => link.evidence).join(' · ')}>

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -135,6 +135,7 @@ let make_hooks
   : Agent_sdk.Hooks.hooks =
   let sse_turn_complete = "keeper_turn_complete" in
   let tool_start_time = ref 0.0 in
+  let tool_invocation_turn = ref None in
   (* Per-turn tool call counter for SSE enrichment.
      Incremented in post_tool_use, reset in after_turn. *)
   let tool_call_count_ref = ref 0 in
@@ -149,8 +150,9 @@ let make_hooks
     { Agent_sdk.Hooks.empty with
     pre_tool_use = Some (fun event ->
       match event with
-      | Agent_sdk.Hooks.PreToolUse _ ->
+      | Agent_sdk.Hooks.PreToolUse { turn; _ } ->
         tool_start_time := Time_compat.now ();
+        tool_invocation_turn := Some turn;
         Agent_sdk.Hooks.Continue
       | _event -> Agent_sdk.Hooks.Continue);
 
@@ -382,7 +384,14 @@ let make_hooks
     post_tool_use = Some (fun event ->
       match event with
       | Agent_sdk.Hooks.PostToolUse
-          { tool_name; input; output; duration_ms = hook_duration_ms; tool_use_id; _ } ->
+          { tool_name
+          ; input
+          ; output
+          ; duration_ms = hook_duration_ms
+          ; tool_use_id
+          ; schedule
+          ; _
+          } ->
         record_progress ("tool_completed:" ^ tool_name);
         incr tool_call_count_ref;
         (* OAS exposes the provider-facing tool body here as text.  It is not a
@@ -451,6 +460,12 @@ let make_hooks
           Keeper_tool_call_log_context.get_turn_context_record
             ~cell:turn_ctx_cell ()
         in
+        let invocation_turn =
+          match !tool_invocation_turn with
+          | Some turn -> Some turn
+          | None -> tctx.turn
+        in
+        tool_invocation_turn := None;
         (* RFC-0233 PR-1: one mint per execution at this dispatch boundary;
            the log_call row and the trajectory entry below share the value
            so downstream views can join the two stores on a single key. *)
@@ -473,10 +488,11 @@ let make_hooks
              ?thinking_budget:tctx.thinking_budget
              ?prompt_fingerprint:tctx.prompt_fingerprint
              ~execution_id
-             ?tool_use_id:(if tool_use_id = "" then None else Some tool_use_id)
+             ~tool_use_id
+             ~planned_index:schedule.planned_index
              ?trace_id:tctx.trace_id ?session_id:tctx.session_id
              ?generation:tctx.generation
-             ?turn:tctx.turn ?keeper_turn_id:tctx.keeper_turn_id
+             ?turn:invocation_turn ?keeper_turn_id:tctx.keeper_turn_id
              ?task_id:tctx.task_id ?goal_ids:tctx.goal_ids
              ?sandbox_profile:tctx.sandbox_profile
              ?sandbox_root:tctx.sandbox_root

--- a/lib/keeper/keeper_tools_oas_bundle.ml
+++ b/lib/keeper/keeper_tools_oas_bundle.ml
@@ -117,11 +117,15 @@ let make_tool_bundle
                | Keeper_tool_descriptor.Current_task_state ->
                  descriptor.description ^ "\n\n" ^ task_state_hint ~config ~meta
              in
-             Tool_bridge.oas_tool_of_masc
+             Tool_bridge.oas_tool_of_masc_with_execution_env
                ~name:model_name
                ~description
                ~input_schema:descriptor.input_schema
-               (fun input -> h input)))
+               (fun execution_env input ->
+                 h
+                   ?oas_invocation:
+                     (Agent_sdk.Tool.Execution_env.invocation execution_env)
+                   input)))
       model_visible_descriptors
   in
   let bundle =

--- a/lib/keeper/keeper_tools_oas_handler.ml
+++ b/lib/keeper/keeper_tools_oas_handler.ml
@@ -28,7 +28,7 @@ let make_keeper_tool_handler
       ?(translate_input = fun j -> j)
       ?(validate_translated_input = true)
       ()
-  : Yojson.Safe.t -> Tool_result.result
+  : ?oas_invocation:Agent_sdk.Tool.Invocation.t -> Yojson.Safe.t -> Tool_result.result
   =
   let record_result ~input result =
     Option.iter
@@ -36,7 +36,8 @@ let make_keeper_tool_handler
       record_gate_result;
     result
   in
-  fun raw_input ->
+  fun ?oas_invocation raw_input ->
+    let invocation_fields = oas_invocation_fields oas_invocation in
     let handle_validation_error ~input validation_result =
       let output_text = Tool_result.message validation_result in
       let duration_ms = 0 in
@@ -66,7 +67,8 @@ let make_keeper_tool_handler
         ~disposition:validation_result
         ~error_text
         ~extra_fields:
-          (tool_io_preview_fields ~tool_name:name ~input ~output:output_text ())
+          (tool_io_preview_fields ~tool_name:name ~input ~output:output_text ()
+           @ invocation_fields)
         ~site:"input_validation"
         ~ts
         ();
@@ -79,7 +81,7 @@ let make_keeper_tool_handler
         ~keeper_name:meta.name
         ~site:"input_validation"
         (`Assoc
-            [ "ts_unix", `Float ts
+            ([ "ts_unix", `Float ts
             ; "event", `String "tool_exec"
             ; "keeper_name", `String meta.name
             ; "tool", `String name
@@ -87,7 +89,8 @@ let make_keeper_tool_handler
             ; "result_bytes", `Int (String.length output_text)
             ; "disposition", `String disposition
             ; "error", `String error_text
-            ]);
+            ]
+             @ invocation_fields));
       validation_result |> record_result ~input
     in
     match pre_validate_input raw_input with
@@ -131,6 +134,7 @@ let make_keeper_tool_handler
               ?continuation_channel
               ?gate_context
               ?gate_grant
+              ?oas_invocation
               ~input
               ()
             |> record_result ~input

--- a/lib/keeper/keeper_tools_oas_handler.mli
+++ b/lib/keeper/keeper_tools_oas_handler.mli
@@ -39,5 +39,6 @@ val make_keeper_tool_handler
   -> ?translate_input:(Yojson.Safe.t -> Yojson.Safe.t)
   -> ?validate_translated_input:bool
   -> unit
+  -> ?oas_invocation:Agent_sdk.Tool.Invocation.t
   -> Yojson.Safe.t
   -> Tool_result.result

--- a/lib/keeper/keeper_tools_oas_handler_exec.ml
+++ b/lib/keeper/keeper_tools_oas_handler_exec.ml
@@ -26,11 +26,13 @@ let execute_with_observers
       ?continuation_channel
       ?gate_context
       ?gate_grant
+      ?oas_invocation
       ~(input : Yojson.Safe.t)
       ()
   : Tool_result.result
   =
   let t0 = Time_compat.now () in
+  let invocation_fields = oas_invocation_fields oas_invocation in
   try
     let result, duration_ms =
       Inference_utils.timed (fun () ->
@@ -95,7 +97,8 @@ let execute_with_observers
         ~disposition:result.disposition
         ~error_text:detail
         ~extra_fields:
-          (tool_io_preview_fields ~tool_name:name ~input ~output:raw_result ())
+          (tool_io_preview_fields ~tool_name:name ~input ~output:raw_result ()
+           @ invocation_fields)
         ~site:"error_result"
         ~ts
         ();
@@ -110,7 +113,7 @@ let execute_with_observers
         ~keeper_name:meta.name
         ~site:"error_result"
         (`Assoc
-            [ "ts_unix", `Float ts
+            ([ "ts_unix", `Float ts
             ; "event", `String "tool_exec"
             ; "keeper_name", `String meta.name
             ; "tool", `String name
@@ -118,7 +121,8 @@ let execute_with_observers
             ; "result_bytes", `Int (String.length projected_error)
             ; "disposition", `String disposition
             ; "error_preview", `String detail
-            ]);
+            ]
+             @ invocation_fields));
       Keeper_tool_call_log.set_truncation_info
         ~keeper_name:meta.name
         ~original_bytes:(String.length projected_error)
@@ -158,7 +162,8 @@ let execute_with_observers
         ~duration_ms
         ~disposition:result.disposition
         ~extra_fields:
-          (tool_io_preview_fields ~tool_name:name ~input ~output:raw_result ())
+          (tool_io_preview_fields ~tool_name:name ~input ~output:raw_result ()
+           @ invocation_fields)
         ~site:"success"
         ~ts
         ();
@@ -176,7 +181,8 @@ let execute_with_observers
              ; "duration_ms", `Int duration_ms
              ; "result_bytes", `Int original_len
              ; "disposition", `String disposition
-             ]));
+             ]
+             @ invocation_fields));
       Keeper_tool_call_log.set_truncation_info
         ~keeper_name:meta.name
         ~original_bytes:original_len
@@ -214,7 +220,8 @@ let execute_with_observers
         ~duration_ms
         ~disposition:result.disposition
         ~extra_fields:
-          (tool_io_preview_fields ~tool_name:name ~input ~output:raw_result ())
+          (tool_io_preview_fields ~tool_name:name ~input ~output:raw_result ()
+           @ invocation_fields)
         ~site:"deferred"
         ~ts
         ();
@@ -223,14 +230,15 @@ let execute_with_observers
         ~keeper_name:meta.name
         ~site:"deferred"
         (`Assoc
-            [ "ts_unix", `Float ts
+            ([ "ts_unix", `Float ts
             ; "event", `String "tool_exec"
             ; "keeper_name", `String meta.name
             ; "tool", `String name
             ; "duration_ms", `Int duration_ms
             ; "result_bytes", `Int (String.length projected_result)
             ; "disposition", `String disposition
-            ]);
+            ]
+             @ invocation_fields));
       Keeper_tool_call_log.set_truncation_info
         ~keeper_name:meta.name
         ~original_bytes:(String.length projected_result)
@@ -269,7 +277,8 @@ let execute_with_observers
       ~disposition:exception_result
       ~error_text
       ~extra_fields:
-        (tool_io_preview_fields ~tool_name:name ~input ~output:error_text ())
+        (tool_io_preview_fields ~tool_name:name ~input ~output:error_text ()
+         @ invocation_fields)
       ~site:"exception"
       ~ts
       ();
@@ -285,7 +294,7 @@ let execute_with_observers
       ~keeper_name:meta.name
       ~site:"exception"
       (`Assoc
-          [ "ts_unix", `Float ts
+          ([ "ts_unix", `Float ts
           ; "event", `String "tool_exec"
           ; "keeper_name", `String meta.name
           ; "tool", `String name
@@ -293,7 +302,8 @@ let execute_with_observers
           ; "result_bytes", `Int (String.length projected_error)
           ; "disposition", `String disposition
           ; "error", `String error_text
-          ]);
+          ]
+           @ invocation_fields));
     Keeper_tool_call_log.set_truncation_info
       ~keeper_name:meta.name
       ~original_bytes:(String.length projected_error)

--- a/lib/keeper/keeper_tools_oas_handler_exec.mli
+++ b/lib/keeper/keeper_tools_oas_handler_exec.mli
@@ -24,6 +24,7 @@ val execute_with_observers
   -> ?continuation_channel:Keeper_continuation_channel.t
   -> ?gate_context:(unit -> Keeper_gate.causal_context)
   -> ?gate_grant:Keeper_gate.cycle_grant
+  -> ?oas_invocation:Agent_sdk.Tool.Invocation.t
   -> input:Yojson.Safe.t
   -> unit
   -> Tool_result.result

--- a/lib/keeper/keeper_tools_oas_handler_telemetry.ml
+++ b/lib/keeper/keeper_tools_oas_handler_telemetry.ml
@@ -59,6 +59,15 @@ let tool_io_preview_fields ~tool_name ~input ?output () =
   @ string_preview_field "tool_output_preview" output_preview
 ;;
 
+let oas_invocation_fields = function
+  | None -> []
+  | Some invocation ->
+    [ "tool_use_id", `String (Agent_sdk.Tool.Invocation.tool_use_id invocation)
+    ; "turn", `Int (Agent_sdk.Tool.Invocation.turn invocation)
+    ; "planned_index", `Int (Agent_sdk.Tool.Invocation.planned_index invocation)
+    ]
+;;
+
 let broadcast_keeper_tool_call_event
       ~keeper_name
       ~tool_name

--- a/lib/keeper/keeper_tools_oas_handler_telemetry.mli
+++ b/lib/keeper/keeper_tools_oas_handler_telemetry.mli
@@ -23,6 +23,12 @@ val tool_io_preview_fields
   -> unit
   -> (string * Yojson.Safe.t) list
 
+(** Exact OAS model-tool occurrence fields. Blank or repeated [tool_use_id]
+    values are preserved because [turn] and [planned_index] provide the scope. *)
+val oas_invocation_fields
+  :  Agent_sdk.Tool.Invocation.t option
+  -> (string * Yojson.Safe.t) list
+
 (** Broadcast a keeper tool-call event via SSE, swallowing non-cancellation
     exceptions and logging a warning instead of crashing the turn. *)
 val broadcast_keeper_tool_call_event

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -382,6 +382,7 @@ let log_call
       ?prompt_fingerprint
       ?execution_id
       ?tool_use_id
+      ?planned_index
       ?trace_id
       ?session_id
       ?generation
@@ -468,8 +469,13 @@ let log_call
          carry, joining this store to oas:tool_called/oas:tool_completed. *)
       let tool_use_id_field =
         match tool_use_id with
-        | Some value when value <> "" -> [ "tool_use_id", `String value ]
-        | Some _ | None -> []
+        | Some value -> [ "tool_use_id", `String value ]
+        | None -> []
+      in
+      let planned_index_field =
+        match planned_index with
+        | Some value -> [ "planned_index", `Int value ]
+        | None -> []
       in
       let session_id_field =
         match session_id with
@@ -574,6 +580,7 @@ let log_call
            @ prompt_fingerprint_field
            @ execution_id_field
            @ tool_use_id_field
+           @ planned_index_field
            @ trace_id_field
            @ session_id_field
            @ generation_field

--- a/lib/keeper_tool_call_log.mli
+++ b/lib/keeper_tool_call_log.mli
@@ -145,6 +145,7 @@ val log_call :
   ?prompt_fingerprint:string ->
   ?execution_id:Ids.Execution_id.t ->
   ?tool_use_id:string ->
+  ?planned_index:int ->
   ?trace_id:string ->
   ?session_id:string ->
   ?generation:int ->
@@ -166,7 +167,9 @@ val log_call :
     dispatch boundary; the trajectory row for the same execution carries
     the identical value. [tool_use_id] is the provider call id for the
     same execution (when the dispatch lane has one) — the key that the
-    oas:tool_called/oas:tool_completed event rows also carry.
+    oas:tool_called/oas:tool_completed event rows also carry. Blank and
+    repeated provider ids remain meaningful when scoped by [turn] and
+    [planned_index], so they are persisted unchanged.
     Output is truncated to 4000 bytes. [model] is a compatibility input only;
     non-empty values are redacted to the neutral runtime lane. [runtime_profile]
     is persisted separately as the operator-facing runtime selector. Turn-policy fields ([lane], [tool_choice],

--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -222,6 +222,25 @@ let oas_tool_of_masc ?descriptor ~name ~description ~input_schema
   in
   Agent_sdk.Tool.create ?descriptor ~name ~description ~parameters oas_handler
 
+let oas_tool_of_masc_with_execution_env
+    ?descriptor
+    ~name
+    ~description
+    ~input_schema
+    handler
+  : Agent_sdk.Tool.t
+  =
+  let parameters = params_of_json_schema input_schema in
+  let oas_handler execution_env json_args =
+    to_oas_typed_result (handler execution_env json_args)
+  in
+  Agent_sdk.Tool.create_with_execution_env
+    ?descriptor
+    ~name
+    ~description
+    ~parameters
+    oas_handler
+
 let () =
   Runtime_agent.set_oas_tool_of_masc_hook (fun ~name ~description ~input_schema handler ->
     oas_tool_of_masc ~name ~description ~input_schema handler)

--- a/lib/tool_bridge.mli
+++ b/lib/tool_bridge.mli
@@ -69,3 +69,14 @@ val oas_tool_of_masc :
     never infers mutation, permission, or concurrency semantics from a tool
     name or catalog read-only flag. Without a descriptor OAS uses its ordinary
     sequential default. *)
+
+val oas_tool_of_masc_with_execution_env :
+  ?descriptor:Agent_sdk.Tool.descriptor ->
+  name:string ->
+  description:string ->
+  input_schema:Yojson.Safe.t ->
+  (Agent_sdk.Tool.Execution_env.t -> Yojson.Safe.t -> Tool_result.result) ->
+  Agent_sdk.Tool.t
+(** Create an OAS [Tool.t] whose handler also receives the exact OAS execution
+    environment. This is for correlation and observability; callers must not
+    treat invocation metadata as authorization. *)

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -100,6 +100,35 @@ let test_read_recent_keeper_filter () =
     Alcotest.(check int) "bob gets 1 entry" 1 (List.length bob_entries);
     Alcotest.(check int) "all gets 2 entries" 2 (List.length all_entries))
 
+let test_exact_oas_occurrence_persisted () =
+  with_tmp_log (fun () ->
+    Keeper_tool_call_log.log_call
+      ~keeper_name:"k"
+      ~tool_name:"tool_a"
+      ~input:(`Assoc [])
+      ~output_text:"ok"
+      ~success:true
+      ~duration_ms:1.0
+      ~tool_use_id:""
+      ~turn:9
+      ~planned_index:4
+      ();
+    match Keeper_tool_call_log.read_recent ~n:1 () with
+    | [ entry ] ->
+      Alcotest.(check (option string))
+        "blank provider id persisted"
+        (Some "")
+        (Safe_ops.json_string_opt "tool_use_id" entry);
+      Alcotest.(check int)
+        "turn persisted"
+        9
+        (Safe_ops.json_int ~default:(-1) "turn" entry);
+      Alcotest.(check int)
+        "planned index persisted"
+        4
+        (Safe_ops.json_int ~default:(-1) "planned_index" entry)
+    | _ -> Alcotest.fail "expected exactly one entry")
+
 (* ── Redaction: tool names do not suppress evidence ────────────── *)
 
 let test_sensitive_named_tool_logged_with_redaction () =
@@ -1188,6 +1217,7 @@ let () =
         [ eio_test "n=0 returns []" test_read_recent_n_zero
         ; eio_test "n<0 returns []" test_read_recent_n_negative
         ; eio_test "keeper filter" test_read_recent_keeper_filter
+        ; eio_test "exact OAS occurrence" test_exact_oas_occurrence_persisted
         ] )
     ; ( "redaction",
         [ eio_test "sensitive-named tool logged with redaction"

--- a/test/test_keeper_tool_call_sse_io_preview.ml
+++ b/test/test_keeper_tool_call_sse_io_preview.ml
@@ -104,6 +104,29 @@ let test_tool_call_event_uses_canonical_disposition () =
     (bool_member "success" event)
 ;;
 
+let test_oas_invocation_fields_preserve_exact_occurrence () =
+  let invocation =
+    Agent_sdk.Tool.Invocation.create
+      ~tool_use_id:""
+      ~turn:11
+      ~planned_index:3
+  in
+  let json =
+    `Assoc
+      (Keeper_tools_oas_handler_telemetry.oas_invocation_fields
+         (Some invocation))
+  in
+  Alcotest.(check (option string))
+    "blank provider id preserved"
+    (Some "")
+    (string_member "tool_use_id" json);
+  Alcotest.(check int) "turn preserved" 11 Yojson.Safe.Util.(member "turn" json |> to_int);
+  Alcotest.(check int)
+    "planned index preserved"
+    3
+    Yojson.Safe.Util.(member "planned_index" json |> to_int)
+;;
+
 let () =
   Alcotest.run
     "keeper_tool_call_sse_io_preview"
@@ -120,6 +143,10 @@ let () =
             "preserves canonical disposition"
             `Quick
             test_tool_call_event_uses_canonical_disposition
+        ; Alcotest.test_case
+            "preserves exact OAS occurrence"
+            `Quick
+            test_oas_invocation_fields_preserve_exact_occurrence
         ] )
     ]
 ;;

--- a/test/test_tool_bridge_externalize.ml
+++ b/test/test_tool_bridge_externalize.ml
@@ -200,6 +200,40 @@ let test_round_trip_through_oas () =
            Alcotest.fail "did not expect Stored when externalize=0")
   | Error _ -> Alcotest.fail "expected Ok"
 
+let test_execution_env_preserves_exact_invocation () =
+  Unix.putenv "MASC_TOOL_EXTERNALIZE" "0";
+  let seen_invocation = ref None in
+  let tool =
+    B.oas_tool_of_masc_with_execution_env
+      ~name:"occurrence_probe"
+      ~description:"capture exact OAS invocation"
+      ~input_schema:(`Assoc [ "type", `String "object" ])
+      (fun execution_env _input ->
+         seen_invocation := Agent_sdk.Tool.Execution_env.invocation execution_env;
+         tool_ok ~tool_name:"occurrence_probe" "ok")
+  in
+  let invocation =
+    Agent_sdk.Tool.Invocation.create
+      ~tool_use_id:""
+      ~turn:7
+      ~planned_index:2
+  in
+  (match Agent_sdk.Tool.execute ~invocation tool (`Assoc []) with
+   | Ok _ -> ()
+   | Error _ -> Alcotest.fail "expected successful bridge execution");
+  match !seen_invocation with
+  | None -> Alcotest.fail "execution environment dropped invocation"
+  | Some seen ->
+    Alcotest.(check string)
+      "blank provider id preserved"
+      ""
+      (Agent_sdk.Tool.Invocation.tool_use_id seen);
+    Alcotest.(check int) "turn preserved" 7 (Agent_sdk.Tool.Invocation.turn seen);
+    Alcotest.(check int)
+      "planned index preserved"
+      2
+      (Agent_sdk.Tool.Invocation.planned_index seen)
+
 (* --- Marker encoding round-trip via the bridge --- *)
 
 let test_externalize_with_temp_base_path () =
@@ -274,6 +308,8 @@ let () =
             test_to_oas_typed_result_preserves_transient_failure_class;
           Alcotest.test_case "round-trip through OAS" `Quick
             test_round_trip_through_oas;
+          Alcotest.test_case "execution env preserves exact invocation" `Quick
+            test_execution_env_preserves_exact_invocation;
         ] );
       ( "externalize",
         [


### PR DESCRIPTION
## What changed

- project Keeper model tools through `Agent_sdk.Tool.create_with_execution_env`
- preserve the exact OAS occurrence tuple (`tool_use_id`, `turn`, `planned_index`) in Keeper SSE events and decision logs
- persist the same tuple in `.masc/tool_calls`, including blank or repeated provider ids
- decode and show the occurrence in the Dashboard tool-call inspector

## Why

OAS 0.215 supplies exact per-occurrence metadata, but MASC still used the simple JSON handler. The durable tool-call log discarded `planned_index` and blank `tool_use_id` values, and the Dashboard decoder then dropped those values again. Operators therefore could not distinguish repeated or blank-id calls in the same model turn.

## Impact

Keeper tool executions can now be correlated by the exact OAS occurrence all the way from dispatch to live telemetry, durable JSONL, and the operator UI. The fields are observability-only and do not participate in authorization, routing, or policy decisions.

This is separate from #24957, which carries external MCP JSON-RPC request identity.

## Validation

- `scripts/dune-local.sh build test/test_tool_bridge_externalize.exe test/test_keeper_tool_call_sse_io_preview.exe test/test_keeper_tool_call_log.exe`
- 49 focused OCaml tests passed
- Dashboard `pnpm typecheck` passed
- 76 focused Dashboard tests passed
- `ocamlformat --check` passed for all changed OCaml files
- `git diff --check` passed

Full Dashboard lint remains blocked by the pre-existing unrelated `dashboard/src/keeper-actions.ts:1008` `no-nested-ternary` violation; no changed-file lint error was reported.
