### PR TITLE
refactor(connector): preserve binding store failures

### DIFF
--- a/lib/gate/channel_gate_binding_store.ml
+++ b/lib/gate/channel_gate_binding_store.ml
@@ -197,10 +197,18 @@ let read_bindings_result store : (binding list, binding_store_error) result =
     |> Result.map_error (fun error ->
          Binding_store_decode_failed { path; error })
 
-let read_bindings store : binding list =
-  match read_bindings_result store with
-  | Ok bindings -> bindings
-  | Error _ -> []
+let bound_channels_result store ~keeper_name =
+  let normalized = String.trim keeper_name in
+  if String.equal normalized "" then Ok []
+  else
+    read_bindings_result store
+    |> Result.map (fun bindings ->
+         List.filter_map
+           (fun (binding : binding) ->
+             if String.equal binding.keeper_name normalized then
+               Some binding.channel_id
+             else None)
+           bindings)
 
 let binding_json (binding : binding) =
   `Assoc
@@ -211,9 +219,7 @@ let binding_json (binding : binding) =
 
 (* Durable atomic write delegated to the Fs_compat durability SSOT:
    tmp -> fsync(tmp) -> rename -> best-effort fsync(parent dir), the same
-   primitive board/event-queue/Memory-OS persistence use. The result-returning
-   form is the authority for transactional callers; [save_bindings] preserves
-   the older connector interface until those callers move to [mutate_bindings]. *)
+   primitive board/event-queue/Memory-OS persistence use. *)
 let save_bindings_result store (bindings : binding list) =
   let path = store.binding_store_path () in
   let normalized =
@@ -236,11 +242,6 @@ let save_bindings_result store (bindings : binding list) =
   | Sys_error detail -> Error detail
   | Unix.Unix_error (code, fn, arg) ->
     Error (unix_error_message path fn arg code)
-
-let save_bindings store bindings =
-  match save_bindings_result store bindings with
-  | Ok () -> ()
-  | Error msg -> raise (Sys_error msg)
 
 let guild_id_items store event =
   match store.guild_id_field with
@@ -279,11 +280,6 @@ let append_audit_event_result store event =
   | Sys_error detail -> Error (Audit_io_failed detail)
   | Unix.Unix_error (code, fn, arg) ->
     Error (Audit_io_failed (unix_error_message path fn arg code))
-
-let append_audit_event store event =
-  match append_audit_event_result store event with
-  | Ok () -> ()
-  | Error error -> raise (Sys_error (audit_append_error_to_string error))
 
 let mutate_bindings store ~decide =
   Cross_context_mutex.with_durable_lock store.mutation_lock (fun () ->

--- a/lib/gate/channel_gate_binding_store.mli
+++ b/lib/gate/channel_gate_binding_store.mli
@@ -73,11 +73,10 @@ val binding_store_error_to_string : binding_store_error -> string
 val audit_append_error_to_string : audit_append_error -> string
 val mutation_error_to_string : mutation_error -> string
 val read_bindings_result : t -> (binding list, binding_store_error) result
-val read_bindings : t -> binding list
+val bound_channels_result :
+  t -> keeper_name:string -> (string list, binding_store_error) result
 val binding_json : binding -> Yojson.Safe.t
-val save_bindings : t -> binding list -> unit
 val audit_event_json : t -> audit_event -> Yojson.Safe.t
-val append_audit_event : t -> audit_event -> unit
 val mutate_bindings :
   t ->
   decide:(binding list -> (binding list * audit_event * 'a, string) result) ->

--- a/lib/gate/channel_gate_connector.ml
+++ b/lib/gate/channel_gate_connector.ml
@@ -21,7 +21,9 @@ module type S = sig
     channel_id:string ->
     actor_name:string ->
     (Yojson.Safe.t, string) result
-  val bound_channels : keeper_name:string -> string list
+  val bound_channels :
+    keeper_name:string ->
+    (string list, Channel_gate_binding_store.binding_store_error) result
   val connected : unit -> bool
 end
 

--- a/lib/gate/channel_gate_connector.mli
+++ b/lib/gate/channel_gate_connector.mli
@@ -49,10 +49,13 @@ module type S = sig
     (Yojson.Safe.t, string) result
   (** Remove a channel-to-keeper binding. *)
 
-  val bound_channels : keeper_name:string -> string list
+  val bound_channels :
+    keeper_name:string ->
+    (string list, Channel_gate_binding_store.binding_store_error) result
   (** Channel ids currently bound to [keeper_name], freshly read from
       the connector's binding store on each call (no cached state).
-      Sorted by channel id. RFC-0223 P2. *)
+      Sorted by channel id. Binding-store failure is distinct from an
+      unbound keeper. RFC-0223 P2. *)
 
   val connected : unit -> bool
   (** Whether the connector's transport is currently believed live.

--- a/lib/gate/channel_gate_discord_state.ml
+++ b/lib/gate/channel_gate_discord_state.ml
@@ -557,26 +557,11 @@ let keeper_for_channel_result ~channel_id =
    presence state. *)
 
 let bound_channels_result ~keeper_name =
-  let normalized = String.trim keeper_name in
-  if String.equal normalized "" then Ok []
-  else
-    read_bindings_lookup_result ()
-    |> Result.map (fun bindings ->
-         bindings
-         |> List.filter_map (fun (b : binding) ->
-              if String.equal b.keeper_name normalized
-              then Some b.channel_id
-              else None))
+  Store.bound_channels_result binding_store ~keeper_name
+  |> Result.map_error (fun error -> Binding_store_read_failed error)
 
 let bound_channels ~keeper_name =
-  match bound_channels_result ~keeper_name with
-  | Ok channels -> channels
-  | Error detail ->
-    Log.Discord.error
-      "Discord binding presence read failed (keeper=%s): %s"
-      keeper_name
-      (binding_lookup_error_to_string detail);
-    []
+  Store.bound_channels_result binding_store ~keeper_name
 
 let connected () =
   (* The in-process gateway (RFC-0203) is the only Discord transport;

--- a/lib/gate/channel_gate_discord_state.mli
+++ b/lib/gate/channel_gate_discord_state.mli
@@ -87,12 +87,12 @@ val resolve_keeper_for_channel_result :
 (** Resolve the keeper for [channel_id]. Exact bindings win. The only
     parent fallback is an in-process thread-registry observation. *)
 
-val bound_channels : keeper_name:string -> string list
+val bound_channels :
+  keeper_name:string ->
+  (string list, Channel_gate_binding_store.binding_store_error) result
 (** Channel snowflakes bound to [keeper_name], freshly read from the
-    binding store on each call. The generic connector interface cannot carry
-    an error, so store failures are logged before returning an empty projection.
-    Callers that need control-flow authority must use
-    {!bound_channels_result}. RFC-0223 P2 presence. *)
+    binding store on each call. Store failure remains distinct from an empty
+    binding set. RFC-0223 P2 presence. *)
 
 val bound_channels_result :
   keeper_name:string -> (string list, binding_lookup_error) result

--- a/lib/gate/channel_gate_imessage_state.ml
+++ b/lib/gate/channel_gate_imessage_state.ml
@@ -112,12 +112,12 @@ let status_json ?(audit_limit = 10) () =
   let binding_store_path = binding_store_read_path () in
   let audit_path = binding_audit_read_path () in
   let configured_bindings_result = read_bindings_result () in
-  let configured_bindings = Result.value ~default:[] configured_bindings_result in
-  let binding_store_read_ok = Result.is_ok configured_bindings_result in
-  let binding_store_error =
-    Result.fold ~ok:(fun _ -> "")
-      ~error:Store.binding_store_error_to_string configured_bindings_result
+  let configured_bindings, binding_store_error =
+    match configured_bindings_result with
+    | Ok bindings -> bindings, ""
+    | Error error -> [], Store.binding_store_error_to_string error
   in
+  let binding_store_read_ok = Result.is_ok configured_bindings_result in
   let recent_audit = read_recent_audit ~limit:audit_limit in
   let available = Option.is_some live_status && binding_store_read_ok in
   let updated_at =
@@ -256,12 +256,16 @@ let bind ~channel_id ~keeper_name ~actor_name =
   else
     Store.mutate_bindings binding_store ~decide:(fun original_bindings ->
       let previous_keeper =
-        original_bindings
-        |> List.find_map (fun (binding : binding) ->
-               if String.equal binding.channel_id channel_id then
-                 Some binding.keeper_name
-               else None)
-        |> Option.value ~default:""
+        match
+          List.find_map
+            (fun (binding : binding) ->
+              if String.equal binding.channel_id channel_id then
+                Some binding.keeper_name
+              else None)
+            original_bindings
+        with
+        | Some name -> name
+        | None -> ""
       in
       let updated_bindings =
         (({ channel_id; keeper_name } : binding)

--- a/lib/gate/channel_gate_imessage_state.ml
+++ b/lib/gate/channel_gate_imessage_state.ml
@@ -64,10 +64,8 @@ let binding_store =
     ~binding_audit_read_path ~guild_id_field:Store.Omit
 
 let read_json_file_opt = Store.read_json_file_opt
-let read_bindings () = Store.read_bindings binding_store
+let read_bindings_result () = Store.read_bindings_result binding_store
 let binding_json = Store.binding_json
-let save_bindings bindings = Store.save_bindings binding_store bindings
-let append_audit_event event = Store.append_audit_event binding_store event
 let read_recent_audit ~limit = Store.read_recent_audit binding_store ~limit
 
 let string_member json key =
@@ -97,13 +95,7 @@ let connector_state_label ~available ~connected ~stale =
    presence state. *)
 
 let bound_channels ~keeper_name =
-  let normalized = String.trim keeper_name in
-  if String.equal normalized "" then []
-  else
-    read_bindings ()
-    |> List.filter_map (fun (b : binding) ->
-           if String.equal b.keeper_name normalized then Some b.channel_id
-           else None)
+  Store.bound_channels_result binding_store ~keeper_name
 
 let connected () =
   (* Same liveness reading as [status_json]: the sidecar heartbeats its
@@ -119,9 +111,15 @@ let status_json ?(audit_limit = 10) () =
   let live_status = read_json_file_opt status_path in
   let binding_store_path = binding_store_read_path () in
   let audit_path = binding_audit_read_path () in
-  let configured_bindings = read_bindings () in
+  let configured_bindings_result = read_bindings_result () in
+  let configured_bindings = Result.value ~default:[] configured_bindings_result in
+  let binding_store_read_ok = Result.is_ok configured_bindings_result in
+  let binding_store_error =
+    Result.fold ~ok:(fun _ -> "")
+      ~error:Store.binding_store_error_to_string configured_bindings_result
+  in
   let recent_audit = read_recent_audit ~limit:audit_limit in
-  let available = Option.is_some live_status in
+  let available = Option.is_some live_status && binding_store_read_ok in
   let updated_at =
     match live_status with
     | Some json -> string_member json "updated_at"
@@ -130,10 +128,14 @@ let status_json ?(audit_limit = 10) () =
   let stale = if not available then true else stale_of_updated_at updated_at in
   let connected =
     match live_status with
-    | Some json -> bool_member json "connected" && not stale
+    | Some json ->
+      binding_store_read_ok && bool_member json "connected" && not stale
     | None -> false
   in
-  let error = if available then "" else "connector status file not found" in
+  let error =
+    if not binding_store_read_ok then binding_store_error
+    else if available then "" else "connector status file not found"
+  in
   let status_field key f default =
     match live_status with
     | Some json -> f json key
@@ -150,6 +152,8 @@ let status_json ?(audit_limit = 10) () =
       ("error", `String error);
       ("status_path", `String status_path);
       ("binding_store_path", `String binding_store_path);
