### PR TITLE
refactor(gate): persist deterministic approval order

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -80,11 +80,14 @@ let install_error_to_string = function
   | Install_storage_failed error -> storage_error_to_string error
 ;;
 
-let pending_store_version = 2
+let pending_store_version = 3
 let pending_store_surface = "keeper_gate_pending"
 let pending_store_mutex = Cross_context_mutex.create ()
 let deliveries : persisted_delivery SMap.t Atomic.t = Atomic.make SMap.empty
 let unavailable_stores : storage_error SMap.t Atomic.t = Atomic.make SMap.empty
+(** Process projection of the next value persisted in each workspace snapshot. *)
+let next_sequences : int SMap.t Atomic.t = Atomic.make SMap.empty
+let first_sequence = 1
 
 (** Serialize one durable pending/delivery snapshot transition across both Eio
     fibers and non-Eio callers.  A plain [Stdlib.Mutex.protect] is invalid here:
@@ -137,6 +140,7 @@ let pending_entry_to_yojson (entry : pending_approval) =
     ; "tool_name", `String entry.tool_name
     ; "input_hash", `String entry.input_hash
     ; "input", entry.input
+    ; "sequence", `Int entry.sequence
     ; "requested_at", `Float entry.requested_at
     ; "turn_id", Json_util.int_opt_to_json entry.turn_id
     ; ( "request_context"
@@ -180,7 +184,7 @@ let map_values_for_base ~base_path map project =
     if String.equal (project value).audit_base_path base_path then Some value else None)
 ;;
 
-let snapshot_to_yojson ~base_path ~pending_map ~delivery_map =
+let snapshot_to_yojson ~base_path ~next_sequence ~pending_map ~delivery_map =
   let pending_entries =
     map_values_for_base ~base_path pending_map Fun.id
     |> List.map pending_entry_to_yojson
@@ -191,12 +195,24 @@ let snapshot_to_yojson ~base_path ~pending_map ~delivery_map =
   in
   `Assoc
     [ "version", `Int pending_store_version
+    ; "next_sequence", `Int next_sequence
     ; "pending", `List pending_entries
     ; "deliveries", `List delivery_entries
     ]
 ;;
 
-let persist_snapshot_unlocked ~base_path ~pending_map ~delivery_map =
+let next_sequence_unlocked ~base_path =
+  match SMap.find_opt base_path (Atomic.get next_sequences) with
+  | Some sequence -> sequence
+  | None -> first_sequence
+;;
+
+let persist_snapshot_with_sequence_unlocked
+      ~base_path
+      ~next_sequence
+      ~pending_map
+      ~delivery_map
+  =
   let path = pending_store_path ~base_path in
   match SMap.find_opt base_path (Atomic.get unavailable_stores) with
   | Some error -> Error error
@@ -204,7 +220,7 @@ let persist_snapshot_unlocked ~base_path ~pending_map ~delivery_map =
     (try
        Fs_compat.mkdir_p (Filename.dirname path);
        let body =
-         snapshot_to_yojson ~base_path ~pending_map ~delivery_map
+         snapshot_to_yojson ~base_path ~next_sequence ~pending_map ~delivery_map
          |> Yojson.Safe.pretty_to_string
        in
        (match Fs_compat.save_file_atomic path body with
@@ -213,6 +229,14 @@ let persist_snapshot_unlocked ~base_path ~pending_map ~delivery_map =
      with
      | Eio.Cancel.Cancelled _ as exn -> raise exn
      | exn -> Error { path; reason = Printexc.to_string exn })
+;;
+
+let persist_snapshot_unlocked ~base_path ~pending_map ~delivery_map =
+  persist_snapshot_with_sequence_unlocked
+    ~base_path
+    ~next_sequence:(next_sequence_unlocked ~base_path)
+    ~pending_map
+    ~delivery_map
 ;;
 
 let reject_unknown_fields ~surface ~allowed fields =
@@ -260,6 +284,13 @@ let optional_nonnegative_int ~surface field fields =
     Error (Printf.sprintf "%s.%s must be a non-negative integer or null" surface field)
 ;;
 
+let required_positive_int ~surface field fields =
+  match List.assoc_opt field fields with
+  | Some (`Int value) when value > 0 -> Ok value
+  | Some _ -> Error (Printf.sprintf "%s.%s must be a positive integer" surface field)
+  | None -> Error (Printf.sprintf "%s.%s is required" surface field)
+;;
+
 let required_float ~surface field fields =
   match List.assoc_opt field fields with
   | Some (`Float value) -> Ok value
@@ -296,6 +327,7 @@ let pending_entry_of_yojson ~base_path json =
           ; "tool_name"
           ; "input_hash"
           ; "input"
+          ; "sequence"
           ; "requested_at"
           ; "turn_id"
           ; "request_context"
@@ -319,6 +351,7 @@ let pending_entry_of_yojson ~base_path json =
       then Ok ()
       else Error (Printf.sprintf "%s.input_hash does not match input" surface)
     in
+    let* sequence = required_positive_int ~surface "sequence" fields in
     let* requested_at = required_float ~surface "requested_at" fields in
     let* turn_id = optional_nonnegative_int ~surface "turn_id" fields in
     let* request_context =
@@ -366,6 +399,7 @@ let pending_entry_of_yojson ~base_path json =
       ; tool_name
       ; input_hash
       ; input
+      ; sequence
       ; requested_at
       ; turn_id
       ; request_context
@@ -502,6 +536,29 @@ let parse_list ~surface parse = function
   | _ -> Error (surface ^ " must be an array")
 ;;
 
+let validate_snapshot_sequences ~next_sequence pending_entries delivery_entries =
+  let sequences =
+    List.map (fun (entry : pending_approval) -> entry.sequence) pending_entries
+    @ List.map
+        (fun (delivery : persisted_delivery) -> delivery.entry.sequence)
+        delivery_entries
+    |> List.sort Int.compare
+  in
+  let rec check previous = function
+    | [] -> Ok ()
+    | sequence :: _ when sequence >= next_sequence ->
+      Error
+        (Printf.sprintf
+           "gate_pending sequence %d must precede next_sequence %d"
+           sequence
+           next_sequence)
+    | sequence :: _ when previous = Some sequence ->
+      Error (Printf.sprintf "gate_pending contains duplicate sequence %d" sequence)
+    | sequence :: rest -> check (Some sequence) rest
+  in
+  check None sequences
+;;
+
 let snapshot_of_yojson ~base_path json =
   match json with
   | `Assoc fields ->
@@ -510,7 +567,7 @@ let snapshot_of_yojson ~base_path json =
     let* () =
       reject_unknown_fields
         ~surface
-        ~allowed:[ "version"; "pending"; "deliveries" ]
+        ~allowed:[ "version"; "next_sequence"; "pending"; "deliveries" ]
         fields
     in
     let* () =
@@ -521,6 +578,7 @@ let snapshot_of_yojson ~base_path json =
       | Some _ -> Error (surface ^ ".version must be an integer")
       | None -> Error (surface ^ ".version is required")
     in
+    let* next_sequence = required_positive_int ~surface "next_sequence" fields in
     let* pending_json = required_member ~surface "pending" fields in
     let* pending_entries =
       parse_list ~surface:"gate_pending.pending" (pending_entry_of_yojson ~base_path) pending_json
@@ -549,7 +607,10 @@ let snapshot_of_yojson ~base_path json =
       | None -> Ok ()
       | Some id -> Error (Printf.sprintf "gate_pending id %s exists in both states" id)
     in
-    Ok (pending_map, delivery_map)
+    let* () =
+      validate_snapshot_sequences ~next_sequence pending_entries delivery_entries
+    in
+    Ok (pending_map, delivery_map, next_sequence)
   | _ -> Error "gate_pending snapshot must be a JSON object"
 ;;
 
@@ -557,7 +618,7 @@ let load_snapshot_unlocked ~base_path =
   let path = pending_store_path ~base_path in
   try
     if not (Sys.file_exists path)
-    then Ok (SMap.empty, SMap.empty)
+    then Ok (SMap.empty, SMap.empty, 1)
     else (
       match Safe_ops.read_json_file_safe path with
       | Error reason ->
@@ -1099,6 +1160,7 @@ let input_preview_of_json (json : Yojson.Safe.t) =
 
 let create_entry
       ~id
+      ~sequence
       ~keeper_name
       ~tool_name
       ~input
@@ -1117,6 +1179,7 @@ let create_entry
   ; tool_name
   ; input_hash
   ; input
+  ; sequence
   ; requested_at = Unix.gettimeofday ()
   ; turn_id
   ; request_context
@@ -1136,6 +1199,7 @@ let pending_entry_json_fields
   [ "id", `String entry.id
   ; "keeper_name", `String entry.keeper_name
   ; "tool_name", `String entry.tool_name
+  ; "sequence", `Int entry.sequence
   ; "requested_at", `Float entry.requested_at
   ; "waiting_s", `Float (Unix.gettimeofday () -. entry.requested_at)
   ; "turn_id", Json_util.int_opt_to_json entry.turn_id
@@ -1178,8 +1242,9 @@ let broadcast_pending entry =
 
 let record_pending (entry : pending_approval) =
   Log.Keeper.info
-    "HITL_APPROVAL_PENDING: id=%s keeper=%s tool=%s"
+    "HITL_APPROVAL_PENDING: id=%s sequence=%d keeper=%s tool=%s"
     entry.id
+    entry.sequence
     entry.keeper_name
     entry.tool_name;
   audit_approval_event
@@ -1619,14 +1684,6 @@ let find_pending_id_in_map
     None
 ;;
 
-let sort_entries_by_requested_at entries =
-  List.sort
-    (fun left right ->
-       let ts_of_json json = (match Json_util.assoc_member_opt "requested_at" json with Some (`Float f) -> f | Some (`Int n) -> Float.of_int n | _ -> 0.0) in
-       Float.compare (ts_of_json left) (ts_of_json right))
-    entries
-;;
-
 (* ── Nonblocking submission ───────────────────────────────── *)
 
 let submit_pending
@@ -1666,32 +1723,46 @@ let submit_pending
       | Some id -> Ok (id, None)
       | None ->
         let id = generate_id () in
-        let entry =
-          create_entry
-            ~id
-            ~keeper_name
-            ~tool_name
-            ~input
-            ?turn_id
-            ?request_context
-            ?task_id
-            ?goal_id
-            ~goal_ids
-            ~continuation_channel
-            ~audit_base_path:base_path
-            ()
-        in
-        let updated = SMap.add id entry map in
-        (match
-           persist_snapshot_unlocked
-             ~base_path
-             ~pending_map:updated
-             ~delivery_map:(Atomic.get deliveries)
-         with
-         | Error _ as error -> error
-         | Ok () ->
-           Atomic.set pending updated;
-           Ok (id, Some entry)))
+        let sequence = next_sequence_unlocked ~base_path in
+        if sequence = max_int
+        then
+          Error
+            { path = pending_store_path ~base_path
+            ; reason = "approval sequence exhausted its integer representation"
+            }
+        else
+          let entry =
+            create_entry
+              ~id
+              ~sequence
+              ~keeper_name
+              ~tool_name
+              ~input
+              ?turn_id
+              ?request_context
+              ?task_id
+              ?goal_id
+              ~goal_ids
+              ~continuation_channel
+              ~audit_base_path:base_path
+              ()
+          in
+          let updated = SMap.add id entry map in
+          let following_sequence = sequence + 1 in
+          (match
+             persist_snapshot_with_sequence_unlocked
+               ~base_path
+               ~next_sequence:following_sequence
+               ~pending_map:updated
+               ~delivery_map:(Atomic.get deliveries)
+           with
+           | Error _ as error -> error
+           | Ok () ->
+             Atomic.set pending updated;
+             Atomic.set
+               next_sequences
+               (SMap.add base_path following_sequence (Atomic.get next_sequences));
+             Ok (id, Some entry)))
   in
   match stored with
   | Error _ as error -> error
@@ -1919,7 +1990,7 @@ let install_persistence_internal ~after_load ~base_path =
       | Error storage_error ->
         mark_store_unavailable_unlocked ~base_path storage_error;
         Error storage_error
-      | Ok (loaded_pending, loaded_deliveries) ->
+      | Ok (loaded_pending, loaded_deliveries, loaded_next_sequence) ->
         let current_pending =
           remove_base_entries ~base_path (Atomic.get pending) Fun.id
         in
@@ -1968,6 +2039,12 @@ let install_persistence_internal ~after_load ~base_path =
               clear_store_unavailable_unlocked ~base_path;
               Atomic.set pending pending_map;
               Atomic.set deliveries delivery_map;
+              Atomic.set
+                next_sequences
+                (SMap.add
+                   base_path
+                   loaded_next_sequence
+                   (Atomic.get next_sequences));
               Ok
                 ( SMap.cardinal loaded_pending
                 , SMap.bindings loaded_deliveries |> List.map snd ))))
