### PR TITLE
fix(runtime): close LKG recovery authority gaps

### DIFF
--- a/docs/design/2026-07-18-supervised-runtime-lkg-operation-matrix.html
+++ b/docs/design/2026-07-18-supervised-runtime-lkg-operation-matrix.html
@@ -50,7 +50,7 @@
       <tr><td>운영자가 AFK여도 supervisor가 실제 서비스를 유지한다.</td><td>supervisor alive가 아니라 HTTP listener와 health proof가 존재</td><td class="bad">실패</td><td class="warn">build-contention 경로 개선, 장시간 soak 필요</td></tr>
       <tr><td>개발 빌드가 production-like runtime을 임의로 교체하지 않는다.</td><td>실행 artifact hash가 이전 health proof와 exact match</td><td class="bad">mtime 기반 stale 판정뿐</td><td class="good">typed descriptor + SHA-256</td></tr>
       <tr><td>복구 불가능한 startup failure를 무한 증폭하지 않는다.</td><td>candidate 미발행 시 동일 child 재실행 0회</td><td class="bad">무한 반복</td><td class="good">terminal exit, 원래 exit code 보존</td></tr>
-      <tr><td>새 코드가 실패해도 검증되지 않은 stale binary를 몰래 실행하지 않는다.</td><td>descriptor schema/path/mode/port/hash 전부 검증</td><td class="warn">수동 opt-in stale 실행 가능</td><td class="good">supervised fallback은 exact LKG만</td></tr>
+      <tr><td>새 코드가 실패해도 검증되지 않은 stale binary를 몰래 실행하지 않는다.</td><td>descriptor schema/path/mode/bind-host/port/hash 전부 검증</td><td class="warn">수동 opt-in stale 실행 가능</td><td class="good">supervised fallback은 exact LKG만</td></tr>
     </tbody>
   </table>
 
@@ -59,35 +59,38 @@
     <thead><tr><th>축</th><th>AS-IS</th><th>TO-BE</th><th>결정 권한</th></tr></thead>
     <tbody>
       <tr><td>빌드 실패</td><td><code>build_dune_target_with_lock</code>가 typed 75를 1로 소실</td><td>원래 status를 보존</td><td><code>dune-local.sh</code> exit taxonomy</td></tr>
-      <tr><td>실행 후보</td><td>선택된 path만 stderr에 출력</td><td>exec 직전 schema v1 descriptor를 atomic publish</td><td><code>start-masc.sh</code></td></tr>
-      <tr><td>정상성</td><td>child가 떠 있거나 포트가 열리면 암묵적 성공</td><td>listener PID = supervised child PID AND <code>/health</code> success</td><td>process supervisor</td></tr>
-      <tr><td>proof 권한</td><td>명시 계약 없음</td><td>proof path는 child 환경에 전달하지 않고 supervisor만 atomic write</td><td>process supervisor</td></tr>
-      <tr><td>LKG 승격</td><td>없음</td><td>candidate bytes를 다시 hash하고 descriptor를 atomic promote</td><td>process supervisor</td></tr>
+      <tr><td>실행 후보</td><td>선택된 path만 stderr에 출력</td><td>exec 직전 schema v2 descriptor를 atomic publish</td><td><code>start-masc.sh</code></td></tr>
+      <tr><td>정상성</td><td>child가 떠 있거나 포트가 열리면 암묵적 성공</td><td>listener PID = supervised child PID AND descriptor bind-host의 <code>/health</code> success</td><td>process supervisor</td></tr>
+      <tr><td>PID 소유권</td><td><code>exec server | tee</code>에서 wrapper/listener PID 분리</td><td>process substitution으로 tee하되 server가 supervisor child PID를 그대로 승계</td><td><code>start-masc.sh</code></td></tr>
+      <tr><td>proof 권한</td><td>명시 계약 없음</td><td>child fork 이후 supervisor가 256-bit nonce를 생성하고 schema/PID/hash/nonce를 atomic write</td><td>process supervisor</td></tr>
+      <tr><td>LKG 승격</td><td>없음</td><td>candidate bytes를 다시 hash하고 <code>_build</code> 밖 durable store로 atomic promote</td><td>process supervisor</td></tr>
       <tr><td>fallback</td><td>환경변수로 알려지지 않은 stale executable 허용 가능</td><td>schema와 SHA가 일치하는 health-promoted artifact만 선택</td><td>artifact contract SSOT</td></tr>
-      <tr><td>retry</td><td>모든 child exit를 동일하게 무한 반복</td><td>exact <code>masc.runtime_health_proof.v1</code>의 PID/hash가 candidate와 일치하지 않으면 terminal; 검증된 runtime exit만 restart 대상</td><td>process supervisor FSM</td></tr>
+      <tr><td>retry</td><td>모든 child exit를 동일하게 무한 반복</td><td>exact <code>masc.runtime_health_proof.v2</code>의 PID/hash/nonce가 일치하지 않으면 terminal; 검증된 runtime exit만 restart 대상</td><td>process supervisor FSM</td></tr>
     </tbody>
   </table>
 
   <h2>3. 메커니즘과 순서</h2>
   <div class="flow">
+    <span class="node">Fork child + private nonce</span><span class="arrow">→</span>
     <span class="node">Build/Select executable</span><span class="arrow">→</span>
     <span class="node">Hash exact bytes</span><span class="arrow">→</span>
-    <span class="node">Publish candidate.v1</span><span class="arrow">→</span>
+    <span class="node">Publish candidate.v2</span><span class="arrow">→</span>
     <span class="node">exec child</span><span class="arrow">→</span>
     <span class="node">PID-bound listener proof</span><span class="arrow">→</span>
-    <span class="node">HTTP health proof</span><span class="arrow">→</span>
-    <span class="node">Atomic LKG promote</span>
+    <span class="node">bind-host HTTP health</span><span class="arrow">→</span>
+    <span class="node">Durable LKG + nonce proof</span>
   </div>
   <p>Correctness는 polling 횟수나 대기 시간으로 결정하지 않는다. probe cadence는 관찰 지연만 바꾸며, 승격 조건은 PID·health·hash의 논리곱이다. timeout이 지나면 성공으로 간주하는 경로는 없다.</p>
 
-  <h2>4. Descriptor v1 불변식</h2>
+  <h2>4. Descriptor v2 불변식</h2>
   <table>
     <thead><tr><th>필드</th><th>허용값</th><th>거부 조건</th></tr></thead>
     <tbody>
