### PR TITLE
refactor(keeper): make settlement WAL the commit point

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -536,6 +536,12 @@ let run_keepalive_unified_turn
              ( Keeper_registry_event_queue.Settled _
              | Keeper_registry_event_queue.Already_settled _ ) ->
            lease_settled := true
+         | Ok (Keeper_registry_event_queue.Committed_followup_failed { detail; _ }) ->
+           lease_settled := true;
+           Log.Keeper.error
+             "registry: requeue committed with follow-up failure keeper=%s: %s"
+             meta_after_triage.name
+             detail
          | Error message ->
            Log.Keeper.error
              "registry: failed to requeue unsettled lease keeper=%s: %s"
@@ -924,7 +930,14 @@ let run_keepalive_unified_turn
               mark_connector_attention_ignored_after_turn
                 ~base_path:ctx.config.base_path
                 ~keeper_name:meta_after_triage.name
-                (connector_attention_event_ids_of_stimuli !consumed_stimuli)));
+                (connector_attention_event_ids_of_stimuli !consumed_stimuli)
+          | Ok (Keeper_registry_event_queue.Committed_followup_failed { detail; _ }) ->
+            lease_settled := true;
+            Log.Keeper.error
+              "registry: settlement committed with follow-up failure keeper=%s: %s"
+              meta_after_triage.name
+              detail;
+            record_settlement_failure detail));
       { meta = meta_after_cycle; cycle_crashed = !settlement_failed }
     with
     | Eio.Cancel.Cancelled _ as e ->

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -43,6 +43,11 @@ type outbox_entry = Keeper_event_queue_persistence.outbox_entry
 type settle_result = Keeper_event_queue_persistence.settle_result =
   | Settled of transition_receipt
   | Already_settled of transition_receipt
+  | Committed_followup_failed of
+      { receipt : transition_receipt
+      ; stage : [ `Checkpoint | `Wal_compaction | `Projection ]
+      ; detail : string
+      }
 
 let lease_stimuli = Keeper_event_queue_persistence.lease_stimuli
 let lease_kind = Keeper_event_queue_persistence.lease_kind

--- a/lib/keeper/keeper_registry_event_queue.mli
+++ b/lib/keeper/keeper_registry_event_queue.mli
@@ -42,6 +42,11 @@ type outbox_entry = Keeper_event_queue_persistence.outbox_entry
 type settle_result = Keeper_event_queue_persistence.settle_result =
   | Settled of transition_receipt
   | Already_settled of transition_receipt
+  | Committed_followup_failed of
+      { receipt : transition_receipt
+      ; stage : [ `Checkpoint | `Wal_compaction | `Projection ]
+      ; detail : string
+      }
 
 val lease_stimuli : lease -> Keeper_event_queue.stimulus list
 val lease_kind : lease -> Keeper_event_queue_persistence.lease_kind

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -38,14 +38,20 @@ type lease = State.lease
 type transition_receipt = State.transition_receipt
 type outbox_entry = State.outbox_entry
 
-type settle_result = State.settle_result =
+type settle_result =
   | Settled of transition_receipt
   | Already_settled of transition_receipt
