### PR TITLE
fix(ci): scope PR axis checks to default branch

### DIFF
--- a/scripts/pr_axis_check.py
+++ b/scripts/pr_axis_check.py
@@ -194,6 +194,24 @@ def get_repo_slug() -> Tuple[str, str]:
     return data["owner"]["login"], data["name"]
 
 
+def get_default_branch(owner: str, repo: str) -> str:
+    """Read the repository default branch from GitHub metadata."""
+    resp = _run_gh([f"/repos/{owner}/{repo}"])
+    default_branch = resp.get("default_branch") if isinstance(resp, dict) else None
+    if not isinstance(default_branch, str) or not default_branch:
+        print(
+            f"GitHub metadata has no default branch for {owner}/{repo}.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    return default_branch
+
+
+def should_scan_axis_staleness(pr_base_ref: str, default_branch: str) -> bool:
+    """Only PRs targeting the repository default branch own mainline staleness."""
+    return pr_base_ref == default_branch
+
+
 def get_pr_base_info(
     pr_number: int, owner: str, repo: str
 ) -> Tuple[Optional[str], Optional[str]]:
@@ -321,16 +339,23 @@ def check_pr_axis_stale(
     pr_number: int,
     owner: str,
     repo: str,
+    default_branch: str,
     hours: int = 24,
     limit: int = 20,
 ) -> List[AxisRisk]:
     """Check if an open PR is at risk of being stale from recent merges."""
+    pr_base_sha, pr_base_ref = get_pr_base_info(pr_number, owner, repo)
+    if not pr_base_ref:
+        print(f"Could not determine base ref for PR #{pr_number}.", file=sys.stderr)
+        sys.exit(2)
+    if not should_scan_axis_staleness(pr_base_ref, default_branch):
+        return []
+
     open_files = get_pr_files(pr_number, owner, repo)
     if not open_files:
         print(f"Warning: no files found for PR #{pr_number}", file=sys.stderr)
         return []
 
-    pr_base_sha, pr_base_ref = get_pr_base_info(pr_number, owner, repo)
     if not pr_base_sha:
         print(
             f"Warning: could not determine base SHA for PR #{pr_number}",
@@ -411,7 +436,7 @@ def check_pr_axis_stale(
 
 
 def scan_all_open_prs(
-    owner: str, repo: str, hours: int, limit: int
+    owner: str, repo: str, default_branch: str, hours: int, limit: int
 ) -> Dict[int, List[AxisRisk]]:
     """Scan all open PRs for axis risks."""
     query = f"""
@@ -439,7 +464,7 @@ query {{
     for pr in open_prs:
         pr_num = pr["number"]
         print(f"Scanning PR #{pr_num}: {pr['title']}", file=sys.stderr)
-        risks = check_pr_axis_stale(pr_num, owner, repo, hours, limit)
+        risks = check_pr_axis_stale(pr_num, owner, repo, default_branch, hours, limit)
         if risks:
             results[pr_num] = risks
 
@@ -565,7 +590,11 @@ def self_test() -> int:
     assert detect_rfc_collisions(noise) == [], "non-RFC-claim paths must not collide"
     print("self-test: non-RFC paths ignored -> no collision (PASS)")
 
-    print("pr_axis_check self-test: all RFC-collision cases passed")
+    assert should_scan_axis_staleness("trunk", "trunk")
+    assert not should_scan_axis_staleness("stack-parent", "trunk")
+    print("self-test: default base scanned, stacked child skipped (PASS)")
+
+    print("pr_axis_check self-test: all structural cases passed")
     return 0
 
 
@@ -617,11 +646,13 @@ def main() -> int:
         print("No RFC number collisions among open PRs.")
         return 0
 
+    default_branch = get_default_branch(owner, repo)
+
     def _block(r: AxisRisk) -> bool:
         return r.confidence != "LOW"
 
     if args.scan_all_open:
-        results = scan_all_open_prs(owner, repo, args.hours, args.limit)
+        results = scan_all_open_prs(owner, repo, default_branch, args.hours, args.limit)
         # Partition into blockers vs warnings
         blockers: Dict[int, List[AxisRisk]] = {}
         warnings: Dict[int, List[AxisRisk]] = {}
@@ -673,7 +704,9 @@ def main() -> int:
     if not args.pr:
         parser.error("Either --pr or --scan-all-open is required")
 
-    single_risks = check_pr_axis_stale(args.pr, owner, repo, args.hours, args.limit)
+    single_risks = check_pr_axis_stale(
+        args.pr, owner, repo, default_branch, args.hours, args.limit
+    )
     single_blockers = [r for r in single_risks if _block(r)]
     single_warnings = [r for r in single_risks if not _block(r)]
 


### PR DESCRIPTION
## Summary

- read the repository default branch from GitHub metadata as the SSOT
- apply mainline axis-staleness checks only to PRs targeting that default branch
- preserve RFC collision checks for stacked children and fail explicitly when branch metadata is unavailable

This removes the false positive on stacked PR #25063 without a waiver, baseline, hardcoded branch name, or time heuristic. The parent PR targeting the default branch remains responsible for mainline drift.

## Validation

- `python3 scripts/pr_axis_check.py --self-test`
- `ruff check scripts/pr_axis_check.py`
- `ruff format --check scripts/pr_axis_check.py`
- `pyright --outputjson scripts/pr_axis_check.py`
- `python3 scripts/pr_axis_check.py --pr 25063` -> no axis risks, exit 0
- `git diff --check origin/main...HEAD`

## Stack

Independent CI correctness leaf on `main`; it unblocks honest validation of stacked implementation PRs such as #25063.