### PR TITLE
fix(fs): offload full durable append transaction

### DIFF
--- a/lib/core/eio_guard.ml
+++ b/lib/core/eio_guard.ml
@@ -17,13 +17,11 @@ let enable () = Atomic.set ready true
 let disable () = Atomic.set ready false
 let is_ready () = Atomic.get ready
 
-type execution_context = Eio_fiber | Non_eio
+type execution_context = Fs_compat.execution_context =
+  | Eio_fiber
+  | Non_eio
 
-let execution_context () =
-  match Eio.Fiber.is_cancelled () with
-  | true | false -> Eio_fiber
-  | exception Effect.Unhandled _ -> Non_eio
-;;
+let execution_context = Fs_compat.execution_context
 
 let is_eio_fiber () = execution_context () = Eio_fiber
 

--- a/lib/core/eio_guard.mli
+++ b/lib/core/eio_guard.mli
@@ -19,7 +19,9 @@ val is_ready : unit -> bool
 
 (** Actual execution context of the current caller. [ready] is process-wide;
     it does not imply that a raw Domain or systhread has an Eio handler. *)
-type execution_context = Eio_fiber | Non_eio
+type execution_context = Fs_compat.execution_context =
+  | Eio_fiber
+  | Non_eio
 
 val execution_context : unit -> execution_context
 val is_eio_fiber : unit -> bool

--- a/lib/fs_compat/dune
+++ b/lib/fs_compat/dune
@@ -30,7 +30,14 @@
  ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
  (flags
   (:standard -w +4))
