### PR TITLE
fix(server): make discord trigger-policy loading typed and env-first

### DIFF
--- a/docs/CONNECTOR-CONFIG-SCHEMA.md
+++ b/docs/CONNECTOR-CONFIG-SCHEMA.md
@@ -5,17 +5,21 @@ each sidecar without hand-editing files. This document enumerates what config
 each sidecar actually reads, where it reads it from, and how the dashboard
 should surface it in a form.
 
-All four current sidecars share the same resolution order (via Pydantic
-`BaseSettings` + `TomlConfigSettingsSource`):
+The remaining external sidecars share the following resolution order via
+Pydantic `BaseSettings` + `TomlConfigSettingsSource`:
 
 ```
 env  >  runtime TOML  >  field defaults
 ```
 
-- Runtime TOML path: `${MASC_BASE_PATH}/.gate/runtime/<name>/config.toml`
+- External-sidecar TOML path: `${MASC_BASE_PATH}/.gate/runtime/<name>/config.toml`
 - Env file: `sidecars/<name>-bot/.env` (cwd-relative at process start)
 - Dashboard should **write the TOML**, not the `.env` — TOML is the persistent
   surface, `.env` is developer scratch.
+
+Discord is no longer a sidecar. Its in-process OCaml gateway resolves the
+trigger-policy env override and the `[discord]` table in MASC `runtime.toml` as
+documented in the Discord section below.
 
 ## Common fields (all sidecars)
 
@@ -41,7 +45,11 @@ the gate-state extension in `lib/gate/channel_gate_discord_state.{ml,mli}`.
 | Env var | Required | Notes |
 |---|---|---|
 | `DISCORD_BOT_TOKEN` | **yes** | Developer Portal → Bot → Reset Token. Read at every `send_message` call, so token rotation does not require a server restart. If unset the gateway logs a warning and skips startup; the rest of the server boots normally. |
-| `MASC_DISCORD_TRIGGER_POLICY` | no (default `mention_only`) | One of `mention_only`, `user_only:<discord_user_id>`, `all`. Closed sum; unknown values fall back to `mention_only`. |
+| `MASC_DISCORD_TRIGGER_POLICY` | no (default `mention_or_thread`) | Closed sum: `mention_only`, `mention_or_thread`, `user_only:<discord_user_id>`, or `all`. Resolution is env > `[discord].trigger_policy` in resolved `runtime.toml` > default. A non-empty invalid env or TOML value is a typed configuration error and the Discord gateway does not start; it is never coerced to a fallback policy. |
+
+An absent or blank env value is unset and falls through to TOML. A missing
+`runtime.toml`, missing `[discord].trigger_policy`, or blank TOML value is also
+unset and yields the default only after both configured planes are absent.
 
 Channel→keeper bindings live where they always did:
 `Channel_gate_discord_state.bind` / `unbind` write to

--- a/docs/rfc/RFC-0203-discord-builtin-gateway.md
+++ b/docs/rfc/RFC-0203-discord-builtin-gateway.md
@@ -3,7 +3,7 @@ title: In-process Discord connector
 rfc: "0203"
 status: Implemented (Phase 3 cutover landed 2026-05-29)
 created: 2026-05-28
-updated: 2026-05-29
+updated: 2026-07-18
 author: vincent
 related: ["0088", "0287"]
 ---
@@ -19,6 +19,12 @@ OCaml Gateway client replaces `sidecars/discord-bot/`. One tool out, push in.
 > ws-direct speaks plain `Eio.Flow.two_way`, so the fd impedance that motivated
 > the functor workaround is gone, and `websocket` 2.17 is dropped as a
 > dependency. The connector design (this RFC) is otherwise unchanged.