@@ -2017,7 +2094,8 @@ module For_testing = struct
     with_pending_store_lock (fun () ->
       Atomic.set pending SMap.empty;
       Atomic.set deliveries SMap.empty;
-      Atomic.set unavailable_stores SMap.empty)
+      Atomic.set unavailable_stores SMap.empty;
+      Atomic.set next_sequences SMap.empty)
   ;;
 
   let install_persistence_with_after_load_hook ~base_path ~after_load =
@@ -2111,34 +2189,26 @@ let resolve ~base_path ~id ~(decision : decision)
 (* ── Query ────────────────────────────────────────────────── *)
 
 (** List all pending approvals as JSON. *)
+let pending_entries_in_sequence_order () =
+  SMap.fold (fun _id entry acc -> entry :: acc) (Atomic.get pending) []
+  |> List.sort (fun left right -> Int.compare left.sequence right.sequence)
+;;
+
 let list_pending_json () : Yojson.Safe.t =
-  let entries =
-    SMap.fold
-      (fun _id entry acc -> `Assoc (pending_entry_json_fields entry) :: acc)
-      (Atomic.get pending)
-      []
-  in
-  `List (sort_entries_by_requested_at entries)
+  pending_entries_in_sequence_order ()
+  |> List.map (fun entry -> `Assoc (pending_entry_json_fields entry))
+  |> fun entries -> `List entries
 ;;
 
 let list_pending_dashboard_json () : Yojson.Safe.t =
-  let entries =
-    SMap.fold
-      (fun _id entry acc ->
-         `Assoc
-           (pending_entry_json_fields
-              ~include_input:true
-              entry)
-         :: acc)
-      (Atomic.get pending)
-      []
-  in
-  `List (sort_entries_by_requested_at entries)
+  pending_entries_in_sequence_order ()
+  |> List.map (fun entry ->
+    `Assoc (pending_entry_json_fields ~include_input:true entry))
+  |> fun entries -> `List entries
 ;;
 
 let list_pending_entries () : pending_approval list =
-  SMap.fold (fun _id entry acc -> entry :: acc) (Atomic.get pending) []
-  |> List.sort (fun left right -> Float.compare left.requested_at right.requested_at)
+  pending_entries_in_sequence_order ()
 ;;
 
 let pending_entry_detail_json (entry : pending_approval) : Yojson.Safe.t =

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -201,12 +201,6 @@ let snapshot_to_yojson ~base_path ~next_sequence ~pending_map ~delivery_map =
     ]
 ;;
 
-let next_sequence_unlocked ~base_path =
-  match SMap.find_opt base_path (Atomic.get next_sequences) with
-  | Some sequence -> sequence
-  | None -> first_sequence
-;;
-
 let persist_snapshot_with_sequence_unlocked
       ~base_path
       ~next_sequence
@@ -231,12 +225,36 @@ let persist_snapshot_with_sequence_unlocked
      | exn -> Error { path; reason = Printexc.to_string exn })
 ;;
 
+type store_lifecycle =
+  | Uninstalled
+  | Ready of int
+  | Unavailable of storage_error
+
+let next_sequence_lifecycle ~base_path =
+  match SMap.find_opt base_path (Atomic.get unavailable_stores) with
+  | Some error -> Unavailable error
+  | None ->
+    (match SMap.find_opt base_path (Atomic.get next_sequences) with
+     | Some sequence -> Ready sequence
+     | None -> Uninstalled)
+;;
+
 let persist_snapshot_unlocked ~base_path ~pending_map ~delivery_map =
-  persist_snapshot_with_sequence_unlocked
-    ~base_path
-    ~next_sequence:(next_sequence_unlocked ~base_path)
-    ~pending_map
-    ~delivery_map
+  match next_sequence_lifecycle ~base_path with
+  | Ready next_sequence ->
+    persist_snapshot_with_sequence_unlocked
+      ~base_path
+      ~next_sequence
+      ~pending_map
+      ~delivery_map
+  | Uninstalled ->
+    Error
+      { path = pending_store_path ~base_path
+      ; reason =
+          "gate_pending store is not installed; install_persistence must \
+           complete before publishing"
+      }
+  | Unavailable error -> Error error
 ;;
 
 let reject_unknown_fields ~surface ~allowed fields =
@@ -614,11 +632,61 @@ let snapshot_of_yojson ~base_path json =
   | _ -> Error "gate_pending snapshot must be a JSON object"
 ;;
 
+let snapshot_version_of_yojson = function
+  | `Assoc fields -> (
+    match List.assoc_opt "version" fields with
+    | Some (`Int version) -> Some version
+    | Some _ | None -> None)
+  | _ -> None
+;;
+
+let quarantine_path ~path ~version =
+  let base = Printf.sprintf "%s.v%d.quarantine" path version in
+  let rec find_free k =
+    let candidate =
+      if k = 0 then base else Printf.sprintf "%s.%d" base k
+    in
+    if Sys.file_exists candidate then find_free (k + 1) else candidate
+  in
+  find_free 0
+;;
+
+(* An unsupported snapshot version is a generational boundary, not
+   corruption: the durable file is preserved verbatim at a visible
+   quarantine path and the store starts a fresh generation. Only a rename
+   failure keeps the old fail-closed behavior — starting fresh while the
+   old file is still in place would let the next [put] overwrite the very
+   evidence the quarantine exists to preserve. *)
+let quarantine_snapshot_unlocked ~path ~version =
+  let target = quarantine_path ~path ~version in
+  try
+    Sys.rename path target;
+    Log.Server.error
+      "gate_pending snapshot version %d is unsupported (current %d); \
+       quarantined to %s and starting a fresh store generation"
+      version pending_store_version target;
+    Ok (SMap.empty, SMap.empty, first_sequence)
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
+    let reason =
+      Printf.sprintf
+        "gate_pending snapshot version %d is unsupported and quarantine \
+         rename to %s failed: %s"
+        version target (Printexc.to_string exn)
+    in
+    report_pending_read_drop
+      ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
+      ~path
+      ~detail:reason;
+    Error { path; reason }
+;;
+
 let load_snapshot_unlocked ~base_path =
   let path = pending_store_path ~base_path in
   try
     if not (Sys.file_exists path)
