### PR TITLE
refactor(gate): persist monotonic approval order

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -80,11 +80,13 @@ let install_error_to_string = function
   | Install_storage_failed error -> storage_error_to_string error
 ;;
 
-let pending_store_version = 2
+let pending_store_version = 3
 let pending_store_surface = "keeper_gate_pending"
 let pending_store_mutex = Cross_context_mutex.create ()
 let deliveries : persisted_delivery SMap.t Atomic.t = Atomic.make SMap.empty
 let unavailable_stores : storage_error SMap.t Atomic.t = Atomic.make SMap.empty
+(** Process projection of the next value persisted in each workspace snapshot. *)
+let next_sequences : int SMap.t Atomic.t = Atomic.make SMap.empty
 
 (** Serialize one durable pending/delivery snapshot transition across both Eio
     fibers and non-Eio callers.  A plain [Stdlib.Mutex.protect] is invalid here:
@@ -135,6 +137,7 @@ let pending_entry_to_yojson (entry : pending_approval) =
     ; "tool_name", `String entry.tool_name
     ; "input_hash", `String entry.input_hash
     ; "input", entry.input
+    ; "sequence", `Int entry.sequence
     ; "requested_at", `Float entry.requested_at
     ; "turn_id", Json_util.int_opt_to_json entry.turn_id
     ; ( "request_context"
@@ -174,7 +177,7 @@ let map_values_for_base ~base_path map project =
     if String.equal (project value).audit_base_path base_path then Some value else None)
 ;;
 
-let snapshot_to_yojson ~base_path ~pending_map ~delivery_map =
+let snapshot_to_yojson ~base_path ~next_sequence ~pending_map ~delivery_map =
   let pending_entries =
     map_values_for_base ~base_path pending_map Fun.id
     |> List.map pending_entry_to_yojson
@@ -185,12 +188,22 @@ let snapshot_to_yojson ~base_path ~pending_map ~delivery_map =
   in
   `Assoc
     [ "version", `Int pending_store_version
+    ; "next_sequence", `Int next_sequence
     ; "pending", `List pending_entries
     ; "deliveries", `List delivery_entries
     ]
 ;;
 
-let persist_snapshot_unlocked ~base_path ~pending_map ~delivery_map =
+let next_sequence_unlocked ~base_path =
+  Option.value (SMap.find_opt base_path (Atomic.get next_sequences)) ~default:1
+;;
+
+let persist_snapshot_with_sequence_unlocked
+      ~base_path
+      ~next_sequence
+      ~pending_map
+      ~delivery_map
+  =
   let path = pending_store_path ~base_path in
   match SMap.find_opt base_path (Atomic.get unavailable_stores) with
   | Some error -> Error error
@@ -198,7 +211,7 @@ let persist_snapshot_unlocked ~base_path ~pending_map ~delivery_map =
     (try
        Fs_compat.mkdir_p (Filename.dirname path);
        let body =
-         snapshot_to_yojson ~base_path ~pending_map ~delivery_map
+         snapshot_to_yojson ~base_path ~next_sequence ~pending_map ~delivery_map
          |> Yojson.Safe.pretty_to_string
        in
        (match Fs_compat.save_file_atomic path body with
@@ -207,6 +220,14 @@ let persist_snapshot_unlocked ~base_path ~pending_map ~delivery_map =
      with
      | Eio.Cancel.Cancelled _ as exn -> raise exn
      | exn -> Error { path; reason = Printexc.to_string exn })
+;;
+
+let persist_snapshot_unlocked ~base_path ~pending_map ~delivery_map =
+  persist_snapshot_with_sequence_unlocked
+    ~base_path
+    ~next_sequence:(next_sequence_unlocked ~base_path)
+    ~pending_map
+    ~delivery_map
 ;;
 
 let reject_unknown_fields ~surface ~allowed fields =
@@ -254,6 +275,13 @@ let optional_nonnegative_int ~surface field fields =
     Error (Printf.sprintf "%s.%s must be a non-negative integer or null" surface field)
 ;;
 
+let required_positive_int ~surface field fields =
+  match List.assoc_opt field fields with
+  | Some (`Int value) when value > 0 -> Ok value
+  | Some _ -> Error (Printf.sprintf "%s.%s must be a positive integer" surface field)
+  | None -> Error (Printf.sprintf "%s.%s is required" surface field)
+;;
+
 let required_float ~surface field fields =
   match List.assoc_opt field fields with
   | Some (`Float value) -> Ok value
@@ -290,6 +318,7 @@ let pending_entry_of_yojson ~base_path json =
           ; "tool_name"
           ; "input_hash"
           ; "input"
+          ; "sequence"
           ; "requested_at"
           ; "turn_id"
           ; "request_context"
@@ -312,6 +341,7 @@ let pending_entry_of_yojson ~base_path json =
       then Ok ()
       else Error (Printf.sprintf "%s.input_hash does not match input" surface)
     in
+    let* sequence = required_positive_int ~surface "sequence" fields in
     let* requested_at = required_float ~surface "requested_at" fields in
     let* turn_id = optional_nonnegative_int ~surface "turn_id" fields in
     let request_context =
@@ -332,6 +362,7 @@ let pending_entry_of_yojson ~base_path json =
       ; tool_name
       ; input_hash
       ; input
+      ; sequence
       ; requested_at
       ; turn_id
       ; request_context
@@ -468,6 +499,29 @@ let parse_list ~surface parse = function
   | _ -> Error (surface ^ " must be an array")
 ;;
 
+let validate_snapshot_sequences ~next_sequence pending_entries delivery_entries =
+  let sequences =
+    List.map (fun (entry : pending_approval) -> entry.sequence) pending_entries
+    @ List.map
+        (fun (delivery : persisted_delivery) -> delivery.entry.sequence)
+        delivery_entries
+    |> List.sort Int.compare
+  in
+  let rec check previous = function
+    | [] -> Ok ()
+    | sequence :: _ when sequence >= next_sequence ->
+      Error
+        (Printf.sprintf
+           "gate_pending sequence %d must precede next_sequence %d"
+           sequence
+           next_sequence)
+    | sequence :: _ when previous = Some sequence ->
+      Error (Printf.sprintf "gate_pending contains duplicate sequence %d" sequence)
+    | sequence :: rest -> check (Some sequence) rest
+  in
+  check None sequences
+;;
+
 let snapshot_of_yojson ~base_path json =
   match json with
   | `Assoc fields ->
@@ -476,7 +530,7 @@ let snapshot_of_yojson ~base_path json =
     let* () =
       reject_unknown_fields
         ~surface
-        ~allowed:[ "version"; "pending"; "deliveries" ]
+        ~allowed:[ "version"; "next_sequence"; "pending"; "deliveries" ]
         fields
     in
     let* () =
@@ -487,6 +541,7 @@ let snapshot_of_yojson ~base_path json =
       | Some _ -> Error (surface ^ ".version must be an integer")
       | None -> Error (surface ^ ".version is required")
     in
+    let* next_sequence = required_positive_int ~surface "next_sequence" fields in
     let* pending_json = required_member ~surface "pending" fields in
     let* pending_entries =
       parse_list ~surface:"gate_pending.pending" (pending_entry_of_yojson ~base_path) pending_json
@@ -515,7 +570,10 @@ let snapshot_of_yojson ~base_path json =
       | None -> Ok ()
       | Some id -> Error (Printf.sprintf "gate_pending id %s exists in both states" id)
     in
-    Ok (pending_map, delivery_map)
+    let* () =
+      validate_snapshot_sequences ~next_sequence pending_entries delivery_entries
+    in
+    Ok (pending_map, delivery_map, next_sequence)
   | _ -> Error "gate_pending snapshot must be a JSON object"
 ;;
 
@@ -523,7 +581,7 @@ let load_snapshot_unlocked ~base_path =
   let path = pending_store_path ~base_path in
   try
     if not (Sys.file_exists path)
-    then Ok (SMap.empty, SMap.empty)
+    then Ok (SMap.empty, SMap.empty, 1)
     else (
       match Safe_ops.read_json_file_safe path with
       | Error reason ->
@@ -1065,6 +1123,7 @@ let input_preview_of_json (json : Yojson.Safe.t) =
 
 let create_entry
       ~id
+      ~sequence
       ~keeper_name
       ~tool_name
       ~input
@@ -1083,6 +1142,7 @@ let create_entry
   ; tool_name
   ; input_hash
   ; input
+  ; sequence
   ; requested_at = Unix.gettimeofday ()
   ; turn_id
   ; request_context = Option.map Keeper_gate_request_context.project request_context
@@ -1102,6 +1162,7 @@ let pending_entry_json_fields
   [ "id", `String entry.id
   ; "keeper_name", `String entry.keeper_name
   ; "tool_name", `String entry.tool_name
+  ; "sequence", `Int entry.sequence
   ; "requested_at", `Float entry.requested_at
   ; "waiting_s", `Float (Unix.gettimeofday () -. entry.requested_at)
   ; "turn_id", Json_util.int_opt_to_json entry.turn_id
@@ -1144,8 +1205,9 @@ let broadcast_pending entry =
 
 let record_pending (entry : pending_approval) =
   Log.Keeper.info
-    "HITL_APPROVAL_PENDING: id=%s keeper=%s tool=%s"
+    "HITL_APPROVAL_PENDING: id=%s sequence=%d keeper=%s tool=%s"
     entry.id
+    entry.sequence
     entry.keeper_name
     entry.tool_name;
   audit_approval_event
@@ -1596,14 +1658,6 @@ let find_pending_id_in_map
     None
 ;;
 
-let sort_entries_by_requested_at entries =
-  List.sort
-    (fun left right ->
-       let ts_of_json json = (match Json_util.assoc_member_opt "requested_at" json with Some (`Float f) -> f | Some (`Int n) -> Float.of_int n | _ -> 0.0) in
-       Float.compare (ts_of_json left) (ts_of_json right))
-    entries
-;;
-
 (* ── Nonblocking submission ───────────────────────────────── *)
 
 let submit_pending
@@ -1643,32 +1697,46 @@ let submit_pending
       | Some id -> Ok (id, None)
       | None ->
         let id = generate_id () in
-        let entry =
-          create_entry
-            ~id
-            ~keeper_name
-            ~tool_name
-            ~input
-            ?turn_id
-            ?request_context
-            ?task_id
-            ?goal_id
-            ~goal_ids
-            ~continuation_channel
-            ~audit_base_path:base_path
-            ()
-        in
-        let updated = SMap.add id entry map in
-        (match
-           persist_snapshot_unlocked
-             ~base_path
-             ~pending_map:updated
-             ~delivery_map:(Atomic.get deliveries)
-         with
-         | Error _ as error -> error
-         | Ok () ->
-           Atomic.set pending updated;
-           Ok (id, Some entry)))
+        let sequence = next_sequence_unlocked ~base_path in
+        if sequence = max_int
+        then
+          Error
+            { path = pending_store_path ~base_path
+            ; reason = "approval sequence exhausted its integer representation"
+            }
+        else
+          let entry =
+            create_entry
+              ~id
+              ~sequence
+              ~keeper_name
+              ~tool_name
+              ~input
+              ?turn_id
+              ?request_context
+              ?task_id
+              ?goal_id
+              ~goal_ids
+              ~continuation_channel
+              ~audit_base_path:base_path
+              ()
+          in
+          let updated = SMap.add id entry map in
+          let following_sequence = sequence + 1 in
+          (match
+             persist_snapshot_with_sequence_unlocked
+               ~base_path
+               ~next_sequence:following_sequence
+               ~pending_map:updated
+               ~delivery_map:(Atomic.get deliveries)
+           with
+           | Error _ as error -> error
+           | Ok () ->
+             Atomic.set pending updated;
+             Atomic.set
+               next_sequences
+               (SMap.add base_path following_sequence (Atomic.get next_sequences));
+             Ok (id, Some entry)))
   in
   match stored with
   | Error _ as error -> error
@@ -1896,7 +1964,7 @@ let install_persistence_internal ~after_load ~base_path =
       | Error storage_error ->
         mark_store_unavailable_unlocked ~base_path storage_error;
         Error storage_error
-      | Ok (loaded_pending, loaded_deliveries) ->
+      | Ok (loaded_pending, loaded_deliveries, loaded_next_sequence) ->
         let current_pending =
           remove_base_entries ~base_path (Atomic.get pending) Fun.id
         in
@@ -1945,6 +2013,12 @@ let install_persistence_internal ~after_load ~base_path =
               clear_store_unavailable_unlocked ~base_path;
               Atomic.set pending pending_map;
               Atomic.set deliveries delivery_map;
+              Atomic.set
+                next_sequences
+                (SMap.add
+                   base_path
+                   loaded_next_sequence
+                   (Atomic.get next_sequences));
               Ok
                 ( SMap.cardinal loaded_pending
                 , SMap.bindings loaded_deliveries |> List.map snd ))))
