### PR TITLE
fix(keeper): thread resolved retry-after through the 429 reconstruction

### DIFF
--- a/lib/keeper/keeper_runtime_attempt.ml
+++ b/lib/keeper/keeper_runtime_attempt.ml
@@ -110,8 +110,13 @@ let sdk_error_to_runtime_outcome err =
            http_error ~code:400 ~body:message
          | ContextOverflow { message; _ } ->
            http_error ~code:400 ~body:message
-         | RateLimited { message; _ } ->
-           http_error ~code:429 ~body:message
+         | RateLimited { message; retry_after } ->
+           (* Reconstruction boundary: [retry_after] is the resolved value
+              (body-or-header) and the header slot is the only retry-after
+              carrier on [HttpError], so it re-enters here rather than being
+              dropped. *)
+           Llm_provider.Http_client.HttpError
+             { code = 429; body = message; retry_after_header = retry_after }
          | PaymentRequired { message } ->
            http_error ~code:402 ~body:message
          | NotFound { message } ->

--- a/test/dune
+++ b/test/dune
@@ -220,6 +220,7 @@
   test_keeper_contract_classifier_pure
   test_compaction_llm_summarizer
   test_keeper_runtime_failure_route
+  test_keeper_runtime_attempt
   test_keeper_allowed_paths
   test_playground_paths
   test_keeper_meta_cwd_resilience
@@ -537,6 +538,7 @@
   test_keeper_contract_classifier_pure
   test_compaction_llm_summarizer
   test_keeper_runtime_failure_route
+  test_keeper_runtime_attempt
   test_keeper_allowed_paths
   test_playground_paths
   test_keeper_meta_cwd_resilience

--- a/test/test_keeper_runtime_attempt.ml
+++ b/test/test_keeper_runtime_attempt.ml
@@ -1,0 +1,40 @@
+(** Mapping tests for [Keeper_runtime_attempt.sdk_error_to_runtime_outcome].
+
+    Pins the 429 reconstruction boundary: the resolved [retry_after] on
+    [Llm_provider.Retry.RateLimited] must re-enter through
+    [HttpError.retry_after_header] instead of being dropped. Both 0.216
+    adaptation passes on 2026-07-17 (#25082, #25084) discarded it with a
+    [{ message; _ }] pattern, so this mapping is fenced by test. *)
+
+module KRA = Masc.Keeper_runtime_attempt
+
+let retry_after_of_outcome = function
+  | Some
+      (Runtime_attempt_fsm.Call_err
+         (Llm_provider.Http_client.HttpError { code = 429; retry_after_header; _ })) ->
+    Some retry_after_header
+  | _ -> None
+
+let rate_limited retry_after =
+  Agent_sdk.Error.Api (Llm_provider.Retry.RateLimited { message = "slow down"; retry_after })
+
+let test_429_threads_resolved_retry_after () =
+  Alcotest.(check (option (option (float 0.0))))
+    "resolved retry-after re-enters via the header slot"
+    (Some (Some 42.0))
+    (retry_after_of_outcome (KRA.sdk_error_to_runtime_outcome (rate_limited (Some 42.0))))
+
+let test_429_without_hint_stays_none () =
+  Alcotest.(check (option (option (float 0.0))))
+    "absent hint maps to None, still a 429 HttpError"
+    (Some None)
+    (retry_after_of_outcome (KRA.sdk_error_to_runtime_outcome (rate_limited None)))
+
+let () =
+  Alcotest.run
+    "keeper_runtime_attempt"
+    [ ( "rate_limited_429"
+      , [ Alcotest.test_case "threads resolved retry_after" `Quick test_429_threads_resolved_retry_after
+        ; Alcotest.test_case "absent hint stays None" `Quick test_429_without_hint_stays_none
+        ] )
+    ]


### PR DESCRIPTION
## Outcome

Preserves OAS-resolved `retry_after` evidence when a rate-limited SDK error is reconstructed for the Keeper runtime FSM.

## Change

- destructure `Retry.RateLimited.retry_after`
- carry it through the existing `HttpError.retry_after_header` slot
- pin the mapping with focused tests

This is a signal-preservation fix at one adapter boundary. It does not add retry policy, a second admission authority, a fallback, or a new public surface.

## Verification

- rebased without conflicts on `main` `3be51c2160591798fe6123e1c4f0544b5b75592c`
- exact head `89eb13a92273a30e2295992e9a8a2189a16f6016`
- changed OCaml parser/`ocamlformat --check`: pass
- `git diff --check origin/main...HEAD`: pass
- previous exact source patch passed the full required CI suite and its counterfactual mapping tests

A concurrent bare `dune build .` caused the repository wrapper to refuse another focused local build; it was not killed or bypassed. This remains Draft until required CI evaluates the rebased head.

## 리뷰 조건 이행 (adversarial PASS 조건 1건)
`retry_after_header` 소비자 후속은 429 backoff/lane 트랙에서 추적: #25051 #25052 #25053 (T1-T7 lane 전수분석) + Draft RFC pair #25055 (shared admission primitive + total LLM dispatch boundary). 소비자가 앉을 자리는 `Runtime_attempt_fsm.should_try_next`의 429 즉시-다음-후보 경로이며, 링크된 트랙이 landing하면 이 필드가 라이브 backoff 입력이 된다.