-    then Ok (SMap.empty, SMap.empty, 1)
+    then Ok (SMap.empty, SMap.empty, first_sequence)
     else (
       match Safe_ops.read_json_file_safe path with
       | Error reason ->
@@ -628,14 +696,18 @@ let load_snapshot_unlocked ~base_path =
           ~detail:reason;
         Error { path; reason }
       | Ok json ->
-        (match snapshot_of_yojson ~base_path json with
-         | Ok snapshot -> Ok snapshot
-         | Error reason ->
-           report_pending_read_drop
-             ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
-             ~path
-             ~detail:reason;
-           Error { path; reason }))
+        (match snapshot_version_of_yojson json with
+         | Some version when version <> pending_store_version ->
+           quarantine_snapshot_unlocked ~path ~version
+         | Some _ | None ->
+           (match snapshot_of_yojson ~base_path json with
+            | Ok snapshot -> Ok snapshot
+            | Error reason ->
+              report_pending_read_drop
+                ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+                ~path
+                ~detail:reason;
+              Error { path; reason })))
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn ->
@@ -1723,22 +1795,30 @@ let submit_pending
       | Some id -> Ok (id, None)
       | None ->
         let id = generate_id () in
-        let sequence = next_sequence_unlocked ~base_path in
-        if sequence = max_int
-        then
-          Error
-            { path = pending_store_path ~base_path
-            ; reason = "approval sequence exhausted its integer representation"
-            }
-        else
-          let entry =
-            create_entry
-              ~id
-              ~sequence
-              ~keeper_name
-              ~tool_name
-              ~input
-              ?turn_id
+        (match next_sequence_lifecycle ~base_path with
+         | Uninstalled ->
+           Error
+             { path = pending_store_path ~base_path
+             ; reason =
+                 "gate_pending store is not installed; submit requires a completed install"
+             }
+         | Unavailable error -> Error error
+         | Ready sequence ->
+           if sequence = max_int
+           then
+             Error
+               { path = pending_store_path ~base_path
+               ; reason = "approval sequence exhausted its integer representation"
+               }
+           else
+             let entry =
+               create_entry
+                 ~id
+                 ~sequence
+                 ~keeper_name
+                 ~tool_name
+                 ~input
+                 ?turn_id
               ?request_context
               ?task_id
               ?goal_id
@@ -1762,7 +1842,7 @@ let submit_pending
              Atomic.set
                next_sequences
                (SMap.add base_path following_sequence (Atomic.get next_sequences));
-             Ok (id, Some entry)))
+             Ok (id, Some entry))))
   in
   match stored with
   | Error _ as error -> error

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -1976,6 +1976,14 @@ let complete_delivery delivery =
            | Ok () -> finish ())))
 ;;
 
+let compare_pending_order left right =
+  match String.compare left.audit_base_path right.audit_base_path with
+  | 0 ->
+    let sequence_order = Int.compare left.sequence right.sequence in
+    if sequence_order = 0 then String.compare left.id right.id else sequence_order
+  | workspace_order -> workspace_order
+;;
+
 let install_persistence_internal ~after_load ~base_path =
   (* Snapshot read and installation are one transition. The hybrid pending
      store lock serializes Eio and non-Eio callers, cooperatively gates Eio
@@ -2047,7 +2055,10 @@ let install_persistence_internal ~after_load ~base_path =
                    (Atomic.get next_sequences));
               Ok
                 ( SMap.cardinal loaded_pending
-                , SMap.bindings loaded_deliveries |> List.map snd ))))
+                , SMap.bindings loaded_deliveries
+                  |> List.map snd
+                  |> List.sort (fun left right ->
+                    compare_pending_order left.entry right.entry) ))))
   in
   match installed with
   | Error storage_error -> Error (Install_storage_failed storage_error)
@@ -2191,7 +2202,7 @@ let resolve ~base_path ~id ~(decision : decision)
 (** List all pending approvals as JSON. *)
 let pending_entries_in_sequence_order () =
   SMap.fold (fun _id entry acc -> entry :: acc) (Atomic.get pending) []
-  |> List.sort (fun left right -> Int.compare left.sequence right.sequence)
+  |> List.sort compare_pending_order
 ;;
 
 let list_pending_json () : Yojson.Safe.t =

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -171,7 +171,8 @@ end
 
 (** Durably enqueue an exact request without suspending the caller. Returns an
     existing id only when the same Keeper, operation identity, canonical input,
-    turn/task/goal identity, and continuation channel are already pending. *)
+    turn/task/goal identity, and continuation channel are already pending. A
+    deduplicated request does not consume a durable queue sequence. *)
 val submit_pending :
   keeper_name:string ->
   tool_name:string ->

