### PR TITLE
fix(keeper): bound memory-os recall, ledger deltas, and shared librarian concurrency

### DIFF
--- a/lib/keeper/keeper_agent_run_post_turn_memory.ml
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.ml
@@ -28,99 +28,117 @@ let run
          meta.Keeper_meta_contract.name)
   in
   (* (1) deterministic write and (2) LLM librarian extraction run on this
-     keeper's memory lane (RFC-0257), detached from the turn lane. Both may
-     touch the keeper's memory stores; the lane's
-     per-keeper mutex serializes them. meta/config are immutable snapshots, so
-     using them after the turn returns does not race a later turn.
-     See RFC #3646 Section 3: Det/NonDet boundary. *)
-  let memory_series () =
-  (try
-     let notes_written =
-       Memory.append_from_tool_results
-         config
-         meta
-         ~turn
-         ~results:tool_results_snapshot
-     in
-     let kinds_written =
-       if notes_written > 0 then [ "long_term" ] else []
-     in
-     if notes_written > 0
-     then
-       Keeper_turn_telemetry.log_keeper_memory_write
-         ~keeper_name:meta.name
-         ~notes_written
-         ~kinds_written
-   with
-   | exn ->
-     Log.Keeper.error ~keeper_name:meta.name
-       "memory_write failed: %s"
-       (Printexc.to_string exn);
-     Otel_metric_store.inc_counter
-       Keeper_metrics.(to_string MemoryWriteFailures)
-       ~labels:[ "keeper", meta.name ]
-       ());
+     keeper's memory lane (RFC-0257), detached from the turn lane, as TWO
+     separate submissions rather than one bundled unit (masc#25052 P3).
+     Before this split, both lived in one closure sharing one
+     Keeper_memory_lane reservation: a librarian call stuck on provider
+     queue wait held that reservation (and the lane's per-keeper mutex) for
+     the whole wait, so a subsequent turn's deterministic write -- bundled
+     in the SAME unit -- could be dropped alongside a saturated librarian
+     attempt, even though the write itself never touches a provider. Split,
+     the deterministic write's own reservation is held only for its (fast,
+     file-only) duration, so provider latency on the librarian side can no
+     longer cause it to be dropped for saturation. Both units still share
+     the keeper's per-keeper mutex (RFC-0257's fairness boundary is
+     unchanged); meta/config are immutable snapshots, so using them after
+     the turn returns does not race a later turn. See RFC #3646 Section 3:
+     Det/NonDet boundary. *)
+  let det_write_series () =
+    (try
+       let notes_written =
+         Memory.append_from_tool_results
+           config
+           meta
+           ~turn
+           ~results:tool_results_snapshot
+       in
+       let kinds_written =
+         if notes_written > 0 then [ "long_term" ] else []
+       in
+       if notes_written > 0
+       then
+         Keeper_turn_telemetry.log_keeper_memory_write
+           ~keeper_name:meta.name
+           ~notes_written
+           ~kinds_written
+     with
+     | exn ->
+       Log.Keeper.error ~keeper_name:meta.name
+         "memory_write failed: %s"
+         (Printexc.to_string exn);
+       Otel_metric_store.inc_counter
+         Keeper_metrics.(to_string MemoryWriteFailures)
+         ~labels:[ "keeper", meta.name ]
+         ());
 
-  (* Memory OS librarian extraction: opt-in, provider-backed, best-effort. *)
-  let librarian_input : Keeper_librarian.input =
-    { trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id
-    ; generation
-    ; messages = librarian_messages
-    }
+    (* Advisory delegation request drafts: keep review artifact persistence on
+       the same bounded post-turn memory lane as draft-skill projection, not
+       on the decision-record append path. Deterministic (no provider call),
+       so it stays in this unit rather than the librarian one. *)
+    (try
+       match deliberation_execution with
+       | None -> ()
+       | Some execution -> (
+         match
+           Keeper_delegation_request_store.write_execution_result
+             ~base_path:config.base_path
+             ~requester:meta.name
+             execution
+         with
+         | Ok [] -> ()
+         | Ok stored ->
+           Log.Keeper.info ~keeper_name:meta.name
+             "delegation_requests wrote=%d dir=%s"
+             (List.length stored)
+             (Keeper_delegation_request_store.requests_dir
+                ~base_path:config.base_path)
+         | Error msg ->
+           Otel_metric_store.inc_counter
+             Keeper_metrics.(to_string DispatchEventFailures)
+             ~labels:[ "keeper", meta.name; "site", "delegation_requests" ]
+             ();
+           Log.Keeper.warn ~keeper_name:meta.name
+             "delegation_requests failed: %s"
+             msg)
+     with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | exn ->
+       Otel_metric_store.inc_counter
+         Keeper_metrics.(to_string DispatchEventFailures)
+         ~labels:[ "keeper", meta.name; "site", "delegation_requests" ]
+         ();
+       Log.Keeper.warn ~keeper_name:meta.name
+         "delegation_requests failed: %s"
+         (Printexc.to_string exn))
   in
-  Keeper_librarian_runtime.run_best_effort
-    ~runtime_id
-    ~keeper_id:meta.name
-    librarian_input;
-
-  (* Advisory delegation request drafts: keep review artifact persistence on the
-     same bounded post-turn memory lane as draft-skill projection, not on the
-     decision-record append path. *)
-  (try
-     match deliberation_execution with
-     | None -> ()
-     | Some execution -> (
-       match
-         Keeper_delegation_request_store.write_execution_result
-           ~base_path:config.base_path
-           ~requester:meta.name
-           execution
-       with
-       | Ok [] -> ()
-       | Ok stored ->
-         Log.Keeper.info ~keeper_name:meta.name
-           "delegation_requests wrote=%d dir=%s"
-           (List.length stored)
-           (Keeper_delegation_request_store.requests_dir
-              ~base_path:config.base_path)
-       | Error msg ->
-         Otel_metric_store.inc_counter
-           Keeper_metrics.(to_string DispatchEventFailures)
-           ~labels:[ "keeper", meta.name; "site", "delegation_requests" ]
-           ();
-         Log.Keeper.warn ~keeper_name:meta.name
-           "delegation_requests failed: %s"
-           msg)
-   with
-   | Eio.Cancel.Cancelled _ as e -> raise e
-   | exn ->
-     Otel_metric_store.inc_counter
-       Keeper_metrics.(to_string DispatchEventFailures)
-       ~labels:[ "keeper", meta.name; "site", "delegation_requests" ]
-       ();
-     Log.Keeper.warn ~keeper_name:meta.name
-       "delegation_requests failed: %s"
-       (Printexc.to_string exn));
-
+  (* Memory OS librarian extraction: opt-in, provider-backed, best-effort. Its
+     own lane unit, separate from [det_write_series] above. *)
+  let librarian_series () =
+    let librarian_input : Keeper_librarian.input =
+      { trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id
+      ; generation
+      ; messages = librarian_messages
+      }
+    in
+    Keeper_librarian_runtime.run_best_effort
+      ~runtime_id
+      ~keeper_id:meta.name
+      librarian_input
   in
-  (* RFC-0257: detach (1)-(2) onto the per-keeper memory lane. When the executor
-     switch is not initialized (tests, early startup) the lane runs them inline,
-     so no memory work is lost. *)
+  (* RFC-0257: detach onto the per-keeper memory lane. When the executor
+     switch is not initialized (tests, early startup) the lane runs units
+     inline, so no memory work is lost. *)
   let (_ : Keeper_memory_lane.outcome) =
     Keeper_memory_lane.submit
       ~base_path:config.base_path
       ~keeper_name:meta.name
