### PR TITLE
refactor(gate): hard-delete product dispatch variants

### DIFF
--- a/docs/rfc/RFC-0317-slack-builtin-gateway.md
+++ b/docs/rfc/RFC-0317-slack-builtin-gateway.md
@@ -20,16 +20,16 @@ One tool out, push in. The mirror of [[RFC-0203]] for Slack.
 > connector registration + `Keeper_chat_queue.Slack` deferred delivery. PR-3
 > (this batch) wires `Server_slack_in_process_gateway` + bootstrap + env
 > (`SLACK_APP_TOKEN`, `MASC_SLACK_TRIGGER_POLICY`) + `slack_observability`,
-> and adds the `connector_kind:Slack` arm together with that gateway (per the
-> "add it together with the gateway, not before" note in `gate_keeper_backend`).
+> and supplies a Slack-owned immutable delivery projection to the generic
+> Keeper acceptance boundary.
 > PR-4 (pending) deletes the sidecar. Ambient recording + idle-keeper wake on
 > non-triggering messages and reaction-as-trigger are follow-up scope, not PR-3.
 
 ## Why
 
-- `sidecars/slack-bot/` is a Python slack-bolt process with its own
-  lifecycle, its own HTTP push path (`/api/v1/gate/message` with
-  `connector_kind = Generic`), and its own failure modes. The server
+- `sidecars/slack-bot/` was a Python slack-bolt process with its own
+  lifecycle, its own HTTP push path (`/api/v1/gate/message`), and its own
+  failure modes. The server
   already in-processes Discord (`lib/gate/discord_*`); Slack is the last
   connector that lives in a separate process. Removing it collapses two
   failure surfaces into one.
@@ -172,13 +172,11 @@ failure (DNS/TLS/handshake) is fed as `Wss_closed` — there is no separate
    it yet.
 2. **PR-2 (landed)**: `slack_rest_client` + `keeper_chat_slack` +
    `channel_gate_slack_state` rewrite (in-process) + connector registration +
-   `Keeper_chat_queue.Slack` deferred-delivery source. (`connector_kind` Slack
-   moved to PR-3: `gate_keeper_backend` withholds the arm until the gateway that
-   emits `dispatch ~connector_kind:Slack` exists, to avoid a dead branch.)
+   `Keeper_chat_queue.Slack` deferred-delivery source.
 3. **PR-3 (this batch)**: `server_slack_in_process_gateway` + bootstrap + env
    (`SLACK_APP_TOKEN`, `MASC_SLACK_TRIGGER_POLICY`) + `slack_observability`
-   + `slack_rest_client.auth_test` (bot identity) + the `connector_kind:Slack`
-   arm (with `route_busy_connector` + the surface/conversation-id arms). Bridges
+   + `slack_rest_client.auth_test` (bot identity) + the leaf-owned typed
+   delivery projection. Bridges
    triggered `Message_create`/`App_mention` to
    `Channel_gate.handle_inbound_streaming` with a threaded streaming reply.
    Ambient recording, idle-keeper wake, and reaction-as-trigger are deferred.

