### PR TITLE
refactor(gate): persist monotonic owner FIFO

### DIFF
--- a/lib/keeper/hitl_summary_worker.ml
+++ b/lib/keeper/hitl_summary_worker.ml
@@ -39,25 +39,6 @@ let readiness () =
             runtime_id))
 ;;
 
-let effective_max_concurrency ~configured ~runtime_limit =
-  match runtime_limit with
-  | Some limit -> Int.min configured limit
-  | None -> configured
-;;
-
-let max_concurrency () =
-  let configured = Keeper_config.hitl_summary_max_concurrency () in
-  let runtime_limit =
-    match Runtime.hitl_summary_runtime_id () with
-    | Some runtime_id ->
-      (match Runtime.get_runtime_by_id runtime_id with
-       | Some runtime -> runtime.Runtime.binding.max_concurrent
-       | None -> None)
-    | None -> None
-  in
-  effective_max_concurrency ~configured ~runtime_limit
-;;
-
 (* ── Metrics ────────────────────────────────────── *)
 
 let () =
@@ -523,7 +504,6 @@ module For_testing = struct
   let summary_llm_error_outcomes = summary_llm_error_outcomes
   let summary_llm_error_retryable = summary_llm_error_retryable
   let sdk_error_of_http_error = sdk_error_of_http_error
-  let effective_max_concurrency = effective_max_concurrency
   let body_timeout_clock = body_timeout_clock
   let system_prompt = system_prompt
   let summary_version = summary_version

--- a/lib/keeper/hitl_summary_worker.mli
+++ b/lib/keeper/hitl_summary_worker.mli
@@ -6,10 +6,6 @@ type summary_provider = private
 
 val provider_config_for_summary : unit -> summary_provider option
 
