### PR TITLE
refactor(keeper): close settlement receipt contract

### DIFF
--- a/lib/keeper_runtime/keeper_event_queue_state.ml
+++ b/lib/keeper_runtime/keeper_event_queue_state.ml
@@ -387,6 +387,15 @@ let settlement_equal left right =
     false
 ;;
 
+let transition_receipt_equal left right =
+  String.equal left.transition_id right.transition_id
+  && String.equal left.event_id right.event_id
+  && String.equal left.lease_id right.lease_id
+  && Int64.equal left.lease_sequence right.lease_sequence
+  && Float.equal left.settled_at right.settled_at
+  && left.settlement = right.settlement
+;;
+
 let validate_settlement = function
   | Ack | Requeue _ -> Ok ()
   | Escalate
@@ -476,6 +485,11 @@ let lease_equal (left : lease) (right : lease) =
 ;;
 
 let settle ~settled_at ~lease ~settlement state =
+  let* () =
+    if Float.is_finite settled_at
+    then Ok ()
+    else Error "event queue settlement time must be finite"
+  in
   let* () = validate_settlement settlement in
   match committed_lease lease state with
   | None ->
@@ -523,6 +537,39 @@ let settle ~settled_at ~lease ~settlement state =
         ; transition_outbox = [ outbox_entry ]
         }
       , Settled receipt )
+;;
+
+let replay_transition_receipt receipt state =
+  match
+    List.find_opt
+      (fun (lease : lease) -> Int64.equal lease.sequence receipt.lease_sequence)
+      state.leases
+  with
+  | Some lease ->
+    let* state, result =
+      settle
+        ~settled_at:receipt.settled_at
+        ~lease
+        ~settlement:receipt.settlement
+        state
+    in
+    let actual =
+      match result with
+      | Settled actual | Already_settled actual -> actual
+    in
+    if transition_receipt_equal receipt actual
+    then Ok state
+    else Error (Printf.sprintf "event queue receipt replay conflict: %s" receipt.lease_id)
+  | None ->
+    (match find_prior_receipt receipt.lease_id state with
+     | Some prior when transition_receipt_equal prior receipt -> Ok state
+     | Some _ ->
+       Error (Printf.sprintf "event queue receipt replay conflict: %s" receipt.lease_id)
+     | None ->
+       Error
+         (Printf.sprintf
+            "event queue receipt has no matching active lease: %s"
+            receipt.lease_id))
 ;;
 
 let recover_leases ~settled_at state =
@@ -594,6 +641,19 @@ let required_field ~context name fields =
   match List.assoc_opt name fields with
   | Some value -> Ok value
   | None -> Error (Printf.sprintf "%s missing required field %s" context name)
+;;
+
+let exact_fields ~context ~expected fields =
+  let rec loop seen = function
+    | [] -> Ok ()
+    | (name, _) :: rest ->
+      if not (List.exists (String.equal name) expected)
+      then Error (Printf.sprintf "%s contains unknown field %s" context name)
+      else if List.exists (String.equal name) seen
+      then Error (Printf.sprintf "%s contains duplicate field %s" context name)
+      else loop (name :: seen) rest
+  in
+  loop [] fields
 ;;
 
 let string_field ~context name fields =
@@ -711,25 +771,31 @@ let settlement_of_yojson json =
   let* fields = assoc_fields ~context json in
   let* kind = string_field ~context "kind" fields in
   match kind with
-  | "ack" -> Ok Ack
+  | "ack" ->
+    let* () = exact_fields ~context ~expected:[ "kind" ] fields in
+    Ok Ack
   | "requeue" ->
+    let* () = exact_fields ~context ~expected:[ "kind"; "reason" ] fields in
     let* reason = string_field ~context "reason" fields in
     let* reason = requeue_reason_of_label reason in
     Ok (Requeue reason)
   | "escalate" ->
