### PR TITLE
fix(keeper): board attention start_async wrong-domain fork 가드 (#25015)

### DIFF
--- a/lib/eio_context/eio_context.ml
+++ b/lib/eio_context/eio_context.ml
@@ -20,6 +20,16 @@ let current_net : eio_net option Atomic.t = Atomic.make None
 let current_clock : float Eio.Time.clock_ty Eio.Resource.t option Atomic.t = Atomic.make None
 let current_mono_clock : Eio.Time.Mono.ty Eio.Resource.t option Atomic.t = Atomic.make None
 let current_sw : Eio.Switch.t option Atomic.t = Atomic.make None
+(* Owner domain of [current_sw]. [Eio.Switch] is domain-local: [Eio.Fiber.fork
+   ~sw] is only legal from the domain that created the switch. The root switch is
+   installed on the main Eio domain at bootstrap, but [get_root_switch_opt] is
+   readable from Domain_pool worker domains. Capturing the owner domain id here
+   lets callers reachable from a worker domain check ownership BEFORE forking and
+   defer instead of crashing with "Switch accessed from wrong domain!". Set
+   together with [current_sw] in [set_switch]. [restore_state] intentionally
+   leaves this untouched: the [current_sw = Some] guard in
+   [root_switch_on_current_domain] makes a stale owner id harmless. See #25015. *)
+let current_sw_domain : int option Atomic.t = Atomic.make None
 (* RFC-0107 Phase D.2c — full Eio standard environment, required by
    piaf [Client.create] (and any other API needing more than just
    [net]/[clock]).  Set once at server bootstrap; read by long-lived
@@ -75,10 +85,16 @@ let get_mono_clock_opt () =
   Atomic.get current_mono_clock
 
 let set_switch sw =
-  Atomic.set current_sw (Some sw)
+  Atomic.set current_sw (Some sw);
+  Atomic.set current_sw_domain (Some (Domain.self () :> int))
 
 let get_root_switch_opt () =
   Atomic.get current_sw
+
+let root_switch_on_current_domain () =
+  match Atomic.get current_sw, Atomic.get current_sw_domain with
+  | Some _, Some owner -> owner = (Domain.self () :> int)
+  | _, _ -> false
 
 let set_env env =
   Atomic.set current_env (Some env)

--- a/lib/eio_context/eio_context.mli
+++ b/lib/eio_context/eio_context.mli
@@ -29,6 +29,15 @@ val get_root_switch_opt : unit -> Eio.Switch.t option
     turn-scoped binding. Use only for work that must survive a single
     keeper turn, such as queued background voice playback. *)
 
+val root_switch_on_current_domain : unit -> bool
+(** [true] iff a root switch is installed ([set_switch] was called) AND the
+    calling domain is the one that installed it. [Eio.Switch] is domain-local,
+    so [Eio.Fiber.fork ~sw:(root switch)] is only legal when this returns
+    [true]; reachable-from-worker-domain callers must consult this before
+    forking on {!get_root_switch_opt} and defer otherwise, rather than let the
+    fork raise [Invalid_argument "Switch accessed from wrong domain!"].
+    Returns [false] before bootstrap and on any Domain_pool worker domain. *)
+
 val set_env : Eio_unix.Stdenv.base -> unit
 (** Set the global Eio standard environment.  Required by long-lived
     consumers that need more than [net]/[clock] (e.g. piaf

--- a/lib/keeper/keeper_board_attention_candidate.ml
+++ b/lib/keeper/keeper_board_attention_candidate.ml
@@ -953,6 +953,20 @@ let start_async ~base_path candidate =
           Worker_unavailable
           "server root switch is not installed";
         false
+      | Some _ when not (Eio_context.root_switch_on_current_domain ()) ->
+        (* The server root switch is domain-local: [Eio.Fiber.fork ~sw] is only
+           legal from the domain that owns it (the main Eio domain). [start_async]
+           is reachable from Domain_pool worker domains (dashboard/status
+           projections that call [resume_pending] / [record_and_start]). Forking
+           on the root switch there raises
+           [Invalid_argument "Switch accessed from wrong domain!"], which is NOT a
+           candidate failure — the judge never ran. Defer silently: release the
+           claim and leave the candidate Pending for the main-domain path (keeper
+           turn / boot [resume_pending]) to start. Recording a retryable_failure
+           here would corrupt the ledger's meaning and drive a write flood
+           (worker retries every projection cycle). See #25015. *)
+        release_active key;
+        false
       | Some sw ->
         (try
            Eio.Fiber.fork ~sw (fun () ->

--- a/test/test_eio_context_fiber_local.ml
+++ b/test/test_eio_context_fiber_local.ml
@@ -132,6 +132,30 @@ let test_get_https_connector_result_is_idempotent () =
   | _ ->
     Alcotest.fail "HTTPS connector result is not stable across repeated reads"
 
+(** [root_switch_on_current_domain] is the domain-ownership guard that keeps
+    board-attention (and any future root-switch fork site) from crashing with
+    "Switch accessed from wrong domain!" when reached from a Domain_pool worker
+    domain. The owner (main) domain that installed the switch via [set_switch]
+    must see [true]; a spawned worker domain reading the same process-global
+    switch must see [false] — the exact condition under which
+    [Eio.Fiber.fork ~sw:root_sw] would otherwise raise. See issue #25015. *)
+let test_root_switch_ownership_is_domain_local () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun root_sw ->
+  Eio_context.set_switch root_sw;
+  Alcotest.(check bool)
+    "owner (main) domain sees itself as root switch owner"
+    true
+    (Eio_context.root_switch_on_current_domain ());
+  let worker_saw_ownership =
+    Eio.Domain_manager.run (Eio.Stdenv.domain_mgr env) (fun () ->
+      Eio_context.root_switch_on_current_domain ())
+  in
+  Alcotest.(check bool)
+    "worker domain is NOT the root switch owner (fork ~sw would raise there)"
+    false
+    worker_saw_ownership
+
 let () =
   Alcotest.run "eio_context_fiber_local"
     [
@@ -164,5 +188,11 @@ let () =
           Alcotest.test_case "get_https_connector_result is idempotent"
             `Quick
             test_get_https_connector_result_is_idempotent;
+        ] );
+      ( "root switch domain ownership (#25015)",
+        [
+          Alcotest.test_case "owner domain true, worker domain false"
+            `Quick
+            test_root_switch_ownership_is_domain_local;
         ] );
     ]


### PR DESCRIPTION
## 목적

`start_async`가 worker 도메인에서 서버 root switch에 `Eio.Fiber.fork`를 시도하다 매번 실패하고, 그 실패를 candidate 원장에 write하며 무한 재시도하던 루프를 끊는다. 이 루프가 health flap의 실제 원인(#25015)이며, `#25008`의 storage bound로도 멈추지 않았다(write 자체가 멈추질 않았음).

## 근본 원인

`Eio.Switch`는 domain-local이라 `Eio.Fiber.fork ~sw`는 switch를 만든 도메인(메인)에서만 합법이다. `start_async`는 Domain_pool worker 도메인에서 reachable하고(`resume_pending`/`record_and_start`를 호출하는 dashboard/status projection), 거기서 root switch에 fork하면 `Invalid_argument("Switch accessed from wrong domain!")`가 난다.

기존 catch는 이를 `record_retryable_failure`로 처리했는데, **judge가 돌지도 않았으므로 candidate 실패가 아니다**. candidate는 Pending으로 남아 매 projection 사이클마다 재시도되고, 매 재시도가 원장 전체를 재파싱+재기록한다(post-#25008 rewrite). 이 자기지속 루프가 write 폭주 + CPU 소모의 정체다.

라이브 서버 로그 실측: `Board attention worker deferred keeper=garnet candidate=<id>: Invalid_argument("Switch accessed from wrong domain!")` 초당 수십 건.

## 변경

- **`eio_context`**: `set_switch` 시점에 root switch의 owner 도메인 id를 캡처(`current_sw_domain`)하고 `root_switch_on_current_domain : unit -> bool`을 노출. 결정론적 소유권 판별 — 선례의 반응형 string-match(`"Switch accessed from wrong domain"`)와 달리 문자열 분류기를 추가하지 않는다.
- **`keeper_board_attention_candidate`**: `start_async`가 비소유 도메인에서 **조용히 defer** — active claim을 해제하고 candidate를 Pending으로 두어 메인 도메인 경로(keeper turn / boot `resume_pending`)가 이후 시작하게 하며, `record_retryable_failure`를 **호출하지 않는다**.
- **test**: `root_switch_on_current_domain`이 owner(메인) 도메인에서 true, spawn된 worker 도메인에서 false임을 검증(정확히 `fork ~sw`가 실패하는 조건).

## 선례 정합

동일한 wrong-domain 방어가 코드베이스에 이미 존재하며, `start_async`만 빠져 있었다:
- `server_dashboard_http_runtime_info.ml` `fork_background_refresh_or_cancel` (fork 실패 시 도메인 학습 후 skip, 기록 안 함)
- `masc_http_client.ml` per-domain pool (PR #20476)
- `keeper_supervisor_launch.ml` keepalive body를 메인 도메인 고정 (RFC-0059)

이 PR은 새 패턴 도입이 아니라 기존 선례를 누락 지점에 적용하는 것이다.

## 로컬 검증 (`MASC_SKIP_PIN_CHECK=1`, 변경은 agent_sdk pin과 직교)

- `test_eio_context_fiber_local`: 7/7 (신규 `root switch domain ownership (#25015)` 포함)
- `test_keeper_board_attention_candidate`: 9/9 (기존 durable judgment + #25008 compaction 회귀 없음)

## Self-review

- **목표**: worker 도메인 fork 실패 → 원장 write 폭주 루프 제거.
- **변경 파일**: `eio_context.ml/.mli`, `keeper_board_attention_candidate.ml`, `test_eio_context_fiber_local.ml` (+70/-1).
- **미검증**: `start_async`를 worker 도메인까지 태우는 정확한 상위 caller(어느 projection)는 미완전 trace — 단 도메인 가드는 caller 무관하게 유효하므로 fix를 막지 않는다. `start_async`는 private + Eio 스케줄러 의존이라 end-to-end 동작 테스트 대신 결정론적 프리미티브(`root_switch_on_current_domain`)의 cross-domain 동작으로 증명.

Refs #25015.