-      <tr><td>schema</td><td><code>masc.runtime_artifact.v1</code></td><td>다른 버전, 추가 line, 누락 line</td></tr>
+      <tr><td>schema</td><td><code>masc.runtime_artifact.v2</code></td><td>다른 버전, 추가 line, 누락 line</td></tr>
       <tr><td>mode</td><td><code>http</code></td><td>unknown/stdio/free-form</td></tr>
       <tr><td>path</td><td>absolute executable path</td><td>relative path, CR/LF, missing, non-executable</td></tr>
       <tr><td>sha256</td><td>64 lowercase hex</td><td>길이/문자 불일치 또는 실제 bytes mismatch</td></tr>
+      <tr><td>bind_host</td><td>HTTP listener의 명시 host</td><td>빈 값, 공백, URL delimiter, CR/LF</td></tr>
       <tr><td>port</td><td>1..65535 integer</td><td>문자열, 범위 밖 값</td></tr>
     </tbody>
   </table>
@@ -101,8 +104,11 @@
       <tr><td>compile failure</td><td>valid LKG 있음</td><td>기존 건강 artifact로 가용성 유지, 오류 노출</td><td>새 실패 artifact 승격</td></tr>
       <tr><td>다른 프로세스가 같은 포트 health 응답</td><td>listener PID ≠ child PID</td><td>승격하지 않음</td><td>HTTP 200만으로 LKG 인정</td></tr>
       <tr><td>health 직전 executable 교체</td><td>candidate hash ≠ 현재 bytes</td><td>승격 거부 및 ERROR</td><td>path identity를 byte identity로 간주</td></tr>
+      <tr><td><code>MASC_LOG_FILE</code> 활성화</td><td>tee가 별도 process지만 server PID는 child PID 유지</td><td>동일 PID listener만 승격</td><td>pipeline wrapper PID를 server로 오인</td></tr>
+      <tr><td><code>dune clean</code> 후 build 실패</td><td>LKG bytes는 descriptor 인접 durable store에 존재</td><td>hash 검증 후 복구</td><td><code>_build</code> 내부 LKG 삭제</td></tr>
+      <tr><td>LAN/IPv6 bind host</td><td>descriptor bind-host와 port</td><td>해당 host의 health를 검증</td><td>127.0.0.1 고정 probe</td></tr>
       <tr><td>candidate가 exec 전에 실패</td><td>descriptor 있음, health proof 없음</td><td>terminal state</td><td>candidate 존재만으로 무한 restart</td></tr>
-      <tr><td>health proof write 중 monitor 종료/파일 위조</td><td>proof schema/PID/hash/EOF 중 하나라도 불일치</td><td>atomic proof가 아니면 terminal state</td><td>파일 존재만으로 restart 권한 부여</td></tr>
+      <tr><td>health proof write 중 monitor 종료/child 위조</td><td>proof schema/PID/hash/nonce/EOF 중 하나라도 불일치</td><td>terminal state</td><td>예측 가능한 파일 내용으로 restart 권한 부여</td></tr>
       <tr><td>health-promoted runtime이 이후 crash</td><td>candidate 발행됨</td><td>기존 continuous restart 책임 유지</td><td>startup failure로 오분류</td></tr>
     </tbody>
   </table>
@@ -112,7 +118,8 @@
     <thead><tr><th>Metric</th><th>Before</th><th>PR gate</th><th>Release gate</th><th>증거</th></tr></thead>
     <tbody>
       <tr><td>build-contention startup attempts</td><td>관찰 구간에서 반복, 1–37초 uptime</td><td>valid LKG 없음: exactly 1</td><td>24h duplicate attempt = 0</td><td>supervisor integration test + logs</td></tr>
-      <tr><td>LKG false promotion</td><td>기능 없음</td><td>PID/hash mismatch cases = 0 promotion</td><td>chaos 1,000회 false promotion = 0</td><td>contract tests + chaos harness</td></tr>
+      <tr><td>LKG false promotion</td><td>기능 없음</td><td>PID/hash/nonce mismatch cases = 0 promotion</td><td>chaos 1,000회 false promotion = 0</td><td>contract tests + chaos harness</td></tr>
+      <tr><td>LKG clean survival</td><td>기능 없음</td><td><code>_build</code> 삭제 후 verify 성공</td><td>24h clean/rebuild fault cycle loss = 0</td><td>contract test + fault injection</td></tr>
       <tr><td>contention recovery availability</td><td>8935 down</td><td>valid LKG fixture executes</td><td>listener recovery p95 ≤ 2s after prior process exit</td><td>local fault injection</td></tr>
       <tr><td>unknown stale artifact execution</td><td>manual opt-in 가능</td><td>hash mismatch execution = 0</td><td>24h execution = 0</td><td>negative integration test + audit log</td></tr>
       <tr><td>mixed workload terminal receipt</td><td>미증명</td><td>이 PR 범위 밖</td><td>10 Keeper × 8h ≥ 99%</td><td>keeper mixed-workload harness</td></tr>

--- a/scripts/lib/runtime-artifact-contract.sh
+++ b/scripts/lib/runtime-artifact-contract.sh
@@ -2,7 +2,7 @@
 # Exact runtime-artifact identity contract shared by start-masc.sh and the
 # process supervisor.  This file is both sourceable and directly executable.
 
