### PR TITLE
fix(runtime): preserve health-verified startup artifact

### DIFF
--- a/docs/design/2026-07-18-supervised-runtime-lkg-operation-matrix.html
+++ b/docs/design/2026-07-18-supervised-runtime-lkg-operation-matrix.html
@@ -1,0 +1,138 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>MASC Supervised Runtime LKG Operation Matrix</title>
+  <style>
+    :root { color-scheme: dark; --bg:#0a0f18; --panel:#111a27; --line:#2b3b50; --text:#e9f0f8; --muted:#9fb0c2; --good:#57d39b; --warn:#ffc857; --bad:#ff6b6b; --accent:#70a5ff; }
+    * { box-sizing: border-box; }
+    body { margin:0; background:var(--bg); color:var(--text); font:15px/1.55 ui-sans-serif,system-ui,-apple-system,sans-serif; }
+    main { max-width:1320px; margin:auto; padding:36px 24px 80px; }
+    h1 { font-size:32px; margin:0 0 8px; }
+    h2 { margin:34px 0 12px; font-size:21px; }
+    h3 { margin:0 0 8px; font-size:16px; }
+    p { margin:8px 0; }
+    code { color:#cfe0ff; background:#182438; padding:2px 5px; border-radius:4px; }
+    .muted { color:var(--muted); }
+    .grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(250px,1fr)); gap:12px; }
+    .card { background:var(--panel); border:1px solid var(--line); border-radius:10px; padding:16px; }
+    .metric { font-size:26px; font-weight:750; }
+    .good { color:var(--good); } .warn { color:var(--warn); } .bad { color:var(--bad); } .accent { color:var(--accent); }
+    table { width:100%; border-collapse:collapse; background:var(--panel); }
+    th,td { border:1px solid var(--line); padding:10px; text-align:left; vertical-align:top; }
+    th { background:#172335; color:#dce8f7; }
+    .flow { display:flex; flex-wrap:wrap; align-items:center; gap:8px; }
+    .node { border:1px solid var(--line); background:var(--panel); padding:10px 13px; border-radius:8px; }
+    .arrow { color:var(--accent); font-weight:800; }
+    ul,ol { margin:7px 0 0 20px; padding:0; }
+    .gate { border-left:4px solid var(--warn); }
+    .fail { border-left:4px solid var(--bad); }
+    .pass { border-left:4px solid var(--good); }
+  </style>
+</head>
+<body>
+<main>
+  <h1>MASC Supervised Runtime LKG Operation Matrix</h1>
+  <p class="muted">Issue #25133 · 2026-07-18 · AFK control-plane availability slice · no prose matching, no stale-binary trust</p>
+
+  <section class="grid">
+    <article class="card fail"><h3>AS-IS availability</h3><div class="metric bad">0 listener</div><p>8935 connection refused while the supervisor process remained alive.</p></article>
+    <article class="card fail"><h3>AS-IS amplification</h3><div class="metric bad">1–37 sec</div><p>Every child exited and was retried after a fixed five-second cooldown.</p></article>
+    <article class="card pass"><h3>TO-BE startup failure</h3><div class="metric good">1 attempt</div><p>No candidate or no PID-bound health proof means a terminal, operator-visible startup state.</p></article>
+    <article class="card pass"><h3>TO-BE fallback authority</h3><div class="metric good">SHA-256</div><p>Only an exact health-promoted artifact may bypass a failed rebuild.</p></article>
+  </section>
+
+  <h2>1. 제품 약속과 판정 기준</h2>
+  <table>
+    <thead><tr><th>고객 약속</th><th>Hard gate</th><th>현재</th><th>이 PR 이후</th></tr></thead>
+    <tbody>
+      <tr><td>운영자가 AFK여도 supervisor가 실제 서비스를 유지한다.</td><td>supervisor alive가 아니라 HTTP listener와 health proof가 존재</td><td class="bad">실패</td><td class="warn">build-contention 경로 개선, 장시간 soak 필요</td></tr>
+      <tr><td>개발 빌드가 production-like runtime을 임의로 교체하지 않는다.</td><td>실행 artifact hash가 이전 health proof와 exact match</td><td class="bad">mtime 기반 stale 판정뿐</td><td class="good">typed descriptor + SHA-256</td></tr>
+      <tr><td>복구 불가능한 startup failure를 무한 증폭하지 않는다.</td><td>candidate 미발행 시 동일 child 재실행 0회</td><td class="bad">무한 반복</td><td class="good">terminal exit, 원래 exit code 보존</td></tr>
+      <tr><td>새 코드가 실패해도 검증되지 않은 stale binary를 몰래 실행하지 않는다.</td><td>descriptor schema/path/mode/port/hash 전부 검증</td><td class="warn">수동 opt-in stale 실행 가능</td><td class="good">supervised fallback은 exact LKG만</td></tr>
+    </tbody>
+  </table>
+
+  <h2>2. AS-IS → TO-BE 코드 Matrix</h2>
+  <table>
+    <thead><tr><th>축</th><th>AS-IS</th><th>TO-BE</th><th>결정 권한</th></tr></thead>
+    <tbody>
+      <tr><td>빌드 실패</td><td><code>build_dune_target_with_lock</code>가 typed 75를 1로 소실</td><td>원래 status를 보존</td><td><code>dune-local.sh</code> exit taxonomy</td></tr>
+      <tr><td>실행 후보</td><td>선택된 path만 stderr에 출력</td><td>exec 직전 schema v1 descriptor를 atomic publish</td><td><code>start-masc.sh</code></td></tr>
+      <tr><td>정상성</td><td>child가 떠 있거나 포트가 열리면 암묵적 성공</td><td>listener PID = supervised child PID AND <code>/health</code> success</td><td>process supervisor</td></tr>
+      <tr><td>LKG 승격</td><td>없음</td><td>candidate bytes를 다시 hash하고 descriptor를 atomic promote</td><td>process supervisor</td></tr>
+      <tr><td>fallback</td><td>환경변수로 알려지지 않은 stale executable 허용 가능</td><td>schema와 SHA가 일치하는 health-promoted artifact만 선택</td><td>artifact contract SSOT</td></tr>
+      <tr><td>retry</td><td>모든 child exit를 동일하게 무한 반복</td><td>PID-bound health proof 없는 exit는 terminal; proof가 있는 runtime exit만 restart 대상</td><td>process supervisor FSM</td></tr>
+    </tbody>
+  </table>
+
+  <h2>3. 메커니즘과 순서</h2>
+  <div class="flow">
+    <span class="node">Build/Select executable</span><span class="arrow">→</span>
+    <span class="node">Hash exact bytes</span><span class="arrow">→</span>
+    <span class="node">Publish candidate.v1</span><span class="arrow">→</span>
+    <span class="node">exec child</span><span class="arrow">→</span>
+    <span class="node">PID-bound listener proof</span><span class="arrow">→</span>
+    <span class="node">HTTP health proof</span><span class="arrow">→</span>
+    <span class="node">Atomic LKG promote</span>
+  </div>
+  <p>Correctness는 polling 횟수나 대기 시간으로 결정하지 않는다. probe cadence는 관찰 지연만 바꾸며, 승격 조건은 PID·health·hash의 논리곱이다. timeout이 지나면 성공으로 간주하는 경로는 없다.</p>
+
+  <h2>4. Descriptor v1 불변식</h2>
+  <table>
+    <thead><tr><th>필드</th><th>허용값</th><th>거부 조건</th></tr></thead>
+    <tbody>
+      <tr><td>schema</td><td><code>masc.runtime_artifact.v1</code></td><td>다른 버전, 추가 line, 누락 line</td></tr>
+      <tr><td>mode</td><td><code>http</code></td><td>unknown/stdio/free-form</td></tr>
+      <tr><td>path</td><td>absolute executable path</td><td>relative path, CR/LF, missing, non-executable</td></tr>
+      <tr><td>sha256</td><td>64 lowercase hex</td><td>길이/문자 불일치 또는 실제 bytes mismatch</td></tr>
+      <tr><td>port</td><td>1..65535 integer</td><td>문자열, 범위 밖 값</td></tr>
+    </tbody>
+  </table>
+
+  <h2>5. Crash/Failure Matrix</h2>
+  <table>
+    <thead><tr><th>사건</th><th>관측 상태</th><th>행동</th><th>금지 행동</th></tr></thead>
+    <tbody>
+      <tr><td>bare Dune으로 build status 75</td><td>valid LKG 있음</td><td>LKG hash 재검증 후 실행</td><td>error text parsing, 임의 stale path</td></tr>
+      <tr><td>bare Dune으로 build status 75</td><td>LKG 없음/불일치</td><td>candidate 미발행, terminal 75</td><td>5초마다 dashboard/build 재실행</td></tr>
+      <tr><td>compile failure</td><td>valid LKG 있음</td><td>기존 건강 artifact로 가용성 유지, 오류 노출</td><td>새 실패 artifact 승격</td></tr>
+      <tr><td>다른 프로세스가 같은 포트 health 응답</td><td>listener PID ≠ child PID</td><td>승격하지 않음</td><td>HTTP 200만으로 LKG 인정</td></tr>
+      <tr><td>health 직전 executable 교체</td><td>candidate hash ≠ 현재 bytes</td><td>승격 거부 및 ERROR</td><td>path identity를 byte identity로 간주</td></tr>
+      <tr><td>candidate가 exec 전에 실패</td><td>descriptor 있음, health proof 없음</td><td>terminal state</td><td>candidate 존재만으로 무한 restart</td></tr>
+      <tr><td>health-promoted runtime이 이후 crash</td><td>candidate 발행됨</td><td>기존 continuous restart 책임 유지</td><td>startup failure로 오분류</td></tr>
+    </tbody>
+  </table>
+
+  <h2>6. 정량 Goal / Evidence Matrix</h2>
+  <table>
+    <thead><tr><th>Metric</th><th>Before</th><th>PR gate</th><th>Release gate</th><th>증거</th></tr></thead>
+    <tbody>
+      <tr><td>build-contention startup attempts</td><td>관찰 구간에서 반복, 1–37초 uptime</td><td>valid LKG 없음: exactly 1</td><td>24h duplicate attempt = 0</td><td>supervisor integration test + logs</td></tr>
+      <tr><td>LKG false promotion</td><td>기능 없음</td><td>PID/hash mismatch cases = 0 promotion</td><td>chaos 1,000회 false promotion = 0</td><td>contract tests + chaos harness</td></tr>
+      <tr><td>contention recovery availability</td><td>8935 down</td><td>valid LKG fixture executes</td><td>listener recovery p95 ≤ 2s after prior process exit</td><td>local fault injection</td></tr>
+      <tr><td>unknown stale artifact execution</td><td>manual opt-in 가능</td><td>hash mismatch execution = 0</td><td>24h execution = 0</td><td>negative integration test + audit log</td></tr>
+      <tr><td>mixed workload terminal receipt</td><td>미증명</td><td>이 PR 범위 밖</td><td>10 Keeper × 8h ≥ 99%</td><td>keeper mixed-workload harness</td></tr>
+    </tbody>
+  </table>
+
+  <h2>7. Rollout 순서</h2>
+  <ol>
+    <li>focused shell integration suite와 changed-file format/lint를 통과한다.</li>
+    <li>빈 runtime root에서 최초 정상 boot 후 LKG descriptor 생성 여부를 확인한다.</li>
+    <li>실행 중 bare Dune을 시작하고 runtime을 종료해 exact LKG 복구를 fault-inject한다.</li>
+    <li>LKG bytes를 변조하고 동일 실험에서 terminal fail-closed를 확인한다.</li>
+    <li>24시간 canary 후 startup attempts, listener downtime, false promotion을 집계한다.</li>
+    <li>그 뒤에만 10 Keeper × 8시간 mixed-workload product gate에 포함한다.</li>
+  </ol>
+
+  <h2>8. Merge 판정</h2>
+  <div class="grid">
+    <article class="card gate"><h3>Merge 가능</h3><p>focused suite green, full CI green, exact failure injection green, review thread 0.</p></article>
+    <article class="card fail"><h3>Merge 금지</h3><p>hash 대신 mtime만 사용, PID 검증 제거, error prose 분기, LKG mismatch에서 stale 실행, candidate 없는 무한 retry.</p></article>
+    <article class="card gate"><h3>제품 1.0</h3><p>이 PR 하나로 Go가 아니다. 10 Keeper × 8h receipt/duplicate/latency와 OAS #2667 계약은 별도 hard gate다.</p></article>
+  </div>
+</main>
+</body>
+</html>

--- a/docs/design/2026-07-18-supervised-runtime-lkg-operation-matrix.html
+++ b/docs/design/2026-07-18-supervised-runtime-lkg-operation-matrix.html
@@ -61,9 +61,10 @@
       <tr><td>빌드 실패</td><td><code>build_dune_target_with_lock</code>가 typed 75를 1로 소실</td><td>원래 status를 보존</td><td><code>dune-local.sh</code> exit taxonomy</td></tr>
       <tr><td>실행 후보</td><td>선택된 path만 stderr에 출력</td><td>exec 직전 schema v1 descriptor를 atomic publish</td><td><code>start-masc.sh</code></td></tr>
       <tr><td>정상성</td><td>child가 떠 있거나 포트가 열리면 암묵적 성공</td><td>listener PID = supervised child PID AND <code>/health</code> success</td><td>process supervisor</td></tr>
+      <tr><td>proof 권한</td><td>명시 계약 없음</td><td>proof path는 child 환경에 전달하지 않고 supervisor만 atomic write</td><td>process supervisor</td></tr>
       <tr><td>LKG 승격</td><td>없음</td><td>candidate bytes를 다시 hash하고 descriptor를 atomic promote</td><td>process supervisor</td></tr>
       <tr><td>fallback</td><td>환경변수로 알려지지 않은 stale executable 허용 가능</td><td>schema와 SHA가 일치하는 health-promoted artifact만 선택</td><td>artifact contract SSOT</td></tr>
-      <tr><td>retry</td><td>모든 child exit를 동일하게 무한 반복</td><td>PID-bound health proof 없는 exit는 terminal; proof가 있는 runtime exit만 restart 대상</td><td>process supervisor FSM</td></tr>
+      <tr><td>retry</td><td>모든 child exit를 동일하게 무한 반복</td><td>exact <code>masc.runtime_health_proof.v1</code>의 PID/hash가 candidate와 일치하지 않으면 terminal; 검증된 runtime exit만 restart 대상</td><td>process supervisor FSM</td></tr>
     </tbody>
   </table>
 
@@ -101,6 +102,7 @@
       <tr><td>다른 프로세스가 같은 포트 health 응답</td><td>listener PID ≠ child PID</td><td>승격하지 않음</td><td>HTTP 200만으로 LKG 인정</td></tr>
       <tr><td>health 직전 executable 교체</td><td>candidate hash ≠ 현재 bytes</td><td>승격 거부 및 ERROR</td><td>path identity를 byte identity로 간주</td></tr>
       <tr><td>candidate가 exec 전에 실패</td><td>descriptor 있음, health proof 없음</td><td>terminal state</td><td>candidate 존재만으로 무한 restart</td></tr>
+      <tr><td>health proof write 중 monitor 종료/파일 위조</td><td>proof schema/PID/hash/EOF 중 하나라도 불일치</td><td>atomic proof가 아니면 terminal state</td><td>파일 존재만으로 restart 권한 부여</td></tr>
       <tr><td>health-promoted runtime이 이후 crash</td><td>candidate 발행됨</td><td>기존 continuous restart 책임 유지</td><td>startup failure로 오분류</td></tr>
     </tbody>
   </table>

--- a/scripts/lib/runtime-artifact-contract.sh
+++ b/scripts/lib/runtime-artifact-contract.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# Exact runtime-artifact identity contract shared by start-masc.sh and the
+# process supervisor.  This file is both sourceable and directly executable.
+
+MASC_RUNTIME_ARTIFACT_SCHEMA="masc.runtime_artifact.v1"
+
+masc_runtime_artifact_hash () {
+  local path="${1:-}"
+  [ -f "$path" ] || return 1
+
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$path" | awk '{ print $1 }'
+  elif command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$path" | awk '{ print $1 }'
+  else
+    printf 'no SHA-256 implementation found (requires shasum or sha256sum)\n' >&2
+    return 127
+  fi
+}
+
+masc_runtime_artifact_valid_hash () {
+  local value="${1:-}"
+  [ "${#value}" -eq 64 ] || return 1
+  case "$value" in
+    *[!0-9a-f]*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+masc_runtime_artifact_valid_port () {
+  local value="${1:-}"
+  case "$value" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  [ "$value" -ge 1 ] && [ "$value" -le 65535 ]
+}
+
+masc_runtime_artifact_descriptor_write () {
+  local file="${1:-}"
+  local mode="${2:-}"
+  local path="${3:-}"
+  local sha256="${4:-}"
+  local port="${5:-}"
+  local parent temp
+
+  [ -n "$file" ] || return 2
+  [ "$mode" = "http" ] || return 2
+  case "$path" in
+    /*) ;;
+    *) return 2 ;;
+  esac
+  case "$path" in
+    *$'\n'*|*$'\r'*) return 2 ;;
+  esac
+  masc_runtime_artifact_valid_hash "$sha256" || return 2
+  masc_runtime_artifact_valid_port "$port" || return 2
+
+  parent="$(dirname "$file")"
+  mkdir -p "$parent" || return 1
+  temp="$file.tmp.$$"
+  umask 077
+  if ! printf '%s\n%s\n%s\n%s\n%s\n' \
+      "$MASC_RUNTIME_ARTIFACT_SCHEMA" "$mode" "$path" "$sha256" "$port" \
+      >"$temp"
+  then
+    rm -f "$temp"
+    return 1
+  fi
+  chmod 600 "$temp" || {
+    rm -f "$temp"
+    return 1
+  }
+  mv -f "$temp" "$file"
+}
+
+masc_runtime_artifact_descriptor_read () {
+  local file="${1:-}"
+  local schema mode path sha256 port
+
+  [ -f "$file" ] || return 1
+  {
+    IFS= read -r schema || return 1
+    IFS= read -r mode || return 1
+    IFS= read -r path || return 1
+    IFS= read -r sha256 || return 1
+    IFS= read -r port || return 1
+    if IFS= read -r _; then
+      return 1
+    fi
+  } <"$file"
+
+  [ "$schema" = "$MASC_RUNTIME_ARTIFACT_SCHEMA" ] || return 1
+  [ "$mode" = "http" ] || return 1
+  case "$path" in
+    /*) ;;
+    *) return 1 ;;
+  esac
+  masc_runtime_artifact_valid_hash "$sha256" || return 1
+  masc_runtime_artifact_valid_port "$port" || return 1
+
+  MASC_ARTIFACT_MODE="$mode"
+  MASC_ARTIFACT_PATH="$path"
+  MASC_ARTIFACT_SHA256="$sha256"
+  MASC_ARTIFACT_PORT="$port"
+  export MASC_ARTIFACT_MODE MASC_ARTIFACT_PATH MASC_ARTIFACT_SHA256 MASC_ARTIFACT_PORT
+}
+
+masc_runtime_artifact_descriptor_verify () {
+  local file="${1:-}"
+  local actual
+
+  masc_runtime_artifact_descriptor_read "$file" || return 1
+  [ -f "$MASC_ARTIFACT_PATH" ] || return 1
+  [ -x "$MASC_ARTIFACT_PATH" ] || return 1
+  actual="$(masc_runtime_artifact_hash "$MASC_ARTIFACT_PATH")" || return 1
+  [ "$actual" = "$MASC_ARTIFACT_SHA256" ]
+}
+
+masc_runtime_artifact_promote () {
+  local candidate_file="${1:-}"
+  local lkg_file="${2:-}"
+  local repo_root="${3:-}"
+  local source_path source_hash mode port promoted_path promoted_dir temp actual
+
+  masc_runtime_artifact_descriptor_verify "$candidate_file" || return 1
+  source_path="$MASC_ARTIFACT_PATH"
+  source_hash="$MASC_ARTIFACT_SHA256"
+  mode="$MASC_ARTIFACT_MODE"
+  port="$MASC_ARTIFACT_PORT"
+  promoted_path="$source_path"
+
+  # Local Dune outputs are mutable.  Preserve the exact healthy bytes beside
+  # the selected executable so Sys.executable_name keeps the same repo/layout
+  # ancestry on fallback.  Release and installed artifacts remain at their
+  # already-stable path and are still protected by the descriptor hash.
+  case "$source_path" in
+    "$repo_root"/_build/*)
+      promoted_dir="$(dirname "$source_path")"
+      promoted_path="$promoted_dir/.masc-lkg-$source_hash-$(basename "$source_path")"
+      if [ ! -f "$promoted_path" ]; then
+        temp="$promoted_path.tmp.$$"
+        cp -p "$source_path" "$temp" || {
+          rm -f "$temp"
+          return 1
+        }
+        chmod 700 "$temp" || {
+          rm -f "$temp"
+          return 1
+        }
+        actual="$(masc_runtime_artifact_hash "$temp")" || {
+          rm -f "$temp"
+          return 1
+        }
+        if [ "$actual" != "$source_hash" ]; then
+          rm -f "$temp"
+          return 1
+        fi
+        mv -f "$temp" "$promoted_path" || {
+          rm -f "$temp"
+          return 1
+        }
+      fi
+      actual="$(masc_runtime_artifact_hash "$promoted_path")" || return 1
+      [ "$actual" = "$source_hash" ] || return 1
+      ;;
+  esac
+
+  masc_runtime_artifact_descriptor_write "$lkg_file" "$mode" \
+    "$promoted_path" "$source_hash" "$port"
+}
+
+masc_runtime_artifact_cli () {
+  local command="${1:-}"
+  shift || true
+  case "$command" in
+    hash)
+      [ "$#" -eq 1 ] || return 2
+      masc_runtime_artifact_hash "$1"
+      ;;
+    write)
+      [ "$#" -eq 5 ] || return 2
+      masc_runtime_artifact_descriptor_write "$1" "$2" "$3" "$4" "$5"
+      ;;
+    verify)
+      [ "$#" -eq 1 ] || return 2
+      masc_runtime_artifact_descriptor_verify "$1"
+      ;;
+    promote)
+      [ "$#" -eq 3 ] || return 2
+      masc_runtime_artifact_promote "$1" "$2" "$3"
+      ;;
+    *)
+      printf 'usage: %s {hash FILE|write FILE MODE PATH SHA256 PORT|verify FILE|promote CANDIDATE LKG REPO_ROOT}\n' \
+        "$0" >&2
+      return 2
+      ;;
+  esac
+}
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  set -euo pipefail
+  masc_runtime_artifact_cli "$@"
+fi

--- a/scripts/start-masc-supervised.sh
+++ b/scripts/start-masc-supervised.sh
@@ -48,10 +48,12 @@ ARTIFACT_CONTRACT="${MASC_RUNTIME_ARTIFACT_CONTRACT:-$REPO_ROOT/scripts/lib/runt
 LKG_FILE="${MASC_RUNTIME_LKG_FILE:-$REPO_ROOT/logs/masc-runtime-lkg.v1}"
 ATTEMPT_DIR="$(dirname "$LKG_FILE")"
 CANDIDATE_FILE="$ATTEMPT_DIR/masc-runtime-candidate.$$.v1"
-PROOF_FILE="$ATTEMPT_DIR/masc-runtime-health-proof.$$.sha256"
+PROOF_FILE="$ATTEMPT_DIR/masc-runtime-health-proof.$$.v1"
+HEALTH_PROOF_SCHEMA="masc.runtime_health_proof.v1"
 active_pid=""
 active_kind=""
 monitor_pid=""
+completed_pid=""
 stop_signal=""
 stop_exit_code=0
 stop_forwarded_pid=""
@@ -85,6 +87,51 @@ done
 source "$ARTIFACT_CONTRACT"
 mkdir -p "$ATTEMPT_DIR"
 
+write_health_proof() {
+  local child_pid="$1"
+  local artifact_hash="$2"
+  local temp="$PROOF_FILE.tmp.$$"
+
+  case "$child_pid" in
+    ''|*[!0-9]*) return 2 ;;
+  esac
+  masc_runtime_artifact_valid_hash "$artifact_hash" || return 2
+
+  umask 077
+  if ! printf '%s\n%s\n%s\n' \
+      "$HEALTH_PROOF_SCHEMA" "$child_pid" "$artifact_hash" >"$temp"
+  then
+    rm -f "$temp"
+    return 1
+  fi
+  chmod 600 "$temp" || {
+    rm -f "$temp"
+    return 1
+  }
+  mv -f "$temp" "$PROOF_FILE"
+}
+
+verify_health_proof() {
+  local expected_pid="$1"
+  local schema proof_pid proof_hash
+
+  [ -f "$PROOF_FILE" ] || return 1
+  {
+    IFS= read -r schema || return 1
+    IFS= read -r proof_pid || return 1
+    IFS= read -r proof_hash || return 1
+    if IFS= read -r _; then
+      return 1
+    fi
+  } <"$PROOF_FILE"
+
+  [ "$schema" = "$HEALTH_PROOF_SCHEMA" ] || return 1
+  [ "$proof_pid" = "$expected_pid" ] || return 1
+  masc_runtime_artifact_valid_hash "$proof_hash" || return 1
+  masc_runtime_artifact_descriptor_read "$CANDIDATE_FILE" || return 1
+  [ "$proof_hash" = "$MASC_ARTIFACT_SHA256" ]
+}
+
 monitor_runtime_candidate() {
   local child_pid="$1"
   local listener_pid=""
@@ -103,8 +150,11 @@ monitor_runtime_candidate() {
           return
         fi
         if masc_runtime_artifact_promote "$CANDIDATE_FILE" "$LKG_FILE" "$REPO_ROOT"; then
-          printf '%s\n' "$actual_hash" >"$PROOF_FILE"
-          log "health-verified runtime artifact promoted sha256=$actual_hash pid=$child_pid"
+          if write_health_proof "$child_pid" "$actual_hash"; then
+            log "health-verified runtime artifact promoted sha256=$actual_hash pid=$child_pid"
+          else
+            log "ERROR: healthy runtime artifact promotion lacked an exact health proof"
+          fi
         else
           log "ERROR: healthy runtime artifact failed exact LKG promotion"
         fi
@@ -176,6 +226,7 @@ run_active() {
     fi
   fi
 
+  completed_pid="$active_pid"
   active_pid=""
   active_kind=""
   stop_forwarded_pid=""
@@ -214,7 +265,6 @@ while true; do
     MASC_RUNTIME_ARTIFACT_CONTRACT="$ARTIFACT_CONTRACT" \
     MASC_RUNTIME_LKG_FILE="$LKG_FILE" \
     MASC_RUNTIME_CANDIDATE_FILE="$CANDIDATE_FILE" \
-    MASC_RUNTIME_HEALTH_PROOF_FILE="$PROOF_FILE" \
     MASC_ENABLE_VERIFIED_LKG_FALLBACK=1 \
     "$REPO_ROOT/start-masc.sh" "$@"
   exit_code=$?
@@ -236,8 +286,8 @@ while true; do
     log "terminal startup state: no runtime candidate was published; refusing restart amplification"
     exit "$exit_code"
   fi
-  if [ ! -f "$PROOF_FILE" ]; then
-    log "terminal startup state: runtime candidate never reached PID-bound health; refusing restart amplification"
+  if ! verify_health_proof "$completed_pid"; then
+    log "terminal startup state: runtime candidate lacks an exact PID-bound health proof; refusing restart amplification"
     exit "$exit_code"
   fi
 

--- a/scripts/start-masc-supervised.sh
+++ b/scripts/start-masc-supervised.sh
@@ -15,10 +15,16 @@
 #                                     (default: <repo-root>/logs/masc-supervisor.log)
 #   MASC_RESTART_COOLDOWN_SEC       — sleep between restart attempts
 #                                     (default: 5)
+#   MASC_RUNTIME_LKG_FILE           — health-verified artifact descriptor
+#                                     (default: <repo-root>/logs/masc-runtime-lkg.v1)
+#   MASC_SUPERVISOR_HEALTH_PROBE_SEC — observation cadence only; never a
+#                                     readiness timeout (default: 1)
 #
 # Restart contract:
 #   Every child exit is logged with its real exit status and uptime.
-#   Child failures never revoke the supervisor's restart responsibility.
+#   A PID-bound healthy runtime keeps continuous restart responsibility.
+#   A startup that never publishes a candidate or never reaches PID-bound
+#   health is terminal, so deterministic startup failures are not amplified.
 #   TERM, INT, and HUP remain explicit external stop signals: they are
 #   forwarded to the active child and terminate the supervisor.
 #
@@ -37,8 +43,15 @@ LOG_FILE="${MASC_SUPERVISOR_LOG:-$REPO_ROOT/logs/masc-supervisor.log}"
 mkdir -p "$(dirname "$LOG_FILE")"
 
 COOLDOWN_SEC="${MASC_RESTART_COOLDOWN_SEC:-5}"
+HEALTH_PROBE_SEC="${MASC_SUPERVISOR_HEALTH_PROBE_SEC:-1}"
+ARTIFACT_CONTRACT="${MASC_RUNTIME_ARTIFACT_CONTRACT:-$REPO_ROOT/scripts/lib/runtime-artifact-contract.sh}"
+LKG_FILE="${MASC_RUNTIME_LKG_FILE:-$REPO_ROOT/logs/masc-runtime-lkg.v1}"
+ATTEMPT_DIR="$(dirname "$LKG_FILE")"
+CANDIDATE_FILE="$ATTEMPT_DIR/masc-runtime-candidate.$$.v1"
+PROOF_FILE="$ATTEMPT_DIR/masc-runtime-health-proof.$$.sha256"
 active_pid=""
 active_kind=""
+monitor_pid=""
 stop_signal=""
 stop_exit_code=0
 stop_forwarded_pid=""
@@ -46,6 +59,60 @@ stop_forwarded_pid=""
 log() {
   printf '[%s][supervisor] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" \
     | tee -a "$LOG_FILE" >&2
+}
+
+if [ ! -r "$ARTIFACT_CONTRACT" ]; then
+  log "ERROR: runtime artifact contract unavailable: $ARTIFACT_CONTRACT"
+  exit 78
+fi
+case "$HEALTH_PROBE_SEC" in
+  ''|*[!0-9]*)
+    log "ERROR: MASC_SUPERVISOR_HEALTH_PROBE_SEC must be a positive integer"
+    exit 78
+    ;;
+esac
+if [ "$HEALTH_PROBE_SEC" -lt 1 ]; then
+  log "ERROR: MASC_SUPERVISOR_HEALTH_PROBE_SEC must be at least 1"
+  exit 78
+fi
+for required_command in lsof curl; do
+  if ! command -v "$required_command" >/dev/null 2>&1; then
+    log "ERROR: required runtime health-proof command unavailable: $required_command"
+    exit 78
+  fi
+done
+# shellcheck source=/dev/null
+source "$ARTIFACT_CONTRACT"
+mkdir -p "$ATTEMPT_DIR"
+
+monitor_runtime_candidate() {
+  local child_pid="$1"
+  local listener_pid=""
+  local actual_hash=""
+
+  while kill -0 "$child_pid" 2>/dev/null; do
+    if masc_runtime_artifact_descriptor_read "$CANDIDATE_FILE"; then
+      listener_pid="$(lsof -ti "tcp:$MASC_ARTIFACT_PORT" -sTCP:LISTEN 2>/dev/null | head -n 1 || true)"
+      if [ "$listener_pid" = "$child_pid" ] \
+        && curl -fsS --max-time 1 \
+          "http://127.0.0.1:$MASC_ARTIFACT_PORT/health" >/dev/null 2>&1
+      then
+        actual_hash="$(masc_runtime_artifact_hash "$MASC_ARTIFACT_PATH")" || return
+        if [ "$actual_hash" != "$MASC_ARTIFACT_SHA256" ]; then
+          log "ERROR: healthy listener artifact changed before LKG promotion"
+          return
+        fi
+        if masc_runtime_artifact_promote "$CANDIDATE_FILE" "$LKG_FILE" "$REPO_ROOT"; then
+          printf '%s\n' "$actual_hash" >"$PROOF_FILE"
+          log "health-verified runtime artifact promoted sha256=$actual_hash pid=$child_pid"
+        else
+          log "ERROR: healthy runtime artifact failed exact LKG promotion"
+        fi
+        return
+      fi
+    fi
+    sleep "$HEALTH_PROBE_SEC"
+  done
 }
 
 forward_stop_to_active() {
@@ -86,9 +153,20 @@ run_active() {
   "$@" &
   active_pid=$!
   stop_forwarded_pid=""
+  monitor_pid=""
+  if [ "$kind" = "masc" ]; then
+    monitor_runtime_candidate "$active_pid" &
+    monitor_pid=$!
+  fi
   forward_stop_to_active
   wait "$active_pid"
   status=$?
+
+  if [ -n "$monitor_pid" ]; then
+    kill "$monitor_pid" 2>/dev/null || true
+    wait "$monitor_pid" 2>/dev/null || true
+    monitor_pid=""
+  fi
 
   if [ -n "$stop_signal" ]; then
     wait "$active_pid" 2>/dev/null
@@ -125,13 +203,20 @@ fi
 
 while true; do
   stop_if_requested
+  rm -f "$CANDIDATE_FILE" "$PROOF_FILE"
   log "starting masc"
   start_epoch=$(date +%s)
 
   # No `set -e` is active, so a failing start-masc.sh does not abort this
   # loop; `|| true` here would make `$?` observe `true` and record every
   # exit — including SIGSEGV (139) and SIGTERM (143) — as code=0.
-  run_active "masc" "$REPO_ROOT/start-masc.sh" "$@"
+  run_active "masc" env \
+    MASC_RUNTIME_ARTIFACT_CONTRACT="$ARTIFACT_CONTRACT" \
+    MASC_RUNTIME_LKG_FILE="$LKG_FILE" \
+    MASC_RUNTIME_CANDIDATE_FILE="$CANDIDATE_FILE" \
+    MASC_RUNTIME_HEALTH_PROOF_FILE="$PROOF_FILE" \
+    MASC_ENABLE_VERIFIED_LKG_FALLBACK=1 \
+    "$REPO_ROOT/start-masc.sh" "$@"
   exit_code=$?
   end_epoch=$(date +%s)
   uptime_s=$((end_epoch - start_epoch))
@@ -146,6 +231,15 @@ while true; do
 
   log "masc exited code=${exit_code}${exit_detail} uptime=${uptime_s}s"
   stop_if_requested
+
+  if [ ! -f "$CANDIDATE_FILE" ]; then
+    log "terminal startup state: no runtime candidate was published; refusing restart amplification"
+    exit "$exit_code"
+  fi
+  if [ ! -f "$PROOF_FILE" ]; then
+    log "terminal startup state: runtime candidate never reached PID-bound health; refusing restart amplification"
+    exit "$exit_code"
+  fi
 
   log "restart in ${COOLDOWN_SEC}s"
   run_active "restart cooldown" sleep "$COOLDOWN_SEC"

--- a/start-masc.sh
+++ b/start-masc.sh
@@ -167,6 +167,7 @@ dune_build_with_stale_retry() {
 build_dune_target_with_lock() {
     local target="$1"
     local label="$2"
+    local build_status=0
     if ! acquire_build_lock; then
         if is_truthy "${MASC_ALLOW_STALE_EXE_ON_BUILD_LOCK:-0}"; then
             echo "Warning: proceeding without rebuilding $label because MASC_ALLOW_STALE_EXE_ON_BUILD_LOCK=1." >&2
@@ -175,12 +176,14 @@ build_dune_target_with_lock() {
         echo "Error: unable to acquire build lock for $label; refusing to continue with a stale or missing executable." >&2
         return 1
     fi
-    if ! dune_build_with_stale_retry "$target" "$label"; then
+    if dune_build_with_stale_retry "$target" "$label"; then
         release_build_lock
-        return 1
+        return 0
+    else
+        build_status=$?
+        release_build_lock
+        return "$build_status"
     fi
-    release_build_lock
-    return 0
 }
 
 is_truthy() {
@@ -188,6 +191,71 @@ is_truthy() {
         1|true|yes|y|on) return 0 ;;
         *) return 1 ;;
     esac
+}
+
+RUNTIME_ARTIFACT_CONTRACT="${MASC_RUNTIME_ARTIFACT_CONTRACT:-$SCRIPT_DIR/scripts/lib/runtime-artifact-contract.sh}"
+USING_VERIFIED_LKG=""
+
+runtime_artifact_contract_requested() {
+    [ -n "${MASC_RUNTIME_CANDIDATE_FILE:-}" ] \
+        || [ -n "${MASC_RUNTIME_LKG_FILE:-}" ] \
+        || is_truthy "${MASC_ENABLE_VERIFIED_LKG_FALLBACK:-0}"
+}
+
+if runtime_artifact_contract_requested; then
+    if [ ! -r "$RUNTIME_ARTIFACT_CONTRACT" ]; then
+        echo "Error: runtime artifact contract is unavailable: $RUNTIME_ARTIFACT_CONTRACT" >&2
+        exit 78
+    fi
+    # shellcheck source=/dev/null
+    source "$RUNTIME_ARTIFACT_CONTRACT"
+fi
+
+select_verified_lkg() {
+    local lkg_file="${MASC_RUNTIME_LKG_FILE:-}"
+    if [ -z "$lkg_file" ]; then
+        echo "Error: verified LKG fallback requested without MASC_RUNTIME_LKG_FILE." >&2
+        return 1
+    fi
+    if ! masc_runtime_artifact_descriptor_verify "$lkg_file"; then
+        echo "Error: last-known-good artifact failed exact verification: $lkg_file" >&2
+        return 1
+    fi
+    USING_VERIFIED_LKG="1"
+    MASC_EIO_EXE="$MASC_ARTIFACT_PATH"
+    echo "[startup] using health-verified last-known-good artifact: $MASC_EIO_EXE sha256=$MASC_ARTIFACT_SHA256" >&2
+    return 0
+}
+
+recover_verified_lkg_after_build_failure() {
+    local build_status="$1"
+    local label="$2"
+    if is_truthy "${MASC_ENABLE_VERIFIED_LKG_FALLBACK:-0}" \
+        && select_verified_lkg
+    then
+        echo "[startup] $label build unavailable (status=$build_status); availability preserved by exact LKG fallback." >&2
+        return 0
+    fi
+    return "$build_status"
+}
+
+publish_runtime_candidate() {
+    local candidate_file="${MASC_RUNTIME_CANDIDATE_FILE:-}"
+    local selected_exe="$1"
+    local selected_port="$2"
+    local sha256
+
+    [ -n "$candidate_file" ] || return 0
+    sha256="$(masc_runtime_artifact_hash "$selected_exe")" || {
+        echo "Error: failed to hash selected runtime artifact: $selected_exe" >&2
+        return 1
+    }
+    if ! masc_runtime_artifact_descriptor_write "$candidate_file" http \
+        "$selected_exe" "$sha256" "$selected_port"
+    then
+        echo "Error: failed to publish runtime candidate descriptor: $candidate_file" >&2
+        return 1
+    fi
 }
 
 is_absolute_path() {
@@ -855,11 +923,18 @@ if [ "$HTTP_MODE" = "true" ] && [ -z "$MASC_EIO_EXE" ]; then
         echo "Error: dune not found. Install dune first." >&2
         exit 1
     fi
-    if ! build_dune_target_with_lock "bin/main_eio.exe" "main_eio.exe"; then
-        echo "Error: build failed." >&2
-        exit 1
+    if build_dune_target_with_lock "bin/main_eio.exe" "main_eio.exe"; then
+        :
+    else
+        build_status=$?
+        if ! recover_verified_lkg_after_build_failure "$build_status" "main_eio.exe"; then
+            echo "Error: build failed (status=$build_status) and no exact verified LKG is available." >&2
+            exit "$build_status"
+        fi
     fi
-    if [ -x "$LOCAL_EIO_EXE" ]; then
+    if [ -n "$USING_VERIFIED_LKG" ]; then
+        :
+    elif [ -x "$LOCAL_EIO_EXE" ]; then
         MASC_EIO_EXE="$LOCAL_EIO_EXE"
     else
         echo "Error: build failed." >&2
@@ -889,17 +964,25 @@ fi
 
 # Rebuild Eio version if sources are newer than the executable (avoids stale binary runs)
 # NOTE: Lwt version (main.exe) is deprecated - Eio is now the default
-if [ "$HTTP_MODE" = "true" ] && [ -n "$MASC_EIO_EXE" ] && command -v dune >/dev/null 2>&1; then
+if [ "$HTTP_MODE" = "true" ] && [ -n "$MASC_EIO_EXE" ] \
+    && [ -z "$USING_VERIFIED_LKG" ] && command -v dune >/dev/null 2>&1; then
     if find "$SCRIPT_DIR/bin" "$SCRIPT_DIR/lib" \
         -type f \( -name '*.ml' -o -name '*.mli' -o -name 'dune' \) \
         -newer "$MASC_EIO_EXE" 2>/dev/null | head -n 1 | grep -q .; then
         echo "Rebuilding MASC MCP server (stale executable detected)..." >&2
-        if ! build_dune_target_with_lock "bin/main_eio.exe" "main_eio.exe"; then
-            echo "Error: rebuild failed." >&2
-            exit 1
+        if build_dune_target_with_lock "bin/main_eio.exe" "main_eio.exe"; then
+            :
+        else
+            build_status=$?
+            if ! recover_verified_lkg_after_build_failure "$build_status" "main_eio.exe"; then
+                echo "Error: rebuild failed (status=$build_status) and no exact verified LKG is available." >&2
+                exit "$build_status"
+            fi
         fi
 
-        if [ -x "$LOCAL_EIO_EXE" ]; then
+        if [ -n "$USING_VERIFIED_LKG" ]; then
+            :
+        elif [ -x "$LOCAL_EIO_EXE" ]; then
             MASC_EIO_EXE="$LOCAL_EIO_EXE"
         elif [ -x "$WORKSPACE_EIO_EXE" ]; then
             MASC_EIO_EXE="$WORKSPACE_EIO_EXE"
@@ -977,11 +1060,18 @@ if [ "$EIO_MODE" = "true" ]; then
             echo "Error: dune not found. Cannot build Eio server." >&2
             exit 1
         fi
-        if ! build_dune_target_with_lock "bin/main_eio.exe" "main_eio.exe"; then
-            echo "Error: Failed to build Eio server (main_eio.exe)." >&2
-            exit 1
+        if build_dune_target_with_lock "bin/main_eio.exe" "main_eio.exe"; then
+            :
+        else
+            build_status=$?
+            if ! recover_verified_lkg_after_build_failure "$build_status" "main_eio.exe"; then
+                echo "Error: Failed to build Eio server (status=$build_status) and no exact verified LKG is available." >&2
+                exit "$build_status"
+            fi
         fi
-        if [ -x "$WORKSPACE_EIO_EXE" ]; then
+        if [ -n "$USING_VERIFIED_LKG" ]; then
+            :
+        elif [ -x "$WORKSPACE_EIO_EXE" ]; then
             MASC_EIO_EXE="$WORKSPACE_EIO_EXE"
         elif [ -x "$LOCAL_EIO_EXE" ]; then
             MASC_EIO_EXE="$LOCAL_EIO_EXE"
@@ -1044,6 +1134,9 @@ if [ "$EIO_MODE" = "true" ] && [ "$HTTP_MODE" = "true" ]; then
         echo "  MCP endpoint: /mcp (set MASC_HTTP_BASE_URL for an absolute origin)" >&2
     fi
     echo "  MCP Accept: application/json, text/event-stream" >&2
+    if ! publish_runtime_candidate "$SELECTED_EXE" "$PORT"; then
+        exit 78
+    fi
     launch_from_base_path "$SELECTED_EXE" --host="$HOST" --port="$PORT" --base-path="$RESOLVED_BASE_PATH"
 elif [ "$HTTP_MODE" = "true" ]; then
     echo "Starting MASC MCP server (HTTP mode, $RUNTIME_NAME)..." >&2

--- a/test/test_start_masc_script.ml
+++ b/test/test_start_masc_script.ml
@@ -1398,11 +1398,14 @@ fi
                {|
 #!/bin/bash
 set -eu
+if [ "${MASC_RUNTIME_HEALTH_PROOF_FILE+x}" = x ]; then
+  exit 70
+fi
 printf '%%s\n' "$$" > %s
 hash="$("${MASC_RUNTIME_ARTIFACT_CONTRACT:?}" hash "$0")"
 "$MASC_RUNTIME_ARTIFACT_CONTRACT" write \
   "${MASC_RUNTIME_CANDIDATE_FILE:?}" http "$0" "$hash" 9999
-while [ ! -f "${MASC_RUNTIME_HEALTH_PROOF_FILE:?}" ]; do
+while ! grep -q "pid=$$" "${MASC_SUPERVISOR_LOG:?}" 2>/dev/null; do
   sleep 0.02
 done
 kill -TERM "$PPID"
@@ -1431,6 +1434,59 @@ while true; do sleep 1; done
           check bool "promotion is operator-visible" true
             (contains_substring stderr
                "health-verified runtime artifact promoted")))
+
+let test_supervisor_rejects_malformed_health_proof () =
+  with_temp_dir "start-masc-supervisor-malformed-proof" (fun repo_root ->
+      with_temp_dir "start-masc-supervisor-malformed-proof-bin" (fun fake_bin ->
+          let scripts_dir = Filename.concat repo_root "scripts" in
+          let lib_dir = Filename.concat scripts_dir "lib" in
+          let supervisor_script =
+            Filename.concat scripts_dir "start-masc-supervised.sh"
+          in
+          let child_script = Filename.concat repo_root "start-masc.sh" in
+          let invocation_count = Filename.concat repo_root "invocation-count" in
+          let lkg_file = Filename.concat repo_root "last-known-good.v1" in
+          let log_file = Filename.concat repo_root "supervisor.log" in
+          mkdir_p lib_dir;
+          mkdir_p fake_bin;
+          copy_script (supervised_script_path ()) supervisor_script;
+          copy_script (runtime_artifact_contract_path ())
+            (Filename.concat lib_dir "runtime-artifact-contract.sh");
+          write_executable (Filename.concat fake_bin "lsof")
+            "#!/bin/sh\nexit 0\n";
+          write_executable (Filename.concat fake_bin "curl")
+            "#!/bin/sh\nexit 1\n";
+          write_executable child_script
+            (Printf.sprintf
+               {|
+#!/bin/bash
+set -eu
+printf '1\n' > %s
+hash="$("${MASC_RUNTIME_ARTIFACT_CONTRACT:?}" hash "$0")"
+"$MASC_RUNTIME_ARTIFACT_CONTRACT" write \
+  "${MASC_RUNTIME_CANDIDATE_FILE:?}" http "$0" "$hash" 9999
+: > "$(dirname "${MASC_RUNTIME_LKG_FILE:?}")/masc-runtime-health-proof.${PPID}.v1"
+exit 23
+|}
+               (quote invocation_count));
+          let code, stdout, stderr =
+            run_script ~cwd:repo_root supervisor_script
+              ~env:
+                [
+                  ("MASC_RUNTIME_LKG_FILE", lkg_file);
+                  ("MASC_SUPERVISOR_LOG", log_file);
+                  ("MASC_RESTART_COOLDOWN_SEC", "0");
+                  ("PATH", fake_bin ^ ":" ^ Sys.getenv "PATH");
+                ]
+              []
+          in
+          check int "malformed proof preserves child failure" 23 code;
+          check string "malformed proof cannot authorize a restart" "1\n"
+            (read_file invocation_count);
+          check string "supervisor writes no stdout" "" stdout;
+          check bool "invalid proof is operator-visible" true
+            (contains_substring stderr
+               "lacks an exact PID-bound health proof")))
 
 let test_supervisor_restarts_without_exit_limit_and_preserves_status () =
   with_temp_dir "start-masc-supervised-script" (fun repo_root ->
@@ -1474,7 +1530,7 @@ printf '%%s\n' "$$" > %s
 hash="$("${MASC_RUNTIME_ARTIFACT_CONTRACT:?}" hash "$0")"
 "$MASC_RUNTIME_ARTIFACT_CONTRACT" write \
   "${MASC_RUNTIME_CANDIDATE_FILE:?}" http "$0" "$hash" 9999
-while [ ! -f "${MASC_RUNTIME_HEALTH_PROOF_FILE:?}" ]; do
+while ! grep -q "pid=$$" "${MASC_SUPERVISOR_LOG:?}" 2>/dev/null; do
   sleep 0.02
 done
 if [ "$count" -ge 6 ]; then
@@ -1594,6 +1650,8 @@ let () =
             test_supervisor_stops_on_startup_without_candidate;
           test_case "supervisor promotes PID-bound healthy candidate" `Quick
             test_supervisor_promotes_pid_bound_healthy_candidate;
+          test_case "supervisor rejects malformed health proof" `Quick
+            test_supervisor_rejects_malformed_health_proof;
           test_case
             "supervisor restarts without exit limit and preserves status"
             `Quick

--- a/test/test_start_masc_script.ml
+++ b/test/test_start_masc_script.ml
@@ -16,6 +16,9 @@ let loopback_script_path () =
 let supervised_script_path () =
   source_file "scripts/start-masc-supervised.sh"
 
+let runtime_artifact_contract_path () =
+  source_file "scripts/lib/runtime-artifact-contract.sh"
+
 let quote = Filename.quote
 
 let read_file path =
@@ -143,6 +146,27 @@ let run_process ?(env = []) ~cwd prog argv =
 let run_script ?env ~cwd script args =
   run_process ?env ~cwd "/bin/bash"
     (Array.of_list ("/bin/bash" :: script :: args))
+
+let run_contract ~cwd args =
+  run_process ~cwd "/bin/bash"
+    (Array.of_list
+       ("/bin/bash" :: runtime_artifact_contract_path () :: args))
+
+let artifact_hash ~cwd path =
+  let code, stdout, stderr = run_contract ~cwd [ "hash"; path ] in
+  if code <> 0 then
+    failf "artifact hash failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout
+      stderr;
+  String.trim stdout
+
+let write_artifact_descriptor ~cwd ~file ~mode ~path ~sha256 ~port =
+  let code, stdout, stderr =
+    run_contract ~cwd
+      [ "write"; file; mode; path; sha256; string_of_int port ]
+  in
+  if code <> 0 then
+    failf "artifact descriptor write failed (%d)\nstdout:\n%s\nstderr:\n%s"
+      code stdout stderr
 
 let copy_script src dst =
   write_executable dst (read_file src)
@@ -975,6 +999,111 @@ let test_stale_executable_requires_build_lock () =
 	            (contains_substring stderr
 	               "refusing to continue with a stale or missing executable")))
 
+let test_build_tempfail_runs_only_hash_verified_lkg () =
+  with_temp_dir "start-masc-verified-lkg" (fun dir ->
+      with_temp_dir "start-masc-verified-lkg-bin" (fun fake_bin ->
+          let script = Filename.concat dir "start-masc.sh" in
+          let scripts_dir = Filename.concat dir "scripts" in
+          let lkg_exe = Filename.concat dir "verified-lkg-main_eio.exe" in
+          let lkg_file = Filename.concat dir "last-known-good.v1" in
+          let candidate_file = Filename.concat dir "candidate.v1" in
+          let capture = Filename.concat dir "captured-lkg.txt" in
+          let source = Filename.concat dir "bin/main_eio.ml" in
+          copy_script (script_path ()) script;
+          ignore (make_config_root dir);
+          make_fake_eio_exe dir;
+          write_fake_eio_exe lkg_exe ~marker:"verified-lkg";
+          mkdir_p scripts_dir;
+          mkdir_p fake_bin;
+          write_executable (Filename.concat scripts_dir "dune-local.sh")
+            "#!/bin/sh\nexit 75\n";
+          write_executable (Filename.concat fake_bin "dune")
+            "#!/bin/sh\nexit 75\n";
+          mkdir_p (Filename.dirname source);
+          write_file source "let () = ()\n";
+          let future = Unix.time () +. 10.0 in
+          Unix.utimes source future future;
+          let lkg_hash = artifact_hash ~cwd:dir lkg_exe in
+          write_artifact_descriptor ~cwd:dir ~file:lkg_file ~mode:"http"
+            ~path:lkg_exe ~sha256:lkg_hash ~port:9972;
+          let code, stdout, stderr =
+            run_script ~cwd:dir script
+              ~env:
+                [
+                  ("FAKE_CAPTURE_FILE", capture);
+                  ("MASC_BASE_PATH", dir);
+                  ("MASC_ENABLE_VERIFIED_LKG_FALLBACK", "1");
+                  ("MASC_RUNTIME_LKG_FILE", lkg_file);
+                  ("MASC_RUNTIME_CANDIDATE_FILE", candidate_file);
+                  ( "MASC_RUNTIME_ARTIFACT_CONTRACT",
+                    runtime_artifact_contract_path () );
+                  ("PATH", fake_bin ^ ":" ^ Sys.getenv "PATH");
+                ]
+              [ "--http"; "--port"; "9972"; "--base-path"; dir ]
+          in
+          if code <> 0 then
+            failf "verified LKG fallback failed (%d)\nstdout:\n%s\nstderr:\n%s"
+              code stdout stderr;
+          let captured = read_file capture in
+          check bool "verified LKG executable was selected" true
+            (contains_substring captured "FAKE_EXE_MARKER=verified-lkg");
+          check bool "unverified stale executable was not selected" false
+            (contains_substring captured "FAKE_EXE_MARKER=local");
+          check bool "fallback decision is explicit" true
+            (contains_substring stderr
+               "using health-verified last-known-good artifact");
+          check bool "launched artifact candidate is published" true
+            (Sys.file_exists candidate_file);
+          let candidate = read_file candidate_file in
+          check bool "candidate preserves exact LKG hash" true
+            (contains_substring candidate lkg_hash)))
+
+let test_build_tempfail_rejects_lkg_hash_mismatch () =
+  with_temp_dir "start-masc-invalid-lkg" (fun dir ->
+      with_temp_dir "start-masc-invalid-lkg-bin" (fun fake_bin ->
+          let script = Filename.concat dir "start-masc.sh" in
+          let scripts_dir = Filename.concat dir "scripts" in
+          let lkg_exe = Filename.concat dir "invalid-lkg-main_eio.exe" in
+          let lkg_file = Filename.concat dir "last-known-good.v1" in
+          let capture = Filename.concat dir "captured-invalid-lkg.txt" in
+          let source = Filename.concat dir "bin/main_eio.ml" in
+          copy_script (script_path ()) script;
+          ignore (make_config_root dir);
+          make_fake_eio_exe dir;
+          write_fake_eio_exe lkg_exe ~marker:"must-not-run";
+          mkdir_p scripts_dir;
+          mkdir_p fake_bin;
+          write_executable (Filename.concat scripts_dir "dune-local.sh")
+            "#!/bin/sh\nexit 75\n";
+          write_executable (Filename.concat fake_bin "dune")
+            "#!/bin/sh\nexit 75\n";
+          mkdir_p (Filename.dirname source);
+          write_file source "let () = ()\n";
+          let future = Unix.time () +. 10.0 in
+          Unix.utimes source future future;
+          write_artifact_descriptor ~cwd:dir ~file:lkg_file ~mode:"http"
+            ~path:lkg_exe ~sha256:(String.make 64 '0') ~port:9972;
+          let code, _stdout, stderr =
+            run_script ~cwd:dir script
+              ~env:
+                [
+                  ("FAKE_CAPTURE_FILE", capture);
+                  ("MASC_BASE_PATH", dir);
+                  ("MASC_ENABLE_VERIFIED_LKG_FALLBACK", "1");
+                  ("MASC_RUNTIME_LKG_FILE", lkg_file);
+                  ( "MASC_RUNTIME_ARTIFACT_CONTRACT",
+                    runtime_artifact_contract_path () );
+                  ("PATH", fake_bin ^ ":" ^ Sys.getenv "PATH");
+                ]
+              [ "--http"; "--port"; "9972"; "--base-path"; dir ]
+          in
+          check bool "hash mismatch keeps startup failed closed" true (code <> 0);
+          check bool "mismatched LKG never executed" false
+            (Sys.file_exists capture);
+          check bool "hash mismatch is operator-visible" true
+            (contains_substring stderr
+               "last-known-good artifact failed exact verification")))
+
 let test_default_build_lock_is_worktree_local () =
   let source = read_file (script_path ()) in
   check bool "default build lock is worktree-local" true
@@ -1202,36 +1331,23 @@ let test_loopback_disables_keeper_autoboot_by_default_and_requires_opt_in ()
       check bool "loopback honors explicit keeper autoboot opt-in" true
         (contains_substring captured_override "MASC_KEEPER_BOOTSTRAP_ENABLED=true"))
 
-let test_supervisor_restarts_without_exit_limit_and_preserves_status () =
-  with_temp_dir "start-masc-supervised-script" (fun repo_root ->
+let test_supervisor_stops_on_startup_without_candidate () =
+  with_temp_dir "start-masc-supervisor-terminal" (fun repo_root ->
       let scripts_dir = Filename.concat repo_root "scripts" in
+      let lib_dir = Filename.concat scripts_dir "lib" in
       let supervisor_script =
         Filename.concat scripts_dir "start-masc-supervised.sh"
       in
       let child_script = Filename.concat repo_root "start-masc.sh" in
       let invocation_count = Filename.concat repo_root "invocation-count" in
       let log_file = Filename.concat repo_root "supervisor.log" in
-      mkdir_p scripts_dir;
+      mkdir_p lib_dir;
       copy_script (supervised_script_path ()) supervisor_script;
+      copy_script (runtime_artifact_contract_path ())
+        (Filename.concat lib_dir "runtime-artifact-contract.sh");
       write_executable child_script
         (Printf.sprintf
-           {|#!/bin/sh
-set -eu
-count=0
-if [ -f %s ]; then
-  count="$(cat %s)"
-fi
-count=$((count + 1))
-printf '%%s\n' "$count" > %s
-if [ "$count" -ge 6 ]; then
-  kill -TERM "$PPID"
-  while true; do
-    sleep 1
-  done
-fi
-exit 23
-|}
-           (quote invocation_count) (quote invocation_count)
+           "#!/bin/sh\nset -eu\nprintf '1\\n' > %s\nexit 75\n"
            (quote invocation_count));
       let code, stdout, stderr =
         run_script ~cwd:repo_root supervisor_script
@@ -1242,19 +1358,163 @@ exit 23
             ]
           []
       in
-      check int "external stop signal remains explicit" 143 code;
-      check string "child keeps restarting after repeated failures" "6\n"
+      check int "typed startup temporary failure is preserved" 75 code;
+      check string "startup failure is not amplified" "1\n"
         (read_file invocation_count);
-      let log = read_file log_file in
-      check bool "real child exit status is recorded" true
-        (contains_substring log "masc exited code=23");
-      check bool "child failure is not rewritten as success" false
-        (contains_substring log "masc exited code=0");
       check string "supervisor writes no stdout" "" stdout;
-      check bool "external stop is logged" true
-        (contains_substring stderr "supervisor received SIGTERM");
-      check bool "finite crash-loop abort is absent" false
-        (contains_substring stderr "ABORT:"))
+      check bool "terminal startup state is operator-visible" true
+        (contains_substring stderr
+           "terminal startup state: no runtime candidate was published"))
+
+let test_supervisor_promotes_pid_bound_healthy_candidate () =
+  with_temp_dir "start-masc-supervisor-lkg" (fun repo_root ->
+      with_temp_dir "start-masc-supervisor-lkg-bin" (fun fake_bin ->
+          let scripts_dir = Filename.concat repo_root "scripts" in
+          let lib_dir = Filename.concat scripts_dir "lib" in
+          let supervisor_script =
+            Filename.concat scripts_dir "start-masc-supervised.sh"
+          in
+          let child_script = Filename.concat repo_root "start-masc.sh" in
+          let listener_pid_file = Filename.concat repo_root "listener-pid" in
+          let lkg_file = Filename.concat repo_root "last-known-good.v1" in
+          let log_file = Filename.concat repo_root "supervisor.log" in
+          mkdir_p lib_dir;
+          mkdir_p fake_bin;
+          copy_script (supervised_script_path ()) supervisor_script;
+          copy_script (runtime_artifact_contract_path ())
+            (Filename.concat lib_dir "runtime-artifact-contract.sh");
+          write_executable (Filename.concat fake_bin "lsof")
+            {|
+#!/bin/sh
+set -eu
+if [ -f "${FAKE_LISTENER_PID_FILE:?}" ]; then
+  cat "$FAKE_LISTENER_PID_FILE"
+fi
+|};
+          write_executable (Filename.concat fake_bin "curl")
+            "#!/bin/sh\nexit 0\n";
+          write_executable child_script
+            (Printf.sprintf
+               {|
+#!/bin/bash
+set -eu
+printf '%%s\n' "$$" > %s
+hash="$("${MASC_RUNTIME_ARTIFACT_CONTRACT:?}" hash "$0")"
+"$MASC_RUNTIME_ARTIFACT_CONTRACT" write \
+  "${MASC_RUNTIME_CANDIDATE_FILE:?}" http "$0" "$hash" 9999
+while [ ! -f "${MASC_RUNTIME_HEALTH_PROOF_FILE:?}" ]; do
+  sleep 0.02
+done
+kill -TERM "$PPID"
+while true; do sleep 1; done
+|}
+               (quote listener_pid_file));
+          let code, stdout, stderr =
+            run_script ~cwd:repo_root supervisor_script
+              ~env:
+                [
+                  ("FAKE_LISTENER_PID_FILE", listener_pid_file);
+                  ("MASC_RUNTIME_LKG_FILE", lkg_file);
+                  ("MASC_SUPERVISOR_LOG", log_file);
+                  ("MASC_SUPERVISOR_HEALTH_PROBE_SEC", "1");
+                  ("PATH", fake_bin ^ ":" ^ Sys.getenv "PATH");
+                ]
+              []
+          in
+          check int "external stop remains explicit after LKG proof" 143 code;
+          check string "supervisor writes no stdout" "" stdout;
+          check bool "health proof promotes LKG descriptor" true
+            (Sys.file_exists lkg_file);
+          let expected_hash = artifact_hash ~cwd:repo_root child_script in
+          check bool "promoted descriptor retains exact artifact hash" true
+            (contains_substring (read_file lkg_file) expected_hash);
+          check bool "promotion is operator-visible" true
+            (contains_substring stderr
+               "health-verified runtime artifact promoted")))
+
+let test_supervisor_restarts_without_exit_limit_and_preserves_status () =
+  with_temp_dir "start-masc-supervised-script" (fun repo_root ->
+      with_temp_dir "start-masc-supervised-script-bin" (fun fake_bin ->
+          let scripts_dir = Filename.concat repo_root "scripts" in
+          let lib_dir = Filename.concat scripts_dir "lib" in
+          let supervisor_script =
+            Filename.concat scripts_dir "start-masc-supervised.sh"
+          in
+          let child_script = Filename.concat repo_root "start-masc.sh" in
+          let invocation_count = Filename.concat repo_root "invocation-count" in
+          let listener_pid_file = Filename.concat repo_root "listener-pid" in
+          let lkg_file = Filename.concat repo_root "last-known-good.v1" in
+          let log_file = Filename.concat repo_root "supervisor.log" in
+          mkdir_p lib_dir;
+          mkdir_p fake_bin;
+          copy_script (supervised_script_path ()) supervisor_script;
+          copy_script (runtime_artifact_contract_path ())
+            (Filename.concat lib_dir "runtime-artifact-contract.sh");
+          write_executable (Filename.concat fake_bin "lsof")
+            {|
+#!/bin/sh
+set -eu
+if [ -f "${FAKE_LISTENER_PID_FILE:?}" ]; then
+  cat "$FAKE_LISTENER_PID_FILE"
+fi
+|};
+          write_executable (Filename.concat fake_bin "curl")
+            "#!/bin/sh\nexit 0\n";
+          write_executable child_script
+            (Printf.sprintf
+               {|#!/bin/bash
+set -eu
+count=0
+if [ -f %s ]; then
+  count="$(cat %s)"
+fi
+count=$((count + 1))
+printf '%%s\n' "$count" > %s
+printf '%%s\n' "$$" > %s
+hash="$("${MASC_RUNTIME_ARTIFACT_CONTRACT:?}" hash "$0")"
+"$MASC_RUNTIME_ARTIFACT_CONTRACT" write \
+  "${MASC_RUNTIME_CANDIDATE_FILE:?}" http "$0" "$hash" 9999
+while [ ! -f "${MASC_RUNTIME_HEALTH_PROOF_FILE:?}" ]; do
+  sleep 0.02
+done
+if [ "$count" -ge 6 ]; then
+  kill -TERM "$PPID"
+  while true; do
+    sleep 1
+  done
+fi
+exit 23
+|}
+               (quote invocation_count) (quote invocation_count)
+               (quote invocation_count) (quote listener_pid_file));
+          let code, stdout, stderr =
+            run_script ~cwd:repo_root supervisor_script
+              ~env:
+                [
+                  ("FAKE_LISTENER_PID_FILE", listener_pid_file);
+                  ("MASC_RUNTIME_LKG_FILE", lkg_file);
+                  ("MASC_SUPERVISOR_HEALTH_PROBE_SEC", "1");
+                  ("MASC_SUPERVISOR_LOG", log_file);
+                  ("MASC_RESTART_COOLDOWN_SEC", "0");
+                  ("PATH", fake_bin ^ ":" ^ Sys.getenv "PATH");
+                ]
+              []
+          in
+          check int "external stop signal remains explicit" 143 code;
+          check string "child keeps restarting after repeated healthy failures"
+            "6\n" (read_file invocation_count);
+          let log = read_file log_file in
+          check bool "real child exit status is recorded" true
+            (contains_substring log "masc exited code=23");
+          check bool "each restart is preceded by health proof" true
+            (contains_substring log "health-verified runtime artifact promoted");
+          check bool "child failure is not rewritten as success" false
+            (contains_substring log "masc exited code=0");
+          check string "supervisor writes no stdout" "" stdout;
+          check bool "external stop is logged" true
+            (contains_substring stderr "supervisor received SIGTERM");
+          check bool "finite crash-loop abort is absent" false
+            (contains_substring stderr "ABORT:")))
 
 let () =
   run "start_masc_script"
@@ -1301,6 +1561,10 @@ let () =
             test_dune_cache_temp_error_retries_with_cache_disabled;
 	          test_case "stale executable requires build lock" `Quick
 	            test_stale_executable_requires_build_lock;
+	          test_case "build tempfail runs only hash-verified LKG" `Quick
+	            test_build_tempfail_runs_only_hash_verified_lkg;
+	          test_case "build tempfail rejects LKG hash mismatch" `Quick
+	            test_build_tempfail_rejects_lkg_hash_mismatch;
 	          test_case "default build lock is worktree-local" `Quick
 	            test_default_build_lock_is_worktree_local;
 	          test_case "stdio entrypoint uses shared base path guard" `Quick
@@ -1326,6 +1590,10 @@ let () =
             "loopback disables keeper autoboot by default and requires opt-in"
             `Quick
             test_loopback_disables_keeper_autoboot_by_default_and_requires_opt_in;
+          test_case "supervisor stops on startup without candidate" `Quick
+            test_supervisor_stops_on_startup_without_candidate;
+          test_case "supervisor promotes PID-bound healthy candidate" `Quick
+            test_supervisor_promotes_pid_bound_healthy_candidate;
           test_case
             "supervisor restarts without exit limit and preserves status"
             `Quick


### PR DESCRIPTION
## 문제

감독 재시작이 로컬 개발 빌드 가능성과 결합되어 있습니다. 다른 Dune 빌드가 락을 점유하면 `start-masc.sh`의 typed temporary failure(75)가 일반 실패로 축약되고, supervisor가 건강한 런타임 후보가 한 번도 뜨지 않았는데도 5초마다 재시도합니다.

실제 장애에서 child는 1–37초 안에 exit 1을 반복했고, 8935 listener가 없는 동안 dashboard/build 작업만 계속 증폭되었습니다.

Closes #25133

## 변경

- exact 5-line `masc.runtime_artifact.v1` descriptor를 런타임 artifact SSOT로 추가
- executable의 절대 경로와 SHA-256을 원자적으로 기록·검증
- mutable Dune artifact는 content-addressed sibling LKG로 복사 후 재해시
- supervisor가 다음 세 조건을 모두 증명한 후보만 LKG로 승격
  - listener PID = supervised child PID
  - `/health` 성공
  - 실행 artifact hash = candidate descriptor hash
- build/rebuild 실패 시 검증된 LKG만 실행
- candidate 또는 PID-bound health proof가 없는 시작 실패는 terminal로 처리해 retry amplification 차단
- 이미 health-proven인 runtime의 실제 crash만 기존 연속 재시작 의미 유지
- build exit 75를 끝까지 보존

## 제품 효과

- 개발 빌드 경합 중에도 검증된 LKG가 있으면 서비스 복구 가능
- hash mismatch/unknown stale executable 실행은 0
- 첫 실행조차 성공하지 못한 프로세스의 무한 재시도는 1회 terminal
- “프로세스가 떴다”가 아닌 “그 child가 실제 listener이고 health를 통과했다”를 복구 권한의 근거로 사용

## 검증

- RED: 구현 전 신규 fault-path 테스트 4/4 실패 확인
- `bash -n`: 통과
- `shellcheck scripts/lib/runtime-artifact-contract.sh scripts/start-masc-supervised.sh`: 통과
- `ocamlformat --check test/test_start_masc_script.ml`: 통과
- `git diff --check`: 통과
- 이전 구현 단계에서 관련 focused tests 통과
- 현재-head 전체 focused 재실행: 외부 bare Dune 프로세스가 repo lock을 장시간 점유해 아직 미완료
- Build and Test 포함 PR CI를 완료 기준으로 유지하며, 그 전까지 Draft 유지

## 설계/운영 Matrix

`docs/design/2026-07-18-supervised-runtime-lkg-operation-matrix.html`

정량 목표와 AS-IS/TO-BE FSM, descriptor invariant, failure matrix, 10 Keeper AFK 제품 게이트를 포함합니다.
