### PR TITLE
fix(keeper): make compaction accounting exact

### DIFF
--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -71,7 +71,7 @@ type compaction_rejection =
   | Plan_unavailable_or_invalid
   | Structurally_unchanged
   | Checkpoint_not_reduced
-  | Invalid_structural_evidence
+  | Invalid_structural_evidence of Keeper_compaction_evidence.decode_error
 
 let compaction_rejection_to_string = function
   | Runtime_identity_unavailable -> "runtime_identity_unavailable"
@@ -79,7 +79,9 @@ let compaction_rejection_to_string = function
   | Plan_unavailable_or_invalid -> "plan_unavailable_or_invalid"
   | Structurally_unchanged -> "structurally_unchanged"
   | Checkpoint_not_reduced -> "checkpoint_not_reduced"
-  | Invalid_structural_evidence -> "invalid_structural_evidence"
+  | Invalid_structural_evidence error ->
+    "invalid_structural_evidence:"
+    ^ Keeper_compaction_evidence.decode_error_to_string error
 ;;
 
 type compaction_decision =
@@ -285,8 +287,12 @@ let compact_for_request_typed
       ~message_count:before_messages;
     { context = ctx; decision = Rejected (trigger, reason); evidence = None }
   | Ok requested ->
+    let planned_message_count = List.length requested.messages in
     let messages, pair_repair_stats =
       Keeper_context_core.repair_broken_tool_call_pairs_with_stats requested.messages
+    in
+    let pair_repair_dropped_message_count =
+      planned_message_count - List.length messages
     in
     let compacted_ctx =
       sync_oas_context
@@ -323,12 +329,13 @@ let compact_for_request_typed
           ~after_message_count:after_messages
           ~summarized_message_count:requested.summarized_message_count
           ~dropped_message_count:requested.dropped_message_count
+          ~pair_repair_dropped_message_count
           ~before_tool_use_count
           ~after_tool_use_count
           ~before_tool_result_count
           ~after_tool_result_count
       with
-      | Error _ -> reject Invalid_structural_evidence
+      | Error error -> reject (Invalid_structural_evidence error)
       | Ok evidence ->
         let tool_use_sample_json =
           List.map
@@ -362,6 +369,8 @@ let compact_for_request_typed
                         , `Int pair_repair_stats.dropped_tool_uses )
                       ; ( "dropped_tool_results"
                         , `Int pair_repair_stats.dropped_tool_results )
