### PR TITLE
fix(keeper): migrate compaction evidence exactly

### DIFF
--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -73,15 +73,21 @@ type compaction_rejection =
   | Checkpoint_not_reduced
   | Invalid_structural_evidence of Keeper_compaction_evidence.decode_error
 
-let compaction_rejection_to_string = function
+let compaction_rejection_to_tag = function
   | Runtime_identity_unavailable -> "runtime_identity_unavailable"
   | Summarizer_unavailable -> "summarizer_unavailable"
   | Plan_unavailable_or_invalid -> "plan_unavailable_or_invalid"
   | Structurally_unchanged -> "structurally_unchanged"
   | Checkpoint_not_reduced -> "checkpoint_not_reduced"
+  | Invalid_structural_evidence _ -> "invalid_structural_evidence"
+;;
+
+let compaction_rejection_to_string = function
   | Invalid_structural_evidence error ->
-    "invalid_structural_evidence:"
+    compaction_rejection_to_tag (Invalid_structural_evidence error)
+    ^ ":"
     ^ Keeper_compaction_evidence.decode_error_to_string error
+  | reason -> compaction_rejection_to_tag reason
 ;;
 
 type compaction_decision =

--- a/lib/keeper/keeper_compact_policy.mli
+++ b/lib/keeper/keeper_compact_policy.mli
@@ -19,7 +19,12 @@ type compaction_decision =
   | Not_requested
   | Skipped_no_checkpoint
 
+val compaction_rejection_to_tag : compaction_rejection -> string
+(** Stable categorical tag without instance-specific evidence detail. *)
+
 val compaction_rejection_to_string : compaction_rejection -> string
+(** Diagnostic detail. Unlike {!compaction_rejection_to_tag}, this may include
+    the rejected evidence values. *)
 val compaction_decision_to_string : compaction_decision -> string
 val compaction_decision_prepared : compaction_decision -> bool
 val compaction_decision_applied : compaction_decision -> bool

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -91,7 +91,7 @@ let compaction_recovery_error_to_tag = function
     "checkpoint_not_found"
   | Checkpoint_load_failed _ -> "checkpoint_load_failed"
   | Compaction_rejected reason ->
-    Keeper_compact_policy.compaction_rejection_to_string reason
+    Keeper_compact_policy.compaction_rejection_to_tag reason
   | Compaction_evidence_missing -> "compaction_evidence_missing"
   | Unexpected_compaction_decision _ -> "unexpected_compaction_decision"
   | Checkpoint_superseded _ -> "checkpoint_superseded"

--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -382,14 +382,11 @@ let decision_public_allowlist =
     ; "payload_role"; "trigger"; "trigger_detail"; "kind"; "limit_tokens"
     ; "ratio"; "threshold"; "count"
     ; "source_requeued"; "exact_evidence"
-    ; "before_checkpoint_bytes"; "after_checkpoint_bytes"
-    ; "before_message_count"; "after_message_count"
-    ; "summarized_message_count"; "dropped_message_count"
-    ; "pair_repair_dropped_message_count"
-    ; "before_tool_use_count"; "after_tool_use_count"
-    ; "before_tool_result_count"; "after_tool_result_count"
     ; "clock_refs"
     ]
+
+let compaction_evidence_public_allowlist =
+  StringSet.of_list Keeper_compaction_evidence.wire_field_names
 
 let clock_refs_public_allowlist =
   StringSet.of_list
@@ -398,6 +395,21 @@ let clock_refs_public_allowlist =
     ; "compaction_id"; "compaction_source"; "event_bus_correlation_id"
     ; "event_bus_run_id"; "parent_event_id"; "caused_by"; "logical_seq"
     ]
+
+type decision_projection_scope =
+  | Decision
+  | Clock_refs
+  | Compaction_evidence
+
+let decision_allowlist = function
+  | Decision -> decision_public_allowlist
+  | Clock_refs -> clock_refs_public_allowlist
+  | Compaction_evidence -> compaction_evidence_public_allowlist
+
+let decision_child_scope scope key =
+  if String.equal key "clock_refs" then Clock_refs
+  else if String.equal key "exact_evidence" then Compaction_evidence
+  else scope
 
 let rec reject_unknown_fields ~allowlist path = function
   | `Assoc fields ->
@@ -430,27 +442,24 @@ let reject_retired_manifest_fields fields =
   | None -> Ok ()
 
 let reject_retired_decision_fields decision =
-  let rec check path = function
+  let rec check scope path = function
     | `Assoc fields ->
