### PR TITLE
fix(keeper): reject unresolved turn context capacity

### DIFF
--- a/lib/keeper/keeper_context_runtime.ml
+++ b/lib/keeper/keeper_context_runtime.ml
@@ -120,6 +120,18 @@ type max_context_resolution = {
   effective_budget : int;
 }
 
+type max_context_resolution_error =
+  | Invalid_requested_context_override of int
+  | Runtime_context_window_unavailable of { runtime_id : string }
+
+let max_context_resolution_error_to_string = function
+  | Invalid_requested_context_override requested ->
+    Printf.sprintf "requested context override must be positive, got %d" requested
+  | Runtime_context_window_unavailable { runtime_id } ->
+    Printf.sprintf
+      "no configured runtime context window resolved for runtime id %S"
+      runtime_id
+
 type context_budget_source =
   | Runtime_provider_cap
   | Requested_override
@@ -387,18 +399,49 @@ let resolve_max_context_resolution ~requested_override (labels : string list)
   ; effective_budget
   }
 
+let resolve_max_context_resolution_for_runtime_id
+      ~requested_override
+      ~runtime_id
+  =
+  match requested_override with
+  | Some requested when requested <= 0 ->
+    Error (Invalid_requested_context_override requested)
+  | Some _ | None ->
+    (match Runtime.get_runtime_by_id runtime_id with
+     | None -> Error (Runtime_context_window_unavailable { runtime_id })
+     | Some runtime ->
+       (match Runtime.resolve_max_context_of_runtime runtime with
+        | None -> Error (Runtime_context_window_unavailable { runtime_id })
+        | Some (runtime_budget, _) ->
+          let requested_context_window =
+            match requested_override with
+            | None -> runtime_budget
+            | Some requested -> requested
+          in
+          let effective_budget = min requested_context_window runtime_budget in
+          Ok
+            { requested_override
+            ; primary_budget = runtime_budget
+            ; runtime_budget
+            ; requested_context_window
+            ; effective_budget
+            }))
+
 let resolve_max_context_resolution_of_meta (m : keeper_meta)
     : max_context_resolution =
-  (* RFC-0207: the per-keeper routed runtime ([runtime_id_of_meta] — the same id
-     [keeper_turn_driver] dispatches to) is the authoritative budget source.
+  (* Projection-only compatibility path for manual compaction, operator/status,
+     dashboard, and tool surfaces that do not yet return typed capacity errors.
+     Actual direct/unified turn admission uses
+     [resolve_max_context_resolution_for_runtime_id] and never falls through
+     this ordered-label/default path.
+
      [effective_model_labels_for_turn] projects through
      [Provider_runtime_projection.default_execution_model_strings], which ignores
      the runtime id and returns the GLOBAL preferred labels (an RFC-0206
      single-binding artifact), so on its own the budget would size against
      [runtime].default and could admit prompts exceeding a smaller per-keeper
-     model's window.  Prepend the routed id so [resolve_max_context_resolution]'s
-     [find_map] sizes against it first; the projection labels remain as
-     fallback. *)
+     model's window. Prepend the routed id so these remaining projections prefer
+     it until their typed hard-cut removes this fallback API. *)
   let labels = runtime_id_of_meta m :: effective_model_labels_for_turn m in
   resolve_max_context_resolution
     ~requested_override:m.max_context_override labels

--- a/lib/keeper/keeper_context_runtime.mli
+++ b/lib/keeper/keeper_context_runtime.mli
@@ -103,6 +103,10 @@ type max_context_resolution =
   ; effective_budget : int
   }
 
+type max_context_resolution_error =
+  | Invalid_requested_context_override of int
+  | Runtime_context_window_unavailable of { runtime_id : string }
+
 type context_budget_source =
   | Runtime_provider_cap
   | Requested_override
@@ -209,6 +213,15 @@ val resolve_max_context_resolution
   -> max_context_resolution
 
 val resolve_max_context_resolution_of_meta : keeper_meta -> max_context_resolution
+
+val resolve_max_context_resolution_for_runtime_id
+  :  requested_override:int option
+  -> runtime_id:string
+  -> (max_context_resolution, max_context_resolution_error) result
+
+val max_context_resolution_error_to_string
+  :  max_context_resolution_error
+  -> string
 
 val context_budget_source_of_resolution
   :  max_context_resolution

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -552,20 +552,31 @@ let run_keeper_invocation_turn_admitted
             Progress.stop_tracking turn_task_id;
             tool_result_error ("" ^ e)
 	      | Ok () ->
