### PR TITLE
refactor(server): share the presence last_seen_ms projection

### DIFF
--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -649,15 +649,9 @@ let dashboard_ide_snapshot_json ~(config : Workspace.config) : Yojson.Safe.t =
            | None -> None
            | Some keeper_name ->
              let last_seen_ms =
-               match Masc_domain.parse_iso8601_opt agent.last_seen with
-               | Some seconds -> Int64.of_float (seconds *. 1000.0)
-               | None ->
-                 Log.Server.warn
-                   "dashboard IDE presence mapped invalid last_seen timestamp to 0 \
-                    agent=%s value=%S"
-                   agent.name
-                   agent.last_seen;
-                 0L
+               Server_presence.last_seen_ms
+                 ~context:"dashboard IDE presence"
+                 agent
              in
              Some
                (`Assoc

--- a/lib/server/server_ide_http.ml
+++ b/lib/server/server_ide_http.ml
@@ -532,14 +532,7 @@ let build_presence_snapshot state =
          | None, _ | _, None -> None
          | Some keeper_id, Some status ->
            let last_seen_ms =
-             match Masc_domain.parse_iso8601_opt agent.last_seen with
-             | Some seconds -> Int64.of_float (seconds *. 1000.0)
-             | None ->
-               Log.Server.warn
-                 "IDE presence mapped invalid last_seen timestamp to 0 agent=%s value=%S"
-                 agent.name
-                 agent.last_seen;
-               0L
+             Server_presence.last_seen_ms ~context:"IDE presence" agent
            in
            Some
              (`Assoc

--- a/lib/server/server_presence.ml
+++ b/lib/server/server_presence.ml
@@ -1,0 +1,13 @@
+(** Shared presence projections for the HTTP servers. *)
+
+let last_seen_ms ~context (agent : Masc_domain.agent) =
+  match Masc_domain.parse_iso8601_opt agent.last_seen with
+  | Some seconds -> Int64.of_float (seconds *. 1000.0)
+  | None ->
+    Log.Server.warn
+      "%s mapped invalid last_seen timestamp to 0 agent=%s value=%S"
+      context
+      agent.name
+      agent.last_seen;
+    0L
+;;

--- a/lib/server/server_presence.mli
+++ b/lib/server/server_presence.mli
@@ -1,0 +1,7 @@
+(** Shared presence projections for the HTTP servers. *)
+
+val last_seen_ms : context:string -> Masc_domain.agent -> Int64.t
+(** Milliseconds-since-epoch projection of [agent.last_seen] for presence
+    rows. An unparsable timestamp maps to [0L] after a warning tagged with
+    [context]. The IDE and dashboard presence endpoints share this policy
+    so the same agent cannot render different presence values per surface. *)

--- a/test/test_server_ide_http.ml
+++ b/test/test_server_ide_http.ml
@@ -405,6 +405,21 @@ let test_presence_projects_only_canonical_keeper_identity () =
       (json_string_member "busy keeper" "role" busy))
 ;;
 
+let test_presence_last_seen_ms_shared_projection () =
+  let valid =
+    presence_agent
+      ~keeper_name:"ms-keeper"
+      ~last_seen:"2020-01-01T00:00:00Z"
+      ~status:Masc_domain.Active
+      "runtime-ms"
+  in
+  check int64 "valid ISO8601 maps to epoch milliseconds" 1577836800000L
+    (Server_presence.last_seen_ms ~context:"test presence" valid);
+  let invalid = { valid with Masc_domain.last_seen = "not-a-timestamp" } in
+  check int64 "invalid timestamp maps to 0" 0L
+    (Server_presence.last_seen_ms ~context:"test presence" invalid)
+;;
+
 let test_post_annotations_rejects_client_keeper_id () =
   with_ide_server (fun ~base_path ~state:_ ~router ->
     let token = create_worker_token base_path "alice" in
@@ -1052,6 +1067,10 @@ let () =
             "presence projects canonical keeper identity and status"
             `Quick
             test_presence_projects_only_canonical_keeper_identity
+        ; test_case
+            "last_seen_ms shared projection maps valid ISO and invalid to 0"
+            `Quick
+            test_presence_last_seen_ms_shared_projection
         ] )
     ; ( "scope_contract"
       , [ test_case


### PR DESCRIPTION
## 목표
48h 병합 SSOT 감사에서 확정된 하드코딩 산포 해소: `last_seen` → epoch ms 변환 + invalid→`0L`+warn 정책이 #24826에 의해 두 HTTP 서버에 동일 블록으로 복붙됨. 같은 위젯 개념을 렌더하는 두 표면이라, 한쪽 정책 변경 시 IDE/dashboard presence가 같은 agent에 대해 조용히 달라진다.

## 변경
- `Server_presence.last_seen_ms ~context agent` 신설 (`lib/server/server_presence.ml`/`.mli`)
- `server_ide_http.ml`, `server_dashboard_http.ml` 두 소비처를 헬퍼 호출로 교체 (로그 context 라벨은 표면별 유지)

## 검증
- `dune build --root .` 전체 green
- `test_server_ide_http` 34 tests green — 신규 test case 포함: valid ISO8601 `2020-01-01T00:00:00Z` → `1577836800000L`, invalid 문자열 → `0L`

## 관련
- 감사 형제 PR: #25149 #25161 / 감사 발견 이슈: #25139–#25144 / MASC task-2301

🤖 Generated with [Claude Code](https://claude.com/claude-code)
