### PR TITLE
fix(config): close env-boundary gaps from the #25123 audit

### DIFF
--- a/lib/env_keeper_scrub.ml
+++ b/lib/env_keeper_scrub.ml
@@ -38,16 +38,33 @@ let allow_exact : string list =
   ; "MASC_TELEMETRY_ENABLED"; "MASC_PARSE_WARN"
   ; "MASC_DATA_DIR"; "MASC_PERSONAS_DIR"
   ; "MASC_SECRET_DIR"
-  ; "MASC_TEST_FAKE_DOCKER_PATH"
-  ; "MASC_KEEPER_TEST_DOCKER_LOG"
   ]
+
+(* Test-harness-only propagation (masc#25123): these keys drive the fake
+   docker shim in the sandbox suites, which observe them from the spawned
+   docker subprocess. They are inherited only when the current process is a
+   test executable (same [test_] basename gate as [Fs_compat]); a production
+   server process never propagates them, so they are not test backdoors on
+   the production boundary. *)
+let test_only_allow : string list =
+  [ "MASC_TEST_FAKE_DOCKER_PATH"; "MASC_KEEPER_TEST_DOCKER_LOG" ]
+
+let running_under_test_executable () =
+  String.starts_with
+    ~prefix:"test_"
+    (String.lowercase_ascii (Filename.basename Sys.executable_name))
 
 let allow_exact_table =
   let t = Hashtbl.create (List.length allow_exact) in
   List.iter (fun k -> Hashtbl.replace t k ()) allow_exact;
   t
 
-let is_allowed key = Hashtbl.mem allow_exact_table key
+let is_allowed_for ~test_executable key =
+  Hashtbl.mem allow_exact_table key
+  || (test_executable && List.mem key test_only_allow)
+
+let is_allowed key =
+  is_allowed_for ~test_executable:(running_under_test_executable ()) key
 
 let key_of_entry entry =
   match String.index_opt entry '=' with

--- a/lib/env_keeper_scrub.mli
+++ b/lib/env_keeper_scrub.mli
@@ -6,7 +6,14 @@
     credential-name inference. *)
 
 val is_allowed : string -> bool
