### PR TITLE
refactor(keeper)!: replace compaction plan enumeration with boundary form

### DIFF
--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -245,14 +245,18 @@ let requested_messages (meta : keeper_meta) messages =
        (match summarize ~messages with
         | None -> Error Plan_unavailable_or_invalid
         | Some plan ->
-          if plan.summarized = [] && plan.dropped = []
+          if Keeper_compaction_llm_summarizer.summarized_count plan = 0
           then Error Structurally_unchanged
           else
             Ok
               { messages = Keeper_compaction_llm_summarizer.apply plan ~messages
               ; selected_runtime_id = plan.selected_runtime_id
-              ; summarized_message_count = List.length plan.summarized
-              ; dropped_message_count = List.length plan.dropped
+              ; summarized_message_count =
+                  Keeper_compaction_llm_summarizer.summarized_count plan
+                (* The boundary plan form has no drop bucket (masc#25099):
+                   everything below the cut folds into the summary. The
+                   evidence field stays for schema compatibility. *)
+              ; dropped_message_count = 0
               }))
 ;;
 

--- a/lib/keeper/keeper_compaction_llm_summarizer.ml
+++ b/lib/keeper/keeper_compaction_llm_summarizer.ml
@@ -8,11 +8,15 @@ module Int_set = Set.Make (Int)
 
 type compaction_plan =
   { summary : string
-  ; kept : int list
-  ; summarized : int list
-  ; dropped : int list
+  ; keep_from : int
+  ; pinned_keep : int list
+  ; message_count : int
   ; selected_runtime_id : string option
   }
+
+(* Messages folded into the summary: everything below [keep_from] except the
+   pinned exceptions. [plan_of_json] guarantees pinned_keep ⊂ [0, keep_from). *)
+let summarized_count plan = plan.keep_from - List.length plan.pinned_keep
 
 type summarizer = messages:Agent_sdk.Types.message list -> compaction_plan option
 
@@ -39,8 +43,8 @@ let plan_schema_supported provider_cfg =
 
 let message role text : Agent_sdk.Types.message = Agent_sdk.Types.text_message role text
 
-(* One indexed line per message: "[i] role: <text>". The model must classify
-   every [i] into exactly one of kept/summarized/dropped. *)
+(* One indexed line per message: "[i] role: <text>". The model reads the
+   indices to place the [keep_from] boundary and the pinned exceptions. *)
 let indexed_messages_text (messages : Agent_sdk.Types.message list) =
   messages
   |> List.mapi (fun idx (m : Agent_sdk.Types.message) ->
@@ -58,20 +62,21 @@ let indexed_messages_text (messages : Agent_sdk.Types.message list) =
 let messages_for_plan ~(messages : Agent_sdk.Types.message list) =
   let count = List.length messages in
   let system =
-    "You compact a keeper's working context. Classify EVERY message, by its \
-     0-based index, into exactly one of: kept (verbatim, still load-bearing), \
-     summarized (folded into the summary), or dropped (low value, discard). \
-     Every index in range must appear in exactly one list; do not invent \
-     indices. Prefer keeping recent messages and any with concrete code paths, \
-     commands, decisions, or unresolved blockers. Write one durable [summary] \
-     prose block that stands in for the summarized messages. Do not invent \
-     facts. Do not include markdown fences."
+    "You compact a keeper's working context. Pick ONE cut index keep_from: \
+     every message at index >= keep_from is kept verbatim; every message \
+     before it is folded into one durable summary. Choose keep_from so the \
+     recent, still load-bearing tail survives. If a few messages BEFORE the \
+     cut must survive verbatim (concrete code paths, commands, decisions, \
+     unresolved blockers), list their indices in pinned_keep; keep that list \
+     short, and use [] when nothing qualifies. Write the summary so it stands \
+     in for everything before keep_from except the pinned messages. Do not \
+     invent facts. Do not include markdown fences."
   in
   let user =
     Printf.sprintf
       "message_count: %d\nmessages:\n%s\n\nReturn a JSON object with fields \
-       summary, kept_indices, summarized_indices, dropped_indices covering \
-       every index in [0, %d) exactly once."
+       summary (string), keep_from (integer in [0, %d]), and pinned_keep \
+       (array of integers, each in [0, keep_from), [] when empty)."
       count
       (indexed_messages_text messages)
       count
@@ -104,70 +109,75 @@ let string_field key = function
      | None -> Error (Printf.sprintf "missing %s" key))
   | _ -> Error "plan must be a JSON object"
 
+let int_field key = function
+  | `Assoc fields ->
+    (match List.assoc_opt key fields with
+     | Some (`Int n) -> Ok n
+     | Some _ -> Error (Printf.sprintf "%s must be an integer" key)
+     | None -> Error (Printf.sprintf "missing %s" key))
+  | _ -> Error "plan must be a JSON object"
+
 let ( let* ) = Result.bind
 
