### PR TITLE
fix(keeper): adapt to agent_sdk 0.216.0 typed invocation surface

### DIFF
--- a/lib/keeper/keeper_event_bridge.ml
+++ b/lib/keeper/keeper_event_bridge.ml
@@ -219,7 +219,8 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
          ~error_retryable:projection.error_retryable
          ~error_detail:projection.error_detail
          ())
-  | Agent_sdk.Event_bus.ToolCalled { agent_name; tool_name; tool_use_id; _ } ->
+  | Agent_sdk.Event_bus.ToolCalled { agent_name; tool_name; invocation; _ } ->
+    let tool_use_id = Agent_sdk.Tool.Invocation.tool_use_id invocation in
     (* tool_called publishes before execution, so the keeper hook has not
        minted an execution_id yet — this row carries the provider call id
        only; the matching tool_completed row carries both. *)
@@ -229,7 +230,8 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
          @ (if tool_use_id = "" then [] else [ "tool_use_id", `String tool_use_id ]))
     in
     Some (wrap ~event_type:"tool_called" ~payload ~agent_name ~tool_name ())
-  | Agent_sdk.Event_bus.ToolCompleted { agent_name; tool_name; tool_use_id; _ } ->
+  | Agent_sdk.Event_bus.ToolCompleted { agent_name; tool_name; invocation; _ } ->
+    let tool_use_id = Agent_sdk.Tool.Invocation.tool_use_id invocation in
     (* RFC-0233 PR-2: the keeper post_tool_use hook registered the
        tool_use_id ↔ execution_id pair before OAS published this event,
        so the lookup is deterministic. A miss means the execution did not

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -150,9 +150,9 @@ let make_hooks
     { Agent_sdk.Hooks.empty with
     pre_tool_use = Some (fun event ->
       match event with
-      | Agent_sdk.Hooks.PreToolUse { turn; _ } ->
+      | Agent_sdk.Hooks.PreToolUse { invocation; _ } ->
         tool_start_time := Time_compat.now ();
-        tool_invocation_turn := Some turn;
+        tool_invocation_turn := Some (Agent_sdk.Tool.Invocation.turn invocation);
         Agent_sdk.Hooks.Continue
       | _event -> Agent_sdk.Hooks.Continue);
 

--- a/lib/keeper/keeper_runtime_attempt.ml
+++ b/lib/keeper/keeper_runtime_attempt.ml
@@ -25,13 +25,13 @@ let provider_error_to_http_error = function
       ; message = detail
       }
   | Llm_provider.Error.AuthError { detail; _ } ->
-    Llm_provider.Http_client.HttpError { code = 401; body = detail }
+    Llm_provider.Http_client.HttpError { code = 401; body = detail; retry_after_header = None }
   | Llm_provider.Error.AuthorizationError { detail; _ } ->
-    Llm_provider.Http_client.HttpError { code = 403; body = detail }
+    Llm_provider.Http_client.HttpError { code = 403; body = detail; retry_after_header = None }
   | Llm_provider.Error.ServerError { code; detail; _ } ->
-    Llm_provider.Http_client.HttpError { code; body = detail }
+    Llm_provider.Http_client.HttpError { code; body = detail; retry_after_header = None }
   | Llm_provider.Error.InvalidRequest { reason; _ } ->
-    Llm_provider.Http_client.HttpError { code = 400; body = reason }
+    Llm_provider.Http_client.HttpError { code = 400; body = reason; retry_after_header = None }
   | Llm_provider.Error.ProviderTerminal { reason; detail; _ } ->
     let body = if String.trim detail = "" then reason else detail in
     Llm_provider.Http_client.ProviderFailure
@@ -105,9 +105,9 @@ let sdk_error_to_runtime_outcome err =
        let http_err =
          match api_err with
          | Llm_provider.Retry.InvalidRequest { message; _ } ->
-           Llm_provider.Http_client.HttpError { code = 400; body = message }
+           Llm_provider.Http_client.HttpError { code = 400; body = message; retry_after_header = None }
          | ContextOverflow { message; _ } ->
-           Llm_provider.Http_client.HttpError { code = 400; body = message }
+           Llm_provider.Http_client.HttpError { code = 400; body = message; retry_after_header = None }
          | RateLimited { message; _ } ->
            Llm_provider.Http_client.HttpError { code = 429; body = message }
          | PaymentRequired { message } ->


### PR DESCRIPTION
## main red 수리 (P0)

pin bump v0.216.0(#25075)이 breaking 3종 미적응 상태로 병합돼 **main이 `613cbcbf72`부터 전 CI run red** (bump 자신의 run 포함, 이후 병합 6건은 red 위 동승).

## 적응 내용 (3파일, 컴파일 에러 전점 대응)

| 0.216.0 변경 | masc 적응 |
|---|---|
| `Http_client.HttpError`에 `retry_after_header : float option` 추가 | `keeper_runtime_attempt.ml` 합성 생성 6곳에 `= None` — 원천 `Llm_provider.Error` variant들(ServerError 포함)에 retry 정보가 없음을 `error.mli`로 확인, None이 정확값 |
| `Event_bus.ToolCalled/ToolCompleted`: `tool_use_id` → `invocation : Tool.Invocation.t` | `keeper_event_bridge.ml`에서 `Tool.Invocation.tool_use_id`로 접근, 빈-id 가드 보존 |
| `Hooks.PreToolUse`: `turn` → `invocation` | `keeper_hooks_oas.ml`에서 `Tool.Invocation.turn` |

## 검증

- 로컬 스위치 0.216.0 정렬 확인(`g20865f7`), 3사이트는 CI 실패 로그의 정확한 에러 지점
- 전수 스윕: 로컬 `@check`는 fleet 빌드 락 큐 대기 중이라 **본 PR CI가 병렬 전수 검증** — 잔여 사이트가 나오면 본 PR에서 즉시 추가 수리
- 미검증: 위 CI 완주 전까지 3사이트 외 잔여 파손 존재 가능성

## 관련

- #25075 (원인 bump) / #25035 (별건 CI 유령취소)
- 병합 즉시 main green 복귀 → 동결된 merge loop 재개

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PgGNxsWM8yCaJiHnTzrVa