### PR TITLE
fix(server): remove shadowing inline board GET routes from h1 dispatch

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -252,62 +252,6 @@ let dispatch_route ~router ~request ~path ~upgrade reqd =
   | `DELETE, "/mcp/operator" ->
       handle_delete_mcp
         ~profile:Server_mcp_transport_http.Operator_remote request reqd
-  | `GET, "/api/v1/board/flairs" ->
-      let flairs = List.map Board.flair_to_yojson Board.available_flairs in
-      let json = `Assoc [("flairs", `List flairs)] in
-      Http.Response.json (Yojson.Safe.to_string json) reqd
-  | `GET, "/api/v1/board/hearths" ->
-      let hearths = Board_dispatch.list_hearths () in
-      let json = `Assoc [
-        ("hearths", `List (List.map (fun (name, count) ->
-          `Assoc [("name", `String name); ("count", `Int count)]
-        ) hearths));
-      ] in
-      Http.Response.json (Yojson.Safe.to_string json) reqd
-  | `GET, "/api/v1/board/curation" ->
-      let json =
-        match Board_dispatch.latest_curation_snapshot () with
-        | None -> `Assoc [ ("snapshot", `Null) ]
-        | Some snap ->
-            `Assoc [ ("snapshot", Board_curation.snapshot_to_yojson snap) ]
-      in
-      Http.Response.json (Yojson.Safe.to_string json) reqd
-  | `GET, "/api/v1/board/sub-boards" ->
-      let sub_boards = Board_dispatch.list_sub_boards () in
-      let json =
-        `Assoc
-          [
-            ( "sub_boards",
-              `List (List.map Board.sub_board_to_yojson sub_boards) );
-          ]
-      in
-      Http.Response.json (Yojson.Safe.to_string json) reqd
-  | `GET, "/api/v1/board/karma/ledger" ->
-      let agent = query_param request "agent" in
-      let limit =
-        int_query_param request "limit" ~default:500 |> clamp ~min_v:1 ~max_v:5000
-      in
-      let events = Board_dispatch.get_karma_ledger ?agent ~limit () in
-      let totals =
-        Board_dispatch.get_all_karma ()
-        |> List.sort (fun (_, a) (_, b) -> compare b a)
-      in
-      let json =
-        `Assoc
-          [
-            ("events", `List (List.map Board.karma_event_to_yojson events));
-            ("count", `Int (List.length events));
-            ("scoring_rule", `String "up=+1,down=0");
-            ( "totals",
-              `List
-                (List.map
-                   (fun (agent_name, k) ->
-                     `Assoc
-                       [ ("agent", `String agent_name); ("karma", `Int k) ])
-                   totals) );
-          ]
-      in
-      Http.Response.json (Yojson.Safe.to_string json) reqd
   (* Board reads/reactions are owned by the typed route table: exact routes
      ([/api/v1/board/reactions], [/catalog]) win over the board prefix route,
      and the prefix route resolves the bearer-bound reaction actor itself. *)


### PR DESCRIPTION
## Problem

`bin/main_eio.ml:255-310` answered `GET /api/v1/board/{flairs,hearths,curation,sub-boards,karma/ledger}` inline, ahead of the `| _ -> Http.Router.dispatch` fallthrough. The same 5 paths are also registered in the typed route table (`lib/server/server_routes_http_routes_activity.ml:691,714,719,724,1065`) — but with `with_public_read` (strict-mode auth) and TTL cache.

The inline copy always wins, so:
- the registered routes are **unreachable** in production, and
- the 5 board reads are served **unauthenticated even with `MASC_HTTP_AUTH_STRICT`** — the intended auth gate is trapped in dead code.

## Fix

Delete the 5 inline arms; requests now reach the typed route table (auth + cache). The comment at the fallthrough site ("Board reads/reactions are owned by the typed route table") becomes true.

**Safety check before deletion**: JSON response shapes compared 5/5 identical between inline and router implementations; dashboard consumers of all 5 endpoints expect the same shape.

Out of scope: the h2 gateway copy (`server_h2_gateway_routes_extra.ml:110-136`) — separate decision.

## Verification

- `dune build bin/main_eio.exe` ✓

Found by adversarial wiring audit (2026-07-17). Security-relevant.