### PR TITLE
fix(verifier): remove post-purge residue

### DIFF
--- a/dashboard/src/components/tools/prompt-book-panel.test.ts
+++ b/dashboard/src/components/tools/prompt-book-panel.test.ts
@@ -62,10 +62,10 @@ const PROMPTS: DashboardPromptItem[] = [
     char_count: 60,
   }),
   makePrompt({
-    key: 'verification.action_verifier',
+    key: 'verification.anti_rationalization',
     category: 'verification',
-    description: 'action verifier',
-    file_path: 'config/prompts/verification.action_verifier.md',
+    description: 'anti-rationalization guidance',
+    file_path: 'config/prompts/verification.anti_rationalization.md',
     char_count: 50,
   }),
   makePrompt({

--- a/docs/spec/C-implementation-status.md
+++ b/docs/spec/C-implementation-status.md
@@ -152,7 +152,9 @@ External memory projection은 제거됨. Hebbian Learning(synapse model)은 reti
 ### 13-OAS Integration (100% IMPL)
 
 단방향 경계(MASC→OAS) 14개 모듈에서 완벽 준수.
-Oas_worker, Runtime config, Verifier, Event bus(13 types), Context compaction(4 strategies) 전부 운용.
+Oas_worker, Runtime config, Event bus(13 types), Context compaction(4 strategies)를
+운용한다. 별도 Verifier bridge와 action-verifier prompt는 consumer가 없어 제거됐고,
+도메인별 structured judgment가 각 호출 경계를 소유한다.
 
 ### 14-Configuration (100% IMPL)
 

--- a/scripts/lint/exhaustive-guard.allowlist
+++ b/scripts/lint/exhaustive-guard.allowlist
@@ -816,7 +816,6 @@ lib/verification.ml:185
 lib/verification.ml:268
 lib/verification.ml:274
 lib/verification.ml:279
-lib/verifier_core.ml:42
 lib/voice/voice_bridge.ml:294
 lib/voice/voice_bridge.ml:784
 lib/voice/voice_config.ml:123


### PR DESCRIPTION
## Summary

Follow-up to merged #25138.

- remove the deleted verifier_core allowlist entry
- replace the dashboard prompt-book fixture that still referenced verification.action_verifier
- correct the implementation-status document so verifier is historical, not operational

## Validation

- dashboard targeted Vitest: 1 file, 3 tests passed
- dashboard tsc --noEmit: passed
- exhaustive guard: passed with pre-existing advisory warnings only
- git diff --check: passed

[근거] exact commit 4c25bf01107d; checked 2026-07-18 KST; confidence High.