### PR TITLE
refactor(compaction)!: purge dead cooldown authority

### DIFF
--- a/dashboard/src/api/dashboard-keeper-config.ts
+++ b/dashboard/src/api/dashboard-keeper-config.ts
@@ -208,7 +208,6 @@ function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfi
       ratio_gate: asLooseNumber(compaction.ratio_gate) ?? 0.85,
       message_gate: asInt(compaction.message_gate) ?? 0,
       token_gate: asInt(compaction.token_gate) ?? 0,
-      cooldown_sec: asInt(compaction.cooldown_sec) ?? 0,
     },
     proactive: {
       enabled: asLooseBoolean(proactive.enabled),
@@ -308,7 +307,6 @@ export type KeeperConfigUpdatePayload = {
   compaction_ratio_gate?: number
   compaction_message_gate?: number
   compaction_token_gate?: number
-  compaction_cooldown_sec?: number
 }
 
 export async function patchKeeperConfig(

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -1902,7 +1902,6 @@ describe('fetchKeeperConfig', () => {
         ratio_gate: '0.85',
         message_gate: '16',
         token_gate: '24000',
-        cooldown_sec: '120',
       },
       proactive: {
         enabled: 'true',

--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -67,7 +67,6 @@ function makeKeeperConfig(overrides: Partial<KeeperConfig> = {}): KeeperConfig {
       ratio_gate: 0.85,
       message_gate: 16,
       token_gate: 24000,
-      cooldown_sec: 120,
     },
     proactive: {
       enabled: true,
@@ -459,7 +458,6 @@ function makeKeeperConfigForSandbox(overrides: Partial<KeeperConfig> = {}): Keep
       ratio_gate: 0.8,
       message_gate: 0,
       token_gate: 0,
-      cooldown_sec: 0,
     } as KeeperConfig['compaction'],
     proactive: {
       enabled: false,
@@ -658,7 +656,6 @@ describe('buildRuntimePayload — sandbox diffing', () => {
         ratio_gate: 0.8,
         message_gate: 0,
         token_gate: 24000,
-        cooldown_sec: 0,
       },
     })
     const payload = buildRuntimePayload(draftFrom(c, {
@@ -676,7 +673,6 @@ describe('buildRuntimePayload — sandbox diffing', () => {
         ratio_gate: 0.8,
         message_gate: 0,
         token_gate: 24000,
-        cooldown_sec: 0,
       },
     })
     const payload = buildRuntimePayload(draftFrom(c, {

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -284,7 +284,6 @@ export type RuntimeDraft = {
   compaction_ratio_gate: number
   compaction_message_gate: number
   compaction_token_gate: number
-  compaction_cooldown_sec: number
 }
 
 const runtimeDraft = signal<RuntimeDraft | null>(null)
@@ -360,7 +359,6 @@ export function initRuntimeDraftFromConfig(c: KeeperConfig): RuntimeDraft {
     compaction_ratio_gate: c.compaction.ratio_gate,
     compaction_message_gate: c.compaction.message_gate,
     compaction_token_gate: c.compaction.token_gate,
-    compaction_cooldown_sec: c.compaction.cooldown_sec,
   }
 }
 
@@ -615,7 +613,6 @@ export function keeperConfigControlInventory(
             'compaction.ratio_gate',
             'compaction.message_gate',
             'compaction.token_gate',
-            'compaction.cooldown_sec',
             'proactive.enabled',
           ],
         ),
@@ -809,7 +806,6 @@ export function buildRuntimePayload(draft: RuntimeDraft, orig: KeeperConfig): Ke
   if (draft.compaction_ratio_gate !== orig.compaction.ratio_gate) payload.compaction_ratio_gate = draft.compaction_ratio_gate
   if (draft.compaction_message_gate !== orig.compaction.message_gate) payload.compaction_message_gate = draft.compaction_message_gate
   if (draft.compaction_token_gate !== orig.compaction.token_gate) payload.compaction_token_gate = draft.compaction_token_gate
-  if (draft.compaction_cooldown_sec !== orig.compaction.cooldown_sec) payload.compaction_cooldown_sec = draft.compaction_cooldown_sec
   return payload
 }
 
@@ -851,7 +847,6 @@ function computeRuntimeDirtyFlags(rd: RuntimeDraft, c: KeeperConfig): Record<str
     compaction_ratio_gate: 'compaction_ratio_gate' in payload,
     compaction_message_gate: 'compaction_message_gate' in payload,
     compaction_token_gate: 'compaction_token_gate' in payload,
-    compaction_cooldown_sec: 'compaction_cooldown_sec' in payload,
   }
 }
 
@@ -1965,16 +1960,11 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
         onChange=${(v: number) => updateRuntimeDraft('compaction_token_gate', v)}
         min=${0} max=${maxContextOverrideTokens} step=${1000} suffix="tok"
         dirty=${dirtyFlags.compaction_token_gate} />
-      <${InlineNumberRow} label="쿨다운 (초)" value=${rd.compaction_cooldown_sec}
-        onChange=${(v: number) => updateRuntimeDraft('compaction_cooldown_sec', v)}
-        min=${0} max=${3600} step=${30} suffix="s"
-        dirty=${dirtyFlags.compaction_cooldown_sec} />
     ` : html`
       <${ConfigRow} label="프로필" value=${c.compaction.profile || MISSING_DATA_DASH} />
       <${ConfigRow} label="비율 게이트" value=${formatPct(c.compaction.ratio_gate)} />
       <${ConfigRow} label="메시지 게이트" value=${String(c.compaction.message_gate)} />
       <${ConfigRow} label="토큰 게이트" value=${formatTokens(c.compaction.token_gate)} />
-      <${ConfigRow} label="쿨다운" value=${c.compaction.cooldown_sec + 's'} />
     `}
 
     <${SectionHeader} title="프로액티브" />

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -1398,7 +1398,6 @@ interface KeeperConfigCompaction {
   ratio_gate: number
   message_gate: number
   token_gate: number
-  cooldown_sec: number
 }
 
 interface KeeperConfigProactive {

--- a/docs/spec/05-keeper-agent.md
+++ b/docs/spec/05-keeper-agent.md
@@ -514,14 +514,6 @@ Keeper turn에서 어떤 "skill" 경로를 사용할지 결정:
 
 `max_checkpoints_retained = 3`. `save` 후 `prune`이 호출되어 초과분을 삭제한다.
 
-### INV-KEEPER-004: compaction cooldown 강제
-
-`compact_if_needed`는 실제 완료된 마지막 compaction 시각을 기준으로
-`compaction_cooldown_sec`를 적용한다. Assistant text나 proactive turn은 이
-clock을 갱신하지 않는다.
-
-
-
 ### INV-KEEPER-006: proactive judgment boundary
 
 proactive 행동의 의미와 품질은 configured LLM이 판단한다. 문장 종결어미, 단어 목록, 유사도, 재시도 횟수 같은 로컬 휴리스틱은 최종 판정이나 의미 있는 fallback을 만들 수 없다. 빈 출력과 모델 실패는 관측 가능한 오류로 남으며 Keeper의 다른 활동을 중단시키지 않는다.

--- a/lib/dashboard/dashboard_http_keeper_snapshot.ml
+++ b/lib/dashboard/dashboard_http_keeper_snapshot.ml
@@ -216,7 +216,6 @@ let keeper_config_json (config : Workspace.config) (name : string)
           ("ratio_gate", `Float m.compaction.ratio_gate);
           ("message_gate", `Int m.compaction.message_gate);
           ("token_gate", `Int m.compaction.token_gate);
-          ("cooldown_sec", `Int m.compaction.cooldown_sec);
         ]
       in
       let proactive =

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -115,19 +115,6 @@ let keeper_memory_os_recall_max_bytes_rp =
     ~description:"Rendered recall block byte threshold to log/count as over-budget (0 = disabled)" ()
 let keeper_memory_os_recall_max_bytes () : int =
   Runtime_params.get keeper_memory_os_recall_max_bytes_rp
-
-(** Cooldown between compaction attempts.  Previous default (90s) exceeded
-    the proactive heartbeat interval (30s), permanently blocking compaction
-    for proactive keepers.  15s allows compaction to fire every other cycle. *)
-let keeper_compaction_cooldown_sec_rp =
-  _rp_int ~key:"keeper.compaction.cooldown_sec"
-    ~default:(fun () -> int_of_env_default "MASC_KEEPER_COMPACTION_COOLDOWN_SEC"
-                          ~default:15 ~min_v:0 ~max_v:two_days_seconds_int)
-    ~min_v:0 ~max_v:two_days_seconds_int
-    ~description:"Compaction cooldown (seconds)" ()
-let keeper_compaction_cooldown_sec () : int =
-  Runtime_params.get keeper_compaction_cooldown_sec_rp
-
 let keeper_bootstrap_proactive_warmup_sec_rp =
   _rp_int ~key:"keeper.proactive.warmup_sec"
     ~default:(fun () -> int_of_env_default "MASC_KEEPER_BOOTSTRAP_PROACTIVE_WARMUP_SEC"
@@ -168,9 +155,6 @@ let normalize_compaction_message_gate (v : int) : int =
 
 let normalize_compaction_token_gate (v : int) : int =
   clamp_int v ~min_v:0 ~max_v:5000000
-
-let normalize_compaction_cooldown_sec (v : int) : int =
-  clamp_int v ~min_v:0 ~max_v:two_days_seconds_int
 
 let default_compaction_profile = "custom"
 

--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -127,7 +127,6 @@ val resolve_compaction_policy :
 val normalize_compaction_ratio_gate : float -> float
 val normalize_compaction_message_gate : int -> int
 val normalize_compaction_token_gate : int -> int
-val normalize_compaction_cooldown_sec : int -> int
 
 (** {1 Runtime Parameters}
 
@@ -138,7 +137,6 @@ val normalize_compaction_cooldown_sec : int -> int
 val keeper_compact_ratio : unit -> float
 val keeper_compact_max_messages : unit -> int
 val keeper_compact_max_tokens : unit -> int
-val keeper_compaction_cooldown_sec : unit -> int
 val keeper_compaction_policy_from_env : unit -> float * int * int
 
 (** Memory OS recall selection budget (masc#25052 P1). See the .ml for the

--- a/lib/keeper/keeper_config_text.ml
+++ b/lib/keeper/keeper_config_text.ml
@@ -84,6 +84,7 @@ let removed_keeper_input_key_names =
     "tool_denylist";
     "shards";
     "policy_voice_enabled";
+    "compaction_cooldown_sec";
   ]
 
 let removed_keeper_sandbox_input_key_names =

--- a/lib/keeper/keeper_meta_contract.ml
+++ b/lib/keeper/keeper_meta_contract.ml
@@ -15,7 +15,6 @@ type compaction_policy =
   ; ratio_gate : float
   ; message_gate : int
   ; token_gate : int
-  ; cooldown_sec : int
   }
 
 type proactive_policy =

--- a/lib/keeper/keeper_meta_contract.mli
+++ b/lib/keeper/keeper_meta_contract.mli
@@ -21,7 +21,6 @@ type compaction_policy = {
   ratio_gate : float;
   message_gate : int;
   token_gate : int;
-  cooldown_sec : int;
 }
 
 type proactive_policy = {

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -145,13 +145,6 @@ let parse_keeper_policy (json : Yojson.Safe.t) ~(keeper_name : string)
       Safe_ops.json_int ~default:env_token_gate "compaction_token_gate" json
       |> normalize_compaction_token_gate
     in
-    let compaction_cooldown_sec =
-      Safe_ops.json_int
-        ~default:(keeper_compaction_cooldown_sec ())
-        "compaction_cooldown_sec"
-        json
-      |> normalize_compaction_cooldown_sec
-    in
     let pp_always_allow = None in
     (* TOML-only (see note above); overlaid by [ensure_keeper_meta]. *)
     Ok
@@ -166,7 +159,6 @@ let parse_keeper_policy (json : Yojson.Safe.t) ~(keeper_name : string)
           ; ratio_gate = compaction_ratio_gate
           ; message_gate = compaction_message_gate
           ; token_gate = compaction_token_gate
-          ; cooldown_sec = compaction_cooldown_sec
           }
       ; pp_always_allow
       }
@@ -370,6 +362,7 @@ type removed_keeper_meta_field =
   | Tool_access
   | Tool_denylist
   | Policy_voice_enabled
+  | Compaction_cooldown
   | Last_blocker
 
 let removed_keeper_meta_field_of_key = function
@@ -380,6 +373,7 @@ let removed_keeper_meta_field_of_key = function
   | "tool_access" -> Some Tool_access
   | "tool_denylist" -> Some Tool_denylist
   | "policy_voice_enabled" -> Some Policy_voice_enabled
+  | "compaction_cooldown_sec" -> Some Compaction_cooldown
   | "last_blocker" -> Some Last_blocker
   | _ -> None
 ;;
@@ -392,6 +386,7 @@ let removed_keeper_meta_field_to_wire = function
   | Tool_access -> "tool_access"
   | Tool_denylist -> "tool_denylist"
   | Policy_voice_enabled -> "policy_voice_enabled"
+  | Compaction_cooldown -> "compaction_cooldown_sec"
   | Last_blocker -> "last_blocker"
 ;;
 
@@ -411,7 +406,8 @@ let reject_removed_keeper_meta_shapes (json : Yojson.Safe.t) =
        | Some (Persona_profile_path as field)
        | Some (Tool_access as field)
        | Some (Tool_denylist as field)
-       | Some (Policy_voice_enabled as field) ->
+       | Some (Policy_voice_enabled as field)
+       | Some (Compaction_cooldown as field) ->
          Error
            ( "removed keeper meta field is no longer supported: "
              ^ removed_keeper_meta_field_to_wire field )

--- a/lib/keeper/keeper_meta_json_scrub.ml
+++ b/lib/keeper/keeper_meta_json_scrub.ml
@@ -21,7 +21,6 @@ let config_field_names =
   ; "proactive_enabled"
   ; "compaction_profile"; "compaction_ratio_gate"
   ; "compaction_message_gate"; "compaction_token_gate"
-  ; "compaction_cooldown_sec"
   ; "max_checkpoint_messages"; "keep_recent_tool_results"
     (* tool_heavy_* fields were removed with the tool_heavy compaction
        trigger; kept here so legacy persisted JSON sheds the dead keys. *)

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -266,10 +266,6 @@ let keeper_schemas : tool_schema list = [
           ("type", `String "integer");
           ("description", `String "Token count gate for compaction (0 disables this gate). Overrides compaction profile when set.");
         ]);
-        ("compaction_cooldown_sec", `Assoc [
-          ("type", `String "integer");
-          ("description", `String "Minimum seconds between completed compactions. 0 disables the cooldown.");
-        ]);
         ("allowed_paths", `Assoc [
           ("type", `String "array");
           ("items", `Assoc [("type", `String "string")]);

--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -110,16 +110,6 @@ let handle_keeper_list ctx args : tool_result =
               in
               empty, note
           in
-            let compaction_cooldown_remaining_s =
-              let cooldown = Float.of_int m.compaction.cooldown_sec in
-              if cooldown <= 0.0 then
-                0.0
-              else if m.runtime.compaction_rt.last_ts <= 0.0 then
-                0.0
-              else
-                let elapsed = now_ts -. m.runtime.compaction_rt.last_ts in
-                max 0.0 (cooldown -. elapsed)
-          in
           let context_json =
             match last_metrics with
             | None -> `Assoc [("source", `String "none")]
