### PR TITLE
fix(keeper): replace Board_unavailable exception with typed disposition result

### DIFF
--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -28,6 +28,48 @@ let pending_board_event_of_stimulus ~meta_after_triage stim =
     stim
 ;;
 
+(* Board-unavailable-result: the intake layer is where the poison/transient
+   distinction is acted on (Keeper_world_observation only reports the read
+   failure). Both dispositions return [] for this turn — the leased stimulus
+   is treated as consumed either way; see [keeper_heartbeat_loop.ml]'s
+   settlement path, which acks the claimed lease based on the turn outcome,
+   not on whether any one board rendering succeeded. Permanent unavailability
+   (the dominant real cause, e.g. a swept post) must never resurface, so
+   dropping it is the fix. Transient unavailability is logged distinctly so
+   operators can tell the two apart, but — unlike the cursor-based scan path
+   in [Keeper_world_observation.collect_board_events], which can locally
+   retain its cursor — this queued-stimulus path has no per-stimulus
+   requeue lever below the whole-lease Ack/Requeue decision, so a genuine
+   retry for this one stimulus is not wired here. *)
+let pending_board_events_of_stimulus_result ~meta_after_triage stim =
+  match pending_board_event_of_stimulus ~meta_after_triage stim with
+  | Ok events_opt -> Option.to_list events_opt
+  | Error (unavailable : Keeper_world_observation_board_signal.board_unavailable) ->
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string ObservationQueryFailures)
+      ~labels:
+        [ ( "operation"
+          , Runtime_observation_query_operation.(to_label Board_stimulus_intake) )
+        ]
+      ();
+    (match Keeper_world_observation_board_signal.disposition_of_unavailable unavailable with
+     | Keeper_world_observation_board_signal.Permanent ->
+       Log.Keeper.warn
+         "stimulus intake: board read permanently unavailable, consuming stimulus \
+          without retry stimulus_id=%s keeper=%s: %s"
+         stim.Keeper_event_queue.post_id
+         meta_after_triage.name
+         (Keeper_world_observation_board_signal.unavailable_to_string unavailable)
+     | Keeper_world_observation_board_signal.Transient ->
+       Log.Keeper.warn
+         "stimulus intake: board read transiently unavailable, dropping this turn's \
+          rendering stimulus_id=%s keeper=%s: %s"
+         stim.Keeper_event_queue.post_id
+         meta_after_triage.name
+         (Keeper_world_observation_board_signal.unavailable_to_string unavailable));
+    []
+;;
+
 let record_event_queue_stimulus_reaction
       ~(ctx : _ context)
       ~keeper_name
@@ -127,7 +169,7 @@ let consume_single_heartbeat_stimulus
     meta_after_triage.name;
   match stim.payload with
   | Keeper_event_queue.Board_signal _ | Keeper_event_queue.Board_attention _ ->
