### PR TITLE
fix(board): flusher fork wrong-domain 가드 (root-switch fork 감사 후속, #25015)

### DIFF
--- a/lib/board/board_dispatch.ml
+++ b/lib/board/board_dispatch.ml
@@ -189,6 +189,16 @@ let start_flusher_actor ~sw store =
 let ensure_flusher_actor store =
   match Eio_context.get_switch_opt () with
   | None -> ()
+  | Some _ when not (Eio_context.root_switch_on_current_domain ()) ->
+      (* The flusher forks a daemon on the server root switch (get_switch_opt's
+         atomic fallback outside a turn). Eio.Fiber.fork_daemon ~sw is only legal
+         on the switch's owning (main) domain, but ensure_flusher_actor is
+         reachable from Domain_pool worker domains (board/dashboard projections).
+         Defer on a non-owning domain: the flusher is a single CAS-guarded daemon
+         started on the main domain at boot (mcp_server init_jsonl), so skipping
+         here starts nothing twice and loses nothing. Mirrors the
+         Keeper_board_attention_candidate.start_async guard (#25015). *)
+      ()
   | Some sw ->
       let rec loop attempts_left =
         let current = Atomic.get backend_state in


### PR DESCRIPTION
## 목적

`Board_dispatch.ensure_flusher_actor`가 worker 도메인에서 root switch에 flusher daemon을 fork하려다 wrong-domain으로 크래시할 수 있는 잠재 결함에, #25033이 도입한 동일 predicate(`Eio_context.root_switch_on_current_domain`) 가드를 적용한다. root-switch fork 클래스 전역 감사(#25015)의 후속.

## 배경 (코드베이스 전역 감사)

#25033(merged)로 `start_async`의 wrong-domain fork 폭주를 고친 뒤, **Eio root-switch fork 사이트 전역**을 감사했다(canon은 공식 문서 근거).

- **Eio README, Multicore Support**: "Most Eio concurrency primitives (fibers, switches, basic conditions) are **not safe to share between domains**." 도메인 간 통신은 Stream/Promise 권장.
- **OCaml 5.4 Domain**: `(Domain.self():>int)`는 프로그램 전체에서 재사용 안 되는 unique id; `self_index`는 종료 후 재사용됨 → 지속 정체성엔 전자.
- **OCaml Memory model**: Atomic 쓰기는 도메인 간 happens-before/가시성 확립; 공유 plain `ref`는 data race.

감사 결과(3 클래스):
- domain-id 재사용, cross-domain state/mutex(poison class 포함): **위반 0, 이미 일관 적용**.
- root-switch fork: active crash 위반 0. worker-reachable **무가드 fork는 2곳** — `start_async`(#25033에서 수정, 실제 크래시하던 유일 사이트)와 **본 PR의 `ensure_flusher_actor`**(CAS-once + boot-order로만 가려져 있던 잠재 결함).

## 변경

`ensure_flusher_actor`가 비소유 도메인에서 `Eio_context.root_switch_on_current_domain ()`로 판별해 flusher fork를 **defer**(release 없이 `()`). flusher는 main 도메인 boot(`mcp_server init_jsonl`)에서 CAS-once로 시작되는 단일 daemon이라 worker 도메인에서 skip해도 이중 시작·유실이 없다. `start_async` 가드와 동형.

## 검증

- board lib 컴파일 통과(새 main base, `MASC_SKIP_PIN_CHECK=1`).
- `test_board_dispatch`: flusher 관련 케이스(votes: "vote persisted by flusher actor", "flusher start retries forced CAS conflicts", "flusher start backoff") 통과 = 가드가 정상 경로를 막지 않음.
- **선재(pre-existing) 실패 1건**: `posts/12 "dedup hit does not fan out"`. **반사실 확인**으로 본 변경 없이도 실패 → 이 PR과 무관(별도 이슈로 트리아지 예정).

## 이 PR 범위 밖 (감사 후속 — 별도 진행)

- `keeper_msg_async.ml` fork(background_sw=root): worker 도메인 도달 시 skip은 **메시지 유실**이라 부적절. RFC-0059 main-domain invariant **문서화/assert** 권고(behavioral 가드 금지). correctness-critical → 완전 검증 후 별도 PR.
- 가드 idiom 3종(proactive / reactive `Invalid_argument` catch / `background_refresh_unavailable_domains`) 통일: `Eio_context`에 canonical combinator 추출 리팩터(server/dashboard/operator/keeper 다중 파일).
- `validation.last_rejection_time` `ref`→`float Atomic.t`(Atomic 형제와 일관).

Refs #25015. Follows #25033.
