### PR TITLE
fix(keeper): resolve compaction summarizer through the structured-judge lane

### DIFF
--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -182,22 +182,55 @@ type requested_compaction =
   ; dropped_message_count : int
   }
 
+(* Non-empty, trimmed runtime id from a lazily-invoked source, or [None] on a
+   blank result or an unresolvable identity ([Failure], e.g.
+   [default_runtime_id_or_fail] when the runtime state is uninitialized). [f]
+   must be a thunk, not an already-evaluated value: OCaml forces arguments
+   before a function call, so catching [Failure] here only works if the
+   raising call happens inside this match. *)
+let trimmed_runtime_id_opt (f : unit -> string) =
+  match f () with
+  | runtime_id ->
+    let trimmed = String.trim runtime_id in
+    if trimmed = "" then None else Some trimmed
+  | exception Failure _ -> None
+;;
+
+(* The structured-judge lane is schema-capable by construction (RFC-0307):
+   every consumer that needs provider-native structured output (board
+   attention judgment, failure judgment, HITL summary) routes there instead of
+   inheriting a keeper's own chat assignment. Compaction used to be the one
+   exception, sourcing its runtime solely from the keeper's chat assignment
+   ([Keeper_meta_contract.runtime_id_of_meta]) — which, for most of the fleet,
+   resolves to [runtime].default. That default is picked for chat throughput,
+   not schema support, so schema-ineligible chat models (e.g.
+   deepseek-v4-flash) left compaction permanently rejecting with
+   [Summarizer_unavailable]: those keepers could never compact, so their
+   history only grew until every turn hit a provider ContextOverflow (#25051).
+
+   Trying the structured-judge id first fixes that without weakening the
+   fail-closed schema check in
+   [Keeper_compaction_llm_summarizer.eligible_candidate]: it is just a
+   higher-priority *candidate*, still filtered for schema support like any
+   other. The keeper's own chat runtime stays as a later candidate — sound
+   only because that per-candidate schema filter still applies to it, so an
+   already-eligible chat model (or an operator-configured compaction lane) is
+   never displaced. *)
+let compaction_runtime_ids (meta : keeper_meta) =
+  List.filter_map
+    Fun.id
+    [ trimmed_runtime_id_opt Runtime.runtime_id_for_structured_judge
+    ; trimmed_runtime_id_opt (fun () -> Keeper_meta_contract.runtime_id_of_meta meta)
+    ]
+;;
+
 let requested_messages (meta : keeper_meta) messages =
-  let runtime_id =
-    try
-      let runtime_id = Keeper_meta_contract.runtime_id_of_meta meta in
-      if String.trim runtime_id = ""
-      then Error Runtime_identity_unavailable
-      else Ok runtime_id
-    with
-    | Failure _ -> Error Runtime_identity_unavailable
-  in
-  match runtime_id with
-  | Error _ as error -> error
-  | Ok runtime_id ->
+  match compaction_runtime_ids meta with
+  | [] -> Error Runtime_identity_unavailable
+  | runtime_ids ->
     (match
        Keeper_compaction_llm_summarizer.make
-         ~runtime_id
+         ~runtime_ids
          ~keeper_name:meta.name
          ()
      with
@@ -384,3 +417,7 @@ let compact_for_request_typed
         ; evidence = Some evidence
         })
 ;;
+
+module For_testing = struct
+  let compaction_runtime_ids = compaction_runtime_ids
+end

--- a/lib/keeper/keeper_compact_policy.mli
+++ b/lib/keeper/keeper_compact_policy.mli
@@ -70,3 +70,15 @@ val register_record_pre_compact
       -> trigger:Compaction_trigger.t
       -> pre_compact_event option)
   -> unit
+
+module For_testing : sig
+  (** Priority-ordered candidate runtime ids for the compaction plan call: the
+      structured-judge lane first (schema-capable by construction, RFC-0307),
+      then the keeper's own chat runtime as a lower-priority candidate. Both
+      are seed ids into
+      {!Keeper_compaction_llm_summarizer.candidate_runtime_ids_for_assignments};
+      an id that is blank or fails to resolve (e.g. runtime state not yet
+      initialized) is omitted rather than failing the whole list. Empty only
+      when neither source resolves. *)
+  val compaction_runtime_ids : Keeper_meta_contract.keeper_meta -> string list
+end