--- a/lib/keeper/keeper_gate.ml
+++ b/lib/keeper/keeper_gate.ml
@@ -928,5 +928,4 @@ module For_testing = struct
 
   let claim_auto_judge = claim_auto_judge
   let release_auto_judge = release_auto_judge
-  let reset_active_auto_judges () = Atomic.set active_auto_judges Auto_judge_owners.empty
 end

--- a/lib/keeper/keeper_gate.ml
+++ b/lib/keeper/keeper_gate.ml
@@ -920,3 +920,13 @@ let decide ?cycle_grant ~keeper_always_allow request =
       ();
     Unavailable reason
 ;;
+
+module For_testing = struct
+  let ready_auto_judges_for_owner ~base_path ~keeper_name entries =
+    ready_auto_judges_for_owner ~base_path ~keeper_name entries
+  ;;
+
+  let claim_auto_judge = claim_auto_judge
+  let release_auto_judge = release_auto_judge
+  let reset_active_auto_judges () = Atomic.set active_auto_judges Auto_judge_owners.empty
+end

--- a/lib/keeper/keeper_gate.ml
+++ b/lib/keeper/keeper_gate.ml
@@ -342,8 +342,7 @@ let compare_auto_judge_entries
       (left : Keeper_approval_queue.pending_approval)
       (right : Keeper_approval_queue.pending_approval)
   =
-  let by_time = Float.compare left.requested_at right.requested_at in
-  if by_time <> 0 then by_time else String.compare left.id right.id
+  Int.compare left.sequence right.sequence
 ;;
 
 let ready_auto_judges_for_owner ?exclude_id ~base_path ~keeper_name entries =

--- a/lib/keeper/keeper_gate.mli
+++ b/lib/keeper/keeper_gate.mli
@@ -116,3 +116,15 @@ val authorization_source_to_string : authorization_source -> string
 val deferred_reason_to_string : deferred_reason -> string
 val unavailable_reason_to_string : unavailable_reason -> string
 val decision_to_yojson : decision -> Yojson.Safe.t
+
+module For_testing : sig
+  val ready_auto_judges_for_owner :
+    base_path:string ->
+    keeper_name:string ->
+    Keeper_approval_queue.pending_approval list ->
+    Keeper_approval_queue.pending_approval list
+
+  val claim_auto_judge : Keeper_approval_queue.pending_approval -> bool
+  val release_auto_judge : Keeper_approval_queue.pending_approval -> unit
+  val reset_active_auto_judges : unit -> unit
+end

--- a/lib/keeper/keeper_gate.mli
+++ b/lib/keeper/keeper_gate.mli
@@ -126,5 +126,4 @@ module For_testing : sig
 
   val claim_auto_judge : Keeper_approval_queue.pending_approval -> bool
   val release_auto_judge : Keeper_approval_queue.pending_approval -> unit
-  val reset_active_auto_judges : unit -> unit
 end

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.ml
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.ml
@@ -29,6 +29,7 @@ type pending_approval =
   ; tool_name : string
   ; input_hash : string
   ; input : Yojson.Safe.t
+  ; sequence : int
   ; requested_at : float
   ; turn_id : int option
   ; request_context : Yojson.Safe.t option

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.mli
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.mli
@@ -24,13 +24,15 @@ and summary_status =
   | Summary_available of hitl_context_summary
   | Summary_failed of { reason : string; retryable : bool }
 
-(** A pending request never owns or suspends a Keeper lane. *)
+(** A pending request never owns or suspends a Keeper lane. [sequence] is the
+    durable queue-issued order identity; [requested_at] is observation only. *)
 type pending_approval =
   { id : string
   ; keeper_name : string
   ; tool_name : string
   ; input_hash : string
   ; input : Yojson.Safe.t
+  ; sequence : int
   ; requested_at : float
   ; turn_id : int option
   ; request_context : Yojson.Safe.t option

--- a/test/test_hitl_summary_worker.ml
+++ b/test/test_hitl_summary_worker.ml
@@ -55,6 +55,7 @@ let sample_entry : Q.pending_approval =
         ; "body", `String "hello"
         ; "api_key", `String "sk-test-secret"
         ]
+  ; sequence = 1
   ; requested_at = 1780587600.0
   ; turn_id = None
   ; request_context =

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -499,16 +499,31 @@ let test_monotonic_sequence_survives_restart () =
 
 let test_same_owner_drain_uses_sequence_not_wall_clock () =
   let base_path = temp_dir () in