-MASC_RUNTIME_ARTIFACT_SCHEMA="masc.runtime_artifact.v1"
+MASC_RUNTIME_ARTIFACT_SCHEMA="masc.runtime_artifact.v2"
 
 masc_runtime_artifact_hash () {
   local path="${1:-}"
@@ -35,12 +35,34 @@ masc_runtime_artifact_valid_port () {
   [ "$value" -ge 1 ] && [ "$value" -le 65535 ]
 }
 
+masc_runtime_artifact_valid_host () {
+  local value="${1:-}"
+  case "$value" in
+    ''|*[[:space:]/?#@]*|*$'\n'*|*$'\r'*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+masc_runtime_artifact_probe_host () {
+  local bind_host="${1:-}"
+
+  masc_runtime_artifact_valid_host "$bind_host" || return 1
+  case "$bind_host" in
+    0.0.0.0|'*') printf '%s\n' '127.0.0.1' ;;
+    ::|'[::]') printf '%s\n' '[::1]' ;;
+    \[*\]) printf '%s\n' "$bind_host" ;;
+    *:*) printf '[%s]\n' "$bind_host" ;;
+    *) printf '%s\n' "$bind_host" ;;
+  esac
+}
+
 masc_runtime_artifact_descriptor_write () {
   local file="${1:-}"
   local mode="${2:-}"
   local path="${3:-}"
   local sha256="${4:-}"
-  local port="${5:-}"
+  local bind_host="${5:-}"
+  local port="${6:-}"
   local parent temp
 
   [ -n "$file" ] || return 2
@@ -53,14 +75,16 @@ masc_runtime_artifact_descriptor_write () {
     *$'\n'*|*$'\r'*) return 2 ;;
   esac
   masc_runtime_artifact_valid_hash "$sha256" || return 2
+  masc_runtime_artifact_valid_host "$bind_host" || return 2
   masc_runtime_artifact_valid_port "$port" || return 2
 
   parent="$(dirname "$file")"
   mkdir -p "$parent" || return 1
   temp="$file.tmp.$$"
   umask 077
-  if ! printf '%s\n%s\n%s\n%s\n%s\n' \
-      "$MASC_RUNTIME_ARTIFACT_SCHEMA" "$mode" "$path" "$sha256" "$port" \
+  if ! printf '%s\n%s\n%s\n%s\n%s\n%s\n' \
+      "$MASC_RUNTIME_ARTIFACT_SCHEMA" "$mode" "$path" "$sha256" \
+      "$bind_host" "$port" \
       >"$temp"
   then
     rm -f "$temp"
@@ -75,7 +99,7 @@ masc_runtime_artifact_descriptor_write () {
 
 masc_runtime_artifact_descriptor_read () {
   local file="${1:-}"
-  local schema mode path sha256 port
+  local schema mode path sha256 bind_host port
 
   [ -f "$file" ] || return 1
   {
@@ -83,6 +107,7 @@ masc_runtime_artifact_descriptor_read () {
     IFS= read -r mode || return 1
     IFS= read -r path || return 1
     IFS= read -r sha256 || return 1
+    IFS= read -r bind_host || return 1
     IFS= read -r port || return 1
     if IFS= read -r _; then
       return 1
@@ -96,13 +121,16 @@ masc_runtime_artifact_descriptor_read () {
     *) return 1 ;;
   esac
   masc_runtime_artifact_valid_hash "$sha256" || return 1
+  masc_runtime_artifact_valid_host "$bind_host" || return 1
   masc_runtime_artifact_valid_port "$port" || return 1
 
   MASC_ARTIFACT_MODE="$mode"
   MASC_ARTIFACT_PATH="$path"
   MASC_ARTIFACT_SHA256="$sha256"
+  MASC_ARTIFACT_BIND_HOST="$bind_host"
   MASC_ARTIFACT_PORT="$port"
-  export MASC_ARTIFACT_MODE MASC_ARTIFACT_PATH MASC_ARTIFACT_SHA256 MASC_ARTIFACT_PORT
+  export MASC_ARTIFACT_MODE MASC_ARTIFACT_PATH MASC_ARTIFACT_SHA256
+  export MASC_ARTIFACT_BIND_HOST MASC_ARTIFACT_PORT
 }
 
 masc_runtime_artifact_descriptor_verify () {
@@ -120,23 +148,26 @@ masc_runtime_artifact_promote () {
   local candidate_file="${1:-}"
   local lkg_file="${2:-}"
   local repo_root="${3:-}"
-  local source_path source_hash mode port promoted_path promoted_dir temp actual
+  local source_path source_hash mode bind_host port promoted_path promoted_dir temp actual
 
   masc_runtime_artifact_descriptor_verify "$candidate_file" || return 1
   source_path="$MASC_ARTIFACT_PATH"
   source_hash="$MASC_ARTIFACT_SHA256"
   mode="$MASC_ARTIFACT_MODE"
+  bind_host="$MASC_ARTIFACT_BIND_HOST"
   port="$MASC_ARTIFACT_PORT"
   promoted_path="$source_path"
 
-  # Local Dune outputs are mutable.  Preserve the exact healthy bytes beside
-  # the selected executable so Sys.executable_name keeps the same repo/layout
-  # ancestry on fallback.  Release and installed artifacts remain at their
-  # already-stable path and are still protected by the descriptor hash.
+  # Local Dune outputs are mutable and `dune clean` deletes all of _build.
+  # Preserve exact healthy bytes beside the durable LKG descriptor, outside
+  # _build but still beneath the configured repository by default. Release and
+  # installed artifacts remain at their already-stable path and are hash-bound.
   case "$source_path" in
     "$repo_root"/_build/*)
-      promoted_dir="$(dirname "$source_path")"
-      promoted_path="$promoted_dir/.masc-lkg-$source_hash-$(basename "$source_path")"
+      promoted_dir="$(dirname "$lkg_file")/.masc-runtime-artifacts"
+      mkdir -p "$promoted_dir" || return 1
+      chmod 700 "$promoted_dir" || return 1
+      promoted_path="$promoted_dir/$source_hash-$(basename "$source_path")"
       if [ ! -f "$promoted_path" ]; then
         temp="$promoted_path.tmp.$$"
         cp -p "$source_path" "$temp" || {
@@ -166,7 +197,7 @@ masc_runtime_artifact_promote () {
   esac
 
   masc_runtime_artifact_descriptor_write "$lkg_file" "$mode" \
-    "$promoted_path" "$source_hash" "$port"
+    "$promoted_path" "$source_hash" "$bind_host" "$port"
 }
 
 masc_runtime_artifact_cli () {
@@ -178,8 +209,8 @@ masc_runtime_artifact_cli () {
       masc_runtime_artifact_hash "$1"
       ;;
     write)
-      [ "$#" -eq 5 ] || return 2
-      masc_runtime_artifact_descriptor_write "$1" "$2" "$3" "$4" "$5"
+      [ "$#" -eq 6 ] || return 2
+      masc_runtime_artifact_descriptor_write "$1" "$2" "$3" "$4" "$5" "$6"
       ;;
     verify)
       [ "$#" -eq 1 ] || return 2
@@ -190,7 +221,7 @@ masc_runtime_artifact_cli () {
       masc_runtime_artifact_promote "$1" "$2" "$3"
       ;;
     *)
-      printf 'usage: %s {hash FILE|write FILE MODE PATH SHA256 PORT|verify FILE|promote CANDIDATE LKG REPO_ROOT}\n' \
+      printf 'usage: %s {hash FILE|write FILE MODE PATH SHA256 BIND_HOST PORT|verify FILE|promote CANDIDATE LKG REPO_ROOT}\n' \
         "$0" >&2
       return 2
       ;;

--- a/scripts/start-masc-supervised.sh
+++ b/scripts/start-masc-supervised.sh
@@ -16,7 +16,7 @@
 #   MASC_RESTART_COOLDOWN_SEC       — sleep between restart attempts
 #                                     (default: 5)
 #   MASC_RUNTIME_LKG_FILE           — health-verified artifact descriptor
-#                                     (default: <repo-root>/logs/masc-runtime-lkg.v1)
+#                                     (default: <repo-root>/logs/masc-runtime-lkg.v2)
 #   MASC_SUPERVISOR_HEALTH_PROBE_SEC — observation cadence only; never a
 #                                     readiness timeout (default: 1)
 #
@@ -45,15 +45,17 @@ mkdir -p "$(dirname "$LOG_FILE")"
 COOLDOWN_SEC="${MASC_RESTART_COOLDOWN_SEC:-5}"
 HEALTH_PROBE_SEC="${MASC_SUPERVISOR_HEALTH_PROBE_SEC:-1}"
 ARTIFACT_CONTRACT="${MASC_RUNTIME_ARTIFACT_CONTRACT:-$REPO_ROOT/scripts/lib/runtime-artifact-contract.sh}"
-LKG_FILE="${MASC_RUNTIME_LKG_FILE:-$REPO_ROOT/logs/masc-runtime-lkg.v1}"
+LKG_FILE="${MASC_RUNTIME_LKG_FILE:-$REPO_ROOT/logs/masc-runtime-lkg.v2}"
 ATTEMPT_DIR="$(dirname "$LKG_FILE")"
-CANDIDATE_FILE="$ATTEMPT_DIR/masc-runtime-candidate.$$.v1"
-PROOF_FILE="$ATTEMPT_DIR/masc-runtime-health-proof.$$.v1"
-HEALTH_PROOF_SCHEMA="masc.runtime_health_proof.v1"
+CANDIDATE_FILE="$ATTEMPT_DIR/masc-runtime-candidate.$$.v2"
+PROOF_FILE="$ATTEMPT_DIR/masc-runtime-health-proof.$$.v2"
+HEALTH_PROOF_SCHEMA="masc.runtime_health_proof.v2"
 active_pid=""
 active_kind=""
+active_nonce=""
 monitor_pid=""
 completed_pid=""
+completed_nonce=""
 stop_signal=""
 stop_exit_code=0
 stop_forwarded_pid=""
@@ -77,29 +79,43 @@ if [ "$HEALTH_PROBE_SEC" -lt 1 ]; then
   log "ERROR: MASC_SUPERVISOR_HEALTH_PROBE_SEC must be at least 1"
   exit 78
 fi
-for required_command in lsof curl; do
+for required_command in lsof curl od tr; do
   if ! command -v "$required_command" >/dev/null 2>&1; then
     log "ERROR: required runtime health-proof command unavailable: $required_command"
     exit 78
   fi
 done
+if [ ! -r /dev/urandom ]; then
+  log "ERROR: supervisor-owned health proof randomness unavailable: /dev/urandom"
+  exit 78
+fi
 # shellcheck source=/dev/null
 source "$ARTIFACT_CONTRACT"
 mkdir -p "$ATTEMPT_DIR"
 
+generate_health_nonce() {
+  local nonce
+
+  nonce="$(LC_ALL=C od -An -N32 -tx1 /dev/urandom | tr -d ' \n')" || return 1
+  masc_runtime_artifact_valid_hash "$nonce" || return 1
+  printf '%s\n' "$nonce"
+}
+
 write_health_proof() {
   local child_pid="$1"
   local artifact_hash="$2"
+  local nonce="$3"
   local temp="$PROOF_FILE.tmp.$$"
 
   case "$child_pid" in
     ''|*[!0-9]*) return 2 ;;
   esac
   masc_runtime_artifact_valid_hash "$artifact_hash" || return 2
+  masc_runtime_artifact_valid_hash "$nonce" || return 2
 
   umask 077
-  if ! printf '%s\n%s\n%s\n' \
-      "$HEALTH_PROOF_SCHEMA" "$child_pid" "$artifact_hash" >"$temp"
+  if ! printf '%s\n%s\n%s\n%s\n' \
+      "$HEALTH_PROOF_SCHEMA" "$child_pid" "$artifact_hash" "$nonce" >"$temp"
   then
     rm -f "$temp"
     return 1
@@ -113,13 +129,15 @@ write_health_proof() {
 
 verify_health_proof() {
   local expected_pid="$1"
-  local schema proof_pid proof_hash
+  local expected_nonce="$2"
+  local schema proof_pid proof_hash proof_nonce
 
   [ -f "$PROOF_FILE" ] || return 1
   {
     IFS= read -r schema || return 1
     IFS= read -r proof_pid || return 1
     IFS= read -r proof_hash || return 1
+    IFS= read -r proof_nonce || return 1
     if IFS= read -r _; then
       return 1
     fi
@@ -128,21 +146,25 @@ verify_health_proof() {
   [ "$schema" = "$HEALTH_PROOF_SCHEMA" ] || return 1
   [ "$proof_pid" = "$expected_pid" ] || return 1
   masc_runtime_artifact_valid_hash "$proof_hash" || return 1
+  [ "$proof_nonce" = "$expected_nonce" ] || return 1
   masc_runtime_artifact_descriptor_read "$CANDIDATE_FILE" || return 1
   [ "$proof_hash" = "$MASC_ARTIFACT_SHA256" ]
 }
 
 monitor_runtime_candidate() {
   local child_pid="$1"
+  local nonce="$2"
   local listener_pid=""
   local actual_hash=""
+  local probe_host=""
 
   while kill -0 "$child_pid" 2>/dev/null; do
     if masc_runtime_artifact_descriptor_read "$CANDIDATE_FILE"; then
       listener_pid="$(lsof -ti "tcp:$MASC_ARTIFACT_PORT" -sTCP:LISTEN 2>/dev/null | head -n 1 || true)"
+      probe_host="$(masc_runtime_artifact_probe_host "$MASC_ARTIFACT_BIND_HOST")" || return
       if [ "$listener_pid" = "$child_pid" ] \
         && curl -fsS --max-time 1 \
-          "http://127.0.0.1:$MASC_ARTIFACT_PORT/health" >/dev/null 2>&1
+          --url "http://$probe_host:$MASC_ARTIFACT_PORT/health" >/dev/null 2>&1
       then
         actual_hash="$(masc_runtime_artifact_hash "$MASC_ARTIFACT_PATH")" || return
         if [ "$actual_hash" != "$MASC_ARTIFACT_SHA256" ]; then
@@ -150,7 +172,7 @@ monitor_runtime_candidate() {
           return
         fi
         if masc_runtime_artifact_promote "$CANDIDATE_FILE" "$LKG_FILE" "$REPO_ROOT"; then
-          if write_health_proof "$child_pid" "$actual_hash"; then
+          if write_health_proof "$child_pid" "$actual_hash" "$nonce"; then
             log "health-verified runtime artifact promoted sha256=$actual_hash pid=$child_pid"
           else
             log "ERROR: healthy runtime artifact promotion lacked an exact health proof"
@@ -202,10 +224,22 @@ run_active() {
   active_kind="$kind"
   "$@" &
   active_pid=$!
+  active_nonce=""
   stop_forwarded_pid=""
   monitor_pid=""
   if [ "$kind" = "masc" ]; then
-    monitor_runtime_candidate "$active_pid" &
+    if ! active_nonce="$(generate_health_nonce)"; then
+      log "ERROR: unable to generate supervisor-owned health proof nonce"
+      kill -TERM "$active_pid" 2>/dev/null || true
+      wait "$active_pid" 2>/dev/null || true
+      completed_pid="$active_pid"
+      completed_nonce=""
+      active_pid=""
+      active_kind=""
+      stop_forwarded_pid=""
+      return 78
+    fi
+    monitor_runtime_candidate "$active_pid" "$active_nonce" &
     monitor_pid=$!
   fi
   forward_stop_to_active
@@ -227,8 +261,10 @@ run_active() {
   fi
 
   completed_pid="$active_pid"
+  completed_nonce="$active_nonce"
   active_pid=""
   active_kind=""
+  active_nonce=""
   stop_forwarded_pid=""
   return "$status"
 }
@@ -286,7 +322,7 @@ while true; do
     log "terminal startup state: no runtime candidate was published; refusing restart amplification"
     exit "$exit_code"
   fi
-  if ! verify_health_proof "$completed_pid"; then
+  if ! verify_health_proof "$completed_pid" "$completed_nonce"; then
     log "terminal startup state: runtime candidate lacks an exact PID-bound health proof; refusing restart amplification"
     exit "$exit_code"
   fi

--- a/scripts/start-masc-supervised.sh
+++ b/scripts/start-masc-supervised.sh
@@ -25,6 +25,8 @@
 #   A PID-bound healthy runtime keeps continuous restart responsibility.
 #   A startup that never publishes a candidate or never reaches PID-bound
 #   health is terminal, so deterministic startup failures are not amplified.
+#   A zero child status without that proof is supervisor failure (EX_SOFTWARE),
+#   not evidence that a runnable service was installed.
 #   TERM, INT, and HUP remain explicit external stop signals: they are
 #   forwarded to the active child and terminate the supervisor.
 #
@@ -50,6 +52,7 @@ ATTEMPT_DIR="$(dirname "$LKG_FILE")"
 CANDIDATE_FILE="$ATTEMPT_DIR/masc-runtime-candidate.$$.v2"
 PROOF_FILE="$ATTEMPT_DIR/masc-runtime-health-proof.$$.v2"
 HEALTH_PROOF_SCHEMA="masc.runtime_health_proof.v2"
+readonly UNPROVEN_RUNTIME_EXIT_CODE=70
 active_pid=""
 active_kind=""
 active_nonce=""
@@ -63,6 +66,16 @@ stop_forwarded_pid=""
 log() {
   printf '[%s][supervisor] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" \
     | tee -a "$LOG_FILE" >&2
+}
+
+exit_terminal_unproven() {
+  local child_status="$1"
+
+  if [ "$child_status" -eq 0 ]; then
+    log "ERROR: child exited successfully without a health-verified runtime; reporting supervisor failure"
+    exit "$UNPROVEN_RUNTIME_EXIT_CODE"
+  fi
+  exit "$child_status"
 }
 
 if [ ! -r "$ARTIFACT_CONTRACT" ]; then
@@ -320,11 +333,11 @@ while true; do
 
   if [ ! -f "$CANDIDATE_FILE" ]; then
     log "terminal startup state: no runtime candidate was published; refusing restart amplification"
-    exit "$exit_code"
+    exit_terminal_unproven "$exit_code"
   fi
   if ! verify_health_proof "$completed_pid" "$completed_nonce"; then
     log "terminal startup state: runtime candidate lacks an exact PID-bound health proof; refusing restart amplification"
-    exit "$exit_code"
+    exit_terminal_unproven "$exit_code"
   fi
 
   log "restart in ${COOLDOWN_SEC}s"

--- a/start-masc.sh
+++ b/start-masc.sh
@@ -242,7 +242,8 @@ recover_verified_lkg_after_build_failure() {
 publish_runtime_candidate() {
     local candidate_file="${MASC_RUNTIME_CANDIDATE_FILE:-}"
     local selected_exe="$1"
-    local selected_port="$2"
+    local selected_host="$2"
+    local selected_port="$3"
     local sha256
 
     [ -n "$candidate_file" ] || return 0
@@ -251,7 +252,7 @@ publish_runtime_candidate() {
         return 1
     }
     if ! masc_runtime_artifact_descriptor_write "$candidate_file" http \
-        "$selected_exe" "$sha256" "$selected_port"
+        "$selected_exe" "$sha256" "$selected_host" "$selected_port"
     then
         echo "Error: failed to publish runtime candidate descriptor: $candidate_file" >&2
         return 1
@@ -1107,8 +1108,7 @@ launch_from_base_path() {
     if [ -n "${MASC_LOG_FILE:-}" ]; then
         mkdir -p "$(dirname "$MASC_LOG_FILE")"
         echo "  Log file: $MASC_LOG_FILE (stdout+stderr tee'd)" >&2
-        set -o pipefail
-        exec "$@" 2>&1 | tee -a "$MASC_LOG_FILE"
+        exec "$@" > >(tee -a "$MASC_LOG_FILE") 2>&1
     else
         exec "$@"
     fi
@@ -1134,7 +1134,7 @@ if [ "$EIO_MODE" = "true" ] && [ "$HTTP_MODE" = "true" ]; then
         echo "  MCP endpoint: /mcp (set MASC_HTTP_BASE_URL for an absolute origin)" >&2
     fi
     echo "  MCP Accept: application/json, text/event-stream" >&2
-    if ! publish_runtime_candidate "$SELECTED_EXE" "$PORT"; then
+    if ! publish_runtime_candidate "$SELECTED_EXE" "$HOST" "$PORT"; then
         exit 78
     fi
     launch_from_base_path "$SELECTED_EXE" --host="$HOST" --port="$PORT" --base-path="$RESOLVED_BASE_PATH"

--- a/test/test_start_masc_script.ml
+++ b/test/test_start_masc_script.ml
@@ -1410,6 +1410,69 @@ let test_supervisor_stops_on_startup_without_candidate () =
         (contains_substring stderr
            "terminal startup state: no runtime candidate was published"))
 
+let test_supervisor_zero_exit_without_health_proof_fails_closed () =
+  let run_case ~name ~publish_candidate ~terminal_message =
+    with_temp_dir name (fun repo_root ->
+        let scripts_dir = Filename.concat repo_root "scripts" in
+        let lib_dir = Filename.concat scripts_dir "lib" in
+        let fake_bin = Filename.concat repo_root "fake-bin" in
+        let supervisor_script =
+          Filename.concat scripts_dir "start-masc-supervised.sh"
+        in
+        let child_script = Filename.concat repo_root "start-masc.sh" in
+        let invocation_count = Filename.concat repo_root "invocation-count" in
+        let lkg_file = Filename.concat repo_root "last-known-good.v2" in
+        let log_file = Filename.concat repo_root "supervisor.log" in
+        mkdir_p lib_dir;
+        mkdir_p fake_bin;
+        copy_script (supervised_script_path ()) supervisor_script;
+        copy_script (runtime_artifact_contract_path ())
+          (Filename.concat lib_dir "runtime-artifact-contract.sh");
+        write_executable (Filename.concat fake_bin "lsof")
+          "#!/bin/sh\nexit 0\n";
+        write_executable (Filename.concat fake_bin "curl")
+          "#!/bin/sh\nexit 1\n";
+        let publish_candidate_script =
+          if publish_candidate then
+            {|
+hash="$(${MASC_RUNTIME_ARTIFACT_CONTRACT:?} hash "$0")"
+"$MASC_RUNTIME_ARTIFACT_CONTRACT" write \
+  "${MASC_RUNTIME_CANDIDATE_FILE:?}" http "$0" "$hash" 127.0.0.1 9999
+|}
+          else ""
+        in
+        write_executable child_script
+          (Printf.sprintf
+             "#!/bin/bash\nset -eu\nprintf '1\\n' > %s\n%s\nexit 0\n"
+             (quote invocation_count) publish_candidate_script);
+        let code, stdout, stderr =
+          run_script ~cwd:repo_root supervisor_script
+            ~env:
+              [
+                ("MASC_RUNTIME_LKG_FILE", lkg_file);
+                ("MASC_SUPERVISOR_LOG", log_file);
+                ("MASC_RESTART_COOLDOWN_SEC", "0");
+                ("PATH", fake_bin ^ ":" ^ Sys.getenv "PATH");
+              ]
+            []
+        in
+        check int "unproven runtime cannot report supervisor success" 70 code;
+        check string "unproven startup is not amplified" "1\n"
+          (read_file invocation_count);
+        check string "supervisor writes no stdout" "" stdout;
+        check bool "terminal state is operator-visible" true
+          (contains_substring stderr terminal_message);
+        check bool "successful child is reclassified as supervisor failure" true
+          (contains_substring stderr
+             "child exited successfully without a health-verified runtime"))
+  in
+  run_case ~name:"start-masc-supervisor-zero-without-candidate"
+    ~publish_candidate:false
+    ~terminal_message:"no runtime candidate was published";
+  run_case ~name:"start-masc-supervisor-zero-without-proof"
+    ~publish_candidate:true
+    ~terminal_message:"lacks an exact PID-bound health proof"
+
 let test_supervisor_promotes_pid_bound_healthy_candidate () =
   with_temp_dir "start-masc-supervisor-lkg" (fun repo_root ->
       with_temp_dir "start-masc-supervisor-lkg-bin" (fun fake_bin ->
@@ -1709,6 +1772,8 @@ let () =
             test_loopback_disables_keeper_autoboot_by_default_and_requires_opt_in;
           test_case "supervisor stops on startup without candidate" `Quick
             test_supervisor_stops_on_startup_without_candidate;
+          test_case "supervisor zero exit without health proof fails closed"
+            `Quick test_supervisor_zero_exit_without_health_proof_fails_closed;
           test_case "supervisor promotes PID-bound healthy candidate" `Quick
             test_supervisor_promotes_pid_bound_healthy_candidate;
           test_case "supervisor rejects malformed health proof" `Quick

--- a/test/test_start_masc_script.ml
+++ b/test/test_start_masc_script.ml
@@ -159,10 +159,10 @@ let artifact_hash ~cwd path =
       stderr;
   String.trim stdout
 
-let write_artifact_descriptor ~cwd ~file ~mode ~path ~sha256 ~port =
+let write_artifact_descriptor ~cwd ~file ~mode ~path ~sha256 ~bind_host ~port =
   let code, stdout, stderr =
     run_contract ~cwd
-      [ "write"; file; mode; path; sha256; string_of_int port ]
+      [ "write"; file; mode; path; sha256; bind_host; string_of_int port ]
   in
   if code <> 0 then
     failf "artifact descriptor write failed (%d)\nstdout:\n%s\nstderr:\n%s"
@@ -1005,8 +1005,8 @@ let test_build_tempfail_runs_only_hash_verified_lkg () =
           let script = Filename.concat dir "start-masc.sh" in
           let scripts_dir = Filename.concat dir "scripts" in
           let lkg_exe = Filename.concat dir "verified-lkg-main_eio.exe" in
-          let lkg_file = Filename.concat dir "last-known-good.v1" in
-          let candidate_file = Filename.concat dir "candidate.v1" in
+          let lkg_file = Filename.concat dir "last-known-good.v2" in
+          let candidate_file = Filename.concat dir "candidate.v2" in
           let capture = Filename.concat dir "captured-lkg.txt" in
           let source = Filename.concat dir "bin/main_eio.ml" in
           copy_script (script_path ()) script;
@@ -1025,7 +1025,7 @@ let test_build_tempfail_runs_only_hash_verified_lkg () =
           Unix.utimes source future future;
           let lkg_hash = artifact_hash ~cwd:dir lkg_exe in
           write_artifact_descriptor ~cwd:dir ~file:lkg_file ~mode:"http"
-            ~path:lkg_exe ~sha256:lkg_hash ~port:9972;
+            ~path:lkg_exe ~sha256:lkg_hash ~bind_host:"127.0.0.1" ~port:9972;
           let code, stdout, stderr =
             run_script ~cwd:dir script
               ~env:
@@ -1064,7 +1064,7 @@ let test_build_tempfail_rejects_lkg_hash_mismatch () =
           let script = Filename.concat dir "start-masc.sh" in
           let scripts_dir = Filename.concat dir "scripts" in
           let lkg_exe = Filename.concat dir "invalid-lkg-main_eio.exe" in
-          let lkg_file = Filename.concat dir "last-known-good.v1" in
+          let lkg_file = Filename.concat dir "last-known-good.v2" in
           let capture = Filename.concat dir "captured-invalid-lkg.txt" in
           let source = Filename.concat dir "bin/main_eio.ml" in
           copy_script (script_path ()) script;
@@ -1082,7 +1082,8 @@ let test_build_tempfail_rejects_lkg_hash_mismatch () =
           let future = Unix.time () +. 10.0 in
           Unix.utimes source future future;
           write_artifact_descriptor ~cwd:dir ~file:lkg_file ~mode:"http"
-            ~path:lkg_exe ~sha256:(String.make 64 '0') ~port:9972;
+            ~path:lkg_exe ~sha256:(String.make 64 '0')
+            ~bind_host:"127.0.0.1" ~port:9972;
           let code, _stdout, stderr =
             run_script ~cwd:dir script
               ~env:
@@ -1103,6 +1104,49 @@ let test_build_tempfail_rejects_lkg_hash_mismatch () =
           check bool "hash mismatch is operator-visible" true
             (contains_substring stderr
                "last-known-good artifact failed exact verification")))
+
+let test_promoted_dune_lkg_survives_build_tree_cleanup () =
+  with_temp_dir "start-masc-durable-lkg" (fun repo_root ->
+      let build_root = Filename.concat repo_root "_build" in
+      let source_exe =
+        Filename.concat build_root "default/bin/main_eio.exe"
+      in
+      let logs_dir = Filename.concat repo_root "logs" in
+      let candidate_file = Filename.concat logs_dir "candidate.v2" in
+      let lkg_file = Filename.concat logs_dir "last-known-good.v2" in
+      write_fake_eio_exe source_exe ~marker:"durable-source";
+      mkdir_p logs_dir;
+      let source_hash = artifact_hash ~cwd:repo_root source_exe in
+      write_artifact_descriptor ~cwd:repo_root ~file:candidate_file ~mode:"http"
+        ~path:source_exe ~sha256:source_hash ~bind_host:"127.0.0.1"
+        ~port:9972;
+      let code, stdout, stderr =
+        run_contract ~cwd:repo_root
+          [ "promote"; candidate_file; lkg_file; repo_root ]
+      in
+      if code <> 0 then
+        failf "LKG promotion failed (%d)\nstdout:\n%s\nstderr:\n%s" code
+          stdout stderr;
+      let descriptor_lines = String.split_on_char '\n' (read_file lkg_file) in
+      let promoted_path = List.nth descriptor_lines 2 in
+      check bool "promoted path is outside dune build tree" false
+        (contains_substring promoted_path "/_build/");
+      rm_rf build_root;
+      let verify_code, verify_stdout, verify_stderr =
+        run_contract ~cwd:repo_root [ "verify"; lkg_file ]
+      in
+      if verify_code <> 0 then
+        failf
+          "promoted LKG did not survive build tree cleanup (%d)\nstdout:\n%s\nstderr:\n%s"
+          verify_code verify_stdout verify_stderr)
+
+let test_log_tee_preserves_server_pid () =
+  let source = read_file (script_path ()) in
+  check bool "log tee uses PID-preserving process substitution" true
+    (contains_substring source
+       "exec \"$@\" > >(tee -a \"$MASC_LOG_FILE\") 2>&1");
+  check bool "log tee does not retain a pipeline wrapper" false
+    (contains_substring source "exec \"$@\" 2>&1 | tee")
 
 let test_default_build_lock_is_worktree_local () =
   let source = read_file (script_path ()) in
@@ -1376,7 +1420,8 @@ let test_supervisor_promotes_pid_bound_healthy_candidate () =
           in
           let child_script = Filename.concat repo_root "start-masc.sh" in
           let listener_pid_file = Filename.concat repo_root "listener-pid" in
-          let lkg_file = Filename.concat repo_root "last-known-good.v1" in
+          let curl_capture = Filename.concat repo_root "curl-capture" in
+          let lkg_file = Filename.concat repo_root "last-known-good.v2" in
           let log_file = Filename.concat repo_root "supervisor.log" in
           mkdir_p lib_dir;
           mkdir_p fake_bin;
@@ -1392,7 +1437,7 @@ if [ -f "${FAKE_LISTENER_PID_FILE:?}" ]; then
 fi
 |};
           write_executable (Filename.concat fake_bin "curl")
-            "#!/bin/sh\nexit 0\n";
+            "#!/bin/sh\nset -eu\nprintf '%s\\n' \"$*\" > \"${FAKE_CURL_CAPTURE:?}\"\nexit 0\n";
           write_executable child_script
             (Printf.sprintf
                {|
@@ -1404,12 +1449,16 @@ fi
 printf '%%s\n' "$$" > %s
 hash="$("${MASC_RUNTIME_ARTIFACT_CONTRACT:?}" hash "$0")"
 "$MASC_RUNTIME_ARTIFACT_CONTRACT" write \
-  "${MASC_RUNTIME_CANDIDATE_FILE:?}" http "$0" "$hash" 9999
+  "${MASC_RUNTIME_CANDIDATE_FILE:?}" http "$0" "$hash" 192.0.2.10 9999
+attempts=0
 while ! grep -q "pid=$$" "${MASC_SUPERVISOR_LOG:?}" 2>/dev/null; do
+  attempts=$((attempts + 1))
+  [ "$attempts" -lt 250 ] || exit 71
   sleep 0.02
 done
 kill -TERM "$PPID"
-while true; do sleep 1; done
+sleep 2
+exit 72
 |}
                (quote listener_pid_file));
           let code, stdout, stderr =
@@ -1417,6 +1466,7 @@ while true; do sleep 1; done
               ~env:
                 [
                   ("FAKE_LISTENER_PID_FILE", listener_pid_file);
+                  ("FAKE_CURL_CAPTURE", curl_capture);
                   ("MASC_RUNTIME_LKG_FILE", lkg_file);
                   ("MASC_SUPERVISOR_LOG", log_file);
                   ("MASC_SUPERVISOR_HEALTH_PROBE_SEC", "1");
@@ -1431,6 +1481,9 @@ while true; do sleep 1; done
           let expected_hash = artifact_hash ~cwd:repo_root child_script in
           check bool "promoted descriptor retains exact artifact hash" true
             (contains_substring (read_file lkg_file) expected_hash);
+          check bool "configured bind host determines health probe" true
+            (contains_substring (read_file curl_capture)
+               "http://192.0.2.10:9999/health");
           check bool "promotion is operator-visible" true
             (contains_substring stderr
                "health-verified runtime artifact promoted")))
@@ -1445,7 +1498,7 @@ let test_supervisor_rejects_malformed_health_proof () =
           in
           let child_script = Filename.concat repo_root "start-masc.sh" in
           let invocation_count = Filename.concat repo_root "invocation-count" in
-          let lkg_file = Filename.concat repo_root "last-known-good.v1" in
+          let lkg_file = Filename.concat repo_root "last-known-good.v2" in
           let log_file = Filename.concat repo_root "supervisor.log" in
           mkdir_p lib_dir;
           mkdir_p fake_bin;
@@ -1464,8 +1517,10 @@ set -eu
 printf '1\n' > %s
 hash="$("${MASC_RUNTIME_ARTIFACT_CONTRACT:?}" hash "$0")"
 "$MASC_RUNTIME_ARTIFACT_CONTRACT" write \
-  "${MASC_RUNTIME_CANDIDATE_FILE:?}" http "$0" "$hash" 9999
-: > "$(dirname "${MASC_RUNTIME_LKG_FILE:?}")/masc-runtime-health-proof.${PPID}.v1"
+  "${MASC_RUNTIME_CANDIDATE_FILE:?}" http "$0" "$hash" 127.0.0.1 9999
+printf 'masc.runtime_health_proof.v2\n%%s\n%%s\n%%s\n' \
+  "$$" "$hash" "$(printf '0%%.0s' {1..64})" \
+  > "$(dirname "${MASC_RUNTIME_LKG_FILE:?}")/masc-runtime-health-proof.${PPID}.v2"
 exit 23
 |}
                (quote invocation_count));
@@ -1499,7 +1554,7 @@ let test_supervisor_restarts_without_exit_limit_and_preserves_status () =
           let child_script = Filename.concat repo_root "start-masc.sh" in
           let invocation_count = Filename.concat repo_root "invocation-count" in
           let listener_pid_file = Filename.concat repo_root "listener-pid" in
-          let lkg_file = Filename.concat repo_root "last-known-good.v1" in
+          let lkg_file = Filename.concat repo_root "last-known-good.v2" in
           let log_file = Filename.concat repo_root "supervisor.log" in
           mkdir_p lib_dir;
           mkdir_p fake_bin;
@@ -1529,15 +1584,17 @@ printf '%%s\n' "$count" > %s
 printf '%%s\n' "$$" > %s
 hash="$("${MASC_RUNTIME_ARTIFACT_CONTRACT:?}" hash "$0")"
 "$MASC_RUNTIME_ARTIFACT_CONTRACT" write \
-  "${MASC_RUNTIME_CANDIDATE_FILE:?}" http "$0" "$hash" 9999
+  "${MASC_RUNTIME_CANDIDATE_FILE:?}" http "$0" "$hash" 127.0.0.1 9999
+attempts=0
 while ! grep -q "pid=$$" "${MASC_SUPERVISOR_LOG:?}" 2>/dev/null; do
+  attempts=$((attempts + 1))
+  [ "$attempts" -lt 250 ] || exit 71
   sleep 0.02
 done
 if [ "$count" -ge 6 ]; then
   kill -TERM "$PPID"
-  while true; do
-    sleep 1
-  done
+  sleep 2
+  exit 72
 fi
 exit 23
 |}
@@ -1621,6 +1678,10 @@ let () =
 	            test_build_tempfail_runs_only_hash_verified_lkg;
 	          test_case "build tempfail rejects LKG hash mismatch" `Quick
 	            test_build_tempfail_rejects_lkg_hash_mismatch;
+	          test_case "promoted dune LKG survives build tree cleanup" `Quick
+	            test_promoted_dune_lkg_survives_build_tree_cleanup;
+	          test_case "log tee preserves server PID" `Quick
+	            test_log_tee_preserves_server_pid;
 	          test_case "default build lock is worktree-local" `Quick
 	            test_default_build_lock_is_worktree_local;
 	          test_case "stdio entrypoint uses shared base path guard" `Quick


### PR DESCRIPTION
## 긴급 후속

#25146이 2026-07-18 16:57 KST에 merge된 뒤 adversarial structural review에서 실제 기능 정지/거짓 복구 경로를 확인했습니다. 이 PR은 현재 `main@1379c5ccee` 위의 corrective commits이며, 현재 head는 `9ece7ff1ec`입니다.

Follow-up to #25146 and #25133.

## Merge blockers fixed

1. **`MASC_LOG_FILE` PID 분리**
   - Before: `exec server | tee`가 wrapper PID와 listener PID를 분리
   - Failure: LKG 승격 불가, SIGTERM 시 listener orphan 가능
   - After: process substitution으로 tee하되 server가 supervised child PID를 그대로 승계

2. **`dune clean`이 LKG 삭제**
   - Before: content-addressed LKG가 `_build` 내부
   - Failure: `dune clean` 후 fallback descriptor가 삭제된 파일을 가리킴
   - After: descriptor 인접 `.masc-runtime-artifacts/` durable store에 exact bytes 저장

3. **non-loopback host가 영구 미증명**
   - Before: health probe가 `127.0.0.1` 고정
   - Failure: LAN/IPv6 bind는 정상 listener여도 첫 exit 후 supervision 종료
   - After: exact descriptor의 bind host/port로 probe; wildcard bind만 contract-defined loopback으로 정규화

4. **child가 health proof 위조 가능**
   - Before: proof filename/PID/hash를 child가 예측 가능
   - Failure: listener 없이 exact-looking proof로 restart 권한 획득 가능
   - After: child fork 이후 supervisor가 256-bit nonce를 생성; schema/PID/hash/nonce/EOF가 모두 일치해야 restart 허용

5. **검증되지 않은 zero-exit가 supervisor 성공으로 투영**
   - Before: candidate/proof가 없어도 child exit `0`이면 supervisor도 `0`
   - Failure: runnable service가 설치되지 않았는데 운영 계층은 성공으로 판단
   - After: nonzero child status는 그대로 보존하고, zero status without exact proof는 named `EX_SOFTWARE=70` supervisor failure로 fail-closed

## Versioned contract

Merged v1의 필드 수를 조용히 바꾸지 않습니다.

- Runtime artifact: `masc.runtime_artifact.v2` = schema/mode/path/SHA-256/bind-host/port
- Health proof: `masc.runtime_health_proof.v2` = schema/child PID/artifact SHA-256/supervisor-owned nonce
- Default files: `masc-runtime-lkg.v2`, per-attempt candidate/proof v2
- v1은 추정 migration 없이 hard-cut; invalid/missing v2는 fail-closed

Promotion requires PID-bound listener AND configured-host `/health` AND exact current bytes. Exact proof가 없는 startup exit는 terminal이며 health-proven crash만 restart합니다.

## Tests

- promoted Dune LKG survives complete `_build` deletion
- non-loopback descriptor drives the exact health URL
- forged PID/hash proof with wrong nonce cannot authorize restart
- zero-exit with no candidate and zero-exit with candidate/no proof both fail with 70, without restart amplification
- existing nonzero child statuses remain preserved
- log tee preserves server PID
- health wait fixtures are bounded

## Verification

- `bash -n scripts/start-masc-supervised.sh`: green
- `shellcheck scripts/start-masc-supervised.sh`: green
- `ocamlformat --check test/test_start_masc_script.ml`: green
- `python3 scripts/check_test_coverage.py`: green
- `git diff --check`: green
- focused Dune is still pending because unrelated sessions currently run bare Dune; the shared wrapper must remain fail-closed
- exact-head Build and Test CI is required; keep Draft / do-not-merge until green

## Design matrix

`docs/design/2026-07-18-supervised-runtime-lkg-operation-matrix.html`

This closes runtime recovery authority gaps only. It does not change the 1.0 No-Go: 10 Keeper × 8h mixed-workload SLO and queue settlement remain separate hard gates.