### PR TITLE
refactor(keeper): consume no-eligible summary from task SSOT leaf

### DIFF
--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -234,10 +234,8 @@ let no_eligible_action_for_claim_scope claim_goal_scope ~excluded_count =
       scope_hint
 ;;
 
-let no_eligible_exclusion_summary ~scope_excluded_count =
-  Printf.sprintf
-    "Diagnostics: goal_scope_or_filter=%d."
-    scope_excluded_count
+let no_eligible_exclusion_summary =
+  Masc_task_handlers.Tool_task_no_eligible.no_eligible_exclusion_summary
 ;;
 
 


### PR DESCRIPTION
## 목표
48h 병합 SSOT 감사(base `b56878055c`^..`3be51c2160`)에서 확정된 N-of-M 병렬 저작 위반 해소: `no_eligible_exclusion_summary`가 두 모듈에 동일 시그니처로 독립 정의되어 있고 이미 케이스 drift가 발생한 상태.

## 변경
- `lib/keeper/keeper_tool_task_runtime.ml:237` 사설 복제본 삭제 → `Masc_task_handlers.Tool_task_no_eligible.no_eligible_exclusion_summary` alias 소비 (`tool_task_handlers.ml:557`과 동일 idiom)

## 근거
- #24826이 blocker→exclusion rename을 keeper 복제본/SSOT 리프/handlers wrapper 3곳에서 각각 수행 (병렬 저작)
- 실측 drift: keeper 복제본 `"Diagnostics: goal_scope_or_filter=%d."` vs SSOT 리프 `"diagnostics: goal_scope_or_filter=%d."` — 같은 렌더 개념이 표면별로 다른 산문
- `Tool_task_no_eligible`은 doc comment에 "Verbatim extract from Tool_task" 명시된 SSOT 리프이며, `masc` 라이브러리는 이미 `masc.task_handlers` 의존 (lib/dune:270) — 경계 방향 문제 없음
- 렌더 결과: keeper no-eligible 메시지의 `Diagnostics:` → `diagnostics:` (dashboard prefix 분류기는 `"No eligible tasks"` prefix만 매칭하므로 영향 없음, 이 문자열을 고정하는 테스트 0건 확인)

## 검증
- `dune build --root .` 전체 green (agent_sdk 0.216.3 pin 동기화 후)
- `test_keeper_task_outcomes` 6 tests / `test_tool_task_coverage` 97 tests green
- 문자열 재고정 테스트는 의도적으로 미추가: 정의가 하나가 되어 drift가 타입 수준에서 불가능해졌고, 산문 substring 고정은 이번 감사가 지적한 안티패턴

## 관련
- 잔여 범위 (렌더러 3벌→1 수렴 + dashboard prefix 분류기 2벌 구조화 전환): #25144
- 감사 발견 이슈: #25139 #25140 #25141 #25142 #25143 / 기존 이슈 보강: #25034
- MASC task-2301

🤖 Generated with [Claude Code](https://claude.com/claude-code)