+  let other_base_path = temp_dir () in
   Fun.protect
     ~finally:(fun () ->
       AQ.For_testing.reset_runtime_state ();
-      cleanup_dir base_path)
+      cleanup_dir base_path;
+      cleanup_dir other_base_path)
     (fun () ->
        AQ.For_testing.reset_runtime_state ();
        let first = submit ~base_path ~keeper_name:"fifo-owner" ~input:(`Int 1) in
        let second = submit ~base_path ~keeper_name:"fifo-owner" ~input:(`Int 2) in
+       let other =
+         submit ~base_path:other_base_path ~keeper_name:"fifo-owner" ~input:(`Int 3)
+       in
        let first = { (pending_entry_exn first) with requested_at = 500.0 } in
        let second = { (pending_entry_exn second) with requested_at = 1.0 } in
+       let expected_global =
+         if String.compare base_path other_base_path < 0
+         then [ first.id; second.id; other ]
+         else [ other; first.id; second.id ]
+       in
+       Alcotest.(check (list string))
+         "global projection groups deterministic workspace-local FIFO"
+         expected_global
+         (AQ.list_pending_entries ()
+          |> List.map (fun (entry : AQ.pending_approval) -> entry.id));
        match
          Gate.For_testing.ready_auto_judges_for_owner
            ~base_path

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -48,6 +48,10 @@ let require_some message = function
   | None -> Alcotest.fail message
 ;;
 
+let pending_entry_exn id =
+  AQ.get_pending_entry ~id |> require_some ("pending approval not found: " ^ id)
+;;
+
 let drop_resolution ~base_path ~keeper_name resolution =
   let post_id = Keeper_event_queue.hitl_resolution_post_id resolution in
   match Registry_queue.drop_by_post_id ~base_path keeper_name ~post_id with
@@ -258,7 +262,8 @@ let test_install_serializes_snapshot_read_with_same_base_mutation () =
        write_pending_snapshot
          ~base_path
          (`Assoc
-            [ "version", `Int 2
+            [ "version", `Int 3
+            ; "next_sequence", `Int 1
             ; "pending", `List []
             ; "deliveries", `List []
             ]);
@@ -394,6 +399,11 @@ let test_submit_is_nonblocking_and_exactly_deduplicated () =
        in
        Alcotest.(check bool) "changed field is a different request" true
          (not (String.equal first changed));
+       Alcotest.(check int) "first request sequence" 1 (pending_entry_exn first).sequence;
+       Alcotest.(check int)
+         "dedup does not consume sequence"
+         2
+         (pending_entry_exn changed).sequence;
        (match AQ.get_pending_entry ~id:first with
         | None -> Alcotest.fail "pending request missing"
         | Some entry ->
@@ -462,6 +472,29 @@ let test_unversioned_request_context_is_not_replayed_as_exact () =
           Alcotest.fail "unversioned projected context was treated as exact evidence"
         | None -> Alcotest.fail "legacy pending request was not restored");
        reject_and_cleanup ~base_path id)
+;;
+
+let test_monotonic_sequence_survives_restart () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      AQ.For_testing.reset_runtime_state ();
+      cleanup_dir base_path)
+    (fun () ->
+       AQ.For_testing.reset_runtime_state ();
+       let first = submit ~base_path ~keeper_name:"sequence-owner" ~input:(`Int 1) in
+       let second = submit ~base_path ~keeper_name:"sequence-owner" ~input:(`Int 2) in
+       Alcotest.(check int) "first durable sequence" 1 (pending_entry_exn first).sequence;
+       Alcotest.(check int) "second durable sequence" 2 (pending_entry_exn second).sequence;
+       AQ.For_testing.reset_runtime_state ();
+       ignore (install_exn ~base_path);
+       let third = submit ~base_path ~keeper_name:"sequence-owner" ~input:(`Int 3) in
+       Alcotest.(check int) "restart continues sequence" 3 (pending_entry_exn third).sequence;
+       let open Yojson.Safe.Util in
+       Alcotest.(check int)
+         "next sequence is durable"
+         4
+         (read_pending_snapshot ~base_path |> member "next_sequence" |> to_int))
 ;;
 
 let test_resolution_is_durable_and_origin_scoped () =
@@ -1135,7 +1168,8 @@ let test_malformed_snapshot_fails_install_and_is_observed () =
        write_pending_snapshot
          ~base_path
          (`Assoc
-            [ "version", `Int 2
+            [ "version", `Int 3
+            ; "next_sequence", `Int 1
             ; "pending", `List [ `String "malformed-entry" ]
             ; "deliveries", `List []
             ]);
@@ -1165,7 +1199,8 @@ let test_malformed_snapshot_fails_install_and_is_observed () =
          (Yojson.Safe.equal
             persisted
             (`Assoc
-               [ "version", `Int 2
+               [ "version", `Int 3
+               ; "next_sequence", `Int 1
                ; "pending", `List [ `String "malformed-entry" ]
                ; "deliveries", `List []
                ]));
@@ -1204,7 +1239,8 @@ let test_persisted_delivery_replays_before_origin_wake () =
        write_pending_snapshot
          ~base_path
          (`Assoc
-            [ "version", `Int 2
+            [ "version", `Int 3
+            ; "next_sequence", `Int 2
             ; "pending", `List []
             ; ( "deliveries"
               , `List
@@ -1294,7 +1330,8 @@ let test_one_delivery_replay_failure_does_not_stop_others () =
        write_pending_snapshot
          ~base_path
          (`Assoc
-            [ "version", `Int 2
+            [ "version", `Int 3
+            ; "next_sequence", `Int 3
             ; "pending", `List []
             ; ( "deliveries"
               , `List
@@ -1536,6 +1573,10 @@ let () =
             "unversioned context is never replayed as exact"
             `Quick
             test_unversioned_request_context_is_not_replayed_as_exact
+        ; Alcotest.test_case
+            "durable sequence survives restart"
+            `Quick
+            test_monotonic_sequence_survives_restart
         ; Alcotest.test_case
             "dedup keeps distinct origins"
             `Quick

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -497,6 +497,61 @@ let test_monotonic_sequence_survives_restart () =
          (read_pending_snapshot ~base_path |> member "next_sequence" |> to_int))
 ;;
 
+let test_same_owner_drain_uses_sequence_not_wall_clock () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      AQ.For_testing.reset_runtime_state ();
+      cleanup_dir base_path)
+    (fun () ->
+       AQ.For_testing.reset_runtime_state ();
+       let first = submit ~base_path ~keeper_name:"fifo-owner" ~input:(`Int 1) in
+       let second = submit ~base_path ~keeper_name:"fifo-owner" ~input:(`Int 2) in
+       let first = { (pending_entry_exn first) with requested_at = 500.0 } in
+       let second = { (pending_entry_exn second) with requested_at = 1.0 } in
+       match
+         Gate.For_testing.ready_auto_judges_for_owner
+           ~base_path
+           ~keeper_name:"fifo-owner"
+           [ second; first ]
+       with
+       | [ oldest; newest ] ->
+         Alcotest.(check string) "oldest sequence first" first.id oldest.id;
+         Alcotest.(check string) "next sequence second" second.id newest.id
+       | entries ->
+         Alcotest.failf "two same-owner entries expected, got %d" (List.length entries))
+;;
+
+let test_different_owners_claim_in_parallel () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Gate.For_testing.reset_active_auto_judges ();
+      AQ.For_testing.reset_runtime_state ();
+      cleanup_dir base_path)
+    (fun () ->
+       AQ.For_testing.reset_runtime_state ();
+       Gate.For_testing.reset_active_auto_judges ();
+       let owner_a =
+         pending_entry_exn (submit ~base_path ~keeper_name:"owner-a" ~input:(`Int 1))
+       in
+       let owner_a_next =
+         pending_entry_exn (submit ~base_path ~keeper_name:"owner-a" ~input:(`Int 2))
+       in
+       let owner_b =
+         pending_entry_exn (submit ~base_path ~keeper_name:"owner-b" ~input:(`Int 1))
+       in
+       Alcotest.(check bool) "first owner activates" true
+         (Gate.For_testing.claim_auto_judge owner_a);
+       Alcotest.(check bool) "same owner remains queued" false
+         (Gate.For_testing.claim_auto_judge owner_a_next);
+       Alcotest.(check bool) "different owner activates in parallel" true
+         (Gate.For_testing.claim_auto_judge owner_b);
+       Gate.For_testing.release_auto_judge owner_a;
+       Alcotest.(check bool) "same owner next activates after release" true
+         (Gate.For_testing.claim_auto_judge owner_a_next))
+;;
+
 let test_resolution_is_durable_and_origin_scoped () =
   let base_path = temp_dir () in
   let keeper_name = "queue-origin" in
@@ -1577,6 +1632,14 @@ let () =
             "durable sequence survives restart"
             `Quick
             test_monotonic_sequence_survives_restart
+        ; Alcotest.test_case
+            "same owner drains by durable sequence"
+            `Quick
+            test_same_owner_drain_uses_sequence_not_wall_clock
+        ; Alcotest.test_case
+            "different owners activate in parallel"
+            `Quick
+            test_different_owners_claim_in_parallel
         ; Alcotest.test_case
             "dedup keeps distinct origins"
             `Quick

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -1371,17 +1371,13 @@ let test_one_delivery_replay_failure_does_not_stop_others () =
       cleanup_dir base_path)
     (fun () ->
        AQ.For_testing.reset_runtime_state ();
-       let failing_id =
-         submit
-           ~base_path
-           ~keeper_name
-           ~input:(`Assoc [ "target", `String "remember-fails" ])
-       in
-       let successful_id =
-         submit
-           ~base_path
-           ~keeper_name
-           ~input:(`Assoc [ "target", `String "independent-success" ])
+       let first_id, second_id, successful_id =
+         List.init 3 (fun index ->
+           submit ~base_path ~keeper_name ~input:(`Assoc [ "target", `Int index ]))
+         |> List.sort (fun left right -> String.compare right left)
+         |> function
+         | [ first; second; third ] -> first, second, third
+         | _ -> Alcotest.fail "three approvals expected"
        in
        let pending_entries =
          let open Yojson.Safe.Util in
@@ -1397,19 +1393,28 @@ let test_one_delivery_replay_failure_does_not_stop_others () =
          | Some entry -> entry
          | None -> Alcotest.fail ("missing persisted entry " ^ id)
        in