--- a/docs/rfc/RFC-0317-slack-builtin-gateway.md
+++ b/docs/rfc/RFC-0317-slack-builtin-gateway.md
@@ -47,9 +47,11 @@ Slack WSS ↔ slack_socket_client (OCaml, Eio fiber, reuses discord_wss_connecti
                 ↓ parse envelope, ack, emit
           Slack_gateway_state (pure FSM: hello/connected/reconnect)
                 ↓ Emit_event (message/app_mention)
-          Channel_gate.handle_inbound_streaming (existing)
+          Channel_gate.handle_inbound (existing)
                 ↓
-          keeper workspace (existing)
+          Gate_keeper_backend.accept_connector
+                ↓ durable receipt
+          Keeper_chat_queue (existing)
 
 keeper → Channel_gate_slack_state.send_message → Masc_http_client.post_sync chat.postMessage
 ```
@@ -178,7 +180,9 @@ failure (DNS/TLS/handshake) is fed as `Wss_closed` — there is no separate
    + `slack_rest_client.auth_test` (bot identity) + the leaf-owned typed
    delivery projection. Bridges
    triggered `Message_create`/`App_mention` to
-   `Channel_gate.handle_inbound_streaming` with a threaded streaming reply.
+   `Channel_gate.handle_inbound`, which durably accepts the exact leaf delivery
+   before returning the threaded queue acknowledgement. Final replies are owned
+   by the serial Keeper chat consumer and Slack outbound adapter.
    Ambient recording, idle-keeper wake, and reaction-as-trigger are deferred.
 4. **PR-4 (pending)**: delete `sidecars/slack-bot/` + remove Slack branch from
    `server_routes_http_routes_sidecar` + drop `channel_gate_sidecar_state`

--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -1,40 +1,6 @@
 (** Gate_keeper_backend -- adapter between the Channel Gate and the keeper subsystem.
     See [gate_keeper_backend.mli] for the full contract. *)
 
-(* ── Connector deferred-reply routing (RFC-connector-deferred-reply-via-chat-queue) ─────────────── *)
-
-(* [connector_kind] is the typed identity of the connector a [dispatch] serves.
-   It is a property of the connector, not of each message, so it is baked in at
-   dispatch-construction time (the Discord gateway passes [~connector_kind:Discord]
-   when it builds its dispatch). The per-message channel_id / user_id arrive as the
-   ordinary [channel_workspace_id] / [channel_user_id] dispatch fields.
-
-   This lives in [masc] (not the [masc_gate] [dispatch_fn] type) on purpose:
-   [message_source] is a [masc] type, and putting it on a [masc_gate] signature
-   would be a [masc_gate -> masc] dependency cycle. Threading the typed kind as an
-   injected dispatch argument keeps [masc_gate] connector-neutral (RFC-0226) while
-   letting the busy branch route without string-matching the [channel] lane. *)
-type connector_kind =
-  | Discord
-  | Slack
-      (** RFC-0317: the in-process Slack Socket Mode gateway
-          ([Server_slack_in_process_gateway]) builds its dispatch with
-          [~connector_kind:Slack]. Like [Discord] it has an outbound adapter
-          ([Keeper_chat_slack.adapter_loop], drained by the serial chat
-          consumer), so a message arriving mid-turn projects onto the chat queue
-          for deferred delivery rather than the outbound-less async poll store.
-          Added together with that gateway, not before. *)
-  | Generic
-      (** Every connector that is not a wired in-process inbound gateway with its
-          own outbound adapter. Today this is the HTTP gate-route lane
-          (imessage-bot, cli-connector) which POSTs and awaits synchronously, so
-          a busy message keeps the async [masc_keeper_msg] poll path; see
-          RFC-connector-deferred-reply-via-chat-queue §3.3 option (a). *)
-
-type submission_owner =
-  | Authenticated_caller of string
-  | Channel_actor
-
 type connector_delivery =
   { source : Keeper_chat_queue.message_source
   ; surface : Surface_ref.t
@@ -347,9 +313,6 @@ let metadata_value key metadata =
       if value = "" then None else Some value
   | None -> None
 
-let metadata_value_any keys metadata =
-  List.find_map (fun key -> metadata_value key metadata) keys
-
 let assoc_string_if_present key value =
   match non_empty_opt value with
   | None -> []
@@ -366,97 +329,31 @@ let gate_address ~channel ~channel_workspace_id ?conversation_id
   @ opt_assoc_string_if_present "conversation_id" conversation_id
   @ opt_assoc_string_if_present "external_message_id" external_message_id
 
-let discord_channel_id ~channel_workspace_id ~metadata =
-  match metadata_value_any [ "discord.channel_id"; "discord_channel_id" ] metadata with
-  | Some channel_id -> channel_id
-  | None -> String.trim channel_workspace_id
+let surface_for_channel_context ~channel ~channel_workspace_id ?conversation_id
+    ?external_message_id () =
+  let label =
+    match non_empty_opt channel with
+    | Some lane -> lane
+    | None -> "gate"
+  in
+  Surface_ref.Gate
+    { label
+    ; address =
+        gate_address ~channel ~channel_workspace_id ?conversation_id
+          ?external_message_id ()
+    }
 
-let discord_guild_id metadata =
-  metadata_value_any [ "discord.guild_id"; "discord_guild_id" ] metadata
-
-(* Slack surface derivation (RFC-0317). The in-process gateway sets
-   [channel_workspace_id = channel_id] and mirrors it as [slack.channel_id]
-   metadata; prefer the metadata key, fall back to the workspace id. *)
-let slack_channel_id ~channel_workspace_id ~metadata =
-  match metadata_value_any [ "slack.channel_id"; "slack_channel_id" ] metadata with
-  | Some channel_id -> channel_id
-  | None -> String.trim channel_workspace_id
-
-let slack_team_id metadata =
-  metadata_value_any [ "slack.team_id"; "slack_team_id" ] metadata
-
-let slack_thread_ts metadata =
-  metadata_value_any [ "slack.thread_ts"; "slack_thread_ts" ] metadata
-
-let surface_for_channel_context ~connector_kind ~channel ~channel_workspace_id
-    ~metadata ?conversation_id ?external_message_id () =
-  match connector_kind with
-  | Discord ->
-      Surface_ref.Discord
-        {
-          guild_id = discord_guild_id metadata;
-          channel_id = discord_channel_id ~channel_workspace_id ~metadata;
-          parent_channel_id =
-            metadata_value_any
-              [ "discord.parent_channel_id"; "discord_parent_channel_id" ]
-              metadata;
-          thread_id =
-            metadata_value_any [ "discord.thread_id"; "discord_thread_id" ] metadata;
-        }
-  | Slack ->
-      Surface_ref.Slack
-        {
-          team_id = slack_team_id metadata;
-          channel_id = slack_channel_id ~channel_workspace_id ~metadata;
-          thread_ts = slack_thread_ts metadata;
-        }
-  | Generic ->
-      let label =
-        match non_empty_opt channel with
-        | Some lane -> lane
-        | None -> "gate"
-      in
-      Surface_ref.Gate
-        {
-          label;
-          address =
-            gate_address ~channel ~channel_workspace_id ?conversation_id
-              ?external_message_id ();
-        }
-
-let conversation_id_for_channel_context ~connector_kind ~channel
-    ~channel_workspace_id ~metadata =
+let conversation_id_for_channel_context ~channel ~channel_workspace_id ~metadata =
   match metadata_value "conversation_id" metadata with
   | Some value -> Some value
-  | None -> (
-      match connector_kind with
-      | Discord ->
-          let channel_id = discord_channel_id ~channel_workspace_id ~metadata in
-          (match non_empty_opt channel_id with
-           | None -> None
-           | Some channel_id ->
-               let guild_label =
-                 match discord_guild_id metadata with
-                 | Some guild_id -> guild_id
-                 | None -> "dm"
-               in
-               Some (Printf.sprintf "discord:%s:channel:%s" guild_label channel_id))
-      | Slack ->
-          (* Same shape as the in-process gateway's [slack_conversation_id] so
-             the inbound-recorded conversation and the busy-deferred delivery
-             reference one id (Slack threads share the parent channel id). *)
-          let channel_id = slack_channel_id ~channel_workspace_id ~metadata in
-          (match non_empty_opt channel_id with
-           | None -> None
-           | Some channel_id -> Some (Printf.sprintf "slack:channel:%s" channel_id))
-      | Generic ->
-          (match non_empty_opt channel, non_empty_opt channel_workspace_id with
-           | Some lane, Some workspace_id ->
-               Some (Printf.sprintf "gate:%s:workspace:%s" lane workspace_id)
-           | _ -> None))
+  | None ->
+    (match non_empty_opt channel, non_empty_opt channel_workspace_id with
+     | Some lane, Some workspace_id ->
+       Some (Printf.sprintf "gate:%s:workspace:%s" lane workspace_id)
+     | _ -> None)
 
 let external_message_id_for_channel_context ~idempotency_key ~metadata =
-  match metadata_value_any [ "external_message_id"; "discord.message_id" ] metadata with
+  match metadata_value "external_message_id" metadata with
   | Some value -> Some value
   | None -> non_empty_opt idempotency_key
 
@@ -701,8 +598,8 @@ let persist_connector_assistant_reply ~base_dir ~keeper_name ~source ?surface
    below either pass it ([dispatch_with_text_snapshot]) or omit it so it defaults
    to [None] ([dispatch]). Without the unit the optional leaks into [dispatch]'s
    inferred type and breaks the .mli signature. Do not drop the [()]. *)
-let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~submission_owner
-    ~sw ~clock ~proc_mgr ~net ~publication_recovery_provider ~config
+let dispatch_core ?on_text_snapshot ~submitted_by ~sw ~clock ~proc_mgr ~net
+    ~publication_recovery_provider ~config
     ~channel ~channel_user_id ~channel_user_name ~channel_workspace_id
     ~keeper_name ~idempotency_key ~metadata ~content () =
   let keeper_name = String.trim keeper_name in
@@ -715,11 +612,6 @@ let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~submission_owne
   let redact_json = Keeper_secret_redaction.redact_json redaction in
   let agent_name =
     agent_name_for_channel_actor ~channel ~channel_workspace_id ~channel_user_id
-  in
-  let submitted_by =
-    match submission_owner with
-    | Authenticated_caller caller -> caller
-    | Channel_actor -> agent_name
   in
   (* Use filesystem-safe sanitizer: this key is later used as a directory
      component in session_dir. An unsanitized channel_workspace_id with '..' or '/'
@@ -742,8 +634,7 @@ let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~submission_owne
   let lane = String.trim channel in
   let opt value = match String.trim value with "" -> None | v -> Some v in
   let conversation_id =
-    conversation_id_for_channel_context ~connector_kind ~channel
-      ~channel_workspace_id ~metadata
+    conversation_id_for_channel_context ~channel ~channel_workspace_id ~metadata
   in
   let external_message_id =
     external_message_id_for_channel_context ~idempotency_key ~metadata
@@ -754,8 +645,8 @@ let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~submission_owne
     |> ensure_metadata "external_message_id" external_message_id
   in
   let surface =
-    surface_for_channel_context ~connector_kind ~channel ~channel_workspace_id
-      ~metadata ?conversation_id ?external_message_id ()
+    surface_for_channel_context ~channel ~channel_workspace_id
+      ?conversation_id ?external_message_id ()
   in
   (* RFC-0232 §3.3: the connector decoded a structured mention of this
      channel's bound keeper (e.g. Discord <@snowflake>, invisible to
@@ -927,89 +818,20 @@ let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~submission_owne
   | `Async_ack (_, None) | `Streaming None ->
       Gate_protocol.Unavailable_result
 
-(* [connector_kind] is a required labelled argument (not optional): these
-   wrappers are partially applied to produce a [Channel_gate.dispatch_fn] /
-   [streaming_dispatch_fn], so a leading erasable optional would either fail to
-   erase (warning 16) or linger into the resulting function type and not match
-   the connector-neutral [dispatch_fn] shape. Requiring the connector to name
-   its kind also makes a missing wiring a compile error rather than a silent
-   [Generic] default. *)
-let dispatch ~connector_kind ~submission_owner ~sw ~clock ~proc_mgr ~net
-    ~publication_recovery_provider ~config
-    ~channel
+let dispatch ~submitted_by ~sw ~clock ~proc_mgr ~net
+    ~publication_recovery_provider ~config ~channel
     ~channel_user_id ~channel_user_name ~channel_workspace_id ~keeper_name
     ~idempotency_key ~metadata ~content =
-  match connector_kind with
-  | Discord ->
-    let delivery =
-      { source =
-          Keeper_chat_queue.Discord
-            { channel_id = channel_workspace_id; user_id = channel_user_id }
-      ; surface =
-          surface_for_channel_context ~connector_kind ~channel
-            ~channel_workspace_id ~metadata ()
-      ; conversation_id =
-          conversation_id_for_channel_context ~connector_kind ~channel
-            ~channel_workspace_id ~metadata
-      ; external_message_id =
-          external_message_id_for_channel_context ~idempotency_key ~metadata
-      }
-    in
-    accept_connector ~delivery ~clock ~config ~channel
-      ~channel_user_id ~channel_user_name ~channel_workspace_id ~keeper_name
-      ~idempotency_key ~metadata ~content
-  | Slack ->
-    let thread_ts =
-      match slack_thread_ts metadata with
-      | Some thread_ts -> Some thread_ts
-      | None ->
-        metadata_value_any [ "slack.message_ts"; "slack_message_ts" ] metadata
-    in
-    let delivery =
-      { source =
-          Keeper_chat_queue.Slack
-            { channel_id = channel_workspace_id
-            ; user_id = channel_user_id
-            ; user_name = channel_user_name
-            ; team_id = slack_team_id metadata
-            ; thread_ts
-            }
-      ; surface =
-          surface_for_channel_context ~connector_kind ~channel
-            ~channel_workspace_id ~metadata ()
-      ; conversation_id =
-          conversation_id_for_channel_context ~connector_kind ~channel
-            ~channel_workspace_id ~metadata
-      ; external_message_id =
-          external_message_id_for_channel_context ~idempotency_key ~metadata
-      }
-    in
-    accept_connector ~delivery ~clock ~config ~channel
-      ~channel_user_id ~channel_user_name ~channel_workspace_id ~keeper_name
-      ~idempotency_key ~metadata ~content
-  | Generic ->
-    dispatch_core ~connector_kind ~submission_owner ~sw ~clock ~proc_mgr ~net
-      ~publication_recovery_provider ~config ~channel ~channel_user_id
-      ~channel_user_name ~channel_workspace_id ~keeper_name ~idempotency_key
-      ~metadata ~content ()
+  dispatch_core ~submitted_by ~sw ~clock ~proc_mgr ~net
+    ~publication_recovery_provider ~config ~channel ~channel_user_id
+    ~channel_user_name ~channel_workspace_id ~keeper_name ~idempotency_key
+    ~metadata ~content ()
 
-let dispatch_with_text_snapshot ~connector_kind ~submission_owner
-    ~on_text_snapshot ~sw ~clock ~proc_mgr ~net ~publication_recovery_provider
-    ~config ~channel ~channel_user_id ~channel_user_name ~channel_workspace_id
-    ~keeper_name ~idempotency_key ~metadata ~content =
-  match connector_kind with
-  | Discord ->
-    dispatch ~connector_kind ~submission_owner ~sw ~clock ~proc_mgr ~net
-      ~publication_recovery_provider ~config ~channel ~channel_user_id
-      ~channel_user_name ~channel_workspace_id ~keeper_name ~idempotency_key
-      ~metadata ~content
-  | Slack ->
-    dispatch ~connector_kind ~submission_owner ~sw ~clock ~proc_mgr ~net
-      ~publication_recovery_provider ~config ~channel ~channel_user_id
-      ~channel_user_name ~channel_workspace_id ~keeper_name ~idempotency_key
-      ~metadata ~content
-  | Generic ->
-    dispatch_core ~connector_kind ~submission_owner ~on_text_snapshot ~sw
-      ~clock ~proc_mgr ~net ~publication_recovery_provider ~config ~channel
-      ~channel_user_id ~channel_user_name ~channel_workspace_id ~keeper_name
-      ~idempotency_key ~metadata ~content ()
+let dispatch_with_text_snapshot ~submitted_by ~on_text_snapshot ~sw ~clock
+    ~proc_mgr ~net ~publication_recovery_provider ~config ~channel
+    ~channel_user_id ~channel_user_name ~channel_workspace_id ~keeper_name
+    ~idempotency_key ~metadata ~content =
+  dispatch_core ~submitted_by ~on_text_snapshot ~sw ~clock ~proc_mgr ~net
+    ~publication_recovery_provider ~config ~channel ~channel_user_id
+    ~channel_user_name ~channel_workspace_id ~keeper_name ~idempotency_key
+    ~metadata ~content ()

--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -42,24 +42,6 @@ type connector_delivery =
   ; external_message_id : string option
   }
 
-(* [route_busy_connector] decides where a connector message goes when the keeper
-   is already in flight. Pure and exhaustive over [connector_kind] so a new
-   connector forces a routing decision at compile time (no catch-all). [Discord]
-   projects onto the chat queue, whose serial consumer drains it after the slot
-   frees and delivers the reply through the connector's outbound adapter
-   ([Keeper_chat_discord.adapter_loop]); [Generic] has no such adapter and falls
-   back to the async poll store. *)
-let route_busy_connector (kind : connector_kind) ~channel_id ~user_id ~user_name
-    ~team_id ~thread_ts :
-    [ `Enqueue_chat_queue of Keeper_chat_queue.message_source | `Async_poll ] =
-  match kind with
-  | Discord -> `Enqueue_chat_queue (Keeper_chat_queue.Discord { channel_id; user_id })
-  | Slack ->
-    `Enqueue_chat_queue
-      (Keeper_chat_queue.Slack
-         { channel_id; user_id; user_name; team_id; thread_ts })
-  | Generic -> `Async_poll
-
 (* ── Keeper response parsing ─────────────────────────────────── *)
 
 let extract_turn_stats (body : string) : Gate_protocol.turn_stats option =
@@ -842,49 +824,13 @@ let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~submission_owne
                  "channel gate text snapshot callback failed (keeper=%s): %s"
                  keeper_name (Printexc.to_string exn))
   in
