### PR TITLE
refactor(compaction): name the exact_evidence envelope key once

### DIFF
--- a/lib/keeper/keeper_manual_compaction.ml
+++ b/lib/keeper/keeper_manual_compaction.ml
@@ -50,7 +50,7 @@ let append_manifest ~config ~base_dir ~(meta : keeper_meta) recovery =
               (`Assoc
                 [ "trigger", `String (Compaction_trigger.to_label trigger)
                 ; "trigger_detail", Compaction_trigger.to_detail_json trigger
-                ; ( "exact_evidence"
+                ; ( Keeper_compaction_evidence.exact_evidence_key
                   , Keeper_compaction_evidence.to_json recovery.evidence )
                 ])))
       ~checkpoint_path

--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -381,7 +381,7 @@ let decision_public_allowlist =
     ; "media_dropped_total"; "media_dropped_counts"
     ; "payload_role"; "trigger"; "trigger_detail"; "kind"; "limit_tokens"
     ; "ratio"; "threshold"; "count"
-    ; "source_requeued"; "exact_evidence"
+    ; "source_requeued"; Keeper_compaction_evidence.exact_evidence_key
     ; "clock_refs"
     ]
 
@@ -408,7 +408,8 @@ let decision_allowlist = function
 
 let decision_child_scope scope key =
   if String.equal key "clock_refs" then Clock_refs
-  else if String.equal key "exact_evidence" then Compaction_evidence
+  else if String.equal key Keeper_compaction_evidence.exact_evidence_key
+  then Compaction_evidence
   else scope
 
 let rec reject_unknown_fields ~allowlist path = function

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -275,7 +275,7 @@ let append_provider_overflow_manifest
                ; "trigger_detail", Compaction_trigger.to_detail_json trigger
                ; "source_requeued", `Bool true
                ; "error", error
-               ; ( "exact_evidence"
+               ; ( Keeper_compaction_evidence.exact_evidence_key
                  , Keeper_compaction_evidence.to_json evidence )
                ]))
         Keeper_runtime_manifest.Context_compacted

--- a/lib/keeper_compaction_evidence/keeper_compaction_evidence.ml
+++ b/lib/keeper_compaction_evidence/keeper_compaction_evidence.ml
@@ -89,6 +89,7 @@ let all_fields =
 ;;
 
 let wire_field_names = List.map field_name all_fields
+let exact_evidence_key = "exact_evidence"
 
 let known_field name =
   List.exists (fun field -> String.equal name (field_name field)) all_fields

--- a/lib/keeper_compaction_evidence/keeper_compaction_evidence.mli
+++ b/lib/keeper_compaction_evidence/keeper_compaction_evidence.mli
@@ -65,6 +65,11 @@ val decode_error_to_string : decode_error -> string
 val wire_field_names : string list
 (** Canonical JSON field names for public projection and closed decoding. *)
 
+val exact_evidence_key : string
+(** JSON envelope key under which a manifest decision payload carries the
+    [to_json] evidence object. Writers, the manifest projection allowlist,
+    and dashboard readers spell the key through this constant. *)
+
 val create
   :  selected_runtime_id:string option
   -> before_checkpoint_bytes:int

--- a/lib/server/dune
+++ b/lib/server/dune
@@ -22,6 +22,10 @@
   ;; #20929: server bootstrap converges <base>/.masc/config/prompts onto the
   ;; binary-embedded config/ tree so merged prompt edits ship on restart.
   masc.embedded_config
+  ;; server_dashboard_http_keeper_api reads the manifest decision payload
+  ;; through Keeper_compaction_evidence.exact_evidence_key; dune does not
+  ;; re-export it through the masc dep, so masc_server lists it explicitly.
+  masc.keeper_compaction_evidence
   ;; RFC-0266 Phase 4: GET /api/v1/dashboard/fusion-runs names
   ;; Fusion_run_registry directly; dune does not re-export it through the masc
   ;; dep, so masc_server lists masc.fusion_core explicitly.

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -850,7 +850,10 @@ let compaction_context_snapshot_json
          ; compaction_source
          ; status = row.status
          ; links = compaction_snapshot_links_json row.links
-         ; exact_evidence = Json_util.assoc_member_opt "exact_evidence" row.decision
+         ; exact_evidence =
+             Json_util.assoc_member_opt
+               Keeper_compaction_evidence.exact_evidence_key
+               row.decision
          ; reinjection_observation =
              compaction_reinjection_observation_json
                ~manifest_rows

--- a/test/keeper_compaction_evidence/test_keeper_compaction_evidence.ml
+++ b/test/keeper_compaction_evidence/test_keeper_compaction_evidence.ml
@@ -17,6 +17,13 @@ let evidence : Keeper_compaction_evidence.t =
 
 let canonical = Keeper_compaction_evidence.to_json evidence
 
+let test_exact_evidence_envelope_key () =
+  Alcotest.(check string)
+    "persisted envelope key"
+    "exact_evidence"
+    Keeper_compaction_evidence.exact_evidence_key
+;;
+
 let fields = function
   | `Assoc fields -> fields
   | _ -> Alcotest.fail "canonical evidence must be an object"
@@ -248,6 +255,10 @@ let () =
     "keeper compaction evidence"
     [ ( "projection"
       , [ Alcotest.test_case
+            "exact evidence envelope key"
+            `Quick
+            test_exact_evidence_envelope_key
+        ; Alcotest.test_case
             "projection and roundtrip"
             `Quick
             test_projection_and_roundtrip


### PR DESCRIPTION
## 목표

`"exact_evidence"` envelope key가 writer, manifest projection, child-scope router, dashboard reader에 bare literal로 흩어져 컴파일러가 drift를 잡지 못하던 SSOT 위반을 제거합니다.

## 변경

- `Keeper_compaction_evidence.exact_evidence_key`를 wire-field SSOT에 추가
- production 소비 5곳을 상수로 전환
  - `keeper_unified_turn.ml`
  - `keeper_manual_compaction.ml`
  - `keeper_runtime_manifest.ml` allowlist + router
  - `server_dashboard_http_keeper_api.ml`
- server library에 필요한 직접 dune dependency만 추가
- 독립 회귀 테스트가 상수를 재사용하지 않고 persisted wire 값 `"exact_evidence"`와 정확히 일치함을 검증

두 writer의 payload 구성은 서로 달라 불필요한 builder 추출은 하지 않습니다. 기존 JSON fixture의 raw literal도 wire 호환성 검증을 위해 유지합니다.

## Exact evidence

- Head: `aaad8ecc89`
- `ocamlformat --check`: PASS
- `git diff --check`: PASS
- `python3 scripts/check_test_coverage.py`: PASS
- focused Dune: 다른 세션의 bare Dune 때문에 wrapper admission exit 75, bypass하지 않음
- previous implementation head Build and Test: PASS
- exact-head CI: rerun 중

이 PR은 Draft이며 exact-head required CI가 끝날 때까지 do-not-merge입니다.

[근거] exact head/diff/coverage checker/wrapper admission; checked 2026-07-18 KST; confidence High.