-(* The three index lists must together partition [0, message_count) exactly.
-   An invalid LLM plan is an explicit error, never a silent repair. *)
-let validate_partition ~message_count ~kept ~summarized ~dropped =
-  let all = kept @ summarized @ dropped in
-  let seen = Array.make message_count false in
-  let rec check = function
-    | [] -> Ok ()
-    | idx :: rest ->
-      if idx < 0 || idx >= message_count then
-        Error (Printf.sprintf "index %d out of range [0, %d)" idx message_count)
-      else if seen.(idx) then Error (Printf.sprintf "index %d appears more than once" idx)
-      else begin
-        seen.(idx) <- true;
-        check rest
-      end
-  in
-  let* () = check all in
-  let missing = ref [] in
-  Array.iteri (fun idx covered -> if not covered then missing := idx :: !missing) seen;
-  match !missing with
-  | [] -> Ok ()
-  | xs ->
-    Error
-      (Printf.sprintf
-         "indices not covered: %s"
-         (String.concat "," (List.rev_map string_of_int xs)))
-
-let validate_non_empty_output ~message_count ~kept ~summarized =
-  if message_count > 0 && kept = [] && summarized = [] then
-    Error "plan would produce empty compaction output"
-  else Ok ()
-
+(* Boundary validation (masc#25099): the cut must land inside [0,
+   message_count] and every pinned exception must precede it. Coverage gaps
+   and duplicate bucket assignments are unrepresentable in this form, so
+   there is no partition check to fail. Duplicates inside [pinned_keep]
+   denote the same set and collapse under set parsing; an out-of-range pin
+   is a semantic violation and stays an explicit error, never a silent
+   repair. *)
 let plan_of_json ~message_count json =
   let* summary = string_field Schema.compaction_plan_field_summary json in
   let summary = String.trim summary in
-  let* kept = int_list_field Schema.compaction_plan_field_kept_indices json in
-  let* summarized = int_list_field Schema.compaction_plan_field_summarized_indices json in
-  let* dropped = int_list_field Schema.compaction_plan_field_dropped_indices json in
-  (* The summary must be non-empty exactly when [apply] will use it. *)
+  let* keep_from = int_field Schema.compaction_plan_field_keep_from json in
+  let* pinned_raw = int_list_field Schema.compaction_plan_field_pinned_keep json in
   let* () =
-    if summarized <> [] && summary = ""
-    then Error "summary must be non-empty when summarized indices are present"
+    if keep_from < 0 || keep_from > message_count
+    then
+      Error
+        (Printf.sprintf "keep_from %d out of range [0, %d]" keep_from message_count)
     else Ok ()
   in
-  let* () = validate_partition ~message_count ~kept ~summarized ~dropped in
-  let* () = validate_non_empty_output ~message_count ~kept ~summarized in
+  let pinned_keep = List.sort_uniq compare pinned_raw in
   let* () =
-    if summarized = [] && dropped = []
-    then Error "plan keeps every message without summarizing or dropping any"
+    match List.find_opt (fun idx -> idx < 0 || idx >= keep_from) pinned_keep with
+    | Some idx ->
+      Error
+        (Printf.sprintf
+           "pinned_keep index %d out of range [0, keep_from=%d)"
+           idx
+           keep_from)
+    | None -> Ok ()
+  in
+  let* () =
+    if keep_from - List.length pinned_keep = 0
+    then Error "plan keeps every message without summarizing any"
     else Ok ()
   in
-  Ok { summary; kept; summarized; dropped; selected_runtime_id = None }
+  (* The summary always stands in for at least one message here, so it must
+     carry content. *)
+  let* () =
+    if summary = "" then Error "summary must be non-empty" else Ok ()
+  in
+  Ok { summary; keep_from; pinned_keep; message_count; selected_runtime_id = None }
 
 (* Marker prefix so the folded summary is recognizable in the transcript and
    by downstream tooling, matching the memory-bank [MEMORY_SUMMARY] convention. *)
 let summary_marker = "[COMPACTION_SUMMARY]"
 
 let apply (plan : compaction_plan) ~(messages : Agent_sdk.Types.message list) =
-  let summarized = List.fold_left (fun s i -> Int_set.add i s) Int_set.empty plan.summarized in
-  let dropped = List.fold_left (fun s i -> Int_set.add i s) Int_set.empty plan.dropped in
+  let pinned = Int_set.of_list plan.pinned_keep in
+  (* Position of the first summarized message: the lowest index below the cut
+     that is not pinned. [plan_of_json] guarantees one exists; [-1] keeps this
+     total anyway (it matches no index, so a malformed plan degrades to
+     keeping the pinned/tail messages rather than raising). *)
   let first_summarized =
