### PR TITLE
fix(keeper): drop dead compaction gates from keeper status API

### DIFF
--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -125,10 +125,6 @@ let compaction_decision_applied = function
   | Prepared _ | Rejected _ | Not_requested | Skipped_no_checkpoint -> false
 ;;
 
-let compaction_policy_of_keeper (meta : keeper_meta) : float * int * int =
-  meta.compaction.ratio_gate, meta.compaction.message_gate, meta.compaction.token_gate
-;;
-
 let strategy_names = [ "ConfiguredLlm" ]
 
 let record_pre_compact

--- a/lib/keeper/keeper_compact_policy.mli
+++ b/lib/keeper/keeper_compact_policy.mli
@@ -35,11 +35,6 @@ type compaction_preparation =
   ; evidence : Keeper_compaction_evidence.t option
   }
 
-(** Legacy configuration projection retained until the unused ratio/message/
-    token gates are removed from [keeper_meta]. It is not consulted by
-    {!compact_for_request_typed}. *)
-val compaction_policy_of_keeper : Keeper_meta_contract.keeper_meta -> float * int * int
-
 (** Apply a caller-owned request. Only a valid configured-LLM plan that
     strictly reduces the exact serialized checkpoint byte length is prepared.
     Every refusal preserves the original context and returns a typed reason.

--- a/lib/keeper/keeper_context_runtime.ml
+++ b/lib/keeper/keeper_context_runtime.ml
@@ -61,8 +61,6 @@ let load_context_from_checkpoint = Keeper_context_core.load_context_from_checkpo
 (* Re-export from Keeper_compact_policy                              *)
 (* ================================================================ *)
 
-let compaction_policy_of_keeper = Keeper_compact_policy.compaction_policy_of_keeper
-
 type compaction_decision = Keeper_compact_policy.compaction_decision =
   | Applied of Compaction_trigger.t
   | Prepared of Compaction_trigger.t

--- a/lib/keeper/keeper_context_runtime.mli
+++ b/lib/keeper/keeper_context_runtime.mli
@@ -125,8 +125,6 @@ val load_context_from_checkpoint
 
 (** {1 Compaction} *)
 
-val compaction_policy_of_keeper : keeper_meta -> float * int * int
-
 type compaction_decision = Keeper_compact_policy.compaction_decision =
   | Applied of Compaction_trigger.t
   | Prepared of Compaction_trigger.t

--- a/lib/keeper/keeper_execution.ml
+++ b/lib/keeper/keeper_execution.ml
@@ -13,7 +13,6 @@ include Keeper_prompt
 
 let log_keeper_exn = Keeper_context_runtime.log_keeper_exn
 let load_context_from_checkpoint = Keeper_context_runtime.load_context_from_checkpoint
-let compaction_policy_of_keeper = Keeper_context_runtime.compaction_policy_of_keeper
 let generate_trace_id = Keeper_context_runtime.generate_trace_id
 let effective_model_labels_for_turn = Keeper_context_runtime.effective_model_labels_for_turn
 let memory_check_default_json = Keeper_context_runtime.memory_check_default_json

--- a/lib/keeper/keeper_execution.mli
+++ b/lib/keeper/keeper_execution.mli
@@ -32,11 +32,6 @@ val memory_check_default_json : unit -> Yojson.Safe.t
 (* Proactive emission and explicit workspace replies are now handled
    by Keeper_unified_turn via the unified keeper loop. *)
 
-(** {1 Compaction} *)
-
-(** Extract compaction policy tuple from keeper metadata. *)
-val compaction_policy_of_keeper : keeper_meta -> float * int * int
-
 (** {1 Trace and Model} *)
 
 (** Generate unique trace ID for a keeper turn. *)

--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -58,9 +58,6 @@ let handle_keeper_list ctx args : tool_result =
           let last_compaction_saved_tokens =
             max 0 (m.runtime.compaction_rt.last_before_tokens - m.runtime.compaction_rt.last_after_tokens)
           in
-          let (compact_ratio_gate, compact_message_gate, compact_token_gate) =
-            compaction_policy_of_keeper m
-          in
           let metrics_store = Keeper_types_support.keeper_metrics_store ctx.config m.name in
           let metrics_window_lines = Dated_jsonl.read_recent_lines metrics_store 120 in
           let last_metrics =
@@ -174,9 +171,6 @@ let handle_keeper_list ctx args : tool_result =
               ("compaction_count", `Int m.runtime.compaction_rt.count);
               ("last_compaction_saved_tokens", `Int last_compaction_saved_tokens);
               ("compaction_profile", `String m.compaction.profile);
-              ("compaction_ratio_gate", `Float compact_ratio_gate);
-              ("compaction_message_gate", `Int compact_message_gate);
-              ("compaction_token_gate", `Int compact_token_gate);
               ("autoboot_enabled", `Bool m.autoboot_enabled);
               ("proactive_enabled", `Bool m.proactive.enabled);
               ("proactive_count_total", `Int m.runtime.proactive_rt.count_total);

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -443,9 +443,6 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
          let last_compaction_saved_tokens =
            max 0 (m.runtime.compaction_rt.last_before_tokens - m.runtime.compaction_rt.last_after_tokens)
          in
-         let (compact_ratio_gate, compact_message_gate, compact_token_gate) =
-           compaction_policy_of_keeper m
-         in
 
          let metrics_store = Keeper_types_support.keeper_metrics_store config m.name in
          let memory_bank_path =
@@ -893,10 +890,6 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
         ] @ runtime_blocker_fields @ attention_fields @ [
            ("compaction_policy", `Assoc [
              ("profile", `String m.compaction.profile);
-             ("ratio_gate", `Float compact_ratio_gate);
-             ("message_gate", `Int compact_message_gate);
-             ("token_gate", `Int compact_token_gate);
-             ("token_gate_enabled", `Bool (compact_token_gate > 0));
            ]);
            ("status_options", `Assoc [
              ("fast", `Bool fast);


### PR DESCRIPTION
## Problem

`compaction_policy_of_keeper` is a legacy projection that `compact_for_request_typed` never consults — its own .mli says so (`keeper_compact_policy.mli:38-41`), and `docs/KEEPER-FULL-FEATURE-PURGE-MANIFEST.md` §4 calls the ratio/message/token gates "producer/display-only dead configuration, not real compaction triggers".

Yet `keeper_status.ml` and `keeper_status_detail.ml` rendered `compaction_ratio_gate` / `compaction_message_gate` / `compaction_token_gate` / `token_gate_enabled` in the operator-facing status JSON — a false contract: changing the gate values changes nothing.

## Fix

Remove the status JSON fields and the projection chain (`keeper_compact_policy` → `keeper_context_runtime` → `keeper_execution`). Pure deletions (−32 lines).

Scope follows manifest §9 ordering: the `keeper_meta` `compaction.*` source fields stay (TOML deserialization compat); their removal belongs to the compaction rewrite slice.

Dashboard: the keys are optional in `dashboard/src` types and degrade to `null` safely; `dashboard_bonsai` does not read them.

## Follow-ups identified (out of scope here)

Same dead gates still surface via `dashboard_http_keeper.ml` (consumed as required fields by masc TUI `tui_decode.ml:224`), `dashboard_http_keeper_snapshot.ml` (config write surface), and `keeper_measurement.ml` (per-turn JSONL). Each needs its own slice.

## Verification

- `dune build lib/` ✓
- `test_keeper_status_bridge` 2 ✓ / `test_keeper_effective_meta_overlay` 16 ✓ (calls the modified handlers directly)

Found by adversarial wiring audit (2026-07-17).