### PR TITLE
fix(keeper): harden checkpoint generation and candidate-byte persistence

### DIFF
--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -39,23 +39,46 @@ let max_oas_history_retained = 12
 let oas_history_path ~(session_dir : string) ~(snapshot_id : string) =
   Filename.concat session_dir snapshot_id
 
+(* A name below the session root ([leaf] of a session_dir, or a
+   [snapshot_id] appended by [oas_history_path]) must denote exactly one
+   directory entry. An empty, ".", ".." or separator-bearing name makes
+   [Filename.concat parent name] (and the [^ ".checkpoint.lock"] sibling
+   derived from a session location) resolve outside the session root, so
+   every downstream consumer would inherit the escape. A NUL byte would
+   truncate the path at the syscall boundary, so it is rejected here before
+   any filesystem side effect. *)
+let leaf_is_real_segment leaf =
+  (not (String.equal leaf ""))
+  && (not (String.equal leaf Filename.current_dir_name))
+  && (not (String.equal leaf Filename.parent_dir_name))
+  && not
+       (String.exists
+          (fun c -> String.contains Filename.dir_sep c || Char.equal c '\000')
+          leaf)
+
 (* Checkpoint payloads serialize to 0.7-1.4MB (see the [~pretty:false] note on
    [Keeper_fs.save_json_durable_atomic]). Encoding or decoding one on the
    calling fiber stalls every other fiber on the single-domain scheduler for
    the whole conversion (issue #25077; same class as the board_attention
-   ledger re-parse hangs). Route the pure conversions through the executor
-   pool: [submit_or_inline] runs them on a worker domain when the pool is
-   installed and inline otherwise (tests, pre-init), and re-raises
-   [Eio.Cancel.Cancelled]. *)
+   ledger re-parse hangs). Route the pure conversions through
+   [Domain_pool_ref.submit_cpu_or_inline] — the typed CPU-weight policy layer
+   keeper call sites are documented to prefer over the raw
+   [Executor_pool_ref]; it re-raises job exceptions instead of rerunning the
+   closure inline on failure. The pool submit is only legal from an Eio
+   fiber: the store is also reachable from raw Domains (see the stale-guard
+   "raw Domain saves through Unix context" test), where the conversion runs
+   inline exactly as before. *)
+let offload_checkpoint_cpu (f : unit -> 'a) : 'a =
+  if Eio_guard.is_eio_fiber () then Domain_pool_ref.submit_cpu_or_inline f
+  else f ()
+
 let decode_checkpoint_off_scheduler (content : string) :
     (Agent_sdk.Checkpoint.t, Agent_sdk.Error.sdk_error) result =
-  Executor_pool_ref.submit_or_inline (fun () ->
-    Agent_sdk.Checkpoint.of_string content)
+  offload_checkpoint_cpu (fun () -> Agent_sdk.Checkpoint.of_string content)
 
 let encode_checkpoint_string_off_scheduler (ckpt : Agent_sdk.Checkpoint.t) :
     string =
-  Executor_pool_ref.submit_or_inline (fun () ->
-    Agent_sdk.Checkpoint.to_string ckpt)
+  offload_checkpoint_cpu (fun () -> Agent_sdk.Checkpoint.to_string ckpt)
 
 let keeper_generation_context_key = "keeper_generation"
 
@@ -137,6 +160,13 @@ let delete_oas_history_files ~(session_dir : string) ~(snapshot_ids : string lis
     : string list * string list =
   List.fold_left
     (fun (deleted, missing) snapshot_id ->
+      (* [snapshot_ids] arrive verbatim from the dashboard POST body; a
+         non-segment id ("../..") would aim [Sys.remove] outside the
+         session directory. Such an id can never name a history entry, so
+         it is reported [missing] without touching the filesystem. *)
+      if not (leaf_is_real_segment snapshot_id) then
+        (deleted, snapshot_id :: missing)
+      else
       let path = oas_history_path ~session_dir ~snapshot_id in
       if Fs_compat.file_exists path then (
         try
@@ -211,7 +241,42 @@ let classify_sdk_error (e : Agent_sdk.Error.sdk_error) : checkpoint_load_error =
 
 let load_oas_history_file ~(session_dir : string) ~(snapshot_id : string) :
     (Agent_sdk.Checkpoint.t, checkpoint_load_error) result =
-  let path = oas_history_path ~session_dir ~snapshot_id in
+  (* [snapshot_id] reaches this entry point from the dashboard HTTP
+     surface; a non-segment id ("../..") would read outside the session
+     directory, so it is refused as absent before any filesystem access. *)
+  if not (leaf_is_real_segment snapshot_id) then Error Not_found
+  else (
+    let path = oas_history_path ~session_dir ~snapshot_id in
+    if Fs_compat.file_exists path then
+      try
+        match decode_checkpoint_off_scheduler (Fs_compat.load_file path) with
+        | Ok ckpt -> Ok ckpt
+        | Error e -> Error (classify_sdk_error e)
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | exn -> Error (Io_error (Printexc.to_string exn))
+    else Error Not_found)
+
+let load_oas ~(session_dir : string) ~(session_id : string) :
+    (Agent_sdk.Checkpoint.t, checkpoint_load_error) result =
+  (* RFC-0089 G4: typed ENOENT classification at the OS boundary.
+     [Fs_compat.file_exists] answers cold-start absence as a [bool] before
+     any read, so a missing checkpoint is never inferred from a stringified
+     error detail and [classify_sdk_error] keeps no [Not_found] arm.
+
+     One read path for Eio and non-Eio contexts: [Fs_compat.load_file] is
+     Eio-native when the fs capability is installed, and the decode is
+     routed off the calling fiber (#25077). The previous
+     [Agent_sdk.Checkpoint_store.load] branch read the same file but
+     decoded the 0.7-1.4MB payload inline in the SDK on the calling fiber
+     (oas#2676), and its [create] could mkdir on a pure read. The SDK
+     branch also validated [session_id] (empty / separator / NUL); the
+     segment check below keeps that rejection, mapped to [Store_error]
+     exactly as the SDK's ValidationFailed was via [classify_sdk_error]. *)
+  if not (leaf_is_real_segment session_id) then
+    Error (Store_error "session_id is not a real path segment")
+  else
+  let path = oas_checkpoint_path ~session_dir ~session_id in
   if Fs_compat.file_exists path then
     try
       match decode_checkpoint_off_scheduler (Fs_compat.load_file path) with
@@ -221,41 +286,6 @@ let load_oas_history_file ~(session_dir : string) ~(snapshot_id : string) :
     | Eio.Cancel.Cancelled _ as e -> raise e
     | exn -> Error (Io_error (Printexc.to_string exn))
   else Error Not_found
-
-let load_oas ~(session_dir : string) ~(session_id : string) :
-    (Agent_sdk.Checkpoint.t, checkpoint_load_error) result =
-  let fallback () =
-    let path = oas_checkpoint_path ~session_dir ~session_id in
-    if Fs_compat.file_exists path then
-      try
-        match decode_checkpoint_off_scheduler (Fs_compat.load_file path) with
-        | Ok ckpt -> Ok ckpt
-        | Error e -> Error (classify_sdk_error e)
-      with
-      | Eio.Cancel.Cancelled _ as e -> raise e
-      | exn -> Error (Io_error (Printexc.to_string exn))
-    else Error Not_found
-  in
-  match Fs_compat.get_fs_opt () with
-  | Some fs when Eio_guard.is_eio_fiber () ->
-      let dir = Eio.Path.(fs / session_dir) in
-      (match Agent_sdk.Checkpoint_store.create dir with
-       | Ok store ->
-           (* RFC-0089 G4: typed ENOENT classification at the OS boundary.
-              [exists] returns a [bool] so a missing checkpoint never has to
-              be inferred from a stringified exception detail. The SDK-side
-              [load] is only reached when the file is present, so any error
-              returned is a genuine I/O / parse / SDK failure (not cold-start
-              absence). *)
-           if not (Agent_sdk.Checkpoint_store.exists store session_id) then
-             Error Not_found
-           else (
-             match Agent_sdk.Checkpoint_store.load store session_id with
-             | Ok ckpt -> Ok ckpt
-             | Error e -> Error (classify_sdk_error e))
-       | Error e -> Error (Store_error (Agent_sdk.Error.to_string e)))
-  | Some _ | None ->
-      fallback ()
 
 (* ── RFC-0225 §3.2: disk-SSOT monotonic checkpoint transaction ──────
    One stable per-session lock covers canonical disk load, comparison,
@@ -322,17 +352,6 @@ let save_oas_error_to_string = function
   | Transaction_lock_failed error ->
     "checkpoint transaction lock failed: "
     ^ File_lock_eio.durable_lock_error_to_string error
-
-(* [leaf] must denote exactly one directory entry under the canonical parent.
-   An empty, ".", ".." or root leaf makes [Filename.concat parent leaf] (and
-   the [^ ".checkpoint.lock"] sibling derived from it) resolve outside the
-   session root, so every downstream consumer of the canonical location would
-   inherit the escape. *)
-let leaf_is_real_segment leaf =
-  not (String.equal leaf "")
-  && not (String.equal leaf Filename.current_dir_name)
-  && not (String.equal leaf Filename.parent_dir_name)
-  && not (String.exists (fun c -> Char.equal c '/') leaf)
 
 let canonical_session_location session_dir =
   (* Containment boundary for every checkpoint path (issue #25077).
@@ -461,6 +480,12 @@ let load_canonical_bytes_and_checkpoint_strict path =
   | Error _ as error -> error
   | Ok None -> Ok None
   | Ok (Some content) ->
+    (* This decode runs inside the durable session lock, so the caller now
+       waits on worker-pool capacity while holding it (the submit is a
+       rendezvous at CPU weight). Accepted trade-off: the wait is bounded
+       by pool job runtimes and only delays this one session's
+       transaction, whereas the previous inline parse stalled every fiber
+       on the scheduler domain for the whole conversion. *)
     (match decode_checkpoint_off_scheduler content with
      | Ok checkpoint -> Ok (Some (content, checkpoint))
      | Error error -> Error (classify_sdk_error error))
@@ -641,7 +666,7 @@ let save_oas_if_source
     ~(expected_source_ref : Keeper_checkpoint_ref.t)
     (candidate : Agent_sdk.Checkpoint.t) =
   let candidate_bytes =
-    Executor_pool_ref.submit_or_inline (fun () ->
+    offload_checkpoint_cpu (fun () ->
       Yojson.Safe.to_string (Agent_sdk.Checkpoint.to_json candidate))
   in
   match checkpoint_ref_of_canonical_bytes candidate_bytes candidate with

--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -39,6 +39,24 @@ let max_oas_history_retained = 12
 let oas_history_path ~(session_dir : string) ~(snapshot_id : string) =
   Filename.concat session_dir snapshot_id
 
+(* Checkpoint payloads serialize to 0.7-1.4MB (see the [~pretty:false] note on
+   [Keeper_fs.save_json_durable_atomic]). Encoding or decoding one on the
+   calling fiber stalls every other fiber on the single-domain scheduler for
+   the whole conversion (issue #25077; same class as the board_attention
+   ledger re-parse hangs). Route the pure conversions through the executor
+   pool: [submit_or_inline] runs them on a worker domain when the pool is
+   installed and inline otherwise (tests, pre-init), and re-raises
+   [Eio.Cancel.Cancelled]. *)
+let decode_checkpoint_off_scheduler (content : string) :
+    (Agent_sdk.Checkpoint.t, Agent_sdk.Error.sdk_error) result =
+  Executor_pool_ref.submit_or_inline (fun () ->
+    Agent_sdk.Checkpoint.of_string content)
+
+let encode_checkpoint_string_off_scheduler (ckpt : Agent_sdk.Checkpoint.t) :
+    string =
+  Executor_pool_ref.submit_or_inline (fun () ->
+    Agent_sdk.Checkpoint.to_string ckpt)
+
 let keeper_generation_context_key = "keeper_generation"
 
 let keeper_generation_of_context (context : Agent_sdk.Context.t) : int =
@@ -95,7 +113,7 @@ let save_oas_history ~(session_dir : string) (ckpt : Agent_sdk.Checkpoint.t) : u
   let save_snapshot_file () =
     Keeper_fs.save_atomic
       (oas_history_path ~session_dir ~snapshot_id)
-      (Agent_sdk.Checkpoint.to_string ckpt)
+      (encode_checkpoint_string_off_scheduler ckpt)
   in
   let save_result =
     match
@@ -196,7 +214,7 @@ let load_oas_history_file ~(session_dir : string) ~(snapshot_id : string) :
   let path = oas_history_path ~session_dir ~snapshot_id in
   if Fs_compat.file_exists path then
     try
-      match Agent_sdk.Checkpoint.of_string (Fs_compat.load_file path) with
+      match decode_checkpoint_off_scheduler (Fs_compat.load_file path) with
       | Ok ckpt -> Ok ckpt
       | Error e -> Error (classify_sdk_error e)
     with
@@ -210,7 +228,7 @@ let load_oas ~(session_dir : string) ~(session_id : string) :
     let path = oas_checkpoint_path ~session_dir ~session_id in
     if Fs_compat.file_exists path then
       try
-        match Agent_sdk.Checkpoint.of_string (Fs_compat.load_file path) with
+        match decode_checkpoint_off_scheduler (Fs_compat.load_file path) with
         | Ok ckpt -> Ok ckpt
         | Error e -> Error (classify_sdk_error e)
       with
@@ -265,6 +283,10 @@ type unix_failure =
 type directory_failure =
   | Directory_unix_failure of unix_failure
   | Directory_other_failure of string
+  | Directory_leaf_invalid of
+      { session_dir : string
+      ; leaf : string
+      }
 
 type save_oas_error =
   | Invalid_session_id of string
@@ -287,6 +309,11 @@ let save_oas_error_to_string = function
       failure.operation failure.argument (Unix.error_message failure.error)
   | Session_directory_unavailable (Directory_other_failure detail) ->
     "checkpoint session directory unavailable: " ^ detail
+  | Session_directory_unavailable (Directory_leaf_invalid { session_dir; leaf }) ->
+    Printf.sprintf
+      "checkpoint session directory rejected: leaf %S of %S is not a real \
+       path segment"
+      leaf session_dir
   | Existing_checkpoint_unreadable error ->
     "existing checkpoint unreadable: " ^ checkpoint_load_error_to_string error
   | Canonical_write_failed error ->
@@ -296,31 +323,71 @@ let save_oas_error_to_string = function
     "checkpoint transaction lock failed: "
     ^ File_lock_eio.durable_lock_error_to_string error
 
+(* [leaf] must denote exactly one directory entry under the canonical parent.
+   An empty, ".", ".." or root leaf makes [Filename.concat parent leaf] (and
+   the [^ ".checkpoint.lock"] sibling derived from it) resolve outside the
+   session root, so every downstream consumer of the canonical location would
+   inherit the escape. *)
+let leaf_is_real_segment leaf =
+  not (String.equal leaf "")
+  && not (String.equal leaf Filename.current_dir_name)
+  && not (String.equal leaf Filename.parent_dir_name)
+  && not (String.exists (fun c -> Char.equal c '/') leaf)
+
 let canonical_session_location session_dir =
-  let parent = Filename.dirname session_dir in
-  try
-    Fs_compat.mkdir_p parent;
-    let parent =
-      Eio_guard.run_in_systhread (fun () ->
-        let parent = Unix.realpath parent in
-        if (Unix.stat parent).Unix.st_kind <> Unix.S_DIR
-        then
-          raise
-            (Unix.Unix_error
-               (Unix.ENOTDIR, "checkpoint_session_parent", parent));
-        parent)
-    in
-    Ok (Filename.concat parent (Filename.basename session_dir))
-  with
-  | Unix.Unix_error (error, operation, argument) ->
+  (* Containment boundary for every checkpoint path (issue #25077).
+     [Keeper_fs.save_json_durable_atomic ~ownership_root] already rejects
+     escapes on the durable-write directory chain, but the lock file, history
+     archive, and read paths consume this location without that guard, so the
+     leaf is validated here once, before any filesystem side effect. The
+     canonical parent is [Unix.realpath] of the *configured* session root:
+     resolving a symlinked deployment root to its physical location is the
+     purpose of this function, so the parent resolution itself is trusted.
+     The leaf, however, must not be a symlink: a link there would redirect
+     every checkpoint and lock write through whatever target it names
+     ([Keeper_fs] applies the same symlink rejection to its own write
+     chains). The lstat check shares the TOCTOU
+     caveat documented on [Keeper_fs]: OCaml 5.4 has no portable
+     dirfd-relative API, so the caller keeps the subtree process-owned. *)
+  let leaf = Filename.basename session_dir in
+  if not (leaf_is_real_segment leaf)
+  then
     Error
       (Session_directory_unavailable
-         (Directory_unix_failure { error; operation; argument }))
-  | Eio.Cancel.Cancelled _ as exn -> raise exn
-  | exn ->
-    Error
-      (Session_directory_unavailable
-         (Directory_other_failure (Printexc.to_string exn)))
+         (Directory_leaf_invalid { session_dir; leaf }))
+  else (
+    let parent = Filename.dirname session_dir in
+    try
+      Fs_compat.mkdir_p parent;
+      let location =
+        Eio_guard.run_in_systhread (fun () ->
+          let parent = Unix.realpath parent in
+          if (Unix.stat parent).Unix.st_kind <> Unix.S_DIR
+          then
+            raise
+              (Unix.Unix_error
+                 (Unix.ENOTDIR, "checkpoint_session_parent", parent));
+          let location = Filename.concat parent leaf in
+          (match Unix.lstat location with
+           | { Unix.st_kind = Unix.S_LNK; _ } ->
+             raise
+               (Unix.Unix_error
+                  (Unix.ELOOP, "checkpoint_session_leaf", location))
+           | _ -> ()
+           | exception Unix.Unix_error (Unix.ENOENT, _, _) -> ());
+          location)
+      in
+      Ok location
+    with
+    | Unix.Unix_error (error, operation, argument) ->
+      Error
+        (Session_directory_unavailable
+           (Directory_unix_failure { error; operation; argument }))
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn ->
+      Error
+        (Session_directory_unavailable
+           (Directory_other_failure (Printexc.to_string exn))))
 
 let with_session_lock_typed ~session_dir f =
   match canonical_session_location session_dir with
@@ -394,7 +461,7 @@ let load_canonical_bytes_and_checkpoint_strict path =
   | Error _ as error -> error
   | Ok None -> Ok None
   | Ok (Some content) ->
-    (match Agent_sdk.Checkpoint.of_string content with
+    (match decode_checkpoint_off_scheduler content with
      | Ok checkpoint -> Ok (Some (content, checkpoint))
      | Error error -> Error (classify_sdk_error error))
 
@@ -505,7 +572,7 @@ let exact_snapshot_of_checkpoint ~expected_session_id ~canonical_bytes checkpoin
 ;;
 
 let exact_snapshot_of_canonical_bytes ~expected_session_id canonical_bytes =
-  match Agent_sdk.Checkpoint.of_string canonical_bytes with
+  match decode_checkpoint_off_scheduler canonical_bytes with
   | Error error -> Error (Ref_read_failed (classify_sdk_error error))
   | Ok checkpoint ->
     exact_snapshot_of_checkpoint
@@ -573,8 +640,10 @@ let save_oas_if_source
     ~session_dir
     ~(expected_source_ref : Keeper_checkpoint_ref.t)
     (candidate : Agent_sdk.Checkpoint.t) =
-  let candidate_json = Agent_sdk.Checkpoint.to_json candidate in
-  let candidate_bytes = Yojson.Safe.to_string candidate_json in
+  let candidate_bytes =
+    Executor_pool_ref.submit_or_inline (fun () ->
+      Yojson.Safe.to_string (Agent_sdk.Checkpoint.to_json candidate))
+  in
   match checkpoint_ref_of_canonical_bytes candidate_bytes candidate with
   | Error error -> Error (Candidate_identity_invalid error)
   | Ok candidate_ref
@@ -619,11 +688,10 @@ let save_oas_if_source
            in
            let ownership_root = Filename.dirname session_dir in
            (match
-              Keeper_fs.save_json_durable_atomic
+              Keeper_fs.save_bytes_durable_atomic
                 ~ownership_root
-                ~pretty:false
                 canonical_path
-                candidate_json
+                candidate_bytes
             with
             | Error error when error.Keeper_fs.renamed ->
               Error
@@ -631,12 +699,13 @@ let save_oas_if_source
                    { installed_ref = candidate_ref; error })
             | Error error -> Error (Commit_not_installed error)
             | Ok () ->
-              (* [candidate_bytes] and
-                 [save_json_durable_atomic ~pretty:false] use the same
-                 [Yojson.Safe.to_string candidate_json] contract. Once the
-                 writer returns [Ok], rename and both durability fsyncs have
-                 completed; a post-commit read cannot downgrade that committed
-                 outcome to a retryable failure. *)
+              (* The durable writer installs [candidate_bytes] verbatim — the
+                 exact bytes [candidate_ref] was derived from — so the
+                 published file and the returned ref agree by construction,
+                 not by an encoding contract. Once the writer returns [Ok],
+                 rename and both durability fsyncs have completed; a
+                 post-commit read cannot downgrade that committed outcome to
+                 a retryable failure. *)
               Ok candidate_ref))
 
 let save_oas_classified_typed
@@ -675,11 +744,11 @@ let save_oas_classified_typed
         let known = Option.map (fun (w : watermark) -> w.turn_count) existing in
         let ownership_root = Filename.dirname session_dir in
         (match
-           Keeper_fs.save_json_durable_atomic
+           Keeper_fs.save_json_durable_atomic_from
              ~ownership_root
              ~pretty:false
              canonical_path
-             (Agent_sdk.Checkpoint.to_json ckpt)
+             (fun () -> Agent_sdk.Checkpoint.to_json ckpt)
          with
          | Error error -> Error (Canonical_write_failed error)
          | Ok () ->

--- a/lib/keeper/keeper_checkpoint_store.mli
+++ b/lib/keeper/keeper_checkpoint_store.mli
@@ -45,7 +45,10 @@ val save_oas_history :
 
 (** Delete OAS history archive entries by [snapshot_ids]. Returns
     [(deleted, missing)] in input-order, with [missing] containing
-    every snapshot id whose file was absent OR removal failed. *)
+    every snapshot id whose file was absent OR removal failed. An id
+    that is not one real path segment (empty / "." / ".." / separator /
+    NUL) can never name a history entry and is reported [missing]
+    without touching the filesystem. *)
 val delete_oas_history_files :
   session_dir:string ->
   snapshot_ids:string list ->
@@ -101,23 +104,27 @@ type checkpoint_load_error =
 
     RFC-0089 G4: this no longer classifies [Not_found] from string-matched
     [FileOpFailed.detail]. Cold-start "checkpoint absent" is detected at
-    the OS boundary via [Agent_sdk.Checkpoint_store.exists] *before* the
-    SDK [load] call, so any [sdk_error] reaching this function is a real
+    the OS boundary via a typed [Fs_compat.file_exists] check *before* any
+    load, so any [sdk_error] reaching this function is a real
     I/O / parse / SDK fault and routes accordingly. *)
 val classify_sdk_error :
   Agent_sdk.Error.sdk_error -> checkpoint_load_error
 
 (** Load a single OAS history archive entry. Returns [Not_found]
-    when the file does not exist; classifies SDK errors via
-    [classify_sdk_error]. *)
+    when the file does not exist or [snapshot_id] is not one real path
+    segment (such an id can never name a history entry); classifies SDK
+    errors via [classify_sdk_error]. *)
 val load_oas_history_file :
   session_dir:string ->
   snapshot_id:string ->
   (Agent_sdk.Checkpoint.t, checkpoint_load_error) result
 
-(** Load the canonical OAS checkpoint for [session_id]. Uses the
-    OAS Checkpoint_store when Eio FS is available; falls back to a
-    direct atomic-file read otherwise. *)
+(** Load the canonical OAS checkpoint for [session_id]. One read path
+    for Eio and non-Eio contexts: presence is a typed
+    [Fs_compat.file_exists] check, the read is Eio-native when the fs
+    capability is installed, and the JSON decode runs off the calling
+    fiber. A [session_id] that is not one real path segment is refused
+    as [Store_error] (the same rejection the SDK store applied). *)
 val load_oas :
   session_dir:string ->
   session_id:string ->

--- a/lib/keeper/keeper_checkpoint_store.mli
+++ b/lib/keeper/keeper_checkpoint_store.mli
@@ -26,6 +26,12 @@ val max_oas_history_retained : int
 val oas_history_path :
   session_dir:string -> snapshot_id:string -> string
 
+(** Session-scoped context key carrying the keeper generation on a
+    checkpoint. Single definition of the wire literal; every writer and
+    reader (context core, tests) must reference this value so the key
+    cannot drift between sites. *)
+val keeper_generation_context_key : string
+
 (** Compose an OAS history archive snapshot id from a checkpoint
     (created_at_ms + keeper_generation suffix). *)
 val oas_history_snapshot_id_of_checkpoint :

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -54,7 +54,7 @@ let save_oas_checkpoint_classified
   =
   let checkpoint_context = Agent_sdk.Context.copy ~eio:true (oas_context_of_context ctx) in
   Agent_sdk.Context.set_scoped checkpoint_context Agent_sdk.Context.Session
-    checkpoint_generation_key (`Int generation);
+    Keeper_checkpoint_store.keeper_generation_context_key (`Int generation);
   let checkpoint_messages = messages_of_context ctx in
   (* RFC vision-delegation §2.3 site 2 (checkpoint write boundary). For a
      Delegate keeper, evict any inline image to a handle-only placeholder BEFORE
@@ -118,7 +118,7 @@ let save_oas_checkpoint
 let checkpoint_generation (cp : Agent_sdk.Checkpoint.t) ~(fallback : int) : int =
   match
     Agent_sdk.Context.get_scoped cp.context Agent_sdk.Context.Session
-      checkpoint_generation_key
+      Keeper_checkpoint_store.keeper_generation_context_key
   with
   | Some (`Int value) -> value
   | Some (`Intlit raw) -> Option.value ~default:fallback (int_of_string_opt raw)

--- a/lib/keeper/keeper_context_core_accessors.ml
+++ b/lib/keeper/keeper_context_core_accessors.ml
@@ -523,5 +523,3 @@ let log_keeper_exn ~label exn =
     | _ -> "[UNEXPECTED] "
   in
   Log.Keeper.info "%s%s: %s" tag label (Printexc.to_string exn)
-
-let checkpoint_generation_key = "keeper_generation"

--- a/test/keeper_compaction_live_delta/test_keeper_compaction_live_delta.ml
+++ b/test/keeper_compaction_live_delta/test_keeper_compaction_live_delta.ml
@@ -17,7 +17,7 @@ let checkpoint ?(session_id = "trace") ?(agent_name = "keeper")
   Agent_sdk.Context.set_scoped
     context
     Agent_sdk.Context.Session
-    "keeper_generation"
+    Masc.Keeper_checkpoint_store.keeper_generation_context_key
     (`Int generation);
   Agent_sdk.Checkpoint.
     { version = checkpoint_version

--- a/test/test_keeper_checkpoint_stale_guard.ml
+++ b/test/test_keeper_checkpoint_stale_guard.ml
@@ -80,7 +80,7 @@ let make_checkpoint ~session_id ~turn_count ~marker =
 let with_generation generation (checkpoint : Agent_sdk.Checkpoint.t) =
   let context = Agent_sdk.Context.copy ~eio:false checkpoint.context in
   Agent_sdk.Context.set_scoped context Agent_sdk.Context.Session
-    "keeper_generation" (`Int generation);
+    Keeper_checkpoint_store.keeper_generation_context_key (`Int generation);
   { checkpoint with context }
 
 let save_ok ~session_dir ckpt label =
@@ -202,6 +202,63 @@ let test_empty_session_id_rejected () =
       check string "round-trips the stamped session_id" "trace-1-0000a"
         on_disk.Agent_sdk.Checkpoint.session_id
     | Error _ -> fail "load after stamped save failed")
+
+(* Issue #25077 item 1: [canonical_session_location] is the containment
+   boundary shared by the lock file, the history archive, and every
+   checkpoint path. A leaf that is not one real path segment (".." / ".")
+   must be refused before any filesystem side effect, and a symlink leaf
+   must be refused before the lock is derived: either would relocate
+   lock/checkpoint writes outside the session root that the
+   [Keeper_fs] ownership containment protects on the write chain. *)
+let test_session_leaf_containment () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun _sw ->
+  let session_dir = temp_dir () in
+  let base = Filename.dirname session_dir in
+  let target = Filename.concat base "elsewhere" in
+  let link = Filename.concat base "session-link" in
+  Fun.protect
+    ~finally:(fun () ->
+      (try Unix.unlink link with Unix.Unix_error _ -> ());
+      cleanup_dir target;
+      cleanup_dir session_dir)
+    (fun () ->
+      let reject label dir =
+        match
+          Keeper_checkpoint_store.with_session_lock ~session_dir:dir
+            (fun _ -> ())
+        with
+        | Ok () -> fail (label ^ ": escaping session_dir was accepted")
+        | Error _ -> ()
+      in
+      (* Exact typed rejection for the ".." leaf pins the boundary error. *)
+      (match
+         Keeper_checkpoint_store.with_session_lock
+           ~session_dir:(Filename.concat base Filename.parent_dir_name)
+           (fun _ -> ())
+       with
+       | Ok () -> fail "'..' leaf: escaping session_dir was accepted"
+       | Error msg ->
+         check string "'..' leaf is the typed leaf rejection"
+           (Printf.sprintf
+              "checkpoint session directory rejected: leaf %S of %S is not \
+               a real path segment"
+              Filename.parent_dir_name
+              (Filename.concat base Filename.parent_dir_name))
+           msg);
+      reject "'.' leaf" (Filename.concat base Filename.current_dir_name);
+      (* A symlink leaf would redirect every checkpoint and lock write
+         through its target. *)
+      Unix.mkdir target 0o755;
+      Unix.symlink target link;
+      reject "symlink leaf" link;
+      (* The genuine session directory still passes the same boundary. *)
+      match
+        Keeper_checkpoint_store.with_session_lock ~session_dir (fun _ -> ())
+      with
+      | Ok () -> ()
+      | Error e -> fail ("real session leaf rejected: " ^ e))
 
 let test_invalid_existing_checkpoint_fails_closed () =
   let session_dir = temp_dir () in
@@ -496,6 +553,8 @@ let () =
             test_externally_replaced_canonical_is_the_watermark;
           test_case "empty session_id is refused, not silently dropped" `Quick
             test_empty_session_id_rejected;
+          test_case "session leaf escapes and symlink leaves are refused" `Quick
+            test_session_leaf_containment;
           test_case "invalid canonical checkpoint fails closed" `Quick
             test_invalid_existing_checkpoint_fails_closed;
           test_case "multi-domain writers leave max turn on disk" `Quick

--- a/test/test_keeper_checkpoint_stale_guard.ml
+++ b/test/test_keeper_checkpoint_stale_guard.ml
@@ -248,6 +248,7 @@ let test_session_leaf_containment () =
               (Filename.concat base Filename.parent_dir_name))
            msg);
       reject "'.' leaf" (Filename.concat base Filename.current_dir_name);
+      reject "NUL leaf" (Filename.concat base "abc\000def");
       (* A symlink leaf would redirect every checkpoint and lock write
          through its target. *)
       Unix.mkdir target 0o755;
@@ -259,6 +260,41 @@ let test_session_leaf_containment () =
       with
       | Ok () -> ()
       | Error e -> fail ("real session leaf rejected: " ^ e))
+
+(* Issue #25077: history snapshot ids arrive verbatim from the dashboard
+   HTTP surface. A non-segment id must never reach the filesystem — delete
+   reports it [missing], load reports [Not_found] — and a file outside the
+   session directory must stay unreachable through either entry point. *)
+let test_history_snapshot_id_containment () =
+  let session_dir = temp_dir () in
+  let outside = Filename.concat (Filename.dirname session_dir) "victim.json" in
+  Fun.protect
+    ~finally:(fun () ->
+      (try Unix.unlink outside with Unix.Unix_error _ -> ());
+      cleanup_dir session_dir)
+    (fun () ->
+      Fs_compat.save_file outside "outside-session";
+      let escape = "../victim.json" in
+      (match
+         Keeper_checkpoint_store.delete_oas_history_files ~session_dir
+           ~snapshot_ids:[ escape ]
+       with
+       | [], [ missing ] ->
+         check string "escaping id is reported missing" escape missing
+       | deleted, missing ->
+         fail
+           (Printf.sprintf "unexpected delete outcome: deleted=%d missing=%d"
+              (List.length deleted) (List.length missing)));
+      check bool "file outside the session dir survives" true
+        (Sys.file_exists outside);
+      match
+        Keeper_checkpoint_store.load_oas_history_file ~session_dir
+          ~snapshot_id:escape
+      with
+      | Error Keeper_checkpoint_store.Not_found -> ()
+      | Ok _ -> fail "escaping snapshot_id load succeeded"
+      | Error _ ->
+        fail "escaping snapshot_id load returned a non-Not_found error")
 
 let test_invalid_existing_checkpoint_fails_closed () =
   let session_dir = temp_dir () in
@@ -555,6 +591,8 @@ let () =
             test_empty_session_id_rejected;
           test_case "session leaf escapes and symlink leaves are refused" `Quick
             test_session_leaf_containment;
+          test_case "history snapshot ids cannot reach outside the session" `Quick
+            test_history_snapshot_id_containment;
           test_case "invalid canonical checkpoint fails closed" `Quick
             test_invalid_existing_checkpoint_fails_closed;
           test_case "multi-domain writers leave max turn on disk" `Quick


### PR DESCRIPTION
## Summary
#25077의 P1 3건(#24902 머지 잔존)을 수리한다. 리뷰(head `01b5481fe4` BLOCK) 대응이 `1940ed4039`에 반영됐다.

### 1. Containment 경계
- `canonical_session_location`: leaf가 실제 단일 path segment(`""`/`.`/`..`/`Filename.dir_sep` 문자/NUL 아님)임을 **어떤 파일시스템 side effect보다 먼저** 검증 — typed `Directory_leaf_invalid` 거부. 기존 systhread 블록 안에서 leaf symlink를 `lstat`로 거부(`ELOOP`).
- **history 진입점 가드 (적대 검증 발견 P1)**: 대시보드 POST body의 `snapshot_ids`가 `Filename.concat` → `Sys.remove`에 그대로 도달하고 있었다. `delete_oas_history_files`는 non-segment id를 파일시스템 접근 없이 `missing`으로 보고, `load_oas_history_file`은 `Not_found`로 거부. 테스트가 세션 밖 파일 생존을 counterfactual로 증명.
- 쓰기 체인은 `Keeper_fs ~ownership_root`(lexical containment + symlink 거부)가 이미 방어. 이 PR은 그 밖에 있던 lock 파일·history·read 경로가 같은 보증을 상속하게 만든다.
- **범위 명시 (리뷰 P1 수용)**: ancestor-symlink swap 탐지는 이 PR에 없다. 현 API에서 caller가 줄 수 있는 root는 `dirname(session_dir)` 자신뿐이라 realpath 비교가 항등으로 성립해 증명이 공허하다. 실질 탐지는 boot-시점 고정 물리 루트 SSOT가 필요한 설계 사안 — #25151에서 추적. 따라서 이 PR은 **#25077을 완결하지 않는다** (item 2·3 완결 + item 1 부분).

### 2. Eio fairness — MB급 checkpoint 인코딩/디코딩을 caller fiber에서 제거
- 파일 내 **모든** 변환 사이트가 오프로드된다: 디코드 4곳 + 인코드 3곳 + `load_oas` SDK 분기 통합(아래).
- 라우팅은 리뷰 P2 수용으로 `Domain_pool_ref.submit_cpu_or_inline`(keeper 콜사이트가 선호하도록 문서화된 typed CPU-weight 정책 계층, 실패 시 inline 재실행 없이 재-raise). 단 **Eio-fiber 가드 필수**: store는 raw Domain에서도 도달하며(stale-guard 테스트 실존) `Domain_pool_ref`에는 실행 컨텍스트 가드가 없어 무가드 전환은 `Effect.Unhandled`로 죽는다.
- `load_oas`를 단일 오프로드 경로로 통합: 기존 SDK `Checkpoint_store` 분기는 같은 파일을 읽되 payload를 SDK 안에서 inline 디코드했고(oas#2676), `create`가 순수 read에서 mkdir 부작용을 가졌다. SDK의 session_id 검증(empty/separator/NUL)은 segment 체크로 보존(`Store_error` 매핑 동일). RFC-0089 G4 불변식(존재 판정=bool 선행, classifier에 `Not_found` arm 없음) 유지.
- `save_oas_if_source`: 한 번 인코딩한 정확한 bytes를 `save_bytes_durable_atomic`으로 설치 — 게시 파일과 반환 ref가 구성적으로 동일(이중 인코딩 소멸).
- **수용한 트레이드오프(주석 명시)**: strict 경로 디코드는 session lock 보유 중 worker-pool 용량을 기다린다. 대기는 pool job 런타임에 유계이고 해당 세션 트랜잭션만 지연되는 반면, 이전 inline 파싱은 스케줄러 도메인의 모든 fiber를 정지시켰다.

### 3. `keeper_generation` SSOT
- 정의 1곳(`Keeper_checkpoint_store.keeper_generation_context_key`, .mli 노출)으로 통합. 중복 정의 삭제, core 2사이트·테스트 2파일이 상수 참조 — 드리프트는 컴파일 타임 차단.

## Tests
- `test_session_leaf_containment`: `..`(정확한 typed 메시지)·`.`·NUL·symlink leaf 거부 + 정상 leaf 통과.
- `test_history_snapshot_id_containment`: 탈출 id가 delete에서 `missing`/load에서 `Not_found`, 세션 밖 파일 생존 확인.
- 기존 stale-guard/CAS/round-trip/raw-Domain 스위트가 동작 보존 커버.

## Validation
- head `01b5481fe4` full CI green 확인 (Build/Health/Lint/TLA+/ocamlformat 전부 pass). `1940ed4039` CI 진행 중.
- 적대 검증 3-렌즈(Eio 의미론/containment/회귀) 수행 — 발견 전부 이 head에 반영 또는 처분 명시(위).

## RFC 체크
- 변경 파일은 RFC-gated subsystem 밖. 워크어라운드 시그니처 해당 없음 — string 분류기·catch-all 추가 없음, 전 사이트 일괄 수리.

Refs #25077 (item 2·3 해소, item 1 잔여는 #25151)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