-    List.fold_left min max_int plan.summarized
+    let rec go idx =
+      if idx >= plan.keep_from then -1
+      else if Int_set.mem idx pinned then go (idx + 1)
+      else idx
+    in
+    go 0
   in
   let summary_msg =
     message Agent_sdk.Types.Assistant (summary_marker ^ " " ^ plan.summary)
@@ -175,12 +185,13 @@ let apply (plan : compaction_plan) ~(messages : Agent_sdk.Types.message list) =
   messages
   |> List.mapi (fun idx m -> idx, m)
   |> List.filter_map (fun (idx, m) ->
-    if Int_set.mem idx dropped then None
-    else if Int_set.mem idx summarized then
+    if idx >= plan.keep_from then Some m
+    else if Int_set.mem idx pinned then Some m
+    else if idx = first_summarized then
       (* Emit the single summary message at the position of the first
          summarized index; the rest of the summarized indices collapse away. *)
-      if idx = first_summarized then Some summary_msg else None
-    else Some m)
+      Some summary_msg
+    else None)
 
 let plan_of_response ~message_count response =
   match

--- a/lib/keeper/keeper_compaction_llm_summarizer.mli
+++ b/lib/keeper/keeper_compaction_llm_summarizer.mli
@@ -2,21 +2,31 @@
     produces a structured {!compaction_plan}; unavailable providers and invalid
     plans fail explicitly as [None]. *)
 