-  let slack_reply_thread_ts =
-    match slack_thread_ts metadata with
-    | Some thread_ts -> Some thread_ts
-    | None -> metadata_value_any [ "slack.message_ts"; "slack_message_ts" ] metadata
-  in
   let defer_to_existing_work
       (admission_rejection : Keeper_turn_admission.rejection) =
-    match
-      route_busy_connector connector_kind
-        ~channel_id:channel_workspace_id ~user_id:channel_user_id
-        ~user_name:channel_user_name ~team_id:(slack_team_id metadata)
-        ~thread_ts:slack_reply_thread_ts
-    with
-    | `Enqueue_chat_queue source ->
-      (* RFC-connector-deferred-reply-via-chat-queue: route accepted connector
-         input onto the durable queue whenever the authoritative if-free
-         admission reports Busy. This includes a receipt committed or leased
-         after any outer observation but before the turn slot was acquired. *)
-      (match
-         Keeper_chat_queue.enqueue ~keeper_name
-           { Keeper_chat_queue.content = String.trim content
-           ; user_blocks = []
-           ; attachments = []
-           ; timestamp = Eio.Time.now clock
-           ; source
-           ; user_row_origin = Keeper_chat_store.Already_persisted_upstream
-           }
-       with
-       | Ok receipt -> `Queued_to_chat_lane (admission_rejection, receipt)
-       | Error error ->
-         Log.Server.error
-           "channel gate durable chat enqueue failed (keeper=%s, lane=%s): %s"
-           keeper_name lane
-           (Keeper_chat_queue.mutation_error_to_string error);
-         `Chat_queue_error error)
-    | `Async_poll ->
-      `Async_ack
-        ( admission_rejection.in_flight
-        , Some
-            (Keeper_tool_surface.dispatch_keeper_msg
-               ~submitted_by
-               keeper_ctx
-               ~args) )
+    `Async_ack
+      ( admission_rejection.in_flight
+      , Some
+          (Keeper_tool_surface.dispatch_keeper_msg ~submitted_by keeper_ctx
+             ~args) )
   in
   let dispatch_result =
     (* The admission boundary, not a route-level peek, owns the FIFO decision.
@@ -951,43 +897,6 @@ let dispatch_core ?on_text_snapshot ?(connector_kind = Generic) ~submission_owne
           }
       in
       Gate_protocol.Reply { content = reply; structured; stats; message_request }
