### PR TITLE
fix(keeper): preserve attention work across fair batch admissions

### DIFF
--- a/docs/design/2026-07-17-keeper-mixed-workload-operation-goal-matrix.html
+++ b/docs/design/2026-07-17-keeper-mixed-workload-operation-goal-matrix.html
@@ -1,0 +1,465 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>MASC Keeper 10-Lane Mixed Workload Operation Goal Matrix</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #071018;
+      --panel: #0d1a24;
+      --panel-2: #122331;
+      --line: #294154;
+      --text: #e9f1f7;
+      --muted: #9fb1be;
+      --cyan: #54d6d2;
+      --green: #73e2a7;
+      --amber: #ffc857;
+      --red: #ff6b6b;
+      --blue: #79a8ff;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background:
+        radial-gradient(circle at 18% 0%, rgba(84, 214, 210, .12), transparent 32rem),
+        radial-gradient(circle at 90% 18%, rgba(121, 168, 255, .10), transparent 28rem),
+        var(--bg);
+      color: var(--text);
+      font: 15px/1.55 ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    main { max-width: 1480px; margin: 0 auto; padding: 38px 24px 80px; }
+    h1, h2, h3 { line-height: 1.22; letter-spacing: -.025em; }
+    h1 { margin: 0 0 12px; font-size: clamp(32px, 5vw, 58px); }
+    h2 { margin: 56px 0 18px; font-size: 28px; }
+    h3 { margin: 24px 0 10px; font-size: 19px; color: var(--cyan); }
+    p { margin: 8px 0 14px; }
+    code, pre { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    code { color: #b9f4ef; }
+    pre {
+      margin: 12px 0;
+      padding: 16px;
+      overflow: auto;
+      border: 1px solid var(--line);
+      border-radius: 12px;
+      background: #08131c;
+      color: #d9e7ef;
+    }
+    a { color: var(--cyan); }
+    .eyebrow { color: var(--cyan); text-transform: uppercase; letter-spacing: .16em; font-weight: 750; }
+    .lede { max-width: 980px; color: #c8d8e2; font-size: 19px; }
+    .stamp { color: var(--muted); font-size: 13px; }
+    .banner {
+      margin: 28px 0;
+      padding: 20px 22px;
+      border: 1px solid #7a3f45;
+      border-left: 5px solid var(--red);
+      border-radius: 12px;
+      background: rgba(94, 31, 39, .28);
+    }
+    .banner strong { color: #ffd5d5; }
+    .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(205px, 1fr)); gap: 12px; }
+    .card {
+      min-height: 132px;
+      padding: 17px;
+      border: 1px solid var(--line);
+      border-radius: 14px;
+      background: linear-gradient(145deg, rgba(18, 35, 49, .95), rgba(10, 24, 34, .95));
+    }
+    .card .value { margin-top: 4px; font-size: 30px; font-weight: 800; color: var(--cyan); }
+    .card .label { color: var(--muted); }
+    .card.bad .value { color: var(--red); }
+    .card.warn .value { color: var(--amber); }
+    .card.good .value { color: var(--green); }
+    .grid-2 { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px; }
+    .panel { padding: 20px; border: 1px solid var(--line); border-radius: 14px; background: var(--panel); }
+    .flow { white-space: pre-wrap; color: #d4e5ee; }
+    .table-wrap { overflow-x: auto; border: 1px solid var(--line); border-radius: 14px; }
+    table { width: 100%; border-collapse: collapse; min-width: 1020px; background: rgba(13, 26, 36, .92); }
+    th, td { padding: 12px 13px; border-bottom: 1px solid var(--line); text-align: left; vertical-align: top; }
+    th { position: sticky; top: 0; z-index: 1; background: #152837; color: #d9f8f5; font-size: 13px; }
+    tr:last-child td { border-bottom: 0; }
+    .metric { white-space: nowrap; font-variant-numeric: tabular-nums; }
+    .tag { display: inline-block; margin: 2px 4px 2px 0; padding: 2px 8px; border-radius: 999px; border: 1px solid var(--line); font-size: 12px; }
+    .p0 { color: #ffd1d1; border-color: #8f4a52; background: #3b1c23; }
+    .p1 { color: #ffe3aa; border-color: #85692a; background: #332a15; }
+    .p2 { color: #bde9ff; border-color: #376a82; background: #172d39; }
+    .ok { color: var(--green); }
+    .warn-text { color: var(--amber); }
+    .bad-text { color: var(--red); }
+    .muted { color: var(--muted); }
+    ol, ul { padding-left: 22px; }
+    li { margin: 6px 0; }
+    .phase { border-left: 4px solid var(--blue); }
+    .invariant { border-left: 4px solid var(--green); }
+    .decision { border-left: 4px solid var(--amber); }
+    .small { font-size: 13px; }
+    @media (max-width: 850px) {
+      main { padding: 24px 14px 60px; }
+      .grid-2 { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+<main>
+  <div class="eyebrow">MASC 1.0 / Executable strategy</div>
+  <h1>10 Keeper Mixed-Workload<br>Operation Goal Matrix</h1>
+  <p class="lede">10개 Keeper가 Discord·Slack·Dashboard·Voice에서 동시에 대화하고, 서로 협업하며, 코드 작성·정보 수집·이미지 생성·장기 작업·메모리 기록·컴팩션을 수행하는 상황을 대상으로 한다. 목표는 평균 처리량이 아니라 <strong>직접 요청의 반응성, 영속 복구, lane 공정성, 자원 상한, 감사 가능한 상태 전이</strong>를 동시에 만족하는 것이다.</p>
+  <p class="stamp">Baseline captured: 2026-07-17 16:28 KST · repo/runtime commit cd9b4f655d · PR target #25073 head 63c58e47d3</p>
+
+  <div class="banner">
+    <strong>현재 판정: 혼합 부하 사용 불가.</strong> HTTP 서버는 응답했지만 13개 bootable Keeper 중 실행 fiber가 0이었고, 당시 16개 event queue가 모두 v2라 v3-only reader에서 거부됐다. 16:30 KST에 원본 snapshot이 외부 작업으로 v3로 변환되고 서버가 재시작 단계에 들어갔으므로, 아래 baseline은 변환 전 장애 상태와 변환 직전 backlog를 고정한 것이다. v3 재기동 검증 전에는 “복구 완료”로 계산하지 않는다.
+  </div>
+
+  <section>
+    <h2>1. Live baseline</h2>
+    <div class="cards">
+      <div class="card bad"><div class="label">Executable Keeper fibers</div><div class="value">0 / 13</div><div>목표 시나리오 10개를 실행할 capacity가 0</div></div>
+      <div class="card bad"><div class="label">Event queue read errors</div><div class="value">16 / 16</div><div>v2 snapshot을 v3-only reader가 거부</div></div>
+      <div class="card warn"><div class="label">Attention candidates</div><div class="value">3,644</div><div>520개 고유 signal이 평균 7.01배 증폭</div></div>
+      <div class="card warn"><div class="label">Pending attention</div><div class="value">890</div><div>439 + 451, age 약 15.3시간</div></div>
+      <div class="card warn"><div class="label">Candidate ledger</div><div class="value">38 MB</div><div>전체 request JSON 26.18 MB</div></div>
+      <div class="card"><div class="label">Health endpoint p50 / p95</div><div class="value">3.6 / 16.7 ms</div><div>20회 cache-hit 측정; 제품 실행 가능성 증거는 아님</div></div>
+      <div class="card warn"><div class="label">Full health recompute</div><div class="value">4.2 s</div><div>snapshot refresh 자체 비용</div></div>
+      <div class="card"><div class="label">Historical relevance</div><div class="value">48.1%</div><div>1,325 relevant / 2,754 consumed</div></div>
+    </div>
+    <p class="small muted">정확한 원본 수치: unique signals 520, candidate fan-out p50 6 / p95 14 / max 14, consumed irrelevant 1,429(51.9%), pending 890, batch request max 208,369 bytes. bytes를 token으로 임의 환산하지 않는다.</p>
+  </section>
+
+  <section>
+    <h2>1.5 Product usefulness gate</h2>
+    <div class="banner">
+      <strong>고객 Job-to-be-done:</strong> 어느 채널에서 Keeper에게 일을 맡겨도 접수 사실을 즉시 알고, 다른 동시 작업 때문에 귀머거리가 되지 않으며, 결과 또는 구조화된 실패가 원래 채널로 정확히 한 번 돌아오고, 재시작·컴팩션 후에도 그 약속이 이어져야 한다. 내부 heartbeat나 HTTP 200은 고객 가치로 점수화하지 않는다.
+    </div>
+    <div class="table-wrap">
+      <table>
+        <thead><tr><th>제품 축</th><th>Weight</th><th>현재 관측</th><th>#25073 단독 효과</th><th>1.0 정량 gate</th></tr></thead>
+        <tbody>
+          <tr><td>실행 가능성</td><td>25%</td><td>0/13 executable → 0점</td><td>queue schema 장애를 고치지 않으므로 0점 유지</td><td>목표 10 Keeper 10/10 executable, 8시간 동안 fleet reaction capacity &gt; 0</td></tr>
+          <tr><td>End-to-end useful completion</td><td>25%</td><td>실행 fiber 0이라 측정 불가 → fail-closed 0점</td><td>attention 판정 비용만 줄이며 고객 결과 완료를 증명하지 않음</td><td>명시적 거절 제외 요청의 terminal receipt ≥ 99%, duplicate terminal effect = 0</td></tr>
+          <tr><td>직접 요청 반응성</td><td>15%</td><td>owner lane이 ambient provider call에 30–50초 점유될 수 있음</td><td>55/57 calls 연속 점유를 1 call/admission으로 제한; call 자체의 점유는 남음</td><td>enqueue→turn-start p95 ≤ 2s, 접수 응답 p95 ≤ 5s</td></tr>
+          <tr><td>채널·세션 연속성</td><td>15%</td><td>Discord presence만 alive; Slack/Voice E2E 미검증</td><td>영향 없음</td><td>Discord/Slack/Dashboard/Voice route accuracy 100%, restart replay 100%</td></tr>
+          <tr><td>무유실·판정 정확성</td><td>10%</td><td>blind TTL + partial verdict 무증거 Pending</td><td>TTL 제거, exact ID coverage, context cohort로 개선</td><td>silent discard = 0, cross-context batch = 0, 모든 defer에 typed evidence</td></tr>
+          <tr><td>운영자 신뢰</td><td>10%</td><td>health cache는 수 ms이나 fleet는 0</td><td>영향 없음</td><td>incomplete count를 green/zero로 투영한 횟수 = 0</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <p><strong>점수 공식:</strong> <code>Σ(weight × gate achievement)</code>. 각 gate는 통과 1 / 실패·Unknown 0으로 계산한다. 샘플이 없는 주장은 0점, HTTP 생존은 실행 가능성의 대체 지표가 아니다. 따라서 현재 live 제품 점수는 <strong>0.0 / 10</strong>이다. v3 fleet를 복구하고 본 follow-up의 무유실 계약까지 통과해도, completion·latency·channel·operator gate가 미검증이면 최대 <strong>3.5 / 10</strong>이다. 즉 #25073 계열만으로는 출시 점수 9.0에 도달하지 않는다.</p>
+    <p><strong>9.0 release floor:</strong> 위 6개 축의 가중 합 ≥ 9.0이고, 동시에 실행 가능성·terminal exactly-once·silent loss 세 hard gate가 모두 통과해야 한다. 평균 점수가 높아도 이 셋 중 하나가 0이면 출시 불가다.</p>
+  </section>
+
+  <section>
+    <h2>2. Scenario contract</h2>
+    <div class="table-wrap">
+      <table>
+        <thead><tr><th>Work class</th><th>실제 예</th><th>현재 소유 lane</th><th>실패 시 사용자 증상</th><th>1.0 계약</th></tr></thead>
+        <tbody>
+          <tr><td>Direct input</td><td>Discord/Slack/Dashboard mention, 승인 응답</td><td>Keeper turn admission + chat queue</td><td>ambient backlog 뒤에서 응답 지연</td><td>ambient보다 먼저 admission. enqueue→turn-start p95 ≤ 2s</td></tr>
+          <tr><td>Ambient attention</td><td>공개 Board post/comment/reaction의 의미 판정</td><td>현재 owner lane에서 provider 호출</td><td>한 Keeper가 수십 분 deaf</td><td>owner lane 밖의 judgment plane. owner는 판정 결과 commit만 수행</td></tr>
+          <tr><td>K2K collaboration</td><td>다른 Keeper의 post, task handoff, 검증 요청</td><td>Board/event queue</td><td>fan-out·중복·순서 역전</td><td>typed audience + durable identity + exactly-once settlement</td></tr>
+          <tr><td>Code/research job</td><td>긴 shell, repo 분석, 웹 조사</td><td>도구가 inline이면 turn fiber</td><td>작업 중 새 메시지에 반응 불가</td><td>spawn→durable result→wake. turn에서 blocking await 금지</td></tr>
+          <tr><td>Image generation</td><td>이미지 생성·분석·후속 수정</td><td>media-capable runtime/tool call</td><td>모델 capability 실패 또는 장시간 lane 점유</td><td>declared capability gate + background result handle</td></tr>
+          <tr><td>Voice</td><td>TTS/STT/session playback</td><td>voice bridge + per-agent session</td><td>playback lock·provider timeout·대화 lane 정지</td><td>voice session state와 turn state 분리, terminal result를 원 channel로 전달</td></tr>
+          <tr><td>Memory/compaction</td><td>post-turn memory, checkpoint, context overflow</td><td>post-turn / compaction admission</td><td>chat와 compaction이 서로 막는 priority inversion</td><td>checkpoint writer 단일 소유 + compaction reservation + 결과 재개</td></tr>
+          <tr><td>AFK catch-up</td><td>사용자가 명시적으로 Away, 야간 backlog 처리</td><td>현재 별도 계약 없음</td><td>idle 추정 오류 또는 무한 drain</td><td>명시적 persisted mode만 사용. 최근 입력시간으로 추정 금지</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section>
+    <h2>3. AS-IS control flow</h2>
+    <div class="grid-2">
+      <div class="panel">
+        <h3>Channel / Board ingress</h3>
+        <pre class="flow">Discord / Slack / Dashboard / Board
+        │
+        ├─ exact address ──► durable event queue
+        │                     │
+        │                     └─► Keeper owner admission
+        │
+        └─ no deterministic address
+              └─► candidate copied per Keeper
+                     └─► owner admission
+                            └─► structured judge call(s)
+                                   └─► durable event queue</pre>
+        <p>Semantic judgment가 owner admission 안에 있다. 느린 provider가 한 Keeper의 모든 입력·도구·메모리 진행을 막는다.</p>
+      </div>
+      <div class="panel">
+        <h3>Long-running tool work</h3>
+        <pre class="flow">Keeper turn
+   ├─ provider reasoning
+   ├─ code / research / voice / image tool
+   │      └─ inline wait이면 같은 turn 계속 점유
+   ├─ post-turn memory
+   └─ compaction / settlement
+
+다른 Keeper는 병렬 실행 가능
+같은 Keeper의 새 Discord/Slack 메시지는 대기</pre>
+        <p>10 Keeper는 10개 lane 병렬성이 있지만 각 Keeper 내부는 single-flight다. 한 lane의 장기 작업을 background job으로 분리하지 않으면 해당 인격은 작업 완료까지 deaf 상태다.</p>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>4. PR #25073 measured Before / After</h2>
+    <div class="table-wrap">
+      <table>
+        <thead><tr><th>Metric</th><th>Before: current main</th><th>PR #25073</th><th>Delta</th><th>남는 문제</th></tr></thead>
+        <tbody>
+          <tr><td>Pending candidates</td><td class="metric">890</td><td class="metric">890</td><td>상태량 동일</td><td>producer fan-out은 바뀌지 않음</td></tr>
+          <tr><td>Judge calls</td><td class="metric">890</td><td class="metric">112</td><td class="ok">−778 / −87.4%</td><td>55회와 57회를 각 owner turn 안에서 연속 실행</td></tr>
+          <tr><td>hitl-switch-verifier</td><td class="metric">439 calls</td><td class="metric">55 calls</td><td class="ok">7.98× 감소</td><td>30–50s/call이면 lane 27.5–45.8분 점유</td></tr>
+          <tr><td>idealist</td><td class="metric">451 calls</td><td class="metric">57 calls</td><td class="ok">7.91× 감소</td><td>30–50s/call이면 lane 28.5–47.5분 점유</td></tr>
+          <tr><td>Batch request bytes</td><td>single request 분포</td><td class="metric">p50 40–41KB<br>p95 70–99KB<br>max 208KB</td><td>request 수 감소</td><td>provider tokenizer/capability에 의한 admission 없음</td></tr>
+          <tr><td>Context integrity</td><td>candidate별 context</td><td>첫 candidate context 공유</td><td class="bad-text">회귀 가능</td><td>현재 890건은 keeper별 context 1종이라 이번 데이터에는 미발현</td></tr>
+          <tr><td>Expiry</td><td>없음</td><td>wall-clock 24h</td><td>backlog 상한</td><td>AFK/주말 종료와 장애를 구분하지 못하는 blind TTL</td></tr>
+          <tr><td>Ledger commits</td><td>candidate별 다중 whole-file rewrite</td><td>동일</td><td class="bad-text">개선 없음</td><td>batch verdict를 candidate별로 commit</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <p class="small muted">30–50초는 PR 본문의 2026-07-17 provider 관측 범위다. 이번 측정 시점에는 Keeper fiber가 0이라 live provider latency를 재측정할 수 없었다.</p>
+  </section>
+
+  <section>
+    <h2>5. TO-BE architecture</h2>
+    <div class="panel invariant">
+      <h3>Load-bearing invariant</h3>
+      <p><strong>Keeper owner admission에는 사용자 대화, 상태 결정, 짧은 durable commit만 들어간다.</strong> provider batch 판단, 이미지 생성, 장기 코드 실행, 리서치, 음성 합성은 job plane에서 실행하고 결과를 durable stimulus로 되돌린다.</p>
+    </div>
+    <pre class="flow">Typed ingress
+  ├─ Direct(channel, identity, thread) ───────────────┐
+  ├─ ThreadParticipant(...) ──────────────────────────┤
+  ├─ Broadcast(...) ──────────────────────────────────┤
+  └─ Discoverable(signal) ─► Attention Router         │
+                               │                       │
+                               ├─ provider capability  │
+                               ├─ exact token budget   │
+                               ├─ context fingerprint  │
+                               └─ durable judgments    │
+                                                       ▼
+                                          Per-Keeper Event Queue v3
+                                                       │
+                                                       ▼
+                                       Keeper owner admission (short)
+                                           ├─ decide / spawn job
+                                           ├─ commit checkpoint
+                                           └─ return admission
+                                                       │
+                       ┌───────────────────────────────┴───────────────┐
+                       ▼                                               ▼
+             Background Job Plane                             Memory / Compaction
+        code · research · image · voice              single checkpoint writer + reservation
+                       │                                               │
+                       └──────── durable completion stimulus ──────────┘</pre>
+  </section>
+
+  <section>
+    <h2>6. No-heuristic mechanism</h2>
+    <div class="grid-2">
+      <div class="panel decision">
+        <h3>AFK is explicit, never guessed</h3>
+        <pre>type operator_mode =
+  | Interactive
+  | Catch_up of { operation_id : Operation_id.t }
+
+type mode_source =
+  | Dashboard_operator
+  | Scheduled_operation
+  | Api_operator</pre>
+        <ul>
+          <li>“마지막 키보드 입력 후 N분”으로 Away를 추정하지 않는다.</li>
+          <li>Catch-up 시작/종료는 durable operation으로 기록한다.</li>
+          <li>어떤 mode에서도 direct queue가 존재하면 ambient worker는 owner admission을 얻지 않는다.</li>
+          <li>Catch-up은 provider permit을 늘릴 수 있지만 owner admission의 single-flight invariant는 깨지 않는다.</li>
+        </ul>
+      </div>
+      <div class="panel decision">
+        <h3>Batch capacity is declared, not guessed</h3>
+        <pre>type batch_budget =
+  { runtime_id : Runtime_id.t
+  ; max_context_tokens : int
+  ; max_output_tokens : int option
+  ; tokenizer : Provider_tokenizer.t
+  }
+
+Token_accounting_unavailable
+  ⇒ typed defer, never byte/4 fallback</pre>
+        <ul>
+          <li>model max-context는 Runtime/OAS capability SSOT에서 읽는다.</li>
+          <li>정확한 provider tokenizer가 없으면 batch admission을 거부한다.</li>
+          <li>candidate 개수 8이나 bytes/token 환산을 안전 근거로 사용하지 않는다.</li>
+          <li>output schema의 요청 ID 완전 일치가 아니면 typed partial failure다.</li>
+        </ul>
+      </div>
+    </div>
+
+    <h3>Typed work and state transitions</h3>
+    <pre>type work_class =
+  | Direct_input of Keeper_continuation_channel.t
+  | Approval_resolution
+  | Compaction_recovery
+  | Background_completion of Job_id.t
+  | Ambient_attention of Candidate_id.t
+
+type attention_state =
+  | Pending
+  | Leased of Lease.t
+  | Judged of Judgment.t
+  | Delivery_blocked of Durable_error.t
+  | Consumed of Receipt.t
+  | Superseded of Candidate_id.t
+
+type job_state =
+  | Submitted
+  | Running of Resource_lease.t
+  | Completed of Artifact_ref.t
+  | Failed of Job_error.t
+  | Cancelled of Cancellation_receipt.t</pre>
+    <p>TTL로 임의 폐기하지 않는다. 같은 의미 슬롯의 새 signal이 도착하면 <code>Superseded</code>, Task가 종료되면 명시적 lifecycle transition, 운영자가 폐기하면 operation receipt를 남긴다.</p>
+  </section>
+
+  <section>
+    <h2>7. Goal execution matrix</h2>
+    <div class="table-wrap">
+      <table>
+        <thead><tr><th>ID</th><th>Goal</th><th>Baseline</th><th>1.0 target</th><th>Metric / hard gate</th><th>Code owner</th><th>PR</th></tr></thead>
+        <tbody>
+          <tr><td><span class="tag p0">G0</span></td><td>v3 queue recovery</td><td>0 executable, 16 read errors</td><td>요청 시나리오 10/10 executable, read error 0</td><td><code>executable=10 ∧ schema_errors=0</code></td><td>event_queue_persistence, bootstrap</td><td>PR-0</td></tr>
+          <tr><td><span class="tag p0">G1</span></td><td>Direct responsiveness</td><td>ambient drain이 owner slot 장기 점유 가능</td><td>enqueue→turn-start p95 ≤ 2s</td><td>10-lane harness에서 direct latency p95</td><td>turn_admission, chat queue</td><td>PR-1</td></tr>
+          <tr><td><span class="tag p0">G2</span></td><td>One provider quantum per admission</td><td>55/57 calls 한 turn</td><td>admission당 provider call ≤ 1</td><td><code>max_calls_per_admission = 1</code></td><td>board_attention_candidate, heartbeat</td><td>PR-1</td></tr>
+          <tr><td><span class="tag p0">G3</span></td><td>No silent loss</td><td>missing verdict 무증거 Pending, blind TTL</td><td>silent drop 0, 모든 defer에 typed reason</td><td><code>requested_ids = terminal_ids ∪ deferred_ids</code></td><td>judgment contract</td><td>PR-1</td></tr>
+          <tr><td><span class="tag p1">G4</span></td><td>Context correctness</td><td>첫 candidate context 공유</td><td>batch context fingerprint cardinality = 1</td><td>mixed-context fixture에서 cross-context 0</td><td>candidate, prompt contract</td><td>PR-1</td></tr>
+          <tr><td><span class="tag p1">G5</span></td><td>Atomic durable batch commit</td><td>whole-file rewrite candidate별 반복</td><td>판정 batch당 durable rewrite = 1</td><td>439 fixture에서 rewrite count 55 이하</td><td>candidate ledger transaction</td><td>PR-2</td></tr>
+          <tr><td><span class="tag p1">G6</span></td><td>Routing amplification</td><td>평균 7.01×, p95 14×</td><td>Targets 신호 amplification = target count; Discoverable 별도 측정</td><td><code>created_candidates / signal</code> audience별 분리</td><td>Board audience, attention router</td><td>PR-3</td></tr>
+          <tr><td><span class="tag p1">G7</span></td><td>Background work isolation</td><td>inline tool이 Keeper를 deaf하게 만들 수 있음</td><td>long job inline-await 0, terminal delivery exactly once</td><td>10 Keeper × mixed jobs에서 direct latency gate 유지</td><td>background job registry/executor</td><td>PR-4..6</td></tr>
+          <tr><td><span class="tag p1">G8</span></td><td>Resource backpressure</td><td>작업 종류별 분산된 제한</td><td>provider/FD/job permit의 단일 typed SSOT</td><td>cap+1이 fork 없이 typed reject; FD baseline 복귀</td><td>resource leases</td><td>PR-5</td></tr>
+          <tr><td><span class="tag p1">G9</span></td><td>Memory/compaction progress</td><td>turn/post-turn/compaction 경쟁</td><td>overflow 상태에서 compaction completion 100%, direct receipt 보존</td><td>compaction starvation 0 / checkpoint writer concurrency 1</td><td>compaction reservation, checkpoint</td><td>PR-7</td></tr>
+          <tr><td><span class="tag p2">G10</span></td><td>Operator truth</td><td>health cache fast여도 fleet 0 가능</td><td>UI가 capacity, queue completeness, stale snapshot을 분리</td><td>green status with incomplete counts = 0</td><td>health/dashboard projection</td><td>PR-8</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section>
+    <h2>8. PR slicing and exact order</h2>
+    <div class="panel phase">
+      <h3>PR-0 — Restore executable truth</h3>
+      <ol>
+        <li>v3 snapshot validator를 offline/live 동일 parser로 실행한다.</li>
+        <li>10개 목표 Keeper가 등록되고 executable인지 확인한다.</li>
+        <li>queue pending/inflight counts가 complete인지 확인한다.</li>
+        <li>Discord/Slack ingress smoke는 Keeper turn receipt까지 확인한다.</li>
+      </ol>
+      <p><strong>Exit:</strong> 10/10 executable, queue read errors 0, direct receipt 10/10. 이 단계 전에는 성능 실험 금지.</p>
+    </div>
+    <div class="panel phase">
+      <h3>PR-1 — Follow-up to merged #25073: fairness and correctness</h3>
+      <ol>
+        <li>blind TTL/Expired 정책을 제거하고 typed defer/supersession 계획으로 전환한다.</li>
+        <li>동일 keeper_context fingerprint만 한 batch에 포함한다.</li>
+        <li>요청 ID와 응답 ID의 완전성 검증, partial outcome을 typed failure로 기록한다.</li>
+        <li>owner admission당 정확히 한 provider batch만 실행하고 remaining이면 durable continuation wake를 남긴다.</li>
+        <li>현재 890 fixture로 calls 112, admission 112, cross-context 0, silent drop 0을 검증한다.</li>
+      </ol>
+      <p><strong>Live state:</strong> #25073은 2026-07-17 16:31 KST에 merge됐다. 아래 수정은 merge된 TTL·batch 경로를 되돌리는 것이 아니라 최신 main 위 후속 draft PR로 제출한다.</p>
+      <p><strong>Exit:</strong> Build/Test green + mixed context + direct preemption + 439/451 backlog simulation.</p>
+      <p><strong>Exact-token dependency:</strong> OAS draft PR <a href="https://github.com/jeong-sik/oas/pull/2647">#2647</a>가 prepared completion request의 provider-owned input count와 output receipt를 추가 중이다. 현재 구현은 Anthropic만 지원하며, 측정한 request artifact와 실제 dispatch artifact의 동일성을 아직 보장하지 않는다고 인터페이스가 명시한다. 따라서 #25073의 <code>batch_max_candidates = 8</code>은 1.0 승인 기준이 아니며, #2647 merge → OAS release/pin → 동일 artifact fit admission 연결 전까지 hardcoded-cap blocker로 취급한다.</p>
+    </div>
+    <div class="panel phase">
+      <h3>PR-2/3 — Atomic ledger and signal-centric routing</h3>
+      <ol>
+        <li>batch verdict를 한 durable rewrite로 commit한다.</li>
+        <li>Board audience를 Targets/Broadcast/ThreadParticipants/Discoverable closed sum으로 만든다.</li>
+        <li>direct signal을 non-target Keeper candidate로 fan-out하지 않는다.</li>
+        <li>Discoverable만 owner lane 밖의 attention router로 보낸다.</li>
+      </ol>
+      <p><strong>Exit:</strong> direct amplification equals explicit target count; discoverable amplification and cost are 별도 지표.</p>
+    </div>
+    <div class="panel phase">
+      <h3>PR-4..7 — Background jobs, media, memory</h3>
+      <ol>
+        <li>기존 fusion spawn→wake pattern을 generic typed job state로 확장한다.</li>
+        <li>code/research/image/voice를 capability와 resource lease로 admission한다.</li>
+        <li>inner Eio switch로 FD를 job 종료 시 회수한다.</li>
+        <li>결과는 originating continuation channel로 exactly once 전달한다.</li>
+        <li>checkpoint writer와 compaction reservation을 한 소유권 모델로 통합한다.</li>
+      </ol>
+      <p><strong>Exit:</strong> 10 Keeper mixed workload에서 direct latency·FD·terminal delivery·compaction gate 동시 통과.</p>
+    </div>
+  </section>
+
+  <section>
+    <h2>9. 10-Keeper release harness</h2>
+    <div class="table-wrap">
+      <table>
+        <thead><tr><th>Lane</th><th>Foreground</th><th>Background</th><th>Memory pressure</th><th>Injected fault</th><th>Pass condition</th></tr></thead>
+        <tbody>
+          <tr><td>K1</td><td>Discord direct chat</td><td>code build</td><td>normal</td><td>none</td><td>turn-start ≤ 2s while build continues</td></tr>
+          <tr><td>K2</td><td>Slack thread</td><td>web research</td><td>normal</td><td>429 Retry-After</td><td>typed retry; other lanes progress</td></tr>
+          <tr><td>K3</td><td>Dashboard approval</td><td>image generation</td><td>normal</td><td>non-image runtime first</td><td>capability reroute or fail-closed before provider</td></tr>
+          <tr><td>K4</td><td>Voice request</td><td>TTS playback</td><td>normal</td><td>voice endpoint timeout</td><td>lane releases; terminal failure delivered once</td></tr>
+          <tr><td>K5</td><td>K2K verification</td><td>long shell</td><td>normal</td><td>process cancellation</td><td>FD baseline, cancelled receipt once</td></tr>
+          <tr><td>K6</td><td>Board mention</td><td>ambient attention</td><td>normal</td><td>partial verdict</td><td>direct wins; omitted IDs typed deferred</td></tr>
+          <tr><td>K7</td><td>Discord + Slack burst</td><td>none</td><td>near context cap</td><td>compaction requested</td><td>compaction completes; both receipts preserved</td></tr>
+          <tr><td>K8</td><td>none</td><td>AFK catch-up</td><td>normal</td><td>operator returns</td><td>new direct work preempts next quantum</td></tr>
+          <tr><td>K9</td><td>Broadcast</td><td>image + research</td><td>normal</td><td>server restart</td><td>jobs/queue recover without duplicate terminal effect</td></tr>
+          <tr><td>K10</td><td>Task handoff</td><td>code + verifier</td><td>compaction boundary</td><td>queue settlement failure</td><td>lease requeues; handoff remains auditable</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section>
+    <h2>10. Stop / go rules</h2>
+    <div class="grid-2">
+      <div class="panel">
+        <h3 class="bad-text">STOP</h3>
+        <ul>
+          <li>event queue count가 incomplete인데 pending=0으로 표시됨</li>
+          <li>direct 요청이 ambient provider call 두 번 이상 뒤에서 대기</li>
+          <li>provider tokenizer 없이 bytes/4 등으로 batch token을 추정</li>
+          <li>AFK를 wall-clock idle로 추정</li>
+          <li>누락 verdict, job cancellation, delivery failure가 무증거 Pending으로 남음</li>
+          <li>background job이 turn switch 또는 server root switch에 FD를 누수</li>
+        </ul>
+      </div>
+      <div class="panel">
+        <h3 class="ok">GO</h3>
+        <ul>
+          <li>10/10 executable + queue read errors 0</li>
+          <li>admission당 attention provider call ≤ 1</li>
+          <li>direct enqueue→turn-start p95 ≤ 2s</li>
+          <li>silent loss 0, terminal exactly once</li>
+          <li>batch context fingerprint cardinality 1</li>
+          <li>10-lane mixed harness에서 FD·compaction·connector SLO 동시 통과</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>11. Reproducible evidence commands</h2>
+    <pre># Fleet and durable queue truth
+curl -fsS 'http://127.0.0.1:8935/health?full=1' | jq '{overall_status, keeper_fleet_safety, keeper_event_queue}'
+
+# Snapshot schema inventory
+find /Users/dancer/me/.masc/keepers -name event-queue.json \
+  -exec jq -r '.schema' {} + | sort | uniq -c
+
+# Attention state counts
+jq -s 'group_by(.status.kind) | map({status:.[0].status.kind,count:length})' \
+  /Users/dancer/me/.masc/board_attention_candidates/*.jsonl
+
+# Candidate amplification
+jq -s '[.[]|(.signal|tojson)] | {candidates:length,signals:(unique|length)}' \
+  /Users/dancer/me/.masc/board_attention_candidates/*.jsonl
+
+# Focused OCaml verification
+scripts/dune-local.sh build test/test_keeper_board_attention_candidate.exe
+_build/default/test/test_keeper_board_attention_candidate.exe</pre>
+  </section>
+</main>
+</body>
+</html>

--- a/docs/design/2026-07-17-keeper-mixed-workload-operation-goal-matrix.html
+++ b/docs/design/2026-07-17-keeper-mixed-workload-operation-goal-matrix.html
@@ -365,7 +365,7 @@ type job_state =
       </ol>
       <p><strong>Live state:</strong> #25073은 2026-07-17 16:31 KST에 merge됐다. 아래 수정은 merge된 TTL·batch 경로를 되돌리는 것이 아니라 최신 main 위 후속 draft PR로 제출한다.</p>
       <p><strong>Exit:</strong> Build/Test green + mixed context + direct preemption + 439/451 backlog simulation.</p>
-      <p><strong>Exact-token dependency:</strong> OAS draft PR <a href="https://github.com/jeong-sik/oas/pull/2647">#2647</a>가 prepared completion request의 provider-owned input count와 output receipt를 추가 중이다. 현재 구현은 Anthropic만 지원하며, 측정한 request artifact와 실제 dispatch artifact의 동일성을 아직 보장하지 않는다고 인터페이스가 명시한다. 따라서 #25073의 <code>batch_max_candidates = 8</code>은 1.0 승인 기준이 아니며, #2647 merge → OAS release/pin → 동일 artifact fit admission 연결 전까지 hardcoded-cap blocker로 취급한다.</p>
+      <p><strong>Exact-token dependency:</strong> OAS PR <a href="https://github.com/jeong-sik/oas/pull/2647">#2647</a>은 2026-07-17에 merge되어 prepared completion request의 provider-owned input count와 output receipt를 제공한다. 현재 구현은 Anthropic만 지원하며, 측정한 request artifact와 실제 dispatch artifact의 동일성을 아직 보장하지 않는다고 인터페이스가 명시한다. 따라서 #25073의 <code>batch_max_candidates = 8</code>은 1.0 승인 기준이 아니며, OAS release/pin → 동일 artifact fit admission 연결 전까지 hardcoded-cap blocker로 취급한다. 즉 dependency merge는 완료됐지만 MASC 제품 경로는 아직 완료되지 않았다.</p>
     </div>
     <div class="panel phase">
       <h3>PR-2/3 — Atomic ledger and signal-centric routing</h3>

--- a/docs/design/2026-07-17-keeper-mixed-workload-operation-goal-matrix.html
+++ b/docs/design/2026-07-17-keeper-mixed-workload-operation-goal-matrix.html
@@ -106,24 +106,27 @@
   <div class="eyebrow">MASC 1.0 / Executable strategy</div>
   <h1>10 Keeper Mixed-Workload<br>Operation Goal Matrix</h1>
   <p class="lede">10개 Keeper가 Discord·Slack·Dashboard·Voice에서 동시에 대화하고, 서로 협업하며, 코드 작성·정보 수집·이미지 생성·장기 작업·메모리 기록·컴팩션을 수행하는 상황을 대상으로 한다. 목표는 평균 처리량이 아니라 <strong>직접 요청의 반응성, 영속 복구, lane 공정성, 자원 상한, 감사 가능한 상태 전이</strong>를 동시에 만족하는 것이다.</p>
-  <p class="stamp">Failure baseline: 2026-07-17 16:28 KST · latest observation: 2026-07-17 17:53 KST · live runtime commit f887c86aff · follow-up PR #25092</p>
+  <p class="stamp">Failure baseline: 2026-07-17 16:28 KST · latest observation: 2026-07-18 11:02 KST · live runtime commit 3b8fa29337 · follow-up PR #25092</p>
 
   <div class="banner">
-    <strong>현재 판정: 기능은 부분 사용 가능, 고객 제품은 No-Go.</strong> 16:28 KST에는 13개 bootable Keeper 중 실행 fiber가 0이고 16개 event queue가 모두 v2라 v3-only reader에서 거부됐다. 17:53 KST 재측정에서는 16/16 snapshot이 v3이고 13/13 Keeper가 executable이지만, effective reaction capacity는 11/13, durable event는 pending 1,054 + inflight 4, oldest age는 약 42.3시간이다. 따라서 새 요청 일부는 실행될 수 있어도 “맡긴 작업이 예측 가능한 시간 안에 끝난다”는 고객 계약은 증명되지 않았다.
+    <strong>현재 판정: 기능은 부분 사용 가능, 고객 제품은 No-Go.</strong> 16:28 KST에는 13개 bootable Keeper 중 실행 fiber가 0이고 16개 event queue가 모두 v2라 v3-only reader에서 거부됐다. 2026-07-18 11:02 KST의 last-good full snapshot은 13/13 executable과 effective reaction capacity 13/13을 보고하지만, snapshot 자체가 refresh timeout으로 stale이고 overall status는 degraded/operator action required다. durable event도 pending 859 + inflight 9, oldest age 약 59.5시간으로 남아 있다. 따라서 순간 capacity 회복은 “맡긴 작업이 예측 가능한 시간 안에 끝난다”는 고객 계약의 증명이 아니다.
   </div>
 
   <section>
     <h2>1. Live baseline</h2>
     <div class="cards">
-      <div class="card warn"><div class="label">Executable / effective</div><div class="value">13 / 13 · 11 / 13</div><div>6 running, 5 recovering, 2 compacting-blocked</div></div>
+      <div class="card warn"><div class="label">Executable / effective</div><div class="value">13 / 13 · 13 / 13</div><div>last-good snapshot; current full refresh is stale</div></div>
       <div class="card warn"><div class="label">Event queue read errors</div><div class="value">16 → 0</div><div>16/16 v3 변환 완료; backlog settlement는 별개</div></div>
-      <div class="card bad"><div class="label">Durable event queue</div><div class="value">1,054 + 4</div><div>pending + inflight, oldest 약 42.3시간, read errors 0</div></div>
+      <div class="card bad"><div class="label">Durable event queue</div><div class="value">859 + 9</div><div>pending + inflight, oldest 약 59.5시간, read errors 0</div></div>
+      <div class="card warn"><div class="label">Queue delta vs 17:53</div><div class="value">pending -195</div><div>inflight +5, 그러나 oldest +17.2시간</div></div>
       <div class="card warn"><div class="label">Attention candidates</div><div class="value">3,644</div><div>520개 고유 signal이 평균 7.01배 증폭</div></div>
       <div class="card warn"><div class="label">Pending attention</div><div class="value">890 / 7.46 MB</div><div>439 + 451; fixed 8-cap은 실제 context capacity와 무관</div></div>
       <div class="card warn"><div class="label">Candidate ledger</div><div class="value">38 MB</div><div>전체 request JSON 26.18 MB</div></div>
+      <div class="card"><div class="label">Batch ledger rewrite</div><div class="value">16 → 2</div><div>8-candidate success 기준 -87.5%; 890 fixture 1,780 → 224</div></div>
       <div class="card"><div class="label">Health endpoint p50 / p95</div><div class="value">3.6 / 16.7 ms</div><div>20회 cache-hit 측정; 제품 실행 가능성 증거는 아님</div></div>
       <div class="card warn"><div class="label">Full health recompute</div><div class="value">4.2 s</div><div>snapshot refresh 자체 비용</div></div>
       <div class="card"><div class="label">Historical relevance</div><div class="value">48.1%</div><div>1,325 relevant / 2,754 consumed</div></div>
+      <div class="card bad"><div class="label">Full snapshot truth</div><div class="value">STALE</div><div>refresh timeout 20s; last-good age 약 143s</div></div>
     </div>
     <p class="small muted">정확한 원본 수치: unique signals 520, candidate fan-out p50 6 / p95 14 / max 14, consumed irrelevant 1,429(51.9%), pending 890, batch request max 208,369 bytes. bytes를 token으로 임의 환산하지 않는다.</p>
   </section>
@@ -137,17 +140,17 @@
       <table>
         <thead><tr><th>제품 축</th><th>Weight</th><th>현재 관측</th><th>#25073 단독 효과</th><th>1.0 정량 gate</th></tr></thead>
         <tbody>
-          <tr><td>실행 가능성</td><td>25%</td><td>13/13 executable이나 effective 11/13; 8시간 증거 없음 → 0점</td><td>queue schema 장애와 무관</td><td>목표 10 Keeper 10/10 executable, 8시간 동안 fleet reaction capacity = 10</td></tr>
-          <tr><td>End-to-end useful completion</td><td>25%</td><td>durable event pending 1,054, oldest 42.3시간, mixed-workload terminal SLO 표본 없음 → 0점</td><td>attention 판정 비용만 줄이며 고객 결과 완료를 증명하지 않음</td><td>명시적 거절 제외 요청의 terminal receipt ≥ 99%, duplicate terminal effect = 0</td></tr>
+          <tr><td>실행 가능성</td><td>25%</td><td>last-good은 13/13이나 full snapshot stale, 8시간 증거 없음 → 0점</td><td>queue schema 장애와 무관</td><td>목표 10 Keeper 10/10 executable, 8시간 동안 fleet reaction capacity = 10</td></tr>
+          <tr><td>End-to-end useful completion</td><td>25%</td><td>durable event pending 859, oldest 59.5시간, mixed-workload terminal SLO 표본 없음 → 0점</td><td>attention 판정 비용만 줄이며 고객 결과 완료를 증명하지 않음</td><td>명시적 거절 제외 요청의 terminal receipt ≥ 99%, duplicate terminal effect = 0</td></tr>
           <tr><td>직접 요청 반응성</td><td>15%</td><td>owner lane이 ambient provider call에 30–50초 점유될 수 있고 direct-input p95 미측정 → 0점</td><td>55/57 calls 연속 점유를 1 call/admission으로 제한; call 자체의 점유는 남음</td><td>enqueue→turn-start p95 ≤ 2s, 접수 응답 p95 ≤ 5s</td></tr>
           <tr><td>채널·세션 연속성</td><td>15%</td><td>transport/presence 생존만 확인; Slack/Voice/원채널 terminal E2E 미검증 → 0점</td><td>영향 없음</td><td>Discord/Slack/Dashboard/Voice route accuracy 100%, restart replay 100%</td></tr>
           <tr><td>무유실·판정 정확성</td><td>10%</td><td>live main은 blind TTL + partial verdict 계약을 보유; follow-up 미병합 → 0점</td><td>후속 #25092에서 TTL 제거, exact ID coverage, context cohort로 개선</td><td>silent discard = 0, cross-context batch = 0, 모든 defer에 typed evidence</td></tr>
-          <tr><td>운영자 신뢰</td><td>10%</td><td>HTTP status는 ok지만 overall degraded/operator action required, stale pending 1,054 → 0점</td><td>영향 없음</td><td>incomplete count를 green/zero로 투영한 횟수 = 0</td></tr>
+          <tr><td>운영자 신뢰</td><td>10%</td><td>HTTP status는 ok지만 overall degraded/operator action required, full snapshot stale → 0점</td><td>영향 없음</td><td>incomplete count를 green/zero로 투영한 횟수 = 0</td></tr>
         </tbody>
       </table>
     </div>
     <p><strong>점수 공식:</strong> <code>Σ(weight × gate achievement)</code>. 각 gate는 통과 1 / 실패·Unknown 0으로 계산한다. 샘플이 없는 주장은 0점, HTTP 생존과 point-in-time fiber 수는 8시간 실행 가능성의 대체 지표가 아니다. 따라서 fleet가 회복된 현재도 엄격한 live 제품 점수는 <strong>0.0 / 10</strong>이다. v3 fleet가 8시간 gate를 통과하고 본 follow-up의 무유실 계약까지 통과하면 최대 <strong>3.5 / 10</strong>이지만, completion·latency·channel·operator gate 없이는 그 이상을 받을 수 없다. 즉 #25073 계열만으로는 출시 점수 9.0에 도달하지 않는다.</p>
-    <p><strong>고객 유용성 결론:</strong> 개발자·운영자가 제한된 canary를 시작하고 새 요청 일부를 처리할 기반은 회복됐다. 그러나 일반 고객에게 “맡기고 떠나도 결과가 온다”고 약속할 수 있는 제품은 아니다. 1,054개 pending을 정상 처리·격리·실패 종결하는 증거 없이 채널 수나 Keeper 수를 늘리면 고객 가치는 늘지 않고 지연과 불신만 증폭된다.</p>
+    <p><strong>고객 유용성 결론:</strong> 개발자·운영자가 제한된 canary를 시작하고 새 요청 일부를 처리할 기반은 회복됐다. 그러나 일반 고객에게 “맡기고 떠나도 결과가 온다”고 약속할 수 있는 제품은 아니다. 859개 pending과 9개 inflight를 정상 처리·격리·실패 종결하는 증거 없이 채널 수나 Keeper 수를 늘리면 고객 가치는 늘지 않고 지연과 불신만 증폭된다.</p>
     <p><strong>9.0 release floor:</strong> 위 6개 축의 가중 합 ≥ 9.0이고, 동시에 실행 가능성·terminal exactly-once·silent loss 세 hard gate가 모두 통과해야 한다. 평균 점수가 높아도 이 셋 중 하나가 0이면 출시 불가다.</p>
   </section>
 
@@ -333,7 +336,7 @@ type job_state =
           <tr><td><span class="tag p0">G2</span></td><td>One provider quantum per admission</td><td>55/57 calls 한 turn</td><td>admission당 provider call ≤ 1</td><td><code>max_calls_per_admission = 1</code></td><td>board_attention_candidate, heartbeat</td><td>PR-1</td></tr>
           <tr><td><span class="tag p0">G3</span></td><td>No silent loss</td><td>missing verdict 무증거 Pending, blind TTL</td><td>silent drop 0, 모든 defer에 typed reason</td><td><code>requested_ids = terminal_ids ∪ deferred_ids</code></td><td>judgment contract</td><td>PR-1</td></tr>
           <tr><td><span class="tag p1">G4</span></td><td>Context correctness</td><td>첫 candidate context 공유</td><td>batch context fingerprint cardinality = 1</td><td>mixed-context fixture에서 cross-context 0</td><td>candidate, prompt contract</td><td>PR-1</td></tr>
-          <tr><td><span class="tag p1">G5</span></td><td>Atomic durable batch commit</td><td>whole-file rewrite candidate별 반복</td><td>판정 batch당 durable rewrite = 1</td><td>439 fixture에서 rewrite count 55 이하</td><td>candidate ledger transaction</td><td>PR-2</td></tr>
+          <tr><td><span class="tag p1">G5</span></td><td>Atomic durable batch commit</td><td>verdict/consumed를 candidate별 commit해 최대 2N rewrite</td><td>batch 크기와 무관하게 verdict 1회 + consumed 1회 = 2</td><td>8-candidate fixture에서 candidate-ledger rewrite = 2</td><td>candidate ledger transaction</td><td>PR-1</td></tr>
           <tr><td><span class="tag p1">G6</span></td><td>Routing amplification</td><td>평균 7.01×, p95 14×</td><td>Targets 신호 amplification = target count; Discoverable 별도 측정</td><td><code>created_candidates / signal</code> audience별 분리</td><td>Board audience, attention router</td><td>PR-3</td></tr>
           <tr><td><span class="tag p1">G7</span></td><td>Background work isolation</td><td>inline tool이 Keeper를 deaf하게 만들 수 있음</td><td>long job inline-await 0, terminal delivery exactly once</td><td>10 Keeper × mixed jobs에서 direct latency gate 유지</td><td>background job registry/executor</td><td>PR-4..6</td></tr>
           <tr><td><span class="tag p1">G8</span></td><td>Resource backpressure</td><td>작업 종류별 분산된 제한</td><td>provider/FD/job permit의 단일 typed SSOT</td><td>cap+1이 fork 없이 typed reject; FD baseline 복귀</td><td>resource leases</td><td>PR-5</td></tr>
@@ -363,17 +366,18 @@ type job_state =
         <li>동일 keeper_context fingerprint만 한 batch에 포함한다.</li>
         <li>요청 ID와 응답 ID의 완전성 검증, partial outcome을 typed failure로 기록한다.</li>
         <li>owner admission당 정확히 한 provider batch만 실행하고 remaining이면 durable continuation wake를 남긴다.</li>
+        <li>verdict 전체를 1회 atomic commit하고 idempotent event enqueue 뒤 consumed 전체를 1회 commit한다.</li>
         <li>현재 890 fixture로 calls 112, admission 112, cross-context 0, silent drop 0을 검증한다.</li>
       </ol>
       <p><strong>Live state:</strong> #25073은 2026-07-17 16:31 KST에 merge됐다. 아래 수정은 merge된 TTL·batch 경로를 되돌리는 것이 아니라 최신 main 위 후속 draft PR로 제출한다.</p>
       <p><strong>Exit:</strong> Build/Test green + mixed context + direct preemption + 439/451 backlog simulation.</p>
-      <p><strong>Exact-token dependency:</strong> OAS PR <a href="https://github.com/jeong-sik/oas/pull/2647">#2647</a>은 2026-07-17에 merge됐고 v0.216.1로 release되어 prepared completion request의 provider-owned input count와 output receipt를 제공한다. 그러나 구현은 Anthropic wire만 지원하고, 현재 MASC structured judge는 <code>ollama_cloud_native.minimax-m3-native-structured</code>다. 측정한 request artifact와 실제 dispatch artifact의 동일성도 인터페이스가 보장하지 않는다. 따라서 OAS pin만 올리거나 Anthropic-only fail-close를 연결하면 현재 고객 경로가 정지한다. #25073의 <code>batch_max_candidates = 8</code> 역시 1.0 승인 기준이 아니다. 필요한 선행 계약은 현재 judge wire의 exact count 또는 provider-edge typed context-overflow, 그리고 동일 prepared artifact admission/dispatch다.</p>
-      <p><strong>Provider-product contradiction:</strong> Ollama 공식 문서는 2026-07-17 확인 기준 Ollama Cloud structured outputs 미지원이라고 명시하지만, repo config는 native <code>/api/chat</code> schema path를 live-verified 계약으로 선언한다. 이 차이는 코드 주석으로 해소할 수 없다. 동일 Cloud endpoint에 대한 반복 가능한 contract test와 실패 시 typed startup rejection이 없으면 고객 환경에 따라 구조화 판정이 조용히 prose로 퇴행할 수 있다.</p>
+      <p><strong>Exact-fit dependency, adversarial update:</strong> OAS v0.216.1의 provider-owned input count는 Anthropic wire만 지원하고 현재 judge는 Ollama-native다. <a href="https://github.com/ollama/ollama/blob/main/docs/api.md">Ollama 공식 API</a>는 <code>/api/chat</code> 성공 응답의 <code>prompt_eval_count</code>만 제공하며 public tokenize/preflight endpoint를 정의하지 않는다. 또한 native chat은 context 초과를 client-visible typed overflow로 보장하지 않고 입력을 truncate할 수 있다. Cloud 400의 <code>error</code> 문자열을 파싱하는 방식은 금지한다. 따라서 OAS <a href="https://github.com/jeong-sik/oas/issues/2667">#2667</a>을 가짜 exact-fit 계약으로 구현하지 않는다. fixed <code>batch_max_candidates = 8</code> 제거의 선행 설계는 persisted partition scheduler다: response candidate-id 집합이 정확히 일치한 partition만 commit하고, contract failure partition은 결정론적으로 분할하며, 각 attempt는 owner admission 밖의 judgment plane에서 실행한다.</p>
+      <p><strong>Structured-output contract:</strong> 현재 Ollama 공식 API는 <code>format</code> JSON schema 기반 structured output을 문서화한다. 그러나 설정된 Cloud 모델·endpoint가 동일 계약을 반복 가능하게 지킨다는 증거는 별개다. 동일 endpoint contract test와 typed startup rejection이 없으면 고객 환경에 따라 구조화 판정이 prose 또는 partial ID 응답으로 퇴행할 수 있다.</p>
     </div>
     <div class="panel phase">
-      <h3>PR-2/3 — Atomic ledger and signal-centric routing</h3>
+      <h3>PR-2/3 — Partition scheduler and signal-centric routing</h3>
       <ol>
-        <li>batch verdict를 한 durable rewrite로 commit한다.</li>
+        <li>fixed 8-cap을 persisted binary partition state로 교체하고 judgment plane으로 이동한다.</li>
         <li>Board audience를 Targets/Broadcast/ThreadParticipants/Discoverable closed sum으로 만든다.</li>
         <li>direct signal을 non-target Keeper candidate로 fan-out하지 않는다.</li>
         <li>Discoverable만 owner lane 밖의 attention router로 보낸다.</li>

--- a/docs/design/2026-07-17-keeper-mixed-workload-operation-goal-matrix.html
+++ b/docs/design/2026-07-17-keeper-mixed-workload-operation-goal-matrix.html
@@ -106,20 +106,20 @@
   <div class="eyebrow">MASC 1.0 / Executable strategy</div>
   <h1>10 Keeper Mixed-Workload<br>Operation Goal Matrix</h1>
   <p class="lede">10개 Keeper가 Discord·Slack·Dashboard·Voice에서 동시에 대화하고, 서로 협업하며, 코드 작성·정보 수집·이미지 생성·장기 작업·메모리 기록·컴팩션을 수행하는 상황을 대상으로 한다. 목표는 평균 처리량이 아니라 <strong>직접 요청의 반응성, 영속 복구, lane 공정성, 자원 상한, 감사 가능한 상태 전이</strong>를 동시에 만족하는 것이다.</p>
-  <p class="stamp">Failure baseline: 2026-07-17 16:28 KST · recovery observation: 2026-07-17 17:28 KST · live runtime commit f887c86aff · follow-up PR #25092</p>
+  <p class="stamp">Failure baseline: 2026-07-17 16:28 KST · latest observation: 2026-07-17 17:53 KST · live runtime commit f887c86aff · follow-up PR #25092</p>
 
   <div class="banner">
-    <strong>현재 판정: 인프라 회복, 고객 제품은 No-Go.</strong> 16:28 KST에는 13개 bootable Keeper 중 실행 fiber가 0이고 16개 event queue가 모두 v2라 v3-only reader에서 거부됐다. 17:28 KST 재측정에서는 16/16 snapshot이 v3이고 13/13 Keeper가 executable이지만, durable event 1,130개가 모두 pending이며 oldest age는 약 41.9시간이다. 따라서 서버와 fleet는 다시 실행 가능하지만 “고객 작업이 끝난다”는 제품 계약은 아직 증명되지 않았다.
+    <strong>현재 판정: 기능은 부분 사용 가능, 고객 제품은 No-Go.</strong> 16:28 KST에는 13개 bootable Keeper 중 실행 fiber가 0이고 16개 event queue가 모두 v2라 v3-only reader에서 거부됐다. 17:53 KST 재측정에서는 16/16 snapshot이 v3이고 13/13 Keeper가 executable이지만, effective reaction capacity는 11/13, durable event는 pending 1,054 + inflight 4, oldest age는 약 42.3시간이다. 따라서 새 요청 일부는 실행될 수 있어도 “맡긴 작업이 예측 가능한 시간 안에 끝난다”는 고객 계약은 증명되지 않았다.
   </div>
 
   <section>
     <h2>1. Live baseline</h2>
     <div class="cards">
-      <div class="card warn"><div class="label">Executable Keeper fibers</div><div class="value">0 → 13 / 13</div><div>point-in-time capacity 회복; 8시간 지속성은 미검증</div></div>
+      <div class="card warn"><div class="label">Executable / effective</div><div class="value">13 / 13 · 11 / 13</div><div>6 running, 5 recovering, 2 compacting-blocked</div></div>
       <div class="card warn"><div class="label">Event queue read errors</div><div class="value">16 → 0</div><div>16/16 v3 변환 완료; backlog settlement는 별개</div></div>
-      <div class="card bad"><div class="label">Durable events pending</div><div class="value">1,130 / 1,130</div><div>inflight 0, oldest 약 41.9시간, 13 Keeper에서 stale</div></div>
+      <div class="card bad"><div class="label">Durable event queue</div><div class="value">1,054 + 4</div><div>pending + inflight, oldest 약 42.3시간, read errors 0</div></div>
       <div class="card warn"><div class="label">Attention candidates</div><div class="value">3,644</div><div>520개 고유 signal이 평균 7.01배 증폭</div></div>
-      <div class="card warn"><div class="label">Pending attention</div><div class="value">890</div><div>439 + 451, age 약 15.3시간</div></div>
+      <div class="card warn"><div class="label">Pending attention</div><div class="value">890 / 7.46 MB</div><div>439 + 451; fixed 8-cap은 실제 context capacity와 무관</div></div>
       <div class="card warn"><div class="label">Candidate ledger</div><div class="value">38 MB</div><div>전체 request JSON 26.18 MB</div></div>
       <div class="card"><div class="label">Health endpoint p50 / p95</div><div class="value">3.6 / 16.7 ms</div><div>20회 cache-hit 측정; 제품 실행 가능성 증거는 아님</div></div>
       <div class="card warn"><div class="label">Full health recompute</div><div class="value">4.2 s</div><div>snapshot refresh 자체 비용</div></div>
@@ -137,17 +137,17 @@
       <table>
         <thead><tr><th>제품 축</th><th>Weight</th><th>현재 관측</th><th>#25073 단독 효과</th><th>1.0 정량 gate</th></tr></thead>
         <tbody>
-          <tr><td>실행 가능성</td><td>25%</td><td>13/13 executable point sample; 8시간 증거 없음 → 0점</td><td>queue schema 장애와 무관</td><td>목표 10 Keeper 10/10 executable, 8시간 동안 fleet reaction capacity &gt; 0</td></tr>
-          <tr><td>End-to-end useful completion</td><td>25%</td><td>durable event 1,130/1,130 pending, mixed-workload terminal SLO 표본 없음 → 0점</td><td>attention 판정 비용만 줄이며 고객 결과 완료를 증명하지 않음</td><td>명시적 거절 제외 요청의 terminal receipt ≥ 99%, duplicate terminal effect = 0</td></tr>
+          <tr><td>실행 가능성</td><td>25%</td><td>13/13 executable이나 effective 11/13; 8시간 증거 없음 → 0점</td><td>queue schema 장애와 무관</td><td>목표 10 Keeper 10/10 executable, 8시간 동안 fleet reaction capacity = 10</td></tr>
+          <tr><td>End-to-end useful completion</td><td>25%</td><td>durable event pending 1,054, oldest 42.3시간, mixed-workload terminal SLO 표본 없음 → 0점</td><td>attention 판정 비용만 줄이며 고객 결과 완료를 증명하지 않음</td><td>명시적 거절 제외 요청의 terminal receipt ≥ 99%, duplicate terminal effect = 0</td></tr>
           <tr><td>직접 요청 반응성</td><td>15%</td><td>owner lane이 ambient provider call에 30–50초 점유될 수 있고 direct-input p95 미측정 → 0점</td><td>55/57 calls 연속 점유를 1 call/admission으로 제한; call 자체의 점유는 남음</td><td>enqueue→turn-start p95 ≤ 2s, 접수 응답 p95 ≤ 5s</td></tr>
           <tr><td>채널·세션 연속성</td><td>15%</td><td>transport/presence 생존만 확인; Slack/Voice/원채널 terminal E2E 미검증 → 0점</td><td>영향 없음</td><td>Discord/Slack/Dashboard/Voice route accuracy 100%, restart replay 100%</td></tr>
           <tr><td>무유실·판정 정확성</td><td>10%</td><td>live main은 blind TTL + partial verdict 계약을 보유; follow-up 미병합 → 0점</td><td>후속 #25092에서 TTL 제거, exact ID coverage, context cohort로 개선</td><td>silent discard = 0, cross-context batch = 0, 모든 defer에 typed evidence</td></tr>
-          <tr><td>운영자 신뢰</td><td>10%</td><td>overall degraded/operator action required, stale pending 1,130 → 0점</td><td>영향 없음</td><td>incomplete count를 green/zero로 투영한 횟수 = 0</td></tr>
+          <tr><td>운영자 신뢰</td><td>10%</td><td>HTTP status는 ok지만 overall degraded/operator action required, stale pending 1,054 → 0점</td><td>영향 없음</td><td>incomplete count를 green/zero로 투영한 횟수 = 0</td></tr>
         </tbody>
       </table>
     </div>
     <p><strong>점수 공식:</strong> <code>Σ(weight × gate achievement)</code>. 각 gate는 통과 1 / 실패·Unknown 0으로 계산한다. 샘플이 없는 주장은 0점, HTTP 생존과 point-in-time fiber 수는 8시간 실행 가능성의 대체 지표가 아니다. 따라서 fleet가 회복된 현재도 엄격한 live 제품 점수는 <strong>0.0 / 10</strong>이다. v3 fleet가 8시간 gate를 통과하고 본 follow-up의 무유실 계약까지 통과하면 최대 <strong>3.5 / 10</strong>이지만, completion·latency·channel·operator gate 없이는 그 이상을 받을 수 없다. 즉 #25073 계열만으로는 출시 점수 9.0에 도달하지 않는다.</p>
-    <p><strong>고객 유용성 결론:</strong> 개발자·운영자가 제한된 canary를 시작할 기반은 회복됐지만, 일반 고객에게 “맡기고 떠나도 결과가 온다”고 약속할 수 있는 제품은 아니다. 1,130개 pending을 정상 처리·격리·실패 종결하는 증거 없이 채널 수나 Keeper 수를 늘리면 고객 가치는 늘지 않고 지연과 불신만 증폭된다.</p>
+    <p><strong>고객 유용성 결론:</strong> 개발자·운영자가 제한된 canary를 시작하고 새 요청 일부를 처리할 기반은 회복됐다. 그러나 일반 고객에게 “맡기고 떠나도 결과가 온다”고 약속할 수 있는 제품은 아니다. 1,054개 pending을 정상 처리·격리·실패 종결하는 증거 없이 채널 수나 Keeper 수를 늘리면 고객 가치는 늘지 않고 지연과 불신만 증폭된다.</p>
     <p><strong>9.0 release floor:</strong> 위 6개 축의 가중 합 ≥ 9.0이고, 동시에 실행 가능성·terminal exactly-once·silent loss 세 hard gate가 모두 통과해야 한다. 평균 점수가 높아도 이 셋 중 하나가 0이면 출시 불가다.</p>
   </section>
 
@@ -367,7 +367,8 @@ type job_state =
       </ol>
       <p><strong>Live state:</strong> #25073은 2026-07-17 16:31 KST에 merge됐다. 아래 수정은 merge된 TTL·batch 경로를 되돌리는 것이 아니라 최신 main 위 후속 draft PR로 제출한다.</p>
       <p><strong>Exit:</strong> Build/Test green + mixed context + direct preemption + 439/451 backlog simulation.</p>
-      <p><strong>Exact-token dependency:</strong> OAS PR <a href="https://github.com/jeong-sik/oas/pull/2647">#2647</a>은 2026-07-17에 merge되어 prepared completion request의 provider-owned input count와 output receipt를 제공한다. 현재 구현은 Anthropic만 지원하며, 측정한 request artifact와 실제 dispatch artifact의 동일성을 아직 보장하지 않는다고 인터페이스가 명시한다. 따라서 #25073의 <code>batch_max_candidates = 8</code>은 1.0 승인 기준이 아니며, OAS release/pin → 동일 artifact fit admission 연결 전까지 hardcoded-cap blocker로 취급한다. 즉 dependency merge는 완료됐지만 MASC 제품 경로는 아직 완료되지 않았다.</p>
+      <p><strong>Exact-token dependency:</strong> OAS PR <a href="https://github.com/jeong-sik/oas/pull/2647">#2647</a>은 2026-07-17에 merge됐고 v0.216.1로 release되어 prepared completion request의 provider-owned input count와 output receipt를 제공한다. 그러나 구현은 Anthropic wire만 지원하고, 현재 MASC structured judge는 <code>ollama_cloud_native.minimax-m3-native-structured</code>다. 측정한 request artifact와 실제 dispatch artifact의 동일성도 인터페이스가 보장하지 않는다. 따라서 OAS pin만 올리거나 Anthropic-only fail-close를 연결하면 현재 고객 경로가 정지한다. #25073의 <code>batch_max_candidates = 8</code> 역시 1.0 승인 기준이 아니다. 필요한 선행 계약은 현재 judge wire의 exact count 또는 provider-edge typed context-overflow, 그리고 동일 prepared artifact admission/dispatch다.</p>
+      <p><strong>Provider-product contradiction:</strong> Ollama 공식 문서는 2026-07-17 확인 기준 Ollama Cloud structured outputs 미지원이라고 명시하지만, repo config는 native <code>/api/chat</code> schema path를 live-verified 계약으로 선언한다. 이 차이는 코드 주석으로 해소할 수 없다. 동일 Cloud endpoint에 대한 반복 가능한 contract test와 실패 시 typed startup rejection이 없으면 고객 환경에 따라 구조화 판정이 조용히 prose로 퇴행할 수 있다.</p>
     </div>
     <div class="panel phase">
       <h3>PR-2/3 — Atomic ledger and signal-centric routing</h3>

--- a/docs/design/2026-07-17-keeper-mixed-workload-operation-goal-matrix.html
+++ b/docs/design/2026-07-17-keeper-mixed-workload-operation-goal-matrix.html
@@ -106,17 +106,18 @@
   <div class="eyebrow">MASC 1.0 / Executable strategy</div>
   <h1>10 Keeper Mixed-Workload<br>Operation Goal Matrix</h1>
   <p class="lede">10개 Keeper가 Discord·Slack·Dashboard·Voice에서 동시에 대화하고, 서로 협업하며, 코드 작성·정보 수집·이미지 생성·장기 작업·메모리 기록·컴팩션을 수행하는 상황을 대상으로 한다. 목표는 평균 처리량이 아니라 <strong>직접 요청의 반응성, 영속 복구, lane 공정성, 자원 상한, 감사 가능한 상태 전이</strong>를 동시에 만족하는 것이다.</p>
-  <p class="stamp">Baseline captured: 2026-07-17 16:28 KST · repo/runtime commit cd9b4f655d · PR target #25073 head 63c58e47d3</p>
+  <p class="stamp">Failure baseline: 2026-07-17 16:28 KST · recovery observation: 2026-07-17 17:28 KST · live runtime commit f887c86aff · follow-up PR #25092</p>
 
   <div class="banner">
-    <strong>현재 판정: 혼합 부하 사용 불가.</strong> HTTP 서버는 응답했지만 13개 bootable Keeper 중 실행 fiber가 0이었고, 당시 16개 event queue가 모두 v2라 v3-only reader에서 거부됐다. 16:30 KST에 원본 snapshot이 외부 작업으로 v3로 변환되고 서버가 재시작 단계에 들어갔으므로, 아래 baseline은 변환 전 장애 상태와 변환 직전 backlog를 고정한 것이다. v3 재기동 검증 전에는 “복구 완료”로 계산하지 않는다.
+    <strong>현재 판정: 인프라 회복, 고객 제품은 No-Go.</strong> 16:28 KST에는 13개 bootable Keeper 중 실행 fiber가 0이고 16개 event queue가 모두 v2라 v3-only reader에서 거부됐다. 17:28 KST 재측정에서는 16/16 snapshot이 v3이고 13/13 Keeper가 executable이지만, durable event 1,130개가 모두 pending이며 oldest age는 약 41.9시간이다. 따라서 서버와 fleet는 다시 실행 가능하지만 “고객 작업이 끝난다”는 제품 계약은 아직 증명되지 않았다.
   </div>
 
   <section>
     <h2>1. Live baseline</h2>
     <div class="cards">
-      <div class="card bad"><div class="label">Executable Keeper fibers</div><div class="value">0 / 13</div><div>목표 시나리오 10개를 실행할 capacity가 0</div></div>
-      <div class="card bad"><div class="label">Event queue read errors</div><div class="value">16 / 16</div><div>v2 snapshot을 v3-only reader가 거부</div></div>
+      <div class="card warn"><div class="label">Executable Keeper fibers</div><div class="value">0 → 13 / 13</div><div>point-in-time capacity 회복; 8시간 지속성은 미검증</div></div>
+      <div class="card warn"><div class="label">Event queue read errors</div><div class="value">16 → 0</div><div>16/16 v3 변환 완료; backlog settlement는 별개</div></div>
+      <div class="card bad"><div class="label">Durable events pending</div><div class="value">1,130 / 1,130</div><div>inflight 0, oldest 약 41.9시간, 13 Keeper에서 stale</div></div>
       <div class="card warn"><div class="label">Attention candidates</div><div class="value">3,644</div><div>520개 고유 signal이 평균 7.01배 증폭</div></div>
       <div class="card warn"><div class="label">Pending attention</div><div class="value">890</div><div>439 + 451, age 약 15.3시간</div></div>
       <div class="card warn"><div class="label">Candidate ledger</div><div class="value">38 MB</div><div>전체 request JSON 26.18 MB</div></div>
@@ -136,16 +137,17 @@
       <table>
         <thead><tr><th>제품 축</th><th>Weight</th><th>현재 관측</th><th>#25073 단독 효과</th><th>1.0 정량 gate</th></tr></thead>
         <tbody>
-          <tr><td>실행 가능성</td><td>25%</td><td>0/13 executable → 0점</td><td>queue schema 장애를 고치지 않으므로 0점 유지</td><td>목표 10 Keeper 10/10 executable, 8시간 동안 fleet reaction capacity &gt; 0</td></tr>
-          <tr><td>End-to-end useful completion</td><td>25%</td><td>실행 fiber 0이라 측정 불가 → fail-closed 0점</td><td>attention 판정 비용만 줄이며 고객 결과 완료를 증명하지 않음</td><td>명시적 거절 제외 요청의 terminal receipt ≥ 99%, duplicate terminal effect = 0</td></tr>
-          <tr><td>직접 요청 반응성</td><td>15%</td><td>owner lane이 ambient provider call에 30–50초 점유될 수 있음</td><td>55/57 calls 연속 점유를 1 call/admission으로 제한; call 자체의 점유는 남음</td><td>enqueue→turn-start p95 ≤ 2s, 접수 응답 p95 ≤ 5s</td></tr>
-          <tr><td>채널·세션 연속성</td><td>15%</td><td>Discord presence만 alive; Slack/Voice E2E 미검증</td><td>영향 없음</td><td>Discord/Slack/Dashboard/Voice route accuracy 100%, restart replay 100%</td></tr>
-          <tr><td>무유실·판정 정확성</td><td>10%</td><td>blind TTL + partial verdict 무증거 Pending</td><td>TTL 제거, exact ID coverage, context cohort로 개선</td><td>silent discard = 0, cross-context batch = 0, 모든 defer에 typed evidence</td></tr>
-          <tr><td>운영자 신뢰</td><td>10%</td><td>health cache는 수 ms이나 fleet는 0</td><td>영향 없음</td><td>incomplete count를 green/zero로 투영한 횟수 = 0</td></tr>
+          <tr><td>실행 가능성</td><td>25%</td><td>13/13 executable point sample; 8시간 증거 없음 → 0점</td><td>queue schema 장애와 무관</td><td>목표 10 Keeper 10/10 executable, 8시간 동안 fleet reaction capacity &gt; 0</td></tr>
+          <tr><td>End-to-end useful completion</td><td>25%</td><td>durable event 1,130/1,130 pending, mixed-workload terminal SLO 표본 없음 → 0점</td><td>attention 판정 비용만 줄이며 고객 결과 완료를 증명하지 않음</td><td>명시적 거절 제외 요청의 terminal receipt ≥ 99%, duplicate terminal effect = 0</td></tr>
+          <tr><td>직접 요청 반응성</td><td>15%</td><td>owner lane이 ambient provider call에 30–50초 점유될 수 있고 direct-input p95 미측정 → 0점</td><td>55/57 calls 연속 점유를 1 call/admission으로 제한; call 자체의 점유는 남음</td><td>enqueue→turn-start p95 ≤ 2s, 접수 응답 p95 ≤ 5s</td></tr>
+          <tr><td>채널·세션 연속성</td><td>15%</td><td>transport/presence 생존만 확인; Slack/Voice/원채널 terminal E2E 미검증 → 0점</td><td>영향 없음</td><td>Discord/Slack/Dashboard/Voice route accuracy 100%, restart replay 100%</td></tr>
+          <tr><td>무유실·판정 정확성</td><td>10%</td><td>live main은 blind TTL + partial verdict 계약을 보유; follow-up 미병합 → 0점</td><td>후속 #25092에서 TTL 제거, exact ID coverage, context cohort로 개선</td><td>silent discard = 0, cross-context batch = 0, 모든 defer에 typed evidence</td></tr>
+          <tr><td>운영자 신뢰</td><td>10%</td><td>overall degraded/operator action required, stale pending 1,130 → 0점</td><td>영향 없음</td><td>incomplete count를 green/zero로 투영한 횟수 = 0</td></tr>
         </tbody>
       </table>
     </div>
-    <p><strong>점수 공식:</strong> <code>Σ(weight × gate achievement)</code>. 각 gate는 통과 1 / 실패·Unknown 0으로 계산한다. 샘플이 없는 주장은 0점, HTTP 생존은 실행 가능성의 대체 지표가 아니다. 따라서 현재 live 제품 점수는 <strong>0.0 / 10</strong>이다. v3 fleet를 복구하고 본 follow-up의 무유실 계약까지 통과해도, completion·latency·channel·operator gate가 미검증이면 최대 <strong>3.5 / 10</strong>이다. 즉 #25073 계열만으로는 출시 점수 9.0에 도달하지 않는다.</p>
+    <p><strong>점수 공식:</strong> <code>Σ(weight × gate achievement)</code>. 각 gate는 통과 1 / 실패·Unknown 0으로 계산한다. 샘플이 없는 주장은 0점, HTTP 생존과 point-in-time fiber 수는 8시간 실행 가능성의 대체 지표가 아니다. 따라서 fleet가 회복된 현재도 엄격한 live 제품 점수는 <strong>0.0 / 10</strong>이다. v3 fleet가 8시간 gate를 통과하고 본 follow-up의 무유실 계약까지 통과하면 최대 <strong>3.5 / 10</strong>이지만, completion·latency·channel·operator gate 없이는 그 이상을 받을 수 없다. 즉 #25073 계열만으로는 출시 점수 9.0에 도달하지 않는다.</p>
+    <p><strong>고객 유용성 결론:</strong> 개발자·운영자가 제한된 canary를 시작할 기반은 회복됐지만, 일반 고객에게 “맡기고 떠나도 결과가 온다”고 약속할 수 있는 제품은 아니다. 1,130개 pending을 정상 처리·격리·실패 종결하는 증거 없이 채널 수나 Keeper 수를 늘리면 고객 가치는 늘지 않고 지연과 불신만 증폭된다.</p>
     <p><strong>9.0 release floor:</strong> 위 6개 축의 가중 합 ≥ 9.0이고, 동시에 실행 가능성·terminal exactly-once·silent loss 세 hard gate가 모두 통과해야 한다. 평균 점수가 높아도 이 셋 중 하나가 0이면 출시 불가다.</p>
   </section>
 

--- a/lib/keeper/keeper_board_attention_candidate.ml
+++ b/lib/keeper/keeper_board_attention_candidate.ml
@@ -725,20 +725,29 @@ let update_ledger ~base_path ~keeper_name decide =
      made every update O(n^2) because the durable transaction re-parses the whole
      ledger before writing. Rewriting keeps the file bounded to the number of
      distinct candidates. *)
-  match
-    Fs_compat.rewrite_private_file_durable_locked_result path (fun content ->
-      match load_candidates_from_content content with
-      | Error detail -> None, Error detail
-      | Ok candidates ->
-        (match decide candidates with
-         | Error _ as error -> None, error
-         | Ok (None, result) -> None, Ok result
-         | Ok (Some candidate, result) ->
-           let compacted = latest_candidates (candidates @ [ candidate ]) in
-           Some (serialize_candidates compacted), Ok result))
+  try
+    match
+      Fs_compat.rewrite_private_file_durable_locked_result path (fun content ->
+        match load_candidates_from_content content with
+        | Error detail -> None, Error detail
+        | Ok candidates ->
+          (match decide candidates with
+           | Error _ as error -> None, error
+           | Ok (None, result) -> None, Ok result
+           | Ok (Some candidate, result) ->
+             let compacted = latest_candidates (candidates @ [ candidate ]) in
+             Some (serialize_candidates compacted), Ok result))
+    with
+    | Error error -> Error error
+    | Ok result -> result
   with
-  | Error error -> Error error
-  | Ok result -> result
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | (Sys_error _ | Unix.Unix_error _) as exn ->
+    Error
+      (Printf.sprintf
+         "Board attention ledger update failed path=%s: %s"
+         path
+         (Printexc.to_string exn))
 ;;
 
 let find_candidate candidates candidate_id =

--- a/lib/keeper/keeper_board_attention_candidate.ml
+++ b/lib/keeper/keeper_board_attention_candidate.ml
@@ -10,7 +10,6 @@ type retryable_failure_kind =
   | Provider_unavailable
   | Response_contract_unavailable
   | Durable_delivery_unavailable
-  | Lifecycle_policy_migrated
 
 type retryable_failure =
   { kind : retryable_failure_kind
@@ -88,7 +87,6 @@ let retryable_failure_kind_to_string = function
   | Provider_unavailable -> "provider_unavailable"
   | Response_contract_unavailable -> "response_contract_unavailable"
   | Durable_delivery_unavailable -> "durable_delivery_unavailable"
-  | Lifecycle_policy_migrated -> "lifecycle_policy_migrated"
 ;;
 
 let retryable_failure_kind_of_string = function
@@ -97,7 +95,6 @@ let retryable_failure_kind_of_string = function
   | "provider_unavailable" -> Some Provider_unavailable
   | "response_contract_unavailable" -> Some Response_contract_unavailable
   | "durable_delivery_unavailable" -> Some Durable_delivery_unavailable
-  | "lifecycle_policy_migrated" -> Some Lifecycle_policy_migrated
   | _ -> None
 ;;
 
@@ -529,20 +526,6 @@ let status_of_yojson json =
     let* consumed_at_json = field ~context "consumed_at" fields in
     let* consumed_at = float_json ~context:(context ^ ".consumed_at") consumed_at_json in
     Ok (Consumed { judgment; delivery; consumed_at })
-  | "expired" ->
-    let* () = exact_fields ~context [ "kind"; "expired_at" ] fields in
-    let* expired_at_json = field ~context "expired_at" fields in
-    let* expired_at = float_json ~context:(context ^ ".expired_at") expired_at_json in
-    Ok
-      (Pending
-         { last_failure =
-             Some
-               { kind = Lifecycle_policy_migrated
-               ; detail =
-                   "legacy wall-clock expiry recovered to Pending; no customer work was discarded"
-               ; failed_at = expired_at
-               }
-         })
   | value -> Error (Printf.sprintf "unknown Board attention candidate status %S" value)
 ;;
 

--- a/lib/keeper/keeper_board_attention_candidate.ml
+++ b/lib/keeper/keeper_board_attention_candidate.ml
@@ -846,7 +846,7 @@ let update_candidate_batch ~base_path ~keeper_name candidates transition =
       Ok
         ( (match updated_rows with
            | [] -> None
-           | _ -> Some (List.rev updated_rows))
+           | _ :: _ -> Some (List.rev updated_rows))
         , selected_in_request_order ))
 ;;
 

--- a/lib/keeper/keeper_board_attention_candidate.ml
+++ b/lib/keeper/keeper_board_attention_candidate.ml
@@ -10,6 +10,7 @@ type retryable_failure_kind =
   | Provider_unavailable
   | Response_contract_unavailable
   | Durable_delivery_unavailable
+  | Lifecycle_policy_migrated
 
 type retryable_failure =
   { kind : retryable_failure_kind
@@ -40,13 +41,10 @@ type consumed_state =
   ; consumed_at : float
   }
 
-type expired_state = { expired_at : float }
-
 type status =
   | Pending of pending_state
   | Judged of judged_state
   | Consumed of consumed_state
-  | Expired of expired_state
 
 type candidate =
   { candidate_id : string
@@ -90,6 +88,7 @@ let retryable_failure_kind_to_string = function
   | Provider_unavailable -> "provider_unavailable"
   | Response_contract_unavailable -> "response_contract_unavailable"
   | Durable_delivery_unavailable -> "durable_delivery_unavailable"
+  | Lifecycle_policy_migrated -> "lifecycle_policy_migrated"
 ;;
 
 let retryable_failure_kind_of_string = function
@@ -98,6 +97,7 @@ let retryable_failure_kind_of_string = function
   | "provider_unavailable" -> Some Provider_unavailable
   | "response_contract_unavailable" -> Some Response_contract_unavailable
   | "durable_delivery_unavailable" -> Some Durable_delivery_unavailable
+  | "lifecycle_policy_migrated" -> Some Lifecycle_policy_migrated
   | _ -> None
 ;;
 
@@ -301,11 +301,6 @@ let status_to_yojson = function
       ; "judgment", judgment_to_yojson consumed.judgment
       ; "delivery", `String (delivery_to_string consumed.delivery)
       ; "consumed_at", `Float consumed.consumed_at
-      ]
-  | Expired expired ->
-    `Assoc
-      [ "kind", `String "expired"
-      ; "expired_at", `Float expired.expired_at
       ]
 ;;
 
@@ -538,7 +533,16 @@ let status_of_yojson json =
     let* () = exact_fields ~context [ "kind"; "expired_at" ] fields in
     let* expired_at_json = field ~context "expired_at" fields in
     let* expired_at = float_json ~context:(context ^ ".expired_at") expired_at_json in
-    Ok (Expired { expired_at })
+    Ok
+      (Pending
+         { last_failure =
+             Some
+               { kind = Lifecycle_policy_migrated
+               ; detail =
+                   "legacy wall-clock expiry recovered to Pending; no customer work was discarded"
+               ; failed_at = expired_at
+               }
+         })
   | value -> Error (Printf.sprintf "unknown Board attention candidate status %S" value)
 ;;
 
@@ -795,7 +799,7 @@ let record_retryable_failure ~base_path candidate failure =
               { current with
                 status = Judged { judged with last_failure = Some failure }
               })
-       | Consumed _ | Expired _ -> None)
+       | Consumed _ -> None)
 ;;
 
 let record_judgment ~base_path candidate judgment =
@@ -810,7 +814,7 @@ let record_judgment ~base_path candidate judgment =
            { current with
              status = Judged { judgment; last_failure = None }
            }
-       | Judged _ | Consumed _ | Expired _ -> None)
+       | Judged _ | Consumed _ -> None)
 ;;
 
 let mark_consumed ~base_path candidate judgment delivery =
@@ -827,7 +831,7 @@ let mark_consumed ~base_path candidate judgment delivery =
                Consumed
                  { judgment; delivery; consumed_at = Time_compat.now () }
            }
-       | Pending _ | Consumed _ | Expired _ -> None)
+       | Pending _ | Consumed _ -> None)
 ;;
 
 let failure ~kind detail = { kind; detail; failed_at = Time_compat.now () }
@@ -930,7 +934,7 @@ let reject_unregistered_tool ~name ~args:_ =
 
 let rec process_with_judge ~base_path ~judge candidate =
   match candidate.status with
-  | Consumed _ | Expired _ -> Ok candidate
+  | Consumed _ -> Ok candidate
   | Judged judged -> consume_judged ~base_path candidate judged
   | Pending _ ->
     (match judge candidate with
@@ -953,7 +957,7 @@ let record_and_wake ~base_path candidate =
       match persisted.status with
       | Pending _ | Judged _ ->
         Wake_requested (request_owner_wake ~site:"duplicate" ~base_path persisted)
-      | Consumed _ | Expired _ -> Wake_not_required
+      | Consumed _ -> Wake_not_required
     in
     Ok
       { candidate = persisted
@@ -962,29 +966,56 @@ let record_and_wake ~base_path candidate =
       }
 ;;
 
-(* ── TTL and batch judgment ───────────────────────────── *)
+(* ── Batch judgment ───────────────────────────────────── *)
 
 let prompt_name_batch = Keeper_prompt_names.board_attention_judgment_batch
 let batch_max_candidates = 8
-let candidate_ttl_sec = 86_400.0
 
-let is_pending_expired ~now candidate =
-  match candidate.status with
-  | Pending _ ->
-    Float.compare candidate.recorded_at (now -. candidate_ttl_sec) < 0
-  | Judged _ | Consumed _ | Expired _ -> false
+let rec canonical_json = function
+  | `Assoc fields ->
+    `Assoc
+      (fields
+       |> List.map (fun (key, value) -> key, canonical_json value)
+       |> List.sort (fun (left, _) (right, _) -> String.compare left right))
+  | `List values -> `List (List.map canonical_json values)
+  | (`Bool _ | `Float _ | `Int _ | `Intlit _ | `Null | `String _) as scalar ->
+    scalar
 ;;
 
-let expire_candidate ~base_path ~now candidate =
-  update_candidate
-    ~base_path
-    candidate.candidate_id
-    candidate.keeper_name
-    (fun current ->
-       match current.status with
-       | Pending _ ->
-         Some { current with status = Expired { expired_at = now } }
-       | Judged _ | Consumed _ | Expired _ -> None)
+let keeper_context_key candidate =
+  match candidate.judgment_request with
+  | `Assoc fields ->
+    (match List.assoc_opt "keeper_context" fields with
+     | Some context -> Ok (Yojson.Safe.to_string (canonical_json context))
+     | None -> Error "judgment request lacks keeper_context")
+  | _ -> Error "judgment request is not an object"
+;;
+
+let select_context_batch candidates =
+  match candidates with
+  | [] -> [], []
+  | first :: rest ->
+    (match keeper_context_key first with
+     | Error _ -> [ first ], rest
+     | Ok first_key ->
+       let rec loop selected deferred selected_count = function
+         | [] -> List.rev selected, List.rev deferred
+         | candidate :: tail ->
+           if selected_count < batch_max_candidates
+           then
+             (match keeper_context_key candidate with
+              | Ok key when String.equal first_key key ->
+                loop
+                  (candidate :: selected)
+                  deferred
+                  (selected_count + 1)
+                  tail
+              | Ok _ | Error _ ->
+                loop selected (candidate :: deferred) selected_count tail)
+           else
+             loop selected (candidate :: deferred) selected_count tail
+       in
+       loop [ first ] [] 1 rest)
 ;;
 
 let batch_request_json candidates =
@@ -1143,20 +1174,6 @@ let apply_judgment ~base_path candidate judgment =
   process_with_judge ~base_path ~judge:(fun _ -> Ok judgment) candidate
 ;;
 
-let chunks_of size items =
-  let rec loop current count chunks = function
-    | [] ->
-      (match current with
-       | [] -> List.rev chunks
-       | _ -> List.rev (List.rev current :: chunks))
-    | x :: rest ->
-      if count = size
-      then loop [ x ] 1 (List.rev current :: chunks) rest
-      else loop (x :: current) (count + 1) chunks rest
-  in
-  loop [] 0 [] items
-;;
-
 let record_batch_failure ~base_path candidate failure =
   match record_retryable_failure ~base_path candidate failure with
   | Ok _ -> ()
@@ -1169,35 +1186,45 @@ let record_batch_failure ~base_path candidate failure =
       detail
 ;;
 
-let drain_pending_with_judge_batch ~base_path ~keeper_name ~now ~judge_batch =
-  let* candidates = load_candidates ~base_path ~keeper_name in
-  let stale, judged_ready, pending =
+let validate_batch_coverage batch judgments =
+  let requested =
     List.fold_left
-      (fun (stale, judged_ready, pending) candidate ->
+      (fun ids candidate -> Id_set.add candidate.candidate_id ids)
+      Id_set.empty
+      batch
+  in
+  let returned =
+    Candidate_map.fold
+      (fun candidate_id _ ids -> Id_set.add candidate_id ids)
+      judgments
+      Id_set.empty
+  in
+  if Id_set.equal requested returned
+  then Ok ()
+  else
+    let missing = Id_set.diff requested returned |> Id_set.elements in
+    let unknown = Id_set.diff returned requested |> Id_set.elements in
+    Error
+      (failure
+         ~kind:Response_contract_unavailable
+         (Printf.sprintf
+            "batch verdict identity mismatch missing=[%s] unknown=[%s]"
+            (String.concat "," missing)
+            (String.concat "," unknown)))
+;;
+
+let drain_pending_with_judge_batch ~base_path ~keeper_name ~judge_batch =
+  let* candidates = load_candidates ~base_path ~keeper_name in
+  let judged_ready, pending =
+    List.fold_left
+      (fun (judged_ready, pending) candidate ->
          match candidate.status with
-         | Pending _ when is_pending_expired ~now candidate ->
-           candidate :: stale, judged_ready, pending
-         | Pending _ -> stale, judged_ready, candidate :: pending
-         | Judged judged -> stale, (candidate, judged) :: judged_ready, pending
-         | Consumed _ | Expired _ -> stale, judged_ready, pending)
-      ([], [], [])
+         | Pending _ -> judged_ready, candidate :: pending
+         | Judged judged -> (candidate, judged) :: judged_ready, pending
+         | Consumed _ -> judged_ready, pending)
+      ([], [])
       candidates
   in
-  (* Stale pending rows expire first: the durable backlog must die even while
-     the provider is unavailable. *)
-  let* () =
-    List.fold_left
-      (fun result candidate ->
-         match result with
-         | Error _ -> result
-         | Ok () ->
-           (match expire_candidate ~base_path ~now candidate with
-            | Ok _ -> Ok ()
-            | Error detail -> Error detail))
-      (Ok ())
-      stale
-  in
-  let expired_count = List.length stale in
   (* Already-judged verdicts deliver without new model calls. *)
   let* judged_consumed, judged_remaining =
     List.fold_left
@@ -1209,66 +1236,65 @@ let drain_pending_with_judge_batch ~base_path ~keeper_name ~now ~judge_batch =
             | Ok current ->
               (match current.status with
                | Consumed _ -> Ok (consumed + 1, remaining)
-               | Pending _ | Judged _ | Expired _ -> Ok (consumed, remaining + 1))
+               | Pending _ | Judged _ -> Ok (consumed, remaining + 1))
             | Error detail -> Error detail))
       (Ok (0, 0))
       judged_ready
   in
-  (* Fresh pending rows are judged in batches. A failed batch aborts the
-     round: the next keepalive turn owns the retry cadence, not a hot loop. *)
-  let batches = chunks_of batch_max_candidates (List.rev pending) in
-  let rec loop report = function
-    | [] -> Ok report
-    | batch :: rest ->
+  (* A single owner admission performs at most one provider call, and that
+     call contains one exact persisted Keeper context. Other contexts and
+     capacity overflow remain durable for a later admission. *)
+  let batch, deferred = select_context_batch (List.rev pending) in
+  let* batch_report =
+    match batch with
+    | [] -> Ok { attempted = 0; consumed = 0; remaining = 0 }
+    | _ ->
       (match judge_batch batch with
        | Error failure ->
          List.iter
            (fun candidate -> record_batch_failure ~base_path candidate failure)
            batch;
-         let deferred =
-           List.fold_left
-             (fun count rest_batch -> count + List.length rest_batch)
-             (List.length batch)
-             rest
-         in
          Ok
-           { report with
-             attempted = report.attempted + List.length batch
-           ; remaining = report.remaining + deferred
+           { attempted = List.length batch
+           ; consumed = 0
+           ; remaining = List.length batch + List.length deferred
            }
-       | Ok map ->
-         (match
-            List.fold_left
-              (fun result candidate ->
-                 match result with
-                 | Error _ -> result
-                 | Ok (consumed, remaining) ->
-                   (match Candidate_map.find_opt candidate.candidate_id map with
-                    | None -> Ok (consumed, remaining + 1)
-                    | Some judgment ->
-                      (match apply_judgment ~base_path candidate judgment with
-                       | Ok current ->
-                         (match current.status with
-                          | Consumed _ -> Ok (consumed + 1, remaining)
-                          | Pending _ | Judged _ | Expired _ ->
-                            Ok (consumed, remaining + 1))
-                       | Error detail -> Error detail)))
-              (Ok (0, 0))
-              batch
-          with
-          | Error detail -> Error detail
-          | Ok (consumed, remaining) ->
-            loop
-              { attempted = report.attempted + List.length batch
-              ; consumed = report.consumed + consumed
-              ; remaining = report.remaining + remaining
+       | Ok judgments ->
+         (match validate_batch_coverage batch judgments with
+          | Error failure ->
+            List.iter
+              (fun candidate -> record_batch_failure ~base_path candidate failure)
+              batch;
+            Ok
+              { attempted = List.length batch
+              ; consumed = 0
+              ; remaining = List.length batch + List.length deferred
               }
-              rest))
+          | Ok () ->
+            let* consumed, remaining =
+              List.fold_left
+                (fun result candidate ->
+                   let* consumed, remaining = result in
+                   match Candidate_map.find_opt candidate.candidate_id judgments with
+                   | None ->
+                     Error "validated batch verdict disappeared before application"
+                   | Some judgment ->
+                     let* current = apply_judgment ~base_path candidate judgment in
+                     (match current.status with
+                      | Consumed _ -> Ok (consumed + 1, remaining)
+                      | Pending _ | Judged _ -> Ok (consumed, remaining + 1)))
+                (Ok (0, 0))
+                batch
+            in
+            Ok
+              { attempted = List.length batch
+              ; consumed
+              ; remaining = remaining + List.length deferred
+              }))
   in
-  let* batch_report = loop { attempted = 0; consumed = 0; remaining = 0 } batches in
   Ok
     { attempted = batch_report.attempted + judged_consumed + judged_remaining
-    ; consumed = batch_report.consumed + judged_consumed + expired_count
+    ; consumed = batch_report.consumed + judged_consumed
     ; remaining = batch_report.remaining + judged_remaining
     }
 ;;
@@ -1277,14 +1303,13 @@ let drain_pending_on_owner_lane ~base_path ~keeper_name =
   drain_pending_with_judge_batch
     ~base_path
     ~keeper_name
-    ~now:(Time_compat.now ())
     ~judge_batch:(run_judge_batch ~base_path)
 ;;
 
 module For_testing = struct
   let drain_pending_with_judge_batch = drain_pending_with_judge_batch
 
-  let drain_pending_with_judge ~base_path ~keeper_name ~now ~judge =
+  let drain_pending_with_judge ~base_path ~keeper_name ~judge =
     let judge_batch candidates =
       let rec fold map = function
         | [] -> Ok map
@@ -1296,7 +1321,7 @@ module For_testing = struct
       in
       fold Candidate_map.empty candidates
     in
-    drain_pending_with_judge_batch ~base_path ~keeper_name ~now ~judge_batch
+    drain_pending_with_judge_batch ~base_path ~keeper_name ~judge_batch
   ;;
 end
 ;;

--- a/lib/keeper/keeper_board_attention_candidate.ml
+++ b/lib/keeper/keeper_board_attention_candidate.ml
@@ -703,7 +703,7 @@ let ledger_rewrite_observer : (unit -> unit) Atomic.t =
   Atomic.make (fun () -> ())
 ;;
 
-let update_ledger_many ~base_path ~keeper_name decide =
+let update_ledger_many ?(move_updated_to_back = false) ~base_path ~keeper_name decide =
   let path = candidate_path ~base_path ~keeper_name in
   (* Compact on write: a committed change rewrites the ledger as the deduped
      latest-per-id set (via [latest_candidates]) instead of appending one row.
@@ -723,7 +723,21 @@ let update_ledger_many ~base_path ~keeper_name decide =
            | Error _ as error -> None, error
            | Ok (None, result) -> None, Ok result
            | Ok (Some updated, result) ->
-             let compacted = latest_candidates (candidates @ updated) in
+             let compacted =
+               if move_updated_to_back
+               then
+                 let updated_ids =
+                   List.fold_left
+                     (fun ids candidate -> Id_set.add candidate.candidate_id ids)
+                     Id_set.empty
+                     updated
+                 in
+                 List.filter
+                   (fun candidate -> not (Id_set.mem candidate.candidate_id updated_ids))
+                   candidates
+                 @ updated
+               else latest_candidates (candidates @ updated)
+             in
              Some (serialize_candidates compacted), Ok result))
     with
     | Error error -> Error error
@@ -780,7 +794,13 @@ let update_candidate ~base_path candidate_id keeper_name transition =
        | Some updated -> Ok (Some updated, updated)))
 ;;
 
-let update_candidate_batch ~base_path ~keeper_name candidates transition =
+let update_candidate_batch
+      ?(move_updated_to_back = false)
+      ~base_path
+      ~keeper_name
+      candidates
+      transition
+  =
   let requested =
     List.fold_left
       (fun result candidate ->
@@ -792,7 +812,7 @@ let update_candidate_batch ~base_path ~keeper_name candidates transition =
       candidates
   in
   let* requested = requested in
-  update_ledger_many ~base_path ~keeper_name (fun current_rows ->
+  update_ledger_many ~move_updated_to_back ~base_path ~keeper_name (fun current_rows ->
     let found, updated_rows, selected =
       List.fold_left
         (fun (found, updated_rows, selected) current ->
@@ -801,7 +821,9 @@ let update_candidate_batch ~base_path ~keeper_name candidates transition =
            else
              let next = transition current in
              ( Id_set.add current.candidate_id found
-             , (if next = current then updated_rows else next :: updated_rows)
+             , (if next = current && not move_updated_to_back
+                then updated_rows
+                else next :: updated_rows)
              , Candidate_map.add current.candidate_id next selected ))
         (Id_set.empty, [], Candidate_map.empty)
         current_rows
@@ -1238,10 +1260,19 @@ let record_batch_failures ~base_path candidates failure =
   | first :: _ ->
     (match
        update_candidate_batch
+         ~move_updated_to_back:true
          ~base_path
          ~keeper_name:first.keeper_name
          candidates
-         (fun current -> candidate_with_retryable_failure current failure)
+         (fun current ->
+            match current.status with
+            | Pending _ ->
+              { current with status = Pending { last_failure = Some failure } }
+            | Judged judged ->
+              { current with
+                status = Judged { judged with last_failure = Some failure }
+              }
+            | Consumed _ -> current)
      with
      | Ok _ -> Ok ()
      | Error detail ->
@@ -1278,96 +1309,90 @@ let delivery_of_judgment judgment =
   | Keeper_board_attention_judgment.Relevant -> Enqueued_to_keeper_lane
 ;;
 
-let enqueue_batch_deliveries ~base_path candidates =
-  List.fold_left
-    (fun result candidate ->
-       let* () = result in
-       match candidate.status with
-       | Judged judged ->
-         (match judged.judgment.verdict.decision with
-          | Keeper_board_attention_judgment.Not_relevant -> Ok ()
-          | Keeper_board_attention_judgment.Relevant ->
-            let stimulus = board_attention_stimulus candidate in
-            (match
-               Keeper_registry_event_queue.enqueue_if_missing_durable_result
-                 ~base_path
-                 ~event_id:candidate.candidate_id
-                 candidate.keeper_name
-                 stimulus
-             with
-             | Keeper_registry_event_queue.Enqueued
-             | Keeper_registry_event_queue.Already_present -> Ok ()
-             | Keeper_registry_event_queue.Identity_conflict detail
-             | Keeper_registry_event_queue.Storage_error detail -> Error detail))
+type batch_consumption =
+  | Delivery_complete of int
+  | Delivery_blocked of
+      { consumed : int
+      ; remaining : int
+      }
+
+let deliver_judged ~base_path candidate judged =
+  let* () =
+    match judged.judgment.verdict.decision with
+    | Keeper_board_attention_judgment.Not_relevant -> Ok ()
+    | Keeper_board_attention_judgment.Relevant ->
+      let stimulus = board_attention_stimulus candidate in
+      (match
+         Keeper_registry_event_queue.enqueue_if_missing_durable_result
+           ~base_path
+           ~event_id:candidate.candidate_id
+           candidate.keeper_name
+           stimulus
+       with
+       | Keeper_registry_event_queue.Enqueued
+       | Keeper_registry_event_queue.Already_present -> Ok ()
+       | Keeper_registry_event_queue.Identity_conflict detail
+       | Keeper_registry_event_queue.Storage_error detail -> Error detail)
+  in
+  mark_consumed ~base_path candidate judged.judgment (delivery_of_judgment judged.judgment)
+;;
+
+(* Delivery is committed candidate-by-candidate before control returns to the
+   owner lane, so an earlier durable enqueue cannot be acknowledged while its
+   ledger row still waits behind a later failing candidate. *)
+let consume_judged_batch ~base_path candidates =
+  let rec loop consumed wake_candidate = function
+    | [] ->
+      (match wake_candidate with
+       | None -> ()
+       | Some candidate ->
+         let (_ : Keeper_registry.wakeup_outcome) =
+           request_owner_wake ~site:"durable_batch_delivery" ~base_path candidate
+         in
+         ());
+      Ok (Delivery_complete consumed)
+    | candidate :: rest ->
+      (match candidate.status with
+       | Consumed _ -> loop consumed wake_candidate rest
        | Pending _ ->
          Error
            (Printf.sprintf
               "candidate %s was not durably judged before batch delivery"
               candidate.candidate_id)
-       | Consumed _ -> Ok ())
-    (Ok ())
-    candidates
-;;
-
-(* The candidate ledger and Keeper event queue are separate durable files, so
-   pretending they share one atomic transaction would create an unprovable
-   exactly-once boundary. The caller first commits every verdict as [Judged].
-   This function then performs idempotent event enqueues and commits every
-   [Consumed] row together. A crash between those steps replays from [Judged];
-   event identity makes the enqueue replay safe. *)
-let consume_judged_batch ~base_path candidates =
-  match candidates with
-  | [] -> Ok (0, 0)
-  | first :: _ ->
-    (match enqueue_batch_deliveries ~base_path candidates with
-     | Error detail ->
-       let delivery_failure = failure ~kind:Durable_delivery_unavailable detail in
-       let* () = record_batch_failures ~base_path candidates delivery_failure in
-       Ok (0, List.length candidates)
-     | Ok () ->
-       let consumed_at = Time_compat.now () in
-       let* current =
-         update_candidate_batch
-           ~base_path
-           ~keeper_name:first.keeper_name
-           candidates
-           (fun candidate ->
-              match candidate.status with
-              | Judged judged ->
-                { candidate with
-                  status =
-                    Consumed
-                      { judgment = judged.judgment
-                      ; delivery = delivery_of_judgment judged.judgment
-                      ; consumed_at
-                      }
-                }
-              | Pending _ | Consumed _ -> candidate)
-       in
-       let consumed, remaining, wake_candidate =
-         List.fold_left
-           (fun (consumed, remaining, wake_candidate) candidate ->
-              match candidate.status with
-              | Consumed { delivery = Enqueued_to_keeper_lane; _ } ->
-                ( consumed + 1
-                , remaining
-                , (match wake_candidate with
-                   | Some _ -> wake_candidate
-                   | None -> Some candidate) )
-              | Consumed { delivery = Not_relevant; _ } ->
-                consumed + 1, remaining, wake_candidate
-              | Pending _ | Judged _ -> consumed, remaining + 1, wake_candidate)
-           (0, 0, None)
-           current
-       in
-       (match wake_candidate with
-        | None -> ()
-        | Some candidate ->
-          let (_ : Keeper_registry.wakeup_outcome) =
-            request_owner_wake ~site:"durable_batch_delivery" ~base_path candidate
-          in
-          ());
-       Ok (consumed, remaining))
+       | Judged judged ->
+         (match deliver_judged ~base_path candidate judged with
+          | Ok consumed_candidate ->
+            (match consumed_candidate.status with
+             | Consumed { delivery = Enqueued_to_keeper_lane; _ } ->
+               let wake_candidate =
+                 match wake_candidate with
+                 | Some _ -> wake_candidate
+                 | None -> Some consumed_candidate
+               in
+               loop (consumed + 1) wake_candidate rest
+             | Consumed { delivery = Not_relevant; _ } ->
+               loop (consumed + 1) wake_candidate rest
+             | Pending _ | Judged _ ->
+               Error
+                 (Printf.sprintf
+                    "candidate %s did not commit delivery completion"
+                    candidate.candidate_id))
+          | Error detail ->
+            let delivery_failure =
+              failure ~kind:Durable_delivery_unavailable detail
+            in
+            let remaining_candidates = candidate :: rest in
+            let* () =
+              record_batch_failures
+                ~base_path
+                remaining_candidates
+                delivery_failure
+            in
+            Ok
+              (Delivery_blocked
+                 { consumed; remaining = List.length remaining_candidates })))
+  in
+  loop 0 None candidates
 ;;
 
 let validate_batch_coverage batch judgments =
@@ -1411,17 +1436,22 @@ let drain_pending_with_judge_batch ~base_path ~keeper_name ~judge_batch =
   in
   (* Already-judged verdicts deliver without new model calls. *)
   let judged_candidates = List.map fst judged_ready in
-  let* judged_consumed, judged_remaining =
-    consume_judged_batch ~base_path judged_candidates
+  let* judged_delivery = consume_judged_batch ~base_path judged_candidates in
+  let judged_consumed, judged_remaining, judged_blocked =
+    match judged_delivery with
+    | Delivery_complete consumed -> consumed, 0, false
+    | Delivery_blocked { consumed; remaining } -> consumed, remaining, true
   in
   (* A single owner admission performs at most one provider call, and that
      call contains one exact persisted Keeper context. Other contexts and
      capacity overflow remain durable for a later admission. *)
   let batch, deferred = select_context_batch (List.rev pending) in
   let* batch_report =
-    match batch with
-    | [] -> Ok { attempted = 0; consumed = 0; remaining = 0 }
-    | _ ->
+    match judged_blocked, batch with
+    | true, _ ->
+      Ok { attempted = 0; consumed = 0; remaining = List.length pending }
+    | false, [] -> Ok { attempted = 0; consumed = 0; remaining = 0 }
+    | false, _ ->
       (match judge_batch batch with
        | Error failure ->
          let* () = record_batch_failures ~base_path batch failure in
@@ -1441,16 +1471,23 @@ let drain_pending_with_judge_batch ~base_path ~keeper_name ~judge_batch =
               }
           | Ok () ->
             let* judged = record_batch_judgments ~base_path batch judgments in
-            let* consumed, remaining = consume_judged_batch ~base_path judged in
+            let* delivery = consume_judged_batch ~base_path judged in
+            let consumed, remaining, delivery_blocked =
+              match delivery with
+              | Delivery_complete consumed -> consumed, 0, false
+              | Delivery_blocked { consumed; remaining } ->
+                consumed, remaining, true
+            in
             let remaining = remaining + List.length deferred in
             let continuation_candidate =
-              match deferred with
-              | candidate :: _ -> Some candidate
-              | [] when remaining > 0 ->
+              match delivery_blocked, deferred with
+              | true, _ -> None
+              | false, candidate :: _ -> Some candidate
+              | false, [] when remaining > 0 ->
                 (match judged with
                  | candidate :: _ -> Some candidate
                  | [] -> None)
-              | [] -> None
+              | false, [] -> None
             in
             (match continuation_candidate with
              | None -> ()

--- a/lib/keeper/keeper_board_attention_candidate.ml
+++ b/lib/keeper/keeper_board_attention_candidate.ml
@@ -1176,14 +1176,24 @@ let apply_judgment ~base_path candidate judgment =
 
 let record_batch_failure ~base_path candidate failure =
   match record_retryable_failure ~base_path candidate failure with
-  | Ok _ -> ()
+  | Ok _ -> Ok ()
   | Error detail ->
-    Log.Keeper.error
-      "Board attention batch failure evidence could not be persisted keeper=%s \
-       candidate=%s: %s"
-      candidate.keeper_name
-      candidate.candidate_id
-      detail
+    Error
+      (Printf.sprintf
+         "Board attention batch failure evidence could not be persisted keeper=%s \
+          candidate=%s: %s"
+         candidate.keeper_name
+         candidate.candidate_id
+         detail)
+;;
+
+let record_batch_failures ~base_path candidates failure =
+  List.fold_left
+    (fun result candidate ->
+       let* () = result in
+       record_batch_failure ~base_path candidate failure)
+    (Ok ())
+    candidates
 ;;
 
 let validate_batch_coverage batch judgments =
@@ -1251,9 +1261,7 @@ let drain_pending_with_judge_batch ~base_path ~keeper_name ~judge_batch =
     | _ ->
       (match judge_batch batch with
        | Error failure ->
-         List.iter
-           (fun candidate -> record_batch_failure ~base_path candidate failure)
-           batch;
+         let* () = record_batch_failures ~base_path batch failure in
          Ok
            { attempted = List.length batch
            ; consumed = 0
@@ -1262,9 +1270,7 @@ let drain_pending_with_judge_batch ~base_path ~keeper_name ~judge_batch =
        | Ok judgments ->
          (match validate_batch_coverage batch judgments with
           | Error failure ->
-            List.iter
-              (fun candidate -> record_batch_failure ~base_path candidate failure)
-              batch;
+            let* () = record_batch_failures ~base_path batch failure in
             Ok
               { attempted = List.length batch
               ; consumed = 0

--- a/lib/keeper/keeper_board_attention_candidate.ml
+++ b/lib/keeper/keeper_board_attention_candidate.ml
@@ -1442,10 +1442,27 @@ let drain_pending_with_judge_batch ~base_path ~keeper_name ~judge_batch =
           | Ok () ->
             let* judged = record_batch_judgments ~base_path batch judgments in
             let* consumed, remaining = consume_judged_batch ~base_path judged in
+            let remaining = remaining + List.length deferred in
+            let continuation_candidate =
+              match deferred with
+              | candidate :: _ -> Some candidate
+              | [] when remaining > 0 -> List.hd_opt judged
+              | [] -> None
+            in
+            (match continuation_candidate with
+             | None -> ()
+             | Some candidate ->
+               let (_ : Keeper_registry.wakeup_outcome) =
+                 request_owner_wake
+                   ~site:"successful_batch_continuation"
+                   ~base_path
+                   candidate
+               in
+               ());
             Ok
               { attempted = List.length batch
               ; consumed
-              ; remaining = remaining + List.length deferred
+              ; remaining
               }))
   in
   Ok

--- a/lib/keeper/keeper_board_attention_candidate.ml
+++ b/lib/keeper/keeper_board_attention_candidate.ml
@@ -1446,7 +1446,10 @@ let drain_pending_with_judge_batch ~base_path ~keeper_name ~judge_batch =
             let continuation_candidate =
               match deferred with
               | candidate :: _ -> Some candidate
-              | [] when remaining > 0 -> List.hd_opt judged
+              | [] when remaining > 0 ->
+                (match judged with
+                 | candidate :: _ -> Some candidate
+                 | [] -> None)
               | [] -> None
             in
             (match continuation_candidate with

--- a/lib/keeper/keeper_board_attention_candidate.ml
+++ b/lib/keeper/keeper_board_attention_candidate.ml
@@ -716,7 +716,11 @@ let serialize_candidates candidates =
   String.concat "" (List.map append_row candidates)
 ;;
 
-let update_ledger ~base_path ~keeper_name decide =
+let ledger_rewrite_observer : (unit -> unit) Atomic.t =
+  Atomic.make (fun () -> ())
+;;
+
+let update_ledger_many ~base_path ~keeper_name decide =
   let path = candidate_path ~base_path ~keeper_name in
   (* Compact on write: a committed change rewrites the ledger as the deduped
      latest-per-id set (via [latest_candidates]) instead of appending one row.
@@ -726,6 +730,7 @@ let update_ledger ~base_path ~keeper_name decide =
      ledger before writing. Rewriting keeps the file bounded to the number of
      distinct candidates. *)
   try
+    (Atomic.get ledger_rewrite_observer) ();
     match
       Fs_compat.rewrite_private_file_durable_locked_result path (fun content ->
         match load_candidates_from_content content with
@@ -734,8 +739,8 @@ let update_ledger ~base_path ~keeper_name decide =
           (match decide candidates with
            | Error _ as error -> None, error
            | Ok (None, result) -> None, Ok result
-           | Ok (Some candidate, result) ->
-             let compacted = latest_candidates (candidates @ [ candidate ]) in
+           | Ok (Some updated, result) ->
+             let compacted = latest_candidates (candidates @ updated) in
              Some (serialize_candidates compacted), Ok result))
     with
     | Error error -> Error error
@@ -748,6 +753,14 @@ let update_ledger ~base_path ~keeper_name decide =
          "Board attention ledger update failed path=%s: %s"
          path
          (Printexc.to_string exn))
+;;
+
+let update_ledger ~base_path ~keeper_name decide =
+  update_ledger_many ~base_path ~keeper_name (fun candidates ->
+    match decide candidates with
+    | Error _ as error -> error
+    | Ok (None, result) -> Ok (None, result)
+    | Ok (Some candidate, result) -> Ok (Some [ candidate ], result))
 ;;
 
 let find_candidate candidates candidate_id =
@@ -784,8 +797,78 @@ let update_candidate ~base_path candidate_id keeper_name transition =
        | Some updated -> Ok (Some updated, updated)))
 ;;
 
+let update_candidate_batch ~base_path ~keeper_name candidates transition =
+  let requested =
+    List.fold_left
+      (fun result candidate ->
+         let* ids = result in
+         if Id_set.mem candidate.candidate_id ids
+         then Error ("duplicate candidate in atomic batch: " ^ candidate.candidate_id)
+         else Ok (Id_set.add candidate.candidate_id ids))
+      (Ok Id_set.empty)
+      candidates
+  in
+  let* requested = requested in
+  update_ledger_many ~base_path ~keeper_name (fun current_rows ->
+    let found, updated_rows, selected =
+      List.fold_left
+        (fun (found, updated_rows, selected) current ->
+           if not (Id_set.mem current.candidate_id requested)
+           then found, updated_rows, selected
+           else
+             let next = transition current in
+             ( Id_set.add current.candidate_id found
+             , (if next = current then updated_rows else next :: updated_rows)
+             , Candidate_map.add current.candidate_id next selected ))
+        (Id_set.empty, [], Candidate_map.empty)
+        current_rows
+    in
+    if not (Id_set.equal requested found)
+    then
+      let missing = Id_set.diff requested found |> Id_set.elements in
+      Error
+        (Printf.sprintf
+           "Board attention candidates not found for atomic batch: [%s]"
+           (String.concat "," missing))
+    else
+      let* selected_in_request_order =
+        List.fold_left
+          (fun result candidate ->
+             let* selected_rows = result in
+             match Candidate_map.find_opt candidate.candidate_id selected with
+             | Some current -> Ok (current :: selected_rows)
+             | None ->
+               Error ("atomic batch result missing candidate " ^ candidate.candidate_id))
+          (Ok [])
+          candidates
+        |> Result.map List.rev
+      in
+      Ok
+        ( (match updated_rows with
+           | [] -> None
+           | _ -> Some (List.rev updated_rows))
+        , selected_in_request_order ))
+;;
+
 let same_failure left right =
   left.kind = right.kind && String.equal left.detail right.detail
+;;
+
+let candidate_with_retryable_failure current failure =
+  match current.status with
+  | Pending pending ->
+    (match pending.last_failure with
+     | Some existing when same_failure existing failure -> current
+     | Some _ | None ->
+       { current with status = Pending { last_failure = Some failure } })
+  | Judged judged ->
+    (match judged.last_failure with
+     | Some existing when same_failure existing failure -> current
+     | Some _ | None ->
+       { current with
+         status = Judged { judged with last_failure = Some failure }
+       })
+  | Consumed _ -> current
 ;;
 
 let record_retryable_failure ~base_path candidate failure =
@@ -794,21 +877,8 @@ let record_retryable_failure ~base_path candidate failure =
     candidate.candidate_id
     candidate.keeper_name
     (fun current ->
-       match current.status with
-       | Pending pending ->
-         (match pending.last_failure with
-          | Some existing when same_failure existing failure -> None
-          | Some _ | None ->
-            Some { current with status = Pending { last_failure = Some failure } })
-       | Judged judged ->
-         (match judged.last_failure with
-          | Some existing when same_failure existing failure -> None
-          | Some _ | None ->
-            Some
-              { current with
-                status = Judged { judged with last_failure = Some failure }
-              })
-       | Consumed _ -> None)
+       let updated = candidate_with_retryable_failure current failure in
+       if updated = current then None else Some updated)
 ;;
 
 let record_judgment ~base_path candidate judgment =
@@ -1179,30 +1249,142 @@ let run_judge_batch ~base_path candidates =
 
 (* ── Owner-lane batch drain ───────────────────────────── *)
 
-let apply_judgment ~base_path candidate judgment =
-  process_with_judge ~base_path ~judge:(fun _ -> Ok judgment) candidate
-;;
-
-let record_batch_failure ~base_path candidate failure =
-  match record_retryable_failure ~base_path candidate failure with
-  | Ok _ -> Ok ()
-  | Error detail ->
-    Error
-      (Printf.sprintf
-         "Board attention batch failure evidence could not be persisted keeper=%s \
-          candidate=%s: %s"
-         candidate.keeper_name
-         candidate.candidate_id
-         detail)
-;;
-
 let record_batch_failures ~base_path candidates failure =
+  match candidates with
+  | [] -> Ok ()
+  | first :: _ ->
+    (match
+       update_candidate_batch
+         ~base_path
+         ~keeper_name:first.keeper_name
+         candidates
+         (fun current -> candidate_with_retryable_failure current failure)
+     with
+     | Ok _ -> Ok ()
+     | Error detail ->
+       Error
+         (Printf.sprintf
+            "Board attention batch failure evidence could not be persisted keeper=%s: %s"
+            first.keeper_name
+            detail))
+;;
+
+let record_batch_judgments ~base_path candidates judgments =
+  match candidates with
+  | [] -> Ok []
+  | first :: _ ->
+    update_candidate_batch
+      ~base_path
+      ~keeper_name:first.keeper_name
+      candidates
+      (fun current ->
+         match current.status with
+         | Pending _ ->
+           (match Candidate_map.find_opt current.candidate_id judgments with
+            | Some judgment ->
+              { current with
+                status = Judged { judgment; last_failure = None }
+              }
+            | None -> current)
+         | Judged _ | Consumed _ -> current)
+;;
+
+let delivery_of_judgment judgment =
+  match judgment.verdict.decision with
+  | Keeper_board_attention_judgment.Not_relevant -> Not_relevant
+  | Keeper_board_attention_judgment.Relevant -> Enqueued_to_keeper_lane
+;;
+
+let enqueue_batch_deliveries ~base_path candidates =
   List.fold_left
     (fun result candidate ->
        let* () = result in
-       record_batch_failure ~base_path candidate failure)
+       match candidate.status with
+       | Judged judged ->
+         (match judged.judgment.verdict.decision with
+          | Keeper_board_attention_judgment.Not_relevant -> Ok ()
+          | Keeper_board_attention_judgment.Relevant ->
+            let stimulus = board_attention_stimulus candidate in
+            (match
+               Keeper_registry_event_queue.enqueue_if_missing_durable_result
+                 ~base_path
+                 ~event_id:candidate.candidate_id
+                 candidate.keeper_name
+                 stimulus
+             with
+             | Keeper_registry_event_queue.Enqueued
+             | Keeper_registry_event_queue.Already_present -> Ok ()
+             | Keeper_registry_event_queue.Identity_conflict detail
+             | Keeper_registry_event_queue.Storage_error detail -> Error detail))
+       | Pending _ ->
+         Error
+           (Printf.sprintf
+              "candidate %s was not durably judged before batch delivery"
+              candidate.candidate_id)
+       | Consumed _ -> Ok ())
     (Ok ())
     candidates
+;;
+
+(* The candidate ledger and Keeper event queue are separate durable files, so
+   pretending they share one atomic transaction would create an unprovable
+   exactly-once boundary. The caller first commits every verdict as [Judged].
+   This function then performs idempotent event enqueues and commits every
+   [Consumed] row together. A crash between those steps replays from [Judged];
+   event identity makes the enqueue replay safe. *)
+let consume_judged_batch ~base_path candidates =
+  match candidates with
+  | [] -> Ok (0, 0)
+  | first :: _ ->
+    (match enqueue_batch_deliveries ~base_path candidates with
+     | Error detail ->
+       let delivery_failure = failure ~kind:Durable_delivery_unavailable detail in
+       let* () = record_batch_failures ~base_path candidates delivery_failure in
+       Ok (0, List.length candidates)
+     | Ok () ->
+       let consumed_at = Time_compat.now () in
+       let* current =
+         update_candidate_batch
+           ~base_path
+           ~keeper_name:first.keeper_name
+           candidates
+           (fun candidate ->
+              match candidate.status with
+              | Judged judged ->
+                { candidate with
+                  status =
+                    Consumed
+                      { judgment = judged.judgment
+                      ; delivery = delivery_of_judgment judged.judgment
+                      ; consumed_at
+                      }
+                }
+              | Pending _ | Consumed _ -> candidate)
+       in
+       let consumed, remaining, wake_candidate =
+         List.fold_left
+           (fun (consumed, remaining, wake_candidate) candidate ->
+              match candidate.status with
+              | Consumed { delivery = Enqueued_to_keeper_lane; _ } ->
+                ( consumed + 1
+                , remaining
+                , (match wake_candidate with
+                   | Some _ -> wake_candidate
+                   | None -> Some candidate) )
+              | Consumed { delivery = Not_relevant; _ } ->
+                consumed + 1, remaining, wake_candidate
+              | Pending _ | Judged _ -> consumed, remaining + 1, wake_candidate)
+           (0, 0, None)
+           current
+       in
+       (match wake_candidate with
+        | None -> ()
+        | Some candidate ->
+          let (_ : Keeper_registry.wakeup_outcome) =
+            request_owner_wake ~site:"durable_batch_delivery" ~base_path candidate
+          in
+          ());
+       Ok (consumed, remaining))
 ;;
 
 let validate_batch_coverage batch judgments =
@@ -1245,20 +1427,9 @@ let drain_pending_with_judge_batch ~base_path ~keeper_name ~judge_batch =
       candidates
   in
   (* Already-judged verdicts deliver without new model calls. *)
+  let judged_candidates = List.map fst judged_ready in
   let* judged_consumed, judged_remaining =
-    List.fold_left
-      (fun result (candidate, judged) ->
-         match result with
-         | Error _ -> result
-         | Ok (consumed, remaining) ->
-           (match consume_judged ~base_path candidate judged with
-            | Ok current ->
-              (match current.status with
-               | Consumed _ -> Ok (consumed + 1, remaining)
-               | Pending _ | Judged _ -> Ok (consumed, remaining + 1))
-            | Error detail -> Error detail))
-      (Ok (0, 0))
-      judged_ready
+    consume_judged_batch ~base_path judged_candidates
   in
   (* A single owner admission performs at most one provider call, and that
      call contains one exact persisted Keeper context. Other contexts and
@@ -1286,21 +1457,8 @@ let drain_pending_with_judge_batch ~base_path ~keeper_name ~judge_batch =
               ; remaining = List.length batch + List.length deferred
               }
           | Ok () ->
-            let* consumed, remaining =
-              List.fold_left
-                (fun result candidate ->
-                   let* consumed, remaining = result in
-                   match Candidate_map.find_opt candidate.candidate_id judgments with
-                   | None ->
-                     Error "validated batch verdict disappeared before application"
-                   | Some judgment ->
-                     let* current = apply_judgment ~base_path candidate judgment in
-                     (match current.status with
-                      | Consumed _ -> Ok (consumed + 1, remaining)
-                      | Pending _ | Judged _ -> Ok (consumed, remaining + 1)))
-                (Ok (0, 0))
-                batch
-            in
+            let* judged = record_batch_judgments ~base_path batch judgments in
+            let* consumed, remaining = consume_judged_batch ~base_path judged in
             Ok
               { attempted = List.length batch
               ; consumed
@@ -1322,6 +1480,14 @@ let drain_pending_on_owner_lane ~base_path ~keeper_name =
 ;;
 
 module For_testing = struct
+  let set_ledger_rewrite_observer observer =
+    Atomic.set ledger_rewrite_observer observer
+  ;;
+
+  let reset_ledger_rewrite_observer () =
+    Atomic.set ledger_rewrite_observer (fun () -> ())
+  ;;
+
   let drain_pending_with_judge_batch = drain_pending_with_judge_batch
 
   let drain_pending_with_judge ~base_path ~keeper_name ~judge =

--- a/lib/keeper/keeper_board_attention_candidate.mli
+++ b/lib/keeper/keeper_board_attention_candidate.mli
@@ -156,6 +156,10 @@ val drain_pending_on_owner_lane :
     - The response must cover the exact requested candidate-id set. Unknown,
       duplicate, or missing identities fail the whole attempted batch and
       persist retryable response-contract evidence for every attempted row.
+    - A successful fresh batch commits every [Judged] row in one candidate
+      ledger rewrite, performs idempotent relevant-event delivery, then commits
+      every [Consumed] row in one candidate ledger rewrite. The rewrite count
+      is therefore two regardless of batch cardinality.
     - Pending rows never expire from wall-clock age. Supersession or operator
       discard requires a separate typed lifecycle operation. *)
 
@@ -165,6 +169,11 @@ val batch_max_candidates : int
 module Candidate_map : Map.S with type key = string
 
 module For_testing : sig
+  val set_ledger_rewrite_observer : (unit -> unit) -> unit
+  val reset_ledger_rewrite_observer : unit -> unit
+  (** Observe ledger-rewrite transaction calls in focused tests. Production
+      installs no observer. *)
+
   val drain_pending_with_judge :
     base_path:string ->
     keeper_name:string ->

--- a/lib/keeper/keeper_board_attention_candidate.mli
+++ b/lib/keeper/keeper_board_attention_candidate.mli
@@ -12,7 +12,6 @@ type retryable_failure_kind =
   | Provider_unavailable
   | Response_contract_unavailable
   | Durable_delivery_unavailable
-  | Lifecycle_policy_migrated
 
 type retryable_failure =
   { kind : retryable_failure_kind

--- a/lib/keeper/keeper_board_attention_candidate.mli
+++ b/lib/keeper/keeper_board_attention_candidate.mli
@@ -1,11 +1,10 @@
 (** Durable Board-attention judgment boundary.
 
-    A candidate is persisted before any model call. Its lifecycle is
-    [Pending -> Judged -> Consumed], with [Pending -> Expired] as the terminal
-    path for rows that outlived their relevance window. Relevant judgments
-    become normal Keeper-lane events only after an exact candidate-id durable
-    queue commit; failures retain the latest retryable evidence and never
-    consume the candidate. *)
+    A candidate is persisted before any model call. Its only lifecycle is
+    [Pending -> Judged -> Consumed]. Relevant judgments become normal
+    Keeper-lane events only after an exact candidate-id durable queue commit;
+    failures retain the latest retryable evidence and never consume or
+    silently expire the candidate. *)
 
 type retryable_failure_kind =
   | Runtime_configuration_unavailable
@@ -13,6 +12,7 @@ type retryable_failure_kind =
   | Provider_unavailable
   | Response_contract_unavailable
   | Durable_delivery_unavailable
+  | Lifecycle_policy_migrated
 
 type retryable_failure =
   { kind : retryable_failure_kind
@@ -43,13 +43,10 @@ type consumed_state =
   ; consumed_at : float
   }
 
-type expired_state = { expired_at : float }
-
 type status =
   | Pending of pending_state
   | Judged of judged_state
   | Consumed of consumed_state
-  | Expired of expired_state
 
 type candidate =
   { candidate_id : string
@@ -144,26 +141,23 @@ val record_and_wake :
 
 val drain_pending_on_owner_lane :
   base_path:string -> keeper_name:string -> (drain_report, string) result
-(** Synchronously process every non-terminal durable candidate. Production
+(** Synchronously process at most one fresh-pending batch plus all already
+    judged durable candidates. Production
     calls this only while holding the Keeper's turn admission slot; no
     dashboard/producer domain may call it.
 
     Semantics:
-    - Pending rows older than {!candidate_ttl_sec} transition to [Expired]
-      first; the durable backlog dies even while the provider is unavailable.
     - Already-judged verdicts deliver without new model calls.
-    - Fresh pending rows are judged in batches of up to
-      {!batch_max_candidates} per model call. A failed batch aborts the round:
-      the next keepalive turn owns the retry cadence, so provider outages
-      cannot turn the drain into a hot retry loop.
-    - Verdicts referencing unknown or duplicate candidate identities are
-      rejected as response-contract failures. Candidates absent from a
-      successful batch verdict stay [Pending] without failure evidence.
-    [drain_report.consumed] includes expired rows. *)
-
-val candidate_ttl_sec : float
-(** Operational policy constant: a pending candidate older than this many
-    seconds (24h) is expired by the next drain. *)
+    - One provider call receives only candidates whose persisted
+      [keeper_context] values are structurally equal. Other contexts remain
+      pending for a later admission.
+    - At most one provider call runs per admission. Remaining candidates are
+      reported durably rather than drained behind the first call.
+    - The response must cover the exact requested candidate-id set. Unknown,
+      duplicate, or missing identities fail the whole attempted batch and
+      persist retryable response-contract evidence for every attempted row.
+    - Pending rows never expire from wall-clock age. Supersession or operator
+      discard requires a separate typed lifecycle operation. *)
 
 val batch_max_candidates : int
 (** Maximum candidates judged per model call. *)
@@ -174,7 +168,6 @@ module For_testing : sig
   val drain_pending_with_judge :
     base_path:string ->
     keeper_name:string ->
-    now:float ->
     judge:(candidate -> (judgment, retryable_failure) result) ->
     (drain_report, string) result
   (** Per-candidate judging adapter over the batch engine. *)
@@ -182,7 +175,6 @@ module For_testing : sig
   val drain_pending_with_judge_batch :
     base_path:string ->
     keeper_name:string ->
-    now:float ->
     judge_batch:(candidate list -> (judgment Candidate_map.t, retryable_failure) result) ->
     (drain_report, string) result
 end

--- a/test/test_keeper_board_attention_candidate.ml
+++ b/test/test_keeper_board_attention_candidate.ml
@@ -782,6 +782,27 @@ let test_batch_failure_aborts_round_and_records_evidence () =
      | None -> Alcotest.fail "deferred candidate vanished")
 ;;
 
+let test_batch_failure_evidence_write_error_propagates () =
+  with_temp_base "board-attention-failure-write" @@ fun base_path ->
+  let keeper_name = "sangsu" in
+  ignore (record_or_fail ~base_path (candidate ~keeper_name ()) : A.candidate);
+  let path = ledger_path_or_fail ~base_path ~keeper_name in
+  let failure : A.retryable_failure =
+    { kind = A.Provider_unavailable; detail = "provider unavailable"; failed_at = 100.0 }
+  in
+  match
+    A.For_testing.drain_pending_with_judge_batch
+      ~base_path
+      ~keeper_name
+      ~judge_batch:(fun _ ->
+        Sys.remove path;
+        Unix.mkdir path 0o700;
+        Error failure)
+  with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "failure-evidence storage error was silently accepted"
+;;
+
 let test_successful_drain_runs_one_provider_batch_per_admission () =
   with_temp_base "board-attention-one-quantum" @@ fun base_path ->
   let keeper_name = "sangsu" in
@@ -992,6 +1013,10 @@ let () =
             "batch failure aborts round with evidence"
             `Quick
             test_batch_failure_aborts_round_and_records_evidence
+        ; Alcotest.test_case
+            "batch failure evidence write error propagates"
+            `Quick
+            test_batch_failure_evidence_write_error_propagates
         ; Alcotest.test_case
             "successful drain runs one provider batch per admission"
             `Quick

--- a/test/test_keeper_board_attention_candidate.ml
+++ b/test/test_keeper_board_attention_candidate.ml
@@ -802,31 +802,45 @@ let test_batch_failure_evidence_write_error_propagates () =
 let test_successful_drain_runs_one_provider_batch_per_admission () =
   with_temp_base "board-attention-one-quantum" @@ fun base_path ->
   let keeper_name = "sangsu" in
-  List.iter
-    (fun index ->
-       let post_id = Printf.sprintf "post-%d" index in
-       ignore
-         (record_or_fail
-            ~base_path
-            (candidate ~keeper_name ~signal:(signal ~post_id ()) ())))
-    (List.init (A.batch_max_candidates + 1) (fun index -> index + 1));
-  let calls = ref 0 in
-  let report =
-    match
-      A.For_testing.drain_pending_with_judge_batch
-        ~base_path
-        ~keeper_name
-        ~judge_batch:(fun candidates ->
-          incr calls;
-          all_not_relevant candidates)
-    with
-    | Ok report -> report
-    | Error detail -> Alcotest.failf "one-quantum drain failed: %s" detail
-  in
-  Alcotest.(check int) "one provider call" 1 !calls;
-  Alcotest.(check int) "one batch attempted" A.batch_max_candidates report.attempted;
-  Alcotest.(check int) "one batch consumed" A.batch_max_candidates report.consumed;
-  Alcotest.(check int) "next admission owns remainder" 1 report.remaining
+  let entry = Registry.register ~base_path keeper_name (meta keeper_name) in
+  Fun.protect
+    ~finally:(fun () -> Registry.unregister ~base_path keeper_name)
+    (fun () ->
+       List.iter
+         (fun index ->
+            let post_id = Printf.sprintf "post-%d" index in
+            ignore
+              (record_or_fail
+                 ~base_path
+                 (candidate ~keeper_name ~signal:(signal ~post_id ()) ())))
+         (List.init (A.batch_max_candidates + 1) (fun index -> index + 1));
+       let calls = ref 0 in
+       let report =
+         match
+           A.For_testing.drain_pending_with_judge_batch
+             ~base_path
+             ~keeper_name
+             ~judge_batch:(fun candidates ->
+               incr calls;
+               all_not_relevant candidates)
+         with
+         | Ok report -> report
+         | Error detail -> Alcotest.failf "one-quantum drain failed: %s" detail
+       in
+       Alcotest.(check int) "one provider call" 1 !calls;
+       Alcotest.(check int)
+         "one batch attempted"
+         A.batch_max_candidates
+         report.attempted;
+       Alcotest.(check int)
+         "one batch consumed"
+         A.batch_max_candidates
+         report.consumed;
+       Alcotest.(check int) "next admission owns remainder" 1 report.remaining;
+       Alcotest.(check bool)
+         "successful partial drain schedules continuation"
+         true
+         (Atomic.get entry.fiber_wakeup))
 ;;
 
 let test_successful_batch_uses_two_candidate_ledger_rewrites () =

--- a/test/test_keeper_board_attention_candidate.ml
+++ b/test/test_keeper_board_attention_candidate.ml
@@ -31,13 +31,13 @@ let post_id value = board_id Masc.Board.Post_id.of_string "post" value
 let comment_id value = board_id Masc.Board.Comment_id.of_string "comment" value
 let agent_id value = board_id Masc.Board.Agent_id.of_string "agent" value
 
-let meta keeper_name =
+let meta ?(instructions = "Use the lane context and complete the task") keeper_name =
   let json =
     `Assoc
       [ "name", `String keeper_name
       ; "agent_name", `String ("keeper-" ^ keeper_name ^ "-agent")
       ; "trace_id", `String ("trace-" ^ keeper_name)
-      ; "instructions", `String "Use the lane context and complete the task"
+      ; "instructions", `String instructions
       ; "sandbox_profile", `String "local"
       ; "network_mode", `String "inherit"
       ; "mention_targets", `List [ `String keeper_name ]
@@ -97,10 +97,15 @@ let comments () : Masc.Board.comment list =
   ]
 ;;
 
-let candidate ?(keeper_name = "sangsu") ?(signal = signal ()) () =
+let candidate
+      ?(keeper_name = "sangsu")
+      ?(instructions = "Use the lane context and complete the task")
+      ?(signal = signal ())
+      ()
+  =
   match
     A.of_board_evidence
-      ~meta:(meta keeper_name)
+      ~meta:(meta ~instructions keeper_name)
       ~recorded_at:100.0
       ~signal
       ~post:(post ~id:signal.post_id ())
@@ -136,7 +141,7 @@ let test_roundtrip_preserves_full_evidence_and_pending_state () =
   let candidate = candidate () in
   (match candidate.status with
    | A.Pending { last_failure = None } -> ()
-   | A.Pending { last_failure = Some _ } | A.Judged _ | A.Consumed _ | A.Expired _ ->
+   | A.Pending { last_failure = Some _ } | A.Judged _ | A.Consumed _ ->
      Alcotest.fail "new candidate was not clean Pending");
   let request_fields =
     match candidate.judgment_request with
@@ -204,7 +209,7 @@ let test_worker_record_wakes_then_owner_lane_drains () =
             } ->
           (match persisted.status with
            | A.Pending { last_failure = None } -> ()
-           | A.Pending { last_failure = Some _ } | A.Judged _ | A.Consumed _ | A.Expired _ ->
+           | A.Pending { last_failure = Some _ } | A.Judged _ | A.Consumed _ ->
              Alcotest.fail "worker-side record invoked or mutated the judgment")
         | Ok _ -> Alcotest.fail "worker-side record returned the wrong typed acceptance"
         | Error detail -> Alcotest.failf "worker-side record failed: %s" detail);
@@ -218,7 +223,6 @@ let test_worker_record_wakes_then_owner_lane_drains () =
            A.For_testing.drain_pending_with_judge
              ~base_path
              ~keeper_name:pending.keeper_name
-             ~now:100.0
              ~judge:(fun _ -> Ok (judgment J.Relevant))
          with
          | Ok report -> report
@@ -270,7 +274,7 @@ let test_retryable_judge_failure_remains_pending () =
       "typed failure preserved"
       "provider_unavailable"
       (A.retryable_failure_kind_to_string observed.kind)
-  | A.Pending { last_failure = None } | A.Judged _ | A.Consumed _ | A.Expired _ ->
+  | A.Pending { last_failure = None } | A.Judged _ | A.Consumed _ ->
     Alcotest.fail "retryable judge failure consumed the candidate"
 ;;
 
@@ -289,7 +293,7 @@ let test_not_relevant_transitions_directly_to_consumed () =
   in
   (match current.status with
    | A.Consumed { delivery = A.Not_relevant; _ } -> ()
-   | A.Consumed _ | A.Pending _ | A.Judged _ | A.Expired _ ->
+   | A.Consumed _ | A.Pending _ | A.Judged _ ->
      Alcotest.fail "not-relevant verdict did not reach Consumed");
   let queue =
     Keeper_event_queue_persistence.load
@@ -317,7 +321,7 @@ let test_relevant_consumes_only_after_exact_durable_enqueue () =
   in
   (match current.status with
    | A.Consumed { delivery = A.Enqueued_to_keeper_lane; _ } -> ()
-   | A.Consumed _ | A.Pending _ | A.Judged _ | A.Expired _ ->
+   | A.Consumed _ | A.Pending _ | A.Judged _ ->
      Alcotest.fail "relevant verdict consumed before durable delivery");
   let queue =
     Keeper_event_queue_persistence.load
@@ -368,7 +372,7 @@ let test_delivery_storage_error_retains_judged_state () =
   | A.Judged
       { last_failure = Some { kind = A.Durable_delivery_unavailable; _ }; _ } ->
     ()
-  | A.Judged _ | A.Pending _ | A.Consumed _ | A.Expired _ ->
+  | A.Judged _ | A.Pending _ | A.Consumed _ ->
     Alcotest.fail "durable delivery storage error did not retain Judged"
 ;;
 
@@ -470,7 +474,7 @@ let test_update_ledger_compacts_to_distinct () =
          "latest failure wins after compaction"
          "provider unavailable 5"
          observed.detail
-     | A.Pending { last_failure = None } | A.Judged _ | A.Consumed _ | A.Expired _ ->
+     | A.Pending { last_failure = None } | A.Judged _ | A.Consumed _ ->
        Alcotest.fail "compaction dropped the latest pending failure")
   | Ok candidates ->
     Alcotest.failf "expected one compacted candidate, got %d" (List.length candidates)
@@ -615,55 +619,58 @@ let all_not_relevant candidates =
        candidates)
 ;;
 
-let test_drain_expires_stale_pending_without_model_call () =
-  with_temp_base "board-attention-ttl" @@ fun base_path ->
+let test_old_pending_is_judged_without_wall_clock_expiry () =
+  with_temp_base "board-attention-no-wall-clock-expiry" @@ fun base_path ->
   let keeper_name = "sangsu" in
-  let _ = record_or_fail ~base_path (candidate ~keeper_name ()) in
+  let old = { (candidate ~keeper_name ()) with recorded_at = -1_000_000.0 } in
+  let _ = record_or_fail ~base_path old in
   let report =
     match
       A.For_testing.drain_pending_with_judge_batch
         ~base_path
         ~keeper_name
-        ~now:(100.0 +. A.candidate_ttl_sec +. 1.0)
-        ~judge_batch:(fun _ ->
-          Alcotest.fail "stale candidate reached the model judge")
-    with
-    | Ok report -> report
-    | Error detail -> Alcotest.failf "ttl drain failed: %s" detail
-  in
-  Alcotest.(check int) "no model attempt for stale rows" 0 report.attempted;
-  Alcotest.(check int) "stale row counted as consumed" 1 report.consumed;
-  Alcotest.(check int) "nothing remains" 0 report.remaining;
-  match (only_loaded ~base_path ~keeper_name).status with
-  | A.Expired _ -> ()
-  | A.Pending _ | A.Judged _ | A.Consumed _ ->
-    Alcotest.fail "stale candidate was not expired"
-;;
-
-let test_drain_fresh_pending_is_not_expired () =
-  with_temp_base "board-attention-fresh" @@ fun base_path ->
-  let keeper_name = "sangsu" in
-  let _ = record_or_fail ~base_path (candidate ~keeper_name ()) in
-  let report =
-    match
-      A.For_testing.drain_pending_with_judge_batch
-        ~base_path
-        ~keeper_name
-        ~now:100.0
         ~judge_batch:all_not_relevant
     with
     | Ok report -> report
-    | Error detail -> Alcotest.failf "fresh drain failed: %s" detail
+    | Error detail -> Alcotest.failf "old pending drain failed: %s" detail
   in
-  Alcotest.(check int) "fresh row attempted" 1 report.attempted;
-  Alcotest.(check int) "fresh row consumed" 1 report.consumed;
+  Alcotest.(check int) "old row reaches judge" 1 report.attempted;
+  Alcotest.(check int) "old row consumed by verdict" 1 report.consumed;
+  Alcotest.(check int) "nothing remains" 0 report.remaining;
   match (only_loaded ~base_path ~keeper_name).status with
   | A.Consumed { delivery = A.Not_relevant; _ } -> ()
-  | A.Consumed _ | A.Pending _ | A.Judged _ | A.Expired _ ->
-    Alcotest.fail "fresh candidate did not consume as not_relevant"
+  | A.Consumed _ | A.Pending _ | A.Judged _ ->
+    Alcotest.fail "old pending candidate was silently discarded"
 ;;
 
-let test_batch_verdict_missing_candidate_stays_pending_without_failure () =
+let test_legacy_expired_row_is_recovered_to_pending () =
+  let legacy_json =
+    match A.candidate_to_json (candidate ()) with
+    | `Assoc fields ->
+      `Assoc
+        (("status", `Assoc [ "kind", `String "expired"; "expired_at", `Float 123.5 ])
+         :: List.remove_assoc "status" fields)
+    | _ -> Alcotest.fail "candidate fixture did not encode as an object"
+  in
+  match A.candidate_of_json legacy_json with
+  | Ok
+      { status =
+          A.Pending
+            { last_failure =
+                Some
+                  { kind = A.Lifecycle_policy_migrated
+                  ; failed_at
+                  ; _
+                  }
+            }
+      ; _
+      } ->
+    Alcotest.(check (float 0.001)) "legacy expiry timestamp retained" 123.5 failed_at
+  | Ok _ -> Alcotest.fail "legacy Expired row was not recovered to Pending"
+  | Error detail -> Alcotest.failf "legacy Expired migration failed: %s" detail
+;;
+
+let test_batch_verdict_missing_candidate_fails_whole_batch_with_evidence () =
   with_temp_base "board-attention-partial" @@ fun base_path ->
   let keeper_name = "sangsu" in
   let first = record_or_fail ~base_path (candidate ~keeper_name ()) in
@@ -677,7 +684,6 @@ let test_batch_verdict_missing_candidate_stays_pending_without_failure () =
       A.For_testing.drain_pending_with_judge_batch
         ~base_path
         ~keeper_name
-        ~now:100.0
         ~judge_batch:(fun _ ->
           Ok
             (A.Candidate_map.add
@@ -689,18 +695,29 @@ let test_batch_verdict_missing_candidate_stays_pending_without_failure () =
     | Error detail -> Alcotest.failf "partial drain failed: %s" detail
   in
   Alcotest.(check int) "both attempted" 2 report.attempted;
-  Alcotest.(check int) "one consumed" 1 report.consumed;
-  Alcotest.(check int) "one remains" 1 report.remaining;
+  Alcotest.(check int) "partial response consumes nothing" 0 report.consumed;
+  Alcotest.(check int) "whole batch remains" 2 report.remaining;
   match A.load_candidates ~base_path ~keeper_name with
   | Ok candidates ->
-    (match
-       List.find_opt
-         (fun (c : A.candidate) -> String.equal c.candidate_id second.candidate_id)
-         candidates
-     with
-     | Some { status = A.Pending { last_failure = None }; _ } -> ()
-     | Some _ -> Alcotest.fail "unjudged candidate gained failure evidence"
-     | None -> Alcotest.fail "unjudged candidate vanished from the ledger")
+    List.iter
+      (fun target ->
+         match
+           List.find_opt
+             (fun (c : A.candidate) -> String.equal c.candidate_id target.candidate_id)
+             candidates
+         with
+         | Some
+             { status =
+                 A.Pending
+                   { last_failure =
+                       Some { kind = A.Response_contract_unavailable; _ }
+                   }
+             ; _
+             } ->
+           ()
+         | Some _ -> Alcotest.fail "partial response lacked contract-failure evidence"
+         | None -> Alcotest.fail "partial-response candidate vanished")
+      [ first; second ]
   | Error detail -> Alcotest.failf "candidate load failed: %s" detail
 ;;
 
@@ -724,7 +741,6 @@ let test_batch_failure_aborts_round_and_records_evidence () =
       A.For_testing.drain_pending_with_judge_batch
         ~base_path
         ~keeper_name
-        ~now:100.0
         ~judge_batch:(fun _ -> Error failure)
     with
     | Ok report -> report
@@ -766,16 +782,90 @@ let test_batch_failure_aborts_round_and_records_evidence () =
      | None -> Alcotest.fail "deferred candidate vanished")
 ;;
 
-let test_expired_status_codec_roundtrip () =
-  let fixture = candidate () in
-  let expired = { fixture with status = A.Expired { expired_at = 123.5 } } in
-  match A.candidate_of_json (A.candidate_to_json expired) with
-  | Ok decoded ->
-    (match decoded.status with
-     | A.Expired { expired_at } -> Alcotest.(check (float 0.001)) "expired_at" 123.5 expired_at
-     | A.Pending _ | A.Judged _ | A.Consumed _ ->
-       Alcotest.fail "expired status did not roundtrip")
-  | Error detail -> Alcotest.failf "expired codec failed: %s" detail
+let test_successful_drain_runs_one_provider_batch_per_admission () =
+  with_temp_base "board-attention-one-quantum" @@ fun base_path ->
+  let keeper_name = "sangsu" in
+  List.iter
+    (fun index ->
+       let post_id = Printf.sprintf "post-%d" index in
+       ignore
+         (record_or_fail
+            ~base_path
+            (candidate ~keeper_name ~signal:(signal ~post_id ()) ()))
+         : A.candidate)
+    (List.init (A.batch_max_candidates + 1) (fun index -> index + 1));
+  let calls = ref 0 in
+  let report =
+    match
+      A.For_testing.drain_pending_with_judge_batch
+        ~base_path
+        ~keeper_name
+        ~judge_batch:(fun candidates ->
+          incr calls;
+          all_not_relevant candidates)
+    with
+    | Ok report -> report
+    | Error detail -> Alcotest.failf "one-quantum drain failed: %s" detail
+  in
+  Alcotest.(check int) "one provider call" 1 !calls;
+  Alcotest.(check int) "one batch attempted" A.batch_max_candidates report.attempted;
+  Alcotest.(check int) "one batch consumed" A.batch_max_candidates report.consumed;
+  Alcotest.(check int) "next admission owns remainder" 1 report.remaining
+;;
+
+let test_batch_never_mixes_persisted_keeper_contexts () =
+  with_temp_base "board-attention-context-cohort" @@ fun base_path ->
+  let keeper_name = "sangsu" in
+  let first =
+    record_or_fail
+      ~base_path
+      (candidate
+         ~keeper_name
+         ~instructions:"context-a"
+         ~signal:(signal ~post_id:"post-a1" ())
+         ())
+  in
+  let second =
+    record_or_fail
+      ~base_path
+      (candidate
+         ~keeper_name
+         ~instructions:"context-b"
+         ~signal:(signal ~post_id:"post-b" ())
+         ())
+  in
+  let third =
+    record_or_fail
+      ~base_path
+      (candidate
+         ~keeper_name
+         ~instructions:"context-a"
+         ~signal:(signal ~post_id:"post-a2" ())
+         ())
+  in
+  let observed_ids = ref [] in
+  let report =
+    match
+      A.For_testing.drain_pending_with_judge_batch
+        ~base_path
+        ~keeper_name
+        ~judge_batch:(fun candidates ->
+          observed_ids := List.map (fun (c : A.candidate) -> c.candidate_id) candidates;
+          all_not_relevant candidates)
+    with
+    | Ok report -> report
+    | Error detail -> Alcotest.failf "context-cohort drain failed: %s" detail
+  in
+  Alcotest.(check int) "same-context cohort attempted" 2 report.attempted;
+  Alcotest.(check int) "same-context cohort consumed" 2 report.consumed;
+  Alcotest.(check int) "different context deferred" 1 report.remaining;
+  List.iter
+    (fun expected ->
+       if not (List.exists (String.equal expected.candidate_id) !observed_ids)
+       then Alcotest.failf "same-context candidate %s was omitted" expected.candidate_id)
+    [ first; third ];
+  if List.exists (String.equal second.candidate_id) !observed_ids
+  then Alcotest.fail "different Keeper contexts were mixed in one provider call"
 ;;
 
 let test_batch_verdict_codec_roundtrip () =
@@ -887,25 +977,29 @@ let () =
         ] )
     ; ( "batch drain"
       , [ Alcotest.test_case
-            "stale pending expires without model call"
+            "old pending is never expired by wall clock"
             `Quick
-            test_drain_expires_stale_pending_without_model_call
+            test_old_pending_is_judged_without_wall_clock_expiry
         ; Alcotest.test_case
-            "fresh pending is not expired"
+            "legacy expired row is recovered to Pending"
             `Quick
-            test_drain_fresh_pending_is_not_expired
+            test_legacy_expired_row_is_recovered_to_pending
         ; Alcotest.test_case
-            "missing verdict keeps candidate pending"
+            "missing verdict fails the whole batch with evidence"
             `Quick
-            test_batch_verdict_missing_candidate_stays_pending_without_failure
+            test_batch_verdict_missing_candidate_fails_whole_batch_with_evidence
         ; Alcotest.test_case
             "batch failure aborts round with evidence"
             `Quick
             test_batch_failure_aborts_round_and_records_evidence
         ; Alcotest.test_case
-            "expired status codec roundtrip"
+            "successful drain runs one provider batch per admission"
             `Quick
-            test_expired_status_codec_roundtrip
+            test_successful_drain_runs_one_provider_batch_per_admission
+        ; Alcotest.test_case
+            "batch never mixes persisted Keeper contexts"
+            `Quick
+            test_batch_never_mixes_persisted_keeper_contexts
         ; Alcotest.test_case
             "batch verdict codec roundtrip"
             `Quick

--- a/test/test_keeper_board_attention_candidate.ml
+++ b/test/test_keeper_board_attention_candidate.ml
@@ -652,7 +652,7 @@ let test_old_pending_is_judged_without_wall_clock_expiry () =
     Alcotest.fail "old pending candidate was silently discarded"
 ;;
 
-let test_legacy_expired_row_is_recovered_to_pending () =
+let test_removed_expired_status_is_rejected () =
   let legacy_json =
     match A.candidate_to_json (candidate ()) with
     | `Assoc fields ->
@@ -662,21 +662,8 @@ let test_legacy_expired_row_is_recovered_to_pending () =
     | _ -> Alcotest.fail "candidate fixture did not encode as an object"
   in
   match A.candidate_of_json legacy_json with
-  | Ok
-      { status =
-          A.Pending
-            { last_failure =
-                Some
-                  { kind = A.Lifecycle_policy_migrated
-                  ; failed_at
-                  ; _
-                  }
-            }
-      ; _
-      } ->
-    Alcotest.(check (float 0.001)) "legacy expiry timestamp retained" 123.5 failed_at
-  | Ok _ -> Alcotest.fail "legacy Expired row was not recovered to Pending"
-  | Error detail -> Alcotest.failf "legacy Expired migration failed: %s" detail
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "removed Expired status was accepted by the durable schema"
 ;;
 
 let test_batch_verdict_missing_candidate_fails_whole_batch_with_evidence () =
@@ -1096,9 +1083,9 @@ let () =
             `Quick
             test_old_pending_is_judged_without_wall_clock_expiry
         ; Alcotest.test_case
-            "legacy expired row is recovered to Pending"
+            "removed expired status is rejected"
             `Quick
-            test_legacy_expired_row_is_recovered_to_pending
+            test_removed_expired_status_is_rejected
         ; Alcotest.test_case
             "missing verdict fails the whole batch with evidence"
             `Quick

--- a/test/test_keeper_board_attention_candidate.ml
+++ b/test/test_keeper_board_attention_candidate.ml
@@ -843,7 +843,7 @@ let test_successful_drain_runs_one_provider_batch_per_admission () =
          (Atomic.get entry.fiber_wakeup))
 ;;
 
-let test_successful_batch_uses_two_candidate_ledger_rewrites () =
+let test_successful_batch_commits_each_delivery_before_return () =
   with_temp_base "board-attention-atomic-batch" @@ fun base_path ->
   let keeper_name = "sangsu" in
   List.iter
@@ -871,8 +871,8 @@ let test_successful_batch_uses_two_candidate_ledger_rewrites () =
        in
        Alcotest.(check int) "whole batch consumed" A.batch_max_candidates report.consumed;
        Alcotest.(check int)
-         "one judgment commit plus one consumed commit"
-         2
+         "one judgment commit plus one commit per delivery"
+         (A.batch_max_candidates + 1)
          !rewrites;
        let queued =
          Keeper_event_queue_persistence.load ~base_path ~keeper_name
@@ -927,6 +927,166 @@ let test_batch_delivery_failure_preserves_all_judgments () =
          | A.Pending _ | A.Judged _ | A.Consumed _ ->
            Alcotest.fail "batch delivery failure lost a durable judgment")
       candidates
+;;
+
+let test_partial_delivery_commits_before_later_failure () =
+  with_temp_base "board-attention-partial-delivery" @@ fun base_path ->
+  let keeper_name = "sangsu" in
+  let first =
+    record_or_fail
+      ~base_path
+      (candidate ~keeper_name ~signal:(signal ~post_id:"post-first" ()) ())
+  in
+  let second =
+    record_or_fail
+      ~base_path
+      (candidate ~keeper_name ~signal:(signal ~post_id:"post-second" ()) ())
+  in
+  let conflict : Keeper_event_queue.stimulus =
+    { post_id = "conflict"
+    ; urgency = Keeper_event_queue.Normal
+    ; arrived_at = 99.0
+    ; payload = Keeper_event_queue.Bootstrap
+    }
+  in
+  (match
+     Masc.Keeper_registry_event_queue.enqueue_if_missing_durable_result
+       ~base_path
+       ~event_id:second.candidate_id
+       keeper_name
+       conflict
+   with
+   | Masc.Keeper_registry_event_queue.Enqueued -> ()
+   | _ -> Alcotest.fail "conflicting delivery fixture was not enqueued");
+  let report =
+    match
+      A.For_testing.drain_pending_with_judge_batch
+        ~base_path
+        ~keeper_name
+        ~judge_batch:all_relevant
+    with
+    | Ok report -> report
+    | Error detail -> Alcotest.failf "partial delivery drain failed: %s" detail
+  in
+  Alcotest.(check int) "first delivery committed" 1 report.consumed;
+  Alcotest.(check int) "failed delivery remains" 1 report.remaining;
+  match A.load_candidates ~base_path ~keeper_name with
+  | Error detail -> Alcotest.failf "candidate load failed: %s" detail
+  | Ok candidates ->
+    let status candidate =
+      List.find_opt
+        (fun (current : A.candidate) ->
+           String.equal current.candidate_id candidate.A.candidate_id)
+        candidates
+      |> Option.map (fun (current : A.candidate) -> current.status)
+    in
+    (match status first with
+     | Some (A.Consumed { delivery = A.Enqueued_to_keeper_lane; _ }) -> ()
+     | Some (A.Consumed _ | A.Pending _ | A.Judged _) | None ->
+       Alcotest.fail "earlier durable enqueue was not committed");
+    (match status second with
+     | Some
+         (A.Judged
+           { last_failure = Some { kind = A.Durable_delivery_unavailable; _ }
+           ; _
+           }) ->
+       ()
+     | Some (A.Consumed _ | A.Pending _ | A.Judged _) | None ->
+       Alcotest.fail "later failed delivery did not remain retryable")
+;;
+
+let test_delivery_failure_does_not_request_immediate_retry () =
+  with_temp_base "board-attention-delivery-backoff" @@ fun base_path ->
+  let keeper_name = "sangsu" in
+  let entry = Registry.register ~base_path keeper_name (meta keeper_name) in
+  Fun.protect
+    ~finally:(fun () -> Registry.unregister ~base_path keeper_name)
+    (fun () ->
+       let persisted = record_or_fail ~base_path (candidate ~keeper_name ()) in
+       let conflict : Keeper_event_queue.stimulus =
+         { post_id = "conflict"
+         ; urgency = Keeper_event_queue.Normal
+         ; arrived_at = 99.0
+         ; payload = Keeper_event_queue.Bootstrap
+         }
+       in
+       (match
+          Masc.Keeper_registry_event_queue.enqueue_if_missing_durable_result
+            ~base_path
+            ~event_id:persisted.candidate_id
+            keeper_name
+            conflict
+        with
+        | Masc.Keeper_registry_event_queue.Enqueued -> ()
+        | _ -> Alcotest.fail "conflicting delivery fixture was not enqueued");
+       Atomic.set entry.fiber_wakeup false;
+       let report =
+         match
+           A.For_testing.drain_pending_with_judge_batch
+             ~base_path
+             ~keeper_name
+             ~judge_batch:all_relevant
+         with
+         | Ok report -> report
+         | Error detail -> Alcotest.failf "delivery failure drain failed: %s" detail
+       in
+       Alcotest.(check int) "failed delivery remains" 1 report.remaining;
+       Alcotest.(check bool)
+         "delivery outage waits for heartbeat retry"
+         false
+         (Atomic.get entry.fiber_wakeup))
+;;
+
+let test_failed_context_rotates_behind_untried_context () =
+  with_temp_base "board-attention-context-rotation" @@ fun base_path ->
+  let keeper_name = "sangsu" in
+  let first =
+    record_or_fail
+      ~base_path
+      (candidate
+         ~keeper_name
+         ~instructions:"context-a"
+         ~signal:(signal ~post_id:"post-a" ())
+         ())
+  in
+  let second =
+    record_or_fail
+      ~base_path
+      (candidate
+         ~keeper_name
+         ~instructions:"context-b"
+         ~signal:(signal ~post_id:"post-b" ())
+         ())
+  in
+  let first_attempt = ref [] in
+  let failure : A.retryable_failure =
+    { kind = A.Provider_unavailable; detail = "deterministic failure"; failed_at = 100.0 }
+  in
+  let run judge_batch =
+    match A.For_testing.drain_pending_with_judge_batch ~base_path ~keeper_name ~judge_batch with
+    | Ok report -> report
+    | Error detail -> Alcotest.failf "context rotation drain failed: %s" detail
+  in
+  ignore
+    (run (fun candidates ->
+       first_attempt := List.map (fun (candidate : A.candidate) -> candidate.candidate_id) candidates;
+       Error failure)
+     : A.drain_report);
+  let second_attempt = ref [] in
+  ignore
+    (run (fun candidates ->
+       second_attempt :=
+         List.map (fun (candidate : A.candidate) -> candidate.candidate_id) candidates;
+       all_not_relevant candidates)
+     : A.drain_report);
+  Alcotest.(check (list string))
+    "oldest cohort attempted first"
+    [ first.candidate_id ]
+    !first_attempt;
+  Alcotest.(check (list string))
+    "failed cohort persisted behind deferred context"
+    [ second.candidate_id ]
+    !second_attempt
 ;;
 
 let test_batch_never_mixes_persisted_keeper_contexts () =
@@ -1117,13 +1277,25 @@ let () =
             `Quick
             test_successful_drain_runs_one_provider_batch_per_admission
         ; Alcotest.test_case
-            "successful batch uses two candidate-ledger rewrites"
+            "successful batch commits each delivery before return"
             `Quick
-            test_successful_batch_uses_two_candidate_ledger_rewrites
+            test_successful_batch_commits_each_delivery_before_return
         ; Alcotest.test_case
             "batch delivery failure preserves all judgments"
             `Quick
             test_batch_delivery_failure_preserves_all_judgments
+        ; Alcotest.test_case
+            "partial delivery commits before later failure"
+            `Quick
+            test_partial_delivery_commits_before_later_failure
+        ; Alcotest.test_case
+            "delivery failure does not request immediate retry"
+            `Quick
+            test_delivery_failure_does_not_request_immediate_retry
+        ; Alcotest.test_case
+            "failed context rotates behind untried context"
+            `Quick
+            test_failed_context_rotates_behind_untried_context
         ; Alcotest.test_case
             "batch never mixes persisted Keeper contexts"
             `Quick

--- a/test/test_keeper_board_attention_candidate.ml
+++ b/test/test_keeper_board_attention_candidate.ml
@@ -619,6 +619,15 @@ let all_not_relevant candidates =
        candidates)
 ;;
 
+let all_relevant candidates =
+  Ok
+    (List.fold_left
+       (fun map (candidate : A.candidate) ->
+          A.Candidate_map.add candidate.candidate_id (judgment J.Relevant) map)
+       A.Candidate_map.empty
+       candidates)
+;;
+
 let test_old_pending_is_judged_without_wall_clock_expiry () =
   with_temp_base "board-attention-no-wall-clock-expiry" @@ fun base_path ->
   let keeper_name = "sangsu" in
@@ -833,6 +842,92 @@ let test_successful_drain_runs_one_provider_batch_per_admission () =
   Alcotest.(check int) "next admission owns remainder" 1 report.remaining
 ;;
 
+let test_successful_batch_uses_two_candidate_ledger_rewrites () =
+  with_temp_base "board-attention-atomic-batch" @@ fun base_path ->
+  let keeper_name = "sangsu" in
+  List.iter
+    (fun index ->
+       let post_id = Printf.sprintf "post-%d" index in
+       ignore
+         (record_or_fail
+            ~base_path
+            (candidate ~keeper_name ~signal:(signal ~post_id ()) ())))
+    (List.init A.batch_max_candidates (fun index -> index + 1));
+  let rewrites = ref 0 in
+  A.For_testing.set_ledger_rewrite_observer (fun () -> incr rewrites);
+  Fun.protect
+    ~finally:A.For_testing.reset_ledger_rewrite_observer
+    (fun () ->
+       let report =
+         match
+           A.For_testing.drain_pending_with_judge_batch
+             ~base_path
+             ~keeper_name
+             ~judge_batch:all_relevant
+         with
+         | Ok report -> report
+         | Error detail -> Alcotest.failf "atomic batch drain failed: %s" detail
+       in
+       Alcotest.(check int) "whole batch consumed" A.batch_max_candidates report.consumed;
+       Alcotest.(check int)
+         "one judgment commit plus one consumed commit"
+         2
+         !rewrites;
+       let queued =
+         Keeper_event_queue_persistence.load ~base_path ~keeper_name
+         |> Keeper_event_queue.length
+       in
+       Alcotest.(check int)
+         "every relevant verdict has one durable event"
+         A.batch_max_candidates
+         queued)
+;;
+
+let test_batch_delivery_failure_preserves_all_judgments () =
+  with_temp_base "board-attention-batch-delivery-error" @@ fun base_path ->
+  let keeper_name = "sangsu" in
+  List.iter
+    (fun index ->
+       let post_id = Printf.sprintf "post-%d" index in
+       ignore
+         (record_or_fail
+            ~base_path
+            (candidate ~keeper_name ~signal:(signal ~post_id ()) ())))
+    [ 1; 2 ];
+  let keepers_path =
+    Filename.concat (Common.masc_dir_from_base_path ~base_path) "keepers"
+  in
+  let oc = open_out_bin keepers_path in
+  output_string oc "event queue directory blocker";
+  close_out oc;
+  let report =
+    match
+      A.For_testing.drain_pending_with_judge_batch
+        ~base_path
+        ~keeper_name
+        ~judge_batch:all_relevant
+    with
+    | Ok report -> report
+    | Error detail -> Alcotest.failf "batch delivery failure drain failed: %s" detail
+  in
+  Alcotest.(check int) "delivery failure consumes none" 0 report.consumed;
+  Alcotest.(check int) "both judgments remain" 2 report.remaining;
+  match A.load_candidates ~base_path ~keeper_name with
+  | Error detail -> Alcotest.failf "candidate load failed: %s" detail
+  | Ok candidates ->
+    List.iter
+      (fun (candidate : A.candidate) ->
+         match candidate.status with
+         | A.Judged
+             { last_failure = Some { kind = A.Durable_delivery_unavailable; _ }
+             ; _
+             } ->
+           ()
+         | A.Pending _ | A.Judged _ | A.Consumed _ ->
+           Alcotest.fail "batch delivery failure lost a durable judgment")
+      candidates
+;;
+
 let test_batch_never_mixes_persisted_keeper_contexts () =
   with_temp_base "board-attention-context-cohort" @@ fun base_path ->
   let keeper_name = "sangsu" in
@@ -1020,6 +1115,14 @@ let () =
             "successful drain runs one provider batch per admission"
             `Quick
             test_successful_drain_runs_one_provider_batch_per_admission
+        ; Alcotest.test_case
+            "successful batch uses two candidate-ledger rewrites"
+            `Quick
+            test_successful_batch_uses_two_candidate_ledger_rewrites
+        ; Alcotest.test_case
+            "batch delivery failure preserves all judgments"
+            `Quick
+            test_batch_delivery_failure_preserves_all_judgments
         ; Alcotest.test_case
             "batch never mixes persisted Keeper contexts"
             `Quick

--- a/test/test_keeper_board_attention_candidate.ml
+++ b/test/test_keeper_board_attention_candidate.ml
@@ -700,7 +700,7 @@ let test_batch_verdict_missing_candidate_fails_whole_batch_with_evidence () =
   match A.load_candidates ~base_path ~keeper_name with
   | Ok candidates ->
     List.iter
-      (fun target ->
+      (fun (target : A.candidate) ->
          match
            List.find_opt
              (fun (c : A.candidate) -> String.equal c.candidate_id target.candidate_id)
@@ -812,8 +812,7 @@ let test_successful_drain_runs_one_provider_batch_per_admission () =
        ignore
          (record_or_fail
             ~base_path
-            (candidate ~keeper_name ~signal:(signal ~post_id ()) ()))
-         : A.candidate)
+            (candidate ~keeper_name ~signal:(signal ~post_id ()) ())))
     (List.init (A.batch_max_candidates + 1) (fun index -> index + 1));
   let calls = ref 0 in
   let report =
@@ -881,7 +880,7 @@ let test_batch_never_mixes_persisted_keeper_contexts () =
   Alcotest.(check int) "same-context cohort consumed" 2 report.consumed;
   Alcotest.(check int) "different context deferred" 1 report.remaining;
   List.iter
-    (fun expected ->
+    (fun (expected : A.candidate) ->
        if not (List.exists (String.equal expected.candidate_id) !observed_ids)
        then Alcotest.failf "same-context candidate %s was omitted" expected.candidate_id)
     [ first; third ];


### PR DESCRIPTION
## Why

Merged PR #25073 improved Board-attention throughput, but customer work could still be expired by wall clock, mixed Keeper contexts could enter one judgment prompt, partial model responses lacked durable failure evidence, and one owner admission could issue repeated provider batches.

## What changed

- remove wall-clock expiry from the current lifecycle; the only accepted durable states are `Pending -> Judged -> Consumed`
- reject removed lifecycle states instead of guessing a migration into current state
- canonicalize persisted `keeper_context` and admit only one equal-context cohort per provider call
- require exact requested/returned candidate-ID coverage; missing, duplicate, or unknown IDs fail the whole attempted batch
- persist retryable evidence explicitly and propagate evidence-write failures
- execute at most one fresh provider batch per owner admission and leave the remainder durable
- atomically commit fresh verdicts, perform idempotent delivery by candidate event ID, then atomically commit consumed rows
- add the 10-Keeper mixed-workload product/architecture/goal matrix

The candidate ledger and Keeper event queue are separate durable stores, not a falsely claimed transaction. A crash after verdict commit resumes from `Judged`; duplicate event enqueue is safe by candidate event ID.

## Quantitative Before / After

- 8-candidate successful batch candidate-ledger rewrites: **16 -> 2 (-87.5%)**
- provider calls per owner admission: at most 1
- cross-context candidates per model call: 0
- partial-ID commit: 0 by contract
- silent wall-clock expiry: removed

## Product boundary

This PR closes the fairness, context-integrity, silent-expiry, evidence-propagation, and candidate-ledger write-amplification defects in its scope. It does **not** claim that the fixed cap, background judgment plane, restart-complete partition scheduler, or 10-Keeper product SLO is solved. The strict product score therefore remains **0.0/10** until the matrix gates have executable evidence.

## Capacity blocker

The fixed `batch_max_candidates = 8` remains a 1.0 blocker. It is not replaced with a tokenizer estimate, byte heuristic, Cloud error-prose match, or malformed-response split.

The follow-up may split a persisted immutable partition only when the actual dispatched provider/model contract supplies a typed capacity or typed overflow fact. Missing, duplicate, unknown, or malformed judgment output is a response-contract failure and must remain retryable evidence for the same partition; it does not authorize bisection. OAS #2667 remains fail-closed until actual-wire fit authority exists.

## Verification

- `ocamlformat` on touched OCaml files: passed
- `ocamlc -stop-after parsing` on touched OCaml files: passed
- `git diff --check`: passed
- focused wrapper build was attempted, but correctly refused because another session is running a bare Dune process outside `scripts/dune-local.sh`; no lock bypass or process termination was attempted
- current-head PR CI is the build authority and is pending

## Merge gate

Keep this Draft and `status:do-not-merge` until current-head CI, focused executable evidence, and an adversarial current-head review pass. The stacked partition-scheduler PR must be restacked after this strict-schema base and separately remove its legacy `Judged` drain and untyped response-failure bisection.
