### PR TITLE
refactor(gate): hard-cut product routing from generic busy core

### DIFF
--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -42,24 +42,6 @@ type connector_delivery =
   ; external_message_id : string option
   }
 
-(* [route_busy_connector] decides where a connector message goes when the keeper
-   is already in flight. Pure and exhaustive over [connector_kind] so a new
-   connector forces a routing decision at compile time (no catch-all). [Discord]
-   projects onto the chat queue, whose serial consumer drains it after the slot
-   frees and delivers the reply through the connector's outbound adapter
-   ([Keeper_chat_discord.adapter_loop]); [Generic] has no such adapter and falls
-   back to the async poll store. *)
-let route_busy_connector (kind : connector_kind) ~channel_id ~user_id ~user_name
-    ~team_id ~thread_ts :
-    [ `Enqueue_chat_queue of Keeper_chat_queue.message_source | `Async_poll ] =
-  match kind with
-  | Discord -> `Enqueue_chat_queue (Keeper_chat_queue.Discord { channel_id; user_id })
-  | Slack ->
-    `Enqueue_chat_queue
-      (Keeper_chat_queue.Slack
-         { channel_id; user_id; user_name; team_id; thread_ts })
-  | Generic -> `Async_poll
-
 (* ── Keeper response parsing ─────────────────────────────────── *)
 
 let extract_turn_stats (body : string) : Gate_protocol.turn_stats option =
@@ -842,49 +824,13 @@ let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~submission_owne
                  "channel gate text snapshot callback failed (keeper=%s): %s"
                  keeper_name (Printexc.to_string exn))
   in
-  let slack_reply_thread_ts =
-    match slack_thread_ts metadata with
-    | Some thread_ts -> Some thread_ts
-    | None -> metadata_value_any [ "slack.message_ts"; "slack_message_ts" ] metadata
-  in
   let defer_to_existing_work
       (admission_rejection : Keeper_turn_admission.rejection) =
-    match
-      route_busy_connector connector_kind
-        ~channel_id:channel_workspace_id ~user_id:channel_user_id
-        ~user_name:channel_user_name ~team_id:(slack_team_id metadata)
-        ~thread_ts:slack_reply_thread_ts
-    with
-    | `Enqueue_chat_queue source ->
-      (* RFC-connector-deferred-reply-via-chat-queue: route accepted connector
-         input onto the durable queue whenever the authoritative if-free
-         admission reports Busy. This includes a receipt committed or leased
-         after any outer observation but before the turn slot was acquired. *)
-      (match
-         Keeper_chat_queue.enqueue ~keeper_name
-           { Keeper_chat_queue.content = String.trim content
-           ; user_blocks = []
-           ; attachments = []
-           ; timestamp = Eio.Time.now clock
-           ; source
-           ; user_row_origin = Keeper_chat_store.Already_persisted_upstream
-           }
-       with
-       | Ok receipt -> `Queued_to_chat_lane (admission_rejection, receipt)
-       | Error error ->
-         Log.Server.error
-           "channel gate durable chat enqueue failed (keeper=%s, lane=%s): %s"
-           keeper_name lane
-           (Keeper_chat_queue.mutation_error_to_string error);
-         `Chat_queue_error error)
-    | `Async_poll ->
-      `Async_ack
-        ( admission_rejection.in_flight
-        , Some
-            (Keeper_tool_surface.dispatch_keeper_msg
-               ~submitted_by
-               keeper_ctx
-               ~args) )
+    `Async_ack
+      ( admission_rejection.in_flight
+      , Some
+          (Keeper_tool_surface.dispatch_keeper_msg ~submitted_by keeper_ctx
+             ~args) )
   in
   let dispatch_result =
     (* The admission boundary, not a route-level peek, owns the FIFO decision.
@@ -951,43 +897,6 @@ let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~submission_owne
           }
       in
       Gate_protocol.Reply { content = reply; structured; stats; message_request }
-  | `Queued_to_chat_lane (admission_rejection, receipt) ->
-      (* RFC-connector-deferred-reply-via-chat-queue: the message was enqueued onto [Keeper_chat_queue]; the
-         connector gets a busy ACK now and the deferred reply later via the
-         serial consumer's outbound adapter. The existing [message_request]
-         envelope carries the durable receipt id and queue revision so the
-         connector can correlate that later delivery. *)
-      let duration_ms =
-        Mtime.Span.to_uint64_ns (Mtime.span (Mtime_clock.now ()) start_mtime)
-        |> Int64.div 1_000_000L
-        |> Int64.to_int
-      in
-      let message_request =
-        chat_queue_message_request ~channel ~channel_user_id ~keeper_name
-          ~admission_rejection ~metadata receipt
-      in
-      let reply =
-        redact_text
-          (busy_ack_reply_text_queued ~admission_rejection ~keeper_name
-             ~receipt_id:message_request.request_id
-             ~recovery_required_count:receipt.recovery_required_count)
-      in
-      let stats =
-        Some { Gate_protocol.model_used = "runtime"; duration_ms; tokens_used = 0 }
-      in
-      Gate_protocol.Reply
-        { content = reply
-        ; structured = None
-        ; stats
-        ; message_request = Some message_request
-        }
-  | `Chat_queue_error error ->
-      Gate_protocol.Keeper_error_result
-        (redact_text
-           (Printf.sprintf
-              "%s is busy; your message was not queued because the durable chat queue rejected it: %s"
-              keeper_name
-              (Keeper_chat_queue.mutation_error_to_string error)))
   | `Streaming (Some result) when not (Tool_result.is_failed result) ->
       let body = Tool_result.message result in
       let duration_ms =