@@ -206,8 +196,6 @@ let handle_keeper_list ctx args : tool_result =
             ]
             @ runtime_blocker_fields
             @ attention_fields @ [
-              ("compaction_cooldown_sec", `Int m.compaction.cooldown_sec);
-              ("compaction_cooldown_remaining_s", `Float compaction_cooldown_remaining_s);
               ("autonomous_turn_count", `Int m.runtime.autonomous_turn_count);
               ("autonomous_text_turn_count", `Int m.runtime.autonomous_text_turn_count);
               ("autonomous_tool_turn_count", `Int m.runtime.autonomous_tool_turn_count);

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -23,7 +23,6 @@ type parsed_args = {
   compaction_ratio_gate_opt : float option;
   compaction_message_gate_opt : int option;
   compaction_token_gate_opt : int option;
-  compaction_cooldown_sec_opt : int option;
   sandbox_profile_opt : string option;
   network_mode_opt : string option;
   instructions_arg : string option;
@@ -152,9 +151,6 @@ let parse ?(allow_sandbox_fields = false) (ctx : _ context) (args : Yojson.Safe.
     let compaction_ratio_gate_opt = Safe_ops.json_float_opt "compaction_ratio_gate" args in
     let compaction_message_gate_opt = Safe_ops.json_int_opt "compaction_message_gate" args in
     let compaction_token_gate_opt = Safe_ops.json_int_opt "compaction_token_gate" args in
-    let compaction_cooldown_sec_opt =
-      Safe_ops.json_int_opt "compaction_cooldown_sec" args
-    in
     let sandbox_profile_opt = Safe_ops.json_string_opt "sandbox_profile" args in
     let network_mode_opt = Safe_ops.json_string_opt "network_mode" args in
     let instructions_arg = get_string_opt args "instructions" in
@@ -207,7 +203,6 @@ let parse ?(allow_sandbox_fields = false) (ctx : _ context) (args : Yojson.Safe.
       compaction_ratio_gate_opt;
       compaction_message_gate_opt;
       compaction_token_gate_opt;
-      compaction_cooldown_sec_opt;
       sandbox_profile_opt;
       network_mode_opt;
       instructions_arg;

--- a/lib/keeper/keeper_turn_up_args.mli
+++ b/lib/keeper/keeper_turn_up_args.mli
@@ -27,7 +27,6 @@ type parsed_args =
   ; compaction_ratio_gate_opt : float option
   ; compaction_message_gate_opt : int option
   ; compaction_token_gate_opt : int option
-  ; compaction_cooldown_sec_opt : int option
   ; sandbox_profile_opt : string option
   ; network_mode_opt : string option
   ; instructions_arg : string option

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -103,12 +103,6 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
               let (env_ratio_gate, env_message_gate, env_token_gate) =
                 keeper_compaction_policy_from_env ()
               in
-              let compaction_cooldown_sec =
-                Option.value
-                  ~default:(keeper_compaction_cooldown_sec ())
-                  p.compaction_cooldown_sec_opt
-                |> normalize_compaction_cooldown_sec
-              in
               let
                 ( compaction_profile,
                   compaction_ratio_gate,
@@ -249,7 +243,6 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
           ratio_gate = compaction_ratio_gate;
           message_gate = compaction_message_gate;
           token_gate = compaction_token_gate;
-          cooldown_sec = compaction_cooldown_sec;
         };
         created_at = now_iso ();
         updated_at = now_iso ();

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -176,11 +176,6 @@ let update_keeper ?(preserve_prompt_defaults = false)
       ratio_gate = compaction_ratio_gate;
       message_gate = compaction_message_gate;
       token_gate = compaction_token_gate;
-      cooldown_sec =
-        Option.value
-          ~default:old.compaction.cooldown_sec
-          p.compaction_cooldown_sec_opt
-        |> normalize_compaction_cooldown_sec;
     };
     max_context_override =
       (if p.max_context_override_present then p.max_context_override_opt

--- a/lib/keeper/keeper_types_profile_toml.mli
+++ b/lib/keeper/keeper_types_profile_toml.mli
@@ -41,11 +41,9 @@ val resolve_compaction_policy :
 val normalize_compaction_ratio_gate : float -> float
 val normalize_compaction_message_gate : int -> int
 val normalize_compaction_token_gate : int -> int
-val normalize_compaction_cooldown_sec : int -> int
 val keeper_compact_ratio : unit -> float
 val keeper_compact_max_messages : unit -> int
 val keeper_compact_max_tokens : unit -> int
-val keeper_compaction_cooldown_sec : unit -> int
 val keeper_compaction_policy_from_env : unit -> float * int * int
 val keeper_bootstrap_proactive_warmup_sec : unit -> int
 val keeper_bootstrap_stagger_step_sec : unit -> int

--- a/lib/keeper/keeper_types_profile_toml_io.mli
+++ b/lib/keeper/keeper_types_profile_toml_io.mli
@@ -41,11 +41,9 @@ val resolve_compaction_policy :
 val normalize_compaction_ratio_gate : float -> float
 val normalize_compaction_message_gate : int -> int
 val normalize_compaction_token_gate : int -> int
-val normalize_compaction_cooldown_sec : int -> int
 val keeper_compact_ratio : unit -> float
 val keeper_compact_max_messages : unit -> int
 val keeper_compact_max_tokens : unit -> int
-val keeper_compaction_cooldown_sec : unit -> int
 val keeper_compaction_policy_from_env : unit -> float * int * int
 val keeper_bootstrap_proactive_warmup_sec : unit -> int
 val keeper_bootstrap_stagger_step_sec : unit -> int

--- a/lib/keeper/keeper_types_profile_toml_normalizers.mli
+++ b/lib/keeper/keeper_types_profile_toml_normalizers.mli
@@ -41,11 +41,9 @@ val resolve_compaction_policy :
 val normalize_compaction_ratio_gate : float -> float
 val normalize_compaction_message_gate : int -> int
 val normalize_compaction_token_gate : int -> int
-val normalize_compaction_cooldown_sec : int -> int
 val keeper_compact_ratio : unit -> float
 val keeper_compact_max_messages : unit -> int
 val keeper_compact_max_tokens : unit -> int
-val keeper_compaction_cooldown_sec : unit -> int
 val keeper_compaction_policy_from_env : unit -> float * int * int
 val keeper_bootstrap_proactive_warmup_sec : unit -> int
 val keeper_bootstrap_stagger_step_sec : unit -> int

--- a/lib/keeper/keeper_types_profile_toml_parser.mli
+++ b/lib/keeper/keeper_types_profile_toml_parser.mli
@@ -41,11 +41,9 @@ val resolve_compaction_policy :
 val normalize_compaction_ratio_gate : float -> float
 val normalize_compaction_message_gate : int -> int
 val normalize_compaction_token_gate : int -> int
-val normalize_compaction_cooldown_sec : int -> int
 val keeper_compact_ratio : unit -> float
 val keeper_compact_max_messages : unit -> int
 val keeper_compact_max_tokens : unit -> int
-val keeper_compaction_cooldown_sec : unit -> int
 val keeper_compaction_policy_from_env : unit -> float * int * int
 val keeper_bootstrap_proactive_warmup_sec : unit -> int
 val keeper_bootstrap_stagger_step_sec : unit -> int

--- a/lib/keeper_metrics/keeper_measurement.ml
+++ b/lib/keeper_metrics/keeper_measurement.ml
@@ -6,7 +6,6 @@ type threshold_params = {
   compaction_ratio_gate : float;
   compaction_message_gate : int;
   compaction_token_gate : int;
-  compaction_cooldown_sec : int;
   model_ratio_multiplier : float;
 }
 
@@ -45,7 +44,6 @@ let threshold_params_to_json (t : threshold_params) : Yojson.Safe.t =
     "compaction_ratio_gate", `Float t.compaction_ratio_gate;
     "compaction_message_gate", `Int t.compaction_message_gate;
     "compaction_token_gate", `Int t.compaction_token_gate;
-    "compaction_cooldown_sec", `Int t.compaction_cooldown_sec;
     "model_ratio_multiplier", `Float t.model_ratio_multiplier;
   ]
 

--- a/lib/keeper_metrics/keeper_measurement.mli
+++ b/lib/keeper_metrics/keeper_measurement.mli
@@ -17,7 +17,6 @@ type threshold_params = {
   compaction_ratio_gate : float;
   compaction_message_gate : int;
   compaction_token_gate : int;
-  compaction_cooldown_sec : int;
   model_ratio_multiplier : float;
 }
 

--- a/lib/runtime_settings.ml
+++ b/lib/runtime_settings.ml
@@ -428,12 +428,11 @@ let surfaces =
     };
     {
       id = "keeper_compaction";
-      description = "Keeper context compaction thresholds and cooldown";
+      description = "Keeper context compaction thresholds";
       param_keys = [
         "keeper.compaction.ratio";
         "keeper.compaction.max_messages";
         "keeper.compaction.max_tokens";
-        "keeper.compaction.cooldown_sec";
       ];
     };
     {

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -403,7 +403,6 @@ let dashboard_config_int_fields =
   [
     "compaction_message_gate";
     "compaction_token_gate";
-    "compaction_cooldown_sec";
   ]
 
 let dashboard_config_float_fields =
@@ -598,9 +597,6 @@ let validate_dashboard_config_field key value =
          | "compaction_token_gate" ->
              validate_dashboard_normalized_int key
                Keeper_config.normalize_compaction_token_gate value
-         | "compaction_cooldown_sec" ->
-             validate_dashboard_normalized_int key
-               Keeper_config.normalize_compaction_cooldown_sec value
          | _ -> Ok ())
     | other -> dashboard_field_type_error key "an integer" other
   else if List.mem key dashboard_config_float_fields then