-  | `Queued_to_chat_lane (admission_rejection, receipt) ->
-      (* RFC-connector-deferred-reply-via-chat-queue: the message was enqueued onto [Keeper_chat_queue]; the
-         connector gets a busy ACK now and the deferred reply later via the
-         serial consumer's outbound adapter. The existing [message_request]
-         envelope carries the durable receipt id and queue revision so the
-         connector can correlate that later delivery. *)
-      let duration_ms =
-        Mtime.Span.to_uint64_ns (Mtime.span (Mtime_clock.now ()) start_mtime)
-        |> Int64.div 1_000_000L
-        |> Int64.to_int
-      in
-      let message_request =
-        chat_queue_message_request ~channel ~channel_user_id ~keeper_name
-          ~admission_rejection ~metadata receipt
-      in
-      let reply =
-        redact_text
-          (busy_ack_reply_text_queued ~admission_rejection ~keeper_name
-             ~receipt_id:message_request.request_id
-             ~recovery_required_count:receipt.recovery_required_count)
-      in
-      let stats =
-        Some { Gate_protocol.model_used = "runtime"; duration_ms; tokens_used = 0 }
-      in
-      Gate_protocol.Reply
-        { content = reply
-        ; structured = None
-        ; stats
-        ; message_request = Some message_request
-        }
-  | `Chat_queue_error error ->
-      Gate_protocol.Keeper_error_result
-        (redact_text
-           (Printf.sprintf
-              "%s is busy; your message was not queued because the durable chat queue rejected it: %s"
-              keeper_name
-              (Keeper_chat_queue.mutation_error_to_string error)))
   | `Streaming (Some result) when not (Tool_result.is_failed result) ->
       let body = Tool_result.message result in
       let duration_ms =

--- a/lib/gate_keeper_backend.mli
+++ b/lib/gate_keeper_backend.mli
@@ -60,21 +60,6 @@ val accept_connector :
     queue receipt and transcript delivery key; retries converge without a
     derived hash namespace. *)
 
-val route_busy_connector :
-  connector_kind ->
-  channel_id:string ->
-  user_id:string ->
-  user_name:string ->
-  team_id:string option ->
-  thread_ts:string option ->
-  [ `Enqueue_chat_queue of Keeper_chat_queue.message_source | `Async_poll ]
-(** Pure routing decision for a connector message that arrives while the keeper
-    has an in-flight turn. Exhaustive over {!connector_kind}: [Discord] and
-    [Slack] return [`Enqueue_chat_queue] with the typed source so the serial
-    {!Keeper_chat_consumer} drains and delivers it after the slot frees;
-    [Generic] returns [`Async_poll]. Exposed for unit testing the decision in
-    isolation. *)
-
 val dispatch :
   connector_kind:connector_kind ->
   submission_owner:submission_owner ->

--- a/lib/gate_keeper_backend.mli
+++ b/lib/gate_keeper_backend.mli
@@ -10,25 +10,7 @@
 
     @since 2.222.0 *)
 
-(** {1 Connector deferred-reply routing (RFC-connector-deferred-reply-via-chat-queue)} *)
-
-type connector_kind =
-  | Discord
-  | Slack
-  | Generic
-(** The typed identity of the connector a {!dispatch} serves, injected at
-    dispatch-construction time. [Discord] and [Slack] each have an in-process
-    inbound gateway and an outbound adapter, so a busy message projects onto the
-    chat queue; [Generic] (the HTTP gate-route lane: imessage-bot, cli-connector)
-    keeps the async [masc_keeper_msg] poll path. See
-    RFC-connector-deferred-reply-via-chat-queue §3.2–3.3 and RFC-0317. *)
-
-type submission_owner =
-  | Authenticated_caller of string
-  | Channel_actor
-(** Owner of an async request produced by this dispatch. [Channel_actor] uses
-    the external actor's deterministic gate identity. [Authenticated_caller]
-    keeps poll/cancel authority with the already-authenticated HTTP principal. *)
+(** {1 Connector delivery} *)
 
 type connector_delivery =
   { source : Keeper_chat_queue.message_source
@@ -61,8 +43,7 @@ val accept_connector :
     derived hash namespace. *)
 
 val dispatch :
-  connector_kind:connector_kind ->
-  submission_owner:submission_owner ->
+  submitted_by:string ->
   sw:Eio.Switch.t ->
   clock:_ Eio.Time.clock ->
   proc_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t option ->
@@ -79,28 +60,17 @@ val dispatch :
   metadata:(string * string) list ->
   content:string ->
   Gate_protocol.dispatch_result
-(** [Discord]/[Slack] delegates to {!accept_connector}: every message enters
-    [Keeper_chat_queue] before this call returns, regardless of current Keeper
-    admission. [Generic] builds a keeper context and retains the HTTP/poll
-    contract. The durable connector enqueue is acknowledged
-    only after its durable snapshot commits; the reply's [message_request]
-    carries the queue receipt id and revision. When admission is fenced by a
-    typed Keeper shutdown operation, the same envelope carries
-    [shutdown_operation_id] and the ACK says the receipt waits for the next
-    active lane rather than promising completion of a current turn.
-    Persistence failure returns an explicit [Keeper_error_result], never a
-    queued ACK. [Generic]
-    returns an accepted async request envelope ([Keeper_msg_async]) instead of
-    blocking the connector request behind that turn. The [channel] and
-    [channel_user_id] are used to construct the agent name
+(** Build the generic HTTP Gate Keeper context. A busy Keeper returns an
+    accepted async request envelope ([Keeper_msg_async]) instead of blocking the
+    HTTP request. Durable connector leaves use {!accept_connector} and do not
+    enter this path. The [channel] and [channel_user_id] construct the agent name
     ([gate:<channel>:<workspace_id>:<user_id>]) for conversation identity;
-    [submission_owner] independently binds poll/cancel authority. The other connector fields are
-    injected into the keeper-visible message body so external user identity
-    survives memory and handoff boundaries. *)
+    [submitted_by] independently binds poll/cancel authority. The other generic
+    Gate fields are injected into the keeper-visible message body so external
+    user identity survives memory and handoff boundaries. *)
 
 val dispatch_with_text_snapshot :
-  connector_kind:connector_kind ->
-  submission_owner:submission_owner ->
+  submitted_by:string ->
   on_text_snapshot:(string -> unit) ->
   sw:Eio.Switch.t ->
   clock:_ Eio.Time.clock ->

--- a/lib/server/server_routes_http_routes_channel_gate.ml
+++ b/lib/server/server_routes_http_routes_channel_gate.ml
@@ -140,15 +140,11 @@ let handle_gate_message ~sw ~clock ~submitted_by state request reqd =
     let request_started = Unix.gettimeofday () in
     let workspace_scope = Mcp_server.workspace_scope state in
     let dispatch =
-      (* RFC-connector-deferred-reply-via-chat-queue: the HTTP gate route is the convergence point for sidecar
-         connectors (imessage-bot, cli-connector) that POST and await the reply
-         synchronously. They have no in-process outbound adapter, so [Generic]
-         keeps their existing async [masc_keeper_msg] poll behaviour when the
-         keeper is busy. *)
+      (* The HTTP gate route posts and awaits synchronously. A busy Keeper keeps
+         the async [masc_keeper_msg] poll contract; durable connector leaves use
+         [accept_connector] before entering their Keeper lane. *)
       Gate_keeper_backend.dispatch
-        ~connector_kind:Gate_keeper_backend.Generic
-        ~submission_owner:(Gate_keeper_backend.Authenticated_caller submitted_by)
-        ~sw ~clock
+        ~submitted_by ~sw ~clock
         ~proc_mgr:state.Mcp_server.proc_mgr
         ~net:state.Mcp_server.net
         ~publication_recovery_provider:

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -2779,63 +2779,9 @@ let test_extract_message_request_ack_falls_back_to_keeper_name () =
         ("expected Ok with fallback keeper_name: "
          ^ Gate_keeper_backend.ack_parse_failure_to_string failure)
 
-(* ── RFC-connector-deferred-reply-via-chat-queue connector deferred-reply routing ───────────────── *)
-
-let test_route_busy_discord_enqueues () =
-  match
-    Gate_keeper_backend.route_busy_connector Gate_keeper_backend.Discord
-      ~channel_id:"123456789" ~user_id:"u-42"
-      ~user_name:"discord-user" ~team_id:None ~thread_ts:None
-  with
-  | `Enqueue_chat_queue (Keeper_chat_queue.Discord { channel_id; user_id }) ->
-      check string "discord channel_id threaded" "123456789" channel_id;
-      check string "discord user_id threaded" "u-42" user_id
-  | `Enqueue_chat_queue _ ->
-      fail "Discord must map to a Discord message_source, not another variant"
-  | `Async_poll -> fail "Discord has an outbound adapter; must enqueue, not poll"
-
-
-let test_route_busy_slack_enqueues () =
-  match
-    Gate_keeper_backend.route_busy_connector Gate_keeper_backend.Slack
-      ~channel_id:"C0SLACK" ~user_id:"U-99"
-      ~user_name:"slack-user" ~team_id:(Some "T0SLACK")
-      ~thread_ts:(Some "171.001")
-  with
-  | `Enqueue_chat_queue
-      (Keeper_chat_queue.Slack
-         { channel_id; user_id; user_name; team_id; thread_ts }) ->
-      check string "slack channel threaded" "C0SLACK" channel_id;
-      check string "slack user_id threaded" "U-99" user_id;
-      check string "slack user name threaded" "slack-user" user_name;
-      check (option string) "slack team threaded" (Some "T0SLACK") team_id;
-      check (option string) "slack reply thread threaded" (Some "171.001") thread_ts
-  | `Enqueue_chat_queue _ ->
-      fail "Slack must map to a Slack message_source, not another variant"
-  | `Async_poll -> fail "Slack has an outbound adapter; must enqueue, not poll"
-
-let test_route_busy_generic_falls_back () =
-  match
-    Gate_keeper_backend.route_busy_connector Gate_keeper_backend.Generic
-      ~channel_id:"x" ~user_id:"y"
-      ~user_name:"generic-user" ~team_id:None ~thread_ts:None
-  with
-  | `Async_poll -> check bool "generic falls back to async poll" true true
-  | `Enqueue_chat_queue _ ->
-      fail "Generic has no in-process outbound adapter; must not enqueue (RFC-connector-deferred-reply-via-chat-queue §3.3a)"
-
 let () =
   Alcotest.run "Gate_keeper_backend"
     [
-      ( "route_busy_connector",
-        [
-          test_case "Discord enqueues with channel_id/user_id" `Quick
-            test_route_busy_discord_enqueues;
-          test_case "Slack enqueues with channel/user_id" `Quick
-            test_route_busy_slack_enqueues;
-          test_case "Generic falls back to async poll" `Quick
-            test_route_busy_generic_falls_back;
-        ] );
       ( "helpers",
         [
           test_case "agent name is stable" `Quick

--- a/test/test_keeper_busy_connector_deferred.ml
+++ b/test/test_keeper_busy_connector_deferred.ml
@@ -1,508 +1,46 @@
-(* test_keeper_busy_connector_deferred.ml — RFC-connector-deferred-reply-via-chat-queue §4.
-
-   Production-path proof (not a pure-helper test): a Discord connector message
-   that arrives while the keeper already holds an in-flight turn is routed
-   through [Gate_keeper_backend.dispatch] onto [Keeper_chat_queue] (where the
-   serial consumer can drain it and deliver the reply via the Discord outbound
-   adapter), NOT the outbound-less async [Keeper_msg_async] poll store — the
-   RFC root-cause fix. It also pins the recording-ownership invariant: the gate
-   inbound boundary records the connector user line exactly once, with no paired
-   assistant row yet (the message is still pending, waiting to be drained).
-
-   The Discord busy branch enqueues and returns a queued ACK without running a
-   keeper turn, so this needs no provider: [proc_mgr]/[net] are [None] and the
-   admission slot is held by a sibling fiber for the whole assertion window. *)
+(* The product-specific busy router was deleted: Discord and Slack leaves now
+   inject one typed delivery into [accept_connector]. This target retains only
+   the production acceptance invariants that are not covered by the leaf
+   projection tests. *)
 
 open Masc
 
 let failures = ref 0
 
-let check name cond =
-  if cond then Printf.printf "  \xe2\x9c\x93 %s\n%!" name
+let check name condition =
+  if condition
+  then Printf.printf "  \xe2\x9c\x93 %s\n%!" name
   else (
     incr failures;
     Printf.printf "  \xe2\x9c\x97 %s\n%!" name)
+;;
 
 let contains ~affix text = Astring.String.is_infix ~affix text
-
-let keeper_name = "busy-connector-keeper"
-
-(* Hold the keeper's admission slot busy in a forked fiber (the proven pattern
-   from test_keeper_turn_admission): the body resolves [started] then blocks on
-   [release], so the slot stays occupied across [f]. *)
-let with_busy_slot ~base ~sw f =
-  let started, set_started = Eio.Promise.create () in
-  let release, set_release = Eio.Promise.create () in
-  Eio.Fiber.fork ~sw (fun () ->
-    ignore
-      (Keeper_turn_admission.run_serialized ~base_path:base ~keeper_name
-         (fun () ->
-           Eio.Promise.resolve set_started ();
-           Eio.Promise.await release)));
-  Eio.Promise.await started;
-  let result = f () in
-  Eio.Promise.resolve set_release ();
-  result
-
-let with_unpublished_busy_slot ~base ~sw f =
-  let started, set_started = Eio.Promise.create () in
-  let release, set_release = Eio.Promise.create () in
-  Eio.Fiber.fork ~sw (fun () ->
-    Keeper_turn_admission.For_testing.with_unpublished_turn_lock
-      ~base_path:base ~keeper_name (fun () ->
-        Eio.Promise.resolve set_started ();
-        Eio.Promise.await release));
-  Eio.Promise.await started;
-  let result = f () in
-  Eio.Promise.resolve set_release ();
-  result
+let keeper_name = "connector-acceptance-keeper"
 
 let count_user_lines ~base =
-  (* The gate inbound boundary records the connector user line as a pending
-     (assistant-less) row. Count those rows for the keeper to assert exactly-once
-     recording. *)
-  List.length
-    (List.filter
-       (fun (m : Keeper_chat_store.chat_message) ->
-          match m.role with Keeper_chat_store.Role.User -> true | _ -> false)
-       (Keeper_chat_store.load ~base_dir:base ~keeper_name))
+  Keeper_chat_store.load ~base_dir:base ~keeper_name
+  |> List.filter (fun (message : Keeper_chat_store.chat_message) ->
+    match message.role with
+    | Keeper_chat_store.Role.User -> true
+    | Keeper_chat_store.Role.Assistant | Keeper_chat_store.Role.Tool -> false)
+  |> List.length
+;;
 
 let configure_queue ~base =
   Keeper_chat_queue.For_testing.reset ();
   let report = Keeper_chat_queue.configure_persistence ~base_path:base in
-  check "chat queue persistence configured without load errors"
-    (report.load_errors = [])
-
-let test_busy_discord_enqueues () =
-  Printf.printf
-    "Test: busy Discord dispatch enqueues onto Keeper_chat_queue (not async poll)\n%!";
-  let base =
-    Filename.concat (Filename.get_temp_dir_name ())
-      (Printf.sprintf "masc-busy-conn-%d-%d" (Unix.getpid ())
-         (int_of_float (Unix.gettimeofday () *. 1_000_000.)))
-  in
-  Unix.mkdir base 0o755;
-  Fun.protect
-    ~finally:(fun () ->
-      ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote base))))
-    (fun () ->
-      Eio_main.run @@ fun env ->
-      Fs_compat.set_fs (Eio.Stdenv.fs env);
-      let clock = Eio.Stdenv.clock env in
-      let config = Workspace.default_config base in
-      ignore (Workspace.init config ~agent_name:(Some keeper_name));
-      Keeper_turn_admission.For_testing.reset ();
-      configure_queue ~base;
-      Eio.Switch.run (fun sw ->
-        Eio.Switch.on_release sw Keeper_chat_queue.For_testing.reset;
-        let reply =
-          with_busy_slot ~base ~sw (fun () ->
-            Gate_keeper_backend.dispatch
-              ~connector_kind:Gate_keeper_backend.Discord
-              ~submission_owner:Gate_keeper_backend.Channel_actor
-              ~sw ~clock ~proc_mgr:None ~net:None
-              ~publication_recovery_provider:
-                Masc_test_deps.non_runtime_publication_recovery_provider
-              ~config
-              ~channel:"discord" ~channel_user_id:"user-42"
-              ~channel_user_name:"Tester" ~channel_workspace_id:"chan-777"
-              ~keeper_name ~idempotency_key:"discord-msg-777"
-              ~metadata:[] ~content:"are you there?")
-        in
-        (* The connector receives a busy ACK now; the deferred reply arrives
-           later via the consumer. The existing message-request envelope carries
-           the durable queue receipt instead of an async-poll request id. *)
-        let ack_receipt_id = ref None in
-        (match reply with
-         | Gate_protocol.Reply
-             { message_request = Some request; content; _ } ->
-             ack_receipt_id := Some request.request_id;
-             check "busy connector ACK is queued"
-               (request.status = Gate_protocol.Queued);
-             check "busy connector ACK carries queue status source"
-               (List.assoc_opt "status_source" request.metadata
-                = Some "keeper_chat_queue");
-             check "busy connector ACK carries queue revision"
-               (List.assoc_opt "queue_revision" request.metadata <> None);
-             check "busy connector ACK carries recovery-required depth"
-               (List.assoc_opt "recovery_required_count" request.metadata
-                = Some "0");
-             check "busy ACK text is non-empty" (String.length content > 0)
-         | Gate_protocol.Reply { message_request = None; _ } ->
-             check "busy connector ACK carries durable receipt" false
-         | Gate_protocol.Keeper_error_result _
-         | Gate_protocol.Unavailable_result ->
-             check "busy Discord dispatch returns a Reply (not error/unavailable)"
-               false);
-        (* The message lands on the chat queue with the typed Discord source so
-           the serial consumer can drain it and route the reply to the channel. *)
-        let snapshot = Keeper_chat_queue.snapshot ~keeper_name in
-        check "exactly one durable receipt is pending"
-          (List.length snapshot.pending = 1);
-        check "no durable receipt is inflight yet"
-          (snapshot.inflight = []);
-        check "queue snapshot has no load errors" (snapshot.load_errors = []);
-        (match snapshot.pending with
-         | [ { Keeper_chat_queue.receipt_id; message =
-                 { Keeper_chat_queue.source =
-                     Keeper_chat_queue.Discord { channel_id; user_id }
-                 ; content
-                 ; _
-                 }
-             ; _
-             } ] ->
-             check "ACK and pending receipt ids match"
-               (Some (Keeper_chat_queue.Receipt_id.to_string receipt_id)
-                = !ack_receipt_id);
-             check "queued source is the Discord channel_id"
-               (channel_id = "chan-777");
-             check "queued source carries the user_id" (user_id = "user-42");
-             check "queued content is the user's message"
-               (content = "are you there?")
-         | _ -> check "queue holds one Discord receipt" false);
-        (match Keeper_chat_queue.lease_next ~keeper_name with
-         | `Leased lease ->
-             check "lease carries the pending receipt"
-               (match snapshot.pending with
-                | [ receipt ] ->
-                  Keeper_chat_queue.Receipt_id.equal
-                    lease.item.receipt_id receipt.receipt_id
-                | [] | _ :: _ :: _ -> false);
-             (match
-                Keeper_chat_queue.finalize ~keeper_name
-                  ~lease_id:lease.lease_id
-                  ~outcome:
-                    (Keeper_chat_queue.Mark_delivered
-                       { completed_at = Time_compat.now (); outcome_ref = None })
-              with
-              | `Finalized receipt_id ->
-                  check "finalize records the delivered receipt"
-                    (Keeper_chat_queue.Receipt_id.equal
-                       receipt_id lease.item.receipt_id)
-              | `Unknown_lease | `Error _ ->
-                  check "leased receipt finalizes" false)
-         | `Empty | `Already_leased _ | `Recovery_required _ | `Error _ ->
-             check "pending receipt leases" false);
-        (* Ownership invariant (RFC §3.4): the gate inbound boundary recorded the
-           user line exactly once; no paired assistant row exists yet because the
-           turn has not been drained. *)
-        check "gate inbound recorded the connector user line exactly once"
-          (count_user_lines ~base = 1)))
-
-let test_unpublished_busy_slot_queues_without_resolved_meta () =
-  Printf.printf
-    "Test: unresolved-meta Gate queues during the lock-before-in-flight window\n%!";
-  let base =
-    Filename.concat (Filename.get_temp_dir_name ())
-      (Printf.sprintf "masc-unpublished-conn-%d-%d" (Unix.getpid ())
-         (int_of_float (Unix.gettimeofday () *. 1_000_000.)))
-  in
-  Unix.mkdir base 0o755;
-  Fun.protect
-    ~finally:(fun () ->
-      ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote base))))
-    (fun () ->
-      Eio_main.run @@ fun env ->
-      Fs_compat.set_fs (Eio.Stdenv.fs env);
-      let clock = Eio.Stdenv.clock env in
-      let config = Workspace.default_config base in
-      ignore (Workspace.init config ~agent_name:(Some keeper_name));
-      Keeper_turn_admission.For_testing.reset ();
-      configure_queue ~base;
-      Eio.Switch.run (fun sw ->
-        Eio.Switch.on_release sw Keeper_chat_queue.For_testing.reset;
-        let reply =
-          with_unpublished_busy_slot ~base ~sw (fun () ->
-            check "raw lock has no published in-flight metadata"
-              (Keeper_turn_admission.in_flight ~base_path:base ~keeper_name = None);
-            Gate_keeper_backend.dispatch
-              ~connector_kind:Gate_keeper_backend.Discord
-              ~submission_owner:Gate_keeper_backend.Channel_actor
-              ~sw ~clock ~proc_mgr:None ~net:None
-              ~publication_recovery_provider:
-                Masc_test_deps.non_runtime_publication_recovery_provider
-              ~config
-              ~channel:"discord" ~channel_user_id:"user-unpublished"
-              ~channel_user_name:"Tester" ~channel_workspace_id:"chan-unpublished"
-              ~keeper_name ~idempotency_key:"discord-msg-unpublished"
-              ~metadata:[] ~content:"queue me during admission")
-        in
-        (match reply with
-         | Gate_protocol.Reply { message_request = Some request; _ } ->
-           check "unpublished busy slot returns a queued ACK"
-             (request.status = Gate_protocol.Queued)
-         | Gate_protocol.Reply { message_request = None; _ }
-         | Gate_protocol.Keeper_error_result _
-         | Gate_protocol.Unavailable_result ->
-           check "unpublished busy slot returns a queued ACK" false);
-        let snapshot = Keeper_chat_queue.snapshot ~keeper_name in
-        check "unpublished busy slot durably preserves the connector message"
-          (List.length snapshot.pending = 1 && snapshot.inflight = [])))
-
-let test_busy_discord_persist_failure_is_explicit () =
-  Printf.printf
-    "Test: busy Discord dispatch fails closed when durable enqueue fails\n%!";
-  let base =
-    Filename.concat (Filename.get_temp_dir_name ())
-      (Printf.sprintf "masc-busy-conn-fail-%d-%d" (Unix.getpid ())
-         (int_of_float (Unix.gettimeofday () *. 1_000_000.)))
-  in
-  Unix.mkdir base 0o755;
-  Fun.protect
-    ~finally:(fun () ->
-      ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote base))))
-    (fun () ->
-      Eio_main.run @@ fun env ->
-      Fs_compat.set_fs (Eio.Stdenv.fs env);
-      let clock = Eio.Stdenv.clock env in
-      let config = Workspace.default_config base in
-      ignore (Workspace.init config ~agent_name:(Some keeper_name));
-      Keeper_turn_admission.For_testing.reset ();
-      configure_queue ~base;
-      Eio.Switch.run (fun sw ->
-        Eio.Switch.on_release sw Keeper_chat_queue.For_testing.reset;
-        let reply =
-          with_busy_slot ~base ~sw (fun () ->
-            Keeper_chat_queue.For_testing.fail_transaction_at_stages
-              [ Mutation_applied ];
-            Gate_keeper_backend.dispatch
-              ~connector_kind:Gate_keeper_backend.Discord
-              ~submission_owner:Gate_keeper_backend.Channel_actor
-              ~sw ~clock ~proc_mgr:None ~net:None
-              ~publication_recovery_provider:
-                Masc_test_deps.non_runtime_publication_recovery_provider
-              ~config
-              ~channel:"discord" ~channel_user_id:"user-42"
-              ~channel_user_name:"Tester" ~channel_workspace_id:"chan-777"
-              ~keeper_name ~idempotency_key:"discord-msg-persist-fail"
-              ~metadata:[] ~content:"do not lose me")
-        in
-        (match reply with
-         | Gate_protocol.Keeper_error_result message ->
-             check "persistence failure is returned explicitly"
-               (String.length message > 0)
-         | Gate_protocol.Reply _ | Gate_protocol.Unavailable_result ->
-             check "persistence failure never claims queued" false);
-        let snapshot = Keeper_chat_queue.snapshot ~keeper_name in
-        check "failed enqueue leaves no pending receipt"
-          (snapshot.pending = []);
-        check "failed enqueue does not advance queue revision"
-          (snapshot.revision = 0L)))
-
-let test_pending_receipt_prevents_direct_overtake () =
-  Printf.printf "Test: active receipt queues a later connector turn without a live slot\n%!";
-  let base =
-    Filename.concat (Filename.get_temp_dir_name ())
-      (Printf.sprintf "masc-pending-conn-%d-%d" (Unix.getpid ())
-         (int_of_float (Unix.gettimeofday () *. 1_000_000.)))
-  in
-  Unix.mkdir base 0o755;
-  Fun.protect
-    ~finally:(fun () ->
-      ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote base))))
-    (fun () ->
-      Eio_main.run @@ fun env ->
-      Fs_compat.set_fs (Eio.Stdenv.fs env);
-      let clock = Eio.Stdenv.clock env in
-      let config = Workspace.default_config base in
-      ignore (Workspace.init config ~agent_name:(Some keeper_name));
-      Keeper_turn_admission.For_testing.reset ();
-      configure_queue ~base;
-      ignore
-        (Keeper_chat_queue.enqueue ~keeper_name
-           { content = "first"
-           ; user_blocks = []
-           ; attachments = []
-           ; timestamp = Eio.Time.now clock
-           ; source =
-               Keeper_chat_queue.Discord
-                 { channel_id = "chan-777"; user_id = "user-42" }
-           ; user_row_origin = Keeper_chat_store.Already_persisted_upstream
-           });
-      Eio.Switch.run @@ fun sw ->
-      let reply =
-        Gate_keeper_backend.dispatch
-          ~connector_kind:Gate_keeper_backend.Discord
-          ~submission_owner:Gate_keeper_backend.Channel_actor
-          ~sw ~clock ~proc_mgr:None ~net:None
-          ~publication_recovery_provider:
-            Masc_test_deps.non_runtime_publication_recovery_provider
-          ~config
-          ~channel:"discord" ~channel_user_id:"user-42"
-          ~channel_user_name:"Tester" ~channel_workspace_id:"chan-777"
-          ~keeper_name ~idempotency_key:"discord-msg-778"
-          ~metadata:[] ~content:"second"
-      in
-      (match reply with
-       | Gate_protocol.Reply { message_request = Some request; _ } ->
-         check "later connector input is queued" (request.status = Gate_protocol.Queued)
-       | _ -> check "later connector input is queued" false);
-      let snapshot = Keeper_chat_queue.snapshot ~keeper_name in
-      check "FIFO keeps both accepted receipts pending"
-        (List.map (fun item -> item.Keeper_chat_queue.message.content) snapshot.pending
-         = [ "first"; "second" ]))
-
-let test_busy_slack_preserves_thread_context () =
-  Printf.printf "Test: busy Slack dispatch preserves reply-thread identity\n%!";
-  let base =
-    Filename.concat (Filename.get_temp_dir_name ())
-      (Printf.sprintf "masc-busy-slack-%d-%d" (Unix.getpid ())
-         (int_of_float (Unix.gettimeofday () *. 1_000_000.)))
-  in
-  Unix.mkdir base 0o755;
-  Fun.protect
-    ~finally:(fun () ->
-      ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote base))))
-    (fun () ->
-      Eio_main.run @@ fun env ->
-      Fs_compat.set_fs (Eio.Stdenv.fs env);
-      let clock = Eio.Stdenv.clock env in
-      let config = Workspace.default_config base in
-      ignore (Workspace.init config ~agent_name:(Some keeper_name));
-      Keeper_turn_admission.For_testing.reset ();
-      configure_queue ~base;
-      Eio.Switch.run @@ fun sw ->
-      let reply =
-        with_busy_slot ~base ~sw (fun () ->
-          Gate_keeper_backend.dispatch
-            ~connector_kind:Gate_keeper_backend.Slack
-            ~submission_owner:Gate_keeper_backend.Channel_actor
-            ~sw ~clock ~proc_mgr:None ~net:None
-            ~publication_recovery_provider:
-              Masc_test_deps.non_runtime_publication_recovery_provider
-            ~config
-            ~channel:"slack" ~channel_user_id:"U-42"
-            ~channel_user_name:"Slack User" ~channel_workspace_id:"C-777"
-            ~keeper_name ~idempotency_key:"slack-msg-171.001"
-            ~metadata:
-              [ "slack.message_ts", "171.001"
-              ; "slack.team_id", "T-777"
-              ]
-            ~content:"threaded question")
-      in
-      (match reply with
-       | Gate_protocol.Reply { message_request = Some request; _ } ->
-         check "Slack busy input is queued" (request.status = Gate_protocol.Queued)
-       | _ -> check "Slack busy input is queued" false);
-      match (Keeper_chat_queue.snapshot ~keeper_name).pending with
-      | [ { message =
-              { source =
-                  Keeper_chat_queue.Slack
-                    { channel_id; user_id; user_name; team_id; thread_ts }
-              ; _
-              }
-          ; _
-          } ] ->
-        check "Slack channel retained" (channel_id = "C-777");
-        check "Slack user retained" (user_id = "U-42" && user_name = "Slack User");
-        check "Slack team retained" (team_id = Some "T-777");
-        check "top-level message roots deferred reply thread"
-          (thread_ts = Some "171.001")
-      | _ -> check "one typed Slack receipt is pending" false)
+  check "chat queue persistence configured without load errors" (report.load_errors = [])
+;;
 
 let test_exact_source_identity_converges () =
   Printf.printf
     "Test: durable connector acceptance converges on the producer request id\n%!";
   let base =
-    Filename.concat (Filename.get_temp_dir_name ())
-      (Printf.sprintf "masc-connector-accept-%d-%d" (Unix.getpid ())
-         (int_of_float (Unix.gettimeofday () *. 1_000_000.)))
-  in
-  Unix.mkdir base 0o755;
-  Fun.protect
-    ~finally:(fun () ->
-      ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote base))))
-    (fun () ->
-      Eio_main.run @@ fun env ->
-      Fs_compat.set_fs (Eio.Stdenv.fs env);
-      let clock = Eio.Stdenv.clock env in
-      let config = Workspace.default_config base in
-      ignore (Workspace.init config ~agent_name:(Some keeper_name));
-      configure_queue ~base;
-      let accept metadata =
-        Gate_keeper_backend.accept_connector
-          ~delivery:
-            { source =
-                Keeper_chat_queue.Discord
-                  { channel_id = "channel-exact"; user_id = "user-exact" }
-            ; surface =
-                Surface_ref.Discord
-                  { guild_id = None
-                  ; channel_id = "channel-exact"
-                  ; parent_channel_id = None
-                  ; thread_id = None
-                  }
-            ; conversation_id = Some "discord:dm:channel:channel-exact"
-            ; external_message_id = Some "source-123"
-            }
-          ~clock ~config
-          ~channel:"discord" ~channel_user_id:"user-exact"
-          ~channel_user_name:"Exact User"
-          ~channel_workspace_id:"channel-exact" ~keeper_name
-          ~idempotency_key:"discord-msg-source-123"
-          ~metadata
-          ~content:"deliver exactly once"
-      in
-      (match
-         accept
-           [ "conversation_id", "discord:dm:channel:another-channel"
-           ; "external_message_id", "source-123"
-           ]
-       with
-       | Gate_protocol.Keeper_error_result detail ->
-         check "conflicting metadata identity fails closed"
-           (contains ~affix:"conflicts with metadata" detail)
-       | Gate_protocol.Reply _
-       | Gate_protocol.Unavailable_result ->
-         check "conflicting metadata identity fails closed" false);
-      let request_of_reply = function
-        | Gate_protocol.Reply { message_request = Some request; _ } -> request
-        | Gate_protocol.Reply { message_request = None; _ }
-        | Gate_protocol.Keeper_error_result _
-        | Gate_protocol.Unavailable_result ->
-          failwith "durable connector acceptance did not return a receipt"
-      in
-      let metadata = [ "external_message_id", "source-123" ] in
-      let first = request_of_reply (accept metadata) in
-      let repeated = request_of_reply (accept metadata) in
-      check "receipt is the exact producer request identity"
-        (first.request_id = "discord-msg-source-123");
-      check "active replay returns the same receipt"
-        (repeated.request_id = first.request_id);
-      let pending = (Keeper_chat_queue.snapshot ~keeper_name).pending in
-      check "active replay keeps one FIFO receipt" (List.length pending = 1);
-      check "accepted user transcript row is idempotent"
-        (count_user_lines ~base = 1);
-      (match Keeper_chat_queue.lease_next ~keeper_name with
-       | `Leased lease ->
-         ignore
-           (Keeper_chat_queue.finalize ~keeper_name ~lease_id:lease.lease_id
-              ~outcome:
-                (Keeper_chat_queue.Mark_delivered
-                   { completed_at = Time_compat.now (); outcome_ref = None })
-             : [ `Finalized of Keeper_chat_queue.Receipt_id.t
-               | `Unknown_lease
-               | `Error of Keeper_chat_queue.mutation_error
-               ])
-       | `Empty | `Already_leased _ | `Recovery_required _ | `Error _ ->
-         check "source receipt leases before terminal replay" false);
-      let terminal = request_of_reply (accept metadata) in
-      check "terminal replay reports done without redispatch"
-        (terminal.status = Gate_protocol.Done);
-      let snapshot = Keeper_chat_queue.snapshot ~keeper_name in
-      check "terminal replay does not create pending work"
-        (snapshot.pending = [] && Int64.equal snapshot.terminal_count 1L))
-
-let test_shutdown_fenced_connector_ack
-    ~label ~connector_kind ~channel ~channel_user_id ~channel_user_name
-    ~channel_workspace_id ~metadata ~content ~source_matches =
-  Printf.printf
-    "Test: shutdown-fenced %s ACK carries typed operation cause\n%!"
-    label;
-  let base =
-    Filename.concat (Filename.get_temp_dir_name ())
-      (Printf.sprintf "masc-shutdown-conn-%s-%d-%d"
-         (String.lowercase_ascii label)
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf
+         "masc-connector-accept-%d-%d"
          (Unix.getpid ())
          (int_of_float (Unix.gettimeofday () *. 1_000_000.)))
   in
@@ -511,118 +49,104 @@ let test_shutdown_fenced_connector_ack
     ~finally:(fun () ->
       ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote base))))
     (fun () ->
-      Eio_main.run @@ fun env ->
-      Fs_compat.set_fs (Eio.Stdenv.fs env);
-      let clock = Eio.Stdenv.clock env in
-      let config = Workspace.default_config base in
-      ignore (Workspace.init config ~agent_name:(Some keeper_name));
-      Keeper_turn_admission.For_testing.reset ();
-      configure_queue ~base;
-      let operation_id = Keeper_shutdown_types.Operation_id.generate () in
-      let operation_id_text =
-        Keeper_shutdown_types.Operation_id.to_string operation_id
-      in
-      (match
-         Keeper_turn_admission.begin_shutdown
-           ~base_path:base ~keeper_name ~operation_id
-       with
-       | Keeper_turn_admission.Shutdown_reserved _ -> ()
-       | Keeper_turn_admission.Shutdown_already_reserved _ ->
-         check (label ^ " shutdown fence is newly reserved") false);
-      Eio.Switch.run (fun sw ->
-        Eio.Switch.on_release sw Keeper_chat_queue.For_testing.reset;
-        let reply =
-          Gate_keeper_backend.dispatch
-            ~connector_kind
-            ~submission_owner:Gate_keeper_backend.Channel_actor
-            ~sw ~clock ~proc_mgr:None ~net:None
-            ~publication_recovery_provider:
-              Masc_test_deps.non_runtime_publication_recovery_provider
-            ~config
-            ~channel ~channel_user_id ~channel_user_name ~channel_workspace_id
-            ~keeper_name
-            ~idempotency_key:("shutdown-fenced-" ^ String.lowercase_ascii label)
-            ~metadata ~content
-        in
-        (match reply with
-         | Gate_protocol.Reply
-             { message_request = Some request; content = ack_text; _ } ->
-           check (label ^ " shutdown-fenced input is durably queued")
-             (request.status = Gate_protocol.Queued);
-           check (label ^ " ACK metadata carries shutdown operation id")
-             (List.assoc_opt "shutdown_operation_id" request.metadata
-              = Some operation_id_text);
-           check (label ^ " ACK names the stopping operation")
-             (contains
-                ~affix:
-                  (Printf.sprintf "is stopping under shutdown operation %s"
-                     operation_id_text)
-                ack_text);
-           check (label ^ " ACK promises the next active lane")
-             (contains
-                ~affix:"durably queued and will wait for the next active lane"
-                ack_text);
-           check (label ^ " ACK does not claim the current turn will finish")
-             (not (contains ~affix:"current turn finishes" ack_text))
+       Eio_main.run
+       @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       let clock = Eio.Stdenv.clock env in
+       let config = Workspace.default_config base in
+       ignore (Workspace.init config ~agent_name:(Some keeper_name));
+       configure_queue ~base;
+       let accept metadata =
+         Gate_keeper_backend.accept_connector
+           ~delivery:
+             { source =
+                 Keeper_chat_queue.Discord
+                   { channel_id = "channel-exact"; user_id = "user-exact" }
+             ; surface =
+                 Surface_ref.Discord
+                   { guild_id = None
+                   ; channel_id = "channel-exact"
+                   ; parent_channel_id = None
+                   ; thread_id = None
+                   }
+             ; conversation_id = Some "discord:dm:channel:channel-exact"
+             ; external_message_id = Some "source-123"
+             }
+           ~clock
+           ~config
+           ~channel:"discord"
+           ~channel_user_id:"user-exact"
+           ~channel_user_name:"Exact User"
+           ~channel_workspace_id:"channel-exact"
+           ~keeper_name
+           ~idempotency_key:"discord-msg-source-123"
+           ~metadata
+           ~content:"deliver exactly once"
+       in
+       (match
+          accept
+            [ "conversation_id", "discord:dm:channel:another-channel"
+            ; "external_message_id", "source-123"
+            ]
+        with
+        | Gate_protocol.Keeper_error_result detail ->
+          check
+            "conflicting metadata identity fails closed"
+            (contains ~affix:"conflicts with metadata" detail)
+        | Gate_protocol.Reply _ | Gate_protocol.Unavailable_result ->
+          check "conflicting metadata identity fails closed" false);
+       let request_of_reply = function
+         | Gate_protocol.Reply { message_request = Some request; _ } -> request
          | Gate_protocol.Reply { message_request = None; _ }
          | Gate_protocol.Keeper_error_result _
          | Gate_protocol.Unavailable_result ->
-           check (label ^ " shutdown-fenced input returns a queued ACK") false);
-        (match (Keeper_chat_queue.snapshot ~keeper_name).pending with
-         | [ { Keeper_chat_queue.message = { source; _ }; _ } ] ->
-           check (label ^ " shutdown-fenced receipt retains connector source")
-             (source_matches source)
-         | _ ->
-           check (label ^ " shutdown-fenced receipt is pending exactly once") false));
-      match
-        Keeper_turn_admission.rollback_shutdown
-          ~base_path:base ~keeper_name ~operation_id
-      with
-      | Keeper_turn_admission.Shutdown_rolled_back -> ()
-      | Keeper_turn_admission.Shutdown_not_reserved
-      | Keeper_turn_admission.Shutdown_reserved_by_other _ ->
-        check (label ^ " shutdown fence rolls back") false)
-
-let test_shutdown_fenced_discord_ack () =
-  test_shutdown_fenced_connector_ack
-    ~label:"Discord" ~connector_kind:Gate_keeper_backend.Discord
-    ~channel:"discord" ~channel_user_id:"discord-user"
-    ~channel_user_name:"Discord User" ~channel_workspace_id:"discord-channel"
-    ~metadata:[] ~content:"keep this until restart"
-    ~source_matches:(function
-      | Keeper_chat_queue.Discord { channel_id; user_id } ->
-        channel_id = "discord-channel" && user_id = "discord-user"
-      | Keeper_chat_queue.Dashboard _ | Keeper_chat_queue.Slack _ -> false)
-
-let test_shutdown_fenced_slack_ack () =
-  test_shutdown_fenced_connector_ack
-    ~label:"Slack" ~connector_kind:Gate_keeper_backend.Slack
-    ~channel:"slack" ~channel_user_id:"U-SHUTDOWN"
-    ~channel_user_name:"Slack User" ~channel_workspace_id:"C-SHUTDOWN"
-    ~metadata:
-      [ "slack.message_ts", "171.999"
-      ; "slack.team_id", "T-SHUTDOWN"
-      ]
-    ~content:"keep this until restart"
-    ~source_matches:(function
-      | Keeper_chat_queue.Slack
-          { channel_id; user_id; team_id; thread_ts; _ } ->
-        channel_id = "C-SHUTDOWN"
-        && user_id = "U-SHUTDOWN"
-        && team_id = Some "T-SHUTDOWN"
-        && thread_ts = Some "171.999"
-      | Keeper_chat_queue.Dashboard _ | Keeper_chat_queue.Discord _ -> false)
+           failwith "durable connector acceptance did not return a receipt"
+       in
+       let metadata = [ "external_message_id", "source-123" ] in
+       let first = request_of_reply (accept metadata) in
+       let repeated = request_of_reply (accept metadata) in
+       check
+         "receipt is the exact producer request identity"
+         (String.equal first.request_id "discord-msg-source-123");
+       check
+         "active replay returns the same receipt"
+         (String.equal repeated.request_id first.request_id);
+       let pending = (Keeper_chat_queue.snapshot ~keeper_name).pending in
+       check "active replay keeps one FIFO receipt" (List.length pending = 1);
+       check "accepted user transcript row is idempotent" (count_user_lines ~base = 1);
+       (match Keeper_chat_queue.lease_next ~keeper_name with
+        | `Leased lease ->
+          ignore
+            (Keeper_chat_queue.finalize
+               ~keeper_name
+               ~lease_id:lease.lease_id
+               ~outcome:
+                 (Keeper_chat_queue.Mark_delivered
+                    { completed_at = Time_compat.now (); outcome_ref = None })
+             : [ `Finalized of Keeper_chat_queue.Receipt_id.t
+               | `Unknown_lease
+               | `Error of Keeper_chat_queue.mutation_error
+               ])
+        | `Empty | `Already_leased _ | `Recovery_required _ | `Error _ ->
+          check "source receipt leases before terminal replay" false);
+       let terminal = request_of_reply (accept metadata) in
+       check
+         "terminal replay reports done without redispatch"
+         (terminal.status = Gate_protocol.Done);
+       let snapshot = Keeper_chat_queue.snapshot ~keeper_name in
+       check
+         "terminal replay does not create pending work"
+         (snapshot.pending = [] && Int64.equal snapshot.terminal_count 1L))
+;;
 
 let () =
-  test_busy_discord_enqueues ();
-  test_unpublished_busy_slot_queues_without_resolved_meta ();
-  test_busy_discord_persist_failure_is_explicit ();
-  test_pending_receipt_prevents_direct_overtake ();
-  test_busy_slack_preserves_thread_context ();
   test_exact_source_identity_converges ();
-  test_shutdown_fenced_discord_ack ();
-  test_shutdown_fenced_slack_ack ();
-  if !failures > 0 then (
+  (* For_testing.reset now requires an Eio context (main's idiom runs it via
+     Switch.on_release inside the test); at process exit it is moot, so the
+     toplevel call is dropped rather than leaking the effect. *)
+  if !failures > 0
+  then (
     Printf.printf "FAILED: %d check(s)\n%!" !failures;
     exit 1)
-  else Printf.printf "All keeper_busy_connector_deferred checks passed\n%!"
+  else Printf.printf "All connector acceptance checks passed\n%!"
+;;


### PR DESCRIPTION
## Why

After connector leaves inject typed delivery through `accept_connector`, the generic Gate API must not retain product variants or derive Discord/Slack surfaces from loose metadata.

Repaired recut of #24920 on #25025.

## What

- delete public `connector_kind` and `submission_owner` product-routing variants
- make generic HTTP Gate accept an explicit authenticated `submitted_by`
- delete Discord/Slack surface, conversation, and alias derivation from generic core
- keep product delivery only in Discord/Slack leaf gateways
- correct RFC-0317 to the actual `Channel_gate.handle_inbound → accept_connector → Keeper_chat_queue` path
- purge obsolete generic-product tests and retain only exact typed delivery conflict/idempotency proof

## Boundary

- product connector authority stays at MASC leaves
- generic Gate remains connector-neutral
- no OAS changes
- no connector string matching or metadata aliases

## Focused proof

- `ocamlformat --check`: passed
- `ocamlc -stop-after parsing`: passed
- `git diff --check`: passed
- code/call-path grep confirms no old product dispatch arguments in the retained target

Stack: #25020 → #25021 → #25024 → #25025
Head reviewed: `89bfa2d112`