+                      ; ( "dropped_messages"
+                        , `Int pair_repair_dropped_message_count )
                       ; "dropped_tool_use_samples", `List tool_use_sample_json
                       ; "dropped_tool_result_ids", `List tool_result_id_json
                       ] )

--- a/lib/keeper/keeper_compact_policy.mli
+++ b/lib/keeper/keeper_compact_policy.mli
@@ -9,7 +9,7 @@ type compaction_rejection =
   | Plan_unavailable_or_invalid
   | Structurally_unchanged
   | Checkpoint_not_reduced
-  | Invalid_structural_evidence
+  | Invalid_structural_evidence of Keeper_compaction_evidence.decode_error
 
 (** [Prepared] is structural only; [Applied] requires a durable save. *)
 type compaction_decision =

--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -385,6 +385,7 @@ let decision_public_allowlist =
     ; "before_checkpoint_bytes"; "after_checkpoint_bytes"
     ; "before_message_count"; "after_message_count"
     ; "summarized_message_count"; "dropped_message_count"
+    ; "pair_repair_dropped_message_count"
     ; "before_tool_use_count"; "after_tool_use_count"
     ; "before_tool_result_count"; "after_tool_result_count"
     ; "clock_refs"

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -102,7 +102,7 @@ let compaction_recovery_error_data ?dispatch_error error =
       Precondition_failed
     | Compaction_rejected Summarizer_unavailable
     | Compaction_rejected Plan_unavailable_or_invalid
-    | Compaction_rejected Invalid_structural_evidence
+    | Compaction_rejected (Invalid_structural_evidence _)
     | Compaction_evidence_missing
     | Unexpected_compaction_decision _ -> Internal_error
     | Checkpoint_superseded _ -> Conflict

--- a/lib/keeper_compaction_evidence/keeper_compaction_evidence.ml
+++ b/lib/keeper_compaction_evidence/keeper_compaction_evidence.ml
@@ -6,6 +6,7 @@ type t =
   ; after_message_count : int
   ; summarized_message_count : int
   ; dropped_message_count : int
+  ; pair_repair_dropped_message_count : int
   ; before_tool_use_count : int
   ; after_tool_use_count : int
   ; before_tool_result_count : int
@@ -19,6 +20,7 @@ type field =
   | After_message_count
   | Summarized_message_count
   | Dropped_message_count
+  | Pair_repair_dropped_message_count
   | Before_tool_use_count
   | After_tool_use_count
   | Before_tool_result_count
@@ -47,45 +49,109 @@ type decode_error =
       ; after_message_count : int
       ; summarized_message_count : int
       ; dropped_message_count : int
+      ; pair_repair_dropped_message_count : int
       }
   | No_messages_compacted
 
-let schema =
-  [ Before_checkpoint_bytes, "before_checkpoint_bytes"
-  ; After_checkpoint_bytes, "after_checkpoint_bytes"
-  ; Before_message_count, "before_message_count"
-  ; After_message_count, "after_message_count"
-  ; Summarized_message_count, "summarized_message_count"
-  ; Dropped_message_count, "dropped_message_count"
-  ; Before_tool_use_count, "before_tool_use_count"
-  ; After_tool_use_count, "after_tool_use_count"
-  ; Before_tool_result_count, "before_tool_result_count"
-  ; After_tool_result_count, "after_tool_result_count"
+let field_name = function
+  | Before_checkpoint_bytes -> "before_checkpoint_bytes"
+  | After_checkpoint_bytes -> "after_checkpoint_bytes"
+  | Before_message_count -> "before_message_count"
+  | After_message_count -> "after_message_count"
+  | Summarized_message_count -> "summarized_message_count"
+  | Dropped_message_count -> "dropped_message_count"
+  | Pair_repair_dropped_message_count -> "pair_repair_dropped_message_count"
+  | Before_tool_use_count -> "before_tool_use_count"
+  | After_tool_use_count -> "after_tool_use_count"
+  | Before_tool_result_count -> "before_tool_result_count"
+  | After_tool_result_count -> "after_tool_result_count"
+;;
+
+let all_fields =
+  [ Before_checkpoint_bytes
+  ; After_checkpoint_bytes
+  ; Before_message_count
+  ; After_message_count
+  ; Summarized_message_count
+  ; Dropped_message_count
+  ; Pair_repair_dropped_message_count
+  ; Before_tool_use_count
+  ; After_tool_use_count
+  ; Before_tool_result_count
+  ; After_tool_result_count
   ]
 ;;
 
-let field_name field = List.assoc field schema
-let known_field name = List.exists (fun (_, key) -> String.equal name key) schema
+let known_field name =
+  List.exists (fun field -> String.equal name (field_name field)) all_fields
+;;
+
+let field_error_to_string = function
+  | Missing -> "missing"
+  | Duplicate -> "duplicate"
+  | Expected_integer -> "expected_integer"
+  | Negative_integer -> "negative_integer"
+;;
+
+let measure_to_string = function
+  | Checkpoint_bytes -> "checkpoint_bytes"
+  | Messages -> "messages"
+  | Tool_uses -> "tool_uses"
+  | Tool_results -> "tool_results"
+;;
+
+let decode_error_to_string = function
+  | Expected_object -> "expected_object"
+  | Unknown_field name -> "unknown_field:" ^ name
+  | Invalid_field (field, error) ->
+    Printf.sprintf
+      "invalid_field:%s:%s"
+      (field_name field)
+      (field_error_to_string error)
+  | Empty_selected_runtime_id -> "empty_selected_runtime_id"
+  | Invalid_transition (measure, before, after) ->
+    Printf.sprintf
+      "invalid_transition:%s:%d:%d"
+      (measure_to_string measure)
+      before
+      after
+  | Invalid_message_accounting
+      { before_message_count
+      ; after_message_count
+      ; summarized_message_count
+      ; dropped_message_count
+      ; pair_repair_dropped_message_count
+      } ->
+    Printf.sprintf
+      "invalid_message_accounting:before=%d:after=%d:summarized=%d:dropped=%d:pair_repair_dropped=%d"
+      before_message_count
+      after_message_count
+      summarized_message_count
+      dropped_message_count
+      pair_repair_dropped_message_count
+  | No_messages_compacted -> "no_messages_compacted"
+;;
 
 let ( let* ) = Result.bind
 
-let message_accounting_is_possible
+let message_accounting_is_exact
       ~before_message_count
       ~after_message_count
       ~summarized_message_count
       ~dropped_message_count
+      ~pair_repair_dropped_message_count
   =
   summarized_message_count <= before_message_count
   && dropped_message_count <= before_message_count - summarized_message_count
   &&
-  if summarized_message_count = 0
-  then
-    after_message_count = before_message_count - dropped_message_count
-  else (
-    let maximum_after = before_message_count - dropped_message_count in
-    let minimum_after = maximum_after - summarized_message_count + 1 in
-    after_message_count >= minimum_after
-    && after_message_count <= maximum_after)
+  let after_plan =
+    before_message_count
+    - dropped_message_count
+    - summarized_message_count
+    + if summarized_message_count = 0 then 0 else 1
+  in
+  pair_repair_dropped_message_count <= after_plan
+  && after_message_count = after_plan - pair_repair_dropped_message_count
 ;;
 
 let decode_nonnegative_integer fields field =
@@ -109,6 +175,7 @@ let create
       ~after_message_count
       ~summarized_message_count
       ~dropped_message_count
+      ~pair_repair_dropped_message_count
       ~before_tool_use_count
       ~after_tool_use_count
       ~before_tool_result_count
@@ -121,6 +188,7 @@ let create
     ; After_message_count, after_message_count
     ; Summarized_message_count, summarized_message_count
     ; Dropped_message_count, dropped_message_count
+    ; Pair_repair_dropped_message_count, pair_repair_dropped_message_count
     ; Before_tool_use_count, before_tool_use_count
     ; After_tool_use_count, after_tool_use_count
     ; Before_tool_result_count, before_tool_result_count
@@ -158,11 +226,12 @@ let create
        then Error No_messages_compacted
        else if
          not
-           (message_accounting_is_possible
+           (message_accounting_is_exact
               ~before_message_count
               ~after_message_count
               ~summarized_message_count
-              ~dropped_message_count)
+              ~dropped_message_count
+              ~pair_repair_dropped_message_count)
        then
          Error
            (Invalid_message_accounting
@@ -170,6 +239,7 @@ let create
               ; after_message_count
               ; summarized_message_count
               ; dropped_message_count
+              ; pair_repair_dropped_message_count
               })
        else
          Ok
@@ -180,6 +250,7 @@ let create
            ; after_message_count
            ; summarized_message_count
            ; dropped_message_count
+           ; pair_repair_dropped_message_count
            ; before_tool_use_count
            ; after_tool_use_count
            ; before_tool_result_count
@@ -205,6 +276,9 @@ let of_json ~selected_runtime_id = function
     let* after_message_count = integer After_message_count in
     let* summarized_message_count = integer Summarized_message_count in
     let* dropped_message_count = integer Dropped_message_count in
+    let* pair_repair_dropped_message_count =
+      integer Pair_repair_dropped_message_count
+    in
     let* before_tool_use_count = integer Before_tool_use_count in
     let* after_tool_use_count = integer After_tool_use_count in
     let* before_tool_result_count = integer Before_tool_result_count in
@@ -217,6 +291,7 @@ let of_json ~selected_runtime_id = function
       ~after_message_count
       ~summarized_message_count
       ~dropped_message_count
+      ~pair_repair_dropped_message_count
       ~before_tool_use_count
       ~after_tool_use_count
       ~before_tool_result_count
@@ -232,6 +307,8 @@ let to_json evidence =
     ; "after_message_count", `Int evidence.after_message_count
     ; "summarized_message_count", `Int evidence.summarized_message_count
     ; "dropped_message_count", `Int evidence.dropped_message_count
+    ; ( "pair_repair_dropped_message_count"
+      , `Int evidence.pair_repair_dropped_message_count )
     ; "before_tool_use_count", `Int evidence.before_tool_use_count
     ; "after_tool_use_count", `Int evidence.after_tool_use_count
     ; "before_tool_result_count", `Int evidence.before_tool_result_count

--- a/lib/keeper_compaction_evidence/keeper_compaction_evidence.mli
+++ b/lib/keeper_compaction_evidence/keeper_compaction_evidence.mli
@@ -8,6 +8,7 @@ type t =
   ; after_message_count : int
   ; summarized_message_count : int
   ; dropped_message_count : int
+  ; pair_repair_dropped_message_count : int
   ; before_tool_use_count : int
   ; after_tool_use_count : int
   ; before_tool_result_count : int
@@ -21,6 +22,7 @@ type field =
   | After_message_count
   | Summarized_message_count
   | Dropped_message_count
+  | Pair_repair_dropped_message_count
   | Before_tool_use_count
   | After_tool_use_count
   | Before_tool_result_count
@@ -49,8 +51,11 @@ type decode_error =
       ; after_message_count : int
       ; summarized_message_count : int
       ; dropped_message_count : int
+      ; pair_repair_dropped_message_count : int
       }
   | No_messages_compacted
+
+val decode_error_to_string : decode_error -> string
 
 val create
   :  selected_runtime_id:string option
@@ -60,13 +65,17 @@ val create
   -> after_message_count:int
   -> summarized_message_count:int
   -> dropped_message_count:int
+  -> pair_repair_dropped_message_count:int
   -> before_tool_use_count:int
   -> after_tool_use_count:int
   -> before_tool_result_count:int
   -> after_tool_result_count:int
   -> (t, decode_error) result
 (** Construct evidence through the same closed validation boundary used by
-    persisted JSON restoration. *)
+    persisted JSON restoration. Message accounting is exact:
+    [after = before - dropped - summarized + summary_message
+     - pair_repair_dropped], where [summary_message] is one exactly when
+    [summarized] is non-zero. *)
 
 val to_json : t -> Yojson.Safe.t
 (** Structural observation projection of the exact measured counts.

--- a/test/keeper_compaction_evidence/test_keeper_compaction_evidence.ml
+++ b/test/keeper_compaction_evidence/test_keeper_compaction_evidence.ml
@@ -7,6 +7,7 @@ let evidence : Keeper_compaction_evidence.t =
     ~after_message_count:6
     ~summarized_message_count:6
     ~dropped_message_count:1
+    ~pair_repair_dropped_message_count:0
     ~before_tool_use_count:3
     ~after_tool_use_count:1
     ~before_tool_result_count:3
@@ -29,6 +30,13 @@ let replace name value json =
        (fields json))
 ;;
 