+
+> **Trigger-policy contract update (2026-07-18).** The live closed sum now
+> includes `mention_or_thread`, which is the default. Resolution is
+> `MASC_DISCORD_TRIGGER_POLICY` > `[discord].trigger_policy` in the resolved
+> `runtime.toml` > default. A non-empty invalid env or TOML value prevents the
+> Discord gateway from starting; it is never silently replaced by a default.
 
 > **Phase 3 cutover note (2026-05-29).** Phase 1 (#19355) and Phase 2
 > REST/state (#19362) landed as planned. Phase 2 dual-run
@@ -62,8 +68,11 @@ keeper → discord_send_message tool → Channel_gate_discord_state.send_message
 - **In = push.** Gateway WSS. No polling. Heartbeat op 1 every ~30s, dispatch op 0 events arrive when Discord sends them.
 - **Out = one tool.** `discord_send_message(channel_id, content)`. Snowflake `channel_id` covers guild text + DM + thread uniformly.
 - **No `discord_react`, no `discord_send_dm`, no `discord_watch`.** Anything reactions/DMs/threads can do is already covered by send_message + push inbound.
-- **Inbound filter.** One env var `DISCORD_TRIGGER_POLICY` decides which pushed messages reach the keeper workspace. Three values only — typed variant, no string classifier:
-  - `mention_only` (default) — only messages that @-mention the bot user
+- **Inbound filter.** The `MASC_DISCORD_TRIGGER_POLICY` env override and
+  `[discord].trigger_policy` runtime-TOML key select which pushed messages reach
+  the keeper workspace. Four values only — typed variant, no string classifier:
+  - `mention_or_thread` (default) — require a bot mention in ordinary channels; continue automatically inside an active thread
+  - `mention_only` — only messages that @-mention the bot user
   - `user_only:<discord_user_id>` — only messages from one specific Discord user, in any connected channel/DM/thread
   - `all` — every message in connected channels (high traffic; explicit opt-in)
 
@@ -88,7 +97,7 @@ Token: reuse `sidecars/discord-bot/.env` `DISCORD_BOT_TOKEN` during dual-run; re
 If a follow-up PR adds any of these, it violates this RFC. Reject and escalate.
 
 - `discord_react`, `discord_send_dm`, `discord_send_thread`, `discord_send_guild`, `discord_edit_message`, `discord_watch` — channel_id unifies, push delivers. Re-splitting brings back the fragmentation we're killing.
-- Trigger policies beyond the three listed in §Shape (e.g. keyword match, regex, role-based, AI-classifier). That door opens straight onto the RFC-0088 §2 string-classifier anti-pattern. If you need finer routing, do it in the keeper, not in the connector.
+- Trigger policies beyond the four listed in §Shape (e.g. keyword match, regex, role-based, AI-classifier). That door opens straight onto the RFC-0088 §2 string-classifier anti-pattern. If you need finer routing, do it in the keeper, not in the connector.
 - Polling. The reason this RFC exists is the sidecar's heartbeat polling failure mode. Adding any "check if there's a new message" loop on the OCaml side defeats the rewrite.
 - Counter-as-fix on Gateway disconnects. Supervisor backs off (exponential, max 10 restarts / 60s window, then error log). No silent `gateway_disconnect_count` while spinning.
 - String classifier on Discord error responses. Discord returns typed JSON with numeric `code`; decode into a variant.
@@ -105,8 +114,8 @@ If a follow-up PR adds any of these, it violates this RFC. Reject and escalate.
 
 - Tool surface: **one tool, `discord_send_message`.** No `masc_` prefix. No `discord_react`.
 - DM + threads + guild text all routed through the same tool via `channel_id`.
-- Inbound trigger: default `mention_only`. `user_only:<id>` for "내 말에만 반응", `all` as explicit opt-in for high-traffic mode.
-- Hermes Agents reference = [NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent). Confirmed prior art with the same "single gateway process for all messaging platforms (Discord/Telegram/Slack/Signal/Matrix/...)" architecture. Hermes Discord default = mention-only (`DISCORD_REQUIRE_MENTION=true`), matching our `mention_only` default. Hermes' `DISCORD_ALLOWED_USERS` ≈ our `user_only:<id>`. Differences kept deliberate: Hermes supports role-based + channel allowlists; we do not (see §Non-goals — string/role classifier anti-pattern, single-operator setup).
+- Inbound trigger: default `mention_or_thread`. `mention_only` is the stricter explicit mode; `user_only:<id>` means "내 말에만 반응"; `all` is an explicit high-traffic opt-in.
+- Hermes Agents reference = [NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent). Confirmed prior art with the same "single gateway process for all messaging platforms (Discord/Telegram/Slack/Signal/Matrix/...)" architecture. Hermes' mention-only mode corresponds to our explicit `mention_only`; Hermes' `DISCORD_ALLOWED_USERS` ≈ our `user_only:<id>`. Differences kept deliberate: MASC's default also continues an active Discord thread, and Hermes supports role-based + channel allowlists while MASC does not (see §Non-goals — string/role classifier anti-pattern, single-operator setup).
 - Python supervisor alternative rejected: defeats "내장" intent and leaves venv as deploy dep.
 - All-sidecars-at-once rejected: per-sidecar RFCs; this one is Discord only.
 

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -94,10 +94,9 @@ let load_trigger_policy_from_toml ~path =
                   Error (Trigger_policy_invalid { path; detail })))))
 ;;
 