-    let* reason_label = string_field ~context "reason" fields in
-    let reason_detail =
-      match List.assoc_opt "reason_detail" fields with
-      | Some json -> json
-      | None -> `Null
+    let* () =
+      exact_fields
+        ~context
+        ~expected:[ "kind"; "reason"; "reason_detail"; "successor" ]
+        fields
     in
+    let* reason_label = string_field ~context "reason" fields in
+    let* reason_detail = required_field ~context "reason_detail" fields in
     let* reason = escalation_reason_of_wire ~label:reason_label ~detail_json:reason_detail in
     let* successor =
       match List.assoc_opt "successor" fields with
-      | None | Some `Null -> Ok None
+      | Some `Null -> Ok None
       | Some json ->
         let* successor = Keeper_event_queue.stimulus_of_yojson json in
         Ok (Some successor)
+      | None -> Error "event queue settlement missing required field successor"
     in
     let settlement = Escalate { reason; successor } in
     let* () = validate_settlement settlement in
@@ -751,6 +817,19 @@ let transition_receipt_to_yojson receipt =
 let transition_receipt_of_yojson json =
   let context = "event queue transition receipt" in
   let* fields = assoc_fields ~context json in
+  let* () =
+    exact_fields
+      ~context
+      ~expected:
+        [ "transition_id"
+        ; "event_id"
+        ; "lease_id"
+        ; "lease_sequence"
+        ; "settled_at_unix"
+        ; "settlement"
+        ]
+      fields
+  in
   let* transition_id = string_field ~context "transition_id" fields in
   let* event_id = string_field ~context "event_id" fields in
   let* lease_id = string_field ~context "lease_id" fields in
@@ -763,7 +842,11 @@ let transition_receipt_of_yojson json =
     Printf.sprintf "%s:%s" expected_lease_id (settlement_kind_label settlement)
   in
   let expected_event_id = event_id_of_transition expected_transition_id in
-  if not (String.equal lease_id expected_lease_id)
+  if Int64.compare lease_sequence 1L < 0
+  then Error "event queue receipt lease sequence must be positive"
+  else if not (Float.is_finite settled_at)
+  then Error "event queue receipt settlement time must be finite"
+  else if not (String.equal lease_id expected_lease_id)
   then Error (Printf.sprintf "event queue receipt lease id mismatch: %s" lease_id)
   else if not (String.equal transition_id expected_transition_id)
   then Error (Printf.sprintf "event queue receipt transition id mismatch: %s" transition_id)

--- a/lib/keeper_runtime/keeper_event_queue_state.mli
+++ b/lib/keeper_runtime/keeper_event_queue_state.mli
@@ -113,7 +113,13 @@ val settle :
 
     [Retry_after_observed] and [Context_compaction_retry] retain the exact
     leased stimuli at the pending FIFO tail so unrelated work in the same lane
-    can proceed before another provider attempt. *)
+    can proceed before another provider attempt. Non-finite settlement times
+    are rejected. *)
+
+val replay_transition_receipt : transition_receipt -> t -> (t, string) result
+(** Apply one canonical durable receipt to its exact active lease. Replaying
+    the same retained receipt is idempotent; a different receipt or a missing
+    lease is an explicit conflict. *)
 
 val recover_leases : settled_at:float -> t -> (t, string) result
 (** Requeue every active lease with [Registration_recovery], preserving claim
@@ -139,6 +145,7 @@ val release_legacy_inflight :
 
 val lease_to_yojson : lease -> Yojson.Safe.t
 val lease_of_yojson : Yojson.Safe.t -> (lease, string) result
+val transition_receipt_equal : transition_receipt -> transition_receipt -> bool
 val transition_receipt_to_yojson : transition_receipt -> Yojson.Safe.t
 val transition_receipt_of_yojson : Yojson.Safe.t -> (transition_receipt, string) result
 val to_yojson : t -> Yojson.Safe.t

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -97,6 +97,108 @@ let test_claim_codec_ack_idempotency () =
    | Ok _ -> Alcotest.fail "conflicting second settlement was accepted")
 ;;
 
+let test_canonical_receipt_replay () =
+  let state =
+    State.with_pending (queue [ stimulus "replay" 1.0 ]) State.empty
+  in
+  let claimed, lease = claim_head state in
+  let lease = require_some "replay lease" lease in
+  let settled, result =
+    State.settle ~settled_at:11.0 ~lease ~settlement:State.Ack claimed
+    |> require_ok "settle replay fixture"
+  in
+  let receipt =
+    match result with
+    | State.Settled receipt -> receipt
+    | State.Already_settled _ -> Alcotest.fail "replay fixture was already settled"
+  in
+  let decoded =
+    State.transition_receipt_to_yojson receipt
+    |> State.transition_receipt_of_yojson
+    |> require_ok "canonical receipt roundtrip"
+  in
+  Alcotest.(check bool)
+    "receipt equality survives codec"
+    true
+    (State.transition_receipt_equal receipt decoded);
+  let replayed =
+    State.replay_transition_receipt decoded claimed
+    |> require_ok "replay canonical receipt"
+  in
+  Alcotest.(check string)
+    "replay reconstructs exact state"
+    (State.to_yojson settled |> Yojson.Safe.to_string)
+    (State.to_yojson replayed |> Yojson.Safe.to_string);
+  let repeated =
+    State.replay_transition_receipt decoded replayed
+    |> require_ok "replay canonical receipt idempotently"
+  in
+  Alcotest.(check string)
+    "idempotent replay preserves state"
+    (State.to_yojson replayed |> Yojson.Safe.to_string)
+    (State.to_yojson repeated |> Yojson.Safe.to_string);
+  let conflicting = { decoded with event_id = "wrong-event-id" } in
+  match State.replay_transition_receipt conflicting claimed with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "conflicting receipt replay was accepted"
+;;
+
+let test_receipt_codec_is_closed_and_finite () =
+  let state =
+    State.with_pending (queue [ stimulus "codec" 1.0 ]) State.empty
+  in
+  let claimed, lease = claim_head state in
+  let lease = require_some "codec lease" lease in
+  (match State.settle ~settled_at:Float.nan ~lease ~settlement:State.Ack claimed with
+   | Error _ -> ()
+   | Ok _ -> Alcotest.fail "non-finite settlement time was accepted");
+  let _, result =
+    State.settle ~settled_at:12.0 ~lease ~settlement:State.Ack claimed
+    |> require_ok "settle codec fixture"
+  in
+  let receipt =
+    match result with
+    | State.Settled receipt -> receipt
+    | State.Already_settled _ -> Alcotest.fail "codec fixture was already settled"
+  in
+  let fields =
+    match State.transition_receipt_to_yojson receipt with
+    | `Assoc fields -> fields
+    | _ -> Alcotest.fail "receipt encoder did not return an object"
+  in
+  let rejects label json =
+    match State.transition_receipt_of_yojson json with
+    | Error _ -> ()
+    | Ok _ -> Alcotest.failf "%s was accepted" label
+  in
+  rejects "unknown receipt field" (`Assoc (("extra", `Null) :: fields));
+  rejects
+    "duplicate receipt field"
+    (`Assoc (("transition_id", `String receipt.transition_id) :: fields));
+  rejects
+    "non-finite receipt time"
+    (`Assoc
+       (List.map
+          (fun (name, value) ->
+             if String.equal name "settled_at_unix"
+             then name, `Float Float.infinity
+             else name, value)
+          fields));
+  rejects
+    "unknown settlement field"
+    (`Assoc
+       (List.map
+          (fun (name, value) ->
+             if String.equal name "settlement"
+             then (
+               match value with
+               | `Assoc settlement_fields ->
+                 name, `Assoc (("extra", `Null) :: settlement_fields)
+               | _ -> Alcotest.fail "settlement encoder did not return an object")
+             else name, value)
+          fields))
+;;
+
 let test_claim_leases_earliest_ready_without_reordering_skipped_work () =
   let blocked =
     { (stimulus "blocked" 1.0) with urgency = Queue.Immediate }