+	        (match
+	           Keeper_context_runtime.resolve_max_context_resolution_for_runtime_id
+	             ~requested_override:meta.max_context_override
+	             ~runtime_id:turn_runtime_id
+	         with
+	         | Error error ->
+	           Progress.stop_tracking turn_task_id;
+	           tool_result_error
+	             (Keeper_context_runtime.max_context_resolution_error_to_string error)
+	         | Ok resolution ->
 	            let max_runtime_context =
-	              let resolution =
-	                Keeper_context_runtime.resolve_max_context_resolution
-	                  ~requested_override:meta.max_context_override effective_models
+              let () =
+                match resolution.requested_override with
+                | Some requested ->
+                  Log.Keeper.debug
+                    "%s: using max_context_override=%d context_budget=%d primary_budget=%d effective_budget=%d (manual turn)"
+                    meta.name
+                    requested
+                    resolution.requested_context_window
+                    resolution.primary_budget
+                    resolution.effective_budget
+                | None -> ()
               in
-            (match resolution.requested_override with
-            | Some requested ->
-              Log.Keeper.debug
-                "%s: using max_context_override=%d context_budget=%d primary_budget=%d effective_budget=%d (manual turn)"
-                meta.name requested resolution.requested_context_window resolution.primary_budget
-                resolution.effective_budget
-	            | None -> ());
-	              resolution.effective_budget
-	            in
+              resolution.effective_budget
+            in
             let base_dir =
               let root = session_base_dir ctx.config in
               match channel_session_key with
@@ -1036,7 +1047,7 @@ let run_keeper_invocation_turn_admitted
               in
               tool_result_ok_data reply_json
 
-)))))))))
+))))))))))
 
 let handle_keeper_invocation
       ?on_text_delta

--- a/lib/keeper/keeper_turn_runtime_budget.ml
+++ b/lib/keeper/keeper_turn_runtime_budget.ml
@@ -590,10 +590,11 @@ let runtime_budget_logged : unit StringMap.t Atomic.t =
 let runtime_budget_log_key ~keeper_name ~primary_budget ~runtime_budget =
   Printf.sprintf "%s|%d|%d" keeper_name primary_budget runtime_budget
 
-let resolved_max_context_for_turn ~(meta : keeper_meta) : int =
-  let resolution =
-    Keeper_context_runtime.resolve_max_context_resolution_of_meta meta
-  in
+let resolved_max_context_for_turn
+      ~(meta : keeper_meta)
+      (resolution : Keeper_context_runtime.max_context_resolution)
+  : int
+  =
   if resolution.primary_budget < resolution.runtime_budget then begin
     let key =
       runtime_budget_log_key

--- a/lib/keeper/keeper_turn_runtime_budget.mli
+++ b/lib/keeper/keeper_turn_runtime_budget.mli
@@ -240,7 +240,10 @@ val post_turn_resilience_handles :
     per keeper to respect [Shared_audit.Store]'s single-writer chain
     contract. *)
 
-val resolved_max_context_for_turn : meta:keeper_meta -> int
+val resolved_max_context_for_turn
+  :  meta:keeper_meta
+  -> Keeper_context_runtime.max_context_resolution
+  -> int
 (** Resolve the initial keeper turn context budget from the keeper's routed
-    runtime, so lifecycle context math matches the provider that will receive
-    the first request. *)
+    runtime's prevalidated resolution, so lifecycle context math matches the
+    provider that will receive the first request. *)

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -67,10 +67,13 @@ val context_overflow_event_of_error
   :  Agent_sdk.Error.sdk_error
   -> Keeper_state_machine.event option
 
-(** Resolve the initial keeper turn context budget from the keeper's routed
-    runtime, so lifecycle context math matches the provider that will receive
-    the first request. Exposed for regression tests. *)
-val resolved_max_context_for_turn : meta:Keeper_meta_contract.keeper_meta -> int
+(** Project the initial keeper turn context budget from the routed runtime's
+    prevalidated resolution, so lifecycle context math matches the provider
+    that will receive the first request. Exposed for regression tests. *)
+val resolved_max_context_for_turn
+  :  meta:Keeper_meta_contract.keeper_meta
+  -> Keeper_context_runtime.max_context_resolution
+  -> int
 
 (** Ensure local-provider discovery is refreshed before a turn when the
     selected labels depend on runtime discovery. Exposed for targeted tests. *)

