### PR TITLE
refactor(memory)!: defer endpoint admission to OAS

### DIFF
--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -65,74 +65,6 @@ let with_provider_slot ~keeper_id ~clock:_ f =
         (fun () -> Some (f ()))
 ;;
 
-(* masc#25052 P3: process-global per-RUNTIME slot, additive to (not a
-   replacement for) the per-keeper slot above. RFC-0257 fixed keeper
-   starvation by giving each keeper its own capacity-1 budget, but that
-   means N keepers can each hold their OWN slot and call the SAME shared
-   runtime (e.g. a single local model declared max_concurrent=1)
-   concurrently -- the runtime's own declared concurrency ceiling was never
-   enforced, only the per-keeper one was. This gate is keyed by [runtime_id]
-   and sized from the runtime's own [binding.max_concurrent] declaration
-   (mirrors Hitl_summary_worker.effective_max_concurrency's shape: the
-   runtime's declaration is authoritative, not a separately configured
-   default). A runtime that declares no [max_concurrent] gets capacity 0
-   here, which disables the gate entirely -- unchanged behavior for runtimes
-   that never asked for a cap.
-
-   oas#2641 (Provider_config.max_concurrent_requests, applied at binding
-   construction) is the eventual convergence point once the pinned agent_sdk
-   reaches it; this worktree is pinned to v0.215.0 (pre-#2641), so the gate
-   lives here in MASC in the meantime. *)
-let runtime_slots_mu = Eio.Mutex.create ()
-let runtime_slots : (string, provider_slot) Hashtbl.t = Hashtbl.create 16
-
-let runtime_slot_capacity ~runtime_id =
-  match Runtime.get_runtime_by_id runtime_id with
-  | Some runtime ->
-    (* Closed mapping, not a permissive default: runtime_toml rejects
-       non-positive max-concurrent at parse ("0 was historically used as an
-       omission sentinel", runtime_toml.ml ~:782), so [Some 0] is unreachable
-       here and 0 unambiguously encodes "no declared bound = gate disabled"
-       (see the .mli contract for with_runtime_slot). *)
-    (* DET-OK: None -> 0 is the closed gate-disabled encoding above. *)
-    Option.value runtime.Runtime.binding.max_concurrent ~default:0
-  | None -> 0
-;;
-
-let runtime_slot_for ~runtime_id capacity =
-  Eio_guard.with_mutex runtime_slots_mu (fun () ->
-    match Hashtbl.find_opt runtime_slots runtime_id with
-    | Some slot when slot.capacity = capacity -> slot
-    | _ ->
-      let slot = { capacity; in_use = 0 } in
-      Hashtbl.replace runtime_slots runtime_id slot;
-      slot)
-;;
-
-let with_runtime_slot ~runtime_id f =
-  let capacity = runtime_slot_capacity ~runtime_id in
-  if capacity <= 0
-  then Some (f ())
-  else (
-    let slot = runtime_slot_for ~runtime_id capacity in
-    let acquired =
-      Eio_guard.with_mutex runtime_slots_mu (fun () ->
-        if slot.in_use >= slot.capacity
-        then false
-        else (
-          slot.in_use <- slot.in_use + 1;
-          true))
-    in
-    if not acquired
-    then None
-    else
-      Fun.protect
-        ~finally:(fun () ->
-          Eio_guard.with_mutex runtime_slots_mu (fun () ->
-            slot.in_use <- Int.max 0 (slot.in_use - 1)))
-        (fun () -> Some (f ())))
-;;
-
 let enabled () =
   (* Default on: a keeper without conversation ingestion is the pathology
      the Memory OS exists to fix (2026-06-12 diagnosis, issue #20909).
@@ -622,16 +554,15 @@ let run_best_effort ?complete ~runtime_id ~keeper_id (inp : Keeper_librarian.inp
              | Some clock -> (
              match
                with_provider_slot ~keeper_id ~clock (fun () ->
-                 with_runtime_slot ~runtime_id (fun () ->
-                   extract_and_append_with_provider_classified
-                     ?complete
-                     ~clock
-                     ~sw
-                     ~net
-                     ~keeper_id
-                     ~runtime_id
-                     ~provider_cfg
-                     inp))
+                 extract_and_append_with_provider_classified
+                   ?complete
+                   ~clock
+                   ~sw
+                   ~net
+                   ~keeper_id
+                   ~runtime_id
+                   ~provider_cfg
+                   inp)
              with
              | None ->
                Otel_metric_store.inc_counter
@@ -643,26 +574,14 @@ let run_best_effort ?complete ~runtime_id ~keeper_id (inp : Keeper_librarian.inp
                  "memory os librarian skipped runtime=%s: per-keeper provider slot busy (capacity=%d)"
                  runtime_id
                  (per_keeper_slot_capacity ())
-             | Some None ->
-               (* Per-keeper slot acquired, but the shared runtime's declared
-                  max_concurrent is already saturated by other keepers. *)
-               Otel_metric_store.inc_counter
-                 Keeper_metrics.(to_string MemoryOsLibrarianRuntimeSlotBusy)
-                 ~labels:[ "keeper", keeper_id; "runtime_id", runtime_id ]
-                 ();
-               Log.Keeper.warn ~keeper_name:keeper_id
-                 "memory os librarian skipped runtime=%s: shared runtime provider slot busy \
-                  (capacity=%d)"
-                 runtime_id
-                 (runtime_slot_capacity ~runtime_id)
-             | Some (Some (Ok episode)) ->
+             | Some (Ok episode) ->
                cadence_record_success ~keeper_id ~trace_id:inp.trace_id;
                Log.Keeper.info ~keeper_name:keeper_id
                  "memory os librarian wrote episode trace_id=%s generation=%d claims=%d"
                  episode.Keeper_memory_os_types.trace_id
                  episode.generation
                  (List.length episode.claims)
-             | Some (Some (Error err)) ->
+             | Some (Error err) ->
                Otel_metric_store.inc_counter
                  Keeper_metrics.(to_string EpisodeCreateFailures)
                  ~labels:[ "keeper", keeper_id; "site", "memory_os_librarian" ]

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -106,7 +106,8 @@ val provider_for_librarian
     the librarian output budget (default 4096, overridable with
     [MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_TOKENS], floor 1) and requests the
     structured episode output schema. The selected provider config's exact
-    temperature is preserved, including omission. *)
+    temperature and [max_concurrent_requests] are preserved, including
+    omission. OAS [Complete] remains the single endpoint admission owner. *)
 
 type extraction_error =
   | Prompt_render_failed of string
@@ -142,23 +143,6 @@ val with_provider_slot
     provider slot registry is guarded through [Eio_guard.with_mutex], avoiding
     blocking stdlib locks on keeper runtime fibers. Exposed for storm-guard
     regression coverage (#21376). *)
-
-val runtime_slot_capacity : runtime_id:string -> int
-(** [runtime_id]'s declared concurrency ceiling (its [Runtime.t.binding
-    .max_concurrent]), or [0] when the runtime declares none. [0] means
-    {!with_runtime_slot} applies no additional gate for that runtime. *)
-
-val with_runtime_slot : runtime_id:string -> (unit -> 'a) -> 'a option
-(** Run [f] under a process-global slot keyed by [runtime_id], sized by
-    {!runtime_slot_capacity}. Additive to {!with_provider_slot}, not a
-    replacement: the per-keeper slot bounds one keeper's own concurrency,
-    this bounds the SHARED runtime's declared concurrency across all
-    keepers (masc#25052 P3 -- RFC-0257's per-keeper slot alone lets N
-    keepers each call the same capacity-1 local runtime concurrently). At
-    capacity 0 (no declared [max_concurrent]) [f] always runs ([Some]);
-    otherwise the (capacity+1)-th concurrent entrant across all keepers
-    returns [None] (drop, not block). Exposed for concurrency-bound
-    regression coverage. *)
 
 val librarian_provider_clock_unavailable_error : string
 (** Stable error returned before provider I/O when provider-backed librarian
@@ -226,4 +210,5 @@ val run_best_effort
   -> unit
 (** Run the opt-in post-turn librarian path.
 
-    Non-cancel failures are logged and counted, never raised. *)
+    Non-cancel failures are logged and counted, never raised. Runtime dispatch
+    uses OAS endpoint admission; this path adds no runtime-wide MASC slot. *)

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -198,7 +198,6 @@ type t =
   | MemoryOsRecallEpisodesTruncated
   | MemoryOsRecallBytesOverBudget
   | MemoryOsEpisodeRetentionPruned
-  | MemoryOsLibrarianRuntimeSlotBusy
   | RuntimeHttpProbeJsonParseFailures
   | VisionAnalyze
   | VisionCandidateAttempts
@@ -432,8 +431,6 @@ let to_string = function
       "masc_keeper_memory_os_recall_bytes_over_budget_total"
   | MemoryOsEpisodeRetentionPruned ->
       "masc_keeper_memory_os_episode_retention_pruned_total"
-  | MemoryOsLibrarianRuntimeSlotBusy ->
-      "masc_keeper_memory_os_librarian_runtime_slot_busy_total"
   | RuntimeHttpProbeJsonParseFailures ->
       "masc_runtime_http_probe_json_parse_failures_total"
   | VisionAnalyze -> "masc_keeper_vision_analyze_total"

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -189,7 +189,6 @@ type t =
   | MemoryOsRecallEpisodesTruncated
   | MemoryOsRecallBytesOverBudget
   | MemoryOsEpisodeRetentionPruned
-  | MemoryOsLibrarianRuntimeSlotBusy
   | RuntimeHttpProbeJsonParseFailures
   | VisionAnalyze
   | VisionCandidateAttempts

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -854,6 +854,20 @@ let test_memory_provider_configs_use_runtime_temperature () =
         consolidation.temperature)
 ;;
 
+let test_librarian_provider_config_preserves_provider_admission () =
+  let projected max_concurrent_requests =
+    Librarian_runtime.provider_for_librarian
+      { (test_provider_cfg ()) with max_concurrent_requests }
+  in
+  List.iter
+    (fun expected ->
+       Alcotest.(check (option int))
+         "librarian projection preserves OAS provider admission"
+         expected
+         (projected expected).max_concurrent_requests)
+    [ None; Some 5 ]
+;;
+
 let with_memory_os_env name value f =
   let old = Sys.getenv_opt name in
   Unix.putenv name value;
@@ -3501,149 +3515,6 @@ let test_librarian_provider_slot_gate_is_per_keeper () =
         !first))
 ;;
 