@@ -1023,6 +1125,14 @@ let () =
     "keeper event queue v2"
     [ ( "state"
       , [ Alcotest.test_case "claim codec ack idempotency" `Quick test_claim_codec_ack_idempotency
+        ; Alcotest.test_case
+            "canonical receipt replay"
+            `Quick
+            test_canonical_receipt_replay
+        ; Alcotest.test_case
+            "receipt codec is closed and finite"
+            `Quick
+            test_receipt_codec_is_closed_and_finite
         ; Alcotest.test_case
             "claim earliest ready without reordering"
             `Quick


### PR DESCRIPTION
## Stack

- parent: #25018 — exact ordered settlement source identity
- this leaf: canonical settlement receipt codec/equality/replay
- next: cursor-bound append+fsync WAL and checkpoint outcome

## What changed

- close the durable settlement receipt JSON schema and reject unknown or duplicate fields
- validate positive lease sequence and finite settlement timestamp
- expose exact receipt equality
- replay one receipt against the exact active lease
- make identical retained replay idempotent and conflicting/missing replay explicit errors
- make settlement itself reject non-finite timestamps

## Why

The next WAL leaf needs one canonical State-owned payload. Persisting generic JSON or reconstructing a settlement from projections would create a second authority. This leaf gives WAL a typed receipt that State can encode, decode, compare, and replay without consulting Board, Gate, Connector, or any other product surface.

This does **not** add the WAL writer or claim crash recovery is complete.

## Validation

- `git diff --check`
- `ocamlformat --check lib/keeper_runtime/keeper_event_queue_state.ml lib/keeper_runtime/keeper_event_queue_state.mli test/test_keeper_event_queue_state_v2.ml`
- `scripts/dune-local.sh build test/test_keeper_event_queue_state_v2.exe`
- direct executable: 15/15 passed

Diff: 218 changed lines.