+      ("binding_store_read_ok", `Bool binding_store_read_ok);
+      ("binding_store_error", `String binding_store_error);
       ("audit_path", `String audit_path);
       ("updated_at", `String updated_at);
       ("reply_mode", `String (status_field "reply_mode" string_member ""));
@@ -219,6 +223,8 @@ let connector_json ?gate_status_json ?(audit_limit = 10) () =
       ("stale", `Bool (bool_member status "stale"));
       ("stale_after_sec", `Int (int_member status "stale_after_sec"));
       ("error", `String (string_member status "error"));
+      ("binding_store_read_ok", status |> U.member "binding_store_read_ok");
+      ("binding_store_error", status |> U.member "binding_store_error");
       ("updated_at", `String (string_member status "updated_at"));
       ("reply_mode", `String (string_member status "reply_mode"));
       ("self_chat_guid", `String (string_member status "self_chat_guid"));
@@ -240,10 +246,6 @@ let connector_json ?gate_status_json ?(audit_limit = 10) () =
       ("observed_channel", observed_channel);
     ]
 
-let rollback_bindings original_bindings =
-  try save_bindings original_bindings with
-  | Sys_error _ -> ()
-
 let bind ~channel_id ~keeper_name ~actor_name =
   let channel_id = String.trim channel_id in
   let keeper_name = String.trim keeper_name in
@@ -252,29 +254,25 @@ let bind ~channel_id ~keeper_name ~actor_name =
   else if keeper_name = "" then
     Error "keeper_name is required"
   else
-    let original_bindings = read_bindings () in
-    let previous_keeper =
-      original_bindings
-      |> List.find_map (fun (binding : binding) ->
-             if String.equal binding.channel_id channel_id then
-               Some binding.keeper_name
-             else
-               None)
-      |> Option.value ~default:""
-    in
-    let updated_bindings =
-      (({ channel_id; keeper_name } : binding)
-       :: List.filter
-            (fun (binding : binding) ->
-              not (String.equal binding.channel_id channel_id))
-            original_bindings)
-      |> List.sort (fun (a : binding) (b : binding) ->
-             String.compare a.channel_id b.channel_id)
-    in
-    try
-      save_bindings updated_bindings;
-      append_audit_event
-        Store.{
+    Store.mutate_bindings binding_store ~decide:(fun original_bindings ->
+      let previous_keeper =
+        original_bindings
+        |> List.find_map (fun (binding : binding) ->
+               if String.equal binding.channel_id channel_id then
+                 Some binding.keeper_name
+               else None)
+        |> Option.value ~default:""
+      in
+      let updated_bindings =
+        (({ channel_id; keeper_name } : binding)
+         :: List.filter
+              (fun (binding : binding) ->
+                not (String.equal binding.channel_id channel_id))
+              original_bindings)
+        |> List.sort (fun (a : binding) (b : binding) ->
+               String.compare a.channel_id b.channel_id)
+      in
+      let event = Store.{
           timestamp = Gate_time_util.iso8601_of_unix (Unix.gettimeofday ());
           action = "bind";
           guild_id = None;
@@ -283,36 +281,32 @@ let bind ~channel_id ~keeper_name ~actor_name =
           actor_id = actor_name;
           actor_name;
           previous_keeper;
-        };
-      Ok (status_json ())
-    with
-    | Sys_error msg ->
-        rollback_bindings original_bindings;
-        Error msg
+        }
+      in
+      Ok (updated_bindings, event, ()))
+    |> Result.map_error Store.mutation_error_to_string
+    |> Result.map (fun () -> status_json ())
 
 let unbind ~channel_id ~actor_name =
   let channel_id = String.trim channel_id in
   if channel_id = "" then
     Error "channel_id is required"
   else
-    let original_bindings = read_bindings () in
-    match
-      original_bindings
-      |> List.find_opt (fun (binding : binding) ->
-             String.equal binding.channel_id channel_id)
-    with
-    | None -> Error "binding not found"
-    | Some (removed_binding : binding) ->
+    Store.mutate_bindings binding_store ~decide:(fun original_bindings ->
+      match
+        original_bindings
+        |> List.find_opt (fun (binding : binding) ->
+               String.equal binding.channel_id channel_id)
+      with
+      | None -> Error "binding not found"
+      | Some (removed_binding : binding) ->
         let updated_bindings =
           List.filter
             (fun (binding : binding) ->
               not (String.equal binding.channel_id channel_id))
             original_bindings
         in
-        try
-          save_bindings updated_bindings;
-          append_audit_event
-            Store.{
+        let event = Store.{
               timestamp = Gate_time_util.iso8601_of_unix (Unix.gettimeofday ());
               action = "unbind";
               guild_id = None;
@@ -321,9 +315,8 @@ let unbind ~channel_id ~actor_name =
               actor_id = actor_name;
               actor_name;
               previous_keeper = removed_binding.keeper_name;
-            };
-          Ok (status_json ())
-        with
-        | Sys_error msg ->
-            rollback_bindings original_bindings;
-            Error msg
+            }
+        in
+        Ok (updated_bindings, event, ()))
+    |> Result.map_error Store.mutation_error_to_string
+    |> Result.map (fun () -> status_json ())

--- a/lib/gate/channel_gate_imessage_state.mli
+++ b/lib/gate/channel_gate_imessage_state.mli
@@ -55,9 +55,11 @@ val unbind :
 
 (** {1 Presence (RFC-0223 P2)} *)
 
-val bound_channels : keeper_name:string -> string list
+val bound_channels :
+  keeper_name:string ->
+  (string list, Channel_gate_binding_store.binding_store_error) result
 (** Channel ids bound to [keeper_name], freshly read from the binding
-    store on each call. *)
+    store on each call. Store failure is distinct from no bindings. *)
 
 val connected : unit -> bool
 (** Whether the sidecar's status file reports a live, non-stale

--- a/lib/gate/channel_gate_sidecar_state.ml
+++ b/lib/gate/channel_gate_sidecar_state.ml
@@ -114,12 +114,12 @@ module Make (Config : Config) = struct
     let binding_store_path = binding_store_read_path () in
     let audit_path = binding_audit_read_path () in
     let configured_bindings_result = read_bindings_result () in
-    let configured_bindings = Result.value ~default:[] configured_bindings_result in
-    let binding_store_read_ok = Result.is_ok configured_bindings_result in
-    let binding_store_error =
-      Result.fold ~ok:(fun _ -> "")
-        ~error:Store.binding_store_error_to_string configured_bindings_result
+    let configured_bindings, binding_store_error =
+      match configured_bindings_result with
+      | Ok bindings -> bindings, ""
+      | Error error -> [], Store.binding_store_error_to_string error
     in
+    let binding_store_read_ok = Result.is_ok configured_bindings_result in
     let recent_audit = read_recent_audit ~limit:audit_limit in
     let available = Option.is_some live_status && binding_store_read_ok in
     let updated_at =
@@ -314,12 +314,16 @@ module Make (Config : Config) = struct
     else
       Store.mutate_bindings binding_store ~decide:(fun original_bindings ->
         let previous_keeper =
-          original_bindings
-          |> List.find_map (fun (binding : binding) ->
-                 if String.equal binding.channel_id channel_id then
-                   Some binding.keeper_name
-                 else None)
-          |> Option.value ~default:""
+          match
+            List.find_map
+              (fun (binding : binding) ->
+                if String.equal binding.channel_id channel_id then
+                  Some binding.keeper_name
+                else None)
+              original_bindings
+          with
+          | Some name -> name
+          | None -> ""
         in
         let updated_bindings =
           ({ channel_id; keeper_name } : binding)

--- a/lib/gate/channel_gate_sidecar_state.ml
+++ b/lib/gate/channel_gate_sidecar_state.ml
@@ -64,10 +64,8 @@ module Make (Config : Config) = struct
       ~guild_id_field:Store.Include_empty
 
   let read_json_file_opt = Store.read_json_file_opt
-  let read_bindings () = Store.read_bindings binding_store
+  let read_bindings_result () = Store.read_bindings_result binding_store
   let binding_json = Store.binding_json
-  let save_bindings bindings = Store.save_bindings binding_store bindings
-  let append_audit_event event = Store.append_audit_event binding_store event
   let read_recent_audit ~limit = Store.read_recent_audit binding_store ~limit
 
   let string_member json key =
@@ -99,13 +97,7 @@ module Make (Config : Config) = struct
      cached presence state. *)
 
   let bound_channels ~keeper_name =
-    let normalized = String.trim keeper_name in
-    if String.equal normalized "" then []
-    else
-      read_bindings ()
-      |> List.filter_map (fun (b : binding) ->
-             if String.equal b.keeper_name normalized then Some b.channel_id
-             else None)
+    Store.bound_channels_result binding_store ~keeper_name
 
   let connected () =
     (* Same liveness reading as [status_json]: the sidecar heartbeats
@@ -121,9 +113,15 @@ module Make (Config : Config) = struct
     let live_status = read_json_file_opt status_path in
     let binding_store_path = binding_store_read_path () in
     let audit_path = binding_audit_read_path () in
-    let configured_bindings = read_bindings () in
+    let configured_bindings_result = read_bindings_result () in
+    let configured_bindings = Result.value ~default:[] configured_bindings_result in
+    let binding_store_read_ok = Result.is_ok configured_bindings_result in
+    let binding_store_error =
+      Result.fold ~ok:(fun _ -> "")
+        ~error:Store.binding_store_error_to_string configured_bindings_result
+    in
     let recent_audit = read_recent_audit ~limit:audit_limit in
-    let available = Option.is_some live_status in
+    let available = Option.is_some live_status && binding_store_read_ok in
     let updated_at =
       match live_status with
       | Some json -> string_member json "updated_at"
@@ -132,10 +130,14 @@ module Make (Config : Config) = struct
     let stale = if not available then true else stale_of_updated_at updated_at in
     let connected =
       match live_status with
-      | Some json -> bool_member json "connected" && not stale
+      | Some json ->
+        binding_store_read_ok && bool_member json "connected" && not stale
       | None -> false
     in
-    let error = if available then "" else "connector status file not found" in
+    let error =
+      if not binding_store_read_ok then binding_store_error
+      else if available then "" else "connector status file not found"
+    in
     let status_field key f default =
       match live_status with
       | Some json -> f json key
@@ -152,6 +154,8 @@ module Make (Config : Config) = struct
         ("error", `String error);
         ("status_path", `String status_path);
         ("binding_store_path", `String binding_store_path);