--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -275,20 +275,50 @@ let candidates_for_assignment ~keeper_name assignment_id =
   | `Lane lane ->
     resolve_lane [] (Runtime_lane.ordered_candidates lane)
 
-type make_fn = runtime_id:string -> keeper_name:string -> unit -> summarizer option
+(* Collapse duplicate runtime ids while keeping the first (highest-priority)
+   occurrence, so a seed assignment that resolves to the same runtime as a
+   later seed is only ever tried once. *)
+let dedup_candidates candidates =
+  let seen = Hashtbl.create 8 in
+  List.filter
+    (fun candidate ->
+      if Hashtbl.mem seen candidate.runtime_id
+      then false
+      else begin
+        Hashtbl.add seen candidate.runtime_id ();
+        true
+      end)
+    candidates
+
+(* [assignment_ids] is a priority-ordered list of seed ids (each independently
+   a Runtime or a Runtime Lane, per {!candidates_for_assignment}). Every
+   eligible candidate from every seed is tried, seed order first and then
+   per-seed lane order, with cross-seed duplicates collapsed. A seed that
+   fails to resolve (Missing, or a Lane candidate that disappeared)
+   contributes no candidates rather than aborting the other seeds — the
+   overall chain is empty only when every seed is empty. *)
+let candidates_for_assignments ~keeper_name assignment_ids =
+  assignment_ids
+  |> List.concat_map (fun assignment_id ->
+    match candidates_for_assignment ~keeper_name assignment_id with
+    | None -> []
+    | Some candidates -> candidates)
+  |> dedup_candidates
+
+type make_fn = runtime_ids:string list -> keeper_name:string -> unit -> summarizer option
 let make_override : make_fn option Atomic.t = Atomic.make None
 
-let make_resolved ?complete ~(runtime_id : string) ~(keeper_name : string) ()
+let make_resolved ?complete ~(runtime_ids : string list) ~(keeper_name : string) ()
   : summarizer option
   =
-  match candidates_for_assignment ~keeper_name runtime_id with
-  | None -> None
-  | Some [] ->
+  let assignments_label = String.concat "," runtime_ids in
+  match candidates_for_assignments ~keeper_name runtime_ids with
+  | [] ->
     Log.Keeper.warn ~keeper_name
-      "compaction LLM summarizer has no eligible candidate assignment=%s"
-      runtime_id;
+      "compaction LLM summarizer has no eligible candidate assignments=%s"
+      assignments_label;
     None
-  | Some candidates ->
+  | candidates ->
     (match Eio_context.get_switch_opt (), Eio_context.get_net_opt () with
      | Some sw, Some net ->
        let clock = Eio_context.get_clock_opt () in
@@ -297,8 +327,8 @@ let make_resolved ?complete ~(runtime_id : string) ~(keeper_name : string) ()
            let rec attempt = function
              | [] ->
                Log.Keeper.warn ~keeper_name
-                 "compaction LLM candidate chain exhausted assignment=%s"
-                 runtime_id;
+                 "compaction LLM candidate chain exhausted assignments=%s"
+                 assignments_label;
                None
              | candidate :: rest ->
                (match
@@ -308,8 +338,8 @@ let make_resolved ?complete ~(runtime_id : string) ~(keeper_name : string) ()
                 with
                 | Some _ as plan ->
                   Log.Keeper.info ~keeper_name
-                    "compaction LLM candidate succeeded assignment=%s runtime=%s"
-                    runtime_id candidate.runtime_id;
+                    "compaction LLM candidate succeeded assignments=%s runtime=%s"
+                    assignments_label candidate.runtime_id;
                   plan
                 | None -> attempt rest)
            in
@@ -318,16 +348,16 @@ let make_resolved ?complete ~(runtime_id : string) ~(keeper_name : string) ()
        List.iter
          (fun candidate ->
            Log.Keeper.warn ~keeper_name
-             "compaction LLM candidate skipped runtime=%s assignment=%s: Eio \
+             "compaction LLM candidate skipped runtime=%s assignments=%s: Eio \
               context unavailable"
-             candidate.runtime_id runtime_id)
+             candidate.runtime_id assignments_label)
        candidates;
        None)
 
-let make ?complete ~runtime_id ~keeper_name () =
+let make ?complete ~runtime_ids ~keeper_name () =
   match Atomic.get make_override with
-  | Some override -> override ~runtime_id ~keeper_name ()
-  | None -> make_resolved ?complete ~runtime_id ~keeper_name ()
+  | Some override -> override ~runtime_ids ~keeper_name ()
+  | None -> make_resolved ?complete ~runtime_ids ~keeper_name ()
 
 module For_testing = struct
   let with_make_override override f =
@@ -339,4 +369,8 @@ module For_testing = struct
   let candidate_runtime_ids_for_assignment ~keeper_name ~runtime_id =
     candidates_for_assignment ~keeper_name runtime_id
     |> Option.map (List.map (fun candidate -> candidate.runtime_id))
+
+  let candidate_runtime_ids_for_assignments ~keeper_name ~runtime_ids =
+    candidates_for_assignments ~keeper_name runtime_ids
+    |> List.map (fun candidate -> candidate.runtime_id)
 end

--- a/lib/keeper/keeper_compaction_llm_summarizer.mli
+++ b/lib/keeper/keeper_compaction_llm_summarizer.mli
@@ -28,18 +28,21 @@ type summarizer = messages:Agent_sdk.Types.message list -> compaction_plan optio
     {!Llm_provider.Complete.complete}; overridable in tests. *)
 type complete_fn = Keeper_provider_subcall.complete_fn
 
-(** [make ~runtime_id ~keeper_name ()] resolves [runtime_id] as a Runtime or
-    Runtime Lane. A Runtime contributes its exact provider config; a Lane tries
-    its configured Runtime candidates in declared order until one returns a
-    valid plan. Missing, ineligible, and failed candidates are logged with
-    their Runtime id. No default Runtime is substituted. [complete] overrides
-    the Provider boundary in tests.
+(** [make ~runtime_ids ~keeper_name ()] resolves each id in [runtime_ids],
+    most-preferred first, exactly as a single {!candidate_runtime_ids_for_assignment}
+    would: a Runtime contributes its exact provider config, a Lane tries its
+    configured Runtime candidates in declared order. Every eligible candidate
+    across every seed id is tried, seed order first and then per-seed lane
+    order, with candidates that resolve to the same Runtime id collapsed to
+    their first (highest-priority) occurrence. Missing, ineligible, and failed
+    candidates are logged with their Runtime id. No default Runtime is
+    substituted. [complete] overrides the Provider boundary in tests.
 
     The compaction owner imposes no wall-clock deadline. Cancellation belongs
     to the owning Keeper lane or to the Provider transport boundary. *)
 val make
   :  ?complete:complete_fn
-  -> runtime_id:string
+  -> runtime_ids:string list
   -> keeper_name:string
   -> unit
   -> summarizer option
@@ -68,7 +71,7 @@ val apply
 
 module For_testing : sig
   val with_make_override
-    :  (runtime_id:string -> keeper_name:string -> unit -> summarizer option)
+    :  (runtime_ids:string list -> keeper_name:string -> unit -> summarizer option)
     -> (unit -> 'a)
     -> 'a
 
@@ -78,10 +81,20 @@ module For_testing : sig
     :  Llm_provider.Provider_config.t
     -> Llm_provider.Provider_config.t
 
-  (** Eligible Runtime ids for a Runtime/Lane assignment, in exact declaration
-      order. Provider configs are intentionally not exposed. *)
+  (** Eligible Runtime ids for a single Runtime/Lane assignment, in exact
+      declaration order. Provider configs are intentionally not exposed. *)
   val candidate_runtime_ids_for_assignment
     :  keeper_name:string
     -> runtime_id:string
     -> string list option
+
+  (** Eligible Runtime ids across a priority-ordered list of seed
+      Runtime/Lane assignments, in exact seed-then-declaration order, with
+      cross-seed duplicates collapsed to their first occurrence. Unlike
+      {!candidate_runtime_ids_for_assignment}, this never returns [None]: a
+      seed that fails to resolve simply contributes no candidates. *)
+  val candidate_runtime_ids_for_assignments
+    :  keeper_name:string
+    -> runtime_ids:string list
+    -> string list
 end

--- a/test/test_compaction_llm_summarizer.ml
+++ b/test/test_compaction_llm_summarizer.ml
@@ -7,6 +7,7 @@
 
 open Masc
 module C = Keeper_compaction_llm_summarizer
+module Compact_policy = Keeper_compact_policy
 
 let plan_json ~summary ~kept ~summarized ~dropped : Yojson.Safe.t =
   let ints xs = `List (List.map (fun i -> `Int i) xs) in
@@ -106,6 +107,137 @@ let test_lane_candidates_keep_declared_order () =
   Alcotest.(check (option (list string))) "declared candidate order"
     (Some [ "local.kimi_like"; "fallback.kimi_like" ])
     actual
+
+(* -- #25051 P0: structured-judge lane precedes an ineligible chat runtime --
+
+   On the live fleet, most keepers inherit [runtime].default for chat, which
+   is picked for chat throughput and is not guaranteed to support the
+   provider-native structured-output schema the compaction plan call needs.
+   [runtime].structured_judge, by contrast, is explicitly reserved for
+   schema-capable requests (RFC-0307), the same lane board-attention judgment
+   and failure judgment already use. These fixtures give "chat" no
+   [supports-structured-output] (ineligible, mirrors deepseek-v4-flash in
+   config/runtime.toml) and "judge" [supports-structured-output = true]
+   (eligible), so the tests below can tell the two candidate sources apart. *)
+
+let ineligible_chat_runtime_id = "lane_split_chat.chat_model"
+let eligible_judge_runtime_id = "lane_split_judge.judge_model"
+
+let lane_split_runtime_toml =
+  "[providers.lane_split_chat]\n\
+   display-name = \"Lane Split Chat\"\n\
+   protocol = \"ollama-http\"\n\
+   endpoint = \"http://localhost:11434\"\n\
+   \n\
+   [providers.lane_split_judge]\n\
+   display-name = \"Lane Split Judge\"\n\
+   protocol = \"ollama-http\"\n\
+   endpoint = \"http://localhost:11436\"\n\
+   \n\
+   [models.chat_model]\n\
+   api-name = \"chat-model\"\n\
+   max-context = 1024\n\
+   \n\
+   [models.chat_model.capabilities]\n\
+   supports-structured-output = false\n\
+   \n\
+   [models.judge_model]\n\
+   api-name = \"judge-model\"\n\
+   max-context = 1024\n\
+   \n\
+   [models.judge_model.capabilities]\n\
+   supports-structured-output = true\n\
+   \n\
+   [lane_split_chat.chat_model]\n\
+   \n\
+   [lane_split_judge.judge_model]\n\
+   \n\
+   [runtime]\n\
+   default = \"lane_split_chat.chat_model\"\n\
+   structured_judge = \"lane_split_judge.judge_model\"\n"
+
+let with_lane_split_runtime f =
+  let path = Filename.temp_file "compaction_lane_split_runtime" ".toml" in
+  let runtime_snapshot = Runtime.For_testing.snapshot () in
+  let oc = open_out path in
+  output_string oc lane_split_runtime_toml;
+  close_out oc;
+  Fun.protect
+    ~finally:(fun () ->
+      Runtime.For_testing.restore runtime_snapshot;
+      try Sys.remove path with
+      | Sys_error _ -> ())
+    (fun () ->
+      match Runtime.save_config_text ~runtime_config_path:path lane_split_runtime_toml with
+      | Error detail -> Alcotest.failf "runtime config should load: %s" detail
+      | Ok () -> f ())
+
+let test_ineligible_chat_runtime_alone_has_no_candidate () =
+  with_lane_split_runtime @@ fun () ->
+  (* Reproduces the #25051 P0 symptom directly: when the keeper's own chat
+     runtime is the only seed (the pre-fix behaviour), an ineligible model
+     resolves to zero candidates, so the summarizer is permanently
+     unavailable for that keeper. *)
+  Alcotest.(check (option (list string)))
+    "an ineligible seed alone resolves no candidates"
+    (Some [])
+    (C.For_testing.candidate_runtime_ids_for_assignment
+       ~keeper_name:"keeper-test"
+       ~runtime_id:ineligible_chat_runtime_id)
+
+let test_structured_judge_seed_reaches_eligible_candidate () =
+  with_lane_split_runtime @@ fun () ->
+  (* The fix: seeding the chain with the structured-judge id first gives the
+     chain an eligible candidate even though the keeper's own chat runtime
+     (still present as a lower-priority seed) remains ineligible. *)
+  Alcotest.(check (list string))
+    "structured-judge seed supplies the only eligible candidate, ordered first"
+    [ eligible_judge_runtime_id ]
+    (C.For_testing.candidate_runtime_ids_for_assignments
+       ~keeper_name:"keeper-test"
+       ~runtime_ids:[ eligible_judge_runtime_id; ineligible_chat_runtime_id ])
+
+let test_both_seeds_unresolvable_yields_no_candidate () =
+  with_lane_split_runtime @@ fun () ->
+  (* No silent fallback: an unresolvable structured-judge id alongside an
+     ineligible chat runtime must still resolve to zero candidates, never a
+     surprise fallback onto the ineligible model. *)
+  Alcotest.(check (list string))
+    "no candidate when every seed fails to resolve or is ineligible"
+    []
+    (C.For_testing.candidate_runtime_ids_for_assignments
+       ~keeper_name:"keeper-test"
+       ~runtime_ids:[ "no.such.runtime"; ineligible_chat_runtime_id ])
+
+let test_duplicate_seed_collapses_to_one_candidate () =
+  with_lane_split_runtime @@ fun () ->
+  Alcotest.(check (list string))
+    "the same runtime id named twice as a seed is tried once"
+    [ eligible_judge_runtime_id ]
+    (C.For_testing.candidate_runtime_ids_for_assignments
+       ~keeper_name:"keeper-test"
+       ~runtime_ids:[ eligible_judge_runtime_id; eligible_judge_runtime_id ])
+
+let make_test_meta name =
+  match Masc_test_deps.meta_of_json_fixture (`Assoc [ "name", `String name ]) with
+  | Ok m -> m
+  | Error e -> Alcotest.failf "meta fixture failed: %s" e
+
+let test_compact_policy_prefers_structured_judge_over_chat_runtime () =
+  with_lane_split_runtime @@ fun () ->
+  (* End-to-end proof at the Keeper_compact_policy call site (not just the
+     summarizer's candidate resolution): a keeper with no explicit runtime
+     assignment inherits [runtime].default for chat (ineligible here), yet
+     the candidate-id list built for the compaction plan call still puts the
+     structured-judge runtime first. Counterfactual: on the pre-#25051 code,
+     [Compact_policy.For_testing] does not exist (single [runtime_id] sourced
+     solely from the keeper's own chat assignment), so this fails to compile
+     on that base — verified by stashing this fix and re-running the build. *)
+  let meta = make_test_meta "lane-split-keeper" in
+  Alcotest.(check (list string))
+    "structured-judge runtime precedes the keeper's own chat runtime"
+    [ eligible_judge_runtime_id; ineligible_chat_runtime_id ]
+    (Compact_policy.For_testing.compaction_runtime_ids meta)
 
 (* -- plan_of_json: valid partition accepted -- *)
 
@@ -237,6 +369,18 @@ let () =
             test_provider_for_plan_preserves_temperature_omission
         ; Alcotest.test_case "lane candidates keep declared order" `Quick
             test_lane_candidates_keep_declared_order
+        ] )
+    ; ( "structured_judge_lane_split_25051"
+      , [ Alcotest.test_case "ineligible chat runtime alone has no candidate" `Quick
+            test_ineligible_chat_runtime_alone_has_no_candidate
+        ; Alcotest.test_case "structured-judge seed reaches an eligible candidate" `Quick
+            test_structured_judge_seed_reaches_eligible_candidate
+        ; Alcotest.test_case "both seeds unresolvable yields no candidate" `Quick
+            test_both_seeds_unresolvable_yields_no_candidate
+        ; Alcotest.test_case "duplicate seed collapses to one candidate" `Quick
+            test_duplicate_seed_collapses_to_one_candidate
+        ; Alcotest.test_case "compact policy prefers structured judge over chat runtime" `Quick
+            test_compact_policy_prefers_structured_judge_over_chat_runtime
         ] )
     ; ( "plan_of_json"
       , [ Alcotest.test_case "valid partition accepted" `Quick test_valid_partition_accepted

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -297,7 +297,7 @@ let test_manual_compaction_serializes_owner_lane () =
       Atomic.set owner_entry.fiber_stop true;
       let outcome =
         Masc.Keeper_compaction_llm_summarizer.For_testing.with_make_override
-          (fun ~runtime_id:_ ~keeper_name:_ () ->
+          (fun ~runtime_ids:_ ~keeper_name:_ () ->
              Some (fun ~messages:_ -> Some plan))
           run_cycle
       in


### PR DESCRIPTION
## Why

**#25051 (적대 검증 P0)**: 컴팩션 summarizer가 keeper 자신의 chat runtime에서 모델을 해석 → 라이브 16 keeper 중 12(deepseek-v4-flash ×9, glm-coding ×3)가 structured-output 부적격 → 매 시도 `Summarizer_unavailable` → **영구 컴팩션 불가** → 히스토리 단조 성장 → 매 턴 provider overflow (#24838 게이트웨이 5MB 400 계열). librarian/structured_judge/hitl_summary/cross_verifier는 이미 스키마 가능 runtime으로 분리돼 있었고 **컴팩션만 chat default를 상속하는 마지막 소비자**였다.

라이브 실증: #25019 배포 후 4분 내 rondo/taskmaster/ramarama/verifier가 동일 실패 (해당 이슈 코멘트 참조).

## What

- `Keeper_compaction_llm_summarizer.make`: `runtime_id:string` → `runtime_ids:string list` (우선순위순). 시드별 해석 후 runtime_id 기준 dedup(최우선 승리).
- `Keeper_compact_policy.compaction_runtime_ids`: `[structured_judge; keeper chat runtime]` 시드. 판정 레인이 선두, keeper 자신의 runtime은 **후보별 적격성 검사가 유지되므로** 후순위 후보로 존치 (fail-closed 타입 불변: 전 후보 탈락 시 `Summarizer_unavailable`). `Runtime_identity_unavailable`은 양쪽 소스 모두 해석 실패 시에만.
- 테스트 5종 추가 (suite 20 green): **부적격 시드 단독 → empty = P0 증상 재현(counterfactual)** / structured-judge 시드가 부적격 chat runtime을 우회해 적격 후보 도달 / 양쪽 불해석 → empty(silent fallback 없음) / 중복 시드 dedup / compact-policy 레벨 우선순위 e2e.

## Scope note

#25051의 P1 절반(proactive ratio/token 게이트 배선)은 **의도적으로 미포함** — 열린 PR #25046이 같은 모듈(컴팩션 단위 변경, 직교)을 건드리고 있어 그 착지 후 별도 PR로. 이 PR은 P0만 절단한다.

## Verification

- `test_compaction_llm_summarizer.exe` 20/20 green (exit 0).
- 신규 API는 `.mli` 계약 우선으로 문서화, For_testing seam 2종 추가.

관련: #25051 · #24838 · #25019 · RFC-0307

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012KXQWcg9KtaC7KruGQTnwX