-(* Env > TOML > default — the precedence every other env↔TOML pair in this
-   codebase resolves with and the one config/runtime.toml documents for this
-   key. An invalid env value is a load error like an invalid TOML value; an
-   empty/unset env falls through to the TOML plane. *)
+(* Env > TOML > default — the precedence config/runtime.toml documents for
+   this key. An invalid env value is a load error like an invalid TOML value;
+   an empty/unset env falls through to the TOML plane. *)
 let resolved_trigger_policy () =
   match trimmed_env "MASC_DISCORD_TRIGGER_POLICY" with
   | Some raw ->

--- a/lib/server/server_discord_in_process_gateway.ml
+++ b/lib/server/server_discord_in_process_gateway.ml
@@ -31,46 +31,90 @@ let bot_token_opt () = trimmed_env "DISCORD_BOT_TOKEN"
    "quiet, mention-triggered bot" baseline per RFC-0203. *)
 let default_trigger_policy : Gw.trigger_policy = Gw.Mention_or_thread
 
-(* Parse a configured trigger policy. Delegates to the single strict
-   parser in Discord_gateway_state so config and the (test-covered)
-   canonical grammar can never drift. An empty value is "unset" and
-   silently takes the default; a non-empty value that fails to parse
-   (typo, removed variant) is logged and falls back to the default
-   rather than being silently coerced into a policy the operator did
-   not write. *)
-let parse_trigger_policy raw : Gw.trigger_policy =
-  let s = String.trim raw in
-  if String.equal s "" then default_trigger_policy
-  else
-    match Discord_gateway_state.parse_trigger_policy s with
-    | Ok policy -> policy
-    | Error msg ->
-      Log.Server.warn
-        "discord trigger_policy %S rejected (%s); using default %s"
-        s msg
-        (Discord_gateway_state.trigger_policy_to_string default_trigger_policy);
-      default_trigger_policy
+(* Typed trigger-policy loading, mirroring the Slack sibling
+   ([Server_slack_in_process_gateway.load_trigger_policy_from_toml]): a
+   missing file or missing key is "unset" (default applies); an unreadable
+   file, malformed TOML, wrong field type, or a value the strict grammar
+   rejects is an explicit load error and the gateway does not start —
+   never a silent fallback onto a policy the operator did not write
+   (masc#25123 / PR #25126 recut). *)
 
+type trigger_policy_toml_load =
+  | Runtime_toml_missing
+  | Trigger_policy_missing
+  | Trigger_policy_loaded of Gw.trigger_policy
+
+type trigger_policy_load_error =
+  | Runtime_toml_unreadable of { path : string; detail : string }
+  | Runtime_toml_invalid of { path : string; detail : string }
+  | Trigger_policy_invalid of { path : string; detail : string }
+  | Trigger_policy_env_invalid of { detail : string }
+
+let trigger_policy_load_error_to_string = function
+  | Runtime_toml_unreadable { path; detail } ->
+    Printf.sprintf "cannot read %s: %s" path detail
+  | Runtime_toml_invalid { path; detail } ->
+    Printf.sprintf "invalid TOML in %s: %s" path detail
+  | Trigger_policy_invalid { path; detail } ->
+    Printf.sprintf "invalid discord.trigger_policy in %s: %s" path detail
+  | Trigger_policy_env_invalid { detail } ->
+    Printf.sprintf "invalid MASC_DISCORD_TRIGGER_POLICY: %s" detail
+;;
+
+let load_trigger_policy_from_toml ~path =
+  match Unix.lstat path with
+  | exception Unix.Unix_error (Unix.ENOENT, _, _) -> Ok Runtime_toml_missing
+  | exception Unix.Unix_error (code, _, _) ->
+    Error (Runtime_toml_unreadable { path; detail = Unix.error_message code })
+  | _ ->
+    (match Safe_ops.read_file_safe path with
+     | Error detail -> Error (Runtime_toml_unreadable { path; detail })
+     | Ok content ->
+       (match Otoml.Parser.from_string_result content with
+        | Error detail -> Error (Runtime_toml_invalid { path; detail })
+        | Ok toml ->
+          (match
+             Field_resolution.resolve_string toml [ "discord"; "trigger_policy" ]
+           with
+           | Field_resolution.Missing -> Ok Trigger_policy_missing
+           | Field_resolution.Type_mismatch { expected; message; _ } ->
+             Error
+               (Trigger_policy_invalid
+                  { path
+                  ; detail = Printf.sprintf "expected %s: %s" expected message
+                  })
+           | Field_resolution.Present raw ->
+             let raw = String.trim raw in
+             if String.equal raw ""
+             then Ok Trigger_policy_missing
+             else
+               (match Discord_gateway_state.parse_trigger_policy raw with
+                | Ok policy -> Ok (Trigger_policy_loaded policy)
+                | Error detail ->
+                  Error (Trigger_policy_invalid { path; detail })))))
+;;
+
+(* Env > TOML > default — the precedence every other env↔TOML pair in this
+   codebase resolves with and the one config/runtime.toml documents for this
+   key. An invalid env value is a load error like an invalid TOML value; an
+   empty/unset env falls through to the TOML plane. *)
 let resolved_trigger_policy () =
-  let from_toml () =
-    try
-      let resolution = Config_dir_resolver.resolve () in
-      let toml_path =
-        Filename.concat resolution.Config_dir_resolver.config_root.path
-          Config_dir_resolver.runtime_toml_filename
-      in
-      if Sys.file_exists toml_path then
-        let tbl = Otoml.Parser.from_file toml_path in
-        Otoml.find_opt tbl Otoml.get_string [ "discord"; "trigger_policy" ]
-      else None
-    with _ -> None
-  in
-  match from_toml () with
-  | Some raw -> parse_trigger_policy raw
+  match trimmed_env "MASC_DISCORD_TRIGGER_POLICY" with
+  | Some raw ->
+    (match Discord_gateway_state.parse_trigger_policy raw with
+     | Ok policy -> Ok policy
+     | Error detail -> Error (Trigger_policy_env_invalid { detail }))
   | None ->
-    (match trimmed_env "MASC_DISCORD_TRIGGER_POLICY" with
-    | None -> Gw.Mention_or_thread
-    | Some raw -> parse_trigger_policy raw)
+    let resolution = Config_dir_resolver.resolve () in
+    let toml_path =
+      Filename.concat resolution.Config_dir_resolver.config_root.path
+        Config_dir_resolver.runtime_toml_filename
+    in
+    (match load_trigger_policy_from_toml ~path:toml_path with
+     | Error _ as error -> error
+     | Ok (Trigger_policy_loaded policy) -> Ok policy
+     | Ok (Runtime_toml_missing | Trigger_policy_missing) ->
+       Ok default_trigger_policy)
 
 (* ---------------------------------------------------------------- *)
 (* Inbound delivery                                                 *)
@@ -642,7 +686,16 @@ let start ~sw ~env ~clock ~state =
     Log.Server.warn
       "RFC-0203: DISCORD_BOT_TOKEN is unset; in-process Discord gateway not started"
   | Some token ->
-    let policy = resolved_trigger_policy () in
+    (match resolved_trigger_policy () with
+     | Error error ->
+       (* Same fail-closed posture as the Slack sibling (RFC-0317): a
+          malformed policy configuration must stop the gateway, not boot it
+          on a policy the operator did not write. *)
+       Log.Server.error
+         "RFC-0203: Discord trigger-policy configuration rejected; gateway \
+          not started (%s)"
+         (trigger_policy_load_error_to_string error)
+     | Ok policy ->
     State.set_trigger_policy policy;
     let ingress =
       Connector_ingress_lane.create
@@ -685,4 +738,4 @@ let start ~sw ~env ~clock ~state =
       | exn ->
         Log.Server.error
           "RFC-0203: in-process Discord gateway crashed: %s"
-          (Printexc.to_string exn))
+          (Printexc.to_string exn)))

