### PR TITLE
docs(rfc)!: withdraw global admission authority

### DIFF
--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -46,7 +46,7 @@ implementation_prs: []             # [14181, 14550] 형식 (정수). RFC body �
 
 | # | Title | Status | Last activity | Sub-docs |
 |---|---|---|---|---|
-| 0000 | MASC × OAS Consolidated Master Design (SSOT) | Draft | 63c38bf628 2026-07-17 | - |
+| 0000 | MASC × OAS Consolidated Master Design (SSOT) | Draft | b07a069c5c 2026-07-17 | - |
 | 0001 | Withdraw heuristic uncertainty governance | Withdrawn | 7b62a87d44 2026-07-13 | - |
 | 0002 | Keeper 11-State Machine + Det/NonDet Boundary Formalization | reference | 7b62a87d44 2026-07-13 | - |
 | 0003 | Withdraw composite lifecycle projection hierarchy | Withdrawn | 7b62a87d44 2026-07-13 | - |
@@ -332,9 +332,9 @@ implementation_prs: []             # [14181, 14550] 형식 (정수). RFC body �
 | conn | Durable Keeper chat receipts and connector delivery settlement | Active | 9d59e83655 2026-07-14 | - |
 | elim | Withdrawn command-policy classification experiment | Withdrawn | 7b62a87d44 2026-07-13 | - |
 | keep | Vision-as-a-tool delegation (decouple multimodal input from conversation runt... | Draft | 7b62a87d44 2026-07-13 | - |
-| masc | Masc_oas_bridge as the total LLM dispatch boundary | Draft | (untracked) | - |
+| masc | Withdraw budget-and-slot authority from the MASC OAS bridge | Withdrawn | d5bd126498 2026-07-17 | - |
 | runt | Per-runtime note field & dashboard surfacing | Draft | 03d5feaf25 2026-07-08 | - |
-| shar | Shared typed admission primitive + knob-binding policy | Draft | (untracked) | - |
+| shar | Withdraw shared MASC admission and knob-binding policy | Withdrawn | d5bd126498 2026-07-17 | - |
 | type | Withdraw product-specific egress effect classification | Withdrawn | 7b62a87d44 2026-07-13 | - |
 
 ### 신규 RFC

--- a/docs/rfc/RFC-masc-oas-bridge-total-llm-dispatch-boundary.md
+++ b/docs/rfc/RFC-masc-oas-bridge-total-llm-dispatch-boundary.md
@@ -1,17 +1,25 @@
 ---
 rfc: "masc-oas-bridge-total-llm-dispatch-boundary"
-title: "Masc_oas_bridge as the total LLM dispatch boundary"
-status: Draft
+title: "Withdraw budget-and-slot authority from the MASC OAS bridge"
+status: Withdrawn
 created: 2026-07-17
 updated: 2026-07-17
 author: vincent
 supersedes: []
-superseded_by: null
+superseded_by: "0000"
 related: ["0159", "0206", "0338", "shared-admission-primitive-knob-binding-policy"]
 implementation_prs: []
 ---
 
-# RFC-masc-oas-bridge-total-llm-dispatch-boundary — Masc_oas_bridge as the total LLM dispatch boundary
+# RFC-masc-oas-bridge-total-llm-dispatch-boundary — Withdraw bridge admission authority
+
+> **WITHDRAWN — DO NOT IMPLEMENT.** A small typed MASC→OAS projection boundary
+> is valid; making it a mandatory `run_bounded` budget/slot authority is not.
+> MASC must not duplicate OAS provider admission, impose implicit deadlines,
+> or make one LLM lane wait behind an unrelated global/lane cap. Each caller
+> owns only its typed product operation and immutable observation; configured
+> LLM judgment and OAS own their respective semantic and provider boundaries.
+> Historical analysis below is retained only until the stacked tombstone PR.
 
 ## 0. Summary
 

--- a/docs/rfc/RFC-shared-admission-primitive-knob-binding-policy.md
+++ b/docs/rfc/RFC-shared-admission-primitive-knob-binding-policy.md
@@ -1,17 +1,25 @@
 ---
 rfc: "shared-admission-primitive-knob-binding-policy"
-title: "Shared typed admission primitive + knob-binding policy"
-status: Draft
+title: "Withdraw shared MASC admission and knob-binding policy"
+status: Withdrawn
 created: 2026-07-17
 updated: 2026-07-17
 author: vincent
 supersedes: []
-superseded_by: null
+superseded_by: "0000"
 related: ["0153", "0158", "0206", "0225", "0334", "masc-oas-bridge-total-llm-dispatch-boundary"]
 implementation_prs: []
 ---
 
-# RFC-shared-admission-primitive-knob-binding-policy — Shared typed admission primitive + knob-binding policy
+# RFC-shared-admission-primitive-knob-binding-policy — Withdraw shared MASC admission
+
+> **WITHDRAWN — DO NOT IMPLEMENT.** The proposed global cardinality-N
+> `Admission.Make`, `Skip_if_full`, `Wait_fifo`, and knob-name lint would
+> recreate MASC-side admission authority across independent Keeper lanes.
+> Explicit provider/account concurrency belongs to OAS endpoint admission;
+> MASC observes it and keeps each Keeper owner runnable. A blocked activity
+> may park, but it may not deny, drop, pause, or fleet-serialize other work.
+> Historical analysis below is retained only until the stacked tombstone PR.
 
 ## 0. Summary
 


### PR DESCRIPTION
## Adversarial finding

The newly merged Draft pair proposed the exact authority being removed from MASC: a fleet/lane cardinality-N `Admission.Make`, `Skip_if_full` denial, FIFO waiting behind unrelated work, and a mandatory budget-and-slot-aware `run_bounded` bridge for every LLM dispatch.

Typed code does not make that policy objective. These surfaces duplicate OAS endpoint/account admission, can stall independent Keeper lanes, and turn observation/config declarations back into MASC execution authority.

## Change

- mark both RFCs `Withdrawn`
- point them to RFC-0000
- add an explicit DO NOT IMPLEMENT boundary statement
- regenerate the RFC index

This first 38-line safety leaf prevents new implementation from following the Draft while two stacked tombstone leaves remove the historical proposal bodies under the 400-line PR limit.

## Preserved direction

A small typed MASC->OAS projection boundary remains valid. Explicit provider concurrency stays in OAS; MASC product operations, LLM judgment, owner-local parking/wake, and immutable observations remain separate.