--- a/lib/keeper/keeper_unified_turn_pre_dispatch.ml
+++ b/lib/keeper/keeper_unified_turn_pre_dispatch.ml
@@ -65,21 +65,34 @@ let build_runtime_execution
        log_pre_dispatch_error ~site:"ensure_local_discovery_ready" e;
        Error (Agent_sdk.Error.Internal e)
      | Ok () ->
-       let max_context_resolution =
-         Keeper_context_runtime.resolve_max_context_resolution_of_meta meta
-       in
-       let max_context =
-         Keeper_turn_runtime_budget.resolved_max_context_for_turn
-           ~meta
-       in
-       let temperature =
-         Runtime_inference.resolve_temperature
-           ~runtime_id
-           ~fallback:Keeper_config.keeper_unified_temperature
-       in
-       Ok
-         { Keeper_turn_runtime_budget.runtime_id
-         ; max_context_resolution
-         ; max_context
-         ; temperature
-         })
+       (match
+          Keeper_context_runtime.resolve_max_context_resolution_for_runtime_id
+            ~requested_override:meta.max_context_override
+            ~runtime_id
+        with
+        | Error error ->
+          let detail =
+            Keeper_context_runtime.max_context_resolution_error_to_string error
+          in
+          log_pre_dispatch_error ~site:"resolve_context_window" detail;
+          Error
+            (Agent_sdk.Error.Config
+               (Agent_sdk.Error.InvalidConfig
+                  { field = "runtime.context_window"; detail }))
+        | Ok max_context_resolution ->
+          let max_context =
+            Keeper_turn_runtime_budget.resolved_max_context_for_turn
+              ~meta
+              max_context_resolution
+          in
+          let temperature =
+            Runtime_inference.resolve_temperature
+              ~runtime_id
+              ~fallback:Keeper_config.keeper_unified_temperature
+          in
+          Ok
+            { Keeper_turn_runtime_budget.runtime_id
+            ; max_context_resolution
+            ; max_context
+            ; temperature
+            }))

--- a/lib/keeper/keeper_unified_turn_pre_dispatch.mli
+++ b/lib/keeper/keeper_unified_turn_pre_dispatch.mli
@@ -39,7 +39,9 @@ val build_runtime_execution
     Failure modes (returned as [Error]):
     - [Keeper_types_support.ensure_api_keys_for_labels] missing required keys.
     - [ensure_local_discovery_ready] local-runtime discovery fail.
+    - The exact [runtime_id] has no configured context window.
+    - [meta.max_context_override] is not positive.
 
     OAS alone owns provider/model ceiling validation and envelope-specific
-    clamping. The function is total over its two failure modes plus the [Ok]
-    case; no exceptions cross the boundary. *)
+    clamping. No context-window default or ordered-label fallback is applied at
+    this turn-admission boundary. *)

--- a/test/test_runtime_per_keeper_routing.ml
+++ b/test/test_runtime_per_keeper_routing.ml
@@ -958,6 +958,32 @@ let test_context_budget_uses_selected_runtime () =
       oversized_override.Keeper_context_runtime.effective_budget)
 ;;
 
+let test_strict_context_budget_rejects_unavailable_and_invalid_override () =
+  with_runtime_initialized (fun () ->
+    (match
+       Keeper_context_runtime.resolve_max_context_resolution_for_runtime_id
+         ~requested_override:None
+         ~runtime_id:"missing.runtime"
+     with
+     | Error
+         (Keeper_context_runtime.Runtime_context_window_unavailable
+            { runtime_id }) ->
+       Alcotest.(check string)
+         "typed error retains the exact unresolved runtime id"
+         "missing.runtime"
+         runtime_id
+     | Error _ -> Alcotest.fail "unexpected strict context resolution error"
+     | Ok _ -> Alcotest.fail "unknown runtime must not receive a default capacity");
+    match
+      Keeper_context_runtime.resolve_max_context_resolution_for_runtime_id
+        ~requested_override:(Some 0)
+        ~runtime_id:"openai.gpt"
+    with
+    | Error (Keeper_context_runtime.Invalid_requested_context_override 0) -> ()
+    | Error _ -> Alcotest.fail "unexpected invalid override error"
+    | Ok _ -> Alcotest.fail "non-positive override must not be silently ignored")
+;;
+
 let test_context_budget_source_is_shared_ssot () =
   with_runtime_initialized (fun () ->
     let source requested_override =
@@ -981,12 +1007,11 @@ let test_context_budget_source_is_shared_ssot () =
       (source (Some 1_000_000)))
 ;;
 