+        ("binding_store_read_ok", `Bool binding_store_read_ok);
+        ("binding_store_error", `String binding_store_error);
         ("audit_path", `String audit_path);
         ("updated_at", `String updated_at);
         ("last_message_at", `String (status_field "last_message_at" string_member ""));
@@ -268,6 +272,8 @@ module Make (Config : Config) = struct
         ("error", `String (string_member status "error"));
         ("status_path", `String (string_member status "status_path"));
         ("binding_store_path", `String (string_member status "binding_store_path"));
+        ("binding_store_read_ok", status |> U.member "binding_store_read_ok");
+        ("binding_store_error", status |> U.member "binding_store_error");
         ("audit_path", `String (string_member status "audit_path"));
         ("updated_at", `String (string_member status "updated_at"));
         ("last_message_at", `String (string_member status "last_message_at"));
@@ -300,38 +306,31 @@ module Make (Config : Config) = struct
             ] );
       ]
 
-  let rollback_bindings original_bindings =
-    try save_bindings original_bindings with
-    | Sys_error _ -> ()
-
   let bind ~channel_id ~keeper_name ~actor_name =
     let channel_id = String.trim channel_id in
     let keeper_name = String.trim keeper_name in
     if channel_id = "" then Error "channel_id is required"
     else if keeper_name = "" then Error "keeper_name is required"
     else
-      let original_bindings = read_bindings () in
-      let previous_keeper =
-        original_bindings
-        |> List.find_map (fun (binding : binding) ->
-               if String.equal binding.channel_id channel_id then
-                 Some binding.keeper_name
-               else None)
-        |> Option.value ~default:""
-      in
-      let updated_bindings =
-        ({ channel_id; keeper_name } : binding)
-        :: List.filter
-             (fun (binding : binding) ->
-               not (String.equal binding.channel_id channel_id))
-             original_bindings
-        |> List.sort (fun (a : binding) (b : binding) ->
-               String.compare a.channel_id b.channel_id)
-      in
-      try
-        save_bindings updated_bindings;
-        append_audit_event
-          Store.{
+      Store.mutate_bindings binding_store ~decide:(fun original_bindings ->
+        let previous_keeper =
+          original_bindings
+          |> List.find_map (fun (binding : binding) ->
+                 if String.equal binding.channel_id channel_id then
+                   Some binding.keeper_name
+                 else None)
+          |> Option.value ~default:""
+        in
+        let updated_bindings =
+          ({ channel_id; keeper_name } : binding)
+          :: List.filter
+               (fun (binding : binding) ->
+                 not (String.equal binding.channel_id channel_id))
+               original_bindings
+          |> List.sort (fun (a : binding) (b : binding) ->
+                 String.compare a.channel_id b.channel_id)
+        in
+        let event = Store.{
             timestamp = Gate_time_util.iso8601_of_unix (Unix.gettimeofday ());
             action = "bind";
             guild_id = None;
@@ -340,35 +339,31 @@ module Make (Config : Config) = struct
             actor_id = actor_name;
             actor_name;
             previous_keeper;
-          };
-        Ok (status_json ())
-      with
-      | Sys_error msg ->
-          rollback_bindings original_bindings;
-          Error msg
+          }
+        in
+        Ok (updated_bindings, event, ()))
+      |> Result.map_error Store.mutation_error_to_string
+      |> Result.map (fun () -> status_json ())
 
   let unbind ~channel_id ~actor_name =
     let channel_id = String.trim channel_id in
     if channel_id = "" then Error "channel_id is required"
     else
-      let original_bindings = read_bindings () in
-      match
-        List.find_opt
-          (fun (binding : binding) -> String.equal binding.channel_id channel_id)
-          original_bindings
-      with
-      | None -> Error "binding not found"
-      | Some previous ->
+      Store.mutate_bindings binding_store ~decide:(fun original_bindings ->
+        match
+          List.find_opt
+            (fun (binding : binding) -> String.equal binding.channel_id channel_id)
+            original_bindings
+        with
+        | None -> Error "binding not found"
+        | Some previous ->
           let updated_bindings =
             List.filter
               (fun (binding : binding) ->
                 not (String.equal binding.channel_id channel_id))
               original_bindings
           in
-          try
-            save_bindings updated_bindings;
-            append_audit_event
-              Store.{
+          let event = Store.{
                 timestamp = Gate_time_util.iso8601_of_unix (Unix.gettimeofday ());
                 action = "unbind";
                 guild_id = None;
@@ -377,10 +372,9 @@ module Make (Config : Config) = struct
                 actor_id = actor_name;
                 actor_name;
                 previous_keeper = previous.keeper_name;
-              };
-            Ok (status_json ())
-          with
-          | Sys_error msg ->
-              rollback_bindings original_bindings;
-              Error msg
+              }
+          in
+          Ok (updated_bindings, event, ()))
+      |> Result.map_error Store.mutation_error_to_string
+      |> Result.map (fun () -> status_json ())
 end

--- a/lib/gate/channel_gate_slack_state.ml
+++ b/lib/gate/channel_gate_slack_state.ml
@@ -120,12 +120,10 @@ let status_json ?(audit_limit = 10) () =
   let startup_ok = Option.is_none startup_error in
   let configured_bindings_result = read_bindings_result () in
   let binding_store_read_ok = Result.is_ok configured_bindings_result in
-  let configured_bindings =
-    Result.value ~default:[] configured_bindings_result
-  in
-  let binding_store_error =
-    Result.fold ~ok:(fun _ -> "")
-      ~error:Store.binding_store_error_to_string configured_bindings_result
+  let configured_bindings, binding_store_error =
+    match configured_bindings_result with
+    | Ok bindings -> bindings, ""
+    | Error error -> [], Store.binding_store_error_to_string error
   in
   let available = app_present && startup_ok && binding_store_read_ok in
   let connected =

--- a/lib/gate/channel_gate_slack_state.ml
+++ b/lib/gate/channel_gate_slack_state.ml
@@ -54,11 +54,8 @@ let binding_store =
     ~binding_audit_path ~binding_audit_read_path:binding_audit_path
     ~guild_id_field:Store.Omit
 
-let read_bindings () = Store.read_bindings binding_store
 let read_bindings_result () = Store.read_bindings_result binding_store
 let binding_json = Store.binding_json
-let save_bindings bindings = Store.save_bindings binding_store bindings
-let append_audit_event event = Store.append_audit_event binding_store event
 let read_recent_audit ~limit = Store.read_recent_audit binding_store ~limit
 
 let stale_after_sec () =
@@ -121,9 +118,19 @@ let status_json ?(audit_limit = 10) () =
   let app_present = Option.is_some (app_token_opt ()) in
   (* Socket Mode needs the app token; without it the gateway never starts. *)
   let startup_ok = Option.is_none startup_error in
-  let available = app_present && startup_ok in
+  let configured_bindings_result = read_bindings_result () in
+  let binding_store_read_ok = Result.is_ok configured_bindings_result in
+  let configured_bindings =
+    Result.value ~default:[] configured_bindings_result
+  in
+  let binding_store_error =
+    Result.fold ~ok:(fun _ -> "")
+      ~error:Store.binding_store_error_to_string configured_bindings_result
+  in
+  let available = app_present && startup_ok && binding_store_read_ok in
   let connected =
     startup_ok
+    && binding_store_read_ok
     && match gateway_state with
        | Connected -> true
        | Disconnected | Awaiting_hello | Reconnect_pending _ | Failed _ -> false
@@ -132,7 +139,7 @@ let status_json ?(audit_limit = 10) () =
   (* NDT-OK: status_json is a dashboard observation boundary; this timestamp
      reports gateway freshness and is not used for control flow. *)
   let updated_at = Gate_time_util.iso8601_of_unix (Unix.gettimeofday ()) in
-  let error =
+  let transport_error =
     match startup_error with
     | Some message -> message
     | None ->
@@ -142,7 +149,9 @@ let status_json ?(audit_limit = 10) () =
        | Failed msg -> msg
        | Awaiting_hello | Connected | Reconnect_pending _ -> "")
   in
-  let configured_bindings = read_bindings () in
+  let error =
+    if not binding_store_read_ok then binding_store_error else transport_error
+  in
   let recent_audit = read_recent_audit ~limit:audit_limit in
   let configured_binding_json = List.map binding_json configured_bindings in
   `Assoc
@@ -160,6 +169,8 @@ let status_json ?(audit_limit = 10) () =
     ; ("binding_store_path", `String (binding_store_path ()))
     ; ("audit_path", `String (binding_audit_path ()))
     ; ("binding_source", `String "persisted")
+    ; ("binding_store_read_ok", `Bool binding_store_read_ok)
+    ; ("binding_store_error", `String binding_store_error)
     ; ("runtime_bindings_count", `Int (List.length configured_bindings))
     ; ("configured_bindings", `List configured_binding_json)
     ; ("recent_audit", `List recent_audit)
@@ -214,17 +225,13 @@ let connector_json ?gate_status_json ?(audit_limit = 10) () =
       :: without_identity)
   | other -> other
 