--- a/scripts/harness/workload/keeper_continuity_validation.sh
+++ b/scripts/harness/workload/keeper_continuity_validation.sh
@@ -33,7 +33,6 @@ PRESSURE_BYTES="${PRESSURE_BYTES:-20000}"
 PRESSURE_PAUSE_SEC="${PRESSURE_PAUSE_SEC:-1}"
 KEEPER_COMPACTION_RATIO_GATE="${KEEPER_COMPACTION_RATIO_GATE:-0.10}"
 KEEPER_COMPACTION_MESSAGE_GATE="${KEEPER_COMPACTION_MESSAGE_GATE:-2}"
-KEEPER_COMPACTION_COOLDOWN_SEC="${KEEPER_COMPACTION_COOLDOWN_SEC:-0}"
 
 SERVER_PID=""
 SERVER_LOG="$RUN_DIR/server.log"
@@ -533,7 +532,6 @@ create_keeper() {
     --arg runtime_id "$KEEPER_RUNTIME_NAME" \
     --argjson compaction_ratio_gate "$KEEPER_COMPACTION_RATIO_GATE" \
     --argjson compaction_message_gate "$KEEPER_COMPACTION_MESSAGE_GATE" \
-    --argjson compaction_cooldown_sec "$KEEPER_COMPACTION_COOLDOWN_SEC" \
     '{
       name:$name,
       goal:$goal,
@@ -543,7 +541,6 @@ create_keeper() {
       compaction_ratio_gate:$compaction_ratio_gate,
       compaction_message_gate:$compaction_message_gate,
       compaction_token_gate:0,
-      compaction_cooldown_sec:$compaction_cooldown_sec,
       drift_enabled:false
     } + (if ($runtime_id | length) > 0 then {runtime_id:$runtime_id} else {} end)')"
   call_mcp_tool 1100 "masc_keeper_up" "$args" 60

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -1538,7 +1538,6 @@ let test_operator_update_supersedes_exact_blocked_shutdown () =
         ; compaction_ratio_gate_opt = None
         ; compaction_message_gate_opt = None
         ; compaction_token_gate_opt = None
-        ; compaction_cooldown_sec_opt = None
         ; sandbox_profile_opt = None
         ; network_mode_opt = None
         ; instructions_arg = Some "new operator intent"

--- a/test/test_keeper_identity_parse.ml
+++ b/test/test_keeper_identity_parse.ml
@@ -155,6 +155,22 @@ let test_legacy_goal_meta_rejected () =
       (Astring.String.is_infix ~affix:"removed keeper meta field" msg
        && Astring.String.is_infix ~affix:"goal" msg)
 
+let test_removed_compaction_cooldown_meta_rejected () =
+  match
+    strict_meta_of_fields
+      [ ("name", `String "alice")
+      ; ("agent_name", `String "keeper-alice-agent")
+      ; ("trace_id", `String "alice-001")
+      ; ("compaction_cooldown_sec", `Int 15)
+      ]
+  with
+  | Ok _ -> fail "removed compaction_cooldown_sec meta must be rejected"
+  | Error msg ->
+    check bool
+      "error names removed compaction_cooldown_sec"
+      true
+      (Astring.String.is_infix ~affix:"compaction_cooldown_sec" msg)
+
 let () =
   run "keeper_identity_parse"
     [ ( "parse_keeper_identity"
@@ -172,5 +188,7 @@ let () =
             test_removed_voice_policy_meta_rejected
         ; test_case "removed legacy goal meta" `Quick
             test_legacy_goal_meta_rejected
+        ; test_case "removed compaction cooldown meta" `Quick
+            test_removed_compaction_cooldown_meta_rejected
         ] )
     ]

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -642,6 +642,22 @@ policy_voice_enabled = true
          true
          (contains_substring msg "keeper.policy_voice_enabled"))
 