-(* masc#25052 P3: process-global per-runtime slot, additive to the
-   per-keeper slot above. Capacity comes from the loaded runtime binding's
-   [max-concurrent], not an env var. *)
-let memory_runtime_max_concurrent_1_toml =
-  {|
-[runtime]
-default = "p0.default"
-
-[providers.p0]
-protocol = "openai-compatible-http"
-endpoint = "https://p0.example/v1"
-
-[models.default]
-api-name = "default"
-max-context = 4096
-temperature = 1.0
-
-[p0.default]
-max-concurrent = 1
-|}
-;;
-
-let memory_runtime_two_max_concurrent_1_toml =
-  {|
-[runtime]
-default = "p0.default"
-
-[providers.p0]
-protocol = "openai-compatible-http"
-endpoint = "https://p0.example/v1"
-
-[models.default]
-api-name = "default"
-max-context = 4096
-temperature = 1.0
-
-[models.alt]
-api-name = "alt"
-max-context = 4096
-temperature = 1.0
-
-[p0.default]
-max-concurrent = 1
-
-[p0.alt]
-max-concurrent = 1
-|}
-;;
-
-let test_librarian_runtime_slot_gate_caps_at_declared_capacity () =
-  with_runtime_config_toml memory_runtime_max_concurrent_1_toml (fun () ->
-    with_eio (fun ~sw ~net:_ ~clock ->
-      (* [max-concurrent = 1] in the loaded binding: while one entrant holds
-         the runtime slot, a concurrent entrant for the SAME runtime_id
-         drops ([None]) instead of blocking. *)
-      let entered, resolve_entered = Eio.Promise.create () in
-      let release, resolve_release = Eio.Promise.create () in
-      let first = ref None in
-      Eio.Fiber.fork ~sw (fun () ->
-        first
-        := Some
-             (Librarian_runtime.with_runtime_slot ~runtime_id:"p0.default" (fun () ->
-                Eio.Promise.resolve resolve_entered ();
-                Eio.Promise.await release;
-                "ran")));
-      Eio.Promise.await entered;
-      let second =
-        Librarian_runtime.with_runtime_slot ~runtime_id:"p0.default" (fun () -> "ran")
-      in
-      Eio.Promise.resolve resolve_release ();
-      wait_for_ref ~clock "first runtime slot holder" first;
-      Alcotest.(check (option string))
-        "concurrent entrant drops at the runtime's declared capacity"
-        None
-        second;
-      Alcotest.(check (option (option string)))
-        "slot holder ran"
-        (Some (Some "ran"))
-        !first))
-;;
-
-let test_librarian_runtime_slot_gate_disabled_when_undeclared () =
-  (* [memory_runtime_resolution_toml]'s [p0.default] binding declares no
-     [max-concurrent] -> capacity 0 -> the gate is a no-op, both run. *)
-  with_runtime_config_toml memory_runtime_resolution_toml (fun () ->
-    with_eio (fun ~sw ~net:_ ~clock ->
-      let entered, resolve_entered = Eio.Promise.create () in
-      let release, resolve_release = Eio.Promise.create () in
-      let first = ref None in
-      Eio.Fiber.fork ~sw (fun () ->
-        first
-        := Some
-             (Librarian_runtime.with_runtime_slot ~runtime_id:"p0.default" (fun () ->
-                Eio.Promise.resolve resolve_entered ();
-                Eio.Promise.await release;
-                "ran")));
-      Eio.Promise.await entered;
-      let second =
-        Librarian_runtime.with_runtime_slot ~runtime_id:"p0.default" (fun () -> "ran")
-      in
-      Eio.Promise.resolve resolve_release ();
-      wait_for_ref ~clock "first runtime slot holder" first;
-      Alcotest.(check (option string))
-        "no declared cap: concurrent entrant also ran"
-        (Some "ran")
-        second;
-      Alcotest.(check (option (option string)))
-        "slot holder ran"
-        (Some (Some "ran"))
-        !first))
-;;
-
-let test_librarian_runtime_slot_gate_is_per_runtime () =
-  with_runtime_config_toml memory_runtime_two_max_concurrent_1_toml (fun () ->
-    with_eio (fun ~sw ~net:_ ~clock ->
-      (* A slot held for runtime "p0.default" must not block runtime
-         "p0.alt", even though both declare the same capacity. *)
-      let entered, resolve_entered = Eio.Promise.create () in
-      let release, resolve_release = Eio.Promise.create () in
-      let first = ref None in
-      Eio.Fiber.fork ~sw (fun () ->
-        first
-        := Some
-             (Librarian_runtime.with_runtime_slot ~runtime_id:"p0.default" (fun () ->
-                Eio.Promise.resolve resolve_entered ();
-                Eio.Promise.await release;
-                "ran")));
-      Eio.Promise.await entered;
-      let other_runtime =
-        Librarian_runtime.with_runtime_slot ~runtime_id:"p0.alt" (fun () -> "ran")
-      in
-      Eio.Promise.resolve resolve_release ();
-      wait_for_ref ~clock "first runtime slot holder" first;
-      Alcotest.(check (option string))
-        "different runtime_id runs despite the other's capacity held"
-        (Some "ran")
-        other_runtime;
-      Alcotest.(check (option (option string)))
-        "slot holder ran"
-        (Some (Some "ran"))
-        !first))
-;;
-
 (* ---------- Explicit validity only ---------- *)
 
 let test_fact_validity_uses_only_stored_value () =