-let rollback_bindings original = save_bindings original
-
 let bind ~channel_id ~keeper_name ~actor_name =
   let channel_id = String.trim channel_id in
   let keeper_name = String.trim keeper_name in
   if String.equal channel_id "" then Error "channel_id is required"
   else if String.equal keeper_name "" then Error "keeper_name is required"
   else
-    match read_bindings_result () with
-    | Error error -> Error (Store.binding_store_error_to_string error)
-    | Ok original_bindings ->
+    Store.mutate_bindings binding_store ~decide:(fun original_bindings ->
       let previous_keeper =
         match
           List.find_map
@@ -245,11 +252,9 @@ let bind ~channel_id ~keeper_name ~actor_name =
         |> List.sort (fun (a : binding) (b : binding) ->
                String.compare a.channel_id b.channel_id)
       in
-      try
-        save_bindings updated_bindings;
-        append_audit_event
-          Store.
-            { timestamp =
+      let event =
+        Store.
+          { timestamp =
                 (* NDT-OK: binding audit wall-clock is operator-facing
                    telemetry only. *)
                 Gate_time_util.iso8601_of_unix (Unix.gettimeofday ())
@@ -259,17 +264,17 @@ let bind ~channel_id ~keeper_name ~actor_name =
             ; keeper_name
             ; actor_id = actor_name
             ; actor_name
-            ; previous_keeper };
-        Ok (status_json ())
-      with Sys_error msg -> rollback_bindings original_bindings; Error msg
+            ; previous_keeper }
+      in
+      Ok (updated_bindings, event, ()))
+    |> Result.map_error Store.mutation_error_to_string
+    |> Result.map (fun () -> status_json ())
 
 let unbind ~channel_id ~actor_name =
   let channel_id = String.trim channel_id in
   if String.equal channel_id "" then Error "channel_id is required"
   else
