### PR TITLE
fix(core): guard Domain_pool_ref submits against non-Eio callers (#25158)

### DIFF
--- a/lib/core/domain_pool_ref.ml
+++ b/lib/core/domain_pool_ref.ml
@@ -14,14 +14,21 @@ let domain_count_opt () =
   | Some p -> Some (Domain_pool.domain_count p)
 ;;
 
+(* A pool submit performs Eio effects; from a raw systhread/Domain there is
+   no Eio handler and it would raise [Effect.Unhandled]. Guarding here gives
+   every caller that runs in both contexts the inline fallback once, instead
+   of each call site carrying its own [is_eio_fiber] check (#25158). *)
+
 let submit_io_or_inline f =
-  match Atomic.get pool with
-  | Some p -> Domain_pool.submit_io p f
-  | None -> f ()
+  match Atomic.get pool, Eio_guard.execution_context () with
+  | Some p, Eio_guard.Eio_fiber -> Domain_pool.submit_io p f
+  | Some _, Eio_guard.Non_eio
+  | None, (Eio_guard.Eio_fiber | Eio_guard.Non_eio) -> f ()
 ;;
 
 let submit_cpu_or_inline f =
-  match Atomic.get pool with
-  | Some p -> Domain_pool.submit_cpu p f
-  | None -> f ()
+  match Atomic.get pool, Eio_guard.execution_context () with
+  | Some p, Eio_guard.Eio_fiber -> Domain_pool.submit_cpu p f
+  | Some _, Eio_guard.Non_eio
+  | None, (Eio_guard.Eio_fiber | Eio_guard.Non_eio) -> f ()
 ;;

--- a/lib/core/domain_pool_ref.mli
+++ b/lib/core/domain_pool_ref.mli
@@ -13,8 +13,12 @@ val domain_count_opt : unit -> int option
 (** Current worker-domain count, when the pool has been installed. *)
 
 val submit_io_or_inline : (unit -> 'a) -> 'a
-(** Submit IO-bound work to the shared domain pool, or run inline when the
-    process has not installed the pool yet. *)
+(** Submit IO-bound work to the shared domain pool. Runs inline when the
+    process has not installed the pool yet, or when the caller is not on an
+    Eio fiber (raw systhread/Domain) — a pool submit there would perform
+    Eio effects with no handler and raise [Effect.Unhandled]. Job
+    exceptions re-raise; there is no inline re-run on failure. *)
 
 val submit_cpu_or_inline : (unit -> 'a) -> 'a
-(** Submit CPU-bound work to the shared domain pool, or run inline when absent. *)
+(** CPU-bound variant of {!submit_io_or_inline}, with the same
+    absent-pool and non-Eio-caller inline fallback. *)

--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -64,13 +64,12 @@ let leaf_is_real_segment leaf =
    [Domain_pool_ref.submit_cpu_or_inline] — the typed CPU-weight policy layer
    keeper call sites are documented to prefer over the raw
    [Executor_pool_ref]; it re-raises job exceptions instead of rerunning the
-   closure inline on failure. The pool submit is only legal from an Eio
-   fiber: the store is also reachable from raw Domains (see the stale-guard
-   "raw Domain saves through Unix context" test), where the conversion runs
-   inline exactly as before. *)
+   closure inline on failure, and falls back to inline execution for
+   non-Eio callers itself (#25158) — the store is also reachable from raw
+   Domains (see the stale-guard "raw Domain saves through Unix context"
+   test). *)
 let offload_checkpoint_cpu (f : unit -> 'a) : 'a =
-  if Eio_guard.is_eio_fiber () then Domain_pool_ref.submit_cpu_or_inline f
-  else f ()
+  Domain_pool_ref.submit_cpu_or_inline f
 
 let decode_checkpoint_off_scheduler (content : string) :
     (Agent_sdk.Checkpoint.t, Agent_sdk.Error.sdk_error) result =

--- a/lib/keeper/keeper_fs.ml
+++ b/lib/keeper/keeper_fs.ml
@@ -461,7 +461,13 @@ let save_json_durable_atomic_from_with
         ~before_stage
         Payload_encode
         (fun () ->
-           Executor_pool_ref.submit_or_inline (fun () -> encode (json_source ())))
+           (* [Domain_pool_ref] is the typed CPU-weight policy layer keeper
+              call sites prefer (#25158). Unlike [Executor_pool_ref], a job
+              exception re-raises here instead of being conflated with a
+              pool failure and re-run inline; [run_durable_write_stage]
+              turns it into a typed [Payload_encode] failure. *)
+           Domain_pool_ref.submit_cpu_or_inline (fun () ->
+             encode (json_source ())))
     in
     save_bytes_durable_atomic_core
       ~before_stage

--- a/test/test_domain_pool.ml
+++ b/test/test_domain_pool.ml
@@ -173,6 +173,29 @@ let test_ref_submits_to_shared_pool () =
         (worker_domain <> main_domain);
       R.clear_for_tests ()))
 
+let test_ref_inline_from_raw_domain_with_pool () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      R.clear_for_tests ();
+      let dm = Eio.Stdenv.domain_mgr env in
+      let pool = D.create ~sw ~domain_count:1 dm in
+      R.set pool;
+      (* A raw Domain has no Eio effect handler, so a pool submit from it
+         would raise [Effect.Unhandled]. With the pool installed, the ref
+         must detect the non-Eio caller and run inline in that caller's own
+         domain (#25158). *)
+      let raw =
+        Domain.spawn (fun () ->
+          let self = (Domain.self () :> int) in
+          let observed =
+            R.submit_cpu_or_inline (fun () -> (Domain.self () :> int))
+          in
+          (self, observed))
+      in
+      let self, observed = Domain.join raw in
+      check int "raw-domain caller runs inline in its own domain" self observed;
+      R.clear_for_tests ()))
+
 (* ── Suite ──────────────────────────────────────────────── *)
 
 let () =
@@ -210,5 +233,7 @@ let () =
     "ref", [
       test_case "inline when absent" `Quick test_ref_runs_inline_when_absent;
       test_case "submits to shared pool" `Quick test_ref_submits_to_shared_pool;
+      test_case "inline from raw domain with pool installed" `Quick
+        test_ref_inline_from_raw_domain_with_pool;
     ];
   ]


### PR DESCRIPTION
## Summary
#25158 수리 — #25137 리뷰 대응에서 확립된 두 사실을 구조적으로 정착시킨다.

### 1. `Domain_pool_ref.submit_{io,cpu}_or_inline`에 실행 컨텍스트 가드 내장
pool 설치 + 비-Eio(raw systhread/Domain) 호출자 조합에서 pool submit은 Eio effect를 핸들러 없는 스레드에서 수행해 `Effect.Unhandled`로 죽는다. 가드를 ref 내부에 한 번 넣어, 양쪽 컨텍스트에서 도는 모든 콜사이트가 각자 `is_eio_fiber` 체크를 들고 다니지 않게 한다. 2×2 match는 catch-all 없이 전 조합 명시. `.mli`에 폴백 조건과 "job 예외는 재-raise, inline 재실행 없음" 계약 명문화.

### 2. `Keeper_fs.save_json_durable_atomic_from` 라우팅 교체
기존 raw `Executor_pool_ref.submit_or_inline`은 catch-all에서 **job 자체의 예외를 pool 인프라 실패와 혼동**해 "executor_pool submit failed" WARN 후 클로저를 inline 재실행했다 — MB급 인코딩 2회(두 번째는 스케줄러 fiber) + 오진 유도 로그. `Domain_pool_ref`(keeper 콜사이트가 선호하도록 문서화된 typed CPU-weight 정책 계층)로 교체: job 예외는 1회 재-raise되고 `run_durable_write_stage`가 typed `Payload_encode` 실패로 매핑, `Cancelled`는 그대로 전파. silent 폴백 → typed fail-loud 순개선.

### 3. `Keeper_checkpoint_store.offload_checkpoint_cpu` 단순화
#25137에서 넣은 로컬 가드가 1에 의해 중복이 되어 제거 (동작 동일).

## Tests
- 신규 `test_ref_inline_from_raw_domain_with_pool`: pool 설치 상태에서 `Domain.spawn`한 raw Domain이 `submit_cpu_or_inline`을 호출하면 자기 도메인에서 inline 실행됨을 증명 — **수정 전에는 이 테스트가 `Effect.Unhandled`로 실패한다** (counterfactual).
- 기존 ref 테스트 2건(absent→inline, Eio fiber→pool)과 stale-guard raw-Domain 저장 테스트가 회귀 커버.

## Validation
- 빌드/테스트는 PR CI로 검증. `git diff --check` clean.

## RFC 체크
- RFC-gated subsystem 밖. 워크어라운드 시그니처 해당 없음 — catch-all 제거 방향이며 추가 아님.

Closes #25158

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