-    pending_board_event_of_stimulus ~meta_after_triage stim |> Option.to_list
+    pending_board_events_of_stimulus_result ~meta_after_triage stim
   | Keeper_event_queue.Fusion_completed c ->
     (* RFC-0266: an async fusion deliberation finished and woke this keeper.
        Surface the resolved answer as a pending_board_event so this turn acts
@@ -138,7 +180,7 @@ let consume_single_heartbeat_stimulus
       c.run_id
       c.ok
       meta_after_triage.name;
-    pending_board_event_of_stimulus ~meta_after_triage stim |> Option.to_list
+    pending_board_events_of_stimulus_result ~meta_after_triage stim
   | Keeper_event_queue.Bg_completed c ->
     (* RFC-0290: a background job finished and woke this keeper. Surface the
        outcome as a pending_board_event so the turn acts on it. Returning []
@@ -151,14 +193,14 @@ let consume_single_heartbeat_stimulus
        | Keeper_event_queue.Bg_ok _ -> true
        | Keeper_event_queue.Bg_failed _ -> false)
       meta_after_triage.name;
-    pending_board_event_of_stimulus ~meta_after_triage stim |> Option.to_list
+    pending_board_events_of_stimulus_result ~meta_after_triage stim
   | Keeper_event_queue.Schedule_due sw ->
     Log.Keeper.info
       "turn entry: scheduled wake delivered schedule_id=%s due_at=%.3f (keeper=%s)"
       sw.schedule_id
       sw.due_at
       meta_after_triage.name;
-    pending_board_event_of_stimulus ~meta_after_triage stim |> Option.to_list
+    pending_board_events_of_stimulus_result ~meta_after_triage stim
   | Keeper_event_queue.Goal_assigned ga ->
     (* RFC-0315 P3 W0: a newly assigned standing objective is actionable
        work. Promote it to a pending observation so the assignment turn does
@@ -168,7 +210,7 @@ let consume_single_heartbeat_stimulus
       ga.ga_goal_id
       ga.ga_assigned_by
       meta_after_triage.name;
-    pending_board_event_of_stimulus ~meta_after_triage stim |> Option.to_list
+    pending_board_events_of_stimulus_result ~meta_after_triage stim
   | Keeper_event_queue.Failure_judgment fj ->
     (* RFC-0313 W2: a deterministic turn failure awaits an LLM-boundary
        verdict. Promote it to a pending observation so the judgment turn does
@@ -180,7 +222,7 @@ let consume_single_heartbeat_stimulus
       (Keeper_runtime_failure_route.judgment_class_label fj.fj_judgment)
       (Keeper_runtime_failure_route.judgment_provenance_label fj.fj_provenance)
       meta_after_triage.name;
-    pending_board_event_of_stimulus ~meta_after_triage stim |> Option.to_list
+    pending_board_events_of_stimulus_result ~meta_after_triage stim
   | Keeper_event_queue.Manual_compaction_requested ->
     Log.Keeper.info
       "turn entry: manual compaction request delivered (keeper=%s)"
@@ -255,7 +297,7 @@ let consume_board_stimulus_batch ~meta_after_triage batch =
       "turn digest: coalesced %d board signals into one turn (keeper=%s)"
       batch_len
       meta_after_triage.name;
-  List.filter_map
+  List.concat_map
     (fun (stim : Keeper_event_queue.stimulus) ->
        Otel_metric_store.inc_counter
          Keeper_metrics.(to_string StimulusConsumed)
@@ -267,7 +309,7 @@ let consume_board_stimulus_batch ~meta_after_triage batch =
          stim.post_id
          (stimulus_urgency_to_string stim.urgency)
          meta_after_triage.name;
-       pending_board_event_of_stimulus ~meta_after_triage stim)
+       pending_board_events_of_stimulus_result ~meta_after_triage stim)
     batch
 ;;
 

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.mli
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.mli
@@ -15,11 +15,27 @@ val stimulus_urgency_to_string : Keeper_event_queue.urgency -> string
 
 (** [pending_board_event_of_stimulus ~meta_after_triage stim] wraps a
     stimulus into a pending board event, threading the keeper meta's
-    continuity summary. *)
+    continuity summary. [Error unavailable] reports a failed board read
+    (board-unavailable-result); this function only reports, it does not
+    decide disposition — see [pending_board_events_of_stimulus_result] for
+    the consuming layer's classify + drop/retain behavior. *)
 val pending_board_event_of_stimulus
   :  meta_after_triage:keeper_meta
   -> Keeper_event_queue.stimulus
-  -> Keeper_world_observation.pending_board_event option
+  -> (Keeper_world_observation.pending_board_event option, Keeper_world_observation_board_signal.board_unavailable) result
+
+(** [pending_board_events_of_stimulus_result ~meta_after_triage stim] renders
+    [stim] into zero-or-one pending board events. On [Error unavailable] it
+    classifies the failure via
+    {!Keeper_world_observation_board_signal.disposition_of_unavailable},
+    logs and counts it, and returns [] — the stimulus is treated as consumed
+    for this turn either way. See the [.ml] for why a queued stimulus has no
+    per-item requeue lever distinct from the whole-lease Ack/Requeue
+    decision. *)
+val pending_board_events_of_stimulus_result
+  :  meta_after_triage:keeper_meta
+  -> Keeper_event_queue.stimulus
+  -> Keeper_world_observation.pending_board_event list
 
 (** [record_event_queue_stimulus_turn_started ~ctx ~keeper_name stim] writes
     a generic [Turn_started] reaction for an event-queue stimulus after the

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -330,62 +330,61 @@ let pending_board_event_of_board_signal
       ~(meta : keeper_meta)
       ~arrived_at:(_ : float)
       (signal : Board_dispatch.board_signal)
-  : pending_board_event
+  : (pending_board_event, Board_signal.board_unavailable) result
   =
   let self_ids = self_ids meta in
   let matched = board_signal_match ~meta ~signal in
-  let post_snapshot =
-    match Board_dispatch.get_post ~post_id:signal.post_id with
-    | Ok post -> post
-    | Error error ->
-      Board_signal.raise_unavailable
-        { operation = Board_signal.Get_post; post_id = signal.post_id; error }
-  in
-  let title, preview, hearth, post_kind, updated_at =
-    let post : Board.post = post_snapshot in
-    ( post.title
-    , short_preview ~max_len:80 post.content
-    , post.hearth
-    , post.post_kind
-    , post.updated_at )
-  in
-  let event_kind = pending_board_event_kind_of_signal signal in
-  let self_commented, new_external_since, latest_external_author, latest_external_preview =
-    match signal.kind with
-    | Board_dispatch.Board_post_created -> false, 0, None, None
-    | Board_dispatch.Board_comment_added ->
-      (match check_self_comment_status ~self_ids ~post_id:signal.post_id with
-       | Board_signal.Unavailable unavailable ->
-         Board_signal.raise_unavailable unavailable
-       | Board_signal.Available (`New_external (count, author, preview)) ->
-         true, count, Some author, Some preview
-       | Board_signal.Available `No_new_external ->
-         true, 0, Some signal.author, Some (short_preview ~max_len:60 signal.content)
-       | Board_signal.Available `Never ->
-         false, 1, Some signal.author, Some (short_preview ~max_len:60 signal.content))
-    | Board_dispatch.Board_reaction_changed _ ->
-      (match check_self_comment_status ~self_ids ~post_id:signal.post_id with
-       | Board_signal.Unavailable unavailable ->
-         Board_signal.raise_unavailable unavailable
-       | Board_signal.Available `Never -> false, 0, None, None
-       | Board_signal.Available (`No_new_external | `New_external _) ->
-         true, 0, None, None)
-  in
-  { event_kind
-  ; post_id = signal.post_id
-  ; author = signal.author
-  ; title
-  ; preview
-  ; hearth
-  ; post_kind
-  ; updated_at
-  ; explicit_mention = matched.explicit_mention
-  ; matched_targets = matched.matched_targets
-  ; self_commented
-  ; new_external_since
-  ; latest_external_author
-  ; latest_external_preview
-  }
+  match Board_dispatch.get_post ~post_id:signal.post_id with
+  | Error error ->
+    Error { Board_signal.operation = Board_signal.Get_post; post_id = signal.post_id; error }
+  | Ok post_snapshot ->
+    let title, preview, hearth, post_kind, updated_at =
+      let post : Board.post = post_snapshot in
+      ( post.title
+      , short_preview ~max_len:80 post.content
+      , post.hearth
+      , post.post_kind
+      , post.updated_at )
+    in
+    let event_kind = pending_board_event_kind_of_signal signal in
+    let comment_derived =
+      match signal.kind with
+      | Board_dispatch.Board_post_created -> Ok (false, 0, None, None)
+      | Board_dispatch.Board_comment_added ->
+        (match check_self_comment_status ~self_ids ~post_id:signal.post_id with
+         | Board_signal.Unavailable unavailable -> Error unavailable
+         | Board_signal.Available (`New_external (count, author, preview)) ->
+           Ok (true, count, Some author, Some preview)
+         | Board_signal.Available `No_new_external ->
+           Ok (true, 0, Some signal.author, Some (short_preview ~max_len:60 signal.content))
+         | Board_signal.Available `Never ->
+           Ok (false, 1, Some signal.author, Some (short_preview ~max_len:60 signal.content)))
+      | Board_dispatch.Board_reaction_changed _ ->
+        (match check_self_comment_status ~self_ids ~post_id:signal.post_id with
+         | Board_signal.Unavailable unavailable -> Error unavailable
+         | Board_signal.Available `Never -> Ok (false, 0, None, None)
+         | Board_signal.Available (`No_new_external | `New_external _) ->
+           Ok (true, 0, None, None))
+    in
+    (match comment_derived with
+     | Error unavailable -> Error unavailable
+     | Ok (self_commented, new_external_since, latest_external_author, latest_external_preview) ->
+       Ok
+         { event_kind
+         ; post_id = signal.post_id
+         ; author = signal.author
+         ; title
+         ; preview
+         ; hearth
+         ; post_kind
+         ; updated_at
+         ; explicit_mention = matched.explicit_mention
+         ; matched_targets = matched.matched_targets
+         ; self_commented
+         ; new_external_since
+         ; latest_external_author
+         ; latest_external_preview
+         })
 ;;
 
 (* RFC-0266: fusion answers are the deliberation result the keeper requested,
@@ -671,17 +670,19 @@ let pending_board_event_of_goal_assignment
 let pending_board_event_of_stimulus
       ~(meta : keeper_meta)
   (stimulus : Keeper_event_queue.stimulus)
-  : pending_board_event option
+  : (pending_board_event option, Board_signal.board_unavailable) result
   =
   match stimulus.payload with
   | Keeper_event_queue.Board_signal bs ->
-    Some
+    Result.map
+      (fun ev -> Some ev)
       (pending_board_event_of_board_signal
          ~meta
          ~arrived_at:stimulus.arrived_at
          (Board_signal.board_signal_of_board_stimulus ~post_id:stimulus.post_id bs))
   | Keeper_event_queue.Board_attention attention ->
-    Some
+    Result.map
+      (fun ev -> Some ev)
       (pending_board_event_of_board_signal
          ~meta
          ~arrived_at:stimulus.arrived_at
@@ -689,25 +690,30 @@ let pending_board_event_of_stimulus
             ~post_id:stimulus.post_id
             attention.signal))
   | Keeper_event_queue.Fusion_completed fc ->
-    Some (pending_board_event_of_fusion_completion ~meta ~arrived_at:stimulus.arrived_at fc)
+    Ok (Some (pending_board_event_of_fusion_completion ~meta ~arrived_at:stimulus.arrived_at fc))
   | Keeper_event_queue.Bg_completed c ->
-    Some
-      (pending_board_event_of_bg_job_completion ~meta ~arrived_at:stimulus.arrived_at c)
+    Ok
+      (Some
+         (pending_board_event_of_bg_job_completion ~meta ~arrived_at:stimulus.arrived_at c))
   | Keeper_event_queue.Schedule_due sw ->
-    Some
-      (pending_board_event_of_scheduled_wake
-         ~meta
-         ~post_id:stimulus.post_id
-         ~arrived_at:stimulus.arrived_at
-         sw)
+    Ok
+      (Some
+         (pending_board_event_of_scheduled_wake
+            ~meta
+            ~post_id:stimulus.post_id
+            ~arrived_at:stimulus.arrived_at
+            sw))
   | Keeper_event_queue.Failure_judgment fj ->
-    Some (pending_board_event_of_failure_judgment ~meta ~arrived_at:stimulus.arrived_at fj)
+    Ok
+      (Some
+         (pending_board_event_of_failure_judgment ~meta ~arrived_at:stimulus.arrived_at fj))
   | Keeper_event_queue.Goal_assigned ga ->
-    Some
-      (pending_board_event_of_goal_assignment
-         ~meta
-         ~arrived_at:stimulus.arrived_at
-         ga)
+    Ok
+      (Some
+         (pending_board_event_of_goal_assignment
+            ~meta
+            ~arrived_at:stimulus.arrived_at
+            ga))
   | Keeper_event_queue.Bootstrap
   | Keeper_event_queue.Connector_attention _
   | Keeper_event_queue.Hitl_resolved _
@@ -716,7 +722,7 @@ let pending_board_event_of_stimulus
        fires via the trigger itself; [Hitl_resolved] carries no observation to
        inject — the keeper resumes on its own state once the approval is gone
        from the queue. *)
-    None
+    Ok None
 ;;
 
 (** Collect recent board activity using cursor-based tracking.
@@ -799,6 +805,39 @@ let collect_board_events_with_cursor_policy
               (board_signal_match ~meta ~signal).explicit_mention)
            recent)
     in
+    (* Board-unavailable-result: classify + log + count a failed read
+       encountered mid-scan, without raising. [Permanent] means this one post
+       can never resolve (e.g. swept from the store) — the caller skips it
+       and keeps scanning. [Transient] means the caller stops scanning here
+       and returns what it already has, so the cursor is not advanced past
+       the blocked post and the same post is retried next cycle (preserves
+       the pre-existing "retained cursor" semantics, now via Result instead
+       of exception + re-raise). *)
+    let log_and_count_unavailable ~context (unavailable : Board_signal.board_unavailable) =
+      let disposition = Board_signal.disposition_of_unavailable unavailable in
+      Otel_metric_store.inc_counter
+        Keeper_metrics.(to_string ObservationQueryFailures)
+        ~labels:[ ("operation", Runtime_observation_query_operation.(to_label Board_events)) ]
+        ();
+      (match disposition with
+       | Board_signal.Permanent ->
+         Log.Keeper.warn
+           "board event collection (%s): permanently unavailable, skipping post_id=%s \
+            keeper=%s: %s"
+           context
+           unavailable.Board_signal.post_id
+           meta.name
+           (Board_signal.unavailable_to_string unavailable)
+       | Board_signal.Transient ->
+         Log.Keeper.warn
+           "board event collection (%s): retained cursor (transient unavailable) \
+            post_id=%s keeper=%s: %s"
+           context
+           unavailable.Board_signal.post_id
+           meta.name
+           (Board_signal.unavailable_to_string unavailable));
+      disposition
+    in
     let rec consume_posts last_cursor acc = function
       | [] -> List.rev acc, last_cursor
       | (p : Board.post) :: rest ->
@@ -807,7 +846,9 @@ let collect_board_events_with_cursor_policy
         let comment_status = check_self_comment_status ~self_ids ~post_id in
         (match comment_status with
          | Board_signal.Unavailable unavailable ->
-           Board_signal.raise_unavailable unavailable
+           (match log_and_count_unavailable ~context:"comment status" unavailable with
+            | Board_signal.Permanent -> consume_posts (Some next_cursor) acc rest
+            | Board_signal.Transient -> List.rev acc, last_cursor)
          | Board_signal.Available `No_new_external ->
            Log.Keeper.debug
              "board dedup: skipping post_id=%s (no new external since my comment)"
@@ -827,26 +868,28 @@ let collect_board_events_with_cursor_policy
            let matched = board_signal_match ~meta ~signal in
            if not matched.explicit_mention
            then (
-             (match
-                Keeper_board_attention_candidate.of_board_signal
-                  ~meta
-                  ~recorded_at:(Time_compat.now ())
-                  signal
-              with
-              | Board_signal.Unavailable unavailable ->
-                Board_signal.raise_unavailable unavailable
-              | Board_signal.Available candidate ->
-                (match
-                   Keeper_board_attention_candidate.record_and_start
-                     ~base_path
-                     candidate
-                 with
-                 | Ok _ -> ()
-                 | Error detail ->
-                   raise
-                     (Keeper_board_attention_candidate.Candidate_unavailable
-                        detail)));
-             consume_posts (Some next_cursor) acc rest)
+             match
+               Keeper_board_attention_candidate.of_board_signal
+                 ~meta
+                 ~recorded_at:(Time_compat.now ())
+                 signal
+             with
+             | Board_signal.Unavailable unavailable ->
+               (match log_and_count_unavailable ~context:"candidate" unavailable with
+                | Board_signal.Permanent -> consume_posts (Some next_cursor) acc rest
+                | Board_signal.Transient -> List.rev acc, last_cursor)
+             | Board_signal.Available candidate ->
+               (match
+                  Keeper_board_attention_candidate.record_and_start
+                    ~base_path
+                    candidate
+                with
+                | Ok _ -> ()
+                | Error detail ->
+                  raise
+                    (Keeper_board_attention_candidate.Candidate_unavailable
+                       detail));
+               consume_posts (Some next_cursor) acc rest)
            else
              consume_posts
                
@@ -943,18 +986,6 @@ let collect_board_events_with_cursor_policy
     final_events, new_count, mention_count
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
-  | Board_signal.Board_unavailable unavailable as exn ->
-    Otel_metric_store.inc_counter
-      Keeper_metrics.(to_string ObservationQueryFailures)
-      ~labels:
-        [ ( "operation"
-          , Runtime_observation_query_operation.(to_label Board_events) )
-        ]
-      ();
-    Log.Keeper.warn
-      "board event collection retained cursor: %s"
-      (Board_signal.unavailable_to_string unavailable);
-    raise exn
   | Keeper_board_attention_candidate.Candidate_unavailable detail as exn ->
     Otel_metric_store.inc_counter
       Keeper_metrics.(to_string ObservationQueryFailures)

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -280,11 +280,16 @@ val apply_failure_judgment_guidance :
 (** Convert a queued Event Layer stimulus back into structured board activity
     for the next keeper prompt. [Board_signal], [Fusion_completed] (RFC-0266),
     [Bg_completed] (RFC-0290), and [Schedule_due] produce [Some];
-    [Bootstrap] returns [None] (no prompt injection). *)
+    [Bootstrap] returns [None] (no prompt injection).
+    [Error unavailable] means the underlying board read for [Board_signal] /
+    [Board_attention] failed (board-unavailable-result). Callers classify via
+    {!Keeper_world_observation_board_signal.disposition_of_unavailable} and
+    decide whether to drop or retain the stimulus — this function only
+    reports the read failure, it does not decide. *)
 val pending_board_event_of_stimulus :
   meta:Keeper_meta_contract.keeper_meta ->
   Keeper_event_queue.stimulus ->
-  pending_board_event option
+  (pending_board_event option, Keeper_world_observation_board_signal.board_unavailable) result
 
 val read_scheduled_automation_observation :
   keeper_name:string option ->

--- a/lib/keeper/keeper_world_observation_board_signal.ml
+++ b/lib/keeper/keeper_world_observation_board_signal.ml
@@ -33,7 +33,62 @@ type comment_state =
 
 type comment_status = comment_state board_read
 
-exception Board_unavailable of board_unavailable
+(* Board-unavailable disposition: whether a failed board read is worth
+   retrying. Closed set so a new [Board.board_error] variant forces a
+   classification decision here rather than defaulting to either
+   "retry forever" (the old crash-loop bug: [Post_not_found] modeled as
+   transient) or "silently drop" (would swallow a real transient hiccup). *)
+type disposition =
+  | Permanent
+      (** Retrying the same read produces the same error. Callers must
+          consume/drop the stimulus and must not requeue it. *)
+  | Transient
+      (** An environment-level hiccup unrelated to whether the post/comment
+          exists. Callers may retain the stimulus for a later cycle. *)
+
+let disposition_of_error : Board.board_error -> disposition = function
+  | Board.Post_not_found _ ->
+    (* The post was deleted or swept from the store. Post ids are
+       cryptographically random (never reused), so this never resolves on
+       retry — the dominant real-world cause of the crash-loop this type
+       replaces (masc keeper cycle exception incident, board post swept
+       from the in-memory store). *)
+    Permanent
+  | Board.Comment_not_found _ ->
+    (* Same permanence argument as [Post_not_found], for a comment id. *)
+    Permanent
+  | Board.Invalid_id _ ->
+    (* The id string embedded in the stimulus is malformed. Retrying with
+       the same string reproduces the same validation failure. *)
+    Permanent
+  | Board.Io_error _ ->
+    (* Store/disk-level hiccup unrelated to whether the target exists; the
+       next read is expected to succeed once the environment recovers. *)
+    Transient
+  | Board.Validation_error _ ->
+    (* Not reachable from [get_post]/[get_comments] today (only write paths
+       produce it). Classified [Permanent] for exhaustiveness: it signals
+       the input itself fails a business rule, which retrying does not
+       change. *)
+    Permanent
+  | Board.Already_voted _ ->
+    (* Not reachable from a read path. Classified [Permanent]: it names an
+       already-settled action conflict, not a timing issue that retry
+       resolves. *)
+    Permanent
+  | Board.Already_exists _ ->
+    (* Not reachable from a read path. Same deterministic-conflict
+       reasoning as [Already_voted]. *)
+    Permanent
+  | Board.Unauthorized _ ->
+    (* Not reachable from a read path. An identity/ownership gate rejection
+       is deterministic and does not resolve by retrying. *)
+    Permanent
+;;
+
+let disposition_of_unavailable (unavailable : board_unavailable) =
+  disposition_of_error unavailable.error
+;;
 
 let board_read_operation_to_string = function
   | Get_post -> "get_post"
@@ -47,8 +102,6 @@ let unavailable_to_string unavailable =
     unavailable.post_id
     (Board.show_board_error unavailable.error)
 ;;
-
-let raise_unavailable unavailable = raise (Board_unavailable unavailable)
 
 let board_reaction_target_of_queue = function
   | Keeper_event_queue.Reaction_post -> Board.Reaction_post

--- a/lib/keeper/keeper_world_observation_board_signal.mli
+++ b/lib/keeper/keeper_world_observation_board_signal.mli
@@ -27,11 +27,24 @@ type comment_state =
 
 type comment_status = comment_state board_read
 
-exception Board_unavailable of board_unavailable
+(** Whether a failed board read is worth retrying (RFC board-unavailable-result).
+    Closed set: adding a new {!Board.board_error} variant forces a
+    classification decision in {!disposition_of_error} rather than defaulting
+    to "retry forever" or "silently drop". *)
+type disposition =
+  | Permanent
+      (** Retrying the same read reproduces the same error (e.g. the post
+          was deleted). Callers must consume/drop the affected stimulus and
+          must not requeue it. *)
+  | Transient
+      (** An environment-level hiccup unrelated to whether the target
+          exists. Callers may retain the stimulus for a later cycle. *)
+
+val disposition_of_error : Board.board_error -> disposition
+val disposition_of_unavailable : board_unavailable -> disposition
 
 val board_read_operation_to_string : board_read_operation -> string
 val unavailable_to_string : board_unavailable -> string
-val raise_unavailable : board_unavailable -> 'a
 
 val board_signal_of_board_stimulus
   :  post_id:string

--- a/lib/runtime_observation_query_operation.ml
+++ b/lib/runtime_observation_query_operation.ml
@@ -4,6 +4,7 @@ type t =
   | Count_running_keeper_fibers
   | Cursor_stale
   | Board_events
+  | Board_stimulus_intake
   | Scheduled_automation
   | Empty_run_reasons
   | Reconcile_read_meta
@@ -14,6 +15,7 @@ let to_label = function
   | Count_running_keeper_fibers -> "count_running_keeper_fibers"
   | Cursor_stale -> "cursor_stale"
   | Board_events -> "board_events"
+  | Board_stimulus_intake -> "board_stimulus_intake"
   | Scheduled_automation -> "scheduled_automation"
   | Empty_run_reasons -> "empty_run_reasons"
   | Reconcile_read_meta -> "reconcile_read_meta"

--- a/lib/runtime_observation_query_operation.mli
+++ b/lib/runtime_observation_query_operation.mli
@@ -10,7 +10,12 @@ type t =
   | Read_current_task (** [meta.current_task_id] → backlog record resolve failure (RFC-0315). *)
   | Count_running_keeper_fibers
   | Cursor_stale
-  | Board_events
+  | Board_events (** Cursor-based board scan (collect_board_events). *)
+  | Board_stimulus_intake
+      (** Event-queue stimulus intake (consume_single_heartbeat_stimulus /
+          consume_board_stimulus_batch) — distinct from [Board_events] so the
+          scan path and the queued-stimulus path do not conflate failure
+          sources in the same metric. *)
   | Scheduled_automation
   | Empty_run_reasons
   | Reconcile_read_meta (** Supervisor reconcile-loop meta read failure (#14828 sweep). *)

--- a/test/dune
+++ b/test/dune
@@ -738,6 +738,16 @@
  (modules test_fusion_wake)
  (libraries masc_test_deps masc.fusion_core))
 
+; Board-unavailable-result: keeper_world_observation_board_signal's
+; Board_unavailable exception -> (_, board_unavailable) result conversion.
+; Pins the poison/transient classification table and the reported incident
+; (a stimulus naming a swept post crashing the keeper heartbeat forever).
+
+(test
+ (name test_keeper_board_unavailable)
+ (modules test_keeper_board_unavailable)
+ (libraries masc_test_deps))
+
 ; Fusion OAS failure-detail tests need Fusion_types constructors from
 ; masc.fusion_core, which is intentionally not re-exported via masc.
 

--- a/test/test_fusion_wake.ml
+++ b/test/test_fusion_wake.ml
@@ -288,9 +288,13 @@ let test_fusion_completion_is_actionable () =
       ~meta
       (fusion_stimulus ~resolved_answer:"ANSWER-TOKEN-xyz" ())
   with
-  | Some (ev : Keeper_world_observation.pending_board_event) ->
+  | Ok (Some (ev : Keeper_world_observation.pending_board_event)) ->
     check bool "stimulus path preview carries the answer" true (contains ~needle:"ANSWER-TOKEN-xyz" ev.preview)
-  | None -> fail "Fusion_completed stimulus must produce Some pending_board_event, not None"
+  | Ok None -> fail "Fusion_completed stimulus must produce Some pending_board_event, not None"
+  | Error unavailable ->
+    fail
+      ("Fusion_completed stimulus must not hit a board read: "
+       ^ Keeper_world_observation_board_signal.unavailable_to_string unavailable)
 ;;
 
 (* RFC-0290: a completed background job follows the same non-empty delivery
@@ -329,13 +333,17 @@ let test_bg_completion_is_actionable () =
       ~meta
       (bg_stimulus ~bg_outcome:(Keeper_event_queue.Bg_ok "BG-ANSWER-TOKEN") ())
   with
-  | Some (ev : Keeper_world_observation.pending_board_event) ->
+  | Ok (Some (ev : Keeper_world_observation.pending_board_event)) ->
     check
       bool
       "stimulus path preview carries the background output"
       true
       (contains ~needle:"BG-ANSWER-TOKEN" ev.preview)
-  | None -> fail "Bg_completed stimulus must produce Some pending_board_event, not None"
+  | Ok None -> fail "Bg_completed stimulus must produce Some pending_board_event, not None"
+  | Error unavailable ->
+    fail
+      ("Bg_completed stimulus must not hit a board read: "
+       ^ Keeper_world_observation_board_signal.unavailable_to_string unavailable)
 ;;
 
 let test_bg_failure_missing_board_post_id_fallback () =
@@ -383,10 +391,14 @@ let test_scheduled_wake_is_actionable () =
       ~meta
       (schedule_stimulus ~message:"SCHEDULE-ANSWER-TOKEN" ())
   with
-  | Some (ev : Keeper_world_observation.pending_board_event) ->
+  | Ok (Some (ev : Keeper_world_observation.pending_board_event)) ->
     check bool "stimulus path preview carries the schedule message" true
       (contains ~needle:"SCHEDULE-ANSWER-TOKEN" ev.preview)
-  | None -> fail "Schedule_due stimulus must produce Some pending_board_event, not None"
+  | Ok None -> fail "Schedule_due stimulus must produce Some pending_board_event, not None"
+  | Error unavailable ->
+    fail
+      ("Schedule_due stimulus must not hit a board read: "
+       ^ Keeper_world_observation_board_signal.unavailable_to_string unavailable)
 ;;
 
 (* (3) an empty board_post_id (sink failed to create the post) still delivers

--- a/test/test_keeper_board_unavailable.ml
+++ b/test/test_keeper_board_unavailable.ml
@@ -1,0 +1,195 @@
+(* Board-unavailable-result — keeper_world_observation_board_signal's
+   [Board_unavailable] exception (and [raise_unavailable]) were removed in
+   favor of an explicit [(_, board_unavailable) result] contract.
+
+   Incident this replaces: [Board_dispatch.get_post] returning
+   [Post_not_found] (a post swept from the in-memory store — permanent) was
+   modeled as a transient exception. Nothing on the stimulus-intake path
+   caught it, so it crashed the keeper heartbeat cycle via the generic
+   handler in [keeper_heartbeat_loop.ml], the lease was requeued as
+   [Cycle_crashed], and the SAME poisoned stimulus re-crashed every
+   heartbeat forever.
+
+   These tests pin:
+   1. [disposition_of_error] classifies every [Board.board_error] variant —
+      the compiler enforces exhaustiveness, this test pins the actual table.
+   2. the incident's exact shape (a stimulus naming a post_id that was never
+      created) no longer raises, is reported as [Error unavailable]
+      classified [Permanent], and the stimulus-intake layer consumes it
+      without crashing — stable across a second pass, unlike the old
+      exception-based loop. *)
+
+open Alcotest
+open Masc
+
+let () = Mirage_crypto_rng_unix.use_default ()
+let () = Random.self_init ()
+
+(** Temp directory for test isolation — set before any Board.global call
+    (mirrors test_board_dispatch.ml's [fresh_test_base_path]). *)
+let fresh_test_base_path () =
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-test-board-unavailable-%06x" (Random.bits ()))
+  in
+  Unix.putenv "MASC_BASE_PATH" dir;
+  dir
+;;
+
+let with_eio f () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  ignore (fresh_test_base_path ());
+  Board.reset_global_for_test ();
+  Board_dispatch.reset_for_test ();
+  Board_dispatch.init_jsonl ();
+  f ()
+;;
+
+let test_meta name =
+  match
+    Keeper_meta_json_parse.meta_of_json
+      (`Assoc
+         [ "name", `String name
+         ; "agent_name", `String ("keeper-" ^ name ^ "-agent")
+         ; "trace_id", `String ("trace-" ^ name)
+         ; "sandbox_profile", `String "local"
+         ; "network_mode", `String "inherit"
+         ])
+  with
+  | Ok meta -> meta
+  | Error message -> Alcotest.failf "test meta failed: %s" message
+;;
+
+(* (1) Exhaustive classification, pinned. A future new [Board.board_error]
+   variant forces [disposition_of_error] to grow (compiler-enforced); this
+   test pins today's actual poison/transient split so a change to the table
+   is a deliberate, reviewed diff rather than a silent behavior change. *)
+let test_disposition_of_error_classifies_every_variant () =
+  let module BS = Keeper_world_observation_board_signal in
+  let is_permanent err = BS.disposition_of_error err = BS.Permanent in
+  let is_transient err = BS.disposition_of_error err = BS.Transient in
+  check bool "Post_not_found is permanent (post swept, never resolves on retry)" true
+    (is_permanent (Board.Post_not_found "p"));
+  check bool "Comment_not_found is permanent (same argument, for a comment id)" true
+    (is_permanent (Board.Comment_not_found "c"));
+  check bool "Invalid_id is permanent (malformed id string never becomes valid)" true
+    (is_permanent (Board.Invalid_id "bad id"));
+  check bool "Io_error is transient (store/disk hiccup, retry may succeed)" true
+    (is_transient (Board.Io_error "disk hiccup"));
+  check bool "Validation_error is permanent (deterministic input-validation failure)" true
+    (is_permanent (Board.Validation_error "x"));
+  check bool "Already_voted is permanent (deterministic action conflict)" true
+    (is_permanent (Board.Already_voted "x"));
+  check bool "Already_exists is permanent (deterministic conflict)" true
+    (is_permanent (Board.Already_exists "x"));
+  check bool "Unauthorized is permanent (deterministic identity rejection)" true
+    (is_permanent (Board.Unauthorized "x"))
+;;
+
+let poison_post_id = "nonexistent-post-poison-test"
+
+(* A [Board_signal] stimulus naming a post_id that was never created in this
+   test's isolated JSONL store — the exact shape of the reported incident
+   (post swept from the store between the signal firing and the keeper
+   consuming it). *)
+let poison_board_signal_stimulus () : Keeper_event_queue.stimulus =
+  { Keeper_event_queue.post_id = poison_post_id
+  ; urgency = Keeper_event_queue.Normal
+  ; arrived_at = Time_compat.now ()
+  ; payload =
+      Keeper_event_queue.Board_signal
+        { kind = Keeper_event_queue.Post_created
+        ; author = "external-author"
+        ; title = "poison stimulus"
+        ; content = "references a post_id that was never created"
+        ; hearth = None
+        ; updated_at = Some (Time_compat.now ())
+        }
+  }
+;;
+
+(* (2) [pending_board_event_of_stimulus] must report the failed board read
+   as [Error unavailable] — never raise — and it must classify [Permanent],
+   the dominant real crash-loop cause. *)
+let test_poison_stimulus_reports_permanent_error () =
+  let meta = test_meta "poison-report" in
+  match
+    Keeper_world_observation.pending_board_event_of_stimulus
+      ~meta
+      (poison_board_signal_stimulus ())
+  with
+  | Ok _ -> fail "a stimulus naming a nonexistent post must not resolve to Ok"
+  | Error unavailable ->
+    check
+      bool
+      "post_id names the missing post"
+      true
+      (String.equal
+         unavailable.Keeper_world_observation_board_signal.post_id
+         poison_post_id);
+    check
+      bool
+      "classifies Permanent (masc keeper-cycle-exception incident cause)"
+      true
+      (Keeper_world_observation_board_signal.disposition_of_unavailable unavailable
+       = Keeper_world_observation_board_signal.Permanent)
+;;
+
+(* (3) The stimulus-intake layer is where the crash actually happened:
+   [Board_signal.raise_unavailable] propagated past every catch site up to
+   [keeper_heartbeat_loop.ml]'s generic exception handler, which requeued
+   the lease as [Cycle_crashed] — so the SAME poisoned stimulus re-crashed
+   the keeper heartbeat every cycle forever. This pins the fix: the intake
+   helper must not raise, must return [], and a second pass over the same
+   stimulus (simulating the next heartbeat cycle re-leasing the same
+   durable stimulus) must ALSO return [] — the counterfactual for the old
+   loop, which would have crashed again here instead. *)
+let test_poison_stimulus_intake_does_not_crash_and_stays_dropped () =
+  let meta = test_meta "poison-intake" in
+  let stim = poison_board_signal_stimulus () in
+  let first_pass =
+    Keeper_heartbeat_stimulus_intake.pending_board_events_of_stimulus_result
+      ~meta_after_triage:meta
+      stim
+  in
+  check
+    int
+    "first pass produces no pending_board_event (consumed, not crashed)"
+    0
+    (List.length first_pass);
+  let second_pass =
+    Keeper_heartbeat_stimulus_intake.pending_board_events_of_stimulus_result
+      ~meta_after_triage:meta
+      stim
+  in
+  check
+    int
+    "second pass over the same stimulus stays empty (no crash-loop resurgence)"
+    0
+    (List.length second_pass)
+;;
+
+let () =
+  run
+    "keeper_board_unavailable"
+    [ ( "disposition"
+      , [ test_case
+            "disposition_of_error classifies every board_error variant"
+            `Quick
+            test_disposition_of_error_classifies_every_variant
+        ] )
+    ; ( "poison stimulus (masc keeper-cycle-exception incident)"
+      , [ test_case
+            "pending_board_event_of_stimulus reports Permanent, does not raise"
+            `Quick
+            (with_eio test_poison_stimulus_reports_permanent_error)
+        ; test_case
+            "stimulus intake consumes without crash, stable on repeat"
+            `Quick
+            (with_eio test_poison_stimulus_intake_does_not_crash_and_stays_dropped)
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Why

`Board_unavailable` 예외가 stimulus-intake 경로에서 아무에게도 잡히지 않고 keeper cycle을 crash시켰다. lease가 `Cycle_crashed`로 재큐되면서 **같은 poison stimulus(삭제·스윕된 post의 `Post_not_found` — 영구 조건)가 매 하트비트마다 재폭발** (albini/sangsu 16건/일). 영구 조건을 transient 예외로 모델링한 타입 설계 오류가 뿌리. #24886 인시던트의 병행 결함.

## What

- `Board_unavailable` 예외/`raise_unavailable` 삭제 → board signal read 전 경로 `(_, board_unavailable) result` 전환.
- 닫힌 `disposition` 분류기 (`Permanent | Transient`) — `Board.board_error` 8개 variant 전수, arm별 근거 주석, catch-all 없음 (새 variant 추가 시 컴파일 에러로 분류 결정 강제).
- intake 경로: 두 disposition 모두 크래시 없이 소비. disposition별 구분 WARN + `ObservationQueryFailures` 카운터 신규 라벨 `Board_stimulus_intake` (scan 경로의 `Board_events`와 분리).
- scan 경로: Result 흐름으로 진짜 재시도 시맨틱 유지 — Permanent는 해당 post만 스킵하고 cursor 전진, Transient는 batch 중단 + cursor 유지(다음 사이클 재시도).

## 스코프에서 STOP한 것 (개선이 아니라 보고)

Transient intake 실패의 per-stimulus requeue는 lease 전체 단위 Ack/Requeue 구조(`settlement_of_cycle_outcome`이 턴 결과로만 결정)에 막혀 이번 전환 범위를 넘는 리팩터 → **#25040**으로 분리 (현 read-path는 동기 IO가 없어 `Io_error` 도달 불가, 실질 P3).

## Verification

- 신규 `test/test_keeper_board_unavailable.ml` 3/3: variant 8종 분류 전수 pin / 실재하지 않는 post_id로 재현한 인시던트 시나리오에서 raise 없이 `Error` 반환 / **counterfactual** — 같은 poison stimulus 2회 호출 모두 `[]` (옛 크래시-루프 재발 불가).
- `test_fusion_wake` 14/14 (시그니처 전파 수정 포함), `test_board_dispatch` 77/78 — 유일 실패는 base에서도 재현되는 사전 존재 결함 #24847 (`git stash` 베이스라인 대조로 확인, 본 PR 미접촉 영역).
- 빌드 exit 0 (`MASC_SKIP_PIN_CHECK=1`, 독립 worktree `_build`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012KXQWcg9KtaC7KruGQTnwX
