### PR TITLE
fix(oas): consume v0.216 invocation and HTTP contracts

### DIFF
--- a/lib/keeper/keeper_event_bridge.ml
+++ b/lib/keeper/keeper_event_bridge.ml
@@ -167,6 +167,14 @@ let wrap_event
     Suppressing warning 11 ([@warning "-11"]) is therefore the entire
     point of this function's shape — do not remove it without also
     removing the catch-all. *)
+let invocation_payload_fields invocation =
+  let tool_use_id = Agent_sdk.Tool.Invocation.tool_use_id invocation in
+  [ "turn", `Int (Agent_sdk.Tool.Invocation.turn invocation)
+  ; "planned_index", `Int (Agent_sdk.Tool.Invocation.planned_index invocation)
+  ]
+  @ (if tool_use_id = "" then [] else [ "tool_use_id", `String tool_use_id ])
+;;
+
 let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t option =
   let { Agent_sdk.Event_bus.correlation_id; run_id; ts; caused_by; _ } = evt.meta in
   let wrap = wrap_event ~ts ~correlation_id ~run_id ?caused_by in
@@ -219,23 +227,22 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
          ~error_retryable:projection.error_retryable
          ~error_detail:projection.error_detail
          ())
-  | Agent_sdk.Event_bus.ToolCalled { agent_name; tool_name; invocation; _ } ->
-    let tool_use_id = Agent_sdk.Tool.Invocation.tool_use_id invocation in
+  | Agent_sdk.Event_bus.ToolCalled { invocation; agent_name; tool_name; _ } ->
     (* tool_called publishes before execution, so the keeper hook has not
        minted an execution_id yet — this row carries the provider call id
        only; the matching tool_completed row carries both. *)
     let payload =
       `Assoc
         ([ "agent_name", `String agent_name; "tool_name", `String tool_name ]
-         @ (if tool_use_id = "" then [] else [ "tool_use_id", `String tool_use_id ]))
+         @ invocation_payload_fields invocation)
     in
     Some (wrap ~event_type:"tool_called" ~payload ~agent_name ~tool_name ())
-  | Agent_sdk.Event_bus.ToolCompleted { agent_name; tool_name; invocation; _ } ->
-    let tool_use_id = Agent_sdk.Tool.Invocation.tool_use_id invocation in
+  | Agent_sdk.Event_bus.ToolCompleted { invocation; agent_name; tool_name; _ } ->
     (* RFC-0233 PR-2: the keeper post_tool_use hook registered the
        tool_use_id ↔ execution_id pair before OAS published this event,
        so the lookup is deterministic. A miss means the execution did not
        go through a keeper hook (worker/eval lanes), not a failure. *)
+    let tool_use_id = Agent_sdk.Tool.Invocation.tool_use_id invocation in
     let execution_id_fields =
       match
         if tool_use_id = "" then None
@@ -247,7 +254,7 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
     let payload =
       `Assoc
         ([ "agent_name", `String agent_name; "tool_name", `String tool_name ]
-         @ (if tool_use_id = "" then [] else [ "tool_use_id", `String tool_use_id ])
+         @ invocation_payload_fields invocation
          @ execution_id_fields)
     in
     Some (wrap ~event_type:"tool_completed" ~payload ~agent_name ~tool_name ())

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -135,7 +135,6 @@ let make_hooks
   : Agent_sdk.Hooks.hooks =
   let sse_turn_complete = "keeper_turn_complete" in
   let tool_start_time = ref 0.0 in
-  let tool_invocation_turn = ref None in
   (* Per-turn tool call counter for SSE enrichment.
      Incremented in post_tool_use, reset in after_turn. *)
   let tool_call_count_ref = ref 0 in
@@ -150,9 +149,8 @@ let make_hooks
     { Agent_sdk.Hooks.empty with
     pre_tool_use = Some (fun event ->
       match event with
-      | Agent_sdk.Hooks.PreToolUse { invocation; _ } ->
+      | Agent_sdk.Hooks.PreToolUse _ ->
         tool_start_time := Time_compat.now ();
-        tool_invocation_turn := Some (Agent_sdk.Tool.Invocation.turn invocation);
         Agent_sdk.Hooks.Continue
       | _event -> Agent_sdk.Hooks.Continue);
 
@@ -384,12 +382,11 @@ let make_hooks
     post_tool_use = Some (fun event ->
       match event with
       | Agent_sdk.Hooks.PostToolUse
-          { tool_name
+          { invocation
+          ; tool_name
           ; input
           ; output
           ; duration_ms = hook_duration_ms
-          ; tool_use_id
-          ; schedule
           ; _
           } ->
         record_progress ("tool_completed:" ^ tool_name);
@@ -460,12 +457,8 @@ let make_hooks
           Keeper_tool_call_log_context.get_turn_context_record
             ~cell:turn_ctx_cell ()
         in
-        let invocation_turn =
-          match !tool_invocation_turn with
-          | Some turn -> Some turn
-          | None -> tctx.turn
-        in
-        tool_invocation_turn := None;
+        let tool_use_id = Agent_sdk.Tool.Invocation.tool_use_id invocation in
+        let invocation_turn = Some (Agent_sdk.Tool.Invocation.turn invocation) in
         (* RFC-0233 PR-1: one mint per execution at this dispatch boundary;
            the log_call row and the trajectory entry below share the value
            so downstream views can join the two stores on a single key. *)
@@ -489,7 +482,7 @@ let make_hooks
              ?prompt_fingerprint:tctx.prompt_fingerprint
              ~execution_id
              ~tool_use_id
-             ~planned_index:schedule.planned_index
+             ~planned_index:(Agent_sdk.Tool.Invocation.planned_index invocation)
              ?trace_id:tctx.trace_id ?session_id:tctx.session_id
              ?generation:tctx.generation
              ?turn:invocation_turn ?keeper_turn_id:tctx.keeper_turn_id
@@ -615,7 +608,7 @@ let make_hooks
       | _event -> Agent_sdk.Hooks.Continue);
 
     on_error = Some (function
-      | Agent_sdk.Hooks.OnError { detail; context = err_ctx } ->
+      | Agent_sdk.Hooks.OnError { detail; context = err_ctx; _ } ->
         Otel_metric_store.inc_counter
           Keeper_metrics.(to_string LifecycleCallbackFailures)
           ~labels:[(label_keeper, (!meta_ref).name); (label_callback, callback_label_on_error)]
@@ -626,7 +619,7 @@ let make_hooks
       | _event -> Agent_sdk.Hooks.Continue);
 
     on_tool_error = Some (function
-      | Agent_sdk.Hooks.OnToolError { tool_name; error } ->
+      | Agent_sdk.Hooks.OnToolError { tool_name; error; _ } ->
         let keeper_name = (!meta_ref).name in
         (* [OnToolError] carries opaque text but no typed MASC failure class.
            Do not reclassify it by decoding a JSON-looking message. *)

--- a/lib/keeper/keeper_runtime_attempt.ml
+++ b/lib/keeper/keeper_runtime_attempt.ml
@@ -8,6 +8,9 @@ let capacity_backpressure_source_to_failure_scope = function
   | Keeper_internal_error.Runtime_slot ->
     Llm_provider.Http_client.Failure_scope_unknown
 
+let http_error ~code ~body =
+  Llm_provider.Http_client.HttpError { code; body; retry_after_header = None }
+
 let provider_error_to_http_error = function
   | Llm_provider.Error.RateLimit { retry_after; detail; _ }
   | Llm_provider.Error.HardQuota { retry_after; detail; _ } ->
@@ -25,13 +28,13 @@ let provider_error_to_http_error = function
       ; message = detail
       }
   | Llm_provider.Error.AuthError { detail; _ } ->
-    Llm_provider.Http_client.HttpError { code = 401; body = detail; retry_after_header = None }
+    http_error ~code:401 ~body:detail
   | Llm_provider.Error.AuthorizationError { detail; _ } ->
-    Llm_provider.Http_client.HttpError { code = 403; body = detail; retry_after_header = None }
+    http_error ~code:403 ~body:detail
   | Llm_provider.Error.ServerError { code; detail; _ } ->
-    Llm_provider.Http_client.HttpError { code; body = detail; retry_after_header = None }
+    http_error ~code ~body:detail
   | Llm_provider.Error.InvalidRequest { reason; _ } ->
-    Llm_provider.Http_client.HttpError { code = 400; body = reason; retry_after_header = None }
+    http_error ~code:400 ~body:reason
   | Llm_provider.Error.ProviderTerminal { reason; detail; _ } ->
     let body = if String.trim detail = "" then reason else detail in
     Llm_provider.Http_client.ProviderFailure
@@ -41,8 +44,9 @@ let provider_error_to_http_error = function
       ; message = body
       }
   | Llm_provider.Error.NotFound { detail; _ } ->
-    Llm_provider.Http_client.HttpError
-      { code = 404; body = if String.trim detail = "" then "model not found" else detail }
+    http_error
+      ~code:404
+      ~body:(if String.trim detail = "" then "model not found" else detail)
   | Llm_provider.Error.Timeout { detail; timeout_phase; _ } ->
     Llm_provider.Http_client.TimeoutError
       { message = detail
@@ -59,11 +63,9 @@ let provider_error_to_http_error = function
       ; message = detail
       }
   | Llm_provider.Error.MissingApiKey { var_name } ->
-    Llm_provider.Http_client.HttpError
-      { code = 401; body = Printf.sprintf "missing API key: %s" var_name }
+    http_error ~code:401 ~body:(Printf.sprintf "missing API key: %s" var_name)
   | Llm_provider.Error.InvalidConfig { field; detail } ->
-    Llm_provider.Http_client.HttpError
-      { code = 400; body = Printf.sprintf "%s: %s" field detail }
+    http_error ~code:400 ~body:(Printf.sprintf "%s: %s" field detail)
   | Llm_provider.Error.UnknownVariant { type_name; value } ->
     Llm_provider.Http_client.ProviderTerminal
       { kind = Llm_provider.Http_client.Other "unknown_variant"
@@ -105,23 +107,23 @@ let sdk_error_to_runtime_outcome err =
        let http_err =
          match api_err with
          | Llm_provider.Retry.InvalidRequest { message; _ } ->
-           Llm_provider.Http_client.HttpError { code = 400; body = message; retry_after_header = None }
+           http_error ~code:400 ~body:message
          | ContextOverflow { message; _ } ->
-           Llm_provider.Http_client.HttpError { code = 400; body = message; retry_after_header = None }
+           http_error ~code:400 ~body:message
          | RateLimited { message; _ } ->
-           Llm_provider.Http_client.HttpError { code = 429; body = message }
+           http_error ~code:429 ~body:message
          | PaymentRequired { message } ->
-           Llm_provider.Http_client.HttpError { code = 402; body = message }
+           http_error ~code:402 ~body:message
          | NotFound { message } ->
-           Llm_provider.Http_client.HttpError { code = 404; body = message }
+           http_error ~code:404 ~body:message
          | ServerError { status; message } ->
-           Llm_provider.Http_client.HttpError { code = status; body = message }
+           http_error ~code:status ~body:message
          | AuthError { message } ->
-           Llm_provider.Http_client.HttpError { code = 401; body = message }
+           http_error ~code:401 ~body:message
          | AuthorizationError { message } ->
-           Llm_provider.Http_client.HttpError { code = 403; body = message }
+           http_error ~code:403 ~body:message
          | Overloaded { message } ->
-           Llm_provider.Http_client.HttpError { code = 529; body = message }
+           http_error ~code:529 ~body:message
          | NetworkError { message; kind } ->
            Llm_provider.Http_client.NetworkError { message; kind }
          | Timeout { message } ->

--- a/lib/provider_http_error.ml
+++ b/lib/provider_http_error.ml
@@ -23,7 +23,7 @@ let to_message (err : Llm_provider.Http_client.http_error) : string =
       Printf.sprintf "provider terminal: %s" message
   | Llm_provider.Http_client.ProviderFailure { kind; message } ->
       Llm_provider.Http_client.provider_failure_to_string ~kind ~message
-  | Llm_provider.Http_client.HttpError { code; body } ->
+  | Llm_provider.Http_client.HttpError { code; body; _ } ->
       Printf.sprintf "HTTP %d: %s" code
         (if String.length body > max_body_length
          then String.sub body 0 max_body_length ^ body_truncation_suffix

--- a/lib/runtime/runtime_attempt_fsm.ml
+++ b/lib/runtime/runtime_attempt_fsm.ml
@@ -42,7 +42,7 @@ let decide_and_record ~runtime_id:_ ~accept_on_exhaustion ~is_last outcome =
   decide ~accept_on_exhaustion ~is_last outcome
 
 let to_user_message = function
-  | Some (Llm_provider.Http_client.HttpError { code; body }) ->
+  | Some (Llm_provider.Http_client.HttpError { code; body; _ }) ->
     Printf.sprintf
       "HTTP %d: %s"
       code

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -177,7 +177,7 @@ let make_tool_tracking_hooks ?context () =
     ; on_error =
         Some
           (function
-            | Agent_sdk.Hooks.OnError { detail; context = err_ctx } ->
+            | Agent_sdk.Hooks.OnError { detail; context = err_ctx; _ } ->
               Log.LocalWorker.warn "worker on_error: %s (context: %s)" detail err_ctx;
               Agent_sdk.Hooks.Continue
             | Agent_sdk.Hooks.BeforeTurn _
@@ -191,7 +191,7 @@ let make_tool_tracking_hooks ?context () =
     ; on_tool_error =
         Some
           (function
-            | Agent_sdk.Hooks.OnToolError { tool_name; error } ->
+            | Agent_sdk.Hooks.OnToolError { tool_name; error; _ } ->
               Log.LocalWorker.warn "worker tool_error: %s — %s" tool_name error;
               Agent_sdk.Hooks.Continue
             | Agent_sdk.Hooks.BeforeTurn _

--- a/test/test_keeper_execution_join.ml
+++ b/test/test_keeper_execution_join.ml
@@ -19,6 +19,10 @@ let string_of_field = function
   | Some (`String s) -> Some s
   | _ -> None
 
+let int_of_field = function
+  | Some (`Int value) -> Some value
+  | _ -> None
+
 (* ── Join table semantics ─────────────────────────────── *)
 
 let test_record_take_roundtrip () =
@@ -60,18 +64,36 @@ let mk_event ?caused_by payload : Agent_sdk.Event_bus.event =
   ; payload
   }
 
+let invocation ?(turn = 0) ?(planned_index = 0) tool_use_id =
+  Agent_sdk.Tool.Invocation.create
+    ~tool_use_id
+    ~turn
+    ~schedule:
+      { planned_index
+      ; batch_index = 0
+      ; batch_size = 1
+      ; execution_mode = Agent_sdk.Tool.Serial
+      }
+
 let test_tool_called_carries_tool_use_id () =
   Join.For_testing.clear ();
   let json =
     Bridge.native_event_to_json
       (mk_event
          (Agent_sdk.Event_bus.ToolCalled
-            { agent_name = "oas-r1"; tool_name = "Read"; tool_use_id = "tu-3"
-            ; input = `Null; turn = 0 }))
+            { invocation = invocation "tu-3"
+            ; agent_name = "oas-r1"
+            ; tool_name = "Read"
+            ; input = `Null
+            }))
     |> Option.get
   in
   check (option string) "payload tool_use_id" (Some "tu-3")
     (string_of_field (payload_member "tool_use_id" json));
+  check (option int) "payload turn" (Some 0)
+    (int_of_field (payload_member "turn" json));
+  check (option int) "payload planned_index" (Some 0)
+    (int_of_field (payload_member "planned_index" json));
   check bool "tool_called has no execution_id (mint happens after publish)"
     true
     (payload_member "execution_id" json = None)
@@ -84,14 +106,21 @@ let test_tool_completed_stamps_execution_id () =
     Bridge.native_event_to_json
       (mk_event ~caused_by:"run-called-1"
          (Agent_sdk.Event_bus.ToolCompleted
-            { agent_name = "keeper-x-agent"; tool_name = "Read"
-            ; tool_use_id = "tu-4"; output = Ok { content = "ok"; _meta = None }; turn = 1 }))
+            { invocation = invocation ~turn:1 ~planned_index:3 "tu-4"
+            ; agent_name = "keeper-x-agent"
+            ; tool_name = "Read"
+            ; output = Ok { content = "ok"; _meta = None }
+            }))
     |> Option.get
   in
   check (option string) "payload execution_id" (Some "exec-2-0001")
     (string_of_field (payload_member "execution_id" json));
   check (option string) "payload tool_use_id" (Some "tu-4")
     (string_of_field (payload_member "tool_use_id" json));
+  check (option int) "payload exact turn" (Some 1)
+    (int_of_field (payload_member "turn" json));
+  check (option int) "payload exact planned_index" (Some 3)
+    (int_of_field (payload_member "planned_index" json));
   check (option string) "envelope caused_by survives serialization"
     (Some "run-called-1")
     (string_of_field (member "caused_by" json));
@@ -104,8 +133,11 @@ let test_tool_completed_without_entry_omits_execution_id () =
     Bridge.native_event_to_json
       (mk_event
          (Agent_sdk.Event_bus.ToolCompleted
-            { agent_name = "oas-worker"; tool_name = "Execute"
-            ; tool_use_id = "tu-5"; output = Ok { content = "ok"; _meta = None }; turn = 2 }))
+            { invocation = invocation ~turn:2 "tu-5"
+            ; agent_name = "oas-worker"
+            ; tool_name = "Execute"
+            ; output = Ok { content = "ok"; _meta = None }
+            }))
     |> Option.get
   in
   check bool "no execution_id field for non-keeper execution" true
@@ -119,8 +151,11 @@ let test_empty_tool_use_id_omitted_from_payload () =
     Bridge.native_event_to_json
       (mk_event
          (Agent_sdk.Event_bus.ToolCalled
-            { agent_name = "oas-r1"; tool_name = "Read"; tool_use_id = ""
-            ; input = `Null; turn = 0 }))
+            { invocation = invocation ""
+            ; agent_name = "oas-r1"
+            ; tool_name = "Read"
+            ; input = `Null
+            }))
     |> Option.get
   in
   check bool "empty provider id is omitted" true

--- a/test/test_keeper_hooks_oas_introspection.ml
+++ b/test/test_keeper_hooks_oas_introspection.ml
@@ -125,17 +125,19 @@ let test_pre_tool_use_is_observation_only () =
   let hooks = make_runtime_hooks () in
   let event =
     Agent_sdk.Hooks.PreToolUse
-      { tool_use_id = "toolu_observation_only"
+      { invocation =
+          Agent_sdk.Tool.Invocation.create
+            ~tool_use_id:"toolu_observation_only"
+            ~turn:7
+            ~schedule:
+              { planned_index = 0
+              ; batch_index = 0
+              ; batch_size = 1
+              ; execution_mode = Agent_sdk.Tool.Serial
+              }
       ; tool_name = "opaque_internal_name"
       ; input = `Assoc [ "command", `String "opaque external effect" ]
       ; accumulated_cost_usd = 1234.0
-      ; turn = 7
-      ; schedule =
-          { planned_index = 0
-          ; batch_index = 0
-          ; batch_size = 1
-          ; execution_mode = Agent_sdk.Tool.Serial
-          }
       }
   in
   match Agent_sdk.Hooks.invoke_validated hooks.pre_tool_use event with

--- a/test/test_keeper_tool_call_sse_io_preview.ml
+++ b/test/test_keeper_tool_call_sse_io_preview.ml
@@ -109,7 +109,12 @@ let test_oas_invocation_fields_preserve_exact_occurrence () =
     Agent_sdk.Tool.Invocation.create
       ~tool_use_id:""
       ~turn:11
-      ~planned_index:3
+      ~schedule:
+        { planned_index = 3
+        ; batch_index = 0
+        ; batch_size = 1
+        ; execution_mode = Agent_sdk.Tool.Serial
+        }
   in
   let json =
     `Assoc

--- a/test/test_keeper_unified_turn_event_bus.ml
+++ b/test/test_keeper_unified_turn_event_bus.ml
@@ -23,25 +23,35 @@ let dummy_event payload =
   }
 ;;
 
+let invocation name =
+  Agent_sdk.Tool.Invocation.create
+    ~tool_use_id:name
+    ~turn:0
+    ~schedule:
+      { planned_index = 0
+      ; batch_index = 0
+      ; batch_size = 1
+      ; execution_mode = Agent_sdk.Tool.Serial
+      }
+;;
+
 let tool_called name =
   dummy_event
     (Agent_sdk.Event_bus.ToolCalled
-       { agent_name = "a"
+       { invocation = invocation name
+       ; agent_name = "a"
        ; tool_name = name
-       ; tool_use_id = name
        ; input = `Null
-       ; turn = 0
        })
 ;;
 
 let tool_completed name =
   dummy_event
     (Agent_sdk.Event_bus.ToolCompleted
-       { agent_name = "a"
+       { invocation = invocation name
+       ; agent_name = "a"
        ; tool_name = name
-       ; tool_use_id = name
        ; output = Ok { Agent_sdk.Types.content = "done"; _meta = None }
-       ; turn = 0
        })
 ;;
 

--- a/test/test_keeper_vision_tool.ml
+++ b/test/test_keeper_vision_tool.ml
@@ -743,7 +743,9 @@ let test_retryable_provider_error_tries_next_runtime () =
         incr calls;
         models := config.Llm_provider.Provider_config.model_id :: !models;
         if !calls = 1 then
-          Error (Llm_provider.Http_client.HttpError { code = 500; body = "down" })
+          Error
+            (Llm_provider.Http_client.HttpError
+               { code = 500; body = "down"; retry_after_header = None })
         else Ok (ok_response "second runtime answered")
       in
       let raw =
@@ -782,7 +784,9 @@ let test_candidate_failover_is_not_cut_off_by_local_deadline () =
       let complete ~sw:_ ~net:_ ?clock:_ ~config ~messages:_ () =
         incr calls;
         models := config.Llm_provider.Provider_config.model_id :: !models;
-        Error (Llm_provider.Http_client.HttpError { code = 500; body = "down" })
+        Error
+          (Llm_provider.Http_client.HttpError
+             { code = 500; body = "down"; retry_after_header = None })
       in
       let raw =
         Eio_main.run (fun env ->
@@ -814,7 +818,7 @@ let test_non_retryable_provider_error_stops_without_trying_next_runtime () =
         models := config.Llm_provider.Provider_config.model_id :: !models;
         Error
           (Llm_provider.Http_client.HttpError
-             { code = 401; body = "bad credentials" })
+             { code = 401; body = "bad credentials"; retry_after_header = None })
       in
       let raw =
         Eio_main.run (fun env ->

--- a/test/test_provider_http_error.ml
+++ b/test/test_provider_http_error.ml
@@ -20,7 +20,7 @@ let test_simple_variants () =
   msg "HttpError short body -> HTTP code: body" "HTTP 503: upstream down"
     (Provider_http_error.to_message
        (Llm_provider.Http_client.HttpError
-          { code = 503; body = "upstream down" }))
+          { code = 503; body = "upstream down"; retry_after_header = None }))
 
 let test_http_body_truncation () =
   let body = String.make (Provider_http_error.max_body_length + 50) 'x' in
@@ -31,7 +31,8 @@ let test_http_body_truncation () =
   in
   msg "HTTP body > max_body_length truncated with ellipsis" expected
     (Provider_http_error.to_message
-       (Llm_provider.Http_client.HttpError { code = 500; body }))
+       (Llm_provider.Http_client.HttpError
+          { code = 500; body; retry_after_header = None }))
 
 let () =
   Alcotest.run "provider_http_error"

--- a/test/test_runtime_attempt_fsm.ml
+++ b/test/test_runtime_attempt_fsm.ml
@@ -9,7 +9,7 @@
 open Runtime_attempt_fsm
 
 let mk_http_err ?(code = 429) ?(body = "") () =
-  Llm_provider.Http_client.HttpError { code; body }
+  Llm_provider.Http_client.HttpError { code; body; retry_after_header = None }
 
 let mk_network_err ?(message = "net err") () =
   Llm_provider.Http_client.NetworkError

--- a/test/test_tool_bridge_externalize.ml
+++ b/test/test_tool_bridge_externalize.ml
@@ -216,7 +216,12 @@ let test_execution_env_preserves_exact_invocation () =
     Agent_sdk.Tool.Invocation.create
       ~tool_use_id:""
       ~turn:7
-      ~planned_index:2
+      ~schedule:
+        { planned_index = 2
+        ; batch_index = 0
+        ; batch_size = 1
+        ; execution_mode = Agent_sdk.Tool.Serial
+        }
   in
   (match Agent_sdk.Tool.execute ~invocation tool (`Assoc []) with
    | Ok _ -> ()


### PR DESCRIPTION
## Problem

MASC pinned OAS/`agent_sdk` v0.216.0, but main still destructured the removed flat `tool_use_id`, `turn`, and `schedule` fields from hook/event records. It also constructed the expanded `HttpError` record without explicit retry-header evidence. The authoritative main CI failed in Build, Lint, and Health.

#25082 landed a partial emergency repair while this PR was in progress, but its own full checks were cancelled and the next main CI remained red on `PostToolUse.tool_use_id` plus another incomplete `HttpError` constructor. This PR is rebased on that merge and retains only the complete consumer migration and occurrence-observation improvements.

## Change

- consume the single `Tool.Invocation.t` authority in keeper hooks and the native event bridge
- derive `tool_use_id`, `turn`, and `planned_index` from that exact invocation
- include exact occurrence coordinates in `tool_called` and `tool_completed` SSE payloads
- preserve the existing empty provider-ID compatibility behavior
- construct `HttpError` with explicit `retry_after_header = None` where MASC has no header evidence
- update event/hook fixtures to construct one canonical invocation

## Validation

- `ocamlformat 0.29.0 --check` on all 12 touched OCaml files
- `git diff --check`
- `scripts/dune-local.sh build` completed all six focused executable targets against the v0.216.0 pin
- focused executables green: keeper execution join 10/10, hook introspection 5/5, unified turn event bus 13/13, runtime attempt FSM 23/23, provider HTTP error 2/2, keeper vision assertions green

The repository-wide `@fmt` target also reports pre-existing drift in untouched `dune` files; none are included in this change.

## Evidence

Failed main CI run: https://github.com/jeong-sik/masc/actions/runs/29562805847

Failed post-#25082 main CI run: https://github.com/jeong-sik/masc/actions/runs/29564569082

Observed v0.216.0 compile failures:

- `keeper_event_bridge.ml`: removed `ToolCalled.tool_use_id`
- `keeper_hooks_oas.ml`: removed `PreToolUse.turn`
- `keeper_runtime_attempt.ml`: required `HttpError.retry_after_header`

## Boundary

This is a consumer migration to OAS's canonical public types. It does not reach into OAS private modules, add a parallel identity, or infer identity from strings.