- (libraries fs_compat_internal eio eio.unix unix yojson uuidm digestif))
+ (libraries
+  fs_compat_internal
+  eio
+  eio.unix
+  unix
+  yojson
+  uuidm
+  digestif))
 
 (library
  (name fs_compat_test_support)

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -35,6 +35,16 @@ let get_fs_opt () = Atomic.get global_fs
 (** Check if Eio fs is available *)
 let has_fs () = Option.is_some (Atomic.get global_fs)
 
+type execution_context =
+  | Eio_fiber
+  | Non_eio
+
+let execution_context () =
+  match Eio.Fiber.is_cancelled () with
+  | true | false -> Eio_fiber
+  | exception Effect.Unhandled _ -> Non_eio
+;;
+
 (** Normalize [Eio.Io] to [Sys_error] so callers only need one catch.
     Eio operations raise [Eio.Io _] on permission errors, missing files, etc.
     Stdlib I/O already raises [Sys_error], so wrapping only the Eio branch
@@ -1718,11 +1728,10 @@ module Capability_append_for_testing = struct
   let append_fd_observed = append_fd_observed
 end
 
-let run_blocking_private_file_transaction ~label ~path f =
-  with_fs_or_fallback
-    ~path
-    ~fallback:f
-    (fun _fs -> Eio_unix.run_in_systhread ~label f)
+let run_blocking_private_file_transaction ~label ~path:_ f =
+  match execution_context () with
+  | Non_eio -> f ()
+  | Eio_fiber -> Eio_unix.run_in_systhread ~label f
 ;;
 
 module Private_jsonl_slice = struct
@@ -1925,63 +1934,69 @@ let append_private_jsonl_durable_locked_with_expected_end_offset_result
     match expected_end_offset with
     | Some offset when offset < 0 -> Error (Negative_expected_end_offset offset)
     | _ ->
-      test_exec_home_guard ~op:"append_private_jsonl_durable_locked" path;
-      let dir = Filename.dirname path in
-      mkdir_p_memoized dir;
-      let path_mu = get_append_path_mutex path in
       run_blocking_private_file_transaction
         ~label:"fs-compat-durable-append"
         ~path
         (fun () ->
-      Stdlib.Mutex.protect path_mu (fun () ->
-        let fd =
-          Unix.openfile path
-            [ Unix.O_RDWR; Unix.O_CREAT; Unix.O_APPEND; Unix.O_CLOEXEC ]
-            0o600
-        in
-        Fun.protect
-          ~finally:(fun () -> Unix.close fd)
-          (fun () ->
-             Unix.fchmod fd 0o600;
-             fsync_parent_directory dir;
-             (* See Unix.lseek: only the file-position side effect is required. *)
-             ignore (Unix.lseek fd 0 Unix.SEEK_SET : int);
-             lock_whole_file fd;
-             let original_length = Unix.lseek fd 0 Unix.SEEK_END in
-             match expected_end_offset with
-             | Some expected when expected <> original_length ->
-               Error
-                 (End_offset_mismatch
-                    { expected; actual = original_length })
-             | _ ->
-               let tail_is_complete =
-                 if original_length = 0
-                 then true
-                 else (
-                   (* See Unix.lseek: only the file-position side effect is required. *)
-                   ignore (Unix.lseek fd (original_length - 1) Unix.SEEK_SET : int);
-                   let byte = Bytes.create 1 in
-                   let rec read_tail () =
-                     match Unix.read fd byte 0 1 with
-                     | 1 -> Char.equal (Bytes.get byte 0) '\n'
-                     | 0 -> false
-                     | _ -> false
-                     | exception Unix.Unix_error (Unix.EINTR, _, _) -> read_tail ()
-                   in
-                   read_tail ())
-               in
-               if not tail_is_complete
-               then Error Incomplete_jsonl_tail
-               else (
-                 (* See Unix.lseek: only the file-position side effect is required. *)
-                 ignore (Unix.lseek fd 0 Unix.SEEK_END : int);
-                 append_fd_durable
-                   ~io:durable_append_unix_io
-                   ~fd
-                   ~original_length
-                   suffix
-                 |> Result.map_error (fun error -> Durable_jsonl_append_failed error)
-                 |> Result.map (fun () -> original_length + String.length suffix)))))
+           test_exec_home_guard ~op:"append_private_jsonl_durable_locked" path;
+           let dir = Filename.dirname path in
+           Mkdir_memo.mkdir_p_memoized
+             ~mkdir_p:(fun dir ->
+               test_exec_home_guard ~op:"mkdir_p" dir;
+               mkdir_p_unix dir)
+             dir;
+           let path_mu = get_append_path_mutex path in
+           Stdlib.Mutex.protect path_mu (fun () ->
+             let fd =
+               Unix.openfile path
+                 [ Unix.O_RDWR; Unix.O_CREAT; Unix.O_APPEND; Unix.O_CLOEXEC ]
+                 0o600
+             in
+             Fun.protect
+               ~finally:(fun () -> Unix.close fd)
+               (fun () ->
+                  Unix.fchmod fd 0o600;
+                  fsync_parent_directory dir;
+                  (* See Unix.lseek: only the file-position side effect is required. *)
+                  ignore (Unix.lseek fd 0 Unix.SEEK_SET : int);
+                  lock_whole_file fd;
+                  let original_length = Unix.lseek fd 0 Unix.SEEK_END in
+                  match expected_end_offset with
+                  | Some expected when expected <> original_length ->
+                    Error
+                      (End_offset_mismatch
+                         { expected; actual = original_length })
+                  | _ ->
+                    let tail_is_complete =
+                      if original_length = 0
+                      then true
+                      else (
+                        (* See Unix.lseek: only the file-position side effect is required. *)
+                        ignore (Unix.lseek fd (original_length - 1) Unix.SEEK_SET : int);
+                        let byte = Bytes.create 1 in
+                        let rec read_tail () =
+                          match Unix.read fd byte 0 1 with
+                          | 1 -> Char.equal (Bytes.get byte 0) '\n'
+                          | 0 -> false
+                          | _ -> false
+                          | exception Unix.Unix_error (Unix.EINTR, _, _) -> read_tail ()
+                        in
+                        read_tail ())
+                    in
+                    if not tail_is_complete
+                    then Error Incomplete_jsonl_tail
+                    else (
+                      (* See Unix.lseek: only the file-position side effect is required. *)
+                      ignore (Unix.lseek fd 0 Unix.SEEK_END : int);
+                      append_fd_durable
+                        ~io:durable_append_unix_io
+                        ~fd
+                        ~original_length
+                        suffix
+                      |> Result.map_error (fun error ->
+                        Durable_jsonl_append_failed error)
+                      |> Result.map (fun () ->
+                        original_length + String.length suffix)))))
 ;;
 
 let append_private_jsonl_durable_locked_with_end_offset_result path suffix =

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -26,6 +26,14 @@ val get_fs_opt : unit -> Eio.Fs.dir_ty Eio.Path.t option
 (** Check if Eio fs is available. *)
 val has_fs : unit -> bool
 
+type execution_context =
+  | Eio_fiber
+  | Non_eio
+
+val execution_context : unit -> execution_context
+(** Actual execution context of the current caller. Process-global filesystem
+    installation does not imply that a raw Domain has an Eio effect handler. *)
+
 type exact_path_kind =
   | Exact_missing
   | Exact_kind of Unix.file_kind
@@ -816,9 +824,11 @@ type private_jsonl_append_error =
     {!update_private_file_durable_locked_result}, verifies only that an existing
     file ends at a newline boundary, then appends and fsyncs with rollback on
     failure. Every transaction also fsyncs the parent directory. Runtime cost
-    is proportional to [suffix], not to historical file size. When the Eio
-    filesystem is active, the entire blocking lock/write/fsync transaction runs
-    in a system thread so one contended file cannot stop unrelated fibers. *)
+    is proportional to [suffix], not to historical file size. From an Eio
+    fiber, the entire blocking lock/write/fsync transaction runs in a system
+    thread, including directory creation and in-process mutex acquisition, so
+    one contended file cannot stop unrelated fibers. Non-Eio callers execute
+    the same transaction directly. *)
 val append_private_jsonl_durable_locked_with_end_offset_result :
   string -> string -> (int, private_jsonl_append_error) result
 