+       let entry_at sequence id =
+         match entry_for id with
+         | `Assoc fields ->
+           `Assoc (("sequence", `Int sequence) :: List.remove_assoc "sequence" fields)
+         | _ -> Alcotest.fail "persisted entry object expected"
+       in
        write_pending_snapshot
          ~base_path
          (`Assoc
             [ "version", `Int 3
-            ; "next_sequence", `Int 3
+            ; "next_sequence", `Int 4
             ; "pending", `List []
             ; ( "deliveries"
               , `List
                   [ delivery_json
-                      ~entry:(entry_for failing_id)
+                      ~entry:(entry_at 1 first_id)
                       ~remember_rule:true
                   ; delivery_json
-                      ~entry:(entry_for successful_id)
+                      ~entry:(entry_at 2 second_id)
+                      ~remember_rule:true
+                  ; delivery_json
+                      ~entry:(entry_at 3 successful_id)
                       ~remember_rule:false
                   ] )
             ]);
@@ -1420,13 +1425,13 @@ let test_one_delivery_replay_failure_does_not_stop_others () =
        let report = install_exn ~base_path in
        Alcotest.(check int) "independent delivery replayed" 1 report.replayed_deliveries;
        Alcotest.(check int)
-         "one replay failure reported"
-         1
+         "two replay failures reported"
+         2
          (List.length report.delivery_replay_failures);
-       Alcotest.(check string)
-         "failing approval identified"
-         failing_id
-         (List.hd report.delivery_replay_failures).approval_id;
+       Alcotest.(check (list string))
+         "replay failures preserve durable sequence"
+         [ first_id; second_id ]
+         (List.map (fun failure -> failure.AQ.approval_id) report.delivery_replay_failures);
        Alcotest.(check bool) "later delivery reached origin" true
          (Option.is_some
             (durable_resolution_opt
@@ -1438,7 +1443,7 @@ let test_one_delivery_replay_failure_does_not_stop_others () =
             match durable_resolution_opt ~base_path ~keeper_name ~approval_id with
             | Some resolution -> drop_resolution ~base_path ~keeper_name resolution
             | None -> ())
-         [ failing_id; successful_id ])
+         [ first_id; second_id; successful_id ])
 ;;
 
 let test_submit_surfaces_storage_failure () =

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -115,6 +115,12 @@ let reject_and_cleanup ~base_path id =
   | Error error -> Alcotest.fail (AQ.resolve_error_to_string error)
 ;;
 
+let install_exn ~base_path =
+  match AQ.install_persistence ~base_path with
+  | Ok report -> report
+  | Error error -> Alcotest.fail (AQ.install_error_to_string error)
+;;
+
 let test_pending_store_lock_serializes_eio_fibers () =
   Eio_main.run @@ fun _environment ->
   let first_entered, signal_first_entered = Eio.Promise.create () in
@@ -149,6 +155,7 @@ let test_dedup_never_merges_distinct_origins () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_path)
     (fun () ->
+       ignore (install_exn ~base_path);
        let input = `Assoc [ "target", `String "same-action" ] in
        let dashboard_a =
          Keeper_continuation_channel.dashboard ~thread_id:"thread-a"
@@ -245,12 +252,6 @@ let delivery_json ~entry ~remember_rule =
     ]
 ;;
 
-let install_exn ~base_path =
-  match AQ.install_persistence ~base_path with
-  | Ok report -> report
-  | Error error -> Alcotest.fail (AQ.install_error_to_string error)
-;;
-
 let test_install_serializes_snapshot_read_with_same_base_mutation () =
   let base_path = temp_dir () in
   Fun.protect
@@ -333,6 +334,7 @@ let test_submit_is_nonblocking_and_exactly_deduplicated () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_path)
     (fun () ->
+       ignore (install_exn ~base_path);
        let input =
          `Assoc
            [ "target", `String "document"
@@ -435,6 +437,7 @@ let test_unversioned_request_context_is_not_replayed_as_exact () =
       cleanup_dir base_path)
     (fun () ->
        AQ.For_testing.reset_runtime_state ();
+       ignore (install_exn ~base_path);
        let id =
          submit_with_context
            ~request_context:(`Assoc [ "history_digest", `String "retired-projection" ])
@@ -482,6 +485,7 @@ let test_monotonic_sequence_survives_restart () =
       cleanup_dir base_path)
     (fun () ->
        AQ.For_testing.reset_runtime_state ();
+       ignore (install_exn ~base_path);
        let first = submit ~base_path ~keeper_name:"sequence-owner" ~input:(`Int 1) in
        let second = submit ~base_path ~keeper_name:"sequence-owner" ~input:(`Int 2) in
        Alcotest.(check int) "first durable sequence" 1 (pending_entry_exn first).sequence;
@@ -507,6 +511,8 @@ let test_same_owner_drain_uses_sequence_not_wall_clock () =
       cleanup_dir other_base_path)
     (fun () ->
        AQ.For_testing.reset_runtime_state ();
+       ignore (install_exn ~base_path);
+       ignore (install_exn ~base_path:other_base_path);
        let first = submit ~base_path ~keeper_name:"fifo-owner" ~input:(`Int 1) in
        let second = submit ~base_path ~keeper_name:"fifo-owner" ~input:(`Int 2) in
        let other =
@@ -538,33 +544,49 @@ let test_same_owner_drain_uses_sequence_not_wall_clock () =
 ;;
 
 let test_different_owners_claim_in_parallel () =
+  (* Real concurrent proof: fibers race the per-owner claim, so the
+     one-winner-per-owner invariant is exercised under actual Atomic
+     contention instead of sequential calls.  Unique owner names keep the
+     process-global active map isolated without a production reset. *)
   let base_path = temp_dir () in
+  let suffix = string_of_int (int_of_float (Unix.gettimeofday () *. 1_000_000.0)) in
   Fun.protect
     ~finally:(fun () ->
-      Gate.For_testing.reset_active_auto_judges ();
       AQ.For_testing.reset_runtime_state ();
       cleanup_dir base_path)
     (fun () ->
        AQ.For_testing.reset_runtime_state ();
-       Gate.For_testing.reset_active_auto_judges ();
-       let owner_a =
-         pending_entry_exn (submit ~base_path ~keeper_name:"owner-a" ~input:(`Int 1))
+       ignore (install_exn ~base_path);
+       let owner_a = "owner-a-" ^ suffix in
+       let owner_b = "owner-b-" ^ suffix in
+       let entry_a1 =
+         pending_entry_exn (submit ~base_path ~keeper_name:owner_a ~input:(`Int 1))
        in
-       let owner_a_next =
-         pending_entry_exn (submit ~base_path ~keeper_name:"owner-a" ~input:(`Int 2))
+       let entry_a2 =
+         pending_entry_exn (submit ~base_path ~keeper_name:owner_a ~input:(`Int 2))
        in
-       let owner_b =
-         pending_entry_exn (submit ~base_path ~keeper_name:"owner-b" ~input:(`Int 1))
+       let entry_b1 =
+         pending_entry_exn (submit ~base_path ~keeper_name:owner_b ~input:(`Int 1))
        in
-       Alcotest.(check bool) "first owner activates" true
-         (Gate.For_testing.claim_auto_judge owner_a);
-       Alcotest.(check bool) "same owner remains queued" false
-         (Gate.For_testing.claim_auto_judge owner_a_next);
-       Alcotest.(check bool) "different owner activates in parallel" true
-         (Gate.For_testing.claim_auto_judge owner_b);
-       Gate.For_testing.release_auto_judge owner_a;
-       Alcotest.(check bool) "same owner next activates after release" true
-         (Gate.For_testing.claim_auto_judge owner_a_next))
+       let winners_a = Atomic.make 0 in
+       let winners_b = Atomic.make 0 in
+       let hammer entry winners =
+         for _ = 1 to 40 do
+           if Gate.For_testing.claim_auto_judge entry
+           then ignore (Atomic.fetch_and_add winners 1)
+         done
+       in
+       Eio_main.run (fun _env ->
+         Eio.Switch.run (fun sw ->
+           Eio.Fiber.fork ~sw (fun () -> hammer entry_a1 winners_a);
+           Eio.Fiber.fork ~sw (fun () -> hammer entry_a1 winners_a);
+           Eio.Fiber.fork ~sw (fun () -> hammer entry_b1 winners_b);
+           Eio.Fiber.fork ~sw (fun () -> hammer entry_b1 winners_b)));
+       Alcotest.(check int) "one winner for owner A under contention" 1 (Atomic.get winners_a);
+       Alcotest.(check int) "one winner for owner B in parallel" 1 (Atomic.get winners_b);
+       Gate.For_testing.release_auto_judge entry_a1;
+       Alcotest.(check bool) "same owner re-claims after release" true
+         (Gate.For_testing.claim_auto_judge entry_a2))
 ;;
 
 let test_resolution_is_durable_and_origin_scoped () =
@@ -574,6 +596,7 @@ let test_resolution_is_durable_and_origin_scoped () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_path)
     (fun () ->
+       ignore (install_exn ~base_path);
        let input = `Assoc [ "target", `String "document"; "body", `String "hello" ] in
        let id = submit ~base_path ~keeper_name ~input in
        let result =
@@ -671,6 +694,7 @@ let test_cycle_grant_uses_exact_effect_and_is_consumed_once () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_path)
     (fun () ->
+       ignore (install_exn ~base_path);
        let approval_id =
          submit_with_context
            ~turn_id:17
@@ -804,6 +828,7 @@ let test_summary_updates_never_resolve_pending_request () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_path)
     (fun () ->
+       ignore (install_exn ~base_path);
        let id = submit ~base_path ~keeper_name ~input:(`Assoc [ "request", `String "x" ]) in
        check_update "mark pending" true (AQ.mark_summary_pending ~id);
        check_update
@@ -842,6 +867,7 @@ let test_all_summary_failures_accept_explicit_restart () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_path)
     (fun () ->
+       ignore (install_exn ~base_path);
        let retryable_id =
          submit ~base_path ~keeper_name ~input:(`Assoc [ "request", `String "retry" ])
        in
@@ -894,6 +920,7 @@ let test_operator_recovery_reopens_all_failed_summaries () =
       AQ.For_testing.reset_runtime_state ();
       cleanup_dir base_path)
     (fun () ->
+       ignore (install_exn ~base_path);
        let request_context =
          `Assoc
            [ "history_messages", `List [ `String "exact prior evidence" ]
@@ -959,6 +986,7 @@ let test_dashboard_retry_rejects_cross_workspace_approval () =
       cleanup_dir base_b)
     (fun () ->
        AQ.For_testing.reset_runtime_state ();
+       ignore (install_exn ~base_path:base_a);
        let approval_id =
          submit
            ~base_path:base_a
@@ -1008,6 +1036,7 @@ let test_dashboard_resolve_rejects_cross_workspace_approval () =
       cleanup_dir base_b)
     (fun () ->
        AQ.For_testing.reset_runtime_state ();
+       ignore (install_exn ~base_path:base_a);
        let approval_id =
          submit
            ~base_path:base_a
@@ -1064,6 +1093,7 @@ let test_lane_activity_does_not_retry_failed_auto_judge () =
       AQ.For_testing.reset_runtime_state ();
       cleanup_dir base_path)
     (fun () ->
+       ignore (install_exn ~base_path);
        let id_a =
          submit
            ~base_path
@@ -1140,6 +1170,7 @@ let test_decisive_summary_finalizes_after_restart () =
       cleanup_dir base_path)
     (fun () ->
        AQ.For_testing.reset_runtime_state ();
+       ignore (install_exn ~base_path);
        let id =
          submit
            ~base_path
@@ -1185,6 +1216,7 @@ let test_inflight_auto_judge_preserves_durable_restart_marker () =
       cleanup_dir base_path)
     (fun () ->
        AQ.For_testing.reset_runtime_state ();
+       ignore (install_exn ~base_path);
        let id =
          submit
            ~base_path
@@ -1283,6 +1315,98 @@ let test_malformed_snapshot_fails_install_and_is_observed () =
        Alcotest.(check bool) "malformed snapshot observed" true (after -. before >= 1.0))
 ;;
 
+let test_unsupported_version_snapshot_is_quarantined_and_store_starts_fresh () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      AQ.For_testing.reset_runtime_state ();
+      cleanup_dir base_path)
+    (fun () ->
+       AQ.For_testing.reset_runtime_state ();
+       write_pending_snapshot
+         ~base_path
+         (`Assoc
+            [ "version", `Int 2
+            ; "pending", `List []
+            ; "deliveries", `List []
+            ]);
+       (match AQ.install_persistence ~base_path with
+        | Ok _ -> ()
+        | Error _ ->
+          Alcotest.fail "unsupported version must quarantine, not fail install");
+       let store_path = AQ.For_testing.pending_store_path ~base_path in
+       Alcotest.(check bool) "original moved away" false
+         (Sys.file_exists store_path);
+       let quarantine_path = store_path ^ ".v2.quarantine" in
+       Alcotest.(check bool) "quarantine file exists" true
+         (Sys.file_exists quarantine_path);
+       let preserved = Yojson.Safe.from_file quarantine_path in
+       Alcotest.(check bool) "content preserved verbatim" true
+         (Yojson.Safe.equal
+            preserved
+            (`Assoc
+               [ "version", `Int 2
+               ; "pending", `List []
+               ; "deliveries", `List []
+               ]));
+       let id =
+         submit ~base_path ~keeper_name:"queue-quarantine"
+           ~input:(`Assoc [ "target", `String "after-quarantine" ])
+       in
+       Alcotest.(check int) "fresh generation starts at sequence 1" 1
+         (pending_entry_exn id).sequence)
+;;
+
+let test_quarantine_name_collision_uses_next_free_name () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      AQ.For_testing.reset_runtime_state ();
+      cleanup_dir base_path)
+    (fun () ->
+       AQ.For_testing.reset_runtime_state ();
+       let store_path = AQ.For_testing.pending_store_path ~base_path in
+       write_pending_snapshot
+         ~base_path
+         (`Assoc
+            [ "version", `Int 2
+            ; "pending", `List []
+            ; "deliveries", `List []
+            ]);
+       let occupied = store_path ^ ".v2.quarantine" in
+       ensure_dir (Filename.dirname occupied);
+       Out_channel.with_open_text occupied (fun channel ->
+         output_string channel "prior quarantine");
+       (match AQ.install_persistence ~base_path with
+        | Ok _ -> ()
+        | Error _ -> Alcotest.fail "install must quarantine");
+       Alcotest.(check bool) "prior quarantine kept" true
+         (Sys.file_exists occupied);
+       Alcotest.(check bool) "next free name used" true
+         (Sys.file_exists (store_path ^ ".v2.quarantine.1")))
+;;
+
+let test_unreadable_json_snapshot_is_not_quarantined () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      AQ.For_testing.reset_runtime_state ();
+      cleanup_dir base_path)
+    (fun () ->
+       AQ.For_testing.reset_runtime_state ();
+       let store_path = AQ.For_testing.pending_store_path ~base_path in
+       ensure_dir (Filename.dirname store_path);
+       Out_channel.with_open_text store_path (fun channel ->
+         output_string channel "{not-json");
+       (match AQ.install_persistence ~base_path with
+        | Ok _ -> Alcotest.fail "unreadable snapshot must not install"
+        | Error _ -> ());
+       Alcotest.(check bool) "file left in place" true
+         (Sys.file_exists store_path);
+       Alcotest.(check bool) "no quarantine created" false
+         (Sys.file_exists (store_path ^ ".v2.quarantine")))
+;;
+
 let test_persisted_delivery_replays_before_origin_wake () =
   let base_path = temp_dir () in
   let keeper_name = "queue-replay-origin" in
@@ -1292,6 +1416,7 @@ let test_persisted_delivery_replays_before_origin_wake () =
       cleanup_dir base_path)
     (fun () ->
        AQ.For_testing.reset_runtime_state ();
+       ignore (install_exn ~base_path);
        let id =
          submit
            ~base_path
@@ -1371,6 +1496,7 @@ let test_one_delivery_replay_failure_does_not_stop_others () =
       cleanup_dir base_path)
     (fun () ->
        AQ.For_testing.reset_runtime_state ();
+       ignore (install_exn ~base_path);
        let first_id, second_id, successful_id =
          List.init 3 (fun index ->
            submit ~base_path ~keeper_name ~input:(`Assoc [ "target", `Int index ]))
@@ -1476,6 +1602,7 @@ let test_default_auto_judge_defers_without_blocking () =
       cleanup_dir base_path)
     (fun () ->
        AQ.For_testing.reset_runtime_state ();
+       ignore (install_exn ~base_path);
        let request : Gate.request =
          { keeper_name
          ; operation = "external-effect"
@@ -1516,6 +1643,7 @@ let test_unavailable_cycle_grant_never_falls_through () =
       AQ.For_testing.reset_runtime_state ();
       cleanup_dir base_path)
     (fun () ->
+       ignore (install_exn ~base_path);
        let approval_id = submit ~base_path ~keeper_name ~input in
        (match AQ.resolve ~base_path ~id:approval_id ~decision:AQ.Decision.Approve with
         | Ok () -> ()
@@ -1567,6 +1695,7 @@ let test_nonapproved_resolution_payload_is_delivered () =
       AQ.For_testing.reset_runtime_state ();
       cleanup_dir base_path)
     (fun () ->
+       ignore (install_exn ~base_path);
        let reject_id =
          submit
            ~base_path
@@ -1708,6 +1837,18 @@ let () =
             "malformed snapshot is explicit"
             `Quick
             test_malformed_snapshot_fails_install_and_is_observed
+        ; Alcotest.test_case
+            "unsupported version quarantines and restarts fresh"
+            `Quick
+            test_unsupported_version_snapshot_is_quarantined_and_store_starts_fresh
+        ; Alcotest.test_case
+            "quarantine name collision uses next free name"
+            `Quick
+            test_quarantine_name_collision_uses_next_free_name
+        ; Alcotest.test_case
+            "unreadable json is not quarantined"
+            `Quick
+            test_unreadable_json_snapshot_is_not_quarantined
         ; Alcotest.test_case
             "delivery journal replays"
             `Quick

--- a/test/test_keeper_approval_queue_rules.ml
+++ b/test/test_keeper_approval_queue_rules.ml
@@ -252,7 +252,11 @@ let with_gate_fixture f =
       AQ.For_testing.reset_runtime_state ();
       AQ.For_testing.reset_audit_store ();
       cleanup_dir base_path)
-    (fun () -> f base_path)
+    (fun () ->
+       (match AQ.install_persistence ~base_path with
+        | Ok _report -> ()
+        | Error error -> fail (AQ.install_error_to_string error));
+       f base_path)
 ;;
 
 let exact_rule_lookup_failure_count () =

--- a/test/test_keeper_gate_effect_coverage.ml
+++ b/test/test_keeper_gate_effect_coverage.ml
@@ -65,6 +65,12 @@ let with_clean_gate_runtime f =
     f
 ;;
 
+let install_exn ~base_path =
+  match Keeper_approval_queue.install_persistence ~base_path with
+  | Ok report -> report
+  | Error error -> fail (Keeper_approval_queue.install_error_to_string error)
+;;
+
 let with_publication_recovery
       ~registry_root
       ~(meta : Keeper_meta_contract.keeper_meta)
@@ -179,6 +185,7 @@ let test_keeper_effects_defer_without_dispatch () =
   (match Keeper_gate_mode.set config ~actor:"test" Keeper_gate_mode.Manual with
    | Ok _ -> ()
    | Error error -> fail ("failed to select manual Gate mode: " ^ error));
+  ignore (install_exn ~base_path);
   let meta = make_meta "gate-deferred-keeper" in
   with_publication_recovery
     ~registry_root:base_path
@@ -295,6 +302,7 @@ let test_ollama_probe_defer_and_unavailable_do_not_dispatch () =
    with
    | Ok _ -> ()
    | Error error -> fail ("failed to select manual Gate mode: " ^ error));
+  ignore (install_exn ~base_path:deferred_base);
   let meta = make_meta "ollama-gate-deferred-keeper" in
   let deferred =
     Keeper_tool_in_process_runtime.handle_masc_local_runtime_with_outcome
@@ -383,6 +391,7 @@ let test_voice_effect_defers_without_gating_local_reads () =
   (match Keeper_gate_mode.set config ~actor:"test" Keeper_gate_mode.Manual with
    | Ok _ -> ()
    | Error error -> fail ("failed to select manual Gate mode: " ^ error));
+  ignore (install_exn ~base_path);
   let meta = make_meta "voice-gate-keeper" in
   let listen_input =
     `Assoc

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -50,6 +50,11 @@ let cleanup_dir dir =
   in
   try rm dir with _ -> ()
 
+let install_exn ~base_path =
+  match AQ.install_persistence ~base_path with
+  | Ok report -> report
+  | Error error -> fail (AQ.install_error_to_string error)
+
 let rec wait_until ~clock ~deadline predicate =
   if predicate ()
   then true
@@ -344,6 +349,7 @@ let test_pending_hitl_approval_keeper_names_filters_persisted_pending () =
       let _workspace =
         Masc.Workspace.init config ~agent_name:(Some supervisor_agent_name)
       in
+      ignore (install_exn ~base_path:config.base_path);
       let blocked = make_meta "hitl-blocked" in
       let clear = make_meta "hitl-clear" in
       List.iter
@@ -1034,6 +1040,7 @@ let test_sweep_reports_pending_hitl_approval () =
       Log.set_level Log.Info;
       let config = Masc.Workspace.default_config base_dir in
       let _workspace = Masc.Workspace.init config ~agent_name:(Some supervisor_agent_name) in
+      ignore (install_exn ~base_path:config.base_path);
       let meta = make_meta name in
       (match Keeper_meta_store.write_meta config meta with
        | Ok () -> ()


### PR DESCRIPTION
## What changed

- Persist a positive, monotonic approval enqueue sequence in each workspace Gate snapshot.
- Order pending approvals and Auto Judge work by that durable sequence.
- Keep `requested_at` as observability data rather than execution-order authority.
- Advance the snapshot schema to version 3; an older-version snapshot is quarantined verbatim to `<pending>.v<N>.quarantine` (next free name on collision) and the store starts a fresh generation instead of bricking the gate.
- Prove same-owner FIFO and different-owner independent claims through the test-only Gate surface merged from #25136.

## Why

Wall-clock ordering is not a durable fact and can change under equal, skewed, or replayed timestamps. Queue order must survive restart and remain deterministic without heuristic tie-breaking. The initial sequence is now an explicit typed schema invariant, not an `Option.value` fallback.

This leaf is scoped to Gate queue ordering. It does not add product routing, connector-specific policy, global grants, or cross-Keeper serialization.

## Exact evidence

- Head SHA: `028b15cc8b`
- Diff: **348 changed lines** (`274 additions / 74 deletions`)
- Base: `main` at reconstruction time (`3be51c2160591798fe6123e1c4f0544b5b75592c`)
- `git diff --check`: PASS
- `ocamlformat --check`: PASS
- deterministic-boundary ratchet: PASS
- Meta Guards on the exact deterministic-sequence repair: PASS
- exact combined head Build and Test: running; CI remains the build authority

## Local focused build status

The original reconstruction did not run the focused build because the installed `agent_sdk` was then `0.216.2` while main required `>= 0.216.3`; the pin guard was not bypassed. GitHub Build and Test passed on the pre-expression-fix head, and exact-head CI was retriggered by the amendment.

## Stack

#25136 was merged into this PR's head branch (not into `main`) on 2026-07-18. #25135 is now the single 348-line implementation+proof merge boundary and remains Draft.

[근거] local exact-head diff/format/determinism commands and `gh pr checks 25135`; checked 2026-07-18 17:05 KST; confidence High.

