### PR TITLE
fix(tool): re-register masc_pause_status in control tool schemas

### DIFF
--- a/bin/gen_tool_descriptors.ml
+++ b/bin/gen_tool_descriptors.ml
@@ -172,6 +172,17 @@ let masc_resume_spec : tool_spec =
   }
 ;;
 
+let masc_pause_status_spec : tool_spec =
+  { name = "masc_pause_status"
+  ; description =
+      "Return the current pause status of the workspace and any paused keepers. \
+       Read-only; takes no arguments."
+  ; parameters = []
+  ; additional_properties = false
+  ; behavior_contract = []
+  }
+;;
+
 (* === PR-2: plan group (8 tools) === *)
 
 let masc_plan_init_spec : tool_spec =
@@ -589,6 +600,7 @@ let () =
   emit_header buf;
   emit_named_tool_schema buf "masc_pause_schema" masc_pause_spec;
   emit_named_tool_schema buf "masc_resume_schema" masc_resume_spec;
+  emit_named_tool_schema buf "masc_pause_status_schema" masc_pause_status_spec;
   emit_schemas_list buf phase6_specs;
   print_string (Buffer.contents buf)
 ;;

--- a/lib/tool_schemas/tool_schemas_misc.ml
+++ b/lib/tool_schemas/tool_schemas_misc.ml
@@ -40,17 +40,20 @@ let config_category_enum_strings =
 type control_operation =
   | Pause
   | Resume
+  | Pause_status
 
-let control_operations = [ Pause; Resume ]
+let control_operations = [ Pause; Resume; Pause_status ]
 
 let control_operation_id = function
   | Pause -> "pause"
   | Resume -> "resume"
+  | Pause_status -> "pause_status"
 ;;
 
 let control_schema = function
   | Pause -> Tool_descriptors_gen.masc_pause_schema
   | Resume -> Tool_descriptors_gen.masc_resume_schema
+  | Pause_status -> Tool_descriptors_gen.masc_pause_status_schema
 ;;
 
 let control_schemas = List.map control_schema control_operations

--- a/lib/tool_schemas/tool_schemas_misc.mli
+++ b/lib/tool_schemas/tool_schemas_misc.mli
@@ -39,6 +39,7 @@ val config_category_enum_strings : string list
 type control_operation =
   | Pause
   | Resume
+  | Pause_status
 (** Closed set of operator control tools. *)
 
 val control_operations : control_operation list

--- a/test/test_tool_descriptors_gen.ml
+++ b/test/test_tool_descriptors_gen.ml
@@ -91,6 +91,9 @@ let test_control_schemas_use_dedicated_typed_projection () =
   in
   let pause = Tool_schemas_misc.control_schema Tool_schemas_misc.Pause in
   let resume = Tool_schemas_misc.control_schema Tool_schemas_misc.Resume in
+  let pause_status =
+    Tool_schemas_misc.control_schema Tool_schemas_misc.Pause_status
+  in
   Alcotest.check
     yojson_testable
     "pause projection keeps generated canonical schema"
@@ -101,9 +104,14 @@ let test_control_schemas_use_dedicated_typed_projection () =
     "resume projection keeps generated canonical schema"
     Tool_descriptors_gen.masc_resume_schema.input_schema
     resume.input_schema;
+  Alcotest.check
+    yojson_testable
+    "pause_status projection keeps generated canonical schema"
+    Tool_descriptors_gen.masc_pause_status_schema.input_schema
+    pause_status.input_schema;
   Alcotest.(check (list string))
     "typed control projection is exhaustive"
-    [ "masc_pause"; "masc_resume" ]
+    [ "masc_pause"; "masc_resume"; "masc_pause_status" ]
     (List.map
        (fun operation ->
           (Tool_schemas_misc.control_schema operation).name)
@@ -118,7 +126,7 @@ let test_control_schemas_use_dedicated_typed_projection () =
          (name ^ " absent from effective public misc schemas")
          false
          (has_schema name Tool_schemas_misc.schemas))
-    [ "masc_pause"; "masc_resume" ];
+    [ "masc_pause"; "masc_resume"; "masc_pause_status" ];
   Alcotest.(check bool)
     "masc_pause has reason property"
     true
@@ -126,7 +134,11 @@ let test_control_schemas_use_dedicated_typed_projection () =
   Alcotest.(check int)
     "masc_resume has no input properties"
     0
-    (List.length (properties resume))
+    (List.length (properties resume));
+  Alcotest.(check int)
+    "masc_pause_status has no input properties"
+    0
+    (List.length (properties pause_status))
 ;;
 
 let test_masc_tool_help_name_matches () =
@@ -350,7 +362,7 @@ let () =
         ] )
     ; ( "control schema SSOT"
       , [ Alcotest.test_case
-            "pause and resume use a dedicated typed projection"
+            "control tools use a dedicated typed projection"
             `Quick
             test_control_schemas_use_dedicated_typed_projection
         ] )


### PR DESCRIPTION
## Problem

`masc_pause_status` had a dispatch arm (`lib/tool_control.ml:152`), a handler, .mli docs, and live external clients (`dashboard/src/components/flow-control/flow-control-state.ts:49`, Rust viewer) — but no tag-registry registration. Since `Tool_dispatch.mint_token` validates `Hashtbl.mem tag_registry` (`lib/tool/tool_dispatch.ml:323-327`), every MCP call returned "Unknown tool".

Root cause: #20098 (hand-written → generated descriptors) dropped `Pause_status` from `control_operations` (`lib/tool_schemas/tool_schemas_misc.ml`).

## Fix

- Emit `masc_pause_status_schema` from `bin/gen_tool_descriptors.ml` (read-only, no arguments — same contract as `masc_resume`)
- Add `Pause_status` to `control_operation` / `control_operations` / `control_operation_id` / `control_schema`
- Pin the projection in `test_tool_descriptors_gen.ml`

Note: `tool_required_permission` was removed repo-wide by #20098, so no permission mapping exists for pause/resume either — nothing to add for pause_status (parity).

## Verification

- `dune build lib/tool_schemas` (regenerated descriptors contain the new schema)
- `test_tool_descriptors_gen` 22 ✓ / `test_tool_control_coverage` 12 ✓ / `test_keeper_tag_dispatch` 4 ✓
- Chain confirmed in code: `Tool_spec.register ~module_tag:Mod_control` → `tag_registry` → `mint_token` ✓ → `Mod_control` dispatch → existing arm

Found by adversarial wiring audit (2026-07-17).