### PR TITLE
fix(runtime): project declared provider concurrency

### DIFF
--- a/lib/runtime/runtime_adapter.ml
+++ b/lib/runtime/runtime_adapter.ml
@@ -344,7 +344,7 @@ let model_capabilities_override_of_model_spec
 ;;
 
 (* --- provider × model spec → Provider_config.t --- *)
-let provider_config_from_declared_provider ?keep_alive ?num_ctx
+let provider_config_from_declared_provider ?keep_alive ?num_ctx ?max_concurrent_requests
     (provider : Runtime_schema.provider) (spec : Runtime_schema.model_spec)
   : (Llm_provider.Provider_config.t, string) result =
   let registry_entry = find_registry_entry provider.id in
@@ -405,6 +405,7 @@ let provider_config_from_declared_provider ?keep_alive ?num_ctx
             ?keep_alive
             ?num_ctx
             ?connect_timeout_s:provider.connect_timeout_s
+            ?max_concurrent_requests
             ())
      | Error reason -> Error reason)
   | Cli _ ->
@@ -429,6 +430,7 @@ let provider_config_from_declared_provider ?keep_alive ?num_ctx
             ?keep_alive
             ?num_ctx
             ?connect_timeout_s:provider.connect_timeout_s
+            ?max_concurrent_requests
             ())
      | Error reason -> Error reason)
 ;;
@@ -454,6 +456,7 @@ let binding_to_provider_config (cfg : Runtime_schema.config) (binding : Runtime_
        provider_config_from_declared_provider
          ?keep_alive:binding.keep_alive
          ?num_ctx:binding.num_ctx
+         ?max_concurrent_requests:binding.max_concurrent
          provider
          spec)
 ;;

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -1710,7 +1710,7 @@ let test_server_degraded_init_rejects_uncatalogued_default () =
          check bool "error rejects alternate default routing" true
            (String_util.contains_substring msg "default fallback"))
 
-let test_runtime_toml_max_concurrent_flows_to_candidate () =
+let test_runtime_toml_max_concurrent_flows_to_provider_config () =
   with_fake_runtime_model_catalog @@ fun () ->
   let content =
     "[providers.local]\n\
@@ -1757,16 +1757,11 @@ let test_runtime_toml_max_concurrent_flows_to_candidate () =
             (Printf.sprintf "%s binding max_concurrent" id)
             expected
             rt.Runtime.binding.max_concurrent;
-          let candidate =
-            Runtime_candidate.of_provider_config
-              ~max_concurrent:rt.Runtime.binding.max_concurrent
-              rt.Runtime.provider_config
-          in
           check
             (option int)
-            (Printf.sprintf "%s candidate max_concurrent" id)
+            (Printf.sprintf "%s provider_config max_concurrent_requests" id)
             expected
-            (Runtime_candidate.max_concurrent candidate)
+            rt.Runtime.provider_config.max_concurrent_requests
       in
       expect "local.no-cap" None;
       expect "local.capped" (Some 5))
@@ -2413,8 +2408,8 @@ let () =
             test_runtime_toml_separates_wizard_default_from_runtime_default_marker;
           test_case "non-positive max-concurrent is rejected" `Quick
             test_runtime_toml_rejects_non_positive_max_concurrent;
-          test_case "max-concurrent flows from binding to runtime candidate" `Quick
-            test_runtime_toml_max_concurrent_flows_to_candidate;
+          test_case "max-concurrent flows from binding to provider config" `Quick
+            test_runtime_toml_max_concurrent_flows_to_provider_config;
           test_case
             "deprecated capability notice warns once per process, not per parse"
             `Quick test_deprecated_capability_notice_warns_once_per_process;


### PR DESCRIPTION
## Why

MASC parsed each Runtime binding max-concurrent declaration but only copied it into an inert Runtime_candidate field. OAS v0.216 already owns generic endpoint/account FIFO admission at Complete.complete, so Keeper, HITL, and compaction calls were bypassing the operator-declared provider allowance.

## What

- immutably project binding.max_concurrent into Provider_config.max_concurrent_requests
- cover both HTTP and typed CLI materialization branches
- replace the stale candidate-only assertion with the real dispatch config contract

## Boundary

This adds no Gate cap and no provider/model/URL heuristic. None remains unbounded. Some n is only the explicit Runtime declaration and is enforced once by OAS at the provider transport boundary.

## Verification

- OAS pin v0.216.0 / 20865f7b3dde: PASS
- ocamlformat --check: PASS
- git diff --check: PASS
- focused local Dune is not claimed because shared Dune/opam locks were active; Build and Test is CI authority

Diff: 20 changed lines (+9/-11).