### PR TITLE
perf(keeper): memoize attention ledger reads on stat identity

### DIFF
--- a/lib/keeper/keeper_board_attention_candidate.ml
+++ b/lib/keeper/keeper_board_attention_candidate.ml
@@ -614,9 +614,68 @@ let read_locked path parse =
   | Ok result -> result
 ;;
 
+(* Read-side stat memo. Keeper cycles call [resume_pending] (and thus
+   [load_candidates]) far more often than the ledger changes, and every call
+   re-read and re-parsed the whole file — with multi-MB ledgers this was a
+   dominant CPU source (issue #25003: concurrent whole-file Yojson parses in
+   systhreads starving the domain's main event loop). Every producer replaces
+   the ledger through an atomic temp+rename ([update_ledger] via
+   [Fs_compat.rewrite_private_file_durable_locked_result]), so any content
+   change allocates a new inode; (dev, ino, mtime, size) equality therefore
+   implies unchanged content. One entry per keeper ledger path, so the table
+   stays as small as the fleet. *)
+type ledger_stat_key =
+  { stat_dev : int
+  ; stat_ino : int
+  ; stat_mtime : float
+  ; stat_size : int
+  }
+
+let ledger_stat_key_opt path =
+  match Unix.stat path with
+  | stats ->
+    Some
+      { stat_dev = stats.st_dev
+      ; stat_ino = stats.st_ino
+      ; stat_mtime = stats.st_mtime
+      ; stat_size = stats.st_size
+      }
+  | exception Unix.Unix_error _ -> None
+;;
+
+let candidate_read_memo : (string, ledger_stat_key * candidate list) Hashtbl.t =
+  Hashtbl.create 16
+;;
+
+(* Stdlib mutex on purpose: touched from systhread read paths and module-level
+   state; the critical sections are Hashtbl lookups with no yield. *)
+let candidate_read_memo_mutex = Stdlib.Mutex.create ()
+
 let load_candidates ~base_path ~keeper_name =
   let path = candidate_path ~base_path ~keeper_name in
-  read_locked path load_candidates_from_content
+  let before = ledger_stat_key_opt path in
+  let cached =
+    match before with
+    | None -> None
+    | Some key ->
+      Stdlib.Mutex.protect candidate_read_memo_mutex (fun () ->
+        match Hashtbl.find_opt candidate_read_memo path with
+        | Some (cached_key, candidates) when cached_key = key -> Some candidates
+        | Some _ | None -> None)
+  in
+  match cached with
+  | Some candidates -> Ok candidates
+  | None ->
+    let* candidates = read_locked path load_candidates_from_content in
+    (* Double-stat: memoize only when the file identity is unchanged across
+       the read; a concurrent rewrite lands as a new inode and skips the
+       store, so the next call re-reads. *)
+    (match before, ledger_stat_key_opt path with
+     | Some key_before, Some key_after when key_before = key_after ->
+       Stdlib.Mutex.protect candidate_read_memo_mutex (fun () ->
+         Hashtbl.replace candidate_read_memo path (key_before, candidates))
+     | Some _, (Some _ | None) | None, (Some _ | None) -> ());
+    Ok candidates
 ;;
 
 let append_row candidate = Yojson.Safe.to_string (candidate_to_json candidate) ^ "\n"

--- a/test/test_keeper_board_attention_candidate.ml
+++ b/test/test_keeper_board_attention_candidate.ml
@@ -408,6 +408,135 @@ let test_update_ledger_compacts_to_distinct () =
   | Error detail -> Alcotest.failf "load after compaction failed: %s" detail
 ;;
 
+(* --- read-side stat memo (#25003) -------------------------------------
+   The memo key is (dev, ino, mtime, size). Production writes always go
+   through atomic temp+rename (new inode), so the only way to observe a
+   cache HIT deterministically is to mutate the file while preserving all
+   four key fields: an in-place same-length byte flip plus [Unix.utimes]
+   restore. A stale (pre-flip) result then proves the parse was skipped;
+   bumping mtime afterwards proves invalidation. *)
+
+let loaded_ids ~base_path ~keeper_name =
+  match A.load_candidates ~base_path ~keeper_name with
+  | Ok candidates -> List.map (fun (c : A.candidate) -> c.candidate_id) candidates
+  | Error detail -> Alcotest.failf "candidate load failed: %s" detail
+;;
+
+(* µs-aligned so the utimes(float µs) -> stat(float ns) round trip is exact
+   and the memo key compares equal across the in-place mutation. *)
+let fixed_mtime = 1700000000.5
+let bumped_mtime = 1700000001.5
+
+let index_of_substring haystack needle =
+  let hay_len = String.length haystack
+  and needle_len = String.length needle in
+  let rec loop i =
+    if i + needle_len > hay_len
+    then None
+    else if String.equal (String.sub haystack i needle_len) needle
+    then Some i
+    else loop (i + 1)
+  in
+  loop 0
+;;
+
+let rec find_file_named ~name path =
+  if Sys.file_exists path
+  then
+    if Sys.is_directory path
+    then
+      Array.fold_left
+        (fun found entry ->
+           match found with
+           | Some _ -> found
+           | None -> find_file_named ~name (Filename.concat path entry))
+        None
+        (Sys.readdir path)
+    else if String.equal (Filename.basename path) name
+    then Some path
+    else None
+  else None
+;;
+
+let ledger_path_or_fail ~base_path ~keeper_name =
+  match find_file_named ~name:(keeper_name ^ ".jsonl") base_path with
+  | Some path -> path
+  | None -> Alcotest.failf "ledger file for %s not found under %s" keeper_name base_path
+;;
+
+let flip_candidate_id_in_place path =
+  let ic = open_in_bin path in
+  let len = in_channel_length ic in
+  let content = really_input_string ic len in
+  close_in ic;
+  let marker = {|"candidate_id":"|} in
+  let start =
+    match index_of_substring content marker with
+    | Some index -> index + String.length marker
+    | None -> Alcotest.fail "candidate_id marker not found in ledger"
+  in
+  let original = content.[start] in
+  let flipped = if Char.equal original 'f' then '0' else 'f' in
+  let mutated =
+    String.mapi (fun i c -> if i = start then flipped else c) content
+  in
+  Alcotest.(check int) "in-place mutation keeps length" len (String.length mutated);
+  let fd = Unix.openfile path [ Unix.O_WRONLY ] 0o600 in
+  Fun.protect
+    ~finally:(fun () -> Unix.close fd)
+    (fun () ->
+      let written = Unix.write_substring fd mutated 0 len in
+      Alcotest.(check int) "in-place write is complete" len written)
+;;
+
+let test_load_memo_skips_reparse_when_stat_key_unchanged () =
+  with_temp_base "attention-read-memo-hit" (fun base_path ->
+    let keeper_name = "sangsu" in
+    let recorded = record_or_fail ~base_path (candidate ()) in
+    let path = ledger_path_or_fail ~base_path ~keeper_name in
+    Unix.utimes path fixed_mtime fixed_mtime;
+    (match loaded_ids ~base_path ~keeper_name with
+     | [ id ] ->
+       Alcotest.(check string) "first load parses the ledger" recorded.candidate_id id
+     | ids -> Alcotest.failf "expected one candidate, got %d" (List.length ids));
+    flip_candidate_id_in_place path;
+    Unix.utimes path fixed_mtime fixed_mtime;
+    (match loaded_ids ~base_path ~keeper_name with
+     | [ id ] ->
+       Alcotest.(check string)
+         "unchanged stat key serves the memoized parse"
+         recorded.candidate_id
+         id
+     | ids -> Alcotest.failf "expected one candidate, got %d" (List.length ids));
+    Unix.utimes path bumped_mtime bumped_mtime;
+    (* Invalidation proof: a re-read parses the mutated bytes, and the flipped
+       candidate_id no longer matches the content-identity digest, so the
+       loader must surface the integrity error. A stale cache hit would keep
+       returning [Ok] with the original id instead. *)
+    match A.load_candidates ~base_path ~keeper_name with
+    | Ok _ -> Alcotest.fail "mtime bump did not invalidate the memo (stale Ok served)"
+    | Error detail ->
+      (match index_of_substring detail "does not match" with
+       | Some _ -> ()
+       | None -> Alcotest.failf "unexpected load error after invalidation: %s" detail))
+;;
+
+let test_load_memo_invalidated_by_atomic_rewrite () =
+  with_temp_base "attention-read-memo-rewrite" (fun base_path ->
+    let keeper_name = "sangsu" in
+    let first = record_or_fail ~base_path (candidate ()) in
+    (match loaded_ids ~base_path ~keeper_name with
+     | [ id ] -> Alcotest.(check string) "first load" first.candidate_id id
+     | ids -> Alcotest.failf "expected one candidate, got %d" (List.length ids));
+    let second =
+      record_or_fail ~base_path (candidate ~signal:(signal ~post_id:"post-2" ()) ())
+    in
+    let ids = loaded_ids ~base_path ~keeper_name in
+    Alcotest.(check int) "rename-rewrite is observed" 2 (List.length ids);
+    if not (List.exists (String.equal second.candidate_id) ids)
+    then Alcotest.fail "second candidate missing after atomic rewrite")
+;;
+
 let () =
   Alcotest.run
     "keeper_board_attention_candidate"
@@ -448,6 +577,16 @@ let () =
             "update ledger compacts to distinct candidate count"
             `Quick
             test_update_ledger_compacts_to_distinct
+        ] )
+    ; ( "read memo"
+      , [ Alcotest.test_case
+            "unchanged stat key skips reparse"
+            `Quick
+            test_load_memo_skips_reparse_when_stat_key_unchanged
+        ; Alcotest.test_case
+            "atomic rewrite invalidates memo"
+            `Quick
+            test_load_memo_invalidated_by_atomic_rewrite
         ] )
     ]
 ;;


### PR DESCRIPTION
## 문제 (#25003 발견 2의 read 측)

keeper 사이클의 `resume_pending` → `load_candidates`가 **매 호출 원장 전체를 read+parse**. 완전체 바이너리(#25008+#25012 포함) 재기동 후에도 부팅 ~3분 뒤 `/health` 8s+ 파동이 재발했고, 봉쇄 상태 `sample`에서 **88개 systhread가 동시에 Yojson lex** 중(masterlock 점유 → main 루프 기아)이었음.

결정적 근거: 오프라인 dedup을 돌려도 54.7→38.7MB에 그침(대부분 이미 #25008이 압축한 상태, albini 429→429행 중복 0) — **크기가 아니라 사이클마다의 전량 재파싱이 잔존 근본**.

## 수리

`load_candidates`에 경로당 1개의 `(dev, ino, mtime, size)` 키 memo:
- 모든 프로듀서가 atomic temp+rename으로만 교체(`update_ledger` → `rewrite_private_file_durable_locked_result`) → 내용 변경 = 새 inode = 키 미스가 **불변식으로 보장**
- read를 감싼 double-stat: 읽는 중 파일 identity가 움직였으면 memoize 스킵(다음 호출이 재읽기)
- 캐시는 keeper 원장 경로당 1엔트리(fleet 크기) — Stdlib.Mutex(임계구역에 yield 없음, module-level state)

## 검증 (11/11 pass, 기존 9개 무회귀)

- **cache hit 증명(backdoor 없음)**: same-inode·same-length in-place 변조 + `utimes`로 stat 키 복원 → memoized 결과 반환 = 재파싱이 없었다는 행동적 증거
- **invalidation 증명**: mtime bump 후 로드가 content-identity digest 검증기의 Error("candidate_id does not match…")를 반환 — 변조 바이트를 실제로 재파싱해야만 나올 수 있는 결과 (모듈의 integrity 검증이 판별기 역할)
- **rename 무효화**: 두 번째 record(atomic rewrite) 후 2건 로드 확인
- ocamlformat clean
- 미검증: 프로덕션 효과는 머지+재배포 후 `sample`로 (성공 기준: Yojson 동시-lex 스레드 수 급감 + `/health` 파동 소멸)

## 관련

- #25003 (발견 2 read 측) / #25008 (write 측 compact — 본 PR의 rename 불변식 전제) / #24912 (systhread 구조 — 본 PR은 그 유입량 자체를 줄임)
- 오프라인 압축 실측 로그와 sample 분석은 #25003 코멘트 참조

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PgGNxsWM8yCaJiHnTzrVa