-(** Effective Auto Judge worker cap. The subsystem cap is further bounded by
-    the selected runtime binding's [max_concurrent] declaration. *)
-val max_concurrency : unit -> int
-
 (** Verify that the registry-owned Gate judgment prompt is renderable and that
     the exact [runtime].hitl_summary runtime is configured and loaded. *)
 val readiness : unit -> (unit, string) result
@@ -82,9 +78,6 @@ module For_testing : sig
 
   val sdk_error_of_http_error
     : Llm_provider.Http_client.http_error -> Agent_sdk.Error.sdk_error
-
-  val effective_max_concurrency
-    : configured:int -> runtime_limit:int option -> int
 
   val body_timeout_clock
     : unit -> float Eio.Time.clock_ty Eio.Resource.t option

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -80,11 +80,13 @@ let install_error_to_string = function
   | Install_storage_failed error -> storage_error_to_string error
 ;;
 
-let pending_store_version = 2
+let pending_store_version = 3
 let pending_store_surface = "keeper_gate_pending"
 let pending_store_mutex = Cross_context_mutex.create ()
 let deliveries : persisted_delivery SMap.t Atomic.t = Atomic.make SMap.empty
 let unavailable_stores : storage_error SMap.t Atomic.t = Atomic.make SMap.empty
+(** Process projection of the next value persisted in each workspace snapshot. *)
+let next_sequences : int SMap.t Atomic.t = Atomic.make SMap.empty
 
 (** Serialize one durable pending/delivery snapshot transition across both Eio
     fibers and non-Eio callers.  A plain [Stdlib.Mutex.protect] is invalid here:
@@ -135,6 +137,7 @@ let pending_entry_to_yojson (entry : pending_approval) =
     ; "tool_name", `String entry.tool_name
     ; "input_hash", `String entry.input_hash
     ; "input", entry.input
+    ; "sequence", `Int entry.sequence
     ; "requested_at", `Float entry.requested_at
     ; "turn_id", Json_util.int_opt_to_json entry.turn_id
     ; ( "request_context"
@@ -174,7 +177,7 @@ let map_values_for_base ~base_path map project =
     if String.equal (project value).audit_base_path base_path then Some value else None)
 ;;
 
-let snapshot_to_yojson ~base_path ~pending_map ~delivery_map =
+let snapshot_to_yojson ~base_path ~next_sequence ~pending_map ~delivery_map =
   let pending_entries =
     map_values_for_base ~base_path pending_map Fun.id
     |> List.map pending_entry_to_yojson
@@ -185,12 +188,22 @@ let snapshot_to_yojson ~base_path ~pending_map ~delivery_map =
   in
   `Assoc
     [ "version", `Int pending_store_version
+    ; "next_sequence", `Int next_sequence
     ; "pending", `List pending_entries
     ; "deliveries", `List delivery_entries
     ]
 ;;
 
-let persist_snapshot_unlocked ~base_path ~pending_map ~delivery_map =
+let next_sequence_unlocked ~base_path =
+  Option.value (SMap.find_opt base_path (Atomic.get next_sequences)) ~default:1
+;;
+
+let persist_snapshot_with_sequence_unlocked
+      ~base_path
+      ~next_sequence
+      ~pending_map
+      ~delivery_map
+  =
   let path = pending_store_path ~base_path in
   match SMap.find_opt base_path (Atomic.get unavailable_stores) with
   | Some error -> Error error
@@ -198,7 +211,7 @@ let persist_snapshot_unlocked ~base_path ~pending_map ~delivery_map =
     (try
        Fs_compat.mkdir_p (Filename.dirname path);
        let body =
-         snapshot_to_yojson ~base_path ~pending_map ~delivery_map
+         snapshot_to_yojson ~base_path ~next_sequence ~pending_map ~delivery_map
          |> Yojson.Safe.pretty_to_string
        in
        (match Fs_compat.save_file_atomic path body with
@@ -207,6 +220,14 @@ let persist_snapshot_unlocked ~base_path ~pending_map ~delivery_map =
      with
      | Eio.Cancel.Cancelled _ as exn -> raise exn
      | exn -> Error { path; reason = Printexc.to_string exn })
+;;
+
+let persist_snapshot_unlocked ~base_path ~pending_map ~delivery_map =
+  persist_snapshot_with_sequence_unlocked
+    ~base_path
+    ~next_sequence:(next_sequence_unlocked ~base_path)
+    ~pending_map
+    ~delivery_map
 ;;
 
 let reject_unknown_fields ~surface ~allowed fields =
@@ -254,6 +275,13 @@ let optional_nonnegative_int ~surface field fields =
     Error (Printf.sprintf "%s.%s must be a non-negative integer or null" surface field)
 ;;
 
+let required_positive_int ~surface field fields =
+  match List.assoc_opt field fields with
+  | Some (`Int value) when value > 0 -> Ok value
+  | Some _ -> Error (Printf.sprintf "%s.%s must be a positive integer" surface field)
+  | None -> Error (Printf.sprintf "%s.%s is required" surface field)
+;;
+
 let required_float ~surface field fields =
   match List.assoc_opt field fields with
   | Some (`Float value) -> Ok value
@@ -290,6 +318,7 @@ let pending_entry_of_yojson ~base_path json =
           ; "tool_name"
           ; "input_hash"
           ; "input"
+          ; "sequence"
           ; "requested_at"
           ; "turn_id"
           ; "request_context"
@@ -312,6 +341,7 @@ let pending_entry_of_yojson ~base_path json =
       then Ok ()
       else Error (Printf.sprintf "%s.input_hash does not match input" surface)
     in
+    let* sequence = required_positive_int ~surface "sequence" fields in
     let* requested_at = required_float ~surface "requested_at" fields in
     let* turn_id = optional_nonnegative_int ~surface "turn_id" fields in
     let request_context =
@@ -332,6 +362,7 @@ let pending_entry_of_yojson ~base_path json =
       ; tool_name
       ; input_hash
       ; input
+      ; sequence
       ; requested_at
       ; turn_id
       ; request_context
@@ -468,6 +499,29 @@ let parse_list ~surface parse = function
   | _ -> Error (surface ^ " must be an array")
 ;;
 
+let validate_snapshot_sequences ~next_sequence pending_entries delivery_entries =
+  let sequences =
+    List.map (fun (entry : pending_approval) -> entry.sequence) pending_entries
+    @ List.map
+        (fun (delivery : persisted_delivery) -> delivery.entry.sequence)
+        delivery_entries
+    |> List.sort Int.compare
+  in
+  let rec check previous = function
+    | [] -> Ok ()
+    | sequence :: _ when sequence >= next_sequence ->
+      Error
+        (Printf.sprintf
+           "gate_pending sequence %d must precede next_sequence %d"
+           sequence
+           next_sequence)
+    | sequence :: _ when previous = Some sequence ->
+      Error (Printf.sprintf "gate_pending contains duplicate sequence %d" sequence)
+    | sequence :: rest -> check (Some sequence) rest
+  in
+  check None sequences
+;;
+
 let snapshot_of_yojson ~base_path json =
   match json with
   | `Assoc fields ->
@@ -476,7 +530,7 @@ let snapshot_of_yojson ~base_path json =
     let* () =
       reject_unknown_fields
         ~surface
-        ~allowed:[ "version"; "pending"; "deliveries" ]
+        ~allowed:[ "version"; "next_sequence"; "pending"; "deliveries" ]
         fields
     in
     let* () =
@@ -487,6 +541,7 @@ let snapshot_of_yojson ~base_path json =
       | Some _ -> Error (surface ^ ".version must be an integer")
       | None -> Error (surface ^ ".version is required")
     in
+    let* next_sequence = required_positive_int ~surface "next_sequence" fields in
     let* pending_json = required_member ~surface "pending" fields in
     let* pending_entries =
       parse_list ~surface:"gate_pending.pending" (pending_entry_of_yojson ~base_path) pending_json
@@ -515,7 +570,10 @@ let snapshot_of_yojson ~base_path json =
       | None -> Ok ()
       | Some id -> Error (Printf.sprintf "gate_pending id %s exists in both states" id)
     in
-    Ok (pending_map, delivery_map)
+    let* () =
+      validate_snapshot_sequences ~next_sequence pending_entries delivery_entries
+    in
+    Ok (pending_map, delivery_map, next_sequence)
   | _ -> Error "gate_pending snapshot must be a JSON object"
 ;;
 
@@ -523,7 +581,7 @@ let load_snapshot_unlocked ~base_path =
   let path = pending_store_path ~base_path in
   try
     if not (Sys.file_exists path)
-    then Ok (SMap.empty, SMap.empty)
+    then Ok (SMap.empty, SMap.empty, 1)
     else (
       match Safe_ops.read_json_file_safe path with
       | Error reason ->
@@ -1065,6 +1123,7 @@ let input_preview_of_json (json : Yojson.Safe.t) =
 
 let create_entry
       ~id
+      ~sequence
       ~keeper_name
       ~tool_name
       ~input
@@ -1083,6 +1142,7 @@ let create_entry
   ; tool_name
   ; input_hash
   ; input
+  ; sequence
   ; requested_at = Unix.gettimeofday ()
   ; turn_id
   ; request_context = Option.map Keeper_gate_request_context.project request_context
@@ -1102,6 +1162,7 @@ let pending_entry_json_fields
   [ "id", `String entry.id
   ; "keeper_name", `String entry.keeper_name
   ; "tool_name", `String entry.tool_name
+  ; "sequence", `Int entry.sequence
   ; "requested_at", `Float entry.requested_at
   ; "waiting_s", `Float (Unix.gettimeofday () -. entry.requested_at)
   ; "turn_id", Json_util.int_opt_to_json entry.turn_id
@@ -1144,8 +1205,9 @@ let broadcast_pending entry =
 
 let record_pending (entry : pending_approval) =
   Log.Keeper.info
-    "HITL_APPROVAL_PENDING: id=%s keeper=%s tool=%s"
+    "HITL_APPROVAL_PENDING: id=%s sequence=%d keeper=%s tool=%s"
     entry.id
+    entry.sequence
     entry.keeper_name
     entry.tool_name;
   audit_approval_event
@@ -1596,14 +1658,6 @@ let find_pending_id_in_map
     None
 ;;
 
-let sort_entries_by_requested_at entries =
-  List.sort
-    (fun left right ->
-       let ts_of_json json = (match Json_util.assoc_member_opt "requested_at" json with Some (`Float f) -> f | Some (`Int n) -> Float.of_int n | _ -> 0.0) in
-       Float.compare (ts_of_json left) (ts_of_json right))
-    entries
-;;
-
 (* ── Nonblocking submission ───────────────────────────────── *)
 
 let submit_pending
@@ -1643,32 +1697,46 @@ let submit_pending
       | Some id -> Ok (id, None)
       | None ->
         let id = generate_id () in
-        let entry =
-          create_entry
-            ~id
-            ~keeper_name
-            ~tool_name
-            ~input
-            ?turn_id
-            ?request_context
-            ?task_id
-            ?goal_id
-            ~goal_ids
-            ~continuation_channel
-            ~audit_base_path:base_path
-            ()
-        in
-        let updated = SMap.add id entry map in
-        (match
-           persist_snapshot_unlocked
-             ~base_path
-             ~pending_map:updated
-             ~delivery_map:(Atomic.get deliveries)
-         with
-         | Error _ as error -> error
-         | Ok () ->
-           Atomic.set pending updated;
-           Ok (id, Some entry)))
+        let sequence = next_sequence_unlocked ~base_path in
+        if sequence = max_int
+        then
+          Error
+            { path = pending_store_path ~base_path
+            ; reason = "approval sequence exhausted its integer representation"
+            }
+        else
+          let entry =
+            create_entry
+              ~id
+              ~sequence
+              ~keeper_name
+              ~tool_name
+              ~input
+              ?turn_id
+              ?request_context
+              ?task_id
+              ?goal_id
+              ~goal_ids
+              ~continuation_channel
+              ~audit_base_path:base_path
+              ()
+          in
+          let updated = SMap.add id entry map in
+          let following_sequence = sequence + 1 in
+          (match
+             persist_snapshot_with_sequence_unlocked
+               ~base_path
+               ~next_sequence:following_sequence
+               ~pending_map:updated
+               ~delivery_map:(Atomic.get deliveries)
+           with
+           | Error _ as error -> error
+           | Ok () ->
+             Atomic.set pending updated;
+             Atomic.set
+               next_sequences
+               (SMap.add base_path following_sequence (Atomic.get next_sequences));
+             Ok (id, Some entry)))
   in
   match stored with
   | Error _ as error -> error
@@ -1896,7 +1964,7 @@ let install_persistence_internal ~after_load ~base_path =
       | Error storage_error ->
         mark_store_unavailable_unlocked ~base_path storage_error;
         Error storage_error
-      | Ok (loaded_pending, loaded_deliveries) ->
+      | Ok (loaded_pending, loaded_deliveries, loaded_next_sequence) ->
         let current_pending =
           remove_base_entries ~base_path (Atomic.get pending) Fun.id
         in
@@ -1945,6 +2013,12 @@ let install_persistence_internal ~after_load ~base_path =
               clear_store_unavailable_unlocked ~base_path;
               Atomic.set pending pending_map;
               Atomic.set deliveries delivery_map;
+              Atomic.set
+                next_sequences
+                (SMap.add
+                   base_path
+                   loaded_next_sequence
+                   (Atomic.get next_sequences));
               Ok
                 ( SMap.cardinal loaded_pending
                 , SMap.bindings loaded_deliveries |> List.map snd ))))