-    match read_bindings_result () with
-    | Error error -> Error (Store.binding_store_error_to_string error)
-    | Ok original_bindings -> (
+    Store.mutate_bindings binding_store ~decide:(fun original_bindings ->
       match
         original_bindings
         |> List.find_opt (fun (b : binding) ->
@@ -283,11 +288,9 @@ let unbind ~channel_id ~actor_name =
               not (String.equal b.channel_id channel_id))
             original_bindings
         in
-        try
-          save_bindings updated_bindings;
-          append_audit_event
-            Store.
-              { timestamp =
+        let event =
+          Store.
+            { timestamp =
                   (* NDT-OK: binding audit wall-clock is operator-facing
                      telemetry only. *)
                   Gate_time_util.iso8601_of_unix (Unix.gettimeofday ())
@@ -297,9 +300,11 @@ let unbind ~channel_id ~actor_name =
               ; keeper_name = removed.keeper_name
               ; actor_id = actor_name
               ; actor_name
-              ; previous_keeper = removed.keeper_name };
-          Ok (status_json ())
-        with Sys_error msg -> rollback_bindings original_bindings; Error msg)
+              ; previous_keeper = removed.keeper_name }
+        in
+        Ok (updated_bindings, event, ()))
+    |> Result.map_error Store.mutation_error_to_string
+    |> Result.map (fun () -> status_json ())
 
 (* ---- In-process gateway support (replaces sidecars/slack-bot/) ---- *)
 
@@ -324,7 +329,7 @@ let resolve_keeper_for_channel_result ~channel_id =
   if String.equal normalized "" then Ok None
   else
     match read_bindings_result () with
-    | Error error -> Error (Store.binding_store_error_to_string error)
+    | Error error -> Error error
     | Ok candidates -> (
       match binding_for_channel candidates ~channel_id:normalized with
       | Some b ->
@@ -336,30 +341,9 @@ let resolve_keeper_for_channel_result ~channel_id =
              ; via_parent = false })
       | None -> Ok None)
 
-let resolve_keeper_for_channel ~channel_id =
-  let normalized = String.trim channel_id in
-  match resolve_keeper_for_channel_result ~channel_id:normalized with
-  | Ok resolution -> resolution
-  | Error msg ->
-    if not (String.equal normalized "") then
-      Log.Slack.warn "slack binding lookup failed for channel_id=%s: %s"
-        normalized msg;
-    None
-
-let keeper_for_channel ~channel_id =
-  match resolve_keeper_for_channel ~channel_id with
-  | None -> None
-  | Some resolution -> Some resolution.keeper_name
-
 (* RFC-0223 P2 presence surface. Recomputed per call — no cached state. *)
 let bound_channels ~keeper_name =
