### PR TITLE
fix(ci): restore per-base staleness scope for stacked PRs

### DIFF
--- a/.github/workflows/pr-axis-check.yml
+++ b/.github/workflows/pr-axis-check.yml
@@ -2,7 +2,11 @@ name: PR Axis Cross-Check
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    # `edited` re-runs the check when a parent merge auto-retargets a stacked
+    # child's base branch (base change arrives as an `edited` event); the job
+    # is a single API-driven script, so the extra runs on title/body edits
+    # are cheap and cancelled by the concurrency group.
+    types: [opened, synchronize, reopened, edited]
   workflow_dispatch:
     inputs:
       pr_number:

--- a/scripts/pr_axis_check.py
+++ b/scripts/pr_axis_check.py
@@ -194,22 +194,14 @@ def get_repo_slug() -> Tuple[str, str]:
     return data["owner"]["login"], data["name"]
 
 
-def get_default_branch(owner: str, repo: str) -> str:
-    """Read the repository default branch from GitHub metadata."""
-    resp = _run_gh([f"/repos/{owner}/{repo}"])
-    default_branch = resp.get("default_branch") if isinstance(resp, dict) else None
-    if not isinstance(default_branch, str) or not default_branch:
-        print(
-            f"GitHub metadata has no default branch for {owner}/{repo}.",
-            file=sys.stderr,
-        )
-        sys.exit(2)
-    return default_branch
-
-
-def should_scan_axis_staleness(pr_base_ref: str, default_branch: str) -> bool:
-    """Only PRs targeting the repository default branch own mainline staleness."""
-    return pr_base_ref == default_branch
+def merged_pr_in_scope(pr_base_ref: Optional[str], merged_base_ref: Optional[str]) -> bool:
+    """A merged PR is comparison-relevant only when it landed on the open PR's
+    own base branch: default-branch PRs compare against default-branch merges,
+    stacked PRs compare against sibling merges into the same parent branch.
+    Missing refs stay in scope (conservative: never silently drop a signal)."""
+    if not pr_base_ref or not merged_base_ref:
+        return True
+    return merged_base_ref == pr_base_ref
 
 
 def get_pr_base_info(
@@ -339,7 +331,6 @@ def check_pr_axis_stale(
     pr_number: int,
     owner: str,
     repo: str,
-    default_branch: str,
     hours: int = 24,
     limit: int = 20,
 ) -> List[AxisRisk]:
@@ -348,8 +339,6 @@ def check_pr_axis_stale(
     if not pr_base_ref:
         print(f"Could not determine base ref for PR #{pr_number}.", file=sys.stderr)
         sys.exit(2)
-    if not should_scan_axis_staleness(pr_base_ref, default_branch):
-        return []
 
     open_files = get_pr_files(pr_number, owner, repo)
     if not open_files:
@@ -378,12 +367,10 @@ def check_pr_axis_stale(
         if not overlap:
             continue
 
-        # This guard is about stale PRs caused by recent merges into the same
-        # target branch. Stacked PRs can be merged into another feature branch;
-        # treating those as mainline merges creates a false BUILD_DEP_BREAK
-        # blocker for their own base PR.
-        merged_base_ref = merged.get("baseRefName")
-        if pr_base_ref and merged_base_ref and merged_base_ref != pr_base_ref:
+        # Staleness is scoped per base branch: a default-branch PR compares
+        # against default-branch merges, a stacked PR against sibling merges
+        # into the same parent branch (the #25063/#25044 incident class).
+        if not merged_pr_in_scope(pr_base_ref, merged.get("baseRefName")):
             continue
 
         # Skip if the merged PR is already included in the current PR's base.
@@ -436,7 +423,7 @@ def check_pr_axis_stale(
 
 
 def scan_all_open_prs(
-    owner: str, repo: str, default_branch: str, hours: int, limit: int
+    owner: str, repo: str, hours: int, limit: int
 ) -> Dict[int, List[AxisRisk]]:
     """Scan all open PRs for axis risks."""
     query = f"""
@@ -464,7 +451,7 @@ query {{
     for pr in open_prs:
         pr_num = pr["number"]
         print(f"Scanning PR #{pr_num}: {pr['title']}", file=sys.stderr)
-        risks = check_pr_axis_stale(pr_num, owner, repo, default_branch, hours, limit)
+        risks = check_pr_axis_stale(pr_num, owner, repo, hours, limit)
         if risks:
             results[pr_num] = risks
 
@@ -590,9 +577,18 @@ def self_test() -> int:
     assert detect_rfc_collisions(noise) == [], "non-RFC-claim paths must not collide"
     print("self-test: non-RFC paths ignored -> no collision (PASS)")
 
-    assert should_scan_axis_staleness("trunk", "trunk")
-    assert not should_scan_axis_staleness("stack-parent", "trunk")
-    print("self-test: default base scanned, stacked child skipped (PASS)")
+    assert merged_pr_in_scope("trunk", "trunk"), "same-base merge is in scope"
+    assert not merged_pr_in_scope("trunk", "stack-parent"), (
+        "merge into another branch is out of scope for a trunk PR"
+    )
+    assert merged_pr_in_scope("stack-parent", "stack-parent"), (
+        "sibling merge into the same parent branch is in scope for a stacked PR"
+    )
+    assert not merged_pr_in_scope("stack-parent", "trunk"), (
+        "trunk merge is out of scope for a stacked PR (parent PR owns it)"
+    )
+    assert merged_pr_in_scope(None, "trunk"), "missing base ref stays in scope"
+    print("self-test: per-base staleness scope incl. stacked siblings (PASS)")
 
     print("pr_axis_check self-test: all structural cases passed")
     return 0
@@ -646,13 +642,11 @@ def main() -> int:
         print("No RFC number collisions among open PRs.")
         return 0
 
-    default_branch = get_default_branch(owner, repo)
-
     def _block(r: AxisRisk) -> bool:
         return r.confidence != "LOW"
 
     if args.scan_all_open:
-        results = scan_all_open_prs(owner, repo, default_branch, args.hours, args.limit)
+        results = scan_all_open_prs(owner, repo, args.hours, args.limit)
         # Partition into blockers vs warnings
         blockers: Dict[int, List[AxisRisk]] = {}
         warnings: Dict[int, List[AxisRisk]] = {}
@@ -704,9 +698,7 @@ def main() -> int:
     if not args.pr:
         parser.error("Either --pr or --scan-all-open is required")
 
-    single_risks = check_pr_axis_stale(
-        args.pr, owner, repo, default_branch, args.hours, args.limit
-    )
+    single_risks = check_pr_axis_stale(args.pr, owner, repo, args.hours, args.limit)
     single_blockers = [r for r in single_risks if _block(r)]
     single_warnings = [r for r in single_risks if not _block(r)]
 


### PR DESCRIPTION
## What
#25070이 도입한 "base≠default branch면 axis staleness 검사 전체 스킵"을 **base별 스코프**로 교체한다:

- PR은 **자기 base 브랜치에 착지한 머지만** 비교한다. base=main PR은 #25070 이전과 동일 동작, 스택 PR은 같은 부모 브랜치로 머지된 **형제 감지가 복원**된다.
- `merged_pr_in_scope` 순수 함수로 추출하고 self-test 5케이스로 고정 (실행 확인: 전부 PASS).
- 워크플로 `types`에 `edited` 추가 — 부모 머지로 자식 base가 main으로 자동 재타겟될 때 재실행. 이 job은 API 스크립트 하나라 title/body 수정 재실행 비용은 무시 가능(concurrency cancel 존재).
- `get_default_branch`/`should_scan_axis_staleness`는 스킵 전용 배관이라 죽은 코드로 제거.

## Why (#25076)
#25070의 전제("#25063 false positive")는 성립하지 않았다 — ancestry 분석 결과 #25063에 대한 #25044 플래그는 **진짜 base drift**였다 (오늘 #25063이 실제로 stale rebase 상태였음이 별도 리뷰에서 확인됨). 진짜 false positive(이미 base에 포함된 머지)는 기존 `merge_commit_already_in_base` 가드가 정확히 걸러낸다. 전체 스킵은 오늘 06:09~06:11Z에 실제 발생한 스택 내부 형제 머지(#25057/#25058/#25060) 시나리오를 무풍지대로 만들었다.

## 검증
- `python3 scripts/pr_axis_check.py --self-test` 전부 PASS (신규 scope 케이스 5개 포함).
- 나머지는 CI에서 확인.

## 연관
- #25076 (이 PR이 닫음), #25070 (스코프 축소 원인 PR), #24374 (stacked PR job 미생성 — 별개 갭, 이 PR 범위 아님).

Closes #25076.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvELzG8FNa99yDKAs8Yz3A
