### PR TITLE
fix(compaction): reject invalid tool identities

### DIFF
--- a/lib/keeper/keeper_compaction_unit.ml
+++ b/lib/keeper/keeper_compaction_unit.ml
@@ -6,6 +6,21 @@ type closed_unit =
   | Closed_tool_cycle of T.message list
 
 type structural_error =
+  | Empty_tool_use_id of
+      { message_index : int
+      ; block_index : int
+      ; tool_use_id : string
+      }
+  | Empty_tool_result_id of
+      { message_index : int
+      ; block_index : int
+      ; tool_use_id : string
+      }
+  | Message_tool_call_id_mismatch of
+      { message_index : int
+      ; message_tool_call_id : string
+      ; content_tool_use_ids : string list
+      }
   | Orphan_tool_result of
       { message_index : int
       ; tool_use_id : string
@@ -50,21 +65,59 @@ type open_cycle =
   ; messages_rev : T.message list
   }
 
-let top_level_anchors blocks =
-  List.fold_left
-    (fun (uses, results) -> function
-      | T.ToolUse { id; _ } -> id :: uses, results
-      | T.ToolResult { tool_use_id; _ } -> uses, tool_use_id :: results
-      | T.Text _
+(* Blank classification must not normalize the provider-owned identity used
+   by cycle matching and persisted evidence. *)
+let tool_id_is_blank tool_use_id = String.trim tool_use_id = ""
+
+let top_level_anchors ~message_index blocks =
+  let rec collect block_index uses results = function
+    | [] -> Ok (List.rev uses, List.rev results)
+    | T.ToolUse { id; _ } :: _ when tool_id_is_blank id ->
+      Error
+        (Empty_tool_use_id
+           { message_index; block_index; tool_use_id = id })
+    | T.ToolUse { id; _ } :: rest ->
+      collect (block_index + 1) (id :: uses) results rest
+    | T.ToolResult { tool_use_id; _ } :: _ when tool_id_is_blank tool_use_id ->
+      Error
+        (Empty_tool_result_id
+           { message_index; block_index; tool_use_id })
+    | T.ToolResult { tool_use_id; _ } :: rest ->
+      collect (block_index + 1) uses (tool_use_id :: results) rest
+    | (T.Text _
       | T.Thinking _
       | T.ReasoningDetails _
       | T.RedactedThinking _
       | T.Image _
       | T.Document _
-      | T.Audio _ ->
-          uses, results)
-    ([], []) blocks
-  |> fun (uses, results) -> List.rev uses, List.rev results
+      | T.Audio _)
+      :: rest ->
+      collect (block_index + 1) uses results rest
+  in
+  collect 0 [] [] blocks
+
+let validate_message_tool_call_id ~message_index ~content_tool_use_ids = function
+  | None -> Ok ()
+  | Some message_tool_call_id ->
+    (match content_tool_use_ids with
+     | [ content_tool_use_id ]
+       when String.equal message_tool_call_id content_tool_use_id ->
+       Ok ()
+     | content_tool_use_ids ->
+       Error
+         (Message_tool_call_id_mismatch
+            { message_index; message_tool_call_id; content_tool_use_ids }))
+
+let validated_top_level_anchors ~message_index (message : T.message) =
+  match top_level_anchors ~message_index message.content with
+  | Error _ as error -> error
+  | Ok (tool_ids, result_ids) ->
+    Result.map
+      (fun () -> tool_ids, result_ids)
+      (validate_message_tool_call_id
+         ~message_index
+         ~content_tool_use_ids:result_ids
+         message.tool_call_id)
 
 let rec add_tool_ids ~message_index seen = function
   | [] -> Ok seen
@@ -90,6 +143,7 @@ let is_result_role = function
   | T.System | T.Assistant -> false
 
 let partition messages =
+  let ( let* ) = Result.bind in
   let rec loop index units_rev seen_tools seen_results open_cycle = function
     | [] ->
         let protected_suffix =
@@ -99,7 +153,9 @@ let partition messages =
         in
         Ok { closed_prefix = List.rev units_rev; protected_suffix }
     | (message : T.message) :: rest ->