-(** A validated compaction plan over a working set of [n] messages. Every
-    index in [kept]/[summarized]/[dropped] is in [\[0, n)], the three sets are
-    pairwise disjoint, and together they cover every index exactly once. For
-    non-empty inputs, at least one [kept] or [summarized] index is required so
-    applying the plan cannot erase the entire working set. At least one
-    [summarized] or [dropped] index is required, so all-kept no-ops are invalid. *)
+(** A validated boundary compaction plan over a working set of
+    [message_count] messages (masc#25099). Messages at index >= [keep_from]
+    are kept verbatim; messages before the cut fold into the single [summary]
+    prose block, except the [pinned_keep] exceptions which also survive
+    verbatim. Invariants established by {!plan_of_json}: [0 <= keep_from <=
+    message_count]; [pinned_keep] is sorted, duplicate-free, and every element
+    is in [\[0, keep_from)]; at least one message is summarized ([keep_from >
+    List.length pinned_keep]), so all-kept no-ops are invalid and [summary] is
+    non-empty. Coverage gaps and duplicate bucket assignments — the dominant
+    failure modes of the retired 3-way index-enumeration form — are
+    unrepresentable. *)
 type compaction_plan = private
   { summary : string
-  ; kept : int list
-  ; summarized : int list
-  ; dropped : int list
+  ; keep_from : int
+  ; pinned_keep : int list
+  ; message_count : int
+    (** Working-set size the plan was validated against. *)
   ; selected_runtime_id : string option
     (** Exact Runtime candidate that produced this plan. [None] only for a
         plan parsed directly through {!plan_of_json} before provider binding. *)
   }
+
+(** Number of messages the plan folds into the summary:
+    [keep_from - List.length pinned_keep]. Positive for every validated plan. *)
+val summarized_count : compaction_plan -> int
 
 (** [summarizer ~messages] returns [Some plan] when the LLM produced a valid
     plan over [messages], or [None] on any failure (provider error, empty
@@ -49,21 +59,22 @@ val make
 
 (** Parse+validate a raw structured response into a plan over [message_count]
     messages. Exposed for tests. Returns [Error] with a reason on any
-    structural violation (out-of-range / negative / duplicate / non-covering
-    indices, empty output for a non-empty working set, or a missing/empty
-    summary). *)
+    structural violation ([keep_from] outside [\[0, message_count\]], a pinned
+    index outside [\[0, keep_from)], an all-kept no-op plan, or a
+    missing/empty summary). Duplicates inside [pinned_keep] denote the same
+    set and collapse under set parsing. *)
 val plan_of_json
   :  message_count:int
   -> Yojson.Safe.t
   -> (compaction_plan, string) result
 
 (** [apply plan ~messages] rebuilds the working set from a validated [plan]:
-    [kept] indices survive verbatim, the [summarized] indices are replaced by a
-    single assistant memory-summary message ([plan.summary]), and [dropped]
-    indices are removed. Original message order is preserved; the summary is
-    inserted at the position of the first summarized index. [plan] is assumed
-    to have been validated against [List.length messages] (it partitions the
-    index space), so this is total. *)
+    messages at index >= [keep_from] and the [pinned_keep] exceptions survive
+    verbatim; everything else is replaced by a single assistant
+    memory-summary message ([plan.summary]). Original message order is
+    preserved; the summary is inserted at the position of the first
+    summarized index. [plan] is assumed to have been validated against
+    [List.length messages], so this is total. *)
 val apply
   :  compaction_plan
   -> messages:Agent_sdk.Types.message list

--- a/lib/keeper/keeper_structured_output_schema.ml
+++ b/lib/keeper/keeper_structured_output_schema.ml
@@ -99,25 +99,27 @@ let memory_bank_summary_output_schema =
   object_schema ~required:(List.map fst fields) fields
 ;;
 
-(* Compaction plan (RFC-0313-adjacent W2). The LLM classifies each working-set
-   message by 0-based index into kept / summarized / dropped, and returns one
-   [summary] prose block that stands in for the summarized indices. Index-based
-   (not free-text rewrite) so the original messages are never fabricated — the
-   consumer reconstructs the context by index, matching the
-   [consolidation_plan] member_indices/drop_indices precedent. Field names are
-   exported as constants so the parser shares this SSOT. *)
+(* Compaction plan (RFC-0313-adjacent W2, boundary form — masc#25099). The LLM
+   picks ONE cut index [keep_from]: messages at index >= keep_from survive
+   verbatim, everything before it folds into the single [summary] prose block,
+   except the few [pinned_keep] indices (< keep_from) that must survive
+   verbatim. Boundary-based (not a full 3-way index enumeration) so coverage
+   gaps and duplicate assignments are unrepresentable — the enumeration form
+   failed statistically on 1300+-message histories (indices not covered /
+   duplicate index / giant-output JSON truncation; masc#25099 live evidence).
+   Index-based (not free-text rewrite) so the original messages are never
+   fabricated. Field names are exported as constants so the parser shares
+   this SSOT. *)
 let compaction_plan_field_summary = "summary"
-let compaction_plan_field_kept_indices = "kept_indices"
-let compaction_plan_field_summarized_indices = "summarized_indices"
-let compaction_plan_field_dropped_indices = "dropped_indices"
+let compaction_plan_field_keep_from = "keep_from"
+let compaction_plan_field_pinned_keep = "pinned_keep"
 
 let compaction_plan_output_schema =
   let int_array = `Assoc [ "type", `String "array"; "items", integer_schema ] in
   let fields =
     [ compaction_plan_field_summary, string_schema
-    ; compaction_plan_field_kept_indices, int_array
-    ; compaction_plan_field_summarized_indices, int_array
-    ; compaction_plan_field_dropped_indices, int_array
+    ; compaction_plan_field_keep_from, integer_schema
+    ; compaction_plan_field_pinned_keep, int_array
     ]
   in
   object_schema ~required:(List.map fst fields) fields

--- a/lib/keeper/keeper_structured_output_schema.mli
+++ b/lib/keeper/keeper_structured_output_schema.mli
@@ -18,13 +18,13 @@ val memory_bank_summary_output_schema : Yojson.Safe.t
     W2 compaction-plan parser as the single source of truth. *)
 val compaction_plan_field_summary : string
 
-val compaction_plan_field_kept_indices : string
-val compaction_plan_field_summarized_indices : string
-val compaction_plan_field_dropped_indices : string
+val compaction_plan_field_keep_from : string
+val compaction_plan_field_pinned_keep : string
 
 val compaction_plan_output_schema : Yojson.Safe.t
-(** JSON object the LLM compaction summarizer must return: a [summary] prose
-    block plus kept / summarized / dropped 0-based message indices. *)
+(** JSON object the LLM compaction summarizer must return (boundary form,
+    masc#25099): a [summary] prose block, the [keep_from] cut index, and the
+    [pinned_keep] verbatim exceptions below the cut. *)
 
 val vision_analyze_output_schema : Yojson.Safe.t
 (** JSON object the one-shot vision analyzer provider must return. *)

--- a/test/test_compaction_llm_summarizer.ml
+++ b/test/test_compaction_llm_summarizer.ml
@@ -9,13 +9,12 @@ open Masc
 module C = Keeper_compaction_llm_summarizer
 module Compact_policy = Keeper_compact_policy
 
-let plan_json ~summary ~kept ~summarized ~dropped : Yojson.Safe.t =
+let plan_json ~summary ~keep_from ~pinned : Yojson.Safe.t =
   let ints xs = `List (List.map (fun i -> `Int i) xs) in
   `Assoc
     [ "summary", `String summary