--- a/lib/server/server_discord_in_process_gateway.mli
+++ b/lib/server/server_discord_in_process_gateway.mli
@@ -27,14 +27,34 @@ val default_trigger_policy : Discord_gateway_client.trigger_policy
 (** Policy used when none is configured (empty/unset): the quiet,
     mention-triggered baseline ([Mention_or_thread]). *)
 
-val parse_trigger_policy : string -> Discord_gateway_client.trigger_policy
-(** Resolve a configured trigger-policy string. Empty/whitespace is
-    treated as unset and returns {!default_trigger_policy}. A non-empty
-    value is parsed by the single canonical grammar
-    ({!Discord_gateway_state.parse_trigger_policy}); a value that fails
-    to parse is logged via [Log.Server] and falls back to the default,
-    rather than being silently coerced. Exposed for unit testing the
-    config boundary. *)
+(** Typed trigger-policy loading, mirroring the Slack sibling. A missing
+    runtime.toml or missing key is "unset"; unreadable/malformed
+    TOML, a wrong field type, or a value the strict grammar rejects is an
+    explicit load error — the gateway does not start on one (fail-closed,
+    masc#25123). *)
+type trigger_policy_toml_load =
+  | Runtime_toml_missing
+  | Trigger_policy_missing
+  | Trigger_policy_loaded of Discord_gateway_client.trigger_policy
+
+type trigger_policy_load_error =
+  | Runtime_toml_unreadable of { path : string; detail : string }
+  | Runtime_toml_invalid of { path : string; detail : string }
+  | Trigger_policy_invalid of { path : string; detail : string }
+  | Trigger_policy_env_invalid of { detail : string }
+
+val trigger_policy_load_error_to_string : trigger_policy_load_error -> string
+
+val load_trigger_policy_from_toml :
+  path:string -> (trigger_policy_toml_load, trigger_policy_load_error) result
+(** Exposed for unit testing the config boundary. *)
+
+val resolved_trigger_policy :
+  unit -> (Discord_gateway_client.trigger_policy, trigger_policy_load_error) result
+(** Env > TOML > default. [MASC_DISCORD_TRIGGER_POLICY] wins when set and
+    valid; an invalid env value is a load error (never a silent default);
+    otherwise the [discord.trigger_policy] runtime.toml key applies, and a
+    missing file/key yields {!default_trigger_policy}. *)
 
 module For_testing : sig
   val submit_triggered_event :

--- a/lib/workspace/workspace_utils_backend_setup.ml
+++ b/lib/workspace/workspace_utils_backend_setup.ml
@@ -117,7 +117,6 @@ let sync_test_base_path_env resolved_path =
     | _ ->
         Unix.putenv Env_config_core.base_path_env_key resolved_path;
         Unix.putenv Env_config_core.base_path_input_env_key resolved_path;
-        Unix.putenv "MASC_TEST_SYNCED_BASE_PATH" resolved_path;
         Log.Workspace.info "Synchronized MASC_BASE_PATH=%s for test executable %s"
           resolved_path (Filename.basename Sys.executable_name)
 

--- a/test/test_server_discord_trigger_policy.ml
+++ b/test/test_server_discord_trigger_policy.ml
@@ -4,8 +4,8 @@
    wrong field type, an invalid policy value, or an invalid
    MASC_DISCORD_TRIGGER_POLICY env value is an explicit load error — the
    gateway must not boot on a policy the operator did not write. Env wins
-   over TOML, matching every other env↔TOML pair in the codebase and the
-   precedence config/runtime.toml documents for this key. *)
+   over TOML, matching the precedence config/runtime.toml documents for this
+   key. *)
 
 open Alcotest
 open Masc