@@ -1994,7 +2068,8 @@ module For_testing = struct
     with_pending_store_lock (fun () ->
       Atomic.set pending SMap.empty;
       Atomic.set deliveries SMap.empty;
-      Atomic.set unavailable_stores SMap.empty)
+      Atomic.set unavailable_stores SMap.empty;
+      Atomic.set next_sequences SMap.empty)
   ;;
 
   let install_persistence_with_after_load_hook ~base_path ~after_load =
@@ -2088,34 +2163,26 @@ let resolve ~base_path ~id ~(decision : decision)
 (* ── Query ────────────────────────────────────────────────── *)
 
 (** List all pending approvals as JSON. *)
+let pending_entries_in_sequence_order () =
+  SMap.fold (fun _id entry acc -> entry :: acc) (Atomic.get pending) []
+  |> List.sort (fun left right -> Int.compare left.sequence right.sequence)
+;;
+
 let list_pending_json () : Yojson.Safe.t =
-  let entries =
-    SMap.fold
-      (fun _id entry acc -> `Assoc (pending_entry_json_fields entry) :: acc)
-      (Atomic.get pending)
-      []
-  in
-  `List (sort_entries_by_requested_at entries)
+  pending_entries_in_sequence_order ()
+  |> List.map (fun entry -> `Assoc (pending_entry_json_fields entry))
+  |> fun entries -> `List entries
 ;;
 
 let list_pending_dashboard_json () : Yojson.Safe.t =
-  let entries =
-    SMap.fold
-      (fun _id entry acc ->
-         `Assoc
-           (pending_entry_json_fields
-              ~include_input:true
-              entry)
-         :: acc)
-      (Atomic.get pending)
-      []
-  in
-  `List (sort_entries_by_requested_at entries)
+  pending_entries_in_sequence_order ()
+  |> List.map (fun entry ->
+    `Assoc (pending_entry_json_fields ~include_input:true entry))
+  |> fun entries -> `List entries
 ;;
 
 let list_pending_entries () : pending_approval list =
-  SMap.fold (fun _id entry acc -> entry :: acc) (Atomic.get pending) []
-  |> List.sort (fun left right -> Float.compare left.requested_at right.requested_at)
+  pending_entries_in_sequence_order ()
 ;;
 
 let pending_entry_detail_json (entry : pending_approval) : Yojson.Safe.t =

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -171,7 +171,8 @@ end
 
 (** Durably enqueue an exact request without suspending the caller. Returns an
     existing id only when the same Keeper, operation identity, canonical input,
-    turn/task/goal identity, and continuation channel are already pending. *)
+    turn/task/goal identity, and continuation channel are already pending. A
+    deduplicated request does not consume a durable queue sequence. *)
 val submit_pending :
   keeper_name:string ->
   tool_name:string ->

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -239,29 +239,11 @@ let hitl_summary_temperature_rp =
 let hitl_summary_temperature () : float =
   Runtime_params.get hitl_summary_temperature_rp
 
-(** Maximum number of request-local Auto Judge calls that may be in flight.
-    A bounded queue prevents an operator recovery of a large durable backlog
-    from turning into an unbounded provider burst. *)
-let hitl_summary_max_concurrency_rp =
-  _rp_int ~key:"keeper.hitl_summary.max_concurrency"
-    ~default:(fun () ->
-      int_of_env_default
-        "MASC_KEEPER_HITL_SUMMARY_MAX_CONCURRENCY"
-        ~default:4
-        ~min_v:1
-        ~max_v:32)
-    ~min_v:1
-    ~max_v:32
-    ~description:"Maximum concurrent HITL Auto Judge calls" ()
-let hitl_summary_max_concurrency () : int =
-  Runtime_params.get hitl_summary_max_concurrency_rp
-
 (** Force module initialization to guarantee all runtime params are registered
     before [Runtime_params.restore]. Call from server bootstrap. *)
 let ensure_runtime_params_init () =
   let (_ : float) = Runtime_params.get keeper_unified_temperature_rp in
   let (_ : float) = Runtime_params.get hitl_summary_temperature_rp in
-  let (_ : int) = Runtime_params.get hitl_summary_max_concurrency_rp in
   ()
 
 let keeper_enable_thinking_rp =

--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -153,7 +153,6 @@ val keeper_unified_max_tokens : unit -> int
 (** {2 HITL Context-Summary Worker Policy} *)
 
 val hitl_summary_temperature : unit -> float
-val hitl_summary_max_concurrency : unit -> int
 
 val keeper_status_fast_default : unit -> bool
 

--- a/lib/keeper/keeper_gate.ml
+++ b/lib/keeper/keeper_gate.ml
@@ -274,31 +274,94 @@ type auto_judge_start_outcome =
   | Started
   | Skipped
 
-module Auto_judge_ids = Set_util.StringSet
+type auto_judge_retry_outcome =
+  | Retry_started
+  | Retry_queued
+  | Retry_skipped
 
-let active_auto_judges : Auto_judge_ids.t Atomic.t =
-  Atomic.make Auto_judge_ids.empty
+module Auto_judge_owner = struct
+  type t = string * string
+
+  let compare (left_base, left_keeper) (right_base, right_keeper) =
+    let by_base = String.compare left_base right_base in
+    if by_base <> 0 then by_base else String.compare left_keeper right_keeper
+  ;;
+end
+
+module Auto_judge_owners = Map.Make (Auto_judge_owner)
+module Auto_judge_owner_set = Set.Make (Auto_judge_owner)
+
+let auto_judge_owner (entry : Keeper_approval_queue.pending_approval) =
+  entry.audit_base_path, entry.keeper_name
 ;;
 
-let rec claim_auto_judge id =
+(** Immutable process projection of the one active approval for each exact
+    workspace/Keeper owner. The durable approval queue remains the work SSOT. *)
+let active_auto_judges : string Auto_judge_owners.t Atomic.t =
+  Atomic.make Auto_judge_owners.empty
+;;
+
+let rec claim_auto_judge (entry : Keeper_approval_queue.pending_approval) =
   let active = Atomic.get active_auto_judges in
-  if Auto_judge_ids.mem id active
-     || Auto_judge_ids.cardinal active
-        >= Hitl_summary_worker.max_concurrency ()
-  then false
-  else
-    let claimed = Auto_judge_ids.add id active in
+  let owner = auto_judge_owner entry in
+  match Auto_judge_owners.find_opt owner active with
+  | Some _ -> false
+  | None ->
+    let claimed = Auto_judge_owners.add owner entry.id active in
     if Atomic.compare_and_set active_auto_judges active claimed
     then true
-    else claim_auto_judge id
+    else claim_auto_judge entry
 ;;
 
-let rec release_auto_judge id =
+let rec release_auto_judge (entry : Keeper_approval_queue.pending_approval) =
   let active = Atomic.get active_auto_judges in
-  let released = Auto_judge_ids.remove id active in
-  if not (Atomic.compare_and_set active_auto_judges active released)
-  then release_auto_judge id
+  let owner = auto_judge_owner entry in
+  match Auto_judge_owners.find_opt owner active with
+  | Some active_id when String.equal active_id entry.id ->
+    let released = Auto_judge_owners.remove owner active in
+    if not (Atomic.compare_and_set active_auto_judges active released)
+    then release_auto_judge entry
+  | Some _ | None -> ()
 ;;
+
+let active_auto_judge_for_owner ~base_path ~keeper_name =
+  Auto_judge_owners.find_opt
+    (base_path, keeper_name)
+    (Atomic.get active_auto_judges)
+;;
+
+let auto_judge_entry_ready (entry : Keeper_approval_queue.pending_approval) =
+  match entry.summary_status with
+  | Keeper_approval_queue.Summary_not_requested
+  | Keeper_approval_queue.Summary_pending -> true
+  | Keeper_approval_queue.Summary_available _
+  | Keeper_approval_queue.Summary_failed _ -> false
+;;
+
+let compare_auto_judge_entries
+      (left : Keeper_approval_queue.pending_approval)
+      (right : Keeper_approval_queue.pending_approval)
+  =
+  let by_time = Float.compare left.requested_at right.requested_at in
+  if by_time <> 0 then by_time else String.compare left.id right.id
+;;
+
+let ready_auto_judges_for_owner ?exclude_id ~base_path ~keeper_name entries =
+  entries
+  |> List.filter (fun (entry : Keeper_approval_queue.pending_approval) ->
+    String.equal entry.audit_base_path base_path
+    && String.equal entry.keeper_name keeper_name
+    && (match exclude_id with
+        | Some id -> not (String.equal id entry.id)
+        | None -> true)
+    && auto_judge_entry_ready entry)
+  |> List.sort compare_auto_judge_entries
+;;
+
+type auto_judge_drain_outcome =
+  { started_id : string option
+  ; failures : (string * string) list
+  }
 
 let rec spawn_claimed_auto_judge_entry
       (entry : Keeper_approval_queue.pending_approval)
@@ -348,7 +411,7 @@ let rec spawn_claimed_auto_judge_entry
   in
   let fail_before_worker ~reason ~retryable =
     Fun.protect
-      ~finally:(fun () -> release_auto_judge approval_id)
+      ~finally:(fun () -> release_auto_judge entry)
       (fun () ->
          on_failure ~reason ~retryable;
          Error reason)
@@ -358,7 +421,7 @@ let rec spawn_claimed_auto_judge_entry
       Ok (Hitl_summary_worker.provider_config_for_summary ())
     with
     | Eio.Cancel.Cancelled _ as exn ->
-      release_auto_judge approval_id;
+      release_auto_judge entry;
       raise exn
     | exn ->
       Error
@@ -375,14 +438,18 @@ let rec spawn_claimed_auto_judge_entry
          ~on_summary
          ~on_failure
          ~on_finish:(fun () ->
-           release_auto_judge approval_id;
-           (* fire-and-forget: the queue owns subsequent worker completion. *)
-           ignore (drain_auto_judges ~base_path:entry.audit_base_path))
+           release_auto_judge entry;
+           ignore
+             (drain_auto_judge_owner
+                ~exclude_id:entry.id
+                ~base_path:entry.audit_base_path
+                ~keeper_name:entry.keeper_name
+                ()))
          ();
        Ok Started
      with
      | Eio.Cancel.Cancelled _ as exn ->
-       release_auto_judge approval_id;
+       release_auto_judge entry;
        raise exn
      | exn ->
        let reason =
@@ -401,104 +468,158 @@ let rec spawn_claimed_auto_judge_entry
   | Some _, Error reason -> fail_before_worker ~reason ~retryable:true
 
 and spawn_auto_judge_entry (entry : Keeper_approval_queue.pending_approval) =
-  if claim_auto_judge entry.id
+  if claim_auto_judge entry
   then spawn_claimed_auto_judge_entry entry
   else Ok Skipped
 
 and retry_auto_judge_entry (entry : Keeper_approval_queue.pending_approval) =
-  if not (claim_auto_judge entry.id)
-  then Ok Skipped
-  else
-    match Keeper_approval_queue.restart_failed_summary ~id:entry.id with
-    | Error error ->
-      release_auto_judge entry.id;
-      Error (Keeper_approval_queue.storage_error_to_string error)
-    | Ok false ->
-      release_auto_judge entry.id;
-      Ok Skipped
-    | Ok true -> spawn_claimed_auto_judge_entry entry
+  match Keeper_approval_queue.restart_failed_summary ~id:entry.id with
+  | Error error -> Error (Keeper_approval_queue.storage_error_to_string error)
+  | Ok false -> Ok Retry_skipped
+  | Ok true ->
+    (match
+       drain_auto_judge_owner
+         ~base_path:entry.audit_base_path
+         ~keeper_name:entry.keeper_name
+         ()
+     with
+     | Error reason -> Error reason
+     | Ok outcome ->
+       (match List.assoc_opt entry.id outcome.failures, outcome.started_id with
+        | Some reason, _ -> Error reason
+        | None, Some id when String.equal id entry.id -> Ok Retry_started
+        | None, (Some _ | None) -> Ok Retry_queued))
 
 and start_auto_judge approval_id =
   match Keeper_approval_queue.get_pending_entry ~id:approval_id with
   | None -> Ok Skipped
   | Some entry ->
-    if not (claim_auto_judge approval_id)
+    if not (claim_auto_judge entry)
     then Ok Skipped
     else
       (match Keeper_approval_queue.mark_summary_pending ~id:approval_id with
        | Error error ->
-         release_auto_judge approval_id;
+         release_auto_judge entry;
          Error (Keeper_approval_queue.storage_error_to_string error)
        | Ok false ->
-         release_auto_judge approval_id;
+         release_auto_judge entry;
          Ok Skipped
        | Ok true -> spawn_claimed_auto_judge_entry entry)
 
+and start_auto_judge_entry (entry : Keeper_approval_queue.pending_approval) =
+  match Keeper_approval_queue.get_pending_entry ~id:entry.id with
+  | None -> Ok Skipped
+  | Some current ->
+    (match current.summary_status with
+     | Keeper_approval_queue.Summary_not_requested -> start_auto_judge current.id
+     | Keeper_approval_queue.Summary_pending -> spawn_auto_judge_entry current
+     | Keeper_approval_queue.Summary_available _
+     | Keeper_approval_queue.Summary_failed _ -> Ok Skipped)
+
+and drain_auto_judge_owner_queue ?exclude_id ~base_path ~keeper_name () =
+  let rec loop failures = function
+    | [] -> { started_id = None; failures = List.rev failures }
+    | entry :: rest ->
+      (match start_auto_judge_entry entry with
+       | Ok Started ->
+         { started_id = Some entry.id; failures = List.rev failures }
+       | Ok Skipped ->
+         (match active_auto_judge_for_owner ~base_path ~keeper_name with
+          | Some _ -> { started_id = None; failures = List.rev failures }
+          | None -> loop failures rest)
+       | Error reason ->
+         Log.Keeper.error
+           ~keeper_name
+           "Auto Judge owner drain failed approval=%s: %s"
+           entry.id
+           reason;
+         loop ((entry.id, reason) :: failures) rest)
+  in
+  Keeper_approval_queue.list_pending_entries ()
+  |> ready_auto_judges_for_owner ?exclude_id ~base_path ~keeper_name
+  |> loop []
+
+and drain_auto_judge_owner ?exclude_id ~base_path ~keeper_name () =
+  match Keeper_gate_mode.read ~base_path with
+  | Ok Keeper_gate_mode.Auto_judge ->
+    Ok (drain_auto_judge_owner_queue ?exclude_id ~base_path ~keeper_name ())
+  | Ok (Keeper_gate_mode.Manual | Keeper_gate_mode.Always_allow) ->
+    Ok { started_id = None; failures = [] }
+  | Error detail ->
+    Log.Keeper.error
+      ~keeper_name
+      "Auto Judge owner drain unavailable workspace=%s: %s"
+      base_path
+      detail;
+    Error detail
+
 and drain_auto_judges ~base_path =
   match Keeper_gate_mode.read ~base_path with
-  | Error _
+  | Error detail ->
+    Log.Keeper.error
+      "Auto Judge workspace drain unavailable workspace=%s: %s"
+      base_path
+      detail;
+    []
   | Ok (Keeper_gate_mode.Manual | Keeper_gate_mode.Always_allow) -> []
   | Ok Keeper_gate_mode.Auto_judge ->
-    let capacity =
-      Hitl_summary_worker.max_concurrency ()
-      - Auto_judge_ids.cardinal (Atomic.get active_auto_judges)
-    in
-    if capacity <= 0
-    then []
-    else
+    let owners =
       Keeper_approval_queue.list_pending_entries ()
-      |> List.filter (fun (entry : Keeper_approval_queue.pending_approval) ->
-        String.equal entry.audit_base_path base_path
-        &&
-        match entry.summary_status with
-        | Keeper_approval_queue.Summary_not_requested
-        | Keeper_approval_queue.Summary_pending -> true
-        | Keeper_approval_queue.Summary_available _
-        | Keeper_approval_queue.Summary_failed _ -> false)
-      |> List.sort
-           (fun (left : Keeper_approval_queue.pending_approval)
-                (right : Keeper_approval_queue.pending_approval) ->
-              Float.compare left.requested_at right.requested_at)
-      |> List.filteri (fun index _ -> index < capacity)
-      |> List.filter_map (fun (entry : Keeper_approval_queue.pending_approval) ->
-        let started =
-          match entry.summary_status with
-          | Keeper_approval_queue.Summary_not_requested -> start_auto_judge entry.id
-          | Keeper_approval_queue.Summary_pending -> spawn_auto_judge_entry entry
-          | Keeper_approval_queue.Summary_available _
-          | Keeper_approval_queue.Summary_failed _ -> Ok Skipped
-        in
-        match started with
-        | Ok Started -> Some entry.id
-        | Ok Skipped -> None
-        | Error reason ->
-          Log.Keeper.error
-            ~keeper_name:entry.keeper_name
-            "Auto Judge bounded drain failed approval=%s: %s"
-            entry.id
-            reason;
-          None)
+      |> List.fold_left
+           (fun owners (entry : Keeper_approval_queue.pending_approval) ->
+              if String.equal entry.audit_base_path base_path
+                 && auto_judge_entry_ready entry
+              then Auto_judge_owner_set.add (auto_judge_owner entry) owners
+              else owners)
+           Auto_judge_owner_set.empty
+    in
+    Auto_judge_owner_set.fold
+      (fun (_, keeper_name) started_ids ->
+         let outcome =
+           drain_auto_judge_owner_queue ~base_path ~keeper_name ()
+         in
+         match outcome.started_id with
+         | Some id -> id :: started_ids
+         | None -> started_ids)
+      owners
+      []
+    |> List.rev
 ;;
 
 type recovered_work =
-  | Restart_worker of Keeper_approval_queue.pending_approval
+  | Activate_worker of Keeper_approval_queue.pending_approval
   | Finalize_judgment of
       Keeper_approval_queue.pending_approval
       * Keeper_approval_queue.hitl_context_summary
 
 let recovered_work_for_base_path ~base_path =
-  Keeper_approval_queue.list_pending_entries ()
-  |> List.filter_map (fun (entry : Keeper_approval_queue.pending_approval) ->
+  let enabled =
+    match Keeper_gate_mode.read ~base_path with
+    | Ok Keeper_gate_mode.Auto_judge -> true
+    | Ok (Keeper_gate_mode.Manual | Keeper_gate_mode.Always_allow) -> false
+    | Error detail ->
+      Log.Keeper.error
+        "Auto Judge recovery unavailable workspace=%s: %s"
+        base_path
+        detail;
+      false
+  in
+  if not enabled
+  then []
+  else
+    Keeper_approval_queue.list_pending_entries ()
+    |> List.sort compare_auto_judge_entries
+    |> List.filter_map (fun (entry : Keeper_approval_queue.pending_approval) ->
     if not (String.equal entry.audit_base_path base_path)
     then None
     else
       match entry.summary_status with
-      | Keeper_approval_queue.Summary_pending -> Some (Restart_worker entry)
+      | Keeper_approval_queue.Summary_not_requested
+      | Keeper_approval_queue.Summary_pending -> Some (Activate_worker entry)
       | Keeper_approval_queue.Summary_available
           ({ judgment = (Keeper_approval_queue.Approve | Keeper_approval_queue.Deny); _ }
            as summary) ->
         Some (Finalize_judgment (entry, summary))
-      | Keeper_approval_queue.Summary_not_requested
       | Keeper_approval_queue.Summary_available
           { judgment = Keeper_approval_queue.Require_human; _ }
       | Keeper_approval_queue.Summary_failed _ ->
@@ -508,7 +629,7 @@ let recovered_work_for_base_path ~base_path =
 let observe_recovered_work kind (entry : Keeper_approval_queue.pending_approval) =
   let event_type, outcome =
     match kind with
-    | `Restart_worker ->
+    | `Activate_worker ->
       "auto_judge_restart_worker_recovered", "restart_worker_recovered"
     | `Finalize_judgment ->
       "auto_judge_restart_judgment_recovered", "restart_judgment_recovered"
@@ -543,10 +664,18 @@ let retry_failed_auto_judge ~base_path ~requested_by approval_id =
     Error ("pending approval not found: " ^ approval_id)
   | Some entry ->
     (match retry_auto_judge_entry entry with
-     | Error _ as error -> error
-     | Ok Skipped ->
+     | Error reason -> Error reason
+     | Ok Retry_skipped ->
        Error ("approval summary is not failed or is already active: " ^ approval_id)
-     | Ok Started ->
+     | Ok Retry_queued ->
+       Log.Keeper.info
+         ~keeper_name:entry.keeper_name
+         "auto judge operator retry queued approval=%s operation=%s actor=%s"
+         entry.id
+         entry.tool_name
+         requested_by;
+       Ok ()
+     | Ok Retry_started ->
        Log.Keeper.info
          ~keeper_name:entry.keeper_name
          "auto judge operator retry started approval=%s operation=%s actor=%s"
@@ -580,9 +709,9 @@ let resume_persisted_auto_judges ~base_path =
       (fun (started_ids, finalized_ids, skipped_ids, failures) work ->
          let entry, result =
            match work with
-           | Restart_worker entry ->
-             observe_recovered_work `Restart_worker entry;
-             entry, `Start (spawn_auto_judge_entry entry)
+           | Activate_worker entry ->
+             observe_recovered_work `Activate_worker entry;
+             entry, `Start (start_auto_judge_entry entry)
            | Finalize_judgment (entry, summary) ->
              observe_recovered_work `Finalize_judgment entry;
              entry, `Finalize (resolve_judgment entry ~approval_id:entry.id summary)
@@ -654,17 +783,25 @@ let defer request reason =
     let reason =
       match reason with
       | Judge_requested ->
-        let started =
-          try start_auto_judge approval_id with
+        let drained =
+          try
+            drain_auto_judge_owner
+              ~base_path:request.base_path
+              ~keeper_name:request.keeper_name
+              ()
+          with
           | Eio.Cancel.Cancelled _ as exn -> raise exn
           | exn ->
             Error
               ("Auto Judge start failed before worker launch: "
                ^ Printexc.to_string exn)
         in
-        (match started with
-         | Ok (Started | Skipped) -> Judge_requested
-         | Error detail -> Auto_judge_unavailable detail)
+        (match drained with
+         | Error detail -> Auto_judge_unavailable detail
+         | Ok outcome ->
+           (match List.assoc_opt approval_id outcome.failures with
+            | Some detail -> Auto_judge_unavailable detail
+            | None -> Judge_requested))
       | Human_requested | Auto_judge_unavailable _ | Mode_state_invalid _ -> reason
     in
     Deferred { approval_id; reason }

--- a/lib/keeper/keeper_gate.ml
+++ b/lib/keeper/keeper_gate.ml
@@ -289,7 +289,6 @@ module Auto_judge_owner = struct
 end
 
 module Auto_judge_owners = Map.Make (Auto_judge_owner)
-module Auto_judge_owner_set = Set.Make (Auto_judge_owner)
 
 let auto_judge_owner (entry : Keeper_approval_queue.pending_approval) =
   entry.audit_base_path, entry.keeper_name
@@ -342,8 +341,7 @@ let compare_auto_judge_entries
       (left : Keeper_approval_queue.pending_approval)
       (right : Keeper_approval_queue.pending_approval)
   =
-  let by_time = Float.compare left.requested_at right.requested_at in
-  if by_time <> 0 then by_time else String.compare left.id right.id
+  Int.compare left.sequence right.sequence
 ;;
 
 let ready_auto_judges_for_owner ?exclude_id ~base_path ~keeper_name entries =
@@ -356,6 +354,23 @@ let ready_auto_judges_for_owner ?exclude_id ~base_path ~keeper_name entries =
         | None -> true)
     && auto_judge_entry_ready entry)
   |> List.sort compare_auto_judge_entries
+;;
+
+let ready_auto_judge_heads ~base_path entries =
+  entries
+  |> List.fold_left
+       (fun owners (entry : Keeper_approval_queue.pending_approval) ->
+          if not (String.equal entry.audit_base_path base_path)
+             || not (auto_judge_entry_ready entry)
+          then owners
+          else
+            let owner = auto_judge_owner entry in
+            match Auto_judge_owners.find_opt owner owners with
+            | Some current when compare_auto_judge_entries current entry <= 0 -> owners
+            | Some _ | None -> Auto_judge_owners.add owner entry owners)
+       Auto_judge_owners.empty
+  |> Auto_judge_owners.bindings
+  |> List.map snd
 ;;
 
 type auto_judge_drain_outcome =
@@ -563,27 +578,18 @@ and drain_auto_judges ~base_path =
     []
   | Ok (Keeper_gate_mode.Manual | Keeper_gate_mode.Always_allow) -> []
   | Ok Keeper_gate_mode.Auto_judge ->
-    let owners =
-      Keeper_approval_queue.list_pending_entries ()
-      |> List.fold_left
-           (fun owners (entry : Keeper_approval_queue.pending_approval) ->
-              if String.equal entry.audit_base_path base_path
-                 && auto_judge_entry_ready entry
-              then Auto_judge_owner_set.add (auto_judge_owner entry) owners
-              else owners)
-           Auto_judge_owner_set.empty
-    in
-    Auto_judge_owner_set.fold
-      (fun (_, keeper_name) started_ids ->
+    Keeper_approval_queue.list_pending_entries ()
+    |> ready_auto_judge_heads ~base_path
+    |> List.filter_map (fun (entry : Keeper_approval_queue.pending_approval) ->
          let outcome =
-           drain_auto_judge_owner_queue ~base_path ~keeper_name ()
+           drain_auto_judge_owner_queue
+             ~base_path
+             ~keeper_name:entry.keeper_name
+             ()
          in
          match outcome.started_id with
-         | Some id -> id :: started_ids
-         | None -> started_ids)
-      owners
-      []
-    |> List.rev
+         | Some id -> Some id
+         | None -> None)
 ;;
 
 type recovered_work =
@@ -921,3 +927,10 @@ let decide ?cycle_grant ~keeper_always_allow request =
       ();
     Unavailable reason
 ;;
+
+module For_testing = struct
+  let ready_auto_judge_heads = ready_auto_judge_heads
+  let claim_auto_judge = claim_auto_judge
+  let release_auto_judge = release_auto_judge
+  let reset_active_auto_judges () = Atomic.set active_auto_judges Auto_judge_owners.empty
+end

--- a/lib/keeper/keeper_gate.mli
+++ b/lib/keeper/keeper_gate.mli
@@ -85,8 +85,8 @@ val decide :
   decision
 
 (** Recover durable Auto Judge work for exactly one workspace. Each exact
-    [(base_path, keeper_name)] owner activates at most its oldest pending
-    judgment; completion drains only that owner's FIFO. Decisive persisted
+    [(base_path, keeper_name)] owner activates at most its lowest durable
+    approval sequence; completion drains only that owner's FIFO. Decisive persisted
     output is finalized without creating a worker. Failed judgments are never
     retried merely because a process restarted. Every recovery candidate id
     has an explicit started, finalized, skipped, or failed outcome. *)
@@ -116,3 +116,14 @@ val authorization_source_to_string : authorization_source -> string
 val deferred_reason_to_string : deferred_reason -> string
 val unavailable_reason_to_string : unavailable_reason -> string
 val decision_to_yojson : decision -> Yojson.Safe.t
+
+module For_testing : sig
+  val ready_auto_judge_heads :
+    base_path:string ->
+    Keeper_approval_queue.pending_approval list ->
+    Keeper_approval_queue.pending_approval list
+
+  val claim_auto_judge : Keeper_approval_queue.pending_approval -> bool
+  val release_auto_judge : Keeper_approval_queue.pending_approval -> unit
+  val reset_active_auto_judges : unit -> unit
+end

--- a/lib/keeper/keeper_gate.mli
+++ b/lib/keeper/keeper_gate.mli
@@ -84,11 +84,12 @@ val decide :
   request ->
   decision
 
-(** Recover durable Auto Judge work for exactly one workspace: restart an
-    interrupted [Summary_pending] worker and finalize decisive
-    [Summary_available] output. Failed judgments are never retried merely
-    because a process restarted. Every recovery candidate id has an explicit
-    started, finalized, skipped, or failed outcome. *)
+(** Recover durable Auto Judge work for exactly one workspace. Each exact
+    [(base_path, keeper_name)] owner activates at most its oldest pending
+    judgment; completion drains only that owner's FIFO. Decisive persisted
+    output is finalized without creating a worker. Failed judgments are never
+    retried merely because a process restarted. Every recovery candidate id
+    has an explicit started, finalized, skipped, or failed outcome. *)
 val resume_persisted_auto_judges :
   base_path:string -> auto_judge_resume_report
 
@@ -106,8 +107,8 @@ type operator_recovery_report =
   }
 
 (** Reopen failed request-local judgments after an explicit operator selection
-    of Auto Judge, then start a concurrency-bounded drain of every unresolved
-    judgment for the workspace. *)
+    of Auto Judge, then activate one FIFO drain for each Keeper owner with
+    unresolved work in the workspace. *)
 val request_operator_auto_judge_recovery :
   base_path:string -> (operator_recovery_report, string) result
 

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.ml
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.ml
@@ -29,6 +29,7 @@ type pending_approval =
   ; tool_name : string
   ; input_hash : string
   ; input : Yojson.Safe.t
+  ; sequence : int
   ; requested_at : float
   ; turn_id : int option
   ; request_context : Yojson.Safe.t option

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.mli
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.mli
@@ -24,13 +24,15 @@ and summary_status =
   | Summary_available of hitl_context_summary
   | Summary_failed of { reason : string; retryable : bool }
 
-(** A pending request never owns or suspends a Keeper lane. *)
+(** A pending request never owns or suspends a Keeper lane. [sequence] is the
+    durable queue-issued order identity; [requested_at] is observation only. *)
 type pending_approval =
   { id : string
   ; keeper_name : string
   ; tool_name : string
   ; input_hash : string
   ; input : Yojson.Safe.t
+  ; sequence : int
   ; requested_at : float
   ; turn_id : int option
   ; request_context : Yojson.Safe.t option

--- a/test/test_hitl_summary_worker.ml
+++ b/test/test_hitl_summary_worker.ml
@@ -55,6 +55,7 @@ let sample_entry : Q.pending_approval =
         ; "body", `String "hello"
         ; "api_key", `String "sk-test-secret"
         ]
+  ; sequence = 1
   ; requested_at = 1780587600.0
   ; turn_id = None
   ; request_context =

--- a/test/test_hitl_summary_worker.ml
+++ b/test/test_hitl_summary_worker.ml
@@ -190,17 +190,6 @@ let test_request_context_projection_is_idempotent () =
     (Masc.Keeper_gate_request_context.project projected)
 ;;
 
-let test_concurrency_respects_runtime_binding () =
-  check int "runtime binding narrows subsystem cap" 1
-    (Worker.For_testing.effective_max_concurrency
-       ~configured:4
-       ~runtime_limit:(Some 1));
-  check int "subsystem cap remains when runtime omits a limit" 4
-    (Worker.For_testing.effective_max_concurrency
-       ~configured:4
-       ~runtime_limit:None)
-;;
-
 let test_plain_json_requires_exact_object () =
   let expected = judgment_json "require_human" in
   match Worker.For_testing.extract_json_object (Yojson.Safe.to_string expected) with
@@ -372,10 +361,6 @@ let () =
             "context carries exact input"
             `Quick
             test_context_bundle_contains_exact_input_without_derived_classification
-        ; test_case
-            "runtime binding caps judge concurrency"
-            `Quick
-            test_concurrency_respects_runtime_binding
         ; test_case
             "request context projection is idempotent"
             `Quick

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -48,6 +48,10 @@ let require_some message = function
   | None -> Alcotest.fail message
 ;;
 
+let pending_entry_exn id =
+  AQ.get_pending_entry ~id |> require_some ("pending approval not found: " ^ id)
+;;
+
 let drop_resolution ~base_path ~keeper_name resolution =
   let post_id = Keeper_event_queue.hitl_resolution_post_id resolution in
   match Registry_queue.drop_by_post_id ~base_path keeper_name ~post_id with
@@ -258,7 +262,8 @@ let test_install_serializes_snapshot_read_with_same_base_mutation () =
        write_pending_snapshot
          ~base_path
          (`Assoc
-            [ "version", `Int 2
+            [ "version", `Int 3
+            ; "next_sequence", `Int 1
             ; "pending", `List []
             ; "deliveries", `List []
             ]);
@@ -374,6 +379,11 @@ let test_submit_is_nonblocking_and_exactly_deduplicated () =
        in
        Alcotest.(check bool) "changed field is a different request" true
          (not (String.equal first changed));
+       Alcotest.(check int) "first request sequence" 1 (pending_entry_exn first).sequence;
+       Alcotest.(check int)
+         "dedup does not consume sequence"
+         2
+         (pending_entry_exn changed).sequence;
        (match AQ.get_pending_entry ~id:first with
         | None -> Alcotest.fail "pending request missing"
         | Some entry ->
@@ -394,6 +404,73 @@ let test_submit_is_nonblocking_and_exactly_deduplicated () =
         | None -> Alcotest.fail "pending request was not restored");
        reject_and_cleanup ~base_path first;
        reject_and_cleanup ~base_path changed)
+;;
+
+let test_monotonic_sequence_survives_restart () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      AQ.For_testing.reset_runtime_state ();
+      cleanup_dir base_path)
+    (fun () ->
+       AQ.For_testing.reset_runtime_state ();
+       let first = submit ~base_path ~keeper_name:"sequence-owner" ~input:(`Int 1) in
+       let second = submit ~base_path ~keeper_name:"sequence-owner" ~input:(`Int 2) in
+       Alcotest.(check int) "first durable sequence" 1 (pending_entry_exn first).sequence;
+       Alcotest.(check int) "second durable sequence" 2 (pending_entry_exn second).sequence;
+       AQ.For_testing.reset_runtime_state ();
+       ignore (install_exn ~base_path);
+       let third = submit ~base_path ~keeper_name:"sequence-owner" ~input:(`Int 3) in
+       Alcotest.(check int) "restart continues sequence" 3 (pending_entry_exn third).sequence;
+       let open Yojson.Safe.Util in
+       Alcotest.(check int)
+         "next sequence is durable"
+         4
+         (read_pending_snapshot ~base_path |> member "next_sequence" |> to_int))
+;;
+
+let test_same_owner_head_uses_sequence_not_wall_clock () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      AQ.For_testing.reset_runtime_state ();
+      cleanup_dir base_path)
+    (fun () ->
+       AQ.For_testing.reset_runtime_state ();
+       let first = submit ~base_path ~keeper_name:"fifo-owner" ~input:(`Int 1) in
+       let second = submit ~base_path ~keeper_name:"fifo-owner" ~input:(`Int 2) in
+       let first = { (pending_entry_exn first) with requested_at = 500.0 } in
+       let second = { (pending_entry_exn second) with requested_at = 1.0 } in
+       match Gate.For_testing.ready_auto_judge_heads ~base_path [ second; first ] with
+       | [ head ] -> Alcotest.(check string) "oldest sequence wins" first.id head.id
+       | heads ->
+         Alcotest.failf "one same-owner head expected, got %d" (List.length heads))
+;;
+
+let test_different_owners_claim_in_parallel () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Gate.For_testing.reset_active_auto_judges ();
+      AQ.For_testing.reset_runtime_state ();
+      cleanup_dir base_path)
+    (fun () ->
+       AQ.For_testing.reset_runtime_state ();
+       Gate.For_testing.reset_active_auto_judges ();
+       let owner_a = pending_entry_exn (submit ~base_path ~keeper_name:"owner-a" ~input:(`Int 1)) in
+       let owner_a_next =
+         pending_entry_exn (submit ~base_path ~keeper_name:"owner-a" ~input:(`Int 2))
+       in
+       let owner_b = pending_entry_exn (submit ~base_path ~keeper_name:"owner-b" ~input:(`Int 1)) in
+       Alcotest.(check bool) "first owner activates" true
+         (Gate.For_testing.claim_auto_judge owner_a);
+       Alcotest.(check bool) "same owner remains queued" false
+         (Gate.For_testing.claim_auto_judge owner_a_next);
+       Alcotest.(check bool) "different owner activates in parallel" true
+         (Gate.For_testing.claim_auto_judge owner_b);
+       Gate.For_testing.release_auto_judge owner_a;
+       Alcotest.(check bool) "same owner next activates after release" true
+         (Gate.For_testing.claim_auto_judge owner_a_next))
 ;;
 
 let test_resolution_is_durable_and_origin_scoped () =
@@ -1048,7 +1125,8 @@ let test_malformed_snapshot_fails_install_and_is_observed () =
        write_pending_snapshot
          ~base_path
          (`Assoc
-            [ "version", `Int 2
+            [ "version", `Int 3
+            ; "next_sequence", `Int 1
             ; "pending", `List [ `String "malformed-entry" ]
             ; "deliveries", `List []
             ]);
@@ -1078,7 +1156,8 @@ let test_malformed_snapshot_fails_install_and_is_observed () =
          (Yojson.Safe.equal
             persisted
             (`Assoc
-               [ "version", `Int 2
+               [ "version", `Int 3
+               ; "next_sequence", `Int 1
                ; "pending", `List [ `String "malformed-entry" ]
                ; "deliveries", `List []
                ]));
@@ -1117,7 +1196,8 @@ let test_persisted_delivery_replays_before_origin_wake () =
        write_pending_snapshot
          ~base_path
          (`Assoc
-            [ "version", `Int 2
+            [ "version", `Int 3
+            ; "next_sequence", `Int 2
             ; "pending", `List []
             ; ( "deliveries"
               , `List
@@ -1207,7 +1287,8 @@ let test_one_delivery_replay_failure_does_not_stop_others () =
        write_pending_snapshot
          ~base_path
          (`Assoc
-            [ "version", `Int 2
+            [ "version", `Int 3
+            ; "next_sequence", `Int 3
             ; "pending", `List []
             ; ( "deliveries"
               , `List
@@ -1445,6 +1526,18 @@ let () =
             "submit is nonblocking and exact"
             `Quick
             test_submit_is_nonblocking_and_exactly_deduplicated
+        ; Alcotest.test_case
+            "durable sequence survives restart"
+            `Quick
+            test_monotonic_sequence_survives_restart
+        ; Alcotest.test_case
+            "same owner drains by durable sequence"
+            `Quick
+            test_same_owner_head_uses_sequence_not_wall_clock
+        ; Alcotest.test_case
+            "different owners activate in parallel"
+            `Quick
+            test_different_owners_claim_in_parallel
         ; Alcotest.test_case
             "dedup keeps distinct origins"
             `Quick


### PR DESCRIPTION
## Summary

- persist an immutable monotonic sequence for every approval queue entry
- order each Keeper owner queue by durable sequence instead of observational timestamps
- preserve per-owner activation while preventing stale completion from releasing a newer owner

`requested_at` remains observability only. Deduplication does not consume sequence values. No global concurrency cap, risk hierarchy, hard-forbidden policy, timeout, or grant heuristic is introduced.

## Stack

- base: #25049 — per-Keeper owner drain (397 lines)
- this leaf: durable monotonic FIFO (379 lines)

The previous #25057 was merged into its feature parent rather than `main`; this recut restores the required sub-400-line review boundary.

## Validation

- focused wrapper build: green
- `test_keeper_approval_queue`: 24/24
- `test_hitl_summary_worker`: 15/15
- `ocamlformat --check` on changed OCaml files
- `git diff --check`

Full suite remains CI authority.