@@ -1994,7 +2068,8 @@ module For_testing = struct
     with_pending_store_lock (fun () ->
       Atomic.set pending SMap.empty;
       Atomic.set deliveries SMap.empty;
-      Atomic.set unavailable_stores SMap.empty)
+      Atomic.set unavailable_stores SMap.empty;
+      Atomic.set next_sequences SMap.empty)
   ;;
 
   let install_persistence_with_after_load_hook ~base_path ~after_load =
@@ -2088,34 +2163,26 @@ let resolve ~base_path ~id ~(decision : decision)
 (* ── Query ────────────────────────────────────────────────── *)
 
 (** List all pending approvals as JSON. *)
+let pending_entries_in_sequence_order () =
+  SMap.fold (fun _id entry acc -> entry :: acc) (Atomic.get pending) []
+  |> List.sort (fun left right -> Int.compare left.sequence right.sequence)
+;;
+
 let list_pending_json () : Yojson.Safe.t =
-  let entries =
-    SMap.fold
-      (fun _id entry acc -> `Assoc (pending_entry_json_fields entry) :: acc)
-      (Atomic.get pending)
-      []
-  in
-  `List (sort_entries_by_requested_at entries)
+  pending_entries_in_sequence_order ()
+  |> List.map (fun entry -> `Assoc (pending_entry_json_fields entry))
+  |> fun entries -> `List entries
 ;;
 
 let list_pending_dashboard_json () : Yojson.Safe.t =
-  let entries =
-    SMap.fold
-      (fun _id entry acc ->
-         `Assoc
-           (pending_entry_json_fields
-              ~include_input:true
-              entry)
-         :: acc)
-      (Atomic.get pending)
-      []
-  in
-  `List (sort_entries_by_requested_at entries)
+  pending_entries_in_sequence_order ()
+  |> List.map (fun entry ->
+    `Assoc (pending_entry_json_fields ~include_input:true entry))
+  |> fun entries -> `List entries
 ;;
 
 let list_pending_entries () : pending_approval list =
-  SMap.fold (fun _id entry acc -> entry :: acc) (Atomic.get pending) []
-  |> List.sort (fun left right -> Float.compare left.requested_at right.requested_at)
+  pending_entries_in_sequence_order ()
 ;;
 
 let pending_entry_detail_json (entry : pending_approval) : Yojson.Safe.t =

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -171,7 +171,8 @@ end
 
 (** Durably enqueue an exact request without suspending the caller. Returns an
     existing id only when the same Keeper, operation identity, canonical input,
-    turn/task/goal identity, and continuation channel are already pending. *)
+    turn/task/goal identity, and continuation channel are already pending. A
+    deduplicated request does not consume a durable queue sequence. *)
 val submit_pending :
   keeper_name:string ->
   tool_name:string ->

--- a/lib/keeper/keeper_gate.ml
+++ b/lib/keeper/keeper_gate.ml
@@ -289,7 +289,6 @@ module Auto_judge_owner = struct
 end
 
 module Auto_judge_owners = Map.Make (Auto_judge_owner)
-module Auto_judge_owner_set = Set.Make (Auto_judge_owner)
 
 let auto_judge_owner (entry : Keeper_approval_queue.pending_approval) =
   entry.audit_base_path, entry.keeper_name
@@ -342,8 +341,7 @@ let compare_auto_judge_entries
       (left : Keeper_approval_queue.pending_approval)
       (right : Keeper_approval_queue.pending_approval)
   =
-  let by_time = Float.compare left.requested_at right.requested_at in
-  if by_time <> 0 then by_time else String.compare left.id right.id
+  Int.compare left.sequence right.sequence
 ;;
 
 let ready_auto_judges_for_owner ?exclude_id ~base_path ~keeper_name entries =
@@ -356,6 +354,23 @@ let ready_auto_judges_for_owner ?exclude_id ~base_path ~keeper_name entries =
         | None -> true)
     && auto_judge_entry_ready entry)
   |> List.sort compare_auto_judge_entries
+;;
+
+let ready_auto_judge_heads ~base_path entries =
+  entries
+  |> List.fold_left
+       (fun owners (entry : Keeper_approval_queue.pending_approval) ->
+          if not (String.equal entry.audit_base_path base_path)
+             || not (auto_judge_entry_ready entry)
+          then owners
+          else
+            let owner = auto_judge_owner entry in
+            match Auto_judge_owners.find_opt owner owners with
+            | Some current when compare_auto_judge_entries current entry <= 0 -> owners
+            | Some _ | None -> Auto_judge_owners.add owner entry owners)
+       Auto_judge_owners.empty
+  |> Auto_judge_owners.bindings
+  |> List.map snd
 ;;
 
 type auto_judge_drain_outcome =
@@ -564,27 +579,18 @@ and drain_auto_judges ~base_path =
     []
   | Ok (Keeper_gate_mode.Manual | Keeper_gate_mode.Always_allow) -> []
   | Ok Keeper_gate_mode.Auto_judge ->
-    let owners =
-      Keeper_approval_queue.list_pending_entries ()
-      |> List.fold_left
-           (fun owners (entry : Keeper_approval_queue.pending_approval) ->
-              if String.equal entry.audit_base_path base_path
-                 && auto_judge_entry_ready entry
-              then Auto_judge_owner_set.add (auto_judge_owner entry) owners
-              else owners)
-           Auto_judge_owner_set.empty
-    in
-    Auto_judge_owner_set.fold
-      (fun (_, keeper_name) started_ids ->
+    Keeper_approval_queue.list_pending_entries ()
+    |> ready_auto_judge_heads ~base_path
+    |> List.filter_map (fun (entry : Keeper_approval_queue.pending_approval) ->
          let outcome =
-           drain_auto_judge_owner_queue ~base_path ~keeper_name ()
+           drain_auto_judge_owner_queue
+             ~base_path
+             ~keeper_name:entry.keeper_name
+             ()
          in
          match outcome.started_id with
-         | Some id -> id :: started_ids
-         | None -> started_ids)
-      owners
-      []
-    |> List.rev
+         | Some id -> Some id
+         | None -> None)
 ;;
 
 type recovered_work =
@@ -922,3 +928,10 @@ let decide ?cycle_grant ~keeper_always_allow request =
       ();
     Unavailable reason
 ;;
+
+module For_testing = struct
+  let ready_auto_judge_heads = ready_auto_judge_heads
+  let claim_auto_judge = claim_auto_judge
+  let release_auto_judge = release_auto_judge
+  let reset_active_auto_judges () = Atomic.set active_auto_judges Auto_judge_owners.empty
+end

--- a/lib/keeper/keeper_gate.mli
+++ b/lib/keeper/keeper_gate.mli
@@ -85,8 +85,8 @@ val decide :
   decision
 
 (** Recover durable Auto Judge work for exactly one workspace. Each exact
-    [(base_path, keeper_name)] owner activates at most its oldest pending
-    judgment; completion drains only that owner's FIFO. Decisive persisted
+    [(base_path, keeper_name)] owner activates at most its lowest durable
+    approval sequence; completion drains only that owner's FIFO. Decisive persisted
     output is finalized without creating a worker. Failed judgments are never
     retried merely because a process restarted. Every recovery candidate id
     has an explicit started, finalized, skipped, or failed outcome. *)
@@ -116,3 +116,14 @@ val authorization_source_to_string : authorization_source -> string
 val deferred_reason_to_string : deferred_reason -> string
 val unavailable_reason_to_string : unavailable_reason -> string
 val decision_to_yojson : decision -> Yojson.Safe.t
+
+module For_testing : sig
+  val ready_auto_judge_heads :
+    base_path:string ->
+    Keeper_approval_queue.pending_approval list ->
+    Keeper_approval_queue.pending_approval list
+
+  val claim_auto_judge : Keeper_approval_queue.pending_approval -> bool
+  val release_auto_judge : Keeper_approval_queue.pending_approval -> unit
+  val reset_active_auto_judges : unit -> unit
+end

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.ml
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.ml
@@ -29,6 +29,7 @@ type pending_approval =
   ; tool_name : string
   ; input_hash : string
   ; input : Yojson.Safe.t
+  ; sequence : int
   ; requested_at : float
   ; turn_id : int option
   ; request_context : Yojson.Safe.t option

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.mli
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.mli
@@ -24,13 +24,15 @@ and summary_status =
   | Summary_available of hitl_context_summary
   | Summary_failed of { reason : string; retryable : bool }
 
-(** A pending request never owns or suspends a Keeper lane. *)
+(** A pending request never owns or suspends a Keeper lane. [sequence] is the
+    durable queue-issued order identity; [requested_at] is observation only. *)
 type pending_approval =
   { id : string
   ; keeper_name : string
   ; tool_name : string
   ; input_hash : string
   ; input : Yojson.Safe.t
+  ; sequence : int
   ; requested_at : float
   ; turn_id : int option
   ; request_context : Yojson.Safe.t option

--- a/test/test_hitl_summary_worker.ml
+++ b/test/test_hitl_summary_worker.ml
@@ -18,6 +18,7 @@ let sample_entry : Q.pending_approval =
         ; "body", `String "hello"
         ; "api_key", `String "sk-test-secret"
         ]
+  ; sequence = 1
   ; requested_at = 1780587600.0
   ; turn_id = None
   ; request_context =

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -48,6 +48,10 @@ let require_some message = function
   | None -> Alcotest.fail message
 ;;
 
+let pending_entry_exn id =
+  AQ.get_pending_entry ~id |> require_some ("pending approval not found: " ^ id)
+;;
+
 let drop_resolution ~base_path ~keeper_name resolution =
   let post_id = Keeper_event_queue.hitl_resolution_post_id resolution in
   match Registry_queue.drop_by_post_id ~base_path keeper_name ~post_id with
@@ -258,7 +262,8 @@ let test_install_serializes_snapshot_read_with_same_base_mutation () =
        write_pending_snapshot
          ~base_path
          (`Assoc
-            [ "version", `Int 2
+            [ "version", `Int 3
+            ; "next_sequence", `Int 1
             ; "pending", `List []
             ; "deliveries", `List []
             ]);
@@ -374,6 +379,11 @@ let test_submit_is_nonblocking_and_exactly_deduplicated () =
        in
        Alcotest.(check bool) "changed field is a different request" true
          (not (String.equal first changed));
+       Alcotest.(check int) "first request sequence" 1 (pending_entry_exn first).sequence;
+       Alcotest.(check int)
+         "dedup does not consume sequence"
+         2
+         (pending_entry_exn changed).sequence;
        (match AQ.get_pending_entry ~id:first with
         | None -> Alcotest.fail "pending request missing"
         | Some entry ->
@@ -394,6 +404,73 @@ let test_submit_is_nonblocking_and_exactly_deduplicated () =
         | None -> Alcotest.fail "pending request was not restored");
        reject_and_cleanup ~base_path first;
        reject_and_cleanup ~base_path changed)