@@ -51,9 +51,7 @@ let ps p = Discord_gateway_state.trigger_policy_to_string p
 let default_str = ps G.default_trigger_policy
 
 let write_file path content =
-  let oc = open_out path in
-  output_string oc content;
-  close_out oc
+  Out_channel.with_open_bin path (fun oc -> output_string oc content)
 ;;
 
 (* -- load_trigger_policy_from_toml: the TOML plane in isolation -- *)
@@ -137,7 +135,9 @@ let test_toml_invalid_policy_is_load_error () =
    sandbox suites already use. *)
 let with_config_root dir f =
   with_env "MASC_CONFIG_DIR" dir @@ fun () ->
-  with_env "MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE" "1" f
+  with_env "MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE" "1" @@ fun () ->
+  Config_dir_resolver.reset ();
+  Fun.protect ~finally:Config_dir_resolver.reset f
 
 let test_env_valid_wins_over_toml () =
   with_temp_dir @@ fun dir ->

--- a/test/test_server_discord_trigger_policy.ml
+++ b/test/test_server_discord_trigger_policy.ml
@@ -1,14 +1,11 @@
-(* F941 — the server's resolved-config trigger-policy parser must
-   delegate to the single canonical grammar in [Discord_gateway_state]
-   so production config and the (separately test-covered) grammar can
-   never drift apart. Before this, a permissive duplicate parser lived
-   in [Server_discord_in_process_gateway]; adding a new policy variant
-   to the strict grammar would have left prod silently coercing it.
-
-   These assertions pin the wrapper's contract: an empty value is unset
-   (=> default), the four valid forms parse through to the same variant
-   the strict grammar yields, and an unparseable value falls back to the
-   default rather than producing a half-formed policy. *)
+(* F941 / masc#25123 — the server's trigger-policy loading is typed and
+   fail-closed, mirroring the Slack sibling: a missing runtime.toml or a
+   missing key is "unset" (default applies); unreadable/malformed TOML, a
+   wrong field type, an invalid policy value, or an invalid
+   MASC_DISCORD_TRIGGER_POLICY env value is an explicit load error — the
+   gateway must not boot on a policy the operator did not write. Env wins
+   over TOML, matching every other env↔TOML pair in the codebase and the
+   precedence config/runtime.toml documents for this key. *)
 
 open Alcotest
 open Masc