-        let allowlist =
-          if String.equal path "" then decision_public_allowlist
-          else if String.equal path "clock_refs" then clock_refs_public_allowlist
-          else decision_public_allowlist
-        in
+        let allowlist = decision_allowlist scope in
         List.find_map
           (fun (key, value) ->
             let full_path = if String.equal path "" then key else path ^ "." ^ key in
-            if StringSet.mem key allowlist then check full_path value
+            if StringSet.mem key allowlist then
+              check (decision_child_scope scope key) full_path value
             else Some full_path)
           fields
     | `List values ->
         values
         |> List.mapi (fun idx value -> idx, value)
         |> List.find_map (fun (idx, value) ->
-          check (Printf.sprintf "%s[%d]" path idx) value)
+          check scope (Printf.sprintf "%s[%d]" path idx) value)
     | _ -> None
   in
-  match check "" decision with
+  match check Decision "" decision with
   | Some path ->
       Error
         (Printf.sprintf
@@ -459,13 +468,9 @@ let reject_retired_decision_fields decision =
   | None -> Ok ()
 
 let rec public_projection_of_decision decision =
-  let rec project path = function
+  let rec project scope path = function
     | `Assoc fields ->
-        let allowlist =
-          if String.equal path "" then decision_public_allowlist
-          else if String.equal path "clock_refs" then clock_refs_public_allowlist
-          else decision_public_allowlist
-        in
+        let allowlist = decision_allowlist scope in
         `Assoc
           (List.filter_map
              (fun (key, value) ->
@@ -473,14 +478,15 @@ let rec public_projection_of_decision decision =
                  Some
                    ( key
                    , project
+                       (decision_child_scope scope key)
                        (if String.equal path "" then key else path ^ "." ^ key)
                        value )
                else None)
              fields)
-    | `List values -> `List (List.map (project path) values)
+    | `List values -> `List (List.map (project scope path) values)
     | other -> other
   in
-  project "" decision
+  project Decision "" decision
 
 let to_json manifest =
   `Assoc

--- a/lib/keeper_compaction_evidence/keeper_compaction_evidence.ml
+++ b/lib/keeper_compaction_evidence/keeper_compaction_evidence.ml
@@ -51,6 +51,12 @@ type decode_error =
       ; dropped_message_count : int
       ; pair_repair_dropped_message_count : int
       }
+  | Legacy_message_accounting_not_derivable of
+      { before_message_count : int
+      ; after_message_count : int
+      ; summarized_message_count : int
+      ; dropped_message_count : int
+      }
   | No_messages_compacted
 
 let field_name = function
@@ -81,6 +87,8 @@ let all_fields =
   ; After_tool_result_count
   ]
 ;;
+
+let wire_field_names = List.map field_name all_fields
 
 let known_field name =
   List.exists (fun field -> String.equal name (field_name field)) all_fields
@@ -129,6 +137,18 @@ let decode_error_to_string = function
       summarized_message_count
       dropped_message_count
       pair_repair_dropped_message_count
+  | Legacy_message_accounting_not_derivable
+      { before_message_count
+      ; after_message_count
+      ; summarized_message_count
+      ; dropped_message_count
+      } ->
+    Printf.sprintf
+      "legacy_message_accounting_not_derivable:before=%d:after=%d:summarized=%d:dropped=%d"
+      before_message_count
+      after_message_count
+      summarized_message_count
+      dropped_message_count
   | No_messages_compacted -> "no_messages_compacted"
 ;;
 