+;;
+
+let test_monotonic_sequence_survives_restart () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      AQ.For_testing.reset_runtime_state ();
+      cleanup_dir base_path)
+    (fun () ->
+       AQ.For_testing.reset_runtime_state ();
+       let first = submit ~base_path ~keeper_name:"sequence-owner" ~input:(`Int 1) in
+       let second = submit ~base_path ~keeper_name:"sequence-owner" ~input:(`Int 2) in
+       Alcotest.(check int) "first durable sequence" 1 (pending_entry_exn first).sequence;
+       Alcotest.(check int) "second durable sequence" 2 (pending_entry_exn second).sequence;
+       AQ.For_testing.reset_runtime_state ();
+       ignore (install_exn ~base_path);
+       let third = submit ~base_path ~keeper_name:"sequence-owner" ~input:(`Int 3) in
+       Alcotest.(check int) "restart continues sequence" 3 (pending_entry_exn third).sequence;
+       let open Yojson.Safe.Util in
+       Alcotest.(check int)
+         "next sequence is durable"
+         4
+         (read_pending_snapshot ~base_path |> member "next_sequence" |> to_int))
+;;
+
+let test_same_owner_head_uses_sequence_not_wall_clock () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      AQ.For_testing.reset_runtime_state ();
+      cleanup_dir base_path)
+    (fun () ->
+       AQ.For_testing.reset_runtime_state ();
+       let first = submit ~base_path ~keeper_name:"fifo-owner" ~input:(`Int 1) in
+       let second = submit ~base_path ~keeper_name:"fifo-owner" ~input:(`Int 2) in
+       let first = { (pending_entry_exn first) with requested_at = 500.0 } in
+       let second = { (pending_entry_exn second) with requested_at = 1.0 } in
+       match Gate.For_testing.ready_auto_judge_heads ~base_path [ second; first ] with
+       | [ head ] -> Alcotest.(check string) "oldest sequence wins" first.id head.id
+       | heads ->
+         Alcotest.failf "one same-owner head expected, got %d" (List.length heads))
+;;
+
+let test_different_owners_claim_in_parallel () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Gate.For_testing.reset_active_auto_judges ();
+      AQ.For_testing.reset_runtime_state ();
+      cleanup_dir base_path)
+    (fun () ->
+       AQ.For_testing.reset_runtime_state ();
+       Gate.For_testing.reset_active_auto_judges ();
+       let owner_a = pending_entry_exn (submit ~base_path ~keeper_name:"owner-a" ~input:(`Int 1)) in
+       let owner_a_next =
+         pending_entry_exn (submit ~base_path ~keeper_name:"owner-a" ~input:(`Int 2))
+       in
+       let owner_b = pending_entry_exn (submit ~base_path ~keeper_name:"owner-b" ~input:(`Int 1)) in
+       Alcotest.(check bool) "first owner activates" true
+         (Gate.For_testing.claim_auto_judge owner_a);
+       Alcotest.(check bool) "same owner remains queued" false
+         (Gate.For_testing.claim_auto_judge owner_a_next);
+       Alcotest.(check bool) "different owner activates in parallel" true
+         (Gate.For_testing.claim_auto_judge owner_b);
+       Gate.For_testing.release_auto_judge owner_a;
+       Alcotest.(check bool) "same owner next activates after release" true
+         (Gate.For_testing.claim_auto_judge owner_a_next))
 ;;
 
 let test_resolution_is_durable_and_origin_scoped () =