@@ -53,38 +50,135 @@ let with_temp_dir f =
 let ps p = Discord_gateway_state.trigger_policy_to_string p
 let default_str = ps G.default_trigger_policy
 
-let test_empty_is_default () =
-  check string "empty => default" default_str (ps (G.parse_trigger_policy ""))
+let write_file path content =
+  let oc = open_out path in
+  output_string oc content;
+  close_out oc
+;;
 
-let test_whitespace_is_default () =
-  check string "whitespace => default" default_str
-    (ps (G.parse_trigger_policy "   "))
+(* -- load_trigger_policy_from_toml: the TOML plane in isolation -- *)
 
-let test_valid_values_parse_through () =
-  (* Each valid form yields exactly what the strict grammar yields,
-     proving the wrapper delegates rather than re-implementing. *)
-  List.iter
-    (fun raw ->
-      let expected =
-        match Discord_gateway_state.parse_trigger_policy raw with
-        | Ok p -> ps p
-        | Error msg -> failf "strict grammar rejected %S: %s" raw msg
-      in
-      check string (Printf.sprintf "%S parses through" raw) expected
-        (ps (G.parse_trigger_policy raw)))
-    [ "mention_only"; "mention_or_thread"; "all"; "user_only:VINCENT" ]
+let test_toml_missing_file_is_unset () =
+  with_temp_dir @@ fun dir ->
+  match
+    G.load_trigger_policy_from_toml
+      ~path:(Filename.concat dir "runtime.toml")
+  with
+  | Ok G.Runtime_toml_missing -> ()
+  | Ok _ -> fail "expected Runtime_toml_missing"
+  | Error e -> failf "expected missing, got error: %s"
+                 (G.trigger_policy_load_error_to_string e)
 
-let test_unknown_falls_back_to_default () =
-  (* A typo must not produce a policy the operator did not write. The
-     wrapper logs (via Log.Server) and returns the default. *)
-  check string "typo => default" default_str
-    (ps (G.parse_trigger_policy "mention_ony"))
+let test_toml_missing_key_is_unset () =
+  with_temp_dir @@ fun dir ->
+  let path = Filename.concat dir "runtime.toml" in
+  write_file path "[discord]\nother = \"x\"\n";
+  match G.load_trigger_policy_from_toml ~path with
+  | Ok G.Trigger_policy_missing -> ()
+  | Ok _ -> fail "expected Trigger_policy_missing"
+  | Error e -> failf "expected missing key, got error: %s"
+                 (G.trigger_policy_load_error_to_string e)
 