-  let normalized = String.trim keeper_name in
-  if String.equal normalized "" then []
-  else
-    read_bindings ()
-    |> List.filter_map (fun (b : binding) ->
-           if String.equal b.keeper_name normalized then Some b.channel_id
-           else None)
+  Store.bound_channels_result binding_store ~keeper_name
 
 let connected () =
   (* The in-process gateway (RFC-0317) is the only Slack transport; its run

--- a/lib/gate/channel_gate_slack_state.mli
+++ b/lib/gate/channel_gate_slack_state.mli
@@ -11,11 +11,6 @@ include Channel_gate_connector.S
 
 (** {1 In-process gateway support} *)
 
-val keeper_for_channel : channel_id:string -> string option
-(** Look up the keeper bound to a Slack channel id. [None] when no binding
-    exists, the channel id is blank, or the binding store is unreadable after
-    logging the read failure. *)
-
 type keeper_binding_resolution = {
   keeper_name : string;
   incoming_channel_id : string;
@@ -23,15 +18,12 @@ type keeper_binding_resolution = {
   via_parent : bool;
 }
 
-val resolve_keeper_for_channel :
-  channel_id:string -> keeper_binding_resolution option
-(** Resolve the keeper for [channel_id]. Slack threads share the parent
-    channel id, so this is a single exact lookup — no thread→parent fallback. *)
-
 val resolve_keeper_for_channel_result :
-  channel_id:string -> (keeper_binding_resolution option, string) result
-(** Typed variant of {!resolve_keeper_for_channel}. Store read failures return
-    [Error] instead of being collapsed into an unbound channel. *)
+  channel_id:string ->
+  (keeper_binding_resolution option,
+   Channel_gate_binding_store.binding_store_error) result
+(** Resolve the keeper for [channel_id]. Store read failures remain typed and
+    distinct from an unbound channel. *)
 
 val record_ready : bot_user_id:string -> unit
 (** Called by the in-process gateway's hello handler. Stores the bot identity

--- a/lib/gate/gate_surface.ml
+++ b/lib/gate/gate_surface.ml
@@ -24,21 +24,47 @@ let of_source ~source ~workspace_id ~channel_id =
 
 type surface_presence = { surface : t; alive : bool }
 
+type presence_failure =
+  { connector_id : string
+  ; error : Channel_gate_binding_store.binding_store_error
+  }
+
+type presence_snapshot =
+  { surfaces : surface_presence list
+  ; failures : presence_failure list
+  }
+
 let surface_of_connector ~channel ~channel_id =
   of_source ~source:channel ~workspace_id:None ~channel_id:(Some channel_id)
 
 let connected_surfaces_for_keeper ~keeper_name =
-  let connector_surfaces =
+  let connector_surfaces, failures =
     Channel_gate_connector.all ()
-    |> List.concat_map (fun (module C : Channel_gate_connector.S) ->
-           let alive = C.connected () in
-           C.bound_channels ~keeper_name
-           |> List.map (fun channel_id ->
-                  { surface = surface_of_connector ~channel:C.channel ~channel_id
-                  ; alive
-                  }))
+    |> List.fold_left
+         (fun (surfaces, failures) (module C : Channel_gate_connector.S) ->
+           match C.bound_channels ~keeper_name with
+           | Error error ->
+             surfaces, { connector_id = C.connector_id; error } :: failures
+           | Ok channel_ids ->
+             let alive = C.connected () in
+             let connector_surfaces =
+               List.map
+                 (fun channel_id ->
+                   { surface =
+                       surface_of_connector ~channel:C.channel ~channel_id
+                   ; alive
+                   })
+                 channel_ids
+             in
+             List.rev_append connector_surfaces surfaces, failures)
+         ([], [])
+  in
+  let surfaces =
+    connector_surfaces
     (* Registry iteration order is a Hashtbl fold; sort for stable
        prompt rendering. *)
     |> List.sort compare
   in
-  { surface = Dashboard; alive = true } :: connector_surfaces
+  { surfaces = { surface = Dashboard; alive = true } :: surfaces
+  ; failures = List.sort compare failures
+  }

--- a/lib/gate/gate_surface.mli
+++ b/lib/gate/gate_surface.mli
@@ -37,15 +37,27 @@ val of_source :
 
 type surface_presence = { surface : t; alive : bool }
 
+type presence_failure =
+  { connector_id : string
+  ; error : Channel_gate_binding_store.binding_store_error
+  }
+
+type presence_snapshot =
+  { surfaces : surface_presence list
+  ; failures : presence_failure list
+  }
+
 val connected_surfaces_for_keeper :
-  keeper_name:string -> surface_presence list
+  keeper_name:string -> presence_snapshot
 (** Surfaces currently attached to [keeper_name], recomputed from the
     connector registry's binding stores and liveness sources on every
     call — no cached presence state (RFC-0223 §2 principle 6).
 
     The dashboard is always present and alive (the bearer-gated chat
     route always exists; no per-keeper dashboard attachment is
-    tracked). Connector entries come from
+    tracked). A failed binding-store read is retained in [failures] while
+    healthy connector surfaces remain available; it is never projected as an
+    empty binding list. Connector entries come from
     {!Channel_gate_connector.all}, so only connectors registered in
     this process (server startup) are visible. Sorted for stable
     prompt rendering. *)

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -421,10 +421,14 @@ let handle_surface_post_with_outcome
         (Keeper_surface_post.error_json
            (Channel_gate_discord_state.binding_lookup_error_to_string detail))
     | Ok bound_discord_channels ->
-      let bound_slack_channels =
-        Channel_gate_slack_state.bound_channels ~keeper_name:meta.name
-      in
-      (match
+      (match Channel_gate_slack_state.bound_channels ~keeper_name:meta.name with
+       | Error detail ->
+         fail
+           ~class_:Tool_result.Runtime_failure
+           (Keeper_surface_post.error_json
+              (Channel_gate_binding_store.binding_store_error_to_string detail))
+       | Ok bound_slack_channels ->
+       match
          Keeper_surface_post.resolve_target ~surface ~channel_id
            ~bound_slack_channels ~bound_discord_channels ()
        with

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -642,6 +642,7 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
             true)
       observation.connected_surfaces
   in
+  let connector_presence_failures = observation.connected_surface_failures in
   let turn_decision =
     (* RFC-0315: prefer the scheduler's actual decision (threaded through the
        turn runner) over a local recompute. The recompute cannot see
@@ -681,7 +682,7 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
        dashboard is attached: every keeper has the dashboard, so dashboard-only
        presence carries no signal. *)
     | Keeper_context_layers.Connected_surfaces ->
-      if connector_presence <> [] then (
+      if connector_presence <> [] || connector_presence_failures <> [] then (
         let ubuf = Buffer.create 256 in
         Buffer.add_string ubuf "### Connected Surfaces\n";
         List.iter
@@ -689,6 +690,14 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
             Buffer.add_string ubuf
               (Printf.sprintf "- %s\n" (format_surface_presence p)))
           observation.connected_surfaces;
+        List.iter
+          (fun (failure : Gate_surface.presence_failure) ->
+            Buffer.add_string ubuf
+              (Printf.sprintf "- %s binding presence unavailable: %s\n"
+                 failure.connector_id
+                 (Channel_gate_binding_store.binding_store_error_to_string
+                    failure.error)))
+          connector_presence_failures;
         Buffer.add_string ubuf (connected_surface_discretion_prompt ());
         Buffer.add_char ubuf '\n';
         Buffer.add_char ubuf '\n';

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -85,6 +85,7 @@ type world_observation =
   ; backlog_updated_since_last_scheduled_autonomous : bool
   ; running_keeper_fiber_count : int
   ; connected_surfaces : Gate_surface.surface_presence list
+  ; connected_surface_failures : Gate_surface.presence_failure list
   }
 
 type keeper_cycle_channel =
@@ -1061,6 +1062,9 @@ let observe
       in
       events
   in
+  let surface_presence =
+    Gate_surface.connected_surfaces_for_keeper ~keeper_name:meta.name
+  in
   { pending_messages
   ; pending_board_events
   ; idle_seconds
@@ -1072,8 +1076,8 @@ let observe
   ; scheduled_automation
   ; backlog_updated_since_last_scheduled_autonomous
   ; running_keeper_fiber_count
-  ; connected_surfaces =
-      Gate_surface.connected_surfaces_for_keeper ~keeper_name:meta.name
+  ; connected_surfaces = surface_presence.surfaces
+  ; connected_surface_failures = surface_presence.failures
   }
 ;;
 
@@ -1094,6 +1098,9 @@ let observe_direct_keeper_msg ~(config : Workspace.config) ~(meta : keeper_meta)
       ~config
       ~now:(Time_compat.now ())
   in
+  let surface_presence =
+    Gate_surface.connected_surfaces_for_keeper ~keeper_name:meta.name
+  in
   { pending_messages = []
   ; pending_board_events = []
   ; idle_seconds = compute_idle_seconds ~meta
@@ -1105,8 +1112,8 @@ let observe_direct_keeper_msg ~(config : Workspace.config) ~(meta : keeper_meta)
   ; scheduled_automation
   ; backlog_updated_since_last_scheduled_autonomous
   ; running_keeper_fiber_count = count_running_keeper_fibers ~config
-  ; connected_surfaces =
-      Gate_surface.connected_surfaces_for_keeper ~keeper_name:meta.name
+  ; connected_surfaces = surface_presence.surfaces
+  ; connected_surface_failures = surface_presence.failures
   }
 ;;
 

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -117,6 +117,10 @@ type world_observation = {
       Recomputed from binding stores + connector liveness on every
       observation; the dashboard entry is always present. Presence
       only — no conversation content, no counts. *)
+
+  connected_surface_failures : Gate_surface.presence_failure list;
+  (** Connector binding stores that could not be read during presence
+      observation. Healthy connector surfaces remain available. *)
 }
 
 type keeper_cycle_channel =

--- a/lib/server/server_slack_in_process_gateway.ml
+++ b/lib/server/server_slack_in_process_gateway.ml
@@ -331,7 +331,8 @@ let submit_event ?deliver ?team_id ingress ~dispatch_for_delivery ~clock
       Slack_observability.record_inbound_dispatch Slack_observability.Gate_error;
       Log.Server.error
         "Slack ingress binding unavailable channel=%s event=%s: %s"
-        channel_id event_id reason
+        channel_id event_id
+        (Channel_gate_binding_store.binding_store_error_to_string reason)
     | Ok resolved_binding -> (
       match accept_event ~resolved_binding ~dispatch_for_delivery ~team_id ev with
       | None -> ()

--- a/test/test_channel_gate_binding_store.ml
+++ b/test/test_channel_gate_binding_store.ml
@@ -49,6 +49,14 @@ let sample_event ?guild_id ~action () =
       previous_keeper = "";
     }
 
+let seed_bindings dir (bindings : Store.binding list) =
+  `Assoc
+    (List.map
+       (fun (binding : Store.binding) ->
+         binding.channel_id, `String binding.keeper_name)
+       bindings)
+  |> Yojson.Safe.to_file (Filename.concat dir "bindings.json")
+
 let test_normalizes_bindings_json () =
   let bindings =
     Store.normalize_bindings_json
@@ -83,20 +91,6 @@ let test_rejects_malformed_binding_rows () =
       [ "channel-1", `String "luna"
       ; "channel-1", `String "sangsu"
       ])