+  | Committed_followup_failed of
+      { receipt : transition_receipt
+      ; stage : [ `Checkpoint | `Wal_compaction | `Projection ]
+      ; detail : string
+      }
 
 let lease_stimuli (lease : lease) = lease.stimuli
 let lease_kind = State.lease_kind
 
 let snapshot_filename = "event-queue.json"
+let settlement_wal_filename = "event-queue-settlements.jsonl"
 let unsupported_inflight_filename = "event-queue-inflight.json"
 
 let owner_error_to_string = Owner_lock.resolve_error_to_string
@@ -68,6 +74,26 @@ let keeper_runtime_dir_of_owner owner =
 
 let snapshot_path_of_owner owner =
   Filename.concat (keeper_runtime_dir_of_owner owner) snapshot_filename
+;;
+
+let settlement_wal_path_of_owner owner =
+  Filename.concat (keeper_runtime_dir_of_owner owner) settlement_wal_filename
+;;
+
+let compact_settlement_wal_unlocked owner =
+  let path = settlement_wal_path_of_owner owner in
+  match
+    Fs_compat.rewrite_private_file_durable_locked_result path (fun existing ->
+      (if String.equal existing "" then None else Some ""), ())
+  with
+  | Ok () -> Ok ()
+  | Error detail ->
+    Error
+      (Printf.sprintf
+         "failed to compact checkpointed settlement WAL keeper=%s path=%s: %s"
+         (keeper_name_of_owner owner)
+         path
+         detail)
 ;;
 
 let unsupported_inflight_path_of_owner owner =
@@ -179,14 +205,105 @@ let reject_unsupported_inflight owner =
     Error (Printf.sprintf "failed to inspect unsupported sidecar %s: %s" path (Printexc.to_string exn))
 ;;
 
+let bump_revision state =
+  if Int64.equal (State.revision state) Int64.max_int
+  then Error "event queue revision exhausted"
+  else Ok (State.with_revision (Int64.succ (State.revision state)) state)
+;;
+
+let settlement_wal_entry_to_line owner receipt =
+  `Assoc
+    [ "schema", `String "masc.keeper_event_queue.settlement.v1"
+    ; "base_path", `String (Owner_lock.base_path owner)
+    ; "keeper_name", `String (keeper_name_of_owner owner)
+    ; "receipt", State.transition_receipt_to_yojson receipt
+    ]
+  |> Yojson.Safe.to_string
+  |> fun row -> row ^ "\n"
+;;
+
+let settlement_wal_receipt_of_json owner = function
+  | `Assoc fields ->
+    (match List.sort (fun (left, _) (right, _) -> String.compare left right) fields with
+     | [ ("base_path", `String base_path)
+       ; ("keeper_name", `String keeper_name)
+       ; ("receipt", receipt)
+       ; ("schema", `String schema)
+       ] ->
+       if not (String.equal schema "masc.keeper_event_queue.settlement.v1")
+       then Error (Printf.sprintf "unsupported settlement WAL schema: %s" schema)
+       else if
+         not
+           (String.equal base_path (Owner_lock.base_path owner)
+            && String.equal keeper_name (keeper_name_of_owner owner))
+       then Error "settlement WAL row owner does not match its Keeper lane"
+       else State.transition_receipt_of_yojson receipt
+     | _ -> Error "settlement WAL row fields are not exact")
+  | _ -> Error "settlement WAL row must be a JSON object"
+;;
+
+let replay_settlement_wal_bytes owner state bytes =
+  let rec replay state = function
+    | [] | [ "" ] -> Ok state
+    | "" :: _ -> Error "settlement WAL contains an empty row"
+    | line :: rest ->
+      (match
+         try Ok (Yojson.Safe.from_string line) with
+         | Yojson.Json_error detail -> Error detail
+       with
+       | Error detail -> Error ("invalid settlement WAL JSON: " ^ detail)
+       | Ok json ->
+         (match settlement_wal_receipt_of_json owner json with
+          | Error _ as error -> error
+          | Ok receipt ->
+            (match State.replay_transition_receipt receipt state with
+             | Error _ as error -> error
+             | Ok state -> replay state rest)))
+  in
+  replay state (String.split_on_char '\n' bytes)
+;;
+
+let replay_settlement_wal_unlocked owner state =
+  let path = settlement_wal_path_of_owner owner in
+  match Fs_compat.read_private_jsonl_slice_locked_result path ~from:0 with
+  | Error error ->
+    Error
+      (Printf.sprintf
+         "failed to read settlement WAL keeper=%s path=%s: %s"
+         (keeper_name_of_owner owner)
+         path
+         (Fs_compat.Private_jsonl_slice.error_to_string error))
+  | Ok { bytes = ""; _ } -> Ok state
+  | Ok slice ->
+    (match replay_settlement_wal_bytes owner state slice.bytes with
+     | Error detail -> Error (Printf.sprintf "failed to replay %s: %s" path detail)
+     | Ok replayed ->
+       (match bump_revision replayed with
+        | Error _ as error -> error
+        | Ok replayed ->
+          (match save_state_unlocked owner replayed with
+           | Ok () ->
+             (match compact_settlement_wal_unlocked owner with
+              | Ok () -> Ok replayed
+              | Error detail ->
+                Error
+                  ("settlement WAL checkpoint recovered but compaction failed: "
+                   ^ detail))
+           | Error detail ->
+             Error
+               (Printf.sprintf
+                  "settlement WAL is committed but checkpoint replay failed: %s"
+                  detail))))
+;;
+
 let load_state_unlocked owner =
   match reject_unsupported_inflight owner with
   | Error _ as error -> error
   | Ok () ->
     (match read_primary_unlocked owner with
      | Error _ as error -> error
-     | Ok (Primary_current state) -> Ok state
-     | Ok Primary_missing -> Ok State.empty)
+     | Ok (Primary_current state) -> replay_settlement_wal_unlocked owner state
+     | Ok Primary_missing -> replay_settlement_wal_unlocked owner State.empty)
 ;;
 
 let load_state_result ~base_path ~keeper_name =
@@ -389,12 +506,6 @@ let discover_keeper_names_with_snapshots ~base_path =
        })
 ;;
 
-let bump_revision state =
-  if Int64.equal (State.revision state) Int64.max_int
-  then Error "event queue revision exhausted"
-  else Ok (State.with_revision (Int64.succ (State.revision state)) state)
-;;
-
 let commit_transform_unlocked owner ~after_commit transform =
   match load_state_unlocked owner with
   | Error _ as error -> error
@@ -519,6 +630,72 @@ let claim_board_result
     | Ok (state, lease) -> Ok (state, lease))
 ;;
 
+let commit_settlement_unlocked
+      owner
+      ~after_commit
+      ~settled_at
+      ~lease
+      ~settlement
+      current
+  =
+  match State.settle ~settled_at ~lease ~settlement current with
+  | Error _ as error -> error
+  | Ok (state, State.Already_settled receipt) ->
+    Ok (Already_settled receipt, State.pending state)
+  | Ok (state, State.Settled receipt) ->
+    (match bump_revision state with
+     | Error _ as error -> error
+     | Ok checkpoint ->
+       let suffix = settlement_wal_entry_to_line owner receipt in
+       let path = settlement_wal_path_of_owner owner in
+       (match
+          Fs_compat.append_private_jsonl_durable_locked_at_end_offset_result
+            path
+            ~expected_end_offset:0
+            suffix
+        with
+        | Error error ->
+          Error
+            (Printf.sprintf
+               "settlement WAL commit failed keeper=%s path=%s: %s"
+               (keeper_name_of_owner owner)
+               path
+               (Fs_compat.private_jsonl_append_error_to_string error))
+        | Ok _committed_end_offset ->
+          let pending = State.pending checkpoint in
+          (match save_state_unlocked owner checkpoint with
+           | Error detail ->
+             Ok
+               ( Committed_followup_failed
+                   { receipt; stage = `Checkpoint; detail }
+               , pending )
+           | Ok () ->
+             (match compact_settlement_wal_unlocked owner with
+              | Error detail ->
+                Ok
+                  ( Committed_followup_failed
+                      { receipt; stage = `Wal_compaction; detail }
+                  , pending )
+              | Ok () ->
+                (match
+                   try
+                     after_commit pending;
+                     Ok ()
+                   with
+                   | Eio.Cancel.Cancelled _ as exn ->
+                     Error
+                       ("pending projection cancelled after settlement commit: "
+                        ^ Printexc.to_string exn)
+                   | exn -> Error (Printexc.to_string exn)
+                 with
+                 | Ok () -> Ok (Settled receipt, pending)
+                 | Error detail ->
+                   Ok
+                     ( Committed_followup_failed
+                         { receipt; stage = `Projection; detail }
+                     , pending ))))))
+;;
+
 let settle_result
       ?(after_commit = fun _ -> ())
       ~base_path
