### PR TITLE
fix(dashboard): reject invalid context override wire

### DIFF
--- a/dashboard/src/api/dashboard-keeper-config.ts
+++ b/dashboard/src/api/dashboard-keeper-config.ts
@@ -3,7 +3,7 @@
 // from dashboard.ts so existing consumers (`from './api/dashboard'`) are unchanged.
 
 import { get, post } from './core'
-import { isRecord, asBoolean, asInt, asNullableString, asNumber, asStringArray, asRecordArray } from '../components/common/normalize'
+import { isRecord, asBoolean, asInt, asNullableString, asNumber, asStringArray, asRecordArray, isPositiveSafeInteger } from '../components/common/normalize'
 import { ensureDevToken } from './dev-token'
 import { asKeeperRuntimeBlockerClass } from '../lib/runtime-blocker-class'
 import type { KeeperConfig, KeeperFeatureStatus, KeeperHookSlot } from '../types'
@@ -36,6 +36,14 @@ function asLooseNumber(value: unknown): number | undefined {
 
 function asLooseNullableNumber(value: unknown): number | null {
   return asLooseNumber(value) ?? null
+}
+
+function decodeMaxContextOverride(value: unknown): number | null {
+  if (value === null) return null
+  if (isPositiveSafeInteger(value)) return value
+  throw new Error(
+    'Invalid keeper config response: max_context_override must be a positive safe integer or null',
+  )
 }
 
 function normalizeStringList(value: unknown): string[] {
@@ -167,7 +175,7 @@ function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfi
     name: asNullableString(data.name) ?? requestedName,
     active_goal_ids: normalizeStringList(data.active_goal_ids),
     autoboot_enabled: asLooseBoolean(data.autoboot_enabled, true),
-    max_context_override: asInt(data.max_context_override) ?? null,
+    max_context_override: decodeMaxContextOverride(data.max_context_override),
     sandbox_profile: asNullableString(data.sandbox_profile) ?? '(unknown sandbox_profile)',
     network_mode: asNullableString(data.network_mode) ?? '(unknown network_mode)',
     sandbox_last_error: asNullableString(data.sandbox_last_error),

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -1899,12 +1899,12 @@ describe('dashboard goals decoding', () => {
 })
 
 describe('fetchKeeperConfig', () => {
-  it('normalizes singleton string, numeric string, and boolean string fields', async () => {
+  it('normalizes singleton and boolean string fields with a canonical context override', async () => {
     const rawResponse = {
       name: 'keeper-sangsu',
       active_goal_ids: ['goal-runtime'],
       autoboot_enabled: 'false',
-      max_context_override: '64000',
+      max_context_override: 64_000,
       sandbox_profile: 'docker',
       network_mode: 'none',
       sandbox_last_error: 'sandbox docker exec failed',
@@ -2044,11 +2044,51 @@ describe('fetchKeeperConfig', () => {
     expect(result.field_presence?.producer).toBe('dashboard-keeper-config.normalizer')
   })
 
+  it.each([
+    ['numeric string', '"64000"'],
+    ['fractional numeric string', '"3.9"'],
+    ['float', '3.9'],
+    ['zero', '0'],
+    ['negative integer', '-1'],
+    ['unsafe integer', '9007199254740992'],
+    ['out-of-range number', '1e309'],
+  ])('rejects a non-canonical max_context_override wire value: %s', async (_label, wireValue) => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        `{"name":"keeper-sangsu","max_context_override":${wireValue}}`,
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      ),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(fetchKeeperConfig('keeper-sangsu')).rejects.toThrowError(
+      'Invalid keeper config response: max_context_override must be a positive safe integer or null',
+    )
+  })
+
+  it('rejects a missing max_context_override wire field', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('{"name":"keeper-sangsu"}', {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(fetchKeeperConfig('keeper-sangsu')).rejects.toThrowError(
+      'Invalid keeper config response: max_context_override must be a positive safe integer or null',
+    )
+  })
+
   it('tracks raw keeper config field presence before defaults are normalized', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(
         JSON.stringify({
           name: 'keeper-sangsu',
+          max_context_override: null,
           prompt: {
             instructions: 'raw instructions only',
           },
@@ -2076,6 +2116,7 @@ describe('fetchKeeperConfig', () => {
       new Response(
         JSON.stringify({
           name: 'keeper-sangsu',
+          max_context_override: null,
           field_presence: {
             schema: 'keeper.config.field_presence.v1',
             producer: 'dashboard_http_keeper_snapshot',
@@ -2115,6 +2156,7 @@ describe('fetchKeeperConfig', () => {
         new Response(
           JSON.stringify({
             name: 'keeper-sangsu',
+            max_context_override: null,
             metrics,
           }),
           {
@@ -2156,6 +2198,7 @@ describe('fetchKeeperConfig', () => {
         new Response(
           JSON.stringify({
             name: 'keeper-sangsu',
+            max_context_override: null,
             runtime: {
               runtime_blocker_class: blockerClass,
               runtime_blocker_summary: blockerClass,
@@ -2182,6 +2225,7 @@ describe('keeper config mutation API', () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({
         name: 'keeper-sangsu',
+        max_context_override: null,
         execution: {
           selected_runtime_id: 'b.two',
           selected_runtime_canonical: 'b.two',


### PR DESCRIPTION
## Outcome

Hard-cut Dashboard GET compatibility coercion for Keeper context overrides. The wire contract is now exactly `null | positive safe integer`; malformed or missing values fail explicitly.

## Scope

- replace generic `asInt` coercion for `max_context_override` with an exact structural decoder
- reject missing, string, fractional, zero, negative, unsafe-integer, and out-of-range values
- replace the legacy numeric-string fixture with canonical JSON integer input
- retain `null` as the sole canonical cleared value

No migration or string-number compatibility is retained. This is C3 stacked on #25113; unknown provider capacity and prepared-request source fit remain separate work.

## Stack

- #25112 exact known provider capacity
- #25113 override-bound and silent write/persistence coercion purge
- this PR strict Dashboard read decoder

## Verification

- TypeScript typecheck: PASS
- focused `dashboard.test.ts`: 89/89
- `git diff --check`: PASS
- 60 changed lines, below the 400-line leaf limit

[근거] exact diff `c92cde6031..a373b8b203` and focused dashboard output; checked 2026-07-17 KST; confidence High.