### PR TITLE
fix(keeper): tag reaction ledger rows with the v2 identity generation

### DIFF
--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -32,7 +32,12 @@ type reaction_kind =
 
 module Event_id_set = Set.Make (String)
 
-let schema = "keeper.reaction_ledger.v1"
+(* v1 rows carry digest-format durable ids ("krl…"); #25018 switched the
+   identity to (receipt.event_id, source_index) without bumping the tag
+   (#25080). v2 marks the new identity generation. Reads never dispatch on
+   this tag (rows are consumed by record_kind/stimulus_id), so v1 rows keep
+   loading; the summary segregates them for observability instead. *)
+let schema = "keeper.reaction_ledger.v2"
 
 let stimulus_kind_to_string = function
   | Board_signal -> "board_signal"
@@ -880,6 +885,7 @@ let summarize_rows ~keeper_name ~limit rows =
   let unsupported_stimulus_count = ref 0 in
   let payload_parse_error_count = ref 0 in
   let unknown_reaction_count = ref 0 in
+  let prior_schema_row_count = ref 0 in
   let latest_recorded_at = ref None in
   let latest_stimulus_id = ref None in
   let completion_contract_result_counts = Hashtbl.create 8 in
@@ -1024,6 +1030,12 @@ let summarize_rows ~keeper_name ~limit rows =
   in
   List.iter
     (fun row ->
+      (match string_field "schema" row with
+       | Some tag when String.equal tag schema -> ()
+       | Some _ | None ->
+         (* v1 (digest identity) or pre-tag rows: still consumed below, but
+            counted so a mixed-generation window is visible in health. *)
+         incr prior_schema_row_count);
       (match float_field "recorded_at_unix" row with
        | Some value -> latest_recorded_at := Some value
        | None -> ());
@@ -1118,6 +1130,7 @@ let summarize_rows ~keeper_name ~limit rows =
     ; "unsupported_stimulus_count", `Int !unsupported_stimulus_count
     ; "payload_parse_error_count", `Int !payload_parse_error_count
     ; "unknown_reaction_count", `Int !unknown_reaction_count
+    ; "prior_schema_row_count", `Int !prior_schema_row_count
     ; "cursor_swept_stimulus_count", `Int !cursor_swept_stimulus_count
     ; "legacy_cursor_swept_stimulus_count", `Int !legacy_cursor_swept_stimulus_count
     ; "pending_stimulus_count", `Int pending_stimulus_count
@@ -1156,6 +1169,7 @@ let error_summary ~keeper_name ~limit error =
     ; "unsupported_stimulus_count", `Int 0
     ; "payload_parse_error_count", `Int 0
     ; "unknown_reaction_count", `Int 0
+    ; "prior_schema_row_count", `Int 0
     ; "cursor_swept_stimulus_count", `Int 0
     ; "legacy_cursor_swept_stimulus_count", `Int 0
     ; "pending_stimulus_count", `Int 0

--- a/test/test_keeper_reaction_ledger.ml
+++ b/test/test_keeper_reaction_ledger.ml
@@ -180,7 +180,7 @@ let test_event_queue_stimulus_and_turn_reaction () =
   in
   check int "two rows persisted" 2 (List.length rows);
   let stimulus_row = List.nth rows 0 in
-  check_member_string "stimulus schema" "keeper.reaction_ledger.v1" "schema" stimulus_row;
+  check_member_string "stimulus schema" "keeper.reaction_ledger.v2" "schema" stimulus_row;
   check_member_string "stimulus record kind" "stimulus" "record_kind" stimulus_row;
   check_member_string "board stimulus id" "board:post-42" "stimulus_id" stimulus_row;
   check_member_string
@@ -258,6 +258,8 @@ let test_event_queue_reaction_evidence_matches_exact_stimulus_id () =
     (summary |> member "event_queue_ack_count" |> to_int);
   check int "event queue ack is not unknown" 0
     (summary |> member "unknown_reaction_count" |> to_int);
+  check int "rows written by this binary carry the current schema" 0
+    (summary |> member "prior_schema_row_count" |> to_int);
   let missing =
     Keeper_reaction_ledger.event_queue_reaction_evidence
       ~base_path
@@ -1147,6 +1149,52 @@ let test_reaction_kind_string_roundtrip () =
        (Keeper_reaction_ledger.reaction_kind_of_string "legacy_custom"))
 ;;
 
+let test_prior_schema_rows_are_segregated_but_consumed () =
+  with_temp_base
+  @@ fun base_path ->
+  let keeper_name = "sangsu" in
+  Keeper_reaction_ledger.record_event_queue_stimulus
+    ~base_path
+    ~keeper_name
+    (board_stimulus ());
+  (* Hand-written v1-generation row (digest identity era, #25080): reads must
+     keep consuming it while the summary makes the mixed window visible. *)
+  let store =
+    Dated_jsonl.create
+      ~base_dir:
+        (Filename.concat
+           (Filename.concat
+              (Filename.concat (Common.masc_dir_from_base_path ~base_path) "keepers")
+              keeper_name)
+           "reaction-ledger")
+      ()
+  in
+  Dated_jsonl.append
+    store
+    (`Assoc
+        [ "schema", `String "keeper.reaction_ledger.v1"
+        ; "record_kind", `String "stimulus"
+        ; "event_id", `String "krl:deadbeef"
+        ; "keeper_name", `String keeper_name
+        ; "recorded_at_unix", `Float 1200.0
+        ; "stimulus_id", `String "board:post-legacy"
+        ; "stimulus", `Assoc [ "kind", `String "board_signal" ]
+        ]);
+  let summary =
+    Keeper_reaction_ledger.summary_for_keeper ~base_path ~keeper_name ~limit:10
+  in
+  check
+    int
+    "both generations are consumed"
+    2
+    (summary |> member "stimulus_count" |> to_int);
+  check
+    int
+    "prior-generation rows are segregated"
+    1
+    (summary |> member "prior_schema_row_count" |> to_int)
+;;
+
 let () =
   run
     "keeper_reaction_ledger"
@@ -1155,6 +1203,10 @@ let () =
             "event queue stimulus and turn reaction are durable"
             `Quick
             test_event_queue_stimulus_and_turn_reaction
+        ; test_case
+            "prior schema rows are segregated but consumed"
+            `Quick
+            test_prior_schema_rows_are_segregated_but_consumed
         ; test_case
             "event queue reaction evidence matches exact stimulus id"
             `Quick


### PR DESCRIPTION
## What (#25080 수리)
reaction ledger의 write-side schema 태그를 `keeper.reaction_ledger.v1` → `v2`로 올린다. #25018이 durable identity를 digest(`krl…`) → `(receipt.event_id, source_index)`로 바꾸면서 태그를 안 올려, 배포 경계에서 두 세대 행이 구분 불가능했다.

## 하드컷 아님 (의도적)
read 경로는 schema 태그로 dispatch하지 않는다(행 소비는 `record_kind`/`stimulus_id` 기준) — **v1 행은 계속 읽힌다.** 오늘 #25078(스키마 하드컷 → 16/16 keeper 부트 거부)과 같은 실패 모드를 만들지 않기 위해 exact-match 거부를 넣지 않았다. 대신 keeper summary에 `prior_schema_row_count`를 추가해 혼합 세대 창이 fleet health에서 보이게 했다.

## 검증
- 테스트 2속성 고정: v1 행이 여전히 stimulus로 집계됨(소비 유지) + `prior_schema_row_count`로 분리 집계됨. 현 바이너리가 쓴 행은 0.
- 대시보드 normalizer는 필드 선택형이라 additive 필드 안전 (확인함).
- 빌드/테스트는 CI에서.

## 연관
- 원인: #25018 (merged) 리뷰 잔존 P1 → 이슈 #25080 (이 PR이 닫음).
- blast radius: 유일 소비자 = fleet health 카운트 (정착 상태 무관) — #25080 분석 참조.

Closes #25080.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvELzG8FNa99yDKAs8Yz3A