-    ; "kept_indices", ints kept
-    ; "summarized_indices", ints summarized
-    ; "dropped_indices", ints dropped
+    ; "keep_from", `Int keep_from
+    ; "pinned_keep", ints pinned
     ]
 
 let is_ok = function Ok _ -> true | Error _ -> false
@@ -239,79 +238,105 @@ let test_compact_policy_prefers_structured_judge_over_chat_runtime () =
     [ eligible_judge_runtime_id; ineligible_chat_runtime_id ]
     (Compact_policy.For_testing.compaction_runtime_ids meta)
 
-(* -- plan_of_json: valid partition accepted -- *)
+(* -- plan_of_json: valid boundary plans accepted -- *)
 
-let test_valid_partition_accepted () =
-  let json = plan_json ~summary:"folded" ~kept:[ 3; 4 ] ~summarized:[ 0; 1 ] ~dropped:[ 2 ] in
+let test_valid_boundary_accepted () =
+  let json = plan_json ~summary:"folded" ~keep_from:3 ~pinned:[] in
   Alcotest.(check bool)
-    "a full disjoint partition of [0,5) parses"
+    "a cut inside [0,5] with no pins parses"
     true
     (is_ok (C.plan_of_json ~message_count:5 json))
 
+let test_valid_boundary_with_pins_accepted () =
+  let json = plan_json ~summary:"folded" ~keep_from:3 ~pinned:[ 1 ] in
+  match C.plan_of_json ~message_count:5 json with
+  | Error e -> Alcotest.failf "expected valid plan, got %s" e
+  | Ok plan ->
+    Alcotest.(check int)
+      "summarized_count excludes the pinned exception"
+      2
+      (C.summarized_count plan);
+    Alcotest.(check int) "message_count is recorded" 5 plan.C.message_count
+
+let test_full_summarization_accepted () =
+  (* keep_from = message_count folds the entire working set into the summary.
+     The summary message itself is the output, so — unlike the retired
+     enumeration form's all-dropped plan — the result is never empty. This is
+     the escape hatch for extreme overflow. *)
+  let json = plan_json ~summary:"everything folded" ~keep_from:2 ~pinned:[] in
+  Alcotest.(check bool)
+    "a cut at message_count summarizes everything"
+    true
+    (is_ok (C.plan_of_json ~message_count:2 json))
+
+let test_duplicate_pins_collapse () =
+  (* Duplicates inside pinned_keep denote the same set: set parsing, not a
+     validation game the LLM can lose. *)
+  let json = plan_json ~summary:"S" ~keep_from:3 ~pinned:[ 1; 1 ] in
+  match C.plan_of_json ~message_count:4 json with
+  | Error e -> Alcotest.failf "expected valid plan, got %s" e
+  | Ok plan ->
+    Alcotest.(check (list int)) "pins collapse to a set" [ 1 ] plan.C.pinned_keep
+
+(* -- plan_of_json: structural violations rejected (no silent repair) -- *)
+
 let test_all_kept_rejected () =
-  let json = plan_json ~summary:"n/a" ~kept:[ 0; 1; 2 ] ~summarized:[] ~dropped:[] in
+  let json = plan_json ~summary:"n/a" ~keep_from:0 ~pinned:[] in
   Alcotest.(check bool)
     "keeping everything is not semantic compaction"
     true
     (is_error (C.plan_of_json ~message_count:3 json))
 
-let test_drop_only_with_kept_accepted () =
-  let json = plan_json ~summary:"unused" ~kept:[ 1 ] ~summarized:[] ~dropped:[ 0 ] in
+let test_all_pinned_below_cut_rejected () =
+  (* Pinning every message below the cut leaves nothing to summarize — the
+     boundary form's other spelling of the all-kept no-op. *)
+  let json = plan_json ~summary:"n/a" ~keep_from:2 ~pinned:[ 0; 1 ] in
   Alcotest.(check bool)
-    "drop-only plans are valid when at least one message remains"
+    "a cut whose prefix is fully pinned is a no-op plan"
     true
-    (is_ok (C.plan_of_json ~message_count:2 json))
+    (is_error (C.plan_of_json ~message_count:3 json))
 
-(* -- plan_of_json: structural violations rejected (no silent repair) -- *)
-
-let test_out_of_range_rejected () =
-  let json = plan_json ~summary:"x" ~kept:[ 0; 1 ] ~summarized:[ 5 ] ~dropped:[] in
+let test_keep_from_out_of_range_rejected () =
+  let json = plan_json ~summary:"x" ~keep_from:6 ~pinned:[] in
   Alcotest.(check bool)
-    "an index >= message_count is rejected"
+    "keep_from > message_count is rejected"
     true
-    (is_error (C.plan_of_json ~message_count:2 json))
+    (is_error (C.plan_of_json ~message_count:5 json))
 
-let test_negative_rejected () =
-  let json = plan_json ~summary:"x" ~kept:[ -1; 0 ] ~summarized:[ 1 ] ~dropped:[] in
+let test_keep_from_negative_rejected () =
+  let json = plan_json ~summary:"x" ~keep_from:(-1) ~pinned:[] in
   Alcotest.(check bool)
-    "a negative index is rejected"
+    "a negative keep_from is rejected"
     true
-    (is_error (C.plan_of_json ~message_count:2 json))
+    (is_error (C.plan_of_json ~message_count:5 json))
 
-let test_duplicate_rejected () =
-  let json = plan_json ~summary:"x" ~kept:[ 0; 1 ] ~summarized:[ 1 ] ~dropped:[] in
+let test_pin_at_or_after_cut_rejected () =
+  let json = plan_json ~summary:"x" ~keep_from:2 ~pinned:[ 2 ] in
   Alcotest.(check bool)
-    "an index appearing in two lists is rejected"
+    "a pin at or after keep_from is rejected"
     true
-    (is_error (C.plan_of_json ~message_count:2 json))
+    (is_error (C.plan_of_json ~message_count:5 json))
 
-let test_missing_index_rejected () =
-  let json = plan_json ~summary:"x" ~kept:[ 0 ] ~summarized:[] ~dropped:[] in
+let test_negative_pin_rejected () =
+  let json = plan_json ~summary:"x" ~keep_from:2 ~pinned:[ -1 ] in
   Alcotest.(check bool)
-    "a partition that omits an in-range index is rejected"
+    "a negative pinned index is rejected"
     true
-    (is_error (C.plan_of_json ~message_count:2 json))
+    (is_error (C.plan_of_json ~message_count:5 json))
 
-let test_all_dropped_rejected () =
-  let json = plan_json ~summary:"S" ~kept:[] ~summarized:[] ~dropped:[ 0; 1 ] in
+let test_empty_summary_rejected () =
+  let json = plan_json ~summary:"   " ~keep_from:1 ~pinned:[] in
   Alcotest.(check bool)
-    "a non-empty working set must not compact to empty output"
-    true
-    (is_error (C.plan_of_json ~message_count:2 json))
-
-let test_empty_summary_rejected_when_summarizing () =
-  let json = plan_json ~summary:"   " ~kept:[ 1 ] ~summarized:[ 0 ] ~dropped:[] in
-  Alcotest.(check bool)
-    "a blank summary is rejected when there are summarized indices to fold"
+    "a blank summary is rejected — it always stands in for messages"
     true
     (is_error (C.plan_of_json ~message_count:2 json))
 
 let test_missing_field_rejected () =
-  let json = `Assoc [ "summary", `String "x"; "kept_indices", `List [] ] in
+  let json = `Assoc [ "summary", `String "x"; "pinned_keep", `List [] ] in
   Alcotest.(check bool)
-    "a plan missing summarized_indices/dropped_indices is rejected"
+    "a plan missing keep_from is rejected"
     true
-    (is_error (C.plan_of_json ~message_count:0 json))
+    (is_error (C.plan_of_json ~message_count:2 json))
 
 (* -- apply: reconstruction honours the plan -- *)
 
@@ -326,16 +351,16 @@ let sample =
   ; msg Agent_sdk.Types.User "u3"
   ]
 
-let test_apply_keeps_summarizes_drops () =
-  (* kept: 3 ; summarized: 0,1 ; dropped: 2 *)
-  let json = plan_json ~summary:"S" ~kept:[ 3 ] ~summarized:[ 0; 1 ] ~dropped:[ 2 ] in
+let test_apply_folds_prefix_keeps_tail () =
+  (* keep_from: 3 → summarized: 0,1,2 ; kept: 3 *)
+  let json = plan_json ~summary:"S" ~keep_from:3 ~pinned:[] in
   match C.plan_of_json ~message_count:4 json with
   | Error e -> Alcotest.failf "expected valid plan, got %s" e
   | Ok plan ->
     let out = C.apply plan ~messages:sample in
     let out_texts = texts out in
-    (* summary replaces indices 0,1 at position of first summarized (0);
-       index 2 dropped; index 3 kept. Result: [summary; u3]. *)
+    (* summary replaces indices 0..2 at the position of the first summarized
+       index (0); index 3 survives. Result: [summary; u3]. *)
     Alcotest.(check int) "two messages remain" 2 (List.length out);
     Alcotest.(check bool)
       "first is the compaction summary"
@@ -349,16 +374,59 @@ let test_apply_keeps_summarizes_drops () =
       [ "u3" ]
       (List.tl out_texts)
 
-let test_apply_drop_only_preserves_kept () =
-  let json = plan_json ~summary:"unused" ~kept:[ 0; 1; 2 ] ~summarized:[] ~dropped:[ 3 ] in
+let test_apply_pinned_survives_verbatim () =
+  (* keep_from: 3, pinned: 1 → summarized: 0,2 ; the summary lands at index 0
+     and the pinned message keeps its relative position. *)
+  let json = plan_json ~summary:"S" ~keep_from:3 ~pinned:[ 1 ] in
   match C.plan_of_json ~message_count:4 json with
   | Error e -> Alcotest.failf "expected valid plan, got %s" e
   | Ok plan ->
     let out = C.apply plan ~messages:sample in
-    Alcotest.(check (list string))
-      "drop-only removes only the selected message"
-      [ "u0"; "a1"; "t2" ]
-      (texts out)
+    (match texts out with
+     | summary :: rest ->
+       Alcotest.(check bool)
+         "summary leads the rebuilt working set"
+         true
+         (Astring.String.is_prefix ~affix:"[COMPACTION_SUMMARY]" summary);
+       Alcotest.(check (list string))
+         "pinned and tail messages survive verbatim, in order"
+         [ "a1"; "u3" ]
+         rest
+     | [] -> Alcotest.fail "apply produced an empty working set")
+
+let test_apply_pin_at_zero_shifts_summary_position () =
+  (* keep_from: 2, pinned: 0 → summarized: 1 only; the summary is emitted at
+     the first non-pinned index below the cut, after the pinned message. *)
+  let json = plan_json ~summary:"S" ~keep_from:2 ~pinned:[ 0 ] in
+  match C.plan_of_json ~message_count:4 json with
+  | Error e -> Alcotest.failf "expected valid plan, got %s" e
+  | Ok plan ->
+    (match texts (C.apply plan ~messages:sample) with
+     | [ first; second; third; fourth ] ->
+       Alcotest.(check string) "pinned message stays first" "u0" first;
+       Alcotest.(check bool)
+         "summary replaces the summarized message in place"
+         true
+         (Astring.String.is_prefix ~affix:"[COMPACTION_SUMMARY]" second);
+       Alcotest.(check (list string))
+         "tail survives verbatim"
+         [ "t2"; "u3" ]
+         [ third; fourth ]
+     | other ->
+       Alcotest.failf "expected 4 messages, got %d" (List.length other))
+
+let test_apply_full_summarization_leaves_only_summary () =
+  let json = plan_json ~summary:"S" ~keep_from:4 ~pinned:[] in
+  match C.plan_of_json ~message_count:4 json with
+  | Error e -> Alcotest.failf "expected valid plan, got %s" e
+  | Ok plan ->
+    (match texts (C.apply plan ~messages:sample) with
+     | [ only ] ->
+       Alcotest.(check bool)
+         "the summary is the entire rebuilt working set"
+         true
+         (Astring.String.is_prefix ~affix:"[COMPACTION_SUMMARY]" only)
+     | other -> Alcotest.failf "expected 1 message, got %d" (List.length other))
 
 let () =
   Alcotest.run "compaction_llm_summarizer"
@@ -383,22 +451,33 @@ let () =
             test_compact_policy_prefers_structured_judge_over_chat_runtime
         ] )
     ; ( "plan_of_json"
-      , [ Alcotest.test_case "valid partition accepted" `Quick test_valid_partition_accepted
+      , [ Alcotest.test_case "valid boundary accepted" `Quick test_valid_boundary_accepted
+        ; Alcotest.test_case "valid boundary with pins accepted" `Quick
+            test_valid_boundary_with_pins_accepted
+        ; Alcotest.test_case "full summarization accepted" `Quick
+            test_full_summarization_accepted
+        ; Alcotest.test_case "duplicate pins collapse" `Quick test_duplicate_pins_collapse
         ; Alcotest.test_case "all kept rejected" `Quick test_all_kept_rejected
-        ; Alcotest.test_case "drop-only with kept accepted" `Quick
-            test_drop_only_with_kept_accepted
-        ; Alcotest.test_case "out of range rejected" `Quick test_out_of_range_rejected
-        ; Alcotest.test_case "negative rejected" `Quick test_negative_rejected
-        ; Alcotest.test_case "duplicate rejected" `Quick test_duplicate_rejected
-        ; Alcotest.test_case "missing index rejected" `Quick test_missing_index_rejected
-        ; Alcotest.test_case "all dropped rejected" `Quick test_all_dropped_rejected
-        ; Alcotest.test_case "empty summary rejected when summarizing" `Quick
-            test_empty_summary_rejected_when_summarizing
+        ; Alcotest.test_case "all pinned below cut rejected" `Quick
+            test_all_pinned_below_cut_rejected
+        ; Alcotest.test_case "keep_from out of range rejected" `Quick
+            test_keep_from_out_of_range_rejected
+        ; Alcotest.test_case "keep_from negative rejected" `Quick
+            test_keep_from_negative_rejected
+        ; Alcotest.test_case "pin at or after cut rejected" `Quick
+            test_pin_at_or_after_cut_rejected
+        ; Alcotest.test_case "negative pin rejected" `Quick test_negative_pin_rejected
+        ; Alcotest.test_case "empty summary rejected" `Quick test_empty_summary_rejected
         ; Alcotest.test_case "missing field rejected" `Quick test_missing_field_rejected
         ] )
     ; ( "apply"
-      , [ Alcotest.test_case "keeps/summarizes/drops" `Quick test_apply_keeps_summarizes_drops
-        ; Alcotest.test_case "drop-only preserves kept" `Quick
-            test_apply_drop_only_preserves_kept
+      , [ Alcotest.test_case "folds prefix, keeps tail" `Quick
+            test_apply_folds_prefix_keeps_tail
+        ; Alcotest.test_case "pinned survives verbatim" `Quick
+            test_apply_pinned_survives_verbatim
+        ; Alcotest.test_case "pin at zero shifts summary position" `Quick
+            test_apply_pin_at_zero_shifts_summary_position
+        ; Alcotest.test_case "full summarization leaves only summary" `Quick
+            test_apply_full_summarization_leaves_only_summary
         ] )
     ]

--- a/test/test_keeper_post_turn_wirein_order.ml
+++ b/test/test_keeper_post_turn_wirein_order.ml
@@ -303,9 +303,8 @@ let test_manual_compaction_serializes_owner_lane () =
           ~message_count:4
           (`Assoc
             [ "summary", `String "owner-lane compacted context"
-            ; "kept_indices", `List [ `Int 0 ]
-            ; "summarized_indices", `List [ `Int 1; `Int 2; `Int 3 ]
-            ; "dropped_indices", `List []
+            ; "keep_from", `Int 4
+            ; "pinned_keep", `List [ `Int 0 ]
             ])
         |> Result.get_ok
       in


### PR DESCRIPTION
## Summary

컴팩션 플랜 스키마를 **완전 인덱스 전거명**(kept/summarized/dropped 3-way partition) → **구간(boundary) 형** `{summary, keep_from, pinned_keep}`으로 교체합니다. Closes #25099.

## Why (라이브 증거)

2026-07-17 배포 창에서 5 keeper × 7회 플랜 콜 **전패** — 세 모드 전부 partition 계약 위반이었고 재시도는 수렴하지 않았습니다 (#25099 본문/코멘트의 라이브 로그):

- `indices not covered: 1081,1294` (1300+ 인덱스 중 2개 누락 — N이 클수록 누락 확률이 1로 수렴)
- `indices not covered: 266,267,268,…` (**연속 범위 통누락** — LLM이 "여기부터 요약"이라 말하고 싶었던 흔적, boundary였다면 표현 자체가 불가능한 실수)
- `index 182 appears more than once` (버킷 간 중복)
- `invalid structured response: JSON parse error` (O(N) 인덱스 출력의 절단)

## 설계

- `keep_from` 이상 = verbatim 유지, 미만 = 단일 `[COMPACTION_SUMMARY]`로 접힘, `pinned_keep` = 컷 이전 verbatim 예외 소수.
- **누락·중복이 타입상 표현 불가** → `validate_partition` 삭제(강화가 아니라 존재 이유 소멸). 검증은 keep_from 범위 + pinned 범위 + no-op 가드로 축소.
- `pinned_keep` 내부 중복은 집합 의미론으로 수렴(Set 파싱 — 같은 집합의 다른 표기이지 repair가 아님). 범위 밖 pin은 명시적 에러 유지 (fail-closed).
- 출력이 O(N)→O(1)+예외 소수로 축소 — JSON 절단 모드도 함께 완화.
- **의미 변화**: `keep_from = message_count`(전부 요약)가 유효해짐 — summary 메시지가 출력 자체라 결과가 비지 않음(구 all-dropped와 다름). 극단 overflow의 탈출구.
- dropped 버킷 소멸: 컷 이전은 버려지는 게 아니라 요약에 흡수. evidence 필드는 스키마 호환 유지(`dropped_message_count = 0` 고정 + 주석), `summarized_message_count`는 신설 `summarized_count`로 유도.

## 접촉면

- `keeper_structured_output_schema.ml/.mli` — 스키마/필드 상수 hard-cut (LLM-facing 휘발성 표면이라 durable 마이그레이션 불요 — #25078과 다른 클래스)
- `keeper_compaction_llm_summarizer.ml/.mli` — 타입(private record + `message_count`)·프롬프트·파싱·`apply`·`summarized_count`
- `keeper_compact_policy.ml` — no-op 가드/evidence 카운트 유도
- 테스트: plan_of_json 12케이스 + apply 4케이스 재작성, post_turn 픽스처를 `keep_from=4, pinned=[0]`로 이전

## 검증 (로컬)

- `test_compaction_llm_summarizer.exe`: **24/24 green** (#25051 judge-lane suite 무접촉 통과 포함)
- `test_keeper_post_turn_wirein_order.exe`: **4/4 green**
- 잔존 구 필드명 참조 전수 스캔 0건

## 남는 것 (범위 밖)

- #25067 (플랜 콜 input bounding) — 입력 축은 별개, rondo 507.2k 마진 문제는 이 PR로 해소되지 않음
- 라이브 검증: 머지+배포 후 requeue 중인 keeper들의 플랜 콜이 boundary 계약으로 수렴하는지 관찰 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