-let test_user_only_empty_id_falls_back () =
-  (* The strict grammar rejects an empty id; the wrapper falls back to
-     the default instead of constructing User_only "". *)
-  check string "user_only: empty id => default" default_str
-    (ps (G.parse_trigger_policy "user_only:"))
+let test_toml_empty_value_is_unset () =
+  with_temp_dir @@ fun dir ->
+  let path = Filename.concat dir "runtime.toml" in
+  write_file path "[discord]\ntrigger_policy = \"  \"\n";
+  match G.load_trigger_policy_from_toml ~path with
+  | Ok G.Trigger_policy_missing -> ()
+  | Ok _ -> fail "expected Trigger_policy_missing for blank value"
+  | Error e -> failf "expected unset, got error: %s"
+                 (G.trigger_policy_load_error_to_string e)
+
+let test_toml_valid_value_loads () =
+  with_temp_dir @@ fun dir ->
+  let path = Filename.concat dir "runtime.toml" in
+  write_file path "[discord]\ntrigger_policy = \"mention_only\"\n";
+  match G.load_trigger_policy_from_toml ~path with
+  | Ok (G.Trigger_policy_loaded p) ->
+    check string "loaded policy" "mention_only" (ps p)
+  | Ok _ -> fail "expected loaded policy"
+  | Error e -> failf "expected policy, got error: %s"
+                 (G.trigger_policy_load_error_to_string e)
+
+let test_toml_malformed_is_load_error () =
+  with_temp_dir @@ fun dir ->
+  let path = Filename.concat dir "runtime.toml" in
+  write_file path "[discord\ntrigger_policy = \"mention_only\"\n";
+  match G.load_trigger_policy_from_toml ~path with
+  | Error (G.Runtime_toml_invalid _) -> ()
+  | Error e -> failf "expected Runtime_toml_invalid, got: %s"
+                 (G.trigger_policy_load_error_to_string e)
+  | Ok _ -> fail "malformed TOML must not load"
+
+let test_toml_wrong_type_is_load_error () =
+  with_temp_dir @@ fun dir ->
+  let path = Filename.concat dir "runtime.toml" in
+  write_file path "[discord]\ntrigger_policy = 7\n";
+  match G.load_trigger_policy_from_toml ~path with
+  | Error (G.Trigger_policy_invalid _) -> ()
+  | Error e -> failf "expected Trigger_policy_invalid, got: %s"
+                 (G.trigger_policy_load_error_to_string e)
+  | Ok _ -> fail "a non-string trigger_policy must not load"
+
+let test_toml_invalid_policy_is_load_error () =
+  with_temp_dir @@ fun dir ->
+  let path = Filename.concat dir "runtime.toml" in
+  write_file path "[discord]\ntrigger_policy = \"mention_ony\"\n";
+  match G.load_trigger_policy_from_toml ~path with
+  | Error (G.Trigger_policy_invalid _) -> ()
+  | Error e -> failf "expected Trigger_policy_invalid, got: %s"
+                 (G.trigger_policy_load_error_to_string e)
+  | Ok _ -> fail "a typo policy must not load"
+
+(* -- resolved_trigger_policy: env > TOML > default -- *)
+
+(* Point the config resolver at a temp config root so the TOML plane is
+   under test control. MASC_CONFIG_DIR is the documented override the
+   sandbox suites already use. *)
+let with_config_root dir f =
+  with_env "MASC_CONFIG_DIR" dir @@ fun () ->
+  with_env "MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE" "1" f
+
+let test_env_valid_wins_over_toml () =
+  with_temp_dir @@ fun dir ->
+  write_file (Filename.concat dir "runtime.toml")
+    "[discord]\ntrigger_policy = \"all\"\n";
+  with_config_root dir @@ fun () ->
+  with_env "MASC_DISCORD_TRIGGER_POLICY" "mention_only" @@ fun () ->
+  match G.resolved_trigger_policy () with
+  | Ok p -> check string "env wins over TOML" "mention_only" (ps p)
+  | Error e -> failf "expected env policy, got error: %s"
+                 (G.trigger_policy_load_error_to_string e)
+
+let test_env_invalid_is_load_error () =
+  with_temp_dir @@ fun dir ->
+  with_config_root dir @@ fun () ->
+  with_env "MASC_DISCORD_TRIGGER_POLICY" "mention_ony" @@ fun () ->
+  match G.resolved_trigger_policy () with
+  | Error (G.Trigger_policy_env_invalid _) -> ()
+  | Error e -> failf "expected env_invalid, got: %s"
+                 (G.trigger_policy_load_error_to_string e)
+  | Ok p -> failf "invalid env must not resolve, got %s" (ps p)
+
+let test_env_unset_falls_to_toml () =
+  with_temp_dir @@ fun dir ->
+  write_file (Filename.concat dir "runtime.toml")
+    "[discord]\ntrigger_policy = \"all\"\n";
+  with_config_root dir @@ fun () ->
+  with_env "MASC_DISCORD_TRIGGER_POLICY" "" @@ fun () ->
+  match G.resolved_trigger_policy () with
+  | Ok p -> check string "TOML applies when env unset" "all" (ps p)
+  | Error e -> failf "expected TOML policy, got error: %s"
+                 (G.trigger_policy_load_error_to_string e)
+
+let test_all_unset_is_default () =
+  with_temp_dir @@ fun dir ->
+  with_config_root dir @@ fun () ->
+  with_env "MASC_DISCORD_TRIGGER_POLICY" "" @@ fun () ->
+  match G.resolved_trigger_policy () with
+  | Ok p -> check string "default when nothing configured" default_str (ps p)
+  | Error e -> failf "expected default, got error: %s"
+                 (G.trigger_policy_load_error_to_string e)
 
 let discord_message ~message_id =
   Discord_gateway_client.Message_create
@@ -190,15 +284,24 @@ let test_durable_accept_precedes_delivery_handoff () =
 
 let () =
   run "server_discord_trigger_policy"