--- a/lib/gate_keeper_backend.mli
+++ b/lib/gate_keeper_backend.mli
@@ -60,21 +60,6 @@ val accept_connector :
     queue receipt and transcript delivery key; retries converge without a
     derived hash namespace. *)
 
-val route_busy_connector :
-  connector_kind ->
-  channel_id:string ->
-  user_id:string ->
-  user_name:string ->
-  team_id:string option ->
-  thread_ts:string option ->
-  [ `Enqueue_chat_queue of Keeper_chat_queue.message_source | `Async_poll ]
-(** Pure routing decision for a connector message that arrives while the keeper
-    has an in-flight turn. Exhaustive over {!connector_kind}: [Discord] and
-    [Slack] return [`Enqueue_chat_queue] with the typed source so the serial
-    {!Keeper_chat_consumer} drains and delivers it after the slot frees;
-    [Generic] returns [`Async_poll]. Exposed for unit testing the decision in
-    isolation. *)
-
 val dispatch :
   connector_kind:connector_kind ->
   submission_owner:submission_owner ->

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -2779,63 +2779,9 @@ let test_extract_message_request_ack_falls_back_to_keeper_name () =
         ("expected Ok with fallback keeper_name: "
          ^ Gate_keeper_backend.ack_parse_failure_to_string failure)
 
-(* ── RFC-connector-deferred-reply-via-chat-queue connector deferred-reply routing ───────────────── *)
-
-let test_route_busy_discord_enqueues () =
-  match
-    Gate_keeper_backend.route_busy_connector Gate_keeper_backend.Discord
-      ~channel_id:"123456789" ~user_id:"u-42"
-      ~user_name:"discord-user" ~team_id:None ~thread_ts:None
-  with
-  | `Enqueue_chat_queue (Keeper_chat_queue.Discord { channel_id; user_id }) ->
-      check string "discord channel_id threaded" "123456789" channel_id;
-      check string "discord user_id threaded" "u-42" user_id
-  | `Enqueue_chat_queue _ ->
-      fail "Discord must map to a Discord message_source, not another variant"
-  | `Async_poll -> fail "Discord has an outbound adapter; must enqueue, not poll"
-
-
-let test_route_busy_slack_enqueues () =
-  match
-    Gate_keeper_backend.route_busy_connector Gate_keeper_backend.Slack
-      ~channel_id:"C0SLACK" ~user_id:"U-99"
-      ~user_name:"slack-user" ~team_id:(Some "T0SLACK")
-      ~thread_ts:(Some "171.001")
-  with
-  | `Enqueue_chat_queue
-      (Keeper_chat_queue.Slack
-         { channel_id; user_id; user_name; team_id; thread_ts }) ->
-      check string "slack channel threaded" "C0SLACK" channel_id;
-      check string "slack user_id threaded" "U-99" user_id;
-      check string "slack user name threaded" "slack-user" user_name;
-      check (option string) "slack team threaded" (Some "T0SLACK") team_id;
-      check (option string) "slack reply thread threaded" (Some "171.001") thread_ts
-  | `Enqueue_chat_queue _ ->
-      fail "Slack must map to a Slack message_source, not another variant"
-  | `Async_poll -> fail "Slack has an outbound adapter; must enqueue, not poll"
-
-let test_route_busy_generic_falls_back () =
-  match
-    Gate_keeper_backend.route_busy_connector Gate_keeper_backend.Generic
-      ~channel_id:"x" ~user_id:"y"
-      ~user_name:"generic-user" ~team_id:None ~thread_ts:None
-  with
-  | `Async_poll -> check bool "generic falls back to async poll" true true
-  | `Enqueue_chat_queue _ ->
-      fail "Generic has no in-process outbound adapter; must not enqueue (RFC-connector-deferred-reply-via-chat-queue §3.3a)"
-
 let () =
   Alcotest.run "Gate_keeper_backend"
     [
-      ( "route_busy_connector",
-        [
-          test_case "Discord enqueues with channel_id/user_id" `Quick
-            test_route_busy_discord_enqueues;
-          test_case "Slack enqueues with channel/user_id" `Quick
-            test_route_busy_slack_enqueues;
-          test_case "Generic falls back to async poll" `Quick
-            test_route_busy_generic_falls_back;
-        ] );
       ( "helpers",
         [
           test_case "agent name is stable" `Quick


### PR DESCRIPTION
## Why

Discord and Slack now inject exact typed delivery at their leaf boundary. Keeping a second product router inside generic Gate busy handling duplicates authority and can enqueue a differently-derived source.

Clean recut of #24633 on #25024.

## What

- delete `route_busy_connector` and its public test-only surface
- delete Discord/Slack chat-queue routing from generic `dispatch_core`
- retain only the connector-neutral async request path in generic busy handling
- leave product durable acceptance exclusively in `accept_connector`

## Boundary

- connector leaves own product identity and durable delivery
- generic Gate core has no Discord/Slack product variants
- no OAS changes

## Focused proof

- `ocamlformat --check`: passed
- `ocamlc -stop-after parsing`: passed
- `git diff --check`: passed

Stack: #25020 → #25021 → #25024
Head reviewed: `c08b273d48`