+let remove name json =
+  `Assoc
+    (List.filter
+       (fun (key, _) -> not (String.equal key name))
+       (fields json))
+;;
+
 let test_projection_and_roundtrip () =
   let expected =
     `Assoc
@@ -38,6 +46,7 @@ let test_projection_and_roundtrip () =
       ; "after_message_count", `Int 6
       ; "summarized_message_count", `Int 6
       ; "dropped_message_count", `Int 1
+      ; "pair_repair_dropped_message_count", `Int 0
       ; "before_tool_use_count", `Int 3
       ; "after_tool_use_count", `Int 1
       ; "before_tool_result_count", `Int 3
@@ -76,6 +85,12 @@ let test_rejections () =
   let impossible_accounting =
     replace "summarized_message_count" (`Int 999) canonical
   in
+  let inexact_after = replace "after_message_count" (`Int 7) canonical in
+  let excessive_pair_repair =
+    canonical
+    |> replace "after_message_count" (`Int 0)
+    |> replace "pair_repair_dropped_message_count" (`Int 7)
+  in
   List.iter
     (fun (label, runtime_id, expected, json) ->
        check label runtime_id expected json)
@@ -93,6 +108,30 @@ let test_rejections () =
       , evidence.selected_runtime_id
       , Invalid_field (After_message_count, Duplicate)
       , duplicate )
+    ; ( "unknown field"
+      , evidence.selected_runtime_id
+      , Unknown_field "retired_counter"
+      , `Assoc (("retired_counter", `Int 1) :: fields canonical) )
+    ; ( "missing field"
+      , evidence.selected_runtime_id
+      , Invalid_field (Before_tool_use_count, Missing)
+      , remove "before_tool_use_count" canonical )
+    ; ( "non-integer field"
+      , evidence.selected_runtime_id
+      , Invalid_field (Before_tool_result_count, Expected_integer)
+      , replace "before_tool_result_count" (`String "3") canonical )
+    ; ( "message count increase"
+      , evidence.selected_runtime_id
+      , Invalid_transition (Messages, 12, 13)
+      , replace "after_message_count" (`Int 13) canonical )
+    ; ( "tool use count increase"
+      , evidence.selected_runtime_id
+      , Invalid_transition (Tool_uses, 3, 4)
+      , replace "after_tool_use_count" (`Int 4) canonical )
+    ; ( "tool result count increase"
+      , evidence.selected_runtime_id
+      , Invalid_transition (Tool_results, 3, 4)
+      , replace "after_tool_result_count" (`Int 4) canonical )
     ; ( "impossible message accounting"
       , evidence.selected_runtime_id
       , Invalid_message_accounting
@@ -100,9 +139,57 @@ let test_rejections () =
           ; after_message_count = 6
           ; summarized_message_count = 999
           ; dropped_message_count = 1
+          ; pair_repair_dropped_message_count = 0
           }
       , impossible_accounting )
+    ; ( "inexact after count"
+      , evidence.selected_runtime_id
+      , Invalid_message_accounting
+          { before_message_count = 12
+          ; after_message_count = 7
+          ; summarized_message_count = 6
+          ; dropped_message_count = 1
+          ; pair_repair_dropped_message_count = 0
+          }
+      , inexact_after )
+    ; ( "excessive pair repair count"
+      , evidence.selected_runtime_id
+      , Invalid_message_accounting
+          { before_message_count = 12
+          ; after_message_count = 0
+          ; summarized_message_count = 6
+          ; dropped_message_count = 1
+          ; pair_repair_dropped_message_count = 7
+          }
+      , excessive_pair_repair )
     ]
+;;
+
+let test_exact_pair_repair_accounting () =
+  match
+    Keeper_compaction_evidence.create
+      ~selected_runtime_id:evidence.selected_runtime_id
+      ~before_checkpoint_bytes:4096
+      ~after_checkpoint_bytes:1024
+      ~before_message_count:12
+      ~after_message_count:4
+      ~summarized_message_count:6
+      ~dropped_message_count:1
+      ~pair_repair_dropped_message_count:2
+      ~before_tool_use_count:3
+      ~after_tool_use_count:1
+      ~before_tool_result_count:3
+      ~after_tool_result_count:1
+  with
+  | Ok exact ->
+    Alcotest.(check int)
+      "pair-repair message drops preserved"
+      2
+      exact.pair_repair_dropped_message_count
+  | Error error ->
+    Alcotest.failf
+      "exact pair-repair accounting rejected: %s"
+      (Keeper_compaction_evidence.decode_error_to_string error)
 ;;
 
 let () =
@@ -114,5 +201,9 @@ let () =
             `Quick
             test_projection_and_roundtrip
         ; Alcotest.test_case "closed rejections" `Quick test_rejections
+        ; Alcotest.test_case
+            "exact pair-repair accounting"
+            `Quick
+            test_exact_pair_repair_accounting
         ] )
     ]