-        let tool_ids, result_ids = top_level_anchors message.content in
+        let* tool_ids, result_ids =
+          validated_top_level_anchors ~message_index:index message
+        in
         (match message.role, tool_ids with
         | (T.System | T.User | T.Tool), tool_use_id :: _ ->
             Error (Non_assistant_tool_use { message_index = index; tool_use_id })

--- a/lib/keeper/keeper_compaction_unit.mli
+++ b/lib/keeper/keeper_compaction_unit.mli
@@ -10,6 +10,21 @@ type closed_unit =
   | Closed_tool_cycle of Agent_sdk.Types.message list
 
 type structural_error =
+  | Empty_tool_use_id of
+      { message_index : int
+      ; block_index : int
+      ; tool_use_id : string
+      }
+  | Empty_tool_result_id of
+      { message_index : int
+      ; block_index : int
+      ; tool_use_id : string
+      }
+  | Message_tool_call_id_mismatch of
+      { message_index : int
+      ; message_tool_call_id : string
+      ; content_tool_use_ids : string list
+      }
   | Orphan_tool_result of
       { message_index : int
       ; tool_use_id : string

--- a/test/test_keeper_compaction_unit.ml
+++ b/test/test_keeper_compaction_unit.ml
@@ -1,8 +1,8 @@
 module U = Masc.Keeper_compaction_unit
 module T = Agent_sdk.Types
 
-let message role content : T.message =
-  { role; content; name = None; tool_call_id = None; metadata = [] }
+let message ?tool_call_id role content : T.message =
+  { role; content; name = None; tool_call_id; metadata = [] }
 
 let text role value = message role [ T.Text value ]
 
@@ -146,6 +146,122 @@ let test_mixed_request_result_error () =
       ()
   | _ -> Alcotest.fail "expected typed mixed request/result"
 
+let test_empty_tool_use_id_error () =
+  List.iter
+    (fun tool_use_id ->
+       match U.partition [ message T.Assistant [ use tool_use_id ] ] with
+       | Error
+           (U.Empty_tool_use_id
+             { message_index = 0; block_index = 0; tool_use_id = actual }) ->
+         Alcotest.(check string) "raw empty ToolUse id" tool_use_id actual
+       | _ -> Alcotest.fail "expected typed empty ToolUse id")
+    [ ""; " \t\n" ]
+;;
+
+let test_empty_tool_result_id_error () =
+  List.iter
+    (fun tool_use_id ->
+       let request = message T.Assistant [ use "expected" ] in
+       let response = message T.Tool [ result tool_use_id ] in
+       match U.partition [ request; response ] with
+       | Error
+           (U.Empty_tool_result_id
+             { message_index = 1; block_index = 0; tool_use_id = actual }) ->
+         Alcotest.(check string) "raw empty ToolResult id" tool_use_id actual
+       | _ -> Alcotest.fail "expected typed empty ToolResult id")
+    [ ""; " \t\n" ]
+;;
+
+let test_parallel_empty_tool_use_id_error () =
+  let request =
+    message T.Assistant
+      [ use "call-a"; T.Text "between"; use " \t"; use "call-b" ]
+  in
+  match U.partition [ request ] with
+  | Error
+      (U.Empty_tool_use_id
+        { message_index = 0; block_index = 2; tool_use_id = " \t" }) ->
+    ()
+  | _ -> Alcotest.fail "expected typed empty parallel ToolUse id"
+;;
+
+let test_parallel_empty_tool_result_id_error () =
+  let request = message T.Assistant [ use "call-a"; use "call-b" ] in
+  let response =
+    message T.Tool [ result "call-a"; T.Text "between"; result "\n " ]
+  in
+  match U.partition [ request; response ] with
+  | Error
+      (U.Empty_tool_result_id
+        { message_index = 1; block_index = 2; tool_use_id = "\n " }) ->
+    ()
+  | _ -> Alcotest.fail "expected typed empty parallel ToolResult id"
+;;
+
+let test_message_content_tool_id_mismatch_error () =
+  let request = message T.Assistant [ use "content-id" ] in
+  let response =
+    message ~tool_call_id:"message-id" T.Tool [ result "content-id" ]
+  in
+  match U.partition [ request; response ] with
+  | Error
+      (U.Message_tool_call_id_mismatch
+        { message_index = 1
+        ; message_tool_call_id = "message-id"
+        ; content_tool_use_ids = [ "content-id" ]
+        }) ->
+    ()
+  | _ -> Alcotest.fail "expected typed message/content ToolResult id mismatch"
+;;
+
+let test_message_tool_id_without_result_error () =
+  let message = message ~tool_call_id:"stray-id" T.Tool [ T.Text "no result" ] in
+  match U.partition [ message ] with
+  | Error
+      (U.Message_tool_call_id_mismatch
+        { message_index = 0
+        ; message_tool_call_id = "stray-id"
+        ; content_tool_use_ids = []
+        }) ->
+    ()
+  | _ -> Alcotest.fail "expected typed message ToolResult id mismatch"
+;;
+
+let test_nonblank_tool_ids_remain_exact () =
+  let exact_id = "  exact-id  " in
+  let request = message T.Assistant [ use exact_id ] in
+  let response =
+    message ~tool_call_id:exact_id T.Tool [ result exact_id ]
+  in
+  let cycle = [ request; response ] in
+  let output = U.partition cycle |> require_ok in
+  check_exact
+    "nonblank id is not normalized"
+    [ U.Closed_tool_cycle cycle ]
+    output.closed_prefix;
+  match
+    U.partition
+      [ request; message ~tool_call_id:"exact-id" T.Tool [ result "exact-id" ] ]
+  with
+  | Error (U.Unknown_tool_result { message_index = 1; tool_use_id = "exact-id" }) ->
+    ()
+  | _ -> Alcotest.fail "trimmed ToolResult id must not match the raw ToolUse id"
+;;
+
+let test_invalid_identity_prevents_plan_callback () =
+  let plan_calls = ref 0 in
+  let outcome =
+    U.partition [ message T.Assistant [ use " \t" ] ]
+    |> Result.map (fun (partition : U.partition) ->
+      incr plan_calls;
+      partition.closed_prefix)
+  in
+  (match outcome with
+   | Error (U.Empty_tool_use_id _) -> ()
+   | _ -> Alcotest.fail "expected invalid identity before plan callback");
+  Alcotest.(check int) "plan callback count" 0 !plan_calls
+;;
+
 let () =
   Alcotest.run "keeper_compaction_unit"
     [ ( "partition"
@@ -170,5 +286,21 @@ let () =
         ; Alcotest.test_case "duplicate use" `Quick test_duplicate_tool_use_error
         ; Alcotest.test_case "mixed request/result" `Quick
             test_mixed_request_result_error
+        ; Alcotest.test_case "empty ToolUse id" `Quick
+            test_empty_tool_use_id_error
+        ; Alcotest.test_case "empty ToolResult id" `Quick
+            test_empty_tool_result_id_error
+        ; Alcotest.test_case "parallel empty ToolUse id" `Quick
+            test_parallel_empty_tool_use_id_error
+        ; Alcotest.test_case "parallel empty ToolResult id" `Quick
+            test_parallel_empty_tool_result_id_error
+        ; Alcotest.test_case "message/content id mismatch" `Quick
+            test_message_content_tool_id_mismatch_error
+        ; Alcotest.test_case "message id without result" `Quick
+            test_message_tool_id_without_result_error
+        ; Alcotest.test_case "nonblank ids remain exact" `Quick
+            test_nonblank_tool_ids_remain_exact
+        ; Alcotest.test_case "invalid identity stops plan callback" `Quick
+            test_invalid_identity_prevents_plan_callback
         ] )
     ]


### PR DESCRIPTION
## Scope

- reject blank or whitespace-only `ToolUse` / `ToolResult` identities as typed structural errors
- require `message.tool_call_id` to match the message's single content `ToolResult` identity exactly
- preserve non-blank identities byte-for-byte; trimming is used only for blank validation

## Boundary

This is a structural compaction foundation only. It does **not** claim that production preflight, LLM compaction, checkpoint reinjection, or overflow recovery is complete. The next stacked leaf must carry exact preflight source snapshots through dispatch/CAS and prove malformed history invokes no dispatch callback.

## Verification

- focused OCaml build: PASS
- compaction unit tests: 20/20 PASS
- `ocamlformat --check`: PASS
- `git diff --check`: PASS
- hostile review: P0 none, P1 none

## Size

229 changed lines (<400).
