### PR TITLE
test(gate): prove owner-local drain order

### DIFF
--- a/lib/keeper/keeper_gate.ml
+++ b/lib/keeper/keeper_gate.ml
@@ -920,3 +920,13 @@ let decide ?cycle_grant ~keeper_always_allow request =
       ();
     Unavailable reason
 ;;
+
+module For_testing = struct
+  let ready_auto_judges_for_owner ~base_path ~keeper_name entries =
+    ready_auto_judges_for_owner ~base_path ~keeper_name entries
+  ;;
+
+  let claim_auto_judge = claim_auto_judge
+  let release_auto_judge = release_auto_judge
+  let reset_active_auto_judges () = Atomic.set active_auto_judges Auto_judge_owners.empty
+end

--- a/lib/keeper/keeper_gate.mli
+++ b/lib/keeper/keeper_gate.mli
@@ -116,3 +116,15 @@ val authorization_source_to_string : authorization_source -> string
 val deferred_reason_to_string : deferred_reason -> string
 val unavailable_reason_to_string : unavailable_reason -> string
 val decision_to_yojson : decision -> Yojson.Safe.t
+
+module For_testing : sig
+  val ready_auto_judges_for_owner :
+    base_path:string ->
+    keeper_name:string ->
+    Keeper_approval_queue.pending_approval list ->
+    Keeper_approval_queue.pending_approval list
+
+  val claim_auto_judge : Keeper_approval_queue.pending_approval -> bool
+  val release_auto_judge : Keeper_approval_queue.pending_approval -> unit
+  val reset_active_auto_judges : unit -> unit
+end

--- a/test/test_keeper_approval_queue.ml
+++ b/test/test_keeper_approval_queue.ml
@@ -497,6 +497,61 @@ let test_monotonic_sequence_survives_restart () =
          (read_pending_snapshot ~base_path |> member "next_sequence" |> to_int))
 ;;
 
+let test_same_owner_drain_uses_sequence_not_wall_clock () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      AQ.For_testing.reset_runtime_state ();
+      cleanup_dir base_path)
+    (fun () ->
+       AQ.For_testing.reset_runtime_state ();
+       let first = submit ~base_path ~keeper_name:"fifo-owner" ~input:(`Int 1) in
+       let second = submit ~base_path ~keeper_name:"fifo-owner" ~input:(`Int 2) in
+       let first = { (pending_entry_exn first) with requested_at = 500.0 } in
+       let second = { (pending_entry_exn second) with requested_at = 1.0 } in
+       match
+         Gate.For_testing.ready_auto_judges_for_owner
+           ~base_path
+           ~keeper_name:"fifo-owner"
+           [ second; first ]
+       with
+       | [ oldest; newest ] ->
+         Alcotest.(check string) "oldest sequence first" first.id oldest.id;
+         Alcotest.(check string) "next sequence second" second.id newest.id
+       | entries ->
+         Alcotest.failf "two same-owner entries expected, got %d" (List.length entries))
+;;
+
+let test_different_owners_claim_in_parallel () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Gate.For_testing.reset_active_auto_judges ();
+      AQ.For_testing.reset_runtime_state ();
+      cleanup_dir base_path)
+    (fun () ->
+       AQ.For_testing.reset_runtime_state ();
+       Gate.For_testing.reset_active_auto_judges ();
+       let owner_a =
+         pending_entry_exn (submit ~base_path ~keeper_name:"owner-a" ~input:(`Int 1))
+       in
+       let owner_a_next =
+         pending_entry_exn (submit ~base_path ~keeper_name:"owner-a" ~input:(`Int 2))
+       in
+       let owner_b =
+         pending_entry_exn (submit ~base_path ~keeper_name:"owner-b" ~input:(`Int 1))
+       in
+       Alcotest.(check bool) "first owner activates" true
+         (Gate.For_testing.claim_auto_judge owner_a);
+       Alcotest.(check bool) "same owner remains queued" false
+         (Gate.For_testing.claim_auto_judge owner_a_next);
+       Alcotest.(check bool) "different owner activates in parallel" true
+         (Gate.For_testing.claim_auto_judge owner_b);
+       Gate.For_testing.release_auto_judge owner_a;
+       Alcotest.(check bool) "same owner next activates after release" true
+         (Gate.For_testing.claim_auto_judge owner_a_next))
+;;
+
 let test_resolution_is_durable_and_origin_scoped () =
   let base_path = temp_dir () in
   let keeper_name = "queue-origin" in
@@ -1577,6 +1632,14 @@ let () =
             "durable sequence survives restart"
             `Quick
             test_monotonic_sequence_survives_restart
+        ; Alcotest.test_case
+            "same owner drains by durable sequence"
+            `Quick
+            test_same_owner_drain_uses_sequence_not_wall_clock
+        ; Alcotest.test_case
+            "different owners activate in parallel"
+            `Quick
+            test_different_owners_claim_in_parallel
         ; Alcotest.test_case
             "dedup keeps distinct origins"
             `Quick


### PR DESCRIPTION
## What changed

- Expose the existing owner-scoped Auto Judge selection and claim operations through a test-only module.
- Prove same-owner work drains by durable sequence even when wall-clock timestamps disagree.
- Prove different Keeper owners can claim work independently while the next item for the same owner remains queued.

## Why

The ordering leaf needs a direct proof that Lane-per-Keeper FIFO is real and that one Keeper cannot serialize or stop unrelated Keepers. The proof targets `Keeper_gate` owner filtering and claims; it does not exercise or restore deleted product/connector dispatch.

## Exact evidence

- Head SHA: `7c02f2bb86`
- Diff: **85 changed lines** (`85 additions / 0 deletions`)
- Base: `codex/gate-order-v8-20260718` at `164e47ee92`
- Stable patch-id remains `44e3a707153b992a30c8b1c0b1d2620f0db1136e`
- `git diff --check`: PASS
- `ocamlformat --check`: PASS
- OCaml parser (`ocamlc -stop-after parsing`): PASS

## Local focused build status

The original reconstruction did not run the focused build because the installed `agent_sdk` was then `0.216.2` while main required `>= 0.216.3`; the pin guard was not bypassed. Exact-head CI is the build authority.

## Stack

This is stacked leaf 2/2. It must remain based on `codex/gate-order-v8-20260718` until leaf 1 lands.

[근거] local exact-head diff/format/parser commands and `gh pr view 25136`; checked 2026-07-18 17:05 KST; confidence High.
