### PR TITLE
fix(compaction): preserve exact provider capacity

### DIFF
--- a/lib/keeper/keeper_context_runtime.ml
+++ b/lib/keeper/keeper_context_runtime.ml
@@ -360,18 +360,12 @@ let effective_model_labels_for_turn (m : keeper_meta) : string list =
 
 let resolve_max_context_resolution ~requested_override (labels : string list)
     : max_context_resolution =
-  let min_keeper_context = Keeper_config.min_keeper_context_tokens in
-  let clamp resolved =
-    let local_clamped = resolved in
-    max min_keeper_context local_clamped
-  in
-  let default_budget = Runtime.default_max_context () |> clamp in
+  let default_budget = Runtime.default_max_context () in
   let runtime_budget =
     labels
     |> List.find_map (fun label ->
            String.trim label
-           |> Runtime.max_context_of_runtime_id
-           |> Option.map clamp)
+           |> Runtime.max_context_of_runtime_id)
     (* Labels are an ordered runtime-budget preference list. If none resolve,
        the precomputed default runtime budget preserves config-less tests.
        DET-OK: dispatch still fail-fast validates the selected runtime id before
@@ -382,8 +376,7 @@ let resolve_max_context_resolution ~requested_override (labels : string list)
   let primary_budget = runtime_budget in
   let requested_context_window =
     match requested_override with
-    | Some requested when requested > 0 ->
-      max min_keeper_context requested
+    | Some requested when requested > 0 -> requested
     | _ -> primary_budget
   in
   let effective_budget = min requested_context_window primary_budget in

--- a/lib/keeper/keeper_manual_compaction.ml
+++ b/lib/keeper/keeper_manual_compaction.ml
@@ -9,9 +9,8 @@ type failure =
       Keeper_post_turn.compaction_recovery_error
       * (unit, Keeper_context_runtime.lifecycle_dispatch_error) result
 let primary_max_context meta =
-  let min_context = Keeper_config.min_keeper_context_tokens in
   let resolution = Keeper_context_runtime.resolve_max_context_resolution_of_meta meta in
-  max min_context resolution.effective_budget
+  resolution.effective_budget
 ;;
 let append_manifest ~config ~base_dir ~(meta : keeper_meta) recovery =
   match recovery.Keeper_context_runtime.compaction.trigger with

--- a/lib/keeper/keeper_tool_surface.ml
+++ b/lib/keeper/keeper_tool_surface.ml
@@ -454,16 +454,15 @@ let handle_keeper_reset ctx args : tool_result =
 
     Returns the resolved primary provider/runtime context window, separate from
     any requested [max_context_override].
-    Returns [min_keeper_context_tokens] when meta is unavailable. *)
+    Returns the configured default Runtime capacity when meta is unavailable. *)
 let resolve_primary_max_context (meta : Keeper_meta_contract.keeper_meta option) : int =
-  let min_ctx = Keeper_config.min_keeper_context_tokens in
   match meta with
-  | None -> min_ctx
+  | None -> Runtime.default_max_context ()
   | Some meta ->
     let resolution =
       Keeper_context_runtime.resolve_max_context_resolution_of_meta meta
     in
-    max min_ctx resolution.effective_budget
+    resolution.effective_budget
 
 let manual_compaction_wakeup_observation ~base_path keeper_name =
   match

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -172,6 +172,12 @@ max-context = 64000
 tools-support = true
 streaming = true
 
+[models.small]
+api-name = "small"
+max-context = 32000
+tools-support = true
+streaming = true
+
 [models.gpt.capabilities]
 max-output-tokens = 32000
 supports-tool-choice = true
@@ -199,6 +205,9 @@ max-concurrent = 4
 
 [openai.gpt]
 is-default = true
+max-concurrent = 1
+
+[openai.small]
 max-concurrent = 1
 |}
 ;;
@@ -306,6 +315,13 @@ max_context_tokens = 64000
 supports_tools = true
 supports_response_format_json = true
 supports_structured_output = true
+supports_native_streaming = true
+
+[[models]]
+id_prefix = "openai_compat/small"
+base = "openai_chat"
+max_context_tokens = 32000
+supports_tools = true
 supports_native_streaming = true
 
 [[providers]]
@@ -914,6 +930,11 @@ let test_context_budget_uses_selected_runtime () =
         ~requested_override:None
         [ "openai.gpt" ]
     in
+    let small_budget =
+      Keeper_context_runtime.resolve_max_context_resolution
+        ~requested_override:None
+        [ "openai.small" ]
+    in
     Alcotest.(check int)
       "default runtime budget"
       128000
@@ -921,7 +942,11 @@ let test_context_budget_uses_selected_runtime () =
     Alcotest.(check int)
       "selected runtime budget"
       64000
-      selected_budget.Keeper_context_runtime.effective_budget)
+      selected_budget.Keeper_context_runtime.effective_budget;
+    Alcotest.(check int)
+      "provider capacity below 64k is not enlarged"
+      32000
+      small_budget.Keeper_context_runtime.effective_budget)
 ;;
 
 let test_context_budget_source_is_shared_ssot () =


### PR DESCRIPTION
## Outcome

Preserve the exact selected Runtime/provider context capacity, including valid capacities below 64k. Manual compaction and the Keeper tool surface no longer enlarge a known provider value.

## Scope

- remove the 64k upward clamp from Runtime capacity resolution
- preserve positive requested overrides exactly, then narrow with the provider capacity
- use the configured default Runtime capacity only when Keeper metadata/capacity is unavailable
- prove a known 32k provider remains 32k

This is C1 of #25110. It does **not** claim unknown-capacity removal, prepared-request source fit, oversized compaction waves, or final reinjection proof.

## Stack

Base: #25102 exact OAS v0.216.2 pin at `e68eac28ee`.

## Verification

- focused wrapper build: PASS
- `test_runtime_per_keeper_routing`: 39/39
- `ocamlformat --check`: PASS
- `git diff --check`: PASS
- full build/test delegated to Draft PR CI

[근거] source diff `e68eac28ee..1194e3ae54` and focused wrapper output; checked 2026-07-17 KST; confidence High.