### PR DESCRIPTION
## What changed

- persist the exact number of messages removed by post-plan tool-pair repair
- replace range-based message accounting with one exact structural equation
- preserve the concrete `Keeper_compaction_evidence.decode_error` in compaction rejection state and logs
- make field-to-wire-name mapping exhaustive instead of `List.assoc`-backed
- extend the focused table test for malformed fields, transition increases, exact accounting, and valid pair-repair drops

## Why

#24907 was merged while its latest adversarial review still identified a P1. The LLM compaction plan replaces all summarized messages with exactly one summary message, then tool-pair repair may remove additional empty structural messages. The merged validator only checked a range, so it accepted impossible `after_message_count` values and could reject valid repaired output. The policy also collapsed every constructor error to an unparameterized `Invalid_structural_evidence`, losing the typed cause.

The new invariant is exact:

`after = before - dropped - summarized + summary_message(0|1) - pair_repair_dropped`

## Impact

Impossible persisted evidence now fails closed with its precise typed reason. Valid pair-repair reductions remain representable and observable. No numeric heuristic, silent repair, or string classifier is introduced.

## Validation

- `ocamlc -stop-after parsing` on all changed OCaml sources: pass
- `ocamlformat --check` on all changed OCaml sources: pass
- `git diff --check`: pass
- focused Dune build was not started because the repo wrapper detected another live bare `dune build .`; no lock bypass was used
- full build/test authority: PR CI

Follow-up to merged #24907.