-(* Production path: [resolve_max_context_resolution_of_meta] must budget against
-   the keeper's routed runtime (openai.gpt = 64000), NOT [runtime].default
-   (runpod_mtp.qwen = 128000).  Without prepending [runtime_id_of_meta], the
-   projection labels (global, runtime-id-agnostic) would size against the
-   default and admit oversized prompts for a per-keeper routed runtime. *)
-let test_of_meta_budgets_against_routed_runtime () =
+(* Remaining projection path: [resolve_max_context_resolution_of_meta] must
+   prefer the keeper's routed runtime (openai.gpt = 64000), NOT
+   [runtime].default (runpod_mtp.qwen = 128000). Actual turn admission is
+   exercised separately through the strict runtime-ID resolver. *)
+let test_of_meta_projection_budgets_against_routed_runtime () =
   with_runtime_initialized (fun () ->
     (* [budgettest] is assigned [openai.gpt] in [[runtime.assignments]]. *)
     let res =
@@ -1003,8 +1028,19 @@ let test_turn_context_window_uses_routed_runtime () =
   with_runtime_initialized (fun () ->
     (* [budgettest] is assigned [openai.gpt] in [[runtime.assignments]]. *)
     let budget =
-      Keeper_turn_runtime_budget.resolved_max_context_for_turn
-        ~meta:(make_meta "budgettest")
+      let meta = make_meta "budgettest" in
+      let resolution =
+        match
+          Keeper_context_runtime.resolve_max_context_resolution_for_runtime_id
+            ~requested_override:meta.max_context_override
+            ~runtime_id:(Keeper_meta_contract.runtime_id_of_meta meta)
+        with
+        | Ok resolution -> resolution
+        | Error error ->
+          Alcotest.fail
+            (Keeper_context_runtime.max_context_resolution_error_to_string error)
+      in
+      Keeper_turn_runtime_budget.resolved_max_context_for_turn ~meta resolution
     in
     Alcotest.(check int)
       "turn context window uses routed runtime, not runtime-id-agnostic labels"
@@ -1875,9 +1911,13 @@ let () =
             `Quick
             test_context_budget_source_is_shared_ssot
         ; Alcotest.test_case
-            "of_meta budgets against the routed runtime (production path)"
+            "strict context budget rejects unavailable capacity and invalid override"
             `Quick
-            test_of_meta_budgets_against_routed_runtime
+            test_strict_context_budget_rejects_unavailable_and_invalid_override
+        ; Alcotest.test_case
+            "of_meta projection prefers the routed runtime"
+            `Quick
+            test_of_meta_projection_budgets_against_routed_runtime
         ; Alcotest.test_case
             "turn context window uses the routed runtime"
             `Quick


### PR DESCRIPTION
## Outcome

The actual Keeper turn admission path resolves context capacity from the exact selected Runtime and rejects an unusable capacity as typed configuration failure.

## Implemented

- resolve context capacity from the exact selected Runtime ID
- distinguish missing Runtime, unavailable capacity, and a non-positive explicit override
- use the same strict resolution in unified turns, direct turns, and Runtime-rotation retry setup
- remove ordered-label and global-default fallback from actual turn admission
- retain the old resolver only as a projection compatibility path; it is not an admission authority

## Boundary

This leaf hardens actual unified/direct turn admission only. It does not claim every projection is strict yet. Manual compaction, Keeper context creation, the Keeper tool surface, operator/dashboard/heartbeat/status projections, Runtime.default_max_context, and Runtime_constants.fallback_context_window remain follow-up purge scope.

## Verification

- head: 196494694eca51f715f75b3e363c3a91806bad56
- base: main 3be51c2160591798fe6123e1c4f0544b5b75592c
- net diff: 9 files, 188 insertions, 59 deletions
- focused runtime routing executable: 40/40 pass
- current-head ocamlformat, parser, and git diff checks: pass
- current-head GitHub CI: pending

## Merge condition

Code review P0/P1: 0. Keep Draft and status:do-not-merge until required checks on the rewritten head complete.

[근거] git diff against main, focused test executable, and gh pr view; checked 2026-07-18 KST; confidence High.