-
-let test_save_and_read_bindings_round_trip () =
-  with_temp_dir @@ fun dir ->
-  let store = store_for_dir dir ~guild_id_field:Store.Omit in
-  Store.save_bindings store
-    [
-      ({ channel_id = "z-channel"; keeper_name = "luna" } : Store.binding);
-      ({ channel_id = "a-channel"; keeper_name = "arya" } : Store.binding);
-    ];
-  let bindings = Store.read_bindings store in
-  check int "two bindings" 2 (List.length bindings);
-  let first = List.hd bindings in
-  check string "read sorted channel" "a-channel" first.channel_id;
-  check string "read sorted keeper" "arya" first.keeper_name
 
 let test_read_bindings_result_missing_store_is_empty () =
   with_temp_dir @@ fun dir ->
@@ -134,7 +128,7 @@ let test_audit_failure_rolls_back_binding_mutation () =
   let original =
     [ ({ channel_id = "channel-1"; keeper_name = "luna" } : Store.binding) ]
   in
-  Store.save_bindings store original;
+  seed_bindings dir original;
   let result =
     Store.mutate_bindings store ~decide:(fun _ ->
       Ok
@@ -189,7 +183,7 @@ let test_failed_mutation_cannot_erase_concurrent_success () =
       ~binding_audit_read_path:(fun () -> audit_path)
       ~guild_id_field:Store.Omit
   in
-  Store.save_bindings store
+  seed_bindings dir
     [ ({ channel_id = "original"; keeper_name = "luna" } : Store.binding) ];
   let bind channel_id keeper_name =
     Store.mutate_bindings store ~decide:(fun bindings ->
@@ -258,9 +252,17 @@ let test_audit_guild_id_policy () =
 let test_append_and_read_recent_audit () =
   with_temp_dir @@ fun dir ->
   let store = store_for_dir dir ~guild_id_field:Store.Include_empty in
-  Store.append_audit_event store (sample_event ~action:"bind" ());
-  Store.append_audit_event store (sample_event ~action:"rebind" ());
-  Store.append_audit_event store (sample_event ~action:"unbind" ());
+  let append action =
+    match
+      Store.mutate_bindings store ~decide:(fun bindings ->
+        Ok (bindings, sample_event ~action (), ()))
+    with
+    | Ok () -> ()
+    | Error error -> fail (Store.mutation_error_to_string error)
+  in
+  append "bind";
+  append "rebind";
+  append "unbind";
   let recent = Store.read_recent_audit store ~limit:2 in
   check int "limit applied" 2 (List.length recent);
   check string "newest first" "unbind"
@@ -276,8 +278,6 @@ let () =
           test_case "normalizes binding JSON" `Quick test_normalizes_bindings_json;
           test_case "rejects malformed binding rows" `Quick
             test_rejects_malformed_binding_rows;
-          test_case "saves and reads bindings" `Quick
-            test_save_and_read_bindings_round_trip;
           test_case "missing binding store is empty" `Quick
             test_read_bindings_result_missing_store_is_empty;
           test_case "invalid binding store is an error" `Quick

--- a/test/test_channel_gate_connector_routes.ml
+++ b/test/test_channel_gate_connector_routes.ml
@@ -121,7 +121,36 @@ let test_slack_binding_store_error_is_typed () =
         ~channel_id:"C123"
     with
     | Ok _ -> fail "expected invalid Slack binding store to return Error"
-    | Error err -> check bool "reports read error" true (String.length err > 0))
+    | Error _ -> ())
+
+let check_binding_store_failure_projection label json =
+  check bool (label ^ " binding read failed") false
+    (json |> U.member "binding_store_read_ok" |> U.to_bool);
+  check bool (label ^ " unavailable") false
+    (json |> U.member "available" |> U.to_bool);
+  check bool (label ^ " binding error retained") true
+    (json |> U.member "binding_store_error" |> U.to_string
+     |> String.length |> ( < ) 0)
+
+let test_slack_status_surfaces_binding_store_failure () =
+  with_temp_dir @@ fun dir ->
+  with_sidecar_paths "slack" dir (fun () ->
+    let oc = open_out_bin (Filename.concat dir "slack-bindings.json") in
+    Fun.protect
+      ~finally:(fun () -> close_out_noerr oc)
+      (fun () -> output_string oc "{not-json");
+    check_binding_store_failure_projection "slack"
+      (Channel_gate_slack_state.connector_json ()))
+
+let test_telegram_status_surfaces_binding_store_failure () =
+  with_temp_dir @@ fun dir ->
+  with_sidecar_paths "telegram" dir (fun () ->
+    let oc = open_out_bin (Filename.concat dir "telegram-bindings.json") in
+    Fun.protect
+      ~finally:(fun () -> close_out_noerr oc)
+      (fun () -> output_string oc "{not-json");
+    check_binding_store_failure_projection "telegram"
+      (Channel_gate_telegram_state.connector_json ()))
 
 
 let test_slack_default_paths_resolve_under_base_path () =
@@ -243,10 +272,14 @@ let () =
             test_slack_bind_persists_binding_and_audit;
           test_case "slack binding read errors are typed" `Quick
             test_slack_binding_store_error_is_typed;
+          test_case "slack status surfaces binding read failure" `Quick
+            test_slack_status_surfaces_binding_store_failure;
           test_case "slack default paths resolve under base path" `Quick
             test_slack_default_paths_resolve_under_base_path;
           test_case "telegram connector json reads runtime status" `Quick
             test_telegram_connector_json_reads_runtime_status;
+          test_case "telegram status surfaces binding read failure" `Quick
+            test_telegram_status_surfaces_binding_store_failure;
           test_case "slack connector json carries connector_id/display_name" `Quick
             test_slack_connector_json_carries_identity;
         ] );

--- a/test/test_channel_gate_discord_state.ml
+++ b/test/test_channel_gate_discord_state.ml
@@ -19,7 +19,7 @@ module Registry_test_connector_a = struct
     Ok (`Assoc [ "variant", `String "a" ])
   let unbind ~channel_id:_ ~actor_name:_ =
     Ok (`Assoc [ "variant", `String "a" ])
-  let bound_channels ~keeper_name:_ = []
+  let bound_channels ~keeper_name:_ = Ok []
   let connected () = false
 end
 module Registry_test_connector_b = struct

--- a/test/test_channel_gate_imessage_state.ml
+++ b/test/test_channel_gate_imessage_state.ml
@@ -88,6 +88,23 @@ let test_connector_json_keeps_redacted_guid () =
     check string "self-chat guid redacted" "any;-;[redacted]"
       (json |> U.member "self_chat_guid" |> U.to_string))
 
+let test_malformed_binding_store_is_explicit () =
+  with_temp_dir @@ fun dir ->
+  with_imessage_paths dir (fun () ->
+    Yojson.Safe.to_file (Filename.concat dir "status.json") sample_status_json;
+    let oc = open_out_bin (Filename.concat dir "bindings.json") in
+    Fun.protect
+      ~finally:(fun () -> close_out_noerr oc)
+      (fun () -> output_string oc "{not-json");
+    let json = IMessage_state.connector_json () in
+    check bool "binding read failed" false
+      (json |> U.member "binding_store_read_ok" |> U.to_bool);
+    check bool "connector unavailable" false
+      (json |> U.member "available" |> U.to_bool);
+    check bool "binding error retained" true
+      (json |> U.member "binding_store_error" |> U.to_string
+       |> String.length |> ( < ) 0))
+
 let () =
   run "channel_gate_imessage_state"
     [
@@ -97,5 +114,7 @@ let () =
             test_status_json_redacts_self_chat_guid;
           test_case "connector json keeps redacted self-chat guid" `Quick
             test_connector_json_keeps_redacted_guid;
+          test_case "malformed binding store is explicit" `Quick
+            test_malformed_binding_store_is_explicit;
         ] );
     ]

--- a/test/test_gate_surface.ml
+++ b/test/test_gate_surface.ml
@@ -108,9 +108,10 @@ let test_dashboard_always_present () =
       let surfaces =
         Surface.connected_surfaces_for_keeper ~keeper_name:"unbound-keeper"
       in
+      check int "no presence failures" 0 (List.length surfaces.failures);
       check (list presence) "dashboard only"
         [ { Surface.surface = Surface.Dashboard; alive = true } ]
-        surfaces)
+        surfaces.surfaces)
 
 let test_bound_discord_channel_listed_offline_without_gateway () =
   register_discord ();
@@ -120,6 +121,7 @@ let test_bound_discord_channel_listed_offline_without_gateway () =
       let surfaces =
         Surface.connected_surfaces_for_keeper ~keeper_name:"surface-keeper"
       in
+      check int "no presence failures" 0 (List.length surfaces.failures);
       check (list presence) "dashboard + own discord channel, not alive"
         [ { Surface.surface = Surface.Dashboard; alive = true }
         ; { Surface.surface =
@@ -128,7 +130,27 @@ let test_bound_discord_channel_listed_offline_without_gateway () =
           ; alive = false
           }
         ]
-        surfaces)
+        surfaces.surfaces)
+
+let test_binding_failure_is_not_empty_presence () =
+  register_discord ();
+  let path = Filename.temp_file "gate-surface-bindings" ".json" in
+  Yojson.Safe.to_file path (`Assoc [ ("bad", `Int 1) ]);
+  Unix.putenv "MASC_DISCORD_BINDING_STORE_PATH" path;
+  Fun.protect
+    ~finally:(fun () ->
+      Unix.putenv "MASC_DISCORD_BINDING_STORE_PATH" "";
+      try Sys.remove path with Sys_error _ -> ())
+    (fun () ->
+      let snapshot =
+        Surface.connected_surfaces_for_keeper ~keeper_name:"surface-keeper"
+      in
+      check int "dashboard remains present" 1 (List.length snapshot.surfaces);
+      match snapshot.failures with
+      | [ failure ] ->
+        check string "connector identity retained" "discord" failure.connector_id
+      | failures ->
+        failf "expected one typed presence failure, got %d" (List.length failures))
 
 let test_bound_channels_blank_keeper_is_empty () =
   with_binding_store
@@ -168,6 +190,8 @@ let () =
             `Quick test_bound_discord_channel_listed_offline_without_gateway;
           test_case "bound_channels blank keeper" `Quick
             test_bound_channels_blank_keeper_is_empty;
+          test_case "binding failure is not empty presence" `Quick
+            test_binding_failure_is_not_empty_presence;
           test_case "discord not connected without run loop" `Quick
             test_discord_not_connected_without_run_loop;
         ] );

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -316,6 +316,7 @@ let base_observation : WO.world_observation =
   ; backlog_updated_since_last_scheduled_autonomous = false
   ; running_keeper_fiber_count = 0
   ; connected_surfaces = []
+  ; connected_surface_failures = []
   }
 
 (* ══════════════════════════════════════════════════════════

--- a/test/test_keeper_connector_attention_wake.ml
+++ b/test/test_keeper_connector_attention_wake.ml
@@ -131,6 +131,7 @@ let quiet_obs : WO.world_observation =
   ; backlog_updated_since_last_scheduled_autonomous = false
   ; running_keeper_fiber_count = 1
   ; connected_surfaces = []
+  ; connected_surface_failures = []
   }
 
 let reasons_of_verdict = function

--- a/test/test_keeper_lifecycle_global_gate.ml
+++ b/test/test_keeper_lifecycle_global_gate.ml
@@ -108,6 +108,7 @@ let base_obs : WO.world_observation =
   ; backlog_updated_since_last_scheduled_autonomous = false
   ; running_keeper_fiber_count = 1
   ; connected_surfaces = []
+  ; connected_surface_failures = []
   }
 ;;
 

--- a/test/test_keeper_raw_task_signal_wake.ml
+++ b/test/test_keeper_raw_task_signal_wake.ml
@@ -16,6 +16,7 @@ let base_observation : WO.world_observation =
   ; backlog_updated_since_last_scheduled_autonomous = false
   ; running_keeper_fiber_count = 1
   ; connected_surfaces = []
+  ; connected_surface_failures = []
   }
 ;;
 

--- a/test/test_keeper_surface_presence_prompt.ml
+++ b/test/test_keeper_surface_presence_prompt.ml
@@ -62,6 +62,7 @@ let base_observation : WO.world_observation =
     backlog_updated_since_last_scheduled_autonomous = false;
     running_keeper_fiber_count = 0;
     connected_surfaces = [];
+    connected_surface_failures = [];
   }
 
 let meta : Masc.Keeper_meta_contract.keeper_meta =
@@ -202,6 +203,21 @@ let test_empty_presence_has_no_section () =
   check bool "no section when empty" false
     (contains ~needle:"### Connected Surfaces" user)
 
+let test_binding_presence_failure_is_visible () =
+  let failure : Gate_surface.presence_failure =
+    { connector_id = "telegram"
+    ; error = Channel_gate_binding_store.Binding_store_io_failed "read failed"
+    }
+  in
+  let user =
+    user_message
+      { base_observation with connected_surface_failures = [ failure ] }
+  in
+  check bool "failure section visible" true
+    (contains ~needle:"### Connected Surfaces" user);
+  check bool "connector failure visible" true
+    (contains ~needle:"telegram binding presence unavailable" user)
+
 let test_namespace_state_names_running_keeper_fibers () =
   let user =
     user_message { base_observation with running_keeper_fiber_count = 2 }
@@ -252,6 +268,8 @@ let () =
             test_dashboard_only_keeper_has_no_section;
           test_case "empty presence has no section" `Quick
             test_empty_presence_has_no_section;
+          test_case "binding presence failure is visible" `Quick
+            test_binding_presence_failure_is_visible;
           test_case "namespace state names running keeper fibers" `Quick
             test_namespace_state_names_running_keeper_fibers;
           test_case "profile defaults feed identity prompt" `Quick

--- a/test/test_keeper_unified_persona_block.ml
+++ b/test/test_keeper_unified_persona_block.ml
@@ -45,6 +45,7 @@ let base_observation : WO.world_observation =
     backlog_updated_since_last_scheduled_autonomous = false;
     running_keeper_fiber_count = 0;
     connected_surfaces = [];
+    connected_surface_failures = [];
   }
 
 let make_meta name : Masc.Keeper_meta_contract.keeper_meta =

--- a/test/test_keeper_unified_verification_surface.ml
+++ b/test/test_keeper_unified_verification_surface.ml
@@ -17,6 +17,7 @@ let base_observation : WO.world_observation =
     backlog_updated_since_last_scheduled_autonomous = false;
     running_keeper_fiber_count = 0;
     connected_surfaces = [];
+    connected_surface_failures = [];
   }
 
 let sample_board_event : WO.pending_board_event =

--- a/test/test_keeper_wake_turn_context.ml
+++ b/test/test_keeper_wake_turn_context.ml
@@ -69,6 +69,7 @@ let base_observation : WO.world_observation =
     backlog_updated_since_last_scheduled_autonomous = false;
     running_keeper_fiber_count = 0;
     connected_surfaces = [];
+    connected_surface_failures = [];
   }
 
 let meta_of_json json =


### PR DESCRIPTION
## Summary
- replace the generic connector empty-list projection with a typed binding-store result
- accumulate connector-specific presence failures without suppressing healthy connector surfaces
- serialize Slack, iMessage, and Telegram binding mutations through the shared durable mutation boundary
- remove legacy read/save/audit wrappers that collapsed or raised persistence failures
- expose binding-store failure truth in connector dashboard projections and Keeper world prompts

## Verification
- `ocamlformat --inplace` on all touched OCaml sources
- `ocamlc -stop-after parsing` on touched implementations
- `git diff --check`
- focused `scripts/dune-local.sh build ...` attempted twice; correctly blocked with exit 75 by unrelated bare Dune processes, so CI remains the build authority

Fixes #25120