@@ -528,8 +705,30 @@ let settle_result
       ~settlement
       ()
   =
-  commit_transform ~base_path ~keeper_name ~after_commit (fun state ->
-    State.settle ~settled_at ~lease ~settlement state)
+  match resolve_owner ~base_path ~keeper_name with
+  | Error _ as error -> error
+  | Ok owner ->
+    (try
+       Owner_lock.with_durable_lock owner (fun () ->
+         match load_state_unlocked owner with
+         | Error _ as error -> error
+         | Ok state ->
+           commit_settlement_unlocked
+             owner
+             ~after_commit
+             ~settled_at
+             ~lease
+             ~settlement
+             state
+           |> Result.map fst)
+     with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn ->
+       Error
+         (Printf.sprintf
+            "event queue settlement raised keeper=%s: %s"
+            (keeper_name_of_owner owner)
+            (Printexc.to_string exn)))
 ;;
 
 let prepare_registration_result
@@ -539,10 +738,38 @@ let prepare_registration_result
       ~settled_at
       ()
   =
-  commit_transform ~base_path ~keeper_name ~after_commit (fun state ->
-    match State.recover_leases ~settled_at state with
-    | Error _ as error -> error
-    | Ok state -> Ok (state, State.pending state))
+  match resolve_owner ~base_path ~keeper_name with
+  | Error _ as error -> error
+  | Ok owner ->
+    (try
+       Owner_lock.with_durable_lock owner (fun () ->
+         match load_state_unlocked owner with
+         | Error _ as error -> error
+         | Ok state ->
+           (match State.active_lease state with
+            | None -> Ok (State.pending state)
+            | Some lease ->
+              (match
+                 commit_settlement_unlocked
+                   owner
+                   ~after_commit
+                   ~settled_at
+                   ~lease
+                   ~settlement:(Requeue Registration_recovery)
+                   state
+               with
+               | Error _ as error -> error
+               | Ok ((Settled _ | Already_settled _), pending) -> Ok pending
+               | Ok (Committed_followup_failed { detail; _ }, _) ->
+                 Error ("registration settlement committed with follow-up failure: " ^ detail))))
+     with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn ->
+       Error
+         (Printf.sprintf
+            "event queue registration settlement raised keeper=%s: %s"
+            (keeper_name_of_owner owner)
+            (Printexc.to_string exn)))
 ;;
 
 let mark_transition_projected_result ~base_path ~keeper_name ~transition_id =

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -1,6 +1,6 @@
 (** Durable per-Keeper Event Layer state.
 
-    [event-queue.json] uses one v3 envelope containing pending stimuli, active
+    [event-queue.json] keeps the v3 envelope containing pending stimuli, active
     typed leases, the monotonic lease sequence and the transition outbox.
     Older schemas are unsupported. [event-queue-inflight.json] is rejected
     explicitly rather than migrated or treated as a second authority. *)