@@ -165,6 +185,50 @@ let decode_nonnegative_integer fields field =
   | [ _, `Int _ ] -> Error (Invalid_field (field, Negative_integer))
   | [ _ ] -> Error (Invalid_field (field, Expected_integer))
   | _ -> Error (Invalid_field (field, Duplicate))
+;;
+
+let decode_optional_nonnegative_integer fields field =
+  match
+    List.filter
+      (fun (name, _) -> String.equal name (field_name field))
+      fields
+  with
+  | [] -> Ok None
+  | [ _, `Int value ] when value >= 0 -> Ok (Some value)
+  | [ _, `Int _ ] -> Error (Invalid_field (field, Negative_integer))
+  | [ _ ] -> Error (Invalid_field (field, Expected_integer))
+  | _ -> Error (Invalid_field (field, Duplicate))
+;;
+
+let derive_legacy_pair_repair_dropped_message_count
+      ~before_message_count
+      ~after_message_count
+      ~summarized_message_count
+      ~dropped_message_count
+  =
+  let invalid () =
+    Error
+      (Legacy_message_accounting_not_derivable
+         { before_message_count
+         ; after_message_count
+         ; summarized_message_count
+         ; dropped_message_count
+         })
+  in
+  if summarized_message_count > before_message_count
+  then invalid ()
+  else if dropped_message_count > before_message_count - summarized_message_count
+  then invalid ()
+  else
+    let after_plan =
+      before_message_count
+      - dropped_message_count
+      - summarized_message_count
+      + if summarized_message_count = 0 then 0 else 1
+    in
+    if after_message_count > after_plan
+    then invalid ()
+    else Ok (after_plan - after_message_count)
 ;;
 
 let create
@@ -276,8 +340,20 @@ let of_json ~selected_runtime_id = function
     let* after_message_count = integer After_message_count in
     let* summarized_message_count = integer Summarized_message_count in
     let* dropped_message_count = integer Dropped_message_count in
+    let* encoded_pair_repair_dropped_message_count =
+      decode_optional_nonnegative_integer
+        fields
+        Pair_repair_dropped_message_count
+    in
     let* pair_repair_dropped_message_count =
-      integer Pair_repair_dropped_message_count
+      match encoded_pair_repair_dropped_message_count with
+      | Some count -> Ok count
+      | None ->
+        derive_legacy_pair_repair_dropped_message_count
+          ~before_message_count
+          ~after_message_count
+          ~summarized_message_count
+          ~dropped_message_count
     in
     let* before_tool_use_count = integer Before_tool_use_count in
     let* after_tool_use_count = integer After_tool_use_count in

--- a/lib/keeper_compaction_evidence/keeper_compaction_evidence.mli
+++ b/lib/keeper_compaction_evidence/keeper_compaction_evidence.mli
@@ -53,9 +53,17 @@ type decode_error =
       ; dropped_message_count : int
       ; pair_repair_dropped_message_count : int
       }
+  | Legacy_message_accounting_not_derivable of
+      { before_message_count : int
+      ; after_message_count : int
+      ; summarized_message_count : int
+      ; dropped_message_count : int
+      }
   | No_messages_compacted
 
 val decode_error_to_string : decode_error -> string
+val wire_field_names : string list
+(** Canonical JSON field names for public projection and closed decoding. *)
 
 val create
   :  selected_runtime_id:string option
@@ -87,6 +95,9 @@ val of_json
   -> (t, decode_error) result
 (** Restore persisted structural evidence. The Runtime identity is supplied
     from its enclosing typed projection rather than duplicated in the counts
-    object. Unknown, duplicate, missing, malformed, or objectively impossible
-    evidence is rejected explicitly. [Checkpoint_bytes] must strictly reduce;
-    the other measures may stay equal but cannot increase. *)
+    object. Rows written before [pair_repair_dropped_message_count] was added
+    are migrated by deriving that count exactly from the other message counts;
+    an impossible derivation is rejected. Other unknown, duplicate, missing,
+    malformed, or objectively impossible evidence is rejected explicitly.
+    [Checkpoint_bytes] must strictly reduce; the other measures may stay equal
+    but cannot increase. *)

--- a/test/keeper_compaction_evidence/test_keeper_compaction_evidence.ml
+++ b/test/keeper_compaction_evidence/test_keeper_compaction_evidence.ml
@@ -192,6 +192,57 @@ let test_exact_pair_repair_accounting () =
       (Keeper_compaction_evidence.decode_error_to_string error)
 ;;
 
+let test_legacy_pair_repair_migration () =
+  let open Keeper_compaction_evidence in
+  let restore json =
+    of_json ~selected_runtime_id:evidence.selected_runtime_id json
+  in
+  (match restore (remove "pair_repair_dropped_message_count" canonical) with
+   | Ok restored ->
+     Alcotest.(check int)
+       "zero pair-repair count derived"
+       0
+       restored.pair_repair_dropped_message_count
+   | Error error ->
+     Alcotest.failf
+       "legacy zero pair-repair evidence rejected: %s"
+       (decode_error_to_string error));
+  let with_pair_repair =
+    canonical
+    |> replace "after_message_count" (`Int 4)
+    |> remove "pair_repair_dropped_message_count"
+  in
+  (match restore with_pair_repair with
+   | Ok restored ->
+     Alcotest.(check int)
+       "non-zero pair-repair count derived"
+       2
+       restored.pair_repair_dropped_message_count
+   | Error error ->
+     Alcotest.failf
+       "legacy non-zero pair-repair evidence rejected: %s"
+       (decode_error_to_string error));
+  let impossible =
+    canonical
+    |> replace "after_message_count" (`Int 7)
+    |> remove "pair_repair_dropped_message_count"
+  in
+  match restore impossible with
+  | Error
+      (Legacy_message_accounting_not_derivable
+        { before_message_count = 12
+        ; after_message_count = 7
+        ; summarized_message_count = 6
+        ; dropped_message_count = 1
+        }) ->
+    ()
+  | Error error ->
+    Alcotest.failf
+      "unexpected legacy migration rejection: %s"
+      (decode_error_to_string error)
+  | Ok _ -> Alcotest.fail "impossible legacy evidence decoded"
+;;
+
 let () =
   Alcotest.run
     "keeper compaction evidence"
@@ -205,5 +256,9 @@ let () =
             "exact pair-repair accounting"
             `Quick
             test_exact_pair_repair_accounting
+        ; Alcotest.test_case
+            "legacy pair-repair migration"
+            `Quick
+            test_legacy_pair_repair_migration
         ] )
     ]

--- a/test/stanzas/test_keeper_post_turn_wirein_order.inc
+++ b/test/stanzas/test_keeper_post_turn_wirein_order.inc
@@ -1,4 +1,4 @@
 (test
  (name test_keeper_post_turn_wirein_order)
  (modules test_keeper_post_turn_wirein_order)
- (libraries masc_test_deps))
+ (libraries masc_test_deps masc.keeper_compaction_evidence))

--- a/test/stanzas/test_keeper_runtime_manifest_completeness.inc
+++ b/test/stanzas/test_keeper_runtime_manifest_completeness.inc
@@ -1,4 +1,4 @@
 (test
  (name test_keeper_runtime_manifest_completeness)
  (modules test_keeper_runtime_manifest_completeness)
- (libraries alcotest masc yojson))
+ (libraries alcotest masc masc.keeper_compaction_evidence yojson))

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -32,6 +32,21 @@ let test_prepared_becomes_applied_only_after_save () =
     check string "saved checkpoint returned" "durable-checkpoint" checkpoint
   | Ok _ -> fail "successful checkpoint save did not produce Applied Manual"
 
+let test_compaction_rejection_tag_is_stable () =
+  let error =
+    Post_turn.Compaction_rejected
+      (Compact_policy.Invalid_structural_evidence
+         Keeper_compaction_evidence.No_messages_compacted)
+  in
+  check string
+    "categorical tag excludes evidence detail"
+    "invalid_structural_evidence"
+    (Post_turn.compaction_recovery_error_to_tag error);
+  check string
+    "diagnostic detail remains observable"
+    "compaction rejected: invalid_structural_evidence:no_messages_compacted"
+    (Post_turn.compaction_recovery_error_to_string error)
+
 let make_meta
       ?(name = "post-turn-no-auto-compact")
       ?(trace_id = "trace-post-turn-no-auto-compact")
@@ -327,6 +342,9 @@ let test_manual_compaction_serializes_owner_lane () =
       check int "manifest records post-turn source size" 4
         Yojson.Safe.Util.(manifest.decision |> member "exact_evidence"
                           |> member "before_message_count" |> to_int);
+      check int "manifest records pair-repair drops" 0
+        Yojson.Safe.Util.(manifest.decision |> member "exact_evidence"
+                          |> member "pair_repair_dropped_message_count" |> to_int);
       Registry_queue.settle_result
         ~base_path
         meta.name
@@ -342,6 +360,8 @@ let () =
     "durable compaction", [
       test_case "Prepared requires a successful checkpoint save"
         `Quick test_prepared_becomes_applied_only_after_save;
+      test_case "compaction rejection tag is stable"
+        `Quick test_compaction_rejection_tag_is_stable;
       test_case "regular post-turn does not auto-compact"
         `Quick test_regular_post_turn_does_not_auto_compact;
       test_case "manual compaction serializes the owner lane"

--- a/test/test_keeper_runtime_manifest_completeness.ml
+++ b/test/test_keeper_runtime_manifest_completeness.ml
@@ -122,16 +122,33 @@ let test_is_complete_turn () =
     (M.is_complete_turn complete)
 
 let test_compaction_evidence_public_projection () =
+  let evidence =
+    Keeper_compaction_evidence.create
+      ~selected_runtime_id:(Some "compact-runtime")
+      ~before_checkpoint_bytes:4096
+      ~after_checkpoint_bytes:1024
+      ~before_message_count:12
+      ~after_message_count:4
+      ~summarized_message_count:6
+      ~dropped_message_count:1
+      ~pair_repair_dropped_message_count:2
+      ~before_tool_use_count:3
+      ~after_tool_use_count:1
+      ~before_tool_result_count:3
+      ~after_tool_result_count:1
+    |> Result.get_ok
+    |> Keeper_compaction_evidence.to_json
+  in
   let decision =
+    let evidence_with_cross_scope_field =
+      match evidence with
+      | `Assoc fields -> `Assoc (("error", `String "must-not-leak") :: fields)
+      | _ -> Alcotest.fail "canonical compaction evidence must be an object"
+    in
     M.with_payload_role
       ~payload_role:M.Checkpoint
       (`Assoc
-        [ ( "exact_evidence"
-          , `Assoc
-              [ "before_checkpoint_bytes", `Int 4096
-              ; "after_checkpoint_bytes", `Int 1024
-              ] )
-        ])
+        [ "exact_evidence", evidence_with_cross_scope_field ])
   in
   let json =
     manifest ~event:M.Context_compacted ~decision ~links:(links ())
@@ -149,7 +166,12 @@ let test_compaction_evidence_public_projection () =
      |> member "decision"
      |> member "exact_evidence"
      |> member "before_checkpoint_bytes"
-     |> to_int)
+     |> to_int);
+  Alcotest.check
+    (Alcotest.testable Yojson.Safe.pp Yojson.Safe.equal)
+    "all canonical evidence fields retained"
+    evidence
+    (json |> member "decision" |> member "exact_evidence")
 
 let () =
   Alcotest.run "keeper_runtime_manifest_completeness"


### PR DESCRIPTION
## Summary
- restore pre-#25037 evidence rows by exactly deriving the absent pair-repair drop count from persisted message counts
- reject non-derivable legacy rows with a typed decode error instead of defaulting or silently accepting them
- make compaction evidence wire names the SSOT for manifest projection and keep projection scopes typed
- separate stable compaction rejection tags from detailed observable diagnostics

## Verification
- `git diff --check`
- `ocamlc -stop-after parsing` on all touched `.ml` files
- `ocamlformat --check` on all touched OCaml files
- focused Dune targets deferred to PR CI because the repo-wide local Dune lock is owned by another active worktree; the lock was not bypassed

## Context
Post-merge adversarial repair for #25037. This preserves persisted evidence compatibility without heuristic defaults and removes duplicated evidence field names from the runtime manifest.