### PR TITLE
fix(dashboard): decode pair_repair_dropped_message_count evidence

### DIFF
--- a/dashboard/src/api/dashboard-turn-records.ts
+++ b/dashboard/src/api/dashboard-turn-records.ts
@@ -229,6 +229,9 @@ export type KeeperCompactionExactEvidence = {
   readonly after_message_count: number
   readonly summarized_message_count: number
   readonly dropped_message_count: number
+  /** Messages additionally removed by tool-pair repair (#25037). Null for
+   *  rows persisted before the field existed. */
+  readonly pair_repair_dropped_message_count: number | null
   readonly before_tool_use_count: number
   readonly after_tool_use_count: number
   readonly before_tool_result_count: number
@@ -589,9 +592,16 @@ function decodeCompactionExactEvidence(raw: unknown): KeeperCompactionExactEvide
     before_tool_result_count: asNumber(raw.before_tool_result_count),
     after_tool_result_count: asNumber(raw.after_tool_result_count),
   }
-  return Object.values(evidence).some(value => value === undefined)
-    ? undefined
-    : evidence as KeeperCompactionExactEvidence
+  if (Object.values(evidence).some(value => value === undefined)) return undefined
+  // Optional: absent on rows persisted before #25037; must not void the row.
+  const pairRepairDropped =
+    typeof raw.pair_repair_dropped_message_count === 'number'
+      ? raw.pair_repair_dropped_message_count
+      : null
+  return {
+    ...evidence,
+    pair_repair_dropped_message_count: pairRepairDropped,
+  } as KeeperCompactionExactEvidence
 }
 
 const COMPACTION_REINJECTION_STATES: readonly KeeperCompactionReinjectionState[] = [

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -580,6 +580,37 @@ describe('keeper tool telemetry fetchers', () => {
               checkpoint_loaded_receipts: 0, context_injected_receipts: 0,
             },
           },
+          {
+            id: 'manifest:trace-c:context_compacted:2026-06-26T04:04:00Z',
+            keeper: 'keeper-alpha',
+            ts_iso: '2026-06-26T04:04:00Z',
+            ts_unix: null,
+            trace_id: 'trace-c',
+            keeper_turn_id: 14,
+            source: 'runtime_manifest',
+            trigger: 'proactive(90%)',
+            runtime_id: 'oas-seoul-1',
+            display_runtime: 'oas-seoul-1',
+            before_tokens: 180000,
+            after_tokens: 90000,
+            saved_tokens: 90000,
+            compaction_id: 'cmp-43',
+            compaction_source: 'event_bus',
+            status: 'observed',
+            links: { receipt_path: null, checkpoint_path: null, tool_call_log_path: null },
+            exact_evidence: {
+              before_checkpoint_bytes: 2048, after_checkpoint_bytes: 512,
+              before_message_count: 9, after_message_count: 3,
+              summarized_message_count: 4, dropped_message_count: 1,
+              pair_repair_dropped_message_count: 2,
+              before_tool_use_count: 2, after_tool_use_count: 1,
+              before_tool_result_count: 2, after_tool_result_count: 1,
+            },
+            reinjection_observation: {
+              state: 'not_linked', keeper_turn_id: null,
+              checkpoint_loaded_receipts: 0, context_injected_receipts: 0,
+            },
+          },
         ],
       }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
     ))
@@ -601,6 +632,11 @@ describe('keeper tool telemetry fetchers', () => {
     expect(result.items[1]?.before_tokens).toBeNull()
     expect(result.items[1]?.runtime_id).toBeNull()
     expect(result.items[1]?.links.checkpoint_path).toBeNull()
+    // Rows persisted before #25037 lack pair_repair_dropped_message_count:
+    // the field decodes to null without voiding the rest of the evidence.
+    expect(result.items[0]?.exact_evidence?.before_checkpoint_bytes).toBe(4096)
+    expect(result.items[0]?.exact_evidence?.pair_repair_dropped_message_count).toBeNull()
+    expect(result.items[2]?.exact_evidence?.pair_repair_dropped_message_count).toBe(2)
   })
 })
 