+let test_profile_rejects_removed_compaction_cooldown_key () =
+  let input = {|
+[keeper]
+compaction_cooldown_sec = 15
+|} in
+  match TL.parse_toml input with
+  | Error e -> fail e
+  | Ok doc ->
+    (match KTP.profile_defaults_of_toml doc with
+     | Ok _ -> fail "expected removed keeper.compaction_cooldown_sec error"
+     | Error msg ->
+       check bool
+         "mentions removed compaction cooldown key"
+         true
+         (contains_substring msg "keeper.compaction_cooldown_sec"))
+
 (* ================================================================ *)
 (* File loading tests                                                *)
 (* ================================================================ *)
@@ -1938,6 +1954,8 @@ let () =
             test_profile_rejects_removed_shards_key;
           test_case "rejects removed voice policy key" `Quick
             test_profile_rejects_removed_voice_policy_key;
+          test_case "rejects removed compaction cooldown key" `Quick
+            test_profile_rejects_removed_compaction_cooldown_key;
           test_case "rejects keeper.runtime_id key" `Quick
             test_profile_rejects_runtime_id_key;
           test_case "rejects keeper.model key" `Quick

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -578,6 +578,20 @@ let test_keeper_goal_arg_rejected () =
     Alcotest.(check bool) "goal mentioned" true
       (contains_substring ~needle:"goal" msg)
 