-      memory_series
+      det_write_series
+  in
+  let (_ : Keeper_memory_lane.outcome) =
+    Keeper_memory_lane.submit
+      ~base_path:config.base_path
+      ~keeper_name:meta.name
+      librarian_series
   in
   (* Post-turn memory recall evidence is logged to decisions.jsonl. *)
   (try

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -65,6 +65,57 @@ let keeper_compact_max_tokens_rp =
 let keeper_compact_max_tokens () : int =
   Runtime_params.get keeper_compact_max_tokens_rp
 
+(* masc#25052 P1: Memory OS recall selection budget. Before this,
+   Keeper_memory_os_recall.render_context_exn injected the keeper's ENTIRE
+   current fact/episode store into every turn's prompt -- no selection
+   contract existed, so a keeper that accumulated facts/episodes without
+   bound (no retention existed either -- see the episode retention wired
+   into Keeper_memory_os_gc below) grew its per-turn prompt injection
+   without limit. These three knobs are the boundary: how many facts, how
+   many episodes, and how many rendered bytes recall may inject per turn.
+
+   Defaults are set at/above the largest volume observed in the 2026-07-17
+   lane analysis that diagnosed this (~300 facts, ~380 episode summaries,
+   ~1.5MB rendered per keeper turn), so a typical keeper today is truncated
+   by NONE of these -- this establishes a ceiling, not a retroactive
+   downsizing. Operators tune live via Runtime_params (no restart) as real
+   volumes grow. Truncation, when it does trigger, is always logged and
+   counted (Keeper_metrics.MemoryOsRecallFactsTruncated /
+   RecallEpisodesTruncated / RecallBytesOverBudget) -- never silent. *)
+let keeper_memory_os_recall_max_facts_rp =
+  _rp_int ~key:"keeper.memory_os.recall.max_facts"
+    ~default:(fun () -> int_of_env_default "MASC_KEEPER_MEMORY_OS_RECALL_MAX_FACTS"
+                          ~default:500 ~min_v:0 ~max_v:100_000)
+    ~min_v:0 ~max_v:100_000
+    ~description:"Max facts Memory OS recall injects per turn (0 = inject none)" ()
+let keeper_memory_os_recall_max_facts () : int =
+  Runtime_params.get keeper_memory_os_recall_max_facts_rp
+
+let keeper_memory_os_recall_max_episodes_rp =
+  _rp_int ~key:"keeper.memory_os.recall.max_episodes"
+    ~default:(fun () -> int_of_env_default "MASC_KEEPER_MEMORY_OS_RECALL_MAX_EPISODES"
+                          ~default:500 ~min_v:0 ~max_v:100_000)
+    ~min_v:0 ~max_v:100_000
+    ~description:"Max episodes Memory OS recall injects per turn (0 = inject none)" ()
+let keeper_memory_os_recall_max_episodes () : int =
+  Runtime_params.get keeper_memory_os_recall_max_episodes_rp
+
+(* Observability-only for now: logged and counted
+   (MemoryOsRecallBytesOverBudget) when the rendered block exceeds this, but
+   not itself used to drop additional facts/episodes -- max_facts/
+   max_episodes above are the enforced boundary. A byte-accurate secondary
+   truncation is a reasonable follow-up once real overage data exists;
+   scope-cut here rather than adding untested incremental-trim logic. 0
+   disables the check (unbounded). *)
+let keeper_memory_os_recall_max_bytes_rp =
+  _rp_int ~key:"keeper.memory_os.recall.max_bytes"
+    ~default:(fun () -> int_of_env_default "MASC_KEEPER_MEMORY_OS_RECALL_MAX_BYTES"
+                          ~default:2_000_000 ~min_v:0 ~max_v:50_000_000)
+    ~min_v:0 ~max_v:50_000_000
+    ~description:"Rendered recall block byte threshold to log/count as over-budget (0 = disabled)" ()
+let keeper_memory_os_recall_max_bytes () : int =
+  Runtime_params.get keeper_memory_os_recall_max_bytes_rp
+
 (** Cooldown between compaction attempts.  Previous default (90s) exceeded
     the proactive heartbeat interval (30s), permanently blocking compaction
     for proactive keepers.  15s allows compaction to fire every other cycle. *)

--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -141,6 +141,13 @@ val keeper_compact_max_tokens : unit -> int
 val keeper_compaction_cooldown_sec : unit -> int
 val keeper_compaction_policy_from_env : unit -> float * int * int
 
+(** Memory OS recall selection budget (masc#25052 P1). See the .ml for the
+    growth problem this bounds and the default-sizing rationale. *)
+val keeper_memory_os_recall_max_facts : unit -> int
+val keeper_memory_os_recall_max_episodes : unit -> int
+val keeper_memory_os_recall_max_bytes : unit -> int
+(** Observability-only threshold (see .ml); not itself an enforced drop. *)
+
 val keeper_bootstrap_proactive_warmup_sec : unit -> int
 val keeper_bootstrap_stagger_step_sec : unit -> int
 val keeper_bootstrap_retry_interval_sec : unit -> int

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -65,6 +65,67 @@ let with_provider_slot ~keeper_id ~clock:_ f =
         (fun () -> Some (f ()))
 ;;
 
+(* masc#25052 P3: process-global per-RUNTIME slot, additive to (not a
+   replacement for) the per-keeper slot above. RFC-0257 fixed keeper
+   starvation by giving each keeper its own capacity-1 budget, but that
+   means N keepers can each hold their OWN slot and call the SAME shared
+   runtime (e.g. a single local model declared max_concurrent=1)
+   concurrently -- the runtime's own declared concurrency ceiling was never
+   enforced, only the per-keeper one was. This gate is keyed by [runtime_id]
+   and sized from the runtime's own [binding.max_concurrent] declaration
+   (mirrors Hitl_summary_worker.effective_max_concurrency's shape: the
+   runtime's declaration is authoritative, not a separately configured
+   default). A runtime that declares no [max_concurrent] gets capacity 0
+   here, which disables the gate entirely -- unchanged behavior for runtimes
+   that never asked for a cap.
+
+   oas#2641 (Provider_config.max_concurrent_requests, applied at binding
+   construction) is the eventual convergence point once the pinned agent_sdk
+   reaches it; this worktree is pinned to v0.215.0 (pre-#2641), so the gate
+   lives here in MASC in the meantime. *)
+let runtime_slots_mu = Eio.Mutex.create ()
+let runtime_slots : (string, provider_slot) Hashtbl.t = Hashtbl.create 16
+
+let runtime_slot_capacity ~runtime_id =
+  match Runtime.get_runtime_by_id runtime_id with
+  | Some runtime -> Option.value runtime.Runtime.binding.max_concurrent ~default:0
+  | None -> 0
+;;
+
+let runtime_slot_for ~runtime_id capacity =
+  Eio_guard.with_mutex runtime_slots_mu (fun () ->
+    match Hashtbl.find_opt runtime_slots runtime_id with
+    | Some slot when slot.capacity = capacity -> slot
+    | _ ->
+      let slot = { capacity; in_use = 0 } in
+      Hashtbl.replace runtime_slots runtime_id slot;
+      slot)
+;;
+
+let with_runtime_slot ~runtime_id f =
+  let capacity = runtime_slot_capacity ~runtime_id in
+  if capacity <= 0
+  then Some (f ())
+  else (
+    let slot = runtime_slot_for ~runtime_id capacity in
+    let acquired =
+      Eio_guard.with_mutex runtime_slots_mu (fun () ->
+        if slot.in_use >= slot.capacity
+        then false
+        else (
+          slot.in_use <- slot.in_use + 1;
+          true))
+    in
+    if not acquired
+    then None
+    else
+      Fun.protect
+        ~finally:(fun () ->
+          Eio_guard.with_mutex runtime_slots_mu (fun () ->
+            slot.in_use <- Int.max 0 (slot.in_use - 1)))
+        (fun () -> Some (f ())))
+;;
+
 let enabled () =
   (* Default on: a keeper without conversation ingestion is the pathology
      the Memory OS exists to fix (2026-06-12 diagnosis, issue #20909).
@@ -554,15 +615,16 @@ let run_best_effort ?complete ~runtime_id ~keeper_id (inp : Keeper_librarian.inp
              | Some clock -> (
              match
                with_provider_slot ~keeper_id ~clock (fun () ->
-                 extract_and_append_with_provider_classified
-                   ?complete
-                   ~clock
-                   ~sw
-                   ~net
-                   ~keeper_id
-                   ~runtime_id
-                   ~provider_cfg
-                   inp)
+                 with_runtime_slot ~runtime_id (fun () ->
+                   extract_and_append_with_provider_classified
+                     ?complete
+                     ~clock
+                     ~sw
+                     ~net
+                     ~keeper_id
+                     ~runtime_id
+                     ~provider_cfg
+                     inp))
              with
              | None ->
                Otel_metric_store.inc_counter
@@ -574,14 +636,26 @@ let run_best_effort ?complete ~runtime_id ~keeper_id (inp : Keeper_librarian.inp
                  "memory os librarian skipped runtime=%s: per-keeper provider slot busy (capacity=%d)"
                  runtime_id
                  (per_keeper_slot_capacity ())
-             | Some (Ok episode) ->
+             | Some None ->
+               (* Per-keeper slot acquired, but the shared runtime's declared
+                  max_concurrent is already saturated by other keepers. *)
+               Otel_metric_store.inc_counter
+                 Keeper_metrics.(to_string MemoryOsLibrarianRuntimeSlotBusy)
+                 ~labels:[ "keeper", keeper_id; "runtime_id", runtime_id ]
+                 ();
+               Log.Keeper.warn ~keeper_name:keeper_id
+                 "memory os librarian skipped runtime=%s: shared runtime provider slot busy \
+                  (capacity=%d)"
+                 runtime_id
+                 (runtime_slot_capacity ~runtime_id)
+             | Some (Some (Ok episode)) ->
                cadence_record_success ~keeper_id ~trace_id:inp.trace_id;
                Log.Keeper.info ~keeper_name:keeper_id
                  "memory os librarian wrote episode trace_id=%s generation=%d claims=%d"
                  episode.Keeper_memory_os_types.trace_id
                  episode.generation
                  (List.length episode.claims)
-             | Some (Error err) ->
+             | Some (Some (Error err)) ->
                Otel_metric_store.inc_counter
                  Keeper_metrics.(to_string EpisodeCreateFailures)
                  ~labels:[ "keeper", keeper_id; "site", "memory_os_librarian" ]

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -88,7 +88,14 @@ let runtime_slots : (string, provider_slot) Hashtbl.t = Hashtbl.create 16
 
 let runtime_slot_capacity ~runtime_id =
   match Runtime.get_runtime_by_id runtime_id with
-  | Some runtime -> Option.value runtime.Runtime.binding.max_concurrent ~default:0
+  | Some runtime ->
+    (* Closed mapping, not a permissive default: runtime_toml rejects
+       non-positive max-concurrent at parse ("0 was historically used as an
+       omission sentinel", runtime_toml.ml ~:782), so [Some 0] is unreachable
+       here and 0 unambiguously encodes "no declared bound = gate disabled"
+       (see the .mli contract for with_runtime_slot). *)
+    (* DET-OK: None -> 0 is the closed gate-disabled encoding above. *)
+    Option.value runtime.Runtime.binding.max_concurrent ~default:0
   | None -> 0
 ;;
 

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -143,6 +143,23 @@ val with_provider_slot
     blocking stdlib locks on keeper runtime fibers. Exposed for storm-guard
     regression coverage (#21376). *)
 
+val runtime_slot_capacity : runtime_id:string -> int
+(** [runtime_id]'s declared concurrency ceiling (its [Runtime.t.binding
+    .max_concurrent]), or [0] when the runtime declares none. [0] means
+    {!with_runtime_slot} applies no additional gate for that runtime. *)
+
+val with_runtime_slot : runtime_id:string -> (unit -> 'a) -> 'a option
+(** Run [f] under a process-global slot keyed by [runtime_id], sized by
+    {!runtime_slot_capacity}. Additive to {!with_provider_slot}, not a
+    replacement: the per-keeper slot bounds one keeper's own concurrency,
+    this bounds the SHARED runtime's declared concurrency across all
+    keepers (masc#25052 P3 -- RFC-0257's per-keeper slot alone lets N
+    keepers each call the same capacity-1 local runtime concurrently). At
+    capacity 0 (no declared [max_concurrent]) [f] always runs ([Some]);
+    otherwise the (capacity+1)-th concurrent entrant across all keepers
+    returns [None] (drop, not block). Exposed for concurrency-bound
+    regression coverage. *)
+
 val librarian_provider_clock_unavailable_error : string
 (** Stable error returned before provider I/O when provider-backed librarian
     extraction is called without a clock. Exposed so callers/tests do not

--- a/lib/keeper/keeper_memory_os_recall.ml
+++ b/lib/keeper/keeper_memory_os_recall.ml
@@ -112,23 +112,100 @@ type render_result =
   ; failure_reason : unavailable_reason option
   }
 
+(* masc#25052 P1: selection budget. Before this, every current fact/episode
+   in the store was injected every turn -- no selection contract existed.
+   [select_most_recent ~budget ~key ~recency items] keeps the [budget] most
+   recent items (by [recency], descending) and returns them in their
+   ORIGINAL relative order (a stable filter over [items], not a reordering)
+   alongside the drop count, so turns that fit within budget see byte-for-
+   byte the same order they always did -- only the truncation CASE picks
+   which items survive, never how the survivors are arranged. [key] must be
+   a stable per-item identity (claim_identity for facts, "trace_id:gN" for
+   episodes) so membership after sorting can be checked without relying on
+   structural/physical equality. *)
+let select_most_recent ~budget ~key ~recency items =
+  let n = List.length items in
+  if n <= budget
+  then items, 0
+  else (
+    let kept_keys =
+      items
+      |> List.map (fun item -> item, recency item)
+      |> List.stable_sort (fun (_, a) (_, b) -> Float.compare b a)
+      |> List.filteri (fun i _ -> i < budget)
+      |> List.map (fun (item, _) -> key item)
+      |> Set_util.StringSet.of_list
+    in
+    let selected = List.filter (fun item -> Set_util.StringSet.mem (key item) kept_keys) items in
+    selected, n - budget)
+;;
+
+let episode_key (e : episode) = Printf.sprintf "%s:g%d" e.trace_id e.generation
+
+let log_truncation ~keeper_id ~kind ~metric ~store_count ~injected_count ~dropped ~budget =
+  Otel_metric_store.inc_counter
+    Keeper_metrics.(to_string metric)
+    ~labels:[ "keeper", keeper_id ]
+    ~delta:(Float.of_int dropped)
+    ();
+  Log.Keeper.warn
+    "memory os recall truncated %s keeper=%s: store=%d injected=%d dropped=%d budget=%d"
+    kind
+    keeper_id
+    store_count
+    injected_count
+    dropped
+    budget
+;;
+
 let render_context_exn ~keeper_id ~now () =
-  let facts =
+  let all_facts =
     File_lock_eio.with_lock (Keeper_memory_os_io.facts_path ~keeper_id) (fun () ->
       Keeper_memory_os_io.read_facts_all ~keeper_id
       |> List.filter (fact_is_current ~now))
   in
-  let n_facts_in_store = List.length facts in
-  let episodes =
+  (* Diagnostic: the TOTAL store size, independent of the selection budget
+     below -- this is what tells an operator "the store has grown past what
+     recall injects" rather than silently equalling whatever got selected. *)
+  let n_facts_in_store = List.length all_facts in
+  let all_episodes =
     Keeper_memory_os_io.read_episodes_all ~keeper_id
     |> List.filter (episode_is_current ~now)
   in
-  let injected_fact_keys = List.map (fun f -> claim_identity f) facts in
-  let injected_episode_keys =
-    List.map
-      (fun (e : episode) -> Printf.sprintf "%s:g%d" e.trace_id e.generation)
-      episodes
+  let max_facts = Keeper_config.keeper_memory_os_recall_max_facts () in
+  let max_episodes = Keeper_config.keeper_memory_os_recall_max_episodes () in
+  let facts, facts_dropped =
+    select_most_recent ~budget:max_facts ~key:claim_identity ~recency:reference_time all_facts
   in
+  let episodes, episodes_dropped =
+    select_most_recent
+      ~budget:max_episodes
+      ~key:episode_key
+      ~recency:(fun (e : episode) -> e.created_at)
+      all_episodes
+  in
+  if facts_dropped > 0
+  then
+    log_truncation
+      ~keeper_id
+      ~kind:"facts"
+      ~metric:Keeper_metrics.MemoryOsRecallFactsTruncated
+      ~store_count:n_facts_in_store
+      ~injected_count:(List.length facts)
+      ~dropped:facts_dropped
+      ~budget:max_facts;
+  if episodes_dropped > 0
+  then
+    log_truncation
+      ~keeper_id
+      ~kind:"episodes"
+      ~metric:Keeper_metrics.MemoryOsRecallEpisodesTruncated
+      ~store_count:(List.length all_episodes)
+      ~injected_count:(List.length episodes)
+      ~dropped:episodes_dropped
+      ~budget:max_episodes;
+  let injected_fact_keys = List.map (fun f -> claim_identity f) facts in
+  let injected_episode_keys = List.map episode_key episodes in
   let block, injected_fact_keys, injected_episode_keys, failure_reason =
     match facts, episodes with
     | [], [] -> "", [], [], None
@@ -144,6 +221,19 @@ let render_context_exn ~keeper_id ~now () =
          , []
          , Some Prompt_render_error ))
   in
+  let max_bytes = Keeper_config.keeper_memory_os_recall_max_bytes () in
+  if max_bytes > 0 && String.length block > max_bytes
+  then (
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string MemoryOsRecallBytesOverBudget)
+      ~labels:[ "keeper", keeper_id ]
+      ();
+    Log.Keeper.warn
+      "memory os recall block over byte budget keeper=%s: bytes=%d budget=%d (not truncated; \
+       raise keeper.memory_os.recall.max_bytes or lower max_facts/max_episodes)"
+      keeper_id
+      (String.length block)
+      max_bytes);
   { block; injected_fact_keys; injected_episode_keys; n_facts_in_store; failure_reason }
 ;;
 

--- a/lib/keeper/keeper_memory_os_recall.mli
+++ b/lib/keeper/keeper_memory_os_recall.mli
@@ -2,15 +2,27 @@
 
     Recall is intentionally one-way at prompt time: it reads persisted facts
     and episodes and returns their exact text in an advisory block suitable for
-    OAS [extra_system_context]. *)
+    OAS [extra_system_context].
+
+    masc#25052 P1: recall used to inject every current fact/episode in the
+    store, unbounded. It now applies a selection budget
+    ([Keeper_config.keeper_memory_os_recall_max_facts] /
+    [_max_episodes], live-tunable, default sized above all observed real
+    volumes): within budget, nothing changes (same items, same order); over
+    budget, the most-recent-[reference_time]/[created_at] items survive,
+    still rendered in their original relative order, and the drop is logged
+    plus counted (never silent). *)
 
 val render_context
   :  keeper_id:string
   -> now:float
   -> unit
   -> string
-(** Render every current fact and episode in persisted source order, without
-    truncation, ranking, deduplication, or fixed-size slices. *)
+(** Render every current fact and episode in persisted source order, up to
+    the configured selection budget (see the module doc). Below budget this
+    is byte-for-byte the old "no truncation, ranking, deduplication, or
+    fixed-size slices" behavior; over budget, the most recent items are kept
+    and a truncation is logged and counted. *)
 
 val enabled : unit -> bool
 (** Kill-switch flag [MASC_KEEPER_MEMORY_OS_RECALL] (default [true]).

--- a/lib/keeper/keeper_recall_injection_ledger.ml
+++ b/lib/keeper/keeper_recall_injection_ledger.ml
@@ -2,33 +2,67 @@
    append pattern (Keeper_hooks_oas_cost_events): a Dated_jsonl store under
    masc_root, append wrapped so a write failure degrades to a log line and never
    propagates into the turn. Retention is deliberately kept out of append's hot
-   path and handled by server maintenance. *)
+   path and handled by server maintenance.
+
+   Schema v2 (masc#25052): see the .mli doc comment for why full key lists were
+   replaced with per-keeper deltas. *)
+
+module SS = Set_util.StringSet
 
 let base_dir ~masc_root = Filename.concat masc_root "recall_injections"
 
+let field_schema_version = "schema_version"
 let field_keeper_id = "keeper_id"
 let field_trace_id = "trace_id"
 let field_turn = "turn"
 let field_injected_fact_keys = "injected_fact_keys"
 let field_injected_episode_keys = "injected_episode_keys"
+let field_added_fact_keys = "added_fact_keys"
+let field_removed_fact_keys = "removed_fact_keys"
+let field_added_episode_keys = "added_episode_keys"
+let field_removed_episode_keys = "removed_episode_keys"
+let field_content_hash = "content_hash"
 let field_n_facts_in_store = "n_facts_in_store"
+let field_n_episodes_in_store = "n_episodes_in_store"
 let field_ts = "ts"
 let field_failure_reason = "failure_reason"
 let failure_reason_read_error = "read_error"
 let failure_reason_prompt_render_error = "prompt_render_error"
 let failure_reason_unknown_label = "unknown_failure_reason"
 
+(* Legacy rows (schema_version absent) are v1. v2 is the first delta schema. *)
+let schema_version_legacy = 1
+let schema_version_delta = 2
+
+type payload =
+  | Full_snapshot of
+      { fact_keys : string list
+      ; episode_keys : string list
+      }
+  | Delta of
+      { added_fact_keys : string list
+      ; removed_fact_keys : string list
+      ; added_episode_keys : string list
+      ; removed_episode_keys : string list
+      ; content_hash : string
+      }
+
 type record =
   { keeper_id : string
-  ; injected_fact_keys : string list
-  ; injected_episode_keys : string list
+  ; trace_id : string
+  ; turn : int
+  ; ts : float option
   ; failure_reason : string option
+  ; n_facts_in_store : int option
+  ; n_episodes_in_store : int option
+  ; payload : payload
   }
 
 type decode_error =
   [ `Expected_object
   | `Missing_field of string
   | `Invalid_field of string
+  | `Unsupported_schema_version of int
   ]
 
 let json_required_string_field fields key =
@@ -36,6 +70,28 @@ let json_required_string_field fields key =
   | Some (`String value) -> Ok value
   | Some _ -> Error (`Invalid_field key)
   | None -> Error (`Missing_field key)
+;;
+
+let json_required_int_field fields key =
+  match List.assoc_opt key fields with
+  | Some (`Int value) -> Ok value
+  | Some _ -> Error (`Invalid_field key)
+  | None -> Error (`Missing_field key)
+;;
+
+let json_optional_int_field fields key =
+  match List.assoc_opt key fields with
+  | Some (`Int value) -> Ok (Some value)
+  | Some _ -> Error (`Invalid_field key)
+  | None -> Ok None
+;;
+
+let json_optional_float_field fields key =
+  match List.assoc_opt key fields with
+  | Some (`Float value) -> Ok (Some value)
+  | Some (`Int value) -> Ok (Some (Float.of_int value))
+  | Some _ -> Error (`Invalid_field key)
+  | None -> Ok None
 ;;
 
 let json_required_string_list_field fields key =
@@ -58,20 +114,74 @@ let json_optional_string_field fields key =
   | None -> Ok None
 ;;
 
+let payload_of_fields fields =
+  match json_optional_int_field fields field_schema_version with
+  | Error _ as e -> e
+  | Ok (None | Some 1) ->
+    (match
+       ( json_required_string_list_field fields field_injected_fact_keys
+       , json_required_string_list_field fields field_injected_episode_keys )
+     with
+     | Ok fact_keys, Ok episode_keys -> Ok (Full_snapshot { fact_keys; episode_keys })
+     | Error err, _ | _, Error err -> Error err)
+  | Ok (Some 2) ->
+    (match
+       ( json_required_string_list_field fields field_added_fact_keys
+       , json_required_string_list_field fields field_removed_fact_keys
+       , json_required_string_list_field fields field_added_episode_keys
+       , json_required_string_list_field fields field_removed_episode_keys
+       , json_required_string_field fields field_content_hash )
+     with
+     | ( Ok added_fact_keys
+       , Ok removed_fact_keys
+       , Ok added_episode_keys
+       , Ok removed_episode_keys
+       , Ok content_hash ) ->
+       Ok
+         (Delta
+            { added_fact_keys; removed_fact_keys; added_episode_keys
+            ; removed_episode_keys; content_hash
+            })
+     | Error err, _, _, _, _
+     | _, Error err, _, _, _
+     | _, _, Error err, _, _
+     | _, _, _, Error err, _
+     | _, _, _, _, Error err -> Error err)
+  | Ok (Some other) -> Error (`Unsupported_schema_version other)
+;;
+
 let record_of_json_result = function
   | `Assoc fields ->
     (match
        ( json_required_string_field fields field_keeper_id
-       , json_required_string_list_field fields field_injected_fact_keys
-       , json_required_string_list_field fields field_injected_episode_keys
-       , json_optional_string_field fields field_failure_reason )
+       , json_required_string_field fields field_trace_id
+       , json_required_int_field fields field_turn )
      with
-     | Ok keeper_id, Ok injected_fact_keys, Ok injected_episode_keys, Ok failure_reason ->
-       Ok { keeper_id; injected_fact_keys; injected_episode_keys; failure_reason }
-     | Error err, _, _, _
-     | _, Error err, _, _
-     | _, _, Error err, _
-     | _, _, _, Error err -> Error err)
+     | Error err, _, _ | _, Error err, _ | _, _, Error err -> Error err
+     | Ok keeper_id, Ok trace_id, Ok turn ->
+       (match
+          ( json_optional_float_field fields field_ts
+          , json_optional_string_field fields field_failure_reason
+          , json_optional_int_field fields field_n_facts_in_store
+          , json_optional_int_field fields field_n_episodes_in_store
+          , payload_of_fields fields )
+        with
+        | Error err, _, _, _, _
+        | _, Error err, _, _, _
+        | _, _, Error err, _, _
+        | _, _, _, Error err, _
+        | _, _, _, _, Error err -> Error err
+        | Ok ts, Ok failure_reason, Ok n_facts_in_store, Ok n_episodes_in_store, Ok payload ->
+          Ok
+            { keeper_id
+            ; trace_id
+            ; turn
+            ; ts
+            ; failure_reason
+            ; n_facts_in_store
+            ; n_episodes_in_store
+            ; payload
+            }))
   | _ -> Error `Expected_object
 ;;
 
@@ -88,6 +198,72 @@ let bounded_failure_reason_label = function
   | _ -> failure_reason_unknown_label
 ;;
 
+(* ── Pure delta primitives ────────────────────────────────────────────── *)
+
+let diff_keys ~previous ~current =
+  let prev_set = SS.of_list previous in
+  let curr_set = SS.of_list current in
+  SS.elements (SS.diff curr_set prev_set), SS.elements (SS.diff prev_set curr_set)
+;;
+
+let apply_delta ~previous ~added ~removed =
+  let base = SS.of_list previous in
+  let added_set = SS.of_list added in
+  let removed_set = SS.of_list removed in
+  SS.elements (SS.diff (SS.union base added_set) removed_set)
+;;
+
+(* Not a security digest: a cheap, order/duplicate-independent change-detection
+   and self-consistency signal (tests check that replaying a [Delta] row's
+   materialized set hashes back to the row's own [content_hash]). *)
+let content_hash_of ~fact_keys ~episode_keys =
+  let canon keys = keys |> SS.of_list |> SS.elements |> String.concat "\x1f" in
+  Digest.to_hex (Digest.string (canon fact_keys ^ "\x1e" ^ canon episode_keys))
+;;
+
+type materialized =
+  { record : record
+  ; fact_keys : string list
+  ; episode_keys : string list
+  }
+
+let materialize records =
+  (* Precondition (see .mli): [records] is already chronological. Keyed purely
+     by [keeper_id] because this is a pure, call-local fold over an in-memory
+     list -- not the process-lifetime [Delta_state] registry below. *)
+  let state : (string, SS.t * SS.t) Hashtbl.t = Hashtbl.create 16 in
+  List.map
+    (fun record ->
+       let prev_facts, prev_episodes =
+         Option.value
+           (Hashtbl.find_opt state record.keeper_id)
+           ~default:(SS.empty, SS.empty)
+       in
+       let facts, episodes =
+         match record.payload with
+         | Full_snapshot { fact_keys; episode_keys } ->
+           SS.of_list fact_keys, SS.of_list episode_keys
+         | Delta
+             { added_fact_keys
+             ; removed_fact_keys
+             ; added_episode_keys
+             ; removed_episode_keys
+             ; content_hash = _
+             } ->
+           ( SS.diff (SS.union prev_facts (SS.of_list added_fact_keys)) (SS.of_list removed_fact_keys)
+           , SS.diff
+               (SS.union prev_episodes (SS.of_list added_episode_keys))
+               (SS.of_list removed_episode_keys) )
+       in
+       Hashtbl.replace state record.keeper_id (facts, episodes);
+       { record; fact_keys = SS.elements facts; episode_keys = SS.elements episodes })
+    records
+;;
+
+(* ── Serialisers ──────────────────────────────────────────────────────── *)
+
+(* Legacy (v1, [Full_snapshot]) serialiser. Pure. Kept for round-trip tests
+   and fixtures; [append] below writes v2 [Delta] rows exclusively. *)
 let to_json
       ?failure_reason
       ~keeper_id
@@ -101,7 +277,8 @@ let to_json
   : Yojson.Safe.t
   =
   let fields =
-    [ field_keeper_id, `String keeper_id
+    [ field_schema_version, `Int schema_version_legacy
+    ; field_keeper_id, `String keeper_id
     ; field_trace_id, `String trace_id
     ; field_turn, `Int turn
     ; field_injected_fact_keys, `List (List.map (fun k -> `String k) injected_fact_keys)
@@ -119,7 +296,147 @@ let to_json
   `Assoc fields
 ;;
 
+let to_json_delta
+      ?failure_reason
+      ~keeper_id
+      ~trace_id
+      ~turn
+      ~added_fact_keys
+      ~removed_fact_keys
+      ~added_episode_keys
+      ~removed_episode_keys
+      ~content_hash
+      ~n_facts_in_store
+      ~n_episodes_in_store
+      ~now
+      ()
+  : Yojson.Safe.t
+  =
+  let fields =
+    [ field_schema_version, `Int schema_version_delta
+    ; field_keeper_id, `String keeper_id
+    ; field_trace_id, `String trace_id
+    ; field_turn, `Int turn
+    ; field_added_fact_keys, `List (List.map (fun k -> `String k) added_fact_keys)
+    ; field_removed_fact_keys, `List (List.map (fun k -> `String k) removed_fact_keys)
+    ; ( field_added_episode_keys
+      , `List (List.map (fun k -> `String k) added_episode_keys) )
+    ; ( field_removed_episode_keys
+      , `List (List.map (fun k -> `String k) removed_episode_keys) )
+    ; field_content_hash, `String content_hash
+    ; field_n_facts_in_store, `Int n_facts_in_store
+    ; field_n_episodes_in_store, `Int n_episodes_in_store
+    ; field_ts, `Float now
+    ]
+  in
+  let fields =
+    match failure_reason with
+    | None -> fields
+    | Some reason -> fields @ [ field_failure_reason, `String reason ]
+  in
+  `Assoc fields
+;;
+
 let make_store ~masc_root () = Dated_jsonl.create ~base_dir:(base_dir ~masc_root) ()
+
+(* ── Per-keeper previous-state registry (for append-time delta) ─────────
+   Process-local, in-memory, keyed by (masc_root, keeper_id) rather than just
+   keeper_id: this module has no [t] handle carrying identity across calls
+   (every [append] call re-derives its [Dated_jsonl.t] from [masc_root]), and
+   tests exercise multiple distinct masc_roots with reused keeper_id strings
+   ("alpha", "keeper-a", ...) inside one test binary process. Keying by
+   keeper_id alone would let one test's delta baseline leak into an unrelated
+   test using the same keeper name against a different masc_root.
+
+   [peek] and [commit] are separate short critical sections rather than one
+   held across the [Dated_jsonl.append] call: the store's own append path
+   acquires an [Eio.Mutex] and performs blocking file I/O, and a
+   [Stdlib.Mutex] critical section must never yield (see
+   Keeper_memory_lane's [state_mu] for the same invariant). Splitting them
+   means a failed write leaves the registry at the last *persisted* baseline
+   (not the attempted-but-lost one), so the next append recomputes the full
+   delta including whatever the failed write dropped -- the ledger never
+   silently skips a change because a prior write happened to fail. The
+   narrow race this permits (two concurrent appends for the very same
+   keeper interleaving peek/write/commit) is benign under replay: a
+   redundant "added X" when X is already present is a no-op set union, not a
+   correctness bug. In normal operation one keeper's turns are processed
+   sequentially, so this race is not expected to occur at all. *)
+module Delta_state = struct
+  let mu = Stdlib.Mutex.create ()
+  let table : (string * string, SS.t * SS.t) Hashtbl.t = Hashtbl.create 64
+
+  let peek ~masc_root ~keeper_id =
+    Stdlib.Mutex.protect mu (fun () ->
+      Option.value
+        (Hashtbl.find_opt table (masc_root, keeper_id))
+        ~default:(SS.empty, SS.empty))
+  ;;
+
+  let commit ~masc_root ~keeper_id ~facts ~episodes =
+    Stdlib.Mutex.protect mu (fun () ->
+      Hashtbl.replace table (masc_root, keeper_id) (facts, episodes))
+  ;;
+
+  let reset_for_testing () = Stdlib.Mutex.protect mu (fun () -> Hashtbl.reset table)
+end
+
+let error_label_of_exn exn =
+  exn
+  |> Keeper_memory_recall_exn_class.classify
+  |> Keeper_memory_recall_exn_class.to_label
+;;
+
+let append
+      ?failure_reason
+      ~masc_root
+      ~keeper_id
+      ~trace_id
+      ~turn
+      ~injected_fact_keys
+      ~injected_episode_keys
+      ~n_facts_in_store
+      ~now
+      ()
+  =
+  let store = make_store ~masc_root () in
+  let prev_facts, prev_episodes = Delta_state.peek ~masc_root ~keeper_id in
+  let curr_facts = SS.of_list injected_fact_keys in
+  let curr_episodes = SS.of_list injected_episode_keys in
+  let added_fact_keys = SS.elements (SS.diff curr_facts prev_facts) in
+  let removed_fact_keys = SS.elements (SS.diff prev_facts curr_facts) in
+  let added_episode_keys = SS.elements (SS.diff curr_episodes prev_episodes) in
+  let removed_episode_keys = SS.elements (SS.diff prev_episodes curr_episodes) in
+  let content_hash =
+    content_hash_of ~fact_keys:injected_fact_keys ~episode_keys:injected_episode_keys
+  in
+  let entry =
+    to_json_delta
+      ?failure_reason
+      ~keeper_id
+      ~trace_id
+      ~turn
+      ~added_fact_keys
+      ~removed_fact_keys
+      ~added_episode_keys
+      ~removed_episode_keys
+      ~content_hash
+      ~n_facts_in_store
+      ~n_episodes_in_store:(List.length injected_episode_keys)
+      ~now
+      ()
+  in
+  try
+    Dated_jsonl.append store entry;
+    Delta_state.commit ~masc_root ~keeper_id ~facts:curr_facts ~episodes:curr_episodes
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    Log.Keeper.warn
+      "recall_injection_ledger: failed to write %s: %s"
+      (Dated_jsonl.base_dir store)
+      (Printexc.to_string exn)
+;;
 
 type prune_error =
   [ `Sys_error
@@ -142,46 +459,6 @@ let prune_failure_label = function
   | _ -> `Unexpected_exception
 ;;
 
-let error_label_of_exn exn =
-  exn
-  |> Keeper_memory_recall_exn_class.classify
-  |> Keeper_memory_recall_exn_class.to_label
-;;
-
-let append
-      ?failure_reason
-      ~masc_root
-      ~keeper_id
-      ~trace_id
-      ~turn
-      ~injected_fact_keys
-      ~injected_episode_keys
-      ~n_facts_in_store
-      ~now
-      ()
-  =
-  let store = make_store ~masc_root () in
-  let entry =
-    to_json
-      ?failure_reason
-      ~keeper_id
-      ~trace_id
-      ~turn
-      ~injected_fact_keys
-      ~injected_episode_keys
-      ~n_facts_in_store
-      ~now
-      ()
-  in
-  try Dated_jsonl.append store entry with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | exn ->
-    Log.Keeper.warn
-      "recall_injection_ledger: failed to write %s: %s"
-      (Dated_jsonl.base_dir store)
-      (Printexc.to_string exn)
-;;
-
 let prune_older_than ~masc_root ~retention_days =
   try Ok (Dated_jsonl.prune (make_store ~masc_root ()) ~days:retention_days) with
   | Eio.Cancel.Cancelled _ as e -> raise e
@@ -193,3 +470,7 @@ let prune_older_than ~masc_root ~retention_days =
       (string_of_prune_error label);
     Error label
 ;;
+
+module For_testing = struct
+  let reset_delta_state = Delta_state.reset_for_testing
+end

--- a/lib/keeper/keeper_recall_injection_ledger.mli
+++ b/lib/keeper/keeper_recall_injection_ledger.mli
@@ -7,6 +7,40 @@
     forge carries PR/CI merge state), consumed offline by recall_outcome_eval
     (RFC-0264 P3) to compute recall_relevance / recall_harm.
 
+    Schema v2 (2026-07-17, masc#25052): the pre-existing schema wrote the FULL
+    injected fact/episode key list on every turn. Because {!Keeper_memory_os_recall}
+    injects the store's *entire* current fact/episode set every turn (no
+    selection budget existed before this change), every append cost was
+    proportional to store size, not to what actually changed. With no
+    compaction of this ledger, per-keeper turns accumulated O(turns * store_size)
+    bytes — the same "append without compaction" class of bug diagnosed in the
+    2026-07-17 board_attention_candidate boot-hang incident.
+
+    v2 rows instead carry only the fact/episode keys that changed since the
+    keeper's immediately preceding row ({!payload} = [Delta]), plus a
+    [content_hash] of the full injected set so a reader can detect "did the
+    injected set change" without materializing it, and plus store-size
+    counters ([n_facts_in_store] / [n_episodes_in_store]) that were already
+    (or are now) O(1) scalars — unrelated to the growth bug and kept as-is.
+
+    Legacy rows (schema_version absent, written before this change) still
+    decode as {!payload} = [Full_snapshot]: the full list they always carried
+    IS the exact injected set at that turn, so no replay is needed for them.
+    {!materialize} treats a [Full_snapshot] row as resetting a keeper's running
+    state to exactly that row's lists, and a [Delta] row as applying
+    added/removed to the running state — so mixed legacy/v2 history for the
+    same keeper replays correctly, and a fresh process's first v2 row for a
+    keeper (diffed against an empty prior state) is automatically a full
+    accounting even though it is tagged [Delta].
+
+    Two real (non-telemetry) readers exist and are adapted by this change:
+    {!Keeper_recall_outcome_eval} (offline, full-history scan — replay is
+    always exact) and the dashboard memory-quality summary in
+    [Server_dashboard_http_memory_subsystems] (bounded recent-lines sample —
+    replay is exact for any keeper whose sampled window include its own
+    genesis row, which the schema change makes far more likely since v2 rows
+    are only written on an actual change).
+
     Properties:
     - Append-only, never read on the hot path -> cannot change recall behaviour.
     - Best-effort: a write failure is logged and never aborts the turn.
@@ -25,11 +59,35 @@
 val base_dir : masc_root:string -> string
 (** Directory that stores recall injection JSONL day files. *)
 
+type payload =
+  | Full_snapshot of
+      { fact_keys : string list
+      ; episode_keys : string list
+      }
+  (** The complete injected key sets at this turn. Written by legacy
+      (schema_version absent) rows, and by {!to_json} (kept for round-trip
+      tests and fixtures that need a self-contained row). *)
+  | Delta of
+      { added_fact_keys : string list
+      ; removed_fact_keys : string list
+      ; added_episode_keys : string list
+      ; removed_episode_keys : string list
+      ; content_hash : string
+      }
+  (** Only the fact/episode keys that changed relative to the keeper's
+      previous row. [content_hash] is {!content_hash_of} over the full
+      injected set at this turn, so a reconstructed set can be checked for
+      internal consistency without re-deriving it from application state. *)
+
 type record =
   { keeper_id : string
-  ; injected_fact_keys : string list
-  ; injected_episode_keys : string list
+  ; trace_id : string
+  ; turn : int
+  ; ts : float option
   ; failure_reason : string option
+  ; n_facts_in_store : int option
+  ; n_episodes_in_store : int option
+  ; payload : payload
   }
 (** Typed subset of the append schema consumed by read-only dashboard/eval
     surfaces. Field ownership stays here so consumers do not duplicate ledger
@@ -39,6 +97,7 @@ type decode_error =
   [ `Expected_object
   | `Missing_field of string
   | `Invalid_field of string
+  | `Unsupported_schema_version of int
   ]
 (** Bounded decode failure for read-only consumers that must surface schema
     drift instead of silently dropping malformed rows. *)
@@ -54,6 +113,44 @@ val bounded_failure_reason_label : string -> string
     strings are grouped as {!failure_reason_unknown_label} to avoid high-cardinality
     dashboard output. *)
 
+val diff_keys : previous:string list -> current:string list -> string list * string list
+(** [diff_keys ~previous ~current] is [(added, removed)]: keys in [current] but
+    not [previous], and keys in [previous] but not [current]. Order-independent
+    (both inputs are treated as sets); output lists are sorted. Pure. *)
+
+val apply_delta : previous:string list -> added:string list -> removed:string list -> string list
+(** [apply_delta ~previous ~added ~removed] is [(previous ∪ added) \ removed],
+    sorted and deduplicated. Inverse companion to {!diff_keys}: for any
+    [previous]/[current], applying the delta {!diff_keys} computed reproduces
+    [current] exactly (as a set). Pure. *)
+
+val content_hash_of : fact_keys:string list -> episode_keys:string list -> string
+(** Stable digest over the full injected set (order/duplicate independent). Not
+    a security digest — a cheap change-detection / self-consistency signal. *)
+
+type materialized =
+  { record : record
+  ; fact_keys : string list
+  ; episode_keys : string list
+  }
+(** [record] paired with the full fact/episode key set actually in effect at
+    that row, after replaying {!payload} against the keeper's prior rows. *)
+
+val materialize : record list -> materialized list
+(** Reconstruct the full injected key set at each record by replaying
+    [payload] per [keeper_id]. Precondition: [records] is already in
+    chronological (oldest-first) order — both {!Keeper_recall_outcome_eval}'s
+    full-tree scan and {!Dated_jsonl.read_recent_lines} already provide this,
+    so no re-sort happens here (a re-sort by [ts] would be *unsound*: [ts] is
+    optional and legacy rows may omit it; true chronology is append order,
+    which the callers already preserve). A [Full_snapshot] row resets the
+    keeper's running state to exactly its own lists; a [Delta] row applies
+    added/removed to the running state (starting from the empty set for a
+    keeper's first appearance in [records], which is exact when [records]
+    covers that keeper's full history, and a documented under-approximation —
+    never an over-approximation — otherwise). Cross-keeper relative order in
+    the output is unspecified; per-keeper relative order matches the input. *)
+
 val to_json
   :  ?failure_reason:string
   -> keeper_id:string
@@ -65,8 +162,9 @@ val to_json
   -> now:float
   -> unit
   -> Yojson.Safe.t
-(** Pure record serialiser. Exposed for round-trip tests. [failure_reason],
-    when present, is a bounded reason label from the recall renderer. *)
+(** Legacy (schema v1, [Full_snapshot]) pure record serialiser. Exposed for
+    round-trip tests and fixtures that need a self-contained row independent of
+    any keeper's prior state. Not used by {!append} since schema v2. *)
 
 val append
   :  ?failure_reason:string
@@ -80,9 +178,19 @@ val append
   -> now:float
   -> unit
   -> unit
-(** Append one injection record. Best-effort: never raises except to re-raise
-    [Eio.Cancel.Cancelled]. Retention is intentionally handled by server
-    maintenance, not by append. *)
+(** Append one injection record. Computes the delta against [keeper_id]'s
+    previous [injected_fact_keys]/[injected_episode_keys] (in-memory,
+    process-local, scoped by [(masc_root, keeper_id)]) and writes a v2
+    [Delta] row: this is the fix for the O(store_size) per-turn growth
+    ([injected_fact_keys]/[injected_episode_keys] here are still the caller's
+    full current sets — computing that live snapshot is not itself the growth
+    bug; persisting a full copy of it every turn was). A keeper's first
+    append in a fresh process (no prior in-memory state) diffs against the
+    empty set, so its row's "delta" is the full current set — an accurate,
+    one-time, bounded-by-keeper-count cost, not a per-turn one.
+
+    Best-effort: never raises except to re-raise [Eio.Cancel.Cancelled].
+    Retention is intentionally handled by server maintenance, not by append. *)
 
 type prune_error =
   [ `Sys_error
@@ -106,3 +214,11 @@ val prune_older_than
     filesystem guarantee that every matched unlink succeeded. [Error label]
     makes prune setup failures visible to maintenance callers after logging
     with a bounded label. [Eio.Cancel.Cancelled] is re-raised. *)
+
+module For_testing : sig
+  val reset_delta_state : unit -> unit
+  (** Clear the in-memory per-(masc_root, keeper_id) "previous injected set"
+      registry that {!append} diffs against. Test isolation only — production
+      has no reset path (a lost registry after restart just means the next
+      append per keeper is a one-time full accounting, which is safe). *)
+end

--- a/lib/keeper/keeper_recall_outcome_eval.ml
+++ b/lib/keeper/keeper_recall_outcome_eval.ml
@@ -3,6 +3,7 @@
 
 module String_map = Map.Make (String)
 module String_set = Set.Make (String)
+module Ledger = Keeper_recall_injection_ledger
 
 type recall_record =
   { keeper_id : string
@@ -210,36 +211,32 @@ let parse_json_line ~path ~line_no line =
     Error (Printf.sprintf "%s:%d: malformed JSONL row: %s" path line_no msg)
 ;;
 
-let parse_recall_json = function
-  | `Assoc _ as json ->
-    (match
-       ( Json_util.get_string_nonempty json "keeper_id"
-       , Json_util.get_string_nonempty json "trace_id"
-       , Json_util.get_int json "turn" )
-     with
-     | Some keeper_id, Some trace_id, Some turn ->
-       let injected_fact_keys = Json_util.get_string_list json "injected_fact_keys" in
-       let injected_episode_keys =
-         Json_util.get_string_list json "injected_episode_keys"
-       in
-       Some
-         { keeper_id
-         ; trace_id
-         ; turn
-         ; injected_fact_keys
-         ; injected_fact_key_count =
-             Option.value
-               (Json_util.get_int json "injected_fact_key_count")
-               ~default:(List.length injected_fact_keys)
-         ; injected_episode_key_count =
-             Option.value
-               (Json_util.get_int json "injected_episode_key_count")
-               ~default:(List.length injected_episode_keys)
-         ; failure_reason = Json_util.get_string_nonempty json "failure_reason"
-         ; ts = Json_util.get_float json "ts"
-         }
-     | _ -> None)
-  | _ -> None
+(* RFC-0264 P3 / masc#25052: decode via the ledger's shared decoder (SSOT for
+   field names) instead of re-spelling "keeper_id"/"trace_id"/... here. The
+   ledger now writes v2 delta rows ([Ledger.payload = Delta]) instead of a
+   full key list per turn, so a single decoded [Ledger.record] no longer
+   carries the actual injected set on its own -- [evaluate] below replays
+   [Ledger.materialize] over the *entire* recall_dir tree (already scanned in
+   chronological order by [find_jsonl]) to reconstruct it, which is exact here
+   because the scan is unbounded (unlike the dashboard's bounded recent-lines
+   sample).
+
+   The previous "injected_fact_key_count" / "injected_episode_key_count"
+   override fields are retired: no writer ever produced them (only hand-built
+   test fixtures did), and every real row's injected count is the length of
+   its own key list. *)
+let parse_recall_ledger_json json = Result.to_option (Ledger.record_of_json_result json)
+
+let recall_record_of_materialized (m : Ledger.materialized) : recall_record =
+  { keeper_id = m.record.keeper_id
+  ; trace_id = m.record.trace_id
+  ; turn = m.record.turn
+  ; injected_fact_keys = m.fact_keys
+  ; injected_fact_key_count = List.length m.fact_keys
+  ; injected_episode_key_count = List.length m.episode_keys
+  ; failure_reason = m.record.failure_reason
+  ; ts = m.record.ts
+  }
 ;;
 
 let parse_ended_at json =
@@ -551,7 +548,13 @@ let fact_key_summaries recall_records traces =
 let evaluate ~masc_root =
   let recall_dir = Keeper_recall_injection_ledger.base_dir ~masc_root in
   let receipts_dir = Filename.concat masc_root Common.keepers_runtime_dirname in
-  let recall_records, recall_stats = load_records recall_dir parse_recall_json in
+  let ledger_records, recall_stats = load_records recall_dir parse_recall_ledger_json in
+  (* [find_jsonl]/[load_records] already walk month/day files in ascending
+     (chronological) order and preserve line order within a file, satisfying
+     [Ledger.materialize]'s ordering precondition without an extra sort. *)
+  let recall_records =
+    ledger_records |> Ledger.materialize |> List.map recall_record_of_materialized
+  in
   let receipts, receipt_stats =
     let files, scan_stats = find_receipt_jsonl receipts_dir in
     let records, load_stats = load_records_from_files files parse_receipt_json in

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -196,6 +196,7 @@ type t =
   | MemoryOsReobserveEchoSuppressed
   | MemoryOsRecallFactsTruncated
   | MemoryOsRecallEpisodesTruncated
+  | MemoryOsRecallBytesOverBudget
   | MemoryOsEpisodeRetentionPruned
   | MemoryOsLibrarianRuntimeSlotBusy
   | RuntimeHttpProbeJsonParseFailures
@@ -427,6 +428,8 @@ let to_string = function
       "masc_keeper_memory_os_recall_facts_truncated_total"
   | MemoryOsRecallEpisodesTruncated ->
       "masc_keeper_memory_os_recall_episodes_truncated_total"
+  | MemoryOsRecallBytesOverBudget ->
+      "masc_keeper_memory_os_recall_bytes_over_budget_total"
   | MemoryOsEpisodeRetentionPruned ->
       "masc_keeper_memory_os_episode_retention_pruned_total"
   | MemoryOsLibrarianRuntimeSlotBusy ->

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -194,6 +194,10 @@ type t =
   | MemoryRecallReadErrors
   | MemoryOsRecallUnavailable
   | MemoryOsReobserveEchoSuppressed
+  | MemoryOsRecallFactsTruncated
+  | MemoryOsRecallEpisodesTruncated
+  | MemoryOsEpisodeRetentionPruned
+  | MemoryOsLibrarianRuntimeSlotBusy
   | RuntimeHttpProbeJsonParseFailures
   | VisionAnalyze
   | VisionCandidateAttempts
@@ -419,6 +423,14 @@ let to_string = function
       "masc_keeper_memory_os_recall_unavailable_total"
   | MemoryOsReobserveEchoSuppressed ->
       "masc_keeper_memory_os_reobserve_echo_suppressed_total"
+  | MemoryOsRecallFactsTruncated ->
+      "masc_keeper_memory_os_recall_facts_truncated_total"
+  | MemoryOsRecallEpisodesTruncated ->
+      "masc_keeper_memory_os_recall_episodes_truncated_total"
+  | MemoryOsEpisodeRetentionPruned ->
+      "masc_keeper_memory_os_episode_retention_pruned_total"
+  | MemoryOsLibrarianRuntimeSlotBusy ->
+      "masc_keeper_memory_os_librarian_runtime_slot_busy_total"
   | RuntimeHttpProbeJsonParseFailures ->
       "masc_runtime_http_probe_json_parse_failures_total"
   | VisionAnalyze -> "masc_keeper_vision_analyze_total"

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -185,6 +185,11 @@ type t =
   | MemoryRecallReadErrors
   | MemoryOsRecallUnavailable
   | MemoryOsReobserveEchoSuppressed
+  | MemoryOsRecallFactsTruncated
+  | MemoryOsRecallEpisodesTruncated
+  | MemoryOsRecallBytesOverBudget
+  | MemoryOsEpisodeRetentionPruned
+  | MemoryOsLibrarianRuntimeSlotBusy
   | RuntimeHttpProbeJsonParseFailures
   | VisionAnalyze
   | VisionCandidateAttempts

--- a/lib/server/server_dashboard_http_memory_subsystems.ml
+++ b/lib/server/server_dashboard_http_memory_subsystems.ml
@@ -284,41 +284,52 @@ let empty_recall_quality_summary ~decode_error_records ~error =
   }
 ;;
 
+(* masc#25052: the ledger now writes v2 delta rows (only the keys that
+   changed since the keeper's previous row), so a raw [record] no longer
+   carries the full injected set on its own. [Keeper_recall_injection_ledger
+   .materialize] replays [payload] per keeper over this sample (already
+   chronological -- see [load_recall_quality_records] below) to reconstruct
+   it. This is exact whenever the sample includes a keeper's own genesis row,
+   which is far more likely now than under the old schema: v2 rows are only
+   written when the injected set actually changes, so a fixed-size recent
+   sample now spans much more of each keeper's real history. Legacy
+   (schema v1) rows replay to exactly their own list, so this is a
+   behavior-preserving generalization for any all-legacy sample (e.g. the
+   existing fixtures in test_server_dashboard_http_memory_subsystems.ml). *)
 let summarize_recall_quality ({ records; decode_error_records } : memory_quality_rows) =
   let initial = empty_recall_quality_summary ~decode_error_records ~error:None in
-  List.fold_left
-    (fun summary (record : Keeper_recall_injection_ledger.record) ->
-       let failure_counts =
-         match record.failure_reason with
-         | None -> summary.failure_counts
-         | Some reason ->
-           let reason =
-             Keeper_recall_injection_ledger.bounded_failure_reason_label reason
-           in
-           increment_count reason summary.failure_counts
-       in
-       let has_recall =
-         record.injected_fact_keys <> [] || record.injected_episode_keys <> []
-       in
-       let fact_counts, total_fact_injections =
-         List.fold_left
-           (fun (counts, total) key -> increment_count key counts, total + 1)
-           (summary.fact_counts, summary.total_fact_injections)
-           record.injected_fact_keys
-       in
-       { summary with
-         sampled_records = summary.sampled_records + 1
-       ; records_with_recall =
-           summary.records_with_recall + (if has_recall then 1 else 0)
-       ; failure_records =
-           summary.failure_records
-           + (if Option.is_some record.failure_reason then 1 else 0)
-       ; failure_counts
-       ; fact_counts
-       ; total_fact_injections
-       })
-    initial
-    records
+  records
+  |> Keeper_recall_injection_ledger.materialize
+  |> List.fold_left
+       (fun summary (m : Keeper_recall_injection_ledger.materialized) ->
+          let failure_counts =
+            match m.record.failure_reason with
+            | None -> summary.failure_counts
+            | Some reason ->
+              let reason =
+                Keeper_recall_injection_ledger.bounded_failure_reason_label reason
+              in
+              increment_count reason summary.failure_counts
+          in
+          let has_recall = m.fact_keys <> [] || m.episode_keys <> [] in
+          let fact_counts, total_fact_injections =
+            List.fold_left
+              (fun (counts, total) key -> increment_count key counts, total + 1)
+              (summary.fact_counts, summary.total_fact_injections)
+              m.fact_keys
+          in
+          { summary with
+            sampled_records = summary.sampled_records + 1
+          ; records_with_recall =
+              summary.records_with_recall + (if has_recall then 1 else 0)
+          ; failure_records =
+              summary.failure_records
+              + (if Option.is_some m.record.failure_reason then 1 else 0)
+          ; failure_counts
+          ; fact_counts
+          ; total_fact_injections
+          })
+       initial
 ;;
 
 let recall_quality_summary_json ~sample_limit ~top_key_limit summary =

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -3316,6 +3316,89 @@ let with_env name value f =
   Fun.protect ~finally:(fun () -> restore_env name old) f
 ;;
 
+(* masc#25052 P1: selection budget. Below budget, recall's behavior is
+   unchanged (asserted throughout the rest of this file, all of which use far
+   fewer than the 500-fact/500-episode default). This proves the truncation
+   case: over budget, only the most-recent-[last_verified_at] facts survive,
+   the drop is counted, and the dropped items are gone from the block. *)
+let test_recall_selection_budget_truncates_facts_by_recency () =
+  with_env "MASC_KEEPER_MEMORY_OS_RECALL_MAX_FACTS" "3" (fun () ->
+    with_prompt_registry (fun () ->
+      with_temp_keepers_dir (fun _keepers_dir ->
+        let keeper_id = "budget-truncation-keeper" in
+        let now = 1_000_000.0 in
+        (* last_verified_at strictly increases with i, so i=5 is most recent
+           and i=1 is oldest; with a budget of 3 only i=3,4,5 should survive. *)
+        List.iter
+          (fun i ->
+            let f =
+              { (fact_fixture ~now ()) with
+                Types.claim = Printf.sprintf "fact number %d" i
+              ; Types.claim_id = Some (Printf.sprintf "fact-%d" i)
+              ; Types.last_verified_at = Some (now -. (float_of_int (5 - i) *. 100.0))
+              }
+            in
+            Memory_io.append_fact ~keeper_id f)
+          [ 1; 2; 3; 4; 5 ];
+        let ctx = Recall.render_context ~keeper_id ~now () in
+        List.iter
+          (fun i ->
+            Alcotest.(check bool)
+              (Printf.sprintf "most recent fact %d survives the budget" i)
+              true
+              (contains (Printf.sprintf "fact number %d" i) ctx))
+          [ 3; 4; 5 ];
+        List.iter
+          (fun i ->
+            Alcotest.(check bool)
+              (Printf.sprintf "oldest fact %d is truncated" i)
+              false
+              (contains (Printf.sprintf "fact number %d" i) ctx))
+          [ 1; 2 ];
+        Alcotest.(check bool)
+          "truncation is counted (masc_keeper_memory_os_recall_facts_truncated_total)"
+          true
+          (Metrics.metric_value_or_zero
+             Keeper_metrics.(to_string MemoryOsRecallFactsTruncated)
+             ~labels:[ "keeper", keeper_id ]
+             ()
+           >= 2.0))))
+;;
+
+let test_recall_selection_budget_no_truncation_below_budget () =
+  with_env "MASC_KEEPER_MEMORY_OS_RECALL_MAX_FACTS" "3" (fun () ->
+    with_prompt_registry (fun () ->
+      with_temp_keepers_dir (fun _keepers_dir ->
+        let keeper_id = "budget-under-keeper" in
+        let now = 1_000_000.0 in
+        List.iter
+          (fun i ->
+            let f =
+              { (fact_fixture ~now ()) with
+                Types.claim = Printf.sprintf "under budget fact %d" i
+              ; Types.claim_id = Some (Printf.sprintf "under-fact-%d" i)
+              ; Types.last_verified_at = Some (now -. (float_of_int (3 - i) *. 100.0))
+              }
+            in
+            Memory_io.append_fact ~keeper_id f)
+          [ 1; 2; 3 ];
+        let ctx = Recall.render_context ~keeper_id ~now () in
+        List.iter
+          (fun i ->
+            Alcotest.(check bool)
+              (Printf.sprintf "fact %d present at exactly the budget" i)
+              true
+              (contains (Printf.sprintf "under budget fact %d" i) ctx))
+          [ 1; 2; 3 ];
+        Alcotest.(check (float 0.001))
+          "no truncation counted when store fits the budget"
+          0.0
+          (Metrics.metric_value_or_zero
+             Keeper_metrics.(to_string MemoryOsRecallFactsTruncated)
+             ~labels:[ "keeper", keeper_id ]
+             ()))))
+;;
+
 let test_librarian_provider_slot_gate_caps_at_capacity () =
   with_env Env_config.KeeperMemoryOs.librarian_global_slot_env_key "1" (fun () ->
     with_eio (fun ~sw ~net:_ ~clock ->
@@ -4736,6 +4819,14 @@ let () =
             "preserves repeated claim rows"
             `Quick
             test_recall_preserves_repeated_claims
+        ; Alcotest.test_case
+            "selection budget truncates by recency"
+            `Quick
+            test_recall_selection_budget_truncates_facts_by_recency
+        ; Alcotest.test_case
+            "selection budget is a no-op at or below budget"
+            `Quick
+            test_recall_selection_budget_no_truncation_below_budget
         ] )
     ; ( "retention"
       , [ Alcotest.test_case

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -3501,6 +3501,149 @@ let test_librarian_provider_slot_gate_is_per_keeper () =
         !first))
 ;;
 
+(* masc#25052 P3: process-global per-runtime slot, additive to the
+   per-keeper slot above. Capacity comes from the loaded runtime binding's
+   [max-concurrent], not an env var. *)
+let memory_runtime_max_concurrent_1_toml =
+  {|
+[runtime]
+default = "p0.default"
+
+[providers.p0]
+protocol = "openai-compatible-http"
+endpoint = "https://p0.example/v1"
+
+[models.default]
+api-name = "default"
+max-context = 4096
+temperature = 1.0
+
+[p0.default]
+max-concurrent = 1
+|}
+;;
+
+let memory_runtime_two_max_concurrent_1_toml =
+  {|
+[runtime]
+default = "p0.default"
+
+[providers.p0]
+protocol = "openai-compatible-http"
+endpoint = "https://p0.example/v1"
+
+[models.default]
+api-name = "default"
+max-context = 4096
+temperature = 1.0
+
+[models.alt]
+api-name = "alt"
+max-context = 4096
+temperature = 1.0
+
+[p0.default]
+max-concurrent = 1
+
+[p0.alt]
+max-concurrent = 1
+|}
+;;
+
+let test_librarian_runtime_slot_gate_caps_at_declared_capacity () =
+  with_runtime_config_toml memory_runtime_max_concurrent_1_toml (fun () ->
+    with_eio (fun ~sw ~net:_ ~clock ->
+      (* [max-concurrent = 1] in the loaded binding: while one entrant holds
+         the runtime slot, a concurrent entrant for the SAME runtime_id
+         drops ([None]) instead of blocking. *)
+      let entered, resolve_entered = Eio.Promise.create () in
+      let release, resolve_release = Eio.Promise.create () in
+      let first = ref None in
+      Eio.Fiber.fork ~sw (fun () ->
+        first
+        := Some
+             (Librarian_runtime.with_runtime_slot ~runtime_id:"p0.default" (fun () ->
+                Eio.Promise.resolve resolve_entered ();
+                Eio.Promise.await release;
+                "ran")));
+      Eio.Promise.await entered;
+      let second =
+        Librarian_runtime.with_runtime_slot ~runtime_id:"p0.default" (fun () -> "ran")
+      in
+      Eio.Promise.resolve resolve_release ();
+      wait_for_ref ~clock "first runtime slot holder" first;
+      Alcotest.(check (option string))
+        "concurrent entrant drops at the runtime's declared capacity"
+        None
+        second;
+      Alcotest.(check (option (option string)))
+        "slot holder ran"
+        (Some (Some "ran"))
+        !first))
+;;
+
+let test_librarian_runtime_slot_gate_disabled_when_undeclared () =
+  (* [memory_runtime_resolution_toml]'s [p0.default] binding declares no
+     [max-concurrent] -> capacity 0 -> the gate is a no-op, both run. *)
+  with_runtime_config_toml memory_runtime_resolution_toml (fun () ->
+    with_eio (fun ~sw ~net:_ ~clock ->
+      let entered, resolve_entered = Eio.Promise.create () in
+      let release, resolve_release = Eio.Promise.create () in
+      let first = ref None in
+      Eio.Fiber.fork ~sw (fun () ->
+        first
+        := Some
+             (Librarian_runtime.with_runtime_slot ~runtime_id:"p0.default" (fun () ->
+                Eio.Promise.resolve resolve_entered ();
+                Eio.Promise.await release;
+                "ran")));
+      Eio.Promise.await entered;
+      let second =
+        Librarian_runtime.with_runtime_slot ~runtime_id:"p0.default" (fun () -> "ran")
+      in
+      Eio.Promise.resolve resolve_release ();
+      wait_for_ref ~clock "first runtime slot holder" first;
+      Alcotest.(check (option string))
+        "no declared cap: concurrent entrant also ran"
+        (Some "ran")
+        second;
+      Alcotest.(check (option (option string)))
+        "slot holder ran"
+        (Some (Some "ran"))
+        !first))
+;;
+
+let test_librarian_runtime_slot_gate_is_per_runtime () =
+  with_runtime_config_toml memory_runtime_two_max_concurrent_1_toml (fun () ->
+    with_eio (fun ~sw ~net:_ ~clock ->
+      (* A slot held for runtime "p0.default" must not block runtime
+         "p0.alt", even though both declare the same capacity. *)
+      let entered, resolve_entered = Eio.Promise.create () in
+      let release, resolve_release = Eio.Promise.create () in
+      let first = ref None in
+      Eio.Fiber.fork ~sw (fun () ->
+        first
+        := Some
+             (Librarian_runtime.with_runtime_slot ~runtime_id:"p0.default" (fun () ->
+                Eio.Promise.resolve resolve_entered ();
+                Eio.Promise.await release;
+                "ran")));
+      Eio.Promise.await entered;
+      let other_runtime =
+        Librarian_runtime.with_runtime_slot ~runtime_id:"p0.alt" (fun () -> "ran")
+      in
+      Eio.Promise.resolve resolve_release ();
+      wait_for_ref ~clock "first runtime slot holder" first;
+      Alcotest.(check (option string))
+        "different runtime_id runs despite the other's capacity held"
+        (Some "ran")
+        other_runtime;
+      Alcotest.(check (option (option string)))
+        "slot holder ran"
+        (Some (Some "ran"))
+        !first))
+;;
+
 (* ---------- Explicit validity only ---------- *)
 
 let test_fact_validity_uses_only_stored_value () =
@@ -4909,6 +5052,18 @@ let () =
             "provider slot gate isolates keepers (P0-4)"
             `Quick
             test_librarian_provider_slot_gate_is_per_keeper
+        ; Alcotest.test_case
+            "runtime slot gate caps at the declared max-concurrent"
+            `Quick
+            test_librarian_runtime_slot_gate_caps_at_declared_capacity
+        ; Alcotest.test_case
+            "runtime slot gate is a no-op when no max-concurrent is declared"
+            `Quick
+            test_librarian_runtime_slot_gate_disabled_when_undeclared
+        ; Alcotest.test_case
+            "runtime slot gate isolates runtimes"
+            `Quick
+            test_librarian_runtime_slot_gate_is_per_runtime
         ] )
     ; ( "rfc-0259 volatile"
       , [ Alcotest.test_case

--- a/test/test_keeper_recall_injection_ledger.ml
+++ b/test/test_keeper_recall_injection_ledger.ml
@@ -1,7 +1,7 @@
-(* RFC-0264 P2: unit tests for the recall-injection ledger record serialiser and
-   retention maintenance hook. The serialiser checks are pure; retention checks
-   use a temporary dated JSONL tree to keep append-time pruning out of the hot
-   path. *)
+(* RFC-0264 P2 / masc#25052: unit tests for the recall-injection ledger record
+   serialiser, the v2 delta schema, and retention maintenance. The serialiser
+   checks are pure; retention checks use a temporary dated JSONL tree to keep
+   append-time pruning out of the hot path. *)
 
 module Ledger = Masc.Keeper_recall_injection_ledger
 open Yojson.Safe.Util
@@ -13,6 +13,11 @@ let check name cond =
   else (
     incr failed;
     Printf.printf "[FAIL] %s\n%!" name)
+
+let check_string_list name expected actual =
+  check
+    name
+    (List.sort String.compare expected = List.sort String.compare actual)
 
 let rec rm_rf path =
   if Sys.file_exists path
@@ -99,6 +104,205 @@ let test_prune_older_than_removes_old_day_file () =
        false);
   check "manual retention removes old recall file" (not (Sys.file_exists old_file))
 
+(* ── v2 delta append, via a temp masc_root + Eio (append is the only path
+   that touches the process-local Delta_state registry and Dated_jsonl I/O) ─ *)
+
+(* This file predates Alcotest (see the [check] harness above) and uses a
+   plain exit-code runner, so a decode failure while building a fixture is a
+   hard test-writer bug, not a data condition under test -- [failwith] is the
+   right escape here, not another [check] row. *)
+let fixture_fail msg = failwith msg
+
+let read_all_records ~masc_root =
+  let store = Dated_jsonl.create ~base_dir:(Ledger.base_dir ~masc_root) () in
+  Dated_jsonl.read_recent store 1000
+  |> List.map (fun json ->
+    match Ledger.record_of_json_result json with
+    | Ok record -> record
+    | Error _ -> fixture_fail "unexpected decode failure in ledger fixture")
+;;
+
+let test_append_writes_delta_row_and_updates_registry () =
+  with_temp_masc_root "recall-ledger-delta-append" @@ fun masc_root ->
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Ledger.For_testing.reset_delta_state ();
+  Ledger.append
+    ~masc_root
+    ~keeper_id:"gamma"
+    ~trace_id:"trace-g"
+    ~turn:1
+    ~injected_fact_keys:[ "x"; "y" ]
+    ~injected_episode_keys:[]
+    ~n_facts_in_store:2
+    ~now:1.0
+    ();
+  Ledger.append
+    ~masc_root
+    ~keeper_id:"gamma"
+    ~trace_id:"trace-g"
+    ~turn:2
+    ~injected_fact_keys:[ "y"; "z" ]
+    ~injected_episode_keys:[ "trace-g:g0" ]
+    ~n_facts_in_store:2
+    ~now:2.0
+    ();
+  match read_all_records ~masc_root with
+  | [ first; second ] ->
+    (match first.payload with
+     | Ledger.Delta { added_fact_keys; removed_fact_keys; _ } ->
+       check_string_list
+         "first append (fresh registry) is a full accounting: added = [x; y]"
+         [ "x"; "y" ]
+         added_fact_keys;
+       check "first append has no removals (nothing prior)" (removed_fact_keys = [])
+     | Ledger.Full_snapshot _ ->
+       check "first append is tagged Delta, not Full_snapshot" false);
+    (match second.payload with
+     | Ledger.Delta
+         { added_fact_keys; removed_fact_keys; added_episode_keys; removed_episode_keys; _ } ->
+       check_string_list "second append adds only the new key" [ "z" ] added_fact_keys;
+       check_string_list "second append removes only the dropped key" [ "x" ] removed_fact_keys;
+       check_string_list "second append adds the new episode key" [ "trace-g:g0" ]
+         added_episode_keys;
+       check "second append removes no episode keys" (removed_episode_keys = [])
+     | Ledger.Full_snapshot _ ->
+       check "second append is tagged Delta, not Full_snapshot" false)
+  | rows ->
+    check (Printf.sprintf "expected exactly 2 rows, got %d" (List.length rows)) false
+;;
+
+let test_append_no_change_produces_empty_delta_regardless_of_store_size () =
+  with_temp_masc_root "recall-ledger-delta-nochange" @@ fun masc_root ->
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Ledger.For_testing.reset_delta_state ();
+  let small = List.init 10 (fun i -> Printf.sprintf "fact-%d" i) in
+  let large = List.init 1000 (fun i -> Printf.sprintf "fact-%d" i) in
+  let row_bytes_of_second_append ~keeper_id ~facts =
+    Ledger.append
+      ~masc_root
+      ~keeper_id
+      ~trace_id:"trace-1"
+      ~turn:1
+      ~injected_fact_keys:facts
+      ~injected_episode_keys:[]
+      ~n_facts_in_store:(List.length facts)
+      ~now:1.0
+      ();
+    Ledger.append
+      ~masc_root
+      ~keeper_id
+      ~trace_id:"trace-1"
+      ~turn:2
+      ~injected_fact_keys:facts
+      ~injected_episode_keys:[]
+      ~n_facts_in_store:(List.length facts)
+      ~now:2.0
+      ();
+    let store = Dated_jsonl.create ~base_dir:(Ledger.base_dir ~masc_root) () in
+    match Dated_jsonl.read_recent_lines store 2 with
+    | [ _first; second_line ] -> String.length second_line
+    | lines -> fixture_fail (Printf.sprintf "expected 2 lines, got %d" (List.length lines))
+  in
+  let small_bytes = row_bytes_of_second_append ~keeper_id:"small-store-keeper" ~facts:small in
+  let large_bytes = row_bytes_of_second_append ~keeper_id:"large-store-keeper" ~facts:large in
+  (* Both second rows are empty-delta rows (nothing changed since turn 1):
+     their byte size must be governed by the fixed field overhead, not by
+     store size. A generous 3x margin absorbs keeper_id/trace_id string
+     length differences without hiding a real O(store_size) regression
+     (which would make [large_bytes] roughly 100x [small_bytes], not ~1x). *)
+  check
+    (Printf.sprintf
+       "unchanged-set row bytes independent of store size (small=%d large=%d)"
+       small_bytes
+       large_bytes)
+    (large_bytes < small_bytes * 3)
+;;
+
+let test_materialize_replays_legacy_and_delta_rows () =
+  let full ~keeper_id ~trace_id ~turn ~fact_keys ~episode_keys =
+    { Ledger.keeper_id
+    ; trace_id
+    ; turn
+    ; ts = Some (float_of_int turn)
+    ; failure_reason = None
+    ; n_facts_in_store = None
+    ; n_episodes_in_store = None
+    ; payload = Ledger.Full_snapshot { fact_keys; episode_keys }
+    }
+  in
+  let delta
+        ~keeper_id
+        ~trace_id
+        ~turn
+        ~added_fact_keys
+        ~removed_fact_keys
+        ~added_episode_keys
+        ~removed_episode_keys
+    =
+    { Ledger.keeper_id
+    ; trace_id
+    ; turn
+    ; ts = Some (float_of_int turn)
+    ; failure_reason = None
+    ; n_facts_in_store = None
+    ; n_episodes_in_store = None
+    ; payload =
+        Ledger.Delta
+          { added_fact_keys
+          ; removed_fact_keys
+          ; added_episode_keys
+          ; removed_episode_keys
+          ; content_hash =
+              Ledger.content_hash_of ~fact_keys:added_fact_keys ~episode_keys:added_episode_keys
+          }
+    }
+  in
+  let records =
+    [ full ~keeper_id:"k" ~trace_id:"t1" ~turn:1 ~fact_keys:[ "a"; "b" ] ~episode_keys:[]
+    ; delta
+        ~keeper_id:"k"
+        ~trace_id:"t1"
+        ~turn:2
+        ~added_fact_keys:[ "c" ]
+        ~removed_fact_keys:[ "a" ]
+        ~added_episode_keys:[ "t1:g0" ]
+        ~removed_episode_keys:[]
+    ]
+  in
+  match Ledger.materialize records with
+  | [ first; second ] ->
+    check_string_list "genesis snapshot materializes to its own list" [ "a"; "b" ]
+      first.fact_keys;
+    check_string_list "delta row materializes to (prior + added) - removed" [ "b"; "c" ]
+      second.fact_keys;
+    check_string_list "delta row materializes episode keys" [ "t1:g0" ] second.episode_keys
+  | rows -> check (Printf.sprintf "expected 2 materialized rows, got %d" (List.length rows)) false
+;;
+
+let test_materialize_keeps_keepers_independent () =
+  let row keeper_id turn keys =
+    { Ledger.keeper_id
+    ; trace_id = "t"
+    ; turn
+    ; ts = None
+    ; failure_reason = None
+    ; n_facts_in_store = None
+    ; n_episodes_in_store = None
+    ; payload = Ledger.Full_snapshot { fact_keys = keys; episode_keys = [] }
+    }
+  in
+  let records = [ row "keeper-a" 1 [ "shared" ]; row "keeper-b" 1 [ "other" ] ] in
+  match Ledger.materialize records with
+  | [ a; b ] ->
+    check_string_list "keeper-a materializes its own set only" [ "shared" ] a.fact_keys;
+    check_string_list "keeper-b materializes its own set only" [ "other" ] b.fact_keys
+  | rows -> check (Printf.sprintf "expected 2 materialized rows, got %d" (List.length rows)) false
+;;
+
 let () =
   let j =
     Ledger.to_json
@@ -159,11 +363,14 @@ let () =
   let round_trip = Yojson.Safe.from_string (Yojson.Safe.to_string j) in
   check "round-trip equal" (Yojson.Safe.equal j round_trip);
   (match Ledger.record_of_json_result round_trip with
-   | Ok record ->
-     check "typed decoder preserves keeper_id" (record.keeper_id = "alpha");
-     check
-       "typed decoder preserves fact keys"
-       (record.injected_fact_keys = [ "fact one"; "fact two" ])
+   | Ok { payload = Ledger.Full_snapshot { fact_keys; episode_keys }; keeper_id; trace_id; turn; _ } ->
+     check "typed decoder preserves keeper_id" (keeper_id = "alpha");
+     check "typed decoder preserves trace_id" (trace_id = "trace-1");
+     check "typed decoder preserves turn" (turn = 3);
+     check "typed decoder preserves fact keys" (fact_keys = [ "fact one"; "fact two" ]);
+     check "typed decoder preserves episode keys" (episode_keys = [ "trace-1:g0" ])
+   | Ok { payload = Ledger.Delta _; _ } ->
+     check "legacy row decodes as Full_snapshot, not Delta" false
    | Error _ -> check "typed decoder accepts own schema" false);
   (match Ledger.record_of_json_result (`Assoc []) with
    | Error (`Missing_field "keeper_id") -> check "missing keeper_id is visible" true
@@ -172,6 +379,8 @@ let () =
      Ledger.record_of_json_result
        (`Assoc
          [ "keeper_id", `String "alpha"
+         ; "trace_id", `String "trace-1"
+         ; "turn", `Int 1
          ; "injected_fact_keys", `List [ `Int 1 ]
          ; "injected_episode_keys", `List []
          ])
@@ -179,6 +388,20 @@ let () =
    | Error (`Invalid_field "injected_fact_keys") ->
      check "invalid fact key list is visible" true
    | _ -> check "invalid fact key list is visible" false);
+  (match
+     Ledger.record_of_json_result
+       (`Assoc
+         [ "keeper_id", `String "alpha"
+         ; "trace_id", `String "trace-1"
+         ; "turn", `Int 1
+         ; "schema_version", `Int 99
+         ; "injected_fact_keys", `List []
+         ; "injected_episode_keys", `List []
+         ])
+   with
+   | Error (`Unsupported_schema_version 99) ->
+     check "unknown schema_version is a typed error, not a silent fallback" true
+   | _ -> check "unknown schema_version is a typed error, not a silent fallback" false);
   check
     "known recall failure label stays stable"
     (Ledger.bounded_failure_reason_label "prompt_render_error"
@@ -187,8 +410,32 @@ let () =
     "unknown recall failure label is bounded"
     (Ledger.bounded_failure_reason_label "free-form provider detail"
      = Ledger.failure_reason_unknown_label);
+  (* Pure delta primitives: round-trip and direct cases. *)
+  let added, removed = Ledger.diff_keys ~previous:[ "a"; "b" ] ~current:[ "b"; "c" ] in
+  check_string_list "diff_keys added" [ "c" ] added;
+  check_string_list "diff_keys removed" [ "a" ] removed;
+  check_string_list
+    "apply_delta reconstructs current from previous + diff_keys"
+    [ "b"; "c" ]
+    (Ledger.apply_delta ~previous:[ "a"; "b" ] ~added ~removed);
+  check_string_list
+    "diff_keys of identical sets is empty"
+    []
+    (fst (Ledger.diff_keys ~previous:[ "a"; "b" ] ~current:[ "b"; "a" ]));
+  check
+    "content_hash_of is order-independent"
+    (Ledger.content_hash_of ~fact_keys:[ "a"; "b" ] ~episode_keys:[]
+     = Ledger.content_hash_of ~fact_keys:[ "b"; "a" ] ~episode_keys:[]);
+  check
+    "content_hash_of distinguishes different sets"
+    (Ledger.content_hash_of ~fact_keys:[ "a" ] ~episode_keys:[]
+     <> Ledger.content_hash_of ~fact_keys:[ "a"; "b" ] ~episode_keys:[]);
+  test_materialize_replays_legacy_and_delta_rows ();
+  test_materialize_keeps_keepers_independent ();
   test_append_does_not_prune_old_day_file ();
   test_prune_older_than_removes_old_day_file ();
+  test_append_writes_delta_row_and_updates_registry ();
+  test_append_no_change_produces_empty_delta_regardless_of_store_size ();
   if !failed > 0
   then (
     Printf.printf "\n%d check(s) failed\n%!" !failed;

--- a/test/test_keeper_recall_outcome_eval.ml
+++ b/test/test_keeper_recall_outcome_eval.ml
@@ -96,7 +96,11 @@ let test_surfaces_bad_rows_and_uses_typed_outcome () =
   with_temp_masc_root (fun masc_root ->
     write_lines
       (Filename.concat masc_root "recall_injections/2026-06/27.jsonl")
-      [ {|{"keeper_id":"alpha","trace_id":"trace-1","turn":1,"injected_fact_keys":["a"],"injected_fact_key_count":7,"injected_episode_keys":[],"ts":1.0}|}
+      [ (* "injected_fact_key_count" here is deliberately unrelated to the
+           actual list length: this schema field is dead (masc#25052 —
+           no writer ever produced it) and is no longer read, so the
+           divergence below asserts it is now IGNORED rather than trusted. *)
+        {|{"keeper_id":"alpha","trace_id":"trace-1","turn":1,"injected_fact_keys":["a"],"injected_fact_key_count":7,"injected_episode_keys":[],"ts":1.0}|}
       ; {|{"keeper_id":"alpha","turn":2,"injected_fact_keys":[],"injected_episode_keys":[]}|}
       ; {|{"keeper_id":|}
       ];
@@ -113,7 +117,8 @@ let test_surfaces_bad_rows_and_uses_typed_outcome () =
     let report = Eval.evaluate ~masc_root in
     Alcotest.(check int) "recall records" 1 report.recall_records;
     Alcotest.(check int) "typed cancelled outcome" 1 report.outcome_cancelled;
-    Alcotest.(check int) "explicit injected count" 7 report.injected_fact_keys;
+    Alcotest.(check int) "count derived from actual list, not the dead override field" 1
+      report.injected_fact_keys;
     Alcotest.(check int) "malformed rows" 1 report.malformed_jsonl_rows;
     Alcotest.(check int) "invalid recall rows" 1 report.invalid_recall_rows;
     Alcotest.(check int) "invalid receipt rows" 1 report.invalid_receipt_rows;


### PR DESCRIPTION
## Why

**#25052 (lane 전수 분석, 적대 검증 P1×2 + P2)**: memory-os의 read/write 경계 결함 3건이 boot-hang 인시던트(#24886 계열)와 동일한 "compaction 없는 append 원장" 패턴으로 진행형 — recall-주입 원장 라이브 **583MB, +154MB/일**, recall이 전체 store(~1.5MB)를 매 턴 주입, librarian 서브콜이 `[ollama.gemma] max-concurrent=1` 선언을 우회.

## What (3 commits)

1. **원장 delta 스키마** (`1e2acb403d`): 전량 키 목록 → v2 delta 행(added/removed + content_hash + 카운터). 레거시 행은 Full_snapshot으로 계속 디코드. 소비자 2곳(offline eval·대시보드) 전수 조사 후 `materialize` replay로 명시 적응. **property 증거: 10-fact vs 1000-fact store에서 no-op 행 282 vs 284 bytes = 행 크기가 store 크기와 독립**.
2. **recall 선택 예산** (`63df42f88f`): `keeper_memory_os_recall_max_facts/_max_episodes` (Runtime_params, 기본 500). 예산 이하면 순서 불변, 초과 시 recency 기준 생존자 선택 + **truncation은 로그+카운터로 항상 가시화**. max_bytes는 관측 전용(의도적 스코프 컷, 본문 명시).
3. **librarian 동시성 + det-write 분리** (`f26f7b4d8f`): pin이 0.215.0(oas#2641 이전)이므로 process-global `with_runtime_slot`(runtime_id 키, `binding.max_concurrent` 사이즈, 미선언=게이트 비활성·동작 불변). 포화 시 **drop(None) — block이 아님**: 여기서 대기하면 mem_mu 보유 중 provider 대기라는 원래 결함을 재생산. det-write(memory-bank/delegation)와 LLM 추출을 별도 lane 제출로 분리 — provider 지연이 결정론 데이터를 도매금 drop시키던 공유 예약 문제 해소 (RFC-0257 keeper별 mutex 경계는 불변).

## 스코프 컷 (명시)

- episodes/events **retention은 미포함** → **#25065** (rewrite-with-subset 프리미티브 필요, read-side의 write-side 쌍둥이).
- oas#2641 착지 후 `with_runtime_slot`은 provider-측 admission으로 수렴 가능 (마이그레이션 노트 코드 주석).

## Verification

- 전 스위트 실행 green: recall_injection_ledger 41/41 · recall_outcome_eval 5/5 · dashboard_memory_subsystems 9/9 · keeper_memory_os 109/109(신규 5 포함) · turn_outcome/event_queue 스팟.
- **`@check` 전체 컴파일 exit 0** (시그니처 변경의 미스캔 caller 클래스 사전 차단 — #25062에서 학습).

관련: #25052 · #25065 · #24886 · oas#2641 · RFC-0257

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012KXQWcg9KtaC7KruGQTnwX