--- a/dashboard/src/components/keeper-workspace/compaction-inspector-overlay.ts
+++ b/dashboard/src/components/keeper-workspace/compaction-inspector-overlay.ts
@@ -514,7 +514,7 @@ export function CompactionInspectorOverlay({
           <div class="turn-sec">
             <h4>유지 · 요약 · 폐기</h4>
             ${ev.summarizedCount != null || ev.droppedCount != null
-              ? html`<div class="cmp-trigger"><span class="sub-k">LLM plan</span><span class="mono">summarized=${ev.summarizedCount ?? '—'} · dropped=${ev.droppedCount ?? '—'}</span></div>`
+              ? html`<div class="cmp-trigger"><span class="sub-k">LLM plan</span><span class="mono">summarized=${ev.summarizedCount ?? '—'} · dropped=${ev.droppedCount ?? '—'}${ev.pairRepairDroppedCount != null ? ` · pair_repair_dropped=${ev.pairRepairDroppedCount}` : ''}</span></div>`
               : null}
             ${ev.kept.length === 0 && ev.summarized.length === 0 && ev.dropped.length === 0
               ? html`<${DataGapNote}>현재 백엔드 projection은 kept / summarized / dropped 목록을 노출하지 않습니다. 이 snapshot은 "컴팩션 이벤트 발생"과 가능한 token 계측만 증명합니다.</${DataGapNote}>`

--- a/dashboard/src/components/keeper-workspace/compaction-snapshots.ts
+++ b/dashboard/src/components/keeper-workspace/compaction-snapshots.ts
@@ -34,6 +34,7 @@ export interface CompactionSnapshot {
   readonly detailSource?: string | null
   readonly summarizedCount?: number | null
   readonly droppedCount?: number | null
+  readonly pairRepairDroppedCount?: number | null
   readonly reinjection?: KeeperCompactionReinjectionObservation
   readonly kept: readonly string[]
   readonly summarized: readonly string[]
@@ -118,6 +119,7 @@ function backendSnapshotToLocal(snapshot: BackendCompactionSnapshot): Compaction
     detailSource: snapshot.source,
     summarizedCount: evidence?.summarized_message_count ?? null,
     droppedCount: evidence?.dropped_message_count ?? null,
+    pairRepairDroppedCount: evidence?.pair_repair_dropped_message_count ?? null,
     reinjection: snapshot.reinjection_observation,
     kept: [],
     summarized: [],


### PR DESCRIPTION
## What
#25037이 wire payload에 추가한 `pair_repair_dropped_message_count`를 대시보드가 실제로 소비하게 한다 (24h 병합 감사 발견, P2).

- `dashboard-turn-records.ts`: evidence 타입/디코더에 필드 추가. **optional (`number | null`)** — 필수로 넣으면 디코더의 "하나라도 undefined면 evidence 전체 폐기" 규칙 때문에 #25037 이전에 영속된 레거시 행의 evidence가 전멸한다. absent→null.
- `compaction-snapshots.ts`: `pairRepairDroppedCount` projection 추가.
- `compaction-inspector-overlay.ts`: LLM plan 행에 `pair_repair_dropped=N` 표시 (null이면 미표시).
- 테스트: 레거시 행(필드 부재)→null이면서 evidence 유지, 신규 행→값 표시 양방향 고정.

## Why
백엔드는 `keeper_manual_compaction.ml`/`keeper_unified_turn.ml`이 `Keeper_compaction_evidence.to_json`으로 이 필드를 이미 내보내는데, 프론트 디코더가 unknown key를 버려서 **"accounting을 exact로 만든 바로 그 숫자"가 evidence 패널에서 보이지 않았다**. 사용자(운영자)는 pair repair가 몇 개를 추가로 지웠는지 대시보드에서 확인할 수 없었음.

## 검증
- Dashboard 테스트는 CI에서 확인.

## 연관
- 이전: #25037 (merged — 이 필드의 생산자), #25050 (allowlist SSOT).
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvELzG8FNa99yDKAs8Yz3A