+let test_keeper_compaction_cooldown_arg_rejected () =
+  let args = `Assoc [ "compaction_cooldown_sec", `Int 15 ] in
+  match
+    Masc.Keeper_config.reject_removed_keeper_input_keys
+      ~tool_name:"masc_keeper_up"
+      args
+  with
+  | Ok () -> Alcotest.fail "removed compaction cooldown arg should be rejected"
+  | Error msg ->
+    Alcotest.(check bool)
+      "compaction_cooldown_sec mentioned"
+      true
+      (contains_substring ~needle:"compaction_cooldown_sec" msg)
+
 let test_masc_keeper_up_schema () =
   match find_registered_tool "masc_keeper_up" with
   | None -> Alcotest.fail "masc_keeper_up not found"
@@ -852,6 +866,8 @@ let () =
         test_keeper_shards_arg_rejected;
       Alcotest.test_case "keeper-goal-arg-rejected" `Quick
         test_keeper_goal_arg_rejected;
+      Alcotest.test_case "keeper-compaction-cooldown-arg-rejected" `Quick
+        test_keeper_compaction_cooldown_arg_rejected;
       Alcotest.test_case "keeper-up" `Quick
         test_masc_keeper_up_schema;
       Alcotest.test_case "keeper-sandbox-args-rejected" `Quick


### PR DESCRIPTION
## Why

Compaction cooldown was no longer part of admission, but remained configurable and observable across Keeper tool input, TOML, persisted meta, status, schema, and dashboard. That created dead authority: operators could believe a delay was enforced when runtime behavior ignored it.

## What

- hard-delete compaction_cooldown_sec from runtime/config/meta/status/schema/dashboard surfaces
- reject the retired key explicitly in tool input and Keeper TOML
- reject persisted retired meta explicitly; no compatibility migration or silent scrub
- preserve manual/provider-overflow LLM compaction paths

## Verification

- ocamlformat --check on touched OCaml files: PASS
- git diff --check: PASS
- dashboard TypeScript typecheck: PASS
- focused dashboard Vitest: 148/148 PASS
- focused OCaml wrapper: not claimed; another live Dune/opam-switch owner prevented an isolated run, so Build and Test remains CI authority

Diff: 171 changed lines (+59/-112).