--- a/lib/fs_compat/mkdir_memo.mli
+++ b/lib/fs_compat/mkdir_memo.mli
@@ -12,9 +12,10 @@
     fallback. Cycle-free placement inside [fs_compat]'s wrapped
     library. *)
 
-(** [mkdir_p_memoized ~mkdir_p path] calls [mkdir_p path] only on
-    the first request for [path] in this process. Subsequent calls
-    skip the stat/mkdir entirely. *)
+(** [mkdir_p_memoized ~mkdir_p path] skips [mkdir_p path] after the
+    first successful completion for [path] in this process. Concurrent
+    cache misses may call [mkdir_p path] more than once, so the callback
+    must accept an already-created directory. *)
 val mkdir_p_memoized : mkdir_p:(string -> unit) -> string -> unit
 
 (** Reset the cache. Test-only — production code relies on

--- a/test/stanzas/test_fs_compat_durable_append.inc
+++ b/test/stanzas/test_fs_compat_durable_append.inc
@@ -1,4 +1,4 @@
 (test
  (name test_fs_compat_durable_append)
  (modules test_fs_compat_durable_append)
- (libraries fs_compat alcotest unix))
+ (libraries fs_compat alcotest eio eio_main unix))

--- a/test/test_fs_compat_durable_append.ml
+++ b/test/test_fs_compat_durable_append.ml
@@ -365,6 +365,32 @@ let test_private_jsonl_append_rejects_incomplete_suffix () =
   | Ok () -> fail "append accepted a non-terminated JSONL suffix"
 ;;
 
+let test_private_jsonl_append_respects_execution_context () =
+  with_temp_jsonl "" @@ fun path ->
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Fun.protect
+    ~finally:Fs_compat.clear_fs
+    (fun () ->
+       (match
+          Fs_compat.append_private_jsonl_durable_locked_result path "{\"fiber\":1}\n"
+        with
+        | Ok () -> ()
+        | Error error -> fail (Fs_compat.private_jsonl_append_error_to_string error));
+       let raw_domain_result =
+         Domain.spawn (fun () ->
+           Fs_compat.append_private_jsonl_durable_locked_result path "{\"domain\":2}\n")
+         |> Domain.join
+       in
+       (match raw_domain_result with
+        | Ok () -> ()
+        | Error error -> fail (Fs_compat.private_jsonl_append_error_to_string error));
+       check string
+         "Eio fiber and raw Domain append once"
+         "{\"fiber\":1}\n{\"domain\":2}\n"
+         (Fs_compat.load_file path))
+;;
+
 let () =
   run
     "fs_compat durable append"
@@ -430,6 +456,10 @@ let () =
             "private JSONL append rejects incomplete suffix"
             `Quick
             test_private_jsonl_append_rejects_incomplete_suffix
+        ; test_case
+            "private JSONL append respects execution context"
+            `Quick
+            test_private_jsonl_append_respects_execution_context
         ] )
     ]
 ;;


### PR DESCRIPTION
## Outcome

Moves the complete private durable-file transaction off the Eio scheduler domain: test guard, directory resolution/creation, memo registry, per-path mutex acquisition, open/lock/read/write/fsync, and rollback now execute in one system-thread callback.

## Boundary

- `Fs_compat.execution_context` is the actual-caller SSOT reused by `Eio_guard`; process-global filesystem state is not used as a scheduling proxy.
- Eio fibers run the blocking callback in a system thread. Raw Domains and other non-Eio callers run it directly.
- Only the context probe handles `Effect.Unhandled`; callback failures are never caught and replayed inline.
- The callback contains only Stdlib/Unix operations and performs no Eio effect.
- No timeout, capacity, retry loop, inline-on-saturation fallback, actor, or product/tool/provider knowledge is added.
- The `Mkdir_memo` contract now states the real concurrent-miss behavior.

This PR does not claim the later per-Keeper projection actor hard cut.

## Stack

- Parent: #24971 exact JSONL cursor CAS.
- Diff against parent: 8 files, 136 additions / 73 deletions (209 changed lines).

## Verification

- `scripts/dune-local.sh build test/test_fs_compat_durable_append.exe test/test_executor_pool_eio_mutex.exe`
- durable append: 17/17 passed, including Eio-fiber plus ready raw-Domain regression
- Eio context/mutex boundary: 4/4 passed
- `ocamlformat --check`, parser checks, and `git diff --check`

Full build remains PR CI authority.