-(** [is_allowed key] returns [true] only for an exact inherited-host key. *)
+(** [is_allowed key] returns [true] only for an exact inherited-host key —
+    plus, when the current process is a test executable ([test_] basename),
+    the fake-docker shim keys the sandbox suites observe from spawned
+    subprocesses. A production process never inherits those. *)
+
+val is_allowed_for : test_executable:bool -> string -> bool
+(** [is_allowed] with the test-executable gate made explicit, so tests can
+    assert both sides of the shim-key boundary. *)
 
 val filter_environment : string array -> string array
 (** Return a copy of the given [Unix.environment]-shaped array with only

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -65,12 +65,17 @@ let resolved_trigger_policy () =
       else None
     with _ -> None
   in
-  match from_toml () with
+  (* Env > TOML > default — the same precedence every other env↔TOML pair in
+     this codebase uses (keeper_runtime_config key_to_env, runtime lanes), and
+     the precedence config/runtime.toml documents for this key. This site was
+     the one inversion (TOML-first), which silently ignored the env var
+     whenever [discord].trigger_policy was set (masc#25123). *)
+  match trimmed_env "MASC_DISCORD_TRIGGER_POLICY" with
   | Some raw -> parse_trigger_policy raw
   | None ->
-    (match trimmed_env "MASC_DISCORD_TRIGGER_POLICY" with
-    | None -> Gw.Mention_or_thread
-    | Some raw -> parse_trigger_policy raw)
+    (match from_toml () with
+    | Some raw -> parse_trigger_policy raw
+    | None -> Gw.Mention_or_thread)
 
 (* ---------------------------------------------------------------- *)
 (* Inbound delivery                                                 *)

--- a/lib/workspace/workspace_utils_backend_setup.ml
+++ b/lib/workspace/workspace_utils_backend_setup.ml
@@ -117,7 +117,6 @@ let sync_test_base_path_env resolved_path =
     | _ ->
         Unix.putenv Env_config_core.base_path_env_key resolved_path;
         Unix.putenv Env_config_core.base_path_input_env_key resolved_path;
-        Unix.putenv "MASC_TEST_SYNCED_BASE_PATH" resolved_path;
         Log.Workspace.info "Synchronized MASC_BASE_PATH=%s for test executable %s"
           resolved_path (Filename.basename Sys.executable_name)
 

--- a/test/test_env_keeper_scrub.ml
+++ b/test/test_env_keeper_scrub.ml
@@ -42,6 +42,26 @@ let unknown_masc_keys_are_not_inherited () =
     (Env_keeper_scrub.is_allowed "MASC_INTERNAL_MCP_TOKEN")
 ;;
 
+(* The fake-docker shim keys must cross the boundary only for test
+   executables — a production process never inherits them (masc#25123). *)
+let shim_keys_gated_on_test_executable () =
+  List.iter
+    (fun key ->
+       Alcotest.(check bool)
+         (Printf.sprintf "%s denied for production processes" key)
+         false
+         (Env_keeper_scrub.is_allowed_for ~test_executable:false key);
+       Alcotest.(check bool)
+         (Printf.sprintf "%s allowed for test executables" key)
+         true
+         (Env_keeper_scrub.is_allowed_for ~test_executable:true key))
+    [ "MASC_TEST_FAKE_DOCKER_PATH"; "MASC_KEEPER_TEST_DOCKER_LOG" ];
+  (* This suite runs as a test_ executable, so the current-process view
+     agrees with the test side of the gate. *)
+  Alcotest.(check bool) "shim key allowed in this test process" true
+    (Env_keeper_scrub.is_allowed "MASC_TEST_FAKE_DOCKER_PATH")
+;;
+
 let filter_environment_keeps_only_allowed () =
   let input =
     [| "ANTHROPIC_API_KEY=sk-ant-secret"
@@ -134,6 +154,8 @@ let () =
       , [ Alcotest.test_case "basic envs are allowed" `Quick allowed_basic_envs
         ; Alcotest.test_case "unknown host keys are not inherited" `Quick
             unknown_host_keys_are_not_inherited
+        ; Alcotest.test_case "shim keys gated on test executable" `Quick
+            shim_keys_gated_on_test_executable
         ; Alcotest.test_case "unknown MASC keys are not inherited" `Quick
             unknown_masc_keys_are_not_inherited
         ] )

--- a/test/test_workspace_utils_coverage.ml
+++ b/test/test_workspace_utils_coverage.ml
@@ -258,7 +258,6 @@ let test_default_config_syncs_test_base_path_env () =
   in
   with_envs
     [ ("MASC_BASE_PATH", None);
-      ("MASC_TEST_SYNCED_BASE_PATH", None);
       ("MASC_TEST_ALLOW_BASE_PATH_OVERRIDE", None) ]
     (fun () ->
       ignore (Workspace_utils.default_config requested);
@@ -274,7 +273,6 @@ let test_auto_synced_test_base_path_does_not_override_later_requests () =
   in
   with_envs
     [ ("MASC_BASE_PATH", None);
-      ("MASC_TEST_SYNCED_BASE_PATH", None);
       ("MASC_TEST_ALLOW_BASE_PATH_OVERRIDE", None) ]
     (fun () ->
       ignore (Workspace_utils.default_config first);


### PR DESCRIPTION
## Summary

#25123 감사(env/TOML 정리)의 Wave 1(b) — 버그성 수리 3건. 죽은 노브 22 제거(Wave 1a)는 별도 PR.

## 수리

### 1. Discord trigger-policy 우선순위 역전 (실버그)
코드베이스의 env↔TOML 42쌍 전부 + `config/runtime.toml` 문서가 **env > TOML > default**를 약속하는데, 이 사이트만 TOML을 먼저 읽어 `[discord].trigger_policy`가 설정돼 있으면 `MASC_DISCORD_TRIGGER_POLICY`를 아예 읽지 않았습니다. env-first로 재배열 — 관례·문서와 일치.

### 2. fake-docker shim 키를 프로덕션 env 경계에서 제거
`MASC_TEST_FAKE_DOCKER_PATH` / `MASC_KEEPER_TEST_DOCKER_LOG`가 `Env_keeper_scrub`의 무조건 allowlist에 있어 **프로덕션 서버가 keeper 서브프로세스로 전파**했습니다. sandbox 테스트는 이 전파에 실기능으로 의존하므로(스폰된 fake docker가 env로 로그 경로를 받음) 삭제가 아니라 **test-executable basename 가드**(`Fs_compat`과 동일한 `test_` prefix 규칙) 뒤로 이동 — 테스트 프로세스는 전파 유지, 프로덕션 프로세스는 절대 상속 불가. `is_allowed_for ~test_executable`로 양면을 테스트에서 증명.

### 3. `MASC_TEST_SYNCED_BASE_PATH` 완전 삭제
test-executable 전용 putenv로 발행되던 관찰 마커인데, **값을 읽는 곳이 없음** — 테스트 참조도 env-리셋 행뿐이고 단언은 이미 `MASC_BASE_PATH` 실값으로 함.

## 검증 (로컬)

- `test_env_keeper_scrub`: **8/8** (양면 gate 케이스 신규)
- `test_workspace_utils_coverage`: **76/76**
- `masc_server` 라이브러리(discord 사이트 포함) 컴파일 통과

## 관련

- #25123 (감사 마스터 이슈 — Wave 1a/2/3 추적)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