-    [ ( "parse_trigger_policy"
-      , [ test_case "empty => default" `Quick test_empty_is_default
-        ; test_case "whitespace => default" `Quick test_whitespace_is_default
-        ; test_case "valid values parse through strict grammar" `Quick
-            test_valid_values_parse_through
-        ; test_case "unknown => default (no silent coercion)" `Quick
-            test_unknown_falls_back_to_default
-        ; test_case "user_only empty id => default" `Quick
-            test_user_only_empty_id_falls_back
+    [ ( "toml_loader"
+      , [ test_case "missing file => unset" `Quick test_toml_missing_file_is_unset
+        ; test_case "missing key => unset" `Quick test_toml_missing_key_is_unset
+        ; test_case "blank value => unset" `Quick test_toml_empty_value_is_unset
+        ; test_case "valid value loads" `Quick test_toml_valid_value_loads
+        ; test_case "malformed TOML => load error" `Quick
+            test_toml_malformed_is_load_error
+        ; test_case "wrong type => load error" `Quick
+            test_toml_wrong_type_is_load_error
+        ; test_case "invalid policy => load error" `Quick
+            test_toml_invalid_policy_is_load_error
+        ] )
+    ; ( "resolved_precedence"
+      , [ test_case "valid env wins over TOML" `Quick test_env_valid_wins_over_toml
+        ; test_case "invalid env => load error (no silent default)" `Quick
+            test_env_invalid_is_load_error
+        ; test_case "unset env falls to TOML" `Quick test_env_unset_falls_to_toml
+        ; test_case "all unset => default" `Quick test_all_unset_is_default
         ] )
     ; ( "ingress handoff"
       , [ test_case "durable accept precedes Discord delivery" `Quick

--- a/test/test_workspace_utils_coverage.ml
+++ b/test/test_workspace_utils_coverage.ml
@@ -258,7 +258,6 @@ let test_default_config_syncs_test_base_path_env () =
   in
   with_envs
     [ ("MASC_BASE_PATH", None);
-      ("MASC_TEST_SYNCED_BASE_PATH", None);
       ("MASC_TEST_ALLOW_BASE_PATH_OVERRIDE", None) ]
     (fun () ->
       ignore (Workspace_utils.default_config requested);
@@ -274,7 +273,6 @@ let test_auto_synced_test_base_path_does_not_override_later_requests () =
   in
   with_envs
     [ ("MASC_BASE_PATH", None);
-      ("MASC_TEST_SYNCED_BASE_PATH", None);
       ("MASC_TEST_ALLOW_BASE_PATH_OVERRIDE", None) ]
     (fun () ->
       ignore (Workspace_utils.default_config first);


### PR DESCRIPTION
## Summary

Discord trigger-policy loading is now a typed, fail-closed configuration boundary.

- resolve `MASC_DISCORD_TRIGGER_POLICY` > `[discord].trigger_policy` in resolved `runtime.toml` > `Mention_or_thread`
- distinguish missing file/key from unreadable file, malformed TOML, wrong field type, invalid policy, and invalid env
- do not start the Discord gateway when a configured non-empty policy is invalid
- remove the former catch-all/silent default path and the unused `MASC_TEST_SYNCED_BASE_PATH` marker
- keep parsing on the canonical closed `Discord_gateway_state.trigger_policy` grammar

Slack shares the typed fail-closed loader shape but currently has a different precedence. This PR does not falsely claim cross-connector precedence uniformity; it implements the Discord contract already documented by `config/runtime.toml`.

## SSOT repair

- `docs/CONNECTOR-CONFIG-SCHEMA.md` now describes the in-process Discord path, four closed variants, `mention_or_thread` default, exact precedence, and fail-closed behavior
- implemented RFC-0203 records the live trigger-policy contract instead of its superseded three-variant/default claim

## Test repair

The earlier precedence tests changed `MASC_CONFIG_DIR` without resetting `Config_dir_resolver`'s process-global cache, so their result depended on test order. `with_config_root` now resets the resolver before and after each fixture, and fixture writes use `Out_channel.with_open_bin` for guaranteed close.

## Verification

- rebased on current `main` `bc440e853c579bd2bd84241ebe27ee7b6cce244c`
- OCaml parse check for changed implementation/test: PASS
- ocamlformat and `git diff --check`: PASS
- exact-head GitHub `Build and Test` and `CI Gate`: PASS, including the corrected cache-isolated test suite

## Related

- #25126 (closed source PR)
- #25123 (campaign)