@@ -5053,17 +4924,9 @@ let () =
             `Quick
             test_librarian_provider_slot_gate_is_per_keeper
         ; Alcotest.test_case
-            "runtime slot gate caps at the declared max-concurrent"
+            "provider projection preserves OAS admission"
             `Quick
-            test_librarian_runtime_slot_gate_caps_at_declared_capacity
-        ; Alcotest.test_case
-            "runtime slot gate is a no-op when no max-concurrent is declared"
-            `Quick
-            test_librarian_runtime_slot_gate_disabled_when_undeclared
-        ; Alcotest.test_case
-            "runtime slot gate isolates runtimes"
-            `Quick
-            test_librarian_runtime_slot_gate_is_per_runtime
+            test_librarian_provider_config_preserves_provider_admission
         ] )
     ; ( "rfc-0259 volatile"
       , [ Alcotest.test_case


### PR DESCRIPTION
## Summary
- delete the runtime-id keyed Librarian slot that dropped work at saturation
- remove its duplicate busy metric and obsolete tests
- prove the Librarian provider projection retains the OAS admission declaration

## Why
The deleted slot keyed admission by MASC runtime ID and returned `None` when busy, so aliases could bypass it and work could be lost. OAS owns the real endpoint/account FIFO and waits without dropping the request.

## Validation
- `ocamlformat --check`
- `git diff --check`
- removed-symbol residue search: zero
- focused/full Dune delegated to PR CI because shared repo locks are active

Stacked on the candidate-collapse leaf. Exact leaf: 299 changed lines.