@@ -1048,7 +1125,8 @@ let test_malformed_snapshot_fails_install_and_is_observed () =
        write_pending_snapshot
          ~base_path
          (`Assoc
-            [ "version", `Int 2
+            [ "version", `Int 3
+            ; "next_sequence", `Int 1
             ; "pending", `List [ `String "malformed-entry" ]
             ; "deliveries", `List []
             ]);
@@ -1078,7 +1156,8 @@ let test_malformed_snapshot_fails_install_and_is_observed () =
          (Yojson.Safe.equal
             persisted
             (`Assoc
-               [ "version", `Int 2
+               [ "version", `Int 3
+               ; "next_sequence", `Int 1
                ; "pending", `List [ `String "malformed-entry" ]
                ; "deliveries", `List []
                ]));
@@ -1117,7 +1196,8 @@ let test_persisted_delivery_replays_before_origin_wake () =
        write_pending_snapshot
          ~base_path
          (`Assoc
-            [ "version", `Int 2
+            [ "version", `Int 3
+            ; "next_sequence", `Int 2
             ; "pending", `List []
             ; ( "deliveries"
               , `List
@@ -1207,7 +1287,8 @@ let test_one_delivery_replay_failure_does_not_stop_others () =
        write_pending_snapshot
          ~base_path
          (`Assoc
-            [ "version", `Int 2
+            [ "version", `Int 3
+            ; "next_sequence", `Int 3
             ; "pending", `List []
             ; ( "deliveries"
               , `List
@@ -1445,6 +1526,18 @@ let () =
             "submit is nonblocking and exact"
             `Quick
             test_submit_is_nonblocking_and_exactly_deduplicated
+        ; Alcotest.test_case
+            "durable sequence survives restart"
+            `Quick
+            test_monotonic_sequence_survives_restart
+        ; Alcotest.test_case
+            "same owner drains by durable sequence"
+            `Quick
+            test_same_owner_head_uses_sequence_not_wall_clock
+        ; Alcotest.test_case
+            "different owners activate in parallel"
+            `Quick
+            test_different_owners_claim_in_parallel
         ; Alcotest.test_case
             "dedup keeps distinct origins"
             `Quick


### PR DESCRIPTION
## What

- hard-cut the approval queue snapshot to typed v3 state with a workspace `next_sequence`
- assign positive unique sequence values and order each Keeper owner queue by sequence, never wall clock
- keep dedup idempotent without consuming a new sequence
- fail explicitly on sequence exhaustion instead of wrapping or silently reusing identity
- preserve restart continuity and allow different Keeper owners to claim/release independently

## Boundary

This is per-`(base_path, keeper)` FIFO identity. It adds no risk hierarchy, numeric admission cap, global grant, command/tool-name classifier, implicit retry, or provider/vendor special case. It is stacked on #25049.

## Validation

- previous exact parent (`2fa0e6b30d`) focused build green
- direct approval queue tests: 24/24 green
- direct HITL summary tests: 13/13 green
- latest parent is rebased on `6d8d4364fe`; child leaf is 379 changed lines and `git diff --check` clean
- exact latest focused build was not claimed: repeated unrelated bare `dune build` processes starved the guarded wrapper; PR CI is the latest-head build authority

## Adversarial cases

- wall-clock inversion still drains by durable sequence
- restart keeps the next sequence strictly above every persisted item
- duplicate enqueue does not advance sequence
- stale completion cannot release a newer owner
- different owners make progress independently

## Not claimed

This leaf does not implement Scheduler occurrence grants or product-level semantic approval. Each effect still requires the configured Always Allowed, Auto Judge, or nonblocking Manual decision path.