@@ -42,9 +42,14 @@ type lease = Keeper_event_queue_state.lease
 type transition_receipt = Keeper_event_queue_state.transition_receipt
 type outbox_entry = Keeper_event_queue_state.outbox_entry
 
-type settle_result = Keeper_event_queue_state.settle_result =
+type settle_result =
   | Settled of transition_receipt
   | Already_settled of transition_receipt
+  | Committed_followup_failed of
+      { receipt : transition_receipt
+      ; stage : [ `Checkpoint | `Wal_compaction | `Projection ]
+      ; detail : string
+      }
 
 val lease_stimuli : lease -> Keeper_event_queue.stimulus list
 val lease_kind : lease -> lease_kind
@@ -111,7 +116,9 @@ val load_snapshot_pair_with_errors :
 val load_state_result :
   base_path:string -> keeper_name:string -> (Keeper_event_queue_state.t, string) result
 (** Strict state read used by tests and operator projection. A malformed v3
-    envelope or v3-plus-legacy residue is an [Error], never an empty queue. *)
+    envelope or v3-plus-legacy residue is an [Error], never an empty queue.
+    Committed WAL rows are replayed idempotently, checkpointed, and then
+    compacted to the exact empty suffix before the state is returned. *)
 
 val claim_when_result :
   ?after_commit:(Keeper_event_queue.t -> unit) ->
@@ -139,6 +146,11 @@ val settle_result :
   settlement:settlement ->
   unit ->
   (settle_result, string) result
+(** Append and fsync the owner-bound canonical receipt before checkpointing the
+    state snapshot. Once checkpointed, the exact WAL prefix is durably compacted
+    rather than retained by an arbitrary size policy. A post-commit checkpoint,
+    WAL-compaction or pending-projection failure is returned as a committed
+    outcome, never relabelled as an uncommitted error. *)
 
 val prepare_registration_result :
   ?after_commit:(Keeper_event_queue.t -> unit) ->
@@ -150,7 +162,8 @@ val prepare_registration_result :
 (** Registration boundary for a newly-owned lane. Requeues an abandoned lease,
     records its stable [Registration_recovery] transition, and returns the
     resulting pending projection from the same durable transaction. A malformed
-    state is an [Error]; registration must not substitute an empty queue. *)
+    state is an [Error]; registration must not substitute an empty queue.
+    Post-commit [Error] names that fact; retry replays the exact WAL cursor. *)
 
 val mark_transition_projected_result :
   base_path:string ->

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -113,6 +113,7 @@ let settle_and_project
     | Error error -> Alcotest.fail ("event queue settlement failed: " ^ error)
     | Ok (Masc.Keeper_registry_event_queue.Settled receipt)
     | Ok (Masc.Keeper_registry_event_queue.Already_settled receipt) -> receipt
+    | Ok _ -> Alcotest.fail "event queue settlement follow-up failed"
   in
   match
     Masc.Keeper_registry_event_queue.mark_transition_projected_result
@@ -1190,6 +1191,7 @@ let () =
         with
         | Ok (Masc.Keeper_registry_event_queue.Settled receipt)
         | Ok (Masc.Keeper_registry_event_queue.Already_settled receipt) -> receipt
+        | Ok _ -> Alcotest.fail "board digest settlement follow-up failed"
         | Error error -> Alcotest.fail ("board digest settlement failed: " ^ error)
       in
       (match
@@ -1295,6 +1297,7 @@ let () =
             Alcotest.failf
               "late registry registration repeated settlement for %s"
               expected_post_id
+          | Ok _ -> Alcotest.fail "late registration settlement follow-up failed"
           | Error error ->
             Alcotest.failf
               "late registry registration failed to settle %s: %s"
@@ -1588,6 +1591,7 @@ let () =
         | Ok (Masc.Keeper_registry_event_queue.Settled receipt) -> receipt
         | Ok (Masc.Keeper_registry_event_queue.Already_settled _) ->
           Alcotest.fail "first requeue unexpectedly reused a prior receipt"
+        | Ok _ -> Alcotest.fail "first requeue settlement follow-up failed"
         | Error error -> Alcotest.fail ("typed requeue failed: " ^ error)
       in
       assert (length (Keeper_event_queue_persistence.load ~base_path ~keeper_name) = 2);
@@ -1606,6 +1610,7 @@ let () =
        | Ok (Masc.Keeper_registry_event_queue.Already_settled _)
        | Ok (Masc.Keeper_registry_event_queue.Settled _) ->
          Alcotest.fail "repeated requeue changed the durable receipt"
+       | Ok _ -> Alcotest.fail "repeated requeue settlement follow-up failed"
        | Error error -> Alcotest.fail ("idempotent requeue failed: " ^ error));
       assert (length (Keeper_event_queue_persistence.load ~base_path ~keeper_name) = 2);
       (match

--- a/test/test_keeper_event_queue_state_v2.ml
+++ b/test/test_keeper_event_queue_state_v2.ml
@@ -749,6 +749,76 @@ let write_state path state =
   |> require_ok ("write fixture " ^ path)
 ;;
 
+let test_settlement_wal_commit_replay_and_owner_fence () =
+  with_temp_dir "keeper-event-queue-settlement-wal" (fun base_path ->
+    let keeper_name = "wal_owner" in
+    Persistence.update_result ~base_path ~keeper_name (fun pending ->
+      Queue.enqueue pending (stimulus "wal-source" 1.0))
+    |> require_ok "seed WAL owner";
+    let lease =
+      Persistence.claim_when_result
+        ~base_path ~keeper_name ~claimed_at:2.0 ~ready:(fun _ -> true) ()
+      |> require_ok "claim WAL source"
+      |> require_some "WAL lease"
+    in
+    let owner_dir = keeper_dir ~base_path ~keeper_name in
+    let wal_path = Filename.concat owner_dir "event-queue-settlements.jsonl" in
+    Fs_compat.save_file_atomic wal_path "" |> require_ok "create WAL";
+    Unix.chmod owner_dir 0o500;
+    let outcome =
+      Fun.protect
+        ~finally:(fun () -> Unix.chmod owner_dir 0o700)
+        (fun () ->
+           Persistence.settle_result
+             ~base_path ~keeper_name ~settled_at:3.0 ~lease ~settlement:State.Ack ())
+      |> require_ok "commit with blocked checkpoint"
+    in
+    (match outcome with
+     | Persistence.Committed_followup_failed { stage = `Checkpoint; _ } -> ()
+     | _ -> Alcotest.fail "checkpoint failure did not preserve committed outcome");
+    let committed_wal = Fs_compat.load_file wal_path in
+    Alcotest.(check bool)
+      "committed receipt remains in WAL before recovery"
+      true
+      (not (String.equal committed_wal ""));
+    let replayed =
+      Persistence.load_state_result ~base_path ~keeper_name
+      |> require_ok "replay committed WAL suffix"
+    in
+    Alcotest.(check int) "active lease replayed once" 0 (List.length (State.leases replayed));
+    Alcotest.(check string)
+      "checkpointed WAL is compacted exactly"
+      ""
+      (Fs_compat.load_file wal_path);
+    let replayed_again =
+      Persistence.load_state_result ~base_path ~keeper_name
+      |> require_ok "load after exact WAL compaction"
+    in
+    Alcotest.(check int64)
+      "applied WAL row is not replayed again"
+      (State.revision replayed)
+      (State.revision replayed_again);
+    let peer = "wal_peer" in
+    Persistence.update_result ~base_path ~keeper_name:peer (fun pending ->
+      Queue.enqueue pending (stimulus "peer-source" 4.0))
+    |> require_ok "seed peer owner";
+    ignore
+      (Persistence.claim_when_result
+         ~base_path ~keeper_name:peer ~claimed_at:5.0 ~ready:(fun _ -> true) ()
+       |> require_ok "claim peer source"
+       |> require_some "peer lease");
+    let peer_wal =
+      Filename.concat
+        (keeper_dir ~base_path ~keeper_name:peer)
+        "event-queue-settlements.jsonl"
+    in
+    Fs_compat.save_file_atomic peer_wal committed_wal
+    |> require_ok "copy stale owner WAL";
+    match Persistence.load_state_result ~base_path ~keeper_name:peer with
+    | Error _ -> ()
+    | Ok _ -> Alcotest.fail "another Keeper owner's WAL receipt was replayed")
+;;
+
 let test_context_compaction_retry_is_durable_and_lane_local () =
   with_temp_dir "keeper-event-queue-v2-retry-tail" (fun base_path ->
     let keeper_name = "retry_tail_keeper" in
@@ -793,7 +863,7 @@ let test_context_compaction_retry_is_durable_and_lane_local () =
         |> require_ok "settle context-compacted source"
       with
       | Persistence.Settled receipt -> receipt
-      | Persistence.Already_settled _ ->
+      | _ ->
         Alcotest.fail "first retryable settlement was already settled"
     in
     let peer_lease =
@@ -948,7 +1018,7 @@ let test_transition_outbox_projects_with_stable_identity () =
         |> require_ok "settle projection source"
       with
       | Persistence.Settled receipt -> receipt
-      | Persistence.Already_settled _ ->
+      | _ ->
         Alcotest.fail "first projection settlement was already settled"
     in
     (match
@@ -1145,6 +1215,10 @@ let () =
             "context compaction retry is durable and lane-local"
             `Quick
             test_context_compaction_retry_is_durable_and_lane_local
+        ; Alcotest.test_case
+            "settlement WAL commit replay and owner fence"
+            `Quick
+            test_settlement_wal_commit_replay_and_owner_fence
         ; Alcotest.test_case
             "unsupported snapshots fail closed"
             `Quick

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -484,6 +484,7 @@ let test_acked_occurrence_recovery_does_not_enqueue_or_wake_again () =
        with
        | Ok (Keeper_registry_event_queue.Settled _)
        | Ok (Keeper_registry_event_queue.Already_settled _) -> ()
+       | Ok _ -> fail "scheduled occurrence settlement follow-up failed"
        | Error detail -> fail detail);
       (match Keeper_heartbeat_loop.project_transition_outbox ~base_path ~keeper_name with
        | Ok () -> ()
@@ -754,6 +755,7 @@ let test_keeper_wake_dashboard_tracks_runtime_inflight_lease () =
         | Error error -> fail ("scheduled wake settlement failed: " ^ error)
         | Ok (Keeper_registry_event_queue.Settled receipt)
         | Ok (Keeper_registry_event_queue.Already_settled receipt) -> receipt
+        | Ok _ -> fail "scheduled wake settlement follow-up failed"
       in
       (match
          Keeper_registry_event_queue.mark_transition_projected_result


### PR DESCRIPTION
## What

- append and fsync one owner-bound canonical `State.transition_receipt` as the settlement commit point
- require the settlement WAL to be empty before append; an uncheckpointed row is replayed first or the owner lane fails explicitly
- keep the existing `keeper.event_queue.state.v3` snapshot contract unchanged
- replay the WAL idempotently, checkpoint it, then durably rewrite the exact checkpointed WAL prefix to empty
- reject rows from another BasePath/Keeper and malformed/unknown WAL shapes explicitly
- return checkpoint, WAL-compaction, and pending-projection failures as one committed outcome with a typed stage
- keep heartbeat from requeueing a lease whose settlement already committed
- route registration recovery through the same settlement commit helper

## Boundary

The WAL stores no generic payload or product/tool/vendor classification: only exact owner identity and the canonical transition receipt. There is no schema migration, compatibility reader, fallback, size/age/turn/budget cap, timeout, or semantic heuristic. WAL cleanup is driven only by the exact successful checkpoint, not by an arbitrary threshold.

## Crash law

- crash after WAL fsync and before snapshot: next owner load replays the receipt once
- crash after snapshot and before WAL rewrite: replay is idempotent against the canonical receipt, then the WAL is cleared
- normal success: snapshot contains the receipt and the WAL is empty before live projection
- cleanup failure: `Committed_followup_failed { stage = `Wal_compaction; ... }`; no uncommitted retry is inferred

Because every owner mutation begins with strict load/replay and refuses to continue when recovery cannot checkpoint/compact, the recovery WAL cannot accumulate arbitrary committed history.

## Validation

- `ocamlformat --check` green
- `git diff --check` green
- retired v4/cursor residue search: zero
- exact leaf: 388 changed lines
- focused Dune joined the shared repo lock queue and was cancelled rather than bypassing other sessions; Draft CI is the build/test authority

## Remaining purge

The now-unreachable pure `State.recover_leases` public API remains a separate legacy deletion leaf. It no longer bypasses the commit law in production.